### PR TITLE
AGI: Use correct volume for PCjr output

### DIFF
--- a/engines/agi/sound_pcjr.cpp
+++ b/engines/agi/sound_pcjr.cpp
@@ -207,7 +207,7 @@ int SoundGenPCJr::volumeCalc(SndGenChan *chan) {
 				chan->attenuationCopy = attenuation;
 
 				attenuation &= 0x0F;
-				attenuation += _mixer->getVolumeForSoundType(Audio::Mixer::kSFXSoundType) / 17;
+				attenuation += (16 - _mixer->getVolumeForSoundType(Audio::Mixer::kSFXSoundType) / 17);
 				if (attenuation > 0x0F)
 					attenuation = 0x0F;
 			}

--- a/engines/agi/sound_pcjr.cpp
+++ b/engines/agi/sound_pcjr.cpp
@@ -411,7 +411,7 @@ int SoundGenPCJr::chanGen(int chan, int16 *stream, int len) {
 		if (tpcm->noteCount <= 0) {
 			// get new tone data
 			if ((tpcm->avail) && (getNextNote(chan) == 0)) {
-				tpcm->atten = _channel[chan].attenuation;
+				tpcm->atten = volumeCalc(&_channel[chan]);
 				tpcm->freqCount = _channel[chan].freqCount;
 				tpcm->genType = _channel[chan].genType;
 

--- a/engines/agi/sound_pcjr.cpp
+++ b/engines/agi/sound_pcjr.cpp
@@ -205,7 +205,6 @@ int SoundGenPCJr::volumeCalc(SndGenChan *chan) {
 				chan->attenuationCopy = attenuation;
 
 				attenuation &= 0x0F;
-				attenuation += (16 - _mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType) / 17);
 				if (attenuation > 0x0F)
 					attenuation = 0x0F;
 			}
@@ -475,8 +474,9 @@ int SoundGenPCJr::fillSquare(ToneChan *t, int16 *buf, int len) {
 
 	count = len;
 
+	int16 amp = (int16)(volTable[t->atten] * _mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType) / Audio::Mixer::kMaxMixerVolume);
 	while (count > 0) {
-		*(buf++) = t->sign ? volTable[t->atten] : -volTable[t->atten];
+		*(buf++) = t->sign ? amp : -amp;
 		count--;
 
 		// get next sample
@@ -513,8 +513,9 @@ int SoundGenPCJr::fillNoise(ToneChan *t, int16 *buf, int len) {
 
 	count = len;
 
+	int16 amp = (int16)(volTable[t->atten] * _mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType) / Audio::Mixer::kMaxMixerVolume);
 	while (count > 0) {
-		*(buf++) = t->sign ? volTable[t->atten] : -volTable[t->atten];
+		*(buf++) = t->sign ? amp : -amp;
 		count--;
 
 		// get next sample

--- a/engines/agi/sound_pcjr.cpp
+++ b/engines/agi/sound_pcjr.cpp
@@ -120,8 +120,6 @@ SoundGenPCJr::SoundGenPCJr(AgiBase *vm, Audio::Mixer *pMixer) : SoundGen(vm, pMi
 	else
 		_dissolveMethod = 0;
 
-	_dissolveMethod = 3;
-
 	memset(_channel, 0, sizeof(_channel));
 	memset(_tchannel, 0, sizeof(_tchannel));
 
@@ -207,7 +205,7 @@ int SoundGenPCJr::volumeCalc(SndGenChan *chan) {
 				chan->attenuationCopy = attenuation;
 
 				attenuation &= 0x0F;
-				attenuation += (16 - _mixer->getVolumeForSoundType(Audio::Mixer::kSFXSoundType) / 17);
+				attenuation += (16 - _mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType) / 17);
 				if (attenuation > 0x0F)
 					attenuation = 0x0F;
 			}


### PR DESCRIPTION
This looks like a regression from commit 24bb5da: AGI: Add a layer of abstraction between the sound chip and the two players

I am quite unfamiliar with this code, so I prefer to get some feedback before pushing to master.