### PR TITLE
CHEWY: Add detection entries for German versions

### DIFF
--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -70,6 +70,38 @@ static const ChewyGameDescription gameDescriptions[] = {
 			GUIO1(GUIO_NONE)
 		},
 	},
+	
+	{
+		// Chewy - ESC von F5 - German
+		// The source CD-ROM has the Matrix code SONOPRESS R-7885 B
+		// Most likely a newer re-release, it contains several demos and files from 1996
+		// Provided by rootfather
+		{
+			"chewy",
+			0,
+			AD_ENTRY1s("atds.tap", "c117e884cc5b4bbe50ae1217d13916c4", 231071),
+			Common::DE_DEU,
+			Common::kPlatformDOS,
+			ADGF_NO_FLAGS,
+			GUIO1(GUIO_NONE)
+		},
+	},
+	
+	{
+		// Chewy - ESC von F5 - German
+		// The source CD-ROM has the Matrix code SONOPRESS M-2742 A
+		// CD-ROM has the label "CHEWY_V1_0"
+		// Provided by rootfather
+		{
+			"chewy",
+			0,
+			AD_ENTRY1s("atds.tap", "e22f97761c0e7772ec99660f2277b1a4", 231001),
+			Common::DE_DEU,
+			Common::kPlatformDOS,
+			ADGF_NO_FLAGS,
+			GUIO1(GUIO_NONE)
+		},
+	},
 
 	{ AD_TABLE_END_MARKER }
 };


### PR DESCRIPTION
I own two original disks of "Chewy: ESC von F5", and here are the detection entries.

The game was originally published in German, the English version followed later. Both game entries will show the first scene and the "This is a test message".