### PR TITLE
WME: Multirect 2014

### DIFF
--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -26,20 +26,20 @@
  * Copyright (c) 2011 Jan Nedoma
  */
 
+#include "common/system.h"
+#include "common/queue.h"
+#include "common/config-manager.h"
+#include "engines/wintermute/base/base_surface_storage.h"
+#include "engines/wintermute/base/base_game.h"
+#include "engines/wintermute/base/base_sprite.h"
+#include "engines/wintermute/base/gfx/base_image.h"
+#include "engines/wintermute/base/gfx/osystem/dirty_rect_container.h"
 #include "engines/wintermute/base/gfx/osystem/base_render_osystem.h"
 #include "engines/wintermute/base/gfx/osystem/base_surface_osystem.h"
 #include "engines/wintermute/base/gfx/osystem/render_ticket.h"
-#include "engines/wintermute/base/base_surface_storage.h"
-#include "engines/wintermute/base/gfx/base_image.h"
 #include "engines/wintermute/math/math_util.h"
-#include "engines/wintermute/base/base_game.h"
-#include "engines/wintermute/base/base_sprite.h"
-#include "common/system.h"
 #include "graphics/transparent_surface.h"
-#include "common/queue.h"
-#include "common/config-manager.h"
 
-#define DIRTY_RECT_LIMIT 800
 
 namespace Wintermute {
 
@@ -57,7 +57,9 @@ BaseRenderOSystem::BaseRenderOSystem(BaseGame *inGame) : BaseRenderer(inGame) {
 
 	_borderLeft = _borderRight = _borderTop = _borderBottom = 0;
 	_ratioX = _ratioY = 1.0f;
-	_dirtyRect = nullptr;
+
+	_dirtyRects = new DirtyRectContainer();
+
 	_disableDirtyRects = false;
 	if (ConfMan.hasKey("dirty_rects")) {
 		_disableDirtyRects = !ConfMan.getBool("dirty_rects");
@@ -75,8 +77,8 @@ BaseRenderOSystem::~BaseRenderOSystem() {
 		delete ticket;
 	}
 
-	delete _dirtyRect;
-
+	_dirtyRects->reset();
+	delete _dirtyRects;
 	_renderSurface->free();
 	delete _renderSurface;
 	_blankSurface->free();
@@ -154,8 +156,7 @@ bool BaseRenderOSystem::indicatorFlip() {
 bool BaseRenderOSystem::flip() {
 	if (_skipThisFrame) {
 		_skipThisFrame = false;
-		delete _dirtyRect;
-		_dirtyRect = nullptr;
+		_dirtyRects->reset();
 		g_system->updateScreen();
 		_needsFlip = false;
 
@@ -195,12 +196,11 @@ bool BaseRenderOSystem::flip() {
 			g_system->copyRectToScreen((byte *)_renderSurface->getPixels(), _renderSurface->pitch, 0, 0, _renderSurface->w, _renderSurface->h);
 		}
 		//  g_system->copyRectToScreen((byte *)_renderSurface->getPixels(), _renderSurface->pitch, _dirtyRect->left, _dirtyRect->top, _dirtyRect->width(), _dirtyRect->height());
-		delete _dirtyRect;
-		_dirtyRect = nullptr;
+		_dirtyRects->reset();
 		_needsFlip = false;
 	}
-	_lastFrameIter = _renderQueue.end();
 
+	_lastFrameIter = _renderQueue.end();
 	g_system->updateScreen();
 
 	return STATUS_OK;
@@ -365,12 +365,7 @@ void BaseRenderOSystem::drawFromQueuedTicket(const RenderQueueIterator &ticket) 
 }
 
 void BaseRenderOSystem::addDirtyRect(const Common::Rect &rect) {
-	if (!_dirtyRect) {
-		_dirtyRect = new Common::Rect(rect);
-	} else {
-		_dirtyRect->extend(rect);
-	}
-	_dirtyRect->clip(_renderRect);
+	_dirtyRects->addDirtyRect(rect, _renderRect);
 }
 
 void BaseRenderOSystem::drawTickets() {
@@ -389,53 +384,67 @@ void BaseRenderOSystem::drawTickets() {
 			++it;
 		}
 	}
-	if (!_dirtyRect || _dirtyRect->width() == 0 || _dirtyRect->height() == 0) {
-		it = _renderQueue.begin();
-		while (it != _renderQueue.end()) {
-			RenderTicket *ticket = *it;
-			ticket->_wantsDraw = false;
-			++it;
+
+
+	Common::Array<Common::Rect *> optimized = _dirtyRects->getOptimized();
+
+	if (!optimized.size()) {
+		for (it = _renderQueue.begin(); it != _renderQueue.end(); ++it) {
+				RenderTicket *ticket = *it;
+				ticket->_wantsDraw = false;
 		}
 		return;
 	}
 
-	it = _renderQueue.begin();
-	_lastFrameIter = _renderQueue.end();
-	// A special case: If the screen has one giant OPAQUE rect to be drawn, then we skip filling
-	// the background color. Typical use-case: Fullscreen FMVs.
-	// Caveat: The FPS-counter will invalidate this.
-	if (it != _lastFrameIter && _renderQueue.front() == _renderQueue.back() && (*it)->_transform._alphaDisable == true) {
-		// If our single opaque rect fills the dirty rect, we can skip filling.
-		if (*_dirtyRect != (*it)->_dstRect) {
+	for (uint i = 0; i < optimized.size(); i++) {
+		Common::Rect *_dirtyRect = optimized[i];
+		// Apply the clear-color to the dirty rect.
+		_renderSurface->fillRect(*_dirtyRect, _clearColor);
+		_lastFrameIter = _renderQueue.end();
+		it = _renderQueue.begin();
+
+		// A special case: If the screen has one giant OPAQUE rect to be drawn, then we skip filling
+		// the background color. Typical use-case: Fullscreen FMVs.
+		// Caveat: The FPS-counter will invalidate this.
+		if (it != _lastFrameIter && _renderQueue.front() == _renderQueue.back() && (*it)->_transform._alphaDisable == true) {
+			// If our single opaque rect fills the dirty rect, we can skip filling.
+			if (*_dirtyRect != (*it)->_dstRect) {
+				// Apply the clear-color to the dirty rect.
+				_renderSurface->fillRect(*_dirtyRect, _clearColor);
+			}
+			// Otherwise Do NOT fill.
+		} else {
 			// Apply the clear-color to the dirty rect.
 			_renderSurface->fillRect(*_dirtyRect, _clearColor);
 		}
-		// Otherwise Do NOT fill.
-	} else {
-		// Apply the clear-color to the dirty rect.
-		_renderSurface->fillRect(*_dirtyRect, _clearColor);
-	}
-	for (; it != _renderQueue.end(); ++it) {
-		RenderTicket *ticket = *it;
-		if (ticket->_dstRect.intersects(*_dirtyRect)) {
-			// dstClip is the area we want redrawn.
-			Common::Rect dstClip(ticket->_dstRect);
-			// reduce it to the dirty rect
-			dstClip.clip(*_dirtyRect);
-			// we need to keep track of the position to redraw the dirty rect
-			Common::Rect pos(dstClip);
-			int16 offsetX = ticket->_dstRect.left;
-			int16 offsetY = ticket->_dstRect.top;
-			// convert from screen-coords to surface-coords.
-			dstClip.translate(-offsetX, -offsetY);
 
-			drawFromSurface(ticket, &pos, &dstClip);
-			_needsFlip = true;
+
+		for (; it != _renderQueue.end(); ++it) {
+			RenderTicket *ticket = *it;
+			if (ticket->_dstRect.intersects(*_dirtyRect)) {
+				// dstClip is the area we want redrawn.
+				Common::Rect dstClip(ticket->_dstRect);
+				// reduce it to the dirty rect
+				dstClip.clip(*_dirtyRect);
+				// we need to keep track of the position to redraw the dirty rect
+				Common::Rect pos(dstClip);
+				int16 offsetX = ticket->_dstRect.left;
+				int16 offsetY = ticket->_dstRect.top;
+				// convert from screen-coords to surface-coords.
+				dstClip.translate(-offsetX, -offsetY);
+
+				drawFromSurface(ticket, &pos, &dstClip);
+				_needsFlip = true;
+			}
+			// Some tickets want redraw but don't actually clip the dirty area (typically the ones that shouldnt become clear-color)
+			ticket->_wantsDraw = false;
 		}
-		// Some tickets want redraw but don't actually clip the dirty area (typically the ones that shouldnt become clear-color)
-		ticket->_wantsDraw = false;
+		g_system->copyRectToScreen((byte *)_renderSurface->getBasePtr(_dirtyRect->left, _dirtyRect->top), _renderSurface->pitch, _dirtyRect->left, _dirtyRect->top, _dirtyRect->width(), _dirtyRect->height());
+	} // endfor
+
+
+
 	}
-	g_system->copyRectToScreen((byte *)_renderSurface->getBasePtr(_dirtyRect->left, _dirtyRect->top), _renderSurface->pitch, _dirtyRect->left, _dirtyRect->top, _dirtyRect->width(), _dirtyRect->height());
 
 	it = _renderQueue.begin();
 	// Clean out the old tickets
@@ -448,7 +457,7 @@ void BaseRenderOSystem::drawTickets() {
 		} else {
 			++it;
 		}
-	}
+	} // endwhile
 
 }
 

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -385,6 +385,10 @@ void BaseRenderOSystem::drawTickets() {
 		}
 	}
 
+#if DEBUG_RECTS == DEBUG_RECTS_BLACKOUT
+	_renderSurface->fillRect(Common::Rect(0,0, _renderSurface->w, _renderSurface->h), kDebugColor);
+	g_system->copyRectToScreen((byte *)_renderSurface->getBasePtr(0, 0), _renderSurface->pitch, 0, 0, _renderSurface->w, _renderSurface->h);
+#endif
 
 	Common::Array<Common::Rect *> optimized = _dirtyRects->getOptimized();
 
@@ -444,7 +448,29 @@ void BaseRenderOSystem::drawTickets() {
 
 
 
+
+#if DEBUG_RECTS == DEBUG_RECTS_OUTLINE
+	for (uint i = 0; i < _oldOptimized.size(); i++) {
+		Common::Rect *_dirtyRect = &_oldOptimized[i];
+		_renderSurface->frameRect(_oldOptimized[i], 0xFF000000);
+		g_system->copyRectToScreen((byte *)_renderSurface->getBasePtr(_dirtyRect->left, _dirtyRect->top), _renderSurface->pitch, _dirtyRect->left, _dirtyRect->top, _dirtyRect->width(), _dirtyRect->height());
 	}
+
+	for (uint i = 0; i < optimized.size(); i++) {
+		Common::Rect *_dirtyRect = (optimized[i]);
+		_renderSurface->frameRect(*(optimized[i]), kDebugColor);
+		g_system->copyRectToScreen((byte *)_renderSurface->getBasePtr(_dirtyRect->left, _dirtyRect->top), _renderSurface->pitch, _dirtyRect->left, _dirtyRect->top, _dirtyRect->width(), _dirtyRect->height());
+	}
+#endif
+
+#ifdef DEBUG_RECTS
+	_oldOptimized.clear();
+
+	for (uint i = 0; i < optimized.size(); i++) {
+		_oldOptimized.push_back(*(optimized[i]));
+	}
+
+#endif
 
 	it = _renderQueue.begin();
 	// Clean out the old tickets

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.h
@@ -136,6 +136,7 @@ private:
 
 	DirtyRectContainer *_dirtyRects;
 
+	Common::Rect *_gigaRect;
 	Common::List<RenderTicket *> _renderQueue;
 
 	bool _needsFlip;

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.h
@@ -29,15 +29,17 @@
 #ifndef WINTERMUTE_BASE_RENDERER_SDL_H
 #define WINTERMUTE_BASE_RENDERER_SDL_H
 
-#include "engines/wintermute/base/gfx/base_renderer.h"
-#include "common/rect.h"
-#include "graphics/surface.h"
 #include "common/list.h"
+#include "common/rect.h"
+#include "engines/wintermute/base/gfx/base_renderer.h"
+#include "graphics/surface.h"
 #include "graphics/transform_struct.h"
 
 namespace Wintermute {
 class BaseSurfaceOSystem;
 class RenderTicket;
+class DirtyRectContainer;
+
 /**
  * A 2D-renderer implementation for WME.
  * This renderer makes use of a "ticket"-system, where all draw-calls
@@ -126,7 +128,9 @@ private:
 	void drawFromSurface(RenderTicket *ticket);
 	// Dirty-rects:
 	void drawFromSurface(RenderTicket *ticket, Common::Rect *dstRect, Common::Rect *clipRect);
-	Common::Rect *_dirtyRect;
+
+	DirtyRectContainer *_dirtyRects;
+
 	Common::List<RenderTicket *> _renderQueue;
 
 	bool _needsFlip;

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.h
@@ -35,6 +35,11 @@
 #include "graphics/surface.h"
 #include "graphics/transform_struct.h"
 
+#define NO_DEBUG_RECTS 0
+#define DEBUG_RECTS_OUTLINE 1
+#define DEBUG_RECTS_BLACKOUT 2
+#define DEBUG_RECTS NO_DEBUG_RECTS
+
 namespace Wintermute {
 class BaseSurfaceOSystem;
 class RenderTicket;
@@ -150,6 +155,13 @@ private:
 	uint32 _clearColor;
 
 	bool _skipThisFrame;
+
+#ifdef DEBUG_RECTS
+	static const int kDebugColor = 0xFF00FF00;
+	Common::Array<Common::Rect> _oldOptimized;
+#endif
+
+
 	int _lastScreenChangeID; // previous value of OSystem::getScreenChangeID()
 };
 

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.h
@@ -37,7 +37,6 @@
 
 #define NO_DEBUG_RECTS 0
 #define DEBUG_RECTS_OUTLINE 1
-#define DEBUG_RECTS_BLACKOUT 2
 #define DEBUG_RECTS NO_DEBUG_RECTS
 
 namespace Wintermute {

--- a/engines/wintermute/base/gfx/osystem/dirty_rect_container.cpp
+++ b/engines/wintermute/base/gfx/osystem/dirty_rect_container.cpp
@@ -52,10 +52,6 @@ void DirtyRectContainer::safeEnqueue(Common::Rect *slice, SmartList<Common::Rect
 }
 
 void DirtyRectContainer::addDirtyRect(const Common::Rect &rect, const Common::Rect &clipRect) {
-	// We get the clipping rect information along with rects for legacy reasons.
-	// We assume it does not change mid-frame and, if we don't have  one, we store it.
-	// This is later relevant if getOptimized gets called without being fed rects first;
-
 	if (_clipRect == nullptr) {
 		_clipRect = new Common::Rect(clipRect);
 	} else {
@@ -65,10 +61,6 @@ void DirtyRectContainer::addDirtyRect(const Common::Rect &rect, const Common::Re
 
 #if ENABLE_BAILOUT
 	if (_rectList.size() > kMaxInputRects) {
-		// This should not really happen in real world usage,
-		// but there is a possibility of being flooded with rects.
-		// At which point, we bail out.
-		// This is, basically, the 'unrealistic' case, something went wrong.
 		if (!_dRectOverflow) {
 			_dRectOverflow = true;
 		}

--- a/engines/wintermute/base/gfx/osystem/dirty_rect_container.cpp
+++ b/engines/wintermute/base/gfx/osystem/dirty_rect_container.cpp
@@ -59,7 +59,8 @@ void DirtyRectContainer::addDirtyRect(const Common::Rect &rect, const Common::Re
 	if (_clipRect == nullptr) {
 		_clipRect = new Common::Rect(clipRect);
 	} else {
-		assert(clipRect.equals(*_clipRect));
+		_clipRect->extend(clipRect);
+		assert(clipRect.contains(*_clipRect));
 	}
 
 #if ENABLE_BAILOUT

--- a/engines/wintermute/base/gfx/osystem/dirty_rect_container.cpp
+++ b/engines/wintermute/base/gfx/osystem/dirty_rect_container.cpp
@@ -1,0 +1,609 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+
+#include "engines/wintermute/base/gfx/osystem/dirty_rect_container.h"
+
+namespace Wintermute {
+
+DirtyRectContainer::DirtyRectContainer() {
+	_clipRect = nullptr;
+}
+
+DirtyRectContainer::~DirtyRectContainer() {
+	reset();
+	delete _clipRect;
+}
+
+void DirtyRectContainer::safeEnqueue(Common::Rect *slice, Common::Array<Common::Rect *> *queue) {
+	if (slice->width() != 0 && slice->height() != 0) {
+		assert(slice->isValidRect());
+		queue->push_back(slice);
+		_cleanMe.push_back(slice);
+	} else {
+		delete slice;
+	}
+}
+
+void DirtyRectContainer::addDirtyRect(const Common::Rect &rect, const Common::Rect &clipRect) {
+	// We get the clipping rect information along with rects for legacy reasons.
+	// We assume it does not change mid-frame and, if we don't have  one, we store it.
+	// This is later relevant if getOptimized gets called without being fed rects first;
+
+	if (_clipRect == nullptr) {
+		_clipRect = new Common::Rect(clipRect);
+	} else {
+		assert(clipRect.equals(*_clipRect));
+	}
+
+	Common::Rect *tmp = new Common::Rect(rect);
+	tmp->clip(clipRect);
+	if (tmp->width() != 0 && tmp->height() != 0) {
+		_rectArray.push_back(tmp);
+	}
+}
+
+void DirtyRectContainer::reset() {
+	for (int i = _rectArray.size() - 1; i >= 0; i--) {
+		delete _rectArray[i];
+		_rectArray.remove_at(i);
+	}
+
+	for (int i = _cleanMe.size() - 1; i >= 0; i--) {
+		delete _cleanMe[i];
+		_cleanMe.remove_at(i);
+	}
+	delete _clipRect;
+	_clipRect = nullptr;
+}
+
+Common::Array<Common::Rect *> DirtyRectContainer::getOptimized() {
+	Common::Array<Common::Rect *> ret;
+	Common::Array<Common::Rect *> queue;
+
+	if (_clipRect == nullptr) {
+		/*
+		 * We get clipRect together with the rects for historical reasons.
+		 * No cliprect means no rects, which means nothing was dirtied.
+		 * We return an empty list with a clear conscience.
+		 */
+		assert(_rectArray.size() == 0);
+		return ret;
+	}
+
+	assert(ret.size() == 0);
+	assert(queue.size() == 0);
+	for (uint i = 0; i < _rectArray.size(); i++) {
+		assert(_clipRect->contains(*_rectArray[i]));
+		queue.push_back(_rectArray[i]);
+	}
+
+	assert(queue.size() == _rectArray.size());
+
+	while (queue.size()) {
+		/* We iterate through the rect list and we see what to do with them.
+		 * We take the one at the bottom and compare it with the existing rects.
+		 * If we are really lucky, there is no overlap.
+		 * Otherwise, we will end up in one of the cases in the giant if.
+		 */
+
+		Common::Rect *candidate = queue[0];
+		assert(_clipRect->contains(*candidate));
+
+		bool discard = false;
+
+		assert(candidate->width() != 0 || candidate->height() != 0);
+		assert(candidate->isValidRect());
+
+		for (uint i = 0; i < ret.size() && !discard; i++) {
+			Common::Rect *existing = ret[i];
+			assert(_clipRect->contains(*existing));
+			assert(existing->width() != 0 && existing->height() != 0);
+			Common::Rect intersecting = existing->findIntersectingRect(*candidate);
+			if ((intersecting.width() == 0) && (intersecting.height() == 0)) {
+				// Wonderful. candidate has no intersection with existing.
+				// We can move on and compare it with the next existing one.
+			} else if (existing->contains(*candidate)) {
+				// candidate is entirely contained in an existing rect.
+				// We throw it away.
+				discard = true;
+			} else if (candidate->contains(*(existing))) {
+				/*
+				 * This is the other way around, it looks like
+				 *
+				 *  C C C C C C   (C = candidate, X = eXisting)
+				 *  C X X X X C
+				 *  C C C C C C
+				 *
+				 * We slice it to
+				 *
+				 *    n n n n n
+				 *  w X X X X X e
+				 *    s s s s s
+				 *
+				 * And put n,s,w,e back in the queue.
+				 *
+				 */
+
+				Common::Rect *nSlice = new Common::Rect(*candidate);
+				nSlice->bottom = existing->top;
+				safeEnqueue(nSlice, &queue);
+
+				Common::Rect *sSlice = new Common::Rect(*candidate);
+				sSlice->top = existing->bottom;
+				safeEnqueue(sSlice, &queue);
+
+				Common::Rect *eSlice = new Common::Rect(*candidate);
+				eSlice->bottom = existing->bottom;
+				eSlice->top = existing->top;
+				eSlice->left = existing->right;
+				safeEnqueue(eSlice, &queue);
+
+				Common::Rect *wSlice = new Common::Rect(*candidate);
+				wSlice->bottom = existing->bottom;
+				wSlice->top = existing->top;
+				wSlice->right = existing->left;
+				safeEnqueue(wSlice, &queue);
+
+				discard = true;
+
+			} else if (existing->left <= candidate->left &&
+			           existing->right >= candidate->right &&
+			           existing->top >= candidate->top &&
+			           existing->bottom <= candidate->bottom) { // Cross shaped intersections
+				/*
+				 * Cross-shaped intersections like:
+				 *
+				 *     C C
+				 *     C C
+				 * X X X X X X
+				 *     C C
+				 *     C C
+				 *
+				 * and the other way around.
+				 * We split them like:
+				 *
+				 *     C C
+				 *     C C
+				 * X X X X X X
+				 *     X X
+				 *     X X
+				 *
+				 * We hold on to C and enqueue b for later processing.
+				 *
+				 */
+
+
+				Common::Rect *topSlice = new Common::Rect(*candidate);
+				Common::Rect *bottomSlice = new Common::Rect(*candidate);
+
+				topSlice->bottom = existing->top;
+				bottomSlice->top = existing->bottom;
+
+				safeEnqueue(topSlice, &queue);
+				safeEnqueue(bottomSlice, &queue);
+
+				discard = true;
+
+			} else if (existing->left >= candidate->left &&
+			           existing->right <= candidate->right &&
+			           existing->top <= candidate->top &&
+			           existing->bottom >= candidate->bottom) {
+
+				/*
+				 * Inverse version of the above
+				 */
+				Common::Rect *rightSlice = new Common::Rect(*candidate);
+				Common::Rect *leftSlice = new Common::Rect(*candidate);
+
+				rightSlice->left = existing->right;
+				leftSlice->right = existing->left;
+
+				safeEnqueue(rightSlice, &queue);
+				safeEnqueue(leftSlice, &queue);
+
+				discard = true;
+
+
+
+
+			} else if (candidate->right <= existing->right &&
+			           candidate->top >= existing->top &&
+			           candidate->bottom <= existing->bottom &&
+			           candidate->left <= existing->left) {
+				/*
+				 *      X X
+				 *  C C C X
+				 *  C C C X
+				 *      X X
+				 */
+
+				candidate->right = existing->left;
+
+			} else if (candidate->right >= existing->right &&
+			           candidate->top >= existing->top &&
+			           candidate->bottom <= existing->bottom &&
+			           candidate->left >= existing->left) {
+				/*
+				 *  X X
+				 *  X C C C C
+				 *  X C C C C
+				 *  X X
+				 */
+
+				candidate->left = existing->right;
+
+			} else if (candidate->right <= existing->right &&
+			           candidate->top <= existing->top &&
+			           candidate->bottom <= existing->bottom &&
+			           candidate->left >= existing->left) {
+				/*
+				 *    C C
+				 *    C C
+				 *  X C C X
+				 *  X X X X
+				 */
+
+				candidate->bottom = existing->top;
+
+			} else if (candidate->right <= existing->right &&
+			           candidate->top >= existing->top &&
+			           candidate->bottom >= existing->bottom &&
+			           candidate->left >= existing->left) {
+				/*
+				 *  X X X X
+				 *  X C C X
+				 *    C C
+				 *    C C
+				 */
+
+				candidate->top = existing->bottom;
+
+			} else if (candidate->right >= existing->right &&
+			           candidate->top >= existing->top &&
+			           candidate->bottom >= existing->bottom &&
+			           candidate->left <= existing->left) {
+				/*
+				 *    X X
+				 *  C X X C
+				 *  C C C C
+				 *  C C C C
+				 */
+				Common::Rect *nwSlice = new Common::Rect(*candidate);
+				Common::Rect *neSlice = new Common::Rect(*candidate);
+				Common::Rect *sSlice = new Common::Rect(*candidate);
+
+				sSlice->top = existing->bottom;
+
+				nwSlice->bottom = existing->bottom;
+				nwSlice->right = existing->left;
+
+				neSlice->bottom = existing->bottom;
+				neSlice->left = existing->right;
+
+				safeEnqueue(sSlice, &queue);
+				safeEnqueue(nwSlice, &queue);
+				safeEnqueue(neSlice, &queue);
+
+				discard = true;
+
+			} else if (candidate->right >= existing->right &&
+			           candidate->top >= existing->top &&
+			           candidate->bottom >= existing->bottom &&
+			           candidate->left <= existing->left) {
+				/*
+				 *
+				 *  C C C C
+				 *  C C C C
+				 *  C X X C
+				 *    X X
+				 *
+				 */
+				Common::Rect *swSlice = new Common::Rect(*candidate);
+				Common::Rect *seSlice = new Common::Rect(*candidate);
+				Common::Rect *nSlice = new Common::Rect(*candidate);
+
+				nSlice->bottom = existing->bottom;
+
+				swSlice->top = existing->top;
+				swSlice->right = existing->left;
+
+				seSlice->top = existing->top;
+				seSlice->left = existing->right;
+
+				safeEnqueue(nSlice, &queue);
+				safeEnqueue(swSlice, &queue);
+				safeEnqueue(seSlice, &queue);
+
+				discard = true;
+
+			} else if (candidate->top <= existing->top &&
+			           candidate->right >= existing->right &&
+			           candidate->left >= existing->left &&
+			           candidate->bottom >= existing->bottom) {
+				/*
+				 *   C C C C
+				 * X X C C C
+				 * X X C C C
+				 *   C C C C
+				 */
+				Common::Rect *nwSlice = new Common::Rect(*candidate);
+				Common::Rect *swSlice = new Common::Rect(*candidate);
+				Common::Rect *eSlice = new Common::Rect(*candidate);
+
+				eSlice->left = existing->right;
+
+				nwSlice->bottom = existing->top;
+				nwSlice->right = existing->right;
+
+				swSlice->top = existing->bottom;
+				swSlice->right = existing->right;
+
+				safeEnqueue(eSlice, &queue);
+				safeEnqueue(nwSlice, &queue);
+				safeEnqueue(swSlice, &queue);
+
+				discard = true;
+
+			} else if (candidate->top <= existing->top &&
+			           candidate->right >= existing->right &&
+			           candidate->left >= existing->left &&
+			           candidate->bottom >= existing->bottom) {
+				/*
+				 * C C C C
+				 * C C X X X
+				 * C C X X X
+				 * C C C C
+				 */
+				Common::Rect *neSlice = new Common::Rect(*candidate);
+				Common::Rect *seSlice = new Common::Rect(*candidate);
+				Common::Rect *wSlice = new Common::Rect(*candidate);
+
+				wSlice->right = existing->left;
+
+				neSlice->bottom = existing->top;
+				neSlice->left = existing->left;
+
+				seSlice->top = existing->bottom;
+				seSlice->left = existing->left;
+
+				safeEnqueue(wSlice, &queue);
+				safeEnqueue(neSlice, &queue);
+				safeEnqueue(seSlice, &queue);
+
+				discard = true;
+
+			} else if (intersecting.top >= candidate->top &&
+			           intersecting.left >= candidate->left &&
+			           intersecting.bottom == candidate->bottom &&
+			           intersecting.right == candidate->right
+			          ) { // SE case
+
+				/*
+				 *  C C C
+				 *  C C C
+				 *  C C I X X
+				 *      X X X
+				 *      X X X
+				 *
+				 */
+				assert(
+				    !(intersecting.left == candidate->left &&
+				      intersecting.right == candidate->right &&
+				      intersecting.top == candidate->top &&
+				      intersecting.bottom == candidate->bottom)
+				);
+				assert((intersecting.width() != 0) && (intersecting.height() != 0));
+
+				Common::Rect *nSlice = new Common::Rect(*candidate);
+				Common::Rect *swSlice = new Common::Rect(*candidate);
+
+				nSlice->bottom = intersecting.top;
+
+				safeEnqueue(nSlice, &queue);
+
+				swSlice->right = intersecting.left;
+				swSlice->top = intersecting.top;
+
+				assert(intersecting.findIntersectingRect(*swSlice).width() == 0 ||
+				       intersecting.findIntersectingRect(*swSlice).height() == 0);
+
+				assert(intersecting.findIntersectingRect(*nSlice).width() == 0 ||
+				       intersecting.findIntersectingRect(*nSlice).height() == 0);
+
+
+				safeEnqueue(swSlice, &queue);
+
+				discard = true;
+
+			} else if (intersecting.top >= candidate->top &&
+			           intersecting.left == candidate->left &&
+			           intersecting.bottom == candidate->bottom &&
+			           intersecting.right <= candidate->right
+			          ) { // SW case
+
+				/*
+				 *      C C C
+				 *      C C C
+				 *  X X I C C
+				 *  X X X
+				 *  X X X
+				 *
+				 */
+				assert(
+				    !(intersecting.left == candidate->left &&
+				      intersecting.right == candidate->right &&
+				      intersecting.top == candidate->top &&
+				      intersecting.bottom == candidate->bottom)
+				);
+				assert((intersecting.width() != 0) && (intersecting.height() != 0));
+
+				Common::Rect *nSlice = new Common::Rect(*candidate);
+				Common::Rect *seSlice = new Common::Rect(*candidate);
+
+				nSlice->bottom = intersecting.top;
+
+				safeEnqueue(nSlice, &queue);
+
+				seSlice->left = intersecting.right;
+				seSlice->top = intersecting.top;
+
+				assert(intersecting.findIntersectingRect(*seSlice).width() == 0 ||
+				       intersecting.findIntersectingRect(*seSlice).height() == 0);
+
+				assert(intersecting.findIntersectingRect(*nSlice).width() == 0 ||
+				       intersecting.findIntersectingRect(*nSlice).height() == 0);
+
+				safeEnqueue(seSlice, &queue);
+
+				discard = true;
+
+			} else if (intersecting.top == candidate->top &&
+			           intersecting.left == candidate->left &&
+			           intersecting.bottom <= candidate->bottom &&
+			           intersecting.right <= candidate->right
+			          ) { // NW case
+
+				/*
+				 *
+				 *  X X X
+				 *  X X X
+				 *  X X I C C
+				 *      C C C
+				 *      C C C
+				 *
+				 */
+				assert(
+				    !(intersecting.left == candidate->left &&
+				      intersecting.right == candidate->right &&
+				      intersecting.top == candidate->top &&
+				      intersecting.bottom == candidate->bottom)
+				);
+				assert((intersecting.width() != 0) && (intersecting.height() != 0));
+
+				Common::Rect *sSlice = new Common::Rect(*candidate);
+				Common::Rect *neSlice = new Common::Rect(*candidate);
+
+				sSlice->top = intersecting.bottom;
+
+				safeEnqueue(sSlice, &queue);
+
+				neSlice->left = intersecting.right;
+				neSlice->bottom = intersecting.bottom;
+
+				assert(intersecting.findIntersectingRect(*neSlice).width() == 0 ||
+				       intersecting.findIntersectingRect(*neSlice).height() == 0);
+
+				assert(intersecting.findIntersectingRect(*sSlice).width() == 0 ||
+				       intersecting.findIntersectingRect(*sSlice).height() == 0);
+
+				safeEnqueue(neSlice, &queue);
+
+				discard = true;
+
+			} else if (intersecting.top == candidate->top &&
+			           intersecting.left >= candidate->left &&
+			           intersecting.bottom <= candidate->bottom &&
+			           intersecting.right == candidate->right) { // NE case
+
+				/*
+				 *
+				 *      X X X
+				 *      X X X
+				 *  C C I X X
+				 *  C C C
+				 *  C C C
+				 *
+				 */
+				assert(
+				    !(intersecting.left == candidate->left &&
+				      intersecting.right == candidate->right &&
+				      intersecting.top == candidate->top &&
+				      intersecting.bottom == candidate->bottom)
+				);
+				assert((intersecting.width() != 0) && (intersecting.height() != 0));
+
+				Common::Rect *sSlice = new Common::Rect(*candidate);
+				Common::Rect *nwSlice = new Common::Rect(*candidate);
+
+				sSlice->top = intersecting.bottom;
+
+				safeEnqueue(sSlice, &queue);
+
+				nwSlice->right = intersecting.left;
+				nwSlice->bottom = intersecting.bottom;
+
+				assert(intersecting.findIntersectingRect(*nwSlice).width() == 0 ||
+				       intersecting.findIntersectingRect(*nwSlice).height() == 0);
+
+				assert(intersecting.findIntersectingRect(*sSlice).width() == 0 ||
+				       intersecting.findIntersectingRect(*sSlice).height() == 0);
+
+				safeEnqueue(nwSlice, &queue);
+
+				discard = true;
+
+			}
+
+		} // End loop
+
+		/*
+		 * At this point we should have taken out of candidate all bits that
+		 * overlap with existing rects and/or bits that we have decided to
+		 * push back in the queue for later processing.
+		 * We assert that whatever's left of candidate has no overlap with
+		 * anything in the return list.
+		 *
+		 * If marked for discard we ignore it altogether (consider
+		 * marking for discard the equivalent of replacing it with a 0x0 rect after
+		 * having verified each pixel is contained elsewhere and/or having sliced
+		 * off and enqueued the 'useful' parts).
+		 *
+		 */
+
+		if (!discard) {
+			assert(candidate->isValidRect());
+			// There should not be anything that makes the rect invalid
+			// (worse that can happen, 0x0), so this is probably worth
+			// investigating if it ever happens.
+			if (candidate->width() > 0 && candidate->height() > 0) {
+				ret.push_back(candidate);
+			}
+		}
+
+		queue.remove_at(0);
+	} // End while loop
+
+#if DEBUG_COUNT_RECTS
+	warning("%d rects to %d", _rectArray.size(), ret.size());
+#endif
+
+	return ret;
+}
+} // End of namespace Wintermute
+

--- a/engines/wintermute/base/gfx/osystem/dirty_rect_container.cpp
+++ b/engines/wintermute/base/gfx/osystem/dirty_rect_container.cpp
@@ -130,7 +130,7 @@ SmartList<Common::Rect *> DirtyRectContainer::getOptimized() {
 	assert(queue.size() == _rectList.size());
 
 #if CONSISTENCY_CHECK
-	int targetPixels = _clipRect->width() *_clipRect->height();
+	int targetPixels = _clipRect->width() * _clipRect->height();
 	int filledPixels = 0;
 #endif
 #if DISABLE_OPTIMIZATION

--- a/engines/wintermute/base/gfx/osystem/dirty_rect_container.h
+++ b/engines/wintermute/base/gfx/osystem/dirty_rect_container.h
@@ -33,6 +33,7 @@
 #include "common/rect.h"
 #include <limits.h>
 
+#define CONSISTENCY_CHECK 0
 #define ENABLE_BAILOUT 0
 #define DEBUG_COUNT_RECTS 0
 
@@ -97,6 +98,7 @@ private:
 	static const uint kMaxInputRects = UINT_MAX;
 	/* Max input rects before we fall back to a single giant rect. */
 #endif
+
 	Common::Array<Common::Rect *> _rectArray;
 	/**
 	 * List of temporary rects created by the class to be delete()d
@@ -116,6 +118,16 @@ private:
 	 * may decide to do so.
 	 */
 	bool _tempDisableDRects;
+
+#if CONSISTENCY_CHECK
+	/**
+	 * Double-checks consistency of output pixel by pixel.
+	 * Returns the number of pixels that would have been drawn
+	 * if overlaps were not treated, including duplicates.
+	 */
+	int consistencyCheck(Common::Array<Common::Rect *> &optimized);
+#endif
+
 };
 } // End of namespace Wintermute
 

--- a/engines/wintermute/base/gfx/osystem/dirty_rect_container.h
+++ b/engines/wintermute/base/gfx/osystem/dirty_rect_container.h
@@ -120,7 +120,6 @@ public:
 	 */
 	SmartList<Common::Rect *> getOptimized();
 	bool gotDRectOverflow();
-
 private:
 #if ENABLE_BAILOUT
 	/*

--- a/engines/wintermute/base/gfx/osystem/dirty_rect_container.h
+++ b/engines/wintermute/base/gfx/osystem/dirty_rect_container.h
@@ -48,7 +48,16 @@
 #endif
 
 namespace Wintermute {
-
+/**
+ * SmartList extends Common::List caching the number of elements
+ * (as _number) in order to gain some speed.
+ */
+/*
+ * TODO: It's probably worth exploring replacing this
+ * with a priority queue where larger rects and opaque rects
+ * end up at the front. This should save a couple of cycles,
+ * provided that it's not much costly.
+ */
 template <typename T>
 class SmartList : public Common::List<T> {
 	int _counter;

--- a/engines/wintermute/base/gfx/osystem/dirty_rect_container.h
+++ b/engines/wintermute/base/gfx/osystem/dirty_rect_container.h
@@ -1,0 +1,95 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+#ifndef WINTERMUTE_DIRTY_RECT_CONTAINER_H
+#define WINTERMUTE_DIRTY_RECT_CONTAINER_H
+
+#include "common/array.h"
+#include "common/rect.h"
+#include <limits.h>
+
+#define DEBUG_COUNT_RECTS 0
+
+namespace Wintermute {
+class DirtyRectContainer {
+public:
+	DirtyRectContainer();
+	~DirtyRectContainer();
+	/**
+	 * @brief Add a dirty rect. To be called by the outside world.
+	 * For historical reasons the dirty rect is to be accompained by
+	 * the clipping rect (aka "the viewport").
+	 * If getOptimized() is called /before/ a single rect (and
+	 * the clipping rect) is added, you get an empty list.
+	 *
+	 * The clipping rect is supposed to stay the same until the frame is
+	 * rendered (or, for our purpouses: until reset() is called)
+	 */
+	void addDirtyRect(const Common::Rect &rect, const Common::Rect &clipRect);
+	/**
+	 * @brief Resets the DirtyRectContainer, frees memory and gets ready
+	 * for a new frame.
+	 * Call this once you've done everything and have rendered your frame
+	 * (or at least you've got your list of dirty rects for this frame)
+	 * and are ready to start fresh.
+	 *
+	 * PAY ATTENTION to the fact that addDirtyRect takes aliases.
+	 * When you call this, it's gonna delete your rects, so not
+	 * a good move if you still need them.
+	 */
+	void reset();
+	/**
+	 * @brief Returns an optimized list of rects where duplicates and
+	 * intersections are eschewed, thus providing a minimal cover of
+	 * the dirtied area.
+	 * The returned rect list is supposed to contain only and all
+	 * of the pixels contained in the input rects.
+	 *
+	 * Profiling shows the actual blitting to be, generally speaking,
+	 * very costly, so spending some time computing a minimal cover
+	 * makes sense except for very big inputs.
+	 */
+	Common::Array<Common::Rect *> getOptimized();
+private:
+	Common::Array<Common::Rect *> _rectArray;
+	/**
+	 * List of temporary rects created by the class to be delete()d
+	 * when the renderer is done with them (not before!).
+	 * This is performed by reset()
+	 */
+	Common::Array<Common::Rect *> _cleanMe;
+	/**
+	 * Safe enqueue utility.
+	 * Good for leaks, good for readability.
+	 */
+	void safeEnqueue(Common::Rect *slice, Common::Array<Common::Rect *> *queue);
+	Common::Rect *_clipRect;
+};
+} // End of namespace Wintermute
+
+#endif

--- a/engines/wintermute/module.mk
+++ b/engines/wintermute/module.mk
@@ -53,6 +53,7 @@ MODULE_OBJS := \
 	base/gfx/osystem/base_surface_osystem.o \
 	base/gfx/osystem/base_render_osystem.o \
 	base/gfx/osystem/render_ticket.o \
+	base/gfx/osystem/dirty_rect_container.o \
 	base/particles/part_particle.o \
 	base/particles/part_emitter.o \
 	base/particles/part_force.o \


### PR DESCRIPTION
2014, prettified, simplified version of https://github.com/scummvm/scummvm/pull/392

Provides the ability to keep track of multiple dirty rects in Wintermute, saving on blitting.

Unfortunately, with lots of rects if becomes useless and we fall back to the usual single rect approach.