### PR TITLE
Symbian : add Theora support

### DIFF
--- a/video/theora_decoder.cpp
+++ b/video/theora_decoder.cpp
@@ -360,7 +360,11 @@ static double rint(double v) {
 }
 
 bool TheoraDecoder::VorbisAudioTrack::decodeSamples() {
+#ifdef USE_TREMOR && __SYMBIAN32__
+	ogg_int32_t **pcm;
+#else
 	float **pcm;
+#endif
 
 	// if there's pending, decoded audio, grab it
 	int ret = vorbis_synthesis_pcmout(&_vorbisDSP, &pcm);

--- a/video/theora_decoder.h
+++ b/video/theora_decoder.h
@@ -33,7 +33,12 @@
 #include "graphics/surface.h"
 
 #include <theora/theoradec.h>
+
+#ifdef USE_TREMOR && __SYMBIAN32__
+#include <tremor/ivorbiscodec.h>
+#else
 #include <vorbis/codec.h>
+#endif
 
 namespace Common {
 class SeekableReadStream;


### PR DESCRIPTION
Symbian use fixed-point Theora decoder unlike other backends.