### PR TITLE
TITANIC: Star control dvector class refactor

### DIFF
--- a/engines/titanic/star_control/dvector.cpp
+++ b/engines/titanic/star_control/dvector.cpp
@@ -101,7 +101,7 @@ DAffine DVector::getFrameTransform(const DVector &v) {
 	return matrix4.compose(matrix3);
 }
 
-DAffine DVector::fn5() const {
+DAffine DVector::RotXY() const {
 	DVector v1 = getAnglesAsVect();
 	DAffine m1, m2;
 	m1.setRotationMatrix(X_AXIS, v1._y * Rad2Deg);

--- a/engines/titanic/star_control/dvector.cpp
+++ b/engines/titanic/star_control/dvector.cpp
@@ -84,7 +84,7 @@ DVector DVector::getAnglesAsVect() const {
 	return dest;
 }
 
-DAffine DVector::fn4(const DVector &v) {
+DAffine DVector::getFrameTransform(const DVector &v) {
 	DAffine matrix1, matrix2, matrix3, matrix4;
 
 	DVector vector1 = getAnglesAsVect();

--- a/engines/titanic/star_control/dvector.cpp
+++ b/engines/titanic/star_control/dvector.cpp
@@ -60,10 +60,10 @@ DVector DVector::DAffMatrixProdVec(const DAffine &m) {
 	return dest;
 }
 
-void DVector::fn2(double angle) {
+void DVector::RotVectAxisY(double angle_deg) {
 	const double FACTOR = 2 * M_PI / 360.0;
-	double sinVal = sin(angle * FACTOR);
-	double cosVal = cos(angle * FACTOR);
+	double sinVal = sin(angle_deg * FACTOR);
+	double cosVal = cos(angle_deg * FACTOR);
 	double x = cosVal * _x - sinVal * _z;
 	double z = cosVal * _z + sinVal * _x;
 

--- a/engines/titanic/star_control/dvector.cpp
+++ b/engines/titanic/star_control/dvector.cpp
@@ -40,11 +40,23 @@ double DVector::getDistance(const DVector &src) {
 	return sqrt((src._x - _x) * (src._x - _x) + (src._y - _y) * (src._y - _y) + (src._z - _z) * (src._z - _z));
 }
 
-DVector DVector::fn1(const DAffine &m) {
+DVector DVector::DAffMatrixProdVec(const DAffine &m) {
 	DVector dest;
-	dest._x = m._col3._x * _z + m._col2._x * _y + m._col1._x * _x + m._col4._x;
-	dest._y = m._col2._y * _y + m._col3._y * _z + m._col1._y * _x + m._col4._y;
-	dest._z = m._col3._z * _z + m._col2._z * _y + m._col1._z * _x + m._col4._z;
+	dest._x = m._col1._x * _x +
+                  m._col2._x * _y +
+                  m._col3._x * _z +
+                  m._col4._x;
+
+	dest._y = m._col1._y * _x +
+                  m._col2._y * _y +
+                  m._col3._y * _z +
+                  m._col4._y;
+
+	dest._z = m._col1._z * _x +
+                  m._col2._z * _y +
+                  m._col3._z * _z +
+                  m._col4._z;
+
 	return dest;
 }
 

--- a/engines/titanic/star_control/dvector.cpp
+++ b/engines/titanic/star_control/dvector.cpp
@@ -26,6 +26,9 @@
 
 namespace Titanic {
 
+const double Rad2Deg = 180.0 / M_PI;
+const double Deg2Rad = 1.0 / Rad2Deg;
+
 double DVector::normalize() {
 	double hyp = sqrt(_x * _x + _y * _y + _z * _z);
 	assert(hyp);
@@ -61,9 +64,8 @@ DVector DVector::DAffMatrixProdVec(const DAffine &m) {
 }
 
 void DVector::RotVectAxisY(double angle_deg) {
-	const double FACTOR = 2 * M_PI / 360.0;
-	double sinVal = sin(angle_deg * FACTOR);
-	double cosVal = cos(angle_deg * FACTOR);
+	double sinVal = sin(angle_deg * Deg2Rad);
+	double cosVal = cos(angle_deg * Deg2Rad);
 	double x = cosVal * _x - sinVal * _z;
 	double z = cosVal * _z + sinVal * _x;
 
@@ -71,51 +73,39 @@ void DVector::RotVectAxisY(double angle_deg) {
 	_z = z;
 }
 
-DVector DVector::fn3() const {
+DVector DVector::getAnglesAsVect() const {
 	DVector vector = *this;
 	DVector dest;
-	dest._x = vector.normalize();
-	dest._y = acos(vector._y);
-
-	if (ABS(vector._z) < 0.00001) {
-		if (vector._x < 0.0) {
-			dest._z = 2 * M_PI - (M_PI / 2.0);
-		} else {
-			dest._z = M_PI / 2.0;
-		}
-	} else {
-		dest._z = atan(vector._x / vector._z);
-		if (vector._x < 0.0)
-			dest._z += 2 * M_PI;
-	}
+	dest._x = vector.normalize(); // scale that makes this vector have magnitude=1, also does the scaling
+	dest._y = acos(vector._y);    // radian distance/angle that this vector's y component is from the +y axis,
+                                      // result is restricted to [0,pi]
+	dest._z = atan2(vector._x,vector._z); // result is restricted to [-pi,pi]
 
 	return dest;
 }
 
 DAffine DVector::fn4(const DVector &v) {
-	const double FACTOR = 180.0 / M_PI;
 	DAffine matrix1, matrix2, matrix3, matrix4;
 
-	DVector vector1 = fn3();
-	matrix1.setRotationMatrix(X_AXIS, vector1._y * FACTOR);
-	matrix2.setRotationMatrix(Y_AXIS, -(vector1._z * FACTOR));
+	DVector vector1 = getAnglesAsVect();
+	matrix1.setRotationMatrix(X_AXIS, vector1._y * Rad2Deg);
+	matrix2.setRotationMatrix(Y_AXIS, -(vector1._z * Rad2Deg));
 	matrix3 = matrix1.compose(matrix2);
 	matrix4 = matrix3.inverseTransform();
 
-	vector1 = v.fn3();
-	matrix1.setRotationMatrix(X_AXIS, vector1._y * FACTOR);
-	matrix2.setRotationMatrix(Y_AXIS, -(vector1._z * FACTOR));
+	vector1 = v.getAnglesAsVect();
+	matrix1.setRotationMatrix(X_AXIS, vector1._y * Rad2Deg);
+	matrix2.setRotationMatrix(Y_AXIS, -(vector1._z * Rad2Deg));
 	matrix3 = matrix1.compose(matrix2);
 
 	return matrix4.compose(matrix3);
 }
 
 DAffine DVector::fn5() const {
-	const double FACTOR = 180.0 / M_PI;
-	DVector v1 = fn3();
+	DVector v1 = getAnglesAsVect();
 	DAffine m1, m2;
-	m1.setRotationMatrix(X_AXIS, v1._y * FACTOR);
-	m2.setRotationMatrix(Y_AXIS, -(v1._z * FACTOR));
+	m1.setRotationMatrix(X_AXIS, v1._y * Rad2Deg);
+	m2.setRotationMatrix(Y_AXIS, -(v1._z * Rad2Deg));
 	return m1.compose(m2);
 }
 

--- a/engines/titanic/star_control/dvector.h
+++ b/engines/titanic/star_control/dvector.h
@@ -73,7 +73,12 @@ public:
 	 * a vector rotation based on input vector v
 	 */
 	DAffine getFrameTransform(const DVector &v);
-	DAffine fn5() const;
+
+	/**
+         * Returns a affine matrix that does a x then a y axis frame rotation
+	 * based on the orientation of this vector
+	 */
+	DAffine RotXY() const;
 
 	/**
 	 * Returns true if the passed vector equals this one

--- a/engines/titanic/star_control/dvector.h
+++ b/engines/titanic/star_control/dvector.h
@@ -60,7 +60,13 @@ public:
 	 */
 	void RotVectAxisY(double angle_deg);
 
-	DVector fn3() const;
+	/**
+         * Returns a vector, v, that represents a magnitude, and two angles in radians
+	 * 1. Scale this vector to be unit magnitude and store scale in x component of v
+         * 2. X rotation angle from +y axis of this vector is put in y component of v
+         * 3. z component output of v is the 4-quadrant angle that z makes with x (Y axis rotation)
+	 */
+	DVector getAnglesAsVect() const;
 	DAffine fn4(const DVector &v);
 	DAffine fn5() const;
 

--- a/engines/titanic/star_control/dvector.h
+++ b/engines/titanic/star_control/dvector.h
@@ -55,7 +55,11 @@ public:
 	 */
 	DVector DAffMatrixProdVec(const DAffine &m);
 
-	void fn2(double angle);
+	/**
+	 * Rotate this vector about the Y axis
+	 */
+	void RotVectAxisY(double angle_deg);
+
 	DVector fn3() const;
 	DAffine fn4(const DVector &v);
 	DAffine fn5() const;

--- a/engines/titanic/star_control/dvector.h
+++ b/engines/titanic/star_control/dvector.h
@@ -48,7 +48,13 @@ public:
 	 */
 	double getDistance(const DVector &src);
 
-	DVector fn1(const DAffine &m);
+	/**
+	 * Returns the matrix product with this vector and 
+         * also does a z translations
+	 * Doesn't change this vector
+	 */
+	DVector DAffMatrixProdVec(const DAffine &m);
+
 	void fn2(double angle);
 	DVector fn3() const;
 	DAffine fn4(const DVector &v);

--- a/engines/titanic/star_control/dvector.h
+++ b/engines/titanic/star_control/dvector.h
@@ -67,7 +67,12 @@ public:
          * 3. z component output of v is the 4-quadrant angle that z makes with x (Y axis rotation)
 	 */
 	DVector getAnglesAsVect() const;
-	DAffine fn4(const DVector &v);
+
+	/**
+         * Returns a matrix that contains the frame rotation based on this vector and 
+	 * a vector rotation based on input vector v
+	 */
+	DAffine getFrameTransform(const DVector &v);
 	DAffine fn5() const;
 
 	/**

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -509,7 +509,7 @@ void CStarCamera::lockMarker2(CViewport *viewport, const FVector &v) {
 	int minDegree = 0;
 	for (int degree = 0; degree < 360; ++degree) {
 		tempPos = m4._col1;
-		tempPos.fn2((double)degree);
+		tempPos.RotVectAxisY((double)degree);
 		double distance = tempV2.getDistance(tempPos);
 
 		if (distance < minDistance) {
@@ -518,10 +518,10 @@ void CStarCamera::lockMarker2(CViewport *viewport, const FVector &v) {
 		}
 	}
 
-	m4._col1.fn2((double)minDegree);
-	m4._col2.fn2((double)minDegree);
-	m4._col3.fn2((double)minDegree);
-	m4._col4.fn2((double)minDegree);
+	m4._col1.RotVectAxisY((double)minDegree);
+	m4._col2.RotVectAxisY((double)minDegree);
+	m4._col3.RotVectAxisY((double)minDegree);
+	m4._col4.RotVectAxisY((double)minDegree);
 	m4._col1 = m4._col1.DAffMatrixProdVec(m1);
 	m4._col2 = m4._col2.DAffMatrixProdVec(m1);
 	m4._col3 = m4._col3.DAffMatrixProdVec(m1);

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -289,7 +289,7 @@ void CStarCamera::setViewportAngle(const FPoint &angles) {
 
 		tempV1 = _matrix._row2 - _matrix._row1;
 		diffV = tempV1;
-		m1 = diffV.fn5();
+		m1 = diffV.RotXY();
 		m1 = m1.compose(subX);
 		subX = m1.inverseTransform();
 		subX = subX.compose(subY);
@@ -459,7 +459,7 @@ void CStarCamera::lockMarker2(CViewport *viewport, const FVector &v) {
 
 	DAffine m2(X_AXIS, _matrix._row1);
 	DVector tempV1 = v - _matrix._row1;
-	DAffine m1 = tempV1.fn5();
+	DAffine m1 = tempV1.RotXY();
 	m1 = m1.compose(m2);
 	m2 = m1.inverseTransform();
 	

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -321,15 +321,15 @@ void CStarCamera::setViewportAngle(const FPoint &angles) {
 		tempV7._x = m3._row3._x * 1000000.0 + tempV3._x;
 
 		mrow3 = tempV8 = tempV7;
-		tempV3 = tempV3.fn1(subX);
-		mrow1 = mrow1.fn1(subX);
-		mrow2 = mrow2.fn1(subX);
-		mrow3 = mrow3.fn1(subX);
+		tempV3 = tempV3.DAffMatrixProdVec(subX);
+		mrow1 = mrow1.DAffMatrixProdVec(subX);
+		mrow2 = mrow2.DAffMatrixProdVec(subX);
+		mrow3 = mrow3.DAffMatrixProdVec(subX);
 
-		tempV3 = tempV3.fn1(m1);
-		mrow1 = mrow1.fn1(m1);
-		mrow2 = mrow2.fn1(m1);
-		mrow3 = mrow3.fn1(m1);
+		tempV3 = tempV3.DAffMatrixProdVec(m1);
+		mrow1 = mrow1.DAffMatrixProdVec(m1);
+		mrow2 = mrow2.DAffMatrixProdVec(m1);
+		mrow3 = mrow3.DAffMatrixProdVec(m1);
 
 		mrow1 -= tempV3;
 		mrow2 -= tempV3;
@@ -497,11 +497,11 @@ void CStarCamera::lockMarker2(CViewport *viewport, const FVector &v) {
 	tempV3._z = m5._row3._z * 1000000.0 + m4._col1._z;
 	m4._col4 = tempV3;
 
-	tempV2 = tempV2.fn1(m2);
-	m4._col1 = m4._col1.fn1(m2);
-	m4._col3 = m4._col3.fn1(m2);
-	m4._col2 = m4._col2.fn1(m2);
-	m4._col4 = m4._col4.fn1(m2);
+	tempV2 = tempV2.DAffMatrixProdVec(m2);
+	m4._col1 = m4._col1.DAffMatrixProdVec(m2);
+	m4._col3 = m4._col3.DAffMatrixProdVec(m2);
+	m4._col2 = m4._col2.DAffMatrixProdVec(m2);
+	m4._col4 = m4._col4.DAffMatrixProdVec(m2);
 
 	// Find the angle that gives the minimum distance
 	DVector tempPos;
@@ -522,10 +522,10 @@ void CStarCamera::lockMarker2(CViewport *viewport, const FVector &v) {
 	m4._col2.fn2((double)minDegree);
 	m4._col3.fn2((double)minDegree);
 	m4._col4.fn2((double)minDegree);
-	m4._col1 = m4._col1.fn1(m1);
-	m4._col2 = m4._col2.fn1(m1);
-	m4._col3 = m4._col3.fn1(m1);
-	m4._col4 = m4._col4.fn1(m1);
+	m4._col1 = m4._col1.DAffMatrixProdVec(m1);
+	m4._col2 = m4._col2.DAffMatrixProdVec(m1);
+	m4._col3 = m4._col3.DAffMatrixProdVec(m1);
+	m4._col4 = m4._col4.DAffMatrixProdVec(m1);
 
 	m4._col3 -= m4._col1;
 	m4._col2 -= m4._col1;

--- a/engines/titanic/star_control/unmarked_camera_mover.cpp
+++ b/engines/titanic/star_control/unmarked_camera_mover.cpp
@@ -44,10 +44,10 @@ void CUnmarkedCameraMover::moveTo(const FVector &srcV, const FVector &destV, con
 void CUnmarkedCameraMover::proc10(const FVector &v1, const FVector &v2, const FVector &v3, const FMatrix &m) {
 	if (isLocked())
 		decLockCount();
-
+	//TODO: v3 is unused
 	DVector vector1 = v1;
 	DVector vector2 = v2;
-	DAffine matrix1 = vector2.fn4(vector1);
+	DAffine matrix1 = vector2.getFrameTransform(vector1);
 	DAffine matrix2 = matrix1.compose(m);
 
 	_autoMover.proc3(m, matrix2);


### PR DESCRIPTION
Renamed functions from ambiguous names to ones with their function. This code involves matrix rotations, and transforms so the naming was along those lines.

Added lots of comments.

Changed out a questionable 4-quadrant atan implementation to use the standard atan2 instead.

Tested it out works the same as before.

I may come up with better naming and refactoring like combing with fvector after I read more of the star control code (I just focused on dvector for this change set).