### PR TITLE
ALL: Unify messages concerning engine data files

### DIFF
--- a/README
+++ b/README
@@ -1742,6 +1742,28 @@ Broken Sword
     cz  - Czech
 
 
+5.6) Common issues:
+---- --------------
+"Engine data file missing/corrupt/wrong version"
+
+Some engines require some additional data (besides the game itself) to run
+a game. This data usually is included in the ScummVM installation package to
+ensure you always have the right version. But if for some reason you get an
+error about the engine data file, here are a few things you can try:
+
+- (Re)download and install the latest version of ScummVM package
+Because the package should contain the required data, this should fix it.
+
+- Download the engine data file manually from github
+On https://github.com/scummvm/scummvm/blob/master/dists/engine-data/ you can
+find the latest versions of all engine data files.
+
+- Check your path settings
+ScummVM will scan it's own directory and the Extra Path directory for the
+engine data files. Try moving the engine data file into those one of those
+directories.
+
+
 6.0) Saved Games:
 ---- ----------
 Saved games are by default put in the current directory on some platforms

--- a/README
+++ b/README
@@ -52,6 +52,7 @@ Table of Contents:
  * 5.3 Graphics Filters
  * 5.4 Hotkeys
  * 5.5 Language Options
+ * 5.6 Common issues
 6.0) Saved Games
  * 6.1 Autosaves
  * 6.2 Converting saved games

--- a/README
+++ b/README
@@ -52,7 +52,6 @@ Table of Contents:
  * 5.3 Graphics Filters
  * 5.4 Hotkeys
  * 5.5 Language Options
- * 5.6 Common issues
 6.0) Saved Games
  * 6.1 Autosaves
  * 6.2 Converting saved games
@@ -1741,28 +1740,6 @@ Broken Sword
     es  - Spanish
     pt  - Portuguese
     cz  - Czech
-
-
-5.6) Common issues:
----- --------------
-"Engine data file missing/corrupt/wrong version"
-
-Some engines require some additional data (besides the game itself) to run
-a game. This data usually is included in the ScummVM installation package to
-ensure you always have the right version. But if for some reason you get an
-error about the engine data file, here are a few things you can try:
-
-- (Re)download and install the latest version of ScummVM package
-Because the package should contain the required data, this should fix it.
-
-- Download the engine data file manually from github
-On https://github.com/scummvm/scummvm/blob/master/dists/engine-data/ you can
-find the latest versions of all engine data files.
-
-- Check your path settings
-ScummVM will scan it's own directory and the Extra Path directory for the
-engine data files. Try moving the engine data file into those one of those
-directories.
 
 
 6.0) Saved Games:

--- a/engines/access/POTFILES
+++ b/engines/access/POTFILES
@@ -1,0 +1,1 @@
+engines/access/resources.cpp

