### PR TITLE
Update of German README and German Quickstart

### DIFF
--- a/doc/de/Liesmich
+++ b/doc/de/Liesmich
@@ -1,13 +1,13 @@
-﻿ScummVM – Liesmich-Datei
+ScummVM - Liesmich-Datei
 ------------------------------------------------------------------------
 
-Dieses Dokument ist eine auszugsweise Übersetzung der englischen README-Datei. 
-Das Original-Dokument enthält viel mehr Informationen. Sollten Sie hier also 
-nicht das finden, was Sie benötigen und ein wenig Englisch können, sollten Sie 
-sich die englische README-Datei ansehen.
+Dieses Dokument ist eine teilweise Übersetzung der englischen README-Datei. Das
+Original-Dokument enthält viel mehr Informationen. Sollten Sie hier also nicht
+das finden, was Sie benötigen und ein wenig Englisch können, sollten Sie sich
+die englische README-Datei ansehen.
 
-Für weitere Informationen, Kompatibilitätslisten, Einzelheiten zu Spenden, die 
-neusten veröffentlichten Versionen, Fortschrittsberichte und mehr besuchen Sie 
+Für weitere Informationen, Kompatibilitätslisten, Einzelheiten zu Spenden, die
+neusten veröffentlichten Versionen, Fortschrittsberichte und mehr besuchen Sie
 bitte die ScummVM-Website unter der Adresse: http://www.scummvm.org/
 
 
@@ -31,9 +31,24 @@ Inhaltsverzeichnis:
  * 3.10 Hinweise zu Gobliiins
  * 3.11 Hinweise zu Inherit the Earth: Quest for the Orb (Macintosh)
  * 3.12 Hinweise zu Simon the Sorcerer 1 und 2
- * 3.13 Hinweise zu Floyd – Es gibt noch Helden
+ * 3.13 Hinweise zu Floyd - Es gibt noch Helden
  * 3.14 Hinweise zu The Legend of Kyrandia
  * 3.15 Hinweise zum vorhersagenden Eingabedialog bei Sierras AGI-Spielen
+ * 3.16 Hinweise zu Mickey's Space Adventure
+ * 3.17 Hinweise zu Winnie the Pooh
+ * 3.18 Hinweise zu Troll's Tale
+ * 3.19 Hinweise zu Draci Historie
+ * 3.20 Bekannte Probleme
+4.0) Unterstützte Plattformen
+5.0) ScummVM verwenden
+ * 5.1 Kommandozeilenoptionen
+ * 5.2 Sprachoptionen
+ * 5.3 Grafikfilter
+ * 5.4 Globales Menü
+ * 5.5 Tastenkürzel
+6.0) Spielstände
+ * 6.1 Automatische Spielstände
+ * 6.2 Spielstände umwandeln
 
 
 1.0) Einführung:
@@ -41,78 +56,78 @@ Inhaltsverzeichnis:
 
 1.1) Über ScummVM:
 ---- -------------
-ScummVM ist ein Programm, welches es Ihnen ermöglicht, bestimmte klassische 
-Grafik-Adventure (unter anderem aus dem Point-and-Click-Bereich) zu spielen, 
-vorausgesetzt, Sie sind im Besitz der Dateien des Spiels. Der Trick dabei ist: 
-ScummVM ersetzt lediglich die Funktion der ausführbaren Dateien, die mit den 
-Spielen kamen, was ermöglicht, diese Spiele auf Systemen zu spielen, für welche 
+ScummVM ist ein Programm, welches es Ihnen ermöglicht, bestimmte klassische
+Grafik-Adventure (unter anderem aus dem Point-and-Click-Bereich) zu spielen,
+vorausgesetzt, Sie sind im Besitz der Dateien des Spiels. Der Trick dabei ist:
+ScummVM ersetzt lediglich die Funktion der ausführbaren Dateien, die mit den
+Spielen kamen, was ermöglicht, diese Spiele auf Systemen zu spielen, für welche
 sie nie erstellt wurden!
 
-Ursprünglich wurde dieses Programm dafür entwickelt, um SCUMM-Spiele von 
-LucasArts auszuführen, wie beispielsweise Maniac Mansion, Monkey Island, Day of 
-the Tentacle oder Sam & Max. SCUMM steht als Abkürzung für „Script Creation 
-Utility for Maniac Mansion“ (deutsch etwa: Skripterstellungsdienstprogramm für 
-Maniac Mansion), was das erste Spiel von LucasArts war, für welches LucasArts 
-dieses System entworfen hatte. Und viel später verlieh es seinen Namen an 
+Ursprünglich wurde dieses Programm dafür entwickelt, um SCUMM-Spiele von
+LucasArts auszuführen, wie beispielsweise Maniac Mansion, Monkey Island, Day of
+the Tentacle oder Sam & Max. SCUMM steht als Abkürzung für „Script Creation
+Utility for Maniac Mansion“ (deutsch etwa: Skripterstellungsdienstprogramm für
+Maniac Mansion), was das erste Spiel von LucasArts war, für welches LucasArts
+dieses System entworfen hatte. Und viel später verlieh es seinen Namen an
 ScummVM (wobei „VM“ für „Virtuelle Maschine“ steht).
 
-Mit der Zeit wurde Unterstützung für viele Nicht-SCUMM-Spiele hinzugefügt und 
-ScummVM unterstützt nun auch viele AGI- und SCI-Spiele von Sierra (wie 
-beispielsweise King's Quest 1-6, Space Quest 1-5, ...), Discworld 1 und 2, Simon 
-the Sorcerer 1 und 2, Beneath A Steel Sky, Lure of the Temptress, Baphomets 
-Fluch I und II, Flight of the Amazon Queen, Gobliiins 1-3, die Adventure-Reihe 
-The Legend of Kyrandia, viele der SCUMM-Spiele für Kinder von Humongous 
-Entertainment (einschließlich der Spiele von Fritzi Fisch und Töff-Töff) und 
-viele mehr. Sie können eine vollständige Liste mit Einzelheiten einsehen, welche 
-Auskunft darüber gibt, welche Spiele unterstützt werden und wie gut. Gehen Sie 
-hierfür auf die Kompatibilitätsseite. ScummVM wird fortlaufend verbessert, also 
+Mit der Zeit wurde Unterstützung für viele Nicht-SCUMM-Spiele hinzugefügt und
+ScummVM unterstützt nun auch viele AGI- und SCI-Spiele von Sierra (wie
+beispielsweise King's Quest 1-6, Space Quest 1-5, ...), Discworld 1 und 2, Simon
+the Sorcerer 1 und 2, Beneath A Steel Sky, Lure of the Temptress, Baphomets
+Fluch I und II, Flight of the Amazon Queen, Gobliiins 1-3, die Adventure-Reihe
+The Legend of Kyrandia, viele der SCUMM-Spiele für Kinder von Humongous
+Entertainment (einschließlich der Spiele von Fritzi Fisch und Töff-Töff) und
+viele mehr. Sie können eine vollständige Liste mit Einzelheiten einsehen, welche
+Auskunft darüber gibt, welche Spiele unterstützt werden und wie gut. Gehen Sie
+hierfür auf die Kompatibilitätsseite. ScummVM wird fortlaufend verbessert, also
 schauen Sie öfter einmal vorbei.
 
-Unter den Systemen, mit denen Sie diese Spiele spielen können, befinden sich 
+Unter den Systemen, mit denen Sie diese Spiele spielen können, befinden sich
 normale Schreibtisch-Computer (mit den Betriebssystemen Windows, Linux,
-Mac OS X, ...), Spielekonsolen (Dreamcast, Nintendo DS & Wii, PS2, PSP, ...), 
+Mac OS X, ...), Spielekonsolen (Dreamcast, Nintendo DS & Wii, PS2, PSP, ...),
 Smartphones (Android, iPhone, PocketPC, Symbian ...) und einige weitere.
 
-Zurzeit befindet sich ScummVM immer noch stark in der Entwicklung. Seien Sie 
-sich bewusst, dass wir zwar versuchen, dass viele Spiele mit wenigen erheblichen 
-Fehlern durchgespielt werden können, aber es dennoch zu Abstürzen kommen kann 
-und wir keine Gewähr übernehmen. Davon abgesehen: Einige Spiele werden seit 
-längerer Zeit unterstützt und sollten in jeder neusten stabilen veröffentlichten 
-Version ohne größere Probleme laufen. Sie können sich einen Eindruck davon 
-verschaffen, wie gut jedes Spiel unter ScummVM läuft, indem Sie auf die 
-Kompatibilitätsseite schauen. Wenn Sie sich ein wenig im Internet umsehen, 
-können Sie feststellen, dass ScummVM sogar kommerziell genutzt wird, um einige 
-der unterstützen Spiele für moderne Plattformen wiederzuveröffentlichen. Dies 
-zeigt, dass mehrere Firmen mit der Qualität der Software zufrieden sind und wie 
+Zurzeit befindet sich ScummVM immer noch stark in der Entwicklung. Seien Sie
+sich bewusst, dass wir zwar versuchen, dass viele Spiele mit wenigen erheblichen
+Fehlern durchgespielt werden können, aber es dennoch zu Abstürzen kommen kann
+und wir keine Gewähr übernehmen. Davon abgesehen: Einige Spiele werden seit
+längerer Zeit unterstützt und sollten in jeder neusten stabilen veröffentlichten
+Version ohne größere Probleme laufen. Sie können sich einen Eindruck davon
+verschaffen, wie gut jedes Spiel unter ScummVM läuft, indem Sie auf die
+Kompatibilitätsseite schauen. Wenn Sie sich ein wenig im Internet umsehen,
+können Sie feststellen, dass ScummVM sogar kommerziell genutzt wird, um einige
+der unterstützen Spiele für moderne Plattformen wiederzuveröffentlichen. Dies
+zeigt, dass mehrere Firmen mit der Qualität der Software zufrieden sind und wie
 gut einige der Spiele mit Hilfe des Programms laufen.
 
-Wenn Ihnen ScummVM gefällt, können Sie uns gerne Geld spenden, indem Sie auf die 
-PayPal-Schaltfläche auf der ScummVM-Website klicken. Dies hilft uns dabei, 
-notwendige Dienstprogramme zu kaufen, um ScummVM einfacher und schneller zu 
-entwickeln. Wenn Sie nicht spenden können, dürfen Sie auch gerne einen Patch 
+Wenn Ihnen ScummVM gefällt, können Sie uns gerne Geld spenden, indem Sie auf die
+PayPal-Schaltfläche auf der ScummVM-Website klicken. Dies hilft uns dabei,
+notwendige Dienstprogramme zu kaufen, um ScummVM einfacher und schneller zu
+entwickeln. Wenn Sie nicht spenden können, dürfen Sie auch gerne einen Patch
 beisteuern.
 
 1.2) Schnellstart:
 ---- -------------
-WICHTIG: In dieser kurzen Anleitung wird davon ausgegangen, dass Sie ScummVM auf 
-Deutsch benutzen. Standardmäßig wird ScummVM die Sprache Ihres Betriebssystems 
-verwenden. Wenn Sie ScummVM lieber auf Englisch verwenden möchten, benutzen Sie 
+WICHTIG: In dieser kurzen Anleitung wird davon ausgegangen, dass Sie ScummVM auf
+Deutsch benutzen. Standardmäßig wird ScummVM die Sprache Ihres Betriebssystems
+verwenden. Wenn Sie ScummVM lieber auf Englisch verwenden möchten, benutzen Sie
 bitte die Anleitung in der englischen README-Datei.
 
-Für die ungeduldigen unter den Anwendern ist hier in fünf einfachen Schritten 
+Für die ungeduldigen unter den Anwendern ist hier in fünf einfachen Schritten
 kurz beschrieben, wie man ScummVM lauffähig macht und das Programm verwendet.
 
-1. Laden Sie ScummVM unter der Adresse http://www.scummvm.org/downloads.php 
+1. Laden Sie ScummVM unter der Adresse http://www.scummvm.org/downloads.php
 herunter und installieren Sie es.
 
