### PR TITLE
GRAPHICS: Create copyRectToSurface member function

### DIFF
--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -133,22 +133,28 @@ const Surface Surface::getSubArea(const Common::Rect &area) const {
 	return subSurface;
 }
 
-void Surface::copyRectToSurface(const void *buffer, int pitch, int x, int y, int width, int height) {
+void Surface::copyRectToSurface(const void *buffer, int pitch, int destX, int destY, int width, int height) {
 	assert(buffer);
 
-	assert(x >= 0 && x < w);
-	assert(y >= 0 && y < h);
-	assert(height > 0 && y + height <= h);
-	assert(width > 0 && x + width <= w);
+	assert(destX >= 0 && destX < w);
+	assert(destY >= 0 && destY < h);
+	assert(height > 0 && destY + height <= h);
+	assert(width > 0 && destX + width <= w);
 
 	// Copy buffer data to internal buffer
 	const byte *src = (const byte *)buffer;
-	byte *dst = (byte *)getBasePtr(x, y);
+	byte *dst = (byte *)getBasePtr(destX, destY);
 	for (int i = 0; i < height; i++) {
 		memcpy(dst, src, width * format.bytesPerPixel);
 		src += pitch;
 		dst += this->pitch;
 	}
+}
+
+void Surface::copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect subRect) {
+	assert(srcSurface.format == format);
+
+	copyRectToSurface(srcSurface.getBasePtr(subRect.left, subRect.top), srcSurface.pitch, destX, destY, subRect.width(), subRect.height());
 }
 
 void Surface::hLine(int x, int y, int x2, uint32 color) {

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -214,12 +214,23 @@ public:
 	 *
 	 * @param buffer    The buffer containing the graphics data source
 	 * @param pitch     The pitch of the buffer (number of bytes in a scanline)
-	 * @param x         The x coordinate of the destination rectangle
-	 * @param y         The y coordinate of the destination rectangle
+	 * @param destX     The x coordinate of the destination rectangle
+	 * @param destY     The y coordinate of the destination rectangle
 	 * @param width     The width of the destination rectangle
 	 * @param height    The height of the destination rectangle
 	 */
-	void copyRectToSurface(const void *buffer, int pitch, int x, int y, int width, int height);
+	void copyRectToSurface(const void *buffer, int pitch, int destX, int destY, int width, int height);
+	/**
+	 * Copies a bitmap to the Surface internal buffer. The pixel format
+	 * of buffer must match the pixel format of the Surface.
+	 *
+	 * @param srcSurface    The source of the bitmap data
+	 * @param destX         The x coordinate of the destination rectangle
+	 * @param destY         The y coordinate of the destination rectangle
+	 * @param subRect       The subRect of surface to be blitted
+	 * @return                
+	 */
+	void copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect subRect);
 
 	/**
 	 * Convert the data to another pixel format.


### PR DESCRIPTION
This is a pretty simple addition. It copies a bitmap from a buffer to a sub-rectangle of the Surface's internal buffer. It's modeled off of OSystem::copyRectToScreen()
