### PR TITLE
AMIGAOS: Re-add a DosList feature

### DIFF
--- a/backends/fs/amigaos4/amigaos4-fs.cpp
+++ b/backends/fs/amigaos4/amigaos4-fs.cpp
@@ -381,15 +381,17 @@ AbstractFSList AmigaOSFilesystemNode::listVolumes() const {
 	dosList = IDOS->NextDosEntry(dosList, LDF_VOLUMES);
 	while (dosList) {
 		if (dosList->dol_Type == DLT_VOLUME &&
-			dosList->dol_Name) {
+			dosList->dol_Name &&
+			dosList->dol_Port) {
 
 			// The original line was
 			//if (dosList->dol_Type == DLT_VOLUME &&
 			//dosList->dol_Name &&
 			//dosList->dol_Task) {
 			// which errored using SDK 53.24 with a 'struct dosList' has no member called 'dol_Task'
-			// I removed dol_Task because it's not used anywhere else
-			// and it neither brought up further errors nor crashes or regressions
+			// The reason for that was that
+			// 1) dol_Task wasn't a task pointer, it is a message port instead
+			// 2) It was redefined to be dol_Port in dos/obsolete.h in afore mentioned SDK
 
 			// Copy name to buffer
 			IDOS->CopyStringBSTRToC(dosList->dol_Name, buffer, MAXPATHLEN);


### PR DESCRIPTION
To keep consistency with the original code i re-added the DosList feature dol_Port (which was taken out due to a compiler error using SDK 53.24 and was named wrong anyway).
It offers a message port for the DosList.