### PR TITLE
SCI: Fix kArrayFill

### DIFF
--- a/engines/sci/engine/segment.h
+++ b/engines/sci/engine/segment.h
@@ -738,17 +738,17 @@ public:
 		switch (_type) {
 		case kArrayTypeInt16:
 		case kArrayTypeID: {
-			reg_t *target = (reg_t *)_data + index;
-			while (count--) {
+			for (uint16 i = 0; i < count; ++i) {
+				reg_t *target = (reg_t *)_data + index + i;
 				*target = value;
 			}
 			break;
 		}
 		case kArrayTypeByte:
 		case kArrayTypeString: {
-			byte *target = (byte *)_data + index;
 			const byte fillValue = value.getOffset();
-			while (count--) {
+			for (uint16 i = 0; i < count; ++i) {
+				byte *target = (byte *)_data + index + i;
 				*target = fillValue;
 			}
 			break;


### PR DESCRIPTION
The ScummVM implementation of class SciArray::fill() has a bug where it
will overwrite the array[index] with the value count times, rather than
fill the array starting from index count times.

This patch fixes that behavior. This was noticed because the LSL7 dice
game was broken, it was impossible to lose. After this patch the dice
game works as expected.