### PR TITLE
Fix error when using XDM

### DIFF
--- a/configure
+++ b/configure
@@ -3447,7 +3447,7 @@ case $_backend in
 		case $_sdlversion in
 			2.0.*)
 				add_line_to_config_mk "USE_SDL2 = 1"
-				append_var SDL_NET_LIBS "-lSDL2_net"
+				append_var SDL_NET_LIBS "-lSDL2_net -lX11"
 				;;
 			*)
 				append_var SDL_NET_LIBS "-lSDL_net"


### PR DESCRIPTION
Fixes error message when logged in via XDM:

    XDM authorization key matches an existing client!Could not initialize SDL: No available video device!

Evidently this error is caused by XDM using a non-standard magic cookie name. Linking to libX11 fixes this error.

This can supposedly be worked around by specifying `DisplayManager*authName: MIT-MAGIC-COOKIE-1` inside /etc/X11/xdm/xdm-config.

(Source: https://forums.gentoo.org/viewtopic-t-716898-highlight-matches+existing+client.html)

A big hint that lead to adding `-lX11` to the link step was from a comment in the SDL source itself:

     /* On Tru64 if linking without -lX11, it fails and you get following message.
      * Xlib: connection to ":0.0" refused by server
      * Xlib: XDM authorization key matches an existing client!
      *
      * It succeeds if retrying 1 second later
      * or if running xhost +localhost on shell.
      */

(Source: https://www.libsdl.org/tmp/SDL/src/video/x11/SDL_x11video.c)

This was broken in e2b3a9366eaad23549ad8be9316872e48a9ac11b, and it seems that mistakenly linking to the older version of libSDL_net (1.2.8 in this case) was circumventing this error, possibly because it's linked to libX11, whereas libSDL2_net is not linked to libX11.

Version information:
* XDM version: 1.1.11
* xorg-server version: 1.19.3
* SDL2 version: 2.0.5
* SDL2_net version: 2.0.1
* Slackware64 14.2 + current