### PR TITLE
COMMON: Use true nullptr in Visual Studio 2010+ and true override in VS 2012+

### DIFF
--- a/common/c++11-compat.h
+++ b/common/c++11-compat.h
@@ -32,13 +32,17 @@
 // though.
 //
 #if !defined(nullptr)  // XCode 5.0.1 has __cplusplus=199711 but defines this
+#if !defined(_MSC_VER) || _MSC_VER < 1600
 #define nullptr 0
+#endif
 #endif
 
 //
 // Replacement for the override keyword. This allows compilation of code
 // which uses it, but does not feature any semantic.
 //
+#if !defined(_MSC_VER) || _MSC_VER < 1700
 #define override
+#endif
 
 #endif


### PR DESCRIPTION
Those compilers support these features despite not being fully C++11-compliant.

http://msdn.microsoft.com/en-us/library/hh567368.aspx says that VS 2010 has "partial" support for `override`. I don't know what that entails and I can't test it, so I err on the side of caution and only enable it in 2012 and up.
