### PR TITLE
ANDROID: Allow build with non-ancient SDK

### DIFF
--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -48,10 +48,10 @@ PLUGIN_RESOURCES = \
 #LDFLAGS += -Wl,--gc-sections
 #CXXFLAGS += -ffunction-sections -fdata-sections -fvisibility=hidden -fvisibility-inlines-hidden
 
-AAPT = $(ANDROID_SDK)/platform-tools/aapt
+AAPT = $(ANDROID_SDK)/$(ANDROID_BTOOLS)/aapt
 ADB = $(ANDROID_SDK)/platform-tools/adb
-DX = $(ANDROID_SDK)/platform-tools/dx
-APKBUILDER = $(ANDROID_SDK)/tools/apkbuilder
+DX = $(ANDROID_SDK)/$(ANDROID_BTOOLS)/dx
+APKBUILDER = java -Xmx128M -classpath $(ANDROID_SDK)/tools/lib/sdklib.jar com.android.sdklib.build.ApkBuilderMain
 JAVAC ?= javac
 JAVACFLAGS = -source 1.5 -target 1.5
 

--- a/configure
+++ b/configure
@@ -2157,6 +2157,12 @@ case $_host_os in
 		LDFLAGS="$LDFLAGS -L$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/`$CXX -dumpversion`/libs/$ABI/"
 		LIBS="$LIBS -lsupc++"
 		add_line_to_config_mk "ANDROID_SDK = $ANDROID_SDK"
+		if test -d "$ANDROID_SDK"/build-tools; then
+			_build_tools_version=`cd "$ANDROID_SDK"/build-tools && ls -1 | sort -rn | head -1`
+			add_line_to_config_mk "ANDROID_BTOOLS = build-tools/$_build_tools_version"
+		else
+			add_line_to_config_mk "ANDROID_BTOOLS = platform-tools"
+		fi
 		_seq_midi=no
 		;;
 	beos*)


### PR DESCRIPTION
This change makes it possible to build ScummVM for Android with an Android SDK that is not over 3 years old...  :-)
