### PR TITLE
COMMON: Add support for endian-safe reading/writing of int64

### DIFF
--- a/common/endian.h
+++ b/common/endian.h
@@ -49,6 +49,17 @@
 #	error No endianness defined
 #endif
 
+
+#define SWAP_CONSTANT_64(a) \
+	((uint64)((((a) >> 56) & 0x000000FF) | \
+	          (((a) >> 40) & 0x0000FF00) | \
+	          (((a) >> 24) & 0x00FF0000) | \
+	          (((a) >>  8) & 0xFF000000) | \
+	          (((a) & 0xFF000000) <<  8) | \
+	          (((a) & 0x00FF0000) << 24) | \
+	          (((a) & 0x0000FF00) << 40) | \
+	          (((a) & 0x000000FF) << 56) ))
+
 #define SWAP_CONSTANT_32(a) \
 	((uint32)((((a) >> 24) & 0x00FF) | \
 	          (((a) >>  8) & 0xFF00) | \
@@ -58,6 +69,62 @@
 #define SWAP_CONSTANT_16(a) \
 	((uint16)((((a) >>  8) & 0x00FF) | \
 	          (((a) <<  8) & 0xFF00) ))
+
+/**
+ * Swap the bytes in a 64 bit word in order to convert LE encoded data to BE
+ * and vice versa.
+ */
+
+// machine/compiler-specific variants come first, fallback last
+
+// Test for GCC and if the target has the MIPS rel.2 instructions (we know the psp does)
+//
+// TODO: Fix this #if statement. It isn't changed from 32 bit. Is there a 64 bit swap instruction?
+#if defined(__GNUC__) && (defined(__psp__) || defined(_MIPS_ARCH_MIPS32R2) || defined(_MIPS_ARCH_MIPS64R2))
+
+	FORCEINLINE uint32 SWAP_BYTES_32(const uint32 a) {
+		if (__builtin_constant_p(a)) {
+			return SWAP_CONSTANT_32(a);
+		} else {
+			uint32 result;
+#	if defined(__psp__)
+			// use special allegrex instruction
+			__asm__ ("wsbw %0,%1" : "=r" (result) : "r" (a));
+#	else
+			__asm__ ("wsbh %0,%1\n"
+			         "rotr %0,%0,16" : "=r" (result) : "r" (a));
+#	endif
+			return result;
+		}
+	}
+
+// Test for GCC >= 4.3.0 as this version added the bswap builtin
+#elif GCC_ATLEAST(4, 3)
+
+	FORCEINLINE uint64 SWAP_BYTES_64(uint64 a) {
+		return __builtin_bswap64(a);
+	}
+
+#elif defined(_MSC_VER)
+
+	FORCEINLINE uint64 SWAP_BYTES_64(uint64 a) {
+		return _byteswap_uint64(a);
+	}
+
+// generic fallback
+#else
+
+	inline uint64 SWAP_BYTES_64(uint64 a) {
+		uint32 low = (uint32)a, high = (uint32)(a >> 32);
+		uint16 lowLow = (uint16)low, lowHigh = (uint16)(low >> 16),
+		       highLow = (uint16)high, highHigh = (uint16)(high >> 16);
+
+		return ((uint64)(((uint32)(uint16)((lowLow   >> 8) | (lowLow   << 8)) << 16) |
+		                          (uint16)((lowHigh  >> 8) | (lowHigh  << 8))) << 32) |
+		                (((uint32)(uint16)((highLow  >> 8) | (highLow  << 8)) << 16) |
+		                          (uint16)((highHigh >> 8) | (highHigh << 8)))
+	}
+#endif
 
 /**
  * Swap the bytes in a 32 bit word in order to convert LE encoded data to BE
@@ -173,6 +240,11 @@
 		return ((const Unaligned32 *)ptr)->val;
 	}
 
+	FORCEINLINE uint64 READ_UINT64(const void *ptr) {
+		struct Unaligned64 { uint64 val; } __attribute__ ((__packed__, __may_alias__));
+		return ((const Unaligned64 *)ptr)->val;
+	}
+
 	FORCEINLINE void WRITE_UINT16(void *ptr, uint16 value) {
 		struct Unaligned16 { uint16 val; } __attribute__ ((__packed__, __may_alias__));
 		((Unaligned16 *)ptr)->val = value;
@@ -181,6 +253,11 @@
 	FORCEINLINE void WRITE_UINT32(void *ptr, uint32 value) {
 		struct Unaligned32 { uint32 val; } __attribute__ ((__packed__, __may_alias__));
 		((Unaligned32 *)ptr)->val = value;
+	}
+
+	FORCEINLINE void WRITE_UINT64(void *ptr, uint64 value) {
+		struct Unaligned64 { uint64 val; } __attribute__((__packed__, __may_alias__));
+		((Unaligned64 *)ptr)->val = value;
 	}
 
 #elif !defined(SCUMM_NEED_ALIGNMENT)
@@ -193,12 +270,20 @@
 		return *(const uint32 *)(ptr);
 	}
 
+	FORCEINLINE uint64 READ_UINT64(const void *ptr) {
+		return *(const uint64 *)(ptr);
+	}
+
 	FORCEINLINE void WRITE_UINT16(void *ptr, uint16 value) {
 		*(uint16 *)(ptr) = value;
 	}
 
 	FORCEINLINE void WRITE_UINT32(void *ptr, uint32 value) {
 		*(uint32 *)(ptr) = value;
+	}
+
+	FORCEINLINE void WRITE_UINT64(void *ptr, uint64 value) {
+		*(uint64 *)(ptr) = value;
 	}
 
 
@@ -215,6 +300,10 @@
 			const uint8 *b = (const uint8 *)ptr;
 			return (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | (b[0]);
 		}
+		inline uint64 READ_UINT64(const void *ptr) {
+			const uint8 *b = (const uint8 *)ptr;
+			return (b[7] << 56) | (b[6] << 48) | (b[5] << 40) | (b[4] << 32) | (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | (b[0]);
+		}
 		inline void WRITE_UINT16(void *ptr, uint16 value) {
 			uint8 *b = (uint8 *)ptr;
 			b[0] = (uint8)(value >> 0);
@@ -227,6 +316,17 @@
 			b[2] = (uint8)(value >> 16);
 			b[3] = (uint8)(value >> 24);
 		}
+		inline void WRITE_UINT64(void *ptr, uint64 value) {
+			uint8 *b = (uint8 *)ptr;
+			b[0] = (uint8)(value >>  0);
+			b[1] = (uint8)(value >>  8);
+			b[2] = (uint8)(value >> 16);
+			b[3] = (uint8)(value >> 24);
+			b[4] = (uint8)(value >> 32);
+			b[5] = (uint8)(value >> 40);
+			b[6] = (uint8)(value >> 48);
+			b[7] = (uint8)(value >> 56);
+		}
 
 #	elif defined(SCUMM_BIG_ENDIAN)
 
@@ -237,6 +337,10 @@
 		inline uint32 READ_UINT32(const void *ptr) {
 			const uint8 *b = (const uint8 *)ptr;
 			return (b[0] << 24) | (b[1] << 16) | (b[2] << 8) | (b[3]);
+		}
+		inline uint64 READ_UINT64(const void *ptr) {
+			const uint8 *b = (const uint8 *)ptr;
+			return (b[0] << 56) | (b[1] << 48) | (b[2] << 40) | (b[3] << 32) | (b[4] << 24) | (b[5] << 16) | (b[6] << 8) | (b[7]);
 		}
 		inline void WRITE_UINT16(void *ptr, uint16 value) {
 			uint8 *b = (uint8 *)ptr;
@@ -250,6 +354,17 @@
 			b[2] = (uint8)(value >>  8);
 			b[3] = (uint8)(value >>  0);
 		}
+		inline void WRITE_UINT64(void *ptr, uint64 value) {
+			uint8 *b = (uint8 *)ptr;
+			b[0] = (uint8)(value >> 56);
+			b[1] = (uint8)(value >> 48);
+			b[2] = (uint8)(value >> 40);
+			b[3] = (uint8)(value >> 32);
+			b[4] = (uint8)(value >> 24);
+			b[5] = (uint8)(value >> 16);
+			b[6] = (uint8)(value >>  8);
+			b[7] = (uint8)(value >>  0);
+		}
 
 #	endif
 
@@ -261,25 +376,33 @@
 
 	#define READ_LE_UINT16(a) READ_UINT16(a)
 	#define READ_LE_UINT32(a) READ_UINT32(a)
+	#define READ_LE_UINT64(a) READ_UINT64(a)
 
 	#define WRITE_LE_UINT16(a, v) WRITE_UINT16(a, v)
 	#define WRITE_LE_UINT32(a, v) WRITE_UINT32(a, v)
+	#define WRITE_LE_UINT64(a, v) WRITE_UINT64(a, v)
 
+	#define FROM_LE_64(a) ((uint64)(a))
 	#define FROM_LE_32(a) ((uint32)(a))
 	#define FROM_LE_16(a) ((uint16)(a))
 
+	#define FROM_BE_64(a) SWAP_BYTES_64(a)
 	#define FROM_BE_32(a) SWAP_BYTES_32(a)
 	#define FROM_BE_16(a) SWAP_BYTES_16(a)
 
+	#define TO_LE_64(a) ((uint64)(a))
 	#define TO_LE_32(a) ((uint32)(a))
 	#define TO_LE_16(a) ((uint16)(a))
 
+	#define TO_BE_64(a) SWAP_BYTES_64(a)
 	#define TO_BE_32(a) SWAP_BYTES_32(a)
 	#define TO_BE_16(a) SWAP_BYTES_16(a)
 
+	#define CONSTANT_LE_64(a) ((uint64)(a))
 	#define CONSTANT_LE_32(a) ((uint32)(a))
 	#define CONSTANT_LE_16(a) ((uint16)(a))
 
+	#define CONSTANT_BE_64(a) SWAP_CONSTANT_64(a)
 	#define CONSTANT_BE_32(a) SWAP_CONSTANT_32(a)
 	#define CONSTANT_BE_16(a) SWAP_CONSTANT_16(a)
 
@@ -294,6 +417,10 @@
 			const uint8 *b = (const uint8 *)ptr;
 			return (b[0] << 24) | (b[1] << 16) | (b[2] << 8) | (b[3]);
 		}
+		inline uint64 READ_BE_UINT64(const void *ptr) {
+			const uint8 *b = (const uint8 *)ptr;
+			return (b[0] << 56) | b[1] << 48) | b[2] << 40) | b[3] << 32) | b[4] << 24) | (b[5] << 16) | (b[6] << 8) | (b[7]);
+		}
 		inline void WRITE_BE_UINT16(void *ptr, uint16 value) {
 			uint8 *b = (uint8 *)ptr;
 			b[0] = (uint8)(value >> 8);
@@ -306,6 +433,17 @@
 			b[2] = (uint8)(value >>  8);
 			b[3] = (uint8)(value >>  0);
 		}
+		inline void WRITE_BE_UINT64(void *ptr, uint64 value) {
+			uint8 *b = (uint8 *)ptr;
+			b[0] = (uint8)(value >> 56);
+			b[1] = (uint8)(value >> 48);
+			b[2] = (uint8)(value >> 40);
+			b[3] = (uint8)(value >> 32);
+			b[4] = (uint8)(value >> 24);
+			b[5] = (uint8)(value >> 16);
+			b[6] = (uint8)(value >> 8);
+			b[7] = (uint8)(value >> 0);
+		}
 #	else
 
 		inline uint16 READ_BE_UINT16(const void *ptr) {
@@ -314,11 +452,17 @@
 		inline uint32 READ_BE_UINT32(const void *ptr) {
 			return SWAP_BYTES_32(READ_UINT32(ptr));
 		}
+		inline uint32 READ_BE_UINT64(const void *ptr) {
+			return SWAP_BYTES_64(READ_UINT64(ptr));
+		}
 		inline void WRITE_BE_UINT16(void *ptr, uint16 value) {
 			WRITE_UINT16(ptr, SWAP_BYTES_16(value));
 		}
 		inline void WRITE_BE_UINT32(void *ptr, uint32 value) {
 			WRITE_UINT32(ptr, SWAP_BYTES_32(value));
+		}
+		inline void WRITE_BE_UINT64(void *ptr, uint64 value) {
+			WRITE_UINT64(ptr, SWAP_BYTES_64(value));
 		}
 
 #	endif	// if defined(SCUMM_NEED_ALIGNMENT)
@@ -327,25 +471,33 @@
 
 	#define READ_BE_UINT16(a) READ_UINT16(a)
 	#define READ_BE_UINT32(a) READ_UINT32(a)
+	#define READ_BE_UINT64(a) READ_UINT64(a)
 
 	#define WRITE_BE_UINT16(a, v) WRITE_UINT16(a, v)
 	#define WRITE_BE_UINT32(a, v) WRITE_UINT32(a, v)
+	#define WRITE_BE_UINT64(a, v) WRITE_UINT64(a, v)
 
+	#define FROM_LE_64(a) SWAP_BYTES_64(a)
 	#define FROM_LE_32(a) SWAP_BYTES_32(a)
 	#define FROM_LE_16(a) SWAP_BYTES_16(a)
 
+	#define FROM_BE_64(a) ((uint64)(a))
 	#define FROM_BE_32(a) ((uint32)(a))
 	#define FROM_BE_16(a) ((uint16)(a))
 
+	#define TO_LE_64(a) SWAP_BYTES_64(a)
 	#define TO_LE_32(a) SWAP_BYTES_32(a)
 	#define TO_LE_16(a) SWAP_BYTES_16(a)
 
+	#define TO_BE_64(a) ((uint64)(a))	
 	#define TO_BE_32(a) ((uint32)(a))
 	#define TO_BE_16(a) ((uint16)(a))
 
+	#define CONSTANT_LE_64(a) SWAP_CONSTANT_64(a)	
 	#define CONSTANT_LE_32(a) SWAP_CONSTANT_32(a)
 	#define CONSTANT_LE_16(a) SWAP_CONSTANT_16(a)
 
+	#define CONSTANT_BE_64(a) ((uint64)(a))
 	#define CONSTANT_BE_32(a) ((uint32)(a))
 	#define CONSTANT_BE_16(a) ((uint16)(a))
 
@@ -360,6 +512,10 @@
 		const uint8 *b = (const uint8 *)ptr;
 		return (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | (b[0]);
 	}
+	inline uint64 READ_LE_UINT64(const void *ptr) {
+		const uint8 *b = (const uint8 *)ptr;
+		return (b[7] << 56) | (b[6] << 48) | (b[5] << 40) | (b[4] << 32) | (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | (b[0]);
+	}
 	inline void WRITE_LE_UINT16(void *ptr, uint16 value) {
 		uint8 *b = (uint8 *)ptr;
 		b[0] = (uint8)(value >> 0);
@@ -372,6 +528,17 @@
 		b[2] = (uint8)(value >> 16);
 		b[3] = (uint8)(value >> 24);
 	}
+	inline void WRITE_LE_UINT64(void *ptr, uint64 value) {
+		uint8 *b = (uint8 *)ptr;
+		b[0] = (uint8)(value >>  0);
+		b[1] = (uint8)(value >>  8);
+		b[2] = (uint8)(value >> 16);
+		b[3] = (uint8)(value >> 24);
+		b[4] = (uint8)(value >> 32);
+		b[5] = (uint8)(value >> 40);
+		b[6] = (uint8)(value >> 48);
+		b[7] = (uint8)(value >> 56);
+	}
 #	else
 
 	inline uint16 READ_LE_UINT16(const void *ptr) {
@@ -380,11 +547,17 @@
 	inline uint32 READ_LE_UINT32(const void *ptr) {
 		return SWAP_BYTES_32(READ_UINT32(ptr));
 	}
+	inline uint64 READ_LE_UINT64(const void *ptr) {
+		return SWAP_BYTES_64(READ_UINT64(ptr));
+	}
 	inline void WRITE_LE_UINT16(void *ptr, uint16 value) {
 		WRITE_UINT16(ptr, SWAP_BYTES_16(value));
 	}
 	inline void WRITE_LE_UINT32(void *ptr, uint32 value) {
 		WRITE_UINT32(ptr, SWAP_BYTES_32(value));
+	}
+	inline void WRITE_LE_UINT64(void *ptr, uint64 value) {
+		WRITE_UINT64(ptr, SWAP_BYTES_64(value));
 	}
 
 #	endif	// if defined(SCUMM_NEED_ALIGNMENT)

--- a/common/stream.h
+++ b/common/stream.h
@@ -266,7 +266,7 @@ public:
 	 * if a read error occurred (for which client code can check by
 	 * calling err() and eos() ).
 	 */
-	uint32 readUint64LE() {
+	uint64 readUint64LE() {
 		uint64 val;
 		read(&val, 8);
 		return FROM_LE_64(val);
@@ -305,7 +305,7 @@ public:
 	 * if a read error occurred (for which client code can check by
 	 * calling err() and eos() ).
 	 */
-	uint32 readUint64BE() {
+	uint64 readUint64BE() {
 		uint64 val;
 		read(&val, 8);
 		return FROM_BE_64(val);

--- a/common/stream.h
+++ b/common/stream.h
@@ -125,6 +125,11 @@ public:
 		write(&value, 4);
 	}
 
+	void writeUint64LE(uint64 value) {
+		value = TO_LE_64(value);
+		write(&value, 8);
+	}
+
 	void writeUint16BE(uint16 value) {
 		value = TO_BE_16(value);
 		write(&value, 2);
@@ -135,6 +140,11 @@ public:
 		write(&value, 4);
 	}
 
+	void writeUint64BE(uint64 value) {
+		value = TO_BE_64(value);
+		write(&value, 8);
+	}
+
 	FORCEINLINE void writeSint16LE(int16 value) {
 		writeUint16LE((uint16)value);
 	}
@@ -143,12 +153,20 @@ public:
 		writeUint32LE((uint32)value);
 	}
 
+	FORCEINLINE void writeSint64LE(int64 value) {
+		writeUint64LE((uint64)value);
+	}
+
 	FORCEINLINE void writeSint16BE(int16 value) {
 		writeUint16BE((uint16)value);
 	}
 
 	FORCEINLINE void writeSint32BE(int32 value) {
 		writeUint32BE((uint32)value);
+	}
+
+	FORCEINLINE void writeSint64BE(int64 value) {
+		writeUint64BE((uint64)value);
 	}
 
 	/**
@@ -242,6 +260,19 @@ public:
 	}
 
 	/**
+	 * Read an unsigned 64-bit word stored in little endian (LSB first) order
+	 * from the stream and return it.
+	 * Performs no error checking. The return value is undefined
+	 * if a read error occurred (for which client code can check by
+	 * calling err() and eos() ).
+	 */
+	uint32 readUint64LE() {
+		uint64 val;
+		read(&val, 8);
+		return FROM_LE_64(val);
+	}
+
+	/**
 	 * Read an unsigned 16-bit word stored in big endian (MSB first) order
 	 * from the stream and return it.
 	 * Performs no error checking. The return value is undefined
@@ -268,6 +299,19 @@ public:
 	}
 
 	/**
+	 * Read an unsigned 64-bit word stored in big endian (MSB first) order
+	 * from the stream and return it.
+	 * Performs no error checking. The return value is undefined
+	 * if a read error occurred (for which client code can check by
+	 * calling err() and eos() ).
+	 */
+	uint32 readUint64BE() {
+		uint64 val;
+		read(&val, 8);
+		return FROM_BE_64(val);
+	}
+
+	/**
 	 * Read a signed 16-bit word stored in little endian (LSB first) order
 	 * from the stream and return it.
 	 * Performs no error checking. The return value is undefined
@@ -290,6 +334,17 @@ public:
 	}
 
 	/**
+	 * Read a signed 64-bit word stored in little endian (LSB first) order
+	 * from the stream and return it.
+	 * Performs no error checking. The return value is undefined
+	 * if a read error occurred (for which client code can check by
+	 * calling err() and eos() ).
+	 */
+	FORCEINLINE int64 readSint64LE() {
+		return (int64)readUint64LE();
+	}
+
+	/**
 	 * Read a signed 16-bit word stored in big endian (MSB first) order
 	 * from the stream and return it.
 	 * Performs no error checking. The return value is undefined
@@ -309,6 +364,17 @@ public:
 	 */
 	FORCEINLINE int32 readSint32BE() {
 		return (int32)readUint32BE();
+	}
+
+	/**
+	 * Read a signed 64-bit word stored in big endian (MSB first) order
+	 * from the stream and return it.
+	 * Performs no error checking. The return value is undefined
+	 * if a read error occurred (for which client code can check by
+	 * calling err() and eos() ).
+	 */
+	FORCEINLINE int64 readSint64BE() {
+		return (int64)readUint64BE();
 	}
 
 	/**

--- a/test/common/endian.h
+++ b/test/common/endian.h
@@ -10,6 +10,18 @@ class EndianTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(MKTAG('A','B','C','D'), tag);
 	}
 
+	void test_READ_BE_UINT64() {
+		const char data[8] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xFF};
+		uint64 value = READ_BE_UINT64(data);
+		TS_ASSERT_EQUALS(value, 0x123456789ABCDEFFULL);
+	}
+
+	void test_READ_LE_UINT64() {
+		const char data[8] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xFF};
+		uint64 value = READ_LE_UINT64(data);
+		TS_ASSERT_EQUALS(value, 0xFFEDCBA978563412ULL);
+	}
+
 	void test_READ_BE_UINT32() {
 		const char data[4] = { 0x12, 0x34, 0x56, 0x78 };
 		uint32 value = READ_BE_UINT32(data);

--- a/test/common/memoryreadstream.h
+++ b/test/common/memoryreadstream.h
@@ -60,28 +60,32 @@ class MemoryReadStreamTestSuite : public CxxTest::TestSuite {
 	}
 
 	void test_seek_read_le() {
-		byte contents[] = { 1, 2, 3, 4, 5, 6, 7 };
+		byte contents[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 		Common::MemoryReadStream ms(contents, sizeof(contents));
 
 		TS_ASSERT_EQUALS(ms.readUint16LE(), 0x0201UL);
 		TS_ASSERT_EQUALS(ms.pos(), 2);
 		TS_ASSERT_EQUALS(ms.readUint32LE(), 0x06050403UL);
 		TS_ASSERT_EQUALS(ms.pos(), 6);
-		TS_ASSERT_EQUALS(ms.readByte(), 0x07);
-		TS_ASSERT_EQUALS(ms.pos(), 7);
+		TS_ASSERT_EQUALS(ms.readUint64LE(), 0x0E0D0C0B0A090807ULL);
+		TS_ASSERT_EQUALS(ms.pos(), 14);
+		TS_ASSERT_EQUALS(ms.readByte(), 0x0F);
+		TS_ASSERT_EQUALS(ms.pos(), 15);
 		TS_ASSERT(!ms.eos());
 	}
 
 	void test_seek_read_be() {
-		byte contents[] = { 1, 2, 3, 4, 5, 6, 7 };
+		byte contents[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 		Common::MemoryReadStream ms(contents, sizeof(contents));
 
 		TS_ASSERT_EQUALS(ms.readUint16BE(), 0x0102UL);
 		TS_ASSERT_EQUALS(ms.pos(), 2);
 		TS_ASSERT_EQUALS(ms.readUint32BE(), 0x03040506UL);
 		TS_ASSERT_EQUALS(ms.pos(), 6);
-		TS_ASSERT_EQUALS(ms.readByte(), 0x07);
-		TS_ASSERT_EQUALS(ms.pos(), 7);
+		TS_ASSERT_EQUALS(ms.readUint64LE(), 0x0708090A0B0C0D0EULL);
+		TS_ASSERT_EQUALS(ms.pos(), 14);
+		TS_ASSERT_EQUALS(ms.readByte(), 0x0F);
+		TS_ASSERT_EQUALS(ms.pos(), 15);
 		TS_ASSERT(!ms.eos());
 	}
 

--- a/test/common/memoryreadstreamendian.h
+++ b/test/common/memoryreadstreamendian.h
@@ -60,54 +60,62 @@ class MemoryReadStreamEndianTestSuite : public CxxTest::TestSuite {
 	}
 
 	void test_seek_read_le() {
-		byte contents[] = { 1, 2, 3, 4, 5, 6, 7 };
+		byte contents[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 		Common::MemoryReadStreamEndian ms(contents, sizeof(contents), false);
 
 		TS_ASSERT_EQUALS(ms.readUint16LE(), 0x0201UL);
 		TS_ASSERT_EQUALS(ms.pos(), 2);
 		TS_ASSERT_EQUALS(ms.readUint32LE(), 0x06050403UL);
 		TS_ASSERT_EQUALS(ms.pos(), 6);
-		TS_ASSERT_EQUALS(ms.readByte(), 0x07);
-		TS_ASSERT_EQUALS(ms.pos(), 7);
+		TS_ASSERT_EQUALS(ms.readUint64LE(), 0x0E0D0C0B0A090807ULL);
+		TS_ASSERT_EQUALS(ms.pos(), 14);
+		TS_ASSERT_EQUALS(ms.readByte(), 0x0F);
+		TS_ASSERT_EQUALS(ms.pos(), 15);
 		TS_ASSERT(!ms.eos());
 	}
 
 	void test_seek_read_be() {
-		byte contents[] = { 1, 2, 3, 4, 5, 6, 7 };
+		byte contents[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 		Common::MemoryReadStreamEndian ms(contents, sizeof(contents), false);
 
 		TS_ASSERT_EQUALS(ms.readUint16BE(), 0x0102UL);
 		TS_ASSERT_EQUALS(ms.pos(), 2);
 		TS_ASSERT_EQUALS(ms.readUint32BE(), 0x03040506UL);
 		TS_ASSERT_EQUALS(ms.pos(), 6);
-		TS_ASSERT_EQUALS(ms.readByte(), 0x07);
-		TS_ASSERT_EQUALS(ms.pos(), 7);
+		TS_ASSERT_EQUALS(ms.readUint64LE(), 0x0708090A0B0C0D0EULL);
+		TS_ASSERT_EQUALS(ms.pos(), 14);
+		TS_ASSERT_EQUALS(ms.readByte(), 0x0F);
+		TS_ASSERT_EQUALS(ms.pos(), 15);
 		TS_ASSERT(!ms.eos());
 	}
 
 	void test_seek_read_le2() {
-		byte contents[] = { 1, 2, 3, 4, 5, 6, 7 };
+		byte contents[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 		Common::MemoryReadStreamEndian ms(contents, sizeof(contents), false);
 
 		TS_ASSERT_EQUALS(ms.readUint16(), 0x0201UL);
 		TS_ASSERT_EQUALS(ms.pos(), 2);
 		TS_ASSERT_EQUALS(ms.readUint32(), 0x06050403UL);
 		TS_ASSERT_EQUALS(ms.pos(), 6);
-		TS_ASSERT_EQUALS(ms.readByte(), 0x07);
-		TS_ASSERT_EQUALS(ms.pos(), 7);
+		TS_ASSERT_EQUALS(ms.readUint64LE(), 0x0E0D0C0B0A090807ULL);
+		TS_ASSERT_EQUALS(ms.pos(), 14);
+		TS_ASSERT_EQUALS(ms.readByte(), 0x0F);
+		TS_ASSERT_EQUALS(ms.pos(), 15);
 		TS_ASSERT(!ms.eos());
 	}
 
 	void test_seek_read_be2() {
-		byte contents[] = { 1, 2, 3, 4, 5, 6, 7 };
+		byte contents[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 		Common::MemoryReadStreamEndian ms(contents, sizeof(contents), true);
 
 		TS_ASSERT_EQUALS(ms.readUint16(), 0x0102UL);
 		TS_ASSERT_EQUALS(ms.pos(), 2);
 		TS_ASSERT_EQUALS(ms.readUint32(), 0x03040506UL);
 		TS_ASSERT_EQUALS(ms.pos(), 6);
-		TS_ASSERT_EQUALS(ms.readByte(), 0x07);
-		TS_ASSERT_EQUALS(ms.pos(), 7);
+		TS_ASSERT_EQUALS(ms.readUint64LE(), 0x0708090A0B0C0D0EULL);
+		TS_ASSERT_EQUALS(ms.pos(), 14);
+		TS_ASSERT_EQUALS(ms.readByte(), 0x0F);
+		TS_ASSERT_EQUALS(ms.pos(), 15);
 		TS_ASSERT(!ms.eos());
 	}
 };


### PR DESCRIPTION
The concept is rather self explanatory. There are however, some potential problems:

1. First, I need someone to help me figure out if there is a mips instruction for 64 bit swap, and if so, help me write the asm
2. clone2727 brought up the point that int64 can be disabled in configure. If int64 is disabled, this code will fail to compile. There are a couple choices
  1. Surround this code with #ifdef guards. This isn't the best solution because any engines that use the code will now be restricted to backends that allow int64.
  2. Are there actually backends that don't have support for int64? If not, then we could remove the option to disabled int64 in configure


Let me know if you have any questions and feel free to comment.