### PR TITLE
PS2: Implement algorithm for day of week for use in tm_wday.

### DIFF
--- a/backends/platform/ps2/ps2time.cpp
+++ b/backends/platform/ps2/ps2time.cpp
@@ -105,8 +105,14 @@ void OSystem_PS2::readRtcTime(void) {
 		g_day, g_month, g_year + 2000);
 }
 
-void OSystem_PS2::getTimeAndDate(TimeDate &t) const {
+// Tomohiko Sakamoto's 1993 algorithm for any Gregorian date
+static int dayOfWeek(int y, int m, int d) {
+	static const int t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
+	y -= m < 3;
+	return (y + y/4 - y/100 + y/400 + t[m-1] + d) % 7;
+}
 
+void OSystem_PS2::getTimeAndDate(TimeDate &t) const {
 	uint32 currentSecs = g_timeSecs + (msecCount - g_lastTimeCheck) / 1000;
 	if (currentSecs >= SECONDS_PER_DAY) {
 		buildNewDate(+1);
@@ -120,9 +126,5 @@ void OSystem_PS2::getTimeAndDate(TimeDate &t) const {
 	t.tm_year = g_year + 100;
 	t.tm_mday = g_day;
 	t.tm_mon  = g_month - 1;
-#ifdef RELEASE_BUILD
-	#error getTimeAndDate() is not setting the day of the week
-#else
-	t.tm_wday = 0; // FIXME
-#endif
+	t.tm_wday = dayOfWeek(t.tm_year, t.tm_mon, t.tm_mday);
 }


### PR DESCRIPTION
This implements an algorithm to supply day of the week for the PS2 backend by calculation from Y/M/D values, as the platform RTC and/or structures exposed do not provide this information.

Since I don't have a PS2, I have not been able to compile or test this, but it should be fine.
However, I have tested the algorithm seperately and it looks correct.

After this fix is merged, we should look at moving this algorithm up to the common code function i.e. rather than having this functionality duplicated over various backends in varying ways, we should look at having the backend returned structure place say -1 in the field if there is no H/W / platform API for "day of the week", which then invokes this algorithm to replace the value before the engine/base code gets the Time/Date structure. Otherwise, the value supplied by the platform API is used.
