### PR TITLE
RASPBERRYPI: remove some default configure options

### DIFF
--- a/backends/platform/sdl/raspberrypi/README.RASPBERRYPI
+++ b/backends/platform/sdl/raspberrypi/README.RASPBERRYPI
@@ -69,9 +69,4 @@ You can find concise instructions for this on the ScummVM wiki:
 
 http://wiki.scummvm.org/index.php/Compiling_ScummVM/RPI 
 
-The configure script is disabling scalers because we prefer dispmanx for that, which 
-makes scalers unnecessary on a CPU limited platform like this, timestamps because most people
-doesn't have an RTC on the Raspberry Pi, and event recorder to save SD card write cycles.
-All these are automatically disabled when we crosscompile by passing "--host=raspberrypi".
-
 Enjoy!

--- a/configure
+++ b/configure
@@ -2651,10 +2651,6 @@ if test -n "$_host"; then
 			append_var LDFLAGS "-L$RPI_ROOT/opt/vc/lib"
 			# This is so optional OpenGL ES includes are found.
 			append_var CXXFLAGS "-I$RPI_ROOT/opt/vc/include"
-			_savegame_timestamp=no
-			_eventrec=no
-			_build_scalers=no
-			_build_hq_scalers=no
 			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
 			# since SDL2 manages dispmanx/GLES2 very well internally.
 			# SDL1 is bit-rotten on this platform.


### PR DESCRIPTION
Remove the turning off of the following options when building for the
Raspberry Pi, as they may be useful for users - eg timestamps for
internet connected Pis, or people wanting to use the event recorder, or
scalers. Update the README.RASPBERRYPI to reflect these changes.
- _savegame_timestamp
- _eventrec
- _build_scalers
- _build_hq_scalers
