### PR TITLE
TITANIC: Daffine and fmatrix work

### DIFF
--- a/engines/titanic/star_control/daffine.cpp
+++ b/engines/titanic/star_control/daffine.cpp
@@ -115,69 +115,29 @@ void DAffine::setRotationMatrix(Axis axis, double angleDeg) {
 	}
 }
 
-//TODO: Check math and provide source
+//TODO: Check column 4 math
 DAffine DAffine::inverseTransform() const {
-	double val1 = _col1._x * _col3._z * _col2._y;
-	double val2 = 0.0;
-	double val3 = val1;
+        DAffine m;
+       //Inverse of rotation matrix is the transpose
+	m._col1._x = _col1._x;
+	m._col2._x = _col1._y;
+	m._col3._x = _col1._z;
+	m._col1._y = _col2._x;
+	m._col2._y = _col2._y;
+	m._col3._y = _col2._z;
+	m._col1._z = _col3._x;
+	m._col2._z = _col3._y;
+	m._col3._z = _col3._z;
 
-	if (val1 < 0.0) {
-		val2 = val3;
-		val1 = 0.0;
-	}
-
-	double val4 = _col3._x * _col1._y * _col2._z;
-	if (val4 < 0.0)
-		val2 = val2 + val4;
-	else
-		val1 = val1 + val4;
-
-	double val5 = _col3._y * _col1._z * _col2._x;
-	if (val5 < 0.0)
-		val2 = val2 + val5;
-	else
-		val1 = val1 + val5;
-
-	if (-(_col3._x * _col2._y * _col1._z) < 0.0)
-		val2 = val2 - _col3._x * _col2._y * _col1._z;
-	else
-		val1 = val1 - _col3._x * _col2._y * _col1._z;
-	if (-(_col1._y * _col3._z * _col2._x) < 0.0)
-		val2 = val2 - _col1._y * _col3._z * _col2._x;
-	else
-		val1 = val1 - _col1._y * _col3._z * _col2._x;
-
-	val3 = _col3._y * _col2._z;
-	double val6 = -(_col1._x * val3);
-	if (val6 < 0.0)
-		val2 = val2 + val6;
-	else
-		val1 = val1 + val6;
-
-	double val7 = val2 + val1;
-	assert(!(val7 == 0.0 || fabs(val7 / (val1 - val2)) < 1.0e-10));
-
-	double val8 = _col3._z * _col2._y;
-	double val9 = 1.0 / val7;
-
-	DAffine m;
-	m._col1._x = (val8 - val3) * val9;
-	m._col2._x = -((_col3._z * _col2._x - _col3._x * _col2._z) * val9);
-	m._col3._x = (_col3._y * _col2._x - _col3._x * _col2._y) * val9;
-	m._col1._y = -((_col1._y * _col3._z - _col3._y * _col1._z) * val9);
-	m._col2._y = (_col1._x * _col3._z - _col3._x * _col1._z) * val9;
-	m._col3._y = -((_col1._x * _col3._y - _col3._x * _col1._y) * val9);
-	m._col1._z = (_col1._y * _col2._z - _col2._y * _col1._z) * val9;
-	m._col2._z = -((_col1._x * _col2._z - _col1._z * _col2._x) * val9);
-	m._col3._z = (_col1._x * _col2._y - _col1._y * _col2._x) * val9;
-
-	m._col4._x = -(m._col1._x * _col4._x + _col4._y * m._col2._x
-		+ _col4._z * m._col3._x);
-	m._col4._y = -(_col4._z * m._col3._y + _col4._y * m._col2._y
-		+ _col4._x * m._col1._y);
-	m._col4._z = -(_col4._z * m._col3._z + _col4._x * m._col1._z
-		+ _col4._y * m._col2._z);
-
+	m._col4._x = -(_col4._x * m._col1._x
+                    + _col4._y * m._col2._x
+		     + _col4._z * m._col3._x);
+	m._col4._y = -(_col4._x * m._col1._y
+                    + _col4._y * m._col2._y
+                    + _col4._z * m._col3._y);
+	m._col4._z = -(_col4._x * m._col1._z
+                    + _col4._y * m._col2._z
+                    + _col4._z * m._col3._z);
 	return m;
 }
 

--- a/engines/titanic/star_control/fpose.cpp
+++ b/engines/titanic/star_control/fpose.cpp
@@ -146,69 +146,28 @@ void FPose::copyFrom(const FMatrix &src) {
 	_row3 = src._row3;
 }
 
