### PR TITLE
GUI: Stop processing input events from macOS file browser dialog

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -992,6 +992,10 @@ void SdlEventSource::resetKeyboardEmulation(int16 x_max, int16 y_max) {
 	_km.joy_y = 0;
 }
 
+void SdlEventSource::clearEvents() {
+	SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+}
+
 bool SdlEventSource::handleResizeEvent(Common::Event &event, int w, int h) {
 	if (_graphicsManager) {
 		_graphicsManager->notifyResize(w, h);

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -51,6 +51,11 @@ public:
 	 */
 	virtual void resetKeyboardEmulation(int16 x_max, int16 y_max);
 
+	/**
+	 * Flush the SDL event queue
+	 */
+	virtual void clearEvents();
+
 protected:
 	/** @name Keyboard mouse emulation
 	 * Disabled by fingolfin 2004-12-18.

--- a/common/EventDispatcher.cpp
+++ b/common/EventDispatcher.cpp
@@ -70,6 +70,12 @@ void EventDispatcher::dispatch() {
 	}
 }
 
+void EventDispatcher::clearEvents() {
+	for (List<SourceEntry>::iterator i = _sources.begin(); i != _sources.end(); ++i) {
+		i->source->clearEvents();
+	}
+}
+
 void EventDispatcher::registerMapper(EventMapper *mapper, bool autoFree) {
 	if (_autoFreeMapper) {
 		delete _mapper;

--- a/common/events.h
+++ b/common/events.h
@@ -154,6 +154,11 @@ public:
 	 * By default we allow mapping for every event source.
 	 */
 	virtual bool allowMapping() const { return true; }
+
+	/**
+	 * Clear any pending events that have been queued up in the event source backend
+	 */
+	virtual void clearEvents() { }
 };
 
 /**
@@ -280,6 +285,12 @@ public:
 	 * This dispatches *all* events the sources offer.
 	 */
 	void dispatch();
+
+	/**
+	 * Tells the event sources to forget their queued
+	 * events.
+	 */
+	void clearEvents();
 
 	/**
 	 * Registers an event mapper with the dispatcher.

--- a/gui/browser_osx.mm
+++ b/gui/browser_osx.mm
@@ -29,6 +29,7 @@
 #include "common/system.h"
 #include "common/algorithm.h"
 #include "common/translation.h"
+#include "common/events.h"
 
 #include <AppKit/NSNibDeclarations.h>
 #include <AppKit/NSOpenPanel.h>
@@ -176,6 +177,15 @@ int BrowserDialog::runModal() {
 		g_system->setFeatureState(OSystem::kFeatureFullscreenMode, true);
 		g_system->endGFXTransaction();
 	}
+
+	// While the native macOS file browser is open, any input events (e.g. keypresses) are
+	// still received by the NSApplication. With SDL backend for example this results in the
+	// events being queued and processed after we return, thus dispatching events that were
+	// intended for the native file browser. For example: pressing Esc to cancel the native
+	// macOS file browser would cause the application to quit in addition to closing the
+	// file browser.
+	// Clear the event sources' event queue.
+	g_system->getEventManager()->getEventDispatcher()->clearEvents();
 
 	return choiceMade;
 }


### PR DESCRIPTION
This fixes a bug I observed that is related to the macOS file browser.

After the macOS browser is closed, all events that happened while the macOS browser was open were being sent to ScummVM.

Here's the basic repeatable test case:
- From the launcher, Add game, the macOS-specific browser dialog opens
- press down arrow 4 times
- press cancel (and maybe move the mouse over the launcher to force the events to be processed)
- the down arrow events are passed to the launcher and the game screen (bad)

A variant of this is if you press some keys and then press Esc to cancel out of the launcher. This will cause the entire launcher to quit when it receives the Esc key.

A more devious variant of this test case: When pressing Up/Down and then Enter/Return to select a game you want to add and that game happens to have variants (e.g. PQ2). That variant picking dialog will be rapidly confirmed as it gets the arrow keys and enter key. The user may not even see it appear and disappear.
