### PR TITLE
CRUISE: Fix font space width

### DIFF
--- a/engines/cruise/font.cpp
+++ b/engines/cruise/font.cpp
@@ -30,7 +30,7 @@
 
 namespace Cruise {
 
-const int SPACE_WIDTH = 4;
+const int SPACE_WIDTH = 5;
 
 /**
  * Determines the line size by finding the highest character in the given font set


### PR DESCRIPTION
The game uses 5px space instead of 4px.

Some screenshots for comparison. First DOSBox, then the current ScummVM.
English version:
![e1](https://cloud.githubusercontent.com/assets/10910745/21073177/c54c0b7e-bee0-11e6-9c55-08ed14bc5f89.png)
![e2](https://cloud.githubusercontent.com/assets/10910745/21073178/c947f12a-bee0-11e6-8813-e1a9cf3900ae.png)
Italian version. Symbols are narrower, but the space is still the same:
![e3](https://cloud.githubusercontent.com/assets/10910745/21073182/decdf8dc-bee0-11e6-9a5f-fb4d04eaf98c.png)


