### PR TITLE
MOHAWK: Myst and Riven saves and controls readme additions

### DIFF
--- a/README
+++ b/README
@@ -1902,6 +1902,14 @@ versions.
     - Rename the saved game to 'elvira2-pc.xxx' (DOS version) or
       'elvira2.xxx' (Other versions)
 
+  Myst
+    - Rename the saved game to 'myst-xxx.mys'
+    - Saves from the masterpiece edition and the regular edition are interchangeable
+
+  Riven
+    - Rename the saved game to 'riven-xxx.rvn'
+    - Saves from the CD and DVD edition are not interchangeable
+
   Simon the Sorcerer 1
     - Rename the saved game to 'simon1.xxx'
 

--- a/README
+++ b/README
@@ -909,8 +909,14 @@ that direction. The player can then simply click on the edges of the
 game's screen to change location, similar to many adventure games, which
 is simpler and more straightforward than moving around using the menu.
 
+3.15) Myst game notes:
+----- -------------------------------
+Left Click: Move/action
+Space: Pause the game
+Esc: Skip cutscene
 
-3.15) Nippon Safes Inc. Amiga notes:
+
+3.16) Nippon Safes Inc. Amiga notes:
 ----- ------------------------------
 For this game, you will need disk0, , global.table, pointer and
 it (en, fr, ge for the international version).
@@ -919,13 +925,20 @@ In addition, you will need to rename disk image 2 to disk1,
 disk image 3 to disk2, disk image 4 to disk3 and disk image 5 to disk4.
 
 
-3.16) Simon the Sorcerer games notes:
+3.17) Riven game notes:
+----- -------------------------------
+Left Click: Move/action
+Arrow Keys: Movement
+Space: Pause the game
+Esc: Skip cutscene
+
+3.18) Simon the Sorcerer games notes:
 ----- -------------------------------
 If you have the dual version of Simon the Sorcerer 1 or 2 on CD, you
 will find the Windows version in the main directory of the CD and the
 DOS version in the DOS directory of the CD.
 
-3.17) Starship Titanic game notes:
+3.19) Starship Titanic game notes:
 ----------------------------------
 Basic Movements:
 Left Click: Move action
@@ -958,7 +971,7 @@ Miscellaneous controls:
 Ctrl + C: Open up the developer's cheat room
 Ctrl + D: Open up the ScummVM Debugger
 
-3.18) The Curse of Monkey Island notes:
+3.20) The Curse of Monkey Island notes:
 ----- ---------------------------------
 For this game, you will need the comi.la0, comi.la1 and comi.la2 files.
 The comi.la0 file can be found on either CD, but since they are
@@ -970,7 +983,7 @@ two CDs. Some of the files appear on both CDs, but again they're
 identical.
 
 
-3.19) The Feeble Files notes:
+3.21) The Feeble Files notes:
 ----- -----------------------
 Amiga/Macintosh:
 You need to install a small pack of cutscenes that are missing in both
@@ -997,7 +1010,7 @@ Rename voices.wav on CD3 to voices3.wav
 Rename voices.wav on CD4 to voices4.wav
 
 
-3.20) The Legend of Kyrandia notes:
+3.22) The Legend of Kyrandia notes:
 ----- -----------------------------
 To run The Legend of Kyrandia under ScummVM you need the 'kyra.dat'
 file. The file should always be included in official ScummVM packages.
@@ -1008,14 +1021,14 @@ thus you only need to grab it in case ScummVM complains about the file
 being missing.
 
 
-3.21) Troll's Tale notes:
+3.23) Troll's Tale notes:
 ----- -------------------
 The original game came in a PC booter disk, therefore it is necessary to
 dump the contents of that disk in an image file and name it "troll.img"
 to be able to play the game under ScummVM.
 
 
-3.22) Winnie the Pooh notes:
+3.24) Winnie the Pooh notes:
 ----- ----------------------
 It is possible to import saved games from the original interpreter of the
 game into ScummVM.
@@ -1030,7 +1043,7 @@ game's screen to change location, similar to many adventure games, which
 is simpler and more straightforward than moving around using the menu.
 
 
-3.23) Sierra AGI games: Predictive Input Dialog:
+3.25) Sierra AGI games: Predictive Input Dialog:
 ----- ------------------------------------------
 The Predictive Input Dialog is a ScummVM aid for running AGI engine
 games (which notoriously require command line input) on devices with
@@ -1084,7 +1097,7 @@ naturally mapping the functionality to the numeric keypad. Also, the
 dialog's buttons can be navigated with the arrow and the enter keys.
 
 
-3.24) Sierra SCI games: Simultaneous speech and subtitles:
+3.26) Sierra SCI games: Simultaneous speech and subtitles:
 ----- ----------------------------------------------------
 Certain CD versions of Sierra SCI games had both speech and text
 resources. Some have an option to toggle between the two, but there are
@@ -1173,7 +1186,7 @@ Torin's Passage CD:
     Mixer" from the in-game "Game" menu and setting the speech volume
     to zero.
 
-3.25) Zork games notes:
+3.27) Zork games notes:
 ----- -----------------
 To run the supported Zork games (Zork Nemesis: The Forbidden Lands
 and Zork: Grand Inquisitor) you need to copy some (extra) data to it's
@@ -1270,7 +1283,7 @@ Copy the zassetsc directory into the game root directory
 Copy the zassetse directory into the game root directory
 
 
-3.26) Commodore64 games notes:
+3.28) Commodore64 games notes:
 ----- ------------------------
 Both Maniac Mansion and Zak McKracken run but Maniac Mansion is not yet
 playable. Simply name the D64 disks "maniac1.d64" and "maniac2.d64"
@@ -1284,7 +1297,7 @@ to Commodore64. We recommend using the much simpler approach described
 in the previous paragraph.
 
 
-3.27) Macintosh games notes:
+3.29) Macintosh games notes:
 ----- ----------------------
 All LucasArts SCUMM based adventures, except COMI, also exist in versions
 for the Macintosh. ScummVM can use most (all?) of them, however, in some


### PR DESCRIPTION
Add basic controls for riven and myst.

List that riven and myst can have saves from original game and how to rename the saves.

The controls are pretty basic for myst/riven, but I was already adding details for the saved games so I thought I would add that also. Skipping the cutscenes (with the escape key) will be really useful to someone if they don't know that is an option.