### PR TITLE
Proof-of-Concept: Display unknown version information in GUI

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -514,7 +514,7 @@ GameDescriptor EngineManager::findGameInLoadedPlugins(const Common::String &game
 	return result;
 }
 
-GameList EngineManager::detectGames(const Common::FSList &fslist) const {
+GameList EngineManager::detectGames(const Common::FSList &fslist, Common::String *error) const {
 	GameList candidates;
 	EnginePlugin::List plugins;
 	EnginePlugin::List::const_iterator iter;
@@ -524,7 +524,14 @@ GameList EngineManager::detectGames(const Common::FSList &fslist) const {
 		// Iterate over all known games and for each check if it might be
 		// the game in the presented directory.
 		for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
-			candidates.push_back((**iter)->detectGames(fslist));
+			Common::String unknownVersion;
+			candidates.push_back((**iter)->detectGames(fslist, &unknownVersion));
+
+			// TODO: Should we really just concatenate all the error messages
+			// about unknown versions from all engines?
+			if (error && !unknownVersion.empty()) {
+				*error += unknownVersion;
+			}
 		}
 	} while (PluginManager::instance().loadNextPlugin());
 	return candidates;

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -261,7 +261,7 @@ public:
 
 	virtual GameDescriptor findGame(const char *gameid) const;
 
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+	virtual GameList detectGames(const Common::FSList &fslist, Common::String *error) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 
@@ -294,9 +294,10 @@ protected:
 	 * @param language	restrict results to specified language
 	 * @param platform	restrict results to specified platform
 	 * @param extra		restrict results to specified extra string (only if kADFlagUseExtraAsHint is set)
+	 * @param error		optional error string about unknown version(s)
 	 * @return	list of ADGameDescription pointers corresponding to matched games
 	 */
-	ADGameDescList detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra) const;
+	ADGameDescList detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, Common::String *unknownVersion) const;
 
 	/**
 	 * Iterates over all ADFileBasedFallback records inside fileBasedFallback.
@@ -315,8 +316,9 @@ protected:
 	/**
 	 * Log and print a report that we found an unknown game variant, together with the file
 	 * names, sizes and MD5 sums.
+	 * @return Information about unknown version.
 	 */
-	void reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps) const;
+	Common::String reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps) const;
 
 	// TODO
 	void updateGameDescriptor(GameDescriptor &desc, const ADGameDescription *realDesc) const;

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -78,8 +78,12 @@ public:
 	 * Runs the engine's game detector on the given list of files, and returns a
 	 * (possibly empty) list of games supported by the engine which it was able
 	 * to detect amongst the given files.
+	 *
+	 * @param error Optional error string about unknown game versions. This
+	 *              should be in the GUI language and only be used for
+	 *              displaying it through our GUI.
 	 */
