### PR TITLE
Gesture-event interface for touchscreens

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -30,6 +30,7 @@
 #include "backends/events/default/default-events.h"
 #include "backends/keymapper/keymapper.h"
 #include "backends/keymapper/remap-dialog.h"
+#include "backends/touchmapper/touchmapper.h"
 #include "backends/vkeybd/virtual-keyboard.h"
 
 #include "engines/engine.h"
@@ -66,6 +67,10 @@ DefaultEventManager::DefaultEventManager(Common::EventSource *boss) :
 	_remap = false;
 #else
 	_dispatcher.registerMapper(new Common::DefaultEventMapper());
+#endif
+#ifdef ENABLE_TOUCHMAPPER
+	_touchmapper = new Common::Touchmapper(this);
+	_dispatcher.registerMapper(_touchmapper);
 #endif
 }
 

--- a/backends/events/default/default-events.h
+++ b/backends/events/default/default-events.h
@@ -33,6 +33,9 @@ class Keymapper;
 #ifdef ENABLE_VKEYBD
 class VirtualKeyboard;
 #endif
+#ifdef ENABLE_TOUCHMAPPER
+class Touchmapper;
+#endif
 }
 
 
@@ -44,6 +47,10 @@ class DefaultEventManager : public Common::EventManager, Common::EventObserver {
 #ifdef ENABLE_KEYMAPPER
 	Common::Keymapper *_keymapper;
 	bool _remap;
+#endif
+
+#ifdef ENABLE_TOUCHMAPPER
+	Common::Touchmapper *_touchmapper;
 #endif
 
 	Common::ArtificialEventSource _artificialEventSource;

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -40,6 +40,11 @@ MODULE_OBJS += \
 	keymapper/remap-dialog.o
 endif
 
+ifdef ENABLE_TOUCHMAPPER
+MODULE_OBJS += \
+	touchmapper/touchmapper.o
+endif
+
 ifdef USE_OPENGL
 MODULE_OBJS += \
 	graphics/opengl/glerrorcheck.o \

--- a/backends/touchmapper/touchmapper.cpp
+++ b/backends/touchmapper/touchmapper.cpp
@@ -20,11 +20,20 @@
 *
 */
 
+#include "common/system.h"
+#include "engines/engine.h"
 #include "backends/touchmapper/touchmapper.h"
+#include "common/config-manager.h"
 
 namespace Common {
 
 Touchmapper::Touchmapper(EventManager *evtMgr) {
+	if (ConfMan.hasKey("direct_input") && ConfMan.getBool("direct_input"))
+		inputMode = kDirectInput;
+	else
+		inputMode = kTouchpadMode;
+
+	_dragAndDrop = false;
 }
 
 Touchmapper::~Touchmapper() {
@@ -33,6 +42,115 @@ Touchmapper::~Touchmapper() {
 List<Event> Touchmapper::mapEvent(const Event &ev, EventSource *source) {
 	List<Event> events;
 	Event mappedEvent;
+
+	// FIXME: Maybe check something else instead!
+	if (g_engine && !g_engine->isPaused()) {
+		if (inputMode == kDirectInput) {
+			switch (ev.type) {
+				case EVENT_FINGERMOVE:
+					g_system->warpMouse(ev.finger[0].position.x, ev.finger[0].position.y);
+					break;
+				case EVENT_SINGLETAP:
+					g_system->warpMouse(ev.finger[0].position.x, ev.finger[0].position.y);
+					mappedEvent.type = EVENT_LBUTTONUP;
+					break;
+				case EVENT_TAPDOWN:
+					g_system->warpMouse(ev.finger[0].position.x, ev.finger[0].position.y);
+					mappedEvent.type = EVENT_LBUTTONDOWN;
+					break;
+				case EVENT_SIMULATE_MBUTTONUP:
+					g_system->warpMouse(ev.finger[0].position.x, ev.finger[0].position.y);
+					mappedEvent.type = EVENT_MBUTTONUP;
+					break;
+				case EVENT_SIMULATE_MBUTTONDOWN:
+					g_system->warpMouse(ev.finger[0].position.x, ev.finger[0].position.y);
+					mappedEvent.type = EVENT_MBUTTONDOWN;
+					break;
+				case EVENT_SIMULATE_RBUTTONUP:
+					g_system->warpMouse(ev.finger[0].position.x, ev.finger[0].position.y);
+					mappedEvent.type = EVENT_RBUTTONUP;
+					break;
+				case EVENT_SIMULATE_RBUTTONDOWN:
+					g_system->warpMouse(ev.finger[0].position.x, ev.finger[0].position.y);
+					mappedEvent.type = EVENT_RBUTTONDOWN;
+					break;
+			}
+		} else if (inputMode == kTouchpadMode) {
+			int mousex;
+			int mousey;
+
+			mousex = g_system->getEventManager()->getMousePos().x;
+			mousey = g_system->getEventManager()->getMousePos().y;
+
+			if (!_dragAndDrop) {
+				switch (ev.type) {
+					case EVENT_FINGERMOVE:
+					case EVENT_TAPDOWN:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						break;
+					case EVENT_DOUBLETAP:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						mappedEvent.type = EVENT_LBUTTONDOWN;
+						_dragAndDrop = true;
+						break;
+					case EVENT_SINGLETAP:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						mappedEvent.type = EVENT_LBUTTONUP;
+						break;
+					case EVENT_SIMULATE_LBUTTONDOWN:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						mappedEvent.type = EVENT_LBUTTONDOWN;
+						break;
+					case EVENT_SIMULATE_MBUTTONUP:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						mappedEvent.type = EVENT_MBUTTONUP;
+						break;
+					case EVENT_SIMULATE_MBUTTONDOWN:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						mappedEvent.type = EVENT_MBUTTONDOWN;
+						break;
+					case EVENT_SIMULATE_RBUTTONUP:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						mappedEvent.type = EVENT_RBUTTONUP;
+						break;
+					case EVENT_SIMULATE_RBUTTONDOWN:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						mappedEvent.type = EVENT_RBUTTONDOWN;
+						break;
+				}
+			} else {
+				switch (ev.type) {
+					case EVENT_FINGERMOVE:
+					case EVENT_TAPDOWN:
+					case EVENT_SINGLETAP:
+					case EVENT_SIMULATE_LBUTTONDOWN:
+					case EVENT_SIMULATE_MBUTTONUP:
+					case EVENT_SIMULATE_MBUTTONDOWN:
+					case EVENT_SIMULATE_RBUTTONUP:
+					case EVENT_SIMULATE_RBUTTONDOWN:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						break;
+					case EVENT_DOUBLETAP:
+						g_system->warpMouse(mousex + ev.finger[0].deltax, mousey + ev.finger[0].deltay);
+						mappedEvent.type = EVENT_LBUTTONUP;
+						_dragAndDrop = false;
+						break;
+				}
+			}
+		}
+	} else {
+		// In GUI
+		switch (ev.type) {
+			case EVENT_SIMULATE_RBUTTONUP:
+			case EVENT_SIMULATE_MBUTTONUP:
+				mappedEvent.type = EVENT_SINGLETAP;
+				break;
+			case EVENT_SIMULATE_LBUTTONDOWN:
+			case EVENT_SIMULATE_MBUTTONDOWN:
+			case EVENT_SIMULATE_RBUTTONDOWN:
+				break;
+		}
+	}
 
 	// if it didn't get mapped, just pass it through
 	if (mappedEvent.type == EVENT_INVALID)

--- a/backends/touchmapper/touchmapper.cpp
+++ b/backends/touchmapper/touchmapper.cpp
@@ -1,0 +1,45 @@
+/* ScummVM - Graphic Adventure Engine
+*
+* ScummVM is the legal property of its developers, whose names
+* are too numerous to list here. Please refer to the COPYRIGHT
+* file distributed with this source distribution.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+
+#include "backends/touchmapper/touchmapper.h"
+
+namespace Common {
+
+Touchmapper::Touchmapper(EventManager *evtMgr) {
+}
+
+Touchmapper::~Touchmapper() {
+}
+
+List<Event> Touchmapper::mapEvent(const Event &ev, EventSource *source) {
+	List<Event> events;
+	Event mappedEvent;
+
+	// if it didn't get mapped, just pass it through
+	if (mappedEvent.type == EVENT_INVALID)
+		mappedEvent = ev;
+
+	events.push_back(mappedEvent);
+	return events;
+}
+
+} // End of namespace Common

--- a/backends/touchmapper/touchmapper.h
+++ b/backends/touchmapper/touchmapper.h
@@ -1,0 +1,49 @@
+/* ScummVM - Graphic Adventure Engine
+*
+* ScummVM is the legal property of its developers, whose names
+* are too numerous to list here. Please refer to the COPYRIGHT
+* file distributed with this source distribution.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+
+#ifndef COMMON_TOUCHMAPPER_H
+#define COMMON_TOUCHMAPPER_H
+
+#include "common/scummsys.h"
+
+#include "common/events.h"
+#include "common/list.h"
+#include "common/hashmap.h"
+#include "common/stack.h"
+#include "backends/keymapper/hardware-input.h"
+#include "backends/keymapper/keymap.h"
+
+namespace Common {
+
+class Touchmapper : public Common::DefaultEventMapper {
+public:
+
+	Touchmapper(EventManager *eventMan);
+	~Touchmapper();
+
+	// EventMapper interface
+	virtual List<Event> mapEvent(const Event &ev, EventSource *source);
+};
+
+} // End of namespace Common
+
+#endif // #ifndef COMMON_TOUCHMAPPER_H

--- a/backends/touchmapper/touchmapper.h
+++ b/backends/touchmapper/touchmapper.h
@@ -42,6 +42,16 @@ public:
 
 	// EventMapper interface
 	virtual List<Event> mapEvent(const Event &ev, EventSource *source);
+
+	enum InputMode {
+		kDirectInput = 0,
+		kTouchpadMode = 1
+	};
+
+	InputMode inputMode;
+
+private:
+	bool _dragAndDrop;
 };
 
 } // End of namespace Common

--- a/common/events.h
+++ b/common/events.h
@@ -24,6 +24,7 @@
 #define COMMON_EVENTS_H
 
 #include "common/keyboard.h"
+#include "common/finger.h"
 #include "common/queue.h"
 #include "common/rect.h"
 #include "common/noncopyable.h"
@@ -87,6 +88,22 @@ enum EventType {
 	,
 	EVENT_VIRTUAL_KEYBOARD = 20
 #endif
+#ifdef ENABLE_TOUCHMAPPER
+	,
+	EVENT_FINGERMOVE = 21,
+	// Triggered if a finger touches and leaves the screen at the same location
+	EVENT_SINGLETAP = 22,
+	// Triggered when finger touches screen
+	EVENT_TAPDOWN = 23,
+	// Triggered when finger leaves screen
+	EVENT_TAPUP = 24,
+	EVENT_DOUBLETAP = 25,
+	EVENT_SIMULATE_LBUTTONDOWN = 26,
+	EVENT_SIMULATE_MBUTTONDOWN = 27,
+	EVENT_SIMULATE_MBUTTONUP = 28,
+	EVENT_SIMULATE_RBUTTONDOWN = 29,
+	EVENT_SIMULATE_RBUTTONUP = 30
+#endif
 };
 
 typedef uint32 CustomEventType;
@@ -113,6 +130,14 @@ struct Event {
 	 * screen area as defined by the most recent call to initSize().
 	 */
 	Point mouse;
+
+
+	/**
+	 * Fingers
+	 */
+#ifdef ENABLE_TOUCHMAPPER
+	FingerState finger[5];
+#endif
 
 #ifdef ENABLE_KEYMAPPER
 	// IMPORTANT NOTE: This is part of the WIP Keymapper. If you plan to use
@@ -355,6 +380,7 @@ private:
 };
 
 class Keymapper;
+class Touchmapper;
 
 /**
  * The EventManager provides user input events to the client code.

--- a/common/finger.h
+++ b/common/finger.h
@@ -38,7 +38,7 @@ struct FingerState {
 	int deltax;
 	int deltay;
 
-	int holdTime;
+	uint32 holdTime;
 
 	byte flags;
 };

--- a/common/finger.h
+++ b/common/finger.h
@@ -1,0 +1,48 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef COMMON_FINGER_H
+#define COMMON_FINGER_H
+
+#include "common/scummsys.h"
+#include "common/rect.h"
+
+namespace Common {
+
+struct FingerState {
+	/**
+	 * Position of the finger, in virtual screen coordinates. 
+	 * Virtual screen coordinates means: the coordinate system of the
+	 * screen area as defined by the most recent call to initSize().
+	 */
+	Point position;
+	int deltax;
+	int deltay;
+
+	int holdTime;
+
+	byte flags;
+};
+
+} // End of namespace Common
+
+#endif

--- a/common/finger.h
+++ b/common/finger.h
@@ -39,8 +39,6 @@ struct FingerState {
 	int deltay;
 
 	uint32 holdTime;
-
-	byte flags;
 };
 
 } // End of namespace Common

--- a/configure
+++ b/configure
@@ -143,6 +143,7 @@ _bink=yes
 # Default vkeybd/keymapper/eventrec options
 _vkeybd=no
 _keymapper=no
+_touchmapper=no
 _eventrec=auto
 # GUI translation options
 _translation=yes
@@ -1054,6 +1055,8 @@ for ac_option in $@; do
 	--disable-vkeybd)         _vkeybd=no      ;;
 	--enable-keymapper)       _keymapper=yes  ;;
 	--disable-keymapper)      _keymapper=no   ;;
