### PR TITLE
IOS: Adds support for iPad

### DIFF
--- a/dists/ios7/Info.plist
+++ b/dists/ios7/Info.plist
@@ -26,6 +26,11 @@
 	<string>1.8.0pre</string>
 	<key>UIApplicationExitsOnSuspend</key>
 	<false/>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchImages</key>

--- a/dists/ios7/Info.plist.in
+++ b/dists/ios7/Info.plist.in
@@ -26,6 +26,11 @@
 	<string>@VERSION@</string>
 	<key>UIApplicationExitsOnSuspend</key>
 	<false/>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchImages</key>


### PR DESCRIPTION
These keys are automatically added by Xcode when one compiles a regular Xcode project, but are missing when compiling from the command line.