### PR TITLE
SCUMM: Fix bug 6739 - Untranslated dialogs

### DIFF
--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -180,9 +180,9 @@ static const ResString string_map_table_v345[] = {
 	// I18N: You may specify 'Yes' symbol at the end of the line, like this:
 	// "Moechten Sie wirklich neu starten?  (J/N)J"
 	// Will react to J as 'Yes'
-	{5, _s("Are you sure you want to restart?  (Y/N)")},
+	{5, _s("Are you sure you want to restart?  (Y/N)Y")},
 	// I18N: you may specify 'Yes' symbol at the end of the line. See previous comment
-	{6, _s("Are you sure you want to quit?  (Y/N)")},
+	{6, _s("Are you sure you want to quit?  (Y/N)Y")},
 
 	// Added in SCUMM4
 	{7, _s("Save")},
@@ -460,7 +460,7 @@ const Common::String InfoDialog::queryResString(int stringno) {
 			tmp += chr;
 		}
 	}
-	return tmp;
+	return _(tmp);
 }
 
 #pragma mark -


### PR DESCRIPTION
This causes the dialogs of v6 games to be translated too. I Play tested it with freddi1 and also got the confirmed that the strings really have a Y at the end (in at least this game).
