### PR TITLE
SDL: Do not reset window size when engines update rendering surface

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -27,6 +27,7 @@
 #include "common/noncopyable.h"
 #include "common/keyboard.h"
 
+#include "graphics/mode.h"
 #include "graphics/palette.h"
 
 /**
@@ -58,6 +59,7 @@ public:
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const = 0;
 #endif
 	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) = 0;
+	virtual void initSizeHint(const Graphics::ModeList &modes) = 0;
 	virtual int getScreenChangeID() const = 0;
 
 	virtual void beginGFXTransaction() = 0;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -509,16 +509,8 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, _glContextMajor);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, _glContextMinor);
 
-	if (!_window->createOrUpdateWindow(width, height, flags)) {
-		// We treat fullscreen requests as a "hint" for now. This means in
-		// case it is not available we simply ignore it.
-		if (_wantsFullScreen) {
-			_window->createOrUpdateWindow(width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
-		}
-
-		if (!_window->getSDLWindow()) {
-			return false;
-		}
+	if (!createOrUpdateWindow(width, height, flags)) {
+		return false;
 	}
 
 	_glContext = SDL_GL_CreateContext(_window->getSDLWindow());

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -268,22 +268,19 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) {
 	}
 }
 
-bool OpenGLSdlGraphicsManager::setGraphicsMode(int mode) {
+void OpenGLSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
 	// HACK: This is stupid but the SurfaceSDL backend defaults to 2x. This
 	// assures that the launcher (which requests 320x200) has a reasonable
 	// size. It also makes small games have a reasonable size (i.e. at least
 	// 640x400). We follow the same logic here until we have a better way to
 	// give hints to our backend for that.
-	_graphicsScale = 2;
+	if (w > 320) {
+		_graphicsScale = 1;
+	} else {
+		_graphicsScale = 2;
+	}
 
-	return OpenGLGraphicsManager::setGraphicsMode(mode);
-}
-
-void OpenGLSdlGraphicsManager::resetGraphicsScale() {
-	OpenGLGraphicsManager::resetGraphicsScale();
-
-	// HACK: See OpenGLSdlGraphicsManager::setGraphicsMode.
-	_graphicsScale = 1;
+	return OpenGLGraphicsManager::initSize(w, h, format);
 }
 
 #ifdef USE_RGB_COLOR

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -43,8 +43,7 @@ public:
 	virtual void setFeatureState(OSystem::Feature f, bool enable);
 	virtual bool getFeatureState(OSystem::Feature f);
 
-	virtual bool setGraphicsMode(int mode);
-	virtual void resetGraphicsScale();
+	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format) override;
 
 #ifdef USE_RGB_COLOR
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const;
@@ -69,6 +68,8 @@ protected:
 	virtual void refreshScreen();
 
 	virtual void *getProcAddress(const char *name) const;
+	virtual int getGraphicsModeScale(int mode) const override { return 1; }
+
 private:
 	bool setupMode(uint width, uint height);
 

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -23,12 +23,14 @@
 #include "backends/graphics/sdl/sdl-graphics.h"
 #include "backends/platform/sdl/sdl-sys.h"
 #include "backends/events/sdl/sdl-events.h"
+#include "common/config-manager.h"
 #include "common/textconsole.h"
+#include "graphics/scaler/aspect.h"
 
 SdlGraphicsManager::SdlGraphicsManager(SdlEventSource *source, SdlWindow *window)
 	: _eventSource(source), _window(window)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	, _allowWindowSizeReset(false), _lastFlags(0)
+	, _allowWindowSizeReset(false), _hintedWidth(0), _hintedHeight(0), _lastFlags(0)
 #endif
 	  {
 }
@@ -63,7 +65,7 @@ bool SdlGraphicsManager::setState(const State &state) {
 #ifdef USE_RGB_COLOR
 		initSize(state.screenWidth, state.screenHeight, &state.pixelFormat);
 #else
-		initSize(state.screenWidth, state.screenHeight, 0);
+		initSize(state.screenWidth, state.screenHeight, nullptr);
 #endif
 		setFeatureState(OSystem::kFeatureAspectRatioCorrection, state.aspectRatio);
 		setFeatureState(OSystem::kFeatureFullscreenMode, state.fullscreen);
@@ -76,8 +78,82 @@ bool SdlGraphicsManager::setState(const State &state) {
 	}
 }
 
+bool SdlGraphicsManager::defaultGraphicsModeConfig() const {
+	const Common::ConfigManager::Domain *transientDomain = ConfMan.getDomain(Common::ConfigManager::kTransientDomain);
+	if (transientDomain && transientDomain->contains("gfx_mode")) {
+		const Common::String &mode = transientDomain->getVal("gfx_mode");
+		if (!mode.equalsIgnoreCase("normal") && !mode.equalsIgnoreCase("default")) {
+			return false;
+		}
+	}
+
+	const Common::ConfigManager::Domain *gameDomain = ConfMan.getActiveDomain();
+	if (gameDomain && gameDomain->contains("gfx_mode")) {
+		const Common::String &mode = gameDomain->getVal("gfx_mode");
+		if (!mode.equalsIgnoreCase("normal") && !mode.equalsIgnoreCase("default")) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+int SdlGraphicsManager::getGraphicsModeIdByName(const Common::String &name) const {
+	const OSystem::GraphicsMode *mode = getSupportedGraphicsModes();
+	while (mode && mode->name != nullptr) {
+		if (name.equalsIgnoreCase(mode->name)) {
+			return mode->id;
+		}
+		++mode;
+	}
+	return -1;
+}
+
+void SdlGraphicsManager::initSizeHint(const Graphics::ModeList &modes) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-bool SdlGraphicsManager::createOrUpdateWindow(const int width, const int height, const Uint32 flags) {
+	const bool useDefault = defaultGraphicsModeConfig();
+
+	int scale = getGraphicsModeScale(getGraphicsModeIdByName(ConfMan.get("gfx_mode")));
+	if (scale == -1) {
+		warning("Unknown scaler; defaulting to 1");
+		scale = 1;
+	}
+
+	int16 bestWidth = 0, bestHeight = 0;
+	const Graphics::ModeList::const_iterator end = modes.end();
+	for (Graphics::ModeList::const_iterator it = modes.begin(); it != end; ++it) {
+		int16 width = it->width, height = it->height;
+
+		// TODO: Normalize AR correction by passing a PAR in the mode list
+		// instead of checking the dimensions here like this, since not all
+		// 320x200/640x400 uses are with non-square pixels (e.g. DreamWeb).
+		if (ConfMan.getBool("aspect_ratio")) {
+			if ((width == 320 && height == 200) || (width == 640 && height == 400)) {
+				height = real2Aspect(height);
+			}
+		}
+
+		if (!useDefault || width <= 320) {
+			width *= scale;
+			height *= scale;
+		}
+
+		if (bestWidth < width) {
+			bestWidth = width;
+		}
+
+		if (bestHeight < height) {
+			bestHeight = height;
+		}
+	}
+
+	_hintedWidth = bestWidth;
+	_hintedHeight = bestHeight;
+#endif
+}
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+bool SdlGraphicsManager::createOrUpdateWindow(int width, int height, const Uint32 flags) {
 	if (!_window) {
 		return false;
 	}
@@ -88,6 +164,13 @@ bool SdlGraphicsManager::createOrUpdateWindow(const int width, const int height,
 	// size or pixel format of the internal game surface (since a user may have
 	// resized the game window)
 	if (!_window->getSDLWindow() || _lastFlags != flags || _allowWindowSizeReset) {
+		if (_hintedWidth) {
+			width = _hintedWidth;
+		}
+		if (_hintedHeight) {
+			height = _hintedHeight;
+		}
+
 		if (!_window->createOrUpdateWindow(width, height, flags)) {
 			return false;
 		}

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -123,6 +123,17 @@ public:
 	SdlWindow *getWindow() const { return _window; }
 
 protected:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+public:
+	void unlockWindowSize() { _allowWindowSizeReset = true; }
+
+protected:
+	Uint32 _lastFlags;
+	bool _allowWindowSizeReset;
+
+	bool createOrUpdateWindow(const int width, const int height, const Uint32 flags);
+#endif
+
 	SdlEventSource *_eventSource;
 	SdlWindow *_window;
 };

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -122,14 +122,26 @@ public:
 	 */
 	SdlWindow *getWindow() const { return _window; }
 
+	virtual void initSizeHint(const Graphics::ModeList &modes) override;
+
 protected:
+	virtual int getGraphicsModeScale(int mode) const = 0;
+
+	bool defaultGraphicsModeConfig() const;
+	int getGraphicsModeIdByName(const Common::String &name) const;
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 public:
-	void unlockWindowSize() { _allowWindowSizeReset = true; }
+	void unlockWindowSize() {
+		_allowWindowSizeReset = true;
+		_hintedWidth = 0;
+		_hintedHeight = 0;
+	}
 
 protected:
 	Uint32 _lastFlags;
 	bool _allowWindowSizeReset;
