### PR TITLE
SCI32: Graphics rendering code updates

### DIFF
--- a/engines/sci/graphics/celobj32.cpp
+++ b/engines/sci/graphics/celobj32.cpp
@@ -799,8 +799,8 @@ CelObjView::CelObjView(const GuiResourceId viewId, const int16 loopNo, const int
 	if (_scaledWidth == 0 || _scaledHeight == 0) {
 		byte sizeFlag = data[5];
 		if (sizeFlag == 0) {
-			_scaledWidth = 320;
-			_scaledHeight = 200;
+			_scaledWidth = kLowResX;
+			_scaledHeight = kLowResY;
 		} else if (sizeFlag == 1) {
 			_scaledWidth = 640;
 			_scaledHeight = 480;
@@ -985,8 +985,8 @@ CelObjPic::CelObjPic(const GuiResourceId picId, const int16 celNo) {
 		_scaledWidth = sizeFlag1;
 		_scaledHeight = sizeFlag2;
 	} else if (sizeFlag1 == 0) {
-		_scaledWidth = 320;
-		_scaledHeight = 200;
+		_scaledWidth = kLowResX;
+		_scaledHeight = kLowResY;
 	} else if (sizeFlag1 == 1) {
 		_scaledWidth = 640;
 		_scaledHeight = 480;

--- a/engines/sci/graphics/celobj32.h
+++ b/engines/sci/graphics/celobj32.h
@@ -31,6 +31,20 @@
 namespace Sci {
 typedef Common::Rational Ratio;
 
+// SCI32 has four different coordinate systems:
+// 1. low resolution, 2. game/script resolution,
+// 3. text/bitmap resolution, 4. screen resolution
+//
+// In CelObj, these values are used when there is
+// no baked in resolution of cels.
+//
+// In ScreenItem, it is used when deciding which
+// path to take to calculate dimensions.
+enum {
+	kLowResX = 320,
+	kLowResY = 200
+};
+
 enum CelType {
 	kCelTypeView  = 0,
 	kCelTypePic   = 1,

--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -700,6 +700,8 @@ void GfxFrameout::calcLists(ScreenItemListList &drawLists, EraseListList &eraseL
 		const Plane *outerPlane = _planes[outerPlaneIndex];
 		const Plane *visiblePlane = _visiblePlanes.findByObject(outerPlane->_object);
 
+		// NOTE: SSCI only ever checks for kPlaneTypeTransparent here, even
+		// though kPlaneTypeTransparentPicture is also a transparent plane
 		if (outerPlane->_type == kPlaneTypeTransparent) {
 			foundTransparentPlane = true;
 		}
@@ -890,6 +892,8 @@ void GfxFrameout::calcLists(ScreenItemListList &drawLists, EraseListList &eraseL
 		}
 	}
 
+	// NOTE: SSCI only looks for kPlaneTypeTransparent, not
+	// kPlaneTypeTransparentPicture
 	if (foundTransparentPlane) {
 		for (PlaneList::size_type planeIndex = 0; planeIndex < planeCount; ++planeIndex) {
 			for (PlaneList::size_type i = planeIndex + 1; i < planeCount; ++i) {

--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -492,7 +492,7 @@ void GfxFrameout::kernelAddPicAt(const reg_t planeObject, const GuiResourceId pi
 #pragma mark -
 #pragma mark Rendering
 
-void GfxFrameout::frameOut(const bool shouldShowBits, const Common::Rect &rect) {
+void GfxFrameout::frameOut(const bool shouldShowBits, const Common::Rect &eraseRect) {
 // TODO: Robot
 //	if (_robot != nullptr) {
 //		_robot.doRobot();
@@ -510,7 +510,7 @@ void GfxFrameout::frameOut(const bool shouldShowBits, const Common::Rect &rect) 
 		remapMarkRedraw();
 	}
 
-	calcLists(screenItemLists, eraseLists, rect);
+	calcLists(screenItemLists, eraseLists, eraseRect);
 
 	for (ScreenItemListList::iterator list = screenItemLists.begin(); list != screenItemLists.end(); ++list) {
 		list->sort();
@@ -597,14 +597,17 @@ void GfxFrameout::calcLists(ScreenItemListList &drawLists, EraseListList &eraseL
 	RectList rectlist;
 	Common::Rect outRects[4];
 
+// NOTE: The third rectangle parameter is only ever given a non-empty rect
+// by VMD code, via `frameOut`
+void GfxFrameout::calcLists(ScreenItemListList &drawLists, EraseListList &eraseLists, const Common::Rect &eraseRect) {
 	int deletedPlaneCount = 0;
 	bool addedToRectList = false;
 	int planeCount = _planes.size();
 	bool foundTransparentPlane = false;
 
-	if (!calcRect.isEmpty()) {
-		addedToRectList = true;
-		rectlist.add(calcRect);
+	if (!eraseRect.isEmpty()) {
+		addedToEraseList = true;
+		rectlist.add(eraseRect);
 	}
 
 	for (int outerPlaneIndex = 0; outerPlaneIndex < planeCount; ++outerPlaneIndex) {
@@ -885,8 +888,6 @@ void GfxFrameout::palMorphFrameOut(const int8 *styleRanges, const ShowStyleEntry
 	_showList.add(rect);
 	showBits();
 
-	Common::Rect calcRect(0, 0);
-
 	// NOTE: The original engine allocated these as static arrays of 100
 	// pointers to ScreenItemList / RectList
 	ScreenItemListList screenItemLists;
@@ -899,7 +900,7 @@ void GfxFrameout::palMorphFrameOut(const int8 *styleRanges, const ShowStyleEntry
 		remapMarkRedraw();
 	}
 
-	calcLists(screenItemLists, eraseLists, calcRect);
+	calcLists(screenItemLists, eraseLists);
 	for (ScreenItemListList::iterator list = screenItemLists.begin(); list != screenItemLists.end(); ++list) {
 		list->sort();
 	}
@@ -959,7 +960,7 @@ void GfxFrameout::palMorphFrameOut(const int8 *styleRanges, const ShowStyleEntry
 		remapMarkRedraw();
 	}
 
-	calcLists(screenItemLists, eraseLists, calcRect);
+	calcLists(screenItemLists, eraseLists);
 	for (ScreenItemListList::iterator list = screenItemLists.begin(); list != screenItemLists.end(); ++list) {
 		list->sort();
 	}

--- a/engines/sci/graphics/frameout.h
+++ b/engines/sci/graphics/frameout.h
@@ -376,8 +376,10 @@ private:
 	 * over the entire screen for rendering the next frame.
 	 * The draw and erase lists in `drawLists` and
 	 * `eraseLists` each represent one plane on the screen.
+	 * The optional `eraseRect` argument allows a specific
+	 * area of the screen to be erased.
 	 */
-	void calcLists(ScreenItemListList &drawLists, EraseListList &eraseLists, const Common::Rect &calcRect);
+	void calcLists(ScreenItemListList &drawLists, EraseListList &eraseLists, const Common::Rect &eraseRect = Common::Rect());
 
 	/**
 	 * Erases the areas in the given erase list from the
@@ -430,9 +432,10 @@ public:
 	/**
 	 * Updates the internal screen buffer for the next
 	 * frame. If `shouldShowBits` is true, also sends the
-	 * buffer to hardware.
+	 * buffer to hardware. If `eraseRect` is non-empty,
+	 * it is added to the erase list for this frame.
 	 */
-	void frameOut(const bool shouldShowBits, const Common::Rect &rect = Common::Rect());
+	void frameOut(const bool shouldShowBits, const Common::Rect &eraseRect = Common::Rect());
 
 	/**
 	 * Modifies the raw pixel data for the next frame with

--- a/engines/sci/graphics/plane32.h
+++ b/engines/sci/graphics/plane32.h
@@ -32,19 +32,21 @@
 
 namespace Sci {
 enum PlaneType {
-	kPlaneTypeColored     = 0,
-	kPlaneTypePicture     = 1,
-	kPlaneTypeTransparent = 2,
-	kPlaneTypeOpaque      = 3
+	kPlaneTypeColored            = 0,
+	kPlaneTypePicture            = 1,
+	kPlaneTypeTransparent        = 2,
+	kPlaneTypeOpaque             = 3,
+	kPlaneTypeTransparentPicture = 4
 };
 
 enum PlanePictureCodes {
-	// NOTE: Any value at or below 65532 means the plane
+	// NOTE: Any value at or below 65531 means the plane
 	// is a kPlaneTypePicture.
-	kPlanePic            = 65532,
-	kPlanePicOpaque      = 65533,
-	kPlanePicTransparent = 65534,
-	kPlanePicColored     = 65535
+	kPlanePic                   = 65531,
+	kPlanePicTransparentPicture = 65532,
+	kPlanePicOpaque             = 65533,
+	kPlanePicTransparent        = 65534,
+	kPlanePicColored            = 65535
 };
 
 #pragma mark -

--- a/engines/sci/graphics/screen_item32.cpp
+++ b/engines/sci/graphics/screen_item32.cpp
@@ -273,7 +273,9 @@ void ScreenItem::calcRects(const Plane &plane) {
 		// Cel may use a coordinate system that is not the same size as the
 		// script coordinate system (usually this means high-resolution
 		// pictures with low-resolution scripts)
-		if (celObj._scaledWidth != scriptWidth || celObj._scaledHeight != scriptHeight) {
+		if (celObj._scaledWidth != kLowResX || celObj._scaledHeight != kLowResY) {
+			// high resolution coordinates
+
 			if (_useInsetRect) {
 				const Ratio scriptToCelX(celObj._scaledWidth, scriptWidth);
 				const Ratio scriptToCelY(celObj._scaledHeight, scriptHeight);
@@ -345,6 +347,8 @@ void ScreenItem::calcRects(const Plane &plane) {
 			_ratioX = scaleX * celToScreenX;
 			_ratioY = scaleY * celToScreenY;
 		} else {
+			// low resolution coordinates
+
 			int displaceX = celObj._displace.x;
 			if (_mirrorX != celObj._mirrorX && _celInfo.type != kCelTypePic) {
 				displaceX = celObj._width - celObj._displace.x - 1;
@@ -582,7 +586,9 @@ Common::Rect ScreenItem::getNowSeenRect(const Plane &plane) const {
 		displaceX = celObj._width - displaceX - 1;
 	}
 
-	if (celObj._scaledWidth != scriptWidth || celObj._scaledHeight != scriptHeight) {
+	if (celObj._scaledWidth != kLowResX || celObj._scaledHeight != kLowResY) {
+		// high resolution coordinates
+
 		if (_useInsetRect) {
 			Ratio scriptToCelX(celObj._scaledWidth, scriptWidth);
 			Ratio scriptToCelY(celObj._scaledHeight, scriptHeight);
@@ -616,6 +622,8 @@ Common::Rect ScreenItem::getNowSeenRect(const Plane &plane) const {
 		mulinc(nsRect, celToScriptX, celToScriptY);
 		nsRect.translate(_position.x - displaceX, _position.y - displaceY);
 	} else {
+		// low resolution coordinates
+
 		if (!scaleX.isOne() || !scaleY.isOne()) {
 			mulinc(nsRect, scaleX, scaleY);
 			// TODO: This was in the original code, baked into the

--- a/engines/sci/graphics/screen_item32.cpp
+++ b/engines/sci/graphics/screen_item32.cpp
@@ -657,23 +657,43 @@ ScreenItem *ScreenItemList::findByObject(const reg_t object) const {
 	return *screenItemIt;
 }
 void ScreenItemList::sort() {
-	// TODO: SCI engine used _unsorted as an array of indexes into the
-	// list itself and then performed the same swap operations on the
-	// _unsorted array as the _storage array during sorting, but the
-	// only reason to do this would be if some of the pointers in the
-	// list were replaced so the pointer values themselves couldn’t
-	// simply be recorded and then restored later. It is not yet
-	// verified whether this simplification of the sort/unsort is
-	// safe.
-	for (size_type i = 0; i < size(); ++i) {
-		_unsorted[i] = (*this)[i];
+	if (size() < 2) {
+		return;
 	}
 
-	Common::sort(begin(), end(), sortHelper);
+	for (size_type i = 0; i < size(); ++i) {
+		_unsorted[i] = i;
+	}
+
+	for (size_type i = size() - 1; i > 0; --i) {
+		bool swap = false;
+
+		for (size_type j = 0; j < i; ++j)  {
+			value_type &a = operator[](j);
+			value_type &b = operator[](j + 1);
+
+			if (a == nullptr || *a > *b) {
+				SWAP(a, b);
+				SWAP(_unsorted[j], _unsorted[j + 1]);
+				swap = true;
+			}
+		}
+
+		if (!swap) {
+			break;
+		}
+	}
 }
 void ScreenItemList::unsort() {
+	if (size() < 2) {
+		return;
+	}
+
 	for (size_type i = 0; i < size(); ++i) {
-		(*this)[i] = _unsorted[i];
+		while (_unsorted[i] != i) {
+			SWAP(operator[](_unsorted[i]), operator[](i));
+			SWAP(_unsorted[_unsorted[i]], _unsorted[i]);
+		}
 	}
 }
 

--- a/engines/sci/graphics/screen_item32.h
+++ b/engines/sci/graphics/screen_item32.h
@@ -236,6 +236,24 @@ public:
 		return false;
 	}
 
+	inline bool operator>(const ScreenItem &other) const {
+		if (_priority > other._priority) {
+			return true;
+		}
+
+		if (_priority == other._priority) {
+			if (_position.y + _z > other._position.y + other._z) {
+				return true;
+			}
+
+			if (_position.y + _z == other._position.y + other._z) {
+				return _object > other._object;
+			}
+		}
+
+		return false;
+	}
+
 	/**
 	 * Calculates the dimensions and scaling parameters for
 	 * the screen item, using the given plane as the parent
@@ -279,12 +297,10 @@ public:
 
 typedef StablePointerArray<ScreenItem, 250> ScreenItemListBase;
 class ScreenItemList : public ScreenItemListBase {
-	inline static bool sortHelper(const ScreenItem *a, const ScreenItem *b) {
-		return *a < *b;
-	}
-public:
-	ScreenItem *_unsorted[250];
+private:
+	size_type _unsorted[250];
 
+public:
 	ScreenItem *findByObject(const reg_t object) const;
 	void sort();
 	void unsort();


### PR DESCRIPTION
The goal with this pass was primarily to get documentation in place, and try to clean up by giving variables more descriptive names, but while I was working on doing this I discovered some rendering errors in Torin when scrolling the transparent transcript window (opened by the book icon at the bottom-left). This sent me on a wild goose chase for a while that had me first try implementing `kPlaneTypeTransparentPicture`, before discovering that `_moved` and `_updated` were reversed in a couple of places and that’s why things were screwy. (As it turns out that swap was messing up rendering in quite a few games—just not the ones we’ve been mostly looking at!)

I also discovered that some 320x200 constant values were still existing in games with high-resolution scripts, so it seems that the ScreenItem rect calculation code doesn’t care whether the cel and game script resolutions are mismatched so much; rather, it seems to care whether or not the cels are low-resolution.

I also found looks like some late SCI games seem to use the “hi res pics” rendering path, so left that in for now, although it’s still always disabled (it still acts weird when it’s turned on in SQ6 and GK1—not sure if that is because it’s buggy/wrong or because it just can’t handle the way those games build their rendering trees).