### PR TITLE
POSIX: Add $SNAP to search path if available.

### DIFF
--- a/backends/platform/sdl/posix/posix.cpp
+++ b/backends/platform/sdl/posix/posix.cpp
@@ -141,6 +141,22 @@ Common::String OSystem_POSIX::getDefaultConfigFileName() {
 	return configFile;
 }
 
+void OSystem_POSIX::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
+	const char *snap = getenv("SNAP");
+	if (snap) {
+		Common::String dataPath = Common::String(snap) + DATA_PATH;
+		Common::FSNode dataNode(dataPath);
+		if (dataNode.exists() && dataNode.isDirectory()) {
+			// This is the same priority which is used for the data path (below),
+			// but we insert this one first, so it will be searched first.
+			s.add(dataPath, new Common::FSDirectory(dataNode, 4), priority);
+		}
+	}
+
+	// For now, we always add the data path, just in case SNAP doesn't make sense.
+	OSystem_SDL::addSysArchivesToSearchSet(s, priority);
+}
+
 Common::WriteStream *OSystem_POSIX::createLogFile() {
 	// Start out by resetting _logFilePath, so that in case
 	// of a failure, we know that no log file is open.

--- a/backends/platform/sdl/posix/posix.h
+++ b/backends/platform/sdl/posix/posix.h
@@ -38,6 +38,8 @@ public:
 	virtual void init();
 	virtual void initBackend();
 
+	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0);
+
 protected:
 	/**
 	 * Base string for creating the default path and filename for the


### PR DESCRIPTION
This allows ScummVM to find data files while running in a snap (e.g.
from the new Ubuntu store).