### PR TITLE
CINE: Show splash screen in CD version of Future Wars

### DIFF
--- a/engines/cine/cine.cpp
+++ b/engines/cine/cine.cpp
@@ -22,10 +22,14 @@
 
 #include "common/config-manager.h"
 #include "common/debug-channels.h"
+#include "common/events.h"
 
 #include "engines/util.h"
 
 #include "graphics/cursorman.h"
+#include "graphics/palette.h"
+
+#include "image/iff.h"
 
 #include "cine/cine.h"
 #include "cine/bg_list.h"
@@ -89,6 +93,10 @@ void CineEngine::syncSoundSettings() {
 }
 
 Common::Error CineEngine::run() {
+	if (g_cine->getGameType() == GType_FW && (g_cine->getFeatures() & GF_CD)) {
+		showSplashScreen();
+	}
+
 	// Initialize backend
 	initGraphics(320, 200, false);
 
@@ -237,6 +245,47 @@ void CineEngine::initialize() {
 		strcpy(currentPrcName, BOOT_PRC_NAME);
 		setMouseCursor(MOUSE_CURSOR_NORMAL);
 	}
+}
+
+void CineEngine::showSplashScreen() {
+	Common::File file;
+	if (!file.open("sony.lbm"))
+		return;
+
+	Image::IFFDecoder decoder;
+	if (!decoder.loadStream(file))
+		return;
+
+	const Graphics::Surface *surface = decoder.getSurface();
+	if (surface->w == 640 && surface->h == 480) {
+		initGraphics(640, 480, true);
+
+		const byte *palette = decoder.getPalette();
+		int paletteColorCount = decoder.getPaletteColorCount();
+		g_system->getPaletteManager()->setPalette(palette, 0, paletteColorCount);
+
+		g_system->copyRectToScreen(surface->getPixels(), 640, 0, 0, 640, 480);
+		g_system->updateScreen();
+
+		Common::EventManager *eventMan = g_system->getEventManager();
+
+		bool done = false;
+		uint32 now = g_system->getMillis();
+
+		while (!done && g_system->getMillis() - now < 2000) {
+			Common::Event event;
+			while (eventMan->pollEvent(event)) {
+				if (event.type == Common::EVENT_KEYDOWN && event.kbd.keycode == Common::KEYCODE_ESCAPE) {
+					done = true;
+					break;
+				}
+				if (shouldQuit())
+					done = true;
+			}
+		}
+	}
+
+	decoder.destroy();
 }
 
 } // End of namespace Cine

--- a/engines/cine/cine.h
+++ b/engines/cine/cine.h
@@ -145,6 +145,7 @@ public:
 
 private:
 	void initialize();
+	void showSplashScreen();
 	void resetEngine();
 	bool loadPlainSaveFW(Common::SeekableReadStream &in, CineSaveGameFormat saveGameFormat);
 	bool loadTempSaveOS(Common::SeekableReadStream &in);


### PR DESCRIPTION
This simply shows the Sony splash screen included with the CD version of Future Wars. I think it does all the necessary sanity checking and cleanups, though some might find it a bit hackish.