### PR TITLE
SCUMM: Fix bug #6683, Loading a game saved during 'leadup' to a cutscene

### DIFF
--- a/engines/scumm/room.cpp
+++ b/engines/scumm/room.cpp
@@ -250,7 +250,13 @@ void ScummEngine::setupRoomSubBlocks() {
 	_EPAL_offs = 0;
 	_CLUT_offs = 0;
 	_PALS_offs = 0;
-
+	
+	// Games up to version 3, can have a 'prequel' to a cutscene, which is a blank screen with text at the top of the screen...
+	// If the game was saved during this, the current room is set to 0
+	if (_game.version <= 3)
+		if (_currentScript == 0xFF && _roomResource == 0 && _currentRoom == 0 )
+			return;
+					
 	// Determine the room and room script base address
 	roomResPtr = roomptr = getResourceAddress(rtRoom, _roomResource);
 	if (_game.version == 8)
@@ -587,7 +593,13 @@ void ScummEngine_v3old::setupRoomSubBlocks() {
 	_EPAL_offs = 0;
 	_CLUT_offs = 0;
 	_PALS_offs = 0;
-
+	
+	// Games up to version 3, can have a 'prequel' to a cutscene, which is a blank screen with text at the top of the screen...
+	// If the game was saved during this, the current room is set to 0
+	if (_game.version <= 3)
+		if (_currentScript == 0xFF && _roomResource == 0 && _currentRoom == 0 )
+			return;
+			
 	// Determine the room and room script base address
 	roomptr = getResourceAddress(rtRoom, _roomResource);
 	if (!roomptr)


### PR DESCRIPTION
When loading a game which was saved during a 'lead up' to a cutscene, _currentRoom is set to 0 (this occurs in MM/Zak/Indy3).

This started as of commit '973cb9a281e7b2dc73b7c640172954cc5f0bacfd' (27/04/2005), the new 'loadRoomSubBlocks' function began being used, which has a check to ensure a room resource was returned.
