### PR TITLE
Fullpipe Common::String + memory leak fixes

### DIFF
--- a/engines/fullpipe/behavior.cpp
+++ b/engines/fullpipe/behavior.cpp
@@ -70,7 +70,7 @@ void BehaviorManager::initBehavior(Scene *sc, GameVar *var) {
 
 			_behaviors.push_back(behinfo);
 		} else {
-			StaticANIObject *ani = sc->getStaticANIObject1ByName((char *)subvar->_varName.c_str(), -1);
+			StaticANIObject *ani = sc->getStaticANIObject1ByName(subvar->_varName, -1);
 			if (ani) {
 				for (uint i = 0; i < sc->_staticANIObjectList1.size(); i++) {
 					if (((StaticANIObject *)sc->_staticANIObjectList1[i])->_id == ani->_id) {
@@ -279,7 +279,7 @@ void BehaviorInfo::initObjectBehavior(GameVar *var, Scene *sc, StaticANIObject *
 		if (strcmp(var->_value.stringValue, "ROOT"))
 			break;
 
-		GameVar *v1 = g_fp->getGameLoaderGameVar()->getSubVarByName("BEHAVIOR")->getSubVarByName(ani->getName().c_str());
+		GameVar *v1 = g_fp->getGameLoaderGameVar()->getSubVarByName("BEHAVIOR")->getSubVarByName(ani->getName());
 		if (v1 == var)
 			return;
 
@@ -317,7 +317,7 @@ BehaviorAnim::BehaviorAnim(GameVar *var, Scene *sc, StaticANIObject *ani, int *m
 	_flags = 0;
 	_behaviorMoves = 0;
 
-	Statics *st = ani->getStaticsByName((char *)var->_varName.c_str());
+	Statics *st = ani->getStaticsByName(var->_varName);
 	if (st)
 		_staticsId = st->_staticsId;
 
@@ -346,7 +346,7 @@ BehaviorMove::BehaviorMove(GameVar *subvar, Scene *sc, int *delay) {
 	_delay = 0;
 	_percent = 0;
 	_flags = 0;
-	_messageQueue = sc->getMessageQueueByName((char *)subvar->_varName.c_str());
+	_messageQueue = sc->getMessageQueueByName(subvar->_varName);
 
 	GameVar *vart = subvar->getSubVarByName("dwDelay");
 	if (vart)

--- a/engines/fullpipe/behavior.cpp
+++ b/engines/fullpipe/behavior.cpp
@@ -49,7 +49,7 @@ void BehaviorManager::clear() {
 }
 
 void BehaviorManager::initBehavior(Scene *sc, GameVar *var) {
-	debugC(2, kDebugBehavior, "BehaviorManager::initBehavior(%d, %s)", sc->_sceneId, transCyrillic((byte *)var->_varName));
+	debugC(2, kDebugBehavior, "BehaviorManager::initBehavior(%d, %s)", sc->_sceneId, transCyrillic(var->_varName));
 
 	clear();
 	_scene = sc;
@@ -63,7 +63,7 @@ void BehaviorManager::initBehavior(Scene *sc, GameVar *var) {
 	debugC(3, kDebugBehavior, "BehaviorManager::initBehavior. have Variable");
 
 	for (GameVar *subvar = behvar->_subVars; subvar; subvar = subvar->_nextVarObj) {
-		debugC(3, kDebugBehavior, "BehaviorManager::initBehavior. subVar %s", transCyrillic((byte *)subvar->_varName));
+		debugC(3, kDebugBehavior, "BehaviorManager::initBehavior. subVar %s", transCyrillic(subvar->_varName));
 		if (!strcmp(subvar->_varName, "AMBIENT")) {
 			behinfo = new BehaviorInfo;
 			behinfo->initAmbientBehavior(subvar, sc);
@@ -151,7 +151,7 @@ void BehaviorManager::updateBehavior(BehaviorInfo *behaviorInfo, BehaviorAnim *e
 }
 
 void BehaviorManager::updateStaticAniBehavior(StaticANIObject *ani, int delay, BehaviorAnim *bhe) {
-	debugC(6, kDebugBehavior, "BehaviorManager::updateStaticAniBehavior(%s)", transCyrillic((byte *)ani->_objectName));
+	debugC(6, kDebugBehavior, "BehaviorManager::updateStaticAniBehavior(%s)", transCyrillic(ani->_objectName));
 
 	MessageQueue *mq = 0;
 
@@ -243,7 +243,7 @@ void BehaviorInfo::clear() {
 }
 
 void BehaviorInfo::initAmbientBehavior(GameVar *var, Scene *sc) {
-	debugC(4, kDebugBehavior, "BehaviorInfo::initAmbientBehavior(%s)", transCyrillic((byte *)var->_varName));
+	debugC(4, kDebugBehavior, "BehaviorInfo::initAmbientBehavior(%s)", transCyrillic(var->_varName));
 
 	clear();
 	_animsCount = 1;
@@ -267,8 +267,8 @@ void BehaviorInfo::initAmbientBehavior(GameVar *var, Scene *sc) {
 }
 
 void BehaviorInfo::initObjectBehavior(GameVar *var, Scene *sc, StaticANIObject *ani) {
-	Common::String s((char *)transCyrillic((byte *)var->_varName));
-	debugC(4, kDebugBehavior, "BehaviorInfo::initObjectBehavior(%s, %d, %s)", s.c_str(), sc->_sceneId, transCyrillic((byte *)ani->_objectName));
+	Common::String s((char *)transCyrillic(var->_varName));
+	debugC(4, kDebugBehavior, "BehaviorInfo::initObjectBehavior(%s, %d, %s)", s.c_str(), sc->_sceneId, transCyrillic(ani->_objectName));
 
 	clear();
 

--- a/engines/fullpipe/behavior.cpp
+++ b/engines/fullpipe/behavior.cpp
@@ -64,13 +64,13 @@ void BehaviorManager::initBehavior(Scene *sc, GameVar *var) {
 
 	for (GameVar *subvar = behvar->_subVars; subvar; subvar = subvar->_nextVarObj) {
 		debugC(3, kDebugBehavior, "BehaviorManager::initBehavior. subVar %s", transCyrillic(subvar->_varName));
-		if (!strcmp(subvar->_varName, "AMBIENT")) {
+		if (subvar->_varName == "AMBIENT") {
 			behinfo = new BehaviorInfo;
 			behinfo->initAmbientBehavior(subvar, sc);
 
 			_behaviors.push_back(behinfo);
 		} else {
-			StaticANIObject *ani = sc->getStaticANIObject1ByName(subvar->_varName, -1);
+			StaticANIObject *ani = sc->getStaticANIObject1ByName((char *)subvar->_varName.c_str(), -1);
 			if (ani) {
 				for (uint i = 0; i < sc->_staticANIObjectList1.size(); i++) {
 					if (((StaticANIObject *)sc->_staticANIObjectList1[i])->_id == ani->_id) {
@@ -279,7 +279,7 @@ void BehaviorInfo::initObjectBehavior(GameVar *var, Scene *sc, StaticANIObject *
 		if (strcmp(var->_value.stringValue, "ROOT"))
 			break;
 
-		GameVar *v1 = g_fp->getGameLoaderGameVar()->getSubVarByName("BEHAVIOR")->getSubVarByName(ani->getName());
+		GameVar *v1 = g_fp->getGameLoaderGameVar()->getSubVarByName("BEHAVIOR")->getSubVarByName(ani->getName().c_str());
 		if (v1 == var)
 			return;
 
@@ -317,7 +317,7 @@ BehaviorAnim::BehaviorAnim(GameVar *var, Scene *sc, StaticANIObject *ani, int *m
 	_flags = 0;
 	_behaviorMoves = 0;
 
-	Statics *st = ani->getStaticsByName(var->_varName);
+	Statics *st = ani->getStaticsByName((char *)var->_varName.c_str());
 	if (st)
 		_staticsId = st->_staticsId;
 
@@ -346,7 +346,7 @@ BehaviorMove::BehaviorMove(GameVar *subvar, Scene *sc, int *delay) {
 	_delay = 0;
 	_percent = 0;
 	_flags = 0;
-	_messageQueue = sc->getMessageQueueByName(subvar->_varName);
+	_messageQueue = sc->getMessageQueueByName((char *)subvar->_varName.c_str());
 
 	GameVar *vart = subvar->getSubVarByName("dwDelay");
 	if (vart)

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -131,10 +131,6 @@ FullpipeEngine::FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc)
 
 	_stream2playing = false;
 
-	memset(_sceneTracks, 0, sizeof(_sceneTracks));
-	memset(_trackName, 0, sizeof(_trackName));
-	memset(_sceneTracksCurrentTrack, 0, sizeof(_sceneTracksCurrentTrack));
-
 	_numSceneTracks = 0;
 	_sceneTrackHasSequence = false;
 	_sceneTrackIsPlaying = false;

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -552,7 +552,7 @@ void FullpipeEngine::updateScreen() {
 	++_updateTicks;
 }
 
-int FullpipeEngine::getObjectEnumState(const char *name, const char *state) {
+int FullpipeEngine::getObjectEnumState(Common::String name, const char *state) {
 	GameVar *var = _gameLoader->_gameVar->getSubVarByName("OBJSTATES");
 
 	if (!var) {
@@ -569,7 +569,7 @@ int FullpipeEngine::getObjectEnumState(const char *name, const char *state) {
 	return 0;
 }
 
-int FullpipeEngine::getObjectState(const char *objname) {
+int FullpipeEngine::getObjectState(Common::String objname) {
 	GameVar *var = _gameLoader->_gameVar->getSubVarByName("OBJSTATES");
 
 	if (var)
@@ -578,7 +578,7 @@ int FullpipeEngine::getObjectState(const char *objname) {
   return 0;
 }
 
-void FullpipeEngine::setObjectState(const char *name, int state) {
+void FullpipeEngine::setObjectState(Common::String name, int state) {
 	GameVar *var = _gameLoader->_gameVar->getSubVarByName("OBJSTATES");
 
 	if (!var) {

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -165,15 +165,15 @@ public:
 	int _currSoundListCount;
 	bool _soundEnabled;
 	bool _flgSoundList;
-	char _sceneTracks[10][260];
+	Common::String _sceneTracks[10];
 	int _numSceneTracks;
 	bool _sceneTrackHasSequence;
 	int _musicMinDelay;
 	int _musicMaxDelay;
 	int _musicLocal;
-	char _trackName[2600];
+	Common::String _trackName;
 	int _trackStartDelay;
-	char _sceneTracksCurrentTrack[260];
+	Common::String _sceneTracksCurrentTrack;
 	bool _sceneTrackIsPlaying;
 
 	void stopAllSounds();
@@ -183,8 +183,8 @@ public:
 	int getSceneTrack();
 	void updateTrackDelay();
 	void startSceneTrack();
-	void startSoundStream1(const char *trackName);
-	void playOggSound(const char *trackName, Audio::SoundHandle *stream);
+	void startSoundStream1(Common::String trackName);
+	void playOggSound(Common::String trackName, Audio::SoundHandle *stream);
 	void stopSoundStream2();
 	void stopAllSoundStreams();
 	void stopAllSoundInstances(int id);

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -272,9 +272,9 @@ public:
 	void setCursor(int id);
 	void updateCursorCommon();
 
-	int getObjectState(const char *objname);
-	void setObjectState(const char *name, int state);
-	int getObjectEnumState(const char *name, const char *state);
+	int getObjectState(Common::String objname);
+	void setObjectState(Common::String name, int state);
+	int getObjectEnumState(Common::String name, const char *state);
 
 	void sceneAutoScrolling();
 	bool sceneSwitcher(EntranceInfo *entrance);

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -475,7 +475,7 @@ void Picture::freePicture() {
 	if (_bitmap) {
 		if (testFlags() && !_field_54) {
 			freeData();
-			free(_bitmap);
+			delete _bitmap;
 			_bitmap = 0;
 		}
 	}

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -591,8 +591,9 @@ void Picture::getDibInfo() {
 	}
 
 	Common::MemoryReadStream *s = new Common::MemoryReadStream(_data + off - 32, 32);
-
 	_bitmap->load(s);
+	delete s;
+
 	_bitmap->_pixels = _data;
 
 	_bitmap->decode((int32 *)(_paletteData ? _paletteData : g_fp->_globalPalette));

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -470,7 +470,7 @@ Picture::~Picture() {
 }
 
 void Picture::freePicture() {
-	debugC(5, kDebugMemory, "Picture::freePicture(): file: %s", _memfilename);
+	debugC(5, kDebugMemory, "Picture::freePicture(): file: %s", _memfilename.c_str());
 
 	if (_bitmap) {
 		if (testFlags() && !_field_54) {
@@ -532,7 +532,7 @@ bool Picture::load(MfcArchive &file) {
 
 	getData();
 
-	debugC(5, kDebugLoading, "Picture::load: loaded <%s>", _memfilename);
+	debugC(5, kDebugLoading, "Picture::load: loaded <%s>", _memfilename.c_str());
 
 	return true;
 }
@@ -552,7 +552,7 @@ void Picture::setAOIDs() {
 }
 
 void Picture::init() {
-	debugC(5, kDebugLoading, "Picture::init(), %s", _memfilename);
+	debugC(5, kDebugLoading, "Picture::init(), %s", _memfilename.c_str());
 
 	MemoryObject::getData();
 
@@ -585,7 +585,7 @@ void Picture::getDibInfo() {
 	}
 
 	if (!_data) {
-		warning("Picture::getDibInfo: data is empty <%s>", _memfilename);
+		warning("Picture::getDibInfo: data is empty <%s>", _memfilename.c_str());
 
 		MemoryObject::load();
 	}
@@ -611,7 +611,7 @@ void Picture::draw(int x, int y, int style, int angle) {
 	int x1 = x;
 	int y1 = y;
 
-	debugC(7, kDebugDrawing, "Picture::draw(%d, %d, %d, %d) (%s)", x, y, style, angle, _memfilename);
+	debugC(7, kDebugDrawing, "Picture::draw(%d, %d, %d, %d) (%s)", x, y, style, angle, _memfilename.c_str());
 
 	if (x != -1)
 		x1 = x;

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -41,7 +41,6 @@ Background::Background() {
 	_bigPictureArray1Count = 0;
 	_bigPictureArray2Count = 0;
 	_bigPictureArray = 0;
-	_bgname = 0;
 	_palette = 0;
 }
 
@@ -260,7 +259,6 @@ GameObject::GameObject() {
 	_priority = 0;
 	_field_20 = 0;
 	_field_8 = 0;
-	_objectName = 0;
 }
 
 GameObject::GameObject(GameObject *src) {
@@ -268,8 +266,7 @@ GameObject::GameObject(GameObject *src) {
 	_flags = 0;
 	_id = src->_id;
 
-	_objectName = (char *)calloc(strlen(src->_objectName) + 1, 1);
-	strncpy(_objectName, src->_objectName, strlen(src->_objectName));
+	_objectName = src->_objectName;
 
 	_ox = src->_ox;
 	_oy = src->_oy;
@@ -279,7 +276,6 @@ GameObject::GameObject(GameObject *src) {
 }
 
 GameObject::~GameObject() {
-	free(_objectName);
 }
 
 bool GameObject::load(MfcArchive &file) {

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -39,7 +39,6 @@ struct Bitmap {
 	int _y;
 	int _width;
 	int _height;
-	byte *_pixels;
 	int _type;
 	int _dataSize;
 	int _flags;
@@ -52,10 +51,10 @@ struct Bitmap {
 	~Bitmap();
 
 	void load(Common::ReadStream *s);
-	void decode(int32 *palette);
+	void decode(byte *pixels, int32 *palette);
 	void putDib(int x, int y, int32 *palette, byte alpha);
-	bool putDibRB(int32 *palette);
-	void putDibCB(int32 *palette);
+	bool putDibRB(byte *pixels, int32 *palette);
+	void putDibCB(byte *pixels, int32 *palette);
 
 	void colorFill(uint32 *dest, int len, int32 color);
 	void paletteFill(uint32 *dest, byte *src, int len, int32 *palette);

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -133,7 +133,7 @@ class GameObject : public CObject {
 	int _field_8;
 	int16 _flags;
 	int16 _id;
-	char *_objectName;
+	Common::String _objectName;
 	int _ox;
 	int _oy;
 	int _priority;
@@ -150,7 +150,7 @@ class GameObject : public CObject {
 	void renumPictures(Common::Array<PictureObject *> *lst);
 	void setFlags(int16 flags) { _flags = flags; }
 	void clearFlags() { _flags = 0; }
-	const char *getName() { return _objectName; }
+	Common::String getName() { return _objectName; }
 
 	bool getPicAniInfo(PicAniInfo *info);
 	bool setPicAniInfo(PicAniInfo *info);
@@ -186,7 +186,7 @@ class Background : public CObject {
   public:
 	Common::Array<PictureObject *> _picObjList;
 
-	char *_bgname;
+	Common::String _bgname;
 	int _x;
 	int _y;
 	int16 _messageQueueId;

--- a/engines/fullpipe/interaction.cpp
+++ b/engines/fullpipe/interaction.cpp
@@ -428,7 +428,6 @@ Interaction::Interaction() {
 	_staticsId2 = 0;
 	_field_28 = 0;
 	_sceneId = -1;
-	_actionName = 0;
 }
 
 Interaction::~Interaction() {
@@ -438,8 +437,6 @@ Interaction::~Interaction() {
 	}
 
 	delete _messageQueue;
-
-	free(_actionName);
 }
 
 bool Interaction::load(MfcArchive &file) {
@@ -496,20 +493,20 @@ bool Interaction::canInteract(GameObject *obj1, GameObject *obj2, int invId) {
 
 	if (_objectState1) {
 		if (_flags & 0x10) {
-			if ((g_fp->getObjectState(obj1->getName()) & _objectState1) == 0)
+			if ((g_fp->getObjectState(obj1->getName().c_str()) & _objectState1) == 0)
 				return false;
 		} else {
-			if (g_fp->getObjectState(obj1->getName()) != _objectState1)
+			if (g_fp->getObjectState(obj1->getName().c_str()) != _objectState1)
 				return false;
 		}
 	}
 
 	if (_objectState2) {
 		if (_flags & 0x10) {
-			if ((g_fp->getObjectState(obj2->getName()) & _objectState2) == 0)
+			if ((g_fp->getObjectState(obj2->getName().c_str()) & _objectState2) == 0)
 				return false;
 		} else {
-			if (g_fp->getObjectState(obj2->getName()) != _objectState2)
+			if (g_fp->getObjectState(obj2->getName().c_str()) != _objectState2)
 				return false;
 		}
 	}

--- a/engines/fullpipe/interaction.cpp
+++ b/engines/fullpipe/interaction.cpp
@@ -128,7 +128,7 @@ bool InteractionController::handleInteraction(StaticANIObject *subj, GameObject 
 			if (cinter->_messageQueue)
 				cinter->_messageQueue->calcDuration(subj);
 
-			debugC(5, kDebugInteractions, "Interaction: %s", transCyrillic((byte *)cinter->_actionName));
+			debugC(5, kDebugInteractions, "Interaction: %s", transCyrillic(cinter->_actionName));
 
 			PicAniInfo aniInfo;
 

--- a/engines/fullpipe/interaction.cpp
+++ b/engines/fullpipe/interaction.cpp
@@ -493,20 +493,20 @@ bool Interaction::canInteract(GameObject *obj1, GameObject *obj2, int invId) {
 
 	if (_objectState1) {
 		if (_flags & 0x10) {
-			if ((g_fp->getObjectState(obj1->getName().c_str()) & _objectState1) == 0)
+			if ((g_fp->getObjectState(obj1->getName()) & _objectState1) == 0)
 				return false;
 		} else {
-			if (g_fp->getObjectState(obj1->getName().c_str()) != _objectState1)
+			if (g_fp->getObjectState(obj1->getName()) != _objectState1)
 				return false;
 		}
 	}
 
 	if (_objectState2) {
 		if (_flags & 0x10) {
-			if ((g_fp->getObjectState(obj2->getName().c_str()) & _objectState2) == 0)
+			if ((g_fp->getObjectState(obj2->getName()) & _objectState2) == 0)
 				return false;
 		} else {
-			if (g_fp->getObjectState(obj2->getName().c_str()) != _objectState2)
+			if (g_fp->getObjectState(obj2->getName()) != _objectState2)
 				return false;
 		}
 	}

--- a/engines/fullpipe/interaction.h
+++ b/engines/fullpipe/interaction.h
@@ -50,7 +50,7 @@ class Interaction : public CObject {
 	int _sceneId;
 	int _field_28;
 	uint _flags;
-	char *_actionName;
+	Common::String _actionName;
 
  public:
 	Interaction();

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -391,7 +391,7 @@ int MctlLadder::findObjectPos(StaticANIObject *obj) {
 bool MctlLadder::initMovement(StaticANIObject *ani, MctlLadderMovement *movement) {
 	debugC(4, kDebugPathfinding, "MctlLadder::initMovement(*%d, ...)", ani->_id);
 
-	GameVar *v = g_fp->getGameLoaderGameVar()->getSubVarByName(ani->getName().c_str());
+	GameVar *v = g_fp->getGameLoaderGameVar()->getSubVarByName(ani->getName());
 
 	if (!v)
 		return false;
@@ -1744,7 +1744,7 @@ bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
 	item->_obj = obj;
 	item->_objectId = obj->_id;
 
-	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(obj->_objectName.c_str());
+	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(obj->_objectName);
 	if (!var)
 		return false;
 

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -54,7 +54,7 @@ void MotionController::enableLinks(const char *linkName, bool enable) {
 
 				MovGraphLink *lnk = (MovGraphLink *)*l;
 
-				if (!strcmp(lnk->_name, linkName)) {
+				if (lnk->_name == linkName) {
 					if (enable)
 						lnk->_flags |= 0x20000000;
 					else
@@ -82,7 +82,7 @@ MovGraphLink *MotionController::getLinkByName(const char *name) {
 
 					MovGraphLink *lnk = (MovGraphLink *)*l;
 
-					if (!strcmp(lnk->_name, name))
+					if (lnk->_name == name)
 						return lnk;
 				}
 			}
@@ -97,7 +97,7 @@ MovGraphLink *MotionController::getLinkByName(const char *name) {
 
 			MovGraphLink *lnk = (MovGraphLink *)*l;
 
-			if (!strcmp(lnk->_name, name))
+			if (lnk->_name == name)
 				return lnk;
 		}
 	}
@@ -391,7 +391,7 @@ int MctlLadder::findObjectPos(StaticANIObject *obj) {
 bool MctlLadder::initMovement(StaticANIObject *ani, MctlLadderMovement *movement) {
 	debugC(4, kDebugPathfinding, "MctlLadder::initMovement(*%d, ...)", ani->_id);
 
-	GameVar *v = g_fp->getGameLoaderGameVar()->getSubVarByName(ani->getName());
+	GameVar *v = g_fp->getGameLoaderGameVar()->getSubVarByName(ani->getName().c_str());
 
 	if (!v)
 		return false;
@@ -1744,7 +1744,7 @@ bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
 	item->_obj = obj;
 	item->_objectId = obj->_id;
 
-	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(obj->_objectName);
+	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(obj->_objectName.c_str());
 	if (!var)
 		return false;
 
@@ -2900,7 +2900,6 @@ MovGraphLink::MovGraphLink() {
 	_field_3C = 0;
 	_field_38 = 0;
 	_movGraphReact = 0;
-	_name = 0;
 
 	_objtype = kObjTypeMovGraphLink;
 }

--- a/engines/fullpipe/motion.h
+++ b/engines/fullpipe/motion.h
@@ -228,7 +228,7 @@ class MovGraphLink : public CObject {
 	double _length;
 	double _angle;
 	MovGraphReact *_movGraphReact;
-	char *_name;
+	Common::String _name;
 
   public:
 	MovGraphLink();

--- a/engines/fullpipe/objects.h
+++ b/engines/fullpipe/objects.h
@@ -90,10 +90,10 @@ class GameVar : public CObject {
 
 	virtual bool load(MfcArchive &file);
 	virtual void save(MfcArchive &file);
-	GameVar *getSubVarByName(const char *name);
-	bool setSubVarAsInt(const char *name, int value);
-	int getSubVarAsInt(const char *name);
-	GameVar *addSubVarAsInt(const char *name, int value);
+	GameVar *getSubVarByName(Common::String name);
+	bool setSubVarAsInt(Common::String name, int value);
+	int getSubVarAsInt(Common::String name);
+	GameVar *addSubVarAsInt(Common::String name, int value);
 	bool addSubVar(GameVar *subvar);
 	int getSubVarsCount();
 	GameVar *getSubVarByIndex(int idx);

--- a/engines/fullpipe/objects.h
+++ b/engines/fullpipe/objects.h
@@ -33,7 +33,7 @@ class SceneTagList;
 class GameProject : public CObject {
  public:
 	int _field_4;
-	char *_headerFilename;
+	Common::String _headerFilename;
 	SceneTagList *_sceneTagList;
 	int _field_10;
 
@@ -80,7 +80,7 @@ class GameVar : public CObject {
 	GameVar *_parentVarObj;
 	GameVar *_subVars;
 	GameVar *_field_14;
-	char *_varName;
+	Common::String _varName;
 	VarValue _value;
 	int _varType;
 

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -165,7 +165,7 @@ bool Scene::load(MfcArchive &file) {
 	_sceneId = file.readUint16LE();
 
 	_sceneName = file.readPascalString();
-	debug(0, "scene: <%s> %d", transCyrillic((byte *)_sceneName), _sceneId);
+	debug(0, "scene: <%s> %d", transCyrillic(_sceneName), _sceneId);
 
 	int count = file.readUint16LE();
 	debugC(7, kDebugLoading, "scene.ani: %d", count);

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -72,7 +72,6 @@ bool SceneTagList::load(MfcArchive &file) {
 SceneTag::SceneTag() {
 	_field_4 = 0;
 	_scene = 0;
-	_tag = 0;
 	_sceneId = 0;
 }
 
@@ -86,14 +85,12 @@ bool SceneTag::load(MfcArchive &file) {
 
 	_tag = file.readPascalString();
 
-	debugC(6, kDebugLoading, "sceneId: %d  tag: %s", _sceneId, _tag);
+	debugC(6, kDebugLoading, "sceneId: %d  tag: %s", _sceneId, _tag.c_str());
 
 	return true;
 }
 
 SceneTag::~SceneTag() {
-	free(_tag);
-
 	delete _scene;
 	delete _field_4;
 }
@@ -130,7 +127,6 @@ Scene::Scene() {
 	_shadows = 0;
 	_soundList = 0;
 	_libHandle = 0;
-	_sceneName = 0;
 }
 
 Scene::~Scene() {
@@ -153,8 +149,6 @@ Scene::~Scene() {
 	delete _libHandle;
 
 	// delete _field_BC;
-
-	free(_sceneName);
 }
 
 bool Scene::load(MfcArchive &file) {
@@ -221,10 +215,10 @@ bool Scene::load(MfcArchive &file) {
 
 	_libHandle = g_fp->_currArchive;
 
-	if (_picObjList.size() > 0 && _bgname && strlen(_bgname) > 1) {
+	if (_picObjList.size() > 0 && _bgname.size() > 1) {
 		char fname[260];
 
-		strcpy(fname, _bgname);
+		strcpy(fname, _bgname.c_str());
 		strcpy(strrchr(fname, '.') + 1, "col");
 
 		MemoryObject *col = new MemoryObject();
@@ -312,7 +306,7 @@ StaticANIObject *Scene::getStaticANIObject1ById(int obj, int a3) {
 
 StaticANIObject *Scene::getStaticANIObject1ByName(char *name, int a3) {
 	for (uint i = 0; i < _staticANIObjectList1.size(); i++) {
-		if (!strcmp(_staticANIObjectList1[i]->_objectName, name) && (a3 == -1 || _staticANIObjectList1[i]->_odelay == a3))
+		if (_staticANIObjectList1[i]->_objectName == name && (a3 == -1 || _staticANIObjectList1[i]->_odelay == a3))
 			return _staticANIObjectList1[i];
 	}
 
@@ -373,7 +367,7 @@ PictureObject *Scene::getPictureObjectById(int objId, int flags) {
 
 PictureObject *Scene::getPictureObjectByName(const char *objName, int flags) {
 	for (uint i = 0; i < _picObjList.size(); i++) {
-		if (!strcmp(((PictureObject *)_picObjList[i])->_objectName, objName) && (((PictureObject *)_picObjList[i])->_odelay == flags || flags == -1))
+		if (((PictureObject *)_picObjList[i])->_objectName == objName && (((PictureObject *)_picObjList[i])->_odelay == flags || flags == -1))
 			return (PictureObject *)_picObjList[i];
 	}
 
@@ -413,14 +407,14 @@ void Scene::preloadMovements(GameVar *var) {
 		return;
 
 	for (GameVar *i = preload->_subVars; i; i = i->_nextVarObj) {
-		StaticANIObject *ani = getStaticANIObject1ByName(i->_varName, -1);
+		StaticANIObject *ani = getStaticANIObject1ByName((char *)i->_varName.c_str(), -1);
 
 		if (ani) {
 			GameVar *subVars = i->_subVars;
 
 			if (subVars) {
 				for (;subVars; subVars = subVars->_nextVarObj) {
-					Movement *mov = ani->getMovementByName(subVars->_varName);
+					Movement *mov = ani->getMovementByName((char *)subVars->_varName.c_str());
 
 					if (mov)
 						mov->loadPixelData();
@@ -442,9 +436,9 @@ void Scene::initObjectCursors(const char *varname) {
 	int minId = 0xffff;
 
 	for (GameVar *sub = cursorsVar->_subVars; sub; sub = sub->_nextVarObj) {
-		GameObject *obj = getPictureObjectByName(sub->_varName, -1);
+		GameObject *obj = getPictureObjectByName((char *)sub->_varName.c_str(), -1);
 
-		if (obj || (obj = getStaticANIObject1ByName(sub->_varName, -1)) != 0) {
+		if (obj || (obj = getStaticANIObject1ByName((char *)sub->_varName.c_str(), -1)) != 0) {
 			if (obj->_id < minId)
 				minId = obj->_id;
 			if (obj->_id > maxId)
@@ -458,10 +452,10 @@ void Scene::initObjectCursors(const char *varname) {
 	g_fp->_objectIdCursors.resize(maxId - minId + 1);
 
 	for (GameVar *sub = cursorsVar->_subVars; sub; sub = sub->_nextVarObj) {
-		GameObject *obj = getPictureObjectByName(sub->_varName, -1);
+		GameObject *obj = getPictureObjectByName((char *)sub->_varName.c_str(), -1);
 
 		if (!obj)
-			obj = getStaticANIObject1ByName(sub->_varName, -1);
+			obj = getStaticANIObject1ByName((char *)sub->_varName.c_str(), -1);
 
 		PictureObject *pic = getGameLoaderInventory()->getScene()->getPictureObjectByName(sub->_value.stringValue, -1);
 

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -96,11 +96,11 @@ SceneTag::~SceneTag() {
 }
 
 void SceneTag::loadScene() {
-	char *archname = genFileName(0, _sceneId, "nl");
+	Common::String archname = genFileName(0, _sceneId, "nl");
 
 	Common::Archive *arch = makeNGIArchive(archname);
 
-	char *fname = genFileName(0, _sceneId, "sc");
+	Common::String fname = genFileName(0, _sceneId, "sc");
 
 	Common::SeekableReadStream *file = arch->createReadStreamForMember(fname);
 
@@ -116,9 +116,6 @@ void SceneTag::loadScene() {
 	delete file;
 
 	g_fp->_currArchive = 0;
-
-	free(fname);
-	free(archname);
 }
 
 Scene::Scene() {
@@ -166,7 +163,7 @@ bool Scene::load(MfcArchive &file) {
 
 	for (int i = 0; i < count; i++) {
 		int aniNum = file.readUint16LE();
-		char *aniname = genFileName(0, aniNum, "ani");
+		Common::String aniname = genFileName(0, aniNum, "ani");
 
 		Common::SeekableReadStream *f = g_fp->_currArchive->createReadStreamForMember(aniname);
 
@@ -180,7 +177,6 @@ bool Scene::load(MfcArchive &file) {
 		_staticANIObjectList1.push_back(ani);
 
 		delete f;
-		free(aniname);
 	}
 
 	count = file.readUint16LE();
@@ -188,7 +184,7 @@ bool Scene::load(MfcArchive &file) {
 
 	for (int i = 0; i < count; i++) {
 		int qNum = file.readUint16LE();
-		char *qname = genFileName(0, qNum, "qu");
+		Common::String qname = genFileName(0, qNum, "qu");
 
 		Common::SeekableReadStream *f = g_fp->_currArchive->createReadStreamForMember(qname);
 		MfcArchive archive(f);
@@ -202,7 +198,6 @@ bool Scene::load(MfcArchive &file) {
 		_messageQueueList.push_back(mq);
 
 		delete f;
-		free(qname);
 	}
 
 	count = file.readUint16LE();
@@ -227,32 +222,26 @@ bool Scene::load(MfcArchive &file) {
 		_palette = col;
 	}
 
-	char *shdname = genFileName(0, _sceneId, "shd");
+	Common::String shdname = genFileName(0, _sceneId, "shd");
 
 	Shadows *shd = new Shadows();
 
 	if (shd->loadFile(shdname))
 		_shadows = shd;
 
-	free(shdname);
-
-	char *slsname = genFileName(0, _sceneId, "sls");
+	Common::String slsname = genFileName(0, _sceneId, "sls");
 
 	if (g_fp->_soundEnabled) {
 		_soundList = new SoundList();
 
 		if (g_fp->_flgSoundList) {
-			char *nlname = genFileName(17, _sceneId, "nl");
+			Common::String nlname = genFileName(17, _sceneId, "nl");
 
 			_soundList->loadFile(slsname, nlname);
-
-			free(nlname);
 		} else {
 			_soundList->loadFile(slsname, 0);
 		}
 	}
-
-	free(slsname);
 
 	initStaticANIObjects();
 

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -304,9 +304,9 @@ StaticANIObject *Scene::getStaticANIObject1ById(int obj, int a3) {
 	return 0;
 }
 
-StaticANIObject *Scene::getStaticANIObject1ByName(char *name, int a3) {
+StaticANIObject *Scene::getStaticANIObject1ByName(Common::String &name, int a3) {
 	for (uint i = 0; i < _staticANIObjectList1.size(); i++) {
-		if (_staticANIObjectList1[i]->_objectName == name && (a3 == -1 || _staticANIObjectList1[i]->_odelay == a3))
+		if ((_staticANIObjectList1[i]->_objectName == name) && (a3 == -1 || _staticANIObjectList1[i]->_odelay == a3))
 			return _staticANIObjectList1[i];
 	}
 
@@ -365,9 +365,9 @@ PictureObject *Scene::getPictureObjectById(int objId, int flags) {
 	return 0;
 }
 
-PictureObject *Scene::getPictureObjectByName(const char *objName, int flags) {
+PictureObject *Scene::getPictureObjectByName(Common::String objName, int flags) {
 	for (uint i = 0; i < _picObjList.size(); i++) {
-		if (((PictureObject *)_picObjList[i])->_objectName == objName && (((PictureObject *)_picObjList[i])->_odelay == flags || flags == -1))
+		if ((((PictureObject *)_picObjList[i])->_objectName == objName) && (((PictureObject *)_picObjList[i])->_odelay == flags || flags == -1))
 			return (PictureObject *)_picObjList[i];
 	}
 
@@ -393,9 +393,9 @@ MessageQueue *Scene::getMessageQueueById(int messageId) {
 	return 0;
 }
 
-MessageQueue *Scene::getMessageQueueByName(char *name) {
+MessageQueue *Scene::getMessageQueueByName(Common::String &name) {
 	for (uint i = 0; i < _messageQueueList.size(); i++)
-		if (!strcmp(_messageQueueList[i]->_queueName.c_str(), name))
+		if (_messageQueueList[i]->_queueName == name)
 			return _messageQueueList[i];
 
 	return 0;
@@ -407,14 +407,14 @@ void Scene::preloadMovements(GameVar *var) {
 		return;
 
 	for (GameVar *i = preload->_subVars; i; i = i->_nextVarObj) {
-		StaticANIObject *ani = getStaticANIObject1ByName((char *)i->_varName.c_str(), -1);
+		StaticANIObject *ani = getStaticANIObject1ByName(i->_varName, -1);
 
 		if (ani) {
 			GameVar *subVars = i->_subVars;
 
 			if (subVars) {
 				for (;subVars; subVars = subVars->_nextVarObj) {
-					Movement *mov = ani->getMovementByName((char *)subVars->_varName.c_str());
+					Movement *mov = ani->getMovementByName(subVars->_varName);
 
 					if (mov)
 						mov->loadPixelData();
@@ -436,9 +436,9 @@ void Scene::initObjectCursors(const char *varname) {
 	int minId = 0xffff;
 
 	for (GameVar *sub = cursorsVar->_subVars; sub; sub = sub->_nextVarObj) {
-		GameObject *obj = getPictureObjectByName((char *)sub->_varName.c_str(), -1);
+		GameObject *obj = getPictureObjectByName(sub->_varName, -1);
 
-		if (obj || (obj = getStaticANIObject1ByName((char *)sub->_varName.c_str(), -1)) != 0) {
+		if (obj || (obj = getStaticANIObject1ByName(sub->_varName, -1)) != 0) {
 			if (obj->_id < minId)
 				minId = obj->_id;
 			if (obj->_id > maxId)
@@ -452,10 +452,10 @@ void Scene::initObjectCursors(const char *varname) {
 	g_fp->_objectIdCursors.resize(maxId - minId + 1);
 
 	for (GameVar *sub = cursorsVar->_subVars; sub; sub = sub->_nextVarObj) {
-		GameObject *obj = getPictureObjectByName((char *)sub->_varName.c_str(), -1);
+		GameObject *obj = getPictureObjectByName(sub->_varName, -1);
 
 		if (!obj)
-			obj = getStaticANIObject1ByName((char *)sub->_varName.c_str(), -1);
+			obj = getStaticANIObject1ByName(sub->_varName, -1);
 
 		PictureObject *pic = getGameLoaderInventory()->getScene()->getPictureObjectByName(sub->_value.stringValue, -1);
 

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -210,7 +210,7 @@ bool Scene::load(MfcArchive &file) {
 
 	_libHandle = g_fp->_currArchive;
 
-	if (_picObjList.size() > 0 && _bgname.size() > 1) {
+	if (_picObjList.size() > 0 && !_bgname.empty()) {
 		char fname[260];
 
 		strcpy(fname, _bgname.c_str());

--- a/engines/fullpipe/scene.h
+++ b/engines/fullpipe/scene.h
@@ -38,7 +38,7 @@ class Scene : public Background {
 	Shadows *_shadows;
 	SoundList *_soundList;
 	int16 _sceneId;
-	char *_sceneName;
+	Common::String _sceneName;
 	int _field_BC;
 	NGIArchive *_libHandle;
 
@@ -94,7 +94,7 @@ class Scene : public Background {
 class SceneTag : public CObject {
  public:
 	CObject *_field_4;
-	char *_tag;
+	Common::String _tag;
 	Scene *_scene;
 	int16 _sceneId;
 

--- a/engines/fullpipe/scene.h
+++ b/engines/fullpipe/scene.h
@@ -59,16 +59,16 @@ class Scene : public Background {
 
 	StaticANIObject *getAniMan();
 	StaticANIObject *getStaticANIObject1ById(int obj, int a3);
-	StaticANIObject *getStaticANIObject1ByName(char *name, int a3);
+	StaticANIObject *getStaticANIObject1ByName(Common::String &name, int a3);
 	MessageQueue *getMessageQueueById(int messageId);
-	MessageQueue *getMessageQueueByName(char *name);
+	MessageQueue *getMessageQueueByName(Common::String &name);
 
 	void deleteStaticANIObject(StaticANIObject *obj);
 	void addStaticANIObject(StaticANIObject *obj, bool addList2);
 
 	void setPictureObjectsFlag4();
 	PictureObject *getPictureObjectById(int objId, int flags);
-	PictureObject *getPictureObjectByName(const char *name, int keyCode);
+	PictureObject *getPictureObjectByName(Common::String name, int keyCode);
 	void deletePictureObject(PictureObject *obj);
 	void preloadMovements(GameVar *var);
 

--- a/engines/fullpipe/sound.cpp
+++ b/engines/fullpipe/sound.cpp
@@ -257,7 +257,8 @@ void FullpipeEngine::setSceneMusicParameters(GameVar *gvar) {
 
 	GameVar *var = gvar->getSubVarByName("MUSIC");
 
-	memset(_sceneTracks, 0, sizeof(_sceneTracks));
+	for (int i = 0; i < 10; i++)
+		_sceneTracks[i].clear();
 
 	_numSceneTracks = 0;
 	_sceneTrackHasSequence = false;
@@ -273,7 +274,7 @@ void FullpipeEngine::setSceneMusicParameters(GameVar *gvar) {
 
 		while (sub) {
 			if (_musicAllowed & sub->_value.intValue) {
-				Common::strlcpy(_sceneTracks[_numSceneTracks], sub->_varName.c_str(), 260);
+				_sceneTracks[_numSceneTracks] = sub->_varName;
 
 				_numSceneTracks++;
 			}
@@ -291,7 +292,7 @@ void FullpipeEngine::setSceneMusicParameters(GameVar *gvar) {
 	if (seq) {
 		_sceneTrackHasSequence = true;
 
-		Common::strlcpy(_trackName, seq->_value.stringValue, 2600);
+		_trackName = seq->_value.stringValue;
 	}
 
 	if (_musicLocal)
@@ -320,12 +321,12 @@ void FullpipeEngine::startSceneTrack() {
 			int trackNum = getSceneTrack();
 
 			if (trackNum == -1) {
-				strcpy(_sceneTracksCurrentTrack, "silence");
+				_sceneTracksCurrentTrack = "silence";
 
 				_trackStartDelay = 2880;
 				_sceneTrackIsPlaying = 0;
 			} else {
-				strcpy(_sceneTracksCurrentTrack, _sceneTracks[trackNum]);
+				_sceneTracksCurrentTrack = _sceneTracks[trackNum];
 
 				startSoundStream1(_sceneTracksCurrentTrack);
 
@@ -363,20 +364,20 @@ int FullpipeEngine::getSceneTrack() {
 	return res;
 }
 
-void FullpipeEngine::startSoundStream1(const char *trackName) {
+void FullpipeEngine::startSoundStream1(Common::String trackName) {
 	stopAllSoundStreams();
 
 	playOggSound(trackName, _soundStream1);
 }
 
-void FullpipeEngine::playOggSound(const char *trackName, Audio::SoundHandle *stream) {
+void FullpipeEngine::playOggSound(Common::String trackName, Audio::SoundHandle *stream) {
 #ifdef USE_VORBIS
 	if (_mixer->isSoundHandleActive(*stream))
 		return;
 
 	Common::File *track = new Common::File();
 	if (!track->open(trackName)) {
-		warning("Could not open %s", trackName);
+		warning("Could not open %s", trackName.c_str());
 		delete track;
 		return;
 	}
@@ -429,7 +430,8 @@ void FullpipeEngine::playTrack(GameVar *sceneVar, const char *name, bool delayed
 
 	GameVar *var = sceneVar->getSubVarByName(name);
 
-	memset(_sceneTracks, 0, sizeof(_sceneTracks));
+	for (int i = 0; i < 10; i++)
+		_sceneTracks[i].clear();
 
 	_numSceneTracks = 0;
 	_sceneTrackHasSequence = false;
@@ -445,7 +447,7 @@ void FullpipeEngine::playTrack(GameVar *sceneVar, const char *name, bool delayed
 
 		while (sub) {
 			if (_musicAllowed & sub->_value.intValue) {
-				Common::strlcpy(_sceneTracks[_numSceneTracks], sub->_varName.c_str(), 260);
+				_sceneTracks[_numSceneTracks] = sub->_varName;
 
 				_numSceneTracks++;
 			}
@@ -463,12 +465,12 @@ void FullpipeEngine::playTrack(GameVar *sceneVar, const char *name, bool delayed
 	if (seq) {
 		_sceneTrackHasSequence = true;
 
-		Common::strlcpy(_trackName, seq->_value.stringValue, 2600);
+		_trackName = seq->_value.stringValue;
 	}
 
 	if (delayed) {
 		if (_sceneTrackIsPlaying && _numSceneTracks == 1) {
-			if (strcmp(_sceneTracksCurrentTrack, _sceneTracks[0]))
+			if (_sceneTracksCurrentTrack != _sceneTracks[0])
 				stopAllSoundStreams();
 		}
 

--- a/engines/fullpipe/sound.cpp
+++ b/engines/fullpipe/sound.cpp
@@ -50,13 +50,13 @@ SoundList::~SoundList() {
 	free(_soundItems);
 }
 
-bool SoundList::load(MfcArchive &file, char *fname) {
+bool SoundList::load(MfcArchive &file, Common::String fname) {
 	debugC(5, kDebugLoading, "SoundList::load()");
 
 	_soundItemsCount = file.readUint32LE();
 	_soundItems = (Sound **)calloc(_soundItemsCount, sizeof(Sound *));
 
-	if (fname) {
+	if (!fname.empty()) {
 	  _libHandle = (NGIArchive *)makeNGIArchive(fname);
 	} else {
 		_libHandle = 0;
@@ -73,7 +73,7 @@ bool SoundList::load(MfcArchive &file, char *fname) {
 
 }
 
-bool SoundList::loadFile(const char *fname, char *libname) {
+bool SoundList::loadFile(Common::String fname, Common::String libname) {
 	Common::File file;
 
 	if (!file.open(fname))

--- a/engines/fullpipe/sound.cpp
+++ b/engines/fullpipe/sound.cpp
@@ -273,7 +273,7 @@ void FullpipeEngine::setSceneMusicParameters(GameVar *gvar) {
 
 		while (sub) {
 			if (_musicAllowed & sub->_value.intValue) {
-				Common::strlcpy(_sceneTracks[_numSceneTracks], sub->_varName, 260);
+				Common::strlcpy(_sceneTracks[_numSceneTracks], sub->_varName.c_str(), 260);
 
 				_numSceneTracks++;
 			}
@@ -445,7 +445,7 @@ void FullpipeEngine::playTrack(GameVar *sceneVar, const char *name, bool delayed
 
 		while (sub) {
 			if (_musicAllowed & sub->_value.intValue) {
-				Common::strlcpy(_sceneTracks[_numSceneTracks], sub->_varName, 260);
+				Common::strlcpy(_sceneTracks[_numSceneTracks], sub->_varName.c_str(), 260);
 
 				_numSceneTracks++;
 			}

--- a/engines/fullpipe/sound.h
+++ b/engines/fullpipe/sound.h
@@ -67,9 +67,9 @@ class SoundList : public CObject {
  public:
 	SoundList();
 	~SoundList();
-	virtual bool load(MfcArchive &file, char *fname);
+	virtual bool load(MfcArchive &file, Common::String fname);
 	virtual bool load(MfcArchive &file) { assert(0); return false; } // Disable base class
-	bool loadFile(const char *fname, char *libname);
+	bool loadFile(Common::String fname, Common::String libname);
 
 	int getCount() { return _soundItemsCount; }
 	Sound *getSoundByIndex(int idx) { return _soundItems[idx]; }

--- a/engines/fullpipe/stateloader.cpp
+++ b/engines/fullpipe/stateloader.cpp
@@ -467,7 +467,7 @@ bool GameVar::load(MfcArchive &file) {
 	for (int i = 0; i < file.getLevel(); i++)
 		debugCN(6, kDebugLoading, " ");
 
-	debugCN(6, kDebugLoading, "<%s>: ", transCyrillic((byte *)_varName));
+	debugCN(6, kDebugLoading, "<%s>: ", transCyrillic(_varName));
 
 	switch (_varType) {
 	case 0:

--- a/engines/fullpipe/stateloader.cpp
+++ b/engines/fullpipe/stateloader.cpp
@@ -492,18 +492,18 @@ bool GameVar::load(MfcArchive &file) {
 	return true;
 }
 
-GameVar *GameVar::getSubVarByName(const char *name) {
+GameVar *GameVar::getSubVarByName(Common::String name) {
 	GameVar *sv = 0;
 
 	if (_subVars != 0) {
 		sv = _subVars;
-		for (;sv && scumm_stricmp(sv->_varName.c_str(), name); sv = sv->_nextVarObj)
+		for (;sv && scumm_stricmp(sv->_varName.c_str(), name.c_str()); sv = sv->_nextVarObj)
 			;
 	}
 	return sv;
 }
 
-bool GameVar::setSubVarAsInt(const char *name, int value) {
+bool GameVar::setSubVarAsInt(Common::String name, int value) {
 	GameVar *var = getSubVarByName(name);
 
 	if (var) {
@@ -523,7 +523,7 @@ bool GameVar::setSubVarAsInt(const char *name, int value) {
 	return addSubVar(var);
 }
 
-int GameVar::getSubVarAsInt(const char *name) {
+int GameVar::getSubVarAsInt(Common::String name) {
 	GameVar *var = getSubVarByName(name);
 
 	if (var)
@@ -532,7 +532,7 @@ int GameVar::getSubVarAsInt(const char *name) {
 		return 0;
 }
 
-GameVar *GameVar::addSubVarAsInt(const char *name, int value) {
+GameVar *GameVar::addSubVarAsInt(Common::String name, int value) {
 	if (getSubVarByName(name)) {
 		return 0;
 	} else {

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -418,7 +418,7 @@ Statics *StaticANIObject::getStaticsById(int itemId) {
 	return 0;
 }
 
-Statics *StaticANIObject::getStaticsByName(char *name) {
+Statics *StaticANIObject::getStaticsByName(Common::String &name) {
 	for (uint i = 0; i < _staticsList.size(); i++)
 		if (_staticsList[i]->_staticsName == name)
 			return _staticsList[i];
@@ -450,7 +450,7 @@ int StaticANIObject::getMovementIdById(int itemId) {
 	return 0;
 }
 
-Movement *StaticANIObject::getMovementByName(char *name) {
+Movement *StaticANIObject::getMovementByName(Common::String &name) {
 	for (uint i = 0; i < _movements.size(); i++)
 		if (_movements[i]->_objectName == name)
 			return _movements[i];
@@ -681,7 +681,7 @@ void StaticANIObject::draw2() {
 }
 
 MovTable *StaticANIObject::countMovements() {
-	GameVar *preloadSubVar = g_fp->getGameLoaderGameVar()->getSubVarByName(getName().c_str())->getSubVarByName("PRELOAD");
+	GameVar *preloadSubVar = g_fp->getGameLoaderGameVar()->getSubVarByName(getName())->getSubVarByName("PRELOAD");
 
 	if (!preloadSubVar || preloadSubVar->getSubVarsCount() == 0)
 		return 0;
@@ -706,7 +706,7 @@ MovTable *StaticANIObject::countMovements() {
 }
 
 void StaticANIObject::setSpeed(int speed) {
-	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(getName().c_str())->getSubVarByName("SpeedUp");
+	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(getName())->getSubVarByName("SpeedUp");
 
 	if (!var)
 		return;

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1428,7 +1428,8 @@ Common::Point *StaticANIObject::calcStepLen(Common::Point *p) {
 
 Statics::Statics() {
 	_staticsId = 0;
-	_picture = 0;
+	_picture = nullptr;
+	_data = nullptr;
 }
 
 Statics::~Statics() {
@@ -1474,7 +1475,6 @@ void Statics::init() {
 		freePixelData();
 		// TODO: properly dispose old _bitmap
 		_bitmap = reversed;
-		// _data = ... // useless?
 	}
 }
 
@@ -2199,6 +2199,7 @@ DynamicPhase::DynamicPhase() {
 	_field_7E = 0;
 	_dynFlags = 0;
 	_someY = 0;
+	_data = nullptr;
 }
 
 DynamicPhase::~DynamicPhase() {
@@ -2217,7 +2218,6 @@ DynamicPhase::DynamicPhase(DynamicPhase *src, bool reverse) {
 			src->init();
 
 		_bitmap = src->_bitmap->reverseImage();
-		_data = _bitmap->_pixels;
 		_dataSize = src->_dataSize;
 
 		if (g_fp->_currArchive) {

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -420,7 +420,7 @@ Statics *StaticANIObject::getStaticsById(int itemId) {
 
 Statics *StaticANIObject::getStaticsByName(char *name) {
 	for (uint i = 0; i < _staticsList.size(); i++)
-		if (!strcmp(_staticsList[i]->_staticsName, name))
+		if (_staticsList[i]->_staticsName == name)
 			return _staticsList[i];
 
 	return 0;
@@ -1430,12 +1430,10 @@ Common::Point *StaticANIObject::calcStepLen(Common::Point *p) {
 Statics::Statics() {
 	_staticsId = 0;
 	_picture = 0;
-	_staticsName = 0;
 }
 
 Statics::~Statics() {
 	delete _picture;
-	free(_staticsName);
 }
 
 Statics::Statics(Statics *src, bool reverse) : DynamicPhase(src, reverse) {
@@ -1443,13 +1441,9 @@ Statics::Statics(Statics *src, bool reverse) : DynamicPhase(src, reverse) {
 
 	if (reverse) {
 		_staticsId ^= 0x4000;
-		int newlen = strlen(src->_staticsName) + strlen(sO_MirroredTo) + 1;
-		_staticsName = (char *)calloc(newlen, 1);
-
-		snprintf(_staticsName, newlen, "%s%s", sO_MirroredTo, src->_staticsName);
+		_staticsName = sO_MirroredTo + src->_staticsName;
 	} else {
-		_staticsName = (char *)calloc(strlen(src->_staticsName) + 1, 1);
-		strncpy(_staticsName, src->_staticsName, strlen(src->_staticsName) + 1);
+		_staticsName = src->_staticsName;
 	}
 
 	_memfilename = (char *)calloc(strlen(src->_memfilename) + 1, 1);
@@ -1466,7 +1460,7 @@ bool Statics::load(MfcArchive &file) {
 	_staticsId = file.readUint16LE();
 
 	_staticsName = file.readPascalString();
-	debugC(7, kDebugLoading, "statics: <%s> id: %d (%x)", transCyrillic((byte *)_staticsName), _staticsId, _staticsId);
+	debugC(7, kDebugLoading, "statics: <%s> id: %d (%x)", transCyrillic((byte *)_staticsName.c_str()), _staticsId, _staticsId);
 
 	_picture = new Picture();
 	_picture->load(file);

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1446,8 +1446,7 @@ Statics::Statics(Statics *src, bool reverse) : DynamicPhase(src, reverse) {
 		_staticsName = src->_staticsName;
 	}
 
-	_memfilename = (char *)calloc(strlen(src->_memfilename) + 1, 1);
-	strncpy(_memfilename, src->_memfilename, strlen(src->_memfilename) + 1);
+	_memfilename = src->_memfilename;
 
 	_picture = new Picture();
 }
@@ -2236,8 +2235,7 @@ DynamicPhase::DynamicPhase(DynamicPhase *src, bool reverse) {
 		_mfield_8 = src->_mfield_8;
 		_mflags = src->_mflags;
 
-		_memfilename = (char *)calloc(strlen(src->_memfilename) + 1, 1);
-		strncpy(_memfilename, src->_memfilename, strlen(src->_memfilename) + 1);
+		_memfilename = src->_memfilename;
 		_dataSize = src->_dataSize;
 		_mfield_10 = src->_mfield_10;
 		_libHandle = src->_libHandle;

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1538,6 +1538,10 @@ Movement::~Movement() {
 		if (_updateFlag1)
 			_dynamicPhases.remove_at(0);
 
+		// FIXME: At this point, the last entry in _dynamicPhases is invalid
+		for (uint i = 0; i < _dynamicPhases.size() - 1; i++)
+			_dynamicPhases[i]->freePixelData();
+
 		_dynamicPhases.clear();
 	}
 

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -223,7 +223,7 @@ bool StaticANIObject::load(MfcArchive &file) {
 	for (int i = 0; i < count; i++) {
 		int movNum = file.readUint16LE();
 
-		char *movname = genFileName(_id, movNum, "mov");
+		Common::String movname = genFileName(_id, movNum, "mov");
 
 		Common::SeekableReadStream *f = g_fp->_currArchive->createReadStreamForMember(movname);
 
@@ -236,7 +236,6 @@ bool StaticANIObject::load(MfcArchive &file) {
 		_movements.push_back(mov);
 
 		delete f;
-		free(movname);
 	}
 
 	Common::Point pt;

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1472,8 +1472,9 @@ void Statics::init() {
 
 	if (_staticsId & 0x4000) {
 		Bitmap *reversed = _bitmap->reverseImage();
-		freePixelData();
 		// TODO: properly dispose old _bitmap
+		// Enabling the call below causes corruption in flipped bitmaps
+		//freePixelData();
 		_bitmap = reversed;
 	}
 }

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -605,7 +605,7 @@ void StaticANIObject::draw() {
 	Common::Point point;
 	Common::Rect rect;
 
-	debugC(6, kDebugDrawing, "StaticANIObject::draw() (%s) [%d] [%d, %d]", transCyrillic((byte *)_objectName), _id, _ox, _oy);
+	debugC(6, kDebugDrawing, "StaticANIObject::draw() (%s) [%d] [%d, %d]", transCyrillic(_objectName), _id, _ox, _oy);
 
 	if (_shadowsOn && g_fp->_currentScene && g_fp->_currentScene->_shadows
 		&& (getCurrDimensions(point)->x != 1 || getCurrDimensions(point)->y != 1)) {
@@ -665,7 +665,7 @@ void StaticANIObject::draw() {
 }
 
 void StaticANIObject::draw2() {
-	debugC(6, kDebugDrawing, "StatciANIObject::draw2(): id: (%s) %d [%d, %d]", transCyrillic((byte *)_objectName), _id, _ox, _oy);
+	debugC(6, kDebugDrawing, "StatciANIObject::draw2(): id: (%s) %d [%d, %d]", transCyrillic(_objectName), _id, _ox, _oy);
 
 	if ((_flags & 4) && (_flags & 0x10)) {
 		if (_movement) {
@@ -790,7 +790,7 @@ Common::Point *StaticANIObject::getSomeXY(Common::Point &p) {
 void StaticANIObject::update(int counterdiff) {
 	int mqid;
 
-	debugC(6, kDebugAnimation, "StaticANIObject::update() (%s) [%d] [%d, %d] fl: %x", transCyrillic((byte *)_objectName), _id, _ox, _oy, _flags);
+	debugC(6, kDebugAnimation, "StaticANIObject::update() (%s) [%d] [%d, %d] fl: %x", transCyrillic(_objectName), _id, _ox, _oy, _flags);
 
 	if (_flags & 2) {
 		_messageNum--;
@@ -1300,7 +1300,7 @@ bool StaticANIObject::startAnim(int movementId, int messageQueueId, int dynPhase
 	if (_flags & 0x80)
 		return false;
 
-	debugC(4, kDebugAnimation, "StaticANIObject::startAnim(%d, %d, %d) (%s [%d]) [%d, %d]", movementId, messageQueueId, dynPhaseIdx, transCyrillic((byte *)_objectName), _id, _ox, _oy);
+	debugC(4, kDebugAnimation, "StaticANIObject::startAnim(%d, %d, %d) (%s [%d]) [%d, %d]", movementId, messageQueueId, dynPhaseIdx, transCyrillic(_objectName), _id, _ox, _oy);
 
 	if (_messageQueueId) {
 		updateGlobalMessageQueue(messageQueueId, _id);
@@ -1459,7 +1459,7 @@ bool Statics::load(MfcArchive &file) {
 	_staticsId = file.readUint16LE();
 
 	_staticsName = file.readPascalString();
-	debugC(7, kDebugLoading, "statics: <%s> id: %d (%x)", transCyrillic((byte *)_staticsName.c_str()), _staticsId, _staticsId);
+	debugC(7, kDebugLoading, "statics: <%s> id: %d (%x)", transCyrillic(_staticsName), _staticsId, _staticsId);
 
 	_picture = new Picture();
 	_picture->load(file);

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -452,7 +452,7 @@ int StaticANIObject::getMovementIdById(int itemId) {
 
 Movement *StaticANIObject::getMovementByName(char *name) {
 	for (uint i = 0; i < _movements.size(); i++)
-		if (!strcmp(_movements[i]->_objectName, name))
+		if (_movements[i]->_objectName == name)
 			return _movements[i];
 
 	return 0;
@@ -681,7 +681,7 @@ void StaticANIObject::draw2() {
 }
 
 MovTable *StaticANIObject::countMovements() {
-	GameVar *preloadSubVar = g_fp->getGameLoaderGameVar()->getSubVarByName(getName())->getSubVarByName("PRELOAD");
+	GameVar *preloadSubVar = g_fp->getGameLoaderGameVar()->getSubVarByName(getName().c_str())->getSubVarByName("PRELOAD");
 
 	if (!preloadSubVar || preloadSubVar->getSubVarsCount() == 0)
 		return 0;
@@ -695,7 +695,7 @@ MovTable *StaticANIObject::countMovements() {
 		movTable->movs[i] = 2;
 
 		for (GameVar *sub = preloadSubVar->_subVars; sub; sub = sub->_nextVarObj) {
-			if (scumm_stricmp(_movements[i]->getName(), sub->_varName) == 0) {
+			if (scumm_stricmp(_movements[i]->getName().c_str(), sub->_varName.c_str()) == 0) {
 				movTable->movs[i] = 1;
 				break;
 			}
@@ -706,7 +706,7 @@ MovTable *StaticANIObject::countMovements() {
 }
 
 void StaticANIObject::setSpeed(int speed) {
-	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(getName())->getSubVarByName("SpeedUp");
+	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(getName().c_str())->getSubVarByName("SpeedUp");
 
 	if (!var)
 		return;

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -89,7 +89,7 @@ class DynamicPhase : public StaticPhase {
 class Statics : public DynamicPhase {
  public:
  	int16 _staticsId;
-	char *_staticsName;
+	Common::String _staticsName;
 	Picture *_picture;
 
   public:

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -204,10 +204,10 @@ public:
 
 	void setOXY(int x, int y);
 	Statics *getStaticsById(int id);
-	Statics *getStaticsByName(char *name);
+	Statics *getStaticsByName(Common::String &name);
 	Movement *getMovementById(int id);
 	int getMovementIdById(int itemId);
-	Movement *getMovementByName(char *name);
+	Movement *getMovementByName(Common::String &name);
 	Common::Point *getCurrDimensions(Common::Point &p);
 
 	Common::Point *getSomeXY(Common::Point &p);

--- a/engines/fullpipe/utils.cpp
+++ b/engines/fullpipe/utils.cpp
@@ -121,7 +121,6 @@ void MfcArchive::writePascalString(const char *str, bool twoByte) {
 }
 
 MemoryObject::MemoryObject() {
-	_memfilename = 0;
 	_mfield_8 = 0;
 	_mfield_C = 0;
 	_mfield_10 = -1;
@@ -134,19 +133,14 @@ MemoryObject::MemoryObject() {
 
 MemoryObject::~MemoryObject() {
 	freeData();
-	if (_memfilename)
-		free(_memfilename);
 }
 
 bool MemoryObject::load(MfcArchive &file) {
 	debugC(5, kDebugLoading, "MemoryObject::load()");
 	_memfilename = file.readPascalString();
 
-	if (char *p = strchr(_memfilename, '\\')) {
-		for (char *d = _memfilename; *p;) {
-			p++;
-			*d++ = *p;
-		}
+	while (_memfilename.contains('\\')) {
+		_memfilename.deleteChar(0);
 	}
 
 	if (g_fp->_currArchive) {
@@ -157,10 +151,10 @@ bool MemoryObject::load(MfcArchive &file) {
 	return true;
 }
 
-void MemoryObject::loadFile(char *filename) {
-	debugC(5, kDebugLoading, "MemoryObject::loadFile(<%s>)", filename);
+void MemoryObject::loadFile(Common::String filename) {
+	debugC(5, kDebugLoading, "MemoryObject::loadFile(<%s>)", filename.c_str());
 
-	if (!*filename)
+	if (filename.empty())
 		return;
 
 	if (!_data) {
@@ -176,7 +170,7 @@ void MemoryObject::loadFile(char *filename) {
 
 			_dataSize = s->size();
 
-			debugC(5, kDebugLoading, "Loading %s (%d bytes)", filename, _dataSize);
+			debugC(5, kDebugLoading, "Loading %s (%d bytes)", filename.c_str(), _dataSize);
 			_data = (byte *)calloc(_dataSize, 1);
 			s->read(_data, _dataSize);
 
@@ -205,7 +199,7 @@ byte *MemoryObject::loadData() {
 }
 
 void MemoryObject::freeData() {
-	debugC(8, kDebugMemory, "MemoryObject::freeData(): file: %s", _memfilename);
+	debugC(8, kDebugMemory, "MemoryObject::freeData(): file: %s", _memfilename.c_str());
 
 	if (_data)
 		free(_data);
@@ -238,9 +232,9 @@ bool MemoryObject2::load(MfcArchive &file) {
 
 	_mflags |= 1;
 
-	debugC(5, kDebugLoading, "MemoryObject2::load: <%s>", _memfilename);
+	debugC(5, kDebugLoading, "MemoryObject2::load: <%s>", _memfilename.c_str());
 
-	if (_memfilename && *_memfilename) {
+	if (!_memfilename.empty()) {
 		MemoryObject::loadFile(_memfilename);
 	}
 

--- a/engines/fullpipe/utils.cpp
+++ b/engines/fullpipe/utils.cpp
@@ -33,7 +33,7 @@
 
 namespace Fullpipe {
 
-bool CObject::loadFile(const char *fname) {
+bool CObject::loadFile(Common::String fname) {
 	Common::File file;
 
 	if (!file.open(fname))
@@ -486,16 +486,16 @@ void MfcArchive::writeObject(CObject *obj) {
 	}
 }
 
-char *genFileName(int superId, int sceneId, const char *ext) {
-	char *s = (char *)calloc(256, 1);
+Common::String genFileName(int superId, int sceneId, const char *ext) {
+	Common::String s;
 
 	if (superId) {
-		snprintf(s, 255, "%04d%04d.%s", superId, sceneId, ext);
+		s = Common::String::format("%04d%04d.%s", superId, sceneId, ext);
 	} else {
-		snprintf(s, 255, "%04d.%s", sceneId, ext);
+		s = Common::String::format("%04d.%s", sceneId, ext);
 	}
 
-	debugC(7, kDebugLoading, "genFileName: %s", s);
+	debugC(7, kDebugLoading, "genFileName: %s", s.c_str());
 
 	return s;
 }

--- a/engines/fullpipe/utils.cpp
+++ b/engines/fullpipe/utils.cpp
@@ -104,7 +104,7 @@ char *MfcArchive::readPascalString(bool twoByte) {
 	tmp = (char *)calloc(len + 1, 1);
 	read(tmp, len);
 
-	debugC(9, kDebugLoading, "readPascalString: %d <%s>", len, transCyrillic((byte *)tmp));
+	debugC(9, kDebugLoading, "readPascalString: %d <%s>", len, transCyrillic(tmp));
 
 	return tmp;
 }
@@ -498,7 +498,8 @@ char *genFileName(int superId, int sceneId, const char *ext) {
 }
 
 // Translates cp-1251..utf-8
-byte *transCyrillic(byte *s) {
+byte *transCyrillic(Common::String str) {
+	byte *s = (byte *)str.c_str();
 	static byte tmp[1024];
 
 #ifndef WIN32

--- a/engines/fullpipe/utils.cpp
+++ b/engines/fullpipe/utils.cpp
@@ -92,9 +92,10 @@ bool DWordArray::load(MfcArchive &file) {
 	return true;
 }
 
-char *MfcArchive::readPascalString(bool twoByte) {
+Common::String MfcArchive::readPascalString(bool twoByte) {
 	char *tmp;
 	int len;
+	Common::String result;
 
 	if (twoByte)
 		len = readUint16LE();
@@ -103,21 +104,23 @@ char *MfcArchive::readPascalString(bool twoByte) {
 
 	tmp = (char *)calloc(len + 1, 1);
 	read(tmp, len);
+	result = tmp;
+	free(tmp);
 
-	debugC(9, kDebugLoading, "readPascalString: %d <%s>", len, transCyrillic(tmp));
+	debugC(9, kDebugLoading, "readPascalString: %d <%s>", len, transCyrillic(result));
 
-	return tmp;
+	return result;
 }
 
-void MfcArchive::writePascalString(const char *str, bool twoByte) {
-	int len = strlen(str);
+void MfcArchive::writePascalString(Common::String str, bool twoByte) {
+	int len = str.size();
 
 	if (twoByte)
 		writeUint16LE(len);
 	else
 		writeByte(len);
 
-	write(str, len);
+	write(str.c_str(), len);
 }
 
 MemoryObject::MemoryObject() {
@@ -388,7 +391,7 @@ CObject *MfcArchive::readClass() {
 }
 
 CObject *MfcArchive::parseClass(bool *isCopyReturned) {
-	char *name;
+	Common::String name;
 	int objectId = 0;
 	CObject *res = 0;
 
@@ -404,13 +407,13 @@ CObject *MfcArchive::parseClass(bool *isCopyReturned) {
 		debugC(7, kDebugLoading, "parseClass::schema = %d", schema);
 
 		name = readPascalString(true);
-		debugC(7, kDebugLoading, "parseClass::class <%s>", name);
+		debugC(7, kDebugLoading, "parseClass::class <%s>", name.c_str());
 
-		if (!_classMap.contains(name)) {
-			error("Unknown class in MfcArchive: <%s>", name);
+		if (!_classMap.contains(name.c_str())) {
+			error("Unknown class in MfcArchive: <%s>", name.c_str());
 		}
 
-		objectId = _classMap[name];
+		objectId = _classMap[name.c_str()];
 
 		debugC(7, kDebugLoading, "tag: %d 0x%x (%x)", _objectMap.size() - 1, _objectMap.size() - 1, objectId);
 

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -130,7 +130,7 @@ class MemoryObject : CObject {
 	friend class Scene;
 
  protected:
-	char *_memfilename;
+	Common::String _memfilename;
 	int _mfield_8;
 	int _mfield_C;
 	int _mfield_10;
@@ -145,7 +145,7 @@ class MemoryObject : CObject {
 	virtual ~MemoryObject();
 
 	virtual bool load(MfcArchive &file);
-	void loadFile(char *filename);
+	void loadFile(Common::String filename);
 	void load() { loadFile(_memfilename); }
 	byte *getData();
 	byte *loadData();

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -117,7 +117,7 @@ public:
 	virtual void save(MfcArchive &out) { error("Not implemented for obj type: %d", _objtype); }
 	virtual ~CObject() {}
 
-	bool loadFile(const char *fname);
+	bool loadFile(Common::String fname);
 };
 
 class ObList : public Common::List<CObject *>, public CObject {
@@ -180,7 +180,7 @@ class DWordArray : public Common::Array<int32>, public CObject {
 	virtual bool load(MfcArchive &file);
 };
 
-char *genFileName(int superId, int sceneId, const char *ext);
+Common::String genFileName(int superId, int sceneId, const char *ext);
 byte *transCyrillic(Common::String str);
 
 } // End of namespace Fullpipe

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -67,8 +67,8 @@ public:
 	MfcArchive(Common::SeekableReadStream *file);
 	MfcArchive(Common::WriteStream *file);
 
-	char *readPascalString(bool twoByte = false);
-	void writePascalString(const char *str, bool twoByte = false);
+	Common::String readPascalString(bool twoByte = false);
+	void writePascalString(Common::String str, bool twoByte = false);
 	int readCount();
 	double readDouble();
 	CObject *parseClass(bool *isCopyReturned);

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -181,7 +181,7 @@ class DWordArray : public Common::Array<int32>, public CObject {
 };
 
 char *genFileName(int superId, int sceneId, const char *ext);
-byte *transCyrillic(byte *s);
+byte *transCyrillic(Common::String str);
 
 } // End of namespace Fullpipe
 


### PR DESCRIPTION
In this pull request, I've changed a lot of engine strings in Fullpipe so that they are handled via Common::String. This results in cleaner and more manageable code.

I've tried splitting up the commits so that all relevant changes are grouped together

Update: I've also added some memory leak fixes to this branch, as part of fixing memory leaks in this engine. These are relevant, because the original intention of this branch was to optimize code and identify memory leaks.