-2. Erstellen Sie ein Verzeichnis auf Ihrer Festplatte und kopieren Sie die 
-Dateien des Spiels vom Original-Datenträger in dieses Verzeichnis. Wiederholen 
-Sie diesen Vorgang für jedes Spiel, das Sie spielen möchten (es ist besser, für 
+2. Erstellen Sie ein Verzeichnis auf Ihrer Festplatte und kopieren Sie die
+Dateien des Spiels vom Original-Datenträger in dieses Verzeichnis. Wiederholen
+Sie diesen Vorgang für jedes Spiel, das Sie spielen möchten (es ist besser, für
 jedes Spiel ein eigenes Verzeichnis zu verwenden).
 
 3. Starten Sie ScummVM.
 
-Sollte an diesem Punkt ScummVM auf Englisch statt auf Deutsch erscheinen, gehen 
+Sollte an diesem Punkt ScummVM auf Englisch statt auf Deutsch erscheinen, gehen
 Sie wie folgt vor, um die Spracheinstellung zu ändern:
 -Klicken Sie auf „Options“.
 -Klicken Sie auf den rechten Pfeil in der Reiterleiste und wählen den Reiter
@@ -121,61 +136,61 @@ Sie wie folgt vor, um die Spracheinstellung zu ändern:
 -Bestätigen Sie die erscheinende Nachricht, klicken auf „Quit“, um ScummVM zu
  beenden, und starten dann das Programm erneut.
 
-Nun klicken Sie auf „Spiel hinzufügen“, wählen das Verzeichnis mit den Dateien 
-des Spiels aus (versuchen Sie nicht, die Dateien des Spiels selbst auszuwählen!) 
+Nun klicken Sie auf „Spiel hinzufügen“, wählen das Verzeichnis mit den Dateien
+des Spiels aus (versuchen Sie nicht, die Dateien des Spiels selbst auszuwählen!)
 und klicken Sie auf „Auswählen“.
 
-4. Ein Dialog sollte erscheinen, der Ihnen ermöglicht, verschiedene 
-Einstellungen vorzunehmen, sollten Sie dies wünschen (es sollte jedoch in 
+4. Ein Dialog sollte erscheinen, der Ihnen ermöglicht, verschiedene
+Einstellungen vorzunehmen, sollten Sie dies wünschen (es sollte jedoch in
 Ordnung sein, alles voreingestellt zu belassen). Bestätigen Sie diesen Dialog.
 
-5. Wählen Sie das Spiel aus der Liste aus, welches Sie spielen möchten, und 
+5. Wählen Sie das Spiel aus der Liste aus, welches Sie spielen möchten, und
 klicken Sie auf „Starten“.
 
-ScummVM behält die Spiele in der Liste, die Sie hinzufügen. Wenn Sie also 
-ScummVM schließen, werden beim nächsten Start alle Spiele, die Sie zuvor 
-hinzugefügt haben, in der Liste angezeigt. Sie können somit direkt zu Schritt 5 
+ScummVM behält die Spiele in der Liste, die Sie hinzufügen. Wenn Sie also
+ScummVM schließen, werden beim nächsten Start alle Spiele, die Sie zuvor
+hinzugefügt haben, in der Liste angezeigt. Sie können somit direkt zu Schritt 5
 übergehen, außer Sie wollen noch mehr Spiele hinzufügen.
 
-Tipp: Wenn Sie mehrere Spiele auf einmal hinzufügen möchten, drücken Sie die 
-Umschalt-Taste (Shift), bevor Sie auf „Spiel hinzufügen“ klicken. Diese 
-Schaltfläche wird somit ihren Text zu „Durchsuchen“ umändern und wenn Sie dann 
-auf diese klicken, werden Sie auch dazu aufgefordert, ein Verzeichnis 
-auszuwählen, nur dieses Mal wird ScummVM alle Unterverzeichnisse automatisch 
+Tipp: Wenn Sie mehrere Spiele auf einmal hinzufügen möchten, drücken Sie die
+Umschalt-Taste (Shift), bevor Sie auf „Spiel hinzufügen“ klicken. Diese
+Schaltfläche wird somit ihren Text zu „Durchsuchen“ umändern und wenn Sie dann
+auf diese klicken, werden Sie auch dazu aufgefordert, ein Verzeichnis
+auszuwählen, nur dieses Mal wird ScummVM alle Unterverzeichnisse automatisch
 nach unterstützen Spielen durchsuchen.
 
 
 2.0) Kontakt:
 ---- --------
-Der einfachste Weg, um mit dem ScummVM-Team in Verbindung zu treten, ist, 
-Fehlerberichte einzusenden (siehe Abschnitt 2.1) oder durch Verwendung des 
+Der einfachste Weg, um mit dem ScummVM-Team in Verbindung zu treten, ist,
+Fehlerberichte einzusenden (siehe Abschnitt 2.1) oder durch Verwendung des
 Forums unter der Adresse http://forums.scummvm.org .
-Sie können ebenso der Mailing-Liste scummvm-devel beitreten und an diese E-Mails 
-versenden oder mit uns im IRC chatten (#scummvm unter irc.freenode.net). Bitte 
-fordern Sie uns nicht dazu auf, ein nicht unterstütztes Spiel zu unterstützen. 
-Lesen Sie zuerst die Seite FAQ (Häufig gestellte Fragen) auf unserer Website. 
-Bitte beachten Sie, dass die offizielle Sprache des Forums, der Mailing-Liste 
-und des Chats Englisch ist und keine andere Sprache dort verwendet werden 
+Sie können ebenso der Mailing-Liste scummvm-devel beitreten und an diese E-Mails
+versenden oder mit uns im IRC chatten (#scummvm unter irc.freenode.net). Bitte
+fordern Sie uns nicht dazu auf, ein nicht unterstütztes Spiel zu unterstützen.
+Lesen Sie zuerst die Seite FAQ (Häufig gestellte Fragen) auf unserer Website.
+Bitte beachten Sie, dass die offizielle Sprache des Forums, der Mailing-Liste
+und des Chats Englisch ist und keine andere Sprache dort verwendet werden
 sollte.
 
 
 2.1) Fehler berichten:
 ---- -----------------
-Um einen Fehler zu berichten, erstellen Sie bitte ein SourceForge-Konto und 
-folgen Sie dem Link „Bug Tracker“ auf der ScummVM-Website. Bitte stellen Sie 
-sicher, dass sich der Bug wiedererzeugen lässt und immer noch in der neusten 
-Version von SVN oder des Daily Builds auftritt. Bitte sehen Sie auch auf der 
-Kompatibilitätsliste der ScummVM-Website für dieses Spiel nach, um 
+Um einen Fehler zu berichten, erstellen Sie bitte ein SourceForge-Konto und
+folgen Sie dem Link „Bug Tracker“ auf der ScummVM-Website. Bitte stellen Sie
+sicher, dass sich der Bug wiedererzeugen lässt und immer noch in der neusten
+Version von Git oder des Daily Builds auftritt. Bitte sehen Sie auch auf der
+Kompatibilitätsliste der ScummVM-Website für dieses Spiel nach, um
 sicherzustellen, dass das Problem nicht bereits bekannt ist:
 
   http://www.scummvm.org/compatibility_stable.php
 
-Bitte berichten Sie keine Fehler zu Spielen, die nicht als durchspielbar im 
+Bitte berichten Sie keine Fehler zu Spielen, die nicht als durchspielbar im
 Bereich „Supported Games“ oder der Kompatibilitätsliste aufgelistet sind.
 Wir -wissen-, dass diese Spiele Fehler aufweisen.
 
 Bitte liefern Sie folgende Informationen:
-    - ScummVM-Version (BITTE mit neuster Version von SVN oder des Daily Builds
+    - ScummVM-Version (BITTE mit neuster Version von Git oder des Daily Builds
       testen)
     - Einzelheiten zum Fehler, einschließlich Anweisungen, um den Fehler
       hervorzurufen
@@ -183,21 +198,21 @@ Bitte liefern Sie folgende Informationen:
     - Version des Spiels (Version mit Sprachausgabe [Talkie],
       Diskettenversion, ...)
     - Plattform und gegebenenfalls Compiler (Win32, Linux, FreeBSD, ...)
-    - Fügen Sie – wenn möglich - einen Speicherstand hinzu.
+    - Fügen Sie - wenn möglich - einen Speicherstand hinzu.
     - Wenn dieser Fehler erst seit kurzem Auftritt, teilen Sie bitte die letzte
       Version ohne den Fehler mit und die erste Version mit diesem Fehler.
       Auf diese Weise können wir diesen schneller beseitigen, indem wir die
       vorgenommen Veränderungen einsehen.
 
-Zum Schluss möchten wir Sie noch bitten, jeden Punkt einzeln zu berichten. Bitte 
-senden Sie nicht mehrere Punkte mit demselben Ticket ein, ansonsten wird es 
-schwierig, den Status jedes einzelnen Fehlers zu verfolgen. Denken Sie bitte 
+Zum Schluss möchten wir Sie noch bitten, jeden Punkt einzeln zu berichten. Bitte
+senden Sie nicht mehrere Punkte mit demselben Ticket ein, ansonsten wird es
+schwierig, den Status jedes einzelnen Fehlers zu verfolgen. Denken Sie bitte
 auch daran, dass alle Fehlerberichte in Englisch verfasst sein müssen.
 
 
 3.0) Unterstützte Spiele:
 ---- --------------------
-Im Moment gelten folgende Spiele als funktionsfähig gemeldet und sollten bis zum 
+Im Moment gelten folgende Spiele als funktionsfähig gemeldet und sollten bis zum
 Ende spielbar sein:
 
 SCUMM-Spiele von LucasArts:
@@ -293,6 +308,7 @@ SCUMM-Spiele von Humongous Entertainment:
      Blue's 123 Time Activities                  [Blues123Time]
      Blue's ABC Time Activities                  [BluesABCTime]
      Blue's Art Time Activities                  [arttime]
+     Blue's Birthday Adventure                   [BluesBirthday]
      Blue's Reading Time Activities              [readtime]
      Fatty Bear's Birthday Surprise              [fbear]
      Fatty Bear's Fun Pack                       [fbpack]
@@ -347,11 +363,11 @@ Spiele von Living Books:
      The Berenstain Bears in the Dark            [beardark]
      The New Kid on the Block                    [newkid]
 
-Die folgenden Spiele sollten geladen werden, sind aber noch nicht vollständig 
-spielbar. Spielen erfolgt auf eigenes Risiko. Bitte reichen Sie für diese Spiele 
+Die folgenden Spiele sollten geladen werden, sind aber noch nicht vollständig
+spielbar. Spielen erfolgt auf eigenes Risiko. Bitte reichen Sie für diese Spiele
 keine Fehlerberichte ein.
-Wenn Sie über den neusten Stand bezüglich der Kompatibilität des Spiels erfahren 
-möchten, besuchen Sie unsere Website und schauen Sie in der Kompatibilitätsliste 
+Wenn Sie über den neusten Stand bezüglich der Kompatibilität des Spiels erfahren
+möchten, besuchen Sie unsere Website und schauen Sie in der Kompatibilitätsliste
 nach.
 
      Backyard Baseball 2003                      [baseball2003]
@@ -359,38 +375,37 @@ nach.
      Backyard Soccer                             [soccer]
      Backyard Soccer MLS                         [soccermls]
      Backyard Soccer 2004                        [soccer2004]
-     Blue's Birthday Adventure                   [BluesBirthday]
      Blue's Treasure Hunt                        [BluesTreasureHunt]
      Pajama Sam: Games to Play on Any Day        [pjgames]
 
-Die folgenden Spiele basieren auf der SCUMM-Engine, werden aber (noch) nicht von 
+Die folgenden Spiele basieren auf der SCUMM-Engine, werden aber (noch) nicht von
 ScummVM unterstützt:
 
      Andere Spiele von Humongous Entertainment
 
-Seien Sie sich bitte bewusst, dass die Engines („Motoren“ der Spiele) Fehler 
-enthalten können und manche Funktionen möglicherweise fehlen, was es unmöglich 
-macht, das Spiel zu Ende zu spielen. Speichern Sie oft und bitte schicken Sie 
-englische Fehlerberichte ein (Anweisungen zum Senden von Fehlerberichten finden 
-Sie oben), wenn Sie einen solchen Fehler in einem „unterstützten“ Spiel 
+Seien Sie sich bitte bewusst, dass die Engines („Motoren“ der Spiele) Fehler
+enthalten können und manche Funktionen möglicherweise fehlen, was es unmöglich
+macht, das Spiel zu Ende zu spielen. Speichern Sie oft und bitte schicken Sie
+englische Fehlerberichte ein (Anweisungen zum Senden von Fehlerberichten finden
+Sie oben), wenn Sie einen solchen Fehler in einem „unterstützten“ Spiel
 vorfinden.
 
 
 3.1) Kopierschutz:
 ---- -------------
-Das ScummVM-Team duldet keine Spielepiraterie. Es gibt jedoch Fälle, in denen 
-die Spielefirmen (wie beispielsweise LucasArts) selbst „gecrackte“ 
-Ausführdateien in ihre Spiele gepackt haben -- in diesen Fällen beinhalten die 
-Dateien des Spiels immer noch die Kopierschutzskripte, aber der Interpreter 
-umgeht sie (ähnlich wie illegale gecrackte Versionen es tun können, nur dass es 
-hier der Spielehersteller getan hat). Es gibt für uns keinerlei Möglichkeit, den 
-Unterschied zwischen einer legitimen und einer illegalen Spieldatei zu erkennen, 
-also wird ScummVM bei Spielen, von denen wir wissen, dass eine gecrackte Version 
-des Orginalinterpreters zu irgendeinem Zeitpunkt verkauft wurde, immer den 
+Das ScummVM-Team duldet keine Spielepiraterie. Es gibt jedoch Fälle, in denen
+die Spielefirmen (wie beispielsweise LucasArts) selbst „gecrackte“
+Ausführdateien in ihre Spiele gepackt haben -- in diesen Fällen beinhalten die
+Dateien des Spiels immer noch die Kopierschutzskripte, aber der Interpreter
+umgeht sie (ähnlich wie illegale gecrackte Versionen es tun können, nur dass es
+hier der Spielehersteller getan hat). Es gibt für uns keinerlei Möglichkeit, den
+Unterschied zwischen einer legitimen und einer illegalen Spieldatei zu erkennen,
+also wird ScummVM bei Spielen, von denen wir wissen, dass eine gecrackte Version
+des Orginalinterpreters zu irgendeinem Zeitpunkt verkauft wurde, immer den
 Kopierschutz umgehen müssen.
 
-In einigen Fällen wird ScummVM immer noch den Kopierschutzbildschirm anzeigen. 
-Versuchen Sie, irgendeine Antwort einzugeben. Die Chancen stehen gut, dass sie 
+In einigen Fällen wird ScummVM immer noch den Kopierschutzbildschirm anzeigen.
+Versuchen Sie, irgendeine Antwort einzugeben. Die Chancen stehen gut, dass sie
 akzeptiert wird.
 
 ScummVM wird den Kopierschutz in folgenden Spielen überspringen:
@@ -413,35 +428,35 @@ ScummVM wird den Kopierschutz in folgenden Spielen überspringen:
 
 3.2) Hinweise zu Commodore64-Spielen:
 ---- --------------------------------
-Sowohl Maniac Mansion als auch Zak McKracken laufen, aber Maniac Mansion ist 
-noch nicht spielbar. Benennen Sie einfach die D64-Datenträger um in 
-„maniac1.d64“ und „maniac2.d64“ und entsprechend „zak1.d64“ und „zak2.d64“, dann 
-sollte ScummVM in der Lage sein, das Spiel automatisch zu erkennen, wenn Sie auf 
+Sowohl Maniac Mansion als auch Zak McKracken laufen, aber Maniac Mansion ist
+noch nicht spielbar. Benennen Sie einfach die D64-Datenträger um in
+„maniac1.d64“ und „maniac2.d64“ und entsprechend „zak1.d64“ und „zak2.d64“, dann
+sollte ScummVM in der Lage sein, das Spiel automatisch zu erkennen, wenn Sie auf
 das richtige Verzeichnis zeigen.
 
-Alternativ können Sie „extract_mm_c64“ aus dem Tools-Paket verwenden, um die 
-Spieldateien zu extrahieren. Dann wird das Spiel jedoch nicht einwandfrei von 
-ScummVM automatisch erkannt und Sie müssen sicherstellen, dass Commodore64 als 
-Plattform eingestellt ist. Wir empfehlen, auf die viel einfachere Methode 
+Alternativ können Sie „extract_mm_c64“ aus dem Tools-Paket verwenden, um die
+Spieldateien zu extrahieren. Dann wird das Spiel jedoch nicht einwandfrei von
+ScummVM automatisch erkannt und Sie müssen sicherstellen, dass Commodore64 als
+Plattform eingestellt ist. Wir empfehlen, auf die viel einfachere Methode
 zurückzugreifen, die im vorherigen Absatz beschrieben ist.
 
 
 3.3) Hinweise zu Maniac Mansion NES:
 ---- -------------------------------
-Unterstützte Versionen sind Deutsch (G) [G=German], Englisch GB (E), Französisch 
-(F), Italienisch (I), Schwedisch (SW) und Englisch US (U). ScummVM benötigt nur 
+Unterstützte Versionen sind Deutsch (G) [G=German], Englisch GB (E), Französisch
+(F), Italienisch (I), Schwedisch (SW) und Englisch US (U). ScummVM benötigt nur
 den PRG-Bereich und nicht die gesamte ROM-Datei, um das Spiel laufen zu lassen.
 
-Damit das Spiel funktioniert, müssen Sie die ersten 16 Bytes aus der ROM-Datei 
-entfernen, die Sie verwenden wollen. Das klappt mit jedem Hexeditor, solange Sie 
-mit diesem kopieren und einfügen können. Nachdem Sie die ROM-Datei mit dem 
-Hexeditor geöffnet haben, kopieren Sie alles von der zweiten Reihe (17. Byte) 
-bis zum Ende. Danach fügen Sie den kopierten Inhalt in eine neue Hexdatei ein. 
-Speichern Sie die neue Datei unter dem Namen „Maniac Mansion (XX).prg“, wobei XX 
-für die Sprachversion steht, die Sie verwenden wollen (G, E, F, I, SW oder U). 
+Damit das Spiel funktioniert, müssen Sie die ersten 16 Bytes aus der ROM-Datei
+entfernen, die Sie verwenden wollen. Das klappt mit jedem Hexeditor, solange Sie
+mit diesem kopieren und einfügen können. Nachdem Sie die ROM-Datei mit dem
+Hexeditor geöffnet haben, kopieren Sie alles von der zweiten Reihe (17. Byte)
+bis zum Ende. Danach fügen Sie den kopierten Inhalt in eine neue Hexdatei ein.
+Speichern Sie die neue Datei unter dem Namen „Maniac Mansion (XX).prg“, wobei XX
+für die Sprachversion steht, die Sie verwenden wollen (G, E, F, I, SW oder U).
 Die Größe der neuen Datei sollte genau 262144 Bytes betragen.
 
-Wenn Sie das Spiel manuell hinzufügen, stellen Sie sicher, dass die Plattform 
+Wenn Sie das Spiel manuell hinzufügen, stellen Sie sicher, dass die Plattform
 auf NES eingestellt ist.
 
 Die häufigsten Fehler, die verhindern, dass das Spiel läuft:
