### PR TITLE
TITANIC: Don't allow unlocking stars while locking onto a star

### DIFF
--- a/engines/titanic/star_control/star_camera.h
+++ b/engines/titanic/star_control/star_camera.h
@@ -49,7 +49,8 @@ private:
 	FMatrix _lockedStarsPos; // Each row represents the location of a locked star
 	CCameraMover *_mover;
 	CViewport _viewport;
-	bool _isMoved;
+	bool _isMoved; // TODO: determine if this is being used
+	bool _isInLockingProcess; // The mover/view is homing in on a new star
 private:
 	/**
 	 * Set up a handler
@@ -75,6 +76,13 @@ public:
 
 	virtual void proc2(const CViewport *src);
 	virtual void proc3(const CNavigationInfo *src);
+
+	/**
+	 * The mover/view is not currently homing in on a new star
+	 * This can mean it is unmarked, or that it is fully locked 
+	 * onto one star or more (but not in the process of doing so)
+	 */
+	bool isNotInLockingProcess();
 
 	/**
 	 * Set the camera position

--- a/engines/titanic/star_control/star_view.cpp
+++ b/engines/titanic/star_control/star_view.cpp
@@ -434,7 +434,7 @@ void CStarView::lockStar() {
 }
 
 void CStarView::unlockStar() {
-	if (_starField && !_showingPhoto) {
+	if (_starField && !_showingPhoto && _camera.isNotInLockingProcess()) {
 		_camera.removeLockedStar();
 		_starField->fn8(_photoSurface);
 	}


### PR DESCRIPTION
Fixes #10170.

I've added a boolean variable that tracks whether the game is
in the process of locking onto a star or not.

When the user hits the unlock button _isInLockingProcess gets checked and
the request to unlock is denied if the locking on is currently happening.

Once the locking on is finished then the release is lifted and the user
can unlock at this time (or after locking onto the next star).