### PR TITLE
SYMBIAN : fix compilation

### DIFF
--- a/engines/sherlock/events.h
+++ b/engines/sherlock/events.h
@@ -30,7 +30,7 @@
 
 namespace Sherlock {
 
-#define GAME_FRAME_RATE 50
+#define GAME_FRAME_RATE 30
 #define GAME_FRAME_TIME (1000 / GAME_FRAME_RATE)
 
 enum CursorId { ARROW = 0, MAGNIFY = 1, WAIT = 2, EXIT_ZONES_START = 5, INVALID_CURSOR = -1 };


### PR DESCRIPTION
This commit fixes compilation error due conflict between builting macro "remove" and various functions named "remove" in engines