### PR TITLE
DIRECTOR: Clean up renderText and use MacFont in MacText.

### DIFF
--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -752,11 +752,6 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	else
 		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
 
-	if (width == 0 || height == 0) {
-		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
-		return;
-	}
-
 	if (_vm->getVersion() >= 4) {
 		if (textSize == NULL)
 			width = textCast->initialRect.right;
@@ -771,7 +766,12 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		// textCast->fontId = _vm->_wm->_fontMan->getFontIdByName(_vm->getCurrentScore()->_fontMap[textCast->fontId]);
 	}
 
-	Graphics::MacFont* macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
+	if (width == 0 || height == 0) {
+		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
+		return;
+	}
+
+	Graphics::MacFont *macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
 
 	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
 

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -847,7 +847,6 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	}
 
 	Graphics::MacFont *macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
-	// TODO: MacText must destroy me
 
 	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
 

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -742,6 +742,38 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		return;
 
 	TextCast *textCast = _sprites[spriteId]->_buttonCast != nullptr ? (TextCast*)_sprites[spriteId]->_buttonCast : _sprites[spriteId]->_textCast;
+	int x = _sprites[spriteId]->_startPoint.x; // +rectLeft;
+	int y = _sprites[spriteId]->_startPoint.y; // +rectTop;
+	int height = textCast->initialRect.height(); //_sprites[spriteId]->_height;
+	int width;
+
+	if (_vm->getVersion() >= 4 && textSize != NULL)
+		width = textCast->initialRect.right;
+	else
+		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
+
+	if (width == 0 || height == 0) {
+		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
+		return;
+	}
+
+	if (_vm->getVersion() >= 4) {
+		if (textSize == NULL)
+			width = textCast->initialRect.right;
+		else {
+			width = textSize->width();
+		}
+	}
+
+	if (_vm->getCurrentScore()->_fontMap.contains(textCast->fontId)) {
+		// We need to make sure that the Shared Cast fonts have been loaded in?
+		// might need a mapping table here of our own.
+		// textCast->fontId = _vm->_wm->_fontMan->getFontIdByName(_vm->getCurrentScore()->_fontMap[textCast->fontId]);
+	}
+
+	Graphics::MacFont* macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
+
+	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
 
 	uint32 unk1 = textStream->readUint32();
 	uint32 strLen = textStream->readUint32();
@@ -827,42 +859,12 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	//uint32 rectLeft = textCast->initialRect.left;
 	//uint32 rectTop = textCast->initialRect.top;
 
-	int x = _sprites[spriteId]->_startPoint.x; // +rectLeft;
-	int y = _sprites[spriteId]->_startPoint.y; // +rectTop;
-	int height = textCast->initialRect.height(); //_sprites[spriteId]->_height;
-	int width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
-
-	if (_vm->getVersion() >= 4 && textSize != NULL)
-		width = textCast->initialRect.right;
-
-	if (_vm->getCurrentScore()->_fontMap.contains(textCast->fontId)) {
-		// We need to make sure that the Shared Cast fonts have been loaded in?
-		// might need a mapping table here of our own.
-		// textCast->fontId = _vm->_wm->_fontMan->getFontIdByName(_vm->getCurrentScore()->_fontMap[textCast->fontId]);
-	}
-
-	if (width == 0 || height == 0) {
-		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
-		return;
-	}
-
-	Graphics::MacFont *macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
-
-	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
 
 	int alignment = (int)textCast->textAlign;
 	if (alignment == -1)
 		alignment = 3;
 	else
 		alignment++;
-
-	if (_vm->getVersion() >= 4) {
-		if (textSize == NULL)
-			width = textCast->initialRect.right;
-		else {
-			width = textSize->width();
-		}
-	}
 
 	Graphics::MacText mt(ftext, _vm->_wm, macFont, 0x00, 0xff, width, (Graphics::TextAlign)alignment);
 	mt.setInterLinear(1);

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -846,11 +846,10 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		return;
 	}
 
-	Graphics::MacFont macFont = Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
+	Graphics::MacFont *macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
+	// TODO: MacText must destroy me
 
-	const Graphics::Font *font = _vm->_wm->_fontMan->getFont(macFont);
-
-	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(macFont));
+	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
 
 	int alignment = (int)textCast->textAlign;
 	if (alignment == -1)
@@ -866,7 +865,7 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		}
 	}
 
-	Graphics::MacText mt(ftext, _vm->_wm, font, 0x00, 0xff, width, (Graphics::TextAlign)alignment);
+	Graphics::MacText mt(ftext, _vm->_wm, macFont, 0x00, 0xff, width, (Graphics::TextAlign)alignment);
 	mt.setInterLinear(1);
 	mt.render();
 	const Graphics::ManagedSurface *textSurface = mt.getSurface();

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -747,17 +747,14 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	int height = textCast->initialRect.height(); //_sprites[spriteId]->_height;
 	int width;
 
