### PR TITLE
MACOSX: Update menu translations to match Apple guidelines

### DIFF
--- a/po/da_DA.po
+++ b/po/da_DA.po
@@ -347,7 +347,7 @@ msgstr "~A~fslut"
 
 #: gui/launcher.cpp:578 backends/platform/sdl/macosx/appmenu_osx.mm:96
 msgid "Quit ScummVM"
-msgstr "Afslut ScummVM"
+msgstr "Slut ScummVM"
 
 #: gui/launcher.cpp:579
 msgid "A~b~out..."
@@ -2360,25 +2360,24 @@ msgstr "Pegeplade tilstand deaktiveret."
 #: backends/platform/sdl/macosx/appmenu_osx.mm:78
 #, fuzzy
 msgid "Hide ScummVM"
-msgstr "Afslut ScummVM"
+msgstr "Skjul ScummVM"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"
-msgstr ""
+msgstr "Skjul andre"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"
-msgstr ""
+msgstr "Vis alle"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:110
 #: backends/platform/sdl/macosx/appmenu_osx.mm:121
-#, fuzzy
 msgid "Window"
-msgstr "Windows MIDI"
+msgstr "Vindue"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:115
 msgid "Minimize"
-msgstr ""
+msgstr "Minimer"
 
 #: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:45
 msgid "Normal (no scaling)"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -2404,15 +2404,15 @@ msgstr "Touchpad-Modus ausgeschaltet."
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:78
 msgid "Hide ScummVM"
-msgstr "ScummVM verbergen"
+msgstr "ScummVM ausblenden"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"
-msgstr "Andere verbergen"
+msgstr "Andere ausblenden"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"
-msgstr "Alles zeigen"
+msgstr "Alle einblenden"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:110
 #: backends/platform/sdl/macosx/appmenu_osx.mm:121
@@ -2421,7 +2421,7 @@ msgstr "Fenster"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:115
 msgid "Minimize"
-msgstr "Minimieren"
+msgstr "Im Dock ablegen"
 
 #: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:45
 msgid "Normal (no scaling)"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -347,7 +347,7 @@ msgstr "~S~alir"
 
 #: gui/launcher.cpp:578 backends/platform/sdl/macosx/appmenu_osx.mm:96
 msgid "Quit ScummVM"
-msgstr "Cerrar ScummVM"
+msgstr "Salir de ScummVM"
 
 #: gui/launcher.cpp:579
 msgid "A~b~out..."
@@ -2388,7 +2388,7 @@ msgstr "Modo Touchpad desactivado."
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:78
 msgid "Hide ScummVM"
-msgstr "Oculta ScummVM"
+msgstr "Ocultar ScummVM"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -2396,15 +2396,15 @@ msgstr "Mode touchpad désactivé"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:78
 msgid "Hide ScummVM"
-msgstr "Cacher ScummVM"
+msgstr "Masquer ScummVM"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"
-msgstr "Masquer les Autres"
+msgstr "Masquer les autres"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"
-msgstr "Tout Afficher"
+msgstr "Tout afficher"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:110
 #: backends/platform/sdl/macosx/appmenu_osx.mm:121
@@ -2413,7 +2413,7 @@ msgstr "Fenêtre"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:115
 msgid "Minimize"
-msgstr "Minimiser"
+msgstr "Placer dans le Dock"
 
 #: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:45
 msgid "Normal (no scaling)"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -346,7 +346,7 @@ msgstr "C~h~iudi"
 
 #: gui/launcher.cpp:578 backends/platform/sdl/macosx/appmenu_osx.mm:96
 msgid "Quit ScummVM"
-msgstr "Chiudi ScummVM"
+msgstr "Esci da ScummVM"
 
 #: gui/launcher.cpp:579
 msgid "A~b~out..."
@@ -2395,11 +2395,11 @@ msgstr "Nascondi ScummVM"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"
-msgstr "Nascondi altri"
+msgstr "Nascondi altre"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"
-msgstr "Mostra tutti"
+msgstr "Mostra tutte"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:110
 #: backends/platform/sdl/macosx/appmenu_osx.mm:121
@@ -2408,7 +2408,7 @@ msgstr "Finestra"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:115
 msgid "Minimize"
-msgstr "Minimizza"
+msgstr "Contrai"
 
 #: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:45
 msgid "Normal (no scaling)"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -2360,25 +2360,24 @@ msgstr "Touchpad-modus deaktivert."
 #: backends/platform/sdl/macosx/appmenu_osx.mm:78
 #, fuzzy
 msgid "Hide ScummVM"
