### PR TITLE
BUILD: Link against libogg when FLAC is used but not libvorbis.

### DIFF
--- a/configure
+++ b/configure
@@ -3327,18 +3327,18 @@ if test "$_flac" = auto ; then
 int main(void) { return FLAC__STREAM_SYNC_LEN >> 30; /* guaranteed to be 0 */ }
 EOF
 	if test "$_vorbis" = yes ; then
-		cc_check $FLAC_CFLAGS $FLAC_LIBS $OGG_CFLAGS $OGG_LIBS \
-			-lFLAC -logg && _flac=yes
-	else
 		cc_check $FLAC_CFLAGS $FLAC_LIBS \
 			-lFLAC && _flac=yes
+	else
+		cc_check $FLAC_CFLAGS $FLAC_LIBS $OGG_CFLAGS $OGG_LIBS \
+			-lFLAC -logg && _flac=yes
 	fi
 fi
 if test "$_flac" = yes ; then
 	if test "$_vorbis" = yes ; then
-		LIBS="$LIBS $FLAC_LIBS $OGG_LIBS -lFLAC -logg"
-	else
 		LIBS="$LIBS $FLAC_LIBS -lFLAC"
+	else
+		LIBS="$LIBS $FLAC_LIBS $OGG_LIBS -lFLAC -logg"
 	fi
 	INCLUDES="$INCLUDES $FLAC_CFLAGS"
 fi

--- a/ports.mk
+++ b/ports.mk
@@ -116,6 +116,9 @@ endif
 
 ifdef USE_FLAC
 OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libFLAC.a
+ifndef USE_VORBIS
+OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libogg.a
+endif
 endif
 
 ifdef USE_FLUIDSYNTH


### PR DESCRIPTION
The old code oddly linked against libogg when vorbis was enabled. However, in
this case libogg is already linked against. Since FLAC requires libogg we
should also link against it even when vorbis is disabled. This should fix
static libFLAC linking when libvorbis is disabled.

It might be noteworthy that statically linking against libFLAC when it was build with libogg support disabled worked before and should be broken now when libogg is not present at all... I am however not sure how we can detect that libFLAC depends on libogg easily. If anybody has some suggestions, that's most welcome.
