### PR TITLE
VIDEO: Add an over-ridable wrapper for the AVI audio track handler

### DIFF
--- a/video/avi_decoder.cpp
+++ b/video/avi_decoder.cpp
@@ -100,6 +100,10 @@ AVIDecoder::~AVIDecoder() {
 	close();
 }
 
+AVIDecoder::AVIAudioTrack *AVIDecoder::createAudioTrack(AVIStreamHeader sHeader, PCMWaveFormat wvInfo) {
+	return new AVIAudioTrack(sHeader, wvInfo, _soundType);
+}
+
 void AVIDecoder::runHandle(uint32 tag) {
 	assert(_fileStream);
 	if (_fileStream->eos())
@@ -251,7 +255,7 @@ void AVIDecoder::handleStreamHeader() {
 		if (wvInfo.channels == 2)
 			sHeader.sampleSize /= 2;
 
-		addTrack(new AVIAudioTrack(sHeader, wvInfo, _soundType));
+		addTrack(createAudioTrack(sHeader, wvInfo));
 	}
 
 	// Ensure that we're at the end of the chunk

--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -66,7 +66,6 @@ public:
 protected:
 	 void readNextPacket();
 
-private:
 	struct BitmapInfoHeader {
 		uint32 size;
 		uint32 width;
@@ -175,7 +174,6 @@ private:
 	protected:
 		Common::Rational getFrameRate() const { return Common::Rational(_vidsHeader.rate, _vidsHeader.scale); }
 
-	private:
 		AVIStreamHeader _vidsHeader;
 		BitmapInfoHeader _bmInfo;
 		byte _palette[3 * 256];
@@ -192,13 +190,12 @@ private:
 		AVIAudioTrack(const AVIStreamHeader &streamHeader, const PCMWaveFormat &waveFormat, Audio::Mixer::SoundType soundType);
 		~AVIAudioTrack();
 
-		void queueSound(Common::SeekableReadStream *stream);
+		virtual void queueSound(Common::SeekableReadStream *stream);
 		Audio::Mixer::SoundType getSoundType() const { return _soundType; }
 
 	protected:
 		Audio::AudioStream *getAudioStream() const;
 
-	private:
 		// Audio Codecs
 		enum {
 			kWaveFormatNone = 0,
@@ -226,6 +223,9 @@ private:
 	void runHandle(uint32 tag);
 	void handleList();
 	void handleStreamHeader();
+
+	public:
+		virtual AVIAudioTrack *createAudioTrack(AVIStreamHeader sHeader, PCMWaveFormat wvInfo);
 };
 
 } // End of namespace Video


### PR DESCRIPTION
This is an alternative way to implement the changes suggested in
PR #340, which avoids code duplication of common code at the
engine level.

This is based on a suggestion made by clone2727, so the original
idea belongs to him.
Engines can now override the common AVI audio track handler with a
custom one. This is needed for the Z-Engine AVI videos, since they
use a custom audio decoder that is only used in the two Z-Engine
games, and has its own fake AVI audio format (17). This clashes with
the MS IMA ADPCM format, and therefore shouldn't pollute the common
AVI video decoder code. The addition of this over-ridable method
allows the Z-Engine to add its own custom AVI decoder while avoiding
code duplication.
