### PR TITLE
WINTERMUTE: Fixed parentFolder name check, Fix bug #6655 (Dead City - hotspot text issue)

### DIFF
--- a/engines/wintermute/base/base_file_manager.cpp
+++ b/engines/wintermute/base/base_file_manager.cpp
@@ -227,7 +227,7 @@ bool BaseFileManager::registerPackages() {
 
 			// Again, make the parent's name all lowercase to avoid any case
 			// issues.
-			Common::String parentName = fileIt->getParent().getName();
+			Common::String parentName = it->getName();
 			parentName.toLowercase();
 
 			// Avoid registering all the language files


### PR DESCRIPTION
In Dead City, WinterMute loads the wrong font (outline_red2.font) instead of outline_white.font, which is used by the original. This is a Windows-only issue. 

It seems that calling getParent returns trailing '\' which is absent on POSIX based file systems but not on Windows. This causes Wintermute to load outline_red2.font from russian.dcp, which is not desired.  This is fixed by calling it->getName() directly, which returns the folder name (without the trailing '\').