### PR TITLE
WII: Fix color key handling for 16bit mouse cursors.

### DIFF
--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -717,8 +717,8 @@ void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 			u16 *d = (u16 *) tmp;
 			for (u16 y = 0; y < h; ++y) {
 				for (u16 x = 0; x < w; ++x) {
-					if (*s++ != _mouseKeyColor)
-						*d++ |= 7 << 12;
+					if (*s++ == _mouseKeyColor)
+						*d++ &= ~(7 << 12);
 					else
 						d++;
 				}


### PR DESCRIPTION
This should fix bug #6108 "WII: Zak FM-TOWNS mouse cursor encased in blue box".

This has not been tested since I don't own any Wii. But it will make the cursor color key handling more sane, i.e. instead of making non color key pixels opaque it will make the pixels with the color key fully transparent. Other pixels should already be opaque when no alpha channel is used to due cross blit. And if an alpha channel is used the input knows probably what it wants transparent and what it doesn't. (I don't we give any guarantees that this last case is anyhow supported though).
