### PR TITLE
I18N: Update/add POTFILES, enable some more strings for translation

### DIFF
--- a/engines/gnap/POTFILES
+++ b/engines/gnap/POTFILES
@@ -1,0 +1,1 @@
+engines/gnap/menu.cpp

--- a/engines/kyra/POTFILES
+++ b/engines/kyra/POTFILES
@@ -1,4 +1,5 @@
 engines/kyra/detection.cpp
+engines/kyra/eobcommon.cpp
 engines/kyra/lol.cpp
 engines/kyra/sound_midi.cpp
 engines/kyra/saveload_eob.cpp

--- a/engines/mads/POTFILES
+++ b/engines/mads/POTFILES
@@ -1,1 +1,2 @@
 engines/mads/detection.cpp
+engines/mads/nebular/dialogs_nebular.cpp

--- a/engines/sci/POTFILES
+++ b/engines/sci/POTFILES
@@ -1,2 +1,3 @@
 engines/sci/detection.cpp
 engines/sci/engine/kfile.cpp
+engines/sci/graphics/controls32.cpp

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -1117,10 +1117,10 @@ Common::Error ScummMetaEngine::createInstance(OSystem *syst, Engine **engine) co
 	if (!findInMD5Table(res.md5.c_str())) {
 		Common::String md5Warning;
 
-		md5Warning = "Your game version appears to be unknown. If this is *NOT* a fan-modified\n";
-		md5Warning += "version (in particular, not a fan-made translation), please, report the\n";
-		md5Warning += "following data to the ScummVM team along with name of the game you tried\n";
-		md5Warning += "to add and its version/language/etc.:\n";
+		md5Warning = _("Your game version appears to be unknown. If this is *NOT* a fan-modified\n"
+		               "version (in particular, not a fan-made translation), please, report the\n"
+		               "following data to the ScummVM team along with name of the game you tried\n"
+		               "to add and its version/language/etc.:\n");
 
 		md5Warning += Common::String::format("  SCUMM gameid '%s', file '%s', MD5 '%s'\n\n",
 				res.game.gameid,
@@ -1135,8 +1135,8 @@ Common::Error ScummMetaEngine::createInstance(OSystem *syst, Engine **engine) co
 	// We don't support the "Lite" version off puttzoo iOS because it contains
 	// the full game.
 	if (!strcmp(res.game.gameid, "puttzoo") && !strcmp(res.extra, "Lite")) {
-		GUIErrorMessage("The Lite version of Putt-Putt Saves the Zoo iOS is not supported to avoid piracy.\n"
-		                "The full version is available for purchase from the iTunes Store.");
+		GUIErrorMessage(_("The Lite version of Putt-Putt Saves the Zoo iOS is not supported to avoid piracy.\n"
+		                  "The full version is available for purchase from the iTunes Store."));
 		return Common::kUnsupportedGameidError;
 	}
 

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -219,11 +219,11 @@ void ToonEngine::parseInput() {
 				if (slotNum >= 0 && slotNum <= 9 && canSaveGameStateCurrently()) {
 					if (saveGame(slotNum, "")) {
 						// ok
-						Common::String buf = Common::String::format("Saved game in slot #%d ", slotNum);
+						Common::String buf = Common::String::format(_("Saved game in slot #%d "), slotNum);
 						GUI::TimedMessageDialog dialog(buf, 1000);
 						dialog.runModal();
 					} else {
-						Common::String buf = Common::String::format("Could not quick save into slot #%d", slotNum);
+						Common::String buf = Common::String::format(_("Could not quick save into slot #%d"), slotNum);
 						GUI::MessageDialog dialog(buf, "OK", 0);
 						dialog.runModal();
 
@@ -236,11 +236,11 @@ void ToonEngine::parseInput() {
 				if (slotNum >= 0 && slotNum <= 9 && canLoadGameStateCurrently()) {
 					if (loadGame(slotNum)) {
 						// ok
-						Common::String buf = Common::String::format("Savegame #%d quick loaded", slotNum);
+						Common::String buf = Common::String::format(_("Savegame #%d quick loaded"), slotNum);
 						GUI::TimedMessageDialog dialog(buf, 1000);
 						dialog.runModal();
 					} else {
-						Common::String buf = Common::String::format("Could not quick load the savegame #%d", slotNum);
+						Common::String buf = Common::String::format(_("Could not quick load the savegame #%d"), slotNum);
 						GUI::MessageDialog dialog(buf, "OK", 0);
 						warning("%s", buf.c_str());
 						dialog.runModal();
@@ -4914,7 +4914,7 @@ bool ToonEngine::loadToonDat() {
 	in.open("toon.dat");
 
 	if (!in.isOpen()) {
-		msg = "You're missing the 'toon.dat' file. Get it from the ScummVM website";
+		msg = _("You're missing the 'toon.dat' file. Get it from the ScummVM website");
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -4926,7 +4926,7 @@ bool ToonEngine::loadToonDat() {
 	buf[4] = '\0';
 
 	if (strcmp(buf, "TOON")) {
-		msg = "File 'toon.dat' is corrupt. Get it from the ScummVM website";
+		msg = _("File 'toon.dat' is corrupt. Get it from the ScummVM website");
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -4936,7 +4936,7 @@ bool ToonEngine::loadToonDat() {
 	minVer = in.readByte();
 
 	if ((majVer != TOON_DAT_VER_MAJ) || (minVer != TOON_DAT_VER_MIN)) {
-		msg = Common::String::format("File 'toon.dat' is wrong version. Expected %d.%d but got %d.%d. Get it from the ScummVM website", TOON_DAT_VER_MAJ, TOON_DAT_VER_MIN, majVer, minVer);
+		msg = Common::String::format(_("File 'toon.dat' is wrong version. Expected %d.%d but got %d.%d. Get it from the ScummVM website"), TOON_DAT_VER_MAJ, TOON_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 

--- a/engines/wage/POTFILES
+++ b/engines/wage/POTFILES
@@ -1,0 +1,1 @@
+engines/wage/saveload.cpp

--- a/engines/zvision/POTFILES
+++ b/engines/zvision/POTFILES
@@ -1,1 +1,2 @@
 engines/zvision/detection_tables.h
+engines/zvision/file/save_manager.cpp

--- a/engines/zvision/file/save_manager.cpp
+++ b/engines/zvision/file/save_manager.cpp
@@ -217,11 +217,11 @@ bool SaveManager::readSaveGameHeader(Common::InSaveFile *in, SaveGameHeader &hea
 		uint tempVersion = header.version;
 		GUI::MessageDialog dialog(
 			Common::String::format(
-				"This save file uses version %u, but this engine only "
-				"supports up to version %d. You will need an updated version "
-				"of the engine to use this save file.", tempVersion, SAVE_VERSION
+				_("This save file uses version %u, but this engine only "
+				  "supports up to version %d. You will need an updated version "
+				  "of the engine to use this save file."), tempVersion, SAVE_VERSION
 			),
-		"OK");
+		_("OK"));
 		dialog.runModal();
 	}
 


### PR DESCRIPTION
This PR adds and updates some POTFILES, mostly for consistency purposes. Besides that, a few strings were added to translation. I also enabled translation for the "unknown game warning" in the SCUMM engine - we have it enabled in advancedDetector.cpp since ages.

Let me know if I did something wrong 👍 