### PR TITLE
WINTERMUTE: Correctly find .ogg version of .wav files

### DIFF
--- a/engines/wintermute/base/sound/base_sound_manager.cpp
+++ b/engines/wintermute/base/sound/base_sound_manager.cpp
@@ -100,15 +100,14 @@ BaseSoundBuffer *BaseSoundMgr::addSound(const Common::String &filename, Audio::M
 	BaseSoundBuffer *sound;
 
 	Common::String useFilename = filename;
+	useFilename.toLowercase();
 	// try to switch WAV to OGG file (if available)
-	AnsiString ext = PathUtil::getExtension(filename);
-	if (StringUtil::compareNoCase(ext, "wav")) {
-		AnsiString path = PathUtil::getDirectoryName(filename);
-		AnsiString name = PathUtil::getFileNameWithoutExtension(filename);
-
-		AnsiString newFile = PathUtil::combine(path, name + "ogg");
-		if (BaseFileManager::getEngineInstance()->hasFile(newFile)) {
-			useFilename = newFile;
+	if (useFilename.hasSuffix(".wav")) {
+		Common::String oggFilename = useFilename;
+		oggFilename.erase(oggFilename.size() - 4);
+		oggFilename = oggFilename + ".ogg";
+		if (BaseFileManager::getEngineInstance()->hasFile(oggFilename)) {
+			useFilename = oggFilename;
 		}
 	}
 


### PR DESCRIPTION
As it was, it didn't work because it turned
"some\\windows\\path.wav" into "some/system/pathogg" (not ".ogg"), so any file called by the scripts with its ".wav" extension but actually present in compressed .ogg form on the .dcp archive could not be found.

base_disk_file.cpp (apparently) takes care of preprocessing the path to make it system-agnostic already for those files which reside on the disk.

This one should fix https://sourceforge.net/p/scummvm/bugs/7088/

The corresponding bit in the original engine is:

```
	// try to switch WAV to OGG file (if available)
	_splitpath(Filename, drive, dir, fname, ext);
	if(_stricmp(ext, ".WAV")==0){
		_makepath(NewFile, drive, dir, fname, ".OGG");
		CBFile* file = Game->m_FileManager->OpenFile(NewFile);
		if(file){
			Filename = NewFile;
			Game->m_FileManager->CloseFile(file);
		}
	}

```

This way it should work reliably on all platforms like this, but just to be sure I would love it if somebody who runs Windows would check it before merging (I won't probably be able to do it before tomorrow).