### PR TITLE
Fix some of the win32 dists file

### DIFF
--- a/dists/win32/ScummVM.iss
+++ b/dists/win32/ScummVM.iss
@@ -106,6 +106,7 @@ Source: doc/se/LasMig.txt; DestDir: {app}; Flags: ignoreversion isreadme; Langua
 Source: README-SDL.txt; DestDir: {app}; Flags: ignoreversion
 Source: scummvm.exe; DestDir: {app}; Flags: ignoreversion
 Source: SDL2.dll; DestDir: {app}; Flags: replacesameversion
+Source: WinSparkle.dll; DestDir: {app}; Flags: replacesameversion
 ;Mirgration script for saved games in Windows NT4 onwards
 Source: migration.bat; DestDir: {app}; Flags: ignoreversion; MinVersion: 0, 1
 Source: migration.txt; DestDir: {app}; Flags: ignoreversion; MinVersion: 0, 1

--- a/dists/win32/migration.txt
+++ b/dists/win32/migration.txt
@@ -1,5 +1,7 @@
 AUTHORS.txt
 COPYING.LGPL.txt
+COPYING.BSD.txt
+COPYING.FREEFONT.txt
 COPYING.txt
 COPYRIGHT.txt
 drascula.dat
@@ -16,7 +18,8 @@ README.txt
 scummclassic.zip
 scummmodern.zip
 scummvm.exe
-SDL.dll
+SDL2.dll
+WinSparkle.dll
 sky.cpt
 teenagent.dat
 migration.bat


### PR DESCRIPTION
Migrations.txt needs to list WinSparkle.dll, in addition several of the later LICENSE files were missing. The iss file needs to also deploy WinSparkle.dll.