### PR TITLE
ANDROID: Fix a race condition

### DIFF
--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -86,13 +86,15 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 		Log.d(LOG_TAG, String.format("surfaceChanged: %dx%d (%d)",
 										width, height, format));
 
+		// store values for the native code
+		// make sure to do it before notifying the lock
+		// as it leads to a race condition otherwise
+		setSurface(width, height);
+
 		synchronized(_sem_surface) {
 			_surface_holder = holder;
 			_sem_surface.notifyAll();
 		}
-
-		// store values for the native code
-		setSurface(width, height);
 	}
 
 	// SurfaceHolder callback


### PR DESCRIPTION
setSurface is done in a different thread than the one that starts the scummvm main. The main thread would then wait until the setSurface thread notifies. The setSurface thread would notify before it actually calls setSurface, meaning if the thread is preemted before calling setSurface, initSurface will assert, causing the app to crash.

I've never actually seen this crash in ScummVM, but this fixes the issue for ResidualVM. I assume it happens in ResidualVM because we are using a native size surface which takes longer to create.
