### PR TITLE
VIDEO: Include the correct header in theora_decoder.h

### DIFF
--- a/video/theora_decoder.h
+++ b/video/theora_decoder.h
@@ -20,7 +20,7 @@
  *
  */
 
-#include "common/scummsys.h"	// for USE_THEORADEC
+#include "config.h"	// for USE_THEORADEC
 
 #ifdef USE_THEORADEC
 


### PR DESCRIPTION
USE_THEORADEC comes from config.h.
It usually is included by something else anyway so it's not a big deal, but it does make IntelliSense sad.