-	if (_vm->getVersion() >= 4 && textSize != NULL)
-		width = textCast->initialRect.right;
-	else
-		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
-
 	if (_vm->getVersion() >= 4) {
 		if (textSize == NULL)
 			width = textCast->initialRect.right;
 		else {
 			width = textSize->width();
 		}
+	} else {
+		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
 	}
 
 	if (_vm->getCurrentScore()->_fontMap.contains(textCast->fontId)) {

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -737,41 +737,10 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, uint1
 	renderText(surface, spriteId, textStream, NULL);
 }
 
-void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Common::SeekableSubReadStreamEndian *textStream, Common::Rect *textSize) {
-	if (textStream == NULL)
-		return;
-
-	TextCast *textCast = _sprites[spriteId]->_buttonCast != nullptr ? (TextCast*)_sprites[spriteId]->_buttonCast : _sprites[spriteId]->_textCast;
-	int x = _sprites[spriteId]->_startPoint.x; // +rectLeft;
-	int y = _sprites[spriteId]->_startPoint.y; // +rectTop;
-	int height = textCast->initialRect.height(); //_sprites[spriteId]->_height;
-	int width;
-
-	if (_vm->getVersion() >= 4) {
-		if (textSize == NULL)
-			width = textCast->initialRect.right;
-		else {
-			width = textSize->width();
-		}
-	} else {
-		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
-	}
-
-	if (_vm->getCurrentScore()->_fontMap.contains(textCast->fontId)) {
-		// We need to make sure that the Shared Cast fonts have been loaded in?
-		// might need a mapping table here of our own.
-		// textCast->fontId = _vm->_wm->_fontMan->getFontIdByName(_vm->getCurrentScore()->_fontMap[textCast->fontId]);
-	}
-
-	if (width == 0 || height == 0) {
-		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
-		return;
-	}
-
-	Graphics::MacFont *macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
-
-	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
-
+Common::String Frame::readTextStream(Common::SeekableSubReadStreamEndian *textStream, TextCast *textCast) {
+	// TODO: move me somewhere more appropriate
+	// TODO: remove ugly side effects on textStream?
+	Common::String ftext;
 	uint32 unk1 = textStream->readUint32();
 	uint32 strLen = textStream->readUint32();
 	uint32 dataLen = textStream->readUint32();
@@ -784,8 +753,6 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		}
 		text += ch;
 	}
-
-	Common::String ftext;
 
 	debugC(3, kDebugText, "renderText: unk1: %d strLen: %d dataLen: %d textlen: %u", unk1, strLen, dataLen, text.size());
 	if (strLen < 200)
@@ -832,12 +799,12 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 		debugCN(4, kDebugText, "*");
 
 		ftext += Common::String::format("\001\015%c%c%c%c%c%c%c%c%c%c%c%c",
-						(textCast->fontId >> 8) & 0xff, textCast->fontId & 0xff,
-						textCast->textSlant & 0xff, unk3f & 0xff,
-						(textCast->fontSize >> 8) & 0xff, textCast->fontSize & 0xff,
-						(textCast->palinfo1 >> 8) & 0xff, textCast->palinfo1 & 0xff,
-						(textCast->palinfo2 >> 8) & 0xff, textCast->palinfo2 & 0xff,
-						(textCast->palinfo3 >> 8) & 0xff, textCast->palinfo3 & 0xff);
+										(textCast->fontId >> 8) & 0xff, textCast->fontId & 0xff,
+										textCast->textSlant & 0xff, unk3f & 0xff,
+										(textCast->fontSize >> 8) & 0xff, textCast->fontSize & 0xff,
+										(textCast->palinfo1 >> 8) & 0xff, textCast->palinfo1 & 0xff,
+										(textCast->palinfo2 >> 8) & 0xff, textCast->palinfo2 & 0xff,
+										(textCast->palinfo3 >> 8) & 0xff, textCast->palinfo3 & 0xff);
 
 		formattingCount--;
 	}
@@ -845,6 +812,46 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	ftext += text;
 
 	debugC(4, kDebugText, "%s", text.c_str());
