### PR TITLE
SCI: Clean up some aspects of call handling

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -3094,7 +3094,10 @@ bool Console::cmdBacktrace(int argc, const char **argv) {
 			break;
 
 		case EXEC_STACK_TYPE_KERNEL: // Kernel function
-			debugPrintf(" %x:[%x]  k%s(", i, call.debugOrigin, _engine->getKernel()->getKernelName(call.debugSelector).c_str());
+			if (call.debugKernelSubFunction == -1)
+				debugPrintf(" %x:[%x]  k%s(", i, call.debugOrigin, _engine->getKernel()->getKernelName(call.debugKernelFunction).c_str());
+			else
+				debugPrintf(" %x:[%x]  k%s(", i, call.debugOrigin, _engine->getKernel()->getKernelName(call.debugKernelFunction, call.debugKernelSubFunction).c_str());
 			break;
 
 		case EXEC_STACK_TYPE_VARSELECTOR:

--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -84,23 +84,15 @@ uint Kernel::getKernelNamesSize() const {
 }
 
 const Common::String &Kernel::getKernelName(uint number) const {
-	// FIXME: The following check is a temporary workaround for an issue
-	// leading to crashes when using the debugger's backtrace command.
-	if (number >= _kernelNames.size())
-		return _invalid;
+	assert(number < _kernelFuncs.size());
 	return _kernelNames[number];
 }
 
 Common::String Kernel::getKernelName(uint number, uint subFunction) const {
-	// FIXME: The following check is a temporary workaround for an issue
-	// leading to crashes when using the debugger's backtrace command.
-	if (number >= _kernelFuncs.size())
-		return _invalid;
+	assert(number < _kernelFuncs.size());
 	const KernelFunction &kernelCall = _kernelFuncs[number];
 
-	if (subFunction >= kernelCall.subFunctionCount)
-		return _invalid;
-
+	assert(subFunction < kernelCall.subFunctionCount);
 	return kernelCall.subFunctions[subFunction].name;
 }
 

--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -91,6 +91,20 @@ const Common::String &Kernel::getKernelName(uint number) const {
 	return _kernelNames[number];
 }
 
+Common::String Kernel::getKernelName(uint number, uint subFunction) const {
+	// FIXME: The following check is a temporary workaround for an issue
+	// leading to crashes when using the debugger's backtrace command.
+	if (number >= _kernelFuncs.size())
+		return _invalid;
+	const KernelFunction &kernelCall = _kernelFuncs[number];
+
+	if (subFunction >= kernelCall.subFunctionCount)
+		return _invalid;
+
+	return kernelCall.subFunctions[subFunction].name;
+}
+
+
 int Kernel::findKernelFuncPos(Common::String kernelFuncName) {
 	for (uint32 i = 0; i < _kernelNames.size(); i++)
 		if (_kernelNames[i] == kernelFuncName)

--- a/engines/sci/engine/kernel.h
+++ b/engines/sci/engine/kernel.h
@@ -158,6 +158,7 @@ public:
 
 	uint getKernelNamesSize() const;
 	const Common::String &getKernelName(uint number) const;
+	Common::String getKernelName(uint number, uint subFunction) const;
 
 	/**
 	 * Determines the selector ID of a selector by its name.

--- a/engines/sci/engine/kmisc.cpp
+++ b/engines/sci/engine/kmisc.cpp
@@ -605,18 +605,28 @@ reg_t kEmpty(EngineState *s, int argc, reg_t *argv) {
 reg_t kStub(EngineState *s, int argc, reg_t *argv) {
 	Kernel *kernel = g_sci->getKernel();
 	int kernelCallNr = -1;
+	int kernelSubCallNr = -1;
 
 	Common::List<ExecStack>::const_iterator callIterator = s->_executionStack.end();
 	if (callIterator != s->_executionStack.begin()) {
 		callIterator--;
 		ExecStack lastCall = *callIterator;
-		kernelCallNr = lastCall.debugSelector;
+		kernelCallNr = lastCall.debugKernelFunction;
+		kernelSubCallNr = lastCall.debugKernelSubFunction;
 	}
 
-	Common::String warningMsg = "Dummy function k" + kernel->getKernelName(kernelCallNr) +
-								Common::String::format("[%x]", kernelCallNr) +
-								" invoked. Params: " +
-								Common::String::format("%d", argc) + " (";
+	Common::String warningMsg;
+	if (kernelSubCallNr == -1) {
+		warningMsg = "Dummy function k" + kernel->getKernelName(kernelCallNr) +
+		             Common::String::format("[%x]", kernelCallNr);
+	} else {
+		warningMsg = "Dummy function k" + kernel->getKernelName(kernelCallNr, kernelSubCallNr) +
+		             Common::String::format("[%x:%x]", kernelCallNr, kernelSubCallNr);
+
+	}
+
+	warningMsg += " invoked. Params: " +
+	              Common::String::format("%d", argc) + " (";
 
 	for (int i = 0; i < argc; i++) {
 		warningMsg +=  Common::String::format("%04x:%04x", PRINT_REG(argv[i]));

--- a/engines/sci/engine/vm.cpp
+++ b/engines/sci/engine/vm.cpp
@@ -834,7 +834,6 @@ void run_vm(EngineState *s) {
 			int argc = (opparams[1] >> 1) // Given as offset, but we need count
 			           + 1 + s->r_rest;
 			StackPtr call_base = s->xs->sp - argc;
-			s->xs->sp[1].incOffset(s->r_rest);
 
 			uint32 localCallOffset = s->xs->addr.pc.getOffset() + opparams[0];
 

--- a/engines/sci/engine/vm.h
+++ b/engines/sci/engine/vm.h
@@ -93,16 +93,19 @@ struct ExecStack {
 
 	SegmentId local_segment; // local variables etc
 
-	Selector debugSelector;   // The selector which was used to call or -1 if not applicable
-	int debugExportId;        // The exportId which was called or -1 if not applicable
-	int debugLocalCallOffset; // Local call offset or -1 if not applicable
-	int debugOrigin;          // The stack frame position the call was made from, or -1 if it was the initial call
+	Selector debugSelector;     // The selector which was used to call or -1 if not applicable
+	int debugExportId;          // The exportId which was called or -1 if not applicable
+	int debugLocalCallOffset;   // Local call offset or -1 if not applicable
+	int debugOrigin;            // The stack frame position the call was made from, or -1 if it was the initial call
+	int debugKernelFunction;    // The kernel function called, or -1 if not applicable
+	int debugKernelSubFunction; // The kernel subfunction called, or -1 if not applicable
 	ExecStackType type;
 
 	reg_t* getVarPointer(SegManager *segMan) const;
 
 	ExecStack(reg_t objp_, reg_t sendp_, StackPtr sp_, int argc_, StackPtr argp_,
 				SegmentId localsSegment_, reg32_t pc_, Selector debugSelector_,
+				int debugKernelFunction_, int debugKernelSubFunction_,
 				int debugExportId_, int debugLocalCallOffset_, int debugOrigin_,
 				ExecStackType type_) {
 		objp = objp_;
@@ -118,6 +121,8 @@ struct ExecStack {
 		else
 			local_segment = pc_.getSegment();
 		debugSelector = debugSelector_;
+		debugKernelFunction = debugKernelFunction_;
+		debugKernelSubFunction = debugKernelSubFunction_;
 		debugExportId = debugExportId_;
 		debugLocalCallOffset = debugLocalCallOffset_;
 		debugOrigin = debugOrigin_;

--- a/engines/sci/engine/vm.h
+++ b/engines/sci/engine/vm.h
@@ -115,7 +115,6 @@ struct ExecStack {
 		fp = sp = sp_;
 		argc = argc_;
 		variables_argp = argp_;
-		*variables_argp = make_reg(0, argc);  // The first argument is argc
 		if (localsSegment_ != 0xFFFF)
 			local_segment = localsSegment_;
 		else

--- a/engines/sci/engine/workarounds.cpp
+++ b/engines/sci/engine/workarounds.cpp
@@ -780,7 +780,7 @@ SciWorkaroundSolution trackOriginAndFindWorkaround(int index, const SciWorkaroun
 		Common::List<ExecStack>::const_iterator callIterator = state->_executionStack.end();
 		while (callIterator != state->_executionStack.begin()) {
 			callIterator--;
-			ExecStack loopCall = *callIterator;
+			const ExecStack &loopCall = *callIterator;
 			if ((loopCall.debugSelector != -1) || (loopCall.debugExportId != -1)) {
 				lastCall->debugSelector = loopCall.debugSelector;
 				lastCall->debugExportId = loopCall.debugExportId;


### PR DESCRIPTION
This has a few risky commits:

"Improve kernel subfunction logging" adds kernel subfunction information to ExecStack, and removes the re-use of debugSelector for kernel call information. I think I untangled all uses of this, but this could use review and testing. (Especially in workaround processing.)

"Remove unclear &rest handling" is potentially dangerous. It removes a change to a value _above_ the current stack pointer, which seems to have no clear effect. My guess is that this is an unintended part of these two commits from FreeSCI[*], attempting to adjust argc on the stack. Incorrectly setting argc would not necessarily have been noticed, as `add_exec_stack_entry` would store it on the stack properly afterwards. This also needs review and testing.

[*] wjp/freesci-archive@349958902d0e7a3f66e949c46cdac4633462cd8c and wjp/freesci-archive@b4daf42d0c75c042b2c0ce076e78167431879291 

"Remove unexpected side effect from ExecStack constructor" moves setting `argp[0]` to `argc` from its very well-hidden spot in a constructor to the calling code, to make stack handling more explicit. This needs review too.