### PR TITLE
COMMON: Add new standard methods to Array

### DIFF
--- a/common/array.h
+++ b/common/array.h
@@ -87,10 +87,10 @@ public:
 	 * Construct an array by copying data from a regular array.
 	 */
 	template<class T2>
-	Array(const T2 *data, size_type n) {
+	Array(const T2 *array, size_type n) {
 		_size = n;
 		allocCapacity(n);
-		uninitialized_copy(data, data + _size, _storage);
+		uninitialized_copy(array, array + _size, _storage);
 	}
 
 	~Array() {
@@ -121,6 +121,16 @@ public:
 		_size--;
 		// We also need to destroy the last object properly here.
 		_storage[_size].~T();
+	}
+
+	/** Returns a pointer to the underlying memory serving as element storage. */
+	const T *data() const {
+		return _storage;
+	}
+
+	/** Returns a pointer to the underlying memory serving as element storage. */
+	T *data() {
+		return _storage;
 	}
 
 	/** Returns a reference to the first element of the array. */

--- a/common/array.h
+++ b/common/array.h
@@ -59,6 +59,23 @@ protected:
 public:
 	Array() : _capacity(0), _size(0), _storage(0) {}
 
+	/**
+	 * Constructs an array with `count` default-inserted instances of T. No
+	 * copies are made.
+	 */
+	explicit Array(size_type count) : _size(0) {
+		allocCapacity(count);
+		resize(count);
+	}
+
+	/**
+	 * Constructs an array with `count` copies of elements with value `value`.
+	 */
+	Array(size_type count, const T &value) : _size(count) {
+		allocCapacity(count);
+		uninitialized_fill_n(_storage, count, value);
+	}
+
 	Array(const Array<T> &array) : _capacity(array._size), _size(array._size), _storage(0) {
 		if (array._storage) {
 			allocCapacity(_size);

--- a/common/memory.h
+++ b/common/memory.h
@@ -55,11 +55,11 @@ void uninitialized_fill(Type *first, Type *last, const Value &x) {
  * It requires the range [dst, dst + n) to be valid and
  * uninitialized.
  */
-/*template<class Type, class Value>
+template<class Type, class Value>
 void uninitialized_fill_n(Type *dst, size_t n, const Value &x) {
 	while (n--)
 		new ((void *)dst++) Type(x);
-}*/
+}
 
 } // End of namespace Common
 

--- a/test/common/array.h
+++ b/test/common/array.h
@@ -298,6 +298,49 @@ class ArrayTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(array2.size(), (unsigned int)3);
 	}
 
+	class Copyable {
+		bool _copied;
+		int _value;
+		Copyable &operator=(Copyable &);
+	public:
+		Copyable() : _copied(false), _value(1) {}
+		explicit Copyable(const int v) : _copied(false), _value(v) {}
+		Copyable(const Copyable &other) : _copied(true), _value(other._value) {}
+		bool copied() const { return _copied; }
+		int value() const { return _value; }
+	};
+
+	void test_array_constructor_count() {
+		Common::Array<int> array(10);
+		TS_ASSERT_EQUALS(array.size(), 10U);
+		TS_ASSERT_EQUALS(array[0], 0);
+		TS_ASSERT_EQUALS(array[9], 0);
+	}
+
+	void test_array_constructor_count_copy_value() {
+		Common::Array<int> trivial(5, 1);
+		TS_ASSERT_EQUALS(trivial.size(), 5U);
+		TS_ASSERT_EQUALS(trivial[0], 1);
+		TS_ASSERT_EQUALS(trivial[4], 1);
+
+		Copyable c(123);
+		typedef Common::Array<Copyable> NonTrivialArray;
+
+		NonTrivialArray nonTrivialCopy(3, c);
+		TS_ASSERT_EQUALS(nonTrivialCopy.size(), 3U);
+		for (NonTrivialArray::size_type i = 0; i < nonTrivialCopy.size(); ++i) {
+			TS_ASSERT_EQUALS(nonTrivialCopy[0].value(), 123);
+			TS_ASSERT(nonTrivialCopy[0].copied());
+		}
+
+		NonTrivialArray nonTrivialDefault(3);
+		TS_ASSERT_EQUALS(nonTrivialDefault.size(), 3U);
+		for (NonTrivialArray::size_type i = 0; i < nonTrivialDefault.size(); ++i) {
+			TS_ASSERT_EQUALS(nonTrivialDefault[0].value(), 1);
+			TS_ASSERT(!nonTrivialDefault[0].copied());
+		}
+	}
+
 	void test_array_constructor_str() {
 		const char *array1[] = { "a", "b", "c" };
 

--- a/test/common/array.h
+++ b/test/common/array.h
@@ -353,6 +353,15 @@ class ArrayTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(array2.size(), (unsigned int)3);
 	}
 
+	void test_data() {
+		Common::Array<int> array;
+		TS_ASSERT(array.data() == nullptr);
+		array.resize(2);
+		TS_ASSERT(array.data() != nullptr);
+		TS_ASSERT_EQUALS(array.data(), &array.front());
+		TS_ASSERT_EQUALS(array.data() + array.size() - 1, &array.back());
+	}
+
 	void test_front_back_push_pop() {
 		Common::Array<int> container;
 


### PR DESCRIPTION
This PR adds:

1. New [constructor signatures (2) and (3)](http://en.cppreference.com/w/cpp/container/vector/vector), for common constructions to create arrays of a specific size.
2. New [data method](http://en.cppreference.com/w/cpp/container/vector/data), for retrieving a pointer to the underlying storage of a Common::Array, even when the array is empty.

I don’t feel like these should be at all controversial since they are just imports from the C++ standard library, and there are tests, but let me know if there are any objections.