### PR TITLE
GUI: remove addDirtyRect() that kept clearing objects above a list

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -298,10 +298,6 @@ void ThemeItemDrawDataClip::drawSelf(bool draw, bool restore) {
 			_engine->renderer()->drawStepClip(_area, _clip, *step, _dynamicData);
 		}
 	}
-
-	extendedRect.clip(_clip);
-
-	_engine->addDirtyRect(extendedRect);
 }
 
 void ThemeItemTextData::drawSelf(bool draw, bool restore) {


### PR DESCRIPTION
The partial invalidation of the screen cut off objects that were located
above a list, like the build time / git hash on the main screen. Removing
addDirtyRect() fixed the bug and I didn't find any case where artifacts
were left behind.

BUG: #6394 (GUI: "List View" save page draws over font)