### PR TITLE
GUI: Disable speech volume slider in subtitle only mode.

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -570,6 +570,12 @@ void OptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 		// 'true' because if control is disabled then event do not pass
 		setVolumeSettingsState(true);
 		break;
+	case kSubtitleToggle:
+		// We update the slider settings here, when there are sliders, to
+		// disable the speech volume in case we are in subtitle only mode.
+		if (_musicVolumeSlider)
+			setVolumeSettingsState(true);
+		break;
 	case kSubtitleSpeedChanged:
 		_subSpeedLabel->setValue(_subSpeedSlider->getValue());
 		_subSpeedLabel->draw();
@@ -691,6 +697,9 @@ void OptionsDialog::setVolumeSettingsState(bool enabled) {
 	_sfxVolumeLabel->setEnabled(ena);
 
 	ena = enabled && !_muteCheckbox->getState();
+	// Disable speech volume slider, when we are in subtitle only mode.
+	if (_subToggleGroup)
+		ena = ena && _subToggleGroup->getValue() != kSubtitlesSubs;
 	if (_guioptions.contains(GUIO_NOSPEECH))
 		ena = false;
 


### PR DESCRIPTION
The description says it all, this pull requests makes the GUI disable the speech volume slider when the user is in subtitle only mode. What I find slightly confusing now is that it also disables the speech volume slider in the "Options"/"Edit game" menus, where the subtitle settings are in another tab, but maybe it actually helps people not to wonder why the speech volume settings has no effect.

Happy to hear your thoughts on this.
