### PR TITLE
I18N: Localise language names in GUI

### DIFF
--- a/common/language.cpp
+++ b/common/language.cpp
@@ -45,7 +45,7 @@ const LanguageDescription g_languages[] = {
 	{    "jp", "ja_JP", "Japanese", JA_JPN },
 	{    "kr", "ko_KR", "Korean", KO_KOR },
 	{    "lv", "lv_LV", "Latvian", LV_LAT },
-	{    "nb", "nb_NO", "Norwegian Bokm\xE5l", NB_NOR }, // TODO Someone should verify the unix locale
+	{    "nb", "nb_NO", "Norwegian Bokmaal", NB_NOR },
 	{    "pl", "pl_PL", "Polish", PL_POL },
 	{    "br", "pt_BR", "Portuguese", PT_BRA },
 	{    "ru", "ru_RU", "Russian", RU_RUS },

--- a/devtools/create_translations/create_translations.cpp
+++ b/devtools/create_translations/create_translations.cpp
@@ -120,10 +120,31 @@ int main(int argc, char *argv[]) {
 		// Check file extension
 		int len = strlen(argv[i]);
 		if (scumm_stricmp(argv[i] + len - 2, "po") == 0) {
-			PoMessageEntryList *po = parsePoFile(argv[i], messageIds);
-			if (po != NULL) {
-				translations.push_back(po);
-				++numLangs;
+
+			// Get language from file name and create PoMessageEntryList
+			char langBuf[16];
+			int index = 0, start_index = strlen(argv[i]) - 1;
+			while (start_index > 0 && argv[i][start_index - 1] != '/' && argv[i][start_index - 1] != '\\') {
+				--start_index;
+			}
+			while (argv[i][start_index + index] != '.' && argv[i][start_index + index] != '\0') {
+				langBuf[index] = argv[i][start_index + index];
+				++index;
+			}
+			langBuf[index] = '\0';
+			int lang;
+			for (lang = 0; lang < numLangs; lang++) {
+				if (!strcmp(translations[lang]->language(), langBuf)) {
+					parsePoFile(langBuf, argv[i], translations[lang], messageIds);
+					break;
+				}
+			}
+			if (lang == numLangs) {
+				PoMessageEntryList *po = parsePoFile(langBuf, argv[i], NULL, messageIds);
+				if (po != NULL) {
+					translations.push_back(po);
+					++numLangs;
+				}
 			}
 		} else if (scumm_stricmp(argv[i] + len - 2, "cp") == 0) {
 			// Else try to parse an codepage

--- a/devtools/create_translations/po_parser.cpp
+++ b/devtools/create_translations/po_parser.cpp
@@ -254,7 +254,7 @@ const PoMessageEntry *PoMessageEntryList::entry(int index) const {
 }
 
 
-PoMessageEntryList *parsePoFile(const char *file, PoMessageList& messages) {
+PoMessageEntryList *parsePoFile(const char *language, const char *file, PoMessageEntryList *list, PoMessageList& messages) {
 	FILE *inFile = fopen(file, "r");
 	if (!inFile)
 		return NULL;
@@ -262,17 +262,8 @@ PoMessageEntryList *parsePoFile(const char *file, PoMessageList& messages) {
 	char msgidBuf[1024], msgctxtBuf[1024], msgstrBuf[1024];
 	char line[1024], *currentBuf = msgstrBuf;
 
-	// Get language from file name and create PoMessageEntryList
-	int index = 0, start_index = strlen(file) - 1;
-	while (start_index > 0 && file[start_index - 1] != '/' && file[start_index - 1] != '\\') {
-		--start_index;
-	}
-	while (file[start_index + index] != '.' && file[start_index + index] != '\0') {
-		msgidBuf[index] = file[start_index + index];
-		++index;
-	}
-	msgidBuf[index] = '\0';
-	PoMessageEntryList *list = new PoMessageEntryList(msgidBuf);
+	if (!list)
+		list = new PoMessageEntryList(language);
 
 	// Initialize the message attributes.
 	bool fuzzy = false;

--- a/devtools/create_translations/po_parser.h
+++ b/devtools/create_translations/po_parser.h
@@ -103,7 +103,7 @@ private:
 };
 
 
-PoMessageEntryList *parsePoFile(const char *file, PoMessageList &);
+PoMessageEntryList *parsePoFile(const char *language, const char *file, PoMessageEntryList *, PoMessageList &);
 char *stripLine(char *);
 char *parseLine(const char *line, const char *field);
 

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -22,6 +22,7 @@
 
 #include "engines/game.h"
 #include "common/gui_options.h"
+#include "common/translation.h"
 
 
 const PlainGameDescriptor *findPlainGameDescriptor(const char *gameid, const PlainGameDescriptor *list) {
@@ -91,7 +92,7 @@ void GameDescriptor::updateDesc(const char *extra) {
 		if (hasCustomLanguage) {
 			if (hasExtraDesc || hasCustomPlatform)
 				descr += "/";
-			descr += Common::getLanguageDescription(language());
+			descr += _(Common::getLanguageDescription(language()));
 		}
 		descr += ")";
 		setVal("description", descr);

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -88,6 +88,524 @@ enum {
 	kCmdSavePathClear = 'PSAC'
 };
 
+<<<<<<< 69d43ce1e23d0e3e8d8a5826169a20a2a0cd4b33
+=======
+/*
+ * TODO: Clean up this ugly design: we subclass EditTextWidget to perform
+ * input validation. It would be much more elegant to use a decorator pattern,
+ * or a validation callback, or something like that.
+ */
+class DomainEditTextWidget : public EditTextWidget {
+public:
+	DomainEditTextWidget(GuiObject *boss, const String &name, const String &text, const char *tooltip = 0)
+		: EditTextWidget(boss, name, text, tooltip) {
+	}
+
+protected:
+	bool tryInsertChar(byte c, int pos) {
+		if (Common::isAlnum(c) || c == '-' || c == '_') {
+			_editString.insertChar(c, pos);
+			return true;
+		}
+		return false;
+	}
+};
+
+/*
+ * A dialog that allows the user to edit a config game entry.
+ * TODO: add widgets for some/all of the following
+ * - Maybe scaler/graphics mode. But there are two problems:
+ *   1) Different backends can have different scalers with different names,
+ *      so we first have to add a way to query those... no Ender, I don't
+ *      think a bitmasked property() value is nice for this,  because we would
+ *      have to add to the bitmask values whenever a backends adds a new scaler).
+ *   2) At the time the launcher is running, the GFX backend is already setup.
+ *      So when a game is run via the launcher, the custom scaler setting for it won't be
+ *      used. So we'd also have to add an API to change the scaler during runtime
+ *      (the SDL backend can already do that based on user input, but there is no API
+ *      to achieve it)
+ *   If the APIs for 1&2 are in place, we can think about adding this to the Edit&Option dialogs
+ */
+
+class EditGameDialog : public OptionsDialog {
+	typedef Common::String String;
+	typedef Common::Array<Common::String> StringArray;
+public:
+	EditGameDialog(const String &domain, const String &desc);
+
+	void open();
+	void close();
+	virtual void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
+
+protected:
+	EditTextWidget *_descriptionWidget;
+	DomainEditTextWidget *_domainWidget;
+
+	StaticTextWidget *_gamePathWidget;
+	StaticTextWidget *_extraPathWidget;
+	StaticTextWidget *_savePathWidget;
+	ButtonWidget *_extraPathClearButton;
+	ButtonWidget *_savePathClearButton;
+
+	StaticTextWidget *_langPopUpDesc;
+	PopUpWidget *_langPopUp;
+	StaticTextWidget *_platformPopUpDesc;
+	PopUpWidget *_platformPopUp;
+
+	CheckboxWidget *_globalGraphicsOverride;
+	CheckboxWidget *_globalAudioOverride;
+	CheckboxWidget *_globalMIDIOverride;
+	CheckboxWidget *_globalMT32Override;
+	CheckboxWidget *_globalVolumeOverride;
+
+	ExtraGuiOptions _engineOptions;
+};
+
+EditGameDialog::EditGameDialog(const String &domain, const String &desc)
+	: OptionsDialog(domain, "GameOptions") {
+	// Retrieve all game specific options.
+	const EnginePlugin *plugin = 0;
+	// To allow for game domains without a gameid.
+	// TODO: Is it intentional that this is still supported?
+	String gameId(ConfMan.get("gameid", domain));
+	if (gameId.empty())
+		gameId = domain;
+	// Retrieve the plugin, since we need to access the engine's MetaEngine
+	// implementation.
+	EngineMan.findGame(gameId, &plugin);
+	if (plugin) {
+		_engineOptions = (*plugin)->getExtraGuiOptions(domain);
+	} else {
+		warning("Plugin for target \"%s\" not found! Game specific settings might be missing", domain.c_str());
+	}
+
+	// GAME: Path to game data (r/o), extra data (r/o), and save data (r/w)
+	String gamePath(ConfMan.get("path", _domain));
+	String extraPath(ConfMan.get("extrapath", _domain));
+	String savePath(ConfMan.get("savepath", _domain));
+
+	// GAME: Determine the description string
+	String description(ConfMan.get("description", domain));
+	if (description.empty() && !desc.empty()) {
+		description = desc;
+	}
+
+	// GUI:  Add tab widget
+	TabWidget *tab = new TabWidget(this, "GameOptions.TabWidget");
+
+	//
+	// 1) The game tab
+	//
+	tab->addTab(_("Game"));
+
+	// GUI:  Label & edit widget for the game ID
+	if (g_system->getOverlayWidth() > 320)
+		new StaticTextWidget(tab, "GameOptions_Game.Id", _("ID:"), _("Short game identifier used for referring to saved games and running the game from the command line"));
+	else
+		new StaticTextWidget(tab, "GameOptions_Game.Id", _c("ID:", "lowres"), _("Short game identifier used for referring to saved games and running the game from the command line"));
+	_domainWidget = new DomainEditTextWidget(tab, "GameOptions_Game.Domain", _domain, _("Short game identifier used for referring to saved games and running the game from the command line"));
+
+	// GUI:  Label & edit widget for the description
+	if (g_system->getOverlayWidth() > 320)
+		new StaticTextWidget(tab, "GameOptions_Game.Name", _("Name:"), _("Full title of the game"));
+	else
+		new StaticTextWidget(tab, "GameOptions_Game.Name", _c("Name:", "lowres"), _("Full title of the game"));
+	_descriptionWidget = new EditTextWidget(tab, "GameOptions_Game.Desc", description, _("Full title of the game"));
+
+	// Language popup
+	_langPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.LangPopupDesc", _("Language:"), _("Language of the game. This will not turn your Spanish game version into English"));
+	_langPopUp = new PopUpWidget(tab, "GameOptions_Game.LangPopup", _("Language of the game. This will not turn your Spanish game version into English"));
+	_langPopUp->appendEntry(_("<default>"), (uint32)Common::UNK_LANG);
+	_langPopUp->appendEntry("", (uint32)Common::UNK_LANG);
+	const Common::LanguageDescription *l = Common::g_languages;
+	for (; l->code; ++l) {
+		if (checkGameGUIOptionLanguage(l->id, _guioptionsString))
+			_langPopUp->appendEntry(_(l->description), l->id);
+	}
+
+	// Platform popup
+	if (g_system->getOverlayWidth() > 320)
+		_platformPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.PlatformPopupDesc", _("Platform:"), _("Platform the game was originally designed for"));
+	else
+		_platformPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.PlatformPopupDesc", _c("Platform:", "lowres"), _("Platform the game was originally designed for"));
+	_platformPopUp = new PopUpWidget(tab, "GameOptions_Game.PlatformPopup", _("Platform the game was originally designed for"));
+	_platformPopUp->appendEntry(_("<default>"));
+	_platformPopUp->appendEntry("");
+	const Common::PlatformDescription *p = Common::g_platforms;
+	for (; p->code; ++p) {
+		_platformPopUp->appendEntry(p->description, p->id);
+	}
+
+	//
+	// 2) The engine tab (shown only if there are custom engine options)
+	//
+	if (_engineOptions.size() > 0) {
+		tab->addTab(_("Engine"));
+
+		addEngineControls(tab, "GameOptions_Engine.", _engineOptions);
+	}
+
+	//
+	// 3) The graphics tab
+	//
+	_graphicsTabId = tab->addTab(g_system->getOverlayWidth() > 320 ? _("Graphics") : _("GFX"));
+
+	if (g_system->getOverlayWidth() > 320)
+		_globalGraphicsOverride = new CheckboxWidget(tab, "GameOptions_Graphics.EnableTabCheckbox", _("Override global graphic settings"), 0, kCmdGlobalGraphicsOverride);
+	else
+		_globalGraphicsOverride = new CheckboxWidget(tab, "GameOptions_Graphics.EnableTabCheckbox", _c("Override global graphic settings", "lowres"), 0, kCmdGlobalGraphicsOverride);
+
+	addGraphicControls(tab, "GameOptions_Graphics.");
+
+	//
+	// 4) The audio tab
+	//
+	tab->addTab(_("Audio"));
+
+	if (g_system->getOverlayWidth() > 320)
+		_globalAudioOverride = new CheckboxWidget(tab, "GameOptions_Audio.EnableTabCheckbox", _("Override global audio settings"), 0, kCmdGlobalAudioOverride);
+	else
+		_globalAudioOverride = new CheckboxWidget(tab, "GameOptions_Audio.EnableTabCheckbox", _c("Override global audio settings", "lowres"), 0, kCmdGlobalAudioOverride);
+
+	addAudioControls(tab, "GameOptions_Audio.");
+	addSubtitleControls(tab, "GameOptions_Audio.");
+
+	//
+	// 5) The volume tab
+	//
+	if (g_system->getOverlayWidth() > 320)
+		tab->addTab(_("Volume"));
+	else
+		tab->addTab(_c("Volume", "lowres"));
+
+	if (g_system->getOverlayWidth() > 320)
+		_globalVolumeOverride = new CheckboxWidget(tab, "GameOptions_Volume.EnableTabCheckbox", _("Override global volume settings"), 0, kCmdGlobalVolumeOverride);
+	else
+		_globalVolumeOverride = new CheckboxWidget(tab, "GameOptions_Volume.EnableTabCheckbox", _c("Override global volume settings", "lowres"), 0, kCmdGlobalVolumeOverride);
+
+	addVolumeControls(tab, "GameOptions_Volume.");
+
+	//
+	// 6) The MIDI tab
+	//
+	_globalMIDIOverride = NULL;
+	if (!_guioptions.contains(GUIO_NOMIDI)) {
+		tab->addTab(_("MIDI"));
+
+		if (g_system->getOverlayWidth() > 320)
+			_globalMIDIOverride = new CheckboxWidget(tab, "GameOptions_MIDI.EnableTabCheckbox", _("Override global MIDI settings"), 0, kCmdGlobalMIDIOverride);
+		else
+			_globalMIDIOverride = new CheckboxWidget(tab, "GameOptions_MIDI.EnableTabCheckbox", _c("Override global MIDI settings", "lowres"), 0, kCmdGlobalMIDIOverride);
+
+		addMIDIControls(tab, "GameOptions_MIDI.");
+	}
+
+	//
+	// 7) The MT-32 tab
+	//
+	_globalMT32Override = NULL;
+	if (!_guioptions.contains(GUIO_NOMIDI)) {
+		tab->addTab(_("MT-32"));
+
+		if (g_system->getOverlayWidth() > 320)
+			_globalMT32Override = new CheckboxWidget(tab, "GameOptions_MT32.EnableTabCheckbox", _("Override global MT-32 settings"), 0, kCmdGlobalMT32Override);
+		else
+			_globalMT32Override = new CheckboxWidget(tab, "GameOptions_MT32.EnableTabCheckbox", _c("Override global MT-32 settings", "lowres"), 0, kCmdGlobalMT32Override);
+
+		addMT32Controls(tab, "GameOptions_MT32.");
+	}
+
+	//
+	// 8) The Paths tab
+	//
+	if (g_system->getOverlayWidth() > 320)
+		tab->addTab(_("Paths"));
+	else
+		tab->addTab(_c("Paths", "lowres"));
+
+	// These buttons have to be extra wide, or the text will be truncated
+	// in the small version of the GUI.
+
+	// GUI:  Button + Label for the game path
+	if (g_system->getOverlayWidth() > 320)
+		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _("Game Path:"), 0, kCmdGameBrowser);
+	else
+		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _c("Game Path:", "lowres"), 0, kCmdGameBrowser);
+	_gamePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.GamepathText", gamePath);
+
+	// GUI:  Button + Label for the additional path
+	if (g_system->getOverlayWidth() > 320)
+		new ButtonWidget(tab, "GameOptions_Paths.Extrapath", _("Extra Path:"), _("Specifies path to additional data used by the game"), kCmdExtraBrowser);
+	else
+		new ButtonWidget(tab, "GameOptions_Paths.Extrapath", _c("Extra Path:", "lowres"), _("Specifies path to additional data used by the game"), kCmdExtraBrowser);
+	_extraPathWidget = new StaticTextWidget(tab, "GameOptions_Paths.ExtrapathText", extraPath, _("Specifies path to additional data used by the game"));
+
+	_extraPathClearButton = addClearButton(tab, "GameOptions_Paths.ExtraPathClearButton", kCmdExtraPathClear);
+
+	// GUI:  Button + Label for the save path
+	if (g_system->getOverlayWidth() > 320)
+		new ButtonWidget(tab, "GameOptions_Paths.Savepath", _("Save Path:"), _("Specifies where your saved games are put"), kCmdSaveBrowser);
+	else
+		new ButtonWidget(tab, "GameOptions_Paths.Savepath", _c("Save Path:", "lowres"), _("Specifies where your saved games are put"), kCmdSaveBrowser);
+	_savePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.SavepathText", savePath, _("Specifies where your saved games are put"));
+
+	_savePathClearButton = addClearButton(tab, "GameOptions_Paths.SavePathClearButton", kCmdSavePathClear);
+
+	// Activate the first tab
+	tab->setActiveTab(0);
+	_tabWidget = tab;
+
+	// Add OK & Cancel buttons
+	new ButtonWidget(this, "GameOptions.Cancel", _("Cancel"), 0, kCloseCmd);
+	new ButtonWidget(this, "GameOptions.Ok", _("OK"), 0, kOKCmd);
+}
+
+void EditGameDialog::open() {
+	OptionsDialog::open();
+
+	String extraPath(ConfMan.get("extrapath", _domain));
+	if (extraPath.empty() || !ConfMan.hasKey("extrapath", _domain)) {
+		_extraPathWidget->setLabel(_c("None", "path"));
+	}
+
+	String savePath(ConfMan.get("savepath", _domain));
+	if (savePath.empty() || !ConfMan.hasKey("savepath", _domain)) {
+		_savePathWidget->setLabel(_("Default"));
+	}
+
+	int sel, i;
+	bool e;
+
+	// En-/disable dialog items depending on whether overrides are active or not.
+
+	e = ConfMan.hasKey("gfx_mode", _domain) ||
+		ConfMan.hasKey("render_mode", _domain) ||
+		ConfMan.hasKey("fullscreen", _domain) ||
+		ConfMan.hasKey("aspect_ratio", _domain);
+	_globalGraphicsOverride->setState(e);
+
+	e = ConfMan.hasKey("music_driver", _domain) ||
+		ConfMan.hasKey("output_rate", _domain) ||
+		ConfMan.hasKey("opl_driver", _domain) ||
+		ConfMan.hasKey("subtitles", _domain) ||
+		ConfMan.hasKey("talkspeed", _domain);
+	_globalAudioOverride->setState(e);
+
+	e = ConfMan.hasKey("music_volume", _domain) ||
+		ConfMan.hasKey("sfx_volume", _domain) ||
+		ConfMan.hasKey("speech_volume", _domain);
+	_globalVolumeOverride->setState(e);
+
+	if (!_guioptions.contains(GUIO_NOMIDI)) {
+		e = ConfMan.hasKey("soundfont", _domain) ||
+			ConfMan.hasKey("multi_midi", _domain) ||
+			ConfMan.hasKey("midi_gain", _domain);
+		_globalMIDIOverride->setState(e);
+	}
+
+	if (!_guioptions.contains(GUIO_NOMIDI)) {
+		e = ConfMan.hasKey("native_mt32", _domain) ||
+			ConfMan.hasKey("enable_gs", _domain);
+		_globalMT32Override->setState(e);
+	}
+
+	// TODO: game path
+
+	const Common::Language lang = Common::parseLanguage(ConfMan.get("language", _domain));
+
+	if (ConfMan.hasKey("language", _domain)) {
+		_langPopUp->setSelectedTag(lang);
+	} else {
+		_langPopUp->setSelectedTag((uint32)Common::UNK_LANG);
+	}
+
+	if (_langPopUp->numEntries() <= 3) { // If only one language is avaliable
+		_langPopUpDesc->setEnabled(false);
+		_langPopUp->setEnabled(false);
+	}
+
+	// Set the state of engine-specific checkboxes
+	for (uint j = 0; j < _engineOptions.size(); ++j) {
+		// The default values for engine-specific checkboxes are not set when
+		// ScummVM starts, as this would require us to load and poll all of the
+		// engine plugins on startup. Thus, we set the state of each custom
+		// option checkbox to what is specified by the engine plugin, and
+		// update it only if a value has been set in the configuration of the
+		// currently selected game.
+		bool isChecked = _engineOptions[j].defaultState;
+		if (ConfMan.hasKey(_engineOptions[j].configOption, _domain))
+			isChecked = ConfMan.getBool(_engineOptions[j].configOption, _domain);
+		_engineCheckboxes[j]->setState(isChecked);
+	}
+
+	const Common::PlatformDescription *p = Common::g_platforms;
+	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", _domain));
+	sel = 0;
+	for (i = 0; p->code; ++p, ++i) {
+		if (platform == p->id)
+			sel = i + 2;
+	}
+	_platformPopUp->setSelected(sel);
+}
+
+
+void EditGameDialog::close() {
+	if (getResult()) {
+		ConfMan.set("description", _descriptionWidget->getEditString(), _domain);
+
+		Common::Language lang = (Common::Language)_langPopUp->getSelectedTag();
+		if (lang < 0)
+			ConfMan.removeKey("language", _domain);
+		else
+			ConfMan.set("language", Common::getLanguageCode(lang), _domain);
+
+		String gamePath(_gamePathWidget->getLabel());
+		if (!gamePath.empty())
+			ConfMan.set("path", gamePath, _domain);
+
+		String extraPath(_extraPathWidget->getLabel());
+		if (!extraPath.empty() && (extraPath != _c("None", "path")))
+			ConfMan.set("extrapath", extraPath, _domain);
+		else
+			ConfMan.removeKey("extrapath", _domain);
+
+		String savePath(_savePathWidget->getLabel());
+		if (!savePath.empty() && (savePath != _("Default")))
+			ConfMan.set("savepath", savePath, _domain);
+		else
+			ConfMan.removeKey("savepath", _domain);
+
+		Common::Platform platform = (Common::Platform)_platformPopUp->getSelectedTag();
+		if (platform < 0)
+			ConfMan.removeKey("platform", _domain);
+		else
+			ConfMan.set("platform", Common::getPlatformCode(platform), _domain);
+
+		// Set the state of engine-specific checkboxes
+		for (uint i = 0; i < _engineOptions.size(); i++) {
+			ConfMan.setBool(_engineOptions[i].configOption, _engineCheckboxes[i]->getState(), _domain);
+		}
+	}
+	OptionsDialog::close();
+}
+
+void EditGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
+	switch (cmd) {
+	case kCmdGlobalGraphicsOverride:
+		setGraphicSettingsState(data != 0);
+		draw();
+		break;
+	case kCmdGlobalAudioOverride:
+		setAudioSettingsState(data != 0);
+		setSubtitleSettingsState(data != 0);
+		if (_globalVolumeOverride == NULL)
+			setVolumeSettingsState(data != 0);
+		draw();
+		break;
+	case kCmdGlobalMIDIOverride:
+		setMIDISettingsState(data != 0);
+		draw();
+		break;
+	case kCmdGlobalMT32Override:
+		setMT32SettingsState(data != 0);
+		draw();
+		break;
+	case kCmdGlobalVolumeOverride:
+		setVolumeSettingsState(data != 0);
+		draw();
+		break;
+	case kCmdChooseSoundFontCmd: {
+		BrowserDialog browser(_("Select SoundFont"), false);
+
+		if (browser.runModal() > 0) {
+			// User made this choice...
+			Common::FSNode file(browser.getResult());
+			_soundFont->setLabel(file.getPath());
+
+			if (!file.getPath().empty() && (file.getPath() != _c("None", "path")))
+				_soundFontClearButton->setEnabled(true);
+			else
+				_soundFontClearButton->setEnabled(false);
+
+			draw();
+		}
+		break;
+	}
+
+	// Change path for the game
+	case kCmdGameBrowser: {
+		BrowserDialog browser(_("Select directory with game data"), true);
+		if (browser.runModal() > 0) {
+			// User made his choice...
+			Common::FSNode dir(browser.getResult());
+
+			// TODO: Verify the game can be found in the new directory... Best
+			// done with optional specific gameid to pluginmgr detectgames?
+			// FSList files = dir.listDir(FSNode::kListFilesOnly);
+
+			_gamePathWidget->setLabel(dir.getPath());
+			draw();
+		}
+		draw();
+		break;
+	}
+
+	// Change path for extra game data (eg, using sword cutscenes when playing via CD)
+	case kCmdExtraBrowser: {
+		BrowserDialog browser(_("Select additional game directory"), true);
+		if (browser.runModal() > 0) {
+			// User made his choice...
+			Common::FSNode dir(browser.getResult());
+			_extraPathWidget->setLabel(dir.getPath());
+			draw();
+		}
+		draw();
+		break;
+	}
+	// Change path for stored save game (perm and temp) data
+	case kCmdSaveBrowser: {
+		BrowserDialog browser(_("Select directory for saved games"), true);
+		if (browser.runModal() > 0) {
+			// User made his choice...
+			Common::FSNode dir(browser.getResult());
+			_savePathWidget->setLabel(dir.getPath());
+			draw();
+		}
+		draw();
+		break;
+	}
+
+	case kCmdExtraPathClear:
+		_extraPathWidget->setLabel(_c("None", "path"));
+		break;
+
+	case kCmdSavePathClear:
+		_savePathWidget->setLabel(_("Default"));
+		break;
+
+	case kOKCmd: {
+		// Write back changes made to config object
+		String newDomain(_domainWidget->getEditString());
+		if (newDomain != _domain) {
+			if (newDomain.empty()
+				|| newDomain.hasPrefix("_")
+				|| newDomain == ConfigManager::kApplicationDomain
+				|| ConfMan.hasGameDomain(newDomain)) {
+				MessageDialog alert(_("This game ID is already taken. Please choose another one."));
+				alert.runModal();
+				return;
+			}
+			ConfMan.renameGameDomain(_domain, newDomain);
+			_domain = newDomain;
+		}
+		}
+		// FALL THROUGH to default case
+	default:
+		OptionsDialog::handleCommand(sender, cmd, data);
+	}
+}
+
+>>>>>>> I18N: Add support for language names translation
 #pragma mark -
 
 LauncherDialog::LauncherDialog()

--- a/po/languages/languages.pot
+++ b/po/languages/languages.pot
@@ -1,0 +1,86 @@
+# LANGUAGE translation for ScummVM.
+# Copyright (C) YEAR ScummVM Team
+# This file is distributed under the same license as the ScummVM package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ScummVM 1.8.0git\n"
+"Report-Msgid-Bugs-To: scummvm-devel@lists.sf.net\n"
+"POT-Creation-Date: 2014-11-11 14:32+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=iso-8859-1\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Chinese (China)"
+msgstr ""
+
+msgid "Chinese (Taiwan)"
+msgstr ""
+
+msgid "Croatian"
+msgstr ""
+
+msgid "Czech"
+msgstr ""
+
+msgid "Dutch"
+msgstr ""
+
+msgid "English"
+msgstr ""
+
+msgid "English (GB)"
+msgstr ""
+
+msgid "English (US)"
+msgstr ""
+
+msgid "French"
+msgstr ""
+
+msgid "German"
+msgstr ""
+
+msgid "Greek"
+msgstr ""
+
+msgid "Hebrew"
+msgstr ""
+
+msgid "Hungarian"
+msgstr ""
+
+msgid "Italian"
+msgstr ""
+
+msgid "Japanese"
+msgstr ""
+
+msgid "Korean"
+msgstr ""
+
+msgid "Latvian"
+msgstr ""
+
+msgid "Norwegian Bokmål"
+msgstr ""
+
+msgid "Polish"
+msgstr ""
+
+msgid "Portuguese"
+msgstr ""
+
+msgid "Russian"
+msgstr ""
+
+msgid "Spanish"
+msgstr ""
+
+msgid "Swedish"
+msgstr ""

--- a/po/languages/nl_NL.po
+++ b/po/languages/nl_NL.po
@@ -1,86 +1,86 @@
 # LANGUAGE translation for ScummVM.
 # Copyright (C) YEAR ScummVM Team
 # This file is distributed under the same license as the ScummVM package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# FIRST AUTHOR scummvm@bencastricum.nl, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ScummVM 1.8.0git\n"
 "Report-Msgid-Bugs-To: scummvm-devel@lists.sf.net\n"
 "POT-Creation-Date: 2014-11-11 14:32+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2014-11-11 14:36+0100\n"
+"Last-Translator: Ben Castricum <scummvm@bencastricum.nl>\n"
+"Language-Team: Ben Castricum <scummvm@bencastricum.nl>\n"
+"Language: Nederlands\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ascii\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 msgid "Chinese (China)"
-msgstr ""
+msgstr "Chinees (China)"
 
 msgid "Chinese (Taiwan)"
-msgstr ""
+msgstr "Chinees (Taiwan)"
 
 msgid "Croatian"
-msgstr ""
+msgstr "Kroatisch"
 
 msgid "Czech"
-msgstr ""
+msgstr "Tsjechisch"
 
 msgid "Dutch"
-msgstr ""
+msgstr "Nederlands"
 
 msgid "English"
-msgstr ""
+msgstr "Engels"
 
 msgid "English (GB)"
-msgstr ""
+msgstr "Engels (GB)"
 
 msgid "English (US)"
-msgstr ""
+msgstr "Engels (VS)"
 
 msgid "French"
-msgstr ""
+msgstr "Frans"
 
 msgid "German"
-msgstr ""
+msgstr "Duits"
 
 msgid "Greek"
-msgstr ""
+msgstr "Grieks"
 
 msgid "Hebrew"
-msgstr ""
+msgstr "Hebreeuws"
 
 msgid "Hungarian"
-msgstr ""
+msgstr "Hongaars"
 
 msgid "Italian"
-msgstr ""
+msgstr "Italiaans"
 
 msgid "Japanese"
-msgstr ""
+msgstr "Japans"
 
 msgid "Korean"
-msgstr ""
+msgstr "Koreaans"
 
 msgid "Latvian"
-msgstr ""
+msgstr "Lets"
 
-msgid "Norwegian Bokmål"
-msgstr ""
+msgid "Norwegian Bokmaal"
+msgstr "Noors - Bokmaal"
 
 msgid "Polish"
-msgstr ""
+msgstr "Pools"
 
 msgid "Portuguese"
-msgstr ""
+msgstr "Portugees"
 
 msgid "Russian"
-msgstr ""
+msgstr "Russisch"
 
 msgid "Spanish"
-msgstr ""
+msgstr "Spaans"
 
 msgid "Swedish"
-msgstr ""
+msgstr "Zweeds"

--- a/po/module.mk
+++ b/po/module.mk
@@ -1,5 +1,5 @@
 POTFILE := $(srcdir)/po/scummvm.pot
-POFILES := $(wildcard $(srcdir)/po/*.po)
+POFILES := $(wildcard $(srcdir)/po/*.po $(srcdir)/po/languages/*.po)
 CPFILES := $(wildcard $(srcdir)/po/*.cp)
 
 ENGINE_INPUT_POTFILES := $(sort $(wildcard $(srcdir)/engines/*/POTFILES))


### PR DESCRIPTION
This approach is based on placing the language names in a separate .po(t) file. Only for languages which are compatible with the current GUI limitations (Latin-1) a .po file should be created.
