### PR TITLE
CONFIGURE: Add option for building on RAM-constrained platforms eg. RPi.

### DIFF
--- a/configure
+++ b/configure
@@ -1814,6 +1814,7 @@ EOF
 	# We need at least 256MB for a static build with all engines...
 	if test "$_compile_free_memory" -lt "256" ; then
 		echo insufficient
+		echo "To override this check, pass --disable-ramcheck option to configure."
 		exit 1
 	else
 		echo ok

--- a/configure
+++ b/configure
@@ -128,6 +128,7 @@ _taskbar=yes
 _updates=no
 _libunity=auto
 # Default option behavior yes/no
+_ramcheck=yes
 _swapless_build=no
 _debug_build=auto
 _release_build=auto
@@ -889,6 +890,7 @@ Optional Features:
   --enable-c++11           build as C++11 if the compiler allows that
   --disable-debug          disable building with debugging symbols
   --enable-Werror          treat warnings as errors
+  --disable-ramcheck       bypass check for sufficient RAM to compile
   --enable-swapless-build  enable options to help avoid out of memory errors
                            when building on swapless RAM-constrained platforms
   --enable-release         enable building in release mode (this activates
@@ -1168,6 +1170,9 @@ for ac_option in $@; do
 		;;
 	--enable-Werror)
 		CXXFLAGS="$CXXFLAGS -Werror"
+		;;
+	--disable-ramcheck)
+		_ramcheck=no
 		;;
 	--enable-swapless-build)
 		_swapless_build=yes
@@ -1788,29 +1793,33 @@ fi;
 # Check for sufficient compile time memory
 #
 echo_n "Checking compile time memory... "
-if test -n "$_host"; then
-	# can't execute while cross compiling so use alternate test
-	# /proc/meminfo returns a result in kB so the awk term converts to Mb discarding the decimal fraction.
-	_compile_free_memory=`grep -i MemTotal /proc/meminfo | awk '{ print ($2-$2%1024)/1024 }'`
-else
-	cat > tmp_memory_check.cpp << EOF
+if test "$_ramcheck" = yes ; then
+	if test -n "$_host"; then
+		# can't execute while cross compiling so use alternate test
+		# /proc/meminfo returns a result in kB so the awk term converts to Mb discarding the decimal fraction.
+		_compile_free_memory=`grep -i MemTotal /proc/meminfo | awk '{ print ($2-$2%1024)/1024 }'`
+	else
+		cat > tmp_memory_check.cpp << EOF
 #include <unistd.h>
 #include <stdio.h>
 size_t getTotalSystemMemory() { long pages = sysconf(_SC_PHYS_PAGES); long page_size = sysconf(_SC_PAGE_SIZE); return pages * page_size; }
 int main(void) { printf("%lu\n", getTotalSystemMemory()/1024/1024); return 0; }
 EOF
-	$CXX $CXXFLAGS -o $TMPO tmp_memory_check.cpp
-	_compile_free_memory=`$TMPO`
-fi
-cc_check_clean tmp_memory_check.cpp
-echo_n $_compile_free_memory;
-echo_n " MB... "
-# We need at least 256MB for a static build with all engines...
-if test "$_compile_free_memory" -lt "256" ; then
-	echo insufficient
-	exit 1
+		$CXX $CXXFLAGS -o $TMPO tmp_memory_check.cpp
+		_compile_free_memory=`$TMPO`
+	fi
+	cc_check_clean tmp_memory_check.cpp
+	echo_n $_compile_free_memory;
+	echo_n " MB... "
+	# We need at least 256MB for a static build with all engines...
+	if test "$_compile_free_memory" -lt "256" ; then
+		echo insufficient
+		exit 1
+	else
+		echo ok
+	fi
 else
-	echo ok
+	echo skipped
 fi
 
 #

--- a/configure
+++ b/configure
@@ -128,6 +128,7 @@ _taskbar=yes
 _updates=no
 _libunity=auto
 # Default option behavior yes/no
+_swapless_build=no
 _debug_build=auto
 _release_build=auto
 _optimizations=auto
@@ -1169,7 +1170,7 @@ for ac_option in $@; do
 		CXXFLAGS="$CXXFLAGS -Werror"
 		;;
 	--enable-swapless-build)
