### PR TITLE
ANDROID: Fixed tapping touchpad not sending left clicks

### DIFF
--- a/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
+++ b/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
@@ -7,91 +7,6 @@ import android.view.View;
 
 /**
  * Contains helper methods for mouse/hover events that were introduced in Android 4.0.
- *
- * Mouse (hover) events seem to be a bit arbitrary, so here's couple of scenarios:
- *
- *
- * 1. Galaxy Note 2 (4.1) + stylus:
- * Tool type: TOOL_TYPE_STYLUS
- *
- * Key: 238 ACTION_DOWN (once)
- * Key: 238 ACTION_UP (once)
- * Hover: ACTION_HOVER_ENTER (once)
- * Hover: ACTION_HOVER_MOVE (multiple, while hovering)
- *
- * touch screen with the pen:
- * Hover: ACTION_HOVER_EXIT, ButtonState: 0 (once)
- * Touch: ACTION_DOWN, ButtonState: 0 (once)
- * Touch: ACTION_MOVE, ButtonState: 0 (multiple, while pressing)
- * Touch: ACTION_UP, ButtonState: 0 (once)
- * Hover: ACTION_HOVER_ENTER (once)
- *
- * press the stylus button while hovering:
- * Hover: ACTION_HOVER_MOVE, ButtonState: 2 (multiple, while pressing button)
- * Hover: ACTION_HOVER_MOVE, ButtonState: 0 (multiple, after release)
- *
- *
- * 2. Galaxy Note 2 (4.1) + mouse (usb):
- * Tool type: TOOL_TYPE_MOUSE
- *
- * Hover: ACTION_HOVER_ENTER (once)
- * Hover: ACTION_HOVER_MOVE (multiple, while hovering)
- *
- * press left button:
- * Hover: ACTION_HOVER_EXIT, ButtonState: 1 (once)
- * Touch: ACTION_DOWN, ButtonState: 1 (once)
- * Touch: ACTION_MOVE, ButtonState: 1 (multiple, while pressing)
- * Touch: ACTION_UP, ButtonState: 0 (once)
- * Hover: ACTION_HOVER_ENTER, ButtonState: 0 (once)
- *
- * press right button:
- * Key: KEYCODE_BACK, ACTION_DOWN
- * Hover: ACTION_HOVER_MOVE, ButtonState: 2 (multiple, while pressing button)
- * Hover: ACTION_HOVER_MOVE, ButtonState: 0 (once)
- * Key: KEYCODE_BACK, ACTION_UP
- *
- *
- * 3. Asus eeePad Transformer Prime running CyanogenMod 10 (Android 4.1) + mouse (usb):
- * Tool type: TOOL_TYPE_MOUSE
- *
- * Hover: ACTION_HOVER_ENTER (once)
- * Hover: ACTION_HOVER_MOVE (multiple, while hovering)
- *
- * press left button:
- * Hover: ACTION_HOVER_EXIT, ButtonState: 1 (once)
- * Touch: ACTION_DOWN, ButtonState: 1 (once)
- * Touch: ACTION_MOVE, ButtonState: 1 (multiple, while pressing)
- * Touch: ACTION_UP, ButtonState: 0 (once)
- * Hover: ACTION_HOVER_ENTER, ButtonState: 0 (once)
- *
- * press right button:
- * Hover: ACTION_HOVER_EXIT, ButtonState: 2 (once)
- * Touch: ACTION_DOWN, ButtonState: 2 (once)
- * Touch: ACTION_MOVE, ButtonState: 2 (multiple, while pressing)
- * Touch: ACTION_UP, ButtonState: 0 (once)
- * Hover: ACTION_HOVER_ENTER, ButtonState: 0 (once)
- *
- *
- * 4. Asus eeePad Transformer Prime running CyanogenMod 10 (Android 4.1) + touchpad:
- * Tool type: TOOL_TYPE_FINGER
- *
- * Hover: ACTION_HOVER_ENTER (once)
- * Hover: ACTION_HOVER_MOVE (multiple, while hovering)
- *
- * press left button:
- * Hover: ACTION_HOVER_EXIT, ButtonState: 1 (once)
- * Touch: ACTION_DOWN, ButtonState: 1 (once)
- * Touch: ACTION_MOVE, ButtonState: 1 (multiple, while pressing)
- * Touch: ACTION_UP, ButtonState: 0 (once)
- * Hover: ACTION_HOVER_ENTER, ButtonState: 0 (once)
- *
- * press right button:
- * Hover: ACTION_HOVER_EXIT, ButtonState: 2 (once)
- * Touch: ACTION_DOWN, ButtonState: 2 (once)
- * Touch: ACTION_MOVE, ButtonState: 2 (multiple, while pressing)
- * Touch: ACTION_UP, ButtonState: 0 (once)
- * Hover: ACTION_HOVER_ENTER, ButtonState: 0 (once)
- *
  */
 public class MouseHelper {
 	private View.OnHoverListener _listener;
@@ -126,7 +41,7 @@ public class MouseHelper {
 		return new View.OnHoverListener() {
 			@Override
 			public boolean onHover(View view, MotionEvent e) {
-				return onTouch(e, true);
+				return onMouseEvent(e, true);
 			}
 		};
 	}
@@ -153,16 +68,16 @@ public class MouseHelper {
 		       ((sources & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD);
 	}
 
-	public boolean onTouch(MotionEvent e, boolean hover) {
+	public boolean onMouseEvent(MotionEvent e, boolean hover) {
 		_scummvm.pushEvent(ScummVMEvents.JE_MOUSE_MOVE, (int)e.getX(), (int)e.getY(), 0, 0, 0);
 		
 		int buttonState = e.getButtonState();
 
 		boolean lmbDown = (buttonState & MotionEvent.BUTTON_PRIMARY) == MotionEvent.BUTTON_PRIMARY;
 
-		if (e.getToolType(0) == MotionEvent.TOOL_TYPE_STYLUS) {
-			// when using stylus, ButtonState is 0
-			lmbDown = !hover;
+		if (!hover && e.getAction() != MotionEvent.ACTION_UP && buttonState == 0) {
+			// On some device types, ButtonState is 0 even when tapping on the touchpad or using the stylus on the screen etc.
+			lmbDown = true;
 		}
 
 		if (lmbDown) {

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMEvents.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMEvents.java
@@ -193,7 +193,7 @@ public class ScummVMEvents implements
 			boolean isMouse = MouseHelper.isMouse(e);
 			if (isMouse) {
 				// mouse button is pressed
-				return _mouseHelper.onTouch(e, false);
+				return _mouseHelper.onMouseEvent(e, false);
 			}
 		}
 


### PR DESCRIPTION
Tested with touchpad on Transformer Prime, running CyanogenMOD 10. Also retested with USB mouse, stylus (Galaxy Note 2) and regular touch screen controls.
