### PR TITLE
Fix Bug : #7172

### DIFF
--- a/engines/sword25/util/lua_unpersist.cpp
+++ b/engines/sword25/util/lua_unpersist.cpp
@@ -118,7 +118,7 @@ static void registerObjectInIndexTable(UnSerializationInfo *info, int index) {
 	// Make sure there is enough room on the stack
 	lua_checkstack(info->luaState, 2);
 
-	lua_pushlightuserdata(info->luaState, (void *)index);
+	lua_pushlightuserdata(info->luaState, reinterpret_cast<void *>(index));
 	// >>>>> permTbl indexTbl ...... obj index
 
 	lua_pushvalue(info->luaState, -2);
@@ -198,7 +198,7 @@ static void unpersist(UnSerializationInfo *info) {
 		} else {
 			// Fetch the object from the indexTbl
 
-			lua_pushlightuserdata(info->luaState, (void *)index);
+			lua_pushlightuserdata(info->luaState, reinterpret_cast<void *>(index));
 			// >>>>> permTbl indexTbl ...... index
 
 			lua_gettable(info->luaState, 2);


### PR DESCRIPTION
Engine Sword 25: The bug "https://bugs.scummvm.org/ticket/7172" is fixed. 

#Bug's description: GCC's -Wint-to-pointer-cast (on amd64) complaints about the casting of an integer value into a pointer type in two places within Lua.
#reinterpret_cast<type> (expr) is used to fix it.
