### PR TITLE
MOHAWK: Ambient sound fading for Riven and some changes to the video-handling

### DIFF
--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -193,6 +193,7 @@ void MohawkEngine_Riven::handleEvents() {
 	checkTimer();
 	bool needsUpdate = _gfx->runScheduledWaterEffects();
 	needsUpdate |= _video->updateMovies();
+	_sound->updateSLST();
 
 	Common::Event event;
 
@@ -700,6 +701,7 @@ void MohawkEngine_Riven::delayAndUpdate(uint32 ms) {
 	while (_system->getMillis() < startTime + ms && !shouldQuit()) {
 		bool needsUpdate = _gfx->runScheduledWaterEffects();
 		needsUpdate |= _video->updateMovies();
+		_sound->updateSLST();
 
 		Common::Event event;
 		while (_system->getEventManager()->pollEvent(event))

--- a/engines/mohawk/sound.h
+++ b/engines/mohawk/sound.h
@@ -66,9 +66,19 @@ struct SndHandle {
 	uint16 id;
 };
 
+struct SLSTSndFade {
+	int16 start;
+	int16 end;
+	byte flag;
+	uint32 startMillis;
+	int32 durationMillis;
+};
+
 struct SLSTSndHandle {
 	Audio::SoundHandle *handle;
 	uint16 id;
+	SLSTSndFade volumeFade;
+	SLSTSndFade balanceFade;
 };
 
 struct ADPCMStatus { // Holds ADPCM status data, but is irrelevant for us.
@@ -148,6 +158,8 @@ public:
 	void pauseSLST();
 	void resumeSLST();
 	void stopAllSLST(bool fade = false);
+	void updateSLST();
+	static byte convertRivenVolume(uint16 volume, uint16 globalVolume);
 	static byte convertRivenVolume(uint16 volume);
 
 private:
@@ -169,8 +181,13 @@ private:
 	SndHandle _mystBackgroundSound;
 
 	// Riven-specific
-	void playSLSTSound(uint16 index, bool fade, bool loop, uint16 volume, int16 balance);
+	void playSLSTSound(uint16 index, bool fade, bool loop, byte volume, int8 balance);
 	void stopSLSTSound(uint16 id, bool fade);
+	void removeSLSTSound(uint16 id);
+	void setVolumeFadingSLST(uint16 id, byte start, byte end, bool remove = false);
+	void setBalanceFadingSLST(uint16 id, int8 start, int8 end);
+	void initFadeSLST(SLSTSndFade *fade, byte flag, int16 start, int16 end, int32 duration);
+	bool doFadeSLST(SLSTSndFade *fade, int16 *result, bool *remove = NULL);
 	Common::Array<SLSTSndHandle> _currentSLSTSounds;
 };
 

--- a/engines/mohawk/video.h
+++ b/engines/mohawk/video.h
@@ -26,6 +26,8 @@
 #include "common/array.h"
 #include "graphics/pixelformat.h"
 #include "video/video_decoder.h"
+#include "audio/mixer.h"
+#include "graphics/surface.h"
 
 namespace Mohawk {
 
@@ -50,6 +52,8 @@ struct VideoEntry {
 	uint16 y;
 	bool loop;
 	bool enabled;
+	byte volume;
+	Graphics::Surface surface;
 	Audio::Timestamp start, end;
 
 	// Identification
@@ -74,10 +78,10 @@ public:
 	~VideoManager();
 
 	// Generic movie functions
-	void playMovieBlocking(const Common::String &filename, uint16 x = 0, uint16 y = 0, bool clearScreen = false);
-	void playMovieBlockingCentered(const Common::String &filename, bool clearScreen = true);
-	VideoHandle playMovie(const Common::String &filename, int16 x = -1, int16 y = -1, bool loop = false);
-	VideoHandle playMovie(uint16 id, int16 x = -1, int16 y = -1, bool loop = false);
+	void playMovieBlocking(const Common::String &filename, uint16 x = 0, uint16 y = 0, bool clearScreen = false, byte volume = Audio::Mixer::kMaxChannelVolume);
+	void playMovieBlockingCentered(const Common::String &filename, bool clearScreen = true, byte volume = Audio::Mixer::kMaxChannelVolume);
+	VideoHandle playMovie(const Common::String &filename, int16 x = -1, int16 y = -1, bool loop = false, byte volume = Audio::Mixer::kMaxChannelVolume);
+	VideoHandle playMovie(uint16 id, int16 x = -1, int16 y = -1, bool loop = false, byte volume = Audio::Mixer::kMaxChannelVolume);
 	bool updateMovies();
 	void pauseVideos();
 	void resumeVideos();
@@ -120,8 +124,8 @@ private:
 	// Keep tabs on any videos playing
 	Common::Array<VideoEntry> _videoStreams;
 
-	VideoHandle createVideoHandle(uint16 id, uint16 x, uint16 y, bool loop);
-	VideoHandle createVideoHandle(const Common::String &filename, uint16 x, uint16 y, bool loop);
+	VideoHandle createVideoHandle(uint16 id, uint16 x, uint16 y, bool loop, byte volume);
+	VideoHandle createVideoHandle(const Common::String &filename, uint16 x, uint16 y, bool loop, byte volume);
 };
 
 } // End of namespace Mohawk

--- a/video/qt_decoder.cpp
+++ b/video/qt_decoder.cpp
@@ -63,6 +63,8 @@ QuickTimeDecoder::QuickTimeDecoder() {
 	_palette = 0;
 	_width = _height = 0;
 	_needUpdate = false;
+	_volume = Audio::Mixer::kMaxChannelVolume;
+	_balance = 0;
 }
 
 QuickTimeDecoder::~QuickTimeDecoder() {
@@ -94,10 +96,24 @@ uint32 QuickTimeDecoder::getFrameCount() const {
 	return count;
 }
 
+void QuickTimeDecoder::setVolume(byte volume) {
+	_volume = volume;
+	if (g_system->getMixer()->isSoundHandleActive(_audHandle))
+		g_system->getMixer()->setChannelVolume(_audHandle, volume);
+
+}
+
+void QuickTimeDecoder::setBalance(int8 balance) {
+	_balance = balance;
+	if (g_system->getMixer()->isSoundHandleActive(_audHandle))
+		g_system->getMixer()->setChannelBalance(_audHandle, balance);
+
+}
+
 void QuickTimeDecoder::startAudio() {
 	if (_audStream) {
 		updateAudioBuffer();
-		g_system->getMixer()->playStream(Audio::Mixer::kPlainSoundType, &_audHandle, _audStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO);
+		g_system->getMixer()->playStream(Audio::Mixer::kPlainSoundType, &_audHandle, _audStream, -1, _volume, _balance, DisposeAfterUse::NO);
 	} // else no audio or the audio compression is not supported
 }
 

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -115,6 +115,11 @@ public:
 	void seekToTime(Audio::Timestamp time);
 	uint32 getDuration() const { return _duration * 1000 / _timeScale; }
 
+	void setVolume(byte volume);
+	void setBalance(int8 balance);
+
+	byte getVolume() { return _volume; }
+	int8 getBalance() { return _balance; }
 protected:
 	class VideoSampleDesc : public Common::QuickTimeParser::SampleDesc {
 	public:
@@ -152,6 +157,9 @@ private:
 	bool _needUpdate;
 
 	uint16 _width, _height;
+
+	byte _volume;
+	int8 _balance;
 
 	Graphics::Surface *_scaledSurface;
 	void scaleSurface(const Graphics::Surface *src, Graphics::Surface *dst,


### PR DESCRIPTION
These commits primarily adds volume and balance ambient sound fading for Riven. In the process I also added volume for videos and a fix for the issue with water overwriting sunners.

To fix the water overwriting sunners-issue the video is now rendered to an off-screen surface which is then rendered every update instead of only when there was a new frame in the video. It has been tested with Myst as well and it works there so I hope nothing was broken.