### PR TITLE
Fix support for libunity in configure

### DIFF
--- a/configure
+++ b/configure
@@ -3863,6 +3863,10 @@ EOF
 	esac
 fi
 if test "$_libunity" = yes ; then
+	if test "$LIBUNITY_CFLAGS" = "" || test "$LIBUNITY_LIBS" = ""; then
+		LIBUNITY_LIBS="$LIBUNITY_LIBS `pkg-config --libs 'unity > 3.8.1' 2>> "$TMPLOG"`"
+		LIBUNITY_CFLAGS="$LIBUNITY_CFLAGS `pkg-config --cflags 'unity > 3.8.1' 2>> "$TMPLOG"`"
+	fi
 	LIBS="$LIBS $LIBUNITY_LIBS"
 	INCLUDES="$INCLUDES $LIBUNITY_CFLAGS"
 fi


### PR DESCRIPTION
This should fix http://sourceforge.net/p/scummvm/bugs/6688/
Two things:
1. For some reason we asked for unity exactly == 3.8.4.
Bad for everyone who isn't stuck in 2011.
2. If unity was explicity enabled BUT we weren't explictly provided a prefix, we didn't set LIBUNITY_LIBS and -_CFLAGS

There might be other problems, of course, as @wjp noted
