### PR TITLE
Return NULL in wrapCompressedReadStream for compressed streams when ZLIB is disabled.

### DIFF
--- a/common/zlib.cpp
+++ b/common/zlib.cpp
@@ -392,17 +392,21 @@ public:
 #endif	// USE_ZLIB
 
 SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped, uint32 knownSize) {
-#if defined(USE_ZLIB)
 	if (toBeWrapped) {
 		uint16 header = toBeWrapped->readUint16BE();
 		bool isCompressed = (header == 0x1F8B ||
 				     ((header & 0x0F00) == 0x0800 &&
 				      header % 31 == 0));
 		toBeWrapped->seek(-2, SEEK_CUR);
-		if (isCompressed)
+		if (isCompressed) {
+#if defined(USE_ZLIB)
 			return new GZipReadStream(toBeWrapped, knownSize);
-	}
+#else
+			delete toBeWrapped;
+			return NULL;
 #endif
+		}
+	}
 	return toBeWrapped;
 }
 

--- a/common/zlib.h
+++ b/common/zlib.h
@@ -103,7 +103,9 @@ bool inflateZlibInstallShield(byte *dst, uint dstLen, const byte *src, uint srcL
  * provides transparent on-the-fly decompression. Assumes the data it
  * retrieves from the wrapped stream to be either uncompressed or in gzip
  * format. In the former case, the original stream is returned unmodified
- * (and in particular, not wrapped).
+ * (and in particular, not wrapped). In the latter case the stream is
+ * returned wrapped, unless there is no ZLIB support, then NULL is returned
+ * and the old stream is destroyed.
  *
  * Certain GZip-formats don't supply an easily readable length, if you
  * still need the length carried along with the stream, and you know


### PR DESCRIPTION
As the title suggests this changes wrapCompressedReadStream to return NULL when it gets an compressed stream, but zLib is not available.

My main motivation for this is that I found the former handling of just returning the stream a bit confusing. DefaultSaveFileManager::openForLoading would now return NULL when it encounters a compressed stream but no zLib support is available. This seems a better solution then returning the engine the compressed stream.

Anyway open for comments.