@@ -451,36 +466,36 @@ Die häufigsten Fehler, die verhindern, dass das Spiel läuft:
   * Sie versuchen, in ScummVM die VOLLE ROM-DATEI zu laden und nicht nur den
     PRG-Bereich.
 
-Es ist auch möglich, die einzelnen LFL-Dateien aus dem PRG-Bereich zu 
-extrahieren. Um dies zu tun, verwenden Sie das Dienstprogramm „extract_mm_nes“ 
+Es ist auch möglich, die einzelnen LFL-Dateien aus dem PRG-Bereich zu
+extrahieren. Um dies zu tun, verwenden Sie das Dienstprogramm „extract_mm_nes“
 aus dem Tools-Paket.
 
 
 3.4) Hinweise zu Macintosh-Spielen:
 ---- ------------------------------
-Alle auf SCUMM basierenden Adventures von Lucasarts, mit Ausnahme von COMI, 
-existieren auch als Versionen für den Macintosh. ScummVM kann die meisten 
-(alle?) von diesen verwenden, jedoch ist in manchen Fällen zusätzliche Arbeit 
-erforderlich. Zuallererst: Wenn Sie keinen Macintosh dafür verwenden, könnte es 
-kompliziert werden, auf die CD- oder Diskettendaten zuzugreifen. Der Grund 
-hierfür ist, dass der Mac ein spezielles Datenträgerformat nutzt, welches sich 
-HFS nennt, und das andere Systeme normalerweise nicht unterstützen. Es gibt 
+Alle auf SCUMM basierenden Adventures von Lucasarts, mit Ausnahme von COMI,
+existieren auch als Versionen für den Macintosh. ScummVM kann die meisten
+(alle?) von diesen verwenden, jedoch ist in manchen Fällen zusätzliche Arbeit
+erforderlich. Zuallererst: Wenn Sie keinen Macintosh dafür verwenden, könnte es
+kompliziert werden, auf die CD- oder Diskettendaten zuzugreifen. Der Grund
+hierfür ist, dass der Mac ein spezielles Datenträgerformat nutzt, welches sich
+HFS nennt, und das andere Systeme normalerweise nicht unterstützen. Es gibt
 jedoch zahlreiche kostenlose Tools, die es ermöglichen, einen solchen HFS-
-Datenträger zu lesen. Z. B. „HFVExplorer“ für Windows und „hfsutils“ für Linux 
+Datenträger zu lesen. Z. B. „HFVExplorer“ für Windows und „hfsutils“ für Linux
 und andere Betriebssysteme, die Unix ähnlich sind.
 
-Die meisten neueren Spiele für den Macintosh wurden nur mit einer einzigen 
-Spieldatei ausgeliefert (beachten Sie, dass in manchen Fällen diese Spieldatei 
-unsichtbar gemacht wurde und Sie somit zusätzliche Tools benötigen, um diese zu 
-kopieren). ScummVM ist in der Lage, eine solche Spieldatei direkt zu verwenden; 
-verweisen Sie ScummVM einfach auf das Verzeichnis, welches diese enthält und es 
+Die meisten neueren Spiele für den Macintosh wurden nur mit einer einzigen
+Spieldatei ausgeliefert (beachten Sie, dass in manchen Fällen diese Spieldatei
+unsichtbar gemacht wurde und Sie somit zusätzliche Tools benötigen, um diese zu
+kopieren). ScummVM ist in der Lage, eine solche Spieldatei direkt zu verwenden;
+verweisen Sie ScummVM einfach auf das Verzeichnis, welches diese enthält und es
 sollte klappen (so wie mit jedem anderen unterstützten Spiel).
 
-Wir stellen außerdem ein Tool mit dem Namen „extract_scumm_mac“ im Tools-Paket 
-zur Verfügung, um die Daten aus diesen Spieldateien zu extrahieren, aber dies 
+Wir stellen außerdem ein Tool mit dem Namen „extract_scumm_mac“ im Tools-Paket
+zur Verfügung, um die Daten aus diesen Spieldateien zu extrahieren, aber dies
 ist weder erforderlich noch wird es empfohlen.
 
-Für weitere Informationen dazu, wie Sie Macintosh-Spieldateien auf Ihre 
+Für weitere Informationen dazu, wie Sie Macintosh-Spieldateien auf Ihre
 Festplatte kopieren können, lesen Sie:
 
   http://wiki.scummvm.org/index.php/HOWTO-Mac_Games
@@ -488,211 +503,211 @@ Festplatte kopieren können, lesen Sie:
 
 3.5) Hinweise zu Spielen auf mehren CDs:
 ---- -----------------------------------
-Allgemein kann ScummVM nicht sehr gut mit Spielen auf mehreren CDs umgehen. Das 
-liegt daran, dass ScummVM annimmt, alles von einem Spiel in einem Verzeichnis 
-vorzufinden. Selbst wenn ScummVM einige Fälle berücksichtigt und den Anwender 
-dazu auffordert, die CD zu wechseln, so installierten die ursprünglichen 
-ausführbaren Dateien des Spiels normalerweise eine kleine Anzahl an Dateien auf 
-die Festplatte. Sofern diese Dateien nicht auf allen CDs vorgefunden werden 
+Allgemein kann ScummVM nicht sehr gut mit Spielen auf mehreren CDs umgehen. Das
+liegt daran, dass ScummVM annimmt, alles von einem Spiel in einem Verzeichnis
+vorzufinden. Selbst wenn ScummVM einige Fälle berücksichtigt und den Anwender
+dazu auffordert, die CD zu wechseln, so installierten die ursprünglichen
+ausführbaren Dateien des Spiels normalerweise eine kleine Anzahl an Dateien auf
+die Festplatte. Sofern diese Dateien nicht auf allen CDs vorgefunden werden
 können, wird ScummVM Schwierigkeiten haben.
 
-Glücklicherweise hat ScummVM keine Probleme damit, die Spiele komplett von der 
-Festplatte aus laufen zu lassen, wenn Sie ein Verzeichnis mit der richtigen 
-Kombination der Dateien erstellen. Wenn eine Datei auf mehr als einer CD 
-vorkommt, ist es normalerweise egal, welche sie in das Verzeichnis 
+Glücklicherweise hat ScummVM keine Probleme damit, die Spiele komplett von der
+Festplatte aus laufen zu lassen, wenn Sie ein Verzeichnis mit der richtigen
+Kombination der Dateien erstellen. Wenn eine Datei auf mehr als einer CD
+vorkommt, ist es normalerweise egal, welche sie in das Verzeichnis
 hineinkopieren.
 
 
 3.6) Hinweise zu The Curse of Monkey Island:
 ---- ---------------------------------------
-Für dieses Spiel benötigen Sie die Dateien comi.la0, comi.la1 und comi.la2. Die 
-Datei comi.la0 kann auf beiden CDs vorgefunden werden, ist aber auf beiden 
+Für dieses Spiel benötigen Sie die Dateien comi.la0, comi.la1 und comi.la2. Die
+Datei comi.la0 kann auf beiden CDs vorgefunden werden, ist aber auf beiden
 identisch, womit es egal ist, welche der beiden Sie verwenden.
 
-Zusätzlich müssen Sie ein Unterverzeichnis namens „resource“ erstellen, das alle 
-Dateien des Unterverzeichnisses „resource“ auf –beiden- CDs beinhaltet. Einige 
-dieser Dateien lassen sich auf beiden CDs vorfinden, jedoch sind sie auch in 
+Zusätzlich müssen Sie ein Unterverzeichnis namens „resource“ erstellen, das alle
+Dateien des Unterverzeichnisses „resource“ auf -beiden- CDs beinhaltet. Einige
+dieser Dateien lassen sich auf beiden CDs vorfinden, jedoch sind sie auch in
 diesem Fall identisch.
 
 
 3.7) Hinweise zu den Baphomets-Fluch-Spielen:
 ---- ----------------------------------------
-Die Anweisungen für die Baphomets-Fluch-Spiele sind für die ausverkauften 
-Software-Versionen, bei welchen sich jedes Spiel auf je zwei CDs befindet, da 
-diese am leichtesten erhältlich waren, als ScummVM Unterstützung für diese 
-Spiele erlangte. Wir hoffen, dass sie allgemein ausreichend ausführlich sind, um 
+Die Anweisungen für die Baphomets-Fluch-Spiele sind für die ausverkauften
+Software-Versionen, bei welchen sich jedes Spiel auf je zwei CDs befindet, da
+diese am leichtesten erhältlich waren, als ScummVM Unterstützung für diese
+Spiele erlangte. Wir hoffen, dass sie allgemein ausreichend ausführlich sind, um
 für andere Ausgaben genauso hilfreich zu sein.
 
 
 3.7.1) Zwischensequenzen der Baphomets-Fluch-Spiele:
 ------ ---------------------------------------------
-Die Zwischensequenzen für die Baphomets-Fluch-Spiele haben eine kleine 
-Geschichte (schauen Sie im nächsten Abschnitt, wenn Sie interessiert sind), aber 
-im Großen und Ganzen müssen Sie nur die .SMK-Dateien aus den „SMACKS“- oder 
-„SMACKSHI“-Verzeichnissen auf den CDs in dasselbe Verzeichnis wie die anderen 
-Spieldateien kopieren. (Baphomets Fluch hat ein „SMACKSLO“-Verzeichnis mit 
-denselben Zwischensequenzen, aber diese sind von niedrigerer Qualität.) Sie 
-können sie auch in einem Unterverzeichnis namens „video“ ablegen, wenn Ihnen das 
+Die Zwischensequenzen für die Baphomets-Fluch-Spiele haben eine kleine
+Geschichte (schauen Sie im nächsten Abschnitt, wenn Sie interessiert sind), aber
+im Großen und Ganzen müssen Sie nur die .SMK-Dateien aus den „SMACKS“- oder
+„SMACKSHI“-Verzeichnissen auf den CDs in dasselbe Verzeichnis wie die anderen
+Spieldateien kopieren. (Baphomets Fluch hat ein „SMACKSLO“-Verzeichnis mit
+denselben Zwischensequenzen, aber diese sind von niedrigerer Qualität.) Sie
+können sie auch in einem Unterverzeichnis namens „video“ ablegen, wenn Ihnen das
 lieber ist.
 
-Einige Neuausgaben der Spiele, wie beispielsweise die PlayStation-Version, haben 
-keine Smacker-Videos. Revolution Software hat uns freundlicherweise erlaubt, die 
-Zwischensequenzen umgewandelt auf unserer Website als Download zur Verfügung zu 
+Einige Neuausgaben der Spiele, wie beispielsweise die PlayStation-Version, haben
+keine Smacker-Videos. Revolution Software hat uns freundlicherweise erlaubt, die
+Zwischensequenzen umgewandelt auf unserer Website als Download zur Verfügung zu
 stellen. Siehe hierfür:
 
   http://www.scummvm.org/downloads.php
 
-Diese Zwischensequenzen werden im DXA-Format mit FLAC-Audio zur Verfügung 
-gestellt. Ihre Qualität ist durch die Verwendung verlustfreier Kompression 
-gleich wie im Originalspiel. Um diese Zwischensequenzen abspielen zu können, ist 
-eine Version von ScummVM erforderlich, die sowohl mit Unterstützung von FLAC als 
+Diese Zwischensequenzen werden im DXA-Format mit FLAC-Audio zur Verfügung
+gestellt. Ihre Qualität ist durch die Verwendung verlustfreier Kompression
+gleich wie im Originalspiel. Um diese Zwischensequenzen abspielen zu können, ist
+eine Version von ScummVM erforderlich, die sowohl mit Unterstützung von FLAC als
 auch zlib kompiliert wurde.
 
-Für Systeme, die zu langsam sind, um die Entschlüsselung von FLAC-Audio zu 
+Für Systeme, die zu langsam sind, um die Entschlüsselung von FLAC-Audio zu
 handhaben, wird die Tonspur für diese Zwischensequenzen gesondert auch mit Ogg-
-Vorbis-Audio angeboten. Um diese Zwischensequenzen mit Ogg-Vorbis-Audio 
-abspielen zu können, ist eine Version von ScummVM erforderlich, die sowohl mit 
+Vorbis-Audio angeboten. Um diese Zwischensequenzen mit Ogg-Vorbis-Audio
+abspielen zu können, ist eine Version von ScummVM erforderlich, die sowohl mit
 Unterstützung von libVorbis als auch zlib kompiliert wurde.
 
-Für Baphomets Fluch bieten wir auch ein Untertitel-Paket an. Entpacken Sie es 
-einfach und folgen Sie den Anweisungen in der liesmich.txt. (Baphomets Fluch II 
+Für Baphomets Fluch bieten wir auch ein Untertitel-Paket an. Entpacken Sie es
+einfach und folgen Sie den Anweisungen in der liesmich.txt. (Baphomets Fluch II
 hat bereits Untertitel; für diese ist keine zusätzliche Arbeit notwendig.)
 
 
 3.7.2) Zwischensequenzen der Baphomets-Fluch-Spiele im Rückblick
 ------ ---------------------------------------------------------
-Die Originalausgaben der Baphomets-Fluch-Spiele verwendeten das Smacker™-Format 
-der RAD Game Tools. Da RAD uns nicht die ältere Ur-Version dieses Formats 
-offenlegen wollte und uns aufforderte, es nicht mittels Reverse Engineering zu 
+Die Originalausgaben der Baphomets-Fluch-Spiele verwendeten das Smacker™-Format
+der RAD Game Tools. Da RAD uns nicht die ältere Ur-Version dieses Formats
+offenlegen wollte und uns aufforderte, es nicht mittels Reverse Engineering zu
 rekonstruieren, musste eine alternative Lösung gefunden werden.
 
-In Baphomets Fluch II war es möglich, die Sprachausgabe ohne das Video 
-wiederzugeben. Dies blieb bis ScummVM 1.0.0 eine Ausweichmöglichkeit, war aber 
+In Baphomets Fluch II war es möglich, die Sprachausgabe ohne das Video
+wiederzugeben. Dies blieb bis ScummVM 1.0.0 eine Ausweichmöglichkeit, war aber
 nie die alleinige Lösung für eine stabile Veröffentlichung.
 
-In ScummVM 0.6.0 verwendeten wir MPEG, das einen zumutbaren Kompromiss zwischen 
-Größe und Qualität bot. In ScummVM 0.10.0 wurde dies durch DXA abgelöst (das 
-ursprünglich für Adventure Softs „Floyd – Es gibt noch Helden“ hinzugefügt 
-wurde). Dies gab uns die Möglichkeit, die Zwischensequenzen mit genau derselben 
-Qualität wie im Original anzubieten, zu dem Preis, dass die Dateien größer 
+In ScummVM 0.6.0 verwendeten wir MPEG, das einen zumutbaren Kompromiss zwischen
+Größe und Qualität bot. In ScummVM 0.10.0 wurde dies durch DXA abgelöst (das
+ursprünglich für Adventure Softs „Floyd - Es gibt noch Helden“ hinzugefügt
+wurde). Dies gab uns die Möglichkeit, die Zwischensequenzen mit genau derselben
+Qualität wie im Original anzubieten, zu dem Preis, dass die Dateien größer
 waren.
 
-Schließlich wurde Anfang 2006 das Smacker-Format für das FFmpeg-Projekt mittels 
-Reverse Engineering rekonstruiert. Dank der harten Arbeit in diesem Projekt 
-unterstützt ScummVM nun die originalen Zwischensequenzen. Zur selben Zeit wurde 
-die MPEG-Unterstützung eingestellt. Vom technischen Standpunkt war das eine gute 
-Sache, da das Entschlüsseln von MPEG-Filmen mit vielen Schwierigkeiten verbunden 
+Schließlich wurde Anfang 2006 das Smacker-Format für das FFmpeg-Projekt mittels
+Reverse Engineering rekonstruiert. Dank der harten Arbeit in diesem Projekt
+unterstützt ScummVM nun die originalen Zwischensequenzen. Zur selben Zeit wurde
+die MPEG-Unterstützung eingestellt. Vom technischen Standpunkt war das eine gute
+Sache, da das Entschlüsseln von MPEG-Filmen mit vielen Schwierigkeiten verbunden
 war und diese ohnehin nicht so gut aussahen wie Smacker- und DXA-Versionen.
 
 
 3.7.3) Baphomets Fluch:
 ------ ----------------
