### PR TITLE
AUDIO: Wrap around in the Timestamp constructor

### DIFF
--- a/audio/timestamp.cpp
+++ b/audio/timestamp.cpp
@@ -39,12 +39,10 @@ Timestamp::Timestamp(uint ms, uint fr) {
 Timestamp::Timestamp(uint s, uint frames, uint fr) {
 	assert(fr > 0);
 
-	_secs = s;
+	_secs = s + (frames / fr);
 	_framerateFactor = 1000 / Common::gcd<uint>(1000, fr);
 	_framerate = fr * _framerateFactor;
-	_numFrames = frames * _framerateFactor;
-
-	normalize();
+	_numFrames = (frames % fr) * _framerateFactor;
 }
 
 Timestamp Timestamp::convertToFramerate(uint newFramerate) const {

--- a/test/audio/timestamp.h
+++ b/test/audio/timestamp.h
@@ -2,6 +2,8 @@
 
 #include "audio/timestamp.h"
 
+#include <limits.h>
+
 class TimestampTestSuite : public CxxTest::TestSuite
 {
 	public:
@@ -237,5 +239,16 @@ class TimestampTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(c.msecs(), 1500);
 		TS_ASSERT_EQUALS(c.numberOfFrames(), 11025);
 		TS_ASSERT_EQUALS(c.totalNumberOfFrames(), 33075);
+	}
+
+	void test_no_overflow() {
+		// The constructor should not overflow and give incoherent values
+		const Audio::Timestamp a = Audio::Timestamp(0, UINT_MAX, 1000);
+
+		int secs = UINT_MAX / 1000;
+		int frames = UINT_MAX % 1000;
+
+		TS_ASSERT_EQUALS(a.secs(), secs);
+		TS_ASSERT_EQUALS(a.numberOfFrames(), frames);
 	}
 };


### PR DESCRIPTION
The Audio::Timestamp(uint s, uint frames, uint fr) constructor would overflow the _numFrames variable, for big enough frame count / framerate couples.

The fix performs the "wrap around" operation that would occur in the "normalize" method directly in the constructor to avoid the integer overflow.

The "making of" video in the Xbox version of Myst III in ResidualVM triggered this bug.
