### PR TITLE
JANITORIAL: Add [Debug|Release][32|64] to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,10 @@ ipch/
 #Ignore default Visual Studio build folders
 [Dd]ebug/
 [Rr]elease/
+[Dd]ebug32/
+[Rr]elease32/
+[Dd]ebug64/
+[Rr]elease64/
 
 #Ignore Qt Creator project files
 ScummVM.config


### PR DESCRIPTION
MSVC11 seems to be using these as new default when running on x64.
