### PR TITLE
SDL: Limit minimum window size to the game/launcher resolution when resizing the window 

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -243,6 +243,11 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		return true;
 
 	case SDL_VIDEORESIZE:
+		// Very bad things happen with our widgets reflow & size calculations when we resize too small
+		// Here, we limit the minimum size to the game/launcher resolution
+		ev.resize.w = MAX((int)g_system->getWidth(),  ev.resize.w);
+		ev.resize.h = MAX((int)g_system->getHeight(), ev.resize.h);
+
 		// HACK: Send a fake event, handled by OpenGLSdlGraphicsManager
 		event.type = (Common::EventType)OSystem_SDL::kSdlEventResize;
 		event.mouse.x = ev.resize.w;


### PR DESCRIPTION
This prevents our reflow code from exiting with error() when widgets are resized too small and one assert when calculating list entries in ListWidget (height minus padding would result in a negative value). This was mainly a problem with the OpenGL backend.

**Note**: On Windows, it doesn't look like SDL exposes resize events _while_ doing a resize, which would allow us to limit the resize to the minimum window size instead of resize after the fact. This means we only get the SDL_VIDEORESIZE when the user releases the mouse.

It seems the behavior is different on Linux, where the events are generated during resize (and the contents of the window refreshed too).
