### PR TITLE
Create project fixes

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -386,9 +386,15 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 		} else {
 			// On MacOS X prior to 10.9 the OS is sometimes adding a -psn_X_XXXXXX argument (where X are digits)
 			// to pass the process serial number. We need to ignore it to avoid an error.
+			// When using XCode it also adds -NSDocumentRevisionsDebugMode YES argument if XCode option
+			// "Allow debugging when using document Versions Browser" is on (which is the default).
 #ifdef MACOSX
 			if (strncmp(s, "-psn_", 5) == 0)
 				continue;
+			if (strcmp(s, "-NSDocumentRevisionsDebugMode") == 0) {
+				++i; // Also skip the YES that follows
+				continue;
+			}
 #endif
 
 			bool isLongCmd = (s[0] == '-' && s[1] == '-');

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -309,6 +309,23 @@
 	#endif
 #endif
 
+//
+// Determine 64 bitness
+// Reference: http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros
+//
+#if !defined(HAVE_CONFIG_H)
+
+	#if defined(__x86_64__) || \
+		  defined(_M_X64) || \
+		  defined(__ppc64__) || \
+		  defined(__powerpc64__) || \
+		  defined(__LP64__)
+
+		#define SCUMM_64BITS
+
+	#endif
+
+#endif
 
 //
 // Some more system specific settings.

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1024,6 +1024,7 @@ const Feature s_features[] = {
 	{         "scalers",          "USE_SCALERS",         "", true,  "Scalers" },
 	{       "hqscalers",       "USE_HQ_SCALERS",         "", true,  "HQ scalers" },
 	{           "16bit",        "USE_RGB_COLOR",         "", true,  "16bit color support" },
+	{         "highres",          "USE_HIGHRES",         "", true,  "high resolution" },
 	{         "mt32emu",          "USE_MT32EMU",         "", true,  "integrated MT-32 emulator" },
 	{            "nasm",             "USE_NASM",         "", true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
 	{          "opengl",           "USE_OPENGL",         "", true,  "OpenGL support" },

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -86,6 +86,11 @@ struct EngineDesc {
 	 * Whether the engine should be included in the build or not.
 	 */
 	bool enable;
+	
+	/**
+	 * Features required for this engine.
+	 */
+	StringList requiredFeatures;
 
 	/**
 	 * A list of all available sub engine names. Sub engines are engines

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -950,6 +950,7 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	scummvmOSX_LdFlags.push_back("-lvorbis");
 	scummvmOSX_LdFlags.push_back("-lmad");
 	scummvmOSX_LdFlags.push_back("-lFLAC");
+	scummvmOSX_LdFlags.push_back("-lcurl");
 	if (setup.useSDL2) {
 		scummvmOSX_LdFlags.push_back("-lSDL2main");
 		scummvmOSX_LdFlags.push_back("-lSDL2");


### PR DESCRIPTION
This PR contains a collection of fixes for issues I encountered using create_project. The commits are independent from each others so we could decide to only keep some of them.

I am not familiar with create_project. I don't often use it and I had never looked at its source code before today. So don't hesitate to point issues or suggest better ways to fix some of the issues.

All the fixes result from looking at an issue recently posted in the iPhone forum (http://forums.scummvm.org/viewtopic.php?t=13965&start=120#83734). Compiling the current master code requires using `--disable-engine=fullpipe`. The first commit fixes this specific error (that also occur when compiling for OS X and I assume Windows). The other commits result from issues I noticed when testing this (for example that using --disable-16bit did not disable engines that require 16 bit color such as fulllpipe or riven, while using configure does it).




