### PR TITLE
Implemeted 'reverse_iterator'

### DIFF
--- a/common/list.h
+++ b/common/list.h
@@ -110,7 +110,7 @@ public:
 	 */
 	reverse_iterator erase(reverse_iterator pos) {
 		assert(pos != reverse_end());
-		return reverse_iterator(&iterator(erase(pos._node)._prev));
+		return reverse_iterator(erase(pos._node)._prev);
 	}
 
 	/**
@@ -128,7 +128,7 @@ public:
 	 */
 	reverse_iterator reverse_erase(reverse_iterator pos) {
 		assert(pos != reverse_end());
-		return reverse_iterator(&iterator(erase(pos._node)._next));
+		return reverse_iterator(erase(pos._node)._next);
 	}
 
 	/**
@@ -260,7 +260,7 @@ public:
 	}
 
 	reverse_iterator reverse_begin() {
-		return reverse_iterator(&iterator(_anchor._prev));
+		return reverse_iterator(_anchor._prev);
 	}
 
 	iterator end() {
@@ -268,7 +268,7 @@ public:
 	}
 
 	reverse_iterator reverse_end() {
-		return reverse_iterator(&iterator(_anchor));
+		return reverse_iterator(&_anchor);
 	}
 
 	const_iterator begin() const {
@@ -276,7 +276,7 @@ public:
 	}
 
 	const_reverse_iterator reverse_begin() const {
-		return const_reverse_iterator(&const_iterator(_anchor._prev));
+		return const_reverse_iterator(_anchor._prev);
 	}
 
 	const_iterator end() const {
@@ -284,7 +284,7 @@ public:
 	}
 
 	const_reverse_iterator reverse_end() const {
-		return const_reverse_iterator(const_iterator(const_cast<NodeBase *>(&_anchor)));
+		return const_reverse_iterator(const_cast<NodeBase *>(&_anchor));
 	}
 
 protected:

--- a/common/list_intern.h
+++ b/common/list_intern.h
@@ -104,6 +104,7 @@ namespace ListInternal {
 		typedef const Node<T> *	NodePtr;
 		typedef const T &		ValueRef;
 		typedef const T *		ValuePtr;
+		typedef const T			ValueType;
 
 		const NodeBase *_node;
 
@@ -162,54 +163,55 @@ namespace ListInternal {
 		typedef T *			ValuePtr;
 		typedef T			ValueType;
 
-		Iterator<T> *_iter;
+		NodeBase *_node;
 
 		// Constructor and Copy
-		ReverseIterator() : _iter(0) {}
-		explicit ReverseIterator(Iterator<T>* iter) : _iter(iter) {}
+		ReverseIterator() : _node(0) {}
+		explicit ReverseIterator(NodeBase* node) : _node(node) {}
+		explicit ReverseIterator(Iterator<T>& iter) : _node(iter._node) {}
 
 		// Prefix inc
 		Self &operator++() {
-			if (_iter && _iter->_node)
-				_iter->_node = _iter->_node->_prev;
+			if (_node)
+				_node = _node->_prev;
 			return *this;
 		}
 		// Postfix inc
 		Self operator++(int) {
-			Self tmp(_iter);
+			Self tmp(_node);
 			++(*this);
 			return tmp;
 		}
 		// Prefix dec
 		Self &operator--() {
-			if (_iter && _iter->_node)
-				_iter->_node = _iter->_node->_next;
+			if (_node)
+				_node = _node->_next;
 			return *this;
 		}
 		// Postfix dec
 		Self operator--(int) {
-			Self tmp(_iter);
+			Self tmp(_node);
 			--(*this);
 			return tmp;
 		}
 		ValueRef operator*() const {
-			assert(_iter && _iter->_node);
-			return static_cast<NodePtr>(_iter->_node)->_data;
+			assert(_node);
+			return static_cast<NodePtr>(_node)->_data;
 		}
 		ValuePtr operator->() const {
 			return &(operator*());
 		}
 
 		bool operator==(const Self &x) const {
-			if (_iter)
-				return _iter->_node == x->_iter->_node;
+			if (_node)
+				return _node == x._node;
 
 			return false;
 		}
 
 		bool operator!=(const Self &x) const {
-			if (_iter)
-				return _iter->_node != x->_iter->_node;
+			if (_node)
+				return _node != x._node;
 
 			return false;
 		}
@@ -225,56 +227,56 @@ namespace ListInternal {
 		typedef const T *				ValuePtr;
 		typedef const T					ValueType;
 
-		const Iterator<T> *_iter;
+		const NodeBase *_node;
 
 		// Constructor and Copy
-		ConstReverseIterator() : _iter(0) {}
-		explicit ConstReverseIterator(Iterator<T>* iter) : _iter(iter) {}
-		ConstReverseIterator(const ConstReverseIterator<T> &x) : _iter(x._iter) {}
+		ConstReverseIterator() : _node(0) {}
+		explicit ConstReverseIterator(NodeBase *node) : _node(node) {}
+		explicit ConstReverseIterator(ConstIterator<T>& iter) : _node(iter._node) {}
+		ConstReverseIterator(const ConstReverseIterator<T> &x) : _node(x._node) {}
 
 		// Prefix inc
 		Self &operator++() {
-			if (_iter && _iter->_node)
-				_iter->_node = _iter->_node->_prev;
+			if (_node)
+				_node = _node->_prev;
 			return *this;
 		}
 		// Postfix inc
 		Self operator++(int) {
-			Self tmp(_iter);
+			Self tmp(_node);
 			++(*this);
-			7 = 6;
 			return tmp;
 		}
 		// Prefix dec
 		Self &operator--() {
-			if (_iter && _iter->_node)
-				_iter->_node = _iter->_node->_next;
+			if (_node)
+				_node = _node->_next;
 			return *this;
 		}
 		// Postfix dec
 		Self operator--(int) {
-			Self tmp(_iter);
+			Self tmp(_node);
 			--(*this);
 			return tmp;
 		}
 		ValueRef operator*() const {
-			assert(_iter && _iter->_node);
-			return static_cast<NodePtr>(_iter->_node)->_data;
+			assert(_node);
+			return static_cast<NodePtr>(_node)->_data;
 		}
 		ValuePtr operator->() const {
 			return &(operator*());
 		}
 
 		bool operator==(const Self &x) const {
-			if (_iter)
-				return _iter->_node == x->_iter->_node;
+			if (_node)
+				return _node == x._node;
 
 			return false;
 		}
 
 		bool operator!=(const Self &x) const {
-			if (_iter)
-				return _iter->_node != x->_iter->_node;
+			if (_node)
+				return _node != x._node;
 
 			return false;
 		}
@@ -305,12 +307,12 @@ namespace ListInternal {
 	// ReverseIterator vs. ConstReverseIterator
 	template<typename T>
 	bool operator==(const ReverseIterator<T>& a, const ConstReverseIterator<T>& b) {
-		return a._iter->_node == b._iter->_node;
+		return a._node == b._node;
 	}
 
 	template<typename T>
 	bool operator!=(const ReverseIterator<T>& a, const ConstReverseIterator<T>& b) {
-		return a._iter->_node != b._iter->_node;
+		return a._node != b._node;
 	}
 
 	// == and != are commutative
@@ -327,12 +329,12 @@ namespace ListInternal {
 	// Iterator vs. ReverseIterator
 	template<typename T>
 	bool operator==(Iterator<T>& a, ReverseIterator<T>& b) {
-		return a._node == b._iter->_node;
+		return a._node == b._node;
 	}
 
 	template<typename T>
 	bool operator!=(Iterator<T>& a, ReverseIterator<T>& b) {
-		return a._node != b._iter->_node;
+		return a._node != b._node;
 	}
 
 	// == and != are commutative
@@ -349,34 +351,34 @@ namespace ListInternal {
 	// ReverseIterator vs ConstIterator
 	template<typename T>
 	bool operator==(const ReverseIterator<T>& a, const ConstIterator<T>& b) {
-		return a._iter->_node == b._node;
+		return a._node == b._node;
 	}
 
 	template<typename T>
 	bool operator!=(const ReverseIterator<T>& a, const ConstIterator<T>& b) {
-		return a._iter->_node != b._node;
+		return a._node != b._node;
 	}
 
 	// == and != are commutative
 	template<typename T>
 	bool operator==(const ConstIterator<T>& a, const ReverseIterator<T>& b) {
-		return a._iter->_node == b._node;
+		return a._node == b._node;
 	}
 
 	template<typename T>
 	bool operator!=(const ConstIterator<T>& a, const ReverseIterator<T>& b) {
-		return a._iter->_node != b._node;
+		return a._node != b._node;
 	}
 
 	// Iterator vs. ConstReverseIterator
 	template<typename T>
 	bool operator==(const Iterator<T>& a, const ConstReverseIterator<T>& b) {
-		return a._node == b._iter->_node;
+		return a._node == b._node;
 	}
 
 	template<typename T>
 	bool operator!=(const Iterator<T>& a, const ConstReverseIterator<T>& b) {
-		return a._node != b._iter->_node;
+		return a._node != b._node;
 	}
 }
 

--- a/test/common/list.h
+++ b/test/common/list.h
@@ -207,7 +207,6 @@ class ListTestSuite : public CxxTest::TestSuite
 	void test_reverse() {
 		Common::List<int> container;
 		Common::List<int>::reverse_iterator iter;
-		Common::List<int>::iterator iter2;
 
 		// Fill the container with some random data
 		container.push_back(17);
@@ -230,17 +229,17 @@ class ListTestSuite : public CxxTest::TestSuite
 		++iter;
 		TS_ASSERT_EQUALS(iter, container.end());
 
-		iter2 = container.reverse_begin();
+		iter = container.reverse_begin();
 
-		iter = container.reverse_erase(iter2);
-		TS_ASSERT_DIFFERS(iter2, container.end());
-		TS_ASSERT_EQUALS(*iter2, 33);
+		iter = container.erase(iter);
+		TS_ASSERT_DIFFERS(iter, container.end());
+		TS_ASSERT_EQUALS(*iter, 33);
 
-		iter2 = container.reverse_erase(iter2);
-		TS_ASSERT_DIFFERS(iter2, container.end());
-		TS_ASSERT_EQUALS(*iter2, 17);
+		iter = container.erase(iter);
+		TS_ASSERT_DIFFERS(iter, container.end());
+		TS_ASSERT_EQUALS(*iter, 17);
 
-		iter2 = container.reverse_erase(iter2);
+		iter = container.erase(iter);
 		TS_ASSERT_EQUALS(iter, container.end());
 
 		TS_ASSERT_EQUALS(container.begin(), container.end());

--- a/test/module.mk
+++ b/test/module.mk
@@ -32,7 +32,7 @@ test/runner: test/runner.cpp $(TEST_LIBS)
 	$(QUIET_LINK)$(CXX) $(TEST_CXXFLAGS) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ $+ $(TEST_LDFLAGS)
 test/runner.cpp: $(TESTS)
 	@mkdir -p test
-	$(srcdir)/test/cxxtest/cxxtestgen.py $(TEST_FLAGS) -o $@ $+
+	python $(srcdir)/test/cxxtest/cxxtestgen.py $(TEST_FLAGS) -o $@ $+
 
 
 clean: clean-test


### PR DESCRIPTION
I implemented a reverse_iterator class for common.list. I still need to do some unit testing in order to make sure all the operators are working correctly, but I wanted to go ahead and do a pull request to see your thoughts on the topic.

ScummVM builds fine, but most of the engines fail due to reverse_begin and reverse_end returning a reverse_iterator object instead of an iterator object
