### PR TITLE
Do not hardcode resolutions for aspect ratio correction

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -36,8 +36,11 @@
 #include "common/tokenizer.h"
 #include "common/rect.h"
 #endif
+#include "common/gui_options.h"
+#include "common/config-manager.h"
 
 #include "graphics/conversion.h"
+#include "graphics/scaler/aspect.h"
 #ifdef USE_OSD
 #include "graphics/fontman.h"
 #include "graphics/font.h"
@@ -1207,12 +1210,10 @@ frac_t OpenGLGraphicsManager::getDesiredGameScreenAspect() const {
 	const uint height = _currentState.gameHeight;
 
 	if (_currentState.aspectRatioCorrection) {
-		// In case we enable aspect ratio correction we force a 4/3 ratio.
-		// But just for 320x200 and 640x400 games, since other games do not need
-		// this.
-		if ((width == 320 && height == 200) || (width == 640 && height == 400)) {
-			return intToFrac(4) / 3;
-		}
+		// Check that the current domain supports aspect ratio correction
+		bool supportsAspectRatio = !Common::checkGameGUIOption(GUIO_NOASPECT, ConfMan.get("guioptions", ConfMan.getActiveDomainName()));
+		if (supportsAspectRatio)
+			return intToFrac(width) / real2Aspect(height);
 	}
 
 	return intToFrac(width) / height;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -808,8 +808,11 @@ bool SurfaceSdlGraphicsManager::loadGFXMode() {
 	_videoMode.overlayWidth = _videoMode.screenWidth * _videoMode.scaleFactor;
 	_videoMode.overlayHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
 
-	if (_videoMode.screenHeight != 200 && _videoMode.screenHeight != 400)
-		_videoMode.aspectRatioCorrection = false;
+	if (_videoMode.aspectRatioCorrection) {
+		// Check that he current domain supports aspect ratio correction
+		if (Common::checkGameGUIOption(GUIO_NOASPECT, ConfMan.get("guioptions", ConfMan.getActiveDomainName())))
+			_videoMode.aspectRatioCorrection = false;
+	}
 
 	if (_videoMode.aspectRatioCorrection)
 		_videoMode.overlayHeight = real2Aspect(_videoMode.overlayHeight);


### PR DESCRIPTION
The changes in this PR aim at correcting missing aspect ratio correction for some SCI games that should support it. This was reported in the forum for King's Quest V mac, which uses a resolution of 320x190: http://forums.scummvm.org/viewtopic.php?t=14303

The issue is that in both the SurfaceSDL and OpenGL backends the code checks the resolutions to decide whether to apply the correction or not, and only apply it for 320x200 and 640x400 resolutions.

My initial fix was to simply add more resolutions to the tests, and this can be found here: https://github.com/scummvm/scummvm/compare/master...criezy:sci-ar

On IRC yesterday snover asked: "can AR setting be retrieved from the engine instead of hardcoding numbers into the backend?" So I looked at a different approach and this is what I am proposing here. It checks whether the GUIO_NOASPECT is defined by the current target and applies the aspect ratio correction if it isn't.

Do you see issues with this approach?