### PR TITLE
WINTERMUTE: Log warning if addSound is called with empty filename

### DIFF
--- a/engines/wintermute/base/sound/base_sound_manager.cpp
+++ b/engines/wintermute/base/sound/base_sound_manager.cpp
@@ -97,6 +97,11 @@ BaseSoundBuffer *BaseSoundMgr::addSound(const Common::String &filename, Audio::M
 		return nullptr;
 	}
 
+	if (filename.empty()) {
+		// At least one game, Bickadoodle, calls playSound with an empty filename, see #6594
+		BaseEngine::LOG(0, "addSound called with empty filename");
+	}
+
 	BaseSoundBuffer *sound;
 
 	Common::String useFilename = filename;


### PR DESCRIPTION
Bickadoodle does this.

<s>Fixes #6594</s> It doesn't, that is best handled in #733 
