### PR TITLE
TITANIC: CStarCamera Refactoring and CStarCrosshairs logic fix

### DIFF
--- a/engines/titanic/star_control/base_stars.cpp
+++ b/engines/titanic/star_control/base_stars.cpp
@@ -561,7 +561,7 @@ int CBaseStars::baseFn2(CSurfaceArea *surfaceArea, CStarCamera *camera) {
 /*------------------------------------------------------------------------*/
 
 void CStarVector::apply() {
-	_owner->adDAffineRow(_vector);
+	_owner->addLockedStar(_vector);
 }
 
 } // End of namespace Titanic

--- a/engines/titanic/star_control/base_stars.cpp
+++ b/engines/titanic/star_control/base_stars.cpp
@@ -23,6 +23,7 @@
 #include "titanic/star_control/base_stars.h"
 #include "titanic/star_control/star_camera.h"
 #include "titanic/star_control/star_ref.h"
+#include "titanic/support/simple_file.h"
 #include "titanic/titanic.h"
 
 namespace Titanic {

--- a/engines/titanic/star_control/base_stars.h
+++ b/engines/titanic/star_control/base_stars.h
@@ -23,7 +23,6 @@
 #ifndef TITANIC_BASE_STARS_H
 #define TITANIC_BASE_STARS_H
 
-#include "titanic/support/simple_file.h"
 #include "titanic/star_control/frange.h"
 #include "titanic/star_control/star_closeup.h"
 #include "titanic/star_control/surface_area.h"
@@ -33,6 +32,7 @@ namespace Titanic {
 enum StarMode { MODE_STARFIELD = 0, MODE_PHOTO = 1 };
 
 class CStarCamera;
+class SimpleFile;
 
 struct CBaseStarEntry {
 	byte _red;

--- a/engines/titanic/star_control/camera_auto_mover.cpp
+++ b/engines/titanic/star_control/camera_auto_mover.cpp
@@ -49,8 +49,12 @@ void CCameraAutoMover::proc2(const FVector &oldPos, const FVector &newPos,
 	_srcPos = oldPos;
 	_destPos = newPos;
 	_posDelta = _destPos - _srcPos;
-	_distance = _posDelta.normalize();
-
+       float temp = 0.0;
+	if (!_posDelta.normalize(temp)) { // Do the normalization, put the scale amount in temp,
+                                         // but if it is unsuccessful, crash
+              assert(temp);
+       }
+       _distance = temp;
 	_active = false;
 	_field34 = false;
 	_transitionPercent = 1.0;
@@ -73,8 +77,12 @@ void CCameraAutoMover::setPath(const FVector &srcV, const FVector &destV, const 
 	_srcPos = srcV;
 	_destPos = destV;
 	_posDelta = _destPos - _srcPos;
-	_distance = _posDelta.normalize();
-
+       float temp = 0.0;
+	if (!_posDelta.normalize(temp)) { // Do the normalization, put the scale amount in temp,
+                                         // but if it is unsuccessful, crash
+              assert(temp);
+       }
+       _distance = temp;
 	_active = false;
 	_field34 = false;
 	_field40 = -1;

--- a/engines/titanic/star_control/camera_auto_mover.cpp
+++ b/engines/titanic/star_control/camera_auto_mover.cpp
@@ -21,7 +21,10 @@
  */
 
 #include "titanic/star_control/camera_auto_mover.h"
+#include "titanic/star_control/fmatrix.h"
+#include "titanic/star_control/error_code.h"
 #include "common/textconsole.h"
+
 
 namespace Titanic {
 

--- a/engines/titanic/star_control/camera_auto_mover.h
+++ b/engines/titanic/star_control/camera_auto_mover.h
@@ -23,12 +23,14 @@
 #ifndef TITANIC_CAMERA_AUTO_MOVER_H
 #define TITANIC_CAMERA_AUTO_MOVER_H
 
-#include "titanic/star_control/error_code.h"
-#include "titanic/star_control/fmatrix.h"
 #include "titanic/star_control/fvector.h"
 #include "titanic/star_control/orientation_changer.h"
+#include "common/array.h"
 
 namespace Titanic {
+
+class CErrorCode;
+class FMatrix;
 
 /**
  * Base class for automatic movement of the starview camera

--- a/engines/titanic/star_control/dvector.cpp
+++ b/engines/titanic/star_control/dvector.cpp
@@ -26,14 +26,16 @@
 
 namespace Titanic {
 
-double DVector::normalize() {
-	double hyp = sqrt(_x * _x + _y * _y + _z * _z);
-	assert(hyp);
+bool DVector::normalize(double & hyp) {
+	hyp = sqrt(_x * _x + _y * _y + _z * _z);
+	if (hyp==0) {
+              return false;
+       }
 
 	_x *= 1.0 / hyp;
 	_y *= 1.0 / hyp;
 	_z *= 1.0 / hyp;
-	return hyp;
+	return true;
 }
 
 double DVector::getDistance(const DVector &src) {
@@ -73,7 +75,11 @@ void DVector::rotVectAxisY(double angleDeg) {
 DVector DVector::getAnglesAsVect() const {
 	DVector vector = *this;
 	DVector dest;
-	dest._x = vector.normalize(); // scale that makes this vector have magnitude=1, also does the scaling
+
+       if (!vector.normalize(dest._x)) {  // Makes this vector have magnitude=1, put the scale amount in dest._x,
+                                          // but if it is unsuccessful, crash
+              assert(dest._x);
+       }
 	dest._y = acos(vector._y);    // radian distance/angle that this vector's y component is from the +y axis,
                                       // result is restricted to [0,pi]
 	dest._z = atan2(vector._x,vector._z); // result is restricted to [-pi,pi]

--- a/engines/titanic/star_control/dvector.h
+++ b/engines/titanic/star_control/dvector.h
@@ -44,7 +44,16 @@ public:
 	DVector(double x, double y, double z) : _x(x), _y(y), _z(z) {}
 	DVector(const FVector &v) : _x(v._x), _y(v._y), _z(v._z) {}
 
-	double normalize();
+	/**
+	 * Attempts to normalizes the vector so the length from origin equals 1.0
+        * Return value is whether or not it was successful in normalizing
+        * First argument is scale value that normalizes the vector
+        * TODO: split this function into 2. One that calculates the normalization
+        * and another that does the normalization. The 2nd would assert if a 
+        * normalization of one was requested. This is cleaner than the current 
+        * implementation.
+	 */
+	bool normalize(double &);
 
 	/**
 	 * Returns the distance between this vector and the passed one

--- a/engines/titanic/star_control/fmatrix.cpp
+++ b/engines/titanic/star_control/fmatrix.cpp
@@ -127,10 +127,18 @@ void FMatrix::set(const FVector &v) {
 	_row2 = _row3.fn1();
 
 	_row1 = _row3.crossProduct(_row2);
-	_row1.normalize();
+
+       float unused_scale=0.0;
+       if (!_row1.normalize(unused_scale)) {  // Do the normalization, put the scale amount in unused_scale,
+                                              // but if it is unsuccessful, crash
+              assert(unused_scale);
+       }
 
 	_row2 = _row3.crossProduct(_row1);
-	_row2.normalize();
+       if (!_row2.normalize(unused_scale)) {  // Do the normalization, put the scale amount in unused_scale,
+                                              // but if it is unsuccessful, crash
+              assert(unused_scale);
+       }
 }
 
 void FMatrix::matRProd(const FMatrix &m) {

--- a/engines/titanic/star_control/fmatrix.cpp
+++ b/engines/titanic/star_control/fmatrix.cpp
@@ -22,6 +22,7 @@
 
 #include "titanic/star_control/fmatrix.h"
 #include "titanic/star_control/daffine.h"
+#include "titanic/support/simple_file.h"
 
 namespace Titanic {
 
@@ -39,7 +40,7 @@ void matProd(const FMatrix &a, const FMatrix &m, FMatrix &C) {
 	C._row3._z = a._row3._x * m._row1._z + a._row3._y * m._row2._z + a._row3._z * m._row3._z;
 }
 
-// member functions
+// Member functions
 
 FMatrix::FMatrix() :
 	_row1(1.0, 0.0, 0.0), _row2(0.0, 1.0, 0.0), _row3(0.0, 0.0, 1.0) {

--- a/engines/titanic/star_control/fmatrix.h
+++ b/engines/titanic/star_control/fmatrix.h
@@ -23,13 +23,13 @@
 #ifndef TITANIC_FMATRIX_H
 #define TITANIC_FMATRIX_H
 
-#include "titanic/support/simple_file.h"
 #include "titanic/star_control/fvector.h"
 
 namespace Titanic {
 
 class DAffine;
 class DVector;
+class SimpleFile;
 
 /**
  * Floating point matrix class.

--- a/engines/titanic/star_control/fvector.cpp
+++ b/engines/titanic/star_control/fvector.cpp
@@ -48,20 +48,25 @@ FVector FVector::crossProduct(const FVector &src) const {
 	);
 }
 
-float FVector::normalize() {
-	float hyp = sqrt(_x * _x + _y * _y + _z * _z);
-	assert(hyp);
+bool FVector::normalize(float & hyp) {
+	hyp = sqrt(_x * _x + _y * _y + _z * _z);
+	if (hyp==0) {
+              return false;
+       }
 
 	_x *= 1.0 / hyp;
 	_y *= 1.0 / hyp;
 	_z *= 1.0 / hyp;
-	return hyp;
+	return true;
 }
 
 FVector FVector::addAndNormalize(const FVector &v) const {
 	FVector tempV(_x + v._x, _y + v._y, _z + v._z);
-	tempV.normalize();
-
+       float unused_scale=0.0;
+       if (!tempV.normalize(unused_scale)) {  // Do the normalization, put the scale amount in unused_scale,
+                                              // but if it is unsuccessful, crash
+              assert(unused_scale);
+       }
 	return tempV;
 }
 

--- a/engines/titanic/star_control/fvector.h
+++ b/engines/titanic/star_control/fvector.h
@@ -59,9 +59,15 @@ public:
 	FVector crossProduct(const FVector &src) const;
 
 	/**
-	 * Normalizes the vector so the length from origin equals 1.0
+	 * Attempts to normalizes the vector so the length from origin equals 1.0
+        * Return value is whether or not it was successful in normalizing
+        * First argument is scale value that normalizes the vector
+        * TODO: split this function into 2. One that calculates the normalization
+        * and another that does the normalization. The 2nd would assert if a 
+        * normalization of one was requested. This is cleaner than the current 
+        * implementation.
 	 */
-	float normalize();
+	bool normalize(float &);
 
 	/**
 	 * Adds the current vector and a passed one together, normalizes them,

--- a/engines/titanic/star_control/marked_auto_mover.cpp
+++ b/engines/titanic/star_control/marked_auto_mover.cpp
@@ -21,6 +21,8 @@
  */
 
 #include "titanic/star_control/marked_auto_mover.h"
+#include "titanic/star_control/error_code.h"
+#include "common/array.h"
 #include "common/textconsole.h"
 
 namespace Titanic {

--- a/engines/titanic/star_control/marked_camera_mover.cpp
+++ b/engines/titanic/star_control/marked_camera_mover.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "titanic/star_control/marked_camera_mover.h"
+#include "common/array.h"
 #include "common/textconsole.h"
 
 namespace Titanic {

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -21,10 +21,14 @@
  */
 
 #include "titanic/star_control/star_camera.h"
-#include "titanic/star_control/unmarked_camera_mover.h"
-#include "titanic/star_control/marked_camera_mover.h"
+#include "titanic/star_control/camera_mover.h"
 #include "titanic/star_control/daffine.h"
 #include "titanic/star_control/fmatrix.h"
+#include "titanic/star_control/fpoint.h"
+#include "titanic/star_control/marked_camera_mover.h"
+#include "titanic/star_control/unmarked_camera_mover.h"
+#include "titanic/star_control/error_code.h"
+#include "titanic/support/simple_file.h"
 #include "titanic/titanic.h"
 
 namespace Titanic {
@@ -51,6 +55,10 @@ void CStarCamera::deinit() {
 	delete _newOrientation;
 	_priorOrientation = nullptr;
 	_newOrientation = nullptr;
+}
+
+bool CStarCamera::isLocked() { 
+       return _mover->isLocked(); 
 }
 
 CStarCamera::~CStarCamera() {

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -276,9 +276,14 @@ void CStarCamera::setViewportAngle(const FPoint &angles) {
 		tempV4 -= tempV1;
 		tempV5 -= tempV1;
 		tempV6 -= tempV1;
-		tempV4.normalize();
-		tempV5.normalize();
-		tempV6.normalize();
+
+              float unused_scale=0.0;
+              if (!tempV4.normalize(unused_scale) ||
+                  !tempV5.normalize(unused_scale) ||
+                  !tempV6.normalize(unused_scale)) {  // Do the normalization, put the scale amount in unused_scale,
+                                                      // but if it is unsuccessful, crash
+                     assert(unused_scale);
+              }
 
 		tempV1 += row1;
 		m1.set(tempV4, tempV5, tempV6);
@@ -345,9 +350,15 @@ void CStarCamera::setViewportAngle(const FPoint &angles) {
 		mrow1 -= tempV3;
 		mrow2 -= tempV3;
 		mrow3 -= tempV3;
-		mrow1.normalize();
-		mrow2.normalize();
-		mrow3.normalize();
+
+              double unused_scale=0.0;
+              if (!mrow1.normalize(unused_scale) ||
+                  !mrow2.normalize(unused_scale) ||
+                  !mrow3.normalize(unused_scale)) {  // Do the normalization, put the scale amount in unused_scale,
+                                                     // but if it is unsuccessful, crash
+                     assert(unused_scale);
+              }
+
 		tempV16 = tempV3;
 
 		m3.set(mrow1, mrow2, mrow3);
@@ -459,8 +470,12 @@ void CStarCamera::lockMarker1(FVector v1, FVector v2, FVector v3) {
 	tempV._x = val9 - _viewport._valArray[2];
 	tempV._y = val8;
 
-	v3.normalize();
-	tempV.normalize();
+       float unused_scale=0.0;
+       if (!v3.normalize(unused_scale) ||
+        !tempV.normalize(unused_scale)) {  // Do the normalization, put the scale amount in unused_scale,
+                                           // but if it is unsuccessful, crash
+              assert(unused_scale);
+       }
 
 	FMatrix matrix = _viewport.getOrientation();
 	const FVector &pos = _viewport._position;
@@ -548,9 +563,15 @@ void CStarCamera::lockMarker2(CViewport *viewport, const FVector &v) {
 	m4._col2 -= m4._col1;
 	m4._col4 -= m4._col1;
 
-	m4._col3.normalize();
-	m4._col2.normalize();
-	m4._col4.normalize();
+       double unused_scale=0.0;
+       if (!m4._col2.normalize(unused_scale) ||
+           !m4._col3.normalize(unused_scale) ||
+           !m4._col4.normalize(unused_scale) ) {  // Do the normalizations, put the scale amount in unused_scale,
+                                                  // but if any of the normalizations are unsuccessful,
+                                                  // crash
+              assert(unused_scale);
+       }
+       
 	m5.set(m4._col3, m4._col2, m4._col4);
 
 	FVector newPos = m4._col1;

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -563,21 +563,24 @@ void CStarCamera::lockMarker2(CViewport *viewport, const FVector &v) {
 	m4._col2 -= m4._col1;
 	m4._col4 -= m4._col1;
 
+       FMatrix m6 = _viewport.getOrientation();
+
        double unused_scale=0.0;
        if (!m4._col2.normalize(unused_scale) ||
            !m4._col3.normalize(unused_scale) ||
            !m4._col4.normalize(unused_scale) ) {  // Do the normalizations, put the scale amount in unused_scale,
-                                                  // but if any of the normalizations are unsuccessful,
-                                                  // crash
+                                                  // but if any of the normalizations are unsuccessful, crash
               assert(unused_scale);
        }
        
 	m5.set(m4._col3, m4._col2, m4._col4);
 
 	FVector newPos = m4._col1;
-	FMatrix m6 = _viewport.getOrientation();
-	_mover->proc8(_viewport._position, newPos, m6, m5);
-
+	
+       if (_viewport._position != newPos) {
+              // Only change view if positions are different
+	       _mover->proc8(_viewport._position, newPos, m6, m5);
+       }
 	CStarVector *sv = new CStarVector(this, v);
 	_mover->setVector(sv);
 }
@@ -591,7 +594,11 @@ void CStarCamera::lockMarker3(CViewport *viewport, const FVector &v) {
 	FVector newPos = viewport->_position;
 	FVector oldPos = _viewport._position;
 
-	_mover->proc8(oldPos, newPos, oldOr, newOr);
+       if (oldPos != newPos) {
+              // Only change view if positions are different
+	       _mover->proc8(oldPos, newPos, oldOr, newOr);
+       }
+
 	CStarVector *sv = new CStarVector(this, v);
 	_mover->setVector(sv);
 }

--- a/engines/titanic/star_control/star_camera.cpp
+++ b/engines/titanic/star_control/star_camera.cpp
@@ -362,7 +362,7 @@ void CStarCamera::setViewportAngle(const FPoint &angles) {
        }
 }
 
-bool CStarCamera::adDAffineRow(const FVector v) {
+bool CStarCamera::addLockedStar(const FVector v) {
 	if (_star_lock_state == THREE_LOCKED)
 		return false;
 
@@ -376,7 +376,7 @@ bool CStarCamera::adDAffineRow(const FVector v) {
 	return true;
 }
 
-bool CStarCamera::removeMatrixRow() {
+bool CStarCamera::removeLockedStar() {
 	if (_star_lock_state == ZERO_LOCKED)
 		return false;
 

--- a/engines/titanic/star_control/star_camera.h
+++ b/engines/titanic/star_control/star_camera.h
@@ -33,6 +33,8 @@
 
 namespace Titanic {
 
+enum StarLockState { ZERO_LOCKED=0, ONE_LOCKED=1, TWO_LOCKED=2, THREE_LOCKED=3 };
+
 /**
  * Implements a reference point from which the starmap can be viewed
  */
@@ -41,7 +43,7 @@ private:
 	static FMatrix *_priorOrientation;
 	static FMatrix *_newOrientation;
 private:
-	int _matrixRow;
+	StarLockState _star_lock_state;
 	FMatrix _matrix;
 	CCameraMover *_mover;
 	CViewport _viewport;
@@ -107,7 +109,7 @@ public:
 	virtual void increaseForwardSpeed();
 
 	/**
-	 * Decreases movement speed in backward direction
+	 * Increases movement speed in backward direction
 	 */
 	virtual void increaseBackwardSpeed();
 
@@ -155,7 +157,10 @@ public:
 	 */
 	virtual void setViewportAngle(const FPoint &angles);
 
-	virtual int getMatrixRow() const { return _matrixRow; }
+	/**
+	 * How many stars are currently locked onto
+	 */
+	virtual StarLockState getStarLockState() const { return _star_lock_state; }
 
 	/**
 	 * Adds the row for a locked in marker

--- a/engines/titanic/star_control/star_camera.h
+++ b/engines/titanic/star_control/star_camera.h
@@ -165,13 +165,18 @@ public:
 	virtual StarLockState getStarLockState() const { return _star_lock_state; }
 
 	/**
-	 * Adds the row for a locked in marker
+	 * Adds the row for a locked in marker/star
 	 * @remarks		This can't be a pass-by-reference, since adding
 	 * the vector for the star destroys the calling star vector
 	 */
-	virtual bool adDAffineRow(const FVector v);
+	virtual bool addLockedStar(const FVector v);
 
-	virtual bool removeMatrixRow();
+	/**
+	 * Removes the most recent locked in marker/star
+	 * @remarks		This can't be a pass-by-reference, since adding
+	 * the vector for the star destroys the calling star vector
+	 */
+	virtual bool removeLockedStar();
 	virtual void proc36(double *v1, double *v2, double *v3, double *v4);
 
 	/**

--- a/engines/titanic/star_control/star_camera.h
+++ b/engines/titanic/star_control/star_camera.h
@@ -23,15 +23,17 @@
 #ifndef TITANIC_STAR_CAMERA_H
 #define TITANIC_STAR_CAMERA_H
 
-#include "titanic/support/simple_file.h"
 #include "titanic/star_control/fmatrix.h"
-#include "titanic/star_control/fpoint.h"
 #include "titanic/star_control/base_stars.h"
 #include "titanic/star_control/viewport.h"
-#include "titanic/star_control/camera_mover.h"
-#include "titanic/star_control/error_code.h"
 
 namespace Titanic {
+
+class CCameraMover;
+class CErrorCode;
+class CNavigationInfo;
+class FPoint;
+class SimpleFile;
 
 enum StarLockState { ZERO_LOCKED=0, ONE_LOCKED=1, TWO_LOCKED=2, THREE_LOCKED=3 };
 
@@ -62,7 +64,7 @@ private:
 	/**
 	 * Return whether the handler is locked
 	 */
-	bool isLocked() { return _mover->isLocked(); }
+	bool isLocked();
 public:
 	static void init();
 	static void deinit();

--- a/engines/titanic/star_control/star_control.cpp
+++ b/engines/titanic/star_control/star_control.cpp
@@ -20,17 +20,18 @@
  *
  */
 
-#include "titanic/support/screen_manager.h"
-#include "titanic/pet_control/pet_control.h"
 #include "titanic/star_control/star_control.h"
 #include "titanic/star_control/daffine.h"
-#include "titanic/star_control/error_code.h"
 #include "titanic/star_control/fpose.h"
+#include "titanic/star_control/camera_mover.h"
 #include "titanic/star_control/star_camera.h"
-#include "titanic/game_manager.h"
+#include "titanic/star_control/error_code.h"
 #include "titanic/core/dont_save_file_item.h"
 #include "titanic/core/project_item.h"
 #include "titanic/core/view_item.h"
+#include "titanic/pet_control/pet_control.h"
+#include "titanic/support/screen_manager.h"
+#include "titanic/game_manager.h"
 
 namespace Titanic {
 

--- a/engines/titanic/star_control/star_crosshairs.cpp
+++ b/engines/titanic/star_control/star_crosshairs.cpp
@@ -39,9 +39,15 @@ void CStarCrosshairs::selectStar(int index, CVideoSurface *surface,
 			// All the stars selected so far have been matched. Only allow
 			// a selection addition if not all three stars have been found
 			if (!isSolved()) {
-				// Don't allow the most recent match to be re-selected
+				// Don't allow the most recent match or the one before
+                            // it to be re-selected (while they are locked/matched)
 				if (_positions[index] != _entries[_entryIndex]) {
-					surface->lock();
+					if (_entryIndex == 1) {//2 stars are matched
+                                          if (_positions[index] == _entries[_entryIndex-1]) {
+                                                 return;
+                                          }
+                                   }
+                                   surface->lock();
 
 					// Draw crosshairs around the selected star
 					CSurfaceArea surfaceArea(surface);
@@ -63,6 +69,7 @@ void CStarCrosshairs::selectStar(int index, CVideoSurface *surface,
 			// So we allow the user to reselect it to remove the selection, or shift
 			// the selection to some other star
 			if (_positions[index] == _entries[_entryIndex]) {
+                            // Player has selected the most recent star
 				// Remove the crosshairs for the previously selected star
 				surface->lock();
 				CSurfaceArea surfaceArea(surface);
@@ -76,6 +83,16 @@ void CStarCrosshairs::selectStar(int index, CVideoSurface *surface,
 				const CBaseStarEntry *starP = starField->getDataPtr(_positions[index]._index1);
 				markers->addStar(starP);
 			} else {
+                            // Player has selected some other star other than the most recent
+                            // Remove/Add it if it is not one of the other star(s) already matched
+
+                            // Check that it is not a previously star and don't remove it if it is
+                            for (int i=0;i<_entryIndex;i++) {
+                                   if (_positions[index] == _entries[i]) {
+                                          return;
+                                   }
+                            }
+                            
 				// Erase the prior selection and draw the new one
 				surface->lock();
 				CSurfaceArea surfaceArea(surface);

--- a/engines/titanic/star_control/star_view.cpp
+++ b/engines/titanic/star_control/star_view.cpp
@@ -20,13 +20,16 @@
  *
  */
 
-#include "titanic/support/screen_manager.h"
 #include "titanic/star_control/star_view.h"
+#include "titanic/star_control/camera_mover.h"
+#include "titanic/star_control/fvector.h"
 #include "titanic/star_control/star_control.h"
 #include "titanic/star_control/star_field.h"
+#include "titanic/star_control/error_code.h"
+#include "titanic/support/screen_manager.h"
+#include "titanic/support/simple_file.h"
 #include "titanic/core/game_object.h"
 #include "titanic/messages/pet_messages.h"
-#include "titanic/titanic.h"
 
 namespace Titanic {
 

--- a/engines/titanic/star_control/star_view.cpp
+++ b/engines/titanic/star_control/star_view.cpp
@@ -430,7 +430,7 @@ void CStarView::lockStar() {
 
 void CStarView::unlockStar() {
 	if (_starField && !_showingPhoto) {
-		_camera.removeMatrixRow();
+		_camera.removeLockedStar();
 		_starField->fn8(_photoSurface);
 	}
 }

--- a/engines/titanic/star_control/star_view.h
+++ b/engines/titanic/star_control/star_view.h
@@ -23,18 +23,17 @@
 #ifndef TITANIC_STAR_VIEW_H
 #define TITANIC_STAR_VIEW_H
 
-#include "titanic/support/simple_file.h"
-#include "titanic/support/video_surface.h"
 #include "titanic/star_control/star_camera.h"
 #include "titanic/star_control/viewport.h"
 #include "titanic/star_control/surface_fader.h"
-#include "titanic/star_control/error_code.h"
-#include "titanic/star_control/fvector.h"
 
 namespace Titanic {
 
+class CErrorCode;
 class CStarControl;
 class CStarField;
+class CVideoSurface;
+class FVector;
 
 class CStarView {
 private:

--- a/engines/titanic/star_control/unmarked_auto_mover.cpp
+++ b/engines/titanic/star_control/unmarked_auto_mover.cpp
@@ -21,6 +21,8 @@
  */
 
 #include "titanic/star_control/unmarked_auto_mover.h"
+#include "titanic/star_control/error_code.h"
+#include "common/array.h"
 #include "common/textconsole.h"
 
 namespace Titanic {

--- a/engines/titanic/star_control/unmarked_auto_mover.cpp
+++ b/engines/titanic/star_control/unmarked_auto_mover.cpp
@@ -98,7 +98,12 @@ int CUnmarkedAutoMover::proc5(CErrorCode &errorCode, FVector &pos, FMatrix &orie
 
 	v2 = orientation._row3;
 	v3 = _destPos - pos;
-	v3.normalize();
+
+       float unused_scale=0.0;
+       if (!v3.normalize(unused_scale)) {  // Do the normalization, put the scale amount in unused_scale,
+                                           // but if it is unsuccessful, crash
+              assert(unused_scale);
+       }
 
 	double val = orientation._row3._x * v3._x + orientation._row3._y * v3._y + orientation._row3._z * v3._z;
 	bool flag = false;

--- a/engines/titanic/star_control/unmarked_camera_mover.cpp
+++ b/engines/titanic/star_control/unmarked_camera_mover.cpp
@@ -21,10 +21,11 @@
  */
 
 #include "titanic/star_control/unmarked_camera_mover.h"
-#include "titanic/star_control/daffine.h"
 #include "titanic/star_control/dvector.h"
-#include "titanic/titanic.h"
+#include "titanic/star_control/daffine.h"
+#include "titanic/star_control/error_code.h"
 #include "common/textconsole.h"
+#include "titanic/titanic.h"
 
 namespace Titanic {
 


### PR DESCRIPTION
1. Added an enum for star_camera that is more informative about number of stars locked on. Many other classes still use it as an int so this could be expanded to those, later.
2. Reduce some file dependencies of files related to the star_camera class.
3. Some function renames and more comments
4. Fix for #10126. There were a lot of ways it crashed then mentioned in the ticket so I fixed all the different ways and tested the puzzle a lot. That section of code may benefit from case statements or more functions.