### PR TITLE
COMMON: [GSoC] Fix wrong warning message

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -148,8 +148,11 @@ static Common::Error runGame(const EnginePlugin *plugin, OSystem &system, const 
 #endif
 
 	// Verify that the game path refers to an actual directory
-	if (!(dir.exists() && dir.isDirectory()))
+        if (!dir.exists()) {
+		err = Common::kPathDoesNotExist;
+        } else if (!dir.isDirectory()) {
 		err = Common::kPathNotDirectory;
+        }
 
 	// Create the game engine
 	if (err.getCode() == Common::kNoError) {


### PR DESCRIPTION
The if was wrong, we split in two the validation of the path, first we check if it's a existing path and then if the path is a directory

Bug:
https://sourceforge.net/p/scummvm/bugs/6765/