### PR TITLE
CONFIGURE: Silence undefined-var-template warning

### DIFF
--- a/configure
+++ b/configure
@@ -164,6 +164,7 @@ _build_scalers=yes
 _build_hq_scalers=yes
 _enable_prof=no
 _global_constructors=no
+_no_undefined_var_template=no
 _bink=yes
 _cloud=auto
 # Default vkeybd/keymapper/eventrec options
@@ -2023,12 +2024,29 @@ echocheck "whether -Wglobal-constructors work"
 cat > $TMPC << EOF
 int main() { return 0; }
 EOF
-cc_check -Wglobal-constructors && _global_constructors=yes
+cc_check -Wglobal-constructors -Werror && _global_constructors=yes
 
 if test "$_global_constructors" = yes; then
 	append_var CXXFLAGS "-Wglobal-constructors"
 fi
 echo $_global_constructors
+
+# If the compiler supports the -Wundefined-var-template flag, silence that warning.
+# We get this warning a lot with regard to the Singleton class as we explicitly
+# instantiate each specialisation. An alternate way to deal with it would be to
+# change the way we instantiate the singleton classes as done in PR #967.
+# Note: we check the -Wundefined-var-template as gcc does not error out on unknown
+# -Wno-xxx flags.
+echocheck "whether -Wno-undefined-var-template work"
+cat > $TMPC << EOF
+int main() { return 0; }
+EOF
+cc_check -Wundefined-var-template -Werror && _no_undefined_var_template=yes
+
+if test "$_no_undefined_var_template" = yes; then
+	append_var CXXFLAGS "-Wno-undefined-var-template"
+fi
+echo $_no_undefined_var_template
 
 echo_n "Checking for $_host_alias-strings... " >> "$TMPLOG"
 if `which $_host_alias-strings >/dev/null 2>&1`; then


### PR DESCRIPTION
We get this warning a lot for the Singleton class due to the way we instantiate its specializations. An alternative way to fix the issue would be to change the way we do this instantiation, as proposed in PR #967, but this had drawbacks (related to loading plugins).

Silencing the warning doesn't seem to be an issue to me as we get a link error anyway in case we forget an instantiation. The warning is only useful insofar as it allows pinpointing the exact issue.

I opted to check if the flag is supported rather than add it depending if have_clang is set to yes and the compiler version as apple uses different clang versions from other releases, and using the gcc version reported by clang might not be a good indicator.

Note: I also added a `-Werror` when we check if a warning is supported, as otherwise, at least with clang, using an unsupported warning flag only produces a warning and returns status 0. So the flag ends up being used.

The change works as expected for the impacted clang version. I have not tested with older versions or gcc but I am counting on the travis checks in this PR to confirm my change are fine for those.