### PR TITLE
SCUMM: Fix bug #6724 by changing the assert into a warning

### DIFF
--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -1013,8 +1013,11 @@ void ScummEngine::resetRoomObject(ObjectData *od, const byte *room, const byte *
 		od->actordir = (byte)READ_LE_UINT16(&imhd->v7.actordir);
 
 	} else if (_game.version == 6) {
-		assert(imhd);
 		od->obj_nr = READ_LE_UINT16(&(cdhd->v6.obj_id));
+		// This used to be an assert(imhd) but the Russion version of FF1 triggered it.
+		// FIXME: Needs a real fix (tm) where we skip the assert for only the Russian version 
+		if (!imhd)
+			warning("resetRoomObject() called but no imhd was found for object %d in room %d",od->obj_nr,int(room));
 
 		od->width = READ_LE_UINT16(&cdhd->v6.w);
 		od->height = READ_LE_UINT16(&cdhd->v6.h);


### PR DESCRIPTION
This is the quick & dirty fix for #6724. It's unclear to me how the real fix should look like. For a game specific work-around the game's language should be part of _game structure and we would need a GID for FF1. Not something I would like to dive into without knowing if I am on the right track there.
