### PR TITLE
GRAPHICS: Serialize PixelFormat for thumbnails and allow 4Bpp surfaces.

### DIFF
--- a/graphics/thumbnail.h
+++ b/graphics/thumbnail.h
@@ -50,8 +50,6 @@ bool skipThumbnail(Common::SeekableReadStream &in);
 
 /**
  * Loads a thumbnail from the given input stream.
- * The loaded thumbnail will be automatically converted to the
- * current overlay pixelformat.
  */
 Graphics::Surface *loadThumbnail(Common::SeekableReadStream &in);
 


### PR DESCRIPTION
This allows any 2Bpp/4Bpp Surfaces to be serialized via saveThumbnail and loadThumbnail now. It furthermore will preserve the loaded Surface in loadThumbnail.

Another possible solution would be what pull request #245 is doing, which would be requring that 4Bpp thumbnails are ARGB8888. This pull request goes a bit further, since it would allow abitrary non 1-Bpp Surfaces to be serialized.