-Für dieses Spiel benötigen Sie die Dateien aus dem Verzeichnis clusters von 
-beiden CDs. Für die Windows- und Macintosh-Versionen benötigen Sie auch die 
-Datei speech.clu aus dem Verzeichnis speech von beiden CDs. Da diese jedoch 
-nicht identisch sind, müssen Sie diese in speech1.clu und speech2.clu für CD 1 
-und 2 entsprechend umbenennen. Die PlayStation-Version erfordert die Dateien 
+Für dieses Spiel benötigen Sie die Dateien aus dem Verzeichnis clusters von
+beiden CDs. Für die Windows- und Macintosh-Versionen benötigen Sie auch die
+Datei speech.clu aus dem Verzeichnis speech von beiden CDs. Da diese jedoch
+nicht identisch sind, müssen Sie diese in speech1.clu und speech2.clu für CD 1
+und 2 entsprechend umbenennen. Die PlayStation-Version erfordert die Dateien
 speech.tab, speech.dat, speech.lis, und speech.inf.
 
-Zusätzlich benötigen die Windows- und Macintosh-Versionen das Unterverzeichnis 
-„music“ mit allen Dateien der „music“-Unterverzeichnisse auf beiden CDs. Einige 
-dieser Dateien tauchen auf beiden CDs auf, aber in diesen Fällen sind sie 
-entweder identisch oder in einem Fall nahezu so identisch, dass es wenig 
-Unterschied macht. Die PlayStation-Version erfordert die Dateien tunes.dat und 
+Zusätzlich benötigen die Windows- und Macintosh-Versionen das Unterverzeichnis
+„music“ mit allen Dateien der „music“-Unterverzeichnisse auf beiden CDs. Einige
+dieser Dateien tauchen auf beiden CDs auf, aber in diesen Fällen sind sie
+entweder identisch oder in einem Fall nahezu so identisch, dass es wenig
+Unterschied macht. Die PlayStation-Version erfordert die Dateien tunes.dat und
 tunes.tab.
 
 
 3.7.4) Baphomets Fluch II:
 ------ -------------------
-Für dieses Spiel benötigen Sie die Dateien aus dem Verzeichnis clusters von 
-beiden CDs. (Ein paar von ihnen sind streng genommen eigentlich nicht notwendig, 
+Für dieses Spiel benötigen Sie die Dateien aus dem Verzeichnis clusters von
+beiden CDs. (Ein paar von ihnen sind streng genommen eigentlich nicht notwendig,
 aber diejenigen, über die Unsicherheit besteht, sind alle ziemlich klein.)
-Sie müssen die Dateien speech.clu und music.clu umbenennen, und zwar in 
-speech1.clu, speech2.clu, music1.clu und music2.clu, sodass ScummVM weiß, welche 
-der Dateien von CD 1 und welche von CD 2 sind. Alle anderen Dateien, die in 
-beiden „clusters“-Verzeichnissen auftauchen, sind identisch. Verwenden Sie in 
+Sie müssen die Dateien speech.clu und music.clu umbenennen, und zwar in
+speech1.clu, speech2.clu, music1.clu und music2.clu, sodass ScummVM weiß, welche
+der Dateien von CD 1 und welche von CD 2 sind. Alle anderen Dateien, die in
+beiden „clusters“-Verzeichnissen auftauchen, sind identisch. Verwenden Sie in
 diesen Fällen die Datei, die Sie möchten.
 
-Zusätzlich brauchen Sie die Datei cd.inf und optional die Datei startup.inf aus 
+Zusätzlich brauchen Sie die Datei cd.inf und optional die Datei startup.inf aus
 dem Verzeichnis sword2 von CD 1.
 
 
 3.8) Hinweise zu Beneath a Steel Sky:
 ---- --------------------------------
-Beginnend mit ScummVM 0.8.0 benötigen Sie die zusätzliche Datei „SKY.CPT“, um 
+Beginnend mit ScummVM 0.8.0 benötigen Sie die zusätzliche Datei „SKY.CPT“, um
 Beneath a Steel Sky laufen lassen.
 
-Diese Datei ist auf der Seite „Downloads“ der ScummVM-Website verfügbar. Sie 
-können sie entweder im Verzeichnis mit den anderen Spieldateien (SKY.DNR, 
-SKY.DSK) ablegen, in einem Extrapfad oder im Verzeichnis, in dem sich Ihre 
+Diese Datei ist auf der Seite „Downloads“ der ScummVM-Website verfügbar. Sie
+können sie entweder im Verzeichnis mit den anderen Spieldateien (SKY.DNR,
+SKY.DSK) ablegen, in einem Extrapfad oder im Verzeichnis, in dem sich Ihre
 ausführbare ScummVM-Datei befindet.
 
 
 3.9) Hinweise zu Flight of the Amazon Queen:
 ---- ---------------------------------------
-Um eine Nicht-Freeware-Version von Flight of the Amazon Queen zu verwenden (von 
-einer Original-CD), müssen Sie die Datei „queen.tbl“ (erhältlich von der Seite 
-„Downloads“ auf unserer Website) entweder im Verzeichnis mit der Spieldatei 
-„queen.1“ ablegen, in einem Extrapfad oder im Verzeichnis, in dem sich Ihre 
+Um eine Nicht-Freeware-Version von Flight of the Amazon Queen zu verwenden (von
+einer Original-CD), müssen Sie die Datei „queen.tbl“ (erhältlich von der Seite
+„Downloads“ auf unserer Website) entweder im Verzeichnis mit der Spieldatei
+„queen.1“ ablegen, in einem Extrapfad oder im Verzeichnis, in dem sich Ihre
 ausführbare ScummVM-Datei befindet.
 
-Alternativ können Sie das Tool „compress_queen“ aus dem Tools-Paket verwenden, 
-um Ihre FOTAQ-Spieldatei neu „zusammenzubauen“, um die Tabellendatei für diese 
-spezielle Version miteinzubeziehen und somit die Laufzeit-Abhängigkeit von der 
-Datei „queen.tbl“ zu lösen. Dieses Tool kann auch die Sprachausgabe und 
-Soundeffekte mittels MP3, OGG oder FLAC komprimieren.
+Alternativ können Sie das Tool „compress_queen“ aus dem Tools-Paket verwenden,
+um Ihre FOTAQ-Spieldatei neu „zusammenzubauen“, um die Tabellendatei für diese
+spezielle Version miteinzubeziehen und somit die Laufzeit-Abhängigkeit von der
+Datei „queen.tbl“ zu lösen. Dieses Tool kann auch die Sprachausgabe und
+Sound-Effekte mittels MP3, OGG oder FLAC komprimieren.
 
 
 3.10) Hinweise zu Gobliiins:
 ----- ----------------------
-Die CD-Versionen der Gobliiins-Serie enthalten einen großen Audio-Titel, den Sie 
+Die CD-Versionen der Gobliiins-Serie enthalten einen großen Audio-Titel, den Sie
 extrahieren müssen (siehe Abschnitt über die Verwendung komprimierter Audio-
-Dateien) sowie ins Spielverzeichnis kopieren, wenn Sie Musik im Spiel hören 
-möchten, ohne die CD die ganze Zeit im Laufwerk haben zu müssen. Die 
-Sprachausgabe ist auch in diesem Titel und ihre Lautstärke wird deshalb ebenso 
+Dateien) sowie ins Spielverzeichnis kopieren, wenn Sie Musik im Spiel hören
+möchten, ohne die CD die ganze Zeit im Laufwerk haben zu müssen. Die
+Sprachausgabe ist auch in diesem Titel und ihre Lautstärke wird deshalb ebenso
 über die Musiklautstärke-Regelung geändert.
 
 
 3.11) Hinweise zu Inherit the Earth: Quest for the Orb (Macintosh):
 ----- -------------------------------------------------------------
-Um die Neuausgabe des Spiels für Mac OS X von Wyrmkeep laufen zu lassen, müssen 
-Sie die Daten von der CD auf die Festplatte kopieren. Wenn Sie an einem PC 
+Um die Neuausgabe des Spiels für Mac OS X von Wyrmkeep laufen zu lassen, müssen
+Sie die Daten von der CD auf die Festplatte kopieren. Wenn Sie an einem PC
 arbeiten, lesen Sie hierfür:
 
   http://wiki.scummvm.org/index.php/HOWTO-Mac_Games
 
-Obwohl hier in erster Linie über SCUMM-Spiele gesprochen wird, findet das 
-Dienstprogramm „HFVExplorer“ Erwähnung, welches Sie benötigen, um die Dateien zu 
-extrahieren. Beachten Sie, dass Sie die Sprachausgabedaten aus „Inherit the 
-Earth Voices“ im selben Verzeichnis ablegen müssen wie die Spieldaten, die sich 
+Obwohl hier in erster Linie über SCUMM-Spiele gesprochen wird, findet das
+Dienstprogramm „HFVExplorer“ Erwähnung, welches Sie benötigen, um die Dateien zu
+extrahieren. Beachten Sie, dass Sie die Sprachausgabedaten aus „Inherit the
+Earth Voices“ im selben Verzeichnis ablegen müssen wie die Spieldaten, die sich
 an folgendem Ort befinden:
 
   Inherit the Earth.app/Contents/Resources
 
-Bei der alten Ausgabe für Mac OS 9 müssen Sie die Dateien im MacBinary-Format 
-kopieren, da sie sowohl Ressourcen- und Datenverzweigungen beinhalten sollten. 
+Bei der alten Ausgabe für Mac OS 9 müssen Sie die Dateien im MacBinary-Format
+kopieren, da sie sowohl Ressourcen- und Datenverzweigungen beinhalten sollten.
 Kopieren Sie alle „ITE *“-Dateien.
 
 
 3.12) Hinweise zu Simon the Sorcerer 1 und 2:
 ----- ---------------------------------------
-Wenn Sie die Doppel-Version von Simon the Sorcerer 1 oder 2 auf CD haben, finden 
-Sie die Windows-Version im Hauptverzeichnis der CD und die DOS-Version im 
+Wenn Sie die Doppel-Version von Simon the Sorcerer 1 oder 2 auf CD haben, finden
+Sie die Windows-Version im Hauptverzeichnis der CD und die DOS-Version im
 DOS-Verzeichnis der CD.
 
 
-3.13) Hinweise zu Floyd – Es gibt noch Helden:
+3.13) Hinweise zu Floyd - Es gibt noch Helden:
 ----- ----------------------------------------
-Wenn Sie die Windows-Version von Floyd – Es gibt noch Helden haben, sind einige 
+Wenn Sie die Windows-Version von Floyd - Es gibt noch Helden haben, sind einige
 Dinge zu beachten.
 
-Viele notwendige Dateien für das Spiel sind in einer InstallShield-Datei namens 
-data1.cab gespeichert, die ScummVM nicht entpacken kann. Sie müssen das 
-Original-Installationsprogramm oder i5comp verwenden, um die Inhalte dieser 
-Datei zu entpacken. Das Tool i5comp für die Dekompression kann durch Suchen im 
+Viele notwendige Dateien für das Spiel sind in einer InstallShield-Datei namens
+data1.cab gespeichert, die ScummVM nicht entpacken kann. Sie müssen das
+Original-Installationsprogramm oder i5comp verwenden, um die Inhalte dieser
+Datei zu entpacken. Das Tool i5comp für die Dekompression kann durch Suchen im
 Internet gefunden werden.
 
-Um die Sprachdateien in ScummVM zu verwenden, müssen sie nach dem Kopiervorgang 
+Um die Sprachdateien in ScummVM zu verwenden, müssen sie nach dem Kopiervorgang
 wie folgt umbenannt werden:
 voices.wav von CD1 in voices1.wav
 voices.wav von CD2 in voices2.wav
@@ -702,69 +717,759 @@ voices.wav von CD4 in voices4.wav
 
 3.14) Hinweise zu The Legend of Kyrandia:
 ----- -----------------------------------
-Um The Legend of Kyrandia unter ScummVM laufen zu lassen, benötigen Sie die 
-Datei „kyra.dat“, welche auf der Seite „Downloads“ der ScummVM-Website gefunden 
+Um The Legend of Kyrandia unter ScummVM laufen zu lassen, benötigen Sie die
+Datei „kyra.dat“, welche auf der Seite „Downloads“ der ScummVM-Website gefunden
 werden kann.
 
 
 3.15) Hinweise zum vorhersagenden Eingabedialog bei Sierras AGI-Spielen:
 ----- ------------------------------------------------------------------
-Der vorhersagende Eingabedialog ist ein ScummVM-Hilfsmittel, um die englischen 
-Spiele der AGI-Engine (die offensichtlich Kommandozeilen-Eingabe erfordern) auf 
-Geräten laufen zu lassen, die eingeschränkte Tastatur-Unterstützung haben. Da es 
-mühsam ist, mit emulierten Tastaturen zu tippen, können in solchen Fällen 
-Befehle schnell und einfach über den vorhersagenden Eingabedialog eingegeben 
+Der vorhersagende Eingabedialog ist ein ScummVM-Hilfsmittel, um die englischen
+Spiele der AGI-Engine (die offensichtlich Kommandozeilen-Eingabe erfordern) auf
+Geräten laufen zu lassen, die eingeschränkte Tastatur-Unterstützung haben. Da es
+mühsam ist, mit emulierten Tastaturen zu tippen, können in solchen Fällen
+Befehle schnell und einfach über den vorhersagenden Eingabedialog eingegeben
 werden.
 
-Um die vorhersagende Eingabe in AGI-Spielen zu aktivieren, müssen Sie die Datei 
-pred.dic in den Extrapfad von ScummVM oder in das Verzeichnis des Spiels 
-kopieren, das Sie spielen möchten. Dieses Wörterbuch wurde erstellt, indem alle 
-bekannten AGI-Spiele analysiert wurden, und enthält den maximalen Satz 
+Um die vorhersagende Eingabe in AGI-Spielen zu aktivieren, müssen Sie die Datei
+pred.dic in den Extrapfad von ScummVM oder in das Verzeichnis des Spiels
+kopieren, das Sie spielen möchten. Dieses Wörterbuch wurde erstellt, indem alle
+bekannten AGI-Spiele analysiert wurden, und enthält den maximalen Satz
 gebräuchlicher Wörter.
 
-Wenn das Wörterbuch erkannt wurde, wird der vorhersagende Eingabedialog entweder 
-durch Klicken auf den Kommandozeilenbereich angezeigt (dort, wo auch immer eine 
-Tastatureingabe erforderlich ist, auch in Dialogfeldern) oder in einigen Ports 
+Wenn das Wörterbuch erkannt wurde, wird der vorhersagende Eingabedialog entweder
+durch Klicken auf den Kommandozeilenbereich angezeigt (dort, wo auch immer eine
+Tastatureingabe erforderlich ist, auch in Dialogfeldern) oder in einigen Ports
 durch Drücken eines bestimmten Tastenkürzels.
 
