### PR TITLE
COMPOSER: Remove leading dots from file paths read from book.ini

### DIFF
--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -351,7 +351,7 @@ Common::String ComposerEngine::getFilename(const Common::String &section, uint i
 }
 
 Common::String ComposerEngine::mangleFilename(Common::String filename) {
-	while (filename.size() && (filename[0] == '~' || filename[0] == ':' || filename[0] == '\\'))
+	while (filename.size() && (filename[0] == '~' || filename[0] == ':' || filename[0] == '\\' || filename[0] == '.'))
 		filename = filename.c_str() + 1;
 
 	uint slashesToStrip = _directoriesToStrip;


### PR DESCRIPTION
book.ini in the French version of Gregory has file paths with this format: '../data/page99.rsc'.

According to the data structure described in bug #6548, removing the leading '../' should allow the engine to find the resource file where it is located, in the data folder.

I can't test this fix because I don't have the game. I would be glad if someone could test it or at least verify it does not break the other games.