### PR TITLE
GUI: Remove dummy FluidSynth Settings button from Edit Game

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -868,10 +868,6 @@ void OptionsDialog::addMIDIControls(GuiObject *boss, const Common::String &prefi
 	_midiGainSlider->setMaxValue(1000);
 	_midiGainLabel = new StaticTextWidget(boss, prefix + "mcMidiGainLabel", "1.00");
 
-#ifdef USE_FLUIDSYNTH
-	new ButtonWidget(boss, prefix + "mcFluidSynthSettings", _("FluidSynth Settings"), 0, kFluidSynthSettingsCmd);
-#endif
-
 	_enableMIDISettings = true;
 }
 
@@ -1108,6 +1104,10 @@ GlobalOptionsDialog::GlobalOptionsDialog()
 	//
 	_midiTabId = tab->addTab(_("MIDI"));
 	addMIDIControls(tab, "GlobalOptions_MIDI.");
+
+#ifdef USE_FLUIDSYNTH
+	new ButtonWidget(tab, "GlobalOptions_MIDI.mcFluidSynthSettings", _("FluidSynth Settings"), 0, kFluidSynthSettingsCmd);
+#endif
 
 	//
 	// 4) The MT-32 tab


### PR DESCRIPTION
Remove dummy FluidSynth Settings button from Edit Game.
The FluidSynth Settings button actually works only from the Options dialog.
https://sourceforge.net/p/scummvm/bugs/6821/