### PR TITLE
SCUMM: Prevent false detection of Steam games

### DIFF
--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -660,6 +660,12 @@ static void detectGames(const Common::FSList &fslist, Common::List<DetectorResul
 		if (d.md5Entry)
 			continue;
 
+		// Prevent executables being detected as Steam variant. If we don't
+		// know the md5, then it's just the regular executable. Otherwise we
+		// will most likely fail on trying read the index from the executable.
+		// Fixes bug #10290
+		if (gfp->genMethod == kGenRoomNumSteam || gfp->genMethod == kGenDiskNumSteam)
+			continue;
 
 		//  ____            _     ____
 		// |  _ \ __ _ _ __| |_  |___ \ *


### PR DESCRIPTION
Ignore steam files of which we don't know the MD5. Currently this causes a [crash (assert)](https://bugs.scummvm.org/ticket/10290) on trying to read the (non-existing) index file from the executable. Unknown steam variants can't be handled anyway because we need to hardcode the offset to the game index file in ScummVM.