### PR TITLE
GRAPHICS: [GSoC] Fix leaks and bugs in MacGui

### DIFF
--- a/graphics/macgui/macwindow.cpp
+++ b/graphics/macgui/macwindow.cpp
@@ -324,19 +324,19 @@ void MacWindow::loadBorder(Common::SeekableReadStream &file, bool active, int lo
 	source = *(bmpDecoder.getSurface());
 
 	source.convertToInPlace(surface->getSupportedPixelFormat(), bmpDecoder.getPalette());
-	surface->create(source.w, source.h, source.format);
 	surface->copyFrom(source);
 	surface->applyColorKey(255, 0, 255, false);
 
 	if (active)
-		_macBorder.addActiveBorder(*surface);
+		_macBorder.addActiveBorder(surface);
 	else
-		_macBorder.addInactiveBorder(*surface);
+		_macBorder.addInactiveBorder(surface);
 
 	if (!_macBorder.hasOffsets())
 		_macBorder.setOffsets(lo, ro, to, bo);
 
 	updateInnerDims();
+	source.free();
 }
 
 void MacWindow::setCloseable(bool closeable) {

--- a/graphics/macgui/macwindow.cpp
+++ b/graphics/macgui/macwindow.cpp
@@ -336,7 +336,6 @@ void MacWindow::loadBorder(Common::SeekableReadStream &file, bool active, int lo
 		_macBorder.setOffsets(lo, ro, to, bo);
 
 	updateInnerDims();
-	source.free();
 }
 
 void MacWindow::setCloseable(bool closeable) {

--- a/graphics/macgui/macwindow.cpp
+++ b/graphics/macgui/macwindow.cpp
@@ -317,14 +317,14 @@ void MacWindow::setScroll(float scrollPos, float scrollSize) {
 
 void MacWindow::loadBorder(Common::SeekableReadStream &file, bool active, int lo, int ro, int to, int bo) {
 	Image::BitmapDecoder bmpDecoder;
-	Graphics::Surface source;
+	Graphics::Surface *source;
 	Graphics::TransparentSurface *surface = new Graphics::TransparentSurface();
 
 	bmpDecoder.loadStream(file);
-	source = *(bmpDecoder.getSurface());
+	source = bmpDecoder.getSurface()->convertTo(surface->getSupportedPixelFormat(), bmpDecoder.getPalette());
 
-	source.convertToInPlace(surface->getSupportedPixelFormat(), bmpDecoder.getPalette());
-	surface->copyFrom(source);
+	surface->create(source->w, source->h, surface->getSupportedPixelFormat());
+	surface->copyFrom(*source);
 	surface->applyColorKey(255, 0, 255, false);
 
 	if (active)
@@ -336,6 +336,8 @@ void MacWindow::loadBorder(Common::SeekableReadStream &file, bool active, int lo
 		_macBorder.setOffsets(lo, ro, to, bo);
 
 	updateInnerDims();
+	source->free();
+	delete source;
 }
 
 void MacWindow::setCloseable(bool closeable) {

--- a/graphics/macgui/macwindowborder.cpp
+++ b/graphics/macgui/macwindowborder.cpp
@@ -112,6 +112,7 @@ void MacWindowBorder::blitBorderInto(ManagedSurface &destination, bool active) {
 
 	src->blit(srf, 0, 0, srf.w, srf.h, palette, kColorCount);
 	destination.transBlitFrom(srf, kColorGreen2);
+	srf.free();
 }
 
 } // End of namespace Graphics

--- a/graphics/macgui/macwindowborder.cpp
+++ b/graphics/macgui/macwindowborder.cpp
@@ -71,15 +71,15 @@ bool MacWindowBorder::hasBorder(bool active) {
 	return active ? _activeInitialized : _inactiveInitialized;
 }
 
-void MacWindowBorder::addActiveBorder(TransparentSurface &source) {
+void MacWindowBorder::addActiveBorder(TransparentSurface *source) {
 	assert(!_activeBorder);
-	_activeBorder = new NinePatchBitmap(&source, false);
+	_activeBorder = new NinePatchBitmap(source, true);
 	_activeInitialized = true;
 }
 
-void MacWindowBorder::addInactiveBorder(TransparentSurface &source) {
+void MacWindowBorder::addInactiveBorder(TransparentSurface *source) {
 	assert(!_inactiveBorder);
-	_inactiveBorder = new NinePatchBitmap(&source, false);
+	_inactiveBorder = new NinePatchBitmap(source, true);
 	_inactiveInitialized = true;
 }
 

--- a/graphics/macgui/macwindowborder.h
+++ b/graphics/macgui/macwindowborder.h
@@ -86,14 +86,14 @@ public:
 	 * Will fail if there is already an active border.
 	 * @param The surface that will be displayed.
 	 */
-	void addActiveBorder(TransparentSurface &source);
+	void addActiveBorder(TransparentSurface *source);
 
 	/**
 	 * Add the given surface as the display of the border in the inactive state.
 	 * Will fail if there is already an inactive border.
 	 * @param The surface that will be displayed.
 	 */
-	void addInactiveBorder(TransparentSurface &source);
+	void addInactiveBorder(TransparentSurface *source);
 
 	/**
 	 * Accessor function for the custom offsets.

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -322,6 +322,7 @@ void MacWindowManager::removeMarked() {
 	}
 	_windowsToRemove.clear();
 	_needsRemoval = false;
+	_lastId = _windows.size();
 }
 
 void MacWindowManager::removeFromStack(BaseMacWindow *target) {

--- a/graphics/nine_patch.cpp
+++ b/graphics/nine_patch.cpp
@@ -260,8 +260,10 @@ void NinePatchBitmap::blit(Graphics::Surface &target, int dx, int dy, int dw, in
 }
 
 NinePatchBitmap::~NinePatchBitmap() {
-	if (_destroy_bmp)
+	if (_destroy_bmp) {
+		_bmp->free();
 		delete _bmp;
+	}
 }
 
 void NinePatchBitmap::drawRegions(Graphics::Surface &target, int dx, int dy, int dw, int dh) {

--- a/graphics/nine_patch.cpp
+++ b/graphics/nine_patch.cpp
@@ -230,24 +230,27 @@ void NinePatchBitmap::blit(Graphics::Surface &target, int dx, int dy, int dw, in
 		if (!palette)
 			warning("Trying to blit into a surface with 1bpp, you need the palette.");
 
-		Surface srf;
-		srf.create(target.w, target.h, _bmp->format);
+		Surface *srf = new Surface();
+		srf->create(target.w, target.h, _bmp->format);
 
-		drawRegions(srf, dx, dy, dw, dh);
+		drawRegions(*srf, dx, dy, dw, dh);
 
 		//TODO: This can be further optimized by keeping the data between draws,
 		// and using a unique identifier for each palette, so that it only gets
 		// recalculated when the palette changes.
 		_cached_colors.clear();
 
-		for (uint i = 0; i < srf.w; ++i) {
-			for (uint j = 0; j < srf.h; ++j) {
-				uint32 color = *(uint32*)srf.getBasePtr(i, j);
+		for (uint i = 0; i < srf->w; ++i) {
+			for (uint j = 0; j < srf->h; ++j) {
+				uint32 color = *(uint32*)srf->getBasePtr(i, j);
 				if (color > 0) {
 					*((byte *)target.getBasePtr(i, j)) = closestGrayscale(color, palette, numColors);
 				}
 			}
 		}
+
+		srf->free();
+		delete srf;
 
 		return;
 	}


### PR DESCRIPTION
Since the addition of MacGui to mainline, a number of leaks and minor bugs in the code have been found, via Valgrind. They were mostly due to `free()` not being called when appropriate, which in a particular case created a 10MB leak every time the GUI was drawn. Regarding the bugs, there was only one found, which creashed the game when closing a window, due to a leftover index.

This PR is part of the cleanup of my GSoC project.