### PR TITLE
Add snapcraft.yaml so you can `snapcraft build`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,63 @@
+name: scummvm
+version: "1.9.0git"
+summary: ScummVM
+description: |
+    ScummVM is a program which allows you to run certain classic graphical
+    point-and-click adventure games, provided you already have their data
+    files. The clever part about this: ScummVM just replaces the executables
+    shipped with the game, allowing you to play them on systems for which
+    they were never designed!
+confinement: strict
+
+apps:
+  scummvm:
+    command: scummvm
+    plugs: [x11, home, pulseaudio, unity7, opengl]
+
+parts:
+  scummvm:
+    source: .
+    plugin: autotools
+#    Quick test build
+#    configflags:
+#      - --disable-all-engines
+#      - --enable-engine=scumm
+    build-packages:
+      - g++
+      - make
+      - libsdl1.2-dev
+      - libjpeg62-dev
+      - libmpeg2-4-dev
+      - libogg-dev
+      - libvorbis-dev
+      - libflac-dev
+      - libmad0-dev
+      - libpng12-dev
+      - libtheora-dev
+      - libfaad-dev
+      - libfluidsynth-dev
+      - libfreetype6-dev
+      - zlib1g-dev
+      - libunity-dev
+    stage-packages:
+      - libicu55
+      - libasound2
+      - libc6
+      - libfaad2
+      - libflac8
+      - libfluidsynth1
+      - libgl1-mesa-dri
+      - libgl1-mesa-glx
+      - libjpeg62
+      - libjpeg8
+      - libmad0
+      - libmpeg2-4
+      - libogg0
+      - libpng12-0
+      - libsdl1.2debian
+      - libsndio6.1
+      - libstdc++6
+      - libtheora0
+      - libvorbis0a
+      - libvorbisfile3
+      - zlib1g


### PR DESCRIPTION
Now that https://github.com/scummvm/scummvm/pull/795 is merged, enabling snaps, we can merge the snapcraft.yaml.

This file is essentially the "Makefile" for the `snapcraft` binary, which will build a squashfs that can be mounted and run in a heavily AppArmor-constrained process space.

Right now this snapcraft.yaml allows access to the user's home directory through the `home` plug on line 15, but in future it would be possible to bundle games into their own snaps along with specific revisions of scummvm, and those could operate entirely without filesystem access outside the snap jail.  This can work no matter the base OS, as the environment overlays atop a ~60MB `ubuntu-core` image.

I've demonstrated this work in person to fuzzie, and have built 1.9.0git snaps using `snapcraft cleanbuild` which even does the build step in an lxd of the `ubuntu-core` environment.

I'm not sure how best to document this build information, so any guidance there would be welcomed.
