### PR TITLE
COMMON: Add support for arrays & limited custom deleters to smart pointers

### DIFF
--- a/common/ptr.h
+++ b/common/ptr.h
@@ -26,6 +26,7 @@
 #include "common/scummsys.h"
 #include "common/noncopyable.h"
 #include "common/safe-bool.h"
+#include "common/type-traits.h"
 #include "common/types.h"
 
 namespace Common {
@@ -40,13 +41,20 @@ class SharedPtrDeletionImpl : public SharedPtrDeletionInternal {
 public:
 	SharedPtrDeletionImpl(T *ptr) : _ptr(ptr) {}
 	~SharedPtrDeletionImpl() {
-		// Checks if the supplied type is not just a plain
-		// forward definition, taken from boost::checked_delete
-		// This makes the user really aware what he tries to do
-		// when using this with an incomplete type.
-		typedef char completeCheck[sizeof(T) ? 1 : -1];
-		(void)sizeof(completeCheck);
+		STATIC_ASSERT(sizeof(T) > 0, SharedPtr_cannot_delete_incomplete_type);
 		delete _ptr;
+	}
+private:
+	T *_ptr;
+};
+
+template<class T>
+class SharedPtrDeletionImpl<T[]> : public SharedPtrDeletionInternal {
+public:
+	SharedPtrDeletionImpl(T ptr[]) : _ptr(ptr) {}
+	~SharedPtrDeletionImpl() {
+		STATIC_ASSERT(sizeof(T) > 0, SharedPtr_cannot_delete_incomplete_type);
+		delete[] _ptr;
 	}
 private:
 	T *_ptr;
@@ -110,14 +118,15 @@ class SharedPtr : public SafeBool<SharedPtr<T> > {
 #endif
 public:
 	typedef int RefValue;
-	typedef T ValueType;
-	typedef T *PointerType;
-	typedef T &ReferenceType;
+	typedef typename RemoveArray<T>::type ValueType;
+	typedef ValueType *PointerType;
+	typedef ValueType &ReferenceType;
 
-	SharedPtr() : _refCount(0), _deletion(0), _pointer(0) {}
+	SharedPtr() : _refCount(0), _deletion(nullptr), _pointer(nullptr) {}
 
 	template<class T2>
-	explicit SharedPtr(T2 *p) : _refCount(new RefValue(1)), _deletion(new SharedPtrDeletionImpl<T2>(p)), _pointer(p) {}
+	explicit SharedPtr(T2 *p) : _refCount(new RefValue(1)), _deletion(new SharedPtrDeletionImpl<T2>(p)), _pointer(p) {
+	}
 
 	template<class T2, class D>
 	SharedPtr(T2 *p, D d) : _refCount(new RefValue(1)), _deletion(new SharedPtrDeletionDeleterImpl<T2, D>(p, d)), _pointer(p) {}
@@ -153,8 +162,15 @@ public:
 		return *this;
 	}
 
-	ReferenceType operator*() const { assert(_pointer); return *_pointer; }
-	PointerType operator->() const { assert(_pointer); return _pointer; }
+	ReferenceType operator*() const {
+		assert(_pointer);
+		return *_pointer;
+	}
+
+	PointerType operator->() const {
+		assert(_pointer);
+		return _pointer;
+	}
 
 	/**
 	 * Returns the plain pointer value. Be sure you know what you
@@ -178,13 +194,13 @@ public:
 	bool unique() const { return refCount() == 1; }
 
 	/**
-	 * Resets the SharedPtr object to a NULL pointer.
+	 * Resets the SharedPtr object to a null pointer.
 	 */
 	void reset() {
 		decRef();
-		_deletion = 0;
-		_refCount = 0;
-		_pointer = 0;
+		_refCount = nullptr;
+		_deletion = nullptr;
+		_pointer = nullptr;
 	}
 
 	template<class T2>
@@ -211,9 +227,9 @@ private:
 			if (!*_refCount) {
 				delete _refCount;
 				delete _deletion;
-				_deletion = 0;
-				_refCount = 0;
-				_pointer = 0;
+				_refCount = nullptr;
+				_deletion = nullptr;
+				_pointer = nullptr;
 			}
 		}
 	}
@@ -223,17 +239,131 @@ private:
 	PointerType _pointer;
 };
 
