### PR TITLE
AMIGAOS: Fix amigaos.mk to make the rexx script work on local builds

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -11,8 +11,13 @@ ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) $(AMIGAOSPATH)/extras/
 endif
 	cat ${srcdir}/README | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
-	rx dists/amiga/RM2AG.rx README.conv
+	// AREXX doesn't understand makefile variables in it's execution path, i.e. ${srcdir}.
+	// It will break with a Program not found error. Therefore copying the script to cwd
+	// and removing it again once it finished.
+	cp ${srcdir}/dists/amiga/RM2AG.rx ${srcdir}
+	rx RM2AG.rx README.conv
 	cp README.guide $(AMIGAOSPATH)
+	rm RM2AG.rx
 	rm README.conv
 	rm README.guide
 	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -14,7 +14,7 @@ endif
 	// AREXX doesn't understand makefile variables in it's execution path, i.e. ${srcdir}.
 	// It will break with a Program not found error. Therefore copying the script to cwd
 	// and removing it again once it has finished.
-	cp ${srcdir}/dists/amiga/RM2AG.rx ${srcdir}
+	cp ${srcdir}/dists/amiga/RM2AG.rx .
 	rx RM2AG.rx README.conv
 	cp README.guide $(AMIGAOSPATH)
 	rm RM2AG.rx

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -11,7 +11,7 @@ ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) $(AMIGAOSPATH)/extras/
 endif
 	cat ${srcdir}/README | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
-	rx ${srcdir}/dists/amiga/RM2AG.rx README.conv
+	rx dists/amiga/RM2AG.rx README.conv
 	cp README.guide $(AMIGAOSPATH)
 	rm README.conv
 	rm README.guide

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -13,7 +13,7 @@ endif
 	cat ${srcdir}/README | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
 	// AREXX doesn't understand makefile variables in it's execution path, i.e. ${srcdir}.
 	// It will break with a Program not found error. Therefore copying the script to cwd
-	// and removing it again once it finished.
+	// and removing it again once it has finished.
 	cp ${srcdir}/dists/amiga/RM2AG.rx ${srcdir}
 	rx RM2AG.rx README.conv
 	cp README.guide $(AMIGAOSPATH)

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -11,9 +11,9 @@ ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) $(AMIGAOSPATH)/extras/
 endif
 	cat ${srcdir}/README | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
-	// AREXX doesn't understand makefile variables in it's execution path, i.e. ${srcdir}.
-	// It will break with a Program not found error. Therefore copying the script to cwd
-	// and removing it again once it has finished.
+# AREXX doesn't understand makefile variables in it's execution path, i.e. ${srcdir}. It will
+# break with a Program not found error. Therefore copying the script to the cwd and
+# removing it again, once it has finished.
 	cp ${srcdir}/dists/amiga/RM2AG.rx .
 	rx RM2AG.rx README.conv
 	cp README.guide $(AMIGAOSPATH)


### PR DESCRIPTION
Arexx can't workread makefile variables in paths.
It will error out with a "Program not found!" error.
Removing makefiles pre-defined "($srcdir)/" part makes it work on my platform for local native builds.

This is up for discussion of course, as it will still break buildbot's install procedure if i understand correctly.