### PR TITLE
DEBUGGER: Drop events when using readline debugger

### DIFF
--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -42,6 +42,7 @@
 #elif defined(USE_READLINE)
 	#include <readline/readline.h>
 	#include <readline/history.h>
+	#include "common/events.h"
 #endif
 
 
@@ -191,6 +192,15 @@ char *readline_completionFunction(const char *text, int state) {
 	return g_readline_debugger->readlineComplete(text, state);
 }
 
+void readline_eventFunction() {
+	Common::EventManager *eventMan = g_system->getEventManager();
+
+	Common::Event event;
+	while (eventMan->pollEvent(event)) {
+		// drop all events
+	}
+}
+
 #ifdef USE_READLINE_INT_COMPLETION
 typedef int RLCompFunc_t(const char *, int);
 #else
@@ -228,6 +238,7 @@ void Debugger::enter() {
 
 	g_readline_debugger = this;
 	rl_completion_entry_function = (RLCompFunc_t *)&readline_completionFunction;
+	rl_event_hook = (rl_hook_func_t *)&readline_eventFunction;
 
 	char *line_read = 0;
 	do {


### PR DESCRIPTION
Some Windows users find that Windows marks ScummVM as unresponsive when using the readline debugger, because it doesn't consume events. This patch fixes this by dropping all incoming events while readline is waiting for input (thanks @waltervn for verifying).

I have not tested this with non-GNU readline (i.e. the OS X one), which might not have rl_event_hook, so it would be nice if someone could test it there (and we can add an extra check to configure if necessary).