### PR TITLE
TITANIC: DAffine refactor

### DIFF
--- a/engines/titanic/star_control/daffine.cpp
+++ b/engines/titanic/star_control/daffine.cpp
@@ -65,6 +65,7 @@ DAffine::DAffine(const FMatrix &src) {
 	_col3 = src._row3;
 }
 
+//TODO: What is _static_ for?
 void DAffine::init() {
 	_static = nullptr;
 }
@@ -74,7 +75,24 @@ void DAffine::deinit() {
 	_static = nullptr;
 }
 
+void DAffine::clear() {
+	_col1._x = 0.0;
+	_col1._y = 0.0;
+	_col1._z = 0.0;
+	_col2._x = 0.0;
+	_col2._y = 0.0;
+	_col2._z = 0.0;
+	_col3._x = 0.0;
+	_col3._y = 0.0;
+	_col3._z = 0.0;
+	_col4._x = 0.0;
+	_col4._y = 0.0;
+	_col4._z = 0.0;
+}
+
 void DAffine::setRotationMatrix(Axis axis, double angleDeg) {
+        clear();
+
 	double sinVal = sin(angleDeg * Deg2Rad);
 	double cosVal = cos(angleDeg * Deg2Rad);
 
@@ -108,6 +126,7 @@ void DAffine::setRotationMatrix(Axis axis, double angleDeg) {
 	}
 }
 
