### PR TITLE
GUI: Enable EGA Undithering in global options dialog

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -216,7 +216,7 @@ void OptionsDialog::open() {
 #endif // SMALL_SCREEN_DEVICE
 
 		// EGA undithering setting
-		if (_guioptions.contains(GUIO_EGAUNDITHER)  || _domain.equals(Common::ConfigManager::kApplicationDomain)) {
+		if (_guioptions.contains(GUIO_EGAUNDITHER)  || _domain == Common::ConfigManager::kApplicationDomain) {
 			_disableDitheringCheckbox->setEnabled(true);
 			_disableDitheringCheckbox->setState(ConfMan.getBool("disable_dithering", _domain));
 		} else {


### PR DESCRIPTION
This provides a way to globally turn on EGA Undithering while still preventing games that don't have GUIO_EGAUNDITHER from being able to modify it in the game-specific options.
