### PR TITLE
ENGINES: Allow detection entries to match on full paths

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -345,7 +345,7 @@ void AdvancedMetaEngine::reportUnknown(const Common::FSNode &path, const ADFileP
 	g_system->logMessage(LogMessageType::kInfo, report.c_str());
 }
 
-void AdvancedMetaEngine::composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth) const {
+void AdvancedMetaEngine::composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::String &parentName) const {
 	if (depth <= 0)
 		return;
 
@@ -353,6 +353,8 @@ void AdvancedMetaEngine::composeFileHashMap(FileMap &allFiles, const Common::FSL
 		return;
 
 	for (Common::FSList::const_iterator file = fslist.begin(); file != fslist.end(); ++file) {
+		Common::String tstr = (_matchFullPaths && !parentName.empty() ? parentName + "/" : "") + file->getName();
+
 		if (file->isDirectory()) {
 			Common::FSList files;
 
@@ -372,10 +374,8 @@ void AdvancedMetaEngine::composeFileHashMap(FileMap &allFiles, const Common::FSL
 			if (!file->getChildren(files, Common::FSNode::kListAll))
 				continue;
 
-			composeFileHashMap(allFiles, files, depth - 1);
+			composeFileHashMap(allFiles, files, depth - 1, tstr);
 		}
-
-		Common::String tstr = file->getName();
 
 		// Strip any trailing dot
 		if (tstr.lastChar() == '.')
@@ -625,6 +625,7 @@ AdvancedMetaEngine::AdvancedMetaEngine(const void *descs, uint descItemSize, con
 	_guiOptions = GUIO_NONE;
 	_maxScanDepth = 1;
 	_directoryGlobs = NULL;
+	_matchFullPaths = false;
 }
 
 void AdvancedMetaEngine::initSubSystems(const ADGameDescription *gameDesc) const {

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -251,6 +251,17 @@ protected:
 	 */
 	const char * const *_directoryGlobs;
 
+	/**
+	 * If true, filenames will be matched against the entire path, relative to
+	 * the root detection directory (e.g. "foo/bar.000" for a file at
+	 * "<root>/foo/bar.000"). Otherwise, filenames only match the basename
+	 * (e.g. "bar.000" for the same file).
+	 *
+	 * @note _maxScanDepth and _directoryGlobs must still be configured to allow
+	 * the detector to find files inside subdirectories.
+	 */
+	bool _matchFullPaths;
+
 public:
 	AdvancedMetaEngine(const void *descs, uint descItemSize, const PlainGameDescriptor *gameIds, const ADExtraGuiOptionsMap *extraGuiOptions = 0);
 
@@ -326,7 +337,7 @@ protected:
 	 * Compose a hashmap of all files in fslist.
 	 * Includes nifty stuff like removing trailing dots and ignoring case.
 	 */
-	void composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth) const;
+	void composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::String &parentName = Common::String()) const;
 
 	/** Get the properties (size and MD5) of this file. */
 	bool getFileProperties(const Common::FSNode &parent, const FileMap &allFiles, const ADGameDescription &game, const Common::String fname, ADFileProperties &fileProps) const;


### PR DESCRIPTION
This allows an engine to match files that exist multiple times
in the same game directory with the same basename.

For example, different releases of Torin's Passage in SCI engine
come with zero or more GERMAN, FRENCH, ENGLISH, etc. directories,
all containing files with the same basenames but with different
contents per language. Because the allFiles map used only the
basename of a file as a key, it could not match more than one of
these localization directories, which made it impossible to select
from all the possible languages.

See https://github.com/csnover/scummvm/commit/425dd7ed19a32611b3cba1b0f812aac496602b61 for an example implementation.

This all came about because there are multiple releases of Torin with different available localizations but with the same main resource bundles, so I could not figure out any other way to differentiate these releases without making the detector capable of matching paths instead of just basenames:

* The GOG.com release has the same multi-language EN/FR/DE resource bundles as the multi-language English audio CD release, but it does not include any of the translated message directories for some reason, so without subdirectory matching (to exclude the non-existing localizations), people adding the GOG release would end up getting options to choose languages that do not exist in this release
* Based on the detection entries that were already in the detection table, the Spanish and Italian releases also use the same EN/FR/DE resource bundles and English audio as the English multilanguage release, and just include some new message resources with the ES/IT translations. Without subdirectory matching, the same problem occurs here where people with both the GOG release *and* the EN/FR/DE release will get options for ES/IT translations which do not exist

Refs Trac#9772.