### PR TITLE
JANITORIAL: Typos found by lintian

### DIFF
--- a/engines/kyra/timer.cpp
+++ b/engines/kyra/timer.cpp
@@ -90,7 +90,7 @@ void TimerManager::reset() {
 void TimerManager::addTimer(uint8 id, TimerFunc *func, int countdown, bool enabled) {
 	Iterator timer = Common::find_if(_timers.begin(), _timers.end(), TimerEqual(id));
 	if (timer != _timers.end()) {
-		warning("Adding allready existing timer %d", id);
+		warning("Adding already existing timer %d", id);
 		return;
 	}
 

--- a/engines/lab/console.cpp
+++ b/engines/lab/console.cpp
@@ -81,7 +81,7 @@ bool Console::Cmd_DumpSceneResources(int argc, const char **argv) {
 		"ResetBuffer", "SpecialCmd", "CShowMessage", "PlaySoundNoWait"
 	};
 
-	debugPrintf("Room mesage: %s\n", roomData->_roomMsg.c_str());
+	debugPrintf("Room message: %s\n", roomData->_roomMsg.c_str());
 	debugPrintf("Transition: %s (%d)\n", transitions[roomData->_transitionType], roomData->_transitionType);
 
 	debugPrintf("Script:\n");

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -359,7 +359,7 @@ void Sound::playSound(int soundID) {
 			_currentCDSound = soundID;
 		} else {
 			// All other sound types are ignored
-			warning("Scumm::Sound::playSound: encountered audio resoure with chunk type 'SOUN' and sound type %d", type);
+			warning("Scumm::Sound::playSound: encountered audio resource with chunk type 'SOUN' and sound type %d", type);
 		}
 	}
 	else if ((_vm->_game.platform == Common::kPlatformMacintosh) && (_vm->_game.id == GID_INDY3) && READ_BE_UINT16(ptr + 8) == 0x1C) {

--- a/graphics/fonts/bdf.cpp
+++ b/graphics/fonts/bdf.cpp
@@ -702,7 +702,7 @@ BdfFont *BdfFont::loadFromCache(Common::SeekableReadStream &stream) {
 
 BdfFont *BdfFont::scaleFont(BdfFont *src, int newSize) {
 	if (!src) {
-		warning("Emtpy font reference in scale font");
+		warning("Empty font reference in scale font");
 		return NULL;
 	}
 


### PR DESCRIPTION
I've not fixed this one, maybe it's on purpose:

RELASE -> RELEASE

engines/mads/staticres.cpp:const char *const kGameReleaseTitleStr =
"GAME RELASE VERSION INFO";