-	virtual GameList detectGames(const Common::FSList &fslist) const = 0;
+	virtual GameList detectGames(const Common::FSList &fslist, Common::String *error = nullptr) const = 0;
 
 	/**
 	 * Tries to instantiate an engine instance based on the settings of
@@ -259,7 +263,7 @@ class EngineManager : public Common::Singleton<EngineManager> {
 public:
 	GameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const EnginePlugin **plugin = NULL) const;
 	GameDescriptor findGame(const Common::String &gameName, const EnginePlugin **plugin = NULL) const;
-	GameList detectGames(const Common::FSList &fslist) const;
+	GameList detectGames(const Common::FSList &fslist, Common::String *error = nullptr) const;
 	const EnginePlugin::List &getPlugins() const;
 };
 

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -914,7 +914,7 @@ public:
 	virtual bool hasFeature(MetaEngineFeature f) const;
 	virtual GameList getSupportedGames() const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+	virtual GameList detectGames(const Common::FSList &fslist, Common::String *error) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 
@@ -977,7 +977,7 @@ static Common::String generatePreferredTarget(const DetectorResult &x) {
 	return res;
 }
 
-GameList ScummMetaEngine::detectGames(const Common::FSList &fslist) const {
+GameList ScummMetaEngine::detectGames(const Common::FSList &fslist, Common::String *error) const {
 	GameList detectedGames;
 	Common::List<DetectorResult> results;
 

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -79,7 +79,7 @@ public:
 	virtual GameList getSupportedGames() const;
 	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+	virtual GameList detectGames(const Common::FSList &fslist, Common::String *error) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 
@@ -141,7 +141,7 @@ GameDescriptor SkyMetaEngine::findGame(const char *gameid) const {
 	return GameDescriptor();
 }
 
-GameList SkyMetaEngine::detectGames(const Common::FSList &fslist) const {
+GameList SkyMetaEngine::detectGames(const Common::FSList &fslist, Common::String *error) const {
 	GameList detectedGames;
 	bool hasSkyDsk = false;
 	bool hasSkyDnr = false;

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -89,7 +89,7 @@ public:
 	virtual bool hasFeature(MetaEngineFeature f) const;
 	virtual GameList getSupportedGames() const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+	virtual GameList detectGames(const Common::FSList &fslist, Common::String *error) const;
 	virtual SaveStateList listSaves(const char *target) const;
 	virtual int getMaximumSaveSlot() const;
 	virtual void removeSaveState(const char *target, int slot) const;
@@ -176,7 +176,7 @@ void Sword1CheckDirectory(const Common::FSList &fslist, bool *filesFound, bool r
 	}
 }
 
-GameList SwordMetaEngine::detectGames(const Common::FSList &fslist) const {
+GameList SwordMetaEngine::detectGames(const Common::FSList &fslist, Common::String *error) const {
 	int i, j;
 	GameList detectedGames;
 	bool filesFound[NUM_FILES_TO_CHECK];

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -95,7 +95,7 @@ public:
 	virtual GameList getSupportedGames() const;
 	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+	virtual GameList detectGames(const Common::FSList &fslist, Common::String *error) const;
 	virtual SaveStateList listSaves(const char *target) const;
 	virtual int getMaximumSaveSlot() const;
 	virtual void removeSaveState(const char *target, int slot) const;
@@ -222,7 +222,7 @@ GameList detectGamesImpl(const Common::FSList &fslist, bool recursion = false) {
 	return detectedGames;
 }
 
-GameList Sword2MetaEngine::detectGames(const Common::FSList &fslist) const {
+GameList Sword2MetaEngine::detectGames(const Common::FSList &fslist, Common::String *error) const {
 	return detectGamesImpl(fslist);
 }
 
@@ -276,7 +276,7 @@ Common::Error Sword2MetaEngine::createInstance(OSystem *syst, Engine **engine) c
 
 	// Invoke the detector
 	Common::String gameid = ConfMan.get("gameid");
-	GameList detectedGames = detectGames(fslist);
+	GameList detectedGames = detectGames(fslist, nullptr);
 
 	for (uint i = 0; i < detectedGames.size(); i++) {
 		if (detectedGames[i].gameid() == gameid) {

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -845,20 +845,46 @@ void LauncherDialog::addGame() {
 
 			// ...so let's determine a list of candidates, games that
 			// could be contained in the specified directory.
-			GameList candidates(EngineMan.detectGames(files));
+			Common::String errors;
+			GameList candidates(EngineMan.detectGames(files, &errors));
 
 			int idx;
 			if (candidates.empty()) {
 				// No game was found in the specified directory
-				MessageDialog alert(_("ScummVM could not find any game in the specified directory!"));
+				Common::String couldNotFindGame = _("ScummVM could not find any game in the specified directory!");
+
+				if (!errors.empty()) {
+					couldNotFindGame += "\n\n";
+					couldNotFindGame += errors;
+				}
+
+				MessageDialog alert(couldNotFindGame);
 				alert.runModal();
 				idx = -1;
 
 				looping = true;
 			} else if (candidates.size() == 1) {
+				// In case we got information about an unknown version display
+				// it to the user, so he can inform us about it.
+				// CHECKME: Could it be possible that we get this warning from
+				// a different engine than that we got the detection entry
+				// from? In that case we probably should not display it...
+				// See also the TODO in EngineManager::detectGames inside
+				// base/plugins.cpp.
+				if (!errors.empty()) {
+					Common::String unknownVersion = _("ScummVM does not know the exact game version in the specified directory!");
+					unknownVersion += "\n\n";
+					unknownVersion += errors;
+
+					MessageDialog alert(unknownVersion);
+					alert.runModal();
+				}
+
 				// Exact match
 				idx = 0;
 			} else {
+				// TODO: Should we display unknown version information here?
+
 				// Display the candidates to the user and let her/him pick one
 				StringArray list;
 				for (idx = 0; idx < (int)candidates.size(); idx++)


### PR DESCRIPTION
I wanted to push this out for discussion for a long time, so let's do it now :-P. As the title suggests this is a try at showing unknown version information on detection to the user. This will hopefully raise awareness of the users that even though ScummVM might detect a game he still might have an unkown version (and thus that we would like to get a report about it).

The GUI is pretty a simple hack (and should be replaced by a proper scrollable text field, since otherwise it doesn't really fit in lowres mode). The API extensions to detectGames is also really simple and we might think of making this nicer (maybe we add a getLastDetectionError/Information?).

Attached some screenshots so you get a feeling of how it looks like. These show the dialog which will come up when ScummVM's AdvancedDetector detects a game via fallback.
Hires:
![scummvm-hires-unknown](https://cloud.githubusercontent.com/assets/177695/2614894/b3b6eff0-bbf0-11e3-8b60-91d9a94646d1.png)
Lowres:
![scummvm-lores-unknown](https://cloud.githubusercontent.com/assets/177695/2614897/bac1ccca-bbf0-11e3-8024-f248a71f4acd.png)