### PR TITLE
COMMON: Add helper macro for printing rects

### DIFF
--- a/common/rect.h
+++ b/common/rect.h
@@ -27,6 +27,8 @@
 #include "common/util.h"
 #include "common/debug.h"
 
+#define PRINT_RECT(x) (x).left,(x).top,(x).right,(x).bottom
+
 namespace Common {
 
 /**

--- a/engines/sci/graphics/helpers.h
+++ b/engines/sci/graphics/helpers.h
@@ -52,10 +52,6 @@ typedef int16 TextAlignment;
 #define PORTS_FIRSTWINDOWID 2
 #define PORTS_FIRSTSCRIPTWINDOWID 3
 
-#ifdef ENABLE_SCI32
-#define PRINT_RECT(x) (x).left,(x).top,(x).right,(x).bottom
-#endif
-
 struct Port {
 	uint16 id;
 	int16 top, left;


### PR DESCRIPTION
I’ve been using this macro fairly frequently in all sorts of code that uses rects during debugging, so it seems like something that would be generally useful. Since this changes `common/rect.h` it will invalidate pretty much every object cache so I didn’t want to just commit this and tie up buildbot for hours unexpectedly. Unless there is some objection to its inclusion in common, please feel free to land this whenever it won’t be too disruptive to others (or just let me know when that would be and I will do it then).