### PR TITLE
SAGA: Silent Cppcheck warning in Sprite::loadList().

### DIFF
--- a/engines/saga/sprite.cpp
+++ b/engines/saga/sprite.cpp
@@ -102,7 +102,6 @@ void Sprite::loadList(int resourceId, SpriteList &spriteList) {
 	bool bigHeader = _vm->getGameId() == GID_IHNM || _vm->isMacResources();
 
 	for (i = oldSpriteCount; i < spriteList.size(); i++) {
-		spriteInfo = &spriteList[i];
 		if (bigHeader)
 			offset = readS.readUint32();
 		else
@@ -117,6 +116,7 @@ void Sprite::loadList(int resourceId, SpriteList &spriteList) {
 
 		spritePointer = spriteListData.getBuffer();
 		spritePointer += offset;
+		spriteInfo = &spriteList[i];
 
 		if (bigHeader) {
 			Common::MemoryReadStreamEndian readS2(spritePointer, 8, _spriteContext->isBigEndian());


### PR DESCRIPTION
This patch silents a false positive reported by Cppcheck stating that spriteInfo is invalid after the resize() of spriteList in line 114. It's false because the function returns immediately after the mentioned resize() and spriteInfo doesn't get the chance to be dereferenced while pointing to an invalid address. The patch simply postpones the assignment to spriteInfo, which makes Cppcheck happy and causes no side effects.
