### PR TITLE
SCI: Cleanup of Save/Load Code

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -1861,7 +1861,7 @@ bool Console::cmdSavedBits(int argc, const char **argv) {
 
 	for (uint i = 0; i < entries.size(); ++i) {
 		uint16 offset = entries[i].getOffset();
-		const Hunk& h = hunks->_table[offset];
+		const Hunk& h = hunks->at(offset);
 		if (strcmp(h.type, "SaveBits()") == 0) {
 			byte* memoryPtr = (byte *)h.mem;
 
@@ -1928,7 +1928,7 @@ bool Console::cmdShowSavedBits(int argc, const char **argv) {
 		return true;
 	}
 
-	const Hunk& h = hunks->_table[memoryHandle.getOffset()];
+	const Hunk& h = hunks->at(memoryHandle.getOffset());
 
 	if (strcmp(h.type, "SaveBits()") != 0) {
 		debugPrintf("Invalid address.\n");
@@ -2144,32 +2144,32 @@ bool Console::segmentInfo(int nr) {
 	break;
 
 	case SEG_TYPE_CLONES: {
-		CloneTable *ct = (CloneTable *)mobj;
+		CloneTable &ct = *(CloneTable *)mobj;
 
 		debugPrintf("clones\n");
 
-		for (uint i = 0; i < ct->_table.size(); i++)
-			if (ct->isValidEntry(i)) {
+		for (uint i = 0; i < ct.size(); i++)
+			if (ct.isValidEntry(i)) {
 				reg_t objpos = make_reg(nr, i);
 				debugPrintf("  [%04x] %s; copy of ", i, _engine->_gamestate->_segMan->getObjectName(objpos));
 				// Object header
-				const Object *obj = _engine->_gamestate->_segMan->getObject(ct->_table[i].getPos());
+				const Object *obj = _engine->_gamestate->_segMan->getObject(ct[i].getPos());
 				if (obj)
-					debugPrintf("[%04x:%04x] %s : %3d vars, %3d methods\n", PRINT_REG(ct->_table[i].getPos()),
-								_engine->_gamestate->_segMan->getObjectName(ct->_table[i].getPos()),
+					debugPrintf("[%04x:%04x] %s : %3d vars, %3d methods\n", PRINT_REG(ct[i].getPos()),
+								_engine->_gamestate->_segMan->getObjectName(ct[i].getPos()),
 								obj->getVarCount(), obj->getMethodCount());
 			}
 	}
 	break;
 
 	case SEG_TYPE_LISTS: {
-		ListTable *lt = (ListTable *)mobj;
+		ListTable &lt = *(ListTable *)mobj;
 
 		debugPrintf("lists\n");
-		for (uint i = 0; i < lt->_table.size(); i++)
-			if (lt->isValidEntry(i)) {
+		for (uint i = 0; i < lt.size(); i++)
+			if (lt.isValidEntry(i)) {
 				debugPrintf("  [%04x]: ", i);
-				printList(&(lt->_table[i]));
+				printList(&lt[i]);
 			}
 	}
 	break;
@@ -2180,13 +2180,13 @@ bool Console::segmentInfo(int nr) {
 	}
 
 	case SEG_TYPE_HUNK: {
-		HunkTable *ht = (HunkTable *)mobj;
+		HunkTable &ht = *(HunkTable *)mobj;
 
-		debugPrintf("hunk  (total %d)\n", ht->entries_used);
-		for (uint i = 0; i < ht->_table.size(); i++)
-			if (ht->isValidEntry(i)) {
+		debugPrintf("hunk  (total %d)\n", ht.entries_used);
+		for (uint i = 0; i < ht.size(); i++)
+			if (ht.isValidEntry(i)) {
 				debugPrintf("    [%04x] %d bytes at %p, type=%s\n",
-				          i, ht->_table[i].size, ht->_table[i].mem, ht->_table[i].type);
+				          i, ht[i].size, ht[i].mem, ht[i].type);
 			}
 	}
 	break;
@@ -4362,7 +4362,7 @@ void Console::printList(List *list) {
 			return;
 		}
 
-		node = &(nt->_table[pos.getOffset()]);
+		node = &nt->at(pos.getOffset());
 
 		debugPrintf("\t%04x:%04x  : %04x:%04x -> %04x:%04x\n", PRINT_REG(pos), PRINT_REG(node->key), PRINT_REG(node->value));
 
@@ -4392,7 +4392,7 @@ int Console::printNode(reg_t addr) {
 			return 1;
 		}
 
-		list = &(lt->_table[addr.getOffset()]);
+		list = &lt->at(addr.getOffset());
 
 		debugPrintf("%04x:%04x : first x last = (%04x:%04x, %04x:%04x)\n", PRINT_REG(addr), PRINT_REG(list->first), PRINT_REG(list->last));
 	} else {
@@ -4411,7 +4411,7 @@ int Console::printNode(reg_t addr) {
 			debugPrintf("Address does not contain a node\n");
 			return 1;
 		}
-		node = &(nt->_table[addr.getOffset()]);
+		node = &nt->at(addr.getOffset());
 
 		debugPrintf("%04x:%04x : prev x next = (%04x:%04x, %04x:%04x); maps %04x:%04x -> %04x:%04x\n",
 		          PRINT_REG(addr), PRINT_REG(node->pred), PRINT_REG(node->succ), PRINT_REG(node->key), PRINT_REG(node->value));

--- a/engines/sci/engine/savegame.cpp
+++ b/engines/sci/engine/savegame.cpp
@@ -165,7 +165,6 @@ void syncWithSerializer(Common::Serializer &s, SciString &obj) {
 template<typename T>
 struct DefaultSyncer : Common::BinaryFunction<Common::Serializer, T, void> {
 	void operator()(Common::Serializer &s, T &obj) const {
-		//obj.saveLoadWithSerializer(s);
 		syncWithSerializer(s, obj);
 	}
 };

--- a/engines/sci/engine/savegame.cpp
+++ b/engines/sci/engine/savegame.cpp
@@ -60,14 +60,120 @@ namespace Sci {
 
 #pragma mark -
 
-// Experimental hack: Use syncWithSerializer to sync. By default, this assume
-// the object to be synced is a subclass of Serializable and thus tries to invoke
-// the saveLoadWithSerializer() method. But it is possible to specialize this
-// template function to handle stuff that is not implementing that interface.
-template<typename T>
-void syncWithSerializer(Common::Serializer &s, T &obj) {
+// These are serialization functions for various objects.
+
+void syncWithSerializer(Common::Serializer &s, Common::Serializable &obj) {
 	obj.saveLoadWithSerializer(s);
 }
+
+// FIXME: Object could implement Serializable to make use of the function
+// above.
+void syncWithSerializer(Common::Serializer &s, Object &obj) {
+	obj.saveLoadWithSerializer(s);
+}
+
+void syncWithSerializer(Common::Serializer &s, reg_t &obj) {
+	// Segment and offset are accessed directly here
+	s.syncAsUint16LE(obj._segment);
+	s.syncAsUint16LE(obj._offset);
+}
+
+void syncWithSerializer(Common::Serializer &s, synonym_t &obj) {
+	s.syncAsUint16LE(obj.replaceant);
+	s.syncAsUint16LE(obj.replacement);
+}
+
+void syncWithSerializer(Common::Serializer &s, Class &obj) {
+	s.syncAsSint32LE(obj.script);
+	syncWithSerializer(s, obj.reg);
+}
+
+void syncWithSerializer(Common::Serializer &s, SegmentObjTable<Clone>::Entry &obj) {
+	s.syncAsSint32LE(obj.next_free);
+
+	syncWithSerializer(s, (Clone &)obj);
+}
+
+void syncWithSerializer(Common::Serializer &s, SegmentObjTable<List>::Entry &obj) {
+	s.syncAsSint32LE(obj.next_free);
+
+	syncWithSerializer(s, obj.first);
+	syncWithSerializer(s, obj.last);
+}
+
+void syncWithSerializer(Common::Serializer &s, SegmentObjTable<Node>::Entry &obj) {
+	s.syncAsSint32LE(obj.next_free);
+
+	syncWithSerializer(s, obj.pred);
+	syncWithSerializer(s, obj.succ);
+	syncWithSerializer(s, obj.key);
+	syncWithSerializer(s, obj.value);
+}
+
+#ifdef ENABLE_SCI32
+void syncWithSerializer(Common::Serializer &s, SegmentObjTable<SciArray<reg_t> >::Entry &obj) {
+	s.syncAsSint32LE(obj.next_free);
+
+	byte type = 0;
+	uint32 size = 0;
+
+	if (s.isSaving()) {
+		type = (byte)obj.getType();
+		size = obj.getSize();
+	}
+	s.syncAsByte(type);
+	s.syncAsUint32LE(size);
+	if (s.isLoading()) {
+		obj.setType((int8)type);
+
+		// HACK: Skip arrays that have a negative type
+		if ((int8)type < 0)
+			return;
+
+		obj.setSize(size);
+	}
+
+	for (uint32 i = 0; i < size; i++) {
+		reg_t value;
+
+		if (s.isSaving())
+			value = obj.getValue(i);
+
+		syncWithSerializer(s, value);
+
+		if (s.isLoading())
+			obj.setValue(i, value);
+	}
+}
+
+void syncWithSerializer(Common::Serializer &s, SegmentObjTable<SciString>::Entry &obj) {
+	s.syncAsSint32LE(obj.next_free);
+
+	uint32 size = 0;
+
+	if (s.isSaving()) {
+		size = obj.getSize();
+		s.syncAsUint32LE(size);
+	} else {
+		s.syncAsUint32LE(size);
+		obj.setSize(size);
+	}
+
+	for (uint32 i = 0; i < size; i++) {
+		char value = 0;
+
+		if (s.isSaving())
+			value = obj.getValue(i);
+
+		s.syncAsByte(value);
+
+		if (s.isLoading())
+			obj.setValue(i, value);
+	}
+}
+#endif
+
+#pragma mark -
 
 // By default, sync using syncWithSerializer, which in turn can easily be overloaded.
 template<typename T>
@@ -114,20 +220,6 @@ template<typename T>
 void syncArray(Common::Serializer &s, Common::Array<T> &arr) {
 	ArraySyncer<T> sync;
 	sync(s, arr);
-}
-
-
-template<>
-void syncWithSerializer(Common::Serializer &s, reg_t &obj) {
-	// Segment and offset are accessed directly here
-	s.syncAsUint16LE(obj._segment);
-	s.syncAsUint16LE(obj._offset);
-}
-
-template<>
-void syncWithSerializer(Common::Serializer &s, synonym_t &obj) {
-	s.syncAsUint16LE(obj.replaceant);
-	s.syncAsUint16LE(obj.replacement);
 }
 
 void SegManager::saveLoadWithSerializer(Common::Serializer &s) {
@@ -247,12 +339,6 @@ void SegManager::saveLoadWithSerializer(Common::Serializer &s) {
 }
 
 
-template<>
-void syncWithSerializer(Common::Serializer &s, Class &obj) {
-	s.syncAsSint32LE(obj.script);
-	syncWithSerializer(s, obj.reg);
-}
-
 static void sync_SavegameMetadata(Common::Serializer &s, SavegameMetadata &obj) {
 	s.syncString(obj.name);
 	s.syncVersion(CURRENT_SAVEGAME_VERSION);
@@ -331,95 +417,6 @@ void Object::saveLoadWithSerializer(Common::Serializer &s) {
 	syncArray<reg_t>(s, _variables);
 }
 
-template<>
-void syncWithSerializer(Common::Serializer &s, SegmentObjTable<Clone>::Entry &obj) {
-	s.syncAsSint32LE(obj.next_free);
-
-	syncWithSerializer<Object>(s, obj);
-}
-
-template<>
-void syncWithSerializer(Common::Serializer &s, SegmentObjTable<List>::Entry &obj) {
-	s.syncAsSint32LE(obj.next_free);
-
-	syncWithSerializer(s, obj.first);
-	syncWithSerializer(s, obj.last);
-}
-
-template<>
-void syncWithSerializer(Common::Serializer &s, SegmentObjTable<Node>::Entry &obj) {
-	s.syncAsSint32LE(obj.next_free);
-
-	syncWithSerializer(s, obj.pred);
-	syncWithSerializer(s, obj.succ);
-	syncWithSerializer(s, obj.key);
-	syncWithSerializer(s, obj.value);
-}
-
-#ifdef ENABLE_SCI32
-template<>
-void syncWithSerializer(Common::Serializer &s, SegmentObjTable<SciArray<reg_t> >::Entry &obj) {
-	s.syncAsSint32LE(obj.next_free);
-
-	byte type = 0;
-	uint32 size = 0;
-
-	if (s.isSaving()) {
-		type = (byte)obj.getType();
-		size = obj.getSize();
-	}
-	s.syncAsByte(type);
-	s.syncAsUint32LE(size);
-	if (s.isLoading()) {
-		obj.setType((int8)type);
-
-		// HACK: Skip arrays that have a negative type
-		if ((int8)type < 0)
-			return;
-
-		obj.setSize(size);
-	}
-
-	for (uint32 i = 0; i < size; i++) {
-		reg_t value;
-
-		if (s.isSaving())
-			value = obj.getValue(i);
-
-		syncWithSerializer(s, value);
-
-		if (s.isLoading())
-			obj.setValue(i, value);
-	}
-}
-
-template<>
-void syncWithSerializer(Common::Serializer &s, SegmentObjTable<SciString>::Entry &obj) {
-	s.syncAsSint32LE(obj.next_free);
-
-	uint32 size = 0;
-
-	if (s.isSaving()) {
-		size = obj.getSize();
-		s.syncAsUint32LE(size);
-	} else {
-		s.syncAsUint32LE(size);
-		obj.setSize(size);
-	}
-
-	for (uint32 i = 0; i < size; i++) {
-		char value = 0;
-
-		if (s.isSaving())
-			value = obj.getValue(i);
-
-		s.syncAsByte(value);
-
-		if (s.isLoading())
-			obj.setValue(i, value);
-	}
-}
-#endif
 
 template<typename T>
 void sync_Table(Common::Serializer &s, T &obj) {

--- a/engines/sci/engine/scriptdebug.cpp
+++ b/engines/sci/engine/scriptdebug.cpp
@@ -741,13 +741,13 @@ void logKernelCall(const KernelFunction *kernelCall, const KernelSubFunction *ke
 					switch (mobj->getType()) {
 					case SEG_TYPE_HUNK:
 					{
-						HunkTable *ht = (HunkTable *)mobj;
+						HunkTable &ht = *(HunkTable *)mobj;
 						int index = argv[parmNr].getOffset();
-						if (ht->isValidEntry(index)) {
+						if (ht.isValidEntry(index)) {
 							// NOTE: This ", deleted" isn't as useful as it could
 							// be because it prints the status _after_ the kernel
 							// call.
-							debugN(" ('%s' hunk%s)", ht->_table[index].type, ht->_table[index].mem ? "" : ", deleted");
+							debugN(" ('%s' hunk%s)", ht[index].type, ht[index].mem ? "" : ", deleted");
 						} else
 							debugN(" (INVALID hunk ref)");
 						break;

--- a/engines/sci/engine/segment.cpp
+++ b/engines/sci/engine/segment.cpp
@@ -97,7 +97,7 @@ Common::Array<reg_t> CloneTable::listAllOutgoingReferences(reg_t addr) const {
 		error("Unexpected request for outgoing references from clone at %04x:%04x", PRINT_REG(addr));
 	}
 
-	const Clone *clone = &(_table[addr.getOffset()]);
+	const Clone *clone = &at(addr.getOffset());
 
 	// Emit all member variables (including references to the 'super' delegate)
 	for (uint i = 0; i < clone->getVarCount(); i++)
@@ -112,7 +112,7 @@ Common::Array<reg_t> CloneTable::listAllOutgoingReferences(reg_t addr) const {
 
 void CloneTable::freeAtAddress(SegManager *segMan, reg_t addr) {
 #ifdef GC_DEBUG
-	Object *victim_obj = &(_table[addr.getOffset()]);
+	Object *victim_obj = &at(addr.getOffset());
 
 	if (!(victim_obj->_flags & OBJECT_FLAG_FREED))
 		warning("[GC] Clone %04x:%04x not reachable and not freed (freeing now)", PRINT_REG(addr));
@@ -208,7 +208,7 @@ Common::Array<reg_t> ListTable::listAllOutgoingReferences(reg_t addr) const {
 		error("Invalid list referenced for outgoing references: %04x:%04x", PRINT_REG(addr));
 	}
 
-	const List *list = &(_table[addr.getOffset()]);
+	const List *list = &at(addr.getOffset());
 
 	tmp.push_back(list->first);
 	tmp.push_back(list->last);
@@ -225,7 +225,7 @@ Common::Array<reg_t> NodeTable::listAllOutgoingReferences(reg_t addr) const {
 	if (!isValidEntry(addr.getOffset())) {
 		error("Invalid node referenced for outgoing references: %04x:%04x", PRINT_REG(addr));
 	}
-	const Node *node = &(_table[addr.getOffset()]);
+	const Node *node = &at(addr.getOffset());
 
 	// We need all four here. Can't just stick with 'pred' OR 'succ' because node operations allow us
 	// to walk around from any given node
@@ -252,13 +252,13 @@ SegmentRef DynMem::dereference(reg_t pointer) {
 SegmentRef ArrayTable::dereference(reg_t pointer) {
 	SegmentRef ret;
 	ret.isRaw = false;
-	ret.maxSize = _table[pointer.getOffset()].getSize() * 2;
-	ret.reg = _table[pointer.getOffset()].getRawData();
+	ret.maxSize = at(pointer.getOffset()).getSize() * 2;
+	ret.reg = at(pointer.getOffset()).getRawData();
 	return ret;
 }
 
 void ArrayTable::freeAtAddress(SegManager *segMan, reg_t sub_addr) {
-	_table[sub_addr.getOffset()].destroy();
+	at(sub_addr.getOffset()).destroy();
 	freeEntry(sub_addr.getOffset());
 }
 
@@ -268,7 +268,7 @@ Common::Array<reg_t> ArrayTable::listAllOutgoingReferences(reg_t addr) const {
 		error("Invalid array referenced for outgoing references: %04x:%04x", PRINT_REG(addr));
 	}
 
-	const SciArray<reg_t> *array = &(_table[addr.getOffset()]);
+	const SciArray<reg_t> *array = &at(addr.getOffset());
 
 	for (uint32 i = 0; i < array->getSize(); i++) {
 		reg_t value = array->getValue(i);
@@ -305,8 +305,8 @@ void SciString::fromString(const Common::String &string) {
 SegmentRef StringTable::dereference(reg_t pointer) {
 	SegmentRef ret;
 	ret.isRaw = true;
-	ret.maxSize = _table[pointer.getOffset()].getSize();
-	ret.raw = (byte *)_table[pointer.getOffset()].getRawData();
+	ret.maxSize = at(pointer.getOffset()).getSize();
+	ret.raw = (byte *)at(pointer.getOffset()).getRawData();
 	return ret;
 }
 

--- a/engines/sci/engine/segment.h
+++ b/engines/sci/engine/segment.h
@@ -210,7 +210,8 @@ struct Hunk {
 template<typename T>
 struct SegmentObjTable : public SegmentObj {
 	typedef T value_type;
-	struct Entry : public T {
+	struct Entry {
+		T data;
 		int next_free; /* Only used for free entries */
 	};
 	enum { HEAPENTRY_INVALID = -1 };
@@ -218,7 +219,8 @@ struct SegmentObjTable : public SegmentObj {
 	int first_free; /**< Beginning of a singly linked list for entries */
 	int entries_used; /**< Statistical information */
 
-	Common::Array<Entry> _table;
+	typedef Common::Array<Entry> ArrayType;
+	ArrayType _table;
 
 public:
 	SegmentObjTable(SegmentType type) : SegmentObj(type) {
@@ -274,8 +276,8 @@ public:
 
 	uint size() const { return _table.size(); }
 
-	T &at(uint index) { return _table[index]; }
-	const T &at(uint index) const { return _table[index]; }
+	T &at(uint index) { return _table[index].data; }
+	const T &at(uint index) const { return _table[index].data; }
 
 	T &operator[](uint index) { return at(index); }
 	const T &operator[](uint index) const { return at(index); }

--- a/engines/sci/engine/segment.h
+++ b/engines/sci/engine/segment.h
@@ -215,7 +215,6 @@ struct SegmentObjTable : public SegmentObj {
 	};
 	enum { HEAPENTRY_INVALID = -1 };
 
-
 	int first_free; /**< Beginning of a singly linked list for entries */
 	int entries_used; /**< Statistical information */
 
@@ -272,6 +271,14 @@ public:
 				tmp.push_back(make_reg(segId, i));
 		return tmp;
 	}
+
+	uint size() const { return _table.size(); }
+
+	T &at(uint index) { return _table[index]; }
+	const T &at(uint index) const { return _table[index]; }
+
+	T &operator[](uint index) { return at(index); }
+	const T &operator[](uint index) const { return at(index); }
 };
 
 
@@ -323,8 +330,8 @@ struct HunkTable : public SegmentObjTable<Hunk> {
 	}
 
 	void freeEntryContents(int idx) {
-		free(_table[idx].mem);
-		_table[idx].mem = 0;
+		free(at(idx).mem);
+		at(idx).mem = 0;
 	}
 
 	virtual void freeEntry(int idx) {
@@ -502,7 +509,7 @@ struct StringTable : public SegmentObjTable<SciString> {
 	StringTable() : SegmentObjTable<SciString>(SEG_TYPE_STRING) {}
 
 	virtual void freeAtAddress(SegManager *segMan, reg_t sub_addr) {
-		_table[sub_addr.getOffset()].destroy();
+		at(sub_addr.getOffset()).destroy();
 		freeEntry(sub_addr.getOffset());
 	}
 


### PR DESCRIPTION
This removes an old hack in savegame.cpp which relied on template specialization to synchronize types. It uses much more natural function overloading instead, which is also nicer to distribute over multiple files, if desired.

Additionally, I cleaned up serialization of `SegmentObjTable::Entry` objects. The former approach required each individual `SegmentObjTale` subclass to specialize the serialization method for `Entry` and make sure `next_free` is serialized correctly. Now, only the contained type in `SegmentObjTable` needs to be serializable with `syncWithSerializer` and a generic serialization for `Entry` exists which takes care of `next_free`.
SegmentObjTable can now be easily used with fundamental types and pointers too.

I tested this manually by loading older KQ6CD saved games. I loaded various (~10) and then walked around a bit to see for obvious brokenness. I could not find any.

Additionally, I did some more involved tests using `cmp` to check for binary differences in written save files. Here, I altered `gamestate_delayedrestore` to immediately save again (with zeroed out meta data like time to avoid differences there). I did this to both my branch and master. With this change in place I loaded all my saved games (4 KQ5CD, 7 KQ6 German, 49 KQ6 CD) from command line multiple times each.
Then I scanned for differences in the generated save files with `cmp`. It turns out saved games created using this method have a slight chance of being different in all cases. This means there can be slight differences between master and my branch. But also between different runs from master (or different runs from my branch). I did not really figure out where this might come from, but since it happens in master too, I don't think this is a regression from my changes. Since it does not consistently happen it could also be just normal behavior due to timing differences.