### PR TITLE
copySavefile

### DIFF
--- a/backends/saves/savefile.cpp
+++ b/backends/saves/savefile.cpp
@@ -31,8 +31,7 @@
 
 namespace Common {
 
-bool SaveFileManager::renameSavefile(const String &oldFilename, const String &newFilename) {
-
+bool SaveFileManager::copySavefile(const String &oldFilename, const String &newFilename) {
 	InSaveFile *inFile = 0;
 	OutSaveFile *outFile = 0;
 	uint32 size = 0;
@@ -57,9 +56,8 @@ bool SaveFileManager::renameSavefile(const String &oldFilename, const String &ne
 			if (!error) {
 				outFile->write(buffer, size);
 				outFile->finalize();
-				if (!outFile->err()) {
-					success = removeSavefile(oldFilename);
-				}
+
+				success = !outFile->err();
 			}
 		}
 
@@ -69,6 +67,13 @@ bool SaveFileManager::renameSavefile(const String &oldFilename, const String &ne
 	}
 
 	return success;
+}
+
+bool SaveFileManager::renameSavefile(const String &oldFilename, const String &newFilename) {
+	if (!copySavefile(oldFilename, newFilename))
+		return false;
+
+	return removeSavefile(oldFilename);
 }
 
 String SaveFileManager::popErrorDesc() {

--- a/common/savefile.h
+++ b/common/savefile.h
@@ -136,6 +136,14 @@ public:
 	virtual bool renameSavefile(const String &oldName, const String &newName);
 
 	/**
+	 * Copy the given savefile.
+	 * @param oldName Old name.
+	 * @param newName New name.
+	 * @return true if no error occurred. false otherwise.
+	 */
+	virtual bool copySavefile(const String &oldName, const String &newName);
+
+	/**
 	 * Request a list of available savegames with a given DOS-style pattern,
 	 * also known as "glob" in the UNIX world. Refer to the Common::matchString()
 	 * function to learn about the precise pattern format.


### PR DESCRIPTION
The ring engine (not yet in trunk) needs to be able to copy save files around.

This patch adds a new copySavefile function to SaveFileManager.

It is basically the same as renameSaveFile without the removeSavefile at the end. The renameSaveFile function has been updated to simply call copySavefile and remove the original save if it succeeds.
