### PR TITLE
SCUMM: Fix bug #4556 (Maniac: Purple Tentacle appears in Lab after being chased out)

### DIFF
--- a/engines/scumm/script_v2.cpp
+++ b/engines/scumm/script_v2.cpp
@@ -1189,6 +1189,25 @@ void ScummEngine_v2::o2_startScript() {
 		}
 	}
 
+    // WORKAROUND bug #4556: Purple Tentacle can appear in the lab, after being 
+    // chased out and end up stuck in the room. This bug is triggered if the player
+    // enters the lab within 45 minutes of first entering the mansion and has chased Purple Tentacle
+    // out. Eventually the cutscene with Purple Tentacle chasing Sandy in the lab
+    // will play. This script leaves Purple Tentacle in the room causing him to become
+    // a permanent resident.
+    // Our fix is simply to prevent the Cutscene playing, if the lab has already been stormed
+    if (_game.id == GID_MANIAC) {
+        if (_game.version >= 1 && script == 155) {
+            if (VAR(120) == 1)
+                return;
+        }
+        // Script numbers are different in V0
+        if (_game.version == 0 && script == 150) {
+            if (VAR(104) == 1)
+                return;
+        }
+    }
+
 	runScript(script, 0, 0, 0);
 }
 


### PR DESCRIPTION
This is caused by a scripting oversight which will occur if you enter the lab entry room in less than 45 minutes since the first cutscene with Dr. Fred and Sandy.
Its simply because the cutscene trigger is time based and puts Purple tentacle in the room, leaving him in it on completion.

This fix will prevent the cutscene with Purple Tentacle, Sandy and Dr. Fred from executing if the lab has been stormed (someone kindly set a variable for us at the beginning of the 'storm' script, which isn't used anywhere else in the game)


These script numbers are for V0, however the V1/V2 scripts are usually (x + 5)

script-143 (Cutscene: Dr. Fred / Sandy #1) is triggered by USE on roomobj-1-28 (Outside side of the Front Door). At completion of the cutscene, it executes script-151.

script-151 (Cutscene: Purple Tentacle chases Sandy Trigger) delays for 45 minutes, before executing script-150.
script-150 (Cutscene: Purple Tentacle chases Sandy) puts Purple Tentacle, Sandy and Dr. Fred into the Lab Entry, and only removes Sandy at completion.

script-94  (Cutscene: Weird Ed: Storm Dr. Freds Lab) puts Weird Ed in the Lab Entry and assumes purple is already present. At completion of this script, both Weird Ed and Purple are sent to Room0.
