### PR TITLE
GUI: Restore previous settings if GUI cannot be rendered

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -722,7 +722,9 @@ bool ThemeEngine::addFont(TextData textId, const Common::String &file, const Com
 #ifdef USE_TRANSLATION
 			TransMan.setLanguage("C");
 #endif
-			warning("Failed to load localized font '%s'. Using non-localized font and default GUI language instead", localized.c_str());
+			warning("Failed to load localized font '%s'.", localized.c_str());
+
+			return false;
 		}
 	}
 


### PR DESCRIPTION
This PR focuses on GlobalOptionsDialog::apply() to determine incompatible font/charset and fallback to previous settings on error.
'Greek' always triggers an error out of unknown reasons to me. It is the only language with charset iso-8859-7, so looking at ThemeEngine::init(), how fonts/charsets are loaded and why it fails and falls back to ASCII is the next step.

@criezy you mentioned in #919 that you have mapped out combinations that broke previously.
Would be great if you could reply and paste your list here :)