### PR TITLE
CONFIGURE: Allow ppc as alias for powerpc

### DIFF
--- a/configure
+++ b/configure
@@ -2167,7 +2167,7 @@ cc_check_clean tmp_find_type_with_size.cpp
 # for the smaller sizes.
 echo_n "Alignment required... "
 case $_host_cpu in
-	i[3-6]86 | amd64 | x86_64 | powerpc*)
+	i[3-6]86 | amd64 | x86_64 | powerpc* | ppc*)
 		# Unaligned access should work
 		_need_memalign=no
 		;;
@@ -2228,7 +2228,7 @@ case $_host_cpu in
 		echo "MIPS"
 		append_var DEFINES "-DMIPS_TARGET"
 		;;
-	powerpc*)
+	powerpc* | ppc*)
 		echo "PowerPC"
 		append_var DEFINES "-DPPC_TARGET"
 		;;


### PR DESCRIPTION
OpenBSD, for example, uses ppc instead of powerpc.

This lets OpenBSD/macppc use ``_need_memalign=no``.

A similar fix, for amd64/x86_64, was commited in ed53292194682fb2ebc0d5a7ecd23e482899aefc.