### PR TITLE
GRAPHICS: Fix conversion from 1-bit to 8-bit alpha in colorToARGB.

### DIFF
--- a/graphics/pixelformat.h
+++ b/graphics/pixelformat.h
@@ -97,7 +97,13 @@ struct PixelFormat {
 	}
 
 	inline void colorToARGB(uint32 color, uint8 &a, uint8 &r, uint8 &g, uint8 &b) const {
-		a = (aBits() == 0) ? 0xFF : (((color >> aShift) << aLoss) & 0xFF);
+		if (aBits() == 0) {
+			a = 0xFF;
+		} else if (aBits() == 1) {
+			a = (color >> aShift) ? 0xFF : 0;
+		} else {
+			a = ((color >> aShift) << aLoss) & 0xFF;
+		}
 		r = ((color >> rShift) << rLoss) & 0xFF;
 		g = ((color >> gShift) << gLoss) & 0xFF;
 		b = ((color >> bShift) << bLoss) & 0xFF;


### PR DESCRIPTION
The colorToARGB method in PixelFormat has an issue if the pixel format specifies a 1-bit alpha channel.

The naive (but fast) method used for mapping the color channels to the 8-bit value range darkens the color a bit in the process. This is especially noticeable with a 1-bit alpha channel. A 1-bit alpha value 1 is mapped to the 8-bit value 128, so the resulting color will be half transparent.

This PR adds special handling for the 1-bit alpha case, so the returned color will either be fully transparent or fully opaque depending on the value of the alpha bit.

We encountered the issue in ResidualVM with Escape from Monkey Island where we need to convert pixel buffers in 1555 pixel format to RGBA. If any future ScummVM engines attempt to do something similar, this fix may save the devs some headache.
