### PR TITLE
COMMON: Add stddef.h to scummsys.h for ptrdiff_t

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -132,6 +132,7 @@
 	#include <stdlib.h>
 	#include <string.h>
 	#include <stdarg.h>
+	#include <stddef.h>
 	#include <assert.h>
 	#include <ctype.h>
 	// MSVC does not define M_PI, M_SQRT2 and other math defines by default.


### PR DESCRIPTION
As mentioned by @wjp, this header is included already by Director, SCUMM, Sky, and Sword25 engines so it should be fine to load in scummsys.h, but I always want to get a double-check before I put anything new into common.