### PR TITLE
GRAPHICS: Include bytesPerPixel in toString representation

### DIFF
--- a/graphics/pixelformat.cpp
+++ b/graphics/pixelformat.cpp
@@ -58,7 +58,7 @@ Common::String PixelFormat::toString() const {
 		digits += '0' + 8 - componentLoss;
 	}
 
-	return letters + digits;
+	return letters + digits + '@' + ('0' + bytesPerPixel);
 }
 
 } // End of namespace Graphics


### PR DESCRIPTION
Greetings from ResidualVM.

While debugging color issues, I felt the need to have the total byte count in addition to format: `RGB888` can mean 3 or 4 bytes.

My initial idea would be to get to something like: `RGB-8888` for the 4-bytes variant, but typically PixelFormats I have seen then lack the alpha shift as it does not matter for conversions and [un]packing, so I gave up when this code became significantly longer than it currently is. And I believe seeing the actual byte size value is enough to tell the debugging developer that there is more to this packing format than meets the eye.

So I settled for `RGB888@3` and `RGB888@4` for given examples, as the change becomes trivial.

I could not spot callers which would expect a certain format, so I believe it *should* be safe to change this output. This said, this method has many homonyms.