### PR TITLE
VIDEO: Add missing include to bink_decoder.h

### DIFF
--- a/video/bink_decoder.h
+++ b/video/bink_decoder.h
@@ -26,6 +26,8 @@
 
 #include "common/scummsys.h"
 
+#include "graphics/surface.h"
+
 #ifdef USE_BINK
 
 #ifndef VIDEO_BINK_DECODER_H


### PR DESCRIPTION
While working on Residual I noticed BinkDecoder was missing an include to graphics/surface.h, which had worked fine up to that point as i included graphics/surface.h before binkdecoder.h, but it should probably be corrected to avoid having to include in a specific order.
