### PR TITLE
Delay deletion of widgets when rebuilding launcher and options dialogs

### DIFF
--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -27,6 +27,7 @@
 #include "common/singleton.h"
 #include "common/stack.h"
 #include "common/str.h"
+#include "common/list.h"
 
 #include "gui/ThemeEngine.h"
 
@@ -44,6 +45,7 @@ namespace GUI {
 
 class Dialog;
 class ThemeEval;
+class GuiObject;
 
 #define g_gui	(GUI::GuiManager::instance())
 
@@ -99,6 +101,13 @@ public:
 	 */
 	bool checkScreenChange();
 
+	/**
+	 * Tell the GuiManager to delete the given GuiObject later. If a parent
+	 * dialog is provided and is present in the DialogStack, the object will
+	 * only be deleted when that dialog is the top level dialog.
+	 */
+	void addToTrash(GuiObject*, Dialog* parent = 0);
+
 	bool _launched;
 
 protected:
@@ -136,6 +145,13 @@ protected:
 	int		_cursorAnimateCounter;
 	int		_cursorAnimateTimer;
 	byte	_cursor[2048];
+
+	// delayed deletion of GuiObject
+	struct GuiObjectTrashItem {
+		GuiObject* object;
+		Dialog* parent;
+	};
+	Common::List<GuiObjectTrashItem> _guiObjectTrash;
 
 	void initKeymap();
 	void pushKeymap();

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -204,7 +204,10 @@ void LauncherDialog::clean() {
 	while (_firstWidget) {
 		Widget* w = _firstWidget;
 		removeWidget(w);
-		delete w;
+		// This is called from rebuild() which may result from handleCommand being called by
+		// a child widget sendCommand call. In such a case sendCommand is still being executed
+		// so we should not delete yet the child widget. Thus delay the deletion.
+		g_gui.addToTrash(w, this);
 	}
 	delete _browser;
 	delete _loadDialog;

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -423,7 +423,10 @@ void OptionsDialog::clean() {
 	while (_firstWidget) {
 		Widget* w = _firstWidget;
 		removeWidget(w);
-		delete w;
+		// This is called from rebuild() which may result from handleCommand being called by
+		// a child widget sendCommand call. In such a case sendCommand is still being executed
+		// so we should not delete yet the child widget. Thus delay the deletion.
+		g_gui.addToTrash(w, this);
 	}
 	init();
 }


### PR DESCRIPTION
Currently changing the GUI language in the options results in an invalid write in delete memory. Here is one of the two possible valgrind error:
```
==38272== Invalid write of size 1
==38272==    at 0x10198D44E: GUI::ButtonWidget::handleMouseUp(int, int, int, int) (widget.cpp:341)
==38272==    by 0x101927DBE: GUI::Dialog::handleMouseUp(int, int, int, int) (dialog.cpp:212)
==38272==    by 0x101936FF0: GUI::GuiManager::processEvent(Common::Event const&, GUI::Dialog*) (gui-manager.cpp:553)
==38272==    by 0x101936819: GUI::GuiManager::runLoop() (gui-manager.cpp:334)
==38272==    by 0x101927779: GUI::Dialog::runModal() (dialog.cpp:80)
==38272==    by 0x10193C399: GUI::LauncherDialog::handleCommand(GUI::CommandSender*, unsigned int, unsigned int) (launcher.cpp:642)
==38272==    by 0x101A05D7A: GUI::CommandSender::sendCommand(unsigned int, unsigned int) (object.h:55)
==38272==    by 0x10198D449: GUI::ButtonWidget::handleMouseUp(int, int, int, int) (widget.cpp:339)
==38272==    by 0x101927DBE: GUI::Dialog::handleMouseUp(int, int, int, int) (dialog.cpp:212)
==38272==    by 0x101936FF0: GUI::GuiManager::processEvent(Common::Event const&, GUI::Dialog*) (gui-manager.cpp:553)
==38272==    by 0x101936819: GUI::GuiManager::runLoop() (gui-manager.cpp:334)
==38272==    by 0x101927779: GUI::Dialog::runModal() (dialog.cpp:80)
==38272==  Address 0x104f015dd is 221 bytes inside a block of size 232 free'd
==38272==    at 0x4D8D: free (vg_replace_malloc.c:477)
==38272==    by 0x101991441: GUI::ButtonWidget::~ButtonWidget() (widget.h:197)
==38272==    by 0x1019442BF: GUI::OptionsDialog::clean() (options.cpp:426)
==38272==    by 0x10195247E: GUI::GlobalOptionsDialog::clean() (options.cpp:1793)
==38272==    by 0x101944312: GUI::OptionsDialog::rebuild() (options.cpp:433)
==38272==    by 0x101952CB1: GUI::GlobalOptionsDialog::apply() (options.cpp:1854)
==38272==    by 0x101947718: GUI::OptionsDialog::handleCommand(GUI::CommandSender*, unsigned int, unsigned int) (options.cpp:812)
==38272==    by 0x1019545D3: GUI::GlobalOptionsDialog::handleCommand(GUI::CommandSender*, unsigned int, unsigned int) (options.cpp:2149)
==38272==    by 0x101A05D7A: GUI::CommandSender::sendCommand(unsigned int, unsigned int) (object.h:55)
==38272==    by 0x10198D449: GUI::ButtonWidget::handleMouseUp(int, int, int, int) (widget.cpp:339)
==38272==    by 0x101927DBE: GUI::Dialog::handleMouseUp(int, int, int, int) (dialog.cpp:212)
==38272==    by 0x101936FF0: GUI::GuiManager::processEvent(Common::Event const&, GUI::Dialog*) (gui-manager.cpp:553)
```

What happens is that when we click on Apply (or OK) after changing the GUI language in the options, ButtonWidget::handleMouseUp is called for that button:
```
void ButtonWidget::handleMouseUp(int x, int y, int button, int clickCount) {
	if (isEnabled() && _duringPress && x >= 0 && x < _w && y >= 0 && y < _h) {
		setUnpressedState();
		sendCommand(_cmd, 0);
	}
	_duringPress = false;
}
```
The `sendCommand` call results in `OptionsDialog::handleCommand` being called, which applies the changes and rebuilds the dialog. Rebuilding the dialog causes the Apply and OK buttons to be deleted. Then after it returns from `sendCommand`, it sets the `_duringPress` flag, and because the button has been deleted this results in the invalid write.

The other valgrind error is very similar and is for the "Options" button of the launcher dialog, because the launcher dialog is also rebuilt when applying the language change, and setting the `_duringPress` flag of that deleted button occurs after closing the options dialog that run modally from the `handleCommand` of the launcher dialog.

One easy way to avoid this invalid write would be to set the flag before calling sendCommand and do nothing after returning from sendCommand:
```
void ButtonWidget::handleMouseUp(int x, int y, int button, int clickCount) {
	if (isEnabled() && _duringPress && x >= 0 && x < _w && y >= 0 && y < _h) {
		_duringPress = false;
		setUnpressedState();
		sendCommand(_cmd, 0);
	} else
		_duringPress = false;
}
```

But even if that fixes that invalid write, I don't like the idea of deleting an object while we are executing one of its function. So instead I looked at delaying the deletion of the GuiObject when rebuilding the options and launcher dialog.
