### PR TITLE
Handle Alt-x internally in SCUMM.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -65,6 +65,7 @@ For a more comprehensive changelog of the latest experimental code, see:
    - Implemented original Maniac Mansion v0-v1 walking code.
    - It is now possible to play Maniac Mansion from within Day of the
      Tentacle, with a few caveats. See README for details.
+   - Alt-x can now be used to quit SCUMM games on all platforms.
 
  Tinsel:
    - Improved AdLib music support in Discworld 1.

--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,10 @@ For a more comprehensive changelog of the latest experimental code, see:
  General:
    - Updated Munt MT-32 emulation code to version 1.5.0.
 
+ SDL:
+   - Alt-x no longer quits ScummVM on platforms exhibiting this behavior
+     before. A notable example is our Windows port.
+
  3 Skulls of the Toltecs:
    - Improved AdLib music support.
 

--- a/README
+++ b/README
@@ -1505,6 +1505,7 @@ other games.
                              of the middle mouse button or wheel.
 
   SCUMM:
+    Alt-x                  - Quit
     Ctrl 0-9 and Alt 0-9   - Load and save game state
     Ctrl-d                 - Starts the debugger
     Ctrl-f                 - Toggle fast mode

--- a/README
+++ b/README
@@ -1487,7 +1487,7 @@ other games.
     Ctrl-F5                - Displays the Global Menu
     Cmd-q                  - Quit (Mac OS X)
     Ctrl-q                 - Quit (other unices including Linux)
-    Ctrl-z OR Alt-x        - Quit (other platforms)
+    Ctrl-z                 - Quit (other platforms)
     Ctrl-u                 - Mute all sounds
     Ctrl-m                 - Toggle mouse capture
     Ctrl-Alt 1-8           - Switch between graphics filters

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -545,8 +545,8 @@ bool SdlEventSource::handleKeyDown(SDL_Event &ev, Common::Event &event) {
 		return true;
 	}
 #else
-	// Ctrl-z and Alt-X quit
-	if ((event.kbd.hasFlags(Common::KBD_CTRL) && ev.key.keysym.sym == 'z') || (event.kbd.hasFlags(Common::KBD_ALT) && ev.key.keysym.sym == 'x')) {
+	// Ctrl-z quits
+	if ((event.kbd.hasFlags(Common::KBD_CTRL) && ev.key.keysym.sym == 'z')) {
 		event.type = Common::EVENT_QUIT;
 		return true;
 	}
@@ -603,11 +603,6 @@ bool SdlEventSource::handleKeyUp(SDL_Event &ev, Common::Event &event) {
 #if defined(MACOSX)
 	if ((mod & KMOD_META) && ev.key.keysym.sym == 'q')
 		return false;	// On Macintosh, Cmd-Q quits
-#elif defined(POSIX)
-	// Control Q has already been handled above
-#else
-	if ((mod & KMOD_ALT) && ev.key.keysym.sym == 'x')
-		return false;	// Alt-x quit
 #endif
 
 	// If we reached here, this isn't an event handled by handleKeyDown(), thus

--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -130,6 +130,14 @@ void ScummEngine::parseEvent(Common::Event event) {
 			_debugger->attach();
 		} else if (event.kbd.hasFlags(Common::KBD_CTRL) && event.kbd.keycode == Common::KEYCODE_s) {
 			_res->resourceStats();
+		} else if (event.kbd.hasFlags(Common::KBD_ALT) && event.kbd.keycode == Common::KEYCODE_x) {
+			// TODO: Some SCUMM games quit when Alt-x is pressed. However, not
+			// all of them seem to exhibit this behavior. LordHoto found that
+			// the Loom manual does not mention this hotkey. On the other hand
+			// the Sam&Max manual mentions that Alt-x does so on "most"
+			// platforms. We should really check which games exhibit this
+			// behavior and only use it for them.
+			quitGame();
 		} else {
 			// Normal key press, pass on to the game.
 			_keyPressed = event.kbd;


### PR DESCRIPTION
This moves handling of Alt-x to quit ScummVM to the SCUMM engine. cbd867329e018d7eca12b3a8842e52b8db9f494d suggests which is why it was added in the first place.

Alt-x is used in AGI's Leisure Suit Larry in the Land of the Lounge Lizards to skip the age protection. This pull request assures that this works on our ports formerly using Alt-x to quit ScummVM.

The README is updated accordingly and the changes are also mentioned in the NEWS file.