+	--enable-touchmapper)     _touchmapper=yes  ;;
+	--disable-touchmapper)    _touchmapper=no   ;;
 	--enable-eventrecorder)   _eventrec=yes  ;;
 	--disable-eventrecorder)  _eventrec=no   ;;
 	--enable-text-console)    _text_console=yes ;;
@@ -3916,6 +3919,7 @@ define_in_config_if_yes $_nasm 'USE_NASM'
 #
 define_in_config_if_yes $_vkeybd 'ENABLE_VKEYBD'
 define_in_config_if_yes $_keymapper 'ENABLE_KEYMAPPER'
+define_in_config_if_yes $_touchmapper 'ENABLE_TOUCHMAPPER'
 define_in_config_if_yes $_eventrec 'ENABLE_EVENTRECORDER'
 
 #
@@ -4080,6 +4084,10 @@ fi
 
 if test "$_keymapper" = yes ; then
 	echo_n ", keymapper"
+fi
+
+if test "$_touchmapper" = yes ; then
+	echo_n ", touchmapper"
 fi
 
 if test "$_eventrec" = yes ; then

--- a/gui/about.h
+++ b/gui/about.h
@@ -50,6 +50,11 @@ public:
 	void drawDialog();
 	void handleTickle();
 	void handleMouseUp(int x, int y, int button, int clickCount);