-Der vorhersagende Eingabedialog funktioniert in drei Modi, zwischen denen mit 
-der Schaltfläche (*)Pre/123/Abc gewechselt werden kann. Die primäre 
-Eingabemethode ist der vorhersagende Modus (Pre), welcher der Worterkennung bei 
-„schnellem Tippen“ auf Mobilfunktelefonen ähnelt. Das Alphabet ist in neun 
-Gruppen unterteilt, die naturgemäß den neun Ziffern auf dem Ziffernblock 
-zugeteilt sind (0 ist die Leertaste). Um ein Wort einzugeben, drücken Sie einmal 
-die Ziffer der Gruppe, die den Buchstaben des Worts enthält, den Sie tippen 
-möchten, dann gehen Sie zum nächsten Buchstaben über. Um z. B. den Befehl „look“ 
-einzugeben, sollten Sie 5665 drücken. Während Sie schrittweise die Ziffernfolge 
-des beabsichtigten Wortes eingeben, wird auf das Wörterbuch zugegriffen, um 
-bekannte Wörter, die mit Ihrer Eingabe bis zu diesem Punkt übereinstimmen, zu 
-finden. Während Sie mehr und mehr Tasten drücken, läuft die Vorhersage auf das 
-richtige Wort zu. Das ist der Grund, warum das angezeigte Wort sich zwischen 
-einem Tastendruck drastisch verändern kann. Es gibt jedoch Fälle, in denen mehr 
-als ein Wort dieselbe Zahlenkombination teilen. Z. B. haben die Worte „quit“ und 
-„suit“ dieselbe Nummer, nämlich 7848. In diesen Fällen hilft die Schaltfläche 
-(#)next weiter. Durch ihre Betätigung können Sie durch die Liste der Wörter 
-schalten, welche denselben Zahlencode haben und schließlich das richtige Wort 
+Der vorhersagende Eingabedialog funktioniert in drei Modi, zwischen denen mit
+der Schaltfläche (*)Pre/123/Abc gewechselt werden kann. Die primäre
+Eingabemethode ist der vorhersagende Modus (Pre), welcher der Worterkennung bei
+„schnellem Tippen“ auf Mobilfunktelefonen ähnelt. Das Alphabet ist in neun
+Gruppen unterteilt, die naturgemäß den neun Ziffern auf dem Ziffernblock
+zugeteilt sind (0 ist die Leertaste). Um ein Wort einzugeben, drücken Sie einmal
+die Ziffer der Gruppe, die den Buchstaben des Worts enthält, den Sie tippen
+möchten, dann gehen Sie zum nächsten Buchstaben über. Um z. B. den Befehl „look“
+einzugeben, sollten Sie 5665 drücken. Während Sie schrittweise die Ziffernfolge
+des beabsichtigten Wortes eingeben, wird auf das Wörterbuch zugegriffen, um
+bekannte Wörter, die mit Ihrer Eingabe bis zu diesem Punkt übereinstimmen, zu
+finden. Während Sie mehr und mehr Tasten drücken, läuft die Vorhersage auf das
+richtige Wort zu. Das ist der Grund, warum das angezeigte Wort sich zwischen
+einem Tastendruck drastisch verändern kann. Es gibt jedoch Fälle, in denen mehr
+als ein Wort dieselbe Zahlenkombination teilen. Z. B. haben die Worte „quit“ und
+„suit“ dieselbe Nummer, nämlich 7848. In diesen Fällen hilft die Schaltfläche
+(#)next weiter. Durch ihre Betätigung können Sie durch die Liste der Wörter
+schalten, welche denselben Zahlencode haben und schließlich das richtige Wort
 akzeptieren, indem Sie die (0) für Leertaste oder OK drücken.
 
-Die zweite Eingabemethode (123) ist die numerische Eingabe: Jede Taste, die Sie 
+Die zweite Eingabemethode (123) ist die numerische Eingabe: Jede Taste, die Sie
 drücken, wird als tatsächliche Ziffer eingegeben.
 
-Die dritte Eingabemethode (Abc) ist die Multi-Tipp-Alpha-Eingabemthode. Dieser 
-Modus ist dazu gedacht, um freien Text einzugeben, ohne die Hilfe des 
-Wörterbuchschemas des vorhersagenden Modus (Pre). Der Text wird Buchstabe für 
-Buchstabe eingegeben. Für jeden Buchstaben drücken Sie zuerst die Ziffer der 
-Gruppe, die den Buchstaben beinhaltet, den Sie tippen wollen, dann verwenden Sie 
-die Schaltfläche (#)next, um durch die Buchstaben zu schalten, bis der richtige 
-erscheint, und wiederholen dies mit der nächsten Ziffer. Um z. B. das Wort 
-„look“ einzugeben, müssen Sie folgendes Drücken: 5##6##6##5#
+Die dritte Eingabemethode (Abc) ist die Multi-Tipp-Alpha-Eingabemthode. Dieser
+Modus ist dazu gedacht, um freien Text einzugeben, ohne die Hilfe des
+Wörterbuchschemas des vorhersagenden Modus (Pre). Der Text wird Buchstabe für
+Buchstabe eingegeben. Für jeden Buchstaben drücken Sie zuerst die Ziffer der
+Gruppe, die den Buchstaben beinhaltet, den Sie tippen wollen, dann verwenden Sie
+die Schaltfläche (#)next, um durch die Buchstaben zu schalten, bis der richtige
+erscheint, und wiederholen dies mit der nächsten Ziffer. Um z. B. das Wort
+„look“ einzugeben, müssen Sie Folgendes drücken: 5##6##6##5#
 
-Der Dialog kann vollständig mit der Maus verwendet werden, aber ein paar 
-Maßnahmen wurden getroffen, um dessen Verwendung bei einigen ScummVM-Ports 
-komfortabler zu gestalten, indem naturgemäß dessen Funktionsweise dem 
-Ziffernblock zugewiesen wurde. Ebenso können die Schaltflächen mittels der 
+Der Dialog kann vollständig mit der Maus verwendet werden, aber ein paar
+Maßnahmen wurden getroffen, um dessen Verwendung bei einigen ScummVM-Ports
+komfortabler zu gestalten, indem naturgemäß dessen Funktionsweise dem
+Ziffernblock zugewiesen wurde. Ebenso können die Schaltflächen mittels der
 Pfeiltasten und der Eingabetaste gesteuert werden.
 
 
-(Übersetzung basiert auf README mit SHA1 ID: 
-eae06884b6c6da23b7932ceba65e435d9be6ef82)
+3.16) Hinweise zu Mickey's Space Adventure:
+----- -------------------------------------
+Um Mickey's Space Adventure unter ScummVM laufen zu lassen, benötigen Sie die
+originale EXE-Datei des Spiels (mickey.exe) sowie die Spieldateien.
+
+Für das Spiel gibt es unter ScummVM umfangreiche Mausunterstützung, obwohl es im
+Originalspiel überhaupt keine Mausunterstützung hab. Menüpunkte können mit der
+Maus ausgewählt werden und es ist auch möglich, mittels Maus an andere Orten zu
+wechseln. Wenn die Maus über die Kanten des Bildschirms bewegt wird, ändert sich
+die Farbe des Zeigers in Rot, wenn es möglich ist, in diese Richtung zu gehen.
+Der Spieler kann dann einfach auf die Kanten des Spielbildschirms klicken, um
+den Ort zu wechseln, ähnlich wie in vielen Adventures, was einfacher und viel
+unkomplizierter ist, als sich mit dem Menü umherzubewegen.
+
+
+3.17) Hinweise zu Winnie the Pooh:
+----- ----------------------------
+Es ist möglich, Spielstände vom Original-Interpreters des Spiels in ScummVM zu
+importieren.
+
+Für das Spiel gibt es unter ScummVM umfangreiche Mausunterstützung, obwohl es im
+Originalspiel überhaupt keine Mausunterstützung hab. Menüpunkte können mit der
+Maus ausgewählt werden und es ist auch möglich, mittels Maus an andere Orten zu
+wechseln. Wenn die Maus über die Kanten des Bildschirms bewegt wird, ändert sich
+die Farbe des Zeigers in Rot, wenn es möglich ist, in diese Richtung zu gehen.
+Der Spieler kann dann einfach auf die Kanten des Spielbildschirms klicken, um
+den Ort zu wechseln, ähnlich wie in vielen Adventures, was einfacher und viel
+unkomplizierter ist, als sich mit dem Menü umherzubewegen.
+
+
+3.18) Hinweise zu Troll's Tale:
+----- -------------------------
+Das Originalspiel wurde auf einer PC-Boot-Diskette ausgeliefert, weshalb es
+notwendig ist, die Inhalte dieser Diskette in einer Abbild-Datei auszugeben und
+diese „troll.img“ zu nennen, um das Spiel unter ScummVM spielen zu können.
+
+
+3.19) Hinweise zu Draci Historie:
+----- ---------------------------
+Es gibt vier Sprachvarianten des Spiels: Tschechisch, Deutsch, Englisch und
+Polnisch. Jede von ihnen wird in einem gesonderten Archiv bereitgestellt. Die
+einzige offizielle Version ist die tschechische, während die deutsche, englische
+und polnische immer in Bearbeitung waren und nie offiziell veröffentlicht
+wurden. Obwohl alle Texte vollständig übersetzt sind, ist bekannt, dass einige
+von ihnen Fehler enthalten.
+
+Es existiert optionale tschechische Sprachausgabe für das Spiel. Aus Gründen der
+Bandbreite können Sie diese in einem gesonderten Archiv herunterladen und dann
+im Verzeichnis des Spiels entpacken. Sie können mit allen Sprachvarianten die
+tschechische Sprachausgabe hören, während Sie Untertitel lesen.
+
+Alle Spieldateien und die Komplettlösung können von der folgenden Website
+heruntergeladen werden: http://www.ucw.cz/draci-historie/index-en.html
+
+
+3.20) Bekannte Probleme:
+----- ------------------
+Diese veröffentlichte Version hat die unten folgenden bekannten Probleme. Es ist
+nicht notwendig, diese zu berichten, jedoch sind Patches, um diese zu beheben,
+willkommen. Wenn Sie einen Fehler entdecken, der weder hier noch auf der
+Kompatibilitätsseite der Website aufgeführt ist, sehen Sie bitte im Abschnitt
+„Fehler berichten“ nach, wenn Sie ihn melden möchten.
+
+  Spiele mit Ton von CD:
+    - Bei Spielen, die auf Audio von CD zurückgreifen (FM-TOWNS-Spiele,
+      Loom-CD-Version usw.), ist es möglich, dass Anwender von Microsoft Windows
+      2000/XP zufällige Abstürze erleben. Das liegt an einem lange bestehenden
+      Windows-Fehler, der dazu führt, dass fehlerhafte Spieldaten von der CD
+      ausgelesen werden. Bitte kopieren Sie die Spieldaten in ein Verzeichnis
+      Ihrer Festplatte, um dies zu vermeiden.
+
+  FM-TOWNS-Versionen:
+    - Die Kanji-Versionen erfordern die Schriftart-ROM-Datei von FM-TOWNS.
+    - ScummVM stürzt bei Kanji-Versionen der folgenden Spielen zufällig ab, wenn
+      die Schriftart-ROM-Datei von FM-TOWNS verwendet wird:
+      The Secret of Monkey Island, Monkey Island 2: LeChuck's Revenge
+      und Indiana Jones and the Fate of Atlantis
+
+  Loom:
+    - Das Abschalten der Untertitel über die Spieleinstellungen funktioniert
+      nicht zuverlässig, da die Loom-Skripte diese wieder einschalten.
+    - MIDI-Unterstützung in der EGA-Version erfordert das Roland-Update von
+      LucasArts.
+    - Die Kanji-Version der PC-Engine erfordert die Systemkarten-ROM-Datei.
+
+  The Secret of Monkey Island:
+    - MIDI-Unterstützung in der EGA-Version erfordert das Roland-Update von
+      LucasArts.
+
+  Beneath a Steel Sky:
+    - Amiga-Versionen werden nicht unterstützt.
+    - Disketten-Demos werden nicht unterstützt.
+    - Kein Fehler: In der CD-Version fehlt in einigen Dialogen Sprachausgabe;
+      das ist normal.
+
+  Elvira - Mistress of the Dark
+    - Keine Musik in der Atari-ST-Version
+
+  Elvira II - The Jaws of Cerberus
+    - Keine Musik in der Atari-ST-Version
+    - Keine Sound-Effekte in der PC-Version
+    - Palettenprobleme in der Atari-ST-Version
+
+  Inherit the Earth: Quest for the Orb
+    - Amiga-Versionen werden nicht unterstützt.
+
+  Simon the Sorcerer 1:
+    - Untertitel sind in den deutschen und englischen CD-Versionen nicht
+      verfügbar, da bei diesen der überwiegende Teil der Untertiteltexte fehlt.
+
+  Simon the Sorcerer 2:
+    - Sprache und Untertitel zusammen führen manchmal dazu, dass die
+      Sprachausgabe vorzeitig abgeschnitten wird. Dies ist eine Beschränkung des
+      Originalspiels.
+    - Nur die Standardsprache (Englisch) der Spieldaten wird bei den Amiga- und
+      Macintosh-Versionen unterstützt.
+
+  Simon the Sorcerer's Game Pack:
+    - Keine Unterstützung für das Anzeigen, Anlegen, Laden oder Speichern von
+      Highscores.
+    - Keine Unterstützung in Swampy Adventures für das Anzeigen von Namen von
+      Gegenständen, wenn man über diese mit der Maus fährt
+
+  Floyd - Es gibt noch Helden:
+    - Untertitel sind oft unvollständig und nur in Englisch, da sie im
+      Originalspiel immer ausgeschaltet waren.
+
+  The Legend of Kyrandia:
+    - Keine Musik- oder Sound-Effekte in der Macintosh-Diskettenversion.
+    - Die Macintosh-CD-Version verwendet eingebundene DOS-Musik und
+      DOS-Sound-Effekte.
+    - PC-9821-Versionen fehlt Unterstützung für Sound-Effekte.
+
+  Spiele von Humongous Entertainment:
+    - Nur die Originaloberfläche kann zum Laden und Speichern verwendet werden.
+    - Keine Unterstützung für den Mehrspielermodus und das Ausdrucken von
+      Bildern
+
+
+4.0) Unterstützte Plattformen:
+---- -------------------------
+ScummVM wurde portiert, um auf vielen Plattformen und Betriebssystemen zu
+lauffähig zu sein. Links zu diesen Ports können entweder auf der ScummVM-Website
+oder durch Suchen mit einer Suchmaschine gefunden werden. Vielen Dank an unsere
+Porter für ihre Bemühungen. Wenn Sie eine Portierung für ScummVM haben und diese
+zum Entwicklungsbereich (master Git) beisteuern möchten, können Sie uns gerne
+kontaktieren!
+
+Die unterstützten Plattformen beinhalten (aber beschränken sich nicht auf):
+
+        UNIX            (Linux, Solaris, IRIX, *BSD, ...)
+        Windows
+        Windows CE und Windows Mobile (einschließlich Smartphones und PocketPCs)
+        Mac OS X
+        AmigaOS
+        Android
+        BeOS
+        Dreamcast
+        GP2x
+        iPhone          (auch einschließlich iPod Touch und iPad)
+        Maemo           (Nokia-Internet-Tablets 770, N800, N810, N900)
+        Nintendo 64
+        Nintendo DS
+        Nintendo GameCube
+        Nintendo Wii
+        OS/2
+        PlayStation 2
+        PlayStation Portable
+        Symbian
+        WebOS
+
+Die Portierung von Dreamcast unterstützt weder The Curse of Monkey Island noch
+The Dig. Der Portierung von Nintendo DS fehlt Unterstützung für Vollgas, The Dig
+und The Curse of Monkey Island.
+Für weitere plattformabhängige Beschränkungen verweisen wir auf unser Wiki:
+  http://wiki.scummvm.org/index.php/Platforms
+
+In der Portierung von Macintosh wird die rechte Maustaste über den Cmd-Klick
+emuliert (d. h. Sie klicken die Maustaste, während Sie die Command-/Apple-
+/Propeller-Taste gedrückt halten).
+
+Es gibt inoffizielle Portierungen für eine Vielzahl von Plattformen,
+einschließlich PlayStation 3, Xbox und Xbox 360. Bitte beachten Sie, dass diese
+nicht von uns hergestellt werden, weshalb wir diese weder befürworten noch
+unterstützen können. Benutzung erfolgt auf eigene Gefahr!
+
+
+5.0) ScummVM verwenden:
+---- ------------------
+Bitte beachten Sie, dass ScummVM standardmäßig Spielstände in dem Verzeichnis
+speichert, in welchem es ausgeführt wird, also sollten Sie davon absehen, es von
+mehr als einem Ort aus zu verwenden. Weitere Informationen, einschließlich
+darüber, wie man einen Pfad für Spielstände bestimmt, um dieses Problem zu
+vermeiden, befinden sich im Abschnitt 6.0.
+
+ScummVM kann direkt durch Aufruf der EXE-Datei gestartet werden. In diesem Fall
+wird das eingebaute Startmenü aktiviert. Hier können Sie Spiele hinzufügen,
+(klicken Sie auf „Spiel hinzufügen“) oder Spiele starten, die bereits
+konfiguriert wurden. Es können auch mehrere Spiele auf einmal hinzugefügt
+werden. Indem Sie die Umschalttaste (Shift) gedrückt halten und auf „Spiel
+hinzufügen“ klicken (beachten Sie, dass sich die Beschreibung in „Durchsuchen“
+ändert), können Sie ein Verzeichnis bestimmen, wodurch ScummVM versuchen wird,
+in allen Unterverzeichnissen dieses Verzeichnisses Spiele zu erkennen.
+
+ScummVM kann mittels Argumenten in der Kommandozeile auch direkt in ein Spiel
+gestartet werden -- siehe nächster Abschnitt.
+
+
+5.1) Kommandozeilenoptionen:
+---- -----------------------
+
+  Verwendung: scummvm [OPTIONEN]... [SPIEL]
+
+  [SPIEL]                  Kurzer Name des zu ladenden Spiels. Z. B. „monkey“
+                           für Monkey Island. Dies kann entweder eine
+                           vorbestimmte Kennung eines Spiels sein oder ein
+                           benutzerkonfiguriertes Ziel.
+
+  -v, --version            Zeigt ScummVM-Versionsinformation und beendet.
+  -h, --help               Zeigt kurzen Hilfetext und beendet.
+  -z, --list-games         Zeigt Liste unterstützter Spiele und beendet.
+  -t, --list-targets       Zeigt Liste konfigurierter Ziele und beendet.
+  --list-saves=ZIEL        Zeigt Liste von Spielständen für das festgelegte
+                           Spiel (ZIEL)
+  --console                Aktiviert das Konsolenfenster
+                           (standardmäßig aktiviert) (nur Windows)
+
+  -c, --config=KONFIGURATIONSDATEI
+                           Verwendet alternative Konfigurationsdatei.
+  -p, --path=PFAD          Pfad zum installierten Spiel
+  -x, --save-slot[=ZAHL]   Zu ladender Speicherplatz
+                           (Standard: automatischer Spielstand)
+  -f, --fullscreen         Erzwingt Vollbildmodus.
+  -F, --no-fullscreen      Erzwingt Fenstermodus.
+  -g, --gfx-mode=MODUS     Wählt Grafikwandler (siehe auch Abschnitt 5.3).
+  --gui-theme=THEMA        Wählt Oberflächenthema (Standard, modern, klassisch).
+  --themepath=PFAD         Pfad zu gespeicherten Oberflächenthemen
+  --list-themes            Zeigt Liste aller verwendbaren Oberflächenthemen.
+  -e, --music-driver=MODUS
+                           Wählt Musiktreiber (siehe auch Abschnitt 7.0).
+  -q, --language=SPRACHE   Wählt Spielsprache (siehe auch Abschnitt 5.2).
+  -m, --music-volume=ZAHL  Wählt Musiklautstärke, 0-255 (Standard: 192).
+  -s, --sfx-volume=ZAHL    Wählt Effektlautstärke, 0-255 (Standard: 192).
+  -r, --speech-volume=ZAHL
+                           Wählt Sprachlautstärke, 0-255 (Standard: 192).
+  --midi-gain=ZAHL         Wählt MIDI-Lautstärke, 0-1000 (Standard: 100)
+                           (wird nur von einigen MIDI-Treibern unterstützt).
+  -n, --subtitles          Aktiviert Untertitel (in Spielen mit Sprachausgabe).
+  -b, --boot-param=ZAHL    Ruft Boot-Skript (Boot-Parameter) mit dieser Zahl
+                           auf.
+  -d, --debuglevel=ZAHL    Legt Debug-Ausführlichkeit fest.
+  --debugflags=FLAGGEN     Aktiviert für Engine spezifische Debug-Flaggen
+                           (getrennt durch Kommas).
+  -u, --dump-scripts       Aktiviert die Skriptausgabe, wenn ein Verzeichnis
+                           namens 'dumps' im aktuellen Verzeichnis existiert.
+
+  --cdrom=ZAHL             CD-Laufwerk, von dem CD-Titel wiedergegeben werden
+                           sollen (Standard: 0 = erstes Laufwerk)
+  --joystick[=ZAHL]        Aktiviert Joystick (Standard: 0 = erster Joystick).
+  --platform=WORT          Bestimmt Spielplattform (erlaubte Werte: 2gs, 3do,
+                           acorn, amiga, atari, c64, fmtowns, mac, nes, pc,
+                           pce, segacd, windows).
+  --savepath=PFAD          Pfad zu gespeicherten Spielständen
+  --extrapath=PFAD         Extrapfad zu zusätzlichen Spieldaten
+  --soundfont=DATEI        Wählt SoundFont für MIDI-Wiedergabe (wird nur
+                           von einigen MIDI-Treibern unterstützt).
+  --multi-midi             Aktiviert Kombinierung von AdLib und MIDI.
+  --native-mt32            Echte Roland-MT-32-Emulation
+                           (GM-Emulation deaktiviert)
+  --enable-gs              Aktiviert Roland-GS-Modus für MIDI-Wiedergabe.
+  --output-rate=FREQUENZ   Wählt Ausgabefrequenz in Hz (z. B. 22050).
+  --opl-driver=TREIBER     Wählt AdLib-(OPL-)Emulator (db, mame).
+  --aspect-ratio           Aktiviert Seitenverhältniskorrektur.
+  --render-mode=MODUS      Aktiviert zusätzlichen Render-Modus (cga, ega,
+                           hercGreen, hercAmber, amiga).
+
+  --alt-intro              Verwendet alternativen Vorspann für CD-Versionen von
+                           Beneath a Steel Sky und Flight of the Amazon Queen.
+  --copy-protection        Aktiviert Kopierschutz in Spielen, für welche ihn
+                           ScummVM standardmäßig deaktiviert.
+  --talkspeed=ZAHL         Wählt Textverzögerung bei SCUMM-Spielen oder
+                           Texttempo bei anderen Spielen (Standard: 60).
+  --demo-mode              Startet Maniac Mansion im Demo-Modus
+                           (klassische Version).
+  --tempo=ZAHL             Wählt Musiktempo (in Prozent, 50-200) für
+                           SCUMM-Spiele (Standard: 100).
+
+
+Die Bedeutung der meisten langen Optionen (d. h. diejenigen Optionen, die mit
+einem Doppelstrich beginnen) kann durch Anhängen der Vorsilbe „no-“ umgekehrt
+werden. Z. B. wird --no-aspect-ratio die Seitenverhältniskorrektur ausschalten.
+Das ist nützlich, falls man eine Einstellung in der Konfigurationsdatei
+übergehen möchte.
+
+Ein kurzer Spielname („Spielziel“), den Sie am Ende der Kommandozeile sehen,
+legt fest, welches Spiel gestartet wird. Dieser bezieht sich entweder auf ein
+willkürlich vom Anwender definiertes Ziel (aus der Konfigurationsdatei) oder auf
+eine vorbestimmte Spielkennung. Eine kurze Liste von Letzterem ist in
+Abschnitt 3.0 zu finden.
+
+Beispiele:
+ * Win32:
+  Startet Monkey Island im Vollbildmodus von Festplatte:
+   C:\Games\LucasArts\scummvm.exe -f -pC:\Games\LucasArts\monkey\ monkey
+  Startet Vollgas von CD, im Vollbildmodus und mit aktivierten Untertiteln:
+   C:\Games\LucasArts\scummvm.exe -f -n -pD:\resource\ ft
+
+* Unix:
+  Startet Monkey Island im Vollbildmodus von Festplatte:
+   /path/to/scummvm -f -p/games/LucasArts/monkey/ monkey
+  Startet Vollgas von CD, im Vollbildmodus und mit aktivierten Untertiteln:
+   /path/to/scummvm -f -n -p/cdrom/resource/ ft
+
+
+5.2) Sprachoptionen:
+---- ---------------
+ScummVM beinhaltet Sprachoptionen für Maniac Mansion, Zak McKracken,
+The Dig, The Curse of Monkey Island, Beneath a Steel Sky und Baphomets Fluch.
+
+Beachten Sie, dass mit Ausnahme von Beneath a Steel Sky, Broken Sword,
+mehrsprachigen Versionen der Goblins-Spiele und Nippon Safes Inc. die Verwendung
+dieser Option nicht die Sprache des Spiels ändert (die normalerweise fest
+programmiert ist), sondern nur dazu verwendet wird, um die passende Schriftart
+zu wählen (z. B. für eine deutsche Version eines Spiels, in der Umlaute
+enthalten sind).
+
+Eine Ausnahme bilden The Dig und The Curse of Monkey Island -- nicht-englische
+Versionen dieser Spiele können auf Englisch eingestellt werden. Dies hat
+allerdings nur Auswirkungen auf die Untertitel; die Sprachausgabe bleibt
+dieselbe.
+
+Maniac Mansion und Zak McKracken
+    en  - Englisch (Standard)
+    de  - Deutsch
+    fr  - Französisch
+    it  - Italienisch
+    es  - Spanisch
+
+The Dig
+    jp  - Japanisch
+    zh  - Chinesisch
+    kr  - Koreanisch
+
+The Curse of Monkey Island
+    en  - Englisch (Standard)
+    de  - Deutsch
+    fr  - Französisch
+    it  - Italienisch
+    pt  - Portugiesisch
+    es  - Spanisch
+    jp  - Japanisch
+    zh  - Chinesisch
+    kr  - Koreanisch
+
+Beneath a Steel Sky
+    gb  - Englisch (Großbritannien) (Standard)
+    en  - Englisch (USA)
+    de  - Deutsch
+    fr  - Französisch
+    it  - Italienisch
+    pt  - Portugiesisch
+    es  - Spanisch
+    se  - Schwedisch
+
+Baphomets Fluch
+    en  - Englisch (Standard)
+    de  - Deutsch
+    fr  - Französisch
+    it  - Italienisch
+    es  - Spanisch
+    pt  - Portugiesisch
+    cz  - Tschechisch
+
+
+5.3) Grafikfilter:
+---- -------------
+ScummVM bietet mehrere Kantenglättungsfilter, um zu versuchen, die bildliche
+Qualität zu verbessern. Dies sind die gleichen Filter, die in vielen anderen
+Emulatoren verwendet werden, wie beispielsweise MAME. Diese Filter nehmen die
+Originalgrafik und skalieren sie um einen bestimmten festen Faktor
+(normalerweise zwei- oder dreifach), bevor sie Ihnen diese anzeigen. Wenn somit
+z. B. ein Spiel ursprünglich in der Auflösung 320x200 läuft (typisch für die
+meisten SCUMM-Spiele), wird ein Filter mit zweifacher Skalierung die Grafiken
+mit der Auflösung 640x400 ausgeben. Gleichermaßen werden Sie durch die
+Verwendung eines 3x-Filters die Auflösung 960x600 erhalten.
+
+Die einzelnen Grafikoptionen im Überblick:
+    1x         - Kein Filter, keine Skalierung. Am schnellsten.
+    2x         - Kein Filter, Faktor 2 (Standard für Spiele, die nicht in der
+                 Auflösung 640x480 laufen).
+    3x         - Kein Filter, Faktor 3.
+    2xsai      - 2xSAI-Filter, Faktor 2.
+    super2xsai - Verbesserter 2xSAI-Filter, Faktor 2.
+    supereagle - Weniger verschwommen als 2xSAI, aber langsamer. Faktor 2.
+    advmame2x  - Basiert nicht auf Verwischen wie 2xSAI, schnell. Faktor 2.
+    advmame3x  - Basiert nicht auf Verwischen wie 2xSAI, schnell. Faktor 3.
+    hq2x       - Sehr hochwertiger, qualitativer Filter, aber langsam. Faktor 2.
+    hq3x       - Sehr hochwertiger, qualitativer Filter, aber langsam. Faktor 3.
+    tv2x       - Zeilensprungfilter, emuliert Fernsehgerät. Faktor 2.
+    dotmatrix  - Punktraster-Effekt. Faktor 2.
+
+Um einen Grafikfilter auszuwählen, übergeben Sie dessen Namen über die Option
+„-g“ an scummvm, z. B. mit der Eingabe:
+
+    scummvm -gadvmame2x monkey2
+
+Hinweis 1: Nicht alle Systeme unterstützen alle (oder überhaupt welche) der oben
+aufgeführten Filter; einige unterstützen womöglich zusätzliche. Die Filter, die
+oben aufgeführt sind, werden standardmäßig vom SDL-System unterstützt.
+
+Hinweis 2: Filter können sehr langsam sein, wenn ScummVM mit einer
+Debug-Konfiguration ohne Optimierungen kompiliert wurde. Auch hat es immer
+Geschwindigkeitsauswirkungen, wenn eine Form der Kantenglättungs- oder linearen
+Filterung verwendet wird.
+
+Hinweis 3: Die FM-TOWNS-Version von Zak McKracken verwendet ursprünglich die
+Auflösung 320x240, daher werden skalierende Grafikfilter das Bild auf 640x480
+oder 960x720 skalieren. Gleichermaßen werden Spiele, die ursprünglich die
+Auflösung 640x480 verwendet haben (wie beispielsweise The Curse of Monkey Island
+oder Baphomets Fluch), auf 1280x960 und 1920x1440 skaliert.
+
+
+5.4) Globales Menü:
+---- --------------
+Das globale Menü ist ein allgemeines Menü, das in allen Spiel-Engines verfügbar
+ist und mit Strg+F5 aufgerufen werden kann. In diesem Menü befinden sich
+folgende Schaltflächen: „Fortsetzen“, „Optionen“, „Über“, „Zur Spieleliste
+zurück“ und „Beenden“. Wenn Sie „Optionen“ auswählen, wird ein Dialog angezeigt,
+in welchem einfache Audio-Einstellungen, wie beispielsweise Lautstärkepegel,
+festgelegt werden können. Wenn Sie „Zurück zur Spieleliste“ wählen, wird das
+momentane Spiel beendet und das Programm kehrt zur Spieleliste zurück, von der
+aus ein anderes Spiel gestartet werden kann.
+
+Hinweis: Das Zurückkehren zur Spieleliste wird nicht von allen Engines
+unterstützt, weshalb die Schaltfläche im globalen Menü deaktiviert wird, wenn
+diese Funktion nicht verfügbar ist.
+
+Die Engines, die momentan das Zurückkehren zur Spieleliste unterstützen, sind:
+
+    AGI
+    AGOS
+    CINE
+    DRACI
+    GOB
+    GROOVIE
+    KYRA
+    LURE
+    PARALLACTION
+    QUEEN
+    SAGA
+    SCUMM
+    SKY
+    SWORD1
+    SWORD2
+    TOUCHE
+    TUCKER
+
+
+5.5) Tastenkürzel:
+---- -------------
+ScummVM unterstützt zahlreiche Tastenkürzel in Spielen. Sie unterscheiden sich
+zwischen SCUMM-Spielen und anderen Spielen.
+
+  Allgemein:
+    Strg+F5                - Zeigt globales Menü.
+    Cmd+q                  - Beenden (Mac OS X)
+    Strg+q                 - Beenden (andere UNIX-Systeme einschließlich Linux)
+    Strg+z ODER Alt+x      - Beenden (andere Plattformen)
+    Strg+u                 - Allen Ton abschalten - EIN/AUS
+    Strg+m                 - Mausbegrenzung in Fenster EIN/AUS
+    Strg+Alt 1-8           - Wechselt zwischen Grafikfiltern.
+    Strg+Alt + oder -      - Skalierungsfaktor höher/niedriger
+    Strg+Alt+a             - Seitenverhältniskorrektur EIN/AUS
+                             Die meisten Spiele verwenden die Auflösung
+                             320x200 Pixel, was auf modernen Monitoren
+                             zusammengequetscht aussehen kann. Die
+                             Seitenverhältniskorrektur streckt das Bild
+                             stattdessen auf 320x240 Pixel oder um ein
+                             Vielfaches davon.
+    Alt+Enter              - Wechselt zwischen Vollbild- und Fenstermodus.
+    Alt+s                  - Macht Bildschirmfoto (nur für SDL-System).
+
+  SCUMM:
+    Strg 0-9 und Alt 0-9   - Lädt und speichert entsprechenden Speicherstand.
+    Strg+d                 - Startet den Debugger.
+    Strg+f                 - Schneller Modus EIN/AUS
+    Strg+g                 - SEHR schneller Modus EIN/AUS
+    Strg+t                 - Wechselt zwischen
+                             „Speech only“ (nur Sprachausgabe),
+                             „Speech and Subtitles“ (Sprachausgabe und
+                             Untertitel) und „Subtitles only“ (nur Untertitel).
+    Tilde (~)              - Zeigt/verbirgt Debugging-Konsole.
+    [ und ]                - Musiklautstärke, leiser/lauter
+    - und +                - Texttempo, langsamer/schneller
+    F5                     - Ruft Menü zum Speichern und Laden auf.
+    Alt+F5                 - Ruft das Original-Menü zum Speichern und Laden auf,
+                             sofern eines im Spiel enthalten ist. Sie können mit
+                             diesem Spiele speichern und laden, jedoch ist es
+                             für diesen Zweck nicht vorgesehen und kann in
+                             einigen Spielen ScummVM zum Absturz bringen.
+    i                      - Zeigt IQ-Punkte an (Indiana Jones and the Last
+                             Crusade und Indiana Jones and the Fate of
+                             Atlantis).
+    Leertaste              - Spielpause
+    Punkt (.)              - Überspringt aktuelle Textzeile in machen Spielen.
+    Enter                  - Simuliert Klick mit linker Maustaste.
+    Tabulator              - Simuliert Klick mit rechter Maustaste.
+
+  Beneath a Steel Sky:
+    Strg+d                 - Startet den Debugger.
+    Strg+f                 - Schneller Modus EIN/AUS
+    Strg+g                 - SEHR schneller Modus EIN/AUS
+    F5                     - Ruft Menü zum Speichern und Laden auf.
+    Escape                 - Überspringt den Vorspann des Spiels.
+    Punkt (.)              - Überspringt aktuelle Textzeile.
+
+  Baphomets Fluch:
+    F5 oder Escape         - Ruft Menü zum Speichern und Laden auf.
+
+  Baphomets Fluch II:
+    Strg+d                 - Startet den Debugger.
+    Strg+f                 - Schneller Modus EIN/AUS
+    p                      - Spielpause
+
+  Draci Historie:
+    F5                     - Zeigt globales Menü.
+    Linksklick             - Laufen, untersuchen
+    Rechtsklick            - Verwenden, reden
+    Maus nach oben, i      - Inventar
+    Maus nach unten, m     - Karte
+    Escape                 - Vorspann überspringen, Karte/Inventar schließen
+    beliebiger Klick       - Überspringt aktuellen Satz.
+    q                      - Schnelles Laufen EIN/AUS
+
+  Flight of the Amazon Queen:
+    Strg+d                 - Startet den Debugger.
+    Strg+f                 - Schneller Modus EIN/AUS
+    F1                     - Tagebuch benutzen (speichern/laden)
+    F11                    - Schnelles Speichern
+    F12                    - Schnelles Laden
+    Escape                 - Überspringt Zwischensequenzen.
+    Leertaste              - Überspringt aktuelle Textzeile.
+
+  Future Wars
+    F1                     - Untersuchen
+    F2                     - Nehmen
+    F3                     - Inventar
+    F4                     - Verwenden
+    F5                     - Aktivieren
+    F6                     - Sprechen
+    F9                     - „Aktivieren“-Menü
+    F10                    - „Verwenden“-Menü
+    Escape                 - Befehlsmenü aufrufen
+
+  Nippon Safes
+    Strg+d                 - Startet den Debugger.
+    l                      - Spiel laden
+    s                      - Spiel speichern
+
+
+  Simon the Sorcerer 1 und 2:
+    Strg 0-9 und Alt 0-9   - Lädt und speichert entsprechenden Speicherstand.
+    Strg+d                 - Startet den Debugger.
+    Strg+f                 - Schneller Modus EIN/AUS
+    F1 - F3                - Texttempo, schneller - langsamer
+    F10                    - Zeigt alle Figuren und Objekte, mit denen man
+                             interagieren kann.
+    Escape                 - Überspringt Zwischensequenzen.
+    - und +                - Musiklautstärke, leiser/lauter
+    m                      - Musik EIN/AUS
+    s                      - Sound-Effekte EIN/AUS
+    b                      - Hintergrundgeräusche EIN/AUS
+                             [nur in Simon the Sorcerer 2 möglich]
+    Pause                  - Spielpause
+    t                      - Wechselt zwischen Sprachausgabe allein und
+                             Sprachausgabe und Untertiteln zusammen
+                             [Simon the Sorcerer 1 CD (außer Deutsch und
+                             Englisch) und Simon the Sorcerer 2 CD
+                             (alle Sprachen)].
+    v                      - Wechselt zwischen Untertiteln allein und
+                             Sprachausgabe und Untertiteln zusammen
+                             [nur Simon the Sorcerer 2 CD].
+
+  Simon the Sorcerer's Game Pack
+    Strg-d                 - Startet den Debugger.
+    Strg-f                 - Schneller Modus EIN/AUS
+    F12                    - Hohes Tempo in Swampy Adventures EIN/AUS
+    - und +                - Musiklautstärke, leiser/lauter
+    m                      - Musik EIN/AUS
+    s                      - Sound-Effekte EIN/AUS
+    Pause                  - Spielpause
+
+  Floyd - Es gibt noch Helden
+    Strg+d                 - Startet den Debugger.
+    Strg+f                 - Schneller Modus EIN/AUS
+    F7                     - Wechselt Figuren.
+    F9                     - Klickbereichnamen EIN/AUS
+    s                      - Sound-Effekte EIN/AUS
+    Pause                  - Spielpause
+    t                      - Wechselt zwischen Sprachausgabe allein und
+                             Sprachausgabe und Untertiteln zusammen.
+    v                      - Wechselt zwischen Untertiteln allein und
+                             Sprachausgabe und Untertiteln zusammen.
+
+  The Legend of Kyrandia:
+    Strg 0-9 und Alt 0-9   - Lädt und speichert entsprechenden Speicherstand.
+    Strg-d                 - Startet den Debugger.
+
+  TeenAgent
+    F5                     - Zeigt globales Menü.
+
+  Touché: Die Abenteuer des fünften Musketiers:
+    Strg-f                 - Schneller Modus EIN/AUS
+    F5                     - Zeigt Optionen.
+    F9                     - Schnelles Gehen EIN
+    F10                    - Schnelles Gehen AUS
+    Escape                 - Beenden
+    Leertaste              - Überspringt aktuelle Textzeile.
+    t                      - Wechselt zwischen „Nur Sprachausgabe“,
+                             „Sprachausgabe und Text“ und „Nur Text“.
+
+Beachten Sie, dass von der Verwendung von Strg+f oder Strg+g abgeraten wird:
+Spiele können abstürzen, wenn sie schneller als mit ihrer normalen
+Geschwindigkeit laufen, da Skripte aus dem Takt kommen.
+
+Hinweis für WinCE-Anwender: Wegen der beschränkten Tastatureingabe-Möglichkeiten
+bei den meisten Geräten wird ein kleiner Teil dieser Tastenkürzel über die
+Neutastenzuweisung und/oder Konsolenaktionen unterstützt. Näheres ist in der
+Datei README-WinCE.txt nachzulesen.
+
+
+6.0) Spielstände:
+---- ------------
+Spielstände werden bei einigen Plattformen standardmäßig im aktuellen
+Verzeichnis gespeichert und bei anderen in voreingestellten Verzeichnissen.
+Sehen Sie sich das Beispiel weiter unten in dieser Liesmich-Datei an.
+
+Die folgenden Plattformen haben ein anderes Standardverzeichnis:
+    Mac OS X:            $HOME/Documents/ScummVM Savegames/
+    Andere UNIX-Systeme: $HOME/.scummvm/
+
+
+6.1) Automatische Spielstände:
+---- -------------------------
+Bei einigen Spielen (nämlich „Beneath a Steel Sky“, „Flight of the Amazon
+Queen“, allen AGI-Spielen und allen SCUMM-Spielen) wird ScummVM standardmäßig
+automatisch alle fünf Minuten den momentanen Spielstand speichern (über die
+Konfigurationseinstellung „autosave_period“ [Zeitspanne für automatisches
+Speichern] kann dies geändert werden). Bei AGI- und SCUMM-Spielen werden diese
+automatischen Spielstände auf Platz 0 abgelegt. Bei der SCUMM-Engine kann dieser
+Speicherstand über die Tastenkombination Strg+0 oder über das F5-Menü geladen
+werden.
+
+
+6.2) Spielstände umwandeln:
+---- ----------------------
+Die Verwendung von Spielständen aus den Originalversionen wird nicht von allen
+Spiel-Engines unterstützt. Nur bei den folgenden Spielen können Spielstände aus
+den Originalversionen verwendet werden.
+
+  Elvira 1
+    - Fügen Sie 8 Bytes (Name für Spielstand) am Anfang der Spielstanddatei
+      hinzu.
+    - Benennen Sie die Spielstanddatei in „elvira1.xxx“ um.
+
+  Elvira 2
+    - Fügen Sie 8 Bytes (Name für Spielstand) am Anfang der Spielstanddatei
+      hinzu.
+    - Benennen Sie die Spielstanddatei in „elvira2-pc.xxx“ (DOS-Versionen) oder
+      „elvira2.xxx“ (andere Versionen) um.
+
+  Waxworks
+    - Fügen Sie 8 Bytes (Name für Spielstand) am Anfang der Spielstanddatei
+      hinzu.
+    - Benennen Sie die Spielstanddatei in „waxworks-pc.xxx“ (DOS-Versionen) oder
+      „waxworks.xxx“ (andere Versionen) um.
+
+  Simon the Sorcerer 1
+    - Benennen Sie die Spielstanddatei in „simon1.xxx“ um.
+
+  Simon the Sorcerer 2
+    - Benennen Sie die Spielstanddatei in „simon2.xxx“ um.
+
+  Floyd - Es gibt noch Helden
+    - Benennen Sie die Spielstanddatei in „feeble.xxx“ um.
+
+Hierbei steht „xxx“ für den genauen Speicherplatz (z. B. 001), auf welchem sich
+der Spielstand unter ScummVM befinden soll.
+
+
+(Übersetzung basiert auf README mit SHA1 ID:
+9bb2ba7eee5f18b878845eb49ac282b84ab5d164)

