### PR TITLE
SCI32: Small changes to get the demos of LSL7, Lighthouse and RAMA working

### DIFF
--- a/engines/sci/engine/kernel_tables.h
+++ b/engines/sci/engine/kernel_tables.h
@@ -868,7 +868,7 @@ static SciKernelMapEntry s_kernelMap[] = {
 	// our own memory manager and garbage collector, thus we simply call FlushResources, which in turn invokes
 	// our garbage collector (i.e. the SCI0-SCI1.1 semantics).
 	{ "Purge", kFlushResources,    SIG_EVERYWHERE,           "i",                     NULL,            NULL },
-	{ MAP_CALL(SetShowStyle),      SIG_EVERYWHERE,           "ioiiiii([ri])(i)",      NULL,            NULL },
+	{ MAP_CALL(SetShowStyle),      SIG_EVERYWHERE,           "ioiiiii([ri])([ri])",   NULL,            NULL },
 	{ MAP_CALL(String),            SIG_EVERYWHERE,           "(.*)",                  kString_subops,  NULL },
 	{ MAP_CALL(UpdatePlane),       SIG_EVERYWHERE,           "o",                     NULL,            NULL },
 	{ MAP_CALL(UpdateScreenItem),  SIG_EVERYWHERE,           "o",                     NULL,            NULL },

--- a/engines/sci/engine/kgraphics32.cpp
+++ b/engines/sci/engine/kgraphics32.cpp
@@ -390,7 +390,7 @@ reg_t kSetShowStyle(EngineState *s, int argc, reg_t *argv) {
 		divisions = argc > 7 ? argv[7].toSint16() : -1;
 	}
 	// SCI 2.1mid–2.1late
-	else if (getSciVersion() < SCI_VERSION_3) {
+	else if (getSciVersion() < SCI_VERSION_3 && g_sci->getGameId() != GID_LSL7) {
 		blackScreen = 0;
 		pFadeArray = argc > 7 ? argv[7] : NULL_REG;
 		divisions = argc > 8 ? argv[8].toSint16() : -1;

--- a/engines/sci/engine/klists.cpp
+++ b/engines/sci/engine/klists.cpp
@@ -813,6 +813,9 @@ reg_t kArrayGetSize(EngineState *s, int argc, reg_t *argv) {
 }
 
 reg_t kArrayGetElement(EngineState *s, int argc, reg_t *argv) {
+	if (s->_segMan->getSegmentType(argv[0].getSegment()) == SEG_TYPE_SCRIPT)
+		return kStrAt(s, 2, argv);
+
 	SciArray &array = *s->_segMan->lookupArray(argv[0]);
 	return array.getAsID(argv[1].toUint16());
 }
@@ -824,6 +827,13 @@ reg_t kArraySetElements(EngineState *s, int argc, reg_t *argv) {
 }
 
 reg_t kArrayFree(EngineState *s, int argc, reg_t *argv) {
+	if (s->_segMan->getSegmentType(argv[0].getSegment()) == SEG_TYPE_SCRIPT) {
+		reg_t source = make_reg(argv[0].getSegment(), argv[0].getOffset() + 1);
+		reg_t dest = argv[0];
+		s->_segMan->strcpy(dest, source);
+		return s->r_acc;
+	}
+
 	s->_segMan->freeArray(argv[0]);
 	return s->r_acc;
 }

--- a/engines/sci/engine/segment.h
+++ b/engines/sci/engine/segment.h
@@ -797,9 +797,9 @@ public:
 		if (flags & kArrayTrimRight) {
 			source = data + strlen((char *)data) - 1;
 			while (source > data && *source != showChar && *source <= kWhitespaceBoundary) {
+				*source = '\0';
 				--source;
 			}
-			*source = '\0';
 		}
 
 		if (flags & kArrayTrimCenter) {

--- a/engines/sci/engine/workarounds.cpp
+++ b/engines/sci/engine/workarounds.cpp
@@ -342,6 +342,8 @@ const SciWorkaroundEntry uninitializedReadWorkarounds[] = {
 	{ GID_LSL6HIRES,      -1,    85,  0,             "LL6Inv", "init",                            NULL,     0, { WORKAROUND_FAKE,   0 } }, // when creating a new game
 	{ GID_LSL6HIRES,      -1, 64950,  1,            "Feature", "handleEvent",                     NULL,     0, { WORKAROUND_FAKE,   0 } }, // at least when entering swimming pool area
 	{ GID_LSL6HIRES,      -1, 64964,  0,              "DPath", "init",                            NULL,     1, { WORKAROUND_FAKE,   0 } }, // during the game
+	{ GID_LSL7,           50, 64017,  0,             "oFlags", "clear",                           NULL,     0, { WORKAROUND_FAKE,   0 } }, // when starting the demo
+	{ GID_LSL7,         9000, 64892,  0,      "oEventHandler", "killAllEventHogs",                NULL,     1, { WORKAROUND_FAKE,   0 } }, // when clicking on help in the dice mini game
 	{ GID_MOTHERGOOSE256, -1,     0,  0,                 "MG", "doit",                            NULL,     5, { WORKAROUND_FAKE,   0 } }, // SCI1.1: When moving the cursor all the way to the left during the game - bug #5224
 	{ GID_MOTHERGOOSE256, -1,   992,  0,             "AIPath", "init",                            NULL,     0, { WORKAROUND_FAKE,   0 } }, // Happens in the demo and full version. In the demo, it happens when walking two screens from mother goose's house to the north. In the full version, it happens in rooms 7 and 23 - bug #5269
 	{ GID_MOTHERGOOSE256, 90,    90,  0,        "introScript", "changeState",                     NULL,    65, { WORKAROUND_FAKE,   0 } }, // SCI1(CD): At the very end, after the game is completed and restarted - bug #5626

--- a/engines/sci/graphics/font.cpp
+++ b/engines/sci/graphics/font.cpp
@@ -38,7 +38,9 @@ GfxFontFromResource::GfxFontFromResource(ResourceManager *resMan, GfxScreen *scr
 
 	_resource = resMan->findResource(ResourceId(kResourceTypeFont, resourceId), true);
 	if (!_resource) {
-		error("font resource %d not found", resourceId);
+		// The Lighthouse demo does not contain any fonts
+		warning("font resource %d not found", resourceId);
+		return;
 	}
 	_resourceData = _resource->data;
 
@@ -54,8 +56,10 @@ GfxFontFromResource::GfxFontFromResource(ResourceManager *resMan, GfxScreen *scr
 }
 
 GfxFontFromResource::~GfxFontFromResource() {
-	delete[] _chars;
-	_resMan->unlockResource(_resource);
+	if (_resource) {
+		delete[] _chars;
+		_resMan->unlockResource(_resource);
+	}
 }
 
 GuiResourceId GfxFontFromResource::getResourceId() {


### PR DESCRIPTION
Here are some small changes to get the demos of LSL7 and Lighthouse working. With these changes, both demos work fine. They are both SCI2.1 late (unlike the full versions, which are SCI3).

The demo of RAMA is also SCI2.1 late, and needs a change to work, but that requires some further thought (it tries to reference a script as an array)