### PR TITLE
SCI: Various breakpoint improvements

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -3729,22 +3729,22 @@ bool Console::cmdBreakpointList(int argc, const char **argv) {
 	Common::List<Breakpoint>::const_iterator end = _debugState._breakpoints.end();
 	for (; bp != end; ++bp) {
 		debugPrintf("  #%i: ", i);
-		switch (bp->type) {
+		switch (bp->_type) {
 		case BREAK_SELECTOREXEC:
-			debugPrintf("Execute %s\n", bp->name.c_str());
+			debugPrintf("Execute %s\n", bp->_name.c_str());
 			break;
 		case BREAK_SELECTORREAD:
-			debugPrintf("Read %s\n", bp->name.c_str());
+			debugPrintf("Read %s\n", bp->_name.c_str());
 			break;
 		case BREAK_SELECTORWRITE:
-			debugPrintf("Write %s\n", bp->name.c_str());
+			debugPrintf("Write %s\n", bp->_name.c_str());
 			break;
 		case BREAK_EXPORT:
-			bpdata = bp->address;
+			bpdata = bp->_address;
 			debugPrintf("Execute script %d, export %d\n", bpdata >> 16, bpdata & 0xFFFF);
 			break;
 		case BREAK_ADDRESS:
-			debugPrintf("Execute address %04x:%04x\n", PRINT_REG(bp->regAddress));
+			debugPrintf("Execute address %04x:%04x\n", PRINT_REG(bp->_regAddress));
 		}
 
 		i++;
@@ -3790,7 +3790,7 @@ bool Console::cmdBreakpointDelete(int argc, const char **argv) {
 	// Update EngineState::_activeBreakpointTypes.
 	int type = 0;
 	for (bp = _debugState._breakpoints.begin(); bp != end; ++bp) {
-		type |= bp->type;
+		type |= bp->_type;
 	}
 
 	_debugState._activeBreakpointTypes = type;
@@ -3812,8 +3812,8 @@ bool Console::cmdBreakpointMethod(int argc, const char **argv) {
 	   Thus, we can't check whether the command argument is a valid method name.
 	   A breakpoint set on an invalid method name will just never trigger. */
 	Breakpoint bp;
-	bp.type = BREAK_SELECTOREXEC;
-	bp.name = argv[1];
+	bp._type = BREAK_SELECTOREXEC;
+	bp._name = argv[1];
 
 	_debugState._breakpoints.push_back(bp);
 	_debugState._activeBreakpointTypes |= BREAK_SELECTOREXEC;
@@ -3829,8 +3829,8 @@ bool Console::cmdBreakpointRead(int argc, const char **argv) {
 	}
 
 	Breakpoint bp;
-	bp.type = BREAK_SELECTORREAD;
-	bp.name = argv[1];
+	bp._type = BREAK_SELECTORREAD;
+	bp._name = argv[1];
 
 	_debugState._breakpoints.push_back(bp);
 	_debugState._activeBreakpointTypes |= BREAK_SELECTORREAD;
@@ -3846,8 +3846,8 @@ bool Console::cmdBreakpointWrite(int argc, const char **argv) {
 	}
 
 	Breakpoint bp;
-	bp.type = BREAK_SELECTORWRITE;
-	bp.name = argv[1];
+	bp._type = BREAK_SELECTORWRITE;
+	bp._name = argv[1];
 
 	_debugState._breakpoints.push_back(bp);
 	_debugState._activeBreakpointTypes |= BREAK_SELECTORWRITE;
@@ -3891,9 +3891,9 @@ bool Console::cmdBreakpointFunction(int argc, const char **argv) {
 	   Thus, we can't check whether the command argument is a valid method name.
 	   A breakpoint set on an invalid method name will just never trigger. */
 	Breakpoint bp;
-	bp.type = BREAK_EXPORT;
+	bp._type = BREAK_EXPORT;
 	// script number, export number
-	bp.address = (atoi(argv[1]) << 16 | atoi(argv[2]));
+	bp._address = (atoi(argv[1]) << 16 | atoi(argv[2]));
 
 	_debugState._breakpoints.push_back(bp);
 	_debugState._activeBreakpointTypes |= BREAK_EXPORT;
@@ -3917,8 +3917,8 @@ bool Console::cmdBreakpointAddress(int argc, const char **argv) {
 	}
 
 	Breakpoint bp;
-	bp.type = BREAK_ADDRESS;
-	bp.regAddress = make_reg32(addr.getSegment(), addr.getOffset());
+	bp._type = BREAK_ADDRESS;
+	bp._regAddress = make_reg32(addr.getSegment(), addr.getOffset());
 
 	_debugState._breakpoints.push_back(bp);
 	_debugState._activeBreakpointTypes |= BREAK_ADDRESS;

--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -3816,7 +3816,7 @@ static bool stringToBreakpointAction(Common::String str, BreakpointAction &actio
 		action = BREAK_BACKTRACE;
 	else if (str == "inspect")
 		action = BREAK_INSPECT;
-	else if (str == "none")
+	else if (str == "ignore")
 		action = BREAK_NONE;
 	else
 		return false;
@@ -3846,7 +3846,7 @@ bool Console::cmdBreakpointAction(int argc, const char **argv) {
 		debugPrintf("         log    : log without breaking\n");
 		debugPrintf("         bt     : show backtrace without breaking\n");
 		debugPrintf("         inspect: show object (only for bpx/bpr/bpw)\n");
-		debugPrintf("         none   : ignore breakpoint\n");
+		debugPrintf("         ignore : ignore breakpoint\n");
 		return true;
 	}
 

--- a/engines/sci/console.h
+++ b/engines/sci/console.h
@@ -191,6 +191,8 @@ private:
 	 */
 	void printKernelCallsFound(int kernelFuncNum, bool showFoundScripts);
 
+	void printBreakpoint(int index, const Breakpoint &bp);
+
 	SciEngine *_engine;
 	DebugState &_debugState;
 	Common::String _videoFile;

--- a/engines/sci/console.h
+++ b/engines/sci/console.h
@@ -45,7 +45,6 @@ public:
 	void printArray(reg_t reg);
 	void printBitmap(reg_t reg);
 #endif
-	int printObject(reg_t reg);
 
 private:
 	virtual void preEnter();

--- a/engines/sci/console.h
+++ b/engines/sci/console.h
@@ -149,6 +149,7 @@ private:
 	// Breakpoints
 	bool cmdBreakpointList(int argc, const char **argv);
 	bool cmdBreakpointDelete(int argc, const char **argv);
+	bool cmdBreakpointAction(int argc, const char **argv);
 	bool cmdBreakpointMethod(int argc, const char **argv);
 	bool cmdBreakpointRead(int argc, const char **argv);
 	bool cmdBreakpointWrite(int argc, const char **argv);

--- a/engines/sci/debug.h
+++ b/engines/sci/debug.h
@@ -47,9 +47,11 @@ enum BreakpointType {
 };
 
 enum BreakpointAction {
-	BREAK_BREAK, // break into debugger when breakpoint is triggered
-	BREAK_LOG, // log the breakpoint, and don't break into debugger
-	BREAK_BACKTRACE // show a backtrace, and don't break into debugger
+	BREAK_NONE,      // ignore breakpoint
+	BREAK_BREAK,     // break into debugger when breakpoint is triggered
+	BREAK_LOG,       // log the breakpoint, and don't break into debugger
+	BREAK_BACKTRACE, // show a backtrace, and don't break into debugger
+	BREAK_INSPECT    // show object, and don't break into debugger
 };
 
 struct Breakpoint {
@@ -81,6 +83,8 @@ struct DebugState {
 	StackPtr old_sp;
 	Common::List<Breakpoint> _breakpoints;   //< List of breakpoints
 	int _activeBreakpointTypes;  //< Bit mask specifying which types of breakpoints are active
+
+	void updateActiveBreakpointTypes();
 };
 
 // Various global variables used for debugging are declared here

--- a/engines/sci/debug.h
+++ b/engines/sci/debug.h
@@ -47,10 +47,10 @@ enum BreakpointType {
 };
 
 struct Breakpoint {
-	BreakpointType type;
-	uint32 address;     ///< Breakpoints on exports
-	reg32_t regAddress; ///< Breakpoints on addresses
-	Common::String name; ///< Breakpoints on selector names
+	BreakpointType _type;
+	uint32 _address;     ///< Breakpoints on exports
+	reg32_t _regAddress; ///< Breakpoints on addresses
+	Common::String _name; ///< Breakpoints on selector names
 };
 
 enum DebugSeeking {

--- a/engines/sci/debug.h
+++ b/engines/sci/debug.h
@@ -31,7 +31,7 @@ namespace Sci {
 // These types are used both as identifiers and as elements of bitfields
 enum BreakpointType {
 	/**
-	 * Break when a selector is executed. Data contains (char *) selector name
+	 * Break when a selector is executed. Data contains selector name
 	 * (in the format Object::Method)
 	 */
 	BREAK_SELECTOREXEC  = 1 << 0, // break when a function selector is executed
@@ -39,11 +39,12 @@ enum BreakpointType {
 	BREAK_SELECTORWRITE = 1 << 2, // break when a variable selector is written
 
 	/**
-	 * Break when an exported function is called. Data contains
+	 * Break when an exported function is called. _address contains
 	 * script_no << 16 | export_no.
 	 */
 	BREAK_EXPORT        = 1 << 3,
-	BREAK_ADDRESS       = 1 << 4  // break when pc is at this address
+	BREAK_ADDRESS       = 1 << 4, // break when pc is at _regAddress
+	BREAK_KERNEL        = 1 << 5  // break on named kernel call
 };
 
 enum BreakpointAction {

--- a/engines/sci/debug.h
+++ b/engines/sci/debug.h
@@ -46,11 +46,18 @@ enum BreakpointType {
 	BREAK_ADDRESS       = 1 << 4  // break when pc is at this address
 };
 
+enum BreakpointAction {
+	BREAK_BREAK, // break into debugger when breakpoint is triggered
+	BREAK_LOG, // log the breakpoint, and don't break into debugger
+	BREAK_BACKTRACE // show a backtrace, and don't break into debugger
+};
+
 struct Breakpoint {
 	BreakpointType _type;
 	uint32 _address;     ///< Breakpoints on exports
 	reg32_t _regAddress; ///< Breakpoints on addresses
 	Common::String _name; ///< Breakpoints on selector names
+	BreakpointAction _action;
 };
 
 enum DebugSeeking {

--- a/engines/sci/debug.h
+++ b/engines/sci/debug.h
@@ -48,10 +48,8 @@ enum BreakpointType {
 
 struct Breakpoint {
 	BreakpointType type;
-	union {
-		uint32 address;     ///< Breakpoints on exports
-		reg32_t regAddress; ///< Breakpoints on addresses
-	};
+	uint32 address;     ///< Breakpoints on exports
+	reg32_t regAddress; ///< Breakpoints on addresses
 	Common::String name; ///< Breakpoints on selector names
 };
 

--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -601,7 +601,6 @@ void Kernel::mapFunctions() {
 		_kernelFuncs[id].workarounds = NULL;
 		_kernelFuncs[id].subFunctions = NULL;
 		_kernelFuncs[id].subFunctionCount = 0;
-		_kernelFuncs[id].debugLogging = false;
 		if (kernelName.empty()) {
 			// No name was given -> must be an unknown opcode
 			warning("Kernel function %x unknown", id);
@@ -720,85 +719,6 @@ void Kernel::mapFunctions() {
 				mapped + ignored, _kernelNames.size(), mapped, ignored);
 
 	return;
-}
-
-bool Kernel::debugSetFunction(const char *kernelName, int logging, int breakpoint) {
-	if (strcmp(kernelName, "*")) {
-		for (uint id = 0; id < _kernelFuncs.size(); id++) {
-			if (_kernelFuncs[id].name) {
-				if (strcmp(kernelName, _kernelFuncs[id].name) == 0) {
-					if (_kernelFuncs[id].subFunctions) {
-						// sub-functions available and main name matched, in that case set logging of all sub-functions
-						KernelSubFunction *kernelSubCall = _kernelFuncs[id].subFunctions;
-						uint kernelSubCallCount = _kernelFuncs[id].subFunctionCount;
-						for (uint subId = 0; subId < kernelSubCallCount; subId++) {
-							if (kernelSubCall->function) {
-								if (logging != -1)
-									kernelSubCall->debugLogging = logging == 1 ? true : false;
-								if (breakpoint != -1)
-									kernelSubCall->debugBreakpoint = breakpoint == 1 ? true : false;
-							}
-							kernelSubCall++;
-						}
-						return true;
-					}
-					// function name matched, set for this one and exit
-					if (logging != -1)
-						_kernelFuncs[id].debugLogging = logging == 1 ? true : false;
-					if (breakpoint != -1)
-						_kernelFuncs[id].debugBreakpoint = breakpoint == 1 ? true : false;
-					return true;
-				} else {
-					// main name was not matched
-					if (_kernelFuncs[id].subFunctions) {
-						// Sub-Functions available
-						KernelSubFunction *kernelSubCall = _kernelFuncs[id].subFunctions;
-						uint kernelSubCallCount = _kernelFuncs[id].subFunctionCount;
-						for (uint subId = 0; subId < kernelSubCallCount; subId++) {
-							if (kernelSubCall->function) {
-								if (strcmp(kernelName, kernelSubCall->name) == 0) {
-									// sub-function name matched, set for this one and exit
-									if (logging != -1)
-										kernelSubCall->debugLogging = logging == 1 ? true : false;
-									if (breakpoint != -1)
-										kernelSubCall->debugBreakpoint = breakpoint == 1 ? true : false;
-									return true;
-								}
-							}
-							kernelSubCall++;
-						}
-					}
-				}
-			}
-		}
-		return false;
-	}
-	// Set debugLogging for all calls
-	for (uint id = 0; id < _kernelFuncs.size(); id++) {
-		if (_kernelFuncs[id].name) {
-			if (!_kernelFuncs[id].subFunctions) {
-				// No sub-functions, enable actual kernel function
-				if (logging != -1)
-					_kernelFuncs[id].debugLogging = logging == 1 ? true : false;
-				if (breakpoint != -1)
-					_kernelFuncs[id].debugBreakpoint = breakpoint == 1 ? true : false;
-			} else {
-				// Sub-Functions available, enable those too
-				KernelSubFunction *kernelSubCall = _kernelFuncs[id].subFunctions;
-				uint kernelSubCallCount = _kernelFuncs[id].subFunctionCount;
-				for (uint subId = 0; subId < kernelSubCallCount; subId++) {
-					if (kernelSubCall->function) {
-						if (logging != -1)
-							kernelSubCall->debugLogging = logging == 1 ? true : false;
-						if (breakpoint != -1)
-							kernelSubCall->debugBreakpoint = breakpoint == 1 ? true : false;
-					}
-					kernelSubCall++;
-				}
-			}
-		}
-	}
-	return true;
 }
 
 #ifdef ENABLE_SCI32

--- a/engines/sci/engine/kernel.h
+++ b/engines/sci/engine/kernel.h
@@ -143,8 +143,6 @@ struct KernelFunction {
 	const SciWorkaroundEntry *workarounds;
 	KernelSubFunction *subFunctions;
 	uint16 subFunctionCount;
-	bool debugLogging;
-	bool debugBreakpoint;
 };
 
 class Kernel {
@@ -236,11 +234,6 @@ public:
 	 * name table of the resource (the format changed between version 0 and 1).
 	 */
 	void loadKernelNames(GameFeatures *features);
-
-	/**
-	 * Sets debug flags for a kernel function
-	 */
-	bool debugSetFunction(const char *kernelName, int logging, int breakpoint);
 
 private:
 	/**

--- a/engines/sci/engine/scriptdebug.cpp
+++ b/engines/sci/engine/scriptdebug.cpp
@@ -681,11 +681,14 @@ void Kernel::dissectScript(int scriptNumber, Vocabulary *vocab) {
 
 bool SciEngine::checkSelectorBreakpoint(BreakpointType breakpointType, reg_t send_obj, int selector) {
 	Common::String methodName = _gamestate->_segMan->getObjectName(send_obj);
-	methodName += ("::" + getKernel()->getSelectorName(selector));
+	methodName += "::" + getKernel()->getSelectorName(selector);
 
 	Common::List<Breakpoint>::const_iterator bpIter;
 	for (bpIter = _debugState._breakpoints.begin(); bpIter != _debugState._breakpoints.end(); ++bpIter) {
-		if ((*bpIter).type == breakpointType && (*bpIter).name == methodName) {
+		if (bpIter->type != breakpointType)
+			continue;
+		if (bpIter->name == methodName ||
+		    (bpIter->name.hasSuffix("::") && methodName.hasPrefix(bpIter->name))) {
 			_console->debugPrintf("Break on %s (in [%04x:%04x])\n", methodName.c_str(), PRINT_REG(send_obj));
 			_debugState.debugging = true;
 			_debugState.breakpointWasHit = true;

--- a/engines/sci/engine/scriptdebug.cpp
+++ b/engines/sci/engine/scriptdebug.cpp
@@ -685,10 +685,10 @@ bool SciEngine::checkSelectorBreakpoint(BreakpointType breakpointType, reg_t sen
 
 	Common::List<Breakpoint>::const_iterator bpIter;
 	for (bpIter = _debugState._breakpoints.begin(); bpIter != _debugState._breakpoints.end(); ++bpIter) {
-		if (bpIter->type != breakpointType)
+		if (bpIter->_type != breakpointType)
 			continue;
-		if (bpIter->name == methodName ||
-		    (bpIter->name.hasSuffix("::") && methodName.hasPrefix(bpIter->name))) {
+		if (bpIter->_name == methodName ||
+		    (bpIter->_name.hasSuffix("::") && methodName.hasPrefix(bpIter->_name))) {
 			_console->debugPrintf("Break on %s (in [%04x:%04x])\n", methodName.c_str(), PRINT_REG(send_obj));
 			_debugState.debugging = true;
 			_debugState.breakpointWasHit = true;
@@ -704,7 +704,7 @@ bool SciEngine::checkExportBreakpoint(uint16 script, uint16 pubfunct) {
 
 		Common::List<Breakpoint>::const_iterator bp;
 		for (bp = _debugState._breakpoints.begin(); bp != _debugState._breakpoints.end(); ++bp) {
-			if (bp->type == BREAK_EXPORT && bp->address == bpaddress) {
+			if (bp->_type == BREAK_EXPORT && bp->_address == bpaddress) {
 				_console->debugPrintf("Break on script %d, export %d\n", script, pubfunct);
 				_debugState.debugging = true;
 				_debugState.breakpointWasHit = true;
@@ -720,7 +720,7 @@ bool SciEngine::checkAddressBreakpoint(const reg32_t &address) {
 	if (_debugState._activeBreakpointTypes & BREAK_ADDRESS) {
 		Common::List<Breakpoint>::const_iterator bp;
 		for (bp = _debugState._breakpoints.begin(); bp != _debugState._breakpoints.end(); ++bp) {
-			if (bp->type == BREAK_ADDRESS && bp->regAddress == address) {
+			if (bp->_type == BREAK_ADDRESS && bp->_regAddress == address) {
 				_console->debugPrintf("Break at %04x:%04x\n", PRINT_REG(address));
 				_debugState.debugging = true;
 				_debugState.breakpointWasHit = true;

--- a/engines/sci/engine/scriptdebug.cpp
+++ b/engines/sci/engine/scriptdebug.cpp
@@ -28,6 +28,7 @@
 #include "sci/engine/state.h"
 #include "sci/engine/kernel.h"
 #include "sci/engine/script.h"
+#include "sci/engine/scriptdebug.h"
 
 namespace Sci {
 
@@ -690,8 +691,12 @@ bool SciEngine::checkSelectorBreakpoint(BreakpointType breakpointType, reg_t sen
 		if (bpIter->_name == methodName ||
 		    (bpIter->_name.hasSuffix("::") && methodName.hasPrefix(bpIter->_name))) {
 			_console->debugPrintf("Break on %s (in [%04x:%04x])\n", methodName.c_str(), PRINT_REG(send_obj));
-			_debugState.debugging = true;
-			_debugState.breakpointWasHit = true;
+			if (bpIter->_action == BREAK_BREAK) {
+				_debugState.debugging = true;
+				_debugState.breakpointWasHit = true;
+			} else if (bpIter->_action == BREAK_BACKTRACE) {
+				logBacktrace();
+			}
 			return true;
 		}
 	}
@@ -706,8 +711,12 @@ bool SciEngine::checkExportBreakpoint(uint16 script, uint16 pubfunct) {
 		for (bp = _debugState._breakpoints.begin(); bp != _debugState._breakpoints.end(); ++bp) {
 			if (bp->_type == BREAK_EXPORT && bp->_address == bpaddress) {
 				_console->debugPrintf("Break on script %d, export %d\n", script, pubfunct);
-				_debugState.debugging = true;
-				_debugState.breakpointWasHit = true;
+				if (bp->_action == BREAK_BREAK) {
+					_debugState.debugging = true;
+					_debugState.breakpointWasHit = true;
+				} else if (bp->_action == BREAK_BACKTRACE) {
+					logBacktrace();
+				}
 				return true;
 			}
 		}
@@ -722,8 +731,12 @@ bool SciEngine::checkAddressBreakpoint(const reg32_t &address) {
 		for (bp = _debugState._breakpoints.begin(); bp != _debugState._breakpoints.end(); ++bp) {
 			if (bp->_type == BREAK_ADDRESS && bp->_regAddress == address) {
 				_console->debugPrintf("Break at %04x:%04x\n", PRINT_REG(address));
-				_debugState.debugging = true;
-				_debugState.breakpointWasHit = true;
+				if (bp->_action == BREAK_BREAK) {
+					_debugState.debugging = true;
+					_debugState.breakpointWasHit = true;
+				} else if (bp->_action == BREAK_BACKTRACE) {
+					logBacktrace();
+				}
 				return true;
 			}
 		}

--- a/engines/sci/engine/scriptdebug.h
+++ b/engines/sci/engine/scriptdebug.h
@@ -1,0 +1,38 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef SCI_ENGINE_SCRIPTDEBUG_H
+#define SCI_ENGINE_SCRIPTDEBUG_H
+
+namespace Sci {
+
+#ifndef REDUCE_MEMORY_USAGE
+extern const char *opcodeNames[];
+#endif
+
+void debugSelectorCall(reg_t send_obj, Selector selector, int argc, StackPtr argp, ObjVarRef &varp, reg_t funcp, SegManager *segMan, SelectorType selectorType);
+
+void logKernelCall(const KernelFunction *kernelCall, const KernelSubFunction *kernelSubCall, EngineState *s, int argc, reg_t *argv, reg_t result);
+
+}
+
+#endif

--- a/engines/sci/engine/scriptdebug.h
+++ b/engines/sci/engine/scriptdebug.h
@@ -35,6 +35,8 @@ void debugPropertyAccess(Object *obj, reg_t objp, unsigned int index, reg_t curV
 
 void logKernelCall(const KernelFunction *kernelCall, const KernelSubFunction *kernelSubCall, EngineState *s, int argc, reg_t *argv, reg_t result);
 
+void logBacktrace();
+
 }
 
 #endif

--- a/engines/sci/engine/scriptdebug.h
+++ b/engines/sci/engine/scriptdebug.h
@@ -37,6 +37,8 @@ void logKernelCall(const KernelFunction *kernelCall, const KernelSubFunction *ke
 
 void logBacktrace();
 
+bool printObject(reg_t obj);
+
 }
 
 #endif

--- a/engines/sci/engine/scriptdebug.h
+++ b/engines/sci/engine/scriptdebug.h
@@ -39,6 +39,8 @@ void logBacktrace();
 
 bool printObject(reg_t obj);
 
+bool matchKernelBreakpointPattern(const Common::String &pattern, const Common::String &name);
+
 }
 
 #endif

--- a/engines/sci/engine/scriptdebug.h
+++ b/engines/sci/engine/scriptdebug.h
@@ -31,6 +31,8 @@ extern const char *opcodeNames[];
 
 void debugSelectorCall(reg_t send_obj, Selector selector, int argc, StackPtr argp, ObjVarRef &varp, reg_t funcp, SegManager *segMan, SelectorType selectorType);
 
+void debugPropertyAccess(Object *obj, reg_t objp, unsigned int index, reg_t curValue, reg_t newValue, SegManager *segMan, BreakpointType breakpointType);
+
 void logKernelCall(const KernelFunction *kernelCall, const KernelSubFunction *kernelSubCall, EngineState *s, int argc, reg_t *argv, reg_t result);
 
 }

--- a/engines/sci/engine/vm.cpp
+++ b/engines/sci/engine/vm.cpp
@@ -1135,29 +1135,60 @@ void run_vm(EngineState *s) {
 
 		case op_pToa: // 0x31 (49)
 			// Property To Accumulator
+			if (g_sci->_debugState._activeBreakpointTypes & BREAK_SELECTORREAD) {
+				debugPropertyAccess(obj, s->xs->objp, opparams[0],
+				                    validate_property(s, obj, opparams[0]), NULL_REG,
+				                    s->_segMan, BREAK_SELECTORREAD);
+			}
 			s->r_acc = validate_property(s, obj, opparams[0]);
 			break;
 
 		case op_aTop: // 0x32 (50)
+			{
 			// Accumulator To Property
-			validate_property(s, obj, opparams[0]) = s->r_acc;
+			reg_t &opProperty = validate_property(s, obj, opparams[0]);
+			if (g_sci->_debugState._activeBreakpointTypes & BREAK_SELECTORWRITE) {
+				debugPropertyAccess(obj, s->xs->objp, opparams[0],
+				                    opProperty, s->r_acc,
+				                    s->_segMan, BREAK_SELECTORWRITE);
+			}
+
+			opProperty = s->r_acc;
 #ifdef ENABLE_SCI32
 			updateInfoFlagViewVisible(obj, opparams[0], true);
 #endif
 			break;
+		}
 
 		case op_pTos: // 0x33 (51)
+			{
 			// Property To Stack
-			PUSH32(validate_property(s, obj, opparams[0]));
+			reg_t value = validate_property(s, obj, opparams[0]);
+			if (g_sci->_debugState._activeBreakpointTypes & BREAK_SELECTORREAD) {
+				debugPropertyAccess(obj, s->xs->objp, opparams[0],
+				                    value, NULL_REG,
+				                    s->_segMan, BREAK_SELECTORREAD);
+			}
+			PUSH32(value);
 			break;
+		}
 
 		case op_sTop: // 0x34 (52)
+			{
 			// Stack To Property
-			validate_property(s, obj, opparams[0]) = POP32();
+			reg_t newValue = POP32();
+			reg_t &opProperty = validate_property(s, obj, opparams[0]);
+			if (g_sci->_debugState._activeBreakpointTypes & BREAK_SELECTORWRITE) {
+				debugPropertyAccess(obj, s->xs->objp, opparams[0],
+				                    opProperty, newValue,
+				                    s->_segMan, BREAK_SELECTORWRITE);
+			}
+			opProperty = newValue;
 #ifdef ENABLE_SCI32
 			updateInfoFlagViewVisible(obj, opparams[0], true);
 #endif
 			break;
+		}
 
 		case op_ipToa: // 0x35 (53)
 		case op_dpToa: // 0x36 (54)
@@ -1167,10 +1198,25 @@ void run_vm(EngineState *s) {
 			// Increment/decrement a property and copy to accumulator,
 			// or push to stack
 			reg_t &opProperty = validate_property(s, obj, opparams[0]);
+			reg_t oldValue = opProperty;
+
+			if (g_sci->_debugState._activeBreakpointTypes & BREAK_SELECTORREAD) {
+				debugPropertyAccess(obj, s->xs->objp, opparams[0],
+				                    oldValue, NULL_REG,
+				                    s->_segMan, BREAK_SELECTORREAD);
+			}
+
 			if (opcode & 1)
 				opProperty += 1;
 			else
 				opProperty -= 1;
+
+			if (g_sci->_debugState._activeBreakpointTypes & BREAK_SELECTORWRITE) {
+				debugPropertyAccess(obj, s->xs->objp, opparams[0],
+				                    oldValue, opProperty,
+				                    s->_segMan, BREAK_SELECTORWRITE);
+			}
+
 #ifdef ENABLE_SCI32
 			updateInfoFlagViewVisible(obj, opparams[0], true);
 #endif

--- a/engines/sci/engine/vm.cpp
+++ b/engines/sci/engine/vm.cpp
@@ -42,6 +42,7 @@
 #include "sci/engine/selector.h"	// for SELECTOR
 #include "sci/engine/gc.h"
 #include "sci/engine/workarounds.h"
+#include "sci/engine/scriptdebug.h"
 
 namespace Sci {
 
@@ -119,10 +120,6 @@ static bool validate_variable(reg_t *r, reg_t *stack_base, int type, int max, in
 
 	return true;
 }
-
-#ifndef REDUCE_MEMORY_USAGE
-extern const char *opcodeNames[]; // from scriptdebug.cpp
-#endif
 
 static reg_t read_var(EngineState *s, int type, int index) {
 	if (validate_variable(s->variables[type], s->stack_base, type, s->variablesMax[type], index)) {
@@ -263,8 +260,6 @@ static void _exec_varselectors(EngineState *s) {
 	}
 }
 
-// from scriptdebug.cpp
-extern void debugSelectorCall(reg_t send_obj, Selector selector, int argc, StackPtr argp, ObjVarRef &varp, reg_t funcp, SegManager *segMan, SelectorType selectorType);
 
 ExecStack *send_selector(EngineState *s, reg_t send_obj, reg_t work_obj, StackPtr sp, int framesize, StackPtr argp) {
 	// send_obj and work_obj are equal for anything but 'super'
@@ -345,9 +340,6 @@ static void addKernelCallToExecStack(EngineState *s, int kernelCallNr, int kerne
 						-1, kernelCallNr, kernelSubCallNr, -1, -1, s->_executionStack.size() - 1, EXEC_STACK_TYPE_KERNEL);
 	s->_executionStack.push_back(xstack);
 }
-
-// from scriptdebug.cpp
-extern void logKernelCall(const KernelFunction *kernelCall, const KernelSubFunction *kernelSubCall, EngineState *s, int argc, reg_t *argv, reg_t result);
 
 static void callKernelFunc(EngineState *s, int kernelCallNr, int argc) {
 	Kernel *kernel = g_sci->getKernel();

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -42,6 +42,7 @@
 #include "sci/engine/script.h"	// for script_adjust_opcode_formats
 #include "sci/engine/script_patches.h"
 #include "sci/engine/selector.h"	// for SELECTOR
+#include "sci/engine/scriptdebug.h"
 
 #include "sci/sound/audio.h"
 #include "sci/sound/music.h"
@@ -637,7 +638,7 @@ void SciEngine::initStackBaseWithSelector(Selector selector) {
 
 	// Register the first element on the execution stack
 	if (!send_selector(_gamestate, _gameObjectAddress, _gameObjectAddress, _gamestate->stack_base, 2, _gamestate->stack_base)) {
-		_console->printObject(_gameObjectAddress);
+		printObject(_gameObjectAddress);
 		error("initStackBaseWithSelector: error while registering the first selector in the call stack");
 	}
 

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -315,6 +315,7 @@ public:
 	bool checkAddressBreakpoint(const reg32_t &address);
 
 public:
+	bool checkKernelBreakpoint(const Common::String &name);
 
 	/**
 	 * Processes a multilanguage string based on the current language settings and


### PR DESCRIPTION
This improves breakpoints in a number of ways:

* Fix regression from 0f9c33e02f1cb2c740c1eb0dcaad96dd22ec29e7 that broke wildcard selector breakpoints
* Add `bpw`/`bpr` handling to property access opcodes (`aTop` and such). (Catching property reads/writes inside kernel functions is still not done.)
* Add new `bp_action` (alias `bpact`) command to set the action to perform when an individual breakpoint is triggered:
  * `break`: break into debugger (the default)
  * `log`: only log the breakpoint, but don't break
  * `bt`: show a backtrace, but don't break
  * `inspect`: show the current obj (`bpw`, `bpr`, `bpx` only), but don't break
  * `none`: ignore this breakpoint