### PR TITLE
GRAPHICS: Allow arbitrary input sizes for thumbnail scaling.

### DIFF
--- a/graphics/scaler.h
+++ b/graphics/scaler.h
@@ -89,10 +89,4 @@ extern bool createThumbnailFromScreen(Graphics::Surface *surf);
  */
 extern bool createThumbnail(Graphics::Surface *surf, const uint8 *pixels, int w, int h, const uint8 *palette);
 
-/**
- * Downscale screenshot to thumbnale size.
- *
- */
-extern bool createThumbnail(Graphics::Surface &out, Graphics::Surface &in);
-
 #endif


### PR DESCRIPTION
Instead of a fixed 1/2 or 1/4 scaling we do a two step scaling now:
1) Scale image to width < 160_2 && height < [100,120]_2 with 1/4 or 1/2
   nearest-neighbor.
2) Use a bilinear scaler to scale aspect preserving to 160x[100,120]

This fixes bug #3614568 "GRAPHICS: Odd thumbnail sizes crash".

This is a completely hacked up implementation based on some old code from 2011. Any feedback is appreciated.
