### PR TITLE
SDL: Only recreate SDL2 window when necessary

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -489,13 +489,9 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 		_glContext = nullptr;
 	}
 
-	_window->destroyWindow();
-
-	uint32 flags = SDL_WINDOW_OPENGL;
+	uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
 	if (_wantsFullScreen) {
 		flags |= SDL_WINDOW_FULLSCREEN;
-	} else {
-		flags |= SDL_WINDOW_RESIZABLE;
 	}
 
 	// Request a OpenGL (ES) context we can use.
@@ -503,11 +499,11 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, _glContextMajor);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, _glContextMinor);
 
-	if (!_window->createWindow(width, height, flags)) {
+	if (!_window->createOrUpdateWindow(width, height, flags)) {
 		// We treat fullscreen requests as a "hint" for now. This means in
 		// case it is not available we simply ignore it.
 		if (_wantsFullScreen) {
-			_window->createWindow(width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+			_window->createOrUpdateWindow(width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 		}
 
 		if (!_window->getSDLWindow()) {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -214,6 +214,10 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 
 SurfaceSdlGraphicsManager::~SurfaceSdlGraphicsManager() {
 	unloadGFXMode();
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_window)
+		_window->destroyWindow();
+#endif
 	if (_mouseSurface)
 		SDL_FreeSurface(_mouseSurface);
 	_mouseSurface = 0;
@@ -2644,13 +2648,11 @@ void SurfaceSdlGraphicsManager::notifyVideoExpose() {
 	_forceFull = true;
 }
 
-#ifdef USE_SDL_RESIZABLE_WINDOW
 void SurfaceSdlGraphicsManager::notifyResize(const uint width, const uint height) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	setWindowResolution(width, height);
 #endif
 }
-#endif
 
 void SurfaceSdlGraphicsManager::transformMouseCoordinates(Common::Point &point) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -2683,9 +2685,6 @@ void SurfaceSdlGraphicsManager::deinitializeRenderer() {
 
 	SDL_DestroyRenderer(_renderer);
 	_renderer = nullptr;
-
-	if (_window)
-		_window->destroyWindow();
 }
 
 void SurfaceSdlGraphicsManager::setWindowResolution(int width, int height) {
@@ -2746,7 +2745,7 @@ SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, 
 		createWindowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
 
-	if (!_window->createWindow(width, height, createWindowFlags)) {
+	if (!_window->createOrUpdateWindow(width, height, createWindowFlags)) {
 		return nullptr;
 	}
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -156,9 +156,7 @@ public:
 
 	// SdlGraphicsManager interface
 	virtual void notifyVideoExpose();
-#ifdef USE_SDL_RESIZABLE_WINDOW
 	virtual void notifyResize(const uint width, const uint height);
-#endif
 	virtual void transformMouseCoordinates(Common::Point &point);
 	virtual void notifyMousePos(Common::Point mouse);
 

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -81,14 +81,14 @@ public:
 	SDL_Window *getSDLWindow() const { return _window; }
 
 	/**
-	 * Creates a new SDL window (and destroys the old one).
+	 * Creates or updates the SDL window.
 	 *
 	 * @param width   Width of the window.
 	 * @param height  Height of the window.
 	 * @param flags   SDL flags passed to SDL_CreateWindow
 	 * @return true on success, false otherwise
 	 */
-	bool createWindow(int width, int height, uint32 flags);
+	bool createOrUpdateWindow(int width, int height, uint32 flags);
 
 	/**
 	 * Destroys the current SDL window.
@@ -99,6 +99,15 @@ protected:
 	SDL_Window *_window;
 
 private:
+	uint32 _lastFlags;
+
+	/**
+	 * Switching between software and OpenGL modes requires the window to be
+	 * destroyed and recreated. These properties store the position of the last
+	 * window so the new window will be created in the same place.
+	 */
+	int _lastX, _lastY;
+
 	bool _inputGrabState;
 	Common::String _windowCaption;
 #endif


### PR DESCRIPTION
Destroying and recreating the SDL window whenever the video mode changes in SDL2 is not necessary and causes several problems:

1. In windowed mode, the game window shifts position;
2. In fullscreen mode in macOS, every time the window is recreated, it causes the OS to play its switch-to-fullscreen animation again and emit system alert noises;
3. The window content flickers; and
4. The engine loses events from the old destroyed window.

This patch changes the SDL backend code to avoid destroying and recreating the SDL window when using SDL2, except when switching between OpenGL modes, which cannot be done without recreating the window.