### PR TITLE
ANDROID: Fix color key handling for 16bit mouse cursors.

### DIFF
--- a/backends/platform/android/gfx.cpp
+++ b/backends/platform/android/gfx.cpp
@@ -760,7 +760,7 @@ void OSystem_Android::setMouseCursor(const void *buf, uint w, uint h,
 		for (uint16 y = 0; y < h; ++y, d += pitch / 2 - w)
 			for (uint16 x = 0; x < w; ++x, d++)
 				if (*s++ == (keycolor & 0xffff))
-					*d &= ~1;
+					*d = 0;
 
 		_mouse_texture->updateBuffer(0, 0, w, h, tmp, pitch);
 


### PR DESCRIPTION
This should fix a issue similarly to bug #6108: "WII: Zak FM-TOWNS mouse cursor encased in blue box". Which is reported over here: http://forums.scummvm.org/viewtopic.php?t=12299

Again completely untested. But it will make the cursor color key handling more sane, i.e. instead of making non color key pixels opaque it will make the pixels with the color key fully transparent. Other pixels should already be opaque when no alpha channel is used to due cross blit. And if an alpha channel is used the input knows probably what it wants transparent and what it doesn't. (I don't we give any guarantees that this last case is anyhow supported though).
