### PR TITLE
BLADERUNNER: Add detection for German version

### DIFF
--- a/engines/bladerunner/detection_tables.h
+++ b/engines/bladerunner/detection_tables.h
@@ -39,6 +39,20 @@ static const ADGameDescription gameDescriptions[] = {
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
+	
+	// BladeRunner (German)
+	{
+		"bladerunner",
+		0,
+		{
+			{"STARTUP.MIX", 0, "57d674ed860148a530b7f4957cbe65ec", 2314301},
+			AD_LISTEND
+		},
+		Common::DE_DEU,
+		Common::kPlatformWindows,
+		ADGF_NO_FLAGS,
+		GUIO0()
+	},
 	AD_TABLE_END_MARKER
 };
 


### PR DESCRIPTION
I received my original copy of the German "Blade Runner" release today, so here is the detection entry.

At the moment, it seems that the German release is unsupported by the engine. I did a full installation from my original CDs on a Windows XP VM and copied the full "BLADE" directory on the virtual HDD to my main machine.

After starting the game, it fails with the following error message:
```
Opening hashed: MUSIC.MIX
Opening hashed: SFX.MIX
Opening hashed: SPCHSFX.TLK
getResource: Resource ACTORS.TRE not found.
```

I added the detection information as a Pull Request, because I don't know if you want to merge the detection entry at the current state.