### PR TITLE
LURE: Fix bug #3604370 - "LURE: ANDROID, Action item scrolling too sensitive"

### DIFF
--- a/engines/lure/menu.cpp
+++ b/engines/lure/menu.cpp
@@ -31,7 +31,7 @@
 #include "lure/events.h"
 #include "lure/lure.h"
 
-#if defined(_WIN32_WCE) || defined(__SYMBIAN32__) || defined(WEBOS)
+#if defined(_WIN32_WCE) || defined(__SYMBIAN32__) || defined(WEBOS) || defined(__ANDROID__)
 #define LURE_CLICKABLE_MENUS
 #endif
 


### PR DESCRIPTION
LURE: Fix bug #3604370 - "LURE: ANDROID, Action item scrolling too sensitive"

You can't scroll the menus properly because the code assumes it can reposition the mouse cursor to the middle of the screen, so as soon as you move the threshold number of pixels off with your finger on android, the menu scrolls right to the end. I guess other touch devices will need this too.
