### PR TITLE
GUI: Enable EGA Undithering in global options dialog 1

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -216,7 +216,7 @@ void OptionsDialog::open() {
 #endif // SMALL_SCREEN_DEVICE
 
 		// EGA undithering setting
-		if (_guioptions.contains(GUIO_EGAUNDITHER)) {
+		if (_guioptions.contains(GUIO_EGAUNDITHER)  || _domain == Common::ConfigManager::kApplicationDomain) {
 			_disableDitheringCheckbox->setEnabled(true);
 			_disableDitheringCheckbox->setState(ConfMan.getBool("disable_dithering", _domain));
 		} else {
@@ -609,7 +609,7 @@ void OptionsDialog::setGraphicSettingsState(bool enabled) {
 	else
 		_aspectCheckbox->setEnabled(enabled);
 #endif
-	if (_guioptions.contains(GUIO_EGAUNDITHER))
+	if (_guioptions.contains(GUIO_EGAUNDITHER) && enabled)
 		_disableDitheringCheckbox->setEnabled(true);
 	else
 		_disableDitheringCheckbox->setEnabled(false);


### PR DESCRIPTION
This provides a way to globally turn on EGA Undithering while still preventing games that don't have GUIO_EGAUNDITHER from being able to modify it in the game-specific options.

rebased https://github.com/scummvm/scummvm/pull/111 for cleaner history.
