### PR TITLE
Fix regression in MP3 decoder

### DIFF
--- a/audio/decoders/aiff.cpp
+++ b/audio/decoders/aiff.cpp
@@ -102,7 +102,7 @@ RewindableAudioStream *makeAIFFStream(Common::SeekableReadStream *stream, Dispos
 	bool foundSSND = false;
 
 	uint16 channels = 0, bitsPerSample = 0;
-	uint32 blockAlign = 0, rate = 0;
+	uint32 rate = 0;
 	uint32 codec = kCodecPCM; // AIFF default
 	Common::SeekableReadStream *dataStream = 0;
 
@@ -128,7 +128,7 @@ RewindableAudioStream *makeAIFFStream(Common::SeekableReadStream *stream, Dispos
 		case MKTAG('S', 'S', 'N', 'D'):
 			foundSSND = true;
 			/* uint32 offset = */ stream->readUint32BE();
-			blockAlign = stream->readUint32BE();
+			/* uint32 blockAlign = */ stream->readUint32BE();
 			dataStream = new Common::SeekableSubReadStream(stream, stream->pos(), stream->pos() + length - 8, disposeAfterUse);
 			break;
 		case MKTAG('F', 'V', 'E', 'R'):

--- a/audio/decoders/mp3.cpp
+++ b/audio/decoders/mp3.cpp
@@ -331,7 +331,11 @@ MP3Stream::MP3Stream(Common::SeekableReadStream *inStream, DisposeAfterUse::Flag
 		_length(0, 1000) {
 
 	// Initialize the stream with some data
+	// This is also necessary so that _frame
+	// is setup and we can retrieve channels/rate.
 	decodeMP3Data(*_inStream);
+	_channels = MAD_NCHANNELS(&_frame.header);
+	_rate = _frame.header.samplerate;
 
 	// Calculate the length of the stream
 	while (_state != MP3_STATE_EOS)
@@ -351,13 +355,6 @@ MP3Stream::MP3Stream(Common::SeekableReadStream *inStream, DisposeAfterUse::Flag
 	// Reinit stream
 	_state = MP3_STATE_INIT;
 	_inStream->seek(0);
-
-	// Decode the first chunk of data. This is necessary so that _frame
-	// is setup and we can retrieve channels/rate.
-	decodeMP3Data(*_inStream);
-
-	_channels = MAD_NCHANNELS(&_frame.header);
-	_rate = _frame.header.samplerate;
 }
 
 int MP3Stream::readBuffer(int16 *buffer, const int numSamples) {


### PR DESCRIPTION
Commit 562234b96b37a8944b6c626354220f5d21357dee introduced a regression in MP3Stream: _rate was used uninitialised which caused issue https://github.com/residualvm/residualvm/issues/1212 in residualvm:

<pre>
==11139== Conditional jump or move depends on uninitialised value(s)
==11139==    at 0x8AD9BC: Audio::MP3Stream::MP3Stream(Common::SeekableReadStream*, DisposeAfterUse::Flag) (mp3.cpp:346)
==11139==    by 0x8AE923: Audio::makeMP3Stream(Common::SeekableReadStream*, DisposeAfterUse::Flag) (mp3.cpp:521)
==11139==    by 0x4EDEA7: Grim::MP3Track::openSound(Common::String const&, Common::String const&, Audio::Timestamp const*) (mp3track.cpp:182)
==11139==    by 0x46F430: Grim::EMISound::initTrack(Common::String const&, Audio::Mixer::SoundType, Audio::Timestamp const*) const (emisound.cpp:456)
==11139==    by 0x46FA39: Grim::EMISound::setMusicState(int) (emisound.cpp:548)
==11139==    by 0x463998: Grim::SoundPlayer::setMusicState(int) (sound.cpp:82)
==11139==    by 0x41F194: Grim::GrimEngine::mainLoop() (grim.cpp:863)
==11139==    by 0x41CFE5: Grim::GrimEngine::run() (grim.cpp:369)
==11139==    by 0x40A581: runGame(PluginSubclass<MetaEngine> const*, OSystem&, Common::String const&) (main.cpp:231)
==11139==    by 0x40B340: scummvm_main (main.cpp:477)
==11139==    by 0x40920D: main (posix-main.cpp:45)
</pre>

The first commit fixes this problem.

Additionally, I added another small commit to prevent a compiler warning about a set, but otherwise unused variable.