--- a/doc/de/Schnellstart
+++ b/doc/de/Schnellstart
@@ -1,10 +1,10 @@
-Dieses Dokument ist eine auszugsweise Übersetzung der englischen REAMDE-Datei. 
-Das Original-Dokument enthält viel mehr Informationen. Sollten Sie hier also 
-nicht das finden, was Sie benötigen und ein wenig Englisch können, sollten Sie 
+Dieses Dokument ist eine auszugsweise Übersetzung der englischen README-Datei.
+Das Original-Dokument enthält viel mehr Informationen. Sollten Sie hier also
+nicht das finden, was Sie benötigen und ein wenig Englisch können, sollten Sie
 sich die englische README-Datei ansehen.
 
-Für weitere Informationen, Kompatibilitätslisten, Einzelheiten zu Spenden, die 
-neusten veröffentlichten Versionen, Fortschrittsberichte und mehr besuchen Sie 
+Für weitere Informationen, Kompatibilitätslisten, Einzelheiten zu Spenden, die
+neusten veröffentlichten Versionen, Fortschrittsberichte und mehr besuchen Sie
 bitte die ScummVM-Website unter der Adresse: http://www.scummvm.org/
 
 
@@ -22,78 +22,78 @@ Inhaltsverzeichnis:
 
 1.1) Über ScummVM:
 ---- -------------
