### PR TITLE
COMMON: Add Atari 8-bit platform

### DIFF
--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -31,6 +31,7 @@ const PlatformDescription g_platforms[] = {
 	{ "3do", "3do", "3do", "3DO", kPlatform3DO },
 	{ "acorn", "acorn", "acorn", "Acorn", kPlatformAcorn },
 	{ "amiga", "ami", "amiga", "Amiga", kPlatformAmiga },
+	{ "atari8", "atari8", "atari8", "Atari 8-bit", kPlatformAtari8Bit },
 	{ "atari", "atari-st", "st", "Atari ST", kPlatformAtariST },
 	{ "c64", "c64", "c64", "Commodore 64", kPlatformC64 },
 	{ "pc", "dos", "ibm", "DOS", kPlatformDOS },

--- a/common/platform.h
+++ b/common/platform.h
@@ -38,6 +38,7 @@ class String;
 enum Platform {
 	kPlatformDOS,
 	kPlatformAmiga,
+	kPlatformAtari8Bit,
 	kPlatformAtariST,
 	kPlatformMacintosh,
 	kPlatformFMTowns,


### PR DESCRIPTION
This adds a platform for the [Atari 8-bit family](https://en.wikipedia.org/wiki/Atari_8-bit_family). As 'atari' is already used for the Atari ST platform, I set all the codes to 'atari8'.