### PR TITLE
SCUMM,GUI: Add checkbox to toggle COMI's object_labels (Do not merge)

### DIFF
--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -301,6 +301,16 @@ ConfigDialog::ConfigDialog(bool subtitleControls)
 	}
 
 	//
+	// Custom engine options
+	//
+	const EnginePlugin *plugin = 0;
+	EngineMan.findGame(ConfMan.get("gameid"), &plugin);
+	if (plugin) {
+		_engineOptions = (*plugin)->getExtraGuiOptions(_domain);
+		addEngineControls(this, "GlobalConfig.");
+	}
+
+	//
 	// Add the buttons
 	//
 

--- a/engines/scumm/POTFILES
+++ b/engines/scumm/POTFILES
@@ -1,3 +1,4 @@
+engines/scumm/detection.cpp
 engines/scumm/dialogs.cpp
 engines/scumm/help.cpp
 engines/scumm/input.cpp

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -29,6 +29,7 @@
 #include "common/md5.h"
 #include "common/savefile.h"
 #include "common/system.h"
+#include "common/translation.h"
 
 #include "audio/mididrv.h"
 
@@ -957,6 +958,7 @@ public:
 	virtual int getMaximumSaveSlot() const;
 	virtual void removeSaveState(const char *target, int slot) const;
 	virtual SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const;
+	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const;
 };
 
 bool ScummMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -1327,6 +1329,21 @@ SaveStateDescriptor ScummMetaEngine::querySaveMetaInfos(const char *target, int 
 	}
 
 	return desc;
+}
+
+static const ExtraGuiOption scummComiObjectLabelsOption = {
+	_s("Show Object Line"),
+	_s("Show the names of objects at the bottom of the screen"),
+	"object_labels",
+	true
+};
+
+const ExtraGuiOptions ScummMetaEngine::getExtraGuiOptions(const Common::String &target) const {
+	ExtraGuiOptions options;
+	if (target.empty() || ConfMan.get("gameid", target) == "comi") {
+		options.push_back(scummComiObjectLabelsOption);
+	}
+	return options;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(SCUMM)

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2011,6 +2011,9 @@ void ScummEngine::syncSoundSettings() {
 		_scummVars[632] = ConfMan.getBool("subtitles");
 	}
 
+	if (_game.id == GID_CMI) {
+		_scummVars[176] = ConfMan.getBool("object_labels");
+	}
 }
 
 void ScummEngine::setTalkSpeed(int talkspeed) {

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -151,8 +151,6 @@ protected:
 	CheckboxWidget *_globalMIDIOverride;
 	CheckboxWidget *_globalMT32Override;
 	CheckboxWidget *_globalVolumeOverride;
-
-	ExtraGuiOptions _engineOptions;
 };
 
 EditGameDialog::EditGameDialog(const String &domain, const String &desc)
@@ -236,7 +234,7 @@ EditGameDialog::EditGameDialog(const String &domain, const String &desc)
 	if (_engineOptions.size() > 0) {
 		tab->addTab(_("Engine"));
 
-		addEngineControls(tab, "GameOptions_Engine.", _engineOptions);
+		addEngineControls(tab, "GameOptions_Engine.");
 	}
 
 	//
@@ -416,20 +414,6 @@ void EditGameDialog::open() {
 		_langPopUp->setEnabled(false);
 	}
 
-	// Set the state of engine-specific checkboxes
-	for (uint j = 0; j < _engineOptions.size(); ++j) {
-		// The default values for engine-specific checkboxes are not set when
-		// ScummVM starts, as this would require us to load and poll all of the
-		// engine plugins on startup. Thus, we set the state of each custom
-		// option checkbox to what is specified by the engine plugin, and
-		// update it only if a value has been set in the configuration of the
-		// currently selected game.
-		bool isChecked = _engineOptions[j].defaultState;
-		if (ConfMan.hasKey(_engineOptions[j].configOption, _domain))
-			isChecked = ConfMan.getBool(_engineOptions[j].configOption, _domain);
-		_engineCheckboxes[j]->setState(isChecked);
-	}
-
 	const Common::PlatformDescription *p = Common::g_platforms;
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", _domain));
 	sel = 0;
@@ -472,11 +456,6 @@ void EditGameDialog::close() {
 			ConfMan.removeKey("platform", _domain);
 		else
 			ConfMan.set("platform", Common::getPlatformCode(platform), _domain);
-
-		// Set the state of engine-specific checkboxes
-		for (uint i = 0; i < _engineOptions.size(); i++) {
-			ConfMan.setBool(_engineOptions[i].configOption, _engineCheckboxes[i]->getState(), _domain);
-		}
 	}
 	OptionsDialog::close();
 }

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -315,6 +315,20 @@ void OptionsDialog::open() {
 		_subSpeedSlider->setValue(speed);
 		_subSpeedLabel->setValue(speed);
 	}
