### PR TITLE
SCUMM: MANIAC V1 Demo: GF_DEMO was not being set

### DIFF
--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -502,6 +502,7 @@ static void computeGameSettingsFromMD5(const Common::FSList &fslist, const GameF
 				// (since they have identical MD5):
 				if (dr.game.id == GID_MANIAC && !strcmp(gfp->pattern, "%02d.MAN")) {
 					dr.extra = "V1 Demo";
+					dr.game.features = GF_DEMO;
 				}
 
 				// HACK: Try to detect languages for translated games


### PR DESCRIPTION
Script 1 was being executed by runBootscript, instead of script 9... resulting in an attempt to load Room 11 (which does not exist in the demo).
