### PR TITLE
SDL: Add experimental support for SDL2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -565,6 +565,7 @@ Other contributions
      Jeroen Janssen               - Numerous readability and bugfix patches
      Keith Kaisershot             - Several Pegasus Prime patches
      Andreas Karlsson             - Initial port for SymbianOS
+     Stefan Kristiansson          - Initial work on SDL2 support
      Claudio Matsuoka             - Daily Linux builds
      Thomas Mayer                 - PSP port contributions
      Sean Murray                  - ScummVM tools GUI application (GSoC 2007

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ ifeq "$(findstring config.mk,$(MAKEFILE_LIST))" "config.mk"
 	LDFLAGS="$(SAVED_LDFLAGS)" CXX="$(SAVED_CXX)" \
 			CXXFLAGS="$(SAVED_CXXFLAGS)" CPPFLAGS="$(SAVED_CPPFLAGS)" \
 			ASFLAGS="$(SAVED_ASFLAGS)" WINDRESFLAGS="$(SAVED_WINDRESFLAGS)" \
+			SDL_CONFIG="$(SAVED_SDL_CONFIG)" \
 			$(srcdir)/configure $(SAVED_CONFIGFLAGS)
 else
 	$(error You need to run $(srcdir)/configure before you can run make. Check $(srcdir)/configure --help for a list of parameters)

--- a/backends/audiocd/sdl/sdl-audiocd.cpp
+++ b/backends/audiocd/sdl/sdl-audiocd.cpp
@@ -24,8 +24,11 @@
 
 #if defined(SDL_BACKEND)
 
-#include "common/textconsole.h"
 #include "backends/audiocd/sdl/sdl-audiocd.h"
+
+#if !SDL_VERSION_ATLEAST(1, 3, 0)
+
+#include "common/textconsole.h"
 
 SdlAudioCDManager::SdlAudioCDManager()
 	:
@@ -132,5 +135,7 @@ void SdlAudioCDManager::updateCD() {
 		_cdEndTime = SDL_GetTicks() + _cdrom->track[_cdTrack].length * 1000 / CD_FPS;
 	}
 }
+
+#endif // !SDL_VERSION_ATLEAST(1, 3, 0)
 
 #endif

--- a/backends/audiocd/sdl/sdl-audiocd.h
+++ b/backends/audiocd/sdl/sdl-audiocd.h
@@ -27,6 +27,8 @@
 
 #include "backends/platform/sdl/sdl-sys.h"
 
+#if !SDL_VERSION_ATLEAST(1, 3, 0)
+
 /**
  * The SDL audio cd manager. Implements real audio cd playback.
  */
@@ -46,5 +48,7 @@ protected:
 	int _cdTrack, _cdNumLoops, _cdStartFrame, _cdDuration;
 	uint32 _cdEndTime, _cdStopTime;
 };
+
+#endif // !SDL_VERSION_ATLEAST(1, 3, 0)
 
 #endif

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -173,7 +173,9 @@ void SdlEventSource::handleKbdMouse() {
 				_km.y_down_count = 1;
 			}
 
-			SDL_WarpMouse((Uint16)_km.x, (Uint16)_km.y);
+			if (_graphicsManager) {
+				_graphicsManager->warpMouseInWindow((Uint16)_km.x, (Uint16)_km.y);
+			}
 		}
 	}
 }
@@ -429,7 +431,9 @@ bool SdlEventSource::handleKeyDown(SDL_Event &ev, Common::Event &event) {
 
 	// Ctrl-m toggles mouse capture
 	if (event.kbd.hasFlags(Common::KBD_CTRL) && ev.key.keysym.sym == 'm') {
-		toggleMouseGrab();
+		if (_graphicsManager) {
+			_graphicsManager->toggleMouseGrab();
+		}
 		return false;
 	}
 
@@ -750,13 +754,6 @@ bool SdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 	}
 #endif
 	return false;
-}
-
-void SdlEventSource::toggleMouseGrab() {
-	if (SDL_WM_GrabInput(SDL_GRAB_QUERY) == SDL_GRAB_OFF)
-		SDL_WM_GrabInput(SDL_GRAB_ON);
-	else
-		SDL_WM_GrabInput(SDL_GRAB_OFF);
 }
 
 void SdlEventSource::resetKeyboadEmulation(int16 x_max, int16 y_max) {

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -183,7 +183,7 @@ void SdlEventSource::handleKbdMouse() {
 			}
 
 			if (_graphicsManager) {
-				_graphicsManager->warpMouseInWindow((Uint16)_km.x, (Uint16)_km.y);
+				_graphicsManager->getWindow()->warpMouseInWindow((Uint16)_km.x, (Uint16)_km.y);
 			}
 		}
 	}
@@ -471,7 +471,7 @@ bool SdlEventSource::handleKeyDown(SDL_Event &ev, Common::Event &event) {
 	// Ctrl-m toggles mouse capture
 	if (event.kbd.hasFlags(Common::KBD_CTRL) && ev.key.keysym.sym == 'm') {
 		if (_graphicsManager) {
-			_graphicsManager->toggleMouseGrab();
+			_graphicsManager->getWindow()->toggleMouseGrab();
 		}
 		return false;
 	}

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -125,7 +125,7 @@ protected:
 	/**
 	 * Maps the ASCII value of key
 	 */
-	virtual int mapKey(SDLKey key, SDLMod mod, Uint16 unicode);
+	int mapKey(SDLKey key, SDLMod mod, Uint16 unicode);
 
 	/**
 	 * Configures the key modifiers flags status
@@ -136,6 +136,17 @@ protected:
 	 * Translates SDL key codes to OSystem key codes
 	 */
 	Common::KeyCode SDLToOSystemKeycode(const SDLKey key);
+
+	/**
+	 * Notify graphics manager of a resize request.
+	 */
+	bool handleResizeEvent(Common::Event &event, int w, int h);
+
+	/**
+	 * Extracts unicode information for the specific key sym.
+	 * May only be used for key down events.
+	 */
+	uint32 obtainUnicode(const SDL_keysym keySym);
 };
 
 #endif

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -49,11 +49,6 @@ public:
 	 */
 	virtual void resetKeyboadEmulation(int16 x_max, int16 y_max);
 