-// This looks like DAffine DAffine::inverseTransform()
-FPose FPose::fn4() const {
-	float v2, v3, v6, v7, v8, v9, v10, v11;
-	float v12, v13, v14, v15, v16, v17, v18;
+FPose FPose::inverseTransform() const {
 	FPose result;
 
-	v16 = _row3._z * _row2._y;
-	v2 = _row1._x * v16;
-	v3 = 0.0;
-	v18 = v2;
-	if (v2 < 0.0) {
-		v3 = v18;
-		v2 = 0.0;
-	}
-	v6 = _row3._x * _row1._y * _row2._z;
-	if (v6 < 0.0)
-		v3 = v3 + v6;
-	else
-		v2 = v2 + v6;
-	v7 = _row3._y * _row1._z * _row2._x;
-	if (v7 < 0.0)
-		v3 = v3 + v7;
-	else
-		v2 = v2 + v7;
-	if (-(_row3._x * _row1._z * _row2._y) < 0.0)
-		v3 = v3 - _row3._x * _row1._z * _row2._y;
-	else
-		v2 = v2 - _row3._x * _row1._z * _row2._y;
-	if (-(_row1._y * _row2._x * _row3._z) < 0.0)
-		v3 = v3 - _row1._y * _row2._x * _row3._z;
-	else
-		v2 = v2 - _row1._y * _row2._x * _row3._z;
-	v17 = _row2._z * _row3._y;
-	if (-(_row1._x * v17) < 0.0)
-		v3 = v3 - _row1._x * v17;
-	else
-		v2 = v2 - _row1._x * v17;
-	v18 = v3 + v2;
-	assert(!(v18 == 0.0 || fabs(v18 / (v2 - v3)) < 1.0e-10));
+	result._row1._x = _row1._x;
+	result._row2._x = _row1._y;
+	result._row3._x = _row1._z;
+	result._row1._y = _row2._x;
+	result._row2._y = _row2._y;
+	result._row3._y = _row2._z;
+	result._row1._z = _row3._x;
+	result._row2._z = _row3._y;
+	result._row3._z = _row3._z;
 
-	v8 = 1.0 / v18;
-	v18 = v8;
-	result._row1._x = (v16 - v17) * v8;
-	result._row2._x = -(_row2._x * _row3._z - _row3._x * _row2._z) * v8;
-	result._row3._x = (_row3._y * _row2._x - _row3._x * _row2._y) * v8;
-	result._row1._y = -(_row1._y * _row3._z - _row3._y * _row1._z) * v8;
-	result._row2._y = (_row1._x * _row3._z - _row3._x * _row1._z) * v8;
-	result._row3._y = -(_row1._x * _row3._y - _row3._x * _row1._y) * v8;
-	result._row1._z = (_row1._y * _row2._z - _row1._z * _row2._y) * v8;
-	result._row2._z = -(_row1._x * _row2._z - _row1._z * _row2._x) * v8;
-	v9 = result._row1._x;
-	v10 = result._row2._y;
-	v11 = result._row3._y;
-	v12 = result._row1._z;
-	v13 = result._row2._z;
-	result._row3._z = (_row1._x * _row2._y - _row1._y * _row2._x) * v18;
-	v14 = v9;
-	v15 = result._row3._z;
-	result._vector._x = -(v14 * _vector._x
-		+ _vector._y * result._row2._x
-		+ _vector._z * result._row3._x);
-	result._vector._y = -(_vector._x * result._row1._y + v10 * _vector._y + v11 * _vector._z);
-	result._vector._z = -(v12 * _vector._x + v13 * _vector._y + v15 * _vector._z);
+	result._vector._x = -(_vector._x * result._row1._x
+		            + _vector._y * result._row2._x
+		            + _vector._z * result._row3._x);
+	result._vector._y = -(_vector._x * result._row1._y
+                           + _vector._y * result._row2._y
+                           + _vector._z * result._row3._y);
+	result._vector._z = -(_vector._x * result._row1._z
+                           + _vector._y * result._row2._z
+                           + _vector._z * result._row3._z);
 
 	return result;
 }

--- a/engines/titanic/star_control/fpose.cpp
+++ b/engines/titanic/star_control/fpose.cpp
@@ -83,6 +83,7 @@ void FPose::identity() {
 	_vector.clear();
 }
 
+// Source: https://en.wikipedia.org/wiki/Rotation_matrix
 void FPose::setRotationMatrix(Axis axis, float amount) {
 	const float ROTATION = 2 * M_PI / 360.0;
 	float sinVal = sin(amount * ROTATION);
@@ -104,11 +105,11 @@ void FPose::setRotationMatrix(Axis axis, float amount) {
 	case Y_AXIS:
 		_row1._x = cosVal;
 		_row1._y = 0.0;
-		_row1._z = sinVal;
+		_row1._z = -sinVal;
 		_row2._x = 0.0;
 		_row2._y = 1.0;
 		_row2._z = 0.0;
-		_row3._x = -sinVal;
+		_row3._x = sinVal;
 		_row3._y = 0.0;
 		_row3._z = cosVal;
 		break;
@@ -145,6 +146,7 @@ void FPose::copyFrom(const FMatrix &src) {
 	_row3 = src._row3;
 }
 
+// This looks like DAffine DAffine::inverseTransform()
 FPose FPose::fn4() const {
 	float v2, v3, v6, v7, v8, v9, v10, v11;
 	float v12, v13, v14, v15, v16, v17, v18;

--- a/engines/titanic/star_control/fpose.h
+++ b/engines/titanic/star_control/fpose.h
@@ -29,6 +29,7 @@ namespace Titanic {
 
 /*
  * This class combines a position and orientation in 3D space
+ * TODO: consider merging with DAffine
  */
 class FPose : public FMatrix {
 public:
@@ -59,6 +60,9 @@ public:
 	 */
 	void copyFrom(const FMatrix &src);
 
+        /**
+         * Probably the inverse of the this 3x4
+         */
 	FPose fn4() const;
 };
 

--- a/engines/titanic/star_control/fpose.h
+++ b/engines/titanic/star_control/fpose.h
@@ -29,7 +29,7 @@ namespace Titanic {
 
 /*
  * This class combines a position and orientation in 3D space
- * TODO: consider merging with DAffine
+ * TODO: Merge with DAffine
  */
 class FPose : public FMatrix {
 public:
@@ -61,9 +61,9 @@ public:
 	void copyFrom(const FMatrix &src);
 
         /**
-         * Probably the inverse of the this 3x4
+         * The inverse of rotation and the position vector
          */
-	FPose fn4() const;
+	FPose inverseTransform() const;
 };
 
 } // End of namespace Titanic

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -230,14 +230,14 @@ void CStarCamera::setViewportAngle(const FPoint &angles) {
 	if (_matrixRow == -1) {
 		// No locked markers
 		FPose subX(X_AXIS, angles._y);
-		FPose subY(Y_AXIS, angles._x);
+		FPose subY(Y_AXIS, -angles._x); // needs to be negative or looking left will cause the view to go right
 		FPose sub(subX, subY);
 		proc22(sub);
 	} else if (_matrixRow == 0) {
 		// 1 marker is locked in
 		FVector row1 = _matrix._row1;
 		FPose poseX(X_AXIS, angles._y);
-		FPose poseY(Y_AXIS, angles._x);
+		FPose poseY(Y_AXIS, -angles._x); // needs to be negative or looking left will cause the view to go right
 		FPose pose(poseX, poseY);
 
 		FMatrix m1 = _viewport.getOrientation();

--- a/engines/titanic/star_control/star_view.cpp
+++ b/engines/titanic/star_control/star_view.cpp
@@ -176,9 +176,8 @@ bool CStarView::KeyCharMsg(int key, CErrorCode *errorCode) {
 	}
 
 	case Common::KEYCODE_z:
-	case Common::KEYCODE_c:
 		if (matchedIndex == -1) {
-			pose.setRotationMatrix(key == Common::KEYCODE_z ? Y_AXIS : X_AXIS, 1.0);
+			pose.setRotationMatrix(Y_AXIS, -1.0);
 			_camera.proc22(pose);
 			_camera.updatePosition(errorCode);
 			return true;
@@ -211,7 +210,7 @@ bool CStarView::KeyCharMsg(int key, CErrorCode *errorCode) {
 
 	case Common::KEYCODE_x:
 		if (matchedIndex == -1) {
-			pose.setRotationMatrix(Y_AXIS, -1.0);
+			pose.setRotationMatrix(Y_AXIS, 1.0);
 			_camera.proc22(pose);
 			_camera.updatePosition(errorCode);
 			return true;
@@ -220,7 +219,7 @@ bool CStarView::KeyCharMsg(int key, CErrorCode *errorCode) {
 
 	case Common::KEYCODE_QUOTE:
 		if (matchedIndex == -1) {
-			pose.setRotationMatrix(X_AXIS, -1.0);
+			pose.setRotationMatrix(X_AXIS, 1.0);
 			_camera.proc22(pose);
 			_camera.updatePosition(errorCode);
 			return true;
@@ -229,7 +228,7 @@ bool CStarView::KeyCharMsg(int key, CErrorCode *errorCode) {
 
 	case Common::KEYCODE_SLASH:
 		if (matchedIndex == -1) {
-			pose.setRotationMatrix(X_AXIS, 1.0);
+			pose.setRotationMatrix(X_AXIS, -1.0);
 			_camera.proc22(pose);
 			_camera.updatePosition(errorCode);
 			return true;

--- a/engines/titanic/star_control/viewport.cpp
+++ b/engines/titanic/star_control/viewport.cpp
@@ -248,7 +248,7 @@ void CViewport::reset() {
 
 	_rawPose.copyFrom(_orientation);
 	_rawPose._vector = _position;
-	_currentPose = _rawPose.fn4();
+	_currentPose = _rawPose.inverseTransform();
 
 	_center = FPoint((double)_width * 0.5, (double)_height * 0.5);
 	_centerVector._x = MIN(_center._x, _center._y);


### PR DESCRIPTION
1. Changed fpose, which is like daffine, but float, to have yaxis rotation like wikipedia
2. Fixed unmarked looking with keyboard keys and mouse going wrong way because of last change by adding negatives to angle directions.
3. Replaced inverse computation for daffine and fpose to just take transpose for rotation part of inverse.
This replaces a lot of code, and prevents stability issues.