### PR TITLE
GUI: Add repeatEvent flag to widgets and dialogs handleKeyDown calls

### DIFF
--- a/engines/gob/gob.cpp
+++ b/engines/gob/gob.cpp
@@ -76,7 +76,7 @@ public:
 	PauseDialog();
 
 	virtual void reflowLayout();
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 
 private:
 	Common::String _message;
@@ -106,7 +106,7 @@ void PauseDialog::reflowLayout() {
 	_text->setSize(_w - 8, _h);
 }
 
-void PauseDialog::handleKeyDown(Common::KeyState state) {
+void PauseDialog::handleKeyDown(Common::KeyState state, bool) {
 	// Close on CTRL+p
 	if ((state.hasFlags(Common::KBD_CTRL)) && (state.keycode == Common::KEYCODE_p))
 		close();

--- a/engines/mohawk/dialogs.cpp
+++ b/engines/mohawk/dialogs.cpp
@@ -70,11 +70,11 @@ void InfoDialog::reflowLayout() {
 PauseDialog::PauseDialog(MohawkEngine *vm, const Common::String &message) : InfoDialog(vm, message) {
 }
 
-void PauseDialog::handleKeyDown(Common::KeyState state) {
+void PauseDialog::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	if (state.ascii == ' ')
 		close();
 	else
-		InfoDialog::handleKeyDown(state);
+		InfoDialog::handleKeyDown(state, repeatEvent);
 }
 
 enum {

--- a/engines/mohawk/dialogs.h
+++ b/engines/mohawk/dialogs.h
@@ -56,7 +56,7 @@ public:
 		close();
 	}
 
-	virtual void handleKeyDown(Common::KeyState state) {
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent) {
 		setResult(state.ascii);
 		close();
 	}
@@ -67,7 +67,7 @@ public:
 class PauseDialog : public InfoDialog {
 public:
 	PauseDialog(MohawkEngine* vm, const Common::String &message);
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 };
 
 #ifdef ENABLE_MYST

--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -471,11 +471,11 @@ PauseDialog::PauseDialog(ScummEngine *scumm, int res)
 	: InfoDialog(scumm, res) {
 }
 
-void PauseDialog::handleKeyDown(Common::KeyState state) {
+void PauseDialog::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	if (state.ascii == ' ')  // Close pause dialog if space key is pressed
 		close();
 	else
-		ScummDialog::handleKeyDown(state);
+		ScummDialog::handleKeyDown(state, repeatEvent);
 }
 
 ConfirmDialog::ConfirmDialog(ScummEngine *scumm, int res)
@@ -493,7 +493,7 @@ ConfirmDialog::ConfirmDialog(ScummEngine *scumm, int res)
 	}
 }
 
-void ConfirmDialog::handleKeyDown(Common::KeyState state) {
+void ConfirmDialog::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	Common::KeyCode keyYes, keyNo;
 
 	Common::getLanguageYesNo(keyYes, keyNo);
@@ -505,7 +505,7 @@ void ConfirmDialog::handleKeyDown(Common::KeyState state) {
 		setResult(1);
 		close();
 	} else
-		ScummDialog::handleKeyDown(state);
+		ScummDialog::handleKeyDown(state, repeatEvent);
 }
 
 #pragma mark -
@@ -548,7 +548,7 @@ void ValueDisplayDialog::reflowLayout() {
 	_h = height;
 }
 
-void ValueDisplayDialog::handleKeyDown(Common::KeyState state) {
+void ValueDisplayDialog::handleKeyDown(Common::KeyState state, bool) {
 	if (state.ascii == _incKey || state.ascii == _decKey) {
 		if (state.ascii == _incKey && _value < _max)
 			_value++;
@@ -580,7 +580,7 @@ void SubtitleSettingsDialog::handleTickle() {
 		close();
 }
 
-void SubtitleSettingsDialog::handleKeyDown(Common::KeyState state) {
+void SubtitleSettingsDialog::handleKeyDown(Common::KeyState state, bool) {
 	if (state.keycode == Common::KEYCODE_t && state.hasFlags(Common::KBD_CTRL)) {
 		cycleValue();
 
@@ -620,11 +620,11 @@ Indy3IQPointsDialog::Indy3IQPointsDialog(ScummEngine *scumm, char* text)
 	: InfoDialog(scumm, text) {
 }
 
-void Indy3IQPointsDialog::handleKeyDown(Common::KeyState state) {
+void Indy3IQPointsDialog::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	if (state.ascii == 'i')
 		close();
 	else
-		ScummDialog::handleKeyDown(state);
+		ScummDialog::handleKeyDown(state, repeatEvent);
 }
 
 DebugInputDialog::DebugInputDialog(ScummEngine *scumm, char* text)
@@ -633,7 +633,7 @@ DebugInputDialog::DebugInputDialog(ScummEngine *scumm, char* text)
 	done = 0;
 }
 
-void DebugInputDialog::handleKeyDown(Common::KeyState state) {
+void DebugInputDialog::handleKeyDown(Common::KeyState state, bool) {
 	if (state.keycode == Common::KEYCODE_BACKSPACE && buffer.size() > 0) {
 		buffer.deleteLastChar();
 		Common::String total = mainText + ' ' + buffer;

--- a/engines/scumm/dialogs.h
+++ b/engines/scumm/dialogs.h
@@ -85,7 +85,7 @@ public:
 		setResult(0);
 		close();
 	}
-	virtual void handleKeyDown(Common::KeyState state) {
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent) {
 		setResult(state.ascii);
 		close();
 	}
@@ -105,7 +105,7 @@ protected:
 class PauseDialog : public InfoDialog {
 public:
 	PauseDialog(ScummEngine *scumm, int res);
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 };
 
 /**
@@ -115,7 +115,7 @@ public:
 class ConfirmDialog : public InfoDialog {
 public:
 	ConfirmDialog(ScummEngine *scumm, int res);
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 
 protected:
 	char _yesKey, _noKey;
@@ -135,7 +135,7 @@ public:
 	virtual void handleMouseDown(int x, int y, int button, int clickCount) {
 		close();
 	}
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 
 	virtual void reflowLayout();
 
@@ -164,7 +164,7 @@ public:
 	virtual void handleMouseDown(int x, int y, int button, int clickCount) {
 		close();
 	}
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 protected:
 	int _value;
 	uint32 _timer;
@@ -176,13 +176,13 @@ protected:
 class Indy3IQPointsDialog : public InfoDialog {
 public:
 	Indy3IQPointsDialog(ScummEngine *scumm, char* text);
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 };
 
 class DebugInputDialog : public InfoDialog {
 public:
 	DebugInputDialog(ScummEngine *scumm, char* text);
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 	bool done;
 	Common::String buffer;
 	Common::String mainText;

--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -1356,7 +1356,7 @@ void ScummEngine_v72he::debugInput(byte* string) {
 	runDialog(dialog);
 	while (!dialog.done) {
 		parseEvents();
-		dialog.handleKeyDown(_keyPressed);
+		dialog.handleKeyDown(_keyPressed, false);
 	}
 
 	writeVar(0, 0);

--- a/gui/KeysDialog.cpp
+++ b/gui/KeysDialog.cpp
@@ -122,9 +122,9 @@ void KeysDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	}
 }
 
-void KeysDialog::handleKeyDown(Common::KeyState state){
+void KeysDialog::handleKeyDown(Common::KeyState state, bool repeatEvent){
 	if (!Actions::Instance()->mappingActive())
-		Dialog::handleKeyDown(state);
+		Dialog::handleKeyDown(state, repeatEvent);
 }
 
 void KeysDialog::handleKeyUp(Common::KeyState state) {

--- a/gui/KeysDialog.h
+++ b/gui/KeysDialog.h
@@ -37,7 +37,7 @@ public:
 
 	virtual void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data);
 	virtual void handleKeyUp(Common::KeyState state);
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 
 protected:
 

--- a/gui/Tooltip.h
+++ b/gui/Tooltip.h
@@ -54,9 +54,10 @@ protected:
 		close();
 		_parent->handleMouseWheel(x + (getAbsX() - _parent->getAbsX()), y + (getAbsX() - _parent->getAbsX()), direction);
 	}
-	virtual void handleKeyDown(Common::KeyState state) {
-		close();
-		_parent->handleKeyDown(state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent) {
+		if (!repeatEvent)
+			close();
+		_parent->handleKeyDown(state, repeatEvent);
 	}
 	virtual void handleKeyUp(Common::KeyState state) {
 		close();

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -277,7 +277,7 @@ void AboutDialog::handleMouseUp(int x, int y, int button, int clickCount) {
 	close();
 }
 
-void AboutDialog::handleKeyDown(Common::KeyState state) {
+void AboutDialog::handleKeyDown(Common::KeyState state, bool) {
 	if (state.ascii)
 		_willClose = true;
 }

--- a/gui/about.h
+++ b/gui/about.h
@@ -51,7 +51,7 @@ public:
 	void drawDialog();
 	void handleTickle();
 	void handleMouseUp(int x, int y, int button, int clickCount);
-	void handleKeyDown(Common::KeyState state);
+	void handleKeyDown(Common::KeyState state, bool repeatEvent);
 	void handleKeyUp(Common::KeyState state);
 
 	void reflowLayout();

--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -252,7 +252,7 @@ void ConsoleDialog::handleMouseWheel(int x, int y, int direction) {
 	_scrollBar->handleMouseWheel(x, y, direction);
 }
 
-void ConsoleDialog::handleKeyDown(Common::KeyState state) {
+void ConsoleDialog::handleKeyDown(Common::KeyState state, bool) {
 	int i;
 
 	if (_slideMode != kNoSlideMode)

--- a/gui/console.h
+++ b/gui/console.h
@@ -137,7 +137,7 @@ public:
 	void handleTickle();
 	void reflowLayout();
 	void handleMouseWheel(int x, int y, int direction);
-	void handleKeyDown(Common::KeyState state);
+	void handleKeyDown(Common::KeyState state, bool repeatEvent);
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
 
 	int printFormat(int dummy, const char *format, ...) GCC_PRINTF(3, 4);

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -222,9 +222,9 @@ void Dialog::handleMouseWheel(int x, int y, int direction) {
 		w->handleMouseWheel(x - (w->getAbsX() - _x), y - (w->getAbsY() - _y), direction);
 }
 
-void Dialog::handleKeyDown(Common::KeyState state) {
+void Dialog::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	if (_focusedWidget) {
-		if (_focusedWidget->handleKeyDown(state))
+		if (_focusedWidget->handleKeyDown(state, repeatEvent))
 			return;
 	}
 
@@ -256,7 +256,7 @@ void Dialog::handleKeyDown(Common::KeyState state) {
 		Widget *w = _firstWidget;
 		while (w) {
 			if (w->_type == kTabWidget)
-				if (w->handleKeyDown(state))
+				if (w->handleKeyDown(state, repeatEvent))
 					return;
 
 			w = w->_next;

--- a/gui/dialog.h
+++ b/gui/dialog.h
@@ -95,7 +95,7 @@ protected:
 	virtual void handleMouseDown(int x, int y, int button, int clickCount);
 	virtual void handleMouseUp(int x, int y, int button, int clickCount);
 	virtual void handleMouseWheel(int x, int y, int direction);
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 	virtual void handleKeyUp(Common::KeyState state);
 	virtual void handleMouseMoved(int x, int y, int button);
 	virtual void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -517,6 +517,8 @@ void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDi
 	Common::Point mouse(event.mouse.x - activeDialog->_x, event.mouse.y - activeDialog->_y);
 	switch (event.type) {
 	case Common::EVENT_KEYDOWN:
+		// TODO: Using event.synthetic here is not correct. Repeat key down events are synthetic
+		// but there are other synthetic events (for examples events replayed by the event recorder).
 		activeDialog->handleKeyDown(event.kbd, event.synthetic);
 		break;
 	case Common::EVENT_KEYUP:

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -517,7 +517,7 @@ void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDi
 	Common::Point mouse(event.mouse.x - activeDialog->_x, event.mouse.y - activeDialog->_y);
 	switch (event.type) {
 	case Common::EVENT_KEYDOWN:
-		activeDialog->handleKeyDown(event.kbd);
+		activeDialog->handleKeyDown(event.kbd, event.synthetic);
 		break;
 	case Common::EVENT_KEYUP:
 		activeDialog->handleKeyUp(event.kbd);

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1056,7 +1056,7 @@ void LauncherDialog::loadGame(int item) {
 	}
 }
 
-void LauncherDialog::handleKeyDown(Common::KeyState state) {
+void LauncherDialog::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	if (state.keycode == Common::KEYCODE_TAB) {
 		// Toggle between the game list and the quick search field.
 		if (getFocusWidget() == _searchWidget) {
@@ -1065,7 +1065,7 @@ void LauncherDialog::handleKeyDown(Common::KeyState state) {
 			setFocusWidget(_searchWidget);
 		}
 	}
-	Dialog::handleKeyDown(state);
+	Dialog::handleKeyDown(state, repeatEvent);
 	updateButtons();
 }
 

--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -49,7 +49,7 @@ public:
 
 	virtual void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
 
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 	virtual void handleKeyUp(Common::KeyState state);
 
 protected:

--- a/gui/predictivedialog.cpp
+++ b/gui/predictivedialog.cpp
@@ -195,7 +195,7 @@ void PredictiveDialog::handleKeyUp(Common::KeyState state) {
 	}
 }
 
-void PredictiveDialog::handleKeyDown(Common::KeyState state) {
+void PredictiveDialog::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	_curPressedButton = kNoAct;
 	_needRefresh = false;
 
@@ -348,7 +348,7 @@ void PredictiveDialog::handleKeyDown(Common::KeyState state) {
 		_curPressedButton = ButtonId(state.keycode - Common::KEYCODE_KP1);
 		break;
 	default:
-		Dialog::handleKeyDown(state);
+		Dialog::handleKeyDown(state, repeatEvent);
 	}
 
 	if (_lastButton != _curPressedButton)

--- a/gui/predictivedialog.h
+++ b/gui/predictivedialog.h
@@ -42,7 +42,7 @@ public:
 
 	virtual void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data);
 	virtual void handleKeyUp(Common::KeyState state);
-	virtual void handleKeyDown(Common::KeyState state);
+	virtual void handleKeyDown(Common::KeyState state, bool repeatEvent);
 	virtual void handleTickle();
 
 	const char *getResult() const { return _predictiveResult; }

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -121,7 +121,7 @@ public:
 	virtual void handleMouseLeft(int button) {}
 	virtual void handleMouseMoved(int x, int y, int button) {}
 	virtual void handleMouseWheel(int x, int y, int direction) {}
-	virtual bool handleKeyDown(Common::KeyState state) { return false; }	// Return true if the event was handled
+	virtual bool handleKeyDown(Common::KeyState state, bool repeatEvent) { return false; }	// Return true if the event was handled
 	virtual bool handleKeyUp(Common::KeyState state) { return false; }	// Return true if the event was handled
 	virtual void handleTickle() {}
 

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -85,7 +85,7 @@ void EditableWidget::handleTickle() {
 	}
 }
 
-bool EditableWidget::handleKeyDown(Common::KeyState state) {
+bool EditableWidget::handleKeyDown(Common::KeyState state, bool) {
 	bool handled = true;
 	bool dirty = false;
 	bool forcecaret = false;

--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -70,7 +70,7 @@ public:
 	virtual const String &getEditString() const		{ return _editString; }
 
 	virtual void handleTickle();
-	virtual bool handleKeyDown(Common::KeyState state);
+	virtual bool handleKeyDown(Common::KeyState state, bool repeatEvent);
 	virtual void reflowLayout();
 
 	bool setCaretPos(int newPos);

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -284,7 +284,7 @@ static int matchingCharsIgnoringCase(const char *x, const char *y, bool &stop) {
 	return match;
 }
 
-bool ListWidget::handleKeyDown(Common::KeyState state) {
+bool ListWidget::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	bool handled = true;
 	bool dirty = false;
 	int oldSelectedItem = _selectedItem;
@@ -326,7 +326,7 @@ bool ListWidget::handleKeyDown(Common::KeyState state) {
 		}
 	} else if (_editMode) {
 		// Class EditableWidget handles all text editing related key presses for us
-		handled = EditableWidget::handleKeyDown(state);
+		handled = EditableWidget::handleKeyDown(state, repeatEvent);
 	} else {
 		// not editmode
 

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -125,7 +125,7 @@ public:
 	virtual void handleMouseDown(int x, int y, int button, int clickCount);
 	virtual void handleMouseUp(int x, int y, int button, int clickCount);
 	virtual void handleMouseWheel(int x, int y, int direction);
-	virtual bool handleKeyDown(Common::KeyState state);
+	virtual bool handleKeyDown(Common::KeyState state, bool repeatEvent);
 	virtual bool handleKeyUp(Common::KeyState state);
 	virtual void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
 

--- a/gui/widgets/popup.cpp
+++ b/gui/widgets/popup.cpp
@@ -54,7 +54,7 @@ public:
 	void handleMouseUp(int x, int y, int button, int clickCount);
 	void handleMouseWheel(int x, int y, int direction);	// Scroll through entries with scroll wheel
 	void handleMouseMoved(int x, int y, int button);	// Redraw selections depending on mouse position
-	void handleKeyDown(Common::KeyState state);	// Scroll through entries with arrow keys etc.
+	void handleKeyDown(Common::KeyState state, bool repeatEvent);	// Scroll through entries with arrow keys etc.
 
 protected:
 	void drawMenuEntry(int entry, bool hilite);
@@ -206,7 +206,7 @@ void PopUpDialog::handleMouseMoved(int x, int y, int button) {
 	setSelection(item);
 }
 
-void PopUpDialog::handleKeyDown(Common::KeyState state) {
+void PopUpDialog::handleKeyDown(Common::KeyState state, bool) {
 	if (state.keycode == Common::KEYCODE_ESCAPE) {
 		// Don't change the previous selection
 		setResult(-1);

--- a/gui/widgets/tab.cpp
+++ b/gui/widgets/tab.cpp
@@ -226,13 +226,13 @@ void TabWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 	}
 }
 
-bool TabWidget::handleKeyDown(Common::KeyState state) {
+bool TabWidget::handleKeyDown(Common::KeyState state, bool repeatEvent) {
 	if (state.hasFlags(Common::KBD_SHIFT) && state.keycode == Common::KEYCODE_TAB)
 		adjustTabs(kTabBackwards);
 	else if (state.keycode == Common::KEYCODE_TAB)
 		adjustTabs(kTabForwards);
 
-	return Widget::handleKeyDown(state);
+	return Widget::handleKeyDown(state, repeatEvent);
 }
 
 void TabWidget::adjustTabs(int value) {

--- a/gui/widgets/tab.h
+++ b/gui/widgets/tab.h
@@ -99,7 +99,7 @@ public:
 	}
 
 	virtual void handleMouseDown(int x, int y, int button, int clickCount);
-	virtual bool handleKeyDown(Common::KeyState state);
+	virtual bool handleKeyDown(Common::KeyState state, bool repeatEvent);
 	virtual void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
 
 	virtual void reflowLayout();


### PR DESCRIPTION
This allows widgets and dialogs to know if the call correspond to an initial key down event or a repeated key down event. This is used in the Tooltip to avoid closing the tooltip on repeated key down events. Otherwise this makes it for example impossible to see the tooltip on the Mass Add button (since we get Shift key down repeated events).

This is an alternate (and in my opinion cleaner solution) than what otto gin tried to implement in PR #716. In that PR I suggested we might want to pass the full event to the widgets and dialogs event handlers. But since I am lazy I decided to only modify handleKeyDown by adding a flag.

Note: I could have changed only Dialog (and classes that derive from it) but decided to also change the Widget class for consistency. No Widget currently use that flag.

I am submitting this as a pull request to get opinions on whether this is the best way to fix this tooltip issue.