### PR TITLE
GRAPHICS: Fix colorToARGB's alpha value when no alpha channel is present

### DIFF
--- a/graphics/pixelformat.h
+++ b/graphics/pixelformat.h
@@ -97,7 +97,7 @@ struct PixelFormat {
 	}
 
 	inline void colorToARGB(uint32 color, uint8 &a, uint8 &r, uint8 &g, uint8 &b) const {
-		a = ((color >> aShift) << aLoss) & 0xFF;
+		a = (aBits() == 0) ? 0xFF : (((color >> aShift) << aLoss) & 0xFF);
 		r = ((color >> rShift) << rLoss) & 0xFF;
 		g = ((color >> gShift) << gLoss) & 0xFF;
 		b = ((color >> bShift) << bLoss) & 0xFF;


### PR DESCRIPTION
When there is no alpha channel, it should return 0xFF to signify the color is opaque.

The reason I'm creating this pull request is because I don't know if this is "too hacky" to have in PixelFormat, not to mention it probably won't help with any sort of speed issue.
