### PR TITLE
MACOSX: Allow selecting device for CoreMidi

### DIFF
--- a/backends/midi/coreaudio.cpp
+++ b/backends/midi/coreaudio.cpp
@@ -308,7 +308,7 @@ void MidiDriver_CORE::sysEx(const byte *msg, uint16 length) {
 class CoreAudioMusicPlugin : public MusicPluginObject {
 public:
 	const char *getName() const {
-		return "CoreAudio";
+		return "Apple DLS Software Synthesizer";
 	}
 
 	const char *getId() const {
@@ -321,8 +321,6 @@ public:
 
 MusicDevices CoreAudioMusicPlugin::getDevices() const {
 	MusicDevices devices;
-	// TODO: Return a different music type depending on the configuration
-	// TODO: List the available devices
 	devices.push_back(MusicDevice(this, "", MT_GM));
 	return devices;
 }

--- a/backends/midi/coremidi.cpp
+++ b/backends/midi/coremidi.cpp
@@ -53,7 +53,7 @@ http://lists.apple.com/archives/coreaudio-api/2003/Jul/msg00137.html
  */
 class MidiDriver_CoreMIDI : public MidiDriver_MPU401 {
 public:
-	MidiDriver_CoreMIDI();
+	MidiDriver_CoreMIDI(ItemCount device);
 	~MidiDriver_CoreMIDI();
 	int open();
 	bool isOpen() const { return mOutPort != 0 && mDest != 0; }
@@ -62,13 +62,14 @@ public:
 	void sysEx(const byte *msg, uint16 length);
 
 private:
+	ItemCount mDevice;
 	MIDIClientRef	mClient;
 	MIDIPortRef		mOutPort;
 	MIDIEndpointRef	mDest;
 };
 
-MidiDriver_CoreMIDI::MidiDriver_CoreMIDI()
-	: mClient(0), mOutPort(0), mDest(0) {
+MidiDriver_CoreMIDI::MidiDriver_CoreMIDI(ItemCount device)
+	: mDevice(device), mClient(0), mOutPort(0), mDest(0) {
 
 	OSStatus err;
 	err = MIDIClientCreate(CFSTR("ScummVM MIDI Driver for OS X"), NULL, NULL, &mClient);
@@ -88,9 +89,9 @@ int MidiDriver_CoreMIDI::open() {
 
 	mOutPort = 0;
 
-	int dests = MIDIGetNumberOfDestinations();
-	if (dests > 0 && mClient) {
-		mDest = MIDIGetDestination(0);
+	ItemCount dests = MIDIGetNumberOfDestinations();
+	if (mDevice < dests && mClient) {
+		mDest = MIDIGetDestination(mDevice);
 		err = MIDIOutputPortCreate( mClient,
 									CFSTR("scummvm_output_port"),
 									&mOutPort);
@@ -195,20 +196,59 @@ public:
 
 	MusicDevices getDevices() const;
 	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const;
+
+private:
+	bool getDeviceName(ItemCount deviceIndex, Common::String &outName) const;
 };
 
 MusicDevices CoreMIDIMusicPlugin::getDevices() const {
+	// TODO: Is it possible to get the music type for each device?
+	// Maybe look at the kMIDIPropertyModel property?
+
 	MusicDevices devices;
-	// TODO: Return a different music type depending on the configuration
-	// TODO: List the available devices
-	devices.push_back(MusicDevice(this, "", MT_GM));
+	ItemCount deviceCount = MIDIGetNumberOfDestinations();
+	for (ItemCount i = 0 ; i < deviceCount ; ++i) {
+		Common::String name;
+		if (getDeviceName(i, name))
+			devices.push_back(MusicDevice(this, name, MT_GM));
+	}
 	return devices;
 }
 
-Common::Error CoreMIDIMusicPlugin::createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle) const {
-	*mididriver = new MidiDriver_CoreMIDI();
+Common::Error CoreMIDIMusicPlugin::createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle device) const {
+	ItemCount deviceCount = MIDIGetNumberOfDestinations();
+	for (ItemCount i = 0 ; i < deviceCount ; ++i) {
+		Common::String name;
+		if (getDeviceName(i, name)) {
+			MusicDevice md(this, name, MT_GM);
+			if (md.getHandle() == device) {
+				*mididriver = new MidiDriver_CoreMIDI(i);
+				return Common::kNoError;
+			}
+		}
+	}
 
-	return Common::kNoError;
+	return Common::kUnknownError;
+}
+
+bool CoreMIDIMusicPlugin::getDeviceName(ItemCount deviceIndex, Common::String &outName) const {
+	MIDIEndpointRef dest = MIDIGetDestination(deviceIndex);
+	if (!dest)
+		return false;
+	CFStringRef name = nil;
+	if (MIDIObjectGetStringProperty(dest, kMIDIPropertyDisplayName, &name) == noErr) {
+		char buffer[128];
+		if (CFStringGetCString(name, buffer, sizeof(buffer), kCFStringEncodingASCII)) {
+			outName = buffer;
+			CFRelease(name);
+			return true;
+		}
+		CFRelease(name);
+	}
+	// Rather than fail use a default name
+	warning("Failed to get name for CoreMIDi device %lu", deviceIndex);
+	outName = Common::String::format("Unknown Device %lu", deviceIndex);
+	return true;
 }
 
 //#if PLUGIN_ENABLED_DYNAMIC(COREMIDI)


### PR DESCRIPTION
After reading this [forum post](http://forums.scummvm.org/viewtopic.php?t=14422) I decided to take a look at the CoreMIDI API documentation, and since it seemed easy enough changed the code to try to list available devices so that the user can select which one to use.

I tried this with a software synthesiser and it seems to work correctly. However since I know absolutely nothing about MIDI and don't have any MIDI hardware I decided to open this pull request so that others can have a look, and hopefully try it, before this gets merged.