### PR TITLE
ZVISION: Workaround for bug #6770

### DIFF
--- a/engines/zvision/scripting/scr_file_handling.cpp
+++ b/engines/zvision/scripting/scr_file_handling.cpp
@@ -141,6 +141,24 @@ bool ScriptManager::parseCriteria(Common::SeekableReadStream &stream, Common::Li
 		criteriaList.back().push_back(entry);
 	}
 
+	// WORKAROUND for a script bug in Zork: Grand Inquisitor, room me2j
+	// (Closing the Time Tunnels). When the time tunnel is open the game
+	// shows a close-up of only the tunnel, instead of showing the entire
+	// booth. However, the scripts that draw the lever in its correct
+	// state do not test this flag, causing it to be drawn when it should
+	// not be. This bug does not happen in the original game, suggesting
+	// a ScummVM bug. But I'm not aware of any other such glitches, and it
+	// still seems like a correct way of working around bug #6770.
+	if (_engine->getGameId() == GID_GRANDINQUISITOR && key == 9536) {
+		Puzzle::CriteriaEntry entry;
+		entry.key = 9404; // me2j_time_tunnel_open
+		entry.criteriaOperator = Puzzle::EQUAL_TO;
+		entry.argumentIsAKey = false;
+		entry.argument = 0;
+
+		criteriaList.back().push_back(entry);
+	}
+
 	while (!stream.eos() && !line.contains('}')) {
 		Puzzle::CriteriaEntry entry;
 


### PR DESCRIPTION
Since no one has been able to suggest a fix for any ScummVM bug responsible for bug #6770 ("ZVISION: Control lever still visible after opening Perils of Magic time tunnel"), here's my attempt at fixing it as a script bug in Zork: Grand Inquisitor.

NB: I've only tried the puzzle itself, and I've only tested with the English DVD version of the game. Oh, and I'm also not that familiar with the game engine itself. What could go wrong? :-)