-	/**
-	 * Toggles mouse input grab
-	 */
-	virtual void toggleMouseGrab();
-
 protected:
 	/** @name Keyboard mouse emulation
 	 * Disabled by fingolfin 2004-12-18.

--- a/backends/events/symbiansdl/symbiansdl-events.cpp
+++ b/backends/events/symbiansdl/symbiansdl-events.cpp
@@ -134,7 +134,7 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 						event.type = Common::EVENT_MOUSEMOVE;
 						processMouseEvent(event, _mouseXZone[_currentZone], _mouseYZone[_currentZone]);
 						if (_graphicsManager) {
-							_graphicsManager->warpMouseInWindow(event.mouse.x, event.mouse.y);
+							_graphicsManager->getWindow()->warpMouseInWindow(event.mouse.x, event.mouse.y);
 						}
 				}
 

--- a/backends/events/symbiansdl/symbiansdl-events.cpp
+++ b/backends/events/symbiansdl/symbiansdl-events.cpp
@@ -133,7 +133,9 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 							_currentZone = 0;
 						event.type = Common::EVENT_MOUSEMOVE;
 						processMouseEvent(event, _mouseXZone[_currentZone], _mouseYZone[_currentZone]);
-						SDL_WarpMouse(event.mouse.x, event.mouse.y);
+						if (_graphicsManager) {
+							_graphicsManager->warpMouseInWindow(event.mouse.x, event.mouse.y);
+						}
 				}
 
 				return true;

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -122,7 +122,7 @@ void DINGUXSdlGraphicsManager::initSize(uint w, uint h) {
 	if (w > 320 || h > 240) {
 		setGraphicsMode(GFX_HALF);
 		setGraphicsModeIntern();
-		_eventSource->toggleMouseGrab();
+		toggleMouseGrab();
 	}
 
 	_transactionDetails.sizeChanged = true;

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -35,8 +35,8 @@ static const OSystem::GraphicsMode s_supportedGraphicsModes[] = {
 	{0, 0, 0}
 };
 
-DINGUXSdlGraphicsManager::DINGUXSdlGraphicsManager(SdlEventSource *boss)
-	: SurfaceSdlGraphicsManager(boss) {
+DINGUXSdlGraphicsManager::DINGUXSdlGraphicsManager(SdlEventSource *boss, SdlWindow *window)
+	: SurfaceSdlGraphicsManager(boss, window) {
 }
 
 const OSystem::GraphicsMode *DINGUXSdlGraphicsManager::getSupportedGraphicsModes() const {
@@ -122,7 +122,7 @@ void DINGUXSdlGraphicsManager::initSize(uint w, uint h) {
 	if (w > 320 || h > 240) {
 		setGraphicsMode(GFX_HALF);
 		setGraphicsModeIntern();
-		toggleMouseGrab();
+		_window->toggleMouseGrab();
 	}
 
 	_transactionDetails.sizeChanged = true;

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
@@ -34,7 +34,7 @@ enum {
 
 class DINGUXSdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
-	DINGUXSdlGraphicsManager(SdlEventSource *boss);
+	DINGUXSdlGraphicsManager(SdlEventSource *boss, SdlWindow *window);
 
 	bool hasFeature(OSystem::Feature f);
 	void setFeatureState(OSystem::Feature f, bool enable);

--- a/backends/graphics/gph/gph-graphics.cpp
+++ b/backends/graphics/gph/gph-graphics.cpp
@@ -35,8 +35,8 @@ static const OSystem::GraphicsMode s_supportedGraphicsModes[] = {
 	{0, 0, 0}
 };
 
-GPHGraphicsManager::GPHGraphicsManager(SdlEventSource *sdlEventSource)
-	: SurfaceSdlGraphicsManager(sdlEventSource) {
+GPHGraphicsManager::GPHGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
+	: SurfaceSdlGraphicsManager(sdlEventSource, window) {
 }
 
 const OSystem::GraphicsMode *GPHGraphicsManager::getSupportedGraphicsModes() const {
@@ -141,7 +141,7 @@ void GPHGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *f
 	if (w > 320 || h > 240) {
 		setGraphicsMode(GFX_HALF);
 		setGraphicsModeIntern();
-		_eventSource->toggleMouseGrab();
+		_window->toggleMouseGrab();
 	}
 
 	_videoMode.overlayWidth = 320;

--- a/backends/graphics/gph/gph-graphics.h
+++ b/backends/graphics/gph/gph-graphics.h
@@ -33,7 +33,7 @@ enum {
 
 class GPHGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
-	GPHGraphicsManager(SdlEventSource *boss);
+	GPHGraphicsManager(SdlEventSource *boss, SdlWindow *window);
 
 	bool hasFeature(OSystem::Feature f);
 	void setFeatureState(OSystem::Feature f, bool enable);

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
@@ -45,8 +45,8 @@ static const OSystem::GraphicsMode s_supportedGraphicsModes[] = {
 	{0, 0, 0}
 };
 
-LinuxmotoSdlGraphicsManager::LinuxmotoSdlGraphicsManager(SdlEventSource *sdlEventSource)
- : SurfaceSdlGraphicsManager(sdlEventSource) {
+LinuxmotoSdlGraphicsManager::LinuxmotoSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
+ : SurfaceSdlGraphicsManager(sdlEventSource, window) {
 }
 
 const OSystem::GraphicsMode *LinuxmotoSdlGraphicsManager::getSupportedGraphicsModes() const {
@@ -134,7 +134,7 @@ void LinuxmotoSdlGraphicsManager::initSize(uint w, uint h) {
 	if	(w > 320 || h > 240) {
 		setGraphicsMode(GFX_HALF);
 		setGraphicsModeIntern();
-		toggleMouseGrab();
+		_window->toggleMouseGrab();
 	}
 
 	_transactionDetails.sizeChanged = true;

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
@@ -134,7 +134,7 @@ void LinuxmotoSdlGraphicsManager::initSize(uint w, uint h) {
 	if	(w > 320 || h > 240) {
 		setGraphicsMode(GFX_HALF);
 		setGraphicsModeIntern();
-		_eventSource->toggleMouseGrab();
+		toggleMouseGrab();
 	}
 
 	_transactionDetails.sizeChanged = true;

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.h
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.h
@@ -27,7 +27,7 @@
 
 class LinuxmotoSdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
-	LinuxmotoSdlGraphicsManager(SdlEventSource *sdlEventSource);
+	LinuxmotoSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
 	virtual void initSize(uint w, uint h);
 	virtual void setGraphicsModeIntern();

--- a/backends/graphics/maemosdl/maemosdl-graphics.cpp
+++ b/backends/graphics/maemosdl/maemosdl-graphics.cpp
@@ -29,8 +29,8 @@
 #include "backends/events/maemosdl/maemosdl-events.h"
 #include "backends/graphics/maemosdl/maemosdl-graphics.h"
 
-MaemoSdlGraphicsManager::MaemoSdlGraphicsManager(SdlEventSource *sdlEventSource)
-	: SurfaceSdlGraphicsManager(sdlEventSource) {
+MaemoSdlGraphicsManager::MaemoSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
+	: SurfaceSdlGraphicsManager(sdlEventSource, window) {
 }
 
 bool MaemoSdlGraphicsManager::loadGFXMode() {

--- a/backends/graphics/maemosdl/maemosdl-graphics.h
+++ b/backends/graphics/maemosdl/maemosdl-graphics.h
@@ -29,7 +29,7 @@
 
 class MaemoSdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
-	MaemoSdlGraphicsManager(SdlEventSource *sdlEventSource);
+	MaemoSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
 protected:
 	virtual bool loadGFXMode();

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -29,7 +29,12 @@
 #endif
 
 OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(uint desktopWidth, uint desktopHeight, SdlEventSource *eventSource)
-    : SdlGraphicsManager(eventSource), _lastVideoModeLoad(0), _hwScreen(nullptr), _lastRequestedWidth(0), _lastRequestedHeight(0),
+    : SdlGraphicsManager(eventSource), _lastRequestedHeight(0),
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+      _glContext(),
+#else
+      _lastVideoModeLoad(0), _hwScreen(nullptr),
+#endif
       _graphicsScale(2), _ignoreLoadVideoMode(false), _gotResize(false), _wantsFullScreen(false), _ignoreResizeEvents(0),
       _desiredFullscreenWidth(0), _desiredFullscreenHeight(0) {
 	// Setup OpenGL attributes for SDL
@@ -40,6 +45,17 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(uint desktopWidth, uint deskt
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
 	// Retrieve a list of working fullscreen modes
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	const int numModes = SDL_GetNumDisplayModes(0);
+	for (int i = 0; i < numModes; ++i) {
+		SDL_DisplayMode mode;
+		if (SDL_GetDisplayMode(0, i, &mode)) {
+			continue;
+		}
+
+		_fullscreenVideoModes.push_back(VideoMode(mode.w, mode.h));
+	}
+#else
 	const SDL_Rect *const *availableModes = SDL_ListModes(NULL, SDL_OPENGL | SDL_FULLSCREEN);
 	if (availableModes != (void *)-1) {
 		for (;*availableModes; ++availableModes) {
@@ -47,9 +63,19 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(uint desktopWidth, uint deskt
 
 			_fullscreenVideoModes.push_back(VideoMode(mode->w, mode->h));
 		}
+	}
+#endif
 
-		// Sort the modes in ascending order.
-		Common::sort(_fullscreenVideoModes.begin(), _fullscreenVideoModes.end());
+	// Sort the modes in ascending order.
+	Common::sort(_fullscreenVideoModes.begin(), _fullscreenVideoModes.end());
+
+	// Strip duplicates in video modes.
+	for (uint i = 0; i + 1 < _fullscreenVideoModes.size();) {
+		if (_fullscreenVideoModes[i] == _fullscreenVideoModes[i + 1]) {
+			_fullscreenVideoModes.remove_at(i);
+		} else {
+			++i;
+		}
 	}
 
 	// In case SDL is fine with every mode we will force the desktop mode.
@@ -120,11 +146,19 @@ void OpenGLSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) 
 bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) {
 	switch (f) {
 	case OSystem::kFeatureFullscreenMode:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		if (_window) {
+			return (SDL_GetWindowFlags(_window) & SDL_WINDOW_FULLSCREEN) != 0;
+		} else {
+			return _wantsFullScreen;
+		}
+#else
 		if (_hwScreen) {
 			return (_hwScreen->flags & SDL_FULLSCREEN) != 0;
 		} else {
 			return _wantsFullScreen;
 		}
+#endif
 
 	default:
 		return OpenGLGraphicsManager::getFeatureState(f);
@@ -201,13 +235,20 @@ void OpenGLSdlGraphicsManager::updateScreen() {
 	OpenGLGraphicsManager::updateScreen();
 
 	// Swap OpenGL buffers
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_GL_SwapWindow(_window);
+#else
 	SDL_GL_SwapBuffers();
+#endif
 }
 
 void OpenGLSdlGraphicsManager::notifyVideoExpose() {
 }
 
 void OpenGLSdlGraphicsManager::notifyResize(const uint width, const uint height) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	setActualScreenSize(width, height);
+#else
 	if (!_ignoreResizeEvents && _hwScreen && !(_hwScreen->flags & SDL_FULLSCREEN)) {
 		// We save that we handled a resize event here. We need to know this
 		// so we do not overwrite the users requested window size whenever we
@@ -218,6 +259,7 @@ void OpenGLSdlGraphicsManager::notifyResize(const uint width, const uint height)
 			g_system->quit();
 		}
 	}
+#endif
 }
 
 void OpenGLSdlGraphicsManager::transformMouseCoordinates(Common::Point &point) {
@@ -300,6 +342,58 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 		height = _desiredFullscreenHeight;
 	}
 
+	// This is pretty confusing since RGBA8888 talks about the memory
+	// layout here. This is a different logical layout depending on
+	// whether we run on little endian or big endian. However, we can
+	// only safely assume that RGBA8888 in memory layout is supported.
+	// Thus, we chose this one.
+	const Graphics::PixelFormat rgba8888 =
+#ifdef SCUMM_LITTLE_ENDIAN
+	                                       Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
+#else
+	                                       Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
+#endif
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_glContext) {
+		notifyContextDestroy();
+
+		SDL_GL_DeleteContext(_glContext);
+		_glContext = nullptr;
+	}
+
+	destroyWindow();
+
+	uint32 flags = SDL_WINDOW_OPENGL;
+	if (_wantsFullScreen) {
+		flags |= SDL_WINDOW_FULLSCREEN;
+	} else {
+		flags |= SDL_WINDOW_RESIZABLE;
+	}
+
+	if (!createWindow(width, height, flags)) {
+		// We treat fullscreen requests as a "hint" for now. This means in
+		// case it is not available we simply ignore it.
+		if (_wantsFullScreen) {
+			createWindow(width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		}
+
+		if (!_window) {
+			return false;
+		}
+	}
+
+	_glContext = SDL_GL_CreateContext(_window);
+	if (!_glContext) {
+		return false;
+	}
+
+	notifyContextCreate(rgba8888, rgba8888);
+	int actualWidth, actualHeight;
+	SDL_GetWindowSize(_window, &actualWidth, &actualHeight);
+	setActualScreenSize(actualWidth, actualHeight);
+	return true;
+#else
 	// WORKAROUND: Working around infamous SDL bugs when switching
 	// resolutions too fast. This might cause the event system to supply
 	// incorrect mouse position events otherwise.
@@ -341,17 +435,6 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	_lastVideoModeLoad = SDL_GetTicks();
 
 	if (_hwScreen) {
-		// This is pretty confusing since RGBA8888 talks about the memory
-		// layout here. This is a different logical layout depending on
-		// whether we run on little endian or big endian. However, we can
-		// only safely assume that RGBA8888 in memory layout is supported.
-		// Thus, we chose this one.
-		const Graphics::PixelFormat rgba8888 =
-#ifdef SCUMM_LITTLE_ENDIAN
-		                                       Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#else
-		                                       Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#endif
 		notifyContextCreate(rgba8888, rgba8888);
 		setActualScreenSize(_hwScreen->w, _hwScreen->h);
 	}
@@ -363,6 +446,21 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 		_ignoreResizeEvents = 10;
 
 	return _hwScreen != nullptr;
+#endif
+}
+
+void OpenGLSdlGraphicsManager::getWindowDimensions(int *width, int *height) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_GetWindowSize(_window, width, height);
+#else
+	if (width) {
+		*width = _hwScreen->w;
+	}
+
+	if (height) {
+		*height = _hwScreen->h;
+	}
+#endif
 }
 
 bool OpenGLSdlGraphicsManager::notifyEvent(const Common::Event &event) {
@@ -456,7 +554,9 @@ bool OpenGLSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 					// Calculate the next scaling setting. We approximate the
 					// current scale setting in case the user resized the
 					// window. Then we apply the direction change.
-					_graphicsScale = MAX<int>(_hwScreen->w / _lastRequestedWidth, _hwScreen->h / _lastRequestedHeight);
+					int windowWidth = 0, windowHeight = 0;
+					getWindowDimensions(&windowWidth, &windowHeight);
+					_graphicsScale = MAX<int>(windowWidth / _lastRequestedWidth, windowHeight / _lastRequestedHeight);
 					_graphicsScale = MAX<int>(_graphicsScale + direction, 1);
 
 					// Since we overwrite a user resize here we reset its
@@ -472,7 +572,9 @@ bool OpenGLSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 				}
 
 #ifdef USE_OSD
-				const Common::String osdMsg = Common::String::format("Resolution: %dx%d", _hwScreen->w, _hwScreen->h);
+				int windowWidth = 0, windowHeight = 0;
+				getWindowDimensions(&windowWidth, &windowHeight);
+				const Common::String osdMsg = Common::String::format("Resolution: %dx%d", windowWidth, windowHeight);
 				displayMessageOnOSD(osdMsg.c_str());
 #endif
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -108,7 +108,7 @@ void OpenGLSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) 
 
 	case OSystem::kFeatureIconifyWindow:
 		if (enable) {
-			SDL_WM_IconifyWindow();
+			iconifyWindow();
 		}
 		break;
 
@@ -229,7 +229,7 @@ void OpenGLSdlGraphicsManager::notifyMousePos(Common::Point mouse) {
 }
 
 void OpenGLSdlGraphicsManager::setInternalMousePosition(int x, int y) {
-	SDL_WarpMouse(x, y);
+	warpMouseInWindow(x, y);
 }
 
 bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format) {

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -68,8 +68,14 @@ protected:
 private:
 	bool setupMode(uint width, uint height);
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_GLContext _glContext;
+#else
 	uint32 _lastVideoModeLoad;
 	SDL_Surface *_hwScreen;
+#endif
+
+	void getWindowDimensions(int *width, int *height);
 
 	uint _lastRequestedWidth;
 	uint _lastRequestedHeight;

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -32,7 +32,7 @@
 
 class OpenGLSdlGraphicsManager : public OpenGL::OpenGLGraphicsManager, public SdlGraphicsManager, public Common::EventObserver {
 public:
-	OpenGLSdlGraphicsManager(uint desktopWidth, uint desktopHeight, SdlEventSource *eventSource);
+	OpenGLSdlGraphicsManager(uint desktopWidth, uint desktopHeight, SdlEventSource *eventSource, SdlWindow *window);
 	virtual ~OpenGLSdlGraphicsManager();
 
 	// GraphicsManager API

--- a/backends/graphics/openpandora/op-graphics.cpp
+++ b/backends/graphics/openpandora/op-graphics.cpp
@@ -32,8 +32,8 @@
 
 static SDL_Cursor *hiddenCursor;
 
-OPGraphicsManager::OPGraphicsManager(SdlEventSource *sdlEventSource)
-	: SurfaceSdlGraphicsManager(sdlEventSource) {
+OPGraphicsManager::OPGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
+	: SurfaceSdlGraphicsManager(sdlEventSource, window) {
 }
 
 bool OPGraphicsManager::loadGFXMode() {

--- a/backends/graphics/openpandora/op-graphics.h
+++ b/backends/graphics/openpandora/op-graphics.h
@@ -32,7 +32,7 @@ enum {
 
 class OPGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
-	OPGraphicsManager(SdlEventSource *sdlEventSource);
+	OPGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
 	bool loadGFXMode();
 	void unloadGFXMode();

--- a/backends/graphics/samsungtvsdl/samsungtvsdl-graphics.cpp
+++ b/backends/graphics/samsungtvsdl/samsungtvsdl-graphics.cpp
@@ -28,8 +28,8 @@
 #include "backends/events/samsungtvsdl/samsungtvsdl-events.h"
 #include "backends/graphics/samsungtvsdl/samsungtvsdl-graphics.h"
 
-SamsungTVSdlGraphicsManager::SamsungTVSdlGraphicsManager(SdlEventSource *sdlEventSource)
-	: SurfaceSdlGraphicsManager(sdlEventSource) {
+SamsungTVSdlGraphicsManager::SamsungTVSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
+	: SurfaceSdlGraphicsManager(sdlEventSource, window) {
 }
 
 bool SamsungTVSdlGraphicsManager::hasFeature(OSystem::Feature f) {

--- a/backends/graphics/samsungtvsdl/samsungtvsdl-graphics.h
+++ b/backends/graphics/samsungtvsdl/samsungtvsdl-graphics.h
@@ -29,7 +29,7 @@
 
 class SamsungTVSdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
-	SamsungTVSdlGraphicsManager(SdlEventSource *sdlEventSource);
+	SamsungTVSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
 	bool hasFeature(OSystem::Feature f);
 	void setFeatureState(OSystem::Feature f, bool enable);

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -22,7 +22,9 @@
 
 #include "backends/graphics/sdl/sdl-graphics.h"
 
+#include "backends/platform/sdl/sdl-sys.h"
 #include "backends/events/sdl/sdl-events.h"
+#include "common/textconsole.h"
 
 SdlGraphicsManager::SdlGraphicsManager(SdlEventSource *source)
 	: _eventSource(source) {
@@ -37,4 +39,33 @@ void SdlGraphicsManager::activateManager() {
 
 void SdlGraphicsManager::deactivateManager() {
 	_eventSource->setGraphicsManager(0);
+}
+
+void SdlGraphicsManager::setWindowCaption(const Common::String &caption) {
+	SDL_WM_SetCaption(caption.c_str(), caption.c_str());
+}
+
+void SdlGraphicsManager::setWindowIcon(SDL_Surface *icon) {
+	SDL_WM_SetIcon(icon, NULL);
+	SDL_FreeSurface(icon);
+}
+
+void SdlGraphicsManager::toggleMouseGrab() {
+	if (SDL_WM_GrabInput(SDL_GRAB_QUERY) == SDL_GRAB_OFF) {
+		SDL_WM_GrabInput(SDL_GRAB_ON);
+	} else {
+		SDL_WM_GrabInput(SDL_GRAB_OFF);
+	}
+}
+
+bool SdlGraphicsManager::hasMouseFocus() const {
+	return (SDL_GetAppState() & SDL_APPMOUSEFOCUS);
+}
+
+void SdlGraphicsManager::warpMouseInWindow(uint x, uint y) {
+	SDL_WarpMouse(x, y);
+}
+
+void SdlGraphicsManager::iconifyWindow() {
+	SDL_WM_IconifyWindow();
 }

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -27,10 +27,18 @@
 #include "common/textconsole.h"
 
 SdlGraphicsManager::SdlGraphicsManager(SdlEventSource *source)
-	: _eventSource(source) {
+	: _eventSource(source)
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	  , _window(nullptr), _inputGrabState(false), _windowCaption("ScummVM"), _windowIcon(nullptr)
+#endif
+	{
 }
 
 SdlGraphicsManager::~SdlGraphicsManager() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_FreeSurface(_windowIcon);
+	destroyWindow();
+#endif
 }
 
 void SdlGraphicsManager::activateManager() {
@@ -42,33 +50,111 @@ void SdlGraphicsManager::deactivateManager() {
 }
 
 void SdlGraphicsManager::setWindowCaption(const Common::String &caption) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	_windowCaption = caption;
+	if (_window) {
+		SDL_SetWindowTitle(_window, caption.c_str());
+	}
+#else
 	SDL_WM_SetCaption(caption.c_str(), caption.c_str());
+#endif
 }
 
 void SdlGraphicsManager::setWindowIcon(SDL_Surface *icon) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_FreeSurface(_windowIcon);
+	_windowIcon = icon;
+	if (_window) {
+		SDL_SetWindowIcon(_window, icon);
+	}
+#else
 	SDL_WM_SetIcon(icon, NULL);
 	SDL_FreeSurface(icon);
+#endif
 }
 
 void SdlGraphicsManager::toggleMouseGrab() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window) {
+		_inputGrabState = !(SDL_GetWindowGrab(_window) == SDL_TRUE);
+		SDL_SetWindowGrab(_window, _inputGrabState ? SDL_TRUE : SDL_FALSE);
+	}
+#else
 	if (SDL_WM_GrabInput(SDL_GRAB_QUERY) == SDL_GRAB_OFF) {
 		SDL_WM_GrabInput(SDL_GRAB_ON);
 	} else {
 		SDL_WM_GrabInput(SDL_GRAB_OFF);
 	}
+#endif
 }
 
 bool SdlGraphicsManager::hasMouseFocus() const {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window) {
+		return (SDL_GetWindowFlags(_window) & SDL_WINDOW_MOUSE_FOCUS);
+	} else {
+		return false;
+	}
+#else
 	return (SDL_GetAppState() & SDL_APPMOUSEFOCUS);
+#endif
 }
 
 void SdlGraphicsManager::warpMouseInWindow(uint x, uint y) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window) {
+		SDL_WarpMouseInWindow(_window, x, y);
+	}
+#else
 	SDL_WarpMouse(x, y);
+#endif
 }
 
 void SdlGraphicsManager::iconifyWindow() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window) {
+		SDL_MinimizeWindow(_window);
+	}
+#else
 	SDL_WM_IconifyWindow();
+#endif
 }
+
+SdlGraphicsManager::State::State()
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    : windowIcon(nullptr)
+#endif
+    {
+}
+
+SdlGraphicsManager::State::~State() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_FreeSurface(windowIcon);
+#endif
+}
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+SDL_Surface *copySDLSurface(SDL_Surface *src) {
+	const bool locked = SDL_MUSTLOCK(src) == SDL_TRUE;
+
+	if (locked) {
+		if (SDL_LockSurface(src) != 0) {
+			return nullptr;
+		}
+	}
+
+	SDL_Surface *res = SDL_CreateRGBSurfaceFrom(src->pixels,
+	                       src->w, src->h, src->format->BitsPerPixel,
+	                       src->pitch, src->format->Rmask, src->format->Gmask,
+	                       src->format->Bmask, src->format->Amask);
+
+	if (locked) {
+		SDL_UnlockSurface(src);
+	}
+
+	return res;
+}
+#endif
 
 SdlGraphicsManager::State SdlGraphicsManager::getState() {
 	State state;
@@ -82,10 +168,29 @@ SdlGraphicsManager::State SdlGraphicsManager::getState() {
 	state.pixelFormat   = getScreenFormat();
 #endif
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	state.inputGrabState = _inputGrabState;
+	state.windowCaption  = _windowCaption;
+	state.windowIcon     = copySDLSurface(_windowIcon);
+#endif
+
 	return state;
 }
 
 bool SdlGraphicsManager::setState(const State &state) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	_inputGrabState = state.inputGrabState;
+	if (!_window) {
+		_windowCaption  = state.windowCaption;
+		SDL_FreeSurface(_windowIcon);
+		_windowIcon     = copySDLSurface(state.windowIcon);
+	} else {
+		SDL_SetWindowGrab(_window, _inputGrabState ? SDL_TRUE : SDL_FALSE);
+		setWindowCaption(state.windowCaption);
+		setWindowIcon(copySDLSurface(state.windowIcon));
+	}
+#endif
+
 	beginGFXTransaction();
 #ifdef USE_RGB_COLOR
 		initSize(state.screenWidth, state.screenHeight, &state.pixelFormat);
@@ -102,3 +207,27 @@ bool SdlGraphicsManager::setState(const State &state) {
 		return true;
 	}
 }
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+bool SdlGraphicsManager::createWindow(int width, int height, uint32 flags) {
+	destroyWindow();
+
+	if (_inputGrabState) {
+		flags |= SDL_WINDOW_INPUT_GRABBED;
+	}
+
+	_window = SDL_CreateWindow(_windowCaption.c_str(), SDL_WINDOWPOS_UNDEFINED,
+	                           SDL_WINDOWPOS_UNDEFINED, width, height, flags);
+	if (!_window) {
+		return false;
+	}
+	SDL_SetWindowIcon(_window, _windowIcon);
+
+	return true;
+}
+
+void SdlGraphicsManager::destroyWindow() {
+	SDL_DestroyWindow(_window);
+	_window = nullptr;
+}
+#endif

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -69,3 +69,36 @@ void SdlGraphicsManager::warpMouseInWindow(uint x, uint y) {
 void SdlGraphicsManager::iconifyWindow() {
 	SDL_WM_IconifyWindow();
 }
+
+SdlGraphicsManager::State SdlGraphicsManager::getState() {
+	State state;
+
+	state.screenWidth   = getWidth();
+	state.screenHeight  = getHeight();
+	state.aspectRatio   = getFeatureState(OSystem::kFeatureAspectRatioCorrection);
+	state.fullscreen    = getFeatureState(OSystem::kFeatureFullscreenMode);
+	state.cursorPalette = getFeatureState(OSystem::kFeatureCursorPalette);
+#ifdef USE_RGB_COLOR
+	state.pixelFormat   = getScreenFormat();
+#endif
+
+	return state;
+}
+
+bool SdlGraphicsManager::setState(const State &state) {
+	beginGFXTransaction();
+#ifdef USE_RGB_COLOR
+		initSize(state.screenWidth, state.screenHeight, &state.pixelFormat);
+#else
+		initSize(state.screenWidth, state.screenHeight, 0);
+#endif
+		setFeatureState(OSystem::kFeatureAspectRatioCorrection, state.aspectRatio);
+		setFeatureState(OSystem::kFeatureFullscreenMode, state.fullscreen);
+		setFeatureState(OSystem::kFeatureCursorPalette, state.cursorPalette);
+
+	if (endGFXTransaction() != OSystem::kTransactionSuccess) {
+		return false;
+	} else {
+		return true;
+	}
+}

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -26,19 +26,11 @@
 #include "backends/events/sdl/sdl-events.h"
 #include "common/textconsole.h"
 
-SdlGraphicsManager::SdlGraphicsManager(SdlEventSource *source)
-	: _eventSource(source)
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	  , _window(nullptr), _inputGrabState(false), _windowCaption("ScummVM"), _windowIcon(nullptr)
-#endif
-	{
+SdlGraphicsManager::SdlGraphicsManager(SdlEventSource *source, SdlWindow *window)
+	: _eventSource(source), _window(window) {
 }
 
 SdlGraphicsManager::~SdlGraphicsManager() {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	SDL_FreeSurface(_windowIcon);
-	destroyWindow();
-#endif
 }
 
 void SdlGraphicsManager::activateManager() {
@@ -48,113 +40,6 @@ void SdlGraphicsManager::activateManager() {
 void SdlGraphicsManager::deactivateManager() {
 	_eventSource->setGraphicsManager(0);
 }
-
-void SdlGraphicsManager::setWindowCaption(const Common::String &caption) {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	_windowCaption = caption;
-	if (_window) {
-		SDL_SetWindowTitle(_window, caption.c_str());
-	}
-#else
-	SDL_WM_SetCaption(caption.c_str(), caption.c_str());
-#endif
-}
-
-void SdlGraphicsManager::setWindowIcon(SDL_Surface *icon) {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	SDL_FreeSurface(_windowIcon);
-	_windowIcon = icon;
-	if (_window) {
-		SDL_SetWindowIcon(_window, icon);
-	}
-#else
-	SDL_WM_SetIcon(icon, NULL);
-	SDL_FreeSurface(icon);
-#endif
-}
-
-void SdlGraphicsManager::toggleMouseGrab() {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	if (_window) {
-		_inputGrabState = !(SDL_GetWindowGrab(_window) == SDL_TRUE);
-		SDL_SetWindowGrab(_window, _inputGrabState ? SDL_TRUE : SDL_FALSE);
-	}
-#else
-	if (SDL_WM_GrabInput(SDL_GRAB_QUERY) == SDL_GRAB_OFF) {
-		SDL_WM_GrabInput(SDL_GRAB_ON);
-	} else {
-		SDL_WM_GrabInput(SDL_GRAB_OFF);
-	}
-#endif
-}
-
-bool SdlGraphicsManager::hasMouseFocus() const {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	if (_window) {
-		return (SDL_GetWindowFlags(_window) & SDL_WINDOW_MOUSE_FOCUS);
-	} else {
-		return false;
-	}
-#else
-	return (SDL_GetAppState() & SDL_APPMOUSEFOCUS);
-#endif
-}
-
-void SdlGraphicsManager::warpMouseInWindow(uint x, uint y) {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	if (_window) {
-		SDL_WarpMouseInWindow(_window, x, y);
-	}
-#else
-	SDL_WarpMouse(x, y);
-#endif
-}
-
-void SdlGraphicsManager::iconifyWindow() {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	if (_window) {
-		SDL_MinimizeWindow(_window);
-	}
-#else
-	SDL_WM_IconifyWindow();
-#endif
-}
-
-SdlGraphicsManager::State::State()
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-    : windowIcon(nullptr)
-#endif
-    {
-}
-
-SdlGraphicsManager::State::~State() {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	SDL_FreeSurface(windowIcon);
-#endif
-}
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-SDL_Surface *copySDLSurface(SDL_Surface *src) {
-	const bool locked = SDL_MUSTLOCK(src) == SDL_TRUE;
-
-	if (locked) {
-		if (SDL_LockSurface(src) != 0) {
-			return nullptr;
-		}
-	}
-
-	SDL_Surface *res = SDL_CreateRGBSurfaceFrom(src->pixels,
-	                       src->w, src->h, src->format->BitsPerPixel,
-	                       src->pitch, src->format->Rmask, src->format->Gmask,
-	                       src->format->Bmask, src->format->Amask);
-
-	if (locked) {
-		SDL_UnlockSurface(src);
-	}
-
-	return res;
-}
-#endif
 
 SdlGraphicsManager::State SdlGraphicsManager::getState() {
 	State state;
@@ -167,30 +52,10 @@ SdlGraphicsManager::State SdlGraphicsManager::getState() {
 #ifdef USE_RGB_COLOR
 	state.pixelFormat   = getScreenFormat();
 #endif
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	state.inputGrabState = _inputGrabState;
-	state.windowCaption  = _windowCaption;
-	state.windowIcon     = copySDLSurface(_windowIcon);
-#endif
-
 	return state;
 }
 
 bool SdlGraphicsManager::setState(const State &state) {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	_inputGrabState = state.inputGrabState;
-	if (!_window) {
-		_windowCaption  = state.windowCaption;
-		SDL_FreeSurface(_windowIcon);
-		_windowIcon     = copySDLSurface(state.windowIcon);
-	} else {
-		SDL_SetWindowGrab(_window, _inputGrabState ? SDL_TRUE : SDL_FALSE);
-		setWindowCaption(state.windowCaption);
-		setWindowIcon(copySDLSurface(state.windowIcon));
-	}
-#endif
-
 	beginGFXTransaction();
 #ifdef USE_RGB_COLOR
 		initSize(state.screenWidth, state.screenHeight, &state.pixelFormat);
@@ -208,26 +73,3 @@ bool SdlGraphicsManager::setState(const State &state) {
 	}
 }
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-bool SdlGraphicsManager::createWindow(int width, int height, uint32 flags) {
-	destroyWindow();
-
-	if (_inputGrabState) {
-		flags |= SDL_WINDOW_INPUT_GRABBED;
-	}
-
-	_window = SDL_CreateWindow(_windowCaption.c_str(), SDL_WINDOWPOS_UNDEFINED,
-	                           SDL_WINDOWPOS_UNDEFINED, width, height, flags);
-	if (!_window) {
-		return false;
-	}
-	SDL_SetWindowIcon(_window, _windowIcon);
-
-	return true;
-}
-
-void SdlGraphicsManager::destroyWindow() {
-	SDL_DestroyWindow(_window);
-	_window = nullptr;
-}
-#endif

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -24,10 +24,9 @@
 #define BACKENDS_GRAPHICS_SDL_SDLGRAPHICS_H
 
 #include "backends/graphics/graphics.h"
+#include "backends/platform/sdl/sdl-window.h"
 
-#include "backends/platform/sdl/sdl-sys.h"
 #include "common/rect.h"
-#include "common/str.h"
 
 class SdlEventSource;
 
@@ -38,7 +37,7 @@ class SdlEventSource;
  */
 class SdlGraphicsManager : virtual public GraphicsManager {
 public:
-	SdlGraphicsManager(SdlEventSource *source);
+	SdlGraphicsManager(SdlEventSource *source, SdlWindow *window);
 	virtual ~SdlGraphicsManager();
 
 	/**
@@ -94,49 +93,10 @@ public:
 	virtual void notifyMousePos(Common::Point mouse) = 0;
 
 	/**
-	 * Change the caption of the window.
-	 *
-	 * @param caption New window caption in UTF-8 encoding.
-	 */
-	void setWindowCaption(const Common::String &caption);
-
-	/**
-	 * Attach an icon to the window.
-	 *
-	 * @param icon The surface to use as icon. SdlGraphicsManager takes
-	 *             ownership over it.
-	 */
-	void setWindowIcon(SDL_Surface *icon);
-
-	/**
-	 * Toggle mouse grab state. This decides whether the cursor can leave the
-	 * window or not.
-	 */
-	void toggleMouseGrab();
-
-	/**
-	 * Check whether the application has mouse focus.
-	 */
-	bool hasMouseFocus() const;
-
-	/**
-	 * Warp the mouse to the specified position in window coordinates.
-	 */
-	void warpMouseInWindow(uint x, uint y);
-
-	/**
-	 * Iconifies the window.
-	 */
-	void iconifyWindow();
-
-	/**
 	 * A (subset) of the graphic manager's state. This is used when switching
 	 * between different SDL graphic managers on runtime.
 	 */
 	struct State {
-		State();
-		~State();
-
 		int screenWidth, screenHeight;
 		bool aspectRatio;
 		bool fullscreen;
@@ -144,12 +104,6 @@ public:
 
 #ifdef USE_RGB_COLOR
 		Graphics::PixelFormat pixelFormat;
-#endif
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-		bool inputGrabState;
-		Common::String windowCaption;
-		SDL_Surface *windowIcon;
 #endif
 	};
 
@@ -163,19 +117,14 @@ public:
 	 */
 	bool setState(const State &state);
 
+	/**
+	 * Queries the SDL window.
+	 */
+	SdlWindow *getWindow() const { return _window; }
+
 protected:
 	SdlEventSource *_eventSource;
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	SDL_Window *_window;
-
-	bool createWindow(int width, int height, uint32 flags);
-	void destroyWindow();
-private:
-	bool _inputGrabState;
-	Common::String _windowCaption;
-	SDL_Surface *_windowIcon;
-#endif
+	SdlWindow *_window;
 };
 
 #endif

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -25,7 +25,9 @@
 
 #include "backends/graphics/graphics.h"
 
