### PR TITLE
GRAPHICS: Use MacFont in MacText in lieu of regular Graphics::Font

### DIFF
--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -847,7 +847,6 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	}
 
 	Graphics::MacFont *macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
-	// TODO: MacText must destroy me
 
 	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
 

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -846,11 +846,10 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		return;
 	}
 
-	Graphics::MacFont macFont = Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
+	Graphics::MacFont *macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
+	// TODO: MacText must destroy me
 
-	const Graphics::Font *font = _vm->_wm->_fontMan->getFont(macFont);
-
-	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(macFont));
+	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
 
 	int alignment = (int)textCast->textAlign;
 	if (alignment == -1)
@@ -866,7 +865,7 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		}
 	}
 
-	Graphics::MacText mt(ftext, _vm->_wm, font, 0x00, 0xff, width, (Graphics::TextAlign)alignment);
+	Graphics::MacText mt(ftext, _vm->_wm, macFont, 0x00, 0xff, width, (Graphics::TextAlign)alignment);
 	mt.setInterLinear(1);
 	mt.render();
 	const Graphics::ManagedSurface *textSurface = mt.getSurface();

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -37,6 +37,11 @@ const Font *MacFontRun::getFont() {
 	return font;
 }
 
+
+MacText::~MacText(){
+	delete _macFont;
+}
+
 MacText::MacText(Common::String s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment) {
 	_str = s;
 	_wm = wm;

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -37,10 +37,10 @@ const Font *MacFontRun::getFont() {
 	return font;
 }
 
-MacText::MacText(Common::String s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment) {
+MacText::MacText(Common::String s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment) {
 	_str = s;
 	_wm = wm;
-	_font = font;
+	_macFont = macFont;
 	_fgcolor = fgcolor;
 	_bgcolor = bgcolor;
 	_maxWidth = maxWidth;
@@ -51,7 +51,12 @@ MacText::MacText(Common::String s, MacWindowManager *wm, const Font *font, int f
 
 	_interLinear = 0; // 0 pixels between the lines by default
 
-	_defaultFormatting.font = font;
+	if (macFont) {
+		_defaultFormatting.font = wm->_fontMan->getFont(*macFont);
+	} else {
+		_defaultFormatting.font = NULL;
+	}
+
 	_defaultFormatting.wm = wm;
 
 	_currentFormatting = _defaultFormatting;

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -90,7 +90,7 @@ class MacText {
 public:
 	MacText(Common::String s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor,
 				int maxWidth = -1, TextAlign textAlignment = kTextAlignLeft);
-
+	~MacText();
 	void setInterLinear(int interLinear);
 
 	void draw(ManagedSurface *g, int x, int y, int w, int h, int xoff, int yoff);

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -88,7 +88,7 @@ struct MacTextLine {
 
 class MacText {
 public:
-	MacText(Common::String s, MacWindowManager *wm, const Graphics::Font *font, int fgcolor, int bgcolor,
+	MacText(Common::String s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor,
 				int maxWidth = -1, TextAlign textAlignment = kTextAlignLeft);
 
 	void setInterLinear(int interLinear);
@@ -113,7 +113,7 @@ private:
 	MacWindowManager *_wm;
 
 	Common::String _str;
-	const Graphics::Font *_font;
+	const MacFont *_macFont;
 	int _fgcolor, _bgcolor;
 
 	int _maxWidth;


### PR DESCRIPTION
**NOTE: This has a conflict with #939, I have opened #941 which is #940 + #939 with the conflicts resolved.**
--------------
If you have no objections to either please just merge #941.