### PR TITLE
COMMON: Enhance zlib interface

### DIFF
--- a/common/zlib.cpp
+++ b/common/zlib.cpp
@@ -49,7 +49,7 @@ bool uncompress(byte *dst, unsigned long *dstLen, const byte *src, unsigned long
 	return Z_OK == ::uncompress(dst, dstLen, src, srcLen);
 }
 
-bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen) {
+bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen, const byte *dict, uint dictLen) {
 	if (!dst || !dstLen || !src || !srcLen)
 		return false;
 
@@ -67,6 +67,13 @@ bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen)
 	int err = inflateInit2(&stream, -MAX_WBITS);
 	if (err != Z_OK)
 		return false;
+
+	// Set the dictionary, if provided
+	if (dict != 0) {
+		err = inflateSetDictionary(&stream, const_cast<byte *>(dict), dictLen);
+		if (err != Z_OK)
+			return false;
+	}
 
 	err = inflate(&stream, Z_SYNC_FLUSH);
 	if (err != Z_OK && err != Z_STREAM_END) {

--- a/common/zlib.h
+++ b/common/zlib.h
@@ -37,7 +37,19 @@ class WriteStream;
  * it possible to uncompress data in engines without being forced to link
  * them against zlib, thus simplifying the build system.
  *
- * @return true on success (i.e. Z_OK), false otherwise
+ * Taken from the zlib manual:
+ * Decompresses the src buffer into the dst buffer.
+ * srcLen is the byte length of the source buffer. Upon entry, dstLen is the
+ * total size of the destination buffer, which must be large enough to hold
+ * the entire uncompressed data. Upon exit, dstLen is the actual size of the
+ * compressed buffer.
+ *
+ * @param dst       the buffer to store into.
+ * @param dstLen    a pointer to the size of the destination buffer.
+ * @param src       the data to be decompressed.
+ * @param srcLen    the size of the compressed data.
+ *
+ * @return true on success (i.e. Z_OK), false otherwise.
  */
 bool uncompress(byte *dst, unsigned long *dstLen, const byte *src, unsigned long srcLen);
 
@@ -46,9 +58,24 @@ bool uncompress(byte *dst, unsigned long *dstLen, const byte *src, unsigned long
  * necessary inflate functions to uncompress data compressed with deflate
  * but *not* with the standard zlib header.
  *
- * @return true on success (Z_OK or Z_STREAM_END), false otherwise
+ * Decompresses the src buffer into the dst buffer.
+ * srcLen is the byte length of the source buffer, dstLen is the byte
+ * length of the output buffer.
+ * It decompress as much data as possible, up to dstLen bytes.
+ * If a dictionary is provided through the dict buffer, uses it to initializes
+ * the internal decompression dictionary, before the decompression takes place.
+ *
+ * @param dst       the buffer to store into.
+ * @param dstLen    the size of the destination buffer.
+ * @param src       the data to be decompressed.
+ * @param dstLen    the size of the compressed data.
+ * @param dict      (optional) a decompress dictionary.
+ * @param dictLen   (optional) the size of the dictionary.
+ *                  Mandatory if dict is not 0.
+ *
+ * @return true on success (Z_OK or Z_STREAM_END), false otherwise.
  */
-bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen);
+bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen, const byte *dict = 0, uint dictLen = 0);
 
 #endif
 


### PR DESCRIPTION
This commit enhances the interface of inflateZlibHeaderless by adding an optional parameter to set a decompression dictionary before inflate.
It also documents more extensively this and uncompress functions.