+#include "backends/platform/sdl/sdl-sys.h"
 #include "common/rect.h"
+#include "common/str.h"
 
 class SdlEventSource;
 
@@ -90,6 +92,42 @@ public:
 	 * @param mouse Mouse position.
 	 */
 	virtual void notifyMousePos(Common::Point mouse) = 0;
+
+	/**
+	 * Change the caption of the window.
+	 *
+	 * @param caption New window caption in UTF-8 encoding.
+	 */
+	void setWindowCaption(const Common::String &caption);
+
+	/**
+	 * Attach an icon to the window.
+	 *
+	 * @param icon The surface to use as icon. SdlGraphicsManager takes
+	 *             ownership over it.
+	 */
+	void setWindowIcon(SDL_Surface *icon);
+
+	/**
+	 * Toggle mouse grab state. This decides whether the cursor can leave the
+	 * window or not.
+	 */
+	void toggleMouseGrab();
+
+	/**
+	 * Check whether the application has mouse focus.
+	 */
+	bool hasMouseFocus() const;
+
+	/**
+	 * Warp the mouse to the specified position in window coordinates.
+	 */
+	void warpMouseInWindow(uint x, uint y);
+
+	/**
+	 * Iconifies the window.
+	 */
+	void iconifyWindow();
 
 protected:
 	SdlEventSource *_eventSource;

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -129,6 +129,31 @@ public:
 	 */
 	void iconifyWindow();
 
