### PR TITLE
I18N: Fix missing translation entries

### DIFF
--- a/devtools/create_translations/po_parser.cpp
+++ b/devtools/create_translations/po_parser.cpp
@@ -332,6 +332,13 @@ PoMessageEntryList *parsePoFile(const char *file, PoMessageList& messages) {
 				strcat(currentBuf, stripLine(line));
 		}
 	}
+	if (currentBuf == msgstrBuf) {
+		// add last entry
+		if (*msgstrBuf != '\0' && !fuzzy) {
+			messages.insert(msgidBuf);
+			list->addMessageEntry(msgstrBuf, msgidBuf, msgctxtBuf);
+		}
+	}
 
 	fclose(inFile);
 	return list;


### PR DESCRIPTION
The last translation entry of a .po file was not properly handled.
