### PR TITLE
SCI: Fixes compilation when SCI32 is disabled

### DIFF
--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -619,11 +619,11 @@ void SciEngine::initGraphics() {
 	_gfxPaint = 0;
 	_gfxPaint16 = 0;
 	_gfxPalette16 = 0;
-	_gfxPalette32 = 0;
 	_gfxPorts = 0;
 	_gfxText16 = 0;
 	_gfxTransitions = 0;
 #ifdef ENABLE_SCI32
+	_gfxPalette32 = 0;
 	_gfxControls32 = 0;
 	_gfxText32 = 0;
 	_robotDecoder = 0;

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -346,7 +346,6 @@ public:
 	GfxCursor *_gfxCursor;
 	GfxMenu *_gfxMenu; // Menu for 16-bit gfx
 	GfxPalette *_gfxPalette16;
-	GfxPalette32 *_gfxPalette32; // Palette for 32-bit gfx
 	GfxPaint *_gfxPaint;
 	GfxPaint16 *_gfxPaint16; // Painting in 16-bit gfx
 	GfxPaint32 *_gfxPaint32; // Painting in 32-bit gfx
@@ -358,6 +357,7 @@ public:
 	GfxMacIconBar *_gfxMacIconBar; // Mac Icon Bar manager
 
 #ifdef ENABLE_SCI32
+	GfxPalette32 *_gfxPalette32; // Palette for 32-bit gfx
 	RobotDecoder *_robotDecoder;
 	GfxFrameout *_gfxFrameout; // kFrameout and the like for 32-bit gfx
 #endif


### PR DESCRIPTION
This fixes a compilation issue introduced by the recent refactoring of the SCI engine.