### PR TITLE
SDL: add support for SDL2

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -75,17 +75,21 @@ SdlEventSource::~SdlEventSource() {
 }
 
 int SdlEventSource::mapKey(SDLKey key, SDLMod mod, Uint16 unicode) {
-	if (key >= SDLK_F1 && key <= SDLK_F9) {
-		return key - SDLK_F1 + Common::ASCII_F1;
-	} else if (key >= SDLK_KP0 && key <= SDLK_KP9) {
-		return key - SDLK_KP0 + '0';
-	} else if (key >= SDLK_UP && key <= SDLK_PAGEDOWN) {
+	return mapKey(SDLToOSystemKeycode(key), mod, unicode);
+}
+
+int SdlEventSource::mapKey(Common::KeyCode key, SDLMod mod, Uint16 unicode) {
+	if (key >= Common::KEYCODE_F1 && key <= Common::KEYCODE_F9) {
+		return key - Common::KEYCODE_F1 + Common::ASCII_F1;
+	} else if (key >= Common::KEYCODE_KP0 && key <= Common::KEYCODE_KP9) {
+		return key - Common::KEYCODE_KP0 + '0';
+	} else if (key >= Common::KEYCODE_UP && key <= Common::KEYCODE_PAGEDOWN) {
 		return key;
 	} else if (unicode) {
 		return unicode;
 	} else if (key >= 'a' && key <= 'z' && (mod & KMOD_SHIFT)) {
 		return key & ~0x20;
-	} else if (key >= SDLK_NUMLOCK && key <= SDLK_EURO) {
+	} else if (key >= Common::KEYCODE_NUMLOCK && key <= Common::KEYCODE_EURO) {
 		return 0;
 	}
 	return key;
@@ -171,7 +175,12 @@ void SdlEventSource::handleKbdMouse() {
 				_km.y_down_count = 1;
 			}
 
+#ifndef USE_SDL20
 			SDL_WarpMouse((Uint16)_km.x, (Uint16)_km.y);
+#else
+			if (_graphicsManager)
+				_graphicsManager->warpMouse((Uint16)_km.x, (Uint16)_km.y);
+#endif
 		}
 	}
 }
@@ -338,7 +347,9 @@ Common::KeyCode SdlEventSource::SDLToOSystemKeycode(const SDLKey key) {
 	case SDLK_HELP: return Common::KEYCODE_HELP;
 	case SDLK_PRINT: return Common::KEYCODE_PRINT;
 	case SDLK_SYSREQ: return Common::KEYCODE_SYSREQ;
+#ifndef USE_SDL20
 	case SDLK_BREAK: return Common::KEYCODE_BREAK;
+#endif
 	case SDLK_MENU: return Common::KEYCODE_MENU;
 	case SDLK_POWER: return Common::KEYCODE_POWER;
 	case SDLK_UNDO: return Common::KEYCODE_UNDO;
@@ -385,6 +396,7 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 	case SDL_JOYAXISMOTION:
 		return handleJoyAxisMotion(ev, event);
 
+#ifndef USE_SDL20
 	case SDL_VIDEOEXPOSE:
 		if (_graphicsManager)
 			_graphicsManager->notifyVideoExpose();
@@ -403,6 +415,29 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 			}
 		}
 		return false;
+#else
+	case SDL_WINDOWEVENT:
+		switch (ev.window.event) {
+		case SDL_WINDOWEVENT_EXPOSED:
+			if (_graphicsManager)
+				_graphicsManager->notifyVideoExpose();
+			return false;
+		case SDL_WINDOWEVENT_RESIZED:
+			if (_graphicsManager) {
+				_graphicsManager->notifyResize(ev.window.data1, ev.window.data2);
+
+				// If the screen changed, send an Common::EVENT_SCREEN_CHANGED
+				int screenID = ((OSystem_SDL *)g_system)->getGraphicsManager()->getScreenChangeID();
+				if (screenID != _lastScreenID) {
+					_lastScreenID = screenID;
+					event.type = Common::EVENT_SCREEN_CHANGED;
+					return true;
+				}
+			}
+			return false;
+		}
+		return false;
+#endif
 
 	case SDL_QUIT:
 		event.type = Common::EVENT_QUIT;