-ScummVM ist ein Programm, welches es Ihnen ermöglicht, bestimmte klassische 
-Grafik-Adventure (unter anderem aus dem Point-and-Click-Bereich) zu spielen, 
-vorausgesetzt, Sie sind im Besitz der Dateien des Spiels. Der Trick dabei ist: 
-ScummVM ersetzt lediglich die Funktion der ausführbaren Dateien, die mit den 
-Spielen kamen, was ermöglicht, diese Spiele auf Systemen zu spielen, für welche 
+ScummVM ist ein Programm, welches es Ihnen ermöglicht, bestimmte klassische
+Grafik-Adventure (unter anderem aus dem Point-and-Click-Bereich) zu spielen,
+vorausgesetzt, Sie sind im Besitz der Dateien des Spiels. Der Trick dabei ist:
+ScummVM ersetzt lediglich die Funktion der ausführbaren Dateien, die mit den
+Spielen kamen, was ermöglicht, diese Spiele auf Systemen zu spielen, für welche
 sie nie erstellt wurden!
 
-Ursprünglich wurde dieses Programm dafür entwickelt, um SCUMM-Spiele von 
-LucasArts auszuführen, wie beispielsweise Maniac Mansion, Monkey Island, Day of 
-the Tentacle oder Sam & Max. SCUMM steht als Abkürzung für „Script Creation 
-Utility for Maniac Mansion“ (deutsch etwa: Skripterstellungsdienstprogramm für 
-Maniac Mansion), was das erste Spiel von LucasArts war, für welches LucasArts 
-dieses System entworfen hatte. Und viel später verlieh es seinen Namen an 
+Ursprünglich wurde dieses Programm dafür entwickelt, um SCUMM-Spiele von
+LucasArts auszuführen, wie beispielsweise Maniac Mansion, Monkey Island, Day of
+the Tentacle oder Sam & Max. SCUMM steht als Abkürzung für „Script Creation
+Utility for Maniac Mansion“ (deutsch etwa: Skripterstellungsdienstprogramm für
+Maniac Mansion), was das erste Spiel von LucasArts war, für welches LucasArts
+dieses System entworfen hatte. Und viel später verlieh es seinen Namen an
 ScummVM (wobei „VM“ für „Virtuelle Maschine“ steht).
 
