### PR TITLE
WII: Implement changes needed by DevKitPPC R26 and later

### DIFF
--- a/backends/fs/wii/wii-fs-factory.cpp
+++ b/backends/fs/wii/wii-fs-factory.cpp
@@ -125,6 +125,8 @@ bool WiiFilesystemFactory::failedToMount(FileSystemType type) {
 	return false;
 }
 
+const DISC_INTERFACE* dvd = &__io_wiidvd;
+
 void WiiFilesystemFactory::mount(FileSystemType type) {
 	switch (type) {
 	case kDVD:
@@ -133,7 +135,7 @@ void WiiFilesystemFactory::mount(FileSystemType type) {
 			break;
 
 		printf("mount dvd\n");
-		if (ISO9660_Mount()) {
+		if (ISO9660_Mount("dvd", dvd)) {
 			_dvdMounted = true;
 			_dvdError = false;
 			printf("ISO9660 mounted\n");
@@ -179,7 +181,7 @@ void WiiFilesystemFactory::umount(FileSystemType type) {
 
 		printf("umount dvd\n");
 
-		ISO9660_Unmount();
+		ISO9660_Unmount("dvd:");
 
 		_dvdMounted = false;
 		_dvdError = false;

--- a/backends/fs/wii/wii-fs.h
+++ b/backends/fs/wii/wii-fs.h
@@ -51,7 +51,7 @@ public:
 	 *
 	 * @param path Common::String with the path the new node should point to.
 	 */
-	WiiFilesystemNode(const Common::String &path);
+	WiiFilesystemNode(const Common::String &p);
 	WiiFilesystemNode(const Common::String &p, const struct stat *st);
 
 	virtual bool exists() const;

--- a/backends/platform/wii/main.cpp
+++ b/backends/platform/wii/main.cpp
@@ -225,7 +225,8 @@ int main(int argc, char *argv[]) {
 	printf("shutdown\n");
 
 	SYS_UnregisterResetFunc(&resetinfo);
-	fatUnmountDefault();
+	fatUnmount("usb:/");
+	fatUnmount("sd:/");
 
 	if (res)
 		show_console(res);

--- a/backends/platform/wii/osystem_events.cpp
+++ b/backends/platform/wii/osystem_events.cpp
@@ -188,7 +188,7 @@ void OSystem_Wii::initEvents() {
 	_padAcceleration = 9 - ConfMan.getInt("wii_pad_acceleration");
 
 #ifdef USE_WII_KBD
-	_kbd_active = KEYBOARD_Init() >= 0;
+	_kbd_active = KEYBOARD_Init(NULL) >= 0;
 #endif
 }
 

--- a/backends/platform/wii/wii.mk
+++ b/backends/platform/wii/wii.mk
@@ -17,10 +17,10 @@ geckoupload: $(WII_EXE_STRIPPED)
 	$(DEVKITPPC)/bin/geckoupload $<
 
 wiigdb:
-	$(DEVKITPPC)/bin/powerpc-gekko-gdb -n $(EXECUTABLE)
+	$(DEVKITPPC)/bin/powerpc-eabi-gdb -n $(EXECUTABLE)
 
 wiidebug:
-	$(DEVKITPPC)/bin/powerpc-gekko-gdb -n $(EXECUTABLE) -x $(srcdir)/backends/platform/wii/gdb.txt
+	$(DEVKITPPC)/bin/powerpc-eabi-gdb -n $(EXECUTABLE) -x $(srcdir)/backends/platform/wii/gdb.txt
 
 # target to create a Wii snapshot
 wiidist: all

--- a/configure
+++ b/configure
@@ -1426,7 +1426,7 @@ webos)
 wii)
 	_host_os=wii
 	_host_cpu=ppc
-	_host_alias=powerpc-gekko
+	_host_alias=powerpc-eabi
 	;;
 wince)
 	_host_os=wince
@@ -2704,6 +2704,7 @@ if test -n "$_host"; then
 			_backend="wii"
 			_build_scalers=no
 			_vkeybd=yes
+			_taskbar=no
 			_port_mk="backends/platform/wii/wii.mk"
 			add_line_to_config_mk 'GAMECUBE = 0'
 			add_line_to_config_h '#define AUDIO_REVERSE_STEREO'


### PR DESCRIPTION
This pull request makes ScummVM compilable with newer versions of DevKitPPC. ScummVM can be linked against the original libogc and libfat. That makes some newer WiiMotes work (FR#671), improves audio-/video-playback and contains various improvements.
