### PR TITLE
GUI: Support double quoted debugger parameters

### DIFF
--- a/engines/titanic/core/game_object.cpp
+++ b/engines/titanic/core/game_object.cpp
@@ -1205,28 +1205,11 @@ void CGameObject::loadSurface() {
 }
 
 bool CGameObject::changeView(const CString &viewName) {
-	return changeView(viewName, "");
+	return getRoot()->changeView(viewName, "");
 }
 
 bool CGameObject::changeView(const CString &viewName, const CString &clipName) {
-	CViewItem *newView = parseView(viewName);
-	CGameManager *gameManager = getGameManager();
-	CViewItem *oldView = gameManager->getView();
-
-	if (!oldView || !newView)
-		return false;
-
-	CMovieClip *clip = nullptr;
-	if (!clipName.empty()) {
-		clip = oldView->findNode()->findRoom()->findClip(clipName);
-	} else {
-		CLinkItem *link = oldView->findLink(newView);
-		if (link)
-			clip = link->getClip();
-	}
-
-	gameManager->_gameState.changeView(newView, clip);
-	return true;
+	return getRoot()->changeView(viewName, clipName);
 }
 
 void CGameObject::dragMove(const Point &pt) {

--- a/engines/titanic/core/project_item.cpp
+++ b/engines/titanic/core/project_item.cpp
@@ -626,4 +626,30 @@ CViewItem *CProjectItem::parseView(const CString &viewString) {
 	return view;
 }
 
+bool CProjectItem::changeView(const CString &viewName) {
+	return changeView(viewName, "");
+}
+
+bool CProjectItem::changeView(const CString &viewName, const CString &clipName) {
+	CViewItem *newView = parseView(viewName);
+	CGameManager *gameManager = getGameManager();
+	CViewItem *oldView = gameManager->getView();
+
+	if (!oldView || !newView)
+		return false;
+
+	CMovieClip *clip = nullptr;
+	if (!clipName.empty()) {
+		clip = oldView->findNode()->findRoom()->findClip(clipName);
+	} else {
+		CLinkItem *link = oldView->findLink(newView);
+		if (link)
+			clip = link->getClip();
+	}
+
+	gameManager->_gameState.changeView(newView, clip);
+	return true;
+}
+
+
 } // End of namespace Titanic

--- a/engines/titanic/core/project_item.h
+++ b/engines/titanic/core/project_item.h
@@ -242,6 +242,15 @@ public:
 	 */
 	CViewItem *parseView(const CString &viewString);
 
+	/**
+	 * Change the view
+	 */
+	bool changeView(const CString &viewName, const CString &clipName);
+
+	/**
+	 * Change the view
+	 */
+	bool changeView(const CString &viewName);
 };
 
 } // End of namespace Titanic

