### PR TITLE
PUTTZOO: Fix Bug #6097- Raft disappearing when skipping dialog

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -707,6 +707,13 @@ void ScummEngine_v6::o6_ifNot() {
 void ScummEngine_v6::o6_jump() {
 	int offset = fetchScriptWordSigned();
 
+	// WORKAROUND bug #6097: Pressing escape at the lake side entrance of the cave
+	// while Putt Putt is not on solid ground and still talking will cause the raft
+	// to disappear. This is a script bug in the original game.
+	if (_game.id == GID_PUTTZOO && vm.slot[_currentScript].number == 206 && offset == 176 && !isScriptRunning(202)) {
+		offset = 157;
+	}
+
 	// WORKAROUND bug #2826144: Talking to the guard at the bigfoot party, after
 	// he's let you inside, will cause the game to hang, if you end the conversation.
 	// This is a script bug, due to a missing jump in one segment of the script.


### PR DESCRIPTION
Script 206 from room 35:

[0000](6B) cursorCommand.userPutOff()
[0002](6B) cursorCommand.cursorOff()
[0004](95) beginOverride()
[0005](73) jump b8
[0008](5D) if (!roomvar66) /_00A5_/ {
[000F](BB)   talkEgo("@T44692137,22979@Well, Pep, it looks like we made it to dry land!")
[0052](A9)   wait.waitForMessage()
[0054](BB)   talkEgo("@T44715116,25848@I wonder if we'll find any of the missing baby animals here.")
[00A3](A9)   wait.waitForMessage()
[00A5]() }
[00A5](5E) startScript(1,202,[3])
[00AD](5C) until (!isScriptRunning(202)) /_00B8_/ {
[00B4](6C)   breakHere()
[00B5]() }
[00B8](5D) if (VAR_OVERRIDE) /_010F_/ {

Script 202 sets Var244 (raft location) to 35 (current room), but that script does not get executed if you press escape while Putt Putt is talking because the jump b8 at [0005] jumps over this code. Changing this jump to a jump to A5 should fix this bug.