-template<typename T>
-class ScopedPtr : private NonCopyable, public SafeBool<ScopedPtr<T> > {
+template<class T>
+class SharedPtr<T[]> : public SafeBool<SharedPtr<T[]> > {
+#if !defined(__GNUC__) || GCC_ATLEAST(3, 0)
+	template<class T2> friend class SharedPtr;
+#endif
+public:
+	typedef int RefValue;
+	typedef typename RemoveArray<T>::type ValueType;
+	typedef ValueType *PointerType;
+	typedef ValueType &ReferenceType;
+
+	SharedPtr() : _refCount(0), _deletion(nullptr), _pointer(nullptr) {}
+
+	template<class T2>
+	explicit SharedPtr(T2 p) : _refCount(new RefValue(1)), _deletion(new SharedPtrDeletionImpl<typename RemovePointer<T2>::type[]>(p)), _pointer(p) {
+	}
+
+	template<class T2, class D>
+	SharedPtr(T2 *p, D d) : _refCount(new RefValue(1)), _deletion(new SharedPtrDeletionDeleterImpl<T2, D>(p, d)), _pointer(p) {}
+
+	SharedPtr(const SharedPtr &r) : _refCount(r._refCount), _deletion(r._deletion), _pointer(r._pointer) { if (_refCount) ++(*_refCount); }
+	template<class T2>
+	SharedPtr(const SharedPtr<T2> &r) : _refCount(r._refCount), _deletion(r._deletion), _pointer(r._pointer) { if (_refCount) ++(*_refCount); }
+
+	~SharedPtr() { decRef(); }
+
+	SharedPtr &operator=(const SharedPtr &r) {
+		if (r._refCount)
+			++(*r._refCount);
+		decRef();
+
+		_refCount = r._refCount;
+		_deletion = r._deletion;
+		_pointer = r._pointer;
+
+		return *this;
+	}
+
+	template<class T2>
+	SharedPtr &operator=(const SharedPtr<T2> &r) {
+		if (r._refCount)
+			++(*r._refCount);
+		decRef();
+
+		_refCount = r._refCount;
+		_deletion = r._deletion;
+		_pointer = r._pointer;
+
+		return *this;
+	}
+
+	ReferenceType operator[](const int index) const { return _pointer[index]; }
+	PointerType get() const { return _pointer; }
+	bool operator_bool() const { return _pointer != nullptr; }
+	bool unique() const { return refCount() == 1; }
+	void reset() {
+		decRef();
+		_refCount = nullptr;
+		_deletion = nullptr;
+		_pointer = nullptr;
+	}
+
+	template<class T2>
+	bool operator==(const SharedPtr<T2> &r) const {
+		return _pointer == r.get();
+	}
+
+	template<class T2>
+	bool operator!=(const SharedPtr<T2> &r) const {
+		return _pointer != r.get();
+	}
+
+	RefValue refCount() const { return _refCount ? *_refCount : 0; }
+#if !defined(__GNUC__) || GCC_ATLEAST(3, 0)
+private:
+#endif
+	void decRef() {
+		if (_refCount) {
+			--(*_refCount);
+			if (!*_refCount) {
+				delete _refCount;
+				delete _deletion;
+				_refCount = nullptr;
+				_deletion = nullptr;
+				_pointer = nullptr;
+			}
+		}
+	}
+
+	RefValue *_refCount;
+	SharedPtrDeletionInternal *_deletion;
+	PointerType _pointer;
+};
+
+template <typename T>
+struct DefaultDeleter {
+	inline void operator()(T *object) {
+		STATIC_ASSERT(sizeof(T) > 0, cannot_delete_incomplete_type);
+		delete object;
+	}
+};
+template <typename T>
+struct DefaultDeleter<T[]> {
+	inline void operator()(T object[]) {
+		STATIC_ASSERT(sizeof(T) > 0, cannot_delete_incomplete_type);
+		delete[] object;
+	}
+};
+
+template<typename T, class D = DefaultDeleter<T> >
+class ScopedPtr : private NonCopyable, public SafeBool<ScopedPtr<T, D> > {
 public:
 	typedef T ValueType;
 	typedef T *PointerType;
 	typedef T &ReferenceType;
 
-	explicit ScopedPtr(PointerType o = 0) : _pointer(o) {}
+	explicit ScopedPtr(PointerType o = nullptr) : _pointer(o) {}
 
-	ReferenceType operator*() const { return *_pointer; }
-	PointerType operator->() const { return _pointer; }
+	ReferenceType operator*() const {
+		return *_pointer;
+	}
+
+	PointerType operator->() const {
+		return _pointer;
+	}
 
 	/**
 	 * Implicit conversion operator to bool for convenience, to make
@@ -242,14 +372,14 @@ public:
 	bool operator_bool() const { return _pointer != nullptr; }
 
 	~ScopedPtr() {
-		delete _pointer;
+		D()(_pointer);
 	}
 
 	/**
 	 * Resets the pointer with the new value. Old object will be destroyed
 	 */
-	void reset(PointerType o = 0) {
-		delete _pointer;
+	void reset(PointerType o = nullptr) {
+		D()(_pointer);
 		_pointer = o;
 	}
 
@@ -268,7 +398,7 @@ public:
 	 */
 	PointerType release() {
 		PointerType r = _pointer;
-		_pointer = 0;
+		_pointer = nullptr;
 		return r;
 	}
 
@@ -276,22 +406,55 @@ private:
 	PointerType _pointer;
 };
 
-
-template<typename T>
-class DisposablePtr : private NonCopyable, public SafeBool<DisposablePtr<T> > {
+// This code duplication only necessary because of C++98. C++11 allows default
+// arguments in function templates so can use SFINAE to remove specialised
+// member functions inside a single class definition.
+template<typename T, class D>
+class ScopedPtr<T[], D> : private NonCopyable, public SafeBool<ScopedPtr<T[], D> > {
 public:
-	typedef T  ValueType;
+	typedef T ValueType;
+	typedef T *PointerType;
+	typedef T &ReferenceType;
+
+	explicit ScopedPtr(PointerType o = nullptr) : _pointer(o) {}
+
+	ReferenceType operator[](const int index) const {
+		return _pointer[index];
+	}
+
+	bool operator_bool() const { return _pointer != nullptr; }
+	~ScopedPtr() { D()(_pointer); }
+	void reset(PointerType o = nullptr) { D()(_pointer); _pointer = o; }
+	PointerType get() const { return _pointer; }
+	PointerType release() {
+		PointerType r = _pointer;
+		_pointer = nullptr;
+		return r;
+	}
+private:
+	PointerType _pointer;
+};
+
+template<typename T, class D = DefaultDeleter<T> >
+class DisposablePtr : private NonCopyable, public SafeBool<DisposablePtr<T, D> > {
+public:
+	typedef T ValueType;
 	typedef T *PointerType;
 	typedef T &ReferenceType;
 
 	explicit DisposablePtr(PointerType o, DisposeAfterUse::Flag dispose) : _pointer(o), _dispose(dispose) {}
 
 	~DisposablePtr() {
-		if (_dispose) delete _pointer;
+		if (_dispose) D()(_pointer);
 	}
 
-	ReferenceType operator*() const { return *_pointer; }
-	PointerType operator->() const { return _pointer; }
+	ReferenceType operator*() const {
+		return *_pointer;
+	}
+
+	PointerType operator->() const {
+		return _pointer;
+	}
 
 	/**
 	 * Implicit conversion operator to bool for convenience, to make
@@ -304,6 +467,25 @@ public:
 	 *
 	 * @return the pointer the DisposablePtr manages
 	 */
+	PointerType get() const { return _pointer; }
+
+private:
+	PointerType           _pointer;
+	DisposeAfterUse::Flag _dispose;
+};
+
+template<typename T, class D>
+class DisposablePtr<T[], D> : private NonCopyable, public SafeBool<DisposablePtr<T[], D> > {
+public:
+	typedef T ValueType;
+	typedef T *PointerType;
+	typedef T &ReferenceType;
+
+	explicit DisposablePtr(PointerType o, DisposeAfterUse::Flag dispose) : _pointer(o), _dispose(dispose) {}
+
+	~DisposablePtr() { if (_dispose) D()(_pointer); }
+	ReferenceType operator[](const int index) const { return _pointer[index]; }
+	bool operator_bool() const { return _pointer != nullptr; }
 	PointerType get() const { return _pointer; }
 
 private:

--- a/common/type-traits.h
+++ b/common/type-traits.h
@@ -24,11 +24,39 @@
 #define COMMON_TYPE_TRAITS_H
 
 namespace Common {
-	template <bool b, class T, class U> struct Conditional { typedef T type; };
-	template <class T, class U> struct Conditional<false, T, U> { typedef U type; };
+	template <typename T, T v>
+	struct IntegralConstant {
+		typedef T value_type;
+		typedef IntegralConstant<T, v> type;
+		static const T value = v;
+	};
+
+	typedef IntegralConstant<bool, true> TrueType;
+	typedef IntegralConstant<bool, false> FalseType;
+
+	template <bool Condition, typename T = void> struct EnableIf {};
+	template <typename T> struct EnableIf<true, T> { typedef T type; };
+
+	template <bool Condition, typename T = void> struct DisableIf { typedef T type; };
+	template <typename T> struct DisableIf<true, T> {};
+
+	template <bool b, typename T, typename> struct Conditional { typedef T type; };
+	template <typename T, typename U> struct Conditional<false, T, U> { typedef U type; };
+
 	template <typename T> struct RemoveConst { typedef T type; };
 	template <typename T> struct RemoveConst<const T> { typedef T type; };
+
 	template <typename T> struct AddConst { typedef const T type; };
+
+	template <typename T> struct RemovePointer { typedef T type; };
+	template <typename T> struct RemovePointer<T *> { typedef T type; };
+
+	template <typename T> struct RemoveArray { typedef T type; };
+	template <typename T> struct RemoveArray<T []> { typedef T type; };
+
+	template <class> struct IsArray : FalseType {};
+	template <class T> struct IsArray<T []> : TrueType {};
+	template <class T> struct IsArray<T const []> : TrueType {};
 } // End of namespace Common
 
 #endif

--- a/test/common/ptr.h
+++ b/test/common/ptr.h
@@ -1,9 +1,18 @@
 #include <cxxtest/TestSuite.h>
+#include <typeinfo>
 
 #include "common/ptr.h"
 
 class PtrTestSuite : public CxxTest::TestSuite {
 	public:
+
+	struct A {
+		int a;
+	};
+
+	struct B : public A {
+		int b;
+	};
 
 	// A simple class which keeps track of all its instances
 	class InstanceCountingClass {
@@ -24,6 +33,91 @@ class PtrTestSuite : public CxxTest::TestSuite {
 			TS_ASSERT_EQUALS(InstanceCountingClass::count, 2);
 		}
 		TS_ASSERT_EQUALS(InstanceCountingClass::count, 0);
+	}
+
+	struct CustomDeleter {
+		static bool invoked;
+		void operator()(int *object) {
+			invoked = true;
+			delete object;
+		}
+	};
+
+	void test_scoped_deleter() {
+		CustomDeleter::invoked = false;
+
+		{
+			Common::ScopedPtr<int, CustomDeleter> a(new int(0));
+			TS_ASSERT(!CustomDeleter::invoked);
+		}
+
+		TS_ASSERT(CustomDeleter::invoked);
+	}
+
+	void test_disposable_deleter() {
+		CustomDeleter::invoked = false;
+
+		{
+			Common::DisposablePtr<int, CustomDeleter> a1(new int, DisposeAfterUse::YES);
+			TS_ASSERT(!CustomDeleter::invoked);
+		}
+
+		TS_ASSERT(CustomDeleter::invoked);
+		CustomDeleter::invoked = false;
+
+		int *a = new int;
+		{
+			Common::DisposablePtr<int, CustomDeleter> a2(a, DisposeAfterUse::NO);
+		}
+
+		TS_ASSERT(!CustomDeleter::invoked);
+		delete a;
+	}
+
+	void test_scoped_deref() {
+		A *raw = new A();
+		raw->a = 123;
+		Common::ScopedPtr<A> a(raw);
+		TS_ASSERT_EQUALS(&*a, &*raw);
+		TS_ASSERT_EQUALS(a->a, raw->a);
+	}
+
+	void test_disposable_deref() {
+		A *raw = new A();
+		raw->a = 123;
+		Common::DisposablePtr<A> a(raw, DisposeAfterUse::YES);
+		TS_ASSERT_EQUALS(&*a, &*raw);
+		TS_ASSERT_EQUALS(a->a, raw->a);
+	}
+
+	void test_scoped_array() {
+		Common::ScopedPtr<int[]> a(new int[10]);
+		Common::ScopedPtr<int[], Common::DefaultDeleter<int[]> > rightA(nullptr);
+		TS_ASSERT(typeid(a) == typeid(rightA));
+
+		a[0] = 123;
+		TS_ASSERT_EQUALS(a[0], 123);
+
+		Common::ScopedPtr<const int[]> b(new int[10]);
+		Common::ScopedPtr<const int[], Common::DefaultDeleter<const int[]> > rightB(nullptr);
+		TS_ASSERT(typeid(b) == typeid(rightB));
+
+		a[0] = 1234;
+	}
+
+	void test_disposable_array() {
+		Common::DisposablePtr<int[]> a(new int[10], DisposeAfterUse::YES);
+		Common::DisposablePtr<int[], Common::DefaultDeleter<int[]> > rightA(nullptr, DisposeAfterUse::YES);
+		TS_ASSERT(typeid(a) == typeid(rightA));
+
+		a[0] = 123;
+		TS_ASSERT_EQUALS(a[0], 123);
+
+		Common::DisposablePtr<const int[]> b(new int[10], DisposeAfterUse::YES);
+		Common::DisposablePtr<const int[], Common::DefaultDeleter<const int[]> > rightB(nullptr, DisposeAfterUse::YES);
+		TS_ASSERT(typeid(b) == typeid(rightB));
+
+		a[0] = 1234;
 	}
 
 	void test_assign() {
@@ -74,6 +168,14 @@ class PtrTestSuite : public CxxTest::TestSuite {
 		delete myDeleter.test;
 	}
 
+	void test_shared_array() {
+		Common::SharedPtr<int[]> p1(new int[10]);
+		Common::SharedPtr<int[]> p2 = p1;
+		p1[0] = 123;
+		TS_ASSERT_EQUALS(p1[0], 123);
+		TS_ASSERT_EQUALS(p2[0], 123);
+	}
+
 	void test_compare() {
 		Common::SharedPtr<int> p1(new int(1));
 		Common::SharedPtr<int> p2;
@@ -88,14 +190,6 @@ class PtrTestSuite : public CxxTest::TestSuite {
 		TS_ASSERT(!p1);
 	}
 
-	struct A {
-		int a;
-	};
-
-	struct B : public A {
-		int b;
-	};
-
 	void test_cast() {
 		Common::SharedPtr<B> b(new B);
 		Common::SharedPtr<A> a(b);
@@ -104,3 +198,4 @@ class PtrTestSuite : public CxxTest::TestSuite {
 };
 
 int PtrTestSuite::InstanceCountingClass::count = 0;
+bool PtrTestSuite::CustomDeleter::invoked = false;


### PR DESCRIPTION
This enables ScopedPtr to be used for all cases where raw pointers
are currently used to manage owned memory (assuming C malloc APIs
are replaced with C++ APIs), and brings ScopedPtr closer to
std::unique_ptr in terms of functionality. DisposablePtr also comes
along for the ride, for the moment.

Custom deleters of ScopedPtr are not currently fully conforming to
std::unique_ptr for the sake of simplicity of implementation.
Unlike in the standard library, plain functions and lvalue
references are not supported, nor may custom deleters be passed
to the constructor at runtime. This can be improved in the future,
if necessary, by creating a Pair class that uses the Empty Base
Optimization idiom to avoid extra storage overhead of the deleter
instance when it is not needed, as in typical standard library
implementations, plus some additional type traits to support the
necessary metaprogramming for the different type overloads.

Use of array types in SharedPtr also do not conform to C++17
std::shared_ptr, which checks for convertability between the
argument and an array type instead of having an explicit array
specialization. This should be an OK compromise for now, and
also might even be preferable (earlier C++ standards did not have
any explicit handling of array types in std::shared_ptr, so now
the C++ standard library needs to maintain backwards-compatibility
where we do not).

This patch unfortunately introduces some code duplication due to
the fact that C++98 does not allow default arguments in function
template parameters. Using C++11, there would be no code
duplication.