### PR TITLE
GUI: Fix "eaten" event by dialog which was closed

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -331,10 +331,13 @@ void GuiManager::runLoop() {
 			//
 			// This hopefully fixes strange behavior/crashes with pop-up widgets. (Most easily
 			// triggered in 3x mode or when running ScummVM under Valgrind.)
-			if (activeDialog != getTopDialog() && event.type != Common::EVENT_SCREEN_CHANGED)
-				continue;
-
+			if (activeDialog != getTopDialog() && event.type != Common::EVENT_SCREEN_CHANGED) {
+				processEvent(event, getTopDialog());
+				continue;		
+			}
+			
 			processEvent(event, activeDialog);
+			
 
 			if (event.type == Common::EVENT_MOUSEMOVE) {
 				tooltipCheck = true;
@@ -512,6 +515,8 @@ void GuiManager::screenChange() {
 }
 
 void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDialog) {
+	if (activeDialog == 0)
+		return;
 	int button;
 	uint32 time;
 	Common::Point mouse(event.mouse.x - activeDialog->_x, event.mouse.y - activeDialog->_y);


### PR DESCRIPTION
This patch fix bug #6841
If this runloop catches both the repeated key down event and the key up event.
In this case they key down will close the tooltip, because it got closed the key up event will be ignored.
As a result the LauncherDialog will never get notified the SHIFT state might have changed and not adapt the button description.
In this patch we just pass event to topDialog, if activeDialog was closed.
Also we must check, If topDialog doesn't exist.

Please check, whether it works.
If it is, I should change the comment in code, and maybe we should process tooltipCheck or make updates https://github.com/scummvm/scummvm/blob/master/gui/gui-manager.cpp#L344-L348
