### PR TITLE
Fix crash and wrong fullscreen mode listing when switching to OpenGL

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -57,7 +57,7 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(uint desktopWidth, uint deskt
 	}
 #else
 	const SDL_Rect *const *availableModes = SDL_ListModes(NULL, SDL_OPENGL | SDL_FULLSCREEN);
-	if (availableModes != (void *)-1) {
+	if (availableModes != NULL && availableModes != (void *)-1) {
 		for (;*availableModes; ++availableModes) {
 			const SDL_Rect *mode = *availableModes;
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -236,6 +236,9 @@ protected:
 	};
 	VideoState _videoMode, _oldVideoMode;
 
+	// Original BPP to restore the video mode on unload
+	uint8 _originalBitsPerPixel;
+
 	/** Force full redraw on next updateScreen */
 	bool _forceFull;
 


### PR DESCRIPTION
This fixes an issue when switching to the OpenGL renderer on Windows 8 and later. On those systems, SDL seems to only detects 32bpp modes for fullscreen OpenGL. 

In the OpenGL renderer, we call SDL_ListModes with NULL as the format argument. This causes SDL to use the currently selected screen format as a base to list available modes. On initial load, this format is set to the "best" available (32bpp).

This results in the following behavior:
 - When ScummVM starts in OpenGL mode, the available modes will be listed using 32bpp. Initialization will succeed.
 - When ScummVM starts in non-OpenGL mode, the available OpenGL modes are also listed using 32bpp. The SDL surface renderer then switches the video mode to 16bpp. When switching to OpenGL later, the OpenGL graphics manager is initialized again but SDL_ListModes will now use 16bpp internally, resulting in NULL being returned (and a crash before commit ed3a32a).

Note: This was only tested on Windows 10 with SDL 1.2