### PR TITLE
TITANIC: Star View: Added keyboard key to look up

### DIFF
--- a/engines/titanic/star_control/star_view.cpp
+++ b/engines/titanic/star_control/star_view.cpp
@@ -227,6 +227,15 @@ bool CStarView::KeyCharMsg(int key, CErrorCode *errorCode) {
 		}
 		break;
 
+	case Common::KEYCODE_SLASH:
+		if (matchedIndex == -1) {
+			pose.setRotationMatrix(X_AXIS, 1.0);
+			_camera.proc22(pose);
+			_camera.updatePosition(errorCode);
+			return true;
+		}
+		break;
+
 	default:
 		break;
 	}


### PR DESCRIPTION
Before you could look down, but not up using the keyboard. This fixes "/" not being mapped. This is for #10018. It still remains to change the semicolon ";" functionality so that it goes forward instead of backwords. Currently, there are two keys for going backwords, but none for going forward. 

I don't plan to implement the forward moving part since the math in that involved looks complicated.