### PR TITLE
TESTBED: Fix building with --disable-cloud

### DIFF
--- a/engines/testbed/module.mk
+++ b/engines/testbed/module.mk
@@ -14,7 +14,7 @@ MODULE_OBJS := \
 	testbed.o \
 	testsuite.o
 
-ifdef USE_LIBCURL
+ifdef USE_CLOUD
 MODULE_OBJS += \
 	cloud.o
 endif

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -39,7 +39,7 @@
 #include "testbed/savegame.h"
 #include "testbed/sound.h"
 #include "testbed/testbed.h"
-#ifdef USE_LIBCURL
+#ifdef USE_CLOUD
 #include "testbed/cloud.h"
 #endif
 #ifdef USE_SDL_NET
@@ -140,7 +140,7 @@ TestbedEngine::TestbedEngine(OSystem *syst)
 	// Midi
 	ts = new MidiTestSuite();
 	_testsuiteList.push_back(ts);
-#ifdef USE_LIBCURL
+#ifdef USE_CLOUD
 	// Cloud
 	ts = new CloudTestSuite();
 	_testsuiteList.push_back(ts);


### PR DESCRIPTION
The linker fails when building with `--disable-cloud` and not passing `--disable-libcurl`