### PR TITLE
SDL: Always use sub-pixel joystick pointer

### DIFF
--- a/backends/events/androidsdl/androidsdl-events.cpp
+++ b/backends/events/androidsdl/androidsdl-events.cpp
@@ -50,6 +50,9 @@ bool AndroidSdlEventSource::handleMouseButtonDown(SDL_Event &ev, Common::Event &
 		return false;
 
 	processMouseEvent(event, ev.button.x, ev.button.y);
+	// update KbdMouse
+	_km.x = ev.button.x * MULTIPLIER;
+	_km.y = ev.button.y * MULTIPLIER;
 
 	return true;
 }

--- a/backends/events/gph/gph-events.cpp
+++ b/backends/events/gph/gph-events.cpp
@@ -191,6 +191,9 @@ bool GPHEventSource::handleMouseButtonDown(SDL_Event &ev, Common::Event &event) 
 		return false;
 
 	processMouseEvent(event, ev.button.x, ev.button.y);
+	// update KbdMouse
+	_km.x = ev.button.x * MULTIPLIER;
+	_km.y = ev.button.y * MULTIPLIER;
 
 	return true;
 }
@@ -217,6 +220,9 @@ bool GPHEventSource::handleMouseButtonUp(SDL_Event &ev, Common::Event &event) {
 		return false;
 
 	processMouseEvent(event, ev.button.x, ev.button.y);
+	// update KbdMouse
+	_km.x = ev.button.x * MULTIPLIER;
+	_km.y = ev.button.y * MULTIPLIER;
 
 	return true;
 }

--- a/backends/events/openpandora/op-events.cpp
+++ b/backends/events/openpandora/op-events.cpp
@@ -84,6 +84,9 @@ bool OPEventSource::handleMouseButtonDown(SDL_Event &ev, Common::Event &event) {
 		return false;
 
 	processMouseEvent(event, ev.button.x, ev.button.y);
+	// update KbdMouse
+	_km.x = ev.button.x * MULTIPLIER;
+	_km.y = ev.button.y * MULTIPLIER;
 
 	return true;
 }
@@ -112,6 +115,9 @@ bool OPEventSource::handleMouseButtonUp(SDL_Event &ev, Common::Event &event) {
 		return false;
 
 	processMouseEvent(event, ev.button.x, ev.button.y);
+	// update KbdMouse
+	_km.x = ev.button.x * MULTIPLIER;
+	_km.y = ev.button.y * MULTIPLIER;
 
 	return true;
 }

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -177,10 +177,6 @@ void SdlEventSource::processMouseEvent(Common::Event &event, int x, int y) {
 		_graphicsManager->notifyMousePos(Common::Point(x, y));
 		_graphicsManager->transformMouseCoordinates(event.mouse);
 	}
-
-	// Update the "keyboard mouse" coords
-	_km.x = x * MULTIPLIER;
-	_km.y = y * MULTIPLIER;
 }
 
 bool SdlEventSource::handleKbdMouse(Common::Event &event) {
@@ -311,14 +307,8 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			}
 
 			if (_km.x != oldKmX || _km.y != oldKmY) {
-				// keep hi-res coordinates since 
-				// processMouseEvent will overwrite them with lo-res numbers
-				oldKmX = _km.x;
-				oldKmY = _km.y;
 				event.type = Common::EVENT_MOUSEMOVE;
 				processMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER);
-				_km.x = oldKmX;
-				_km.y = oldKmY;
 				return true;
 			}
 		}
@@ -745,6 +735,9 @@ bool SdlEventSource::handleKeyUp(SDL_Event &ev, Common::Event &event) {
 bool SdlEventSource::handleMouseMotion(SDL_Event &ev, Common::Event &event) {
 	event.type = Common::EVENT_MOUSEMOVE;
 	processMouseEvent(event, ev.motion.x, ev.motion.y);
+	// update KbdMouse
+	_km.x = ev.motion.x * MULTIPLIER;
+	_km.y = ev.motion.y * MULTIPLIER;
 
 	return true;
 }
@@ -768,6 +761,9 @@ bool SdlEventSource::handleMouseButtonDown(SDL_Event &ev, Common::Event &event) 
 		return false;
 
 	processMouseEvent(event, ev.button.x, ev.button.y);
+	// update KbdMouse
+	_km.x = ev.button.x * MULTIPLIER;
+	_km.y = ev.button.y * MULTIPLIER;
 
 	return true;
 }
