### PR TITLE
SDL: More fixes to jerky analog joystick pointer

### DIFF
--- a/backends/events/dinguxsdl/dinguxsdl-events.cpp
+++ b/backends/events/dinguxsdl/dinguxsdl-events.cpp
@@ -72,54 +72,54 @@
 bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 	if (ev.key.keysym.sym == PAD_UP) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.y_vel = -1 * _km.multiplier;
+			_km.y_vel = -1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 0 * _km.multiplier;
+			_km.y_vel = 0 * MULTIPLIER;
 			_km.y_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_DOWN) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.y_vel = 1 * _km.multiplier;
+			_km.y_vel = 1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 0 * _km.multiplier;
+			_km.y_vel = 0 * MULTIPLIER;
 			_km.y_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_LEFT) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.x_vel = -1 * _km.multiplier;
+			_km.x_vel = -1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 0 * _km.multiplier;
+			_km.x_vel = 0 * MULTIPLIER;
 			_km.x_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_RIGHT) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.x_vel = 1 * _km.multiplier;
+			_km.x_vel = 1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 0 * _km.multiplier;
+			_km.x_vel = 0 * MULTIPLIER;
 			_km.x_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_Y) { // left mouse button
@@ -129,7 +129,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_B) { // right mouse button
@@ -139,7 +139,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_RBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_X) { // '.' skip dialogue

--- a/backends/events/dinguxsdl/dinguxsdl-events.cpp
+++ b/backends/events/dinguxsdl/dinguxsdl-events.cpp
@@ -72,54 +72,54 @@
 bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 	if (ev.key.keysym.sym == PAD_UP) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.y_vel = -1;
+			_km.y_vel = -1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 0;
+			_km.y_vel = 0 * _km.multiplier;
 			_km.y_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_DOWN) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.y_vel = 1;
+			_km.y_vel = 1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 0;
+			_km.y_vel = 0 * _km.multiplier;
 			_km.y_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_LEFT) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.x_vel = -1;
+			_km.x_vel = -1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 0;
+			_km.x_vel = 0 * _km.multiplier;
 			_km.x_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_RIGHT) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.x_vel = 1;
