### PR TITLE
NEVERHOOD: Reduce audio header dependencies

### DIFF
--- a/engines/neverhood/diskplayerscene.cpp
+++ b/engines/neverhood/diskplayerscene.cpp
@@ -22,6 +22,7 @@
 
 #include "neverhood/diskplayerscene.h"
 #include "neverhood/mouse.h"
+#include "neverhood/smackerplayer.h"
 
 namespace Neverhood {
 

--- a/engines/neverhood/diskplayerscene.h
+++ b/engines/neverhood/diskplayerscene.h
@@ -26,11 +26,11 @@
 #include "neverhood/neverhood.h"
 #include "neverhood/resourceman.h"
 #include "neverhood/scene.h"
-#include "neverhood/smackerplayer.h"
 
 namespace Neverhood {
 
 class DiskplayerScene;
+class SmackerPlayer;
 
 class AsDiskplayerSceneKey : public AnimatedSprite {
 public:

--- a/engines/neverhood/menumodule.cpp
+++ b/engines/neverhood/menumodule.cpp
@@ -23,6 +23,8 @@
 #include "common/config-manager.h"
 #include "common/translation.h"
 
+#include "audio/mixer.h"
+
 #include "gui/saveload.h"
 
 #include "neverhood/menumodule.h"

--- a/engines/neverhood/modules/module1300.cpp
+++ b/engines/neverhood/modules/module1300.cpp
@@ -23,6 +23,7 @@
 #include "neverhood/diskplayerscene.h"
 #include "neverhood/gamemodule.h"
 #include "neverhood/menumodule.h"
+#include "neverhood/smackerplayer.h"
 #include "neverhood/modules/module1000_sprites.h"
 #include "neverhood/modules/module1200_sprites.h"
 #include "neverhood/modules/module1300.h"

--- a/engines/neverhood/modules/module1300.h
+++ b/engines/neverhood/modules/module1300.h
@@ -26,9 +26,10 @@
 #include "neverhood/neverhood.h"
 #include "neverhood/module.h"
 #include "neverhood/scene.h"
-#include "neverhood/smackerplayer.h"
 
 namespace Neverhood {
+
+class SmackerPlayer;
 
 class Module1300 : public Module {
 public:

--- a/engines/neverhood/modules/module1300_sprites.h
+++ b/engines/neverhood/modules/module1300_sprites.h
@@ -26,7 +26,6 @@
 #include "neverhood/neverhood.h"
 #include "neverhood/module.h"
 #include "neverhood/scene.h"
-#include "neverhood/smackerplayer.h"
 
 namespace Neverhood {
 

--- a/engines/neverhood/modules/module2800.cpp
+++ b/engines/neverhood/modules/module2800.cpp
@@ -23,6 +23,7 @@
 #include "neverhood/diskplayerscene.h"
 #include "neverhood/gamemodule.h"
 #include "neverhood/scene.h"
+#include "neverhood/smackerplayer.h"
 #include "neverhood/modules/module1000_sprites.h"
 #include "neverhood/modules/module1200_sprites.h"
 #include "neverhood/modules/module1700_sprites.h"

--- a/engines/neverhood/navigationscene.h
+++ b/engines/neverhood/navigationscene.h
@@ -26,6 +26,7 @@
 #include "neverhood/neverhood.h"
 #include "neverhood/resourceman.h"
 #include "neverhood/scene.h"
+#include "neverhood/smackerplayer.h"
 
 namespace Neverhood {
 

--- a/engines/neverhood/neverhood.cpp
+++ b/engines/neverhood/neverhood.cpp
@@ -24,6 +24,8 @@
 #include "common/config-manager.h"
 #include "common/textconsole.h"
 
+#include "audio/mixer.h"
+
 #include "base/plugins.h"
 #include "base/version.h"
 

--- a/engines/neverhood/scene.cpp
+++ b/engines/neverhood/scene.cpp
@@ -22,6 +22,7 @@
 
 #include "neverhood/console.h"
 #include "neverhood/scene.h"
+#include "neverhood/smackerplayer.h"
 
 namespace Neverhood {
 

--- a/engines/neverhood/scene.h
+++ b/engines/neverhood/scene.h
@@ -31,13 +31,13 @@
 #include "neverhood/klaymen.h"
 #include "neverhood/module.h"
 #include "neverhood/palette.h"
-#include "neverhood/smackerplayer.h"
 #include "neverhood/sprite.h"
 #include "neverhood/staticdata.h"
 
 namespace Neverhood {
 
 class Console;
+class SmackerPlayer;
 
 class Scene : public Entity {
 public:

--- a/engines/neverhood/screen.cpp
+++ b/engines/neverhood/screen.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "graphics/palette.h"
+#include "video/smk_decoder.h"
 #include "neverhood/screen.h"
 
 namespace Neverhood {

--- a/engines/neverhood/screen.h
+++ b/engines/neverhood/screen.h
@@ -25,10 +25,13 @@
 
 #include "common/array.h"
 #include "graphics/surface.h"
-#include "video/smk_decoder.h"
 #include "neverhood/neverhood.h"
 #include "neverhood/microtiles.h"
 #include "neverhood/graphics.h"
+
+namespace Video {
+	class SmackerDecoder;
+}
 
 namespace Neverhood {
 

--- a/engines/neverhood/smackerscene.cpp
+++ b/engines/neverhood/smackerscene.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "neverhood/smackerscene.h"
+#include "neverhood/smackerplayer.h"
 
 namespace Neverhood {
 

--- a/engines/neverhood/sound.h
+++ b/engines/neverhood/sound.h
@@ -24,23 +24,22 @@
 #define NEVERHOOD_SOUND_H
 
 #include "audio/audiostream.h"
-#include "audio/mixer.h"
 #include "common/array.h"
-#include "graphics/surface.h"
-#include "neverhood/neverhood.h"
-#include "neverhood/resource.h"
+#include "neverhood/resourceman.h"
+
+namespace Common {
+class SeekableReadStream;
+}
+
+namespace Audio {
+class SoundHandle;
+}
 
 namespace Neverhood {
 
-// Convert volume from percent to 0..255
-#define VOLUME(volume) (Audio::Mixer::kMaxChannelVolume / 100 * (volume))
-
-// Convert panning from percent (50% equals center) to -127..0..+127
-#define PANNING(panning) (254 / 100 * (panning) - 127)
-
+class NeverhoodEngine;
 class AudioResourceManSoundItem;
 class AudioResourceManMusicItem;
-class AudioResourceMan;
 
 class SoundResource {
 public:
@@ -214,6 +213,7 @@ private:
 class AudioResourceManSoundItem {
 public:
 	AudioResourceManSoundItem(NeverhoodEngine *vm, uint32 fileHash);
+	~AudioResourceManSoundItem();
 	void loadSound();
 	void unloadSound();
 	void setVolume(int16 volume);
@@ -230,12 +230,13 @@ protected:
 	bool _isPlaying;
 	int16 _volume;
 	int16 _panning;
-	Audio::SoundHandle _soundHandle;
+	Audio::SoundHandle *_soundHandle;
 };
 
 class AudioResourceManMusicItem {
 public:
 	AudioResourceManMusicItem(NeverhoodEngine *vm, uint32 fileHash);
+	~AudioResourceManMusicItem();
 	void playMusic(int16 fadeVolumeStep);
 	void stopMusic(int16 fadeVolumeStep);
 	void unloadMusic();
@@ -259,7 +260,7 @@ protected:
 	bool _isFadingOut;
 	int16 _fadeVolume;
 	int16 _fadeVolumeStep;
-	Audio::SoundHandle _soundHandle;
+	Audio::SoundHandle *_soundHandle;
 };
 
 class AudioResourceMan {


### PR DESCRIPTION
Changed `SoundHandle` to pointers and moved some `#define`s and `#include`s around.

When modifying `audio/mixer.h`, only 17 files require recompilation instead of 59.