--- a/engines/titanic/debugger.cpp
+++ b/engines/titanic/debugger.cpp
@@ -168,9 +168,18 @@ bool Debugger::cmdRoom(int argc, const char **argv) {
 	} else if (argc >= 2) {
 		CRoomItem *roomItem = findRoom(argv[1]);
 
-		if (!roomItem)
-			debugPrintf("Could not find room - %s\n", argv[1]);
-		else if (argc == 2)
+		if (!roomItem && argc == 2) {
+			// Presume it's a full view specified
+			CProjectItem *project = g_vm->_window->_project;
+			CViewItem *view = project->parseView(argv[1]);
+
+			if (view) {
+				project->changeView(argv[1]);
+				return false;
+			} else {
+				debugPrintf("Could not find view - %s\n", argv[1]);
+			}
+		} else if (argc == 2)
 			listRoom(roomItem);
 		else {
 			CNodeItem *nodeItem = findNode(roomItem, argv[2]);

--- a/engines/titanic/debugger.cpp
+++ b/engines/titanic/debugger.cpp
@@ -331,9 +331,6 @@ bool Debugger::cmdMovie(int argc, const char **argv) {
 bool Debugger::cmdSound(int argc, const char **argv) {
 	if (argc == 2) {
 		Common::String name = argv[1];
-		const char *ch = strchr(argv[1], '!');
-		if (ch)
-			name.setChar('#', ch - argv[1]);
 		if (!name.contains("#"))
 			name = "z#" + name;
 

--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -480,9 +480,7 @@ void ConsoleDialog::handleKeyDown(Common::KeyState state) {
 }
 
 void ConsoleDialog::defaultKeyDownHandler(Common::KeyState &state) {
-	if (state.ascii == '~' || state.ascii == '#') {
-		slideUpAndClose();
-	} else if (state.hasFlags(Common::KBD_CTRL)) {
+	if (state.hasFlags(Common::KBD_CTRL)) {
 		specialKeys(state.keycode);
 	} else if ((state.ascii >= 32 && state.ascii <= 127) || (state.ascii >= 160 && state.ascii <= 255)) {
 		for (int i = _promptEndPos - 1; i >= _currentPos; i--)

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -290,7 +290,8 @@ bool Debugger::parseCommand(const char *inputOrig) {
 	const char *param[256];
 
 	// Parse out any params
-	char *input = strdup(inputOrig);	// One of the rare occasions using strdup is OK (although avoiding strtok might be more elegant here).
+	// One of the rare occasions using strdup is OK, since splitCommands needs to modify it
+	char *input = strdup(inputOrig);
 	splitCommand(input, num_params, &param[0]);
 
 	// Handle commands first

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -288,17 +288,10 @@ bool Debugger::handleCommand(int argc, const char **argv, bool &result) {
 bool Debugger::parseCommand(const char *inputOrig) {
 	int num_params = 0;
 	const char *param[256];
-	char *input = strdup(inputOrig);	// One of the rare occasions using strdup is OK (although avoiding strtok might be more elegant here).
 
 	// Parse out any params
-	char *tok = strtok(input, " ");
-	if (tok) {
-		do {
-			param[num_params++] = tok;
-		} while ((tok = strtok(NULL, " ")) != NULL);
-	} else {
-		param[num_params++] = input;
-	}
+	char *input = strdup(inputOrig);	// One of the rare occasions using strdup is OK (although avoiding strtok might be more elegant here).
+	splitCommand(input, num_params, &param[0]);
 
 	// Handle commands first
 	bool result;
@@ -396,6 +389,57 @@ bool Debugger::parseCommand(const char *inputOrig) {
 	debugPrintf("Unknown command or variable\n");
 	free(input);
 	return true;
+}
+
+void Debugger::splitCommand(char *input, int &argc, const char **argv) {
+	byte c;
+	enum states { DULL, IN_WORD, IN_STRING } state = DULL;
+	const char *paramStart = nullptr;
+	
+	argc = 0;
+	for (char *p = input; *p; ++p) {
+		c = (byte)*p;
+
+		switch (state) {
+		case DULL: 
+			// not in a word, not in a double quoted string
+			if (isspace(c))
+				break;
+			
+			// not a space -- if it's a double quote we go to IN_STRING, else to IN_WORD
+			if (c == '"') {
+				state = IN_STRING;
+				paramStart = p + 1; // word starts at *next* char, not this one
+			} else {
+				state = IN_WORD;
+				paramStart = p;		// word starts here
+			}
+			break;
+
+		case IN_STRING:
+			// we're in a double quoted string, so keep going until we hit a close "
+			if (c == '"') {
+				// Add entire quoted string to parameter list
+				*p = '\0';
+				argv[argc++] = paramStart;
+				state = DULL;	// back to "not in word, not in string" state
+			}
+			break;
+
+		case IN_WORD:
+			// we're in a word, so keep going until we get to a space
+			if (isspace(c)) {
+				*p = '\0';
+				argv[argc++] = paramStart;
+				state = DULL;	// back to "not in word, not in string" state
+			}
+			break;
+		}
+	}
+
+	if (state != DULL)
+		// Add in final parameter
+		argv[argc++] = paramStart;
 }
 
 // returns true if something has been completed

--- a/gui/debugger.h
+++ b/gui/debugger.h
@@ -204,6 +204,12 @@ protected:
 private:
 	void enter();
 
+	/**
+	 * Splits up the input into individual parameters
+	 * @remarks		Adapted from code provided by torek on StackOverflow
+	 */
+	void splitCommand(char *input, int &argc, const char **argv);
+
 	bool parseCommand(const char *input);
 	bool tabComplete(const char *input, Common::String &completion) const;
 


### PR DESCRIPTION
This implements splitting of lines entered in the debugger into parameters with support for double quoted strings. In the Titanic engine, this allows for easier specification of specific views to jump to. In other engines, it may make it easier to specify things like item names that include spaces.