### PR TITLE
Add support for WinSparkle

### DIFF
--- a/backends/module.mk
+++ b/backends/module.mk
@@ -119,6 +119,7 @@ MODULE_OBJS += \
 	midi/windows.o \
 	plugins/win32/win32-provider.o \
 	saves/windows/windows-saves.o \
+	updates/win32/win32-updates.o \
 	taskbar/win32/win32-taskbar.o
 endif
 

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -41,6 +41,7 @@
 #include "backends/saves/windows/windows-saves.h"
 #include "backends/fs/windows/windows-fs-factory.h"
 #include "backends/taskbar/win32/win32-taskbar.h"
+#include "backends/updates/win32/win32-updates.h"
 
 #include "common/memstream.h"
 
@@ -81,6 +82,11 @@ void OSystem_Win32::initBackend() {
 	// Create the savefile manager
 	if (_savefileManager == 0)
 		_savefileManager = new WindowsSaveFileManager();
+
+#if defined(USE_SPARKLE)
+	// Initialize updates manager
+	_updateManager = new Win32UpdateManager();
+#endif
 
 	// Invoke parent implementation of this method
 	OSystem_SDL::initBackend();

--- a/backends/updates/win32/win32-updates.cpp
+++ b/backends/updates/win32/win32-updates.cpp
@@ -1,0 +1,132 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+// Disable symbol overrides so that we can use system headers.
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
+#include "common/system.h"
+#include "backends/updates/win32/win32-updates.h"
+
+#ifdef USE_SPARKLE
+#include "common/translation.h"
+#include "common/config-manager.h"
+
+#include <time.h>
+#include <winsparkle.h>
+
+/**
+ * Sparkle is a software update framework for Mac OS X which uses appcasts for
+ * release information. Appcasts are RSS-like XML feeds which contain information
+ * about the most current version at the time. If a new version is available, the
+ * user is presented the release-notes/changes/fixes and is asked if he wants to
+ * update, and if yes the Sparkle framework downloads a signed update package
+ * from the server and automatically installs and restarts the software.
+ * More detailed information is available at the following address:
+ * http://sparkle.andymatuschak.org/
+ *
+ * WinSparkle is a heavily (to the point of being its almost-port) inspired by the
+ * Sparkle framework originally by Andy Matuschak that became the de facto standard
+ * for software updates on OS X.
+ * More detailed information is available at the following address:
+ * https://winsparkle.org/
+ *
+ */
+Win32UpdateManager::Win32UpdateManager() {
+	const char *appcastUrl = "https://www.scummvm.org/appcasts/macosx/release.xml";
+
+	win_sparkle_set_appcast_url(appcastUrl);
+    win_sparkle_init();
+	
+	if (!ConfMan.hasKey("updates_check")
+			|| ConfMan.getInt("updates_check") == Common::UpdateManager::kUpdateIntervalNotSupported) {
+		setAutomaticallyChecksForUpdates(kUpdateStateDisabled);
+	} else {
+		setAutomaticallyChecksForUpdates(kUpdateStateEnabled);
+		setUpdateCheckInterval(normalizeInterval(ConfMan.getInt("updates_check")));
+	}
+}
+
+Win32UpdateManager::~Win32UpdateManager() {
+	win_sparkle_cleanup();
+}
+
+void Win32UpdateManager::checkForUpdates() {
+	win_sparkle_check_update_with_ui();
+}
+
+void Win32UpdateManager::setAutomaticallyChecksForUpdates(UpdateManager::UpdateState state) {
+	if (state == kUpdateStateNotSupported)
+		return;
+
+	win_sparkle_set_automatic_check_for_updates(state == kUpdateStateEnabled ? 1 : 0);
+}
+
+Common::UpdateManager::UpdateState Win32UpdateManager::getAutomaticallyChecksForUpdates() {
+	if (win_sparkle_get_automatic_check_for_updates() == 1)
+		return kUpdateStateEnabled;
+	else
+		return kUpdateStateDisabled;
+}
+
+void Win32UpdateManager::setUpdateCheckInterval(int interval) {
+	if (interval == kUpdateIntervalNotSupported)
+		return;
+
+	interval = normalizeInterval(interval);
+
+	win_sparkle_set_update_check_interval(interval);
+}
+
+int Win32UpdateManager::getUpdateCheckInterval() {
+	// This is kind of a hack but necessary, as the value stored by Sparkle
+	// might have been changed outside of ScummVM (in which case we return the
+	// default interval of one day)
+
+	int updateInterval = win_sparkle_get_update_check_interval();
+	switch (updateInterval) {
+	case kUpdateIntervalOneDay:
+	case kUpdateIntervalOneWeek:
+	case kUpdateIntervalOneMonth:
+		return updateInterval;
+
+	default:
+		// Return the default value (one day)
+		return kUpdateIntervalOneDay;
+	}
+}
+
+bool Win32UpdateManager::getLastUpdateCheckTimeAndDate(TimeDate &t) {
+	time_t updateTime = win_sparkle_get_last_check_time();
+	tm *ut = localtime(&updateTime);
+	
+	t.tm_wday = ut->tm_wday;
+	t.tm_year = ut->tm_year;
+	t.tm_mon  = ut->tm_mon;
+	t.tm_mday = ut->tm_mday;
+	t.tm_hour = ut->tm_hour;
+	t.tm_min  = ut->tm_min;
+	t.tm_sec  = ut->tm_sec;
+
+	return true;
+}
+
+#endif

--- a/backends/updates/win32/win32-updates.cpp
+++ b/backends/updates/win32/win32-updates.cpp
@@ -51,82 +51,82 @@
  *
  */
 Win32UpdateManager::Win32UpdateManager() {
-	const char *appcastUrl = "https://www.scummvm.org/appcasts/macosx/release.xml";
+    const char *appcastUrl = "https://www.scummvm.org/appcasts/macosx/release.xml";
 
-	win_sparkle_set_appcast_url(appcastUrl);
+    win_sparkle_set_appcast_url(appcastUrl);
     win_sparkle_init();
-	
-	if (!ConfMan.hasKey("updates_check")
-			|| ConfMan.getInt("updates_check") == Common::UpdateManager::kUpdateIntervalNotSupported) {
-		setAutomaticallyChecksForUpdates(kUpdateStateDisabled);
-	} else {
-		setAutomaticallyChecksForUpdates(kUpdateStateEnabled);
-		setUpdateCheckInterval(normalizeInterval(ConfMan.getInt("updates_check")));
-	}
+    
+    if (!ConfMan.hasKey("updates_check")
+      || ConfMan.getInt("updates_check") == Common::UpdateManager::kUpdateIntervalNotSupported) {
+        setAutomaticallyChecksForUpdates(kUpdateStateDisabled);
+    } else {
+        setAutomaticallyChecksForUpdates(kUpdateStateEnabled);
+        setUpdateCheckInterval(normalizeInterval(ConfMan.getInt("updates_check")));
+    }
 }
 
 Win32UpdateManager::~Win32UpdateManager() {
-	win_sparkle_cleanup();
+    win_sparkle_cleanup();
 }
 
 void Win32UpdateManager::checkForUpdates() {
-	win_sparkle_check_update_with_ui();
+    win_sparkle_check_update_with_ui();
 }
 
 void Win32UpdateManager::setAutomaticallyChecksForUpdates(UpdateManager::UpdateState state) {
-	if (state == kUpdateStateNotSupported)
-		return;
+    if (state == kUpdateStateNotSupported)
+        return;
 
-	win_sparkle_set_automatic_check_for_updates(state == kUpdateStateEnabled ? 1 : 0);
+    win_sparkle_set_automatic_check_for_updates(state == kUpdateStateEnabled ? 1 : 0);
 }
 
 Common::UpdateManager::UpdateState Win32UpdateManager::getAutomaticallyChecksForUpdates() {
-	if (win_sparkle_get_automatic_check_for_updates() == 1)
-		return kUpdateStateEnabled;
-	else
-		return kUpdateStateDisabled;
+    if (win_sparkle_get_automatic_check_for_updates() == 1)
+        return kUpdateStateEnabled;
+    else
+        return kUpdateStateDisabled;
 }
 
 void Win32UpdateManager::setUpdateCheckInterval(int interval) {
-	if (interval == kUpdateIntervalNotSupported)
-		return;
+    if (interval == kUpdateIntervalNotSupported)
+        return;
 
-	interval = normalizeInterval(interval);
+    interval = normalizeInterval(interval);
 
-	win_sparkle_set_update_check_interval(interval);
+    win_sparkle_set_update_check_interval(interval);
 }
 
 int Win32UpdateManager::getUpdateCheckInterval() {
-	// This is kind of a hack but necessary, as the value stored by Sparkle
-	// might have been changed outside of ScummVM (in which case we return the
-	// default interval of one day)
+    // This is kind of a hack but necessary, as the value stored by Sparkle
+    // might have been changed outside of ScummVM (in which case we return the
+    // default interval of one day)
 
-	int updateInterval = win_sparkle_get_update_check_interval();
-	switch (updateInterval) {
-	case kUpdateIntervalOneDay:
-	case kUpdateIntervalOneWeek:
-	case kUpdateIntervalOneMonth:
-		return updateInterval;
+    int updateInterval = win_sparkle_get_update_check_interval();
+    switch (updateInterval) {
+    case kUpdateIntervalOneDay:
+    case kUpdateIntervalOneWeek:
+    case kUpdateIntervalOneMonth:
+        return updateInterval;
 
-	default:
-		// Return the default value (one day)
-		return kUpdateIntervalOneDay;
-	}
+    default:
+        // Return the default value (one day)
+        return kUpdateIntervalOneDay;
+    }
 }
 
 bool Win32UpdateManager::getLastUpdateCheckTimeAndDate(TimeDate &t) {
-	time_t updateTime = win_sparkle_get_last_check_time();
-	tm *ut = localtime(&updateTime);
-	
-	t.tm_wday = ut->tm_wday;
-	t.tm_year = ut->tm_year;
-	t.tm_mon  = ut->tm_mon;
-	t.tm_mday = ut->tm_mday;
-	t.tm_hour = ut->tm_hour;
-	t.tm_min  = ut->tm_min;
-	t.tm_sec  = ut->tm_sec;
+    time_t updateTime = win_sparkle_get_last_check_time();
+    tm *ut = localtime(&updateTime);
+    
+    t.tm_wday = ut->tm_wday;
+    t.tm_year = ut->tm_year;
+    t.tm_mon  = ut->tm_mon;
+    t.tm_mday = ut->tm_mday;
+    t.tm_hour = ut->tm_hour;
+    t.tm_min  = ut->tm_min;
+    t.tm_sec  = ut->tm_sec;
 
-	return true;
+    return true;
 }
 
 #endif

--- a/backends/updates/win32/win32-updates.h
+++ b/backends/updates/win32/win32-updates.h
@@ -1,0 +1,50 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKENDS_UPDATES_WIN32_H
+#define BACKENDS_UPDATES_WIN32_H
+
+#include "common/scummsys.h"
+
+#if defined(WIN32) && defined(USE_SPARKLE)
+
+#include "common/updates.h"
+
+class Win32UpdateManager : public Common::UpdateManager {
+public:
+	Win32UpdateManager();
+	virtual ~Win32UpdateManager();
+
+	virtual void checkForUpdates();
+
+	virtual void setAutomaticallyChecksForUpdates(UpdateState state);
+	virtual UpdateState getAutomaticallyChecksForUpdates();
+
+	virtual void setUpdateCheckInterval(int interval);
+	virtual int getUpdateCheckInterval();
+
+	virtual bool getLastUpdateCheckTimeAndDate(TimeDate &t);
+};
+
+#endif
+
+#endif // BACKENDS_UPDATES_WIN32_H

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -347,6 +347,20 @@ int main(int argc, char *argv[]) {
 		setup.defines.push_back("MACOSX");
 		setup.defines.push_back("IPHONE");
 	}
+
+	bool updatesEnabled = false;
+	for (FeatureList::const_iterator i = setup.features.begin(); i != setup.features.end(); ++i) {
+		if (i->enable && !strcmp(i->name, "updates"))
+			updatesEnabled = true;
+	}
+	if (updatesEnabled) {
+		setup.defines.push_back("USE_SPARKLE");
+		if (projectType != kProjectXcode)
+			setup.libraries.push_back("winsparkle");
+		else
+			setup.libraries.push_back("sparkle");
+	}
+
 	setup.defines.push_back("SDL_BACKEND");
 	if (!setup.useSDL2) {
 		cout << "\nBuilding against SDL 1.2\n\n";
@@ -964,6 +978,7 @@ const Feature s_features[] = {
 	{          "vkeybd",        "ENABLE_VKEYBD",         "", false, "Virtual keyboard support"},
 	{       "keymapper",     "ENABLE_KEYMAPPER",         "", false, "Keymapper support"},
 	{   "eventrecorder", "ENABLE_EVENTRECORDER",         "", false, "Event recorder support"},
+	{         "updates",          "USE_UPDATES",         "", false, "Updates support"},
 	{      "langdetect",       "USE_DETECTLANG",         "", true,  "System language detection support" } // This feature actually depends on "translation", there
 	                                                                                                      // is just no current way of properly detecting this...
 };

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -81,6 +81,7 @@ BEGIN
         BLOCK "040904b0" // US English, Unicode
         BEGIN
             VALUE "Comments", "Look! A three headed monkey (TM)! .. Nice use of the TM!\0"
+            VALUE "CompanyName", "scummvm.org\0"
             VALUE "FileDescription", "http://www.scummvm.org/\0"
             VALUE "FileVersion", "1.9.0git\0"
             VALUE "InternalName", "scummvm\0"

--- a/dists/scummvm.rc.in
+++ b/dists/scummvm.rc.in
@@ -81,6 +81,7 @@ BEGIN
         BLOCK "040904b0" // US English, Unicode
         BEGIN
             VALUE "Comments", "Look! A three headed monkey (TM)! .. Nice use of the TM!\0"
+            VALUE "CompanyName", "scummvm.org\0"
             VALUE "FileDescription", "http://www.scummvm.org/\0"
             VALUE "FileVersion", "@VERSION@\0"
             VALUE "InternalName", "scummvm\0"


### PR DESCRIPTION
This is a pull request to add support for WinSparkle - an update framework. WinSparkle is a port of Sparkle for MacOS, which is already supported, so the update logic was already there.

Sparkle is using special XML files for update information, called appcasts. The same appcast can be used for both Windows and MacOS updates, and is currently located here:

https://www.scummvm.org/appcasts/macosx/release.xml

Here is some more information, from Sparkle and WinSparkle:

    Sparkle is a software update framework for Mac OS X which uses appcasts for
     release information. Appcasts are RSS-like XML feeds which contain information
     about the most current version at the time. If a new version is available, the
     user is presented the release-notes/changes/fixes and is asked if he wants to
     update, and if yes the Sparkle framework downloads a signed update package
     from the server and automatically installs and restarts the software.
     More detailed information is available at the following address:
     http://sparkle.andymatuschak.org/
    
     WinSparkle is a heavily (to the point of being its almost-port) inspired by the
     Sparkle framework originally by Andy Matuschak that became the de facto standard
     for software updates on OS X.
     More detailed information is available at the following address:
     https://winsparkle.org/