### PR TITLE
SCUMM: Fix bug #2034 - MANIAC V2: Early Collision with Green Tentacle

### DIFF
--- a/engines/scumm/script_v0.cpp
+++ b/engines/scumm/script_v0.cpp
@@ -589,9 +589,9 @@ void ScummEngine_v0::o_loadRoomWithEgo() {
 		return;
 	}
 
-	// The original interpreter seems to set the actors new room X/Y to the last rooms X/Y
-	// This fixes a problem with MM: script 158 in room 12, the 'Oompf!' script
-	// This scripts runs before the actor position is set to the correct location
+	// The original interpreter sets the actors new room X/Y to the last rooms X/Y
+	// This fixes a problem with MM: script 158 in room 12, the 'Oomph!' script
+	// This scripts runs before the actor position is set to the correct room entry location
 	a->putActor(a->getPos().x, a->getPos().y, room);
 	_egoPositioned = false;
 

--- a/engines/scumm/script_v2.cpp
+++ b/engines/scumm/script_v2.cpp
@@ -1390,7 +1390,14 @@ void ScummEngine_v2::o2_loadRoomWithEgo() {
 
 	a = derefActor(VAR(VAR_EGO), "o2_loadRoomWithEgo");
 
-	a->putActor(0, 0, room);
+	// The original interpreter sets the actors new room X/Y to the last rooms X/Y
+	// This fixes a problem with MM: script 161 in room 12, the 'Oomph!' script
+	// This scripts runs before the actor position is set to the correct room entry location
+	if ((_game.id == GID_MANIAC) && (_game.platform != Common::kPlatformNES)) {
+		a->putActor(a->getPos().x, a->getPos().y, room);
+	} else {
+		a->putActor(0, 0, room);
+	}
 	_egoPositioned = false;
 
 	x = (int8)fetchScriptByte();


### PR DESCRIPTION
The original comment in V0 has been modified because it indicated a guess at behavior, when in fact, its the actual original behavior. I've restricted this to MM (excluding NES, as this issue doesn't occur)... because I haven't examined any other games/engine versions.
