### PR TITLE
GUI: Fix the cursor lags in the launcher

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -304,9 +304,9 @@ void GuiManager::runLoop() {
 //		_system->updateScreen();
 
 		if (lastRedraw + waitTime < _system->getMillis(true)) {
+			lastRedraw = _system->getMillis(true);
 			_theme->updateScreen();
 			_system->updateScreen();
-			lastRedraw = _system->getMillis(true);
 		}
 
 		Common::Event event;
@@ -342,9 +342,9 @@ void GuiManager::runLoop() {
 
 
 			if (lastRedraw + waitTime < _system->getMillis(true)) {
+				lastRedraw = _system->getMillis(true);
 				_theme->updateScreen();
 				_system->updateScreen();
-				lastRedraw = _system->getMillis(true);
 			}
 		}
 

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -286,7 +286,7 @@ void GuiManager::runLoop() {
 
 	Common::EventManager *eventMan = _system->getEventManager();
 	uint32 lastRedraw = 0;
-	const uint32 waitTime = 1000 / 45;
+	const uint32 waitTime = 1000 / 60;
 
 	bool tooltipCheck = false;
 


### PR DESCRIPTION
_Disclaimer: I only have basic understanding of C++. The commit I did fixed the problem for my, but I can absolutely not guarantee it has some unwanted side effects. Extensive testing on all backends is highly recommended before merging. It's also very possible I fix this the wrong way._

_The main purpose of this pull request is discussing this issue._

On my current Windows 10 laptop, the mouse cursor in the launcher has a very high lag. It doesn't move smoothly, but stutters. I had the same problem on my Intel Quad-Core with Windows 7 and on Ubuntu. @raziel- reported the same issues on the AmigaOS builds. I don't know if more backends are affected.

The two lines I re-enabled were introduced back in 2008 with commit 85c36885f5bbf2d47276c7702f1b8ccbf22ecc34.

After removing the comment marks, the cursor behaves very smooth on my weak Windows 10 laptop. I couldn't find any side effects, but again, this is mainly for discussion and needs some testing. I can't imagine the original author commented these lines out just for fun. Unfortunately, I can't test with Linux, because I never get a good performance inside a VM and I don't have any spare PC to test.