### PR TITLE
SWORD25: Delay next movie frame by videoDecoder.getTimeToNextFrame()

### DIFF
--- a/engines/sword25/fmv/movieplayer.cpp
+++ b/engines/sword25/fmv/movieplayer.cpp
@@ -123,7 +123,7 @@ void MoviePlayer::update() {
 		if (_decoder.endOfVideo()) {
 			// Movie complete, so unload the movie
 			unloadMovie();
-		} else {
+		} else if (_decoder.needsUpdate()) {
 			const Graphics::Surface *s = _decoder.decodeNextFrame();
 			if (s) {
 				// Transfer the next frame


### PR DESCRIPTION
This fixes the problem that the movies are played too fast
and get out of sync with additionally played speech samples.

This can be tested by watching the intro movies: In the plane, George should start talking about Nico once he is shuffling his papers on the tray. Without the bug fix, the movie plays on my system with twice the speed and he starts talking much later. Additionally, the audio track of the movie gets out of sync with the video, too.


