### PR TITLE
DIRECTOR: Preload Stxts in Score

### DIFF
--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -786,9 +786,7 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, const
 	else
 		alignment++;
 
-	Graphics::MacText mt(stxt->_ftext, _vm->_wm, macFont, 0x00, 0xff, width, (Graphics::TextAlign)alignment);
-
-	mt.setInterLinear(1);
+	Graphics::MacText mt(stxt->_ftext, _vm->_wm, macFont, 0x00, 0xff, width, (Graphics::TextAlign)alignment, 1);
 	mt.render();
 	const Graphics::ManagedSurface *textSurface = mt.getSurface();
 

--- a/engines/director/frame.h
+++ b/engines/director/frame.h
@@ -24,6 +24,7 @@
 #define DIRECTOR_FRAME_H
 
 #include "graphics/managed_surface.h"
+#include "engines/director/stxt.h"
 
 namespace Image {
 	class ImageDecoder;
@@ -127,8 +128,7 @@ private:
 	void playTransition(Score *score);
 	void playSoundChannel();
 	void renderSprites(Graphics::ManagedSurface &surface, bool renderTrail);
-	void renderText(Graphics::ManagedSurface &surface, uint16 spriteId, uint16 castId);
-	void renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Common::SeekableSubReadStreamEndian *textStream, Common::Rect *textSize);
+	void renderText(Graphics::ManagedSurface &surface, uint16 spriteId, const Stxt *stxt, Common::Rect *textSize);
 	void renderShape(Graphics::ManagedSurface &surface, uint16 spriteId);
 	void renderButton(Graphics::ManagedSurface &surface, uint16 spriteId, uint16 textId);
 	void readPaletteInfo(Common::SeekableSubReadStreamEndian &stream);

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -14,6 +14,7 @@ MODULE_OBJS = \
 	score.o \
 	sound.o \
 	sprite.o \
