### PR TITLE
DEVTOOLS: Add a CMake project generator to create_project

### DIFF
--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -1,0 +1,323 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "cmake.h"
+
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+
+namespace CreateProjectTool {
+
+CMakeProvider::CMakeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version)
+	: ProjectProvider(global_warnings, project_warnings, version) {
+}
+
+const CMakeProvider::Library *CMakeProvider::getLibraryFromFeature(const char *feature) const {
+	static const Library s_libraries[] = {
+		{ "sdl",       "FindSDL",      "SDL",      "SDL_INCLUDE_DIR",       "SDL_LIBRARY",         0            },
+		{ "sdl2",      0,              "SDL2",     "SDL2_INCLUDE_DIRS",     "SDL2_LIBRARIES",      0            },
+		{ "freetype",  "FindFreetype", "Freetype", "FREETYPE_INCLUDE_DIRS", "FREETYPE_LIBRARIES",  0            },
+		{ "libz",      "FindZLIB",     "ZLIB",     "ZLIB_INCLUDE_DIRS",     "ZLIB_LIBRARIES",      0            },
+		{ "png",       "FindPNG",      "PNG",      "PNG_INCLUDE_DIRS",      "PNG_LIBRARIES",       0            },
+		{ "jpeg",      "FindJPEG",     "JPEG",     "JPEG_INCLUDE_DIRS",     "JPEG_LIBRARIES",      0            },
+		{ "mpeg2",     "FindMPEG2",    "MPEG2",    "MPEG2_INCLUDE_DIRS",    "MPEG2_mpeg2_LIBRARY", 0            },
+		{ "flac",      0,              0,          0,                       0,                     "FLAC"       },
+		{ "mad",       0,              0,          0,                       0,                     "mad"        },
+		{ "vorbis",    0,              0,          0,                       0,                     "vorbisfile vorbis ogg" },
+		{ "theora",    0,              0,          0,                       0,                     "theoradec"  },
+		{ "fluidsynth",0,              0,          0,                       0,                     "fluidsynth" },
+		{ "faad",      0,              0,          0,                       0,                     "faad"       }
+	};
+
+	for (unsigned int i = 0; i < sizeof(s_libraries) / sizeof(s_libraries[0]); i++) {
+		if (std::strcmp(feature, s_libraries[i].feature) == 0) {
+			return &s_libraries[i];
+		}
+	}
+
+	return 0;
+}
+
+void CMakeProvider::createWorkspace(const BuildSetup &setup) {
+	std::string filename = setup.outputDir + "/CMakeLists.txt";
+	std::ofstream workspace(filename.c_str());
+	if (!workspace)
+		error("Could not open \"" + filename + "\" for writing");
+
+	workspace << "cmake_minimum_required(VERSION 3.2)\n"
+			"project(" << setup.projectDescription << ")\n\n";
+
+	workspace << "# Define the engines and subengines\n";
+	writeEngines(setup, workspace);
+	writeSubEngines(setup, workspace);
+	workspace << "# Generate options for the engines\n";
+	writeEngineOptions(workspace);
+
+	workspace << "include_directories(${" << setup.projectDescription << "_SOURCE_DIR} ${" << setup.projectDescription << "_SOURCE_DIR}/engines\n"
+			"$ENV{"<<LIBS_DEFINE<<"}/include)\n\n";
+
+	workspace << "# Libraries and features\n";
+	writeFeatureLibSearch(workspace, setup.useSDL2 ? "sdl2" : "sdl");
+	for (FeatureList::const_iterator i = setup.features.begin(), end = setup.features.end(); i != end; ++i) {
+		if (!i->enable || featureExcluded(i->name)) continue;
+
+		writeFeatureLibSearch(workspace, i->name);
+		workspace << "add_definitions(-D" << i->define << ")\n";
+	}
+	workspace << "\n";
+
+	writeWarnings(workspace);
+	writeDefines(setup, workspace);
+	workspace << "# Generate definitions for the engines\n";
+	writeEngineDefinitions(workspace);
+
+	workspace << "# Generate \"engines/plugins_table.h\"\n";
+	writeGeneratePluginsTable(workspace);
+}
+
+void CMakeProvider::writeFeatureLibSearch(std::ofstream &workspace, const char *feature) const {
+	const Library *library = getLibraryFromFeature(feature);
+	if (library) {
+		if (library->module) {
+			workspace << "Include(" << library->module << ")\n";
+		}
+		if (library->package) {
+			workspace << "Find_Package(" << library->package << " REQUIRED)\n";
+		}
+		if (library->includesVar) {
+			workspace << "include_directories(${" << library->includesVar << "})\n";
+		}
+	}
+}
+
+void CMakeProvider::writeEngines(const BuildSetup &setup, std::ofstream &workspace) const {
+	workspace << "set(ENGINES";
+	for (EngineDescList::const_iterator i = setup.engines.begin(), end = setup.engines.end(); i != end; ++i) {
+		// We ignore all sub engines here because they require special handling.
+		if (!i->enable || isSubEngine(i->name, setup.engines)) {
+			continue;
+		}
+
+		std::string engineName;
+		std::transform(i->name.begin(), i->name.end(), back_inserter(engineName), toupper);
+
+		workspace << " " << engineName;
+	}
+	workspace << ")\n";
+}
+
+void CMakeProvider::writeSubEngines(const BuildSetup &setup, std::ofstream &workspace) const {
+	for (EngineDescList::const_iterator i = setup.engines.begin(), end = setup.engines.end(); i != end; ++i) {
+		// We ignore all sub engines here because they are handled in the inner loop
+		if (!i->enable || isSubEngine(i->name, setup.engines) || i->subEngines.empty()) {
+			continue;
+		}
+
+		std::string engineName;
+		std::transform(i->name.begin(), i->name.end(), back_inserter(engineName), toupper);
+
+		workspace << "set(SUB_ENGINES_" << engineName;
+		for (StringList::const_iterator j = i->subEngines.begin(), subEnd = i->subEngines.end(); j != subEnd; ++j) {
+			const EngineDesc &subEngine = findEngineDesc(*j, setup.engines);
+			if (!subEngine.enable) continue;
+
+			std::string subEngineName;
+			std::transform(j->begin(), j->end(), back_inserter(subEngineName), toupper);
+
+			workspace << " " << subEngineName;
+		}
+		workspace << ")\n";
+	}
+
+	workspace << "\n";
+}
+
+void CMakeProvider::createProjectFile(const std::string &name, const std::string &, const BuildSetup &setup, const std::string &moduleDir,
+                                           const StringList &includeList, const StringList &excludeList) {
+
+	const std::string projectFile = setup.outputDir + "/CMakeLists.txt";
+	std::ofstream project(projectFile.c_str(), std::ofstream::out | std::ofstream::app);
+	if (!project)
+		error("Could not open \"" + projectFile + "\" for writing");
+
+	if (name == setup.projectName) {
+		project << "add_executable(" << name << "\n";
+	} else {
+		std::string engineName;
+		std::transform(name.begin(), name.end(), back_inserter(engineName), toupper);
+
+		project << "if (ENABLE_" << engineName << ")\n";
+		project << "add_library(" << name << "\n";
+	}
+
+	std::string modulePath;
+	if (!moduleDir.compare(0, setup.srcDir.size(), setup.srcDir)) {
+		modulePath = moduleDir.substr(setup.srcDir.size());
+		if (!modulePath.empty() && modulePath.at(0) == '/')
+			modulePath.erase(0, 1);
+	}
+
+	if (modulePath.size())
+		addFilesToProject(moduleDir, project, includeList, excludeList, setup.filePrefix + '/' + modulePath);
+	else
+		addFilesToProject(moduleDir, project, includeList, excludeList, setup.filePrefix);
+
+
+	project << ")\n";
+	if (name != setup.projectName) {
+		project << "endif()\n";
+	}
+
+	project << "# Libraries\n";
+	if (name == setup.projectName) {
+		const Library *sdlLibrary = getLibraryFromFeature(setup.useSDL2 ? "sdl2" : "sdl");
+		project << "target_link_libraries(" << name << " ${" << sdlLibrary->librariesVar << "})\n";
+
+		for (FeatureList::const_iterator i = setup.features.begin(), end = setup.features.end(); i != end; ++i) {
+			if (!i->enable || featureExcluded(i->name)) continue;
+
+			const Library *library = getLibraryFromFeature(i->name);
+			if (!library) continue;
+
+			if (library->librariesVar) {
+				project << "target_link_libraries(" << name << " ${" << library->librariesVar << "})\n";
+			} else {
+				project << "target_link_libraries(" << name << " " << library->libraries << ")\n";
+			}
+		}
+		project << "if (WIN32)\n";
+		project << "    target_sources(" << name << " PUBLIC dists/" << name << ".rc)\n";
+		project << "    target_link_libraries(" << name << " winmm)\n";
+		project << "endif()\n";
+		project << "\n";
+
+		project << "# Engines libraries handling\n";
+		writeEnginesLibrariesHandling(setup, project);
+
+		project << "set_property(TARGET " << name << " PROPERTY CXX_STANDARD 11)\n";
+		project << "set_property(TARGET " << name << " PROPERTY CXX_STANDARD_REQUIRED ON)\n";
+	}
+}
+
+void CMakeProvider::writeWarnings(std::ofstream &output) const {
+	output << "SET (CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS}";
+	for (StringList::const_iterator i = _globalWarnings.begin(); i != _globalWarnings.end(); ++i) {
+		output << " " << *i;
+	}
+	output << "\")\n";
+}
+
+void CMakeProvider::writeDefines(const BuildSetup &setup, std::ofstream &output) const {
+	output << "if (WIN32)\n";
+	output << "    add_definitions(-DWIN32)\n";
+	output << "else()\n";
+	output << "    add_definitions(-DPOSIX)\n";
+	output << "endif()\n";
+
+	output << "if (CMAKE_SIZEOF_VOID_P MATCHES 8)\n";
+	output << "    add_definitions(-DSCUMM_64BITS)\n";
+	output << "endif()\n";
+
+	output << "add_definitions(-DSDL_BACKEND)\n\n";
+}
+
+void CMakeProvider::writeFileListToProject(const FileNode &dir, std::ofstream &projectFile, const int indentation,
+                                                const StringList &duplicate, const std::string &objPrefix, const std::string &filePrefix) {
+
+	for (FileNode::NodeList::const_iterator i = dir.children.begin(); i != dir.children.end(); ++i) {
+		const FileNode *node = *i;
+
+		if (!node->children.empty()) {
+			writeFileListToProject(*node, projectFile, indentation + 1, duplicate, objPrefix + node->name + '_', filePrefix + node->name + '/');
+		} else {
+			std::string name, ext;
+			splitFilename(node->name, name, ext);
+			projectFile << "\t" << filePrefix + node->name << "\n";
+		}
+	}
+}
+
+const char *CMakeProvider::getProjectExtension() {
+	return ".txt";
+}
+
+void CMakeProvider::writeEngineOptions(std::ofstream &workspace) const {
+	workspace << "foreach(ENGINE IN LISTS ENGINES)\n";
+	workspace << "    OPTION(ENABLE_${ENGINE} \"Enable ${ENGINE}\" ON)\n";
+	workspace << "endforeach(ENGINE)\n\n";
+}
+
+void CMakeProvider::writeGeneratePluginsTable(std::ofstream &workspace) const {
+	workspace << "file(REMOVE \"engines/plugins_table.h\")\n";
+	workspace << "file(APPEND \"engines/plugins_table.h\" \"/* This file is automatically generated by CMake */\\n\")\n";
+	workspace << "foreach(ENGINE IN LISTS ENGINES)\n";
+	workspace << "    if (ENABLE_${ENGINE})\n";
+	workspace << "        file(APPEND \"engines/plugins_table.h\" \"#if PLUGIN_ENABLED_STATIC(${ENGINE})\\n\")\n";
+	workspace << "        file(APPEND \"engines/plugins_table.h\" \"LINK_PLUGIN(${ENGINE})\\n\")\n";
+	workspace << "        file(APPEND \"engines/plugins_table.h\" \"#endif\\n\")\n";
+	workspace << "    endif()\n";
+	workspace << "endforeach()\n\n";
+}
+
+void CMakeProvider::writeEnginesLibrariesHandling(const BuildSetup &setup, std::ofstream &workspace) const {
+	workspace << "foreach(ENGINE IN LISTS ENGINES)\n";
+	workspace << "    if (ENABLE_${ENGINE})\n";
+	workspace << "        string(TOLOWER ${ENGINE} ENGINE_LIB)\n\n";
+	workspace << "        # Enable C++11\n";
+	workspace << "        set_property(TARGET ${ENGINE_LIB} PROPERTY CXX_STANDARD 11)\n";
+	workspace << "        set_property(TARGET ${ENGINE_LIB} PROPERTY CXX_STANDARD_REQUIRED ON)\n\n";
+	workspace << "        # Link against the engine\n";
+	workspace << "        target_link_libraries("<< setup.projectName <<" ${ENGINE_LIB})\n";
+	workspace << "    endif()\n";
+	workspace << "endforeach()\n\n";
+}
+
+void CMakeProvider::writeEngineDefinitions(std::ofstream &workspace) const {
+	workspace << "foreach(ENGINE IN LISTS ENGINES)\n";
+	workspace << "    if (ENABLE_${ENGINE})\n";
+	workspace << "        add_definitions(-DENABLE_${ENGINE})\n";
+	workspace << "        foreach(SUB_ENGINE IN LISTS SUB_ENGINES_${ENGINE})\n";
+	workspace << "            add_definitions(-DENABLE_${SUB_ENGINE})\n";;
+	workspace << "        endforeach(SUB_ENGINE)\n";
+	workspace << "    endif()\n";
+	workspace << "endforeach()\n\n";
+}
+
+bool CMakeProvider::featureExcluded(const char *name) const {
+	return std::strcmp(name, "nasm") == 0 ||
+			std::strcmp(name, "updates") == 0 ; // NASM is not supported for now
+}
+
+const EngineDesc &CMakeProvider::findEngineDesc(const std::string &name, const EngineDescList &engines) const {
+	for (EngineDescList::const_iterator i = engines.begin(), end = engines.end(); i != end; ++i) {
+		if (i->name == name) {
+			return *i;
+		}
+
+	}
+
+	error("Unable to find requested engine");
+}
+
+} // End of CreateProjectTool namespace

