### PR TITLE
SHERLOCK : fix compilation in Symbian

### DIFF
--- a/engines/sherlock/scalpel/tsage/logo.h
+++ b/engines/sherlock/scalpel/tsage/logo.h
@@ -34,6 +34,10 @@
 #include "sherlock/scalpel/tsage/resources.h"
 #include "sherlock/screen.h"
 
+#ifdef __SYMBIAN32__
+#undef remove
+#endif //__SYMBIAN32__
+
 namespace Sherlock {
 namespace Scalpel {
 


### PR DESCRIPTION
In file included from D:\Symbian\Projects\SDL\scummvm\engines\sherlock\scalpel\scalpel.cpp:29:
D:\Symbian\Projects\SDL\scummvm\engines\sherlock/scalpel/tsage/logo.h:191: macro `remove' used without args
ERROR: cpp.EXE failure
make: *** [MAKEFILESCUMMVM_SHERLOCK] Error 33