-		CXXFLAGS="$CXXFLAGS -Wl,--no-keep-memory"
+		_swapless_build=yes
 		;;
 	--enable-release-mode)
 		_release_build=yes
@@ -1782,6 +1783,15 @@ if test "$have_gcc" = yes ; then
 elif test "$have_icc" = yes ; then
 	add_line_to_config_mk 'CXX_UPDATE_DEP_FLAG = -MMD -MF "$(*D)/$(DEPDIR)/$(*F).d" -MQ "$@" -MP'
 fi;
+
+#
+# Update status about swapless build mode
+#
+echo_n "Building with options for swapless build... "
+if test "$_swapless_build" = "yes" ; then
+	CXXFLAGS="$CXXFLAGS -Wl,--no-keep-memory"
+fi
+echo $_swapless_build
 
 #
 # Update status about C++11 mode

--- a/configure
+++ b/configure
@@ -1785,6 +1785,35 @@ elif test "$have_icc" = yes ; then
 fi;
 
 #
+# Check for sufficient compile time memory
+#
+echo_n "Checking compile time memory... "
+if test -n "$_host"; then
+	# can't execute while cross compiling so use alternate test
+	# /proc/meminfo returns a result in kB so the awk term converts to Mb discarding the decimal fraction.
+	_compile_free_memory=`grep -i MemTotal /proc/meminfo | awk '{ print ($2-$2%1024)/1024 }'`
+else
+	cat > tmp_memory_check.cpp << EOF
+#include <unistd.h>
+#include <stdio.h>
+size_t getTotalSystemMemory() { long pages = sysconf(_SC_PHYS_PAGES); long page_size = sysconf(_SC_PAGE_SIZE); return pages * page_size; }
+int main(void) { printf("%lu\n", getTotalSystemMemory()/1024/1024); return 0; }
+EOF
+	$CXX $CXXFLAGS -o $TMPO tmp_memory_check.cpp
+	_compile_free_memory=`$TMPO`
+fi
+cc_check_clean tmp_memory_check.cpp
+echo_n $_compile_free_memory;
+echo_n " MB... "
+# We need at least 256MB for a static build with all engines...
+if test "$_compile_free_memory" -lt "256" ; then
+	echo insufficient
+	exit 1
+else
+	echo ok
+fi
+
+#
 # Update status about swapless build mode
 #
 echo_n "Building with options for swapless build... "

--- a/configure
+++ b/configure
@@ -1789,7 +1789,9 @@ fi;
 #
 echo_n "Building with options for swapless build... "
 if test "$_swapless_build" = "yes" ; then
-	CXXFLAGS="$CXXFLAGS -Wl,--no-keep-memory"
+	if test "$have_gcc" = yes; then
+		CXXFLAGS="$CXXFLAGS -Wl,--no-keep-memory"
+	fi
 fi
 echo $_swapless_build
 

--- a/configure
+++ b/configure
@@ -129,7 +129,7 @@ _updates=no
 _libunity=auto
 # Default option behavior yes/no
 _ramcheck=yes
-_swapless_build=no
+_lowramopts=yes
 _debug_build=auto
 _release_build=auto
 _optimizations=auto
@@ -891,8 +891,8 @@ Optional Features:
   --disable-debug          disable building with debugging symbols
   --enable-Werror          treat warnings as errors
   --disable-ramcheck       bypass check for sufficient RAM to compile
-  --enable-swapless-build  enable options to help avoid out of memory errors
-                           when building on swapless RAM-constrained platforms
+  --disable-lowramopts     disable options to help avoid out of memory errors
+                           when building with insufficient RAM
   --enable-release         enable building in release mode (this activates
                            optimizations)
   --enable-release-mode    enable building in release mode (without optimizations)
@@ -1174,8 +1174,8 @@ for ac_option in $@; do
 	--disable-ramcheck)
 		_ramcheck=no
 		;;
-	--enable-swapless-build)
-		_swapless_build=yes
+	--disable-lowramopts)
+		_lowramopts=no
 		;;
 	--enable-release-mode)
 		_release_build=yes
@@ -1792,47 +1792,52 @@ fi;
 #
 # Check for sufficient compile time memory
 #
