### PR TITLE
MT32: Add --disable-mt32emu-accurate-wg to configure

### DIFF
--- a/audio/softsynth/mt32/mt32emu.h
+++ b/audio/softsynth/mt32/mt32emu.h
@@ -62,7 +62,11 @@
 
 // 0: Use LUTs to speedup WG
 // 1: Use precise float math
+#ifdef USE_MT32EMU_ACCURATE_WG
 #define MT32EMU_ACCURATE_WG 1
+#else
+#define MT32EMU_ACCURATE_WG 0
+#endif
 
 #define MT32EMU_USE_EXTINT 0
 

--- a/configure
+++ b/configure
@@ -156,6 +156,7 @@ _optimizations=auto
 _verbose_build=no
 _text_console=no
 _mt32emu=yes
+_mt32emu_accurate_wg=yes
 _build_scalers=yes
 _build_hq_scalers=yes
 _enable_prof=no
@@ -829,6 +830,9 @@ Optional Features:
   --enable-plugins         enable the support for dynamic plugins
   --default-dynamic        make plugins dynamic by default
   --disable-mt32emu        don't enable the integrated MT-32 emulator
+  --disable-mt32emu-accurate-wg don't enable accurate waveform generation in the
+                           integrated MT-32 emulator (higher performance but less
+                           quality)
   --disable-16bit          don't enable 16bit color support
   --disable-savegame-timestamp don't use timestamps for blank savegame descriptions
   --disable-scalers        exclude scalers
@@ -962,6 +966,8 @@ for ac_option in $@; do
 	--default-dynamic)        _plugins_default=dynamic ;;
 	--enable-mt32emu)         _mt32emu=yes    ;;
 	--disable-mt32emu)        _mt32emu=no     ;;
+	--enable-mt32emu-accurate-wg) _mt32emu_accurate_wg=yes ;;
+	--disable-mt32emu-accurate-wg) _mt32emu_accurate_wg=no ;;
 	--enable-translation)     _translation=yes ;;
 	--disable-translation)    _translation=no ;;
 	--enable-vkeybd)          _vkeybd=yes     ;;
@@ -3060,6 +3066,11 @@ fi
 # Check whether integrated MT-32 emulator support is requested
 #
 define_in_config_if_yes "$_mt32emu" 'USE_MT32EMU'
+
+#
+# Check whether MT32 accurate waveform generation support is requested
+#
+define_in_config_if_yes "$_mt32emu_accurate_wg" 'USE_MT32EMU_ACCURATE_WG'
 
 #
 # Check whether 16bit color support is requested


### PR DESCRIPTION
Using this significantly improves performance and (supposedly) slightly reduces quality.
I couldn't personally tell the difference in quality but the difference in performance on my laptop was significant (dual core 1.8 Ghz CPU couldn't keep up; ALSA buffer underruns)
The default behavior is unchanged.
