### PR TITLE
SCUMM: Maniac V0: Walkbox / Timing improvements

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -272,23 +272,23 @@ void Actor_v0::walkBoxQueueReset() {
 	_walkboxHistory.clear();
 	_walkboxQueueIndex = 0;
 
-	for (uint i = 0; i < ARRAYSIZE( _walkboxQueue ); ++i) {
+	for (uint i = 0; i < ARRAYSIZE(_walkboxQueue); ++i) {
 		_walkboxQueue[i] = kInvalidBox;
 	}
 }
 
 bool Actor_v0::walkBoxQueueAdd(int box) {
 
-	if (_walkboxQueueIndex == ARRAYSIZE( _walkboxQueue ))
+	if (_walkboxQueueIndex == ARRAYSIZE(_walkboxQueue))
 		return false;
 
-	_walkboxQueue[_walkboxQueueIndex++] = box ;
-	_walkboxHistory.push_back( box );
+	_walkboxQueue[_walkboxQueueIndex++] = box;
+	_walkboxHistory.push_back(box);
 	return true;
 }
 
 void Actor_v0::walkboxQueueReverse() {
-	int j = ARRAYSIZE( _walkboxQueue ) - 1;
+	int j = ARRAYSIZE(_walkboxQueue) - 1;
 
 	while (_walkboxQueue[j] == kInvalidBox && j >= 1)
 		--j;
@@ -328,21 +328,21 @@ bool Actor_v0::walkBoxQueuePrepare() {
 	// Build a series of walkboxes from our current position, to the target
 	do {
 		// Add the current box to the queue
-		if (!walkBoxQueueAdd( BoxFound ))
+		if (!walkBoxQueueAdd(BoxFound))
 			return false;
 
 		// Loop until we find a walkbox which hasn't been tested
 		while (_walkboxQueueIndex > 0) {
 
 			// Check if the dest box is a direct neighbour
-			if ((BoxFound = _vm->getNextBox( BoxFound, _walkdata.destbox )) == kInvalidBox) {
+			if ((BoxFound = _vm->getNextBox(BoxFound, _walkdata.destbox)) == kInvalidBox) {
 
 				// Its not, start hunting through this boxes immediate connections
-				byte* boxm = _vm->getBoxConnectionBase( _walkboxQueue[_walkboxQueueIndex - 1] );
+				byte* boxm = _vm->getBoxConnectionBase(_walkboxQueue[_walkboxQueueIndex - 1]);
 
 				// Attempt to find one, which we havn't already used
 				for (; *boxm != kInvalidBox; ++boxm) {
-					if (walkBoxQueueFind( *boxm ) != true)
+					if (walkBoxQueueFind(*boxm) != true)
 						break;
 				}
 
@@ -357,7 +357,7 @@ bool Actor_v0::walkBoxQueuePrepare() {
 
 					_newWalkBoxEntered = true;
 
-					walkBoxQueueAdd( BoxFound );
+					walkBoxQueueAdd(BoxFound);
 
 					walkboxQueueReverse();
 					return true;
@@ -750,7 +750,7 @@ void Actor::startWalkActor(int destX, int destY, int dir) {
 	_walkdata.curbox = _walkbox;
 
 	if (_vm->_game.version == 0) {
-		((Actor_v0*)this)->walkBoxQueuePrepare();
+		((Actor_v0 *)this)->walkBoxQueuePrepare();
 
 	} else if (_vm->_game.version <= 2) {
 		_moving = (_moving & ~(MF_LAST_LEG | MF_IN_LEG)) | MF_NEW_LEG;
@@ -1507,9 +1507,9 @@ void Actor::putActor(int dstX, int dstY, int newRoom) {
 
 	if (_vm->_game.version == 0) {
 
-		((Actor_v0*)this)->_newWalkBoxEntered = false;
-		((Actor_v0*)this)->_CurrentWalkTo = _pos;
-		((Actor_v0*)this)->_NewWalkTo = _pos;
+		((Actor_v0 *)this)->_newWalkBoxEntered = false;
+		((Actor_v0 *)this)->_CurrentWalkTo = _pos;
+		((Actor_v0 *)this)->_NewWalkTo = _pos;
 
 		// V0 always sets the actor to face the camera upon entering a room
 		setDirection(oldDirToNewDir(2));
@@ -2512,7 +2512,7 @@ void Actor_v0::limbFrameCheck(int limb) {
 void Actor_v0::animateCostume() {
 	speakCheck();
 
-	byte count = _vm->_costumeLoader->increaseAnims( this );
+	byte count = _vm->_costumeLoader->increaseAnims(this);
 
 	if (count) {
 		_vm->_V0Delay._actorLimbRedrawDrawCount += count;
@@ -3430,7 +3430,7 @@ void Actor_v0::actorSetWalkTo() {
 
 	_newWalkBoxEntered = false;
 
-	int nextBox = ((ScummEngine_v0*)_vm)->walkboxFindTarget(this, _walkdata.destbox, _walkdata.dest);
+	int nextBox = ((ScummEngine_v0 *)_vm)->walkboxFindTarget(this, _walkdata.destbox, _walkdata.dest);
 	if (nextBox != kInvalidBox) {
 		_walkdata.curbox = nextBox;
 	}
@@ -3471,22 +3471,27 @@ void Actor_v0::saveLoadWithSerializer(Serializer *ser) {
 
 	ser->saveLoadEntries(this, actorEntries);
 
+	// When loading, we need to ensure the limbs are restarted
 	if (ser->isLoading()) {
-		if (_costCommand != 0xFF ) {
-			
-			if (_walkboxQueueIndex < 1) {
 
+		// valid costume command?
+		if (_costCommand != 0xFF) {
+			
+			// Do we have a walkbox queue?
+			if (_walkboxQueueIndex < 1) {
 				_costCommand = 0xFF;
-				setDirection( _facing );
+
+				// Standing Still
+				setDirection(_facing);
 				speakCheck();
-			}
-			else {
-				//_costCommandNew = _costCommand;
-				//_costCommand = 0xFF;
-				//animateActor( _costCommandNew );
+
+			} else {
+				// Force limb direction update
 				_facing = 0;
 				directionUpdate();
-				animateActor( newDirToOldDir( _facing ) );
+
+				// Begin walking
+				animateActor(newDirToOldDir(_facing));
 			}
 		}
 	}
@@ -3633,7 +3638,7 @@ void Actor::saveLoadWithSerializer(Serializer *ser) {
 			_walkdata.point3.y >>= V12_Y_SHIFT;
 		}
 
-		setDirection( _facing );
+		setDirection(_facing);
 	}
 }
 

--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -259,11 +259,123 @@ void Actor_v0::initActor(int mode) {
 		_limb_flipped[i] = false;
 	}
 
+	walkBoxQueueReset();
+
 	if (_vm->_game.features & GF_DEMO) {
 		_sound[0] = v0ActorDemoTalk[_number];
 	} else {
 		_sound[0] = v0ActorTalk[_number];
 	}
+}
+
+void Actor_v0::walkBoxQueueReset() {
+	_walkboxHistory.clear();
+	_walkboxQueueIndex = 0;
+
+	for (uint i = 0; i < ARRAYSIZE( _walkboxQueue ); ++i) {
+		_walkboxQueue[i] = kInvalidBox;
+	}
+}
+
+bool Actor_v0::walkBoxQueueAdd(int box) {
+
+	if (_walkboxQueueIndex == ARRAYSIZE( _walkboxQueue ))
+		return false;
+
+	_walkboxQueue[_walkboxQueueIndex++] = box ;
+	_walkboxHistory.push_back( box );
+	return true;
+}
+
+void Actor_v0::walkboxQueueReverse() {
+	int j = ARRAYSIZE( _walkboxQueue ) - 1;
+
+	while (_walkboxQueue[j] == kInvalidBox && j >= 1)
+		--j;
+
+	if (j <= 1)
+		return;
+
+	for (int i = 1; i < j && j >= 1 ; ++i, --j) {
+		
+		byte tmp = _walkboxQueue[i];
+
+		_walkboxQueue[i] = _walkboxQueue[j];
+		_walkboxQueue[j] = tmp;
+	}
+}
+
+bool Actor_v0::walkBoxQueueFind(int box) {
+
+	for (uint i = 0; i < _walkboxHistory.size(); ++i) {
+		if (box == _walkboxHistory[i])
+			return true;
+	}
+
+	return false;
+}
+
+bool Actor_v0::walkBoxQueuePrepare() {
+	walkBoxQueueReset();
+	int BoxFound = _walkbox;
+
+	if (BoxFound == _walkdata.destbox) {
+
+		_newWalkBoxEntered = true;
+		return true;
+	}
+
+	// Build a series of walkboxes from our current position, to the target
+	do {
+		// Add the current box to the queue
+		if (!walkBoxQueueAdd( BoxFound ))
+			return false;
+
+		// Loop until we find a walkbox which hasn't been tested
+		while (_walkboxQueueIndex > 0) {
+
+			// Check if the dest box is a direct neighbour
+			if ((BoxFound = _vm->getNextBox( BoxFound, _walkdata.destbox )) == kInvalidBox) {
+
+				// Its not, start hunting through this boxes immediate connections
+				byte* boxm = _vm->getBoxConnectionBase( _walkboxQueue[_walkboxQueueIndex - 1] );
+
+				// Attempt to find one, which we havn't already used
+				for (; *boxm != kInvalidBox; ++boxm) {
+					if (walkBoxQueueFind( *boxm ) != true)
+						break;
+				}
+
+				BoxFound = *boxm;
+			}
+
+			// Found one?
+			if (BoxFound != kInvalidBox) {
+
+				// Did we find a connection to the final walkbox
+				if (BoxFound == _walkdata.destbox) {
+
+					_newWalkBoxEntered = true;
+
+					walkBoxQueueAdd( BoxFound );
+
+					walkboxQueueReverse();
+					return true;
+				}
+
+				// Nope, check the next box
+				break;
+			}
+
+			// Drop this box, its useless to us
+			_walkboxQueue[--_walkboxQueueIndex] = kInvalidBox;
+
+			BoxFound = _walkboxQueue[_walkboxQueueIndex - 1];
+		} 
+
+	} while (_walkboxQueueIndex > 0);
+
+	return false;
 }
 
 void Actor::setBox(int box) {
@@ -634,17 +746,18 @@ void Actor::startWalkActor(int destX, int destY, int dir) {
 	_walkdata.dest.y = abr.y;
 	_walkdata.destbox = abr.box;
 	_walkdata.destdir = dir;
-	
+	_walkdata.point3.x = 32000;
+	_walkdata.curbox = _walkbox;
+
 	if (_vm->_game.version == 0) {
-		((Actor_v0*)this)->_newWalkBoxEntered = true;
+		((Actor_v0*)this)->walkBoxQueuePrepare();
+
 	} else if (_vm->_game.version <= 2) {
 		_moving = (_moving & ~(MF_LAST_LEG | MF_IN_LEG)) | MF_NEW_LEG;
  	} else {
  		_moving = (_moving & MF_IN_LEG) | MF_NEW_LEG;
  	}
 
-	_walkdata.point3.x = 32000;
-	_walkdata.curbox = _walkbox;
 }
 
 void Actor::startWalkAnim(int cmd, int angle) {
@@ -861,13 +974,7 @@ L2C36:;
 			stopActorMoving();
 			return;
 		}
-		// 2C98: Yes, an exact copy of what just occurred.. the original does this, so im doing it...
-		//       Just to keep me sane when going over it :)
-		if (A == 0xFF) {
-			setActorFromTmp();
-			stopActorMoving();
-			return;
-		}
+
 		return;
 	}
 
@@ -1398,13 +1505,13 @@ void Actor::putActor(int dstX, int dstY, int newRoom) {
 			showActor();
 	}
 
-	// V0 always sets the actor to face the camera upon entering a room
 	if (_vm->_game.version == 0) {
-		_walkdata.dest = _pos;
 
-		((Actor_v0*)this)->_newWalkBoxEntered = true;
+		((Actor_v0*)this)->_newWalkBoxEntered = false;
 		((Actor_v0*)this)->_CurrentWalkTo = _pos;
+		((Actor_v0*)this)->_NewWalkTo = _pos;
 
+		// V0 always sets the actor to face the camera upon entering a room
 		setDirection(oldDirToNewDir(2));
 	}
 }
@@ -1549,7 +1656,7 @@ AdjustBoxResult Actor_v0::adjustPosInBorderWalkbox(AdjustBoxResult box) {
 		if (A < box.x)
 			return box;
 
-		if (A < 0xA0 || A == 0xA0)
+		if (A <= 0xA0)
 			A = 0;
 
 		Result.x = A;
@@ -1980,9 +2087,10 @@ void ScummEngine::processActors() {
 		if (_game.version == 0) {
 			// 0x057B
 			Actor_v0 *a0 = (Actor_v0*) a;
-			if (a0->_speaking & 1)
+			if (a0->_speaking & 1) {
 				a0->_speaking ^= 0xFE;
-
+				++_V0Delay._actorRedrawCount;
+			}
 			// 0x22B5
 			if (a0->_miscflags & kActorMiscFlagHide)
 				continue;
@@ -2404,8 +2512,13 @@ void Actor_v0::limbFrameCheck(int limb) {
 void Actor_v0::animateCostume() {
 	speakCheck();
 
-	if (_vm->_costumeLoader->increaseAnims(this))
+	byte count = _vm->_costumeLoader->increaseAnims( this );
+
+	if (count) {
+		_vm->_V0Delay._actorLimbRedrawDrawCount += count;
+
 		_needRedraw = true;
+	}
 }
 
 void Actor_v0::speakCheck() {
@@ -3254,7 +3367,7 @@ void Actor_v0::animateActor(int anim) {
 
 	} else {
 
-		if (anim > 4 && anim <= 7)
+		if (anim >= 4 && anim <= 7)
 			_facing = normalizeAngle(oldDirToNewDir(dir));
 	}
 }
@@ -3311,7 +3424,7 @@ void Actor_v0::setActorFromTmp() {
 }
 
 void Actor_v0::actorSetWalkTo() {
-	
+
 	if (_newWalkBoxEntered == false)
 		return;
 
@@ -3350,10 +3463,33 @@ void Actor_v0::saveLoadWithSerializer(Serializer *ser) {
 		MKLINE(Actor_v0, _walkYCount, sleByte, VER(97)),
 		MKLINE(Actor_v0, _walkYCountInc, sleByte, VER(97)),
 		MKLINE(Actor_v0, _walkMaxXYCountInc, sleByte, VER(97)),
+
+		MKARRAY(Actor_v0, _walkboxQueue[0], sleByte, 16, VER(98)),
+		MKLINE(Actor_v0, _walkboxQueueIndex, sleByte, VER(98)),
 		MKEND()
 	};
 
 	ser->saveLoadEntries(this, actorEntries);
+
+	if (ser->isLoading()) {
+		if (_costCommand != 0xFF ) {
+			
+			if (_walkboxQueueIndex < 1) {
+
+				_costCommand = 0xFF;
+				setDirection( _facing );
+				speakCheck();
+			}
+			else {
+				//_costCommandNew = _costCommand;
+				//_costCommand = 0xFF;
+				//animateActor( _costCommandNew );
+				_facing = 0;
+				directionUpdate();
+				animateActor( newDirToOldDir( _facing ) );
+			}
+		}
+	}
 }
 
 void Actor::saveLoadWithSerializer(Serializer *ser) {
@@ -3496,6 +3632,8 @@ void Actor::saveLoadWithSerializer(Serializer *ser) {
 			_walkdata.point3.x >>= V12_X_SHIFT;
 			_walkdata.point3.y >>= V12_Y_SHIFT;
 		}
+
+		setDirection( _facing );
 	}
 }
 

--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -387,8 +387,8 @@ public:
 
 private:
 
-	bool walkBoxQueueAdd( int box );
-	bool walkBoxQueueFind( int box );
+	bool walkBoxQueueAdd(int box);
+	bool walkBoxQueueFind(int box);
 	void walkboxQueueReverse();
 
 public:

--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -350,6 +350,11 @@ class Actor_v0 : public Actor_v2 {
 public:
 	Common::Point _CurrentWalkTo, _NewWalkTo;
 
+	Common::Array<byte> _walkboxHistory;
+
+	byte _walkboxQueue[0x10];
+	byte _walkboxQueueIndex;
+
 	byte _costCommandNew;
 	byte _costCommand;
 	byte _miscflags;
@@ -380,6 +385,12 @@ public:
 
 	bool _limb_flipped[8];
 
+private:
+
+	bool walkBoxQueueAdd( int box );
+	bool walkBoxQueueFind( int box );
+	void walkboxQueueReverse();
+
 public:
 	Actor_v0(ScummEngine *scumm, int id) : Actor_v2(scumm, id) {}
 
@@ -400,6 +411,9 @@ public:
 	byte actorWalkX();
 	byte actorWalkY();
 	byte updateWalkbox();
+
+	void walkBoxQueueReset();
+	bool walkBoxQueuePrepare();
 
 	AdjustBoxResult adjustXYToBeInBox(int dstX, int dstY);
 	AdjustBoxResult adjustPosInBorderWalkbox(AdjustBoxResult box);

--- a/engines/scumm/boxes.cpp
+++ b/engines/scumm/boxes.cpp
@@ -692,6 +692,22 @@ byte *ScummEngine::getBoxMatrixBaseAddr() {
 	return ptr;
 }
 
+byte *ScummEngine::getBoxConnectionBase( int box ) {
+	byte *boxm = getBoxMatrixBaseAddr();
+
+	int boxIndex = 0;
+
+	for (; boxIndex != box; ++boxIndex) {
+
+		while ( *boxm != 0xFF) {
+			++boxm;
+		}
+
+		++boxm;
+	}
+
+	return boxm;
+}
 /**
  * Compute if there is a way that connects box 'from' with box 'to'.
  * Returns the number of a box adjacent to 'from' that is the next on the
@@ -719,21 +735,18 @@ int ScummEngine::getNextBox(byte from, byte to) {
 	boxm = getBoxMatrixBaseAddr();
 
 	if (_game.version == 0) {
-		// calculate shortest paths
-		byte *itineraryMatrix = (byte *)malloc(numOfBoxes * numOfBoxes);
-		calcItineraryMatrix(itineraryMatrix, numOfBoxes);
 
-		dest = to;
-		do {
-			dest = itineraryMatrix[numOfBoxes * from + dest];
-		} while (dest != Actor::kInvalidBox && !areBoxesNeighbors(from, dest));
+		boxm = getBoxConnectionBase( from );
 
-		if (dest == Actor::kInvalidBox)
-			dest = -1;
+		for (; *boxm != 0xFF; ++boxm) {
+			if (*boxm == to)
+				break;
+		}
 
-		free(itineraryMatrix);
-		return dest;
-	} else if (_game.version <= 2) {
+		return *boxm;
+
+	}
+	else if (_game.version <= 2) {
 		// The v2 box matrix is a real matrix with numOfBoxes rows and columns.
 		// The first numOfBoxes bytes contain indices to the start of the corresponding
 		// row (although that seems unnecessary to me - the value is easily computable.
@@ -967,6 +980,7 @@ void ScummEngine::calcItineraryMatrix(byte *itineraryMatrix, int num) {
 	// 255 (= infinity) to all other boxes.
 	for (i = 0; i < num; i++) {
 		for (j = 0; j < num; j++) {
+
 			if (i == j) {
 				adjacentMatrix[i * boxSize + j] = 0;
 				itineraryMatrix[i * boxSize + j] = j;
@@ -1160,20 +1174,31 @@ bool ScummEngine::areBoxesNeighbors(int box1nr, int box2nr) {
 
 byte ScummEngine_v0::walkboxFindTarget(Actor *a, int destbox, Common::Point walkdest) {
 	Actor_v0 *Actor = (Actor_v0*)a;
+	byte nextBox = kOldInvalidBox;
 
-	byte nextBox = getNextBox(a->_walkbox, destbox);
+	// Do we have a walkbox queue to process
+	if (Actor->_walkboxQueueIndex > 1) {
+		nextBox = Actor->_walkboxQueue[--Actor->_walkboxQueueIndex];
 
-	if (nextBox != 0xFF && nextBox == destbox && areBoxesNeighbors(a->_walkbox, nextBox)) {
+		if (Actor->_walkboxQueueIndex <= 1) {
+			Actor->walkBoxQueueReset();
+		}
+	}
+
+	// Target box reached?
+	if (nextBox != Actor::kInvalidBox && nextBox == destbox && areBoxesNeighbors(a->_walkbox, nextBox)) {
 
 		Actor->_NewWalkTo = walkdest;
 		return nextBox;
 	}
 
-	if (nextBox != 0xFF && nextBox != a->_walkbox) {
+	// Next box reached
+	if (nextBox != Actor::kInvalidBox && nextBox != a->_walkbox) {
 
 		getClosestPtOnBox(getBoxCoordinates(nextBox), a->getPos().x, a->getPos().y, Actor->_NewWalkTo.x, Actor->_NewWalkTo.y);
 
 	} else {
+
 		if (walkdest.x == -1)
 			Actor->_NewWalkTo = Actor->_CurrentWalkTo;
 		else

--- a/engines/scumm/boxes.cpp
+++ b/engines/scumm/boxes.cpp
@@ -692,14 +692,14 @@ byte *ScummEngine::getBoxMatrixBaseAddr() {
 	return ptr;
 }
 
-byte *ScummEngine::getBoxConnectionBase( int box ) {
+byte *ScummEngine::getBoxConnectionBase(int box) {
 	byte *boxm = getBoxMatrixBaseAddr();
 
 	int boxIndex = 0;
 
 	for (; boxIndex != box; ++boxIndex) {
 
-		while ( *boxm != 0xFF) {
+		while (*boxm != 0xFF) {
 			++boxm;
 		}
 
@@ -736,7 +736,7 @@ int ScummEngine::getNextBox(byte from, byte to) {
 
 	if (_game.version == 0) {
 
-		boxm = getBoxConnectionBase( from );
+		boxm = getBoxConnectionBase(from);
 
 		for (; *boxm != 0xFF; ++boxm) {
 			if (*boxm == to)
@@ -1173,7 +1173,7 @@ bool ScummEngine::areBoxesNeighbors(int box1nr, int box2nr) {
 }
 
 byte ScummEngine_v0::walkboxFindTarget(Actor *a, int destbox, Common::Point walkdest) {
-	Actor_v0 *Actor = (Actor_v0*)a;
+	Actor_v0 *Actor = (Actor_v0 *)a;
 	byte nextBox = kOldInvalidBox;
 
 	// Do we have a walkbox queue to process
@@ -1195,7 +1195,7 @@ byte ScummEngine_v0::walkboxFindTarget(Actor *a, int destbox, Common::Point walk
 	// Next box reached
 	if (nextBox != Actor::kInvalidBox && nextBox != a->_walkbox) {
 
-		getClosestPtOnBox(getBoxCoordinates(nextBox), a->getPos().x, a->getPos().y, Actor->_NewWalkTo.x, Actor->_NewWalkTo.y);
+		getClosestPtOnBox(getBoxCoordinates(nextBox), a->getRealPos().x, a->getRealPos().y, Actor->_NewWalkTo.x, Actor->_NewWalkTo.y);
 
 	} else {
 

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -3797,7 +3797,7 @@ void ScummEngine::fadeOut(int effect) {
 
 	// V0 wipes the text area before fading out
 	if (_game.version == 0) {
-		updateDirtyScreen( kTextVirtScreen );
+		updateDirtyScreen(kTextVirtScreen);
 	}
 
 	// TheDig can disable fadeIn(), and may call fadeOut() several times

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -3795,6 +3795,11 @@ void ScummEngine::fadeOut(int effect) {
 		_textSurface.fillRect(Common::Rect(0, vs->topline * _textSurfaceMultiplier, _textSurface.pitch, (vs->topline + vs->h) * _textSurfaceMultiplier), 0);
 #endif
 
+	// V0 wipes the text area before fading out
+	if (_game.version == 0) {
+		updateDirtyScreen( kTextVirtScreen );
+	}
+
 	// TheDig can disable fadeIn(), and may call fadeOut() several times
 	// successively. Disabling the _screenEffectFlag check forces the screen
 	// to get cleared. This fixes glitches, at least, in the first cutscenes

--- a/engines/scumm/gfx.h
+++ b/engines/scumm/gfx.h
@@ -58,7 +58,7 @@ struct CameraData {
 /** Virtual screen identifiers */
 enum VirtScreenNumber {
 	kMainVirtScreen = 0,	// The 'stage'
-	kTextVirtScreen = 1,	// In V1-V3 games: the area where text is printed
+	kTextVirtScreen = 1,	// In V0-V3 games: the area where text is printed
 	kVerbVirtScreen = 2,	// The verb area
 	kUnkVirtScreen = 3		// ?? Not sure what this one is good for...
 };

--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -1126,6 +1126,7 @@ void ScummEngine_v80he::clearDrawQueues() {
  */
 void ScummEngine::markObjectRectAsDirty(int obj) {
 	int i, strip;
+	++_V0Delay._objectRedrawCount;
 
 	for (i = 1; i < _numLocalObjects; i++) {
 		if (_objs[i].obj_nr == (uint16)obj) {
@@ -1133,6 +1134,7 @@ void ScummEngine::markObjectRectAsDirty(int obj) {
 				const int minStrip = MAX(_screenStartStrip, _objs[i].x_pos / 8);
 				const int maxStrip = MIN(_screenEndStrip+1, _objs[i].x_pos / 8 + _objs[i].width / 8);
 				for (strip = minStrip; strip < maxStrip; strip++) {
+					++_V0Delay._objectStripRedrawCount;
 					setGfxUsageBit(strip, USAGE_BIT_DIRTY);
 				}
 			}

--- a/engines/scumm/saveload.h
+++ b/engines/scumm/saveload.h
@@ -47,7 +47,7 @@ namespace Scumm {
  * only saves/loads those which are valid for the version of the savegame
  * which is being loaded/saved currently.
  */
-#define CURRENT_VER 97
+#define CURRENT_VER 98
 
 /**
  * An auxillary macro, used to specify savegame versions. We use this instead

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -298,7 +298,14 @@ struct StringTab : StringSlot {
 	}
 };
 
+struct ScummEngine_v0_Delays {
+	bool _screenScroll;
+	uint _objectRedrawCount;
+	uint _objectStripRedrawCount;
+	uint _actorRedrawCount;
+	uint _actorLimbRedrawDrawCount;
 
+};
 
 enum WhereIsObject {
 	WIO_NOT_FOUND = -1,
@@ -1097,6 +1104,8 @@ public:
 	// Indy4 Amiga specific
 	byte *_verbPalette;
 
+	ScummEngine_v0_Delays _V0Delay;
+
 protected:
 	int _shadowPaletteSize;
 	byte _currentPalette[3 * 256];
@@ -1131,7 +1140,7 @@ public:
 
 	byte getNumBoxes();
 	byte *getBoxMatrixBaseAddr();
-	byte *getBoxConnectionBase( int box );
+	byte *getBoxConnectionBase(int box);
 
 	int getNextBox(byte from, byte to);
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1131,6 +1131,8 @@ public:
 
 	byte getNumBoxes();
 	byte *getBoxMatrixBaseAddr();
+	byte *getBoxConnectionBase( int box );
+
 	int getNextBox(byte from, byte to);
 
 	void setBoxFlags(int box, int val);

--- a/engines/scumm/scumm_v0.h
+++ b/engines/scumm/scumm_v0.h
@@ -70,6 +70,10 @@ public:
 
 	byte walkboxFindTarget(Actor *a, int destbox, Common::Point walkdest);
 
+	/* Delay calculation */
+	void DelayReset();
+	int DelayCalculateDelta();
+
 protected:
 	virtual void resetRoomObject(ObjectData *od, const byte *room, const byte *searchptr = NULL);
 


### PR DESCRIPTION
Hey All,

There is currently a number of small issues with MM V0. This patch addresses them, 

1. In the 'V0 Demo' room 5 during the 'hands off demo mode' Sandy runs down, then left to escape Purple Tentacle, instead of going around the stair case (this is due to the original engine finding the first path, not necessarily the fastest. This behavior is now implemented)

1. During the intro, the timing is off between the audio/video. The music builds up, but the "A LucasFilm Production" text has already been displayed.

1. Direction of actors after loading a save game is always putting right

1. Top text area is always cleared prior to screen fade in V0


Notes:

1. Original walkbox algorithm is implemented, we now calculate the walk boxes before walking, then remove them from the array as we walk to them.

2. Counters have been added, and slight delays are added for each object/strip/actor/limb being refreshed, as well as screen scrolls.
The reason this is done, is because the original engine slows down to < 60Hz when certain routines are called (especially screen refresh related). some scripts make use of the 'breakHere' opcode instead of 'Delay', as the script author had the expectation of a previously given instruction taking more than 1 tick worth of time to complete (ie. Maniac Mansion V1-V2 both use Delay(30) to pause between the Mansion lights turning on during the introduction, whereas V0 uses breakHere -- causing the lights to turn on almost instantly in ScummVM, a C64 on the other hand has an expected delay, as the screen is redrawn based on the object change of state  )
The values used are based on visual observation, and are not 100% correct. It is close to the original though (and this removes the workaround for the Dungeon Door).
Comparison of ScummVM vs WinVice here [ScummVM vs WinVice](https://youtu.be/XqHx16AzmKU)
As you play in ScummVM now, it now gives you the sense of playing on a C64 :)


3. Loading/Saving of V0 has been fixed properly, and now supports saving the walkbox queue

4. Fixed