### PR TITLE
BACKENDS: Add zip filesystem node

### DIFF
--- a/backends/fs/zip/zip-fs.cpp
+++ b/backends/fs/zip/zip-fs.cpp
@@ -1,0 +1,126 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/system.h"
+#include "common/archive.h"
+#include "common/unzip.h"
+#include "backends/fs/fs-factory.h"
+#include "backends/fs/zip/zip-fs.h"
+#include "backends/fs/stdiostream.h"
+
+ZipFilesystemNode::ZipFilesystemNode(const Common::String &zipFile, const Common::String &pathInZip, const char sep) {
+	_sep = sep;
+	_zipFile = zipFile;
+	_pathInZip = pathInZip;
+	_path = _zipFile;
+	if (!_pathInZip.empty())
+		_path += '/' + _pathInZip;
+	_displayName = lastPathComponent(_path, _pathInZip.empty() ? _sep : '/');
+	_zipArchive = Common::makeZipArchive(StdioStream::makeFromPath(_zipFile, false));
+
+	// Determine if the path inside the zip is a directory
+	_isValid = _zipArchive != nullptr;
+	_isDirectory = true;
+	if (_zipArchive && !_pathInZip.empty()) {
+		Common::ArchiveMemberList arcList;
+		_zipArchive->listMatchingMembers(arcList, _pathInZip + '/');
+		_isDirectory = !arcList.empty() && !_zipArchive->hasFile(_pathInZip);
+		_isValid = _isDirectory || _zipArchive->hasFile(_pathInZip);
+	}
+}
+
+Common::String ZipFilesystemNode::getParentPath(const Common::String &path, const char sep) {
+	Common::String newPath = normalizePath(path, sep);
+	Common::String last = lastPathComponent(newPath, sep);
+
+	newPath.erase(newPath.size() - last.size(), last.size());
+
+	return normalizePath(newPath, sep);
+}
+
+bool ZipFilesystemNode::getChildren(AbstractFSList &myList, ListMode mode, bool hidden) const {
+	Common::ArchiveMemberList arcList;
+
+	if (!_zipArchive)
+		return false;
+
+	if (_pathInZip.empty())
+		_zipArchive->listMembers(arcList);
+	else
+		_zipArchive->listMatchingMembers(arcList, _pathInZip + '*');
+
+	for (Common::ArchiveMemberList::const_iterator i = arcList.begin(); i != arcList.end(); ++i) {
+		Common::String n((*i)->getName());
+
+		if (getParentPath(n, '/') != _pathInZip)
+			continue;
+
+		myList.push_back(new ZipFilesystemNode(_zipFile, normalizePath(n, '/'), _sep));
+	}
+
+	return true;
+}
+
+AbstractFSNode *ZipFilesystemNode::getChild(const Common::String &n) const {
+	assert(_isDirectory);
+
+	// Make sure the string contains no slashes
+	assert(!n.contains('/'));
+
+	Common::String newPath(_path);
+	if (_path.lastChar() != '/')
+		newPath += '/';
+	newPath += n;
+
+	return new ZipFilesystemNode(_zipFile, newPath, _sep);
+}
+
+AbstractFSNode *ZipFilesystemNode::getParent() const {
+	Common::String newPath;
+
+	if (_pathInZip.empty()) {
+		newPath = getParentPath(_zipFile, _sep);
+		return g_system->getFilesystemFactory()->makeFileNodePath(newPath);
+	}
+
+	newPath = getParentPath(_pathInZip, '/');
+	return new ZipFilesystemNode(_zipFile, newPath, _sep);
+}
+
+bool ZipFilesystemNode::exists() const {
+	return _isDirectory || (_zipArchive && _zipArchive->hasFile(_pathInZip));
+}
+
+Common::SeekableReadStream *ZipFilesystemNode::createReadStream() {
+	if (_pathInZip.empty())
+		return StdioStream::makeFromPath(_zipFile, false);
+
+	assert(_zipArchive);
+	return _zipArchive->createReadStreamForMember(_pathInZip);
+}
+
+Common::WriteStream *ZipFilesystemNode::createWriteStream() {
+	if (_pathInZip.empty())
+		return StdioStream::makeFromPath(_zipFile, true);
+
+	return nullptr;
+}

--- a/backends/fs/zip/zip-fs.h
+++ b/backends/fs/zip/zip-fs.h
@@ -1,0 +1,81 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef ZIP_FILESYSTEM_H
+#define ZIP_FILESYSTEM_H
+
+#include "backends/fs/abstract-fs.h"
+
+/**
+ * Implementation of the ScummVM file system API for zip files.
+ *
+ * Parts of this class are documented in the base interface class, AbstractFSNode.
+ */
+class ZipFilesystemNode : public AbstractFSNode {
+private:
+	Common::String _zipFile;
+	Common::String _pathInZip;
+	Common::Archive *_zipArchive;
+	char _sep;
+protected:
+	Common::String _displayName;
+	Common::String _path;
+	bool _isDirectory;
+	bool _isValid;
+public:
+	/**
+	 * Creates a ZipFilesystemNode with a path to a zip file and a path within the zip,
+	 *
+	 * @param zipFile Common::String with the path to the zip file.
+	 * @param pathInZip Common::String with the path inside the zip file.
+	 * @param sep character used to seperate the path components in the zipFile path
+	 */
+	ZipFilesystemNode(const Common::String &zipFile, const Common::String &pathInZip, const char sep);
+
+	virtual bool exists() const;
+	virtual Common::String getDisplayName() const { return _displayName; }
+	virtual Common::String getName() const { return _displayName; }
+	virtual Common::String getPath() const { return _path; }
+	virtual bool isDirectory() const { return _isDirectory; }
+	virtual bool isReadable() const {return true; }
+	virtual bool isWritable() const { return false; }
+
+	virtual AbstractFSNode *getChild(const Common::String &n) const;
+	virtual bool getChildren(AbstractFSList &list, ListMode mode, bool hidden) const;
+	virtual AbstractFSNode *getParent() const;
+
+	virtual Common::SeekableReadStream *createReadStream();
+	virtual Common::WriteStream *createWriteStream();
+
+	/**
+	 * Removes the last component and returns the parent path of a given path.
+	 *
+	 * Example: /path/to/file => /path/to
+	 *
+	 * @param path the path of which we want to know the parent of
+	 * @param sep  the separator token (usually '/' on Unix-style systems, or '\\' on Windows based stuff)
+	 * @return     the parent of path
+	 */
+	static Common::String getParentPath(const Common::String &path, const char sep);
+
+};
+#endif /*ZIP_FILESYSTEM_H*/


### PR DESCRIPTION
This exposes a zip archive as a file system according to
the ScummVM common API.

The benefit of this is that generic code can use compressed
zip archives transparently without having to special case for
it.

To elaborate a bit more on why I'm doing this - it's a part of the Windows Phone 8.1 port I'm working on
and there's certain restrictions what an app is allowed to gain access to on the file system.
In particular, to be able to read files from the SD-card, the application needs to register a set of
file extensions that it is allowed to read.
With the wide plethora of different types of files that can exist in the game data (to not mention files
without extension), the most viable option I saw was to add support of containing game data in an archive.

To give an idea how the zip-fs backend is thought to be used, I pushed a proof-of-concept commit
that make the posix backend use it here:
https://github.com/skristiansson/scummvm/commit/f808db9dd3cffd4d6a4e3c3d22d5feab813e5286

I realize that pulling in code without current users might be undesirable, but this was self-contained
enough from the rest of the wp 8.1 port, so I thought I'd take a chance to get some input on this while
working on the rest.
