### PR TITLE
Updated Inno Setup Script to include translations

### DIFF
--- a/dists/win32/ScummVM.iss
+++ b/dists/win32/ScummVM.iss
@@ -58,7 +58,9 @@ Name: {group}\Readme; Filename: {app}\README.txt; WorkingDir: {app}; Comment: RE
 Name: {group}\News; Filename: {app}\NEWS.txt; WorkingDir: {app}; Comment: NEWS; Flags: createonlyiffileexists
 
 [Run]
-Filename: {app}\scummvm.exe; Flags: nowait skipifdoesntexist postinstall skipifsilent; Description: Launch ScummVM
+Filename: {app}\scummvm.exe; Flags: nowait skipifdoesntexist postinstall skipifsilent; Description: Launch ScummVM; Languages: en eu br ca cz da nl fi he hu it ja nb pl pt ru sk sl es
+Filename: {app}\scummvm.exe; Flags: nowait skipifdoesntexist postinstall skipifsilent; Description: ScummVM starten; Languages: de
+Filename: {app}\scummvm.exe; Flags: nowait skipifdoesntexist postinstall skipifsilent; Description: Démarrer ScummVM; Languages: fr
 
 [UninstallDelete]
 Type: files; Name: {app}\ISTool.url
@@ -69,7 +71,11 @@ Source: COPYING.txt; DestDir: {app}; Flags: ignoreversion
 Source: COPYING.LGPL.txt; DestDir: {app}; Flags: ignoreversion
 Source: COPYRIGHT.txt; DestDir: {app}; Flags: ignoreversion
 Source: NEWS.txt; DestDir: {app}; Flags: ignoreversion
-Source: README.txt; DestDir: {app}; Flags: ignoreversion isreadme
+Source: README.txt; DestDir: {app}; Flags: ignoreversion isreadme; Languages: en eu br ca cz da nl fi fr he hu it ja nb pl pt ru sk sl es
+Source: README.txt; DestDir: {app}; Flags: ignoreversion; Languages: de
+Source: doc/de/Liesmich.txt; DestDir: {app}/doc/de; Flags: ignoreversion skipifsourcedoesntexist; Languages: en eu br ca cz da nl fi fr he hu it ja nb pl pt ru sk sl es
+Source: doc/de/Liesmich.txt; DestDir: {app}/doc/de; Flags: ignoreversion isreadme skipifsourcedoesntexist; Languages: de
+Source: doc/fr/Quickstart_fr.txt; DestDir: {app}/doc/fr; Flags: ignoreversion skipifsourcedoesntexist
 Source: README-SDL.txt; DestDir: {app}; Flags: ignoreversion
 Source: scummvm.exe; DestDir: {app}; Flags: ignoreversion
 Source: SDL.dll; DestDir: {app}


### PR DESCRIPTION
This pull request is for Kirben. Please review this and if you see no problem,
merge it to the development branch and to your local machine, so that the
translations can be featured and the installer shows the translated
"Launch ScummVM" message. If you see any problems with my modifications,
don't hesitate to tell me.

I didn't include the German and English QuickStart file on purpose.
For the English one: This actually a template; it mentions things like this
file being a translation of the original Readme.
For the German one: I'm not sure if we should include two translated Readmes.
I am still thinking about if one isn't enough to keep track of and if the
QuickStart file should be only for translators with not so much time and
motivation.