-msgstr "Avslutt ScummVM"
+msgstr "Skjul ScummVM"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"
-msgstr ""
+msgstr "Skjul andre"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"
-msgstr ""
+msgstr "Vis alle"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:110
 #: backends/platform/sdl/macosx/appmenu_osx.mm:121
-#, fuzzy
 msgid "Window"
-msgstr "Windows MIDI"
+msgstr "Vindu"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:115
 msgid "Minimize"
-msgstr ""
+msgstr "Minimer"
 
 #: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:45
 msgid "Normal (no scaling)"

--- a/po/nn_NO.po
+++ b/po/nn_NO.po
@@ -2346,9 +2346,8 @@ msgstr ""
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:110
 #: backends/platform/sdl/macosx/appmenu_osx.mm:121
-#, fuzzy
 msgid "Window"
-msgstr "Windows MIDI"
+msgstr ""
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:115
 msgid "Minimize"

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -357,7 +357,7 @@ msgstr "I~n~formacje..."
 
 #: gui/launcher.cpp:579 backends/platform/sdl/macosx/appmenu_osx.mm:70
 msgid "About ScummVM"
-msgstr "O ScummVM"
+msgstr "Ksi±¿ka ScummVM"
 
 #: gui/launcher.cpp:580
 msgid "~O~ptions..."
@@ -2379,11 +2379,11 @@ msgstr "Tryb touchpada wy³±czony."
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:78
 msgid "Hide ScummVM"
-msgstr "Schowaj ScummVM"
+msgstr "Ukryj ScummVM"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"
-msgstr "Schowaj pozosta³e"
+msgstr "Ukryj pozosta³e"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"
@@ -2396,7 +2396,7 @@ msgstr "Okno"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:115
 msgid "Minimize"
-msgstr "Minimalizuj"
+msgstr "Miniaturka"
 
 #: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:45
 msgid "Normal (no scaling)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2413,7 +2413,7 @@ msgstr "Ocultar Outros"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"
-msgstr "Exibir Todos"
+msgstr "Mostrar Tudo"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:110
 #: backends/platform/sdl/macosx/appmenu_osx.mm:121

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -348,7 +348,7 @@ msgstr "~В~ыход"
 
 #: gui/launcher.cpp:578 backends/platform/sdl/macosx/appmenu_osx.mm:96
 msgid "Quit ScummVM"
-msgstr "Выход из ScummVM"
+msgstr "Завершить ScummVM"
 
 #: gui/launcher.cpp:579
 msgid "A~b~out..."
@@ -2391,15 +2391,15 @@ msgstr "Режим тачпада выключен."
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:78
 msgid "Hide ScummVM"
-msgstr "Спрятать ScummVM"
+msgstr "Скрыть ScummVM"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"
-msgstr "Спрятать Другие"
+msgstr "Скрыть остальные"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"
-msgstr "Показать всё"
+msgstr "Показать все"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:110
 #: backends/platform/sdl/macosx/appmenu_osx.mm:121
@@ -2408,7 +2408,7 @@ msgstr "Окно"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:115
 msgid "Minimize"
-msgstr "Минимизировать"
+msgstr "Убрать в Dock"
 
 #: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:45
 msgid "Normal (no scaling)"

--- a/po/se_SE.po
+++ b/po/se_SE.po
@@ -2382,11 +2382,11 @@ msgstr "Touchpad-läge inaktiverat."
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:78
 msgid "Hide ScummVM"
-msgstr "Dölj ScummVM"
+msgstr "Göm ScummVM"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:83
 msgid "Hide Others"
-msgstr "Dölj övriga"
+msgstr "Göm övriga"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:88
 msgid "Show All"


### PR DESCRIPTION
This pull request updates the translations for menu items on Mac OS X to match the Apple guidelines. I only updated a subset of all translations, namely those I quickly found the official translations.

Without this change, the wording used in ScummVM menus is non-standard and different from every other Mac OS X application. That makes it look very unprofessional and crude. Hence this should be fixed.

Note that I deliberately did not run "make update-translations" as part of this commit, as I get a huge number of differences, and I am not sure if these are normal, or due to a difference on my system compared to wherever this is normally done. Also, this would make merge a lot more annoying if somebody else runs "make update-translations" on master in the meantime. Hence, I suggest that after merging this, "make update-translations" should be run and the result committed.
