### PR TITLE
Day of the Tentacle easter egg

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -529,43 +529,21 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 			// at. At the time of writing, this is used for the Maniac Mansion
 			// easter egg in Day of the Tentacle.
 
-			Common::String chainedGames, nextGame, saveSlot;
+			Common::String chainedGame;
+			int saveSlot = -1;
 
-			if (ConfMan.hasKey("chained_games", Common::ConfigManager::kTransientDomain)) {
-				chainedGames = ConfMan.get("chained_games", Common::ConfigManager::kTransientDomain);
-			}
+			ChainedGamesMan.pop(chainedGame, saveSlot);
 
 			// Discard any command line options. It's unlikely that the user
 			// wanted to apply them to *all* games ever launched.
 			ConfMan.getDomain(Common::ConfigManager::kTransientDomain)->clear();
 
-			if (!chainedGames.empty()) {
-				if (chainedGames.contains(',')) {
-					for (uint i = 0; i < chainedGames.size(); i++) {
-						if (chainedGames[i] == ',') {
-							chainedGames.erase(0, i + 1);
-							break;
-						}
-						nextGame += chainedGames[i];
-					}
-					ConfMan.set("chained_games", chainedGames, Common::ConfigManager::kTransientDomain);
-				} else {
-					nextGame = chainedGames;
-					chainedGames.clear();
-					ConfMan.removeKey("chained_games", Common::ConfigManager::kTransientDomain);
+			if (!chainedGame.empty()) {
+				if (saveSlot != -1) {
+					ConfMan.setInt("save_slot", saveSlot, Common::ConfigManager::kTransientDomain);
 				}
-				if (nextGame.contains(':')) {
-					for (int i = nextGame.size() - 1; i >= 0; i--) {
-						if (nextGame[i] == ':') {
-							nextGame.erase(i);
-							break;
-						}
-						saveSlot = nextGame[i] + saveSlot;
-					}
-					ConfMan.setInt("save_slot", atoi(saveSlot.c_str()), Common::ConfigManager::kTransientDomain);
-				}
-				// Start the next game
-				ConfMan.setActiveDomain(nextGame);
+				// Start the chained game
+				ConfMan.setActiveDomain(chainedGame);
 			} else {
 				// Clear the active config domain
 				ConfMan.setActiveDomain("");

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -45,6 +45,7 @@
 #include "common/taskbar.h"
 #include "common/textconsole.h"
 #include "common/translation.h"
+#include "common/singleton.h"
 
 #include "backends/keymapper/keymapper.h"
 
@@ -101,6 +102,36 @@ static void defaultErrorHandler(const char *msg) {
 	}
 }
 
+// Chained games manager
+
+ChainedGamesManager::ChainedGamesManager() {
+	clear();
+}
+
+void ChainedGamesManager::clear() {
+	_chainedGames.clear();
+}
+
+void ChainedGamesManager::push(const Common::String target, const int slot) {
+	Game game;
+	game.target = target;
+	game.slot = slot;
+	_chainedGames.push(game);
+}
+
+bool ChainedGamesManager::pop(Common::String &target, int &slot) {
+	if (_chainedGames.empty()) {
+		return false;
+	}
+	Game game = _chainedGames.pop();
+	target = game.target;
+	slot = game.slot;
+	return true;
+}
+
+namespace Common {
+DECLARE_SINGLETON(ChainedGamesManager);
+}
 
 Engine::Engine(OSystem *syst)
 	: _system(syst),

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -27,6 +27,8 @@
 #include "common/str.h"
 #include "common/language.h"
 #include "common/platform.h"
+#include "common/queue.h"
+#include "common/singleton.h"
 
 class OSystem;
 
@@ -333,6 +335,32 @@ protected:
 	bool shouldPerformAutoSave(int lastSaveTime);
 
 };
+
+// Chained games
+
+/**
+ * Singleton class which manages chained games. A chained game is one that
+ * starts automatically, optionally loading a saved game, instead of returning
+ * to the launcher.
+ */
+class ChainedGamesManager : public Common::Singleton<ChainedGamesManager> {
+private:
+	struct Game {
+		Common::String target;
+		int slot;
+	};
+
+	Common::Queue<Game> _chainedGames;
+
+public:
+	ChainedGamesManager();
+	void clear();
+	void push(const Common::String target, const int slot = -1);
+	bool pop(Common::String &target, int &slot);
+};
+
+/** Convenience shortcut for accessing the chained games manager. */
+#define ChainedGamesMan ChainedGamesManager::instance()
 
 // FIXME: HACK for MidiEmu & error()
 extern Engine *g_engine;

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -149,7 +149,7 @@ void ScummEngine::requestSave(int slot, const Common::String &name) {
 
 void ScummEngine::requestLoad(int slot) {
 	_saveLoadSlot = slot;
-	_saveTemporaryState = false;
+	_saveTemporaryState = (slot == 100);
 	_saveLoadFlag = 2;		// 2 for load
 }
 

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -2597,7 +2597,11 @@ void ScummEngine_v6::o6_kernelSetFunctions() {
 		fadeIn(args[1]);
 		break;
 	case 8:
-		startManiac();
+		if (startManiac()) {
+			// This is so that the surprised exclamation happens
+			// after we return to the game again, not before.
+			o6_breakHere();
+		}
 		break;
 	case 9:
 		killAllScriptsExceptCurrent();

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2601,20 +2601,24 @@ bool ScummEngine::startManiac() {
 	Common::String currentPath = ConfMan.get("path");
 	Common::String maniacTarget;
 
-	// Look for a game with a game path pointing to a 'Maniac' directory
-	// as a subdirectory to the current game.
-	Common::ConfigManager::DomainMap::iterator iter = ConfMan.beginGameDomains();
-	for (; iter != ConfMan.endGameDomains(); ++iter) {
-		Common::ConfigManager::Domain &dom = iter->_value;
-		Common::String path = dom.getVal("path");
+	if (!ConfMan.hasKey("easter_egg")) {
+		// Look for a game with a game path pointing to a 'Maniac' directory
+		// as a subdirectory to the current game.
+		Common::ConfigManager::DomainMap::iterator iter = ConfMan.beginGameDomains();
+		for (; iter != ConfMan.endGameDomains(); ++iter) {
+			Common::ConfigManager::Domain &dom = iter->_value;
+			Common::String path = dom.getVal("path");
 
-		if (path.hasPrefix(currentPath)) {
-			path.erase(0, currentPath.size() + 1);
-			if (path.equalsIgnoreCase("maniac")) {
-				maniacTarget = dom.getVal("gameid");
-				break;
+			if (path.hasPrefix(currentPath)) {
+				path.erase(0, currentPath.size() + 1);
+				if (path.equalsIgnoreCase("maniac")) {
+					maniacTarget = dom.getVal("gameid");
+					break;
+				}
 			}
 		}
+	} else {
+		maniacTarget = ConfMan.get("easter_egg");
 	}
 
 	if (!maniacTarget.empty()) {

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2597,9 +2597,47 @@ void ScummEngine_v90he::runBootscript() {
 }
 #endif
 
-void ScummEngine::startManiac() {
-	debug(0, "stub startManiac()");
-	displayMessage(0, "%s", _("Usually, Maniac Mansion would start now. But ScummVM doesn't do that yet. To play it, go to 'Add Game' in the ScummVM start menu and select the 'Maniac' directory inside the Tentacle game directory."));
+bool ScummEngine::startManiac() {
+	Common::String currentPath = ConfMan.get("path");
+	Common::String maniacTarget;
+
+	// Look for a game with a game path pointing to a 'Maniac' directory
+	// as a subdirectory to the current game.
+	Common::ConfigManager::DomainMap::iterator iter = ConfMan.beginGameDomains();
+	for (; iter != ConfMan.endGameDomains(); ++iter) {
+		Common::ConfigManager::Domain &dom = iter->_value;
+		Common::String path = dom.getVal("path");
+
+		if (path.hasPrefix(currentPath)) {
+			path.erase(0, currentPath.size() + 1);
+			if (path.equalsIgnoreCase("maniac")) {
+				maniacTarget = dom.getVal("gameid");
+				break;
+			}
+		}
+	}
+
+	if (!maniacTarget.empty()) {
+		// Request a temporary save game to be made.
+		_saveLoadFlag = 1;
+		_saveLoadSlot = 100;
+		_saveTemporaryState = true;
+
+		// Set up the chanined games to Maniac Mansion, and then back
+		// to the current game again with that save slot.
+		ConfMan.set("chained_games", maniacTarget + "," + ConfMan.getActiveDomainName() + ":100", Common::ConfigManager::kTransientDomain);
+
+		// Force a return to the launcher. This will start the first
+		// chained game.
+		Common::EventManager *eventMan = g_system->getEventManager();
+		Common::Event event;
+		event.type = Common::EVENT_RTL;
+		eventMan->pushEvent(event);
+		return true;
+	} else {
+		displayMessage(0, "%s", _("Usually, Maniac Mansion would start now. But for that to work, the game files for Maniac Mansion have to be in the 'Maniac' directory inside the Tentacle game directory, and the game has to be added to ScummVM."));
+		return false;
+	}
 }
 
 #pragma mark -

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2625,7 +2625,8 @@ bool ScummEngine::startManiac() {
 
 		// Set up the chanined games to Maniac Mansion, and then back
 		// to the current game again with that save slot.
-		ConfMan.set("chained_games", maniacTarget + "," + ConfMan.getActiveDomainName() + ":100", Common::ConfigManager::kTransientDomain);
+		ChainedGamesMan.push(maniacTarget);
+		ChainedGamesMan.push(ConfMan.getActiveDomainName(), 100);
 
 		// Force a return to the launcher. This will start the first
 		// chained game.

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -654,7 +654,7 @@ protected:
 	int	getScriptSlot();
 
 	void startScene(int room, Actor *a, int b);
-	void startManiac();
+	bool startManiac();
 
 public:
 	void runScript(int script, bool freezeResistant, bool recursive, int *lvarptr, int cycle = 0);


### PR DESCRIPTION
Here is one possible way of supporting the Maniac Mansion easter egg in Day of the Tentacle, by adding a mechanism where instead of returning to the launcher dialog, it automatically launches another game. Optionally with a save game slot to load on startup.

So to start Maniac Mansion it first creates a temporary savegame, using the hitherto unused (I think) save slot 100, adds Maniac Mansion and itself to the "chained games" list and forces a return to the launcher. Manually returning to the launcher from Maniac Mansion resumes Day of the Tentacle at the temporary savegame.

It detects Maniac Mansion by looking if the ScummVM config file contains any game that is in a "Maniac" sub-directory of the current game. Since this may not always work, it also checks for an "easter_egg" config setting, though there is no GUI for it at the moment, and no error handling. (I.e. no checks if the game exists, and setting the game to Day of the Tentacle itself is probably not such a bright idea, for instance...)

Quitting still quits the entire ScummVM. I couldn't think of any sensible way to do otherwise.