### PR TITLE
ANDROID: disable compression for zip-file assets

### DIFF
--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -130,7 +130,18 @@ $(PATH_STAGE_PREFIX).%/res/drawable/scummvm.png: $(PATH_RESOURCES)/drawable/scum
 $(FILE_RESOURCES_MAIN): $(FILE_MANIFEST) $(RESOURCES) $(ANDROID_JAR8) $(DIST_FILES_THEMES) $(DIST_FILES_ENGINEDATA)
 	$(INSTALL) -d $(PATH_BUILD_ASSETS)
 	$(INSTALL) -c -m 644 $(DIST_FILES_THEMES) $(DIST_FILES_ENGINEDATA) $(PATH_BUILD_ASSETS)/
-	$(AAPT) package -f -M $< -S $(PATH_RESOURCES) -A $(PATH_BUILD_ASSETS) -I $(ANDROID_JAR8) -F $@
+	work_dir=`pwd`; \
+	for i in $(PATH_BUILD_ASSETS)/*.zip; do \
+		echo "recompress $$i"; \
+		cd $$work_dir; \
+		$(RM) -rf $(PATH_BUILD_ASSETS)/tmp; \
+		$(MKDIR) $(PATH_BUILD_ASSETS)/tmp; \
+		unzip -q $$i -d $(PATH_BUILD_ASSETS)/tmp; \
+		cd $(PATH_BUILD_ASSETS)/tmp; \
+		zip -r ../`basename $$i` *; \
+	done
+	@$(RM) -rf $(PATH_BUILD_ASSETS)/tmp
+	$(AAPT) package -f -0 zip -M $< -S $(PATH_RESOURCES) -A $(PATH_BUILD_ASSETS) -I $(ANDROID_JAR8) -F $@
 
 $(PATH_BUILD)/%/$(FILE_RESOURCES): $(PATH_BUILD)/%/AndroidManifest.xml $(PATH_STAGE_PREFIX).%/res/values/strings.xml $(PATH_STAGE_PREFIX).%/res/drawable/scummvm.png plugins/lib%.so $(ANDROID_JAR8)
 	$(AAPT) package -f -M $< -S $(PATH_STAGE_PREFIX).$*/res -I $(ANDROID_JAR8) -F $@


### PR DESCRIPTION
At the moment themes are packed into zip-files without compression. When such a zip-file is added to the apk package (basically a zip-file) with aapt the file will be compressed automatically. 
This is fine for scummvm as theme zip-files are not that big. But for residualvm the modern.zip file's size is 1.4 MB which causes trouble:
- First, before android 2.3 there seems to be a restriction on the size of an asset: the uncompressed size must not be greater than 1 MB, which is the case for the 1.4 MB modern.zip.
- Second, on phones with android >= 2.3 (like my Samsung Galaxy S plus) it takes almost one minute until the GUI is displayed because uncompressing the theme is very slow. Most of the time is spent in ZipArchive::listMembers(), probably because opening a file handle with MID_openFd fails in AndroidAssetArchive::createReadStreamForMember() [Error: "This file can not be opened as a file descriptor; it is probably compressed"].

This problem can be solved by compressing the zip-file contents instead of using an uncompressing zip and disable compression for zip-files in aapt (-0 zip). This is done by the patch.
