### PR TITLE
IMAGE: Fix memory leak in writePNG

### DIFF
--- a/image/png.cpp
+++ b/image/png.cpp
@@ -236,6 +236,7 @@ bool PNGDecoder::loadStream(Common::SeekableReadStream &stream) {
 	}
 
 	// Read additional data at the end.
+	// Can endInfo be used here?
 	png_read_end(pngPtr, NULL);
 
 	// Destroy libpng structures
@@ -285,11 +286,6 @@ bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const bo
 	png_infop infoPtr = png_create_info_struct(pngPtr);
 	if (!infoPtr) {
 		png_destroy_write_struct(&pngPtr, NULL);
-		return false;
-	}
-	png_infop endInfo = png_create_info_struct(pngPtr);
-	if (!endInfo) {
-		png_destroy_write_struct(&pngPtr, &infoPtr);
 		return false;
 	}
 


### PR DESCRIPTION
A 2nd pointer (endInfo) is being created for the png structure
(png_create_info_struct()) that is not used and not deleted
at the end of writePNG.

I have removed it entirely.

Unlike writePNG it is needed in PNGDecoder::loadStream as
a part of the destruction process:
png_destroy_read_struct(&pngPtr, &infoPtr, &endInfo);
Maybe it can be used in png_read_end of loadStream.

It is destroyed in loadStream so I have not touched it there.

Fixes Trac#10217.

I tested taking screenshots in riven and it worked fine with no mem leak.