### PR TITLE
ALL: Require DECLARE_SINGLETON to be used in the Common namepsace

### DIFF
--- a/backends/fs/ds/ds-fs-factory.cpp
+++ b/backends/fs/ds/ds-fs-factory.cpp
@@ -27,7 +27,9 @@
 #include "backends/fs/ds/ds-fs.h"
 #include "dsmain.h" //for the isGBAMPAvailable() function
 
+namespace Common {
 DECLARE_SINGLETON(DSFilesystemFactory);
+}
 
 AbstractFSNode *DSFilesystemFactory::makeRootFileNode() const {
 	if (DS::isGBAMPAvailable()) {

--- a/backends/fs/ps2/ps2-fs-factory.cpp
+++ b/backends/fs/ps2/ps2-fs-factory.cpp
@@ -27,7 +27,9 @@
 #include "backends/fs/ps2/ps2-fs-factory.h"
 #include "backends/fs/ps2/ps2-fs.h"
 
+namespace Common {
 DECLARE_SINGLETON(Ps2FilesystemFactory);
+}
 
 AbstractFSNode *Ps2FilesystemFactory::makeRootFileNode() const {
 	return new Ps2FilesystemNode();

--- a/backends/fs/psp/psp-fs-factory.cpp
+++ b/backends/fs/psp/psp-fs-factory.cpp
@@ -43,7 +43,9 @@
 
 #include <unistd.h>
 
+namespace Common {
 DECLARE_SINGLETON(PSPFilesystemFactory);
+}
 
 AbstractFSNode *PSPFilesystemFactory::makeRootFileNode() const {
 	return new PSPFilesystemNode();

--- a/backends/fs/wii/wii-fs-factory.cpp
+++ b/backends/fs/wii/wii-fs-factory.cpp
@@ -40,7 +40,9 @@
 #include <smb.h>
 #endif
 
+namespace Common {
 DECLARE_SINGLETON(WiiFilesystemFactory);
+}
 
 WiiFilesystemFactory::WiiFilesystemFactory() :
 	_dvdMounted(false),

--- a/backends/platform/psp/display_manager.cpp
+++ b/backends/platform/psp/display_manager.cpp
@@ -62,7 +62,9 @@ const OSystem::GraphicsMode DisplayManager::_supportedModes[] = {
 
 // Class VramAllocator -----------------------------------
 
+namespace Common {
 DECLARE_SINGLETON(VramAllocator);
+}
 
 //#define __PSP_DEBUG_FUNCS__	/* For debugging the stack */
 //#define __PSP_DEBUG_PRINT__

--- a/backends/platform/psp/powerman.cpp
+++ b/backends/platform/psp/powerman.cpp
@@ -30,7 +30,9 @@
 //#define __PSP_DEBUG_PRINT__
 #include "backends/platform/psp/trace.h"
 
+namespace Common {
 DECLARE_SINGLETON(PowerManager);
+}
 
 // Function to debug the Power Manager (we have no output to screen)
 inline void PowerManager::debugPM() {

--- a/backends/platform/psp/rtc.cpp
+++ b/backends/platform/psp/rtc.cpp
@@ -34,7 +34,9 @@
 
 
 // Class PspRtc ---------------------------------------------------------------
+namespace Common {
 DECLARE_SINGLETON(PspRtc);
+}
 
 void PspRtc::init() {						// init our starting ticks
 	uint32 ticks[2];

--- a/backends/plugins/elf/memory-manager.cpp
+++ b/backends/plugins/elf/memory-manager.cpp
@@ -29,7 +29,9 @@
 #include "common/util.h"
 #include <malloc.h>
 
+namespace Common {
 DECLARE_SINGLETON(ELFMemoryManager);
+}
 
 ELFMemoryManager::ELFMemoryManager() :
 	_heap(0), _heapSize(0), _heapAlign(0),

--- a/backends/plugins/elf/shorts-segment-manager.cpp
+++ b/backends/plugins/elf/shorts-segment-manager.cpp
@@ -33,7 +33,9 @@ extern char __plugin_hole_start;	// Indicates start of hole in program file for 
 extern char __plugin_hole_end;		// Indicates end of hole in program file
 extern char _gp[];					// Value of gp register
 
+namespace Common {
 DECLARE_SINGLETON(ShortSegmentManager);	// For singleton
+}
 
 ShortSegmentManager::ShortSegmentManager() {
 	_shortsStart = &__plugin_hole_start ;	//shorts segment begins at the plugin hole we made when linking

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -540,7 +540,9 @@ void PluginManager::addToPluginsInMemList(Plugin *plugin) {
 
 #include "engines/metaengine.h"
 
+namespace Common {
 DECLARE_SINGLETON(EngineManager);
+}
 
 /**
  * This function works for both cached and uncached PluginManagers.
@@ -631,7 +633,9 @@ const EnginePlugin::List &EngineManager::getPlugins() const {
 
 #include "audio/musicplugin.h"
 
+namespace Common {
 DECLARE_SINGLETON(MusicManager);
+}
 
 const MusicPlugin::List &MusicManager::getPlugins() const {
 	return (const MusicPlugin::List &)PluginManager::instance().getPlugins(PLUGIN_TYPE_MUSIC);

--- a/common/EventRecorder.cpp
+++ b/common/EventRecorder.cpp
@@ -27,9 +27,9 @@
 #include "common/savefile.h"
 #include "common/textconsole.h"
 
-DECLARE_SINGLETON(Common::EventRecorder);
-
 namespace Common {
+
+DECLARE_SINGLETON(Common::EventRecorder);
 
 #define RECORD_SIGNATURE 0x54455354
 #define RECORD_VERSION 1

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -285,7 +285,7 @@ void SearchManager::clear() {
 	addDirectory(".", ".", -2);
 }
 
-} // namespace Common
-
 DECLARE_SINGLETON(Common::SearchManager);
+
+} // namespace Common
 

--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -27,8 +27,6 @@
 #include "common/system.h"
 #include "common/textconsole.h"
 
-DECLARE_SINGLETON(Common::ConfigManager);
-
 static bool isValidDomainName(const Common::String &domName) {
 	const char *p = domName.c_str();
 	while (*p && (isalnum(static_cast<unsigned char>(*p)) || *p == '-' || *p == '_'))
@@ -37,6 +35,8 @@ static bool isValidDomainName(const Common::String &domName) {
 }
 
 namespace Common {
+
+DECLARE_SINGLETON(Common::ConfigManager);
 
 const char *ConfigManager::kApplicationDomain = "scummvm";
 const char *ConfigManager::kTransientDomain = "__TRANSIENT";

--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -29,9 +29,9 @@
 // TODO: Move gDebugLevel into namespace Common.
 int gDebugLevel = -1;
 
-DECLARE_SINGLETON(Common::DebugManager);
-
 namespace Common {
+
+DECLARE_SINGLETON(Common::DebugManager);
 
 namespace {
 

--- a/common/singleton.h
+++ b/common/singleton.h
@@ -89,15 +89,13 @@ protected:
 };
 
 /**
- * Note that you need to use this macro from the global namespace.
+ * Note that you need to use this macro from the Common namespace.
  *
  * This is because C++ requires initial explicit specialization
  * to be placed in the same namespace as the template.
- * It has to be put in the global namespace to assure the correct
- * namespace Common is referenced.
  */
 #define DECLARE_SINGLETON(T) \
-	template<> T *Common::Singleton<T>::_singleton = 0
+	template<> T *Singleton<T>::_singleton = 0
 
 }	// End of namespace Common
 

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -37,9 +37,9 @@
 
 #ifdef USE_TRANSLATION
 
-DECLARE_SINGLETON(Common::TranslationManager);
-
 namespace Common {
+
+DECLARE_SINGLETON(Common::TranslationManager);
 
 bool operator<(const TLanguage &l, const TLanguage &r) {
 	return strcmp(l.name, r.name) < 0;

--- a/engines/lure/sound.cpp
+++ b/engines/lure/sound.cpp
@@ -31,7 +31,9 @@
 #include "common/endian.h"
 #include "audio/midiparser.h"
 
+namespace Common {
 DECLARE_SINGLETON(Lure::SoundManager);
+}
 
 namespace Lure {
 

--- a/engines/sword25/gfx/animationtemplateregistry.cpp
+++ b/engines/sword25/gfx/animationtemplateregistry.cpp
@@ -34,7 +34,9 @@
 #include "sword25/gfx/animationtemplateregistry.h"
 #include "sword25/gfx/animationtemplate.h"
 
+namespace Common {
 DECLARE_SINGLETON(Sword25::AnimationTemplateRegistry);
+}
 
 namespace Sword25 {
 

--- a/engines/sword25/math/regionregistry.cpp
+++ b/engines/sword25/math/regionregistry.cpp
@@ -34,7 +34,9 @@
 #include "sword25/math/regionregistry.h"
 #include "sword25/math/region.h"
 
+namespace Common {
 DECLARE_SINGLETON(Sword25::RegionRegistry);
+}
 
 namespace Sword25 {
 

--- a/engines/sword25/sword25.cpp
+++ b/engines/sword25/sword25.cpp
@@ -50,7 +50,9 @@
 
 #include "sword25/gfx/animationtemplateregistry.h"	// Needed so we can destroy the singleton
 #include "sword25/gfx/renderobjectregistry.h"		// Needed so we can destroy the singleton
+namespace Common {
 DECLARE_SINGLETON(Sword25::RenderObjectRegistry);
+}
 #include "sword25/math/regionregistry.h"			// Needed so we can destroy the singleton
 
 namespace Sword25 {

--- a/engines/testbed/config-params.cpp
+++ b/engines/testbed/config-params.cpp
@@ -24,7 +24,9 @@
 
 #include "testbed/config-params.h"
 
+namespace Common {
 DECLARE_SINGLETON(Testbed::ConfigParams);
+}
 
 namespace Testbed {
 

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -24,7 +24,9 @@
 #include "common/system.h"
 #include "common/stack.h"
 
+namespace Common {
 DECLARE_SINGLETON(Graphics::CursorManager);
+}
 
 namespace Graphics {
 

--- a/graphics/fontman.cpp
+++ b/graphics/fontman.cpp
@@ -23,7 +23,9 @@
 #include "graphics/fontman.h"
 #include "common/translation.h"
 
+namespace Common {
 DECLARE_SINGLETON(Graphics::FontManager);
+}
 
 namespace Graphics {
 

--- a/graphics/yuv_to_rgb.cpp
+++ b/graphics/yuv_to_rgb.cpp
@@ -189,7 +189,9 @@ const YUVToRGBLookup *YUVToRGBManager::getLookup(Graphics::PixelFormat format) {
 
 } // End of namespace Graphics
 
+namespace Common {
 DECLARE_SINGLETON(Graphics::YUVToRGBManager);
+}
 
 #define YUVToRGBMan (Graphics::YUVToRGBManager::instance())
 

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -39,7 +39,9 @@
 
 #include "graphics/cursorman.h"
 
+namespace Common {
 DECLARE_SINGLETON(GUI::GuiManager);
+}
 
 namespace GUI {
 


### PR DESCRIPTION
Silences the clang warning:

  static data member specialization of '_singleton' must
  originally be declared in namespace 'Common'; accepted as a C++0x
  extension [-Wc++0x-extensions]

Wrapping "namespace Common {}" around the macro assignment causes clang
to complain about a spurious semicolon, and removing the semicolon at
the end of the macro causes some editors to misbehave.

Changing the requirement of using the macro in one namespace (the
global) to another (Common) seems a small price to pay to
silence a warning.
