### PR TITLE
ANDROIDSDL: set default gfx_mode to 2x

### DIFF
--- a/backends/platform/androidsdl/androidsdl-sdl.cpp
+++ b/backends/platform/androidsdl/androidsdl-sdl.cpp
@@ -38,6 +38,9 @@ void OSystem_ANDROIDSDL::initBackend() {
 	if (!ConfMan.hasKey("browser_lastpath"))
 		ConfMan.set("browser_lastpath", "/storage");
 	
+	if (!ConfMan.hasKey("gfx_mode"))
+		ConfMan.set("gfx_mode", "2x");
+	
 	// Call parent implementation of this method
 	OSystem_POSIX::initBackend();
 }


### PR DESCRIPTION
set default gfx_mode to 2x (for android-sdl port)