### PR TITLE
CMD: Fix batch adding of games

### DIFF
--- a/README
+++ b/README
@@ -1361,10 +1361,19 @@ arguments -- see the next section.
   -z, --list-games         Display list of supported games and exit
   -t, --list-targets       Display list of configured targets and exit
   --list-saves=TARGET      Display a list of saved games for the game (TARGET) specified
-  --auto-detect            Display a list of games from current or specified
-                           directory and start the first one found. Use
-                           --path=PATH before--auto-detect to specify a
-                           directory.
+  -a, --add                Add all games from current or specified directory.
+                           If --game=ID is passed only the game with id ID is
+                           added. See also --detect.
+                           Use --path=PATH before -a, --add to specify a directory.
+  --detect                 Display a list of games with their ID from current or
+                           specified directory without adding it to the config.
+                           Use --path=PATH before --detect to specify a directory.
+  --game=ID                In combination with --add or --detect only adds or attempts to
+                           detect the game with id ID.
+  --auto-detect            Display a list of games from current or specified directory
+                           and start the first one. Use --path=PATH before --auto-detect
+                           to specify a directory.
+  --recursive              In combination with --add recurse down all subdirectories
   --console                Enable the console window (default: enabled) (Windows only)
 
   -c, --config=CONFIG      Use alternate configuration file

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -878,9 +878,9 @@ static Common::String detectGames(Common::String path, Common::String recursiveO
 	GameList candidates = recListGames(dir, recursive);
 
 	if (candidates.empty()) {
-		printf("ScummVM could not find any game in %s\n", dir.getPath().c_str());
+		printf("WARNING: ScummVM could not find any game in %s\n", dir.getPath().c_str());
 		if (!recursive) {
-			printf("Consider using --recursive to search inside subdirectories\n");
+			printf("WARNING: Consider using --recursive *before* --add or --detect to search inside subdirectories\n");
 		}
 		return Common::String();
 	}
@@ -1167,15 +1167,18 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		// If we get a non-empty ID, we store it in command so that it gets processed together with the
 		// other command line options below.
 		if (settings["recursive"] == "true") {
-			printf("Autodetection not supported with --recursive; are you sure you didn't want --detect?\n");
+			printf("ERROR: Autodetection not supported with --recursive; are you sure you didn't want --detect?\n");
+			err = Common::kUnknownError;
 			return true;
 			// There is not a particularly good technical reason for this.
 			// From an UX point of view, however, it might get confusing.
 			// Consider removing this if consensus says otherwise.
 		} else {
 			command = detectGames(settings["path"], settings["recursive"]);
-			if (command.empty())
+			if (command.empty()) {
+				err = Common::kNoGameDataFoundError;
 				return true;
+			}
 		}
 	} else if (command == "detect") {
 		detectGames(settings["path"], settings["recursive"]);

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -884,12 +884,11 @@ static Common::String detectGames(Common::String path, Common::String recursiveO
 		}
 		return Common::String();
 	}
-
-	// Print all the candidate found
-	printf("ID                   Description\n");
-	printf("-------------------- ---------------------------------------------------------\n");
+	// TODO this is not especially pretty
+	printf("ID             Description                                                Full Path\n");
+	printf("-------------- ---------------------------------------------------------- ---------------------------------------------------------\n");
 	for (GameList::iterator v = candidates.begin(); v != candidates.end(); ++v) {
-		printf("%-20s %s\n", v->gameid().c_str(), v->description().c_str());
+		printf("%-14s %-58s %s\n", v->gameid().c_str(), v->description().c_str(), (*v)["path"].c_str());
 	}
 
 	return candidates[0].gameid();

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -72,13 +72,15 @@ static const char HELP_STRING[] =
 	"  -a, --add                Add all games from current or specified directory.\n"
 	"                           If --game=ID is passed only the game with id ID is added. See also --detect\n"
 	"                           Use --path=PATH before -a, --add to specify a directory.\n"
