### PR TITLE
MOHAWK: Stopping the handling of mouseclicks if the cursor isn't visible.

### DIFF
--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -40,6 +40,8 @@
 
 #include "gui/message.h"
 
+#include "graphics/cursorman.h"
+
 namespace Mohawk {
 
 // read a null-terminated string from a stream
@@ -223,7 +225,7 @@ Common::Error MohawkEngine_LivingBooks::run() {
 					}
 				}
 
-				if (found)
+				if (found && CursorMan.isVisible())
 					found->handleMouseDown(event.mouse);
 				break;
 


### PR DESCRIPTION
I fixed this bug:
https://sourceforge.net/tracker/?func=detail&aid=3488327&group_id=37116&atid=418820
The problem was that you could click on items on the screen all the
time, even if the cursor wasn't visible. That caused multiple animations
run simultaneously.
Now I fixed it: the engine handles the EVENT_LBUTTONDOWN event only if
the cursor is visible on the screen.
