### PR TITLE
SCI: Set default MT-32 reverb before each sound (updated)

### DIFF
--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -480,7 +480,7 @@ int MidiPlayer_Midi::getVolume() {
 }
 
 void MidiPlayer_Midi::onNewSound() {
-	if (_version <= SCI_VERSION_0_LATE && _defaultReverb >= 0)
+	if (_defaultReverb >= 0)
 		// SCI0 in combination with MT-32 requires a reset of the reverb to
 		// the default value that is present in either the MT-32 patch data
 		// or MT32.DRV itself.

--- a/engines/sci/sound/drivers/mididriver.h
+++ b/engines/sci/sound/drivers/mididriver.h
@@ -106,11 +106,12 @@ public:
 		return _driver ? _driver->property(MIDI_PROP_MASTER_VOLUME, 0xffff) : 0;
 	}
 
+	virtual void onNewSound() { }
+
 	// Returns the current reverb, or -1 when no reverb is active
 	int8 getReverb() const { return _reverb; }
 	// Sets the current reverb, used mainly in MT-32
 	virtual void setReverb(int8 reverb) { _reverb = reverb; }
-	virtual void setDefaultReverb() { }
 
 	virtual void playSwitch(bool play) {
 		if (!play) {

--- a/engines/sci/sound/drivers/mididriver.h
+++ b/engines/sci/sound/drivers/mididriver.h
@@ -110,6 +110,7 @@ public:
 	int8 getReverb() const { return _reverb; }
 	// Sets the current reverb, used mainly in MT-32
 	virtual void setReverb(int8 reverb) { _reverb = reverb; }
+	virtual void setDefaultReverb() { }
 
 	virtual void playSwitch(bool play) {
 		if (!play) {

--- a/engines/sci/sound/midiparser_sci.cpp
+++ b/engines/sci/sound/midiparser_sci.cpp
@@ -419,6 +419,12 @@ void MidiParser_SCI::sendInitCommands() {
 			sendToDriver(0xE0 | i,    0, 64);	// Reset pitch wheel to center
 		}
 	}
+
+	// SCI0 in combination with MT-32 requires a reset of the reverb to
+	// the default value that is present in either the MT-32 patch data
+	// or MT32.DRV itself.
+	if (_soundVersion <= SCI_VERSION_0_LATE)
+		((MidiPlayer *)_driver)->setDefaultReverb();
 }
 
 void MidiParser_SCI::unloadMusic() {

--- a/engines/sci/sound/midiparser_sci.cpp
+++ b/engines/sci/sound/midiparser_sci.cpp
@@ -392,6 +392,8 @@ void MidiParser_SCI::sendInitCommands() {
 	// Set initial voice count
 	if (_pSnd) {
 		if (_soundVersion <= SCI_VERSION_0_LATE) {
+			((MidiPlayer *)_driver)->onNewSound();
+			
 			for (int i = 0; i < 15; ++i) {
 				byte voiceCount = 0;
 				if (_channelUsed[i]) {
@@ -419,8 +421,6 @@ void MidiParser_SCI::sendInitCommands() {
 			sendToDriver(0xE0 | i,    0, 64);	// Reset pitch wheel to center
 		}
 	}
-
-	((MidiPlayer *)_driver)->onNewSound();
 }
 
 void MidiParser_SCI::unloadMusic() {

--- a/engines/sci/sound/midiparser_sci.cpp
+++ b/engines/sci/sound/midiparser_sci.cpp
@@ -420,11 +420,7 @@ void MidiParser_SCI::sendInitCommands() {
 		}
 	}
 
-	// SCI0 in combination with MT-32 requires a reset of the reverb to
-	// the default value that is present in either the MT-32 patch data
-	// or MT32.DRV itself.
-	if (_soundVersion <= SCI_VERSION_0_LATE)
-		((MidiPlayer *)_driver)->setDefaultReverb();
+	((MidiPlayer *)_driver)->onNewSound();
 }
 
 void MidiParser_SCI::unloadMusic() {


### PR DESCRIPTION
Similar to #1022, this is a minimally updated version of #832 by @rklaver.

Again, I have not really been able to test it.

See the description of #832 for further information.