### PR TITLE
TITANIC: Star-control_changes

### DIFF
--- a/engines/titanic/game/captains_wheel.cpp
+++ b/engines/titanic/game/captains_wheel.cpp
@@ -99,6 +99,7 @@ bool CCaptainsWheel::ActMsg(CActMsg *msg) {
 		}
 	} else if (msg->_action == "Go") {
 		if (_stopEnabled) {
+			_goEnabled = false;
 			incTransitions();
 			_stopEnabled = false;
 			_actionNum = 1;

--- a/engines/titanic/game/nav_helmet.cpp
+++ b/engines/titanic/game/nav_helmet.cpp
@@ -37,13 +37,13 @@ END_MESSAGE_MAP()
 
 void CNavHelmet::save(SimpleFile *file, int indent) {
 	file->writeNumberLine(1, indent);
-	file->writeNumberLine(_flag, indent);
+	file->writeNumberLine(_helmetOn, indent);
 	CGameObject::save(file, indent);
 }
 
 void CNavHelmet::load(SimpleFile *file) {
 	file->readNumber();
-	_flag = file->readNumber();
+	_helmetOn = file->readNumber();
 	CGameObject::load(file);
 }
 
@@ -51,7 +51,7 @@ bool CNavHelmet::MovieEndMsg(CMovieEndMsg *msg) {
 	CPetControl *pet = getPetControl();
 	assert(pet);
 
-	if (_flag && pet->isAreaUnlocked()) {
+	if (_helmetOn && pet->isAreaUnlocked()) {
 		setVisible(false);
 
 		pet->setArea(PET_STARFIELD);
@@ -78,8 +78,8 @@ bool CNavHelmet::LeaveViewMsg(CLeaveViewMsg *msg) {
 bool CNavHelmet::PETHelmetOnOffMsg(CPETHelmetOnOffMsg *msg) {
 	CPetControl *pet = getPetControl();
 
-	if (_flag) {
-		_flag = false;
+	if (_helmetOn) {
+		_helmetOn = false;
 		setVisible(true);
 		starFn(STAR_HIDE);
 		playMovie(61, 120, MOVIE_NOTIFY_OBJECT);
@@ -94,7 +94,7 @@ bool CNavHelmet::PETHelmetOnOffMsg(CPETHelmetOnOffMsg *msg) {
 		decTransitions();
 	} else {
 		incTransitions();
-		_flag = true;
+		_helmetOn = true;
 		setVisible(true);
 		playMovie(0, 60, MOVIE_NOTIFY_OBJECT);
 		playSound("a#48.wav");
@@ -105,14 +105,14 @@ bool CNavHelmet::PETHelmetOnOffMsg(CPETHelmetOnOffMsg *msg) {
 }
 
 bool CNavHelmet::PETPhotoOnOffMsg(CPETPhotoOnOffMsg *msg) {
-	if (_flag)
+	if (_helmetOn)
 		starFn(STAR_TOGGLE_MODE);
 
 	return true;
 }
 
 bool CNavHelmet::PETStarFieldLockMsg(CPETStarFieldLockMsg *msg) {
-	if (_flag) {
+	if (_helmetOn) {
 		if (msg->_value) {
 			playSound("a#6.wav");
 			starFn(LOCK_STAR);

--- a/engines/titanic/game/nav_helmet.cpp
+++ b/engines/titanic/game/nav_helmet.cpp
@@ -22,6 +22,7 @@
 
 #include "titanic/game/nav_helmet.h"
 #include "titanic/pet_control/pet_control.h"
+#include "titanic/star_control/star_control.h"
 
 namespace Titanic {
 
@@ -113,12 +114,28 @@ bool CNavHelmet::PETPhotoOnOffMsg(CPETPhotoOnOffMsg *msg) {
 
 bool CNavHelmet::PETStarFieldLockMsg(CPETStarFieldLockMsg *msg) {
 	if (_helmetOn) {
-		if (msg->_value) {
-			playSound("a#6.wav");
-			starFn(LOCK_STAR);
-		} else {
-			playSound("a#5.wav");
-			starFn(UNLOCK_STAR);
+		CPetControl *pet = getPetControl();
+		CStarControl *starControl = 0;
+		bool isStarFieldMode=false;
+
+		if (pet)
+			starControl = pet->getStarControl();
+
+		if (starControl)
+			isStarFieldMode = starControl->isStarFieldMode();
+
+		if (isStarFieldMode) {
+			// locking and unlocking only in starfield
+			// It already does this without the conditional
+			// but now it will also not play the sounds in
+			// photoview
+			if (msg->_value) {
+				playSound("a#6.wav");
+				starFn(LOCK_STAR);
+			} else {
+				playSound("a#5.wav");
+				starFn(UNLOCK_STAR);
+			}
 		}
 	}
 

--- a/engines/titanic/game/nav_helmet.h
+++ b/engines/titanic/game/nav_helmet.h
@@ -38,10 +38,10 @@ class CNavHelmet : public CGameObject {
 	bool PETStarFieldLockMsg(CPETStarFieldLockMsg *msg);
 	bool PETSetStarDestinationMsg(CPETSetStarDestinationMsg *msg);
 private:
-	bool _flag;
+	bool _helmetOn;
 public:
 	CLASSDEF;
-	CNavHelmet() : CGameObject(), _flag(false) {}
+	CNavHelmet() : CGameObject(), _helmetOn(false) {}
 
 	/**
 	 * Save the data for the class to file

--- a/engines/titanic/star_control/star_control.cpp
+++ b/engines/titanic/star_control/star_control.cpp
@@ -145,6 +145,18 @@ void CStarControl::newFrame() {
 	}
 }
 
+bool CStarControl::isStarFieldMode() {
+	if (!_petControl)
+		_petControl = getPetControl();
+
+	if (_petControl) {
+
+		if (_starField.getMode() == MODE_STARFIELD)
+			return true;
+	}
+	return false;
+}
+
 void CStarControl::doAction(StarControlAction action) {
 	if (!_enabled)
 		return;

--- a/engines/titanic/star_control/star_control.h
+++ b/engines/titanic/star_control/star_control.h
@@ -70,6 +70,11 @@ public:
 	virtual void draw(CScreenManager *screenManager);
 
 	/**
+	 * _starField is currently showing the starfield
+	 */
+	bool isStarFieldMode();
+
+	/**
 	 * Does an action in the star control
 	 */
 	void doAction(StarControlAction action);


### PR DESCRIPTION
1. Better naming for flag of helmet being on or off
2. Only play locking/unlocking sounds in starview
3. After hitting go once on captain wheel it resets

Item 2 made more sense. Previously, it would play the locking and unlocking sounds when in skyview, but not actually do any unlocking/locking. This is a deviation from the original, but I think it makes more sense.

Item 3 makes it line up with the original and I think it makes more sense.