### PR TITLE
Add support for Visual Studio 2015 to create_project

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -46,7 +46,7 @@
 
 	#if defined(WIN32)
 
-		#ifdef _MSC_VER
+		#if defined(_MSC_VER) && _MSC_VER <= 1800
 
 		// FIXME: The placement of the workaround functions for MSVC below
 		// require us to include stdio.h and stdarg.h for MSVC here. This

--- a/devtools/README
+++ b/devtools/README
@@ -72,8 +72,8 @@ create_mort (Strangerke)
 
 create_project (LordHoto, Littleboy)
 --------------
-    Creates project files for Visual Studio 2008, 2010, 2012, 2013, Xcode and
-    Code::Blocks out of the configure / Makefile based build system.
+    Creates project files for Visual Studio 2008, 2010, 2012, 2013, 2015,
+    Xcode and Code::Blocks out of the configure / Makefile based build system.
     It also offers a way to enable or disable certain engines and the use
     of external libraries similar to configure. Run the tool without
     any arguments for further help.

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
 	setup.features = getAllFeatures();
 
 	ProjectType projectType = kProjectNone;
-	int msvcVersion = 9;
+	int msvcVersion = 12;
 	bool useSDL2 = false;
 
 	// Parse command line arguments
@@ -176,7 +176,7 @@ int main(int argc, char *argv[]) {
 
 			msvcVersion = atoi(argv[++i]);
 
-			if (msvcVersion != 9 && msvcVersion != 10 && msvcVersion != 11 && msvcVersion != 12) {
+			if (msvcVersion != 9 && msvcVersion != 10 && msvcVersion != 11 && msvcVersion != 12 && msvcVersion != 14) {
 				std::cerr << "ERROR: Unsupported version: \"" << msvcVersion << "\" passed to \"--msvc-version\"!\n";
 				return -1;
 			}
@@ -449,6 +449,9 @@ int main(int argc, char *argv[]) {
 		// 4250 ('class1' : inherits 'class2::member' via dominance)
 		//   two or more members have the same name. Should be harmless
 		//
+		// 4267 ('var' : conversion from 'size_t' to 'type', possible loss of data)
+		//   throws tons and tons of warnings (no immediate plan to fix all usages)
+		//
 		// 4310 (cast truncates constant value)
 		//   used in some engines
 		//
@@ -460,6 +463,8 @@ int main(int argc, char *argv[]) {
 		//
 		// 4351 (new behavior: elements of array 'array' will be default initialized)
 		//   a change in behavior in Visual Studio 2005. We want the new behavior, so it can be disabled
+		//
+		// 4458 (declaration of 'variable' hides class member)
 		//
 		// 4512 ('class' : assignment operator could not be generated)
 		//   some classes use const items and the default assignment operator cannot be generated
@@ -506,9 +511,11 @@ int main(int argc, char *argv[]) {
 		globalWarnings.push_back("4127");
 		globalWarnings.push_back("4244");
 		globalWarnings.push_back("4250");
+		globalWarnings.push_back("4267");
 		globalWarnings.push_back("4310");
 		globalWarnings.push_back("4345");
 		globalWarnings.push_back("4351");
+		globalWarnings.push_back("4458");
 		globalWarnings.push_back("4512");
 		globalWarnings.push_back("4702");
 		globalWarnings.push_back("4706");
@@ -632,6 +639,7 @@ void displayHelp(const char *exe) {
 	        "                           10 stands for \"Visual Studio 2010\"\n"
 	        "                           11 stands for \"Visual Studio 2012\"\n"
 	        "                           12 stands for \"Visual Studio 2013\"\n"
+	        "                           14 stands for \"Visual Studio 2015\"\n"
 	        "                           The default is \"9\", thus \"Visual Studio 2008\"\n"
 	        " --build-events           Run custom build events as part of the build\n"
 	        "                          (default: false)\n"
@@ -654,9 +662,9 @@ void displayHelp(const char *exe) {
 	        "Optional features settings:\n"
 	        " --enable-<name>          enable inclusion of the feature \"name\"\n"
 	        " --disable-<name>         disable inclusion of the feature \"name\"\n"
-			"\n"
-			"SDL settings:\n"
-			" --sdl2                   link to SDL 2.0, instead of SDL 1.2\n"
+	        "\n"
+	        "SDL settings:\n"
+	        " --sdl2                   link to SDL 2.0, instead of SDL 1.2\n"
 	        "\n"
 	        " There are the following features available:\n"
 	        "\n";
@@ -917,7 +925,7 @@ const Feature s_features[] = {
 	{    "libz",        "USE_ZLIB", "zlib",             true, "zlib (compression) support" },
 	{     "mad",         "USE_MAD", "libmad",           true, "libmad (MP3) support" },
 	{  "vorbis",      "USE_VORBIS", "libvorbisfile_static libvorbis_static libogg_static", true, "Ogg Vorbis support" },
-	{    "flac",        "USE_FLAC", "libFLAC_static",   true, "FLAC support" },
+	{    "flac",        "USE_FLAC", "libFLAC_static win_utf8_io_static",   true, "FLAC support" },
 	{     "png",         "USE_PNG", "libpng",           true, "libpng support" },
 	{    "faad",        "USE_FAAD", "libfaad",          false, "AAC support" },
 	{   "mpeg2",       "USE_MPEG2", "libmpeg2",         false, "MPEG-2 support" },
@@ -1046,7 +1054,7 @@ bool producesObjectFile(const std::string &fileName) {
 }
 
 std::string toString(int num) {
-    return static_cast<std::ostringstream*>(&(std::ostringstream() << num))->str();
+	return static_cast<std::ostringstream*>(&(std::ostringstream() << num))->str();
 }
 
 /**

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -55,7 +55,14 @@ int MSBuildProvider::getVisualStudioVersion() {
 	if (_version == 12)
 		return 2013;
 
+	if (_version == 14)
+		return 14;
+
 	error("Unsupported version passed to getVisualStudioVersion");
+}
+
+int MSBuildProvider::getSolutionVersion() {
+	return (_version < 14) ? _version + 1 : _version;
 }
 
 namespace {
@@ -116,7 +123,7 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 	// Shared configuration
 	project << "\t<Import Project=\"$(VCTargetsPath)\\Microsoft.Cpp.Default.props\" />\n";
 
-    std::string version = "v" + toString(_version) + "0";
+	std::string version = "v" + toString(_version) + "0";
 	std::string llvm = "LLVM-vs" + toString(getVisualStudioVersion());
 
 	outputConfigurationType(setup, project, name, "Release|Win32", version);
@@ -177,6 +184,13 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 		project << "\t</ItemGroup>\n";
 	}
 
+	// Visual Studio 2015 automatically imports natvis files that are part of the project
+	if (name == PROJECT_NAME && _version == 14) {
+		project << "\t<ItemGroup>\n";
+		project << "\t\t<None Include=\"" << setup.srcDir << "/devtools/create_project/scripts/scummvm.natvis\" />\n";
+		project << "\t</ItemGroup>\n";
+	}
+
 	project << "\t<Import Project=\"$(VCTargetsPath)\\Microsoft.Cpp.targets\" />\n"
 	           "\t<ImportGroup Label=\"ExtensionTargets\">\n"
 	           "\t</ImportGroup>\n";
@@ -185,7 +199,7 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 		// We override the normal target to ignore the exit code (this allows us to have a clean output and not message about the command exit code)
 		project << "\t\t<Target Name=\"PostBuildEvent\">\n"
 		        << "\t\t\t<Message Text=\"Description: Run tests\" />\n"
-				<< "\t\t\t<Exec Command=\"$(TargetPath)\"  IgnoreExitCode=\"true\" />\n"
+		        << "\t\t\t<Exec Command=\"$(TargetPath)\"  IgnoreExitCode=\"true\" />\n"
 		        << "\t\t</Target>\n";
 	}
 
@@ -304,6 +318,13 @@ void MSBuildProvider::outputProjectSettings(std::ofstream &project, const std::s
 
 		for (StringList::const_iterator i = setup.libraries.begin(); i != setup.libraries.end(); ++i)
 			libraries += *i + ".lib;";
+
+		if (_version == 14)
+		{
+			std::string debug = isRelease ? "" : "d";
+			libraries += "libvcruntime" + debug + ".lib;";
+			libraries += "libucrt" + debug + ".lib;";
+		}
 
 		project << "\t\t<Link>\n"
 		           "\t\t\t<OutputFile>$(OutDir)" << ((setup.devTools || setup.tests) ? name : setup.projectName) << ".exe</OutputFile>\n"

--- a/devtools/create_project/msbuild.h
+++ b/devtools/create_project/msbuild.h
@@ -49,6 +49,7 @@ protected:
 	const char *getProjectExtension();
 	const char *getPropertiesExtension();
 	int getVisualStudioVersion();
+	int getSolutionVersion();
 
 private:
 	struct FileEntry {

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -52,7 +52,7 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 	if (!solution)
 		error("Could not open \"" + setup.outputDir + '/' + setup.projectName + ".sln\" for writing");
 
-	solution << "Microsoft Visual Studio Solution File, Format Version " << _version + 1 << ".00\n";
+	solution << "Microsoft Visual Studio Solution File, Format Version " << getSolutionVersion() << ".00\n";
 	solution << "# Visual Studio " << getVisualStudioVersion() << "\n";
 
 	// Write main project
@@ -157,13 +157,17 @@ void MSVCProvider::createGlobalProp(const BuildSetup &setup) {
 	outputGlobalPropFile(setup, properties, 64, x64Defines, convertPathToWin(setup.filePrefix), setup.runBuildEvents);
 }
 
+int MSVCProvider::getSolutionVersion() {
+	return _version + 1;
+}
+
 std::string MSVCProvider::getPreBuildEvent() const {
 	std::string cmdLine = "";
 
 	cmdLine = "@echo off\n"
 	          "echo Executing Pre-Build script...\n"
-			  "echo.\n"
-			  "@call &quot;$(SolutionDir)../../devtools/create_project/scripts/prebuild.cmd&quot; &quot;$(SolutionDir)/../..&quot;  &quot;$(TargetDir)&quot;\n"
+	          "echo.\n"
+	          "@call &quot;$(SolutionDir)../../devtools/create_project/scripts/prebuild.cmd&quot; &quot;$(SolutionDir)/../..&quot;  &quot;$(TargetDir)&quot;\n"
 	          "EXIT /B0";
 
 	return cmdLine;

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -83,6 +83,11 @@ protected:
 	virtual int getVisualStudioVersion() = 0;
 
 	/**
+	 * Get the Solution version (used in the sln file header)
+	 */
+	virtual int getSolutionVersion();
+
+	/**
 	 * Get the command line for the revision tool (shared between all Visual Studio based providers)
 	 */
 	std::string getPreBuildEvent() const;

--- a/devtools/create_project/msvc14/create_project.sln
+++ b/devtools/create_project/msvc14/create_project.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "create_project", "create_project.vcxproj", "{CF177559-077D-4A08-AABE-BE0FD35F6C63}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF177559-077D-4A08-AABE-BE0FD35F6C63}.Debug|Win32.ActiveCfg = Debug|Win32
+		{CF177559-077D-4A08-AABE-BE0FD35F6C63}.Debug|Win32.Build.0 = Debug|Win32
+		{CF177559-077D-4A08-AABE-BE0FD35F6C63}.Debug|x64.ActiveCfg = Debug|x64
+		{CF177559-077D-4A08-AABE-BE0FD35F6C63}.Debug|x64.Build.0 = Debug|x64
+		{CF177559-077D-4A08-AABE-BE0FD35F6C63}.Release|Win32.ActiveCfg = Release|Win32
+		{CF177559-077D-4A08-AABE-BE0FD35F6C63}.Release|Win32.Build.0 = Release|Win32
+		{CF177559-077D-4A08-AABE-BE0FD35F6C63}.Release|x64.ActiveCfg = Release|x64
+		{CF177559-077D-4A08-AABE-BE0FD35F6C63}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/devtools/create_project/msvc14/create_project.vcxproj
+++ b/devtools/create_project/msvc14/create_project.vcxproj
@@ -1,0 +1,222 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{CF177559-077D-4A08-AABE-BE0FD35F6C63}</ProjectGuid>
+    <RootNamespace>create_project</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <DisableSpecificWarnings>4003;4512;4127</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+    <PostBuildEvent>
+      <Command>@echo off
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc14\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc12\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc11\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc10\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc9\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc8\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\codeblocks\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\iphone\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <DisableSpecificWarnings>4003;4512;4127</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+    <PostBuildEvent>
+      <Command>@echo off
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc14\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc12\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc11\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc10\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc9\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc8\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\codeblocks\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\iphone\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4003;4512;4127</DisableSpecificWarnings>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+    <PostBuildEvent>
+      <Command>@echo off
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc14\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc12\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc11\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc10\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc9\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc8\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\codeblocks\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\iphone\"</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4003;4512;4127</DisableSpecificWarnings>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <PostBuildEvent>
+      <Command>@echo off
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc14\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc12\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc11\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc10\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc9\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\msvc8\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\codeblocks\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)\..\..\..\dists\iphone\"</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\codeblocks.cpp" />
+    <ClCompile Include="..\create_project.cpp" />
+    <ClCompile Include="..\msbuild.cpp" />
+    <ClCompile Include="..\msvc.cpp" />
+    <ClCompile Include="..\visualstudio.cpp" />
+    <ClCompile Include="..\xcode.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\codeblocks.h" />
+    <ClInclude Include="..\config.h" />
+    <ClInclude Include="..\create_project.h" />
+    <ClInclude Include="..\msbuild.h" />
+    <ClInclude Include="..\msvc.h" />
+    <ClInclude Include="..\visualstudio.h" />
+    <ClInclude Include="..\xcode.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\scripts\installer.vbs" />
+    <None Include="..\scripts\postbuild.cmd" />
+    <None Include="..\scripts\prebuild.cmd" />
+    <None Include="..\scripts\revision.vbs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="..\scripts\scummvm.natvis" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/devtools/create_project/msvc14/create_project.vcxproj.filters
+++ b/devtools/create_project/msvc14/create_project.vcxproj.filters
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{2e3580c8-ec3a-4c81-8351-b668c668db2a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{31aaf58c-d3cb-4ed6-8eca-163b4a9b31a6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="scripts">
+      <UniqueIdentifier>{f980f6fb-41b6-4161-b035-58b200c85cad}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\codeblocks.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\create_project.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\msvc.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\msbuild.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\visualstudio.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\xcode.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\codeblocks.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\create_project.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\msvc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\msbuild.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\visualstudio.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xcode.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\scripts\prebuild.cmd">
+      <Filter>scripts</Filter>
+    </None>
+    <None Include="..\scripts\revision.vbs">
+      <Filter>scripts</Filter>
+    </None>
+    <None Include="..\scripts\postbuild.cmd">
+      <Filter>scripts</Filter>
+    </None>
+    <None Include="..\scripts\installer.vbs">
+      <Filter>scripts</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="..\scripts\scummvm.natvis">
+      <Filter>scripts</Filter>
+    </Natvis>
+  </ItemGroup>
+</Project>

--- a/dists/msvc14/create_msvc14.bat
+++ b/dists/msvc14/create_msvc14.bat
@@ -1,0 +1,105 @@
+@echo off
+
+echo.
+echo Automatic creation of the MSVC14 project files
+echo.
+
+if "%~1"=="/stable" goto stable
+if "%~1"=="/STABLE" goto stable
+if "%~1"=="/all"    goto all
+if "%~1"=="/ALL"    goto all
+if "%~1"=="/tools"  goto tools
+if "%~1"=="/TOOLS"  goto tools
+if "%~1"=="/tests"  goto tests
+if "%~1"=="/TESTS"  goto tests
+if "%~1"=="/clean"  goto clean_check
+if "%~1"=="/CLEAN"  goto clean_check
+if "%~1"=="/help"   goto command_help
+if "%~1"=="/HELP"   goto command_help
+if "%~1"=="/?"      goto command_help
+
+if "%~1"==""        goto check_tool
+
+echo Invalid command parameter: %~1
+echo.
+
+:command_help
+echo Valid command parameters are:
+echo   stable   Generated stable engines project files
+echo   all      Generate all engines project files
+echo   tools    Generate project files for the devtools
+echo   clean    Clean generated project files
+echo   help     Show help message
+goto done
+
+:check_tool
+if not exist create_project.exe goto no_tool
+
+:question
+echo.
+set batchanswer=S
+set /p batchanswer="Enable stable engines only, or all engines? (S/a)"
+if "%batchanswer%"=="s" goto stable
+if "%batchanswer%"=="S" goto stable
+if "%batchanswer%"=="a" goto all
+if "%batchanswer%"=="A" goto all
+goto question
+
+:no_tool
+echo create_project.exe not found in the current folder.
+echo You need to build it first and copy it in this
+echo folder
+goto done
+
+:all
+echo.
+echo Creating project files with all engines enabled (stable and unstable)
+echo.
+create_project ..\.. --enable-all-engines --msvc --msvc-version 14 --build-events
+goto done
+
+:stable
+echo.
+echo Creating normal project files, with only the stable engines enabled
+echo.
+create_project ..\.. --msvc --msvc-version 14
+goto done
+
+:tools
+echo.
+echo Creating tools project files
+echo.
+create_project ..\.. --tools --msvc --msvc-version 14
+goto done
+
+:tests
+echo.
+echo Creating tests project files
+echo.
+create_project ..\.. --tests --msvc --msvc-version 14
+goto done
+
+:clean_check
+echo.
+set cleananswer=N
+set /p cleananswer="This will remove all project files. Are you sure you want to continue? (N/y)"
+if "%cleananswer%"=="n" goto done
+if "%cleananswer%"=="N" goto done
+if "%cleananswer%"=="y" goto clean
+if "%cleananswer%"=="Y" goto clean
+goto clean_check
+
+:clean
+echo.
+echo Removing all project files
+del /Q *.vcxproj* > NUL 2>&1
+del /Q *.props > NUL 2>&1
+del /Q *.sln* > NUL 2>&1
+del /Q scummvm* > NUL 2>&1
+del /Q devtools* > NUL 2>&1
+del /Q test_runner.cpp > NUL 2>&1
+goto done
+
+:done
+echo.
+pause

--- a/dists/msvc14/readme.txt
+++ b/dists/msvc14/readme.txt
@@ -1,0 +1,6 @@
+The Visual Studio project files can now be created automatically from the GCC
+files using the create_project tool inside the /devtools/create_project folder.
+
+To create the default project files, build create_project.exe, copy it inside
+this folder and run the create_msvc14.bat file for a default build. You can run
+create_project.exe with no parameters to check the possible command-line options.


### PR DESCRIPTION
This adds support for the new version of Visual Studio. 

Note that an updated set of libraries is required for proper linking and they are not backward compatible with VS 2013. You can grab pre-built libraries from the [scummvm-libs](https://github.com/Templier/scummvm-libs) repository. I can transfer that repository to the organization if desired or let the maintainers update the scummvm_vs_libs.zip package instead.

Tested:
 - Visual Studio 2015 RC in debug and release (win32 & x64)
 - Visual Studio 2013 (using the current library pack)

Tasks to complete before this can be merged:
 - [ ] Do not ignore new warnings (C4267 and C4458)
 - [ ] Recreate the scummvm-libs repository to compile for both VS2013 and VS2015
 - [ ] Update create_project to read 2015 and pre-2015 libraries from different folders
 - [ ] Write script to automate building all libraries
 - [ ] Document process to add/update a library in the repository (using git subtree)
 - [ ] Update wiki with new process to get pre-built binaries for Visual Studio
 - [ ] Transfer ownership of repository to ScummVM organization
 - [ ] Update script to allow building MinGW libraries too (optional)