### PR TITLE
FULLPIPE: Reduce audio header dependencies

### DIFF
--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -24,6 +24,7 @@
 
 #include "common/archive.h"
 #include "common/config-manager.h"
+#include "audio/mixer.h"
 
 #include "engines/util.h"
 
@@ -112,6 +113,8 @@ FullpipeEngine::FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc)
 	_musicLocal = 0;
 	_trackStartDelay = 0;
 
+	_sceneTrackHandle = new Audio::SoundHandle();
+
 	memset(_sceneTracks, 0, sizeof(_sceneTracks));
 	memset(_trackName, 0, sizeof(_trackName));
 	memset(_sceneTracksCurrentTrack, 0, sizeof(_sceneTracksCurrentTrack));
@@ -192,6 +195,7 @@ FullpipeEngine::~FullpipeEngine() {
 	delete _rnd;
 	delete _console;
 	delete _globalMessageQueueList;
+	delete _sceneTrackHandle;
 }
 
 void FullpipeEngine::initialize() {

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -30,8 +30,6 @@
 #include "common/savefile.h"
 #include "common/system.h"
 
-#include "audio/mixer.h"
-
 #include "graphics/transparent_surface.h"
 
 #include "engines/engine.h"
@@ -40,6 +38,10 @@
 #include "fullpipe/console.h"
 
 struct ADGameDescription;
+
+namespace Audio {
+class SoundHandle;
+}
 
 namespace Fullpipe {
 
@@ -312,7 +314,7 @@ public:
 	void lift_openLift();
 
 	GameVar *_musicGameVar;
-	Audio::SoundHandle _sceneTrackHandle;
+	Audio::SoundHandle *_sceneTrackHandle;
 
 public:
 

--- a/engines/fullpipe/sound.h
+++ b/engines/fullpipe/sound.h
@@ -23,6 +23,10 @@
 #ifndef FULLPIPE_SOUND_H
 #define FULLPIPE_SOUND_H
 
+namespace Audio {
+class SoundHandle;
+}
+
 namespace Fullpipe {
 
 class Sound : public MemoryObject {
@@ -31,7 +35,7 @@ class Sound : public MemoryObject {
 	int _directSoundBuffer;
 	int _directSoundBuffers[7];
 	byte *_soundData;
-	Audio::SoundHandle _handle;
+	Audio::SoundHandle *_handle;
 	int _volume;
 
 public:
@@ -45,7 +49,7 @@ public:
 	virtual bool load(MfcArchive &file) { assert(0); return false; } // Disable base class
 	void updateVolume();
 	int getId() const { return _id; }
-	Audio::SoundHandle getHandle() const { return _handle; }
+	Audio::SoundHandle *getHandle() const { return _handle; }
 
 	void play(int flag);
 	void freeSound();


### PR DESCRIPTION
This is an attempt to decouple the audio parts of FULLPIPE from the rest of the engine.

I changed all the `SoundHandle`s to pointers, so `fullpipe.h` and `sound.h` don't have to include `audio/mixer.h`.

The result:
If you change `audio/mixer.h`, only 3 fullpipe files are recompiled instead of 64.