### PR TITLE
SCI32: Store bitmap resources in dynamic instead of hunk memory

### DIFF
--- a/engines/sci/engine/kgraphics32.cpp
+++ b/engines/sci/engine/kgraphics32.cpp
@@ -539,7 +539,7 @@ reg_t kBitmapCreate(EngineState *s, int argc, reg_t *argv) {
 }
 
 reg_t kBitmapDestroy(EngineState *s, int argc, reg_t *argv) {
-	s->_segMan->freeHunkEntry(argv[0]);
+	s->_segMan->freeDynmem(argv[0]);
 	return s->r_acc;
 }
 

--- a/engines/sci/graphics/celobj32.cpp
+++ b/engines/sci/graphics/celobj32.cpp
@@ -1026,7 +1026,7 @@ CelObjMem *CelObjMem::duplicate() const {
 }
 
 byte *CelObjMem::getResPointer() const {
-	return g_sci->getEngineState()->_segMan->getHunkPointer(_info.bitmap);
+	return g_sci->getEngineState()->_segMan->derefBulkPtr(_info.bitmap, 1);
 }
 
 #pragma mark -

--- a/engines/sci/graphics/controls32.cpp
+++ b/engines/sci/graphics/controls32.cpp
@@ -318,7 +318,7 @@ reg_t GfxControls32::kernelEditText(const reg_t controlObject) {
 		g_sci->_gfxFrameout->frameOut(true);
 	}
 
-	_segMan->freeHunkEntry(editor.bitmap);
+	_segMan->freeDynmem(editor.bitmap);
 
 	if (textChanged) {
 		editor.text.trim();

--- a/engines/sci/graphics/paint32.cpp
+++ b/engines/sci/graphics/paint32.cpp
@@ -61,7 +61,7 @@ void GfxPaint32::kernelUpdateLine(ScreenItem *screenItem, Plane *plane, const Co
 	Common::Rect gameRect;
 	BitmapResource bitmap = makeLineBitmap(startPoint, endPoint, priority, color, style, pattern, thickness, gameRect);
 
-	_segMan->freeHunkEntry(screenItem->_celInfo.bitmap);
+	_segMan->freeDynmem(screenItem->_celInfo.bitmap);
 	screenItem->_celInfo.bitmap = bitmap.getObject();
 	screenItem->_celInfo.color = color;
 	screenItem->_position = startPoint;
@@ -80,7 +80,7 @@ void GfxPaint32::kernelDeleteLine(const reg_t screenItemObject, const reg_t plan
 		return;
 	}
 
-	_segMan->freeHunkEntry(screenItem->_celInfo.bitmap);
+	_segMan->freeDynmem(screenItem->_celInfo.bitmap);
 	g_sci->_gfxFrameout->deleteScreenItem(screenItem, plane);
 }
 

--- a/engines/sci/graphics/text32.cpp
+++ b/engines/sci/graphics/text32.cpp
@@ -180,7 +180,7 @@ void GfxText32::setFont(const GuiResourceId fontId) {
 void GfxText32::drawFrame(const Common::Rect &rect, const int16 size, const uint8 color, const bool doScaling) {
 	Common::Rect targetRect = doScaling ? scaleRect(rect) : rect;
 
-	byte *bitmap = _segMan->getHunkPointer(_bitmap);
+	byte *bitmap = _segMan->derefBulkPtr(_bitmap, 1);
 	byte *pixels = bitmap + READ_SCI11ENDIAN_UINT32(bitmap + 28) + rect.top * _width + rect.left;
 
 	// NOTE: Not fully disassembled, but this should be right
@@ -210,7 +210,7 @@ void GfxText32::drawFrame(const Common::Rect &rect, const int16 size, const uint
 }
 
 void GfxText32::drawChar(const char charIndex) {
-	byte *bitmap = _segMan->getHunkPointer(_bitmap);
+	byte *bitmap = _segMan->derefBulkPtr(_bitmap, 1);
 	byte *pixels = bitmap + READ_SCI11ENDIAN_UINT32(bitmap + 28);
 
 	_font->drawToBuffer(charIndex, _drawPosition.y, _drawPosition.x, _foreColor, _dimmed, pixels, _width, _height);
@@ -335,7 +335,7 @@ void GfxText32::invertRect(const reg_t bitmap, int16 bitmapStride, const Common:
 		targetRect = scaleRect(rect);
 	}
 
-	byte *bitmapData = _segMan->getHunkPointer(bitmap);
+	byte *bitmapData = _segMan->derefBulkPtr(bitmap, 1);
 
 	// NOTE: SCI code is super weird here; it seems to be trying to look at the
 	// entire size of the bitmap including the header, instead of just the pixel

--- a/engines/sci/graphics/text32.h
+++ b/engines/sci/graphics/text32.h
@@ -100,7 +100,7 @@ public:
 	 * Ownership of the bitmap is retained by the caller.
 	 */
 	inline BitmapResource(reg_t bitmap) :
-		_bitmap(g_sci->getEngineState()->_segMan->getHunkPointer(bitmap)),
+		_bitmap(g_sci->getEngineState()->_segMan->derefBulkPtr(bitmap, 1)),
 		_object(bitmap) {
 			if (_bitmap == nullptr || getUncompressedDataOffset() != getBitmapHeaderSize()) {
 				error("Invalid Text bitmap %04x:%04x", PRINT_REG(bitmap));
@@ -114,8 +114,8 @@ public:
 	 * segment manager.
 	 */
 	inline BitmapResource(SegManager *segMan, const int16 width, const int16 height, const uint8 skipColor, const int16 displaceX, const int16 displaceY, const int16 scaledWidth, const int16 scaledHeight, const uint32 hunkPaletteOffset, const bool remap) {
-		_object = segMan->allocateHunkEntry("Bitmap()", getBitmapSize(width, height));
-		_bitmap = segMan->getHunkPointer(_object);
+		segMan->allocDynmem(getBitmapSize(width, height), "Bitmap()", &_object);
+		_bitmap = segMan->derefBulkPtr(_object, 1);
 
 		const uint16 bitmapHeaderSize = getBitmapHeaderSize();
 


### PR DESCRIPTION
Hunk memory is volatile, and is not preserved in saved games. The
original stores bitmap resources in a separate kind of memory, which
is preserved in saved games. We preserve the same behavior using
dynamic memory. This allows dynamic text objects to be preserved in
saved games, in scenes where text is dynamically created and shown
together with other scene objects. An example is the movie
title in the cinema marquee in the first scene of SQ6