### PR TITLE
SWORD25: Silence warning in the Lua code

### DIFF
--- a/engines/sword25/util/lua/ldo.cpp
+++ b/engines/sword25/util/lua/ldo.cpp
@@ -98,6 +98,16 @@ static void resetstack (lua_State *L, int status) {
 }
 
 
+// Added in ScummVM. Refer to http://www.lua.org/manual/5.1/manual.html
+static const char* luaErrorDescription[] = {
+	"No error",
+	"Coroutine yield",	// not an actual error, see lua_resume
+	"Runtime error",
+	"Syntax error during pre-compilation",	// refer to lua_load
+	"Memory allocation error",
+	"Error while running the error handler function"
+};
+
 void luaD_throw (lua_State *L, int errcode) {
   if (L->errorJmp) {
     L->errorJmp->status = errcode;

--- a/engines/sword25/util/lua/lua.h
+++ b/engines/sword25/util/lua/lua.h
@@ -48,16 +48,6 @@
 #define LUA_ERRMEM	4
 #define LUA_ERRERR	5
 
-// Added in ScummVM. Refer to http://www.lua.org/manual/5.1/manual.html
-static const char* luaErrorDescription[] = {
-	"No error",
-	"Coroutine yield",	// not an actual error, see lua_resume
-	"Runtime error",
-	"Syntax error during pre-compilation",	// refer to lua_load
-	"Memory allocation error",
-	"Error while running the error handler function"
-};
-
 typedef struct lua_State lua_State;
 
 typedef int (*lua_CFunction) (lua_State *L);


### PR DESCRIPTION
This fixes warnings like this that crop up when compiling sword25
with Apple clang 4.2 (clang-425.0.28) (based on LLVM 3.2svn)
