### PR TITLE
SCI32: Restore return to launcher functionality

### DIFF
--- a/engines/sci/graphics/cursor32.cpp
+++ b/engines/sci/graphics/cursor32.cpp
@@ -25,6 +25,7 @@
 #include "common/memstream.h"
 #include "graphics/cursorman.h"     // for CursorMan
 #include "graphics/maccursor.h"
+#include "sci/event.h"
 #include "sci/graphics/celobj32.h"  // for CelObjView, CelInfo32, Ratio
 #include "sci/graphics/cursor32.h"
 #include "sci/graphics/frameout.h"  // for GfxFrameout
@@ -122,7 +123,7 @@ void GfxCursor32::drawToHardware(const DrawRegion &source) {
 	byte *sourcePixel = source.data + (sourceYOffset * source.rect.width()) + sourceXOffset;
 
 	g_system->copyRectToScreen(sourcePixel, source.rect.width(), drawRect.left, drawRect.top, drawRect.width(), drawRect.height());
-	g_system->updateScreen();
+	g_sci->getEventManager()->updateScreen();
 }
 
 void GfxCursor32::unhide() {

--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -35,6 +35,7 @@
 
 #include "sci/sci.h"
 #include "sci/console.h"
+#include "sci/event.h"
 #include "sci/engine/kernel.h"
 #include "sci/engine/state.h"
 #include "sci/engine/selector.h"
@@ -1123,7 +1124,7 @@ void GfxFrameout::mergeToShowList(const Common::Rect &drawRect, RectList &showLi
 
 void GfxFrameout::showBits() {
 	if (!_showList.size()) {
-		g_system->updateScreen();
+		g_sci->getEventManager()->updateScreen();
 		return;
 	}
 
@@ -1162,7 +1163,7 @@ void GfxFrameout::showBits() {
 	_cursor->donePainting();
 
 	_showList.clear();
-	g_system->updateScreen();
+	g_sci->getEventManager()->updateScreen();
 }
 
 void GfxFrameout::alterVmap(const Palette &palette1, const Palette &palette2, const int8 style, const int8 *const styleRanges) {

--- a/engines/sci/graphics/palette32.cpp
+++ b/engines/sci/graphics/palette32.cpp
@@ -284,7 +284,7 @@ void GfxPalette32::updateHardware(const bool updateScreen) {
 
 	g_system->getPaletteManager()->setPalette(bpal, 0, 256);
 	if (updateScreen) {
-		g_system->updateScreen();
+		g_sci->getEventManager()->updateScreen();
 	}
 }
 


### PR DESCRIPTION
RTL functionality has been broken by commit d0517f515e.
There is a check in EventManager::updateScreen() for shouldQuit(),
which is throttled to 60fps. This also restores the screen update
throttling to 60fps via the EventManager