### PR TITLE
BASE: Remove bad casts between incompatible Plugin types

### DIFF
--- a/audio/musicplugin.h
+++ b/audio/musicplugin.h
@@ -112,11 +112,6 @@ public:
 	virtual Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const = 0;
 };
 
-
-// Music plugins
-
-typedef PluginSubclass<MusicPluginObject> MusicPlugin;
-
 /**
  * Singleton class which manages all Music plugins.
  */
@@ -125,7 +120,7 @@ private:
 	friend class Common::Singleton<SingletonBaseType>;
 
 public:
-	const MusicPlugin::List &getPlugins() const;
+	const PluginList &getPlugins() const;
 };
 
 /** Convenience shortcut for accessing the Music manager. */

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -673,9 +673,9 @@ static void listGames() {
 	printf("Game ID              Full Title                                            \n"
 	       "-------------------- ------------------------------------------------------\n");
 
-	const EnginePlugin::List &plugins = EngineMan.getPlugins();
-	for (EnginePlugin::List::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
-		GameList list = (**iter)->getSupportedGames();
+	const PluginList &plugins = EngineMan.getPlugins();
+	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
+		GameList list = (*iter)->get<MetaEngine>().getSupportedGames();
 		for (GameList::iterator v = list.begin(); v != list.end(); ++v) {
 			printf("%-20s %s\n", v->gameid().c_str(), v->description().c_str());
 		}
@@ -741,7 +741,7 @@ static Common::Error listSaves(const char *target) {
 	gameid.toLowercase();	// Normalize it to lower case
 
 	// Find the plugin that will handle the specified gameid
-	const EnginePlugin *plugin = 0;
+	const Plugin *plugin = nullptr;
 	GameDescriptor game = EngineMan.findGame(gameid, &plugin);
 
 	if (!plugin) {
@@ -749,13 +749,15 @@ static Common::Error listSaves(const char *target) {
 						Common::String::format("target '%s', gameid '%s", target, gameid.c_str()));
 	}
 
-	if (!(*plugin)->hasFeature(MetaEngine::kSupportsListSaves)) {
+	const MetaEngine &metaEngine = plugin->get<MetaEngine>();
+
+	if (!metaEngine.hasFeature(MetaEngine::kSupportsListSaves)) {
 		// TODO: Include more info about the target (desc, engine name, ...) ???
 		return Common::Error(Common::kEnginePluginNotSupportSaves,
 						Common::String::format("target '%s', gameid '%s", target, gameid.c_str()));
 	} else {
 		// Query the plugin for a list of saved games
-		SaveStateList saveList = (*plugin)->listSaves(target);
+		SaveStateList saveList = metaEngine.listSaves(target);
 
 		if (saveList.size() > 0) {
 			// TODO: Include more info about the target (desc, engine name, ...) ???
@@ -793,13 +795,14 @@ static void listThemes() {
 
 /** Lists all output devices */
 static void listAudioDevices() {
-	MusicPlugin::List pluginList = MusicMan.getPlugins();
+	PluginList pluginList = MusicMan.getPlugins();
 
 	printf("ID                             Description\n");
 	printf("------------------------------ ------------------------------------------------\n");
 
-	for (MusicPlugin::List::const_iterator i = pluginList.begin(), iend = pluginList.end(); i != iend; ++i) {
-		MusicDevices deviceList = (**i)->getDevices();
+	for (PluginList::const_iterator i = pluginList.begin(), iend = pluginList.end(); i != iend; ++i) {
+		const MusicPluginObject &musicObject = (*i)->get<MusicPluginObject>();
+		MusicDevices deviceList = musicObject.getDevices();
 		for (MusicDevices::iterator j = deviceList.begin(), jend = deviceList.end(); j != jend; ++j) {
 			printf("%-30s %s\n", Common::String::format("\"%s\"", j->getCompleteId().c_str()).c_str(), j->getCompleteName().c_str());
 		}

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -106,8 +106,8 @@ static bool launcherDialog() {
 	return (dlg.runModal() != -1);
 }
 
-static const EnginePlugin *detectPlugin() {
-	const EnginePlugin *plugin = 0;
+static const Plugin *detectPlugin() {
+	const Plugin *plugin = nullptr;
 
 	// Make sure the gameid is set in the config manager, and that it is lowercase.
 	Common::String gameid(ConfMan.getActiveDomainName());
@@ -141,7 +141,7 @@ static const EnginePlugin *detectPlugin() {
 }
 
 // TODO: specify the possible return values here
-static Common::Error runGame(const EnginePlugin *plugin, OSystem &system, const Common::String &edebuglevels) {
+static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common::String &edebuglevels) {
 	// Determine the game data path, for validation and error messages
 	Common::FSNode dir(ConfMan.get("path"));
 	Common::Error err = Common::kNoError;
@@ -169,15 +169,16 @@ static Common::Error runGame(const EnginePlugin *plugin, OSystem &system, const 
 
 	// Create the game engine
 	if (err.getCode() == Common::kNoError) {
+		const MetaEngine &metaEngine = plugin->get<MetaEngine>();
 		// Set default values for all of the custom engine options
 		// Appareantly some engines query them in their constructor, thus we
 		// need to set this up before instance creation.
-		const ExtraGuiOptions engineOptions = (*plugin)->getExtraGuiOptions(Common::String());
+		const ExtraGuiOptions engineOptions = metaEngine.getExtraGuiOptions(Common::String());
 		for (uint i = 0; i < engineOptions.size(); i++) {
 			ConfMan.registerDefault(engineOptions[i].configOption, engineOptions[i].defaultState);
 		}
 
-		err = (*plugin)->createInstance(&system, &engine);
+		err = metaEngine.createInstance(&system, &engine);
 	}
 
 	// Check for errors
@@ -504,7 +505,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	// cleanly, so this is now enabled to encourage people to fix bits :)
 	while (0 != ConfMan.getActiveDomain()) {
 		// Try to find a plugin which feels responsible for the specified game.
-		const EnginePlugin *plugin = detectPlugin();
+		const Plugin *plugin = detectPlugin();
 		if (plugin) {
 			// Unload all plugins not needed for this game,
 			// to save memory

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -457,7 +457,7 @@ DECLARE_SINGLETON(EngineManager);
  * For the uncached version, we first try to find the plugin using the gameId
  * and only if we can't find it there, we loop through the plugins.
  **/
-GameDescriptor EngineManager::findGame(const Common::String &gameName, const EnginePlugin **plugin) const {
+GameDescriptor EngineManager::findGame(const Common::String &gameName, const Plugin **plugin) const {
 	GameDescriptor result;
 
 	// First look for the game using the plugins in memory. This is critical
@@ -493,18 +493,18 @@ GameDescriptor EngineManager::findGame(const Common::String &gameName, const Eng
 /**
  * Find the game within the plugins loaded in memory
  **/
-GameDescriptor EngineManager::findGameInLoadedPlugins(const Common::String &gameName, const EnginePlugin **plugin) const {
+GameDescriptor EngineManager::findGameInLoadedPlugins(const Common::String &gameName, const Plugin **plugin) const {
 	// Find the GameDescriptor for this target
-	const EnginePlugin::List &plugins = getPlugins();
+	const PluginList &plugins = getPlugins();
 	GameDescriptor result;
 
 	if (plugin)
 		*plugin = 0;
 
-	EnginePlugin::List::const_iterator iter;
+	PluginList::const_iterator iter;
 
 	for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
-		result = (**iter)->findGame(gameName.c_str());
+		result = (*iter)->get<MetaEngine>().findGame(gameName.c_str());
 		if (!result.gameid().empty()) {
 			if (plugin)
 				*plugin = *iter;
@@ -516,22 +516,22 @@ GameDescriptor EngineManager::findGameInLoadedPlugins(const Common::String &game
 
 GameList EngineManager::detectGames(const Common::FSList &fslist) const {
 	GameList candidates;
-	EnginePlugin::List plugins;
-	EnginePlugin::List::const_iterator iter;
+	PluginList plugins;
+	PluginList::const_iterator iter;
 	PluginManager::instance().loadFirstPlugin();
 	do {
 		plugins = getPlugins();
 		// Iterate over all known games and for each check if it might be
 		// the game in the presented directory.
 		for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
-			candidates.push_back((**iter)->detectGames(fslist));
+			candidates.push_back((*iter)->get<MetaEngine>().detectGames(fslist));
 		}
 	} while (PluginManager::instance().loadNextPlugin());
 	return candidates;
 }
 
-const EnginePlugin::List &EngineManager::getPlugins() const {
-	return (const EnginePlugin::List &)PluginManager::instance().getPlugins(PLUGIN_TYPE_ENGINE);
+const PluginList &EngineManager::getPlugins() const {
+	return PluginManager::instance().getPlugins(PLUGIN_TYPE_ENGINE);
 }
 
 
@@ -543,6 +543,6 @@ namespace Common {
 DECLARE_SINGLETON(MusicManager);
 }
 
-const MusicPlugin::List &MusicManager::getPlugins() const {
-	return (const MusicPlugin::List &)PluginManager::instance().getPlugins(PLUGIN_TYPE_MUSIC);
+const PluginList &MusicManager::getPlugins() const {
+	return PluginManager::instance().getPlugins(PLUGIN_TYPE_MUSIC);
 }

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -190,6 +190,15 @@ public:
 	PluginType getType() const;
 	const char *getName() const;
 
+	template <class T>
+	T &get() const {
+		T *pluginObject = dynamic_cast<T *>(_pluginObject);
+		if (!pluginObject) {
+			error("Invalid cast of plugin %s", getName());
+		}
+		return *pluginObject;
+	}
+
 	/**
 	 * The getFileName() function gets the name of the plugin file for those
 	 * plugins that have files (ie. not static). It doesn't require the plugin
@@ -200,25 +209,6 @@ public:
 
 /** List of Plugin instances. */
 typedef Common::Array<Plugin *> PluginList;
-
-/**
- * Convenience template to make it easier defining normal Plugin
- * subclasses. Namely, the PluginSubclass will manage PluginObjects
- * of a type specified via the PO_t template parameter.
- */
-template<class PO_t>
-class PluginSubclass : public Plugin {
-public:
-	PO_t &operator*() const {
-		return *(PO_t *)_pluginObject;
-	}
-
-	PO_t *operator->() const {
-		return (PO_t *)_pluginObject;
-	}
-
-	typedef Common::Array<PluginSubclass *> List;
-};
 
 /**
  * Abstract base class for Plugin factories. Subclasses of this

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -262,20 +262,15 @@ public:
 	//@}
 };
 
-
-// Engine plugins
-
-typedef PluginSubclass<MetaEngine> EnginePlugin;
-
 /**
  * Singleton class which manages all Engine plugins.
  */
 class EngineManager : public Common::Singleton<EngineManager> {
 public:
-	GameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const EnginePlugin **plugin = NULL) const;
-	GameDescriptor findGame(const Common::String &gameName, const EnginePlugin **plugin = NULL) const;
+	GameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const Plugin **plugin = NULL) const;
+	GameDescriptor findGame(const Common::String &gameName, const Plugin **plugin = NULL) const;
 	GameList detectGames(const Common::FSList &fslist) const;
-	const EnginePlugin::List &getPlugins() const;
+	const PluginList &getPlugins() const;
 };
 
 /** Convenience shortcut for accessing the engine manager. */

--- a/engines/neverhood/menumodule.cpp
+++ b/engines/neverhood/menumodule.cpp
@@ -870,7 +870,7 @@ void SavegameListBox::pageDown() {
 }
 
 int GameStateMenu::scummVMSaveLoadDialog(bool isSave, Common::String &saveDesc) {
-	const EnginePlugin *plugin = NULL;
+	const Plugin *plugin = nullptr;
 	EngineMan.findGame(ConfMan.get("gameid"), &plugin);
 	GUI::SaveLoadChooser *dialog;
 	Common::String desc;

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -356,7 +356,7 @@ Common::Error PegasusEngine::showLoadDialog() {
 
 	Common::String gameId = ConfMan.get("gameid");
 
-	const EnginePlugin *plugin = 0;
+	const Plugin *plugin = nullptr;
 	EngineMan.findGame(gameId, &plugin);
 
 	int slot = slc.runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
@@ -380,7 +380,7 @@ Common::Error PegasusEngine::showSaveDialog() {
 
 	Common::String gameId = ConfMan.get("gameid");
 
-	const EnginePlugin *plugin = 0;
+	const Plugin *plugin = nullptr;
 	EngineMan.findGame(gameId, &plugin);
 
 	int slot = slc.runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -598,8 +598,7 @@ void EventRecorder::setFileHeader() {
 		return;
 	}
 	TimeDate t;
-	const EnginePlugin *plugin = 0;
-	GameDescriptor desc = EngineMan.findGame(ConfMan.getActiveDomainName(), &plugin);
+	GameDescriptor desc = EngineMan.findGame(ConfMan.getActiveDomainName());
 	g_system->getTimeAndDate(t);
 	if (_author.empty()) {
 		setAuthor("Unknown Author");
@@ -619,19 +618,19 @@ SDL_Surface *EventRecorder::getSurface(int width, int height) {
 
 bool EventRecorder::switchMode() {
 	const Common::String gameId = ConfMan.get("gameid");
-	const EnginePlugin *plugin = 0;
+	const Plugin *plugin = nullptr;
 	EngineMan.findGame(gameId, &plugin);
-	bool metaInfoSupport = (*plugin)->hasFeature(MetaEngine::kSavesSupportMetaInfo);
+	bool metaInfoSupport = plugin->get<MetaEngine>().hasFeature(MetaEngine::kSavesSupportMetaInfo);
 	bool featuresSupport = metaInfoSupport &&
 						  g_engine->canSaveGameStateCurrently() &&
-						  (*plugin)->hasFeature(MetaEngine::kSupportsListSaves) &&
-						  (*plugin)->hasFeature(MetaEngine::kSupportsDeleteSave);
+						  plugin->get<MetaEngine>().hasFeature(MetaEngine::kSupportsListSaves) &&
+						  plugin->get<MetaEngine>().hasFeature(MetaEngine::kSupportsDeleteSave);
 	if (!featuresSupport) {
 		return false;
 	}
 
 	int emptySlot = 1;
-	SaveStateList saveList = (*plugin)->listSaves(gameId.c_str());
+	SaveStateList saveList = plugin->get<MetaEngine>().listSaves(gameId.c_str());
 	for (SaveStateList::const_iterator x = saveList.begin(); x != saveList.end(); ++x) {
 		int saveSlot = x->getSaveSlot();
 		if (saveSlot == 0) {
@@ -667,9 +666,9 @@ bool EventRecorder::checkForContinueGame() {
 void EventRecorder::deleteTemporarySave() {
 	if (_temporarySlot == -1) return;
 	const Common::String gameId = ConfMan.get("gameid");
-	const EnginePlugin *plugin = 0;
+	const Plugin *plugin = 0;
 	EngineMan.findGame(gameId, &plugin);
-	 (*plugin)->removeSaveState(gameId.c_str(), _temporarySlot);
+	 plugin->get<MetaEngine>().removeSaveState(gameId.c_str(), _temporarySlot);
 	_temporarySlot = -1;
 }
 

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -110,16 +110,16 @@ AboutDialog::AboutDialog()
 	engines += _("Available engines:");
 	addLine(engines.c_str());
 
-	const EnginePlugin::List &plugins = EngineMan.getPlugins();
-	EnginePlugin::List::const_iterator iter = plugins.begin();
+	const PluginList &plugins = EngineMan.getPlugins();
+	PluginList::const_iterator iter = plugins.begin();
 	for (; iter != plugins.end(); ++iter) {
 		Common::String str;
 		str = "C0";
-		str += (**iter).getName();
+		str += (*iter)->getName();
 		addLine(str.c_str());
 
 		str = "C2";
-		str += (**iter)->getOriginalCopyright();
+		str += (*iter)->get<MetaEngine>().getOriginalCopyright();
 		addLine(str.c_str());
 
 		//addLine("");

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -97,7 +97,7 @@ protected:
 EditGameDialog::EditGameDialog(const String &domain, const String &desc)
 	: OptionsDialog(domain, "GameOptions") {
 	// Retrieve all game specific options.
-	const EnginePlugin *plugin = 0;
+	const Plugin *plugin = nullptr;
 	// To allow for game domains without a gameid.
 	// TODO: Is it intentional that this is still supported?
 	String gameId(ConfMan.get("gameid", domain));
@@ -107,7 +107,7 @@ EditGameDialog::EditGameDialog(const String &domain, const String &desc)
 	// implementation.
 	EngineMan.findGame(gameId, &plugin);
 	if (plugin) {
-		_engineOptions = (*plugin)->getExtraGuiOptions(domain);
+		_engineOptions = plugin->get<MetaEngine>().getExtraGuiOptions(domain);
 	} else {
 		warning("Plugin for target \"%s\" not found! Game specific settings might be missing", domain.c_str());
 	}

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -504,7 +504,7 @@ void LauncherDialog::loadGame(int item) {
 	if (gameId.empty())
 		gameId = _domains[item];
 
-	const EnginePlugin *plugin = 0;
+	const Plugin *plugin = nullptr;
 
 	EngineMan.findGame(gameId, &plugin);
 
@@ -512,8 +512,9 @@ void LauncherDialog::loadGame(int item) {
 	target.toLowercase();
 
 	if (plugin) {
-		if ((*plugin)->hasFeature(MetaEngine::kSupportsListSaves) &&
-			(*plugin)->hasFeature(MetaEngine::kSupportsLoadingDuringStartup)) {
+		const MetaEngine &metaEngine = plugin->get<MetaEngine>();
+		if (metaEngine.hasFeature(MetaEngine::kSupportsListSaves) &&
+			metaEngine.hasFeature(MetaEngine::kSupportsLoadingDuringStartup)) {
 			int slot = _loadDialog->runModalWithPluginAndTarget(plugin, target);
 			if (slot >= 0) {
 				ConfMan.setActiveDomain(_domains[item]);

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -1040,9 +1040,9 @@ void OptionsDialog::addAudioControls(GuiObject *boss, const Common::String &pref
 	const Common::String allFlags = MidiDriver::musicType2GUIO((uint32)-1);
 	bool hasMidiDefined = (strpbrk(_guioptions.c_str(), allFlags.c_str()) != NULL);
 
-	const MusicPlugin::List p = MusicMan.getPlugins();
-	for (MusicPlugin::List::const_iterator m = p.begin(); m != p.end(); ++m) {
-		MusicDevices i = (**m)->getDevices();
+	const PluginList p = MusicMan.getPlugins();
+	for (PluginList::const_iterator m = p.begin(); m != p.end(); ++m) {
+		MusicDevices i = (*m)->get<MusicPluginObject>().getDevices();
 		for (MusicDevices::iterator d = i.begin(); d != i.end(); ++d) {
 			Common::String deviceGuiOption = MidiDriver::musicType2GUIO(d->getMusicType());
 
@@ -1078,19 +1078,19 @@ void OptionsDialog::addMIDIControls(GuiObject *boss, const Common::String &prefi
 	_gmDevicePopUp = new PopUpWidget(boss, prefix + "auPrefGmPopup");
 
 	// Populate
-	const MusicPlugin::List p = MusicMan.getPlugins();
+	const PluginList p = MusicMan.getPlugins();
 	// Make sure the null device is the first one in the list to avoid undesired
 	// auto detection for users who don't have a saved setting yet.
-	for (MusicPlugin::List::const_iterator m = p.begin(); m != p.end(); ++m) {
-		MusicDevices i = (**m)->getDevices();
+	for (PluginList::const_iterator m = p.begin(); m != p.end(); ++m) {
+		MusicDevices i = (*m)->get<MusicPluginObject>().getDevices();
 		for (MusicDevices::iterator d = i.begin(); d != i.end(); ++d) {
 			if (d->getMusicDriverId() == "null")
 				_gmDevicePopUp->appendEntry(_("Don't use General MIDI music"), d->getHandle());
 		}
 	}
 	// Now we add the other devices.
-	for (MusicPlugin::List::const_iterator m = p.begin(); m != p.end(); ++m) {
-		MusicDevices i = (**m)->getDevices();
+	for (PluginList::const_iterator m = p.begin(); m != p.end(); ++m) {
+		MusicDevices i = (*m)->get<MusicPluginObject>().getDevices();
 		for (MusicDevices::iterator d = i.begin(); d != i.end(); ++d) {
 			if (d->getMusicType() >= MT_GM) {
 				if (d->getMusicType() != MT_MT32)
@@ -1141,19 +1141,19 @@ void OptionsDialog::addMT32Controls(GuiObject *boss, const Common::String &prefi
 	// GS Extensions setting
 	_enableGSCheckbox = new CheckboxWidget(boss, prefix + "mcGSCheckbox", _("Roland GS Device (enable MT-32 mappings)"), _("Check if you want to enable patch mappings to emulate an MT-32 on a Roland GS device"));
 
-	const MusicPlugin::List p = MusicMan.getPlugins();
+	const PluginList p = MusicMan.getPlugins();
 	// Make sure the null device is the first one in the list to avoid undesired
 	// auto detection for users who don't have a saved setting yet.
-	for (MusicPlugin::List::const_iterator m = p.begin(); m != p.end(); ++m) {
-		MusicDevices i = (**m)->getDevices();
+	for (PluginList::const_iterator m = p.begin(); m != p.end(); ++m) {
+		MusicDevices i = (*m)->get<MusicPluginObject>().getDevices();
 		for (MusicDevices::iterator d = i.begin(); d != i.end(); ++d) {
 			if (d->getMusicDriverId() == "null")
 				_mt32DevicePopUp->appendEntry(_("Don't use Roland MT-32 music"), d->getHandle());
 		}
 	}
 	// Now we add the other devices.
-	for (MusicPlugin::List::const_iterator m = p.begin(); m != p.end(); ++m) {
-		MusicDevices i = (**m)->getDevices();
+	for (PluginList::const_iterator m = p.begin(); m != p.end(); ++m) {
+		MusicDevices i = (*m)->get<MusicPluginObject>().getDevices();
 		for (MusicDevices::iterator d = i.begin(); d != i.end(); ++d) {
 			if (d->getMusicType() >= MT_GM)
 				_mt32DevicePopUp->appendEntry(d->getCompleteName(), d->getHandle());
@@ -1265,10 +1265,10 @@ bool OptionsDialog::loadMusicDeviceSetting(PopUpWidget *popup, Common::String se
 
 	if (_domain != Common::ConfigManager::kApplicationDomain || ConfMan.hasKey(setting, _domain) || preferredType) {
 		const Common::String drv = ConfMan.get(setting, (_domain != Common::ConfigManager::kApplicationDomain && !ConfMan.hasKey(setting, _domain)) ? Common::ConfigManager::kApplicationDomain : _domain);
-		const MusicPlugin::List p = MusicMan.getPlugins();
+		const PluginList p = MusicMan.getPlugins();
 
-		for (MusicPlugin::List::const_iterator m = p.begin(); m != p.end(); ++m) {
-			MusicDevices i = (**m)->getDevices();
+		for (PluginList::const_iterator m = p.begin(); m != p.end(); ++m) {
+			MusicDevices i = (*m)->get<MusicPluginObject>().getDevices();
 			for (MusicDevices::iterator d = i.begin(); d != i.end(); ++d) {
 				if (setting.empty() ? (preferredType == d->getMusicType()) : (drv == d->getCompleteId())) {
 					popup->setSelectedTag(d->getHandle());
@@ -1285,10 +1285,10 @@ void OptionsDialog::saveMusicDeviceSetting(PopUpWidget *popup, Common::String se
 	if (!popup || !_enableAudioSettings)
 		return;
 
-	const MusicPlugin::List p = MusicMan.getPlugins();
+	const PluginList p = MusicMan.getPlugins();
 	bool found = false;
-	for (MusicPlugin::List::const_iterator m = p.begin(); m != p.end() && !found; ++m) {
-		MusicDevices i = (**m)->getDevices();
+	for (PluginList::const_iterator m = p.begin(); m != p.end() && !found; ++m) {
+		MusicDevices i = (*m)->get<MusicPluginObject>().getDevices();
 		for (MusicDevices::iterator d = i.begin(); d != i.end(); ++d) {
 			if (d->getHandle() == popup->getSelectedTag()) {
 				ConfMan.set(setting, d->getCompleteId(), _domain);

--- a/gui/recorderdialog.cpp
+++ b/gui/recorderdialog.cpp
@@ -167,8 +167,7 @@ void RecorderDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 	case kRecordCmd: {
 		TimeDate t;
 		Common::String gameId = ConfMan.get("gameid", _target);
-		const EnginePlugin *plugin = 0;
-		GameDescriptor desc = EngineMan.findGame(gameId, &plugin);
+		GameDescriptor desc = EngineMan.findGame(gameId);
 		g_system->getTimeAndDate(t);
 		EditRecordDialog editDlg(_("Unknown Author"), Common::String::format("%.2d.%.2d.%.4d ", t.tm_mday, t.tm_mon, 1900 + t.tm_year) + desc.description(), "");
 		if (editDlg.runModal() != kOKCmd) {

--- a/gui/saveload.cpp
+++ b/gui/saveload.cpp
@@ -76,14 +76,14 @@ Common::String SaveLoadChooser::createDefaultSaveDescription(const int slot) con
 int SaveLoadChooser::runModalWithCurrentTarget() {
 	const Common::String gameId = ConfMan.get("gameid");
 
-	const EnginePlugin *plugin = 0;
+	const Plugin *plugin = 0;
 	EngineMan.findGame(gameId, &plugin);
 
 	return runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
 }
 
-int SaveLoadChooser::runModalWithPluginAndTarget(const EnginePlugin *plugin, const String &target) {
-	selectChooser(**plugin);
+int SaveLoadChooser::runModalWithPluginAndTarget(const Plugin *plugin, const String &target) {
+	selectChooser(plugin->get<MetaEngine>());
 	if (!_impl)
 		return -1;
 
@@ -98,10 +98,10 @@ int SaveLoadChooser::runModalWithPluginAndTarget(const EnginePlugin *plugin, con
 
 	int ret;
 	do {
-		ret = _impl->run(target, &(**plugin));
+		ret = _impl->run(target, &plugin->get<MetaEngine>());
 #ifndef DISABLE_SAVELOADCHOOSER_GRID
 		if (ret == kSwitchSaveLoadDialog) {
-			selectChooser(**plugin);
+			selectChooser(plugin->get<MetaEngine>());
 		}
 #endif // !DISABLE_SAVELOADCHOOSER_GRID
 	} while (ret < -1);

--- a/gui/saveload.h
+++ b/gui/saveload.h
@@ -51,7 +51,7 @@ public:
 	 * @return The selcted save slot. -1 in case none is selected.
 	 */
 	int runModalWithCurrentTarget();
-	int runModalWithPluginAndTarget(const EnginePlugin *plugin, const String &target);
+	int runModalWithPluginAndTarget(const Plugin *plugin, const String &target);
 
 	const Common::String &getResultString() const;
 


### PR DESCRIPTION
Previously, a C-style cast was used to convert a
Common::Array<Plugin *>, populated with pointers to StaticPlugin
and DynamicPlugin instances, to a
Common::Array<PluginSubclass<T> *>, but PluginSubclass<T> is a
*sibling* class to StaticPlugin/DynamicPlugin, so this cast was
invalid and the results undefined. The methods for retrieving
subclasses of plugins can't be easily changed to just generate an
array of temporary wrapper objects that expose an identical API
which dereferences to the preferred PluginObject subclass because
pointers to these objects are retained by other parts of ScummVM,
so the wrappers would needed to be persisted or they would need to
just re-expose the underlying Plugin object again. This indicated
that a way to solve this problem is to have the callers receive
Plugin objects and get the PluginObject from the Plugin by
explicitly stating their desired type, in a similar manner to
std::get(std::variant), so that the pattern used by this patch to
solve the problem.

An alternative approach might be to do something like subclass
Common::Array to return appropriate objects, but this again seems
to run into the problem with needing some kind of extra wrapper,
more allocations, and additional changes to the callers to use the
wrapper correctly.

I am interested in learning if anyone else has some suggested
alternative approaches that would work better here.