### PR TITLE
TITANIC: Add detection entry for German version

### DIFF
--- a/engines/titanic/detection_tables.h
+++ b/engines/titanic/detection_tables.h
@@ -34,6 +34,18 @@ static const TitanicGameDescription gameDescriptions[] = {
 			GUIO1(GUIO_NONE)
 		},
 	},
+	
+	{
+		{
+			"titanic",
+			0,
+			AD_ENTRY1s("newgame.st", "db22924adfd6730f4b79f4e51b25e779", 87608),
+			Common::DE_DEU,
+			Common::kPlatformWindows,
+			ADGF_NO_FLAGS,
+			GUIO1(GUIO_NONE)
+		},
+	},
 
 	{ AD_TABLE_END_MARKER }
 };


### PR DESCRIPTION
This adds an entry to the detection table for the German version of Starship Titanic, GoG release.

The detection itself works, but there seems to be something going wrong. The create_titanic tool is unable to process the German ST.exe. The application just hangs and creates a broken file. Using the titanic.dat file from the English GoG release causes the game to exit immediately with a black screen.

Maybe this detection entry is useful at the moment. If not, feel free to simply close this PR.