### PR TITLE
NEVERHOOD: Possible fix for bad car behaviour

### DIFF
--- a/engines/neverhood/modules/module2700.cpp
+++ b/engines/neverhood/modules/module2700.cpp
@@ -761,7 +761,7 @@ void Scene2702::moveCarToPoint(NPoint pt) {
 	_tracks.findTrackPoint(pt, minMatchTrackIndex, minMatchDistance, _dataResource);
 	if (minMatchTrackIndex >= 0 && minMatchTrackIndex != _currTrackIndex) {
 		_newTrackIndex = minMatchTrackIndex;
-		_newTrackDestX = pt.x;
+		_newTrackDest = pt;
 		if (_isUpperTrack) {
 			if (_currTrackIndex == 0)
 				sendMessage(_asCar, 0x2003, _trackPoints->size() - 1);
@@ -790,7 +790,7 @@ void Scene2702::changeTrack() {
 		sendMessage(_asCar, NM_POSITION_CHANGE, 0);
 	else
 		sendMessage(_asCar, NM_POSITION_CHANGE, _trackPoints->size() - 1);
-	sendMessage(_asCar, 0x2004, _newTrackDestX);
+	sendMessage(_asCar, 0x2004, _newTrackDest);
 	_newTrackIndex = -1;
 }
 
@@ -1092,7 +1092,7 @@ void Scene2706::moveCarToPoint(NPoint pt) {
 	_tracks.findTrackPoint(pt, minMatchTrackIndex, minMatchDistance, _dataResource);
 	if (minMatchTrackIndex >= 0 && minMatchTrackIndex != _currTrackIndex) {
 		_newTrackIndex = minMatchTrackIndex;
-		_newTrackDestX = pt.x;
+		_newTrackDest = pt;
 		if (_currTrackIndex == 0)
 			sendMessage(_asCar, 0x2003, _trackPoints->size() - 1);
 		else
@@ -1111,7 +1111,7 @@ void Scene2706::changeTrack() {
 		sendMessage(_asCar, NM_POSITION_CHANGE, _trackPoints->size() - 1);
 	else
 		sendMessage(_asCar, NM_POSITION_CHANGE, 0);
-	sendMessage(_asCar, 0x2004, _newTrackDestX);
+	sendMessage(_asCar, 0x2004, _newTrackDest);
 	_newTrackIndex = -1;
 }
 

--- a/engines/neverhood/modules/module2700.cpp
+++ b/engines/neverhood/modules/module2700.cpp
@@ -773,7 +773,7 @@ void Scene2702::moveCarToPoint(NPoint pt) {
 			sendMessage(_asCar, 0x2003, _trackPoints->size() - 1);
 	} else {
 		_newTrackIndex = -1;
-		sendMessage(_asCar, 0x2004, pt.x);
+		sendMessage(_asCar, 0x2004, pt);
 	}
 }
 
@@ -1099,7 +1099,7 @@ void Scene2706::moveCarToPoint(NPoint pt) {
 			sendMessage(_asCar, 0x2003, 0);
 	} else {
 		_newTrackIndex = -1;
-		sendMessage(_asCar, 0x2004, pt.x);
+		sendMessage(_asCar, 0x2004, pt);
 	}
 }
 

--- a/engines/neverhood/modules/module2700.h
+++ b/engines/neverhood/modules/module2700.h
@@ -76,7 +76,7 @@ protected:
 	Sprite *_asCarShadow;
 	Sprite *_asCarTrackShadow;
 	Sprite *_asCarConnectorShadow;
-	int16 _newTrackDestX;
+	NPoint _newTrackDest;
 	bool _isInLight;
 	int _currTrackIndex, _newTrackIndex;
 	bool _isUpperTrack;
@@ -132,7 +132,7 @@ protected:
 	Sprite *_asCarConnector;
 	Sprite *_asCarTrackShadow;
 	Sprite *_asCarConnectorShadow;
-	int16 _newTrackDestX;
+	NPoint _newTrackDest;
 	int _currTrackIndex, _newTrackIndex;
 	Tracks _tracks;
 	NPointArray *_trackPoints;


### PR DESCRIPTION
This is a possible fix for a glitch in The Neverhood that in some cases causes the car to move up even though you're clicking on a spot below it. I'm not sure if it's the correct fix, but I couldn't find any developer familiar with the engine to discuss it with. And even if it's the correct fix, it's possible that the same reasoning also applies to other parts of the code.

There is an overly long commit message that explains the details, as I understand them, but the short version is that a message is sent to the car with the coordinate to travel to, but it only has an X coordinate. The Y coordinate is always zero.