### PR TITLE
Proof-of-Concept: Config manager notifications

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -827,9 +827,8 @@ void upgradeTargets() {
 
 	printf("Upgrading all your existing targets\n");
 
-	Common::ConfigManager::DomainMap &domains = ConfMan.getGameDomains();
-	Common::ConfigManager::DomainMap::iterator iter = domains.begin();
-	for (iter = domains.begin(); iter != domains.end(); ++iter) {
+	Common::ConfigManager::DomainMap::iterator iter = ConfMan.beginGameDomains();
+	for (; iter != ConfMan.endGameDomains(); ++iter) {
 		Common::ConfigManager::Domain &dom = iter->_value;
 		Common::String name(iter->_key);
 		Common::String gameid(dom.getVal("gameid"));

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -891,13 +891,13 @@ void upgradeTargets() {
 		// the target referred to by dom. We update several things
 
 		// Always set the gameid explicitly (in case of legacy targets)
-		dom["gameid"] = g->gameid();
+		dom.setVal("gameid", g->gameid());
 
 		// Always set the GUI options. The user should not modify them, and engines might
 		// gain more features over time, so we want to keep this list up-to-date.
 		if (g->contains("guioptions")) {
 			printf("  -> update guioptions to '%s'\n", (*g)["guioptions"].c_str());
-			dom["guioptions"] = (*g)["guioptions"];
+			dom.setVal("guioptions", (*g)["guioptions"]);
 		} else if (dom.contains("guioptions")) {
 			dom.erase("guioptions");
 		}
@@ -905,13 +905,13 @@ void upgradeTargets() {
 		// Update the language setting but only if none has been set yet.
 		if (lang == Common::UNK_LANG && g->language() != Common::UNK_LANG) {
 			printf("  -> set language to '%s'\n", Common::getLanguageCode(g->language()));
-			dom["language"] = (*g)["language"];
+			dom.setVal("language", (*g)["language"]);
 		}
 
 		// Update the platform setting but only if none has been set yet.
 		if (plat == Common::kPlatformUnknown && g->platform() != Common::kPlatformUnknown) {
 			printf("  -> set platform to '%s'\n", Common::getPlatformCode(g->platform()));
-			dom["platform"] = (*g)["platform"];
+			dom.setVal("platform", (*g)["platform"]);
 		}
 
 		// TODO: We could also update the description. But not everybody will want that.

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -325,6 +325,17 @@ static void setupKeymapper(OSystem &system) {
 
 }
 
+static void watcherConfigKey(const Common::String &key, const Common::String &value) {
+	debug("%s change to %s", key.c_str(), value.c_str());
+}
+
+class Test {
+public:
+	void watcherConfigKey(const Common::String &key, const Common::String &value) {
+		debug("Test: %s change to %s", key.c_str(), value.c_str());
+	}
+};
+
 extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	Common::String specialDebug;
 	Common::String command;
@@ -332,6 +343,13 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	// Verify that the backend has been initialized (i.e. g_system has been set).
 	assert(g_system);
 	OSystem &system = *g_system;
+
+	Common::ConfigManager::NotificationCallbackPtr ptr1 = NOTIFICATION_CALLBACK_FUN(watcherConfigKey);
+	ConfMan.addNotificationCallback("gfx_mode", ptr1);
+	// woops leaking memory... but it's just demonstration anyway
+	Test *test = new Test();
+	Common::ConfigManager::NotificationCallbackPtr ptr2 = NOTIFICATION_CALLBACK_MEM(Test, test, watcherConfigKey);
+	ConfMan.addNotificationCallback("mute", ptr2);
 
 	// Register config manager defaults
 	Base::registerDefaults();

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -293,7 +293,7 @@ bool PluginManagerUncached::loadPluginFromGameId(const Common::String &gameId) {
 
 	if (domain) {
 		if (domain->contains(gameId)) {
-			Common::String filename = (*domain)[gameId];
+			Common::String filename = domain->getVal(gameId);
 
 		    if (loadPluginByFileName(filename)) {
 				return true;
@@ -335,7 +335,7 @@ void PluginManagerUncached::updateConfigWithFileName(const Common::String &gameI
 
 		Common::ConfigManager::Domain *domain = ConfMan.getDomain("plugin_files");
 		assert(domain);
-		(*domain)[gameId] = (*_currentPlugin)->getFileName();
+		domain->setVal(gameId, (*_currentPlugin)->getFileName());
 
 		ConfMan.flushToDisk();
 	}

--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -49,6 +49,29 @@ char const *const ConfigManager::kKeymapperDomain = "keymapper";
 
 
 ConfigManager::ConfigManager() : _activeDomain(0) {
+	_transientDomain._owner = this;
+	_appDomain._owner = this;
+	_defaultsDomain._owner = this;
+#ifdef ENABLE_KEYMAPPER
+	_keymapperDomain._owner = this;
+#endif
+}
+
+ConfigManager::~ConfigManager() {
+	// Clear the owner of all domains. This avoids crashes, because when the
+	// domains are getting destroyed the ConfigManager will be dead already.
+	_transientDomain._owner = nullptr;
+	for (DomainMap::iterator i = _gameDomains.begin(), end = _gameDomains.end(); i != end; ++i) {
+		i->_value._owner = nullptr;
+	}
+	for (DomainMap::iterator i = _miscDomains.begin(), end = _miscDomains.end(); i != end; ++i) {
+		i->_value._owner = nullptr;
+	}
+	_appDomain._owner = nullptr;
+	_defaultsDomain._owner = nullptr;
+#ifdef ENABLE_KEYMAPPER
+	_keymapperDomain._owner = nullptr;
+#endif
 }
 
 void ConfigManager::defragment() {
@@ -60,17 +83,28 @@ void ConfigManager::defragment() {
 
 void ConfigManager::copyFrom(ConfigManager &source) {
 	_transientDomain = source._transientDomain;
+	_transientDomain._owner = this;
 	_gameDomains = source._gameDomains;
+	for (DomainMap::iterator i = _gameDomains.begin(), end = _gameDomains.end(); i != end; ++i) {
+		i->_value._owner = this;
+	}
 	_miscDomains = source._miscDomains;
+	for (DomainMap::iterator i = _miscDomains.begin(), end = _miscDomains.end(); i != end; ++i) {
+		i->_value._owner = this;
+	}
 	_appDomain = source._appDomain;
+	_appDomain._owner = this;
 	_defaultsDomain = source._defaultsDomain;
+	_defaultsDomain._owner = this;
 #ifdef ENABLE_KEYMAPPER
 	_keymapperDomain = source._keymapperDomain;
+	_keymapperDomain._owner = this;
 #endif
 	_domainSaveOrder = source._domainSaveOrder;
 	_activeDomainName = source._activeDomainName;
 	_activeDomain = &_gameDomains[_activeDomainName];
 	_filename = source._filename;
+	_notificationCallbacks = source._notificationCallbacks;
 }
 
 
@@ -117,9 +151,11 @@ void ConfigManager::addDomain(const String &domainName, const ConfigManager::Dom
 		return;
 	if (domainName == kApplicationDomain) {
 		_appDomain = domain;
+		_appDomain._owner = this;
 #ifdef ENABLE_KEYMAPPER
 	} else if (domainName == kKeymapperDomain) {
 		_keymapperDomain = domain;
+		_keymapperDomain._owner = this;
 #endif
 	} else if (domain.contains("gameid")) {
 		// If the domain contains "gameid" we assume it's a game domain
@@ -127,6 +163,7 @@ void ConfigManager::addDomain(const String &domainName, const ConfigManager::Dom
 			warning("Game domain %s already exists in ConfigManager", domainName.c_str());
 
 		_gameDomains[domainName] = domain;
+		_gameDomains[domainName]._owner = this;
 
 		_domainSaveOrder.push_back(domainName);
 
@@ -141,6 +178,7 @@ void ConfigManager::addDomain(const String &domainName, const ConfigManager::Dom
 			warning("Misc domain %s already exists in ConfigManager", domainName.c_str());
 
 		_miscDomains[domainName] = domain;
+		_miscDomains[domainName]._owner = this;
 	}
 }
 
@@ -593,13 +631,36 @@ void ConfigManager::registerDefault(const String &key, bool value) {
 
 
 void ConfigManager::setActiveDomain(const String &domName) {
+	// Save the old values in the active domain. These might be different
+	// afterwards.
+	StringMap oldValues;
+	if (_activeDomain) {
+		for (Domain::const_iterator i = _activeDomain->begin(), iend = _activeDomain->end(); i != iend; ++i) {
+			oldValues[i->_key] = get(i->_key);
+		}
+	}
+
 	if (domName.empty()) {
 		_activeDomain = 0;
 	} else {
 		assert(isValidDomainName(domName));
-		_activeDomain = & _gameDomains[domName];
+		Domain *newActiveDomain = &_gameDomains[domName];
+
+		// In case we switch to a new active domain we will need to save all
+		// the config values which are in the domain to allow for proper
+		// notifications. (i.e. the values in the domain might differ from
+		// the previous one)
+		for (Domain::const_iterator i = newActiveDomain->begin(), iend = newActiveDomain->end(); i != iend; ++i) {
+			oldValues[i->_key] = get(i->_key);
+		}
+
+		_activeDomain = newActiveDomain;
 	}
 	_activeDomainName = domName;
+
+	for (StringMap::const_iterator i = oldValues.begin(), iend = oldValues.end(); i != iend; ++i) {
+		maybeSendNotification(i->_key, i->_value);
+	}
 }
 
 void ConfigManager::addGameDomain(const String &domName) {
@@ -609,7 +670,7 @@ void ConfigManager::addGameDomain(const String &domName) {
 	// TODO: Do we want to generate an error/warning if a domain with
 	// the given name already exists?
 
-	_gameDomains[domName];
+	_gameDomains[domName]._owner = this;
 
 	// Add it to the _domainSaveOrder, if it's not already in there
 	if (find(_domainSaveOrder.begin(), _domainSaveOrder.end(), domName) == _domainSaveOrder.end())
@@ -620,7 +681,7 @@ void ConfigManager::addMiscDomain(const String &domName) {
 	assert(!domName.empty());
 	assert(isValidDomainName(domName));
 
-	_miscDomains[domName];
+	_miscDomains[domName]._owner = this;
 }
 
 void ConfigManager::removeGameDomain(const String &domName) {
@@ -659,6 +720,7 @@ void ConfigManager::renameDomain(const String &oldName, const String &newName, D
 //	_gameDomains[newName].merge(_gameDomains[oldName]);
 	Domain &oldDom = map[oldName];
 	Domain &newDom = map[newName];
+	newDom._owner = this;
 	Domain::const_iterator iter;
 	for (iter = oldDom.begin(); iter != oldDom.end(); ++iter)
 		newDom.setVal(iter->_key, iter->_value);
@@ -676,7 +738,95 @@ bool ConfigManager::hasMiscDomain(const String &domName) const {
 	return isValidDomainName(domName) && _miscDomains.contains(domName);
 }
 
+void ConfigManager::addNotificationCallback(const String &key, NotificationCallbackPtr callback) {
+	// Make sure not to add a callback twice for the same key
+	removeNotificationCallback(key, callback);
+	_notificationCallbacks[key].push_back(callback);
+}
+
+void ConfigManager::removeNotificationCallback(const String &key, NotificationCallbackPtr callback) {
+	if (key.empty()) {
+		for (NotificationCallbackMap::iterator i = _notificationCallbacks.begin(), end = _notificationCallbacks.end();
+		     i != end; ++i) {
+			NotificationCallbackList &list = i->_value;
+			NotificationCallbackList::iterator j = find(list.begin(), list.end(), callback);
+			if (j != list.end()) {
+				list.erase(j);
+			}
+		}
+	} else if (_notificationCallbacks.contains(key)) {
+		NotificationCallbackList &list = _notificationCallbacks[key];
+		NotificationCallbackList::iterator i = find(list.begin(), list.end(), callback);
+		if (i != list.end()) {
+			list.erase(i);
+		}
+	}
+}
+
+void ConfigManager::maybeSendNotification(const String &key, const String &oldValue) {
+	// In case this key is not watched: do nothing.
+	if (!_notificationCallbacks.contains(key)) {
+		return;
+	}
+	// In case the value has not been changed: do nothing.
+	Common::String newValue = get(key);
+	if (newValue == oldValue) {
+		return;
+	}
+
+	const NotificationCallbackList &notificationList = _notificationCallbacks.getVal(key);
+	for (NotificationCallbackList::const_iterator i = notificationList.begin(), end = notificationList.end(); i != end; ++i) {
+		(**i)(key, newValue);
+	}
+}
+
 #pragma mark -
+
+void ConfigManager::Domain::setVal(const String &key, const String &val) {
+	// Save the old value from the config manager
+	Common::String oldValue;
+	if (_owner) {
+		oldValue = _owner->get(key);
+	}
+
+	_entries[key] = val;
+
+	if (_owner) {
+		_owner->maybeSendNotification(key, oldValue);
+	}
+}
+
+void ConfigManager::Domain::clear() {
+	// Save the old values from the config manager
+	StringMap oldValues;
+	if (_owner) {
+		for (StringMap::const_iterator i = _entries.begin(), iend = _entries.end(); i != iend; ++i) {
+			oldValues[i->_key] = _owner->get(i->_key);
+		}
+	}
+
+	_entries.clear();
+
+	if (_owner) {
+		for (StringMap::const_iterator i = oldValues.begin(), iend = oldValues.end(); i != iend; ++i) {
+			_owner->maybeSendNotification(i->_key, i->_value);
+		}
+	}
+}
+
+void ConfigManager::Domain::erase(const String &key) {
+	// Save the old value from the config manager
+	Common::String oldValue;
+	if (_owner) {
+		oldValue = _owner->get(key);
+	}
+
+	_entries.erase(key);
+
+	if (_owner) {
+		_owner->maybeSendNotification(key, oldValue);
+	}
+}
 
 void ConfigManager::Domain::setDomainComment(const String &comment) {
 	_domainComment = comment;

--- a/common/config-manager.h
+++ b/common/config-manager.h
@@ -62,8 +62,7 @@ public:
 
 		bool contains(const String &key) const { return _entries.contains(key); }
 
-		String &operator[](const String &key) { return _entries[key]; }
-		const String &operator[](const String &key) const { return _entries[key]; }
+		void setVal(const String &key, const String &val) { _entries[key] = val; }
 
 		String &getVal(const String &key) { return _entries.getVal(key); }
 		const String &getVal(const String &key) const { return _entries.getVal(key); }

--- a/common/config-manager.h
+++ b/common/config-manager.h
@@ -29,31 +29,48 @@
 #include "common/singleton.h"
 #include "common/str.h"
 #include "common/hash-str.h"
+#include "common/func.h"
+#include "common/ptr.h"
+#include "common/list.h"
 
 namespace Common {
 
 class WriteStream;
 class SeekableReadStream;
 
+#define NOTIFICATION_CALLBACK_FUN(func) \
+	Common::ConfigManager::NotificationCallbackPtr(new Common::Functor2Fun<const Common::String &, const Common::String &, void>(func))
+
+#define NOTIFICATION_CALLBACK_MEM(ClassType, object, func) \
+	Common::ConfigManager::NotificationCallbackPtr(new Common::Functor2Mem<const Common::String &, const Common::String &, void, ClassType>(object, &ClassType::func))
+
 /**
  * The (singleton) configuration manager, used to query & set configuration
  * values using string keys.
- *
- * @todo Implement the callback based notification system (outlined below)
- *       which sends out notifications to interested parties whenever the value
- *       of some specific (or any) configuration key changes.
  */
 class ConfigManager : public Singleton<ConfigManager> {
-
 public:
+	/**
+	 * This is a callback which gets notified when a (globally visible) config
+	 * option has been changed. The first parameter gets the key value, the
+	 * second gets the new value
+	 */
+	typedef Functor2<const String &, const String &, void> NotificationCallback;
+	typedef SharedPtr<NotificationCallback> NotificationCallbackPtr;
 
 	class Domain {
+		friend class ConfigManager;
 	private:
+		ConfigManager *_owner;
+
 		StringMap _entries;
 		StringMap _keyValueComments;
 		String _domainComment;
 
 	public:
+		Domain() : _owner(nullptr) {}
+		~Domain() { clear(); }
+
 		typedef StringMap::const_iterator const_iterator;
 		const_iterator begin() const { return _entries.begin(); }
 		const_iterator end()   const { return _entries.end(); }
@@ -62,14 +79,14 @@ public:
 
 		bool contains(const String &key) const { return _entries.contains(key); }
 
-		void setVal(const String &key, const String &val) { _entries[key] = val; }
+		void setVal(const String &key, const String &val);
 
 		String &getVal(const String &key) { return _entries.getVal(key); }
 		const String &getVal(const String &key) const { return _entries.getVal(key); }
 
-		void clear() { _entries.clear(); }
+		void clear();
 
-		void erase(const String &key) { _entries.erase(key); }
+		void erase(const String &key);
 
 		void setDomainComment(const String &comment);
 		const String &getDomainComment() const;
@@ -78,6 +95,7 @@ public:
 		const String &getKVComment(const String &key) const;
 		bool hasKVComment(const String &key) const;
 	};
+	friend class ConfigManager::Domain;
 
 	typedef HashMap<String, Domain, IgnoreCase_Hash, IgnoreCase_EqualTo> DomainMap;
 
@@ -167,9 +185,28 @@ public:
 	static void			defragment();	// move in memory to reduce fragmentation
 	void 				copyFrom(ConfigManager &source);
 
+	/**
+	 * Add a notification callback bound to a specific key. This is called
+	 * whenever ConfMan.get(key) will start to yield a different value.
+	 *
+	 * @param key The key whose value to watch.
+	 * @parma callback A pointer to the callback.
+	 */
+	void addNotificationCallback(const String &key, NotificationCallbackPtr callback);
+
+	/**
+	 * This removes a notification callback bound to a specific key.
+	 *
+	 * @param key The key to stop watching. (This can be an empty string to
+	 *            indicate that the callback should be removed from all keys).
+	 * @param callback The callback to remove.
+	 */
+	void removeNotificationCallback(const String &key, NotificationCallbackPtr callback);
+
 private:
 	friend class Singleton<SingletonBaseType>;
 	ConfigManager();
+	~ConfigManager();
 
 	void			loadFromStream(SeekableReadStream &stream);
 	void			addDomain(const String &domainName, const Domain &domain);
@@ -185,6 +222,11 @@ private:
 #ifdef ENABLE_KEYMAPPER
 	Domain			_keymapperDomain;
 #endif
+
+	typedef List<NotificationCallbackPtr> NotificationCallbackList;
+	typedef Common::HashMap<String, NotificationCallbackList> NotificationCallbackMap;
+	NotificationCallbackMap _notificationCallbacks;
+	void maybeSendNotification(const String &key, const String &oldValue);
 
 	Array<String>	_domainSaveOrder;
 

--- a/common/config-manager.h
+++ b/common/config-manager.h
@@ -161,7 +161,8 @@ public:
 	bool				hasMiscDomain(const String &domName) const;
 
 	const DomainMap &	getGameDomains() const { return _gameDomains; }
-	DomainMap &			getGameDomains() { return _gameDomains; }
+	DomainMap::iterator beginGameDomains() { return _gameDomains.begin(); }
+	DomainMap::iterator endGameDomains() { return _gameDomains.end(); }
 
 	static void			defragment();	// move in memory to reduce fragmentation
 	void 				copyFrom(ConfigManager &source);

--- a/gui/massadd.cpp
+++ b/gui/massadd.cpp
@@ -211,9 +211,9 @@ void MassAddDialog::handleTickle() {
 					Common::ConfigManager::Domain *dom = ConfMan.getDomain(*iter);
 					assert(dom);
 
-					if ((*dom)["gameid"] == result["gameid"] &&
-					    (*dom)["platform"] == result["platform"] &&
-					    (*dom)["language"] == result["language"]) {
+					if (dom->getVal("gameid") == result["gameid"] &&
+					    dom->getVal("platform") == result["platform"] &&
+					    dom->getVal("language") == result["language"]) {
 						duplicate = true;
 						break;
 					}


### PR DESCRIPTION
As the title suggest this implements notifications support in ConfigManager.

The idea behind this is as follows: Client code might want to know whenever a specific config value is changed. An example for this might be the backend looking to see whether gfx_mode is changed while the options menu is open, in case it sees a change this could automatically switch the mode without our GUI code pushing this change to the backend on its own. As you can see currently, such client code would need to poll for such changes (or hope that someone third-party is calling the client code when it *might* have changed, as in case of the GUI). In general, I think this can be useful when we want to turn our GUI into a proper view/controller of the configuration without it needing special handling for applying various config options.

The implementation itself currently only notifies about "global" changes, i.e. whenever a value for a certain key is changed on the level of ConfMan.get(key). Individual domain changes are not yet notified. (I am not sure whether we actually need the latter anyway...). I think the implementation is rather hacky, but it seems our ConfigManager in general is a bit... well... not so nice. Thus, I consider this a proof-of-concept. (It's also only roughly tested with the horrible hacky commit (c9964f676f82f41ebe6cf80f1124495badce928a) I added which makes some simply output functions watch gfx_mode and mute)

Possible things to wonder about are:

* Do we want more fine grained notifications?

* How can we make this whole code cleaner? (i.e. this Domain::_owner is rather annoying, but I don't see too much of an option around it right now)

* Is this actually an improvement? (At least I think it makes sense, it was a "todo" in the class' docs and fuzzie seemed to like it too).