### PR TITLE
TITANIC: fmatrix refactoring

### DIFF
--- a/engines/titanic/star_control/fmatrix.cpp
+++ b/engines/titanic/star_control/fmatrix.cpp
@@ -29,6 +29,12 @@ FMatrix::FMatrix() :
 	_row1(1.0, 0.0, 0.0), _row2(0.0, 1.0, 0.0), _row3(0.0, 0.0, 1.0) {
 }
 
+FMatrix::FMatrix(const FVector &row1, const FVector &row2, const FVector &row3) {
+	_row1 = row1;
+	_row2 = row2;
+	_row3 = row3;
+}
+
 FMatrix::FMatrix(const DAffine &src) {
 	copyFrom(src);
 }
@@ -81,6 +87,13 @@ void FMatrix::identity() {
 	_row3 = FVector(0.0, 0.0, 1.0);
 }
 
+void FMatrix::set(const FMatrix &m) {
+	_row1 = m._row1;
+	_row2 = m._row2;
+	_row3 = m._row3;
+}
+
+
 void FMatrix::set(const FVector &row1, const FVector &row2, const FVector &row3) {
 	_row1 = row1;
 	_row2 = row2;
@@ -104,36 +117,30 @@ void FMatrix::set(const FVector &v) {
 	_row2.normalize();
 }
 
-void FMatrix::matRProd(const FMatrix &m) {
-	float x1 = _row1._y * m._row2._x + _row1._z * m._row3._x + _row1._x * m._row1._x;
-	float y1 = _row1._x * m._row1._y + m._row2._y * _row1._y + m._row3._y * _row1._z;
-	float z1 = _row1._x * m._row1._z + _row1._y * m._row2._z + _row1._z * m._row3._z;
-	float x2 = m._row1._x * _row2._x + m._row3._x * _row2._z + m._row2._x * _row2._y;
-	float y2 = m._row3._y * _row2._z + m._row1._y * _row2._x + m._row2._y * _row2._y;
-	float z2 = _row2._z * m._row3._z + _row2._x * m._row1._z + _row2._y * m._row2._z;
-	float x3 = m._row1._x * _row3._x + _row3._z * m._row3._x + _row3._y * m._row2._x;
-	float y3 = _row3._y * m._row2._y + _row3._z * m._row3._y + _row3._x * m._row1._y;
-	float z3 = _row3._x * m._row1._z + _row3._y * m._row2._z + _row3._z * m._row3._z;
+void FMatrix::matProd(const FMatrix &a, const FMatrix &m, FMatrix &C) {
+	C._row1._x = a._row1._y * m._row2._x + a._row1._z * m._row3._x + a._row1._x * m._row1._x;
+        C._row1._y = a._row1._x * m._row1._y + m._row2._y * a._row1._y + m._row3._y * a._row1._z;
+        C._row1._z = a._row1._x * m._row1._z + a._row1._y * m._row2._z + a._row1._z * m._row3._z;
+        C._row2._x = m._row1._x * a._row2._x + m._row3._x * a._row2._z + m._row2._x * a._row2._y;
+        C._row2._y = m._row3._y * a._row2._z + m._row1._y * a._row2._x + m._row2._y * a._row2._y;
+        C._row2._z = a._row2._z * m._row3._z + a._row2._x * m._row1._z + a._row2._y * m._row2._z;
+        C._row3._x = m._row1._x * a._row3._x + a._row3._z * m._row3._x + a._row3._y * m._row2._x;
+        C._row3._y = a._row3._y * m._row2._y + a._row3._z * m._row3._y + a._row3._x * m._row1._y;
+        C._row3._z = a._row3._x * m._row1._z + a._row3._y * m._row2._z + a._row3._z * m._row3._z;
+}
 
-	_row1 = FVector(x1, y1, z1);
-	_row2 = FVector(x2, y2, z2);
-	_row3 = FVector(x3, y3, z3);
+void FMatrix::matRProd(const FMatrix &m) {
+        FMatrix C = FMatrix();
+        FMatrix A = FMatrix(_row1,_row2,_row3);
+        matProd(A,m,C);
+        this->set(C);
 }
 
 void FMatrix::matLProd(const FMatrix &m) {
-	float x1 = _row2._x * m._row1._y + m._row1._z * _row3._x + _row1._x * m._row1._x;
-	float y1 = m._row1._x * _row1._y + _row3._y * m._row1._z + _row2._y * m._row1._y;
-	float z1 = m._row1._x * _row1._z + m._row1._y * _row2._z + m._row1._z * _row3._z;
-	float x2 = _row1._x * m._row2._x + _row2._x * m._row2._y + _row3._x * m._row2._z;
-	float y2 = _row3._y * m._row2._z + _row1._y * m._row2._x + _row2._y * m._row2._y;
-	float z2 = m._row2._z * _row3._z + m._row2._x * _row1._z + m._row2._y * _row2._z;
-	float x3 = _row1._x * m._row3._x + m._row3._z * _row3._x + m._row3._y * _row2._x;
-	float y3 = m._row3._y * _row2._y + m._row3._z * _row3._y + m._row3._x * _row1._y;
-	float z3 = m._row3._x * _row1._z + m._row3._y * _row2._z + m._row3._z * _row3._z;
-
-	_row1 = FVector(x1, y1, z1);
-	_row2 = FVector(x2, y2, z2);
-	_row3 = FVector(x3, y3, z3);
+        FMatrix C = FMatrix();
+        FMatrix A = FMatrix(_row1,_row2,_row3);
+        matProd(m,A,C);
+        this->set(C);
 }
 
 } // End of namespace Titanic

--- a/engines/titanic/star_control/fmatrix.cpp
+++ b/engines/titanic/star_control/fmatrix.cpp
@@ -104,7 +104,7 @@ void FMatrix::set(const FVector &v) {
 	_row2.normalize();
 }
 
-void FMatrix::fn2(const FMatrix &m) {
+void FMatrix::matRProd(const FMatrix &m) {
 	float x1 = _row1._y * m._row2._x + _row1._z * m._row3._x + _row1._x * m._row1._x;
 	float y1 = _row1._x * m._row1._y + m._row2._y * _row1._y + m._row3._y * _row1._z;
 	float z1 = _row1._x * m._row1._z + _row1._y * m._row2._z + _row1._z * m._row3._z;
@@ -120,7 +120,7 @@ void FMatrix::fn2(const FMatrix &m) {
 	_row3 = FVector(x3, y3, z3);
 }
 
-void FMatrix::fn3(const FMatrix &m) {
+void FMatrix::matLProd(const FMatrix &m) {
 	float x1 = _row2._x * m._row1._y + m._row1._z * _row3._x + _row1._x * m._row1._x;
 	float y1 = m._row1._x * _row1._y + _row3._y * m._row1._z + _row2._y * m._row1._y;
 	float z1 = m._row1._x * _row1._z + m._row1._y * _row2._z + m._row1._z * _row3._z;

--- a/engines/titanic/star_control/fmatrix.cpp
+++ b/engines/titanic/star_control/fmatrix.cpp
@@ -25,6 +25,21 @@
 
 namespace Titanic {
 
+//Non-member functions
+void matProd(const FMatrix &a, const FMatrix &m, FMatrix &C) {
+        C._row1._x = a._row1._y * m._row2._x + a._row1._z * m._row3._x + a._row1._x * m._row1._x;
+        C._row1._y = a._row1._x * m._row1._y + m._row2._y * a._row1._y + m._row3._y * a._row1._z;
+        C._row1._z = a._row1._x * m._row1._z + a._row1._y * m._row2._z + a._row1._z * m._row3._z;
+        C._row2._x = m._row1._x * a._row2._x + m._row3._x * a._row2._z + m._row2._x * a._row2._y;
+        C._row2._y = m._row3._y * a._row2._z + m._row1._y * a._row2._x + m._row2._y * a._row2._y;
+        C._row2._z = a._row2._z * m._row3._z + a._row2._x * m._row1._z + a._row2._y * m._row2._z;
+        C._row3._x = m._row1._x * a._row3._x + a._row3._z * m._row3._x + a._row3._y * m._row2._x;
+        C._row3._y = a._row3._y * m._row2._y + a._row3._z * m._row3._y + a._row3._x * m._row1._y;
+        C._row3._z = a._row3._x * m._row1._z + a._row3._y * m._row2._z + a._row3._z * m._row3._z;
+}
+
+//member functions
+
 FMatrix::FMatrix() :
 	_row1(1.0, 0.0, 0.0), _row2(0.0, 1.0, 0.0), _row3(0.0, 0.0, 1.0) {
 }
@@ -115,18 +130,6 @@ void FMatrix::set(const FVector &v) {
 
 	_row2 = _row3.crossProduct(_row1);
 	_row2.normalize();
-}
-
-void FMatrix::matProd(const FMatrix &a, const FMatrix &m, FMatrix &C) {
-	C._row1._x = a._row1._y * m._row2._x + a._row1._z * m._row3._x + a._row1._x * m._row1._x;
-        C._row1._y = a._row1._x * m._row1._y + m._row2._y * a._row1._y + m._row3._y * a._row1._z;
-        C._row1._z = a._row1._x * m._row1._z + a._row1._y * m._row2._z + a._row1._z * m._row3._z;
-        C._row2._x = m._row1._x * a._row2._x + m._row3._x * a._row2._z + m._row2._x * a._row2._y;
-        C._row2._y = m._row3._y * a._row2._z + m._row1._y * a._row2._x + m._row2._y * a._row2._y;
-        C._row2._z = a._row2._z * m._row3._z + a._row2._x * m._row1._z + a._row2._y * m._row2._z;
-        C._row3._x = m._row1._x * a._row3._x + a._row3._z * m._row3._x + a._row3._y * m._row2._x;
-        C._row3._y = a._row3._y * m._row2._y + a._row3._z * m._row3._y + a._row3._x * m._row1._y;
-        C._row3._z = a._row3._x * m._row1._z + a._row3._y * m._row2._z + a._row3._z * m._row3._z;
 }
 
 void FMatrix::matRProd(const FMatrix &m) {

--- a/engines/titanic/star_control/fmatrix.h
+++ b/engines/titanic/star_control/fmatrix.h
@@ -92,11 +92,6 @@ public:
 	void set(const FVector &v);
 
         /**
-         * Puts the matrix product between a and m in C, C = am
-         */
-	void matProd(const FMatrix &a, const FMatrix &m, FMatrix &C);
-
-        /**
          * Changes this matrix, A, to be C, where C=Am. Matrix m multiplies this matrix (A) on its Right.
          * m is said to premultiply A (the previous this matrix).
          */
@@ -131,6 +126,13 @@ public:
 		return *rows[idx];
 	}
 };
+
+/**
+* Puts the matrix product between a and m in C, C = am
+* Called by MatLProd and MatLProd
+* Caller must preallocate output matrix
+*/
+void matProd(const FMatrix &a, const FMatrix &m, FMatrix &C);
 
 } // End of namespace Titanic
 

--- a/engines/titanic/star_control/fmatrix.h
+++ b/engines/titanic/star_control/fmatrix.h
@@ -47,6 +47,7 @@ public:
 	FVector _row3;
 public:
 	FMatrix();
+	FMatrix(const FVector &, const FVector &, const FVector &);
 	FMatrix(const DAffine &src);
 	FMatrix(const FMatrix &src);
 
@@ -73,6 +74,11 @@ public:
 	/**
 	 * Sets the data for the matrix
 	 */
+	void set(const FMatrix &m);
+
+	/**
+	 * Sets the data for the matrix
+	 */
 	void set(const FVector &row1, const FVector &row2, const FVector &row3);
 
 	/**
@@ -86,16 +92,19 @@ public:
 	void set(const FVector &v);
 
         /**
-         * Changes this matrix, A, to be C, where C=Am.
-         * Matrix m multiplies this matrix (A) on its Right.
-         * Matrix m is said to premultiply A (previous this matrix).
+         * Puts the matrix product between a and m in C, C = am
+         */
+	void matProd(const FMatrix &a, const FMatrix &m, FMatrix &C);
+
+        /**
+         * Changes this matrix, A, to be C, where C=Am. Matrix m multiplies this matrix (A) on its Right.
+         * m is said to premultiply A (the previous this matrix).
          */
 	void matRProd(const FMatrix &m);
 
         /**
-         * Changes this matrix, A, to be C, where C=mA.
-         * Matrix m multiplies this matrix (A) on its Left.
-         * m is said to postmultiply A (previous this matrix).
+         * Changes this matrix, A, to be C, where C=mA. Matrix m multiplies this matrix (A) on its Left.
+         * m is said to postmultiply A (the previous this matrix).
          */
 	void matLProd(const FMatrix &m);
 

--- a/engines/titanic/star_control/fmatrix.h
+++ b/engines/titanic/star_control/fmatrix.h
@@ -85,8 +85,19 @@ public:
 	 */
 	void set(const FVector &v);
 
-	void fn2(const FMatrix &m);
-	void fn3(const FMatrix &m);
+        /**
+         * Changes this matrix, A, to be C, where C=Am.
+         * Matrix m multiplies this matrix (A) on its Right.
+         * Matrix m is said to premultiply A (previous this matrix).
+         */
+	void matRProd(const FMatrix &m);
+
+        /**
+         * Changes this matrix, A, to be C, where C=mA.
+         * Matrix m multiplies this matrix (A) on its Left.
+         * m is said to postmultiply A (previous this matrix).
+         */
+	void matLProd(const FMatrix &m);
 
 	/**
 	 * Returns true if the passed matrix equals this one

--- a/engines/titanic/star_control/viewport.cpp
+++ b/engines/titanic/star_control/viewport.cpp
@@ -156,7 +156,7 @@ void CViewport::fn12() {
 	FPose s2(s1, m3);
 
 	m1.copyFrom(s2);
-	_orientation.fn2(m1);
+	_orientation.matRProd(m1);
 	_flag = false;
 }
 
@@ -181,7 +181,7 @@ void CViewport::reposition(double factor) {
 }
 
 void CViewport::fn15(const FMatrix &matrix) {
-	_orientation.fn3(matrix);
+	_orientation.matLProd(matrix);
 	_flag = false;
 }
 


### PR DESCRIPTION
1. Renamed 2 functions with unhelpful names.
fn2->MatRProd and fn3->MatLProd
one does the product of matrices on the right side and the other on the left.
2. Pulled common code of matrix product into one function and had the other two functions call that.
3. The general matrix product function was made into a non-member.

The over behavior of the star puzzle doesn't seem any different from these changes.