### PR TITLE
SCUMM: Reduce audio header dependencies

### DIFF
--- a/engines/scumm/he/sound_he.cpp
+++ b/engines/scumm/he/sound_he.cpp
@@ -51,10 +51,12 @@ SoundHE::SoundHE(ScummEngine *parent, Audio::Mixer *mixer)
 	_heMusicTracks(0) {
 
 	memset(_heChannel, 0, sizeof(_heChannel));
+	_heSoundChannels = new Audio::SoundHandle[8]();
 }
 
 SoundHE::~SoundHE() {
 	free(_heMusic);
+	delete[] _heSoundChannels;
 }
 
 void SoundHE::addSoundToQueue(int sound, int heOffset, int heChannel, int heFlags) {

--- a/engines/scumm/he/sound_he.h
+++ b/engines/scumm/he/sound_he.h
@@ -44,7 +44,7 @@ protected:
 	HEMusic *_heMusic;
 	int16 _heMusicTracks;
 
-	Audio::SoundHandle _heSoundChannels[8];
+	Audio::SoundHandle *_heSoundChannels;
 
 public: // Used by createSound()
 	struct {

--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -24,6 +24,7 @@
 #include "common/events.h"
 #include "common/system.h"
 #include "common/translation.h"
+#include "audio/mixer.h"
 
 #include "scumm/debugger.h"
 #include "scumm/dialogs.h"

--- a/engines/scumm/smush/smush_player.cpp
+++ b/engines/scumm/smush/smush_player.cpp
@@ -25,6 +25,8 @@
 #include "common/system.h"
 #include "common/util.h"
 
+#include "audio/mixer.h"
+
 #include "graphics/cursorman.h"
 #include "graphics/palette.h"
 
@@ -242,9 +244,15 @@ SmushPlayer::SmushPlayer(ScummEngine_v7 *scumm) {
 	_paused = false;
 	_pauseStartTime = 0;
 	_pauseTime = 0;
+
+
+	_IACTchannel = new Audio::SoundHandle();
+	_compressedFileSoundHandle = new Audio::SoundHandle();
 }
 
 SmushPlayer::~SmushPlayer() {
+	delete _IACTchannel;
+	delete _compressedFileSoundHandle;
 }
 
 void SmushPlayer::init(int32 speed) {
@@ -271,8 +279,8 @@ void SmushPlayer::init(int32 speed) {
 	vs->pitch = vs->w;
 	_vm->_gdi->_numStrips = vs->w / 8;
 
-	_vm->_mixer->stopHandle(_compressedFileSoundHandle);
-	_vm->_mixer->stopHandle(_IACTchannel);
+	_vm->_mixer->stopHandle(*_compressedFileSoundHandle);
+	_vm->_mixer->stopHandle(*_IACTchannel);
 	_IACTpos = 0;
 	_vm->_smixer->stop();
 }
@@ -470,7 +478,7 @@ void SmushPlayer::handleIACT(int32 subSize, Common::SeekableReadStream &b) {
 
 					if (!_IACTstream) {
 						_IACTstream = Audio::makeQueuingAudioStream(22050, true);
-						_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_IACTchannel, _IACTstream);
+						_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, _IACTchannel, _IACTstream);
 					}
 					_IACTstream->queueBuffer(output_data, 0x1000, DisposeAfterUse::YES, Audio::FLAG_STEREO | Audio::FLAG_16BITS);
 
@@ -1091,7 +1099,7 @@ void SmushPlayer::seekSan(const char *file, int32 pos, int32 contFrame) {
 }
 
 void SmushPlayer::tryCmpFile(const char *filename) {
-	_vm->_mixer->stopHandle(_compressedFileSoundHandle);
+	_vm->_mixer->stopHandle(*_compressedFileSoundHandle);
 
 	_compressedFileMode = false;
 	const char *i = strrchr(filename, '.');
@@ -1110,7 +1118,7 @@ void SmushPlayer::tryCmpFile(const char *filename) {
 	strcpy(fname + (i - filename), ".ogg");
 	if (file->open(fname)) {
 		_compressedFileMode = true;
-		_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_compressedFileSoundHandle, Audio::makeVorbisStream(file, DisposeAfterUse::YES));
+		_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, _compressedFileSoundHandle, Audio::makeVorbisStream(file, DisposeAfterUse::YES));
 		return;
 	}
 #endif
@@ -1119,7 +1127,7 @@ void SmushPlayer::tryCmpFile(const char *filename) {
 	strcpy(fname + (i - filename), ".mp3");
 	if (file->open(fname)) {
 		_compressedFileMode = true;
-		_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_compressedFileSoundHandle, Audio::makeMP3Stream(file, DisposeAfterUse::YES));
+		_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, _compressedFileSoundHandle, Audio::makeMP3Stream(file, DisposeAfterUse::YES));
 		return;
 	}
 #endif
@@ -1185,12 +1193,12 @@ void SmushPlayer::play(const char *filename, int32 speed, int32 offset, int32 st
 			// the sound. Synt to time instead.
 			now = _vm->_system->getMillis() - _pauseTime;
 			elapsed = now - _startTime;
-		} else if (_vm->_mixer->isSoundHandleActive(_compressedFileSoundHandle)) {
+		} else if (_vm->_mixer->isSoundHandleActive(*_compressedFileSoundHandle)) {
 			// Compressed SMUSH files.
-			elapsed = _vm->_mixer->getSoundElapsedTime(_compressedFileSoundHandle);
-		} else if (_vm->_mixer->isSoundHandleActive(_IACTchannel)) {
+			elapsed = _vm->_mixer->getSoundElapsedTime(*_compressedFileSoundHandle);
+		} else if (_vm->_mixer->isSoundHandleActive(*_IACTchannel)) {
 			// Curse of Monkey Island SMUSH files.
-			elapsed = _vm->_mixer->getSoundElapsedTime(_IACTchannel);
+			elapsed = _vm->_mixer->getSoundElapsedTime(*_IACTchannel);
 		} else {
 			// For other SMUSH files, we don't necessarily have any
 			// one channel to sync against, so we have to use
@@ -1245,8 +1253,8 @@ void SmushPlayer::play(const char *filename, int32 speed, int32 offset, int32 st
 			break;
 		if (_vm->shouldQuit() || _vm->_saveLoadFlag || _vm->_smushVideoShouldFinish) {
 			_smixer->stop();
-			_vm->_mixer->stopHandle(_compressedFileSoundHandle);
-			_vm->_mixer->stopHandle(_IACTchannel);
+			_vm->_mixer->stopHandle(*_compressedFileSoundHandle);
+			_vm->_mixer->stopHandle(*_IACTchannel);
 			_IACTpos = 0;
 			break;
 		}

--- a/engines/scumm/smush/smush_player.h
+++ b/engines/scumm/smush/smush_player.h
@@ -24,9 +24,9 @@
 #define SCUMM_SMUSH_PLAYER_H
 
 #include "common/util.h"
-#include "scumm/sound.h"
 
 namespace Audio {
+class SoundHandle;
 class QueuingAudioStream;
 }
 
@@ -65,10 +65,10 @@ private:
 	bool _skipNext;
 	uint32 _frame;
 
-	Audio::SoundHandle _IACTchannel;
+	Audio::SoundHandle *_IACTchannel;
 	Audio::QueuingAudioStream *_IACTstream;
 
-	Audio::SoundHandle _compressedFileSoundHandle;
+	Audio::SoundHandle *_compressedFileSoundHandle;
 	bool _compressedFileMode;
 	byte _IACToutput[4096];
 	int32 _IACTpos;

--- a/engines/scumm/sound.h
+++ b/engines/scumm/sound.h
@@ -26,9 +26,13 @@
 #include "common/scummsys.h"
 #include "common/str.h"
 #include "audio/mididrv.h"
-#include "audio/mixer.h"
 #include "backends/audiocd/audiocd.h"
 #include "scumm/saveload.h"
+
+namespace Audio {
+class Mixer;
+class SoundHandle;
+}
 
 namespace Scumm {
 
@@ -81,12 +85,12 @@ protected:
 	int16 _currentCDSound;
 	int16 _currentMusic;
 
-	Audio::SoundHandle _loomSteamCDAudioHandle;
+	Audio::SoundHandle *_loomSteamCDAudioHandle;
 	bool _isLoomSteam;
 	AudioCDManager::Status _loomSteamCD;
 
 public:
-	Audio::SoundHandle _talkChannelHandle;	// Handle of mixer channel actor is talking on
+	Audio::SoundHandle *_talkChannelHandle;	// Handle of mixer channel actor is talking on
 
 	bool _soundsPaused;
 	byte _sfxMode;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -23,6 +23,7 @@
 
 
 #include "common/config-manager.h"
+#include "audio/mixer.h"
 
 #include "scumm/actor.h"
 #include "scumm/charset.h"
@@ -662,7 +663,7 @@ void ScummEngine::CHARSET_1() {
 					// Special case for HE games
 				} else if (_game.id == GID_LOOM && !ConfMan.getBool("subtitles") && (_sound->pollCD())) {
 					// Special case for Loom (CD), since it only uses CD audio.for sound
-				} else if (!ConfMan.getBool("subtitles") && (!_haveActorSpeechMsg || _mixer->isSoundHandleActive(_sound->_talkChannelHandle))) {
+				} else if (!ConfMan.getBool("subtitles") && (!_haveActorSpeechMsg || _mixer->isSoundHandleActive(*_sound->_talkChannelHandle))) {
 					// Subtitles are turned off, and there is a voice version
 					// of this message -> don't print it.
 				} else {


### PR DESCRIPTION
Changed `SoundHandle` to pointers and moved some `#define`s and `#include`s around.

When modifying `audio/mixer.h`, only 31 files require recompilation instead of 58.
