### PR TITLE
COMMON: Change way the Singleton instances are instantiated

### DIFF
--- a/backends/cloud/cloudmanager.cpp
+++ b/backends/cloud/cloudmanager.cpp
@@ -32,11 +32,6 @@
 #include "backends/networking/sdl_net/localwebserver.h"
 #endif
 
-namespace Common {
-
-DECLARE_SINGLETON(Cloud::CloudManager);
-
-}
 
 namespace Cloud {
 

--- a/backends/fs/ds/ds-fs-factory.cpp
+++ b/backends/fs/ds/ds-fs-factory.cpp
@@ -28,9 +28,6 @@
 #include "backends/fs/ds/ds-fs.h"
 #include "dsmain.h" //for the isGBAMPAvailable() function
 
-namespace Common {
-DECLARE_SINGLETON(DSFilesystemFactory);
-}
 
 AbstractFSNode *DSFilesystemFactory::makeRootFileNode() const {
 	if (DS::isGBAMPAvailable()) {

--- a/backends/fs/ps2/ps2-fs-factory.cpp
+++ b/backends/fs/ps2/ps2-fs-factory.cpp
@@ -28,10 +28,6 @@
 #include "backends/fs/ps2/ps2-fs-factory.h"
 #include "backends/fs/ps2/ps2-fs.h"
 
-namespace Common {
-DECLARE_SINGLETON(Ps2FilesystemFactory);
-}
-
 AbstractFSNode *Ps2FilesystemFactory::makeRootFileNode() const {
 	return new Ps2FilesystemNode();
 }

--- a/backends/fs/psp/psp-fs-factory.cpp
+++ b/backends/fs/psp/psp-fs-factory.cpp
@@ -44,10 +44,6 @@
 
 #include <unistd.h>
 
-namespace Common {
-DECLARE_SINGLETON(PSPFilesystemFactory);
-}
-
 AbstractFSNode *PSPFilesystemFactory::makeRootFileNode() const {
 	return new PSPFilesystemNode();
 }

--- a/backends/fs/wii/wii-fs-factory.cpp
+++ b/backends/fs/wii/wii-fs-factory.cpp
@@ -43,10 +43,6 @@
 #include <smb.h>
 #endif
 
-namespace Common {
-DECLARE_SINGLETON(WiiFilesystemFactory);
-}
-
 WiiFilesystemFactory::WiiFilesystemFactory() :
 	_dvdMounted(false),
 	_smbMounted(false),

--- a/backends/graphics/opengl/shader.cpp
+++ b/backends/graphics/opengl/shader.cpp
@@ -27,10 +27,6 @@
 #include "common/textconsole.h"
 #include "common/util.h"
 
-namespace Common {
-DECLARE_SINGLETON(OpenGL::ShaderManager);
-}
-
 namespace OpenGL {
 
 namespace {

--- a/backends/networking/curl/connectionmanager.cpp
+++ b/backends/networking/curl/connectionmanager.cpp
@@ -29,12 +29,6 @@
 #include "common/timer.h"
 #include <curl/curl.h>
 
-namespace Common {
-
-DECLARE_SINGLETON(Networking::ConnectionManager);
-
-}
-
 namespace Networking {
 
 ConnectionManager::ConnectionManager(): _multi(0), _timerStarted(false), _frame(0) {

--- a/backends/networking/sdl_net/localwebserver.cpp
+++ b/backends/networking/sdl_net/localwebserver.cpp
@@ -51,9 +51,6 @@
 
 namespace Common {
 class MemoryReadWriteStream;
-
-DECLARE_SINGLETON(Networking::LocalWebserver);
-
 }
 
 namespace Networking {

--- a/backends/platform/psp/display_manager.cpp
+++ b/backends/platform/psp/display_manager.cpp
@@ -62,10 +62,6 @@ const OSystem::GraphicsMode DisplayManager::_supportedModes[] = {
 
 // Class VramAllocator -----------------------------------
 
-namespace Common {
-DECLARE_SINGLETON(VramAllocator);
-}
-
 //#define __PSP_DEBUG_FUNCS__	/* For debugging the stack */
 //#define __PSP_DEBUG_PRINT__
 

--- a/backends/platform/psp/powerman.cpp
+++ b/backends/platform/psp/powerman.cpp
@@ -30,10 +30,6 @@
 //#define __PSP_DEBUG_PRINT__
 #include "backends/platform/psp/trace.h"
 
-namespace Common {
-DECLARE_SINGLETON(PowerManager);
-}
-
 // Function to debug the Power Manager (we have no output to screen)
 inline void PowerManager::debugPM() {
 	PSP_DEBUG_PRINT("PM status[%d]. Listcount[%d]. CriticalCount[%d]. ThreadId[%x]. Error[%d]\n",

--- a/backends/platform/psp/rtc.cpp
+++ b/backends/platform/psp/rtc.cpp
@@ -34,9 +34,6 @@
 
 
 // Class PspRtc ---------------------------------------------------------------
-namespace Common {
-DECLARE_SINGLETON(PspRtc);
-}
 
 void PspRtc::init() {						// init our starting ticks
 	uint32 ticks[2];

--- a/backends/plugins/elf/memory-manager.cpp
+++ b/backends/plugins/elf/memory-manager.cpp
@@ -29,10 +29,6 @@
 #include "common/util.h"
 #include <malloc.h>
 
-namespace Common {
-DECLARE_SINGLETON(ELFMemoryManager);
-}
-
 ELFMemoryManager::ELFMemoryManager() :
 	_heap(0), _heapSize(0), _heapAlign(0),
 	_trackAllocs(false), _measuredSize(0), _measuredAlign(0),

--- a/backends/plugins/elf/shorts-segment-manager.cpp
+++ b/backends/plugins/elf/shorts-segment-manager.cpp
@@ -33,10 +33,6 @@ extern char __plugin_hole_start;	// Indicates start of hole in program file for 
 extern char __plugin_hole_end;		// Indicates end of hole in program file
 extern char _gp[];					// Value of gp register
 
-namespace Common {
-DECLARE_SINGLETON(ShortSegmentManager);	// For singleton
-}
-
 ShortSegmentManager::ShortSegmentManager() {
 	_shortsStart = &__plugin_hole_start ;	//shorts segment begins at the plugin hole we made when linking
 	_shortsEnd = &__plugin_hole_end;		//and ends at the end of that hole.

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -446,10 +446,6 @@ void PluginManager::addToPluginsInMemList(Plugin *plugin) {
 
 #include "engines/metaengine.h"
 
-namespace Common {
-DECLARE_SINGLETON(EngineManager);
-}
-
 /**
  * This function works for both cached and uncached PluginManagers.
  * For the cached version, most of the logic here will short circuit.
@@ -538,10 +534,6 @@ const EnginePlugin::List &EngineManager::getPlugins() const {
 // Music plugins
 
 #include "audio/musicplugin.h"
-
-namespace Common {
-DECLARE_SINGLETON(MusicManager);
-}
 
 const MusicPlugin::List &MusicManager::getPlugins() const {
 	return (const MusicPlugin::List &)PluginManager::instance().getPlugins(PLUGIN_TYPE_MUSIC);

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -284,6 +284,4 @@ void SearchManager::clear() {
 	addDirectory(".", ".", -2);
 }
 
-DECLARE_SINGLETON(SearchManager);
-
 } // namespace Common

--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -36,8 +36,6 @@ static bool isValidDomainName(const Common::String &domName) {
 
 namespace Common {
 
-DECLARE_SINGLETON(ConfigManager);
-
 char const *const ConfigManager::kApplicationDomain = "scummvm";
 char const *const ConfigManager::kTransientDomain = "__TRANSIENT";
 

--- a/common/coroutines.cpp
+++ b/common/coroutines.cpp
@@ -33,8 +33,6 @@ namespace Common {
 /** Helper null context instance */
 CoroContext nullContext = NULL;
 
-DECLARE_SINGLETON(CoroutineScheduler);
-
 #ifdef COROUTINE_DEBUG
 namespace {
 /** Count of active coroutines */

--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -34,8 +34,6 @@ bool gDebugChannelsOnly = false;
 
 namespace Common {
 
-DECLARE_SINGLETON(DebugManager);
-
 namespace {
 
 struct DebugLevelComperator {

--- a/common/osd_message_queue.cpp
+++ b/common/osd_message_queue.cpp
@@ -24,8 +24,6 @@
 #include "common/system.h"
 
 namespace Common {
-
-DECLARE_SINGLETON(OSDMessageQueue);
 	
 OSDMessageQueue::OSDMessageQueue() : _lastUpdate(0) {
 }

--- a/common/singleton.h
+++ b/common/singleton.h
@@ -88,14 +88,7 @@ protected:
 	static T *_singleton;
 };
 
-/**
- * Note that you need to use this macro from the Common namespace.
- *
- * This is because C++ requires initial explicit specialization
- * to be placed in the same namespace as the template.
- */
-#define DECLARE_SINGLETON(T) \
-	template<> T *Singleton<T>::_singleton = 0
+template<class T> T *Singleton<T>::_singleton = 0;
 
 } // End of namespace Common
 

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -40,8 +40,6 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(TranslationManager);
-
 bool operator<(const TLanguage &l, const TLanguage &r) {
 	return strcmp(l.name, r.name) < 0;
 }

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -133,10 +133,6 @@ bool ChainedGamesManager::pop(Common::String &target, int &slot) {
 	return true;
 }
 
-namespace Common {
-DECLARE_SINGLETON(ChainedGamesManager);
-}
-
 Engine::Engine(OSystem *syst)
 	: _system(syst),
 		_mixer(_system->getMixer()),

--- a/engines/lure/sound.cpp
+++ b/engines/lure/sound.cpp
@@ -31,10 +31,6 @@
 #include "common/endian.h"
 #include "audio/midiparser.h"
 
-namespace Common {
-DECLARE_SINGLETON(Lure::SoundManager);
-}
-
 namespace Lure {
 
 //#define SOUND_CROP_CHANNELS

--- a/engines/pegasus/gamestate.cpp
+++ b/engines/pegasus/gamestate.cpp
@@ -30,10 +30,6 @@
 #include "pegasus/gamestate.h"
 #include "pegasus/scoring.h"
 
-namespace Common {
-DECLARE_SINGLETON(Pegasus::GameStateManager);
-}
-
 namespace Pegasus {
 
 Common::Error GameStateManager::writeGameState(Common::WriteStream *stream) {

--- a/engines/pegasus/input.cpp
+++ b/engines/pegasus/input.cpp
@@ -30,10 +30,6 @@
 #include "pegasus/input.h"
 #include "pegasus/pegasus.h"
 
-namespace Common {
-DECLARE_SINGLETON(Pegasus::InputDeviceManager);
-}
-
 namespace Pegasus {
 
 InputDeviceManager::InputDeviceManager() {

--- a/engines/sword25/gfx/animationtemplateregistry.cpp
+++ b/engines/sword25/gfx/animationtemplateregistry.cpp
@@ -34,10 +34,6 @@
 #include "sword25/gfx/animationtemplateregistry.h"
 #include "sword25/gfx/animationtemplate.h"
 
-namespace Common {
-DECLARE_SINGLETON(Sword25::AnimationTemplateRegistry);
-}
-
 namespace Sword25 {
 
 bool AnimationTemplateRegistry::persist(OutputPersistenceBlock &writer) {

--- a/engines/sword25/math/regionregistry.cpp
+++ b/engines/sword25/math/regionregistry.cpp
@@ -34,10 +34,6 @@
 #include "sword25/math/regionregistry.h"
 #include "sword25/math/region.h"
 
-namespace Common {
-DECLARE_SINGLETON(Sword25::RegionRegistry);
-}
-
 namespace Sword25 {
 
 bool RegionRegistry::persist(OutputPersistenceBlock &writer) {

--- a/engines/sword25/sword25.cpp
+++ b/engines/sword25/sword25.cpp
@@ -50,9 +50,6 @@
 
 #include "sword25/gfx/animationtemplateregistry.h"	// Needed so we can destroy the singleton
 #include "sword25/gfx/renderobjectregistry.h"		// Needed so we can destroy the singleton
-namespace Common {
-DECLARE_SINGLETON(Sword25::RenderObjectRegistry);
-}
 #include "sword25/math/regionregistry.h"			// Needed so we can destroy the singleton
 
 namespace Sword25 {

--- a/engines/testbed/config-params.cpp
+++ b/engines/testbed/config-params.cpp
@@ -25,10 +25,6 @@
 
 #include "testbed/config-params.h"
 
-namespace Common {
-DECLARE_SINGLETON(Testbed::ConfigParams);
-}
-
 namespace Testbed {
 
 ConfigParams::ConfigParams() {

--- a/engines/wintermute/base/base_engine.cpp
+++ b/engines/wintermute/base/base_engine.cpp
@@ -32,9 +32,6 @@
 #include "engines/wintermute/wintermute.h"
 #include "engines/wintermute/system/sys_class_registry.h"
 #include "common/system.h"
-namespace Common {
-DECLARE_SINGLETON(Wintermute::BaseEngine);
-}
 
 namespace Wintermute {
 

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -25,10 +25,6 @@
 #include "common/system.h"
 #include "common/stack.h"
 
-namespace Common {
-DECLARE_SINGLETON(Graphics::CursorManager);
-}
-
 namespace Graphics {
 
 CursorManager::~CursorManager() {

--- a/graphics/fontman.cpp
+++ b/graphics/fontman.cpp
@@ -26,10 +26,6 @@
 
 #include "common/translation.h"
 
-namespace Common {
-DECLARE_SINGLETON(Graphics::FontManager);
-}
-
 namespace Graphics {
 
 FORWARD_DECLARE_FONT(g_sysfont);

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -668,9 +668,5 @@ Font *loadTTFFont(Common::SeekableReadStream &stream, int size, TTFSizeMode size
 
 } // End of namespace Graphics
 
-namespace Common {
-DECLARE_SINGLETON(Graphics::TTFLibrary);
-} // End of namespace Common
-
 #endif
 

--- a/graphics/yuv_to_rgb.cpp
+++ b/graphics/yuv_to_rgb.cpp
@@ -86,10 +86,6 @@
 #include "graphics/surface.h"
 #include "graphics/yuv_to_rgb.h"
 
-namespace Common {
-DECLARE_SINGLETON(Graphics::YUVToRGBManager);
-}
-
 namespace Graphics {
 
 class YUVToRGBLookup {

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -25,10 +25,6 @@
 
 #ifdef ENABLE_EVENTRECORDER
 
-namespace Common {
-DECLARE_SINGLETON(GUI::EventRecorder);
-}
-
 #include "common/debug-channels.h"
 #include "backends/timer/sdl/sdl-timer.h"
 #include "backends/mixer/sdl/sdl-mixer.h"

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -41,10 +41,6 @@
 
 #include "graphics/cursorman.h"
 
-namespace Common {
-DECLARE_SINGLETON(GUI::GuiManager);
-}
-
 namespace GUI {
 
 enum {


### PR DESCRIPTION
When compiling the current code with clang from a recent XCode version on macOS we get tons of warnings like the following one:
```
./common/singleton.h:70:8: warning: instantiation of variable 'Common::Singleton<GUI::EventRecorder>::_singleton' required here, but no definition is available     [-Wundefined-var-template]
                if (!_singleton)
                    ^
backends/platform/sdl/sdl.cpp:122:9: note: in instantiation of member function 'Common::Singleton<GUI::EventRecorder>::instance' requested here
        delete g_eventRec.getTimerManager();
              ^
./gui/EventRecorder.h:51:41: note: expanded from macro 'g_eventRec'
#define g_eventRec (GUI::EventRecorder::instance())
                                        ^
./common/singleton.h:88:12: note: forward declaration of template entity is here
        static T *_singleton;
                  ^
```

One way to fix those warnings is to replace all the specialisation instantiations (using the DECLARE_SINGLETON() macro) with instantiation of the template variable in singleton.h directly.

This is what this PR does, and I have tested that it compiles and works with gcc as old as 4.0 as well as clang. Somebody should check that Visual Studio is happy with this code as well before the PR gets merged.