### PR TITLE
MORTEVIELLE: added missing inter screen messages

### DIFF
--- a/engines/mortevielle/actions.cpp
+++ b/engines/mortevielle/actions.cpp
@@ -571,6 +571,7 @@ void MortevielleEngine::fctSearch() {
 				_curSearchObjId = getFirstObject();
 				if (_curSearchObjId != 0) {
 					_searchCount = 0;
+					_is = 0;
 					_heroSearching = true;
 					_menu->setSearchMenu();
 					prepareNextObject();
@@ -1678,9 +1679,8 @@ void MortevielleEngine::endGame() {
 	handleDescriptionText(2, 35);
 	startMusicOrSpeech(0);
 	testKey(false);
-	// A wait message was displayed.
-	// testKey (aka tkey1) was called before and after.
-	// This double call is useless, thus removed
+	displayInterScreenMessage(2036);
+	testKey(false);
 	resetVariables();
 }
 

--- a/engines/mortevielle/mortevielle.h
+++ b/engines/mortevielle/mortevielle.h
@@ -416,6 +416,7 @@ public:
 	int _maff;
 	int _caff;
 	int _crep;
+	int _is;		// ???
 
 	byte _destinationArray[7][25];
 
@@ -466,6 +467,7 @@ public:
 	void gameLoaded();
 	void initGame();
 	void displayAloneText();
+	void displayInterScreenMessage(int mesgId);
 	void draw(int x, int y);
 	void charToHour();
 	void hourToChar();

--- a/engines/mortevielle/outtext.cpp
+++ b/engines/mortevielle/outtext.cpp
@@ -227,7 +227,31 @@ void TextHandler::taffich() {
 	Common::String filename, altFilename;
 
 	if ((a != 50) && (a != 51)) {
+		int m = a + 2000;
+
+		if ((m > 2001) && (m < 2010))
+			m = 2001;
+		else if (m == 2011)
+			m = 2010;
+		if (a == 32)
+			m = 2034;
+		else if ((a == 17) && (_vm->_maff == 14))
+			m = 2018;
+		else if (a > 99) {
+			if ((_vm->_is == 1) || (_vm->_is == 0))
+				m = 2031;
+			else
+				m = 2032;
+		}
+
+		if ( ((a > 69) && (a < 80)) || (a == 30) || (a == 31) || (a == 144) || (a == 147) || (a == 149) )
+			m = 2030;
+		else if ( ((a < 27) && ( ((_vm->_maff > 69) && (!_vm->_coreVar._alreadyEnteredManor)) || (_vm->_maff > 99) )) || ((_vm->_maff > 29) && (_vm->_maff < 33)) )
+			m = 2033;
+
+		_vm->displayInterScreenMessage(m);
 		_vm->_maff = a;
+
 		if (a == 159)
 			a = 86;
 		else if (a > 140)

--- a/engines/mortevielle/utils.cpp
+++ b/engines/mortevielle/utils.cpp
@@ -1359,6 +1359,7 @@ void MortevielleEngine::endSearch() {
 	_heroSearching = false;
 	_obpart = false;
 	_searchCount = 0;
+	_is = 0;
 	_menu->unsetSearchMenu();
 }
 
@@ -1469,6 +1470,7 @@ void MortevielleEngine::gameLoaded() {
 	_num = 0;
 	_startTime = 0;
 	_endTime = 0;
+	_is = 0;
 	_searchCount = 0;
 	_roomDoorId = OWN_ROOM;
 	_syn = true;
@@ -2989,6 +2991,26 @@ void MortevielleEngine::displayNarrativePicture(int af, int ob) {
 }
 
 /**
+ * Display a message switching from a screen to another.
+ * @remarks	Originally called 'messint'
+ */
+void MortevielleEngine::displayInterScreenMessage(int mesgId) {
+	clearUpperLeftPart();
+	clearDescriptionBar();
+	clearVerbBar();
+
+	GfxSurface surface;
+	surface.decode(_rightFramePict + 1008);
+	surface._offset.x = 80;
+	surface._offset.y = 40;
+	setPal(90);
+	_screenSurface->drawPicture(surface, 0, 0);
+	_screenSurface->drawPicture(surface, 0, 70);
+	handleDescriptionText(7, mesgId);
+	delay(DISK_ACCESS_DELAY);
+}
+
+/**
  * Prepare Display Text
  * @remarks	Originally called 'affrep'
  */
@@ -3196,6 +3218,7 @@ void MortevielleEngine::prepareNextObject() {
 	} while ((objId == 0) && (_searchCount <= 9));
 
 	if ((objId != 0) && (_searchCount < 11)) {
+		_is++;
 		_caff = objId;
 		_crep = _caff + 400;
 		if (_currBitIndex != 0)


### PR DESCRIPTION
Hi,

Here is the code to display the inter screen messages. They are the small introduction messages shown while loading the next scene. I use a delay() to simulate the disk access delay.

Still don't know what is the _is variable but is seems to be used for this kind of messages.

Voila.
Thanks
Chris



