### PR TITLE
TSAGE: Fix bug #6545 "Ringworld2 - F5 doesn't create a save game the first time"

### DIFF
--- a/engines/tsage/ringworld2/ringworld2_logic.cpp
+++ b/engines/tsage/ringworld2/ringworld2_logic.cpp
@@ -1215,12 +1215,6 @@ void Ringworld2Game::processEvent(Event &event) {
 			R2_GLOBALS._events.setCursorFromFlag();
 			break;
 
-		case Common::KEYCODE_F5:
-			// F5 - Save
-			saveGame();
-			R2_GLOBALS._events.setCursorFromFlag();
-			break;
-
 		case Common::KEYCODE_F7:
 			// F7 - Restore
 			restoreGame();


### PR DESCRIPTION
The save dialog glitched es the F5 event was already processed in
engines/tsage/core.cpp and it caused the to immediately reopen.
