### PR TITLE
BACKENDS: Refactor OpenGL & SDL graphics backends

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -254,4 +254,30 @@ void DefaultEventManager::pushEvent(const Common::Event &event) {
 		_artificialEventSource.addEvent(event);
 }
 
+void DefaultEventManager::purgeMouseEvents() {
+	_dispatcher.dispatch();
+
+	Common::Queue<Common::Event> filteredQueue;
+	while (!_eventQueue.empty()) {
+		Common::Event event = _eventQueue.pop();
+		switch (event.type) {
+		case Common::EVENT_MOUSEMOVE:
+		case Common::EVENT_LBUTTONDOWN:
+		case Common::EVENT_LBUTTONUP:
+		case Common::EVENT_RBUTTONDOWN:
+		case Common::EVENT_RBUTTONUP:
+		case Common::EVENT_WHEELUP:
+		case Common::EVENT_WHEELDOWN:
+		case Common::EVENT_MBUTTONDOWN:
+		case Common::EVENT_MBUTTONUP:
+			// do nothing
+			break;
+		default:
+			filteredQueue.push(event);
+			break;
+		}
+	}
+	_eventQueue = filteredQueue;
+}
+
 #endif // !defined(DISABLE_DEFAULT_EVENTMANAGER)

--- a/backends/events/default/default-events.h
+++ b/backends/events/default/default-events.h
@@ -80,6 +80,7 @@ public:
 	virtual void init();
 	virtual bool pollEvent(Common::Event &event);
 	virtual void pushEvent(const Common::Event &event);
