### PR TITLE
MOHAWK: Added transitions for Riven

### DIFF
--- a/engines/mohawk/riven_graphics.h
+++ b/engines/mohawk/riven_graphics.h
@@ -97,6 +97,7 @@ private:
 
 	// Screen Related
 	Graphics::Surface *_mainScreen;
+	Graphics::Surface *_previousScreen;
 	bool _dirtyScreen;
 	Graphics::PixelFormat _pixelFormat;
 	void clearMainScreen();


### PR DESCRIPTION
This commit adds transitions for Riven. I hope it is good enough :)

I ignored the transition rectangle as I couldn't find any script that used it, so I didn't have anything to compare against.

While testing the transitions I noticed that some behaved a bit different. For example looking up on tspit 128 (when facing the "spawning point" in the beginning) only a part of the new card is used in the transition. All of the transitions I found that behaved this way had different offsets, so it doesn't seem to be some magical constant :)
I can't figure out where these values come from though, maybe they were hard-coded in the original game.
Any ideas ?
