### PR TITLE
SCUMM: Fix bug #3493317 by removing assert() in detection algorithm. 

### DIFF
--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -589,11 +589,11 @@ static void detectGames(const Common::FSList &fslist, Common::List<DetectorResul
 						file.c_str(), md5str.c_str(), filesize);
 
 					// Sanity check: We *should* have found a matching gameid / variant at this point.
-					// If not, then there's a bug in our data tables...
-					assert(dr.game.gameid != 0);
-
-					// Add it to the list of detected games
-					results.push_back(dr);
+					// If not, we may have #ifdef'ed the entry out in our detection_tables.h because we
+					// don't have the required stuff compiled in, or there's a bug in our data tables...
+					if (dr.game.gameid != 0)
+						// Add it to the list of detected games
+						results.push_back(dr);
 				}
 			}
 


### PR DESCRIPTION
In case an MD5 is found the md5table, but the variant from the md5table is not found in detection_tables.h this assert triggers. However since certain variants can be left out compile-time this situation can occur.

This is the easy way. The better way would be not including the MD5s of the games we don't support in the md5table at all. That would require some changes in the md5table.c table as well. And also expand the md5 list with which MD5 requires which optional feature compiled in.
