### PR TITLE
IPHONE: Fix menu gesture

### DIFF
--- a/backends/platform/iphone/osys_events.cpp
+++ b/backends/platform/iphone/osys_events.cpp
@@ -322,7 +322,7 @@ bool OSystem_IPHONE::handleEvent_mouseSecondDragged(Common::Event &event, int x,
 			event.type = Common::EVENT_KEYDOWN;
 			_queuedInputEvent.type = Common::EVENT_KEYUP;
 
-			event.kbd.flags = _queuedInputEvent.kbd.flags = 0;
+			event.kbd.flags = _queuedInputEvent.kbd.flags = Common::KBD_CTRL;
 			event.kbd.keycode = _queuedInputEvent.kbd.keycode = Common::KEYCODE_F5;
 			event.kbd.ascii = _queuedInputEvent.kbd.ascii = Common::ASCII_F5;
 			_queuedEventTime = getMillis() + kQueuedInputEventDelay;


### PR DESCRIPTION
Change the gesture binding from F5 to CTRL-F5

I do realize that the proper fix is setting the event.type=EVENT_MAINMENU and probably setting the _queuedInputEvent.type=EVENT_INVALID but I don't actually have a cross compile environment set up and this is as far as I could comfortably blind-code.

I am kind of hoping this gets merged so the buildbot will do the building for me.
