### PR TITLE
BUILD: Require 64bits integers

### DIFF
--- a/audio/decoders/qdm2.cpp
+++ b/audio/decoders/qdm2.cpp
@@ -233,11 +233,6 @@ private:
 	bool qdm2_decodeFrame(Common::SeekableReadStream &in, QueuingAudioStream *audioStream);
 };
 
-// Fix compilation for non C99-compliant compilers, like MSVC
-#ifndef int64_t
-typedef signed long long int int64_t;
-#endif
-
 #define QDM2_LIST_ADD(list, size, packet) \
 	do { \
 		if (size > 0) \
@@ -323,7 +318,7 @@ static inline uint16 round_sample(int *sum) {
 }
 
 static inline int MULH(int a, int b) {
-	return ((int64_t)(a) * (int64_t)(b))>>32;
+	return ((int64)(a) * (int64)(b))>>32;
 }
 
 // signed 16x16 -> 32 multiply add accumulate
@@ -894,9 +889,8 @@ void QDM2Stream::rndTableInit(void) {
 	uint16 i;
 	uint16 j;
 	uint32 ldw, hdw;
-	// TODO: Replace Code with uint64 less version...
-	int64_t tmp64_1;
-	int64_t random_seed = 0;
+	int64 tmp64_1;
+	int64 random_seed = 0;
 	float delta = 1.0 / 16384.0;
 
 	for(i = 0; i < ARRAYSIZE(_noiseTable); i++) {
@@ -912,7 +906,7 @@ void QDM2Stream::rndTableInit(void) {
 			ldw = (uint32)ldw % (uint32)random_seed;
 			tmp64_1 = (random_seed * 0x55555556);
 			hdw = (uint32)(tmp64_1 >> 32);
-			random_seed = (int64_t)(hdw + (ldw >> 31));
+			random_seed = (int64)(hdw + (ldw >> 31));
 		}
 	}
 
@@ -1490,8 +1484,7 @@ void QDM2Stream::fill_coding_method_array(sb_int8_array tone_level_idx, sb_int8_
 	int ch, sb, j;
 	int tmp, acc, esp_40, comp;
 	int add1, add2, add3, add4;
-	// TODO : Remove multres 64 bit variable necessity...
-	int64_t multres;
+	int64 multres;
 
 	// This should never happen
 	if (nb_channels <= 0)

--- a/common/endian.h
+++ b/common/endian.h
@@ -49,7 +49,6 @@
 #	error No endianness defined
 #endif
 
-#ifdef HAVE_INT64
 #define SWAP_CONSTANT_64(a) \
 	((uint64)((((a) >> 56) & 0x000000FF) | \
 	          (((a) >> 40) & 0x0000FF00) | \
@@ -59,7 +58,6 @@
 	          (((a) & 0x00FF0000) << 24) | \
 	          (((a) & 0x0000FF00) << 40) | \
 	          (((a) & 0x000000FF) << 56) ))
-#endif
 
 #define SWAP_CONSTANT_32(a) \
 	((uint32)((((a) >> 24) & 0x00FF) | \
@@ -150,7 +148,6 @@
 	}
 #endif
 
-#ifdef HAVE_INT64
 /**
  * Swap the bytes in a 64 bit word in order to convert LE encoded data to BE
  * and vice versa.
@@ -202,7 +199,6 @@
 	}
 #endif
 
-#endif // HAVE_INT64
 
 
 /**
@@ -253,7 +249,6 @@
 		((Unaligned32 *)ptr)->val = value;
 	}
 
-#ifdef HAVE_INT64
 	FORCEINLINE uint64 READ_UINT64(const void *ptr) {
 		struct Unaligned64 { uint64 val; } __attribute__ ((__packed__, __may_alias__));
 		return ((const Unaligned64 *)ptr)->val;
@@ -263,7 +258,6 @@
 		struct Unaligned64 { uint64 val; } __attribute__((__packed__, __may_alias__));
 		((Unaligned64 *)ptr)->val = value;
 	}
-#endif
 
 #elif !defined(SCUMM_NEED_ALIGNMENT)
 
@@ -283,7 +277,6 @@
 		*(uint32 *)(ptr) = value;
 	}
 
-#ifdef HAVE_INT64
 	FORCEINLINE uint64 READ_UINT64(const void *ptr) {
 		return *(const uint64 *)(ptr);
 	}
@@ -291,7 +284,6 @@
 	FORCEINLINE void WRITE_UINT64(void *ptr, uint64 value) {
 		*(uint64 *)(ptr) = value;
 	}
-#endif
 
 
 // use software fallback by loading each byte explicitely
@@ -319,7 +311,6 @@
 			b[2] = (uint8)(value >> 16);
 			b[3] = (uint8)(value >> 24);
 		}
-#ifdef HAVE_INT64
 		inline uint64 READ_UINT64(const void *ptr) {
 			const uint8 *b = (const uint8 *)ptr;
 			return ((uint64)b[7] << 56) | ((uint64)b[6] << 48) | ((uint64)b[5] << 40) | ((uint64)b[4] << 32) | ((uint64)b[3] << 24) | ((uint64)b[2] << 16) | ((uint64)b[1] << 8) | ((uint64)b[0]);
@@ -335,7 +326,6 @@
 			b[6] = (uint8)(value >> 48);
 			b[7] = (uint8)(value >> 56);
 		}
-#endif
 
 #	elif defined(SCUMM_BIG_ENDIAN)
 
@@ -359,7 +349,6 @@
 			b[2] = (uint8)(value >>  8);
 			b[3] = (uint8)(value >>  0);
 		}
-#ifdef HAVE_INT64
 		inline uint64 READ_UINT64(const void *ptr) {
 			const uint8 *b = (const uint8 *)ptr;
 			return ((uint64)b[0] << 56) | ((uint64)b[1] << 48) | ((uint64)b[2] << 40) | ((uint64)b[3] << 32) | ((uint64)b[4] << 24) | ((uint64)b[5] << 16) | ((uint64)b[6] << 8) | ((uint64)b[7]);
@@ -375,7 +364,6 @@
 			b[6] = (uint8)(value >>  8);
 			b[7] = (uint8)(value >>  0);
 		}
-#endif
 
 #	endif
 
@@ -409,7 +397,6 @@
 	#define CONSTANT_BE_32(a) SWAP_CONSTANT_32(a)
 	#define CONSTANT_BE_16(a) SWAP_CONSTANT_16(a)
 
-#ifdef HAVE_INT64
 	#define READ_LE_UINT64(a) READ_UINT64(a)
 	#define WRITE_LE_UINT64(a, v) WRITE_UINT64(a, v)
 	#define FROM_LE_64(a) ((uint64)(a))
@@ -418,7 +405,6 @@
 	#define TO_BE_64(a) SWAP_BYTES_64(a)
 	#define CONSTANT_LE_64(a) ((uint64)(a))
 	#define CONSTANT_BE_64(a) SWAP_CONSTANT_64(a)
-#endif
 
 // if the unaligned load and the byteswap take alot instructions its better to directly read and invert
 #	if defined(SCUMM_NEED_ALIGNMENT) && !defined(__mips__)
@@ -443,7 +429,6 @@
 			b[2] = (uint8)(value >>  8);
 			b[3] = (uint8)(value >>  0);
 		}
-#ifdef HAVE_INT64
 		inline uint64 READ_BE_UINT64(const void *ptr) {
 			const uint8 *b = (const uint8 *)ptr;
 			return ((uint64)b[0] << 56) | ((uint64)b[1] << 48) | ((uint64)b[2] << 40) | ((uint64)b[3] << 32) | ((uint64)b[4] << 24) | ((uint64)b[5] << 16) | ((uint64)b[6] << 8) | ((uint64)b[7]);
@@ -459,7 +444,6 @@
 			b[6] = (uint8)(value >> 8);
 			b[7] = (uint8)(value >> 0);
 		}
-#endif
 
 #	else
 
@@ -475,14 +459,12 @@
 		inline void WRITE_BE_UINT32(void *ptr, uint32 value) {
 			WRITE_UINT32(ptr, SWAP_BYTES_32(value));
 		}
-#ifdef HAVE_INT64
 		inline uint64 READ_BE_UINT64(const void *ptr) {
 			return SWAP_BYTES_64(READ_UINT64(ptr));
 		}
 		inline void WRITE_BE_UINT64(void *ptr, uint64 value) {
 			WRITE_UINT64(ptr, SWAP_BYTES_64(value));
 		}
-#endif
 
 #	endif	// if defined(SCUMM_NEED_ALIGNMENT)
 
@@ -512,7 +494,6 @@
 	#define CONSTANT_BE_32(a) ((uint32)(a))
 	#define CONSTANT_BE_16(a) ((uint16)(a))
 
-#ifdef HAVE_INT64
 	#define READ_BE_UINT64(a) READ_UINT64(a)
 	#define WRITE_BE_UINT64(a, v) WRITE_UINT64(a, v)
 	#define FROM_LE_64(a) SWAP_BYTES_64(a)
@@ -521,7 +502,6 @@
 	#define TO_BE_64(a) ((uint64)(a))
 	#define CONSTANT_LE_64(a) SWAP_CONSTANT_64(a)
 	#define CONSTANT_BE_64(a) ((uint64)(a))
-#endif
 
 // if the unaligned load and the byteswap take alot instructions its better to directly read and invert
 #	if defined(SCUMM_NEED_ALIGNMENT) && !defined(__mips__)
@@ -547,7 +527,6 @@
 		b[3] = (uint8)(value >> 24);
 	}
 
-#ifdef HAVE_INT64
 	inline uint64 READ_LE_UINT64(const void *ptr) {
 		const uint8 *b = (const uint8 *)ptr;
 		return ((uint64)b[7] << 56) | ((uint64)b[6] << 48) | ((uint64)b[5] << 40) | ((uint64)b[4] << 32) | ((uint64)b[3] << 24) | ((uint64)b[2] << 16) | ((uint64)b[1] << 8) | ((uint64)b[0]);
@@ -563,7 +542,6 @@
 		b[6] = (uint8)(value >> 48);
 		b[7] = (uint8)(value >> 56);
 	}
-#endif
 
 #	else
 
@@ -579,14 +557,12 @@
 	inline void WRITE_LE_UINT32(void *ptr, uint32 value) {
 		WRITE_UINT32(ptr, SWAP_BYTES_32(value));
 	}
-#ifdef HAVE_INT64
 	inline uint64 READ_LE_UINT64(const void *ptr) {
 		return SWAP_BYTES_64(READ_UINT64(ptr));
 	}
 	inline void WRITE_LE_UINT64(void *ptr, uint64 value) {
 		WRITE_UINT64(ptr, SWAP_BYTES_64(value));
 	}
-#endif
 
 #	endif	// if defined(SCUMM_NEED_ALIGNMENT)
 

--- a/common/hash-ptr.h
+++ b/common/hash-ptr.h
@@ -1,0 +1,43 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef COMMON_HASH_PTR_H
+#define COMMON_HASH_PTR_H
+
+#include "common/func.h"
+
+namespace Common {
+
+/**
+ * Partial specialization of the Hash functor to be able to use pointers as HashMap keys
+ */
+template<typename T>
+struct Hash<T *> {
+	uint operator()(T * const &v) const {
+		uint x = static_cast<uint>(reinterpret_cast<uintptr>(v));
+		return x + (x >> 3);
+	}
+};
+
+} // End of namespace Common
+
+#endif

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -454,11 +454,6 @@ typedef uint32 uintptr;
 
 #endif
 
-//
-// Overlay color type (FIXME: shouldn't be declared here)
-//
-typedef uint16 OverlayColor;
-
 #include "common/forbidden.h"
 
 #endif

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -310,26 +310,6 @@
 #endif
 
 //
-// Determine 64 bitness
-// Reference: http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros
-//
-#if !defined(HAVE_CONFIG_H)
-
-	#if defined(__x86_64__) || \
-		  defined(_M_X64) || \
-		  defined(__ppc64__) || \
-		  defined(__powerpc64__) || \
-		  defined(__LP64__)
-
-		#if !defined(SCUMM_64BITS)
-			#define SCUMM_64BITS
-		#endif
-
-	#endif
-
-#endif
-
-//
 // Some more system specific settings.
 // TODO/FIXME: All of these should be moved to backend specific files (such as portdefs.h)
 //
@@ -452,6 +432,27 @@
 	#endif
 #endif
 
+//
+// Determine 64 bitness
+// Reference: http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros
+//
+#if !defined(HAVE_CONFIG_H)
+
+#if defined(__x86_64__) || \
+		  defined(_M_X64) || \
+		  defined(__ppc64__) || \
+		  defined(__powerpc64__) || \
+		  defined(__LP64__)
+
+typedef uint64 uintptr;
+
+#else
+
+typedef uint32 uintptr;
+
+#endif
+
+#endif
 
 //
 // Overlay color type (FIXME: shouldn't be declared here)

--- a/common/stream.h
+++ b/common/stream.h
@@ -133,12 +133,10 @@ public:
 		write(&value, 4);
 	}
 
-#ifdef HAVE_INT64
 	void writeUint64LE(uint64 value) {
 		value = TO_LE_64(value);
 		write(&value, 8);
 	}
-#endif
 
 	void writeUint16BE(uint16 value) {
 		value = TO_BE_16(value);
@@ -150,12 +148,10 @@ public:
 		write(&value, 4);
 	}
 
-#ifdef HAVE_INT64
 	void writeUint64BE(uint64 value) {
 		value = TO_BE_64(value);
 		write(&value, 8);
 	}
-#endif
 
 	FORCEINLINE void writeSint16LE(int16 value) {
 		writeUint16LE((uint16)value);
@@ -165,11 +161,9 @@ public:
 		writeUint32LE((uint32)value);
 	}
 
-#ifdef HAVE_INT64
 	FORCEINLINE void writeSint64LE(int64 value) {
 		writeUint64LE((uint64)value);
 	}
-#endif
 
 	FORCEINLINE void writeSint16BE(int16 value) {
 		writeUint16BE((uint16)value);
@@ -179,11 +173,9 @@ public:
 		writeUint32BE((uint32)value);
 	}
 
-#ifdef HAVE_INT64
 	FORCEINLINE void writeSint64BE(int64 value) {
 		writeUint64BE((uint64)value);
 	}
-#endif
 
 
 	/**
@@ -301,7 +293,6 @@ public:
 		return FROM_LE_32(val);
 	}
 
-#ifdef HAVE_INT64
 	/**
 	 * Read an unsigned 64-bit word stored in little endian (LSB first) order
 	 * from the stream and return it.
@@ -314,7 +305,6 @@ public:
 		read(&val, 8);
 		return FROM_LE_64(val);
 	}
-#endif
 
 	/**
 	 * Read an unsigned 16-bit word stored in big endian (MSB first) order
@@ -342,7 +332,6 @@ public:
 		return FROM_BE_32(val);
 	}
 
-#ifdef HAVE_INT64
 	/**
 	 * Read an unsigned 64-bit word stored in big endian (MSB first) order
 	 * from the stream and return it.
@@ -355,7 +344,6 @@ public:
 		read(&val, 8);
 		return FROM_BE_64(val);
 	}
-#endif
 
 	/**
 	 * Read a signed 16-bit word stored in little endian (LSB first) order
@@ -379,7 +367,6 @@ public:
 		return (int32)readUint32LE();
 	}
 
-#ifdef HAVE_INT64
 	/**
 	 * Read a signed 64-bit word stored in little endian (LSB first) order
 	 * from the stream and return it.
@@ -390,7 +377,6 @@ public:
 	FORCEINLINE int64 readSint64LE() {
 		return (int64)readUint64LE();
 	}
-#endif
 
 	/**
 	 * Read a signed 16-bit word stored in big endian (MSB first) order
@@ -414,7 +400,6 @@ public:
 		return (int32)readUint32BE();
 	}
 
-#ifdef HAVE_INT64
 	/**
 	 * Read a signed 64-bit word stored in big endian (MSB first) order
 	 * from the stream and return it.
@@ -425,7 +410,6 @@ public:
 	FORCEINLINE int64 readSint64BE() {
 		return (int64)readUint64BE();
 	}
-#endif
 
 	/**
 	 * Read a 32-bit floating point value stored in little endian (LSB first)
@@ -600,13 +584,11 @@ public:
 		return (_bigEndian) ? TO_BE_32(val) : TO_LE_32(val);
 	}
 
-#ifdef HAVE_INT64
 	uint64 readUint64() {
 		uint64 val;
 		read(&val, 8);
 		return (_bigEndian) ? TO_BE_64(val) : TO_LE_64(val);
 	}
-#endif
 
 	FORCEINLINE int16 readSint16() {
 		return (int16)readUint16();
@@ -616,11 +598,9 @@ public:
 		return (int32)readUint32();
 	}
 
-#ifdef HAVE_INT64
 	FORCEINLINE int64 readSint64() {
 		return (int64)readUint64();
 	}
-#endif
 };
 
 /**

--- a/configure
+++ b/configure
@@ -2183,12 +2183,7 @@ echo_n "Type with 8 bytes... "
 type_8_byte=`find_type_with_size 8`
 TMPR="$?"
 echo "$type_8_byte"
-if test $TMPR -eq 0; then
-	_def_64bit_type_signed="typedef signed $type_8_byte int64;"
-	_def_64bit_type_unsigned="typedef unsigned $type_8_byte uint64;"
-fi
-# force cleanup after check for 8 bytes type
-cc_check_clean tmp_find_type_with_size.cpp
+test $TMPR -eq 0 || exit 1	# check exit code of subshell
 
 #
 # Check whether memory alignment is required
@@ -5187,29 +5182,17 @@ typedef unsigned int uint;
 typedef unsigned $type_1_byte uint8;
 typedef unsigned $type_2_byte uint16;
 typedef unsigned $type_4_byte uint32;
+typedef unsigned $type_8_byte uint64;
 typedef signed $type_1_byte int8;
 typedef signed $type_2_byte int16;
 typedef signed $type_4_byte int32;
-EOF
+typedef signed $type_8_byte int64;
 
-if test -n "$_def_64bit_type_unsigned"  ; then
-cat >> config.h << EOF
-
-/* 64-bit stuff */
-$_def_64bit_type_signed
 #if defined(__APPLE__) && !defined(__ppc__)
 #ifndef _UINT64
 #define _UINT64
-$_def_64bit_type_unsigned
 #endif
-#else
-$_def_64bit_type_unsigned
 #endif
-#define HAVE_INT64
-EOF
-fi
-
-cat >> config.h << EOF
 
 #endif /* CONFIG_H */
 EOF

--- a/configure
+++ b/configure
@@ -2149,13 +2149,11 @@ EOF
 echo_n "Checking 64-bitness... "
 pointer_is_32bit
 if test $? -eq 0; then
-	type_ptr=int32
+	type_ptr=uint32
 	echo "no"
-	add_line_to_config_h "/* #define SCUMM_64BITS */"
 else
-	type_ptr=int64
+	type_ptr=uint64
 	echo "yes"
-	add_line_to_config_h "#define SCUMM_64BITS"
 fi
 
 #
@@ -5187,6 +5185,8 @@ typedef signed $type_1_byte int8;
 typedef signed $type_2_byte int16;
 typedef signed $type_4_byte int32;
 typedef signed $type_8_byte int64;
+
+typedef $type_ptr  uintptr;
 
 #if defined(__APPLE__) && !defined(__ppc__)
 #ifndef _UINT64

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -242,10 +242,6 @@ void CMakeProvider::writeDefines(const BuildSetup &setup, std::ofstream &output)
 	output << "    add_definitions(-DPOSIX)\n";
 	output << "endif()\n";
 
-	output << "if (CMAKE_SIZEOF_VOID_P MATCHES 8)\n";
-	output << "    add_definitions(-DSCUMM_64BITS)\n";
-	output << "endif()\n";
-
 	output << "add_definitions(-DSDL_BACKEND)\n\n";
 }
 

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -158,7 +158,6 @@ void MSVCProvider::createGlobalProp(const BuildSetup &setup) {
 	// HACK: This definitely should not be here, but otherwise we would not define SDL_BACKEND for x64.
 	x64Defines.push_back("WIN32");
 	x64Defines.push_back("SDL_BACKEND");
-	x64Defines.push_back("SCUMM_64BITS");
 
 	outputGlobalPropFile(setup, properties, 64, x64Defines, convertPathToWin(setup.filePrefix), setup.runBuildEvents);
 }

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -92,12 +92,8 @@ struct Pointer_EqualTo {
 
 struct Pointer_Hash {
 	uint operator()(const void *x) const {
-#ifdef SCUMM_64BITS
-		uint64 v = (uint64)x;
-		return (v >> 32) ^ (v & 0xffffffff);
-#else
-		return (uint)x;
-#endif
+		uint x = static_cast<uint>(reinterpret_cast<uintptr>(v));
+		return x + (x >> 3);
 	}
 };
 

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -24,6 +24,7 @@
 #define DIRECTOR_LINGO_LINGO_H
 
 #include "audio/audiostream.h"
+#include "common/hash-ptr.h"
 #include "common/hash-str.h"
 
 #include "director/director.h"
@@ -86,18 +87,7 @@ struct FuncDesc {
 	FuncDesc(Common::String n, const char *p) { name = n; proto = p; }
 };
 
-struct Pointer_EqualTo {
-	bool operator()(const void *x, const void *y) const { return x == y; }
-};
-
-struct Pointer_Hash {
-	uint operator()(const void *x) const {
-		uint x = static_cast<uint>(reinterpret_cast<uintptr>(v));
-		return x + (x >> 3);
-	}
-};
-
-typedef Common::HashMap<void *, FuncDesc *, Pointer_Hash, Pointer_EqualTo> FuncHash;
+typedef Common::HashMap<void *, FuncDesc *> FuncHash;
 
 struct Symbol {	/* symbol table entry */
 	Common::String name;

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -23,6 +23,7 @@
 #ifndef FULLPIPE_UTILS_H
 #define FULLPIPE_UTILS_H
 
+#include "common/hash-ptr.h"
 #include "common/hash-str.h"
 #include "common/array.h"
 #include "common/file.h"
@@ -32,18 +33,7 @@ namespace Fullpipe {
 class CObject;
 class NGIArchive;
 
-struct Pointer_EqualTo {
-	bool operator()(const void *x, const void *y) const { return x == y; }
-};
-
-struct Pointer_Hash {
-	uint operator()(const void *x) const {
-		uint x = static_cast<uint>(reinterpret_cast<uintptr>(v));
-		return x + (x >> 3);
-	}
-};
-
-typedef Common::HashMap<void *, int, Pointer_Hash, Pointer_EqualTo> ObjHash;
+typedef Common::HashMap<void *, int> ObjHash;
 
 typedef Common::HashMap<Common::String, int, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> ClassMap;
 

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -38,12 +38,8 @@ struct Pointer_EqualTo {
 
 struct Pointer_Hash {
 	uint operator()(const void *x) const {
-#ifdef SCUMM_64BITS
-		uint64 v = (uint64)x;
-		return (v >> 32) ^ (v & 0xffffffff);
-#else
-		return (uint)x;
-#endif
+		uint x = static_cast<uint>(reinterpret_cast<uintptr>(v));
+		return x + (x >> 3);
 	}
 };
 


### PR DESCRIPTION
ScummVM has a `HAVE_INT64` define to check is the target platform supports 64 bits integers. However `uint64` is used without any checks in the main source code: https://github.com/scummvm/scummvm/blob/d75dab4e55f15133eaef3c25f616e04566427101/common/str.h#L166 

It has been that way for some time, including a release. This is proof enough to me that our target platforms support 64 bits integers, and that the `HAVE_INT64` check can be removed.

This pull request removes that check and makes 64 bits integers mandatory in `configure`. It goes a bit further along that path by replacing the `SCUMM_64BITS` define by a pointer sized integer, `uintptr`, bringing us closer to C99's `stdint.h`.

This pull request also adds a partial template specialization to `Hash` for pointers (Like C++11's std::hash http://en.cppreference.com/w/cpp/utility/hash). The actual pointer hash implementation comes from boost (http://www.boost.org/doc/libs/1_64_0/boost/functional/hash/hash.hpp).