### PR TITLE
Fix tests when building with the event recorder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ os:
   - linux
 
 script:
-  - ./configure --enable-all-engines --disable-eventrecorder
+  - ./configure --enable-all-engines
   - make -j 2
   - make test
   - make devtools

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -492,6 +492,14 @@ AudioCDManager *OSystem_SDL::createAudioCDManager() {
 #endif
 }
 
+Common::SaveFileManager *OSystem_SDL::getSavefileManager() {
+#ifdef ENABLE_EVENTRECORDER
+    return g_eventRec.getSaveManager(_savefileManager);
+#else
+    return _savefileManager;
+#endif
+}
+
 #ifdef USE_OPENGL
 
 const OSystem::GraphicsMode *OSystem_SDL::getSupportedGraphicsModes() const {

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -76,6 +76,7 @@ public:
 	virtual void getTimeAndDate(TimeDate &td) const;
 	virtual Audio::Mixer *getMixer();
 	virtual Common::TimerManager *getTimerManager();
+	virtual Common::SaveFileManager *getSavefileManager();
 
 protected:
 	bool _inited;

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -30,8 +30,6 @@
 #include "graphics/surface.h"
 #include "graphics/scaler.h"
 
-#ifdef ENABLE_EVENTRECORDER
-
 #define RECORD_VERSION 1
 
 namespace Common {
@@ -716,5 +714,3 @@ void PlaybackFile::checkRecordedMD5() {
 
 
 }
-
-#endif // ENABLE_EVENTRECORDER

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -215,10 +215,6 @@
 #include "config.h"
 #endif
 
-// Now we need to adjust some settings when running tests
-#ifdef COMPILING_TESTS
-#undef ENABLE_EVENTRECORDER
-#endif
 
 // In the following we configure various targets, in particular those
 // which can't use our "configure" tool and hence don't use config.h.

--- a/common/system.cpp
+++ b/common/system.cpp
@@ -30,9 +30,6 @@
 #include "common/taskbar.h"
 #include "common/updates.h"
 #include "common/textconsole.h"
-#ifdef ENABLE_EVENTRECORDER
-#include "gui/EventRecorder.h"
-#endif
 
 #include "backends/audiocd/default/default-audiocd.h"
 #include "backends/fs/fs-factory.h"
@@ -161,9 +158,5 @@ Common::TimerManager *OSystem::getTimerManager() {
 }
 
 Common::SaveFileManager *OSystem::getSavefileManager() {
-#ifdef ENABLE_EVENTRECORDER
-	return g_eventRec.getSaveManager(_savefileManager);
-#else
 	return _savefileManager;
-#endif
 }

--- a/common/system.h
+++ b/common/system.h
@@ -1090,7 +1090,7 @@ public:
 	 * and other modifiable persistent game data. For more information,
 	 * refer to the SaveFileManager documentation.
 	 */
-	Common::SaveFileManager *getSavefileManager();
+	virtual Common::SaveFileManager *getSavefileManager();
 
 #if defined(USE_TASKBAR)
 	/**

--- a/test/module.mk
+++ b/test/module.mk
@@ -26,7 +26,6 @@ endif
 #TEST_LDFLAGS += -L/usr/X11R6/lib -lX11
 
 
-test: CXXFLAGS +=  -DCOMPILING_TESTS=1
 test: test/runner
 	./test/runner
 test/runner: test/runner.cpp $(TEST_LIBS)


### PR DESCRIPTION
Remove the EventRecorder dependency from OSystem, pushing it down to SDL. The event recorder only works with SDL backends, so it should be fine.