### PR TITLE
AGOS: RFC: Feeble Files mouse wheel support

### DIFF
--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -834,6 +834,9 @@ protected:
 	void displayBoxStars();
 	void invertBox(HitArea * ha, byte a, byte b, byte c, byte d);
 
+	virtual void handleMouseWheelUp() {}
+	virtual void handleMouseWheelDown() {}
+
 	virtual void initMouse();
 	virtual void handleMouseMoved();
 	virtual void drawMousePointer();
@@ -1974,6 +1977,9 @@ protected:
 
 	virtual void drawImage(VC10_state *state);
 	void scaleClip(int16 h, int16 w, int16 y, int16 x, int16 scrollY);
+
+	virtual void handleMouseWheelUp();
+	virtual void handleMouseWheelDown();
 
 	void drawMousePart(int image, byte x, byte y);
 	virtual void initMouse();

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -517,6 +517,12 @@ void AGOSEngine::delay(uint amount) {
 			case Common::EVENT_RBUTTONUP:
 				_rightClick = true;
 				break;
+			case Common::EVENT_WHEELUP:
+				handleMouseWheelUp();
+				break;
+			case Common::EVENT_WHEELDOWN:
+				handleMouseWheelDown();
+				break;
 			case Common::EVENT_RTL:
 			case Common::EVENT_QUIT:
 				return;

--- a/engines/agos/oracle.cpp
+++ b/engines/agos/oracle.cpp
@@ -34,6 +34,18 @@
 
 namespace AGOS {
 
+void AGOSEngine_Feeble::handleMouseWheelUp() {
+	if (getGameType() == GType_FF && getBitFlag(99)) {
+		oracleTextDown();
+	}
+}
+
+void AGOSEngine_Feeble::handleMouseWheelDown() {
+	if (getGameType() == GType_FF && getBitFlag(99)) {
+		oracleTextUp();
+	}
+}
+
 void AGOSEngine_Feeble::checkLinkBox() {	// Check for boxes spilling over to next row of text
 	if (_hyperLink != 0) {
 		_variableArray[52] = _textWindow->x + _textWindow->textColumn - _variableArray[50];


### PR DESCRIPTION
The Oracle in The Feeble Files has always struck me as having a rather clunky user interface. This is an early attempt at adding mouse wheel support to it.

Unfortunately, it doesn't work quite as well as I had hoped. It seems to work well enough for encyclopedia articles, the status display, etc. But the savegame list isn't updated often (?) enough to look smooth when scrolling through several lines at a time.

Also, it would be nice if it could handle the inventory box as well. I imagine that's simply a matter of checking the current mouse cursor position to determine what the user wants to scroll, and passing the appropriate parameters to inventoryUp() / inventoryDown(). Problem is, I'm not quite sure what the appropriate parameters are.

If this can be made to work, I imagine it could also be extended to cover the inventories and save game lists of Simon the Sorcerer 1 and 2. (Though they never struck me as quite as cumbersome to use as the ones in The Feeble Files.)
