### PR TITLE
SCUMM: MM V0: Fix two walk animation issues

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -937,7 +937,6 @@ L2A33:;
 	}
 
 	if ((_moving & 0x0F) == 3) {
-L2C36:;
 		setTmpFromActor();
 
 		if (!_walkDirX) {
@@ -980,7 +979,6 @@ L2C36:;
 
 	// 2ADA
 	if ((_moving & 0x0F) == 4) {
-L2CA3:;
 		setTmpFromActor();
 
 		if (!_walkDirY) {
@@ -1045,7 +1043,7 @@ L2CA3:;
 
 				directionUpdate();
 				animateActor(newDirToOldDir(_facing));
-				goto L2C36;
+				return;
 
 			} else {
 				// 2B39
@@ -1064,7 +1062,7 @@ L2CA3:;
 
 				directionUpdate();
 				animateActor(newDirToOldDir(_facing));
-				goto L2CA3;
+				return;
 			}
 		}
 	}

--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -2416,6 +2416,7 @@ void Actor_v0::startAnimActor(int f) {
 			return;
 
 		_speaking = 1;
+		speakCheck();
 		return;
 	}
 


### PR DESCRIPTION
Hi,

This PR is for two animation issues,

1. During the cutscene in script-151 (Purple Tentacle chases Sandy), Sandy appears to slide as the walk animation begins durnig the same frame as she begins speaking, this sets the 'repeat' flag for all limbs. We fix this by specifically running the speakCheck function, if speaking has been enabled.

2. Some walkboxes contain a 1 pixel gap, which the original handles using a JMP (when we reach a situation with no valid walkbox), and then move the actor again. I believe on the C64 this is unnoticeable, as it  enough time passes for the interrupts which redraw the screen to fire. In ScummVM, the actor is only drawn once per frame, causing them to move 2 pixels or 'skip'
