### PR TITLE
DRASCULA: Simplify speech mute handling.

### DIFF
--- a/engines/drascula/sound.cpp
+++ b/engines/drascula/sound.cpp
@@ -26,6 +26,7 @@
 
 #include "common/config-manager.h"
 #include "common/textconsole.h"
+#include "common/substream.h"
 
 #include "backends/audiocd/audiocd.h"
 
@@ -165,29 +166,42 @@ void DrasculaEngine::MusicFadeout() {
 void DrasculaEngine::playFile(const char *fname) {
 	Common::SeekableReadStream *stream = _archives.open(fname);
 	if (stream) {
-		int soundSize = stream->size();
-		byte *soundData = (byte *)malloc(soundSize);
+		// TODO: I don't really see a reason why we have this offset here. The
+		// file "S3.ALS" for example does not contain any silence at the start
+		// nor end. Thus it looks like this cuts off part of the sound.
+		//
+		// Would be good if someone could double check this and clarify why
+		// the code is working like this if it is fine and otherwise just fix
+		// it.
+		int startOffset = 32;
+		int soundSize = stream->size() - startOffset;
 
-		if (!(!strcmp(fname, "3.als") && soundSize == 145166 && _lang != kSpanish)) {
-			stream->seek(32);
-		} else {
+		if (!strcmp(fname, "3.als") && soundSize == 145166 && _lang != kSpanish) {
 			// WORKAROUND: File 3.als with English speech files has a big silence at
 			// its beginning and end. We seek past the silence at the beginning,
 			// and ignore the silence at the end
 			// Fixes bug #2111815 - "DRASCULA: Voice delayed"
-			stream->seek(73959, SEEK_SET);
-			soundSize = 117158 - 73959;
+			startOffset = 73959;
+			// TODO: The old code also subtracted 64 later on when creating
+			// the RAW audio stream. It would be good if someone could check
+			// whether this has been properly taking into account when
+			// calculating the soundSize. If it hasn't been taken into account
+			// when it is probably better to remove the minus 64 here.
+			soundSize = 117158 - 73959 - 64;
 		}
 
-		stream->read(soundData, soundSize);
-		delete stream;
+		Common::SeekableReadStream *subStream = new Common::SeekableSubReadStream(
+		    stream, startOffset, startOffset + soundSize, DisposeAfterUse::YES);
+		if (!subStream) {
+			warning("playFile: Out of memory");
+			delete stream;
+			return;
+		}
 
 		_subtitlesDisabled = !ConfMan.getBool("subtitles");
-		if (ConfMan.getBool("speech_mute"))
-			memset(soundData, 0x80, soundSize); // Mute speech but keep the pause
 
-		Audio::AudioStream *sound = Audio::makeRawStream(soundData, soundSize - 64,
-						11025, Audio::FLAG_UNSIGNED);
+		Audio::AudioStream *sound = Audio::makeRawStream(subStream, 11025,
+		                                                 Audio::FLAG_UNSIGNED);
 		_mixer->playStream(Audio::Mixer::kSpeechSoundType, &_soundHandle, sound);
 	} else
 		warning("playFile: Could not open %s", fname);


### PR DESCRIPTION
As the pull request's name suggests this simplifies the handling of speech mute handling in Drascula. I still got the proper delay times and no speech, when speech_mute is set.

There is some TODOs I added about odd parts in the playFile method. Maybe one with more knowledge of the Drascula engine can check them and handle them properly.

Thanks in advance.
