### PR TITLE
SDL: Fix Windows SDL1 keycodes to use the active keyboard layout

### DIFF
--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -148,6 +148,11 @@ protected:
 	 */
 	uint32 obtainUnicode(const SDL_keysym keySym);
 
+	/**
+	 * Extracts the keycode for the specified key sym.
+	 */
+	SDLKey obtainKeycode(const SDL_keysym keySym);
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/**
 	 * Whether _fakeKeyUp contains an event we need to send.


### PR DESCRIPTION
On Windows, SDL 1.2 ignores international keyboard layouts and returns keycodes valid for US keyboards. For example, pressing 'A' on an AZERTY keyboards returns a keycode with the value 'q'. This prevents engines from being able to reliably use the keycodes to identify keys.
SDL 2 does not have this problem, nor SDL 1.2 on macOS and Linux/X11.

The proposed change consists in making Windows API calls to obtain the keycode for the scancode sent by SDL using the currently active keyboard layout.