### PR TITLE
WINTERMUTE: Don't mix different path separators.

### DIFF
--- a/engines/wintermute/base/file/base_disk_file.cpp
+++ b/engines/wintermute/base/file/base_disk_file.cpp
@@ -150,7 +150,14 @@ Common::SeekableReadStream *openDiskFile(const Common::String &filename) {
 	}
 	// File wasn't found in SearchMan, try to parse the path as a relative path.
 	if (!file) {
-		Common::FSNode searchNode = getNodeForRelativePath(filename);
+		Common::String filenameBackSlash = filename;
+		for (size_t i = 0; i < filenameBackSlash.size(); i++) {
+			if (filenameBackSlash[i] == '/') {
+				filenameBackSlash.setChar('\\', i);
+			}
+		}
+
+		Common::FSNode searchNode = getNodeForRelativePath(filenameBackSlash);
 		if (searchNode.exists() && !searchNode.isDirectory() && searchNode.isReadable()) {
 			file = searchNode.createReadStream();
 		}


### PR DESCRIPTION
- Buf fix #7068 : https://sourceforge.net/p/scummvm/bugs/7068/
- Replacing '\' with '/' in filename - getNodeRelativePath()

The assertion happened when the getNodeRelativePath(); function was called, with a string containing '\' char and '/' at the same time. ( /COM0024/secnes\allotment\jonas_dia_04b\jonas_dia_04b\jonas_dia_4b.scene )
As you can see I just added a conversion which replaces the car '/' with '\' in the right place.