+_low_memory_threshold=256 # in MB
+_low_memory=no
 echo_n "Checking compile time memory... "
 if test "$_ramcheck" = yes ; then
-	if test -n "$_host"; then
-		# can't execute while cross compiling so use alternate test
+	_compile_free_memory=-1
+
+	# Linux
+	if test -e /proc/meminfo ; then
 		# /proc/meminfo returns a result in kB so the awk term converts to Mb discarding the decimal fraction.
 		_compile_free_memory=`grep -i MemTotal /proc/meminfo | awk '{ print ($2-$2%1024)/1024 }'`
-	else
-		cat > tmp_memory_check.cpp << EOF
-#include <unistd.h>
-#include <stdio.h>
-size_t getTotalSystemMemory() { long pages = sysconf(_SC_PHYS_PAGES); long page_size = sysconf(_SC_PAGE_SIZE); return pages * page_size; }
-int main(void) { printf("%lu\n", getTotalSystemMemory()/1024/1024); return 0; }
-EOF
-		$CXX $CXXFLAGS -o $TMPO tmp_memory_check.cpp
-		_compile_free_memory=`$TMPO`
 	fi
-	cc_check_clean tmp_memory_check.cpp
-	echo_n $_compile_free_memory;
-	echo_n " MB... "
-	# We need at least 256MB for a static build with all engines...
-	if test "$_compile_free_memory" -lt "256" ; then
-		echo insufficient
-		echo "To override this check, pass --disable-ramcheck option to configure."
-		exit 1
+
+	# BSD / OSX
+	if test -e /usr/sbin/sysctl ; then
+		# /proc/meminfo returns a result in bytes so the awk term converts to Mb discarding the decimal fraction.
+		_compile_free_memory=`sysctl hw.usermem | awk '{ print ($2-$2%(1024*1024))/(1024*1024) }'`
+	fi
+
+	if test "$_compile_free_memory" -eq "-1" ; then
+		echo "Unknown... assuming sufficient"
 	else
-		echo ok
+		echo_n $_compile_free_memory
+		echo_n " MB... "
+		if test "$_compile_free_memory" -lt "$_low_memory_threshold" ; then
+			echo insufficient
+			_low_memory=yes
+		else
+			echo ok
+		fi
 	fi
 else
 	echo skipped
 fi
 
 #
-# Update status about swapless build mode
+# Update status about low memory compile options
 #
-echo_n "Building with options for swapless build... "
-if test "$_swapless_build" = "yes" ; then
-	if test "$have_gcc" = yes; then
-		CXXFLAGS="$CXXFLAGS -Wl,--no-keep-memory"
+if test "$_low_memory" = yes; then
+	echo_n "Building with low memory compile options... "
+	if test "$_lowramopts" = "yes" ; then
+		if test "$have_gcc" = yes; then
+			CXXFLAGS="$CXXFLAGS -Wl,--no-keep-memory"
+		fi
 	fi
+	echo $_lowramopts
 fi
-echo $_swapless_build
 
 #
 # Update status about C++11 mode

--- a/configure
+++ b/configure
@@ -888,6 +888,8 @@ Optional Features:
   --enable-c++11           build as C++11 if the compiler allows that
   --disable-debug          disable building with debugging symbols
   --enable-Werror          treat warnings as errors
+  --enable-swapless-build  enable options to help avoid out of memory errors
+                           when building on swapless RAM-constrained platforms
   --enable-release         enable building in release mode (this activates
                            optimizations)
   --enable-release-mode    enable building in release mode (without optimizations)
@@ -1165,6 +1167,9 @@ for ac_option in $@; do
 		;;
 	--enable-Werror)
 		CXXFLAGS="$CXXFLAGS -Werror"
+		;;
+	--enable-swapless-build)
+		CXXFLAGS="$CXXFLAGS -Wl,--no-keep-memory"
 		;;
 	--enable-release-mode)
 		_release_build=yes


### PR DESCRIPTION
If enabled, this option passes flags to the linker to reduce the
RAM required to build. Without this, the linker caches all the
object symbols into memory for build speed, but this can trigger
Out Of Memory on swapless platforms with limited RAM.