### PR TITLE
ALL: Don't use EventRecorder at all when not compiled in

### DIFF
--- a/audio/mixer.cpp
+++ b/audio/mixer.cpp
@@ -429,7 +429,11 @@ void MixerImpl::pauseHandle(SoundHandle handle, bool paused) {
 
 bool MixerImpl::isSoundIDActive(int id) {
 	Common::StackLock lock(_mutex);
+
+#ifdef ENABLE_EVENTRECORDER
 	g_eventRec.updateSubsystems();
+#endif
+
 	for (int i = 0; i != NUM_CHANNELS; i++)
 		if (_channels[i] && _channels[i]->getId() == id)
 			return true;
@@ -446,7 +450,11 @@ int MixerImpl::getSoundID(SoundHandle handle) {
 
 bool MixerImpl::isSoundHandleActive(SoundHandle handle) {
 	Common::StackLock lock(_mutex);
+
+#ifdef ENABLE_EVENTRECORDER
 	g_eventRec.updateSubsystems();
+#endif
+
 	const int index = handle._val % NUM_CHANNELS;
 	return _channels[index] && _channels[index]->getHandle()._val == handle._val;
 }

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -142,9 +142,15 @@ void ModularBackend::fillScreen(uint32 col) {
 }
 
 void ModularBackend::updateScreen() {
+#ifdef ENABLE_EVENTRECORDER
 	g_eventRec.preDrawOverlayGui();
+#endif
+
 	_graphicsManager->updateScreen();
+
+#ifdef ENABLE_EVENTRECORDER
 	g_eventRec.postDrawOverlayGui();
+#endif
 }
 
 void ModularBackend::setShakePos(int shakeOffset) {

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -98,7 +98,13 @@ OSystem_SDL::~OSystem_SDL() {
 	delete _mixerManager;
 	_mixerManager = 0;
 
+#ifdef ENABLE_EVENTRECORDER
+	// HACK HACK HACK
+	// This is nasty.
 	delete g_eventRec.getTimerManager();
+#else
+	delete _timerManager;
+#endif
 
 	_timerManager = 0;
 	delete _mutexManager;
@@ -193,9 +199,15 @@ void OSystem_SDL::initBackend() {
 		// Setup and start mixer
 		_mixerManager->init();
 	}
+
+#ifdef ENABLE_EVENTRECORDER
 	g_eventRec.registerMixerManager(_mixerManager);
 
 	g_eventRec.registerTimerManager(new SdlTimerManager());
+#else
+	if (_timerManager == 0)
+		_timerManager = new SdlTimerManager();
+#endif
 
 	if (_audiocdManager == 0) {
 		// Audio CD support was removed with SDL 1.3
@@ -470,12 +482,18 @@ void OSystem_SDL::setupIcon() {
 
 uint32 OSystem_SDL::getMillis(bool skipRecord) {
 	uint32 millis = SDL_GetTicks();
+
+#ifdef ENABLE_EVENTRECORDER
 	g_eventRec.processMillis(millis, skipRecord);
+#endif
+
 	return millis;
 }
 
 void OSystem_SDL::delayMillis(uint msecs) {
+#ifdef ENABLE_EVENTRECORDER
 	if (!g_eventRec.processDelayMillis())
+#endif
 		SDL_Delay(msecs);
 }
 
@@ -498,11 +516,20 @@ Audio::Mixer *OSystem_SDL::getMixer() {
 
 SdlMixerManager *OSystem_SDL::getMixerManager() {
 	assert(_mixerManager);
+
+#ifdef ENABLE_EVENTRECORDER
 	return g_eventRec.getMixerManager();
+#else
+	return _mixerManager;
+#endif
 }
 
 Common::TimerManager *OSystem_SDL::getTimerManager() {
+#ifdef ENABLE_EVENTRECORDER
 	return g_eventRec.getTimerManager();
+#else
+	return _timerManager;
+#endif
 }
 
 #ifdef USE_OPENGL

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -427,6 +427,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	// take place after the backend is initiated and the screen has been setup
 	system.getEventManager()->init();
 
+#ifdef ENABLE_EVENTRECORDER
 	// Directly after initializing the event manager, we will initialize our
 	// event recorder.
 	//
@@ -434,6 +435,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	// our event recorder, we might do this at another place. Or even change
 	// the whole API for that ;-).
 	g_eventRec.RegisterEventSource();
+#endif
 
 	// Now as the event manager is created, setup the keymapper
 	setupKeymapper(system);
@@ -471,9 +473,11 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 			// Try to run the game
 			Common::Error result = runGame(plugin, system, specialDebug);
 
+#ifdef ENABLE_EVENTRECORDER
 			// Flush Event recorder file. The recorder does not get reinitialized for next game
 			// which is intentional. Only single game per session is allowed.
 			g_eventRec.deinit();
+#endif
 
 		#if defined(UNCACHED_PLUGINS) && defined(DYNAMIC_MODULES)
 			// do our best to prevent fragmentation by unloading as soon as we can
@@ -526,7 +530,9 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	GUI::GuiManager::destroy();
 	Common::ConfigManager::destroy();
 	Common::DebugManager::destroy();
+#ifdef ENABLE_EVENTRECORDER
 	GUI::EventRecorder::destroy();
+#endif
 	Common::SearchManager::destroy();
 #ifdef USE_TRANSLATION
 	Common::TranslationManager::destroy();

--- a/common/random.cpp
+++ b/common/random.cpp
@@ -30,8 +30,12 @@ RandomSource::RandomSource(const String &name) {
 	// Use system time as RNG seed. Normally not a good idea, if you are using
 	// a RNG for security purposes, but good enough for our purposes.
 	assert(g_system);
-	uint32 seed = g_eventRec.getRandomSeed(name);
-	setSeed(seed);
+
+#ifdef ENABLE_EVENTRECORDER
+	setSeed(g_eventRec.getRandomSeed(name));
+#else
+	setSeed(g_system->getMillis());
+#endif
 }
 
 void RandomSource::setSeed(uint32 seed) {

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -609,7 +609,9 @@ AdvancedMetaEngine::AdvancedMetaEngine(const void *descs, uint descItemSize, con
 }
 
 void AdvancedMetaEngine::initSubSystems(const ADGameDescription *gameDesc) const {
+#ifdef ENABLE_EVENTRECORDER
 	if (gameDesc) {
 		g_eventRec.processGameDescription(gameDesc);
 	}
+#endif
 }

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -23,11 +23,11 @@
 
 #include "gui/EventRecorder.h"
 
+#ifdef ENABLE_EVENTRECORDER
+
 namespace Common {
 DECLARE_SINGLETON(GUI::EventRecorder);
 }
-
-#ifdef ENABLE_EVENTRECORDER
 
 #include "common/debug-channels.h"
 #include "backends/timer/sdl/sdl-timer.h"

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -233,61 +233,6 @@ private:
 
 } // End of namespace GUI
 
-#else
-
-#ifdef SDL_BACKEND
-#include "backends/timer/default/default-timer.h"
-#include "backends/mixer/sdl/sdl-mixer.h"
-#endif
-
-#define g_eventRec (GUI::EventRecorder::instance())
-
-namespace GUI {
-
-class EventRecorder : private Common::EventSource, public Common::Singleton<EventRecorder>, private Common::DefaultEventMapper {
-	friend class Common::Singleton<SingletonBaseType>;
-
-  public:
-	EventRecorder() {
-#ifdef SDL_BACKEND
-	  _timerManager = NULL;
-	  _realMixerManager = NULL;
-#endif
-	}
-	~EventRecorder() {}
-
-	bool pollEvent(Common::Event &ev) { return false; }
-	void RegisterEventSource() {}
-	void deinit() {}
-	void suspendRecording() {}
-	void resumeRecording() {}
-	void preDrawOverlayGui() {}
-	void postDrawOverlayGui() {}
-	void processGameDescription(const ADGameDescription *desc) {}
-	void updateSubsystems() {}
-	uint32 getRandomSeed(const Common::String &name) { return g_system->getMillis(); }
-	Common::SaveFileManager *getSaveManager(Common::SaveFileManager *realSaveManager) { return realSaveManager; }
-
-#ifdef SDL_BACKEND
-  private:
-	DefaultTimerManager *_timerManager;
-	SdlMixerManager *_realMixerManager;
-
-  public:
-	DefaultTimerManager *getTimerManager() { return _timerManager; }
-	void registerTimerManager(DefaultTimerManager *timerManager) { _timerManager = timerManager; }
-
-	SdlMixerManager *getMixerManager() { return _realMixerManager; }
-	void registerMixerManager(SdlMixerManager *mixerManager) { _realMixerManager = mixerManager; }
-
-	void processMillis(uint32 &millis, bool skipRecord) {}
-	bool processDelayMillis() { return false; }
-#endif
-
-};
-
-} // namespace GUI
-
 #endif // ENABLE_EVENTRECORDER
 
 #endif

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -258,8 +258,10 @@ void GuiManager::runLoop() {
 	if (activeDialog == 0)
 		return;
 
+#ifdef ENABLE_EVENTRECORDER
 	// Suspend recording while GUI is shown
 	g_eventRec.suspendRecording();
+#endif
 
 	if (!_stateIsSaved) {
 		saveState();
@@ -361,8 +363,10 @@ void GuiManager::runLoop() {
 		_useStdCursor = false;
 	}
 
+#ifdef ENABLE_EVENTRECORDER
 	// Resume recording once GUI is shown
 	g_eventRec.resumeRecording();
+#endif
 }
 
 #pragma mark -


### PR DESCRIPTION
This adds an ENABLE_EVENTRECORDER ifdef check around any g_eventRec call and also removes the dummy EventRecorder class. This brings the class more in line with what we do with ie. TranslationManager where it doesn't exist if it's not configured to be built.

In addition, this also fixes TimerManager not being destroyed properly when EventRecorder support is not compiled in. This broke OpenGL modes and would crash on quit when using it.
