### PR TITLE
WINTERMUTE: Fix PathUtils

### DIFF
--- a/engines/wintermute/dctypes.h
+++ b/engines/wintermute/dctypes.h
@@ -37,9 +37,6 @@
 
 namespace Wintermute {
 
-//typedef std::string AnsiString;
-//typedef std::string Utf8String;
-//typedef std::wstring WideString;
 typedef Common::String AnsiString;
 typedef Common::String Utf8String;
 typedef Common::U32String WideString;

--- a/engines/wintermute/utils/path_util.cpp
+++ b/engines/wintermute/utils/path_util.cpp
@@ -71,7 +71,11 @@ bool PathUtil::hasTrailingSlash(const Common::String &path) {
 Common::String PathUtil::getDirectoryName(const Common::String &path) {
 	Common::String newPath = unifySeparators(path);
 	Common::String filename = getFileName(path);
-	return Common::String(path.c_str(), path.size() - filename.size());
+	if (hasTrailingSlash(newPath)) {
+		return path;
+	} else {
+		return Common::String(path.c_str(), path.size() - filename.size());
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/engines/wintermute/utils/path_util.cpp
+++ b/engines/wintermute/utils/path_util.cpp
@@ -63,6 +63,10 @@ Common::String PathUtil::combine(const Common::String &path1, const Common::Stri
 	return newPath1 + newPath2;
 }
 
+bool PathUtil::hasTrailingSlash(const Common::String &path) {
+	return (path.size() > 0 && path[path.size() - 1 ] == '/');
+}
+
 //////////////////////////////////////////////////////////////////////////
 Common::String PathUtil::getDirectoryName(const Common::String &path) {
 	Common::String newPath = unifySeparators(path);
@@ -74,10 +78,10 @@ Common::String PathUtil::getDirectoryName(const Common::String &path) {
 Common::String PathUtil::getFileName(const Common::String &path) {
 	Common::String newPath = unifySeparators(path);
 	Common::String lastPart = Common::lastPathComponent(newPath, '/');
-	if (lastPart[lastPart.size() - 1 ] != '/') {
-		return lastPart;
+	if (hasTrailingSlash(newPath)) {
+		return Common::String("");
 	} else {
-		return path;
+		return lastPart;
 	}
 }
 

--- a/engines/wintermute/utils/path_util.cpp
+++ b/engines/wintermute/utils/path_util.cpp
@@ -32,8 +32,8 @@
 namespace Wintermute {
 
 //////////////////////////////////////////////////////////////////////////
-AnsiString PathUtil::unifySeparators(const AnsiString &path) {
-	AnsiString newPath = path;
+Common::String PathUtil::unifySeparators(const Common::String &path) {
+	Common::String newPath = path;
 
 	for (uint32 i = 0; i < newPath.size(); i++) {
 		if (newPath[i] == '\\') {
@@ -45,16 +45,16 @@ AnsiString PathUtil::unifySeparators(const AnsiString &path) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-AnsiString PathUtil::normalizeFileName(const AnsiString &path) {
-	AnsiString newPath = unifySeparators(path);
+Common::String PathUtil::normalizeFileName(const Common::String &path) {
+	Common::String newPath = unifySeparators(path);
 	newPath.toLowercase();
 	return newPath;
 }
 
 //////////////////////////////////////////////////////////////////////////
-AnsiString PathUtil::combine(const AnsiString &path1, const AnsiString &path2) {
-	AnsiString newPath1 = unifySeparators(path1);
-	AnsiString newPath2 = unifySeparators(path2);
+Common::String PathUtil::combine(const Common::String &path1, const Common::String &path2) {
+	Common::String newPath1 = unifySeparators(path1);
+	Common::String newPath2 = unifySeparators(path2);
 
 	if (!newPath1.hasSuffix("/") && !newPath2.hasPrefix("/")) {
 		newPath1 += "/";
@@ -64,15 +64,15 @@ AnsiString PathUtil::combine(const AnsiString &path1, const AnsiString &path2) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-AnsiString PathUtil::getDirectoryName(const AnsiString &path) {
-	AnsiString newPath = unifySeparators(path);
+Common::String PathUtil::getDirectoryName(const Common::String &path) {
+	Common::String newPath = unifySeparators(path);
 	Common::String filename = getFileName(path);
 	return Common::String(path.c_str(), path.size() - filename.size());
 }
 
 //////////////////////////////////////////////////////////////////////////
-AnsiString PathUtil::getFileName(const AnsiString &path) {
-	AnsiString newPath = unifySeparators(path);
+Common::String PathUtil::getFileName(const Common::String &path) {
+	Common::String newPath = unifySeparators(path);
 	Common::String lastPart = Common::lastPathComponent(newPath, '/');
 	if (lastPart[lastPart.size() - 1 ] != '/') {
 		return lastPart;
@@ -82,10 +82,10 @@ AnsiString PathUtil::getFileName(const AnsiString &path) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-AnsiString PathUtil::getFileNameWithoutExtension(const AnsiString &path) {
-	AnsiString fileName = getFileName(path);
+Common::String PathUtil::getFileNameWithoutExtension(const Common::String &path) {
+	Common::String fileName = getFileName(path);
 	// TODO: Prettify this.
-	AnsiString extension = Common::lastPathComponent(fileName, '.');
+	Common::String extension = Common::lastPathComponent(fileName, '.');
 	for (uint32 i = 0; i < extension.size() + 1; i++) {
 		fileName.deleteLastChar();
 	}
@@ -93,8 +93,8 @@ AnsiString PathUtil::getFileNameWithoutExtension(const AnsiString &path) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-AnsiString PathUtil::getExtension(const AnsiString &path) {
-	AnsiString fileName = getFileName(path);
+Common::String PathUtil::getExtension(const Common::String &path) {
+	Common::String fileName = getFileName(path);
 	return Common::lastPathComponent(path, '.');
 }
 

--- a/engines/wintermute/utils/path_util.h
+++ b/engines/wintermute/utils/path_util.h
@@ -42,6 +42,7 @@ public:
 	static Common::String getFileName(const Common::String &path);
 	static Common::String getFileNameWithoutExtension(const Common::String &path);
 	static Common::String getExtension(const Common::String &path);
+	static bool hasTrailingSlash(const Common::String &path);	
 };
 
 } // End of namespace Wintermute

--- a/engines/wintermute/utils/path_util.h
+++ b/engines/wintermute/utils/path_util.h
@@ -35,13 +35,13 @@ namespace Wintermute {
 
 class PathUtil {
 public:
-	static AnsiString unifySeparators(const AnsiString &path);
-	static AnsiString normalizeFileName(const AnsiString &path);
-	static AnsiString combine(const AnsiString &path1, const AnsiString &path2);
-	static AnsiString getDirectoryName(const AnsiString &path);
-	static AnsiString getFileName(const AnsiString &path);
-	static AnsiString getFileNameWithoutExtension(const AnsiString &path);
-	static AnsiString getExtension(const AnsiString &path);
+	static Common::String unifySeparators(const Common::String &path);
+	static Common::String normalizeFileName(const Common::String &path);
+	static Common::String combine(const Common::String &path1, const Common::String &path2);
+	static Common::String getDirectoryName(const Common::String &path);
+	static Common::String getFileName(const Common::String &path);
+	static Common::String getFileNameWithoutExtension(const Common::String &path);
+	static Common::String getExtension(const Common::String &path);
 };
 
 } // End of namespace Wintermute

--- a/test/engines/wintermute/path_utils.h
+++ b/test/engines/wintermute/path_utils.h
@@ -23,6 +23,8 @@ class PathUtilTestSuite : public CxxTest::TestSuite {
 	const Common::String mixedSlashesPath2;
 	const Common::String unixRelativePath;
 	const Common::String windowsRelativePath;
+	const Common::String unixDirPath;
+	const Common::String windowsDirPath;
 	PathUtilTestSuite () :
 		unixPath("/some/file.ext"),
 		unixCapPath("/SOME/FILE.EXT"),
@@ -34,7 +36,9 @@ class PathUtilTestSuite : public CxxTest::TestSuite {
 		mixedSlashesPath1("C:\\this/IS_REALLY\\weird.exe"),
 		mixedSlashesPath2("/pretty\\weird/indeed.txt"),
 		unixRelativePath("some/file.ext"),
-		windowsRelativePath("some\\file.ext")
+		windowsRelativePath("some\\file.ext"),
+		unixDirPath("/some/dir/"),
+		windowsDirPath("C:\\some\\dir\\")
 	{}
 	void test_getdirectoryname() {
 		TS_ASSERT_EQUALS(
@@ -56,6 +60,14 @@ class PathUtilTestSuite : public CxxTest::TestSuite {
 		TS_ASSERT_EQUALS(
 				Wintermute::PathUtil::getDirectoryName(emptyString),
 				Common::String("")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(unixDirPath),
+				Common::String("/some/dir/")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(windowsDirPath),
+				Common::String("C:\\some\\dir\\")
 				);
 	}
 

--- a/test/engines/wintermute/path_utils.h
+++ b/test/engines/wintermute/path_utils.h
@@ -53,6 +53,10 @@ class PathUtilTestSuite : public CxxTest::TestSuite {
 				Wintermute::PathUtil::getDirectoryName(windowsCapPath),
 				Common::String("C:\\SOME\\")
 				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(emptyString),
+				Common::String("")
+				);
 	}
 
 	void test_getfilename() {
@@ -73,12 +77,24 @@ class PathUtilTestSuite : public CxxTest::TestSuite {
 				Common::String("FILE.EXT")
 				);
 		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(emptyString),
+				Common::String("")
+				);
+		TS_ASSERT_EQUALS(
 				Wintermute::PathUtil::getFileName(unixRelativePath),
 				Common::String("file.ext")
 				);
 		TS_ASSERT_EQUALS(
 				Wintermute::PathUtil::getFileName(windowsRelativePath),
 				Common::String("file.ext")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(windowsDirPath),
+				Common::String("")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(unixDirPath),
+				Common::String("")
 				);
 	}
 
@@ -90,6 +106,10 @@ class PathUtilTestSuite : public CxxTest::TestSuite {
 		TS_ASSERT_EQUALS(
 				Wintermute::PathUtil::getExtension(windowsCapPath),
 				Common::String("EXT")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getExtension(emptyString),
+				Common::String("")
 				);
 		TS_ASSERT_EQUALS(
 				Wintermute::PathUtil::getExtension(dualExtPath),
@@ -117,6 +137,10 @@ class PathUtilTestSuite : public CxxTest::TestSuite {
 		TS_ASSERT_EQUALS(
 				Wintermute::PathUtil::getFileNameWithoutExtension(windowsCapPath),
 				Common::String("FILE")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileNameWithoutExtension(emptyString),
+				Common::String("")
 				);
 		TS_ASSERT_EQUALS(
 				Wintermute::PathUtil::getFileNameWithoutExtension(dualExtPath),

--- a/test/engines/wintermute/path_utils.h
+++ b/test/engines/wintermute/path_utils.h
@@ -1,0 +1,200 @@
+#include <cxxtest/TestSuite.h>
+#include "engines/wintermute/utils/path_util.h"
+/**
+ * Test suite for the functions in engines/wintermute/utils/path_util.h
+ *
+ * NOTE: This is not a prescription;
+ *       this was not written by the original engine author;
+ *       this was not written by the engine porter.
+ *
+ * It might, however, help to spot variations in behavior that are introduced by modifications
+ */
+
+class PathUtilTestSuite : public CxxTest::TestSuite {
+	public:
+	const Common::String unixPath;
+	const Common::String unixCapPath;
+	const Common::String windowsPath;
+	const Common::String windowsCapPath;
+	const Common::String emptyString;
+	const Common::String dualExtPath;
+	const Common::String manyExtPath;
+	const Common::String mixedSlashesPath1;
+	const Common::String mixedSlashesPath2;
+	const Common::String unixRelativePath;
+	const Common::String windowsRelativePath;
+	PathUtilTestSuite () :
+		unixPath("/some/file.ext"),
+		unixCapPath("/SOME/FILE.EXT"),
+		windowsPath("C:\\some\\file.ext"),
+		windowsCapPath("C:\\SOME\\FILE.EXT"),
+		emptyString(""),
+		dualExtPath("/some/file.tar.gz"),
+		manyExtPath("/some/file.tar.bz2.gz.zip"),
+		mixedSlashesPath1("C:\\this/IS_REALLY\\weird.exe"),
+		mixedSlashesPath2("/pretty\\weird/indeed.txt"),
+		unixRelativePath("some/file.ext"),
+		windowsRelativePath("some\\file.ext")
+	{}
+	void test_getdirectoryname() {
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(unixPath),
+				Common::String("/some/")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(unixCapPath),
+				Common::String("/SOME/")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(windowsPath),
+				Common::String("C:\\some\\")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(windowsCapPath),
+				Common::String("C:\\SOME\\")
+				);
+	}
+
+	void test_getfilename() {
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(unixPath),
+				Common::String("file.ext")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(unixCapPath),
+				Common::String("FILE.EXT")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(windowsPath),
+				Common::String("file.ext")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(windowsCapPath),
+				Common::String("FILE.EXT")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(unixRelativePath),
+				Common::String("file.ext")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileName(windowsRelativePath),
+				Common::String("file.ext")
+				);
+	}
+
+	void test_getextension() {
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getExtension(windowsPath),
+				Common::String("ext")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getExtension(windowsCapPath),
+				Common::String("EXT")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getExtension(dualExtPath),
+				Common::String("gz")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getExtension(manyExtPath),
+				Common::String("zip")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getExtension(unixRelativePath),
+				Common::String("ext")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getExtension(windowsRelativePath),
+				Common::String("ext")
+				);
+	}
+
+	void test_getfilenamewithoutextension() {
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileNameWithoutExtension(windowsPath),
+				Common::String("file")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileNameWithoutExtension(windowsCapPath),
+				Common::String("FILE")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileNameWithoutExtension(dualExtPath),
+				Common::String("file.tar")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileNameWithoutExtension(manyExtPath),
+				Common::String("file.tar.bz2.gz")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileNameWithoutExtension(unixRelativePath),
+				Common::String("file")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getFileNameWithoutExtension(windowsRelativePath),
+				Common::String("file")
+				);
+	}
+
+	void test_combine_identity() {
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(windowsPath) +
+				Wintermute::PathUtil::getFileNameWithoutExtension(windowsPath) +
+				"." +
+				Wintermute::PathUtil::getExtension(windowsPath),
+				windowsPath
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(windowsCapPath) +
+				Wintermute::PathUtil::getFileNameWithoutExtension(windowsCapPath) +
+				"." +
+				Wintermute::PathUtil::getExtension(windowsCapPath),
+				windowsCapPath
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(unixCapPath) +
+				Wintermute::PathUtil::getFileNameWithoutExtension(unixCapPath) +
+				"." +
+				Wintermute::PathUtil::getExtension(unixCapPath),
+				unixCapPath
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::getDirectoryName(manyExtPath) +
+				Wintermute::PathUtil::getFileNameWithoutExtension(manyExtPath) +
+				"." +
+				Wintermute::PathUtil::getExtension(manyExtPath),
+				manyExtPath
+				);
+	}
+
+	void test_normalize() {
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::normalizeFileName(windowsCapPath),
+				Common::String("c:/some/file.ext")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::normalizeFileName(windowsPath),
+				Common::String("c:/some/file.ext")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::normalizeFileName(mixedSlashesPath1),
+				Common::String("c:/this/is_really/weird.exe")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::normalizeFileName(mixedSlashesPath2),
+				Common::String("/pretty/weird/indeed.txt")
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::normalizeFileName(emptyString),
+				emptyString
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::normalizeFileName(unixRelativePath),
+				unixRelativePath
+				);
+		TS_ASSERT_EQUALS(
+				Wintermute::PathUtil::normalizeFileName(windowsRelativePath),
+				unixRelativePath // NOT windows
+				);
+	}
+};

--- a/test/module.mk
+++ b/test/module.mk
@@ -5,8 +5,8 @@
 #
 ######################################################################
 
-TESTS        := $(srcdir)/test/common/*.h $(srcdir)/test/audio/*.h
-TEST_LIBS    := audio/libaudio.a common/libcommon.a
+TESTS        := $(srcdir)/test/common/*.h $(srcdir)/test/audio/*.h $(srcdir)/test/engines/wintermute/*.h
+TEST_LIBS    := audio/libaudio.a common/libcommon.a engines/wintermute/libwintermute.a
 
 #
 TEST_FLAGS   := --runner=StdioPrinter --no-std --no-eh --include=$(srcdir)/test/cxxtest_mingw.h


### PR DESCRIPTION
This avoids hitting a failing assert when passing strings == "".
E.g. Bickadoodle has a script bug that tries to load an empty filename.

This fixes #6594