+
+	return ftext;
+}
+
+void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Common::SeekableSubReadStreamEndian *textStream, Common::Rect *textSize) {
+	if (textStream == NULL)
+		return;
+
+	TextCast *textCast = _sprites[spriteId]->_buttonCast != nullptr ? (TextCast*)_sprites[spriteId]->_buttonCast : _sprites[spriteId]->_textCast;
+	int x = _sprites[spriteId]->_startPoint.x; // +rectLeft;
+	int y = _sprites[spriteId]->_startPoint.y; // +rectTop;
+	int height = textCast->initialRect.height(); //_sprites[spriteId]->_height;
+	int width;
+
+	if (_vm->getVersion() >= 4) {
+		if (textSize == NULL)
+			width = textCast->initialRect.right;
+		else {
+			width = textSize->width();
+		}
+	} else {
+		width = textCast->initialRect.width(); //_sprites[spriteId]->_width;
+	}
+
+	if (_vm->getCurrentScore()->_fontMap.contains(textCast->fontId)) {
+		// We need to make sure that the Shared Cast fonts have been loaded in?
+		// might need a mapping table here of our own.
+		// textCast->fontId = _vm->_wm->_fontMan->getFontIdByName(_vm->getCurrentScore()->_fontMap[textCast->fontId]);
+	}
+
+	if (width == 0 || height == 0) {
+		warning("renderText: Requested to draw on an empty surface: %d x %d", width, height);
+		return;
+	}
+
+	Graphics::MacFont *macFont = new Graphics::MacFont(textCast->fontId, textCast->fontSize, textCast->textSlant);
+
+	debugC(3, kDebugText, "renderText: x: %d y: %d w: %d h: %d font: '%s'", x, y, width, height, _vm->_wm->_fontMan->getFontName(*macFont));
+
+	Common::String ftext = readTextStream(textStream, textCast);
 
 	uint16 boxShadow = (uint16)textCast->boxShadow;
 	uint16 borderSize = (uint16)textCast->borderSize;

--- a/engines/director/frame.h
+++ b/engines/director/frame.h
@@ -135,6 +135,7 @@ private:
 	void readSprite(Common::SeekableSubReadStreamEndian &stream, uint16 offset, uint16 size);
 	void readMainChannels(Common::SeekableSubReadStreamEndian &stream, uint16 offset, uint16 size);
 	Image::ImageDecoder *getImageFrom(uint16 spriteId);
+	Common::String readTextStream(Common::SeekableSubReadStreamEndian *textStream, TextCast *textCast);
 	void drawBackgndTransSprite(Graphics::ManagedSurface &target, const Graphics::Surface &sprite, Common::Rect &drawRect);
 	void drawMatteSprite(Graphics::ManagedSurface &target, const Graphics::Surface &sprite, Common::Rect &drawRect);
 	void drawGhostSprite(Graphics::ManagedSurface &target, const Graphics::Surface &sprite, Common::Rect &drawRect);

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -37,6 +37,11 @@ const Font *MacFontRun::getFont() {
 	return font;
 }
 
+
+MacText::~MacText(){
+	delete _macFont;
+}
+
 MacText::MacText(Common::String s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment) {
 	_str = s;
 	_wm = wm;

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -37,10 +37,10 @@ const Font *MacFontRun::getFont() {
 	return font;
 }
 
-MacText::MacText(Common::String s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment) {
+MacText::MacText(Common::String s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment) {
 	_str = s;
 	_wm = wm;
-	_font = font;
+	_macFont = macFont;
 	_fgcolor = fgcolor;
 	_bgcolor = bgcolor;
 	_maxWidth = maxWidth;
@@ -51,7 +51,12 @@ MacText::MacText(Common::String s, MacWindowManager *wm, const Font *font, int f
 
 	_interLinear = 0; // 0 pixels between the lines by default
 
-	_defaultFormatting.font = font;
+	if (macFont) {
+		_defaultFormatting.font = wm->_fontMan->getFont(*macFont);
+	} else {
+		_defaultFormatting.font = NULL;
+	}
+
 	_defaultFormatting.wm = wm;
 
 	_currentFormatting = _defaultFormatting;

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -90,7 +90,7 @@ class MacText {
 public:
 	MacText(Common::String s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor,
 				int maxWidth = -1, TextAlign textAlignment = kTextAlignLeft);
-
+	~MacText();
 	void setInterLinear(int interLinear);
 
 	void draw(ManagedSurface *g, int x, int y, int w, int h, int xoff, int yoff);

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -88,7 +88,7 @@ struct MacTextLine {
 
 class MacText {
 public:
-	MacText(Common::String s, MacWindowManager *wm, const Graphics::Font *font, int fgcolor, int bgcolor,
+	MacText(Common::String s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor,
 				int maxWidth = -1, TextAlign textAlignment = kTextAlignLeft);
 
 	void setInterLinear(int interLinear);
@@ -113,7 +113,7 @@ private:
 	MacWindowManager *_wm;
 
 	Common::String _str;
-	const Graphics::Font *_font;
+	const MacFont *_macFont;
 	int _fgcolor, _bgcolor;
 
 	int _maxWidth;


### PR DESCRIPTION
This is #940 + #939 in one handy package, merge conflict-free.
If you have no objections to either please merge this one, since each one conflicts with the other.