### PR TITLE
GUI: Fully hide GMM save/load buttons if not supported by engine

### DIFF
--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -85,11 +85,11 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 	new GUI::ButtonWidget(this, "GlobalMenu.Resume", _("~R~esume"), 0, kPlayCmd, 'P');
 
 	_loadButton = new GUI::ButtonWidget(this, "GlobalMenu.Load", _("~L~oad"), 0, kLoadCmd);
-	// TODO: setEnabled -> setVisible
+	_loadButton->setVisible(_engine->hasFeature(Engine::kSupportsLoadingDuringRuntime));
 	_loadButton->setEnabled(_engine->hasFeature(Engine::kSupportsLoadingDuringRuntime));
 
 	_saveButton = new GUI::ButtonWidget(this, "GlobalMenu.Save", _("~S~ave"), 0, kSaveCmd);
-	// TODO: setEnabled -> setVisible
+	_saveButton->setVisible(_engine->hasFeature(Engine::kSupportsSavingDuringRuntime));
 	_saveButton->setEnabled(_engine->hasFeature(Engine::kSupportsSavingDuringRuntime));
 
 	new GUI::ButtonWidget(this, "GlobalMenu.Options", _("~O~ptions"), 0, kOptionsCmd);


### PR DESCRIPTION
Previously, they were only greyed out. According to the discussion on
patch #8925, this was a limitation of the GUI layout engine when these
buttons were introduced in 2008. This no longer seems to be a problem.

Are there are any potential issues with changing this that I haven't considered? I don't remember the exact situation from 9 years ago.