+	/**
+	 * A (subset) of the graphic manager's state. This is used when switching
+	 * between different SDL graphic managers on runtime.
+	 */
+	struct State {
+		int screenWidth, screenHeight;
+		bool aspectRatio;
+		bool fullscreen;
+		bool cursorPalette;
+
+#ifdef USE_RGB_COLOR
+		Graphics::PixelFormat pixelFormat;
+#endif
+	};
+
+	/**
+	 * Queries the current state of the graphic manager.
+	 */
+	State getState();
+
+	/**
+	 * Setup a basic state of the graphic manager.
+	 */
+	bool setState(const State &state);
+
 protected:
 	SdlEventSource *_eventSource;
 };

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -134,6 +134,9 @@ public:
 	 * between different SDL graphic managers on runtime.
 	 */
 	struct State {
+		State();
+		~State();
+
 		int screenWidth, screenHeight;
 		bool aspectRatio;
 		bool fullscreen;
@@ -141,6 +144,12 @@ public:
 
 #ifdef USE_RGB_COLOR
 		Graphics::PixelFormat pixelFormat;
+#endif
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		bool inputGrabState;
+		Common::String windowCaption;
+		SDL_Surface *windowIcon;
 #endif
 	};
 
@@ -156,6 +165,17 @@ public:
 
 protected:
 	SdlEventSource *_eventSource;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_Window *_window;
+
+	bool createWindow(int width, int height, uint32 flags);
+	void destroyWindow();
+private:
+	bool _inputGrabState;
+	Common::String _windowCaption;
+	SDL_Surface *_windowIcon;
+#endif
 };
 
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -235,7 +235,7 @@ void SurfaceSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable)
 		break;
 	case OSystem::kFeatureIconifyWindow:
 		if (enable)
-			SDL_WM_IconifyWindow();
+			iconifyWindow();
 		break;
 	default:
 		break;
