### PR TITLE
DEVTOOLS: Ignore *.opendb files generated by VS 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ Thumbs.db
 *.sbr
 *.sdf
 *.opensdf
+*.opendb
 obj/
 _ReSharper*/
 ipch/


### PR DESCRIPTION
This commit adds all temporary .opendb files to the .gitignore file.

.opendb files are generated by Visual Studio 2015 during compilation. They are hidden in the file system and seem to be temporary.