### PR TITLE
IOS: Disable idle timer while an engine is running

### DIFF
--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -123,6 +123,9 @@ public:
 	static OSystem_iOS7 *sharedInstance();
 
 	virtual void initBackend();
+	
+	virtual void engineInit();
+	virtual void engineDone();
 
 	virtual bool hasFeature(Feature f);
 	virtual void setFeatureState(Feature f, bool enable);

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -61,6 +61,18 @@ void OSystem_iOS7::fatalError() {
 	}
 }
 
+void OSystem_iOS7::engineInit() {
+	EventsBaseBackend::engineInit();
+	// Prevent the device going to sleep during game play (and in particular cut scenes)
+	[[UIApplication sharedApplication] setIdleTimerDisabled:YES];
+}
+
+void OSystem_iOS7::engineDone() {
+	EventsBaseBackend::engineDone();
+	// Allow the device going to sleep if idle while in the Launcher
+	[[UIApplication sharedApplication] setIdleTimerDisabled:NO];
+}
+
 void OSystem_iOS7::initVideoContext() {
 	_videoContext = [[iOS7AppDelegate iPhoneView] getVideoContext];
 }


### PR DESCRIPTION
After my iPad went to sleep while I was looking at the DOTT intro cutscene I though that maybe it would be nice to disable the idle timer while an engine is running to prevent the iPad going to sleep.

The idle timer is only disabled while an engine is running. It is enabled again when returning to the launcher, so if the user doesn't do anything for a while while in the launcher, the iPad will go to sleep.

I am not sure if this is a good idea or not, so I am submitting this change as a PR.
