### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/dists/android/AndroidManifest.xml
+++ b/dists/android/AndroidManifest.xml
@@ -28,14 +28,6 @@
 				<category android:name="tv.ouya.intent.category.GAME"/>
 			</intent-filter>
 		</activity>
-		<activity android:name=".ScummVMActivity"
-				android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-				android:banner="@drawable/leanback_icon">
-		  <intent-filter>
-				<action android:name="android.intent.action.MAIN"/>
-				<category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
-		  </intent-filter>
-		</activity>
 	</application>
 
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
Remove second activity in MAIN filter causing black screen lockup on some Android devices.