### PR TITLE
WINTERMUTE: Remove useless Rect extra argument from fadeToColor.

### DIFF
--- a/engines/wintermute/base/gfx/base_renderer.h
+++ b/engines/wintermute/base/gfx/base_renderer.h
@@ -84,7 +84,7 @@ public:
 	 * @param a the alpha component to fade too.
 	 * @param rect the portion of the screen to fade (if nullptr, the entire screen will be faded).
 	 */
-	virtual void fadeToColor(byte r, byte g, byte b, byte a, Common::Rect *rect = nullptr) = 0;
+	virtual void fadeToColor(byte r, byte g, byte b, byte a) = 0;
 
 	virtual bool drawLine(int x1, int y1, int x2, int y2, uint32 color); 	// Unused outside indicator-display
 	virtual bool drawRect(int x1, int y1, int x2, int y2, uint32 color, int width = 1); 	// Unused outside indicator-display

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -243,22 +243,16 @@ void BaseRenderOSystem::fade(uint16 alpha) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-void BaseRenderOSystem::fadeToColor(byte r, byte g, byte b, byte a, Common::Rect *rect) {
+void BaseRenderOSystem::fadeToColor(byte r, byte g, byte b, byte a) {
 	Common::Rect fillRect;
 
-	if (rect) {
-		fillRect.left = rect->left;
-		fillRect.top = rect->top;
-		fillRect.setWidth(rect->width());
-		fillRect.setHeight(rect->height());
-	} else {
-		Rect32 rc;
-		_gameRef->getCurrentViewportRect(&rc);
-		fillRect.left = (int16)rc.left;
-		fillRect.top = (int16)rc.top;
-		fillRect.setWidth((int16)(rc.right - rc.left));
-		fillRect.setHeight((int16)(rc.bottom - rc.top));
-	}
+	Rect32 rc;
+	_gameRef->getCurrentViewportRect(&rc);
+	fillRect.left = (int16)rc.left;
+	fillRect.top = (int16)rc.top;
+	fillRect.setWidth((int16)(rc.right - rc.left));
+	fillRect.setHeight((int16)(rc.bottom - rc.top));
+
 	modTargetRect(&fillRect);
 
 	//TODO: This is only here until I'm sure about the final pixelformat

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.h
@@ -70,7 +70,7 @@ public:
 	bool fill(byte r, byte g, byte b, Common::Rect *rect = nullptr) override;
 	Graphics::PixelFormat getPixelFormat() const override;
 	void fade(uint16 alpha) override;
-	void fadeToColor(byte r, byte g, byte b, byte a, Common::Rect *rect = nullptr) override;
+	void fadeToColor(byte r, byte g, byte b, byte a) override;
 
 	bool drawLine(int x1, int y1, int x2, int y2, uint32 color) override;
 


### PR DESCRIPTION
It is not used anywhere, and Mnemonic has confirmed that the original
engine does NOT support anything but full screen fades.
