### PR TITLE
DREAMWEB: disable load button in launcher

### DIFF
--- a/engines/dreamweb/detection.cpp
+++ b/engines/dreamweb/detection.cpp
@@ -43,7 +43,7 @@ public:
 	AdvancedMetaEngine(DreamWeb::gameDescriptions,
 	sizeof(DreamWeb::DreamWebGameDescription), dreamWebGames) {
 		_singleid = "dreamweb";
-		_guioptions = Common::GUIO_NOMIDI;
+		_guioptions = Common::GUIO_NOMIDI | Common::GUIO_NOLAUNCHLOAD;
 	}
 
 	virtual const char *getName() const {


### PR DESCRIPTION
The load button currently resulted in the dialog "This game does not support loading games from the launcher."
This patch disables the button.
