### PR TITLE
Dreamweb cleanup

### DIFF
--- a/engines/dreamweb/stubs.cpp
+++ b/engines/dreamweb/stubs.cpp
@@ -632,7 +632,7 @@ void DreamGenContext::deallocateMem(uint16 segment) {
 	uint16 bseg = data.word(kBuffers);
 	if (!bseg)
 		return;
-	SegmentRef buffers(this);
+	MutableSegmentRef buffers(this);
 	buffers = bseg;
 	uint8 *ptr = buffers.ptr(kSpritetable, tsize);
 	for(uint i = 0; i < tsize; i += 32) {


### PR DESCRIPTION
This cleans up a small part of the dreamweb code; the primary goal was to make it clear that both cs and data are constant and always point to the same data segment. This should enable further optimizations, e.g. one of cs or data could be removed and replaced by the other. Also, code could be converted to directly use the SegmentPtr _realData (to be renamed to something nicer).
Note that this can be done regardless of the changes in this pull request; these changes merely make it impossible to "accidentally" change cs or data. 