+//TODO: Check math and provide source
 DAffine DAffine::inverseTransform() const {
 	double val1 = _col1._x * _col3._z * _col2._y;
 	double val2 = 0.0;
@@ -173,6 +192,7 @@ DAffine DAffine::inverseTransform() const {
 	return m;
 }
 
+//TODO: Check math and provide source
 void DAffine::loadTransform(const CMatrixTransform &src) {
 	double total = src.fn1();
 	double factor = (total <= 0.0) ? 0.0 : 2.0 / total;
@@ -200,6 +220,7 @@ void DAffine::loadTransform(const CMatrixTransform &src) {
 	_col4._z = 0;
 }
 
+//TODO: Check math and provide source
 DAffine DAffine::compose(const DAffine &m) {
 	DAffine dm;
 	dm._col1._x = m._col3._x * _col1._z + m._col2._x * _col1._y

--- a/engines/titanic/star_control/daffine.cpp
+++ b/engines/titanic/star_control/daffine.cpp
@@ -65,7 +65,7 @@ DAffine::DAffine(const FMatrix &src) {
 	_col3 = src._row3;
 }
 
-//TODO: What is _static_ for?
+//TODO: What is _static for?
 void DAffine::init() {
 	_static = nullptr;
 }
@@ -90,6 +90,7 @@ void DAffine::clear() {
 	_col4._z = 0.0;
 }
 
+// Source: https://en.wikipedia.org/wiki/Rotation_matrix
 void DAffine::setRotationMatrix(Axis axis, double angleDeg) {
         clear();
 
@@ -107,9 +108,9 @@ void DAffine::setRotationMatrix(Axis axis, double angleDeg) {
 
 	case Y_AXIS:
 		_col1._x = cosVal;
-		_col1._z = sinVal;
+		_col1._z = -sinVal;
 		_col2._y = 1.0;
-		_col3._x = -sinVal;
+		_col3._x = sinVal;
 		_col3._z = cosVal;
 		break;
 

--- a/engines/titanic/star_control/daffine.cpp
+++ b/engines/titanic/star_control/daffine.cpp
@@ -29,7 +29,7 @@ namespace Titanic {
 DAffine *DAffine::_static;
 
 DAffine::DAffine() :
-	_col1(0.0, 0.0, 0.0), _col2(0.0, 0.0, 0.0), _col3(0.0, 0.0, 0.0) {
+	_col1(0.0, 0.0, 0.0), _col2(0.0, 0.0, 0.0), _col3(0.0, 0.0, 0.0), _col4(0.0, 0.0, 0.0) {
 }
 
 DAffine::DAffine(int mode, const DVector &src) {
@@ -55,8 +55,8 @@ DAffine::DAffine(int mode, const DVector &src) {
 	}
 }
 
-DAffine::DAffine(Axis axis, double amount) {
-	setRotationMatrix(axis, amount);
+DAffine::DAffine(Axis axis, double angleDeg) {
+	setRotationMatrix(axis, angleDeg);
 }
 
 DAffine::DAffine(const FMatrix &src) {
@@ -74,10 +74,9 @@ void DAffine::deinit() {
 	_static = nullptr;
 }
 
-void DAffine::setRotationMatrix(Axis axis, double amount) {
-	const double FACTOR = 0.0174532925199433;
-	double sinVal = sin(amount * FACTOR);
-	double cosVal = cos(amount * FACTOR);
+void DAffine::setRotationMatrix(Axis axis, double angleDeg) {
+	double sinVal = sin(angleDeg * Deg2Rad);
+	double cosVal = cos(angleDeg * Deg2Rad);
 
 	switch (axis) {
 	case X_AXIS:

--- a/engines/titanic/star_control/daffine.h
+++ b/engines/titanic/star_control/daffine.h
@@ -50,6 +50,7 @@ public:
 	static void deinit();
 public:
 	DAffine();
+        //TODO: consider making mode an enum since that is more helpful when it is used in code
 	DAffine(int mode, const DVector &src);
 	DAffine(Axis axis, double angleDeg);
 	DAffine(const FMatrix &src);
@@ -69,18 +70,18 @@ public:
 	 */
 	DAffine inverseTransform() const;
 
-	/**
-	 * Change this Daffine to have its first three columns be some mapping from src matrix
-         * and the 4rth column to be (three) zeros. The mapping is not as simple as replacing
-         * matching row/colmn indices
-	 */
+       /**
+        * Change this Daffine to have its first three columns be some mapping from src matrix
+        * and the 4rth column to be (three) zeros. The mapping is not as simple as replacing
+        * matching row/colmn indices
+        */
 	void loadTransform(const CMatrixTransform &src);
 
-	/**
-	 * Do the affine product between this Daffine on the left
-         * and the m Daffine matrix on the right. This is product is NOT the same
-         * as multiplying two matrices of dimensions 4x4.
-	 */
+       /**
+        * Do the affine product between this Daffine on the right
+        * and the m Daffine matrix on the left. This product is NOT the same
+        * as multiplying two matrices of dimensions 3x4.
+        */
 	DAffine compose(const DAffine &m);
 };
 

--- a/engines/titanic/star_control/daffine.h
+++ b/engines/titanic/star_control/daffine.h
@@ -55,6 +55,11 @@ public:
 	DAffine(const FMatrix &src);
 
 	/**
+	 * Sets all elements to zero
+	 */
+	void clear();
+
+	/**
 	 * Sets up an affine matrix for rotating on a given axis by an amount in degrees
 	 */
 	void setRotationMatrix(Axis axis, double angleDeg);
@@ -65,8 +70,9 @@ public:
 	DAffine inverseTransform() const;
 
 	/**
-	 * Change this Daffine to have its first three columns be the src matrix
-         * and the 4rth column to be (three) zeros
+	 * Change this Daffine to have its first three columns be some mapping from src matrix
+         * and the 4rth column to be (three) zeros. The mapping is not as simple as replacing
+         * matching row/colmn indices
 	 */
 	void loadTransform(const CMatrixTransform &src);
 

--- a/engines/titanic/star_control/daffine.h
+++ b/engines/titanic/star_control/daffine.h
@@ -51,18 +51,30 @@ public:
 public:
 	DAffine();
 	DAffine(int mode, const DVector &src);
-	DAffine(Axis axis, double amount);
+	DAffine(Axis axis, double angleDeg);
 	DAffine(const FMatrix &src);
 
 	/**
-	 * Sets up a matrix for rotating on a given axis by a given amount
+	 * Sets up an affine matrix for rotating on a given axis by an amount in degrees
 	 */
-	void setRotationMatrix(Axis axis, double amount);
+	void setRotationMatrix(Axis axis, double angleDeg);
 
+	/**
+	 * Return the Inverse of this Daffine
+	 */
 	DAffine inverseTransform() const;
 
+	/**
+	 * Change this Daffine to have its first three columns be the src matrix
+         * and the 4rth column to be (three) zeros
+	 */
 	void loadTransform(const CMatrixTransform &src);
 
+	/**
+	 * Do the affine product between this Daffine on the left
+         * and the m Daffine matrix on the right. This is product is NOT the same
+         * as multiplying two matrices of dimensions 4x4.
+	 */
 	DAffine compose(const DAffine &m);
 };
 

--- a/engines/titanic/star_control/dvector.cpp
+++ b/engines/titanic/star_control/dvector.cpp
@@ -26,9 +26,6 @@
 
 namespace Titanic {
 
-const double Rad2Deg = 180.0 / M_PI;
-const double Deg2Rad = 1.0 / Rad2Deg;
-
 double DVector::normalize() {
 	double hyp = sqrt(_x * _x + _y * _y + _z * _z);
 	assert(hyp);

--- a/engines/titanic/star_control/dvector.cpp
+++ b/engines/titanic/star_control/dvector.cpp
@@ -86,13 +86,13 @@ DAffine DVector::getFrameTransform(const DVector &v) {
 
 	DVector vector1 = getAnglesAsVect();
 	matrix1.setRotationMatrix(X_AXIS, vector1._y * Rad2Deg);
-	matrix2.setRotationMatrix(Y_AXIS, -(vector1._z * Rad2Deg));
+	matrix2.setRotationMatrix(Y_AXIS, vector1._z * Rad2Deg);
 	matrix3 = matrix1.compose(matrix2);
 	matrix4 = matrix3.inverseTransform();
 
 	vector1 = v.getAnglesAsVect();
 	matrix1.setRotationMatrix(X_AXIS, vector1._y * Rad2Deg);
-	matrix2.setRotationMatrix(Y_AXIS, -(vector1._z * Rad2Deg));
+	matrix2.setRotationMatrix(Y_AXIS, vector1._z * Rad2Deg);
 	matrix3 = matrix1.compose(matrix2);
 
 	return matrix4.compose(matrix3);
@@ -102,7 +102,7 @@ DAffine DVector::rotXY() const {
 	DVector v1 = getAnglesAsVect();
 	DAffine m1, m2;
 	m1.setRotationMatrix(X_AXIS, v1._y * Rad2Deg);
-	m2.setRotationMatrix(Y_AXIS, -(v1._z * Rad2Deg));
+	m2.setRotationMatrix(Y_AXIS, v1._z * Rad2Deg);
 	return m1.compose(m2);
 }
 

--- a/engines/titanic/star_control/dvector.h
+++ b/engines/titanic/star_control/dvector.h
@@ -27,6 +27,9 @@
 
 namespace Titanic {
 
+const double Rad2Deg = 180.0 / M_PI;
+const double Deg2Rad = 1.0 / Rad2Deg;
+
 class DAffine;
 
 /**


### PR DESCRIPTION
1. Move useful constants in dvector moved to header from the cpp so that DAffine can use them.
2. Improved naming of parameters.
3. Added a clear function to setRotation. There should of been some errors fixed from its use in dvector (without the previous matrices values being reset). Previously if you called setRotation twice it would only update the elements it was changing the 2nd time and not erase the previous values.
4. Changed convention for Y axis rotation. Now all three rotations are consistent with wikipedia. Dvector::getFrameTransform was aware of this and was negating the value so that result should still be same. However, star_camera.cpp line 288 was not so after locking onto the 2nd star the y-axis rotation will now go in the opposite direction as before. The direction is now what the code suggests that that it wants. 

I don't see a big difference in the behavior of the puzzle after this change.