### PR TITLE
COMMON: Add limited support for custom deleters to ScopedPtr

### DIFF
--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -39,7 +39,7 @@ void SaveStateDescriptor::setThumbnail(Graphics::Surface *t) {
 	if (_thumbnail.get() == t)
 		return;
 
-	_thumbnail = Common::SharedPtr<Graphics::Surface>(t, Graphics::SharedPtrSurfaceDeleter());
+	_thumbnail = Common::SharedPtr<Graphics::Surface>(t, Graphics::SurfaceDeleter());
 }
 
 void SaveStateDescriptor::setSaveDate(int year, int month, int day) {

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -334,7 +334,7 @@ public:
  *
  * This deleter assures Surface::free is called on deletion.
  */
-struct SharedPtrSurfaceDeleter {
+struct SurfaceDeleter {
 	void operator()(Surface *ptr) {
 		if (ptr) {
 			ptr->free();

--- a/test/common/ptr.h
+++ b/test/common/ptr.h
@@ -5,6 +5,14 @@
 class PtrTestSuite : public CxxTest::TestSuite {
 	public:
 
+	struct A {
+		int a;
+	};
+
+	struct B : public A {
+		int b;
+	};
+
 	// A simple class which keeps track of all its instances
 	class InstanceCountingClass {
 	public:
@@ -24,6 +32,61 @@ class PtrTestSuite : public CxxTest::TestSuite {
 			TS_ASSERT_EQUALS(InstanceCountingClass::count, 2);
 		}
 		TS_ASSERT_EQUALS(InstanceCountingClass::count, 0);
+	}
+
+	struct CustomDeleter {
+		static bool invoked;
+		void operator()(int *object) {
+			invoked = true;
+			delete object;
+		}
+	};
+
+	void test_scoped_deleter() {
+		CustomDeleter::invoked = false;
+
+		{
+			Common::ScopedPtr<int, CustomDeleter> a(new int(0));
+			TS_ASSERT(!CustomDeleter::invoked);
+		}
+
+		TS_ASSERT(CustomDeleter::invoked);
+	}
+
+	void test_disposable_deleter() {
+		CustomDeleter::invoked = false;
+
+		{
+			Common::DisposablePtr<int, CustomDeleter> a1(new int, DisposeAfterUse::YES);
+			TS_ASSERT(!CustomDeleter::invoked);
+		}
+
+		TS_ASSERT(CustomDeleter::invoked);
+		CustomDeleter::invoked = false;
+
+		int *a = new int;
+		{
+			Common::DisposablePtr<int, CustomDeleter> a2(a, DisposeAfterUse::NO);
+		}
+
+		TS_ASSERT(!CustomDeleter::invoked);
+		delete a;
+	}
+
+	void test_scoped_deref() {
+		A *raw = new A();
+		raw->a = 123;
+		Common::ScopedPtr<A> a(raw);
+		TS_ASSERT_EQUALS(&*a, &*raw);
+		TS_ASSERT_EQUALS(a->a, raw->a);
+	}
+
+	void test_disposable_deref() {
+		A *raw = new A();
+		raw->a = 123;
+		Common::DisposablePtr<A> a(raw, DisposeAfterUse::YES);
+		TS_ASSERT_EQUALS(&*a, &*raw);
+		TS_ASSERT_EQUALS(a->a, raw->a);
 	}
 
 	void test_assign() {
@@ -88,14 +151,6 @@ class PtrTestSuite : public CxxTest::TestSuite {
 		TS_ASSERT(!p1);
 	}
 
-	struct A {
-		int a;
-	};
-
-	struct B : public A {
-		int b;
-	};
-
 	void test_cast() {
 		Common::SharedPtr<B> b(new B);
 		Common::SharedPtr<A> a(b);
@@ -104,3 +159,4 @@ class PtrTestSuite : public CxxTest::TestSuite {
 };
 
 int PtrTestSuite::InstanceCountingClass::count = 0;
+bool PtrTestSuite::CustomDeleter::invoked = false;


### PR DESCRIPTION
Custom deleters of ScopedPtr in this PR are not fully conforming
to C++11's support for custom deleters in std::unique_ptr for the
sake of simplicity of implementation. Unlike in the standard
library, plain functions and lvalue references are not supported,
nor may custom deleters be passed to the constructor at runtime.
This can be improved in the future, if necessary, by doing what
standard library implementations usually do and creating a Pair
class that uses the Empty Base Optimization idiom to avoid extra
storage overhead of the deleter instance when it is not needed, as
in typical standard library implementations, plus some additional
type traits to support the necessary metaprogramming for the
different type overloads.

As it turns out, while my earlier comments about limited
applicability in C++98/03 are valid, there is at least one use
case where this still seems to make sense today, which is when a
temporary surface is created to convert video frames for rendering
if the system does not have the same pixel format as the video.
This seems to be at least somewhat common, and is a use case which
is well served by using ScopedPtr with the existing SurfaceDeleter
(renamed from SharedPtrSurfaceDeleter since it works with more than
just SharedPtr).

One other side-effect of this change is that ScopedPtr and
DisposablePtr can actually be tested since now a custom deleter can
be injected, so this PR also adds tests for those classes.