### PR TITLE
SCUMM: Fix bug #6679 - INDY3 DOS-EGA: book of maps graphic glitch

### DIFF
--- a/engines/scumm/room.cpp
+++ b/engines/scumm/room.cpp
@@ -614,6 +614,15 @@ void ScummEngine_v3old::setupRoomSubBlocks() {
 		}
 	} else {
 		_roomWidth = READ_LE_UINT16(&(rmhd->old.width));
+
+		// WORKAROUND: Fix bad width value for room 64 (book of maps) in
+		// Indy3. A specific version of this game (DOS/EGA v1.0, according to
+		// scumm-md5.txt) has a wrong width of 1793 stored in the data files,
+		// which causes a strange situation in which the book view may scroll
+		// towards the right depending on Indy's position from the previous room.
+		// Fixes bug #6679.
+		if (_game.id == GID_INDY3 && _roomResource == 64 && _roomWidth == 1793)
+			_roomWidth = 320;
 		_roomHeight = READ_LE_UINT16(&(rmhd->old.height));
 	}
 	_numObjectsInRoom = roomptr[20];


### PR DESCRIPTION
This fixes the issue described in bug #6679 (purple box covering part of the screen while looking at the book of maps). A more detailed explanation of what goes on under the hood has been provided in the bugtracker:

http://sourceforge.net/p/scummvm/bugs/6679/

I've done some testing by playing through the game and this change doesn't seem to have introduced any side effects.
