### PR TITLE
JANITORIAL: Hug net-specific stuff in module.mk in ifdef USE_CLOUD

### DIFF
--- a/backends/module.mk
+++ b/backends/module.mk
@@ -56,7 +56,6 @@ MODULE_OBJS += \
 	cloud/onedrive/onedrivelistdirectoryrequest.o \
 	cloud/onedrive/onedriveuploadrequest.o
 endif
-endif
 
 ifdef USE_LIBCURL
 MODULE_OBJS += \
@@ -84,6 +83,7 @@ MODULE_OBJS += \
 	networking/sdl_net/localwebserver.o \
 	networking/sdl_net/reader.o \
 	networking/sdl_net/uploadfileclienthandler.o
+endif
 endif
 
 ifdef USE_ELF_LOADER


### PR DESCRIPTION
I'm not the most familiar person so this *could* be wrong, but things like networking/sdl_net/handlers/filesajaxpagehandler.o look positively like cloud stuff to me.