-Mit der Zeit wurde Unterstützung für viele Nicht-SCUMM-Spiele hinzugefügt und 
-ScummVM unterstützt nun auch viele AGI- und SCI-Spiele von Sierra (wie 
-beispielsweise King's Quest 1-6, Space Quest 1-5, ...), Discworld 1 und 2, Simon 
-the Sorcerer 1 und 2, Beneath A Steel Sky, Lure of the Temptress, Baphomets 
-Fluch I und II, Flight of the Amazon Queen, Gobliiins 1-3, die Adventure-Reihe 
-The Legend of Kyrandia, viele der SCUMM-Spiele für Kinder von Humongous 
-Entertainment (einschließlich der Spiele von Fritzi Fisch und Töff-Töff) und 
-viele mehr. Sie können eine vollständige Liste mit Einzelheiten einsehen, welche 
-Auskunft darüber gibt, welche Spiele unterstützt werden und wie gut. Gehen Sie 
-hierfür auf die Kompatibilitätsseite. ScummVM wird fortlaufend verbessert, also 
+Mit der Zeit wurde Unterstützung für viele Nicht-SCUMM-Spiele hinzugefügt und
+ScummVM unterstützt nun auch viele AGI- und SCI-Spiele von Sierra (wie
+beispielsweise King's Quest 1-6, Space Quest 1-5, ...), Discworld 1 und 2, Simon
+the Sorcerer 1 und 2, Beneath A Steel Sky, Lure of the Temptress, Baphomets
+Fluch I und II, Flight of the Amazon Queen, Gobliiins 1-3, die Adventure-Reihe
+The Legend of Kyrandia, viele der SCUMM-Spiele für Kinder von Humongous
+Entertainment (einschließlich der Spiele von Fritzi Fisch und Töff-Töff) und
+viele mehr. Sie können eine vollständige Liste mit Einzelheiten einsehen, welche
+Auskunft darüber gibt, welche Spiele unterstützt werden und wie gut. Gehen Sie
+hierfür auf die Kompatibilitätsseite. ScummVM wird fortlaufend verbessert, also
 schauen Sie öfter einmal vorbei.
 
-Unter den Systemen, mit denen Sie diese Spiele spielen können, befinden sich 
+Unter den Systemen, mit denen Sie diese Spiele spielen können, befinden sich
 normale Schreibtisch-Computer (mit den Betriebssystemen Windows, Linux,
-Mac OS X, ...), Spielekonsolen (Dreamcast, Nintendo DS & Wii, PS2, PSP, ...), 
+Mac OS X, ...), Spielekonsolen (Dreamcast, Nintendo DS & Wii, PS2, PSP, ...),
 Smartphones (Android, iPhone, PocketPC, Symbian ...) und einige weitere.
 
-Zurzeit befindet sich ScummVM immer noch stark in der Entwicklung. Seien Sie 
-sich bewusst, dass wir zwar versuchen, dass viele Spiele mit wenigen erheblichen 
-Fehlern durchgespielt werden können, aber es dennoch zu Abstürzen kommen kann 
-und wir keine Gewähr übernehmen. Davon abgesehen: Einige Spiele werden seit 
-längerer Zeit unterstützt und sollten in jeder neusten stabilen veröffentlichten 
-Version ohne größere Probleme laufen. Sie können sich einen Eindruck davon 
-verschaffen, wie gut jedes Spiel unter ScummVM läuft, indem Sie auf die 
-Kompatibilitätsseite schauen. Wenn Sie sich ein wenig im Internet umsehen, 
-können Sie feststellen, dass ScummVM sogar kommerziell genutzt wird, um einige 
-der unterstützen Spiele für moderne Plattformen wiederzuveröffentlichen. Dies 
-zeigt, dass mehrere Firmen mit der Qualität der Software zufrieden sind und wie 
+Zurzeit befindet sich ScummVM immer noch stark in der Entwicklung. Seien Sie
+sich bewusst, dass wir zwar versuchen, dass viele Spiele mit wenigen erheblichen
+Fehlern durchgespielt werden können, aber es dennoch zu Abstürzen kommen kann
+und wir keine Gewähr übernehmen. Davon abgesehen: Einige Spiele werden seit
+längerer Zeit unterstützt und sollten in jeder neusten stabilen veröffentlichten
+Version ohne größere Probleme laufen. Sie können sich einen Eindruck davon
+verschaffen, wie gut jedes Spiel unter ScummVM läuft, indem Sie auf die
+Kompatibilitätsseite schauen. Wenn Sie sich ein wenig im Internet umsehen,
+können Sie feststellen, dass ScummVM sogar kommerziell genutzt wird, um einige
+der unterstützen Spiele für moderne Plattformen wiederzuveröffentlichen. Dies
+zeigt, dass mehrere Firmen mit der Qualität der Software zufrieden sind und wie
 gut einige der Spiele mit Hilfe des Programms laufen.
 
-Wenn Ihnen ScummVM gefällt, können Sie uns gerne Geld spenden, indem Sie auf die 
-PayPal-Schaltfläche auf der ScummVM-Website klicken. Dies hilft uns dabei, 
-notwendige Dienstprogramme zu kaufen, um ScummVM einfacher und schneller zu 
-entwickeln. Wenn Sie nicht spenden können, dürfen Sie auch gerne einen Patch 
+Wenn Ihnen ScummVM gefällt, können Sie uns gerne Geld spenden, indem Sie auf die
+PayPal-Schaltfläche auf der ScummVM-Website klicken. Dies hilft uns dabei,
+notwendige Dienstprogramme zu kaufen, um ScummVM einfacher und schneller zu
+entwickeln. Wenn Sie nicht spenden können, dürfen Sie auch gerne einen Patch
 beisteuern.
 
 1.2) Schnellstart:
 ---- -------------
-WICHTIG: In dieser kurzen Anleitung wird davon ausgegangen, dass Sie ScummVM auf 
-Deutsch benutzen. Standardmäßig wird ScummVM die Sprache Ihres Betriebssystems 
-verwenden. Wenn Sie ScummVM lieber auf Englisch verwenden möchten, benutzen Sie 
+WICHTIG: In dieser kurzen Anleitung wird davon ausgegangen, dass Sie ScummVM auf
+Deutsch benutzen. Standardmäßig wird ScummVM die Sprache Ihres Betriebssystems
+verwenden. Wenn Sie ScummVM lieber auf Englisch verwenden möchten, benutzen Sie
 bitte die Anleitung in der englischen README-Datei.
 
-Für die ungeduldigen unter den Anwendern ist hier in fünf einfachen Schritten 
+Für die ungeduldigen unter den Anwendern ist hier in fünf einfachen Schritten
 kurz beschrieben, wie man ScummVM lauffähig macht und das Programm verwendet.
 
-1. Laden Sie ScummVM unter der Adresse http://www.scummvm.org/downloads.php 
+1. Laden Sie ScummVM unter der Adresse http://www.scummvm.org/downloads.php
 herunter und installieren Sie es.
 
-2. Erstellen Sie ein Verzeichnis auf Ihrer Festplatte und kopieren Sie die 
-Dateien des Spiels vom Original-Datenträger in dieses Verzeichnis. Wiederholen 
-Sie diesen Vorgang für jedes Spiel, das Sie spielen möchten (es ist besser, für 
+2. Erstellen Sie ein Verzeichnis auf Ihrer Festplatte und kopieren Sie die
+Dateien des Spiels vom Original-Datenträger in dieses Verzeichnis. Wiederholen
+Sie diesen Vorgang für jedes Spiel, das Sie spielen möchten (es ist besser, für
 jedes Spiel ein eigenes Verzeichnis zu verwenden).
 
 3. Starten Sie ScummVM.
 
-Sollte an diesem Punkt ScummVM auf Englisch statt auf Deutsch erscheinen, gehen 
+Sollte an diesem Punkt ScummVM auf Englisch statt auf Deutsch erscheinen, gehen
 Sie wie folgt vor, um die Spracheinstellung zu ändern:
 -Klicken Sie auf „Options“.
 -Klicken Sie auf den rechten Pfeil in der Reiterleiste und wählen den Reiter
@@ -102,56 +102,56 @@ Sie wie folgt vor, um die Spracheinstellung zu ändern:
 -Bestätigen Sie die erscheinende Nachricht, klicken auf „Quit“, um ScummVM zu
  beenden, und starten dann das Programm erneut.
 
-Nun klicken Sie auf „Spiel hinzufügen“, wählen das Verzeichnis mit den Dateien 
-des Spiels aus (versuchen Sie nicht, die Dateien des Spiels selbst auszuwählen!) 
+Nun klicken Sie auf „Spiel hinzufügen“, wählen das Verzeichnis mit den Dateien
+des Spiels aus (versuchen Sie nicht, die Dateien des Spiels selbst auszuwählen!)
 und klicken Sie auf „Auswählen“.
 
-4. Ein Dialog sollte erscheinen, der Ihnen ermöglicht, verschiedene 
-Einstellungen vorzunehmen, sollten Sie dies wünschen (es sollte jedoch in 
+4. Ein Dialog sollte erscheinen, der Ihnen ermöglicht, verschiedene
+Einstellungen vorzunehmen, sollten Sie dies wünschen (es sollte jedoch in
 Ordnung sein, alles voreingestellt zu belassen). Bestätigen Sie diesen Dialog.
 
-5. Wählen Sie das Spiel aus der Liste aus, welches Sie spielen möchten, und 
+5. Wählen Sie das Spiel aus der Liste aus, welches Sie spielen möchten, und
 klicken Sie auf „Starten“.
 
-ScummVM behält die Spiele in der Liste, die Sie hinzufügen. Wenn Sie also 
-ScummVM schließen, werden beim nächsten Start alle Spiele, die Sie zuvor 
-hinzugefügt haben, in der Liste angezeigt. Sie können somit direkt zu Schritt 5 
+ScummVM behält die Spiele in der Liste, die Sie hinzufügen. Wenn Sie also
+ScummVM schließen, werden beim nächsten Start alle Spiele, die Sie zuvor
+hinzugefügt haben, in der Liste angezeigt. Sie können somit direkt zu Schritt 5
 übergehen, außer Sie wollen noch mehr Spiele hinzufügen.
 
-Tipp: Wenn Sie mehrere Spiele auf einmal hinzufügen möchten, drücken Sie die 
-Umschalt-Taste (Shift), bevor Sie auf „Spiel hinzufügen“ klicken. Diese 
-Schaltfläche wird somit ihren Text zu „Durchsuchen“ umändern und wenn Sie dann 
-auf diese klicken, werden Sie auch dazu aufgefordert, ein Verzeichnis 
-auszuwählen, nur dieses Mal wird ScummVM alle Unterverzeichnisse automatisch 
+Tipp: Wenn Sie mehrere Spiele auf einmal hinzufügen möchten, drücken Sie die
+Umschalt-Taste (Shift), bevor Sie auf „Spiel hinzufügen“ klicken. Diese
+Schaltfläche wird somit ihren Text zu „Durchsuchen“ umändern und wenn Sie dann
+auf diese klicken, werden Sie auch dazu aufgefordert, ein Verzeichnis
+auszuwählen, nur dieses Mal wird ScummVM alle Unterverzeichnisse automatisch
 nach unterstützen Spielen durchsuchen.
 
 
 2.0) Kontakt:
 ---- --------
-Der einfachste Weg, um mit dem ScummVM-Team in Verbindung zu treten, ist, 
-Fehlerberichte einzusenden (siehe Abschnitt 2.1) oder durch Verwendung des 
+Der einfachste Weg, um mit dem ScummVM-Team in Verbindung zu treten, ist,
+Fehlerberichte einzusenden (siehe Abschnitt 2.1) oder durch Verwendung des
 Forums unter der Adresse http://forums.scummvm.org .
-Sie können ebenso der Mailing-Liste scummvm-devel beitreten und an diese E-Mails 
-versenden oder mit uns im IRC chatten (#scummvm unter irc.freenode.net). Bitte 
-fordern Sie uns nicht dazu auf, ein nicht unterstütztes Spiel zu unterstützen. 
-Lesen Sie zuerst die Seite FAQ (Häufig gestellte Fragen) auf unserer Website. 
-Bitte beachten Sie, dass die offizielle Sprache des Forums, der Mailing-Liste 
-und des Chats Englisch ist und keine andere Sprache dort verwendet werden 
+Sie können ebenso der Mailing-Liste scummvm-devel beitreten und an diese E-Mails
+versenden oder mit uns im IRC chatten (#scummvm unter irc.freenode.net). Bitte
+fordern Sie uns nicht dazu auf, ein nicht unterstütztes Spiel zu unterstützen.
+Lesen Sie zuerst die Seite FAQ (Häufig gestellte Fragen) auf unserer Website.
+Bitte beachten Sie, dass die offizielle Sprache des Forums, der Mailing-Liste
+und des Chats Englisch ist und keine andere Sprache dort verwendet werden
 sollte.
 
 
 2.1) Fehler berichten:
 ---- -----------------
-Um einen Fehler zu berichten, erstellen Sie bitte ein SourceForge-Konto und 
-folgen Sie dem Link „Bug Tracker“ auf der ScummVM-Website. Bitte stellen Sie 
-sicher, dass sich der Bug wiedererzeugen lässt und immer noch in der neusten 
-Version von SVN oder des Daily Builds auftritt. Bitte sehen Sie auch auf der 
-Kompatibilitätsliste der ScummVM-Website für dieses Spiel nach, um 
+Um einen Fehler zu berichten, erstellen Sie bitte ein SourceForge-Konto und
+folgen Sie dem Link „Bug Tracker“ auf der ScummVM-Website. Bitte stellen Sie
+sicher, dass sich der Bug wiedererzeugen lässt und immer noch in der neusten
+Version von SVN oder des Daily Builds auftritt. Bitte sehen Sie auch auf der
+Kompatibilitätsliste der ScummVM-Website für dieses Spiel nach, um
 sicherzustellen, dass das Problem nicht bereits bekannt ist:
 
   http://www.scummvm.org/compatibility_stable.php
 
-Bitte berichten Sie keine Fehler zu Spielen, die nicht als durchspielbar im 
+Bitte berichten Sie keine Fehler zu Spielen, die nicht als durchspielbar im
 Bereich „Supported Games“ oder der Kompatibilitätsliste aufgelistet sind.
 Wir -wissen-, dass diese Spiele Fehler aufweisen.
 
@@ -164,13 +164,13 @@ Bitte liefern Sie folgende Informationen:
     - Version des Spiels (Version mit Sprachausgabe [Talkie],
       Diskettenversion, ...)
     - Plattform und gegebenenfalls Compiler (Win32, Linux, FreeBSD, ...)
-    - Fügen Sie – wenn möglich - einen Speicherstand hinzu.
+    - Fügen Sie - wenn möglich - einen Speicherstand hinzu.
     - Wenn dieser Fehler erst seit kurzem Auftritt, teilen Sie bitte die letzte
       Version ohne den Fehler mit und die erste Version mit diesem Fehler.
       Auf diese Weise können wir diesen schneller beseitigen, indem wir die
       vorgenommen Veränderungen einsehen.
 
-Zum Schluss möchten wir Sie noch bitten, jeden Punkt einzeln zu berichten. Bitte 
-senden Sie nicht mehrere Punkte mit demselben Ticket ein, ansonsten wird es 
-schwierig, den Status jedes einzelnen Fehlers zu verfolgen. Denken Sie bitte 
+Zum Schluss möchten wir Sie noch bitten, jeden Punkt einzeln zu berichten. Bitte
+senden Sie nicht mehrere Punkte mit demselben Ticket ein, ansonsten wird es
+schwierig, den Status jedes einzelnen Fehlers zu verfolgen. Denken Sie bitte
 auch daran, dass alle Fehlerberichte in Englisch verfasst sein müssen.


### PR DESCRIPTION
Updated Liesmich (German README) - 2/3 translated now - and fixed typo in Schnellstart (Quickstart) file (thanks to wjp).
