### PR TITLE
GUI: Improve handling of button presses while moving the cursor

### DIFF
--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -277,7 +277,7 @@ void StaticTextWidget::drawWidget() {
 
 ButtonWidget::ButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::String &label, const char *tooltip, uint32 cmd, uint8 hotkey)
 	: StaticTextWidget(boss, x, y, w, h, cleanupHotkey(label), Graphics::kTextAlignCenter, tooltip), CommandSender(boss),
-	  _cmd(cmd), _hotkey(hotkey), _lastTime(0) {
+	  _cmd(cmd), _hotkey(hotkey), _lastTime(0), _duringPress(false) {
 
 	if (hotkey == 0)
 		_hotkey = parseHotkey(label);
@@ -288,7 +288,7 @@ ButtonWidget::ButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Co
 
 ButtonWidget::ButtonWidget(GuiObject *boss, const Common::String &name, const Common::String &label, const char *tooltip, uint32 cmd, uint8 hotkey)
 	: StaticTextWidget(boss, name, cleanupHotkey(label), tooltip), CommandSender(boss),
-	  _cmd(cmd), _hotkey(hotkey), _lastTime(0) {
+	  _cmd(cmd), _hotkey(hotkey), _lastTime(0), _duringPress(false) {
 	if (hotkey == 0)
 		_hotkey = parseHotkey(label);
 	setFlags(WIDGET_ENABLED/* | WIDGET_BORDER*/ | WIDGET_CLEARBG);
@@ -296,13 +296,15 @@ ButtonWidget::ButtonWidget(GuiObject *boss, const Common::String &name, const Co
 }
 
 void ButtonWidget::handleMouseUp(int x, int y, int button, int clickCount) {
-	if (isEnabled() && x >= 0 && x < _w && y >= 0 && y < _h) {
+	if (isEnabled() && _duringPress && x >= 0 && x < _w && y >= 0 && y < _h) {
 		startAnimatePressedState();
 		sendCommand(_cmd, 0);
 	}
+	_duringPress = false;
 }
 
 void ButtonWidget::handleMouseDown(int x, int y, int button, int clickCount) {
+	_duringPress = true;
 	setPressedState();
 }
 
@@ -460,9 +462,10 @@ CheckboxWidget::CheckboxWidget(GuiObject *boss, const Common::String &name, cons
 }
 
 void CheckboxWidget::handleMouseUp(int x, int y, int button, int clickCount) {
-	if (isEnabled() && x >= 0 && x < _w && y >= 0 && y < _h) {
+	if (isEnabled() && _duringPress && x >= 0 && x < _w && y >= 0 && y < _h) {
 		toggleState();
 	}
+	_duringPress = false;
 }
 
 void CheckboxWidget::setState(bool state) {
@@ -523,9 +526,10 @@ RadiobuttonWidget::RadiobuttonWidget(GuiObject *boss, const Common::String &name
 }
 
 void RadiobuttonWidget::handleMouseUp(int x, int y, int button, int clickCount) {
-	if (isEnabled() && x >= 0 && x < _w && y >= 0 && y < _h) {
+	if (isEnabled() && _duringPress && x >= 0 && x < _w && y >= 0 && y < _h) {
 		toggleState();
 	}
+	_duringPress = false;
 }
 
 void RadiobuttonWidget::setState(bool state, bool setGroup) {

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -198,7 +198,7 @@ public:
 
 	void handleMouseUp(int x, int y, int button, int clickCount);
 	void handleMouseDown(int x, int y, int button, int clickCount);
-	void handleMouseEntered(int button)	{ setFlags(WIDGET_HILITED); draw(); }
+	void handleMouseEntered(int button)	{ if (_duringPress) { setFlags(WIDGET_PRESSED); } else { setFlags(WIDGET_HILITED); } draw(); }
 	void handleMouseLeft(int button)	{ clearFlags(WIDGET_HILITED | WIDGET_PRESSED); draw(); }
 	void handleTickle();
 
@@ -211,6 +211,7 @@ public:
 protected:
 	void drawWidget();
 	void wantTickle(bool tickled);
+	bool _duringPress;
 private:
 	uint32 _lastTime;
 };


### PR DESCRIPTION
Submitting this patch for review. It's pretty simple, but I want more eyes on it, as it may affect things I'm unaware of. I've tested it on buttons, radio buttons, checkboxes, load-game dialog (picture buttons), and the AGI predictive text dialog.

The patch keeps track of where a mouse press started when deciding how mouse-over
and mouse-up should behave.

This handles the following situations:

1) If a mouse press starts outside a button (e.g. the UI background),
mouse-up inside the button has no effect. Previously, it triggered a
button click.
2) If a mouse press starts inside a button, the cursor moves outside of
its region, then back inside, the button will show as pressed.
Previously, it showed as highlighted instead of pressed.