+	virtual void purgeMouseEvents() override;
 
 	virtual Common::Point getMousePos() const { return _mousePos; }
 	virtual int getButtonState() const { return _buttonState; }

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -75,7 +75,7 @@ static uint32 convUTF8ToUTF32(const char *src) {
 #endif
 
 SdlEventSource::SdlEventSource()
-    : EventSource(), _scrollLock(false), _joystick(0), _lastScreenID(0), _graphicsManager(0)
+    : EventSource(), _scrollLock(false), _joystick(0), _lastScreenID(0), _graphicsManager(0), _queuedFakeMouseMove(false)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
       , _queuedFakeKeyUp(false), _fakeKeyUp()
 #endif
@@ -505,6 +505,12 @@ bool SdlEventSource::pollEvent(Common::Event &event) {
 	if (screenID != _lastScreenID) {
 		_lastScreenID = screenID;
 		event.type = Common::EVENT_SCREEN_CHANGED;
+		return true;
+	}
+
+	if (_queuedFakeMouseMove) {
+		event = _fakeMouseMove;
+		_queuedFakeMouseMove = false;
 		return true;
 	}
 
@@ -1001,6 +1007,12 @@ void SdlEventSource::resetKeyboardEmulation(int16 x_max, int16 y_max) {
 	_km.modifier = false;
 	_km.joy_x = 0;
 	_km.joy_y = 0;
+}
+
+void SdlEventSource::fakeWarpMouse(const int x, const int y) {
+	_queuedFakeMouseMove = true;
+	_fakeMouseMove.type = Common::EVENT_MOUSEMOVE;
+	_fakeMouseMove.mouse = Common::Point(x, y);
 }
 
 bool SdlEventSource::handleResizeEvent(Common::Event &event, int w, int h) {

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -158,7 +158,7 @@ int SdlEventSource::mapKey(SDLKey sdlKey, SDLMod mod, Uint16 unicode) {
 	} else if (key >= Common::KEYCODE_UP && key <= Common::KEYCODE_PAGEDOWN) {
 		return key;
 	} else if (unicode) {
-		// Return unicode in case it's stil set and wasn't filtered.
+		// Return unicode in case it's still set and wasn't filtered.
 		return unicode;
 	} else if (key >= 'a' && key <= 'z' && (mod & KMOD_SHIFT)) {
 		return key & ~0x20;
@@ -968,9 +968,8 @@ bool SdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		event.kbd.keycode = Common::KEYCODE_F5;
 		event.kbd.ascii = mapKey(SDLK_F5, ev.key.keysym.mod, 0);
 	}
-	// Nap center (space) to tab (default action )
+	// Map center (space) to tab (default action)
 	// I wanted to map the calendar button but the calendar comes up
-	//
 	else if (ev.key.keysym.sym == SDLK_SPACE) {
 		event.type = Common::EVENT_KEYDOWN;
 		event.kbd.keycode = Common::KEYCODE_TAB;

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -174,8 +174,7 @@ void SdlEventSource::processMouseEvent(Common::Event &event, int x, int y) {
 	event.mouse.y = y;
 
 	if (_graphicsManager) {
-		_graphicsManager->notifyMousePos(Common::Point(x, y));
-		_graphicsManager->transformMouseCoordinates(event.mouse);
+		_graphicsManager->notifyMousePosition(event.mouse);
 	}
 }
 

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -117,7 +117,7 @@ protected:
 	 * Assigns the mouse coords to the mouse event. Furthermore notify the
 	 * graphics manager about the position change.
 	 */
-	virtual void processMouseEvent(Common::Event &event, int x, int y);
+	virtual bool processMouseEvent(Common::Event &event, int x, int y);
 
 	/**
 	 * Remaps key events. This allows platforms to configure

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -51,6 +51,12 @@ public:
 	 */
 	virtual void resetKeyboardEmulation(int16 x_max, int16 y_max);
 
+	/**
+	 * Emulates a mouse movement that would normally be caused by a mouse warp
+	 * of the system mouse.
+	 */
+	void fakeWarpMouse(const int x, const int y);
+
 protected:
 	/** @name Keyboard mouse emulation
 	 * Disabled by fingolfin 2004-12-18.
@@ -155,6 +161,18 @@ protected:
 	 * Extracts the keycode for the specified key sym.
 	 */
 	SDLKey obtainKeycode(const SDL_keysym keySym);
+
+	/**
+	 * Whether _fakeMouseMove contains an event we need to send.
+	 */
+	bool _queuedFakeMouseMove;
+
+	/**
+	 * A fake mouse motion event sent when the graphics manager is told to warp
+	 * the mouse but the system mouse is unable to be warped (e.g. because the
+	 * window is not focused).
+	 */
+	Common::Event _fakeMouseMove;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/**

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -487,14 +487,6 @@ bool DINGUXSdlGraphicsManager::getFeatureState(OSystem::Feature f) {
 	}
 }
 
-SurfaceSdlGraphicsManager::MousePos *DINGUXSdlGraphicsManager::getMouseCurState() {
-	return &_mouseCurState;
-}
-
-SurfaceSdlGraphicsManager::VideoState *DINGUXSdlGraphicsManager::getVideoMode() {
-	return &_videoMode;
-}
-
 void DINGUXSdlGraphicsManager::warpMouse(int x, int y) {
 	if (_mouseCurState.x != x || _mouseCurState.y != y) {
 		if (_videoMode.mode == GFX_HALF && !_overlayVisible) {

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
@@ -36,26 +36,23 @@ class DINGUXSdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
 	DINGUXSdlGraphicsManager(SdlEventSource *boss, SdlWindow *window);
 
-	bool hasFeature(OSystem::Feature f);
-	void setFeatureState(OSystem::Feature f, bool enable);
-	bool getFeatureState(OSystem::Feature f);
-	int getDefaultGraphicsMode() const;
+	bool hasFeature(OSystem::Feature f) const override;
+	void setFeatureState(OSystem::Feature f, bool enable) override;
+	bool getFeatureState(OSystem::Feature f) override;
+	int getDefaultGraphicsMode() const override;
 
-	void initSize(uint w, uint h);
-	const OSystem::GraphicsMode *getSupportedGraphicsModes() const;
-	bool setGraphicsMode(const char *name);
-	bool setGraphicsMode(int mode);
-	void setGraphicsModeIntern();
-	void internUpdateScreen();
-	void showOverlay();
-	void hideOverlay();
-	bool loadGFXMode();
-	void drawMouse();
-	void undrawMouse();
-	virtual void warpMouse(int x, int y);
-
-	SurfaceSdlGraphicsManager::MousePos *getMouseCurState();
-	SurfaceSdlGraphicsManager::VideoState *getVideoMode();
+	void initSize(uint w, uint h) override;
+	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
+	bool setGraphicsMode(const char *name) override;
+	bool setGraphicsMode(int mode) override;
+	void setGraphicsModeIntern() override;
+	void internUpdateScreen() override;
+	void showOverlay() override;
+	void hideOverlay() override;
+	bool loadGFXMode() override;
+	void drawMouse() override;
+	void undrawMouse() override;
+	void warpMouse(int x, int y) override;
 
 	virtual void transformMouseCoordinates(Common::Point &point);
 };

--- a/backends/graphics/gph/gph-graphics.cpp
+++ b/backends/graphics/gph/gph-graphics.cpp
@@ -477,7 +477,7 @@ bool GPHGraphicsManager::loadGFXMode() {
 	return true;
 }
 
-bool GPHGraphicsManager::hasFeature(OSystem::Feature f) {
+bool GPHGraphicsManager::hasFeature(OSystem::Feature f) const {
 	return
 	    (f == OSystem::kFeatureAspectRatioCorrection) ||
 	    (f == OSystem::kFeatureCursorPalette);
@@ -497,7 +497,7 @@ void GPHGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
 	}
 }
 
-bool GPHGraphicsManager::getFeatureState(OSystem::Feature f) {
+bool GPHGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	assert(_transactionMode == kTransactionNone);
 
 	switch (f) {
@@ -508,14 +508,6 @@ bool GPHGraphicsManager::getFeatureState(OSystem::Feature f) {
 	default:
 		return false;
 	}
-}
-
-SurfaceSdlGraphicsManager::MousePos *GPHGraphicsManager::getMouseCurState() {
-	return &_mouseCurState;
-}
-
-SurfaceSdlGraphicsManager::VideoState *GPHGraphicsManager::getVideoMode() {
-	return &_videoMode;
 }
 
 void GPHGraphicsManager::warpMouse(int x, int y) {

--- a/backends/graphics/gph/gph-graphics.h
+++ b/backends/graphics/gph/gph-graphics.h
@@ -35,26 +35,23 @@ class GPHGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
 	GPHGraphicsManager(SdlEventSource *boss, SdlWindow *window);
 
-	bool hasFeature(OSystem::Feature f);
-	void setFeatureState(OSystem::Feature f, bool enable);
-	bool getFeatureState(OSystem::Feature f);
-	int getDefaultGraphicsMode() const;
+	bool hasFeature(OSystem::Feature f) const override;
+	void setFeatureState(OSystem::Feature f, bool enable) override;
+	bool getFeatureState(OSystem::Feature f) const;
+	int getDefaultGraphicsMode() const override;
 
-	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL);
-	const OSystem::GraphicsMode *getSupportedGraphicsModes() const;
-	bool setGraphicsMode(const char *name);
-	bool setGraphicsMode(int mode);
-	void setGraphicsModeIntern();
-	void internUpdateScreen();
-	void showOverlay();
-	void hideOverlay();
-	bool loadGFXMode();
-	void drawMouse();
-	void undrawMouse();
-	virtual void warpMouse(int x, int y);
-
-	SurfaceSdlGraphicsManager::MousePos *getMouseCurState();
-	SurfaceSdlGraphicsManager::VideoState *getVideoMode();
+	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL) override;
+	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
+	bool setGraphicsMode(const char *name) override;
+	bool setGraphicsMode(int mode) override;
+	void setGraphicsModeIntern() override;
+	void internUpdateScreen() override;
+	void showOverlay() override;
+	void hideOverlay() override;
+	bool loadGFXMode() override;
+	void drawMouse() override;
+	void undrawMouse() override;
+	void warpMouse(int x, int y) override;
 
 	virtual void transformMouseCoordinates(Common::Point &point);
 };

--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -38,9 +38,9 @@ class GraphicsManager : public PaletteManager {
 public:
 	virtual ~GraphicsManager() {}
 
-	virtual bool hasFeature(OSystem::Feature f) = 0;
+	virtual bool hasFeature(OSystem::Feature f) const = 0;
 	virtual void setFeatureState(OSystem::Feature f, bool enable) = 0;
-	virtual bool getFeatureState(OSystem::Feature f) = 0;
+	virtual bool getFeatureState(OSystem::Feature f) const = 0;
 
 	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const = 0;
 	virtual int getDefaultGraphicsMode() const = 0;
@@ -65,10 +65,10 @@ public:
 	virtual void beginGFXTransaction() = 0;
 	virtual OSystem::TransactionError endGFXTransaction() = 0;
 
-	virtual int16 getHeight() = 0;
-	virtual int16 getWidth() = 0;
+	virtual int16 getHeight() const = 0;
+	virtual int16 getWidth() const = 0;
 	virtual void setPalette(const byte *colors, uint start, uint num) = 0;
-	virtual void grabPalette(byte *colors, uint start, uint num) = 0;
+	virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) = 0;
 	virtual Graphics::Surface *lockScreen() = 0;
 	virtual void unlockScreen() = 0;
@@ -82,10 +82,10 @@ public:
 	virtual void hideOverlay() = 0;
 	virtual Graphics::PixelFormat getOverlayFormat() const = 0;
 	virtual void clearOverlay() = 0;
-	virtual void grabOverlay(void *buf, int pitch) = 0;
-	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h)= 0;
-	virtual int16 getOverlayHeight() = 0;
-	virtual int16 getOverlayWidth() = 0;
+	virtual void grabOverlay(void *buf, int pitch) const = 0;
+	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) = 0;
+	virtual int16 getOverlayHeight() const = 0;
+	virtual int16 getOverlayWidth() const = 0;
 
 	virtual bool showMouse(bool visible) = 0;
 	virtual void warpMouse(int x, int y) = 0;

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.h
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.h
@@ -29,18 +29,18 @@ class LinuxmotoSdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
 	LinuxmotoSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
-	virtual void initSize(uint w, uint h);
-	virtual void setGraphicsModeIntern();
-	virtual bool setGraphicsMode(int mode);
-	virtual void internUpdateScreen();
-	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const;
-	virtual int getDefaultGraphicsMode() const;
-	virtual bool loadGFXMode();
-	virtual void drawMouse();
-	virtual void undrawMouse();
-	virtual void showOverlay();
-	virtual void hideOverlay();
-	virtual void warpMouse(int x, int y);
+	virtual void initSize(uint w, uint h) override;
+	virtual void setGraphicsModeIntern() override;
+	virtual bool setGraphicsMode(int mode) override;
+	virtual void internUpdateScreen() override;
+	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
+	virtual int getDefaultGraphicsMode() const override;
+	virtual bool loadGFXMode() override;
+	virtual void drawMouse() override;
+	virtual void undrawMouse() override;
+	virtual void showOverlay() override;
+	virtual void hideOverlay() override;
+	virtual void warpMouse(int x, int y) override;
 
 	virtual void transformMouseCoordinates(Common::Point &point);
 };

--- a/backends/graphics/maemosdl/maemosdl-graphics.h
+++ b/backends/graphics/maemosdl/maemosdl-graphics.h
@@ -32,7 +32,7 @@ public:
 	MaemoSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
 protected:
-	virtual bool loadGFXMode();
+	virtual bool loadGFXMode() override;
 };
 
 #endif

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -54,8 +54,8 @@ public:
 	void beginGFXTransaction() {}
 	OSystem::TransactionError endGFXTransaction() { return OSystem::kTransactionSuccess; }
 
-	int16 getHeight() { return 0; }
-	int16 getWidth() { return 0; }
+	int16 getHeight() const { return 0; }
+	int16 getWidth() const { return 0; }
 	void setPalette(const byte *colors, uint start, uint num) {}
 	void grabPalette(byte *colors, uint start, uint num) {}
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {}

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -31,55 +31,55 @@ class NullGraphicsManager : public GraphicsManager {
 public:
 	virtual ~NullGraphicsManager() {}
 
-	bool hasFeature(OSystem::Feature f) { return false; }
-	void setFeatureState(OSystem::Feature f, bool enable) {}
-	bool getFeatureState(OSystem::Feature f) { return false; }
+	bool hasFeature(OSystem::Feature f) const override { return false; }
+	void setFeatureState(OSystem::Feature f, bool enable) override {}
+	bool getFeatureState(OSystem::Feature f) const override { return false; }
 
-	const OSystem::GraphicsMode *getSupportedGraphicsModes() const { return s_noGraphicsModes; }
-	int getDefaultGraphicsMode() const { return 0; }
-	bool setGraphicsMode(int mode) { return true; }
-	void resetGraphicsScale(){}
-	int getGraphicsMode() const { return 0; }
-	inline Graphics::PixelFormat getScreenFormat() const {
+	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override { return s_noGraphicsModes; }
+	int getDefaultGraphicsMode() const override { return 0; }
+	bool setGraphicsMode(int mode) override { return true; }
+	void resetGraphicsScale() override {}
+	int getGraphicsMode() const override { return 0; }
+	inline Graphics::PixelFormat getScreenFormat() const override {
 		return Graphics::PixelFormat::createFormatCLUT8();
 	}
-	inline Common::List<Graphics::PixelFormat> getSupportedFormats() const {
+	inline Common::List<Graphics::PixelFormat> getSupportedFormats() const override {
 		Common::List<Graphics::PixelFormat> list;
 		list.push_back(Graphics::PixelFormat::createFormatCLUT8());
 		return list;
 	}
-	void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) {}
-	virtual int getScreenChangeID() const { return 0; }
+	void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) override {}
+	virtual int getScreenChangeID() const override { return 0; }
 
-	void beginGFXTransaction() {}
-	OSystem::TransactionError endGFXTransaction() { return OSystem::kTransactionSuccess; }
+	void beginGFXTransaction() override {}
+	OSystem::TransactionError endGFXTransaction() override { return OSystem::kTransactionSuccess; }
 
-	int16 getHeight() const { return 0; }
-	int16 getWidth() const { return 0; }
-	void setPalette(const byte *colors, uint start, uint num) {}
-	void grabPalette(byte *colors, uint start, uint num) {}
-	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {}
-	Graphics::Surface *lockScreen() { return NULL; }
-	void unlockScreen() {}
-	void fillScreen(uint32 col) {}
-	void updateScreen() {}
-	void setShakePos(int shakeOffset) {}
-	void setFocusRectangle(const Common::Rect& rect) {}
-	void clearFocusRectangle() {}
+	int16 getHeight() const override { return 0; }
+	int16 getWidth() const override { return 0; }
+	void setPalette(const byte *colors, uint start, uint num) override {}
+	void grabPalette(byte *colors, uint start, uint num) const override {}
+	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override {}
+	Graphics::Surface *lockScreen() override { return NULL; }
+	void unlockScreen() override {}
+	void fillScreen(uint32 col) override {}
+	void updateScreen() override {}
+	void setShakePos(int shakeOffset) override {}
+	void setFocusRectangle(const Common::Rect& rect) override {}
+	void clearFocusRectangle() override {}
 
-	void showOverlay() {}
-	void hideOverlay() {}
-	Graphics::PixelFormat getOverlayFormat() const { return Graphics::PixelFormat(); }
-	void clearOverlay() {}
-	void grabOverlay(void *buf, int pitch) {}
-	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {}
-	int16 getOverlayHeight() { return 0; }
-	int16 getOverlayWidth() { return 0; }
+	void showOverlay() override {}
+	void hideOverlay() override {}
+	Graphics::PixelFormat getOverlayFormat() const override { return Graphics::PixelFormat(); }
+	void clearOverlay() override {}
+	void grabOverlay(void *buf, int pitch) const override {}
+	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override {}
+	int16 getOverlayHeight() const override { return 0; }
+	int16 getOverlayWidth() const override { return 0; }
 
-	bool showMouse(bool visible) { return !visible; }
-	void warpMouse(int x, int y) {}
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) {}
-	void setCursorPalette(const byte *colors, uint start, uint num) {}
+	bool showMouse(bool visible) override { return !visible; }
+	void warpMouse(int x, int y) override {}
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override {}
+	void setCursorPalette(const byte *colors, uint start, uint num) override {}
 };
 
 #endif

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -53,14 +53,12 @@ namespace OpenGL {
 OpenGLGraphicsManager::OpenGLGraphicsManager()
     : _currentState(), _oldState(), _transactionMode(kTransactionNone), _screenChangeID(1 << (sizeof(int) * 8 - 2)),
       _pipeline(nullptr),
-      _outputScreenWidth(0), _outputScreenHeight(0), _displayX(0), _displayY(0),
-      _displayWidth(0), _displayHeight(0), _defaultFormat(), _defaultFormatAlpha(),
+      _defaultFormat(), _defaultFormatAlpha(),
       _gameScreen(nullptr), _gameScreenShakeOffset(0), _overlay(nullptr),
-      _overlayVisible(false), _cursor(nullptr),
-      _cursorX(0), _cursorY(0), _cursorDisplayX(0),_cursorDisplayY(0), _cursorHotspotX(0), _cursorHotspotY(0),
+      _cursor(nullptr),
+      _cursorHotspotX(0), _cursorHotspotY(0),
       _cursorHotspotXScaled(0), _cursorHotspotYScaled(0), _cursorWidthScaled(0), _cursorHeightScaled(0),
-      _cursorKeyColor(0), _cursorVisible(false), _cursorDontScale(false), _cursorPaletteEnabled(false),
-      _forceRedraw(false)
+      _cursorKeyColor(0), _cursorVisible(false), _cursorDontScale(false), _cursorPaletteEnabled(false)
 #ifdef USE_OSD
       , _osdMessageChangeRequest(false), _osdMessageAlpha(0), _osdMessageFadeStartTime(0), _osdMessageSurface(nullptr),
       _osdIconSurface(nullptr)
@@ -83,7 +81,7 @@ OpenGLGraphicsManager::~OpenGLGraphicsManager() {
 #endif
 }
 
-bool OpenGLGraphicsManager::hasFeature(OSystem::Feature f) {
+bool OpenGLGraphicsManager::hasFeature(OSystem::Feature f) const {
 	switch (f) {
 	case OSystem::kFeatureAspectRatioCorrection:
 	case OSystem::kFeatureCursorPalette:
@@ -129,7 +127,7 @@ void OpenGLGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
 	}
 }
 
-bool OpenGLGraphicsManager::getFeatureState(OSystem::Feature f) {
+bool OpenGLGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	switch (f) {
 	case OSystem::kFeatureAspectRatioCorrection:
 		return _currentState.aspectRatioCorrection;
@@ -220,10 +218,9 @@ OSystem::TransactionError OpenGLGraphicsManager::endGFXTransaction() {
 #endif
 
 	do {
-		uint requestedWidth  = _currentState.gameWidth;
-		uint requestedHeight = _currentState.gameHeight;
-		const uint desiredAspect = getDesiredGameScreenAspect();
-		requestedHeight = intToFrac(requestedWidth) / desiredAspect;
+		const uint desiredAspect = getDesiredGameAspectRatio();
+		const uint requestedWidth  = _currentState.gameWidth;
+		const uint requestedHeight = intToFrac(requestedWidth) / desiredAspect;
 
 		if (!loadVideoMode(requestedWidth, requestedHeight,
 #ifdef USE_RGB_COLOR
@@ -317,7 +314,7 @@ OSystem::TransactionError OpenGLGraphicsManager::endGFXTransaction() {
 
 	// Update our display area and cursor scaling. This makes sure we pick up
 	// aspect ratio correction and game screen changes correctly.
-	recalculateDisplayArea();
+	recalculateDisplayAreas();
 	recalculateCursorScaling();
 
 	// Something changed, so update the screen change ID.
@@ -347,11 +344,11 @@ void OpenGLGraphicsManager::initSize(uint width, uint height, const Graphics::Pi
 	_currentState.gameHeight = height;
 }
 
-int16 OpenGLGraphicsManager::getWidth() {
+int16 OpenGLGraphicsManager::getWidth() const {
 	return _currentState.gameWidth;
 }
 
-int16 OpenGLGraphicsManager::getHeight() {
+int16 OpenGLGraphicsManager::getHeight() const {
 	return _currentState.gameHeight;
 }
 
@@ -392,6 +389,7 @@ void OpenGLGraphicsManager::updateScreen() {
 
 	// We only update the screen when there actually have been any changes.
 	if (   !_forceRedraw
+		&& !_cursorNeedsRedraw
 	    && !_gameScreen->isDirty()
 	    && !(_overlayVisible && _overlay->isDirty())
 	    && !(_cursorVisible && _cursor && _cursor->isDirty())
@@ -401,7 +399,6 @@ void OpenGLGraphicsManager::updateScreen() {
 	    ) {
 		return;
 	}
-	_forceRedraw = false;
 
 	// Update changes to textures.
 	_gameScreen->updateGLTexture();
@@ -420,14 +417,14 @@ void OpenGLGraphicsManager::updateScreen() {
 		_backBuffer.enableScissorTest(true);
 	}
 
-	const GLfloat shakeOffset = _gameScreenShakeOffset * (GLfloat)_displayHeight / _gameScreen->getHeight();
+	const GLfloat shakeOffset = _gameScreenShakeOffset * (GLfloat)_gameDrawRect.height() / _gameScreen->getHeight();
 
 	// First step: Draw the (virtual) game screen.
-	g_context.getActivePipeline()->drawTexture(_gameScreen->getGLTexture(), _displayX, _displayY + shakeOffset, _displayWidth, _displayHeight);
+	g_context.getActivePipeline()->drawTexture(_gameScreen->getGLTexture(), _gameDrawRect.left, _gameDrawRect.top + shakeOffset, _gameDrawRect.width(), _gameDrawRect.height());
 
 	// Second step: Draw the overlay if visible.
 	if (_overlayVisible) {
-		g_context.getActivePipeline()->drawTexture(_overlay->getGLTexture(), 0, 0, _outputScreenWidth, _outputScreenHeight);
+		g_context.getActivePipeline()->drawTexture(_overlay->getGLTexture(), 0, 0, _overlayDrawRect.width(), _overlayDrawRect.height());
 	}
 
 	// Third step: Draw the cursor if visible.
@@ -437,8 +434,8 @@ void OpenGLGraphicsManager::updateScreen() {
 		const GLfloat cursorOffset = _overlayVisible ? 0 : shakeOffset;
 
 		g_context.getActivePipeline()->drawTexture(_cursor->getGLTexture(),
-		                         _cursorDisplayX - _cursorHotspotXScaled,
-		                         _cursorDisplayY - _cursorHotspotYScaled + cursorOffset,
+		                         _cursorX - _cursorHotspotXScaled,
+		                         _cursorY - _cursorHotspotYScaled + cursorOffset,
 		                         _cursorWidthScaled, _cursorHeightScaled);
 	}
 
@@ -464,8 +461,8 @@ void OpenGLGraphicsManager::updateScreen() {
 		// Set the OSD transparency.
 		g_context.getActivePipeline()->setColor(1.0f, 1.0f, 1.0f, _osdMessageAlpha / 100.0f);
 
-		int dstX = (_outputScreenWidth - _osdMessageSurface->getWidth()) / 2;
-		int dstY = (_outputScreenHeight - _osdMessageSurface->getHeight()) / 2;
+		int dstX = (_windowWidth - _osdMessageSurface->getWidth()) / 2;
+		int dstY = (_windowHeight - _osdMessageSurface->getHeight()) / 2;
 
 		// Draw the OSD texture.
 		g_context.getActivePipeline()->drawTexture(_osdMessageSurface->getGLTexture(),
@@ -481,7 +478,7 @@ void OpenGLGraphicsManager::updateScreen() {
 	}
 
 	if (_osdIconSurface) {
-		int dstX = _outputScreenWidth - _osdIconSurface->getWidth() - kOSDIconRightMargin;
+		int dstX = _windowWidth - _osdIconSurface->getWidth() - kOSDIconRightMargin;
 		int dstY = kOSDIconTopMargin;
 
 		// Draw the OSD icon texture.
@@ -490,6 +487,8 @@ void OpenGLGraphicsManager::updateScreen() {
 	}
 #endif
 
+	_cursorNeedsRedraw = false;
+	_forceRedraw = false;
 	refreshScreen();
 }
 
@@ -507,7 +506,7 @@ void OpenGLGraphicsManager::setFocusRectangle(const Common::Rect& rect) {
 void OpenGLGraphicsManager::clearFocusRectangle() {
 }
 
-int16 OpenGLGraphicsManager::getOverlayWidth() {
+int16 OpenGLGraphicsManager::getOverlayWidth() const {
 	if (_overlay) {
 		return _overlay->getWidth();
 	} else {
@@ -515,28 +514,12 @@ int16 OpenGLGraphicsManager::getOverlayWidth() {
 	}
 }
 
-int16 OpenGLGraphicsManager::getOverlayHeight() {
+int16 OpenGLGraphicsManager::getOverlayHeight() const {
 	if (_overlay) {
 		return _overlay->getHeight();
 	} else {
 		return 0;
 	}
-}
-
-void OpenGLGraphicsManager::showOverlay() {
-	_overlayVisible = true;
-	_forceRedraw = true;
-
-	// Update cursor position.
-	setMousePosition(_cursorX, _cursorY);
-}
-
-void OpenGLGraphicsManager::hideOverlay() {
-	_overlayVisible = false;
-	_forceRedraw = true;
-
-	// Update cursor position.
-	setMousePosition(_cursorX, _cursorY);
 }
 
 Graphics::PixelFormat OpenGLGraphicsManager::getOverlayFormat() const {
@@ -551,7 +534,7 @@ void OpenGLGraphicsManager::clearOverlay() {
 	_overlay->fill(0);
 }
 
-void OpenGLGraphicsManager::grabOverlay(void *buf, int pitch) {
+void OpenGLGraphicsManager::grabOverlay(void *buf, int pitch) const {
 	const Graphics::Surface *overlayData = _overlay->getSurface();
 
 	const byte *src = (const byte *)overlayData->getPixels();
@@ -568,49 +551,12 @@ bool OpenGLGraphicsManager::showMouse(bool visible) {
 	// In case the mouse cursor visibility changed we need to redraw the whole
 	// screen even when nothing else changed.
 	if (_cursorVisible != visible) {
-		_forceRedraw = true;
+		_cursorNeedsRedraw = true;
 	}
 
 	bool last = _cursorVisible;
 	_cursorVisible = visible;
 	return last;
-}
-
-void OpenGLGraphicsManager::warpMouse(int x, int y) {
-	int16 currentX = _cursorX;
-	int16 currentY = _cursorY;
-	adjustMousePosition(currentX, currentY);
-
-	// Check whether the (virtual) coordinate actually changed. If not, then
-	// simply do nothing. This avoids ugly "jittering" due to the actual
-	// output screen having a bigger resolution than the virtual coordinates.
-	if (currentX == x && currentY == y) {
-		return;
-	}
-
-	// Scale the virtual coordinates into actual physical coordinates.
-	if (_overlayVisible) {
-		if (!_overlay) {
-			return;
-		}
-
-		// It might be confusing that we actually have to handle something
-		// here when the overlay is visible. This is because for very small
-		// resolutions we have a minimal overlay size and have to adjust
-		// for that.
-		x = (x * _outputScreenWidth)  / _overlay->getWidth();
-		y = (y * _outputScreenHeight) / _overlay->getHeight();
-	} else {
-		if (!_gameScreen) {
-			return;
-		}
-
-		x = (x * _outputScreenWidth)  / _gameScreen->getWidth();
-		y = (y * _outputScreenHeight) / _gameScreen->getHeight();
-	}
-
-	setMousePosition(x, y);
-	setInternalMousePosition(x, y);
 }
 
 namespace {
@@ -720,7 +666,6 @@ void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int 
 		updateCursorPalette();
 	}
 
-	// Update the scaling.
 	recalculateCursorScaling();
 }
 
@@ -765,8 +710,8 @@ void OpenGLGraphicsManager::osdMessageUpdateSurface() {
 	}
 
 	// Clip the rect
-	width  = MIN<uint>(width,  _displayWidth);
-	height = MIN<uint>(height, _displayHeight);
+	width  = MIN<uint>(width,  _gameDrawRect.width());
+	height = MIN<uint>(height, _gameDrawRect.height());
 
 	delete _osdMessageSurface;
 	_osdMessageSurface = nullptr;
@@ -849,16 +794,13 @@ void OpenGLGraphicsManager::setPalette(const byte *colors, uint start, uint num)
 	updateCursorPalette();
 }
 
-void OpenGLGraphicsManager::grabPalette(byte *colors, uint start, uint num) {
+void OpenGLGraphicsManager::grabPalette(byte *colors, uint start, uint num) const {
 	assert(_gameScreen->hasPalette());
 
 	memcpy(colors, _gamePalette + start * 3, num * 3);
 }
 
-void OpenGLGraphicsManager::setActualScreenSize(uint width, uint height) {
-	_outputScreenWidth = width;
-	_outputScreenHeight = height;
-
+void OpenGLGraphicsManager::handleResizeImpl(const int width, const int height) {
 	// Setup backbuffer size.
 	_backBuffer.setDimensions(width, height);
 
@@ -873,7 +815,7 @@ void OpenGLGraphicsManager::setActualScreenSize(uint width, uint height) {
 	// anyway. Thus, it should not be a real issue for modern hardware.
 	if (   overlayWidth  > (uint)g_context.maxTextureSize
 	    || overlayHeight > (uint)g_context.maxTextureSize) {
-		const frac_t outputAspect = intToFrac(_outputScreenWidth) / _outputScreenHeight;
+		const frac_t outputAspect = intToFrac(_windowWidth) / _windowHeight;
 
 		if (outputAspect > (frac_t)FRAC_ONE) {
 			overlayWidth  = g_context.maxTextureSize;
@@ -906,7 +848,7 @@ void OpenGLGraphicsManager::setActualScreenSize(uint width, uint height) {
 	_overlay->fill(0);
 
 	// Re-setup the scaling for the screen and cursor
-	recalculateDisplayArea();
+	recalculateDisplayAreas();
 	recalculateCursorScaling();
 
 	// Something changed, so update the screen change ID.
@@ -960,8 +902,8 @@ void OpenGLGraphicsManager::notifyContextCreate(const Graphics::PixelFormat &def
 	GL_CALL(glPixelStorei(GL_PACK_ALIGNMENT, 4));
 
 	// Refresh the output screen dimensions if some are set up.
-	if (_outputScreenWidth != 0 && _outputScreenHeight != 0) {
-		setActualScreenSize(_outputScreenWidth, _outputScreenHeight);
+	if (_windowWidth != 0 && _windowHeight != 0) {
+		handleResize(_windowWidth, _windowHeight);
 	}
 
 	// TODO: Should we try to convert textures into one of those formats if
@@ -1029,46 +971,6 @@ void OpenGLGraphicsManager::notifyContextDestroy() {
 
 	// Rest our context description since the context is gone soon.
 	g_context.reset();
-}
-
-void OpenGLGraphicsManager::adjustMousePosition(int16 &x, int16 &y) {
-	if (_overlayVisible) {
-		// It might be confusing that we actually have to handle something
-		// here when the overlay is visible. This is because for very small
-		// resolutions we have a minimal overlay size and have to adjust
-		// for that.
-		// This can also happen when the overlay is smaller than the actual
-		// display size because of texture size limitations.
-		if (_overlay) {
-			x = (x * _overlay->getWidth())  / _outputScreenWidth;
-			y = (y * _overlay->getHeight()) / _outputScreenHeight;
-		}
-	} else if (_gameScreen) {
-		const int16 width  = _gameScreen->getWidth();
-		const int16 height = _gameScreen->getHeight();
-
-		x = (x * width)  / (int)_outputScreenWidth;
-		y = (y * height) / (int)_outputScreenHeight;
-	}
-}
-
-void OpenGLGraphicsManager::setMousePosition(int x, int y) {
-	// Whenever the mouse position changed we force a screen redraw to reflect
-	// changes properly.
-	if (_cursorX != x || _cursorY != y) {
-		_forceRedraw = true;
-	}
-
-	_cursorX = x;
-	_cursorY = y;
-
-	if (_overlayVisible) {
-		_cursorDisplayX = x;
-		_cursorDisplayY = y;
-	} else {
-		_cursorDisplayX = _displayX + (x * _displayWidth)  / _outputScreenWidth;
-		_cursorDisplayY = _displayY + (y * _displayHeight) / _outputScreenHeight;
-	}
 }
 
 Surface *OpenGLGraphicsManager::createSurface(const Graphics::PixelFormat &format, bool wantAlpha) {
@@ -1191,51 +1093,34 @@ bool OpenGLGraphicsManager::getGLPixelFormat(const Graphics::PixelFormat &pixelF
 	}
 }
 
-frac_t OpenGLGraphicsManager::getDesiredGameScreenAspect() const {
-	const uint width  = _currentState.gameWidth;
-	const uint height = _currentState.gameHeight;
-
+bool OpenGLGraphicsManager::gameNeedsAspectRatioCorrection() const {
 	if (_currentState.aspectRatioCorrection) {
+		const uint width = getWidth();
+		const uint height = getHeight();
+
 		// In case we enable aspect ratio correction we force a 4/3 ratio.
 		// But just for 320x200 and 640x400 games, since other games do not need
 		// this.
-		if ((width == 320 && height == 200) || (width == 640 && height == 400)) {
-			return intToFrac(4) / 3;
-		}
+		return (width == 320 && height == 200) || (width == 640 && height == 400);
 	}
 
-	return intToFrac(width) / height;
+	return false;
 }
 
-void OpenGLGraphicsManager::recalculateDisplayArea() {
-	if (!_gameScreen || _outputScreenHeight == 0) {
+void OpenGLGraphicsManager::recalculateDisplayAreas() {
+	if (!_gameScreen) {
 		return;
 	}
 
-	const frac_t outputAspect = intToFrac(_outputScreenWidth) / _outputScreenHeight;
-	const frac_t desiredAspect = getDesiredGameScreenAspect();
-
-	_displayWidth = _outputScreenWidth;
-	_displayHeight = _outputScreenHeight;
-
-	// Adjust one dimension for mantaining the aspect ratio.
-	if (outputAspect < desiredAspect) {
-		_displayHeight = intToFrac(_displayWidth) / desiredAspect;
-	} else if (outputAspect > desiredAspect) {
-		_displayWidth = fracToInt(_displayHeight * desiredAspect);
-	}
-
-	// We center the screen in the middle for now.
-	_displayX = (_outputScreenWidth  - _displayWidth ) / 2;
-	_displayY = (_outputScreenHeight - _displayHeight) / 2;
+	WindowedGraphicsManager::recalculateDisplayAreas();
 
 	// Setup drawing limitation for game graphics.
 	// This involves some trickery because OpenGL's viewport coordinate system
 	// is upside down compared to ours.
-	_backBuffer.setScissorBox(_displayX,
-	                          _outputScreenHeight - _displayHeight - _displayY,
-	                          _displayWidth,
-	                          _displayHeight);
+	_backBuffer.setScissorBox(_gameDrawRect.left,
+	                          _windowHeight - _gameDrawRect.height() - _gameDrawRect.top,
+	                          _gameDrawRect.width(),
+	                          _gameDrawRect.height());
 
 	// Update the cursor position to adjust for new display area.
 	setMousePosition(_cursorX, _cursorY);
@@ -1272,8 +1157,8 @@ void OpenGLGraphicsManager::recalculateCursorScaling() {
 	// In case scaling is actually enabled we will scale the cursor according
 	// to the game screen.
 	if (!_cursorDontScale) {
-		const frac_t screenScaleFactorX = intToFrac(_displayWidth)  / _gameScreen->getWidth();
-		const frac_t screenScaleFactorY = intToFrac(_displayHeight) / _gameScreen->getHeight();
+		const frac_t screenScaleFactorX = intToFrac(_gameDrawRect.width()) / _gameScreen->getWidth();
+		const frac_t screenScaleFactorY = intToFrac(_gameDrawRect.height()) / _gameScreen->getHeight();
 
 		_cursorHotspotXScaled = fracToInt(_cursorHotspotXScaled * screenScaleFactorX);
 		_cursorWidthScaled    = fracToInt(_cursorWidthScaled    * screenScaleFactorX);
@@ -1284,14 +1169,14 @@ void OpenGLGraphicsManager::recalculateCursorScaling() {
 }
 
 #ifdef USE_OSD
-const Graphics::Font *OpenGLGraphicsManager::getFontOSD() {
+const Graphics::Font *OpenGLGraphicsManager::getFontOSD() const {
 	return FontMan.getFontByUsage(Graphics::FontManager::kLocalizedFont);
 }
 #endif
 
 bool OpenGLGraphicsManager::saveScreenshot(const Common::String &filename) const {
-	const uint width  = _outputScreenWidth;
-	const uint height = _outputScreenHeight;
+	const uint width  = _windowWidth;
+	const uint height = _windowHeight;
 
 	// A line of a BMP image must have a size divisible by 4.
 	// We calculate the padding bytes needed here.

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -567,6 +567,18 @@ void applyColorKey(DstPixel *dst, const SrcPixel *src, uint w, uint h, uint dstP
 } // End of anonymous namespace
 
 void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
+
+	_cursorKeyColor = keycolor;
+	_cursorHotspotX = hotspotX;
+	_cursorHotspotY = hotspotY;
+	_cursorDontScale = dontScale;
+
+	if (!w || !h) {
+		delete _cursor;
+		_cursor = nullptr;
+		return;
+	}
+
 	Graphics::PixelFormat inputFormat;
 #ifdef USE_RGB_COLOR
 	if (format) {
@@ -601,11 +613,6 @@ void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int 
 		assert(_cursor);
 		_cursor->enableLinearFiltering(_currentState.filtering);
 	}
-
-	_cursorKeyColor = keycolor;
-	_cursorHotspotX = hotspotX;
-	_cursorHotspotY = hotspotY;
-	_cursorDontScale = dontScale;
 
 	_cursor->allocate(w, h);
 	if (inputFormat.bytesPerPixel == 1) {

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -58,7 +58,7 @@ OpenGLGraphicsManager::OpenGLGraphicsManager()
       _cursor(nullptr),
       _cursorHotspotX(0), _cursorHotspotY(0),
       _cursorHotspotXScaled(0), _cursorHotspotYScaled(0), _cursorWidthScaled(0), _cursorHeightScaled(0),
-      _cursorKeyColor(0), _cursorVisible(false), _cursorDontScale(false), _cursorPaletteEnabled(false)
+      _cursorKeyColor(0), _cursorDontScale(false), _cursorPaletteEnabled(false)
 #ifdef USE_OSD
       , _osdMessageChangeRequest(false), _osdMessageAlpha(0), _osdMessageFadeStartTime(0), _osdMessageSurface(nullptr),
       _osdIconSurface(nullptr)
@@ -545,18 +545,6 @@ void OpenGLGraphicsManager::grabOverlay(void *buf, int pitch) const {
 		dst += pitch;
 		src += overlayData->pitch;
 	}
-}
-
-bool OpenGLGraphicsManager::showMouse(bool visible) {
-	// In case the mouse cursor visibility changed we need to redraw the whole
-	// screen even when nothing else changed.
-	if (_cursorVisible != visible) {
-		_cursorNeedsRedraw = true;
-	}
-
-	bool last = _cursorVisible;
-	_cursorVisible = visible;
-	return last;
 }
 
 namespace {

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -25,7 +25,7 @@
 
 #include "backends/graphics/opengl/opengl-sys.h"
 #include "backends/graphics/opengl/framebuffer.h"
-#include "backends/graphics/graphics.h"
+#include "backends/graphics/windowed.h"
 
 #include "common/frac.h"
 #include "common/mutex.h"
@@ -53,89 +53,76 @@ enum {
 	GFX_OPENGL = 0
 };
 
-class OpenGLGraphicsManager : virtual public GraphicsManager {
+class OpenGLGraphicsManager : virtual public WindowedGraphicsManager {
 public:
 	OpenGLGraphicsManager();
 	virtual ~OpenGLGraphicsManager();
 
 	// GraphicsManager API
-	virtual bool hasFeature(OSystem::Feature f);
-	virtual void setFeatureState(OSystem::Feature f, bool enable);
-	virtual bool getFeatureState(OSystem::Feature f);
+	virtual bool hasFeature(OSystem::Feature f) const override;
+	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
+	virtual bool getFeatureState(OSystem::Feature f) const override;
 
-	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const;
-	virtual int getDefaultGraphicsMode() const;
-	virtual bool setGraphicsMode(int mode);
-	virtual int getGraphicsMode() const;
+	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
+	virtual int getDefaultGraphicsMode() const override;
+	virtual bool setGraphicsMode(int mode) override;
+	virtual int getGraphicsMode() const override;
 
-	virtual void resetGraphicsScale() {}
+	virtual void resetGraphicsScale() override {}
 
 #ifdef USE_RGB_COLOR
-	virtual Graphics::PixelFormat getScreenFormat() const;
-	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const = 0;
+	virtual Graphics::PixelFormat getScreenFormat() const override;
+	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override = 0;
 #endif
 
-	virtual void beginGFXTransaction();
-	virtual OSystem::TransactionError endGFXTransaction();
+	virtual void beginGFXTransaction() override;
+	virtual OSystem::TransactionError endGFXTransaction() override;
 
-	virtual int getScreenChangeID() const;
+	virtual int getScreenChangeID() const override;
 
-	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format);
+	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format) override;
 
-	virtual int16 getWidth();
-	virtual int16 getHeight();
+	virtual int16 getWidth() const override;
+	virtual int16 getHeight() const override;
 
-	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h);
-	virtual void fillScreen(uint32 col);
+	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override;
+	virtual void fillScreen(uint32 col) override;
 
-	virtual void setShakePos(int shakeOffset);
+	virtual void setShakePos(int shakeOffset) override;
 
-	virtual void updateScreen();
+	virtual void updateScreen() override;
 
-	virtual Graphics::Surface *lockScreen();
-	virtual void unlockScreen();
+	virtual Graphics::Surface *lockScreen() override;
+	virtual void unlockScreen() override;
 
-	virtual void setFocusRectangle(const Common::Rect& rect);
-	virtual void clearFocusRectangle();
+	virtual void setFocusRectangle(const Common::Rect& rect) override;
+	virtual void clearFocusRectangle() override;
 
-	virtual int16 getOverlayWidth();
-	virtual int16 getOverlayHeight();
+	virtual int16 getOverlayWidth() const override;
+	virtual int16 getOverlayHeight() const override;
 
-	virtual void showOverlay();
-	virtual void hideOverlay();
+	virtual Graphics::PixelFormat getOverlayFormat() const override;
 
-	virtual Graphics::PixelFormat getOverlayFormat() const;
+	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
+	virtual void clearOverlay() override;
+	virtual void grabOverlay(void *buf, int pitch) const override;
 
-	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
-	virtual void clearOverlay();
-	virtual void grabOverlay(void *buf, int pitch);
+	virtual bool showMouse(bool visible) override;
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) override;
+	virtual void setCursorPalette(const byte *colors, uint start, uint num) override;
 
-	virtual bool showMouse(bool visible);
-	virtual void warpMouse(int x, int y);
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format);
-	virtual void setCursorPalette(const byte *colors, uint start, uint num);
-
-	virtual void displayMessageOnOSD(const char *msg);
-	virtual void displayActivityIconOnOSD(const Graphics::Surface *icon);
+	virtual void displayMessageOnOSD(const char *msg) override;
+	virtual void displayActivityIconOnOSD(const Graphics::Surface *icon) override;
 
 	// PaletteManager interface
-	virtual void setPalette(const byte *colors, uint start, uint num);
-	virtual void grabPalette(byte *colors, uint start, uint num);
+	virtual void setPalette(const byte *colors, uint start, uint num) override;
+	virtual void grabPalette(byte *colors, uint start, uint num) const override;
 
 protected:
 	/**
 	 * Whether an GLES or GLES2 context is active.
 	 */
 	bool isGLESContext() const { return g_context.type == kContextGLES || g_context.type == kContextGLES2; }
-
-	/**
-	 * Set up the actual screen size available for the OpenGL code to do any
-	 * drawing.
-	 *
-	 * @param width  The width of the screen.
-	 * @param height The height of the screen.
-	 */
-	void setActualScreenSize(uint width, uint height);
 
 	/**
 	 * Sets the OpenGL (ES) type the graphics manager shall work with.
@@ -166,33 +153,6 @@ protected:
 	 */
 	void notifyContextDestroy();
 
-	/**
-	 * Adjust the physical mouse coordinates according to the currently visible screen.
-	 */
-	void adjustMousePosition(int16 &x, int16 &y);
-
-	/**
-	 * Set up the mouse position for graphics output.
-	 *
-	 * @param x X coordinate in physical coordinates.
-	 * @param y Y coordinate in physical coordinates.
-	 */
-	void setMousePosition(int x, int y);
-
-	/**
-	 * Query the mouse position in physical coordinates.
-	 */
-	void getMousePosition(int16 &x, int16 &y) const { x = _cursorX; y = _cursorY; }
-
-	/**
-	 * Set up the mouse position for the (event) system.
-	 *
-	 * @param x X coordinate in physical coordinates.
-	 * @param y Y coordinate in physical coordinates.
-	 */
-	virtual void setInternalMousePosition(int x, int y) = 0;
-
-private:
 	/**
 	 * Create a surface with the specified pixel format.
 	 *
@@ -292,8 +252,7 @@ protected:
 	virtual void refreshScreen() = 0;
 
 	/**
-	 * Save a screenshot of the full display as BMP to the given file. This
-	 * uses Common::DumpFile for writing the screenshot.
+	 * Saves a screenshot of the entire window, excluding window decorations.
 	 *
 	 * @param filename The output filename.
 	 * @return true on success, false otherwise
@@ -334,7 +293,6 @@ protected:
 	 */
 	virtual void *getProcAddress(const char *name) const = 0;
 
-private:
 	/**
 	 * Try to determine the internal parameters for a given pixel format.
 	 *
@@ -342,49 +300,9 @@ private:
 	 */
 	bool getGLPixelFormat(const Graphics::PixelFormat &pixelFormat, GLenum &glIntFormat, GLenum &glFormat, GLenum &glType) const;
 
-	//
-	// Actual hardware screen
-	//
-
-	/**
-	 * The width of the physical output.
-	 */
-	uint _outputScreenWidth;
-
-	/**
-	 * The height of the physical output.
-	 */
-	uint _outputScreenHeight;
-
-	/**
-	 * @return The desired aspect of the game screen.
-	 */
-	frac_t getDesiredGameScreenAspect() const;
-
-	/**
-	 * Recalculates the area used to display the game screen.
-	 */
-	void recalculateDisplayArea();
-
-	/**
-	 * The X coordinate of the game screen.
-	 */
-	uint _displayX;
-
-	/**
-	 * The Y coordinate of the game screen.
-	 */
-	uint _displayY;
-
-	/**
-	 * The width of the game screen in physical coordinates.
-	 */
-	uint _displayWidth;
-
-	/**
-	 * The height of the game screen in physical coordinates.
-	 */
-	uint _displayHeight;
+	virtual bool gameNeedsAspectRatioCorrection() const override;
+	virtual void recalculateDisplayAreas() override;
+	virtual void handleResizeImpl(const int width, const int height) override;
 
 	/**
 	 * The default pixel format of the backend.
@@ -396,12 +314,8 @@ private:
 	 */
 	Graphics::PixelFormat _defaultFormatAlpha;
 
-	//
-	// Game screen
-	//
-
 	/**
-	 * The virtual game screen.
+	 * The rendering surface for the virtual game screen.
 	 */
 	Surface *_gameScreen;
 
@@ -420,14 +334,9 @@ private:
 	//
 
 	/**
-	 * The overlay screen.
+	 * The rendering surface for the overlay.
 	 */
 	Surface *_overlay;
-
-	/**
-	 * Whether the overlay is visible or not.
-	 */
-	bool _overlayVisible;
 
 	//
 	// Cursor
@@ -439,37 +348,17 @@ private:
 	void updateCursorPalette();
 
 	/**
-	 * The cursor image.
+	 * The rendering surface for the mouse cursor.
 	 */
 	Surface *_cursor;
 
 	/**
-	 * X coordinate of the cursor in physical coordinates.
-	 */
-	int _cursorX;
-
-	/**
-	 * Y coordinate of the cursor in physical coordinates.
-	 */
-	int _cursorY;
-
-	/**
-	 * X coordinate used for drawing the cursor.
-	 */
-	int _cursorDisplayX;
-
-	/**
-	 * Y coordinate used for drawing the cursor.
-	 */
-	int _cursorDisplayY;
-
-	/**
-	 * The X offset for the cursor hotspot in unscaled coordinates.
+	 * The X offset for the cursor hotspot in unscaled game coordinates.
 	 */
 	int _cursorHotspotX;
 
 	/**
-	 * The Y offset for the cursor hotspot in unscaled coordinates.
+	 * The Y offset for the cursor hotspot in unscaled game coordinates.
 	 */
 	int _cursorHotspotY;
 
@@ -480,22 +369,24 @@ private:
 	void recalculateCursorScaling();
 
 	/**
-	 * The X offset for the cursor hotspot in scaled coordinates.
+	 * The X offset for the cursor hotspot in scaled game display area
+	 * coordinates.
 	 */
 	int _cursorHotspotXScaled;
 
 	/**
-	 * The Y offset for the cursor hotspot in scaled coordinates.
+	 * The Y offset for the cursor hotspot in scaled game display area
+	 * coordinates.
 	 */
 	int _cursorHotspotYScaled;
 
 	/**
-	 * The width of the cursor scaled coordinates.
+	 * The width of the cursor in scaled game display area coordinates.
 	 */
 	uint _cursorWidthScaled;
 
 	/**
-	 * The height of the cursor scaled coordinates.
+	 * The height of the cursor in scaled game display area coordinates.
 	 */
 	uint _cursorHeightScaled;
 
@@ -524,15 +415,6 @@ private:
 	 */
 	byte _cursorPalette[3 * 256];
 
-	//
-	// Misc
-	//
-
-	/**
-	 * Whether the screen contents shall be forced to redrawn.
-	 */
-	bool _forceRedraw;
-
 #ifdef USE_OSD
 	//
 	// OSD
@@ -541,7 +423,7 @@ protected:
 	/**
 	 * Returns the font used for on screen display
 	 */
-	virtual const Graphics::Font *getFontOSD();
+	virtual const Graphics::Font *getFontOSD() const;
 
 private:
 	/**

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -107,7 +107,6 @@ public:
 	virtual void clearOverlay() override;
 	virtual void grabOverlay(void *buf, int pitch) const override;
 
-	virtual bool showMouse(bool visible) override;
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) override;
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) override;
 
@@ -394,11 +393,6 @@ protected:
 	 * The key color.
 	 */
 	uint32 _cursorKeyColor;
-
-	/**
-	 * Whether the cursor is actually visible.
-	 */
-	bool _cursorVisible;
 
 	/**
 	 * Whether no cursor scaling should be applied.

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -241,7 +241,7 @@ private:
 	};
 
 	/**
-	 * The currently setup video state.
+	 * The currently set up video state.
 	 */
 	VideoState _currentState;
 
@@ -444,7 +444,7 @@ private:
 	Surface *_cursor;
 
 	/**
-	 * X coordinate of the cursor in phyiscal coordinates.
+	 * X coordinate of the cursor in physical coordinates.
 	 */
 	int _cursorX;
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -46,7 +46,7 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(uint desktopWidth, uint deskt
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 16);
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-	// Setup proper SDL OpenGL context creation.
+	// Set up proper SDL OpenGL context creation.
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	OpenGL::ContextType glContextType;
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -36,38 +36,37 @@ public:
 	virtual ~OpenGLSdlGraphicsManager();
 
 	// GraphicsManager API
-	virtual void activateManager();
-	virtual void deactivateManager();
+	virtual void activateManager() override;
+	virtual void deactivateManager() override;
 
-	virtual bool hasFeature(OSystem::Feature f);
-	virtual void setFeatureState(OSystem::Feature f, bool enable);
-	virtual bool getFeatureState(OSystem::Feature f);
+	virtual bool hasFeature(OSystem::Feature f) const override;
+	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
+	virtual bool getFeatureState(OSystem::Feature f) const override;
 
 	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format) override;
 
 #ifdef USE_RGB_COLOR
-	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const;
+	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override;
 #endif
 
-	virtual void updateScreen();
+	virtual void updateScreen() override;
 
 	// EventObserver API
-	virtual bool notifyEvent(const Common::Event &event);
+	virtual bool notifyEvent(const Common::Event &event) override;
 
 	// SdlGraphicsManager API
-	virtual void notifyVideoExpose();
-	virtual void notifyResize(const uint width, const uint height);
-	virtual void transformMouseCoordinates(Common::Point &point);
-	virtual void notifyMousePos(Common::Point mouse);
+	virtual void notifyVideoExpose() override;
+	virtual void notifyResize(const int width, const int height) override;
 
 protected:
-	virtual void setInternalMousePosition(int x, int y);
+	virtual bool loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format) override;
 
-	virtual bool loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format);
+	virtual void refreshScreen() override;
 
-	virtual void refreshScreen();
+	virtual void *getProcAddress(const char *name) const override;
 
-	virtual void *getProcAddress(const char *name) const;
+	virtual void handleResizeImpl(const int width, const int height) override;
+
 	virtual int getGraphicsModeScale(int mode) const override { return 1; }
 
 private:
@@ -78,10 +77,7 @@ private:
 	SDL_GLContext _glContext;
 #else
 	uint32 _lastVideoModeLoad;
-	SDL_Surface *_hwScreen;
 #endif
-
-	void getWindowDimensions(int *width, int *height);
 
 	uint _lastRequestedWidth;
 	uint _lastRequestedHeight;
@@ -122,7 +118,7 @@ private:
 	uint _desiredFullscreenWidth;
 	uint _desiredFullscreenHeight;
 
-	virtual bool isHotkey(const Common::Event &event);
+	bool isHotkey(const Common::Event &event) const;
 };
 
 #endif

