### PR TITLE
SCI: Add 'music/' subdir to file path for LSL7 GOG

### DIFF
--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -151,6 +151,7 @@ SciEngine::SciEngine(OSystem *syst, const ADGameDescription *desc, SciGameId gam
 	SearchMan.addSubDirectoryMatching(gameDataDir, "robots");	// robot movie files
 	SearchMan.addSubDirectoryMatching(gameDataDir, "movie");	// VMD movie files
 	SearchMan.addSubDirectoryMatching(gameDataDir, "movies");	// VMD movie files
+	SearchMan.addSubDirectoryMatching(gameDataDir, "music");	// LSL7 music files (GOG version)
 	SearchMan.addSubDirectoryMatching(gameDataDir, "music/22s16");	// LSL7 music files
 	SearchMan.addSubDirectoryMatching(gameDataDir, "vmd");	// VMD movie files
 	SearchMan.addSubDirectoryMatching(gameDataDir, "duk");	// Duck movie files in Phantasmagoria 2


### PR DESCRIPTION
LSL7 originally came with music in two qualities in subdirectories of
the 'music' directory. 22s8 and 22s16. The gog.com release doesn't do
this and only ships the hq music in the root of 'music/'. This PR adds
it to the search path.