### PR TITLE
TEST: Only build Wintermute tests when that engine is enabled

### DIFF
--- a/test/module.mk
+++ b/test/module.mk
@@ -5,8 +5,13 @@
 #
 ######################################################################
 
-TESTS        := $(srcdir)/test/common/*.h $(srcdir)/test/audio/*.h $(srcdir)/test/engines/wintermute/*.h
-TEST_LIBS    := audio/libaudio.a common/libcommon.a engines/wintermute/libwintermute.a
+TESTS        := $(srcdir)/test/common/*.h $(srcdir)/test/audio/*.h
+TEST_LIBS    := audio/libaudio.a common/libcommon.a
+
+ifdef ENABLE_WINTERMUTE
+	TESTS += $(srcdir)/test/engines/wintermute/*.h
+	TEST_LIBS += engines/wintermute/libwintermute.a
+endif
 
 #
 TEST_FLAGS   := --runner=StdioPrinter --no-std --no-eh --include=$(srcdir)/test/cxxtest_mingw.h


### PR DESCRIPTION
This fixes `make test` when wintermute engine is disabled after commit e3fdd8d5fe5b739b28c67539bbdb0b596f9dacbe, but I am not 100% sure that this is the right solution.