### PR TITLE
LURE: Use the mouse pointer for menus on the Wii

### DIFF
--- a/engines/lure/menu.cpp
+++ b/engines/lure/menu.cpp
@@ -31,7 +31,7 @@
 #include "lure/events.h"
 #include "lure/lure.h"
 
-#if defined(_WIN32_WCE) || defined(__SYMBIAN32__) || defined(WEBOS) || defined(__ANDROID__)
+#if defined(_WIN32_WCE) || defined(__SYMBIAN32__) || defined(WEBOS) || defined(__ANDROID__) || defined(__WII__)
 #define LURE_CLICKABLE_MENUS
 #endif
 


### PR DESCRIPTION
Without this, this game is almost unplayable, since the
scrolling menus respond to the slightest tilt of the
Wiimote, typically scrolling from the top straight to the
bottom.  Using a mouse pointer in the menus is much easier.
