### PR TITLE
Video decoder access changes

### DIFF
--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -225,7 +225,7 @@ private:
 
 	void runHandle(uint32 tag);
 	void handleList();
-	void handleStreamHeader();
+	virtual void handleStreamHeader();
 };
 
 } // End of namespace Video


### PR DESCRIPTION
A small change to the avi_decoder class that makes handleStreamHeader() virtual so it can be overridden by inheritors. Z-engine has a somewhat custom avi format and as such needs to override the header handling.
