### PR TITLE
GUI: Remove 'sticky button' feature

### DIFF
--- a/gui/predictivedialog.cpp
+++ b/gui/predictivedialog.cpp
@@ -190,7 +190,7 @@ void PredictiveDialog::saveUserDictToFile() {
 
 void PredictiveDialog::handleKeyUp(Common::KeyState state) {
 	if (_curPressedButton != kNoAct && !_needRefresh) {
-		_button[_curPressedButton]->startAnimatePressedState();
+		_button[_curPressedButton]->setUnpressedState();
 		processButton(_curPressedButton);
 	}
 }
@@ -352,7 +352,7 @@ void PredictiveDialog::handleKeyDown(Common::KeyState state) {
 	}
 
 	if (_lastButton != _curPressedButton)
-		_button[_lastButton]->stopAnimatePressedState();
+		_button[_lastButton]->setUnpressedState();
 
 	if (_curPressedButton != kNoAct && !_needRefresh)
 		_button[_curPressedButton]->setPressedState();
@@ -601,18 +601,6 @@ void PredictiveDialog::processButton(ButtonId button) {
 	if (button == kCancelAct) {
 		saveUserDictToFile();
 		close();
-	}
-}
-
-void PredictiveDialog::handleTickle() {
-	if (_lastTime) {
-		if ((_curTime - _lastTime) > kRepeatDelay) {
-			_lastTime = 0;
-		}
-	}
-
-	if (getTickleWidget()) {
-		getTickleWidget()->handleTickle();
 	}
 }
 

--- a/gui/predictivedialog.h
+++ b/gui/predictivedialog.h
@@ -43,7 +43,6 @@ public:
 	virtual void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data);
 	virtual void handleKeyUp(Common::KeyState state);
 	virtual void handleKeyDown(Common::KeyState state);
-	virtual void handleTickle();
 
 	const char *getResult() const { return _predictiveResult; }
 

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -299,7 +299,7 @@ ButtonWidget::ButtonWidget(GuiObject *boss, const Common::String &name, const Co
 
 void ButtonWidget::handleMouseUp(int x, int y, int button, int clickCount) {
 	if (isEnabled() && _duringPress && x >= 0 && x < _w && y >= 0 && y < _h) {
-		startAnimatePressedState();
+		setUnpressedState();
 		sendCommand(_cmd, 0);
 	}
 	_duringPress = false;
@@ -344,38 +344,15 @@ void ButtonWidget::setHighLighted(bool enable) {
 	draw();
 }
 
-void ButtonWidget::handleTickle() {
-	if (_lastTime) {
-		uint32 curTime = g_system->getMillis();
-		if (curTime - _lastTime > kPressedButtonTime) {
-			stopAnimatePressedState();
-		}
-	}
-}
-
 void ButtonWidget::setPressedState() {
-	wantTickle(true);
 	setFlags(WIDGET_PRESSED);
 	clearFlags(WIDGET_HILITED);
 	draw();
 }
 
-void ButtonWidget::stopAnimatePressedState() {
-	wantTickle(false);
-	_lastTime = 0;
+void ButtonWidget::setUnpressedState() {
 	clearFlags(WIDGET_PRESSED);
 	draw();
-}
-
-void ButtonWidget::startAnimatePressedState() {
-	_lastTime = g_system->getMillis();
-}
-
-void ButtonWidget::wantTickle(bool tickled) {
-	if (tickled)
-		((GUI::Dialog *)_boss)->setTickleWidget(this);
-	else
-		((GUI::Dialog *)_boss)->unSetTickleWidget();
 }
 
 #pragma mark -

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -201,17 +201,12 @@ public:
 	void handleMouseDown(int x, int y, int button, int clickCount);
 	void handleMouseEntered(int button)	{ if (_duringPress) { setFlags(WIDGET_PRESSED); } else { setFlags(WIDGET_HILITED); } draw(); }
 	void handleMouseLeft(int button)	{ clearFlags(WIDGET_HILITED | WIDGET_PRESSED); draw(); }
-	void handleTickle();
 
 	void setHighLighted(bool enable);
 	void setPressedState();
-	void startAnimatePressedState();
-	void stopAnimatePressedState();
-
-	void lostFocusWidget() { stopAnimatePressedState(); }
+	void setUnpressedState();
 protected:
 	void drawWidget();
-	void wantTickle(bool tickled);
 	bool _duringPress;
 private:
 	uint32 _lastTime;


### PR DESCRIPTION
This feature made pressed buttons wait a few moments before returning to an unpressed state. It was half-implemented, and caused several visual bugs.

Fixes [#7083](https://sourceforge.net/p/scummvm/bugs/7083/), which details the bugs involved.

The predictive dialog is buggy. It was buggy before this change, and I only made enough changes so it would compile. If you try to press two num keys at once on the keyboard, you'll notice that the first button pressed will maintain its "pressed" animation.

Once this is merged, I will open a new bug about the predictive dialog, and we can discuss how it should handle multiple key presses.