### PR TITLE
pull request for fixing -dbg packages

### DIFF
--- a/ports.mk
+++ b/ports.mk
@@ -8,7 +8,7 @@
 #
 install:
 	$(INSTALL) -d "$(DESTDIR)$(bindir)"
-	$(INSTALL) -c -s -m 755 "./$(EXECUTABLE)" "$(DESTDIR)$(bindir)/$(EXECUTABLE)"
+	$(INSTALL) -c -m 755 "./$(EXECUTABLE)" "$(DESTDIR)$(bindir)/$(EXECUTABLE)"
 	$(INSTALL) -d "$(DESTDIR)$(mandir)/man6/"
 	$(INSTALL) -c -m 644 "$(srcdir)/dists/scummvm.6" "$(DESTDIR)$(mandir)/man6/scummvm.6"
 	$(INSTALL) -d "$(DESTDIR)$(datarootdir)/pixmaps/"
@@ -19,7 +19,7 @@ install:
 	$(INSTALL) -c -m 644 $(DIST_FILES_THEMES) $(DIST_FILES_ENGINEDATA) "$(DESTDIR)$(datadir)/"
 ifdef DYNAMIC_MODULES
 	$(INSTALL) -d "$(DESTDIR)$(libdir)/scummvm/"
-	$(INSTALL) -c -s -m 644 $(PLUGINS) "$(DESTDIR)$(libdir)/scummvm/"
+	$(INSTALL) -c -m 644 $(PLUGINS) "$(DESTDIR)$(libdir)/scummvm/"
 endif
 
 uninstall:


### PR DESCRIPTION
Without that fix Distributions/packagers have some issues creating
  correct -dbg packages because the stripping occurs before they could
  save the unstripped file.

Signed-off-by: Denis 'GNUtoo' Carikli GNUtoo@no-log.org