+#ifdef ENABLE_TOUCHMAPPER
+	void handleFingerSingleTap(int x, int y, int button, int clickCount) {
+		handleMouseUp(x, y, button, clickCount);
+	};
+#endif
 	void handleKeyDown(Common::KeyState state);
 	void handleKeyUp(Common::KeyState state);
 

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -131,11 +131,6 @@ void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 		}
 		break;
 	case kListSelectionChangedCmd:
-		// We do not allow selecting directories in directory
-		// browser mode, thus we will invalidate the selection
-		// when the user selects an directory over here.
-		if (data != (uint32)-1 && _isDirBrowser && !_nodeContent[data].isDirectory())
-			_fileList->setSelected(-1);
 		break;
 	case kHiddenCmd:
 		// Update whether the user wants hidden files to be shown

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -131,6 +131,11 @@ void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 		}
 		break;
 	case kListSelectionChangedCmd:
+		// We do not allow selecting directories in directory
+		// browser mode, thus we will invalidate the selection
+		// when the user selects an directory over here.
+		if (data != (uint32)-1 && _isDirBrowser && !_nodeContent[data].isDirectory())
+			_fileList->setSelected(-1); 
 		break;
 	case kHiddenCmd:
 		// Update whether the user wants hidden files to be shown

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -166,6 +166,72 @@ void Dialog::drawDialog() {
 	}
 }
 
