### PR TITLE
FULLPIPE: Fix various memory issues in Full Pipe

### DIFF
--- a/engines/fullpipe/anihandler.cpp
+++ b/engines/fullpipe/anihandler.cpp
@@ -61,12 +61,12 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 	int endidx = getStaticsIndexById(idx, staticsIndex);
 	int subidx = startidx + endidx * _items[idx]->statics.size();
 
-	if (!_items[idx]->subItems[subidx]->movement) {
+	if (!_items[idx]->subItems[subidx].movement) {
 		clearVisitsList(idx);
 		seekWay(idx, startidx, endidx, 0, 1);
 	}
 
-	if (!_items[idx]->subItems[subidx]->movement)
+	if (!_items[idx]->subItems[subidx].movement)
 		return 0;
 
 	MessageQueue *mq = new MessageQueue(g_fp->_globalMessageQueueList->compact());
@@ -77,21 +77,21 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 	do {
 		subidx = startidx + endidx * _items[idx]->statics.size();
 
-		point = _items[idx]->subItems[subidx]->movement->calcSomeXY(0, -1);
+		point = _items[idx]->subItems[subidx].movement->calcSomeXY(0, -1);
 
 		if (pointArr) {
 			int sz;
 
-			if (_items[idx]->subItems[subidx]->movement->_currMovement)
-				sz = _items[idx]->subItems[subidx]->movement->_currMovement->_dynamicPhases.size();
+			if (_items[idx]->subItems[subidx].movement->_currMovement)
+				sz = _items[idx]->subItems[subidx].movement->_currMovement->_dynamicPhases.size();
 			else
-				sz = _items[idx]->subItems[subidx]->movement->_dynamicPhases.size();
+				sz = _items[idx]->subItems[subidx].movement->_dynamicPhases.size();
 
 			ex = new ExCommand2(20, ani->_id, &pointArr[i], sz);
 
-			ex->_messageNum = _items[idx]->subItems[subidx]->movement->_id;
+			ex->_messageNum = _items[idx]->subItems[subidx].movement->_id;
 		} else {
-			ex = new ExCommand(ani->_id, 1, _items[idx]->subItems[subidx]->movement->_id, 0, 0, 0, 1, 0, 0, 0);
+			ex = new ExCommand(ani->_id, 1, _items[idx]->subItems[subidx].movement->_id, 0, 0, 0, 1, 0, 0, 0);
 		}
 
 		ex->_param = ani->_odelay;
@@ -101,16 +101,16 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 		mq->addExCommandToEnd(ex);
 
 		if (resStatId)
-			*resStatId = _items[idx]->subItems[subidx]->movement->_id;
+			*resStatId = _items[idx]->subItems[subidx].movement->_id;
 
-		startidx = _items[idx]->subItems[subidx]->staticsIndex;
+		startidx = _items[idx]->subItems[subidx].staticsIndex;
 
 		uint step;
 
-		if (_items[idx]->subItems[subidx]->movement->_currMovement)
-			step = _items[idx]->subItems[subidx]->movement->_currMovement->_dynamicPhases.size();
+		if (_items[idx]->subItems[subidx].movement->_currMovement)
+			step = _items[idx]->subItems[subidx].movement->_currMovement->_dynamicPhases.size();
 		else
-			step = _items[idx]->subItems[subidx]->movement->_dynamicPhases.size();
+			step = _items[idx]->subItems[subidx].movement->_dynamicPhases.size();
 
 		i += step;
 	} while (startidx != endidx);
@@ -166,7 +166,7 @@ void AniHandler::resetData(int objId) {
 		_items[idx]->statics.push_back((Statics *)obj->_staticsList[i]);
 
 		for (uint j = 0; j < obj->_staticsList.size(); j++) // Yes, square
-			_items[idx]->subItems.push_back(new MGMSubItem);
+			_items[idx]->subItems.push_back(MGMSubItem());
 	}
 
 	for (uint i = 0; i < obj->_movements.size(); i++) {
@@ -242,17 +242,17 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 	clearVisitsList(itemIdx);
 	seekWay(itemIdx, st1idx, subOffset, 0, 1);
 
-	MGMSubItem *sub1 = _items[itemIdx]->subItems[subIdx + st2idx * _items[itemIdx]->statics.size()];
-	MGMSubItem *sub2 = _items[itemIdx]->subItems[st1idx + subOffset * _items[itemIdx]->statics.size()];
+	const MGMSubItem &sub1 = _items[itemIdx]->subItems[subIdx + st2idx * _items[itemIdx]->statics.size()];
+	const MGMSubItem &sub2 = _items[itemIdx]->subItems[st1idx + subOffset * _items[itemIdx]->statics.size()];
 
-	if (subIdx != st2idx && !sub1->movement)
+	if (subIdx != st2idx && !sub1.movement)
 		return 0;
 
-	if (st1idx != subOffset && !sub2->movement)
+	if (st1idx != subOffset && !sub2.movement)
 		return 0;
 
-	int n1x = mkQueue->x1 - mkQueue->x2 - sub1->x - sub2->x;
-	int n1y = mkQueue->y1 - mkQueue->y2 - sub1->y - sub2->y;
+	int n1x = mkQueue->x1 - mkQueue->x2 - sub1.x - sub2.x;
+	int n1y = mkQueue->y1 - mkQueue->y2 - sub1.y - sub2.y;
 
 	const Common::Point point1 = mov->calcSomeXY(0, -1);
 
@@ -276,20 +276,20 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 		len = -1;
 		n2x = mult * point1.x;
 		n1x = mult * point1.x;
-		mkQueue->x1 = mkQueue->x2 + mult * point1.x + sub1->x + sub2->x;
+		mkQueue->x1 = mkQueue->x2 + mult * point1.x + sub1.x + sub2.x;
 	}
 
 	if (!(mkQueue->flags & 4)) {
 		n2y = mult * point1.y;
 		n1y = mult * point1.y;
 		len = -1;
-		mkQueue->y1 = mkQueue->y2 + mult * point1.y + sub1->y + sub2->y;
+		mkQueue->y1 = mkQueue->y2 + mult * point1.y + sub1.y + sub2.y;
 	}
 
 	int px = 0;
 	int py = 0;
 
-	if (sub1->movement) {
+	if (sub1.movement) {
 		px = getFramesCount(itemIdx, subIdx, st2idx, 1);
 		py = getFramesCount(itemIdx, subIdx, st2idx, 2);
 	}
@@ -304,7 +304,7 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 		py += mov->countPhasesWithFlag(len, 2);
 	}
 
-	if (sub2->movement) {
+	if (sub2.movement) {
 		px += getFramesCount(itemIdx, st1idx, subOffset, 1);
 		py += getFramesCount(itemIdx, st1idx, subOffset, 2);
 	}
@@ -344,15 +344,15 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 	ExCommand2 *ex2;
 
 	for (int i = subIdx; i != st2idx;) {
-		MGMSubItem *s = _items[itemIdx]->subItems[i + st2idx * _items[itemIdx]->statics.size()];
+		const MGMSubItem &s = _items[itemIdx]->subItems[i + st2idx * _items[itemIdx]->statics.size()];
 
-		ex2 = createCommand(s->movement, mkQueue->ani->_id, x1, y1, &x2, &y2, -1);
+		ex2 = createCommand(s.movement, mkQueue->ani->_id, x1, y1, &x2, &y2, -1);
 		ex2->_parId = mq->_id;
 		ex2->_param = mkQueue->ani->_odelay;
 
 		mq->addExCommandToEnd(ex2);
 
-		i = s->staticsIndex;
+		i = s.staticsIndex;
 	}
 
 	for (int i = 0; i < mult; ++i) {
@@ -371,15 +371,15 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 	}
 
 	for (int j = st1idx; j != subOffset;) {
-		MGMSubItem *s = _items[itemIdx]->subItems[j + subOffset * _items[itemIdx]->statics.size()];
+		const MGMSubItem &s = _items[itemIdx]->subItems[j + subOffset * _items[itemIdx]->statics.size()];
 
-		ex2 = createCommand(s->movement, mkQueue->ani->_id, x1, y1, &x2, &y2, -1);
+		ex2 = createCommand(s.movement, mkQueue->ani->_id, x1, y1, &x2, &y2, -1);
 		ex2->_parId = mq->_id;
 		ex2->_param = mkQueue->ani->_odelay;
 
 		mq->addExCommandToEnd(ex2);
 
-		j = s->staticsIndex;
+		j = s.staticsIndex;
 	}
 
 	ExCommand *ex = new ExCommand(mkQueue->ani->_id, 5, -1, mkQueue->x1, mkQueue->y1, 0, 1, 0, 0, 0);
@@ -406,9 +406,9 @@ int AniHandler::getFramesCount(int idx, int subIdx, int endIdx, int flag) {
 		if (subIdx < 0)
 			break;
 
-		res += _items[idx]->subItems[subIdx + endIdx * _items[idx]->statics.size()]->movement->countPhasesWithFlag(0xffffffff, flag);
+		res += _items[idx]->subItems[subIdx + endIdx * _items[idx]->statics.size()].movement->countPhasesWithFlag(0xffffffff, flag);
 
-		subIdx = _items[idx]->subItems[subIdx + endIdx * _items[idx]->statics.size()]->staticsIndex;
+		subIdx = _items[idx]->subItems[subIdx + endIdx * _items[idx]->statics.size()].staticsIndex;
 	}
 
 	return res;
@@ -459,23 +459,23 @@ Common::Point AniHandler::getTransitionSize(int objectId, int staticsId1, int st
 
 	int subidx = st1idx + st2idx * _items[idx]->statics.size();
 
-	if (!_items[idx]->subItems[subidx]->movement) {
+	if (!_items[idx]->subItems[subidx].movement) {
 		clearVisitsList(idx);
 		seekWay(idx, st1idx, st2idx, false, true);
 
-		if (!_items[idx]->subItems[subidx]->movement) {
+		if (!_items[idx]->subItems[subidx].movement) {
 			clearVisitsList(idx);
 			seekWay(idx, st1idx, st2idx, true, false);
 		}
 	}
 
-	const MGMSubItem *sub = _items[idx]->subItems[subidx];
+	const MGMSubItem &sub = _items[idx]->subItems[subidx];
 
-	if (!sub->movement) {
+	if (!sub.movement) {
 		return Common::Point(0, 0);
 	}
 
-	return Common::Point(sub->x, sub->y);
+	return Common::Point(sub.x, sub.y);
 }
 
 int AniHandler::getStaticsIndexById(int idx, int16 id) {
@@ -518,12 +518,12 @@ int AniHandler::seekWay(int idx, int st1idx, int st2idx, bool flip, bool flop) {
 	debugC(2, kDebugPathfinding, "AniHandler::seekWay(%d, %d, %d, %d, %d)", idx, st1idx, st2idx, flip, flop);
 
 	if (st1idx == st2idx) {
-		memset(item->subItems[subIdx], 0, sizeof(*(item->subItems[subIdx])));
+		memset(&item->subItems[subIdx], 0, sizeof(item->subItems[subIdx]));
 		return 0;
 	}
 
-	if (item->subItems[subIdx]->movement)
-		return item->subItems[subIdx]->field_8;
+	if (item->subItems[subIdx].movement)
+		return item->subItems[subIdx].field_8;
 
 	Common::Point point;
 
@@ -543,22 +543,22 @@ int AniHandler::seekWay(int idx, int st1idx, int st2idx, bool flip, bool flop) {
 			int sz = mov->_currMovement ? mov->_currMovement->_dynamicPhases.size() : mov->_dynamicPhases.size();
 			debugC(1, kDebugPathfinding, "AniHandler::seekWay, want idx: %d, off: %d (%d + %d), sz: %d", idx, stidx + st2idx * _items[idx]->statics.size(), stidx, st2idx, item->subItems.size());
 
-			int newsz = sz + item->subItems[stidx + st2idx * _items[idx]->statics.size()]->field_C;
+			int newsz = sz + item->subItems[stidx + st2idx * _items[idx]->statics.size()].field_C;
 
 			if (recalc < 0)
 				continue;
 
-			if (!item->subItems[subIdx]->movement || item->subItems[subIdx]->field_8 > recalc + 1 ||
-				(item->subItems[subIdx]->field_8 == recalc + 1 && item->subItems[subIdx]->field_C > newsz)) {
-				item->subItems[subIdx]->movement = mov;
-				item->subItems[subIdx]->staticsIndex = stidx;
-				item->subItems[subIdx]->field_8 = recalc + 1;
-				item->subItems[subIdx]->field_C = newsz;
+			if (!item->subItems[subIdx].movement || item->subItems[subIdx].field_8 > recalc + 1 ||
+				(item->subItems[subIdx].field_8 == recalc + 1 && item->subItems[subIdx].field_C > newsz)) {
+				item->subItems[subIdx].movement = mov;
+				item->subItems[subIdx].staticsIndex = stidx;
+				item->subItems[subIdx].field_8 = recalc + 1;
+				item->subItems[subIdx].field_C = newsz;
 
 				point = mov->calcSomeXY(0, -1);
 
-				item->subItems[subIdx]->x = item->subItems[stidx + st2idx * _items[idx]->statics.size()]->x + point.x;
-				item->subItems[subIdx]->y = item->subItems[stidx + st2idx * _items[idx]->statics.size()]->y + point.y;
+				item->subItems[subIdx].x = item->subItems[stidx + st2idx * _items[idx]->statics.size()].x + point.x;
+				item->subItems[subIdx].y = item->subItems[stidx + st2idx * _items[idx]->statics.size()].y + point.y;
 			}
 		} else if (flip) {
 			if (mov->_staticsObj2 != item->statics[st1idx])
@@ -575,25 +575,25 @@ int AniHandler::seekWay(int idx, int st1idx, int st2idx, bool flip, bool flop) {
 			if (recalc < 0)
 				continue;
 
-			if (!item->subItems[subIdx]->movement || item->subItems[subIdx]->field_8 > recalc + 1) {
-				item->subItems[subIdx]->movement = mov;
-				item->subItems[subIdx]->staticsIndex = stidx;
-				item->subItems[subIdx]->field_8 = recalc + 1;
+			if (!item->subItems[subIdx].movement || item->subItems[subIdx].field_8 > recalc + 1) {
+				item->subItems[subIdx].movement = mov;
+				item->subItems[subIdx].staticsIndex = stidx;
+				item->subItems[subIdx].field_8 = recalc + 1;
 
 				int sz = mov->_currMovement ? mov->_currMovement->_dynamicPhases.size() : mov->_dynamicPhases.size();
 
-				item->subItems[subIdx]->field_C = sz + item->subItems[stidx + st2idx * _items[idx]->statics.size()]->field_C;
+				item->subItems[subIdx].field_C = sz + item->subItems[stidx + st2idx * _items[idx]->statics.size()].field_C;
 
 				point = mov->calcSomeXY(0, -1);
 
-				item->subItems[subIdx]->x = item->subItems[stidx + st2idx * _items[idx]->statics.size()]->x - point.x;
-				item->subItems[subIdx]->y = item->subItems[stidx + st2idx * _items[idx]->statics.size()]->y - point.y;
+				item->subItems[subIdx].x = item->subItems[stidx + st2idx * _items[idx]->statics.size()].x - point.x;
+				item->subItems[subIdx].y = item->subItems[stidx + st2idx * _items[idx]->statics.size()].y - point.y;
 			}
 		}
 	}
 
-	if (item->subItems[subIdx]->movement)
-		return item->subItems[subIdx]->field_8;
+	if (item->subItems[subIdx].movement)
+		return item->subItems[subIdx].field_8;
 
 	return -1;
 }
@@ -608,10 +608,10 @@ int AniHandler::getNumMovements(int objectId, int idx1, int idx2) {
 		int to = getStaticsIndexById(idx, idx2);
 
 		debugC(1, kDebugPathfinding, "WWW 6, want idx: %d, off: %d", idx, from + to * _items[idx]->statics.size());
-		MGMSubItem *sub = _items[idx]->subItems[from + to * _items[idx]->statics.size()];
+		const MGMSubItem &sub = _items[idx]->subItems[from + to * _items[idx]->statics.size()];
 
-		if (sub->movement) {
-			idx = sub->field_8;
+		if (sub.movement) {
+			idx = sub.field_8;
 		} else {
 			clearVisitsList(idx);
 			idx = seekWay(idx, from, to, 0, 1);

--- a/engines/fullpipe/anihandler.cpp
+++ b/engines/fullpipe/anihandler.cpp
@@ -33,17 +33,21 @@ void AniHandler::detachAllObjects() {
 	_items.clear();
 }
 
-MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int staticsId, int *resStatId, Common::Point **pointArr) {
-	debugC(4, kDebugPathfinding, "AniHandler::makeQueue(*%d, %d, %d, res, point)", ani->_id, staticsIndex, staticsId);
+MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int, int *, Common::Point **) {
+	debugC(4, kDebugPathfinding, "AniHandler::makeQueue(*%d, %d, id, res, point)", ani->_id, staticsIndex);
 
 	int idx = getIndex(ani->_id);
 
 	if (idx == -1)
 		return 0;
 
+#if 0
 	int stid = staticsId;
 
 	if (!staticsId) {
+#else
+	int stid;
+#endif
 		if (ani->_movement) {
 			stid = ani->_movement->_staticsObj2->_staticsId;
 		} else {
@@ -52,7 +56,9 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 
 			stid = ani->_statics->_staticsId;
 		}
+#if 0
 	}
+#endif
 
 	if (stid == staticsIndex)
 		return new MessageQueue(g_fp->_globalMessageQueueList->compact());
@@ -79,6 +85,7 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 
 		point = _items[idx].subItems[subidx].movement->calcSomeXY(0, -1);
 
+#if 0
 		if (pointArr) {
 			int sz;
 
@@ -91,8 +98,11 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 
 			ex->_messageNum = _items[idx].subItems[subidx].movement->_id;
 		} else {
+#endif
 			ex = new ExCommand(ani->_id, 1, _items[idx].subItems[subidx].movement->_id, 0, 0, 0, 1, 0, 0, 0);
+#if 0
 		}
+#endif
 
 		ex->_param = ani->_odelay;
 		ex->_field_3C = 1;
@@ -100,8 +110,10 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 
 		mq->addExCommandToEnd(ex);
 
+#if 0
 		if (resStatId)
 			*resStatId = _items[idx].subItems[subidx].movement->_id;
+#endif
 
 		startidx = _items[idx].subItems[subidx].staticsIndex;
 

--- a/engines/fullpipe/anihandler.cpp
+++ b/engines/fullpipe/anihandler.cpp
@@ -356,7 +356,7 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 	for (int i = subIdx; i != st2idx;) {
 		const MGMSubItem &s = _items[itemIdx].subItems[i + st2idx * _items[itemIdx].statics.size()];
 
-		ex2 = createCommand(s.movement, mkQueue->ani->_id, x1, y1, &x2, &y2, -1);
+		ex2 = createCommand(s.movement, mkQueue->ani->_id, x1, y1, x2, y2, -1);
 		ex2->_parId = mq->_id;
 		ex2->_param = mkQueue->ani->_odelay;
 
@@ -373,7 +373,7 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 		else
 			plen = -1;
 
-		ex2 = createCommand(mov, mkQueue->ani->_id, x1, y1, &x2, &y2, plen);
+		ex2 = createCommand(mov, mkQueue->ani->_id, x1, y1, x2, y2, plen);
 		ex2->_parId = mq->_id;
 		ex2->_param = mkQueue->ani->_odelay;
 
@@ -383,7 +383,7 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 	for (int j = st1idx; j != subOffset;) {
 		const MGMSubItem &s = _items[itemIdx].subItems[j + subOffset * _items[itemIdx].statics.size()];
 
-		ex2 = createCommand(s.movement, mkQueue->ani->_id, x1, y1, &x2, &y2, -1);
+		ex2 = createCommand(s.movement, mkQueue->ani->_id, x1, y1, x2, y2, -1);
 		ex2->_parId = mq->_id;
 		ex2->_param = mkQueue->ani->_odelay;
 
@@ -701,8 +701,8 @@ Common::Point AniHandler::getNumCycles(Movement *mov, int x, int y, int *mult, i
 	return Common::Point(p2x + p1x * newmult, p2y + p1y * newmult);
 }
 
-ExCommand2 *AniHandler::createCommand(Movement *mov, int objId, int x1, int y1, Common::Point *x2, Common::Point *y2, int len) {
-	debugC(2, kDebugPathfinding, "AniHandler::createCommand(mov, %d, %d, %d, [%d, %d], [%d, %d], %d)", objId, x1, y1, x2->x, x2->y, y2->x, y2->y, len);
+ExCommand2 *AniHandler::createCommand(Movement *mov, int objId, int x1, int y1, Common::Point &x2, Common::Point &y2, int len) {
+	debugC(2, kDebugPathfinding, "AniHandler::createCommand(mov, %d, %d, %d, [%d, %d], [%d, %d], %d)", objId, x1, y1, x2.x, x2.y, y2.x, y2.y, len);
 
 	uint cnt;
 
@@ -714,43 +714,36 @@ ExCommand2 *AniHandler::createCommand(Movement *mov, int objId, int x1, int y1, 
 	if (len > 0 && cnt > (uint)len)
 		cnt = len;
 
-	Common::Point **points = (Common::Point **)malloc(sizeof(Common::Point *) * cnt);
+	PointList points(cnt);
 
 	for (uint i = 0; i < cnt; i++) {
 		int flags = mov->getDynamicPhaseByIndex(i)->getDynFlags();
 
-		points[i] = new Common::Point;
-
 		if (flags & 1) {
-			points[i]->x = x1 + x2->x;
+			points[i].x = x1 + x2.x;
 
-			y2->x -= x2->x;
+			y2.x -= x2.x;
 
-			if (!y2->x)
-				x2->x = 0;
+			if (!y2.x)
+				x2.x = 0;
 		}
 
 		if (flags & 2) {
-			points[i]->y = y1 + x2->y;
+			points[i].y = y1 + x2.y;
 
-			y2->y -= x2->y;
+			y2.y -= x2.y;
 
-			if (!y2->y)
-				x2->y = 0;
+			if (!y2.y)
+				x2.y = 0;
 		}
 	}
 
-	ExCommand2 *ex = new ExCommand2(20, objId, points, cnt);
+	ExCommand2 *ex = new ExCommand2(20, objId, points);
 	ex->_excFlags = 2;
 	ex->_messageNum = mov->_id;
 	ex->_field_14 = len;
 	ex->_field_24 = 1;
 	ex->_param = -1;
-
-	for (uint i = 0; i < cnt; i++)
-		delete points[i];
-
-	free(points);
 
 	return ex;
 }

--- a/engines/fullpipe/anihandler.cpp
+++ b/engines/fullpipe/anihandler.cpp
@@ -59,14 +59,14 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 
 	int startidx = getStaticsIndexById(idx, stid);
 	int endidx = getStaticsIndexById(idx, staticsIndex);
-	int subidx = startidx + endidx * _items[idx]->statics.size();
+	int subidx = startidx + endidx * _items[idx].statics.size();
 
-	if (!_items[idx]->subItems[subidx].movement) {
+	if (!_items[idx].subItems[subidx].movement) {
 		clearVisitsList(idx);
 		seekWay(idx, startidx, endidx, 0, 1);
 	}
 
-	if (!_items[idx]->subItems[subidx].movement)
+	if (!_items[idx].subItems[subidx].movement)
 		return 0;
 
 	MessageQueue *mq = new MessageQueue(g_fp->_globalMessageQueueList->compact());
@@ -75,23 +75,23 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 
 	int i = 0;
 	do {
-		subidx = startidx + endidx * _items[idx]->statics.size();
+		subidx = startidx + endidx * _items[idx].statics.size();
 
-		point = _items[idx]->subItems[subidx].movement->calcSomeXY(0, -1);
+		point = _items[idx].subItems[subidx].movement->calcSomeXY(0, -1);
 
 		if (pointArr) {
 			int sz;
 
-			if (_items[idx]->subItems[subidx].movement->_currMovement)
-				sz = _items[idx]->subItems[subidx].movement->_currMovement->_dynamicPhases.size();
+			if (_items[idx].subItems[subidx].movement->_currMovement)
+				sz = _items[idx].subItems[subidx].movement->_currMovement->_dynamicPhases.size();
 			else
-				sz = _items[idx]->subItems[subidx].movement->_dynamicPhases.size();
+				sz = _items[idx].subItems[subidx].movement->_dynamicPhases.size();
 
 			ex = new ExCommand2(20, ani->_id, &pointArr[i], sz);
 
-			ex->_messageNum = _items[idx]->subItems[subidx].movement->_id;
+			ex->_messageNum = _items[idx].subItems[subidx].movement->_id;
 		} else {
-			ex = new ExCommand(ani->_id, 1, _items[idx]->subItems[subidx].movement->_id, 0, 0, 0, 1, 0, 0, 0);
+			ex = new ExCommand(ani->_id, 1, _items[idx].subItems[subidx].movement->_id, 0, 0, 0, 1, 0, 0, 0);
 		}
 
 		ex->_param = ani->_odelay;
@@ -101,16 +101,16 @@ MessageQueue *AniHandler::makeQueue(StaticANIObject *ani, int staticsIndex, int 
 		mq->addExCommandToEnd(ex);
 
 		if (resStatId)
-			*resStatId = _items[idx]->subItems[subidx].movement->_id;
+			*resStatId = _items[idx].subItems[subidx].movement->_id;
 
-		startidx = _items[idx]->subItems[subidx].staticsIndex;
+		startidx = _items[idx].subItems[subidx].staticsIndex;
 
 		uint step;
 
-		if (_items[idx]->subItems[subidx].movement->_currMovement)
-			step = _items[idx]->subItems[subidx].movement->_currMovement->_dynamicPhases.size();
+		if (_items[idx].subItems[subidx].movement->_currMovement)
+			step = _items[idx].subItems[subidx].movement->_currMovement->_dynamicPhases.size();
 		else
-			step = _items[idx]->subItems[subidx].movement->_dynamicPhases.size();
+			step = _items[idx].subItems[subidx].movement->_dynamicPhases.size();
 
 		i += step;
 	} while (startidx != endidx);
@@ -135,10 +135,8 @@ void AniHandler::attachObject(int objId) {
 	debugC(4, kDebugPathfinding, "AniHandler::addItem(%d)", objId);
 
 	if (getIndex(objId) == -1) {
-		MGMItem *item = new MGMItem();
-
-		item->objId = objId;
-		_items.push_back(item);
+		_items.push_back(MGMItem());
+		_items.back().objId = objId;
 	}
 	resetData(objId);
 }
@@ -149,12 +147,12 @@ void AniHandler::resetData(int objId) {
 	if (idx == -1)
 		return;
 
-	debugC(3, kDebugPathfinding, "AniHandler::resetData. (1) movements1 sz: %d movements2 sz: %d", _items[idx]->movements1.size(), _items[idx]->movements2.size());
+	debugC(3, kDebugPathfinding, "AniHandler::resetData. (1) movements1 sz: %d movements2 sz: %d", _items[idx].movements1.size(), _items[idx].movements2.size());
 
-	_items[idx]->subItems.clear();
-	_items[idx]->statics.clear();
-	_items[idx]->movements1.clear();
-	_items[idx]->movements2.clear();
+	_items[idx].subItems.clear();
+	_items[idx].statics.clear();
+	_items[idx].movements1.clear();
+	_items[idx].movements2.clear();
 
 	StaticANIObject *obj = g_fp->_currentScene->getStaticANIObject1ById(objId, -1);
 
@@ -163,23 +161,23 @@ void AniHandler::resetData(int objId) {
 
 	debugC(1, kDebugPathfinding, "WWW rebuild. idx: %d, size: %d", idx, obj->_staticsList.size() * obj->_staticsList.size());
 	for (uint i = 0; i < obj->_staticsList.size(); i++) {
-		_items[idx]->statics.push_back(obj->_staticsList[i]);
+		_items[idx].statics.push_back(obj->_staticsList[i]);
 
 		for (uint j = 0; j < obj->_staticsList.size(); j++) // Yes, square
-			_items[idx]->subItems.push_back(MGMSubItem());
+			_items[idx].subItems.push_back(MGMSubItem());
 	}
 
 	for (uint i = 0; i < obj->_movements.size(); i++) {
-		_items[idx]->movements1.push_back(obj->_movements[i]);
-		_items[idx]->movements2.push_back(0);
+		_items[idx].movements1.push_back(obj->_movements[i]);
+		_items[idx].movements2.push_back(0);
 	}
 
-	debugC(3, kDebugPathfinding, "AniHandler::resetData. (2) movements1 sz: %d movements2 sz: %d", _items[idx]->movements1.size(), _items[idx]->movements2.size());
+	debugC(3, kDebugPathfinding, "AniHandler::resetData. (2) movements1 sz: %d movements2 sz: %d", _items[idx].movements1.size(), _items[idx].movements2.size());
 }
 
 int AniHandler::getIndex(int objId) {
 	for (uint i = 0; i < _items.size(); i++)
-		if (_items[i]->objId == objId)
+		if (_items[i].objId == objId)
 			return i;
 
 	return -1;
@@ -235,15 +233,15 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 	int st1idx = getStaticsIndexById(itemIdx, mov->_staticsObj2->_staticsId);
 	int subOffset = getStaticsIndexById(itemIdx, mkQueue->staticsId2);
 
-	debugC(3, kDebugPathfinding, "AniHandler::genMovement. (1) movements1 sz: %d movements2 sz: %d", _items[itemIdx]->movements1.size(), _items[itemIdx]->movements2.size());
+	debugC(3, kDebugPathfinding, "AniHandler::genMovement. (1) movements1 sz: %d movements2 sz: %d", _items[itemIdx].movements1.size(), _items[itemIdx].movements2.size());
 
 	clearVisitsList(itemIdx);
 	seekWay(itemIdx, subIdx, st2idx, 0, 1);
 	clearVisitsList(itemIdx);
 	seekWay(itemIdx, st1idx, subOffset, 0, 1);
 
-	const MGMSubItem &sub1 = _items[itemIdx]->subItems[subIdx + st2idx * _items[itemIdx]->statics.size()];
-	const MGMSubItem &sub2 = _items[itemIdx]->subItems[st1idx + subOffset * _items[itemIdx]->statics.size()];
+	const MGMSubItem &sub1 = _items[itemIdx].subItems[subIdx + st2idx * _items[itemIdx].statics.size()];
+	const MGMSubItem &sub2 = _items[itemIdx].subItems[st1idx + subOffset * _items[itemIdx].statics.size()];
 
 	if (subIdx != st2idx && !sub1.movement)
 		return 0;
@@ -344,7 +342,7 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 	ExCommand2 *ex2;
 
 	for (int i = subIdx; i != st2idx;) {
-		const MGMSubItem &s = _items[itemIdx]->subItems[i + st2idx * _items[itemIdx]->statics.size()];
+		const MGMSubItem &s = _items[itemIdx].subItems[i + st2idx * _items[itemIdx].statics.size()];
 
 		ex2 = createCommand(s.movement, mkQueue->ani->_id, x1, y1, &x2, &y2, -1);
 		ex2->_parId = mq->_id;
@@ -371,7 +369,7 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 	}
 
 	for (int j = st1idx; j != subOffset;) {
-		const MGMSubItem &s = _items[itemIdx]->subItems[j + subOffset * _items[itemIdx]->statics.size()];
+		const MGMSubItem &s = _items[itemIdx].subItems[j + subOffset * _items[itemIdx].statics.size()];
 
 		ex2 = createCommand(s.movement, mkQueue->ani->_id, x1, y1, &x2, &y2, -1);
 		ex2->_parId = mq->_id;
@@ -391,7 +389,7 @@ MessageQueue *AniHandler::makeRunQueue(MakeQueueStruct *mkQueue) {
 
 	mq->addExCommandToEnd(ex);
 
-	debugC(3, kDebugPathfinding, "AniHandler::genMovement. (2) movements1 sz: %d movements2 sz: %d", _items[itemIdx]->movements1.size(), _items[itemIdx]->movements2.size());
+	debugC(3, kDebugPathfinding, "AniHandler::genMovement. (2) movements1 sz: %d movements2 sz: %d", _items[itemIdx].movements1.size(), _items[itemIdx].movements2.size());
 
 	return mq;
 }
@@ -406,9 +404,9 @@ int AniHandler::getFramesCount(int idx, int subIdx, int endIdx, int flag) {
 		if (subIdx < 0)
 			break;
 
-		res += _items[idx]->subItems[subIdx + endIdx * _items[idx]->statics.size()].movement->countPhasesWithFlag(0xffffffff, flag);
+		res += _items[idx].subItems[subIdx + endIdx * _items[idx].statics.size()].movement->countPhasesWithFlag(0xffffffff, flag);
 
-		subIdx = _items[idx]->subItems[subIdx + endIdx * _items[idx]->statics.size()].staticsIndex;
+		subIdx = _items[idx].subItems[subIdx + endIdx * _items[idx].statics.size()].staticsIndex;
 	}
 
 	return res;
@@ -457,19 +455,19 @@ Common::Point AniHandler::getTransitionSize(int objectId, int staticsId1, int st
 		return Common::Point(0, 0);
 	}
 
-	int subidx = st1idx + st2idx * _items[idx]->statics.size();
+	int subidx = st1idx + st2idx * _items[idx].statics.size();
 
-	if (!_items[idx]->subItems[subidx].movement) {
+	if (!_items[idx].subItems[subidx].movement) {
 		clearVisitsList(idx);
 		seekWay(idx, st1idx, st2idx, false, true);
 
-		if (!_items[idx]->subItems[subidx].movement) {
+		if (!_items[idx].subItems[subidx].movement) {
 			clearVisitsList(idx);
 			seekWay(idx, st1idx, st2idx, true, false);
 		}
 	}
 
-	const MGMSubItem &sub = _items[idx]->subItems[subidx];
+	const MGMSubItem &sub = _items[idx].subItems[subidx];
 
 	if (!sub.movement) {
 		return Common::Point(0, 0);
@@ -479,11 +477,11 @@ Common::Point AniHandler::getTransitionSize(int objectId, int staticsId1, int st
 }
 
 int AniHandler::getStaticsIndexById(int idx, int16 id) {
-	if (!_items[idx]->statics.size())
+	if (!_items[idx].statics.size())
 		return -1;
 
-	for (uint i = 0; i < _items[idx]->statics.size(); i++) {
-		if (_items[idx]->statics[i]->_staticsId == id)
+	for (uint i = 0; i < _items[idx].statics.size(); i++) {
+		if (_items[idx].statics[i]->_staticsId == id)
 			return i;
 	}
 
@@ -491,11 +489,11 @@ int AniHandler::getStaticsIndexById(int idx, int16 id) {
 }
 
 int AniHandler::getStaticsIndex(int idx, Statics *st) {
-	if (!_items[idx]->statics.size())
+	if (!_items[idx].statics.size())
 		return -1;
 
-	for (uint i = 0; i < _items[idx]->statics.size(); i++) {
-		if (_items[idx]->statics[i] == st)
+	for (uint i = 0; i < _items[idx].statics.size(); i++) {
+		if (_items[idx].statics[i] == st)
 			return i;
 	}
 
@@ -505,69 +503,69 @@ int AniHandler::getStaticsIndex(int idx, Statics *st) {
 void AniHandler::clearVisitsList(int idx) {
 	debugC(2, kDebugPathfinding, "AniHandler::clearVisitsList(%d)", idx);
 
-	for (uint i = 0; i < _items[idx]->movements2.size(); i++)
-		_items[idx]->movements2[i] = 0;
+	for (uint i = 0; i < _items[idx].movements2.size(); i++)
+		_items[idx].movements2[i] = 0;
 
-	debugC(3, kDebugPathfinding, "AniHandler::clearVisitsList. movements1 sz: %d movements2 sz: %d", _items[idx]->movements1.size(), _items[idx]->movements2.size());
+	debugC(3, kDebugPathfinding, "AniHandler::clearVisitsList. movements1 sz: %d movements2 sz: %d", _items[idx].movements1.size(), _items[idx].movements2.size());
 }
 
 int AniHandler::seekWay(int idx, int st1idx, int st2idx, bool flip, bool flop) {
-	MGMItem *item = _items[idx];
-	int subIdx = st1idx + st2idx * item->statics.size();
+	MGMItem &item = _items[idx];
+	int subIdx = st1idx + st2idx * item.statics.size();
 
 	debugC(2, kDebugPathfinding, "AniHandler::seekWay(%d, %d, %d, %d, %d)", idx, st1idx, st2idx, flip, flop);
 
 	if (st1idx == st2idx) {
-		memset(&item->subItems[subIdx], 0, sizeof(item->subItems[subIdx]));
+		memset(&item.subItems[subIdx], 0, sizeof(item.subItems[subIdx]));
 		return 0;
 	}
 
-	if (item->subItems[subIdx].movement)
-		return item->subItems[subIdx].field_8;
+	if (item.subItems[subIdx].movement)
+		return item.subItems[subIdx].field_8;
 
 	Common::Point point;
 
-	debugC(3, kDebugPathfinding, "AniHandler::seekWay. movements1 sz: %d movements2 sz: %d", item->movements1.size(), item->movements2.size());
+	debugC(3, kDebugPathfinding, "AniHandler::seekWay. movements1 sz: %d movements2 sz: %d", item.movements1.size(), item.movements2.size());
 
-	for (uint i = 0; i < item->movements1.size(); i++) {
-		Movement *mov = item->movements1[i];
+	for (uint i = 0; i < item.movements1.size(); i++) {
+		Movement *mov = item.movements1[i];
 
-		if (mov->_staticsObj1 == item->statics[st1idx]) {
-			if (item->movements2[i] || (flop && !mov->_field_50))
+		if (mov->_staticsObj1 == item.statics[st1idx]) {
+			if (item.movements2[i] || (flop && !mov->_field_50))
 				continue;
 
-			item->movements2[i] = 1;
+			item.movements2[i] = 1;
 
 			int stidx = getStaticsIndex(idx, mov->_staticsObj2);
 			int recalc = seekWay(idx, stidx, st2idx, flip, flop);
 			int sz = mov->_currMovement ? mov->_currMovement->_dynamicPhases.size() : mov->_dynamicPhases.size();
-			debugC(1, kDebugPathfinding, "AniHandler::seekWay, want idx: %d, off: %d (%d + %d), sz: %d", idx, stidx + st2idx * _items[idx]->statics.size(), stidx, st2idx, item->subItems.size());
+			debugC(1, kDebugPathfinding, "AniHandler::seekWay, want idx: %d, off: %d (%d + %d), sz: %d", idx, stidx + st2idx * _items[idx].statics.size(), stidx, st2idx, item.subItems.size());
 
-			int newsz = sz + item->subItems[stidx + st2idx * _items[idx]->statics.size()].field_C;
+			int newsz = sz + item.subItems[stidx + st2idx * _items[idx].statics.size()].field_C;
 
 			if (recalc < 0)
 				continue;
 
-			if (!item->subItems[subIdx].movement || item->subItems[subIdx].field_8 > recalc + 1 ||
-				(item->subItems[subIdx].field_8 == recalc + 1 && item->subItems[subIdx].field_C > newsz)) {
-				item->subItems[subIdx].movement = mov;
-				item->subItems[subIdx].staticsIndex = stidx;
-				item->subItems[subIdx].field_8 = recalc + 1;
-				item->subItems[subIdx].field_C = newsz;
+			if (!item.subItems[subIdx].movement || item.subItems[subIdx].field_8 > recalc + 1 ||
+				(item.subItems[subIdx].field_8 == recalc + 1 && item.subItems[subIdx].field_C > newsz)) {
+				item.subItems[subIdx].movement = mov;
+				item.subItems[subIdx].staticsIndex = stidx;
+				item.subItems[subIdx].field_8 = recalc + 1;
+				item.subItems[subIdx].field_C = newsz;
 
 				point = mov->calcSomeXY(0, -1);
 
-				item->subItems[subIdx].x = item->subItems[stidx + st2idx * _items[idx]->statics.size()].x + point.x;
-				item->subItems[subIdx].y = item->subItems[stidx + st2idx * _items[idx]->statics.size()].y + point.y;
+				item.subItems[subIdx].x = item.subItems[stidx + st2idx * _items[idx].statics.size()].x + point.x;
+				item.subItems[subIdx].y = item.subItems[stidx + st2idx * _items[idx].statics.size()].y + point.y;
 			}
 		} else if (flip) {
-			if (mov->_staticsObj2 != item->statics[st1idx])
+			if (mov->_staticsObj2 != item.statics[st1idx])
 				continue;
 
-			if (item->movements2[i] || (flop && !mov->_field_50))
+			if (item.movements2[i] || (flop && !mov->_field_50))
 				continue;
 
-			item->movements2[i] = 1;
+			item.movements2[i] = 1;
 
 			int stidx = getStaticsIndex(idx, mov->_staticsObj1);
 			int recalc = seekWay(idx, stidx, st2idx, flip, flop);
@@ -575,25 +573,25 @@ int AniHandler::seekWay(int idx, int st1idx, int st2idx, bool flip, bool flop) {
 			if (recalc < 0)
 				continue;
 
-			if (!item->subItems[subIdx].movement || item->subItems[subIdx].field_8 > recalc + 1) {
-				item->subItems[subIdx].movement = mov;
-				item->subItems[subIdx].staticsIndex = stidx;
-				item->subItems[subIdx].field_8 = recalc + 1;
+			if (!item.subItems[subIdx].movement || item.subItems[subIdx].field_8 > recalc + 1) {
+				item.subItems[subIdx].movement = mov;
+				item.subItems[subIdx].staticsIndex = stidx;
+				item.subItems[subIdx].field_8 = recalc + 1;
 
 				int sz = mov->_currMovement ? mov->_currMovement->_dynamicPhases.size() : mov->_dynamicPhases.size();
 
-				item->subItems[subIdx].field_C = sz + item->subItems[stidx + st2idx * _items[idx]->statics.size()].field_C;
+				item.subItems[subIdx].field_C = sz + item.subItems[stidx + st2idx * _items[idx].statics.size()].field_C;
 
 				point = mov->calcSomeXY(0, -1);
 
-				item->subItems[subIdx].x = item->subItems[stidx + st2idx * _items[idx]->statics.size()].x - point.x;
-				item->subItems[subIdx].y = item->subItems[stidx + st2idx * _items[idx]->statics.size()].y - point.y;
+				item.subItems[subIdx].x = item.subItems[stidx + st2idx * _items[idx].statics.size()].x - point.x;
+				item.subItems[subIdx].y = item.subItems[stidx + st2idx * _items[idx].statics.size()].y - point.y;
 			}
 		}
 	}
 
-	if (item->subItems[subIdx].movement)
-		return item->subItems[subIdx].field_8;
+	if (item.subItems[subIdx].movement)
+		return item.subItems[subIdx].field_8;
 
 	return -1;
 }
@@ -607,8 +605,8 @@ int AniHandler::getNumMovements(int objectId, int idx1, int idx2) {
 		int from = getStaticsIndexById(idx, idx1);
 		int to = getStaticsIndexById(idx, idx2);
 
-		debugC(1, kDebugPathfinding, "WWW 6, want idx: %d, off: %d", idx, from + to * _items[idx]->statics.size());
-		const MGMSubItem &sub = _items[idx]->subItems[from + to * _items[idx]->statics.size()];
+		debugC(1, kDebugPathfinding, "WWW 6, want idx: %d, off: %d", idx, from + to * _items[idx].statics.size());
+		const MGMSubItem &sub = _items[idx].subItems[from + to * _items[idx].statics.size()];
 
 		if (sub.movement) {
 			idx = sub.field_8;

--- a/engines/fullpipe/anihandler.cpp
+++ b/engines/fullpipe/anihandler.cpp
@@ -163,14 +163,14 @@ void AniHandler::resetData(int objId) {
 
 	debugC(1, kDebugPathfinding, "WWW rebuild. idx: %d, size: %d", idx, obj->_staticsList.size() * obj->_staticsList.size());
 	for (uint i = 0; i < obj->_staticsList.size(); i++) {
-		_items[idx]->statics.push_back((Statics *)obj->_staticsList[i]);
+		_items[idx]->statics.push_back(obj->_staticsList[i]);
 
 		for (uint j = 0; j < obj->_staticsList.size(); j++) // Yes, square
 			_items[idx]->subItems.push_back(MGMSubItem());
 	}
 
 	for (uint i = 0; i < obj->_movements.size(); i++) {
-		_items[idx]->movements1.push_back((Movement *)obj->_movements[i]);
+		_items[idx]->movements1.push_back(obj->_movements[i]);
 		_items[idx]->movements2.push_back(0);
 	}
 

--- a/engines/fullpipe/anihandler.h
+++ b/engines/fullpipe/anihandler.h
@@ -42,7 +42,7 @@ struct MGMSubItem {
 
 struct MGMItem {
 	int16 objId;
-	Common::Array<MGMSubItem *> subItems;
+	Common::Array<MGMSubItem> subItems;
 	Common::Array<Statics *> statics;
 	Common::Array<Movement *> movements1;
 	Common::Array<int> movements2;

--- a/engines/fullpipe/anihandler.h
+++ b/engines/fullpipe/anihandler.h
@@ -84,7 +84,7 @@ public:
 	void clearVisitsList(int idx);
 	int seekWay(int idx, int st1idx, int st2idx, bool flip, bool flop);
 	Common::Point getNumCycles(Movement *mov, int x, int y, int *mult, int *len, int flag);
-	ExCommand2 *createCommand(Movement *mov, int objId, int x1, int y1, Common::Point *x2, Common::Point *y2, int len);
+	ExCommand2 *createCommand(Movement *mov, int objId, int x1, int y1, Common::Point &x2, Common::Point &y2, int len);
 	MessageQueue *makeQueue(StaticANIObject *ani, int staticsIndex, int staticsId, int *resStatId, Common::Point **pointArr);
 	int getFramesCount(int idx, int subIdx, int subOffset, int flag);
 	int getNumMovements(int objectId, int idx1, int idx2);

--- a/engines/fullpipe/anihandler.h
+++ b/engines/fullpipe/anihandler.h
@@ -67,8 +67,8 @@ struct MakeQueueStruct {
 };
 
 class AniHandler : public CObject {
-public:
-	Common::Array<MGMItem *> _items;
+protected:
+	Common::Array<MGMItem> _items;
 
 public:
 	void detachAllObjects();

--- a/engines/fullpipe/anihandler.h
+++ b/engines/fullpipe/anihandler.h
@@ -78,12 +78,12 @@ public:
 
 	MessageQueue *makeRunQueue(MakeQueueStruct *mkQueue);
 	void putObjectToStatics(StaticANIObject *ani, int staticsId);
-	Common::Point *getTransitionSize(Common::Point *point, int aniId, int staticsId1, int staticsId2);
+	Common::Point getTransitionSize(int aniId, int staticsId1, int staticsId2);
 	int getStaticsIndexById(int idx, int16 id);
 	int getStaticsIndex(int idx, Statics *st);
 	void clearVisitsList(int idx);
 	int seekWay(int idx, int st1idx, int st2idx, bool flip, bool flop);
-	Common::Point *getNumCycles(Common::Point *point, Movement *mov, int x, int y, int *mult, int *len, int flag);
+	Common::Point getNumCycles(Movement *mov, int x, int y, int *mult, int *len, int flag);
 	ExCommand2 *createCommand(Movement *mov, int objId, int x1, int y1, Common::Point *x2, Common::Point *y2, int len);
 	MessageQueue *makeQueue(StaticANIObject *ani, int staticsIndex, int staticsId, int *resStatId, Common::Point **pointArr);
 	int getFramesCount(int idx, int subIdx, int subOffset, int flag);

--- a/engines/fullpipe/behavior.cpp
+++ b/engines/fullpipe/behavior.cpp
@@ -39,12 +39,6 @@ BehaviorManager::~BehaviorManager() {
 }
 
 void BehaviorManager::clear() {
-	for (uint i = 0; i < _behaviors.size(); i++) {
-		for (int j = 0; j < _behaviors[i]->_animsCount; j++)
-			delete _behaviors[i]->_behaviorAnims[j];
-
-		delete _behaviors[i];
-	}
 	_behaviors.clear();
 }
 
@@ -53,8 +47,6 @@ void BehaviorManager::initBehavior(Scene *sc, GameVar *var) {
 
 	clear();
 	_scene = sc;
-
-	BehaviorInfo *behinfo;
 
 	GameVar *behvar = var->getSubVarByName("BEHAVIOR");
 	if (!behvar)
@@ -65,20 +57,17 @@ void BehaviorManager::initBehavior(Scene *sc, GameVar *var) {
 	for (GameVar *subvar = behvar->_subVars; subvar; subvar = subvar->_nextVarObj) {
 		debugC(3, kDebugBehavior, "BehaviorManager::initBehavior. subVar %s", transCyrillic(subvar->_varName));
 		if (subvar->_varName == "AMBIENT") {
-			behinfo = new BehaviorInfo;
-			behinfo->initAmbientBehavior(subvar, sc);
-
-			_behaviors.push_back(behinfo);
+			_behaviors.push_back(BehaviorInfo());
+			_behaviors.back().initAmbientBehavior(subvar, sc);
 		} else {
 			StaticANIObject *ani = sc->getStaticANIObject1ByName(subvar->_varName, -1);
 			if (ani) {
 				for (uint i = 0; i < sc->_staticANIObjectList1.size(); i++) {
 					if (((StaticANIObject *)sc->_staticANIObjectList1[i])->_id == ani->_id) {
-						behinfo = new BehaviorInfo;
-						behinfo->initObjectBehavior(subvar, sc, ani);
-						behinfo->_ani = (StaticANIObject *)sc->_staticANIObjectList1[i];
-
-						_behaviors.push_back(behinfo);
+						_behaviors.push_back(BehaviorInfo());
+						BehaviorInfo &behinfo = _behaviors.back();
+						behinfo.initObjectBehavior(subvar, sc, ani);
+						behinfo._ani = sc->_staticANIObjectList1[i];
 					}
 				}
 			}
@@ -92,35 +81,37 @@ void BehaviorManager::updateBehaviors() {
 
 	debugC(6, kDebugBehavior, "BehaviorManager::updateBehaviors()");
 	for (uint i = 0; i < _behaviors.size(); i++) {
-		BehaviorInfo *beh = _behaviors[i];
+		BehaviorInfo &beh = _behaviors[i];
 
-		if (!beh->_ani) {
-			beh->_counter++;
-			if (beh->_counter >= beh->_counterMax)
-				updateBehavior(beh, beh->_behaviorAnims[0]);
+		if (!beh._ani) {
+			beh._counter++;
+			if (beh._counter >= beh._counterMax)
+				updateBehavior(beh, beh._behaviorAnims[0]);
 
 			continue;
 		}
 
-		if (beh->_ani->_movement || !(beh->_ani->_flags & 4) || (beh->_ani->_flags & 2)) {
-			beh->_staticsId = 0;
+		if (beh._ani->_movement || !(beh._ani->_flags & 4) || (beh._ani->_flags & 2)) {
+			beh._staticsId = 0;
 			continue;
 		}
 
-		if (beh->_ani->_statics->_staticsId == beh->_staticsId) {
-			beh->_counter++;
-			if (beh->_counter >= beh->_counterMax) {
-				if (beh->_subIndex >= 0 && !(beh->_flags & 1) && beh->_ani->_messageQueueId <= 0)
-					updateStaticAniBehavior(beh->_ani, beh->_counter, beh->_behaviorAnims[beh->_subIndex]);
+		if (beh._ani->_statics->_staticsId == beh._staticsId) {
+			beh._counter++;
+			if (beh._counter >= beh._counterMax) {
+				if (beh._subIndex >= 0 && !(beh._flags & 1) && beh._ani->_messageQueueId <= 0) {
+					assert(beh._ani);
+					updateStaticAniBehavior(*beh._ani, beh._counter, beh._behaviorAnims[beh._subIndex]);
+				}
 			}
 		} else {
-			beh->_staticsId = beh->_ani->_statics->_staticsId;
-			beh->_counter = 0;
-			beh->_subIndex = -1;
+			beh._staticsId = beh._ani->_statics->_staticsId;
+			beh._counter = 0;
+			beh._subIndex = -1;
 
-			for (int j = 0; j < beh->_animsCount; j++)
-				if (beh->_behaviorAnims[j]->_staticsId == beh->_staticsId) {
-					beh->_subIndex = j;
+			for (int j = 0; j < beh._animsCount; j++)
+				if (beh._behaviorAnims[j]._staticsId == beh._staticsId) {
+					beh._subIndex = j;
 					break;
 				}
 
@@ -128,51 +119,51 @@ void BehaviorManager::updateBehaviors() {
 	}
 }
 
-void BehaviorManager::updateBehavior(BehaviorInfo *behaviorInfo, BehaviorAnim *entry) {
-	debugC(7, kDebugBehavior, "BehaviorManager::updateBehavior() moves: %d", entry->_movesCount);
-	for (int i = 0; i < entry->_movesCount; i++) {
-		BehaviorMove *bhi = entry->_behaviorMoves[i];
-		if (!(bhi->_flags & 1)) {
-			if (bhi->_flags & 2) {
-				MessageQueue *mq = new MessageQueue(bhi->_messageQueue, 0, 1);
+void BehaviorManager::updateBehavior(BehaviorInfo &behaviorInfo, BehaviorAnim &entry) {
+	debugC(7, kDebugBehavior, "BehaviorManager::updateBehavior() moves: %d", entry._behaviorMoves.size());
+	for (uint i = 0; i < entry._behaviorMoves.size(); i++) {
+		BehaviorMove &bhi = entry._behaviorMoves[i];
+		if (!(bhi._flags & 1)) {
+			if (bhi._flags & 2) {
+				MessageQueue *mq = new MessageQueue(bhi._messageQueue, 0, 1);
 
 				mq->sendNextCommand();
 
-				bhi->_flags &= 0xFFFFFFFD;
-			} else if (behaviorInfo->_counter >= bhi->_delay && bhi->_percent && g_fp->_rnd.getRandomNumber(32767) <= entry->_behaviorMoves[i]->_percent) {
-				MessageQueue *mq = new MessageQueue(bhi->_messageQueue, 0, 1);
+				bhi._flags &= 0xFFFFFFFD;
+			} else if (behaviorInfo._counter >= bhi._delay && bhi._percent && g_fp->_rnd.getRandomNumber(32767) <= entry._behaviorMoves[i]._percent) {
+				MessageQueue *mq = new MessageQueue(bhi._messageQueue, 0, 1);
 
 				mq->sendNextCommand();
 
-				behaviorInfo->_counter = 0;
+				behaviorInfo._counter = 0;
 			}
 		}
 	}
 }
 
-void BehaviorManager::updateStaticAniBehavior(StaticANIObject *ani, int delay, BehaviorAnim *bhe) {
-	debugC(6, kDebugBehavior, "BehaviorManager::updateStaticAniBehavior(%s)", transCyrillic(ani->_objectName));
+void BehaviorManager::updateStaticAniBehavior(StaticANIObject &ani, int delay, const BehaviorAnim &beh) {
+	debugC(6, kDebugBehavior, "BehaviorManager::updateStaticAniBehavior(%s)", transCyrillic(ani._objectName));
 
 	MessageQueue *mq = 0;
 
-	if (bhe->_flags & 1) {
+	if (beh._flags & 1) {
 		uint rnd = g_fp->_rnd.getRandomNumber(32767);
 		uint runPercent = 0;
-		for (int i = 0; i < bhe->_movesCount; i++) {
-			if (!(bhe->_behaviorMoves[i]->_flags & 1) && bhe->_behaviorMoves[i]->_percent) {
-				if ((rnd >= runPercent && rnd <= runPercent + bhe->_behaviorMoves[i]->_percent) || i == bhe->_movesCount - 1) {
-					mq = new MessageQueue(bhe->_behaviorMoves[i]->_messageQueue, 0, 1);
+		for (uint i = 0; i < beh._behaviorMoves.size(); i++) {
+			if (!(beh._behaviorMoves[i]._flags & 1) && beh._behaviorMoves[i]._percent) {
+				if ((rnd >= runPercent && rnd <= runPercent + beh._behaviorMoves[i]._percent) || i == beh._behaviorMoves.size() - 1) {
+					mq = new MessageQueue(beh._behaviorMoves[i]._messageQueue, 0, 1);
 					break;
 				}
-				runPercent += bhe->_behaviorMoves[i]->_percent;
+				runPercent += beh._behaviorMoves[i]._percent;
 			}
 		}
 	} else {
-		for (int i = 0; i < bhe->_movesCount; i++) {
-			if (!(bhe->_behaviorMoves[i]->_flags & 1) && delay >= bhe->_behaviorMoves[i]->_delay) {
-				if (bhe->_behaviorMoves[i]->_percent) {
-					if (g_fp->_rnd.getRandomNumber(32767) <= bhe->_behaviorMoves[i]->_percent) {
-						mq = new MessageQueue(bhe->_behaviorMoves[i]->_messageQueue, 0, 1);
+		for (uint i = 0; i < beh._behaviorMoves.size(); i++) {
+			if (!(beh._behaviorMoves[i]._flags & 1) && delay >= beh._behaviorMoves[i]._delay) {
+				if (beh._behaviorMoves[i]._percent) {
+					if (g_fp->_rnd.getRandomNumber(32767) <= beh._behaviorMoves[i]._percent) {
+						mq = new MessageQueue(beh._behaviorMoves[i]._messageQueue, 0, 1);
 						break;
 					}
 				}
@@ -181,8 +172,8 @@ void BehaviorManager::updateStaticAniBehavior(StaticANIObject *ani, int delay, B
 	}
 
 	if (mq) {
-		mq->setParamInt(-1, ani->_odelay);
-		mq->chain(ani);
+		mq->setParamInt(-1, ani._odelay);
+		mq->chain(&ani);
 	}
 }
 
@@ -202,25 +193,25 @@ bool BehaviorManager::setBehaviorEnabled(StaticANIObject *obj, int aniId, int qu
 
 void BehaviorManager::setFlagByStaticAniObject(StaticANIObject *ani, int flag) {
 	for (uint i = 0; i < _behaviors.size(); i++) {
-		BehaviorInfo *beh = _behaviors[i];
+		BehaviorInfo &beh = _behaviors[i];
 
-		if (ani == beh->_ani) {
+		if (ani == beh._ani) {
 			if (flag)
-				beh->_flags &= 0xfffffffe;
+				beh._flags &= 0xfffffffe;
 			else
-				beh->_flags |= 1;
+				beh._flags |= 1;
 		}
 	}
 }
 
 BehaviorMove *BehaviorManager::getBehaviorMoveByMessageQueueDataId(StaticANIObject *ani, int id1, int id2) {
 	for (uint i = 0; i < _behaviors.size(); i++) {
-		if (_behaviors[i]->_ani == ani) {
-			for (uint j = 0; j < _behaviors[i]->_behaviorAnims.size(); j++) {
-				if (_behaviors[i]->_behaviorAnims[j]->_staticsId == id1) {
-					for (int k = 0; k < _behaviors[i]->_behaviorAnims[j]->_movesCount; k++) {
-						if (_behaviors[i]->_behaviorAnims[j]->_behaviorMoves[k]->_messageQueue->_dataId == id2)
-							return _behaviors[i]->_behaviorAnims[j]->_behaviorMoves[k];
+		if (_behaviors[i]._ani == ani) {
+			for (uint j = 0; j < _behaviors[i]._behaviorAnims.size(); j++) {
+				if (_behaviors[i]._behaviorAnims[j]._staticsId == id1) {
+					for (uint k = 0; k < _behaviors[i]._behaviorAnims[j]._behaviorMoves.size(); k++) {
+						if (_behaviors[i]._behaviorAnims[j]._behaviorMoves[k]._messageQueue->_dataId == id2)
+							return &_behaviors[i]._behaviorAnims[j]._behaviorMoves[k];
 					}
 				}
 			}
@@ -231,14 +222,13 @@ BehaviorMove *BehaviorManager::getBehaviorMoveByMessageQueueDataId(StaticANIObje
 }
 
 void BehaviorInfo::clear() {
-	_ani = NULL;
+	_ani = nullptr;
 	_staticsId = 0;
 	_counter = 0;
 	_counterMax = 0;
 	_flags = 0;
 	_subIndex = 0;
 	_animsCount = 0;
-
 	_behaviorAnims.clear();
 }
 
@@ -249,20 +239,18 @@ void BehaviorInfo::initAmbientBehavior(GameVar *var, Scene *sc) {
 	_animsCount = 1;
 	_counterMax = -1;
 
-	BehaviorAnim *bi = new BehaviorAnim();
+	_behaviorAnims.push_back(BehaviorAnim());
+	BehaviorAnim &bi = _behaviorAnims.back();
 
-	_behaviorAnims.push_back(bi);
-
-	bi->_movesCount = var->getSubVarsCount();
-
-	bi->_behaviorMoves = (BehaviorMove **)calloc(bi->_movesCount, sizeof(BehaviorMove *));
-
-	for (int i = 0; i < bi->_movesCount; i++) {
+	int movesCount = var->getSubVarsCount();
+	bi._behaviorMoves.reserve(movesCount);
+	for (int i = 0; i < movesCount; i++) {
 		int delay;
-		bi->_behaviorMoves[i] = new BehaviorMove(var->getSubVarByIndex(i), sc, &delay);
+		bi._behaviorMoves.push_back(BehaviorMove(var->getSubVarByIndex(i), sc, &delay));
+		BehaviorMove &move = bi._behaviorMoves.back();
 
-		if (bi->_behaviorMoves[i]->_delay <_counterMax)
-			_counterMax = bi->_behaviorMoves[i]->_delay;
+		if (move._delay < _counterMax)
+			_counterMax = move._delay;
 	}
 }
 
@@ -293,7 +281,7 @@ void BehaviorInfo::initObjectBehavior(GameVar *var, Scene *sc, StaticANIObject *
 	for (int i = 0; i < _animsCount; i++) {
 		int maxDelay = 0;
 
-		_behaviorAnims.push_back(new BehaviorAnim(var->getSubVarByIndex(i), sc, ani, &maxDelay));
+		_behaviorAnims.push_back(BehaviorAnim(var->getSubVarByIndex(i), sc, ani, &maxDelay));
 
 		if (maxDelay < _counterMax)
 			_counterMax = maxDelay;
@@ -302,38 +290,34 @@ void BehaviorInfo::initObjectBehavior(GameVar *var, Scene *sc, StaticANIObject *
 
 BehaviorAnim::BehaviorAnim() {
 	_staticsId = 0;
-	_movesCount = 0;
 	_flags = 0;
-	_behaviorMoves = NULL;
 }
 
 BehaviorAnim::BehaviorAnim(GameVar *var, Scene *sc, StaticANIObject *ani, int *minDelay) {
 	_staticsId = 0;
-	_movesCount = 0;
 
 	*minDelay = 0xffffffff;
 
 	int totalPercent = 0;
 	_flags = 0;
-	_behaviorMoves = 0;
 
 	Statics *st = ani->getStaticsByName(var->_varName);
 	if (st)
 		_staticsId = st->_staticsId;
 
-	_movesCount = var->getSubVarsCount();
-	if (_movesCount) {
-		_behaviorMoves = (BehaviorMove **)calloc(_movesCount, sizeof(BehaviorMove *));
-
-		for (int i = 0; i < _movesCount; i++) {
+	int movesCount = var->getSubVarsCount();
+	if (movesCount) {
+		_behaviorMoves.reserve(movesCount);
+		for (int i = 0; i < movesCount; i++) {
 			GameVar *subvar = var->getSubVarByIndex(i);
 			int delay = 0;
 
-			_behaviorMoves[i] = new BehaviorMove(subvar, sc, &delay);
+			_behaviorMoves.push_back(BehaviorMove(subvar, sc, &delay));
+			BehaviorMove &move = _behaviorMoves.back();
 			totalPercent += delay;
 
-			if (_behaviorMoves[i]->_delay < *minDelay)
-				*minDelay = _behaviorMoves[i]->_delay;
+			if (move._delay < *minDelay)
+				*minDelay = move._delay;
 		}
 
 		if (!*minDelay && totalPercent == 1000)

--- a/engines/fullpipe/behavior.cpp
+++ b/engines/fullpipe/behavior.cpp
@@ -63,7 +63,7 @@ void BehaviorManager::initBehavior(Scene *sc, GameVar *var) {
 			StaticANIObject *ani = sc->getStaticANIObject1ByName(subvar->_varName, -1);
 			if (ani) {
 				for (uint i = 0; i < sc->_staticANIObjectList1.size(); i++) {
-					if (((StaticANIObject *)sc->_staticANIObjectList1[i])->_id == ani->_id) {
+					if (sc->_staticANIObjectList1[i]->_id == ani->_id) {
 						_behaviors.push_back(BehaviorInfo());
 						BehaviorInfo &behinfo = _behaviors.back();
 						behinfo.initObjectBehavior(subvar, sc, ani);

--- a/engines/fullpipe/behavior.cpp
+++ b/engines/fullpipe/behavior.cpp
@@ -173,7 +173,9 @@ void BehaviorManager::updateStaticAniBehavior(StaticANIObject &ani, int delay, c
 
 	if (mq) {
 		mq->setParamInt(-1, ani._odelay);
-		mq->chain(&ani);
+		if (!mq->chain(&ani)) {
+			g_fp->_globalMessageQueueList->deleteQueueById(mq->_id);
+		}
 	}
 }
 

--- a/engines/fullpipe/behavior.cpp
+++ b/engines/fullpipe/behavior.cpp
@@ -139,7 +139,7 @@ void BehaviorManager::updateBehavior(BehaviorInfo *behaviorInfo, BehaviorAnim *e
 				mq->sendNextCommand();
 
 				bhi->_flags &= 0xFFFFFFFD;
-			} else if (behaviorInfo->_counter >= bhi->_delay && bhi->_percent && g_fp->_rnd->getRandomNumber(32767) <= entry->_behaviorMoves[i]->_percent) {
+			} else if (behaviorInfo->_counter >= bhi->_delay && bhi->_percent && g_fp->_rnd.getRandomNumber(32767) <= entry->_behaviorMoves[i]->_percent) {
 				MessageQueue *mq = new MessageQueue(bhi->_messageQueue, 0, 1);
 
 				mq->sendNextCommand();
@@ -156,7 +156,7 @@ void BehaviorManager::updateStaticAniBehavior(StaticANIObject *ani, int delay, B
 	MessageQueue *mq = 0;
 
 	if (bhe->_flags & 1) {
-		uint rnd = g_fp->_rnd->getRandomNumber(32767);
+		uint rnd = g_fp->_rnd.getRandomNumber(32767);
 		uint runPercent = 0;
 		for (int i = 0; i < bhe->_movesCount; i++) {
 			if (!(bhe->_behaviorMoves[i]->_flags & 1) && bhe->_behaviorMoves[i]->_percent) {
@@ -171,7 +171,7 @@ void BehaviorManager::updateStaticAniBehavior(StaticANIObject *ani, int delay, B
 		for (int i = 0; i < bhe->_movesCount; i++) {
 			if (!(bhe->_behaviorMoves[i]->_flags & 1) && delay >= bhe->_behaviorMoves[i]->_delay) {
 				if (bhe->_behaviorMoves[i]->_percent) {
-					if (g_fp->_rnd->getRandomNumber(32767) <= bhe->_behaviorMoves[i]->_percent) {
+					if (g_fp->_rnd.getRandomNumber(32767) <= bhe->_behaviorMoves[i]->_percent) {
 						mq = new MessageQueue(bhe->_behaviorMoves[i]->_messageQueue, 0, 1);
 						break;
 					}

--- a/engines/fullpipe/behavior.h
+++ b/engines/fullpipe/behavior.h
@@ -36,9 +36,8 @@ struct BehaviorMove {
 
 struct BehaviorAnim {
 	int _staticsId;
-	int _movesCount;
 	int _flags;
-	BehaviorMove **_behaviorMoves;
+	Common::Array<BehaviorMove> _behaviorMoves;
 
 	BehaviorAnim();
 	BehaviorAnim(GameVar *var, Scene *sc, StaticANIObject *ani, int *minDelay);
@@ -52,7 +51,7 @@ struct BehaviorInfo {
 	int _flags;
 	int _subIndex;
 	int _animsCount;
-	Common::Array<BehaviorAnim *> _behaviorAnims;
+	Common::Array<BehaviorAnim> _behaviorAnims;
 
 	BehaviorInfo() { clear(); }
 
@@ -62,7 +61,7 @@ struct BehaviorInfo {
 };
 
 class BehaviorManager : public CObject {
-	Common::Array<BehaviorInfo *> _behaviors;
+	Common::Array<BehaviorInfo> _behaviors;
 	Scene *_scene;
 	bool _isActive;
 
@@ -75,8 +74,8 @@ class BehaviorManager : public CObject {
 	void initBehavior(Scene *scene, GameVar *var);
 
 	void updateBehaviors();
-	void updateBehavior(BehaviorInfo *behaviorInfo, BehaviorAnim *entry);
-	void updateStaticAniBehavior(StaticANIObject *ani, int delay, BehaviorAnim *beh);
+	void updateBehavior(BehaviorInfo &behaviorInfo, BehaviorAnim &entry);
+	void updateStaticAniBehavior(StaticANIObject &ani, int delay, const BehaviorAnim &beh);
 
 	bool setBehaviorEnabled(StaticANIObject *obj, int aniId, int quId, int flag);
 

--- a/engines/fullpipe/detection.cpp
+++ b/engines/fullpipe/detection.cpp
@@ -180,13 +180,11 @@ SaveStateList FullpipeMetaEngine::listSaves(const char *target) const {
 		int slotNum = atoi(file->c_str() + file->size() - 2);
 
 		if (slotNum >= 0 && slotNum <= getMaximumSaveSlot()) {
-			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
+			Common::ScopedPtr<Common::InSaveFile> in(saveFileMan->openForLoading(*file));
 			if (in) {
 				Fullpipe::FullpipeSavegameHeader header;
-				Fullpipe::readSavegameHeader(in, header);
+				Fullpipe::readSavegameHeader(in.get(), header);
 				saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
-				delete header.thumbnail;
-				delete in;
 			}
 		}
 	}
@@ -201,13 +199,12 @@ void FullpipeMetaEngine::removeSaveState(const char *target, int slot) const {
 }
 
 SaveStateDescriptor FullpipeMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
-	Common::InSaveFile *f = g_system->getSavefileManager()->openForLoading(
-		Fullpipe::getSavegameFile(slot));
+	Common::ScopedPtr<Common::InSaveFile> f(g_system->getSavefileManager()->openForLoading(
+		Fullpipe::getSavegameFile(slot)));
 
 	if (f) {
 		Fullpipe::FullpipeSavegameHeader header;
-		Fullpipe::readSavegameHeader(f, header);
-		delete f;
+		Fullpipe::readSavegameHeader(f.get(), header);
 
 		// Create the return descriptor
 		SaveStateDescriptor desc(slot, header.saveName);

--- a/engines/fullpipe/floaters.cpp
+++ b/engines/fullpipe/floaters.cpp
@@ -111,7 +111,7 @@ void Floaters::genFlies(Scene *sc, int x, int y, int priority, int flags) {
 	else
 		nummoves = ani->_movement->_dynamicPhases.size();
 
-	ani->_movement->setDynamicPhaseIndex(g_fp->_rnd->getRandomNumber(nummoves - 1));
+	ani->_movement->setDynamicPhaseIndex(g_fp->_rnd.getRandomNumber(nummoves - 1));
 
 	FloaterArray2 *arr2 = new FloaterArray2;
 
@@ -165,7 +165,7 @@ void Floaters::update() {
 				if (_array2[i]->val4 == _array2[i]->val2 && _array2[i]->val5 == _array2[i]->val3) {
 					_array2[i]->val9 = 0.0;
 
-					_array2[i]->val13 = g_fp->_rnd->getRandomNumber(200) + 20;
+					_array2[i]->val13 = g_fp->_rnd.getRandomNumber(200) + 20;
 
 					if (_array2[i]->fflags & 1) {
 						g_fp->_currentScene->deleteStaticANIObject(_array2[i]->ani);
@@ -190,7 +190,7 @@ void Floaters::update() {
 					_array2[i]->val3 = _array2[i]->val7;
 				} else {
 					if (_array2[i]->fflags & 2) {
-						int idx1 = g_fp->_rnd->getRandomNumber(_array1.size() - 1);
+						int idx1 = g_fp->_rnd.getRandomNumber(_array1.size() - 1);
 
 						_array2[i]->val2 = _array1[idx1]->val1;
 						_array2[i]->val3 = _array1[idx1]->val2;
@@ -202,8 +202,8 @@ void Floaters::update() {
 
 						_hRgn->getBBox(&rect);
 
-						int x2 = rect.left + g_fp->_rnd->getRandomNumber(rect.right - rect.left);
-						int y2 = rect.top + g_fp->_rnd->getRandomNumber(rect.bottom - rect.top);
+						int x2 = rect.left + g_fp->_rnd.getRandomNumber(rect.right - rect.left);
+						int y2 = rect.top + g_fp->_rnd.getRandomNumber(rect.bottom - rect.top);
 
 						if (_hRgn->pointInRegion(x2, y2)) {
 							int dx = _array2[i]->val2 - x2;

--- a/engines/fullpipe/floaters.h
+++ b/engines/fullpipe/floaters.h
@@ -23,6 +23,9 @@
 #ifndef FULLPIPE_FLOATERS_H
 #define FULLPIPE_FLOATERS_H
 
+#include "common/array.h"
+#include "common/ptr.h"
+
 namespace Fullpipe {
 
 class StaticANIObject;
@@ -52,18 +55,16 @@ struct FloaterArray2 {
 	int val15;
 	int fflags;
 
-	FloaterArray2() : ani(0), val2(0), val3(0), val4(0), val5(0), val6(0), val7(0), val8(0),
+	FloaterArray2() : ani(nullptr), val2(0), val3(0), val4(0), val5(0), val6(0), val7(0), val8(0),
 		val9(0.0), val11(0.0), val13(0), countdown(0), val15(0), fflags(0) {}
 };
 
 class Floaters {
 public:
-	ReactPolygonal *_hRgn;
-	Common::Array<FloaterArray1 *> _array1;
-	Common::Array<FloaterArray2 *> _array2;
+	Common::ScopedPtr<ReactPolygonal> _hRgn;
+	Common::Array<FloaterArray1> _array1;
+	Common::Array<FloaterArray2> _array2;
 
-	Floaters() { _hRgn = 0; }
-	~Floaters();
 	void init(GameVar *var);
 	void genFlies(Scene *sc, int x, int y, int priority, int flags);
 	void update();

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -262,6 +262,10 @@ void FullpipeEngine::restartGame() {
 	}
 }
 
+bool FullpipeEngine::shouldQuit() {
+	return !_gameContinue || Engine::shouldQuit();
+}
+
 Common::Error FullpipeEngine::loadGameState(int slot) {
 	if (_gameLoader->readSavegame(getSavegameFile(slot)))
 		return Common::kNoError;
@@ -312,15 +316,16 @@ Common::Error FullpipeEngine::run() {
 	loadAllScenes();
 #endif
 
-	_gameContinue = true;
-
 	int time1 = g_fp->_system->getMillis();
 
 	// Center mouse
 	_system->warpMouse(400, 300);
 
-	while (_gameContinue) {
+	for (;;) {
 		updateEvents();
+		if (shouldQuit()) {
+			break;
+		}
 
 		int time2 = g_fp->_system->getMillis();
 
@@ -436,8 +441,7 @@ void FullpipeEngine::updateEvents() {
 			_mouseScreenPos = event.mouse;
 			break;
 		case Common::EVENT_QUIT:
-			_gameContinue = false;
-			break;
+			return;
 		case Common::EVENT_RBUTTONDOWN:
 			if (!_inputArFlag && (_updateTicks - _lastInputTicks) >= 2) {
 				ex = new ExCommand(0, 17, 107, event.mouse.x, event.mouse.y, 0, 1, 0, 0, 0);

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -48,7 +48,10 @@ namespace Fullpipe {
 FullpipeEngine *g_fp = 0;
 Vars *g_vars = 0;
 
-FullpipeEngine::FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc) {
+FullpipeEngine::FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc) :
+	Engine(syst),
+	_gameDescription(gameDesc),
+	_rnd("fullpipe") {
 	DebugMan.addDebugChannel(kDebugPathfinding, "path", "Pathfinding");
 	DebugMan.addDebugChannel(kDebugDrawing, "drawing", "Drawing");
 	DebugMan.addDebugChannel(kDebugLoading, "loading", "Scene loading");
@@ -69,7 +72,6 @@ FullpipeEngine::FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc)
 	_sfxVolume = ConfMan.getInt("sfx_volume") * 39 - 10000;
 	_musicVolume = ConfMan.getInt("music_volume");
 
-	_rnd = new Common::RandomSource("fullpipe");
 	_console = 0;
 
 	_gameProjectVersion = 0;
@@ -203,7 +205,6 @@ FullpipeEngine::FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc)
 }
 
 FullpipeEngine::~FullpipeEngine() {
-	delete _rnd;
 	delete _console;
 	delete _globalMessageQueueList;
 	delete _soundStream1;

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -76,7 +76,6 @@ FullpipeEngine::FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc)
 	_pictureScale = 8;
 	_scrollSpeed = 0;
 	_currSoundListCount = 0;
-	_globalPalette = 0;
 
 	_updateTicks = 0;
 	_lastInputTicks = 0;
@@ -290,6 +289,7 @@ Common::Error FullpipeEngine::run() {
 	_console = new Console(this);
 
 	initialize();
+	_globalPalette = &_defaultPalette;
 
 	_isSaveAllowed = false;
 
@@ -338,6 +338,7 @@ Common::Error FullpipeEngine::run() {
 			freeGameLoader();
 			_currentScene = 0;
 			_updateTicks = 0;
+			_globalPalette = &_defaultPalette;
 
 			loadGam("fullpipe.gam");
 			_needRestart = false;

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -137,7 +137,6 @@ FullpipeEngine::FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc)
 	_loaderScene = nullptr;
 	_scene2 = nullptr;
 	_scene3 = nullptr;
-	_movTable = nullptr;
 	_messageHandlers = nullptr;
 
 	_updateScreenCallback = nullptr;
@@ -452,7 +451,6 @@ void FullpipeEngine::updateEvents() {
 
 void FullpipeEngine::freeGameLoader() {
 	setCursor(0);
-	delete _movTable;
 	_floaters->stopAll();
 	_gameLoader.reset();
 	_currentScene = 0;

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -77,7 +77,6 @@ class GameObject;
 class GlobalMessageQueueList;
 struct MessageHandler;
 class MessageQueue;
-struct MovTable;
 class AniHandler;
 class NGIArchive;
 class PictureObject;
@@ -86,6 +85,7 @@ class Scene;
 class SoundList;
 class StaticANIObject;
 class Vars;
+typedef Common::Array<int16> MovTable;
 typedef Common::Array<int32> Palette;
 
 int global_messageHandler1(ExCommand *cmd);
@@ -217,7 +217,7 @@ public:
 
 	Common::ScopedPtr<BehaviorManager> _behaviorManager;
 
-	MovTable *_movTable;
+	Common::ScopedPtr<MovTable> _movTable;
 
 	Common::ScopedPtr<Floaters> _floaters;
 	Common::ScopedPtr<AniHandler> _aniHandler;

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -87,6 +87,7 @@ class StaticANIObject;
 class Vars;
 typedef Common::Array<int16> MovTable;
 typedef Common::Array<int32> Palette;
+typedef Common::Array<Common::Point> PointList;
 
 int global_messageHandler1(ExCommand *cmd);
 int global_messageHandler2(ExCommand *cmd);

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -23,12 +23,15 @@
 #ifndef FULLPIPE_FULLPIPE_H
 #define FULLPIPE_FULLPIPE_H
 
+#include "audio/mixer.h"
 #include "common/scummsys.h"
 #include "common/events.h"
 #include "common/keyboard.h"
+#include "common/ptr.h"
 #include "common/random.h"
 #include "common/savefile.h"
 #include "common/system.h"
+#include "graphics/surface.h"
 
 #include "engines/engine.h"
 
@@ -101,8 +104,8 @@ public:
 	FullpipeEngine(OSystem *syst, const ADGameDescription *gameDesc);
 	virtual ~FullpipeEngine();
 
-	Console *_console;
-	GUI::Debugger *getDebugger() { return _console; }
+	Console _console;
+	GUI::Debugger *getDebugger() { return &_console; }
 
 	void initialize();
 	void restartGame();
@@ -123,10 +126,10 @@ public:
 
 	void updateEvents();
 
-	Graphics::Surface *_backgroundSurface;
-	Graphics::PixelFormat *_origFormat;
+	Graphics::Surface _backgroundSurface;
+	Graphics::PixelFormat _origFormat;
 
-	GameLoader *_gameLoader;
+	Common::ScopedPtr<GameLoader> _gameLoader;
 	GameProject *_gameProject;
 	bool loadGam(const char *fname, int scene = 0);
 
@@ -187,7 +190,7 @@ public:
 	void updateTrackDelay();
 	void startSceneTrack();
 	void startSoundStream1(const Common::String &trackName);
-	void playOggSound(const Common::String &trackName, Audio::SoundHandle *stream);
+	void playOggSound(const Common::String &trackName, Audio::SoundHandle &stream);
 	void stopSoundStream2();
 	void stopAllSoundStreams();
 	void stopAllSoundInstances(int id);
@@ -197,7 +200,7 @@ public:
 	int _sfxVolume;
 	int _musicVolume;
 
-	GlobalMessageQueueList *_globalMessageQueueList;
+	Common::ScopedPtr<GlobalMessageQueueList> _globalMessageQueueList;
 	MessageHandler *_messageHandlers;
 
 	int _msgX;
@@ -212,12 +215,12 @@ public:
 	int _mouseVirtY;
 	Common::Point _mouseScreenPos;
 
-	BehaviorManager *_behaviorManager;
+	Common::ScopedPtr<BehaviorManager> _behaviorManager;
 
 	MovTable *_movTable;
 
-	Floaters *_floaters;
-	AniHandler *_aniHandler;
+	Common::ScopedPtr<Floaters> _floaters;
+	Common::ScopedPtr<AniHandler> _aniHandler;
 
 	Common::Array<Common::Point *> _arcadeKeys;
 
@@ -333,10 +336,10 @@ public:
 	void lift_openLift();
 
 	GameVar *_musicGameVar;
-	Audio::SoundHandle *_soundStream1;
-	Audio::SoundHandle *_soundStream2;
-	Audio::SoundHandle *_soundStream3;
-	Audio::SoundHandle *_soundStream4;
+	Audio::SoundHandle _soundStream1;
+	Audio::SoundHandle _soundStream2;
+	Audio::SoundHandle _soundStream3;
+	Audio::SoundHandle _soundStream4;
 
 	bool _stream2playing;
 

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -283,7 +283,7 @@ public:
 	int getObjectEnumState(const Common::String &name, const char *state);
 
 	void sceneAutoScrolling();
-	bool sceneSwitcher(EntranceInfo *entrance);
+	bool sceneSwitcher(const EntranceInfo &entrance);
 	Scene *accessScene(int sceneId);
 	void setSceneMusicParameters(GameVar *var);
 	int convertScene(int scene);

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -83,6 +83,7 @@ class Scene;
 class SoundList;
 class StaticANIObject;
 class Vars;
+typedef Common::Array<int32> Palette;
 
 int global_messageHandler1(ExCommand *cmd);
 int global_messageHandler2(ExCommand *cmd);
@@ -151,7 +152,8 @@ public:
 	Scene *_scene3;
 	StaticANIObject *_aniMan;
 	StaticANIObject *_aniMan2;
-	byte *_globalPalette;
+	Palette _defaultPalette;
+	const Palette *_globalPalette;
 
 	InputController *_inputController;
 	bool _inputDisabled;

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -115,7 +115,7 @@ public:
 	bool isDemo();
 	Common::Language getLanguage() const;
 
-	Common::RandomSource *_rnd;
+	Common::RandomSource _rnd;
 
 	Common::KeyCode _keyState;
 	uint16 _buttonState;

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -106,6 +106,7 @@ public:
 
 	void initialize();
 	void restartGame();
+	bool shouldQuit();
 
 	void setMusicAllowed(int val) { _musicAllowed = val; }
 

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -223,7 +223,7 @@ public:
 	Common::ScopedPtr<Floaters> _floaters;
 	Common::ScopedPtr<AniHandler> _aniHandler;
 
-	Common::Array<Common::Point *> _arcadeKeys;
+	Common::Array<Common::Point> _arcadeKeys;
 
 	void initMap();
 	void updateMap(PreloadItem *pre);

--- a/engines/fullpipe/gameloader.cpp
+++ b/engines/fullpipe/gameloader.cpp
@@ -420,7 +420,7 @@ bool GameLoader::unloadScene(int sceneId) {
 	_sc2array[sceneTag]._motionController->detachAllObjects();
 
 	delete tag->_scene;
-	tag->_scene = 0;
+	tag->_scene = nullptr;
 
 	_sc2array[sceneTag]._isLoaded = 0;
 	_sc2array[sceneTag]._scene = 0;

--- a/engines/fullpipe/gameloader.cpp
+++ b/engines/fullpipe/gameloader.cpp
@@ -286,7 +286,7 @@ bool preloadCallback(PreloadItem &pre, int flag) {
 
 		if (g_fp->_soundEnabled) {
 			g_fp->_currSoundListCount = 1;
-			g_fp->_currSoundList1[0] = g_fp->accessScene(SC_COMMON)->_soundList;
+			g_fp->_currSoundList1[0] = g_fp->accessScene(SC_COMMON)->_soundList.get();
 		}
 
 		g_vars->scene18_inScene18p1 = false;

--- a/engines/fullpipe/gameloader.cpp
+++ b/engines/fullpipe/gameloader.cpp
@@ -253,7 +253,7 @@ bool GameLoader::gotoScene(int sceneId, int entranceId) {
 bool preloadCallback(PreloadItem &pre, int flag) {
 	if (flag) {
 		if (flag == 50)
-			g_fp->_aniMan->preloadMovements(g_fp->_movTable);
+			g_fp->_aniMan->preloadMovements(g_fp->_movTable.get());
 
 		StaticANIObject *pbar = g_fp->_loaderScene->getStaticANIObject1ById(ANI_PBAR, -1);
 

--- a/engines/fullpipe/gameloader.cpp
+++ b/engines/fullpipe/gameloader.cpp
@@ -347,8 +347,8 @@ bool preloadCallback(PreloadItem &pre, int flag) {
 	return true;
 }
 
-void GameLoader::addPreloadItem(PreloadItem *item) {
-	_preloadItems.push_back(new PreloadItem(*item));
+void GameLoader::addPreloadItem(const PreloadItem &item) {
+	_preloadItems.push_back(item);
 }
 
 bool GameLoader::preloadScene(int sceneId, int entranceId) {
@@ -363,7 +363,7 @@ bool GameLoader::preloadScene(int sceneId, int entranceId) {
 	int idx = -1;
 
 	for (uint i = 0; i < _preloadItems.size(); i++)
-		if (_preloadItems[i]->preloadId1 == sceneId && _preloadItems[i]->preloadId2 == entranceId) {
+		if (_preloadItems[i].preloadId1 == sceneId && _preloadItems[i].preloadId2 == entranceId) {
 			idx = i;
 			break;
 		}
@@ -375,7 +375,7 @@ bool GameLoader::preloadScene(int sceneId, int entranceId) {
 	}
 
 	if (_preloadCallback) {
-		if (!_preloadCallback(*_preloadItems[idx], 0))
+		if (!_preloadCallback(_preloadItems[idx], 0))
 			return false;
 	}
 
@@ -387,19 +387,19 @@ bool GameLoader::preloadScene(int sceneId, int entranceId) {
 	unloadScene(sceneId);
 
 	if (_preloadCallback)
-		_preloadCallback(*_preloadItems[idx], 50);
+		_preloadCallback(_preloadItems[idx], 50);
 
-	loadScene(_preloadItems[idx]->sceneId);
+	loadScene(_preloadItems[idx].sceneId);
 
-	ExCommand *ex = new ExCommand(_preloadItems[idx]->sceneId, 17, 62, 0, 0, 0, 1, 0, 0, 0);
+	ExCommand *ex = new ExCommand(_preloadItems[idx].sceneId, 17, 62, 0, 0, 0, 1, 0, 0, 0);
 	ex->_excFlags = 2;
-	ex->_param = _preloadItems[idx]->param;
+	ex->_param = _preloadItems[idx].param;
 
 	_preloadSceneId = 0;
 	_preloadEntranceId = 0;
 
 	if (_preloadCallback)
-		_preloadCallback(*_preloadItems[idx], 100);
+		_preloadCallback(_preloadItems[idx], 100);
 
 	ex->postMessage();
 
@@ -633,14 +633,13 @@ bool PreloadItems::load(MfcArchive &file) {
 
 	clear();
 
+	resize(count);
 	for (int i = 0; i < count; i++) {
-		PreloadItem *t = new PreloadItem();
-		t->preloadId1 = file.readUint32LE();
-		t->preloadId2 = file.readUint32LE();
-		t->sceneId = file.readUint32LE();
-		t->param = file.readSint32LE();
-
-		push_back(t);
+		PreloadItem &t = (*this)[i];
+		t.preloadId1 = file.readUint32LE();
+		t.preloadId2 = file.readUint32LE();
+		t.sceneId = file.readUint32LE();
+		t.param = file.readSint32LE();
 	}
 
 	return true;

--- a/engines/fullpipe/gameloader.cpp
+++ b/engines/fullpipe/gameloader.cpp
@@ -54,8 +54,6 @@ GameLoader::GameLoader() {
 	_interactionController = new InteractionController();
 	_inputController = new InputController();
 
-	_gameProject = 0;
-
 	addMessageHandlerByIndex(global_messageHandler2, 0, 0);
 	insertMessageHandler(global_messageHandler3, 0, 128);
 	insertMessageHandler(global_messageHandler4, 0, 1);
@@ -77,11 +75,8 @@ GameLoader::GameLoader() {
 }
 
 GameLoader::~GameLoader() {
-	delete _gameProject;
 	delete _interactionController;
 	delete _inputController;
-
-	g_fp->_gameLoader = 0;
 
 	for (uint i = 0; i < _sc2array.size(); i++) {
 		if (_sc2array[i]._defPicAniInfos)
@@ -112,11 +107,11 @@ bool GameLoader::load(MfcArchive &file) {
 	_gameName = file.readPascalString();
 	debugC(1, kDebugLoading, "_gameName: %s", _gameName.c_str());
 
-	_gameProject = new GameProject();
+	_gameProject.reset(new GameProject());
 
 	_gameProject->load(file);
 
-	g_fp->_gameProject = _gameProject;
+	g_fp->_gameProject = _gameProject.get();
 
 	if (g_fp->_gameProjectVersion < 12) {
 		error("Old gameProjectVersion: %d", g_fp->_gameProjectVersion);

--- a/engines/fullpipe/gameloader.cpp
+++ b/engines/fullpipe/gameloader.cpp
@@ -38,12 +38,32 @@ Inventory2 *getGameLoaderInventory() {
 	return &g_fp->_gameLoader->_inventory;
 }
 
-MctlCompound *getSc2MctlCompoundBySceneId(int16 sceneId) {
-	for (uint i = 0; i < g_fp->_gameLoader->_sc2array.size(); i++)
-		if (g_fp->_gameLoader->_sc2array[i]._sceneId == sceneId)
-			return (MctlCompound *)g_fp->_gameLoader->_sc2array[i]._motionController;
+static MotionController *getMotionControllerBySceneId(int16 sceneId) {
+	for (uint i = 0; i < g_fp->_gameLoader->_sc2array.size(); i++) {
+		if (g_fp->_gameLoader->_sc2array[i]._sceneId == sceneId) {
+			return g_fp->_gameLoader->_sc2array[i]._motionController;
+		}
+	}
 
-	return 0;
+	return nullptr;
+}
+
+MovGraph *getSc2MovGraphBySceneId(int16 sceneId) {
+	MotionController *mc = getMotionControllerBySceneId(sceneId);
+	if (mc) {
+		assert(mc->_objtype == kObjTypeMovGraph);
+		return static_cast<MovGraph *>(mc);
+	}
+	return nullptr;
+}
+
+MctlCompound *getSc2MctlCompoundBySceneId(int16 sceneId) {
+	MotionController *mc = getMotionControllerBySceneId(sceneId);
+	if (mc) {
+		assert(mc->_objtype == kObjTypeMctlCompound);
+		return static_cast<MctlCompound *>(mc);
+	}
+	return nullptr;
 }
 
 InteractionController *getGameLoaderInteractionController() {
@@ -136,7 +156,7 @@ bool GameLoader::load(MfcArchive &file) {
 
 		debugC(1, kDebugLoading, "sc: %s", tmp);
 
-		_sc2array[i].loadFile((const char *)tmp);
+		_sc2array[i].loadFile(tmp);
 	}
 
 	_preloadItems.load(file);
@@ -146,7 +166,7 @@ bool GameLoader::load(MfcArchive &file) {
 
 	debugC(1, kDebugLoading, "_field_FA: %d\n_field_F8: %d", _field_FA, _field_F8);
 
-	_gameVar = (GameVar *)file.readClass();
+	_gameVar = file.readClass<GameVar>();
 
 	return true;
 }
@@ -615,7 +635,7 @@ bool Sc2::load(MfcArchive &file) {
 
 	_sceneId = file.readUint16LE();
 
-	_motionController = (MotionController *)file.readClass();
+	_motionController = file.readClass<MotionController>();
 
 	_count1 = file.readUint32LE();
 	debugC(4, kDebugLoading, "count1: %d", _count1);

--- a/engines/fullpipe/gameloader.h
+++ b/engines/fullpipe/gameloader.h
@@ -23,6 +23,7 @@
 #ifndef FULLPIPE_GAMELOADER_H
 #define FULLPIPE_GAMELOADER_H
 
+#include "common/ptr.h"
 #include "engines/savestate.h"
 
 #include "fullpipe/objects.h"
@@ -83,7 +84,7 @@ struct FullpipeSavegameHeader {
 	uint32 date;
 	uint16 time;
 	uint32 playtime;
-	Graphics::Surface *thumbnail;
+	Common::SharedPtr<Graphics::Surface> thumbnail;
 };
 
 struct SaveHeader {

--- a/engines/fullpipe/gameloader.h
+++ b/engines/fullpipe/gameloader.h
@@ -39,6 +39,7 @@ class MctlCompound;
 class InputController;
 class InteractionController;
 class MotionController;
+class MovGraph;
 
 class Sc2 : public CObject {
  public:
@@ -148,6 +149,7 @@ void parseSavegameHeader(Fullpipe::FullpipeSavegameHeader &header, SaveStateDesc
 Inventory2 *getGameLoaderInventory();
 InteractionController *getGameLoaderInteractionController();
 MctlCompound *getSc2MctlCompoundBySceneId(int16 sceneId);
+MovGraph *getSc2MovGraphBySceneId(int16 sceneId);
 MctlCompound *getCurrSceneSc2MotionController();
 
 } // End of namespace Fullpipe

--- a/engines/fullpipe/gameloader.h
+++ b/engines/fullpipe/gameloader.h
@@ -71,7 +71,7 @@ struct PreloadItem {
 
 bool preloadCallback(PreloadItem &pre, int flag);
 
-class PreloadItems : public Common::Array<PreloadItem *>, public CObject {
+class PreloadItems : public Common::Array<PreloadItem>, public CObject {
  public:
 	virtual bool load(MfcArchive &file);
 };
@@ -105,7 +105,7 @@ class GameLoader : public CObject {
 	bool preloadScene(int sceneId, int entranceId);
 	bool unloadScene(int sceneId);
 
-	void addPreloadItem(PreloadItem *item);
+	void addPreloadItem(const PreloadItem &item);
 
 	void updateSystems(int counterdiff);
 

--- a/engines/fullpipe/gameloader.h
+++ b/engines/fullpipe/gameloader.h
@@ -46,19 +46,17 @@ class Sc2 : public CObject {
 	int16 _sceneId;
 	int16 _field_2;
 	Scene *_scene;
+	/** owned */
 	MotionController *_motionController;
-	int32 *_data1; // FIXME, could be a struct
-	int _count1;
-	PicAniInfo **_defPicAniInfos;
-	int _defPicAniInfosCount;
-	PicAniInfo **_picAniInfos;
-	int _picAniInfosCount;
-	int _isLoaded;
-	EntranceInfo **_entranceData;
-	int _entranceDataCount;
+	Common::Array<int32> _data1; // FIXME, could be a struct
+	PicAniInfoList _defPicAniInfos;
+	PicAniInfoList _picAniInfos;
+	bool _isLoaded;
+	Common::Array<EntranceInfo> _entranceData;
 
  public:
 	Sc2();
+	virtual ~Sc2();
 	virtual bool load(MfcArchive &file);
 };
 
@@ -112,9 +110,9 @@ class GameLoader : public CObject {
 	void updateSystems(int counterdiff);
 
 	int getSceneTagBySceneId(int sceneId, SceneTag **st);
-	void applyPicAniInfos(Scene *sc, PicAniInfo **picAniInfo, int picAniInfoCount);
+	void applyPicAniInfos(Scene *sc, const PicAniInfoList &picAniInfo);
 	void saveScenePicAniInfos(int sceneId);
-	PicAniInfo **savePicAniInfos(Scene *sc, int flag1, int flag2, int *picAniInfoCount);
+	PicAniInfoList savePicAniInfos(Scene *sc, int flag1, int flag2);
 
 	bool readSavegame(const char *fname);
 	bool writeSavegame(Scene *sc, const char *fname);

--- a/engines/fullpipe/gameloader.h
+++ b/engines/fullpipe/gameloader.h
@@ -121,7 +121,7 @@ class GameLoader : public CObject {
 
 	void restoreDefPicAniInfos();
 
-	GameProject *_gameProject;
+	Common::ScopedPtr<GameProject> _gameProject;
 	InteractionController *_interactionController;
 	InputController *_inputController;
 	Inventory2 _inventory;

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -512,7 +512,7 @@ bool Picture::load(MfcArchive &file) {
 		setAOIDs();
 	}
 
-	assert (g_fp->_gameProjectVersion >= 12);
+	assert(g_fp->_gameProjectVersion >= 12);
 
 	_alpha = file.readUint32LE() & 0xff;
 

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -266,9 +266,6 @@ GameObject::GameObject(GameObject *src) {
 	_field_8 = src->_field_8;
 }
 
-GameObject::~GameObject() {
-}
-
 bool GameObject::load(MfcArchive &file) {
 	debugC(5, kDebugLoading, "GameObject::load()");
 	_odelay = 0;

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -664,9 +664,9 @@ void Picture::setPaletteData(const Palette &pal) {
 	}
 }
 
-void Picture::copyMemoryObject2(Picture *src) {
-	if (_width == src->_width && _height == src->_height) {
-		if (src->_memoryObject2 && src->_memoryObject2->_rows && _memoryObject2) {
+void Picture::copyMemoryObject2(Picture &src) {
+	if (_width == src._width && _height == src._height) {
+		if (src._memoryObject2 && src._memoryObject2->_rows && _memoryObject2) {
 			byte *data = loadData();
 			_memoryObject2->copyData(data, _dataSize);
 			setAOIDs();

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -626,7 +626,7 @@ void Picture::drawRotated(int x, int y, int angle) {
 }
 
 void Picture::displayPicture() {
-	if (!g_fp->_gameContinue)
+	if (g_fp->shouldQuit())
 		return;
 
 	getData();
@@ -644,7 +644,7 @@ void Picture::displayPicture() {
 	g_fp->_system->delayMillis(10);
 	g_fp->_system->updateScreen();
 
-	while (g_fp->_gameContinue) {
+	while (!g_fp->shouldQuit()) {
 		g_fp->updateEvents();
 		g_fp->_system->delayMillis(10);
 		g_fp->_system->updateScreen();

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -635,8 +635,8 @@ void Picture::displayPicture() {
 	if (!_dataSize)
 		return;
 
-	g_fp->_backgroundSurface->fillRect(Common::Rect(0, 0, 800, 600), 0);
-	g_fp->_system->copyRectToScreen(g_fp->_backgroundSurface->getBasePtr(0, 0), g_fp->_backgroundSurface->pitch, 0, 0, 800, 600);
+	g_fp->_backgroundSurface.fillRect(Common::Rect(0, 0, 800, 600), 0);
+	g_fp->_system->copyRectToScreen(g_fp->_backgroundSurface.getBasePtr(0, 0), g_fp->_backgroundSurface.pitch, 0, 0, 800, 600);
 
 	draw(0, 0, 0, 0);
 
@@ -808,8 +808,8 @@ void Bitmap::putDib(int x, int y, const Palette &palette, byte alpha) {
 
 	int alphac = TS_ARGB(0xff, alpha, 0xff, 0xff);
 
-	_surface->blit(*g_fp->_backgroundSurface, x1, y1, _flipping, &sub, alphac);
-	g_fp->_system->copyRectToScreen(g_fp->_backgroundSurface->getBasePtr(x1, y1), g_fp->_backgroundSurface->pitch, x1, y1, sub.width(), sub.height());
+	_surface->blit(g_fp->_backgroundSurface, x1, y1, _flipping, &sub, alphac);
+	g_fp->_system->copyRectToScreen(g_fp->_backgroundSurface.getBasePtr(x1, y1), g_fp->_backgroundSurface.pitch, x1, y1, sub.width(), sub.height());
 }
 
 bool Bitmap::putDibRB(byte *pixels, const Palette &palette) {
@@ -967,7 +967,7 @@ void Bitmap::colorFill(uint32 *dest, int len, int32 color) {
 #endif
 	byte r, g, b;
 
-	g_fp->_origFormat->colorToRGB(color, r, g, b);
+	g_fp->_origFormat.colorToRGB(color, r, g, b);
 
 	uint32 c = TS_ARGB(0xff, r, g, b);
 
@@ -990,7 +990,7 @@ void Bitmap::paletteFill(uint32 *dest, byte *src, int len, const Palette &palett
 	byte r, g, b;
 
 	for (int i = 0; i < len; i++) {
-		g_fp->_origFormat->colorToRGB(READ_LE_UINT32(&palette[*src++]) & 0xffff, r, g, b);
+		g_fp->_origFormat.colorToRGB(palette[*src++] & 0xffff, r, g, b);
 
 		*dest++ = TS_ARGB(0xff, r, g, b);
 	}
@@ -1019,7 +1019,7 @@ void Bitmap::copierKeyColor(uint32 *dest, byte *src, int len, int keyColor, cons
 	if (!cb05_format) {
 		for (int i = 0; i < len; i++) {
 			if (*src != keyColor) {
-				g_fp->_origFormat->colorToRGB(READ_LE_UINT32(&palette[*src]) & 0xffff, r, g, b);
+				g_fp->_origFormat.colorToRGB(palette[*src] & 0xffff, r, g, b);
 				*dest = TS_ARGB(0xff, r, g, b);
 			}
 
@@ -1031,7 +1031,7 @@ void Bitmap::copierKeyColor(uint32 *dest, byte *src, int len, int keyColor, cons
 
 		for (int i = 0; i < len; i++) {
 			if (*src16 != 0) {
-				g_fp->_origFormat->colorToRGB(READ_LE_UINT16(src16) & 0xffff, r, g, b);
+				g_fp->_origFormat.colorToRGB(READ_LE_UINT16(src16), r, g, b);
 				*dest = TS_ARGB(0xff, r, g, b);
 			}
 
@@ -1063,7 +1063,7 @@ void Bitmap::copier(uint32 *dest, byte *src, int len, const Palette &palette, bo
 
 	if (!cb05_format) {
 		for (int i = 0; i < len; i++) {
-			g_fp->_origFormat->colorToRGB(READ_LE_UINT32(&palette[*src++]) & 0xffff, r, g, b);
+			g_fp->_origFormat.colorToRGB(palette[*src++] & 0xffff, r, g, b);
 
 			*dest++ = TS_ARGB(0xff, r, g, b);
 		}
@@ -1071,7 +1071,7 @@ void Bitmap::copier(uint32 *dest, byte *src, int len, const Palette &palette, bo
 		int16 *src16 = (int16 *)src;
 
 		for (int i = 0; i < len; i++) {
-			g_fp->_origFormat->colorToRGB(READ_LE_UINT32(src16++) & 0xffff, r, g, b);
+			g_fp->_origFormat.colorToRGB(READ_LE_UINT16(src16++), r, g, b);
 			*dest++ = TS_ARGB(0xff, r, g, b);
 		}
 	}
@@ -1203,7 +1203,7 @@ DynamicPhase *Shadows::findSize(int width, int height) {
 
 void FullpipeEngine::drawAlphaRectangle(int x1, int y1, int x2, int y2, int alpha) {
 	for (int y = y1; y < y2; y++) {
-		uint32 *ptr = (uint32 *)g_fp->_backgroundSurface->getBasePtr(x1, y);
+		uint32 *ptr = (uint32 *)g_fp->_backgroundSurface.getBasePtr(x1, y);
 
 		for (int x = x1; x < x2; x++) {
 			uint32 color = *ptr;
@@ -1222,8 +1222,8 @@ void FullpipeEngine::sceneFade(Scene *sc, bool direction) {
 		int ticks = g_fp->_system->getMillis();
 		sc->draw();
 
-		drawAlphaRectangle(0, 0, g_fp->_backgroundSurface->w, g_fp->_backgroundSurface->h, direction ? dim : 255 - dim);
-		g_fp->_system->copyRectToScreen(g_fp->_backgroundSurface->getBasePtr(0, 0), g_fp->_backgroundSurface->pitch, 0, 0, 800, 600);
+		drawAlphaRectangle(0, 0, g_fp->_backgroundSurface.w, g_fp->_backgroundSurface.h, direction ? dim : 255 - dim);
+		g_fp->_system->copyRectToScreen(g_fp->_backgroundSurface.getBasePtr(0, 0), g_fp->_backgroundSurface.pitch, 0, 0, 800, 600);
 
 		g_fp->_system->updateScreen();
 		ticks = g_fp->_system->getMillis() - ticks;

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -168,12 +168,6 @@ bool PictureObject::load(MfcArchive &file, bool bigPicture) {
 	return true;
 }
 
-Common::Point *PictureObject::getDimensions(Common::Point *p) {
-	_picture->getDimensions(p);
-
-	return p;
-}
-
 void PictureObject::draw() {
 	if (_flags & 1)
 		_picture->draw(_ox, _oy, 2, 0);
@@ -562,13 +556,6 @@ void Picture::init() {
 	_bitmap->_flags |= 0x1000000;
 }
 
-Common::Point *Picture::getDimensions(Common::Point *p) {
-	p->x = _width;
-	p->y = _height;
-
-	return p;
-}
-
 void Picture::getDibInfo() {
 	int off = _dataSize & ~0xf;
 
@@ -635,14 +622,13 @@ void Picture::draw(int x, int y, int style, int angle) {
 		pal = g_fp->_globalPalette;
 	}
 
-	Common::Point point;
-
 	switch (style) {
-	case 1:
+	case 1: {
 		//flip
-		getDimensions(&point);
-		_bitmap->flipVertical()->drawShaded(1, x1, y1 + 30 + point.y, pal, _alpha);
+		const Dims dims = getDimensions();
+		_bitmap->flipVertical()->drawShaded(1, x1, y1 + 30 + dims.y, pal, _alpha);
 		break;
+	}
 	case 2:
 		//vrtSetFadeRatio(g_vrtDrawHandle, 0.34999999);
 		//vrtSetFadeTable(g_vrtDrawHandle, &unk_477F88, 1.0, 1000.0, 0, 0);
@@ -1214,18 +1200,16 @@ void Shadows::initMovement(Movement *mov) {
 	_items.clear();
 	_items.resize(num);
 
-	Common::Point point;
-
-	_items[0].dynPhase = (DynamicPhase *)mov->_staticsObj1;
-	_items[0].dynPhase->getDimensions(&point);
-	_items[0].width = point.x;
-	_items[0].height = point.y;
+	_items[0].dynPhase = mov->_staticsObj1;
+	Dims dims = _items[0].dynPhase->getDimensions();
+	_items[0].width = dims.x;
+	_items[0].height = dims.y;
 
 	for (uint i = 1; i < num; i++) {
 		_items[i].dynPhase = mov->getDynamicPhaseByIndex(i - 1);
-		_items[i].dynPhase->getDimensions(&point);
-		_items[i].width = point.x;
-		_items[i].height = point.y;
+		dims = _items[i].dynPhase->getDimensions();
+		_items[i].width = dims.x;
+		_items[i].height = dims.y;
 	}
 }
 

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -189,19 +189,17 @@ void PictureObject::drawAt(int x, int y) {
 		_picture->draw(x, y, 0, 0);
 }
 
-bool PictureObject::setPicAniInfo(PicAniInfo *picAniInfo) {
-	if (!(picAniInfo->type & 2) || (picAniInfo->type & 1)) {
-		error("PictureObject::setPicAniInfo(): Wrong type: %d", picAniInfo->type);
-
-		return false;
+bool PictureObject::setPicAniInfo(const PicAniInfo &picAniInfo) {
+	if (!(picAniInfo.type & 2) || (picAniInfo.type & 1)) {
+		error("PictureObject::setPicAniInfo(): Wrong type: %d", picAniInfo.type);
 	}
 
-	if (picAniInfo->type & 2) {
-		setOXY(picAniInfo->ox, picAniInfo->oy);
-		_priority = picAniInfo->priority;
-		_odelay = picAniInfo->field_8;
-		setFlags(picAniInfo->flags);
-		_field_8 = picAniInfo->field_24;
+	if (picAniInfo.type & 2) {
+		setOXY(picAniInfo.ox, picAniInfo.oy);
+		_priority = picAniInfo.priority;
+		_odelay = picAniInfo.field_8;
+		setFlags(picAniInfo.flags);
+		_field_8 = picAniInfo.field_24;
 
 		return true;
 	}
@@ -332,17 +330,17 @@ void GameObject::renumPictures(Common::Array<PictureObject *> *lst) {
 	free(buf);
 }
 
-bool GameObject::getPicAniInfo(PicAniInfo *info) {
+bool GameObject::getPicAniInfo(PicAniInfo &info) {
 	if (_objtype == kObjTypePictureObject) {
-		info->type = 2;
-		info->objectId = _id;
-		info->sceneId = 0;
-		info->field_8 = _odelay;
-		info->flags = _flags;
-		info->field_24 = _field_8;
-		info->ox = _ox;
-		info->oy = _oy;
-		info->priority = _priority;
+		info.type = 2;
+		info.objectId = _id;
+		info.sceneId = 0;
+		info.field_8 = _odelay;
+		info.flags = _flags;
+		info.field_24 = _field_8;
+		info.ox = _ox;
+		info.oy = _oy;
+		info.priority = _priority;
 
 		return true;
 	}
@@ -350,30 +348,30 @@ bool GameObject::getPicAniInfo(PicAniInfo *info) {
 	if (_objtype == kObjTypeStaticANIObject) {
 		StaticANIObject *ani = static_cast<StaticANIObject *>(this);
 
-		info->type = (ani->_messageQueueId << 16) | 1;
-		info->objectId = ani->_id;
-		info->field_8 = ani->_odelay;
-		info->sceneId = ani->_sceneId;
-		info->flags = ani->_flags;
-		info->field_24 = ani->_field_8;
+		info.type = (ani->_messageQueueId << 16) | 1;
+		info.objectId = ani->_id;
+		info.field_8 = ani->_odelay;
+		info.sceneId = ani->_sceneId;
+		info.flags = ani->_flags;
+		info.field_24 = ani->_field_8;
 		if (ani->_movement) {
-			info->ox = ani->_movement->_ox;
-			info->oy = ani->_movement->_oy;
+			info.ox = ani->_movement->_ox;
+			info.oy = ani->_movement->_oy;
 		} else {
-			info->ox = ani->_ox;
-			info->oy = ani->_oy;
+			info.ox = ani->_ox;
+			info.oy = ani->_oy;
 		}
-		info->priority = ani->_priority;
+		info.priority = ani->_priority;
 
 		if (ani->_statics)
-			info->staticsId = ani->_statics->_staticsId;
+			info.staticsId = ani->_statics->_staticsId;
 
 		if (ani->_movement) {
-			info->movementId = ani->_movement->_id;
-			info->dynamicPhaseIndex = ani->_movement->_currDynamicPhaseIndex;
+			info.movementId = ani->_movement->_id;
+			info.dynamicPhaseIndex = ani->_movement->_currDynamicPhaseIndex;
 		}
 
-		info->someDynamicPhaseIndex = ani->_someDynamicPhaseIndex;
+		info.someDynamicPhaseIndex = ani->_someDynamicPhaseIndex;
 
 		return true;
 	}
@@ -381,49 +379,49 @@ bool GameObject::getPicAniInfo(PicAniInfo *info) {
 	return false;
 }
 
-bool GameObject::setPicAniInfo(PicAniInfo *picAniInfo) {
-	if (!(picAniInfo->type & 3)) {
-		warning("StaticANIObject::setPicAniInfo(): Wrong type: %d", picAniInfo->type);
+bool GameObject::setPicAniInfo(const PicAniInfo &picAniInfo) {
+	if (!(picAniInfo.type & 3)) {
+		warning("StaticANIObject::setPicAniInfo(): Wrong type: %d", picAniInfo.type);
 
 		return false;
 	}
 
-	if (picAniInfo->type & 2) {
-		setOXY(picAniInfo->ox, picAniInfo->oy);
-		_priority = picAniInfo->priority;
-		_odelay = picAniInfo->field_8;
-		setFlags(picAniInfo->flags);
-		_field_8 = picAniInfo->field_24;
+	if (picAniInfo.type & 2) {
+		setOXY(picAniInfo.ox, picAniInfo.oy);
+		_priority = picAniInfo.priority;
+		_odelay = picAniInfo.field_8;
+		setFlags(picAniInfo.flags);
+		_field_8 = picAniInfo.field_24;
 
 		return true;
 	}
 
-	if (picAniInfo->type & 1 && _objtype == kObjTypeStaticANIObject) {
+	if (picAniInfo.type & 1 && _objtype == kObjTypeStaticANIObject) {
 		StaticANIObject *ani = static_cast<StaticANIObject *>(this);
 
-		ani->_messageQueueId = (picAniInfo->type >> 16) & 0xffff;
-		ani->_odelay = picAniInfo->field_8;
-		ani->setFlags(picAniInfo->flags);
-		ani->_field_8 = picAniInfo->field_24;
+		ani->_messageQueueId = (picAniInfo.type >> 16) & 0xffff;
+		ani->_odelay = picAniInfo.field_8;
+		ani->setFlags(picAniInfo.flags);
+		ani->_field_8 = picAniInfo.field_24;
 
-		if (picAniInfo->staticsId) {
-			ani->_statics = ani->getStaticsById(picAniInfo->staticsId);
+		if (picAniInfo.staticsId) {
+			ani->_statics = ani->getStaticsById(picAniInfo.staticsId);
 		} else {
 			ani->_statics = 0;
 		}
 
-		if (picAniInfo->movementId) {
-			ani->_movement = ani->getMovementById(picAniInfo->movementId);
+		if (picAniInfo.movementId) {
+			ani->_movement = ani->getMovementById(picAniInfo.movementId);
 			if (ani->_movement)
-				ani->_movement->setDynamicPhaseIndex(picAniInfo->dynamicPhaseIndex);
+				ani->_movement->setDynamicPhaseIndex(picAniInfo.dynamicPhaseIndex);
 		} else {
 			ani->_movement = 0;
 		}
 
-		ani->setOXY(picAniInfo->ox, picAniInfo->oy);
-		ani->_priority = picAniInfo->priority;
+		ani->setOXY(picAniInfo.ox, picAniInfo.oy);
+		ani->_priority = picAniInfo.priority;
 
-		ani->setSomeDynamicPhaseIndex(picAniInfo->someDynamicPhaseIndex);
+		ani->setSomeDynamicPhaseIndex(picAniInfo.someDynamicPhaseIndex);
 
 		return true;
 	}

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -707,7 +707,7 @@ int Picture::getPixelAtPosEx(int x, int y) {
 
 	warning("STUB: Picture::getPixelAtPosEx(%d, %d)", x, y);
 
-	// It looks like this doesn't really work. TODO. FIXME
+	// TODO: It looks like this doesn't really work.
 	if (x < (g_fp->_pictureScale + _width - 1) / g_fp->_pictureScale &&
 			y < (g_fp->_pictureScale + _height - 1) / g_fp->_pictureScale &&
 			_memoryObject2 != 0 && _memoryObject2->_rows != 0)

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -300,8 +300,8 @@ void GameObject::renumPictures(Common::Array<StaticANIObject *> *lst) {
 	int *buf = (int *)calloc(lst->size() + 2, sizeof(int));
 
 	for (uint i = 0; i < lst->size(); i++) {
-		if (_id == ((GameObject *)((*lst)[i]))->_id)
-			buf[((GameObject *)((*lst)[i]))->_odelay] = 1;
+		if (_id == (*lst)[i]->_id)
+			buf[(*lst)[i]->_odelay] = 1;
 	}
 
 	if (buf[_odelay]) {
@@ -318,8 +318,8 @@ void GameObject::renumPictures(Common::Array<PictureObject *> *lst) {
 	int *buf = (int *)calloc(lst->size() + 2, sizeof(int));
 
 	for (uint i = 0; i < lst->size(); i++) {
-		if (_id == ((GameObject *)((*lst)[i]))->_id)
-			buf[((GameObject *)((*lst)[i]))->_odelay] = 1;
+		if (_id == (*lst)[i]->_id)
+			buf[(*lst)[i]->_odelay] = 1;
 	}
 
 	if (buf[_odelay]) {
@@ -348,7 +348,7 @@ bool GameObject::getPicAniInfo(PicAniInfo *info) {
 	}
 
 	if (_objtype == kObjTypeStaticANIObject) {
-		StaticANIObject *ani = (StaticANIObject *)this;
+		StaticANIObject *ani = static_cast<StaticANIObject *>(this);
 
 		info->type = (ani->_messageQueueId << 16) | 1;
 		info->objectId = ani->_id;
@@ -398,8 +398,8 @@ bool GameObject::setPicAniInfo(PicAniInfo *picAniInfo) {
 		return true;
 	}
 
-	if (picAniInfo->type & 1) {
-		StaticANIObject *ani = (StaticANIObject *)this;
+	if (picAniInfo->type & 1 && _objtype == kObjTypeStaticANIObject) {
+		StaticANIObject *ani = static_cast<StaticANIObject *>(this);
 
 		ani->_messageQueueId = (picAniInfo->type >> 16) & 0xffff;
 		ani->_odelay = picAniInfo->field_8;

--- a/engines/fullpipe/gfx.cpp
+++ b/engines/fullpipe/gfx.cpp
@@ -524,7 +524,7 @@ void Picture::init() {
 
 	MemoryObject::getData();
 
-	_bitmap = BitmapPtr(new Bitmap());
+	_bitmap.reset(new Bitmap());
 
 	getDibInfo();
 
@@ -735,7 +735,7 @@ Bitmap::Bitmap(const Bitmap &src) {
 	_type = src._type;
 	_width = src._width;
 	_height = src._height;
-	_surface = TransSurfacePtr(src._surface);
+	_surface = src._surface;
 	_flipping = src._flipping;
 }
 
@@ -773,8 +773,7 @@ bool Bitmap::isPixelHitAtPos(int x, int y) {
 }
 
 void Bitmap::decode(byte *pixels, const Palette &palette) {
-	_surface = TransSurfacePtr(new Graphics::TransparentSurface);
-
+	_surface = TransSurfacePtr(new Graphics::TransparentSurface, Graphics::SurfaceDeleter());
 	_surface->create(_width, _height, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
 
 	if (_type == MKTAG('R', 'B', '\0', '\0'))

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -163,8 +163,8 @@ class GameObject : public CObject {
 	void clearFlags() { _flags = 0; }
 	Common::String getName() { return _objectName; }
 
-	bool getPicAniInfo(PicAniInfo *info);
-	bool setPicAniInfo(PicAniInfo *info);
+	bool getPicAniInfo(PicAniInfo &info);
+	bool setPicAniInfo(const PicAniInfo &info);
 };
 
 class PictureObject : public GameObject {
@@ -187,7 +187,7 @@ class PictureObject : public GameObject {
 	void draw();
 	void drawAt(int x, int y);
 
-	bool setPicAniInfo(PicAniInfo *picAniInfo);
+	bool setPicAniInfo(const PicAniInfo &picAniInfo);
 	bool isPointInside(int x, int y);
 	bool isPixelHitAtPos(int x, int y);
 	void setOXY2();

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -23,6 +23,8 @@
 #ifndef FULLPIPE_GFX_H
 #define FULLPIPE_GFX_H
 
+#include "common/ptr.h"
+
 namespace Graphics {
 	struct Surface;
 	struct TransparentSurface;
@@ -34,7 +36,10 @@ class DynamicPhase;
 class Movement;
 struct PicAniInfo;
 
+typedef Common::Array<int32> Palette;
 typedef Common::Point Dims;
+
+typedef Common::SharedPtr<Graphics::TransparentSurface> TransSurfacePtr;
 
 struct Bitmap {
 	int _x;
@@ -44,52 +49,42 @@ struct Bitmap {
 	int _type;
 	int _dataSize;
 	int _flags;
-	Graphics::TransparentSurface *_surface;
 	int _flipping;
-	bool _copied_surface;
+	TransSurfacePtr _surface;
 
 	Bitmap();
-	Bitmap(Bitmap *src);
+	Bitmap(const Bitmap &src);
 	~Bitmap();
 
 	void load(Common::ReadStream *s);
-	void decode(byte *pixels, int32 *palette);
-	void putDib(int x, int y, int32 *palette, byte alpha);
-	bool putDibRB(byte *pixels, int32 *palette);
-	void putDibCB(byte *pixels, int32 *palette);
+	void decode(byte *pixels, const Palette &palette);
+	void putDib(int x, int y, const Palette &palette, byte alpha);
+	bool putDibRB(byte *pixels, const Palette &palette);
+	void putDibCB(byte *pixels, const Palette &palette);
 
 	void colorFill(uint32 *dest, int len, int32 color);
-	void paletteFill(uint32 *dest, byte *src, int len, int32 *palette);
-	void copierKeyColor(uint32 *dest, byte *src, int len, int keyColor, int32 *palette, bool cb05_format);
-	void copier(uint32 *dest, byte *src, int len, int32 *palette, bool cb05_format);
+	void paletteFill(uint32 *dest, byte *src, int len, const Palette &palette);
+	void copierKeyColor(uint32 *dest, byte *src, int len, int keyColor, const Palette &palette, bool cb05_format);
+	void copier(uint32 *dest, byte *src, int len, const Palette &palette, bool cb05_format);
 
-	Bitmap *reverseImage(bool flip = true);
-	Bitmap *flipVertical();
+	/** ownership of returned object is transferred to caller */
+	Bitmap *reverseImage(bool flip = true) const;
+	/** ownership of returned object is transferred to caller */
+	Bitmap *flipVertical() const;
 
-	void drawShaded(int type, int x, int y, byte *palette, int alpha);
-	void drawRotated(int x, int y, int angle, byte *palette, int alpha);
+	void drawShaded(int type, int x, int y, const Palette &palette, int alpha);
+	void drawRotated(int x, int y, int angle, const Palette &palette, int alpha);
 
 	bool isPixelHitAtPos(int x, int y);
+
+private:
+	Bitmap operator=(const Bitmap &);
 };
 
+typedef Common::SharedPtr<Bitmap> BitmapPtr;
+
 class Picture : public MemoryObject {
- public:
-	Common::Rect _rect;
-	Bitmap *_convertedBitmap;
-	int _x;
-	int _y;
-	int _field_44;
-	int _width;
-	int _height;
-	Bitmap *_bitmap;
-	int _field_54;
-	MemoryObject2 *_memoryObject2;
-	int _alpha;
-	byte *_paletteData;
-
-	void displayPicture();
-
-  public:
+public:
 	Picture();
 	virtual ~Picture();
 
@@ -100,7 +95,7 @@ class Picture : public MemoryObject {
 	void setAOIDs();
 	virtual void init();
 	void getDibInfo();
-	Bitmap *getPixelData();
+	const Bitmap *getPixelData();
 	virtual void draw(int x, int y, int style, int angle);
 	void drawRotated(int x, int y, int angle);
 
@@ -113,10 +108,27 @@ class Picture : public MemoryObject {
 	int getPixelAtPos(int x, int y);
 	int getPixelAtPosEx(int x, int y);
 
-	byte *getPaletteData() { return _paletteData; }
-	void setPaletteData(byte *pal);
+	const Bitmap *getConvertedBitmap() const { return _convertedBitmap.get(); }
+	const Palette &getPaletteData() const { return _paletteData; }
+	void setPaletteData(const Palette &pal);
 
 	void copyMemoryObject2(Picture *src);
+
+	int _x, _y;
+
+protected:
+	Common::Rect _rect;
+	Common::ScopedPtr<Bitmap> _convertedBitmap;
+	int _field_44;
+	int _width;
+	int _height;
+	BitmapPtr _bitmap;
+	int _field_54;
+	Common::ScopedPtr<MemoryObject2> _memoryObject2;
+	int _alpha;
+	Palette _paletteData;
+
+	void displayPicture();
 };
 
 class BigPicture : public Picture {
@@ -191,7 +203,7 @@ class Background : public CObject {
 	int _x;
 	int _y;
 	int16 _messageQueueId;
-	MemoryObject *_palette;
+	Palette _palette;
 	int _bigPictureArray1Count;
 	int _bigPictureArray2Count;
 	BigPicture ***_bigPictureArray;

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -34,6 +34,8 @@ class DynamicPhase;
 class Movement;
 struct PicAniInfo;
 
+typedef Common::Point Dims;
+
 struct Bitmap {
 	int _x;
 	int _y;
@@ -105,7 +107,7 @@ class Picture : public MemoryObject {
 	byte getAlpha() { return (byte)_alpha; }
 	void setAlpha(byte alpha) { _alpha = alpha; }
 
-	Common::Point *getDimensions(Common::Point *p);
+	Dims getDimensions() const { return Dims(_width, _height); }
 	bool isPointInside(int x, int y);
 	bool isPixelHitAtPos(int x, int y);
 	int getPixelAtPos(int x, int y);
@@ -171,7 +173,7 @@ class PictureObject : public GameObject {
 	virtual bool load(MfcArchive &file, bool bigPicture);
 	virtual bool load(MfcArchive &file) { assert(0); return false; } // Disable base class
 
-	Common::Point *getDimensions(Common::Point *p);
+	Dims getDimensions() const { return _picture->getDimensions(); }
 	void draw();
 	void drawAt(int x, int y);
 

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -81,8 +81,6 @@ private:
 	Bitmap operator=(const Bitmap &);
 };
 
-typedef Common::SharedPtr<Bitmap> BitmapPtr;
-
 class Picture : public MemoryObject {
 public:
 	Picture();
@@ -122,7 +120,7 @@ protected:
 	int _field_44;
 	int _width;
 	int _height;
-	BitmapPtr _bitmap;
+	Common::ScopedPtr<Bitmap> _bitmap;
 	int _field_54;
 	Common::ScopedPtr<MemoryObject2> _memoryObject2;
 	int _alpha;

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -112,7 +112,7 @@ public:
 	const Palette &getPaletteData() const { return _paletteData; }
 	void setPaletteData(const Palette &pal);
 
-	void copyMemoryObject2(Picture *src);
+	void copyMemoryObject2(Picture &src);
 
 	int _x, _y;
 

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -167,17 +167,10 @@ class GameObject : public CObject {
 };
 
 class PictureObject : public GameObject {
-  public:
-	Picture *_picture;
-	Common::Array<GameObject *> *_pictureObject2List;
-	int _ox2;
-	int _oy2;
-
-  public:
+public:
 	PictureObject();
 
 	PictureObject(PictureObject *src);
-	virtual ~PictureObject();
 
 	virtual bool load(MfcArchive &file, bool bigPicture);
 	virtual bool load(MfcArchive &file) { assert(0); return false; } // Disable base class
@@ -190,10 +183,18 @@ class PictureObject : public GameObject {
 	bool isPointInside(int x, int y);
 	bool isPixelHitAtPos(int x, int y);
 	void setOXY2();
+
+	Common::SharedPtr<Picture> _picture;
+
+private:
+	Common::Array<GameObject> _pictureObject2List;
+	int _ox2;
+	int _oy2;
 };
 
 class Background : public CObject {
-  public:
+public:
+	/** list items are owned */
 	Common::Array<PictureObject *> _picObjList;
 
 	Common::String _bgname;
@@ -201,18 +202,19 @@ class Background : public CObject {
 	int _y;
 	int16 _messageQueueId;
 	Palette _palette;
-	int _bigPictureArray1Count;
-	int _bigPictureArray2Count;
-	BigPicture ***_bigPictureArray;
+	/** list items are owned */
+	Common::Array<BigPicture *> _bigPictureArray;
+	uint _bigPictureXDim;
+	uint _bigPictureYDim;
 
-  public:
+public:
 	Background();
 	virtual ~Background();
 
 	virtual bool load(MfcArchive &file);
 	void addPictureObject(PictureObject *pct);
 
-	BigPicture *getBigPicture(int x, int y) { return _bigPictureArray[x][y]; }
+	BigPicture *getBigPicture(int x, int y) { return _bigPictureArray[y * _bigPictureYDim + x]; }
 };
 
 struct ShadowsItem {

--- a/engines/fullpipe/gfx.h
+++ b/engines/fullpipe/gfx.h
@@ -153,7 +153,6 @@ class GameObject : public CObject {
   public:
 	GameObject();
 	GameObject(GameObject *src);
-	~GameObject();
 
 	virtual bool load(MfcArchive &file);
 	void setOXY(int x, int y);

--- a/engines/fullpipe/init.cpp
+++ b/engines/fullpipe/init.cpp
@@ -144,7 +144,7 @@ void FullpipeEngine::setLevelStates() {
 
 void FullpipeEngine::addCursor(CursorInfo *cursorInfo, Scene *inv, int pictureId, int hotspotX, int hotspotY, int itemPictureOffsX, int itemPictureOffsY) {
 	cursorInfo->pictureId = pictureId;
-	cursorInfo->picture = inv->getPictureObjectById(pictureId, 0)->_picture;
+	cursorInfo->picture = inv->getPictureObjectById(pictureId, 0)->_picture.get();
 	cursorInfo->hotspotX = hotspotX;
 	cursorInfo->hotspotY = hotspotY;
 	cursorInfo->itemPictureOffsX = itemPictureOffsX;

--- a/engines/fullpipe/input.cpp
+++ b/engines/fullpipe/input.cpp
@@ -262,16 +262,12 @@ void FullpipeEngine::initArcadeKeys(const char *varname) {
 		return;
 
 	int cnt = var->getSubVarsCount();
-
+	_arcadeKeys.resize(cnt);
 	for (int i = 0; i < cnt; i++) {
-		Common::Point *point = new Common::Point;
-
+		Common::Point &point = _arcadeKeys[i];
 		GameVar *sub = var->getSubVarByIndex(i);
-
-		point->x = sub->getSubVarAsInt("X");
-		point->y = sub->getSubVarAsInt("Y");
-
-		_arcadeKeys.push_back(point);
+		point.x = sub->getSubVarAsInt("X");
+		point.y = sub->getSubVarAsInt("Y");
 	}
 }
 
@@ -283,7 +279,7 @@ void FullpipeEngine::processArcade(ExCommand *cmd) {
 
 	if (cmd->_sceneClickX <= g_fp->_aniMan2->_ox) {
 		for (idx = (int)_arcadeKeys.size() - 1; idx >= 0; idx--) {
-			if (_arcadeKeys[idx]->x < g_fp->_aniMan2->_ox)
+			if (_arcadeKeys[idx].x < g_fp->_aniMan2->_ox)
 				break;
 		}
 
@@ -291,7 +287,7 @@ void FullpipeEngine::processArcade(ExCommand *cmd) {
 			return;
 	} else {
 		for (idx = 0; idx < (int)_arcadeKeys.size(); idx++) {
-			if (_arcadeKeys[idx]->x > g_fp->_aniMan2->_ox)
+			if (_arcadeKeys[idx].x > g_fp->_aniMan2->_ox)
 				break;
 		}
 
@@ -299,8 +295,8 @@ void FullpipeEngine::processArcade(ExCommand *cmd) {
 			return;
 	}
 
-	cmd->_sceneClickX = _arcadeKeys[idx]->x;
-	cmd->_sceneClickY = _arcadeKeys[idx]->y;
+	cmd->_sceneClickX = _arcadeKeys[idx].x;
+	cmd->_sceneClickY = _arcadeKeys[idx].y;
 
 	cmd->_x = cmd->_sceneClickX - g_fp->_sceneRect.left;
 	cmd->_y = cmd->_sceneClickY - g_fp->_sceneRect.top;

--- a/engines/fullpipe/input.cpp
+++ b/engines/fullpipe/input.cpp
@@ -215,7 +215,7 @@ void FullpipeEngine::winArcade() {
 void FullpipeEngine::updateCursorCommon() {
 	GameObject *ani = _currentScene->getStaticANIObjectAtPos(_mouseVirtX, _mouseVirtY);
 
-	GameObject *pic = _currentScene->getPictureObjectAtPos(_mouseVirtX, _mouseVirtY);
+	PictureObject *pic = _currentScene->getPictureObjectAtPos(_mouseVirtX, _mouseVirtY);
 	if (!ani || (pic && pic->_priority < ani->_priority))
 		ani = pic;
 
@@ -241,7 +241,7 @@ void FullpipeEngine::updateCursorCommon() {
 			_cursorId = PIC_CSR_DEFAULT_INV;
 			return;
 		}
-		if (_objectIdAtCursor == ANI_LIFTBUTTON && lift_getButtonIdP(((StaticANIObject *)ani)->_statics->_staticsId)) {
+		if (_objectIdAtCursor == ANI_LIFTBUTTON && ani->_objtype == kObjTypeStaticANIObject && lift_getButtonIdP(static_cast<StaticANIObject *>(ani)->_statics->_staticsId)) {
 			_cursorId = PIC_CSR_LIFT;
 			return;
 		}

--- a/engines/fullpipe/input.cpp
+++ b/engines/fullpipe/input.cpp
@@ -71,7 +71,7 @@ void setInputDisabled(bool state) {
 }
 
 void InputController::addCursor(CursorInfo *cursor) {
-	CursorInfo *newc = new CursorInfo(cursor);
+	CursorInfo *newc = new CursorInfo(*cursor);
 	const Dims dims = cursor->picture->getDimensions();
 
 	newc->width = dims.x;
@@ -117,28 +117,6 @@ void InputController::setCursor(int cursorId) {
 			}
 		}
 	}
-}
-
-CursorInfo::CursorInfo() {
-	pictureId = 0;
-	picture = 0;
-	hotspotX = 0;
-	hotspotY = 0;
-	itemPictureOffsX = 0;
-	itemPictureOffsY = 0;
-	width = 0;
-	height = 0;
-}
-
-CursorInfo::CursorInfo(CursorInfo *src) {
-	pictureId = src->pictureId;
-	picture = src->picture;
-	hotspotX = src->hotspotX;
-	hotspotY = src->hotspotY;
-	itemPictureOffsX = src->itemPictureOffsX;
-	itemPictureOffsY = src->itemPictureOffsY;
-	width = src->width;
-	height = src->height;
 }
 
 void FullpipeEngine::setCursor(int id) {

--- a/engines/fullpipe/input.cpp
+++ b/engines/fullpipe/input.cpp
@@ -72,12 +72,10 @@ void setInputDisabled(bool state) {
 
 void InputController::addCursor(CursorInfo *cursor) {
 	CursorInfo *newc = new CursorInfo(cursor);
-	Common::Point p;
+	const Dims dims = cursor->picture->getDimensions();
 
-	cursor->picture->getDimensions(&p);
-
-	newc->width = p.x;
-	newc->height = p.y;
+	newc->width = dims.x;
+	newc->height = dims.y;
 
 	newc->picture->_x = -1;
 	newc->picture->_y = -1;
@@ -331,20 +329,18 @@ void FullpipeEngine::processArcade(ExCommand *cmd) {
 }
 
 void FullpipeEngine::setArcadeOverlay(int picId) {
-	Common::Point point;
-	Common::Point point2;
-
 	_arcadeOverlayX = 800;
 	_arcadeOverlayY = 545;
 
 	_arcadeOverlayHelper = accessScene(SC_INV)->getPictureObjectById(PIC_CSR_HELPERBGR, 0);
 	_arcadeOverlay = accessScene(SC_INV)->getPictureObjectById(picId, 0);
 
-	_arcadeOverlay->getDimensions(&point);
-	_arcadeOverlayHelper->getDimensions(&point2);
+	const Dims dims = _arcadeOverlay->getDimensions();
+	const Dims dims2 = _arcadeOverlayHelper->getDimensions();
 
-	_arcadeOverlayMidX = (point2.x - point.x) / 2;
-	_arcadeOverlayMidY = abs(point2.y - point.y) / 2;
+	// TODO: Only Y gets abs?
+	_arcadeOverlayMidX = (dims2.x - dims.x) / 2;
+	_arcadeOverlayMidY = abs(dims2.y - dims.y) / 2;
 }
 
 int FullpipeEngine::drawArcadeOverlay(int adjust) {

--- a/engines/fullpipe/input.cpp
+++ b/engines/fullpipe/input.cpp
@@ -186,8 +186,8 @@ void FullpipeEngine::defHandleKeyDown(int key) {
 			_normalSpeed = !_normalSpeed;
 			break;
 		case 3:								// OHWAIT
-			_gamePaused = 1;
-			_flgGameIsRunning = 0;
+			_gamePaused = true;
+			_flgGameIsRunning = false;
 			break;
 		case 4:								// MUSOFF
 			if (_musicAllowed & 2)

--- a/engines/fullpipe/input.h
+++ b/engines/fullpipe/input.h
@@ -39,8 +39,7 @@ struct CursorInfo {
 	int width;
 	int height;
 
-	CursorInfo();
-	CursorInfo(CursorInfo *src);
+	CursorInfo() { memset(this, 0, sizeof(*this)); }
 };
 
 typedef Common::Array<CursorInfo *> CursorsArray;

--- a/engines/fullpipe/interaction.cpp
+++ b/engines/fullpipe/interaction.cpp
@@ -172,7 +172,10 @@ bool InteractionController::handleInteraction(StaticANIObject *subj, GameObject 
 		return false;
 
 	if (!inter->_objectId2) {
-		StaticANIObject *ani = (StaticANIObject *)obj;
+		if (obj->_objtype != kObjTypeStaticANIObject)
+			return false;
+
+		StaticANIObject *ani = static_cast<StaticANIObject *>(obj);
 
 		if (!ani->isIdle())
 			return false;
@@ -521,9 +524,14 @@ bool Interaction::isOverlapping(StaticANIObject *subj, GameObject *obj) {
 	if (abs(_xOffs + obj->_ox - subj->_ox) <= 1
 		&& abs(obj->_oy + _yOffs - subj->_oy) <= 1) {
 		if (!_staticsId2 || (subj->_statics != 0 && subj->_statics->_staticsId == _staticsId2)) {
-			StaticANIObject *ani = dynamic_cast<StaticANIObject *>(obj);
-			if (!_staticsId1 || !(_flags & 1) || (ani && ani->_statics != 0 && ani->_statics->_staticsId == _staticsId1))
+			if (!_staticsId1 || !(_flags & 1))
 				return true;
+
+			if (obj->_objtype == kObjTypeStaticANIObject) {
+				const StaticANIObject *ani = static_cast<StaticANIObject *>(obj);
+				if (ani->_statics != 0 && ani->_statics->_staticsId == _staticsId1)
+					return true;
+			}
 		}
 	}
 	return false;

--- a/engines/fullpipe/interaction.cpp
+++ b/engines/fullpipe/interaction.cpp
@@ -56,8 +56,7 @@ bool canInteractAny(GameObject *obj1, GameObject *obj2, int invId) {
 }
 
 InteractionController::~InteractionController() {
-	_interactions.clear();
-
+	Common::for_each(_interactions.begin(), _interactions.end(), Common::DefaultDeleter<Interaction>());
 	removeMessageHandler(124, -1);
 }
 

--- a/engines/fullpipe/interaction.cpp
+++ b/engines/fullpipe/interaction.cpp
@@ -518,12 +518,11 @@ bool Interaction::canInteract(GameObject *obj1, GameObject *obj2, int invId) {
 }
 
 bool Interaction::isOverlapping(StaticANIObject *subj, GameObject *obj) {
-	StaticANIObject *ani = (StaticANIObject *)obj;
-
 	if (abs(_xOffs + obj->_ox - subj->_ox) <= 1
 		&& abs(obj->_oy + _yOffs - subj->_oy) <= 1) {
 		if (!_staticsId2 || (subj->_statics != 0 && subj->_statics->_staticsId == _staticsId2)) {
-			if (!_staticsId1 || !(_flags & 1) || (ani->_statics != 0 && ani->_statics->_staticsId == _staticsId1))
+			StaticANIObject *ani = dynamic_cast<StaticANIObject *>(obj);
+			if (!_staticsId1 || !(_flags & 1) || (ani && ani->_statics != 0 && ani->_statics->_staticsId == _staticsId1))
 				return true;
 		}
 	}

--- a/engines/fullpipe/interaction.cpp
+++ b/engines/fullpipe/interaction.cpp
@@ -129,7 +129,7 @@ bool InteractionController::handleInteraction(StaticANIObject *subj, GameObject 
 
 			PicAniInfo aniInfo;
 
-			obj->getPicAniInfo(&aniInfo);
+			obj->getPicAniInfo(aniInfo);
 
 			if (cinter->_staticsId1 && obj->_objtype == kObjTypeStaticANIObject) {
 				StaticANIObject *ani = static_cast<StaticANIObject *>(obj);
@@ -139,7 +139,7 @@ bool InteractionController::handleInteraction(StaticANIObject *subj, GameObject 
 			int xpos = cinter->_xOffs + obj->_ox;
 			int ypos = cinter->_yOffs + obj->_oy;
 
-			obj->setPicAniInfo(&aniInfo);
+			obj->setPicAniInfo(aniInfo);
 
 			if (abs(xpos - subj->_ox) > 1 || abs(ypos - subj->_oy) > 1) {
 				debugC(0, kDebugPathfinding, "Calling makeQueue() at [%d, %d]", xpos, ypos);
@@ -298,7 +298,7 @@ LABEL_38:
 		bool someFlag = false;
 		PicAniInfo aniInfo;
 
-		obj->getPicAniInfo(&aniInfo);
+		obj->getPicAniInfo(aniInfo);
 
 		if (obj->_objtype == kObjTypeStaticANIObject && inter->_staticsId1) {
 			StaticANIObject *ani = static_cast<StaticANIObject *>(obj);
@@ -310,7 +310,7 @@ LABEL_38:
 		int xpos = inter->_xOffs + obj->_ox;
 		int ypos = inter->_yOffs + obj->_oy;
 
-		obj->setPicAniInfo(&aniInfo);
+		obj->setPicAniInfo(aniInfo);
 
 		if (abs(xpos - subj->_ox) > 1 || abs(ypos - subj->_oy) > 1
 				|| (inter->_staticsId2 != 0 && (subj->_statics == 0 || subj->_statics->_staticsId != inter->_staticsId2))) {

--- a/engines/fullpipe/interaction.cpp
+++ b/engines/fullpipe/interaction.cpp
@@ -543,7 +543,7 @@ bool EntranceInfo::load(MfcArchive &file) {
 	_sceneId = file.readUint32LE();
 	_field_4 = file.readUint32LE();
 	_messageQueueId = file.readUint32LE();
-	file.read(_gap_C, 292); // FIXME, Ugh
+	file.skip(292); // FIXME: Ugh
 	_field_130 = file.readUint32LE();
 
 	return true;

--- a/engines/fullpipe/interaction.h
+++ b/engines/fullpipe/interaction.h
@@ -90,7 +90,6 @@ struct EntranceInfo {
 	int32 _sceneId;
 	int32 _field_4;
 	int32 _messageQueueId;
-	byte _gap_C[292]; // FIXME
 	int32 _field_130;
 
 	bool load(MfcArchive &file);

--- a/engines/fullpipe/interaction.h
+++ b/engines/fullpipe/interaction.h
@@ -62,13 +62,16 @@ class Interaction : public CObject {
 };
 
 class InteractionController : public CObject {
- public:
-	ObList _interactions;
-	int16 _field_20;
+	friend bool canInteractAny(GameObject *obj1, GameObject *obj2, int invId);
+
+public:
+	typedef ObList<Interaction> InteractionList;
 	bool _flag24;
 
  private:
-	static bool compareInteractions(const void *p1, const void *p2);
+	InteractionList _interactions;
+	int16 _field_20;
+	static bool compareInteractions(const Interaction *i1, const Interaction *i2);
 
  public:
 	InteractionController() : _field_20(0), _flag24(true) {}

--- a/engines/fullpipe/inventory.cpp
+++ b/engines/fullpipe/inventory.cpp
@@ -30,27 +30,23 @@
 
 namespace Fullpipe {
 
-Inventory::~Inventory() {
-	_itemsPool.clear();
-}
-
 bool Inventory::load(MfcArchive &file) {
 	debugC(5, kDebugLoading | kDebugInventory, "Inventory::load()");
 
 	_sceneId = file.readUint16LE();
 	int numInvs = file.readUint32LE();
 
+	_itemsPool.resize(numInvs);
 	for (int i = 0; i < numInvs; i++) {
-		InventoryPoolItem *t = new InventoryPoolItem();
-		t->id = file.readUint16LE();
-		t->pictureObjectNormal = file.readUint16LE();
-		t->pictureObjectId1 = file.readUint16LE();
-		t->pictureObjectHover = file.readUint16LE();
-		t->pictureObjectSelected = file.readUint16LE();
-		t->flags = file.readUint32LE();
-		t->field_C = 0;
-		t->field_A = -536;
-		_itemsPool.push_back(t);
+		InventoryPoolItem &t = _itemsPool[i];
+		t.id = file.readUint16LE();
+		t.pictureObjectNormal = file.readUint16LE();
+		t.pictureObjectId1 = file.readUint16LE();
+		t.pictureObjectHover = file.readUint16LE();
+		t.pictureObjectSelected = file.readUint16LE();
+		t.flags = file.readUint32LE();
+		t.field_C = 0;
+		t.field_A = -536;
 	}
 
 	return true;
@@ -61,7 +57,7 @@ int Inventory::getInventoryPoolItemIndexById(int itemId) {
 		return -1;
 
 	for (uint i = 0; i < _itemsPool.size(); i++) {
-		if (_itemsPool[i]->id == itemId)
+		if (_itemsPool[i].id == itemId)
 			return i;
 	}
 
@@ -74,7 +70,7 @@ bool Inventory::setItemFlags(int itemId, int flags) {
 	if (idx < 0)
 		return false;
 	else
-		_itemsPool[idx]->flags = flags;
+		_itemsPool[idx].flags = flags;
 
 	return true;
 }
@@ -200,13 +196,13 @@ int Inventory2::getInventoryItemIndexById(int itemId) {
 }
 
 int Inventory2::getInventoryPoolItemIdAtIndex(int itemId) {
-	return _itemsPool[itemId]->id;
+	return _itemsPool[itemId].id;
 }
 
 int Inventory2::getInventoryPoolItemFieldCById(int itemId) {
 	for (uint i = 0; i < _itemsPool.size(); i++) {
-		if (_itemsPool[i]->id == itemId)
-			return _itemsPool[i]->field_C;
+		if (_itemsPool[i].id == itemId)
+			return _itemsPool[i].field_C;
 	}
 
 	return 0;
@@ -218,7 +214,7 @@ int Inventory2::getItemFlags(int itemId) {
 	if (idx < 0)
 		return 0;
 
-	return _itemsPool[idx]->flags;
+	return _itemsPool[idx].flags;
 }
 
 void Inventory2::rebuildItemRects() {
@@ -241,7 +237,7 @@ void Inventory2::rebuildItemRects() {
 		PictureObject *pic = _scene->_picObjList[i];
 
 		for (uint j = 0; j < _itemsPool.size(); j++) {
-			if (_itemsPool[j]->pictureObjectNormal == pic->_id) {
+			if (_itemsPool[j].pictureObjectNormal == pic->_id) {
 				if (pic->_odelay)
 					_scene->deletePictureObject(pic);
 				else
@@ -256,15 +252,15 @@ void Inventory2::rebuildItemRects() {
 		_inventoryIcons.push_back(InventoryIcon());
 		InventoryIcon &icn = _inventoryIcons.back();
 
-		icn.inventoryItemId = _itemsPool[idx]->id;
+		icn.inventoryItemId = _itemsPool[idx].id;
 
-		icn.pictureObjectNormal = _scene->getPictureObjectById(_itemsPool[idx]->pictureObjectNormal, 0);
-		icn.pictureObjectHover = _scene->getPictureObjectById(_itemsPool[idx]->pictureObjectHover, 0);
-		icn.pictureObjectSelected = _scene->getPictureObjectById(_itemsPool[idx]->pictureObjectSelected, 0);
+		icn.pictureObjectNormal = _scene->getPictureObjectById(_itemsPool[idx].pictureObjectNormal, 0);
+		icn.pictureObjectHover = _scene->getPictureObjectById(_itemsPool[idx].pictureObjectHover, 0);
+		icn.pictureObjectSelected = _scene->getPictureObjectById(_itemsPool[idx].pictureObjectSelected, 0);
 
 		const Dims dims = icn.pictureObjectNormal->getDimensions();
 
-		if (_itemsPool[idx]->flags & 0x10000) {
+		if (_itemsPool[idx].flags & 0x10000) {
 			icn.x1 = 730;
 			icn.y1 = itemY;
 			icn.x2 = dims.x + 730;
@@ -427,7 +423,7 @@ int Inventory2::selectItem(int itemId) {
 	if (_scene) {
 		int idx = getInventoryPoolItemIndexById(itemId);
 
-		Picture *pic = _scene->getPictureObjectById(_itemsPool[idx]->pictureObjectId1, 0)->_picture.get();
+		Picture *pic = _scene->getPictureObjectById(_itemsPool[idx].pictureObjectId1, 0)->_picture.get();
 		g_fp->getGameLoaderInputController()->setCursorItemPicture(pic);
 	}
 

--- a/engines/fullpipe/inventory.cpp
+++ b/engines/fullpipe/inventory.cpp
@@ -238,7 +238,7 @@ void Inventory2::rebuildItemRects() {
 	int itemY = 0;
 
 	for (uint i = 0; i < _scene->_picObjList.size(); i++) {
-		PictureObject *pic = (PictureObject *)_scene->_picObjList[i];
+		PictureObject *pic = _scene->_picObjList[i];
 
 		for (uint j = 0; j < _itemsPool.size(); j++) {
 			if (_itemsPool[j]->pictureObjectNormal == pic->_id) {

--- a/engines/fullpipe/inventory.cpp
+++ b/engines/fullpipe/inventory.cpp
@@ -171,7 +171,7 @@ void Inventory2::removeItem2(Scene *sceneObj, int itemId, int x, int y, int prio
 
 				sceneObj->addStaticANIObject(ani, 1);
 
-				ani->_statics = (Statics *)ani->_staticsList[0];
+				ani->_statics = ani->_staticsList[0];
 				ani->setOXY(x, y);
 				ani->_priority = priority;
 			}

--- a/engines/fullpipe/inventory.cpp
+++ b/engines/fullpipe/inventory.cpp
@@ -256,8 +256,6 @@ void Inventory2::rebuildItemRects() {
 	}
 
 	for (uint i = 0; i < _inventoryItems.size(); i++) {
-		Common::Point point;
-
 		int idx = getInventoryPoolItemIndexById(_inventoryItems[i]->itemId);
 
 		InventoryIcon *icn = new InventoryIcon();
@@ -268,19 +266,19 @@ void Inventory2::rebuildItemRects() {
 		icn->pictureObjectHover = _scene->getPictureObjectById(_itemsPool[idx]->pictureObjectHover, 0);
 		icn->pictureObjectSelected = _scene->getPictureObjectById(_itemsPool[idx]->pictureObjectSelected, 0);
 
-		icn->pictureObjectNormal->getDimensions(&point);
+		const Dims dims = icn->pictureObjectNormal->getDimensions();
 
 		if (_itemsPool[idx]->flags & 0x10000) {
 			icn->x1 = 730;
 			icn->y1 = itemY;
-			icn->x2 = point.x + 730;
-			icn->y2 = point.y + itemY + 10;
+			icn->x2 = dims.x + 730;
+			icn->y2 = dims.y + itemY + 10;
 		} else {
 			icn->x1 = itemX;
 			icn->y1 = itemY;
-			icn->x2 = itemX + point.x;
+			icn->x2 = itemX + dims.x;
 			itemX = icn->x2 + 1;
-			icn->y2 = point.y + itemY + 10;
+			icn->y2 = dims.y + itemY + 10;
 		}
 
 		_inventoryIcons.push_back(icn);

--- a/engines/fullpipe/inventory.cpp
+++ b/engines/fullpipe/inventory.cpp
@@ -427,7 +427,7 @@ int Inventory2::selectItem(int itemId) {
 	if (_scene) {
 		int idx = getInventoryPoolItemIndexById(itemId);
 
-		Picture *pic = _scene->getPictureObjectById(_itemsPool[idx]->pictureObjectId1, 0)->_picture;
+		Picture *pic = _scene->getPictureObjectById(_itemsPool[idx]->pictureObjectId1, 0)->_picture.get();
 		g_fp->getGameLoaderInputController()->setCursorItemPicture(pic);
 	}
 

--- a/engines/fullpipe/inventory.h
+++ b/engines/fullpipe/inventory.h
@@ -66,8 +66,6 @@ struct InventoryItem {
 	InventoryItem(int id, int cnt) : itemId(id), count(cnt) {}
 };
 
-typedef Common::Array<InventoryItem *> InventoryItems;
-
 class PictureObject;
 
 struct InventoryIcon {
@@ -83,11 +81,9 @@ struct InventoryIcon {
 	bool isMouseHover;
 };
 
-typedef Common::Array<InventoryIcon *> InventoryIcons;
-
 class Inventory2 : public Inventory {
-	InventoryItems _inventoryItems;
-	InventoryIcons _inventoryIcons;
+	Common::Array<InventoryItem> _inventoryItems;
+	Common::Array<InventoryIcon> _inventoryIcons;
 	int _selectedId;
 	int _field_48;
 	bool _isInventoryOut;

--- a/engines/fullpipe/inventory.h
+++ b/engines/fullpipe/inventory.h
@@ -40,7 +40,7 @@ struct InventoryPoolItem {
 	int flags;
 };
 
-typedef Common::Array<InventoryPoolItem *> InventoryPoolItems;
+typedef Common::Array<InventoryPoolItem> InventoryPoolItems;
 
 class Inventory : public CObject {
  protected:
@@ -49,7 +49,6 @@ class Inventory : public CObject {
 
  public:
 	Inventory() { _sceneId = 0; }
-	virtual ~Inventory();
 
 	virtual bool load(MfcArchive &file);
 

--- a/engines/fullpipe/lift.cpp
+++ b/engines/fullpipe/lift.cpp
@@ -195,7 +195,7 @@ void FullpipeEngine::lift_init(Scene *sc, int enterSeq, int exitSeq) {
 	_lift = sc->getStaticANIObject1ById(ANI_LIFT, -1);
 
 	for (uint i = 0; i < sc->_staticANIObjectList1.size(); i++) {
-		StaticANIObject *ani = (StaticANIObject *)sc->_staticANIObjectList1[i];
+		StaticANIObject *ani = sc->_staticANIObjectList1[i];
 
 		if (ani->_id == ANI_LIFTBUTTON)
 			ani->_statics = ani->getStaticsById(lift_getButtonIdP(ani->_statics->_staticsId));
@@ -205,7 +205,7 @@ void FullpipeEngine::lift_init(Scene *sc, int enterSeq, int exitSeq) {
 	if (var) {
 		for (var = var->_subVars; var; var = var->_nextVarObj) {
 			for (uint i = 0; i < sc->_staticANIObjectList1.size(); i++) {
-				StaticANIObject *ani = (StaticANIObject *)sc->_staticANIObjectList1[i];
+				StaticANIObject *ani = sc->_staticANIObjectList1[i];
 
 				if (ani->_id == ANI_LIFTBUTTON) {
 					int id = lift_getButtonIdN(ani->_statics->_staticsId);
@@ -506,7 +506,7 @@ bool FullpipeEngine::lift_checkButton(const char *varName) {
 
 void FullpipeEngine::lift_setButtonStatics(Scene *sc, int buttonId) {
 	for (uint i = 0; i < sc->_staticANIObjectList1.size(); i++) {
-		StaticANIObject *ani = (StaticANIObject *)sc->_staticANIObjectList1[i];
+		StaticANIObject *ani = sc->_staticANIObjectList1[i];
 
 		if (ani->_id == ANI_LIFTBUTTON) {
 			int id = lift_getButtonIdN(ani->_statics->_staticsId);

--- a/engines/fullpipe/lift.cpp
+++ b/engines/fullpipe/lift.cpp
@@ -403,12 +403,12 @@ void FullpipeEngine::lift_goAnimation() {
 		int numItems = _gameLoader->_preloadItems.size();
 
 		for (int i = 0; i < numItems; i++) {
-			PreloadItem *pre = _gameLoader->_preloadItems[i];
+			PreloadItem &pre = _gameLoader->_preloadItems[i];
 
-			if (pre->preloadId2 == buttonId && pre->preloadId1 == _currentScene->_sceneId) {
+			if (pre.preloadId2 == buttonId && pre.preloadId1 == _currentScene->_sceneId) {
 				MessageQueue *mq = new MessageQueue(_globalMessageQueueList->compact());
 
-				ExCommand *ex = new ExCommand(ANI_MAN, 1, (pre->param != LiftDown ? MV_MAN_LIFTDOWN : MV_MAN_LIFTUP), 0, 0, 0, 1, 0, 0, 0);
+				ExCommand *ex = new ExCommand(ANI_MAN, 1, (pre.param != LiftDown ? MV_MAN_LIFTDOWN : MV_MAN_LIFTUP), 0, 0, 0, 1, 0, 0, 0);
 
 				ex->_param = -1;
 				ex->_field_24 = 1;

--- a/engines/fullpipe/messagehandlers.cpp
+++ b/engines/fullpipe/messagehandlers.cpp
@@ -754,7 +754,7 @@ int global_messageHandler4(ExCommand *cmd) {
 	return 1;
 }
 
-int MovGraph_messageHandler(ExCommand *cmd) {
+int MovGraph::messageHandler(ExCommand *cmd) {
 	if (cmd->_messageKind != 17)
 		return 0;
 

--- a/engines/fullpipe/messagehandlers.cpp
+++ b/engines/fullpipe/messagehandlers.cpp
@@ -39,18 +39,16 @@ void global_messageHandler_KickStucco() {
 	bool flip = false;
 
 	for (int i = 0; i < end; i++) {
-		ExCommand *ex = mov->getDynamicPhaseByIndex(i)->_exCommand;
+		ExCommand *ex = mov->getDynamicPhaseByIndex(i)->getExCommand();
 
-		if (ex)
-			if (ex->_messageKind == 35)
-				if (ex->_messageNum == SND_CMN_015) {
-					if (flip) {
-						ex->_messageNum = SND_CMN_055;
-					} else {
-						ex->_messageNum = SND_CMN_054;
-						flip = true;
-					}
-				}
+		if (ex && ex->_messageKind == 35 && ex->_messageNum == SND_CMN_015) {
+			if (flip) {
+				ex->_messageNum = SND_CMN_055;
+			} else {
+				ex->_messageNum = SND_CMN_054;
+				flip = true;
+			}
+		}
 	}
 
 	mov = g_fp->_aniMan->getMovementById(MV_MAN_HMRKICK_COINLESS);
@@ -58,18 +56,16 @@ void global_messageHandler_KickStucco() {
 	flip = false;
 
 	for (int i = 0; i < end; i++) {
-		ExCommand *ex = mov->getDynamicPhaseByIndex(i)->_exCommand;
+		ExCommand *ex = mov->getDynamicPhaseByIndex(i)->getExCommand();
 
-		if (ex)
-			if (ex->_messageKind == 35)
-				if (ex->_messageNum == SND_CMN_015) {
-					if (flip) {
-						ex->_messageNum = SND_CMN_055;
-					} else {
-						ex->_messageNum = SND_CMN_054;
-						flip = true;
-					}
-				}
+		if (ex && ex->_messageKind == 35 && ex->_messageNum == SND_CMN_015) {
+			if (flip) {
+				ex->_messageNum = SND_CMN_055;
+			} else {
+				ex->_messageNum = SND_CMN_054;
+				flip = true;
+			}
+		}
 	}
 }
 
@@ -78,24 +74,24 @@ void global_messageHandler_KickMetal() {
 	int end = mov->_currMovement ? mov->_currMovement->_dynamicPhases.size() : mov->_dynamicPhases.size();
 
 	for (int i = 0; i < end; i++) {
-		ExCommand *ex = mov->getDynamicPhaseByIndex(i)->_exCommand;
+		ExCommand *ex = mov->getDynamicPhaseByIndex(i)->getExCommand();
 
-		if (ex)
-			if (ex->_messageKind == 35)
-				if (ex->_messageNum == SND_CMN_054 || ex->_messageNum == SND_CMN_055)
-					ex->_messageNum = SND_CMN_015;
+		if (ex && ex->_messageKind == 35) {
+			if (ex->_messageNum == SND_CMN_054 || ex->_messageNum == SND_CMN_055)
+				ex->_messageNum = SND_CMN_015;
+		}
 	}
 
 	mov = g_fp->_aniMan->getMovementById(MV_MAN_HMRKICK_COINLESS);
 	end = mov->_currMovement ? mov->_currMovement->_dynamicPhases.size() : mov->_dynamicPhases.size();
 
 	for (int i = 0; i < end; i++) {
-		ExCommand *ex = mov->getDynamicPhaseByIndex(i)->_exCommand;
+		ExCommand *ex = mov->getDynamicPhaseByIndex(i)->getExCommand();
 
-		if (ex)
-			if (ex->_messageKind == 35)
-				if (ex->_messageNum == SND_CMN_054 || ex->_messageNum == SND_CMN_055)
-					ex->_messageNum = SND_CMN_015;
+		if (ex && ex->_messageKind == 35) {
+			if (ex->_messageNum == SND_CMN_054 || ex->_messageNum == SND_CMN_055)
+				ex->_messageNum = SND_CMN_015;
+		}
 	}
 }
 

--- a/engines/fullpipe/messagehandlers.cpp
+++ b/engines/fullpipe/messagehandlers.cpp
@@ -517,7 +517,7 @@ int global_messageHandler3(ExCommand *cmd) {
 		return doSomeAnimation2(cmd->_parentId, cmd->_param);
 	case 63:
 		if (cmd->_objtype == kObjTypeObjstateCommand) {
-			ObjstateCommand *c = (ObjstateCommand *)cmd;
+			ObjstateCommand *c = static_cast<ObjstateCommand *>(cmd);
 			result = 1;
 			g_fp->setObjectState(c->_objCommandName.c_str(), c->_value);
 		}
@@ -595,12 +595,14 @@ int global_messageHandler4(ExCommand *cmd) {
 		if (flags <= 0)
 			flags = -1;
 
-		ExCommand2 *cmd2 = (ExCommand2 *)cmd;
+		if (cmd->_objtype == kObjTypeExCommand2) {
+			ExCommand2 *cmd2 = static_cast<ExCommand2 *>(cmd);
 
-		if (cmd->_excFlags & 1) {
-			ani->startAnimSteps(cmd->_messageNum, 0, cmd->_x, cmd->_y, cmd2->_points, cmd2->_pointsSize, flags);
-		} else {
-			ani->startAnimSteps(cmd->_messageNum, cmd->_parId, cmd->_x, cmd->_y, cmd2->_points, cmd2->_pointsSize, flags);
+			if (cmd->_excFlags & 1) {
+				ani->startAnimSteps(cmd->_messageNum, 0, cmd->_x, cmd->_y, cmd2->_points, cmd2->_pointsSize, flags);
+			} else {
+				ani->startAnimSteps(cmd->_messageNum, cmd->_parId, cmd->_x, cmd->_y, cmd2->_points, cmd2->_pointsSize, flags);
+			}
 		}
 		break;
 	}
@@ -769,20 +771,20 @@ int MovGraph::messageHandler(ExCommand *cmd) {
 	if (getSc2MctlCompoundBySceneId(g_fp->_currentScene->_sceneId)->_objtype != kObjTypeMovGraph || !ani)
 		return 0;
 
-	MovGraph *gr = (MovGraph *)getSc2MctlCompoundBySceneId(g_fp->_currentScene->_sceneId);
+	MovGraph *gr = getSc2MovGraphBySceneId(g_fp->_currentScene->_sceneId);
 
 	MovGraphLink *link = 0;
 	double mindistance = 1.0e10;
 	Common::Point point;
 
-	for (ObList::iterator i = gr->_links.begin(); i != gr->_links.end(); ++i) {
+	for (LinkList::iterator i = gr->_links.begin(); i != gr->_links.end(); ++i) {
 		point.x = ani->_ox;
 		point.y = ani->_oy;
 
-		double dst = gr->putToLink(&point, (MovGraphLink *)(*i), 0);
+		double dst = gr->putToLink(&point, *i, 0);
 		if (dst >= 0.0 && dst < mindistance) {
 			mindistance = dst;
-			link = (MovGraphLink *)(*i);
+			link = *i;
 		}
 	}
 

--- a/engines/fullpipe/messagehandlers.cpp
+++ b/engines/fullpipe/messagehandlers.cpp
@@ -599,9 +599,9 @@ int global_messageHandler4(ExCommand *cmd) {
 			ExCommand2 *cmd2 = static_cast<ExCommand2 *>(cmd);
 
 			if (cmd->_excFlags & 1) {
-				ani->startAnimSteps(cmd->_messageNum, 0, cmd->_x, cmd->_y, cmd2->_points, cmd2->_pointsSize, flags);
+				ani->startAnimSteps(cmd->_messageNum, 0, cmd->_x, cmd->_y, cmd2->_points, flags);
 			} else {
-				ani->startAnimSteps(cmd->_messageNum, cmd->_parId, cmd->_x, cmd->_y, cmd2->_points, cmd2->_pointsSize, flags);
+				ani->startAnimSteps(cmd->_messageNum, cmd->_parId, cmd->_x, cmd->_y, cmd2->_points, flags);
 			}
 		}
 		break;

--- a/engines/fullpipe/messagehandlers.cpp
+++ b/engines/fullpipe/messagehandlers.cpp
@@ -801,12 +801,12 @@ int MovGraph::messageHandler(ExCommand *cmd) {
 	}
 
 	if (ani->_movement) {
-		ani->_movement->_currDynamicPhase->_rect->top = 255 - top;
+		ani->_movement->_currDynamicPhase->_rect.top = 255 - top;
 		return 0;
 	}
 
 	if (ani->_statics)
-		ani->_statics->_rect->top = 255 - top;
+		ani->_statics->_rect.top = 255 - top;
 
 	return 0;
 }

--- a/engines/fullpipe/messagehandlers.cpp
+++ b/engines/fullpipe/messagehandlers.cpp
@@ -204,9 +204,9 @@ int global_messageHandler1(ExCommand *cmd) {
 			case '8':
 				{
 					int num = 32;
-					for (int i = 0; i < g_fp->_gameLoader->_sc2array[num]._picAniInfosCount; i++) {
+					for (uint i = 0; i < g_fp->_gameLoader->_sc2array[num]._picAniInfos.size(); i++) {
 						debug("pic %d, %d:", num, i);
-						g_fp->_gameLoader->_sc2array[num]._picAniInfos[i]->print();
+						g_fp->_gameLoader->_sc2array[num]._picAniInfos[i].print();
 					}
 				}
 				break;

--- a/engines/fullpipe/messagehandlers.cpp
+++ b/engines/fullpipe/messagehandlers.cpp
@@ -345,7 +345,7 @@ int global_messageHandler2(ExCommand *cmd) {
 			SoundList *s = g_fp->_currSoundList1[snd];
 			int ms = s->getCount();
 			for (int i = 0; i < ms; i++) {
-				s->getSoundByIndex(i)->setPanAndVolumeByStaticAni();
+				s->getSoundByIndex(i).setPanAndVolumeByStaticAni();
 			}
 		}
 	}

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -303,6 +303,7 @@ bool MessageQueue::load(MfcArchive &file) {
 
 	for (int i = 0; i < count; i++) {
 		ExCommand *tmp = file.readClass<ExCommand>();
+		tmp->_excFlags |= 2;
 		_exCommands.push_back(tmp);
 	}
 

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -883,9 +883,8 @@ bool chainQueue(int queueId, int flags) {
 
 	nmq->_flags |= flags;
 
-	if (!nmq->chain(0)) {
-		delete nmq;
-
+	if (!nmq->chain(nullptr)) {
+		g_fp->_globalMessageQueueList->deleteQueueById(nmq->_id);
 		return false;
 	}
 
@@ -903,8 +902,7 @@ bool chainObjQueue(StaticANIObject *obj, int queueId, int flags) {
 	nmq->_flags |= flags;
 
 	if (!nmq->chain(obj)) {
-		delete nmq;
-
+		g_fp->_globalMessageQueueList->deleteQueueById(nmq->_id);
 		return false;
 	}
 

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -684,7 +684,7 @@ int GlobalMessageQueueList::compact() {
 	for (uint i = 0; i < size();) {
 		if (_storage[i]->_isFinished) {
 			disableQueueById(_storage[i]->_id);
-			remove_at(i);
+			delete remove_at(i);
 		} else {
 			if ((uint)_storage[i]->_id < size() + 2)
 				useList[_storage[i]->_id] = 1;

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -146,36 +146,12 @@ void ExCommand::firef34() {
 	}
 }
 
-ExCommand2::ExCommand2(int messageKind, int parentId, Common::Point **points, int pointsSize) : ExCommand(parentId, messageKind, 0, 0, 0, 0, 1, 0, 0, 0) {
+ExCommand2::ExCommand2(int messageKind, int parentId, const PointList &points) : ExCommand(parentId, messageKind, 0, 0, 0, 0, 1, 0, 0, 0) {
 	_objtype = kObjTypeExCommand2;
-
-	_pointsSize = pointsSize;
-	_points = (Common::Point **)malloc(sizeof(Common::Point *) * pointsSize);
-
-	for (int i = 0; i < pointsSize; i++) {
-		_points[i] = new Common::Point;
-
-		*_points[i] = *points[i];
-	}
+	_points = points;
 }
 
-ExCommand2::ExCommand2(ExCommand2 *src) : ExCommand(src) {
-	_pointsSize = src->_pointsSize;
-	_points = (Common::Point **)malloc(sizeof(Common::Point *) * _pointsSize);
-
-	for (int i = 0; i < _pointsSize; i++) {
-		_points[i] = new Common::Point;
-
-		*_points[i] = *src->_points[i];
-	}
-}
-
-ExCommand2::~ExCommand2() {
-	for (int i = 0; i < _pointsSize; i++)
-		delete _points[i];
-
-	free(_points);
-}
+ExCommand2::ExCommand2(ExCommand2 *src) : ExCommand(src), _points(src->_points) {}
 
 ExCommand2 *ExCommand2::createClone() {
 	return new ExCommand2(this);
@@ -240,9 +216,6 @@ ObjstateCommand::ObjstateCommand(ObjstateCommand *src) : ExCommand(src) {
 	_objtype = kObjTypeObjstateCommand;
 
 	_objCommandName = src->_objCommandName;
-}
-
-ObjstateCommand::~ObjstateCommand() {
 }
 
 bool ObjstateCommand::load(MfcArchive &file) {

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -285,7 +285,7 @@ MessageQueue::~MessageQueue() {
 	if (_field_14)
 		delete _field_14;
 
-	if (_flags & 2) {
+	if (_flags & kInGlobalQueue) {
 		g_fp->_globalMessageQueueList->removeQueueById(_id);
 	}
 

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -362,17 +362,16 @@ bool MessageQueue::load(MfcArchive &file) {
 
 bool MessageQueue::chain(StaticANIObject *ani) {
 	if (checkGlobalExCommandList1() && checkGlobalExCommandList2()) {
-		if (!(getFlags() & 2)) {
+		if (!(getFlags() & kInGlobalQueue)) {
 			g_fp->_globalMessageQueueList->addMessageQueue(this);
-			_flags |= 2;
+			_flags |= kInGlobalQueue;
 		}
 		if (ani) {
 			ani->queueMessageQueue(this);
-			return true;
 		} else {
 			sendNextCommand();
-			return true;
 		}
+		return true;
 	}
 	return false;
 }
@@ -653,8 +652,7 @@ MessageQueue *GlobalMessageQueueList::getMessageQueueById(int id) {
 void GlobalMessageQueueList::deleteQueueById(int id) {
 	for (uint i = 0; i < size(); i++)
 		if (_storage[i]->_id == id) {
-			remove_at(i);
-
+			delete remove_at(i);
 			disableQueueById(id);
 			return;
 		}
@@ -663,7 +661,7 @@ void GlobalMessageQueueList::deleteQueueById(int id) {
 void GlobalMessageQueueList::removeQueueById(int id) {
 	for (uint i = 0; i < size(); i++)
 		if (_storage[i]->_id == id) {
-			_storage[i]->_flags &= 0xFD; // It is quite pointless
+			_storage[i]->_flags &= ~kInGlobalQueue;
 			remove_at(i);
 
 			disableQueueById(id);
@@ -708,7 +706,7 @@ int GlobalMessageQueueList::compact() {
 }
 
 void GlobalMessageQueueList::addMessageQueue(MessageQueue *msg) {
-	msg->setFlags(msg->getFlags() | 2);
+	msg->setFlags(msg->getFlags() | kInGlobalQueue);
 
 	push_back(msg);
 }

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -633,10 +633,7 @@ void GlobalMessageQueueList::disableQueueById(int id) {
 }
 
 int GlobalMessageQueueList::compact() {
-	int *useList = new int[size() + 2];
-
-	for (uint i = 0; i < size() + 2; i++)
-		useList[i] = 0;
+	Common::Array<bool> useList(size() + 2);
 
 	for (uint i = 0; i < size();) {
 		if (_storage[i]->_isFinished) {
@@ -644,7 +641,7 @@ int GlobalMessageQueueList::compact() {
 			delete remove_at(i);
 		} else {
 			if ((uint)_storage[i]->_id < size() + 2)
-				useList[_storage[i]->_id] = 1;
+				useList[_storage[i]->_id] = true;
 			i++;
 		}
 	}
@@ -655,8 +652,6 @@ int GlobalMessageQueueList::compact() {
 		if (!useList[i])
 			break;
 	}
-
-	delete [] useList;
 
 	return i;
 }

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -280,8 +280,6 @@ MessageQueue::~MessageQueue() {
 			delete ex;
 	}
 
-	_exCommands.clear();
-
 	if (_field_14)
 		delete _field_14;
 

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -37,7 +37,7 @@ ExCommand::ExCommand() {
 	_parId = 0;
 }
 
-ExCommand::ExCommand(ExCommand *src) : Message(src) {
+ExCommand::ExCommand(ExCommand *src) : Message(*src) {
 	_field_3C = 1;
 	_messageNum = src->_messageNum;
 	_excFlags = src->_excFlags;
@@ -172,22 +172,6 @@ Message::Message() {
 	_field_2C = 0;
 	_field_30 = 0;
 	_field_34 = 0;
-}
-
-Message::Message(Message *src) {
-	_parentId = src->_parentId;
-	_messageKind = src->_messageKind;
-	_x = src->_x;
-	_y = src->_y;
-	_field_14 = src->_field_14;
-	_sceneClickX = src->_sceneClickX;
-	_sceneClickY = src->_sceneClickY;
-	_field_20 = src->_field_20;
-	_field_24 = src->_field_24;
-	_param = src->_param;
-	_field_2C = src->_field_2C;
-	_field_30 = src->_field_30;
-	_field_34 = src->_field_34;
 }
 
 Message::Message(int16 parentId, int messageKind, int x, int y, int a6, int a7, int sceneClickX, int sceneClickY, int a10) {

--- a/engines/fullpipe/messages.cpp
+++ b/engines/fullpipe/messages.cpp
@@ -317,7 +317,7 @@ MessageQueue::MessageQueue(MessageQueue *src, int parId, int field_38) {
 
 MessageQueue::~MessageQueue() {
 	for (Common::List<ExCommand *>::iterator it = _exCommands.begin(); it != _exCommands.end(); ++it) {
-		ExCommand *ex = (ExCommand *)*it;
+		ExCommand *ex = *it;
 
 		if (ex && ex->_excFlags & 2)
 			delete ex;
@@ -347,8 +347,7 @@ bool MessageQueue::load(MfcArchive &file) {
 	_queueName = file.readPascalString();
 
 	for (int i = 0; i < count; i++) {
-		ExCommand *tmp = (ExCommand *)file.readClass();
-
+		ExCommand *tmp = file.readClass<ExCommand>();
 		_exCommands.push_back(tmp);
 	}
 

--- a/engines/fullpipe/messages.h
+++ b/engines/fullpipe/messages.h
@@ -86,12 +86,10 @@ class ExCommand : public Message {
 
 class ExCommand2 : public ExCommand {
  public:
-	Common::Point **_points;
-	int _pointsSize;
+	PointList _points;
 
-	ExCommand2(int messageKind, int parentId, Common::Point **points, int pointsSize);
+	ExCommand2(int messageKind, int parentId, const PointList &points);
 	ExCommand2(ExCommand2 *src);
-	virtual ~ExCommand2();
 
 	virtual ExCommand2 *createClone();
 };
@@ -104,7 +102,6 @@ class ObjstateCommand : public ExCommand {
  public:
 	ObjstateCommand();
 	ObjstateCommand(ObjstateCommand *src);
-	virtual ~ObjstateCommand();
 
 	virtual bool load(MfcArchive &file);
 

--- a/engines/fullpipe/messages.h
+++ b/engines/fullpipe/messages.h
@@ -163,13 +163,14 @@ class MessageQueue : public CObject {
 };
 
 class GlobalMessageQueueList : public Common::Array<MessageQueue *> {
-  public:
+public:
 	MessageQueue *getMessageQueueById(int id);
 	void deleteQueueById(int id);
 	void removeQueueById(int id);
 	void disableQueueById(int id);
 	/** `msg` becomes owned by `this` */
 	void addMessageQueue(MessageQueue *msg);
+	void clear();
 
 	int compact();
 };

--- a/engines/fullpipe/messages.h
+++ b/engines/fullpipe/messages.h
@@ -53,8 +53,6 @@ class Message : public CObject {
 
  public:
 	Message();
-	Message(Message *src);
-	virtual ~Message() {}
 
 	Message(int16 parentId, int messageKind, int x, int y, int a6, int a7, int sceneClickX, int sceneClickY, int a10);
 };

--- a/engines/fullpipe/messages.h
+++ b/engines/fullpipe/messages.h
@@ -31,6 +31,10 @@
 
 namespace Fullpipe {
 
+enum QueueFlags {
+	kInGlobalQueue = 2
+};
+
 class Message : public CObject {
  public:
 	int _messageKind;
@@ -146,6 +150,7 @@ class MessageQueue : public CObject {
 
 	void setParamInt(int key1, int key2);
 
+	/** `ani` will own `this` if `chain` returns true */
 	bool chain(StaticANIObject *ani);
 	void update();
 	void sendNextCommand();
@@ -168,6 +173,7 @@ class GlobalMessageQueueList : public Common::Array<MessageQueue *> {
 	void deleteQueueById(int id);
 	void removeQueueById(int id);
 	void disableQueueById(int id);
+	/** `msg` becomes owned by `this` */
 	void addMessageQueue(MessageQueue *msg);
 
 	int compact();

--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -1796,9 +1796,9 @@ void ModalHelp::launch() {
 
 	if (_mainMenuScene) {
 		if (g_fp->isDemo() && g_fp->getLanguage() == Common::RU_RUS)
-			_bg = _mainMenuScene->getPictureObjectById(364, 0)->_picture;
+			_bg = _mainMenuScene->getPictureObjectById(364, 0)->_picture.get();
 		else
-			_bg = _mainMenuScene->getPictureObjectById(PIC_HLP_BGR, 0)->_picture;
+			_bg = _mainMenuScene->getPictureObjectById(PIC_HLP_BGR, 0)->_picture.get();
 		_isRunning = 1;
 	}
 }

--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -1338,6 +1338,9 @@ bool ModalMainMenu::handleMessage(ExCommand *message) {
 	if (message->_messageKind != 17)
 		return false;
 
+	if (!_scene)
+		return false;
+
 	Common::Point point;
 
 	if (message->_messageNum == 29) {
@@ -1412,6 +1415,7 @@ bool ModalMainMenu::init(int counterdiff) {
 
 	case PIC_MNU_DEBUG_L:
 		g_fp->_gameLoader->unloadScene(SC_MAINMENU);
+		_scene = nullptr;
 		g_fp->_sceneRect = _screct;
 
 		if (!g_fp->_currentScene)
@@ -1427,6 +1431,7 @@ bool ModalMainMenu::init(int counterdiff) {
 	case PIC_MNU_CONTINUE_L:
 		if (!_mfield_34) {
 			g_fp->_gameLoader->unloadScene(SC_MAINMENU);
+			_scene = nullptr;
 			g_fp->_sceneRect = _screct;
 
 			if (g_fp->_currentScene) {

--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -2156,10 +2156,10 @@ bool ModalSaveGame::getFileInfo(int slot, FileInfo *fileinfo) {
 
 	Fullpipe::parseSavegameHeader(header, desc);
 
-	snprintf(res, 17, "%s %s", desc.getSaveDate().c_str(), desc.getSaveTime().c_str());
+	snprintf(res, sizeof(res), "%s %s", desc.getSaveDate().c_str(), desc.getSaveTime().c_str());
 
 	for (int i = 0; i < 16; i++) {
-		switch(res[i]) {
+		switch (res[i]) {
 		case '.':
 			fileinfo->date[i] = 11;
 			break;

--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -570,10 +570,10 @@ bool ModalMap::init2(int counterdiff) {
 
 int ModalMap::findMapSceneId(int picId) {
 	for (uint i = 0; i < g_fp->_gameLoader->_preloadItems.size(); i++) {
-		PreloadItem *pitem = g_fp->_gameLoader->_preloadItems[i];
+		PreloadItem &pitem = g_fp->_gameLoader->_preloadItems[i];
 
-		if (pitem->preloadId1 == SC_MAP && pitem->preloadId2 == picId) {
-			return pitem->sceneId;
+		if (pitem.preloadId1 == SC_MAP && pitem.preloadId2 == picId) {
+			return pitem.sceneId;
 		}
 	}
 
@@ -705,11 +705,11 @@ void ModalMap::clickButton(PictureObject *pic) {
 		return;
 	}
 
-	PreloadItem *pitem = 0;
+	PreloadItem *pitem = nullptr;
 
 	for (uint i = 0; i < g_fp->_gameLoader->_preloadItems.size(); i++)
-		if (g_fp->_gameLoader->_preloadItems[i]->preloadId2 == SC_MAP) {
-			pitem = g_fp->_gameLoader->_preloadItems[i];
+		if (g_fp->_gameLoader->_preloadItems[i].preloadId2 == SC_MAP) {
+			pitem = &g_fp->_gameLoader->_preloadItems[i];
 			break;
 		}
 
@@ -717,16 +717,16 @@ void ModalMap::clickButton(PictureObject *pic) {
 		PreloadItem preload;
 
 		preload.preloadId2 = SC_MAP;
-		g_fp->_gameLoader->addPreloadItem(&preload);
-		pitem = g_fp->_gameLoader->_preloadItems[g_fp->_gameLoader->_preloadItems.size() - 1];
+		g_fp->_gameLoader->addPreloadItem(preload);
+		pitem = &g_fp->_gameLoader->_preloadItems[g_fp->_gameLoader->_preloadItems.size() - 1];
 	}
 
-	PreloadItem *pitem2 = 0;
+	PreloadItem *pitem2 = nullptr;
 
 	for (uint i = 0; i < g_fp->_gameLoader->_preloadItems.size(); i++)
-		if (g_fp->_gameLoader->_preloadItems[i]->preloadId1 == SC_MAP &&
-				g_fp->_gameLoader->_preloadItems[i]->preloadId2 == pic->_id) {
-			pitem2 = g_fp->_gameLoader->_preloadItems[i];
+		if (g_fp->_gameLoader->_preloadItems[i].preloadId1 == SC_MAP &&
+				g_fp->_gameLoader->_preloadItems[i].preloadId2 == pic->_id) {
+			pitem2 = &g_fp->_gameLoader->_preloadItems[i];
 			break;
 		}
 

--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -525,12 +525,10 @@ bool ModalMap::init2(int counterdiff) {
 
 				g_fp->playSound(SND_CMN_070, 0);
 			} else {
-				Common::Point p1, p2;
+				const Dims d1 = _picI03->getDimensions();
+				const Dims d2 = _highlightedPic->getDimensions();
 
-				_picI03->getDimensions(&p1);
-				_highlightedPic->getDimensions(&p2);
-
-				_picI03->setOXY(_highlightedPic->_ox + p2.x / 2 - p1.x / 2, _highlightedPic->_oy + p2.y / 2 - p1.y / 2);
+				_picI03->setOXY(_highlightedPic->_ox + d2.x / 2 - d1.x / 2, _highlightedPic->_oy + d2.y / 2 - d1.y / 2);
 				_picI03->_flags |= 4;
 			}
 		}
@@ -644,14 +642,12 @@ void ModalMap::initMap() {
 
 	pic = getScenePicture(g_fp->_currentScene->_sceneId);
 
-	Common::Point point;
-	Common::Point point2;
-
 	if (pic) {
-		pic->getDimensions(&point);
+		const Dims dims = pic->getDimensions();
+		Dims dims2;
 
-		_rect2.left = point.x / 2 + pic->_ox - 400;
-		_rect2.top = point.y / 2 + pic->_oy - 300;
+		_rect2.left = dims.x / 2 + pic->_ox - 400;
+		_rect2.top = dims.y / 2 + pic->_oy - 300;
 		_rect2.right = _rect2.left + 800;
 		_rect2.bottom = _rect2.top + 600;
 
@@ -660,15 +656,15 @@ void ModalMap::initMap() {
 		_mapScene->updateScrolling2();
 
 		_pic = _mapScene->getPictureObjectById(PIC_MAP_I02, 0);
-		_pic->getDimensions(&point2);
+		dims2 = _pic->getDimensions();
 
-		_pic->setOXY(pic->_ox + point.x / 2 - point2.x / 2, point.y - point2.y / 2 + pic->_oy - 24);
+		_pic->setOXY(pic->_ox + dims.x / 2 - dims2.x / 2, dims.y - dims2.y / 2 + pic->_oy - 24);
 		_pic->_flags |= 4;
 
 		_pic = _mapScene->getPictureObjectById(PIC_MAP_I01, 0);
-		_pic->getDimensions(&point2);
+		dims2 = _pic->getDimensions();
 
-		_pic->setOXY(pic->_ox + point.x / 2 - point2.x / 2, point.y - point2.y / 2 + pic->_oy - 25);
+		_pic->setOXY(pic->_ox + dims.x / 2 - dims2.x / 2, dims.y - dims2.y / 2 + pic->_oy - 25);
 		_pic->_flags |= 4;
 	}
 
@@ -1134,8 +1130,6 @@ void ModalFinal::update() {
 }
 
 ModalCredits::ModalCredits() {
-	Common::Point point;
-
 	_sceneTitles = g_fp->accessScene(SC_TITLES);
 
 	_creditsPic = _sceneTitles->getPictureObjectById(PIC_TTL_CREDITS, 0);
@@ -1144,15 +1138,15 @@ ModalCredits::ModalCredits() {
 	_fadeIn = true;
 	_fadeOut = false;
 
-	_creditsPic->getDimensions(&point);
+	const Dims dims = _creditsPic->getDimensions();
 
-	_countdown = point.y / 2 + 470;
+	_countdown = dims.y / 2 + 470;
 	_sfxVolume = g_fp->_sfxVolume;
 
 	_currY = 630;
-	_maxY = -1000 - point.y;
+	_maxY = -1000 - dims.y;
 
-	_currX = 400 - point.x / 2;
+	_currX = 400 - dims.x / 2;
 
 	_creditsPic->setOXY(_currX, _currY);
 }
@@ -1641,16 +1635,14 @@ int ModalMainMenu::checkHover(Common::Point &point) {
 }
 
 bool ModalMainMenu::isOverArea(PictureObject *obj, Common::Point *point) {
-	Common::Point p;
-
-	obj->getDimensions(&p);
+	const Dims dims = obj->getDimensions();
 
 	int left = point->x - 8;
 	int right = point->x + 12;
 	int down = point->y - 11;
 	int up = point->y + 9;
 
-	if (left >= obj->_ox && right < obj->_ox + p.x && down >= obj->_oy && up < obj->_oy + p.y)
+	if (left >= obj->_ox && right < obj->_ox + dims.x && down >= obj->_oy && up < obj->_oy + dims.y)
 		return true;
 
 	return false;
@@ -2091,9 +2083,7 @@ void ModalSaveGame::setup(Scene *sc, int mode) {
 	_arrayL.push_back(sc->getPictureObjectById(PIC_MSV_SPACE_D, 0));
 	_arrayD.push_back(sc->getPictureObjectById(PIC_MSV_SPACE_L, 0));
 
-	Common::Point point;
-
-	int x = _bgr->_ox + _bgr->getDimensions(&point)->x / 2;
+	int x = _bgr->_ox + _bgr->getDimensions().x / 2;
 	int y = _bgr->_oy + 90;
 	int w;
 	FileInfo *fileinfo;
@@ -2106,20 +2096,19 @@ void ModalSaveGame::setup(Scene *sc, int mode) {
 
 		if (!getFileInfo(i, fileinfo)) {
 			fileinfo->empty = true;
-			w = _emptyD->getDimensions(&point)->x;
+			w = _emptyD->getDimensions().x;
 		} else {
 			w = 0;
 
 			for (uint j = 0; j < _arrayL.size(); j++) {
-				_arrayL[j]->getDimensions(&point);
-				w += point.x + 2;
+				w += _arrayL[j]->getDimensions().x + 2;
 			}
 		}
 
 		fileinfo->fx1 = x - w / 2;
 		fileinfo->fx2 = x + w / 2;
 		fileinfo->fy1 = y;
-		fileinfo->fy2 = y + _emptyD->getDimensions(&point)->y;
+		fileinfo->fy2 = y + _emptyD->getDimensions().y;
 
 		_files.push_back(fileinfo);
 
@@ -2200,8 +2189,6 @@ void ModalSaveGame::update() {
 
 	g_fp->setCursor(g_fp->_cursorId);
 
-	Common::Point point;
-
 	for (uint i = 0; i < _files.size(); i++) {
 		if (g_fp->_mouseScreenPos.x < _files[i]->fx1 || g_fp->_mouseScreenPos.x > _files[i]->fx2 ||
 			g_fp->_mouseScreenPos.y < _files[i]->fy1 || g_fp->_mouseScreenPos.y > _files[i]->fy2 ) {
@@ -2215,7 +2202,7 @@ void ModalSaveGame::update() {
 					_arrayL[_files[i]->date[j]]->setOXY(x + 1, _files[i]->fy1);
 					_arrayL[_files[i]->date[j]]->draw();
 
-					x += _arrayL[_files[i]->date[j]]->getDimensions(&point)->x + 2;
+					x += _arrayL[_files[i]->date[j]]->getDimensions().x + 2;
 				}
 			}
 		} else {
@@ -2229,7 +2216,7 @@ void ModalSaveGame::update() {
 					_arrayD[_files[i]->date[j]]->setOXY(x + 1, _files[i]->fy1);
 					_arrayD[_files[i]->date[j]]->draw();
 
-					x += _arrayD[_files[i]->date[j]]->getDimensions(&point)->x + 2;
+					x += _arrayD[_files[i]->date[j]]->getDimensions().x + 2;
 				}
 			}
 		}

--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -1234,8 +1234,6 @@ void ModalCredits::update() {
 }
 
 ModalMainMenu::ModalMainMenu() {
-	_areas.clear();
-
 	_lastArea = 0;
 	_hoverAreaId = 0;
 	_mfield_34 = 0;
@@ -1262,66 +1260,68 @@ ModalMainMenu::ModalMainMenu() {
 
 	MenuArea *area;
 
-	area = new MenuArea();
+	_areas.push_back(MenuArea());
+	area = &_areas.back();
 	area->picIdL = PIC_MNU_EXIT_L;
 	area->picObjD = 0;
 	area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 	area->picObjL->_flags &= 0xFFFB;
-	_areas.push_back(area);
 
-	area = new MenuArea();
+	_areas.push_back(MenuArea());
+	area = &_areas.back();
 	area->picIdL = PIC_MNU_CONTINUE_L;
 	area->picObjD = 0;
 	area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 	area->picObjL->_flags &= 0xFFFB;
-	_areas.push_back(area);
 
 	if (isSaveAllowed()) {
-		area = new MenuArea();
+		_areas.push_back(MenuArea());
+		area = &_areas.back();
 		area->picIdL = PIC_MNU_SAVE_L;
 		area->picObjD = 0;
 		area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 		area->picObjL->_flags &= 0xFFFB;
-		_areas.push_back(area);
 	}
 
-	area = new MenuArea();
+	_areas.push_back(MenuArea());
+	area = &_areas.back();
 	area->picIdL = PIC_MNU_LOAD_L;
 	area->picObjD = 0;
 	area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 	area->picObjL->_flags &= 0xFFFB;
-	_areas.push_back(area);
 
-	area = new MenuArea();
+	_areas.push_back(MenuArea());
+	area = &_areas.back();
 	area->picIdL = PIC_MNU_RESTART_L;
 	area->picObjD = 0;
 	area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 	area->picObjL->_flags &= 0xFFFB;
-	_areas.push_back(area);
 
-	area = new MenuArea();
+	_areas.push_back(MenuArea());
+	area = &_areas.back();
 	area->picIdL = PIC_MNU_AUTHORS_L;
 	area->picObjD = 0;
 	area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 	area->picObjL->_flags &= 0xFFFB;
-	_areas.push_back(area);
 
-	area = new MenuArea();
+	_areas.push_back(MenuArea());
+	area = &_areas.back();
 	area->picIdL = PIC_MNU_SLIDER_L;
 	area->picObjD = _scene->getPictureObjectById(PIC_MNU_SLIDER_D, 0);
 	area->picObjD->_flags |= 4;
 	area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 	area->picObjL->_flags &= 0xFFFB;
-	_areas.push_back(area);
+
 	_menuSliderIdx = _areas.size() - 1;
 
-	area = new MenuArea();
+	_areas.push_back(MenuArea());
+	area = &_areas.back();
 	area->picIdL = PIC_MNU_MUSICSLIDER_L;
 	area->picObjD = _scene->getPictureObjectById(PIC_MNU_MUSICSLIDER_D, 0);
 	area->picObjD->_flags |= 4;
 	area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 	area->picObjL->_flags &= 0xFFFB;
-	_areas.push_back(area);
+
 	_musicSliderIdx = _areas.size() - 1;
 
 	if (g_fp->_mainMenu_debugEnabled)
@@ -1348,20 +1348,20 @@ bool ModalMainMenu::handleMessage(ExCommand *message) {
 
 		if (numarea >= 0) {
 			if (numarea == _menuSliderIdx) {
-				_lastArea = _areas[_menuSliderIdx];
+				_lastArea = &_areas[_menuSliderIdx];
 				_sliderOffset = _lastArea->picObjL->_ox - point.x;
 
 				return false;
 			}
 
 			if (numarea == _musicSliderIdx) {
-				_lastArea = _areas[_musicSliderIdx];
+				_lastArea = &_areas[_musicSliderIdx];
 				_sliderOffset = _lastArea->picObjL->_ox - point.x;
 
 				return false;
 			}
 
-			_hoverAreaId = _areas[numarea]->picIdL;
+			_hoverAreaId = _areas[numarea].picIdL;
 		}
 
 		return false;
@@ -1628,23 +1628,23 @@ void ModalMainMenu::updateSliderPos() {
 
 int ModalMainMenu::checkHover(Common::Point &point) {
 	for (uint i = 0; i < _areas.size(); i++) {
-		if (_areas[i]->picObjL->isPixelHitAtPos(point.x, point.y)) {
-			_areas[i]->picObjL->_flags |= 4;
+		if (_areas[i].picObjL->isPixelHitAtPos(point.x, point.y)) {
+			_areas[i].picObjL->_flags |= 4;
 
 			return i;
 		} else {
-			_areas[i]->picObjL->_flags &= 0xFFFB;
+			_areas[i].picObjL->_flags &= 0xFFFB;
 		}
 	}
 
-	if (isOverArea(_areas[_menuSliderIdx]->picObjL, &point)) {
-		_areas[_menuSliderIdx]->picObjL->_flags |= 4;
+	if (isOverArea(_areas[_menuSliderIdx].picObjL, &point)) {
+		_areas[_menuSliderIdx].picObjL->_flags |= 4;
 
 		return _menuSliderIdx;
 	}
 
-	if (isOverArea(_areas[_musicSliderIdx]->picObjL, &point)) {
-		_areas[_musicSliderIdx]->picObjL->_flags |= 4;
+	if (isOverArea(_areas[_musicSliderIdx].picObjL, &point)) {
+		_areas[_musicSliderIdx].picObjL->_flags |= 4;
 
 		return _musicSliderIdx;
 	}
@@ -1697,25 +1697,23 @@ void ModalMainMenu::enableDebugMenu(char c) {
 }
 
 void ModalMainMenu::enableDebugMenuButton() {
-	MenuArea *area;
-
 	for (uint i = 0; i < _areas.size(); i++)
-		if (_areas[i]->picIdL == PIC_MNU_DEBUG_L)
+		if (_areas[i].picIdL == PIC_MNU_DEBUG_L)
 			return;
 
-	area = new MenuArea();
+	_areas.push_back(MenuArea());
+	MenuArea *area = &_areas.back();
 	area->picIdL = PIC_MNU_DEBUG_L;
 	area->picObjD = 0;
 	area->picObjL = _scene->getPictureObjectById(area->picIdL, 0);
 	area->picObjL->_flags &= 0xFFFB;
-	_areas.push_back(area);
 
 	g_fp->_mainMenu_debugEnabled = true;
 }
 
 void ModalMainMenu::setSliderPos() {
 	int x = 173 * (g_fp->_sfxVolume + 3000) / 3000 + 65;
-	PictureObject *obj = _areas[_menuSliderIdx]->picObjD;
+	PictureObject *obj = _areas[_menuSliderIdx].picObjD;
 
 	if (x >= 65) {
 		if (x > 238)
@@ -1725,10 +1723,10 @@ void ModalMainMenu::setSliderPos() {
 	}
 
 	obj->setOXY(x, obj->_oy);
-	_areas[_menuSliderIdx]->picObjL->setOXY(x, obj->_oy);
+	_areas[_menuSliderIdx].picObjL->setOXY(x, obj->_oy);
 
 	x = 173 * g_fp->_musicVolume / 255 + 65;
-	obj = _areas[_musicSliderIdx]->picObjD;
+	obj = _areas[_musicSliderIdx].picObjD;
 
 	if (x >= 65) {
 		if (x > 238)
@@ -1738,7 +1736,7 @@ void ModalMainMenu::setSliderPos() {
 	}
 
 	obj->setOXY(x, obj->_oy);
-	_areas[_musicSliderIdx]->picObjL->setOXY(x, obj->_oy);
+	_areas[_musicSliderIdx].picObjL->setOXY(x, obj->_oy);
 }
 
 ModalHelp::ModalHelp() {

--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -1504,11 +1504,11 @@ void ModalMainMenu::updateVolume() {
 	}
 }
 
-void ModalMainMenu::updateSoundVolume(Sound *snd) {
-	if (!snd->_objectId)
+void ModalMainMenu::updateSoundVolume(Sound &snd) {
+	if (!snd._objectId)
 		return;
 
-	StaticANIObject *ani = g_fp->_currentScene->getStaticANIObject1ById(snd->_objectId, -1);
+	StaticANIObject *ani = g_fp->_currentScene->getStaticANIObject1ById(snd._objectId, -1);
 	if (!ani)
 		return;
 
@@ -1522,7 +1522,7 @@ void ModalMainMenu::updateSoundVolume(Sound *snd) {
 
 			if (ani->_oy <= _screct.bottom) {
 				if (ani->_oy >= _screct.top) {
-					snd->setPanAndVolume(g_fp->_sfxVolume, 0);
+					snd.setPanAndVolume(g_fp->_sfxVolume, 0);
 
 					return;
 				}
@@ -1534,7 +1534,7 @@ void ModalMainMenu::updateSoundVolume(Sound *snd) {
 			par = 0;
 
 			if (dx > 800) {
-				snd->setPanAndVolume(-3500, 0);
+				snd.setPanAndVolume(-3500, 0);
 				return;
 			}
 
@@ -1545,7 +1545,7 @@ void ModalMainMenu::updateSoundVolume(Sound *snd) {
 			int dx = ani->_ox - _screct.right;
 
 			if (dx > 800) {
-				snd->setPanAndVolume(-3500, 0);
+				snd.setPanAndVolume(-3500, 0);
 				return;
 			}
 
@@ -1557,7 +1557,7 @@ void ModalMainMenu::updateSoundVolume(Sound *snd) {
 
 		int32 pp = b * a;
 
-		snd->setPanAndVolume(pan + pp / 800, par);
+		snd.setPanAndVolume(pan + pp / 800, par);
 
 		return;
 	}
@@ -1570,9 +1570,9 @@ void ModalMainMenu::updateSoundVolume(Sound *snd) {
 		if (p > g_fp->_sfxVolume)
 			p = g_fp->_sfxVolume;
 
-		snd->setPanAndVolume(p, dx * (-3500) / 800);
+		snd.setPanAndVolume(p, dx * (-3500) / 800);
 	} else {
-		snd->setPanAndVolume(-3500, 0);
+		snd.setPanAndVolume(-3500, 0);
 	}
 }
 

--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -2340,7 +2340,7 @@ bool ModalDemo::launch() {
 		_scene = sc;
 
 		for (uint i = 1; i < sc->_picObjList.size(); i++) {
-			if (((PictureObject *)sc->_picObjList[i])->_id == 399)
+			if (sc->_picObjList[i]->_id == 399)
 				sc->_picObjList[i]->_flags |= 4;
 			else
 				sc->_picObjList[i]->_flags &= 0xFFFB;

--- a/engines/fullpipe/modal.h
+++ b/engines/fullpipe/modal.h
@@ -23,6 +23,8 @@
 #ifndef FULLPIPE_MODAL_H
 #define FULLPIPE_MODAL_H
 
+#include "video/avi_decoder.h"
+
 namespace Fullpipe {
 
 class PictureObject;
@@ -108,6 +110,9 @@ public:
 	virtual void saveload() {}
 
 	void play(const char *fname);
+
+private:
+	Video::AVIDecoder _decoder;
 };
 
 class ModalMap : public BaseModalObject {

--- a/engines/fullpipe/modal.h
+++ b/engines/fullpipe/modal.h
@@ -205,7 +205,7 @@ class ModalMainMenu : public BaseModalObject {
 public:
 	Scene *_scene;
 	int _hoverAreaId;
-	Common::Array<MenuArea *> _areas;
+	Common::Array<MenuArea> _areas;
 	int _menuSliderIdx;
 	int _musicSliderIdx;
 	MenuArea *_lastArea;

--- a/engines/fullpipe/modal.h
+++ b/engines/fullpipe/modal.h
@@ -319,7 +319,7 @@ public:
 	Scene *_menuScene;
 	int _mode;
 	ModalQuery *_queryDlg;
-	Common::Array <FileInfo *> _files;
+	Common::Array <FileInfo> _files;
 	Common::Array <PictureObject *> _arrayL;
 	Common::Array <PictureObject *> _arrayD;
 	int _queryRes;

--- a/engines/fullpipe/modal.h
+++ b/engines/fullpipe/modal.h
@@ -228,7 +228,7 @@ private:
 	void enableDebugMenu(char c);
 	int checkHover(Common::Point &point);
 	void updateVolume();
-	void updateSoundVolume(Sound *snd);
+	void updateSoundVolume(Sound &snd);
 	void updateSliderPos();
 	bool isOverArea(PictureObject *obj, Common::Point *point);
 };

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -735,7 +735,6 @@ void MctlMQ::clear() {
 	subIndex = 0;
 	item1Index = 0;
 	items.clear();
-	itemsCount = 0;
 	flags = 0;
 }
 
@@ -1531,7 +1530,7 @@ Common::Array<MovArr *> *MovGraph::getHitPoints(int x, int y, int *arrSize, int 
 	return arr;
 }
 
-void MovGraph::findAllPaths(MovGraphLink *lnk, MovGraphLink *lnk2, Common::Array<MovGraphLink *> &tempObList1, Common::Array<MovGraphLink *> &allPaths) {
+void MovGraph::findAllPaths(MovGraphLink *lnk, MovGraphLink *lnk2, MovGraphLinkList &tempObList1, MovGraphLinkList &allPaths) {
 	debugC(4, kDebugPathfinding, "MovGraph::findAllPaths(...)");
 
 	if (lnk == lnk2) {
@@ -1566,8 +1565,8 @@ void MovGraph::findAllPaths(MovGraphLink *lnk, MovGraphLink *lnk2, Common::Array
 Common::Array<MovItem *> *MovGraph::getPaths(MovArr *currPos, MovArr *destPos, int *pathCount) {
 	debugC(4, kDebugPathfinding, "MovGraph::getPaths(...)");
 
-	Common::Array<MovGraphLink *> tempObList1;
-	Common::Array<MovGraphLink *> allPaths;
+	MovGraphLinkList tempObList1;
+	MovGraphLinkList allPaths;
 
 	// Get all paths between two edges of the graph
 	findAllPaths(currPos->_link, destPos->_link, tempObList1, allPaths);
@@ -1677,7 +1676,7 @@ void MovGraph::setEnds(MovStep *step1, MovStep *step2) {
 
 int MctlGraph::getObjIndex(int objectId) {
 	for (uint i = 0; i < _items2.size(); i++)
-		if (_items2[i]->_objectId == objectId)
+		if (_items2[i]._objectId == objectId)
 			return i;
 
 	return -1;
@@ -1685,7 +1684,7 @@ int MctlGraph::getObjIndex(int objectId) {
 
 int MctlGraph::getDirByStatics(int idx, int staticsId) {
 	for (int i = 0; i < 4; i++)
-		if (_items2[idx]->_subItems[i]._staticsId1 == staticsId || _items2[idx]->_subItems[i]._staticsId2 == staticsId)
+		if (_items2[idx]._subItems[i]._staticsId1 == staticsId || _items2[idx]._subItems[i]._staticsId2 == staticsId)
 			return i;
 
 	return -1;
@@ -1693,9 +1692,9 @@ int MctlGraph::getDirByStatics(int idx, int staticsId) {
 
 int MctlGraph::getDirByMovement(int idx, int movId) {
 	for (int i = 0; i < 4; i++)
-		if (_items2[idx]->_subItems[i]._walk[0]._movementId == movId
-		 || _items2[idx]->_subItems[i]._walk[1]._movementId == movId
-		 || _items2[idx]->_subItems[i]._walk[2]._movementId == movId)
+		if (_items2[idx]._subItems[i]._walk[0]._movementId == movId
+		 || _items2[idx]._subItems[i]._walk[1]._movementId == movId
+		 || _items2[idx]._subItems[i]._walk[2]._movementId == movId)
 			return i;
 
 	return -1;
@@ -1708,7 +1707,7 @@ int MctlGraph::getDirByPoint(int index, StaticANIObject *ani) {
 
 		for (int i = 0; i < 4; i++) {
 			debugC(1, kDebugPathfinding, "WWW 5");
-			int tmp = _aniHandler.getNumMovements(ani->_id, ani->_statics->_staticsId, _items2[index]->_subItems[i]._staticsId1);
+			int tmp = _aniHandler.getNumMovements(ani->_id, ani->_statics->_staticsId, _items2[index]._subItems[i]._staticsId1);
 
 			if (tmp >= 0 && (minidx == -1 || tmp < min)) {
 				minidx = i;
@@ -1722,11 +1721,11 @@ int MctlGraph::getDirByPoint(int index, StaticANIObject *ani) {
 	return -1;
 }
 
-bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
+bool MctlGraph::fillData(StaticANIObject *obj, MctlAni &item) {
 	debugC(4, kDebugPathfinding, "MovGraph::fillData(%d, ...)", obj->_id);
 
-	item->_obj = obj;
-	item->_objectId = obj->_id;
+	item._obj = obj;
+	item._objectId = obj->_id;
 
 	GameVar *var = g_fp->getGameLoaderGameVar()->getSubVarByName(obj->_objectName);
 	if (!var)
@@ -1774,15 +1773,15 @@ bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
 				break;
 			}
 
-			item->_subItems[dir]._walk[act]._movementId = idx;
+			item._subItems[dir]._walk[act]._movementId = idx;
 
 			Movement *mov = obj->getMovementById(idx);
 
-			item->_subItems[dir]._walk[act]._mov = mov;
+			item._subItems[dir]._walk[act]._mov = mov;
 			if (mov) {
 				point = mov->calcSomeXY(0, -1);
-				item->_subItems[dir]._walk[act]._mx = point.x;
-				item->_subItems[dir]._walk[act]._my = point.y;
+				item._subItems[dir]._walk[act]._mx = point.x;
+				item._subItems[dir]._walk[act]._my = point.y;
 			}
 		}
 
@@ -1804,15 +1803,15 @@ bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
 				break;
 			}
 
-			item->_subItems[dir]._turn[act]._movementId = idx;
+			item._subItems[dir]._turn[act]._movementId = idx;
 
 			Movement *mov = obj->getMovementById(idx);
 
-			item->_subItems[dir]._turn[act]._mov = mov;
+			item._subItems[dir]._turn[act]._mov = mov;
 			if (mov) {
 				point = mov->calcSomeXY(0, -1);
-				item->_subItems[dir]._turn[act]._mx = point.x;
-				item->_subItems[dir]._turn[act]._my = point.y;
+				item._subItems[dir]._turn[act]._mx = point.x;
+				item._subItems[dir]._turn[act]._my = point.y;
 			}
 		}
 
@@ -1834,20 +1833,20 @@ bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
 				break;
 			}
 
-			item->_subItems[dir]._turnS[act]._movementId = idx;
+			item._subItems[dir]._turnS[act]._movementId = idx;
 
 			Movement *mov = obj->getMovementById(idx);
 
-			item->_subItems[dir]._turnS[act]._mov = mov;
+			item._subItems[dir]._turnS[act]._mov = mov;
 			if (mov) {
 				point = mov->calcSomeXY(0, -1);
-				item->_subItems[dir]._turnS[act]._mx = point.x;
-				item->_subItems[dir]._turnS[act]._my = point.y;
+				item._subItems[dir]._turnS[act]._mx = point.x;
+				item._subItems[dir]._turnS[act]._my = point.y;
 			}
 		}
 
-		item->_subItems[dir]._staticsId1 = item->_subItems[dir]._walk[0]._mov->_staticsObj1->_staticsId;
-		item->_subItems[dir]._staticsId2 = item->_subItems[dir]._walk[0]._mov->_staticsObj2->_staticsId;
+		item._subItems[dir]._staticsId1 = item._subItems[dir]._walk[0]._mov->_staticsObj1->_staticsId;
+		item._subItems[dir]._staticsId2 = item._subItems[dir]._walk[0]._mov->_staticsObj2->_staticsId;
 
 	}
 	return true;
@@ -1861,47 +1860,44 @@ void MctlGraph::attachObject(StaticANIObject *obj) {
 	int id = getObjIndex(obj->_id);
 
 	if (id >= 0) {
-		_items2[id]->_obj = obj;
+		_items2[id]._obj = obj;
 	} else {
-		MctlAni *item = new MctlAni;
-
-		if (fillData(obj, item)) {
-			_items2.push_back(item);
-		} else {
-			delete item;
+		// this is a little dumb due to no move semantics
+		_items2.push_back(MctlAni());
+		if (!fillData(obj, _items2.back())) {
+			_items2.pop_back();
 		}
 	}
 }
 
-void MctlGraph::generateList(MctlMQ *movinfo, Common::Array<MovGraphLink *> *linkList, LinkInfo *lnkSrc, LinkInfo *lnkDst) {
+void MctlGraph::generateList(MctlMQ &movinfo, MovGraphLinkList *linkList, LinkInfo *lnkSrc, LinkInfo *lnkDst) {
 	debugC(4, kDebugPathfinding, "MctlGraph::generateList(...)");
 
 	MctlMQSub *elem;
 	Common::Point point;
 	Common::Rect rect;
 
-	int subIndex = movinfo->subIndex;
+	int subIndex = movinfo.subIndex;
 
-	movinfo->items.clear();
+	movinfo.items.clear();
 
-	elem = new MctlMQSub;
+	movinfo.items.push_back(MctlMQSub());
+	elem = &movinfo.items.back();
 	elem->subIndex = subIndex;
-	elem->x = movinfo->pt1.x;
-	elem->y = movinfo->pt1.y;
+	elem->x = movinfo.pt1.x;
+	elem->y = movinfo.pt1.y;
 	elem->distance = -1;
 
-	movinfo->items.push_back(elem);
-
-	int prevSubIndex = movinfo->subIndex;
+	int prevSubIndex = movinfo.subIndex;
 
 	for (uint i = 0; i < linkList->size(); i++) {
 		int idx1;
 
 		if (linkList->size() <= 1) {
 			if (linkList->size() == 1)
-				idx1 = getDirBySize((*linkList)[0], movinfo->pt2.x - movinfo->pt1.x, movinfo->pt2.y - movinfo->pt1.y);
+				idx1 = getDirBySize((*linkList)[0], movinfo.pt2.x - movinfo.pt1.x, movinfo.pt2.y - movinfo.pt1.y);
 			else
-				idx1 = getDirBySize(0, movinfo->pt2.x - movinfo->pt1.x, movinfo->pt2.y - movinfo->pt1.y);
+				idx1 = getDirBySize(0, movinfo.pt2.x - movinfo.pt1.x, movinfo.pt2.y - movinfo.pt1.y);
 
 			point.y = -1;
 			rect.bottom = -1;
@@ -1916,17 +1912,16 @@ void MctlGraph::generateList(MctlMQ *movinfo, Common::Array<MovGraphLink *> *lin
 			prevSubIndex = idx1;
 			subIndex = idx1;
 
-			elem = new MctlMQSub;
+			movinfo.items.push_back(MctlMQSub());
+			elem = &movinfo.items.back();
 			elem->subIndex = subIndex;
 			elem->x = rect.left;
 			elem->y = rect.top;
 			elem->distance = -1;
-
-			movinfo->items.push_back(elem);
 		}
 
 		if (i != linkList->size() - 1) {
-			while (1) {
+			for (;;) {
 				i++;
 				if (getLinkDir(linkList, i, &rect, 0) != prevSubIndex) {
 					i--;
@@ -1940,84 +1935,77 @@ void MctlGraph::generateList(MctlMQ *movinfo, Common::Array<MovGraphLink *> *lin
 			}
 		}
 
-		if (movinfo->items.back()->subIndex != 10) {
+		if (movinfo.items.back().subIndex != 10) {
 			subIndex = prevSubIndex;
 
-			elem = new MctlMQSub;
+			movinfo.items.push_back(MctlMQSub());
+			elem = &movinfo.items.back();
 			elem->subIndex = 10;
 			elem->x = -1;
 			elem->y = -1;
 			elem->distance = -1;
 
-			movinfo->items.push_back(elem);
-
+			movinfo.items.push_back(MctlMQSub());
+			elem = &movinfo.items.back();
+			elem->subIndex = prevSubIndex;
 			if (i == linkList->size() - 1) {
-				elem = new MctlMQSub;
-				elem->subIndex = prevSubIndex;
-				elem->x = movinfo->pt2.x;
-				elem->y = movinfo->pt2.y;
-				elem->distance = movinfo->distance2;
-
-				movinfo->items.push_back(elem);
+				elem->x = movinfo.pt2.x;
+				elem->y = movinfo.pt2.y;
+				elem->distance = movinfo.distance2;
 			} else {
-				elem = new MctlMQSub;
-				elem->subIndex = prevSubIndex;
 				elem->x = rect.right;
 				elem->y = rect.bottom;
 				elem->distance = point.y;
-
-				movinfo->items.push_back(elem);
 			}
 		}
 	}
 
-	if (subIndex != movinfo->item1Index) {
-		elem = new MctlMQSub;
-		elem->subIndex = movinfo->item1Index;
-		elem->x = movinfo->pt2.x;
-		elem->y = movinfo->pt2.y;
-		elem->distance = movinfo->distance2;
-
-		movinfo->items.push_back(elem);
+	if (subIndex != movinfo.item1Index) {
+		movinfo.items.push_back(MctlMQSub());
+		elem = &movinfo.items.back();
+		elem->subIndex = movinfo.item1Index;
+		elem->x = movinfo.pt2.x;
+		elem->y = movinfo.pt2.y;
+		elem->distance = movinfo.distance2;
 	}
-
-	movinfo->itemsCount = movinfo->items.size();
 }
 
-MessageQueue *MctlGraph::makeWholeQueue(MctlMQ *mctlMQ) {
+MessageQueue *MctlGraph::makeWholeQueue(MctlMQ &mctlMQ) {
 	debugC(4, kDebugPathfinding, "MctlGraph::makeWholeQueue(...)");
 
 	MctlMQ movinfo(mctlMQ);
 
-	int curX = mctlMQ->pt1.x;
-	int curY = mctlMQ->pt1.y;
-	int curDistance = mctlMQ->distance1;
+	int curX = mctlMQ.pt1.x;
+	int curY = mctlMQ.pt1.y;
+	int curDistance = mctlMQ.distance1;
 
 	MessageQueue *mq = new MessageQueue(g_fp->_globalMessageQueueList->compact());
 
-	for (int i = 0; i < mctlMQ->itemsCount - 1; i++) {
-		if (mctlMQ->items[i + 1]->subIndex != 10) {
+	int numItems = mctlMQ.items.size();
+
+	for (int i = 0; i < numItems - 1; i++) {
+		if (mctlMQ.items[i + 1].subIndex != 10) {
 			MG2I *mg2i;
 
-			if (i >= mctlMQ->itemsCount - 2 || mctlMQ->items[i + 2]->subIndex != 10) {
+			if (i >= numItems - 2 || mctlMQ.items[i + 2].subIndex != 10) {
 				movinfo.flags = 0;
-				mg2i = &_items2[mctlMQ->index]->_subItems[mctlMQ->items[i]->subIndex]._turnS[mctlMQ->items[i + 1]->subIndex];
+				mg2i = &_items2[mctlMQ.index]._subItems[mctlMQ.items[i].subIndex]._turnS[mctlMQ.items[i + 1].subIndex];
 			} else {
 				movinfo.flags = 2;
-				mg2i = &_items2[mctlMQ->index]->_subItems[mctlMQ->items[i]->subIndex]._turn[mctlMQ->items[i + 1]->subIndex];
+				mg2i = &_items2[mctlMQ.index]._subItems[mctlMQ.items[i].subIndex]._turn[mctlMQ.items[i + 1].subIndex];
 			}
-			if (i < mctlMQ->itemsCount - 2
-				|| (mctlMQ->items[i]->x == mctlMQ->items[i + 1]->x
-					&& mctlMQ->items[i]->y == mctlMQ->items[i + 1]->y)
-				 || mctlMQ->items[i]->x == -1
-				 || mctlMQ->items[i]->y == -1
-				 || mctlMQ->items[i + 1]->x == -1
-				 || mctlMQ->items[i + 1]->y == -1) {
+			if (i < numItems - 2
+				|| (mctlMQ.items[i].x == mctlMQ.items[i + 1].x
+					&& mctlMQ.items[i].y == mctlMQ.items[i + 1].y)
+				 || mctlMQ.items[i].x == -1
+				 || mctlMQ.items[i].y == -1
+				 || mctlMQ.items[i + 1].x == -1
+				 || mctlMQ.items[i + 1].y == -1) {
 
-				ExCommand *ex = new ExCommand(_items2[mctlMQ->index]->_objectId, 1, mg2i->_movementId, 0, 0, 0, 1, 0, 0, 0);
+				ExCommand *ex = new ExCommand(_items2[mctlMQ.index]._objectId, 1, mg2i->_movementId, 0, 0, 0, 1, 0, 0, 0);
 
 				ex->_excFlags |= 2;
-				ex->_param = _items2[mctlMQ->index]->_obj->_odelay;
+				ex->_param = _items2[mctlMQ.index]._obj->_odelay;
 				ex->_field_24 = 1;
 				ex->_field_14 = -1;
 				mq->addExCommandToEnd(ex);
@@ -2029,45 +2017,43 @@ MessageQueue *MctlGraph::makeWholeQueue(MctlMQ *mctlMQ) {
 
 				memset(&mkQueue, 0, sizeof(mkQueue));
 
-				mkQueue.ani = _items2[mctlMQ->index]->_obj;
+				mkQueue.ani = _items2[mctlMQ.index]._obj;
 				mkQueue.staticsId2 = mg2i->_mov->_staticsObj2->_staticsId;
-				mkQueue.x1 = mctlMQ->items[i + 1]->x;
-				mkQueue.y1 = mctlMQ->items[i + 1]->y;
-				mkQueue.field_1C = mctlMQ->items[i + 1]->distance;
+				mkQueue.x1 = mctlMQ.items[i + 1].x;
+				mkQueue.y1 = mctlMQ.items[i + 1].y;
+				mkQueue.field_1C = mctlMQ.items[i + 1].distance;
 				mkQueue.staticsId1 = mg2i->_mov->_staticsObj1->_staticsId;
 
-				mkQueue.x2 = mctlMQ->items[i]->x;
-				mkQueue.y2 = mctlMQ->items[i]->y;
+				mkQueue.x2 = mctlMQ.items[i].x;
+				mkQueue.y2 = mctlMQ.items[i].y;
 				mkQueue.field_10 = 1;
 				mkQueue.flags = 0x7f;
 				mkQueue.movementId = mg2i->_movementId;
 
-				MessageQueue *mq2 = _aniHandler.makeRunQueue(&mkQueue);
-				mq->mergeQueue(mq2);
+				Common::ScopedPtr<MessageQueue> mq2(_aniHandler.makeRunQueue(&mkQueue));
+				mq->mergeQueue(mq2.get());
 
-				delete mq2;
-
-				curX = mctlMQ->items[i + 1]->x;
-				curY = mctlMQ->items[i + 1]->y;
+				curX = mctlMQ.items[i + 1].x;
+				curY = mctlMQ.items[i + 1].y;
 			}
 		} else {
-			movinfo.item1Index = mctlMQ->items[i]->subIndex;
+			movinfo.item1Index = mctlMQ.items[i].subIndex;
 			movinfo.subIndex = movinfo.item1Index;
 			movinfo.pt1.y = curY;
 			movinfo.pt1.x = curX;
 
 			movinfo.distance1 = curDistance;
-			movinfo.pt2.x = mctlMQ->items[i + 2]->x;
-			movinfo.pt2.y = mctlMQ->items[i + 2]->y;
-			movinfo.distance2 = mctlMQ->items[i + 2]->distance;
+			movinfo.pt2.x = mctlMQ.items[i + 2].x;
+			movinfo.pt2.y = mctlMQ.items[i + 2].y;
+			movinfo.distance2 = mctlMQ.items[i + 2].distance;
 
-			if (i < mctlMQ->itemsCount - 4
-				&& mctlMQ->items[i + 2]->subIndex != 10
-				&& mctlMQ->items[i + 3]->subIndex != 10
-				&& mctlMQ->items[i + 2]->subIndex != mctlMQ->items[i + 3]->subIndex
-				&& mctlMQ->items[i + 4]->subIndex == 10) {
+			if (i < numItems - 4
+				&& mctlMQ.items[i + 2].subIndex != 10
+				&& mctlMQ.items[i + 3].subIndex != 10
+				&& mctlMQ.items[i + 2].subIndex != mctlMQ.items[i + 3].subIndex
+				&& mctlMQ.items[i + 4].subIndex == 10) {
 
-				MG2I *m = &_items2[mctlMQ->index]->_subItems[mctlMQ->items[i + 2]->subIndex]._turn[mctlMQ->items[i + 3]->subIndex];
+				MG2I *m = &_items2[mctlMQ.index]._subItems[mctlMQ.items[i + 2].subIndex]._turn[mctlMQ.items[i + 3].subIndex];
 
 				if (movinfo.item1Index && movinfo.item1Index != 1) {
 					movinfo.pt2.y -= m->_my;
@@ -2077,18 +2063,18 @@ MessageQueue *MctlGraph::makeWholeQueue(MctlMQ *mctlMQ) {
 					movinfo.flags = (movinfo.flags & 2) | 1;
 				}
 
-			} else if (i < mctlMQ->itemsCount - 3
-				&& mctlMQ->items[i + 2]->subIndex != 10
-				&& mctlMQ->items[i + 3]->subIndex != 10
-				&& mctlMQ->items[i + 2]->subIndex != mctlMQ->items[i + 3]->subIndex) {
+			} else if (i < numItems - 3
+				&& mctlMQ.items[i + 2].subIndex != 10
+				&& mctlMQ.items[i + 3].subIndex != 10
+				&& mctlMQ.items[i + 2].subIndex != mctlMQ.items[i + 3].subIndex) {
 
-				MG2I *m = &_items2[mctlMQ->index]->_subItems[mctlMQ->items[i + 2]->subIndex]._turnS[mctlMQ->items[i + 3]->subIndex];
+				MG2I *m = &_items2[mctlMQ.index]._subItems[mctlMQ.items[i + 2].subIndex]._turnS[mctlMQ.items[i + 3].subIndex];
 				movinfo.pt2.x -= m->_mx;
 				movinfo.pt2.y -= m->_my;
-				movinfo.flags = (movinfo.flags & 2) | (mctlMQ->flags & 1);
+				movinfo.flags = (movinfo.flags & 2) | (mctlMQ.flags & 1);
 
 			} else {
-				movinfo.flags = (movinfo.flags & 2) | (mctlMQ->flags & 1);
+				movinfo.flags = (movinfo.flags & 2) | (mctlMQ.flags & 1);
 			}
 
 			i++; // intentional
@@ -2110,8 +2096,8 @@ MessageQueue *MctlGraph::makeWholeQueue(MctlMQ *mctlMQ) {
 		}
 	}
 
-	mctlMQ->pt2.x = movinfo.pt2.x;
-	mctlMQ->pt2.y = movinfo.pt2.y;
+	mctlMQ.pt2.x = movinfo.pt2.x;
+	mctlMQ.pt2.y = movinfo.pt2.y;
 
 	return mq;
 }
@@ -2124,10 +2110,6 @@ int MctlGraph::detachObject(StaticANIObject *obj) {
 
 void MctlGraph::detachAllObjects() {
 	debugC(4, kDebugPathfinding, "MctlGraph::detachAllObjects()");
-
-	for (uint i = 0; i < _items2.size(); i++)
-		delete _items2[i];
-
 	_items2.clear();
 }
 
@@ -2222,7 +2204,7 @@ MessageQueue *MctlGraph::makeQueue(StaticANIObject *obj, int xpos, int ypos, int
 
 		if (subMgm) {
 			obj->_messageQueueId = 0;
-			obj->changeStatics2(_items2[idx]->_subItems[idxsub]._staticsId1);
+			obj->changeStatics2(_items2[idx]._subItems[idxsub]._staticsId1);
 			newx = obj->_ox;
 			newy = obj->_oy;
 		} else {
@@ -2255,7 +2237,7 @@ MessageQueue *MctlGraph::makeQueue(StaticANIObject *obj, int xpos, int ypos, int
 				return 0;
 			}
 
-			ExCommand *ex = new ExCommand(picAniInfo.objectId, 1, _items2[idx]->_subItems[idxsub]._turnS[idxwalk]._movementId, 0, 0, 0, 1, 0, 0, 0);
+			ExCommand *ex = new ExCommand(picAniInfo.objectId, 1, _items2[idx]._subItems[idxsub]._turnS[idxwalk]._movementId, 0, 0, 0, 1, 0, 0, 0);
 
 			ex->_field_24 = 1;
 			ex->_param = picAniInfo.field_8;
@@ -2310,7 +2292,7 @@ MessageQueue *MctlGraph::makeQueue(StaticANIObject *obj, int xpos, int ypos, int
 		}
 	}
 
-	Common::Array<MovGraphLink *> tempLinkList;
+	MovGraphLinkList tempLinkList;
 	double minPath = iterate(&linkInfoSource, &linkInfoDest, &tempLinkList);
 
 	debugC(0, kDebugPathfinding, "MctlGraph::makeQueue(): path: %g  parts: %d", minPath, tempLinkList.size());
@@ -2372,12 +2354,12 @@ MessageQueue *MctlGraph::makeQueue(StaticANIObject *obj, int xpos, int ypos, int
 
 	mctlMQ1.flags = fuzzyMatch != 0;
 
-	if (_items2[idx]->_subItems[idxsub]._staticsId1 != obj->_statics->_staticsId)
+	if (_items2[idx]._subItems[idxsub]._staticsId1 != obj->_statics->_staticsId)
 		mctlMQ1.flags |= 2;
 
-	generateList(&mctlMQ1, &tempLinkList, &linkInfoSource, &linkInfoDest);
+	generateList(mctlMQ1, &tempLinkList, &linkInfoSource, &linkInfoDest);
 
-	MessageQueue *mq = makeWholeQueue(&mctlMQ1);
+	MessageQueue *mq = makeWholeQueue(mctlMQ1);
 
 	linkInfoDest.node = getHitNode(mctlMQ1.pt2.x, mctlMQ1.pt2.y, fuzzyMatch);
 
@@ -2399,7 +2381,7 @@ MessageQueue *MctlGraph::makeQueue(StaticANIObject *obj, int xpos, int ypos, int
 				ex->_excFlags |= 2;
 				mq->addExCommand(ex);
 
-				ex = new ExCommand(picAniInfo.objectId, 22, _items2[idx]->_subItems[idxsub]._staticsId1, 0, 0, 0, 1, 0, 0, 0);
+				ex = new ExCommand(picAniInfo.objectId, 22, _items2[idx]._subItems[idxsub]._staticsId1, 0, 0, 0, 1, 0, 0, 0);
 
 				ex->_param = picAniInfo.field_8;
 				ex->_excFlags |= 3;
@@ -2407,9 +2389,8 @@ MessageQueue *MctlGraph::makeQueue(StaticANIObject *obj, int xpos, int ypos, int
 			}
 		}
 	} else {
-		if (mq)
-			delete mq;
-		mq = 0;
+		delete mq;
+		mq = nullptr;
 	}
 
 	obj->setPicAniInfo(picAniInfo);
@@ -2449,7 +2430,7 @@ int MctlGraph::getDirBySize(MovGraphLink *lnk, int x, int y) {
 		return ((y > 0) + 2);
 }
 
-int MctlGraph::getLinkDir(Common::Array<MovGraphLink *> *linkList, int idx, Common::Rect *rect, Common::Point *point) {
+int MctlGraph::getLinkDir(MovGraphLinkList *linkList, int idx, Common::Rect *rect, Common::Point *point) {
 	debugC(4, kDebugPathfinding, "MctlGraph::getLinkDir(...)");
 
 	MovGraphNode *node1 = (*linkList)[idx]->_graphSrc;
@@ -2505,16 +2486,16 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 	int my1 = 0;
 
 	if (!(info->flags & 2)) {
-		mx1 = _items2[info->index]->_subItems[info->subIndex]._walk[0]._mx;
-		my1 = _items2[info->index]->_subItems[info->subIndex]._walk[0]._my;
+		mx1 = _items2[info->index]._subItems[info->subIndex]._walk[0]._mx;
+		my1 = _items2[info->index]._subItems[info->subIndex]._walk[0]._my;
 	}
 
 	int mx2 = 0;
 	int my2 = 0;
 
 	if (!(info->flags & 4)) {
-		mx2 = _items2[info->index]->_subItems[info->subIndex]._walk[2]._mx;
-		my2 = _items2[info->index]->_subItems[info->subIndex]._walk[2]._my;
+		mx2 = _items2[info->index]._subItems[info->subIndex]._walk[2]._mx;
+		my2 = _items2[info->index]._subItems[info->subIndex]._walk[2]._my;
 	}
 
 	Common::Point point;
@@ -2524,7 +2505,7 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 	int a2 = 0;
 	int mgmLen;
 
-	point = _aniHandler.getNumCycles(_items2[info->index]->_subItems[info->subIndex]._walk[1]._mov, x, y, &mgmLen, &a2, info->flags & 1);
+	point = _aniHandler.getNumCycles(_items2[info->index]._subItems[info->subIndex]._walk[1]._mov, x, y, &mgmLen, &a2, info->flags & 1);
 
 	int x1 = point.x;
 	int y1 = point.y;
@@ -2532,7 +2513,7 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 	if (!(info->flags & 1)) {
 		if (info->subIndex == 1 || info->subIndex == 0) {
 			a2 = -1;
-			x1 = mgmLen * _items2[info->index]->_subItems[info->subIndex]._walk[1]._mx;
+			x1 = mgmLen * _items2[info->index]._subItems[info->subIndex]._walk[1]._mx;
 			x = x1;
 			info->pt2.x = x1 + info->pt1.x + mx1 + mx2;
 		}
@@ -2541,7 +2522,7 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 	if (!(info->flags & 1)) {
 		if (info->subIndex == 2 || info->subIndex == 3) {
 			a2 = -1;
-			y1 = mgmLen * _items2[info->index]->_subItems[info->subIndex]._walk[1]._my;
+			y1 = mgmLen * _items2[info->index]._subItems[info->subIndex]._walk[1]._my;
 			y = y1;
 			info->pt2.y = y1 + info->pt1.y + my1 + my2;
 		}
@@ -2551,23 +2532,23 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 	int cntY = 0;
 
 	if (!(info->flags & 2)) {
-		cntX = _items2[info->index]->_subItems[info->subIndex]._walk[0]._mov->countPhasesWithFlag(-1, 1);
-		cntY = _items2[info->index]->_subItems[info->subIndex]._walk[0]._mov->countPhasesWithFlag(-1, 2);
+		cntX = _items2[info->index]._subItems[info->subIndex]._walk[0]._mov->countPhasesWithFlag(-1, 1);
+		cntY = _items2[info->index]._subItems[info->subIndex]._walk[0]._mov->countPhasesWithFlag(-1, 2);
 	}
 
 	if (mgmLen > 1) {
-		cntX += (mgmLen - 1) * _items2[info->index]->_subItems[info->subIndex]._walk[1]._mov->countPhasesWithFlag(-1, 1);
-		cntY += (mgmLen - 1) * _items2[info->index]->_subItems[info->subIndex]._walk[1]._mov->countPhasesWithFlag(-1, 2);
+		cntX += (mgmLen - 1) * _items2[info->index]._subItems[info->subIndex]._walk[1]._mov->countPhasesWithFlag(-1, 1);
+		cntY += (mgmLen - 1) * _items2[info->index]._subItems[info->subIndex]._walk[1]._mov->countPhasesWithFlag(-1, 2);
 	}
 
 	if (mgmLen > 0) {
-		cntX += _items2[info->index]->_subItems[info->subIndex]._walk[1]._mov->countPhasesWithFlag(a2, 1);
-		cntY += _items2[info->index]->_subItems[info->subIndex]._walk[1]._mov->countPhasesWithFlag(a2, 2);
+		cntX += _items2[info->index]._subItems[info->subIndex]._walk[1]._mov->countPhasesWithFlag(a2, 1);
+		cntY += _items2[info->index]._subItems[info->subIndex]._walk[1]._mov->countPhasesWithFlag(a2, 2);
 	}
 
 	if (!(info->flags & 4)) {
-		cntX += _items2[info->index]->_subItems[info->subIndex]._walk[2]._mov->countPhasesWithFlag(-1, 1);
-		cntY += _items2[info->index]->_subItems[info->subIndex]._walk[2]._mov->countPhasesWithFlag(-1, 2);
+		cntX += _items2[info->index]._subItems[info->subIndex]._walk[2]._mov->countPhasesWithFlag(-1, 1);
+		cntY += _items2[info->index]._subItems[info->subIndex]._walk[2]._mov->countPhasesWithFlag(-1, 2);
 	}
 
 	int dx1 = x - x1;
@@ -2603,9 +2584,9 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 
 	if (info->flags & 2) {
 		ex = new ExCommand(
-							_items2[info->index]->_objectId,
+							_items2[info->index]._objectId,
 							5,
-							_items2[info->index]->_subItems[info->subIndex]._walk[1]._movementId,
+							_items2[info->index]._subItems[info->subIndex]._walk[1]._movementId,
 							info->pt1.x,
 							info->pt1.y,
 							0,
@@ -2616,14 +2597,14 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 
 		ex->_field_14 = info->distance1;
 
-		ex->_param = _items2[info->index]->_obj->_odelay;
+		ex->_param = _items2[info->index]._obj->_odelay;
 		ex->_field_24 = 1;
 		ex->_excFlags |= 2;
 	} else {
 		ex = new ExCommand(
-							 _items2[info->index]->_objectId,
+							 _items2[info->index]._objectId,
 							 5,
-							 _items2[info->index]->_subItems[info->subIndex]._walk[0]._movementId,
+							 _items2[info->index]._subItems[info->subIndex]._walk[0]._movementId,
 							 info->pt1.x,
 							 info->pt1.y,
 							 0,
@@ -2634,21 +2615,21 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 
 		ex->_field_14 = info->distance1;
 
-		ex->_param = _items2[info->index]->_obj->_odelay;
+		ex->_param = _items2[info->index]._obj->_odelay;
 		ex->_field_24 = 1;
 		ex->_excFlags |= 2;
 		mq->addExCommandToEnd(ex);
 
 		ex = _aniHandler.createCommand(
-								  _items2[info->index]->_subItems[info->subIndex]._walk[0]._mov,
-								  _items2[info->index]->_objectId,
+								  _items2[info->index]._subItems[info->subIndex]._walk[0]._mov,
+								  _items2[info->index]._objectId,
 								  x1,
 								  y1,
-								  &x2,
-								  &y2,
+								  x2,
+								  y2,
 								  -1);
 		ex->_parId = mq->_id;
-		ex->_param = _items2[info->index]->_obj->_odelay;
+		ex->_param = _items2[info->index]._obj->_odelay;
 	}
 
 	mq->addExCommandToEnd(ex);
@@ -2662,37 +2643,37 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 			par = -1;
 
 		ex = _aniHandler.createCommand(
-								  _items2[info->index]->_subItems[info->subIndex]._walk[1]._mov,
-								  _items2[info->index]->_objectId,
+								  _items2[info->index]._subItems[info->subIndex]._walk[1]._mov,
+								  _items2[info->index]._objectId,
 								  x1,
 								  y1,
-								  &x2,
-								  &y2,
+								  x2,
+								  y2,
 								  par);
 		ex->_parId = mq->_id;
-		ex->_param = _items2[info->index]->_obj->_odelay;
+		ex->_param = _items2[info->index]._obj->_odelay;
 		mq->addExCommandToEnd(ex);
 	}
 
 	if (!(info->flags & 4)) {
 		ex = _aniHandler.createCommand(
-								  _items2[info->index]->_subItems[info->subIndex]._walk[2]._mov,
-								  _items2[info->index]->_objectId,
+								  _items2[info->index]._subItems[info->subIndex]._walk[2]._mov,
+								  _items2[info->index]._objectId,
 								  x1,
 								  y1,
-								  &x2,
-								  &y2,
+								  x2,
+								  y2,
 								  -1);
 		ex->_parId = mq->_id;
-		ex->_param = _items2[info->index]->_obj->_odelay;
+		ex->_param = _items2[info->index]._obj->_odelay;
 
 		mq->addExCommandToEnd(ex);
 	}
 
-	ex = new ExCommand(_items2[info->index]->_objectId, 5, -1, info->pt2.x, info->pt2.y, 0, 1, 0, 0, 0);
+	ex = new ExCommand(_items2[info->index]._objectId, 5, -1, info->pt2.x, info->pt2.y, 0, 1, 0, 0, 0);
 	ex->_field_14 = info->distance2;
 
-	ex->_param = _items2[info->index]->_obj->_odelay;
+	ex->_param = _items2[info->index]._obj->_odelay;
 	ex->_field_24 = 0;
 	ex->_excFlags |= 2;
 
@@ -2781,7 +2762,7 @@ MovGraphLink *MctlGraph::getNearestLink(int x, int y) {
 		return 0;
 }
 
-double MctlGraph::iterate(LinkInfo *linkInfoSource, LinkInfo *linkInfoDest, Common::Array<MovGraphLink *> *listObj) {
+double MctlGraph::iterate(LinkInfo *linkInfoSource, LinkInfo *linkInfoDest, MovGraphLinkList *listObj) {
 	debugC(4, kDebugPathfinding, "MctlGraph::iterate(...)");
 
 	LinkInfo linkInfoWorkSource;
@@ -2797,7 +2778,7 @@ double MctlGraph::iterate(LinkInfo *linkInfoSource, LinkInfo *linkInfoDest, Comm
 					linkInfoWorkSource.node = 0;
 					linkInfoWorkSource.link = lnk;
 
-					Common::Array<MovGraphLink *> tmpList;
+					MovGraphLinkList tmpList;
 
 					lnk->_flags |= 0x80000000;
 
@@ -2817,7 +2798,7 @@ double MctlGraph::iterate(LinkInfo *linkInfoSource, LinkInfo *linkInfoDest, Comm
 			linkInfoWorkSource.node = linkInfoSource->link->_graphSrc;
 			linkInfoWorkSource.link = 0;
 
-			Common::Array<MovGraphLink *> tmpList;
+			MovGraphLinkList tmpList;
 
 			double newDistance = iterate(&linkInfoWorkSource, linkInfoDest, &tmpList);
 
@@ -2966,28 +2947,24 @@ bool ReactParallel::load(MfcArchive &file) {
 }
 
 void ReactParallel::createRegion() {
-	_points = (Common::Point **)malloc(sizeof(Common::Point *) * 4);
-
-	for (int i = 0; i < 4; i++)
-		_points[i] = new Common::Point;
+	_points.resize(4);
 
 	double at = atan2((double)(_y1 - _y2), (double)(_x1 - _x2)) + 1.570796; // pi/2
 	double sn = sin(at);
 	double cs = cos(at);
 
-	_points[0]->x = (int16)(_x1 - _dx * cs);
-	_points[0]->y = (int16)(_y1 - _dx * sn);
+	_points[0].x = _x1 - _dx * cs;
+	_points[0].y = _y1 - _dx * sn;
 
-	_points[1]->x = (int16)(_x2 - _dx * cs);
-	_points[1]->y = (int16)(_y2 - _dx * sn);
+	_points[1].x = _x2 - _dx * cs;
+	_points[1].y = _y2 - _dx * sn;
 
-	_points[2]->x = (int16)(_x2 + _dy * cs);
-	_points[2]->y = (int16)(_y2 + _dy * sn);
+	_points[2].x = _x2 + _dy * cs;
+	_points[2].y = _y2 + _dy * sn;
 
-	_points[3]->x = (int16)(_x1 + _dy * cs);
-	_points[3]->y = (int16)(_y1 + _dy * sn);
+	_points[3].x = _x1 + _dy * cs;
+	_points[3].y = _y1 + _dy * sn;
 
-	_pointCount = 4;
 	// GdiObject::Attach(_rgn, CreatePolygonRgn(_points, 4, 2);
 }
 
@@ -2999,13 +2976,12 @@ void ReactParallel::setCenter(int x1, int y1, int x2, int y2) {
 }
 
 ReactPolygonal::ReactPolygonal() {
+	// hack for using isValid to avoid creating another state variable for
+	// getBBox
+	_bbox.right = -1;
+
 	_centerX = 0;
 	_centerY = 0;
-	_bbox = 0;
-}
-
-ReactPolygonal::~ReactPolygonal() {
-	delete _bbox;
 }
 
 bool ReactPolygonal::load(MfcArchive &file) {
@@ -3013,18 +2989,11 @@ bool ReactPolygonal::load(MfcArchive &file) {
 
 	_centerX = file.readSint32LE();
 	_centerY = file.readSint32LE();
-	_pointCount = file.readUint32LE();
+	_points.resize(file.readUint32LE());
 
-	if (_pointCount > 0) {
-		_points = (Common::Point **)malloc(sizeof(Common::Point *) * _pointCount);
-
-		for (int i = 0; i < _pointCount; i++) {
-			_points[i] = new Common::Point;
-
-			_points[i]->x = file.readUint32LE();
-			_points[i]->y = file.readUint32LE();
-		}
-
+	for (uint i = 0; i < _points.size(); ++i) {
+		_points[i].x = file.readUint32LE();
+		_points[i].y = file.readUint32LE();
 	}
 
 	createRegion();
@@ -3033,7 +3002,7 @@ bool ReactPolygonal::load(MfcArchive &file) {
 }
 
 void ReactPolygonal::createRegion() {
-	if (_points) {
+	if (_points.size()) {
 
 		// GdiObject::Attach(_rgn, CreatePolygonRgn(_points, _pointCount, 2);
 	}
@@ -3043,52 +3012,46 @@ void ReactPolygonal::setCenter(int x1, int y1, int x2, int y2) {
 	int cX = (x2 + x1) / 2;
 	int cY = (y2 + y1) / 2;
 
-	if (_points) {
-		for (int i = 0; i < _pointCount; i++) {
-			_points[i]->x += cX - _centerX;
-			_points[i]->y += cY - _centerY;
-		}
+	for (uint i = 0; i < _points.size(); ++i) {
+		_points[i].x += cX - _centerX;
+		_points[i].y += cY - _centerY;
 	}
 
 	_centerX = cX;
 	_centerY = cY;
 }
 
-void ReactPolygonal::getBBox(Common::Rect *rect) {
-	if (!_pointCount)
-		return;
+Common::Rect ReactPolygonal::getBBox() {
+	if (!_points.size())
+		return Common::Rect();
 
-	if (_bbox) {
-		*rect = *_bbox;
-		return;
+	if (!_bbox.isValidRect()) {
+		_bbox.left = _points[0].x;
+		_bbox.top = _points[0].y;
+		_bbox.right = _points[0].x;
+		_bbox.bottom = _points[0].y;
+
+		for (uint i = 1; i < _points.size(); ++i) {
+			if (_bbox.left > _points[i].x)
+				_bbox.left = _points[i].x;
+
+			if (_bbox.top > _points[i].y)
+				_bbox.top = _points[i].y;
+
+			if (_bbox.right < _points[i].x)
+				_bbox.right = _points[i].x;
+
+			if (_bbox.bottom < _points[i].y)
+				_bbox.bottom = _points[i].y;
+		}
 	}
 
-	rect->left = _points[0]->x;
-	rect->top = _points[0]->y;
-	rect->right = _points[0]->x;
-	rect->bottom = _points[0]->y;
-
-	for (int i = 1; i < _pointCount; i++) {
-		if (rect->left > _points[i]->x)
-			rect->left = _points[i]->x;
-
-		if (rect->top > _points[i]->y)
-			rect->top = _points[i]->y;
-
-		if (rect->right < _points[i]->x)
-			rect->right = _points[i]->x;
-
-		if (rect->bottom < _points[i]->y)
-			rect->bottom = _points[i]->y;
-	}
-
-	_bbox = new Common::Rect;
-	*_bbox = *rect;
+	return _bbox;
 }
 
 
 bool MovGraphReact::pointInRegion(int x, int y) {
-	if (_pointCount < 3) {
+	if (_points.size() < 3) {
 		return false;
 	}
 
@@ -3099,12 +3062,12 @@ bool MovGraphReact::pointInRegion(int x, int y) {
 	p.x = x;
 	p.y = y;
 
-	p1.x = _points[0]->x;
-	p1.y = _points[0]->y;
+	p1.x = _points[0].x;
+	p1.y = _points[0].y;
 
-	for (int i = 1; i <= _pointCount; i++) {
-		p2.x = _points[i % _pointCount]->x;
-		p2.y = _points[i % _pointCount]->y;
+	for (uint i = 1; i <= _points.size(); i++) {
+		p2.x = _points[i % _points.size()].x;
+		p2.y = _points[i % _points.size()].y;
 
 		if (p.y > MIN(p1.y, p2.y)) {
 			if (p.y <= MAX(p1.y, p2.y)) {

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -49,10 +49,10 @@ void MotionController::enableLinks(const char *linkName, bool enable) {
 		if (con->_objtype == kObjTypeMovGraph) {
 			MovGraph *gr = static_cast<MovGraph *>(con);
 
-			for (ObList::iterator l = gr->_links.begin(); l != gr->_links.end(); ++l) {
-				assert(((CObject *)*l)->_objtype == kObjTypeMovGraphLink);
+			for (MovGraph::LinkList::iterator l = gr->_links.begin(); l != gr->_links.end(); ++l) {
+				assert((*l)->_objtype == kObjTypeMovGraphLink);
 
-				MovGraphLink *lnk = (MovGraphLink *)*l;
+				MovGraphLink *lnk = static_cast<MovGraphLink *>(*l);
 
 				if (lnk->_name == linkName) {
 					if (enable)
@@ -69,18 +69,18 @@ MovGraphLink *MotionController::getLinkByName(const char *name) {
 	debugC(4, kDebugPathfinding, "MotionController::getLinkByName(%s)", name);
 
 	if (_objtype == kObjTypeMctlCompound) {
-		MctlCompound *obj = (MctlCompound *)this;
+		MctlCompound *obj = static_cast<MctlCompound *>(this);
 
 		for (uint i = 0;  i < obj->getMotionControllerCount(); i++) {
 			MotionController *con = obj->getMotionController(i);
 
 			if (con->_objtype == kObjTypeMovGraph) {
-				MovGraph *gr = (MovGraph *)con;
+				MovGraph *gr = static_cast<MovGraph *>(con);
 
-				for (ObList::iterator l = gr->_links.begin(); l != gr->_links.end(); ++l) {
-					assert(((CObject *)*l)->_objtype == kObjTypeMovGraphLink);
+				for (MovGraph::LinkList::iterator l = gr->_links.begin(); l != gr->_links.end(); ++l) {
+					assert((*l)->_objtype == kObjTypeMovGraphLink);
 
-					MovGraphLink *lnk = (MovGraphLink *)*l;
+					MovGraphLink *lnk = static_cast<MovGraphLink *>(*l);
 
 					if (lnk->_name == name)
 						return lnk;
@@ -90,12 +90,12 @@ MovGraphLink *MotionController::getLinkByName(const char *name) {
 	}
 
 	if (_objtype == kObjTypeMovGraph) {
-		MovGraph *gr = (MovGraph *)this;
+		MovGraph *gr = static_cast<MovGraph *>(this);
 
-		for (ObList::iterator l = gr->_links.begin(); l != gr->_links.end(); ++l) {
-			assert(((CObject *)*l)->_objtype == kObjTypeMovGraphLink);
+		for (MovGraph::LinkList::iterator l = gr->_links.begin(); l != gr->_links.end(); ++l) {
+			assert((*l)->_objtype == kObjTypeMovGraphLink);
 
-			MovGraphLink *lnk = (MovGraphLink *)*l;
+			MovGraphLink *lnk = static_cast<MovGraphLink *>(*l);
 
 			if (lnk->_name == name)
 				return lnk;
@@ -116,14 +116,14 @@ bool MctlCompound::load(MfcArchive &file) {
 		debugC(6, kDebugLoading, "CompoundArray[%d]", i);
 		MctlItem *obj = new MctlItem();
 
-		obj->_motionControllerObj = (MotionController *)file.readClass();
+		obj->_motionControllerObj = file.readClass<MotionController>();
 
 		int count1 = file.readUint32LE();
 
 		debugC(6, kDebugLoading, "ConnectionPoint::count: %d", count1);
 		for (int j = 0; j < count1; j++) {
 			debugC(6, kDebugLoading, "ConnectionPoint[%d]", j);
-			MctlConnectionPoint *obj1 = (MctlConnectionPoint *)file.readClass();
+			MctlConnectionPoint *obj1 = file.readClass<MctlConnectionPoint>();
 
 			obj->_connectionPoints.push_back(obj1);
 		}
@@ -132,7 +132,7 @@ bool MctlCompound::load(MfcArchive &file) {
 		obj->_field_24 = file.readUint32LE();
 
 		debugC(6, kDebugLoading, "graphReact");
-		obj->_movGraphReactObj = (MovGraphReact *)file.readClass();
+		obj->_movGraphReactObj = file.readClass<MovGraphReact>();
 
 		_motionControllers.push_back(obj);
 	}
@@ -166,7 +166,7 @@ void MctlCompound::initMctlGraph() {
 		if (_motionControllers[i]->_motionControllerObj->_objtype != kObjTypeMovGraph)
 			continue;
 
-		MovGraph *gr = (MovGraph *)_motionControllers[i]->_motionControllerObj;
+		MovGraph *gr = static_cast<MovGraph *>(_motionControllers[i]->_motionControllerObj);
 
 		MctlGraph *newgr = new MctlGraph();
 
@@ -701,10 +701,10 @@ MctlConnectionPoint *MctlCompound::findClosestConnectionPoint(int ox, int oy, in
 void MctlCompound::replaceNodeX(int from, int to) {
 	for (uint i = 0; i < _motionControllers.size(); i++) {
 		if (_motionControllers[i]->_motionControllerObj->_objtype == kObjTypeMovGraph) {
-			MovGraph *gr = (MovGraph *)_motionControllers[i]->_motionControllerObj;
+			MovGraph *gr = static_cast<MovGraph *>(_motionControllers[i]->_motionControllerObj);
 
-			for (ObList::iterator n = gr->_nodes.begin(); n != gr->_nodes.end(); ++n) {
-				MovGraphNode *node = (MovGraphNode *)*n;
+			for (MovGraph::NodeList::iterator n = gr->_nodes.begin(); n != gr->_nodes.end(); ++n) {
+				MovGraphNode *node = static_cast<MovGraphNode *>(*n);
 
 				if (node->_x == from)
 					node->_x = to;
@@ -816,10 +816,10 @@ MovGraph::MovGraph() {
 }
 
 MovGraph::~MovGraph() {
-	for (ObList::iterator i = _links.begin(); i != _links.end(); ++i)
+	for (LinkList::iterator i = _links.begin(); i != _links.end(); ++i)
 		delete *i;
 
-	for (ObList::iterator i = _nodes.begin(); i != _nodes.end(); ++i)
+	for (NodeList::iterator i = _nodes.begin(); i != _nodes.end(); ++i)
 		delete *i;
 
 	detachAllObjects();
@@ -1395,10 +1395,10 @@ double MovGraph::putToLink(Common::Point *point, MovGraphLink *link, int fuzzyMa
 void MovGraph::recalcLinkParams() {
 	debugC(4, kDebugPathfinding, "MovGraph::recalcLinkParams()");
 
-	for (ObList::iterator i = _links.begin(); i != _links.end(); ++i) {
-		assert(((CObject *)*i)->_objtype == kObjTypeMovGraphLink);
+	for (LinkList::iterator i = _links.begin(); i != _links.end(); ++i) {
+		assert((*i)->_objtype == kObjTypeMovGraphLink);
 
-		MovGraphLink *lnk = (MovGraphLink *)*i;
+		MovGraphLink *lnk = static_cast<MovGraphLink *>(*i);
 
 		lnk->_flags &= 0x7FFFFFFF;
 
@@ -1413,8 +1413,8 @@ bool MovGraph::getNearestPoint(int unusedArg, Common::Point *p, MovArr *movarr) 
 	double mindist = 1.0e20;
 	int resx = 0, resy = 0;
 
-	for (ObList::iterator i = _links.begin(); i != _links.end(); ++i) {
-		MovGraphLink *lnk = (MovGraphLink *)*i;
+	for (LinkList::iterator i = _links.begin(); i != _links.end(); ++i) {
+		MovGraphLink *lnk = static_cast<MovGraphLink *>(*i);
 
 		if ((lnk->_flags & 0x10000000) && !(lnk->_flags & 0x20000000) ) {
 			double dx1 = lnk->_graphSrc->_x - p->x;
@@ -1483,8 +1483,8 @@ Common::Array<MovArr *> *MovGraph::getHitPoints(int x, int y, int *arrSize, int 
 	Common::Array<MovArr *> *arr = new Common::Array<MovArr *>;
 	MovArr *movarr;
 
-	for (ObList::iterator i = _links.begin(); i != _links.end(); ++i) {
-		MovGraphLink *lnk = (MovGraphLink *)*i;
+	for (LinkList::iterator i = _links.begin(); i != _links.end(); ++i) {
+		MovGraphLink *lnk = static_cast<MovGraphLink *>(*i);
 
 		if (flag1) {
 			Common::Point point(x, y);
@@ -1556,8 +1556,8 @@ void MovGraph::findAllPaths(MovGraphLink *lnk, MovGraphLink *lnk2, Common::Array
 
 		tempObList1.push_back(lnk);
 
-		for (ObList::iterator i = _links.begin(); i != _links.end(); ++i) {
-			MovGraphLink *l = (MovGraphLink *)*i;
+		for (LinkList::iterator i = _links.begin(); i != _links.end(); ++i) {
+			MovGraphLink *l = static_cast<MovGraphLink *>(*i);
 
 			if (l->_graphSrc != lnk->_graphSrc) {
 				if (l->_graphDst != lnk->_graphSrc) {
@@ -2430,10 +2430,10 @@ MessageQueue *MctlGraph::makeQueue(StaticANIObject *obj, int xpos, int ypos, int
 }
 
 MovGraphNode *MctlGraph::getHitNode(int x, int y, int strictMatch) {
-	for (ObList::iterator i = _nodes.begin(); i != _nodes.end(); ++i) {
-		assert(((CObject *)*i)->_objtype == kObjTypeMovGraphNode);
+	for (NodeList::iterator i = _nodes.begin(); i != _nodes.end(); ++i) {
+		assert((*i)->_objtype == kObjTypeMovGraphNode);
 
-		MovGraphNode *node = (MovGraphNode *)*i;
+		MovGraphNode *node = *i;
 
 		if (!strictMatch) {
 			if (abs(node->_x - x) < 15 && abs(node->_y - y) < 15)
@@ -2719,10 +2719,10 @@ MovGraphLink *MctlGraph::getHitLink(int x, int y, int idx, int fuzzyMatch) {
 	Common::Point point;
 	MovGraphLink *res = 0;
 
-	for (ObList::iterator i = _links.begin(); i != _links.end(); ++i) {
-		assert(((CObject *)*i)->_objtype == kObjTypeMovGraphLink);
+	for (LinkList::iterator i = _links.begin(); i != _links.end(); ++i) {
+		assert((*i)->_objtype == kObjTypeMovGraphLink);
 
-		MovGraphLink *lnk = (MovGraphLink *)*i;
+		MovGraphLink *lnk = static_cast<MovGraphLink *>(*i);
 
 		if (fuzzyMatch) {
 			point.x = x;
@@ -2755,10 +2755,10 @@ MovGraphLink *MctlGraph::getNearestLink(int x, int y) {
 	double mindist = 1.0e20;
 	MovGraphLink *res = 0;
 
-	for (ObList::iterator i = _links.begin(); i != _links.end(); ++i) {
-		assert(((CObject *)*i)->_objtype == kObjTypeMovGraphLink);
+	for (LinkList::iterator i = _links.begin(); i != _links.end(); ++i) {
+		assert((*i)->_objtype == kObjTypeMovGraphLink);
 
-		MovGraphLink *lnk = (MovGraphLink *)*i;
+		MovGraphLink *lnk = static_cast<MovGraphLink *>(*i);
 
 		if (!(lnk->_flags & 0x20000000)) {
 			double n1x = lnk->_graphSrc->_x;
@@ -2802,8 +2802,8 @@ double MctlGraph::iterate(LinkInfo *linkInfoSource, LinkInfo *linkInfoDest, Comm
 		double minDistance = -1.0;
 
 		if (linkInfoSource->node) {
-			for (ObList::iterator i = _links.begin(); i != _links.end(); ++i) {
-				MovGraphLink *lnk = (MovGraphLink *)*i;
+			for (LinkList::iterator i = _links.begin(); i != _links.end(); ++i) {
+				MovGraphLink *lnk = static_cast<MovGraphLink *>(*i);
 
 				if ((lnk->_graphSrc == linkInfoSource->node || lnk->_graphDst == linkInfoSource->node) && !(lnk->_flags & 0xA0000000)) {
 					linkInfoWorkSource.node = 0;
@@ -2872,10 +2872,10 @@ MovGraphNode *MovGraph::calcOffset(int ox, int oy) {
 	MovGraphNode *res = 0;
 	double mindist = 1.0e10;
 
-	for (ObList::iterator i = _nodes.begin(); i != _nodes.end(); ++i) {
-		assert(((CObject *)*i)->_objtype == kObjTypeMovGraphNode);
+	for (NodeList::iterator i = _nodes.begin(); i != _nodes.end(); ++i) {
+		assert((*i)->_objtype == kObjTypeMovGraphNode);
 
-		MovGraphNode *node = (MovGraphNode *)*i;
+		MovGraphNode *node = static_cast<MovGraphNode *>(*i);
 
 		double dist = sqrt((double)((node->_x - oy) * (node->_x - oy) + (node->_x - ox) * (node->_x - ox)));
 		if (dist < mindist) {
@@ -2917,16 +2917,16 @@ bool MovGraphLink::load(MfcArchive &file) {
 	_flags = file.readUint32LE();
 
 	debugC(8, kDebugLoading, "GraphNode1");
-	_graphSrc = (MovGraphNode *)file.readClass();
+	_graphSrc = file.readClass<MovGraphNode>();
 	debugC(8, kDebugLoading, "GraphNode2");
-	_graphDst = (MovGraphNode *)file.readClass();
+	_graphDst = file.readClass<MovGraphNode>();
 
 	_length = file.readDouble();
 	_angle = file.readDouble();
 
 	debugC(8, kDebugLoading, "length: %g, angle: %g", _length, _angle);
 
-	_movGraphReact = (MovGraphReact *)file.readClass();
+	_movGraphReact = file.readClass<MovGraphReact>();
 	_name = file.readPascalString();
 
 	return true;

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -495,7 +495,7 @@ MessageQueue *MctlLadder::makeQueue(StaticANIObject *ani, int xpos, int ypos, in
 		int ox = ani->_ox;
 		int oy = ani->_oy;
 
-		ani->_movement->calcSomeXY(point, 1, ani->_someDynamicPhaseIndex);
+		point = ani->_movement->calcSomeXY(1, ani->_someDynamicPhaseIndex);
 		ani->_statics = ani->_movement->_staticsObj2;
 		ani->_movement = 0;
 		ani->setOXY(point.x + ox, point.y + oy);
@@ -545,7 +545,7 @@ MessageQueue *MctlLadder::makeQueue(StaticANIObject *ani, int xpos, int ypos, in
 		int ox = ani->_ox;
 		int oy = ani->_oy;
 
-		ani->getMovementById(_ladmovements[pos]->movVars->varUpStop)->calcSomeXY(point, 0, -1);
+		point = ani->getMovementById(_ladmovements[pos]->movVars->varUpStop)->calcSomeXY(0, -1);
 
 		mkQueue.ani = ani;
 
@@ -583,7 +583,7 @@ MessageQueue *MctlLadder::makeQueue(StaticANIObject *ani, int xpos, int ypos, in
 		int nx = ani->_ox;
 		int ny = ani->_oy;
 
-		_aniHandler.getTransitionSize(&point, ani->_id, ani->_statics->_staticsId, _ladmovements[pos]->staticIds[0]);
+		point = _aniHandler.getTransitionSize(ani->_id, ani->_statics->_staticsId, _ladmovements[pos]->staticIds[0]);
 
 		nx += point.x;
 		ny += point.y;
@@ -609,7 +609,7 @@ MessageQueue *MctlLadder::makeQueue(StaticANIObject *ani, int xpos, int ypos, in
 		int nx = ani->_ox;
 		int ny = ani->_oy;
 
-		ani->getMovementById(_ladmovements[pos]->movVars->varDownStop)->calcSomeXY(point, 0, -1);
+		point = ani->getMovementById(_ladmovements[pos]->movVars->varDownStop)->calcSomeXY(0, -1);
 
 		nx += point.x;
 		ny += point.y;
@@ -1796,7 +1796,7 @@ bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
 
 			item->_subItems[dir]._walk[act]._mov = mov;
 			if (mov) {
-				mov->calcSomeXY(point, 0, -1);
+				point = mov->calcSomeXY(0, -1);
 				item->_subItems[dir]._walk[act]._mx = point.x;
 				item->_subItems[dir]._walk[act]._my = point.y;
 			}
@@ -1826,7 +1826,7 @@ bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
 
 			item->_subItems[dir]._turn[act]._mov = mov;
 			if (mov) {
-				mov->calcSomeXY(point, 0, -1);
+				point = mov->calcSomeXY(0, -1);
 				item->_subItems[dir]._turn[act]._mx = point.x;
 				item->_subItems[dir]._turn[act]._my = point.y;
 			}
@@ -1856,7 +1856,7 @@ bool MctlGraph::fillData(StaticANIObject *obj, MctlAni *item) {
 
 			item->_subItems[dir]._turnS[act]._mov = mov;
 			if (mov) {
-				mov->calcSomeXY(point, 0, -1);
+				point = mov->calcSomeXY(0, -1);
 				item->_subItems[dir]._turnS[act]._mx = point.x;
 				item->_subItems[dir]._turnS[act]._my = point.y;
 			}
@@ -2242,7 +2242,7 @@ MessageQueue *MctlGraph::makeQueue(StaticANIObject *obj, int xpos, int ypos, int
 			newx = obj->_ox;
 			newy = obj->_oy;
 		} else {
-			obj->_movement->calcSomeXY(point, 0, picAniInfo.dynamicPhaseIndex);
+			point = obj->_movement->calcSomeXY(0, picAniInfo.dynamicPhaseIndex);
 			newx = obj->_movement->_ox - point.x;
 			newy = obj->_movement->_oy - point.y;
 			if (idxsub != 1 && idxsub) {
@@ -2540,7 +2540,7 @@ MessageQueue *MctlGraph::makeLineQueue(MctlMQ *info) {
 	int a2 = 0;
 	int mgmLen;
 
-	_aniHandler.getNumCycles(&point, _items2[info->index]->_subItems[info->subIndex]._walk[1]._mov, x, y, &mgmLen, &a2, info->flags & 1);
+	point = _aniHandler.getNumCycles(_items2[info->index]->_subItems[info->subIndex]._walk[1]._mov, x, y, &mgmLen, &a2, info->flags & 1);
 
 	int x1 = point.x;
 	int y1 = point.y;

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -105,6 +105,10 @@ MovGraphLink *MotionController::getLinkByName(const char *name) {
 	return 0;
 }
 
+MctlCompound::~MctlCompound() {
+	Common::for_each(_motionControllers.begin(), _motionControllers.end(), Common::DefaultDeleter<MctlItem>());
+}
+
 bool MctlCompound::load(MfcArchive &file) {
 	debugC(5, kDebugLoading, "MctlCompound::load()");
 
@@ -729,18 +733,6 @@ void MctlMQ::clear() {
 
 MctlItem::~MctlItem() {
 	Common::for_each(_connectionPoints.begin(), _connectionPoints.end(), Common::DefaultDeleter<MctlConnectionPoint>());
-}
-
-bool MctlCompoundArray::load(MfcArchive &file) {
-	debugC(5, kDebugLoading, "MctlCompoundArray::load()");
-
-	int count = file.readUint32LE();
-
-	debugC(0, kDebugLoading, "MctlCompoundArray::count = %d", count);
-
-	assert(0);
-
-	return true;
 }
 
 MovGraphItem::MovGraphItem() {

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -713,19 +713,6 @@ MctlConnectionPoint::MctlConnectionPoint() {
 	_mctlmirror = 0;
 }
 
-MctlMQ::MctlMQ(MctlMQ *src) {
-	index = src->index;
-	pt1 = src->pt1;
-	pt2 = src->pt2;
-	distance1 = src->distance1;
-	distance2 = src->distance2;
-	subIndex = src->subIndex;
-	item1Index = src->item1Index;
-	items = src->items;
-	itemsCount = src->itemsCount;
-	flags = src->flags;
-}
-
 void MctlMQ::clear() {
 	index = 0;
 	pt1.x = pt1.y = 0;

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -171,7 +171,9 @@ void MctlCompound::initMctlGraph() {
 		MctlGraph *newgr = new MctlGraph();
 
 		newgr->_links = gr->_links;
+		gr->_links.clear();
 		newgr->_nodes = gr->_nodes;
+		gr->_nodes.clear();
 
 		_motionControllers[i]->_motionControllerObj.reset(newgr);
 	}

--- a/engines/fullpipe/motion.h
+++ b/engines/fullpipe/motion.h
@@ -84,15 +84,15 @@ public:
 
 class MctlItem : public CObject {
 public:
-	MotionController *_motionControllerObj;
-	MovGraphReact *_movGraphReactObj;
+	Common::ScopedPtr<MotionController> _motionControllerObj;
+	Common::ScopedPtr<MovGraphReact> _movGraphReactObj;
 	Common::Array<MctlConnectionPoint *> _connectionPoints;
 	int _field_20;
 	int _field_24;
 	int _field_28;
 
 public:
-	MctlItem() : _movGraphReactObj(0), _motionControllerObj(0), _field_20(0), _field_24(0), _field_28(0) {}
+	MctlItem() : _field_20(0), _field_24(0), _field_28(0) {}
 	~MctlItem();
 };
 
@@ -120,7 +120,7 @@ public:
 	void replaceNodeX(int from, int to);
 
 	uint getMotionControllerCount() { return _motionControllers.size(); }
-	MotionController *getMotionController(int num) { return _motionControllers[num]->_motionControllerObj; }
+	MotionController *getMotionController(int num) { return _motionControllers[num]->_motionControllerObj.get(); }
 };
 
 struct MctlLadderMovementVars {
@@ -414,11 +414,10 @@ public:
 	int _mctlflags;
 	int _mctlstatic;
 	int16 _mctlmirror;
-	MessageQueue *_messageQueueObj;
+	Common::ScopedPtr<MessageQueue> _messageQueueObj;
 	int _motionControllerObj;
 
 	MctlConnectionPoint();
-	~MctlConnectionPoint();
 };
 
 } // End of namespace Fullpipe

--- a/engines/fullpipe/motion.h
+++ b/engines/fullpipe/motion.h
@@ -70,13 +70,9 @@ public:
 
 class MovGraphReact : public CObject {
 public:
-	int _pointCount;
-	Common::Point **_points;
+	PointList _points;
 
 public:
-	MovGraphReact() : _pointCount(0), _points(0) {}
-	~MovGraphReact() { free(_points); }
-
 	virtual void setCenter(int x1, int y1, int x2, int y2) {}
 	virtual void createRegion() {}
 	virtual bool pointInRegion(int x, int y);
@@ -200,20 +196,19 @@ public:
 };
 
 class ReactPolygonal : public MovGraphReact {
-	Common::Rect *_bbox;
+	Common::Rect _bbox;
 	int _centerX;
 	int _centerY;
 
 public:
 	ReactPolygonal();
-	~ReactPolygonal();
 
 	virtual bool load(MfcArchive &file);
 
 	virtual void setCenter(int x1, int y1, int x2, int y2);
 	virtual void createRegion();
 
-	void getBBox(Common::Rect *rect);
+	Common::Rect getBBox();
 };
 
 class MovGraphLink : public CObject {
@@ -238,6 +233,7 @@ class MovGraphLink : public CObject {
 
 	void recalcLength();
 };
+typedef Common::Array<MovGraphLink *> MovGraphLinkList;
 
 struct MovStep {
 	int sfield_0;
@@ -315,7 +311,7 @@ public:
 	MovGraphNode *calcOffset(int ox, int oy);
 	int getObjectIndex(StaticANIObject *ani);
 	Common::Array<MovArr *> *getHitPoints(int x, int y, int *arrSize, int flag1, int flag2);
-	void findAllPaths(MovGraphLink *lnk, MovGraphLink *lnk2, Common::Array<MovGraphLink *> &tempObList1, Common::Array<MovGraphLink *> &tempObList2);
+	void findAllPaths(MovGraphLink *lnk, MovGraphLink *lnk2, MovGraphLinkList &tempObList1, MovGraphLinkList &tempObList2);
 	Common::Array<MovItem *> *getPaths(MovArr *movarr1, MovArr *movarr2, int *listCount);
 	void genMovItem(MovItem *movitem, MovGraphLink *grlink, MovArr *movarr1, MovArr *movarr2);
 	bool getHitPoint(int idx, int x, int y, MovArr *arr, int a6);
@@ -361,12 +357,10 @@ struct MctlMQ {
 	int distance2;
 	int subIndex;
 	int item1Index;
-	Common::Array<MctlMQSub *> items;
-	int itemsCount;
+	Common::Array<MctlMQSub> items;
 	int flags;
 
 	MctlMQ() { clear(); }
-	MctlMQ(MctlMQ *src);
 	void clear();
 };
 
@@ -378,7 +372,7 @@ struct MctlAni { // 744
 
 class MctlGraph : public MovGraph {
 public:
-	Common::Array<MctlAni *> _items2;
+	Common::Array<MctlAni> _items2;
 
 public:
 	virtual void attachObject(StaticANIObject *obj);
@@ -393,16 +387,16 @@ public:
 	int getDirByPoint(int idx, StaticANIObject *ani);
 
 	int getDirBySize(MovGraphLink *lnk, int x, int y);
-	int getLinkDir(Common::Array<MovGraphLink *> *linkList, int idx, Common::Rect *a3, Common::Point *a4);
+	int getLinkDir(MovGraphLinkList *linkList, int idx, Common::Rect *a3, Common::Point *a4);
 
-	bool fillData(StaticANIObject *obj, MctlAni *item);
-	void generateList(MctlMQ *movinfo, Common::Array<MovGraphLink *> *linkList, LinkInfo *lnkSrc, LinkInfo *lnkDst);
-	MessageQueue *makeWholeQueue(MctlMQ *mctlMQ);
+	bool fillData(StaticANIObject *obj, MctlAni &item);
+	void generateList(MctlMQ &movinfo, MovGraphLinkList *linkList, LinkInfo *lnkSrc, LinkInfo *lnkDst);
+	MessageQueue *makeWholeQueue(MctlMQ &mctlMQ);
 
 	MovGraphNode *getHitNode(int x, int y, int strictMatch);
 	MovGraphLink *getHitLink(int x, int y, int idx, int fuzzyMatch);
 	MovGraphLink *getNearestLink(int x, int y);
-	double iterate(LinkInfo *linkInfoSource, LinkInfo *linkInfoDest, Common::Array<MovGraphLink *> *listObj);
+	double iterate(LinkInfo *linkInfoSource, LinkInfo *linkInfoDest, MovGraphLinkList *listObj);
 
 	MessageQueue *makeLineQueue(MctlMQ *movinfo);
 };

--- a/engines/fullpipe/motion.h
+++ b/engines/fullpipe/motion.h
@@ -92,16 +92,13 @@ public:
 	~MctlItem();
 };
 
-class MctlCompoundArray : public Common::Array<MctlItem *>, public CObject {
- public:
-	virtual bool load(MfcArchive &file);
-};
-
 class MctlCompound : public MotionController {
 public:
-	MctlCompoundArray _motionControllers;
+	/** list items are owned */
+	Common::Array<MctlItem *> _motionControllers;
 
 	MctlCompound() { _objtype = kObjTypeMctlCompound; }
+	virtual ~MctlCompound();
 
 	virtual bool load(MfcArchive &file);
 

--- a/engines/fullpipe/motion.h
+++ b/engines/fullpipe/motion.h
@@ -276,17 +276,22 @@ struct MovGraphItem {
 };
 
 class MovGraph : public MotionController {
-public:
+friend class MctlCompound;
+friend class MctlGraph;
+friend class MotionController;
+private:
 	ObList _nodes;
 	ObList _links;
 	int _field_44;
-	Common::Array<MovGraphItem *> _items;
+	Common::Array<MovGraphItem> _items;
 	MovArr *(*_callback1)(StaticANIObject *ani, Common::Array<MovItem *> *items, signed int counter);
 	AniHandler _aniHandler;
 
 public:
 	MovGraph();
 	virtual ~MovGraph();
+
+	static int messageHandler(ExCommand *cmd);
 
 	virtual bool load(MfcArchive &file);
 

--- a/engines/fullpipe/motion.h
+++ b/engines/fullpipe/motion.h
@@ -280,8 +280,10 @@ friend class MctlCompound;
 friend class MctlGraph;
 friend class MotionController;
 private:
-	ObList _nodes;
-	ObList _links;
+	typedef ObList<MovGraphNode> NodeList;
+	typedef ObList<MovGraphLink> LinkList;
+	NodeList _nodes;
+	LinkList _links;
 	int _field_44;
 	Common::Array<MovGraphItem> _items;
 	MovArr *(*_callback1)(StaticANIObject *ani, Common::Array<MovItem *> *items, signed int counter);

--- a/engines/fullpipe/ngiarchive.cpp
+++ b/engines/fullpipe/ngiarchive.cpp
@@ -70,7 +70,6 @@ NGIArchive::NGIArchive(const Common::String &filename) : _ngiFilename(filename) 
 	}
 
 	NgiHeader header;
-	NgiHeader *head;
 
 	for (uint i = 0; i < count; i++) {
 		memcpy(header.filename, &fat[i * 32], 12);
@@ -84,9 +83,7 @@ NGIArchive::NGIArchive(const Common::String &filename) : _ngiFilename(filename) 
 			warning("File has flags: %.8x\n", header.flags & 0x1e0);
 		}
 
-		head = new NgiHeader(header);
-
-		_headers[header.filename] = head;
+		_headers[header.filename].reset(new NgiHeader(header));
 	}
 
 	free(fat);
@@ -98,19 +95,14 @@ NGIArchive::NGIArchive(const Common::String &filename) : _ngiFilename(filename) 
 
 NGIArchive::~NGIArchive() {
 	debugC(0, kDebugLoading, "NGIArchive Destructor Called");
-	NgiHeadersMap::iterator it = _headers.begin();
-	for ( ; it != _headers.end(); ++it) {
-		delete it->_value;
-	}
-
-	g_fp->_currArchive = 0;
+	g_fp->_currArchive = nullptr;
 }
 
 bool NGIArchive::hasFile(const Common::String &name) const {
 	return _headers.contains(name);
 }
 
-	int NGIArchive::listMembers(Common::ArchiveMemberList &list) const {
+int NGIArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int matches = 0;
 
 	NgiHeadersMap::const_iterator it = _headers.begin();
@@ -134,7 +126,7 @@ Common::SeekableReadStream *NGIArchive::createReadStreamForMember(const Common::
 		return 0;
 	}
 
-	NgiHeader *hdr = _headers[name];
+	NgiHeader *hdr = _headers[name].get();
 
 	Common::File archiveFile;
 	archiveFile.open(_ngiFilename);
@@ -149,7 +141,7 @@ Common::SeekableReadStream *NGIArchive::createReadStreamForMember(const Common::
 	return new Common::MemoryReadStream(data, hdr->size, DisposeAfterUse::YES);
 }
 
-Common::Archive *makeNGIArchive(const Common::String &name) {
+NGIArchive *makeNGIArchive(const Common::String &name) {
 	return new NGIArchive(name);
 }
 

--- a/engines/fullpipe/ngiarchive.h
+++ b/engines/fullpipe/ngiarchive.h
@@ -23,6 +23,7 @@
 #ifndef FULLPIPE_NGIARCHIVE_H
 #define FULLPIPE_NGIARCHIVE_H
 
+#include "common/ptr.h"
 #include "common/str.h"
 
 namespace Fullpipe {
@@ -39,7 +40,7 @@ struct NgiHeader {
 	char  filename[NGI_FILENAME_MAX];
 };
 
-typedef Common::HashMap<Common::String, NgiHeader*, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> NgiHeadersMap;
+typedef Common::HashMap<Common::String, Common::ScopedPtr<NgiHeader>, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> NgiHeadersMap;
 
 class NGIArchive : public Common::Archive {
 	NgiHeadersMap _headers;
@@ -62,7 +63,7 @@ public:
  *
  * May return 0 in case of a failure.
  */
-Common::Archive *makeNGIArchive(const Common::String &name);
+NGIArchive *makeNGIArchive(const Common::String &name);
 
 } // End of namespace Fullpipe
 

--- a/engines/fullpipe/objects.h
+++ b/engines/fullpipe/objects.h
@@ -23,6 +23,7 @@
 #ifndef FULLPIPE_OBJECTS_H
 #define FULLPIPE_OBJECTS_H
 
+#include "common/ptr.h"
 #include "fullpipe/utils.h"
 
 namespace Fullpipe {
@@ -34,12 +35,11 @@ class GameProject : public CObject {
  public:
 	int _field_4;
 	Common::String _headerFilename;
-	SceneTagList *_sceneTagList;
+	Common::ScopedPtr<SceneTagList> _sceneTagList;
 	int _field_10;
 
  public:
 	GameProject();
-	~GameProject();
 	virtual bool load(MfcArchive &file);
 };
 

--- a/engines/fullpipe/objects.h
+++ b/engines/fullpipe/objects.h
@@ -66,6 +66,7 @@ struct PicAniInfo {
 
 	PicAniInfo() { memset(this, 0, sizeof(PicAniInfo)); }
 };
+typedef Common::Array<PicAniInfo> PicAniInfoList;
 
 union VarValue {
 	float floatValue;

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -61,9 +61,8 @@ bool SceneTagList::load(MfcArchive &file) {
 	int numEntries = file.readUint16LE();
 
 	for (int i = 0; i < numEntries; i++) {
-		SceneTag *t = new SceneTag();
-		t->load(file);
-		push_back(*t);
+		push_back(SceneTag());
+		back().load(file);
 	}
 
 	return true;

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -655,7 +655,7 @@ void Scene::update(int counterdiff) {
 }
 
 void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
-	if (!_picObjList.size() && !_bigPictureArray1Count)
+	if (!_picObjList.size() && !_bigPictureXDim)
 		return;
 
 	if (_palette.size()) {
@@ -682,11 +682,11 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 
 	Dims dims;
 
-	debugC(1, kDebugDrawing, "_bigPict: %d objlist: %d", _bigPictureArray1Count, _picObjList.size());
+	debugC(1, kDebugDrawing, "_bigPict: %d objlist: %d", _bigPictureXDim, _picObjList.size());
 
-	if (drawBg && _bigPictureArray1Count && _picObjList.size()) {
+	if (drawBg && _bigPictureXDim && _picObjList.size()) {
 
-		dims = _bigPictureArray[0][0]->getDimensions();
+		dims = _bigPictureArray[0]->getDimensions();
 
 		int width = dims.x;
 		int height = dims.y;
@@ -716,26 +716,26 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 		int bgPosX = g_fp->_sceneRect.left - bgOffsetX;
 
 		if (bgPosX < g_fp->_sceneRect.right - 1) {
-			while (1) {
-				int v25 = bgNumY;
+			for (;;) {
+				uint v25 = bgNumY;
 				for (int y = g_fp->_sceneRect.top - bgOffsetY; y < g_fp->_sceneRect.bottom - 1;) {
-					BigPicture *v27 = _bigPictureArray[bgNumX][v25];
+					BigPicture *v27 = getBigPicture(bgNumX, v25);
 					v27->draw(bgPosX, y, 0, 0);
 					y += v27->getDimensions().y;
 					v25++;
 
-					if (v25 >= _bigPictureArray2Count) {
+					if (v25 >= _bigPictureYDim) {
 						if (!(_picObjList[0]->_flags & 0x20))
 							break;
 						v25 = 0;
 					}
 				}
-				dims = _bigPictureArray[bgNumX][0]->getDimensions();
+				dims = getBigPicture(bgNumX, 0)->getDimensions();
 				int oldx = dims.x + bgPosX;
 				bgPosX += dims.x;
 				bgNumX++;
 
-				if (bgNumX >= _bigPictureArray1Count) {
+				if (bgNumX >= (int)_bigPictureXDim) {
 					if (!(_picObjList[0]->_flags & 0x2))
 						break;
 					bgNumX = 0;

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -251,7 +251,7 @@ void Scene::init() {
 	g_fp->_sceneRect.moveTo(0, 0);
 
 	for (uint i = 0; i < _picObjList.size(); i++)
-		((PictureObject *)_picObjList[i])->clearFlags();
+		_picObjList[i]->clearFlags();
 
 	for (uint i = 0; i < _staticANIObjectList1.size(); i++)
 		_staticANIObjectList1[i]->clearFlags();
@@ -324,7 +324,7 @@ void Scene::addStaticANIObject(StaticANIObject *obj, bool addList2) {
 
 void Scene::setPictureObjectsFlag4() {
 	for (uint i = 0; i < _picObjList.size(); i++) {
-		((PictureObject *)_picObjList[i])->_flags |= 4;
+		_picObjList[i]->_flags |= 4;
 	}
 }
 
@@ -335,8 +335,8 @@ void Scene::stopAllSounds() {
 
 PictureObject *Scene::getPictureObjectById(int objId, int flags) {
 	for (uint i = 1; i < _picObjList.size(); i++) {
-		if (((PictureObject *)_picObjList[i])->_id == objId && ((PictureObject *)_picObjList[i])->_odelay == flags)
-			return (PictureObject *)_picObjList[i];
+		if (_picObjList[i]->_id == objId && _picObjList[i]->_odelay == flags)
+			return _picObjList[i];
 	}
 
 	return 0;
@@ -344,8 +344,8 @@ PictureObject *Scene::getPictureObjectById(int objId, int flags) {
 
 PictureObject *Scene::getPictureObjectByName(const Common::String &objName, int flags) {
 	for (uint i = 0; i < _picObjList.size(); i++) {
-		if ((((PictureObject *)_picObjList[i])->_objectName == objName) && (((PictureObject *)_picObjList[i])->_odelay == flags || flags == -1))
-			return (PictureObject *)_picObjList[i];
+		if ((_picObjList[i]->_objectName == objName) && (_picObjList[i]->_odelay == flags || flags == -1))
+			return _picObjList[i];
 	}
 
 	return 0;
@@ -353,7 +353,7 @@ PictureObject *Scene::getPictureObjectByName(const Common::String &objName, int 
 
 void Scene::deletePictureObject(PictureObject *obj) {
 	for (uint i = 0; i < _picObjList.size(); i++) {
-		if (((PictureObject *)_picObjList[i]) == obj) {
+		if (_picObjList[i] == obj) {
 			_picObjList.remove_at(i);
 			delete obj;
 
@@ -547,7 +547,7 @@ void Scene::updateScrolling() {
 		int offsetY = 0;
 
 		if (_x < 0) {
-			if (!g_fp->_sceneRect.left && !(((PictureObject *)_picObjList[0])->_flags & 2))
+			if (!g_fp->_sceneRect.left && !(_picObjList[0]->_flags & 2))
 				_x = 0;
 
 			if (_x <= -g_fp->_scrollSpeed) {
@@ -620,7 +620,7 @@ PictureObject *Scene::getPictureObjectAtPos(int x, int y) {
 	PictureObject *res = 0;
 
 	for (uint i = 0; i < _picObjList.size(); i++) {
-		PictureObject *p = (PictureObject *)_picObjList[i];
+		PictureObject *p = _picObjList[i];
 		if ((p->_field_8 & 0x100) && (p->_flags & 4) &&
 				p->isPixelHitAtPos(x, y) &&
 				(!res || res->_priority >= p->_priority))
@@ -635,7 +635,7 @@ int Scene::getPictureObjectIdAtPos(int x, int y) {
 	int res = 0;
 
 	for (uint i = 0; i < _picObjList.size(); i++) {
-		PictureObject *p = (PictureObject *)_picObjList[i];
+		PictureObject *p = _picObjList[i];
 		if ((p->_field_8 & 0x100) && (p->_flags & 4) &&
 				p->isPixelHitAtPos(x, y) &&
 				(!res || resp->_priority >= p->_priority)) {
@@ -673,7 +673,7 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 #endif
 
 	if (minPri == -1 && _picObjList.size())
-		minPri = ((PictureObject *)_picObjList.back())->_priority - 1;
+		minPri = _picObjList.back()->_priority - 1;
 
 	if (maxPri == -1)
 		maxPri = 60000;
@@ -725,7 +725,7 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 					v25++;
 
 					if (v25 >= _bigPictureArray2Count) {
-						if (!(((PictureObject *)_picObjList[0])->_flags & 0x20))
+						if (!(_picObjList[0]->_flags & 0x20))
 							break;
 						v25 = 0;
 					}
@@ -736,7 +736,7 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 				bgNumX++;
 
 				if (bgNumX >= _bigPictureArray1Count) {
-					if (!(((PictureObject *)_picObjList[0])->_flags & 0x2))
+					if (!(_picObjList[0]->_flags & 0x2))
 						break;
 					bgNumX = 0;
 				}
@@ -748,7 +748,7 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 
 
 	for (uint i = 1; i < _picObjList.size(); i++) {
-		PictureObject *obj = (PictureObject *)_picObjList[i];
+		PictureObject *obj = _picObjList[i];
 
 		if (obj->_priority < minPri || obj->_priority >= maxPri)
 			continue;

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -523,7 +523,7 @@ void Scene::draw() {
 	updateScrolling();
 
 	// Clean previous stuff
-	g_fp->_backgroundSurface->fillRect(Common::Rect(0, 0, 800, 600), 0);
+	g_fp->_backgroundSurface.fillRect(Common::Rect(0, 0, 800, 600), 0);
 
 	drawContent(60000, 0, true);
 

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -68,17 +68,16 @@ bool SceneTagList::load(MfcArchive &file) {
 	return true;
 }
 
-SceneTag::SceneTag() {
-	_field_4 = 0;
-	_scene = 0;
-	_sceneId = 0;
+SceneTag::SceneTag() :
+	_scene(nullptr),
+	_sceneId(0) {}
+
+SceneTag::~SceneTag() {
+	delete _scene;
 }
 
 bool SceneTag::load(MfcArchive &file) {
 	debugC(5, kDebugLoading, "SceneTag::load()");
-
-	_field_4 = 0;
-	_scene = 0;
 
 	_sceneId = file.readUint16LE();
 
@@ -89,11 +88,6 @@ bool SceneTag::load(MfcArchive &file) {
 	return true;
 }
 
-SceneTag::~SceneTag() {
-	delete _scene;
-	delete _field_4;
-}
-
 void SceneTag::loadScene() {
 	Common::String archname = genFileName(0, _sceneId, "nl");
 
@@ -101,20 +95,19 @@ void SceneTag::loadScene() {
 
 	Common::String fname = genFileName(0, _sceneId, "sc");
 
-	Common::SeekableReadStream *file = arch->createReadStreamForMember(fname);
+	Common::ScopedPtr<Common::SeekableReadStream> file(arch->createReadStreamForMember(fname));
 
+	delete _scene;
 	_scene = new Scene();
 
-	MfcArchive archive(file);
+	MfcArchive archive(file.get());
 
 	_scene->load(archive);
 
 	if (_scene->_shadows)
 		_scene->_shadows->init();
 
-	delete file;
-
-	g_fp->_currArchive = 0;
+	g_fp->_currArchive = nullptr;
 }
 
 Scene::Scene() : _sceneId(0), _field_BC(0) {}

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -591,13 +591,11 @@ void Scene::updateScrolling() {
 
 void Scene::updateScrolling2() {
 	if (_picObjList.size()) {
-		Common::Point point;
 		int offsetY = 0;
 		int offsetX = 0;
 
-		((PictureObject *)_picObjList[0])->getDimensions(&point);
-
-		int flags = ((PictureObject *)_picObjList[0])->_flags;
+		const Dims dims = _picObjList[0]->getDimensions();
+		const int flags = _picObjList[0]->_flags;
 
 		if (g_fp->_sceneRect.left < 0 && !(flags & 2))
 			offsetX = -g_fp->_sceneRect.left;
@@ -605,11 +603,11 @@ void Scene::updateScrolling2() {
 		if (g_fp->_sceneRect.top < 0 && !(flags & 0x20))
 			offsetY = -g_fp->_sceneRect.top;
 
-		if (g_fp->_sceneRect.right > point.x - 1 && g_fp->_sceneRect.left > 0 && !(flags & 2))
-			offsetX = point.x - g_fp->_sceneRect.right - 1;
+		if (g_fp->_sceneRect.right > dims.x - 1 && g_fp->_sceneRect.left > 0 && !(flags & 2))
+			offsetX = dims.x - g_fp->_sceneRect.right - 1;
 
-		if (g_fp->_sceneRect.bottom > point.y - 1 && g_fp->_sceneRect.top > 0 && !(flags & 0x20))
-			offsetY = point.y - g_fp->_sceneRect.bottom - 1;
+		if (g_fp->_sceneRect.bottom > dims.y - 1 && g_fp->_sceneRect.top > 0 && !(flags & 0x20))
+			offsetY = dims.y - g_fp->_sceneRect.bottom - 1;
 
 		g_fp->_sceneRect.translate(offsetX, offsetY);
 	}
@@ -694,35 +692,35 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 
 	debugC(1, kDebugDrawing, "-> Scene::drawContent(>%d, <%d, %d)", minPri, maxPri, drawBg);
 
-	Common::Point point;
+	Dims dims;
 
 	debugC(1, kDebugDrawing, "_bigPict: %d objlist: %d", _bigPictureArray1Count, _picObjList.size());
 
 	if (drawBg && _bigPictureArray1Count && _picObjList.size()) {
 
-		_bigPictureArray[0][0]->getDimensions(&point);
+		dims = _bigPictureArray[0][0]->getDimensions();
 
-		int width = point.x;
-		int height = point.y;
+		int width = dims.x;
+		int height = dims.y;
 
 		debugC(8, kDebugDrawing, "w: %d h:%d", width, height);
 
-		((PictureObject *)_picObjList[0])->getDimensions(&point);
+		dims = _picObjList[0]->getDimensions();
 
-		debugC(8, kDebugDrawing, "w2: %d h2:%d", point.x, point.y);
+		debugC(8, kDebugDrawing, "w2: %d h2:%d", dims.x, dims.y);
 
-		int bgStX = g_fp->_sceneRect.left % point.x;
+		int bgStX = g_fp->_sceneRect.left % dims.x;
 
 		if (bgStX < 0)
-			bgStX += point.x;
+			bgStX += dims.x;
 
 		int bgNumX = bgStX / width;
 		int bgOffsetX = bgStX % width;
 
-		int bgStY = g_fp->_sceneRect.top % point.y;
+		int bgStY = g_fp->_sceneRect.top % dims.y;
 
 		if (bgStY < 0)
-			bgStY += point.y;
+			bgStY += dims.y;
 
 		int bgNumY = bgStY / height;
 		int bgOffsetY = bgStY % height;
@@ -735,7 +733,7 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 				for (int y = g_fp->_sceneRect.top - bgOffsetY; y < g_fp->_sceneRect.bottom - 1;) {
 					BigPicture *v27 = _bigPictureArray[bgNumX][v25];
 					v27->draw(bgPosX, y, 0, 0);
-					y += v27->getDimensions(&point)->y;
+					y += v27->getDimensions().y;
 					v25++;
 
 					if (v25 >= _bigPictureArray2Count) {
@@ -744,9 +742,9 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 						v25 = 0;
 					}
 				}
-				_bigPictureArray[bgNumX][0]->getDimensions(&point);
-				int oldx = point.x + bgPosX;
-				bgPosX += point.x;
+				dims = _bigPictureArray[bgNumX][0]->getDimensions();
+				int oldx = dims.x + bgPosX;
+				bgPosX += dims.x;
 				bgNumX++;
 
 				if (bgNumX >= _bigPictureArray1Count) {
@@ -772,10 +770,10 @@ void Scene::drawContent(int minPri, int maxPri, bool drawBg) {
 
 		debugC(8, kDebugDrawing, "obj: %d %d", objX, objY);
 
-		obj->getDimensions(&point);
+		dims = obj->getDimensions();
 
-		int width = point.x;
-		int height = point.y;
+		int width = dims.x;
+		int height = dims.y;
 
 		if (obj->_flags & 8) {
 			while (objX > g_fp->_sceneRect.right) {

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -342,7 +342,7 @@ void Scene::setPictureObjectsFlag4() {
 
 void Scene::stopAllSounds() {
 	for (int i = 0; i < _soundList->getCount(); i++)
-		_soundList->getSoundByIndex(i)->stop();
+		_soundList->getSoundByIndex(i).stop();
 }
 
 PictureObject *Scene::getPictureObjectById(int objId, int flags) {

--- a/engines/fullpipe/scene.cpp
+++ b/engines/fullpipe/scene.cpp
@@ -117,18 +117,9 @@ void SceneTag::loadScene() {
 	g_fp->_currArchive = 0;
 }
 
-Scene::Scene() {
-	_sceneId = 0;
-	_field_BC = 0;
-	_shadows = 0;
-	_soundList = 0;
-	_libHandle = 0;
-}
+Scene::Scene() : _sceneId(0), _field_BC(0) {}
 
 Scene::~Scene() {
-	delete _soundList;
-	delete _shadows;
-
 	// _faObjlist is not used
 
 	for (uint i = 0; i < _messageQueueList.size(); i++)
@@ -140,8 +131,6 @@ Scene::~Scene() {
 		delete _staticANIObjectList1[i];
 
 	_staticANIObjectList1.clear();
-
-	delete _libHandle;
 
 	// delete _field_BC;
 }
@@ -206,7 +195,7 @@ bool Scene::load(MfcArchive &file) {
 		assert(0);
 	}
 
-	_libHandle = g_fp->_currArchive;
+	_libHandle.reset(g_fp->_currArchive);
 
 	if (_picObjList.size() > 0 && !_bgname.empty()) {
 		char fname[260];
@@ -231,12 +220,14 @@ bool Scene::load(MfcArchive &file) {
 	Shadows *shd = new Shadows();
 
 	if (shd->loadFile(shdname))
-		_shadows = shd;
+		_shadows.reset(shd);
+	else
+		delete shd;
 
 	Common::String slsname = genFileName(0, _sceneId, "sls");
 
 	if (g_fp->_soundEnabled) {
-		_soundList = new SoundList();
+		_soundList.reset(new SoundList());
 
 		if (g_fp->_flgSoundList) {
 			Common::String nlname = genFileName(17, _sceneId, "nl");

--- a/engines/fullpipe/scene.h
+++ b/engines/fullpipe/scene.h
@@ -65,6 +65,7 @@ class Scene : public Background {
 	MessageQueue *getMessageQueueByName(const Common::String &name);
 
 	void deleteStaticANIObject(StaticANIObject *obj);
+	/** takes ownership of the passed obj */
 	void addStaticANIObject(StaticANIObject *obj, bool addList2);
 
 	void setPictureObjectsFlag4();
@@ -94,14 +95,14 @@ class Scene : public Background {
 
 class SceneTag : public CObject {
  public:
-	CObject *_field_4;
 	Common::String _tag;
+	/** owned, but cannot use ScopedPtr because this object must be copyable */
 	Scene *_scene;
 	int16 _sceneId;
 
  public:
 	SceneTag();
-	~SceneTag();
+	virtual ~SceneTag();
 
 	virtual bool load(MfcArchive &file);
 	void loadScene();

--- a/engines/fullpipe/scene.h
+++ b/engines/fullpipe/scene.h
@@ -23,6 +23,7 @@
 #ifndef FULLPIPE_SCENE_H
 #define FULLPIPE_SCENE_H
 
+#include "common/ptr.h"
 #include "fullpipe/gfx.h"
 
 namespace Fullpipe {
@@ -35,12 +36,12 @@ class Scene : public Background {
 	Common::Array<StaticANIObject *> _staticANIObjectList2;
 	Common::Array<MessageQueue *> _messageQueueList;
 	// PtrList _faObjectList; // not used
-	Shadows *_shadows;
-	SoundList *_soundList;
+	Common::ScopedPtr<Shadows> _shadows;
+	Common::ScopedPtr<SoundList> _soundList;
 	int16 _sceneId;
 	Common::String _sceneName;
 	int _field_BC;
-	NGIArchive *_libHandle;
+	Common::ScopedPtr<NGIArchive> _libHandle;
 
   public:
 	Scene();

--- a/engines/fullpipe/scene.h
+++ b/engines/fullpipe/scene.h
@@ -32,7 +32,9 @@ class MessageQueue;
 
 class Scene : public Background {
  public:
+	/** list items are owned */
 	Common::Array<StaticANIObject *> _staticANIObjectList1;
+
 	Common::Array<StaticANIObject *> _staticANIObjectList2;
 	Common::Array<MessageQueue *> _messageQueueList;
 	// PtrList _faObjectList; // not used

--- a/engines/fullpipe/scenes.cpp
+++ b/engines/fullpipe/scenes.cpp
@@ -530,11 +530,11 @@ void FullpipeEngine::sceneAutoScrolling() {
 	}
 }
 
-bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
+bool FullpipeEngine::sceneSwitcher(const EntranceInfo &entrance) {
 	GameVar *sceneVar;
 	Common::Point sceneDim;
 
-	Scene *scene = accessScene(entrance->_sceneId);
+	Scene *scene = accessScene(entrance._sceneId);
 
 	if (!scene)
 		return 0;
@@ -563,7 +563,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 	_updateFlag = true;
 	_flgCanOpenMap = true;
 
-	if (entrance->_sceneId == SC_DBGMENU) {
+	if (entrance._sceneId == SC_DBGMENU) {
 		_inventoryScene = 0;
 	} else {
 		_gameLoader->loadScene(SC_INV);
@@ -594,7 +594,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 	_aniMan->setOXY(0, 0);
 
 	_aniMan2 = _aniMan;
-	MctlCompound *cmp = getSc2MctlCompoundBySceneId(entrance->_sceneId);
+	MctlCompound *cmp = getSc2MctlCompoundBySceneId(entrance._sceneId);
 	cmp->initMctlGraph();
 	cmp->attachObject(_aniMan);
 	cmp->activate();
@@ -612,7 +612,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 	removeMessageHandler(2, -1);
 	_updateScreenCallback = 0;
 
-	switch (entrance->_sceneId) {
+	switch (entrance._sceneId) {
 	case SC_INTRO1:
 		sceneVar = _gameLoader->_gameVar->getSubVarByName("SC_INTRO1");
 		scene->preloadMovements(sceneVar);
@@ -639,7 +639,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 		scene01_fixEntrance();
 		sceneVar = _gameLoader->_gameVar->getSubVarByName("SC_1");
 		scene->preloadMovements(sceneVar);
-		scene01_initScene(scene, entrance->_field_4);
+		scene01_initScene(scene, entrance._field_4);
 		_behaviorManager->initBehavior(scene, sceneVar);
 		scene->initObjectCursors("SC_1");
 		setSceneMusicParameters(sceneVar);
@@ -854,7 +854,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 
 			scene18_initScene2(g_fp->_scene3);
 			scene18_preload();
-			scene19_setMovements(g_fp->_scene3, entrance->_field_4);
+			scene19_setMovements(g_fp->_scene3, entrance._field_4);
 
 			g_vars->scene18_inScene18p1 = true;
 		}
@@ -938,12 +938,12 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 	case SC_25:
 		sceneVar = _gameLoader->_gameVar->getSubVarByName("SC_25");
 		scene->preloadMovements(sceneVar);
-		scene25_initScene(scene, entrance->_field_4);
+		scene25_initScene(scene, entrance._field_4);
 		_behaviorManager->initBehavior(scene, sceneVar);
 		scene->initObjectCursors("SC_25");
 		setSceneMusicParameters(sceneVar);
 		addMessageHandler(sceneHandler25, 2);
-		scene25_setupWater(scene, entrance->_field_4);
+		scene25_setupWater(scene, entrance._field_4);
 		_updateCursorCallback = scene25_updateCursor;
 		break;
 
@@ -995,7 +995,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 	case SC_30:
 		sceneVar = _gameLoader->_gameVar->getSubVarByName("SC_30");
 		scene->preloadMovements(sceneVar);
-		scene30_initScene(scene, entrance->_field_4);
+		scene30_initScene(scene, entrance._field_4);
 		_behaviorManager->initBehavior(scene, sceneVar);
 		scene->initObjectCursors("SC_30");
 		setSceneMusicParameters(sceneVar);
@@ -1115,7 +1115,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 		break;
 
 	default:
-		error("Unknown scene %d", entrance->_sceneId);
+		error("Unknown scene %d", entrance._sceneId);
 		break;
 	}
 

--- a/engines/fullpipe/scenes.cpp
+++ b/engines/fullpipe/scenes.cpp
@@ -573,15 +573,15 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 	if (_soundEnabled) {
 		if (scene->_soundList) {
 			_currSoundListCount = 2;
-			_currSoundList1[0] = accessScene(SC_COMMON)->_soundList;
-			_currSoundList1[1] = scene->_soundList;
+			_currSoundList1[0] = accessScene(SC_COMMON)->_soundList.get();
+			_currSoundList1[1] = scene->_soundList.get();
 
 			for (int i = 0; i < scene->_soundList->getCount(); i++) {
 				scene->_soundList->getSoundByIndex(i).updateVolume();
 			}
 		} else {
 			_currSoundListCount = 1;
-			_currSoundList1[0] = accessScene(SC_COMMON)->_soundList;
+			_currSoundList1[0] = accessScene(SC_COMMON)->_soundList.get();
 		}
 	}
 

--- a/engines/fullpipe/scenes.cpp
+++ b/engines/fullpipe/scenes.cpp
@@ -539,7 +539,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 	if (!scene)
 		return 0;
 
-	((PictureObject *)scene->_picObjList.front())->getDimensions(&sceneDim);
+	sceneDim = scene->_picObjList.front()->getDimensions();
 	_sceneWidth = sceneDim.x;
 	_sceneHeight = sceneDim.y;
 

--- a/engines/fullpipe/scenes.cpp
+++ b/engines/fullpipe/scenes.cpp
@@ -577,7 +577,7 @@ bool FullpipeEngine::sceneSwitcher(EntranceInfo *entrance) {
 			_currSoundList1[1] = scene->_soundList;
 
 			for (int i = 0; i < scene->_soundList->getCount(); i++) {
-				scene->_soundList->getSoundByIndex(i)->updateVolume();
+				scene->_soundList->getSoundByIndex(i).updateVolume();
 			}
 		} else {
 			_currSoundListCount = 1;

--- a/engines/fullpipe/scenes/scene02.cpp
+++ b/engines/fullpipe/scenes/scene02.cpp
@@ -113,12 +113,12 @@ int sceneHandler02(ExCommand *ex) {
 			if (g_vars->scene02_boxDelay >= 1) {
 				--g_vars->scene02_boxDelay;
 			} else if (g_fp->_floaters->_array2.size() >= 1) {
-				if (g_fp->_floaters->_array2[0]->val5 == -50) {
+				if (g_fp->_floaters->_array2[0].val5 == -50) {
 					g_fp->_floaters->stopAll();
 					g_vars->scene02_boxOpen = false;
 					g_vars->scene02_boxDelay = 100 * g_fp->_rnd.getRandomNumber(32767) + 150;
 				} else {
-					g_fp->_floaters->_array2[0]->val3 = -50;
+					g_fp->_floaters->_array2[0].val3 = -50;
 				}
 			} else {
 				g_fp->_floaters->genFlies(g_fp->_currentScene, g_fp->_rnd.getRandomNumber(700) + 100, -50, 0, 0);

--- a/engines/fullpipe/scenes/scene02.cpp
+++ b/engines/fullpipe/scenes/scene02.cpp
@@ -56,7 +56,7 @@ void scene02_initScene(Scene *sc) {
 		g_vars->scene02_boxOpen = false;
 	} else {
 		g_vars->scene02_boxOpen = true;
-		g_vars->scene02_boxDelay = 100 * g_fp->_rnd->getRandomNumber(32767) + 150;
+		g_vars->scene02_boxDelay = 100 * g_fp->_rnd.getRandomNumber(32767) + 150;
 	}
 
 	g_fp->_floaters->init(g_fp->_gameLoader->_gameVar->getSubVarByName("SC_2"));
@@ -116,13 +116,13 @@ int sceneHandler02(ExCommand *ex) {
 				if (g_fp->_floaters->_array2[0]->val5 == -50) {
 					g_fp->_floaters->stopAll();
 					g_vars->scene02_boxOpen = false;
-					g_vars->scene02_boxDelay = 100 * g_fp->_rnd->getRandomNumber(32767) + 150;
+					g_vars->scene02_boxDelay = 100 * g_fp->_rnd.getRandomNumber(32767) + 150;
 				} else {
 					g_fp->_floaters->_array2[0]->val3 = -50;
 				}
 			} else {
-				g_fp->_floaters->genFlies(g_fp->_currentScene, g_fp->_rnd->getRandomNumber(700) + 100, -50, 0, 0);
-				g_vars->scene02_boxDelay = 500 * g_fp->_rnd->getRandomNumber(32767) + 1000;
+				g_fp->_floaters->genFlies(g_fp->_currentScene, g_fp->_rnd.getRandomNumber(700) + 100, -50, 0, 0);
+				g_vars->scene02_boxDelay = 500 * g_fp->_rnd.getRandomNumber(32767) + 1000;
 			}
 		}
 

--- a/engines/fullpipe/scenes/scene03.cpp
+++ b/engines/fullpipe/scenes/scene03.cpp
@@ -210,7 +210,7 @@ void sceneHandler03_takeEgg(ExCommand *ex) {
 			 && ex1) {
 
 			if (ex1->_objtype == kObjTypeObjstateCommand) {
-				ObjstateCommand *com = (ObjstateCommand *)ex1;
+				ObjstateCommand *com = static_cast<ObjstateCommand *>(ex1);
 
 				com->_value = g_fp->getObjectEnumState(sO_EggGulper, sO_WantsNothing);
 			}

--- a/engines/fullpipe/scenes/scene04.cpp
+++ b/engines/fullpipe/scenes/scene04.cpp
@@ -275,7 +275,7 @@ void sceneHandler04_checkBigBallClick() {
 
 	if (ball)
 		for (uint i = 0; i < ball->_movements.size(); i++)
-			((Movement *)ball->_movements[i])->_counterMax = 73;
+			ball->_movements[i]->_counterMax = 73;
 
 	g_vars->scene04_bigBallIn = true;
 }
@@ -1127,7 +1127,7 @@ void sceneHandler04_bigBallOut() {
 
 	if (ball && ball->_flags & 4)
 		for (uint i = 0; i < ball->_movements.size(); i++)
-			((Movement *)ball->_movements[i])->_counterMax = 0;
+			ball->_movements[i]->_counterMax = 0;
 
 	g_vars->scene04_bigBallIn = false;
 }

--- a/engines/fullpipe/scenes/scene04.cpp
+++ b/engines/fullpipe/scenes/scene04.cpp
@@ -958,7 +958,7 @@ void sceneHandler04_walkKozyawka() {
 void sceneHandler04_bottleUpdateObjects(int off) {
 	for (Common::List<GameObject *>::iterator it = g_vars->scene04_bottleObjList.begin(); it != g_vars->scene04_bottleObjList.end(); ++it) {
 		if ((*it)->_objtype == kObjTypeStaticANIObject) {
-			StaticANIObject *st = (StaticANIObject *)*it;
+			StaticANIObject *st = static_cast<StaticANIObject *>(*it);
 
 			st->setOXY(st->_ox, off + st->_oy);
 		} else {
@@ -1138,7 +1138,7 @@ void sceneHandler04_leaveLadder(ExCommand *ex) {
 
 	if (!(g_fp->_aniMan->_flags & 0x100)) {
 		if (getSc2MctlCompoundBySceneId(g_fp->_currentScene->_sceneId)->_objtype == kObjTypeMctlCompound) {
-			MctlCompound *mc = (MctlCompound *)getSc2MctlCompoundBySceneId(g_fp->_currentScene->_sceneId);
+			MctlCompound *mc = static_cast<MctlCompound *>(getSc2MctlCompoundBySceneId(g_fp->_currentScene->_sceneId));
 
 			if (mc->_motionControllers[0]->_movGraphReactObj->pointInRegion(g_fp->_sceneRect.left + ex->_x, g_fp->_sceneRect.top + ex->_y)) {
 				if (g_vars->scene04_ladder->collisionDetection(g_fp->_aniMan)) {

--- a/engines/fullpipe/scenes/scene04.cpp
+++ b/engines/fullpipe/scenes/scene04.cpp
@@ -56,7 +56,7 @@ void scene04_speakerCallback(int *phase) {
 
 			if (scene04_speakerPhases[g_vars->scene04_speakerPhase + 6 * g_vars->scene04_speakerVariant] < 0) {
 				g_vars->scene04_speakerPhase = 0;
-				g_vars->scene04_speakerVariant = g_fp->_rnd->getRandomNumber(2);
+				g_vars->scene04_speakerVariant = g_fp->_rnd.getRandomNumber(2);
 			}
 		} else {
 			++g_vars->scene04_speakerPhase;
@@ -709,9 +709,9 @@ MessageQueue *sceneHandler04_kozFly6(StaticANIObject *ani) {
 
 	mkQueue.ani = ani;
 	mkQueue.staticsId2 = ST_KZW_SIT;
-	mkQueue.x1 = 397 - 4 * g_fp->_rnd->getRandomNumber(1);
+	mkQueue.x1 = 397 - 4 * g_fp->_rnd.getRandomNumber(1);
 	mkQueue.field_1C = ani->_priority;
-	mkQueue.y1 = g_vars->scene04_bottle->_oy - 4 * g_fp->_rnd->getRandomNumber(1) + 109;
+	mkQueue.y1 = g_vars->scene04_bottle->_oy - 4 * g_fp->_rnd.getRandomNumber(1) + 109;
 	mkQueue.field_10 = 1;
 	mkQueue.flags = 78;
 	mkQueue.movementId = MV_KZW_JUMPROTATE;
@@ -1253,7 +1253,7 @@ void sceneHandler04_bigBallWalkIn() {
 		 && (!ball || !(ball->_flags & 4))
 		 && g_vars->scene04_ladder->collisionDetection(g_fp->_aniMan) > 3) {
 
-		if (!g_fp->_rnd->getRandomNumber(49)) {
+		if (!g_fp->_rnd.getRandomNumber(49)) {
 			if (g_vars->scene04_bigBallFromLeft)
 				chainQueue(QU_BALL_WALKR, 0);
 			else

--- a/engines/fullpipe/scenes/scene04.cpp
+++ b/engines/fullpipe/scenes/scene04.cpp
@@ -1086,13 +1086,13 @@ void updateSound() {
 		return;
 
 	case 1:
-		if (!g_fp->_mixer->isSoundHandleActive(*g_fp->_soundStream2)) {
+		if (!g_fp->_mixer->isSoundHandleActive(g_fp->_soundStream2)) {
 			g_fp->playOggSound("sc4_loop.ogg", g_fp->_soundStream3);
 			g_vars->scene04_musicStage = 2;
 		}
 		break;
 	case 2:
-		if (!g_fp->_mixer->isSoundHandleActive(*g_fp->_soundStream3)) {
+		if (!g_fp->_mixer->isSoundHandleActive(g_fp->_soundStream3)) {
 			if (g_fp->_stream2playing) { // Looop it
 				g_fp->playOggSound("sc4_loop.ogg", g_fp->_soundStream3);
 			} else {
@@ -1102,7 +1102,7 @@ void updateSound() {
 		}
 		break;
 	case 3:
-		if (!g_fp->_mixer->isSoundHandleActive(*g_fp->_soundStream4)) {
+		if (!g_fp->_mixer->isSoundHandleActive(g_fp->_soundStream4)) {
 			g_vars->scene04_musicStage = 0;
 		}
 		break;

--- a/engines/fullpipe/scenes/scene04.cpp
+++ b/engines/fullpipe/scenes/scene04.cpp
@@ -97,8 +97,8 @@ void scene04_initScene(Scene *sc) {
 			for (uint i = 0; i < kozsize; i++) {
 				kozmov->setDynamicPhaseIndex(i);
 
-				if (kozmov->_framePosOffsets) {
-					g_vars->scene04_jumpingKozyawki[i] = *kozmov->_framePosOffsets[kozmov->_currDynamicPhaseIndex];
+				if (kozmov->_framePosOffsets.size()) {
+					g_vars->scene04_jumpingKozyawki[i] = kozmov->_framePosOffsets[kozmov->_currDynamicPhaseIndex];
 				} else {
 					kozmov->_somePoint.x = 0;
 					kozmov->_somePoint.y = 0;
@@ -114,8 +114,8 @@ void scene04_initScene(Scene *sc) {
 			for (uint i = 0; i < kozsize; i++) {
 				kozmov->setDynamicPhaseIndex(i);
 
-				if (kozmov->_framePosOffsets) {
-					g_vars->scene04_jumpRotateKozyawki[i] = *kozmov->_framePosOffsets[kozmov->_currDynamicPhaseIndex];
+				if (kozmov->_framePosOffsets.size()) {
+					g_vars->scene04_jumpRotateKozyawki[i] = kozmov->_framePosOffsets[kozmov->_currDynamicPhaseIndex];
 				} else {
 					kozmov->_somePoint.x = 0;
 					kozmov->_somePoint.y = 0;
@@ -747,8 +747,8 @@ void sceneHandler04_kozMove(Movement *mov, int from, int to, Common::Point *poin
 		mov->setDynamicPhaseIndex(i);
 
 		Common::Point *p;
-		if (mov->_framePosOffsets) {
-			p = mov->_framePosOffsets[mov->_currDynamicPhaseIndex];
+		if (mov->_framePosOffsets.size()) {
+			p = &mov->_framePosOffsets[mov->_currDynamicPhaseIndex];
 		} else {
 			p = &mov->_somePoint;
 			p->x = 0;

--- a/engines/fullpipe/scenes/scene04.cpp
+++ b/engines/fullpipe/scenes/scene04.cpp
@@ -1003,9 +1003,7 @@ void sceneHandler04_springWobble() {
 		}
 	}
 
-	Common::Point point;
-
-	int oldpos = g_vars->scene04_spring->getCurrDimensions(point)->y - oldDynIndex;
+	int oldpos = g_vars->scene04_spring->getCurrDimensions().y - oldDynIndex;
 
 	if (g_vars->scene04_dynamicPhaseIndex) {
 		if (!g_vars->scene04_spring->_movement)
@@ -1017,7 +1015,7 @@ void sceneHandler04_springWobble() {
 	}
 
 	if (g_vars->scene04_dynamicPhaseIndex != oldDynIndex) {
-		sceneHandler04_bottleUpdateObjects(oldpos - (g_vars->scene04_spring->getCurrDimensions(point)->y - g_vars->scene04_dynamicPhaseIndex));
+		sceneHandler04_bottleUpdateObjects(oldpos - (g_vars->scene04_spring->getCurrDimensions().y - g_vars->scene04_dynamicPhaseIndex));
 	}
 }
 
@@ -1316,8 +1314,6 @@ void sceneHandler04_testPlank(ExCommand *ex) {
 }
 
 void sceneHandler04_updateBottle() {
-	Common::Point point;
-
 	int yoff;
 
 	if (g_vars->scene04_hand->_movement)
@@ -1325,7 +1321,7 @@ void sceneHandler04_updateBottle() {
 	else
 		yoff = g_vars->scene04_hand->_oy;
 
-	int newy = g_vars->scene04_hand->getSomeXY(point)->y + yoff + 140;
+	int newy = g_vars->scene04_hand->getSomeXY().y + yoff + 140;
 
 	sceneHandler04_bottleUpdateObjects(newy - g_vars->scene04_spring->_oy);
 

--- a/engines/fullpipe/scenes/scene05.cpp
+++ b/engines/fullpipe/scenes/scene05.cpp
@@ -151,12 +151,12 @@ void sceneHandler05_genFlies() {
 	if (g_vars->scene05_floatersTicker <= 1000)
 		return;
 
-	if (g_fp->_rnd->getRandomNumber(1)) {
-		int numFlies = g_fp->_rnd->getRandomNumber(3) + 1;
+	if (g_fp->_rnd.getRandomNumber(1)) {
+		int numFlies = g_fp->_rnd.getRandomNumber(3) + 1;
 
 		for (int i = 0; i < numFlies; i++) {
-			int x = g_fp->_rnd->getRandomNumber(55) + 538;
-			int y = g_fp->_rnd->getRandomNumber(60) + i * 30 + 520;
+			int x = g_fp->_rnd.getRandomNumber(55) + 538;
+			int y = g_fp->_rnd.getRandomNumber(60) + i * 30 + 520;
 
 			g_fp->_floaters->genFlies(g_fp->_currentScene, x, y, 5, 1);
 			g_fp->_floaters->_array2.back()->val2 = 585;

--- a/engines/fullpipe/scenes/scene05.cpp
+++ b/engines/fullpipe/scenes/scene05.cpp
@@ -159,9 +159,9 @@ void sceneHandler05_genFlies() {
 			int y = g_fp->_rnd.getRandomNumber(60) + i * 30 + 520;
 
 			g_fp->_floaters->genFlies(g_fp->_currentScene, x, y, 5, 1);
-			g_fp->_floaters->_array2.back()->val2 = 585;
-			g_fp->_floaters->_array2.back()->val3 = -70;
-			g_fp->_floaters->_array2.back()->val11 = 8.0;
+			g_fp->_floaters->_array2.back().val2 = 585;
+			g_fp->_floaters->_array2.back().val3 = -70;
+			g_fp->_floaters->_array2.back().val11 = 8.0;
 		}
 	}
 

--- a/engines/fullpipe/scenes/scene06.cpp
+++ b/engines/fullpipe/scenes/scene06.cpp
@@ -437,23 +437,23 @@ void sceneHandler06_catchBall() {
 
 			if (g_vars->scene06_mumsy->_movement->_id == MV_MOM_JUMPFW) {
 				if (g_vars->scene06_mumsy->_movement->_currDynamicPhaseIndex <= 5) {
-					g_vars->scene06_mumsy->_movement->calcSomeXY(point, 0, g_vars->scene06_mumsy->_movement->_currDynamicPhaseIndex);
+					point = g_vars->scene06_mumsy->_movement->calcSomeXY(0, g_vars->scene06_mumsy->_movement->_currDynamicPhaseIndex);
 
 					point.x = -point.x;
 					point.y = -point.y;
 				} else {
-					g_vars->scene06_mumsy->_movement->calcSomeXY(point, 1, -1);
+					point = g_vars->scene06_mumsy->_movement->calcSomeXY(1, -1);
 
 					g_vars->scene06_mumsyPos++;
 				}
 			} else if (g_vars->scene06_mumsy->_movement->_id == MV_MOM_JUMPBK) {
 				if (g_vars->scene06_mumsy->_movement->_currDynamicPhaseIndex <= 4) {
-					g_vars->scene06_mumsy->_movement->calcSomeXY(point, 0, g_vars->scene06_mumsy->_movement->_currDynamicPhaseIndex);
+					point = g_vars->scene06_mumsy->_movement->calcSomeXY(0, g_vars->scene06_mumsy->_movement->_currDynamicPhaseIndex);
 
 					point.x = -point.x;
 					point.y = -point.y;
 				} else {
-					g_vars->scene06_mumsy->_movement->calcSomeXY(point, 1, -1);
+					point = g_vars->scene06_mumsy->_movement->calcSomeXY(1, -1);
 
 					g_vars->scene06_mumsyPos--;
 				}

--- a/engines/fullpipe/scenes/scene06.cpp
+++ b/engines/fullpipe/scenes/scene06.cpp
@@ -382,7 +382,7 @@ void sceneHandler06_throwBall() {
 }
 
 void sceneHandler06_eggieWalk() {
-	if (15 - g_vars->scene06_numBallsGiven >= 4 && !g_fp->_rnd->getRandomNumber(9)) {
+	if (15 - g_vars->scene06_numBallsGiven >= 4 && !g_fp->_rnd.getRandomNumber(9)) {
 		StaticANIObject *ani = g_fp->_currentScene->getStaticANIObject1ById(ANI_EGGIE, -1);
 
 		if (!ani || !(ani->_flags & 4)) {

--- a/engines/fullpipe/scenes/scene06.cpp
+++ b/engines/fullpipe/scenes/scene06.cpp
@@ -53,13 +53,13 @@ int scene06_updateCursor() {
 
 			return PIC_CSR_ARCADE2_D;
 		}
-		if (g_fp->_aniMan == (StaticANIObject *)g_fp->_objectAtCursor) {
+		if (g_fp->_aniMan == g_fp->_objectAtCursor) {
 			if (g_fp->_aniMan->_statics->_staticsId == ST_MAN6_BALL && g_fp->_cursorId == PIC_CSR_DEFAULT) {
 				g_fp->_cursorId = PIC_CSR_ITN;
 
 				return PIC_CSR_ITN;
 			}
-		} else if (g_fp->_objectAtCursor && (StaticANIObject *)g_fp->_objectAtCursor == g_vars->scene06_currentBall
+		} else if (g_fp->_objectAtCursor && g_fp->_objectAtCursor == g_vars->scene06_currentBall
 					&& g_fp->_cursorId == PIC_CSR_DEFAULT) {
 			g_fp->_cursorId = PIC_CSR_ITN;
 		}

--- a/engines/fullpipe/scenes/scene08.cpp
+++ b/engines/fullpipe/scenes/scene08.cpp
@@ -193,9 +193,7 @@ int sceneHandler08_calcOffset(int off, int flag) {
 }
 
 void sceneHandler08_pushCallback(int *par) {
-	Common::Point point;
-
-	int y = g_fp->_aniMan->_oy + g_fp->_aniMan->getSomeXY(point)->y;
+	int y = g_fp->_aniMan->_oy + g_fp->_aniMan->getSomeXY().y;
 
 	if (g_fp->_aniMan->_statics && g_fp->_aniMan->_statics->_staticsId == ST_MAN8_FLYDOWN)
 		y -= 25;
@@ -253,7 +251,7 @@ void sceneHandler08_airMoves() {
 		int y = g_fp->_aniMan->_oy;
 		Common::Point point;
 
-		if (703 - g_fp->_aniMan->getSomeXY(point)->y - y < 150) {
+		if (703 - g_fp->_aniMan->getSomeXY().y - y < 150) {
 			if (g_fp->_aniMan->_statics) {
 				if (g_fp->_aniMan->_statics->_staticsId == ST_MAN8_FLYDOWN) {
 					y -= 25;
@@ -358,7 +356,7 @@ void sceneHandler08_calcFlight() {
 	if (g_vars->scene08_manOffsetY < g_vars->scene08_stairsOffset)
 		g_vars->scene08_manOffsetY = g_vars->scene08_stairsOffset;
 
-	y = y + g_fp->_aniMan->getSomeXY(point)->y;
+	y = y + g_fp->_aniMan->getSomeXY().y;
 
 	if (g_fp->_aniMan->_statics && g_fp->_aniMan->_statics->_staticsId == ST_MAN8_FLYDOWN)
 		y -= 25;

--- a/engines/fullpipe/scenes/scene09.cpp
+++ b/engines/fullpipe/scenes/scene09.cpp
@@ -190,14 +190,14 @@ void sceneHandler09_spitterClick() {
 	if (g_vars->scene09_spitter->_flags & 4) {
 		PicAniInfo info;
 
-		g_vars->scene09_spitter->getPicAniInfo(&info);
+		g_vars->scene09_spitter->getPicAniInfo(info);
 		g_vars->scene09_spitter->_messageQueueId = 0;
 		g_vars->scene09_spitter->changeStatics2(ST_PLV_SIT);
 
 		int x = g_vars->scene09_spitter->_ox - 10;
 		int y = g_vars->scene09_spitter->_oy + 145;
 
-		g_vars->scene09_spitter->setPicAniInfo(&info);
+		g_vars->scene09_spitter->setPicAniInfo(info);
 
 		if (ABS(x - g_fp->_aniMan->_ox) > 1 || ABS(y - g_fp->_aniMan->_oy) > 1) {
 			MessageQueue *mq = getCurrSceneSc2MotionController()->startMove(g_fp->_aniMan, x, y, 1, ST_MAN_UP);

--- a/engines/fullpipe/scenes/scene11.cpp
+++ b/engines/fullpipe/scenes/scene11.cpp
@@ -134,9 +134,7 @@ void scene11_initScene(Scene *sc) {
 		getCurrSceneSc2MotionController()->enableLinks(sO_CloseThing1, 1);
 		getCurrSceneSc2MotionController()->enableLinks(sO_CloseThing2, 1);
 		getCurrSceneSc2MotionController()->enableLinks(sO_CloseThing3, 0);
-
-		((MctlCompound *)getCurrSceneSc2MotionController())->replaceNodeX(805, 905);
-
+		getCurrSceneSc2MotionController()->replaceNodeX(805, 905);
 		getSc2MctlCompoundBySceneId(sc->_sceneId)->replaceNodeX(303, 353);
 	} else if (swingie == g_fp->getObjectEnumState(sO_Swingie, sO_IsStandingInBoots)
 				|| swingie == g_fp->getObjectEnumState(sO_Swingie, sO_IsStandingInCorner)) {
@@ -148,8 +146,7 @@ void scene11_initScene(Scene *sc) {
 		getCurrSceneSc2MotionController()->enableLinks(sO_CloseThing1, 0);
 		getCurrSceneSc2MotionController()->enableLinks(sO_CloseThing2, 1);
 		getCurrSceneSc2MotionController()->enableLinks(sO_CloseThing3, 0);
-
-		((MctlCompound *)getCurrSceneSc2MotionController())->replaceNodeX(905, 805);
+		getCurrSceneSc2MotionController()->replaceNodeX(905, 805);
 	} else {
 		g_vars->scene11_swingIsSwinging = false;
 		g_vars->scene11_swingieStands = false;

--- a/engines/fullpipe/scenes/scene12.cpp
+++ b/engines/fullpipe/scenes/scene12.cpp
@@ -50,9 +50,9 @@ void scene12_initScene(Scene *sc) {
 void sceneHandler12_updateFloaters() {
 	g_fp->_floaters->genFlies(g_fp->_currentScene, 397, -50, 100, 6);
 
-	g_fp->_floaters->_array2[0]->countdown = g_fp->_rnd.getRandomNumber(6) + 4;
-	g_fp->_floaters->_array2[0]->val6 = 397;
-	g_fp->_floaters->_array2[0]->val7 = -50;
+	g_fp->_floaters->_array2[0].countdown = g_fp->_rnd.getRandomNumber(6) + 4;
+	g_fp->_floaters->_array2[0].val6 = 397;
+	g_fp->_floaters->_array2[0].val7 = -50;
 }
 
 int sceneHandler12(ExCommand *cmd) {

--- a/engines/fullpipe/scenes/scene12.cpp
+++ b/engines/fullpipe/scenes/scene12.cpp
@@ -42,15 +42,15 @@ void scene12_initScene(Scene *sc) {
 	g_vars->scene12_fly = g_fp->getObjectState(sO_Fly_12);
 
 	if (g_vars->scene12_fly)
-		g_vars->scene12_flyCountdown = g_fp->_rnd->getRandomNumber(600) + 600;
+		g_vars->scene12_flyCountdown = g_fp->_rnd.getRandomNumber(600) + 600;
 
-	g_fp->setObjectState(sO_Fly_12, g_fp->_rnd->getRandomNumber(1));
+	g_fp->setObjectState(sO_Fly_12, g_fp->_rnd.getRandomNumber(1));
 }
 
 void sceneHandler12_updateFloaters() {
 	g_fp->_floaters->genFlies(g_fp->_currentScene, 397, -50, 100, 6);
 
-	g_fp->_floaters->_array2[0]->countdown = g_fp->_rnd->getRandomNumber(6) + 4;
+	g_fp->_floaters->_array2[0]->countdown = g_fp->_rnd.getRandomNumber(6) + 4;
 	g_fp->_floaters->_array2[0]->val6 = 397;
 	g_fp->_floaters->_array2[0]->val7 = -50;
 }

--- a/engines/fullpipe/scenes/scene15.cpp
+++ b/engines/fullpipe/scenes/scene15.cpp
@@ -128,7 +128,7 @@ int sceneHandler15(ExCommand *cmd) {
 		break;
 
 	case MSG_SC15_ASSDRYG:
-		if (g_fp->_rnd->getRandomNumber(1))
+		if (g_fp->_rnd.getRandomNumber(1))
 			g_fp->playSound(SND_15_011, 0);
 		else
 			g_fp->playSound(SND_15_006, 0);

--- a/engines/fullpipe/scenes/scene16.cpp
+++ b/engines/fullpipe/scenes/scene16.cpp
@@ -86,7 +86,7 @@ void scene16_initScene(Scene *sc) {
 
 		StaticANIObject *ani = new StaticANIObject(g_fp->accessScene(SC_COMMON)->getStaticANIObject1ById(ANI_BEARDED_CMN, -1));
 		ani->_movement = 0;
-		ani->_statics = (Statics *)ani->_staticsList[0];
+		ani->_statics = ani->_staticsList[0];
 		sc->addStaticANIObject(ani, 1);
 	}
 

--- a/engines/fullpipe/scenes/scene17.cpp
+++ b/engines/fullpipe/scenes/scene17.cpp
@@ -157,9 +157,9 @@ void sceneHandler17_moonshineFill() {
 void sceneHandler17_updateFlies() {
 	g_fp->_floaters->genFlies(g_fp->_currentScene, 239, -50, 20, 4);
 
-	g_fp->_floaters->_array2[0]->countdown = g_fp->_rnd.getRandomNumber(5) + 6;
-	g_fp->_floaters->_array2[0]->val6 = 239;
-	g_fp->_floaters->_array2[0]->val7 = -50;
+	g_fp->_floaters->_array2[0].countdown = g_fp->_rnd.getRandomNumber(5) + 6;
+	g_fp->_floaters->_array2[0].val6 = 239;
+	g_fp->_floaters->_array2[0].val7 = -50;
 }
 
 

--- a/engines/fullpipe/scenes/scene17.cpp
+++ b/engines/fullpipe/scenes/scene17.cpp
@@ -62,9 +62,9 @@ void scene17_restoreState() {
 	g_vars->scene17_flyState = g_fp->getObjectState(sO_Fly_17);
 
 	if (g_vars->scene17_flyState <= 0 ) {
-		g_vars->scene17_flyCountdown = g_fp->_rnd->getRandomNumber(600) + 600;
+		g_vars->scene17_flyCountdown = g_fp->_rnd.getRandomNumber(600) + 600;
 
-		g_vars->scene17_flyState = g_fp->_rnd->getRandomNumber(4) + 1;
+		g_vars->scene17_flyState = g_fp->_rnd.getRandomNumber(4) + 1;
 	}
 
 	g_fp->setObjectState(sO_Fly_17, g_vars->scene17_flyState - 1);
@@ -157,7 +157,7 @@ void sceneHandler17_moonshineFill() {
 void sceneHandler17_updateFlies() {
 	g_fp->_floaters->genFlies(g_fp->_currentScene, 239, -50, 20, 4);
 
-	g_fp->_floaters->_array2[0]->countdown = g_fp->_rnd->getRandomNumber(5) + 6;
+	g_fp->_floaters->_array2[0]->countdown = g_fp->_rnd.getRandomNumber(5) + 6;
 	g_fp->_floaters->_array2[0]->val6 = 239;
 	g_fp->_floaters->_array2[0]->val7 = -50;
 }

--- a/engines/fullpipe/scenes/scene18and19.cpp
+++ b/engines/fullpipe/scenes/scene18and19.cpp
@@ -181,7 +181,7 @@ void scene18_setupSwingers(StaticANIObject *ani, Scene *sc) {
 		else
 			ani->startAnim(MV_KSL_SWING, 0, -1);
 
-		ani->_movement->setDynamicPhaseIndex(g_fp->_rnd->getRandomNumber(17));
+		ani->_movement->setDynamicPhaseIndex(g_fp->_rnd.getRandomNumber(17));
 
 		g_vars->scene18_swingers.push_back(swinger);
 	}

--- a/engines/fullpipe/scenes/scene18and19.cpp
+++ b/engines/fullpipe/scenes/scene18and19.cpp
@@ -130,6 +130,7 @@ void scene19_setMovements(Scene *sc, int entranceId) {
 void scene19_preload() {
 	for (SceneTagList::iterator s = g_fp->_gameProject->_sceneTagList->begin(); s != g_fp->_gameProject->_sceneTagList->end(); ++s) {
 		if (s->_sceneId == SC_18) {
+			delete s->_scene;
 			s->_scene = g_fp->_scene3;
 
 			break;

--- a/engines/fullpipe/scenes/scene18and19.cpp
+++ b/engines/fullpipe/scenes/scene18and19.cpp
@@ -217,9 +217,9 @@ void scene18_initScene1(Scene *sc) {
 	g_vars->scene18_girlJumpY += newy;
 
 	for (uint i = 0; i < g_vars->scene18_swingers.size(); i++) {
-		g_vars->scene18_swingers[i]->ani->getPicAniInfo(&info);
+		g_vars->scene18_swingers[i]->ani->getPicAniInfo(info);
 		sc->addStaticANIObject(g_vars->scene18_swingers[i]->ani, 1);
-		g_vars->scene18_swingers[i]->ani->setPicAniInfo(&info);
+		g_vars->scene18_swingers[i]->ani->setPicAniInfo(info);
 
 		g_vars->scene18_swingers[i]->sx += newx;
 		g_vars->scene18_swingers[i]->sy += newy;
@@ -257,9 +257,9 @@ void scene18_initScene1(Scene *sc) {
 
 	g_fp->playSound(sndid, 1);
 
-	g_vars->scene18_boy->getPicAniInfo(&info);
+	g_vars->scene18_boy->getPicAniInfo(info);
 	sc->addStaticANIObject(g_vars->scene18_boy, 1);
-	g_vars->scene18_boy->setPicAniInfo(&info);
+	g_vars->scene18_boy->setPicAniInfo(info);
 
 	int x, y;
 
@@ -273,9 +273,9 @@ void scene18_initScene1(Scene *sc) {
 
 	g_vars->scene18_boy->setOXY(newx + x, newy + y);
 
-	g_vars->scene18_girl->getPicAniInfo(&info);
+	g_vars->scene18_girl->getPicAniInfo(info);
 	sc->addStaticANIObject(g_vars->scene18_girl, 1);
-	g_vars->scene18_girl->setPicAniInfo(&info);
+	g_vars->scene18_girl->setPicAniInfo(info);
 
 	if (g_vars->scene18_girl->_movement) {
 		x = g_vars->scene18_girl->_movement->_ox;

--- a/engines/fullpipe/scenes/scene20.cpp
+++ b/engines/fullpipe/scenes/scene20.cpp
@@ -84,13 +84,13 @@ void scene20_initScene(Scene *sc) {
 	g_fp->_floaters->init(g_fp->getGameLoaderGameVar()->getSubVarByName("SC_20"));
 
 	for (int i = 0; i < 3; i++) {
-		g_fp->_floaters->genFlies(sc, g_fp->_rnd->getRandomNumber(101) + 70, g_fp->_rnd->getRandomNumber(51) + 175, 100, 0);
-		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val13 = g_fp->_rnd->getRandomNumber(9);
+		g_fp->_floaters->genFlies(sc, g_fp->_rnd.getRandomNumber(101) + 70, g_fp->_rnd.getRandomNumber(51) + 175, 100, 0);
+		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val13 = g_fp->_rnd.getRandomNumber(9);
 	}
 
 	g_fp->_currentScene = oldsc;
 
-	g_vars->scene20_fliesCountdown = g_fp->_rnd->getRandomNumber(200) + 400;
+	g_vars->scene20_fliesCountdown = g_fp->_rnd.getRandomNumber(200) + 400;
 }
 
 void sceneHandler20_updateFlies() {
@@ -101,7 +101,7 @@ void sceneHandler20_updateFlies() {
 		g_fp->_floaters->_array2[sz - 1]->val2 = 250;
 		g_fp->_floaters->_array2[sz - 1]->val3 = 200;
 	} else {
-		int idx = g_fp->_rnd->getRandomNumber(sz);
+		int idx = g_fp->_rnd.getRandomNumber(sz);
 
 		g_fp->_floaters->_array2[idx]->countdown = 0;
 		g_fp->_floaters->_array2[idx]->fflags |= 4u;
@@ -112,7 +112,7 @@ void sceneHandler20_updateFlies() {
 		g_fp->_floaters->_array2[idx]->ani->_priority = 200;
 	}
 
-	g_vars->scene20_fliesCountdown = g_fp->_rnd->getRandomNumber(200) + 400;
+	g_vars->scene20_fliesCountdown = g_fp->_rnd.getRandomNumber(200) + 400;
 }
 
 int sceneHandler20(ExCommand *cmd) {

--- a/engines/fullpipe/scenes/scene20.cpp
+++ b/engines/fullpipe/scenes/scene20.cpp
@@ -85,7 +85,7 @@ void scene20_initScene(Scene *sc) {
 
 	for (int i = 0; i < 3; i++) {
 		g_fp->_floaters->genFlies(sc, g_fp->_rnd.getRandomNumber(101) + 70, g_fp->_rnd.getRandomNumber(51) + 175, 100, 0);
-		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val13 = g_fp->_rnd.getRandomNumber(9);
+		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].val13 = g_fp->_rnd.getRandomNumber(9);
 	}
 
 	g_fp->_currentScene = oldsc;
@@ -98,18 +98,18 @@ void sceneHandler20_updateFlies() {
 
 	if (sz < 3) {
 		g_fp->_floaters->genFlies(g_fp->_currentScene, 253, 650, 200, 0);
-		g_fp->_floaters->_array2[sz - 1]->val2 = 250;
-		g_fp->_floaters->_array2[sz - 1]->val3 = 200;
+		g_fp->_floaters->_array2[sz - 1].val2 = 250;
+		g_fp->_floaters->_array2[sz - 1].val3 = 200;
 	} else {
 		int idx = g_fp->_rnd.getRandomNumber(sz);
 
-		g_fp->_floaters->_array2[idx]->countdown = 0;
-		g_fp->_floaters->_array2[idx]->fflags |= 4u;
-		g_fp->_floaters->_array2[idx]->val2 = 250;
-		g_fp->_floaters->_array2[idx]->val3 = 200;
-		g_fp->_floaters->_array2[idx]->val6 = 253;
-		g_fp->_floaters->_array2[idx]->val7 = 650;
-		g_fp->_floaters->_array2[idx]->ani->_priority = 200;
+		g_fp->_floaters->_array2[idx].countdown = 0;
+		g_fp->_floaters->_array2[idx].fflags |= 4u;
+		g_fp->_floaters->_array2[idx].val2 = 250;
+		g_fp->_floaters->_array2[idx].val3 = 200;
+		g_fp->_floaters->_array2[idx].val6 = 253;
+		g_fp->_floaters->_array2[idx].val7 = 650;
+		g_fp->_floaters->_array2[idx].ani->_priority = 200;
 	}
 
 	g_vars->scene20_fliesCountdown = g_fp->_rnd.getRandomNumber(200) + 400;

--- a/engines/fullpipe/scenes/scene25.cpp
+++ b/engines/fullpipe/scenes/scene25.cpp
@@ -441,7 +441,7 @@ void sceneHandler25_walkOnLadder(StaticANIObject *ani, Common::Point *pnt, Messa
 
 	if (flag) {
 		if (ani->_movement) {
-			ani->_movement->calcSomeXY(point, 0, ani->_movement->_currDynamicPhaseIndex);
+			point = ani->_movement->calcSomeXY(0, ani->_movement->_currDynamicPhaseIndex);
 			newx = point.x;
 			aniY = ani->_oy - point.y;
 		}
@@ -478,7 +478,7 @@ void sceneHandler25_walkOnLadder(StaticANIObject *ani, Common::Point *pnt, Messa
 				newy = pnty;
 			}
 
-			ani->getMovementById(ex->_messageNum)->calcSomeXY(point, 0, -1);
+			point = ani->getMovementById(ex->_messageNum)->calcSomeXY(0, -1);
 			pntx += point.x;
 			pnty += point.y;
 		}

--- a/engines/fullpipe/scenes/scene25.cpp
+++ b/engines/fullpipe/scenes/scene25.cpp
@@ -161,14 +161,14 @@ void sceneHandler25_enterMan() {
 void sceneHandler25_enterTruba() {
 	PicAniInfo info;
 
-	g_fp->_aniMan->getPicAniInfo(&info);
+	g_fp->_aniMan->getPicAniInfo(info);
 	g_fp->_aniMan->_messageQueueId = 0;
 	g_fp->_aniMan->changeStatics2(g_fp->_aniMan->_statics->_staticsId);
 
 	int x = g_fp->_aniMan->_ox;
 	int y = g_fp->_aniMan->_oy;
 
-	g_fp->_aniMan->setPicAniInfo(&info);
+	g_fp->_aniMan->setPicAniInfo(info);
 
 	int id = g_fp->_aniMan->_statics->_staticsId;
 	int qid = 0;
@@ -196,14 +196,14 @@ void sceneHandler25_saveEntrance(int value) {
 void sceneHandler25_toLadder() {
 	PicAniInfo info;
 
-	g_fp->_aniMan->getPicAniInfo(&info);
+	g_fp->_aniMan->getPicAniInfo(info);
 	g_fp->_aniMan->_messageQueueId = 0;
 	g_fp->_aniMan->changeStatics2(g_fp->_aniMan->_statics->_staticsId);
 
 	int x = g_fp->_aniMan->_ox;
 	int y = g_fp->_aniMan->_oy;
 
-	g_fp->_aniMan->setPicAniInfo(&info);
+	g_fp->_aniMan->setPicAniInfo(info);
 
 	int id = g_fp->_aniMan->_statics->_staticsId;
 	int qid = 0;
@@ -275,14 +275,14 @@ void sceneHandler25_sneeze() {
 void sceneHandler25_rowShovel() {
 	PicAniInfo info;
 
-	g_fp->_aniMan->getPicAniInfo(&info);
+	g_fp->_aniMan->getPicAniInfo(info);
 	g_fp->_aniMan->_messageQueueId = 0;
 	g_fp->_aniMan->changeStatics2(g_fp->_aniMan->_statics->_staticsId);
 
 	int x = g_fp->_aniMan->_ox;
 	int y = g_fp->_aniMan->_oy;
 
-	g_fp->_aniMan->setPicAniInfo(&info);
+	g_fp->_aniMan->setPicAniInfo(info);
 
 	int id = g_fp->_aniMan->_statics->_staticsId;
 	int qid = 0;
@@ -309,14 +309,14 @@ void sceneHandler25_rowShovel() {
 void sceneHandler25_rowHand() {
 	PicAniInfo info;
 
-	g_fp->_aniMan->getPicAniInfo(&info);
+	g_fp->_aniMan->getPicAniInfo(info);
 	g_fp->_aniMan->_messageQueueId = 0;
 	g_fp->_aniMan->changeStatics2(g_fp->_aniMan->_statics->_staticsId);
 
 	int x = g_fp->_aniMan->_ox;
 	int y = g_fp->_aniMan->_oy;
 
-	g_fp->_aniMan->setPicAniInfo(&info);
+	g_fp->_aniMan->setPicAniInfo(info);
 
 	int id = g_fp->_aniMan->_statics->_staticsId;
 	int qid = 0;
@@ -363,14 +363,14 @@ void sceneHandler25_tryWater() {
 void sceneHandler25_tryRow(int obj) {
 	PicAniInfo info;
 
-	g_fp->_aniMan->getPicAniInfo(&info);
+	g_fp->_aniMan->getPicAniInfo(info);
 	g_fp->_aniMan->_messageQueueId = 0;
 	g_fp->_aniMan->changeStatics2(ST_MAN_RIGHT | 0x4000);
 
 	int x = g_fp->_aniMan->_ox;
 	int y = g_fp->_aniMan->_oy;
 
-	g_fp->_aniMan->setPicAniInfo(&info);
+	g_fp->_aniMan->setPicAniInfo(info);
 
 	int qid = 0;
 

--- a/engines/fullpipe/scenes/scene25.cpp
+++ b/engines/fullpipe/scenes/scene25.cpp
@@ -229,29 +229,29 @@ void sceneHandler25_toLadder() {
 }
 
 void sceneHandler25_animateBearders() {
-	if (g_fp->_rnd->getRandomNumber(32767) < 218) {
+	if (g_fp->_rnd.getRandomNumber(32767) < 218) {
 		MessageQueue *mq;
 
 		mq = new MessageQueue(g_fp->_currentScene->getMessageQueueById(QU_SC25_BEARDED), 0, 1);
 
 		mq->setParamInt(-1, g_vars->scene25_bearders[0]->_odelay);
-		mq->getExCommandByIndex(0)->_x = g_fp->_rnd->getRandomNumber(650) + 100;
+		mq->getExCommandByIndex(0)->_x = g_fp->_rnd.getRandomNumber(650) + 100;
 		mq->chain(0);
 
 		g_vars->scene25_beardersCounter = 0;
 
-		if (g_fp->_rnd->getRandomNumber(32767) < 0x1FFF) {
+		if (g_fp->_rnd.getRandomNumber(32767) < 0x1FFF) {
 			mq = new MessageQueue(g_fp->_currentScene->getMessageQueueById(QU_SC25_BEARDED2), 0, 1);
 
 			mq->setParamInt(-1, g_vars->scene25_bearders[1]->_odelay);
-			mq->getExCommandByIndex(0)->_x = g_fp->_rnd->getRandomNumber(650) + 100;
+			mq->getExCommandByIndex(0)->_x = g_fp->_rnd.getRandomNumber(650) + 100;
 			mq->chain(0);
 
-			if (g_fp->_rnd->getRandomNumber(32767) < 8191) {
+			if (g_fp->_rnd.getRandomNumber(32767) < 8191) {
 				mq = new MessageQueue(g_fp->_currentScene->getMessageQueueById(QU_SC25_BEARDED3), 0, 1);
 
 				mq->setParamInt(-1, g_vars->scene25_bearders[2]->_odelay);
-				mq->getExCommandByIndex(0)->_x = g_fp->_rnd->getRandomNumber(650) + 100;
+				mq->getExCommandByIndex(0)->_x = g_fp->_rnd.getRandomNumber(650) + 100;
 				mq->chain(0);
 			}
 		}
@@ -259,7 +259,7 @@ void sceneHandler25_animateBearders() {
 }
 
 void sceneHandler25_sneeze() {
-	if (g_fp->_rnd->getRandomNumber(32767) % 10) {
+	if (g_fp->_rnd.getRandomNumber(32767) % 10) {
 		if (g_fp->_aniMan->_statics->_staticsId == ST_MAN25_ONBOARD) {
 			g_fp->_aniMan->startAnim(MV_MAN25_ONBOARD, 0, -1);
 		} else if (g_fp->_aniMan->_statics->_staticsId == (ST_MAN25_ONBOARD|0x4000)) {
@@ -570,7 +570,7 @@ int sceneHandler25(ExCommand *cmd) {
 		break;
 
 	case MSG_BRD_TURN:
-		switch (g_fp->_rnd->getRandomNumber(3)) {
+		switch (g_fp->_rnd.getRandomNumber(3)) {
 		case 0:
 			g_fp->playSound(SND_25_025, 0);
 			break;

--- a/engines/fullpipe/scenes/scene27.cpp
+++ b/engines/fullpipe/scenes/scene27.cpp
@@ -235,7 +235,7 @@ void sceneHandler27_startBat(StaticANIObject *bat) {
 	newbat->currX = newbat->powerCos + (double)g_fp->_aniMan->_ox + 42.0;
 	newbat->currY = newbat->powerSin + (double)g_fp->_aniMan->_oy + 58.0;
 
-	bat->_statics = (Statics *)bat->_staticsList[0];
+	bat->_statics = bat->_staticsList[0];
 	bat->setOXY((int)newbat->currX, (int)newbat->currY);
 	bat->_flags |= 4;
 

--- a/engines/fullpipe/scenes/scene27.cpp
+++ b/engines/fullpipe/scenes/scene27.cpp
@@ -335,7 +335,7 @@ void sceneHandler27_knockBats(int bat1n, int bat2n) {
 	debugC(2, kDebugSceneLogic, "scene27: knockBats(%d, %d)", bat1n, bat2n);
 
 	if (bat1->power != 0.0) {
-		double rndF = (double)g_fp->_rnd->getRandomNumber(32767) * 0.03 / 32767.0 - 0.015
+		double rndF = (double)g_fp->_rnd.getRandomNumber(32767) * 0.03 / 32767.0 - 0.015
 			+ atan2(bat2->currY - bat1->currY, bat2->currX - bat1->currX);
 
 		double pow1x = cos(bat1->angle - rndF) * ((bat2->currX - bat1->currX) >= 0 ? bat1->power : -bat1->power);
@@ -349,7 +349,7 @@ void sceneHandler27_knockBats(int bat1n, int bat2n) {
 
 		debugC(3, kDebugSceneLogic, "scene27: knockBats: bat1 to: powerCos: %f powerSin: %f", bat1->powerCos, bat1->powerSin);
 
-		double rndF2 = (double)g_fp->_rnd->getRandomNumber(32767) * 0.03 / 32767.0 - 0.015
+		double rndF2 = (double)g_fp->_rnd.getRandomNumber(32767) * 0.03 / 32767.0 - 0.015
 								+ atan2(bat1->currY - bat2->currY, bat1->currX - bat2->currX);
 		double pow2x = cos(bat2->angle - rndF2) * ((bat1->currX - bat2->currX) >= 0 ? bat2->power : -bat2->power);
 		double pow2y = sin(bat2->angle - rndF2) * ((bat1->currY - bat2->currY) >= 0 ? bat2->power : -bat2->power);

--- a/engines/fullpipe/scenes/scene28.cpp
+++ b/engines/fullpipe/scenes/scene28.cpp
@@ -86,7 +86,7 @@ void sceneHandler28_makeFaces(ExCommand *cmd) {
 		for (int i = 0; i < 5; i++) {
 			int pos;
 
-			while (frames[pos = g_fp->_rnd->getRandomNumber(4)] == 0)
+			while (frames[pos = g_fp->_rnd.getRandomNumber(4)] == 0)
 				;
 
 			mq->getExCommandByIndex(i)->_messageNum = frames[pos];
@@ -173,12 +173,12 @@ void sceneHandler28_turnOn2() {
 		g_fp->_floaters->genFlies(g_fp->_currentScene, 1013, 329, 60, 4);
 
 		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val13 = 30;
-		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->countdown = g_fp->_rnd->getRandomNumber(12) + 12;
+		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->countdown = g_fp->_rnd.getRandomNumber(12) + 12;
 
 		g_fp->_floaters->genFlies(g_fp->_currentScene, 1074, 311, 60, 4);
 
 		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val13 = 30;
-		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->countdown = g_fp->_rnd->getRandomNumber(12) + 12;
+		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->countdown = g_fp->_rnd.getRandomNumber(12) + 12;
 	}
 
 	g_vars->scene28_fliesArePresent = false;

--- a/engines/fullpipe/scenes/scene28.cpp
+++ b/engines/fullpipe/scenes/scene28.cpp
@@ -172,13 +172,13 @@ void sceneHandler28_turnOn2() {
 	if (g_vars->scene28_fliesArePresent) {
 		g_fp->_floaters->genFlies(g_fp->_currentScene, 1013, 329, 60, 4);
 
-		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val13 = 30;
-		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->countdown = g_fp->_rnd.getRandomNumber(12) + 12;
+		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].val13 = 30;
+		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].countdown = g_fp->_rnd.getRandomNumber(12) + 12;
 
 		g_fp->_floaters->genFlies(g_fp->_currentScene, 1074, 311, 60, 4);
 
-		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val13 = 30;
-		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->countdown = g_fp->_rnd.getRandomNumber(12) + 12;
+		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].val13 = 30;
+		g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].countdown = g_fp->_rnd.getRandomNumber(12) + 12;
 	}
 
 	g_vars->scene28_fliesArePresent = false;
@@ -467,8 +467,8 @@ int sceneHandler28(ExCommand *cmd) {
 		g_fp->_floaters->update();
 
 		for (uint i = 0; i < g_fp->_floaters->_array2.size(); i++)
-			if (g_fp->_floaters->_array2[i]->val13 == 1)
-				g_fp->_floaters->_array2[i]->ani->_priority = 15;
+			if (g_fp->_floaters->_array2[i].val13 == 1)
+				g_fp->_floaters->_array2[i].ani->_priority = 15;
 
 		g_fp->_behaviorManager->updateBehaviors();
 

--- a/engines/fullpipe/scenes/scene29.cpp
+++ b/engines/fullpipe/scenes/scene29.cpp
@@ -569,7 +569,7 @@ void sceneHandler29_manRideBack() {
 
 void sceneHandler29_shoot() {
 	if (g_vars->scene29_arcadeIsOn && g_vars->scene29_manX < 1310) {
-		if (g_fp->_rnd->getRandomNumber(32767) <= 16383|| g_vars->scene29_shooter1->_movement || g_vars->scene29_shooter1->_statics->_staticsId != ST_STR1_RIGHT) {
+		if (g_fp->_rnd.getRandomNumber(32767) <= 16383|| g_vars->scene29_shooter1->_movement || g_vars->scene29_shooter1->_statics->_staticsId != ST_STR1_RIGHT) {
 			if (!g_vars->scene29_shooter2->_movement && g_vars->scene29_shooter2->_statics->_staticsId == ST_STR2_RIGHT) {
 				if (g_vars->scene29_shooter2->_flags & 4) {
 					g_vars->scene29_shooter2->startAnim(MV_STR2_SHOOT, 0, -1);
@@ -637,7 +637,7 @@ void sceneHandler29_animBearded() {
 		if (g_vars->scene29_arcadeIsOn && g_vars->scene29_bearders[i]->wbcounter > 30) {
 			int newx;
 
-			if (g_fp->_rnd->getRandomNumber(1))
+			if (g_fp->_rnd.getRandomNumber(1))
 				goto dostuff;
 
 			if (g_vars->scene29_manX <= 700) {

--- a/engines/fullpipe/scenes/scene33.cpp
+++ b/engines/fullpipe/scenes/scene33.cpp
@@ -211,7 +211,7 @@ void sceneHandler33_clickZones(ExCommand *cmd) {
 	double mindist = 1e10;
 
 	for (uint i = 0; i < g_fp->_currentScene->_staticANIObjectList1.size(); i++) {
-		StaticANIObject *ani = (StaticANIObject *)g_fp->_currentScene->_staticANIObjectList1[i];
+		StaticANIObject *ani = g_fp->_currentScene->_staticANIObjectList1[i];
 
 		if (ani->_id == ANI_VENT_33) {
 			int dx = ani->_ox - cmd->_sceneClickX;

--- a/engines/fullpipe/scenes/scene34.cpp
+++ b/engines/fullpipe/scenes/scene34.cpp
@@ -160,9 +160,9 @@ void sceneHandler34_climb() {
 void sceneHandler34_genFlies() {
 	g_fp->_floaters->genFlies(g_fp->_currentScene, 1072, -50, 100, 4);
 
-	g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->countdown = 1;
-	g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val6 = 1072;
-	g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val7 = -50;
+	g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].countdown = 1;
+	g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].val6 = 1072;
+	g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].val7 = -50;
 
 	g_vars->scene34_fliesCountdown = g_fp->_rnd.getRandomNumber(500) + 500;
 }

--- a/engines/fullpipe/scenes/scene34.cpp
+++ b/engines/fullpipe/scenes/scene34.cpp
@@ -87,7 +87,7 @@ void scene34_initScene(Scene *sc) {
 	g_vars->scene34_dudeClimbed = false;
 	g_vars->scene34_dudeOnBoard = false;
 	g_vars->scene34_dudeOnCactus = false;
-	g_vars->scene34_fliesCountdown = g_fp->_rnd->getRandomNumber(500) + 500;
+	g_vars->scene34_fliesCountdown = g_fp->_rnd.getRandomNumber(500) + 500;
 
 	g_fp->_floaters->init(g_fp->getGameLoaderGameVar()->getSubVarByName("SC_34"));
 
@@ -164,7 +164,7 @@ void sceneHandler34_genFlies() {
 	g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val6 = 1072;
 	g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val7 = -50;
 
-	g_vars->scene34_fliesCountdown = g_fp->_rnd->getRandomNumber(500) + 500;
+	g_vars->scene34_fliesCountdown = g_fp->_rnd.getRandomNumber(500) + 500;
 }
 
 void sceneHandler34_fromCactus(ExCommand *cmd) {

--- a/engines/fullpipe/scenes/scene35.cpp
+++ b/engines/fullpipe/scenes/scene35.cpp
@@ -123,10 +123,10 @@ void sceneHandler35_genFlies() {
 	StaticANIObject *fly = g_fp->_currentScene->getStaticANIObject1ById(ANI_FLY, -1);
 
 	int xoff = 0;
-	if ((!fly || !(fly->_flags & 4)) && !(g_fp->_rnd->getRandomNumber(32767) % 30)) {
+	if ((!fly || !(fly->_flags & 4)) && !(g_fp->_rnd.getRandomNumber(32767) % 30)) {
 		int x, y;
 
-		if (g_fp->_rnd->getRandomNumber(1)) {
+		if (g_fp->_rnd.getRandomNumber(1)) {
 			x = 600;
 			y = 0;
 		} else {
@@ -134,10 +134,10 @@ void sceneHandler35_genFlies() {
 			y = 600;
 		}
 
-		int numFlies = g_fp->_rnd->getRandomNumber(3) + 1;
+		int numFlies = g_fp->_rnd.getRandomNumber(3) + 1;
 
 		while (numFlies--) {
-			g_fp->_floaters->genFlies(g_fp->_currentScene, g_fp->_rnd->getRandomNumber(55) + 1057,  g_fp->_rnd->getRandomNumber(60) + x + xoff, 4, 1);
+			g_fp->_floaters->genFlies(g_fp->_currentScene, g_fp->_rnd.getRandomNumber(55) + 1057,  g_fp->_rnd.getRandomNumber(60) + x + xoff, 4, 1);
 
 			xoff += 40;
 

--- a/engines/fullpipe/scenes/scene35.cpp
+++ b/engines/fullpipe/scenes/scene35.cpp
@@ -141,9 +141,9 @@ void sceneHandler35_genFlies() {
 
 			xoff += 40;
 
-			g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val2 = 1084;
-			g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val3 = y;
-			g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1]->val11 = 8.0;
+			g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].val2 = 1084;
+			g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].val3 = y;
+			g_fp->_floaters->_array2[g_fp->_floaters->_array2.size() - 1].val11 = 8.0;
 		}
 
 		g_vars->scene35_fliesCounter = 0;

--- a/engines/fullpipe/scenes/scene38.cpp
+++ b/engines/fullpipe/scenes/scene38.cpp
@@ -101,7 +101,7 @@ void sceneHandler38_propose() {
 	if (!g_vars->scene38_tally->_movement) {
 		if (g_vars->scene38_tally->_flags & 4) {
 			if (!(g_vars->scene38_tally->_flags & 2) && g_vars->scene38_tallyCounter > 0
-				&& g_fp->_rnd->getRandomNumber(32767) < 32767) {
+				&& g_fp->_rnd.getRandomNumber(32767) < 32767) {
 				chainQueue(QU_DLD_DENY, 0);
 				g_vars->scene38_tallyCounter = 0;
 			}
@@ -112,7 +112,7 @@ void sceneHandler38_propose() {
 void sceneHandler38_point() {
 	if ((!g_vars->scene38_boss->_movement && ((g_vars->scene38_boss->_flags & 4) || !(g_vars->scene38_boss->_flags & 2)))
 		&& g_vars->scene38_bossCounter > 0
-		&& g_fp->_rnd->getRandomNumber(32767) < 32767) {
+		&& g_fp->_rnd.getRandomNumber(32767) < 32767) {
 		if (g_vars->scene38_boss->_statics->_staticsId == ST_GLV_HAMMER) {
 			chainQueue(QU_GLV_TOSMALL, 0);
 			g_vars->scene38_bossCounter = 0;
@@ -130,7 +130,7 @@ void sceneHandler38_hammerKick() {
 		if (g_vars->scene38_shorty->_flags & 4) {
 			if (!(g_vars->scene38_shorty->_flags & 2) && g_vars->scene38_shortyCounter > 1
 				&& g_vars->scene38_shorty->_statics->_staticsId == ST_MLS_LEFT2
-				&& g_fp->_rnd->getRandomNumber(32767) < 3276) {
+				&& g_fp->_rnd.getRandomNumber(32767) < 3276) {
 				chainQueue(QU_MLS_TURNR, 0);
 				g_vars->scene38_shortyCounter = 0;
 			}
@@ -150,7 +150,7 @@ void sceneHandler38_drink() {
 		if (g_vars->scene38_shorty->_flags & 4) {
 			if (!(g_vars->scene38_shorty->_flags & 2) && g_vars->scene38_shortyCounter > 0
 				&& g_vars->scene38_shorty->_statics->_staticsId == ST_MLS_LEFT2
-				&& g_fp->_rnd->getRandomNumber(32767) < 3276) {
+				&& g_fp->_rnd.getRandomNumber(32767) < 3276) {
 				chainQueue(QU_MLS_TURNR, 0);
 				g_vars->scene38_shortyCounter = 0;
 			}
@@ -189,9 +189,9 @@ void sceneHandler38_animateAlcoholics() {
 			} else {
 				int bossAnim = 0;
 
-				if (g_fp->_rnd->getRandomNumber(32767) >= 1310 || g_vars->scene38_boss->_statics->_staticsId != ST_GLV_HAMMER) {
-					if (g_fp->_rnd->getRandomNumber(32767) >= 1310) {
-						if (g_fp->_rnd->getRandomNumber(32767) < 1310) {
+				if (g_fp->_rnd.getRandomNumber(32767) >= 1310 || g_vars->scene38_boss->_statics->_staticsId != ST_GLV_HAMMER) {
+					if (g_fp->_rnd.getRandomNumber(32767) >= 1310) {
+						if (g_fp->_rnd.getRandomNumber(32767) < 1310) {
 							if (bossSt == ST_GLV_HAMMER)
 								bossAnim = QU_GLV_DRINK;
 							else if (bossSt == ST_GLV_NOHAMMER)
@@ -237,10 +237,10 @@ void sceneHandler38_animateAlcoholics() {
 	if (g_vars->scene38_tallyCounter >= 50) {
 		int tallyAnim = 0;
 
-		if (g_fp->_rnd->getRandomNumber(32767) >= 1310) {
-			if (g_fp->_rnd->getRandomNumber(32767) >= 1310) {
-				if (g_fp->_rnd->getRandomNumber(32767) >= 1310) {
-					if (g_fp->_rnd->getRandomNumber(32767) < 1310)
+		if (g_fp->_rnd.getRandomNumber(32767) >= 1310) {
+			if (g_fp->_rnd.getRandomNumber(32767) >= 1310) {
+				if (g_fp->_rnd.getRandomNumber(32767) >= 1310) {
+					if (g_fp->_rnd.getRandomNumber(32767) < 1310)
 						tallyAnim = QU_DLD_ICK;
 				} else {
 					tallyAnim = QU_DLD_GLOT;
@@ -285,9 +285,9 @@ void sceneHandler38_animateAlcoholics() {
 
 	int shortyAnim = 0;
 
-	if (g_fp->_rnd->getRandomNumber(32767) >= 1310) {
-		if (g_fp->_rnd->getRandomNumber(32767) >= 1310 || g_vars->scene38_shorty->_statics->_staticsId != ST_MLS_LEFT2) {
-			if (g_vars->scene38_boss->_statics->_staticsId != ST_GLV_SLEEP2 && g_vars->scene38_bossCounter > 30 && g_fp->_rnd->getRandomNumber(32767) < 0x3FFF && g_vars->scene38_shorty->_statics->_staticsId == ST_MLS_LEFT2)
+	if (g_fp->_rnd.getRandomNumber(32767) >= 1310) {
+		if (g_fp->_rnd.getRandomNumber(32767) >= 1310 || g_vars->scene38_shorty->_statics->_staticsId != ST_MLS_LEFT2) {
+			if (g_vars->scene38_boss->_statics->_staticsId != ST_GLV_SLEEP2 && g_vars->scene38_bossCounter > 30 && g_fp->_rnd.getRandomNumber(32767) < 0x3FFF && g_vars->scene38_shorty->_statics->_staticsId == ST_MLS_LEFT2)
 				shortyAnim = QU_MLS_HAND;
 		} else {
 			shortyAnim = QU_MLS_BLINK;

--- a/engines/fullpipe/scenes/sceneDbg.cpp
+++ b/engines/fullpipe/scenes/sceneDbg.cpp
@@ -45,7 +45,7 @@ GameObject *sceneHandlerDbgMenu_getObjectAtXY(int x, int y) {
 		return 0;
 
 	for (uint i = 1; i < g_fp->_currentScene->_picObjList.size(); i++) {
-		PictureObject *pic = (PictureObject *)g_fp->_currentScene->_picObjList[i];
+		PictureObject *pic = g_fp->_currentScene->_picObjList[i];
 
 		if (x >= pic->_ox && y >= pic->_oy) {
 			const Dims dims = pic->getDimensions();

--- a/engines/fullpipe/scenes/sceneDbg.cpp
+++ b/engines/fullpipe/scenes/sceneDbg.cpp
@@ -48,11 +48,8 @@ GameObject *sceneHandlerDbgMenu_getObjectAtXY(int x, int y) {
 		PictureObject *pic = (PictureObject *)g_fp->_currentScene->_picObjList[i];
 
 		if (x >= pic->_ox && y >= pic->_oy) {
-			Common::Point point;
-
-			pic->getDimensions(&point);
-
-			if (x <= pic->_ox + point.x && y <= pic->_oy + point.y && pic != g_vars->selector)
+			const Dims dims = pic->getDimensions();
+			if (x <= pic->_ox + dims.x && y <= pic->_oy + dims.y && pic != g_vars->selector)
 				return pic;
 		}
 	}

--- a/engines/fullpipe/scenes/sceneFinal.cpp
+++ b/engines/fullpipe/scenes/sceneFinal.cpp
@@ -124,7 +124,7 @@ void sceneHandlerFinal_fallCoin() {
 }
 
 void updateMusic() {
-	if (g_vars->sceneFinal_trackHasStarted && !g_fp->_mixer->isSoundHandleActive(*g_fp->_soundStream1)) { // loop music
+	if (g_vars->sceneFinal_trackHasStarted && !g_fp->_mixer->isSoundHandleActive(g_fp->_soundStream1)) { // loop music
 		sceneHandlerFinal_startMusic("track16.ogg");
 	}
 }

--- a/engines/fullpipe/sound.cpp
+++ b/engines/fullpipe/sound.cpp
@@ -228,8 +228,8 @@ void Sound::stop() {
 void FullpipeEngine::setSceneMusicParameters(GameVar *gvar) {
 	stopSoundStream2();
 
-	if (_mixer->isSoundHandleActive(*_soundStream3))
-		_mixer->stopHandle(*_soundStream4);
+	if (_mixer->isSoundHandleActive(_soundStream3))
+		_mixer->stopHandle(_soundStream4);
 
 	if (_musicLocal)
 		stopAllSoundStreams();
@@ -288,7 +288,7 @@ void FullpipeEngine::updateTrackDelay() {
 
 void FullpipeEngine::startSceneTrack() {
 	if (_sceneTrackIsPlaying) {
-		if (!_mixer->isSoundHandleActive(*_soundStream1)) { // Simulate end of sound callback
+		if (!_mixer->isSoundHandleActive(_soundStream1)) { // Simulate end of sound callback
 			updateTrackDelay();
 		}
 	}
@@ -349,9 +349,9 @@ void FullpipeEngine::startSoundStream1(const Common::String &trackName) {
 	playOggSound(trackName, _soundStream1);
 }
 
-void FullpipeEngine::playOggSound(const Common::String &trackName, Audio::SoundHandle *stream) {
+void FullpipeEngine::playOggSound(const Common::String &trackName, Audio::SoundHandle &stream) {
 #ifdef USE_VORBIS
-	if (_mixer->isSoundHandleActive(*stream))
+	if (_mixer->isSoundHandleActive(stream))
 		return;
 
 	Common::File *track = new Common::File();
@@ -361,7 +361,7 @@ void FullpipeEngine::playOggSound(const Common::String &trackName, Audio::SoundH
 		return;
 	}
 	Audio::RewindableAudioStream *ogg = Audio::makeVorbisStream(track, DisposeAfterUse::YES);
-	_mixer->playStream(Audio::Mixer::kMusicSoundType, stream, ogg);
+	_mixer->playStream(Audio::Mixer::kMusicSoundType, &stream, ogg);
 #endif
 }
 
@@ -399,8 +399,8 @@ void FullpipeEngine::playSound(int id, int flag) {
 }
 
 void FullpipeEngine::playTrack(GameVar *sceneVar, const char *name, bool delayed) {
-	if (_mixer->isSoundHandleActive(*_soundStream3))
-		_mixer->stopHandle(*_soundStream4);
+	if (_mixer->isSoundHandleActive(_soundStream3))
+		_mixer->stopHandle(_soundStream4);
 
 	stopSoundStream2();
 
@@ -491,17 +491,17 @@ void global_messageHandler_handleSound(ExCommand *cmd) {
 void FullpipeEngine::stopSoundStream2() {
 	_stream2playing = false;
 
-	if (_mixer->isSoundHandleActive(*_soundStream3)) {
-		_mixer->stopHandle(*_soundStream2);
-		_mixer->stopHandle(*_soundStream3);
+	if (_mixer->isSoundHandleActive(_soundStream3)) {
+		_mixer->stopHandle(_soundStream2);
+		_mixer->stopHandle(_soundStream3);
 	}
 }
 
 void FullpipeEngine::stopAllSoundStreams() {
-	_mixer->stopHandle(*_soundStream1);
-	_mixer->stopHandle(*_soundStream2);
-	_mixer->stopHandle(*_soundStream3);
-	_mixer->stopHandle(*_soundStream4);
+	_mixer->stopHandle(_soundStream1);
+	_mixer->stopHandle(_soundStream2);
+	_mixer->stopHandle(_soundStream3);
+	_mixer->stopHandle(_soundStream4);
 
 	_stream2playing = false;
 }

--- a/engines/fullpipe/sound.cpp
+++ b/engines/fullpipe/sound.cpp
@@ -57,7 +57,7 @@ bool SoundList::load(MfcArchive &file, const Common::String &fname) {
 	_soundItems = (Sound **)calloc(_soundItemsCount, sizeof(Sound *));
 
 	if (!fname.empty()) {
-	  _libHandle = (NGIArchive *)makeNGIArchive(fname);
+		_libHandle = makeNGIArchive(fname);
 	} else {
 		_libHandle = 0;
 	}

--- a/engines/fullpipe/sound.h
+++ b/engines/fullpipe/sound.h
@@ -23,6 +23,9 @@
 #ifndef FULLPIPE_SOUND_H
 #define FULLPIPE_SOUND_H
 
+#include "common/array.h"
+#include "common/ptr.h"
+
 namespace Audio {
 class SoundHandle;
 }
@@ -60,19 +63,16 @@ public:
 };
 
 class SoundList : public CObject {
-	Sound **_soundItems;
-	int _soundItemsCount;
-	NGIArchive *_libHandle;
+	Common::Array<Sound> _soundItems;
+	Common::ScopedPtr<NGIArchive> _libHandle;
 
  public:
-	SoundList();
-	~SoundList();
 	virtual bool load(MfcArchive &file, const Common::String &fname);
 	virtual bool load(MfcArchive &file) { assert(0); return false; } // Disable base class
 	bool loadFile(const Common::String &fname, const Common::String &libname);
 
-	int getCount() { return _soundItemsCount; }
-	Sound *getSoundByIndex(int idx) { return _soundItems[idx]; }
+	int getCount() { return _soundItems.size(); }
+	Sound &getSoundByIndex(int idx) { return _soundItems[idx]; }
 	Sound *getSoundItemById(int id);
 };
 

--- a/engines/fullpipe/stateloader.cpp
+++ b/engines/fullpipe/stateloader.cpp
@@ -310,7 +310,7 @@ bool FullpipeEngine::loadGam(const char *fname, int scene) {
 	_aniMan = accessScene(SC_COMMON)->getAniMan();
 	_scene2 = 0;
 
-	_movTable = _aniMan->countMovements();
+	_movTable.reset(_aniMan->countMovements());
 
 	_aniMan->setSpeed(1);
 

--- a/engines/fullpipe/stateloader.cpp
+++ b/engines/fullpipe/stateloader.cpp
@@ -359,8 +359,6 @@ bool FullpipeEngine::loadGam(const char *fname, int scene) {
 GameProject::GameProject() {
 	_field_4 = 0;
 	_field_10 = 12;
-
-	_sceneTagList = 0;
 }
 
 bool GameProject::load(MfcArchive &file) {
@@ -380,7 +378,7 @@ bool GameProject::load(MfcArchive &file) {
 	debugC(1, kDebugLoading, "_scrollSpeed = %d", g_fp->_scrollSpeed);
 	debugC(1, kDebugLoading, "_headerFilename = %s", _headerFilename.c_str());
 
-	_sceneTagList = new SceneTagList();
+	_sceneTagList.reset(new SceneTagList());
 
 	_sceneTagList->load(file);
 
@@ -393,10 +391,6 @@ bool GameProject::load(MfcArchive &file) {
 	}
 
 	return true;
-}
-
-GameProject::~GameProject() {
-	delete _sceneTagList;
 }
 
 GameVar::GameVar() {

--- a/engines/fullpipe/stateloader.cpp
+++ b/engines/fullpipe/stateloader.cpp
@@ -85,7 +85,7 @@ bool GameLoader::readSavegame(const char *fname) {
 	Common::MemoryReadStream *archiveStream = new Common::MemoryReadStream(data, header.encSize);
 	MfcArchive *archive = new MfcArchive(archiveStream);
 
-	GameVar *var = (GameVar *)archive->readClass();
+	GameVar *var = archive->readClass<GameVar>();
 
 	GameVar *v = _gameVar->getSubVarByName("OBJSTATES");
 
@@ -301,7 +301,7 @@ bool FullpipeEngine::loadGam(const char *fname, int scene) {
 	_inventory->rebuildItemRects();
 
 	for (uint i = 0; i < _inventory->getScene()->_picObjList.size(); i++)
-		((MemoryObject *)_inventory->getScene()->_picObjList[i]->_picture)->load();
+		_inventory->getScene()->_picObjList[i]->_picture->MemoryObject::load();
 
 	// _sceneSwitcher = sceneSwitcher; // substituted with direct call
 	_gameLoader->_preloadCallback = preloadCallback;
@@ -474,11 +474,11 @@ bool GameVar::load(MfcArchive &file) {
 	}
 
 	file.incLevel();
-	_parentVarObj = (GameVar *)file.readClass();
-	_prevVarObj = (GameVar *)file.readClass();
-	_nextVarObj = (GameVar *)file.readClass();
-	_field_14 = (GameVar *)file.readClass();
-	_subVars = (GameVar *)file.readClass();
+	_parentVarObj = file.readClass<GameVar>();
+	_prevVarObj = file.readClass<GameVar>();
+	_nextVarObj = file.readClass<GameVar>();
+	_field_14 = file.readClass<GameVar>();
+	_subVars = file.readClass<GameVar>();
 	file.decLevel();
 
 	return true;

--- a/engines/fullpipe/stateloader.cpp
+++ b/engines/fullpipe/stateloader.cpp
@@ -109,20 +109,19 @@ bool GameLoader::readSavegame(const char *fname) {
 	debugC(3, kDebugLoading, "Reading %d infos", arrSize);
 
 	for (uint i = 0; i < arrSize; i++) {
-		_sc2array[i]._picAniInfosCount = archive->readUint32LE();
 
-		if (_sc2array[i]._picAniInfosCount)
-			debugC(3, kDebugLoading, "Count %d: %d", i, _sc2array[i]._picAniInfosCount);
+		const uint picAniInfosCount = archive->readUint32LE();
+		if (picAniInfosCount)
+			debugC(3, kDebugLoading, "Count %d: %d", i, picAniInfosCount);
 
-		free(_sc2array[i]._picAniInfos);
-		_sc2array[i]._picAniInfos = (PicAniInfo **)malloc(sizeof(PicAniInfo *) * _sc2array[i]._picAniInfosCount);
+		_sc2array[i]._picAniInfos.clear();
+		_sc2array[i]._picAniInfos.resize(picAniInfosCount);
 
-		for (int j = 0; j < _sc2array[i]._picAniInfosCount; j++) {
-			_sc2array[i]._picAniInfos[j] = new PicAniInfo();
-			_sc2array[i]._picAniInfos[j]->load(*archive);
+		for (uint j = 0; j < picAniInfosCount; j++) {
+			_sc2array[i]._picAniInfos[j].load(*archive);
 		}
 
-		_sc2array[i]._isLoaded = 0;
+		_sc2array[i]._isLoaded = false;
 	}
 
 	delete archiveStream;

--- a/engines/fullpipe/stateloader.cpp
+++ b/engines/fullpipe/stateloader.cpp
@@ -280,7 +280,7 @@ void gameLoaderSavegameCallback(MfcArchive *archive, bool mode) {
 }
 
 bool FullpipeEngine::loadGam(const char *fname, int scene) {
-	_gameLoader = new GameLoader();
+	_gameLoader.reset(new GameLoader());
 
 	if (!_gameLoader->loadFile(fname))
 		return false;

--- a/engines/fullpipe/stateloader.cpp
+++ b/engines/fullpipe/stateloader.cpp
@@ -195,8 +195,6 @@ void fillDummyHeader(Fullpipe::FullpipeSavegameHeader &header) {
 }
 
 bool readSavegameHeader(Common::InSaveFile *in, FullpipeSavegameHeader &header) {
-	header.thumbnail = NULL;
-
 	uint oldPos = in->pos();
 
 	in->seek(-4, SEEK_END);
@@ -239,7 +237,7 @@ bool readSavegameHeader(Common::InSaveFile *in, FullpipeSavegameHeader &header) 
 	header.saveName = Common::String::format("%s %s", desc.getSaveDate().c_str(), desc.getSaveTime().c_str());
 
 	// Get the thumbnail
-	header.thumbnail = Graphics::loadThumbnail(*in);
+	header.thumbnail = Common::SharedPtr<Graphics::Surface>(Graphics::loadThumbnail(*in), Graphics::SurfaceDeleter());
 
 	in->seek(oldPos, SEEK_SET); // Rewind the file
 

--- a/engines/fullpipe/statesaver.cpp
+++ b/engines/fullpipe/statesaver.cpp
@@ -88,13 +88,13 @@ bool GameLoader::writeSavegame(Scene *sc, const char *fname) {
 	debugC(3, kDebugLoading, "Saving %d infos", _sc2array.size());
 
 	for (uint i = 0; i < _sc2array.size(); i++) {
-		archive->writeUint32LE(_sc2array[i]._picAniInfosCount);
+		archive->writeUint32LE(_sc2array[i]._picAniInfos.size());
 
-		if (_sc2array[i]._picAniInfosCount)
-			debugC(3, kDebugLoading, "Count %d: %d", i, _sc2array[i]._picAniInfosCount);
+		if (_sc2array[i]._picAniInfos.size())
+			debugC(3, kDebugLoading, "Count %d: %d", i, _sc2array[i]._picAniInfos.size());
 
-		for (int j = 0; j < _sc2array[i]._picAniInfosCount; j++) {
-			_sc2array[i]._picAniInfos[j]->save(*archive);
+		for (uint j = 0; j < _sc2array[i]._picAniInfos.size(); j++) {
+			_sc2array[i]._picAniInfos[j].save(*archive);
 		}
 	}
 

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -222,17 +222,14 @@ bool StaticANIObject::load(MfcArchive &file) {
 
 		Common::String movname = genFileName(_id, movNum, "mov");
 
-		Common::SeekableReadStream *f = g_fp->_currArchive->createReadStreamForMember(movname);
+		Common::ScopedPtr<Common::SeekableReadStream> f(g_fp->_currArchive->createReadStreamForMember(movname));
 
 		Movement *mov = new Movement();
-
-		MfcArchive archive(f);
-
-		mov->load(archive, this);
-
 		_movements.push_back(mov);
 
-		delete f;
+		MfcArchive archive(f.get());
+
+		mov->load(archive, this);
 	}
 
 	Common::Point pt;

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -112,16 +112,8 @@ StaticANIObject::StaticANIObject() {
 }
 
 StaticANIObject::~StaticANIObject() {
-	for (uint i = 0; i < _staticsList.size(); i++)
-		delete _staticsList[i];
-
-	_staticsList.clear();
-
-	for (uint i = 0; i < _movements.size(); i++)
-		delete _movements[i];
-
-	_movements.clear();
-
+	Common::for_each(_staticsList.begin(), _staticsList.end(), Common::DefaultDeleter<Statics>());
+	Common::for_each(_movements.begin(), _movements.end(), Common::DefaultDeleter<Movement>());
 	g_fp->_aniHandler->detachAllObjects();
 }
 

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1429,14 +1429,17 @@ Movement::~Movement() {
 	if (!_currMovement) {
 		if (_updateFlag1) {
 			_dynamicPhases[0]->freePixelData();
-			_dynamicPhases.remove_at(0);
+			delete _dynamicPhases.remove_at(0);
 		}
 
 		// FIXME: At this point, the last entry in _dynamicPhases is invalid
-		for (uint i = 0; i < _dynamicPhases.size() - 1; i++)
-			_dynamicPhases[i]->freePixelData();
-
-		_dynamicPhases.clear();
+		for (uint i = 0; i < _dynamicPhases.size() - 1; i++) {
+			DynamicPhase *phase = _dynamicPhases[i];
+			if (phase != _staticsObj1 && phase != _staticsObj2)
+				delete phase;
+			else
+				_dynamicPhases[i]->freePixelData();
+		}
 	}
 }
 
@@ -1844,12 +1847,12 @@ void Movement::removeFirstPhase() {
 			gotoNextFrame(0, 0);
 
 		if (!_currMovement) {
-			_dynamicPhases.remove_at(0);
+			delete _dynamicPhases.remove_at(0);
 
 			for (uint i = 0; i < _dynamicPhases.size(); i++) {
-				_framePosOffsets[i].x = _framePosOffsets[i + 1].x;
-				_framePosOffsets[i].y = _framePosOffsets[i + 1].y;
+				_framePosOffsets[i] = _framePosOffsets[i + 1];
 			}
+			_framePosOffsets.pop_back();
 		}
 		_currDynamicPhaseIndex--;
 	}

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1425,7 +1425,7 @@ void Statics::init() {
 	Picture::init();
 
 	if (_staticsId & 0x4000) {
-		_bitmap = BitmapPtr(_bitmap->reverseImage());
+		_bitmap.reset(_bitmap->reverseImage());
 	}
 }
 
@@ -2136,7 +2136,7 @@ DynamicPhase::DynamicPhase(DynamicPhase &src, bool reverse) {
 		if (!src._bitmap)
 			src.init();
 
-		_bitmap = BitmapPtr(src._bitmap->reverseImage());
+		_bitmap.reset(src._bitmap->reverseImage());
 		_dataSize = src._dataSize;
 
 		if (g_fp->_currArchive) {
@@ -2160,7 +2160,7 @@ DynamicPhase::DynamicPhase(DynamicPhase &src, bool reverse) {
 
 		if (src._bitmap) {
 			_field_54 = 1;
-			_bitmap = BitmapPtr(src._bitmap->reverseImage(false));
+			_bitmap.reset(src._bitmap->reverseImage(false));
 		}
 
 		_someX = src._someX;

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1497,7 +1497,7 @@ Movement::~Movement() {
 	for (uint i = 0; i < _dynamicPhases.size(); i++)
 		delete _framePosOffsets[i];
 
-	if (!_currMovement ) {
+	if (!_currMovement) {
 		if (_updateFlag1) {
 			_dynamicPhases[0]->freePixelData();
 			_dynamicPhases.remove_at(0);

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -2112,9 +2112,9 @@ DynamicPhase::DynamicPhase(DynamicPhase *src, bool reverse) {
 	_field_7C = src->_field_7C;
 
 	if (src->getExCommand())
-		_exCommand = src->getExCommand()->createClone();
+		_exCommand.reset(src->getExCommand()->createClone());
 	else
-		_exCommand = 0;
+		_exCommand.reset();
 
 	_initialCountdown = src->_initialCountdown;
 	_field_6A = src->_field_6A;
@@ -2153,11 +2153,6 @@ StaticPhase::StaticPhase() {
 	_initialCountdown = 0;
 	_countdown = 0;
 	_field_68 = 0;
-	_exCommand = 0;
-}
-
-StaticPhase::~StaticPhase() {
-	delete _exCommand;
 }
 
 bool StaticPhase::load(MfcArchive &file) {
@@ -2168,15 +2163,9 @@ bool StaticPhase::load(MfcArchive &file) {
 	_initialCountdown = file.readUint16LE();
 	_field_6A = file.readUint16LE();
 
-	if (g_fp->_gameProjectVersion >= 12) {
-		_exCommand = file.readClass<ExCommand>();
+	assert(g_fp->_gameProjectVersion >= 12);
 
-		return true;
-	}
-
-	assert (g_fp->_gameProjectVersion >= 12);
-
-	warning("StaticPhase::load(): Code continues here");
+	_exCommand.reset(file.readClass<ExCommand>());
 
 	return true;
 }

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -539,14 +539,14 @@ void Movement::draw(bool flipFlag, int angle) {
 	}
 
 	if (flipFlag) {
-		bmp->flipVertical()->drawShaded(1, x, y + 30 + _currDynamicPhase->_rect->bottom, _currDynamicPhase->getPaletteData(), _currDynamicPhase->getAlpha());
+		bmp->flipVertical()->drawShaded(1, x, y + 30 + _currDynamicPhase->_rect.bottom, _currDynamicPhase->getPaletteData(), _currDynamicPhase->getAlpha());
 	} else if (angle) {
 		bmp->drawRotated(x, y, angle, _currDynamicPhase->getPaletteData(), _currDynamicPhase->getAlpha());
 	} else {
 		bmp->putDib(x, y, _currDynamicPhase->getPaletteData(), _currDynamicPhase->getAlpha());
 	}
 
-	if (_currDynamicPhase->_rect->top) {
+	if (_currDynamicPhase->_rect.top) {
 		if (!_currDynamicPhase->getConvertedBitmap()) {
 			//v12 = Picture_getPixelData(v5);
 			//v13 = Bitmap_convertTo16Bit565(v12, (unsigned int *)&_currDynamicPhase->rect);
@@ -595,8 +595,6 @@ void StaticANIObject::draw() {
 	if ((_flags & 4) == 0)
 		return;
 
-	Common::Rect rect;
-
 	debugC(6, kDebugDrawing, "StaticANIObject::draw() (%s) [%d] [%d, %d]", transCyrillic(_objectName), _id, _ox, _oy);
 
 	if (_shadowsOn && g_fp->_currentScene && g_fp->_currentScene->_shadows
@@ -615,7 +613,7 @@ void StaticANIObject::draw() {
 		}
 
 		if (dyn->getDynFlags() & 4) {
-			rect = *dyn->_rect;
+			const Common::Rect &rect = dyn->_rect;
 
 			DynamicPhase *shd = g_fp->_currentScene->_shadows->findSize(rect.width(), rect.height());
 			if (shd) {
@@ -1450,17 +1448,15 @@ Common::Point Statics::getSomeXY() const {
 }
 
 Common::Point Statics::getCenter() const {
-	Common::Rect rect;
-
-	rect = *_rect;
+	Common::Rect rect(_rect);
 
 	if (_staticsId & 0x4000) {
 		const Dims dims = getDimensions();
-		rect.moveTo(dims.x - _rect->right, _rect->top);
+		rect.moveTo(dims.x - _rect.right, _rect.top);
 	}
 
-	return Common::Point(rect.left + _rect->width() / 2,
-						 rect.top + _rect->height() / 2);
+	return Common::Point(rect.left + _rect.width() / 2,
+						 rect.top + _rect.height() / 2);
 }
 
 Movement::Movement() {
@@ -2124,22 +2120,19 @@ void Movement::gotoLastFrame() {
 }
 
 Common::Point Movement::getCenter() const {
-	Common::Rect rect;
-
-	rect = *_currDynamicPhase->_rect;
+	Common::Rect rect(_currDynamicPhase->_rect);
 
 	if (_currMovement) {
 		const Dims dims = _currMovement->getDimensionsOfPhase(_currDynamicPhaseIndex);
-		rect.moveTo(dims.x - _currDynamicPhase->_rect->right, _currDynamicPhase->_rect->top);
+		rect.moveTo(dims.x - _currDynamicPhase->_rect.right, _currDynamicPhase->_rect.top);
 	}
 
-	return Common::Point(rect.left + _currDynamicPhase->_rect->width() / 2,
-						 rect.top + _currDynamicPhase->_rect->height() / 2);
+	return Common::Point(rect.left + _currDynamicPhase->_rect.width() / 2,
+						 rect.top + _currDynamicPhase->_rect.height() / 2);
 }
 
 DynamicPhase::DynamicPhase() {
 	_someX = 0;
-	_rect = 0;
 	_field_7C = 0;
 	_field_7E = 0;
 	_dynFlags = 0;
@@ -2147,14 +2140,9 @@ DynamicPhase::DynamicPhase() {
 	_data = nullptr;
 }
 
-DynamicPhase::~DynamicPhase() {
-	delete _rect;
-}
-
 DynamicPhase::DynamicPhase(DynamicPhase *src, bool reverse) {
 	_field_7C = src->_field_7C;
 	_field_7E = 0;
-	_rect = new Common::Rect();
 
 	debugC(1, kDebugAnimation, "DynamicPhase::DynamicPhase(src, %d)", reverse);
 
@@ -2193,7 +2181,7 @@ DynamicPhase::DynamicPhase(DynamicPhase *src, bool reverse) {
 		_someY = src->_someY;
 	}
 
-	*_rect = *src->_rect;
+	_rect = src->_rect;
 
 	_width = src->_width;
 	_height = src->_height;
@@ -2219,11 +2207,10 @@ bool DynamicPhase::load(MfcArchive &file) {
 	StaticPhase::load(file);
 
 	_field_7C = file.readUint16LE();
-	_rect = new Common::Rect();
-	_rect->left = file.readSint32LE();
-	_rect->top = file.readSint32LE();
-	_rect->right = file.readSint32LE();
-	_rect->bottom = file.readSint32LE();
+	_rect.left = file.readSint32LE();
+	_rect.top = file.readSint32LE();
+	_rect.right = file.readSint32LE();
+	_rect.bottom = file.readSint32LE();
 
 	assert(g_fp->_gameProjectVersion >= 1);
 

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1592,8 +1592,8 @@ Movement::Movement(Movement *src, int *oldIdxs, int newSize, StaticANIObject *an
 				_framePosOffsets[i]->y = src->_framePosOffsets[oldIdxs[i]]->y;
 			}
 		}
-		_staticsObj1 = (Statics *)_dynamicPhases.front();
-		_staticsObj2 = (Statics *)_dynamicPhases.back();
+		_staticsObj1 = dynamic_cast<Statics *>(_dynamicPhases.front());
+		_staticsObj2 = dynamic_cast<Statics *>(_dynamicPhases.back());
 	} else {
 		for (int i = 0; i < newSize; i++) {
 			src->setDynamicPhaseIndex(i);
@@ -2231,7 +2231,7 @@ bool StaticPhase::load(MfcArchive &file) {
 	_field_6A = file.readUint16LE();
 
 	if (g_fp->_gameProjectVersion >= 12) {
-		_exCommand = (ExCommand *)file.readClass();
+		_exCommand = file.readClass<ExCommand>();
 
 		return true;
 	}

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -1954,7 +1954,7 @@ void Movement::loadPixelData() {
 		mov = mov->_currMovement;
 
 	for (uint i = 0; i < mov->_dynamicPhases.size(); i++) {
-		if ((Statics *)mov->_dynamicPhases[i] != mov->_staticsObj2 || !(mov->_staticsObj2->_staticsId & 0x4000))
+		if (mov->_dynamicPhases[i] != mov->_staticsObj2 || !(mov->_staticsObj2->_staticsId & 0x4000))
 			mov->_dynamicPhases[i]->getPixelData();
 	}
 

--- a/engines/fullpipe/statics.cpp
+++ b/engines/fullpipe/statics.cpp
@@ -668,22 +668,19 @@ MovTable *StaticANIObject::countMovements() {
 	GameVar *preloadSubVar = g_fp->getGameLoaderGameVar()->getSubVarByName(getName())->getSubVarByName("PRELOAD");
 
 	if (!preloadSubVar || preloadSubVar->getSubVarsCount() == 0)
-		return 0;
+		return nullptr;
 
 	MovTable *movTable = new MovTable;
-
-	movTable->count = _movements.size();
-	movTable->movs = (int16 *)calloc(_movements.size(), sizeof(int16));
-
+	movTable->reserve(_movements.size());
 	for (uint i = 0; i < _movements.size(); i++) {
-		movTable->movs[i] = 2;
-
+		int16 value = 2;
 		for (GameVar *sub = preloadSubVar->_subVars; sub; sub = sub->_nextVarObj) {
 			if (scumm_stricmp(_movements[i]->getName().c_str(), sub->_varName.c_str()) == 0) {
-				movTable->movs[i] = 1;
+				value = 1;
 				break;
 			}
 		}
+		movTable->push_back(value);
 	}
 
 	return movTable;
@@ -728,9 +725,9 @@ void StaticANIObject::preloadMovements(MovTable *mt) {
 		for (uint i = 0; i < _movements.size(); i++) {
 			Movement *mov = _movements[i];
 
-			if (mt->movs[i] == 1)
+			if ((*mt)[i] == 1)
 				mov->loadPixelData();
-			else if (mt->movs[i] == 2)
+			else if ((*mt)[i] == 2)
 				mov->freePixelData();
 		}
 	}

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -177,7 +177,9 @@ class StaticANIObject : public GameObject {
 	int _initialCounter;
 	void (*_callback1)(int, Common::Point *point, int, int);
 	void (*_callback2)(int *);
+	/** items in list are owned */
 	Common::Array<Movement *> _movements;
+	/** items in list are owned */
 	Common::Array<Statics *> _staticsList;
 	StepArray _stepArray;
 	int16 _field_96;

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -177,9 +177,9 @@ class StaticANIObject : public GameObject {
 	int _initialCounter;
 	void (*_callback1)(int, Common::Point *point, int, int);
 	void (*_callback2)(int *);
-	/** items in list are owned */
+	/** list items are owned */
 	Common::Array<Movement *> _movements;
-	/** items in list are owned */
+	/** list items are owned */
 	Common::Array<Statics *> _staticsList;
 	StepArray _stepArray;
 	int16 _field_96;

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -71,7 +71,7 @@ class DynamicPhase : public StaticPhase {
  public:
 	int _someX;
 	int _someY;
-	Common::Rect *_rect;
+	Common::Rect _rect;
 	int16 _field_7C;
 	int16 _field_7E;
 	int _dynFlags;
@@ -79,7 +79,6 @@ class DynamicPhase : public StaticPhase {
   public:
 	DynamicPhase();
 	DynamicPhase(DynamicPhase *src, bool reverse);
-	virtual ~DynamicPhase();
 
 	virtual bool load(MfcArchive &file);
 

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -53,15 +53,14 @@ class StaticPhase : public Picture {
 	int16 _countdown;
 	int16 _field_68;
 	int16 _field_6A;
-	ExCommand *_exCommand;
+	Common::ScopedPtr<ExCommand> _exCommand;
 
   public:
 	StaticPhase();
-	virtual ~StaticPhase();
 
 	virtual bool load(MfcArchive &file);
 
-	ExCommand *getExCommand() { return _exCommand; }
+	ExCommand *getExCommand() { return _exCommand.get(); }
 };
 
 class DynamicPhase : public StaticPhase {

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -244,6 +244,7 @@ public:
 	void draw();
 	void draw2();
 
+	/** ownership of returned object is transferred to caller */
 	MovTable *countMovements();
 	Common::Point *calcStepLen(Common::Point *p);
 	void setSpeed(int speed);
@@ -257,14 +258,6 @@ public:
 
 	bool getPixelAtPos(int x, int y, uint32 *pixel, bool hitOnly = false);
 	bool isPixelHitAtPos(int x, int y);
-};
-
-struct MovTable {
-	int count;
-	int16 *movs;
-
-	MovTable() { count = 0; movs = 0; }
-	~MovTable() { free(movs); }
 };
 
 } // End of namespace Fullpipe

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -31,23 +31,20 @@ class ExCommand;
 
 class StepArray : public CObject {
 	int _currPointIndex;
-	Common::Point **_points;
-	int _maxPointIndex;
-	int _pointsCount;
-	int _isEos;
+	PointList _points;
+	bool _isEos;
 
   public:
 	StepArray();
-	~StepArray();
 	void clear();
 
-	int getCurrPointIndex() { return _currPointIndex; }
-	int getPointsCount() { return _maxPointIndex; }
+	int getCurrPointIndex() const { return _currPointIndex; }
+	int getPointsCount() const { return _points.size(); }
 
 	Common::Point getCurrPoint() const;
 	Common::Point getPoint(int index, int offset) const;
 	bool gotoNextPoint();
-	void insertPoints(Common::Point **points, int pointsCount);
+	void insertPoints(const PointList &points);
 };
 
 class StaticPhase : public Picture {
@@ -78,7 +75,7 @@ class DynamicPhase : public StaticPhase {
 
   public:
 	DynamicPhase();
-	DynamicPhase(DynamicPhase &src, bool reverse);
+	DynamicPhase(DynamicPhase *src, bool reverse);
 
 	virtual bool load(MfcArchive &file);
 
@@ -93,7 +90,7 @@ class Statics : public DynamicPhase {
 
   public:
 	Statics();
-	Statics(Statics &src, bool reverse);
+	Statics(Statics *src, bool reverse);
 
 	virtual bool load(MfcArchive &file);
 	virtual void init();
@@ -122,7 +119,7 @@ class Movement : public GameObject {
 	int _counter;
 	Common::Array<DynamicPhase *> _dynamicPhases;
 	int _field_78;
-	Common::Array<Common::Point> _framePosOffsets;
+	PointList _framePosOffsets;
 	Movement *_currMovement;
 	int _field_84;
 	DynamicPhase *_currDynamicPhase;
@@ -204,7 +201,7 @@ public:
 	Statics *getStaticsById(int id);
 	Statics *getStaticsByName(const Common::String &name);
 	Movement *getMovementById(int id);
-	int getMovementIdById(int itemId);
+	int getMovementIdById(int itemId) const;
 	Movement *getMovementByName(const Common::String &name);
 	Common::Point getCurrDimensions() const;
 
@@ -232,7 +229,7 @@ public:
 
 	bool startAnim(int movementId, int messageQueueId, int dynPhaseIdx);
 	bool startAnimEx(int movid, int parId, int flag1, int flag2);
-	void startAnimSteps(int movementId, int messageQueueId, int x, int y, Common::Point **points, int pointsCount, int someDynamicPhaseIndex);
+	void startAnimSteps(int movementId, int messageQueueId, int x, int y, const PointList &points, int someDynamicPhaseIndex);
 
 	void hide();
 	void show1(int x, int y, int movementId, int mqId);

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -44,8 +44,8 @@ class StepArray : public CObject {
 	int getCurrPointIndex() { return _currPointIndex; }
 	int getPointsCount() { return _maxPointIndex; }
 
-	Common::Point *getCurrPoint(Common::Point *point);
-	Common::Point *getPoint(Common::Point *point, int index, int offset);
+	Common::Point getCurrPoint() const;
+	Common::Point getPoint(int index, int offset) const;
 	bool gotoNextPoint();
 	void insertPoints(Common::Point **points, int pointsCount);
 };
@@ -101,8 +101,8 @@ class Statics : public DynamicPhase {
 	virtual void init();
 	Statics *getStaticsById(int itemId);
 
-	Common::Point *getSomeXY(Common::Point &p);
-	Common::Point *getCenter(Common::Point *p);
+	Common::Point getSomeXY() const;
+	Common::Point getCenter() const;
 };
 
 class StaticANIObject;
@@ -142,11 +142,11 @@ class Movement : public GameObject {
 	virtual bool load(MfcArchive &file);
 	bool load(MfcArchive &file, StaticANIObject *ani);
 
-	Common::Point *getCurrDynamicPhaseXY(Common::Point &p);
-	Common::Point *getCenter(Common::Point *p);
-	Common::Point *getDimensionsOfPhase(Common::Point *p, int phaseIndex);
+	Common::Point getCurrDynamicPhaseXY() const;
+	Common::Point getCenter() const;
+	Dims getDimensionsOfPhase(int phaseIndex) const;
 
-	Common::Point *calcSomeXY(Common::Point &p, int idx, int dynidx);
+	Common::Point calcSomeXY(int idx, int dynidx);
 
 	void initStatics(StaticANIObject *ani);
 	void updateCurrDynamicPhase();
@@ -208,9 +208,9 @@ public:
 	Movement *getMovementById(int id);
 	int getMovementIdById(int itemId);
 	Movement *getMovementByName(const Common::String &name);
-	Common::Point *getCurrDimensions(Common::Point &p);
+	Common::Point getCurrDimensions() const;
 
-	Common::Point *getSomeXY(Common::Point &p);
+	Common::Point getSomeXY() const;
 
 	void clearFlags();
 	void setFlags40(bool state);

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -116,6 +116,7 @@ class Movement : public GameObject {
 	int _field_50;
 	int _counterMax;
 	int _counter;
+	/** a confusing mix of owned and unowned items */
 	Common::Array<DynamicPhase *> _dynamicPhases;
 	int _field_78;
 	PointList _framePosOffsets;

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -78,7 +78,7 @@ class DynamicPhase : public StaticPhase {
 
   public:
 	DynamicPhase();
-	DynamicPhase(DynamicPhase *src, bool reverse);
+	DynamicPhase(DynamicPhase &src, bool reverse);
 
 	virtual bool load(MfcArchive &file);
 
@@ -89,12 +89,11 @@ class Statics : public DynamicPhase {
  public:
  	int16 _staticsId;
 	Common::String _staticsName;
-	Picture *_picture;
+	Picture _picture;
 
   public:
 	Statics();
-	Statics(Statics *src, bool reverse);
-	virtual ~Statics();
+	Statics(Statics &src, bool reverse);
 
 	virtual bool load(MfcArchive &file);
 	virtual void init();

--- a/engines/fullpipe/statics.h
+++ b/engines/fullpipe/statics.h
@@ -122,7 +122,7 @@ class Movement : public GameObject {
 	int _counter;
 	Common::Array<DynamicPhase *> _dynamicPhases;
 	int _field_78;
-	Common::Point **_framePosOffsets;
+	Common::Array<Common::Point> _framePosOffsets;
 	Movement *_currMovement;
 	int _field_84;
 	DynamicPhase *_currDynamicPhase;

--- a/engines/fullpipe/utils.cpp
+++ b/engines/fullpipe/utils.cpp
@@ -45,22 +45,6 @@ bool CObject::loadFile(const Common::String &fname) {
 	return load(archive);
 }
 
-bool ObList::load(MfcArchive &file) {
-	debugC(5, kDebugLoading, "ObList::load()");
-	int count = file.readCount();
-
-	debugC(9, kDebugLoading, "ObList::count: %d:", count);
-
-	for (int i = 0; i < count; i++) {
-		debugC(9, kDebugLoading, "ObList::[%d]", i);
-		CObject *t = file.readClass();
-
-		push_back(t);
-	}
-
-	return true;
-}
-
 bool ObArray::load(MfcArchive &file) {
 	debugC(5, kDebugLoading, "ObArray::load()");
 	int count = file.readCount();
@@ -68,7 +52,7 @@ bool ObArray::load(MfcArchive &file) {
 	resize(count);
 
 	for (int i = 0; i < count; i++) {
-		CObject *t = file.readClass();
+		CObject *t = file.readClass<CObject>();
 
 		push_back(*t);
 	}
@@ -379,7 +363,7 @@ void MfcArchive::init() {
 	_objectIdMap.push_back(kNullObject);
 }
 
-CObject *MfcArchive::readClass() {
+CObject *MfcArchive::readBaseClass() {
 	bool isCopyReturned;
 	CObject *res = parseClass(&isCopyReturned);
 

--- a/engines/fullpipe/utils.cpp
+++ b/engines/fullpipe/utils.cpp
@@ -24,6 +24,7 @@
 
 #include "common/file.h"
 #include "common/memstream.h"
+#include "common/ptr.h"
 
 #include "fullpipe/objects.h"
 #include "fullpipe/motion.h"
@@ -166,7 +167,7 @@ void MemoryObject::loadFile(const Common::String &filename) {
 		if (g_fp->_currArchive != _libHandle && _libHandle)
 			g_fp->_currArchive = _libHandle;
 
-		Common::SeekableReadStream *s = g_fp->_currArchive->createReadStreamForMember(filename);
+		Common::ScopedPtr<Common::SeekableReadStream> s(g_fp->_currArchive->createReadStreamForMember(filename));
 
 		if (s) {
 			assert(s->size() > 0);
@@ -176,8 +177,6 @@ void MemoryObject::loadFile(const Common::String &filename) {
 			debugC(5, kDebugLoading, "Loading %s (%d bytes)", filename.c_str(), _dataSize);
 			_data = (byte *)calloc(_dataSize, 1);
 			s->read(_data, _dataSize);
-
-			delete s;
 		} else {
 			// We have no object to read. This is fine
 		}

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -59,6 +59,7 @@ public:
 	double readDouble();
 	CObject *parseClass(bool *isCopyReturned);
 
+	/** ownership of returned object is passed to caller */
 	template <typename T>
 	T *readClass() {
 		CObject *obj = readBaseClass();

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -107,7 +107,7 @@ public:
 };
 
 class ObList : public Common::List<CObject *>, public CObject {
- public:
+public:
 	virtual bool load(MfcArchive &file);
 };
 

--- a/engines/fullpipe/utils.h
+++ b/engines/fullpipe/utils.h
@@ -58,7 +58,17 @@ public:
 	int readCount();
 	double readDouble();
 	CObject *parseClass(bool *isCopyReturned);
-	CObject *readClass();
+
+	template <typename T>
+	T *readClass() {
+		CObject *obj = readBaseClass();
+		if (!obj)
+			return nullptr;
+
+		T *res = dynamic_cast<T *>(obj);
+		assert(res);
+		return res;
+	}
 
 	void writeObject(CObject *obj);
 
@@ -76,6 +86,7 @@ public:
 
 private:
 	void init();
+	CObject *readBaseClass();
 };
 
 enum ObjType {
@@ -106,9 +117,24 @@ public:
 	bool loadFile(const Common::String &fname);
 };
 
-class ObList : public Common::List<CObject *>, public CObject {
+template <class T>
+class ObList : public Common::List<T *>, public CObject {
 public:
-	virtual bool load(MfcArchive &file);
+	virtual bool load(MfcArchive &file) {
+		debugC(5, kDebugLoading, "ObList::load()");
+		int count = file.readCount();
+
+		debugC(9, kDebugLoading, "ObList::count: %d:", count);
+
+		for (int i = 0; i < count; i++) {
+			debugC(9, kDebugLoading, "ObList::[%d]", i);
+			T *t = file.readClass<T>();
+
+			this->push_back(t);
+		}
+
+		return true;
+	}
 };
 
 class MemoryObject : CObject {

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -39,7 +39,7 @@ void SaveStateDescriptor::setThumbnail(Graphics::Surface *t) {
 	if (_thumbnail.get() == t)
 		return;
 
-	_thumbnail = Common::SharedPtr<Graphics::Surface>(t, Graphics::SharedPtrSurfaceDeleter());
+	_thumbnail = Common::SharedPtr<Graphics::Surface>(t, Graphics::SurfaceDeleter());
 }
 
 void SaveStateDescriptor::setSaveDate(int year, int month, int day) {

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -121,6 +121,7 @@ public:
 	 * Hence the caller must not delete the surface.
 	 */
 	void setThumbnail(Graphics::Surface *t);
+	void setThumbnail(Common::SharedPtr<Graphics::Surface> t) { _thumbnail = t; }
 
 	/**
 	 * Sets the date the save state was created.

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -334,7 +334,7 @@ public:
  *
  * This deleter assures Surface::free is called on deletion.
  */
-struct SharedPtrSurfaceDeleter {
+struct SurfaceDeleter {
 	void operator()(Surface *ptr) {
 		if (ptr) {
 			ptr->free();

--- a/test/common/ptr.h
+++ b/test/common/ptr.h
@@ -5,6 +5,14 @@
 class PtrTestSuite : public CxxTest::TestSuite {
 	public:
 
+	struct A {
+		int a;
+	};
+
+	struct B : public A {
+		int b;
+	};
+
 	// A simple class which keeps track of all its instances
 	class InstanceCountingClass {
 	public:
@@ -24,6 +32,61 @@ class PtrTestSuite : public CxxTest::TestSuite {
 			TS_ASSERT_EQUALS(InstanceCountingClass::count, 2);
 		}
 		TS_ASSERT_EQUALS(InstanceCountingClass::count, 0);
+	}
+
+	struct CustomDeleter {
+		static bool invoked;
+		void operator()(int *object) {
+			invoked = true;
+			delete object;
+		}
+	};
+
+	void test_scoped_deleter() {
+		CustomDeleter::invoked = false;
+
+		{
+			Common::ScopedPtr<int, CustomDeleter> a(new int(0));
+			TS_ASSERT(!CustomDeleter::invoked);
+		}
+
+		TS_ASSERT(CustomDeleter::invoked);
+	}
+
+	void test_disposable_deleter() {
+		CustomDeleter::invoked = false;
+
+		{
+			Common::DisposablePtr<int, CustomDeleter> a1(new int, DisposeAfterUse::YES);
+			TS_ASSERT(!CustomDeleter::invoked);
+		}
+
+		TS_ASSERT(CustomDeleter::invoked);
+		CustomDeleter::invoked = false;
+
+		int *a = new int;
+		{
+			Common::DisposablePtr<int, CustomDeleter> a2(a, DisposeAfterUse::NO);
+		}
+
+		TS_ASSERT(!CustomDeleter::invoked);
+		delete a;
+	}
+
+	void test_scoped_deref() {
+		A *raw = new A();
+		raw->a = 123;
+		Common::ScopedPtr<A> a(raw);
+		TS_ASSERT_EQUALS(&*a, &*raw);
+		TS_ASSERT_EQUALS(a->a, raw->a);
+	}
+
+	void test_disposable_deref() {
+		A *raw = new A();
+		raw->a = 123;
+		Common::DisposablePtr<A> a(raw, DisposeAfterUse::YES);
+		TS_ASSERT_EQUALS(&*a, &*raw);
+		TS_ASSERT_EQUALS(a->a, raw->a);
 	}
 
 	void test_assign() {
@@ -88,14 +151,6 @@ class PtrTestSuite : public CxxTest::TestSuite {
 		TS_ASSERT(!p1);
 	}
 
-	struct A {
-		int a;
-	};
-
-	struct B : public A {
-		int b;
-	};
-
 	void test_cast() {
 		Common::SharedPtr<B> b(new B);
 		Common::SharedPtr<A> a(b);
@@ -104,3 +159,4 @@ class PtrTestSuite : public CxxTest::TestSuite {
 };
 
 int PtrTestSuite::InstanceCountingClass::count = 0;
+bool PtrTestSuite::CustomDeleter::invoked = false;


### PR DESCRIPTION
This PR contains changes necessary to stop Full Pipe from
leaking memory regularly, fixes the broken RTL, and fixes the
broken in-game save/load screens (mostly; I don't know how to
find a hyphen glyph for drawing the hyphens in the dates so
they are drawn with dot separators instead).

I did not run through the entire game with these changes, just
the first few areas which are immediately accessible without
solving any puzzles. Because these memory leaks were due to
systemic design issues around memory ownership rather than
isolated instances, I expect that there are additional leaks
in other parts of the engine which are not fixed. These
additional leaks can be tracked using separate tickets as they
are discovered.

Fixes Trac#10316, Trac#9654, Trac#9657.