### PR TITLE
MYST: Channelwood elevator restore bugfix

### DIFF
--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -100,6 +100,9 @@ bool MystGameState::load(const Common::String &filename) {
 	syncGameState(s, size == 664);
 	delete loadFile;
 
+	// Set Channelwood elevator state to down, because we start on the lower level
+	_channelwood.elevatorState = 0;
+
 	// Switch us back to the intro stack, to the linking book
 	_vm->changeToStack(kIntroStack, 5, 0, 0);
 


### PR DESCRIPTION
Added a bit that sets the elevator to down in Channelwood when loading a save, as this is the correct behavior of the game.  There's more than one way to get this behavior, but this seems to me to be the most straightforward way to do it.
