### PR TITLE
ALL: Fix optimization unstable code on checking for null after new.

### DIFF
--- a/audio/decoders/voc.cpp
+++ b/audio/decoders/voc.cpp
@@ -559,7 +559,7 @@ SeekableAudioStream *makeVOCStream(Common::SeekableReadStream *stream, byte flag
 
 	SeekableAudioStream *audioStream = new VocStream(stream, (flags & Audio::FLAG_UNSIGNED) != 0, disposeAfterUse);
 
-	if (audioStream && audioStream->endOfData()) {
+	if (audioStream->endOfData()) {
 		delete audioStream;
 		return 0;
 	} else {

--- a/common/quicktime.cpp
+++ b/common/quicktime.cpp
@@ -368,9 +368,6 @@ int QuickTimeParser::readMVHD(Atom atom) {
 int QuickTimeParser::readTRAK(Atom atom) {
 	Track *track = new Track();
 
-	if (!track)
-		return -1;
-
 	track->codecType = CODEC_TYPE_MOV_OTHER;
 	track->startTime = 0; // XXX: check
 	_tracks.push_back(track);

--- a/engines/cge/cge_main.cpp
+++ b/engines/cge/cge_main.cpp
@@ -539,14 +539,12 @@ void CGEEngine::setMapBrick(int x, int z) {
 	debugC(1, kCGEDebugEngine, "CGEEngine::setMapBrick(%d, %d)", x, z);
 
 	Square *s = new Square(this);
-	if (s) {
-		char n[6];
-		s->gotoxy(x * kMapGridX, kMapTop + z * kMapGridZ);
-		sprintf(n, "%02d:%02d", x, z);
-		_clusterMap[z][x] = 1;
-		s->setName(n);
-		_vga->_showQ->insert(s, _vga->_showQ->first());
-	}
+	char n[6];
+	s->gotoxy(x * kMapGridX, kMapTop + z * kMapGridZ);
+	sprintf(n, "%02d:%02d", x, z);
+	_clusterMap[z][x] = 1;
+	s->setName(n);
+	_vga->_showQ->insert(s, _vga->_showQ->first());
 }
 
 void CGEEngine::keyClick() {

--- a/engines/cge/sound.cpp
+++ b/engines/cge/sound.cpp
@@ -186,6 +186,10 @@ DataCk *Fx::load(int idx, int ref) {
 
 DataCk *Fx::loadWave(EncryptedStream *file) {
 	byte *data = (byte *)malloc(file->size());
+
+	if (!data)
+		return 0;
+
 	file->read(data, file->size());
 
 	return new DataCk(data, file->size());

--- a/engines/sci/graphics/picture.cpp
+++ b/engines/sci/graphics/picture.cpp
@@ -283,8 +283,6 @@ void GfxPicture::drawCelData(byte *inbuffer, int size, int headerPos, int rlePos
 	//  That needs to be done cause a mirrored picture may be requested
 	pixelCount = width * height;
 	celBitmap = new byte[pixelCount];
-	if (!celBitmap)
-		error("Unable to allocate temporary memory for picture drawing");
 
 	if (g_sci->getPlatform() == Common::kPlatformMacintosh && getSciVersion() >= SCI_VERSION_2) {
 		// See GfxView::unpackCel() for why this black/white swap is done

--- a/engines/sci/graphics/ports.cpp
+++ b/engines/sci/graphics/ports.cpp
@@ -300,11 +300,6 @@ Window *GfxPorts::addWindow(const Common::Rect &dims, const Common::Rect *restor
 	Window *pwnd = new Window(id);
 	Common::Rect r;
 
-	if (!pwnd) {
-		error("Can't open window");
-		return 0;
-	}
-
 	_windowsById[id] = pwnd;
 
 	// KQ1sci, KQ4, iceman, QfG2 always add windows to the back of the list.

--- a/engines/tony/sound.cpp
+++ b/engines/tony/sound.cpp
@@ -88,7 +88,7 @@ FPSound::~FPSound() {
 bool FPSound::createStream(FPStream **streamPtr) {
 	(*streamPtr) = new FPStream(_soundSupported);
 
-	return (*streamPtr != NULL);
+	return true;
 }
 
 /**

--- a/graphics/sjis.cpp
+++ b/graphics/sjis.cpp
@@ -40,31 +40,25 @@ FontSJIS *FontSJIS::createFont(const Common::Platform platform) {
 	// Try the font ROM of the specified platform
 	if (platform == Common::kPlatformFMTowns) {
 		ret = new FontTowns();
-		if (ret) {
-			if (ret->loadData())
-				return ret;
-		}
+		if (ret->loadData())
+			return ret;
 		delete ret;
 	} else if (platform == Common::kPlatformPCEngine) {
 		ret = new FontPCEngine();
-		if (ret) {
-			if (ret->loadData())
-				return ret;
-		}
+		if (ret->loadData())
+			return ret;
 		delete ret;
 	} // TODO: PC98 font rom support
 	/* else if (platform == Common::kPlatformPC98) {
 		ret = new FontPC98();
-		if (ret) {
-			if (ret->loadData())
-				return ret;
-		}
+		if (ret->loadData())
+			return ret;
 		delete ret;
 	}*/
 
 	// Try ScummVM's font.
 	ret = new FontSjisSVM(platform);
-	if (ret && ret->loadData())
+	if (ret->loadData())
 		return ret;
 	delete ret;
 


### PR DESCRIPTION
This Pull Request is to discuss whether this solution is safe across all ports and the impact on the codebase of this issue... especially with respect to exception usage in new operator calls.

These issues were identified by the STACK tool.

By default, the C++ new operator will throw an exception on allocation
failure, rather than returning a null pointer.

The result is that testing the returned pointer for null is redundant
and _may_ be removed by the compiler.

However, we do not use exceptions as they are not supported by all
compilers and may be disabled.

The resulting "pattern" is thus optimization unstable and may result
in unexpected or errorneous behaviour.

To make this stable without removing the null check, you can qualify
the new operator call with std::nothrow to indicate that this should
return a null, rather than throwing an exception.

It is unclear the behaviour of new when -fno-exceptions is active on
the compiler and whether we should instead be redefining "new" as
"new (std::nothrow)" and adding explicit tests for null and handling
code in all cases.
