### PR TITLE
COMMON: Add Apple II platform

### DIFF
--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -27,6 +27,7 @@ namespace Common {
 
 const PlatformDescription g_platforms[] = {
 	{ "2gs", "2gs", "2gs", "Apple IIgs", kPlatformApple2GS },
+	{ "apple2", "apple2", "apple2", "Apple II", kPlatformApple2 },
 	{ "3do", "3do", "3do", "3DO", kPlatform3DO },
 	{ "acorn", "acorn", "acorn", "Acorn", kPlatformAcorn },
 	{ "amiga", "ami", "amiga", "Amiga", kPlatformAmiga },

--- a/common/platform.h
+++ b/common/platform.h
@@ -50,6 +50,7 @@ enum Platform {
 	kPlatformSegaCD,
 	kPlatform3DO,
 	kPlatformPCEngine,
+	kPlatformApple2,
 	kPlatformApple2GS,
 	kPlatformPC98,
 	kPlatformWii,


### PR DESCRIPTION
Add Apple II to our possible game platforms list (which is not the same as the Apple IIgs which is already there).