### PR TITLE
SDL: Minimal render rate support (force-frame-update)

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -192,6 +192,11 @@ protected:
 	 */
 	virtual void setInternalMousePosition(int x, int y) = 0;
 
+	/**
+	 * Whether the screen contents shall be forced to redrawn.
+	 */
+	bool _forceRedraw;
+
 private:
 	/**
 	 * Create a surface with the specified pixel format.
@@ -527,11 +532,6 @@ private:
 	//
 	// Misc
 	//
-
-	/**
-	 * Whether the screen contents shall be forced to redrawn.
-	 */
-	bool _forceRedraw;
 
 #ifdef USE_OSD
 	//

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -82,6 +82,7 @@ private:
 
 	void getWindowDimensions(int *width, int *height);
 
+	uint _forceFrameUpdate;
 	uint _lastRequestedWidth;
 	uint _lastRequestedHeight;
 	uint _graphicsScale;


### PR DESCRIPTION
Scummvm is optimised to render frames when something changes on screen b some host environments can perform poorly if the app does not reliably refresh its output regularly. For example, Steam overlay will get stuck if it is brought up when the scummvm menu is active. This also affects streaming via a Steam Link. Thus this new option ensures that Scummvm outputs a minimal amount of frames even if nothing is changing in the game renderer.

Currently this is only implemented in the SDL OpenGL renderer.

The new config option is called `force-frame-update` and it takes a integer value representing the desired minimum milliseconds Scummvm should wait before forcing a screen update/refresh. E.g: 50. I don't know if it is possible with Scummvm's config system but it might be good to support a value of _true_ (as well as integers) which would simply ensure a minimum sensible value so the user does not have to think of a good millisecond value.

Note that the rendering system will not force a re-draw of a frame if the app has rendered a changed frame within the desired minimum refresh. Thus if the app is outputting 30fps and force-frame-update is set to 100ms (~10fps) then no duplicate frame will be shown (in theory).

As this is implemented in `OpenGLSdlGraphicsManager::updateScreen()` `OpenGLGraphicsManager::_forceRedraw` has had its access changed to *protected* so that it can be accessed by it's descendant. The reason this has been done in OpenGLSdlGraphicsManager::updateScreen() is so `SDL_GetTicks()` can be used to track the elapsed time. If it is useful for other platforms using OpenGL to have this feature it could be implemented within OpenGLGraphicsManager::updateScreen() provided a suitable platform independent replacement for SDL_GetTicks() is used. This would potentially be better as OpenGLGraphicsManager checks various other states when deciding if the screen should update. If anyone could give some pointers on how I should track ticks in Scummvm that would be appreciated.

The tracking of rendering is done by storing a function static variable in updateScreen() that is updated whenever `_forceRedraw` is found to be _true_. This could be changed to a property of the object if that is preferred?