### PR TITLE
SWORD25: Fix "Resource not released" warnings [GSoC]

### DIFF
--- a/engines/sword25/gfx/animationresource.cpp
+++ b/engines/sword25/gfx/animationresource.cpp
@@ -211,8 +211,9 @@ bool AnimationResource::precacheAllFrames() const {
 			error("Could not precache \"%s\".", (*iter).fileName.c_str());
 			return false;
 		}
-#else
-		Kernel::getInstance()->getResourceManager()->requestResource((*iter).fileName);
+#else		 
+		Resource *pResource = Kernel::getInstance()->getResourceManager()->requestResource((*iter).fileName);
+		pResource->release(); //unlock precached resource
 #endif
 	}
 

--- a/engines/sword25/gfx/fontresource.cpp
+++ b/engines/sword25/gfx/fontresource.cpp
@@ -103,8 +103,9 @@ bool FontResource::parserCallback_font(ParserNode *node) {
 	if (!_pKernel->getResourceManager()->precacheResource(_bitmapFileName)) {
 		error("Could not precache \"%s\".", _bitmapFileName.c_str());
 	}
-#else
-	_pKernel->getResourceManager()->requestResource(_bitmapFileName);
+#else	
+	Resource *pResource = _pKernel->getResourceManager()->requestResource(_bitmapFileName);
+	pResource->release(); //unlock precached resource
 #endif
 
 	return true;

--- a/engines/sword25/gfx/text.cpp
+++ b/engines/sword25/gfx/text.cpp
@@ -77,7 +77,8 @@ bool Text::setFont(const Common::String &font) {
 		return false;
 	}
 #else
-	getResourceManager()->requestResource(font);
+	Resource *pResource = getResourceManager()->requestResource(font);
+	pResource->release(); //unlock precached resource
 	_font = font;
 	updateFormat();
 	forceRefresh();


### PR DESCRIPTION
(Look https://sourceforge.net/p/scummvm/bugs/6980/)

The warning messages were appearing because when PRECACHE_RESOURCES is
not defined, ResourceManager's `requestResource()` was used to manually
"cache" them. When you do that, ResourceManager "locks" the resource
once, so you must `release()` it later.

Resources were not released, and warnings appeared. When you
`release()` resource, it still is loaded ("cached"). Resource's
`getLockCount()` is 0, though, so it might be unloaded by
ResourceManager if there is a lot of resources.