### PR TITLE
GUI: Fix for #9711

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -2420,19 +2420,32 @@ Common::String ThemeEngine::getThemeId(const Common::String &filename) {
 		return "builtin";
 
 	Common::FSNode node(filename);
-	if (!node.exists())
-		return "builtin";
+	if (node.exists()) {
+		if (node.getName().matchString("*.zip", true)) {
+			Common::String id = node.getName();
 
-	if (node.getName().matchString("*.zip", true)) {
-		Common::String id = node.getName();
+			for (int i = 0; i < 4; ++i)
+				id.deleteLastChar();
 
-		for (int i = 0; i < 4; ++i)
-			id.deleteLastChar();
-
-		return id;
-	} else {
-		return node.getName();
+			return id;
+		} else {
+			return node.getName();
+		}
 	}
+
+	// FIXME:
+	// A very ugly hack to map a id to a filename, this will generate
+	// a complete theme list, thus it is slower than it could be.
+	// But it is the easiest solution for now.
+	Common::List<ThemeDescriptor> list;
+	listUsableThemes(list);
+
+	for (Common::List<ThemeDescriptor>::const_iterator i = list.begin(); i != list.end(); ++i) {
+		if (filename.equalsIgnoreCase(i->filename))
+			return i->id;
+	}
+
+	return "builtin";
 }
 
 void ThemeEngine::showCursor() {

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -1838,24 +1838,6 @@ void GlobalOptionsDialog::apply() {
 		g_gui.loadNewTheme(g_gui.theme()->getThemeId(), selected);
 		ConfMan.set("gui_renderer", cfg, _domain);
 	}
-#ifdef USE_TRANSLATION
-	Common::String oldLang = ConfMan.get("gui_language");
-	int selLang = _guiLanguagePopUp->getSelectedTag();
-
-	ConfMan.set("gui_language", TransMan.getLangById(selLang));
-
-	Common::String newLang = ConfMan.get("gui_language").c_str();
-	if (newLang != oldLang) {
-		// Activate the selected language
-		TransMan.setLanguage(selLang);
-
-		// Rebuild the Launcher and Options dialogs
-		g_gui.loadNewTheme(g_gui.theme()->getThemeId(), ThemeEngine::kGfxDisabled, true);
-		rebuild();
-		if (_launcher != 0)
-			_launcher->rebuild();
-	}
-#endif // USE_TRANSLATION
 
 #ifdef USE_UPDATES
 	ConfMan.setInt("updates_check", _updatesPopUp->getSelectedTag());
@@ -1926,6 +1908,24 @@ void GlobalOptionsDialog::apply() {
 		draw();
 		_newTheme.clear();
 	}
+#ifdef USE_TRANSLATION
+	Common::String oldLang = ConfMan.get("gui_language");
+	int selLang = _guiLanguagePopUp->getSelectedTag();
+
+	ConfMan.set("gui_language", TransMan.getLangById(selLang));
+
+	Common::String newLang = ConfMan.get("gui_language").c_str();
+	if (newLang != oldLang) {
+		// Activate the selected language
+		TransMan.setLanguage(selLang);
+
+		// Rebuild the Launcher and Options dialogs
+		g_gui.loadNewTheme(g_gui.theme()->getThemeId(), ThemeEngine::kGfxDisabled, true);
+		rebuild();
+		if (_launcher != 0)
+			_launcher->rebuild();
+	}
+#endif // USE_TRANSLATION
 
 	OptionsDialog::apply();
 }


### PR DESCRIPTION
Fix for [GUI: Changing 'GUI Language' in Global Options removes theme overlay](https://bugs.scummvm.org/ticket/9711).  
Also, _cbcf819_ fixes the theme label to display the correct theme.  
For more details see the commit messages.