### PR TITLE
ALL: Don't use 'defined' in macro definitions

### DIFF
--- a/backends/graphics/opengl/opengl-sys.h
+++ b/backends/graphics/opengl/opengl-sys.h
@@ -48,9 +48,15 @@
 //  0 - Force OpenGL context
 //  1 - Force OpenGL ES context
 //  2 - Force OpenGL ES 2.0 context
-#define USE_FORCED_GL    (defined(USE_GLES_MODE) && USE_GLES_MODE == 0)
-#define USE_FORCED_GLES  (defined(USE_GLES_MODE) && USE_GLES_MODE == 1)
-#define USE_FORCED_GLES2 (defined(USE_GLES_MODE) && USE_GLES_MODE == 2)
+#ifdef USE_GLES_MODE
+	#define USE_FORCED_GL    (USE_GLES_MODE == 0)
+	#define USE_FORCED_GLES  (USE_GLES_MODE == 1)
+	#define USE_FORCED_GLES2 (USE_GLES_MODE == 2)
+#else
+	#define USE_FORCED_GL    0
+	#define USE_FORCED_GLES  0
+	#define USE_FORCED_GLES2 0
+#endif
 
 // On Tizen we include the toolchain's OpenGL file. This is something we
 // actually want to avoid. However, since Tizen uses eglGetProcAddress which

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -79,8 +79,12 @@ extern int pluginTypeVersions[PLUGIN_TYPE_MAX];
 #define PLUGIN_ENABLED_STATIC(ID) \
 	(ENABLE_##ID && !PLUGIN_ENABLED_DYNAMIC(ID))
 
-#define PLUGIN_ENABLED_DYNAMIC(ID) \
-	(ENABLE_##ID && (ENABLE_##ID == DYNAMIC_PLUGIN) && defined(DYNAMIC_MODULES))
+#ifdef DYNAMIC_MODULES
+	#define PLUGIN_ENABLED_DYNAMIC(ID) \
+		(ENABLE_##ID && (ENABLE_##ID == DYNAMIC_PLUGIN))
+#else
+	#define PLUGIN_ENABLED_DYNAMIC(ID) 0
+#endif
 
 // see comments in backends/plugins/elf/elf-provider.cpp
 #if defined(USE_ELF_LOADER) && defined(ELF_LOADER_CXA_ATEXIT)

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -29,7 +29,11 @@
 
 // This is a convenience macro to test whether the compiler used is a GCC
 // version, which is at least major.minor.
-#define GCC_ATLEAST(major, minor) (defined(__GNUC__) && (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor))))
+#ifdef __GNUC__
+	#define GCC_ATLEAST(major, minor) (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor)))
+#else
+	#define GCC_ATLEAST(major, minor) 0
+#endif
 
 #if defined(_WIN32_WCE) && _WIN32_WCE < 300
 	#define NONSTANDARD_PORT


### PR DESCRIPTION
This is undefined behavior and clang warns about it. Specifically, it's not supported by Visual Studio.
See <http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20160118/147239.html>.

I haven't tested these changes carefully. Would be helpful to have more eyeballs :)