### PR TITLE
Clean up renderText

### DIFF
--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -752,11 +752,6 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	else
 		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
 
-	if (width == 0 || height == 0) {
-		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
-		return;
-	}
-
 	if (_vm->getVersion() >= 4) {
 		if (textSize == NULL)
 			width = textCast->initialRect.right;
@@ -769,6 +764,11 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		// We need to make sure that the Shared Cast fonts have been loaded in?
 		// might need a mapping table here of our own.
 		// textCast->fontId = _vm->_wm->_fontMan->getFontIdByName(_vm->getCurrentScore()->_fontMap[textCast->fontId]);
+	}
+
+	if (width == 0 || height == 0) {
+		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
+		return;
 	}
 
 	Graphics::MacFont macFont = Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -737,41 +737,10 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, uint1
 	renderText(surface, spriteId, textStream, NULL);
 }
 
-void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Common::SeekableSubReadStreamEndian *textStream, Common::Rect *textSize) {
-	if (textStream == NULL)
-		return;
-
-	TextCast *textCast = _sprites[spriteId]->_buttonCast != nullptr ? (TextCast*)_sprites[spriteId]->_buttonCast : _sprites[spriteId]->_textCast;
-	int x = _sprites[spriteId]->_startPoint.x; // +rectLeft;
-	int y = _sprites[spriteId]->_startPoint.y; // +rectTop;
-	int height = textCast->initialRect.height(); //_sprites[spriteId]->_height;
-	int width;
-
-	if (_vm->getVersion() >= 4) {
-		if (textSize == NULL)
-			width = textCast->initialRect.right;
-		else {
-			width = textSize->width();
-		}
-	} else {
-		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
-	}
-
-	if (_vm->getCurrentScore()->_fontMap.contains(textCast->fontId)) {
-		// We need to make sure that the Shared Cast fonts have been loaded in?
-		// might need a mapping table here of our own.
-		// textCast->fontId = _vm->_wm->_fontMan->getFontIdByName(_vm->getCurrentScore()->_fontMap[textCast->fontId]);
-	}
-
-	if (width == 0 || height == 0) {
-		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
-		return;
-	}
-
-	Graphics::MacFont macFont = Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
-
-	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(macFont));
-
+Common::String Frame::readTextStream(Common::SeekableSubReadStreamEndian *textStream, TextCast *textCast) {
+	// TODO: move me somewhere more appropriate
+	// TODO: remove ugly side effects on textStream?
+	Common::String ftext;
 	uint32 unk1 = textStream->readUint32();
 	uint32 strLen = textStream->readUint32();
 	uint32 dataLen = textStream->readUint32();
@@ -784,8 +753,6 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		}
 		text += ch;
 	}
-
-	Common::String ftext;
 
 	debugC(3, kDebugText, "renderText: unk1: %d strLen: %d dataLen: %d textlen: %u", unk1, strLen, dataLen, text.size());
 	if (strLen < 200)
@@ -832,12 +799,12 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		debugCN(4, kDebugText, "*");
 
 		ftext += Common::String::format("\001\015%c%c%c%c%c%c%c%c%c%c%c%c",
-						(textCast->fontId >> 8) & 0xff, textCast->fontId & 0xff,
-						textCast->textSlant & 0xff, unk3f & 0xff,
-						(textCast->fontSize >> 8) & 0xff, textCast->fontSize & 0xff,
-						(textCast->palinfo1 >> 8) & 0xff, textCast->palinfo1 & 0xff,
-						(textCast->palinfo2 >> 8) & 0xff, textCast->palinfo2 & 0xff,
-						(textCast->palinfo3 >> 8) & 0xff, textCast->palinfo3 & 0xff);
+										(textCast->fontId >> 8) & 0xff, textCast->fontId & 0xff,
+										textCast->textSlant & 0xff, unk3f & 0xff,
+										(textCast->fontSize >> 8) & 0xff, textCast->fontSize & 0xff,
+										(textCast->palinfo1 >> 8) & 0xff, textCast->palinfo1 & 0xff,
+										(textCast->palinfo2 >> 8) & 0xff, textCast->palinfo2 & 0xff,
+										(textCast->palinfo3 >> 8) & 0xff, textCast->palinfo3 & 0xff);
 
 		formattingCount--;
 	}
