### PR TITLE
TINSEL: Increase maximum number of objects

### DIFF
--- a/engines/tinsel/object.h
+++ b/engines/tinsel/object.h
@@ -34,7 +34,7 @@ struct PALQ;
 
 enum {
 	/** the maximum number of objects */
-	NUM_OBJECTS	= 256,
+	NUM_OBJECTS	= 512,
 
 	// object flags
 	DMA_WNZ		= 0x0001,	///< write non-zero data


### PR DESCRIPTION
This needs to be at least 374 to avoid crashes in the in-game
save/load dialogues with save games using the maximum 40 letters
per save game, so just round up to the next power of two (which
increases memory usage by a whopping ~20KiB) to give more than
enough space for long save game names.

Fixes Trac#6748.

Pretty sure this is fine, save code does not seem to care
about this object list and some quick save/load tests seemed
to work fine, but since I am not familiar with this engine it
seemed like a good idea to PR the change even though it is
otherwise trivial.