### PR TITLE
DIRECTOR: Add detection for Arnie and its demo

### DIFF
--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -85,6 +85,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "vvvampire",	"Victor Vector & Yondo: The Vampire's Coffin"},
 	{ "vvdinosaur",	"Victor Vector & Yondo: The Last Dinosaur Egg"},
 	{ "warlock", 	"Spaceship Warlock"},
+	{ "ernie",		"Ernie"},
 	{ 0, 0 }
 };
 

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -538,7 +538,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 			GUIO1(GUIO_NOASPECT)
 		},
 		GID_GENERIC,
-		2
+		5
 	},
 
 	{
@@ -552,7 +552,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 			GUIO1(GUIO_NOASPECT)
 		},
 		GID_GENERIC,
-		2
+		5
 	},
 
 	{ AD_TABLE_END_MARKER, GID_GENERIC, 0 }

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -527,6 +527,34 @@ static const DirectorGameDescription gameDescriptions[] = {
 		2
 	},
 
+	{
+		{
+			"ernie",
+			"Ernie - Demo",
+			AD_ENTRY1s("ERNIE.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1417371),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_DEMO,
+			GUIO1(GUIO_NOASPECT)
+		},
+		GID_GENERIC,
+		2
+	},
+
+	{
+		{
+			"ernie",
+			"Ernie",
+			AD_ENTRY1s("Ernie.exe", "1a7acbba10a7246ba58c1d53fc7203f5", 1417481),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_NO_FLAGS,
+			GUIO1(GUIO_NOASPECT)
+		},
+		GID_GENERIC,
+		2
+	},
+
 	{ AD_TABLE_END_MARKER, GID_GENERIC, 0 }
 };
 

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -530,7 +530,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	{
 		{
 			"ernie",
-			"Ernie - Demo",
+			"Demo",
 			AD_ENTRY1s("ERNIE.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1417371),
 			Common::EN_ANY,
 			Common::kPlatformWindows,
@@ -544,7 +544,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	{
 		{
 			"ernie",
-			"Ernie",
+			"",
 			AD_ENTRY1s("Ernie.exe", "1a7acbba10a7246ba58c1d53fc7203f5", 1417481),
 			Common::EN_ANY,
 			Common::kPlatformWindows,


### PR DESCRIPTION
My versions are in Swedish but I'm pretty sure there aren't any other versions, that's why I chose `Common::EN_ANY`.

The game doesn't currently boot as `loadCastData` eventually tries to read non-Cast data and asserts [here](https://github.com/scummvm/scummvm/blob/master/engines/director/score.cpp#L495).