### PR TITLE
SCI32: Implement dynamic video rectangles (SetHotRectangles)

### DIFF
--- a/engines/sci/engine/kernel.h
+++ b/engines/sci/engine/kernel.h
@@ -631,6 +631,7 @@ reg_t kFont(EngineState *s, int argc, reg_t *argv);
 reg_t kAddLine(EngineState *s, int argc, reg_t *argv);
 reg_t kUpdateLine(EngineState *s, int argc, reg_t *argv);
 reg_t kDeleteLine(EngineState *s, int argc, reg_t *argv);
+reg_t kSetHotRectangles(EngineState *s, int argc, reg_t *argv);
 
 // Phantasmagoria Mac Special Kernel Function
 reg_t kDoSoundPhantasmagoriaMac(EngineState *s, int argc, reg_t *argv);

--- a/engines/sci/engine/kernel_tables.h
+++ b/engines/sci/engine/kernel_tables.h
@@ -910,6 +910,11 @@ static SciKernelMapEntry s_kernelMap[] = {
 	// an integer and not an object, although it is an object reference.
 	{ MAP_CALL(UpdateLine),        SIG_EVERYWHERE,           "ioiiii(iiiii)",         NULL,            NULL },
 	{ MAP_CALL(DeleteLine),        SIG_EVERYWHERE,           "io",                    NULL,            NULL },
+	// Used by SQ6 to scroll through the inventory via the up/down buttons
+	{ MAP_CALL(MovePlaneItems),    SIG_SINCE_SCI21, SIGFOR_ALL, "oii(i)",             NULL,            NULL },
+	{ MAP_CALL(SetPalStyleRange),  SIG_EVERYWHERE,            "ii",                   NULL,            NULL },
+	{ MAP_CALL(MorphOn),           SIG_EVERYWHERE,            "",                     NULL,            NULL },
+	{ MAP_CALL(SetHotRectangles),  SIG_EVERYWHERE,            "i(r)",                 NULL,            NULL },
 
 	// SCI2.1 Empty Functions
 
@@ -951,19 +956,6 @@ static SciKernelMapEntry s_kernelMap[] = {
 	{ MAP_DUMMY(CheckCDisc),        SIG_EVERYWHERE,           "(.*)",                 NULL,            NULL },
 	{ MAP_DUMMY(GetSaveCDisc),      SIG_EVERYWHERE,           "(.*)",                 NULL,            NULL },
 	{ MAP_DUMMY(TestPoly),          SIG_EVERYWHERE,           "(.*)",                 NULL,            NULL },
-
-	// SCI2.1 unmapped functions - TODO!
-
-	// SetHotRectangles - used by Phantasmagoria 1, script 64981 (used in the chase scene)
-	//     <lskovlun> The idea, if I understand correctly, is that the engine generates events
-	//     of a special HotRect type continuously when the mouse is on that rectangle
-
-	// Used by SQ6 to scroll through the inventory via the up/down buttons
-	{ MAP_CALL(MovePlaneItems),     SIG_SINCE_SCI21, SIGFOR_ALL, "oii(i)",            NULL,            NULL },
-
-	{ MAP_CALL(SetPalStyleRange),   SIG_EVERYWHERE,           "ii",                   NULL,            NULL },
-
-	{ MAP_CALL(MorphOn),            SIG_EVERYWHERE,           "",                     NULL,            NULL },
 
 	// SCI3 Kernel Functions
 	{ MAP_CALL(PlayDuck),           SIG_EVERYWHERE,           "(.*)",                 NULL,            NULL },

--- a/engines/sci/engine/kmisc.cpp
+++ b/engines/sci/engine/kmisc.cpp
@@ -637,6 +637,17 @@ reg_t kPlatform32(EngineState *s, int argc, reg_t *argv) {
 }
 #endif
 
+reg_t kSetHotRectangles(EngineState *s, int argc, reg_t *argv) {
+	if (argc == 1) {
+		g_sci->_gfxCursor32->setHotRectangleStatus(argv[0].toUint16());
+	} else {
+		g_sci->_gfxCursor32->setHotRectangleStatus(true);
+		g_sci->_gfxCursor32->setupHotRectangles(argv[0].toUint16(), argv[1]);
+	}
+
+	return s->r_acc;
+}
+
 reg_t kEmpty(EngineState *s, int argc, reg_t *argv) {
 	// Placeholder for empty kernel functions which are still called from the
 	// engine scripts (like the empty kSetSynonyms function in SCI1.1). This

--- a/engines/sci/graphics/cursor32.h
+++ b/engines/sci/graphics/cursor32.h
@@ -109,6 +109,28 @@ public:
 	 */
 	void clearRestrictedArea();
 
+	/**
+	 * Hot rectangle status, used for special click events in VMD videos
+	 */
+	void setHotRectangleStatus(bool status) {
+		_hotRectanglesEnabled = status;
+	}
+
+	/**
+	 * Hot rectangles, used for special click events in VMD videos
+	 */
+	void setupHotRectangles(uint16 rectCount, reg_t hotRects);
+
+	/**
+	 * Returns true if a hot rectangle event occured. SSCI also held
+	 * the hot rectangle index, but this was never actually used
+	 */
+	bool haveHotRectangleEvent() {
+		bool ev = _hotRectangleEvent;
+		_hotRectangleEvent = false;
+		return ev;
+	}
+
 	void setMacCursorRemapList(int cursorCount, reg_t *cursors);
 
 	virtual void saveLoadWithSerializer(Common::Serializer &ser);
@@ -205,8 +227,19 @@ private:
 	 */
 	bool _writeToVMAP;
 
-	// Mac versions of games use a remap list to remap their cursors
+	/**
+	 * Mac versions of games use a remap list to remap their cursors
+	 */
 	Common::Array<uint16> _macCursorRemap;
+
+	/**
+	 * Hot rectangle status, used for special click events in VMD videos
+	 */
+	bool _hotRectanglesEnabled;
+	int _curHotRectIndex;
+	bool _hotRectangleEvent;
+
+	Common::List<Common::Rect> _hotRectangles;
 
 	/**
 	 * Reads data from the output buffer or hardware
@@ -249,6 +282,11 @@ private:
 	 * Renders the cursor at its new location.
 	 */
 	void move();
+
+	/**
+	 * Checks for hot rectangle clicks and emits relevant events
+	 */
+	void checkHotRectangles();
 };
 
 } // End of namespace Sci

--- a/engines/sci/graphics/video32.cpp
+++ b/engines/sci/graphics/video32.cpp
@@ -486,9 +486,7 @@ AVIPlayer::EventFlags AVIPlayer::playUntilEvent(EventFlags flags) {
 			}
 		}
 
