### PR TITLE
RFC: Include deinterlacing code from LodePNG in PNGDecoder

### DIFF
--- a/graphics/decoders/png.h
+++ b/graphics/decoders/png.h
@@ -108,7 +108,7 @@ private:
 	void constructImage();
 	void unfilterScanLine(byte *dest, const byte *scanLine, const byte *prevLine, uint16 byteWidth, byte filterType, uint16 length);
 	byte paethPredictor(int16 a, int16 b, int16 c);
-
+	void adam7Deinterlace(byte* out);
 	// The original file stream
 	Common::SeekableReadStream *_stream;
 	// The unzipped image data stream


### PR DESCRIPTION
This is a stripped down version of the deinterlacing code used in LodePNG, http://lpi.googlecode.com/svn/trunk/lodepng.cpp code for handling lower bitPerPixel-amounts than 8 was removed, as that should be an uncommon case for the uncommon case that interlaced PNGs are, and it added even more complexity.

It's worth noting that this does not work 100%, almost all the images I threw at it deinterlaced fine, but two proved to be problematic:
https://dl.dropbox.com/u/12443522/ircfiles/fonts-fontmenupismo.png
https://dl.dropbox.com/u/12443522/ircfiles/denicek-denicek.png

Putting the result out again as BMP (for lack of a way to put out PNG) reveals the following:
https://dl.dropbox.com/u/12443522/ircfiles/denicek-denicek-deinterlaced.bmp
https://dl.dropbox.com/u/12443522/ircfiles/fonts-fontmenupismo-deinterlaced.bmp

Both images are from Five Magical Amulets, and the rest of the interlaced data there does work fine.

So:
Is the code otherwise good?
Do anyone have any idea what is wrong for the two failed images?

Edit: Corrected title
