### PR TITLE
WINTERMUTE: Added mappings for VKeyCodes->ScummVM KeyCodes

### DIFF
--- a/engines/wintermute/base/base_keyboard_state.cpp
+++ b/engines/wintermute/base/base_keyboard_state.cpp
@@ -262,41 +262,92 @@ bool BaseKeyboardState::isCurrentPrintable() const {
 }
 
 //////////////////////////////////////////////////////////////////////////
+enum VKeyCodes {
+	kVkReturn     = 13,
+
+	kVkEscape     = 27,
+
+	kVkSpace      = 32,
+	kVkEnd        = 35,
+	kVkHome       = 36,
+	kVkLeft       = 37,
+	kVkUp         = 38,
+	kVkRight      = 39,
+	kVkDown       = 40,
+
+	kVkF1         = 112,
+	kVkF2         = 113,
+	kVkF3         = 114,
+	kVkF4         = 115,
+	kVkF5         = 116,
+	kVkF6         = 117,
+	kVkF7         = 118,
+	kVkF8         = 119,
+	kVkF9         = 120,
+	kVkF10        = 121,
+	kVkF11        = 122,
+	kVkF12        = 123
+
+};
+
+//////////////////////////////////////////////////////////////////////////
 uint32 BaseKeyboardState::keyCodeToVKey(Common::Event *event) {
+	// todo
 	if (event->type != Common::EVENT_KEYDOWN) {
 		return 0;
 	}
 
 	switch (event->kbd.keycode) {
+	case Common::KEYCODE_RETURN:
 	case Common::KEYCODE_KP_ENTER:
-		return Common::KEYCODE_RETURN;
+		return kVkReturn;
+	case Common::KEYCODE_ESCAPE:
+		return kVkEscape;
+	case Common::KEYCODE_SPACE:
+		return kVkSpace;
+	case Common::KEYCODE_END:
+		return kVkEnd;
+	case Common::KEYCODE_HOME:
+		return kVkHome;
+	case Common::KEYCODE_LEFT:
+		return kVkLeft;
+	case Common::KEYCODE_RIGHT:
+		return kVkRight;
+	case Common::KEYCODE_UP:
+		return kVkUp;
+	case Common::KEYCODE_DOWN:
+		return kVkDown;
+	case Common::KEYCODE_F1:
+		return kVkF1;
+	case Common::KEYCODE_F2:
+		return kVkF2;
+	case Common::KEYCODE_F3:
+		return kVkF3;
+	case Common::KEYCODE_F4:
+		return kVkF4;
+	case Common::KEYCODE_F5:
+		return kVkF5;
+	case Common::KEYCODE_F6:
+		return kVkF6;
+	case Common::KEYCODE_F7:
+		return kVkF7;
+	case Common::KEYCODE_F8:
+		return kVkF8;
+	case Common::KEYCODE_F9:
+		return kVkF9;
+	case Common::KEYCODE_F10:
+		return kVkF10;
+	case Common::KEYCODE_F11:
+		return kVkF11;
+	case Common::KEYCODE_F12:
+		return kVkF12;
 	default:
-		return (uint32)event->kbd.ascii;
+		warning("Key not handled: %d '%c'", event->kbd.keycode, event->kbd.keycode);
+		return event->kbd.keycode;
+		break;
 	}
+
 }
-
-enum VKeyCodes {
-	kVkEscape = 27,
-	kVkSpace  = 32,
-	kVkHome   = 36,
-	kVkLeft   = 37,
-	kVkUp     = 38,
-	kVkRight  = 39,
-	kVkDown   = 40,
-
-	kVkF1     = 112,
-	kVkF2     = 113,
-	kVkF3     = 114,
-	kVkF4     = 115,
-	kVkF5     = 116,
-	kVkF6     = 117,
-	kVkF7     = 118,
-	kVkF8     = 119,
-	kVkF9     = 120,
-	kVkF10    = 121,
-	kVkF11    = 122,
-	kVkF12    = 123
-};
 
 //////////////////////////////////////////////////////////////////////////
 Common::KeyCode BaseKeyboardState::vKeyToKeyCode(uint32 vkey) {

--- a/engines/wintermute/base/base_keyboard_state.h
+++ b/engines/wintermute/base/base_keyboard_state.h
@@ -67,7 +67,7 @@ private:
 	bool _currentControl;
 
 	uint8 *_keyStates;
-	uint32 keyCodeToVKey(Common::Event *event);
+	uint32 keyCodeToVKey(Common::Event *event); //TODO, add more mappings
 	Common::KeyCode vKeyToKeyCode(uint32 vkey); //TODO, reimplement using ScummVM-backend
 };
 


### PR DESCRIPTION
Fix bug #6654 (white chamber - some keys don't work)

Wintermute games on ScummVM used SDL keycodes for keyboard mapping, wheras
the game scripts only accept VKeyCodes of Windows. Therefore an initial
set of mappings are added and the debug room is now loading properly, when
HOME is pressed (Rest of the keys need to be tested in-game)