### PR TITLE
GUI: Fix timer's conflict

### DIFF
--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -31,8 +31,8 @@
 namespace GUI {
 
 
-Tooltip::Tooltip() :
-	Dialog(-1, -1, -1, -1), _maxWidth(-1) {
+Tooltip::Tooltip(uint32 bornTime) :
+	Dialog(-1, -1, -1, -1), _maxWidth(-1), _bornTime(bornTime), _firstKeyDownTimeSetted(false){
 
 	_backgroundType = GUI::ThemeEngine::kDialogBackgroundTooltip;
 }

--- a/gui/Tooltip.h
+++ b/gui/Tooltip.h
@@ -27,6 +27,8 @@
 #include "common/str-array.h"
 #include "gui/dialog.h"
 
+#include "common/system.h"
+
 namespace GUI {
 
 class Widget;
@@ -34,9 +36,15 @@ class Widget;
 class Tooltip : public Dialog {
 private:
 	Dialog *_parent;
+	uint32 _bornTime;
+	uint32 _firstKeyDownTime;
+	bool _firstKeyDownTimeSetted;
+	enum{
+		kListenerDelay = 200
+	};
 
 public:
-	Tooltip();
+	Tooltip(uint32 bornTime);
 
 	void setup(Dialog *parent, Widget *widget, int x, int y);
 
@@ -55,7 +63,14 @@ protected:
 		_parent->handleMouseWheel(x + (getAbsX() - _parent->getAbsX()), y + (getAbsX() - _parent->getAbsX()), direction);
 	}
 	virtual void handleKeyDown(Common::KeyState state) {
-		close();
+		// Check if current Tooltip was born after first key down
+		// If it isn't - close Tooltip
+		if (!_firstKeyDownTimeSetted) {
+			_firstKeyDownTimeSetted = true;
+			_firstKeyDownTime = g_system->getMillis(true);
+		}
+		if (_firstKeyDownTime - _bornTime > kListenerDelay)
+			close();
 		_parent->handleKeyDown(state);
 	}
 	virtual void handleKeyUp(Common::KeyState state) {

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -351,7 +351,7 @@ void GuiManager::runLoop() {
 		if (tooltipCheck && _lastMousePosition.time + kTooltipDelay < _system->getMillis(true)) {
 			Widget *wdg = activeDialog->findWidget(_lastMousePosition.x, _lastMousePosition.y);
 			if (wdg && wdg->hasTooltip() && !(wdg->getFlags() & WIDGET_PRESSED)) {
-				Tooltip *tooltip = new Tooltip();
+				Tooltip *tooltip = new Tooltip(_system->getMillis(true));
 				tooltip->setup(activeDialog, wdg, _lastMousePosition.x, _lastMousePosition.y);
 				tooltip->runModal();
 				delete tooltip;


### PR DESCRIPTION
This patch fixes tooltip disapearing.
Try pressing the shift key and hovering over any button. The tooltip will appear and then disappear, it happens because pressing any button, closing the tooltip. As we do not distinguish any difference between the event of the button constantly being pressed and of it being pressed just now, during the next iteration processEvent tooltip closes. That's what I corrected by making a timer that monitors whether the tooltip has been created during the pressed down button (if so is not necessary to close), or whether the button was pressed after (then close)