### PR TITLE
OSX: fix making bundle when freetype2 is enabled

### DIFF
--- a/configure
+++ b/configure
@@ -3501,7 +3501,7 @@ fi
 echocheck "FreeType2"
 echo "$_freetype2"
 
-define_in_config_h_if_yes "$_freetype2" "USE_FREETYPE2"
+define_in_config_if_yes "$_freetype2" "USE_FREETYPE2"
 
 #
 # Check for OpenGL (ES)

--- a/ports.mk
+++ b/ports.mk
@@ -76,6 +76,9 @@ endif
 ifneq ($(BACKEND), iphone)
 # Static libaries, used for the scummvm-static and iphone targets
 OSX_STATIC_LIBS := `$(STATICLIBPATH)/bin/sdl-config --static-libs`
+ifdef USE_FREETYPE2
+OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libfreetype.a $(STATICLIBPATH)/lib/libbz2.a
+endif
 endif
 
 ifdef USE_VORBIS


### PR DESCRIPTION
I put into non iOS section since I can not test it on iOS and don't know if it's actually used there
