### PR TITLE
UNITY: Call g_type_init only with GLib < 2.36

### DIFF
--- a/backends/taskbar/unity/unity-taskbar.cpp
+++ b/backends/taskbar/unity/unity-taskbar.cpp
@@ -33,7 +33,13 @@
 #include <unity.h>
 
 UnityTaskbarManager::UnityTaskbarManager() {
+#if GLIB_CHECK_VERSION(2, 36, 0) == FALSE
+	/*
+	 *  Glib version is < 2.36.0, it still needs g_type_init(),
+	 *  deprecated in later versions
+	 */
 	g_type_init();
+#endif
 
 	_loop = g_main_loop_new(NULL, FALSE);
 


### PR DESCRIPTION
g_type_init() is deprecated and does nothing except raising a number of ugly warnings in GLib >= 2.36, and UnityTaskbarManager::UnityTaskbarManager() does in fact call g_type_init(), so I use GLIB_CHECK_VERSION (https://developer.gnome.org/glib/stable/glib-Version-Information.html) to only call that with legacy GLib
