### PR TITLE
MORTEVIELLE: Added missing mesgId handling for 3rd intro screen

### DIFF
--- a/engines/mortevielle/mortevielle.h
+++ b/engines/mortevielle/mortevielle.h
@@ -92,6 +92,7 @@ enum DataType {
 #define MORT_DAT_REQUIRED_VERSION 1
 #define MORT_DAT "mort.dat"
 #define GAME_FRAME_DELAY (1000 / 50)
+#define DISK_ACCESS_DELAY 3000
 
 const int kTime1 = 410;
 const int kTime2 = 250;

--- a/engines/mortevielle/mouse.cpp
+++ b/engines/mortevielle/mouse.cpp
@@ -51,7 +51,7 @@ void MouseHandler::initMouse() {
  * @remarks	Originally called 'hide_mouse'
  */
 void MouseHandler::hideMouse() {
-	g_system->showMouse(false);
+	// No implementation needed in ScummVM
 }
 
 /**
@@ -59,7 +59,7 @@ void MouseHandler::hideMouse() {
  * @remarks	Originally called 'show_mouse'
  */
 void MouseHandler::showMouse() {
-	g_system->showMouse(true);
+	// ScummVM implementation uses CursorMan for drawing the cursor
 }
 
 /**

--- a/engines/mortevielle/mouse.cpp
+++ b/engines/mortevielle/mouse.cpp
@@ -51,7 +51,7 @@ void MouseHandler::initMouse() {
  * @remarks	Originally called 'hide_mouse'
  */
 void MouseHandler::hideMouse() {
-	// No implementation needed in ScummVM
+	g_system->showMouse(false);
 }
 
 /**
@@ -59,7 +59,7 @@ void MouseHandler::hideMouse() {
  * @remarks	Originally called 'show_mouse'
  */
 void MouseHandler::showMouse() {
-	// ScummVM implementation uses CursorMan for drawing the cursor
+	g_system->showMouse(true);
 }
 
 /**

--- a/engines/mortevielle/utils.cpp
+++ b/engines/mortevielle/utils.cpp
@@ -234,6 +234,7 @@ void MortevielleEngine::setMousePos(const Common::Point &pt) {
 void MortevielleEngine::delay(int amount) {
 	uint32 endTime = g_system->getMillis() + amount;
 
+	_mouse->hideMouse();
 	while (g_system->getMillis() < endTime) {
 		if (g_system->getMillis() > (_lastGameFrame + GAME_FRAME_DELAY)) {
 			_lastGameFrame = g_system->getMillis();
@@ -244,6 +245,7 @@ void MortevielleEngine::delay(int amount) {
 
 		g_system->delayMillis(10);
 	}
+	_mouse->showMouse();
 }
 
 /**
@@ -2124,6 +2126,7 @@ void MortevielleEngine::showTitleScreen() {
 	_caff = 51;
 	_text->taffich();
 	testKeyboard();
+	delay(DISK_ACCESS_DELAY);
 	clearScreen();
 	draw(0, 0);
 
@@ -2519,6 +2522,18 @@ void MortevielleEngine::handleDescriptionText(int f, int mesgId) {
 				_coreVar._pctHintFound[6] = '*';
 			else if (mesgId == 179)
 				_coreVar._pctHintFound[10] = '*';
+			}
+			break;
+		case 7: {
+			prepareScreenType3();
+			Common::String tmpStr = getString(mesgId);
+			// CHECKME: original code seems to consider one extra character
+			// See text position in the 3rd intro screen
+			int size = tmpStr.size() + 1;
+			if (size < 40)
+				_text->displayStr(tmpStr, 252 - size * 3, 86, 50, 3, 5);
+			else
+				_text->displayStr(tmpStr, 144, 86, 50, 3, 5);
 			}
 			break;
 		default:

--- a/engines/mortevielle/utils.cpp
+++ b/engines/mortevielle/utils.cpp
@@ -234,7 +234,7 @@ void MortevielleEngine::setMousePos(const Common::Point &pt) {
 void MortevielleEngine::delay(int amount) {
 	uint32 endTime = g_system->getMillis() + amount;
 
-	_mouse->hideMouse();
+	g_system->showMouse(false);
 	while (g_system->getMillis() < endTime) {
 		if (g_system->getMillis() > (_lastGameFrame + GAME_FRAME_DELAY)) {
 			_lastGameFrame = g_system->getMillis();
@@ -245,7 +245,7 @@ void MortevielleEngine::delay(int amount) {
 
 		g_system->delayMillis(10);
 	}
-	_mouse->showMouse();
+	g_system->showMouse(true);
 }
 
 /**


### PR DESCRIPTION
Hi,

This is the 3rd part of the intro which is currently not handled by the code.

This message is displayed during disk access, so it may not visible as is in ScummVM version as things are quite fast nowadays, a delay is required. Also delay should hide the mouse to prevent frozen screen.

Thanks!