### PR TITLE
DOCS: Add a CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Contributing to ScummVM
 =======================
-Anyone are welcome to post Pull Requests to ScummVM, however, a few things are worth considering before you do so,
+Anyone is welcome to post Pull Requests to ScummVM, however, a few things are worth considering before you do so,
 and while our Wiki contains a more comprehensive list of details for this matter, a short version is listed here:
 
 Code formatting
@@ -13,6 +13,7 @@ As a quick reminder:
 * Spacing between tokens.
 * Capitalization: `ClassName::functionName, _memberVar, normalVariable`.
 * Constants, either `ALL_CAPS_CONSTANT` or `kCamelCaseConstant`.
+
 Do try to follow these as closely as possible.
 
 Commits & Commit Messages
@@ -29,9 +30,9 @@ Portability
 -----------
 In general:
 * Write C++
-* Avoid exceptions
-* Avoid RTTI 
-* Avoid STL
+* No exceptions
+* No RTTI 
+* No STL
 * No inclusion of system headers inside engines.
 * File I/O should be performed through our stream APIs in common/.
 


### PR DESCRIPTION
After looking through a Github [cheat sheet](https://github.com/tiimgreen/github-cheat-sheet), i found that Github allows for [contribution guidelines](https://github.com/tiimgreen/github-cheat-sheet#contributing-guidelines) that shows up when trying to open a Pull Request. (An example is show in the cheat sheet).

I thought it would be helpful to add such a file, to make the relevant information a bit more accessible, and indeed visible for new contributors. I thus created a draft of such a file, making sure to drag out what I remembered as important, but also to supply links to all the relevant wiki pages. Overall this should provide an easier starting point for new contributors ("Where do I find the information you're complaining about me not having read?" should be answered).

This should also add a solution to "Nobody told me about any commit guidelines/code formatting convention/portability rules!".

Overall, this is just a draft, and very open to discussion, correction, fixing etc. Markdown was chosen as Github automatically formats such documents.

Thoughts?
