### PR TITLE
TUCKER: Fix bug #6381 "TUCKER: In 3rd part, "Use Peg" fails...So game uncompletable"

### DIFF
--- a/engines/tucker/tucker.cpp
+++ b/engines/tucker/tucker.cpp
@@ -3682,7 +3682,7 @@ void TuckerEngine::setActionForInventoryObject() {
 		_actionRequiresTwoObjects = false;
 		return;
 	}
-    if ((_partNum == 3 && (_actionObj1Num == 6 || _actionObj1Num == 3 || _actionObj1Num == 17 || _actionObj1Num == 33)) ||
+	if ((_partNum == 3 && (_actionObj1Num == 6 || _actionObj1Num == 3 || _actionObj1Num == 17 || _actionObj1Num == 33)) ||
 		(_partNum == 2 && _actionObj1Num == 19) ||
 		(_partNum == 3 && (_actionObj1Num == 42 && _selectedObjectNum == 18)) ) {
 		_actionVerbLocked = 0;


### PR DESCRIPTION
"Use from inventory" actions which not requires another object are specified by hardcode. I'm just added missing object ID in this condition.
Before this fix you should use object "Peg" with object "Peg". Now it works like in DOS version.

http://sourceforge.net/p/scummvm/bugs/6381/
