### PR TITLE
COMMON: Add getRevTab to FFT

### DIFF
--- a/common/fft.cpp
+++ b/common/fft.cpp
@@ -61,6 +61,10 @@ FFT::~FFT() {
 	delete[] _tmpBuf;
 }
 
+const uint16 *FFT::getRevTab() const {
+	return _revTab;
+}
+
 void FFT::permute(Complex *z) {
 	int np = 1 << _bits;
 

--- a/common/fft.h
+++ b/common/fft.h
@@ -47,6 +47,8 @@ public:
 	FFT(int bits, int inverse);
 	~FFT();
 
+	const uint16 *getRevTab() const;
+
 	/** Do the permutation needed BEFORE calling calc(). */
 	void permute(Complex *z);
 


### PR DESCRIPTION
This change to the FFT class is needed by the WMA decoder from xoreos we intend to merge in ResidualVM in PR https://github.com/residualvm/residualvm/pull/1128.
The common code in ResidualVM is updated from time to time from ScummVM. The intent behind this PR is not to introduce differences for the FFT class between ScummVM and ResidualVM to keep the update process simple for this class.
The changes are simple and should not prove difficult to maintain.