### PR TITLE
GUI: Make (C) sign consistent in all engines

### DIFF
--- a/engines/access/detection.cpp
+++ b/engines/access/detection.cpp
@@ -94,7 +94,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "Access Engine (c) 1989-1994 Access Software";
+		return "Access Engine (C) 1989-1994 Access Software";
 	}
 
 	virtual bool hasFeature(MetaEngineFeature f) const;

--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -123,7 +123,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "Soltys (c) 1994-1996 L.K. Avalon";
+		return "Soltys (C) 1994-1996 L.K. Avalon";
 	}
 
 	virtual const ADGameDescription *fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const;

--- a/engines/cge2/detection.cpp
+++ b/engines/cge2/detection.cpp
@@ -119,7 +119,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "Sfinx (c) 1994-1997 Janus B. Wisniewski and L.K. Avalon";
+		return "Sfinx (C) 1994-1997 Janus B. Wisniewski and L.K. Avalon";
 	}
 
 	virtual const ADGameDescription *fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const;

--- a/engines/hopkins/detection.cpp
+++ b/engines/hopkins/detection.cpp
@@ -111,7 +111,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "Hopkins FBI (c)1997-2003 MP Entertainment";
+		return "Hopkins FBI (C)1997-2003 MP Entertainment";
 	}
 
 	virtual bool hasFeature(MetaEngineFeature f) const;

--- a/engines/lab/detection.cpp
+++ b/engines/lab/detection.cpp
@@ -127,7 +127,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "Labyrinth of Time (c) 2004 The Wyrmkeep Entertainment Co. and Terra Nova Development";
+		return "Labyrinth of Time (C) 2004 The Wyrmkeep Entertainment Co. and Terra Nova Development";
 	}
 
 	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {

--- a/engines/mads/detection.cpp
+++ b/engines/mads/detection.cpp
@@ -149,7 +149,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "MADS (c)";
+		return "MADS (C)";
 	}
 
 	virtual bool hasFeature(MetaEngineFeature f) const;

--- a/engines/tsage/detection.cpp
+++ b/engines/tsage/detection.cpp
@@ -83,7 +83,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "(c) Tsunami Media";
+		return "(C) Tsunami Media";
 	}
 
 	virtual bool hasFeature(MetaEngineFeature f) const {

--- a/engines/voyeur/detection.cpp
+++ b/engines/voyeur/detection.cpp
@@ -75,7 +75,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "Voyeur (c) Philips P.O.V. Entertainment Group";
+		return "Voyeur (C) Philips P.O.V. Entertainment Group";
 	}
 
 	virtual bool hasFeature(MetaEngineFeature f) const;

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -85,7 +85,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "Copyright (c) 2011 Jan Nedoma";
+		return "Copyright (C) 2011 Jan Nedoma";
 	}
 
 	virtual const ADGameDescription *fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const {


### PR DESCRIPTION
The About dialog shows lower case copyright signs (c) on 9 engines, while the majority of engines displays it upper case (C) - so i guess upper case is the way to go.
Changed lower case to upper case on affected engines.

Question: Is there a reason the ASCII char © isn't used?
Is it because some backends can't display those or is ScummVM's font limited or maybe the compiler chokes?