### PR TITLE
ALL: Correct spelling of "Mac OS X" in various places

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -160,7 +160,7 @@ void OpenGLSdlGraphicsManager::detectSupportedFormats() {
 			_hwscreen->format->Rshift, _hwscreen->format->Gshift,
 			_hwscreen->format->Bshift, _hwscreen->format->Ashift);
 
-		// Workaround to MacOSX SDL not providing an accurate Aloss value.
+		// Workaround to SDL not providing an accurate Aloss value on Mac OS X.
 		if (_hwscreen->format->Amask == 0)
 			format.aLoss = 8;
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -458,7 +458,7 @@ void SurfaceSdlGraphicsManager::detectSupportedFormats() {
 			_hwscreen->format->Rshift, _hwscreen->format->Gshift,
 			_hwscreen->format->Bshift, _hwscreen->format->Ashift);
 
-		// Workaround to MacOSX SDL not providing an accurate Aloss value.
+		// Workaround to SDL not providing an accurate Aloss value on Mac OS X.
 		if (_hwscreen->format->Amask == 0)
 			format.aLoss = 8;
 

--- a/common/taskbar.h
+++ b/common/taskbar.h
@@ -34,7 +34,7 @@ namespace Common {
  * The TaskbarManager allows interaction with the ScummVM application icon:
  *  - in the taskbar on Windows 7 and later
  *  - in the launcher for Unity
- *  - in the dock on MacOSX
+ *  - in the dock on Mac OS X
  *  - ...
  *
  * This allows GUI code and engines to display a progress bar, an overlay icon and/or count

--- a/common/updates.h
+++ b/common/updates.h
@@ -30,7 +30,7 @@ namespace Common {
 /**
  * The UpdateManager allows configuring of the automatic update checking
  * for systems that support it:
- *  - using Sparkle on MacOSX
+ *  - using Sparkle on Mac OS X
  *  - using WinSparkle on Windows
  *
  * Most of the update checking is completely automated and this class only

--- a/configure
+++ b/configure
@@ -835,8 +835,8 @@ Optional Libraries:
                            installed (optional)
   --disable-fluidsynth     disable fluidsynth MIDI driver [autodetect]
 
-  --with-sparkle-prefix=DIR   Prefix where sparkle is installed (MacOSX only - optional)
-  --disable-sparkle        disable sparkle automatic update support [MacOSX only - autodetect]
+  --with-sparkle-prefix=DIR   Prefix where sparkle is installed (Mac OS X only - optional)
+  --disable-sparkle        disable sparkle automatic update support [Mac OS X only - autodetect]
 
   --with-sdl-prefix=DIR    Prefix where the sdl-config script is
                            installed (optional)

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -37,7 +37,7 @@ Output using ALSA sequencer device
 .It Em amidi
 Use the MorphOS MIDI system, for MorphOS users
 .It Em core
-CoreAudio sound, for MacOS X users
+CoreAudio sound, for Mac OS X users
 .It Em mt32
 MT-32 emulation
 .It Em null


### PR DESCRIPTION
This pull requests corrects the spelling of "Mac OS X" in various places. Things are a bit confusing regarding that, since previous versions of the OS were called "MacOS 8" and "MacOS 9", but the official name really is "Mac OS X". More recently, in some places it's also just "OS X", but never was "MacOS X" correct.
