### PR TITLE
Chewy: Esc from F5

### DIFF
--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -72,6 +72,7 @@ Common::Error ChewyEngine::run() {
 
 	initialize();
 
+	//_graphics->playVideo(0);
 	_graphics->drawImage("episode1.tgp", 0);
 	//_sound->playSpeech(1);
 	//_sound->playSound(1);

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -31,6 +31,7 @@
 
 #include "chewy/chewy.h"
 #include "chewy/console.h"
+#include "chewy/cursor.h"
 #include "chewy/events.h"
 #include "chewy/graphics.h"
 #include "chewy/resource.h"
@@ -59,12 +60,14 @@ ChewyEngine::~ChewyEngine() {
 	delete _events;
 	delete _text;
 	delete _sound;
+	delete _cursor;
 	delete _graphics;
 	delete _console;
 }
 
 void ChewyEngine::initialize() {
 	_console = new Console(this);
+	_cursor = new Cursor(this);
 	_graphics = new Graphics(this);
 	_sound = new Sound(_mixer);
 	_text = new Text();
@@ -92,8 +95,8 @@ Common::Error ChewyEngine::run() {
 	_graphics->drawSprite("det1.taf", 0, 200, 100);
 	_graphics->loadFont("6x8.tff");
 	_graphics->drawText("This is a test", 200, 80);
-	_graphics->showCursor();
-	_graphics->setCursor(0);
+	_cursor->showCursor();
+	_cursor->setCursor(0);
 	//_sound->playSpeech(1);
 	//_sound->playSound(1);
 	//_sound->playMusic(2);
@@ -106,7 +109,7 @@ Common::Error ChewyEngine::run() {
 
 		// Cursor animation
 		if (_elapsedFrames % 30 == 0)
-			_graphics->animateCursor();
+			_cursor->animateCursor();
 
 		if (_videoNum >= 0) {
 			_graphics->playVideo(_videoNum);

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -35,6 +35,7 @@
 #include "chewy/events.h"
 #include "chewy/graphics.h"
 #include "chewy/resource.h"
+#include "chewy/scene.h"
 #include "chewy/sound.h"
 #include "chewy/text.h"
 
@@ -61,6 +62,7 @@ ChewyEngine::~ChewyEngine() {
 	delete _text;
 	delete _sound;
 	delete _cursor;
+	delete _scene;
 	delete _graphics;
 	delete _console;
 }
@@ -69,6 +71,7 @@ void ChewyEngine::initialize() {
 	_console = new Console(this);
 	_cursor = new Cursor(this);
 	_graphics = new Graphics(this);
+	_scene = new Scene(this);
 	_sound = new Sound(_mixer);
 	_text = new Text();
 	_events = new Events(this, _graphics, _console);
@@ -91,12 +94,8 @@ Common::Error ChewyEngine::run() {
 	}*/
 
 	//_graphics->playVideo(0);
-	_graphics->drawImage("episode1.tgp", 0);
-	_graphics->drawSprite("det1.taf", 0, 200, 100);
-	_graphics->loadFont("6x8.tff");
-	_graphics->drawText("This is a test", 200, 80);
-	_cursor->showCursor();
-	_cursor->setCursor(0);
+	
+	_scene->change(0);
 	//_sound->playSpeech(1);
 	//_sound->playSound(1);
 	//_sound->playMusic(2);
@@ -113,6 +112,7 @@ Common::Error ChewyEngine::run() {
 
 		if (_videoNum >= 0) {
 			_graphics->playVideo(_videoNum);
+			_scene->draw();
 			_videoNum = -1;
 		}
 

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -24,11 +24,13 @@
 #include "common/error.h"
 #include "common/events.h"
 #include "common/system.h"
+#include "graphics/palette.h"
 
 #include "engines/engine.h"
 #include "engines/util.h"
 
 #include "chewy/chewy.h"
+#include "chewy/graphics.h"
 #include "chewy/resource.h"
 
 namespace Chewy {
@@ -56,19 +58,13 @@ ChewyEngine::~ChewyEngine() {
 
 Common::Error ChewyEngine::run() {
 	// Initialize backend
-	initGraphics(320, 200, false);
+	initGraphics(640, 480, true);
 
 	initialize();
 
-	Resource *res = new Resource("comic.tgp");
-	TBFChunk *cur = res->getChunk(1);
-	
-	debug("Chunk 1: packed %d, type %d, pos %d, mode %d, comp %d, unpacked %d, width %d, height %d",
-		cur->packedSize, cur->type, cur->pos, cur->screenMode, cur->compressionFlag, cur->unpackedSize,
-		cur->width, cur->height
-	);
-
-	delete res;
+	Graphics *g = new Graphics();
+	g->drawImage("comic.tgp", 0);
+	delete g;
 
 	// Run a dummy loop
 	Common::Event event;

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -38,6 +38,8 @@ ChewyEngine::ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc)
 	_gameDescription(gameDesc),
 	_rnd("chewy") {
 
+	_console = new Console(this);
+
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 
 	SearchMan.addSubDirectoryMatching(gameDataDir, "back");
@@ -75,8 +77,11 @@ Common::Error ChewyEngine::run() {
 		while (g_system->getEventManager()->pollEvent(event)) {
 			if ((event.type == Common::EVENT_KEYDOWN && event.kbd.keycode == Common::KEYCODE_ESCAPE) || event.type == Common::EVENT_LBUTTONUP)
 				g_engine->quitGame();
+			if (event.type == Common::EVENT_KEYDOWN && event.kbd.flags & Common::KBD_CTRL && event.kbd.keycode == Common::KEYCODE_d)
+				_console->attach();
 		}
 
+		_console->onFrame();
 		g_system->delayMillis(10);
 	}
 

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -35,6 +35,7 @@
 #include "chewy/graphics.h"
 #include "chewy/resource.h"
 #include "chewy/sound.h"
+#include "chewy/text.h"
 
 namespace Chewy {
 
@@ -56,6 +57,7 @@ ChewyEngine::ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc)
 
 ChewyEngine::~ChewyEngine() {
 	delete _events;
+	delete _text;
 	delete _sound;
 	delete _graphics;
 	delete _console;
@@ -65,6 +67,7 @@ void ChewyEngine::initialize() {
 	_console = new Console(this);
 	_graphics = new Graphics(this);
 	_sound = new Sound(_mixer);
+	_text = new Text();
 	_events = new Events(this, _graphics, _console);
 
 	_curCursor = 0;

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -86,6 +86,9 @@ Common::Error ChewyEngine::run() {
 
 	//_graphics->playVideo(0);
 	_graphics->drawImage("episode1.tgp", 0);
+	_graphics->drawSprite("det1.taf", 0, 200, 100);
+	_graphics->loadFont("6x8.tff");
+	_graphics->drawText("This is a test", 200, 80);
 	_graphics->showCursor();
 	_graphics->setCursor(0);
 	//_sound->playSpeech(1);

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -1,0 +1,53 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/error.h"
+
+#include "engines/engine.h"
+#include "engines/util.h"
+
+#include "chewy/chewy.h"
+
+namespace Chewy {
+
+ChewyEngine::ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc)
+	: Engine(syst),
+	_gameDescription(gameDesc),
+	_rnd("chewy") {
+}
+
+ChewyEngine::~ChewyEngine() {
+}
+
+Common::Error ChewyEngine::run() {
+	// Initialize backend
+	initGraphics(320, 200, false);
+
+	initialize();
+
+	return Common::kNoError;
+}
+
+void ChewyEngine::initialize() {
+}
+
+} // End of namespace Chewy

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -79,22 +79,35 @@ Common::Error ChewyEngine::run() {
 
 	//_graphics->playVideo(0);
 	_graphics->drawImage("episode1.tgp", 0);
+	_graphics->showCursor();
+	_graphics->setCursor(0);
 	//_sound->playSpeech(1);
 	//_sound->playSound(1);
 	//_sound->playMusic(2);
 
 	// Run a dummy loop
 	Common::Event event;
+	uint curCursor = 0;
+	const uint maxCursors = 41;
 
 	while (!shouldQuit()) {
 		while (g_system->getEventManager()->pollEvent(event)) {
 			if ((event.type == Common::EVENT_KEYDOWN && event.kbd.keycode == Common::KEYCODE_ESCAPE) || event.type == Common::EVENT_LBUTTONUP)
 				g_engine->quitGame();
+			if ((event.type == Common::EVENT_KEYDOWN && event.kbd.keycode == Common::KEYCODE_SPACE) || event.type == Common::EVENT_RBUTTONUP) {
+				curCursor++;
+				if (curCursor == maxCursors)
+					curCursor = 0;
+				_graphics->setCursor(curCursor);
+			}
+
 			if (event.type == Common::EVENT_KEYDOWN && event.kbd.flags & Common::KBD_CTRL && event.kbd.keycode == Common::KEYCODE_d)
 				_console->attach();
 		}
 
 		_console->onFrame();
+
+		g_system->updateScreen();
 		g_system->delayMillis(10);
 	}
 

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -72,6 +72,11 @@ Common::Error ChewyEngine::run() {
 
 	initialize();
 
+	/*for (uint i = 0; i < 161; i++) {
+		debug("Video %d", i);
+		_graphics->playVideo(i);
+	}*/
+
 	//_graphics->playVideo(0);
 	_graphics->drawImage("episode1.tgp", 0);
 	//_sound->playSpeech(1);

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -30,8 +30,10 @@
 #include "engines/util.h"
 
 #include "chewy/chewy.h"
+#include "chewy/console.h"
 #include "chewy/graphics.h"
 #include "chewy/resource.h"
+#include "chewy/sound.h"
 
 namespace Chewy {
 
@@ -39,8 +41,6 @@ ChewyEngine::ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc)
 	: Engine(syst),
 	_gameDescription(gameDesc),
 	_rnd("chewy") {
-
-	_console = new Console(this);
 
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 
@@ -54,17 +54,28 @@ ChewyEngine::ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc)
 }
 
 ChewyEngine::~ChewyEngine() {
+	delete _console;
+	delete _sound;
+	delete _graphics;
+}
+
+void ChewyEngine::initialize() {
+	_console = new Console(this);
+	_graphics = new Graphics();
+	_sound = new Sound();
 }
 
 Common::Error ChewyEngine::run() {
 	// Initialize backend
-	initGraphics(640, 480, true);
+	//initGraphics(640, 480, true);
+	initGraphics(320, 200, false);
 
 	initialize();
 
-	Graphics *g = new Graphics();
-	g->drawImage("comic.tgp", 0);
-	delete g;
+	_graphics->drawImage("episode1.tgp", 0);
+	//_sound->playSpeech(1);
+	//_sound->playSound(1);
+	//_sound->playMusic(2);
 
 	// Run a dummy loop
 	Common::Event event;
@@ -82,9 +93,6 @@ Common::Error ChewyEngine::run() {
 	}
 
 	return Common::kNoError;
-}
-
-void ChewyEngine::initialize() {
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -63,6 +63,9 @@ void ChewyEngine::initialize() {
 	_console = new Console(this);
 	_graphics = new Graphics();
 	_sound = new Sound();
+
+	_curCursor = 0;
+	_elapsedFrames = 0;
 }
 
 Common::Error ChewyEngine::run() {
@@ -86,29 +89,26 @@ Common::Error ChewyEngine::run() {
 	//_sound->playMusic(2);
 
 	// Run a dummy loop
-	Common::Event event;
-	uint curCursor = 0;
-	const uint maxCursors = 41;
-
 	while (!shouldQuit()) {
-		while (g_system->getEventManager()->pollEvent(event)) {
-			if ((event.type == Common::EVENT_KEYDOWN && event.kbd.keycode == Common::KEYCODE_ESCAPE) || event.type == Common::EVENT_LBUTTONUP)
+		while (g_system->getEventManager()->pollEvent(_event)) {
+			if (_event.type == Common::EVENT_KEYDOWN && _event.kbd.keycode == Common::KEYCODE_ESCAPE)
 				g_engine->quitGame();
-			if ((event.type == Common::EVENT_KEYDOWN && event.kbd.keycode == Common::KEYCODE_SPACE) || event.type == Common::EVENT_RBUTTONUP) {
-				curCursor++;
-				if (curCursor == maxCursors)
-					curCursor = 0;
-				_graphics->setCursor(curCursor);
-			}
-
-			if (event.type == Common::EVENT_KEYDOWN && event.kbd.flags & Common::KBD_CTRL && event.kbd.keycode == Common::KEYCODE_d)
+			if ((_event.type == Common::EVENT_KEYDOWN && _event.kbd.keycode == Common::KEYCODE_SPACE) || _event.type == Common::EVENT_RBUTTONUP)
+				_graphics->nextCursor();
+			if (_event.type == Common::EVENT_KEYDOWN && _event.kbd.flags & Common::KBD_CTRL && _event.kbd.keycode == Common::KEYCODE_d)
 				_console->attach();
 		}
 
 		_console->onFrame();
 
+		// Cursor animation
+		if (_elapsedFrames % 30 == 0)
+			_graphics->animateCursor();
+
 		g_system->updateScreen();
 		g_system->delayMillis(10);
+
+		_elapsedFrames++;
 	}
 
 	return Common::kNoError;

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -41,6 +41,7 @@ class Console;
 class Events;
 class Graphics;
 class Sound;
+class Text;
 
 class ChewyEngine : public Engine {
 public:
@@ -59,6 +60,7 @@ public:
 
 	Graphics *_graphics;
 	Sound *_sound;
+	Text *_text;
 
 protected:
 	// Engine APIs

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef CHEWY_H
-#define CHEWY_H
+#ifndef CHEWY_CHEWY_H
+#define CHEWY_CHEWY_H
 
 
 #include "common/scummsys.h"

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -25,6 +25,7 @@
 
 
 #include "common/scummsys.h"
+#include "common/events.h"
 #include "common/file.h"
 #include "common/util.h"
 #include "common/str.h"
@@ -42,18 +43,6 @@ class Graphics;
 class Sound;
 
 class ChewyEngine : public Engine {
-
-protected:
-	// Engine APIs
-	virtual Common::Error run();
-	virtual bool hasFeature(EngineFeature f) const;
-
-	void shutdown();
-
-	void initialize();
-
-	Console *_console;
-
 public:
 	ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc);
 	virtual ~ChewyEngine();
@@ -68,6 +57,20 @@ public:
 
 	Graphics *_graphics;
 	Sound *_sound;
+
+protected:
+	// Engine APIs
+	virtual Common::Error run();
+	virtual bool hasFeature(EngineFeature f) const;
+
+	void initialize();
+	void shutdown();
+
+	Console *_console;
+
+	Common::Event _event;
+	uint _curCursor;
+	uint _elapsedFrames;
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -1,0 +1,67 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef CHEWY_H
+#define CHEWY_H
+
+
+#include "common/scummsys.h"
+#include "common/file.h"
+#include "common/util.h"
+#include "common/str.h"
+#include "common/hashmap.h"
+#include "common/hash-str.h"
+#include "common/random.h"
+
+#include "engines/engine.h"
+
+namespace Chewy {
+
+struct ChewyGameDescription;
+
+class ChewyEngine : public Engine {
+
+protected:
+	// Engine APIs
+	virtual Common::Error run();
+	virtual bool hasFeature(EngineFeature f) const;
+
+	void shutdown();
+
+	void initialize();
+
+public:
+	ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc);
+	virtual ~ChewyEngine();
+
+	int getGameType() const;
+	uint32 getFeatures() const;
+	Common::Language getLanguage() const;
+	Common::Platform getPlatform() const;
+
+	const ChewyGameDescription *_gameDescription;
+	Common::RandomSource _rnd;
+};
+
+} // End of namespace Chewy
+
+#endif

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -38,6 +38,7 @@ namespace Chewy {
 
 struct ChewyGameDescription;
 class Console;
+class Cursor;
 class Events;
 class Graphics;
 class Sound;
@@ -59,6 +60,7 @@ public:
 	void setPlayVideo(uint num) { _videoNum = num; }
 
 	Graphics *_graphics;
+	Cursor *_cursor;
 	Sound *_sound;
 	Text *_text;
 

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -41,6 +41,7 @@ class Console;
 class Cursor;
 class Events;
 class Graphics;
+class Scene;
 class Sound;
 class Text;
 
@@ -61,6 +62,7 @@ public:
 
 	Graphics *_graphics;
 	Cursor *_cursor;
+	Scene *_scene;
 	Sound *_sound;
 	Text *_text;
 

--- a/engines/chewy/configure.engine
+++ b/engines/chewy/configure.engine
@@ -1,0 +1,3 @@
+# This file is included from the main "configure" script
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+add_engine chewy "Chewy: Esc from F5" no

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -48,12 +48,17 @@ bool Console::Cmd_Dump(int argc, const char **argv) {
 	Common::String dumpFilename = argv[3];
 
 	Resource *res = new Resource(filename);
-	TBFChunk *chunk = res->getChunk(resNum);
+	Chunk *chunk = res->getChunk(resNum);
 	byte *data = res->getChunkData(resNum);
+	uint32 size = chunk->size;
+	if (chunk->type == kResourceTBF) {
+		TBFChunk *tbf = res->getTBFChunk(resNum);
+		size = tbf->unpackedSize;
+	}
 
 	Common::DumpFile outFile;
 	outFile.open(dumpFilename);
-	outFile.write(data, chunk->unpackedSize);
+	outFile.write(data, size);
 	outFile.flush();
 	outFile.close();
 

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -20,15 +20,18 @@
  *
  */
 
-#include "chewy/console.h"
 #include "gui/debugger.h"
+
 #include "chewy/chewy.h"
+#include "chewy/console.h"
+#include "chewy/graphics.h"
 #include "chewy/resource.h"
 
 namespace Chewy {
 
-	Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
+Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
 	registerCmd("dump",			WRAP_METHOD(Console, Cmd_Dump));
+	registerCmd("draw",			WRAP_METHOD(Console, Cmd_Draw));
 }
 
 Console::~Console() {
@@ -58,6 +61,22 @@ bool Console::Cmd_Dump(int argc, const char **argv) {
 	delete res;
 
 	return true;
+}
+
+bool Console::Cmd_Draw(int argc, const char **argv) {
+	if (argc < 3) {
+		debugPrintf("Usage: draw <file> <resource number>\n");
+		return true;
+	}
+
+	Common::String filename = argv[1];
+	int resNum = atoi(argv[2]);
+	
+	Graphics *g = new Graphics();
+	g->drawImage(filename, resNum);
+	delete g;
+
+	return false;
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -108,9 +108,7 @@ bool Console::Cmd_Draw(int argc, const char **argv) {
 	Common::String filename = argv[1];
 	int resNum = atoi(argv[2]);
 	
-	Graphics *g = new Graphics();
-	g->drawImage(filename, resNum);
-	delete g;
+	_vm->_graphics->drawImage(filename, resNum);
 
 	return false;
 }
@@ -157,12 +155,8 @@ bool Console::Cmd_PlayVideo(int argc, const char **argv) {
 		return true;
 	}
 
-	detach();	// close the console
-	
 	int resNum = atoi(argv[1]);
-	Graphics *g = new Graphics();
-	g->playVideo(resNum);
-	delete g;
+	_vm->setPlayVideo(resNum);
 
 	return false;
 }

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -37,6 +37,8 @@ Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
 	registerCmd("play_sound",	WRAP_METHOD(Console, Cmd_PlaySound));
 	registerCmd("play_speech",	WRAP_METHOD(Console, Cmd_PlaySpeech));
 	registerCmd("play_music",	WRAP_METHOD(Console, Cmd_PlayMusic));
+	registerCmd("play_video",	WRAP_METHOD(Console, Cmd_PlayVideo));
+	registerCmd("video_info",	WRAP_METHOD(Console, Cmd_VideoInfo));
 	registerCmd("text",			WRAP_METHOD(Console, Cmd_Text));
 }
 
@@ -145,6 +147,35 @@ bool Console::Cmd_PlayMusic(int argc, const char **argv) {
 
 	int resNum = atoi(argv[1]);
 	_vm->_sound->playMusic(resNum);
+
+	return true;
+}
+
+bool Console::Cmd_PlayVideo(int argc, const char **argv) {
+	if (argc < 2) {
+		debugPrintf("Usage: play_video <number>\n");
+		return true;
+	}
+
+	int resNum = atoi(argv[1]);
+	debugPrintf("TODO: Play video %d", resNum);
+	// TODO
+
+	return true;
+}
+
+bool Console::Cmd_VideoInfo(int argc, const char **argv) {
+	if (argc < 2) {
+		debugPrintf("Usage: video_info <number>\n");
+		return true;
+	}
+
+	int resNum = atoi(argv[1]);
+	VideoResource *res = new VideoResource("cut.tap");
+	VideoChunk *header = res->getVideoHeader(resNum);
+	debugPrintf("Size: %d, %d x %d, %d frames, %d ms frame delay, first frame at %d\n", header->size, header->width, header->height, header->frameCount, header->frameDelay, header->firstFrameOffset);
+	delete header;
+	delete res;
 
 	return true;
 }

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -27,19 +27,21 @@
 #include "chewy/graphics.h"
 #include "chewy/resource.h"
 #include "chewy/sound.h"
+#include "chewy/text.h"
 
 namespace Chewy {
 
 Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
-	registerCmd("dump",			 WRAP_METHOD(Console, Cmd_Dump));
-	registerCmd("dump_bg",		 WRAP_METHOD(Console, Cmd_DumpBg));
-	registerCmd("draw",			 WRAP_METHOD(Console, Cmd_Draw));
-	registerCmd("play_sound",	 WRAP_METHOD(Console, Cmd_PlaySound));
-	registerCmd("play_speech",	 WRAP_METHOD(Console, Cmd_PlaySpeech));
-	registerCmd("play_music",	 WRAP_METHOD(Console, Cmd_PlayMusic));
-	registerCmd("play_video",	 WRAP_METHOD(Console, Cmd_PlayVideo));
-	registerCmd("video_info",	 WRAP_METHOD(Console, Cmd_VideoInfo));
+	registerCmd("dump",          WRAP_METHOD(Console, Cmd_Dump));
+	registerCmd("dump_bg",       WRAP_METHOD(Console, Cmd_DumpBg));
+	registerCmd("draw",          WRAP_METHOD(Console, Cmd_Draw));
+	registerCmd("play_sound",    WRAP_METHOD(Console, Cmd_PlaySound));
+	registerCmd("play_speech",   WRAP_METHOD(Console, Cmd_PlaySpeech));
+	registerCmd("play_music",    WRAP_METHOD(Console, Cmd_PlayMusic));
+	registerCmd("play_video",    WRAP_METHOD(Console, Cmd_PlayVideo));
+	registerCmd("video_info",    WRAP_METHOD(Console, Cmd_VideoInfo));
 	registerCmd("error_message", WRAP_METHOD(Console, Cmd_ErrorMessage));
+	registerCmd("dialog",        WRAP_METHOD(Console, Cmd_Dialog));
 }
 
 Console::~Console() {
@@ -178,7 +180,7 @@ bool Console::Cmd_VideoInfo(int argc, const char **argv) {
 }
 
 bool Console::Cmd_ErrorMessage(int argc, const char **argv) {
-	if (argc < 2) {
+	if (argc < 3) {
 		debugPrintf("Usage: error_message <file> <message number>\n");
 		return true;
 	}
@@ -190,6 +192,27 @@ bool Console::Cmd_ErrorMessage(int argc, const char **argv) {
 	Common::String str = res->getErrorMessage(resNum);
 	this->debugPrintf("Error message: %s\n", str.c_str());
 	delete res;
+
+	return true;
+}
+
+bool Console::Cmd_Dialog(int argc, const char **argv) {
+	if (argc < 3) {
+		debugPrintf("Usage: dialog <dialog> <entry>\n");
+		return true;
+	}
+
+	int dialogNum = atoi(argv[1]);
+	int entryNum  = atoi(argv[2]);
+	uint cur = 0;
+	DialogList *d = _vm->_text->getDialog(dialogNum, entryNum);
+
+	for (DialogList::iterator it = d->begin(); it != d->end(); ++it) {
+		this->debugPrintf("Entry %d: speech %d, text '%s'\n", cur, (*it).speechId, (*it).text.c_str());
+	}
+
+	d->clear();
+	delete d;
 
 	return true;
 }

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -37,6 +37,7 @@ Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
 	registerCmd("play_sound",	WRAP_METHOD(Console, Cmd_PlaySound));
 	registerCmd("play_speech",	WRAP_METHOD(Console, Cmd_PlaySpeech));
 	registerCmd("play_music",	WRAP_METHOD(Console, Cmd_PlayMusic));
+	registerCmd("text",			WRAP_METHOD(Console, Cmd_Text));
 }
 
 Console::~Console() {
@@ -144,6 +145,23 @@ bool Console::Cmd_PlayMusic(int argc, const char **argv) {
 
 	int resNum = atoi(argv[1]);
 	_vm->_sound->playMusic(resNum);
+
+	return true;
+}
+
+bool Console::Cmd_Text(int argc, const char **argv) {
+	if (argc < 2) {
+		debugPrintf("Usage: <file> <text number>\n");
+		return true;
+	}
+
+	Common::String filename = argv[1];
+	int resNum = atoi(argv[2]);
+
+	TextResource *res = new TextResource(filename);
+	Common::String str = res->getText(resNum);
+	this->debugPrintf("Text: %s\n", str.c_str());
+	delete res;
 
 	return true;
 }

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -31,15 +31,15 @@
 namespace Chewy {
 
 Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
-	registerCmd("dump",			WRAP_METHOD(Console, Cmd_Dump));
-	registerCmd("dump_bg",		WRAP_METHOD(Console, Cmd_DumpBg));
-	registerCmd("draw",			WRAP_METHOD(Console, Cmd_Draw));
-	registerCmd("play_sound",	WRAP_METHOD(Console, Cmd_PlaySound));
-	registerCmd("play_speech",	WRAP_METHOD(Console, Cmd_PlaySpeech));
-	registerCmd("play_music",	WRAP_METHOD(Console, Cmd_PlayMusic));
-	registerCmd("play_video",	WRAP_METHOD(Console, Cmd_PlayVideo));
-	registerCmd("video_info",	WRAP_METHOD(Console, Cmd_VideoInfo));
-	registerCmd("text",			WRAP_METHOD(Console, Cmd_Text));
+	registerCmd("dump",			 WRAP_METHOD(Console, Cmd_Dump));
+	registerCmd("dump_bg",		 WRAP_METHOD(Console, Cmd_DumpBg));
+	registerCmd("draw",			 WRAP_METHOD(Console, Cmd_Draw));
+	registerCmd("play_sound",	 WRAP_METHOD(Console, Cmd_PlaySound));
+	registerCmd("play_speech",	 WRAP_METHOD(Console, Cmd_PlaySpeech));
+	registerCmd("play_music",	 WRAP_METHOD(Console, Cmd_PlayMusic));
+	registerCmd("play_video",	 WRAP_METHOD(Console, Cmd_PlayVideo));
+	registerCmd("video_info",	 WRAP_METHOD(Console, Cmd_VideoInfo));
+	registerCmd("error_message", WRAP_METHOD(Console, Cmd_ErrorMessage));
 }
 
 Console::~Console() {
@@ -177,18 +177,18 @@ bool Console::Cmd_VideoInfo(int argc, const char **argv) {
 	return true;
 }
 
-bool Console::Cmd_Text(int argc, const char **argv) {
+bool Console::Cmd_ErrorMessage(int argc, const char **argv) {
 	if (argc < 2) {
-		debugPrintf("Usage: <file> <text number>\n");
+		debugPrintf("Usage: error_message <file> <message number>\n");
 		return true;
 	}
 
 	Common::String filename = argv[1];
 	int resNum = atoi(argv[2]);
 
-	TextResource *res = new TextResource(filename);
-	Common::String str = res->getText(resNum);
-	this->debugPrintf("Text: %s\n", str.c_str());
+	ErrorMessage *res = new ErrorMessage(filename);
+	Common::String str = res->getErrorMessage(resNum);
+	this->debugPrintf("Error message: %s\n", str.c_str());
 	delete res;
 
 	return true;

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -157,11 +157,14 @@ bool Console::Cmd_PlayVideo(int argc, const char **argv) {
 		return true;
 	}
 
+	detach();	// close the console
+	
 	int resNum = atoi(argv[1]);
-	debugPrintf("TODO: Play video %d", resNum);
-	// TODO
+	Graphics *g = new Graphics();
+	g->playVideo(resNum);
+	delete g;
 
-	return true;
+	return false;
 }
 
 bool Console::Cmd_VideoInfo(int argc, const char **argv) {

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -32,6 +32,7 @@ namespace Chewy {
 
 Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
 	registerCmd("dump",			WRAP_METHOD(Console, Cmd_Dump));
+	registerCmd("dump_bg",		WRAP_METHOD(Console, Cmd_DumpBg));
 	registerCmd("draw",			WRAP_METHOD(Console, Cmd_Draw));
 	registerCmd("play_sound",	WRAP_METHOD(Console, Cmd_PlaySound));
 	registerCmd("play_speech",	WRAP_METHOD(Console, Cmd_PlaySpeech));
@@ -55,10 +56,6 @@ bool Console::Cmd_Dump(int argc, const char **argv) {
 	Chunk *chunk = res->getChunk(resNum);
 	byte *data = res->getChunkData(resNum);
 	uint32 size = chunk->size;
-	if (chunk->type == kResourceTBF) {
-		TBFChunk *tbf = res->getTBFChunk(resNum);
-		size = tbf->unpackedSize;
-	}
 
 	Common::DumpFile outFile;
 	outFile.open(dumpFilename);
@@ -71,6 +68,33 @@ bool Console::Cmd_Dump(int argc, const char **argv) {
 
 	return true;
 }
+
+bool Console::Cmd_DumpBg(int argc, const char **argv) {
+	if (argc < 4) {
+		debugPrintf("Usage: dump_bg <file> <resource number> <dump file name>\n");
+		return true;
+	}
+
+	Common::String filename = argv[1];
+	int resNum = atoi(argv[2]);
+	Common::String dumpFilename = argv[3];
+
+	BackgroundResource *res = new BackgroundResource(filename);
+	TBFChunk *image = res->getImage(resNum);
+
+	Common::DumpFile outFile;
+	outFile.open(dumpFilename);
+	outFile.write(image->data, image->size);
+	outFile.flush();
+	outFile.close();
+
+	delete[] image->data;
+	delete image;
+	delete res;
+
+	return true;
+}
+
 
 bool Console::Cmd_Draw(int argc, const char **argv) {
 	if (argc < 3) {

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -26,12 +26,16 @@
 #include "chewy/console.h"
 #include "chewy/graphics.h"
 #include "chewy/resource.h"
+#include "chewy/sound.h"
 
 namespace Chewy {
 
 Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
 	registerCmd("dump",			WRAP_METHOD(Console, Cmd_Dump));
 	registerCmd("draw",			WRAP_METHOD(Console, Cmd_Draw));
+	registerCmd("play_sound",	WRAP_METHOD(Console, Cmd_PlaySound));
+	registerCmd("play_speech",	WRAP_METHOD(Console, Cmd_PlaySpeech));
+	registerCmd("play_music",	WRAP_METHOD(Console, Cmd_PlayMusic));
 }
 
 Console::~Console() {
@@ -82,6 +86,42 @@ bool Console::Cmd_Draw(int argc, const char **argv) {
 	delete g;
 
 	return false;
+}
+
+bool Console::Cmd_PlaySound(int argc, const char **argv) {
+	if (argc < 2) {
+		debugPrintf("Usage: play_sound <number>\n");
+		return true;
+	}
+
+	int resNum = atoi(argv[1]);
+	_vm->_sound->playSound(resNum);
+
+	return true;
+}
+
+bool Console::Cmd_PlaySpeech(int argc, const char **argv) {
+	if (argc < 2) {
+		debugPrintf("Usage: play_speech <number>\n");
+		return true;
+	}
+
+	int resNum = atoi(argv[1]);
+	_vm->_sound->playSpeech(resNum);
+
+	return true;
+}
+
+bool Console::Cmd_PlayMusic(int argc, const char **argv) {
+	if (argc < 2) {
+		debugPrintf("Usage: play_music <number>\n");
+		return true;
+	}
+
+	int resNum = atoi(argv[1]);
+	_vm->_sound->playMusic(resNum);
+
+	return true;
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -42,6 +42,7 @@ Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
 	registerCmd("video_info",    WRAP_METHOD(Console, Cmd_VideoInfo));
 	registerCmd("error_message", WRAP_METHOD(Console, Cmd_ErrorMessage));
 	registerCmd("dialog",        WRAP_METHOD(Console, Cmd_Dialog));
+	registerCmd("text",          WRAP_METHOD(Console, Cmd_Text));
 }
 
 Console::~Console() {
@@ -205,13 +206,30 @@ bool Console::Cmd_Dialog(int argc, const char **argv) {
 	int dialogNum = atoi(argv[1]);
 	int entryNum  = atoi(argv[2]);
 	uint cur = 0;
-	DialogList *d = _vm->_text->getDialog(dialogNum, entryNum);
+	TextEntryList *d = _vm->_text->getDialog(dialogNum, entryNum);
 
-	for (DialogList::iterator it = d->begin(); it != d->end(); ++it) {
+	for (TextEntryList::iterator it = d->begin(); it != d->end(); ++it) {
 		this->debugPrintf("Entry %d: speech %d, text '%s'\n", cur, (*it).speechId, (*it).text.c_str());
 	}
 
 	d->clear();
+	delete d;
+
+	return true;
+}
+
+bool Console::Cmd_Text(int argc, const char **argv) {
+	if (argc < 3) {
+		debugPrintf("Usage: text <dialog> <entry>\n");
+		return true;
+	}
+
+	int dialogNum = atoi(argv[1]);
+	int entryNum = atoi(argv[2]);
+	TextEntry *d = _vm->_text->getText(dialogNum, entryNum);
+
+	debugPrintf("Speech %d, text '%s'\n", d->speechId, d->text.c_str());
+
 	delete d;
 
 	return true;

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -60,4 +60,4 @@ bool Console::Cmd_Dump(int argc, const char **argv) {
 	return true;
 }
 
-} // End of namespace Drascula
+} // End of namespace Chewy

--- a/engines/chewy/console.cpp
+++ b/engines/chewy/console.cpp
@@ -20,51 +20,44 @@
  *
  */
 
-#ifndef CHEWY_H
-#define CHEWY_H
-
-
-#include "common/scummsys.h"
-#include "common/file.h"
-#include "common/util.h"
-#include "common/str.h"
-#include "common/hashmap.h"
-#include "common/hash-str.h"
-#include "common/random.h"
-
-#include "engines/engine.h"
 #include "chewy/console.h"
+#include "gui/debugger.h"
+#include "chewy/chewy.h"
+#include "chewy/resource.h"
 
 namespace Chewy {
 
-struct ChewyGameDescription;
+	Console::Console(ChewyEngine *vm) : GUI::Debugger(), _vm(vm) {
+	registerCmd("dump",			WRAP_METHOD(Console, Cmd_Dump));
+}
 
-class ChewyEngine : public Engine {
+Console::~Console() {
+}
 
-protected:
-	// Engine APIs
-	virtual Common::Error run();
-	virtual bool hasFeature(EngineFeature f) const;
+bool Console::Cmd_Dump(int argc, const char **argv) {
+	if (argc < 4) {
+		debugPrintf("Usage: dump <file> <resource number> <dump file name>\n");
+		return true;
+	}
 
-	void shutdown();
+	Common::String filename = argv[1];
+	int resNum = atoi(argv[2]);
+	Common::String dumpFilename = argv[3];
 
-	void initialize();
+	Resource *res = new Resource(filename);
+	TBFChunk *chunk = res->getChunk(resNum);
+	byte *data = res->getChunkData(resNum);
 
-	Console *_console;
+	Common::DumpFile outFile;
+	outFile.open(dumpFilename);
+	outFile.write(data, chunk->unpackedSize);
+	outFile.flush();
+	outFile.close();
 
-public:
-	ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc);
-	virtual ~ChewyEngine();
+	delete[] data;
+	delete res;
 
-	int getGameType() const;
-	uint32 getFeatures() const;
-	Common::Language getLanguage() const;
-	Common::Platform getPlatform() const;
+	return true;
+}
 
-	const ChewyGameDescription *_gameDescription;
-	Common::RandomSource _rnd;
-};
-
-} // End of namespace Chewy
-
-#endif
+} // End of namespace Drascula

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -43,6 +43,8 @@ private:
 	bool Cmd_PlaySound(int argc, const char **argv);
 	bool Cmd_PlaySpeech(int argc, const char **argv);
 	bool Cmd_PlayMusic(int argc, const char **argv);
+	bool Cmd_PlayVideo(int argc, const char **argv);
+	bool Cmd_VideoInfo(int argc, const char **argv);
 	bool Cmd_Text(int argc, const char **argv);
 };
 

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -47,6 +47,7 @@ private:
 	bool Cmd_VideoInfo(int argc, const char **argv);
 	bool Cmd_ErrorMessage(int argc, const char **argv);
 	bool Cmd_Dialog(int argc, const char **argv);
+	bool Cmd_Text(int argc, const char **argv);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -38,6 +38,7 @@ private:
 	ChewyEngine *_vm;
 
 	bool Cmd_Dump(int argc, const char **argv);
+	bool Cmd_Draw(int argc, const char **argv);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -39,6 +39,9 @@ private:
 
 	bool Cmd_Dump(int argc, const char **argv);
 	bool Cmd_Draw(int argc, const char **argv);
+	bool Cmd_PlaySound(int argc, const char **argv);
+	bool Cmd_PlaySpeech(int argc, const char **argv);
+	bool Cmd_PlayMusic(int argc, const char **argv);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -40,5 +40,5 @@ private:
 	bool Cmd_Dump(int argc, const char **argv);
 };
 
-} // End of namespace Drascula
+} // End of namespace Chewy
 #endif

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -46,6 +46,7 @@ private:
 	bool Cmd_PlayVideo(int argc, const char **argv);
 	bool Cmd_VideoInfo(int argc, const char **argv);
 	bool Cmd_ErrorMessage(int argc, const char **argv);
+	bool Cmd_Dialog(int argc, const char **argv);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -38,6 +38,7 @@ private:
 	ChewyEngine *_vm;
 
 	bool Cmd_Dump(int argc, const char **argv);
+	bool Cmd_DumpBg(int argc, const char **argv);
 	bool Cmd_Draw(int argc, const char **argv);
 	bool Cmd_PlaySound(int argc, const char **argv);
 	bool Cmd_PlaySpeech(int argc, const char **argv);

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -43,6 +43,7 @@ private:
 	bool Cmd_PlaySound(int argc, const char **argv);
 	bool Cmd_PlaySpeech(int argc, const char **argv);
 	bool Cmd_PlayMusic(int argc, const char **argv);
+	bool Cmd_Text(int argc, const char **argv);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -45,7 +45,7 @@ private:
 	bool Cmd_PlayMusic(int argc, const char **argv);
 	bool Cmd_PlayVideo(int argc, const char **argv);
 	bool Cmd_VideoInfo(int argc, const char **argv);
-	bool Cmd_Text(int argc, const char **argv);
+	bool Cmd_ErrorMessage(int argc, const char **argv);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/console.h
+++ b/engines/chewy/console.h
@@ -20,51 +20,25 @@
  *
  */
 
-#ifndef CHEWY_H
-#define CHEWY_H
+#ifndef CHEWY_CONSOLE_H
+#define CHEWY_CONSOLE_H
 
-
-#include "common/scummsys.h"
-#include "common/file.h"
-#include "common/util.h"
-#include "common/str.h"
-#include "common/hashmap.h"
-#include "common/hash-str.h"
-#include "common/random.h"
-
-#include "engines/engine.h"
-#include "chewy/console.h"
+#include "gui/debugger.h"
 
 namespace Chewy {
 
-struct ChewyGameDescription;
+class ChewyEngine;
 
-class ChewyEngine : public Engine {
-
-protected:
-	// Engine APIs
-	virtual Common::Error run();
-	virtual bool hasFeature(EngineFeature f) const;
-
-	void shutdown();
-
-	void initialize();
-
-	Console *_console;
-
+class Console : public GUI::Debugger {
 public:
-	ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc);
-	virtual ~ChewyEngine();
+	Console(ChewyEngine *vm);
+	virtual ~Console(void);
 
-	int getGameType() const;
-	uint32 getFeatures() const;
-	Common::Language getLanguage() const;
-	Common::Platform getPlatform() const;
+private:
+	ChewyEngine *_vm;
 
-	const ChewyGameDescription *_gameDescription;
-	Common::RandomSource _rnd;
+	bool Cmd_Dump(int argc, const char **argv);
 };
 
-} // End of namespace Chewy
-
+} // End of namespace Drascula
 #endif

--- a/engines/chewy/cursor.cpp
+++ b/engines/chewy/cursor.cpp
@@ -1,0 +1,107 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/system.h"
+#include "common/events.h"
+#include "graphics/cursorman.h"
+#include "graphics/palette.h"
+#include "graphics/surface.h"
+
+#include "chewy/cursor.h"
+#include "chewy/resource.h"
+
+namespace Chewy {
+
+const byte _cursorFrames[] = {
+	4, 1, 1, 1,		// walk
+	4, 1, 1, 1,		// pick up / use
+	1, 1, 1, 1, 1,
+	4, 1, 1, 1,		// look
+	4, 1, 1, 1,		// talk
+	4, 1, 1, 1,		// open
+	1,
+	1, 1, 1, 1,		// left, right, up, down
+	1,				// save
+	1,
+	5, 1, 1, 1, 1,
+	1,
+	1,				// use (inventory)
+	1,				// look (inventory)
+	1				// gun
+};
+
+Cursor::Cursor(ChewyEngine *vm) : _vm(vm) {
+	_curCursor = 0;
+	_curCursorFrame = 0;
+	_cursorSprites = new SpriteResource("cursor.taf");
+}
+
+Cursor::~Cursor() {
+	delete _cursorSprites;
+}
+
+void Cursor::setCursor(uint num, bool newCursor) {
+	TAFChunk *cursor = _cursorSprites->getSprite(num);
+	if (newCursor)
+		_curCursor = num;
+
+	CursorMan.replaceCursor(cursor->data, cursor->width, cursor->height, 0, 0, 0);
+
+	delete[] cursor->data;
+	delete cursor;
+}
+
+void Cursor::showCursor() {
+	CursorMan.showMouse(true);
+}
+
+void Cursor::hideCursor() {
+	CursorMan.showMouse(false);
+}
+
+void Cursor::animateCursor() {
+	if (_cursorFrames[_curCursor] > 1) {
+		_curCursorFrame++;
+
+		if (_curCursorFrame >= _cursorFrames[_curCursor])
+			_curCursorFrame = 0;
+
+		setCursor(_curCursor + _curCursorFrame, false);
+	}
+}
+
+void Cursor::nextCursor() {
+	uint maxCursors = ARRAYSIZE(_cursorFrames);
+
+	if (_cursorFrames[_curCursor] > 0)
+		_curCursor += _cursorFrames[_curCursor];
+	else
+		_curCursor++;
+
+	if (_curCursor >= maxCursors)
+		_curCursor = 0;
+
+	_curCursorFrame = 0;
+	setCursor(_curCursor);
+}
+
+} // End of namespace Chewy

--- a/engines/chewy/cursor.h
+++ b/engines/chewy/cursor.h
@@ -20,44 +20,35 @@
  *
  */
 
-#include "common/system.h"
-#include "common/events.h"
+#ifndef CHEWY_CURSOR_H
+#define CHEWY_CURSOR_H
 
 #include "chewy/chewy.h"
-#include "chewy/console.h"
-#include "chewy/cursor.h"
-#include "chewy/events.h"
-#include "chewy/graphics.h"
 
 namespace Chewy {
 
-Events::Events(ChewyEngine *vm, Graphics *graphics, Console *console) :
-	_vm(vm), _graphics(graphics), _console(console) {
+class SpriteResource;
+class Font;
 
-	_eventManager = g_system->getEventManager();
-}
+class Cursor {
+public:
+	Cursor(ChewyEngine *vm);
+	virtual ~Cursor();
 
-void Events::processEvents() {
-	while (_eventManager->pollEvent(_event)) {
-		if (_event.type == Common::EVENT_KEYDOWN) {
-			switch (_event.kbd.keycode) {
-			case Common::KEYCODE_ESCAPE:
-				_vm->quitGame();
-				break;
-			case Common::KEYCODE_SPACE:
-				_vm->_cursor->nextCursor();
-				break;
-			case Common::KEYCODE_d:
-				if (_event.kbd.flags & Common::KBD_CTRL)
-					_console->attach();
-				break;
-			default:
-				break;
-			}
-		} else if (_event.type == Common::EVENT_RBUTTONUP) {
-			_vm->_cursor->nextCursor();
-		}
-	}
-}
+	void setCursor(uint num, bool newCursor = true);
+	void showCursor();
+	void hideCursor();
+	void animateCursor();
+	void nextCursor();
+
+private:
+	ChewyEngine *_vm;
+
+	uint _curCursor;
+	uint _curCursorFrame;
+	SpriteResource *_cursorSprites;
+};
 
 } // End of namespace Chewy
+
+#endif

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -50,6 +50,10 @@ static const PlainGameDescriptor chewyGames[] = {
 	{0, 0}
 };
 
+static const char *directoryGlobs[] = {
+	"back",
+	0
+};
 
 namespace Chewy {
 
@@ -59,7 +63,7 @@ static const ChewyGameDescription gameDescriptions[] = {
 		{
 			"chewy",
 			0,
-			AD_ENTRY1s("XXX", "00000000000000000", 1),
+			AD_ENTRY1s("comic.tgp", "4f03228838663ddecebd750c04687a08", 6529814),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -75,6 +79,8 @@ static const ChewyGameDescription gameDescriptions[] = {
 class ChewyMetaEngine : public AdvancedMetaEngine {
 public:
 	ChewyMetaEngine() : AdvancedMetaEngine(Chewy::gameDescriptions, sizeof(Chewy::ChewyGameDescription), chewyGames) {
+		_maxScanDepth = 2;
+		_directoryGlobs = directoryGlobs;
 		_singleId = "chewy";
 	}
 

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -51,7 +51,7 @@ static const PlainGameDescriptor chewyGames[] = {
 };
 
 static const char *directoryGlobs[] = {
-	"back",
+	"txt",
 	0
 };
 
@@ -63,7 +63,7 @@ static const ChewyGameDescription gameDescriptions[] = {
 		{
 			"chewy",
 			0,
-			AD_ENTRY1s("comic.tgp", "4f03228838663ddecebd750c04687a08", 6529814),
+			AD_ENTRY1s("atds.tap", "e6050c144dd4f23d79ea4f89a8ef306e", 218857),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -138,7 +138,7 @@ SaveStateDescriptor ChewyMetaEngine::querySaveMetaInfos(const char *target, int 
 	return SaveStateDescriptor();
 } // End of namespace Chewy
 
-#if PLUGIN_ENABLED_DYNAMIC(Chewy)
+#if PLUGIN_ENABLED_DYNAMIC(CHEWY)
 	REGISTER_PLUGIN_DYNAMIC(CHEWY, PLUGIN_TYPE_ENGINE, ChewyMetaEngine);
 #else
 	REGISTER_PLUGIN_STATIC(CHEWY, PLUGIN_TYPE_ENGINE, ChewyMetaEngine);

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -1,0 +1,145 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/savefile.h"
+#include "common/system.h"
+#include "base/plugins.h"
+
+#include "engines/advancedDetector.h"
+
+#include "chewy/chewy.h"
+
+
+namespace Chewy {
+
+struct ChewyGameDescription {
+	ADGameDescription desc;
+};
+
+uint32 ChewyEngine::getFeatures() const {
+	return _gameDescription->desc.flags;
+}
+
+Common::Language ChewyEngine::getLanguage() const {
+	return _gameDescription->desc.language;
+}
+
+}
+
+static const PlainGameDescriptor chewyGames[] = {
+	{"chewy", "Chewy: Esc from F5"},
+	{0, 0}
+};
+
+
+namespace Chewy {
+
+static const ChewyGameDescription gameDescriptions[] = {
+
+	{
+		{
+			"chewy",
+			0,
+			AD_ENTRY1s("XXX", "00000000000000000", 1),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_NO_FLAGS,
+			GUIO1(GUIO_NONE)
+		},
+	},
+
+	{ AD_TABLE_END_MARKER }
+};
+
+} // End of namespace Chewy
+
+class ChewyMetaEngine : public AdvancedMetaEngine {
+public:
+	ChewyMetaEngine() : AdvancedMetaEngine(Chewy::gameDescriptions, sizeof(Chewy::ChewyGameDescription), chewyGames) {
+		_singleId = "chewy";
+	}
+
+	virtual const char *getName() const {
+		return "Chewy Engine";
+	}
+
+	virtual const char *getOriginalCopyright() const {
+		return "Chewy Engine New Generation Software (C) 1995";
+	}
+
+	virtual bool hasFeature(MetaEngineFeature f) const;
+	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const;
+	SaveStateList listSaves(const char *target) const;
+	virtual int getMaximumSaveSlot() const;
+	void removeSaveState(const char *target, int slot) const;
+	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const;
+};
+
+bool ChewyMetaEngine::hasFeature(MetaEngineFeature f) const {
+	return
+		(f == kSupportsListSaves) ||
+		(f == kSupportsLoadingDuringStartup) ||
+		(f == kSupportsDeleteSave) ||
+		(f == kSavesSupportMetaInfo) ||
+		(f == kSavesSupportThumbnail) ||
+		(f == kSavesSupportCreationDate) ||
+		(f == kSavesSupportPlayTime);
+}
+
+bool Chewy::ChewyEngine::hasFeature(EngineFeature f) const {
+	return
+		(f == kSupportsRTL) ||
+		(f == kSupportsLoadingDuringRuntime) ||
+		(f == kSupportsSavingDuringRuntime);
+}
+
+bool ChewyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	const Chewy::ChewyGameDescription *gd = (const Chewy::ChewyGameDescription *)desc;
+	if (gd) {
+		*engine = new Chewy::ChewyEngine(syst, gd);
+	}
+	return gd != 0;
+}
+
+SaveStateList ChewyMetaEngine::listSaves(const char *target) const {
+	SaveStateList saveList;
+
+	return saveList;
+}
+
+int ChewyMetaEngine::getMaximumSaveSlot() const {
+	return 999;
+}
+
+void ChewyMetaEngine::removeSaveState(const char *target, int slot) const {
+}
+
+SaveStateDescriptor ChewyMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
+
+	return SaveStateDescriptor();
+} // End of namespace Chewy
+
+#if PLUGIN_ENABLED_DYNAMIC(Chewy)
+	REGISTER_PLUGIN_DYNAMIC(CHEWY, PLUGIN_TYPE_ENGINE, ChewyMetaEngine);
+#else
+	REGISTER_PLUGIN_STATIC(CHEWY, PLUGIN_TYPE_ENGINE, ChewyMetaEngine);
+#endif

--- a/engines/chewy/events.cpp
+++ b/engines/chewy/events.cpp
@@ -20,36 +20,43 @@
  *
  */
 
-#ifndef CHEWY_GRAPHICS_H
-#define CHEWY_GRAPHICS_H
+#include "common/system.h"
+#include "common/events.h"
 
 #include "chewy/chewy.h"
+#include "chewy/console.h"
+#include "chewy/events.h"
+#include "chewy/graphics.h"
 
 namespace Chewy {
 
-class SpriteResource;
+Events::Events(ChewyEngine *vm, Graphics *graphics, Console *console) :
+	_vm(vm), _graphics(graphics), _console(console) {
 
-class Graphics {
-public:
-	Graphics(ChewyEngine *vm);
-	~Graphics();
+	_eventManager = g_system->getEventManager();
+}
 
-	void drawImage(Common::String filename, int imageNum);
-	void playVideo(uint num);
-	void setCursor(uint num, bool newCursor = true);
-	void showCursor();
-	void hideCursor();
-	void animateCursor();
-	void nextCursor();
-
-private:
-	ChewyEngine *_vm;
-
-	uint _curCursor;
-	uint _curCursorFrame;
-	SpriteResource *_cursorSprites;
-};
+void Events::processEvents() {
+	while (_eventManager->pollEvent(_event)) {
+		if (_event.type == Common::EVENT_KEYDOWN) {
+			switch (_event.kbd.keycode) {
+			case Common::KEYCODE_ESCAPE:
+				_vm->quitGame();
+				break;
+			case Common::KEYCODE_SPACE:
+				_graphics->nextCursor();
+				break;
+			case Common::KEYCODE_d:
+				if (_event.kbd.flags & Common::KBD_CTRL)
+					_console->attach();
+				break;
+			default:
+				break;
+			}
+		} else if (_event.type == Common::EVENT_RBUTTONUP) {
+			_graphics->nextCursor();
+		}
+	}
+}
 
 } // End of namespace Chewy
-
-#endif

--- a/engines/chewy/events.h
+++ b/engines/chewy/events.h
@@ -34,7 +34,7 @@ class Console;
 class Events {
 public:
 	Events(ChewyEngine *vm, Graphics *graphics, Console *console);
-	~Events() {}
+	virtual ~Events() {}
 
 	void processEvents();
 

--- a/engines/chewy/events.h
+++ b/engines/chewy/events.h
@@ -20,60 +20,30 @@
  *
  */
 
-#ifndef CHEWY_H
-#define CHEWY_H
+#ifndef CHEWY_EVENTS_H
+#define CHEWY_EVENTS_H
 
-
-#include "common/scummsys.h"
-#include "common/file.h"
-#include "common/util.h"
-#include "common/str.h"
-#include "common/hashmap.h"
-#include "common/hash-str.h"
-#include "common/random.h"
-
-#include "engines/engine.h"
+#include "common/events.h"
 
 namespace Chewy {
 
-struct ChewyGameDescription;
-class Console;
-class Events;
+class ChewyEngine;
 class Graphics;
-class Sound;
+class Console;
 
-class ChewyEngine : public Engine {
+class Events {
 public:
-	ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc);
-	virtual ~ChewyEngine();
+	Events(ChewyEngine *vm, Graphics *graphics, Console *console);
+	~Events() {}
 
-	int getGameType() const;
-	uint32 getFeatures() const;
-	Common::Language getLanguage() const;
-	Common::Platform getPlatform() const;
+	void processEvents();
 
-	const ChewyGameDescription *_gameDescription;
-	Common::RandomSource _rnd;
-
-	void setPlayVideo(uint num) { _videoNum = num; }
-
+private:
+	Common::Event _event;
+	Common::EventManager *_eventManager;
+	ChewyEngine *_vm;
 	Graphics *_graphics;
-	Sound *_sound;
-
-protected:
-	// Engine APIs
-	virtual Common::Error run();
-	virtual bool hasFeature(EngineFeature f) const;
-
-	void initialize();
-	void shutdown();
-
 	Console *_console;
-	Events *_events;
-
-	uint _curCursor;
-	uint _elapsedFrames;
-	int _videoNum;
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -81,5 +81,8 @@ void Graphics::playVideo(uint num) {
 
 		g_system->delayMillis(10);
 	}
+
+	cfoDecoder->close();
 }
+
 } // End of namespace Chewy

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -115,7 +115,7 @@ void Graphics::drawText(Common::String text, uint x, uint y) {
 }
 
 void Graphics::playVideo(uint num) {
-	CfoDecoder *cfoDecoder = new CfoDecoder(_vm->_mixer);
+	CfoDecoder *cfoDecoder = new CfoDecoder(_vm->_sound);
 	VideoResource *videoResource = new VideoResource("cut.tap");
 	Common::SeekableReadStream *videoStream = videoResource->getVideoStream(num);
 

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -1,0 +1,42 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/system.h"
+#include "graphics/palette.h"
+
+#include "chewy/graphics.h"
+#include "chewy/resource.h"
+
+namespace Chewy {
+
+void Graphics::drawImage(Common::String filename, int imageNum) {
+	Resource *res = new Resource("comic.tgp");
+	TBFChunk *cur = res->getChunk(0);
+	byte *buf = res->getChunkData(0);
+
+	g_system->getPaletteManager()->setPalette(cur->palette, 0, 256);
+	g_system->copyRectToScreen(buf, cur->width, 0, 0, cur->width, cur->height);
+	g_system->updateScreen();
+	delete res;
+}
+
+} // End of namespace Chewy

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -29,7 +29,7 @@
 namespace Chewy {
 
 void Graphics::drawImage(Common::String filename, int imageNum) {
-	Resource *res = new Resource("comic.tgp");
+	Resource *res = new Resource(filename);
 	TBFChunk *cur = res->getChunk(imageNum);
 	byte *buf = res->getChunkData(imageNum);
 

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -29,13 +29,15 @@
 namespace Chewy {
 
 void Graphics::drawImage(Common::String filename, int imageNum) {
-	Resource *res = new Resource(filename);
-	TBFChunk *cur = res->getTBFChunk(imageNum);
-	byte *buf = res->getChunkData(imageNum);
+	BackgroundResource *res = new BackgroundResource(filename);
+	TBFChunk *image = res->getImage(imageNum);
 
-	g_system->getPaletteManager()->setPalette(cur->palette, 0, 256);
-	g_system->copyRectToScreen(buf, cur->width, 0, 0, cur->width, cur->height);
+	g_system->getPaletteManager()->setPalette(image->palette, 0, 256);
+	g_system->copyRectToScreen(image->data, image->width, 0, 0, image->width, image->height);
 	g_system->updateScreen();
+
+	delete[] image->data;
+	delete image;
 	delete res;
 }
 

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -93,10 +93,10 @@ void Graphics::loadFont(Common::String filename) {
 
 void Graphics::drawTransparent(uint16 x, uint16 y, byte *data, uint16 width, uint16 height, byte transparentColor) {
 	::Graphics::Surface *screen = g_system->lockScreen();
-	for (uint textX = 0; textX < width; textX++) {
-		for (uint textY = 0; textY < height; textY++) {
-			byte *src = data + (textY * width) + textX;
-			byte *dst = (byte *)screen->getBasePtr(textX + x, textY + y);
+	for (uint curX = 0; curX < width; curX++) {
+		for (uint curY = 0; curY < height; curY++) {
+			byte *src = data + (curY * width) + curX;
+			byte *dst = (byte *)screen->getBasePtr(curX + x, curY + y);
 			if (*src != transparentColor)
 				*dst = *src;
 		}

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -30,8 +30,8 @@ namespace Chewy {
 
 void Graphics::drawImage(Common::String filename, int imageNum) {
 	Resource *res = new Resource("comic.tgp");
-	TBFChunk *cur = res->getChunk(0);
-	byte *buf = res->getChunkData(0);
+	TBFChunk *cur = res->getChunk(imageNum);
+	byte *buf = res->getChunkData(imageNum);
 
 	g_system->getPaletteManager()->setPalette(cur->palette, 0, 256);
 	g_system->copyRectToScreen(buf, cur->width, 0, 0, cur->width, cur->height);

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -34,24 +34,6 @@
 
 namespace Chewy {
 
-const byte _cursorFrames[] = {
-	4, 1, 1, 1,		// walk
-	4, 1, 1, 1,		// pick up / use
-	1, 1, 1, 1, 1,
-	4, 1, 1, 1,		// look
-	4, 1, 1, 1,		// talk
-	4, 1, 1, 1,		// open
-	1,
-	1, 1, 1, 1,		// left, right, up, down
-	1,				// save
-	1,
-	5, 1, 1, 1, 1,
-	1,
-	1,				// use (inventory)
-	1,				// look (inventory)
-	1				// gun
-};
-
 Graphics::Graphics(ChewyEngine *vm) : _vm(vm) {
 	_font = nullptr;
 }

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -30,7 +30,7 @@ namespace Chewy {
 
 void Graphics::drawImage(Common::String filename, int imageNum) {
 	Resource *res = new Resource(filename);
-	TBFChunk *cur = res->getChunk(imageNum);
+	TBFChunk *cur = res->getTBFChunk(imageNum);
 	byte *buf = res->getChunkData(imageNum);
 
 	g_system->getPaletteManager()->setPalette(cur->palette, 0, 256);

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -26,6 +26,7 @@
 #include "graphics/palette.h"
 #include "graphics/surface.h"
 
+#include "chewy/cursor.h"
 #include "chewy/graphics.h"
 #include "chewy/resource.h"
 #include "chewy/text.h"
@@ -52,15 +53,11 @@ const byte _cursorFrames[] = {
 };
 
 Graphics::Graphics(ChewyEngine *vm) : _vm(vm) {
-	_curCursor = 0;
-	_curCursorFrame = 0;
-	_cursorSprites = new SpriteResource("cursor.taf");
 	_font = nullptr;
 }
 
 Graphics::~Graphics() {
 	delete _font;
-	delete _cursorSprites;
 }
 
 void Graphics::drawSprite(Common::String filename, int spriteNum, uint x, uint y) {
@@ -131,7 +128,7 @@ void Graphics::playVideo(uint num) {
 	byte curPalette[256 * 3];
 
 	g_system->getPaletteManager()->grabPalette(curPalette, 0, 256);
-	hideCursor();
+	_vm->_cursor->hideCursor();
 
 	cfoDecoder->start();
 
@@ -160,52 +157,7 @@ void Graphics::playVideo(uint num) {
 	cfoDecoder->close();
 
 	g_system->getPaletteManager()->setPalette(curPalette, 0, 256);
-	showCursor();
-}
-
-void Graphics::setCursor(uint num, bool newCursor) {
-	TAFChunk *cursor = _cursorSprites->getSprite(num);
-	if (newCursor)
-		_curCursor = num;
-
-	CursorMan.replaceCursor(cursor->data, cursor->width, cursor->height, 0, 0, 0);
-
-	delete[] cursor->data;
-	delete cursor;
-}
-
-void Graphics::showCursor() {
-	CursorMan.showMouse(true);
-}
-
-void Graphics::hideCursor() {
-	CursorMan.showMouse(false);
-}
-
-void Graphics::animateCursor() {
-	if (_cursorFrames[_curCursor] > 1) {
-		_curCursorFrame++;
-
-		if (_curCursorFrame >= _cursorFrames[_curCursor])
-			_curCursorFrame = 0;
-
-		setCursor(_curCursor + _curCursorFrame, false);
-	}
-}
-
-void Graphics::nextCursor() {
-	uint maxCursors = ARRAYSIZE(_cursorFrames);
-
-	if (_cursorFrames[_curCursor] > 0)
-		_curCursor += _cursorFrames[_curCursor];
-	else
-		_curCursor++;
-
-	if (_curCursor >= maxCursors)
-		_curCursor = 0;
-
-	_curCursorFrame = 0;
-	setCursor(_curCursor);
+	_vm->_cursor->showCursor();
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -31,6 +31,34 @@
 
 namespace Chewy {
 
+const byte _cursorFrames[] = {
+	4, 1, 1, 1,		// walk
+	4, 1, 1, 1,		// pick up / use
+	1, 1, 1, 1, 1,
+	4, 1, 1, 1,		// look
+	4, 1, 1, 1,		// talk
+	4, 1, 1, 1,		// open
+	1,
+	1, 1, 1, 1,		// left, right, up, down
+	1,				// save
+	1,
+	5, 1, 1, 1, 1,
+	1,
+	1,				// use (inventory)
+	1,				// look (inventory)
+	1				// gun
+};
+
+Graphics::Graphics() {
+	_curCursor = 0;
+	_curCursorFrame = 0;
+	_cursorSprites = new SpriteResource("cursor.taf");
+}
+
+Graphics::~Graphics() {
+	delete _cursorSprites;
+}
+
 void Graphics::drawImage(Common::String filename, int imageNum) {
 	BackgroundResource *res = new BackgroundResource(filename);
 	TBFChunk *image = res->getImage(imageNum);
@@ -86,15 +114,15 @@ void Graphics::playVideo(uint num) {
 	cfoDecoder->close();
 }
 
-void Graphics::setCursor(uint num) {
-	SpriteResource *res = new SpriteResource("cursor.taf");
-	TAFChunk *cursor = res->getSprite(num);
+void Graphics::setCursor(uint num, bool newCursor) {
+	TAFChunk *cursor = _cursorSprites->getSprite(num);
+	if (newCursor)
+		_curCursor = num;
 
 	CursorMan.replaceCursor(cursor->data, cursor->width, cursor->height, 0, 0, 0);
 
 	delete[] cursor->data;
 	delete cursor;
-	delete res;
 }
 
 void Graphics::showCursor() {
@@ -103,6 +131,32 @@ void Graphics::showCursor() {
 
 void Graphics::hideCursor() {
 	CursorMan.showMouse(false);
+}
+
+void Graphics::animateCursor() {
+	if (_cursorFrames[_curCursor] > 1) {
+		_curCursorFrame++;
+
+		if (_curCursorFrame >= _cursorFrames[_curCursor])
+			_curCursorFrame = 0;
+
+		setCursor(_curCursor + _curCursorFrame, false);
+	}
+}
+
+void Graphics::nextCursor() {
+	uint maxCursors = ARRAYSIZE(_cursorFrames);
+
+	if (_cursorFrames[_curCursor] > 0)
+		_curCursor += _cursorFrames[_curCursor];
+	else
+		_curCursor++;
+
+	if (_curCursor >= maxCursors)
+		_curCursor = 0;
+
+	_curCursorFrame = 0;
+	setCursor(_curCursor);
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -128,7 +128,9 @@ void Graphics::playVideo(uint num) {
 	uint16 x = (g_system->getWidth() - cfoDecoder->getWidth()) / 2;
 	uint16 y = (g_system->getHeight() - cfoDecoder->getHeight()) / 2;
 	bool skipVideo = false;
+	byte curPalette[256 * 3];
 
+	g_system->getPaletteManager()->grabPalette(curPalette, 0, 256);
 	hideCursor();
 
 	cfoDecoder->start();
@@ -157,6 +159,7 @@ void Graphics::playVideo(uint num) {
 
 	cfoDecoder->close();
 
+	g_system->getPaletteManager()->setPalette(curPalette, 0, 256);
 	showCursor();
 }
 

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -22,6 +22,7 @@
 
 #include "common/system.h"
 #include "common/events.h"
+#include "graphics/cursorman.h"
 #include "graphics/palette.h"
 
 #include "chewy/graphics.h"
@@ -83,6 +84,25 @@ void Graphics::playVideo(uint num) {
 	}
 
 	cfoDecoder->close();
+}
+
+void Graphics::setCursor(uint num) {
+	SpriteResource *res = new SpriteResource("cursor.taf");
+	TAFChunk *cursor = res->getSprite(num);
+
+	CursorMan.replaceCursor(cursor->data, cursor->width, cursor->height, 0, 0, 0);
+
+	delete[] cursor->data;
+	delete cursor;
+	delete res;
+}
+
+void Graphics::showCursor() {
+	CursorMan.showMouse(true);
+}
+
+void Graphics::hideCursor() {
+	CursorMan.showMouse(false);
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -28,6 +28,7 @@
 
 #include "chewy/graphics.h"
 #include "chewy/resource.h"
+#include "chewy/text.h"
 #include "chewy/video/cfo_decoder.h"
 
 namespace Chewy {

--- a/engines/chewy/graphics.cpp
+++ b/engines/chewy/graphics.cpp
@@ -49,7 +49,7 @@ const byte _cursorFrames[] = {
 	1				// gun
 };
 
-Graphics::Graphics() {
+Graphics::Graphics(ChewyEngine *vm) : _vm(vm) {
 	_curCursor = 0;
 	_curCursorFrame = 0;
 	_cursorSprites = new SpriteResource("cursor.taf");
@@ -73,7 +73,7 @@ void Graphics::drawImage(Common::String filename, int imageNum) {
 }
 
 void Graphics::playVideo(uint num) {
-	CfoDecoder *cfoDecoder = new CfoDecoder();
+	CfoDecoder *cfoDecoder = new CfoDecoder(_vm->_mixer);
 	VideoResource *videoResource = new VideoResource("cut.tap");
 	Common::SeekableReadStream *videoStream = videoResource->getVideoStream(num);
 
@@ -87,9 +87,11 @@ void Graphics::playVideo(uint num) {
 	uint16 y = (g_system->getHeight() - cfoDecoder->getHeight()) / 2;
 	bool skipVideo = false;
 
+	hideCursor();
+
 	cfoDecoder->start();
 
-	while (!g_engine->shouldQuit() && !cfoDecoder->endOfVideo() && !skipVideo) {
+	while (!_vm->shouldQuit() && !cfoDecoder->endOfVideo() && !skipVideo) {
 		if (cfoDecoder->needsUpdate()) {
 			const ::Graphics::Surface *frame = cfoDecoder->decodeNextFrame();
 			if (frame) {
@@ -112,6 +114,8 @@ void Graphics::playVideo(uint num) {
 	}
 
 	cfoDecoder->close();
+
+	showCursor();
 }
 
 void Graphics::setCursor(uint num, bool newCursor) {

--- a/engines/chewy/graphics.h
+++ b/engines/chewy/graphics.h
@@ -41,20 +41,10 @@ public:
 	void loadFont(Common::String filename);
 	void drawText(Common::String text, uint x, uint y);
 
-	void setCursor(uint num, bool newCursor = true);
-	void showCursor();
-	void hideCursor();
-	void animateCursor();
-	void nextCursor();
-
 private:
 	void drawTransparent(uint16 x, uint16 y, byte *data, uint16 width, uint16 height, byte transparentColor);
 
 	ChewyEngine *_vm;
-
-	uint _curCursor;
-	uint _curCursorFrame;
-	SpriteResource *_cursorSprites;
 	Font *_font;
 };
 

--- a/engines/chewy/graphics.h
+++ b/engines/chewy/graphics.h
@@ -32,7 +32,7 @@ class SpriteResource;
 class Graphics {
 public:
 	Graphics(ChewyEngine *vm);
-	~Graphics();
+	virtual ~Graphics();
 
 	void drawImage(Common::String filename, int imageNum);
 	void playVideo(uint num);

--- a/engines/chewy/graphics.h
+++ b/engines/chewy/graphics.h
@@ -27,18 +27,24 @@
 
 namespace Chewy {
 
+class SpriteResource;
+
 class Graphics {
 public:
-	Graphics() {}
-	~Graphics() {}
+	Graphics();
+	~Graphics();
 
 	void drawImage(Common::String filename, int imageNum);
 	void playVideo(uint num);
-	void setCursor(uint num);
+	void setCursor(uint num, bool newCursor = true);
 	void showCursor();
 	void hideCursor();
+	void animateCursor();
+	void nextCursor();
 private:
-
+	uint _curCursor;
+	uint _curCursorFrame;
+	SpriteResource *_cursorSprites;
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/graphics.h
+++ b/engines/chewy/graphics.h
@@ -28,6 +28,7 @@
 namespace Chewy {
 
 class SpriteResource;
+class Font;
 
 class Graphics {
 public:
@@ -35,7 +36,11 @@ public:
 	virtual ~Graphics();
 
 	void drawImage(Common::String filename, int imageNum);
+	void drawSprite(Common::String filename, int spriteNum, uint x, uint y);
 	void playVideo(uint num);
+	void loadFont(Common::String filename);
+	void drawText(Common::String text, uint x, uint y);
+
 	void setCursor(uint num, bool newCursor = true);
 	void showCursor();
 	void hideCursor();
@@ -43,11 +48,14 @@ public:
 	void nextCursor();
 
 private:
+	void drawTransparent(uint16 x, uint16 y, byte *data, uint16 width, uint16 height, byte transparentColor);
+
 	ChewyEngine *_vm;
 
 	uint _curCursor;
 	uint _curCursorFrame;
 	SpriteResource *_cursorSprites;
+	Font *_font;
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/graphics.h
+++ b/engines/chewy/graphics.h
@@ -34,6 +34,9 @@ public:
 
 	void drawImage(Common::String filename, int imageNum);
 	void playVideo(uint num);
+	void setCursor(uint num);
+	void showCursor();
+	void hideCursor();
 private:
 
 };

--- a/engines/chewy/graphics.h
+++ b/engines/chewy/graphics.h
@@ -1,0 +1,42 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef CHEWY_GRAPHICS_H
+#define CHEWY_GRAPHICS_H
+
+#include "chewy/chewy.h"
+
+namespace Chewy {
+
+class Graphics {
+public:
+	Graphics() {}
+	~Graphics() {}
+
+	void drawImage(Common::String filename, int imageNum);
+private:
+
+};
+
+} // End of namespace Chewy
+
+#endif

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -8,6 +8,7 @@ MODULE_OBJS = \
 	events.o \
 	graphics.o \
 	resource.o \
+	scene.o \
 	sound.o \
 	text.o \
 	video/cfo_decoder.o

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -4,6 +4,7 @@ MODULE_OBJS = \
 	chewy.o \
 	console.o \
 	detection.o \
+	graphics.o \
 	resource.o
 
 

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -1,0 +1,14 @@
+MODULE := engines/chewy
+
+MODULE_OBJS = \
+	chewy.o \
+	detection.o
+
+
+# This module can be built as a plugin
+ifeq ($(ENABLE_CHEWY), DYNAMIC_PLUGIN)
+PLUGIN := 1
+endif
+
+# Include common rules
+include $(srcdir)/rules.mk

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -2,7 +2,8 @@ MODULE := engines/chewy
 
 MODULE_OBJS = \
 	chewy.o \
-	detection.o
+	detection.o \
+	resource.o
 
 
 # This module can be built as a plugin

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -4,6 +4,7 @@ MODULE_OBJS = \
 	chewy.o \
 	console.o \
 	detection.o \
+	events.o \
 	graphics.o \
 	resource.o \
 	sound.o \

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -2,6 +2,7 @@ MODULE := engines/chewy
 
 MODULE_OBJS = \
 	chewy.o \
+	console.o \
 	detection.o \
 	resource.o
 

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -6,7 +6,8 @@ MODULE_OBJS = \
 	detection.o \
 	graphics.o \
 	resource.o \
-	sound.o
+	sound.o \
+	video/cfo_decoder.o
 
 # This module can be built as a plugin
 ifeq ($(ENABLE_CHEWY), DYNAMIC_PLUGIN)

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -8,6 +8,7 @@ MODULE_OBJS = \
 	graphics.o \
 	resource.o \
 	sound.o \
+	text.o \
 	video/cfo_decoder.o
 
 # This module can be built as a plugin

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -2,6 +2,7 @@ MODULE := engines/chewy
 
 MODULE_OBJS = \
 	chewy.o \
+	cursor.o \
 	console.o \
 	detection.o \
 	events.o \

--- a/engines/chewy/module.mk
+++ b/engines/chewy/module.mk
@@ -5,8 +5,8 @@ MODULE_OBJS = \
 	console.o \
 	detection.o \
 	graphics.o \
-	resource.o
-
+	resource.o \
+	sound.o
 
 # This module can be built as a plugin
 ifeq ($(ENABLE_CHEWY), DYNAMIC_PLUGIN)

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -22,6 +22,7 @@
 
 #include "common/debug.h"
 #include "common/stream.h"
+#include "common/substream.h"
 #include "common/textconsole.h"
 
 #include "chewy/chewy.h"
@@ -245,6 +246,13 @@ VideoChunk *VideoResource::getVideoHeader(uint num) {
 	vid->firstFrameOffset = _stream.readUint32LE();	// always 22
 
 	return vid;
+}
+
+Common::SeekableReadStream *VideoResource::getVideoStream(uint num) {
+	assert(num < _chunkList.size());
+
+	Chunk *chunk = &_chunkList[num];
+	return new Common::SeekableSubReadStream(&_stream, chunk->pos, chunk->pos + chunk->size);
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -29,6 +29,23 @@
 
 namespace Chewy {
 
+// Resource files - TODO:
+// ======================
+// back/episode1.gep
+// cut/blende.rnd
+// cut/cut.tap
+// misc/*.taf, room/*.taf
+// misc/exit.eib
+// misc/inventar.iib
+// misc/inventar.sib
+// room/csp.int
+// room/test.rdi
+// txt/*.tff
+// txt/*.tap
+// txt/diah.adh
+// txt/inv_st.s and txt/room_st.s
+// txt/inv_use.idx
+
 Resource::Resource(Common::String filename) {
 	const uint32 headerGeneric = MKTAG('N', 'G', 'S', '\0');
 	const uint32 headerTxtDec  = MKTAG('T', 'C', 'F', '\0');

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -1,0 +1,82 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/stream.h"
+#include "common/debug.h"
+#include "common/textconsole.h"
+
+#include "chewy/chewy.h"
+#include "chewy/resource.h"
+
+namespace Chewy {
+
+Resource::Resource(Common::String filename) {
+	_stream.open(filename);
+	uint32 magicBytes = MKTAG('N', 'G', 'S', '\0');
+	if (_stream.readUint32BE() != magicBytes)
+		error("Invalid resource - %s", filename.c_str());
+	_stream.skip(2);	// type
+	_chunkCount = _stream.readUint16LE();
+
+	uint32 tbfID = MKTAG('T', 'B', 'F', '\0');
+
+	for (uint i = 0; i < _chunkCount; i++) {
+		TBFChunk cur;
+		cur.packedSize = _stream.readUint32LE();
+		cur.type = _stream.readUint16LE();
+		cur.pos = _stream.pos();
+		if (_stream.readUint32BE() != tbfID)
+			error("Corrupt resource %s", filename.c_str());
+
+		cur.screenMode = _stream.readUint16LE();
+		cur.compressionFlag = _stream.readUint16LE();
+		cur.unpackedSize = _stream.readUint32LE();
+		cur.width = _stream.readUint16LE();
+		cur.height = _stream.readUint16LE();
+		_stream.read(cur.palette, 3 * 256);
+		_stream.skip(cur.packedSize - TBF_CHUNK_HEADER_SIZE);
+
+		_tbfChunkList.push_back(cur);
+
+		/*debug("Chunk %d: packed %d, type %d, pos %d, mode %d, comp %d, unpacked %d, width %d, height %d",
+			i, cur.packedSize, cur.type, cur.pos, cur.screenMode, cur.compressionFlag, cur.unpackedSize,
+			cur.width, cur.height
+		);*/
+	}
+
+}
+
+Resource::~Resource() {
+	_tbfChunkList.clear();
+	_stream.close();
+}
+
+TBFChunk *Resource::getChunk(int num) {
+	return &_tbfChunkList[num];
+}
+
+Common::SeekableReadStream *Resource::getChunkData(int num) {
+	// TODO
+	return nullptr;
+}
+
+} // End of namespace Chewy

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -268,7 +268,7 @@ SoundChunk *SoundResource::getSound(uint num) {
 	return sound;
 }
 
-Common::String TextResource::getText(uint num) {
+Common::String ErrorMessage::getErrorMessage(uint num) {
 	assert(num < _chunkList.size());
 
 	Chunk *chunk = &_chunkList[num];

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -40,7 +40,6 @@ namespace Chewy {
 // misc/inventar.iib
 // misc/inventar.sib
 // room/test.rdi
-// txt/atds.tap (game texts)
 // txt/diah.adh
 // txt/inv_st.s and txt/room_st.s (inventory/room control bytes)
 // txt/inv_use.idx

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -210,7 +210,7 @@ TBFChunk *BackgroundResource::getImage(uint num) {
 	tbf->width = _stream.readUint16LE();
 	tbf->height = _stream.readUint16LE();
 	for (int j = 0; j < 3 * 256; j++)
-		tbf->palette[j] = _stream.readByte() << 2;
+		tbf->palette[j] = (_stream.readByte() << 2) & 0xff;
 
 	tbf->data = new byte[tbf->size];
 

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -34,64 +34,124 @@ Resource::Resource(Common::String filename) {
 	uint32 magicBytes = MKTAG('N', 'G', 'S', '\0');
 	if (_stream.readUint32BE() != magicBytes)
 		error("Invalid resource - %s", filename.c_str());
-	_stream.skip(2);	// type
+	_resType = (ResourceType)_stream.readUint16LE();
 	_chunkCount = _stream.readUint16LE();
 
-	uint32 tbfID = MKTAG('T', 'B', 'F', '\0');
-
 	for (uint i = 0; i < _chunkCount; i++) {
-		TBFChunk cur;
-		cur.packedSize = _stream.readUint32LE() - TBF_CHUNK_HEADER_SIZE;
-		cur.type = _stream.readUint16LE();
-		if (_stream.readUint32BE() != tbfID)
-			error("Corrupt resource %s", filename.c_str());
-
-		cur.screenMode = _stream.readUint16LE();
-		cur.compressionFlag = _stream.readUint16LE();
-		cur.unpackedSize = _stream.readUint32LE();
-		cur.width = _stream.readUint16LE();
-		cur.height = _stream.readUint16LE();
-		for (int j = 0; j < 3 * 256; j++)
-			cur.palette[j] = _stream.readByte() << 2;
+		Chunk cur;
+		cur.size = _stream.readUint32LE();
+		cur.type = (ResourceType)_stream.readUint16LE();
 		cur.pos = _stream.pos();
 
-		_stream.skip(cur.packedSize);
+		if (cur.type == kResourceTBF) {
+			cur.pos += TBF_CHUNK_HEADER_SIZE;
+			cur.size -= TBF_CHUNK_HEADER_SIZE;
+			readTBFChunk();
+		}
 
-		_tbfChunkList.push_back(cur);
+		_stream.skip(cur.size);
+		_chunkList.push_back(cur);
 	}
-
 }
 
 Resource::~Resource() {
+	_chunkList.clear();
 	_tbfChunkList.clear();
 	_stream.close();
 }
 
-TBFChunk *Resource::getChunk(int num) {
+void Resource::readTBFChunk() {
+	TBFChunk cur;
+	if (_stream.readUint32BE() != MKTAG('T', 'B', 'F', '\0'))
+		error("Corrupt TBF resource");
+
+	cur.screenMode = _stream.readUint16LE();
+	cur.compressionFlag = _stream.readUint16LE();
+	cur.unpackedSize = _stream.readUint32LE();
+	cur.width = _stream.readUint16LE();
+	cur.height = _stream.readUint16LE();
+	for (int j = 0; j < 3 * 256; j++)
+		cur.palette[j] = _stream.readByte() << 2;
+
+	_tbfChunkList.push_back(cur);
+}
+
+uint32 Resource::getChunkCount() const {
+	return _chunkList.size();
+}
+
+Chunk *Resource::getChunk(int num) {
+	return &_chunkList[num];
+}
+
+TBFChunk *Resource::getTBFChunk(int num) {
+	assert(_resType == kResourceTGP);
 	return &_tbfChunkList[num];
 }
 
 byte *Resource::getChunkData(int num) {
-	TBFChunk *chunk = &_tbfChunkList[num];
-	byte *data = new byte[chunk->unpackedSize];
+	Chunk *chunk = &_chunkList[num];
+	byte *data;
 
 	_stream.seek(chunk->pos, SEEK_SET);
 
-	if (!chunk->compressionFlag) {
-		_stream.read(data, chunk->packedSize);
-	} else {
-		// Compressed resources are packed using a very simple RLE compression
-		byte count;
-		byte value;
-		uint32 outPos = 0;
+	if (chunk->type == kResourceTBF) {
+		TBFChunk *tbfChunk = &_tbfChunkList[num];
+		data = new byte[tbfChunk->unpackedSize];
 
-		for (uint i = 0; i < (chunk->packedSize) / 2 && outPos < chunk->unpackedSize; i++) {
-			count = _stream.readByte();
-			value = _stream.readByte();
-			for (byte j = 0; j < count; j++) {
-				data[outPos++] = value;
+		if (!tbfChunk->compressionFlag) {
+			_stream.read(data, chunk->size);
+		} else {
+			// Compressed images are packed using a very simple RLE compression
+			byte count;
+			byte value;
+			uint32 outPos = 0;
+
+			for (uint i = 0; i < (chunk->size) / 2 && outPos < tbfChunk->unpackedSize; i++) {
+				count = _stream.readByte();
+				value = _stream.readByte();
+				for (byte j = 0; j < count; j++) {
+					data[outPos++] = value;
+				}
 			}
 		}
+	} else if (chunk->type == kResourceVOC) {
+		// Voice files are split in blocks, so reassemble them here
+		byte blocksRemaining;
+		uint32 totalLength = 0;
+		uint32 blockSize;
+		
+		// Find the total length of the voice file
+		do {
+			blocksRemaining = _stream.readByte();
+			blockSize =
+				_stream.readByte() +
+				(_stream.readByte() << 8) +
+				(_stream.readByte() << 16);
+
+			totalLength += blockSize;
+			_stream.skip(blockSize);
+		} while (blocksRemaining > 1);
+
+		// Read the voice data
+		data = new byte[totalLength];
+		byte *ptr = data;
+
+		_stream.seek(chunk->pos, SEEK_SET);
+
+		do {
+			blocksRemaining = _stream.readByte();
+			blockSize =
+				 _stream.readByte() +
+				(_stream.readByte() << 8) +
+				(_stream.readByte() << 16);
+			
+			_stream.read(ptr, blockSize);
+			ptr += blockSize;
+		} while (blocksRemaining > 1);
+	} else {
+		data = new byte[chunk->size];
+		_stream.read(data, chunk->size);
 	}
 
 	return data;

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -251,10 +251,11 @@ SoundChunk *SoundResource::getSound(uint num) {
 	// Find the total length of the voice file
 	do {
 		blocksRemaining = _stream.readByte();
-		blockSize =
-			_stream.readByte() +
-			(_stream.readByte() << 8) +
-			(_stream.readByte() << 16);
+
+		byte b1 = _stream.readByte();
+		byte b2 = _stream.readByte();
+		byte b3 = _stream.readByte();
+		blockSize = b1 + (b2 << 8) + (b3 << 16);
 
 		totalLength += blockSize;
 		_stream.skip(blockSize);
@@ -269,10 +270,11 @@ SoundChunk *SoundResource::getSound(uint num) {
 
 	do {
 		blocksRemaining = _stream.readByte();
-		blockSize =
-			_stream.readByte() +
-			(_stream.readByte() << 8) +
-			(_stream.readByte() << 16);
+
+		byte b1 = _stream.readByte();
+		byte b2 = _stream.readByte();
+		byte b3 = _stream.readByte();
+		blockSize = b1 + (b2 << 8) + (b3 << 16);
 
 		_stream.read(ptr, blockSize);
 		ptr += blockSize;

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -40,7 +40,6 @@ namespace Chewy {
 // misc/exit.eib
 // misc/inventar.iib
 // misc/inventar.sib
-// room/csp.int
 // room/test.rdi
 // txt/*.tap
 // txt/diah.adh
@@ -375,8 +374,8 @@ Font::~Font() {
 	line->create(text.size() * _width, _height, ::Graphics::PixelFormat::createFormatCLUT8());
 
 	for (uint i = 0; i < text.size(); i++) {
-		int c = text[i];
-		line->copyRectToSurface(_fontSurface, i * _width, 0, Common::Rect((c - _first) * _width, 0, (c - _first) * _width + _width, _height));
+		uint x = (text[i] - _first) * _width;
+		line->copyRectToSurface(_fontSurface, i * _width, 0, Common::Rect(x, 0, x + _width, _height));
 	}
 
 	return line;

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -34,7 +34,6 @@ namespace Chewy {
 // ======================
 // back/episode1.gep
 // cut/blende.rnd
-// cut/cut.tap
 // misc/*.taf, room/*.taf
 // misc/exit.eib
 // misc/inventar.iib

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -226,4 +226,25 @@ Common::String TextResource::getText(uint num) {
 	return str;
 }
 
+VideoChunk *VideoResource::getVideoHeader(uint num) {
+	assert(num < _chunkList.size());
+
+	Chunk *chunk = &_chunkList[num];
+	VideoChunk *vid = new VideoChunk();
+
+	_stream.seek(chunk->pos, SEEK_SET);
+
+	if (_stream.readUint32BE() != MKTAG('C', 'F', 'O', '\0'))
+		error("Corrupt video resource");
+
+	vid->size = _stream.readUint32LE();	// always 0
+	vid->frameCount = _stream.readUint16LE();
+	vid->width = _stream.readUint16LE();
+	vid->height = _stream.readUint16LE();
+	vid->frameDelay = _stream.readUint32LE();
+	vid->firstFrameOffset = _stream.readUint32LE();	// always 22
+
+	return vid;
+}
+
 } // End of namespace Chewy

--- a/engines/chewy/resource.cpp
+++ b/engines/chewy/resource.cpp
@@ -118,7 +118,6 @@ byte *Resource::getChunkData(uint num) {
 }
 
 void Resource::initSprite(Common::String filename) {
-	uint16 screenMode;;
 	uint32 nextSpriteOffset;
 
 	// TAF (sprite) resources are much different than the rest, so we have a
@@ -126,7 +125,7 @@ void Resource::initSprite(Common::String filename) {
 
 	_resType = kResourceTAF;
 	_encrypted = false;
-	screenMode = _stream.readUint16LE();
+	/*screenMode = */_stream.readUint16LE();
 	_chunkCount = _stream.readUint16LE();
 	_stream.skip(4);		// total size of all sprites
 	_stream.skip(3 * 256);	// palette
@@ -142,7 +141,7 @@ void Resource::initSprite(Common::String filename) {
 		cur.type = kResourceTAF;
 
 		_stream.skip(2 + 2 + 2);	// compression flag, width, height
-		uint32 nextSpriteOffset = _stream.readUint32LE();
+		nextSpriteOffset = _stream.readUint32LE();
 		uint32 spriteImageOffset = _stream.readUint32LE();
 		_stream.skip(1);	// padding
 

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -170,14 +170,6 @@ public:
 	SoundChunk *getSound(uint num);
 };
 
-class ErrorMessage : public Resource {
-public:
-	ErrorMessage(Common::String filename) : Resource(filename) {}
-	virtual ~ErrorMessage() {}
-
-	Common::String getErrorMessage(uint num);
-};
-
 class VideoResource : public Resource {
 public:
 	VideoResource(Common::String filename) : Resource(filename) {}
@@ -185,19 +177,6 @@ public:
 
 	VideoChunk *getVideoHeader(uint num);
 	Common::SeekableReadStream *getVideoStream(uint num);
-};
-
-class Font {
-public:
-	Font(Common::String filename);
-	virtual ~Font();
-
-	::Graphics::Surface *getLine(Common::String text);
-
-private:
-	uint16 _count, _first, _last, _width, _height;
-
-	::Graphics::Surface _fontSurface;
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -1,0 +1,73 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef CHEWY_RESOURCE_H
+#define CHEWY_RESOURCE_H
+
+
+#include "common/scummsys.h"
+#include "common/file.h"
+#include "common/util.h"
+#include "common/str.h"
+#include "common/hashmap.h"
+#include "common/hash-str.h"
+#include "common/random.h"
+
+namespace Chewy {
+
+// 4 + 2 + 2 + 4 + 2 + 2 + 768 = 784 bytes
+#define TBF_CHUNK_HEADER_SIZE 784
+
+struct TBFChunk {
+	uint32 packedSize;	// includes header
+	uint16 type;
+	uint32 pos;	// extra field
+
+	// TBF chunk header
+	// ID (TBF, followed by a zero)
+	uint16 screenMode;
+	uint16 compressionFlag;
+	uint32 unpackedSize;
+	uint16 width;
+	uint16 height;
+	char palette[3 * 256];
+};
+
+typedef Common::Array<TBFChunk> TBFChunkList;
+
+class Resource {
+public:
+	Resource(Common::String filename);
+	~Resource();
+
+	TBFChunk *getChunk(int num);
+	Common::SeekableReadStream *getChunkData(int num);
+
+private:
+	Common::File _stream;
+	uint16 _chunkCount;
+	TBFChunkList _tbfChunkList;
+};
+
+} // End of namespace Chewy
+
+#endif

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -136,6 +136,7 @@ public:
 protected:
 	void initSprite(Common::String filename);
 	void unpackRLE(byte *buffer, uint32 compressedSize, uint32 uncompressedSize);
+	void decrypt(byte *data, uint32 size);
 
 	Common::File _stream;
 	uint16 _chunkCount;

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -86,19 +86,6 @@ struct TBFChunk {
 	byte *data;
 };
 
-// TAF (sprite) chunk header
-/*struct TAFHeader {
-	// TAF chunk header
-	// ID (TAF, followed by a zero)
-	uint16 screenMode;
-	uint16 spriteCount;
-	uint32 size;	// total size (width * height) of all sprites
-	byte palette[3 * 256];
-	uint32 nextSpriteOffset;
-	uint16 correctionTable;
-	// 1 byte padding
-};*/
-
 // TAF (sprite) image data chunk header - 15 bytes
 struct TAFChunk {
 	uint16 compressionFlag;
@@ -160,7 +147,7 @@ protected:
 class SpriteResource : public Resource {
 public:
 	SpriteResource(Common::String filename) : Resource(filename) {}
-	~SpriteResource() {}
+	virtual ~SpriteResource() {}
 
 	TAFChunk *getSprite(uint num);
 };
@@ -168,7 +155,7 @@ public:
 class BackgroundResource : public Resource {
 public:
 	BackgroundResource(Common::String filename) : Resource(filename) {}
-	~BackgroundResource() {}
+	virtual ~BackgroundResource() {}
 
 	TBFChunk *getImage(uint num);
 };
@@ -176,7 +163,7 @@ public:
 class SoundResource : public Resource {
 public:
 	SoundResource(Common::String filename) : Resource(filename) {}
-	~SoundResource() {}
+	virtual ~SoundResource() {}
 
 	SoundChunk *getSound(uint num);
 };
@@ -184,7 +171,7 @@ public:
 class TextResource : public Resource {
 public:
 	TextResource(Common::String filename) : Resource(filename) {}
-	~TextResource() {}
+	virtual ~TextResource() {}
 
 	Common::String getText(uint num);
 };
@@ -192,7 +179,7 @@ public:
 class VideoResource : public Resource {
 public:
 	VideoResource(Common::String filename) : Resource(filename) {}
-	~VideoResource() {}
+	virtual ~VideoResource() {}
 
 	VideoChunk *getVideoHeader(uint num);
 	Common::SeekableReadStream *getVideoStream(uint num);

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -94,6 +94,17 @@ struct SoundChunk {
 	byte *data;
 };
 
+// Video chunk header
+struct VideoChunk {
+	// ID (CFA, followed by a zero)
+	uint32 size;
+	uint16 frameCount;
+	uint16 width;
+	uint16 height;
+	uint32 frameDelay;	// in ms
+	uint32 firstFrameOffset;
+};
+
 typedef Common::Array<Chunk> ChunkList;
 typedef Common::Array<TBFChunk> TBFChunkList;
 
@@ -111,7 +122,7 @@ protected:
 	Common::File _stream;
 	uint16 _chunkCount;
 	ResourceType _resType;
-	byte _encrypted;
+	bool _encrypted;
 
 	ChunkList _chunkList;
 };
@@ -138,6 +149,14 @@ public:
 	~TextResource() {}
 
 	Common::String getText(uint num);
+};
+
+class VideoResource : public Resource {
+public:
+	VideoResource(Common::String filename) : Resource(filename) {}
+	~VideoResource() {}
+
+	VideoChunk *getVideoHeader(uint num);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -70,6 +70,7 @@ enum ResourceType {
 // Generic chunk header
 struct Chunk {
 	uint32 size;
+	uint16 num;	// same as the type below, used in chunks where the type is substituted with count
 	ResourceType type;
 	uint32 pos;	// position of the actual data
 };
@@ -103,13 +104,14 @@ public:
 
 	ResourceType getType() const { return _resType; }
 	uint32 getChunkCount() const;
-	Chunk *getChunk(int num);
-	virtual byte *getChunkData(int num);
+	Chunk *getChunk(uint num);
+	virtual byte *getChunkData(uint num);
 
 protected:
 	Common::File _stream;
 	uint16 _chunkCount;
 	ResourceType _resType;
+	byte _encrypted;
 
 	ChunkList _chunkList;
 };
@@ -119,7 +121,7 @@ public:
 	BackgroundResource(Common::String filename) : Resource(filename) {}
 	~BackgroundResource() {}
 
-	TBFChunk *getImage(int num);
+	TBFChunk *getImage(uint num);
 };
 
 class SoundResource : public Resource {
@@ -127,7 +129,15 @@ public:
 	SoundResource(Common::String filename) : Resource(filename) {}
 	~SoundResource() {}
 
-	SoundChunk *getSound(int num);
+	SoundChunk *getSound(uint num);
+};
+
+class TextResource : public Resource {
+public:
+	TextResource(Common::String filename) : Resource(filename) {}
+	~TextResource() {}
+
+	Common::String getText(uint num);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -34,13 +34,46 @@
 
 namespace Chewy {
 
+enum ResourceType {
+	kResourcePCX = 0,		// unused
+	kResourceTBF = 1,		// contained in TGPs
+	kResourceTAF = 2,
+	kResourceTFF = 3,
+	kResourceVOC = 4,		// contained in TVPs
+	kResourceTPF = 5,		// unused
+	kResourceTMF = 6,		// unused
+	kResourceMOD = 7,		// unused
+	kResourceRAW = 8,		// unused
+	kResourceLBM = 9,		// unused
+	kResourceRDI = 10,
+	kResourceTXT = 11,
+	kResourceIIB = 12,
+	kResourceSIB = 13,
+	kResourceEIB = 14,
+	kResourceATS = 15,		// unused
+	kResourceSAA = 16,		// unused
+	kResourceFLC = 17,		// unused
+	kResourceAAD = 18,		// unused
+	kResourceADS = 19,		// unused
+	kResourceADH = 20,		// used in txt/diah.adh
+	kResourceTGP = 21,		// background, used in back/comic.tgp, back/episode1.tgp and back/gbook.tgp
+	kResourceTVP = 22,		// speech, used in sound/speech.tvp
+	kResourceTTP = 23,		// unused
+	kResourceTAP = 24,		// sound effects, music and cutscenes, used in sound/details.tap and cut/cut.tap
+	kResourceCFO = 25,		// unused
+	kResourceTCF = 26		// error messages, used in err/err_e.tcf (English) and err/err_d.tcf (German)
+};
+
 // 4 + 2 + 2 + 4 + 2 + 2 + 768 = 784 bytes
 #define TBF_CHUNK_HEADER_SIZE 784
 
-struct TBFChunk {
-	uint32 packedSize;	// includes header
-	uint16 type;
+struct Chunk {
+	uint32 size;
+	ResourceType type;
+	uint32 pos;	// position of the actual data
+};
 
+struct TBFChunk {
 	// TBF chunk header
 	// ID (TBF, followed by a zero)
 	uint16 screenMode;
@@ -49,10 +82,9 @@ struct TBFChunk {
 	uint16 width;
 	uint16 height;
 	byte palette[3 * 256];
-
-	uint32 pos;	// position of the actual data
 };
 
+typedef Common::Array<Chunk> ChunkList;
 typedef Common::Array<TBFChunk> TBFChunkList;
 
 class Resource {
@@ -60,12 +92,21 @@ public:
 	Resource(Common::String filename);
 	~Resource();
 
-	TBFChunk *getChunk(int num);
+	ResourceType getType() const { return _resType; }
+	uint32 getChunkCount() const;
+	Chunk *getChunk(int num);
+	TBFChunk *getTBFChunk(int num);
 	byte *getChunkData(int num);
 
-private:
+protected:
 	Common::File _stream;
 	uint16 _chunkCount;
+	ResourceType _resType;
+
+private:
+	void readTBFChunk();
+
+	ChunkList _chunkList;
 	TBFChunkList _tbfChunkList;
 };
 

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -32,6 +32,7 @@
 #include "common/hash-str.h"
 #include "common/random.h"
 #include "common/stream.h"
+#include "graphics/surface.h"
 
 namespace Chewy {
 
@@ -183,6 +184,19 @@ public:
 
 	VideoChunk *getVideoHeader(uint num);
 	Common::SeekableReadStream *getVideoStream(uint num);
+};
+
+class Font {
+public:
+	Font(Common::String filename);
+	virtual ~Font();
+
+	::Graphics::Surface *getLine(Common::String text);
+
+private:
+	uint16 _count, _first, _last, _width, _height;
+
+	::Graphics::Surface _fontSurface;
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -31,6 +31,7 @@
 #include "common/hashmap.h"
 #include "common/hash-str.h"
 #include "common/random.h"
+#include "common/stream.h"
 
 namespace Chewy {
 
@@ -105,6 +106,11 @@ struct VideoChunk {
 	uint32 firstFrameOffset;
 };
 
+enum VideoFrameType {
+	kVideoFrameNormal = 0xF1FA,
+	kVideoFrameCustom = 0xFAF1
+};
+
 typedef Common::Array<Chunk> ChunkList;
 typedef Common::Array<TBFChunk> TBFChunkList;
 
@@ -157,6 +163,7 @@ public:
 	~VideoResource() {}
 
 	VideoChunk *getVideoHeader(uint num);
+	Common::SeekableReadStream *getVideoStream(uint num);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -169,12 +169,12 @@ public:
 	SoundChunk *getSound(uint num);
 };
 
-class TextResource : public Resource {
+class ErrorMessage : public Resource {
 public:
-	TextResource(Common::String filename) : Resource(filename) {}
-	virtual ~TextResource() {}
+	ErrorMessage(Common::String filename) : Resource(filename) {}
+	virtual ~ErrorMessage() {}
 
-	Common::String getText(uint num);
+	Common::String getErrorMessage(uint num);
 };
 
 class VideoResource : public Resource {

--- a/engines/chewy/resource.h
+++ b/engines/chewy/resource.h
@@ -40,7 +40,6 @@ namespace Chewy {
 struct TBFChunk {
 	uint32 packedSize;	// includes header
 	uint16 type;
-	uint32 pos;	// extra field
 
 	// TBF chunk header
 	// ID (TBF, followed by a zero)
@@ -49,7 +48,9 @@ struct TBFChunk {
 	uint32 unpackedSize;
 	uint16 width;
 	uint16 height;
-	char palette[3 * 256];
+	byte palette[3 * 256];
+
+	uint32 pos;	// position of the actual data
 };
 
 typedef Common::Array<TBFChunk> TBFChunkList;
@@ -60,7 +61,7 @@ public:
 	~Resource();
 
 	TBFChunk *getChunk(int num);
-	Common::SeekableReadStream *getChunkData(int num);
+	byte *getChunkData(int num);
 
 private:
 	Common::File _stream;

--- a/engines/chewy/scene.cpp
+++ b/engines/chewy/scene.cpp
@@ -1,0 +1,59 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/system.h"
+#include "common/events.h"
+#include "graphics/cursorman.h"
+#include "graphics/palette.h"
+#include "graphics/surface.h"
+
+#include "chewy/cursor.h"
+#include "chewy/graphics.h"
+#include "chewy/scene.h"
+#include "chewy/resource.h"
+#include "chewy/text.h"
+#include "chewy/video/cfo_decoder.h"
+
+namespace Chewy {
+
+Scene::Scene(ChewyEngine *vm) : _vm(vm) {
+}
+
+Scene::~Scene() {
+}
+
+void Scene::change(uint scene) {
+	_curScene = scene;
+	_vm->_cursor->setCursor(0);
+	_vm->_cursor->showCursor();
+	
+	draw();
+}
+
+void Scene::draw() {
+	_vm->_graphics->drawImage("episode1.tgp", _curScene);
+	_vm->_graphics->drawSprite("det1.taf", 0, 200, 100);
+	_vm->_graphics->loadFont("6x8.tff");
+	_vm->_graphics->drawText("This is a test", 200, 80);
+}
+
+} // End of namespace Chewy

--- a/engines/chewy/scene.h
+++ b/engines/chewy/scene.h
@@ -1,0 +1,45 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef CHEWY_SCENE_H
+#define CHEWY_SCENE_H
+
+#include "chewy/chewy.h"
+
+namespace Chewy {
+
+class Scene {
+public:
+	Scene(ChewyEngine *vm);
+	virtual ~Scene();
+
+	void change(uint scene);
+	void draw();
+
+private:
+	ChewyEngine *_vm;
+	uint _curScene;
+};
+
+} // End of namespace Chewy
+
+#endif

--- a/engines/chewy/sound.cpp
+++ b/engines/chewy/sound.cpp
@@ -1,0 +1,87 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "audio/audiostream.h"
+#include "audio/mixer.h"
+#include "audio/decoders/raw.h"
+#include "common/system.h"
+
+#include "chewy/resource.h"
+#include "chewy/sound.h"
+
+namespace Chewy {
+
+Sound::Sound() {
+	_speechRes = new Resource("speech.tvp");
+	_soundRes = new Resource("details.tap");
+}
+
+Sound::~Sound() {
+	delete _soundRes;
+	delete _speechRes;
+}
+
+void Sound::playSound(int num, bool loop) {
+	Chunk *chunk = _soundRes->getChunk(num);
+	byte *data = _soundRes->getChunkData(num);
+
+	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
+		Audio::makeRawStream(data,
+		chunk->size, 22050, Audio::FLAG_UNSIGNED,
+		DisposeAfterUse::NO),
+		loop ? 0 : 1);
+
+	g_engine->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle, stream);
+}
+
+void Sound::playMusic(int num, bool loop) {
+	uint32 musicNum = _soundRes->getChunkCount() - 1 - num;
+	Chunk *chunk = _soundRes->getChunk(musicNum);
+	byte *data = _soundRes->getChunkData(musicNum);
+
+	// TODO: TMF music files are similar to MOD files. With the following
+	// incorrect implementation, the PCM parts of these files can be played
+	warning("The current music playing implementation is wrong");
+
+	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
+		Audio::makeRawStream(data,
+		chunk->size, 22050, Audio::FLAG_UNSIGNED,
+		DisposeAfterUse::NO),
+		loop ? 0 : 1);
+
+	g_engine->_mixer->playStream(Audio::Mixer::kMusicSoundType, &_musicHandle, stream);
+}
+
+void Sound::playSpeech(int num) {
+	Chunk *chunk = _speechRes->getChunk(num);
+	byte *data = _speechRes->getChunkData(num);
+
+	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
+		Audio::makeRawStream(data,
+		chunk->size, 22050, Audio::FLAG_UNSIGNED,
+		DisposeAfterUse::NO),
+		1);
+
+	g_engine->_mixer->playStream(Audio::Mixer::kSpeechSoundType, &_speechHandle, stream);
+}
+
+} // End of namespace Chewy

--- a/engines/chewy/sound.cpp
+++ b/engines/chewy/sound.cpp
@@ -30,7 +30,8 @@
 
 namespace Chewy {
 
-Sound::Sound() {
+Sound::Sound(Audio::Mixer *mixer) {
+	_mixer = mixer;
 	_speechRes = new SoundResource("speech.tvp");
 	_soundRes = new SoundResource("details.tap");
 }
@@ -51,7 +52,7 @@ void Sound::playSound(int num, bool loop) {
 		DisposeAfterUse::NO),
 		loop ? 0 : 1);
 
-	g_engine->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle, stream);
+	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle, stream);
 
 	delete[] sound->data;
 	delete sound;
@@ -72,7 +73,7 @@ void Sound::playMusic(int num, bool loop) {
 		DisposeAfterUse::NO),
 		loop ? 0 : 1);
 
-	g_engine->_mixer->playStream(Audio::Mixer::kMusicSoundType, &_musicHandle, stream);
+	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_musicHandle, stream);
 }
 
 void Sound::playSpeech(int num) {
@@ -86,7 +87,7 @@ void Sound::playSpeech(int num) {
 		DisposeAfterUse::NO),
 		1);
 
-	g_engine->_mixer->playStream(Audio::Mixer::kSpeechSoundType, &_speechHandle, stream);
+	_mixer->playStream(Audio::Mixer::kSpeechSoundType, &_speechHandle, stream);
 
 	delete[] sound->data;
 	delete sound;

--- a/engines/chewy/sound.cpp
+++ b/engines/chewy/sound.cpp
@@ -41,39 +41,110 @@ Sound::~Sound() {
 	delete _speechRes;
 }
 
-void Sound::playSound(int num, bool loop) {
+void Sound::playSound(int num, bool loop, uint channel) {
 	SoundChunk *sound = _soundRes->getSound(num);
 	byte *data = (byte *)malloc(sound->size);
 	memcpy(data, sound->data, sound->size);
 
-	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
-		Audio::makeRawStream(data,
-		sound->size, 22050, Audio::FLAG_UNSIGNED,
-		DisposeAfterUse::YES),
-		loop ? 0 : 1);
-
-	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle, stream);
+	playSound(data, sound->size, loop, channel);
 
 	delete[] sound->data;
 	delete sound;
+}
+
+void Sound::playSound(byte *data, uint32 size, bool loop, uint channel, DisposeAfterUse::Flag dispose) {
+	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
+		Audio::makeRawStream(data,
+		size, 22050, Audio::FLAG_UNSIGNED,
+		dispose),
+		loop ? 0 : 1);
+
+	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle[channel], stream);
+}
+
+void Sound::pauseSound(uint channel) {
+	assert(channel < MAX_SOUND_EFFECTS);
+	_mixer->pauseHandle(_soundHandle[channel], true);
+}
+
+void Sound::resumeSound(uint channel) {
+	assert(channel < MAX_SOUND_EFFECTS);
+	_mixer->pauseHandle(_soundHandle[channel], false);
+}
+
+void Sound::stopSound(uint channel) {
+	assert(channel < MAX_SOUND_EFFECTS);
+	_mixer->stopHandle(_soundHandle[channel]);
+}
+
+bool Sound::isSoundActive(uint channel) {
+	assert(channel < MAX_SOUND_EFFECTS);
+	return _mixer->isSoundHandleActive(_soundHandle[channel]);
+}
+
+void Sound::setSoundVolume(uint volume) {
+	_mixer->setVolumeForSoundType(Audio::Mixer::kSFXSoundType, volume);
+}
+
+void Sound::setSoundChannelVolume(uint channel, uint volume) {
+	assert(channel < MAX_SOUND_EFFECTS);
+	_mixer->setChannelVolume(_soundHandle[channel], volume);
+}
+
+void Sound::setSoundChannelBalance(uint channel, uint balance) {
+	assert(channel < MAX_SOUND_EFFECTS);
+	_mixer->setChannelBalance(_soundHandle[channel], balance);
 }
 
 void Sound::playMusic(int num, bool loop) {
 	uint32 musicNum = _soundRes->getChunkCount() - 1 - num;
 	Chunk *chunk = _soundRes->getChunk(musicNum);
 	byte *data = _soundRes->getChunkData(musicNum);
+	
+	playMusic(data, chunk->size, loop);
+
+	delete[] data;
+	delete chunk;
+}
+
+void Sound::playMusic(byte *data, uint32 size, bool loop, DisposeAfterUse::Flag dispose) {
+	byte *modData = nullptr;
+	uint32 modSize;
 
 	// TODO: TMF music files are similar to MOD files. With the following
 	// incorrect implementation, the PCM parts of these files can be played
 	warning("The current music playing implementation is wrong");
+	modSize = size;
+	modData = (byte *)malloc(modSize);
+	memcpy(modData, data, size);
 
 	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
-		Audio::makeRawStream(data,
-		chunk->size, 22050, Audio::FLAG_UNSIGNED,
-		DisposeAfterUse::YES),
+		Audio::makeRawStream(modData,
+		modSize, 22050, Audio::FLAG_UNSIGNED,
+		dispose),
 		loop ? 0 : 1);
 
 	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_musicHandle, stream);
+}
+
+void Sound::pauseMusic() {
+	_mixer->pauseHandle(_musicHandle, true);
+}
+
+void Sound::resumeMusic() {
+	_mixer->pauseHandle(_musicHandle, false);
+}
+
+void Sound::stopMusic() {
+	_mixer->stopHandle(_musicHandle);
+}
+
+bool Sound::isMusicActive() {
+	return _mixer->isSoundHandleActive(_musicHandle);
+}
+
+void Sound::setMusicVolume(uint volume) {
+	_mixer->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, volume);
 }
 
 void Sound::playSpeech(int num) {
@@ -91,6 +162,30 @@ void Sound::playSpeech(int num) {
 
 	delete[] sound->data;
 	delete sound;
+}
+
+void Sound::pauseSpeech() {
+	_mixer->pauseHandle(_speechHandle, true);
+}
+
+void Sound::resumeSpeech() {
+	_mixer->pauseHandle(_speechHandle, false);
+}
+
+void Sound::stopSpeech() {
+	_mixer->stopHandle(_speechHandle);
+}
+
+bool Sound::isSpeechActive() {
+	return _mixer->isSoundHandleActive(_speechHandle);
+}
+
+void Sound::setSpeechVolume(uint volume) {
+	_mixer->setVolumeForSoundType(Audio::Mixer::kSpeechSoundType, volume);
+}
+
+void Sound::stopAll() {
+	_mixer->stopAll();
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/sound.cpp
+++ b/engines/chewy/sound.cpp
@@ -213,7 +213,7 @@ void Sound::convertTMFToMod(byte *tmfData, uint32 tmfSize, byte *modData, uint32
 	};
 
 	if (READ_BE_UINT32(tmfPtr) != MKTAG('T', 'M', 'F', '\0'))
-		error("Corrupt TBF resource");
+		error("Corrupt TMF resource");
 	tmfPtr += 4;
 
 	memcpy(modPtr, songName, 20);

--- a/engines/chewy/sound.cpp
+++ b/engines/chewy/sound.cpp
@@ -49,7 +49,7 @@ void Sound::playSound(int num, bool loop) {
 	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
 		Audio::makeRawStream(data,
 		sound->size, 22050, Audio::FLAG_UNSIGNED,
-		DisposeAfterUse::NO),
+		DisposeAfterUse::YES),
 		loop ? 0 : 1);
 
 	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle, stream);
@@ -70,7 +70,7 @@ void Sound::playMusic(int num, bool loop) {
 	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
 		Audio::makeRawStream(data,
 		chunk->size, 22050, Audio::FLAG_UNSIGNED,
-		DisposeAfterUse::NO),
+		DisposeAfterUse::YES),
 		loop ? 0 : 1);
 
 	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_musicHandle, stream);
@@ -84,7 +84,7 @@ void Sound::playSpeech(int num) {
 	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
 		Audio::makeRawStream(data,
 		sound->size, 22050, Audio::FLAG_UNSIGNED,
-		DisposeAfterUse::NO),
+		DisposeAfterUse::YES),
 		1);
 
 	_mixer->playStream(Audio::Mixer::kSpeechSoundType, &_speechHandle, stream);

--- a/engines/chewy/sound.cpp
+++ b/engines/chewy/sound.cpp
@@ -31,8 +31,8 @@
 namespace Chewy {
 
 Sound::Sound() {
-	_speechRes = new Resource("speech.tvp");
-	_soundRes = new Resource("details.tap");
+	_speechRes = new SoundResource("speech.tvp");
+	_soundRes = new SoundResource("details.tap");
 }
 
 Sound::~Sound() {
@@ -41,16 +41,20 @@ Sound::~Sound() {
 }
 
 void Sound::playSound(int num, bool loop) {
-	Chunk *chunk = _soundRes->getChunk(num);
-	byte *data = _soundRes->getChunkData(num);
+	SoundChunk *sound = _soundRes->getSound(num);
+	byte *data = (byte *)malloc(sound->size);
+	memcpy(data, sound->data, sound->size);
 
 	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
 		Audio::makeRawStream(data,
-		chunk->size, 22050, Audio::FLAG_UNSIGNED,
+		sound->size, 22050, Audio::FLAG_UNSIGNED,
 		DisposeAfterUse::NO),
 		loop ? 0 : 1);
 
 	g_engine->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle, stream);
+
+	delete[] sound->data;
+	delete sound;
 }
 
 void Sound::playMusic(int num, bool loop) {
@@ -72,16 +76,20 @@ void Sound::playMusic(int num, bool loop) {
 }
 
 void Sound::playSpeech(int num) {
-	Chunk *chunk = _speechRes->getChunk(num);
-	byte *data = _speechRes->getChunkData(num);
+	SoundChunk *sound = _speechRes->getSound(num);
+	byte *data = (byte *)malloc(sound->size);
+	memcpy(data, sound->data, sound->size);
 
 	Audio::AudioStream *stream = Audio::makeLoopingAudioStream(
 		Audio::makeRawStream(data,
-		chunk->size, 22050, Audio::FLAG_UNSIGNED,
+		sound->size, 22050, Audio::FLAG_UNSIGNED,
 		DisposeAfterUse::NO),
 		1);
 
 	g_engine->_mixer->playStream(Audio::Mixer::kSpeechSoundType, &_speechHandle, stream);
+
+	delete[] sound->data;
+	delete sound;
 }
 
 } // End of namespace Chewy

--- a/engines/chewy/sound.h
+++ b/engines/chewy/sound.h
@@ -28,7 +28,7 @@
 
 namespace Chewy {
 
-class Resource;
+class SoundResource;
 
 class Sound {
 public:
@@ -44,8 +44,8 @@ private:
 	Audio::SoundHandle _musicHandle;
 	Audio::SoundHandle _speechHandle;
 
-	Resource *_speechRes;
-	Resource *_soundRes;
+	SoundResource *_speechRes;
+	SoundResource *_soundRes;
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/sound.h
+++ b/engines/chewy/sound.h
@@ -33,7 +33,7 @@ class SoundResource;
 class Sound {
 public:
 	Sound(Audio::Mixer *mixer);
-	~Sound();
+	virtual ~Sound();
 
 	void playSound(int num, bool loop = false);
 	void playMusic(int num, bool loop = false);

--- a/engines/chewy/sound.h
+++ b/engines/chewy/sound.h
@@ -32,7 +32,7 @@ class SoundResource;
 
 class Sound {
 public:
-	Sound();
+	Sound(Audio::Mixer *mixer);
 	~Sound();
 
 	void playSound(int num, bool loop = false);
@@ -40,6 +40,7 @@ public:
 	void playSpeech(int num);
 
 private:
+	Audio::Mixer *_mixer;
 	Audio::SoundHandle _soundHandle;
 	Audio::SoundHandle _musicHandle;
 	Audio::SoundHandle _speechHandle;

--- a/engines/chewy/sound.h
+++ b/engines/chewy/sound.h
@@ -20,54 +20,32 @@
  *
  */
 
-#ifndef CHEWY_H
-#define CHEWY_H
+#ifndef CHEWY_SOUND_H
+#define CHEWY_SOUND_H
 
-
-#include "common/scummsys.h"
-#include "common/file.h"
-#include "common/util.h"
-#include "common/str.h"
-#include "common/hashmap.h"
-#include "common/hash-str.h"
-#include "common/random.h"
-
-#include "engines/engine.h"
+#include "audio/mixer.h"
+#include "chewy/chewy.h"
 
 namespace Chewy {
 
-struct ChewyGameDescription;
-class Console;
-class Graphics;
-class Sound;
+class Resource;
 
-class ChewyEngine : public Engine {
-
-protected:
-	// Engine APIs
-	virtual Common::Error run();
-	virtual bool hasFeature(EngineFeature f) const;
-
-	void shutdown();
-
-	void initialize();
-
-	Console *_console;
-
+class Sound {
 public:
-	ChewyEngine(OSystem *syst, const ChewyGameDescription *gameDesc);
-	virtual ~ChewyEngine();
+	Sound();
+	~Sound();
 
-	int getGameType() const;
-	uint32 getFeatures() const;
-	Common::Language getLanguage() const;
-	Common::Platform getPlatform() const;
+	void playSound(int num, bool loop = false);
+	void playMusic(int num, bool loop = false);
+	void playSpeech(int num);
 
-	const ChewyGameDescription *_gameDescription;
-	Common::RandomSource _rnd;
+private:
+	Audio::SoundHandle _soundHandle;
+	Audio::SoundHandle _musicHandle;
+	Audio::SoundHandle _speechHandle;
 
-	Graphics *_graphics;
-	Sound *_sound;
+	Resource *_speechRes;
+	Resource *_soundRes;
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/sound.h
+++ b/engines/chewy/sound.h
@@ -72,6 +72,8 @@ private:
 
 	SoundResource *_speechRes;
 	SoundResource *_soundRes;
+
+	void convertTMFToMod(byte *tmfData, uint32 tmfSize, byte *modData, uint32 &modSize);
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/sound.h
+++ b/engines/chewy/sound.h
@@ -30,18 +30,43 @@ namespace Chewy {
 
 class SoundResource;
 
+#define MAX_SOUND_EFFECTS 14
+
 class Sound {
 public:
 	Sound(Audio::Mixer *mixer);
 	virtual ~Sound();
 
-	void playSound(int num, bool loop = false);
+	void playSound(int num, bool loop = false, uint channel = 0);
+	void playSound(byte *data, uint32 size, bool loop = false, uint channel = 0, DisposeAfterUse::Flag dispose = DisposeAfterUse::YES);
+	void pauseSound(uint channel);
+	void resumeSound(uint channel);
+	void stopSound(uint channel);
+	bool isSoundActive(uint channel);
+	void setSoundVolume(uint volume);
+	void setSoundChannelVolume(uint channel, uint volume);
+	void setSoundChannelBalance(uint channel, uint balance);
+
 	void playMusic(int num, bool loop = false);
+	void playMusic(byte *data, uint32 size, bool loop = false, DisposeAfterUse::Flag dispose = DisposeAfterUse::YES);
+	void pauseMusic();
+	void resumeMusic();
+	void stopMusic();
+	bool isMusicActive();
+	void setMusicVolume(uint volume);
+
 	void playSpeech(int num);
+	void pauseSpeech();
+	void resumeSpeech();
+	void stopSpeech();
+	bool isSpeechActive();
+	void setSpeechVolume(uint volume);
+
+	void stopAll();
 
 private:
 	Audio::Mixer *_mixer;
-	Audio::SoundHandle _soundHandle;
+	Audio::SoundHandle _soundHandle[MAX_SOUND_EFFECTS];
 	Audio::SoundHandle _musicHandle;
 	Audio::SoundHandle _speechHandle;
 

--- a/engines/chewy/text.cpp
+++ b/engines/chewy/text.cpp
@@ -181,7 +181,7 @@ Font::~Font() {
 	_fontSurface.free();
 }
 
-::Graphics::Surface *Font::getLine(const Common::String text) {
+::Graphics::Surface *Font::getLine(const Common::String &text) {
 	::Graphics::Surface *line = new ::Graphics::Surface();
 	line->create(text.size() * _width, _height, ::Graphics::PixelFormat::createFormatCLUT8());
 

--- a/engines/chewy/text.cpp
+++ b/engines/chewy/text.cpp
@@ -181,7 +181,7 @@ Font::~Font() {
 	_fontSurface.free();
 }
 
-::Graphics::Surface *Font::getLine(Common::String text) {
+::Graphics::Surface *Font::getLine(const Common::String text) {
 	::Graphics::Surface *line = new ::Graphics::Surface();
 	line->create(text.size() * _width, _height, ::Graphics::PixelFormat::createFormatCLUT8());
 

--- a/engines/chewy/text.cpp
+++ b/engines/chewy/text.cpp
@@ -162,9 +162,10 @@ Font::Font(Common::String filename) {
 
 	for (uint n = 0; n < _count; n++) {
 		for (uint y = 0; y < _height; y++) {
+			p = (byte *)_fontSurface.getBasePtr(n * _width, y);
+
 			for (uint x = n * _width; x < n * _width + _width; x++) {
-				p = (byte *)_fontSurface.getBasePtr(x, y);
-				*p = (cur & (1 << bitIndex)) ? 0 : 0xFF;
+				*p++ = (cur & (1 << bitIndex)) ? 0 : 0xFF;
 
 				bitIndex--;
 				if (bitIndex < 0) {

--- a/engines/chewy/text.cpp
+++ b/engines/chewy/text.cpp
@@ -34,11 +34,11 @@ Text::Text() : Resource("atds.tap") {
 Text::~Text() {
 }
 
-DialogList *Text::getDialog(uint dialogNum, uint entryNum) {
-	DialogList *l = new DialogList();
-
+TextEntryList *Text::getDialog(uint dialogNum, uint entryNum) {
 	if (dialogNum >= kADSTextMax)
-		error("getDialog(): Invalid entry number requested, %d (max %d)", dialogNum, kADSTextMax);
+		error("getDialog(): Invalid entry number requested, %d (max %d)", dialogNum, kADSTextMax - 1);
+
+	TextEntryList *l = new TextEntryList();
 
 	byte *data = getChunkData(dialogNum);
 	byte *ptr = data;
@@ -51,7 +51,7 @@ DialogList *Text::getDialog(uint dialogNum, uint entryNum) {
 
 	for (uint i = 0; i <= entryNum; i++) {
 		do {
-			Dialog curDialog;
+			TextEntry curDialog;
 			ptr++;	// current entry
 			ptr += 2;
 			curDialog.speechId = READ_LE_UINT16(ptr) - VOICE_OFFSET;	ptr += 2;
@@ -79,6 +79,59 @@ DialogList *Text::getDialog(uint dialogNum, uint entryNum) {
 	delete[] data;
 
 	return l;
+}
+
+TextEntry *Text::getText(uint dialogNum, uint entryNum) {
+	if (dialogNum < kADSTextMax)
+		error("getText(): Invalid entry number requested, %d (min %d)", dialogNum, kADSTextMax);
+
+	TextEntry *d = new TextEntry();
+	bool isText = (dialogNum >= kADSTextMax && dialogNum < kADSTextMax + kATSTextMax);
+	bool isAutoDialog = (dialogNum >= kADSTextMax + kATSTextMax && dialogNum < kADSTextMax + kATSTextMax + kAADTextMax);
+	//bool isInvText = (dialogNum >= kADSTextMax + kATSTextMax + kAADTextMax && dialogNum < kADSTextMax + kATSTextMax + kAADTextMax + kINVTextMax);
+
+	byte *data = getChunkData(dialogNum);
+	byte *ptr = data;
+
+	if (isAutoDialog)
+		ptr += 3;
+
+	for (uint i = 0; i <= entryNum; i++) {
+		ptr += 13;
+		d->speechId = READ_LE_UINT16(ptr) - VOICE_OFFSET;	ptr += 2;
+
+		do {
+			if (i == entryNum)
+				d->text += *ptr++;
+			else
+				ptr++;
+
+			if (*ptr == 0 && *(ptr + 1) != kEndText) {
+				// TODO: Split lines
+				*ptr = ' ';
+			}
+		} while (*ptr);
+
+		if (*(ptr + 1) != kEndText || *(ptr + 2) != kEndChunk)
+			error("Invalid text resource - %d", dialogNum);
+
+		if (!isText)
+			ptr += 3;	// 0, kEndText, kEndChunk
+		if (isAutoDialog)
+			ptr += 3;
+
+		if (i == entryNum) {
+			// Found
+			delete[] data;
+			return d;
+		}
+	}
+
+	// Not found
+	delete[] data;
+	delete d;
+
+	return nullptr;
 }
 
 Font::Font(Common::String filename) {

--- a/engines/chewy/text.cpp
+++ b/engines/chewy/text.cpp
@@ -1,0 +1,160 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/rect.h"
+#include "common/system.h"
+
+#include "chewy/resource.h"
+#include "chewy/text.h"
+
+namespace Chewy {
+
+Text::Text() : Resource("atds.tap") {
+}
+
+Text::~Text() {
+}
+
+DialogList *Text::getDialog(uint dialogNum, uint entryNum) {
+	DialogList *l = new DialogList();
+
+	if (dialogNum >= kADSTextMax)
+		error("getDialog(): Invalid entry number requested, %d (max %d)", dialogNum, kADSTextMax);
+
+	byte *data = getChunkData(dialogNum);
+	byte *ptr = data;
+
+	ptr += 2;	// entry number
+	ptr += 2;	// number of persons
+	ptr += 2;	// automove count
+	ptr += 2;	// cursor number
+	ptr += 13;	// misc data
+
+	for (uint i = 0; i <= entryNum; i++) {
+		do {
+			Dialog curDialog;
+			ptr++;	// current entry
+			ptr += 2;
+			curDialog.speechId = READ_LE_UINT16(ptr) - VOICE_OFFSET;	ptr += 2;
+
+			do {
+				curDialog.text += *ptr++;
+
+				if (*ptr == 0 && *(ptr + 1) != kEndText) {
+					// TODO: Split lines
+					*ptr = ' ';
+				}
+			} while (*ptr != kEndText);
+
+			if (i == entryNum)
+				l->push_back(curDialog);
+
+		} while (*(ptr + 1) != kEndEntry);
+
+		ptr += 2;	// kEndText, kEndEntry
+
+		if (*ptr == kEndBlock)	// not found
+			break;
+	}
+
+	delete[] data;
+
+	return l;
+}
+
+Font::Font(Common::String filename) {
+	const uint32 headerFont = MKTAG('T', 'F', 'F', '\0');
+	Common::File stream;
+
+	stream.open(filename);
+
+	uint32 header = stream.readUint32BE();
+
+	if (header != headerFont)
+		error("Invalid resource - %s", filename.c_str());
+
+	stream.skip(4);	// total memory
+	_count = stream.readUint16LE();
+	_first = stream.readUint16LE();
+	_last = stream.readUint16LE();
+	_width = stream.readUint16LE();
+	_height = stream.readUint16LE();
+
+	_fontSurface.create(_width * _count, _height, ::Graphics::PixelFormat::createFormatCLUT8());
+
+	byte cur;
+	int bitIndex = 7;
+	byte *p;
+
+	cur = stream.readByte();
+
+	for (uint n = 0; n < _count; n++) {
+		for (uint y = 0; y < _height; y++) {
+			for (uint x = n * _width; x < n * _width + _width; x++) {
+				p = (byte *)_fontSurface.getBasePtr(x, y);
+				*p = (cur & (1 << bitIndex)) ? 0 : 0xFF;
+
+				bitIndex--;
+				if (bitIndex < 0) {
+					bitIndex = 7;
+					cur = stream.readByte();
+				}
+			}
+		}
+	}
+}
+
+Font::~Font() {
+	_fontSurface.free();
+}
+
+::Graphics::Surface *Font::getLine(Common::String text) {
+	::Graphics::Surface *line = new ::Graphics::Surface();
+	line->create(text.size() * _width, _height, ::Graphics::PixelFormat::createFormatCLUT8());
+
+	for (uint i = 0; i < text.size(); i++) {
+		uint x = (text[i] - _first) * _width;
+		line->copyRectToSurface(_fontSurface, i * _width, 0, Common::Rect(x, 0, x + _width, _height));
+	}
+
+	return line;
+}
+
+Common::String ErrorMessage::getErrorMessage(uint num) {
+	assert(num < _chunkList.size());
+
+	Chunk *chunk = &_chunkList[num];
+	Common::String str;
+	byte *data = new byte[chunk->size];
+
+	_stream.seek(chunk->pos, SEEK_SET);
+	_stream.read(data, chunk->size);
+	if (_encrypted)
+		decrypt(data, chunk->size);
+
+	str = (char *)data;
+	delete[] data;
+
+	return str;
+}
+
+} // End of namespace Chewy

--- a/engines/chewy/text.h
+++ b/engines/chewy/text.h
@@ -1,0 +1,105 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef CHEWY_TEXT_H
+#define CHEWY_TEXT_H
+
+#include "common/list.h"
+#include "chewy/chewy.h"
+#include "chewy/resource.h"
+
+namespace Chewy {
+
+/**
+ * Game texts are contained in txt/atds.tap, and contain the following (in that order):
+ * ADS (Adventure Dialog System) - dialogs, 500 entries max
+ * ATS (Adventure Text System) - text descriptions, 100 entries max
+ * AAD (Adventure Auto Dialog System) - automatic dialogs, 100 entries max
+ * INV - inventory text descriptions, 100 entries max
+ * USE - use action texts, 100 entries max
+ */
+enum MaxTextTypes {
+	kADSTextMax = 500,
+	kATSTextMax = 100,
+	kAADTextMax = 100,
+	kINVTextMax = 100,
+	kUSETextMax = 100
+};
+
+/**
+ * Markers for text entries
+ */
+enum TextEntryMarkers {
+	kEndRow = 0x00,
+	kEndBlock = 0x0b,
+	kEndEntry = 0x0c,
+	kEndText = 0x0d,
+	kEndChunk = 0x0e
+	// There's also 0x0f, block end, which we don't use
+};
+
+#define VOICE_OFFSET 20
+
+struct Dialog {
+	uint16 speechId;
+	Common::String text;
+};
+
+typedef Common::List<Dialog> DialogList;
+
+
+class Text : public Resource {
+public:
+	Text();
+	virtual ~Text();
+
+	DialogList *getDialog(uint dialogNum, uint entryNum);
+	// TODO: getText()
+	// TODO: getAutoDialog()
+	// TODO: getInvDesc()
+	// TODO: getUseText()
+};
+
+class ErrorMessage : public Resource {
+public:
+	ErrorMessage(Common::String filename) : Resource(filename) {}
+	virtual ~ErrorMessage() {}
+
+	Common::String getErrorMessage(uint num);
+};
+
+class Font {
+public:
+	Font(Common::String filename);
+	virtual ~Font();
+
+	::Graphics::Surface *getLine(Common::String text);
+
+private:
+	uint16 _count, _first, _last, _width, _height;
+
+	::Graphics::Surface _fontSurface;
+};
+
+} // End of namespace Chewy
+
+#endif

--- a/engines/chewy/text.h
+++ b/engines/chewy/text.h
@@ -100,7 +100,7 @@ public:
 	Font(Common::String filename);
 	virtual ~Font();
 
-	::Graphics::Surface *getLine(Common::String text);
+	::Graphics::Surface *getLine(const Common::String text);
 
 private:
 	uint16 _count, _first, _last, _width, _height;

--- a/engines/chewy/text.h
+++ b/engines/chewy/text.h
@@ -38,11 +38,11 @@ namespace Chewy {
  * USE - use action texts, 100 entries max
  */
 enum MaxTextTypes {
-	kADSTextMax = 500,
-	kATSTextMax = 100,
-	kAADTextMax = 100,
-	kINVTextMax = 100,
-	kUSETextMax = 100
+	kADSTextMax = 500,	//   0 - 499
+	kATSTextMax = 100,	// 500 - 599
+	kAADTextMax = 100,	// 600 - 699
+	kINVTextMax = 100,	// 700 - 799
+	kUSETextMax = 100	// 800 - 899
 };
 
 /**
@@ -59,12 +59,12 @@ enum TextEntryMarkers {
 
 #define VOICE_OFFSET 20
 
-struct Dialog {
+struct TextEntry {
 	uint16 speechId;
 	Common::String text;
 };
 
-typedef Common::List<Dialog> DialogList;
+typedef Common::List<TextEntry> TextEntryList;
 
 
 class Text : public Resource {
@@ -72,11 +72,19 @@ public:
 	Text();
 	virtual ~Text();
 
-	DialogList *getDialog(uint dialogNum, uint entryNum);
-	// TODO: getText()
-	// TODO: getAutoDialog()
-	// TODO: getInvDesc()
-	// TODO: getUseText()
+	/**
+	 * Gets a list of lines for a specific dialog entry
+	 */
+	TextEntryList *getDialog(uint dialogNum, uint entryNum);
+
+	/**
+	* Gets a line of text of the following types:
+	* - text (ATS) - 500 - 599
+	* - auto dialog (AAD) - 600 - 699
+	* - inventory text (INV) - 700 - 799
+	* - use text (USE) - 800 - 899
+	*/
+	TextEntry *getText(uint dialogNum, uint entryNum);
 };
 
 class ErrorMessage : public Resource {

--- a/engines/chewy/text.h
+++ b/engines/chewy/text.h
@@ -100,7 +100,7 @@ public:
 	Font(Common::String filename);
 	virtual ~Font();
 
-	::Graphics::Surface *getLine(const Common::String text);
+	::Graphics::Surface *getLine(const Common::String &text);
 
 private:
 	uint16 _count, _first, _last, _width, _height;

--- a/engines/chewy/video/cfo_decoder.cpp
+++ b/engines/chewy/video/cfo_decoder.cpp
@@ -33,27 +33,27 @@
 namespace Chewy {
 
 enum CustomSubChunk {
-	kChunkFadeIn = 0,
+	kChunkFadeIn = 0,				// unused
 	kChunkFadeOut = 1,
 	kChunkLoadMusic = 2,
-	kChunkLoadRaw = 3,
+	kChunkLoadRaw = 3,				// unused
 	kChunkLoadVoc = 4,
 	kChunkPlayMusic = 5,
-	kChunkPlaySeq = 6,
-	kChunkPlayPattern = 7,
+	kChunkPlaySeq = 6,				// unused
+	kChunkPlayPattern = 7,			// unused
 	kChunkStopMusic = 8,
 	kChunkWaitMusicEnd = 9,
 	kChunkSetMusicVolume = 10,
-	kChunkSetLoopMode = 11,
-	kChunkPlayRaw = 12,
+	kChunkSetLoopMode = 11,			// unused
+	kChunkPlayRaw = 12,				// unused
 	kChunkPlayVoc = 13,
 	kChunkSetSoundVolume = 14,
 	kChunkSetChannelVolume = 15,
 	kChunkFreeSoundEffect = 16,
-	kChunkMusicFadeIn = 17,
+	kChunkMusicFadeIn = 17,			// unused
 	kChunkMusicFadeOut = 18,
 	kChunkSetBalance = 19,
-	kChunkSetSpeed = 20,
+	kChunkSetSpeed = 20,			// unused
 	kChunkClearScreen = 21
 };
 
@@ -182,18 +182,17 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 
 		switch (frameType) {
 		case kChunkFadeIn:
-			delay = _fileStream->readUint16LE();
-
-			warning("kChunkFadeIn, delay %d", delay);
-			// TODO
+			error("Unused chunk kChunkFadeIn found");
 			break;
 		case kChunkFadeOut:
+			// Used in video 0
 			delay = _fileStream->readUint16LE();
 
 			warning("kChunkFadeOut, delay %d", delay);
 			// TODO
 			break;
 		case kChunkLoadMusic:
+			// Used in videos 0, 18, 34, 71
 			warning("kChunkLoadMusic");
 			// TODO
 			_fileStream->skip(frameSize);
@@ -211,19 +210,16 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 			_fileStream->read(_soundEffects[number], frameSize - 2);
 			break;
 		case kChunkPlayMusic:
+			// Used in videos 0, 18, 34, 71
 			warning("kChunkPlayMusic");
 			// TODO
 			_fileStream->skip(frameSize);
 			break;
 		case kChunkPlaySeq:
-			warning("kChunkPlaySeq");
-			// TODO
-			_fileStream->skip(frameSize);
+			error("Unused chunk kChunkPlaySeq found");
 			break;
 		case kChunkPlayPattern:
-			warning("kChunkPlayPattern");
-			// TODO
-			_fileStream->skip(frameSize);
+			error("Unused chunk kChunkPlayPattern found");
 			break;
 		case kChunkStopMusic:
 			g_engine->_mixer->stopHandle(_musicHandle);
@@ -239,9 +235,7 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 			g_engine->_mixer->setVolumeForSoundType(Audio::Mixer::SoundType::kMusicSoundType, volume);
 			break;
 		case kChunkSetLoopMode:
-			warning("kChunkSetLoopMode");
-			// TODO
-			_fileStream->skip(frameSize);
+			error("Unused chunk kChunkSetLoopMode found");
 			break;
 		case kChunkPlayRaw:
 			error("Unused chunk kChunkPlayRaw found");
@@ -283,11 +277,10 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 			_soundEffects[number] = nullptr;
 			break;
 		case kChunkMusicFadeIn:
-			warning("kChunkMusicFadeIn");
-			// TODO
-			_fileStream->skip(frameSize);
+			error("Unused chunk kChunkMusicFadeIn found");
 			break;
 		case kChunkMusicFadeOut:
+			// Used in videos 0, 71
 			warning("kChunkMusicFadeOut");
 			// TODO
 			_fileStream->skip(frameSize);
@@ -300,9 +293,7 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 			g_engine->_mixer->setChannelBalance(_soundHandle[channel], balance);
 			break;
 		case kChunkSetSpeed:
-			warning("kChunkSetSpeed");
-			// TODO
-			_fileStream->skip(frameSize);
+			error("Unused chunk kChunkSetSpeed found");
 			break;
 		case kChunkClearScreen:
 			g_system->fillScreen(0);

--- a/engines/chewy/video/cfo_decoder.cpp
+++ b/engines/chewy/video/cfo_decoder.cpp
@@ -234,7 +234,7 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 		case kChunkSetMusicVolume:
 			volume = _fileStream->readUint16LE() * Audio::Mixer::kMaxChannelVolume / 63;
 
-			_mixer->setVolumeForSoundType(Audio::Mixer::SoundType::kMusicSoundType, volume);
+			_mixer->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, volume);
 			break;
 		case kChunkSetLoopMode:
 			error("Unused chunk kChunkSetLoopMode found");
@@ -256,13 +256,13 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 				DisposeAfterUse::NO),
 				(repeat == 0) ? 1 : repeat);
 
-			_mixer->setVolumeForSoundType(Audio::Mixer::SoundType::kSFXSoundType, volume);
+			_mixer->setVolumeForSoundType(Audio::Mixer::kSFXSoundType, volume);
 			_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle[channel], stream);
 			break;
 		case kChunkSetSoundVolume:
 			volume = _fileStream->readUint16LE() * Audio::Mixer::kMaxChannelVolume / 63;
 
-			_mixer->setVolumeForSoundType(Audio::Mixer::SoundType::kSFXSoundType, volume);
+			_mixer->setVolumeForSoundType(Audio::Mixer::kSFXSoundType, volume);
 			break;
 		case kChunkSetChannelVolume:
 			channel = _fileStream->readUint16LE();

--- a/engines/chewy/video/cfo_decoder.cpp
+++ b/engines/chewy/video/cfo_decoder.cpp
@@ -23,6 +23,7 @@
 #include "audio/audiostream.h"
 #include "audio/mixer.h"
 #include "audio/decoders/raw.h"
+#include "common/events.h"
 #include "common/stream.h"
 #include "common/system.h"
 #include "engines/engine.h"
@@ -228,6 +229,9 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 			break;
 		case kChunkWaitMusicEnd:
 			do {
+				Common::Event event;
+				while (g_system->getEventManager()->pollEvent(event)) {}	// ignore events
+				g_system->updateScreen();
 				g_system->delayMillis(10);
 			} while (_mixer->isSoundHandleActive(_musicHandle));
 			break;

--- a/engines/chewy/video/cfo_decoder.cpp
+++ b/engines/chewy/video/cfo_decoder.cpp
@@ -209,7 +209,7 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 			delete[] _soundEffects[number];
 
 			_soundEffectSize[number] = frameSize - 2;
-			_soundEffects[number] = (byte *)malloc(frameSize - 2);
+			_soundEffects[number] = new byte[frameSize - 2];
 			_fileStream->read(_soundEffects[number], frameSize - 2);
 			break;
 		case kChunkPlayMusic:

--- a/engines/chewy/video/cfo_decoder.cpp
+++ b/engines/chewy/video/cfo_decoder.cpp
@@ -1,0 +1,261 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/stream.h"
+#include "video/flic_decoder.h"
+
+#include "chewy/video/cfo_decoder.h"
+
+namespace Chewy {
+
+enum CustomSubChunk {
+	kChunkFadeIn = 0,
+	kChunkFadeOut = 1,
+	kChunkLoadMusic = 2,
+	kChunkLoadRaw = 3,
+	kChunkLoadVoc = 4,
+	kChunkPlayMusic = 5,
+	kChunkPlaySeq = 6,
+	kChunkPlayPattern = 7,
+	kChunkStopMusic = 8,
+	kChunkWaitMusicEnd = 9,
+	kChunkSetMusicVolume = 10,
+	kChunkSetLoopMode = 11,
+	kChunkPlayRaw = 12,
+	kChunkPlayVoc = 13,
+	kChunkSetSoundVolume = 14,
+	kChunkSetChannelVolume = 15,
+	kChunkFreeSoundEffect = 16,
+	kChunkMusicFadeIn = 17,
+	kChunkMusicFadeOut = 18,
+	kChunkSetStero = 19,
+	kChunkSetSpeed = 20,
+	kChunkClearScreen = 21
+};
+
+bool CfoDecoder::loadStream(Common::SeekableReadStream *stream) {
+	close();
+
+	if (stream->readUint32BE() != MKTAG('C', 'F', 'O', '\0'))
+		error("Corrupt video resource");
+
+	stream->readUint32LE();	// always 0
+
+	uint16 frameCount = stream->readUint16LE();
+	uint16 width = stream->readUint16LE();
+	uint16 height = stream->readUint16LE();
+
+	addTrack(new CfoVideoTrack(stream, frameCount, width, height));
+	return true;
+}
+
+CfoDecoder::CfoVideoTrack::CfoVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height) :
+	Video::FlicDecoder::FlicVideoTrack(stream, frameCount, width, height, true) {
+	readHeader();
+}
+
+void CfoDecoder::CfoVideoTrack::readHeader() {
+	_frameDelay = _startFrameDelay = _fileStream->readUint32LE();
+	_offsetFrame1 = _fileStream->readUint32LE();
+	_offsetFrame2 = 0;	// doesn't exist, as CFO videos aren't rewindable
+
+	_fileStream->seek(_offsetFrame1);
+}
+
+#define FRAME_TYPE 0xF1FA
+#define CUSTOM_FRAME_TYPE 0xFAF1
+
+const Graphics::Surface *CfoDecoder::CfoVideoTrack::decodeNextFrame() {
+	uint16 frameType;
+
+	// Read chunk
+	/*uint32 frameSize =*/ _fileStream->readUint32LE();
+	frameType = _fileStream->readUint16LE();
+
+	switch (frameType) {
+	case FRAME_TYPE:
+		handleFrame();
+		break;
+	case CUSTOM_FRAME_TYPE:
+		handleCustomFrame();
+		break;
+	default:
+		error("CfoDecoder::decodeFrame(): unknown main chunk type (type = 0x%02X)", frameType);
+		break;
+	}
+
+	_curFrame++;
+	_nextFrameStartTime += _frameDelay;
+
+	return _surface;
+}
+
+#define FLI_SETPAL 4
+#define FLI_SS2    7
+#define FLI_BRUN   15
+#define FLI_COPY   16
+#define PSTAMP     18
+
+void CfoDecoder::CfoVideoTrack::handleFrame() {
+	uint16 chunkCount = _fileStream->readUint16LE();
+
+	// Read subchunks
+	for (uint32 i = 0; i < chunkCount; ++i) {
+		uint32 frameSize = _fileStream->readUint32LE();
+		uint16 frameType = _fileStream->readUint16LE();
+		uint8 *data = new uint8[frameSize - 6];
+		_fileStream->read(data, frameSize - 6);
+
+		switch (frameType) {
+		case FLI_SETPAL:
+			unpackPalette(data);
+			_dirtyPalette = true;
+			break;
+		case FLI_SS2:
+			decodeDeltaFLC(data);
+			break;
+		case FLI_BRUN:
+			decodeByteRun(data);
+			break;
+		case FLI_COPY:
+			copyFrame(data);
+			break;
+		case PSTAMP:
+			/* PSTAMP - skip for now */
+			break;
+		default:
+			error("FlicDecoder::decodeNextFrame(): unknown subchunk type (type = 0x%02X)", frameType);
+			break;
+		}
+
+		delete[] data;
+	}
+}
+
+void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
+	uint16 chunkCount = _fileStream->readUint16LE();
+
+	// Read subchunks
+	for (uint32 i = 0; i < chunkCount; ++i) {
+		uint32 frameSize = _fileStream->readUint32LE();
+		uint16 frameType = _fileStream->readUint16LE();
+		uint8 *data = new uint8[frameSize];
+		_fileStream->read(data, frameSize);
+
+		switch (frameType) {
+		case kChunkFadeIn:
+			warning("kChunkFadeIn");
+			// TODO
+			break;
+		case kChunkFadeOut:
+			warning("kChunkFadeOut");
+			// TODO
+			break;
+		case kChunkLoadMusic:
+			warning("kChunkLoadMusic");
+			// TODO
+			break;
+		case kChunkLoadRaw:
+			warning("kChunkLoadRaw");
+			// TODO
+			break;
+		case kChunkLoadVoc:
+			warning("kChunkLoadVoc");
+			// TODO
+			break;
+		case kChunkPlayMusic:
+			warning("kChunkPlayMusic");
+			break;
+		case kChunkPlaySeq:
+			warning("kChunkPlaySeq");
+			// TODO
+			break;
+		case kChunkPlayPattern:
+			warning("kChunkPlayPattern");
+			// TODO
+			break;
+		case kChunkStopMusic:
+			warning("kChunkStopMusic");
+			// TODO
+			break;
+		case kChunkWaitMusicEnd:
+			warning("kChunkWaitMusicEnd");
+			// TODO
+			break;
+		case kChunkSetMusicVolume:
+			warning("kChunkSetMusicVolume");
+			// TODO
+			break;
+		case kChunkSetLoopMode:
+			warning("kChunkSetLoopMode");
+			// TODO
+			break;
+		case kChunkPlayRaw:
+			warning("kChunkPlayRaw");
+			// TODO
+			break;
+		case kChunkPlayVoc:
+			warning("kChunkPlayVoc");
+			// TODO
+			break;
+		case kChunkSetSoundVolume:
+			warning("kChunkSetSoundVolume");
+			// TODO
+			break;
+		case kChunkSetChannelVolume:
+			warning("kChunkSetChannelVolume");
+			// TODO
+			break;
+		case kChunkFreeSoundEffect:
+			warning("kChunkFreeSoundEffect");
+			// TODO
+			break;
+		case kChunkMusicFadeIn:
+			warning("kChunkMusicFadeIn");
+			// TODO
+			break;
+		case kChunkMusicFadeOut:
+			warning("kChunkMusicFadeOut");
+			// TODO
+			break;
+		case kChunkSetStero:
+			warning("kChunkSetStero");
+			// TODO
+			break;
+		case kChunkSetSpeed:
+			warning("kChunkSetSpeed");
+			// TODO
+			break;
+		case kChunkClearScreen:
+			warning("kChunkClearScreen");
+			// TODO
+			break;
+		default:
+			error("Unknown subchunk: %d", frameType);
+			break;
+		}
+
+		delete[] data;
+	}
+}
+
+} // End of namespace Chewy

--- a/engines/chewy/video/cfo_decoder.h
+++ b/engines/chewy/video/cfo_decoder.h
@@ -23,7 +23,6 @@
 #ifndef CHEWY_VIDEO_CFO_DECODER_H
 #define CHEWY_VIDEO_CFO_DECODER_H
 
-#include "audio/mixer.h"
 #include "graphics/surface.h"
 #include "video/flic_decoder.h"
 
@@ -31,20 +30,22 @@ namespace Chewy {
 
 #define MAX_SOUND_EFFECTS 14
 
+class Sound;
+
 // A FLIC decoder, with a modified header and additional custom frames
 class CfoDecoder : public Video::FlicDecoder {
 public:
-	CfoDecoder(Audio::Mixer *mixer) : Video::FlicDecoder() { _mixer = mixer; }
+	CfoDecoder(Sound *sound) : Video::FlicDecoder(), _sound(sound) {}
 	virtual ~CfoDecoder() {}
 
 	bool loadStream(Common::SeekableReadStream *stream);
 
 private:
-	Audio::Mixer *_mixer;
+	Sound *_sound;
 
 	class CfoVideoTrack : public Video::FlicDecoder::FlicVideoTrack {
 	public:
-		CfoVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height, Audio::Mixer *mixer);
+		CfoVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height, Sound *sound);
 		virtual ~CfoVideoTrack();
 
 		void readHeader();
@@ -58,11 +59,12 @@ private:
 		void handleFrame();
 		void handleCustomFrame();
 
-		Audio::Mixer *_mixer;
-		Audio::SoundHandle _musicHandle;
-		Audio::SoundHandle _soundHandle[MAX_SOUND_EFFECTS];
+		Sound *_sound;
+
 		byte *_soundEffects[MAX_SOUND_EFFECTS];
 		uint32 _soundEffectSize[MAX_SOUND_EFFECTS];
+		byte *_musicData;
+		uint32 _musicSize;
 	};
 };
 

--- a/engines/chewy/video/cfo_decoder.h
+++ b/engines/chewy/video/cfo_decoder.h
@@ -34,15 +34,17 @@ namespace Chewy {
 // A FLIC decoder, with a modified header and additional custom frames
 class CfoDecoder : public Video::FlicDecoder {
 public:
-	CfoDecoder() : Video::FlicDecoder() {}
+	CfoDecoder(Audio::Mixer *mixer) : Video::FlicDecoder() { _mixer = mixer; }
 	virtual ~CfoDecoder() {}
 
 	bool loadStream(Common::SeekableReadStream *stream);
 
 private:
+	Audio::Mixer *_mixer;
+
 	class CfoVideoTrack : public Video::FlicDecoder::FlicVideoTrack {
 	public:
-		CfoVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height);
+		CfoVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height, Audio::Mixer *mixer);
 		virtual ~CfoVideoTrack();
 
 		void readHeader();
@@ -56,6 +58,7 @@ private:
 		void handleFrame();
 		void handleCustomFrame();
 
+		Audio::Mixer *_mixer;
 		Audio::SoundHandle _musicHandle;
 		Audio::SoundHandle _soundHandle[MAX_SOUND_EFFECTS];
 		byte *_soundEffects[MAX_SOUND_EFFECTS];

--- a/engines/chewy/video/cfo_decoder.h
+++ b/engines/chewy/video/cfo_decoder.h
@@ -20,22 +20,38 @@
  *
  */
 
-#ifndef CHEWY_GRAPHICS_H
-#define CHEWY_GRAPHICS_H
+#ifndef CHEWY_VIDEO_CFO_DECODER_H
+#define CHEWY_VIDEO_CFO_DECODER_H
 
-#include "chewy/chewy.h"
+
+#include "graphics/surface.h"
+#include "video/flic_decoder.h"
 
 namespace Chewy {
 
-class Graphics {
+// A FLIC decoder, with a modified header and additional custom frames
+class CfoDecoder : public Video::FlicDecoder {
 public:
-	Graphics() {}
-	~Graphics() {}
+	CfoDecoder() : Video::FlicDecoder() {}
+	virtual ~CfoDecoder() {}
 
-	void drawImage(Common::String filename, int imageNum);
-	void playVideo(uint num);
-private:
+	bool loadStream(Common::SeekableReadStream *stream);
 
+protected:
+	class CfoVideoTrack : public Video::FlicDecoder::FlicVideoTrack {
+	public:
+		CfoVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height);
+		~CfoVideoTrack() {}
+
+		void readHeader();
+
+		bool isRewindable() const { return false; }
+		bool rewind() { return false; }
+
+		const ::Graphics::Surface *decodeNextFrame();
+		void handleFrame();
+		void handleCustomFrame();
+	};
 };
 
 } // End of namespace Chewy

--- a/engines/chewy/video/cfo_decoder.h
+++ b/engines/chewy/video/cfo_decoder.h
@@ -29,7 +29,7 @@
 
 namespace Chewy {
 
-#define MAX_SOUND_EFFECTS 10
+#define MAX_SOUND_EFFECTS 14
 
 // A FLIC decoder, with a modified header and additional custom frames
 class CfoDecoder : public Video::FlicDecoder {

--- a/engines/chewy/video/cfo_decoder.h
+++ b/engines/chewy/video/cfo_decoder.h
@@ -23,11 +23,13 @@
 #ifndef CHEWY_VIDEO_CFO_DECODER_H
 #define CHEWY_VIDEO_CFO_DECODER_H
 
-
+#include "audio/mixer.h"
 #include "graphics/surface.h"
 #include "video/flic_decoder.h"
 
 namespace Chewy {
+
+#define MAX_SOUND_EFFECTS 10
 
 // A FLIC decoder, with a modified header and additional custom frames
 class CfoDecoder : public Video::FlicDecoder {
@@ -37,11 +39,11 @@ public:
 
 	bool loadStream(Common::SeekableReadStream *stream);
 
-protected:
+private:
 	class CfoVideoTrack : public Video::FlicDecoder::FlicVideoTrack {
 	public:
 		CfoVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height);
-		~CfoVideoTrack() {}
+		virtual ~CfoVideoTrack();
 
 		void readHeader();
 
@@ -49,8 +51,15 @@ protected:
 		bool rewind() { return false; }
 
 		const ::Graphics::Surface *decodeNextFrame();
+
+	private:
 		void handleFrame();
 		void handleCustomFrame();
+
+		Audio::SoundHandle _musicHandle;
+		Audio::SoundHandle _soundHandle[MAX_SOUND_EFFECTS];
+		byte *_soundEffects[MAX_SOUND_EFFECTS];
+		uint32 _soundEffectSize[MAX_SOUND_EFFECTS];
 	};
 };
 

--- a/engines/chewy/video/cfo_decoder.h
+++ b/engines/chewy/video/cfo_decoder.h
@@ -58,6 +58,7 @@ private:
 	private:
 		void handleFrame();
 		void handleCustomFrame();
+		void fadeOut();
 
 		Sound *_sound;
 

--- a/video/flic_decoder.h
+++ b/video/flic_decoder.h
@@ -42,6 +42,7 @@ namespace Video {
  * Decoder for FLIC videos.
  *
  * Video decoder used in engines:
+ *  - chewy
  *  - tucker
  */
 class FlicDecoder : public VideoDecoder {
@@ -49,21 +50,23 @@ public:
 	FlicDecoder();
 	virtual ~FlicDecoder();
 
-	bool loadStream(Common::SeekableReadStream *stream);
+	virtual bool loadStream(Common::SeekableReadStream *stream);
 
 	const Common::List<Common::Rect> *getDirtyRects() const;
 	void clearDirtyRects();
 	void copyDirtyRectsToBuffer(uint8 *dst, uint pitch);
 
-private:
+protected:
 	class FlicVideoTrack : public VideoTrack {
 	public:
-		FlicVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height);
+		FlicVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height, bool skipHeader = false);
 		~FlicVideoTrack();
 
+		virtual void readHeader();
+
 		bool endOfTrack() const;
-		bool isRewindable() const { return true; }
-		bool rewind();
+		virtual bool isRewindable() const { return true; }
+		virtual bool rewind();
 
 		uint16 getWidth() const;
 		uint16 getHeight() const;
@@ -71,7 +74,8 @@ private:
 		int getCurFrame() const { return _curFrame; }
 		int getFrameCount() const { return _frameCount; }
 		uint32 getNextFrameStartTime() const { return _nextFrameStartTime; }
-		const Graphics::Surface *decodeNextFrame();
+		virtual const Graphics::Surface *decodeNextFrame();
+		virtual void handleFrame();
 		const byte *getPalette() const { _dirtyPalette = false; return _palette; }
 		bool hasDirtyPalette() const { return _dirtyPalette; }
 
@@ -79,7 +83,7 @@ private:
 		void clearDirtyRects() { _dirtyRects.clear(); }
 		void copyDirtyRectsToBuffer(uint8 *dst, uint pitch);
 
-	private:
+	protected:
 		Common::SeekableReadStream *_fileStream;
 		Graphics::Surface *_surface;
 


### PR DESCRIPTION
This is pull request for the work in progress engine for Chewy: Esc from F5, as requested by @sev- :

http://www.mobygames.com/game/chewy-esc-from-f5

At the moment, the engine supports the majority of the game's resources, i.e.:
- Backgrounds
- Sprites
- Sound effects
- Speech
- Error texts
- Fonts
- Videos (custom FLIC videos, with extra functionality)
- Cursors

There are a lot of things still to be done, including:
- The game's hardcoded logic for its 4 episodes (chapters)
- Sprite animation (e.g. walking)
- Scene animations (e.g. the slime dripping in the first scene, the electricity zaps in the second one)
- Inventory handling
- ~~In-game text~~ (Implemented)
- Menus (main menu, options, in-game action menu)
- Music (custom MOD format)
