### PR TITLE
WINTERMUTE: Add flag for games using low-spec resources

### DIFF
--- a/engines/wintermute/base/sound/base_sound_buffer.cpp
+++ b/engines/wintermute/base/sound/base_sound_buffer.cpp
@@ -33,7 +33,9 @@
 #include "engines/wintermute/wintermute.h"
 #include "audio/audiostream.h"
 #include "audio/mixer.h"
+#ifdef USE_VORBIS
 #include "audio/decoders/vorbis.h"
+#endif
 #include "audio/decoders/wave.h"
 #include "audio/decoders/raw.h"
 #include "common/system.h"
@@ -102,9 +104,12 @@ bool BaseSoundBuffer::loadFromFile(const Common::String &filename, bool forceRel
 	}
 	Common::String strFilename(filename);
 	strFilename.toLowercase();
-	if (strFilename.hasSuffix(".ogg")) {
-		_stream = Audio::makeVorbisStream(_file, DisposeAfterUse::YES);
-	} else if (strFilename.hasSuffix(".wav")) {
+	#ifdef USE_VORBIS
+		if (strFilename.hasSuffix(".ogg")) {
+			_stream = Audio::makeVorbisStream(_file, DisposeAfterUse::YES);
+		}
+	#endif
+	if (strFilename.hasSuffix(".wav")) {
 		int waveSize, waveRate;
 		byte waveFlags;
 		uint16 waveType;

--- a/engines/wintermute/configure.engine
+++ b/engines/wintermute/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine wintermute "Wintermute" yes "" "" "jpeg png zlib vorbis 16bit highres"
+add_engine wintermute "Wintermute" yes "" "" "zlib 16bit highres"

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -43,7 +43,7 @@ static const PlainGameDescriptor wintermuteGames[] = {
 	{"conspiracao",     "Conspiracao Dumont"},
 	{"corrosion",       "Corrosion: Cold Winter Waiting"},
 	{"deadcity",        "Dead City"},
-	{"dfafadventure",        "DFAF Adventure"},
+	{"dfafadventure",   "DFAF Adventure"},
 	{"dreamcat",        "Dreamcat"},
 	{"dreaming",        "Des Reves Elastiques Avec Mille Insectes Nommes Georges"},
 	{"dirtysplit",      "Dirty Split"},
@@ -243,7 +243,7 @@ static const WMEGameDescription gameDescriptions[] = {
 					"data.dcp", "7ebfd50d1a22370ed7b079bcaa631d62", 9070205), Common::RU_RUS, ADGF_UNSTABLE, LATEST_VERSION),
 	// DFAF Adventure
 	WME_WINENTRY("dfafadventure", "",
-		WME_ENTRY1s("data.dcp","5704ebef961176f647742aa66bd09352", 10083417), Common::EN_ANY, ADGF_UNSTABLE, LATEST_VERSION),
+		WME_ENTRY1s("data.dcp","5704ebef961176f647742aa66bd09352", 10083417), Common::EN_ANY, ADGF_UNSTABLE | GF_LOWSPEC_ASSETS, LATEST_VERSION),
 	// Dirty Split (Czech)
 	WME_WINENTRY("dirtysplit", "",
 		WME_ENTRY2s("czech.dcp", "08a71446467cf8f9444cfea446b46ad6", 127697934,
@@ -271,7 +271,7 @@ static const WMEGameDescription gameDescriptions[] = {
 		WME_ENTRY1s("data.dcp", "4af26d97ea063fc1277ce30ae431de90", 8804073), Common::EN_ANY, ADGF_UNSTABLE, LATEST_VERSION),
 	// Dreamcat
 	WME_WINENTRY("dreamcat", "",
-		WME_ENTRY1s("data.dcp","189bd4eef29034f4ff4ed30120eaac4e", 7758040), Common::EN_ANY, ADGF_UNSTABLE, LATEST_VERSION),
+		WME_ENTRY1s("data.dcp","189bd4eef29034f4ff4ed30120eaac4e", 7758040), Common::EN_ANY, ADGF_UNSTABLE | GF_LOWSPEC_ASSETS, LATEST_VERSION),
 	// Dreamscape
 	WME_WINENTRY("dreamscape", "",
 		WME_ENTRY1s("data.dcp",  "7a5752ed4446c862be9f02d7932acf54", 17034377), Common::EN_ANY, ADGF_UNSTABLE, LATEST_VERSION),
@@ -378,7 +378,7 @@ static const WMEGameDescription gameDescriptions[] = {
 					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::ES_ESP, ADGF_UNSTABLE, LATEST_VERSION),
 	// Open Quest
 	WME_WINENTRY("openquest", "",
-		WME_ENTRY1s("data.dcp", "16893e3fc15a211a49654ae66f684f28", 82281736), Common::EN_ANY, ADGF_UNSTABLE | ADGF_DEMO, LATEST_VERSION),	
+		WME_ENTRY1s("data.dcp", "16893e3fc15a211a49654ae66f684f28", 82281736), Common::EN_ANY, ADGF_UNSTABLE | GF_LOWSPEC_ASSETS, LATEST_VERSION),	
 	// Night Train Demo
 	WME_WINENTRY("nighttrain", "",
 		WME_ENTRY1s("data.dcp", "5a027ef84b083a730c9a4c85ec1d3a32", 131760816), Common::EN_ANY, ADGF_UNSTABLE | ADGF_DEMO, LATEST_VERSION),
@@ -589,4 +589,3 @@ static const WMEGameDescription gameDescriptions[] = {
 #undef WEM_ENTRY3s
 #undef WME_WINENTRY
 #undef WME_PLATENTRY
-

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -33,8 +33,8 @@
 #include "engines/util.h"
 #include "engines/wintermute/ad/ad_game.h"
 #include "engines/wintermute/wintermute.h"
-#include "engines/wintermute/game_description.h"
 #include "engines/wintermute/debugger.h"
+#include "engines/wintermute/game_description.h"
 #include "engines/wintermute/platform_osystem.h"
 #include "engines/wintermute/base/base_engine.h"
 
@@ -43,6 +43,8 @@
 #include "engines/wintermute/base/gfx/base_renderer.h"
 #include "engines/wintermute/base/scriptables/script_engine.h"
 #include "engines/wintermute/debugger/debugger_controller.h"
+
+#include "gui/message.h"
 
 namespace Wintermute {
 
@@ -110,7 +112,11 @@ bool WintermuteEngine::hasFeature(EngineFeature f) const {
 Common::Error WintermuteEngine::run() {
 	// Initialize graphics using following:
 	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	initGraphics(800, 600, &format);
+	if (_gameDescription->adDesc.flags & GF_LOWSPEC_ASSETS) {
+		initGraphics(320, 240, &format);
+	} else {
+		initGraphics(800, 600, &format);
+	}
 	if (g_system->getScreenFormat() != format) {
 		error("Wintermute currently REQUIRES 32bpp");
 	}
@@ -139,6 +145,18 @@ Common::Error WintermuteEngine::run() {
 
 int WintermuteEngine::init() {
 	BaseEngine::createInstance(_targetName, _gameDescription->adDesc.gameId, _gameDescription->adDesc.language, _gameDescription->targetExecutable);
+
+	// check dependencies for games with high resolution assets
+	#if not defined(USE_PNG) || not defined(USE_JPEG) || not defined(USE_VORBIS)
+		if (!(_gameDescription->adDesc.flags & GF_LOWSPEC_ASSETS)) {
+			GUI::MessageDialog dialog("This game requires PNG, JPEG and Vorbis support.");
+			dialog.runModal();
+			delete _game;
+			_game = nullptr;
+			return false;
+		}
+	#endif
+
 	_game = new AdGame(_targetName);
 	if (!_game) {
 		return 1;

--- a/engines/wintermute/wintermute.h
+++ b/engines/wintermute/wintermute.h
@@ -45,6 +45,11 @@ enum {
 	kWintermuteDebugGeneral = 1 << 5
 };
 
+enum WintermuteGameFeatures {
+ 	/** A game with low-spec resources. */
+ 	GF_LOWSPEC_ASSETS       = 1 << 0
+};
+
 class WintermuteEngine : public Engine {
 public:
 	WintermuteEngine(OSystem *syst, const WMEGameDescription *desc);


### PR DESCRIPTION
I created three game for Wintermute that use 320x240 resolution, with 8-bit BMP art assets and WAV music, so they don't require the PNG, JPG, or VORBIS libraries.

The games are available here:
https://jennibee.itch.io/dreamcat
https://jennibee.itch.io/openquest-wintermute
https://jennibee.itch.io/dfaf-adventure