--- a/devtools/create_project/cmake.h
+++ b/devtools/create_project/cmake.h
@@ -1,0 +1,85 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef TOOLS_CREATE_PROJECT_CMAKE_H
+#define TOOLS_CREATE_PROJECT_CMAKE_H
+
+#include "create_project.h"
+
+namespace CreateProjectTool {
+
+/**
+ * A ProjectProvider used to generate CMake project descriptions
+ *
+ * Generated CMake projects are minimal, and will only work with GCC.
+ */
+class CMakeProvider : public ProjectProvider {
+public:
+	CMakeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version = 0);
+
+protected:
+
+	void createWorkspace(const BuildSetup &setup);
+
+	void createOtherBuildFiles(const BuildSetup &) {}
+
+	void addResourceFiles(const BuildSetup &setup, StringList &includeList, StringList &excludeList) {}
+
+	void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
+	                       const StringList &includeList, const StringList &excludeList);
+
+	void writeFileListToProject(const FileNode &dir, std::ofstream &projectFile, const int indentation,
+	                            const StringList &duplicate, const std::string &objPrefix, const std::string &filePrefix);
+
+	const char *getProjectExtension();
+
+private:
+	/**
+	 * CMake properties for a library required by a feature
+	 */
+	struct Library {
+		const char *feature;
+		const char *module;
+		const char *package;
+		const char *includesVar;
+		const char *librariesVar;
+		const char *libraries;
+	};
+
+	const Library *getLibraryFromFeature(const char *feature) const;
+
+	void writeWarnings(std::ofstream &output) const;
+	void writeDefines(const BuildSetup &setup, std::ofstream &output) const;
+	void writeEngines(const BuildSetup &setup, std::ofstream &workspace) const;
+	void writeSubEngines(const BuildSetup &setup, std::ofstream &workspace) const;
+	void writeEngineOptions(std::ofstream &workspace) const;
+	void writeGeneratePluginsTable(std::ofstream &workspace) const;
+	void writeEnginesLibrariesHandling(const BuildSetup &setup, std::ofstream &workspace) const;
+	void writeEngineDefinitions(std::ofstream &workspace) const;
+	void writeFeatureLibSearch(std::ofstream &workspace, const char *feature) const;
+	bool featureExcluded(const char *name) const;
+	const EngineDesc &findEngineDesc(const std::string &name, const EngineDescList &engines) const;
+};
+
+} // End of CreateProjectTool namespace
+
+#endif // TOOLS_CREATE_PROJECT_CMAKE_H

