### PR TITLE
AUDIO: Increment total play time when decoding MP3 data.

### DIFF
--- a/audio/decoders/mp3.cpp
+++ b/audio/decoders/mp3.cpp
@@ -59,7 +59,7 @@ protected:
 	State _state;
 
 	Timestamp _length;
-	mad_timer_t _totalTime;
+	mad_timer_t _curTime;
 
 	mad_stream _stream;
 	mad_frame _frame;
@@ -99,7 +99,7 @@ MP3Stream::MP3Stream(Common::SeekableReadStream *inStream, DisposeAfterUse::Flag
 	_posInFrame(0),
 	_state(MP3_STATE_INIT),
 	_length(0, 1000),
-	_totalTime(mad_timer_zero) {
+	_curTime(mad_timer_zero) {
 
 	// The MAD_BUFFER_GUARD must always contain zeros (the reason
 	// for this is that the Layer III Huffman decoder of libMAD
@@ -119,7 +119,7 @@ MP3Stream::MP3Stream(Common::SeekableReadStream *inStream, DisposeAfterUse::Flag
 	// Note that we allow "MAD_ERROR_BUFLEN" as error code here, since according
 	// to mad.h it is also set on EOF.
 	if ((_stream.error == MAD_ERROR_NONE || _stream.error == MAD_ERROR_BUFLEN) && getRate() > 0)
-		_length = Timestamp(mad_timer_count(_totalTime, MAD_UNITS_MILLISECONDS), getRate());
+		_length = Timestamp(mad_timer_count(_curTime, MAD_UNITS_MILLISECONDS), getRate());
 
 	deinitStream();
 
@@ -167,7 +167,7 @@ void MP3Stream::decodeMP3Data() {
 			}
 
 			// Sum up the total playback time so far
-			mad_timer_add(&_totalTime, _frame.header.duration);
+			mad_timer_add(&_curTime, _frame.header.duration);
 			// Synthesize PCM data
 			mad_synth_frame(&_synth, &_frame);
 			_posInFrame = 0;
@@ -222,10 +222,10 @@ bool MP3Stream::seek(const Timestamp &where) {
 	mad_timer_t destination;
 	mad_timer_set(&destination, time / 1000, time % 1000, 1000);
 
-	if (_state != MP3_STATE_READY || mad_timer_compare(destination, _totalTime) < 0)
+	if (_state != MP3_STATE_READY || mad_timer_compare(destination, _curTime) < 0)
 		initStream();
 
-	while (mad_timer_compare(destination, _totalTime) > 0 && _state != MP3_STATE_EOS)
+	while (mad_timer_compare(destination, _curTime) > 0 && _state != MP3_STATE_EOS)
 		readHeader();
 
 	decodeMP3Data();
@@ -244,7 +244,7 @@ void MP3Stream::initStream() {
 
 	// Reset the stream data
 	_inStream->seek(0, SEEK_SET);
-	_totalTime = mad_timer_zero;
+	_curTime = mad_timer_zero;
 	_posInFrame = 0;
 
 	// Update state
@@ -282,7 +282,7 @@ void MP3Stream::readHeader() {
 		}
 
 		// Sum up the total playback time so far
-		mad_timer_add(&_totalTime, _frame.header.duration);
+		mad_timer_add(&_curTime, _frame.header.duration);
 		break;
 	}
 


### PR DESCRIPTION
This fixes a bug in the implementation of `MP3Stream`. If the playback of a MP3 stream hasn't yet reached the end-of-stream, seeking the stream backwards does not work as expected.

`MP3Stream::seek` attempts to determine whether the position to seek to is before or after the current stream position by comparing the seek position to the value of `_totalTime`. On current master `_totalTime` is, however, never incremented during normal MP3 playback, so it does not match the actual stream position. This causes the method not to rewind the stream even though it should.

I discovered the bug while working on Escape from Monkey Island support for ResidualVM (residualvm/residualvm#972).
