### PR TITLE
SDL: Fix build with MacPorts SDL2

### DIFF
--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -67,6 +67,53 @@ typedef struct { int FAKE; } FAKE_FILE;
 #define system FAKE_system
 #endif
 
+// Fix compilation with MacPorts SDL 2
+// It needs various (usually forbidden) symbols from time.h
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_asctime)
+#undef asctime
+#define asctime FAKE_asctime
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_clock)
+#undef clock
+#define clock FAKE_clock
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_ctime)
+#undef ctime
+#define ctime FAKE_ctime
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_difftime)
+#undef difftime
+#define difftime FAKE_difftime
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_getdate)
+#undef getdate
+#define getdate FAKE_getdate
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_gmtime)
+#undef gmtime
+#define gmtime FAKE_gmtime
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_localtime)
+#undef localtime
+#define localtime FAKE_localtime
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_mktime)
+#undef mktime
+#define mktime FAKE_mktime
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_time)
+#undef time
+#define time FAKE_time
+#endif
+
 // HACK: SDL might include windows.h which defines its own ARRAYSIZE.
 // However, we want to use the version from common/util.h. Thus, we make sure
 // that we actually have this definition after including the SDL headers.
@@ -174,6 +221,57 @@ typedef struct { int FAKE; } FAKE_FILE;
 #if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_system)
 #undef system
 #define system(a) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+// re-forbid all those time.h symbols again (if they were forbidden)
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_asctime)
+#undef asctime
+#define asctime(a) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_asctime)
+#undef asctime
+#define asctime(a) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_clock)
+#undef clock
+#define clock() FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_ctime)
+#undef ctime
+#define ctime(a) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_difftime)
+#undef difftime
+#define difftime(a,b) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_getdate)
+#undef getdate
+#define getdate(a) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_gmtime)
+#undef gmtime
+#define gmtime(a) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_localtime)
+#undef localtime
+#define localtime(a) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_mktime)
+#undef mktime
+#define mktime(a) FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
+
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_time)
+#undef time
+#define time(a) FORBIDDEN_SYMBOL_REPLACEMENT
 #endif
 
 // SDL 2 has major API changes. We redefine constants which got renamed to


### PR DESCRIPTION
SDL2 (2.0.4) that comes with MacPorts uses MacPorts' libiconv which ends up depending on `time.h` forbidden symbols

Here is the include-chain to time.h (pre-patch)
```
../backends/platform/sdl/sdl-sys.h:100
/opt/local/include/SDL2/SDL.h:32
/opt/local/include/SDL2/SDL_main.h:25
/opt/local/include/SDL2/SDL_stdinc.h:87
/opt/local/include/iconv.h:111
/usr/include/wchar.h:91
/usr/include/time.h
```

Homebrew doesn't have this problem because it uses the native (XCode) libiconv