+			_km.x_vel = 1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 0;
+			_km.x_vel = 0 * _km.multiplier;
 			_km.x_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_Y) { // left mouse button
@@ -129,7 +129,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_B) { // right mouse button
@@ -139,7 +139,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_RBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_X) { // '.' skip dialogue

--- a/backends/events/gph/gph-events.cpp
+++ b/backends/events/gph/gph-events.cpp
@@ -230,116 +230,116 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 	switch (ev.jbutton.button) {
 	case BUTTON_UP:
 		if (_km.y_down_count != 2) {
-			_km.y_vel = -1 * _km.multiplier;
+			_km.y_vel = -1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = -4 * _km.multiplier;
+			_km.y_vel = -4 * MULTIPLIER;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_DOWN:
 		if (_km.y_down_count != 2) {
-			_km.y_vel = 1 * _km.multiplier;
+			_km.y_vel = 1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 4 * _km.multiplier;
+			_km.y_vel = 4 * MULTIPLIER;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_LEFT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = -1 * _km.multiplier;
+			_km.x_vel = -1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = -4 * _km.multiplier;
+			_km.x_vel = -4 * MULTIPLIER;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_RIGHT:
 		if (_km.x_down_count != 3) {
-			_km.x_vel = 1 * _km.multiplier;
+			_km.x_vel = 1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 4 * _km.multiplier;
+			_km.x_vel = 4 * MULTIPLIER;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_UPLEFT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = -1 * _km.multiplier;
+			_km.x_vel = -1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-				_km.x_vel = -4 * _km.multiplier;
+				_km.x_vel = -4 * MULTIPLIER;
 		}
 		if (_km.y_down_count != 2) {
-			_km.y_vel = -1 * _km.multiplier;
+			_km.y_vel = -1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = -4 * _km.multiplier;
+			_km.y_vel = -4 * MULTIPLIER;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_UPRIGHT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = 1 * _km.multiplier;
+			_km.x_vel = 1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 4 * _km.multiplier;
+			_km.x_vel = 4 * MULTIPLIER;
 		}
 		if (_km.y_down_count != 2) {
-			_km.y_vel = -1 * _km.multiplier;
+			_km.y_vel = -1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = -4 * _km.multiplier;
+			_km.y_vel = -4 * MULTIPLIER;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_DOWNLEFT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = -1 * _km.multiplier;
+			_km.x_vel = -1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = -4 * _km.multiplier;
+			_km.x_vel = -4 * MULTIPLIER;
 		}
 		if (_km.y_down_count != 2) {
-			_km.y_vel = 1 * _km.multiplier;
+			_km.y_vel = 1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 4 * _km.multiplier;
+			_km.y_vel = 4 * MULTIPLIER;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_DOWNRIGHT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = 1 * _km.multiplier;
+			_km.x_vel = 1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 4 * _km.multiplier;
+			_km.x_vel = 4 * MULTIPLIER;
 		}
 		if (_km.y_down_count != 2) {
-			_km.y_vel = 1 * _km.multiplier;
+			_km.y_vel = 1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 4 * _km.multiplier;
+			_km.y_vel = 4 * MULTIPLIER;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_B:
 	case BUTTON_CLICK:
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_X:
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_L:
 		BUTTON_STATE_L = true;
@@ -454,16 +454,16 @@ bool GPHEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 		_km.x_vel = 0;
 		_km.x_down_count = 0;
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_B:
 	case BUTTON_CLICK:
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_X:
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BUTTON_L:
 		BUTTON_STATE_L = false;

--- a/backends/events/gph/gph-events.cpp
+++ b/backends/events/gph/gph-events.cpp
@@ -230,116 +230,116 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 	switch (ev.jbutton.button) {
 	case BUTTON_UP:
 		if (_km.y_down_count != 2) {
-			_km.y_vel = -1;
+			_km.y_vel = -1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = -4;
+			_km.y_vel = -4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_DOWN:
 		if (_km.y_down_count != 2) {
-			_km.y_vel = 1;
+			_km.y_vel = 1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 4;
+			_km.y_vel = 4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_LEFT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = -1;
+			_km.x_vel = -1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = -4;
+			_km.x_vel = -4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_RIGHT:
 		if (_km.x_down_count != 3) {
-			_km.x_vel = 1;
+			_km.x_vel = 1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 4;
+			_km.x_vel = 4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_UPLEFT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = -1;
+			_km.x_vel = -1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-				_km.x_vel = -4;
+				_km.x_vel = -4 * _km.multiplier;
 		}
 		if (_km.y_down_count != 2) {
-			_km.y_vel = -1;
+			_km.y_vel = -1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = -4;
+			_km.y_vel = -4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_UPRIGHT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = 1;
+			_km.x_vel = 1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 4;
+			_km.x_vel = 4 * _km.multiplier;
 		}
 		if (_km.y_down_count != 2) {
-			_km.y_vel = -1;
+			_km.y_vel = -1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = -4;
+			_km.y_vel = -4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_DOWNLEFT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = -1;
+			_km.x_vel = -1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = -4;
+			_km.x_vel = -4 * _km.multiplier;
 		}
 		if (_km.y_down_count != 2) {
-			_km.y_vel = 1;
+			_km.y_vel = 1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 4;
+			_km.y_vel = 4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_DOWNRIGHT:
 		if (_km.x_down_count != 2) {
-			_km.x_vel = 1;
+			_km.x_vel = 1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 4;
+			_km.x_vel = 4 * _km.multiplier;
 		}
 		if (_km.y_down_count != 2) {
-			_km.y_vel = 1;
+			_km.y_vel = 1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 4;
+			_km.y_vel = 4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_B:
 	case BUTTON_CLICK:
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_X:
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_L:
 		BUTTON_STATE_L = true;
@@ -454,16 +454,16 @@ bool GPHEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 		_km.x_vel = 0;
 		_km.x_down_count = 0;
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_B:
 	case BUTTON_CLICK:
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_X:
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_L:
 		BUTTON_STATE_L = false;

--- a/backends/events/linuxmotosdl/linuxmotosdl-events.cpp
+++ b/backends/events/linuxmotosdl/linuxmotosdl-events.cpp
@@ -130,53 +130,53 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 // Joystick to Mouse
 	else if (ev.key.keysym.sym == SDLK_LEFT) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.x_vel = -1;
+			_km.x_vel = -1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 0;
+			_km.x_vel = 0 * _km.multiplier;
 			_km.x_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_RIGHT) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.x_vel = 1;
+			_km.x_vel = 1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 0;
+			_km.x_vel = 0 * _km.multiplier;
 			_km.x_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_DOWN) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.y_vel = 1;
+			_km.y_vel = 1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 0;
+			_km.y_vel = 0 * _km.multiplier;
 			_km.y_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_UP) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.y_vel = -1;
+			_km.y_vel = -1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 0;
+			_km.y_vel = 0 * _km.multiplier;
 			_km.y_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_RETURN) {
@@ -187,7 +187,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_PLUS) {
@@ -197,7 +197,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		} else {
 			event.type = Common::EVENT_RBUTTONUP;
 		}
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_MINUS) {
@@ -208,7 +208,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else {

--- a/backends/events/linuxmotosdl/linuxmotosdl-events.cpp
+++ b/backends/events/linuxmotosdl/linuxmotosdl-events.cpp
@@ -130,53 +130,53 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 // Joystick to Mouse
 	else if (ev.key.keysym.sym == SDLK_LEFT) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.x_vel = -1 * _km.multiplier;
+			_km.x_vel = -1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 0 * _km.multiplier;
+			_km.x_vel = 0 * MULTIPLIER;
 			_km.x_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_RIGHT) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.x_vel = 1 * _km.multiplier;
+			_km.x_vel = 1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
-			_km.x_vel = 0 * _km.multiplier;
+			_km.x_vel = 0 * MULTIPLIER;
 			_km.x_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_DOWN) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.y_vel = 1 * _km.multiplier;
+			_km.y_vel = 1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 0 * _km.multiplier;
+			_km.y_vel = 0 * MULTIPLIER;
 			_km.y_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_UP) {
 		if (ev.type == SDL_KEYDOWN) {
-			_km.y_vel = -1 * _km.multiplier;
+			_km.y_vel = -1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
-			_km.y_vel = 0 * _km.multiplier;
+			_km.y_vel = 0 * MULTIPLIER;
 			_km.y_down_count = 0;
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_RETURN) {
@@ -187,7 +187,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_PLUS) {
@@ -197,7 +197,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		} else {
 			event.type = Common::EVENT_RBUTTONUP;
 		}
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_MINUS) {
@@ -208,7 +208,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 		return true;
 	} else {

--- a/backends/events/maemosdl/maemosdl-events.cpp
+++ b/backends/events/maemosdl/maemosdl-events.cpp
@@ -96,7 +96,7 @@ bool MaemoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 				}
 			} else if (ev.key.keysym.sym == SDLK_F7) {
 				event.type = Common::EVENT_RBUTTONDOWN;
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 				 debug(9, "remapping to right click down");
 				return true;
 			} else if (ev.key.keysym.sym == SDLK_F8) {
@@ -134,7 +134,7 @@ bool MaemoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 				}
 			} else if (ev.key.keysym.sym == SDLK_F7) {
 				event.type = Common::EVENT_RBUTTONUP;
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 					debug(9, "remapping to right click up");
 				return true;
 			} else if (ev.key.keysym.sym == SDLK_F8) {

--- a/backends/events/maemosdl/maemosdl-events.cpp
+++ b/backends/events/maemosdl/maemosdl-events.cpp
@@ -96,7 +96,7 @@ bool MaemoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 				}
 			} else if (ev.key.keysym.sym == SDLK_F7) {
 				event.type = Common::EVENT_RBUTTONDOWN;
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 				 debug(9, "remapping to right click down");
 				return true;
 			} else if (ev.key.keysym.sym == SDLK_F8) {
@@ -134,7 +134,7 @@ bool MaemoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 				}
 			} else if (ev.key.keysym.sym == SDLK_F7) {
 				event.type = Common::EVENT_RBUTTONUP;
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 					debug(9, "remapping to right click up");
 				return true;
 			} else if (ev.key.keysym.sym == SDLK_F8) {

--- a/backends/events/openpandora/op-events.cpp
+++ b/backends/events/openpandora/op-events.cpp
@@ -126,18 +126,18 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_LEFT:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_LBUTTONDOWN : Common::EVENT_LBUTTONUP;
-			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+			processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 			return true;
 			break;
 		case SDLK_RIGHT:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_RBUTTONDOWN : Common::EVENT_RBUTTONUP;
-			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+			processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 			return true;
 			break;
 #if defined(SDL_BUTTON_MIDDLE)
 		case SDLK_UP:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_MBUTTONDOWN : Common::EVENT_MBUTTONUP;
-			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+			processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 			return true;
 			break;
 #endif
@@ -150,12 +150,12 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_HOME:
 			event.type = Common::EVENT_LBUTTONDOWN;
-			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+			processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 			return true;
 			break;
 		case SDLK_END:
 			event.type = Common::EVENT_RBUTTONDOWN;
-			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+			processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 			return true;
 			break;
 		case SDLK_PAGEDOWN:
@@ -188,12 +188,12 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_HOME:
 			event.type = Common::EVENT_LBUTTONUP;
-			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+			processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 			return true;
 			break;
 		case SDLK_END:
 			event.type = Common::EVENT_RBUTTONUP;
-			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+			processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 			return true;
 			break;
 		case SDLK_PAGEDOWN:

--- a/backends/events/openpandora/op-events.cpp
+++ b/backends/events/openpandora/op-events.cpp
@@ -126,18 +126,18 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_LEFT:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_LBUTTONDOWN : Common::EVENT_LBUTTONUP;
-			processMouseEvent(event, _km.x, _km.y);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_RIGHT:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_RBUTTONDOWN : Common::EVENT_RBUTTONUP;
-			processMouseEvent(event, _km.x, _km.y);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 #if defined(SDL_BUTTON_MIDDLE)
 		case SDLK_UP:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_MBUTTONDOWN : Common::EVENT_MBUTTONUP;
-			processMouseEvent(event, _km.x, _km.y);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 #endif
@@ -150,12 +150,12 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_HOME:
 			event.type = Common::EVENT_LBUTTONDOWN;
-			processMouseEvent(event, _km.x, _km.y);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_END:
 			event.type = Common::EVENT_RBUTTONDOWN;
-			processMouseEvent(event, _km.x, _km.y);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_PAGEDOWN:
@@ -188,12 +188,12 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_HOME:
 			event.type = Common::EVENT_LBUTTONUP;
-			processMouseEvent(event, _km.x, _km.y);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_END:
 			event.type = Common::EVENT_RBUTTONUP;
-			processMouseEvent(event, _km.x, _km.y);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_PAGEDOWN:

--- a/backends/events/ps3sdl/ps3sdl-events.cpp
+++ b/backends/events/ps3sdl/ps3sdl-events.cpp
@@ -60,11 +60,11 @@ bool PS3SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event)
 	switch (ev.jbutton.button) {
 	case BTN_CROSS: // Left mouse button
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BTN_CIRCLE: // Right mouse button
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BTN_TRIANGLE: // Game menu
 		event.type = Common::EVENT_KEYDOWN;
@@ -98,11 +98,11 @@ bool PS3SdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 	switch (ev.jbutton.button) {
 	case BTN_CROSS: // Left mouse button
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BTN_CIRCLE: // Right mouse button
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BTN_TRIANGLE: // Game menu
 		event.type = Common::EVENT_KEYUP;

--- a/backends/events/ps3sdl/ps3sdl-events.cpp
+++ b/backends/events/ps3sdl/ps3sdl-events.cpp
@@ -60,11 +60,11 @@ bool PS3SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event)
 	switch (ev.jbutton.button) {
 	case BTN_CROSS: // Left mouse button
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BTN_CIRCLE: // Right mouse button
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BTN_TRIANGLE: // Game menu
 		event.type = Common::EVENT_KEYDOWN;
@@ -98,11 +98,11 @@ bool PS3SdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 	switch (ev.jbutton.button) {
 	case BTN_CROSS: // Left mouse button
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BTN_CIRCLE: // Right mouse button
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		break;
 	case BTN_TRIANGLE: // Game menu
 		event.type = Common::EVENT_KEYUP;

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -270,8 +270,14 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			}
 
 			if (_km.x != oldKmX || _km.y != oldKmY) {
+				// keep hi-res coordinates since 
+				// processMouseEvent will overwrite them with lo-res numbers
+				oldKmX = _km.x;
+				oldKmY = _km.y;
 				event.type = Common::EVENT_MOUSEMOVE;
 				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
+				_km.x = oldKmX;
+				_km.y = oldKmY;
 				return true;
 			}
 		}

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -179,8 +179,8 @@ void SdlEventSource::processMouseEvent(Common::Event &event, int x, int y) {
 	}
 
 	// Update the "keyboard mouse" coords
-	_km.x = x * _km.multiplier;
-	_km.y = y * _km.multiplier;
+	_km.x = x * MULTIPLIER;
+	_km.y = y * MULTIPLIER;
 }
 
 bool SdlEventSource::handleKbdMouse(Common::Event &event) {
@@ -207,36 +207,36 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			if (_km.x_down_count) {
 				if (curTime > _km.x_down_time + 300) {
 					if (_km.x_vel > 0)
-						_km.x_vel += _km.multiplier;
+						_km.x_vel += MULTIPLIER;
 					else
-						_km.x_vel -= _km.multiplier;
+						_km.x_vel -= MULTIPLIER;
 				} else if (curTime > _km.x_down_time + 200) {
 					if (_km.x_vel > 0)
-						_km.x_vel = 5 * _km.multiplier;
+						_km.x_vel = 5 * MULTIPLIER;
 					else
-						_km.x_vel = -5 * _km.multiplier;
+						_km.x_vel = -5 * MULTIPLIER;
 				}
 			}
 			if (_km.y_down_count) {
 				if (curTime > _km.y_down_time + 300) {
 					if (_km.y_vel > 0)
-						_km.y_vel += _km.multiplier;
+						_km.y_vel += MULTIPLIER;
 					else
-						_km.y_vel -= _km.multiplier;
+						_km.y_vel -= MULTIPLIER;
 				} else if (curTime > _km.y_down_time + 200) {
 					if (_km.y_vel > 0)
-						_km.y_vel = 5 * _km.multiplier;
+						_km.y_vel = 5 * MULTIPLIER;
 					else
-						_km.y_vel = -5 * _km.multiplier;
+						_km.y_vel = -5 * MULTIPLIER;
 				}
 			}
 
-			// The modifier key makes the mouse movement slower
-			// The extra factor of delay/25 makes velocities 
-			// independent of kbdMouse update rate
-			// all velovities were originally chosen
-			// at a delay of 25, so that is the reference
-			// operator order is important to avoid overflow
+			// - The modifier key makes the mouse movement slower
+			// - The extra factor "delay/25" ensures velocities 
+			// are independent of the kbdMouse update rate
+			// - all velocities were originally chosen
+			// at a delay of 25, so that is the reference used here
+			// - note: operator order is important to avoid overflow
 			if (_km.modifier) {
 				_km.x += ((_km.x_vel / 10) * ((int16)_km.delay_time)) / 25;
 				_km.y += ((_km.y_vel / 10) * ((int16)_km.delay_time)) / 25;
@@ -247,31 +247,31 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 
 			if (_km.x < 0) {
 				_km.x = 0;
-				_km.x_vel = -1 * _km.multiplier;
+				_km.x_vel = -1 * MULTIPLIER;
 				_km.x_down_count = 1;
-			} else if (_km.x > _km.x_max * _km.multiplier) {
-				_km.x = _km.x_max * _km.multiplier;
-				_km.x_vel = 1 * _km.multiplier;
+			} else if (_km.x > _km.x_max * MULTIPLIER) {
+				_km.x = _km.x_max * MULTIPLIER;
+				_km.x_vel = 1 * MULTIPLIER;
 				_km.x_down_count = 1;
 			}
 
 			if (_km.y < 0) {
 				_km.y = 0;
-				_km.y_vel = -1 * _km.multiplier;
+				_km.y_vel = -1 * MULTIPLIER;
 				_km.y_down_count = 1;
-			} else if (_km.y > _km.y_max * _km.multiplier) {
-				_km.y = _km.y_max * _km.multiplier;
-				_km.y_vel = 1 * _km.multiplier;
+			} else if (_km.y > _km.y_max * MULTIPLIER) {
+				_km.y = _km.y_max * MULTIPLIER;
+				_km.y_vel = 1 * MULTIPLIER;
 				_km.y_down_count = 1;
 			}
 
 			if (_graphicsManager) {
-				_graphicsManager->getWindow()->warpMouseInWindow((Uint16)(_km.x / _km.multiplier), (Uint16)(_km.y / _km.multiplier));
+				_graphicsManager->getWindow()->warpMouseInWindow((Uint16)(_km.x / MULTIPLIER), (Uint16)(_km.y / MULTIPLIER));
 			}
 
 			if (_km.x != oldKmX || _km.y != oldKmY) {
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 				return true;
 			}
 		}
@@ -517,7 +517,7 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		// with a mouse wheel event. However, SDL2 does not supply
 		// these, thus we use whatever we got last time. It seems
 		// these are always stored in _km.x, _km.y.
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 		if (yDir < 0) {
 			event.type = Common::EVENT_WHEELDOWN;
 			return true;
@@ -744,10 +744,10 @@ bool SdlEventSource::handleMouseButtonUp(SDL_Event &ev, Common::Event &event) {
 bool SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 	if (ev.jbutton.button == JOY_BUT_LMOUSE) {
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 	} else if (ev.jbutton.button == JOY_BUT_RMOUSE) {
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 	} else {
 		event.type = Common::EVENT_KEYDOWN;
 		switch (ev.jbutton.button) {
@@ -775,10 +775,10 @@ bool SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 bool SdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 	if (ev.jbutton.button == JOY_BUT_LMOUSE) {
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 	} else if (ev.jbutton.button == JOY_BUT_RMOUSE) {
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+		processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 	} else {
 		event.type = Common::EVENT_KEYUP;
 		switch (ev.jbutton.button) {
@@ -808,7 +808,7 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 	int axis = ev.jaxis.value;
 #ifdef JOY_ANALOG
 	// conversion factor between keyboard mouse and joy axis value
-	int vel_to_axis = (1500 / _km.multiplier);
+	int vel_to_axis = (1500 / MULTIPLIER);
 #else
 	if (axis > JOY_DEADZONE) {
 		axis -= JOY_DEADZONE;
@@ -824,7 +824,7 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 		_km.x_down_count = 0;
 #else
 		if (axis != 0) {
-			_km.x_vel = (axis > 0) ? 1 * _km.multiplier:-1 * _km.multiplier;
+			_km.x_vel = (axis > 0) ? 1 * MULTIPLIER:-1 * MULTIPLIER;
 			_km.x_down_count = 1;
 		} else {
 			_km.x_vel = 0;
@@ -840,7 +840,7 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 		_km.y_down_count = 0;
 #else
 		if (axis != 0) {
-			_km.y_vel = (-axis > 0) ? 1 * _km.multiplier: -1 * _km.multiplier;
+			_km.y_vel = (-axis > 0) ? 1 * MULTIPLIER: -1 * MULTIPLIER;
 			_km.y_down_count = 1;
 		} else {
 			_km.y_vel = 0;

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -232,8 +232,8 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			}
 			// The modifier key makes the mouse movement slower
 			if (_km.modifier) {
-				_km.x += _km.x_vel / 5;
-				_km.y += _km.y_vel / 5;
+				_km.x += _km.x_vel / 10;
+				_km.y += _km.y_vel / 10;
 			} else {
 				_km.x += _km.x_vel;
 				_km.y += _km.y_vel;

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -205,12 +205,12 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 
 		if (_km.x_vel || _km.y_vel) {
 			if (_km.x_down_count) {
-				if (curTime > _km.x_down_time + _km.delay_time * 12) {
+				if (curTime > _km.x_down_time + 300) {
 					if (_km.x_vel > 0)
-						_km.x_vel+=_km.multiplier;
+						_km.x_vel += _km.multiplier;
 					else
-						_km.x_vel-=_km.multiplier;
-				} else if (curTime > _km.x_down_time + _km.delay_time * 8) {
+						_km.x_vel -= _km.multiplier;
+				} else if (curTime > _km.x_down_time + 200) {
 					if (_km.x_vel > 0)
 						_km.x_vel = 5 * _km.multiplier;
 					else
@@ -218,27 +218,33 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 				}
 			}
 			if (_km.y_down_count) {
-				if (curTime > _km.y_down_time + _km.delay_time * 12) {
+				if (curTime > _km.y_down_time + 300) {
 					if (_km.y_vel > 0)
 						_km.y_vel += _km.multiplier;
 					else
 						_km.y_vel -= _km.multiplier;
-				} else if (curTime > _km.y_down_time + _km.delay_time * 8) {
+				} else if (curTime > _km.y_down_time + 200) {
 					if (_km.y_vel > 0)
 						_km.y_vel = 5 * _km.multiplier;
 					else
 						_km.y_vel = -5 * _km.multiplier;
 				}
 			}
+
 			// The modifier key makes the mouse movement slower
+			// The extra factor of delay/25 makes velocities 
+			// independent of kbdMouse update rate
+			// all velovities were originally chosen
+			// at a delay of 25, so that is the reference
+			// operator order is important to avoid overflow
 			if (_km.modifier) {
-				_km.x += _km.x_vel / 10;
-				_km.y += _km.y_vel / 10;
+				_km.x += ((_km.x_vel / 10) * ((int16)_km.delay_time)) / 25;
+				_km.y += ((_km.y_vel / 10) * ((int16)_km.delay_time)) / 25;
 			} else {
-				_km.x += _km.x_vel;
-				_km.y += _km.y_vel;
+				_km.x += (_km.x_vel * ((int16)_km.delay_time)) / 25;
+				_km.y += (_km.y_vel * ((int16)_km.delay_time)) / 25;
 			}
-			
+
 			if (_km.x < 0) {
 				_km.x = 0;
 				_km.x_vel = -1 * _km.multiplier;
@@ -260,7 +266,7 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			}
 
 			if (_graphicsManager) {
-				_graphicsManager->getWindow()->warpMouseInWindow((Uint16) (_km.x / _km.multiplier), (Uint16) (_km.y / _km.multiplier));
+				_graphicsManager->getWindow()->warpMouseInWindow((Uint16)(_km.x / _km.multiplier), (Uint16)(_km.y / _km.multiplier));
 			}
 
 			if (_km.x != oldKmX || _km.y != oldKmY) {
@@ -446,9 +452,6 @@ Common::KeyCode SdlEventSource::SDLToOSystemKeycode(const SDLKey key) {
 }
 
 bool SdlEventSource::pollEvent(Common::Event &event) {
-	if (handleKbdMouse(event)) {
-		return true;
-	}
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	// In case we still need to send a key up event for a key down from a
@@ -474,6 +477,12 @@ bool SdlEventSource::pollEvent(Common::Event &event) {
 		if (dispatchSDLEvent(ev, event))
 			return true;
 	}
+
+	// Handle mouse control via analog joystick and keyboard
+	if (handleKbdMouse(event)) {
+		return true;
+	}
+
 	return false;
 }
 
@@ -799,14 +808,12 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 	int axis = ev.jaxis.value;
 #ifdef JOY_ANALOG
 	// conversion factor between keyboard mouse and joy axis value
-	int vel_to_axis = (3000 / _km.multiplier);
+	int vel_to_axis = (1500 / _km.multiplier);
 #else
 	if (axis > JOY_DEADZONE) {
 		axis -= JOY_DEADZONE;
-		event.type = Common::EVENT_MOUSEMOVE;
 	} else if (axis < -JOY_DEADZONE) {
 		axis += JOY_DEADZONE;
-		event.type = Common::EVENT_MOUSEMOVE;
 	} else
 		axis = 0;
 #endif
@@ -855,16 +862,13 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 		scalingFactor = 1.0f / magnitude * (magnitude - deadZone) / (32769.0f - deadZone);
 		_km.x_vel = (int16) (analogX * scalingFactor * 32768.0f / vel_to_axis);
 		_km.y_vel = (int16) (analogY * scalingFactor * 32768.0f / vel_to_axis);
-		event.type = Common::EVENT_MOUSEMOVE;
 	} else {
 		_km.y_vel = 0;
 		_km.x_vel = 0;
 	}
 #endif
 
-	processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
-
-	return true;
+	return false;
 }
 
 bool SdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
@@ -940,7 +944,6 @@ void SdlEventSource::resetKeyboardEmulation(int16 x_max, int16 y_max) {
 	_km.y_max = y_max;
 	_km.delay_time = 12;
 	_km.last_time = 0;
-	_km.multiplier = 16;
 	_km.modifier = false;
 }
 

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -30,6 +30,10 @@
 #include "common/config-manager.h"
 #include "common/textconsole.h"
 
+#ifdef JOY_ANALOG
+#include "math.h"
+#endif
+
 // FIXME move joystick defines out and replace with confile file options
 // we should really allow users to map any key to a joystick button
 #define JOY_DEADZONE 3200
@@ -175,12 +179,12 @@ void SdlEventSource::processMouseEvent(Common::Event &event, int x, int y) {
 	}
 
 	// Update the "keyboard mouse" coords
-	_km.x = x;
-	_km.y = y;
+	_km.x = x * _km.multiplier;
+	_km.y = y * _km.multiplier;
 }
 
-void SdlEventSource::handleKbdMouse(Common::Event &event) {
-
+bool SdlEventSource::handleKbdMouse(Common::Event &event) {
+	// returns true if an event is generated
 	// Skip recording of these events
 	uint32 curTime = g_system->getMillis(true);
 
@@ -203,63 +207,70 @@ void SdlEventSource::handleKbdMouse(Common::Event &event) {
 			if (_km.x_down_count) {
 				if (curTime > _km.x_down_time + _km.delay_time * 12) {
 					if (_km.x_vel > 0)
-						_km.x_vel++;
+						_km.x_vel+=_km.multiplier;
 					else
-						_km.x_vel--;
+						_km.x_vel-=_km.multiplier;
 				} else if (curTime > _km.x_down_time + _km.delay_time * 8) {
 					if (_km.x_vel > 0)
-						_km.x_vel = 5;
+						_km.x_vel = 5 * _km.multiplier;
 					else
-						_km.x_vel = -5;
+						_km.x_vel = -5 * _km.multiplier;
 				}
 			}
 			if (_km.y_down_count) {
 				if (curTime > _km.y_down_time + _km.delay_time * 12) {
 					if (_km.y_vel > 0)
-						_km.y_vel++;
+						_km.y_vel += _km.multiplier;
 					else
-						_km.y_vel--;
+						_km.y_vel -= _km.multiplier;
 				} else if (curTime > _km.y_down_time + _km.delay_time * 8) {
 					if (_km.y_vel > 0)
-						_km.y_vel = 5;
+						_km.y_vel = 5 * _km.multiplier;
 					else
-						_km.y_vel = -5;
+						_km.y_vel = -5 * _km.multiplier;
 				}
 			}
-
-			_km.x += _km.x_vel;
-			_km.y += _km.y_vel;
-
+			// The modifier key makes the mouse movement slower
+			if (_km.modifier) {
+				_km.x += _km.x_vel / 5;
+				_km.y += _km.y_vel / 5;
+			} else {
+				_km.x += _km.x_vel;
+				_km.y += _km.y_vel;
+			}
+			
 			if (_km.x < 0) {
 				_km.x = 0;
-				_km.x_vel = -1;
+				_km.x_vel = -1 * _km.multiplier;
 				_km.x_down_count = 1;
-			} else if (_km.x > _km.x_max) {
-				_km.x = _km.x_max;
-				_km.x_vel = 1;
+			} else if (_km.x > _km.x_max * _km.multiplier) {
+				_km.x = _km.x_max * _km.multiplier;
+				_km.x_vel = 1 * _km.multiplier;
 				_km.x_down_count = 1;
 			}
 
 			if (_km.y < 0) {
 				_km.y = 0;
-				_km.y_vel = -1;
+				_km.y_vel = -1 * _km.multiplier;
 				_km.y_down_count = 1;
-			} else if (_km.y > _km.y_max) {
-				_km.y = _km.y_max;
-				_km.y_vel = 1;
+			} else if (_km.y > _km.y_max * _km.multiplier) {
+				_km.y = _km.y_max * _km.multiplier;
+				_km.y_vel = 1 * _km.multiplier;
 				_km.y_down_count = 1;
 			}
 
 			if (_graphicsManager) {
-				_graphicsManager->getWindow()->warpMouseInWindow((Uint16)_km.x, (Uint16)_km.y);
+				_graphicsManager->getWindow()->warpMouseInWindow((Uint16) (_km.x / _km.multiplier), (Uint16) (_km.y / _km.multiplier));
 			}
 
 			if (_km.x != oldKmX || _km.y != oldKmY) {
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				return true;
 			}
 		}
 	}
+	return false;
 }
 
 void SdlEventSource::SDLModToOSystemKeyFlags(SDLMod mod, Common::Event &event) {
@@ -435,8 +446,9 @@ Common::KeyCode SdlEventSource::SDLToOSystemKeycode(const SDLKey key) {
 }
 
 bool SdlEventSource::pollEvent(Common::Event &event) {
-	handleKbdMouse(event);
-
+	if (handleKbdMouse(event)) {
+		return true;
+	}
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	// In case we still need to send a key up event for a key down from a
@@ -496,7 +508,7 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		// with a mouse wheel event. However, SDL2 does not supply
 		// these, thus we use whatever we got last time. It seems
 		// these are always stored in _km.x, _km.y.
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		if (yDir < 0) {
 			event.type = Common::EVENT_WHEELDOWN;
 			return true;
@@ -723,10 +735,10 @@ bool SdlEventSource::handleMouseButtonUp(SDL_Event &ev, Common::Event &event) {
 bool SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 	if (ev.jbutton.button == JOY_BUT_LMOUSE) {
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 	} else if (ev.jbutton.button == JOY_BUT_RMOUSE) {
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 	} else {
 		event.type = Common::EVENT_KEYDOWN;
 		switch (ev.jbutton.button) {
@@ -754,10 +766,10 @@ bool SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 bool SdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 	if (ev.jbutton.button == JOY_BUT_LMOUSE) {
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 	} else if (ev.jbutton.button == JOY_BUT_RMOUSE) {
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x, _km.y);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 	} else {
 		event.type = Common::EVENT_KEYUP;
 		switch (ev.jbutton.button) {
@@ -783,7 +795,12 @@ bool SdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 }
 
 bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
+
 	int axis = ev.jaxis.value;
+#ifdef JOY_ANALOG
+	// conversion factor between keyboard mouse and joy axis value
+	int vel_to_axis = (3000 / _km.multiplier);
+#else
 	if (axis > JOY_DEADZONE) {
 		axis -= JOY_DEADZONE;
 		event.type = Common::EVENT_MOUSEMOVE;
@@ -792,14 +809,15 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 		event.type = Common::EVENT_MOUSEMOVE;
 	} else
 		axis = 0;
+#endif
 
 	if (ev.jaxis.axis == JOY_XAXIS) {
 #ifdef JOY_ANALOG
-		_km.x_vel = axis / 2000;
+		_km.x_vel = axis / vel_to_axis;
 		_km.x_down_count = 0;
 #else
 		if (axis != 0) {
-			_km.x_vel = (axis > 0) ? 1:-1;
+			_km.x_vel = (axis > 0) ? 1 * _km.multiplier:-1 * _km.multiplier;
 			_km.x_down_count = 1;
 		} else {
 			_km.x_vel = 0;
@@ -811,11 +829,11 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 		axis = -axis;
 #endif
 #ifdef JOY_ANALOG
-		_km.y_vel = -axis / 2000;
+		_km.y_vel = -axis / vel_to_axis;
 		_km.y_down_count = 0;
 #else
 		if (axis != 0) {
-			_km.y_vel = (-axis > 0) ? 1: -1;
+			_km.y_vel = (-axis > 0) ? 1 * _km.multiplier: -1 * _km.multiplier;
 			_km.y_down_count = 1;
 		} else {
 			_km.y_vel = 0;
@@ -823,8 +841,28 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 		}
 #endif
 	}
+#ifdef JOY_ANALOG
+	// radial and scaled analog joystick deadzone
+	float analogX = (float) (_km.x_vel * vel_to_axis);
+	float analogY = (float) (_km.y_vel * vel_to_axis);
+	float deadZone = (float) JOY_DEADZONE;
+	float scalingFactor = 1.0f;
+	float magnitude = 0.0f;
 
-	processMouseEvent(event, _km.x, _km.y);
+	magnitude = sqrt(analogX * analogX + analogY * analogY);
+
+	if (magnitude >= deadZone) {
+		scalingFactor = 1.0f / magnitude * (magnitude - deadZone) / (32769.0f - deadZone);
+		_km.x_vel = (int16) (analogX * scalingFactor * 32768.0f / vel_to_axis);
+		_km.y_vel = (int16) (analogY * scalingFactor * 32768.0f / vel_to_axis);
+		event.type = Common::EVENT_MOUSEMOVE;
+	} else {
+		_km.y_vel = 0;
+		_km.x_vel = 0;
+	}
+#endif
+
+	processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 	return true;
 }
@@ -900,8 +938,10 @@ bool SdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 void SdlEventSource::resetKeyboardEmulation(int16 x_max, int16 y_max) {
 	_km.x_max = x_max;
 	_km.y_max = y_max;
-	_km.delay_time = 25;
+	_km.delay_time = 12;
 	_km.last_time = 0;
+	_km.multiplier = 16;
+	_km.modifier = false;
 }
 
 bool SdlEventSource::handleResizeEvent(Common::Event &event, int w, int h) {

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -28,6 +28,8 @@
 
 #include "common/events.h"
 
+// multiplier used to increase resolution for keyboard/joystick mouse
+#define MULTIPLIER 16
 
 /**
  * The SDL event source.
@@ -59,7 +61,6 @@ protected:
 
 	struct KbdMouse {
 		int16 x, y, x_vel, y_vel, x_max, y_max, x_down_count, y_down_count;
-		static const int16 multiplier = 16;
 		uint32 last_time, delay_time, x_down_time, y_down_time;
 		bool modifier;
 	};

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -58,8 +58,9 @@ protected:
 	//@{
 
 	struct KbdMouse {
-		int16 x, y, x_vel, y_vel, x_max, y_max, x_down_count, y_down_count;
+		int16 x, y, x_vel, y_vel, x_max, y_max, x_down_count, y_down_count, multiplier;
 		uint32 last_time, delay_time, x_down_time, y_down_time;
+		bool modifier;
 	};
 	KbdMouse _km;
 
@@ -106,7 +107,7 @@ protected:
 	virtual bool handleJoyButtonDown(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyButtonUp(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyAxisMotion(SDL_Event &ev, Common::Event &event);
-	virtual void handleKbdMouse(Common::Event &event);
+	virtual bool handleKbdMouse(Common::Event &event);
 
 	//@}
 

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -58,7 +58,8 @@ protected:
 	//@{
 
 	struct KbdMouse {
-		int16 x, y, x_vel, y_vel, x_max, y_max, x_down_count, y_down_count, multiplier;
+		int16 x, y, x_vel, y_vel, x_max, y_max, x_down_count, y_down_count;
+		static const int16 multiplier = 16;
 		uint32 last_time, delay_time, x_down_time, y_down_time;
 		bool modifier;
 	};

--- a/backends/events/symbiansdl/symbiansdl-events.cpp
+++ b/backends/events/symbiansdl/symbiansdl-events.cpp
@@ -56,76 +56,76 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			switch (loop) {
 			case GUI::ACTION_UP:
 				if (ev.type == SDL_KEYDOWN) {
-					_km.y_vel = -1 * _km.multiplier;
+					_km.y_vel = -1 * MULTIPLIER;
 					_km.y_down_count = 1;
 				} else {
-					_km.y_vel = 0 * _km.multiplier;
+					_km.y_vel = 0 * MULTIPLIER;
 					_km.y_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 				return true;
 
 			case GUI::ACTION_DOWN:
 				if (ev.type == SDL_KEYDOWN) {
-					_km.y_vel = 1 * _km.multiplier;
+					_km.y_vel = 1 * MULTIPLIER;
 					_km.y_down_count = 1;
 				} else {
-					_km.y_vel = 0 * _km.multiplier;
+					_km.y_vel = 0 * MULTIPLIER;
 					_km.y_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 				return true;
 
 			case GUI::ACTION_LEFT:
 				if (ev.type == SDL_KEYDOWN) {
-					_km.x_vel = -1 * _km.multiplier;
+					_km.x_vel = -1 * MULTIPLIER;
 					_km.x_down_count = 1;
 				} else {
-					_km.x_vel = 0 * _km.multiplier;
+					_km.x_vel = 0 * MULTIPLIER;
 					_km.x_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 				return true;
 
 			case GUI::ACTION_RIGHT:
 				if (ev.type == SDL_KEYDOWN) {
-					_km.x_vel = 1 * _km.multiplier;
+					_km.x_vel = 1 * MULTIPLIER;
 					_km.x_down_count = 1;
 				} else {
-					_km.x_vel = 0 * _km.multiplier;
+					_km.x_vel = 0 * MULTIPLIER;
 					_km.x_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 				return true;
 
 			case GUI::ACTION_LEFTCLICK:
 				event.type = (ev.type == SDL_KEYDOWN ? Common::EVENT_LBUTTONDOWN : Common::EVENT_LBUTTONUP);
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 				return true;
 
 			case GUI::ACTION_RIGHTCLICK:
 				event.type = (ev.type == SDL_KEYDOWN ? Common::EVENT_RBUTTONDOWN : Common::EVENT_RBUTTONUP);
-				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
+				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
 
 				return true;
 
 			case GUI::ACTION_ZONE:
 				if (ev.type == SDL_KEYDOWN) {
 					for (int i = 0; i < TOTAL_ZONES; i++)
-						if ( (_km.x / _km.multiplier) >= _zones[i].x && (_km.y / _km.multiplier) >= _zones[i].y &&
-							(_km.x / _km.multiplier) <= _zones[i].x + _zones[i].width && (_km.y / _km.multiplier <= _zones[i].y + _zones[i].height
+						if ( (_km.x / MULTIPLIER) >= _zones[i].x && (_km.y / MULTIPLIER) >= _zones[i].y &&
+							(_km.x / MULTIPLIER) <= _zones[i].x + _zones[i].width && (_km.y / MULTIPLIER <= _zones[i].y + _zones[i].height
 							) {
-							_mouseXZone[i] = _km.x / _km.multiplier;
-							_mouseYZone[i] = _km.y / _km.multiplier;
+							_mouseXZone[i] = _km.x / MULTIPLIER;
+							_mouseYZone[i] = _km.y / MULTIPLIER;
 							break;
 						}
 						_currentZone++;

--- a/backends/events/symbiansdl/symbiansdl-events.cpp
+++ b/backends/events/symbiansdl/symbiansdl-events.cpp
@@ -56,76 +56,76 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			switch (loop) {
 			case GUI::ACTION_UP:
 				if (ev.type == SDL_KEYDOWN) {
-					_km.y_vel = -1;
+					_km.y_vel = -1 * _km.multiplier;
 					_km.y_down_count = 1;
 				} else {
-					_km.y_vel = 0;
+					_km.y_vel = 0 * _km.multiplier;
 					_km.y_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_DOWN:
 				if (ev.type == SDL_KEYDOWN) {
-					_km.y_vel = 1;
+					_km.y_vel = 1 * _km.multiplier;
 					_km.y_down_count = 1;
 				} else {
-					_km.y_vel = 0;
+					_km.y_vel = 0 * _km.multiplier;
 					_km.y_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_LEFT:
 				if (ev.type == SDL_KEYDOWN) {
-					_km.x_vel = -1;
+					_km.x_vel = -1 * _km.multiplier;
 					_km.x_down_count = 1;
 				} else {
-					_km.x_vel = 0;
+					_km.x_vel = 0 * _km.multiplier;
 					_km.x_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_RIGHT:
 				if (ev.type == SDL_KEYDOWN) {
-					_km.x_vel = 1;
+					_km.x_vel = 1 * _km.multiplier;
 					_km.x_down_count = 1;
 				} else {
-					_km.x_vel = 0;
+					_km.x_vel = 0 * _km.multiplier;
 					_km.x_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_LEFTCLICK:
 				event.type = (ev.type == SDL_KEYDOWN ? Common::EVENT_LBUTTONDOWN : Common::EVENT_LBUTTONUP);
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_RIGHTCLICK:
 				event.type = (ev.type == SDL_KEYDOWN ? Common::EVENT_RBUTTONDOWN : Common::EVENT_RBUTTONUP);
-				processMouseEvent(event, _km.x, _km.y);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_ZONE:
 				if (ev.type == SDL_KEYDOWN) {
 					for (int i = 0; i < TOTAL_ZONES; i++)
-						if (_km.x >= _zones[i].x && _km.y >= _zones[i].y &&
-							_km.x <= _zones[i].x + _zones[i].width && _km.y <= _zones[i].y + _zones[i].height
+						if ( (_km.x / _km.multiplier) >= _zones[i].x && (_km.y / _km.multiplier) >= _zones[i].y &&
+							(_km.x / _km.multiplier) <= _zones[i].x + _zones[i].width && (_km.y / _km.multiplier <= _zones[i].y + _zones[i].height
 							) {
-							_mouseXZone[i] = _km.x;
-							_mouseYZone[i] = _km.y;
+							_mouseXZone[i] = _km.x / _km.multiplier;
+							_mouseYZone[i] = _km.y / _km.multiplier;
 							break;
 						}
 						_currentZone++;

--- a/backends/events/wincesdl/wincesdl-events.cpp
+++ b/backends/events/wincesdl/wincesdl-events.cpp
@@ -48,8 +48,8 @@ void WINCESdlEventSource::processMouseEvent(Common::Event &event, int x, int y) 
 	event.mouse.y = y;
 
 	// Update the "keyboard mouse" coords
-	_km.x = event.mouse.x;
-	_km.y = event.mouse.y;
+	_km.x = event.mouse.x * _km.multiplier;
+	_km.y = event.mouse.y * _km.multiplier;
 
 	// Adjust for the screen scaling
 	if (_graphicsMan->_zoomDown)
@@ -69,7 +69,9 @@ bool WINCESdlEventSource::pollEvent(Common::Event &event) {
 
 	memset(&event, 0, sizeof(Common::Event));
 
-	handleKbdMouse(event);
+	if (handleKbdMouse(event) {
+		return true;
+	}
 
 	// If the screen changed, send an Common::EVENT_SCREEN_CHANGED
 	int screenID = _graphicsMan->getScreenChangeID();

--- a/backends/events/wincesdl/wincesdl-events.cpp
+++ b/backends/events/wincesdl/wincesdl-events.cpp
@@ -48,8 +48,8 @@ void WINCESdlEventSource::processMouseEvent(Common::Event &event, int x, int y) 
 	event.mouse.y = y;
 
 	// Update the "keyboard mouse" coords
-	_km.x = event.mouse.x * _km.multiplier;
-	_km.y = event.mouse.y * _km.multiplier;
+	_km.x = event.mouse.x * MULTIPLIER;
+	_km.y = event.mouse.y * MULTIPLIER;
 
 	// Adjust for the screen scaling
 	if (_graphicsMan->_zoomDown)


### PR DESCRIPTION
For some engines such as Dreamweb that a previous fix did not apply to, this fixes bug 6996: Android: Mouse pointer control with analog joystick is unusable.

The improvements are not limited to Android but apply to any host system that uses the SDL backend and allows analog joystick mouse pointer movement (Vita, Raspberry Pi etc.).

This PR fixes the remaining problems with analog joystick mouse pointer control.

Most importantly 

- handleKbdMouse now returns a bool so that the MouseEvents generated by it are not dropped anymore

Other analog joystick problems that are fixed in this PR are:

- increased resolution of analog joystick mouse speeds. It had only ~16 speed increments instead of the max possible 32768.

- improved smoothness of pointer movement. The position of the joystick-controlled mouse pointer is now updated at ~60 fps instead of the original, stuttery ~40 fps.

- improved the joystick deadzone by replacing the axial ("naive") deadzone with a proper radial scaled implementation. See http://www.third-helix.com/2013/04/12/doing-thumbstick-dead-zones-right.html for the differences between the two deadzone methods.

With the changes in this PR, the analog mouse pointer behavior is much improved in all engines.