### PR TITLE
SWORD25: Use more appropriate function for growing the stack

### DIFF
--- a/engines/sword25/util/lua_persistence_util.cpp
+++ b/engines/sword25/util/lua_persistence_util.cpp
@@ -280,15 +280,6 @@ void lua_reallocstack(lua_State *L, int newsize) {
 	correctStack(L, oldstack);
 }
 
-void lua_growstack(lua_State *L, int n) {
-	// Double size is enough?
-	if (n <= L->stacksize) {
-		lua_reallocstack(L, 2 * L->stacksize);
-	} else {
-		lua_reallocstack(L, L->stacksize + n);
-	}
-}
-
 void lua_reallocCallInfo(lua_State *lauState, int newsize) {
 	CallInfo *oldci = lauState->base_ci;
 	lua_reallocvector(lauState, lauState->base_ci, lauState->size_ci, newsize, CallInfo);

--- a/engines/sword25/util/lua_persistence_util.h
+++ b/engines/sword25/util/lua_persistence_util.h
@@ -90,7 +90,6 @@ void unboxUpValue(lua_State *luaState);
 size_t appendStackToStack_reverse(lua_State *from, lua_State *to);
 void correctStack(lua_State *L, TValue *oldstack);
 void lua_reallocstack(lua_State *L, int newsize);
-void lua_growstack(lua_State *L, int n);
 
 void lua_reallocCallInfo(lua_State *lauState, int newsize);
 

--- a/engines/sword25/util/lua_unpersist.cpp
+++ b/engines/sword25/util/lua_unpersist.cpp
@@ -425,7 +425,7 @@ void unpersistThread(UnSerializationInfo *info, int index) {
 
 	// First, deserialize the object stack
 	uint32 stackSize = info->readStream->readUint32LE();
-	lua_growstack(info->luaState, (int)stackSize);
+	lua_checkstack(info->luaState, (int)stackSize);
 
 	// Make sure that the first stack element (a nil, representing
 	// the imaginary top-level C function) is written to the very,


### PR DESCRIPTION
The call to lua_growstack in unpersistThread would unconditionally at
least double the size of the stack. This caused memory usage to grow
exponentially (literally) with the number of serialized threads.

Bugs #6977, #6999.