### PR TITLE
GROOVIE: Change the movie speed option to a number

### DIFF
--- a/README
+++ b/README
@@ -2161,10 +2161,11 @@ keywords:
 
 The 7th Guest adds the following non-standard keyword:
 
-    t7g_speed          string   Video playback speed (normal, tweaked,
-                                im_an_ios)
-
-
+    movie_speed        number   Video playback speed: 0 is normal, 1 plays the
+                                'teeth' animations normally and the rest of the
+                                videos at an increased speed, 2 plays all videos
+                                at an increased speed, matching the iOS version
+								
 8.2) Custom game options that can be toggled via the GUI
 ---- ---------------------------------------------------
 A lot of the custom game options in the previous section can be toggled via the

--- a/engines/groovie/groovie.cpp
+++ b/engines/groovie/groovie.cpp
@@ -57,13 +57,13 @@ GroovieEngine::GroovieEngine(OSystem *syst, const GroovieGameDescription *gd) :
 	SearchMan.addSubDirectoryMatching(gameDataDir, "media");
 	SearchMan.addSubDirectoryMatching(gameDataDir, "system");
 
-	_modeSpeed = kGroovieSpeedNormal;
-	if (ConfMan.hasKey("t7g_speed")) {
-		Common::String speed = ConfMan.get("t7g_speed");
-		if (speed.equals("im_an_ios"))
-			_modeSpeed = kGroovieSpeediOS;
-		else if (speed.equals("tweaked"))
-			_modeSpeed = kGroovieSpeedTweaked;
+ 	_modeSpeed = kGroovieSpeedNormal;	// normal movies, normal 'teeth' animations
+	if (ConfMan.hasKey("movie_speed")) {
+		int speed = ConfMan.getInt("movie_speed");
+		if (speed == 1)
+			_modeSpeed = kGroovieSpeedTweaked;	// fast movies, normal 'teeth' animations
+		else if (speed == 2)
+			_modeSpeed = kGroovieSpeediOS;	// fast movies, fast 'teeth' animations
 	}
 
 	// Initialize the custom debug levels


### PR DESCRIPTION
This simplifies the movie speed option and changes it to a number
(0 - 2), so that it's easier to understand its usage.

Also, this ensures that all per-engine/per-game options are either
booleans or numbers, so they can be represented in the launcher's
GUI via checkboxes (which is already implemented) and via scroll
bars (which can be done in the future). The previous string setting
for T7G's movies could not be represented in our GUI
