### PR TITLE
NEVERHOOD: Fix incorrect dark palette in Scene2206

### DIFF
--- a/engines/neverhood/modules/module2200.cpp
+++ b/engines/neverhood/modules/module2200.cpp
@@ -1586,7 +1586,7 @@ void Scene2206::klaymenInFrontSpikes() {
 }
 
 void Scene2206::klaymenBehindSpikes() {
-	if (!getGlobalVar(V_LIGHTS_ON)) {
+	if (getGlobalVar(V_LIGHTS_ON)) {
 		_palette->addBasePalette(0xB103B604, 0, 65, 0);
 		_palette->startFadeToPalette(12);
 	}


### PR DESCRIPTION
In the Hall of Records, when getting to/from behind the spikes when the room is dark, the palette is incorrectly switched to the 'light' one.

This is due to a misplaced `!`
