### PR TITLE
NEVERHOOD: Don't crash when loading savegames with a high slot ID

### DIFF
--- a/engines/neverhood/menumodule.cpp
+++ b/engines/neverhood/menumodule.cpp
@@ -93,6 +93,10 @@ void MenuModule::setLoadgameInfo(uint index) {
 	_savegameSlot = (*_savegameList)[index].slotNum;
 }
 
+void MenuModule::setLoadgameSlot(int slot) {
+	_savegameSlot = slot;
+}
+
 void MenuModule::setSavegameInfo(const Common::String &description, uint index, bool newSavegame) {
 	_savegameDescription = description;
 	_savegameSlot = newSavegame ? -1 : (*_savegameList)[index].slotNum;
@@ -912,7 +916,7 @@ GameStateMenu::GameStateMenu(NeverhoodEngine *vm, Module *parentModule, Savegame
 
 		if (slot >= 0) {
 			if (!isSave) {
-				((MenuModule*)_parentModule)->setLoadgameInfo(slot);
+				((MenuModule*)_parentModule)->setLoadgameSlot(slot);
 			} else {
 				((MenuModule*)_parentModule)->setSavegameInfo(saveDesc,
 					slot, slot >= saveCount);

--- a/engines/neverhood/menumodule.h
+++ b/engines/neverhood/menumodule.h
@@ -43,6 +43,7 @@ public:
 	MenuModule(NeverhoodEngine *vm, Module *parentModule, int which);
 	virtual ~MenuModule();
 	void setLoadgameInfo(uint index);
+	void setLoadgameSlot(int slot);
 	void setSavegameInfo(const Common::String &description, uint index, bool newSavegame);
 	void setDeletegameInfo(uint index);
 	void refreshSaveGameList();


### PR DESCRIPTION
If you have a list of savegames with a gap in the middle:
  neverhood-win.000
  neverhood-win.001
  neverhood-win.003

loading a savegame after the gap will cause a crash.
This is caused by a confusion in the code between ScummVM's slot (3 in this case),
and the index in the engine's savegame array.