### PR TITLE
AGI: Reduce audio header dependencies

### DIFF
--- a/engines/agi/global.cpp
+++ b/engines/agi/global.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "common/config-manager.h"
+#include "audio/mixer.h"
 
 #include "agi/agi.h"
 #include "agi/graphics.h"

--- a/engines/agi/preagi.cpp
+++ b/engines/agi/preagi.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include "audio/mixer.h"
 #include "audio/softsynth/pcspk.h"
 
 #include "common/debug-channels.h"
@@ -50,6 +51,8 @@ PreAgiEngine::PreAgiEngine(OSystem *syst, const AGIGameDescription *gameDesc) : 
 	memset(&_game, 0, sizeof(struct AgiGame));
 	memset(&_debug, 0, sizeof(struct AgiDebug));
 	memset(&_mouse, 0, sizeof(struct Mouse));
+
+	_speakerHandle = new Audio::SoundHandle();
 }
 
 void PreAgiEngine::initialize() {
@@ -74,7 +77,7 @@ void PreAgiEngine::initialize() {
 	_gfx->initVideo();
 
 	_speakerStream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_speakerHandle,
+	_mixer->playStream(Audio::Mixer::kSFXSoundType, _speakerHandle,
 	                   _speakerStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
 
 	debugC(2, kDebugLevelMain, "Detect game");
@@ -89,8 +92,9 @@ void PreAgiEngine::initialize() {
 }
 
 PreAgiEngine::~PreAgiEngine() {
-	_mixer->stopHandle(_speakerHandle);
+	_mixer->stopHandle(*_speakerHandle);
 	delete _speakerStream;
+	delete _speakerHandle;
 
 	delete _picture;
 	delete _gfx;

--- a/engines/agi/preagi.h
+++ b/engines/agi/preagi.h
@@ -26,6 +26,7 @@
 #include "agi/agi.h"
 
 namespace Audio {
+class SoundHandle;
 class PCSpeaker;
 }
 
@@ -110,7 +111,7 @@ private:
 	int _defaultColor;
 
 	Audio::PCSpeaker *_speakerStream;
-	Audio::SoundHandle _speakerHandle;
+	Audio::SoundHandle *_speakerHandle;
 };
 
 } // End of namespace Agi

--- a/engines/agi/sound.cpp
+++ b/engines/agi/sound.cpp
@@ -29,8 +29,18 @@
 #include "agi/sound_pcjr.h"
 
 #include "common/textconsole.h"
+#include "audio/mixer.h"
 
 namespace Agi {
+
+SoundGen::SoundGen(AgiBase *vm, Audio::Mixer *pMixer) : _vm(vm), _mixer(pMixer) {
+	_sampleRate = pMixer->getOutputRate();
+	_soundHandle = new Audio::SoundHandle();
+}
+
+SoundGen::~SoundGen() {
+	delete _soundHandle;
+}
 
 //
 // TODO: add support for variable sampling rate in the output device

--- a/engines/agi/sound.h
+++ b/engines/agi/sound.h
@@ -23,7 +23,10 @@
 #ifndef AGI_SOUND_H
 #define AGI_SOUND_H
 
-#include "audio/mixer.h"
+namespace Audio {
+class Mixer;
+class SoundHandle;
+}
 
 namespace Agi {
 
@@ -71,11 +74,8 @@ class SoundMgr;
 
 class SoundGen {
 public:
-	SoundGen(AgiBase *vm, Audio::Mixer *pMixer) : _vm(vm), _mixer(pMixer) {
-		_sampleRate = pMixer->getOutputRate();
-	}
-
-	virtual ~SoundGen() {}
+	SoundGen(AgiBase *vm, Audio::Mixer *pMixer);
+	virtual ~SoundGen();
 
 	virtual void play(int resnum) = 0;
 	virtual void stop(void) = 0;
@@ -83,7 +83,7 @@ public:
 	AgiBase *_vm;
 
 	Audio::Mixer *_mixer;
-	Audio::SoundHandle _soundHandle;
+	Audio::SoundHandle *_soundHandle;
 
 	uint32 _sampleRate;
 };

--- a/engines/agi/sound_2gs.cpp
+++ b/engines/agi/sound_2gs.cpp
@@ -27,6 +27,7 @@
 #include "common/memstream.h"
 #include "common/str-array.h"
 #include "common/textconsole.h"
+#include "audio/mixer.h"
 
 #include "agi/agi.h"
 #include "agi/sound_2gs.h"
@@ -55,11 +56,11 @@ SoundGen2GS::SoundGen2GS(AgiBase *vm, Audio::Mixer *pMixer) : SoundGen(vm, pMixe
 	// Load instruments
 	_disableMidi = !loadInstruments();
 
-	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_soundHandle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_mixer->playStream(Audio::Mixer::kMusicSoundType, _soundHandle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
 }
 
 SoundGen2GS::~SoundGen2GS() {
-	_mixer->stopHandle(_soundHandle);
+	_mixer->stopHandle(*_soundHandle);
 	delete[] _wavetable;
 	delete[] _out;
 }

--- a/engines/agi/sound_pcjr.cpp
+++ b/engines/agi/sound_pcjr.cpp
@@ -54,6 +54,7 @@
  *
  */
 
+#include "audio/mixer.h"
 #include "agi/agi.h"
 #include "agi/sound.h"
 #include "agi/sound_pcjr.h"
@@ -123,7 +124,7 @@ SoundGenPCJr::SoundGenPCJr(AgiBase *vm, Audio::Mixer *pMixer) : SoundGen(vm, pMi
 	memset(_channel, 0, sizeof(_channel));
 	memset(_tchannel, 0, sizeof(_tchannel));
 
-	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_soundHandle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_mixer->playStream(Audio::Mixer::kMusicSoundType, _soundHandle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
 
 	_v1data = NULL;
 	_v1size = 0;
@@ -132,7 +133,7 @@ SoundGenPCJr::SoundGenPCJr(AgiBase *vm, Audio::Mixer *pMixer) : SoundGen(vm, pMi
 SoundGenPCJr::~SoundGenPCJr() {
 	free(_chanData);
 
-	_mixer->stopHandle(_soundHandle);
+	_mixer->stopHandle(*_soundHandle);
 }
 
 void SoundGenPCJr::play(int resnum) {

--- a/engines/agi/sound_sarien.cpp
+++ b/engines/agi/sound_sarien.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "common/random.h"
+#include "audio/mixer.h"
 
 #include "agi/agi.h"
 
@@ -92,11 +93,11 @@ SoundGenSarien::SoundGenSarien(AgiBase *vm, Audio::Mixer *pMixer) : SoundGen(vm,
 		debug(0, "Initializing sound: envelopes disabled");
 	}
 
-	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_soundHandle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_mixer->playStream(Audio::Mixer::kMusicSoundType, _soundHandle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
 }
 
 SoundGenSarien::~SoundGenSarien() {
-	_mixer->stopHandle(_soundHandle);
+	_mixer->stopHandle(*_soundHandle);
 
 	free(_sndBuffer);
 }


### PR DESCRIPTION
Changed `SoundHandle` to pointers and moved some `#define`s and `#include`s around.

When modifying `audio/mixer.h`, only 6 files require recompilation instead of 40.