### PR TITLE
GUI: Add three new options for volume slider controls

### DIFF
--- a/common/gui_options.cpp
+++ b/common/gui_options.cpp
@@ -29,6 +29,8 @@ namespace Common {
 
 const struct GameOpt {
 	const char *option;
+	// Each description must be a unique identifier not containing a substring
+	// of any other description
 	const char *desc;
 } g_gameOptions[] = {
 	{ GUIO_NOSUBTITLES,  "sndNoSubs" },
@@ -36,6 +38,9 @@ const struct GameOpt {
 	{ GUIO_NOSPEECH,     "sndNoSpeech" },
 	{ GUIO_NOSFX,        "sndNoSFX" },
 	{ GUIO_NOMIDI,       "sndNoMIDI" },
+	{ GUIO_LINKSPEECHTOSFX, "sndLinkSpeechToSfx" },
+	{ GUIO_LINKMUSICTOSFX,  "sndLinkMusicToSfx" },
+	{ GUIO_NOSPEECHVOLUME,  "sndNoSpchVolume" },
 
 	{ GUIO_NOLAUNCHLOAD, "launchNoLoad" },
 

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -26,6 +26,7 @@
 #define GUIO_NONE            "\000"
 #define GUIO_NOSUBTITLES     "\001"
 #define GUIO_NOMUSIC         "\002"
+// GUIO_NOSPEECH is a combination of GUIO_NOSPEECHVOLUME and GUIO_NOSUBTITLES
 #define GUIO_NOSPEECH        "\003"
 #define GUIO_NOSFX           "\004"
 #define GUIO_NOMIDI          "\005"
@@ -57,6 +58,10 @@
 #define GUIO_RENDERAPPLE2GS  "\041"
 #define GUIO_RENDERATARIST   "\042"
 #define GUIO_RENDERMACINTOSH "\043"
+
+#define GUIO_LINKSPEECHTOSFX "\044"
+#define GUIO_LINKMUSICTOSFX  "\045"
+#define GUIO_NOSPEECHVOLUME  "\046"
 
 // Special GUIO flags for the AdvancedDetector's caching of game specific
 // options.

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -627,18 +627,51 @@ void OptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 		_midiGainLabel->setLabel(Common::String::format("%.2f", (double)_midiGainSlider->getValue() / 100.0));
 		_midiGainLabel->draw();
 		break;
-	case kMusicVolumeChanged:
-		_musicVolumeLabel->setValue(_musicVolumeSlider->getValue());
+	case kMusicVolumeChanged: {
+		const int newValue = _musicVolumeSlider->getValue();
+		_musicVolumeLabel->setValue(newValue);
 		_musicVolumeLabel->draw();
+
+		if (_guioptions.contains(GUIO_LINKMUSICTOSFX)) {
+			updateSfxVolume(newValue);
+
+			if (_guioptions.contains(GUIO_LINKSPEECHTOSFX)) {
+				updateSpeechVolume(newValue);
+			}
+		}
+
 		break;
-	case kSfxVolumeChanged:
+	}
+	case kSfxVolumeChanged: {
+		const int newValue = _sfxVolumeSlider->getValue();
 		_sfxVolumeLabel->setValue(_sfxVolumeSlider->getValue());
 		_sfxVolumeLabel->draw();
+
+		if (_guioptions.contains(GUIO_LINKMUSICTOSFX)) {
+			updateMusicVolume(newValue);
+		}
+
+		if (_guioptions.contains(GUIO_LINKSPEECHTOSFX)) {
+			updateSpeechVolume(newValue);
+		}
+
 		break;
-	case kSpeechVolumeChanged:
-		_speechVolumeLabel->setValue(_speechVolumeSlider->getValue());
+	}
+	case kSpeechVolumeChanged: {
+		const int newValue = _speechVolumeSlider->getValue();
+		_speechVolumeLabel->setValue(newValue);
 		_speechVolumeLabel->draw();
+
+		if (_guioptions.contains(GUIO_LINKSPEECHTOSFX)) {
+			updateSfxVolume(newValue);
+
+			if (_guioptions.contains(GUIO_LINKMUSICTOSFX)) {
+				updateMusicVolume(newValue);
+			}
+		}
+
 		break;
+	}
 	case kMuteAllChanged:
 		// 'true' because if control is disabled then event do not pass
 		setVolumeSettingsState(true);
@@ -769,7 +802,7 @@ void OptionsDialog::setVolumeSettingsState(bool enabled) {
 	// Disable speech volume slider, when we are in subtitle only mode.
 	if (_subToggleGroup)
 		ena = ena && _subToggleGroup->getValue() != kSubtitlesSubs;
-	if (_guioptions.contains(GUIO_NOSPEECH))
+	if (_guioptions.contains(GUIO_NOSPEECH) || _guioptions.contains(GUIO_NOSPEECHVOLUME))
 		ena = false;
 
 	_speechVolumeDesc->setEnabled(ena);
@@ -1140,6 +1173,27 @@ int OptionsDialog::getSubtitleMode(bool subtitles, bool speech_mute) {
 	else
 		warning("Wrong configuration: Both subtitles and speech are off. Assuming subtitles only");
 	return kSubtitlesSubs;
+}
+
+void OptionsDialog::updateMusicVolume(const int newValue) const {
+	_musicVolumeLabel->setValue(newValue);
+	_musicVolumeSlider->setValue(newValue);
+	_musicVolumeLabel->draw();
+	_musicVolumeSlider->draw();
+}
+
+void OptionsDialog::updateSfxVolume(const int newValue) const {
+	_sfxVolumeLabel->setValue(newValue);
+	_sfxVolumeSlider->setValue(newValue);
+	_sfxVolumeLabel->draw();
+	_sfxVolumeSlider->draw();
+}
+
+void OptionsDialog::updateSpeechVolume(const int newValue) const {
+	_speechVolumeLabel->setValue(newValue);
+	_speechVolumeSlider->setValue(newValue);
+	_speechVolumeLabel->draw();
+	_speechVolumeSlider->draw();
 }
 
 void OptionsDialog::reflowLayout() {

--- a/gui/options.h
+++ b/gui/options.h
@@ -175,6 +175,9 @@ private:
 	//
 	// Volume controls
 	//
+	void updateMusicVolume(const int newValue) const;
+	void updateSfxVolume(const int newValue) const;
+	void updateSpeechVolume(const int newValue) const;
 	bool _enableVolumeSettings;
 
 	StaticTextWidget *_musicVolumeDesc;


### PR DESCRIPTION
GUIO_NOSPEECHVOLUME can be used for games that allow toggling of speech but do not provide the ability for users to control speech volume. (e.g. GK2, which has a patch that can enable subtitles, but the game only allows control of music volume.)

GUIO_LINKMUSICTOSFX and GUI_LINKSPEECHTOSFX can be used for games that allow control of music, sfx, and speech in combinations, like games that provide control of digital audio separately from MIDI, or games that only control all three audio types through a single volume control. (e.g. Phant1 and KQ7, respectively.)

(And, before anyone asks: no, it’s not possible to cleanly split audio types in these games, since Robots sometimes contain speech or sound effects or both, and some games like GK2 put speech into non-Audio36 resources.)