### PR TITLE
COMMON: Add an argument to wrapCompressedReadStream, for streams with unknown size()

### DIFF
--- a/common/zlib.cpp
+++ b/common/zlib.cpp
@@ -107,7 +107,7 @@ protected:
 
 public:
 
-	GZipReadStream(SeekableReadStream *w) : _wrapped(w), _stream() {
+	GZipReadStream(SeekableReadStream *w, uint32 knownSize = 0) : _wrapped(w), _stream() {
 		assert(w != 0);
 
 		// Verify file header is correct
@@ -122,7 +122,8 @@ public:
 			_origSize = w->readUint32LE();
 		} else {
 			// Original size not available in zlib format
-			_origSize = 0;
+			// use an otherwise known size if supplied.
+			_origSize = knownSize;
 		}
 		_pos = 0;
 		w->seek(0, SEEK_SET);
@@ -336,7 +337,7 @@ public:
 
 #endif	// USE_ZLIB
 
-SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped) {
+SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped, uint32 knownSize) {
 #if defined(USE_ZLIB)
 	if (toBeWrapped) {
 		uint16 header = toBeWrapped->readUint16BE();
@@ -345,7 +346,7 @@ SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped) {
 				      header % 31 == 0));
 		toBeWrapped->seek(-2, SEEK_CUR);
 		if (isCompressed)
-			return new GZipReadStream(toBeWrapped);
+			return new GZipReadStream(toBeWrapped, knownSize);
 	}
 #endif
 	return toBeWrapped;

--- a/common/zlib.h
+++ b/common/zlib.h
@@ -86,10 +86,18 @@ bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen,
  * format. In the former case, the original stream is returned unmodified
  * (and in particular, not wrapped).
  *
+ * Certain GZip-formats don't supply an easily readable length, if you
+ * still need the length carried along with the stream, and you know
+ * the decompressed length at wrap-time, then it can be supplied as knownSize
+ * here. knownSize will be ignored if the GZip-stream DOES include a length.
+ *
  * It is safe to call this with a NULL parameter (in this case, NULL is
  * returned).
+ *
+ * @param toBeWrapped	the stream to be wrapped (if it is in gzip-format)
+ * @param knownSize		a supplied length of the compressed data (if not available directly) 
  */
-SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped);
+SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped, uint32 knownSize = 0);
 
 /**
  * Take an arbitrary WriteStream and wrap it in a custom stream which provides


### PR DESCRIPTION
While the title might be a tad misleading I'm talking about the files that set _size=0 since we can't tell the size directly from the stream at open-time. For WME, which needs to read a few files completely, and thus needs to know how big a buffer to allocate, it is usefull to have the size available along with the stream.

The current solution I'm using in WME, is to create ANOTHER wrapper-stream, that keeps track of the size, thus ending up with a Common::File inside a Common::SeekableSubReadStream inside a Common::GZipReadStream inside my wrapper stream....

It would thus be preferable, and a tad cleaner, atleast for WME to allow the default-value here to be overriden.
