### PR TITLE
IMAGE: Return 24bpp pixel format for Indeo3

### DIFF
--- a/image/codecs/codec.cpp
+++ b/image/codecs/codec.cpp
@@ -210,7 +210,7 @@ Codec *createBitmapCodec(uint32 tag, int width, int height, int bitsPerPixel) {
 	case MKTAG('c','v','i','d'):
 		return new CinepakDecoder(bitsPerPixel);
 	case MKTAG('I','V','3','2'):
-		return new Indeo3Decoder(width, height);
+		return new Indeo3Decoder(width, height, bitsPerPixel);
 	case MKTAG('I', 'V', '4', '1'):
 	case MKTAG('I', 'V', '4', '2'):
 		return new Indeo4Decoder(width, height, bitsPerPixel);

--- a/image/codecs/indeo3.cpp
+++ b/image/codecs/indeo3.cpp
@@ -40,11 +40,24 @@
 
 namespace Image {
 
-Indeo3Decoder::Indeo3Decoder(uint16 width, uint16 height) : _ModPred(0), _corrector_type(0) {
+Indeo3Decoder::Indeo3Decoder(uint16 width, uint16 height, uint bitsPerPixel) : _ModPred(0), _corrector_type(0) {
 	_iv_frame[0].the_buf = 0;
 	_iv_frame[1].the_buf = 0;
 
-	_pixelFormat = g_system->getScreenFormat();
+	switch (bitsPerPixel) {
+	case 16:
+		_pixelFormat = Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
+		break;
+	case 24:
+		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 0);
+		break;
+	case 32:
+		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
+		break;
+	default:
+		error("Invalid color depth");
+		break;
+	}
 
 	_surface = new Graphics::Surface;
 	_surface->create(width, height, _pixelFormat);

--- a/image/codecs/indeo3.h
+++ b/image/codecs/indeo3.h
@@ -46,7 +46,7 @@ namespace Image {
  */
 class Indeo3Decoder : public Codec {
 public:
-	Indeo3Decoder(uint16 width, uint16 height);
+	Indeo3Decoder(uint16 width, uint16 height, uint bitsPerPixel = 24);
 	~Indeo3Decoder();
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream);

--- a/video/coktel_decoder.cpp
+++ b/video/coktel_decoder.cpp
@@ -1691,7 +1691,7 @@ bool VMDDecoder::openExternalCodec() {
 		if (_videoCodec == kVideoCodecIndeo3) {
 			_isPaletted = false;
 
-			_codec = new Image::Indeo3Decoder(_width, _height);
+			_codec = new Image::Indeo3Decoder(_width, _height, g_system->getScreenFormat().bpp());
 
 		} else {
 			warning("VMDDecoder::openExternalCodec(): Unknown video codec FourCC \"%s\"",


### PR DESCRIPTION
The YUVToRGBManager::convert410 function used by Indeo3 decoder requires at least 16bpp graphics mode. Engines that normally run at 8bpp but switch rendering modes for high-colour video (like SCI) rely on getting accurate pixel format information from the video player in order to mode switch to the best output mode for the video being played.

Indeo3’s current behaviour is to return the system screen pixel format, which means SCI engine is unable to play back Indeo3 video (GK2A.AVI from GK2 demo) because it is told to remain in its 8bpp mode.

~~I don’t know if not returning the system pixel format will cause problems for other engines that run in 16bpp mode, hence this PR. A potentially safer alternative would be to return the system pixel format unless the system pixel format is below 16bpp, at which point the 24bpp format could be used instead.~~ Now the PR follows the same pattern as other codecs that are encapsulated in AVI.