### PR TITLE
NEVERHOOD: Remove NRect constructor

### DIFF
--- a/engines/neverhood/graphics.h
+++ b/engines/neverhood/graphics.h
@@ -43,9 +43,11 @@ struct NDimensions {
 struct NRect {
 	int16 x1, y1, x2, y2;
 
-	NRect() : x1(0), y1(0), x2(0), y2(0) {}
-
-	NRect(int16 x01, int16 y01, int16 x02, int16 y02) : x1(x01), y1(y01), x2(x02), y2(y02) {}
+    static NRect make(int16 x01, int16 y01, int16 x02, int16 y02) {
+        NRect r;
+        r.set(x01, y01, x02, y02);
+		return r;
+    }
 
 	void set(int16 x01, int16 y01, int16 x02, int16 y02) {
 		x1 = x01;

--- a/engines/neverhood/menumodule.cpp
+++ b/engines/neverhood/menumodule.cpp
@@ -338,15 +338,15 @@ MainMenu::MainMenu(NeverhoodEngine *vm, Module *parentModule)
 	};
 
 	static const NRect kMenuButtonCollisionBounds[] = {
-		NRect(52, 121, 110, 156),
-		NRect(52, 192, 109, 222),
-		NRect(60, 257, 119, 286),
-		NRect(67, 326, 120, 354),
-		NRect(70, 389, 128, 416),
-		NRect(523, 113, 580, 144),
-		NRect(525, 176, 577, 206),
-		NRect(527, 384, 580, 412),
-		NRect(522, 255, 580, 289)
+		{  52, 121, 110, 156 },
+		{  52, 192, 109, 222 },
+		{  60, 257, 119, 286 },
+		{  67, 326, 120, 354 },
+		{  70, 389, 128, 416 },
+		{ 523, 113, 580, 144 },
+		{ 525, 176, 577, 206 },
+		{ 527, 384, 580, 412 },
+		{ 522, 255, 580, 289 }
 	};
 
 	setBackground(0x08C0020C);
@@ -1026,17 +1026,17 @@ static const uint32 kSaveGameMenuButtonFileHashes[] = {
 };
 
 static const NRect kSaveGameMenuButtonCollisionBounds[] = {
-	NRect(518, 106, 602, 160),
-	NRect(516, 378, 596, 434),
-	NRect(394, 108, 458, 206),
-	NRect(400, 204, 458, 276),
-	NRect(398, 292, 456, 352),
-	NRect(396, 352, 460, 444)
+	{ 518, 106, 602, 160 },
+	{ 516, 378, 596, 434 },
+	{ 394, 108, 458, 206 },
+	{ 400, 204, 458, 276 },
+	{ 398, 292, 456, 352 },
+	{ 396, 352, 460, 444 }
 };
 
-static const NRect kSaveGameMenuListBoxRect(0, 0, 320, 272);
-static const NRect kSaveGameMenuTextEditRect(0, 0, 377, 17);
-static const NRect kSaveGameMenuMouseRect(50, 47, 427, 64);
+static const NRect kSaveGameMenuListBoxRect = { 0, 0, 320, 272 };
+static const NRect kSaveGameMenuTextEditRect = { 0, 0, 377, 17 };
+static const NRect kSaveGameMenuMouseRect = { 50, 47, 427, 64 };
 
 SaveGameMenu::SaveGameMenu(NeverhoodEngine *vm, Module *parentModule, SavegameList *savegameList)
 	:  GameStateMenu(vm, parentModule, savegameList, kSaveGameMenuButtonFileHashes, kSaveGameMenuButtonCollisionBounds,
@@ -1060,17 +1060,17 @@ static const uint32 kLoadGameMenuButtonFileHashes[] = {
 };
 
 static const NRect kLoadGameMenuButtonCollisionBounds[] = {
-	NRect( 44, 115, 108, 147),
-	NRect( 52, 396, 112, 426),
-	NRect(188, 116, 245, 196),
-	NRect(189, 209, 239, 269),
-	NRect(187, 301, 233, 349),
-	NRect(182, 358, 241, 433)
+	{  44, 115, 108, 147 },
+	{  52, 396, 112, 426 },
+	{ 188, 116, 245, 196 },
+	{ 189, 209, 239, 269 },
+	{ 187, 301, 233, 349 },
+	{ 182, 358, 241, 433 }
 };
 
-static const NRect kLoadGameMenuListBoxRect(0, 0, 320, 271);
-static const NRect kLoadGameMenuTextEditRect(0, 0, 320, 17);
-static const NRect kLoadGameMenuMouseRect(263, 48, 583, 65);
+static const NRect kLoadGameMenuListBoxRect = { 0, 0, 320, 271 };
+static const NRect kLoadGameMenuTextEditRect = { 0, 0, 320, 17 };
+static const NRect kLoadGameMenuMouseRect = { 263, 48, 583, 65 };
 
 LoadGameMenu::LoadGameMenu(NeverhoodEngine *vm, Module *parentModule, SavegameList *savegameList)
 	: GameStateMenu(vm, parentModule, savegameList, kLoadGameMenuButtonFileHashes, kLoadGameMenuButtonCollisionBounds,
@@ -1093,16 +1093,16 @@ static const uint32 kDeleteGameMenuButtonFileHashes[] = {
 };
 
 static const NRect kDeleteGameMenuButtonCollisionBounds[] = {
-	NRect(518,  46, 595,  91),
-	NRect(524, 322, 599, 369),
-	NRect(395,  40, 462, 127),
-	NRect(405, 126, 460, 185),
-	NRect(397, 205, 456, 273),
-	NRect(395, 278, 452, 372)
+	{ 518,  46, 595,  91 },
+	{ 524, 322, 599, 369 },
+	{ 395,  40, 462, 127 },
+	{ 405, 126, 460, 185 },
+	{ 397, 205, 456, 273 },
+	{ 395, 278, 452, 372 }
 };
 
-static const NRect kDeleteGameMenuListBoxRect(0, 0, 320, 271);
-static const NRect kDeleteGameMenuTextEditRect(0, 0, 320, 17);
+static const NRect kDeleteGameMenuListBoxRect = { 0, 0, 320, 271 };
+static const NRect kDeleteGameMenuTextEditRect = { 0, 0, 320, 17 };
 
 DeleteGameMenu::DeleteGameMenu(NeverhoodEngine *vm, Module *parentModule, SavegameList *savegameList)
 	: GameStateMenu(vm, parentModule, savegameList, kDeleteGameMenuButtonFileHashes, kDeleteGameMenuButtonCollisionBounds,
@@ -1128,8 +1128,8 @@ QueryOverwriteMenu::QueryOverwriteMenu(NeverhoodEngine *vm, Module *parentModule
 	};
 
 	static const NRect kQueryOverwriteMenuCollisionBounds[] = {
-		NRect(145, 334, 260, 385),
-		NRect(365, 340, 477, 388)
+		{ 145, 334, 260, 385 },
+		{ 365, 340, 477, 388 }
 	};
 
 	setBackground(0x043692C4);

--- a/engines/neverhood/modules/module1100.cpp
+++ b/engines/neverhood/modules/module1100.cpp
@@ -555,19 +555,19 @@ void Scene1105::createObjects() {
 	_ssSymbolDice[1] = insertSprite<SsScene1105SymbolDie>(1, 339, 304);
 	_ssSymbolDice[2] = insertSprite<SsScene1105SymbolDie>(2, 485, 304);
 
-	_ssSymbol1UpButton = insertSprite<SsScene1105Button>(this, 0x08002860, NRect(146, 362, 192, 403));
+	_ssSymbol1UpButton = insertSprite<SsScene1105Button>(this, 0x08002860, NRect::make(146, 362, 192, 403));
 	addCollisionSprite(_ssSymbol1UpButton);
-	_ssSymbol1DownButton = insertSprite<SsScene1105Button>(this, 0x42012460, NRect(147, 404, 191, 442));
+	_ssSymbol1DownButton = insertSprite<SsScene1105Button>(this, 0x42012460, NRect::make(147, 404, 191, 442));
 	addCollisionSprite(_ssSymbol1DownButton);
-	_ssSymbol2UpButton = insertSprite<SsScene1105Button>(this, 0x100030A0, NRect(308, 361, 355, 402));
+	_ssSymbol2UpButton = insertSprite<SsScene1105Button>(this, 0x100030A0, NRect::make(308, 361, 355, 402));
 	addCollisionSprite(_ssSymbol2UpButton);
-	_ssSymbol2DownButton = insertSprite<SsScene1105Button>(this, 0x840228A0, NRect(306, 406, 352, 445));
+	_ssSymbol2DownButton = insertSprite<SsScene1105Button>(this, 0x840228A0, NRect::make(306, 406, 352, 445));
 	addCollisionSprite(_ssSymbol2DownButton);
-	_ssSymbol3UpButton = insertSprite<SsScene1105Button>(this, 0x20000120, NRect(476, 358, 509, 394));
+	_ssSymbol3UpButton = insertSprite<SsScene1105Button>(this, 0x20000120, NRect::make(476, 358, 509, 394));
 	addCollisionSprite(_ssSymbol3UpButton);
-	_ssSymbol3DownButton = insertSprite<SsScene1105Button>(this, 0x08043121, NRect(463, 401, 508, 438));
+	_ssSymbol3DownButton = insertSprite<SsScene1105Button>(this, 0x08043121, NRect::make(463, 401, 508, 438));
 	addCollisionSprite(_ssSymbol3DownButton);
-	_ssActionButton = insertSprite<SsScene1105Button>(this, 0x8248AD35, NRect(280, 170, 354, 245));
+	_ssActionButton = insertSprite<SsScene1105Button>(this, 0x8248AD35, NRect::make(280, 170, 354, 245));
 	addCollisionSprite(_ssActionButton);
 
 	_isPanelOpen = true;

--- a/engines/neverhood/modules/module2400.cpp
+++ b/engines/neverhood/modules/module2400.cpp
@@ -168,11 +168,11 @@ static const uint32 kScene2401FileHashes3[] = {
 };
 
 static const NRect kScene2401Rects[] = {
-	NRect(369, 331, 394, 389),
-	NRect(395, 331, 419, 389),
-	NRect(420, 331, 441, 389),
-	NRect(442, 331, 464, 389),
-	NRect(465, 331, 491, 389)
+	{ 369, 331, 394, 389 },
+	{ 395, 331, 419, 389 },
+	{ 420, 331, 441, 389 },
+	{ 442, 331, 464, 389 },
+	{ 465, 331, 491, 389 }
 };
 
 static const uint32 kAsScene2401WaterSpitFileHashes2[] = {

--- a/engines/neverhood/modules/module2500.cpp
+++ b/engines/neverhood/modules/module2500.cpp
@@ -29,25 +29,25 @@ static const uint32 kScene2505StaticSprites[] = {
 	0x4000A226, 0
 };
 
-static const NRect kScene2505ClipRect = NRect(0, 0, 564, 480);
+static const NRect kScene2505ClipRect = { 0, 0, 564, 480 };
 
 static const uint32 kScene2506StaticSprites[] = {
 	0x4027AF02, 0
 };
 
-static const NRect kScene2506ClipRect = NRect(0, 0, 640, 441);
+static const NRect kScene2506ClipRect = { 0, 0, 640, 441 };
 
 static const uint32 kScene2508StaticSprites1[] = {
 	0x2F08E610, 0xD844E6A0, 0
 };
 
-static const NRect kScene2508ClipRect1 = NRect(0, 0, 594, 448);
+static const NRect kScene2508ClipRect1 = { 0, 0, 594, 448 };
 
 static const uint32 kScene2508StaticSprites2[] = {
 	0x2F08E610, 0
 };
 
-static const NRect kScene2508ClipRect2 = NRect(0, 0, 594, 448);
+static const NRect kScene2508ClipRect2 = { 0, 0, 594, 448 };
 
 Module2500::Module2500(NeverhoodEngine *vm, Module *parentModule, int which)
 	: Module(vm, parentModule), _soundIndex(0) {

--- a/engines/neverhood/modules/module2700.cpp
+++ b/engines/neverhood/modules/module2700.cpp
@@ -26,14 +26,14 @@
 
 namespace Neverhood {
 
-static const NRect kScene2710ClipRect = NRect(0, 0, 626, 480);
+static const NRect kScene2710ClipRect = { 0, 0, 626, 480 };
 
 static const uint32 kScene2710StaticSprites[] = {
 	0x0D2016C0,
 	0
 };
 
-static const NRect kScene2711ClipRect = NRect(0, 0, 521, 480);
+static const NRect kScene2711ClipRect = { 0, 0, 521, 480 };
 
 static const uint32 kScene2711FileHashes1[] = {
 	0,
@@ -68,14 +68,14 @@ static const uint32 kScene2711FileHashes3[] = {
 	0
 };
 
-static const NRect kScene2724ClipRect = NRect(0, 141, 640, 480);
+static const NRect kScene2724ClipRect = { 0, 141, 640, 480 };
 
 static const uint32 kScene2724StaticSprites[] = {
 	0xC20D00A5,
 	0
 };
 
-static const NRect kScene2725ClipRect = NRect(0, 0, 640, 413);
+static const NRect kScene2725ClipRect = { 0, 0, 640, 413 };
 
 static const uint32 kScene2725StaticSprites[] = {
 	0xC20E00A5,

--- a/engines/neverhood/scene.cpp
+++ b/engines/neverhood/scene.cpp
@@ -212,7 +212,7 @@ Sprite *Scene::insertStaticSprite(uint32 fileHash, int surfacePriority) {
 }
 
 void Scene::insertScreenMouse(uint32 fileHash, const NRect *mouseRect) {
-	NRect rect(-1, -1, -1, -1);
+	NRect rect = NRect::make(-1, -1, -1, -1);
 	if (mouseRect)
 		rect = *mouseRect;
 	insertMouse(new Mouse(_vm, fileHash, rect));


### PR DESCRIPTION
Otherwise, every global variable of type NRect requires a constructor to be
run, which can cause portability issue.

Indeed, -Wglobal-constructors is added by the ScummVM build system for compilers that support it, to flag instances of this.
