### PR TITLE
UNITY: Fix runtime dependency on glib > 2.36 introduced by yours truly

### DIFF
--- a/backends/taskbar/unity/unity-taskbar.cpp
+++ b/backends/taskbar/unity/unity-taskbar.cpp
@@ -38,7 +38,9 @@ UnityTaskbarManager::UnityTaskbarManager() {
 	/*
 	 *  Deprecated in Glib >= 2.36.0
 	 */
-	g_type_init();
+	if (!glib_check_version(2, 36, 0)) {
+		g_type_init();
+	}
 
 	_loop = g_main_loop_new(NULL, FALSE);
 


### PR DESCRIPTION
Tries to address the problem highlighted by @wjp in: https://github.com/tobiatesan/scummvm/commit/fee66db83dbe2279729ee0a106eda3fa79bc962e#commitcomment-8049540

I'm stupid, sorry.
