### PR TITLE
COMMON: Do not use public fix on newer versions of MSVC

### DIFF
--- a/common/singleton.h
+++ b/common/singleton.h
@@ -44,7 +44,7 @@ private:
 	 * and you specialise makeInstance to return an instance of a subclass.
 	 */
 	//template<class T>
-#if defined(_WIN32_WCE) || defined(_MSC_VER) || defined(__WINS__)
+#if defined(_WIN32_WCE) || (defined(_MSC_VER) && _MSC_VER < 1600) || defined(__WINS__)
 //FIXME evc4 and msvc7 doesn't like it as private member
 public:
 #endif


### PR DESCRIPTION
_MSC_VER 1800 is MSVC 2013, where the code compiles correctly without this. It may also work properly in older version, but I don't have any other versions to test with.