+	int _hintedWidth, _hintedHeight;
 
 	bool createOrUpdateWindow(const int width, const int height, const Uint32 flags);
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -614,42 +614,25 @@ bool SurfaceSdlGraphicsManager::setGraphicsMode(int mode) {
 		break;
 #ifdef USE_SCALERS
 	case GFX_DOUBLESIZE:
+	case GFX_2XSAI:
+	case GFX_SUPER2XSAI:
+	case GFX_SUPEREAGLE:
+	case GFX_ADVMAME2X:
+	case GFX_TV2X:
+	case GFX_DOTMATRIX:
+#ifdef USE_HQ_SCALERS
+	case GFX_HQ2X:
+#endif
 		newScaleFactor = 2;
 		break;
 	case GFX_TRIPLESIZE:
-		newScaleFactor = 3;
-		break;
-
-	case GFX_2XSAI:
-		newScaleFactor = 2;
-		break;
-	case GFX_SUPER2XSAI:
-		newScaleFactor = 2;
-		break;
-	case GFX_SUPEREAGLE:
-		newScaleFactor = 2;
-		break;
-	case GFX_ADVMAME2X:
-		newScaleFactor = 2;
-		break;
 	case GFX_ADVMAME3X:
-		newScaleFactor = 3;
-		break;
 #ifdef USE_HQ_SCALERS
-	case GFX_HQ2X:
-		newScaleFactor = 2;
-		break;
 	case GFX_HQ3X:
+#endif
 		newScaleFactor = 3;
 		break;
 #endif
-	case GFX_TV2X:
-		newScaleFactor = 2;
-		break;
-	case GFX_DOTMATRIX:
-		newScaleFactor = 2;
-		break;
-#endif // USE_SCALERS
 
 	default:
 		warning("unknown gfx mode %d", mode);

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -332,7 +332,6 @@ void SurfaceSdlGraphicsManager::beginGFXTransaction() {
 	_transactionDetails.needHotswap = false;
 	_transactionDetails.needUpdatescreen = false;
 
-	_transactionDetails.normal1xScaler = false;
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	_transactionDetails.needTextureUpdate = false;
 #endif
@@ -657,7 +656,6 @@ bool SurfaceSdlGraphicsManager::setGraphicsMode(int mode) {
 		return false;
 	}
 
-	_transactionDetails.normal1xScaler = (mode == GFX_NORMAL);
 	if (_oldVideoMode.setup && _oldVideoMode.scaleFactor != newScaleFactor)
 		_transactionDetails.needHotswap = true;
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -784,9 +784,14 @@ void SurfaceSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFo
 	}
 #endif
 
-	// Avoid redundant res changes
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+	// Avoid redundant res changes, only in SDL1. In SDL2, redundancies may not
+	// actually be redundant if ScummVM is switching between game engines and
+	// the screen dimensions are being reinitialized, since window resizing is
+	// supposed to reset when this happens
 	if ((int)w == _videoMode.screenWidth && (int)h == _videoMode.screenHeight)
 		return;
+#endif
 
 	_videoMode.screenWidth = w;
 	_videoMode.screenHeight = h;
@@ -2797,7 +2802,7 @@ SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, 
 		createWindowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
 
-	if (!_window->createOrUpdateWindow(width, height, createWindowFlags)) {
+	if (!createOrUpdateWindow(width, height, createWindowFlags)) {
 		return nullptr;
 	}
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -190,6 +190,8 @@ protected:
 	/** Hardware screen */
 	SDL_Surface *_hwscreen;
 
+	virtual int getGraphicsModeScale(int mode) const override;
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/* SDL2 features a different API for 2D graphics. We create a wrapper
 	 * around this API to keep the code paths as close as possible. */

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -238,7 +238,6 @@ protected:
 		bool sizeChanged;
 		bool needHotswap;
 		bool needUpdatescreen;
-		bool normal1xScaler;
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		bool needTextureUpdate;
 #endif

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -113,6 +113,10 @@ void ModularBackend::initSize(uint w, uint h, const Graphics::PixelFormat *forma
 	_graphicsManager->initSize(w, h, format);
 }
 
+void ModularBackend::initSizeHint(const Graphics::ModeList &modes) {
+	_graphicsManager->initSizeHint(modes);
+}
+
 int ModularBackend::getScreenChangeID() const {
 	return _graphicsManager->getScreenChangeID();
 }

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -75,6 +75,7 @@ public:
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const;
 #endif
 	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL);
+	virtual void initSizeHint(const Graphics::ModeList &modes) override;
 	virtual int getScreenChangeID() const;
 
 	virtual void beginGFXTransaction();

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -223,6 +223,33 @@ bool SdlWindow::createOrUpdateWindow(int width, int height, uint32 flags) {
 	const uint32 oldNonUpdateableFlags = _lastFlags & ~updateableFlagsMask;
 	const uint32 newNonUpdateableFlags = flags & ~updateableFlagsMask;
 
+	const uint32 fullscreenFlags = flags & fullscreenMask;
+
+	// This is terrible, but there is no way in SDL to get information on the
+	// maximum bounds of a window with decoration, and SDL is too dumb to make
+	// sure the window's surface doesn't grow beyond the display bounds, which
+	// can easily happen with 3x scalers. There is a function in SDL to get the
+	// window decoration size, but it only exists starting in SDL 2.0.5, which
+	// is a buggy release on some platforms so we can't safely use 2.0.5+
+	// features since some users replace the SDL dynamic library with 2.0.4, and
+	// the documentation says it only works on X11 anyway, which means it is
+	// basically worthless. So we'll just try to keep things closeish to the
+	// maximum for now.
+	SDL_DisplayMode displayMode;
+	SDL_GetDesktopDisplayMode(0, &displayMode);
+	if (!fullscreenFlags) {
+		displayMode.w -= 20;
+		displayMode.h -= 30;
+	}
+
+	if (width > displayMode.w) {
+		width = displayMode.w;
+	}
+
+	if (height > displayMode.h) {
+		height = displayMode.h;
+	}
+
 	if (!_window || oldNonUpdateableFlags != newNonUpdateableFlags) {
 		destroyWindow();
 		_window = SDL_CreateWindow(_windowCaption.c_str(), _lastX,
@@ -231,8 +258,6 @@ bool SdlWindow::createOrUpdateWindow(int width, int height, uint32 flags) {
 			setupIcon();
 		}
 	} else {
-		const uint32 fullscreenFlags = flags & fullscreenMask;
-
 		if (fullscreenFlags) {
 			SDL_DisplayMode fullscreenMode;
 			fullscreenMode.w = width;

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -297,20 +297,28 @@ void OSystem_SDL::initBackend() {
 	dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->activateManager();
 }
 
-#if defined(USE_TASKBAR)
 void OSystem_SDL::engineInit() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->unlockWindowSize();
+#endif
+#ifdef USE_TASKBAR
 	// Add the started engine to the list of recent tasks
 	_taskbarManager->addRecent(ConfMan.getActiveDomainName(), ConfMan.get("description"));
 
 	// Set the overlay icon the current running engine
 	_taskbarManager->setOverlayIcon(ConfMan.getActiveDomainName(), ConfMan.get("description"));
+#endif
 }
 
 void OSystem_SDL::engineDone() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->unlockWindowSize();
+#endif
+#ifdef USE_TASKBAR
 	// Remove overlay icon
 	_taskbarManager->setOverlayIcon("", "");
-}
 #endif
+}
 
 void OSystem_SDL::initSDL() {
 	// Check if SDL has not been initialized

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -59,10 +59,8 @@ public:
 
 	// Override functions from ModularBackend and OSystem
 	virtual void initBackend();
-#if defined(USE_TASKBAR)
 	virtual void engineInit();
 	virtual void engineDone();
-#endif
 	virtual void quit();
 	virtual void fatalError();
 

--- a/common/system.h
+++ b/common/system.h
@@ -27,6 +27,7 @@
 #include "common/noncopyable.h"
 #include "common/list.h" // For OSystem::getSupportedFormats()
 #include "graphics/pixelformat.h"
+#include "graphics/mode.h"
 
 namespace Audio {
 class Mixer;
@@ -632,6 +633,18 @@ public:
 	 * @param format	the new virtual screen pixel format
 	 */
 	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) = 0;
+
+	/**
+	 * Send a list of graphics modes to the backend so it can make a decision
+	 * about the best way to set up the display hardware.
+	 *
+	 * Engines that switch between different virtual screen sizes during a game
+	 * should call this function prior to any call to initSize. Engines that use
+	 * only a single screen size do not need to call this function.
+	 *
+	 * @param modes the list of graphics modes the engine will probably use.
+	 */
+	virtual void initSizeHint(const Graphics::ModeList &modes) = 0;
 
 	/**
 	 * Return an int value which is changed whenever any screen

--- a/engines/access/access.cpp
+++ b/engines/access/access.cpp
@@ -153,7 +153,7 @@ AccessEngine::~AccessEngine() {
 }
 
 void AccessEngine::setVGA() {
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 }
 
 void AccessEngine::initialize() {

--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -681,7 +681,7 @@ void AdlEngine::gameLoop() {
 }
 
 Common::Error AdlEngine::run() {
-	initGraphics(DISPLAY_WIDTH * 2, DISPLAY_HEIGHT * 2, true);
+	initGraphics(DISPLAY_WIDTH * 2, DISPLAY_HEIGHT * 2);
 
 	_console = new Console(this);
 	_display = new Display();

--- a/engines/agi/graphics.cpp
+++ b/engines/agi/graphics.cpp
@@ -210,7 +210,7 @@ int GfxMgr::initVideo() {
 	_displayPixels = _displayScreenWidth * _displayScreenHeight;
 	_displayScreen = (byte *)calloc(_displayPixels, 1);
 
-	initGraphics(_displayScreenWidth, _displayScreenHeight, _displayScreenWidth > 320);
+	initGraphics(_displayScreenWidth, _displayScreenHeight);
 
 	setPalette(true); // set gfx-mode palette
 

--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -577,7 +577,7 @@ Common::Error AGOSEngine::init() {
 		_screenHeight = 200;
 	}
 
-	initGraphics(_screenWidth, _screenHeight, getGameType() == GType_FF || getGameType() == GType_PP);
+	initGraphics(_screenWidth, _screenHeight);
 
 	_midi = new MidiPlayer();
 

--- a/engines/avalanche/graphics.cpp
+++ b/engines/avalanche/graphics.cpp
@@ -68,7 +68,7 @@ GraphicManager::~GraphicManager() {
 }
 
 void GraphicManager::init() {
-	initGraphics(kScreenWidth, kScreenHeight * 2, true); // Doubling the height.
+	initGraphics(kScreenWidth, kScreenHeight * 2); // Doubling the height.
 
 	for (int i = 0; i < 64; ++i) {
 		_egaPalette[i][0] = (i >> 2 & 1) * 0xaa + (i >> 5 & 1) * 0x55;
@@ -799,7 +799,7 @@ void GraphicManager::menuRefreshScreen() {
 }
 
 void GraphicManager::menuInitialize() {
-	initGraphics(kScreenWidth, kMenuScreenHeight, true);
+	initGraphics(kScreenWidth, kMenuScreenHeight);
 	_menu.create(kScreenWidth, kMenuScreenHeight, Graphics::PixelFormat::createFormatCLUT8());
 }
 
@@ -808,7 +808,7 @@ void GraphicManager::menuFree() {
 }
 
 void GraphicManager::menuRestoreScreen() {
-	initGraphics(kScreenWidth, 2 * kScreenHeight, true);
+	initGraphics(kScreenWidth, 2 * kScreenHeight);
 }
 
 void GraphicManager::menuLoadPictures() {

--- a/engines/bbvs/bbvs.cpp
+++ b/engines/bbvs/bbvs.cpp
@@ -170,7 +170,7 @@ Common::Error BbvsEngine::run() {
 	_isSaveAllowed = false;
 	_hasSnapshot = false;
 
-	initGraphics(320, 240, false);
+	initGraphics(320, 240);
 
 	_screen = new Screen(_system);
 	_gameModule = new GameModule();

--- a/engines/bbvs/videoplayer.cpp
+++ b/engines/bbvs/videoplayer.cpp
@@ -37,7 +37,7 @@ void BbvsEngine::playVideo(int videoNum) {
 		videoFilename = Common::String::format("vid/video%03d.avi", videoNum - 1);
 
 	// Set the correct video mode
-	initGraphics(320, 240, false, 0);
+	initGraphics(320, 240, nullptr);
 	if (_system->getScreenFormat().bytesPerPixel == 1) {
 		warning("Couldn't switch to a RGB color video mode to play a video.");
 		return;
@@ -84,7 +84,7 @@ void BbvsEngine::playVideo(int videoNum) {
 
 	delete videoDecoder;
 
-	initGraphics(320, 240, false);
+	initGraphics(320, 240);
 
 }
 

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -139,7 +139,7 @@ bool BladeRunnerEngine::hasFeature(EngineFeature f) const {
 
 Common::Error BladeRunnerEngine::run() {
 	Graphics::PixelFormat format = createRGB555();
-	initGraphics(640, 480, true, &format);
+	initGraphics(640, 480, &format);
 
 	_system->showMouse(true);
 

--- a/engines/cge/cge.cpp
+++ b/engines/cge/cge.cpp
@@ -219,7 +219,7 @@ Common::Error CGEEngine::run() {
 	}
 
 	// Initialize graphics using following:
-	initGraphics(kScrWidth, kScrHeight, false);
+	initGraphics(kScrWidth, kScrHeight);
 
 	// Setup necessary game objects
 	init();

--- a/engines/cge2/cge2.cpp
+++ b/engines/cge2/cge2.cpp
@@ -191,7 +191,7 @@ bool CGE2Engine::hasFeature(EngineFeature f) const {
 
 Common::Error CGE2Engine::run() {
 	syncSoundSettings();
-	initGraphics(kScrWidth, kScrHeight, false);
+	initGraphics(kScrWidth, kScrHeight);
 
 	init();
 	cge2_main();

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -83,8 +83,8 @@ void ChewyEngine::initialize() {
 
 Common::Error ChewyEngine::run() {
 	// Initialize backend
-	//initGraphics(640, 480, true);
-	initGraphics(320, 200, false);
+	//initGraphics(640, 480);
+	initGraphics(320, 200);
 
 	initialize();
 

--- a/engines/cine/cine.cpp
+++ b/engines/cine/cine.cpp
@@ -94,8 +94,14 @@ void CineEngine::syncSoundSettings() {
 }
 
 Common::Error CineEngine::run() {
+	Graphics::ModeList modes;
+	modes.push_back(Graphics::Mode(320, 200));
 	if (g_cine->getGameType() == GType_FW && (g_cine->getFeatures() & GF_CD)) {
+		modes.push_back(Graphics::Mode(640, 480));
+		initGraphicsModes(modes);
 		showSplashScreen();
+	} else {
+		initGraphicsModes(modes);
 	}
 
 	// Initialize backend

--- a/engines/cine/cine.cpp
+++ b/engines/cine/cine.cpp
@@ -99,7 +99,7 @@ Common::Error CineEngine::run() {
 	}
 
 	// Initialize backend
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 
 	if (g_cine->getGameType() == GType_FW && (g_cine->getFeatures() & GF_CD))
 		checkCD();
@@ -259,7 +259,7 @@ void CineEngine::showSplashScreen() {
 
 	const Graphics::Surface *surface = decoder.getSurface();
 	if (surface->w == 640 && surface->h == 480) {
-		initGraphics(640, 480, true);
+		initGraphics(640, 480);
 
 		const byte *palette = decoder.getPalette();
 		int paletteColorCount = decoder.getPaletteColorCount();

--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -101,7 +101,7 @@ Common::Error ComposerEngine::run() {
 	uint height = 480;
 	if (_bookIni.hasKey("Height", "Common"))
 		height = atoi(getStringFromConfig("Common", "Height").c_str());
-	initGraphics(width, height, true);
+	initGraphics(width, height);
 	_screen.create(width, height, Graphics::PixelFormat::createFormatCLUT8());
 
 	Graphics::Cursor *cursor = Graphics::makeDefaultWinCursor();

--- a/engines/cruise/cruise.cpp
+++ b/engines/cruise/cruise.cpp
@@ -84,7 +84,7 @@ bool CruiseEngine::hasFeature(EngineFeature f) const {
 
 Common::Error CruiseEngine::run() {
 	// Initialize backend
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 
 	if (!loadLanguageStrings()) {
 		error("Could not setup language data for your version");

--- a/engines/cryo/cryo.cpp
+++ b/engines/cryo/cryo.cpp
@@ -74,7 +74,7 @@ Common::Error CryoEngine::run() {
 	_timerTicks = 0;   // incremented in realtime
 
 	// Initialize graphics using following:
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 	_screen.create(320, 200, Graphics::PixelFormat::createFormatCLUT8());
 
 	_game->run();

--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -228,7 +228,7 @@ void DirectorEngine::testFontScaling() {
 	int w = 640;
 	int h = 480;
 
-	initGraphics(w, h, true);
+	initGraphics(w, h);
 	_system->getPaletteManager()->setPalette(defaultPalette, 0, 256);
 
 	Graphics::ManagedSurface surface;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1170,7 +1170,7 @@ Common::Rect Score::readRect(Common::ReadStreamEndian &stream) {
 }
 
 void Score::startLoop() {
-	initGraphics(_movieRect.width(), _movieRect.height(), true);
+	initGraphics(_movieRect.width(), _movieRect.height());
 
 	_surface->create(_movieRect.width(), _movieRect.height());
 	_trailSurface->create(_movieRect.width(), _movieRect.height());

--- a/engines/dm/dm.cpp
+++ b/engines/dm/dm.cpp
@@ -357,7 +357,7 @@ Common::Error DMEngine::run() {
 	initConstants();
 
 	// scummvm/engine specific
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 	_console = new Console(this);
 	_displayMan = new DisplayMan(this);
 	_dungeonMan = new DungeonMan(this);

--- a/engines/draci/draci.cpp
+++ b/engines/draci/draci.cpp
@@ -150,7 +150,7 @@ static SoundArchive* openAnyPossibleDubbing() {
 
 int DraciEngine::init() {
 	// Initialize graphics using following:
-	initGraphics(kScreenWidth, kScreenHeight, false);
+	initGraphics(kScreenWidth, kScreenHeight);
 
 	// Open game's archives
 	_initArchive = new BArchive(initPath);

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -236,7 +236,7 @@ bool DrasculaEngine::hasFeature(EngineFeature f) const {
 
 Common::Error DrasculaEngine::run() {
 	// Initialize backend
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 
 	switch (getLanguage()) {
 	case Common::EN_ANY:

--- a/engines/dreamweb/stubs.cpp
+++ b/engines/dreamweb/stubs.cpp
@@ -22,6 +22,7 @@
 
 #include "dreamweb/sound.h"
 #include "dreamweb/dreamweb.h"
+#include "engines/util.h"
 #include "common/config-manager.h"
 #include "common/file.h"
 
@@ -562,6 +563,11 @@ void DreamWebEngine::dreamweb() {
 		_foreignRelease = true;
 		break;
 	}
+
+	Graphics::ModeList modes;
+	modes.push_back(Graphics::Mode(320, 200));
+	modes.push_back(Graphics::Mode(640, 480));
+	initGraphicsModes(modes);
 
 	allocateBuffers();
 

--- a/engines/dreamweb/titles.cpp
+++ b/engines/dreamweb/titles.cpp
@@ -99,7 +99,7 @@ void DreamWebEngine::gettingShot() {
 }
 
 void DreamWebEngine::bibleQuote() {
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 
 	showPCX("I00");
 	fadeScreenUps();
@@ -285,7 +285,7 @@ void DreamWebEngine::realCredits() {
 	_sound->loadRoomsSample(_roomsSample);
 	_sound->volumeSet(0);
 
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 	hangOn(35);
 
 	showPCX("I01");

--- a/engines/dreamweb/vgagrafx.cpp
+++ b/engines/dreamweb/vgagrafx.cpp
@@ -151,7 +151,7 @@ void DreamWebEngine::doShake() {
 
 void DreamWebEngine::setMode() {
 	waitForVSync();
-	initGraphics(kScreenwidth, kScreenheight, false);
+	initGraphics(kScreenwidth, kScreenheight);
 }
 
 void DreamWebEngine::showPCX(const Common::String &suffix) {

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -194,38 +194,16 @@ void Engine::initializePath(const Common::FSNode &gamePath) {
 	SearchMan.addDirectory(gamePath.getPath(), gamePath, 0, 4);
 }
 
-void initCommonGFX(bool defaultTo1XScaler) {
+void initCommonGFX() {
 	const Common::ConfigManager::Domain *transientDomain = ConfMan.getDomain(Common::ConfigManager::kTransientDomain);
 	const Common::ConfigManager::Domain *gameDomain = ConfMan.getActiveDomain();
 
 	assert(transientDomain);
 
-	const bool useDefaultGraphicsMode =
-		(!transientDomain->contains("gfx_mode") ||
-		!scumm_stricmp(transientDomain->getVal("gfx_mode").c_str(), "normal") ||
-		!scumm_stricmp(transientDomain->getVal("gfx_mode").c_str(), "default")
-		)
-		 &&
-		(
-		!gameDomain ||
-		!gameDomain->contains("gfx_mode") ||
-		!scumm_stricmp(gameDomain->getVal("gfx_mode").c_str(), "normal") ||
-		!scumm_stricmp(gameDomain->getVal("gfx_mode").c_str(), "default")
-		);
-
-	// See if the game should default to 1x scaler
-	if (useDefaultGraphicsMode && defaultTo1XScaler) {
-		g_system->resetGraphicsScale();
-	} else {
-		// Override global scaler with any game-specific define
-		if (ConfMan.hasKey("gfx_mode")) {
-			Common::String gfxMode = ConfMan.get("gfx_mode");
-			g_system->setGraphicsMode(gfxMode.c_str());
-
-			// HACK: For OpenGL modes, we will still honor the graphics scale override
-			if (defaultTo1XScaler && gfxMode.equalsIgnoreCase("opengl"))
-				g_system->resetGraphicsScale();
-		}
+	// Override global scaler with any game-specific define
+	if (ConfMan.hasKey("gfx_mode")) {
+		Common::String gfxMode = ConfMan.get("gfx_mode");
+		g_system->setGraphicsMode(gfxMode.c_str());
 	}
 
 	// Note: The following code deals with the fullscreen / ASR settings. This
@@ -307,11 +285,11 @@ void splashScreen() {
 	splash = true;
 }
 
-void initGraphics(int width, int height, bool defaultTo1xScaler, const Graphics::PixelFormat *format) {
+void initGraphics(int width, int height, const Graphics::PixelFormat *format) {
 
 	g_system->beginGFXTransaction();
 
-		initCommonGFX(defaultTo1xScaler);
+		initCommonGFX();
 #ifdef USE_RGB_COLOR
 		if (format)
 			g_system->initSize(width, height, format);
@@ -399,20 +377,20 @@ inline PixelFormat findCompatibleFormat(Common::List<PixelFormat> backend, Commo
 }
 
 
-void initGraphics(int width, int height, bool defaultTo1xScaler, const Common::List<Graphics::PixelFormat> &formatList) {
+void initGraphics(int width, int height, const Common::List<Graphics::PixelFormat> &formatList) {
 	Graphics::PixelFormat format = findCompatibleFormat(g_system->getSupportedFormats(), formatList);
-	initGraphics(width, height, defaultTo1xScaler, &format);
+	initGraphics(width, height, &format);
 }
 
-void initGraphics(int width, int height, bool defaultTo1xScaler) {
+void initGraphics(int width, int height) {
 	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
-	initGraphics(width, height, defaultTo1xScaler, &format);
+	initGraphics(width, height, &format);
 }
 
 void GUIErrorMessage(const Common::String &msg) {
 	g_system->setWindowCaption("Error");
 	g_system->beginGFXTransaction();
-		initCommonGFX(false);
+		initCommonGFX();
 		g_system->initSize(320, 200);
 	if (g_system->endGFXTransaction() == OSystem::kTransactionSuccess) {
 		GUI::MessageDialog dialog(msg);

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -353,9 +353,6 @@ void initGraphics(int width, int height, const Graphics::PixelFormat *format) {
 	}
 }
 
-
-using Graphics::PixelFormat;
-
 /**
  * Determines the first matching format between two lists.
  *
@@ -364,16 +361,16 @@ using Graphics::PixelFormat;
  * @return			The first item on the backend list that also occurs on the frontend list
  *					or PixelFormat::createFormatCLUT8() if no matching formats were found.
  */
-inline PixelFormat findCompatibleFormat(Common::List<PixelFormat> backend, Common::List<PixelFormat> frontend) {
+inline Graphics::PixelFormat findCompatibleFormat(const Common::List<Graphics::PixelFormat> &backend, const Common::List<Graphics::PixelFormat> &frontend) {
 #ifdef USE_RGB_COLOR
-	for (Common::List<PixelFormat>::iterator i = backend.begin(); i != backend.end(); ++i) {
-		for (Common::List<PixelFormat>::iterator j = frontend.begin(); j != frontend.end(); ++j) {
+	for (Common::List<Graphics::PixelFormat>::const_iterator i = backend.begin(); i != backend.end(); ++i) {
+		for (Common::List<Graphics::PixelFormat>::const_iterator j = frontend.begin(); j != frontend.end(); ++j) {
 			if (*i == *j)
 				return *i;
 		}
 	}
 #endif
-	return PixelFormat::createFormatCLUT8();
+	return Graphics::PixelFormat::createFormatCLUT8();
 }
 
 

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -280,7 +280,7 @@ Common::Error FullpipeEngine::saveGameState(int slot, const Common::String &desc
 Common::Error FullpipeEngine::run() {
 	const Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
 	// Initialize backend
-	initGraphics(800, 600, true, &format);
+	initGraphics(800, 600, &format);
 
 	_backgroundSurface = new Graphics::Surface;
 	_backgroundSurface->create(800, 600, format);

--- a/engines/gnap/gnap.cpp
+++ b/engines/gnap/gnap.cpp
@@ -200,7 +200,7 @@ Common::Error GnapEngine::run() {
 #else
 	Graphics::PixelFormat format = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
 #endif
-	initGraphics(800, 600, true, &format);
+	initGraphics(800, 600, &format);
 
 	// We do not support color conversion yet
 	if (_system->getScreenFormat() != format)

--- a/engines/gob/gob.cpp
+++ b/engines/gob/gob.cpp
@@ -260,7 +260,7 @@ void GobEngine::setTrueColor(bool trueColor) {
 
 	_features = (_features & ~kFeaturesTrueColor) | (trueColor ? kFeaturesTrueColor : 0);
 
-	_video->setSize(is640x480());
+	_video->setSize();
 
 	_pixelFormat = g_system->getScreenFormat();
 
@@ -708,7 +708,7 @@ Common::Error GobEngine::initGraphics() {
 		_mode   = 0x14;
 	}
 
-	_video->setSize(is640x480());
+	_video->setSize();
 
 	_pixelFormat = g_system->getScreenFormat();
 

--- a/engines/gob/gob.cpp
+++ b/engines/gob/gob.cpp
@@ -25,6 +25,7 @@
 #include "backends/audiocd/audiocd.h"
 #include "base/plugins.h"
 #include "common/config-manager.h"
+#include "engines/util.h"
 #include "audio/mididrv.h"
 #include "audio/mixer.h"
 
@@ -707,6 +708,13 @@ Common::Error GobEngine::initGraphics() {
 		_height = 200;
 		_mode   = 0x14;
 	}
+
+	Graphics::ModeList modes;
+	modes.push_back(Graphics::Mode(_width, _height));
+	if (getGameType() == kGameTypeLostInTime) {
+		modes.push_back(Graphics::Mode(640, 400));
+	}
+	initGraphicsModes(modes);
 
 	_video->setSize();
 

--- a/engines/gob/inter_v2.cpp
+++ b/engines/gob/inter_v2.cpp
@@ -797,7 +797,7 @@ void Inter_v2::o2_initScreen() {
 			height = _vm->_height = 400;
 			_vm->_global->_colorCount = 16;
 
-			_vm->_video->setSize(true);
+			_vm->_video->setSize();
 
 		} else if (_vm->_global->_videoMode == 0x10) {
 
@@ -810,7 +810,7 @@ void Inter_v2::o2_initScreen() {
 			_vm->_height = 200;
 			_vm->_global->_colorCount = 256;
 
-			_vm->_video->setSize(false);
+			_vm->_video->setSize();
 
 		}
 	}

--- a/engines/gob/inter_v5.cpp
+++ b/engines/gob/inter_v5.cpp
@@ -140,13 +140,13 @@ void Inter_v5::o5_initScreen() {
 		_vm->_width = 320;
 		_vm->_height = 200;
 
-		_vm->_video->setSize(false);
+		_vm->_video->setSize();
 
 	} else if (_vm->_global->_videoMode == 0x13) {
 		width = _vm->_width = 640;
 		height = _vm->_height = 480;
 
-		_vm->_video->setSize(true);
+		_vm->_video->setSize();
 	}
 
 	_vm->_global->_fakeVideoMode = videoMode;

--- a/engines/gob/video.cpp
+++ b/engines/gob/video.cpp
@@ -237,11 +237,11 @@ void Video::clearScreen() {
 	g_system->fillScreen(0);
 }
 
-void Video::setSize(bool defaultTo1XScaler) {
+void Video::setSize() {
 	if (_vm->isTrueColor())
-		initGraphics(_vm->_width, _vm->_height, defaultTo1XScaler, 0);
+		initGraphics(_vm->_width, _vm->_height, nullptr);
 	else
-		initGraphics(_vm->_width, _vm->_height, defaultTo1XScaler);
+		initGraphics(_vm->_width, _vm->_height);
 }
 
 void Video::retrace(bool mouse) {

--- a/engines/gob/video.h
+++ b/engines/gob/video.h
@@ -112,7 +112,7 @@ public:
 	void initPrimary(int16 mode);
 	SurfacePtr initSurfDesc(int16 width, int16 height, int16 flags = 0);
 
-	void setSize(bool defaultTo1XScaler);
+	void setSize();
 
 	void clearScreen();
 	void retrace(bool mouse = true);

--- a/engines/groovie/groovie.cpp
+++ b/engines/groovie/groovie.cpp
@@ -106,7 +106,7 @@ Common::Error GroovieEngine::run() {
 	case kGroovieV2: {
 		// Request the mode with the highest precision available
 		Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
-		initGraphics(640, 480, true, &format);
+		initGraphics(640, 480, &format);
 
 		if (_system->getScreenFormat() != format)
 			return Common::kUnsupportedColorMode;
@@ -116,7 +116,7 @@ Common::Error GroovieEngine::run() {
 		break;
 	}
 	case kGroovieT7G:
-		initGraphics(640, 480, true);
+		initGraphics(640, 480);
 		_pixelFormat = Graphics::PixelFormat::createFormatCLUT8();
 		break;
 	}

--- a/engines/hopkins/graphics.cpp
+++ b/engines/hopkins/graphics.cpp
@@ -106,7 +106,7 @@ GraphicsManager::~GraphicsManager() {
 void GraphicsManager::setGraphicalMode(int width, int height) {
 	if (!_initGraphicsFl) {
 		Graphics::PixelFormat pixelFormat16(2, 5, 6, 5, 0, 11, 5, 0, 0);
-		initGraphics(width, height, true, &pixelFormat16);
+		initGraphics(width, height, &pixelFormat16);
 
 		// Init surfaces
 		_backBuffer = _vm->_globals->allocMemory(SCREEN_WIDTH * 2 * SCREEN_HEIGHT);

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -218,7 +218,7 @@ void HugoEngine::gameOverMsg() {
 
 Common::Error HugoEngine::run() {
 	s_Engine = this;
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 
 	_mouse = new MouseHandler(this);
 	_inventory = new InventoryHandler(this);

--- a/engines/kyra/screen.cpp
+++ b/engines/kyra/screen.cpp
@@ -253,10 +253,8 @@ void Screen::setResolution() {
 	_system->getPaletteManager()->grabPalette(palette, 0, 256);
 
 	int width = 320, height = 200;
-	bool defaultTo1xScaler = false;
 
 	if (_vm->gameFlags().useHiRes) {
-		defaultTo1xScaler = true;
 		height = 400;
 
 		if (_debugEnabled)
@@ -270,7 +268,7 @@ void Screen::setResolution() {
 			width = 320;
 	}
 
-	initGraphics(width, height, defaultTo1xScaler);
+	initGraphics(width, height);
 
 	_system->getPaletteManager()->setPalette(palette, 0, 256);
 }

--- a/engines/lab/lab.cpp
+++ b/engines/lab/lab.cpp
@@ -160,9 +160,9 @@ LabEngine::~LabEngine() {
 
 Common::Error LabEngine::run() {
 	if (getFeatures() & GF_LOWRES)
-		initGraphics(320, 200, false);
+		initGraphics(320, 200);
 	else
-		initGraphics(640, 480, true);
+		initGraphics(640, 480);
 
 	_interface = new Interface(this);
 	_event = new EventManager(this);

--- a/engines/lastexpress/lastexpress.cpp
+++ b/engines/lastexpress/lastexpress.cpp
@@ -111,7 +111,7 @@ LastExpressEngine::~LastExpressEngine() {
 Common::Error LastExpressEngine::run() {
 	// Initialize the graphics
 	const Graphics::PixelFormat dataPixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0);
-	initGraphics(640, 480, true, &dataPixelFormat);
+	initGraphics(640, 480, &dataPixelFormat);
 
 	// We do not support color conversion
 	if (_system->getScreenFormat() != dataPixelFormat)

--- a/engines/lure/lure.cpp
+++ b/engines/lure/lure.cpp
@@ -55,7 +55,7 @@ Common::Error LureEngine::init() {
 	_initialized = false;
 	_saveLoadAllowed = false;
 
-	initGraphics(FULL_SCREEN_WIDTH, FULL_SCREEN_HEIGHT, false);
+	initGraphics(FULL_SCREEN_WIDTH, FULL_SCREEN_HEIGHT);
 
 	// Check the version of the lure.dat file
 	Common::File f;

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -146,7 +146,7 @@ void MacVentureEngine::initDebugChannels() {
 
 Common::Error MacVentureEngine::run() {
 	debug("MacVenture::MacVentureEngine::init()");
-	initGraphics(kScreenWidth, kScreenHeight, true);
+	initGraphics(kScreenWidth, kScreenHeight);
 
 	_debugger = new Console(this);
 

--- a/engines/made/made.cpp
+++ b/engines/made/made.cpp
@@ -292,7 +292,7 @@ Common::Error MadeEngine::run() {
 	syncSoundSettings();
 
 	// Initialize backend
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 
 	resetAllTimers();
 

--- a/engines/mads/mads.cpp
+++ b/engines/mads/mads.cpp
@@ -159,7 +159,7 @@ void MADSEngine::saveOptions() {
 }
 
 Common::Error MADSEngine::run() {
-	initGraphics(MADS_SCREEN_WIDTH, MADS_SCREEN_HEIGHT, false);
+	initGraphics(MADS_SCREEN_WIDTH, MADS_SCREEN_HEIGHT);
 	initialize();
 
 	// Run the game

--- a/engines/mohawk/cstime_graphics.cpp
+++ b/engines/mohawk/cstime_graphics.cpp
@@ -32,7 +32,7 @@ namespace Mohawk {
 CSTimeGraphics::CSTimeGraphics(MohawkEngine_CSTime *vm) : GraphicsManager(), _vm(vm) {
 	_bmpDecoder = new MohawkBitmap();
 
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 }
 
 CSTimeGraphics::~CSTimeGraphics() {

--- a/engines/mohawk/livingbooks_graphics.cpp
+++ b/engines/mohawk/livingbooks_graphics.cpp
@@ -34,7 +34,7 @@ namespace Mohawk {
 LBGraphics::LBGraphics(MohawkEngine_LivingBooks *vm, uint16 width, uint16 height) : GraphicsManager(), _vm(vm) {
 	_bmpDecoder = _vm->isPreMohawk() ? new LivingBooksBitmap_v1() : new MohawkBitmap();
 
-	initGraphics(width, height, true);
+	initGraphics(width, height);
 }
 
 LBGraphics::~LBGraphics() {

--- a/engines/mohawk/myst_graphics.cpp
+++ b/engines/mohawk/myst_graphics.cpp
@@ -40,13 +40,13 @@ MystGraphics::MystGraphics(MohawkEngine_Myst* vm) : GraphicsManager(), _vm(vm) {
 
 	if (_vm->getFeatures() & GF_ME) {
 		// High color
-		initGraphics(_viewport.width(), _viewport.height(), true, nullptr);
+		initGraphics(_viewport.width(), _viewport.height(), nullptr);
 
 		if (_vm->_system->getScreenFormat().bytesPerPixel == 1)
 			error("Myst ME requires greater than 256 colors to run");
 	} else {
 		// Paletted
-		initGraphics(_viewport.width(), _viewport.height(), true);
+		initGraphics(_viewport.width(), _viewport.height());
 		clearScreenPalette();
 	}
 

--- a/engines/mohawk/riven_graphics.cpp
+++ b/engines/mohawk/riven_graphics.cpp
@@ -308,7 +308,7 @@ RivenGraphics::RivenGraphics(MohawkEngine_Riven* vm) : GraphicsManager(), _vm(vm
 
 	// Restrict ourselves to a single pixel format to simplify the effects implementation
 	_pixelFormat = Graphics::createPixelFormat<565>();
-	initGraphics(608, 436, true, &_pixelFormat);
+	initGraphics(608, 436, &_pixelFormat);
 
 	// The actual game graphics only take up the first 392 rows. The inventory
 	// occupies the rest of the screen and we don't use the buffer to hold that.

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -247,7 +247,7 @@ void MortevielleEngine::pauseEngineIntern(bool pause) {
  */
 Common::ErrorCode MortevielleEngine::initialize() {
 	// Initialize graphics mode
-	initGraphics(SCREEN_WIDTH, SCREEN_HEIGHT, true);
+	initGraphics(SCREEN_WIDTH, SCREEN_HEIGHT);
 
 	// Set up an intermediate screen surface
 	_screenSurface->create(SCREEN_WIDTH, SCREEN_HEIGHT, Graphics::PixelFormat::createFormatCLUT8());

--- a/engines/neverhood/neverhood.cpp
+++ b/engines/neverhood/neverhood.cpp
@@ -65,7 +65,7 @@ NeverhoodEngine::~NeverhoodEngine() {
 }
 
 Common::Error NeverhoodEngine::run() {
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 

--- a/engines/parallaction/graphics.cpp
+++ b/engines/parallaction/graphics.cpp
@@ -731,7 +731,7 @@ Gfx::Gfx(Parallaction* vm) :
 	_gameType = _vm->getGameType();
 	_doubleBuffering = _gameType != GType_Nippon;
 
-	initGraphics(_vm->_screenWidth, _vm->_screenHeight, _gameType == GType_BRA);
+	initGraphics(_vm->_screenWidth, _vm->_screenHeight);
 
 	setPalette(_palette);
 

--- a/engines/pegasus/graphics.cpp
+++ b/engines/pegasus/graphics.cpp
@@ -35,7 +35,7 @@
 namespace Pegasus {
 
 GraphicsManager::GraphicsManager(PegasusEngine *vm) : _vm(vm) {
-	initGraphics(640, 480, true, NULL);
+	initGraphics(640, 480, nullptr);
 
 	if (_vm->_system->getScreenFormat().bytesPerPixel == 1)
 		error("No true color mode available");

--- a/engines/plumbers/plumbers.cpp
+++ b/engines/plumbers/plumbers.cpp
@@ -88,7 +88,7 @@ static const byte cursorPalette[] = {
 };
 
 Common::Error PlumbersGame::run() {
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 	_console = new Console(this);
 
 	CursorMan.replaceCursor(MOUSECURSOR_SCI, 11, 16, 0, 0, 0);

--- a/engines/prince/graphics.cpp
+++ b/engines/prince/graphics.cpp
@@ -31,7 +31,7 @@
 namespace Prince {
 
 GraphicsMan::GraphicsMan(PrinceEngine *vm) : _vm(vm), _changed(false) {
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 
 	_frontScreen = new Graphics::Surface();
 	_frontScreen->create(640, 480, Graphics::PixelFormat::createFormatCLUT8());

--- a/engines/prince/videoplayer.cpp
+++ b/engines/prince/videoplayer.cpp
@@ -30,7 +30,7 @@ namespace Prince {
 
 void PrinceEngine::playVideo(Common::String videoFilename) {
         // Set the correct video mode
-        initGraphics(640, 480, true, 0);
+        initGraphics(640, 480, nullptr);
         if (_system->getScreenFormat().bytesPerPixel == 1) {
                 warning("Couldn't switch to a RGB color video mode to play a video.");
                 return;
@@ -42,7 +42,7 @@ void PrinceEngine::playVideo(Common::String videoFilename) {
 	if (!videoDecoder->loadFile(videoFilename)) {
 		delete videoDecoder;
 		warning("Unable to open video %s", videoFilename.c_str());
-		initGraphics(640, 480, true);
+		initGraphics(640, 480);
 		return;
 	}
 
@@ -78,7 +78,7 @@ void PrinceEngine::playVideo(Common::String videoFilename) {
 
 	delete videoDecoder;
 
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 }
 
 } // End of namespace Prince

--- a/engines/queen/queen.cpp
+++ b/engines/queen/queen.cpp
@@ -324,7 +324,7 @@ bool Queen::QueenEngine::hasFeature(EngineFeature f) const {
 }
 
 Common::Error QueenEngine::run() {
-	initGraphics(GAME_SCREEN_WIDTH, GAME_SCREEN_HEIGHT, false);
+	initGraphics(GAME_SCREEN_WIDTH, GAME_SCREEN_HEIGHT);
 
 	_resource = new Resource();
 

--- a/engines/saga/gfx.cpp
+++ b/engines/saga/gfx.cpp
@@ -40,7 +40,7 @@ namespace Saga {
 #define RID_IHNM_HOURGLASS_CURSOR 11 // not in demo
 
 Gfx::Gfx(SagaEngine *vm, OSystem *system, int width, int height) : _vm(vm), _system(system) {
-	initGraphics(width, height, width > 320);
+	initGraphics(width, height);
 
 	debug(5, "Init screen %dx%d", width, height);
 	// Convert surface data to R surface data

--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -300,7 +300,7 @@ void Console::postEnter() {
 			if (duckMode) {
 				Common::List<Graphics::PixelFormat> formats;
 				formats.push_back(videoDecoder->getPixelFormat());
-				initGraphics(640, 480, true, formats);
+				initGraphics(640, 480, formats);
 
 				if (g_system->getScreenFormat().bytesPerPixel != videoDecoder->getPixelFormat().bytesPerPixel)
 					error("Could not switch screen format for the duck video");
@@ -316,7 +316,7 @@ void Console::postEnter() {
 #ifdef ENABLE_SCI32
 			// Switch back to 8bpp if we played a duck video
 			if (duckMode)
-				initGraphics(oldWidth, oldHeight, oldWidth > 320);
+				initGraphics(oldWidth, oldHeight);
 #endif
 
 			_engine->_gfxCursor->kernelShow();

--- a/engines/sci/engine/kvideo.cpp
+++ b/engines/sci/engine/kvideo.cpp
@@ -140,7 +140,7 @@ reg_t kShowMovie(EngineState *s, int argc, reg_t *argv) {
 			// The only argument is the string for the video
 
 			// HACK: Switch to 16bpp graphics for Cinepak.
-			initGraphics(screenWidth, screenHeight, screenWidth > 320, NULL);
+			initGraphics(screenWidth, screenHeight, nullptr);
 
 			if (g_system->getScreenFormat().bytesPerPixel == 1) {
 				warning("This video requires >8bpp color to be displayed, but could not switch to RGB color mode");
@@ -176,7 +176,7 @@ reg_t kShowMovie(EngineState *s, int argc, reg_t *argv) {
 				// The only known movie to do use this codec is the GK2 demo trailer
 				// If another video turns up that uses Indeo, we may have to add a better
 				// check.
-				initGraphics(screenWidth, screenHeight, screenWidth > 320, NULL);
+				initGraphics(screenWidth, screenHeight, nullptr);
 
 				if (g_system->getScreenFormat().bytesPerPixel == 1) {
 					warning("This video requires >8bpp color to be displayed, but could not switch to RGB color mode");
@@ -206,7 +206,7 @@ reg_t kShowMovie(EngineState *s, int argc, reg_t *argv) {
 		// HACK: Switch back to 8bpp if we played a true color video.
 		// We also won't be copying the screen to the SCI screen...
 		if (g_system->getScreenFormat().bytesPerPixel != 1)
-			initGraphics(screenWidth, screenHeight, screenWidth > 320);
+			initGraphics(screenWidth, screenHeight);
 		else if (getSciVersion() < SCI_VERSION_2) {
 			g_sci->_gfxScreen->kernelSyncWithFramebuffer();
 			g_sci->_gfxPalette16->kernelSyncScreenPalette();

--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -82,7 +82,7 @@ GfxFrameout::GfxFrameout(SegManager *segMan, GfxPalette32 *palette, GfxTransitio
 	}
 	_currentBuffer.setPixels(calloc(1, _currentBuffer.screenWidth * _currentBuffer.screenHeight));
 	_screenRect = Common::Rect(_currentBuffer.screenWidth, _currentBuffer.screenHeight);
-	initGraphics(_currentBuffer.screenWidth, _currentBuffer.screenHeight, _isHiRes);
+	initGraphics(_currentBuffer.screenWidth, _currentBuffer.screenHeight);
 
 	switch (g_sci->getGameId()) {
 	case GID_HOYLE5:

--- a/engines/sci/graphics/frameout.h
+++ b/engines/sci/graphics/frameout.h
@@ -307,7 +307,7 @@ public:
 	 * Resets the pixel format of the hardware surface to the given format.
 	 */
 	void setPixelFormat(const Graphics::PixelFormat &format) const {
-		initGraphics(_currentBuffer.screenWidth, _currentBuffer.screenHeight, _isHiRes, &format);
+		initGraphics(_currentBuffer.screenWidth, _currentBuffer.screenHeight, &format);
 	}
 
 	/**

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -179,13 +179,13 @@ GfxScreen::GfxScreen(ResourceManager *resMan) : _resMan(resMan) {
 		// We add 2 to the height of the icon bar to add a buffer between the screen and the
 		// icon bar (as did the original interpreter).
 		if (g_sci->getGameId() == GID_KQ6)
-			initGraphics(_displayWidth, _displayHeight + 26 + 2, _displayWidth > 320);
+			initGraphics(_displayWidth, _displayHeight + 26 + 2);
 		else if (g_sci->getGameId() == GID_FREDDYPHARKAS)
-			initGraphics(_displayWidth, _displayHeight + 28 + 2, _displayWidth > 320);
+			initGraphics(_displayWidth, _displayHeight + 28 + 2);
 		else
 			error("Unknown SCI1.1 Mac game");
 	} else
-		initGraphics(_displayWidth, _displayHeight, _displayWidth > 320);
+		initGraphics(_displayWidth, _displayHeight);
 }
 
 GfxScreen::~GfxScreen() {

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -962,7 +962,7 @@ ScummEngine_vCUPhe::~ScummEngine_vCUPhe() {
 }
 
 Common::Error ScummEngine_vCUPhe::run() {
-	initGraphics(CUP_Player::kDefaultVideoWidth, CUP_Player::kDefaultVideoHeight, true);
+	initGraphics(CUP_Player::kDefaultVideoWidth, CUP_Player::kDefaultVideoHeight);
 
 	if (_cupPlayer->open(_filenamePattern.pattern)) {
 		_cupPlayer->play();
@@ -1247,7 +1247,7 @@ Common::Error ScummEngine::init() {
 
 	// Initialize backend
 	if (_renderMode == Common::kRenderHercA || _renderMode == Common::kRenderHercG) {
-		initGraphics(kHercWidth, kHercHeight, true);
+		initGraphics(kHercWidth, kHercHeight);
 	} else {
 		int screenWidth = _screenWidth;
 		int screenHeight = _screenHeight;
@@ -1266,7 +1266,7 @@ Common::Error ScummEngine::init() {
 			_outputPixelFormat = Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0);
 
 			if (_game.platform != Common::kPlatformFMTowns && _game.platform != Common::kPlatformPCEngine) {
-				initGraphics(screenWidth, screenHeight, screenWidth > 320, &_outputPixelFormat);
+				initGraphics(screenWidth, screenHeight, &_outputPixelFormat);
 				if (_outputPixelFormat != _system->getScreenFormat())
 					return Common::kUnsupportedColorMode;
 			} else {
@@ -1281,7 +1281,7 @@ Common::Error ScummEngine::init() {
 					}
 				}
 
-				initGraphics(screenWidth, screenHeight, screenWidth > 320, tryModes);
+				initGraphics(screenWidth, screenHeight, tryModes);
 				if (_system->getScreenFormat().bytesPerPixel != 2)
 					return Common::kUnsupportedColorMode;
 			}
@@ -1298,7 +1298,7 @@ Common::Error ScummEngine::init() {
 		if (_game.platform == Common::kPlatformFMTowns && _game.version == 5)
 			return Common::Error(Common::kUnsupportedColorMode, "This game requires dual graphics layer support which is disabled in this build");
 #endif
-			initGraphics(screenWidth, screenHeight, (screenWidth > 320));
+			initGraphics(screenWidth, screenHeight);
 		}
 	}
 

--- a/engines/sherlock/scalpel/scalpel.cpp
+++ b/engines/sherlock/scalpel/scalpel.cpp
@@ -251,14 +251,14 @@ ScalpelEngine::~ScalpelEngine() {
 void ScalpelEngine::setupGraphics() {
 	if (getPlatform() != Common::kPlatform3DO) {
 		// 320x200 palettized
-		initGraphics(320, 200, false);
+		initGraphics(320, 200);
 	} else {
 		// 3DO actually uses RGB555, but some platforms of ours only support RGB565, so we use that
 		const Graphics::PixelFormat pixelFormatRGB565 = Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
 
 		// First try for a 640x400 mode
 		g_system->beginGFXTransaction();
-		initCommonGFX(true);
+		initCommonGFX();
 		g_system->initSize(640, 400, &pixelFormatRGB565);
 		OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
@@ -266,7 +266,7 @@ void ScalpelEngine::setupGraphics() {
 			_isScreenDoubled = true;
 		} else {
 			// System doesn't support it, so fall back on 320x200 mode
-			initGraphics(320, 200, false, &pixelFormatRGB565);
+			initGraphics(320, 200, &pixelFormatRGB565);
 		}
 	}
 }

--- a/engines/sherlock/tattoo/tattoo.cpp
+++ b/engines/sherlock/tattoo/tattoo.cpp
@@ -51,7 +51,7 @@ void TattooEngine::showOpening() {
 }
 
 void TattooEngine::initialize() {
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 
 	// Initialize the base engine
 	SherlockEngine::initialize();

--- a/engines/sky/sky.cpp
+++ b/engines/sky/sky.cpp
@@ -259,7 +259,7 @@ Common::Error SkyEngine::go() {
 }
 
 Common::Error SkyEngine::init() {
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 
 	_skyDisk = new Disk();
 	_skySound = new Sound(_mixer, _skyDisk, Audio::Mixer::kMaxChannelVolume);

--- a/engines/sludge/graphics.cpp
+++ b/engines/sludge/graphics.cpp
@@ -143,7 +143,7 @@ void GraphicsManager::kill() {
 }
 
 bool GraphicsManager::initGfx() {
-	initGraphics(_winWidth, _winHeight, true, _vm->getScreenPixelFormat());
+	initGraphics(_winWidth, _winHeight, _vm->getScreenPixelFormat());
 	_renderSurface.create(_winWidth, _winHeight, *_vm->getScreenPixelFormat());
 
 	if (!killResizeBackdrop(_winWidth, _winHeight))

--- a/engines/sword1/animation.cpp
+++ b/engines/sword1/animation.cpp
@@ -191,12 +191,12 @@ bool MoviePlayer::load(uint32 id) {
 
 	// Need to switch to true color for PSX/MP2 videos
 	if (_decoderType == kVideoDecoderPSX || _decoderType == kVideoDecoderMP2)
-		initGraphics(g_system->getWidth(), g_system->getHeight(), true, 0);
+		initGraphics(g_system->getWidth(), g_system->getHeight(), nullptr);
 
 	if (!_decoder->loadFile(filename)) {
 		// Go back to 8bpp color
 		if (_decoderType == kVideoDecoderPSX || _decoderType == kVideoDecoderMP2)
-			initGraphics(g_system->getWidth(), g_system->getHeight(), true);
+			initGraphics(g_system->getWidth(), g_system->getHeight());
 
 		return false;
 	}
@@ -422,7 +422,7 @@ bool MoviePlayer::playVideo() {
 
 	// Need to jump back to paletted color
 	if (_decoderType == kVideoDecoderPSX || _decoderType == kVideoDecoderMP2)
-		initGraphics(g_system->getWidth(), g_system->getHeight(), true);
+		initGraphics(g_system->getWidth(), g_system->getHeight());
 
 	return !_vm->shouldQuit() && !skipped;
 }

--- a/engines/sword1/sword1.cpp
+++ b/engines/sword1/sword1.cpp
@@ -94,7 +94,7 @@ SwordEngine::~SwordEngine() {
 
 Common::Error SwordEngine::init() {
 
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 
 	if (0 == scumm_stricmp(ConfMan.get("gameid").c_str(), "sword1mac") ||
 	        0 == scumm_stricmp(ConfMan.get("gameid").c_str(), "sword1macdemo"))

--- a/engines/sword2/animation.cpp
+++ b/engines/sword2/animation.cpp
@@ -103,12 +103,12 @@ bool MoviePlayer::load(const char *name) {
 
 	// Need to switch to true color for PSX/MP2 videos
 	if (_decoderType == kVideoDecoderPSX || _decoderType == kVideoDecoderMP2)
-		initGraphics(g_system->getWidth(), g_system->getHeight(), true, 0);
+		initGraphics(g_system->getWidth(), g_system->getHeight(), nullptr);
 
 	if (!_decoder->loadFile(filename)) {
 		// Go back to 8bpp color
 		if (_decoderType == kVideoDecoderPSX || _decoderType == kVideoDecoderMP2)
-			initGraphics(g_system->getWidth(), g_system->getHeight(), true);
+			initGraphics(g_system->getWidth(), g_system->getHeight());
 
 		return false;
 	}
@@ -145,7 +145,7 @@ void MoviePlayer::play(MovieText *movieTexts, uint32 numMovieTexts, uint32 leadI
 
 	// Need to jump back to paletted color
 	if (_decoderType == kVideoDecoderPSX || _decoderType == kVideoDecoderMP2)
-		initGraphics(640, 480, true);
+		initGraphics(640, 480);
 }
 
 void MoviePlayer::openTextObject(uint32 index) {

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -442,7 +442,7 @@ Common::Error Sword2Engine::run() {
 	_resman = NULL;
 	_memory = NULL;
 
-	initGraphics(640, 480, true);
+	initGraphics(640, 480);
 	_screen = new Screen(this, 640, 480);
 
 	// Create the debugger as early as possible (but not before the

--- a/engines/sword25/sword25.cpp
+++ b/engines/sword25/sword25.cpp
@@ -97,7 +97,7 @@ Common::Error Sword25Engine::run() {
 Common::Error Sword25Engine::appStart() {
 	// Initialize the graphics mode to RGBA8888
 	Graphics::PixelFormat format = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	initGraphics(800, 600, true, &format);
+	initGraphics(800, 600, &format);
 	if (format != g_system->getScreenFormat())
 		return Common::kUnsupportedColorMode;
 

--- a/engines/teenagent/teenagent.cpp
+++ b/engines/teenagent/teenagent.cpp
@@ -540,7 +540,7 @@ Common::Error TeenAgentEngine::run() {
 
 	Common::EventManager *_event = _system->getEventManager();
 
-	initGraphics(kScreenWidth, kScreenHeight, false);
+	initGraphics(kScreenWidth, kScreenHeight);
 	console = new Console(this);
 
 	scene = new Scene(this);

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -185,7 +185,7 @@ void TestbedEngine::invokeTestsuites(TestbedConfigManager &cfMan) {
 
 Common::Error TestbedEngine::run() {
 	// Initialize graphics using following:
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 
 	// As of now we are using GUI::MessageDialog for interaction, Test if it works.
 	// interactive mode could also be modified by a config parameter "non-interactive=1"

--- a/engines/tinsel/tinsel.cpp
+++ b/engines/tinsel/tinsel.cpp
@@ -900,13 +900,13 @@ Common::Error TinselEngine::run() {
 	// Initialize backend
 	if (getGameID() == GID_DW2) {
 #ifndef DW2_EXACT_SIZE
-		initGraphics(640, 480, true);
+		initGraphics(640, 480);
 #else
-		initGraphics(640, 432, true);
+		initGraphics(640, 432);
 #endif
 		_screenSurface.create(640, 432, Graphics::PixelFormat::createFormatCLUT8());
 	} else {
-		initGraphics(320, 200, false);
+		initGraphics(320, 200);
 		_screenSurface.create(320, 200, Graphics::PixelFormat::createFormatCLUT8());
 	}
 

--- a/engines/titanic/support/direct_draw.cpp
+++ b/engines/titanic/support/direct_draw.cpp
@@ -40,7 +40,7 @@ void DirectDraw::setDisplayMode(int width, int height, int bpp, int refreshRate)
 	assert(bpp == 16);
 
 	Graphics::PixelFormat pixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
-	initGraphics(width, height, true, &pixelFormat);
+	initGraphics(width, height, &pixelFormat);
 }
 
 void DirectDraw::diagnostics() {

--- a/engines/toltecs/toltecs.cpp
+++ b/engines/toltecs/toltecs.cpp
@@ -70,7 +70,7 @@ ToltecsEngine::~ToltecsEngine() {
 }
 
 Common::Error ToltecsEngine::run() {
-	initGraphics(640, 400, true);
+	initGraphics(640, 400);
 
 	_isSaveAllowed = true;
 

--- a/engines/tony/window.cpp
+++ b/engines/tony/window.cpp
@@ -54,7 +54,7 @@ RMWindow::~RMWindow() {
  */
 void RMWindow::init() {
 	Graphics::PixelFormat pixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
-	initGraphics(RM_SX, RM_SY, true, &pixelFormat);
+	initGraphics(RM_SX, RM_SY, &pixelFormat);
 
 	reset();
 }

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -1116,7 +1116,7 @@ Common::Error ToonEngine::run() {
 	if (!loadToonDat())
 		return Common::kUnknownError;
 
-	initGraphics(TOON_SCREEN_WIDTH, TOON_SCREEN_HEIGHT, true);
+	initGraphics(TOON_SCREEN_WIDTH, TOON_SCREEN_HEIGHT);
 	init();
 
 	// do we need to load directly a game?

--- a/engines/touche/touche.cpp
+++ b/engines/touche/touche.cpp
@@ -199,7 +199,7 @@ ToucheEngine::~ToucheEngine() {
 }
 
 Common::Error ToucheEngine::run() {
-	initGraphics(kScreenWidth, kScreenHeight, true);
+	initGraphics(kScreenWidth, kScreenHeight);
 
 	Graphics::setupFont(_language);
 

--- a/engines/tsage/tsage.cpp
+++ b/engines/tsage/tsage.cpp
@@ -53,7 +53,7 @@ TSageEngine::TSageEngine(OSystem *system, const tSageGameDescription *gameDesc) 
 }
 
 Common::Error TSageEngine::init() {
-	initGraphics(SCREEN_WIDTH, SCREEN_HEIGHT, false);
+	initGraphics(SCREEN_WIDTH, SCREEN_HEIGHT);
 
 	return Common::kNoError;
 }

--- a/engines/tucker/tucker.cpp
+++ b/engines/tucker/tucker.cpp
@@ -89,7 +89,7 @@ bool TuckerEngine::hasFeature(EngineFeature f) const {
 }
 
 Common::Error TuckerEngine::run() {
-	initGraphics(kScreenWidth, kScreenHeight, false);
+	initGraphics(kScreenWidth, kScreenHeight);
 	syncSoundSettings();
 	_compressedSound.openFile();
 	if (_startSlot == -1)

--- a/engines/util.h
+++ b/engines/util.h
@@ -30,7 +30,7 @@
 /**
  * Setup the backend's graphics mode.
  */
-void initCommonGFX(bool defaultTo1XScaler);
+void initCommonGFX();
 
 /**
  * Setup the backend's screen size and graphics mode.
@@ -45,8 +45,8 @@ void initCommonGFX(bool defaultTo1XScaler);
  * Uses the backend's preferred format if graphics format pointer is NULL.
  * Finds the best compatible format if a list of graphics formats is provided.
  */
-void initGraphics(int width, int height, bool defaultTo1xScaler);
-void initGraphics(int width, int height, bool defaultTo1xScaler, const Graphics::PixelFormat *format);
-void initGraphics(int width, int height, bool defaultTo1xScaler, const Common::List<Graphics::PixelFormat> &formatList);
+void initGraphics(int width, int height);
+void initGraphics(int width, int height, const Graphics::PixelFormat *format);
+void initGraphics(int width, int height, const Common::List<Graphics::PixelFormat> &formatList);
 
 #endif

--- a/engines/util.h
+++ b/engines/util.h
@@ -23,9 +23,11 @@
 #ifndef ENGINES_UTIL_H
 #define ENGINES_UTIL_H
 
+#include "common/array.h"
 #include "common/scummsys.h"
 #include "common/list.h"
 #include "graphics/pixelformat.h"
+#include "graphics/mode.h"
 
 /**
  * Setup the backend's graphics mode.
@@ -33,7 +35,17 @@
 void initCommonGFX();
 
 /**
- * Setup the backend's screen size and graphics mode.
+ * Sends a list of graphics modes to the backend so it can make a decision
+ * about the best way to set up the display hardware.
+ *
+ * Engines that switch between different virtual screen sizes during a game
+ * should call this function prior to any call to initGraphics. Engines that use
+ * only a single screen size do not need to call this function.
+ */
+void initGraphicsModes(const Graphics::ModeList &modes);
+
+/**
+ * Sets up the backend's screen size and graphics mode.
  *
  * Shows an various warnings on certain backend graphics
  * transaction failures (aspect switch, fullscreen switch, etc.).

--- a/engines/voyeur/screen.cpp
+++ b/engines/voyeur/screen.cpp
@@ -54,7 +54,7 @@ Screen::Screen(VoyeurEngine *vm) : Graphics::Screen(), _vm(vm), _drawPtr(&_defau
 }
 
 void Screen::sInitGraphics() {
-	initGraphics(SCREEN_WIDTH, SCREEN_HEIGHT, false);
+	initGraphics(SCREEN_WIDTH, SCREEN_HEIGHT);
 	create(SCREEN_WIDTH, SCREEN_HEIGHT);
 	clearPalette();
 }

--- a/engines/wage/wage.cpp
+++ b/engines/wage/wage.cpp
@@ -106,7 +106,7 @@ WageEngine::~WageEngine() {
 Common::Error WageEngine::run() {
 	debug("WageEngine::init");
 
-	initGraphics(512, 342, true);
+	initGraphics(512, 342);
 
 	// Create debugger console. It requires GFX to be initialized
 	_console = new Console(this);

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -109,7 +109,7 @@ bool WintermuteEngine::hasFeature(EngineFeature f) const {
 Common::Error WintermuteEngine::run() {
 	// Initialize graphics using following:
 	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	initGraphics(800, 600, true, &format);
+	initGraphics(800, 600, &format);
 	if (g_system->getScreenFormat() != format) {
 		error("Wintermute currently REQUIRES 32bpp");
 	}

--- a/engines/xeen/xeen.cpp
+++ b/engines/xeen/xeen.cpp
@@ -107,7 +107,7 @@ void XeenEngine::initialize() {
 	_eventData = f.readStream(f.size());
 
 	// Set graphics mode
-	initGraphics(320, 200, false);
+	initGraphics(320, 200);
 
 	// If requested, load a savegame instead of showing the intro
 	if (ConfMan.hasKey("save_slot")) {

--- a/engines/zvision/zvision.cpp
+++ b/engines/zvision/zvision.cpp
@@ -401,13 +401,13 @@ void ZVision::initScreen() {
 						((WINDOW_HEIGHT - workingWindowHeight) / 2) + workingWindowHeight
 					 );
 
-	initGraphics(WINDOW_WIDTH, WINDOW_HEIGHT, true, &_screenPixelFormat);
+	initGraphics(WINDOW_WIDTH, WINDOW_HEIGHT, &_screenPixelFormat);
 }
 
 void ZVision::initHiresScreen() {
 	_renderManager->upscaleRect(_workingWindow);
 
-	initGraphics(HIRES_WINDOW_WIDTH, HIRES_WINDOW_HEIGHT, true, &_screenPixelFormat);
+	initGraphics(HIRES_WINDOW_WIDTH, HIRES_WINDOW_HEIGHT, &_screenPixelFormat);
 }
 
 } // End of namespace ZVision

--- a/graphics/mode.h
+++ b/graphics/mode.h
@@ -1,0 +1,50 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef GRAPHICS_MODE_H
+#define GRAPHICS_MODE_H
+
+#include "common/array.h"
+
+namespace Graphics {
+
+/**
+ * Represents a hardware video mode.
+ */
+struct Mode {
+	int16 width; ///< The width in pixels
+	int16 height; ///< The height in pixels
+
+	Mode(const int16 w, const int16 h) :
+		width(w),
+		height(h) {}
+
+	bool operator<(const Mode &other) const {
+		return width < other.width && height < other.height;
+	}
+};
+
+typedef Common::Array<Mode> ModeList;
+
+}
+
+#endif


### PR DESCRIPTION
This change allows:

* Engines to update their target rendering surface/size and pixel
  format with the backend multiple times during gameplay;
* Users to resize the ScummVM window without having it reset
  size/position every time an engine updates its target surface
  format;
* Conversions/scaling to continue to run efficiently in hardware,
  instead of requiring engines to pick their maximum possible
  output format once and upscale inefficiently in software;
* The window to reset size once when an engine calls to set its
  initial output size, and to reset again once ScummVM returns to
  the launcher.

This is relevant for at least SCI32 and DreamWeb engines, which
perform graphics mode switches during games.

This is a not-awesome hack, but it seems to be the least terrible
way I could find to enable a satisfactory user experience for
resizing without making more extensive changes to the graphics
manager API, and without forcing engines to opt-in to not breaking
the user experience with their calls to change screen modes (which
should not be the responsibility of game engines).

One potential alternative to having the graphics manager track the
global engine pointer would be to instead use a flag that gets set
and cleared by the main ScummVM loop before it calls to run an
engine, and after the engine run call returns.

Please let me know thoughts or suggestions on making this less gross. Thanks!