### PR TITLE
POSIX: Follow XDG Base Directory Specification for User's Files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,12 @@ For a more comprehensive changelog of the latest experimental code, see:
  SDL:
    - Alt-x no longer quits ScummVM on platforms exhibiting this behavior
      before. A notable example is our Windows port.
+   - On POSIX systems we now follow the XDG Base Directory Specification for
+     placement of files for users. This effectively results in new locations
+     for our configuration file, our log file, and our default savegame path.
+     We still support our previous locations. As long as they are present, we
+     continue to use them. Please refer to the README for the new locations.
+     File locations on Mac OS X are not affected by this change.
 
  3 Skulls of the Toltecs:
    - Improved AdLib music support.

--- a/README
+++ b/README
@@ -1741,7 +1741,16 @@ The platforms that currently have a different default directory are:
     $HOME/Documents/ScummVM Savegames/
 
     Other unices:
-    $HOME/.scummvm/
+    We follow the XDG Base Directory Specification. This means our
+    configuration can be found in:
+    $XDG_DATA_HOME/scummvm/saves/
+
+    If XDG_DATA_HOME is not defined or empty, ~/.local/share will be used
+    as value of XDG_DATA_HOME in accordance with the specification.
+
+    If an earlier version of ScummVM was installed on your system, the
+    previous default location of '~/.scummvm' will be kept. This is detected
+    based on the presence of the path '~/.scummvm'.
 
     Windows Vista/7:
     \Users\username\AppData\Roaming\ScummVM\Saved games\

--- a/README
+++ b/README
@@ -2329,7 +2329,15 @@ By default, the configuration file is saved in, and loaded from:
     previous default location of '<windir>\scummvm.ini' will be kept.
 
     Unix:
-    ~/.scummvmrc
+    We follow the XDG Base Directory Specification. This means our
+    configuration can be found in:
+    $XDG_CONFIG_HOME/scummvm/scummvm.ini
+
+    If XDG_CONFIG_HOME is not defined or empty, '~/.config' will be used
+    as value for XDG_CONFIG_HOME in accordance with the specification.
+
+    If an earlier version of ScummVM was installed on your system, the
+    previous default location of '~/.scummvmrc' will be kept.
 
     Mac OS X:
     ~/Library/Preferences/ScummVM Preferences

--- a/backends/fs/posix/posix-fs.h
+++ b/backends/fs/posix/posix-fs.h
@@ -81,4 +81,18 @@ private:
 	virtual void setFlags();
 };
 
+namespace Posix {
+
+/**
+ * Assure that a directory path exists.
+ *
+ * @param dir The path which is required to exist.
+ * @param prefix An (optional) prefix which should not be created if non existent.
+ *               prefix is prepended to dir if supplied.
+ * @return true in case the directoy exists (or was created), false otherwise.
+ */
+bool assureDirectoryExists(const Common::String &dir, const char *prefix = nullptr);
+
+} // End of namespace Posix
+
 #endif

