### PR TITLE
Corrected spelling in xeen/map.cpp

### DIFF
--- a/engines/xeen/map.cpp
+++ b/engines/xeen/map.cpp
@@ -952,7 +952,7 @@ void Map::load(int mapId) {
 				break;
 			default:
 				_animationInfo.load("dark.dat");
-				_monsterData.load("ddark.mon");
+				_monsterData.load("dark.mon");
 				_wallPicSprites.load("darkpic.dat");
 				break;
 			}


### PR DESCRIPTION
"ddark.mon" -> "dark.mon"