### PR TITLE
BUILD: Speed up Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language:
   - cpp
 
-sudo: required
+sudo: false
+cache: ccache
 
 addons:
   apt:
     packages:
-    - g++ make
     - libsdl2-dev
     - libsdl2-net-dev
     - libcurl4-openssl-dev


### PR DESCRIPTION
container-based infrastructure (by sudo: false) starts and runs
faster:
https://docs.travis-ci.com/user/migrating-from-legacy/

gcc and make are preinstalled by Travis-CI for C++ language
containers, so do not need to be listed as dependencies:
https://docs.travis-ci.com/user/trusty-ci-environment/#Compilers-%26-Build-toolchain

ccache caching prevents wasting time rebuilding unchanged code:
https://docs.travis-ci.com/user/caching#ccache-cache

This should work OK, though there is a [bug](https://github.com/travis-ci/travis-yaml/issues/58) in travis lint which means that there is a slight chance this change might break something. I am happy to monitor and unbreak the build if that happens.