### PR TITLE
BUILD: fix 'make test' compile error

### DIFF
--- a/test/audio/raw.h
+++ b/test/audio/raw.h
@@ -1,6 +1,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "audio/decoders/raw.h"
+#include "audio/audiostream.h"
 
 #include "helper.h"
 


### PR DESCRIPTION
Without this, I get this:

```
In file included from test/runner.cpp:1340:
./test/audio/raw.h: In member function ‘void RawStreamTestSuite::readBufferTestTemplate(int, int, bool, bool)’:
./test/audio/raw.h:17: error: invalid use of incomplete type ‘struct Audio::SeekableAudioStream’
./audio/decoders/raw.h:38: error: forward declaration of ‘struct Audio::SeekableAudioStream’
./test/audio/raw.h:19: error: invalid use of incomplete type ‘struct Audio::SeekableAudioStream’
./audio/decoders/raw.h:38: error: forward declaration of ‘struct Audio::SeekableAudioStream’
...
```
