### PR TITLE
SCI: Set default MT-32 reverb before each sound

### DIFF
--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -67,6 +67,7 @@ public:
 	void setVolume(byte volume);
 	int getVolume();
 	void setReverb(int8 reverb);
+	void setDefaultReverb();
 	void playSwitch(bool play);
 
 private:
@@ -111,6 +112,7 @@ private:
 	int _masterVolume;
 
 	byte _reverbConfig[kReverbConfigNr][3];
+	int8 _defaultReverb;
 	Channel _channels[16];
 	uint8 _percussionMap[128];
 	int8 _keyShift[128];
@@ -127,7 +129,7 @@ private:
 	byte _sysExBuf[kMaxSysExSize];
 };
 
-MidiPlayer_Midi::MidiPlayer_Midi(SciVersion version) : MidiPlayer(version), _playSwitch(true), _masterVolume(15), _isMt32(false), _hasReverb(false), _useMT32Track(true) {
+MidiPlayer_Midi::MidiPlayer_Midi(SciVersion version) : MidiPlayer(version), _playSwitch(true), _masterVolume(15), _isMt32(false), _hasReverb(false), _defaultReverb(-1), _useMT32Track(true) {
 	MidiDriver::DeviceHandle dev = MidiDriver::detectDevice(MDT_MIDI);
 	_driver = MidiDriver::createMidi(dev);
 
@@ -388,6 +390,11 @@ void MidiPlayer_Midi::setReverb(int8 reverb) {
 	_reverb = reverb;
 }
 
+void MidiPlayer_Midi::setDefaultReverb() {
+	if (_defaultReverb >= 0)
+		setReverb(_defaultReverb);
+}
+
 void MidiPlayer_Midi::playSwitch(bool play) {
 	_playSwitch = play;
 	if (play)
@@ -509,7 +516,7 @@ void MidiPlayer_Midi::readMt32Patch(const byte *data, int size) {
 	setMt32Volume(volume);
 
 	// Reverb default only used in (roughly) SCI0/SCI01
-	byte reverb = str->readByte();
+	_defaultReverb = str->readByte();
 
 	_hasReverb = true;
 
@@ -550,7 +557,7 @@ void MidiPlayer_Midi::readMt32Patch(const byte *data, int size) {
 
 	// Reverb for SCI0
 	if (_version <= SCI_VERSION_0_LATE)
-		setReverb(reverb);
+		setReverb(_defaultReverb);
 
 	// Send after-SysEx text
 	str->seek(0);
@@ -679,7 +686,7 @@ void MidiPlayer_Midi::readMt32DrvData() {
 
 		if (size == 2771) {
 			// MT32.DRV in LSL2 early contains more data, like a normal patch
-			byte reverb = f.readByte();
+			_defaultReverb = f.readByte();
 
 			_hasReverb = true;
 
@@ -699,7 +706,7 @@ void MidiPlayer_Midi::readMt32DrvData() {
 			sendMt32SysEx(0x50000, static_cast<Common::SeekableReadStream *>(&f), 256);
 			sendMt32SysEx(0x50200, static_cast<Common::SeekableReadStream *>(&f), 128);
 
-			setReverb(reverb);
+			setReverb(_defaultReverb);
 
 			// Send the after-SysEx text
 			f.seek(0x3d);

--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -382,7 +382,7 @@ int MidiPlayer_Midi::getVolume() {
 }
 
 void MidiPlayer_Midi::onNewSound() {
-	if (_version <= SCI_VERSION_0_LATE && _defaultReverb >= 0)
+	if (_defaultReverb >= 0)
 		// SCI0 in combination with MT-32 requires a reset of the reverb to
 		// the default value that is present in either the MT-32 patch data
 		// or MT32.DRV itself.

--- a/engines/sci/sound/drivers/mididriver.h
+++ b/engines/sci/sound/drivers/mididriver.h
@@ -106,11 +106,12 @@ public:
 		return _driver ? _driver->property(MIDI_PROP_MASTER_VOLUME, 0xffff) : 0;
 	}
 
+	virtual void onNewSound() { }
+
 	// Returns the current reverb, or -1 when no reverb is active
 	int8 getReverb() const { return _reverb; }
 	// Sets the current reverb, used mainly in MT-32
 	virtual void setReverb(int8 reverb) { _reverb = reverb; }
-	virtual void setDefaultReverb() { }
 
 	virtual void playSwitch(bool play) {
 		if (!play) {

--- a/engines/sci/sound/drivers/mididriver.h
+++ b/engines/sci/sound/drivers/mididriver.h
@@ -110,6 +110,7 @@ public:
 	int8 getReverb() const { return _reverb; }
 	// Sets the current reverb, used mainly in MT-32
 	virtual void setReverb(int8 reverb) { _reverb = reverb; }
+	virtual void setDefaultReverb() { }
 
 	virtual void playSwitch(bool play) {
 		if (!play) {

--- a/engines/sci/sound/midiparser_sci.cpp
+++ b/engines/sci/sound/midiparser_sci.cpp
@@ -381,11 +381,7 @@ void MidiParser_SCI::sendInitCommands() {
 		}
 	}
 
-	// SCI0 in combination with MT-32 requires a reset of the reverb to
-	// the default value that is present in either the MT-32 patch data
-	// or MT32.DRV itself.
-	if (_soundVersion <= SCI_VERSION_0_LATE)
-		((MidiPlayer *)_driver)->setDefaultReverb();
+	((MidiPlayer *)_driver)->onNewSound();
 }
 
 void MidiParser_SCI::unloadMusic() {

--- a/engines/sci/sound/midiparser_sci.cpp
+++ b/engines/sci/sound/midiparser_sci.cpp
@@ -353,6 +353,8 @@ void MidiParser_SCI::sendInitCommands() {
 	// Set initial voice count
 	if (_pSnd) {
 		if (_soundVersion <= SCI_VERSION_0_LATE) {
+			((MidiPlayer *)_driver)->onNewSound();
+			
 			for (int i = 0; i < 15; ++i) {
 				byte voiceCount = 0;
 				if (_channelUsed[i]) {
@@ -380,8 +382,6 @@ void MidiParser_SCI::sendInitCommands() {
 			sendToDriver(0xE0 | i,    0, 64);	// Reset pitch wheel to center
 		}
 	}
-
-	((MidiPlayer *)_driver)->onNewSound();
 }
 
 void MidiParser_SCI::unloadMusic() {

--- a/engines/sci/sound/midiparser_sci.cpp
+++ b/engines/sci/sound/midiparser_sci.cpp
@@ -380,6 +380,12 @@ void MidiParser_SCI::sendInitCommands() {
 			sendToDriver(0xE0 | i,    0, 64);	// Reset pitch wheel to center
 		}
 	}
+
+	// SCI0 in combination with MT-32 requires a reset of the reverb to
+	// the default value that is present in either the MT-32 patch data
+	// or MT32.DRV itself.
+	if (_soundVersion <= SCI_VERSION_0_LATE)
+		((MidiPlayer *)_driver)->setDefaultReverb();
 }
 
 void MidiParser_SCI::unloadMusic() {


### PR DESCRIPTION
While playing LSL3 with a MT-32 I noticed that after falling off a cliff there was suddenly a lot of reverb in the sound. This happens both with the emulator and with a real MT-32. After researching this, it turned out that the reverb setting was changed before playing the falling sound, but never reset. After comparing a MIDI capture from ScummVM and DOSBox I concluded that the behaviour of the original interpreter is to send the "default" reverb configuration, as present in the MT-32 patch data resource (or in earlier games MT32.DRV directly) before playing each song, if it got changed.

This fix introduces that behaviour for SCI0 games. I'm not 100% sure about the style of the fix, maybe a regular maintainer can weigh in on this.

I have also tried to verify this with PQ2 (as the reverb in this game was mentioned in an old bug report). The original interpreter sets the reverb data for the intro and if you then walk into the road it will reset the reverb data to a slightly different value (not actually audible to me) that is the default. ScummVM currently does not do this.

(Interestingly, there is a reset of the reverb to the default in the MIDI data of the falling sound resource in LSL3, but the sound is stopped before the player gets to it)