+#ifdef ENABLE_TOUCHMAPPER
+
+void Dialog::handleFingerDown(int x, int y, int button, int clickCount) {
+	Widget *w;
+
+	w = findWidget(x, y);
+
+	if (w && !(w->getFlags() & WIDGET_IGNORE_DRAG))
+		_dragWidget = w;
+
+	// If the click occurred inside a widget which is not the currently
+	// focused one, change the focus to that widget.
+	if (w && w != _focusedWidget && w->wantsFocus()) {
+		setFocusWidget(w);
+	}
+
+	if (w)
+		w->handleFingerDown(x - (w->getAbsX() - _x), y - (w->getAbsY() - _y), button, clickCount);
+}
+
+void Dialog::handleFingerSingleTap(int x, int y, int button, int clickCount) {
+	Widget *w;
+
+	if (_focusedWidget) {
+		//w = _focusedWidget;
+
+		// Lose focus on mouseup unless the widget requested to retain the focus
+		if (! (_focusedWidget->getFlags() & WIDGET_RETAIN_FOCUS )) {
+			releaseFocus();
+		}
+	}
+
+	if (_dragWidget)
+		w = _dragWidget;
+	else
+		w = findWidget(x, y);
+
+	if (w)
+		w->handleFingerSingleTap(x - (w->getAbsX() - _x), y - (w->getAbsY() - _y), button, clickCount);
+
+	_dragWidget = 0;
+}
+	
+void Dialog::handleFingerMoved(int x, int y, int deltax, int deltay, int button) {
+	Widget *w;
+
+	if (_focusedWidget && !_dragWidget) {
+		w = _focusedWidget;
+		int wx = w->getAbsX() - _x;
+		int wy = w->getAbsY() - _y;
+
+		w->handleFingerMoved(x - wx, y - wy, deltax, deltay, button);
+	}
+
+	if (!_dragWidget || !(_dragWidget->getFlags() & WIDGET_TRACK_MOUSE))
+		w = findWidget(x, y);
+	else
+		w = _dragWidget;
+
+	// We only sent mouse move events when the widget requests to be informed about them.
+	if (w)
+		w->handleFingerMoved(x - (w->getAbsX() - _x), y - (w->getAbsY() - _y), deltax, deltay, button);
+}
+
+#endif
+
 void Dialog::handleMouseDown(int x, int y, int button, int clickCount) {
 	Widget *w;
 

--- a/gui/dialog.h
+++ b/gui/dialog.h
@@ -101,6 +101,12 @@ protected:
 #ifdef ENABLE_KEYMAPPER
 	virtual void handleOtherEvent(Common::Event evt);
 #endif
+	
+#ifdef ENABLE_TOUCHMAPPER
+	virtual void handleFingerDown(int x, int y, int button, int clickCount);
+	virtual void handleFingerSingleTap(int x, int y, int button, int clickCount);
+	virtual void handleFingerMoved(int x, int y, int deltax, int deltay, int button);
+#endif
 
 	Widget *findWidget(int x, int y); // Find the widget at pos x,y if any
 	Widget *findWidget(const char *name);

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -556,7 +556,7 @@ void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDi
 /* Touch events */
 #ifdef ENABLE_TOUCHMAPPER
 	case Common::EVENT_FINGERMOVE:
-		activeDialog->handleMouseMoved(finger.x, finger.y, 0);
+		activeDialog->handleFingerMoved(finger.x, finger.y, event.finger[0].deltax, event.finger[0].deltay, 0);
 		if (finger.x != _lastMousePosition.x || finger.y != _lastMousePosition.y) {
 			_lastMousePosition.x = finger.x;
 			_lastMousePosition.y = finger.y;
@@ -575,11 +575,11 @@ void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDi
 			_lastClick.count = 1;
 		}
 		_lastClick.time = time;
-		activeDialog->handleMouseDown(finger.x , finger.y, 1, _lastClick.count);
+		activeDialog->handleFingerDown(finger.x , finger.y, 1, _lastClick.count);
 		break;
-	case Common::EVENT_TAPUP:
+	case Common::EVENT_SINGLETAP:
 		// 1 is left button, we use this when tapping with one finger
-		activeDialog->handleMouseUp(finger.x, finger.y, 1, _lastClick.count);
+		activeDialog->handleFingerSingleTap(finger.x, finger.y, 1, _lastClick.count);
 		break;
 	/* End of touch-events */
 #endif

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -837,9 +837,13 @@ void LauncherDialog::addGame() {
 			Common::FSNode dir(_browser->getResult());
 			Common::FSList files;
 			if (!dir.getChildren(files, Common::FSNode::kListAll)) {
-				MessageDialog alert(_("ScummVM couldn't open the specified directory!"));
-				alert.runModal();
-				return;
+				// If a file is selected, try looking for the game in the directory it resides 
+				dir = dir.getParent();
+				if (!dir.getChildren(files, Common::FSNode::kListAll)) {
+					MessageDialog alert(_("ScummVM couldn't open the specified directory!"));
+					alert.runModal();
+					return;
+				}
 			}
 
 			// ...so let's determine a list of candidates, games that

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -837,13 +837,9 @@ void LauncherDialog::addGame() {
 			Common::FSNode dir(_browser->getResult());
 			Common::FSList files;
 			if (!dir.getChildren(files, Common::FSNode::kListAll)) {
-				// If a file is selected, try looking for the game in the directory it resides 
-				dir = dir.getParent();
-				if (!dir.getChildren(files, Common::FSNode::kListAll)) {
-					MessageDialog alert(_("ScummVM couldn't open the specified directory!"));
-					alert.runModal();
-					return;
-				}
+				MessageDialog alert(_("ScummVM couldn't open the specified directory!"));
+				alert.runModal();
+				return;
 			}
 
 			// ...so let's determine a list of candidates, games that

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -305,6 +305,13 @@ void ButtonWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 	setPressedState();
 }
 
+#ifdef ENABLE_TOUCHMAPPER
+void ButtonWidget::handleFingerMoved(int x, int y, int deltax, int deltay, int button) {
+	clearFlags(WIDGET_HILITED | WIDGET_PRESSED); 
+	draw();
+}
+#endif
+
 void ButtonWidget::drawWidget() {
 	g_gui.theme()->drawButton(Common::Rect(_x, _y, _x+_w, _y+_h), _label, _state, getFlags());
 }

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -31,6 +31,8 @@
 #include "gui/object.h"
 #include "gui/ThemeEngine.h"
 
+#include "common/debug.h"
+
 namespace GUI {
 
 enum {
@@ -123,6 +125,22 @@ public:
 	virtual bool handleKeyDown(Common::KeyState state) { return false; }	// Return true if the event was handled
 	virtual bool handleKeyUp(Common::KeyState state) { return false; }	// Return true if the event was handled
 	virtual void handleTickle() {}
+
+#ifdef ENABLE_TOUCHMAPPER
+	virtual void handleFingerDown(int x, int y, int button, int clickCount) {
+		// Use mouse-handler if no finger-handler is specified
+		handleMouseDown(x, y, button, clickCount);
+	}
+	virtual void handleFingerSingleTap(int x, int y, int button, int clickCount) {
+		// Use mouse-handler if no finger-handler is specified
+		handleMouseUp(x, y, button, clickCount);
+	}
+
+	virtual void handleFingerMoved(int x, int y, int deltax, int deltay, int button) {
+		// Use mouse-handler if no finger-handler is specified
+		handleMouseMoved(x, y, button);
+	}
+#endif
 
 	void draw();
 	void receivedFocus() { _hasFocus = true; receivedFocusWidget(); }

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -219,6 +219,10 @@ public:
 	void handleMouseLeft(int button)	{ clearFlags(WIDGET_HILITED | WIDGET_PRESSED); draw(); }
 	void handleTickle();
 
+#ifdef ENABLE_TOUCHMAPPER
+	void handleFingerMoved(int x, int y, int deltax, int deltay, int button);
+#endif
+
 	void setHighLighted(bool enable);
 	void setPressedState();
 	void startAnimatePressedState();

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -31,8 +31,6 @@
 #include "gui/object.h"
 #include "gui/ThemeEngine.h"
 
-#include "common/debug.h"
-
 namespace GUI {
 
 enum {

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -44,7 +44,7 @@ ListWidget::ListWidget(Dialog *boss, const String &name, const char *tooltip, ui
 	_scrollBar = new ScrollBarWidget(this, _w - _scrollBarWidth + 1, 0, _scrollBarWidth, _h);
 	_scrollBar->setTarget(this);
 
-	setFlags(WIDGET_ENABLED | WIDGET_CLEARBG | WIDGET_RETAIN_FOCUS | WIDGET_WANT_TICKLE);
+	setFlags(WIDGET_ENABLED | WIDGET_CLEARBG | WIDGET_RETAIN_FOCUS | WIDGET_WANT_TICKLE | WIDGET_TRACK_MOUSE);
 	_type = kListWidget;
 	_editMode = false;
 	_numberingMode = kListNumberingOne;

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -133,12 +133,14 @@ void ListWidget::setSelected(int item) {
 			abortEditMode();
 
 		_selectedItem = item;
-
 		// Notify clients that the selection changed.
 		sendCommand(kListSelectionChangedCmd, _selectedItem);
 
-		_currentPos = _selectedItem - _entriesPerPage / 2;
-		scrollToCurrent();
+		if (item != -1) {
+			_currentPos = _selectedItem - _entriesPerPage / 2;
+			scrollToCurrent();
+		}
+
 		draw();
 	}
 }

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -65,6 +65,8 @@ protected:
 	ScrollBarWidget	*_scrollBar;
 	int				_currentKeyDown;
 
+	int				_scrollOffset;
+
 	String			_quickSelectStr;
 	uint32			_quickSelectTime;
 
@@ -127,6 +129,12 @@ public:
 	virtual bool handleKeyDown(Common::KeyState state);
 	virtual bool handleKeyUp(Common::KeyState state);
 	virtual void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
+	
+#ifdef ENABLE_TOUCHMAPPER
+	virtual void handleFingerMoved(int x, int y, int deltax, int deltay, int button);
+	virtual void handleFingerSingleTap(int x, int y, int button, int clickCount);
+	virtual void handleFingerDown(int x, int y, int button, int clickCount);
+#endif
 
 	virtual void reflowLayout();
 

--- a/gui/widgets/popup.cpp
+++ b/gui/widgets/popup.cpp
@@ -55,6 +55,10 @@ public:
 	void handleMouseMoved(int x, int y, int button);	// Redraw selections depending on mouse position
 	void handleKeyDown(Common::KeyState state);	// Scroll through entries with arrow keys etc.
 
+#ifdef ENABLE_TOUCHMAPPER
+	void handleFingerSingleTap(int x, int y, int button, int clickCount);
+#endif
+
 protected:
 	void drawMenuEntry(int entry, bool hilite);
 
@@ -260,6 +264,27 @@ void PopUpDialog::handleKeyDown(Common::KeyState state) {
 		break;
 	}
 }
+
+#ifdef ENABLE_TOUCHMAPPER
+
+void PopUpDialog::handleFingerSingleTap(int x, int y, int button, int clickCount) {
+	int dist = (_clickX - x) * (_clickX - x) + (_clickY - y) * (_clickY - y);
+	if (dist > 3 * 3 || g_system->getMillis() - _openTime > 300) {
+		int item = findItem(x, y);
+	
+		if (item >= 0 && _popUpBoss->_entries[item].name.size() == 0)
+			item = -1;
+
+		setSelection(item);
+		setResult(_selection);
+		close();
+	}
+	_clickX = -1;
+	_clickY = -1;
+	_openTime = (uint32)-1;
+}
+
+#endif
 
 int PopUpDialog::findItem(int x, int y) const {
 	if (x >= 0 && x < _w && y >= 0 && y < _h) {

--- a/gui/widgets/scrollbar.cpp
+++ b/gui/widgets/scrollbar.cpp
@@ -45,8 +45,34 @@ ScrollBarWidget::ScrollBarWidget(GuiObject *boss, int x, int y, int w, int h)
 	_numEntries = 0;
 	_entriesPerPage = 0;
 	_currentPos = 0;
+	_scrollOffset = 0;
 
 	_repeatTimer = 0;
+}
+
+void ScrollBarWidget::handleScroll(int pixels, int stepSize) {
+	int old_pos = _currentPos;
+
+	if (_numEntries < _entriesPerPage)
+		return;
+
+	int i = _scrollOffset + pixels;
+
+	if (i > 0) {
+		while (i >= stepSize) {
+			i = i - stepSize;
+			_currentPos--;	
+		}
+	} else {
+		while (i <= stepSize*-1) {
+			i = i + stepSize;
+			_currentPos++;	
+		}
+	}
+
+	_scrollOffset = i;
+	checkBounds(old_pos);
+	sendCommand(kSetScrollOffset, pixels);
 }
 
 void ScrollBarWidget::handleMouseDown(int x, int y, int button, int clickCount) {
@@ -82,22 +108,6 @@ void ScrollBarWidget::handleMouseDown(int x, int y, int button, int clickCount) 
 void ScrollBarWidget::handleMouseUp(int x, int y, int button, int clickCount) {
 	_draggingPart = kNoPart;
 	_repeatTimer = 0;
-}
-
-void ScrollBarWidget::handleMouseWheel(int x, int y, int direction) {
-	int old_pos = _currentPos;
-
-	if (_numEntries < _entriesPerPage)
-		return;
-
-	if (direction < 0) {
-		_currentPos--;
-	} else {
-		_currentPos++;
-	}
-
-	// Make sure that _currentPos is still inside the bounds
-	checkBounds(old_pos);
 }
 
 void ScrollBarWidget::handleMouseMoved(int x, int y, int button) {

--- a/gui/widgets/scrollbar.cpp
+++ b/gui/widgets/scrollbar.cpp
@@ -105,6 +105,10 @@ void ScrollBarWidget::handleMouseDown(int x, int y, int button, int clickCount) 
 	checkBounds(old_pos);
 }
 
+void ScrollBarWidget::handleMouseWheel(int x, int y, int direction) {
+	handleScroll(direction * -kLineHeight, kLineHeight);
+}
+
 void ScrollBarWidget::handleMouseUp(int x, int y, int button, int clickCount) {
 	_draggingPart = kNoPart;
 	_repeatTimer = 0;

--- a/gui/widgets/scrollbar.h
+++ b/gui/widgets/scrollbar.h
@@ -27,7 +27,8 @@
 namespace GUI {
 
 enum {
-	kSetPositionCmd		= 'SETP'
+	kSetPositionCmd		= 'SETP',
+	kSetScrollOffset	= 'SETS'
 };
 
 
@@ -59,13 +60,14 @@ public:
 	int		_numEntries;
 	int		_entriesPerPage;
 	int		_currentPos;
+	int		_scrollOffset;
 
 public:
 	ScrollBarWidget(GuiObject *boss, int x, int y, int w, int h);
 
+	void handleScroll(int pixels, int stepSize);
 	void handleMouseDown(int x, int y, int button, int clickCount);
 	void handleMouseUp(int x, int y, int button, int clickCount);
-	void handleMouseWheel(int x, int y, int direction);
 	void handleMouseMoved(int x, int y, int button);
 	void handleMouseEntered(int button)	{ setFlags(WIDGET_HILITED); }
 	void handleMouseLeft(int button)	{ clearFlags(WIDGET_HILITED); _part = kNoPart; draw(); }

--- a/gui/widgets/scrollbar.h
+++ b/gui/widgets/scrollbar.h
@@ -68,6 +68,7 @@ public:
 	void handleScroll(int pixels, int stepSize);
 	void handleMouseDown(int x, int y, int button, int clickCount);
 	void handleMouseUp(int x, int y, int button, int clickCount);
+	void handleMouseWheel(int x, int y, int direction);
 	void handleMouseMoved(int x, int y, int button);
 	void handleMouseEntered(int button)	{ setFlags(WIDGET_HILITED); }
 	void handleMouseLeft(int button)	{ clearFlags(WIDGET_HILITED); _part = kNoPart; draw(); }


### PR DESCRIPTION
This pull-request contains some of the work I did during GSoC (It's best the different features be split into separate pullreqs.).

Generally, in ScummVM widgets and dialogs have the function handleMouseDown which is called upon the active dialog when we detect a mouse-down event (EVENT_LBUTTONDOWN), for example. These commits add events for touch events that are to be interpreted by widgets. It also features widgets that are "ported" to work with gestures (i.e. scrolling lists by swiping up/down) and enabling android to use these (configure with -enable-touchmapper). 

In order to get this to work and also to work with games a "touch-mapper" is used, which is an eventManager that interprets touch-events and translates these to either work with touchpad-mode in-game, direct-input in-game or to be interpreted normally in the GUI (also another plus, is that this does not need to be written from scratch for every port).

Anyway, this code seems to work fine for Android-devices, I'd love to get some feedback as well if other gestures should be added, changed, if it may pose problems with other touch-device ports etc.
