### PR TITLE
VIDEO: Wrap 8-bit smacker audio properly

### DIFF
--- a/video/smk_decoder.cpp
+++ b/video/smk_decoder.cpp
@@ -821,8 +821,9 @@ void SmackerDecoder::SmackerAudioTrack::queueCompressedBuffer(byte *buffer, uint
 		// (the exact opposite to the base values)
 		if (!is16Bits) {
 			for (int k = 0; k < (isStereo ? 2 : 1); k++) {
-				bases[k] += (int8) ((int16) audioTrees[k]->getCode(audioBS));
-				*curPointer++ = CLIP<int>(bases[k], 0, 255) ^ 0x80;
+				int8 delta = (int8) ((int16) audioTrees[k]->getCode(audioBS));
+				bases[k] = (bases[k] + delta) & 0xFF;
+				*curPointer++ = bases[k] ^ 0x80;
 				curPos++;
 			}
 		} else {


### PR DESCRIPTION
The accumulator 'bases' is 16-bit but when used in 8-bit audio we need to wrap as if 'bases' is 8-bit. Clipping on output is no longer required.

This fixes noise in The Neverhood's in-game "making of" videos, particularly the section called "Construction, powertools & painting", hash 0x21080009.

The intro video in The Neverhood is 16-bit audio and was not affected by this bug. No other videos or games have been tested.
