### PR TITLE
SDL: Avoid having SDL_SRCALPHA set even if we have alpha in the pixelformat.

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -746,6 +746,8 @@ bool SurfaceSdlGraphicsManager::loadGFXMode() {
 	if (_screen == NULL)
 		error("allocating _screen failed");
 
+	// Avoid having SDL_SRCALPHA set even if we supplied an alpha-channel in the format.
+	SDL_SetAlpha(_screen, 0, 255);
 #else
 	_screen = SDL_CreateRGBSurface(SDL_SWSURFACE, _videoMode.screenWidth, _videoMode.screenHeight, 8, 0, 0, 0, 0);
 	if (_screen == NULL)


### PR DESCRIPTION
There are issues with WME producing "ghosting"-artifacts in Dirty Split and Chivalry when using the SDL-rendering backend. These do not show when running the OpenGL-backend.

Looking into it a bit, it seems that explicitly disabling SDL_SRCALPHA on the _screen surface solves this issue. (As the documentation states that this is implicitly enabled when non-0 alpha-masks are supplied).