@@ -1710,7 +1710,7 @@ void SurfaceSdlGraphicsManager::warpMouse(int x, int y) {
 	int y1 = y;
 
 	// Don't change actual mouse position, when mouse is outside of our window (in case of windowed mode)
-	if (!(SDL_GetAppState( ) & SDL_APPMOUSEFOCUS)) {
+	if (!hasMouseFocus()) {
 		setMousePos(x, y); // but change game cursor position
 		return;
 	}
@@ -1720,9 +1720,9 @@ void SurfaceSdlGraphicsManager::warpMouse(int x, int y) {
 
 	if (_mouseCurState.x != x || _mouseCurState.y != y) {
 		if (!_overlayVisible)
-			SDL_WarpMouse(x * _videoMode.scaleFactor, y1 * _videoMode.scaleFactor);
+			warpMouseInWindow(x * _videoMode.scaleFactor, y1 * _videoMode.scaleFactor);
 		else
-			SDL_WarpMouse(x, y1);
+			warpMouseInWindow(x, y1);
 
 		// SDL_WarpMouse() generates a mouse movement event, so
 		// setMousePos() would be called eventually. However, the

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -116,9 +116,9 @@ static AspectRatio getDesiredAspectRatio() {
 }
 #endif
 
-SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource)
+SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
 	:
-	SdlGraphicsManager(sdlEventSource),
+	SdlGraphicsManager(sdlEventSource, window),
 #ifdef USE_OSD
 	_osdSurface(0), _osdAlpha(SDL_ALPHA_TRANSPARENT), _osdFadeStartTime(0),
 #endif
@@ -239,7 +239,7 @@ void SurfaceSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable)
 		break;
 	case OSystem::kFeatureIconifyWindow:
 		if (enable)
-			iconifyWindow();
+			_window->iconifyWindow();
 		break;
 	default:
 		break;
@@ -1742,7 +1742,7 @@ void SurfaceSdlGraphicsManager::warpMouse(int x, int y) {
 	int y1 = y;
 
 	// Don't change actual mouse position, when mouse is outside of our window (in case of windowed mode)
-	if (!hasMouseFocus()) {
+	if (!_window->hasMouseFocus()) {
 		setMousePos(x, y); // but change game cursor position
 		return;
 	}
@@ -1752,9 +1752,9 @@ void SurfaceSdlGraphicsManager::warpMouse(int x, int y) {
 
 	if (_mouseCurState.x != x || _mouseCurState.y != y) {
 		if (!_overlayVisible)
-			warpMouseInWindow(x * _videoMode.scaleFactor, y1 * _videoMode.scaleFactor);
+			_window->warpMouseInWindow(x * _videoMode.scaleFactor, y1 * _videoMode.scaleFactor);
 		else
-			warpMouseInWindow(x, y1);
+			_window->warpMouseInWindow(x, y1);
 
 		// SDL_WarpMouse() generates a mouse movement event, so
 		// setMousePos() would be called eventually. However, the
@@ -2357,17 +2357,17 @@ void SurfaceSdlGraphicsManager::deinitializeRenderer() {
 	SDL_DestroyRenderer(_renderer);
 	_renderer = nullptr;
 
-	destroyWindow();
+	_window->destroyWindow();
 }
 
 SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags) {
 	deinitializeRenderer();
 
-	if (!createWindow(width, height, (flags & SDL_FULLSCREEN) ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0)) {
+	if (!_window->createWindow(width, height, (flags & SDL_FULLSCREEN) ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0)) {
 		return nullptr;
 	}
 
-	_renderer = SDL_CreateRenderer(_window, -1, 0);
+	_renderer = SDL_CreateRenderer(_window->getSDLWindow(), -1, 0);
 	if (!_renderer) {
 		deinitializeRenderer();
 		return nullptr;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -77,7 +77,7 @@ public:
  */
 class SurfaceSdlGraphicsManager : public SdlGraphicsManager, public Common::EventObserver {
 public:
-	SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource);
+	SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 	virtual ~SurfaceSdlGraphicsManager();
 
 	virtual void activateManager();

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -166,6 +166,17 @@ protected:
 	/** Hardware screen */
 	SDL_Surface *_hwscreen;
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	/* SDL2 features a different API for 2D graphics. We create a wrapper
+	 * around this API to keep the code paths as close as possible. */
+	SDL_Renderer *_renderer;
+	SDL_Texture *_screenTexture;
+	void deinitializeRenderer();
+
+	SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags);
+	void SDL_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects);
+#endif
+
 	/** Unseen game screen */
 	SDL_Surface *_screen;
 #ifdef USE_RGB_COLOR

--- a/backends/graphics/symbiansdl/symbiansdl-graphics.cpp
+++ b/backends/graphics/symbiansdl/symbiansdl-graphics.cpp
@@ -27,8 +27,8 @@
 #include "backends/graphics/symbiansdl/symbiansdl-graphics.h"
 #include "backends/platform/symbian/src/SymbianActions.h"
 
-SymbianSdlGraphicsManager::SymbianSdlGraphicsManager(SdlEventSource *sdlEventSource)
-	: SurfaceSdlGraphicsManager(sdlEventSource) {
+SymbianSdlGraphicsManager::SymbianSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
+	: SurfaceSdlGraphicsManager(sdlEventSource, window) {
 }
 
 int SymbianSdlGraphicsManager::getDefaultGraphicsMode() const {

--- a/backends/graphics/symbiansdl/symbiansdl-graphics.h
+++ b/backends/graphics/symbiansdl/symbiansdl-graphics.h
@@ -27,7 +27,7 @@
 
 class SymbianSdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
-	SymbianSdlGraphicsManager(SdlEventSource *sdlEventSource);
+	SymbianSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
 public:
 	virtual bool hasFeature(OSystem::Feature f);

--- a/backends/graphics/wincesdl/wincesdl-graphics.cpp
+++ b/backends/graphics/wincesdl/wincesdl-graphics.cpp
@@ -42,8 +42,8 @@
 #include "backends/platform/wince/CEScaler.h"
 #include "backends/platform/wince/CEgui/ItemAction.h"
 
-WINCESdlGraphicsManager::WINCESdlGraphicsManager(SdlEventSource *sdlEventSource)
-	: SurfaceSdlGraphicsManager(sdlEventSource),
+WINCESdlGraphicsManager::WINCESdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
+	: SurfaceSdlGraphicsManager(sdlEventSource, window),
 	  _panelInitialized(false), _noDoubleTapRMB(false), _noDoubleTapPT(false),
 	  _toolbarHighDrawn(false), _newOrientation(0), _orientationLandscape(0),
 	  _panelVisible(true), _saveActiveToolbar(NAME_MAIN_PANEL), _panelStateForced(false),

--- a/backends/graphics/wincesdl/wincesdl-graphics.h
+++ b/backends/graphics/wincesdl/wincesdl-graphics.h
@@ -41,7 +41,7 @@ extern bool _hasSmartphoneResolution;
 
 class WINCESdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
-	WINCESdlGraphicsManager(SdlEventSource *sdlEventSource);
+	WINCESdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
 	const OSystem::GraphicsMode *getSupportedGraphicsModes() const;
 	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL);

--- a/backends/mixer/sdl/sdl-mixer.cpp
+++ b/backends/mixer/sdl/sdl-mixer.cpp
@@ -57,11 +57,13 @@ void SdlMixerManager::init() {
 		error("Could not initialize SDL: %s", SDL_GetError());
 	}
 
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
 	const int maxNameLen = 20;
 	char sdlDriverName[maxNameLen];
 	sdlDriverName[0] = '\0';
 	SDL_AudioDriverName(sdlDriverName, maxNameLen);
 	debug(1, "Using SDL Audio Driver \"%s\"", sdlDriverName);
+#endif
 
 	// Get the desired audio specs
 	SDL_AudioSpec desired = getAudioSpec(SAMPLES_PER_SEC);

--- a/backends/mixer/sdl/sdl-mixer.cpp
+++ b/backends/mixer/sdl/sdl-mixer.cpp
@@ -57,13 +57,15 @@ void SdlMixerManager::init() {
 		error("Could not initialize SDL: %s", SDL_GetError());
 	}
 
-#if !SDL_VERSION_ATLEAST(2, 0, 0)
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	const char *sdlDriverName = SDL_GetCurrentAudioDriver();
+#else
 	const int maxNameLen = 20;
 	char sdlDriverName[maxNameLen];
 	sdlDriverName[0] = '\0';
 	SDL_AudioDriverName(sdlDriverName, maxNameLen);
-	debug(1, "Using SDL Audio Driver \"%s\"", sdlDriverName);
 #endif
+	debug(1, "Using SDL Audio Driver \"%s\"", sdlDriverName);
 
 	// Get the desired audio specs
 	SDL_AudioSpec desired = getAudioSpec(SAMPLES_PER_SEC);

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -74,8 +74,10 @@ MODULE_OBJS += \
 
 # SDL 1.3 removed audio CD support
 ifndef USE_SDL13
+ifndef USE_SDL2
 MODULE_OBJS += \
 	audiocd/sdl/sdl-audiocd.o
+endif
 endif
 
 ifdef USE_OPENGL

--- a/backends/platform/dingux/dingux.cpp
+++ b/backends/platform/dingux/dingux.cpp
@@ -33,7 +33,7 @@ void OSystem_SDL_Dingux::initBackend() {
 
 	// Create the graphics manager
 	if (_graphicsManager == 0) {
-		_graphicsManager = new DINGUXSdlGraphicsManager(_eventSource);
+		_graphicsManager = new DINGUXSdlGraphicsManager(_eventSource, _window);
 	}
 
 	// Call parent implementation of this method

--- a/backends/platform/gph/gph-backend.cpp
+++ b/backends/platform/gph/gph-backend.cpp
@@ -159,7 +159,7 @@ void OSystem_GPH::initBackend() {
 
 	// Create the graphics manager
 	if (_graphicsManager == 0) {
-		_graphicsManager = new GPHGraphicsManager(_eventSource);
+		_graphicsManager = new GPHGraphicsManager(_eventSource, _window);
 	}
 
 	/* Pass to POSIX method to do the heavy lifting */

--- a/backends/platform/linuxmoto/linuxmoto-sdl.cpp
+++ b/backends/platform/linuxmoto/linuxmoto-sdl.cpp
@@ -31,7 +31,7 @@ void OSystem_LINUXMOTO::initBackend() {
 		_eventSource = new LinuxmotoSdlEventSource();
 
 	if (_graphicsManager == 0)
-		_graphicsManager = new LinuxmotoSdlGraphicsManager(_eventSource);
+		_graphicsManager = new LinuxmotoSdlGraphicsManager(_eventSource, _window);
 
 	// Call parent implementation of this method
 	OSystem_POSIX::initBackend();

--- a/backends/platform/maemo/maemo.cpp
+++ b/backends/platform/maemo/maemo.cpp
@@ -93,7 +93,7 @@ void OSystem_SDL_Maemo::initBackend() {
 		_eventSource = new MaemoSdlEventSource();
 
 	if (_graphicsManager == 0)
-		_graphicsManager = new MaemoSdlGraphicsManager(_eventSource);
+		_graphicsManager = new MaemoSdlGraphicsManager(_eventSource, _window);
 
 	if (_eventObserver == 0)
 		_eventObserver = new MaemoSdlEventObserver((MaemoSdlEventSource *)_eventSource);

--- a/backends/platform/maemo/maemo.cpp
+++ b/backends/platform/maemo/maemo.cpp
@@ -84,6 +84,15 @@ static void registerDefaultKeyBindings(Common::KeymapperDefaultBindings *_keymap
 }
 #endif
 
+void OSystem_SDL_Maemo::init() {
+	// Use an iconless window for Maemo
+	// also N900 is hit by SDL_WM_SetIcon bug (window cannot receive input)
+	// http://bugzilla.libsdl.org/show_bug.cgi?id=586
+	_window = new SdlIconlessWindow();
+
+	OSystem_POSIX::init();
+}
+
 void OSystem_SDL_Maemo::initBackend() {
 	ConfMan.registerDefault("fullscreen", true);
 	ConfMan.registerDefault("aspect_ratio", true);
@@ -176,12 +185,6 @@ const Maemo::Model OSystem_SDL_Maemo::detectModel() {
 			return *model;
 	}
 	return *model;
-}
-
-void OSystem_SDL_Maemo::setupIcon() {
-	// no Maemo version needs setupIcon
-	// also N900 is hit by SDL_WM_SetIcon bug (window cannot receive input)
-	// http://bugzilla.libsdl.org/show_bug.cgi?id=586
 }
 
 #ifdef ENABLE_KEYMAPPER

--- a/backends/platform/maemo/maemo.h
+++ b/backends/platform/maemo/maemo.h
@@ -36,11 +36,11 @@ public:
 	OSystem_SDL_Maemo();
 	~OSystem_SDL_Maemo();
 
+	virtual void init();
 	virtual void initBackend();
 	virtual void quit();
 	virtual void fatalError();
 	virtual void setWindowCaption(const char *caption);
-	virtual void setupIcon();
 #ifdef ENABLE_KEYMAPPER
 	virtual Common::HardwareInputSet *getHardwareInputSet();
 	virtual Common::Keymap *getGlobalKeymap();

--- a/backends/platform/openpandora/op-backend.cpp
+++ b/backends/platform/openpandora/op-backend.cpp
@@ -147,7 +147,7 @@ void OSystem_OP::initBackend() {
 
 	// Create the graphics manager
 	if (_graphicsManager == 0) {
-		_graphicsManager = new OPGraphicsManager(_eventSource);
+		_graphicsManager = new OPGraphicsManager(_eventSource, _window);
 	}
 
 	/* Pass to POSIX method to do the heavy lifting */

--- a/backends/platform/samsungtv/samsungtv.cpp
+++ b/backends/platform/samsungtv/samsungtv.cpp
@@ -40,7 +40,7 @@ void OSystem_SDL_SamsungTV::initBackend() {
 		_eventSource = new SamsungTVSdlEventSource();
 
 	if (_graphicsManager == 0)
-		_graphicsManager = new SamsungTVSdlGraphicsManager(_eventSource);
+		_graphicsManager = new SamsungTVSdlGraphicsManager(_eventSource, _window);
 
 	// Call parent implementation of this method
 	OSystem_POSIX::initBackend();

--- a/backends/platform/sdl/macosx/macosx.cpp
+++ b/backends/platform/sdl/macosx/macosx.cpp
@@ -47,6 +47,9 @@ OSystem_MacOSX::OSystem_MacOSX()
 }
 
 void OSystem_MacOSX::init() {
+	// Use an iconless window on OS X, as we use a nicer external icon there.
+	_window = new SdlIconlessWindow();
+
 #if defined(USE_TASKBAR)
 	// Initialize taskbar manager
 	_taskbarManager = new MacOSXTaskbarManager();
@@ -101,8 +104,6 @@ void OSystem_MacOSX::addSysArchivesToSearchSet(Common::SearchSet &s, int priorit
 	}
 }
 
-void OSystem_MacOSX::setupIcon() {
-	// Don't set icon on OS X, as we use a nicer external icon there.
 }
 
 bool OSystem_MacOSX::hasFeature(Feature f) {

--- a/backends/platform/sdl/macosx/macosx.h
+++ b/backends/platform/sdl/macosx/macosx.h
@@ -38,7 +38,6 @@ public:
 	virtual void init();
 	virtual void initBackend();
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0);
-	virtual void setupIcon();
 };
 
 #endif

--- a/backends/platform/sdl/module.mk
+++ b/backends/platform/sdl/module.mk
@@ -1,7 +1,8 @@
 MODULE := backends/platform/sdl
 
 MODULE_OBJS := \
-	sdl.o
+	sdl.o \
+	sdl-window.o
 
 ifdef POSIX
 MODULE_OBJS += \

--- a/backends/platform/sdl/module.mk
+++ b/backends/platform/sdl/module.mk
@@ -20,6 +20,7 @@ endif
 ifdef WIN32
 MODULE_OBJS += \
 	win32/win32-main.o \
+	win32/win32-window.o \
 	win32/win32.o
 endif
 

--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -52,10 +52,47 @@ typedef struct { int FAKE; } FAKE_FILE;
 #define strncasecmp FAKE_strncasecmp
 #endif
 
+// HACK: SDL might include windows.h which defines its own ARRAYSIZE.
+// However, we want to use the version from common/util.h. Thus, we make sure
+// that we actually have this definition after including the SDL headers.
+#if defined(ARRAYSIZE) && defined(COMMON_UTIL_H)
+#define HACK_REDEFINE_ARRAYSIZE
+#undef ARRAYSIZE
+#endif
+
 #if defined(__SYMBIAN32__)
 #include <esdl\SDL.h>
 #else
 #include <SDL.h>
+#endif
+
+#include <SDL_syswm.h>
+// SDL_syswm.h will include windows.h on Win32. We need to undefine its
+// ARRAYSIZE definition because we supply our own.
+#undef ARRAYSIZE
+
+#ifdef HACK_REDEFINE_ARRAYSIZE
+#undef HACK_REDEFINE_ARRAYSIZE
+#define ARRAYSIZE(x) ((int)(sizeof(x) / sizeof(x[0])))
+#endif
+
+// In a moment of brilliance Xlib.h included by SDL_syswm.h #defines the
+// following names. In a moment of mental breakdown, which occured upon
+// gazing at Xlib.h, LordHoto decided to undefine them to prevent havoc.
+#ifdef Status
+#undef Status
+#endif
+
+#ifdef Bool
+#undef Bool
+#endif
+
+#ifdef True
+#undef True
+#endif
+
+#ifdef False
+#undef False
 #endif
 
 // Finally forbid FILE again (if it was forbidden to start with)

--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -110,7 +110,7 @@ typedef struct { int FAKE; } FAKE_FILE;
 #define SDL_SRCALPHA    0
 #define SDL_FULLSCREEN  0x40000000
 
-// Compatability implementations for removed functionality.
+// Compatibility implementations for removed functionality.
 int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
 int SDL_SetAlpha(SDL_Surface *surface, Uint32 flag, Uint8 alpha);
 

--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -74,5 +74,50 @@ typedef struct { int FAKE; } FAKE_FILE;
 #define strncasecmp    FORBIDDEN_SYMBOL_REPLACEMENT
 #endif
 
+// SDL 2 has major API changes. We redefine constants which got renamed to
+// ease the transition. This is sometimes dangerous because the values changed
+// too!
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+
+// Type names which changed between SDL 1.2 and SDL 2.
+#define SDLKey     SDL_Keycode
+#define SDLMod     SDL_Keymod
+#define SDL_keysym SDL_Keysym
+
+// Key code constants which got renamed.
+#define SDLK_SCROLLOCK SDLK_SCROLLLOCK
+#define SDLK_NUMLOCK   SDLK_NUMLOCKCLEAR
+#define SDLK_LSUPER    SDLK_LGUI
+#define SDLK_RSUPER    SDLK_RGUI
+#define SDLK_PRINT     SDLK_PRINTSCREEN
+#define SDLK_COMPOSE   SDLK_APPLICATION
+#define SDLK_KP0       SDLK_KP_0
+#define SDLK_KP1       SDLK_KP_1
+#define SDLK_KP2       SDLK_KP_2
+#define SDLK_KP3       SDLK_KP_3
+#define SDLK_KP4       SDLK_KP_4
+#define SDLK_KP5       SDLK_KP_5
+#define SDLK_KP6       SDLK_KP_6
+#define SDLK_KP7       SDLK_KP_7
+#define SDLK_KP8       SDLK_KP_8
+#define SDLK_KP9       SDLK_KP_9
+
+// Meta key constants which got renamed.
+#define KMOD_META KMOD_GUI
+
+// SDL surface flags which got removed.
+#define SDL_SRCCOLORKEY 0
+#define SDL_SRCALPHA    0
+#define SDL_FULLSCREEN  0x40000000
+
+// Compatability implementations for removed functionality.
+int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
+int SDL_SetAlpha(SDL_Surface *surface, Uint32 flag, Uint8 alpha);
+
+#define SDL_SetColorKey SDL_SetColorKey_replacement
+int SDL_SetColorKey_replacement(SDL_Surface *surface, Uint32 flag, Uint32 key);
+
+#endif
+
 
 #endif

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -28,8 +28,6 @@
 
 #include "icons/scummvm.xpm"
 
-#include <SDL_syswm.h>
-
 SdlWindow::SdlWindow()
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	: _window(nullptr), _inputGrabState(false), _windowCaption("ScummVM"), _windowIcon(nullptr)

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -1,0 +1,155 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
+#include "backends/platform/sdl/sdl-window.h"
+
+SdlWindow::SdlWindow()
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	: _window(nullptr), _inputGrabState(false), _windowCaption("ScummVM"), _windowIcon(nullptr)
+#endif
+	{
+}
+
+SdlWindow::~SdlWindow() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_FreeSurface(_windowIcon);
+	destroyWindow();
+#endif
+}
+
+void SdlWindow::setWindowCaption(const Common::String &caption) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	_windowCaption = caption;
+	if (_window) {
+		SDL_SetWindowTitle(_window, caption.c_str());
+	}
+#else
+	SDL_WM_SetCaption(caption.c_str(), caption.c_str());
+#endif
+}
+
+void SdlWindow::setWindowIcon(SDL_Surface *icon) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_FreeSurface(_windowIcon);
+	_windowIcon = icon;
+	if (_window) {
+		SDL_SetWindowIcon(_window, icon);
+	}
+#else
+	SDL_WM_SetIcon(icon, NULL);
+	SDL_FreeSurface(icon);
+#endif
+}
+
+void SdlWindow::toggleMouseGrab() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window) {
+		_inputGrabState = !(SDL_GetWindowGrab(_window) == SDL_TRUE);
+		SDL_SetWindowGrab(_window, _inputGrabState ? SDL_TRUE : SDL_FALSE);
+	}
+#else
+	if (SDL_WM_GrabInput(SDL_GRAB_QUERY) == SDL_GRAB_OFF) {
+		SDL_WM_GrabInput(SDL_GRAB_ON);
+	} else {
+		SDL_WM_GrabInput(SDL_GRAB_OFF);
+	}
+#endif
+}
+
+bool SdlWindow::hasMouseFocus() const {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window) {
+		return (SDL_GetWindowFlags(_window) & SDL_WINDOW_MOUSE_FOCUS);
+	} else {
+		return false;
+	}
+#else
+	return (SDL_GetAppState() & SDL_APPMOUSEFOCUS);
+#endif
+}
+
+void SdlWindow::warpMouseInWindow(uint x, uint y) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window) {
+		SDL_WarpMouseInWindow(_window, x, y);
+	}
+#else
+	SDL_WarpMouse(x, y);
+#endif
+}
+
+void SdlWindow::iconifyWindow() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window) {
+		SDL_MinimizeWindow(_window);
+	}
+#else
+	SDL_WM_IconifyWindow();
+#endif
+}
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+SDL_Surface *copySDLSurface(SDL_Surface *src) {
+	const bool locked = SDL_MUSTLOCK(src) == SDL_TRUE;
+
+	if (locked) {
+		if (SDL_LockSurface(src) != 0) {
+			return nullptr;
+		}
+	}
+
+	SDL_Surface *res = SDL_CreateRGBSurfaceFrom(src->pixels,
+	                       src->w, src->h, src->format->BitsPerPixel,
+	                       src->pitch, src->format->Rmask, src->format->Gmask,
+	                       src->format->Bmask, src->format->Amask);
+
+	if (locked) {
+		SDL_UnlockSurface(src);
+	}
+
+	return res;
+}
+
+bool SdlWindow::createWindow(int width, int height, uint32 flags) {
+	destroyWindow();
+
+	if (_inputGrabState) {
+		flags |= SDL_WINDOW_INPUT_GRABBED;
+	}
+
+	_window = SDL_CreateWindow(_windowCaption.c_str(), SDL_WINDOWPOS_UNDEFINED,
+	                           SDL_WINDOWPOS_UNDEFINED, width, height, flags);
+	if (!_window) {
+		return false;
+	}
+	SDL_SetWindowIcon(_window, _windowIcon);
+
+	return true;
+}
+
+void SdlWindow::destroyWindow() {
+	SDL_DestroyWindow(_window);
+	_window = nullptr;
+}
+#endif

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -28,6 +28,8 @@
 
 #include "icons/scummvm.xpm"
 
+#include <SDL_syswm.h>
+
 SdlWindow::SdlWindow()
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	: _window(nullptr), _inputGrabState(false), _windowCaption("ScummVM"), _windowIcon(nullptr)
@@ -168,6 +170,15 @@ void SdlWindow::iconifyWindow() {
 	}
 #else
 	SDL_WM_IconifyWindow();
+#endif
+}
+
+bool SdlWindow::getSDLWMInformation(SDL_SysWMinfo *info) const {
+	SDL_VERSION(&info->version);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	return SDL_GetWindowWMInfo(_window, info);
+#else
+	return SDL_GetWMInfo(info);
 #endif
 }
 

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -30,14 +30,13 @@
 
 SdlWindow::SdlWindow()
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	: _window(nullptr), _inputGrabState(false), _windowCaption("ScummVM"), _windowIcon(nullptr)
+	: _window(nullptr), _inputGrabState(false), _windowCaption("ScummVM")
 #endif
 	{
 }
 
 SdlWindow::~SdlWindow() {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	SDL_FreeSurface(_windowIcon);
 	destroyWindow();
 #endif
 }
