### PR TITLE
GOB: Reduce audio header dependencies

### DIFF
--- a/engines/gob/gob.cpp
+++ b/engines/gob/gob.cpp
@@ -26,6 +26,7 @@
 #include "base/plugins.h"
 #include "common/config-manager.h"
 #include "audio/mididrv.h"
+#include "audio/mixer.h"
 
 #include "gui/gui-manager.h"
 #include "gui/dialog.h"

--- a/engines/gob/inter_playtoons.cpp
+++ b/engines/gob/inter_playtoons.cpp
@@ -41,7 +41,6 @@
 #include "gob/video.h"
 #include "gob/videoplayer.h"
 #include "gob/save/saveload.h"
-#include "gob/sound/sound.h"
 
 namespace Gob {
 

--- a/engines/gob/inter_v4.cpp
+++ b/engines/gob/inter_v4.cpp
@@ -205,7 +205,7 @@ void Inter_v4::o4_playVmdOrMusic() {
 		return;
 	} else if (props.lastFrame == -9) {
 		_vm->_sound->bgStop();
-		_vm->_sound->bgSetPlayMode(BackgroundAtmosphere::kPlayModeRandom);
+		_vm->_sound->bgSetPlayMode(Sound::kPlayModeRandom);
 		_vm->_sound->bgPlay(file.c_str(), "SND", SOUND_SND, props.palStart);
 		return;
 	} else if (props.lastFrame < 0) {

--- a/engines/gob/pregob/onceupon/onceupon.cpp
+++ b/engines/gob/pregob/onceupon/onceupon.cpp
@@ -30,8 +30,6 @@
 #include "gob/anifile.h"
 #include "gob/aniobject.h"
 
-#include "gob/sound/sound.h"
-
 #include "gob/pregob/txtfile.h"
 #include "gob/pregob/gctfile.h"
 

--- a/engines/gob/pregob/pregob.h
+++ b/engines/gob/pregob/pregob.h
@@ -29,14 +29,14 @@
 #include "gob/util.h"
 #include "gob/aniobject.h"
 
-#include "gob/sound/sounddesc.h"
-
 #include "gob/pregob/txtfile.h"
 
 namespace Gob {
 
 class GobEngine;
+class ANIFile;
 class Surface;
+class SoundDesc;
 
 class GCTFile;
 

--- a/engines/gob/sound/bgatmosphere.cpp
+++ b/engines/gob/sound/bgatmosphere.cpp
@@ -23,6 +23,7 @@
 #include "common/array.h"
 
 #include "gob/sound/bgatmosphere.h"
+#include "gob/sound/sound.h"
 #include "gob/sound/sounddesc.h"
 
 namespace Gob {
@@ -30,7 +31,7 @@ namespace Gob {
 BackgroundAtmosphere::BackgroundAtmosphere(Audio::Mixer &mixer) :
 	SoundMixer(mixer, Audio::Mixer::kMusicSoundType), _rnd("gobBA") {
 
-	_playMode = kPlayModeLinear;
+	_playMode = Sound::kPlayModeLinear;
 	_queuePos = -1;
 	_shaded = false;
 	_shadable = true;
@@ -56,7 +57,7 @@ void BackgroundAtmosphere::stopBA() {
 	SoundMixer::stop(0);
 }
 
-void BackgroundAtmosphere::setPlayMode(PlayMode mode) {
+void BackgroundAtmosphere::setPlayMode(Sound::BackgroundPlayMode mode) {
 	_playMode = mode;
 }
 
@@ -100,11 +101,11 @@ void BackgroundAtmosphere::getNextQueuePos() {
 
 	switch (_playMode) {
 
-	case kPlayModeLinear:
+	case Sound::kPlayModeLinear:
 		_queuePos = (_queuePos + 1) % _queue.size();
 		break;
 
-	case kPlayModeRandom:
+	case Sound::kPlayModeRandom:
 		_queuePos = _rnd.getRandomNumber(_queue.size() - 1);
 		break;
 

--- a/engines/gob/sound/bgatmosphere.h
+++ b/engines/gob/sound/bgatmosphere.h
@@ -27,6 +27,7 @@
 #include "common/mutex.h"
 #include "common/random.h"
 
+#include "gob/sound/sound.h"
 #include "gob/sound/soundmixer.h"
 
 namespace Audio {
@@ -39,18 +40,13 @@ class SoundDesc;
 
 class BackgroundAtmosphere : private SoundMixer {
 public:
-	enum PlayMode {
-		kPlayModeLinear,
-		kPlayModeRandom
-	};
-
 	BackgroundAtmosphere(Audio::Mixer &mixer);
 	~BackgroundAtmosphere();
 
 	void playBA();
 	void stopBA();
 
-	void setPlayMode(PlayMode mode);
+	void setPlayMode(Sound::BackgroundPlayMode mode);
 
 	void queueSample(SoundDesc &sndDesc);
 	void queueClear();
@@ -60,7 +56,7 @@ public:
 	void unshade();
 
 private:
-	PlayMode _playMode;
+	Sound::BackgroundPlayMode _playMode;
 
 	Common::Array<SoundDesc *> _queue;
 	int _queuePos;

--- a/engines/gob/sound/sound.cpp
+++ b/engines/gob/sound/sound.cpp
@@ -28,6 +28,7 @@
 #include "gob/game.h"
 #include "gob/inter.h"
 
+#include "gob/sound/bgatmosphere.h"
 #include "gob/sound/pcspeaker.h"
 #include "gob/sound/soundblaster.h"
 #include "gob/sound/adlplayer.h"
@@ -717,7 +718,7 @@ void Sound::bgStop() {
 	_bgatmos->queueClear();
 }
 
-void Sound::bgSetPlayMode(BackgroundAtmosphere::PlayMode mode) {
+void Sound::bgSetPlayMode(Sound::BackgroundPlayMode mode) {
 	if (!_bgatmos)
 		return;
 

--- a/engines/gob/sound/sound.h
+++ b/engines/gob/sound/sound.h
@@ -23,12 +23,13 @@
 #ifndef GOB_SOUND_SOUND_H
 #define GOB_SOUND_SOUND_H
 
+#include "common/str.h"
 #include "gob/sound/sounddesc.h"
-#include "gob/sound/bgatmosphere.h"
 
 namespace Gob {
 
 class GobEngine;
+class BackgroundAtmosphere;
 class PCSpeaker;
 class SoundBlaster;
 class ADLPlayer;
@@ -39,6 +40,11 @@ class CDROM;
 
 class Sound {
 public:
+	enum BackgroundPlayMode {
+		kPlayModeLinear,
+		kPlayModeRandom
+	};
+
 	static const int kSoundsCount = 60;
 
 	Sound(GobEngine *vm);
@@ -135,7 +141,7 @@ public:
 	void bgPlay(const char *base, const char *ext, SoundType type, int count);
 	void bgStop();
 
-	void bgSetPlayMode(BackgroundAtmosphere::PlayMode mode);
+	void bgSetPlayMode(BackgroundPlayMode mode);
 
 	void bgShade();
 	void bgUnshade();

--- a/engines/gob/videoplayer.cpp
+++ b/engines/gob/videoplayer.cpp
@@ -21,6 +21,8 @@
  */
 
 
+#include "video/coktel_decoder.h"
+
 #include "gob/videoplayer.h"
 #include "gob/global.h"
 #include "gob/dataio.h"

--- a/engines/gob/videoplayer.h
+++ b/engines/gob/videoplayer.h
@@ -29,10 +29,13 @@
 #include "common/str.h"
 
 #include "graphics/surface.h"
-#include "video/coktel_decoder.h"
 
 #include "gob/util.h"
 #include "gob/draw.h"
+
+namespace Video {
+class CoktelDecoder;
+}
 
 namespace Gob {
 


### PR DESCRIPTION
This is an attempt to decouple the audio parts of GOB from the rest of the engine.

I moved the background atmosphere audio enum from `bgatmosphere.h` to `sound.h`, so files that want to use `sound.h` won't have to include `bgatmosphere.h` which includes the `audio/` headers.

The result:
If you change a file in `audio/`, only 8 gob files are recompiled instead of 39.