### PR TITLE
VKEYBD: Make code agnostic of OverlayColor.

### DIFF
--- a/backends/vkeybd/virtual-keyboard-gui.h
+++ b/backends/vkeybd/virtual-keyboard-gui.h
@@ -99,7 +99,7 @@ private:
 	VirtualKeyboard *_kbd;
 	Rect _kbdBound;
 	Graphics::Surface *_kbdSurface;
-	OverlayColor _kbdTransparentColor;
+	uint32 _kbdTransparentColor;
 
 	Point _dragPoint;
 	bool _drag;
@@ -113,7 +113,7 @@ private:
 	const Graphics::Font *_dispFont;
 	int16 _dispX, _dispY;
 	uint _dispI;
-	OverlayColor _dispForeColor, _dispBackColor;
+	uint32 _dispForeColor, _dispBackColor;
 
 	int _lastScreenChanged;
 	int16 _screenW, _screenH;
@@ -121,7 +121,7 @@ private:
 	bool _displaying;
 	bool _firstRun;
 
-	void setupDisplayArea(Rect &r, OverlayColor forecolor);
+	void setupDisplayArea(Rect &r, uint32 forecolor);
 	void move(int16 x, int16 y);
 	void moveToDefaultPosition();
 	void screenChanged();

--- a/backends/vkeybd/virtual-keyboard.h
+++ b/backends/vkeybd/virtual-keyboard.h
@@ -112,11 +112,11 @@ protected:
 		String              resolution;
 		String              bitmapName;
 		Graphics::Surface   *image;
-		OverlayColor        transparentColor;
+		uint32              transparentColor;
 		ImageMap            imageMap;
 		VKEventMap          events;
 		Rect                displayArea;
-		OverlayColor        displayFontColor;
+		uint32              displayFontColor;
 
 		Mode() : image(0) {}
 		~Mode() {


### PR DESCRIPTION
This removes the use of OverlayColor in vkeybd and supports both 16 and 32bit
overlays.

This follows the same logic as 1f1d35bd3d31fe3430b9b5227b6127cfd52e52a2. That is that in case of 32bit SDL or OpenGL overlay support we cannot be sure what bit size is actually used on runtime. Thus, the OverlayColor typedef cannot be used anymore.
