### PR TITLE
SCI32: kNumCels

### DIFF
--- a/engines/sci/engine/state.cpp
+++ b/engines/sci/engine/state.cpp
@@ -380,4 +380,46 @@ void SciEngine::checkVocabularySwitch() {
 	}
 }
 
+SciCallOrigin EngineState::getCurrentCallOrigin() const {
+	// IMPORTANT: This method must always return values that match *exactly* the
+	// values in the workaround tables in workarounds.cpp, or workarounds will
+	// be broken
+
+	Common::String curObjectName = _segMan->getObjectName(xs->sendp);
+	Common::String curMethodName;
+	const Script *localScript = _segMan->getScriptIfLoaded(xs->local_segment);
+	int curScriptNr = localScript->getScriptNumber();
+
+	if (xs->debugLocalCallOffset != -1) {
+		// if lastcall was actually a local call search back for a real call
+		Common::List<ExecStack>::const_iterator callIterator = _executionStack.end();
+		while (callIterator != _executionStack.begin()) {
+			callIterator--;
+			const ExecStack &loopCall = *callIterator;
+			if ((loopCall.debugSelector != -1) || (loopCall.debugExportId != -1)) {
+				xs->debugSelector = loopCall.debugSelector;
+				xs->debugExportId = loopCall.debugExportId;
+				break;
+			}
+		}
+	}
+
+	if (xs->type == EXEC_STACK_TYPE_CALL) {
+		if (xs->debugSelector != -1) {
+			curMethodName = g_sci->getKernel()->getSelectorName(xs->debugSelector);
+		} else if (xs->debugExportId != -1) {
+			curObjectName = "";
+			curMethodName = Common::String::format("export %d", xs->debugExportId);
+		}
+	}
+
+	SciCallOrigin reply;
+	reply.objectName = curObjectName;
+	reply.methodName = curMethodName;
+	reply.scriptNr = curScriptNr;
+	reply.localCallOffset = xs->debugLocalCallOffset;
+	reply.roomNr = currentRoomNumber();
+	return reply;
+}
+
 } // End of namespace Sci

--- a/engines/sci/engine/state.h
+++ b/engines/sci/engine/state.h
@@ -99,6 +99,17 @@ struct VideoState {
 	}
 };
 
+/**
+ * Trace information about a VM function call.
+ */
+struct SciCallOrigin {
+	int scriptNr; //< The source script of the function
+	Common::String objectName; //< The name of the object being called
+	Common::String methodName; //< The name of the method being called
+	int localCallOffset; //< The byte offset of a local script subroutine called by the origin method. -1 if not in a local subroutine.
+	int roomNr; //< The room that was loaded at the time of the call
+};
+
 struct EngineState : public Common::Serializable {
 public:
 	EngineState(SegManager *segMan);
@@ -209,6 +220,11 @@ public:
 	 * Resets the engine state.
 	 */
 	void reset(bool isRestoring);
+
+	/**
+	 * Finds and returns the origin of the current call.
+	 */
+	SciCallOrigin getCurrentCallOrigin() const;
 };
 
 } // End of namespace Sci

