### PR TITLE
MORTEVIELLE: some display bugs fixed

### DIFF
--- a/engines/mortevielle/dialogs.cpp
+++ b/engines/mortevielle/dialogs.cpp
@@ -405,7 +405,7 @@ void DialogManager::drawF3F8() {
 	int f8Width = _vm->_screenSurface->getStringWidth(f8);
 
 	// Write out the bounding box
-	_vm->_screenSurface->drawBox(0, 42, MAX(f3Width, f8Width) + 6, 18, 7);
+	_vm->_screenSurface->drawBox(0, 42, MAX(f3Width, f8Width) + 4, 16, 7);
 }
 
 /**

--- a/engines/mortevielle/dialogs.cpp
+++ b/engines/mortevielle/dialogs.cpp
@@ -66,12 +66,12 @@ int DialogManager::show(const Common::String &msg) {
 		drawAlertBox(10, 5, colNumb);
 	} else {
 		drawAlertBox(8, 7, colNumb);
-		int i = 0;
+		int i = -1;
 		_vm->_screenSurface->_textPos.y = 70;
 		do {
 			curPos.x = 320;
 			Common::String displayStr = "";
-			while ((alertStr[i + 1] != '\174') && (alertStr[i + 1] != '\135')) {
+			while ((alertStr[i + 1] != '|') && (alertStr[i + 1] != ']')) {
 				++i;
 				displayStr += alertStr[i];
 				curPos.x -= 3;

--- a/engines/mortevielle/graphics.cpp
+++ b/engines/mortevielle/graphics.cpp
@@ -1019,6 +1019,8 @@ void ScreenSurface::writeCharacter(const Common::Point &pt, unsigned char ch, in
  *		simulate the original 640x400 surface, all Y values have to be doubled
  */
 void ScreenSurface::drawBox(int x, int y, int dx, int dy, int col) {
+	dx++; dy++;	// Original function draws 1px bigger
+
 	Graphics::Surface destSurface = lockArea(Common::Rect(x, y * 2, x + dx, (y + dy) * 2));
 
 	destSurface.hLine(0, 0, dx, col);

--- a/engines/mortevielle/utils.cpp
+++ b/engines/mortevielle/utils.cpp
@@ -1653,11 +1653,11 @@ void MortevielleEngine::clearDescriptionBar() {
 	_mouse->hideMouse();
 	if (_largestClearScreen) {
 		_screenSurface->fillRect(0, Common::Rect(1, 176, 633, 199));
-		_screenSurface->drawBox(0, 176, 634, 23, 15);
+		_screenSurface->drawBox(0, 175, 634, 24, 15);
 		_largestClearScreen = false;
 	} else {
 		_screenSurface->fillRect(0, Common::Rect(1, 176, 633, 190));
-		_screenSurface->drawBox(0, 176, 634, 14, 15);
+		_screenSurface->drawBox(0, 175, 634, 15, 15);
 	}
 	_mouse->showMouse();
 }


### PR DESCRIPTION
Hi,

This is a patch for the following problems:

- The boxes are 1 pixel bigger in the DOS game. I fixed the drawBox() method to match original code.
- Also, alerts are missing the first character. So I fixed the show() method changing base string read index.

Thanks!