### PR TITLE
LURE: Enabled clickable menus for WebOS.

### DIFF
--- a/engines/lure/menu.cpp
+++ b/engines/lure/menu.cpp
@@ -34,7 +34,7 @@
 #include "lure/events.h"
 #include "lure/lure.h"
 
-#if defined(_WIN32_WCE) || defined(__SYMBIAN32__)
+#if defined(_WIN32_WCE) || defined(__SYMBIAN32__) || defined(WEBOS)
 #define LURE_CLICKABLE_MENUS
 #endif
 


### PR DESCRIPTION
Nothing fancy here. Just enabled clickable menus in LURE engine for the WebOS backend as suggested on the mailing list.
