### PR TITLE
AMIGAOS: Add AmigaOS version format

### DIFF
--- a/base/version.cpp
+++ b/base/version.cpp
@@ -56,6 +56,9 @@
  * to properly work in exports (i.e. release tar balls etc.).
  */
 const char *gScummVMVersion = SCUMMVM_VERSION;
+#ifdef __amigaos4__
+static const char *version_cookie __attribute__((used)) = "$VER: ScummVM " SCUMMVM_VERSION " (" __DATE__ ", " __TIME__ ")";
+#endif
 #ifdef __PLAYSTATION2__
 const char *gScummVMBuildDate = "Git Master"; /* ScummVM Git Master */
 const char *gScummVMVersionDate = SCUMMVM_VERSION " - PlayStation2";


### PR DESCRIPTION
AmigaOS features a "version" command which can read out version information if stored in a sepcific way.
To get to that information it parses the exe for "$VER:" and prints out everything behind it.

This adds such a version information to ScummVM so users on AmigaOS can read it out without the need to use "scummvm --version"
