### PR TITLE
KYRA: Fix MIDI fade-out behaviour

### DIFF
--- a/engines/kyra/sound_midi.cpp
+++ b/engines/kyra/sound_midi.cpp
@@ -323,7 +323,7 @@ void MidiOutput::setSourceVolume(int source, int volume, bool apply) {
 		for (int i = 0; i < 16; ++i) {
 			// Controller 0 in the state table should always be '7' aka
 			// volume control
-			byte realVol = (_channels[i].controllers[0].value * volume) >> 8;
+			byte realVol = (_sources[source].controllers[i][0].value * volume) >> 8;
 			sendIntern(0xB0, i, 0x07, realVol);
 		}
 	}


### PR DESCRIPTION
This takes a bit of explaining...

I noticed that when MIDI music is faded out, the volume first gets louder than before. The simplest way I could find to hear this is to start the Kyrandia 2 intro while the main menu music is still playing.

Here is what I think is happening:

There are two ways that the Kyra MIDI player sets the music:

1) The setSourceVolume() function.
2) Volume events, handled by the MIDI parser. These are caught by send().

Music fade-out is handled by calling setSourceVolume() repeatedly, with smaller and smaller volume.

Note that calling sendIntern() bypasses the send() function.

As I understand it, setSourceVolume() is used to set the music volume as ScummVM sees it. This is stored in _sources[].volume.

The send() function handled music volume as the MIDI parser sees it. This volume is usually (always?) 100, but let's assume it's not. This volume is stored in _sources[].controllers[][].value. Before it's sent to the actual MIDI backend, it's adjusted by what is in _sources[].volume.

So what setSourceVolume() should do, then, is to adjust _sources[].volume, and set the volume to what it would have been if that had been the value in _sources[].volume when the volume was set in send(). But setSourceVolume() used _channels[].controllers[].value, where I think it should be using _sources[].controllers[][].value. So that's the change I've made here.
