### PR TITLE
AGOS: Give each MIDI track its own loop flag (bug #6665)

### DIFF
--- a/engines/agos/midi.h
+++ b/engines/agos/midi.h
@@ -36,6 +36,7 @@ namespace AGOS {
 struct MusicInfo {
 	MidiParser *parser;
 	byte *data;
+	bool loopTrack;
 	byte num_songs;           // For Type 1 SMF resources
 	byte *songs[16];          // For Type 1 SMF resources
 	uint32 song_sizes[16];    // For Type 1 SMF resources
@@ -46,6 +47,7 @@ struct MusicInfo {
 	MusicInfo() { clear(); }
 	void clear() {
 		parser = 0; data = 0; num_songs = 0;
+		loopTrack = false;
 		memset(songs, 0, sizeof(songs));
 		memset(song_sizes, 0, sizeof(song_sizes));
 		memset(channel, 0, sizeof(channel));
@@ -71,7 +73,7 @@ protected:
 
 	// These are only used for music.
 	byte _currentTrack;
-	bool _loopTrack;
+	bool _loopTrackDefault;
 	byte _queuedTrack;
 	bool _loopQueuedTrack;
 


### PR DESCRIPTION
This is one possible fix for bug #6665 ("SIMON1: Music in floppy does not loop after sound-effect") that I've been sitting on for far too long. I've finally taken the time to play through the floppy version of Simon the Sorcerer 1 with it, and I didn't notice any obvious music glitches. However, I haven't played through any of the other games with it.

(Looking at the diff, I see I removed a comment with a reference to another bug when calling setLoop(). That's probably - as I said, it's been a while - because setLoop() now sets the _loopTrackDefault flag, so it wouldn't actually do any good to call it any more.)
