### PR TITLE
BACKENDS: fix FTBFS on GNU Hurd by replacing MAXHOSTNAMELEN with NI_MAXHOST

### DIFF
--- a/backends/midi/timidity.cpp
+++ b/backends/midi/timidity.cpp
@@ -148,7 +148,7 @@ MidiDriver_TIMIDITY::MidiDriver_TIMIDITY() {
 
 int MidiDriver_TIMIDITY::open() {
 	char *res;
-	char timidity_host[MAXHOSTNAMELEN];
+	char timidity_host[NI_MAXHOST];
 	int timidity_port, data_port, i;
 
 	/* count ourselves open */


### PR DESCRIPTION
Bug-ScummVM: https://sourceforge.net/tracker/?func=detail&atid=418820&aid=3614268&group_id=37116

See more in similar http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=387665
