### PR TITLE
AUDIO: Fix CMS chips incorrect pitch.

### DIFF
--- a/audio/softsynth/cms.h
+++ b/audio/softsynth/cms.h
@@ -68,7 +68,9 @@ struct SAA1099 {
 class CMSEmulator {
 public:
 	CMSEmulator(uint32 sampleRate) {
-		_sampleRate = sampleRate;
+		// In PCs the chips run at 7.15909 MHz instead of 8 MHz.
+		// Adjust sampling rate upwards to bring pitch down.
+		_sampleRate = (sampleRate * 352) / 315;
 		memset(_saa1099, 0, sizeof(SAA1099)*2);
 	}
 


### PR DESCRIPTION
The CMS emulation assumes the chips run at 8 MHz clock,
but in PCs they run at 7.15909 MHz, so the emulated pitch
is too high. Adjusting the requested sampling rate higher
by matching amount the pitch is lowered down to normal.