### PR TITLE
DIRECTOR: Refactor lingo-events.cpp so that 1-ary processEvent is the unique entry point to events

### DIFF
--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -30,6 +30,8 @@
 #include "engines/engine.h"
 #include "director/cast.h"
 
+#define CHANNEL_COUNT 30
+
 namespace Common {
 class MacResManager;
 }

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -122,7 +122,7 @@ void DirectorEngine::processEvents() {
 		g_system->delayMillis(10);
 
 		if (sc->getCurrentFrame() > 0)
-			_lingo->processEvent(kEventIdle, kFrameScript, sc->getCurrentFrame());
+			_lingo->processEvent(kEventIdle);
 	}
 }
 

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -110,7 +110,7 @@ void DirectorEngine::processEvents() {
 					warning("Keycode: %d", _keyCode);
 				}
 
-				_lingo->processEvent(kEventKeyDown, kGlobalScript, 0);
+				_lingo->processEvent(kEventKeyDown);
 				break;
 
 			default:

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -71,12 +71,7 @@ void DirectorEngine::processEvents() {
 				sc->_currentMouseDownSpriteId = spriteId;
 
 				debugC(3, kDebugEvents, "event: Button Down @(%d, %d), sprite id: %d", pos.x, pos.y, spriteId);
-
-				if (getVersion() > 3) {
-					// TODO: check that this is the order of script execution!
-					_lingo->processEvent(kEventMouseDown, kCastScript, currentFrame->_sprites[spriteId]->_castId);
-					_lingo->processEvent(kEventMouseDown, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
-				}
+				_lingo->processEvent(kEventMouseDown);
 
 				if (currentFrame->_sprites[spriteId]->_moveable) {
 					warning("Moveable");
@@ -90,18 +85,7 @@ void DirectorEngine::processEvents() {
 
 				debugC(3, kDebugEvents, "event: Button Up @(%d, %d), sprite id: %d", pos.x, pos.y, spriteId);
 
-				if (getVersion() > 3) {
-					// TODO: check that this is the order of script execution!
-					_lingo->processEvent(kEventMouseUp, kCastScript, currentFrame->_sprites[spriteId]->_castId);
-					_lingo->processEvent(kEventMouseUp, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
-				} else {
-					// Frame script overrides sprite script
-					if (!currentFrame->_sprites[spriteId]->_scriptId)
-						_lingo->processEvent(kEventNone, kSpriteScript, currentFrame->_sprites[spriteId]->_castId + 1024);
-					else
-						_lingo->processEvent(kEventNone, kFrameScript, currentFrame->_sprites[spriteId]->_scriptId);
-				}
-
+				_lingo->processEvent(kEventMouseUp);
 				sc->_currentMouseDownSpriteId = 0;
 				break;
 

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -545,14 +545,6 @@ void Frame::playTransition(Score *score) {
 	}
 }
 
-void Frame::executeImmediateScripts() {
-	for (uint16 i = 0; i < CHANNEL_COUNT; i++) {
-		if (_vm->getCurrentScore()->_immediateActions.contains(_sprites[i]->_scriptId)) {
-			g_lingo->processEvent(kEventMouseUp, kFrameScript, _sprites[i]->_scriptId);
-		}
-	}
-}
-
 void Frame::renderSprites(Graphics::ManagedSurface &surface, bool renderTrail) {
 	for (uint16 i = 0; i < CHANNEL_COUNT; i++) {
 		if (_sprites[i]->_enabled) {

--- a/engines/director/frame.h
+++ b/engines/director/frame.h
@@ -33,8 +33,6 @@ namespace Director {
 
 class Sprite;
 
-#define CHANNEL_COUNT 30
-
 enum {
 	kChannelDataSize = (25 * 50)
 };

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -866,7 +866,8 @@ void Lingo::b_continue(int nargs) {
 }
 
 void Lingo::b_dontPassEvent(int nargs) {
-	warning("STUB: b_dontPassEvent");
+	g_lingo->dontPassEvent = true;
+	warning("dontPassEvent raised");
 }
 
 void Lingo::b_nothing(int nargs) {

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -149,23 +149,30 @@ void Lingo::processInputEvent(LEvent event) {
 	Frame *currentFrame = score->_frames[score->getCurrentFrame()];
 	assert(currentFrame != nullptr);
 	uint16 spriteId = score->_currentMouseDownSpriteId;
-	if (event == kEventMouseDown) {
-		if (_vm->getVersion() > 3) {
-			g_lingo->processEvent(kEventMouseDown, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
-			g_lingo->processEvent(kEventMouseDown, kCastScript, currentFrame->_sprites[spriteId]->_castId);
-		}
-		// TODO: Unhandled in D<3?
-	} else if (event == kEventMouseUp) {
-		if (_vm->getVersion() > 3) {
-			// TODO: check that this is the order of script execution!
-			g_lingo->processEvent(kEventMouseUp, kCastScript, currentFrame->_sprites[spriteId]->_castId);
-			g_lingo->processEvent(kEventMouseUp, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
-		} else {
-			// Frame script overrides sprite script
-			if (!currentFrame->_sprites[spriteId]->_scriptId)
-				g_lingo->processEvent(kEventNone, kSpriteScript, currentFrame->_sprites[spriteId]->_castId + 1024);
-			else
-				g_lingo->processEvent(kEventNone, kFrameScript, currentFrame->_sprites[spriteId]->_scriptId);
+
+	primaryEventHandler(event);
+
+	if (g_lingo->dontPassEvent) {
+		g_lingo->dontPassEvent = false;
+	} else {
+		if (event == kEventMouseDown) {
+			if (_vm->getVersion() > 3) {
+				g_lingo->processEvent(kEventMouseDown, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
+				g_lingo->processEvent(kEventMouseDown, kCastScript, currentFrame->_sprites[spriteId]->_castId);
+			}
+			// TODO: Unhandled in D<3?
+		} else if (event == kEventMouseUp) {
+			if (_vm->getVersion() > 3) {
+				// TODO: check that this is the order of script execution!
+				g_lingo->processEvent(kEventMouseUp, kCastScript, currentFrame->_sprites[spriteId]->_castId);
+				g_lingo->processEvent(kEventMouseUp, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
+			} else {
+				// Frame script overrides sprite script
+				if (!currentFrame->_sprites[spriteId]->_scriptId)
+					g_lingo->processEvent(kEventNone, kSpriteScript, currentFrame->_sprites[spriteId]->_castId + 1024);
+				else
+					g_lingo->processEvent(kEventNone, kFrameScript, currentFrame->_sprites[spriteId]->_scriptId);
+			}
 		}
 	}
 }

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "director/lingo/lingo.h"
+#include "director/frame.h"
 
 namespace Director {
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -22,6 +22,7 @@
 
 #include "director/lingo/lingo.h"
 #include "director/frame.h"
+#include "director/sprite.h"
 
 namespace Director {
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -267,6 +267,7 @@ void Lingo::processEvent(LEvent event) {
 		case kEventIdle:
 		case kEventEnterFrame:
 		case kEventExitFrame:
+		case kEventNone:
 			processFrameEvent(event);
 			break;
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -164,8 +164,8 @@ void Lingo::processInputEvent(LEvent event) {
 		} else if (event == kEventMouseUp) {
 			if (_vm->getVersion() > 3) {
 				// TODO: check that this is the order of script execution!
-				g_lingo->processEvent(kEventMouseUp, kCastScript, currentFrame->_sprites[spriteId]->_castId);
 				g_lingo->processEvent(kEventMouseUp, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
+				g_lingo->processEvent(kEventMouseUp, kCastScript, currentFrame->_sprites[spriteId]->_castId);
 			} else {
 				// Frame script overrides sprite script
 				if (!currentFrame->_sprites[spriteId]->_scriptId)

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -217,7 +217,7 @@ void Lingo::processFrameEvent(LEvent event) {
 	} else {
 		int entity;
 
-		if (event == kEventPrepareFrame) {
+		if (event == kEventPrepareFrame || event == kEventIdle) {
 			entity = score->getCurrentFrame();
 		} else {
 			assert(score->_frames[score->getCurrentFrame()] != nullptr);
@@ -264,6 +264,7 @@ void Lingo::processEvent(LEvent event) {
 			processInputEvent(event);
 			break;
 
+		case kEventIdle:
 		case kEventEnterFrame:
 		case kEventExitFrame:
 			processFrameEvent(event);
@@ -272,7 +273,6 @@ void Lingo::processEvent(LEvent event) {
 		case kEventStart:
 		case kEventStartMovie:
 		case kEventStopMovie:
-		case kEventIdle:
 		case kEventTimeout:
 			processGenericEvent(event);
 			break;

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -166,6 +166,8 @@ void Lingo::processInputEvent(LEvent event) {
 				g_lingo->processEvent(event, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
 			}
 			g_lingo->processEvent(event, kCastScript, currentFrame->_sprites[spriteId]->_castId);
+			g_lingo->processEvent(event, kFrameScript, score->_frames[score->getCurrentFrame()]->_actionId);
+			// TODO: Is the kFrameScript call above correct?
 		} else if (event == kEventMouseUp) {
 			// Frame script overrides sprite script
 			if (!currentFrame->_sprites[spriteId]->_scriptId)

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -205,12 +205,17 @@ void Lingo::processFrameEvent(LEvent event) {
 	if (g_lingo->dontPassEvent) {
 		g_lingo->dontPassEvent = false;
 	} else {
-		assert(score->_frames[score->getCurrentFrame()] != nullptr);
-		if (!g_lingo->_scripts[kFrameScript].contains(kFrameScript)) {
-			processEvent(event,
-						 kFrameScript,
-						 score->_frames[score->getCurrentFrame()]->_actionId);
+		int entity;
+
+		if (event == kEventPrepareFrame) {
+			entity = score->getCurrentFrame();
+		} else {
+			assert(score->_frames[score->getCurrentFrame()] != nullptr);
+			entity = score->_frames[score->getCurrentFrame()]->_actionId;
 		}
+		processEvent(event,
+		             kFrameScript,
+		             entity);
 		runMovieScript(event);
 	}
 }

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -233,7 +233,7 @@ void Lingo::processFrameEvent(LEvent event) {
 void Lingo::processGenericEvent(LEvent event) {
 	// Movie Script
 	int id = -1;
-	if (event == kEventStart)
+	if (event == kEventStart || event == kEventPrepareMovie)
 		id = 0;
 	else
 		warning("STUB: processGenericEvent called for something else than kEventStart or kEventPrepareMovie, additional logic probably needed");
@@ -275,6 +275,7 @@ void Lingo::processEvent(LEvent event) {
 		case kEventStartMovie:
 		case kEventStopMovie:
 		case kEventTimeout:
+		case kEventPrepareMovie:
 			processGenericEvent(event);
 			break;
 		case kEventBeginSprite:

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -162,9 +162,33 @@ void Lingo::runMovieScript(LEvent event) {
 }
 
 void Lingo::processFrameEvent(LEvent event) {
-	// Primary Event handler
-	// Score Script
-	// Movie Script
+	/* [in D4] the enterFrame, exitFrame, idle and timeout messages
+	 * are sent to a frame script and then a movie script.  If the
+	 * current frame has no frame script when the event occurs, the
+	 * message goes to movie scripts.
+	 * [...]
+	 * If more than one movie script handles the same message, Lingo
+	 * searches the movie scripts according to their order in the cast
+	 * window [p.81 of D4 docs]
+	 */
+	// TODO: Same for D2-3 or not?
+	Score *score = _vm->getCurrentScore();
+
+	if (event == kEventTimeout) {
+		primaryEventHandler(event);
+	}
+
+	if (g_lingo->dontPassEvent) {
+		g_lingo->dontPassEvent = false;
+	} else {
+		assert(score->_frames[score->getCurrentFrame()] != nullptr);
+		if (!g_lingo->_scripts[kFrameScript].contains(kFrameScript)) {
+			processEvent(event,
+						 kFrameScript,
+						 score->_frames[score->getCurrentFrame()]->_actionId);
+		}
+		runMovieScript(event);
+	}
 }
 
 void Lingo::processGenericEvent(LEvent event) {

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -145,6 +145,29 @@ void Lingo::processInputEvent(LEvent event) {
 	// Script of Cast Member
 	// Score Script
 	// Movie Script
+	Score *score = _vm->getCurrentScore();
+	Frame *currentFrame = score->_frames[score->getCurrentFrame()];
+	assert(currentFrame != nullptr);
+	uint16 spriteId = score->_currentMouseDownSpriteId;
+	if (event == kEventMouseDown) {
+		if (_vm->getVersion() > 3) {
+			g_lingo->processEvent(kEventMouseDown, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
+			g_lingo->processEvent(kEventMouseDown, kCastScript, currentFrame->_sprites[spriteId]->_castId);
+		}
+		// TODO: Unhandled in D<3?
+	} else if (event == kEventMouseUp) {
+		if (_vm->getVersion() > 3) {
+			// TODO: check that this is the order of script execution!
+			g_lingo->processEvent(kEventMouseUp, kCastScript, currentFrame->_sprites[spriteId]->_castId);
+			g_lingo->processEvent(kEventMouseUp, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
+		} else {
+			// Frame script overrides sprite script
+			if (!currentFrame->_sprites[spriteId]->_scriptId)
+				g_lingo->processEvent(kEventNone, kSpriteScript, currentFrame->_sprites[spriteId]->_castId + 1024);
+			else
+				g_lingo->processEvent(kEventNone, kFrameScript, currentFrame->_sprites[spriteId]->_scriptId);
+		}
+	}
 }
 
 void Lingo::runMovieScript(LEvent event) {

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -235,6 +235,12 @@ void Lingo::processFrameEvent(LEvent event) {
 
 void Lingo::processGenericEvent(LEvent event) {
 	// Movie Script
+	int id = -1;
+	if (event == kEventStart)
+		id = 0;
+	else
+		warning("STUB: processGenericEvent called for something else than kEventStart or kEventPrepareMovie, additional logic probably needed");
+	g_lingo->processEvent(event, kMovieScript, id);
 }
 
 void Lingo::processEvent(LEvent event) {
@@ -251,6 +257,7 @@ void Lingo::processEvent(LEvent event) {
 			processFrameEvent(event);
 			break;
 
+		case kEventStart:
 		case kEventStartMovie:
 		case kEventStopMovie:
 		case kEventIdle:

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -105,6 +105,39 @@ Symbol *Lingo::getHandler(Common::String &name) {
 	return _handlers[entityIndex];
 }
 
+void Lingo::primaryEventHandler(LEvent event) {
+	/* When an event occurs the message [...] is first sent to a
+	 * primary event handler: [... if exists it is executed] and the
+	 * event is passed on to other objects unless you explicitly stop
+	 * the message by including the dontPassEventCommand in the script
+	 * [D4 docs page 77]
+	 */
+	debugC(3, kDebugLingoExec, "STUB: primary event handler (%s) not implemented", _eventHandlerTypes[event]);
+	switch (event) {
+	case kEventMouseDown:
+	case kEventMouseUp:
+	case kEventKeyUp:
+	case kEventKeyDown:
+	case kEventTimeout:
+		// TODO
+		break;
+	default:
+		/* N.B.: No primary event handlers for events other than
+		 * keyup, keydown, mouseup, mousedown, timeout
+		 * [see: www.columbia.edu/itc/visualarts/r4110/s2001/handouts
+		 * /03_03_Event_Hierarchy.pdf]
+		 */
+		warning("primaryEventHandler() on event other than mouseDown, mouseUp, keyUp, keyDown, timeout");
+	}
+#ifdef DEBUG_DONTPASSEVENT
+	// #define DEBUG_DONTPASSEVENT to simulate raising of the dontPassEvent flag
+	g_lingo->dontPassEvent = true;
+	debugC(3, kDebugLingoExec, "STUB: primaryEventHandler raising dontPassEvent");
+#else
+	debugC(3, kDebugLingoExec, "STUB: primaryEventHandler not raising dontPassEvent");
+#endif
+}
+
 void Lingo::processInputEvent(LEvent event) {
 	// Primary Event handler
 	// Score Script

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -140,11 +140,16 @@ void Lingo::primaryEventHandler(LEvent event) {
 }
 
 void Lingo::processInputEvent(LEvent event) {
-	// Primary Event handler
-	// Score Script
-	// Script of Cast Member
-	// Score Script
-	// Movie Script
+	/* When the mouseDown or mouseUp occurs over a sprite, the message
+	 * goes first to the sprite script, then to the script of the cast
+	 * member, to the frame script and finally to the movie scripts.
+	 *
+	 * When the mouseDown or mouseUp doesn't occur over a sprite, the
+	 * message goes to the frame script and then to the movie script.
+	 *
+	 * When more than one movie script [...]
+	 * [D4 docs] */
+
 	Score *score = _vm->getCurrentScore();
 	Frame *currentFrame = score->_frames[score->getCurrentFrame()];
 	assert(currentFrame != nullptr);
@@ -155,25 +160,20 @@ void Lingo::processInputEvent(LEvent event) {
 	if (g_lingo->dontPassEvent) {
 		g_lingo->dontPassEvent = false;
 	} else {
-		if (event == kEventMouseDown) {
-			if (_vm->getVersion() > 3) {
-				g_lingo->processEvent(kEventMouseDown, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
-				g_lingo->processEvent(kEventMouseDown, kCastScript, currentFrame->_sprites[spriteId]->_castId);
+		if (_vm->getVersion() > 3) {
+			if (true) {
+				// TODO: Check whether occurring over a sprite
+				g_lingo->processEvent(event, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
 			}
-			// TODO: Unhandled in D<3?
+			g_lingo->processEvent(event, kCastScript, currentFrame->_sprites[spriteId]->_castId);
 		} else if (event == kEventMouseUp) {
-			if (_vm->getVersion() > 3) {
-				// TODO: check that this is the order of script execution!
-				g_lingo->processEvent(kEventMouseUp, kSpriteScript, currentFrame->_sprites[spriteId]->_scriptId);
-				g_lingo->processEvent(kEventMouseUp, kCastScript, currentFrame->_sprites[spriteId]->_castId);
-			} else {
-				// Frame script overrides sprite script
-				if (!currentFrame->_sprites[spriteId]->_scriptId)
-					g_lingo->processEvent(kEventNone, kSpriteScript, currentFrame->_sprites[spriteId]->_castId + 1024);
-				else
-					g_lingo->processEvent(kEventNone, kFrameScript, currentFrame->_sprites[spriteId]->_scriptId);
-			}
+			// Frame script overrides sprite script
+			if (!currentFrame->_sprites[spriteId]->_scriptId)
+				g_lingo->processEvent(kEventNone, kSpriteScript, currentFrame->_sprites[spriteId]->_castId + 1024);
+			else
+				g_lingo->processEvent(kEventNone, kFrameScript, currentFrame->_sprites[spriteId]->_scriptId);
 		}
+		runMovieScript(event);
 	}
 }
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -234,7 +234,6 @@ void Lingo::processFrameEvent(LEvent event) {
 }
 
 void Lingo::processGenericEvent(LEvent event) {
-	// Primary Event handler
 	// Movie Script
 }
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -146,6 +146,21 @@ void Lingo::processInputEvent(LEvent event) {
 	// Movie Script
 }
 
+void Lingo::runMovieScript(LEvent event) {
+	/* If more than one movie script handles the same message, Lingo
+	 * searches the movie scripts according to their order in the cast
+	 * window [p.81 of D4 docs]
+	 */
+
+	for (uint i = 0; i < _scripts[kMovieScript].size(); i++) {
+		// processEvent(event,
+		//			 kMovieScript,
+		//			 ?);
+		// TODO: How do know which script handles the message?
+	}
+	debugC(3, kDebugLingoExec, "STUB: processEvent(event, kMovieScript, ?)");
+}
+
 void Lingo::processFrameEvent(LEvent event) {
 	// Primary Event handler
 	// Score Script

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -175,6 +175,10 @@ void Lingo::processInputEvent(LEvent event) {
 			else
 				g_lingo->processEvent(kEventNone, kFrameScript, currentFrame->_sprites[spriteId]->_scriptId);
 		}
+		if (event == kEventKeyDown) {
+			// TODO: is the above condition necessary or useful?
+			g_lingo->processEvent(event, kGlobalScript, 0);
+		}
 		runMovieScript(event);
 	}
 }

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -203,10 +203,7 @@ void Lingo::processFrameEvent(LEvent event) {
 	 * are sent to a frame script and then a movie script.  If the
 	 * current frame has no frame script when the event occurs, the
 	 * message goes to movie scripts.
-	 * [...]
-	 * If more than one movie script handles the same message, Lingo
-	 * searches the movie scripts according to their order in the cast
-	 * window [p.81 of D4 docs]
+	 * [p.81 of D4 docs]
 	 */
 	// TODO: Same for D2-3 or not?
 	Score *score = _vm->getCurrentScore();
@@ -243,6 +240,21 @@ void Lingo::processGenericEvent(LEvent event) {
 	g_lingo->processEvent(event, kMovieScript, id);
 }
 
+void Lingo::processSpriteEvent(LEvent event) {
+	Score *score = _vm->getCurrentScore();
+	Frame *currentFrame = score->_frames[score->getCurrentFrame()];
+	if (event == kEventBeginSprite) {
+		// TODO: Check if this is also possibly a kSpriteScript?
+		for (uint16 i = 0; i < CHANNEL_COUNT; i++)
+			if (currentFrame->_sprites[i]->_enabled)
+				g_lingo->processEvent(event, kCastScript, currentFrame->_sprites[i]->_scriptId);
+
+	} else {
+		warning("STUB: processSpriteEvent called for something else than kEventBeginSprite, additional logic probably needed");
+	}
+
+}
+
 void Lingo::processEvent(LEvent event) {
 	switch (event) {
 		case kEventKeyUp:
@@ -264,7 +276,8 @@ void Lingo::processEvent(LEvent event) {
 		case kEventTimeout:
 			processGenericEvent(event);
 			break;
-
+		case kEventBeginSprite:
+			processSpriteEvent(event);
 		default:
 			warning("processEvent: Unhandled event %s", _eventHandlerTypes[event]);
 	}

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -26,6 +26,8 @@
 
 #include "director/lingo/lingo.h"
 #include "director/lingo/lingo-gr.h"
+#include "director/frame.h"
+#include "director/sprite.h"
 
 namespace Director {
 

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -404,4 +404,12 @@ void Lingo::runTests() {
 	}
 }
 
+void Lingo::executeImmediateScripts(Frame *frame) {
+	for (uint16 i = 0; i < CHANNEL_COUNT; i++) {
+		if (_vm->getCurrentScore()->_immediateActions.contains(frame->_sprites[i]->_scriptId)) {
+			g_lingo->processEvent(kEventMouseUp, kFrameScript, frame->_sprites[i]->_scriptId);
+		}
+	}
+}
+
 } // End of namespace Director

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -193,6 +193,7 @@ private:
 	// lingo-events.cpp
 private:
 	void initEventHandlerTypes();
+	void primaryEventHandler(LEvent event);
 	void processInputEvent(LEvent event);
 	void processFrameEvent(LEvent event);
 	void processGenericEvent(LEvent event);

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -579,6 +579,9 @@ private:
 	int _floatPrecision;
 
 	bool dontPassEvent;
+
+public:
+	void executeImmediateScripts(Frame *frame);
 };
 
 extern Lingo *g_lingo;

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -198,6 +198,7 @@ private:
 	void processFrameEvent(LEvent event);
 	void processGenericEvent(LEvent event);
 	void runMovieScript(LEvent event);
+	void processSpriteEvent(LEvent event);
 public:
 	ScriptType event2script(LEvent ev);
 	Symbol *getHandler(Common::String &name);

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -197,7 +197,7 @@ private:
 	void processInputEvent(LEvent event);
 	void processFrameEvent(LEvent event);
 	void processGenericEvent(LEvent event);
-
+	void runMovieScript(LEvent event);
 public:
 	ScriptType event2script(LEvent ev);
 	Symbol *getHandler(Common::String &name);

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -576,6 +576,8 @@ private:
 	DirectorEngine *_vm;
 
 	int _floatPrecision;
+
+	bool dontPassEvent;
 };
 
 extern Lingo *g_lingo;

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -199,11 +199,11 @@ private:
 	void processGenericEvent(LEvent event);
 	void runMovieScript(LEvent event);
 	void processSpriteEvent(LEvent event);
+	void processEvent(LEvent event, ScriptType st, int entityId);
 public:
 	ScriptType event2script(LEvent ev);
 	Symbol *getHandler(Common::String &name);
 
-	void processEvent(LEvent event, ScriptType st, int entityId);
 	void processEvent(LEvent event);
 
 public:

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -75,7 +75,7 @@ void DirectorEngine::loadEXE(const Common::String movie) {
 	if (!exeStream)
 		error("Failed to open EXE '%s'", getEXEName().c_str());
 
-	_lingo->processEvent(kEventStart, kMovieScript, 0);
+	_lingo->processEvent(kEventStart);
 
 	exeStream->seek(-4, SEEK_END);
 	exeStream->seek(exeStream->readUint32LE());

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1179,7 +1179,7 @@ void Score::update() {
 	_frames[_currentFrame]->executeImmediateScripts();
 
 	// Enter and exit from previous frame (Director 4)
-	_lingo->processEvent(kEventEnterFrame, kFrameScript, _frames[_currentFrame]->_actionId);
+	_lingo->processEvent(kEventEnterFrame);
 	_lingo->processEvent(kEventNone, kFrameScript, _frames[_currentFrame]->_actionId);
 	// TODO Director 6 - another order
 

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1180,7 +1180,7 @@ void Score::update() {
 
 	// Enter and exit from previous frame (Director 4)
 	_lingo->processEvent(kEventEnterFrame);
-	_lingo->processEvent(kEventNone, kFrameScript, _frames[_currentFrame]->_actionId);
+	_lingo->processEvent(kEventNone);
 	// TODO Director 6 - another order
 
 	if (_vm->getVersion() >= 6) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -72,8 +72,6 @@ Score::Score(DirectorEngine *vm) {
 	if (_vm->getVersion() <= 3) {
 		_lingo->executeScript(kMovieScript, 0);
 	}
-
-	_lingo->processEvent(kEventPrepareMovie, kMovieScript, 0);
 	_movieScriptCount = 0;
 	_labels = NULL;
 	_font = NULL;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1183,19 +1183,12 @@ void Score::update() {
 	_lingo->processEvent(kEventNone, kFrameScript, _frames[_currentFrame]->_actionId);
 	// TODO Director 6 - another order
 
-	// TODO Director 6 step: send beginSprite event to any sprites whose span begin in the upcoming frame
 	if (_vm->getVersion() >= 6) {
-		for (uint16 i = 0; i < CHANNEL_COUNT; i++) {
-			if (_frames[_currentFrame]->_sprites[i]->_enabled) {
-				// TODO: Check if this is also possibly a kSpriteScript?
-				_lingo->processEvent(kEventBeginSprite, kCastScript, _frames[_currentFrame]->_sprites[i]->_scriptId);
-			}
-		}
-	}
-
-	// TODO: Director 6 step: send prepareFrame event to all sprites and the script channel in upcoming frame
-	if (_vm->getVersion() >= 6)
+		_lingo->processEvent(kEventBeginSprite);
+		// TODO Director 6 step: send beginSprite event to any sprites whose span begin in the upcoming frame
 		_lingo->processEvent(kEventPrepareFrame);
+		// TODO: Director 6 step: send prepareFrame event to all sprites and the script channel in upcoming frame
+	}
 
 	Common::SortedArray<Label *>::iterator i;
 	if (_labels != NULL) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1195,7 +1195,7 @@ void Score::update() {
 
 	// TODO: Director 6 step: send prepareFrame event to all sprites and the script channel in upcoming frame
 	if (_vm->getVersion() >= 6)
-		_lingo->processEvent(kEventPrepareFrame, kFrameScript, _currentFrame);
+		_lingo->processEvent(kEventPrepareFrame);
 
 	Common::SortedArray<Label *>::iterator i;
 	if (_labels != NULL) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1241,7 +1241,7 @@ void Score::update() {
 		}
 	}
 
-	_lingo->processEvent(kEventExitFrame, kFrameScript, _frames[_currentFrame]->_actionId);
+	_lingo->processEvent(kEventExitFrame);
 
 	_nextFrameTime = g_system->getMillis() + (float)_currentFrameRate / 60 * 1000;
 }

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1176,7 +1176,7 @@ void Score::update() {
 	_surface->clear();
 	_surface->copyFrom(*_trailSurface);
 
-	_frames[_currentFrame]->executeImmediateScripts();
+	_lingo->executeImmediateScripts(_frames[_currentFrame]);
 
 	// Enter and exit from previous frame (Director 4)
 	_lingo->processEvent(kEventEnterFrame);


### PR DESCRIPTION
This also does slight changes to semantics that follow from the docs and stubs primaryEvent and MovieScript handling.