### PR TITLE
CREATE_PROJECT: Add fix for nested ifs

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1770,18 +1770,20 @@ void ProjectProvider::createModuleList(const std::string &moduleDir, const Strin
 			if (std::find(defines.begin(), defines.end(), *i) == defines.end())
 				shouldInclude.push(false);
 			else
-				shouldInclude.push(true);
+				shouldInclude.push(true && shouldInclude.top());
 		} else if (*i == "ifndef") {
 			if (tokens.size() < 2)
 				error("Malformed ifndef in " + moduleMkFile);
 			++i;
 
 			if (std::find(defines.begin(), defines.end(), *i) == defines.end())
-				shouldInclude.push(true);
+				shouldInclude.push(true && shouldInclude.top());
 			else
 				shouldInclude.push(false);
 		} else if (*i == "else") {
-			shouldInclude.top() = !shouldInclude.top();
+			bool last = shouldInclude.top();
+			shouldInclude.pop();
+			shouldInclude.push(!last && shouldInclude.top());
 		} else if (*i == "endif") {
 			if (shouldInclude.size() <= 1)
 				error("endif without ifdef found in " + moduleMkFile);


### PR DESCRIPTION
This adds a quick ~~workaround~~ fix so that any if blocks nested inside a if block with an unmet condition are handled with push(false) even if their condition is satisfied.

For example, before adding this, upon running create_project.exe --msvc --disable-cloud the block inside

ifdef USE_CLOUD
ifdef USE_LIBCURL
... 
endif
endif

would get evaluated (with unpredictable results) since it was inside USE_LIBCURL (=1).

It now works for me ~~(after applying #962).~~
