### PR TITLE
VIDEO: Add missing include to bink_decoder.h

### DIFF
--- a/video/bink_decoder.h
+++ b/video/bink_decoder.h
@@ -36,6 +36,8 @@
 #include "common/array.h"
 #include "common/rational.h"
 
+#include "graphics/surface.h"
+
 #include "video/video_decoder.h"
 
 namespace Common {


### PR DESCRIPTION
While working on Residual I noticed BinkDecoder was missing an include to graphics/surface.h, which had worked fine up to that point as i included graphics/surface.h before binkdecoder.h, but it should probably be corrected to avoid having to include in a specific order.

I was a bit too quick the first time around, here's the proper fix, inside the guards.
