### PR TITLE
TITANIC: Right Click = Shift + Left Click

### DIFF
--- a/engines/titanic/events.cpp
+++ b/engines/titanic/events.cpp
@@ -72,14 +72,16 @@ void Events::pollEvents() {
 			eventTarget()->middleButtonUp(_mousePos);
 			return;
 		case Common::EVENT_RBUTTONDOWN:
-			_specialButtons |= MK_RBUTTON;
+			_specialButtons |= MK_LBUTTON;
+			_specialButtons |= MK_SHIFT;
 			_mousePos = event.mouse;
-			eventTarget()->rightButtonDown(_mousePos);
+			eventTarget()->leftButtonDown(_mousePos);
 			return;
 		case Common::EVENT_RBUTTONUP:
-			_specialButtons &= ~MK_RBUTTON;
+			_specialButtons &= ~MK_LBUTTON;
+			_specialButtons &= ~MK_SHIFT;
 			_mousePos = event.mouse;
-			eventTarget()->rightButtonUp(_mousePos);
+			eventTarget()->leftButtonUp(_mousePos);
 			return;
 		case Common::EVENT_WHEELUP:
 		case Common::EVENT_WHEELDOWN:


### PR DESCRIPTION
This maps the right click in Titanic to be shift + left click. This allows chevrons and fast-transitions to happen just by right clicking. 

The shift happens on right click down and the shift is undone when right click is released. This is done to not conflict with the shift state of the left click.

When the shift key is down the right click still works as shift + left click. The left click still works as it always has.

Some code cleanup might be done since there are now unused variables (e.x., MK_RBUTTON), but I believe this implementation is behaviorally correct.