### PR TITLE
DRASCULA: fix crash/graphic glitch at castle towers

### DIFF
--- a/engines/drascula/actors.cpp
+++ b/engines/drascula/actors.cpp
@@ -396,6 +396,13 @@ void DrasculaEngine::increaseFrameNum() {
 		curHeight = (int)newHeight;
 		curWidth = (int)newWidth;
 	}
+
+	if ((currentChapter == 5) && (_roomNumber == 45)) {
+		curY = 0;
+		curX = 0;
+		curHeight = 0;
+		curWidth = 0;
+	}
 }
 
 void DrasculaEngine::walkDown() {

--- a/engines/drascula/actors.cpp
+++ b/engines/drascula/actors.cpp
@@ -396,7 +396,10 @@ void DrasculaEngine::increaseFrameNum() {
 		curHeight = (int)newHeight;
 		curWidth = (int)newWidth;
 	}
-
+	
+	// Fix bug #5903 DRASCULA-IT: Crash/graphic glitch at castle towers
+	// Chapter 5 Room 45 is the castle tower part
+	// Fixing the character's coordinate(0,0) in the tower section to prevent out of window coordinates and crash
 	if ((currentChapter == 5) && (_roomNumber == 45)) {
 		curY = 0;
 		curX = 0;

--- a/engines/drascula/talk.cpp
+++ b/engines/drascula/talk.cpp
@@ -478,6 +478,8 @@ void DrasculaEngine::talk(const char *said, const char *filename) {
 			updateRefresh();
 		}
 
+		// Fix bug #5903 DRASCULA-IT: Crash/graphic glitch at castle towers
+		// Without the head we have to fix the subtitle's coordinates(upper-center) at the tower section
 		if (!_subtitlesDisabled) {
 			if (notTowers) {
 				centerText(said, curX, curY);

--- a/engines/drascula/talk.cpp
+++ b/engines/drascula/talk.cpp
@@ -379,6 +379,7 @@ void DrasculaEngine::talk(const char *said, const char *filename) {
 
 	int y_mask_talk = 170;
 	int face;
+	bool notTowers = !((currentChapter == 5) && (_roomNumber == 45));
 
 	if (currentChapter == 6) {
 		if (flags[0] == 0 && _roomNumber == 102) {
@@ -434,44 +435,54 @@ void DrasculaEngine::talk(const char *said, const char *filename) {
 			if (currentChapter == 2)
 				copyRect(x_talk_izq[face], y_mask_talk, curX + 8, curY - 1, TALK_WIDTH, TALK_HEIGHT,
 						extraSurface, screenSurface);
-			else
+			else if (notTowers) {
 				reduce_hare_chico(x_talk_izq[face], y_mask_talk, curX + (int)((8.0f / 100) * factor_red[MIN(201, curY + curHeight)]),
-						curY, TALK_WIDTH, TALK_HEIGHT, factor_red[MIN(201, curY + curHeight)],
-						extraSurface, screenSurface);
-
+					curY, TALK_WIDTH, TALK_HEIGHT, factor_red[MIN(201, curY + curHeight)],
+					extraSurface, screenSurface);
+			}
 			updateRefresh();
 		} else if (trackProtagonist == 1) {
 			if (currentChapter == 2)
 				copyRect(x_talk_dch[face], y_mask_talk, curX + 12, curY, TALK_WIDTH, TALK_HEIGHT,
 					extraSurface, screenSurface);
-			else
+			else if (notTowers) {
 				reduce_hare_chico(x_talk_dch[face], y_mask_talk, curX + (int)((12.0f / 100) * factor_red[MIN(201, curY + curHeight)]),
 					curY, TALK_WIDTH, TALK_HEIGHT, factor_red[MIN(201, curY + curHeight)], extraSurface, screenSurface);
+			}
 			updateRefresh();
 		} else if (trackProtagonist == 2) {
 			if (currentChapter == 2)
 				copyRect(x_talk_izq[face], y_mask_talk, curX + 12, curY, TALK_WIDTH, TALK_HEIGHT,
 					frontSurface, screenSurface);
-			else
+			else if (notTowers) {
 				reduce_hare_chico(x_talk_izq[face], y_mask_talk,
-						talkOffset + curX + (int)((12.0f / 100) * factor_red[MIN(201, curY + curHeight)]),
-						curY, TALK_WIDTH, TALK_HEIGHT, factor_red[MIN(201, curY + curHeight)],
-						frontSurface, screenSurface);
+					talkOffset + curX + (int)((12.0f / 100) * factor_red[MIN(201, curY + curHeight)]),
+					curY, TALK_WIDTH, TALK_HEIGHT, factor_red[MIN(201, curY + curHeight)],
+					frontSurface, screenSurface);
+			}
 			updateRefresh();
 		} else if (trackProtagonist == 3) {
 			if (currentChapter == 2)
 				copyRect(x_talk_dch[face], y_mask_talk, curX + 8, curY, TALK_WIDTH, TALK_HEIGHT,
 					frontSurface, screenSurface);
-			else
+			else if (notTowers) {
 				reduce_hare_chico(x_talk_dch[face], y_mask_talk,
-						talkOffset + curX + (int)((8.0f / 100) * factor_red[MIN(201, curY + curHeight)]),
-						curY, TALK_WIDTH,TALK_HEIGHT, factor_red[MIN(201, curY + curHeight)],
-						frontSurface, screenSurface);
+					talkOffset + curX + (int)((8.0f / 100) * factor_red[MIN(201, curY + curHeight)]),
+					curY, TALK_WIDTH, TALK_HEIGHT, factor_red[MIN(201, curY + curHeight)],
+					frontSurface, screenSurface);
+			}
 			updateRefresh();
 		}
 
-		if (!_subtitlesDisabled)
-			centerText(said, curX, curY);
+		if (!_subtitlesDisabled) {
+			if (notTowers) {
+				centerText(said, curX, curY);
+			}
+			else {
+				centerText(said, 160, 25);
+			}
+		}
+	
 
 		updateScreen();
 		updateEvents();

--- a/engines/drascula/talk.cpp
+++ b/engines/drascula/talk.cpp
@@ -379,6 +379,10 @@ void DrasculaEngine::talk(const char *said, const char *filename) {
 
 	int y_mask_talk = 170;
 	int face;
+	
+	// Fix bug #5903 DRASCULA-IT: Crash/graphic glitch at castle towers
+	// Chapter 5 Room 45 is the castle tower part
+	// We use this variable as a condition below because at the castle towers we don't want to draw out the head 
 	bool notTowers = !((currentChapter == 5) && (_roomNumber == 45));
 
 	if (currentChapter == 6) {


### PR DESCRIPTION
Fix bug #5903 DRASCULA-IT: Crash/graphic glitch at castle towers
http://sourceforge.net/p/scummvm/bugs/5903/

The problem was that if you looked at the tower Hacker's head started flying on the screen with the subtitle and the game crashed.
Now I fixed it: the game is not crash, there is no flying head and the subtitle is fixed on the screen upper-center.

![withoutheadpluscenter](https://cloud.githubusercontent.com/assets/11255536/6431034/8848aaf2-c022-11e4-8b7b-ad88540f1482.png)