--- a/backends/graphics/openpandora/op-graphics.h
+++ b/backends/graphics/openpandora/op-graphics.h
@@ -34,8 +34,8 @@ class OPGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
 	OPGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
-	bool loadGFXMode();
-	void unloadGFXMode();
+	bool loadGFXMode() override;
+	void unloadGFXMode() override;
 };
 
 #endif /* BACKENDS_GRAPHICS_OP_H */

--- a/backends/graphics/psp2sdl/psp2sdl-graphics.h
+++ b/backends/graphics/psp2sdl/psp2sdl-graphics.h
@@ -30,19 +30,19 @@ class PSP2SdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
 	PSP2SdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 	virtual ~PSP2SdlGraphicsManager();
-	
-	virtual OSystem::TransactionError endGFXTransaction();
-	virtual const OSystem::GraphicsMode *getSupportedShaders() const;
+
+	virtual OSystem::TransactionError endGFXTransaction() override;
+	virtual const OSystem::GraphicsMode *getSupportedShaders() const override;
 
 protected:
-	virtual void setGraphicsModeIntern();
-	virtual void unloadGFXMode();
-	virtual bool hotswapGFXMode();
+	virtual void setGraphicsModeIntern() override;
+	virtual void unloadGFXMode() override;
+	virtual bool hotswapGFXMode() override;
 
