### PR TITLE
Sword25 video fix

### DIFF
--- a/engines/sword25/fmv/movieplayer.cpp
+++ b/engines/sword25/fmv/movieplayer.cpp
@@ -58,6 +58,8 @@ MoviePlayer::~MoviePlayer() {
 }
 
 bool MoviePlayer::loadMovie(const Common::String &filename, uint z) {
+	if (isMovieLoaded())
+		unloadMovie();
 	// Get the file and load it into the decoder
 	Common::SeekableReadStream *in = Kernel::getInstance()->getPackage()->getStream(filename);
 	_decoder.loadStream(in);


### PR DESCRIPTION
SWORD25: Fix frozen/flickering title menu movie
Fixes bug #6978.
And then corrected code formatting..