--- a/engines/sci/engine/vm.cpp
+++ b/engines/sci/engine/vm.cpp
@@ -124,7 +124,7 @@ static reg_t read_var(EngineState *s, int type, int index) {
 			case VAR_TEMP: {
 				// Uninitialized read on a temp
 				//  We need to find correct replacements for each situation manually
-				SciTrackOriginReply originReply;
+				SciCallOrigin originReply;
 				SciWorkaroundSolution solution = trackOriginAndFindWorkaround(index, uninitializedReadWorkarounds, &originReply);
 				if (solution.type == WORKAROUND_NONE) {
 #ifdef RELEASE_BUILD
@@ -361,7 +361,7 @@ static void callKernelFunc(EngineState *s, int kernelCallNr, int argc) {
 	if (kernelCall.signature
 			&& !kernel->signatureMatch(kernelCall.signature, argc, argv)) {
 		// signature mismatch, check if a workaround is available
-		SciTrackOriginReply originReply;
+		SciCallOrigin originReply;
 		SciWorkaroundSolution solution = trackOriginAndFindWorkaround(0, kernelCall.workarounds, &originReply);
 		switch (solution.type) {
 		case WORKAROUND_NONE: {
@@ -429,7 +429,7 @@ static void callKernelFunc(EngineState *s, int kernelCallNr, int argc) {
 		const KernelSubFunction &kernelSubCall = kernelCall.subFunctions[subId];
 		if (kernelSubCall.signature && !kernel->signatureMatch(kernelSubCall.signature, argc, argv)) {
 			// Signature mismatch
-			SciTrackOriginReply originReply;
+			SciCallOrigin originReply;
 			SciWorkaroundSolution solution = trackOriginAndFindWorkaround(0, kernelSubCall.workarounds, &originReply);
 			switch (solution.type) {
 			case WORKAROUND_NONE: {

--- a/engines/sci/engine/vm_types.cpp
+++ b/engines/sci/engine/vm_types.cpp
@@ -66,7 +66,7 @@ void reg_t::setOffset(uint32 offset) {
 }
 
 reg_t reg_t::lookForWorkaround(const reg_t right, const char *operation) const {
-	SciTrackOriginReply originReply;
+	SciCallOrigin originReply;
 	SciWorkaroundSolution solution = trackOriginAndFindWorkaround(0, arithmeticWorkarounds, &originReply);
 	if (solution.type == WORKAROUND_NONE)
 		error("Invalid arithmetic operation (%s - params: %04x:%04x and %04x:%04x) from method %s::%s (room %d, script %d, localCall %x)",

--- a/engines/sci/engine/workarounds.h
+++ b/engines/sci/engine/workarounds.h
@@ -24,6 +24,7 @@
 #define SCI_ENGINE_WORKAROUNDS_H
 
 #include "sci/engine/vm_types.h"
+#include "sci/engine/state.h"
 #include "sci/sci.h"
 
 namespace Sci {
@@ -33,13 +34,6 @@ enum SciWorkaroundType {
 	WORKAROUND_IGNORE,    // ignore kernel call
 	WORKAROUND_STILLCALL, // still do kernel call
 	WORKAROUND_FAKE       // fake kernel call / replace temp value / fake opcode
-};
-
-struct SciTrackOriginReply {
-	int scriptNr;
-	Common::String objectName;
-	Common::String methodName;
-	int localCallOffset;
 };
 
 struct SciWorkaroundSolution {
@@ -103,7 +97,7 @@ extern const SciWorkaroundEntry kUnLoad_workarounds[];
 extern const SciWorkaroundEntry kStringPutAt_workarounds[];
 extern const SciWorkaroundEntry kScrollWindowAdd_workarounds[];
 
-extern SciWorkaroundSolution trackOriginAndFindWorkaround(int index, const SciWorkaroundEntry *workaroundList, SciTrackOriginReply *trackOrigin);
+extern SciWorkaroundSolution trackOriginAndFindWorkaround(int index, const SciWorkaroundEntry *workaroundList, SciCallOrigin *trackOrigin);
 
 } // End of namespace Sci
 

--- a/engines/sci/graphics/paint16.cpp
+++ b/engines/sci/graphics/paint16.cpp
@@ -541,7 +541,7 @@ reg_t GfxPaint16::kernelDisplay(const char *text, uint16 languageSplitter, int a
 			break;
 
 		default:
-			SciTrackOriginReply originReply;
+			SciCallOrigin originReply;
 			SciWorkaroundSolution solution = trackOriginAndFindWorkaround(0, kDisplay_workarounds, &originReply);
 			if (solution.type == WORKAROUND_NONE)
 				error("Unknown kDisplay argument (%04x:%04x) from method %s::%s (script %d, localCall %x)",


### PR DESCRIPTION
Every version of SCI32 has a logic error in `kNumCels` (comparison `>` instead of `>=`) that causes games to read garbage data if they ask for a cel count for the one-past-the-end loop. Unfortunately, GK1 does exactly this, and it is plausible that other games do too since the bug in SSCI was never fixed.

This PR does two things:

1. Generalises the code used to get information on the current callee, so that information about buggy scripts can be more easily displayed in errors;
2. Raises an error whenever `kNumCels` is detected to be used in the buggy way, so game scripts relying on invalid reads can be fixed

(Please feel free to bikeshed on more appropriate names for the new EngineState method!)