### PR TITLE
NEVERHOOD: fix musical hut crash in DR, bug #7085

### DIFF
--- a/engines/neverhood/resourceman.cpp
+++ b/engines/neverhood/resourceman.cpp
@@ -104,7 +104,7 @@ static const EntrySizeFix entrySizeFixes[] = {
 	{ 0x008C0AC24,  1031009,   3030,   6498,   3646 },	// Overwrite dialog
 	{ 0x0c6604282, 12813649,  19623,  35894,  30370 },	// One of the fonts when reading Willie's notes
 	{ 0x080283101, 13104841,   1961,   3712,   3511 },	// First message from Willie
-	{ 0x058208810, 46010519,  24852, 131874, 131776 },  // Entry to hut with musical lock (untested)
+	{ 0x058208810, 46010519,  24852, 131874, 114762 },  // Entry to hut with musical lock
 	{ 0x000918480, 17676417,    581,    916,    706 },	// First wall in the museum
 	{ 0x00800090C, 16064875,  19555,  38518,  30263 },	// First wall in the museum
 	{ 0x00008E486, 39600019,    240,    454,    271 },  // Second wall in the museum


### PR DESCRIPTION
Patched size was wrong too.

[https://bugs.scummvm.org/ticket/7085](https://bugs.scummvm.org/ticket/7085)