### PR TITLE
BUILD: Switch SDL backend to SDL2 by default. SDL1 is still a fallback.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language:
   - cpp
 
-sudo: false
+sudo: required
 
 addons:
   apt:
     packages:
     - g++ make
-    - libsdl1.2-dev
-    - libjpeg62-turbo-dev
+    - libsdl2-dev
+    - libjpeg-turbo8-dev
     - libmpeg2-4-dev
     - libogg-dev
     - libvorbis-dev
@@ -31,6 +31,8 @@ compiler:
 
 os:
   - linux
+
+dist: trusty
 
 script:
   - ./configure --enable-all-engines

--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ For a more comprehensive changelog of the latest experimental code, see:
 
  General:
    - Fixed audio corruption in the MS ADPCM decoder.
+   - Switched SDL backend to SDL2 by default. SDL1 is still a fallback.
 
  AGI:
    - Added support for Hercules rendering. Both green and amber modes are

--- a/configure
+++ b/configure
@@ -184,7 +184,7 @@ _amigaospath="Games:ScummVM"
 _staticlibpath=
 _xcodetoolspath=
 _sparklepath=
-_sdlconfig=sdl-config
+_sdlconfig=sdl2-config
 _freetypeconfig=freetype-config
 _sdlpath="$PATH"
 _freetypepath="$PATH"
@@ -368,7 +368,7 @@ define_in_config_if_yes() {
 # TODO: small bit of code to test sdl usability
 find_sdlconfig() {
 	echo_n "Looking for sdl-config... "
-	sdlconfigs="$SDL_CONFIG:$_sdlconfig:sdl-config:sdl11-config:sdl12-config"
+	sdlconfigs="$SDL_CONFIG:$_sdlconfig:sdl2-config:sdl12-config:sdl11-config:sdl-config"
 	_sdlconfig=
 
 	IFS="${IFS=   }"; ac_save_ifs="$IFS"; IFS="$SEPARATOR"
@@ -3122,7 +3122,7 @@ case $_backend in
 		append_var INCLUDES "-I$ANDROID_NDK/sources/cxx-stl/system/include"
 		;;
 	androidsdl)
-		;;		
+		;;
 	dc)
 		append_var INCLUDES '-I$(srcdir)/backends/platform/dc'
 		append_var INCLUDES '-isystem $(ronindir)/include'

--- a/dists/debian/control
+++ b/dists/debian/control
@@ -3,7 +3,7 @@ Section: games
 Priority: optional
 Maintainer: Debian Games Team <pkg-games-devel@lists.alioth.debian.org>
 Uploaders: David Weinehall <tao@debian.org>, Moritz Muehlenhoff <jmm@debian.org>
-Build-Depends: debhelper (>= 7.0.50~), nasm [i386], libsdl1.2-dev, libmad0-dev, libasound2-dev [linux-any], libvorbis-dev, libmpeg2-4-dev, libflac-dev, libz-dev, libfluidsynth-dev, python
+Build-Depends: debhelper (>= 7.0.50~), nasm [i386], libsdl2-dev, libmad0-dev, libasound2-dev [linux-any], libvorbis-dev, libmpeg2-4-dev, libflac-dev, libz-dev, libfluidsynth-dev, python
 Standards-Version: 3.9.2
 Homepage: http://www.scummvm.org
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,7 +25,7 @@ parts:
     build-packages:
       - g++
       - make
-      - libsdl1.2-dev
+      - libsdl2-dev
       - libjpeg62-dev
       - libmpeg2-4-dev
       - libogg-dev
@@ -54,7 +54,7 @@ parts:
       - libmpeg2-4
       - libogg0
       - libpng12-0
-      - libsdl1.2debian
+      - libsdl2-2.0-0
       - libsndio6.1
       - libstdc++6
       - libtheora0


### PR DESCRIPTION
This is the switch of SDL backend to SDL2. All the work has been already prepared, and the use of this library version tested many times. Thus, this patch boils down to adding new references in our build system.