-	"  --game=ID                In combination with --add, only adds the game with id ID. See also --detect\n"
-	"  --detect                 Display a list of games with their ID from current or specified directory\n"
-	"                           without adding it to the config. Use --path=PATH before --detect\n"
-	"                           to specify a directory.\n"
+	"  --detect                 Display a list of games with their ID from current or\n"
+	"                           specified directory without adding it to the config.\n"
+	"                           Use --path=PATH before --detect to specify a directory.\n"
+	"  --game=ID                In combination with --add or --detect only adds or attempts to\n"
+	"                           detect the game with id ID.\n"
 	"  --auto-detect            Display a list of games from current or specified directory\n"
 	"                           and start the first one. Use --path=PATH before --auto-detect\n"
 	"                           to specify a directory.\n"
+	"  --recursive              In combination with --add recurse down all subdirectories\n"
 #if defined(WIN32) && !defined(_WIN32_WCE) && !defined(__SYMBIAN32__)
 	"  --console                Enable the console window (default:enabled)\n"
 #endif
@@ -604,6 +606,9 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			DO_LONG_OPTION("game")
 			END_OPTION
 
+			DO_LONG_OPTION_BOOL("recursive")
+			END_OPTION
+
 			DO_LONG_OPTION("themepath")
 				Common::FSNode path(option);
 				if (!path.exists()) {
@@ -813,14 +818,10 @@ static GameList getGameList(Common::FSNode dir) {
 
 	// detect Games
 	GameList candidates(EngineMan.detectGames(files));
-	if (candidates.empty()) {
-		printf("ScummVM could not find any game in %s\n", dir.getPath().c_str());
-	} else {
-		Common::String dataPath = dir.getPath();
-		// add game data path
-		for (GameList::iterator v = candidates.begin(); v != candidates.end(); ++v) {
-			(*v)["path"] = dataPath;
-		}
+	Common::String dataPath = dir.getPath();
+	// add game data path
+	for (GameList::iterator v = candidates.begin(); v != candidates.end(); ++v) {
+		(*v)["path"] = dataPath;
 	}
 	return candidates;
 }
@@ -851,15 +852,38 @@ static bool addGameToConf(const GameDescriptor &gd) {
 	return true;
 }
 
+static GameList recListGames(Common::FSNode dir, bool recursive) {
+	GameList list = getGameList(dir);
+
+	if (recursive) {
+		Common::FSList files;
+		dir.getChildren(files, Common::FSNode::kListDirectoriesOnly);
+		for (Common::FSList::const_iterator file = files.begin(); file != files.end(); ++file) {
+			GameList rec = recListGames(*file, recursive);
+			for (GameList::const_iterator game = rec.begin(); game != rec.end(); ++game)
+				list.push_back(*game);
+		}
+	}
+
+	return list;
+}
+
 /** Display all games in the given directory, return ID of first detected game */
-static Common::String detectGames(Common::String path) {
+static Common::String detectGames(Common::String path, Common::String recursiveOptStr) {
 	if (path.empty())
 		path = ".";
+	bool recursive = (recursiveOptStr == "true");
 	//Current directory
 	Common::FSNode dir(path);
-	GameList candidates = getGameList(dir);
-	if (candidates.empty())
+	GameList candidates = recListGames(dir, recursive);
+
+	if (candidates.empty()) {
+		printf("ScummVM could not find any game in %s\n", dir.getPath().c_str());
+		if (!recursive) {
+			printf("Consider using --recursive to search inside subdirectories\n");
+		}
 		return Common::String();
+	}
 
 	// Print all the candidate found
 	printf("ID                   Description\n");
@@ -871,7 +895,7 @@ static Common::String detectGames(Common::String path) {
 	return candidates[0].gameid();
 }
 
-static int recAddGames(Common::FSNode dir, Common::String game, bool recursive=true) {
+static int recAddGames(Common::FSNode dir, Common::String game, bool recursive) {
 	int count = 0;
 	GameList list = getGameList(dir);
 	for (GameList::iterator v = list.begin(); v != list.end(); ++v) {
@@ -890,7 +914,7 @@ static int recAddGames(Common::FSNode dir, Common::String game, bool recursive=t
 		Common::FSList files;
 		if (dir.getChildren(files, Common::FSNode::kListDirectoriesOnly)) {
 			for (Common::FSList::const_iterator file = files.begin(); file != files.end(); ++file) {
-				count += recAddGames(*file, game);
+				count += recAddGames(*file, game, recursive);
 			}
 		}
 	}
@@ -898,13 +922,17 @@ static int recAddGames(Common::FSNode dir, Common::String game, bool recursive=t
 	return count;
 }
 
-static bool addGames(Common::String path, Common::String game) {
+static bool addGames(Common::String path, Common::String game, Common::String recursiveOptStr) {
 	if (path.empty())
 		path = ".";
+	bool recursive = (recursiveOptStr == "true");
 	//Current directory
 	Common::FSNode dir(path);
-	int added = recAddGames(dir, game);
+	int added = recAddGames(dir, game, recursive);
 	printf("Added %d games\n", added);
+	if (added == 0 && recursive == false) {
+		printf("Consider using --recursive to search inside subdirectories\n");
+	}
 	ConfMan.flushToDisk();
 	return true;
 }
@@ -1138,15 +1166,23 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		// If auto-detects fails (returns an empty ID) return true to close ScummVM.
 		// If we get a non-empty ID, we store it in command so that it gets processed together with the
 		// other command line options below.
-		command = detectGames(settings["path"]);
-		if (command.empty())
+		if (settings["recursive"] == "true") {
+			printf("Autodetection not supported with --recursive; are you sure you didn't want --detect?\n");
 			return true;
+			// There is not a particularly good technical reason for this.
+			// From an UX point of view, however, it might get confusing.
+			// Consider removing this if consensus says otherwise.
+		} else {
+			command = detectGames(settings["path"], settings["recursive"]);
+			if (command.empty())
+				return true;
+		}
 	} else if (command == "detect") {
-		// Ignore the return value of detectGame.
-		detectGames(settings["path"]);
+		detectGames(settings["path"], settings["recursive"]);
 		return true;
 	} else if (command == "add") {
-		return (addGames(settings["path"], settings["game"]) > 0);
+		addGames(settings["path"], settings["game"], settings["recursive"]);
+		return true;
 	}
 #ifdef DETECTOR_TESTING_HACK
 	else if (command == "test-detector") {


### PR DESCRIPTION
This changes the behaviour of batch adding as discussed in PR926:
https://github.com/scummvm/scummvm/pull/926#discussion_r126132411

Moreover, it adds a --recursive option that controls whether the search is recursive or not.

New semantics is as follows:
    
```
  [-p <dir>] --add                 adds all games in <dir> or working 
                                   dir

  [-p <dir>] --detect              enumerates dectected games in <dir> 
                                   with their ids

  [-p <dir>] --game <id> --add     adds just game <id> if found in <dir>
                                   and not already added

  [-p <dir>] --recursive --add     adds all games in <dir> and subdirs
                                   if not already added

  [-p <dir>] --recursive --game <id> --add    
                                   adds just game <id> if found in <dir>
                                   or its subdirs and not already added

  [-p <dir>] --recursive --detect  enumerates games in <dir> and subdirs

  [-p <dir>] --auto-detect
                                   launches the first game found in <dir>

  [-p <dir>] --recursive --auto-detect
                                   displays error message

```

1. I would appreciate feedback, especially concerning the very last one.

The reason for the displaying an error message when attempting to do 
autodetection on a whole tree is mainly one of UX, IMO it *might* get
confusing on a sufficiently large/deep tree.

The relevant if() can be removed safely if you guys believe it's not the case.

2. Do you have any comments re: message strings, either?

3. As for the rest, if works well enough for me, but I would love if someone could give it a quick spin, especially on a Mac or some exotic platform.

Thanks