-		// TODO: Hot rectangles
-		if ((flags & kEventFlagHotRectangle) /* && event.type == SCI_EVENT_HOT_RECTANGLE */) {
-			warning("Hot rectangles not implemented in VMD player");
+		if ((flags & kEventFlagHotRectangle) && g_sci->_gfxCursor32->haveHotRectangleEvent()) {
 			stopFlag = kEventFlagHotRectangle;
 			break;
 		}
@@ -802,9 +800,7 @@ VMDPlayer::EventFlags VMDPlayer::playUntilEvent(const EventFlags flags) {
 			}
 		}
 
-		// TODO: Hot rectangles
-		if ((flags & kEventFlagHotRectangle) /* && event.type == SCI_EVENT_HOT_RECTANGLE */) {
-			warning("Hot rectangles not implemented in VMD player");
+		if ((flags & kEventFlagHotRectangle) && g_sci->_gfxCursor32->haveHotRectangleEvent()) {
 			stopFlag = kEventFlagHotRectangle;
 			break;
 		}


### PR DESCRIPTION
This is an very rare functionality of the SCI engine, used during the
final chase scene in Phantasmagoria. Essentially, hot rectangles are
given in a list by the scripts while a VMD video is playing, and are
used to stop the video when the mouse enters or leaves a rectangle.
SSCI generates specific hot rectangle events, which are then picked up
by the VMD player, which also include the index of the hot rectangle
that fired the event, however this was never used.

Since this is only checked in one place (the VMD player), in this
implementation we are just storing a flag in the cursor handler when
a hot rectangle event occurs, which is then checked by the VMD player,
instead of injecting custom events