### PR TITLE
GUI: Separate bevel and shadow effect when extending widget rect

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -87,6 +87,7 @@ struct WidgetDrawData {
 	    E.g. when taking into account rounded corners, drop shadows, etc
 	    Used when restoring the widget background */
 	uint16 _backgroundOffset;
+	uint16 _shadowOffset;
 
 	bool _buffer;
 
@@ -271,6 +272,10 @@ void ThemeItemDrawData::drawSelf(bool draw, bool restore) {
 
 	Common::Rect extendedRect = _area;
 	extendedRect.grow(_engine->kDirtyRectangleThreshold + _data->_backgroundOffset);
+	if (_data->_shadowOffset > _data->_backgroundOffset) {
+		extendedRect.right += _data->_shadowOffset - _data->_backgroundOffset;
+		extendedRect.bottom += _data->_shadowOffset - _data->_backgroundOffset;
+	}
 
 	if (restore)
 		_engine->restoreBackground(extendedRect);
@@ -288,6 +293,10 @@ void ThemeItemDrawDataClip::drawSelf(bool draw, bool restore) {
 
 	Common::Rect extendedRect = _area;
 	extendedRect.grow(_engine->kDirtyRectangleThreshold + _data->_backgroundOffset);
+	if (_data->_shadowOffset > _data->_backgroundOffset) {
+		extendedRect.right += _data->_shadowOffset - _data->_backgroundOffset;
+		extendedRect.bottom += _data->_shadowOffset - _data->_backgroundOffset;
+	}
 
 	if (restore)
 		_engine->restoreBackground(extendedRect);
@@ -646,17 +655,18 @@ void ThemeEngine::setGraphicsMode(GraphicsMode mode) {
 }
 
 void WidgetDrawData::calcBackgroundOffset() {
-	uint maxShadow = 0;
+	uint maxShadow = 0, maxBevel = 0;
 	for (Common::List<Graphics::DrawStep>::const_iterator step = _steps.begin();
 	        step != _steps.end(); ++step) {
 		if ((step->autoWidth || step->autoHeight) && step->shadow > maxShadow)
 			maxShadow = step->shadow;
 
-		if (step->drawingCall == &Graphics::VectorRenderer::drawCallback_BEVELSQ && step->bevel > maxShadow)
-			maxShadow = step->bevel;
+		if (step->drawingCall == &Graphics::VectorRenderer::drawCallback_BEVELSQ && step->bevel > maxBevel)
+			maxBevel = step->bevel;
 	}
 
-	_backgroundOffset = maxShadow;
+	_backgroundOffset = maxBevel;
+	_shadowOffset = maxShadow;
 }
 
 void ThemeEngine::restoreBackground(Common::Rect r) {


### PR DESCRIPTION
When widget::draw() is called it asks the ThemeEngine to redraw the background first and then the widget gets redrawn in drawWidget(). The ThemeEngine uses an extended rect to restore the background to include bevel and shadow effects. However if this extended rect overlaps with other widgets, since those other widgets are not redrawn, a part of those will be missing. See for example bug #6394: GUI: List View save page drawns over font.

In case we get overlap we might need to change the way widgets are drawn so that all widgets intersecting the area where the backgroud is restored are redrawn. This commit simply seperate the bevel and shadow effects, and uses the shadow offset only to extend the bottom and right sides of the rectangle (while the bevel offset is still used to extend all four sides). This results in a smaller extended rectangle (if the shadow offset is bigger than the bevel offset, which is the case of the list view) and thus decrease the risk of the issue happening. The particular cases described in bug #6394 are all fixed with this change.

Do you see potential issue with this change? In particular is this OK to assume that the shadow is only drawn on the bottom and right side of widgets?