### PR TITLE
SDL: Fix trying to init non-supported shaders

### DIFF
--- a/backends/graphics/psp2sdl/psp2sdl-graphics.cpp
+++ b/backends/graphics/psp2sdl/psp2sdl-graphics.cpp
@@ -87,20 +87,15 @@ PSP2SdlGraphicsManager::PSP2SdlGraphicsManager(SdlEventSource *sdlEventSource, S
 	}
 	_videoMode.aspectRatioCorrection = false;
 
-	if (g_system->hasFeature(OSystem::kFeatureShader)) {
-		// shader number 0 is the entry NONE (no shader)
-		const OSystem::GraphicsMode *p = s_supportedShadersPSP2;
-		_numShaders = 0;
-		while (p->name) { 
-			_numShaders++;
-			p++;
-		}
-		_currentShader = ConfMan.getInt("shader");
-		if (_currentShader < 0 || _currentShader >= _numShaders) {
-			_currentShader = 0;
-		}
-	} else {
-		_numShaders = 1;
+	// shader number 0 is the entry NONE (no shader)
+	const OSystem::GraphicsMode *p = s_supportedShadersPSP2;
+	_numShaders = 0;
+	while (p->name) { 
+		_numShaders++;
+		p++;
+	}
+	_currentShader = ConfMan.getInt("shader");
+	if (_currentShader < 0 || _currentShader >= _numShaders) {
 		_currentShader = 0;
 	}
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -200,24 +200,12 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 	_videoMode.filtering = ConfMan.getBool("filtering");
 #endif
 
-	// Default backend does not have shaders. Disable check.
-	// TODO: Implement more elegant way.
-	if (0 && g_system->hasFeature(OSystem::kFeatureShader)) {
-		// shader number 0 is the entry NONE (no shader)
-		const OSystem::GraphicsMode *p = s_supportedShaders;
-		_numShaders = 0;
-		while (p->name) {
-			_numShaders++;
-			p++;
-		}
-		_currentShader = ConfMan.getInt("shader");
-		if (_currentShader < 0 || _currentShader >= _numShaders) {
-			_currentShader = 0;
-		}
-	} else {
-		_numShaders = 1;
-		_currentShader = 0;
-	}
+	// the default backend has no shaders
+	// shader number 0 is the entry NONE (no shader)
+	// for an example on shader support,
+	// consult the psp2sdl backend which inherits from this class
+	_currentShader = 0;
+	_numShaders = 1;
 }
 
 SurfaceSdlGraphicsManager::~SurfaceSdlGraphicsManager() {


### PR DESCRIPTION
There was a problem with calling gSystem->hasFeature(kFeatureShader) from within the constructor of SurfaceSdlGraphicsManager. If the system-specific OSystem does not enable that feature, the call is passed on to _graphicsManager->hasFeature(kFeatureShader) by ModularBackend. But since we are in the constructor of _graphicsManager, _graphicsManager is still a NULL pointer at this point and a crash occurs.

This is fixed in this commit.