### PR TITLE
COMMON: Remove the DisposeAfterUse default value from dynamic write memory streams constructors

### DIFF
--- a/audio/decoders/quicktime.cpp
+++ b/audio/decoders/quicktime.cpp
@@ -344,7 +344,7 @@ bool QuickTimeAudioDecoder::QuickTimeAudioTrack::isOldDemuxing() const {
 
 AudioStream *QuickTimeAudioDecoder::QuickTimeAudioTrack::readAudioChunk(uint chunk) {
 	AudioSampleDesc *entry = (AudioSampleDesc *)_parentTrack->sampleDescs[0];
-	Common::MemoryWriteStreamDynamic *wStream = new Common::MemoryWriteStreamDynamic();
+	Common::MemoryWriteStreamDynamic *wStream = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::NO);
 
 	_decoder->_fd->seek(_parentTrack->chunkOffsets[chunk]);
 

--- a/audio/midiparser_qt.cpp
+++ b/audio/midiparser_qt.cpp
@@ -455,7 +455,7 @@ void MidiParser_QT::initCommon() {
 byte *MidiParser_QT::readWholeTrack(Common::QuickTimeParser::Track *track, uint32 &trackSize) {
 	// This just goes through all chunks and appends them together
 
-	Common::MemoryWriteStreamDynamic output;
+	Common::MemoryWriteStreamDynamic output(DisposeAfterUse::NO);
 	uint32 curSample = 0;
 
 	// Read in the note request data first

--- a/backends/networking/curl/networkreadstream.cpp
+++ b/backends/networking/curl/networkreadstream.cpp
@@ -29,35 +29,35 @@
 
 namespace Networking {
 
-static size_t curlDataCallback(char *d, size_t n, size_t l, void *p) {
+size_t NetworkReadStream::curlDataCallback(char *d, size_t n, size_t l, void *p) {
 	NetworkReadStream *stream = (NetworkReadStream *)p;
 	if (stream)
-		return stream->write(d, n * l);
+		return stream->_backingStream.write(d, n * l);
 	return 0;
 }
 
-static size_t curlReadDataCallback(char *d, size_t n, size_t l, void *p) {
+size_t NetworkReadStream::curlReadDataCallback(char *d, size_t n, size_t l, void *p) {
 	NetworkReadStream *stream = (NetworkReadStream *)p;
 	if (stream)
 		return stream->fillWithSendingContents(d, n * l);
 	return 0;
 }
 
-static size_t curlHeadersCallback(char *d, size_t n, size_t l, void *p) {
+size_t NetworkReadStream::curlHeadersCallback(char *d, size_t n, size_t l, void *p) {
 	NetworkReadStream *stream = (NetworkReadStream *)p;
 	if (stream)
 		return stream->addResponseHeaders(d, n * l);
 	return 0;
 }
 
-static int curlProgressCallback(void *p, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
+int NetworkReadStream::curlProgressCallback(void *p, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
 	NetworkReadStream *stream = (NetworkReadStream *)p;
 	if (stream)
 		stream->setProgress(dlnow, dltotal);
 	return 0;
 }
 
-static int curlProgressCallbackOlder(void *p, double dltotal, double dlnow, double ultotal, double ulnow) {
+int NetworkReadStream::curlProgressCallbackOlder(void *p, double dltotal, double dlnow, double ultotal, double ulnow) {
 	// for libcurl older than 7.32.0 (CURLOPT_PROGRESSFUNCTION)
 	return curlProgressCallback(p, (curl_off_t)dltotal, (curl_off_t)dlnow, (curl_off_t)ultotal, (curl_off_t)ulnow);
 }
@@ -178,15 +178,18 @@ void NetworkReadStream::init(const char *url, curl_slist *headersList, Common::H
 	ConnMan.registerEasyHandle(_easy);
 }
 
-NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, Common::String postFields, bool uploading, bool usingPatch) {
+NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, Common::String postFields, bool uploading, bool usingPatch) :
+		_backingStream(DisposeAfterUse::YES) {
 	init(url, headersList, (const byte *)postFields.c_str(), postFields.size(), uploading, usingPatch, false);
 }
 
-NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, Common::HashMap<Common::String, Common::String> formFields, Common::HashMap<Common::String, Common::String> formFiles) {
+NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, Common::HashMap<Common::String, Common::String> formFields, Common::HashMap<Common::String, Common::String> formFiles) :
+		_backingStream(DisposeAfterUse::YES) {
 	init(url, headersList, formFields, formFiles);
 }
 
-NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, const byte *buffer, uint32 bufferSize, bool uploading, bool usingPatch, bool post) {
+NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, const byte *buffer, uint32 bufferSize, bool uploading, bool usingPatch, bool post) :
+		_backingStream(DisposeAfterUse::YES) {
 	init(url, headersList, buffer, bufferSize, uploading, usingPatch, post);
 }
 
@@ -201,7 +204,7 @@ bool NetworkReadStream::eos() const {
 }
 
 uint32 NetworkReadStream::read(void *dataPtr, uint32 dataSize) {
-	uint32 actuallyRead = MemoryReadWriteStream::read(dataPtr, dataSize);
+	uint32 actuallyRead = _backingStream.read(dataPtr, dataSize);
 
 	if (actuallyRead == 0) {
 		if (_requestComplete)

--- a/common/memstream.h
+++ b/common/memstream.h
@@ -184,7 +184,7 @@ protected:
 		_size = new_len;
 	}
 public:
-	MemoryWriteStreamDynamic(DisposeAfterUse::Flag disposeMemory = DisposeAfterUse::NO) : _capacity(0), _size(0), _ptr(0), _data(0), _pos(0), _disposeMemory(disposeMemory) {}
+	explicit MemoryWriteStreamDynamic(DisposeAfterUse::Flag disposeMemory) : _capacity(0), _size(0), _ptr(0), _data(0), _pos(0), _disposeMemory(disposeMemory) {}
 
 	~MemoryWriteStreamDynamic() {
 		if (_disposeMemory)
@@ -247,7 +247,7 @@ private:
 		}
 	}
 public:
-	MemoryReadWriteStream(DisposeAfterUse::Flag disposeMemory = DisposeAfterUse::NO) : _capacity(0), _size(0), _data(0), _writePos(0), _readPos(0), _pos(0), _length(0), _disposeMemory(disposeMemory), _eos(false) {}
+	explicit MemoryReadWriteStream(DisposeAfterUse::Flag disposeMemory) : _capacity(0), _size(0), _data(0), _writePos(0), _readPos(0), _pos(0), _length(0), _disposeMemory(disposeMemory), _eos(false) {}
 
 	~MemoryReadWriteStream() {
 		if (_disposeMemory)

--- a/engines/agi/sound_midi.cpp
+++ b/engines/agi/sound_midi.cpp
@@ -169,7 +169,7 @@ static uint32 convertSND2MIDI(byte *snddata, byte **data) {
 	int n;
 	double ll;
 
-	Common::MemoryWriteStreamDynamic st;
+	Common::MemoryWriteStreamDynamic st(DisposeAfterUse::NO);
 
 	ll = log10(pow(2.0, 1.0 / 12.0));
 

--- a/engines/dm/eventman.cpp
+++ b/engines/dm/eventman.cpp
@@ -782,7 +782,7 @@ void EventManager::processCommandQueue() {
 			delete _vm->_saveThumbnail;
 			_vm->_saveThumbnail = nullptr;
 		} else if (!_vm->_saveThumbnail) {
-			_vm->_saveThumbnail = new Common::MemoryWriteStreamDynamic();
+			_vm->_saveThumbnail = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::YES);
 			Graphics::saveThumbnail(*_vm->_saveThumbnail);
 		}
 

--- a/engines/fullpipe/statesaver.cpp
+++ b/engines/fullpipe/statesaver.cpp
@@ -55,7 +55,7 @@ bool GameLoader::writeSavegame(Scene *sc, const char *fname) {
 	header.updateCounter = _updateCounter;
 	header.unkField = 1;
 
-	Common::MemoryWriteStreamDynamic stream;
+	Common::MemoryWriteStreamDynamic stream(DisposeAfterUse::YES);
 
 	MfcArchive *archive = new MfcArchive(&stream);
 

--- a/engines/gnap/menu.cpp
+++ b/engines/gnap/menu.cpp
@@ -211,7 +211,7 @@ void GnapEngine::runMenu() {
 	_menuDone = false;
 
 	delete _tempThumbnail;
-	_tempThumbnail = new Common::MemoryWriteStreamDynamic;
+	_tempThumbnail = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::YES);
 	Graphics::saveThumbnail(*_tempThumbnail);
 
 	createMenuSprite();

--- a/engines/pegasus/ai/ai_area.cpp
+++ b/engines/pegasus/ai/ai_area.cpp
@@ -78,7 +78,7 @@ void AIArea::saveAIState() {
 
 	delete vm->_aiSaveStream;
 
-	Common::MemoryWriteStreamDynamic out;
+	Common::MemoryWriteStreamDynamic out(DisposeAfterUse::NO);
 	writeAIRules(&out);
 
 	vm->_aiSaveStream = new Common::MemoryReadStream(out.getData(), out.size(), DisposeAfterUse::YES);

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -228,7 +228,7 @@ void ScummEngine_v4::prepareSavegame() {
 	_savePreparedSavegame = NULL;
 
 	// store headerless savegame in a compressed memory stream
-	memStream = new Common::MemoryWriteStreamDynamic();
+	memStream = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::NO);
 	writeStream = Common::wrapCompressedWriteStream(memStream);
 	if (saveState(writeStream, false)) {
 		// we have to finalize the compression-stream first, otherwise the internal

--- a/engines/sword1/control.cpp
+++ b/engines/sword1/control.cpp
@@ -303,7 +303,7 @@ static int volToBalance(int volL, int volR) {
 uint8 Control::runPanel() {
 	// Make a thumbnail of the screen before displaying the menu in case we want to save
 	// the game from the menu.
-	_tempThumbnail = new Common::MemoryWriteStreamDynamic;
+	_tempThumbnail = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::YES);
 	Graphics::saveThumbnail(*_tempThumbnail);
 
 	_panelShown = true;

--- a/engines/sword25/gfx/screenshot.cpp
+++ b/engines/sword25/gfx/screenshot.cpp
@@ -113,11 +113,11 @@ Common::SeekableReadStream *Screenshot::createThumbnail(Graphics::Surface *data)
 	}
 
 	// Create a PNG representation of the thumbnail data
-	Common::MemoryWriteStreamDynamic *stream = new Common::MemoryWriteStreamDynamic();
-	saveToFile(&thumbnail, stream);
+	Common::MemoryWriteStreamDynamic stream(DisposeAfterUse::NO);
+	saveToFile(&thumbnail, &stream);
 
 	// Output a MemoryReadStream that encompasses the written data
-	Common::SeekableReadStream *result = new Common::MemoryReadStream(stream->getData(), stream->size(),
+	Common::SeekableReadStream *result = new Common::MemoryReadStream(stream.getData(), stream.size(),
 		DisposeAfterUse::YES);
 	return result;
 }

--- a/engines/sword25/script/luascript.cpp
+++ b/engines/sword25/script/luascript.cpp
@@ -395,7 +395,7 @@ bool LuaScriptEngine::persist(OutputPersistenceBlock &writer) {
 	lua_getglobal(_state, "_G");
 
 	// Lua persists and stores the data in a WriteStream
-	Common::MemoryWriteStreamDynamic writeStream;
+	Common::MemoryWriteStreamDynamic writeStream(DisposeAfterUse::YES);
 	Lua::persistLua(_state, &writeStream);
 
 	// Persistenzdaten in den Writer schreiben.

--- a/engines/xeen/saves.cpp
+++ b/engines/xeen/saves.cpp
@@ -30,7 +30,17 @@
 namespace Xeen {
 
 OutFile::OutFile(XeenEngine *vm, const Common::String filename) :
-	_vm(vm), _filename(filename) {
+		_vm(vm),
+		_filename(filename),
+		_backingStream(DisposeAfterUse::YES) {
+}
+
+uint32 OutFile::write(const void *dataPtr, uint32 dataSize) {
+	return _backingStream.write(dataPtr, dataSize);
+}
+
+int32 OutFile::pos() const {
+	return _backingStream.pos();
 }
 
 void OutFile::finalize() {
@@ -40,7 +50,7 @@ void OutFile::finalize() {
 		_vm->_saves->_newData[id] = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::YES);
 
 	Common::MemoryWriteStreamDynamic *out = _vm->_saves->_newData[id];
-	out->write(getData(), size());
+	out->write(_backingStream.getData(), _backingStream.size());
 }
 
 /*------------------------------------------------------------------------*/

--- a/engines/xeen/saves.h
+++ b/engines/xeen/saves.h
@@ -60,7 +60,7 @@ private:
 	XeenEngine *_vm;
 	Party &_party;
 	byte *_data;
-	Common::HashMap<uint16, Common::MemoryWriteStreamDynamic > _newData;
+	Common::HashMap<uint16, Common::MemoryWriteStreamDynamic *> _newData;
 
 	void load(Common::SeekableReadStream *stream);
 public:

--- a/engines/xeen/saves.h
+++ b/engines/xeen/saves.h
@@ -44,14 +44,19 @@ struct XeenSavegameHeader {
 class XeenEngine;
 class SavesManager;
 
-class OutFile : public Common::MemoryWriteStreamDynamic {
+class OutFile : public Common::WriteStream {
 private:
 	XeenEngine *_vm;
 	Common::String _filename;
+	Common::MemoryWriteStreamDynamic _backingStream;
 public:
 	OutFile(XeenEngine *vm, const Common::String filename);
 
 	void finalize();
+
+	uint32 write(const void *dataPtr, uint32 dataSize) override;
+
+	int32 pos() const override;
 };
 
 class SavesManager: public BaseCCArchive {

--- a/engines/zvision/file/save_manager.cpp
+++ b/engines/zvision/file/save_manager.cpp
@@ -273,11 +273,11 @@ Common::SeekableReadStream *SaveManager::getSlotFile(uint slot) {
 
 void SaveManager::prepareSaveBuffer() {
 	delete _tempThumbnail;
-	_tempThumbnail = new Common::MemoryWriteStreamDynamic;
+	_tempThumbnail = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::YES);
 	Graphics::saveThumbnail(*_tempThumbnail);
 
 	delete _tempSave;
-	_tempSave = new Common::MemoryWriteStreamDynamic;
+	_tempSave = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::YES);
 	_engine->getScriptManager()->serialize(_tempSave);
 }
 


### PR DESCRIPTION
The default value was DisposeAfterUse::NO, which made it easy to accidentally leak memory by omitting to specify a value.

Also fix various memory leaks due to not setting DisposeAfterUse::YES when constructing dynamic memory streams.
Some non trivial changes were needed in the XEEN engine that @dreammaster may want to check.

I was intending to mark the `MemoryReadWriteStream` and `MemoryWriteStreamDynamic` classes as final because subclassing those seems like a bad idea to me (And they have a non-virtual destructor making it easy to leak memory in a creative way). However there are two remaining subclasses in LASTEXPRESS and SCI. Thoughts?