-	virtual void internUpdateScreen();
-	virtual void updateShader();
-	virtual void setAspectRatioCorrection(bool enable);
-	virtual SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags);
+	virtual void internUpdateScreen() override;
+	virtual void updateShader() override;
+	virtual void setAspectRatioCorrection(bool enable) override;
+	virtual SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags) override;
 	void PSP2_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects);
 	void PSP2_UpdateFiltering();
 

--- a/backends/graphics/samsungtvsdl/samsungtvsdl-graphics.cpp
+++ b/backends/graphics/samsungtvsdl/samsungtvsdl-graphics.cpp
@@ -32,7 +32,7 @@ SamsungTVSdlGraphicsManager::SamsungTVSdlGraphicsManager(SdlEventSource *sdlEven
 	: SurfaceSdlGraphicsManager(sdlEventSource, window) {
 }
 
-bool SamsungTVSdlGraphicsManager::hasFeature(OSystem::Feature f) {
+bool SamsungTVSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 	return
 		(f == OSystem::kFeatureAspectRatioCorrection) ||
 		(f == OSystem::kFeatureCursorPalette);
@@ -48,7 +48,7 @@ void SamsungTVSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enabl
 	}
 }
 
-bool SamsungTVSdlGraphicsManager::getFeatureState(OSystem::Feature f) {
+bool SamsungTVSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	switch (f) {
 	case OSystem::kFeatureAspectRatioCorrection:
 		return SurfaceSdlGraphicsManager::getFeatureState(f);

--- a/backends/graphics/samsungtvsdl/samsungtvsdl-graphics.h
+++ b/backends/graphics/samsungtvsdl/samsungtvsdl-graphics.h
@@ -31,9 +31,9 @@ class SamsungTVSdlGraphicsManager : public SurfaceSdlGraphicsManager {
 public:
 	SamsungTVSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
-	bool hasFeature(OSystem::Feature f);
-	void setFeatureState(OSystem::Feature f, bool enable);
-	bool getFeatureState(OSystem::Feature f);
+	bool hasFeature(OSystem::Feature f) const override;
+	void setFeatureState(OSystem::Feature f, bool enable) override;
+	bool getFeatureState(OSystem::Feature f) const override;
 };
 
 #endif

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -231,11 +231,12 @@ bool SdlGraphicsManager::createOrUpdateWindow(int width, int height, const Uint3
 	}
 
 	// We only update the actual window when flags change (which usually means
-	// fullscreen mode is entered/exited) or when updates are forced so that we
+	// fullscreen mode is entered/exited), when updates are forced so that we
 	// do not reset the window size whenever a game makes a call to change the
 	// size or pixel format of the internal game surface (since a user may have
-	// resized the game window)
-	if (!_window->getSDLWindow() || _lastFlags != flags || _allowWindowSizeReset) {
+	// resized the game window), or when the launcher is visible (since a user
+	// may change the scaler, which should reset the window size)
+	if (!_window->getSDLWindow() || _lastFlags != flags || _overlayVisible || _allowWindowSizeReset) {
 		if (_hintedWidth) {
 			width = _hintedWidth;
 		}

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -212,6 +212,13 @@ bool SdlGraphicsManager::notifyMousePosition(Common::Point &mouse) {
 	return valid;
 }
 
+void SdlGraphicsManager::setSystemMousePosition(const int x, const int y) {
+	assert(_window);
+	if (!_window->warpMouseInWindow(x, y)) {
+		_eventSource->fakeWarpMouse(x, y);
+	}
+}
+
 void SdlGraphicsManager::handleResizeImpl(const int width, const int height) {
 	_eventSource->resetKeyboardEmulation(width - 1, height - 1);
 	_forceRedraw = true;

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -84,8 +84,10 @@ public:
 	 *
 	 * @param mouse The mouse position in window coordinates, which must be
 	 * converted synchronously to virtual coordinates.
+	 * @returns true if the mouse was in a valid position for the game and
+	 * should cause the event to be sent to the game.
 	 */
-	virtual void notifyMousePosition(Common::Point &mouse);
+	virtual bool notifyMousePosition(Common::Point &mouse);
 
 	virtual bool showMouse(const bool visible) override;
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -87,6 +87,8 @@ public:
 	 */
 	virtual void notifyMousePosition(Common::Point &mouse);
 
+	virtual bool showMouse(const bool visible) override;
+
 	/**
 	 * A (subset) of the graphic manager's state. This is used when switching
 	 * between different SDL graphic managers at runtime.

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -150,10 +150,7 @@ protected:
 #endif
 	}
 
-	virtual void setSystemMousePosition(const int x, const int y) override {
-		assert(_window);
-		_window->warpMouseInWindow(x, y);
-	}
+	virtual void setSystemMousePosition(const int x, const int y) override;
 
 	virtual void handleResizeImpl(const int width, const int height) override;
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -62,10 +62,10 @@ public:
 	virtual void notifyVideoExpose() = 0;
 
 	/**
-	 * Notify the graphics manager about an resize event.
+	 * Notify the graphics manager about a resize event.
 	 *
 	 * It is noteworthy that the requested width/height should actually be set
-	 * up as is and not changed by the graphics manager, since else it might
+	 * up as is and not changed by the graphics manager, since otherwise it may
 	 * lead to odd behavior for certain window managers.
 	 *
 	 * It is only required to overwrite this method in case you want a
@@ -94,7 +94,7 @@ public:
 
 	/**
 	 * A (subset) of the graphic manager's state. This is used when switching
-	 * between different SDL graphic managers on runtime.
+	 * between different SDL graphic managers at runtime.
 	 */
 	struct State {
 		int screenWidth, screenHeight;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1876,9 +1876,6 @@ void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, 
 	assert(keycolor <= 0xFF);
 #endif
 
-	if (w == 0 || h == 0)
-		return;
-
 	_mouseCurState.hotX = hotspot_x;
 	_mouseCurState.hotY = hotspot_y;
 
@@ -1889,6 +1886,10 @@ void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, 
 	if (_mouseCurState.w != (int)w || _mouseCurState.h != (int)h) {
 		_mouseCurState.w = w;
 		_mouseCurState.h = h;
+
+		if (!w || !h) {
+			return;
+		}
 
 		if (_mouseOrigSurface)
 			SDL_FreeSurface(_mouseOrigSurface);
@@ -1928,22 +1929,21 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 #else
 	byte color;
 #endif
-	int w, h, i, j;
 
-	if (!_mouseOrigSurface || !_mouseData)
+	int w = _mouseCurState.w;
+	int h = _mouseCurState.h;
+
+	if (!_mouseOrigSurface || !_mouseData || !w || !h)
 		return;
 
 	_cursorNeedsRedraw = true;
 
-	w = _mouseCurState.w;
-	h = _mouseCurState.h;
-
 	SDL_LockSurface(_mouseOrigSurface);
 
 	// Make whole surface transparent
-	for (i = 0; i < h + 2; i++) {
+	for (int i = 0; i < h + 2; i++) {
 		dstPtr = (byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * i;
-		for (j = 0; j < w + 2; j++) {
+		for (int j = 0; j < w + 2; j++) {
 			*(uint16 *)dstPtr = kMouseColorKey;
 			dstPtr += 2;
 		}
@@ -1959,8 +1959,8 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 	else
 		palette = _cursorPalette;
 
-	for (i = 0; i < h; i++) {
-		for (j = 0; j < w; j++) {
+	for (int i = 0; i < h; i++) {
+		for (int j = 0; j < w; j++) {
 #ifdef USE_RGB_COLOR
 			if (_cursorFormat.bytesPerPixel > 1) {
 				if (_cursorFormat.bytesPerPixel == 2)
@@ -2112,7 +2112,7 @@ void SurfaceSdlGraphicsManager::undrawMouse() {
 }
 
 void SurfaceSdlGraphicsManager::drawMouse() {
-	if (!_cursorVisible || !_mouseSurface) {
+	if (!_cursorVisible || !_mouseSurface || !_mouseCurState.w || !_mouseCurState.h) {
 		_mouseBackup.x = _mouseBackup.y = _mouseBackup.w = _mouseBackup.h = 0;
 		return;
 	}

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1991,9 +1991,7 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 		dstPtr += _mouseOrigSurface->pitch - w * 2;
 	}
 
-	int rW, rH;
 	int cursorScale;
-
 	if (_cursorDontScale) {
 		// Don't scale the cursor at all if the user requests this behavior.
 		cursorScale = 1;
@@ -2003,8 +2001,8 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 	}
 
 	// Adapt the real hotspot according to the scale factor.
-	rW = w * cursorScale;
-	rH = h * cursorScale;
+	int rW = w * cursorScale;
+	int rH = h * cursorScale;
 	_mouseCurState.rHotX = _mouseCurState.hotX * cursorScale;
 	_mouseCurState.rHotY = _mouseCurState.hotY * cursorScale;
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1139,14 +1139,14 @@ void SurfaceSdlGraphicsManager::updateScreen() {
 }
 
 void SurfaceSdlGraphicsManager::updateShader() {
-// shader init code goes here
-// currently only used on Vita port
-// the user-selected shaderID should be obtained via ConfMan.getInt("shader")
-// and the corresponding shader should then be activated here
-// this way the user can combine any software scaling (scalers)
-// with any hardware shading (shaders). The shaders could provide
-// scanline masks, overlays, but could also serve for
-// hardware-based up-scaling (sharp-bilinear-simple, etc.)
+	// shader init code goes here
+	// currently only used on Vita port
+	// the user-selected shaderID should be obtained via ConfMan.getInt("shader")
+	// and the corresponding shader should then be activated here
+	// this way the user can combine any software scaling (scalers)
+	// with any hardware shading (shaders). The shaders could provide
+	// scanline masks, overlays, but could also serve for
+	// hardware-based up-scaling (sharp-bilinear-simple, etc.)
 }
 
 void SurfaceSdlGraphicsManager::internUpdateScreen() {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -145,7 +145,7 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 #endif
 	_overlayscreen(0), _tmpscreen2(0),
 	_scalerProc(0), _screenChangeCount(0),
-	_mouseVisible(false), _mouseData(0), _mouseSurface(0),
+	_mouseData(0), _mouseSurface(0),
 	_mouseOrigSurface(0), _cursorDontScale(false), _cursorPaletteDisabled(true),
 	_currentShakePos(0), _newShakePos(0),
 	_paletteDirtyStart(0), _paletteDirtyEnd(0),
@@ -1863,17 +1863,6 @@ void SurfaceSdlGraphicsManager::copyRectToOverlay(const void *buf, int pitch, in
 #pragma mark --- Mouse ---
 #pragma mark -
 
-bool SurfaceSdlGraphicsManager::showMouse(bool visible) {
-	if (_mouseVisible == visible)
-		return visible;
-
-	bool last = _mouseVisible;
-	_mouseVisible = visible;
-	_cursorNeedsRedraw = true;
-
-	return last;
-}
-
 void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspot_x, int hotspot_y, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
 #ifdef USE_RGB_COLOR
 	if (!format)
@@ -2123,7 +2112,7 @@ void SurfaceSdlGraphicsManager::undrawMouse() {
 }
 
 void SurfaceSdlGraphicsManager::drawMouse() {
-	if (!_mouseVisible || !_mouseSurface) {
+	if (!_cursorVisible || !_mouseSurface) {
 		_mouseBackup.x = _mouseBackup.y = _mouseBackup.w = _mouseBackup.h = 0;
 		return;
 	}

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -2792,10 +2792,7 @@ void SurfaceSdlGraphicsManager::recreateScreenTexture() {
 SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags) {
 	deinitializeRenderer();
 
-	uint32 createWindowFlags = 0;
-#ifdef USE_SDL_RESIZABLE_WINDOW
-	createWindowFlags |= SDL_WINDOW_RESIZABLE;
-#endif
+	uint32 createWindowFlags = SDL_WINDOW_RESIZABLE;
 	if ((flags & SDL_FULLSCREEN) != 0) {
 		createWindowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -39,15 +39,6 @@
 #define USE_SDL_DEBUG_FOCUSRECT
 #endif
 
-// We have (some) support for resizable windows when SDL2 is used. However
-// the overlay still uses the resolution setup with SDL_SetVideoMode. This
-// makes the GUI look subpar when the user resizes the window. In addition
-// we do not adapt the scale factor right now. Thus, we disable this code
-// path for now.
-#if SDL_VERSION_ATLEAST(2, 0, 0) && 0
-#define USE_SDL_RESIZABLE_WINDOW
-#endif
-
 #if !defined(_WIN32_WCE) && !defined(__SYMBIAN32__)
 // Uncomment this to enable the 'on screen display' code.
 #define USE_OSD	1

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -129,7 +129,6 @@ public:
 	virtual int16 getOverlayHeight() const override { return _videoMode.overlayHeight; }
 	virtual int16 getOverlayWidth() const override { return _videoMode.overlayWidth; }
 
-	virtual bool showMouse(bool visible) override;
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override;
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) override;
 
@@ -318,7 +317,6 @@ protected:
 			{ }
 	};
 
-	bool _mouseVisible;
 	byte *_mouseData;
 	SDL_Rect _mouseBackup;
 	MousePos _mouseCurState;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -193,9 +193,9 @@ protected:
 
 	/** Unseen game screen */
 	SDL_Surface *_screen;
-#ifdef USE_RGB_COLOR
 	Graphics::PixelFormat _screenFormat;
 	Graphics::PixelFormat _cursorFormat;
+#ifdef USE_RGB_COLOR
 	Common::List<Graphics::PixelFormat> _supportedFormats;
 
 	/**

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -40,7 +40,6 @@
 #endif
 
 #if !defined(_WIN32_WCE) && !defined(__SYMBIAN32__)
-// Uncomment this to enable the 'on screen display' code.
 #define USE_OSD	1
 #endif
 
@@ -80,76 +79,71 @@ public:
 	SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 	virtual ~SurfaceSdlGraphicsManager();
 
-	virtual void activateManager();
-	virtual void deactivateManager();
+	virtual void activateManager() override;
+	virtual void deactivateManager() override;
 
-	virtual bool hasFeature(OSystem::Feature f);
-	virtual void setFeatureState(OSystem::Feature f, bool enable);
-	virtual bool getFeatureState(OSystem::Feature f);
+	virtual bool hasFeature(OSystem::Feature f) const override;
+	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
+	virtual bool getFeatureState(OSystem::Feature f) const override;
 
-	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const;
-	virtual int getDefaultGraphicsMode() const;
-	virtual bool setGraphicsMode(int mode);
-	virtual int getGraphicsMode() const;
-	virtual void resetGraphicsScale();
+	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
+	virtual int getDefaultGraphicsMode() const override;
+	virtual bool setGraphicsMode(int mode) override;
+	virtual int getGraphicsMode() const override;
+	virtual void resetGraphicsScale() override;
 #ifdef USE_RGB_COLOR
-	virtual Graphics::PixelFormat getScreenFormat() const { return _screenFormat; }
-	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const;
+	virtual Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
+	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override;
 #endif
-	virtual const OSystem::GraphicsMode *getSupportedShaders() const;
-	virtual int getShader() const;
-	virtual bool setShader(int id);
-	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL);
-	virtual int getScreenChangeID() const { return _screenChangeCount; }
+	virtual const OSystem::GraphicsMode *getSupportedShaders() const override;
+	virtual int getShader() const override;
+	virtual bool setShader(int id) override;
+	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL) override;
+	virtual int getScreenChangeID() const override { return _screenChangeCount; }
 
-	virtual void beginGFXTransaction();
-	virtual OSystem::TransactionError endGFXTransaction();
+	virtual void beginGFXTransaction() override;
+	virtual OSystem::TransactionError endGFXTransaction() override;
 
-	virtual int16 getHeight();
-	virtual int16 getWidth();
+	virtual int16 getHeight() const override;
+	virtual int16 getWidth() const override;
 
 protected:
 	// PaletteManager API
-	virtual void setPalette(const byte *colors, uint start, uint num);
-	virtual void grabPalette(byte *colors, uint start, uint num);
+	virtual void setPalette(const byte *colors, uint start, uint num) override;
+	virtual void grabPalette(byte *colors, uint start, uint num) const override;
 
 public:
-	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h);
-	virtual Graphics::Surface *lockScreen();
-	virtual void unlockScreen();
-	virtual void fillScreen(uint32 col);
-	virtual void updateScreen();
-	virtual void setShakePos(int shakeOffset);
-	virtual void setFocusRectangle(const Common::Rect& rect);
-	virtual void clearFocusRectangle();
+	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override;
+	virtual Graphics::Surface *lockScreen() override;
+	virtual void unlockScreen() override;
+	virtual void fillScreen(uint32 col) override;
+	virtual void updateScreen() override;
+	virtual void setShakePos(int shakeOffset) override;
+	virtual void setFocusRectangle(const Common::Rect& rect) override;
+	virtual void clearFocusRectangle() override;
 
-	virtual void showOverlay();
-	virtual void hideOverlay();
-	virtual Graphics::PixelFormat getOverlayFormat() const { return _overlayFormat; }
-	virtual void clearOverlay();
-	virtual void grabOverlay(void *buf, int pitch);
-	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
-	virtual int16 getOverlayHeight() { return _videoMode.overlayHeight; }
-	virtual int16 getOverlayWidth() { return _videoMode.overlayWidth; }
+	virtual Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
+	virtual void clearOverlay() override;
+	virtual void grabOverlay(void *buf, int pitch) const override;
+	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
+	virtual int16 getOverlayHeight() const override { return _videoMode.overlayHeight; }
+	virtual int16 getOverlayWidth() const override { return _videoMode.overlayWidth; }
 
-	virtual bool showMouse(bool visible);
-	virtual void warpMouse(int x, int y);
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL);
-	virtual void setCursorPalette(const byte *colors, uint start, uint num);
+	virtual bool showMouse(bool visible) override;
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override;
+	virtual void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 #ifdef USE_OSD
-	virtual void displayMessageOnOSD(const char *msg);
-	virtual void displayActivityIconOnOSD(const Graphics::Surface *icon);
+	virtual void displayMessageOnOSD(const char *msg) override;
+	virtual void displayActivityIconOnOSD(const Graphics::Surface *icon) override;
 #endif
 
 	// Override from Common::EventObserver
-	bool notifyEvent(const Common::Event &event);
+	virtual bool notifyEvent(const Common::Event &event) override;
 
 	// SdlGraphicsManager interface
-	virtual void notifyVideoExpose();
-	virtual void notifyResize(const uint width, const uint height);
-	virtual void transformMouseCoordinates(Common::Point &point);
-	virtual void notifyMousePos(Common::Point mouse);
+	virtual void notifyVideoExpose() override;
+	virtual void notifyResize(const int width, const int height) override;
 
 protected:
 #ifdef USE_OSD
@@ -178,8 +172,11 @@ protected:
 	void drawOSD();
 #endif
 
-	/** Hardware screen */
-	SDL_Surface *_hwscreen;
+	virtual bool gameNeedsAspectRatioCorrection() const override {
+		return _videoMode.aspectRatioCorrection;
+	}
+
+	virtual void handleResizeImpl(const int width, const int height) override;
 
 	virtual int getGraphicsModeScale(int mode) const override;
 
@@ -188,10 +185,7 @@ protected:
 	 * around this API to keep the code paths as close as possible. */
 	SDL_Renderer *_renderer;
 	SDL_Texture *_screenTexture;
-	SDL_Rect _viewport;
-	int _windowWidth, _windowHeight;
 	void deinitializeRenderer();
-	void setWindowResolution(int width, int height);
 	void recreateScreenTexture();
 
 	virtual SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags);
@@ -218,7 +212,6 @@ protected:
 	SDL_Surface *_tmpscreen2;
 
 	SDL_Surface *_overlayscreen;
-	bool _overlayVisible;
 	Graphics::PixelFormat _overlayFormat;
 
 	enum {
@@ -280,14 +273,11 @@ protected:
 	uint8 _originalBitsPerPixel;
 #endif
 
-	/** Force full redraw on next updateScreen */
-	bool _forceFull;
-
 	ScalerProc *_scalerProc;
 	int _scalerType;
 	int _transactionMode;
 
-	// Indicates whether it is needed to free _hwsurface in destructor
+	// Indicates whether it is needed to free _hwSurface in destructor
 	bool _displayDisabled;
 
 	bool _screenIsLocked;
@@ -308,10 +298,6 @@ protected:
 	int _numDirtyRects;
 
 	struct MousePos {
-		// The mouse position, using either virtual (game) or real
-		// (overlay) coordinates.
-		int16 x, y;
-
 		// The size and hotspot of the original cursor image.
 		int16 w, h;
 		int16 hotX, hotY;
@@ -326,14 +312,13 @@ protected:
 		int16 vW, vH;
 		int16 vHotX, vHotY;
 
-		MousePos() : x(0), y(0), w(0), h(0), hotX(0), hotY(0),
+		MousePos() : w(0), h(0), hotX(0), hotY(0),
 					rW(0), rH(0), rHotX(0), rHotY(0), vW(0), vH(0),
 					vHotX(0), vHotY(0)
 			{ }
 	};
 
 	bool _mouseVisible;
-	bool _mouseNeedsRedraw;
 	byte *_mouseData;
 	SDL_Rect _mouseBackup;
 	MousePos _mouseCurState;
@@ -386,21 +371,45 @@ protected:
 	virtual void unloadGFXMode();
 	virtual bool hotswapGFXMode();
 
-	virtual void setFullscreenMode(bool enable);
 	virtual void setAspectRatioCorrection(bool enable);
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	virtual void setFilteringMode(bool enable);
+	void setFilteringMode(bool enable);
 #endif
 
-	virtual int effectiveScreenHeight() const;
-
+	virtual bool saveScreenshot(const char *filename);
 	virtual void setGraphicsModeIntern();
 
-	virtual bool handleScalerHotkeys(Common::KeyCode key);
-	virtual bool isScalerHotkey(const Common::Event &event);
-	virtual void setMousePos(int x, int y);
-	virtual void toggleFullScreen();
-	virtual bool saveScreenshot(const char *filename);
+private:
+	void setFullscreenMode(bool enable);
+	bool handleScalerHotkeys(Common::KeyCode key);
+	bool isScalerHotkey(const Common::Event &event);
+	void toggleFullScreen();
+
+	/**
+	 * Converts the given point from the overlay's coordinate space to the
+	 * game's coordinate space.
+	 */
+	Common::Point convertOverlayToGame(const int x, const int y) const {
+		if (getOverlayWidth() == 0 || getOverlayHeight() == 0) {
+			error("convertOverlayToGame called without a valid overlay");
+		}
+
+		return Common::Point(x * getWidth() / getOverlayWidth(),
+							 y * getHeight() / getOverlayHeight());
+	}
+
+	/**
+	 * Converts the given point from the game's coordinate space to the
+	 * overlay's coordinate space.
+	 */
+	Common::Point convertGameToOverlay(const int x, const int y) const {
+		if (getWidth() == 0 || getHeight() == 0) {
+			error("convertGameToOverlay called without a valid overlay");
+		}
+
+		return Common::Point(x * getOverlayWidth() / getWidth(),
+							 y * getOverlayHeight() / getHeight());
+	}
 };
 
 #endif

--- a/backends/graphics/symbiansdl/symbiansdl-graphics.cpp
+++ b/backends/graphics/symbiansdl/symbiansdl-graphics.cpp
@@ -50,7 +50,7 @@ bool SymbianSdlGraphicsManager::setGraphicsMode(int /*name*/) {
 	return SurfaceSdlGraphicsManager::setGraphicsMode(getDefaultGraphicsMode());
 }
 
-bool SymbianSdlGraphicsManager::hasFeature(OSystem::Feature f) {
+bool SymbianSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 	switch (f) {
 	case OSystem::kFeatureFullscreenMode:
 	case OSystem::kFeatureAspectRatioCorrection:

--- a/backends/graphics/symbiansdl/symbiansdl-graphics.h
+++ b/backends/graphics/symbiansdl/symbiansdl-graphics.h
@@ -30,12 +30,12 @@ public:
 	SymbianSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 
 public:
-	virtual bool hasFeature(OSystem::Feature f);
-	virtual void setFeatureState(OSystem::Feature f, bool enable);
+	virtual bool hasFeature(OSystem::Feature f) const override;
+	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 
-	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const;
-	virtual int getDefaultGraphicsMode() const;
-	virtual bool setGraphicsMode(int mode);
+	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
+	virtual int getDefaultGraphicsMode() const override;
+	virtual bool setGraphicsMode(int mode) override;
 };
 
 #endif

--- a/backends/graphics/wincesdl/wincesdl-graphics.cpp
+++ b/backends/graphics/wincesdl/wincesdl-graphics.cpp
@@ -115,7 +115,7 @@ const OSystem::GraphicsMode *WINCESdlGraphicsManager::getSupportedGraphicsModes(
 		return s_supportedGraphicsModesLow;
 }
 
-bool WINCESdlGraphicsManager::hasFeature(OSystem::Feature f) {
+bool WINCESdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 	return (f == OSystem::kFeatureVirtualKeyboard);
 }
 
@@ -153,7 +153,7 @@ void WINCESdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
 	}
 }
 
-bool WINCESdlGraphicsManager::getFeatureState(OSystem::Feature f) {
+bool WINCESdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	switch (f) {
 	case OSystem::kFeatureFullscreenMode:
 		return false;

--- a/backends/graphics/wincesdl/wincesdl-graphics.h
+++ b/backends/graphics/wincesdl/wincesdl-graphics.h
@@ -46,9 +46,9 @@ public:
 	const OSystem::GraphicsMode *getSupportedGraphicsModes() const;
 	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL);
 
-	bool hasFeature(OSystem::Feature f);
+	bool hasFeature(OSystem::Feature f) const;
 	void setFeatureState(OSystem::Feature f, bool enable);
-	bool getFeatureState(OSystem::Feature f);
+	bool getFeatureState(OSystem::Feature f) const;
 
 	int getDefaultGraphicsMode() const;
 	bool setGraphicsMode(int mode);

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -36,6 +36,7 @@ public:
 		_windowHeight(0),
 		_overlayVisible(false),
 		_forceRedraw(false),
+		_cursorVisible(false),
 		_cursorX(0),
 		_cursorY(0),
 		_cursorNeedsRedraw(false) {}
@@ -182,6 +183,17 @@ protected:
 	 */
 	virtual void setSystemMousePosition(const int x, const int y) = 0;
 
+	virtual bool showMouse(const bool visible) override {
+		if (_cursorVisible == visible) {
+			return visible;
+		}
+
+		const bool last = _cursorVisible;
+		_cursorVisible = visible;
+		_cursorNeedsRedraw = true;
+		return last;
+	}
+
 	/**
 	 * Move ("warp") the mouse cursor to the specified position.
 	 *
@@ -280,6 +292,11 @@ protected:
 	 * Whether the screen must be redrawn on the next frame.
 	 */
 	bool _forceRedraw;
+
+	/**
+	 * Whether the cursor is actually visible.
+	 */
+	bool _cursorVisible;
 
 	/**
 	 * Whether the mouse cursor needs to be redrawn on the next frame.

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -1,0 +1,313 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKENDS_GRAPHICS_WINDOWED_H
+#define BACKENDS_GRAPHICS_WINDOWED_H
+
+#include "backends/graphics/graphics.h"
+#include "common/frac.h"
+#include "common/rect.h"
+#include "common/textconsole.h"
+#include "graphics/scaler/aspect.h"
+
+class WindowedGraphicsManager : virtual public GraphicsManager {
+public:
+	WindowedGraphicsManager() :
+		_windowWidth(0),
+		_windowHeight(0),
+		_overlayVisible(false),
+		_forceRedraw(false),
+		_cursorX(0),
+		_cursorY(0),
+		_cursorNeedsRedraw(false) {}
+
+	virtual void showOverlay() override {
+		if (_overlayVisible)
+			return;
+
+		_activeArea.drawRect = _overlayDrawRect;
+		_activeArea.width = getOverlayWidth();
+		_activeArea.height = getOverlayHeight();
+		_overlayVisible = true;
+		_forceRedraw = true;
+	}
+
+	virtual void hideOverlay() override {
+		if (!_overlayVisible)
+			return;
+
+		_activeArea.drawRect = _gameDrawRect;
+		_activeArea.width = getWidth();
+		_activeArea.height = getHeight();
+		_overlayVisible = false;
+		_forceRedraw = true;
+	}
+
+protected:
+	/**
+	 * @returns whether or not the game screen must have aspect ratio correction
+	 * applied for correct rendering.
+	 */
+	virtual bool gameNeedsAspectRatioCorrection() const = 0;
+
+	/**
+	 * Backend-specific implementation for updating internal surfaces that need
+	 * to reflect the new window size.
+	 */
+	virtual void handleResizeImpl(const int width, const int height) = 0;
+
+	/**
+	 * Converts the given point from the active virtual screen's coordinate
+	 * space to the window's coordinate space (i.e. game-to-window or
+	 * overlay-to-window).
+	 */
+	Common::Point convertVirtualToWindow(const int x, const int y) const {
+		const int targetX = _activeArea.drawRect.left;
+		const int targetY = _activeArea.drawRect.top;
+		const int targetWidth = _activeArea.drawRect.width();
+		const int targetHeight = _activeArea.drawRect.height();
+		const int sourceWidth = _activeArea.width;
+		const int sourceHeight = _activeArea.height;
+
+		if (sourceWidth == 0 || sourceHeight == 0) {
+			error("convertVirtualToWindow called without a valid draw rect");
+		}
+
+		return Common::Point(targetX + x * targetWidth / sourceWidth,
+							 targetY + y * targetHeight / sourceHeight);
+	}
+
+	/**
+	 * Converts the given point from the window's coordinate space to the
+	 * active virtual screen's coordinate space (i.e. window-to-game or
+	 * window-to-overlay).
+	 */
+	Common::Point convertWindowToVirtual(int x, int y) const {
+		const int sourceX = _activeArea.drawRect.left;
+		const int sourceY = _activeArea.drawRect.top;
+		const int sourceMaxX = _activeArea.drawRect.right - 1;
+		const int sourceMaxY = _activeArea.drawRect.bottom - 1;
+		const int sourceWidth = _activeArea.drawRect.width();
+		const int sourceHeight = _activeArea.drawRect.height();
+		const int targetWidth = _activeArea.width;
+		const int targetHeight = _activeArea.height;
+
+		if (sourceWidth == 0 || sourceHeight == 0) {
+			error("convertWindowToVirtual called without a valid draw rect");
+		}
+
+		x = CLIP<int>(x, sourceX, sourceMaxX);
+		y = CLIP<int>(y, sourceY, sourceMaxY);
+
+		return Common::Point(((x - sourceX) * targetWidth) / sourceWidth,
+							 ((y - sourceY) * targetHeight) / sourceHeight);
+	}
+
+	/**
+	 * @returns the desired aspect ratio of the game surface.
+	 */
+	frac_t getDesiredGameAspectRatio() const {
+		if (getHeight() == 0 || gameNeedsAspectRatioCorrection()) {
+			return intToFrac(4) / 3;
+		}
+
+		return intToFrac(getWidth()) / getHeight();
+	}
+
+	/**
+	 * Called after the window has been updated with new dimensions.
+	 *
+	 * @param width The new width of the window, excluding window decoration.
+	 * @param height The new height of the window, excluding window decoration.
+	 */
+	void handleResize(const int width, const int height) {
+		_windowWidth = width;
+		_windowHeight = height;
+		handleResizeImpl(width, height);
+	}
+
+	/**
+	 * Recalculates the display areas for the game and overlay surfaces within
+	 * the window.
+	 */
+	virtual void recalculateDisplayAreas() {
+		if (_windowHeight == 0) {
+			return;
+		}
+
+		const frac_t outputAspect = intToFrac(_windowWidth) / _windowHeight;
+
+		populateDisplayAreaDrawRect(getDesiredGameAspectRatio(), outputAspect, _gameDrawRect);
+
+		if (getOverlayHeight()) {
+			const frac_t overlayAspect = intToFrac(getOverlayWidth()) / getOverlayHeight();
+			populateDisplayAreaDrawRect(overlayAspect, outputAspect, _overlayDrawRect);
+		}
+
+		if (_overlayVisible) {
+			_activeArea.drawRect = _overlayDrawRect;
+			_activeArea.width = getOverlayWidth();
+			_activeArea.height = getOverlayHeight();
+		} else {
+			_activeArea.drawRect = _gameDrawRect;
+			_activeArea.width = getWidth();
+			_activeArea.height = getHeight();
+		}
+	}
+	/**
+	 * Sets the position of the hardware mouse cursor in the host system,
+	 * relative to the window.
+	 *
+	 * @param x X coordinate in window coordinates.
+	 * @param y Y coordinate in window coordinates.
+	 */
+	virtual void setSystemMousePosition(const int x, const int y) = 0;
+
+	/**
+	 * Move ("warp") the mouse cursor to the specified position.
+	 *
+	 * @param x	The new X position of the mouse in virtual screen coordinates.
+	 * @param y	The new Y position of the mouse in virtual screen coordinates.
+	 */
+	void warpMouse(const int x, const int y) {
+		// Check active coordinate instead of window coordinate to avoid warping
+		// the mouse if it is still within the same virtual pixel
+		const Common::Point virtualCursor = convertWindowToVirtual(_cursorX, _cursorY);
+		if (virtualCursor.x != x || virtualCursor.y != y) {
+			// Warping the mouse in SDL generates a mouse movement event, so
+			// `setMousePosition` would be called eventually through the
+			// `notifyMousePosition` callback if we *only* set the system mouse
+			// position here. However, this can cause problems with some games.
+			// For example, the cannon script in CoMI calls to warp the mouse
+			// twice each time the cannon is reloaded, and unless we update the
+			// mouse position immediately, the second call is ignored, which
+			// causes the cannon to change its aim.
+			const Common::Point windowCursor = convertVirtualToWindow(x, y);
+			setMousePosition(windowCursor.x, windowCursor.y);
+			setSystemMousePosition(windowCursor.x, windowCursor.y);
+		}
+	}
+
+	/**
+	 * Sets the position of the rendered mouse cursor in the window.
+	 *
+	 * @param x X coordinate in window coordinates.
+	 * @param y Y coordinate in window coordinates.
+	 */
+	void setMousePosition(int x, int y) {
+		if (_cursorX != x || _cursorY != y) {
+			_cursorNeedsRedraw = true;
+		}
+
+		_cursorX = x;
+		_cursorY = y;
+	}
+
+	/**
+	 * The width of the window, excluding window decoration.
+	 */
+	int _windowWidth;
+
+	/**
+	 * The height of the window, excluding window decoration.
+	 */
+	int _windowHeight;
+
+	/**
+	 * Whether the overlay (i.e. launcher, including the out-of-game launcher)
+	 * is visible or not.
+	 */
+	bool _overlayVisible;
+
+	/**
+	 * The scaled draw rectangle for the game surface within the window.
+	 */
+	Common::Rect _gameDrawRect;
+
+	/**
+	 * The scaled draw rectangle for the overlay (launcher) surface within the
+	 * window.
+	 */
+	Common::Rect _overlayDrawRect;
+
+	/**
+	 * Data about the display area of a virtual screen.
+	 */
+	struct DisplayArea {
+		/**
+		 * The scaled area where the virtual screen is drawn within the window.
+		 */
+		Common::Rect drawRect;
+
+		/**
+		 * The width of the virtual screen's unscaled coordinate space.
+		 */
+		int width;
+
+		/**
+		 * The height of the virtual screen's unscaled coordinate space.
+		 */
+		int height;
+	};
+
+	/**
+	 * Display area information about the currently active virtual screen. This
+	 * will be the overlay screen when the overlay is active, and the game
+	 * screen otherwise.
+	 */
+	DisplayArea _activeArea;
+
+	/**
+	 * Whether the screen must be redrawn on the next frame.
+	 */
+	bool _forceRedraw;
+
+	/**
+	 * Whether the mouse cursor needs to be redrawn on the next frame.
+	 */
+	bool _cursorNeedsRedraw;
+
+	/**
+	 * The position of the mouse cursor, in window coordinates.
+	 */
+	int _cursorX, _cursorY;
+
+private:
+	void populateDisplayAreaDrawRect(const frac_t inputAspect, const frac_t outputAspect, Common::Rect &drawRect) const {
+		int width = _windowWidth;
+		int height = _windowHeight;
+
+		// Maintain aspect ratios
+		if (outputAspect < inputAspect) {
+			height = intToFrac(width) / inputAspect;
+		} else if (outputAspect > inputAspect) {
+			width = fracToInt(height * inputAspect);
+		}
+
+		drawRect.left = (_windowWidth - width) / 2;
+		drawRect.top = (_windowHeight - height) / 2;
+		drawRect.setWidth(width);
+		drawRect.setHeight(height);
+	}
+};
+
+#endif

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -39,7 +39,8 @@ public:
 		_cursorVisible(false),
 		_cursorX(0),
 		_cursorY(0),
-		_cursorNeedsRedraw(false) {}
+		_cursorNeedsRedraw(false),
+		_cursorLastInActiveArea(true) {}
 
 	virtual void showOverlay() override {
 		if (_overlayVisible)
@@ -302,6 +303,12 @@ protected:
 	 * Whether the mouse cursor needs to be redrawn on the next frame.
 	 */
 	bool _cursorNeedsRedraw;
+
+	/**
+	 * Whether the last position of the system cursor was within the active area
+	 * of the window.
+	 */
+	bool _cursorLastInActiveArea;
 
 	/**
 	 * The position of the mouse cursor, in window coordinates.

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -217,6 +217,7 @@ bool ModularBackend::showMouse(bool visible) {
 }
 
 void ModularBackend::warpMouse(int x, int y) {
+	_eventManager->purgeMouseEvents();
 	_graphicsManager->warpMouse(x, y);
 }
 

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -153,7 +153,7 @@ bool SdlWindow::hasMouseFocus() const {
 #endif
 }
 
-void SdlWindow::warpMouseInWindow(uint x, uint y) {
+void SdlWindow::warpMouseInWindow(int x, int y) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_window && hasMouseFocus()) {
 		SDL_WarpMouseInWindow(_window, x, y);

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -135,8 +135,10 @@ void SdlWindow::toggleMouseGrab() {
 #else
 	if (SDL_WM_GrabInput(SDL_GRAB_QUERY) == SDL_GRAB_OFF) {
 		SDL_WM_GrabInput(SDL_GRAB_ON);
+		_inputGrabState = true;
 	} else {
 		SDL_WM_GrabInput(SDL_GRAB_OFF);
+		_inputGrabState = false;
 	}
 #endif
 }
@@ -154,13 +156,15 @@ bool SdlWindow::hasMouseFocus() const {
 }
 
 void SdlWindow::warpMouseInWindow(int x, int y) {
+	if (hasMouseFocus()) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	if (_window && hasMouseFocus()) {
-		SDL_WarpMouseInWindow(_window, x, y);
-	}
+		if (_window) {
+			SDL_WarpMouseInWindow(_window, x, y);
+		}
 #else
-	SDL_WarpMouse(x, y);
+		SDL_WarpMouse(x, y);
 #endif
+	}
 }
 
 void SdlWindow::iconifyWindow() {

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -155,16 +155,20 @@ bool SdlWindow::hasMouseFocus() const {
 #endif
 }
 
-void SdlWindow::warpMouseInWindow(int x, int y) {
+bool SdlWindow::warpMouseInWindow(int x, int y) {
 	if (hasMouseFocus()) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		if (_window) {
 			SDL_WarpMouseInWindow(_window, x, y);
+			return true;
 		}
 #else
 		SDL_WarpMouse(x, y);
+		return true;
 #endif
 	}
+
+	return false;
 }
 
 void SdlWindow::iconifyWindow() {

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -58,7 +58,7 @@ public:
 	/**
 	 * Warp the mouse to the specified position in window coordinates.
 	 */
-	void warpMouseInWindow(uint x, uint y);
+	void warpMouseInWindow(int x, int y);
 
 	/**
 	 * Iconifies the window.

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -58,8 +58,10 @@ public:
 	/**
 	 * Warp the mouse to the specified position in window coordinates. The mouse
 	 * will only be warped if the window is focused in the window manager.
+	 *
+	 * @returns true if the system cursor was warped.
 	 */
-	void warpMouseInWindow(int x, int y);
+	bool warpMouseInWindow(int x, int y);
 
 	/**
 	 * Iconifies the window.

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -56,7 +56,8 @@ public:
 	bool hasMouseFocus() const;
 
 	/**
-	 * Warp the mouse to the specified position in window coordinates.
+	 * Warp the mouse to the specified position in window coordinates. The mouse
+	 * will only be warped if the window is focused in the window manager.
 	 */
 	void warpMouseInWindow(int x, int y);
 
@@ -72,6 +73,11 @@ public:
 	 * for accessing it in a version safe manner.
 	 */
 	bool getSDLWMInformation(SDL_SysWMinfo *info) const;
+
+	bool mouseIsGrabbed() const { return _inputGrabState; }
+
+private:
+	bool _inputGrabState;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 public:
@@ -108,7 +114,6 @@ private:
 	 */
 	int _lastX, _lastY;
 
-	bool _inputGrabState;
 	Common::String _windowCaption;
 #endif
 };

--- a/common/events.h
+++ b/common/events.h
@@ -395,6 +395,11 @@ public:
 	 */
 	virtual void pushEvent(const Event &event) = 0;
 
+	/**
+	 * Purges all unprocessed mouse events already in the event queue.
+	 */
+	virtual void purgeMouseEvents() = 0;
+
 	/** Return the current mouse position */
 	virtual Point getMousePos() const = 0;
 

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -65,9 +65,7 @@ void CursorManager::pushCursor(const void *buf, uint w, uint h, int hotspotX, in
 	cur->_visible = isVisible();
 	_cursorStack.push(cur);
 
-	if (buf) {
-		g_system->setMouseCursor(cur->_data, w, h, hotspotX, hotspotY, keycolor, dontScale, format);
-	}
+	g_system->setMouseCursor(cur->_data, w, h, hotspotX, hotspotY, keycolor, dontScale, format);
 }
 
 void CursorManager::popCursor() {
@@ -80,6 +78,8 @@ void CursorManager::popCursor() {
 	if (!_cursorStack.empty()) {
 		cur = _cursorStack.top();
 		g_system->setMouseCursor(cur->_data, cur->_width, cur->_height, cur->_hotspotX, cur->_hotspotY, cur->_keycolor, cur->_dontScale, &cur->_format);
+	} else {
+		g_system->setMouseCursor(nullptr, 0, 0, 0, 0, 0);
 	}
 
 	g_system->showMouse(isVisible());
@@ -99,6 +99,7 @@ void CursorManager::popAllCursors() {
 		}
 	}
 
+	g_system->setMouseCursor(nullptr, 0, 0, 0, 0, 0);
 	g_system->showMouse(isVisible());
 }
 

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -96,7 +96,7 @@ public:
 	 *
 	 * @see getScreenFormat
 	 */
-	virtual void grabPalette(byte *colors, uint start, uint num) = 0;
+	virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
 };
 
 #endif


### PR DESCRIPTION
The first commit in this PR is https://github.com/scummvm/scummvm/pull/1007 which was needed for the other code to be applied cleanly (I’m being a little lazy here), so if you can, make comments on that other PR for that commit.

This patchset refactors the OpenGL and SDL graphics backends,
primarily to unify window scaling and mouse handling, and to
fix coordinate mapping between the ScummVM window and the
virtual game screen when they have different aspect ratios.

Unified code for these two backends has been moved to a new
header-only WindowedGraphicsManager class, so named because it
contains code for managing graphics managers that interact with
a windowing system and render virtual screens within a larger
physical content window.

The biggest behavioral change here is with the coordinate
system mapping:

Previously, mouse offsets were converted by mapping the whole
space within the window as input to the virtual game screen
without maintaining aspect ratio. This was done to prevent
'stickiness' when the mouse cursor was within the window but
outside of the virtual game screen, but it caused noticeable
distortion of mouse movement speed on the axis with blank
space.

Instead of introducing mouse speed distortion to prevent
stickiness, this patch changes coordinate transformation to
show the system cursor when the mouse moves outside of the virtual
game screen when mouse grab is off, or by holding the mouse inside
the virtual game screen (instead of the entire window) when mouse
grab is on.

This patch also improves some other properties of the
GraphicsManager/PaletteManager interfaces:

* Nullipotent operations (getWidth, getHeight, etc.) of the
  PaletteManager/GraphicsManager interfaces are now const
* Methods marked `virtual` but not inherited by any subclass have
  been de-virtualized
* Extra unnecessary calculations of hardware height in
  SurfaceSdlGraphicsManager have been removed
* Methods have been renamed where appropriate for clarity
  (setWindowSize -> handleResize, etc.)
* C++11 support improved with `override` specifier added on
  overridden virtual methods in subclasses (primarily to avoid
  myself accidentally creating new methods in the subclasses
  by changing types/names during refactoring)

Additional refactoring can and should be done at some point to
continue to deduplicate code between the OpenGL and SDL backends.
Since the primary goal here was to improve the coordinate mapping,
full refactoring of these backends was not completed here.

Please let me know your comments and feedback on these changes. I tested this with…

* SDL1/2 Surface/OpenGL on macOS
* SDL2 Surface/OpenGL on Linux VM

…using SCI engine, EcoQuest floppy (uses backend mouse & AR correction), GK1 CD (mode switches when playing intro with high-quality video on) lo-res & hi-res (no AR correction, forced normal1x scaler).

Hopefully this is not breaking compilation of any of the port-specific graphics managers, but I will probably need to run this patch on buildbot to verify that (and fix whatever might be broken in compilation). Looking forward to your feedback. Thanks!