--- a/devtools/create_project/cmake/CMakeLists.txt
+++ b/devtools/create_project/cmake/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.2)
+project(create_project)
+
+
+set(SOURCE_FILES
+	../cmake.cpp
+	../cmake.h
+	../codeblocks.cpp
+	../codeblocks.h
+	../create_project.cpp
+	../create_project.h
+	../msbuild.cpp
+	../msbuild.h
+	../msvc.cpp
+	../msvc.h
+	../visualstudio.cpp
+	../visualstudio.h
+	../xcode.cpp
+	../xcode.h
+    )
+
+add_executable(create_project ${SOURCE_FILES})
+

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -54,7 +54,7 @@
 #define USE_WIN32_API
 #endif
 
-#ifdef USE_WIN32_API
+#if (defined(_WIN32) || defined(WIN32))
 #include <windows.h>
 #else
 #include <sstream>
@@ -1212,7 +1212,7 @@ bool compareNodes(const FileNode *l, const FileNode *r) {
 
 FileList listDirectory(const std::string &dir) {
 	FileList result;
-#ifdef USE_WIN32_API
+#if defined(_WIN32) || defined(WIN32)
 	WIN32_FIND_DATA fileInformation;
 	HANDLE fileHandle = FindFirstFile((dir + "/*").c_str(), &fileInformation);
 

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "create_project.h"
 
+#include "cmake.h"
 #include "codeblocks.h"
 #include "msvc.h"
 #include "visualstudio.h"
@@ -83,10 +84,18 @@ std::string unifyPath(const std::string &path);
  * @param exe Name of the executable.
  */
 void displayHelp(const char *exe);
+
+/**
+ * Build a list of options to enable or disable GCC warnings
+ *
+ * @param globalWarnings Resulting list of warnings
+ */
+void addGCCWarnings(StringList &globalWarnings);
 } // End of anonymous namespace
 
 enum ProjectType {
 	kProjectNone,
+	kProjectCMake,
 	kProjectCodeBlocks,
 	kProjectMSVC,
 	kProjectXcode
@@ -140,6 +149,14 @@ int main(int argc, char *argv[]) {
 			cout.setf(std::ios_base::right, std::ios_base::adjustfield);
 
 			return 0;
+
+		} else if (!std::strcmp(argv[i], "--cmake")) {
+			if (projectType != kProjectNone) {
+				std::cerr << "ERROR: You cannot pass more than one project type!\n";
+				return -1;
+			}
+
+			projectType = kProjectCMake;
 
 		} else if (!std::strcmp(argv[i], "--codeblocks")) {
 			if (projectType != kProjectNone) {
@@ -334,10 +351,7 @@ int main(int argc, char *argv[]) {
 	StringList featureDefines = getFeatureDefines(setup.features);
 	setup.defines.splice(setup.defines.begin(), featureDefines);
 
-	// Windows only has support for the SDL backend, so we hardcode it here (along with winmm)
-	if (projectType != kProjectXcode) {
-		setup.defines.push_back("WIN32");
-	} else {
+	if (projectType == kProjectXcode) {
 		setup.defines.push_back("POSIX");
 		// Define both MACOSX, and IPHONE, but only one of them will be associated to the
 		// correct target by the Xcode project provider.
@@ -346,6 +360,17 @@ int main(int argc, char *argv[]) {
 		// the files, according to the target.
 		setup.defines.push_back("MACOSX");
 		setup.defines.push_back("IPHONE");
+	} else if (projectType == kProjectMSVC || projectType == kProjectCodeBlocks) {
+		// Windows only has support for the SDL backend, so we hardcode it here (along with winmm)
+		setup.defines.push_back("WIN32");
+	} else {
+		// As a last resort, select the backend files to build based on the platform used to build create_project.
+		// This is broken when cross compiling.
+#if defined(_WIN32) || defined(WIN32)
+		setup.defines.push_back("WIN32");
+#else
+		setup.defines.push_back("POSIX");
+#endif
 	}
 
 	bool updatesEnabled = false;
@@ -397,49 +422,25 @@ int main(int argc, char *argv[]) {
 		std::cerr << "ERROR: No project type has been specified!\n";
 		return -1;
 
+	case kProjectCMake:
+		if (setup.devTools || setup.tests) {
+			std::cerr << "ERROR: Building tools or tests is not supported for the CMake project type!\n";
+			return -1;
+		}
+
+		addGCCWarnings(globalWarnings);
+
+		provider = new CreateProjectTool::CMakeProvider(globalWarnings, projectWarnings);
+
+		break;
+
 	case kProjectCodeBlocks:
 		if (setup.devTools || setup.tests) {
 			std::cerr << "ERROR: Building tools or tests is not supported for the CodeBlocks project type!\n";
 			return -1;
 		}
 
-		////////////////////////////////////////////////////////////////////////////
-		// Code::Blocks is using GCC behind the scenes, so we need to pass a list
-		// of options to enable or disable warnings
-		////////////////////////////////////////////////////////////////////////////
-		//
-		// -Wall
-		//   enable all warnings
-		//
-		// -Wno-long-long -Wno-multichar -Wno-unknown-pragmas -Wno-reorder
-		//   disable annoying and not-so-useful warnings
-		//
-		// -Wpointer-arith -Wcast-qual -Wcast-align
-		// -Wshadow -Wimplicit -Wnon-virtual-dtor -Wwrite-strings
-		//   enable even more warnings...
-		//
-		// -fno-rtti -fno-exceptions -fcheck-new
-		//   disable RTTI and exceptions, and enable checking of pointers returned
-		//   by "new"
-		//
-		////////////////////////////////////////////////////////////////////////////
-
-		globalWarnings.push_back("-Wall");
-		globalWarnings.push_back("-Wno-long-long");
-		globalWarnings.push_back("-Wno-multichar");
-		globalWarnings.push_back("-Wno-unknown-pragmas");
-		globalWarnings.push_back("-Wno-reorder");
-		globalWarnings.push_back("-Wpointer-arith");
-		globalWarnings.push_back("-Wcast-qual");
-		globalWarnings.push_back("-Wcast-align");
-		globalWarnings.push_back("-Wshadow");
-		globalWarnings.push_back("-Wimplicit");
-		globalWarnings.push_back("-Wnon-virtual-dtor");
-		globalWarnings.push_back("-Wwrite-strings");
-		// The following are not warnings at all... We should consider adding them to
-		// a different list of parameters.
-		globalWarnings.push_back("-fno-exceptions");
-		globalWarnings.push_back("-fcheck-new");
+		addGCCWarnings(globalWarnings);
 
 		provider = new CreateProjectTool::CodeBlocksProvider(globalWarnings, projectWarnings);
 
@@ -653,6 +654,7 @@ void displayHelp(const char *exe) {
 	        " Additionally there are the following switches for changing various settings:\n"
 	        "\n"
 	        "Project specific settings:\n"
+	        " --cmake                  build CMake project files\n"
 	        " --codeblocks             build Code::Blocks project files\n"
 	        " --msvc                   build Visual Studio project files\n"
 	        " --xcode                  build XCode project files\n"
@@ -705,6 +707,41 @@ void displayHelp(const char *exe) {
 	for (FeatureList::const_iterator i = features.begin(); i != features.end(); ++i)
 		cout << ' ' << (i->enable ? " enabled" : "disabled") << " | " << std::setw((std::streamsize)15) << i->name << std::setw((std::streamsize)0) << " | " << i->description << '\n';
 	cout.setf(std::ios_base::right, std::ios_base::adjustfield);
+}
+
+void addGCCWarnings(StringList &globalWarnings) {
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// -Wall
+	//   enable all warnings
+	//
+	// -Wno-long-long -Wno-multichar -Wno-unknown-pragmas -Wno-reorder
+	//   disable annoying and not-so-useful warnings
+	//
+	// -Wpointer-arith -Wcast-qual -Wcast-align
+	// -Wshadow -Wimplicit -Wnon-virtual-dtor -Wwrite-strings
+	//   enable even more warnings...
+	//
+	// -fno-exceptions -fcheck-new
+	//   disable exceptions, and enable checking of pointers returned by "new"
+	//
+	////////////////////////////////////////////////////////////////////////////
+
+	globalWarnings.push_back("-Wall");
+	globalWarnings.push_back("-Wno-long-long");
+	globalWarnings.push_back("-Wno-multichar");
+	globalWarnings.push_back("-Wno-unknown-pragmas");
+	globalWarnings.push_back("-Wno-reorder");
+	globalWarnings.push_back("-Wpointer-arith");
+	globalWarnings.push_back("-Wcast-qual");
+	globalWarnings.push_back("-Wcast-align");
+	globalWarnings.push_back("-Wshadow");
+	globalWarnings.push_back("-Wnon-virtual-dtor");
+	globalWarnings.push_back("-Wwrite-strings");
+	// The following are not warnings at all... We should consider adding them to
+	// a different list of parameters.
+	globalWarnings.push_back("-fno-exceptions");
+	globalWarnings.push_back("-fcheck-new");
 }
 
 /**

--- a/devtools/create_project/module.mk
+++ b/devtools/create_project/module.mk
@@ -2,6 +2,7 @@
 MODULE := devtools/create_project
 
 MODULE_OBJS := \
+	cmake.o \
 	create_project.o \
 	codeblocks.o \
 	msvc.o \


### PR DESCRIPTION
This adds a CMake project generator to create_project. You might wonder why it would be a good idea to make a build project generator output a configuration file for another build project generator. I use it to work on ScummVM with CLion as an IDE. CLion uses CMake build files as its native project model.
The CMake build file generated by create_project could probably be used to generate projects for other tools, but I have not tried it.

The generated CMake files have been tested to produce working builds of ScummVM on the following platforms:
- Linux, CMake 3.5, native GCC 6.1
- Windows, CMake 3.4, MSYS2/MinGW64 GCC 5.4

Other platforms may require a bit of tweaking.

The generator has the following known shortcomings which I am not planning to address:
- It is impossible to generate CMake files for the tests and devtools
- create_project must be built on the same platform as the target of the CMake build (no cross compilation support)
- CMake's configuration features are only used for part of the libraries. Other libraries are hardcoded, and are expected to be found at the same location as configured ones.
- ASM scalers and updates are not supported.

This code is based on original work by @somaen and @klusark.