### PR TITLE
OSD messages from any thread

### DIFF
--- a/audio/softsynth/mt32.cpp
+++ b/audio/softsynth/mt32.cpp
@@ -42,6 +42,7 @@
 #include "common/archive.h"
 #include "common/textconsole.h"
 #include "common/translation.h"
+#include "common/osd_message_queue.h"
 
 #include "graphics/fontman.h"
 #include "graphics/surface.h"
@@ -79,7 +80,7 @@ protected:
 		error("MT32emu: Init Error - Missing PCM ROM image");
 	}
 	void showLCDMessage(const char *message) {
-		g_system->displayMessageOnOSD(message);
+		Common::OSDMessageQueue::instance().addMessage(message);
 	}
 };
 

--- a/backends/cloud/storage.cpp
+++ b/backends/cloud/storage.cpp
@@ -28,6 +28,7 @@
 #include "common/debug.h"
 #include "common/file.h"
 #include <common/translation.h>
+#include "common/osd_message_queue.h"
 
 namespace Cloud {
 
@@ -207,7 +208,7 @@ void Storage::savesSyncDefaultCallback(BoolResponse response) {
 
 	if (!response.value)
 		warning("SavesSyncRequest called success callback with `false` argument");
-	g_system->displayMessageOnOSD(_("Saved games sync complete."));
+	Common::OSDMessageQueue::instance().addMessage(_("Saved games sync complete."));
 }
 
 void Storage::savesSyncDefaultErrorCallback(Networking::ErrorResponse error) {
@@ -218,9 +219,9 @@ void Storage::savesSyncDefaultErrorCallback(Networking::ErrorResponse error) {
 	printErrorResponse(error);
 
 	if (error.interrupted)
-		g_system->displayMessageOnOSD(_("Saved games sync was cancelled."));
+		Common::OSDMessageQueue::instance().addMessage(_("Saved games sync was cancelled."));
 	else
-		g_system->displayMessageOnOSD(_("Saved games sync failed.\nCheck your Internet connection."));
+		Common::OSDMessageQueue::instance().addMessage(_("Saved games sync failed.\nCheck your Internet connection."));
 }
 
 ///// DownloadFolderRequest-related /////
@@ -328,7 +329,7 @@ void Storage::directoryDownloadedCallback(FileArrayResponse response) {
 	} else {
 		message = _("Download complete.");
 	}
-	g_system->displayMessageOnOSD(message.c_str());
+	Common::OSDMessageQueue::instance().addMessage(message.c_str());
 }
 
 void Storage::directoryDownloadedErrorCallback(Networking::ErrorResponse error) {
@@ -336,7 +337,7 @@ void Storage::directoryDownloadedErrorCallback(Networking::ErrorResponse error) 
 	_downloadFolderRequest = nullptr;
 	_runningRequestsMutex.unlock();
 
-	g_system->displayMessageOnOSD(_("Download failed."));
+	Common::OSDMessageQueue::instance().addMessage(_("Download failed."));
 }
 
 } // End of namespace Cloud

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -377,7 +377,6 @@ void OpenGLGraphicsManager::updateScreen() {
 
 #ifdef USE_OSD
 	{
-		Common::StackLock lock(_osdMutex);
 		if (_osdMessageChangeRequest) {
 			osdMessageUpdateSurface();
 		}
@@ -741,11 +740,6 @@ void OpenGLGraphicsManager::setCursorPalette(const byte *colors, uint start, uin
 
 void OpenGLGraphicsManager::displayMessageOnOSD(const char *msg) {
 #ifdef USE_OSD
-	// HACK: Actually no client code should use graphics functions from
-	// another thread. But the MT-32 emulator and network synchronization still do,
-	// thus we need to make sure this doesn't happen while a updateScreen call is done.
-	Common::StackLock lock(_osdMutex);
-
 	_osdMessageChangeRequest = true;
 
 	_osdMessageNextData = msg;

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -596,14 +596,6 @@ private:
 		kOSDIconTopMargin = 10,
 		kOSDIconRightMargin = 10
 	};
-
-	/**
-	 * Mutex for the OSD draw calls.
-	 *
-	 * Mutex to allow displayMessageOnOSD and displayActivityIconOnOSD
-	 * to be used from the audio and network threads.
-	 */
-	Common::Mutex _osdMutex;
 #endif
 };
 

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -51,6 +51,7 @@
 #include "common/textconsole.h"
 #include "common/tokenizer.h"
 #include "common/translation.h"
+#include "common/osd_message_queue.h"
 
 #include "gui/gui-manager.h"
 #include "gui/error.h"
@@ -477,6 +478,8 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	g_eventRec.RegisterEventSource();
 #endif
 
+	Common::OSDMessageQueue::instance().registerEventSource();
+
 	// Now as the event manager is created, setup the keymapper
 	setupKeymapper(system);
 
@@ -615,6 +618,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	GUI::GuiManager::destroy();
 	Common::ConfigManager::destroy();
 	Common::DebugManager::destroy();
+	Common::OSDMessageQueue::destroy();
 #ifdef ENABLE_EVENTRECORDER
 	GUI::EventRecorder::destroy();
 #endif

--- a/common/module.mk
+++ b/common/module.mk
@@ -23,6 +23,7 @@ MODULE_OBJS := \
 	memorypool.o \
 	md5.o \
 	mutex.o \
+	osd_message_queue.o \
 	platform.o \
 	quicktime.o \
 	random.o \

--- a/common/osd_message_queue.cpp
+++ b/common/osd_message_queue.cpp
@@ -28,11 +28,14 @@ namespace Common {
 DECLARE_SINGLETON(OSDMessageQueue);
 	
 OSDMessageQueue::OSDMessageQueue() : _lastUpdate(0) {
-	g_system->getEventManager()->getEventDispatcher()->registerSource(this, false);
 }
 
 OSDMessageQueue::~OSDMessageQueue() {
 	g_system->getEventManager()->getEventDispatcher()->unregisterSource(this);
+}
+	
+void OSDMessageQueue::registerEventSource() {
+	g_system->getEventManager()->getEventDispatcher()->registerSource(this, false);
 }
 	
 void OSDMessageQueue::addMessage(const char *msg) {

--- a/common/osd_message_queue.cpp
+++ b/common/osd_message_queue.cpp
@@ -1,0 +1,59 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/osd_message_queue.h"
+#include "common/system.h"
+
+namespace Common {
+
+DECLARE_SINGLETON(OSDMessageQueue);
+	
+OSDMessageQueue::OSDMessageQueue() : _lastUpdate(0) {
+	g_system->getEventManager()->getEventDispatcher()->registerSource(this, false);
+}
+
+OSDMessageQueue::~OSDMessageQueue() {
+	g_system->getEventManager()->getEventDispatcher()->unregisterSource(this);
+}
+	
+void OSDMessageQueue::addMessage(const char *msg) {
+	_mutex.lock();
+	_messages.push(msg);
+	_mutex.unlock();
+}
+
+bool OSDMessageQueue::pollEvent(Common::Event &event) {
+	_mutex.lock();
+	if (!_messages.empty()) {
+		uint t = g_system->getMillis();
+		if (t - _lastUpdate >= kMinimumDelay) {
+			_lastUpdate = t;
+			String msg = _messages.pop();
+			g_system->displayMessageOnOSD(msg.c_str());
+		}
+	}
+	_mutex.unlock();
+
+	return false;
+}
+
+} // End of namespace Common

--- a/common/osd_message_queue.h
+++ b/common/osd_message_queue.h
@@ -39,6 +39,8 @@ public:
 	OSDMessageQueue();
 	~OSDMessageQueue();
 	
+	void registerEventSource();
+	
 	enum {
 		kMinimumDelay = 1000 /** < Minimum delay between two OSD messages (in milliseconds) */
 	};

--- a/common/osd_message_queue.h
+++ b/common/osd_message_queue.h
@@ -1,0 +1,70 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef COMMON_OSD_MESSAGE_QUEUE_H
+#define COMMON_OSD_MESSAGE_QUEUE_H
+
+#include "common/events.h"
+#include "common/singleton.h"
+#include "common/str.h"
+#include "common/queue.h"
+#include "common/mutex.h"
+
+namespace Common {
+
+/**
+ * Queue OSD messages from any thread to be displayed by the graphic thread.
+ */
+class OSDMessageQueue : public Singleton<OSDMessageQueue>, public EventSource {
+public:
+	OSDMessageQueue();
+	~OSDMessageQueue();
+	
+	enum {
+		kMinimumDelay = 1000 /** < Minimum delay between two OSD messages (in milliseconds) */
+	};
+
+	/**
+	 * Add a message to the OSD message queue.
+	 */
+	void addMessage(const char *msg);
+	
+	/**
+	 * Common::EventSource interface
+	 *
+	 * The OSDMessageQueue registers itself as an event source even if it does not
+	 * actually produce events as a mean to be polled periodically by the GUI or
+	 * engine code.
+	 *
+	 * The periodical polling is used to update the OSD messages.
+	 */
+	virtual bool pollEvent(Common::Event &event) override;
+
+private:
+	Mutex _mutex;
+	Queue<String> _messages;
+	uint32 _lastUpdate;
+};
+
+} // End of namespace Common
+
+#endif


### PR DESCRIPTION
This is one attempt to fix bug #9609: SDL: Crash with displayMessageOnOSD called from separate thread in cloud code.

The OpenGL Graphics Manager was not having the issue because there was a hack to handle this case. But instead of also adding a hack to the SurfaceSDL Graphics Manager, or changing the cloud code to make sure all OSD messages are displayed from the graphics thread, I have instead added a OSD message queue class that takes messages from any thread which can then be polled by the graphics thread to be displayed.

I then modified the cloud code and MT32 code to use this new class and removed the hack from the OpenGL Graphics Manager.

I am opening this PR to get opinion on whether this is a good way to fix the issue, and also to get feedback on the actual implementation. For example I used a minimum 1s delay between messages so that each message gets displayed for at least 1s. Should we use a longer delay? Or drop messages to only display the last one when we get several messages in quick succession?