### PR TITLE
SCUMM: Work around script bug in The Dig

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -943,7 +943,7 @@ void ScummEngine::runExitScript() {
 	// effect is also used in room 33, so let's do the same fade out that it
 	// does in that room's exit script.
 	if (_game.id == GID_DIG && _currentRoom == 44) {
-		int scriptCmds[] = { 14, 215, 0x600, 0, 30 };
+		int scriptCmds[] = { 14, 215, 0x600, 0, 30, 0, 0, 0 };
 		_sound->soundKludge(scriptCmds, ARRAYSIZE(scriptCmds));
 	}
 #endif


### PR DESCRIPTION
This is in response to a bug report which, despite several gentle hints that the bug tracker would be more appropriate, was posted to the ScummVM forum at http://forums.scummvm.org/viewtopic.php?t=11183

The short version is that in the spider lair, the entry script may start a sound effect of running water, but this sound is never explicitly stopped so it keeps running, at least for a while. (When I tried it in DOSBox, it kept running until I got back to the Nexus.) It's probably gone unnoticed - both by us and by LucasArts - because it happens in an area of the game where there is a lot of water.

The same sound effect is used in another room, and in that case the exit script does fade it out when you leave, so this workaround attempts to do the same thing.
