### PR TITLE
SCUMM: More precise Player_Mac::durationToSamples

### DIFF
--- a/engines/scumm/player_mac.cpp
+++ b/engines/scumm/player_mac.cpp
@@ -289,12 +289,16 @@ uint32 Player_Mac::durationToSamples(uint16 duration) {
 	// (duration * 473 * _sampleRate) / (4 * 480 * 480)
 	//
 	// But that's likely to cause integer overflow, so we do it in two
-	// steps and hope that the rounding error won't be noticeable.
+	// steps using bitwise operations to perform
+	// ((duration * 473 * _sampleRate) / 4096) without overflowing,
+	// then divide this by 225
+	// (note that 4 * 480 * 480 == 225 * 4096 == 225 << 12)
 	//
 	// The original code is a bit unclear on if it should be 473 or 437,
 	// but since the comments indicated 473 I'm assuming 437 was a typo.
-	uint32 samples = (duration * _sampleRate) / (4 * 480);
-	samples = (samples * 473) / 480;
+	uint32 samples = (duration * _sampleRate);
+	samples = (samples >> 12) * 473 + (((samples & 4095) * 473) >> 12);
+	samples = samples / 225;
 	return samples;
 }
 


### PR DESCRIPTION
Untested, but the largest result in the whole calculation is `duration * _sampleRate`, so as long as it's divided by something greater than 473, the calculation is no more likely to overflow.

Note: the calculation could be made even more accurate by doing:

```
(s * 473 / 480) / (4*480)
= (s - s*7/480) / (4*480)
~= (s - s/60 + s/480) / (4*480)
```

But this comes at the cost of an additional division.  It would also require more tweaking should 473 turn out to be 437.  It's perhaps no better a solution than going to 64-bit math.

EDIT: made a faster and more accurate version using bitwise operations
