### PR TITLE
SCUMM: V0/V1: Fix two graphical issues

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -1510,10 +1510,11 @@ void Actor::putActor(int dstX, int dstY, int newRoom) {
 		((Actor_v0 *)this)->_newWalkBoxEntered = false;
 		((Actor_v0 *)this)->_CurrentWalkTo = _pos;
 		((Actor_v0 *)this)->_NewWalkTo = _pos;
-
-		// V0 always sets the actor to face the camera upon entering a room
-		setDirection(oldDirToNewDir(2));
 	}
+
+	// V0-V1 Maniac always sets the actor to face the camera upon entering a room
+	if (_vm->_game.id == GID_MANIAC && _vm->_game.version <= 1 && _vm->_game.platform != Common::kPlatformNES)
+		setDirection(oldDirToNewDir(2));
 }
 
 static bool inBoxQuickReject(const BoxCoords &box, int x, int y, int threshold) {

--- a/engines/scumm/costume.cpp
+++ b/engines/scumm/costume.cpp
@@ -114,6 +114,10 @@ byte ClassicCostumeRenderer::mainRoutine(int xmoveCur, int ymoveCur) {
 	v1.x = _actorX;
 	v1.y = _actorY;
 
+	// V0/V1 games are off by 1
+	if (_vm->_game.version <= 1)
+		v1.y += 1;
+
 	if (use_scaling) {
 
 		/* Scale direction */

--- a/engines/scumm/script_v2.cpp
+++ b/engines/scumm/script_v2.cpp
@@ -1131,9 +1131,6 @@ void ScummEngine_v2::o2_putActor() {
 	x = getVarOrDirectByte(PARAM_2);
 	y = getVarOrDirectByte(PARAM_3);
 
-	if (_game.id == GID_MANIAC && _game.version <= 1 && _game.platform != Common::kPlatformNES)
-		a->setFacing(180);
-
 	a->putActor(x, y);
 }
 


### PR DESCRIPTION
Hi,

This request is to resolve two issues

https://bugs.scummvm.org/ticket/4515
https://bugs.scummvm.org/ticket/6817

6817:
I have checked against DosBox, and can verify that both MM-V1 and Zak-V1 are off by 1 row, however other games utilising the ClassicCostumeRenderer (MM-V2, Indy-256) are not...

4515: 
The a->setFacing which was originally occurring in o2_putActor, was the cause of this bug. As _facing was being set, eventually a->animateActor is called (via o5_animateActor), the setDirection did nothing as _facing == _direction, but Fred was not facing the camera.
