### PR TITLE
SCI: Unconditionally save palvary state

### DIFF
--- a/engines/sci/engine/savegame.h
+++ b/engines/sci/engine/savegame.h
@@ -37,6 +37,7 @@ struct EngineState;
  *
  * Version - new/changed feature
  * =============================
+ *      40 - always store palvary variables
  *      39 - Accurate SCI32 arrays/strings, score metadata, avatar metadata
  *      38 - SCI32 cursor
  *      37 - Segment entry data changed to pointers
@@ -64,7 +65,7 @@ struct EngineState;
  */
 
 enum {
-	CURRENT_SAVEGAME_VERSION = 39,
+	CURRENT_SAVEGAME_VERSION = 40,
 	MINIMUM_SAVEGAME_VERSION = 14
 };
 

--- a/engines/sci/graphics/palette.cpp
+++ b/engines/sci/graphics/palette.cpp
@@ -852,6 +852,7 @@ void GfxPalette::palVaryCallback(void *refCon) {
 }
 
 void GfxPalette::palVaryIncreaseSignal() {
+	// FIXME: increments from another thread aren't guaranteed to be atomic
 	if (!_palVaryPaused)
 		_palVarySignal++;
 }


### PR DESCRIPTION
Additionally, add workaround to fix up old QfG3 saves with broken
_palVaryPaused state. Fixes bug #9674.