### PR TITLE
SCI: Expand workaround for script bug #3537232

### DIFF
--- a/engines/sci/engine/kgraphics.cpp
+++ b/engines/sci/engine/kgraphics.cpp
@@ -671,7 +671,9 @@ reg_t kPaletteAnimate(EngineState *s, int argc, reg_t *argv) {
 	// palette animation effect slower and visible, and not have the logo screen
 	// get skipped because the scripts don't wait between animation steps. Fixes
 	// bug #3537232.
-	if (g_sci->getGameId() == GID_SQ4 && !g_sci->isCD() && s->currentRoomNumber() == 1)
+	// This problem also happens in the time pod (room#531)
+	// This problem also happens in the ending cutscene time rip (room#21)
+	if (g_sci->getGameId() == GID_SQ4 && !g_sci->isCD())
 		g_sci->sleep(10);
 
 	return s->r_acc;


### PR DESCRIPTION
In Space Quest 4 Floppy, I noticed that the time pod time travel sequences don't animate and sort of freeze.
I was able to fix this by applying the same sleep workaround as was being done for the intro by @bluegr 

Not sure if this is the right way to fix it, but it does fix it.

I also want to know if it is a good idea to maybe remove the room# condition. The rationale being that maybe different versions of the game might have different room numbers for the time pod?