### PR TITLE
fix build under et_EE locale

### DIFF
--- a/configure
+++ b/configure
@@ -21,6 +21,12 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 
+# NLS nuisances.
+LC_ALL=C
+export LC_ALL
+LANGUAGE=C
+export LANGUAGE
+
 # Save the current environment variables for next runs
 SAVED_CONFIGFLAGS=$@
 SAVED_LDFLAGS=$LDFLAGS


### PR DESCRIPTION
work around freetype-config bug by preferring pkg-config:
https://bugs.gentoo.org/show_bug.cgi?id=454804
locale-bug:
https://bugs.gentoo.org/show_bug.cgi?id=437488
