### PR TITLE
Support for older WebOS version 1.4.5

### DIFF
--- a/backends/platform/webos/webos.mk
+++ b/backends/platform/webos/webos.mk
@@ -17,7 +17,7 @@ webosrelease:
 	cp -f gui/themes/scummmodern.zip $(STAGING_DIR)/share/scummvm
 	cp -f scummvm $(STAGING_DIR)/bin
 	$(STRIP) $(STAGING_DIR)/bin/scummvm
-	$(WEBOS_SDK)/bin/palm-package $(STAGING_DIR)
+	$(WEBOS_SDK)/bin/palm-package --use-v1-format $(STAGING_DIR)
 	rm -rf STAGING
 
 .PHONY: webosrelease


### PR DESCRIPTION
Just added a parameter to palm-package command to create a v1 compatible package so it can be released also for WebOS 1.4.5 in the official app catalog.