@@ -845,6 +812,46 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	ftext += text;
 
 	debugC(4, kDebugText, "%s", text.c_str());
+
+	return ftext;
+}
+
+void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Common::SeekableSubReadStreamEndian *textStream, Common::Rect *textSize) {
+	if (textStream == NULL)
+		return;
+
+	TextCast *textCast = _sprites[spriteId]->_buttonCast != nullptr ? (TextCast*)_sprites[spriteId]->_buttonCast : _sprites[spriteId]->_textCast;
+	int x = _sprites[spriteId]->_startPoint.x; // +rectLeft;
+	int y = _sprites[spriteId]->_startPoint.y; // +rectTop;
+	int height = textCast->initialRect.height(); //_sprites[spriteId]->_height;
+	int width;
+
+	if (_vm->getVersion() >= 4) {
+		if (textSize == NULL)
+			width = textCast->initialRect.right;
+		else {
+			width = textSize->width();
+		}
+	} else {
+		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
+	}
+
+	if (_vm->getCurrentScore()->_fontMap.contains(textCast->fontId)) {
+		// We need to make sure that the Shared Cast fonts have been loaded in?
+		// might need a mapping table here of our own.
+		// textCast->fontId = _vm->_wm->_fontMan->getFontIdByName(_vm->getCurrentScore()->_fontMap[textCast->fontId]);
+	}
+
+	if (width == 0 || height == 0) {
+		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
+		return;
+	}
+
+	Graphics::MacFont macFont = Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
+
+	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(macFont));
+
+	Common::String ftext = readTextStream(textStream, textCast);
 
 	uint16 boxShadow = (uint16)textCast->boxShadow;
 	uint16 borderSize = (uint16)textCast->borderSize;

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -747,17 +747,14 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	int height = textCast->initialRect.height(); //_sprites[spriteId]->_height;
 	int width;
 
-	if (_vm->getVersion() >= 4 && textSize != NULL)
-		width = textCast->initialRect.right;
-	else
-		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
-
 	if (_vm->getVersion() >= 4) {
 		if (textSize == NULL)
 			width = textCast->initialRect.right;
 		else {
 			width = textSize->width();
 		}
+	} else {
+		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
 	}
 
 	if (_vm->getCurrentScore()->_fontMap.contains(textCast->fontId)) {

--- a/engines/director/frame.h
+++ b/engines/director/frame.h
@@ -135,6 +135,7 @@ private:
 	void readSprite(Common::SeekableSubReadStreamEndian &stream, uint16 offset, uint16 size);
 	void readMainChannels(Common::SeekableSubReadStreamEndian &stream, uint16 offset, uint16 size);
 	Image::ImageDecoder *getImageFrom(uint16 spriteId);
+	Common::String readTextStream(Common::SeekableSubReadStreamEndian *textStream, TextCast *textCast);
 	void drawBackgndTransSprite(Graphics::ManagedSurface &target, const Graphics::Surface &sprite, Common::Rect &drawRect);
 	void drawMatteSprite(Graphics::ManagedSurface &target, const Graphics::Surface &sprite, Common::Rect &drawRect);
 	void drawGhostSprite(Graphics::ManagedSurface &target, const Graphics::Surface &sprite, Common::Rect &drawRect);


### PR DESCRIPTION
**NOTE: This has a conflict with #940, I have opened #941 which is #940 + #939 with the conflicts resolved.**
If you have no objections to either please just merge #941.
----------------------

While implementing preloading of script text I've done a minuscule bit of housekeeping on renderText (more to come later).

This should be almost exactly semantically equivalent, except that now the block with ``warning("Requested to draw on an empty surface:...)`` uses the ``width``, ``height`` values that are going to be used in the rest of the method body, which I suppose is actually desired.