--- a/backends/platform/sdl/posix/posix.cpp
+++ b/backends/platform/sdl/posix/posix.cpp
@@ -180,12 +180,20 @@ Common::WriteStream *OSystem_POSIX::createLogFile() {
 	prefix = nullptr;
 	logFile = "/mtd_ram";
 #else
-	prefix = getenv("HOME");
-	if (prefix == nullptr) {
-		return 0;
+	// On POSIX systems we follow the XDG Base Directory Specification for
+	// where to store files. The version we based our code upon can be found
+	// over here: http://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+	prefix = getenv("XDG_CACHE_HOME");
+	if (prefix == nullptr || !*prefix) {
+		prefix = getenv("HOME");
+		if (prefix == nullptr) {
+			return 0;
+		}
+
+		logFile = ".cache/";
 	}
 
-	logFile = ".scummvm/logs";
+	logFile += "scummvm/logs";
 #endif
 
 	if (!assureDirectoryExists(logFile, prefix)) {

--- a/backends/platform/sdl/posix/posix.cpp
+++ b/backends/platform/sdl/posix/posix.cpp
@@ -40,6 +40,36 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+namespace {
+/**
+ * Assure that a directory path exists.
+ *
+ * @param path The path which is required to exist.
+ * @return true in case the directoy exists (or was created), false otherwise.
+ */
+bool assureDirectoryExists(const Common::String &path) {
+	struct stat sb;
+
+	// Check whether the dir exists
+	if (stat(path.c_str(), &sb) == -1) {
+		// The dir does not exist, or stat failed for some other reason.
+		if (errno != ENOENT) {
+			return false;
+		}
+
+		// If the problem was that the path pointed to nothing, try
+		// to create the dir.
+		if (mkdir(path.c_str(), 0755) != 0) {
+			return false;
+		}
+	} else if (!S_ISDIR(sb.st_mode)) {
+		// Path is no directory. Oops
+		return false;
+	}
+
+	return true;
+}
+} // End of anonymous namespace
 
 OSystem_POSIX::OSystem_POSIX(Common::String baseConfigName)
 	:
@@ -113,20 +143,7 @@ Common::WriteStream *OSystem_POSIX::createLogFile() {
 	logFile = "/mtd_ram";
 #endif
 
-	struct stat sb;
-
-	// Check whether the dir exists
-	if (stat(logFile.c_str(), &sb) == -1) {
-		// The dir does not exist, or stat failed for some other reason.
-		if (errno != ENOENT)
-			return 0;
-
-		// If the problem was that the path pointed to nothing, try
-		// to create the dir.
-		if (mkdir(logFile.c_str(), 0755) != 0)
-			return 0;
-	} else if (!S_ISDIR(sb.st_mode)) {
-		// Path is no directory. Oops
+	if (!assureDirectoryExists(logFile)) {
 		return 0;
 	}
 
@@ -136,18 +153,7 @@ Common::WriteStream *OSystem_POSIX::createLogFile() {
 	logFile += "/logs";
 #endif
 
-	// Check whether the dir exists
-	if (stat(logFile.c_str(), &sb) == -1) {
-		// The dir does not exist, or stat failed for some other reason.
-		if (errno != ENOENT)
-			return 0;
-
-		// If the problem was that the path pointed to nothing, try
-		// to create the dir.
-		if (mkdir(logFile.c_str(), 0755) != 0)
-			return 0;
-	} else if (!S_ISDIR(sb.st_mode)) {
-		// Path is no directory. Oops
+	if (!assureDirectoryExists(logFile)) {
 		return 0;
 	}
 

--- a/backends/platform/sdl/posix/posix.cpp
+++ b/backends/platform/sdl/posix/posix.cpp
@@ -167,26 +167,33 @@ Common::WriteStream *OSystem_POSIX::createLogFile() {
 	// of a failure, we know that no log file is open.
 	_logFilePath.clear();
 
-	const char *home = getenv("HOME");
-	if (home == NULL)
-		return 0;
-
+	const char *prefix = nullptr;
 	Common::String logFile;
 #ifdef MACOSX
-	logFile = "Library/Logs";
-#elif SAMSUNGTV
-	home = nullptr;
-	logFile = "/mtd_ram";
-#else
-	logFile = ".scummvm/logs";
-#endif
-
-	if (!assureDirectoryExists(logFile, home)) {
+	prefix = getenv("HOME");
+	if (prefix == nullptr) {
 		return 0;
 	}
 
-	if (home) {
-		logFile = Common::String::format("%s/%s", home, logFile.c_str());
+	logFile = "Library/Logs";
+#elif SAMSUNGTV
+	prefix = nullptr;
+	logFile = "/mtd_ram";
+#else
+	prefix = getenv("HOME");
+	if (prefix == nullptr) {
+		return 0;
+	}
+
+	logFile = ".scummvm/logs";
+#endif
+
+	if (!assureDirectoryExists(logFile, prefix)) {
+		return 0;
+	}
+
+	if (prefix) {
+		logFile = Common::String::format("%s/%s", prefix, logFile.c_str());
 	}
 
 	logFile += "/scummvm.log";

--- a/backends/platform/sdl/posix/posix.h
+++ b/backends/platform/sdl/posix/posix.h
@@ -28,7 +28,7 @@
 class OSystem_POSIX : public OSystem_SDL {
 public:
 	// Let the subclasses be able to change _baseConfigName in the constructor
-	OSystem_POSIX(Common::String baseConfigName = ".scummvmrc");
+	OSystem_POSIX(Common::String baseConfigName = "scummvm.ini");
 	virtual ~OSystem_POSIX() {}
 
 	virtual bool hasFeature(Feature f);


### PR DESCRIPTION
This patch makes our POSIX ports use locations for configuration, log, and save games conforming to the XDG Base Directory Specification version 0.8 (right now the latest version, which can be found [here](http://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html)).

The new locations are as follows:
* Configuration file is now placed at `$XDG_CONFIG_HOME/scummvm/scummvm.ini`
* New default savegame directory is at `$XDG_DATA_HOME/scummvm/saves/`
* The log file is now placed at `$XDG_CACHE_HOME/scummvm/scummvm.log`

We still use the old locations for the configuration file and the savegame directory if those exist from a previous ScummVM installation.

This 'fixes' bug [#6036 POSIX: Use XDG dirs instead of HOME](https://sourceforge.net/p/scummvm/bugs/6036/). There is some discussion on the bug report about using a more easily visible location for save files. If we want that, we should do go for it now instead of having to worry about it again later.