@@ -784,6 +780,9 @@ bool SdlEventSource::handleMouseButtonUp(SDL_Event &ev, Common::Event &event) {
 	else
 		return false;
 	processMouseEvent(event, ev.button.x, ev.button.y);
+	// update KbdMouse
+	_km.x = ev.button.x * MULTIPLIER;
+	_km.y = ev.button.y * MULTIPLIER;
 
 	return true;
 }

--- a/backends/events/symbiansdl/symbiansdl-events.cpp
+++ b/backends/events/symbiansdl/symbiansdl-events.cpp
@@ -133,6 +133,10 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 							_currentZone = 0;
 						event.type = Common::EVENT_MOUSEMOVE;
 						processMouseEvent(event, _mouseXZone[_currentZone], _mouseYZone[_currentZone]);
+						// update KbdMouse
+						_km.x = _mouseXZone[_currentZone] * MULTIPLIER;
+						_km.y = _mouseYZone[_currentZone] * MULTIPLIER;
+
 						if (_graphicsManager) {
 							_graphicsManager->getWindow()->warpMouseInWindow(event.mouse.x, event.mouse.y);
 						}

--- a/backends/events/webossdl/webossdl-events.cpp
+++ b/backends/events/webossdl/webossdl-events.cpp
@@ -150,6 +150,9 @@ bool WebOSSdlEventSource::handleMouseButtonDown(SDL_Event &ev,
 			_dragging = true;
 			event.type = Common::EVENT_LBUTTONDOWN;
 			processMouseEvent(event, _curX, _curY);
+			// update KbdMouse
+			_km.x = _curX * MULTIPLIER;
+			_km.y = _curY * MULTIPLIER;
 		}
 		// If we're not in trackpad mode, move the cursor to the tap
 		if (!_trackpadMode) {
@@ -158,11 +161,17 @@ bool WebOSSdlEventSource::handleMouseButtonDown(SDL_Event &ev,
 			// If we're already clicking, hold it until after the move.
 			if (event.type == Common::EVENT_LBUTTONDOWN) {
 				processMouseEvent(event, _curX, _curY);
+				// update KbdMouse
+				_km.x = _curX * MULTIPLIER;
+				_km.y = _curY * MULTIPLIER;
 				g_system->getEventManager()->pushEvent(event);
 			}
 			// Move the mouse
 			event.type = Common::EVENT_MOUSEMOVE;
 			processMouseEvent(event, _curX, _curY);
+			// update KbdMouse
+			_km.x = _curX * MULTIPLIER;
+			_km.y = _curY * MULTIPLIER;
 		}
 		// Watch for a double-tap-triggered drag
 		_dragStartTime = g_system->getMillis();
@@ -191,6 +200,9 @@ bool WebOSSdlEventSource::handleMouseButtonUp(SDL_Event &ev,
 		if (ev.button.which == 0 && _dragging) {
 			event.type = Common::EVENT_LBUTTONUP;
 			processMouseEvent(event, _curX, _curY);
+			// update KbdMouse
+			_km.x = _curX * MULTIPLIER;
+			_km.y = _curY * MULTIPLIER;
 			_dragging = false;
 		} else {
 			// If it was the first finger and the click hasn't been
@@ -199,6 +211,9 @@ bool WebOSSdlEventSource::handleMouseButtonUp(SDL_Event &ev,
 					!_fingerDown[1] && !_fingerDown[2]) {
 				event.type = Common::EVENT_LBUTTONUP;
 				processMouseEvent(event, _curX, _curY);
+				// update KbdMouse
+				_km.x = _curX * MULTIPLIER;
+				_km.y = _curY * MULTIPLIER;
 				g_system->getEventManager()->pushEvent(event);
 				event.type = Common::EVENT_LBUTTONDOWN;
 				if (_queuedDragTime > 0)
@@ -209,6 +224,9 @@ bool WebOSSdlEventSource::handleMouseButtonUp(SDL_Event &ev,
 				// right mouse click.
 				event.type = Common::EVENT_RBUTTONDOWN;
 				processMouseEvent(event, _curX, _curY);
+				// update KbdMouse
+				_km.x = _curX * MULTIPLIER;
+				_km.y = _curY * MULTIPLIER;
 				_queuedRUpTime = g_system->getMillis() + QUEUED_RUP_DELAY;
 			} else if (ev.button.which == 2 &&
 					_fingerDown[0] && _fingerDown[1]) {
@@ -217,6 +235,9 @@ bool WebOSSdlEventSource::handleMouseButtonUp(SDL_Event &ev,
 				// as a right click.
 				event.type = Common::EVENT_MBUTTONUP;
 				processMouseEvent(event, _curX, _curY);
+				// update KbdMouse
+				_km.x = _curX * MULTIPLIER;
+				_km.y = _curY * MULTIPLIER;
 				g_system->getEventManager()->pushEvent(event);
 				event.type = Common::EVENT_MBUTTONDOWN;
 				_fingerDown[1] = false;
@@ -263,6 +284,9 @@ bool WebOSSdlEventSource::handleMouseMotion(SDL_Event &ev,
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
 				processMouseEvent(event, _curX, _curY);
+				// update KbdMouse
+				_km.x = _curX * MULTIPLIER;
+				_km.y = _curY * MULTIPLIER;
 			}
 			break;
 		case 1:
@@ -407,12 +431,18 @@ bool WebOSSdlEventSource::pollEvent(Common::Event &event) {
 	} else if (_queuedRUpTime != 0 && curTime >= _queuedRUpTime) {
 		event.type = Common::EVENT_RBUTTONUP;
 		processMouseEvent(event, _curX, _curY);
+		// update KbdMouse
+		_km.x = _curX * MULTIPLIER;
+		_km.y = _curY * MULTIPLIER;
 		_queuedRUpTime = 0;
 		return true;
 	} else if (_queuedDragTime != 0 && curTime >= _queuedDragTime) {
 		event.type = Common::EVENT_LBUTTONDOWN;
 		_dragging = true;
 		processMouseEvent(event, _curX, _curY);
+		// update KbdMouse
+		_km.x = _curX * MULTIPLIER;
+		_km.y = _curY * MULTIPLIER;
 		_queuedDragTime = 0;
 		return true;
 	}

--- a/backends/events/wincesdl/wincesdl-events.cpp
+++ b/backends/events/wincesdl/wincesdl-events.cpp
@@ -156,6 +156,10 @@ bool WINCESdlEventSource::pollEvent(Common::Event &event) {
 		case SDL_MOUSEMOTION:
 			event.type = Common::EVENT_MOUSEMOVE;
 			processMouseEvent(event, ev.motion.x, ev.motion.y);
+			// update KbdMouse
+			_km.x = ev.motion.x * MULTIPLIER;
+			_km.y = ev.motion.y * MULTIPLIER;
+
 			_graphicsMan->setMousePos(event.mouse.x, event.mouse.y);
 
 			return true;
@@ -168,7 +172,9 @@ bool WINCESdlEventSource::pollEvent(Common::Event &event) {
 			else
 				break;
 			processMouseEvent(event, ev.button.x, ev.button.y);
-
+			// update KbdMouse
+			_km.x = ev.button.x * MULTIPLIER;
+			_km.y = ev.button.y * MULTIPLIER;
 
 			if (event.mouse.x > _tapX)
 				deltaX = event.mouse.x - _tapX;
@@ -244,6 +250,9 @@ bool WINCESdlEventSource::pollEvent(Common::Event &event) {
 			}
 
 			processMouseEvent(event, ev.button.x, ev.button.y);
+			// update KbdMouse
+			_km.x = ev.button.x * MULTIPLIER;
+			_km.y = ev.button.y * MULTIPLIER;
 
 			if (freeLookActive && !_closeClick) {
 				_tapX = event.mouse.x;


### PR DESCRIPTION
With the new joystick pointer speed adjustment in the SDL backend which can be less then one pixel per frame delay, all calls to 
ProcessMouseEvent(event, _km.x / MULTIPLIER, _km.y / MULTIPLIER) 
with those exact second and third arguments need to be prevented from updating _km.x and _km.y since that will destroy the sub-pixel resolution and make the joystick pointer control less precise. But calls to ProcessMouseEvent with other arguments should still update _km.x and _km.y.

Before this PR, the call to ProcessMouseEvent inside handleKbdMouse was made to work correctly by first saving and, after the call, re-loading the hi-res _km.x and _km.y coordinate values. But all the other calls still exhibit the problem of overwriting _km.x and _km.y with imprecise numbers.

To fix this, in this PR, I removed the update of _km.x and _km.y from the processMouseEvent routine, and instead added explicit _km updates to the sources where they are needed. Since most calls to ProcessMouseEvent are in the form ProcessMouseEvent(_km.x / MULTIPLIER, _km.y / MULTIPLIER) this did not require many changes, and I think the result is (IMO) in clearer code since processMouseEvent does not have this side-effect of changing _km.x and _km.y anymore.