### PR TITLE
ENGINES: Improve output of unknown game variant detection

### DIFF
--- a/common/str.cpp
+++ b/common/str.cpp
@@ -444,6 +444,44 @@ void String::trim() {
 	}
 }
 
+void String::wordWrap(const uint32 maxLength) {
+	if (_size < maxLength) {
+		return;
+	}
+
+	makeUnique();
+
+	enum { kNoSpace = 0xFFFFFFFF };
+
+	uint32 i = 0;
+	while (i < _size) {
+		uint32 lastSpace = kNoSpace;
+		uint32 x = 0;
+		while (i < _size && x <= maxLength) {
+			const char c = _str[i];
+			if (c == '\n') {
+				lastSpace = kNoSpace;
+				x = 0;
+			} else {
+				if (Common::isSpace(c)) {
+					lastSpace = i;
+				}
+				++x;
+			}
+			++i;
+		}
+
+		if (x > maxLength) {
+			if (lastSpace == kNoSpace) {
+				insertChar('\n', i - 1);
+			} else {
+				setChar('\n', lastSpace);
+				i = lastSpace + 1;
+			}
+		}
+	}
+}
+
 uint String::hash() const {
 	return hashit(c_str());
 }

--- a/common/str.h
+++ b/common/str.h
@@ -235,6 +235,17 @@ public:
 	 */
 	void trim();
 
+	/**
+	 * Wraps the text in the string to the given line maximum. Lines will be
+	 * broken at any whitespace character. New lines are assumed to be
+	 * represented using '\n'.
+	 *
+	 * This is a very basic line wrap which does not perform tab stop
+	 * calculation, consecutive whitespace collapsing, auto-hyphenation, or line
+	 * balancing.
+	 */
+	void wordWrap(const uint32 maxLength);
+
 	uint hash() const;
 
 	/**@{

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -466,6 +466,7 @@ ADGameDescList AdvancedMetaEngine::detectGame(const Common::FSNode &parent, cons
 
 		bool allFilesPresent = true;
 		int curFilesMatched = 0;
+		bool hashOrSizeMismatch = false;
 
 		// Try to match all files for this game
 		for (fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
@@ -477,16 +478,21 @@ ADGameDescList AdvancedMetaEngine::detectGame(const Common::FSNode &parent, cons
 				break;
 			}
 
+			if (hashOrSizeMismatch)
+				continue;
+
 			if (fileDesc->md5 != NULL && fileDesc->md5 != filesProps[tstr].md5) {
 				debug(3, "MD5 Mismatch. Skipping (%s) (%s)", fileDesc->md5, filesProps[tstr].md5.c_str());
 				fileMissing = true;
-				break;
+				hashOrSizeMismatch = true;
+				continue;
 			}
 
 			if (fileDesc->fileSize != -1 && fileDesc->fileSize != filesProps[tstr].size) {
 				debug(3, "Size Mismatch. Skipping");
 				fileMissing = true;
-				break;
+				hashOrSizeMismatch = true;
+				continue;
 			}
 
 			debug(3, "Matched file: %s", tstr.c_str());

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -117,6 +117,11 @@ struct ADGameDescription {
 typedef Common::Array<const ADGameDescription *> ADGameDescList;
 
 /**
+ * A list of raw game ID strings.
+ */
+typedef Common::Array<const char *> ADGameIdList;
+
+/**
  * End marker for a table of ADGameDescription structs. Use this to
  * terminate a list to be passed to the AdvancedDetector API.
  */
@@ -328,7 +333,7 @@ protected:
 	 * Log and print a report that we found an unknown game variant, together with the file
 	 * names, sizes and MD5 sums.
 	 */
-	void reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps) const;
+	void reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps, const ADGameIdList &matchedGameIds = ADGameIdList()) const;
 
 	// TODO
 	void updateGameDescriptor(GameDescriptor &desc, const ADGameDescription *realDesc) const;

--- a/engines/gob/detection/detection.cpp
+++ b/engines/gob/detection/detection.cpp
@@ -77,7 +77,10 @@ const ADGameDescription *GobMetaEngine::fallbackDetect(const FileMap &allFiles, 
 			return 0;
 	}
 
-	reportUnknown(fslist.begin()->getParent(), filesProps);
+	ADGameIdList gameIds;
+	gameIds.push_back(game->desc.gameId);
+
+	reportUnknown(fslist.begin()->getParent(), filesProps, gameIds);
 	return (const ADGameDescription *)game;
 }
 

--- a/test/common/str.h
+++ b/test/common/str.h
@@ -443,6 +443,28 @@ class StringTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_LESS_THAN(scumm_strnicmp("abCd", "ABCde", 5), 0);
 	}
 
+	void test_wordWrap() {
+		Common::String testString("123456");
+		testString.wordWrap(10);
+		TS_ASSERT(testString == "123456");
+		testString.wordWrap(2);
+		TS_ASSERT(testString == "12\n34\n56");
+		testString = "1234 5678";
+		testString.wordWrap(4);
+		TS_ASSERT(testString == "1234\n5678");
+		testString = "12 3 45";
+		testString.wordWrap(4);
+		TS_ASSERT(testString == "12 3\n45");
+		testString = "\n1\n23 45\n\n";
+		testString.wordWrap(3);
+		TS_ASSERT(testString == "\n1\n23\n45\n\n");
+		testString = "123 ";
+		testString.wordWrap(4);
+		TS_ASSERT(testString == "123 ");
+		testString.wordWrap(3);
+		TS_ASSERT(testString == "123\n");
+	}
+
 	void test_replace() {
 		// Tests created with the results of the STL std::string class
 


### PR DESCRIPTION
When a user tries to add a game expecting it to be a particular game for a
particular engine, but a detector from another engine happens to match some
files that exist in the game directory and reports on those files instead,
this can cause a lot of confusion because the detector doesn't say what
engine or game it thought it matched.

This PR makes the following changes:


1. Adds the name of the matching engine as well as any matching game IDs
   (if applicable) to the detector's logged output, and more specific guidance
   about where to send the detection information (to the bug tracker);
2. Wraps the first part of the report to 80 columns, taking into account the
   dynamic formatting of the string, instead of statically placing newlines
   in ways that doesn't actually work for wrapping dynamic content. To avoid
   anyone else needing to reimplement this kind of primitive word wrapping of
   monospaced text, this functionality was added to Common::String, though it
   could be moved to free function or just kept within the advanced detector if
   it is not desired for it to be part of Common::String;
3. Fixes a buggy-looking behaviour of the detector, where it stopped looking
   for missing files if a hash/size did not match even though there could be
   more missing files in the future. This was most evident when listing out the
   detected game IDs in SCI engine against a synthetic test directory
   containing non-matching files, where every game entry with a RESOURCE.MAP was
   getting matched even though other resource files for those games didn't exist
   in the test directory.

Refs Trac#10272.