### PR TITLE
RFC: CONFIGURE: Allow dependency checks for engines.

### DIFF
--- a/configure
+++ b/configure
@@ -72,6 +72,7 @@ add_engine() {
 	set_var _engine_${1}_build "${3}"
 	set_var _engine_${1}_build_default "${3}"
 	set_var _engine_${1}_subengines "${4}"
+	set_var _engine_${1}_deps "${5}"
 	for sub in ${4}; do
 		set_var _engine_${sub}_sub "yes"
 	done
@@ -464,6 +465,11 @@ get_engine_subengines() {
 	get_var _engine_$1_subengines
 }
 
+# Get the dependencies
+get_engine_dependencies() {
+	get_var _engine_$1_deps
+}
+
 # Ask if this is a subengine
 get_engine_sub() {
 	sub=`get_var _engine_$1_sub`
@@ -529,6 +535,28 @@ engine_disable() {
 		set_var _engine_${engine}_build "no"
 	else
 		engine_option_error ${engine}
+	fi
+}
+
+# Check whether the engine's dependencies are met
+# If that is not the case disable the engine
+check_engine_deps() {
+	unmet_deps=""
+
+	# Check whether the engine is enabled
+	if test `get_engine_build $1` = yes ; then
+		# Collect unmet dependencies
+		for dep in `get_engine_dependencies $1`; do
+			if test `get_var _${dep}` = no ; then
+				unmet_deps="${unmet_deps}${dep} "
+			fi
+		done
+
+		# Check whether there is any unmet dependency
+		if test -n "$unmet_deps"; then
+			echo "WARNING: Disabling engine "`get_engine_name $1`" because the following dependencies are unmet: "$unmet_deps
+			engine_disable $1
+		fi
 	fi
 }
 
@@ -3204,11 +3232,6 @@ fi
 define_in_config_if_yes "$_png" 'USE_PNG'
 echo "$_png"
 
-if test `get_engine_build sword25` = yes && test ! "$_png" = yes ; then
-	echo "...disabling Broken Sword 2.5 engine. PNG is required"
-	engine_disable sword25
-fi
-
 #
 # Check for Theora Decoder
 #
@@ -3870,6 +3893,9 @@ sh -c "
 	fi" 2>/dev/null &
 
 for engine in $_engines; do
+	# Check whether all dependencies are available
+	check_engine_deps $engine
+
 	if test "`get_engine_sub $engine`" = "no" ; then
 		# It's a main engine
 		if test `get_engine_build $engine` = no ; then

--- a/engines/configure.engines
+++ b/engines/configure.engines
@@ -36,7 +36,7 @@ add_engine sci32 "SCI32 games" no
 add_engine sky "Beneath a Steel Sky" yes
 add_engine sword1 "Broken Sword" yes
 add_engine sword2 "Broken Sword II" yes
-add_engine sword25 "Broken Sword 2.5" no
+add_engine sword25 "Broken Sword 2.5" no "" "png"
 add_engine teenagent "Teen Agent" yes
 add_engine testbed "TestBed: the Testing framework" no
 add_engine tinsel "Tinsel" yes


### PR DESCRIPTION
Also adds PNG as a dependency for sword25 and removes the hardcoded check for it.

This is really just for discussion. But it should be helpful for WME too, which for example requires Vorbis right now. This way to specify dependencies can also be helpful for create_project, since we can parse the dependency lists there and process them. Without this change we would need to duplicate such hard coded checks, like the sword25 one, for configure and create_project.

Things which could be done:
- Add Theora and/or 16 bit support as dependency for sword25. Should be trivial to do.
- Nicer output for the missing dependency list. Here we might do something similar to "add_engine" and specify a nice name for each feature.

My sh skills are not the best, so if someone wants to pick this up and further improve it (maybe even after a merge), that would be nice.
