### PR TITLE
SDL: explicitly set unicode parameter to 0 on SDL_KEYUP events

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -514,7 +514,7 @@ bool SdlEventSource::handleKeyUp(SDL_Event &ev, Common::Event &event) {
 
 	event.type = Common::EVENT_KEYUP;
 	event.kbd.keycode = SDLToOSystemKeycode(ev.key.keysym.sym);
-	event.kbd.ascii = mapKey(ev.key.keysym.sym, (SDLMod)ev.key.keysym.mod, (Uint16)ev.key.keysym.unicode);
+	event.kbd.ascii = mapKey(ev.key.keysym.sym, (SDLMod)ev.key.keysym.mod, 0);
 
 	// Ctrl-Alt-<key> will change the GFX mode
 	SDLModToOSystemKeyFlags(mod, event);


### PR DESCRIPTION
As per SDL documentation, unicode character codes are only
generated on keydown events, not on keyup events.
http://www.libsdl.org/release/SDL-1.2.15/docs/html/sdlenableunicode.html

This make it explicit to make it clear from the code that the
unicode character will *not* be provided on keyup events.