--- a/engines/access/resources.cpp
+++ b/engines/access/resources.cpp
@@ -41,7 +41,7 @@ bool Resources::load(Common::String &errorMessage) {
 	Common::File f;
 	Common::String filename = "access.dat";
 	if (!f.open(filename.c_str())) {
-		errorMessage = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
+		errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
 		return false;
 	}
 
@@ -49,7 +49,7 @@ bool Resources::load(Common::String &errorMessage) {
 	char buffer[4];
 	f.read(buffer, 4);
 	if (strncmp(buffer, "SVMA", 4)) {
-		errorMessage = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
+		errorMessage = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
 		return false;
 	}
 
@@ -58,7 +58,7 @@ bool Resources::load(Common::String &errorMessage) {
 	uint version = f.readUint16LE();
 	if (version != expectedVersion) {
 		errorMessage = Common::String::format(
-			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
 			filename.c_str(), expectedVersion, 0, version, 0);
 		return false;
 	}

--- a/engines/access/resources.cpp
+++ b/engines/access/resources.cpp
@@ -24,6 +24,7 @@
 #include "access/access.h"
 #include "access/amazon/amazon_resources.h"
 #include "access/martian/martian_resources.h"
+#include "common/translation.h"
 
 namespace Access {
 
@@ -38,8 +39,9 @@ Resources *Resources::init(AccessEngine *vm) {
 
 bool Resources::load(Common::String &errorMessage) {
 	Common::File f;
-	if (!f.open("access.dat")) {
-		errorMessage = "Could not locate required access.dat file";
+	Common::String filename = "access.dat";
+	if (!f.open(filename.c_str())) {
+		errorMessage = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
 		return false;
 	}
 

--- a/engines/access/resources.cpp
+++ b/engines/access/resources.cpp
@@ -49,7 +49,7 @@ bool Resources::load(Common::String &errorMessage) {
 	char buffer[4];
 	f.read(buffer, 4);
 	if (strncmp(buffer, "SVMA", 4)) {
-		errorMessage = "Located access.dat file had invalid contents";
+		errorMessage = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
 		return false;
 	}
 

--- a/engines/access/resources.cpp
+++ b/engines/access/resources.cpp
@@ -58,8 +58,8 @@ bool Resources::load(Common::String &errorMessage) {
 	uint version = f.readUint16LE();
 	if (version != expectedVersion) {
 		errorMessage = Common::String::format(
-			"Incorrect version of access.dat found. Expected %d but got %d",
-			expectedVersion, version);
+			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			filename.c_str(), expectedVersion, 0, version, 0);
 		return false;
 	}
 

--- a/engines/access/resources.cpp
+++ b/engines/access/resources.cpp
@@ -41,7 +41,7 @@ bool Resources::load(Common::String &errorMessage) {
 	Common::File f;
 	Common::String filename = "access.dat";
 	if (!f.open(filename.c_str())) {
-		errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
+		errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file."), filename.c_str());
 		return false;
 	}
 
@@ -49,7 +49,7 @@ bool Resources::load(Common::String &errorMessage) {
 	char buffer[4];
 	f.read(buffer, 4);
 	if (strncmp(buffer, "SVMA", 4)) {
-		errorMessage = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
+		errorMessage = Common::String::format(_("The '%s' engine data file is corrupt."), filename.c_str());
 		return false;
 	}
 
@@ -58,7 +58,7 @@ bool Resources::load(Common::String &errorMessage) {
 	uint version = f.readUint16LE();
 	if (version != expectedVersion) {
 		errorMessage = Common::String::format(
-			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d."),
 			filename.c_str(), expectedVersion, 0, version, 0);
 		return false;
 	}

--- a/engines/drascula/POTFILES
+++ b/engines/drascula/POTFILES
@@ -1,2 +1,3 @@
+engines/drascula/drascula.cpp
 engines/drascula/detection.cpp
 engines/drascula/saveload.cpp

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -976,7 +976,7 @@ bool DrasculaEngine::loadDrasculaDat() {
 	buf[8] = '\0';
 
 	if (strcmp(buf, "DRASCULA") != 0) {
-		Common::String errorMessage = "File 'drascula.dat' is corrupt. Get it from the ScummVM website";
+		Common::String errorMessage = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -25,6 +25,7 @@
 #include "common/file.h"
 #include "common/config-manager.h"
 #include "common/textconsole.h"
+#include "common/translation.h"
 
 #include "backends/audiocd/audiocd.h"
 
@@ -955,12 +956,13 @@ void DrasculaEngine::hipo_sin_nadie(int counter){
 
 bool DrasculaEngine::loadDrasculaDat() {
 	Common::File in;
+	Common::String filename = "drascula.dat";
 	int i;
 
-	in.open("drascula.dat");
+	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		Common::String errorMessage = "You're missing the 'drascula.dat' file. Get it from the ScummVM website";
+		Common::String errorMessage = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -962,7 +962,7 @@ bool DrasculaEngine::loadDrasculaDat() {
 	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file."), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 
@@ -976,7 +976,7 @@ bool DrasculaEngine::loadDrasculaDat() {
 	buf[8] = '\0';
 
 	if (strcmp(buf, "DRASCULA") != 0) {
-		Common::String errorMessage = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("The '%s' engine data file is corrupt."), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 
@@ -987,7 +987,7 @@ bool DrasculaEngine::loadDrasculaDat() {
 
 	if (ver != DRASCULA_DAT_VER) {
 		Common::String errorMessage = Common::String::format(
-			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d."),
 			filename.c_str(), DRASCULA_DAT_VER, 0, ver, 0);
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -986,7 +986,9 @@ bool DrasculaEngine::loadDrasculaDat() {
 	ver = in.readByte();
 
 	if (ver != DRASCULA_DAT_VER) {
-		Common::String errorMessage = Common::String::format("File 'drascula.dat' is wrong version. Expected %d but got %d. Get it from the ScummVM website", DRASCULA_DAT_VER, ver);
+		Common::String errorMessage = Common::String::format(
+			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			filename.c_str(), DRASCULA_DAT_VER, 0, ver, 0);
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -962,7 +962,7 @@ bool DrasculaEngine::loadDrasculaDat() {
 	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		Common::String errorMessage = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 
@@ -976,7 +976,7 @@ bool DrasculaEngine::loadDrasculaDat() {
 	buf[8] = '\0';
 
 	if (strcmp(buf, "DRASCULA") != 0) {
-		Common::String errorMessage = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 
@@ -987,7 +987,7 @@ bool DrasculaEngine::loadDrasculaDat() {
 
 	if (ver != DRASCULA_DAT_VER) {
 		Common::String errorMessage = Common::String::format(
-			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
 			filename.c_str(), DRASCULA_DAT_VER, 0, ver, 0);
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());

--- a/engines/hugo/POTFILES
+++ b/engines/hugo/POTFILES
@@ -1,1 +1,2 @@
+engines/hugo/hugo.cpp
 engines/hugo/file.cpp

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -454,7 +454,9 @@ bool HugoEngine::loadHugoDat() {
 	int minVer = in.readByte();
 
 	if ((majVer != HUGO_DAT_VER_MAJ) || (minVer != HUGO_DAT_VER_MIN)) {
-		Common::String errorMessage = Common::String::format("File 'hugo.dat' is wrong version. Expected %d.%d but got %d.%d. Get it from the ScummVM website", HUGO_DAT_VER_MAJ, HUGO_DAT_VER_MIN, majVer, minVer);
+		Common::String errorMessage = Common::String::format(
+			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			filename.c_str(),HUGO_DAT_VER_MAJ, HUGO_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(errorMessage);
 		return false;
 	}

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -434,7 +434,7 @@ bool HugoEngine::loadHugoDat() {
 	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file."), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 		return false;
@@ -445,7 +445,7 @@ bool HugoEngine::loadHugoDat() {
 	in.read(buf, 4);
 
 	if (memcmp(buf, "HUGO", 4)) {
-		Common::String errorMessage = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("The '%s' engine data file is corrupt."), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		return false;
 	}
@@ -455,7 +455,7 @@ bool HugoEngine::loadHugoDat() {
 
 	if ((majVer != HUGO_DAT_VER_MAJ) || (minVer != HUGO_DAT_VER_MIN)) {
 		Common::String errorMessage = Common::String::format(
-			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d."),
 			filename.c_str(),HUGO_DAT_VER_MAJ, HUGO_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(errorMessage);
 		return false;

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -27,6 +27,7 @@
 #include "common/debug-channels.h"
 #include "common/config-manager.h"
 #include "common/textconsole.h"
+#include "common/translation.h"
 
 #include "hugo/hugo.h"
 #include "hugo/console.h"
@@ -429,10 +430,11 @@ void HugoEngine::runMachine() {
  */
 bool HugoEngine::loadHugoDat() {
 	Common::File in;
-	in.open("hugo.dat");
+	Common::String filename = "hugo.dat";
+	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		Common::String errorMessage = "You're missing the 'hugo.dat' file. Get it from the ScummVM website";
+		Common::String errorMessage = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 		return false;

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -434,7 +434,7 @@ bool HugoEngine::loadHugoDat() {
 	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		Common::String errorMessage = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		warning("%s", errorMessage.c_str());
 		return false;
@@ -445,7 +445,7 @@ bool HugoEngine::loadHugoDat() {
 	in.read(buf, 4);
 
 	if (memcmp(buf, "HUGO", 4)) {
-		Common::String errorMessage = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		return false;
 	}
@@ -455,7 +455,7 @@ bool HugoEngine::loadHugoDat() {
 
 	if ((majVer != HUGO_DAT_VER_MAJ) || (minVer != HUGO_DAT_VER_MIN)) {
 		Common::String errorMessage = Common::String::format(
-			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
 			filename.c_str(),HUGO_DAT_VER_MAJ, HUGO_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(errorMessage);
 		return false;

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -445,7 +445,7 @@ bool HugoEngine::loadHugoDat() {
 	in.read(buf, 4);
 
 	if (memcmp(buf, "HUGO", 4)) {
-		Common::String errorMessage = "File 'hugo.dat' is corrupt. Get it from the ScummVM website";
+		Common::String errorMessage = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
 		GUIErrorMessage(errorMessage);
 		return false;
 	}

--- a/engines/kyra/staticres.cpp
+++ b/engines/kyra/staticres.cpp
@@ -161,7 +161,7 @@ bool StaticResource::loadStaticResourceFile() {
 	}
 
 	if (!foundWorkingKyraDat) {
-		Common::String errorMessage = "You're missing the '" + StaticResource::staticDataFilename() + "' file or it got corrupted, (re)get it from the ScummVM website";
+		Common::String errorMessage = "You're missing the '" + StaticResource::staticDataFilename() + "' engine data file or it got corrupted. Read the README for instructions.";
 		GUIErrorMessage(errorMessage);
 		error("%s", errorMessage.c_str());
 	}

--- a/engines/kyra/staticres.cpp
+++ b/engines/kyra/staticres.cpp
@@ -161,7 +161,7 @@ bool StaticResource::loadStaticResourceFile() {
 	}
 
 	if (!foundWorkingKyraDat) {
-		Common::String errorMessage = "You're missing the '" + StaticResource::staticDataFilename() + "' engine data file or it got corrupted. Read the README for instructions.";
+		Common::String errorMessage = "You're missing the '" + StaticResource::staticDataFilename() + "' engine data file or it got corrupted.";
 		GUIErrorMessage(errorMessage);
 		error("%s", errorMessage.c_str());
 	}

--- a/engines/lure/POTFILES
+++ b/engines/lure/POTFILES
@@ -1,0 +1,1 @@
+engines/lure/lure.cpp

--- a/engines/lure/lure.cpp
+++ b/engines/lure/lure.cpp
@@ -61,7 +61,7 @@ Common::Error LureEngine::init() {
 	Common::File f;
 	VersionStructure version;
 	if (!f.open(SUPPORT_FILENAME)) {
-		GUIError(_("Unable to locate the '%s' engine data file. Read the README for instructions."), SUPPORT_FILENAME);
+		GUIError(_("Unable to locate the '%s' engine data file."), SUPPORT_FILENAME);
 		return Common::kUnknownError;
 	}
 
@@ -70,10 +70,10 @@ Common::Error LureEngine::init() {
 	f.close();
 
 	if (READ_LE_UINT16(&version.id) != 0xffff) {
-		GUIError(_("The '%s' engine data file is corrupt. Read the README for instructions."), SUPPORT_FILENAME);
+		GUIError(_("The '%s' engine data file is corrupt."), SUPPORT_FILENAME);
 		return Common::kUnknownError;
 	} else if ((version.vMajor != LURE_DAT_MAJOR) || (version.vMinor != LURE_DAT_MINOR)) {
-		GUIError(_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
+		GUIError(_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d."),
 			SUPPORT_FILENAME, LURE_DAT_MAJOR, LURE_DAT_MINOR,
 			version.vMajor, version.vMinor);
 		return Common::kUnknownError;

--- a/engines/lure/lure.cpp
+++ b/engines/lure/lure.cpp
@@ -61,7 +61,7 @@ Common::Error LureEngine::init() {
 	Common::File f;
 	VersionStructure version;
 	if (!f.open(SUPPORT_FILENAME)) {
-		GUIError(_("You're missing the '%s' file. Get it from the ScummVM website"), SUPPORT_FILENAME);
+		GUIError(_("Unable to locate the '%s' engine data file. Read the README for instructions."), SUPPORT_FILENAME);
 		return Common::kUnknownError;
 	}
 
@@ -70,10 +70,10 @@ Common::Error LureEngine::init() {
 	f.close();
 
 	if (READ_LE_UINT16(&version.id) != 0xffff) {
-		GUIError(_("File '%s' is corrupt. Get it from the ScummVM website"), SUPPORT_FILENAME);
+		GUIError(_("The '%s' engine data file is corrupt. Read the README for instructions."), SUPPORT_FILENAME);
 		return Common::kUnknownError;
 	} else if ((version.vMajor != LURE_DAT_MAJOR) || (version.vMinor != LURE_DAT_MINOR)) {
-		GUIError(_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+		GUIError(_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
 			SUPPORT_FILENAME, LURE_DAT_MAJOR, LURE_DAT_MINOR,
 			version.vMajor, version.vMinor);
 		return Common::kUnknownError;

--- a/engines/lure/lure.cpp
+++ b/engines/lure/lure.cpp
@@ -70,7 +70,7 @@ Common::Error LureEngine::init() {
 	f.close();
 
 	if (READ_LE_UINT16(&version.id) != 0xffff) {
-		GUIError("Error validating %s - file is invalid or out of date", SUPPORT_FILENAME);
+		GUIError(_("File '%s' is corrupt. Get it from the ScummVM website"), SUPPORT_FILENAME);
 		return Common::kUnknownError;
 	} else if ((version.vMajor != LURE_DAT_MAJOR) || (version.vMinor != LURE_DAT_MINOR)) {
 		GUIError("Incorrect version of %s file - expected %d.%d but got %d.%d",

--- a/engines/lure/lure.cpp
+++ b/engines/lure/lure.cpp
@@ -24,6 +24,7 @@
 #include "common/debug-channels.h"
 #include "common/system.h"
 #include "common/savefile.h"
+#include "common/translation.h"
 
 #include "engines/util.h"
 
@@ -60,7 +61,7 @@ Common::Error LureEngine::init() {
 	Common::File f;
 	VersionStructure version;
 	if (!f.open(SUPPORT_FILENAME)) {
-		GUIError("Could not locate Lure support file");
+		GUIError(_("You're missing the '%s' file. Get it from the ScummVM website"), SUPPORT_FILENAME);
 		return Common::kUnknownError;
 	}
 

--- a/engines/lure/lure.cpp
+++ b/engines/lure/lure.cpp
@@ -73,7 +73,7 @@ Common::Error LureEngine::init() {
 		GUIError(_("File '%s' is corrupt. Get it from the ScummVM website"), SUPPORT_FILENAME);
 		return Common::kUnknownError;
 	} else if ((version.vMajor != LURE_DAT_MAJOR) || (version.vMinor != LURE_DAT_MINOR)) {
-		GUIError("Incorrect version of %s file - expected %d.%d but got %d.%d",
+		GUIError(_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
 			SUPPORT_FILENAME, LURE_DAT_MAJOR, LURE_DAT_MINOR,
 			version.vMajor, version.vMinor);
 		return Common::kUnknownError;

--- a/engines/mortevielle/POTFILES
+++ b/engines/mortevielle/POTFILES
@@ -1,0 +1,1 @@
+engines/mortevielle/mortevielle.cpp

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -303,7 +303,7 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 
 	// Open the mort.dat file
 	if (!f.open(MORT_DAT)) {
-		Common::String msg = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), MORT_DAT);
+		Common::String msg = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), MORT_DAT);
 		GUIErrorMessage(msg);
 		return Common::kReadingFailed;
 	}
@@ -312,7 +312,7 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 	char fileId[4];
 	f.read(fileId, 4);
 	if (strncmp(fileId, "MORT", 4) != 0) {
-		Common::String msg = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), MORT_DAT);
+		Common::String msg = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), MORT_DAT);
 		GUIErrorMessage(msg);
 		return Common::kReadingFailed;
 	}
@@ -323,7 +323,7 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 
 	if (majVer < MORT_DAT_REQUIRED_VERSION) {
 		Common::String msg = Common::String::format(
-			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
 			MORT_DAT, MORT_DAT_REQUIRED_VERSION, 0, majVer, minVer);
 		GUIErrorMessage(msg);
 		return Common::kReadingFailed;

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -318,11 +318,16 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 	}
 
 	// Check the version
-	if (f.readByte() < MORT_DAT_REQUIRED_VERSION) {
-		GUIErrorMessage("The located mort.dat data file is too old, please download an updated version on scummvm.org");
+	int majVer = f.readByte();
+	int minVer = f.readByte();
+
+	if (majVer < MORT_DAT_REQUIRED_VERSION) {
+		Common::String msg = Common::String::format(
+			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			MORT_DAT, MORT_DAT_REQUIRED_VERSION, 0, majVer, minVer);
+		GUIErrorMessage(msg);
 		return Common::kReadingFailed;
 	}
-	f.readByte();		// Minor version
 
 	// Loop to load resources from the data file
 	while (f.pos() < f.size()) {

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -37,6 +37,7 @@
 #include "common/system.h"
 #include "common/config-manager.h"
 #include "common/debug-channels.h"
+#include "common/translation.h"
 #include "engines/util.h"
 #include "engines/engine.h"
 #include "graphics/palette.h"
@@ -302,7 +303,8 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 
 	// Open the mort.dat file
 	if (!f.open(MORT_DAT)) {
-		GUIErrorMessage("Could not locate 'mort.dat'.");
+		Common::String msg = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), MORT_DAT);
+		GUIErrorMessage(msg);
 		return Common::kReadingFailed;
 	}
 

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -312,7 +312,8 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 	char fileId[4];
 	f.read(fileId, 4);
 	if (strncmp(fileId, "MORT", 4) != 0) {
-		GUIErrorMessage("The located mort.dat data file is invalid");
+		Common::String msg = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), MORT_DAT);
+		GUIErrorMessage(msg);
 		return Common::kReadingFailed;
 	}
 

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -303,7 +303,7 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 
 	// Open the mort.dat file
 	if (!f.open(MORT_DAT)) {
-		Common::String msg = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), MORT_DAT);
+		Common::String msg = Common::String::format(_("Unable to locate the '%s' engine data file."), MORT_DAT);
 		GUIErrorMessage(msg);
 		return Common::kReadingFailed;
 	}
@@ -312,7 +312,7 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 	char fileId[4];
 	f.read(fileId, 4);
 	if (strncmp(fileId, "MORT", 4) != 0) {
-		Common::String msg = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), MORT_DAT);
+		Common::String msg = Common::String::format(_("The '%s' engine data file is corrupt."), MORT_DAT);
 		GUIErrorMessage(msg);
 		return Common::kReadingFailed;
 	}
@@ -323,7 +323,7 @@ Common::ErrorCode MortevielleEngine::loadMortDat() {
 
 	if (majVer < MORT_DAT_REQUIRED_VERSION) {
 		Common::String msg = Common::String::format(
-			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d."),
 			MORT_DAT, MORT_DAT_REQUIRED_VERSION, 0, majVer, minVer);
 		GUIErrorMessage(msg);
 		return Common::kReadingFailed;

--- a/engines/sky/compact.cpp
+++ b/engines/sky/compact.cpp
@@ -128,7 +128,7 @@ SkyCompact::SkyCompact() {
 	_cptFile = new Common::File();
 	Common::String filename = "sky.cpt";
 	if (!_cptFile->open(filename.c_str())) {
-                Common::String msg = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
+                Common::String msg = Common::String::format(_("Unable to locate the '%s' engine data file."), filename.c_str());
                 GUIErrorMessage(msg);
                 error("%s", msg.c_str());
 	}
@@ -138,7 +138,7 @@ SkyCompact::SkyCompact() {
 		error("unknown \"sky.cpt\" version");
 
 	if (SKY_CPT_SIZE != _cptFile->size()) {
-		GUI::MessageDialog dialog(_("The \"sky.cpt\" file has an incorrect size.\nPlease (re)download it from www.scummvm.org"), _("OK"), NULL);
+		GUI::MessageDialog dialog(_("The \"sky.cpt\" engine data file has an incorrect size."), _("OK"), NULL);
 		dialog.runModal();
 		error("Incorrect sky.cpt size (%d, expected: %d)", _cptFile->size(), SKY_CPT_SIZE);
 	}

--- a/engines/sky/compact.cpp
+++ b/engines/sky/compact.cpp
@@ -126,11 +126,11 @@ static const uint32 turnTableOffsets[] = {
 
 SkyCompact::SkyCompact() {
 	_cptFile = new Common::File();
-	if (!_cptFile->open("sky.cpt")) {
-		GUI::MessageDialog dialog(_("Unable to find \"sky.cpt\" file!\n"
-								  "Please download it from www.scummvm.org"), _("OK"), NULL);
-		dialog.runModal();
-		error("Unable to find \"sky.cpt\" file\nPlease download it from www.scummvm.org");
+	Common::String filename = "sky.cpt";
+	if (!_cptFile->open(filename.c_str())) {
+                Common::String msg = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
+                GUIErrorMessage(msg);
+                error("%s", msg.c_str());
 	}
 
 	uint16 fileVersion = _cptFile->readUint16LE();

--- a/engines/sky/compact.cpp
+++ b/engines/sky/compact.cpp
@@ -128,7 +128,7 @@ SkyCompact::SkyCompact() {
 	_cptFile = new Common::File();
 	Common::String filename = "sky.cpt";
 	if (!_cptFile->open(filename.c_str())) {
-                Common::String msg = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
+                Common::String msg = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
                 GUIErrorMessage(msg);
                 error("%s", msg.c_str());
 	}

--- a/engines/teenagent/resources.cpp
+++ b/engines/teenagent/resources.cpp
@@ -94,7 +94,7 @@ bool Resources::loadArchives(const ADGameDescription *gd) {
 	Common::String filename = "teenagent.dat";
 	if (!dat_file->open(filename.c_str())) {
 		delete dat_file;
-		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file."), filename.c_str());
 		warning("%s", errorMessage.c_str());
 		GUIErrorMessage(errorMessage);
 		return false;

--- a/engines/teenagent/resources.cpp
+++ b/engines/teenagent/resources.cpp
@@ -94,7 +94,7 @@ bool Resources::loadArchives(const ADGameDescription *gd) {
 	Common::String filename = "teenagent.dat";
 	if (!dat_file->open(filename.c_str())) {
 		delete dat_file;
-		Common::String errorMessage = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
+		Common::String errorMessage = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
 		warning("%s", errorMessage.c_str());
 		GUIErrorMessage(errorMessage);
 		return false;

--- a/engines/teenagent/resources.cpp
+++ b/engines/teenagent/resources.cpp
@@ -91,9 +91,10 @@ void Resources::precomputeDialogOffsets() {
 
 bool Resources::loadArchives(const ADGameDescription *gd) {
 	Common::File *dat_file = new Common::File();
-	if (!dat_file->open("teenagent.dat")) {
+	Common::String filename = "teenagent.dat";
+	if (!dat_file->open(filename.c_str())) {
 		delete dat_file;
-		Common::String errorMessage = _("You're missing the 'teenagent.dat' file. Get it from the ScummVM website");
+		Common::String errorMessage = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
 		warning("%s", errorMessage.c_str());
 		GUIErrorMessage(errorMessage);
 		return false;

--- a/engines/tony/POTFILES
+++ b/engines/tony/POTFILES
@@ -1,0 +1,1 @@
+engines/tony/tony.cpp

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -195,7 +195,7 @@ bool TonyEngine::loadTonyDat() {
 	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		msg = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
+		msg = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -207,7 +207,7 @@ bool TonyEngine::loadTonyDat() {
 	buf[4] = '\0';
 
 	if (strcmp(buf, "TONY")) {
-		msg = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
+		msg = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -218,7 +218,7 @@ bool TonyEngine::loadTonyDat() {
 
 	if ((majVer != TONY_DAT_VER_MAJ) || (minVer != TONY_DAT_VER_MIN)) {
 		msg = Common::String::format(
-			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
 			filename.c_str(), TONY_DAT_VER_MAJ, TONY_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -207,7 +207,7 @@ bool TonyEngine::loadTonyDat() {
 	buf[4] = '\0';
 
 	if (strcmp(buf, "TONY")) {
-		msg = "File 'tony.dat' is corrupt. Get it from the ScummVM website";
+		msg = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -195,7 +195,7 @@ bool TonyEngine::loadTonyDat() {
 	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		msg = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
+		msg = Common::String::format(_("Unable to locate the '%s' engine data file."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -207,7 +207,7 @@ bool TonyEngine::loadTonyDat() {
 	buf[4] = '\0';
 
 	if (strcmp(buf, "TONY")) {
-		msg = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
+		msg = Common::String::format(_("The '%s' engine data file is corrupt."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -218,7 +218,7 @@ bool TonyEngine::loadTonyDat() {
 
 	if ((majVer != TONY_DAT_VER_MAJ) || (minVer != TONY_DAT_VER_MIN)) {
 		msg = Common::String::format(
-			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d."),
 			filename.c_str(), TONY_DAT_VER_MAJ, TONY_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
@@ -255,7 +255,7 @@ bool TonyEngine::loadTonyDat() {
 
 	int numVariant = in.readUint16BE();
 	if (expectedLangVariant > numVariant - 1) {
-		msg = Common::String::format(_("Font variant not present in '%s' engine data file. Read the README for instructions."), filename.c_str());
+		msg = Common::String::format(_("Font variant not present in '%s' engine data file."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -27,6 +27,7 @@
 #include "common/events.h"
 #include "common/file.h"
 #include "common/installshield_cab.h"
+#include "common/translation.h"
 #include "tony/tony.h"
 #include "tony/custom.h"
 #include "tony/debugger.h"
@@ -189,11 +190,12 @@ Common::ErrorCode TonyEngine::init() {
 bool TonyEngine::loadTonyDat() {
 	Common::String msg;
 	Common::File in;
+	Common::String filename = "tony.dat";
 
-	in.open("tony.dat");
+	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		msg = "You're missing the 'tony.dat' file. Get it from the ScummVM website";
+		msg = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -217,7 +217,9 @@ bool TonyEngine::loadTonyDat() {
 	int minVer = in.readByte();
 
 	if ((majVer != TONY_DAT_VER_MAJ) || (minVer != TONY_DAT_VER_MIN)) {
-		msg = Common::String::format("File 'tony.dat' is wrong version. Expected %d.%d but got %d.%d. Get it from the ScummVM website", TONY_DAT_VER_MAJ, TONY_DAT_VER_MIN, majVer, minVer);
+		msg = Common::String::format(
+			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			filename.c_str(), TONY_DAT_VER_MAJ, TONY_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -255,7 +255,7 @@ bool TonyEngine::loadTonyDat() {
 
 	int numVariant = in.readUint16BE();
 	if (expectedLangVariant > numVariant - 1) {
-		msg = Common::String::format("Font variant not present in 'tony.dat'. Get it from the ScummVM website");
+		msg = Common::String::format(_("Font variant not present in '%s' engine data file. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -4927,7 +4927,7 @@ bool ToonEngine::loadToonDat() {
 	buf[4] = '\0';
 
 	if (strcmp(buf, "TOON")) {
-		msg = _("File 'toon.dat' is corrupt. Get it from the ScummVM website");
+		msg = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -4909,12 +4909,13 @@ void ToonEngine::createShadowLUT() {
 bool ToonEngine::loadToonDat() {
 	Common::File in;
 	Common::String msg;
+	Common::String filename = "toon.dat";
 	int majVer, minVer;
 
-	in.open("toon.dat");
+	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		msg = _("You're missing the 'toon.dat' file. Get it from the ScummVM website");
+		msg = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -4937,7 +4937,9 @@ bool ToonEngine::loadToonDat() {
 	minVer = in.readByte();
 
 	if ((majVer != TOON_DAT_VER_MAJ) || (minVer != TOON_DAT_VER_MIN)) {
-		msg = Common::String::format(_("File 'toon.dat' is wrong version. Expected %d.%d but got %d.%d. Get it from the ScummVM website"), TOON_DAT_VER_MAJ, TOON_DAT_VER_MIN, majVer, minVer);
+		msg = Common::String::format(
+			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			filename.c_str(), TOON_DAT_VER_MAJ, TOON_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -4915,7 +4915,7 @@ bool ToonEngine::loadToonDat() {
 	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		msg = Common::String::format(_("You're missing the '%s' file. Get it from the ScummVM website"), filename.c_str());
+		msg = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -4927,7 +4927,7 @@ bool ToonEngine::loadToonDat() {
 	buf[4] = '\0';
 
 	if (strcmp(buf, "TOON")) {
-		msg = Common::String::format(_("File '%s' is corrupt. Get it from the ScummVM website"), filename.c_str());
+		msg = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -4938,7 +4938,7 @@ bool ToonEngine::loadToonDat() {
 
 	if ((majVer != TOON_DAT_VER_MAJ) || (minVer != TOON_DAT_VER_MIN)) {
 		msg = Common::String::format(
-			_("Incorrect version of the '%s' file found. Expected %d.%d but got %d.%d. Get it from the ScummVM website"),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
 			filename.c_str(), TOON_DAT_VER_MAJ, TOON_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -4915,7 +4915,7 @@ bool ToonEngine::loadToonDat() {
 	in.open(filename.c_str());
 
 	if (!in.isOpen()) {
-		msg = Common::String::format(_("Unable to locate the '%s' engine data file. Read the README for instructions."), filename.c_str());
+		msg = Common::String::format(_("Unable to locate the '%s' engine data file."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -4927,7 +4927,7 @@ bool ToonEngine::loadToonDat() {
 	buf[4] = '\0';
 
 	if (strcmp(buf, "TOON")) {
-		msg = Common::String::format(_("The '%s' engine data file is corrupt. Read the README for instructions."), filename.c_str());
+		msg = Common::String::format(_("The '%s' engine data file is corrupt."), filename.c_str());
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());
 		return false;
@@ -4938,7 +4938,7 @@ bool ToonEngine::loadToonDat() {
 
 	if ((majVer != TOON_DAT_VER_MAJ) || (minVer != TOON_DAT_VER_MIN)) {
 		msg = Common::String::format(
-			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d. Read the README for instructions."),
+			_("Incorrect version of the '%s' engine data file found. Expected %d.%d but got %d.%d."),
 			filename.c_str(), TOON_DAT_VER_MAJ, TOON_DAT_VER_MIN, majVer, minVer);
 		GUIErrorMessage(msg);
 		warning("%s", msg.c_str());


### PR DESCRIPTION
The helps translators a bit by removing filenames from messages so no duplicate messages have to be translated. Some engine didn't display a dialog box about the problem found. Some message were not yet translated.
Feedback appreciated.