+	stxt.o \
 	util.o \
 	lingo/lingo-gr.o \
 	lingo/lingo.o \

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -92,6 +92,7 @@ Score::Score(DirectorEngine *vm) {
 	_loadedButtons = new Common::HashMap<int, ButtonCast *>();
 	_loadedShapes = new Common::HashMap<int, ShapeCast *>();
 	_loadedScripts = new Common::HashMap<int, ScriptCast *>();
+	_loadedStxts = new Common::HashMap<int, const Stxt *>();
 }
 
 void Score::setArchive(Archive *archive) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -190,6 +190,13 @@ void Score::loadArchive() {
 
 			for (Common::Array<uint16>::iterator iterator = stxt.begin(); iterator != stxt.end(); ++iterator) {
 				loadScriptText(*_movieArchive->getResource(MKTAG('S','T','X','T'), *iterator));
+				// Load STXTS
+
+				// TODO: make sure the Stxt is eventually destroyed
+				_loadedStxts->setVal(*iterator,
+									 new Stxt(*_movieArchive->getResource(MKTAG('S','T','X','T'),
+																		  *iterator))
+									 );
 			}
 		}
 	}

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -192,7 +192,6 @@ void Score::loadArchive() {
 				loadScriptText(*_movieArchive->getResource(MKTAG('S','T','X','T'), *iterator));
 				// Load STXTS
 
-				// TODO: make sure the Stxt is eventually destroyed
 				_loadedStxts->setVal(*iterator,
 									 new Stxt(*_movieArchive->getResource(MKTAG('S','T','X','T'),
 																		  *iterator))
@@ -284,6 +283,7 @@ Score::~Score() {
 
 	delete _font;
 	delete _labels;
+	delete _loadedStxts;
 }
 
 void Score::loadPalette(Common::SeekableSubReadStreamEndian &stream) {

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -28,6 +28,7 @@
 #include "director/archive.h"
 #include "director/cast.h"
 #include "director/images.h"
+#include "engines/director/stxt.h"
 
 namespace Graphics {
 	class ManagedSurface;
@@ -133,6 +134,7 @@ public:
 	Common::HashMap<int, BitmapCast *> *_loadedBitmaps;
 	Common::HashMap<int, ShapeCast *> *_loadedShapes;
 	Common::HashMap<int, ScriptCast *> *_loadedScripts;
+	Common::HashMap<int, const Stxt *> *_loadedStxts;
 
 private:
 	uint16 _versionMinor;

--- a/engines/director/stxt.cpp
+++ b/engines/director/stxt.cpp
@@ -1,0 +1,99 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "engines/director/stxt.h"
+
+namespace Director {
+
+Stxt::Stxt (Common::SeekableSubReadStreamEndian &textStream) {
+	// TODO: Side effects on textStream make this a little hard to understand in context?
+	uint32 unk1 = textStream.readUint32();
+	uint32 strLen = textStream.readUint32();
+	uint32 dataLen = textStream.readUint32();
+	Common::String text;
+
+	for (uint32 i = 0; i < strLen; i++) {
+		byte ch = textStream.readByte();
+		if (ch == 0x0d) {
+			ch = '\n';
+		}
+		text += ch;
+	}
+	debugC(3, kDebugText, "Stxt init: unk1: %d strLen: %d dataLen: %d textlen: %u", unk1, strLen, dataLen, text.size());
+	if (strLen < 200)
+		debugC(3, kDebugText, "text: '%s'", text.c_str());
+
+	uint16 formattingCount = textStream.readUint16();
+	uint32 prevPos = 0;
+
+	while (formattingCount) {
+		uint32 formatStartOffset = textStream.readUint32();
+		uint16 unk1f = textStream.readUint16();
+		uint16 unk2f = textStream.readUint16();
+
+		_fontId = textStream.readUint16();
+		_textSlant = textStream.readByte();
+		byte unk3f = textStream.readByte();
+		_fontSize = textStream.readUint16();
+
+		_palinfo1 = textStream.readUint16();
+		_palinfo2 = textStream.readUint16();
+		_palinfo3 = textStream.readUint16();
+
+		debugC(3, kDebugText, "Stxt init: formattingCount: %u, formatStartOffset: %d, unk1: %d unk2: %d, fontId: %d, textSlant: %d",
+			   formattingCount, formatStartOffset, unk1f, unk2f, _fontId, _textSlant);
+
+		debugC(3, kDebugText, "        unk3: %d, fontSize: %d, p0: %x p1: %x p2: %x", unk3f, _fontSize, _palinfo1, _palinfo2, _palinfo3);
+
+		assert(prevPos <= formatStartOffset);  // If this is triggered, we have to implement sorting
+
+		while (prevPos != formatStartOffset) {
+			char f = text.firstChar();
+			_ftext += text.firstChar();
+			text.deleteChar(0);
+
+			if (f == '\001')    // Insert two \001s as a replacement
+				_ftext += '\001';
+
+			prevPos++;
+
+			debugCN(4, kDebugText, "%c", f);
+		}
+
+		debugCN(4, kDebugText, "*");
+
+		_ftext += Common::String::format("\001\015%c%c%c%c%c%c%c%c%c%c%c%c",
+										 (_fontId >> 8) & 0xff, _fontId & 0xff,
+										 _textSlant & 0xff, unk3f & 0xff,
+										 (_fontSize >> 8) & 0xff, _fontSize & 0xff,
+										 (_palinfo1 >> 8) & 0xff, _palinfo1 & 0xff,
+										 (_palinfo2 >> 8) & 0xff, _palinfo2 & 0xff,
+										 (_palinfo3 >> 8) & 0xff, _palinfo3 & 0xff);
+
+		formattingCount--;
+	}
+
+	debugC(4, kDebugText, "%s", text.c_str());
+	_ftext += text;
+}
+
+} // End of namespace Director

--- a/engines/director/stxt.h
+++ b/engines/director/stxt.h
@@ -29,76 +29,7 @@ namespace Director {
 
 class Stxt {
 public:
-	Stxt (Common::SeekableSubReadStreamEndian &textStream) {
-		uint32 unk1 = textStream.readUint32();
-		uint32 strLen = textStream.readUint32();
-		uint32 dataLen = textStream.readUint32();
-		Common::String text;
-
-		for (uint32 i = 0; i < strLen; i++) {
-			byte ch = textStream.readByte();
-			if (ch == 0x0d) {
-				ch = '\n';
-			}
-			text += ch;
-		}
-		debugC(3, kDebugText, "Stxt init: unk1: %d strLen: %d dataLen: %d textlen: %u", unk1, strLen, dataLen, text.size());
-		if (strLen < 200)
-			debugC(3, kDebugText, "text: '%s'", text.c_str());
-
-		uint16 formattingCount = textStream.readUint16();
-		uint32 prevPos = 0;
-
-		while (formattingCount) {
-			uint32 formatStartOffset = textStream.readUint32();
-			uint16 unk1f = textStream.readUint16();
-			uint16 unk2f = textStream.readUint16();
-
-			_fontId = textStream.readUint16();
-			_textSlant = textStream.readByte();
-			byte unk3f = textStream.readByte();
-			_fontSize = textStream.readUint16();
-
-			_palinfo1 = textStream.readUint16();
-			_palinfo2 = textStream.readUint16();
-			_palinfo3 = textStream.readUint16();
-
-			debugC(3, kDebugText, "Stxt init: formattingCount: %u, formatStartOffset: %d, unk1: %d unk2: %d, fontId: %d, textSlant: %d",
-			       formattingCount, formatStartOffset, unk1f, unk2f, _fontId, _textSlant);
-
-			debugC(3, kDebugText, "        unk3: %d, fontSize: %d, p0: %x p1: %x p2: %x", unk3f, _fontSize, _palinfo1, _palinfo2, _palinfo3);
-
-			assert(prevPos <= formatStartOffset);  // If this is triggered, we have to implement sorting
-
-			while (prevPos != formatStartOffset) {
-				char f = text.firstChar();
-				_ftext += text.firstChar();
-				text.deleteChar(0);
-
-				if (f == '\001')    // Insert two \001s as a replacement
-					_ftext += '\001';
-
-				prevPos++;
-
-				debugCN(4, kDebugText, "%c", f);
-			}
-
-			debugCN(4, kDebugText, "*");
-
-			_ftext += Common::String::format("\001\015%c%c%c%c%c%c%c%c%c%c%c%c",
-			                                      (_fontId >> 8) & 0xff, _fontId & 0xff,
-			                                      _textSlant & 0xff, unk3f & 0xff,
-			                                      (_fontSize >> 8) & 0xff, _fontSize & 0xff,
-			                                      (_palinfo1 >> 8) & 0xff, _palinfo1 & 0xff,
-			                                      (_palinfo2 >> 8) & 0xff, _palinfo2 & 0xff,
-			                                      (_palinfo3 >> 8) & 0xff, _palinfo3 & 0xff);
-
-			formattingCount--;
-		}
-
-		debugC(4, kDebugText, "%s", text.c_str());
-		_ftext += text;
-	}
+	Stxt (Common::SeekableSubReadStreamEndian &textStream);
 public:
 	Common::String _ftext;
 	uint32 _fontId;

--- a/engines/director/stxt.h
+++ b/engines/director/stxt.h
@@ -1,0 +1,118 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef DIRECTOR_STXT_H
+#define DIRECTOR_STXT_H
+
+#include "engines/director/director.h"
+
+namespace Director {
+
+class Stxt {
+public:
+	Stxt (Common::SeekableSubReadStreamEndian &textStream) {
+		uint32 unk1 = textStream.readUint32();
+		uint32 strLen = textStream.readUint32();
+		uint32 dataLen = textStream.readUint32();
+		Common::String text;
+
+		for (uint32 i = 0; i < strLen; i++) {
+			byte ch = textStream.readByte();
+			if (ch == 0x0d) {
+				ch = '\n';
+			}
+			text += ch;
+		}
+		debugC(3, kDebugText, "Stxt init: unk1: %d strLen: %d dataLen: %d textlen: %u", unk1, strLen, dataLen, text.size());
+		if (strLen < 200)
+			debugC(3, kDebugText, "text: '%s'", text.c_str());
+
+		uint16 formattingCount = textStream.readUint16();
+		uint32 prevPos = 0;
+
+		while (formattingCount) {
+			uint32 formatStartOffset = textStream.readUint32();
+			uint16 unk1f = textStream.readUint16();
+			uint16 unk2f = textStream.readUint16();
+
+			_fontId = textStream.readUint16();
+			_textSlant = textStream.readByte();
+			byte unk3f = textStream.readByte();
+			_fontSize = textStream.readUint16();
+
+			_palinfo1 = textStream.readUint16();
+			_palinfo2 = textStream.readUint16();
+			_palinfo3 = textStream.readUint16();
+
+			debugC(3, kDebugText, "Stxt init: formattingCount: %u, formatStartOffset: %d, unk1: %d unk2: %d, fontId: %d, textSlant: %d",
+			       formattingCount, formatStartOffset, unk1f, unk2f, _fontId, _textSlant);
+
+			debugC(3, kDebugText, "        unk3: %d, fontSize: %d, p0: %x p1: %x p2: %x", unk3f, _fontSize, _palinfo1, _palinfo2, _palinfo3);
+
+			assert(prevPos <= formatStartOffset);  // If this is triggered, we have to implement sorting
+
+			while (prevPos != formatStartOffset) {
+				char f = text.firstChar();
+				_ftext += text.firstChar();
+				text.deleteChar(0);
+
+				if (f == '\001')    // Insert two \001s as a replacement
+					_ftext += '\001';
+
+				prevPos++;
+
+				debugCN(4, kDebugText, "%c", f);
+			}
+
+			debugCN(4, kDebugText, "*");
+
+			_ftext += Common::String::format("\001\015%c%c%c%c%c%c%c%c%c%c%c%c",
+			                                      (_fontId >> 8) & 0xff, _fontId & 0xff,
+			                                      _textSlant & 0xff, unk3f & 0xff,
+			                                      (_fontSize >> 8) & 0xff, _fontSize & 0xff,
+			                                      (_palinfo1 >> 8) & 0xff, _palinfo1 & 0xff,
+			                                      (_palinfo2 >> 8) & 0xff, _palinfo2 & 0xff,
+			                                      (_palinfo3 >> 8) & 0xff, _palinfo3 & 0xff);
+
+			formattingCount--;
+		}
+
+		debugC(4, kDebugText, "%s", text.c_str());
+		_ftext += text;
+	}
+public:
+	Common::String _ftext;
+	uint32 _fontId;
+	uint16 _fontSize;
+	TextType _textType;
+	TextAlignType _textAlign;
+	SizeType _textShadow;
+	byte _textSlant;
+	uint16 _palinfo1, _palinfo2, _palinfo3;
+	uint16 _unk1f;
+	uint16 _unk2f;
+	byte _unk3f;
+};
+
+} // End of namespace Director
+
+#endif

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -42,7 +42,7 @@ MacText::~MacText(){
 	delete _macFont;
 }
 
-MacText::MacText(Common::String s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment) {
+MacText::MacText(Common::String s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear) {
 	_str = s;
 	_wm = wm;
 	_macFont = macFont;
@@ -53,8 +53,7 @@ MacText::MacText(Common::String s, MacWindowManager *wm, const MacFont *macFont,
 	_textMaxHeight = 0;
 	_surface = nullptr;
 	_textAlignment = textAlignment;
-
-	_interLinear = 0; // 0 pixels between the lines by default
+	_interLinear = interlinear;
 
 	if (macFont) {
 		_defaultFormatting.font = wm->_fontMan->getFont(*macFont);

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -89,7 +89,8 @@ struct MacTextLine {
 class MacText {
 public:
 	MacText(Common::String s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor,
-				int maxWidth = -1, TextAlign textAlignment = kTextAlignLeft);
+			int maxWidth = -1, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0);
+			// 0 pixels between the lines by default
 	~MacText();
 	void setInterLinear(int interLinear);
 


### PR DESCRIPTION
I've opened #943, which I branched off this. In case you like also how the preloading in textCast is done, please just merge that one. Thanks.
-----------------
This preloads Stxts in Score and leaves them there.
If you like where this is going so far, you'll soon get also cached MacTexts.