### PR TITLE
GUI: Rework formatting of the Updates Dialog

### DIFF
--- a/gui/updates-dialog.cpp
+++ b/gui/updates-dialog.cpp
@@ -52,7 +52,7 @@ UpdatesDialog::UpdatesDialog() : Dialog(30, 20, 260, 124) {
 		"which requires access to the Internet.\n"
   		"\n"
 		"Would you like to enable this feature?");
-	const char *message2 = _("(You can always enable it in the options dialog on the Misc tab)");
+	const char *message2 = _("You can always enable it in the options dialog on the Misc tab.");
 
 	// First, determine the size the dialog needs. For this we have to break
 	// down the string into lines, and taking the maximum of their widths.
@@ -60,7 +60,7 @@ UpdatesDialog::UpdatesDialog() : Dialog(30, 20, 260, 124) {
 	// the real size of the dialog
 	Common::Array<Common::String> lines, lines2;
 	int maxlineWidth = g_gui.getFont().wordWrapText(message, screenW - 2 * 20, lines);
-	int maxlineWidth2 = g_gui.getFont(ThemeEngine::kFontStyleTooltip).wordWrapText(message2, screenW - 2 * 20, lines2);
+	int maxlineWidth2 = g_gui.getFont().wordWrapText(message2, screenW - 2 * 20, lines2);
 
 	_w = MAX(MAX(maxlineWidth, maxlineWidth2), (2 * buttonWidth) + 10) + 20;
 
@@ -79,12 +79,12 @@ UpdatesDialog::UpdatesDialog() : Dialog(30, 20, 260, 124) {
 	uint y = 10;
 	for (uint i = 0; i < lines.size(); i++) {
 		new StaticTextWidget(this, 10, y, maxlineWidth, kLineHeight,
-								lines[i], Graphics::kTextAlignCenter);
+								lines[i], Graphics::kTextAlignLeft);
 		y += kLineHeight;
 	}
 	for (uint i = 0; i < lines2.size(); i++) {
 		new StaticTextWidget(this, 10, y, maxlineWidth2, kLineHeight,
-								lines2[i], Graphics::kTextAlignCenter, 0, ThemeEngine::kFontStyleTooltip);
+								lines2[i], Graphics::kTextAlignLeft);
 		y += kLineHeight;
 	}
 


### PR DESCRIPTION
Currently, the "Updates Dialog" that appears when ScummVM is run for the first time uses some text that has the tooltip attribute and is therefore shown in a smaller font.

In my opinion, it looks better if the fonts stay the same within the dialog. Additionally, I aligned everything to the left and removed the brackets around the "you can always..." message.

This is solely my own opinion. If you think it's good as it was before, feel free to discard this PR.

**Before**
![scummvm winsparkle tooltip](https://user-images.githubusercontent.com/11882577/31220846-f6050f8c-a9c1-11e7-887a-d16c28eb7520.PNG)

**After**
![scummvm winsparkle no tooltip leftalign](https://user-images.githubusercontent.com/11882577/31220858-0252f4f2-a9c2-11e7-99f7-4b7125d025b6.PNG)

In case this PR gets accepted, is it reasonable to merge the two messages into one?