### PR TITLE
GUI: fix for bug #9714: unnecessary tab in options

### DIFF
--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -181,8 +181,8 @@ bool OSystem_SDL::hasFeature(Feature f) {
 #endif
 #ifdef JOY_ANALOG
 	if (f == kFeatureJoystickDeadzone) return true;
-#endif
 	if (f == kFeatureKbdMouseSpeed) return true;
+#endif
 	return ModularBackend::hasFeature(f);
 }
 


### PR DESCRIPTION
In option menu the Control tab was showing. 
The only available option in the control tab was pointer speed, which does not affect users of mice.
Therefore the control tab was unnecessary 