@@ -100,16 +99,14 @@ void SdlWindow::setupIcon() {
 	}
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	SDL_FreeSurface(_windowIcon);
-	_windowIcon = sdl_surf;
 	if (_window) {
 		SDL_SetWindowIcon(_window, sdl_surf);
 	}
 #else
 	SDL_WM_SetIcon(sdl_surf, NULL);
-	SDL_FreeSurface(sdl_surf);
 #endif
 
+	SDL_FreeSurface(sdl_surf);
 	free(icon);
 }
 
@@ -214,7 +211,7 @@ bool SdlWindow::createWindow(int width, int height, uint32 flags) {
 	if (!_window) {
 		return false;
 	}
-	SDL_SetWindowIcon(_window, _windowIcon);
+	setupIcon();
 
 	return true;
 }

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -101,7 +101,6 @@ protected:
 private:
 	bool _inputGrabState;
 	Common::String _windowCaption;
-	SDL_Surface *_windowIcon;
 #endif
 };
 

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -27,8 +27,6 @@
 
 #include "common/str.h"
 
-struct SDL_SysWMinfo;
-
 class SdlWindow {
 public:
 	SdlWindow();

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -27,6 +27,8 @@
 
 #include "common/str.h"
 
+struct SDL_SysWMinfo;
+
 class SdlWindow {
 public:
 	SdlWindow();
@@ -64,6 +66,14 @@ public:
 	 * Iconifies the window.
 	 */
 	void iconifyWindow();
+
+	/**
+	 * Query platform specific SDL window manager information.
+	 *
+	 * Since this is an SDL internal structure clients are responsible
+	 * for accessing it in a version safe manner.
+	 */
+	bool getSDLWMInformation(SDL_SysWMinfo *info) const;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 public:

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -1,0 +1,103 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKENDS_PLATFORM_SDL_WINDOW_H
+#define BACKENDS_PLATFORM_SDL_WINDOW_H
+
+#include "backends/platform/sdl/sdl-sys.h"
+
+#include "common/str.h"
+
+class SdlWindow {
+public:
+	SdlWindow();
+	virtual ~SdlWindow();
+
+	/**
+	 * Change the caption of the window.
+	 *
+	 * @param caption New window caption in UTF-8 encoding.
+	 */
+	void setWindowCaption(const Common::String &caption);
+
+	/**
+	 * Attach an icon to the window.
+	 *
+	 * @param icon The surface to use as icon. SdlGraphicsManager takes
+	 *             ownership over it.
+	 */
+	void setWindowIcon(SDL_Surface *icon);
+
+	/**
+	 * Toggle mouse grab state. This decides whether the cursor can leave the
+	 * window or not.
+	 */
+	void toggleMouseGrab();
+
+	/**
+	 * Check whether the application has mouse focus.
+	 */
+	bool hasMouseFocus() const;
+
+	/**
+	 * Warp the mouse to the specified position in window coordinates.
+	 */
+	void warpMouseInWindow(uint x, uint y);
+
+	/**
+	 * Iconifies the window.
+	 */
+	void iconifyWindow();
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+public:
+	/**
+	 * @return The window ScummVM has setup with SDL.
+	 */
+	SDL_Window *getSDLWindow() const { return _window; }
+
+	/**
+	 * Creates a new SDL window (and destroies the old one).
+	 *
+	 * @param width   Width of the window.
+	 * @param height  Height of the window.
+	 * @param flags   SDL flags passed to SDL_CreateWindow
+	 * @return true on success, false otherwise
+	 */
+	bool createWindow(int width, int height, uint32 flags);
+
+	/**
+	 * Destroies the current SDL window.
+	 */
+	void destroyWindow();
+
+protected:
+	SDL_Window *_window;
+
+private:
+	bool _inputGrabState;
+	Common::String _windowCaption;
+	SDL_Surface *_windowIcon;
+#endif
+};
+
+#endif

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -33,19 +33,16 @@ public:
 	virtual ~SdlWindow();
 
 	/**
+	 * Setup the window icon.
+	 */
+	virtual void setupIcon();
+
+	/**
 	 * Change the caption of the window.
 	 *
 	 * @param caption New window caption in UTF-8 encoding.
 	 */
 	void setWindowCaption(const Common::String &caption);
-
-	/**
-	 * Attach an icon to the window.
-	 *
-	 * @param icon The surface to use as icon. SdlGraphicsManager takes
-	 *             ownership over it.
-	 */
-	void setWindowIcon(SDL_Surface *icon);
 
 	/**
 	 * Toggle mouse grab state. This decides whether the cursor can leave the
@@ -98,6 +95,11 @@ private:
 	Common::String _windowCaption;
 	SDL_Surface *_windowIcon;
 #endif
+};
+
+class SdlIconlessWindow : public SdlWindow {
+public:
+	virtual void setupIcon() {}
 };
 
 #endif

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -314,7 +314,7 @@ void OSystem_SDL::setWindowCaption(const char *caption) {
 		}
 	}
 
-	SDL_WM_SetCaption(cap.c_str(), cap.c_str());
+	dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->setWindowCaption(cap);
 }
 
 void OSystem_SDL::quit() {
@@ -477,8 +477,7 @@ void OSystem_SDL::setupIcon() {
 	if (!sdl_surf) {
 		warning("SDL_CreateRGBSurfaceFrom(icon) failed");
 	}
-	SDL_WM_SetIcon(sdl_surf, NULL);
-	SDL_FreeSurface(sdl_surf);
+	dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->setWindowIcon(sdl_surf);
 	free(icon);
 }
 

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -52,8 +52,6 @@
 #include "graphics/cursorman.h"
 #endif
 
-#include "icons/scummvm.xpm"
-
 #include <time.h>	// for getTimeAndDate()
 
 #ifdef USE_DETECTLANG
@@ -258,7 +256,7 @@ void OSystem_SDL::initBackend() {
 	}
 
 	// Setup a custom program icon.
-	setupIcon();
+	_window->setupIcon();
 
 	_inited = true;
 
@@ -440,67 +438,6 @@ Common::String OSystem_SDL::getSystemLanguage() const {
 	return ModularBackend::getSystemLanguage();
 #endif // USE_DETECTLANG
 }
-
-void OSystem_SDL::setupIcon() {
-	int x, y, w, h, ncols, nbytes, i;
-	unsigned int rgba[256];
-	unsigned int *icon;
-
-	if (sscanf(scummvm_icon[0], "%d %d %d %d", &w, &h, &ncols, &nbytes) != 4) {
-		warning("Wrong format of scummvm_icon[0] (%s)", scummvm_icon[0]);
-
-		return;
-	}
-	if ((w > 512) || (h > 512) || (ncols > 255) || (nbytes > 1)) {
-		warning("Could not load the built-in icon (%d %d %d %d)", w, h, ncols, nbytes);
-		return;
-	}
-	icon = (unsigned int*)malloc(w*h*sizeof(unsigned int));
-	if (!icon) {
-		warning("Could not allocate temp storage for the built-in icon");
-		return;
-	}
-
-	for (i = 0; i < ncols; i++) {
-		unsigned char code;
-		char color[32];
-		memset(color, 0, sizeof(color));
-		unsigned int col;
-		if (sscanf(scummvm_icon[1 + i], "%c c %s", &code, color) != 2) {
-			warning("Wrong format of scummvm_icon[%d] (%s)", 1 + i, scummvm_icon[1 + i]);
-		}
-		if (!strcmp(color, "None"))
-			col = 0x00000000;
-		else if (!strcmp(color, "black"))
-			col = 0xFF000000;
-		else if (color[0] == '#') {
-			if (sscanf(color + 1, "%06x", &col) != 1) {
-				warning("Wrong format of color (%s)", color + 1);
-			}
-			col |= 0xFF000000;
-		} else {
-			warning("Could not load the built-in icon (%d %s - %s) ", code, color, scummvm_icon[1 + i]);
-			free(icon);
-			return;
-		}
-
-		rgba[code] = col;
-	}
-	for (y = 0; y < h; y++) {
-		const char *line = scummvm_icon[1 + ncols + y];
-		for (x = 0; x < w; x++) {
-			icon[x + w * y] = rgba[(int)line[x]];
-		}
-	}
-
-	SDL_Surface *sdl_surf = SDL_CreateRGBSurfaceFrom(icon, w, h, 32, w * 4, 0xFF0000, 0x00FF00, 0x0000FF, 0xFF000000);
-	if (!sdl_surf) {
-		warning("SDL_CreateRGBSurfaceFrom(icon) failed");
-	}
-	_window->setWindowIcon(sdl_surf);
-	free(icon);
-}
-
 
 uint32 OSystem_SDL::getMillis(bool skipRecord) {
 	uint32 millis = SDL_GetTicks();

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -104,11 +104,6 @@ protected:
 	 */
 	virtual void initSDL();
 
-	/**
-	 * Setup the window icon.
-	 */
-	virtual void setupIcon();
-
 	// Logging
 	virtual Common::WriteStream *createLogFile() { return 0; }
 	Backends::Log::Log *_logger;

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -29,6 +29,7 @@
 #include "backends/mixer/sdl/sdl-mixer.h"
 #include "backends/events/sdl/sdl-events.h"
 #include "backends/log/log.h"
+#include "backends/platform/sdl/sdl-window.h"
 
 #include "common/array.h"
 
@@ -90,6 +91,11 @@ protected:
 	 * The event source we use for obtaining SDL events.
 	 */
 	SdlEventSource *_eventSource;
+
+	/**
+	 * The SDL output window.
+	 */
+	SdlWindow *_window;
 
 	virtual Common::EventSource *getDefaultEventSource() { return _eventSource; }
 

--- a/backends/platform/sdl/win32/win32-main.cpp
+++ b/backends/platform/sdl/win32/win32-main.cpp
@@ -40,7 +40,9 @@
 #include "base/main.h"
 
 int __stdcall WinMain(HINSTANCE /*hInst*/, HINSTANCE /*hPrevInst*/,  LPSTR /*lpCmdLine*/, int /*iShowCmd*/) {
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_SetModuleHandle(GetModuleHandle(NULL));
+#endif
 	return main(__argc, __argv);
 }
 

--- a/backends/platform/sdl/win32/win32-window.cpp
+++ b/backends/platform/sdl/win32/win32-window.cpp
@@ -1,0 +1,58 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+// Disable symbol overrides so that we can use system headers.
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
+#ifdef WIN32
+
+#include "backends/platform/sdl/win32/win32-window.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#undef ARRAYSIZE // winnt.h defines ARRAYSIZE, but we want our own one...
+
+#include <SDL_syswm.h> // For setting the icon
+
+void SdlWindow_Win32::setupIcon() {
+	HMODULE handle = GetModuleHandle(NULL);
+	HICON   ico    = LoadIcon(handle, MAKEINTRESOURCE(1001 /* IDI_ICON */));
+	if (ico) {
+		SDL_SysWMinfo  wminfo;
+		SDL_VERSION(&wminfo.version);
+		if (SDL_GetWMInfo(&wminfo)) {
+			// Replace the handle to the icon associated with the window class by our custom icon
+			SetClassLongPtr(wminfo.window, GCLP_HICON, (ULONG_PTR)ico);
+
+			// Since there wasn't any default icon, we can't use the return value from SetClassLong
+			// to check for errors (it would be 0 in both cases: error or no previous value for the
+			// icon handle). Instead we check for the last-error code value.
+			if (GetLastError() == ERROR_SUCCESS)
+				return;
+		}
+	}
+
+	// If no icon has been set, fallback to default path
+	SdlWindow::setupIcon();
+}
+
+#endif

--- a/backends/platform/sdl/win32/win32-window.cpp
+++ b/backends/platform/sdl/win32/win32-window.cpp
@@ -31,8 +31,6 @@
 #include <windows.h>
 #undef ARRAYSIZE // winnt.h defines ARRAYSIZE, but we want our own one...
 
-#include <SDL_syswm.h> // For setting the icon
-
 void SdlWindow_Win32::setupIcon() {
 	HMODULE handle = GetModuleHandle(NULL);
 	HICON   ico    = LoadIcon(handle, MAKEINTRESOURCE(1001 /* IDI_ICON */));

--- a/backends/platform/sdl/win32/win32-window.cpp
+++ b/backends/platform/sdl/win32/win32-window.cpp
@@ -37,11 +37,14 @@ void SdlWindow_Win32::setupIcon() {
 	HMODULE handle = GetModuleHandle(NULL);
 	HICON   ico    = LoadIcon(handle, MAKEINTRESOURCE(1001 /* IDI_ICON */));
 	if (ico) {
-		SDL_SysWMinfo  wminfo;
-		SDL_VERSION(&wminfo.version);
-		if (SDL_GetWMInfo(&wminfo)) {
+		SDL_SysWMinfo wminfo;
+		if (getSDLWMInformation(&wminfo)) {
 			// Replace the handle to the icon associated with the window class by our custom icon
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+			SetClassLongPtr(wminfo.info.win.window, GCLP_HICON, (ULONG_PTR)ico);
+#else
 			SetClassLongPtr(wminfo.window, GCLP_HICON, (ULONG_PTR)ico);
+#endif
 
 			// Since there wasn't any default icon, we can't use the return value from SetClassLong
 			// to check for errors (it would be 0 in both cases: error or no previous value for the

--- a/backends/platform/sdl/win32/win32-window.h
+++ b/backends/platform/sdl/win32/win32-window.h
@@ -20,35 +20,18 @@
  *
  */
 
-#ifndef PLATFORM_SDL_WIN32_H
-#define PLATFORM_SDL_WIN32_H
+#ifndef BACKENDS_PLATFORM_SDL_WIN32_WIN32_WINDOW_H
+#define BACKENDS_PLATFORM_SDL_WIN32_WIN32_WINDOW_H
 
-#include "backends/platform/sdl/sdl.h"
+#ifdef WIN32
 
-class OSystem_Win32 : public OSystem_SDL {
+#include "backends/platform/sdl/sdl-window.h"
+
+class SdlWindow_Win32 : public SdlWindow {
 public:
-	virtual void init();
-	virtual void initBackend();
-
-	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0);
-
-	virtual bool hasFeature(Feature f);
-
-	virtual bool displayLogFile();
-
-protected:
-	/**
-	 * The path of the currently open log file, if any.
-	 *
-	 * @note This is currently a string and not an FSNode for simplicity;
-	 * e.g. we don't need to include fs.h here, and currently the
-	 * only use of this value is to use it to open the log file in an
-	 * editor; for that, we need it only as a string anyway.
-	 */
-	Common::String _logFilePath;
-
-	virtual Common::String getDefaultConfigFileName();
-	virtual Common::WriteStream *createLogFile();
+	virtual void setupIcon();
 };
+
+#endif
 
 #endif

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -35,9 +35,8 @@
 #include "common/error.h"
 #include "common/textconsole.h"
 
-#include <SDL_syswm.h> // For setting the icon
-
 #include "backends/platform/sdl/win32/win32.h"
+#include "backends/platform/sdl/win32/win32-window.h"
 #include "backends/saves/windows/windows-saves.h"
 #include "backends/fs/windows/windows-fs-factory.h"
 #include "backends/taskbar/win32/win32-taskbar.h"
@@ -49,6 +48,9 @@
 void OSystem_Win32::init() {
 	// Initialize File System Factory
 	_fsFactory = new WindowsFilesystemFactory();
+
+	// Create Win32 specific window
+	_window = new SdlWindow_Win32();
 
 #if defined(USE_TASKBAR)
 	// Initialize taskbar manager
@@ -124,28 +126,6 @@ bool OSystem_Win32::displayLogFile() {
 		return true;
 
 	return false;
-}
-
-void OSystem_Win32::setupIcon() {
-	HMODULE handle = GetModuleHandle(NULL);
-	HICON   ico    = LoadIcon(handle, MAKEINTRESOURCE(1001 /* IDI_ICON */));
-	if (ico) {
-		SDL_SysWMinfo  wminfo;
-		SDL_VERSION(&wminfo.version);
-		if (SDL_GetWMInfo(&wminfo)) {
-			// Replace the handle to the icon associated with the window class by our custom icon
-			SetClassLongPtr(wminfo.window, GCLP_HICON, (ULONG_PTR)ico);
-
-			// Since there wasn't any default icon, we can't use the return value from SetClassLong
-			// to check for errors (it would be 0 in both cases: error or no previous value for the
-			// icon handle). Instead we check for the last-error code value.
-			if (GetLastError() == ERROR_SUCCESS)
-				return;
-		}
-	}
-
-	// If no icon has been set, fallback to default path
-	OSystem_SDL::setupIcon();
 }
 
 Common::String OSystem_Win32::getDefaultConfigFileName() {

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -54,7 +54,7 @@ void OSystem_Win32::init() {
 
 #if defined(USE_TASKBAR)
 	// Initialize taskbar manager
-	_taskbarManager = new Win32TaskbarManager();
+	_taskbarManager = new Win32TaskbarManager(_window);
 #endif
 
 	// Invoke parent implementation of this method

--- a/backends/platform/symbian/src/SymbianOS.cpp
+++ b/backends/platform/symbian/src/SymbianOS.cpp
@@ -109,7 +109,7 @@ void OSystem_SDL_Symbian::initBackend() {
 		_mixerManager->init();
 	}
 	if (_graphicsManager == 0)
-		_graphicsManager = new SymbianSdlGraphicsManager(_eventSource);
+		_graphicsManager = new SymbianSdlGraphicsManager(_eventSource, _window);
 
 	// Call parent implementation of this method
 	OSystem_SDL::initBackend();

--- a/backends/platform/symbian/src/SymbianOS.cpp
+++ b/backends/platform/symbian/src/SymbianOS.cpp
@@ -63,6 +63,8 @@ OSystem_SDL_Symbian::OSystem_SDL_Symbian()
 
 void OSystem_SDL_Symbian::init() {
 	_RFs = &CEikonEnv::Static()->FsSession();
+	// Use iconless window: it uses the EScummVM.aif file for the icon.
+	_window = new SdlIconlessWindow();
 	_fsFactory = new SymbianFilesystemFactory();
 	OSystem_SDL::init();
 }
@@ -169,10 +171,6 @@ Common::String OSystem_SDL_Symbian::getDefaultConfigFileName() {
 	strcpy(configFile, Symbian::GetExecutablePath());
 	strcat(configFile, DEFAULT_CONFIG_FILE);
 	return configFile;
-}
-
-void OSystem_SDL_Symbian::setupIcon() {
-	// Don't for Symbian: it uses the EScummVM.aif file for the icon.
 }
 
 RFs& OSystem_SDL_Symbian::FsSession() {

--- a/backends/platform/symbian/src/SymbianOS.h
+++ b/backends/platform/symbian/src/SymbianOS.h
@@ -39,7 +39,6 @@ public:
 	virtual void engineDone();
 	virtual bool setGraphicsMode(const char *name);
 	virtual Common::String getDefaultConfigFileName();
-	virtual void setupIcon();
 
 	/**
 	 * Returns reference to File session

--- a/backends/platform/wince/wince-sdl.cpp
+++ b/backends/platform/wince/wince-sdl.cpp
@@ -420,7 +420,7 @@ void OSystem_WINCE3::initBackend() {
 	}
 
 	if (_graphicsManager == 0)
-		_graphicsManager = new WINCESdlGraphicsManager(_eventSource);
+		_graphicsManager = new WINCESdlGraphicsManager(_eventSource, _window);
 
 	((WINCESdlEventSource *)_eventSource)->init(dynamic_cast<WINCESdlGraphicsManager *>(_graphicsManager));
 

--- a/backends/taskbar/win32/win32-taskbar.cpp
+++ b/backends/taskbar/win32/win32-taskbar.cpp
@@ -48,9 +48,6 @@
 
 #include <shlobj.h>
 
-// For HWND
-#include <SDL_syswm.h>
-
 #include "common/scummsys.h"
 
 #include "backends/taskbar/win32/win32-taskbar.h"

--- a/backends/taskbar/win32/win32-taskbar.cpp
+++ b/backends/taskbar/win32/win32-taskbar.cpp
@@ -62,7 +62,7 @@
 // System.Title property key, values taken from http://msdn.microsoft.com/en-us/library/bb787584.aspx
 const PROPERTYKEY PKEY_Title = { /* fmtid = */ { 0xF29F85E0, 0x4FF9, 0x1068, { 0xAB, 0x91, 0x08, 0x00, 0x2B, 0x27, 0xB3, 0xD9 } }, /* propID = */ 2 };
 
-Win32TaskbarManager::Win32TaskbarManager() : _taskbar(NULL), _count(0), _icon(NULL) {
+Win32TaskbarManager::Win32TaskbarManager(SdlWindow *window) : _window(window), _taskbar(NULL), _count(0), _icon(NULL) {
 	// Do nothing if not running on Windows 7 or later
 	if (!isWin7OrLater())
 		return;
@@ -408,12 +408,15 @@ LPWSTR Win32TaskbarManager::ansiToUnicode(const char *s) {
 
 HWND Win32TaskbarManager::getHwnd() {
 	SDL_SysWMinfo wmi;
-	SDL_VERSION(&wmi.version);
-
-	if(!SDL_GetWMInfo(&wmi))
+	if (_window->getSDLWMInformation(&wmi)) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		return wmi.info.win.window;
+#else
+		return wmi.window;
+#endif
+	} else {
 		return NULL;
-
-	return wmi.window;
+	}
 }
 
 #endif

--- a/backends/taskbar/win32/win32-taskbar.h
+++ b/backends/taskbar/win32/win32-taskbar.h
@@ -25,6 +25,8 @@
 
 #if defined(WIN32) && defined(USE_TASKBAR)
 
+#include "backends/platform/sdl/sdl-window.h"
+
 #include "common/str.h"
 #include "common/taskbar.h"
 
@@ -32,7 +34,7 @@ struct ITaskbarList3;
 
 class Win32TaskbarManager : public Common::TaskbarManager {
 public:
-	Win32TaskbarManager();
+	Win32TaskbarManager(SdlWindow *window);
 	virtual ~Win32TaskbarManager();
 
 	virtual void setOverlayIcon(const Common::String &name, const Common::String &description);
@@ -44,6 +46,8 @@ public:
 	virtual void clearError();
 
 private:
+	SdlWindow *_window;
+
 	ITaskbarList3 *_taskbar;
 
 	// Count handling

--- a/configure
+++ b/configure
@@ -171,7 +171,7 @@ _stagingpath="staging"
 _win32path="c:/scummvm"
 _amigaospath="Games:ScummVM"
 _staticlibpath=
-_sdlconfig="$SDL_CONFIG"
+_sdlconfig=sdl-config
 _freetypeconfig=freetype-config
 _sdlpath="$PATH"
 _freetypepath="$PATH"
@@ -354,7 +354,7 @@ define_in_config_if_yes() {
 # TODO: small bit of code to test sdl usability
 find_sdlconfig() {
 	echo_n "Looking for sdl-config... "
-	sdlconfigs="$_sdlconfig:sdl-config:sdl11-config:sdl12-config"
+	sdlconfigs="$SDL_CONFIG:$_sdlconfig:sdl-config:sdl11-config:sdl12-config"
 	_sdlconfig=
 
 	IFS="${IFS=   }"; ac_save_ifs="$IFS"; IFS="$SEPARATOR"

--- a/configure
+++ b/configure
@@ -35,6 +35,7 @@ SAVED_CXXFLAGS=$CXXFLAGS
 SAVED_CPPFLAGS=$CPPFLAGS
 SAVED_ASFLAGS=$ASFLAGS
 SAVED_WINDRESFLAGS=$WINDRESFLAGS
+SAVED_SDL_CONFIG=$SDL_CONFIG
 
 # Use environment vars if set
 CXXFLAGS="$CXXFLAGS $CPPFLAGS"
@@ -170,7 +171,7 @@ _stagingpath="staging"
 _win32path="c:/scummvm"
 _amigaospath="Games:ScummVM"
 _staticlibpath=
-_sdlconfig=sdl-config
+_sdlconfig="$SDL_CONFIG"
 _freetypeconfig=freetype-config
 _sdlpath="$PATH"
 _freetypepath="$PATH"
@@ -4581,6 +4582,7 @@ SAVED_CXXFLAGS     := $SAVED_CXXFLAGS
 SAVED_CPPFLAGS     := $SAVED_CPPFLAGS
 SAVED_ASFLAGS      := $SAVED_ASFLAGS
 SAVED_WINDRESFLAGS := $SAVED_WINDRESFLAGS
+SAVED_SDL_CONFIG   := $SAVED_SDL_CONFIG
 EOF
 
 #

--- a/configure
+++ b/configure
@@ -3070,6 +3070,9 @@ case $_backend in
 			1.3.*)
 				add_line_to_config_mk "USE_SDL13 = 1"
 				;;
+			2.0.*)
+				add_line_to_config_mk "USE_SDL2 = 1"
+				;;
 			*)
 				;;
 		esac

--- a/devtools/credits.pl
+++ b/devtools/credits.pl
@@ -1133,6 +1133,7 @@ begin_credits("Credits");
 				add_person("Jeroen Janssen", "japj", "Numerous readability and bugfix patches");
 				add_person("Keith Kaisershot", "blitter", "Several Pegasus Prime patches");
 				add_person("Andreas Karlsson", "Sprawl", "Initial port for SymbianOS");
+				add_person("Stefan Kristiansson", "skristiansson", "Initial work on SDL2 support");
 				add_person("Claudio Matsuoka", "", "Daily Linux builds");
 				add_person("Thomas Mayer", "", "PSP port contributions");
 				add_person("Sean Murray", "lightcast", "ScummVM tools GUI application (GSoC 2007 task)");

--- a/gui/credits.h
+++ b/gui/credits.h
@@ -694,6 +694,8 @@ static const char *credits[] = {
 "C2""Several Pegasus Prime patches",
 "C0""Andreas Karlsson",
 "C2""Initial port for SymbianOS",
+"C0""Stefan Kristiansson",
+"C2""Initial work on SDL2 support",
 "C0""Claudio Matsuoka",
 "C2""Daily Linux builds",
 "C0""Thomas Mayer",


### PR DESCRIPTION
This is basically a cleaned up and extended version of pull request #540. Unlike #540, this rather tries to directly implement compatibility wrappers for removed/changed functionality. This allows us to get rid of defining deprecated functionality with asserts (which is bad because doing so might allow SDL ports to still compile but then fail on runtime).

Other differences compared to #540:
- Working mouse wheel support
- Does not break the OpenGL backend when ScummVM was compiled with SDL1.2
- Our OpenGL SDL backend builds (thus no --disable-opengl is needed when compiling with SDL2) and seems to work fine
- Window icon setup also working in theory for SDL2 (somehow it is distorted when I tested it on X11 though...)
- Window title/icon gets kept when switching from SurfaceSDL <-> OpenGLSDL
- SDL2 can be explicitly enabled by setting SDL_CONFIG when running configure instead of --enable-sdl2

This is only minimally tested.