### PR TITLE
CRUISE: font: Don't overwrite transparent pixels

### DIFF
--- a/engines/cruise/font.cpp
+++ b/engines/cruise/font.cpp
@@ -200,7 +200,9 @@ void renderWord(const uint8 *fontPtr_Data, uint8 *outBufferPtr, int xOffset, int
 		fontPtr_Data2 += sizeof(uint16);
 
 		for (int j = 0; j < charWidth; j++) {
-			*outBufferPtr = ((bitSet1 >> 15) & 1) | ((bitSet2 >> 14) & 2);
+			if (((bitSet1 >> 15) & 1)) {
+				*outBufferPtr = ((bitSet2 >> 15) & 1) + 1;
+			}
 			outBufferPtr++;
 
 			bitSet1 <<= 1;


### PR DESCRIPTION
Fixes wrong rendering when outlines overlap. Current:
![c2](https://cloud.githubusercontent.com/assets/10910745/21059242/1f5df3e4-be4a-11e6-8e5e-ee39db41f498.png)
With patch:
![c3](https://cloud.githubusercontent.com/assets/10910745/21059262/3659d04a-be4a-11e6-8ab7-ec212883b059.png)
Original (DOSBox):
![c1](https://cloud.githubusercontent.com/assets/10910745/21059275/47310a46-be4a-11e6-994e-4cb09ea47fad.png)

