### PR TITLE
ENGINES: Display savestate date as YYYY-MM-DD

### DIFF
--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -43,7 +43,7 @@ void SaveStateDescriptor::setThumbnail(Graphics::Surface *t) {
 }
 
 void SaveStateDescriptor::setSaveDate(int year, int month, int day) {
-	_saveDate = Common::String::format("%.2d.%.2d.%.4d", day, month, year);
+	_saveDate = Common::String::format("%.4d-%.2d-%.2d", year, month, day);
 }
 
 void SaveStateDescriptor::setSaveTime(int hour, int min) {

--- a/gui/saveload.cpp
+++ b/gui/saveload.cpp
@@ -67,7 +67,7 @@ Common::String SaveLoadChooser::createDefaultSaveDescription(const int slot) con
 	g_system->getTimeAndDate(curTime);
 	curTime.tm_year += 1900; // fixup year
 	curTime.tm_mon++; // fixup month
-	return Common::String::format("%04d.%02d.%02d / %02d:%02d:%02d", curTime.tm_year, curTime.tm_mon, curTime.tm_mday, curTime.tm_hour, curTime.tm_min, curTime.tm_sec);
+	return Common::String::format("%04d-%02d-%02d / %02d:%02d:%02d", curTime.tm_year, curTime.tm_mon, curTime.tm_mday, curTime.tm_hour, curTime.tm_min, curTime.tm_sec);
 #else
 	return Common::String::format("Save %d", slot + 1);
 #endif


### PR DESCRIPTION
This avoids confusion in locales that use MM/DD/YYYY vs DD/MM/YYYY

thanks @csnover for suggesting dashes (like ISO-8601)