### PR TITLE
Clean up use of SearchMan in fallback detection

### DIFF
--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -159,12 +159,13 @@ const ADGameDescription *CGEMetaEngine::fallbackDetect(const FileMap &allFiles, 
 	if (!game)
 		return nullptr;
 
-	SearchMan.clear();
-	SearchMan.addDirectory(fslist.begin()->getParent().getPath(), fslist.begin()->getParent());
+	SearchMan.addDirectory("CGEMetaEngine::fallbackDetect", fslist.begin()->getParent());
 	ResourceManager *resman;
 	resman = new ResourceManager();
 	bool result = resman->exist("CGE.SAY");
 	delete resman;
+
+	SearchMan.remove("CGEMetaEngine::fallbackDetect");
 
 	if (!result)
 		return nullptr;

--- a/engines/cge2/detection.cpp
+++ b/engines/cge2/detection.cpp
@@ -157,12 +157,13 @@ const ADGameDescription *CGE2MetaEngine::fallbackDetect(const FileMap &allFiles,
 	if (!game)
 		return 0;
 
-	SearchMan.clear();
-	SearchMan.addDirectory(fslist.begin()->getParent().getPath(), fslist.begin()->getParent());
+	SearchMan.addDirectory("CGE2MetaEngine::fallbackDetect", fslist.begin()->getParent());
 	ResourceManager *resman;
 	resman = new ResourceManager();
 	bool result = resman->exist("CGE.SAY");
 	delete resman;
+
+	SearchMan.remove("CGE2MetaEngine::fallbackDetect");
 
 	if (!result)
 		return 0;

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -165,26 +165,20 @@ const ADGameDescription *DirectorMetaEngine::fallbackDetect(const FileMap &allFi
 		if (!fileName.hasSuffix(".exe"))
 			continue;
 
-		SearchMan.clear();
-		SearchMan.addDirectory(file->getParent().getName(), file->getParent());
-
-		Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember(file->getName());
-
-		if (!stream)
+		Common::File f;
+		if (!f.open(*file))
 			continue;
 
-		stream->seek(-4, SEEK_END);
+		f.seek(-4, SEEK_END);
 
-		uint32 offset = stream->readUint32LE();
+		uint32 offset = f.readUint32LE();
 
-		if (stream->eos() || offset == 0 || offset >= (uint32)(stream->size() - 4)) {
-			delete stream;
+		if (f.eos() || offset == 0 || offset >= (uint32)(f.size() - 4))
 			continue;
-		}
 
-		stream->seek(offset);
+		f.seek(offset);
 
-		uint32 tag = stream->readUint32LE();
+		uint32 tag = f.readUint32LE();
 
 		switch (tag) {
 		case MKTAG('3', '9', 'J', 'P'):
@@ -200,41 +194,31 @@ const ADGameDescription *DirectorMetaEngine::fallbackDetect(const FileMap &allFi
 			// Prior to version 4, there was no tag here. So we'll use a bit of a
 			// heuristic to detect. The first field is the entry count, of which
 			// there should only be one.
-			if ((tag & 0xFFFF) != 1) {
-				delete stream;
+			if ((tag & 0xFFFF) != 1)
 				continue;
-			}
 
-			stream->skip(3);
+			f.skip(3);
 
-			uint32 mmmSize = stream->readUint32LE();
+			uint32 mmmSize = f.readUint32LE();
 
-			if (stream->eos() || mmmSize == 0) {
-				delete stream;
+			if (f.eos() || mmmSize == 0)
 				continue;
-			}
 
-			byte fileNameSize = stream->readByte();
+			byte fileNameSize = f.readByte();
 
-			if (stream->eos()) {
-				delete stream;
+			if (f.eos())
 				continue;
-			}
 
-			stream->skip(fileNameSize);
-			byte directoryNameSize = stream->readByte();
+			f.skip(fileNameSize);
+			byte directoryNameSize = f.readByte();
 
-			if (stream->eos()) {
-				delete stream;
+			if (f.eos())
 				continue;
-			}
 
-			stream->skip(directoryNameSize);
+			f.skip(directoryNameSize);
 
-			if (stream->pos() != stream->size() - 4) {
-				delete stream;
+			if (f.pos() != f.size() - 4)
 				continue;
-			}
 
 			// Assume v3 at this point (for now at least)
 			desc->version = 3;

--- a/engines/sludge/detection.cpp
+++ b/engines/sludge/detection.cpp
@@ -122,26 +122,22 @@ const ADGameDescription *SludgeMetaEngine::fallbackDetect(const FileMap &allFile
 		if (!(fileName.hasSuffix(".slg") || fileName == "gamedata"))
 			continue;
 
-		SearchMan.clear();
-		SearchMan.addDirectory(file->getParent().getName(), file->getParent());
-
-		Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember(file->getName());
-
-		if (!stream)
+		Common::File f;
+		if (!f.open(*file))
 			continue;
 
 		bool headerBad = false;
-		if (stream->readByte() != 'S')
+		if (f.readByte() != 'S')
 			headerBad = true;
-		if (stream->readByte() != 'L')
+		if (f.readByte() != 'L')
 			headerBad = true;
-		if (stream->readByte() != 'U')
+		if (f.readByte() != 'U')
 			headerBad = true;
-		if (stream->readByte() != 'D')
+		if (f.readByte() != 'D')
 			headerBad = true;
-		if (stream->readByte() != 'G')
+		if (f.readByte() != 'G')
 			headerBad = true;
-		if (stream->readByte() != 'E')
+		if (f.readByte() != 'E')
 			headerBad = true;
 		if (headerBad) {
 			continue;


### PR DESCRIPTION
This makes the engines cge, cge2, sludge and directory leave `SearchMan` unchanged by their fallback detection. This fixes https://bugs.scummvm.org/ticket/10173 .