### PR TITLE
Use parallel build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ os:
 
 script:
   - ./configure --enable-all-engines --disable-eventrecorder
-  - make
+  - make -j 2
   - make test
   - make devtools


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments, container-based
jobs offer two cores, which should provide quicker turnaround times.

Check times against first-ever travis build:
https://travis-ci.org/scummvm/scummvm/builds/147974521