### PR TITLE
SDL2: Improve handling of keyboard repeat events

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -40,7 +40,8 @@ DefaultEventManager::DefaultEventManager(Common::EventSource *boss) :
 	_modifierState(0),
 	_shouldQuit(false),
 	_shouldRTL(false),
-	_confirmExitDialogActive(false) {
+	_confirmExitDialogActive(false),
+	_shouldGenerateKeyRepeatEvents(true) {
 
 	assert(boss);
 
@@ -84,7 +85,9 @@ void DefaultEventManager::init() {
 bool DefaultEventManager::pollEvent(Common::Event &event) {
 	_dispatcher.dispatch();
 
-	handleKeyRepeat();
+	if (_shouldGenerateKeyRepeatEvents) {
+		handleKeyRepeat();
+	}
 
 	if (_eventQueue.empty()) {
 		return false;

--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -247,7 +247,7 @@ void DefaultEventManager::handleKeyRepeat() {
 		}
 	} else {
 		// Check if event should be sent again (keydown)
-		if (_currentKeyDown.keycode != Common::KEYCODE_INVALID && _keyRepeatTime < time) {
+		if (_currentKeyDown.keycode != Common::KEYCODE_INVALID && _keyRepeatTime <= time) {
 			// fire event
 			Common::Event repeatEvent;
 			repeatEvent.type = Common::EVENT_KEYDOWN;

--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -97,7 +97,7 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 	}
 
 	if (result) {
-		event.synthetic = false;
+		event.kbdRepeat = false;
 		switch (event.type) {
 		case Common::EVENT_KEYDOWN:
 			_modifierState = event.kbd.flags;
@@ -233,7 +233,7 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 		if (_currentKeyDown.keycode != 0 && _keyRepeatTime < time) {
 			// fire event
 			event.type = Common::EVENT_KEYDOWN;
-			event.synthetic = true;
+			event.kbdRepeat = true;
 			event.kbd.ascii = _currentKeyDown.ascii;
 			event.kbd.keycode = (Common::KeyCode)_currentKeyDown.keycode;
 			event.kbd.flags = _currentKeyDown.flags;

--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -50,10 +50,6 @@ DefaultEventManager::DefaultEventManager(Common::EventSource *boss) :
 	_dispatcher.registerObserver(this, kEventManPriority, false);
 
 	// Reset key repeat
-	_currentKeyDown.keycode = 0;
-	_currentKeyDown.ascii = 0;
-	_currentKeyDown.flags = 0;
-
 	_keyRepeatTime = 0;
 
 #ifdef ENABLE_VKEYBD
@@ -86,143 +82,161 @@ void DefaultEventManager::init() {
 }
 
 bool DefaultEventManager::pollEvent(Common::Event &event) {
-	// Skip recording of these events
-	uint32 time = g_system->getMillis(true);
-	bool result = false;
-
 	_dispatcher.dispatch();
-	if (!_eventQueue.empty()) {
-		event = _eventQueue.pop();
-		result = true;
+
+	handleKeyRepeat();
+
+	if (_eventQueue.empty()) {
+		return false;
 	}
 
-	if (result) {
-		event.kbdRepeat = false;
-		switch (event.type) {
-		case Common::EVENT_KEYDOWN:
-			_modifierState = event.kbd.flags;
-			// init continuous event stream
-			_currentKeyDown.ascii = event.kbd.ascii;
-			_currentKeyDown.keycode = event.kbd.keycode;
-			_currentKeyDown.flags = event.kbd.flags;
-			_keyRepeatTime = time + kKeyRepeatInitialDelay;
+	event = _eventQueue.pop();
+	bool forwardEvent = true;
 
-			if (event.kbd.keycode == Common::KEYCODE_BACKSPACE) {
-				// WORKAROUND: Some engines incorrectly attempt to use the
-				// ascii value instead of the keycode to detect the backspace
-				// key (a non-portable behavior). This fails at least on
-				// Mac OS X, possibly also on other systems.
-				// As a workaround, we force the ascii value for backspace
-				// key pressed. A better fix would be for engines to stop
-				// making invalid assumptions about ascii values.
-				event.kbd.ascii = Common::KEYCODE_BACKSPACE;
-				_currentKeyDown.ascii = Common::KEYCODE_BACKSPACE;
+	switch (event.type) {
+	case Common::EVENT_KEYDOWN:
+		_modifierState = event.kbd.flags;
+
+		if (event.kbd.keycode == Common::KEYCODE_BACKSPACE) {
+			// WORKAROUND: Some engines incorrectly attempt to use the
+			// ascii value instead of the keycode to detect the backspace
+			// key (a non-portable behavior). This fails at least on
+			// Mac OS X, possibly also on other systems.
+			// As a workaround, we force the ascii value for backspace
+			// key pressed. A better fix would be for engines to stop
+			// making invalid assumptions about ascii values.
+			event.kbd.ascii = Common::KEYCODE_BACKSPACE;
+			_currentKeyDown.ascii = Common::KEYCODE_BACKSPACE;
+		}
+		break;
+
+	case Common::EVENT_KEYUP:
+		_modifierState = event.kbd.flags;
+		break;
+
+	case Common::EVENT_MOUSEMOVE:
+		_mousePos = event.mouse;
+		break;
+
+	case Common::EVENT_LBUTTONDOWN:
+		_mousePos = event.mouse;
+		_buttonState |= LBUTTON;
+		break;
+
+	case Common::EVENT_LBUTTONUP:
+		_mousePos = event.mouse;
+		_buttonState &= ~LBUTTON;
+		break;
+
+	case Common::EVENT_RBUTTONDOWN:
+		_mousePos = event.mouse;
+		_buttonState |= RBUTTON;
+		break;
+
+	case Common::EVENT_RBUTTONUP:
+		_mousePos = event.mouse;
+		_buttonState &= ~RBUTTON;
+		break;
+
+	case Common::EVENT_MAINMENU:
+		if (g_engine && !g_engine->isPaused())
+			g_engine->openMainMenuDialog();
+
+		if (_shouldQuit)
+			event.type = Common::EVENT_QUIT;
+		else if (_shouldRTL)
+			event.type = Common::EVENT_RTL;
+		break;
+#ifdef ENABLE_VKEYBD
+	case Common::EVENT_VIRTUAL_KEYBOARD:
+		if (_vk->isDisplaying()) {
+			_vk->close(true);
+		} else {
+			if (g_engine)
+				g_engine->pauseEngine(true);
+			_vk->show();
+			if (g_engine)
+				g_engine->pauseEngine(false);
+			forwardEvent = false;
+		}
+		break;
+#endif
+#ifdef ENABLE_KEYMAPPER
+	case Common::EVENT_KEYMAPPER_REMAP:
+		if (!_remap) {
+			_remap = true;
+			Common::RemapDialog _remapDialog;
+			if (g_engine)
+				g_engine->pauseEngine(true);
+			_remapDialog.runModal();
+			if (g_engine)
+				g_engine->pauseEngine(false);
+			_remap = false;
+		}
+		break;
+#endif
+	case Common::EVENT_RTL:
+		if (ConfMan.getBool("confirm_exit")) {
+			if (g_engine)
+				g_engine->pauseEngine(true);
+			GUI::MessageDialog alert(_("Do you really want to return to the Launcher?"), _("Launcher"), _("Cancel"));
+			forwardEvent = _shouldRTL = (alert.runModal() == GUI::kMessageOK);
+			if (g_engine)
+				g_engine->pauseEngine(false);
+		} else
+			_shouldRTL = true;
+		break;
+
+	case Common::EVENT_MUTE:
+		if (g_engine)
+			g_engine->flipMute();
+		break;
+
+	case Common::EVENT_QUIT:
+		if (ConfMan.getBool("confirm_exit")) {
+			if (_confirmExitDialogActive) {
+				forwardEvent = false;
+				break;
 			}
+			_confirmExitDialogActive = true;
+			if (g_engine)
+				g_engine->pauseEngine(true);
+			GUI::MessageDialog alert(_("Do you really want to quit?"), _("Quit"), _("Cancel"));
+			forwardEvent = _shouldQuit = (alert.runModal() == GUI::kMessageOK);
+			if (g_engine)
+				g_engine->pauseEngine(false);
+			_confirmExitDialogActive = false;
+		} else
+			_shouldQuit = true;
+
+		break;
+
+	default:
+		break;
+	}
+
+	return forwardEvent;
+}
+
+void DefaultEventManager::handleKeyRepeat() {
+	uint32 time = g_system->getMillis(true);
+
+	if (!_eventQueue.empty()) {
+		// Peek in the event queue
+		const Common::Event &nextEvent = _eventQueue.front();
+
+		switch (nextEvent.type) {
+		case Common::EVENT_KEYDOWN:
+			// init continuous event stream
+			_currentKeyDown = nextEvent.kbd;
+			_keyRepeatTime = time + kKeyRepeatInitialDelay;
 			break;
 
 		case Common::EVENT_KEYUP:
-			_modifierState = event.kbd.flags;
-			if (event.kbd.keycode == _currentKeyDown.keycode) {
+			if (nextEvent.kbd.keycode == _currentKeyDown.keycode) {
 				// Only stop firing events if it's the current key
-				_currentKeyDown.keycode = 0;
+				_currentKeyDown.keycode = Common::KEYCODE_INVALID;
 			}
-			break;
-
-		case Common::EVENT_MOUSEMOVE:
-			_mousePos = event.mouse;
-			break;
-
-		case Common::EVENT_LBUTTONDOWN:
-			_mousePos = event.mouse;
-			_buttonState |= LBUTTON;
-			break;
-
-		case Common::EVENT_LBUTTONUP:
-			_mousePos = event.mouse;
-			_buttonState &= ~LBUTTON;
-			break;
-
-		case Common::EVENT_RBUTTONDOWN:
-			_mousePos = event.mouse;
-			_buttonState |= RBUTTON;
-			break;
-
-		case Common::EVENT_RBUTTONUP:
-			_mousePos = event.mouse;
-			_buttonState &= ~RBUTTON;
-			break;
-
-		case Common::EVENT_MAINMENU:
-			if (g_engine && !g_engine->isPaused())
-				g_engine->openMainMenuDialog();
-
-			if (_shouldQuit)
-				event.type = Common::EVENT_QUIT;
-			else if (_shouldRTL)
-				event.type = Common::EVENT_RTL;
-			break;
-#ifdef ENABLE_VKEYBD
-		case Common::EVENT_VIRTUAL_KEYBOARD:
-			if (_vk->isDisplaying()) {
-				_vk->close(true);
-			} else {
-				if (g_engine)
-					g_engine->pauseEngine(true);
-				_vk->show();
-				if (g_engine)
-					g_engine->pauseEngine(false);
-				result = false;
-			}
-			break;
-#endif
-#ifdef ENABLE_KEYMAPPER
-		case Common::EVENT_KEYMAPPER_REMAP:
-			if (!_remap) {
-				_remap = true;
-				Common::RemapDialog _remapDialog;
-				if (g_engine)
-					g_engine->pauseEngine(true);
-				_remapDialog.runModal();
-				if (g_engine)
-					g_engine->pauseEngine(false);
-				_remap = false;
-			}
-			break;
-#endif
-		case Common::EVENT_RTL:
-			if (ConfMan.getBool("confirm_exit")) {
-				if (g_engine)
-					g_engine->pauseEngine(true);
-				GUI::MessageDialog alert(_("Do you really want to return to the Launcher?"), _("Launcher"), _("Cancel"));
-				result = _shouldRTL = (alert.runModal() == GUI::kMessageOK);
-				if (g_engine)
-					g_engine->pauseEngine(false);
-			} else
-				_shouldRTL = true;
-			break;
-
-		case Common::EVENT_MUTE:
-			if (g_engine)
-				g_engine->flipMute();
-			break;
-
-		case Common::EVENT_QUIT:
-			if (ConfMan.getBool("confirm_exit")) {
-				if (_confirmExitDialogActive) {
-					result = false;
-					break;
-				}
-				_confirmExitDialogActive = true;
-				if (g_engine)
-					g_engine->pauseEngine(true);
-				GUI::MessageDialog alert(_("Do you really want to quit?"), _("Quit"), _("Cancel"));
-				result = _shouldQuit = (alert.runModal() == GUI::kMessageOK);
-				if (g_engine)
-					g_engine->pauseEngine(false);
-				_confirmExitDialogActive = false;
-			} else
-				_shouldQuit = true;
-
 			break;
 
 		default:
@@ -230,19 +244,17 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 		}
 	} else {
 		// Check if event should be sent again (keydown)
-		if (_currentKeyDown.keycode != 0 && _keyRepeatTime < time) {
+		if (_currentKeyDown.keycode != Common::KEYCODE_INVALID && _keyRepeatTime < time) {
 			// fire event
-			event.type = Common::EVENT_KEYDOWN;
-			event.kbdRepeat = true;
-			event.kbd.ascii = _currentKeyDown.ascii;
-			event.kbd.keycode = (Common::KeyCode)_currentKeyDown.keycode;
-			event.kbd.flags = _currentKeyDown.flags;
+			Common::Event repeatEvent;
+			repeatEvent.type = Common::EVENT_KEYDOWN;
+			repeatEvent.kbdRepeat = true;
+			repeatEvent.kbd = _currentKeyDown;
 			_keyRepeatTime = time + kKeyRepeatSustainDelay;
-			result = true;
+
+			_eventQueue.push(repeatEvent);
 		}
 	}
-
-	return result;
 }
 
 void DefaultEventManager::pushEvent(const Common::Event &event) {

--- a/backends/events/default/default-events.h
+++ b/backends/events/default/default-events.h
@@ -67,6 +67,7 @@ class DefaultEventManager : public Common::EventManager, Common::EventObserver {
 		kKeyRepeatSustainDelay = 100
 	};
 
+	bool _shouldGenerateKeyRepeatEvents;
 	Common::KeyState _currentKeyDown;
 	uint32 _keyRepeatTime;
 
@@ -95,6 +96,17 @@ public:
 	 // this, please talk to tsoliman and/or LordHoto.
 	virtual Common::Keymapper *getKeymapper() { return _keymapper; }
 #endif
+
+	/**
+	 * Controls whether repeated key down events are generated while a key is pressed
+	 *
+	 * Backends that generate their own keyboard repeat events should disable this.
+	 *
+	 * @param generateKeyRepeatEvents
+	 */
+	void setGenerateKeyRepeatEvents(bool generateKeyRepeatEvents) {
+		_shouldGenerateKeyRepeatEvents = generateKeyRepeatEvents;
+	}
 };
 
 #endif

--- a/backends/events/default/default-events.h
+++ b/backends/events/default/default-events.h
@@ -67,12 +67,10 @@ class DefaultEventManager : public Common::EventManager, Common::EventObserver {
 		kKeyRepeatSustainDelay = 100
 	};
 
-	struct {
-		uint16 ascii;
-		byte flags;
-		int keycode;
-	} _currentKeyDown;
+	Common::KeyState _currentKeyDown;
 	uint32 _keyRepeatTime;
+
+	void handleKeyRepeat();
 public:
 	DefaultEventManager(Common::EventSource *boss);
 	~DefaultEventManager();

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -696,6 +696,10 @@ bool SdlEventSource::handleKeyDown(SDL_Event &ev, Common::Event &event) {
 	event.kbd.keycode = SDLToOSystemKeycode(sdlKeycode);
 	event.kbd.ascii = mapKey(sdlKeycode, (SDLMod)ev.key.keysym.mod, obtainUnicode(ev.key.keysym));
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	event.kbdRepeat = ev.key.repeat;
+#endif
+
 	return true;
 }
 

--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -443,7 +443,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		}
 
 		if (arg5 > 0)
-			e.synthetic = true;
+			e.kbdRepeat = true;
 
 		// map special keys to 'our' ascii codes
 		switch (e.kbd.keycode) {

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -43,6 +43,7 @@
 #include "backends/audiocd/sdl/sdl-audiocd.h"
 #endif
 
+#include "backends/events/default/default-events.h"
 #include "backends/events/sdl/sdl-events.h"
 #include "backends/mutex/sdl/sdl-mutex.h"
 #include "backends/timer/sdl/sdl-timer.h"
@@ -206,6 +207,16 @@ void OSystem_SDL::initBackend() {
 	// manager didn't provide one yet.
 	if (_eventSource == 0)
 		_eventSource = new SdlEventSource();
+
+	if (_eventManager == nullptr) {
+		DefaultEventManager *eventManager = new DefaultEventManager(_eventSource);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		// SDL 2 generates its own keyboard repeat events.
+		eventManager->setGenerateKeyRepeatEvents(false);
+#endif
+		_eventManager = eventManager;
+	}
+
 
 #ifdef USE_OPENGL
 #if SDL_VERSION_ATLEAST(2, 0, 0)

--- a/backends/platform/tizen/form.cpp
+++ b/backends/platform/tizen/form.cpp
@@ -243,7 +243,6 @@ void TizenAppForm::pushEvent(Common::EventType type, const Point &currentPositio
 void TizenAppForm::pushKey(Common::KeyCode keycode) {
 	if (_eventQueueLock) {
 		Common::Event e;
-		e.synthetic = false;
 		e.kbd.keycode = keycode;
 		e.kbd.ascii = keycode;
 		e.kbd.flags = 0;

--- a/backends/vkeybd/virtual-keyboard.cpp
+++ b/backends/vkeybd/virtual-keyboard.cpp
@@ -242,7 +242,6 @@ void VirtualKeyboard::show() {
 
 		// push keydown & keyup events into the event manager
 		Event evt;
-		evt.synthetic = false;
 		while (!_keyQueue.empty()) {
 			evt.kbd = _keyQueue.pop();
 			evt.type = EVENT_KEYDOWN;

--- a/common/events.h
+++ b/common/events.h
@@ -90,24 +90,29 @@ enum EventType {
 };
 
 typedef uint32 CustomEventType;
+
 /**
  * Data structure for an event. A pointer to an instance of Event
  * can be passed to pollEvent.
  */
 struct Event {
+
 	/** The type of the event. */
 	EventType type;
+
 	/**
 	 * True if this is a key down repeat event.
 	 *
 	 * Only valid for EVENT_KEYDOWN events.
 	 */
 	bool kbdRepeat;
+
 	/**
 	  * Keyboard data; only valid for keyboard events (EVENT_KEYDOWN and
 	  * EVENT_KEYUP). For all other event types, content is undefined.
 	  */
 	KeyState kbd;
+
 	/**
 	 * The mouse coordinates, in virtual screen coordinates. Only valid
 	 * for mouse events.
@@ -385,6 +390,7 @@ public:
 	 * @note	called after graphics system has been set up
 	 */
 	virtual void init() {}
+
 	/**
 	 * Get the next event in the event queue.
 	 * @param event	point to an Event struct, which will be filled with the event data.

--- a/common/events.h
+++ b/common/events.h
@@ -97,10 +97,12 @@ typedef uint32 CustomEventType;
 struct Event {
 	/** The type of the event. */
 	EventType type;
-	/** Flag to indicate if the event is real or synthetic. E.g. keyboard
-	  * repeat events are synthetic.
-	  */
-	bool synthetic;
+	/**
+	 * True if this is a key down repeat event.
+	 *
+	 * Only valid for EVENT_KEYDOWN events.
+	 */
+	bool kbdRepeat;
 	/**
 	  * Keyboard data; only valid for keyboard events (EVENT_KEYDOWN and
 	  * EVENT_KEYUP). For all other event types, content is undefined.
@@ -120,7 +122,7 @@ struct Event {
 	CustomEventType customType;
 #endif
 
-	Event() : type(EVENT_INVALID), synthetic(false) {
+	Event() : type(EVENT_INVALID), kbdRepeat(false) {
 #ifdef ENABLE_KEYMAPPER
 		customType = 0;
 #endif

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -390,7 +390,7 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 		}
 		break;
 	}
-	event.synthetic = true;
+	event.kbdRepeat = true;
 }
 
 void PlaybackFile::readEventsToBuffer(uint32 size) {

--- a/engines/agi/keyboard.cpp
+++ b/engines/agi/keyboard.cpp
@@ -164,42 +164,42 @@ void AgiEngine::processScummVMEvents() {
 				switch (event.kbd.keycode) {
 				case Common::KEYCODE_LEFT:
 				case Common::KEYCODE_KP4:
-					if (_allowSynthetic || !event.synthetic)
+					if (_allowSynthetic || !event.kbdRepeat)
 						key = AGI_KEY_LEFT;
 					break;
 				case Common::KEYCODE_RIGHT:
 				case Common::KEYCODE_KP6:
-					if (_allowSynthetic || !event.synthetic)
+					if (_allowSynthetic || !event.kbdRepeat)
 						key = AGI_KEY_RIGHT;
 					break;
 				case Common::KEYCODE_UP:
 				case Common::KEYCODE_KP8:
-					if (_allowSynthetic || !event.synthetic)
+					if (_allowSynthetic || !event.kbdRepeat)
 						key = AGI_KEY_UP;
 					break;
 				case Common::KEYCODE_DOWN:
 				case Common::KEYCODE_KP2:
-					if (_allowSynthetic || !event.synthetic)
+					if (_allowSynthetic || !event.kbdRepeat)
 						key = AGI_KEY_DOWN;
 					break;
 				case Common::KEYCODE_PAGEUP:
 				case Common::KEYCODE_KP9:
-					if (_allowSynthetic || !event.synthetic)
+					if (_allowSynthetic || !event.kbdRepeat)
 						key = AGI_KEY_UP_RIGHT;
 					break;
 				case Common::KEYCODE_PAGEDOWN:
 				case Common::KEYCODE_KP3:
-					if (_allowSynthetic || !event.synthetic)
+					if (_allowSynthetic || !event.kbdRepeat)
 						key = AGI_KEY_DOWN_RIGHT;
 					break;
 				case Common::KEYCODE_HOME:
 				case Common::KEYCODE_KP7:
-					if (_allowSynthetic || !event.synthetic)
+					if (_allowSynthetic || !event.kbdRepeat)
 						key = AGI_KEY_UP_LEFT;
 					break;
 				case Common::KEYCODE_END:
 				case Common::KEYCODE_KP1:
-					if (_allowSynthetic || !event.synthetic)
+					if (_allowSynthetic || !event.kbdRepeat)
 						key = AGI_KEY_DOWN_LEFT;
 					break;
 				case Common::KEYCODE_KP5:

--- a/engines/dm/eventman.cpp
+++ b/engines/dm/eventman.cpp
@@ -609,7 +609,7 @@ Common::EventType EventManager::processInput(Common::Event *grabKey, Common::Eve
 	while (g_system->getEventManager()->pollEvent(event)) {
 		switch (event.type) {
 		case Common::EVENT_KEYDOWN: {
-			if (event.synthetic)
+			if (event.kbdRepeat)
 				break;
 
 			if (event.kbd.keycode == Common::KEYCODE_d && event.kbd.hasFlags(Common::KBD_CTRL)) {

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -177,7 +177,7 @@ bool EventRecorder::processDelayMillis() {
 }
 
 void EventRecorder::checkForKeyCode(const Common::Event &event) {
-	if ((event.type == Common::EVENT_KEYDOWN) && (event.kbd.flags & Common::KBD_CTRL) && (event.kbd.keycode == Common::KEYCODE_p) && (!event.synthetic)) {
+	if ((event.type == Common::EVENT_KEYDOWN) && (event.kbd.flags & Common::KBD_CTRL) && (event.kbd.keycode == Common::KEYCODE_p) && (!event.kbdRepeat)) {
 		togglePause();
 	}
 }
@@ -445,7 +445,7 @@ Common::List<Common::Event> EventRecorder::mapEvent(const Common::Event &ev, Com
 	evt.mouse.y = evt.mouse.y * (g_system->getOverlayHeight() / g_system->getHeight());
 	switch (_recordMode) {
 	case kRecorderPlayback:
-		if (ev.synthetic != true) {
+		if (ev.kbdRepeat != true) {
 			return Common::List<Common::Event>();
 		}
 		return Common::DefaultEventMapper::mapEvent(ev, source);


### PR DESCRIPTION
Unlike its predecessor, SDL2 always generates keydown repeat events. ScummVM was not updated to account for it. As a result, key repeat events received by the engines are not properly flagged.

This pull request makes sure the repeat events are flagged and disables ScummVM's own repeat event generation when using SDL2. This allows to use the operating system's configured timings for key repeats instead of ScummVM's hardcoded values.