### PR TITLE
GRAPHICS: Don't use sizeof(PixelFormat)

### DIFF
--- a/graphics/pixelformat.h
+++ b/graphics/pixelformat.h
@@ -159,7 +159,7 @@ struct PixelFormat {
 
 	inline bool operator==(const PixelFormat &fmt) const {
 		// TODO: If aLoss==8, then the value of aShift is irrelevant, and should be ignored.
-		return 0 == memcmp(this, &fmt, sizeof(PixelFormat));
+		return 0 == memcmp(this, &fmt, 9);
 	}
 
 	inline bool operator!=(const PixelFormat &fmt) const {


### PR DESCRIPTION
On RISC OS, the PixelFormat structure is padded to word boundary, making the result of sizeof incorrect.