### PR TITLE
COMMON: make XMLParser::loadStream() fail when stream is null

### DIFF
--- a/common/xmlparser.cpp
+++ b/common/xmlparser.cpp
@@ -69,7 +69,7 @@ bool XMLParser::loadBuffer(const byte *buffer, uint32 size, DisposeAfterUse::Fla
 bool XMLParser::loadStream(SeekableReadStream *stream) {
 	_stream = stream;
 	_fileName = "File Stream";
-	return true;
+	return _stream != nullptr;
 }
 
 void XMLParser::close() {


### PR DESCRIPTION
Some users of this method relies on it to fail when
an invalid stream is passed to it
(E.g. VirtualKeyboard::openPack).
