### PR TITLE
ANDROID: Switch minimum & recommended API Level to 9 (Android 2.3).

### DIFF
--- a/dists/android/AndroidManifest.xml
+++ b/dists/android/AndroidManifest.xml
@@ -8,10 +8,11 @@
 		android:installLocation="preferExternal"
 		android:sharedUserId="org.scummvm.scummvm">
 
-	<!-- This version works on Android 1.5 (SDK 3) and newer, but we
-			want Android 2.2 (SDK 8) defaults and features. -->
-	<uses-sdk android:minSdkVersion="3"
-			android:targetSdkVersion="8"/>
+	<!-- This version works on Android 2.3 (API Level 9) onwards,
+	     but not correctly on Android 4.4 (API Level 19) onwards. -->
+	<uses-sdk android:minSdkVersion="9"
+			android:targetSdkVersion="9"
+			android:maxSdkVersion="18" />
 
 	<application android:name=".ScummVMApplication"
 			android:label="@string/app_name"

--- a/dists/android/AndroidManifest.xml.in
+++ b/dists/android/AndroidManifest.xml.in
@@ -8,10 +8,11 @@
 		android:installLocation="preferExternal"
 		android:sharedUserId="org.scummvm.scummvm">
 
-	<!-- This version works on Android 1.5 (SDK 3) and newer, but we
-			want Android 2.2 (SDK 8) defaults and features. -->
-	<uses-sdk android:minSdkVersion="3"
-			android:targetSdkVersion="8"/>
+	<!-- This version works on Android 2.3 (API Level 9) onwards,
+	     but not correctly on Android 4.4 (API Level 19) onwards. -->
+	<uses-sdk android:minSdkVersion="9"
+			android:targetSdkVersion="9"
+			android:maxSdkVersion="18" />
 
 	<application android:name=".ScummVMApplication"
 			android:label="@string/app_name"


### PR DESCRIPTION
Also, add maximum API Level of 18 (Android 4.3) "Jelly Bean".

This is not used by Android so will still allow manual installation of
APKs to devices with newer versions, but is used by the Google Play
Store to filter versions offered to users.

This will reduce complaints from users with newer versions of Android.