### PR TITLE
Common::List has a bidirectional reverse iterator.

### DIFF
--- a/common/list_intern.h
+++ b/common/list_intern.h
@@ -30,138 +30,177 @@ template<typename T> class List;
 
 
 namespace ListInternal {
-	struct NodeBase {
-		NodeBase *_prev;
-		NodeBase *_next;
-	};
+struct NodeBase {
+	NodeBase *_prev;
+	NodeBase *_next;
+};
 
-	template<typename T>
-	struct Node : public NodeBase {
-		T _data;
+template<typename T>
+struct Node : public NodeBase {
+	T _data;
 
-		Node(const T &x) : _data(x) {}
-	};
+	Node(const T &x) : _data(x) {}
+};
 
-	template<typename T> struct ConstIterator;
+template<typename T> struct ConstIterator;
 
-	template<typename T>
-	struct Iterator {
-		typedef Iterator<T>	Self;
-		typedef Node<T> *	NodePtr;
-		typedef T &			ValueRef;
-		typedef T *			ValuePtr;
-		typedef T			ValueType;
+template<typename T>
+struct Iterator {
+	typedef Iterator<T> Self;
+	typedef Node<T> *   NodePtr;
+	typedef T          &ValueRef;
+	typedef T          *ValuePtr;
+	typedef T           ValueType;
 
-		NodeBase *_node;
+	template <typename TT>
+	friend bool operator==(const Iterator<TT>& a, const ConstIterator<TT>& b);
+	template <typename TT>
+	friend bool operator!=(const Iterator<TT>& a, const ConstIterator<TT>& b);
+	friend class ConstIterator<T>;
+	friend class List<T>;
+private:
+	NodeBase *_node;
+	bool _forward;
 
-		Iterator() : _node(0) {}
-		explicit Iterator(NodeBase *node) : _node(node) {}
+	Self iteratorOfSameType(NodeBase *node) {
+		return Iterator(node, _forward);
+	}
+public:
+	Iterator() : _node(0) {}
+	explicit Iterator(NodeBase *node) : _node(node), _forward(true)  {}
+	explicit Iterator(NodeBase *node, bool forward) : _node(node), _forward(forward) {}
 
-		// Prefix inc
-		Self &operator++() {
-			if (_node)
+	// Prefix inc
+	Self &operator++() {
+		if (_node) {
+			if (_forward)
 				_node = _node->_next;
-			return *this;
-		}
-		// Postfix inc
-		Self operator++(int) {
-			Self tmp(_node);
-			++(*this);
-			return tmp;
-		}
-		// Prefix dec
-		Self &operator--() {
-			if (_node)
+			else
 				_node = _node->_prev;
-			return *this;
 		}
-		// Postfix dec
-		Self operator--(int) {
-			Self tmp(_node);
-			--(*this);
-			return tmp;
-		}
-		ValueRef operator*() const {
-			assert(_node);
-			return static_cast<NodePtr>(_node)->_data;
-		}
-		ValuePtr operator->() const {
-			return &(operator*());
-		}
-
-		bool operator==(const Self &x) const {
-			return _node == x._node;
-		}
-
-		bool operator!=(const Self &x) const {
-			return _node != x._node;
-		}
-	};
-
-	template<typename T>
-	struct ConstIterator {
-		typedef ConstIterator<T>	Self;
-		typedef const Node<T> *	NodePtr;
-		typedef const T &		ValueRef;
-		typedef const T *		ValuePtr;
-
-		const NodeBase *_node;
-
-		ConstIterator() : _node(0) {}
-		explicit ConstIterator(const NodeBase *node) : _node(node) {}
-		ConstIterator(const Iterator<T> &x) : _node(x._node) {}
-
-		// Prefix inc
-		Self &operator++() {
-			if (_node)
+		return *this;
+	}
+	// Postfix inc
+	Self operator++(int) {
+		Self tmp(_node);
+		++(*this);
+		return tmp;
+	}
+	// Prefix dec
+	Self &operator--() {
+		if (_node) {
+			if (_forward)
+				_node = _node->_prev;
+			else
 				_node = _node->_next;
-			return *this;
 		}
-		// Postfix inc
-		Self operator++(int) {
-			Self tmp(_node);
-			++(*this);
-			return tmp;
-		}
-		// Prefix dec
-		Self &operator--() {
-			if (_node)
-				_node = _node->_prev;
-			return *this;
-		}
-		// Postfix dec
-		Self operator--(int) {
-			Self tmp(_node);
-			--(*this);
-			return tmp;
-		}
-		ValueRef operator*() const {
-			assert(_node);
-			return static_cast<NodePtr>(_node)->_data;
-		}
-		ValuePtr operator->() const {
-			return &(operator*());
-		}
-
-		bool operator==(const Self &x) const {
-			return _node == x._node;
-		}
-
-		bool operator!=(const Self &x) const {
-			return _node != x._node;
-		}
-	};
-
-
-	template<typename T>
-	bool operator==(const Iterator<T>& a, const ConstIterator<T>& b) {
-		return a._node == b._node;
+		return *this;
+	}
+	// Postfix dec
+	Self operator--(int) {
+		Self tmp(_node);
+		--(*this);
+		return tmp;
+	}
+	ValueRef operator*() const {
+		assert(_node);
+		return static_cast<NodePtr>(_node)->_data;
+	}
+	ValuePtr operator->() const {
+		return &(operator*());
 	}
 
-	template<typename T>
-	bool operator!=(const Iterator<T>& a, const ConstIterator<T>& b) {
-		return a._node != b._node;
+	bool operator==(const Self &x) const {
+		return _node == x._node;
 	}
+
+	bool operator!=(const Self &x) const {
+		return _node != x._node;
+	}
+};
+
+
+template<typename T>
+struct ConstIterator {
+	typedef ConstIterator<T>    Self;
+	typedef const Node<T> * NodePtr;
+	typedef const T        &ValueRef;
+	typedef const T        *ValuePtr;
+
+	template <typename TT>
+	friend bool operator==(const Iterator<TT>& a, const ConstIterator<TT>& b);
+	template <typename TT>
+	friend bool operator!=(const Iterator<TT>& a, const ConstIterator<TT>& b);
+	friend class List<T>;
+private:
+	const NodeBase *_node;
+	bool _forward;
+public:
+	ConstIterator() : _node(0), _forward(true) {}
+	explicit ConstIterator(const NodeBase *node) : _node(node), _forward(true) {}
+	explicit ConstIterator(const NodeBase *node, bool forward) : _node(node), _forward(true) {}
+	ConstIterator(const Iterator<T> &x) : _node(x._node), _forward(x._forward) {}
+
+	// Prefix inc
+	Self &operator++() {
+		if (_node) {
+			if (_forward)
+				_node = _node->_next;
+			else
+				_node = _node->_prev;
+		}
+		return *this;
+	}
+	// Postfix inc
+	Self operator++(int) {
+		Self tmp(_node);
+		++(*this);
+		return tmp;
+	}
+	// Prefix dec
+	Self &operator--() {
+		if (_node) {
+			if (_forward)
+				_node = _node->_prev;
+			else
+				_node = _node->_next;
+		}
+		return *this;
+	}
+	// Postfix dec
+	Self operator--(int) {
+		Self tmp(_node);
+		--(*this);
+		return tmp;
+	}
+	ValueRef operator*() const {
+		assert(_node);
+		return static_cast<NodePtr>(_node)->_data;
+	}
+	ValuePtr operator->() const {
+		return &(operator*());
+	}
+
+	bool operator==(const Self &x) const {
+		return _node == x._node;
+	}
+
+	bool operator!=(const Self &x) const {
+		return _node != x._node;
+	}
+};
+
+
+
+template<typename T>
+bool operator==(const Iterator<T>& a, const ConstIterator<T>& b) {
+	return a._node == b._node;
+}
+
+template<typename T>
+bool operator!=(const Iterator<T>& a, const ConstIterator<T>& b) {
+	return a._node != b._node;
+}
 }
 
 

--- a/engines/agi/menu.cpp
+++ b/engines/agi/menu.cpp
@@ -177,14 +177,14 @@ Menu::Menu(AgiEngine *vm, GfxMgr *gfx, PictureMgr *picture) {
 
 Menu::~Menu() {
 	MenuList::iterator iterh;
-	for (iterh = _menubar.reverse_begin(); iterh != _menubar.end(); ) {
+	for (iterh = _menubar.legacy_reverse_begin(); iterh != _menubar.end(); ) {
 		AgiMenu *m = *iterh;
 
 		debugC(3, kDebugLevelMenu, "deiniting hmenu %s", m->text);
 
 		MenuOptionList::iterator iterv;
 
-		for (iterv = m->down.reverse_begin(); iterv != m->down.end(); ) {
+		for (iterv = m->down.legacy_reverse_begin(); iterv != m->down.end(); ) {
 			AgiMenuOption *d = *iterv;
 
 			debugC(3, kDebugLevelMenu, "  deiniting vmenu %s", d->text);
@@ -233,8 +233,8 @@ void Menu::addItem(const char *s, int code) {
 	d->index = _vIndex++;
 
 	// add to last menu in list
-	assert(_menubar.reverse_begin() != _menubar.end());
-	AgiMenu *m = *_menubar.reverse_begin();
+	assert(_menubar.legacy_reverse_begin() != _menubar.end());
+	AgiMenu *m = *_menubar.legacy_reverse_begin();
 	m->height++;
 
 	_vMaxMenu[m->index] = d->index;
@@ -259,7 +259,7 @@ void Menu::submit() {
 
 	// If a menu has no options, delete it
 	MenuList::iterator iter;
-	for (iter = _menubar.reverse_begin(); iter != _menubar.end(); ) {
+	for (iter = _menubar.legacy_reverse_begin(); iter != _menubar.end(); ) {
 		AgiMenu *m = *iter;
 
 		if (m->down.empty()) {

--- a/engines/agi/sprite.cpp
+++ b/engines/agi/sprite.cpp
@@ -375,7 +375,7 @@ void SpritesMgr::buildNonupdBlitlist() {
  */
 void SpritesMgr::freeList(SpriteList &l) {
 	SpriteList::iterator iter;
-	for (iter = l.reverse_begin(); iter != l.end(); ) {
+	for (iter = l.legacy_reverse_begin(); iter != l.end(); ) {
 		Sprite* s = *iter;
 
 		poolRelease(s->buffer);
@@ -422,7 +422,7 @@ void SpritesMgr::commitSprites(SpriteList &l, bool immediate) {
  */
 void SpritesMgr::eraseSprites(SpriteList &l) {
 	SpriteList::iterator iter;
-	for (iter = l.reverse_begin(); iter != l.end(); --iter) {
+	for (iter = l.legacy_reverse_begin(); iter != l.end(); --iter) {
 		Sprite *s = *iter;
 		objsRestoreArea(s);
 	}

--- a/engines/cine/various.cpp
+++ b/engines/cine/various.cpp
@@ -222,7 +222,7 @@ int16 getObjectUnderCursor(uint16 x, uint16 y) {
 	int width;
 
 	// reverse_iterator would be nice
-	for (it = g_cine->_overlayList.reverse_begin(); it != g_cine->_overlayList.end(); --it) {
+	for (it = g_cine->_overlayList.legacy_reverse_begin(); it != g_cine->_overlayList.end(); --it) {
 		if (it->type >= 2 || !g_cine->_objectTable[it->objIdx].name[0]) {
 			continue;
 		}
@@ -1474,7 +1474,7 @@ void resetGfxEntityEntry(uint16 objIdx) {
 			}
 
 			if (g_cine->_objectTable[objIdx].mask > objectMask) { // Check for B objects' cut point
-				bObjsCutPoint = bObjs.reverse_begin();
+				bObjsCutPoint = bObjs.legacy_reverse_begin();
 				foundCutPoint = true;
 			}
 		}

--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -636,7 +636,7 @@ bool Button::contains(const Common::Point &pos) const {
 
 const Button *ComposerEngine::getButtonFor(const Sprite *sprite, const Common::Point &pos) {
 	for (Common::List<Library>::iterator l = _libraries.begin(); l != _libraries.end(); l++) {
-		for (Common::List<Button>::iterator i = l->_buttons.reverse_begin(); i != l->_buttons.end(); --i) {
+		for (Common::List<Button>::iterator i = l->_buttons.legacy_reverse_begin(); i != l->_buttons.end(); --i) {
 			if (!i->_active)
 				continue;
 

--- a/engines/composer/graphics.cpp
+++ b/engines/composer/graphics.cpp
@@ -493,7 +493,7 @@ void ComposerEngine::removeSprite(uint16 id, uint16 animId) {
 }
 
 const Sprite *ComposerEngine::getSpriteAtPos(const Common::Point &pos) {
-	for (Common::List<Sprite>::iterator i = _sprites.reverse_begin(); i != _sprites.end(); --i) {
+	for (Common::List<Sprite>::iterator i = _sprites.legacy_reverse_begin(); i != _sprites.end(); --i) {
 		// avoid highest-level objects (e.g. the cursor)
 		if (!i->_zorder)
 			continue;

--- a/engines/draci/animation.cpp
+++ b/engines/draci/animation.cpp
@@ -499,7 +499,7 @@ const Animation *AnimationManager::getTopAnimation(int x, int y) const {
 	// Get transparent color for the current screen
 	const int transparent = _vm->_screen->getSurface()->getTransparentColor();
 
-	for (it = _animations.reverse_begin(); it != _animations.end(); --it) {
+	for (it = _animations.legacy_reverse_begin(); it != _animations.end(); --it) {
 
 		Animation *anim = *it;
 

--- a/engines/dreamweb/stubs.cpp
+++ b/engines/dreamweb/stubs.cpp
@@ -1206,7 +1206,7 @@ bool DreamWebEngine::checkIfPerson(uint8 x, uint8 y) {
 
 bool DreamWebEngine::checkIfFree(uint8 x, uint8 y) {
 	Common::List<ObjPos>::const_iterator i;
-	for (i = _freeList.reverse_begin(); i != _freeList.end(); --i) {
+	for (i = _freeList.legacy_reverse_begin(); i != _freeList.end(); --i) {
 		const ObjPos &pos = *i;
 		assert(pos.index != 0xff);
 		if (!pos.contains(x,y))
@@ -1219,7 +1219,7 @@ bool DreamWebEngine::checkIfFree(uint8 x, uint8 y) {
 
 bool DreamWebEngine::checkIfEx(uint8 x, uint8 y) {
 	Common::List<ObjPos>::const_iterator i;
-	for (i = _exList.reverse_begin(); i != _exList.end(); --i) {
+	for (i = _exList.legacy_reverse_begin(); i != _exList.end(); --i) {
 		const ObjPos &pos = *i;
 		assert(pos.index != 0xff);
 		if (!pos.contains(x,y))
@@ -1617,7 +1617,7 @@ void DreamWebEngine::showIcon() {
 
 bool DreamWebEngine::checkIfSet(uint8 x, uint8 y) {
 	Common::List<ObjPos>::const_iterator i;
-	for (i = _setList.reverse_begin(); i != _setList.end(); --i) {
+	for (i = _setList.legacy_reverse_begin(); i != _setList.end(); --i) {
 		const ObjPos &pos = *i;
 		assert(pos.index != 0xff);
 		if (!pos.contains(x,y))

--- a/engines/gob/minigames/geisha/diving.cpp
+++ b/engines/gob/minigames/geisha/diving.cpp
@@ -703,7 +703,7 @@ void Diving::updateAnims() {
 	int16 left, top, right, bottom;
 
 	// Clear the previous animation frames
-	for (Common::List<ANIObject *>::iterator a = _anims.reverse_begin();
+	for (Common::List<ANIObject *>::iterator a = _anims.legacy_reverse_begin();
 			 a != _anims.end(); --a) {
 
 		if ((*a)->clear(*_vm->_draw->_backSurface, left, top, right, bottom))

--- a/engines/gob/minigames/geisha/penetration.cpp
+++ b/engines/gob/minigames/geisha/penetration.cpp
@@ -1414,7 +1414,7 @@ void Penetration::updateAnims() {
 	int16 left = 0, top = 0, right = 0, bottom = 0;
 
 	// Clear the previous map animation frames
-	for (Common::List<ANIObject *>::iterator a = _mapAnims.reverse_begin();
+	for (Common::List<ANIObject *>::iterator a = _mapAnims.legacy_reverse_begin();
 			 a != _mapAnims.end(); --a) {
 
 		(*a)->clear(*_map, left, top, right, bottom);
@@ -1429,7 +1429,7 @@ void Penetration::updateAnims() {
 	}
 
 	// Clear the previous animation frames
-	for (Common::List<ANIObject *>::iterator a = _anims.reverse_begin();
+	for (Common::List<ANIObject *>::iterator a = _anims.legacy_reverse_begin();
 			 a != _anims.end(); --a) {
 
 		if ((*a)->clear(*_vm->_draw->_backSurface, left, top, right, bottom))

--- a/engines/gob/pregob/seqfile.cpp
+++ b/engines/gob/pregob/seqfile.cpp
@@ -306,7 +306,7 @@ void SEQFile::clearAnims() {
 	Objects objects = getOrderedObjects();
 
 	// Remove the animation frames, in reverse drawing order
-	for (Objects::iterator o = objects.reverse_begin(); o != objects.end(); --o) {
+	for (Objects::iterator o = objects.legacy_reverse_begin(); o != objects.end(); --o) {
 		int16 left, top, right, bottom;
 
 		if (o->object->clear(*_vm->_draw->_backSurface, left, top, right, bottom))

--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -606,7 +606,7 @@ void MohawkEngine_LivingBooks::updatePage() {
 		_items[i]->update();
 
 	if (_needsRedraw) {
-		for (Common::List<LBItem *>::const_iterator i = _orderedItems.reverse_begin(); i != _orderedItems.end(); --i)
+		for (Common::List<LBItem *>::const_iterator i = _orderedItems.legacy_reverse_begin(); i != _orderedItems.end(); --i)
 			(*i)->draw();
 
 		_needsRedraw = false;

--- a/engines/sci/engine/gc.cpp
+++ b/engines/sci/engine/gc.cpp
@@ -106,7 +106,7 @@ AddrSet *findAllActiveReferences(EngineState *s) {
 
 	// Initialize value stack
 	// We do this one by hand since the stack doesn't know the current execution stack
-	Common::List<ExecStack>::const_iterator iter = s->_executionStack.reverse_begin();
+	Common::List<ExecStack>::const_iterator iter = s->_executionStack.legacy_reverse_begin();
 
 	// Skip fake kernel stack frame if it's on top
 	if ((*iter).type == EXEC_STACK_TYPE_KERNEL)

--- a/engines/sci/graphics/animate.cpp
+++ b/engines/sci/graphics/animate.cpp
@@ -328,7 +328,7 @@ void GfxAnimate::update() {
 	const AnimateList::iterator end = _list.end();
 
 	// Remove all no-update cels, if requested
-	for (it = _list.reverse_begin(); it != end; --it) {
+	for (it = _list.legacy_reverse_begin(); it != end; --it) {
 		if (it->signal & kSignalNoUpdate) {
 			if (!(it->signal & kSignalRemoveView)) {
 				bitsHandle = readSelector(_s->_segMan, it->object, SELECTOR(underBits));
@@ -474,7 +474,7 @@ void GfxAnimate::restoreAndDelete(int argc, reg_t *argv) {
 		writeSelectorValue(_s->_segMan, it->object, SELECTOR(signal), it->signal);
 	}
 
-	for (it = _list.reverse_begin(); it != end; --it) {
+	for (it = _list.legacy_reverse_begin(); it != end; --it) {
 		// We read out signal here again, this is not by accident but to ensure
 		// that we got an up-to-date signal
 		it->signal = readSelectorValue(_s->_segMan, it->object, SELECTOR(signal));

--- a/engines/sci/graphics/ports.cpp
+++ b/engines/sci/graphics/ports.cpp
@@ -242,7 +242,7 @@ int16 GfxPorts::isFrontWindow(Window *pWnd) {
 
 void GfxPorts::beginUpdate(Window *wnd) {
 	Port *oldPort = setPort(_wmgrPort);
-	PortList::iterator it = _windowList.reverse_begin();
+	PortList::iterator it = _windowList.legacy_reverse_begin();
 	const PortList::iterator end = Common::find(_windowList.begin(), _windowList.end(), wnd);
 	while (it != end) {
 		// We also store Port objects in the window list, but they

--- a/engines/sci/resource.cpp
+++ b/engines/sci/resource.cpp
@@ -1032,7 +1032,7 @@ void ResourceManager::printLRU() {
 void ResourceManager::freeOldResources() {
 	while (MAX_MEMORY < _memoryLRU) {
 		assert(!_LRU.empty());
-		Resource *goner = *_LRU.reverse_begin();
+		Resource *goner = *_LRU.legacy_reverse_begin();
 		removeFromLRU(goner);
 		goner->unalloc();
 #ifdef SCI_VERBOSE_RESMAN

--- a/engines/teenagent/scene.cpp
+++ b/engines/teenagent/scene.cpp
@@ -458,7 +458,7 @@ Animation *Scene::getAnimation(byte slot) {
 }
 
 byte Scene::peekFlagEvent(uint16 addr) const {
-	for (EventList::const_iterator i = events.reverse_begin(); i != events.end(); --i) {
+	for (EventList::const_iterator i = events.legacy_reverse_begin(); i != events.end(); --i) {
 		const SceneEvent &e = *i;
 		if (e.type == SceneEvent::kSetFlag && e.callback == addr)
 			return e.color;

--- a/engines/tsage/debugger.cpp
+++ b/engines/tsage/debugger.cpp
@@ -287,7 +287,7 @@ bool Debugger::Cmd_Hotspots(int argc, const char **argv) {
 
 	// Iterate through the scene items
 	SynchronizedList<SceneItem *>::iterator i;
-	for (i = g_globals->_sceneItems.reverse_begin(); i != g_globals->_sceneItems.end(); --i, ++colIndex) {
+	for (i = g_globals->_sceneItems.legacy_reverse_begin(); i != g_globals->_sceneItems.end(); --i, ++colIndex) {
 		SceneItem *o = *i;
 
 		// Draw the contents of the hotspot area

--- a/engines/tsage/ringworld2/ringworld2_scenes0.cpp
+++ b/engines/tsage/ringworld2/ringworld2_scenes0.cpp
@@ -1314,7 +1314,7 @@ void Scene160::Action1::signal() {
 		breakFlag = true;
 		do {
 			if (!scene->_lineNum || ((scene->_lineNum != -1) &&
-					(((*scene->_creditsList.reverse_begin())->_position.y < 164) || !breakFlag))) {
+					(((*scene->_creditsList.legacy_reverse_begin())->_position.y < 164) || !breakFlag))) {
 				breakFlag = true;
 				Common::String msg = g_resourceManager->getMessage(160, scene->_lineNum++);
 

--- a/test/common/list.h
+++ b/test/common/list.h
@@ -2,9 +2,8 @@
 
 #include "common/list.h"
 
-class ListTestSuite : public CxxTest::TestSuite
-{
-	public:
+class ListTestSuite : public CxxTest::TestSuite {
+public:
 	void test_empty_clear() {
 		Common::List<int> container;
 		TS_ASSERT(container.empty());
@@ -15,7 +14,7 @@ class ListTestSuite : public CxxTest::TestSuite
 		TS_ASSERT(container.empty());
 	}
 
-	public:
+public:
 	void test_size() {
 		Common::List<int> container;
 		TS_ASSERT_EQUALS(container.size(), (unsigned int)0);
@@ -86,6 +85,9 @@ class ListTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(iter, cIter);
 	}
 
+	/**
+	 * Tests insert
+	 */
 	void test_insert() {
 		Common::List<int> container;
 		Common::List<int>::iterator iter;
@@ -126,13 +128,112 @@ class ListTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(*iter, -11);
 		++iter;
 		TS_ASSERT_EQUALS(iter, container.end());
-	}
-
-	void test_erase() {
-		Common::List<int> container;
-		Common::List<int>::iterator first, last;
 
 		// Fill the container with some random data
+		container.clear();
+		container.push_back(17);
+		container.push_back(33);
+		container.push_back(-11);
+
+		// Iterate to after the second element
+		iter = container.reverse_begin();
+		++iter;
+		++iter;
+
+		// Now insert some values here
+		container.insert(iter, 42);
+		container.insert(iter, 43);
+
+		// Verify contents are correct
+		iter = container.begin();
+
+		TS_ASSERT_EQUALS(*iter, 17);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 43);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 42);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 33);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, -11);
+		++iter;
+		TS_ASSERT_EQUALS(iter, container.end());
+
+		//insert into an empty list
+		container.clear();
+		iter = container.begin();
+		container.insert(iter, 55);
+		iter = container.begin();
+		TS_ASSERT_EQUALS(*iter, 55);
+
+		container.clear();
+		iter = container.reverse_begin();
+		container.insert(iter, 55);
+		iter = container.begin();
+		TS_ASSERT_EQUALS(*iter, 55);
+
+		//tests insert over a range
+		Common::List<int> sourceContainer;
+		Common::List<int>::iterator first, last;
+		// Fill the container with some random data
+		container.clear();
+		container.push_back(17);
+		container.push_back(33);
+		container.push_back(-11);
+
+		sourceContainer.push_back(43);
+		sourceContainer.push_back(42);
+
+		first = sourceContainer.begin();
+		last = sourceContainer.end();
+
+		iter = container.begin();
+		iter++;
+		container.insert(iter, first, last);
+
+		// Verify contents are correct
+		iter = container.begin();
+
+		TS_ASSERT_EQUALS(*iter, 17);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 43);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 42);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 33);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, -11);
+		++iter;
+		TS_ASSERT_EQUALS(iter, container.end());
+	}
+
+	/**
+	 * Tests erase, reverse_erase
+	 */
+	void test_erase() {
+		Common::List<int> container;
+		Common::List<int>::iterator returnValue;
+		Common::List<int>::iterator first, last;
+
+		//Tests erase for a range of forward iterators
+
+		// Fills the container with some random data
 		container.push_back(17);
 		container.push_back(33);
 		container.push_back(-11);
@@ -150,7 +251,12 @@ class ListTestSuite : public CxxTest::TestSuite
 		++last;
 
 		// Now erase that range
-		container.erase(first, last);
+		returnValue = container.erase(first, last);
+
+		//A forward iterator to after the last element is returned
+		TS_ASSERT_EQUALS(*returnValue, 43);
+		returnValue++;
+		TS_ASSERT(returnValue == container.end());
 
 		// Verify contents are correct
 		Common::List<int>::iterator iter = container.begin();
@@ -166,6 +272,111 @@ class ListTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(*iter, 43);
 		++iter;
 		TS_ASSERT_EQUALS(iter, container.end());
+
+		//tests erase for a range of reverse iterators
+		container.clear();
+		// Fill the container with some random data
+		container.push_back(17);
+		container.push_back(33);
+		container.push_back(-11);
+		container.push_back(42);
+		container.push_back(43);
+
+		// Iterate to after the second element
+		first = container.reverse_begin();
+		++first;
+		++first;
+
+		// Iterate to after the fourth element
+		last = first;
+		++last;
+		++last;
+
+		returnValue = container.erase(first, last);
+
+		//A forward iterator to after the last element is returned.
+		TS_ASSERT_EQUALS(*returnValue, 17);
+		returnValue++;
+		TS_ASSERT(returnValue == container.reverse_end());
+		iter = container.begin();
+
+		TS_ASSERT_EQUALS(*iter, 17);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 42);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 43);
+		++iter;
+		TS_ASSERT_EQUALS(iter, container.end());
+
+
+		//Tests erase for an iterator
+		container.clear();
+		// Fill the container with some random data
+		container.push_back(17);
+		container.push_back(33);
+		container.push_back(-11);
+		container.push_back(42);
+		container.push_back(43);
+
+		iter = container.begin();
+		iter = container.erase(iter);
+		TS_ASSERT_EQUALS(*iter, 33);
+		//It is still an forward iterator
+		iter++;
+		TS_ASSERT_EQUALS(*iter, -11);
+
+		//Tests erase for an reverse iterator
+		container.clear();
+		// Fill the container with some random data
+		container.push_back(17);
+		container.push_back(33);
+		container.push_back(-11);
+		container.push_back(42);
+		container.push_back(43);
+
+		iter = container.reverse_begin();
+		iter = container.erase(iter);
+		TS_ASSERT_EQUALS(*iter, 42);
+		//It is still an reverse iterator
+		iter++;
+		TS_ASSERT_EQUALS(*iter, -11);
+		//tests reverse erase for an reverse iterator
+		container.clear();
+		// Fill the container with some random data
+		container.push_back(17);
+		container.push_back(33);
+		container.push_back(-11);
+		container.push_back(42);
+		container.push_back(43);
+
+		iter = container.reverse_begin();
+		iter++;
+		iter = container.reverse_erase(iter);
+		TS_ASSERT_EQUALS(*iter, 43);
+		//It is still an reverse iterator
+		iter++;
+		TS_ASSERT_EQUALS(*iter, -11);
+
+		//tests reverse erase for an iterator
+		container.clear();
+		// Fill the container with some random data
+		container.push_back(17);
+		container.push_back(33);
+		container.push_back(-11);
+		container.push_back(42);
+		container.push_back(43);
+
+		iter = container.begin();
+		iter++;
+		iter = container.reverse_erase(iter);
+		TS_ASSERT_EQUALS(*iter, 17);
+		//It is still an forward iterator
+		iter++;
+		TS_ASSERT_EQUALS(*iter, -11);
 	}
 
 	void test_remove() {
@@ -208,48 +419,55 @@ class ListTestSuite : public CxxTest::TestSuite
 		Common::List<int> container;
 		Common::List<int>::iterator iter;
 
+		TS_ASSERT(container.empty());
+		TS_ASSERT_EQUALS(container.reverse_begin(), container.reverse_begin());
+		TS_ASSERT_EQUALS(container.reverse_begin(), container.legacy_reverse_begin());
 		// Fill the container with some random data
 		container.push_back(17);
 		container.push_back(33);
 		container.push_back(-11);
 
 		iter = container.reverse_begin();
+		TS_ASSERT_DIFFERS(iter, container.reverse_end());
 		TS_ASSERT_DIFFERS(iter, container.end());
 
 
 		TS_ASSERT_EQUALS(*iter, -11);
-		--iter;
+		++iter;
 		TS_ASSERT_DIFFERS(iter, container.end());
+		TS_ASSERT_DIFFERS(iter, container.reverse_end());
 
 		TS_ASSERT_EQUALS(*iter, 33);
-		--iter;
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.reverse_end());
 		TS_ASSERT_DIFFERS(iter, container.end());
 
 		TS_ASSERT_EQUALS(*iter, 17);
-		--iter;
+		++iter;
+		TS_ASSERT_EQUALS(iter, container.reverse_end());
 		TS_ASSERT_EQUALS(iter, container.end());
 
 		iter = container.reverse_begin();
+		TS_ASSERT_DIFFERS(iter, container.reverse_end());
 
-		iter = container.reverse_erase(iter);
-		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, -11);
+		iter++;
+		TS_ASSERT_DIFFERS(iter, container.reverse_end());
+
 		TS_ASSERT_EQUALS(*iter, 33);
+		iter++;
+		TS_ASSERT_DIFFERS(iter, container.reverse_end());
 
-		iter = container.reverse_erase(iter);
-		TS_ASSERT_DIFFERS(iter, container.end());
 		TS_ASSERT_EQUALS(*iter, 17);
-
-		iter = container.reverse_erase(iter);
-		TS_ASSERT_EQUALS(iter, container.end());
-
-		TS_ASSERT_EQUALS(container.begin(), container.end());
-		TS_ASSERT_EQUALS(container.reverse_begin(), container.end());
+		iter++;
+		TS_ASSERT_EQUALS(iter, container.reverse_end());
 	}
 
 	void test_front_back_push_pop() {
 		Common::List<int> container;
 
-		container.push_back( 42);
+		container.push_back(42);
 		container.push_back(-23);
 
 		TS_ASSERT_EQUALS(container.front(), 42);
@@ -271,5 +489,76 @@ class ListTestSuite : public CxxTest::TestSuite
 		container.pop_back();
 		TS_ASSERT_EQUALS(container.front(), 99);
 		TS_ASSERT_EQUALS(container.back(),  99);
+	}
+	/**
+	 * Tests == and !=  operators between Iterators, ConstIterators, ReverseIterators and ConstReverseIterators
+	 */
+	void test_iterator_equality() {
+		Common::List<int> container;
+		Common::List<int>::iterator iter;
+		Common::List<int>::const_iterator cIter;
+
+		Common::List<int>::iterator rIter;
+		Common::List<int>::const_iterator crIter;
+		container.push_back(17);
+		//Tests equality for Interators pointing to the same thing
+		iter = container.begin();
+		cIter = container.begin();
+		rIter = container.reverse_begin();
+		crIter = container.reverse_begin();
+		TS_ASSERT(iter == cIter);
+		TS_ASSERT(cIter == iter);
+		TS_ASSERT(iter == rIter);
+		TS_ASSERT(rIter == iter);
+		TS_ASSERT(iter == crIter);
+		TS_ASSERT(crIter == iter);
+		TS_ASSERT(rIter == crIter);
+		TS_ASSERT(crIter == rIter);
+		TS_ASSERT(rIter == cIter);
+		TS_ASSERT(cIter == rIter);
+		TS_ASSERT(crIter == cIter);
+		TS_ASSERT(cIter == crIter);
+		TS_ASSERT(!(iter != cIter));
+		TS_ASSERT(!(cIter != iter));
+		TS_ASSERT(!(iter != rIter));
+		TS_ASSERT(!(rIter != iter));
+		TS_ASSERT(!(iter != crIter));
+		TS_ASSERT(!(crIter != iter));
+		TS_ASSERT(!(rIter != crIter));
+		TS_ASSERT(!(crIter != rIter));
+		TS_ASSERT(!(rIter != cIter));
+		TS_ASSERT(!(cIter != rIter));
+		TS_ASSERT(!(crIter != cIter));
+		TS_ASSERT(!(cIter != crIter));
+
+		//Tests equality for iterators not pointing to anything
+		iter = container.end();
+		cIter = container.end();
+		rIter = container.reverse_end();
+		crIter = container.reverse_end();
+		TS_ASSERT(iter == cIter);
+		TS_ASSERT(cIter == iter);
+		TS_ASSERT(iter == rIter);
+		TS_ASSERT(rIter == iter);
+		TS_ASSERT(iter == crIter);
+		TS_ASSERT(crIter == iter);
+		TS_ASSERT(rIter == crIter);
+		TS_ASSERT(crIter == rIter);
+		TS_ASSERT(rIter == cIter);
+		TS_ASSERT(cIter == rIter);
+		TS_ASSERT(crIter == cIter);
+		TS_ASSERT(cIter == crIter);
+		TS_ASSERT(!(iter != cIter));
+		TS_ASSERT(!(cIter != iter));
+		TS_ASSERT(!(iter != rIter));
+		TS_ASSERT(!(rIter != iter));
+		TS_ASSERT(!(iter != crIter));
+		TS_ASSERT(!(crIter != iter));
+		TS_ASSERT(!(rIter != crIter));
+		TS_ASSERT(!(crIter != rIter));
+		TS_ASSERT(!(rIter != cIter));
+		TS_ASSERT(!(cIter != rIter));
+		TS_ASSERT(!(crIter != cIter));
+		TS_ASSERT(!(cIter != crIter));
 	}
 };


### PR DESCRIPTION
Common::List.reverse_begin() did not work like in the STL, but did
return an bidirectional forward iterator pointing at the end of the
list,instead of an bidirectional reverse iterator pointing at the end of
the list.

Common::List.legacy_reverse_begin()  works like the old reverse_begin()
did, for compitability, but is deprecated.

All code that previously used reverse_begin() uses
legacy_reverse_begin(), but works like before.

New code should not use legacy_reverse_begin().

Changes are for constant iterators as well as for iterators.

Common::List.reverse_begin() returns a bidirectional reverse iterator,
also constant bidirectional reverse iterator.

List.reverse_end() is functionally identical and interchangeable to
List.end().

List::Iterator, List::ConstIterator: reference to underlying List is
private. Small refactoring for oo code quality only.

Expands Testcases to cover all methods of List including the use of
reverse iterators as parameters.

Expands comments.

Fixes http://wiki.scummvm.org/index.php/TODO#Iterator_handling .
Reworks patch previously submitted at
https://sourceforge.net/tracker/index.php?func=detail&aid=3515308&group_id=37116&atid=418822
and https://github.com/scummvm/scummvm/pull/230 .
