### PR TITLE
TITANIC: Change Starview slowdown to reverse

### DIFF
--- a/engines/titanic/star_control/camera_mover.cpp
+++ b/engines/titanic/star_control/camera_mover.cpp
@@ -69,20 +69,17 @@ void CCameraMover::copyTo(CNavigationInfo *dest) {
 	dest->_unusedZ = _unusedZ;
 }
 
-void CCameraMover::increaseSpeed() {
+void CCameraMover::increaseForwardSpeed() {
 	if (!isLocked() && _speed < _maxSpeed) {
 		_speedChangeCtr += _speedChangeInc;
 		_speed += ABS(_speedChangeCtr);
 	}
 }
 
-void CCameraMover::decreaseSpeed() {
-	if (!isLocked()) {
+void CCameraMover::increaseBackwardSpeed() {
+	if (!isLocked() && _speed > -_maxSpeed) {
 		_speedChangeCtr -= _speedChangeInc;
 		_speed -= ABS(_speedChangeCtr);
-
-		if (_speedChangeCtr < 0.0)
-			_speedChangeCtr = 0.0;
 	}
 }
 

--- a/engines/titanic/star_control/camera_mover.h
+++ b/engines/titanic/star_control/camera_mover.h
@@ -53,14 +53,14 @@ public:
 	virtual void copyTo(CNavigationInfo *dest);
 
 	/**
-	 * Increases movement speed
+	 * Increases movement speed in forward direction
 	 */
-	virtual void increaseSpeed();
+	virtual void increaseForwardSpeed();
 
 	/**
-	 * Decreases movement speed
+	 * Decreases movement speed in backward direction
 	 */
-	virtual void decreaseSpeed();
+	virtual void increaseBackwardSpeed();
 
 	/**
 	 * Increase to full speed

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -146,12 +146,12 @@ void CStarCamera::updatePosition(CErrorCode *errorCode) {
 	}
 }
 
-void CStarCamera::increaseSpeed() {
-	_mover->increaseSpeed();
+void CStarCamera::increaseForwardSpeed() {
+	_mover->increaseForwardSpeed();
 }
 
-void CStarCamera::decreaseSpeed() {
-	_mover->decreaseSpeed();
+void CStarCamera::increaseBackwardSpeed() {
+	_mover->increaseBackwardSpeed();
 }
 
 void CStarCamera::fullSpeed() {

--- a/engines/titanic/star_control/star_camera.h
+++ b/engines/titanic/star_control/star_camera.h
@@ -102,14 +102,14 @@ public:
 	virtual void updatePosition(CErrorCode *errorCode);
 
 	/**
-	 * Increases movement speed
+	 * Increases movement speed in forward direction
 	 */
-	virtual void increaseSpeed();
+	virtual void increaseForwardSpeed();
 
 	/**
-	 * Decreases movement speed
+	 * Decreases movement speed in backward direction
 	 */
-	virtual void decreaseSpeed();
+	virtual void increaseBackwardSpeed();
 
 	/**
 	 * Increase to full speed

--- a/engines/titanic/star_control/star_view.cpp
+++ b/engines/titanic/star_control/star_view.cpp
@@ -187,7 +187,7 @@ bool CStarView::KeyCharMsg(int key, CErrorCode *errorCode) {
 
 	case Common::KEYCODE_SEMICOLON:
 		if (matchedIndex == -1) {
-			_camera.increaseSpeed();
+			_camera.increaseForwardSpeed();
 			errorCode->set();
 			return true;
 		}
@@ -195,7 +195,7 @@ bool CStarView::KeyCharMsg(int key, CErrorCode *errorCode) {
 
 	case Common::KEYCODE_PERIOD:
 		if (matchedIndex == -1) {
-			_camera.decreaseSpeed();
+			_camera.increaseBackwardSpeed();
 			errorCode->set();
 			return true;
 		}


### PR DESCRIPTION
This changes the starview manual camera movement using semicolon.
Before it slowed down the ship. To make it more like the original
game it now adds negative velocity so that it slows down then
speeds up in the backward direction.

The functions were renamed accordingly.