@@ -413,6 +448,25 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 	return false;
 }
 
+#ifdef USE_SDL20
+static Uint16 convUTF8ToUCS2(const char *src) {
+	Uint16 ucs2 = 0;
+	char *dst = SDL_iconv_string(
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+		"UCS-2BE",
+#else
+		"UCS-2LE",
+#endif
+		"UTF-8", src, SDL_strlen(src)+1);
+
+	if (dst) {
+		ucs2 = *((Uint16 *)dst);
+		SDL_free(dst);
+	}
+
+	return ucs2;
+}
+#endif
 
 bool SdlEventSource::handleKeyDown(SDL_Event &ev, Common::Event &event) {
 
@@ -468,9 +522,28 @@ bool SdlEventSource::handleKeyDown(SDL_Event &ev, Common::Event &event) {
 	if (remapKey(ev, event))
 		return true;
 
+#ifndef USE_SDL20
+	Uint16 unicode = (Uint16)ev.key.keysym.unicode;
+#else
+	Uint16 unicode = 0;
+	SDL_Event events[2];
+
+	// In SDL2, the unicode field has been removed from the keysym struct.
+	// Instead a SDL_TEXTINPUT event is generated on key combinations that
+	// generates unicode.
+	// Here we peek into the event queue for the event to see if it exists.
+	int n = SDL_PeepEvents(events, 2, SDL_PEEKEVENT, SDL_KEYDOWN, SDL_TEXTINPUT);
+	// Make sure that the TEXTINPUT event belongs to this KEYDOWN
+	// event and not another pending one.
+	if (n > 0 && events[0].type == SDL_TEXTINPUT)
+		unicode = convUTF8ToUCS2(events[0].text.text);
+	else if (n > 1 && events[0].type != SDL_KEYDOWN && events[1].type == SDL_TEXTINPUT)
+		unicode = convUTF8ToUCS2(events[1].text.text);
+#endif
+
 	event.type = Common::EVENT_KEYDOWN;
 	event.kbd.keycode = SDLToOSystemKeycode(ev.key.keysym.sym);
-	event.kbd.ascii = mapKey(ev.key.keysym.sym, (SDLMod)ev.key.keysym.mod, (Uint16)ev.key.keysym.unicode);
+	event.kbd.ascii = mapKey(ev.key.keysym.sym, (SDLMod)ev.key.keysym.mod, unicode);
 
 	return true;
 }
@@ -514,7 +587,12 @@ bool SdlEventSource::handleKeyUp(SDL_Event &ev, Common::Event &event) {
 
 	event.type = Common::EVENT_KEYUP;
 	event.kbd.keycode = SDLToOSystemKeycode(ev.key.keysym.sym);
-	event.kbd.ascii = mapKey(ev.key.keysym.sym, (SDLMod)ev.key.keysym.mod, (Uint16)ev.key.keysym.unicode);
+	event.kbd.ascii = mapKey(ev.key.keysym.sym, (SDLMod)ev.key.keysym.mod,
+#ifndef USE_SDL20
+		(Uint16)ev.key.keysym.unicode);
+#else
+		0);
+#endif
 
 	// Ctrl-Alt-<key> will change the GFX mode
 	SDLModToOSystemKeyFlags(mod, event);
@@ -751,10 +829,17 @@ bool SdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 }
 
 void SdlEventSource::toggleMouseGrab() {
+#ifndef USE_SDL20
 	if (SDL_WM_GrabInput(SDL_GRAB_QUERY) == SDL_GRAB_OFF)
 		SDL_WM_GrabInput(SDL_GRAB_ON);
 	else
 		SDL_WM_GrabInput(SDL_GRAB_OFF);
+#else
+	if (SDL_GetRelativeMouseMode() == SDL_FALSE)
+		SDL_SetRelativeMouseMode(SDL_TRUE);
+	else
+		SDL_SetRelativeMouseMode(SDL_FALSE);
+#endif
 }
 
 void SdlEventSource::resetKeyboadEmulation(int16 x_max, int16 y_max) {

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -131,6 +131,7 @@ protected:
 	 * Maps the ASCII value of key
 	 */
 	virtual int mapKey(SDLKey key, SDLMod mod, Uint16 unicode);
+	virtual int mapKey(Common::KeyCode key, SDLMod mod, Uint16 unicode);
 
 	/**
 	 * Configures the key modifiers flags status

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -146,6 +146,8 @@ public:
 	virtual void transformMouseCoordinates(Common::Point &point);
 	virtual void notifyMousePos(Common::Point mouse);
 
+	virtual void setWindowCaption(const char *title, const char *icon);
+
 protected:
 #ifdef USE_OSD
 	/** Surface containing the OSD message */
@@ -339,6 +341,15 @@ protected:
 	virtual void setMousePos(int x, int y);
 	virtual void toggleFullScreen();
 	virtual bool saveScreenshot(const char *filename);
+
+	// SDL 1.2 / SDL 2.0 incompatibility abstraction methods
+	virtual void setColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
+	virtual void setAlpha(SDL_Surface *surface,  Uint32 flag, Uint8 alpha);
+	virtual void setColorKey(SDL_Surface *surface,  int flag, Uint32 key);
+	virtual void iconifyWindow();
+	virtual void createHwScreen();
+	virtual void destroyHwScreen();
+	virtual void blitToHwScreen();
 };
 
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl20-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl20-graphics.cpp
@@ -1,0 +1,116 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "backends/graphics/surfacesdl/surfacesdl20-graphics.h"
+#include "graphics/scaler/aspect.h"
+
+void SurfaceSdl20GraphicsManager::warpMouse(int x, int y) {
+	int y1 = y;
+
+	if (_videoMode.aspectRatioCorrection && !_overlayVisible)
+		y1 = real2Aspect(y);
+
+	if (_mouseCurState.x != x || _mouseCurState.y != y) {
+		if (!_overlayVisible)
+			SDL_WarpMouseInWindow(_hwwindow, x * _videoMode.scaleFactor, y1 * _videoMode.scaleFactor);
+		else
+			SDL_WarpMouseInWindow(_hwwindow, x, y1);
+
+		setMousePos(x, y1);
+	}
+}
+
+void SurfaceSdl20GraphicsManager::setColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors) {
+	if (surface->format->palette)
+		SDL_SetPaletteColors(surface->format->palette, colors, firstcolor, ncolors);
+}
+
+void SurfaceSdl20GraphicsManager::setAlpha(SDL_Surface *surface,  Uint32 flag, Uint8 alpha) {
+	SDL_SetSurfaceAlphaMod(surface, alpha);
+	if (!flag)
+		SDL_SetSurfaceBlendMode(_screen, SDL_BLENDMODE_NONE);
+}
+
+void SurfaceSdl20GraphicsManager::setColorKey(SDL_Surface *surface,  int flag, Uint32 key) {
+	SDL_SetColorKey(surface, SDL_TRUE, key);
+}
+
+void SurfaceSdl20GraphicsManager::setWindowCaption(const char *title, const char *icon) {
+	_windowTitle = title;
+	SDL_SetWindowTitle(_hwwindow, title);
+}
+
+void SurfaceSdl20GraphicsManager::iconifyWindow() {
+	SDL_MinimizeWindow(_hwwindow);
+}
+
+void SurfaceSdl20GraphicsManager::blitToHwScreen() {
+	int pitch;
+	void *pixels;
+
+	SDL_LockTexture(_hwtexture, NULL, &pixels, &pitch);
+	SDL_ConvertPixels(_hwscreen->w, _hwscreen->h, _hwscreen->format->format,
+		_hwscreen->pixels, _hwscreen->pitch, SDL_PIXELFORMAT_RGBA8888, pixels, pitch);
+	SDL_UnlockTexture(_hwtexture);
+
+	SDL_RenderClear(_hwrenderer);
+	SDL_RenderCopy(_hwrenderer, _hwtexture, NULL, NULL);
+	SDL_RenderPresent(_hwrenderer);
+}
+
+void SurfaceSdl20GraphicsManager::createHwScreen() {
+	_hwwindow = SDL_CreateWindow(_windowTitle.c_str(),
+		SDL_WINDOWPOS_CENTERED,
+		SDL_WINDOWPOS_CENTERED,
+		_videoMode.hardwareWidth, _videoMode.hardwareHeight,
+		_videoMode.fullscreen ?
+			(SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_SHOWN) :
+			SDL_WINDOW_SHOWN);
+	assert(_hwwindow);
+	_hwrenderer = SDL_CreateRenderer(_hwwindow, -1, 0);
+	assert(_hwrenderer);
+	SDL_RenderSetLogicalSize(_hwrenderer, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
+	_hwtexture = SDL_CreateTexture(_hwrenderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
+	_hwscreen = SDL_CreateRGBSurface(SDL_SWSURFACE, _videoMode.hardwareWidth, _videoMode.hardwareHeight, 16, 0, 0, 0, 0);
+}
+
+void SurfaceSdl20GraphicsManager::destroyHwScreen() {
+	if (_hwtexture) {
+		SDL_DestroyTexture(_hwtexture);
+		_hwtexture = NULL;
+	}
+
+	if (_hwrenderer) {
+		SDL_DestroyRenderer(_hwrenderer);
+		_hwrenderer = NULL;
+	}
+
+	if (_hwwindow) {
+		SDL_DestroyWindow(_hwwindow);
+		_hwwindow = NULL;
+	}
+
+	if (_hwscreen) {
+		SDL_FreeSurface(_hwscreen);
+		_hwscreen = NULL;
+	}
+}

--- a/backends/graphics/surfacesdl/surfacesdl20-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl20-graphics.h
@@ -1,0 +1,53 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKENDS_GRAPHICS_SURFACESDL20_GRAPHICS_H
+#define BACKENDS_GRAPHICS_SURFACESDL20_GRAPHICS_H
+
+#include "backends/graphics/surfacesdl/surfacesdl-graphics.h"
+
+class SurfaceSdl20GraphicsManager : public SurfaceSdlGraphicsManager {
+public:
+	SurfaceSdl20GraphicsManager(SdlEventSource *sdlEventSource)
+	:
+	SurfaceSdlGraphicsManager(sdlEventSource), _windowTitle("ScummVM"),
+	_hwwindow(0), _hwrenderer(0), _hwtexture(0) {}
+
+	virtual void setWindowCaption(const char *title, const char *icon);
+
+protected:
+	SDL_Window *_hwwindow;
+	SDL_Renderer *_hwrenderer;
+	SDL_Texture *_hwtexture;
+
+	Common::String _windowTitle;
+
+	virtual void warpMouse(int x, int y);
+	virtual void iconifyWindow();
+	virtual void setColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
+	virtual void setAlpha(SDL_Surface *surface,  Uint32 flag, Uint8 alpha);
+	virtual void setColorKey(SDL_Surface *surface,  int flag, Uint32 key);
+	virtual void createHwScreen();
+	virtual void destroyHwScreen();
+	virtual void blitToHwScreen();
+};
+#endif

--- a/backends/mixer/sdl/sdl-mixer.cpp
+++ b/backends/mixer/sdl/sdl-mixer.cpp
@@ -57,11 +57,13 @@ void SdlMixerManager::init() {
 		error("Could not initialize SDL: %s", SDL_GetError());
 	}
 
+#ifndef USE_SDL20
 	const int maxNameLen = 20;
 	char sdlDriverName[maxNameLen];
 	sdlDriverName[0] = '\0';
 	SDL_AudioDriverName(sdlDriverName, maxNameLen);
 	debug(1, "Using SDL Audio Driver \"%s\"", sdlDriverName);
+#endif
 
 	// Get the desired audio specs
 	SDL_AudioSpec desired = getAudioSpec(SAMPLES_PER_SEC);

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -74,8 +74,10 @@ MODULE_OBJS += \
 
 # SDL 1.3 removed audio CD support
 ifndef USE_SDL13
+ifndef USE_SDL20
 MODULE_OBJS += \
 	audiocd/sdl/sdl-audiocd.o
+endif
 endif
 
 ifdef USE_OPENGL

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -72,6 +72,11 @@ MODULE_OBJS += \
 	plugins/sdl/sdl-provider.o \
 	timer/sdl/sdl-timer.o
 
+ifdef USE_SDL20
+MODULE_OBJS += \
+	graphics/surfacesdl/surfacesdl20-graphics.o
+endif
+
 # SDL 1.3 removed audio CD support
 ifndef USE_SDL13
 ifndef USE_SDL20

--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -74,5 +74,46 @@ typedef struct { int FAKE; } FAKE_FILE;
 #define strncasecmp    FORBIDDEN_SYMBOL_REPLACEMENT
 #endif
 
+// These flags and functions have been removed in SDL 2.0
+// We define the functions here to avoid build errors, but assert to ensure that they never get called
+#ifdef USE_SDL20
+#define SDL_SRCCOLORKEY 0
+#define SDL_SRCALPHA 0
+#define SDL_FULLSCREEN 0
+#define SDL_APPMOUSEFOCUS 0
+
+#define SDL_UpdateRects(a, b, c) assert(0)
+#define SDL_SetColors(a, b, c, d) assert(0)
+#define SDL_SetAlpha(a, b, c) assert(0)
+#define SDL_SetVideoMode(a, b, c, d) (assert(0), (SDL_Surface *)NULL)
+#define SDL_GetAppState() (assert(0), 0)
+#define SDL_WarpMouse(a, b) assert(0)
+#define SDL_WM_IconifyWindow() (assert(0), 0)
+#define SDL_WM_SetCaption(a, b) assert(0)
+
+// Key compat conversions
+#define SDLKey SDL_Keycode
+#define SDLK_SCROLLOCK SDLK_SCROLLLOCK
+#define SDLK_NUMLOCK SDLK_NUMLOCKCLEAR
+#define SDLK_LSUPER SDLK_LGUI
+#define SDLK_RSUPER SDLK_RGUI
+#define SDLK_PRINT SDLK_PRINTSCREEN
+#define SDLK_COMPOSE SDLK_APPLICATION
+#define SDLK_KP0 SDLK_KP_0
+#define SDLK_KP1 SDLK_KP_1
+#define SDLK_KP2 SDLK_KP_2
+#define SDLK_KP3 SDLK_KP_3
+#define SDLK_KP4 SDLK_KP_4
+#define SDLK_KP5 SDLK_KP_5
+#define SDLK_KP6 SDLK_KP_6
+#define SDLK_KP7 SDLK_KP_7
+#define SDLK_KP8 SDLK_KP_8
+#define SDLK_KP9 SDLK_KP_9
+
+// Mod compat conversions
+#define SDLMod SDL_Keymod
+#define KMOD_META KMOD_GUI
+
+#endif
 
 #endif

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -46,7 +46,11 @@
 #include "backends/events/sdl/sdl-events.h"
 #include "backends/mutex/sdl/sdl-mutex.h"
 #include "backends/timer/sdl/sdl-timer.h"
+#ifdef USE_SDL20
+#include "backends/graphics/surfacesdl/surfacesdl20-graphics.h"
+#else
 #include "backends/graphics/surfacesdl/surfacesdl-graphics.h"
+#endif
 #ifdef USE_OPENGL
 #include "backends/graphics/openglsdl/openglsdl-graphics.h"
 #include "graphics/cursorman.h"
@@ -126,8 +130,10 @@ void OSystem_SDL::init() {
 	// Initialize SDL
 	initSDL();
 
+#ifndef USE_SDL20
 	// Enable unicode support if possible
 	SDL_EnableUNICODE(1);
+#endif
 
 	// Disable OS cursor
 	SDL_ShowCursor(SDL_DISABLE);
@@ -158,6 +164,7 @@ void OSystem_SDL::initBackend() {
 	// Check if backend has not been initialized
 	assert(!_inited);
 
+#ifndef USE_SDL20
 	const int maxNameLen = 20;
 	char sdlDriverName[maxNameLen];
 	sdlDriverName[0] = '\0';
@@ -165,6 +172,7 @@ void OSystem_SDL::initBackend() {
 	// Using printf rather than debug() here as debug()/logging
 	// is not active by this point.
 	debug(1, "Using SDL Video Driver \"%s\"", sdlDriverName);
+#endif
 
 	// Create the default event source, in case a custom backend
 	// manager didn't provide one yet.
@@ -205,7 +213,11 @@ void OSystem_SDL::initBackend() {
 #endif
 
 		if (_graphicsManager == 0) {
+#ifdef USE_SDL20
+			_graphicsManager = new SurfaceSdl20GraphicsManager(_eventSource);
+#else
 			_graphicsManager = new SurfaceSdlGraphicsManager(_eventSource);
+#endif
 		}
 	}
 
@@ -314,7 +326,7 @@ void OSystem_SDL::setWindowCaption(const char *caption) {
 		}
 	}
 
-	SDL_WM_SetCaption(cap.c_str(), cap.c_str());
+	dynamic_cast<SurfaceSdlGraphicsManager *>(_graphicsManager)->setWindowCaption(cap.c_str(), cap.c_str());
 }
 
 void OSystem_SDL::quit() {
@@ -477,7 +489,9 @@ void OSystem_SDL::setupIcon() {
 	if (!sdl_surf) {
 		warning("SDL_CreateRGBSurfaceFrom(icon) failed");
 	}
+#ifndef USE_SDL20
 	SDL_WM_SetIcon(sdl_surf, NULL);
+#endif
 	SDL_FreeSurface(sdl_surf);
 	free(icon);
 }

--- a/configure
+++ b/configure
@@ -129,6 +129,7 @@ _freetype2=auto
 _taskbar=auto
 _updates=no
 _libunity=auto
+_sdl2=no
 # Default option behavior yes/no
 _debug_build=auto
 _release_build=auto
@@ -354,7 +355,10 @@ define_in_config_if_yes() {
 find_sdlconfig() {
 	echo_n "Looking for sdl-config... "
 	sdlconfigs="$_sdlconfig:sdl-config:sdl11-config:sdl12-config"
-	_sdlconfig=
+	if test "$_sdl2" = yes ; then
+            sdlconfigs="sdl2-config"
+        fi
+        _sdlconfig=
 
 	IFS="${IFS=   }"; ac_save_ifs="$IFS"; IFS="$SEPARATOR"
 	for path_dir in $_sdlpath; do
@@ -965,6 +969,7 @@ Optional Libraries:
 
   --with-sdl-prefix=DIR    Prefix where the sdl-config script is
                            installed (optional)
+  --enable-sdl2            enable SDL2 support (optional)
 
   --with-freetype2-prefix=DIR Prefix where the freetype-config script is
                            installed (optional)
@@ -1048,6 +1053,8 @@ for ac_option in $@; do
 	--disable-libunity)       _libunity=no    ;;
 	--enable-opengl)          _opengl=yes     ;;
 	--disable-opengl)         _opengl=no      ;;
+	--enable-sdl2)            _sdl2=yes       ;;
+	--disable-sdl2)           _sdl2=no        ;;
 	--enable-bink)            _bink=yes       ;;
 	--disable-bink)           _bink=no        ;;
 	--enable-verbose-build)   _verbose_build=yes ;;
@@ -3054,6 +3061,10 @@ case $_backend in
 		case $_sdlversion in
 			1.3.*)
 				add_line_to_config_mk "USE_SDL13 = 1"
+				;;
+			2.0.*)
+				add_line_to_config_mk "USE_SDL20 = 1"
+				add_line_to_config_h "#define USE_SDL20"
 				;;
 			*)
 				;;


### PR DESCRIPTION
As the title says, this set of patches adds initial support for SDL2.
The commit messages for each patch should contain an explanation to deficiencies
in the related areas, but one thing that is not mentioned is that this does not contain support
for explicitly using OpenGL (although it might be the actual backend SDL2 is using to render).

Also, some of the changes might be considered a bit of hacks (the compatibility defines for an instance),
so I'm certainly up for discussion on how to improve on cleanliness.

I've tested the changes on a normal Linux machine, and as far as my tests goes, the changes are
at a state where they are usable (albeit experimental).