### PR TITLE
TSAGE: Fix uninitialized variable.

### DIFF
--- a/engines/tsage/globals.cpp
+++ b/engines/tsage/globals.cpp
@@ -541,7 +541,7 @@ void Ringworld2Globals::synchronize(Serializer &s) {
 	s.syncAsSint16LE(_v57C2C);
 	s.syncAsSint16LE(_speechSubtitles);
 
-	byte temp;
+	byte temp = 0;
 	s.syncAsByte(temp);
 	s.syncAsByte(_s1550PlayerArea[R2_QUINN].x);
 	s.syncAsByte(_s1550PlayerArea[R2_SEEKER].x);


### PR DESCRIPTION
This patch contains a fix for an uninitialized variable issue introduced by commit 81a2892. This was caught as a warning (-Wmaybe-uninitialized) while compiling scummvm in release mode.
