### PR TITLE
VIDEO: Allow setting the mixer sound type used to play audio tracks

### DIFF
--- a/engines/access/video/movie_decoder.cpp
+++ b/engines/access/video/movie_decoder.cpp
@@ -152,7 +152,7 @@ bool AccessVIDMovieDecoder::loadStream(Common::SeekableReadStream *stream) {
 				soundblasterRate = _stream->readByte();
 				audioSampleRate = 1000000 / (256 - soundblasterRate);
 
-				_audioTrack = new StreamAudioTrack(audioSampleRate);
+				_audioTrack = new StreamAudioTrack(audioSampleRate, getSoundType());
 				addTrack(_audioTrack);
 
 				_stream->seek(chunkStartOffset); // seek back
@@ -194,7 +194,7 @@ bool AccessVIDMovieDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	// If sample rate was found, create an audio track
 	if (audioSampleRate) {
-		_audioTrack = new StreamAudioTrack(audioSampleRate);
+		_audioTrack = new StreamAudioTrack(audioSampleRate, getSoundType());
 		addTrack(_audioTrack);
 	}
 
@@ -641,7 +641,8 @@ bool AccessVIDMovieDecoder::StreamVideoTrack::hasDirtyPalette() const {
 	return _dirtyPalette;
 }
 
-AccessVIDMovieDecoder::StreamAudioTrack::StreamAudioTrack(uint32 sampleRate) {
+AccessVIDMovieDecoder::StreamAudioTrack::StreamAudioTrack(uint32 sampleRate, Audio::Mixer::SoundType soundType) :
+		AudioTrack(soundType) {
 	_totalAudioQueued = 0; // currently 0 milliseconds queued
 
 	_sampleRate  = sampleRate;

--- a/engines/access/video/movie_decoder.h
+++ b/engines/access/video/movie_decoder.h
@@ -119,7 +119,7 @@ private:
 
 	class StreamAudioTrack : public AudioTrack {
 	public:
-		StreamAudioTrack(uint32 sampleRate);
+		StreamAudioTrack(uint32 sampleRate, Audio::Mixer::SoundType soundType);
 		~StreamAudioTrack();
 
 		void queueAudio(Common::SeekableReadStream *stream, byte chunkId);

--- a/engines/kyra/vqa.cpp
+++ b/engines/kyra/vqa.cpp
@@ -105,7 +105,7 @@ bool VQADecoder::loadStream(Common::SeekableReadStream *stream) {
 		case MKTAG('V','Q','H','D'):
 			handleVQHD(_fileStream);
 			if (_header.flags & 1) {
-				audioTrack = new VQAAudioTrack(&_header);
+				audioTrack = new VQAAudioTrack(&_header, getSoundType());
 				addTrack(audioTrack);
 			}
 			foundVQHD = true;
@@ -282,7 +282,8 @@ void VQADecoder::readNextPacket() {
 
 // -----------------------------------------------------------------------
 
-VQADecoder::VQAAudioTrack::VQAAudioTrack(const VQAHeader *header) {
+VQADecoder::VQAAudioTrack::VQAAudioTrack(const VQAHeader *header, Audio::Mixer::SoundType soundType) :
+		AudioTrack(soundType) {
 	_audioStream = Audio::makeQueuingAudioStream(header->freq, false);
 }
 

--- a/engines/kyra/vqa.h
+++ b/engines/kyra/vqa.h
@@ -80,7 +80,7 @@ private:
 
 	class VQAAudioTrack : public AudioTrack {
 	public:
-		VQAAudioTrack(const VQAHeader *header);
+		VQAAudioTrack(const VQAHeader *header, Audio::Mixer::SoundType soundType);
 		~VQAAudioTrack();
 
 		void handleSND0(Common::SeekableReadStream *stream);

--- a/engines/sci/graphics/video32.cpp
+++ b/engines/sci/graphics/video32.cpp
@@ -326,8 +326,10 @@ void SEQPlayer::play(const Common::String &fileName, const int16 numTicks, const
 #pragma mark AVIPlayer
 
 AVIPlayer::AVIPlayer(EventManager *eventMan) :
-	VideoPlayer(eventMan, new Video::AVIDecoder(Audio::Mixer::kSFXSoundType)),
-	_status(kAVINotOpen) {}
+	VideoPlayer(eventMan, new Video::AVIDecoder()),
+	_status(kAVINotOpen) {
+	_decoder->setSoundType(Audio::Mixer::kSFXSoundType);
+}
 
 AVIPlayer::IOStatus AVIPlayer::open(const Common::String &fileName) {
 	if (_status != kAVINotOpen) {
@@ -970,11 +972,13 @@ void VMDPlayer::restrictPalette(const uint8 startColor, const int16 endColor) {
 #pragma mark DuckPlayer
 
 DuckPlayer::DuckPlayer(EventManager *eventMan, SegManager *segMan) :
-	VideoPlayer(eventMan, new Video::AVIDecoder(Audio::Mixer::kSFXSoundType)),
+	VideoPlayer(eventMan, new Video::AVIDecoder()),
 	_plane(nullptr),
 	_status(kDuckClosed),
 	_volume(Audio::Mixer::kMaxChannelVolume),
-	_doFrameOut(false) {}
+	_doFrameOut(false) {
+	_decoder->setSoundType(Audio::Mixer::kSFXSoundType);
+}
 
 void DuckPlayer::open(const GuiResourceId resourceId, const int displayMode, const int16 x, const int16 y) {
 	if (_status != kDuckClosed) {

--- a/engines/sherlock/scalpel/3do/movie_decoder.cpp
+++ b/engines/sherlock/scalpel/3do/movie_decoder.cpp
@@ -146,7 +146,7 @@ bool Scalpel3DOMovieDecoder::loadStream(Common::SeekableReadStream *stream) {
 				_stream->readUint32BE(); // Unknown 0x00000004 compression ratio?
 				_stream->readUint32BE(); // Unknown 0x00000A2C
 
-				_audioTrack = new StreamAudioTrack(audioCodecTag, audioSampleRate, audioChannels);
+				_audioTrack = new StreamAudioTrack(audioCodecTag, audioSampleRate, audioChannels, getSoundType());
 				addTrack(_audioTrack);
 				break;
 
@@ -393,7 +393,8 @@ void Scalpel3DOMovieDecoder::StreamVideoTrack::decodeFrame(Common::SeekableReadS
 	_curFrame++;
 }
 
-Scalpel3DOMovieDecoder::StreamAudioTrack::StreamAudioTrack(uint32 codecTag, uint32 sampleRate, uint32 channels) {
+Scalpel3DOMovieDecoder::StreamAudioTrack::StreamAudioTrack(uint32 codecTag, uint32 sampleRate, uint32 channels, Audio::Mixer::SoundType soundType) :
+		AudioTrack(soundType) {
 	switch (codecTag) {
 	case MKTAG('A','D','P','4'):
 	case MKTAG('S','D','X','2'):

--- a/engines/sherlock/scalpel/3do/movie_decoder.h
+++ b/engines/sherlock/scalpel/3do/movie_decoder.h
@@ -88,7 +88,7 @@ private:
 
 	class StreamAudioTrack : public AudioTrack {
 	public:
-		StreamAudioTrack(uint32 codecTag, uint32 sampleRate, uint32 channels);
+		StreamAudioTrack(uint32 codecTag, uint32 sampleRate, uint32 channels, Audio::Mixer::SoundType soundType);
 		~StreamAudioTrack();
 
 		void queueAudio(Common::SeekableReadStream *stream, uint32 size);

--- a/engines/titanic/support/avi_surface.cpp
+++ b/engines/titanic/support/avi_surface.cpp
@@ -52,7 +52,7 @@ AVISurface::AVISurface(const CResourceKey &key) : _movieName(key.getString()) {
 	_priorFrame = -1;
 
 	// Create a decoder
-	_decoder = new AVIDecoder(Audio::Mixer::kPlainSoundType);
+	_decoder = new AVIDecoder();
 	if (!_decoder->loadFile(_movieName))
 		error("Could not open video - %s", key.getString().c_str());
 

--- a/engines/titanic/support/avi_surface.h
+++ b/engines/titanic/support/avi_surface.h
@@ -43,10 +43,9 @@ enum MovieFlag {
 
 class AVIDecoder : public Video::AVIDecoder {
 public:
-	AVIDecoder(Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType) :
-		Video::AVIDecoder(soundType) {}
-	AVIDecoder(const Common::Rational &frameRateOverride, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType) :
-		Video::AVIDecoder(frameRateOverride, soundType) {}
+	AVIDecoder() {}
+	AVIDecoder(const Common::Rational &frameRateOverride) :
+		Video::AVIDecoder(frameRateOverride) {}
 
 	/**
 	 * Returns the number of video tracks the decoder has

--- a/engines/voyeur/animation.cpp
+++ b/engines/voyeur/animation.cpp
@@ -34,7 +34,7 @@ namespace Voyeur {
 // Number of audio frames to keep audio track topped up when playing back video
 #define SOUND_FRAMES_READAHEAD 3
 
-RL2Decoder::RL2Decoder(Audio::Mixer::SoundType soundType) : _soundType(soundType) {
+RL2Decoder::RL2Decoder() {
 	_paletteStart = 0;
 	_fileStream = nullptr;
 	_soundFrameNumber = -1;
@@ -76,7 +76,7 @@ bool RL2Decoder::loadStream(Common::SeekableReadStream *stream) {
 	// Add an audio track if sound is present
 	_audioTrack = nullptr;
 	if (_header._soundRate) {
-		_audioTrack = new RL2AudioTrack(_header, stream, _soundType);
+		_audioTrack = new RL2AudioTrack(_header, stream, getSoundType());
 		addTrack(_audioTrack);
 	}
 
@@ -433,8 +433,9 @@ Graphics::Surface *RL2Decoder::RL2VideoTrack::getBackSurface() {
 
 /*------------------------------------------------------------------------*/
 
-RL2Decoder::RL2AudioTrack::RL2AudioTrack(const RL2FileHeader &header, Common::SeekableReadStream *stream, Audio::Mixer::SoundType soundType):
-		_header(header), _soundType(soundType) {
+RL2Decoder::RL2AudioTrack::RL2AudioTrack(const RL2FileHeader &header, Common::SeekableReadStream *stream, Audio::Mixer::SoundType soundType) :
+		AudioTrack(soundType),
+		_header(header) {
 	// Create audio straem for the audio track
 	_audStream = Audio::makeQueuingAudioStream(_header._rate, _header._channels == 2);
 }

--- a/engines/voyeur/animation.h
+++ b/engines/voyeur/animation.h
@@ -88,7 +88,6 @@ private:
 
 	class RL2AudioTrack : public AudioTrack {
 	private:
-		Audio::Mixer::SoundType _soundType;
 		const RL2FileHeader &_header;
 		Audio::QueuingAudioStream *_audStream;
 	protected:
@@ -98,7 +97,6 @@ private:
 			Audio::Mixer::SoundType soundType);
 		~RL2AudioTrack();
 
-		Audio::Mixer::SoundType getSoundType() const { return _soundType; }
 		int numQueuedStreams() const { return _audStream->numQueuedStreams(); }
 		virtual bool isSeekable() const { return true; }
 		virtual bool seek(const Audio::Timestamp &time) { return true; }
@@ -156,7 +154,6 @@ private:
 	RL2AudioTrack *_audioTrack;
 	RL2VideoTrack *_videoTrack;
 	Common::SeekableReadStream *_fileStream;
-	Audio::Mixer::SoundType _soundType;
 	RL2FileHeader _header;
 	int _paletteStart;
 	Common::Array<SoundFrame> _soundFrames;
@@ -171,7 +168,7 @@ private:
 	virtual bool seekIntern(const Audio::Timestamp &time);
 
 public:
-	RL2Decoder(Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
+	RL2Decoder();
 	virtual ~RL2Decoder();
 
 	virtual void close();

--- a/engines/zvision/video/zork_avi_decoder.cpp
+++ b/engines/zvision/video/zork_avi_decoder.cpp
@@ -35,10 +35,10 @@ namespace ZVision {
 
 Video::AVIDecoder::AVIAudioTrack *ZorkAVIDecoder::createAudioTrack(Video::AVIDecoder::AVIStreamHeader sHeader, Video::AVIDecoder::PCMWaveFormat wvInfo) {
 	if (wvInfo.tag != kWaveFormatZorkPCM)
-		return new AVIAudioTrack(sHeader, wvInfo, _soundType);
+		return new AVIAudioTrack(sHeader, wvInfo, getSoundType());
 
 	assert(wvInfo.size == 8);
-	return new ZorkAVIAudioTrack(sHeader, wvInfo, _soundType);
+	return new ZorkAVIAudioTrack(sHeader, wvInfo, getSoundType());
 }
 
 ZorkAVIDecoder::ZorkAVIAudioTrack::ZorkAVIAudioTrack(const AVIStreamHeader &streamHeader, const PCMWaveFormat &waveFormat, Audio::Mixer::SoundType soundType) :

--- a/engines/zvision/video/zork_avi_decoder.h
+++ b/engines/zvision/video/zork_avi_decoder.h
@@ -31,8 +31,7 @@ namespace ZVision {
 
 class ZorkAVIDecoder : public Video::AVIDecoder {
 public:
-	ZorkAVIDecoder(Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType) :
-		Video::AVIDecoder(soundType) {}
+	ZorkAVIDecoder() {}
 
 	virtual ~ZorkAVIDecoder() {}
 

--- a/video/avi_decoder.cpp
+++ b/video/avi_decoder.cpp
@@ -76,13 +76,13 @@ enum {
 };
 
 
-AVIDecoder::AVIDecoder(Audio::Mixer::SoundType soundType) :
-		_frameRateOverride(0), _soundType(soundType) {
+AVIDecoder::AVIDecoder() :
+		_frameRateOverride(0) {
 	initCommon();
 }
 
-AVIDecoder::AVIDecoder(const Common::Rational &frameRateOverride, Audio::Mixer::SoundType soundType) :
-	_frameRateOverride(frameRateOverride), _soundType(soundType) {
+AVIDecoder::AVIDecoder(const Common::Rational &frameRateOverride) :
+		_frameRateOverride(frameRateOverride) {
 	initCommon();
 }
 
@@ -91,7 +91,7 @@ AVIDecoder::~AVIDecoder() {
 }
 
 AVIDecoder::AVIAudioTrack *AVIDecoder::createAudioTrack(AVIStreamHeader sHeader, PCMWaveFormat wvInfo) {
-	return new AVIAudioTrack(sHeader, wvInfo, _soundType);
+	return new AVIAudioTrack(sHeader, wvInfo, getSoundType());
 }
 
 bool AVIDecoder::seekToFrame(uint frame) {
@@ -1007,8 +1007,13 @@ void AVIDecoder::AVIVideoTrack::setDither(const byte *palette) {
 	_videoCodec->setDither(Image::Codec::kDitherTypeVFW, palette);
 }
 
-AVIDecoder::AVIAudioTrack::AVIAudioTrack(const AVIStreamHeader &streamHeader, const PCMWaveFormat &waveFormat, Audio::Mixer::SoundType soundType)
-		: _audsHeader(streamHeader), _wvInfo(waveFormat), _soundType(soundType), _audioStream(0), _packetStream(0), _curChunk(0) {
+AVIDecoder::AVIAudioTrack::AVIAudioTrack(const AVIStreamHeader &streamHeader, const PCMWaveFormat &waveFormat, Audio::Mixer::SoundType soundType) :
+		AudioTrack(soundType),
+		_audsHeader(streamHeader),
+		_wvInfo(waveFormat),
+		_audioStream(0),
+		_packetStream(0),
+		_curChunk(0) {
 }
 
 AVIDecoder::AVIAudioTrack::~AVIAudioTrack() {

--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -62,8 +62,8 @@ namespace Video {
  */
 class AVIDecoder : public VideoDecoder {
 public:
-	AVIDecoder(Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
-	AVIDecoder(const Common::Rational &frameRateOverride, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
+	AVIDecoder();
+	AVIDecoder(const Common::Rational &frameRateOverride);
 	virtual ~AVIDecoder();
 
 	bool loadStream(Common::SeekableReadStream *stream);
@@ -263,7 +263,6 @@ protected:
 
 		virtual void createAudioStream();
 		virtual void queueSound(Common::SeekableReadStream *stream);
-		Audio::Mixer::SoundType getSoundType() const { return _soundType; }
 		void skipAudio(const Audio::Timestamp &time, const Audio::Timestamp &frameTime);
 		virtual void resetStream();
 		uint32 getCurChunk() const { return _curChunk; }
@@ -288,7 +287,6 @@ protected:
 
 		AVIStreamHeader _audsHeader;
 		PCMWaveFormat _wvInfo;
-		Audio::Mixer::SoundType _soundType;
 		Audio::AudioStream *_audioStream;
 		Audio::PacketizedAudioStream *_packetStream;
 		uint32 _curChunk;
@@ -317,7 +315,6 @@ protected:
 	bool _foundMovieList;
 	uint32 _movieListStart, _movieListEnd;
 
-	Audio::Mixer::SoundType _soundType;
 	Common::Rational _frameRateOverride;
 
 	int _videoTrackCounter, _audioTrackCounter;

--- a/video/bink_decoder.cpp
+++ b/video/bink_decoder.cpp
@@ -1349,7 +1349,9 @@ void BinkDecoder::BinkVideoTrack::IDCTPut(DecodeContext &ctx, int16 *block) {
 	}
 }
 
-BinkDecoder::BinkAudioTrack::BinkAudioTrack(BinkDecoder::AudioInfo &audio) : _audioInfo(&audio) {
+BinkDecoder::BinkAudioTrack::BinkAudioTrack(BinkDecoder::AudioInfo &audio, Audio::Mixer::SoundType soundType) :
+		AudioTrack(soundType),
+		_audioInfo(&audio) {
 	_audioStream = Audio::makeQueuingAudioStream(_audioInfo->outSampleRate, _audioInfo->outChannels == 2);
 }
 
@@ -1598,7 +1600,7 @@ void BinkDecoder::initAudioTrack(AudioInfo &audio) {
 	else if (audio.codec == kAudioCodecDCT)
 		audio.dct  = new Common::DCT(frameLenBits, Common::DCT::DCT_III);
 
-	addTrack(new BinkAudioTrack(audio));
+	addTrack(new BinkAudioTrack(audio, getSoundType()));
 }
 
 } // End of namespace Video

--- a/video/bink_decoder.h
+++ b/video/bink_decoder.h
@@ -320,7 +320,7 @@ private:
 
 	class BinkAudioTrack : public AudioTrack {
 	public:
-		BinkAudioTrack(AudioInfo &audio);
+		BinkAudioTrack(AudioInfo &audio, Audio::Mixer::SoundType soundType);
 		~BinkAudioTrack();
 
 		/** Decode an audio packet. */

--- a/video/coktel_decoder.cpp
+++ b/video/coktel_decoder.cpp
@@ -2784,6 +2784,7 @@ void VMDDecoder::setAutoStartSound(bool autoStartSound) {
 }
 
 AdvancedVMDDecoder::AdvancedVMDDecoder(Audio::Mixer::SoundType soundType) {
+	setSoundType(soundType);
 	_decoder = new VMDDecoder(g_system->getMixer(), soundType);
 	_decoder->setAutoStartSound(false);
 }
@@ -2860,11 +2861,9 @@ Common::Rational AdvancedVMDDecoder::VMDVideoTrack::getFrameRate() const {
 	return _decoder->getFrameRate();
 }
 
-AdvancedVMDDecoder::VMDAudioTrack::VMDAudioTrack(VMDDecoder *decoder) : _decoder(decoder) {
-}
-
-Audio::Mixer::SoundType AdvancedVMDDecoder::VMDAudioTrack::getSoundType() const {
-	return _decoder->getSoundType();
+AdvancedVMDDecoder::VMDAudioTrack::VMDAudioTrack(VMDDecoder *decoder) :
+		AudioTrack(decoder->getSoundType()),
+		_decoder(decoder) {
 }
 
 Audio::AudioStream *AdvancedVMDDecoder::VMDAudioTrack::getAudioStream() const {

--- a/video/coktel_decoder.h
+++ b/video/coktel_decoder.h
@@ -595,8 +595,6 @@ private:
 	public:
 		VMDAudioTrack(VMDDecoder *decoder);
 
-		Audio::Mixer::SoundType getSoundType() const;
-
 	protected:
 		virtual Audio::AudioStream *getAudioStream() const;
 

--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -142,7 +142,7 @@ void MPEGPSDecoder::readNextPacket() {
 			} else if (startCode >= 0x1C0 && startCode <= 0x1DF) {
 #ifdef USE_MAD
 				// MPEG Audio stream
-				MPEGAudioTrack *audioTrack = new MPEGAudioTrack(*packet);
+				MPEGAudioTrack *audioTrack = new MPEGAudioTrack(*packet, getSoundType());
 				stream = audioTrack;
 				_streamMap[startCode] = audioTrack;
 				addTrack(audioTrack);
@@ -512,7 +512,8 @@ void MPEGPSDecoder::MPEGVideoTrack::findDimensions(Common::SeekableReadStream *f
 
 // The audio code here is almost entirely based on what we do in mp3.cpp
 
-MPEGPSDecoder::MPEGAudioTrack::MPEGAudioTrack(Common::SeekableReadStream &firstPacket) {
+MPEGPSDecoder::MPEGAudioTrack::MPEGAudioTrack(Common::SeekableReadStream &firstPacket, Audio::Mixer::SoundType soundType) :
+		AudioTrack(soundType) {
 	_audStream = Audio::makePacketizedMP3Stream(firstPacket);
 }
 

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -113,7 +113,7 @@ private:
 	// An MPEG audio track
 	class MPEGAudioTrack : public AudioTrack, public MPEGStream {
 	public:
-		MPEGAudioTrack(Common::SeekableReadStream &firstPacket);
+		MPEGAudioTrack(Common::SeekableReadStream &firstPacket, Audio::Mixer::SoundType soundType);
 		~MPEGAudioTrack();
 
 		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts);

--- a/video/psx_decoder.cpp
+++ b/video/psx_decoder.cpp
@@ -247,7 +247,7 @@ void PSXStreamDecoder::readNextPacket() {
 			// We only handle one audio channel so far
 			if (track == 1) {
 				if (!_audioTrack) {
-					_audioTrack = new PSXAudioTrack(sector);
+					_audioTrack = new PSXAudioTrack(sector, getSoundType());
 					addTrack(_audioTrack);
 				}
 
@@ -308,7 +308,8 @@ static const int s_xaTable[5][2] = {
    { 122, -60 }
 };
 
-PSXStreamDecoder::PSXAudioTrack::PSXAudioTrack(Common::SeekableReadStream *sector) {
+PSXStreamDecoder::PSXAudioTrack::PSXAudioTrack(Common::SeekableReadStream *sector, Audio::Mixer::SoundType soundType) :
+		AudioTrack(soundType) {
 	assert(sector);
 	_endOfTrack = false;
 

--- a/video/psx_decoder.h
+++ b/video/psx_decoder.h
@@ -125,7 +125,7 @@ private:
 
 	class PSXAudioTrack : public AudioTrack {
 	public:
-		PSXAudioTrack(Common::SeekableReadStream *sector);
+		PSXAudioTrack(Common::SeekableReadStream *sector, Audio::Mixer::SoundType soundType);
 		~PSXAudioTrack();
 
 		bool endOfTrack() const;

--- a/video/qt_decoder.cpp
+++ b/video/qt_decoder.cpp
@@ -267,8 +267,10 @@ void QuickTimeDecoder::VideoSampleDesc::initCodec() {
 	_videoCodec = Image::createQuickTimeCodec(_codecTag, _parentTrack->width, _parentTrack->height, _bitsPerSample & 0x1f);
 }
 
-QuickTimeDecoder::AudioTrackHandler::AudioTrackHandler(QuickTimeDecoder *decoder, QuickTimeAudioTrack *audioTrack)
-		: _decoder(decoder), _audioTrack(audioTrack) {
+QuickTimeDecoder::AudioTrackHandler::AudioTrackHandler(QuickTimeDecoder *decoder, QuickTimeAudioTrack *audioTrack) :
+		SeekableAudioTrack(decoder->getSoundType()),
+		_decoder(decoder),
+		_audioTrack(audioTrack) {
 }
 
 void QuickTimeDecoder::AudioTrackHandler::updateBuffer() {

--- a/video/smk_decoder.cpp
+++ b/video/smk_decoder.cpp
@@ -277,7 +277,7 @@ uint32 BigHuffmanTree::getCode(Common::BitStream &bs) {
 	return v;
 }
 
-SmackerDecoder::SmackerDecoder(Audio::Mixer::SoundType soundType) : _soundType(soundType) {
+SmackerDecoder::SmackerDecoder() {
 	_fileStream = 0;
 	_firstFrameStart = 0;
 	_frameTypes = 0;
@@ -369,7 +369,7 @@ bool SmackerDecoder::loadStream(Common::SeekableReadStream *stream) {
 			if (_header.audioInfo[i].compression == kCompressionRDFT || _header.audioInfo[i].compression == kCompressionDCT)
 				warning("Unhandled Smacker v2 audio compression");
 
-			addTrack(new SmackerAudioTrack(_header.audioInfo[i], _soundType));
+			addTrack(new SmackerAudioTrack(_header.audioInfo[i], getSoundType()));
 		}
 	}
 
@@ -754,7 +754,8 @@ void SmackerDecoder::SmackerVideoTrack::unpackPalette(Common::SeekableReadStream
 }
 
 SmackerDecoder::SmackerAudioTrack::SmackerAudioTrack(const AudioInfo &audioInfo, Audio::Mixer::SoundType soundType) :
-		_audioInfo(audioInfo), _soundType(soundType) {
+		AudioTrack(soundType),
+		_audioInfo(audioInfo) {
 	_audioStream = Audio::makeQueuingAudioStream(_audioInfo.sampleRate, _audioInfo.isStereo);
 }
 

--- a/video/smk_decoder.h
+++ b/video/smk_decoder.h
@@ -59,7 +59,7 @@ class BigHuffmanTree;
  */
 class SmackerDecoder : public VideoDecoder {
 public:
-	SmackerDecoder(Audio::Mixer::SoundType soundType = Audio::Mixer::kSFXSoundType);
+	SmackerDecoder();
 	virtual ~SmackerDecoder();
 
 	virtual bool loadStream(Common::SeekableReadStream *stream);
@@ -164,8 +164,6 @@ private:
 		bool isRewindable() const { return true; }
 		bool rewind();
 
-		Audio::Mixer::SoundType getSoundType() const { return _soundType; }
-
 		void queueCompressedBuffer(byte *buffer, uint32 bufferSize, uint32 unpackedSize);
 		void queuePCM(byte *buffer, uint32 bufferSize);
 
@@ -173,7 +171,6 @@ private:
 		Audio::AudioStream *getAudioStream() const;
 
 	private:
-		Audio::Mixer::SoundType _soundType;
 		Audio::QueuingAudioStream *_audioStream;
 		AudioInfo _audioInfo;
 	};
@@ -186,8 +183,6 @@ private:
 	byte *_frameTypes;
 
 	uint32 _firstFrameStart;
-
-	Audio::Mixer::SoundType _soundType;
 };
 
 } // End of namespace Video

--- a/video/theora_decoder.cpp
+++ b/video/theora_decoder.cpp
@@ -47,7 +47,7 @@
 
 namespace Video {
 
-TheoraDecoder::TheoraDecoder(Audio::Mixer::SoundType soundType) : _soundType(soundType) {
+TheoraDecoder::TheoraDecoder() {
 	_fileStream = 0;
 
 	_videoTrack = 0;
@@ -177,7 +177,7 @@ bool TheoraDecoder::loadStream(Common::SeekableReadStream *stream) {
 	th_setup_free(theoraSetup);
 
 	if (_hasAudio) {
-		_audioTrack = new VorbisAudioTrack(_soundType, _vorbisInfo);
+		_audioTrack = new VorbisAudioTrack(getSoundType(), _vorbisInfo);
 
 		// Get enough audio data to start us off
 		while (!_audioTrack->hasAudio()) {
@@ -330,7 +330,8 @@ void TheoraDecoder::TheoraVideoTrack::translateYUVtoRGBA(th_ycbcr_buffer &YUVBuf
 
 static vorbis_info *info = 0;
 
-TheoraDecoder::VorbisAudioTrack::VorbisAudioTrack(Audio::Mixer::SoundType soundType, vorbis_info &vorbisInfo) : _soundType(soundType) {
+TheoraDecoder::VorbisAudioTrack::VorbisAudioTrack(Audio::Mixer::SoundType soundType, vorbis_info &vorbisInfo) :
+		AudioTrack(soundType) {
 	vorbis_synthesis_init(&_vorbisDSP, &vorbisInfo);
 	vorbis_block_init(&_vorbisDSP, &_vorbisBlock);
 	info = &vorbisInfo;

--- a/video/theora_decoder.h
+++ b/video/theora_decoder.h
@@ -61,7 +61,7 @@ namespace Video {
  */
 class TheoraDecoder : public VideoDecoder {
 public:
-	TheoraDecoder(Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType);
+	TheoraDecoder();
 	virtual ~TheoraDecoder();
 
 	/**
@@ -110,8 +110,6 @@ private:
 		VorbisAudioTrack(Audio::Mixer::SoundType soundType, vorbis_info &vorbisInfo);
 		~VorbisAudioTrack();
 
-		Audio::Mixer::SoundType getSoundType() const { return _soundType; }
-
 		bool decodeSamples();
 		bool hasAudio() const;
 		bool needsAudio() const;
@@ -126,7 +124,6 @@ private:
 		int _audioBufferFill;
 		ogg_int16_t *_audioBuffer;
 
-		Audio::Mixer::SoundType _soundType;
 		Audio::QueuingAudioStream *_audStream;
 
 		vorbis_block _vorbisBlock;
@@ -141,8 +138,6 @@ private:
 	void ensureAudioBufferSize();
 
 	Common::SeekableReadStream *_fileStream;
-
-	Audio::Mixer::SoundType _soundType;
 
 	ogg_sync_state _oggSync;
 	ogg_page _oggPage;

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -431,6 +431,18 @@ public:
 	void setBalance(int8 balance);
 
 	/**
+	 * Get the mixer sound type audio is being played with.
+	 */
+	Audio::Mixer::SoundType getSoundType() const;
+
+	/**
+	 * Set the mixer sound type used to play the audio tracks.
+	 *
+	 * This must be set before calling loadStream().
+	 */
+	void setSoundType(Audio::Mixer::SoundType soundType);
+
+	/**
 	 * Add an audio track from a stream file.
 	 *
 	 * This calls SeekableAudioStream::openStreamFile() internally
@@ -667,7 +679,7 @@ protected:
 	 */
 	class AudioTrack : public Track {
 	public:
-		AudioTrack();
+		AudioTrack(Audio::Mixer::SoundType soundType);
 		virtual ~AudioTrack() {}
 
 		TrackType getTrackType() const { return kTrackTypeAudio; }
@@ -713,11 +725,6 @@ protected:
 		uint32 getRunningTime() const;
 
 		/**
-		 * Get the sound type to be used when playing this audio track
-		 */
-		virtual Audio::Mixer::SoundType getSoundType() const { return Audio::Mixer::kPlainSoundType; }
-
-		/**
 		 * Mute the track
 		 */
 		void setMute(bool mute);
@@ -732,6 +739,7 @@ protected:
 
 	private:
 		Audio::SoundHandle _handle;
+		Audio::Mixer::SoundType _soundType;
 		byte _volume;
 		int8 _balance;
 		bool _muted;
@@ -743,7 +751,7 @@ protected:
 	 */
 	class RewindableAudioTrack : public AudioTrack {
 	public:
-		RewindableAudioTrack() {}
+		RewindableAudioTrack(Audio::Mixer::SoundType soundType) : AudioTrack(soundType) {}
 		virtual ~RewindableAudioTrack() {}
 
 		bool isRewindable() const { return true; }
@@ -765,7 +773,7 @@ protected:
 	 */
 	class SeekableAudioTrack : public AudioTrack {
 	public:
-		SeekableAudioTrack() {}
+		SeekableAudioTrack(Audio::Mixer::SoundType soundType) : AudioTrack(soundType) {}
 		virtual ~SeekableAudioTrack() {}
 
 		bool isSeekable() const { return true; }
@@ -789,7 +797,7 @@ protected:
 	 */
 	class StreamFileAudioTrack : public SeekableAudioTrack {
 	public:
-		StreamFileAudioTrack();
+		StreamFileAudioTrack(Audio::Mixer::SoundType soundType);
 		~StreamFileAudioTrack();
 
 		/**
@@ -953,6 +961,7 @@ private:
 	uint32 _pauseStartTime;
 	byte _audioVolume;
 	int8 _audioBalance;
+	Audio::Mixer::SoundType _soundType;
 
 	AudioTrack *_mainAudioTrack;
 };


### PR DESCRIPTION
While trying to fix bug Trac#9938, I noticed it was not possible to set the mixer sound type for the audio tracks handled by VideoDecoder. For Riven, it makes sense to set the sound type to SFX since the audio tracks of videos are mostly used for effects. I decided to fix that in VideoDecoder.

Then I saw some subclasses of VideoDecoder already allow to set the sound type. I went on and changed them to get the sound type from VideoDecoder. After doing that, I unexpectedly had no compilation failures. No engine actually sets the mixer sound type for videos. Am I missing something?