### PR TITLE
SCUMM: Prevent darkenPallete() in Room 0 in FT, fixes bug #9871

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1636,6 +1636,9 @@ void ScummEngine_v6::o6_roomOps() {
 		c = pop();
 		b = pop();
 		a = pop();
+		// Prevent assert() error with corner case, fixes bug #9871
+		if (_game.id == GID_FT && _roomResource == 0)
+			break;
 		darkenPalette(a, a, a, b, c);
 		break;
 


### PR DESCRIPTION
Room 0 is a blank screen, fading out has no effect. So simply skipping the call is a reasonable way to prevent the crash mentioned in the bug report.