### PR TITLE
SCUMM: Fix unused variable warnings

### DIFF
--- a/engines/scumm/imuse_digi/dimuse_sndmgr.cpp
+++ b/engines/scumm/imuse_digi/dimuse_sndmgr.cpp
@@ -667,15 +667,18 @@ int32 ImuseDigiSndMgr::getDataFromRegion(SoundDesc *soundDesc, int region, byte 
 		if (scumm_stricmp(fileName, soundDesc->lastFileName) != 0) {
 			int32 offs = 0, len = 0;
 			Common::SeekableReadStream *cmpFile;
+#if defined(USE_FLAC) || defined(USE_VORBIS) || defined(USE_MAD)
 			uint8 soundMode = 0;
+#endif
 
 			sprintf(fileName, "%s_reg%03d.fla", soundDesc->name, region);
 			cmpFile = soundDesc->bundle->getFile(fileName, offs, len);
 			if (len) {
 #ifndef USE_FLAC
 				error("FLAC library compiled support needed");
-#endif
+#else
 				soundMode = 3;
+#endif
 			}
 			if (!len) {
 				sprintf(fileName, "%s_reg%03d.ogg", soundDesc->name, region);
@@ -683,8 +686,9 @@ int32 ImuseDigiSndMgr::getDataFromRegion(SoundDesc *soundDesc, int region, byte 
 				if (len) {
 #ifndef USE_VORBIS
 					error("Vorbis library compiled support needed");
-#endif
+#else
 					soundMode = 2;
+#endif
 				}
 			}
 			if (!len) {
@@ -693,8 +697,9 @@ int32 ImuseDigiSndMgr::getDataFromRegion(SoundDesc *soundDesc, int region, byte 
 				if (len) {
 #ifndef USE_MAD
 					error("Mad library compiled support needed");
-#endif
+#else
 					soundMode = 1;
+#endif
 				}
 			}
 			assert(len);

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -470,8 +470,10 @@ static int compareMP3OffsetTable(const void *a, const void *b) {
 
 void Sound::startTalkSound(uint32 offset, uint32 b, int mode, Audio::SoundHandle *handle) {
 	int num = 0, i;
-	int size = 0;
 	int id = -1;
+#if defined(USE_FLAC) || defined(USE_VORBIS) || defined(USE_MAD)
+	int size = 0;
+#endif
 	Common::ScopedPtr<ScummFile> file;
 
 	if (_vm->_game.id == GID_CMI) {
@@ -562,10 +564,14 @@ void Sound::startTalkSound(uint32 offset, uint32 b, int mode, Audio::SoundHandle
 				num = result->num_tags;
 			}
 			offset = result->new_offset;
+#if defined(USE_FLAC) || defined(USE_VORBIS) || defined(USE_MAD)
 			size = result->compressed_size;
+#endif
 		} else {
 			offset += 8;
+#if defined(USE_FLAC) || defined(USE_VORBIS) || defined(USE_MAD)
 			size = -1;
+#endif
 		}
 
 		file.reset(new ScummFile());


### PR DESCRIPTION
This patch eliminates two unused-but-set-variable warnings when neither one of USE_FLAC, USE_VORBIS and USE_MAD is defined.
