### PR TITLE
ACCESS: Reduce audio header dependencies

### DIFF
--- a/engines/access/sound.cpp
+++ b/engines/access/sound.cpp
@@ -35,10 +35,12 @@
 namespace Access {
 
 SoundManager::SoundManager(AccessEngine *vm, Audio::Mixer *mixer) : _vm(vm), _mixer(mixer) {
+	_effectsHandle = new Audio::SoundHandle();
 }
 
 SoundManager::~SoundManager() {
 	clearSounds();
+	delete _effectsHandle;
 }
 
 void SoundManager::clearSounds() {
@@ -49,8 +51,8 @@ void SoundManager::clearSounds() {
 
 	_soundTable.clear();
 
-	if (_mixer->isSoundHandleActive(_effectsHandle))
-		_mixer->stopHandle(_effectsHandle);
+	if (_mixer->isSoundHandleActive(*_effectsHandle))
+		_mixer->stopHandle(*_effectsHandle);
 
 	while (_queue.size()) {
 		delete _queue[0]._stream;
@@ -159,8 +161,8 @@ void SoundManager::playSound(Resource *res, int priority, bool loop, int soundIn
 		_queue.push_back(QueuedSound(audioStream, soundIndex));
 	}
 
-	if (!_mixer->isSoundHandleActive(_effectsHandle))
-		_mixer->playStream(Audio::Mixer::kSFXSoundType, &_effectsHandle,
+	if (!_mixer->isSoundHandleActive(*_effectsHandle))
+		_mixer->playStream(Audio::Mixer::kSFXSoundType, _effectsHandle,
 						_queue[0]._stream, -1, _mixer->kMaxChannelVolume, 0,
 						DisposeAfterUse::NO);
 }
@@ -168,20 +170,20 @@ void SoundManager::playSound(Resource *res, int priority, bool loop, int soundIn
 void SoundManager::checkSoundQueue() {
 	debugC(5, kDebugSound, "checkSoundQueue");
 
-	if (_queue.empty() || _mixer->isSoundHandleActive(_effectsHandle))
+	if (_queue.empty() || _mixer->isSoundHandleActive(*_effectsHandle))
 		return;
 
 	delete _queue[0]._stream;
 	_queue.remove_at(0);
 
 	if (_queue.size() && _queue[0]._stream)
-		_mixer->playStream(Audio::Mixer::kSFXSoundType, &_effectsHandle,
+		_mixer->playStream(Audio::Mixer::kSFXSoundType, _effectsHandle,
 		   _queue[0]._stream, -1, _mixer->kMaxChannelVolume, 0,
 		   DisposeAfterUse::NO);
 }
 
 bool SoundManager::isSFXPlaying() {
-	return _mixer->isSoundHandleActive(_effectsHandle);
+	return _mixer->isSoundHandleActive(*_effectsHandle);
 }
 
 void SoundManager::loadSounds(Common::Array<RoomInfo::SoundIdent> &sounds) {
@@ -198,7 +200,7 @@ void SoundManager::loadSounds(Common::Array<RoomInfo::SoundIdent> &sounds) {
 void SoundManager::stopSound() {
 	debugC(3, kDebugSound, "stopSound");
 
-	_mixer->stopHandle(_effectsHandle);
+	_mixer->stopHandle(*_effectsHandle);
 }
 
 void SoundManager::freeSounds() {

--- a/engines/access/sound.h
+++ b/engines/access/sound.h
@@ -24,7 +24,6 @@
 #define ACCESS_SOUND_H
 
 #include "common/scummsys.h"
-#include "audio/mixer.h"
 #include "access/files.h"
 #include "audio/midiplayer.h"
 
@@ -32,6 +31,7 @@
 
 namespace Audio {
 class AudioStream;
+class SoundHandle;
 }
 
 namespace Access {
@@ -57,7 +57,7 @@ class SoundManager {
 private:
 	AccessEngine *_vm;
 	Audio::Mixer *_mixer;
-	Audio::SoundHandle _effectsHandle;
+	Audio::SoundHandle *_effectsHandle;
 	Common::Array<QueuedSound> _queue;
 
 	void clearSounds();


### PR DESCRIPTION
**This was not tested!**

Changed `SoundHandle` to pointers and moved some `#define`s and `#include`s around.

When modifying `audio/mixer.h`, only 2 files require recompilation instead of 28.