### PR TITLE
CONFIGURE: Never enable release_build by default.

### DIFF
--- a/configure
+++ b/configure
@@ -2548,10 +2548,13 @@ if test -n "$_host"; then
 			DEFINES="$DEFINES -DREDUCE_MEMORY_USAGE"
 			if test "$_release_build" = no; then
 				DEFINES="$DEFINES -DOP_DEBUG"
-			else
-				# Use -O3 on the OpenPandora for non-debug builds.
+			fi
+
+			# Use -O3 on the OpenPandora for optimized builds.
+			if test "$_optimizations" = yes; then
 				_optimization_level=-O3
 			fi
+
 			define_in_config_if_yes yes 'USE_ARM_NEON_ASPECT_CORRECTOR'
 			CXXFLAGS="$CXXFLAGS -march=armv7-a"
 			CXXFLAGS="$CXXFLAGS -mtune=cortex-a8"


### PR DESCRIPTION
This changes the default for Caanoo, GP2x, GP2xWiz, OpenPandora and PS2.
For those now we only disable debug symbols and enable optimizations by
default.

This seems a left-over from when we splitted the optimization state from the release state. I am not sure whether ther are any other reasons for still enabling release mode by default though.
