### PR TITLE
AGOS: Fix value truncation in AGOSEngine::animateSprites

### DIFF
--- a/engines/agos/draw.cpp
+++ b/engines/agos/draw.cpp
@@ -157,7 +157,7 @@ void AGOSEngine::animateSprites() {
 	}
 
 	if (getGameType() == GType_ELVIRA1 || getGameType() == GType_ELVIRA2) {
-		const uint8 var = (getGameType() == GType_ELVIRA1) ? 293 : 71;
+		const uint var = (getGameType() == GType_ELVIRA1) ? 293 : 71;
 		if (_wallOn && !_variableArray[var]) {
 			_wallOn--;
 


### PR DESCRIPTION
In commit f0581bab4a4b1b4102a7fbdd4a3d54d4397e00e9 the index value
for the array was changed from a constant to a variable, but uint8
is too small to contain 293, so this value was ending up as 37.