### PR TITLE
Fix Bug #6996 (Fixed jerky/laggy analog joystick mouse control)

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -179,11 +179,16 @@ void SdlEventSource::processMouseEvent(Common::Event &event, int x, int y) {
 	_km.y = y;
 }
 
-void SdlEventSource::handleKbdMouse() {
+void SdlEventSource::handleKbdMouse(Common::Event &event) {
+
 	// Skip recording of these events
 	uint32 curTime = g_system->getMillis(true);
 
 	if (curTime >= _km.last_time + _km.delay_time) {
+
+		int16 oldKmX = _km.x;
+		int16 oldKmY = _km.y;
+
 		_km.last_time = curTime;
 		if (_km.x_down_count == 1) {
 			_km.x_down_time = curTime;
@@ -247,6 +252,11 @@ void SdlEventSource::handleKbdMouse() {
 
 			if (_graphicsManager) {
 				_graphicsManager->getWindow()->warpMouseInWindow((Uint16)_km.x, (Uint16)_km.y);
+			}
+
+			if (_km.x != oldKmX || _km.y != oldKmY) {
+				event.type = Common::EVENT_MOUSEMOVE;
+				processMouseEvent(event, _km.x, _km.y);
 			}
 		}
 	}
@@ -425,7 +435,8 @@ Common::KeyCode SdlEventSource::SDLToOSystemKeycode(const SDLKey key) {
 }
 
 bool SdlEventSource::pollEvent(Common::Event &event) {
-	handleKbdMouse();
+	handleKbdMouse(event);
+
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	// In case we still need to send a key up event for a key down from a

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -106,7 +106,7 @@ protected:
 	virtual bool handleJoyButtonDown(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyButtonUp(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyAxisMotion(SDL_Event &ev, Common::Event &event);
-	virtual void handleKbdMouse();
+	virtual void handleKbdMouse(Common::Event &event);
 
 	//@}
 

--- a/backends/events/wincesdl/wincesdl-events.cpp
+++ b/backends/events/wincesdl/wincesdl-events.cpp
@@ -69,7 +69,7 @@ bool WINCESdlEventSource::pollEvent(Common::Event &event) {
 
 	memset(&event, 0, sizeof(Common::Event));
 
-	handleKbdMouse();
+	handleKbdMouse(event);
 
 	// If the screen changed, send an Common::EVENT_SCREEN_CHANGED
 	int screenID = _graphicsMan->getScreenChangeID();


### PR DESCRIPTION
Fixes https://bugs.scummvm.org/ticket/6996

This small change to the source fixes the "stopping, jerky" analog joystick mouse pointer control. In the original source, the mouse pointer was only updated when the analog joystick axes _changed_. Now it is updated also when the joystick axes stay at the same, unchanged values. This fixes the "stop and go" behaviour of the pointer when it is controlled by an analog stick. 

This bug was experienced by me on the Vita, on Android (Nvidia Shield Portable), and reported by several users on Raspberry Pi (RetroPie) when they used their controllers to control the mousepointer instead of a real mouse (or keyboard). 