### PR TITLE
Fix 'unused variable' warnings

### DIFF
--- a/common/unzip.cpp
+++ b/common/unzip.cpp
@@ -334,7 +334,7 @@ int unzGetLocalExtrafield(unzFile file, voidp buf, unsigned len);
 #define SIZEZIPLOCALHEADER (0x1e)
 
 
-const char unz_copyright[] =
+extern const char unz_copyright[] =
    " unzip 0.15 Copyright 1998 Gilles Vollant ";
 
 /* unz_file_info_interntal contain internal info about a file in zipfile*/

--- a/engines/agi/agi.cpp
+++ b/engines/agi/agi.cpp
@@ -492,11 +492,6 @@ struct GameSettings {
 	const char *detectname;
 };
 
-static const GameSettings agiSettings[] = {
-	{"agi", "AGI game", GID_AGI, MDT_ADLIB, "OBJECT"},
-	{NULL, NULL, 0, 0, NULL}
-};
-
 AgiBase::AgiBase(OSystem *syst, const AGIGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc) {
 	// Assign default values to the config manager, in case settings are missing
 	ConfMan.registerDefault("originalsaveload", "false");

--- a/engines/agi/graphics.cpp
+++ b/engines/agi/graphics.cpp
@@ -65,6 +65,8 @@ static const uint8 egaPalette[16 * 3] = {
 	0x3f, 0x3f, 0x3f
 };
 
+#if 0
+
 /**
  * Atari ST AGI palette.
  * Used by all of the tested Atari ST AGI games
@@ -216,6 +218,8 @@ static const uint8 amigaAgiPaletteV3[16 * 3] = {
 	0xF, 0xF, 0x0,
 	0xF, 0xF, 0xF
 };
+
+#endif
 
 /**
  * 16 color amiga-ish palette.
@@ -910,6 +914,7 @@ static const byte sciMouseCursor[] = {
  * 1 = Black (#000000 in 24-bit RGB).
  * 2 = White (#FFFFFF in 24-bit RGB).
  */
+#if 0
 static const byte appleIIgsMouseCursor[] = {
 	2,2,0,0,0,0,0,0,0,
 	2,1,2,0,0,0,0,0,0,
@@ -923,6 +928,7 @@ static const byte appleIIgsMouseCursor[] = {
 	2,2,2,0,2,1,1,2,0,
 	0,0,0,0,0,2,2,2,0
 };
+#endif
 
 /**
  * RGB-palette for the black and white SCI and Apple IIGS arrow cursors.

--- a/engines/agi/preagi_mickey.cpp
+++ b/engines/agi/preagi_mickey.cpp
@@ -892,6 +892,7 @@ void MickeyEngine::drawRoom() {
 	drawRoomAnimation();
 }
 
+#if 0
 const uint8 colorBCG[16][2] = {
 	{ 0x00,	0x00 },	// 0 (black, black)
 	{ 0, 0 },
@@ -910,6 +911,7 @@ const uint8 colorBCG[16][2] = {
 	{ 0, 0 },
 	{ 0xFF,	0xFF }	// F (white, white)
 };
+#endif
 
 void MickeyEngine::drawLogo() {
 	// TODO: clean this up and make it work properly, the logo is drawn way off to the right

--- a/engines/mads/msurface.h
+++ b/engines/mads/msurface.h
@@ -223,8 +223,6 @@ public:
 };
 
 class DepthSurface : public MSurface {
-private:
-	MADSEngine *_vm;
 public:
 	/**
 	 * Depth style
@@ -234,7 +232,7 @@ public:
 	/**
 	 * Constructor
 	 */
-	DepthSurface(MADSEngine *vm) : _vm(vm), _depthStyle(0) {}
+	DepthSurface() : _depthStyle(0) {}
 
 	/**
 	 * Returns the depth at a given position

--- a/engines/mads/scene.cpp
+++ b/engines/mads/scene.cpp
@@ -31,7 +31,7 @@
 namespace MADS {
 
 Scene::Scene(MADSEngine *vm)
-	: _vm(vm), _action(_vm), _depthSurface(vm),
+	: _vm(vm), _action(_vm), _depthSurface(),
 	  _dirtyAreas(_vm),  _dynamicHotspots(vm), _hotspots(vm),
 	  _kernelMessages(vm), _sequences(vm), _sprites(vm), _spriteSlots(vm),
 	  _textDisplay(vm), _userInterface(vm) {
@@ -182,7 +182,7 @@ void Scene::loadScene(int sceneId, const Common::String &prefix, bool palFlag) {
 		flags |= ANIMFLAG_LOAD_BACKGROUND_ONLY;
 
 	_animationData = Animation::init(_vm, this);
-	DepthSurface depthSurface(_vm);
+	DepthSurface depthSurface;
 	_animationData->load(_userInterface, depthSurface, prefix, flags, nullptr, nullptr);
 
 	_vm->_palette->_paletteUsage.load(&_scenePaletteUsage);
@@ -611,7 +611,7 @@ void Scene::loadAnimation(const Common::String &resName, int trigger) {
 	if (_activeAnimation)
 		freeAnimation();
 
-	DepthSurface depthSurface(_vm);
+	DepthSurface depthSurface;
 	UserInterface interfaceSurface(_vm);
 
 	_activeAnimation = Animation::init(_vm, this);

--- a/engines/mohawk/riven_external.cpp
+++ b/engines/mohawk/riven_external.cpp
@@ -2513,7 +2513,7 @@ void RivenExternal::xthideinventory(uint16 argc, uint16 *argv) {
 static const uint32 kMarbleCount = 6;
 static const int kSmallMarbleWidth = 4;
 static const int kSmallMarbleHeight = 2;
-static const int kLargeMarbleSize = 8;
+//static const int kLargeMarbleSize = 8;
 static const int kMarbleHotspotSize = 13;
 static const char *s_marbleNames[] = { "tred", "torange", "tyellow", "tgreen", "tblue", "tviolet" };
 

--- a/engines/neverhood/modules/module2400.cpp
+++ b/engines/neverhood/modules/module2400.cpp
@@ -163,10 +163,12 @@ static const uint32 kScene2401FileHashes1[] = {
 	0x03842920
 };
 
+/*
 static const uint32 kScene2401FileHashes2[] = {
 	0xD0910020, 0xD0910038, 0xD0910008,
 	0xD0910068, 0xD09100A8, 0
 };
+*/
 
 static const uint32 kScene2401FileHashes3[] = {
 	0xD0910020, 0xD0910038, 0xD0910008,

--- a/engines/neverhood/modules/module2700_sprites.cpp
+++ b/engines/neverhood/modules/module2700_sprites.cpp
@@ -24,6 +24,7 @@
 
 namespace Neverhood {
 
+/*
 static const NRect kScene2710ClipRect = { 0, 0, 626, 480 };
 
 static const uint32 kScene2710StaticSprites[] = {
@@ -79,6 +80,7 @@ static const uint32 kScene2725StaticSprites[] = {
 	0xC20E00A5,
 	0
 };
+*/
 
 static const NPoint kCarShadowOffsets[] = {
 	{-63,  3}, {-48, 40}, {-33, 58},

--- a/engines/neverhood/modules/module2800.cpp
+++ b/engines/neverhood/modules/module2800.cpp
@@ -1477,6 +1477,7 @@ static const uint32 kScene2808FileHashes2[] = {
 	0xB0196098
 };
 
+/*
 static const uint32 kClass428FileHashes[] = {
 	0x140022CA,
 	0x4C30A602,
@@ -1491,6 +1492,7 @@ static const uint32 kClass428FileHashes[] = {
 	0x80982841,
 	0x40800711
 };
+*/
 
 Scene2808::Scene2808(NeverhoodEngine *vm, Module *parentModule, int which)
 	: Scene(vm, parentModule), _countdown(0), _testTubeSetNum(which), _leaveResult(0), _isFlowing(false) {

--- a/engines/neverhood/modules/module2800_sprites.cpp
+++ b/engines/neverhood/modules/module2800_sprites.cpp
@@ -574,6 +574,7 @@ uint32 AsScene2806Spew::handleMessage(int messageNum, const MessageParam &param,
 	return messageResult;
 }
 
+/*
 static const uint32 kScene2808FileHashes1[] = {
 	0x90B0392,
 	0x90B0192
@@ -583,6 +584,7 @@ static const uint32 kScene2808FileHashes2[] = {
 	0xB0396098,
 	0xB0196098
 };
+*/
 
 static const uint32 kClass428FileHashes[] = {
 	0x140022CA,

--- a/engines/neverhood/modules/module3000.cpp
+++ b/engines/neverhood/modules/module3000.cpp
@@ -666,6 +666,7 @@ static const uint32 kScene3010ButtonNameHashes[] = {
 	0x01180951
 };
 
+/*
 static const uint32 kScene3010DeadBoltButtonFileHashes1[] = {
 	0x301024C2,
 	0x20280580,
@@ -677,6 +678,7 @@ static const uint32 kScene3010DeadBoltButtonFileHashes2[] = {
 	0x1020A0A0,
 	0x5000A7E8
 };
+*/
 
 Scene3010::Scene3010(NeverhoodEngine *vm, Module *parentModule, int which)
 	: Scene(vm, parentModule), _countdown(0), _doorUnlocked(false), _checkUnlocked(false) {

--- a/engines/neverhood/modules/module3000_sprites.cpp
+++ b/engines/neverhood/modules/module3000_sprites.cpp
@@ -46,6 +46,7 @@ enum {
 	kCTSCount				= 14
 };
 
+/*
 static const uint32 kScene3009CannonScopeVideos[] = {
 	0x1010000D,
 	0x340A0049,
@@ -81,6 +82,7 @@ static const uint32 kScene3009CannonActionVideos[] = {
 	0x040A1069,	// 13
 	0x240A1101	// 14 Lower the cannon
 };
+*/
 
 static const uint32 kSsScene3009SymbolEdgesFileHashes[] = {
 	0x618827A0,

--- a/engines/sword25/sword25.cpp
+++ b/engines/sword25/sword25.cpp
@@ -57,7 +57,6 @@ DECLARE_SINGLETON(Sword25::RenderObjectRegistry);
 
 namespace Sword25 {
 
-const char *const PACKAGE_MANAGER = "archiveFS";
 const char *const DEFAULT_SCRIPT_FILE = "/system/boot.lua";
 
 Sword25Engine::Sword25Engine(OSystem *syst, const ADGameDescription *gameDesc):

--- a/engines/sword25/util/lua/lapi.cpp
+++ b/engines/sword25/util/lua/lapi.cpp
@@ -30,7 +30,7 @@
 #include "common/textconsole.h"
 
 
-const char lua_ident[] =
+extern const char lua_ident[] =
   "Lua: " LUA_RELEASE " " LUA_COPYRIGHT " \n"
   "Authors: " LUA_AUTHORS " \n"
   "URL: www.lua.org\n";

--- a/engines/sword25/util/lua/liolib.cpp
+++ b/engines/sword25/util/lua/liolib.cpp
@@ -24,7 +24,7 @@
 #define IO_OUTPUT	2
 
 
-static const char *const fnames[] = {"input", "output"};
+//static const char *const fnames[] = {"input", "output"};
 
 
 static int pushresult (lua_State *L, int i, const char *filename) {

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -49,7 +49,6 @@ namespace GUI {
 
 const int kMaxRecordsNames = 0x64;
 const int kDefaultScreenshotPeriod = 60000;
-const int kDefaultBPP = 2;
 
 uint32 readTime(Common::ReadStream *inFile) {
 	uint32 d = inFile->readByte();

--- a/image/codecs/mjpeg.cpp
+++ b/image/codecs/mjpeg.cpp
@@ -87,9 +87,11 @@ static const byte s_mjpegValDC[12] = {
 	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
 };
 
+#if 0
 static const byte s_mjpegBitsDCChrominance[17] = {
 	/* 0-base */ 0, 0, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0
 };
+#endif
 
 static const byte s_mjpegBitsACLuminance[17] = {
 	/* 0-base */ 0, 0, 2, 1, 3, 3, 2, 4, 3, 5, 5, 4, 4, 0, 0, 1, 0x7d


### PR DESCRIPTION
This fixes a bunch of warnings about unused variables I receive when compiling ScummVM on Mac OS X 10.8

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/scummvm/scummvm/529)

<!-- Reviewable:end -->
