### PR TITLE
SCI: Play MIDI version of SCI0 sound resource if user prefers it

### DIFF
--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -342,8 +342,28 @@ void SciMusic::soundInitSnd(MusicEntry *pSnd) {
 	pSnd->time = ++_timeCounter;
 
 	if (track) {
+		bool playSample;
+
+		if (_soundVersion <= SCI_VERSION_0_LATE && !_useDigitalSFX) {
+			// For SCI0 the digital sample is present in the same track as the
+			// MIDI. If the user specifically requests not to use the digital
+			// samples, play the MIDI data instead. If the MIDI portion of the
+			// track is empty however, play the digital sample anyway. This is
+			// necessary for e.g. the "Where am I?" sample in the SQ3 intro.
+			playSample = false;
+
+			if (track->channelCount == 2) {
+				SoundResource::Channel &chan = track->channels[0];
+				
+				if (chan.size < 2 || chan.data[1] == 0xfc) {
+					playSample = true;
+				}
+			}
+		} else
+			playSample = (track->digitalChannelNr != -1);
+
 		// Play digital sample
-		if (track->digitalChannelNr != -1) {
+		if (playSample) {
 			byte *channelData = track->channels[track->digitalChannelNr].data;
 			delete pSnd->pStreamAud;
 			byte flags = Audio::FLAG_UNSIGNED;


### PR DESCRIPTION
Hi there! While playing around with ScummVM and a Roland MT-32 I found some things that I thought I might improve. So here it is.

While playing SQ3 with a MT-32 hooked up I noticed that some sound effects where played back through the computer speakers rather than through the MT-32. This happens for example when Roger lands on the ground with a thud after jumping out of the spacecraft at the start of the game. I expected the MT-32 to render these sound effects after turning off "Prefer digital sound effects" for this game, as running the game in DOSBox does. This was not the case.

This fix should force the MIDI data to be played when the option is disabled. This may actually be preferable, as a lot of the sounds that have sample data are actually low quality 11KHz recordings from a MT-32.

Additionally, this fix checks if sample data is the only data present, in which case it plays that. This is the case for some recorded sounds, such as Roger Wilco saying "Where am I?" during the intro.
