### PR TITLE
Titanic: access last save

### DIFF
--- a/engines/titanic/core/project_item.cpp
+++ b/engines/titanic/core/project_item.cpp
@@ -463,7 +463,7 @@ SaveStateList CProjectItem::getSavegameList(const Common::String &target) {
 		const char *ext = strrchr(file->c_str(), '.');
 		int slot = ext ? atoi(ext + 1) : -1;
 
-		if (slot >= 0 && slot < MAX_SAVES) {
+		if (slot >= 0 && slot <= MAX_SAVES) {
 			Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(*file);
 
 			if (in) {

--- a/engines/titanic/core/project_item.cpp
+++ b/engines/titanic/core/project_item.cpp
@@ -35,7 +35,6 @@
 namespace Titanic {
 
 #define CURRENT_SAVEGAME_VERSION 1
-#define MAX_SAVEGAME_SLOTS 99
 #define MINIMUM_SAVEGAME_VERSION 1
 
 static const char *const SAVEGAME_STR = "TNIC";
@@ -464,7 +463,7 @@ SaveStateList CProjectItem::getSavegameList(const Common::String &target) {
 		const char *ext = strrchr(file->c_str(), '.');
 		int slot = ext ? atoi(ext + 1) : -1;
 
-		if (slot >= 0 && slot < MAX_SAVEGAME_SLOTS) {
+		if (slot >= 0 && slot < MAX_SAVES) {
 			Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(*file);
 
 			if (in) {

--- a/engines/titanic/detection.cpp
+++ b/engines/titanic/detection.cpp
@@ -33,8 +33,6 @@
 #include "graphics/colormasks.h"
 #include "graphics/surface.h"
 
-#define MAX_SAVES 99
-
 namespace Titanic {
 
 struct TitanicGameDescription {

--- a/engines/titanic/detection.cpp
+++ b/engines/titanic/detection.cpp
@@ -118,7 +118,7 @@ SaveStateList TitanicMetaEngine::listSaves(const char *target) const {
 		const char *ext = strrchr(file->c_str(), '.');
 		int slot = ext ? atoi(ext + 1) : -1;
 
-		if (slot >= 0 && slot < MAX_SAVES) {
+		if (slot >= 0 && slot <= MAX_SAVES) {
 			Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(*file);
 
 			if (in) {

--- a/engines/titanic/main_game_window.cpp
+++ b/engines/titanic/main_game_window.cpp
@@ -117,7 +117,7 @@ int CMainGameWindow::selectSavegame() {
 	bool hasSavegames = false;
 
 	// Loop through save slots to find any existing save slots
-	for (int idx = 0; idx < MAX_SAVES; ++idx) {
+	for (int idx = 0; idx <= MAX_SAVES; ++idx) {
 		CString saveName = g_vm->getSavegameName(idx);
 		if (!saveName.empty()) {
 			dialog.addSavegame(idx, saveName);


### PR DESCRIPTION
Before titanic couldn't load the last save, or show its name in the GMM once saved. Now it can.

I also made the different files use the same const instead of defining their own.

Now if it is desirable to have more saved games it can just be changed in titanic.h and it works everywhere else.

Resolves #10051