### PR TITLE
WINTERMUTE: Remove fixedPath snippet

### DIFF
--- a/engines/wintermute/base/file/base_disk_file.cpp
+++ b/engines/wintermute/base/file/base_disk_file.cpp
@@ -66,12 +66,6 @@ static Common::FSNode getNodeForRelativePath(const Common::String &filename) {
 		const Common::FSNode gameDataDir(ConfMan.get("path"));
 		Common::FSNode curNode = gameDataDir;
 
-		Common::String fixedPath = "";
-		while (!path.empty()) {
-			fixedPath += path.nextToken() + "/";
-		}
-		fixedPath.deleteLastChar();
-
 		// Parse all path-elements
 		while (!path.empty()) {
 			// Get the next path-component by slicing on '\\'


### PR DESCRIPTION
fixedPath is apparently never used anywhere else in the class and this
loop can cause the next one to never get to run.