+
+	// Custom engine options
+	for (uint j = 0; j < _engineOptions.size(); ++j) {
+		// The default values for engine-specific checkboxes are not set when
+		// ScummVM starts, as this would require us to load and poll all of the
+		// engine plugins on startup. Thus, we set the state of each custom
+		// option checkbox to what is specified by the engine plugin, and
+		// update it only if a value has been set in the configuration of the
+		// currently selected game.
+		bool isChecked = _engineOptions[j].defaultState;
+		if (ConfMan.hasKey(_engineOptions[j].configOption, _domain))
+			isChecked = ConfMan.getBool(_engineOptions[j].configOption, _domain);
+		_engineCheckboxes[j]->setState(isChecked);
+	}
 }
 
 void OptionsDialog::close() {
@@ -441,6 +455,11 @@ void OptionsDialog::close() {
 			} else {
 				ConfMan.removeKey("music_driver", _domain);
 			}
+		}
+
+		// Custom engine options
+		for (uint i = 0; i < _engineOptions.size(); i++) {
+			ConfMan.setBool(_engineOptions[i].configOption, _engineCheckboxes[i]->getState(), _domain);
 		}
 
 		if (_oplPopUp) {
@@ -990,7 +1009,7 @@ void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &pre
 	_enableVolumeSettings = true;
 }
 
-void OptionsDialog::addEngineControls(GuiObject *boss, const Common::String &prefix, const ExtraGuiOptions &engineOptions) {
+void OptionsDialog::addEngineControls(GuiObject *boss, const Common::String &prefix) {
 	// Note: up to 7 engine options can currently fit on screen (the most that
 	// can fit in a 320x200 screen with the classic theme).
 	// TODO: Increase this number by including the checkboxes inside a scroll
@@ -999,7 +1018,7 @@ void OptionsDialog::addEngineControls(GuiObject *boss, const Common::String &pre
 
 	uint i = 1;
 	ExtraGuiOptions::const_iterator iter;
-	for (iter = engineOptions.begin(); iter != engineOptions.end(); ++iter, ++i) {
+	for (iter = _engineOptions.begin(); iter != _engineOptions.end(); ++iter, ++i) {
 		Common::String id = Common::String::format("%d", i);
 		_engineCheckboxes.push_back(new CheckboxWidget(boss,
 			prefix + "customOption" + id + "Checkbox", _(iter->label), _(iter->tooltip)));

--- a/gui/options.h
+++ b/gui/options.h
@@ -83,7 +83,7 @@ protected:
 	// The default value is the launcher's non-scaled talkspeed value. When SCUMM uses the widget,
 	// it uses its own scale
 	void addSubtitleControls(GuiObject *boss, const Common::String &prefix, int maxSliderVal = 255);
-	void addEngineControls(GuiObject *boss, const Common::String &prefix, const ExtraGuiOptions &engineOptions);
+	void addEngineControls(GuiObject *boss, const Common::String &prefix);
 
 	void setGraphicSettingsState(bool enabled);
 	void setAudioSettingsState(bool enabled);
@@ -194,6 +194,7 @@ protected:
 	//
 	// Engine-specific controls
 	//
+	ExtraGuiOptions _engineOptions;
 	CheckboxWidgetList _engineCheckboxes;
 };
 

--- a/gui/themes/scummmodern/scummmodern_layout.stx
+++ b/gui/themes/scummmodern/scummmodern_layout.stx
@@ -835,6 +835,9 @@
 						type = 'SmallLabel'
 				/>
 			</layout>
+			<widget name = 'customOption1Checkbox'
+					type = 'Checkbox'
+			/>
 			<space size = '60'/>
 			<layout type = 'horizontal' padding = '0, 0, 0, 0' spacing = '10'>
 				<widget name='Keys'


### PR DESCRIPTION
_Note_: This is a work in progress. I am submitting it to get feedback.

Curse of Monkey Island has a "Show Object Line" setting in its options that changes the way the "verb" line is displayed. It is currently configurable in ScummVM only through the command line and by manually editing the configuration file. This also means it's only configurable before starting the game, and not while it's running.

This is an attempt to expose the setting in the various graphical option dialogs, specifically the launcher's "Edit Game" and GMM. It had to change some of the GUI internals, since Scumm uses the global options menu.

The first task was to extend the GUI Options to GMM, taking the Launcher code that allows engine to inject their own settings in the "Edit Game" dialog and generalizing it to also add those settings to the in-game "Config" dialog. This was accomplished by moving all of the handling of the GUI elements to `OptionsDialog`, which both the Launcher's `EditGameDialog` and the in-game `ConfigDialog` inherit from. This allows the new setting to appear both in the "Edit Game" dialog and the in-game GMM options dialog.

I then hooked the setting into Scumm, and made sure it's only visible for COMI. I disassembled the scripts to find the variable that is controlled by that setting. (The current support for the setting uses Scumm's "registry" and doesn't reference the variable explicitly)

Things remaining to do:
- [ ] Add the settings to all themes. At the moment I have only added a single custom checkbox to the "Modern" theme. It might not be aligned nicely. I also need to check how many "placeholder" widgets can be crammed into the options dialog, as they take up room even when they're not rendered AFAICT.
- [ ] Figure out if any other engines that have custom settings, and use ScummVM's in-engine options menu are affected.
- [x] Add the new file with translatable strings to POTFILES.
- [ ] Should the new Scumm var have a named constant? A similar setting for Backyard Baseball 2003 (right above my change) doesn't use a constant.
- [ ] I added the setting to `ScummEngine::syncSoundSettings`. That's the logical place for it, but maybe the method should be renamed? :)
- [x] Split this into two commits, for GUI and SCUMM?
