### PR TITLE
RISCOS: Attempt to reduce binary size

### DIFF
--- a/configure
+++ b/configure
@@ -2738,7 +2738,10 @@ case $_host_os in
 		append_var CXXFLAGS "-march=armv3m"
 		append_var CXXFLAGS "-mtune=xscale"
 		append_var LDFLAGS "-static"
-		_optimization_level=-O3
+		_optimization_level=-O2
+		append_var CXXFLAGS "-ffunction-sections"
+		append_var CXXFLAGS "-fdata-sections"
+		append_var LDFLAGS "-Wl,--gc-sections"
 		_port_mk="backends/platform/sdl/riscos/riscos.mk"
 		;;
 	solaris*)


### PR DESCRIPTION
This allows more engines to be linked at once. While this isn't enough to link all engines, this does mean that all engines currently marked as stable can be enabled, so it'll do for now.
