### PR TITLE
LURE: Stop taking address of unaligned pointer

### DIFF
--- a/engines/lure/res.cpp
+++ b/engines/lure/res.cpp
@@ -87,7 +87,7 @@ void Resources::freeData() {
 }
 
 struct AnimRecordTemp {
-	uint16 *offset;
+	uint16 offset;
 	MovementDataList *list;
 };
 
@@ -235,12 +235,12 @@ void Resources::reloadData() {
 
 		// Handle any direction frames
 		AnimRecordTemp dirEntries[4] = {
-			{&animRec->leftOffset, &newEntry->leftFrames},
-			{&animRec->rightOffset, &newEntry->rightFrames},
-			{&animRec->upOffset, &newEntry->upFrames},
-			{&animRec->downOffset, &newEntry->downFrames}};
+			{FROM_LE_16(animRec->leftOffset), &newEntry->leftFrames},
+			{FROM_LE_16(animRec->rightOffset), &newEntry->rightFrames},
+			{FROM_LE_16(animRec->upOffset), &newEntry->upFrames},
+			{FROM_LE_16(animRec->downOffset), &newEntry->downFrames}};
 		for (int dirCtr = 0; dirCtr < 4; ++dirCtr) {
-			offsetVal = READ_LE_UINT16(dirEntries[dirCtr].offset);
+			offsetVal = dirEntries[dirCtr].offset;
 			if (offsetVal != 0) {
 				MovementResource *moveRec = (MovementResource *)
 					(mb->data() + offsetVal);


### PR DESCRIPTION
While usage of these pointers was technically safe because they
were read through an alignment-aware API, taking the address of an
unaligned pointer was generating warnings in Clang, and is not
strictly necessary here. This change solves the warning and also
protects this code from any future change that might cause it to
start reading unsafely.

I think this change should be safe and not cause any trouble, but
I do not have this game so cannot test it myself to be sure. So
if someone else can either test it or look and make sure I did
not do something stupid, I would appreciate it.