### PR TITLE
BADA: Implement the weekday field (tm_wday) of our TimeDate struct

### DIFF
--- a/backends/platform/bada/system.cpp
+++ b/backends/platform/bada/system.cpp
@@ -399,11 +399,11 @@ void BadaSystem::getTimeAndDate(TimeDate &td) const {
 		td.tm_mday = currentTime.GetDay();
 		td.tm_mon = currentTime.GetMonth();
 		td.tm_year = currentTime.GetYear();
-#ifdef RELEASE_BUILD
-		#error getTimeAndDate() is not setting the day of the week
-#else
-		td.tm_wday = 0; // FIXME
-#endif
+
+		Calendar* pCalendar = Osp::Locales::Calendar::CreateInstanceN(CALENDAR_GREGORIAN);
+		pCalendar->SetTime(td.tm_year, td.tm_mon, td.tm_mday);	
+		td.tm_wday = pCalendar->GetTimeField(TIME_FIELD_DAY_OF_WEEK) - 1;
+		delete pCalendar;
 	}
 }
 

--- a/backends/platform/bada/system.h
+++ b/backends/platform/bada/system.h
@@ -28,6 +28,7 @@
 #include <FUi.h>
 #include <FSystem.h>
 #include <FBase.h>
+#include <FLocales.h>
 #include <FIoFile.h>
 
 #include "config.h"


### PR DESCRIPTION
This pull request implements the missing weekday field in the BADA port - refer to commit 249d48f77b395d82b8f2bb67360c5539212f5bc4

This has been based off the relevant example in the official BADA documentation:
http://developer.bada.com/help/index.jsp?topic=/com.osp.cppapireference.help/classOsp_1_1Locales_1_1GregorianCalendar.html

The DateTime struct in BADA doesn't have a weekday member on its own:
http://developer.bada.com/help/index.jsp?topic=/com.osp.cppapireference.help/classOsp_1_1Base_1_1DateTime.html
