### PR TITLE
TINSEL: Add scrollwheel support to save/load and inventory

### DIFF
--- a/engines/tinsel/dialogs.cpp
+++ b/engines/tinsel/dialogs.cpp
@@ -4861,48 +4861,99 @@ static void InvDragEnd() {
 	g_Xchange = g_Ychange = 0;		// Probably no need, but does no harm!
 }
 
-static void MenuPageDown() {
+static bool MenuDown(int lines) {
 	if (cd.box == loadBox || cd.box == saveBox) {
-		if (cd.extraBase < MAX_SAVED_FILES-NUM_RGROUP_BOXES) {
-			FirstFile(cd.extraBase+(NUM_RGROUP_BOXES - 1));
+		if (cd.extraBase < MAX_SAVED_FILES - NUM_RGROUP_BOXES) {
+			FirstFile(cd.extraBase + lines);
 			AddBoxes(true);
-			cd.selBox = NUM_RGROUP_BOXES - 1;
-			Select(cd.selBox, true);
+			return true;
 		}
 	} else if (cd.box == hopperBox1) {
 		if (cd.extraBase < g_numScenes - NUM_RGROUP_BOXES) {
-			FirstScene(cd.extraBase + (NUM_RGROUP_BOXES - 1));
+			FirstScene(cd.extraBase + lines);
 			AddBoxes(true);
-			if (cd.selBox)
-				cd.selBox = NUM_RGROUP_BOXES - 1;
-			Select(cd.selBox, true);
+			return true;
 		}
 	} else if (cd.box == hopperBox2) {
 		if (cd.extraBase < g_numEntries - NUM_RGROUP_BOXES) {
-			FirstEntry(cd.extraBase+(NUM_RGROUP_BOXES - 1));
+			FirstEntry(cd.extraBase + lines);
 			AddBoxes(true);
-			if (cd.selBox)
-				cd.selBox = NUM_RGROUP_BOXES - 1;
-			Select(cd.selBox, true);
+			return true;
 		}
+	}
+	return false;
+}
+
+static bool MenuUp(int lines) {
+	if (cd.extraBase > 0) {
+		if (cd.box == loadBox || cd.box == saveBox)
+			FirstFile(cd.extraBase - lines);
+		else if (cd.box == hopperBox1)
+			FirstScene(cd.extraBase - lines);
+		else if (cd.box == hopperBox2)
+			FirstEntry(cd.extraBase - lines);
+		else
+			return false;
+
+		AddBoxes(true);
+		return true;
+	}
+	return false;
+}
+
+static void MenuRollDown() {
+	if (MenuDown(1)) {
+		if (cd.selBox > 0)
+			cd.selBox--;
+		Select(cd.selBox, true);
+	}
+}
+
+static void MenuRollUp() {
+	if (MenuUp(1)) {
+		if (cd.selBox < NUM_RGROUP_BOXES - 1)
+			cd.selBox++;
+		Select(cd.selBox, true);
+	}
+}
+
+static void MenuPageDown() {
+	if (MenuDown(NUM_RGROUP_BOXES - 1)) {
+		cd.selBox = NUM_RGROUP_BOXES - 1;
+		Select(cd.selBox, true);
 	}
 }
 
 static void MenuPageUp() {
-	if (cd.extraBase > 0) {
-		if (cd.box == loadBox || cd.box == saveBox)
-			FirstFile(cd.extraBase-(NUM_RGROUP_BOXES - 1));
-		else if (cd.box == hopperBox1)
-			FirstScene(cd.extraBase-(NUM_RGROUP_BOXES - 1));
-		else if (cd.box == hopperBox2)
-			FirstEntry(cd.extraBase-(NUM_RGROUP_BOXES - 1));
-		else
-			return;
-
-		AddBoxes(true);
+	if (MenuUp(NUM_RGROUP_BOXES - 1)) {
 		cd.selBox = 0;
 		Select(cd.selBox, true);
 	}
+}
+
+static void InventoryDown() {
+	// This code is a copy of the IB_SLIDE_DOWN case in InvWalkTo
+	// TODO: So share this duplicate code
+	if (g_InvD[g_ino].NoofVicons == 1)
+		if (g_InvD[g_ino].FirstDisp + g_InvD[g_ino].NoofHicons*g_InvD[g_ino].NoofVicons < g_InvD[g_ino].NoofItems)
+			g_InvD[g_ino].FirstDisp += g_InvD[g_ino].NoofHicons;
+	for (int i = 1; i < g_InvD[g_ino].NoofVicons; i++) {
+		if (g_InvD[g_ino].FirstDisp + g_InvD[g_ino].NoofHicons*g_InvD[g_ino].NoofVicons < g_InvD[g_ino].NoofItems)
+			g_InvD[g_ino].FirstDisp += g_InvD[g_ino].NoofHicons;
+	}
+	g_ItemsChanged = true;
+}
+
+static void InventoryUp() {
+	// This code is a copy of the I_SLIDE_UP case in InvWalkTo
+	// TODO: So share this duplicate code
+	if (g_InvD[g_ino].NoofVicons == 1)
+		g_InvD[g_ino].FirstDisp -= g_InvD[g_ino].NoofHicons;
+	for (int i = 1; i < g_InvD[g_ino].NoofVicons; i++)
+		g_InvD[g_ino].FirstDisp -= g_InvD[g_ino].NoofHicons;
+	if (g_InvD[g_ino].FirstDisp < 0)
+		g_InvD[g_ino].FirstDisp = 0;
+	g_ItemsChanged = true;
 }
 
 /**************************************************************************/
@@ -5402,16 +5453,7 @@ extern void EventToInventory(PLR_EVENT pEvent, const Common::Point &coOrds) {
 			// Only act if load or save screen
 			MenuPageDown();
 		} else {
-			// This code is a copy of the IB_SLIDE_DOWN case in InvWalkTo
-			// TODO: So share this duplicate code
-			if (g_InvD[g_ino].NoofVicons == 1)
-				if (g_InvD[g_ino].FirstDisp + g_InvD[g_ino].NoofHicons*g_InvD[g_ino].NoofVicons < g_InvD[g_ino].NoofItems)
-					g_InvD[g_ino].FirstDisp += g_InvD[g_ino].NoofHicons;
-			for (int i = 1; i < g_InvD[g_ino].NoofVicons; i++) {
-				if (g_InvD[g_ino].FirstDisp + g_InvD[g_ino].NoofHicons*g_InvD[g_ino].NoofVicons < g_InvD[g_ino].NoofItems)
-					g_InvD[g_ino].FirstDisp += g_InvD[g_ino].NoofHicons;
-			}
-			g_ItemsChanged = true;
+			InventoryDown();
 		}
 		break;
 
@@ -5420,15 +5462,25 @@ extern void EventToInventory(PLR_EVENT pEvent, const Common::Point &coOrds) {
 			// Only act if load or save screen
 			MenuPageUp();
 		} else {
-			// This code is a copy of the I_SLIDE_UP case in InvWalkTo
-			// TODO: So share this duplicate code
-			if (g_InvD[g_ino].NoofVicons == 1)
-				g_InvD[g_ino].FirstDisp -= g_InvD[g_ino].NoofHicons;
-			for (int i = 1; i < g_InvD[g_ino].NoofVicons; i++)
-				g_InvD[g_ino].FirstDisp -= g_InvD[g_ino].NoofHicons;
-			if (g_InvD[g_ino].FirstDisp < 0)
-				g_InvD[g_ino].FirstDisp = 0;
-			g_ItemsChanged = true;
+			InventoryUp();
+		}
+		break;
+
+	case PLR_WHEEL_DOWN:
+		if (g_ino == INV_MENU) {
+			// Only act if load or save screen
+			MenuRollDown();
+		} else {
+			InventoryDown();
+		}
+		break;
+
+	case PLR_WHEEL_UP:
+		if (g_ino == INV_MENU) {
+			// Only act if load or save screen
+			MenuRollUp();
+		} else {
+			InventoryUp();
 		}
 		break;
 

--- a/engines/tinsel/events.cpp
+++ b/engines/tinsel/events.cpp
@@ -389,7 +389,8 @@ void PlayerEvent(PLR_EVENT pEvent, const Common::Point &coOrds) {
 		"PLR_PROV_WALKTO", "PLR_WALKTO", "PLR_LOOK", "PLR_ACTION", "PLR_ESCAPE",
 		"PLR_MENU", "PLR_QUIT", "PLR_PGUP", "PLR_PGDN", "PLR_HOME", "PLR_END",
 		"PLR_DRAG1_START", "PLR_DRAG1_END", "PLR_DRAG2_START", "PLR_DRAG2_END",
-		"PLR_JUMP", "PLR_NOEVENT"};
+		"PLR_JUMP", "PLR_NOEVENT", "PLR_SAVE", "PLR_LOAD", "PLR_WHEEL_UP",
+		"PLR_WHEEL_DOWN"};
 	debugC(DEBUG_BASIC, kTinselDebugActions, "%s - (%d,%d)",
 		actionList[pEvent], coOrds.x, coOrds.y);
 	static uint32 lastRealAction = 0;	// FIXME: Avoid non-const global vars

--- a/engines/tinsel/events.h
+++ b/engines/tinsel/events.h
@@ -65,6 +65,8 @@ enum PLR_EVENT {
 	PLR_NOEVENT = 16,
 	PLR_SAVE = 17,
 	PLR_LOAD = 18,
+	PLR_WHEEL_UP = 19,
+	PLR_WHEEL_DOWN = 20,
 
 	// Aliases used for DW1 actions
 	PLR_SLEFT = PLR_WALKTO,

--- a/engines/tinsel/tinsel.cpp
+++ b/engines/tinsel/tinsel.cpp
@@ -430,6 +430,14 @@ static void MouseProcess(CORO_PARAM, const void *) {
 				ProcessButEvent(PLR_DRAG2_END);
 			break;
 
+		case Common::EVENT_WHEELUP:
+			PlayerEvent(PLR_WHEEL_UP, mousePos);
+			break;
+
+		case Common::EVENT_WHEELDOWN:
+			PlayerEvent(PLR_WHEEL_DOWN, mousePos);
+			break;
+
 		default:
 			break;
 		}
@@ -1046,6 +1054,8 @@ bool TinselEngine::pollEvent() {
 	case Common::EVENT_LBUTTONUP:
 	case Common::EVENT_RBUTTONDOWN:
 	case Common::EVENT_RBUTTONUP:
+	case Common::EVENT_WHEELUP:
+	case Common::EVENT_WHEELDOWN:
 		// Add button to queue for the mouse process
 		_mouseButtons.push_back(event.type);
 		break;


### PR DESCRIPTION
This adds scrollwheel support to the save/load dialog (which I find pretty useful) and to the inventory (which is much more questionable since it basically duplicates PgUp/PgDown). I'm a bit uncertain about some of the technicalities in dialogs.cpp, but it seems to work correctly to me.
