### PR TITLE
SCI32: Proper implementation of kObjectIntersect

### DIFF
--- a/engines/sci/engine/kgraphics32.cpp
+++ b/engines/sci/engine/kgraphics32.cpp
@@ -245,9 +245,8 @@ reg_t kSetPalStyleRange(EngineState *s, int argc, reg_t *argv) {
 }
 
 reg_t kObjectIntersect(EngineState *s, int argc, reg_t *argv) {
-	Common::Rect objRect1 = g_sci->_gfxCompare->getNSRect(argv[0]);
-	Common::Rect objRect2 = g_sci->_gfxCompare->getNSRect(argv[1]);
-	return make_reg(0, objRect1.intersects(objRect2));
+	uint16 intersectArea = g_sci->_gfxFrameout->kernelObjectIntersection(argv[0], argv[1]);
+	return make_reg(0, intersectArea);
 }
 
 reg_t kIsOnMe(EngineState *s, int argc, reg_t *argv) {

--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -1283,6 +1283,27 @@ bool GfxFrameout::kernelSetNowSeen(const reg_t screenItemObject) const {
 	return true;
 }
 
+const Common::Rect GfxFrameout::getObjectNSRect(const reg_t object) const {
+	const reg_t planeObject = readSelector(_segMan, object, SELECTOR(plane));
+	Plane *plane = _planes.findByObject(planeObject);
+	if (plane == nullptr)
+		error("getObjectNSRect: Plane %04x:%04x not found for screen item %04x:%04x", PRINT_REG(planeObject), PRINT_REG(object));
+
+	ScreenItem *screenItem = plane->_screenItemList.findByObject(object);
+	if (screenItem == nullptr)
+		error("getObjectNSRect: Screen item not found for object %04x:%04x", PRINT_REG(object));
+
+	return screenItem->getNowSeenRect(*plane);
+}
+
+uint16 GfxFrameout::kernelObjectIntersection(const reg_t object1, const reg_t object2) const {
+	const Common::Rect nowSeen1 = getObjectNSRect(object1);
+	const Common::Rect nowSeen2 = getObjectNSRect(object2);
+	Common::Rect intersection = nowSeen1;
+	intersection.clip(nowSeen2);
+	return intersection.width() * intersection.height();
+}
+
 void GfxFrameout::remapMarkRedraw() {
 	for (PlaneList::const_iterator it = _planes.begin(); it != _planes.end(); ++it) {
 		Plane *p = *it;

--- a/engines/sci/graphics/frameout.h
+++ b/engines/sci/graphics/frameout.h
@@ -96,6 +96,10 @@ public:
 	void kernelUpdateScreenItem(const reg_t object);
 	void kernelDeleteScreenItem(const reg_t object);
 	bool kernelSetNowSeen(const reg_t screenItemObject) const;
+	uint16 kernelObjectIntersection(const reg_t object1, const reg_t object2) const;
+
+private:
+	const Common::Rect getObjectNSRect(const reg_t object) const;
 
 #pragma mark -
 #pragma mark Planes


### PR DESCRIPTION
This a rarely used kernel function, which is needed for the arcade
games in PQ4.

Fixes Trac #9855