### PR TITLE
Windows: Use GetUserDefaultUILanguage() instead of GetThreadLocale().

### DIFF
--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -432,7 +432,7 @@ Common::String OSystem_SDL::getSystemLanguage() const {
 	char langName[9];
 	char ctryName[9];
 
-	const LCID languageIdentifier = GetThreadLocale();
+	const LCID languageIdentifier = GetUserDefaultUILanguage();
 
 	if (GetLocaleInfo(languageIdentifier, LOCALE_SISO639LANGNAME, langName, sizeof(langName)) != 0 &&
 		GetLocaleInfo(languageIdentifier, LOCALE_SISO3166CTRYNAME, ctryName, sizeof(ctryName)) != 0) {


### PR DESCRIPTION
The thread locale concerns display options (e.g. date formatting), not
the display language. They are typically, but not necessarily the same,
as Windows allows them to be configured separately.