### PR TITLE
COMMON: Migrate Various Endian Functions to Common from Engine Code.

### DIFF
--- a/common/endian.h
+++ b/common/endian.h
@@ -608,4 +608,36 @@ inline uint32 READ_BE_UINT24(const void *ptr) {
 #define READ_UINT24(a) READ_BE_UINT24(a)
 #endif
 
+inline int16 READ_LE_INT16(const void *ptr) {
+	return static_cast<int16>(READ_LE_UINT16(ptr));
+}
+
+inline void WRITE_LE_INT16(void *ptr, int16 value) {
+	WRITE_LE_UINT16(ptr, static_cast<uint16>(value));
+}
+
+inline int16 READ_BE_INT16(const void *ptr) {
+	return static_cast<int16>(READ_BE_UINT16(ptr));
+}
+
+inline void WRITE_BE_INT16(void *ptr, int16 value) {
+	WRITE_BE_UINT16(ptr, static_cast<uint16>(value));
+}
+
+inline int32 READ_LE_INT32(const void *ptr) {
+	return static_cast<int32>(READ_LE_UINT32(ptr));
+}
+
+inline void WRITE_LE_INT32(void *ptr, int32 value) {
+	WRITE_LE_UINT32(ptr, static_cast<uint32>(value));
+}
+
+inline int32 READ_BE_INT32(const void *ptr) {
+	return static_cast<int32>(READ_BE_UINT32(ptr));
+}
+
+inline void WRITE_BE_INT32(void *ptr, int32 value) {
+	WRITE_BE_UINT32(ptr, static_cast<uint32>(value));
+}
+
 #endif

--- a/engines/hopkins/hopkins.h
+++ b/engines/hopkins/hopkins.h
@@ -72,8 +72,6 @@ enum HopkinsDebugChannels {
  */
 #define MKTAG24(a0,a1,a2) ((uint32)((a2) | (a1) << 8 | ((a0) << 16)))
 
-#define READ_LE_INT16(x) (int16) READ_LE_UINT16(x)
-
 struct HopkinsGameDescription;
 
 class HopkinsEngine : public Engine {

--- a/engines/lure/luredefs.h
+++ b/engines/lure/luredefs.h
@@ -37,9 +37,6 @@ namespace Lure {
 
 #define LURE_DEBUG 1
 
-#define READ_LE_INT16(x) (int16) READ_LE_UINT16(x)
-#define READ_LE_INT32(x) (int32) READ_LE_UINT32(x)
-
 enum {
 	kLureDebugScripts = 1 << 0,
 	kLureDebugAnimations = 1 << 1,

--- a/engines/queen/queen.h
+++ b/engines/queen/queen.h
@@ -30,24 +30,6 @@ namespace Common {
 class SeekableReadStream;
 }
 
-#if defined(_WIN32_WCE) && (_WIN32_WCE <= 300)
-
-#include "common/endian.h"
-
-FORCEINLINE int16 READ_BE_INT16(const void *ptr) {
-	uint16 result;
-	char dummy[2];
-	result = READ_BE_UINT16(ptr);
-	strcpy(dummy, "x"); // Hello, I'm a drunk optimizer. Thanks for helping me.
-	return result;
-}
-
-#else
-
-#define READ_BE_INT16 READ_BE_UINT16
-
-#endif
-
 /**
  * This is the namespace of the Queen engine.
  *

--- a/engines/toon/tools.h
+++ b/engines/toon/tools.h
@@ -36,12 +36,6 @@ const uint32 kCompSPCN = 0x5350434E;
 const uint32 kCompRNC1 = 0x524E4301;
 const uint32 kCompRNC2 = 0x524E4302;
 
-#define READ_LE_INT16(x) (int16) READ_LE_UINT16(x)
-#define READ_LE_INT32(x) (int32) READ_LE_UINT32(x)
-
-#define WRITE_LE_INT16(x, y)  WRITE_LE_UINT16(x, (int16)y)
-#define WRITE_LE_INT32(x, y)  WRITE_LE_UINT32(x, (int32)y)
-
 uint32 decompressSPCN(byte *src, byte *dst, uint32 dstsize);
 uint32 decompressLZSS(byte *src, byte *dst, int dstsize);
 


### PR DESCRIPTION
These changes are a subset of a commit in the external BOLT engine tree used for Merlin's Apprentice:
https://github.com/beholdnec/scummvm-bolt/commit/def568f05f600c87b10a89ca83d40fe80b09ea57

Since this commit mixes engine changes with making changes to common code and other engines, including removal of a WinCE specific hack in the Queen engine, this should be reviewed and merged prior to that engine's future PR discussions.

This will allow the external engine to be rebased and cleaned up in an easier manner without possible conflicts due to work on those other engines in the master tree in the meantime.

Also, the proposed change here to common/endian.h looks reasonable and will avoid other duplications in future of these kind of READ* and WRITE* functions.