### PR TITLE
AUDIO: Update MAME OPL to latest upstream & add dual-OPL2 + OPL3

### DIFF
--- a/audio/fmopl.cpp
+++ b/audio/fmopl.cpp
@@ -59,7 +59,7 @@ OPL::OPL() {
 
 const Config::EmulatorDescription Config::_drivers[] = {
 	{ "auto", "<default>", kAuto, kFlagOpl2 | kFlagDualOpl2 | kFlagOpl3 },
-	{ "mame", _s("MAME OPL emulator"), kMame, kFlagOpl2 },
+	{ "mame", _s("MAME OPL emulator"), kMame, kFlagOpl2 | kFlagDualOpl2 | kFlagOpl3 },
 #ifndef DISABLE_DOSBOX_OPL
 	{ "db", _s("DOSBox OPL emulator"), kDOSBox, kFlagOpl2 | kFlagDualOpl2 | kFlagOpl3 },
 #endif
@@ -167,11 +167,14 @@ OPL *Config::create(DriverId driver, OplType type) {
 
 	switch (driver) {
 	case kMame:
-		if (type == kOpl2)
-			return new MAME::OPL();
-		else
-			warning("MAME OPL emulator only supports OPL2 emulation");
-		return 0;
+		switch (type) {
+		case kOpl2:
+			return new MAME::OPL<kOpl2>();
+		case kDualOpl2:
+			return new MAME::OPL<kDualOpl2>();
+		case kOpl3:
+			return new MAME::OPL<kOpl3>();
+		}
 
 #ifndef DISABLE_DOSBOX_OPL
 	case kDOSBox:

--- a/audio/module.mk
+++ b/audio/module.mk
@@ -46,6 +46,9 @@ MODULE_OBJS := \
 	softsynth/opl/dbopl.o \
 	softsynth/opl/dosbox.o \
 	softsynth/opl/mame.o \
+	softsynth/opl/mame/emu/attotime.o \
+	softsynth/opl/mame/sound/fmopl.o \
+	softsynth/opl/mame/sound/ymf262.o \
 	softsynth/fmtowns_pc98/towns_audio.o \
 	softsynth/fmtowns_pc98/towns_euphony.o \
 	softsynth/fmtowns_pc98/towns_midi.o \

--- a/audio/softsynth/opl/mame.cpp
+++ b/audio/softsynth/opl/mame.cpp
@@ -17,1238 +17,231 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *
- * LGPL licensed version of MAMEs fmopl (V0.37a modified) by
- * Tatsuyuki Satoh. Included from LGPL'ed AdPlug.
- *
  */
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
-#include <math.h>
-
-#include "mame.h"
 
 #include "audio/mixer.h"
 #include "common/system.h"
-#include "common/textconsole.h"
-#include "common/util.h"
 
-#if defined(_WIN32_WCE) || defined(__SYMBIAN32__) || defined(__GP32__) || defined(GP2X) || defined(__MAEMO__) || defined(__DS__) || defined(__MINT__) || defined(__N64__)
-#include "common/config-manager.h"
-#endif
+#include "audio/softsynth/opl/mame.h"
 
-#if defined(__DS__)
-#include "dsmain.h"
-#endif
+#include "mame/sound/fmopl.h"
+#include "mame/sound/ymf262.h"
+
+struct FM_OPL;
+struct OPL3;
 
 namespace OPL {
 namespace MAME {
 
-OPL::~OPL() {
+// emu/drivers/xtal.h
+enum {
+	XTAL_3_579545MHz    = 3579545,      /* NTSC color subcarrier, extremely common, used on 100's of PCBs (Keytronic custom part #48-300-010 is equivalent) */
+	XTAL_14_31818MHz    = 14318181      /* Extremely common, used on 100's of PCBs (4x NTSC subcarrier) */
+};
+
+enum {
+	// Dual OPL2
+	kLeftChannel  = 0,
+	kRightChannel = 2,
+	kBothChannels = 8,
+
+	// OPL3
+	kBank0         = 0,
+	kBank1         = 2,
+	kBank1Selector = 0x100
+};
+
+template <Config::OplType TYPE>
+OPL<TYPE>::~OPL() {
 	stop();
-	MAME::OPLDestroy(_opl);
-	_opl = 0;
+	shutdown();
 }
 
-bool OPL::init() {
-	if (_opl) {
-		stopCallbacks();
-		MAME::OPLDestroy(_opl);
-	}
-
-	_opl = MAME::makeAdLibOPL(g_system->getMixer()->getOutputRate());
-
-	return (_opl != 0);
-}
-
-void OPL::reset() {
-	MAME::OPLResetChip(_opl);
-}
-
-void OPL::write(int a, int v) {
-	MAME::OPLWrite(_opl, a, v);
-}
-
-byte OPL::read(int a) {
-	return MAME::OPLRead(_opl, a);
-}
-
-void OPL::writeReg(int r, int v) {
-	MAME::OPLWriteReg(_opl, r, v);
-}
-
-void OPL::generateSamples(int16 *buffer, int length) {
-	MAME::YM3812UpdateOne(_opl, buffer, length);
-}
-
-/* -------------------- preliminary define section --------------------- */
-/* attack/decay rate time rate */
-#define OPL_ARRATE     141280  /* RATE 4 =  2826.24ms @ 3.6MHz */
-#define OPL_DRRATE    1956000  /* RATE 4 = 39280.64ms @ 3.6MHz */
-
-#define FREQ_BITS 24			/* frequency turn          */
-
-/* counter bits = 20 , octerve 7 */
-#define FREQ_RATE   (1<<(FREQ_BITS-20))
-#define TL_BITS    (FREQ_BITS+2)
-
-/* final output shift , limit minimum and maximum */
-#define OPL_OUTSB   (TL_BITS+3-16)		/* OPL output final shift 16bit */
-#define OPL_MAXOUT   (0x7fff<<OPL_OUTSB)
-#define OPL_MINOUT (-(0x8000<<OPL_OUTSB))
-
-/* -------------------- quality selection --------------------- */
-
-/* sinwave entries */
-/* used static memory = SIN_ENT * 4 (byte) */
-#ifdef __DS__
-#define SIN_ENT_SHIFT 8
-#else
-#define SIN_ENT_SHIFT 11
-#endif
-#define SIN_ENT (1<<SIN_ENT_SHIFT)
-
-/* output level entries (envelope,sinwave) */
-/* envelope counter lower bits */
-int ENV_BITS;
-/* envelope output entries */
-int EG_ENT;
-
-/* used dynamic memory = EG_ENT*4*4(byte)or EG_ENT*6*4(byte) */
-/* used static  memory = EG_ENT*4 (byte)                     */
-int EG_OFF;								 /* OFF */
-int EG_DED;
-int EG_DST;								 /* DECAY START */
-int EG_AED;
-#define EG_AST   0                       /* ATTACK START */
-
-#define EG_STEP (96.0/EG_ENT) /* OPL is 0.1875 dB step  */
-
-/* LFO table entries */
-#define VIB_ENT 512
-#define VIB_SHIFT (32-9)
-#define AMS_ENT 512
-#define AMS_SHIFT (32-9)
-
-#define VIB_RATE_SHIFT 8
-#define VIB_RATE (1<<VIB_RATE_SHIFT)
-
-/* -------------------- local defines , macros --------------------- */
-
-/* register number to channel number , slot offset */
-#define SLOT1 0
-#define SLOT2 1
-
-/* envelope phase */
-#define ENV_MOD_RR  0x00
-#define ENV_MOD_DR  0x01
-#define ENV_MOD_AR  0x02
-
-/* -------------------- tables --------------------- */
-static const int slot_array[32] = {
-	 0, 2, 4, 1, 3, 5,-1,-1,
-	 6, 8,10, 7, 9,11,-1,-1,
-	12,14,16,13,15,17,-1,-1,
-	-1,-1,-1,-1,-1,-1,-1,-1
-};
-
-static uint KSL_TABLE[8 * 16];
-
-static const double KSL_TABLE_SEED[8 * 16] = {
-	/* OCT 0 */
-	0.000, 0.000, 0.000, 0.000,
-	0.000, 0.000, 0.000, 0.000,
-	0.000, 0.000, 0.000, 0.000,
-	0.000, 0.000, 0.000, 0.000,
-	/* OCT 1 */
-	0.000, 0.000, 0.000, 0.000,
-	0.000, 0.000, 0.000, 0.000,
-	0.000, 0.750, 1.125, 1.500,
-	1.875, 2.250, 2.625, 3.000,
-	/* OCT 2 */
-	0.000, 0.000, 0.000, 0.000,
-	0.000, 1.125, 1.875, 2.625,
-	3.000, 3.750, 4.125, 4.500,
-	4.875, 5.250, 5.625, 6.000,
-	/* OCT 3 */
-	0.000, 0.000, 0.000, 1.875,
-	3.000, 4.125, 4.875, 5.625,
-	6.000, 6.750, 7.125, 7.500,
-	7.875, 8.250, 8.625, 9.000,
-	/* OCT 4 */
-	0.000, 0.000, 3.000, 4.875,
-	6.000, 7.125, 7.875, 8.625,
-	9.000, 9.750, 10.125, 10.500,
-	10.875, 11.250, 11.625, 12.000,
-	/* OCT 5 */
-	0.000, 3.000, 6.000, 7.875,
-	9.000, 10.125, 10.875, 11.625,
-	12.000, 12.750, 13.125, 13.500,
-	13.875, 14.250, 14.625, 15.000,
-	/* OCT 6 */
-	0.000, 6.000, 9.000, 10.875,
-	12.000, 13.125, 13.875, 14.625,
-	15.000, 15.750, 16.125, 16.500,
-	16.875, 17.250, 17.625, 18.000,
-	/* OCT 7 */
-	0.000, 9.000, 12.000, 13.875,
-	15.000, 16.125, 16.875, 17.625,
-	18.000, 18.750, 19.125, 19.500,
-	19.875, 20.250, 20.625, 21.000
-};
-
-/* sustain level table (3db per step) */
-/* 0 - 15: 0, 3, 6, 9,12,15,18,21,24,27,30,33,36,39,42,93 (dB)*/
-
-static int SL_TABLE[16];
-
-static const uint SL_TABLE_SEED[16] = {
-	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 31
-};
-
-#define TL_MAX (EG_ENT * 2) /* limit(tl + ksr + envelope) + sinwave */
-/* TotalLevel : 48 24 12  6  3 1.5 0.75 (dB) */
-/* TL_TABLE[ 0      to TL_MAX          ] : plus  section */
-/* TL_TABLE[ TL_MAX to TL_MAX+TL_MAX-1 ] : minus section */
-static int *TL_TABLE;
-
-/* pointers to TL_TABLE with sinwave output offset */
-static int **SIN_TABLE;
-
-/* LFO table */
-static int *AMS_TABLE;
-static int *VIB_TABLE;
-
-/* envelope output curve table */
-/* attack + decay + OFF */
-//static int ENV_CURVE[2*EG_ENT+1];
-//static int ENV_CURVE[2 * 4096 + 1];   // to keep it static ...
-static int *ENV_CURVE;
-
-
-/* multiple table */
-#define ML(a) (uint)(a * 2)
-static const uint MUL_TABLE[16]= {
-/* 1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15 */
-	ML(0.50), ML(1.00), ML(2.00),  ML(3.00), ML(4.00), ML(5.00), ML(6.00), ML(7.00),
-	ML(8.00), ML(9.00), ML(10.00), ML(10.00),ML(12.00),ML(12.00),ML(15.00),ML(15.00)
-};
-#undef ML
-
-/* dummy attack / decay rate ( when rate == 0 ) */
-static int RATE_0[16]=
-{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-
-/* -------------------- static state --------------------- */
-
-/* lock level of common table */
-static int num_lock = 0;
-
-/* work table */
-static void *cur_chip = NULL;	/* current chip point */
-/* currenct chip state */
-/* static OPLSAMPLE  *bufL,*bufR; */
-static OPL_CH *S_CH;
-static OPL_CH *E_CH;
-OPL_SLOT *SLOT7_1, *SLOT7_2, *SLOT8_1, *SLOT8_2;
-
-static int outd[1];
-static int ams;
-static int vib;
-int *ams_table;
-int *vib_table;
-static int amsIncr;
-static int vibIncr;
-static int feedback2;		/* connect for SLOT 2 */
-
-/* --------------------- rebuild tables ------------------- */
-
-#define SC_KSL(mydb) ((uint) (mydb / (EG_STEP / 2)))
-#define SC_SL(db) (int)(db * ((3 / EG_STEP) * (1 << ENV_BITS))) + EG_DST
-
-void OPLBuildTables(int ENV_BITS_PARAM, int EG_ENT_PARAM) {
-	int i;
-
-	ENV_BITS = ENV_BITS_PARAM;
-	EG_ENT = EG_ENT_PARAM;
-	EG_OFF = ((2 * EG_ENT)<<ENV_BITS);  /* OFF          */
-	EG_DED = EG_OFF;
-	EG_DST = (EG_ENT << ENV_BITS);     /* DECAY  START */
-	EG_AED = EG_DST;
-	//EG_STEP = (96.0/EG_ENT);
-
-	for (i = 0; i < ARRAYSIZE(KSL_TABLE_SEED); i++)
-		KSL_TABLE[i] = SC_KSL(KSL_TABLE_SEED[i]);
-
-	for (i = 0; i < ARRAYSIZE(SL_TABLE_SEED); i++)
-		SL_TABLE[i] = SC_SL(SL_TABLE_SEED[i]);
-}
-
-#undef SC_KSL
-#undef SC_SL
-
-/* --------------------- subroutines  --------------------- */
-
-/* status set and IRQ handling */
-inline void OPL_STATUS_SET(FM_OPL *OPL, int flag) {
-	/* set status flag */
-	OPL->status |= flag;
-	if (!(OPL->status & 0x80)) {
-		if (OPL->status & OPL->statusmask) {	/* IRQ on */
-			OPL->status |= 0x80;
-			/* callback user interrupt handler (IRQ is OFF to ON) */
-			if (OPL->IRQHandler)
-				(OPL->IRQHandler)(OPL->IRQParam,1);
+template <Config::OplType TYPE>
+bool OPL<TYPE>::init() {
+	shutdown();
+	const uint rate = g_system->getMixer()->getOutputRate();
+	switch (TYPE) {
+	case Config::kDualOpl2:
+		_opl2 = ym3812_init(&_device2, XTAL_3_579545MHz, rate);
+		if (!_opl2) {
+			return false;
 		}
+		// fall through
+	case Config::kOpl2:
+		_opl = ym3812_init(&_device, XTAL_3_579545MHz, rate);
+		break;
+	case Config::kOpl3:
+		_opl = ymf262_init(&_device, XTAL_14_31818MHz, rate);
+		break;
+	}
+
+	return _opl != nullptr;
+}
+
+template <Config::OplType TYPE>
+void OPL<TYPE>::reset() {
+	switch (TYPE) {
+	case Config::kDualOpl2:
+		ym3812_reset_chip(_opl2);
+		// fall through
+	case Config::kOpl2:
+		ym3812_reset_chip(_opl);
+		break;
+	case Config::kOpl3:
+		ymf262_reset_chip(_opl);
+		break;
 	}
 }
 
-/* status reset and IRQ handling */
-inline void OPL_STATUS_RESET(FM_OPL *OPL, int flag) {
-	/* reset status flag */
-	OPL->status &= ~flag;
-	if ((OPL->status & 0x80)) {
-		if (!(OPL->status & OPL->statusmask)) {
-			OPL->status &= 0x7f;
-			/* callback user interrupt handler (IRQ is ON to OFF) */
-			if (OPL->IRQHandler) (OPL->IRQHandler)(OPL->IRQParam,0);
+template <Config::OplType TYPE>
+void OPL<TYPE>::write(const int port, const int value) {
+	switch (TYPE) {
+	case Config::kOpl2:
+		ym3812_write(_opl, port, value);
+		if (isAddressPort(port)) {
+			_lastReg = value;
 		}
-	}
-}
-
-/* IRQ mask set */
-inline void OPL_STATUSMASK_SET(FM_OPL *OPL, int flag) {
-	OPL->statusmask = flag;
-	/* IRQ handling check */
-	OPL_STATUS_SET(OPL,0);
-	OPL_STATUS_RESET(OPL,0);
-}
-
-/* ----- key on  ----- */
-inline void OPL_KEYON(OPL_SLOT *SLOT) {
-	/* sin wave restart */
-	SLOT->Cnt = 0;
-	/* set attack */
-	SLOT->evm = ENV_MOD_AR;
-	SLOT->evs = SLOT->evsa;
-	SLOT->evc = EG_AST;
-	SLOT->eve = EG_AED;
-}
-
-/* ----- key off ----- */
-inline void OPL_KEYOFF(OPL_SLOT *SLOT) {
-	if (SLOT->evm > ENV_MOD_RR) {
-		/* set envelope counter from envleope output */
-
-		// WORKAROUND: The Kyra engine does something very strange when
-		// starting a new song. For each channel:
-		//
-		// * The release rate is set to "fastest".
-		// * Any note is keyed off.
-		// * A very low-frequency note is keyed on.
-		//
-		// Usually, what happens next is that the real notes is keyed
-		// on immediately, in which case there's no problem.
-		//
-		// However, if the note is again keyed off (because the channel
-		// begins on a rest rather than a note), the envelope counter
-		// was moved from the very lowest point on the attack curve to
-		// the very highest point on the release curve.
-		//
-		// Again, this might not be a problem, if the release rate is
-		// still set to "fastest". But in many cases, it had already
-		// been increased. And, possibly because of inaccuracies in the
-		// envelope generator, that would cause the note to "fade out"
-		// for quite a long time.
-		//
-		// What we really need is a way to find the correct starting
-		// point for the envelope counter, and that may be what the
-		// commented-out line below is meant to do. For now, simply
-		// handle the pathological case.
-
-		if (SLOT->evm == ENV_MOD_AR && SLOT->evc == EG_AST)
-			SLOT->evc = EG_DED;
-		else if (!(SLOT->evc & EG_DST))
-			//SLOT->evc = (ENV_CURVE[SLOT->evc>>ENV_BITS]<<ENV_BITS) + EG_DST;
-			SLOT->evc = EG_DST;
-		SLOT->eve = EG_DED;
-		SLOT->evs = SLOT->evsr;
-		SLOT->evm = ENV_MOD_RR;
-	}
-}
-
-/* ---------- calcrate Envelope Generator & Phase Generator ---------- */
-
-/* return : envelope output */
-inline uint OPL_CALC_SLOT(OPL_SLOT *SLOT) {
-	/* calcrate envelope generator */
-	if ((SLOT->evc += SLOT->evs) >= SLOT->eve) {
-		switch (SLOT->evm) {
-		case ENV_MOD_AR: /* ATTACK -> DECAY1 */
-			/* next DR */
-			SLOT->evm = ENV_MOD_DR;
-			SLOT->evc = EG_DST;
-			SLOT->eve = SLOT->SL;
-			SLOT->evs = SLOT->evsd;
-			break;
-		case ENV_MOD_DR: /* DECAY -> SL or RR */
-			SLOT->evc = SLOT->SL;
-			SLOT->eve = EG_DED;
-			if (SLOT->eg_typ) {
-				SLOT->evs = 0;
-			} else {
-				SLOT->evm = ENV_MOD_RR;
-				SLOT->evs = SLOT->evsr;
+		break;
+	case Config::kDualOpl2:
+		if (port & kBothChannels) {
+			ym3812_write(_opl, port, value);
+			ym3812_write(_opl2, port, value);
+			if (isAddressPort(port)) {
+				_lastReg = _lastReg2 = value;
 			}
-			break;
-		case ENV_MOD_RR: /* RR -> OFF */
-			SLOT->evc = EG_OFF;
-			SLOT->eve = EG_OFF + 1;
-			SLOT->evs = 0;
-			break;
-		}
-	}
-	/* calcrate envelope */
-	return SLOT->TLL + ENV_CURVE[SLOT->evc>>ENV_BITS] + (SLOT->ams ? ams : 0);
-}
-
-/* set algorythm connection */
-static void set_algorythm(OPL_CH *CH) {
-	int *carrier = &outd[0];
-	CH->connect1 = CH->CON ? carrier : &feedback2;
-	CH->connect2 = carrier;
-}
-
-/* ---------- frequency counter for operater update ---------- */
-inline void CALC_FCSLOT(OPL_CH *CH, OPL_SLOT *SLOT) {
-	int ksr;
-
-	/* frequency step counter */
-	SLOT->Incr = CH->fc * SLOT->mul;
-	ksr = CH->kcode >> SLOT->KSR;
-
-	if (SLOT->ksr != ksr) {
-		SLOT->ksr = ksr;
-		/* attack , decay rate recalcration */
-		SLOT->evsa = SLOT->AR[ksr];
-		SLOT->evsd = SLOT->DR[ksr];
-		SLOT->evsr = SLOT->RR[ksr];
-	}
-	SLOT->TLL = SLOT->TL + (CH->ksl_base>>SLOT->ksl);
-}
-
-/* set multi,am,vib,EG-TYP,KSR,mul */
-inline void set_mul(FM_OPL *OPL, int slot, int v) {
-	OPL_CH   *CH   = &OPL->P_CH[slot>>1];
-	OPL_SLOT *SLOT = &CH->SLOT[slot & 1];
-
-	SLOT->mul    = MUL_TABLE[v & 0x0f];
-	SLOT->KSR    = (v & 0x10) ? 0 : 2;
-	SLOT->eg_typ = (v & 0x20) >> 5;
-	SLOT->vib    = (v & 0x40);
-	SLOT->ams    = (v & 0x80);
-	CALC_FCSLOT(CH, SLOT);
-}
-
-/* set ksl & tl */
-inline void set_ksl_tl(FM_OPL *OPL, int slot, int v) {
-	OPL_CH   *CH   = &OPL->P_CH[slot>>1];
-	OPL_SLOT *SLOT = &CH->SLOT[slot & 1];
-	int ksl = v >> 6; /* 0 / 1.5 / 3 / 6 db/OCT */
-
-	SLOT->ksl = ksl ? 3-ksl : 31;
-	SLOT->TL  = (int)((v & 0x3f) * (0.75 / EG_STEP)); /* 0.75db step */
-
-	if (!(OPL->mode & 0x80)) {	/* not CSM latch total level */
-		SLOT->TLL = SLOT->TL + (CH->ksl_base >> SLOT->ksl);
-	}
-}
-
-/* set attack rate & decay rate  */
-inline void set_ar_dr(FM_OPL *OPL, int slot, int v) {
-	OPL_CH   *CH   = &OPL->P_CH[slot>>1];
-	OPL_SLOT *SLOT = &CH->SLOT[slot & 1];
-	int ar = v >> 4;
-	int dr = v & 0x0f;
-
-	SLOT->AR = ar ? &OPL->AR_TABLE[ar << 2] : RATE_0;
-	SLOT->evsa = SLOT->AR[SLOT->ksr];
-	if (SLOT->evm == ENV_MOD_AR)
-		SLOT->evs = SLOT->evsa;
-
-	SLOT->DR = dr ? &OPL->DR_TABLE[dr<<2] : RATE_0;
-	SLOT->evsd = SLOT->DR[SLOT->ksr];
-	if (SLOT->evm == ENV_MOD_DR)
-		SLOT->evs = SLOT->evsd;
-}
-
-/* set sustain level & release rate */
-inline void set_sl_rr(FM_OPL *OPL, int slot, int v) {
-	OPL_CH   *CH   = &OPL->P_CH[slot>>1];
-	OPL_SLOT *SLOT = &CH->SLOT[slot & 1];
-	int sl = v >> 4;
-	int rr = v & 0x0f;
-
-	SLOT->SL = SL_TABLE[sl];
-	if (SLOT->evm == ENV_MOD_DR)
-		SLOT->eve = SLOT->SL;
-	SLOT->RR = &OPL->DR_TABLE[rr<<2];
-	SLOT->evsr = SLOT->RR[SLOT->ksr];
-	if (SLOT->evm == ENV_MOD_RR)
-		SLOT->evs = SLOT->evsr;
-}
-
-/* operator output calcrator */
-
-#define OP_OUT(slot,env,con)   slot->wavetable[((slot->Cnt + con)>>(24-SIN_ENT_SHIFT)) & (SIN_ENT-1)][env]
-/* ---------- calcrate one of channel ---------- */
-inline void OPL_CALC_CH(OPL_CH *CH) {
-	uint env_out;
-	OPL_SLOT *SLOT;
-
-	feedback2 = 0;
-	/* SLOT 1 */
-	SLOT = &CH->SLOT[SLOT1];
-	env_out=OPL_CALC_SLOT(SLOT);
-	if (env_out < (uint)(EG_ENT - 1)) {
-		/* PG */
-		if (SLOT->vib)
-			SLOT->Cnt += (SLOT->Incr * vib) >> VIB_RATE_SHIFT;
-		else
-			SLOT->Cnt += SLOT->Incr;
-		/* connection */
-		if (CH->FB) {
-			int feedback1 = (CH->op1_out[0] + CH->op1_out[1]) >> CH->FB;
-			CH->op1_out[1] = CH->op1_out[0];
-			*CH->connect1 += CH->op1_out[0] = OP_OUT(SLOT, env_out, feedback1);
+		} else if (port & kRightChannel) {
+			ym3812_write(_opl2, port, value);
+			if (isAddressPort(port)) {
+				_lastReg2 = value;
+			}
 		} else {
-			*CH->connect1 += OP_OUT(SLOT, env_out, 0);
-		}
-	} else {
-		CH->op1_out[1] = CH->op1_out[0];
-		CH->op1_out[0] = 0;
-	}
-	/* SLOT 2 */
-	SLOT = &CH->SLOT[SLOT2];
-	env_out=OPL_CALC_SLOT(SLOT);
-	if (env_out < (uint)(EG_ENT - 1)) {
-		/* PG */
-		if (SLOT->vib)
-			SLOT->Cnt += (SLOT->Incr * vib) >> VIB_RATE_SHIFT;
-		else
-			SLOT->Cnt += SLOT->Incr;
-		/* connection */
-		outd[0] += OP_OUT(SLOT, env_out, feedback2);
-	}
-}
-
-/* ---------- calcrate rythm block ---------- */
-#define WHITE_NOISE_db 6.0
-inline void OPL_CALC_RH(FM_OPL *OPL, OPL_CH *CH) {
-	uint env_tam, env_sd, env_top, env_hh;
-	// This code used to do int(OPL->rnd.getRandomBit() * (WHITE_NOISE_db / EG_STEP)),
-	// but EG_STEP = 96.0/EG_ENT, and WHITE_NOISE_db=6.0. So, that's equivalent to
-	// int(OPL->rnd.getRandomBit() * EG_ENT/16). We know that EG_ENT is 4096, or 1024,
-	// or 128, so we can safely avoid any FP ops.
-	int whitenoise = OPL->rnd->getRandomBit() * (EG_ENT>>4);
-
-	int tone8;
-
-	OPL_SLOT *SLOT;
-	int env_out;
-
-	/* BD : same as FM serial mode and output level is large */
-	feedback2 = 0;
-	/* SLOT 1 */
-	SLOT = &CH[6].SLOT[SLOT1];
-	env_out = OPL_CALC_SLOT(SLOT);
-	if (env_out < EG_ENT-1) {
-		/* PG */
-		if (SLOT->vib)
-			SLOT->Cnt += (SLOT->Incr * vib) >> VIB_RATE_SHIFT;
-		else
-			SLOT->Cnt += SLOT->Incr;
-		/* connection */
-		if (CH[6].FB) {
-			int feedback1 = (CH[6].op1_out[0] + CH[6].op1_out[1]) >> CH[6].FB;
-			CH[6].op1_out[1] = CH[6].op1_out[0];
-			feedback2 = CH[6].op1_out[0] = OP_OUT(SLOT, env_out, feedback1);
-		}
-		else {
-			feedback2 = OP_OUT(SLOT, env_out, 0);
-		}
-	} else {
-		feedback2 = 0;
-		CH[6].op1_out[1] = CH[6].op1_out[0];
-		CH[6].op1_out[0] = 0;
-	}
-	/* SLOT 2 */
-	SLOT = &CH[6].SLOT[SLOT2];
-	env_out = OPL_CALC_SLOT(SLOT);
-	if (env_out < EG_ENT-1) {
-		/* PG */
-		if (SLOT->vib)
-			SLOT->Cnt += (SLOT->Incr * vib) >> VIB_RATE_SHIFT;
-		else
-			SLOT->Cnt += SLOT->Incr;
-		/* connection */
-		outd[0] += OP_OUT(SLOT, env_out, feedback2) * 2;
-	}
-
-	// SD  (17) = mul14[fnum7] + white noise
-	// TAM (15) = mul15[fnum8]
-	// TOP (18) = fnum6(mul18[fnum8]+whitenoise)
-	// HH  (14) = fnum7(mul18[fnum8]+whitenoise) + white noise
-	env_sd = OPL_CALC_SLOT(SLOT7_2) + whitenoise;
-	env_tam =OPL_CALC_SLOT(SLOT8_1);
-	env_top = OPL_CALC_SLOT(SLOT8_2);
-	env_hh = OPL_CALC_SLOT(SLOT7_1) + whitenoise;
-
-	/* PG */
-	if (SLOT7_1->vib)
-		SLOT7_1->Cnt += (SLOT7_1->Incr * vib) >> (VIB_RATE_SHIFT-1);
-	else
-		SLOT7_1->Cnt += 2 * SLOT7_1->Incr;
-	if (SLOT7_2->vib)
-		SLOT7_2->Cnt += (CH[7].fc * vib) >> (VIB_RATE_SHIFT-3);
-	else
-		SLOT7_2->Cnt += (CH[7].fc * 8);
-	if (SLOT8_1->vib)
-		SLOT8_1->Cnt += (SLOT8_1->Incr * vib) >> VIB_RATE_SHIFT;
-	else
-		SLOT8_1->Cnt += SLOT8_1->Incr;
-	if (SLOT8_2->vib)
-		SLOT8_2->Cnt += ((CH[8].fc * 3) * vib) >> (VIB_RATE_SHIFT-4);
-	else
-		SLOT8_2->Cnt += (CH[8].fc * 48);
-
-	tone8 = OP_OUT(SLOT8_2,whitenoise,0 );
-
-	/* SD */
-	if (env_sd < (uint)(EG_ENT - 1))
-		outd[0] += OP_OUT(SLOT7_1, env_sd, 0) * 8;
-	/* TAM */
-	if (env_tam < (uint)(EG_ENT - 1))
-		outd[0] += OP_OUT(SLOT8_1, env_tam, 0) * 2;
-	/* TOP-CY */
-	if (env_top < (uint)(EG_ENT - 1))
-		outd[0] += OP_OUT(SLOT7_2, env_top, tone8) * 2;
-	/* HH */
-	if (env_hh  < (uint)(EG_ENT-1))
-		outd[0] += OP_OUT(SLOT7_2, env_hh, tone8) * 2;
-}
-
-/* ----------- initialize time tabls ----------- */
-static void init_timetables(FM_OPL *OPL, int ARRATE, int DRRATE) {
-	int i;
-	double rate;
-
-	/* make attack rate & decay rate tables */
-	for (i = 0; i < 4; i++)
-		OPL->AR_TABLE[i] = OPL->DR_TABLE[i] = 0;
-	for (i = 4; i <= 60; i++) {
-		rate = OPL->freqbase;						/* frequency rate */
-		if (i < 60)
-			rate *= 1.0 + (i & 3) * 0.25;		/* b0-1 : x1 , x1.25 , x1.5 , x1.75 */
-		rate *= 1 << ((i >> 2) - 1);						/* b2-5 : shift bit */
-		rate *= (double)(EG_ENT << ENV_BITS);
-		OPL->AR_TABLE[i] = (int)(rate / ARRATE);
-		OPL->DR_TABLE[i] = (int)(rate / DRRATE);
-	}
-	for (i = 60; i < 76; i++) {
-		OPL->AR_TABLE[i] = EG_AED-1;
-		OPL->DR_TABLE[i] = OPL->DR_TABLE[60];
-	}
-}
-
-/* ---------- generic table initialize ---------- */
-static int OPLOpenTable(void) {
-	int s,t;
-	double rate;
-	int i,j;
-	double pom;
-
-#ifdef __DS__
-	DS::fastRamReset();
-
-	TL_TABLE = (int *) DS::fastRamAlloc(TL_MAX * 2 * sizeof(int *));
-	SIN_TABLE = (int **) DS::fastRamAlloc(SIN_ENT * 4 * sizeof(int *));
-#else
-
-	/* allocate dynamic tables */
-	if ((TL_TABLE = (int *)malloc(TL_MAX * 2 * sizeof(int))) == NULL)
-		return 0;
-
-	if ((SIN_TABLE = (int **)malloc(SIN_ENT * 4 * sizeof(int *))) == NULL) {
-		free(TL_TABLE);
-		return 0;
-	}
-#endif
-
-	if ((AMS_TABLE = (int *)malloc(AMS_ENT * 2 * sizeof(int))) == NULL) {
-		free(TL_TABLE);
-		free(SIN_TABLE);
-		return 0;
-	}
-
-	if ((VIB_TABLE = (int *)malloc(VIB_ENT * 2 * sizeof(int))) == NULL) {
-		free(TL_TABLE);
-		free(SIN_TABLE);
-		free(AMS_TABLE);
-		return 0;
-	}
-	/* make total level table */
-	for (t = 0; t < EG_ENT - 1; t++) {
-		rate = ((1 << TL_BITS) - 1) / pow(10.0, EG_STEP * t / 20);	/* dB -> voltage */
-		TL_TABLE[         t] =  (int)rate;
-		TL_TABLE[TL_MAX + t] = -TL_TABLE[t];
-	}
-	/* fill volume off area */
-	for (t = EG_ENT - 1; t < TL_MAX; t++) {
-		TL_TABLE[t] = TL_TABLE[TL_MAX + t] = 0;
-	}
-
-	/* make sinwave table (total level offet) */
-	/* degree 0 = degree 180                   = off */
-	SIN_TABLE[0] = SIN_TABLE[SIN_ENT /2 ] = &TL_TABLE[EG_ENT - 1];
-	for (s = 1;s <= SIN_ENT / 4; s++) {
-		pom = sin(2 * M_PI * s / SIN_ENT); /* sin     */
-		pom = 20 * log10(1 / pom);	   /* decibel */
-		j = int(pom / EG_STEP);         /* TL_TABLE steps */
-
-		/* degree 0   -  90    , degree 180 -  90 : plus section */
-		SIN_TABLE[          s] = SIN_TABLE[SIN_ENT / 2 - s] = &TL_TABLE[j];
-		/* degree 180 - 270    , degree 360 - 270 : minus section */
-		SIN_TABLE[SIN_ENT / 2 + s] = SIN_TABLE[SIN_ENT - s] = &TL_TABLE[TL_MAX + j];
-	}
-	for (s = 0;s < SIN_ENT; s++) {
-		SIN_TABLE[SIN_ENT * 1 + s] = s < (SIN_ENT / 2) ? SIN_TABLE[s] : &TL_TABLE[EG_ENT];
-		SIN_TABLE[SIN_ENT * 2 + s] = SIN_TABLE[s % (SIN_ENT / 2)];
-		SIN_TABLE[SIN_ENT * 3 + s] = (s / (SIN_ENT / 4)) & 1 ? &TL_TABLE[EG_ENT] : SIN_TABLE[SIN_ENT * 2 + s];
-	}
-
-
-	ENV_CURVE = (int *)malloc(sizeof(int) * (2*EG_ENT+1));
-	if (!ENV_CURVE)
-		error("[OPLOpenTable] Cannot allocate memory");
-
-	/* envelope counter -> envelope output table */
-	for (i=0; i < EG_ENT; i++) {
-		/* ATTACK curve */
-		pom = pow(((double)(EG_ENT - 1 - i) / EG_ENT), 8) * EG_ENT;
-		/* if (pom >= EG_ENT) pom = EG_ENT-1; */
-		ENV_CURVE[i] = (int)pom;
-		/* DECAY ,RELEASE curve */
-		ENV_CURVE[(EG_DST >> ENV_BITS) + i]= i;
-	}
-	/* off */
-	ENV_CURVE[EG_OFF >> ENV_BITS]= EG_ENT - 1;
-	/* make LFO ams table */
-	for (i=0; i < AMS_ENT; i++) {
-		pom = (1.0 + sin(2 * M_PI * i / AMS_ENT)) / 2; /* sin */
-		AMS_TABLE[i]         = (int)((1.0 / EG_STEP) * pom); /* 1dB   */
-		AMS_TABLE[AMS_ENT + i] = (int)((4.8 / EG_STEP) * pom); /* 4.8dB */
-	}
-	/* make LFO vibrate table */
-	for (i=0; i < VIB_ENT; i++) {
-		/* 100cent = 1seminote = 6% ?? */
-		pom = (double)VIB_RATE * 0.06 * sin(2 * M_PI * i / VIB_ENT); /* +-100sect step */
-		VIB_TABLE[i]         = (int)(VIB_RATE + (pom * 0.07)); /* +- 7cent */
-		VIB_TABLE[VIB_ENT + i] = (int)(VIB_RATE + (pom * 0.14)); /* +-14cent */
-	}
-	return 1;
-}
-
-static void OPLCloseTable(void) {
-#ifndef __DS__
-	free(TL_TABLE);
-	free(SIN_TABLE);
-#endif
-	free(AMS_TABLE);
-	free(VIB_TABLE);
-	free(ENV_CURVE);
-}
-
-/* CSM Key Controll */
-inline void CSMKeyControll(OPL_CH *CH) {
-	OPL_SLOT *slot1 = &CH->SLOT[SLOT1];
-	OPL_SLOT *slot2 = &CH->SLOT[SLOT2];
-	/* all key off */
-	OPL_KEYOFF(slot1);
-	OPL_KEYOFF(slot2);
-	/* total level latch */
-	slot1->TLL = slot1->TL + (CH->ksl_base>>slot1->ksl);
-	slot1->TLL = slot1->TL + (CH->ksl_base>>slot1->ksl);
-	/* key on */
-	CH->op1_out[0] = CH->op1_out[1] = 0;
-	OPL_KEYON(slot1);
-	OPL_KEYON(slot2);
-}
-
-/* ---------- opl initialize ---------- */
-static void OPL_initalize(FM_OPL *OPL) {
-	int fn;
-
-	/* frequency base */
-	OPL->freqbase = (OPL->rate) ? ((double)OPL->clock / OPL->rate) / 72 : 0;
-	/* Timer base time */
-	OPL->TimerBase = 1.0/((double)OPL->clock / 72.0 );
-	/* make time tables */
-	init_timetables(OPL, OPL_ARRATE, OPL_DRRATE);
-	/* make fnumber -> increment counter table */
-	for (fn=0; fn < 1024; fn++) {
-		OPL->FN_TABLE[fn] = (uint)(OPL->freqbase * fn * FREQ_RATE * (1<<7) / 2);
-	}
-	/* LFO freq.table */
-	OPL->amsIncr = (int)(OPL->rate ? (double)AMS_ENT * (1 << AMS_SHIFT) / OPL->rate * 3.7 * ((double)OPL->clock/3600000) : 0);
-	OPL->vibIncr = (int)(OPL->rate ? (double)VIB_ENT * (1 << VIB_SHIFT) / OPL->rate * 6.4 * ((double)OPL->clock/3600000) : 0);
-}
-
-/* ---------- write a OPL registers ---------- */
-void OPLWriteReg(FM_OPL *OPL, int r, int v) {
-	OPL_CH *CH;
-	int slot;
-	uint block_fnum;
-
-	switch (r & 0xe0) {
-	case 0x00: /* 00-1f:controll */
-		switch (r & 0x1f) {
-		case 0x01:
-			/* wave selector enable */
-			if (OPL->type&OPL_TYPE_WAVESEL) {
-				OPL->wavesel = v & 0x20;
-				if (!OPL->wavesel) {
-					/* preset compatible mode */
-					int c;
-					for (c = 0; c < OPL->max_ch; c++) {
-						OPL->P_CH[c].SLOT[SLOT1].wavetable = &SIN_TABLE[0];
-						OPL->P_CH[c].SLOT[SLOT2].wavetable = &SIN_TABLE[0];
-					}
-				}
+			ym3812_write(_opl, port, value);
+			if (isAddressPort(port)) {
+				_lastReg = value;
 			}
-			return;
-		case 0x02:	/* Timer 1 */
-			OPL->T[0] = (256-v) * 4;
-			break;
-		case 0x03:	/* Timer 2 */
-			OPL->T[1] = (256-v) * 16;
-			return;
-		case 0x04:	/* IRQ clear / mask and Timer enable */
-			if (v & 0x80) {	/* IRQ flag clear */
-				OPL_STATUS_RESET(OPL, 0x7f);
-			} else {	/* set IRQ mask ,timer enable*/
-				uint8 st1 = v & 1;
-				uint8 st2 = (v >> 1) & 1;
-				/* IRQRST,T1MSK,t2MSK,EOSMSK,BRMSK,x,ST2,ST1 */
-				OPL_STATUS_RESET(OPL, v & 0x78);
-				OPL_STATUSMASK_SET(OPL,((~v) & 0x78) | 0x01);
-				/* timer 2 */
-				if (OPL->st[1] != st2) {
-					double interval = st2 ? (double)OPL->T[1] * OPL->TimerBase : 0.0;
-					OPL->st[1] = st2;
-					if (OPL->TimerHandler) (OPL->TimerHandler)(OPL->TimerParam + 1, interval);
-				}
-				/* timer 1 */
-				if (OPL->st[0] != st1) {
-					double interval = st1 ? (double)OPL->T[0] * OPL->TimerBase : 0.0;
-					OPL->st[0] = st1;
-					if (OPL->TimerHandler) (OPL->TimerHandler)(OPL->TimerParam + 0, interval);
-				}
-			}
-			return;
 		}
 		break;
-	case 0x20:	/* am,vib,ksr,eg type,mul */
-		slot = slot_array[r&0x1f];
-		if (slot == -1)
-			return;
-		set_mul(OPL,slot,v);
-		return;
-	case 0x40:
-		slot = slot_array[r&0x1f];
-		if (slot == -1)
-			return;
-		set_ksl_tl(OPL,slot,v);
-		return;
-	case 0x60:
-		slot = slot_array[r&0x1f];
-		if (slot == -1)
-			return;
-		set_ar_dr(OPL,slot,v);
-		return;
-	case 0x80:
-		slot = slot_array[r&0x1f];
-		if (slot == -1)
-			return;
-		set_sl_rr(OPL,slot,v);
-		return;
-	case 0xa0:
-		switch (r) {
-		case 0xbd:
-			/* amsep,vibdep,r,bd,sd,tom,tc,hh */
-			{
-			uint8 rkey = OPL->rythm ^ v;
-			OPL->ams_table = &AMS_TABLE[v & 0x80 ? AMS_ENT : 0];
-			OPL->vib_table = &VIB_TABLE[v & 0x40 ? VIB_ENT : 0];
-			OPL->rythm  = v & 0x3f;
-			if (OPL->rythm & 0x20) {
-				/* BD key on/off */
-				if (rkey & 0x10) {
-					if (v & 0x10) {
-						OPL->P_CH[6].op1_out[0] = OPL->P_CH[6].op1_out[1] = 0;
-						OPL_KEYON(&OPL->P_CH[6].SLOT[SLOT1]);
-						OPL_KEYON(&OPL->P_CH[6].SLOT[SLOT2]);
-					} else {
-						OPL_KEYOFF(&OPL->P_CH[6].SLOT[SLOT1]);
-						OPL_KEYOFF(&OPL->P_CH[6].SLOT[SLOT2]);
-					}
-				}
-				/* SD key on/off */
-				if (rkey & 0x08) {
-					if (v & 0x08)
-						OPL_KEYON(&OPL->P_CH[7].SLOT[SLOT2]);
-					else
-						OPL_KEYOFF(&OPL->P_CH[7].SLOT[SLOT2]);
-				}/* TAM key on/off */
-				if (rkey & 0x04) {
-					if (v & 0x04)
-						OPL_KEYON(&OPL->P_CH[8].SLOT[SLOT1]);
-					else
-						OPL_KEYOFF(&OPL->P_CH[8].SLOT[SLOT1]);
-				}
-				/* TOP-CY key on/off */
-				if (rkey & 0x02) {
-					if (v & 0x02)
-						OPL_KEYON(&OPL->P_CH[8].SLOT[SLOT2]);
-					else
-						OPL_KEYOFF(&OPL->P_CH[8].SLOT[SLOT2]);
-				}
-				/* HH key on/off */
-				if (rkey & 0x01) {
-					if (v & 0x01)
-						OPL_KEYON(&OPL->P_CH[7].SLOT[SLOT1]);
-					else
-						OPL_KEYOFF(&OPL->P_CH[7].SLOT[SLOT1]);
-				}
-			}
-			}
-			return;
-
-		default:
-			break;
-		}
-		/* keyon,block,fnum */
-		if ((r & 0x0f) > 8)
-			return;
-		CH = &OPL->P_CH[r & 0x0f];
-		if (!(r&0x10)) {	/* a0-a8 */
-			block_fnum  = (CH->block_fnum & 0x1f00) | v;
-		} else {	/* b0-b8 */
-			int keyon = (v >> 5) & 1;
-			block_fnum = ((v & 0x1f) << 8) | (CH->block_fnum & 0xff);
-			if (CH->keyon != keyon) {
-				if ((CH->keyon=keyon)) {
-					CH->op1_out[0] = CH->op1_out[1] = 0;
-					OPL_KEYON(&CH->SLOT[SLOT1]);
-					OPL_KEYON(&CH->SLOT[SLOT2]);
-				} else {
-					OPL_KEYOFF(&CH->SLOT[SLOT1]);
-					OPL_KEYOFF(&CH->SLOT[SLOT2]);
-				}
+	case Config::kOpl3:
+		ymf262_write(_opl, port, value);
+		if (isAddressPort(port)) {
+			if (port & kBank1) {
+				_lastReg2 = value;
+			} else {
+				_lastReg = value;
 			}
 		}
-		/* update */
-		if (CH->block_fnum != block_fnum) {
-			int blockRv = 7 - (block_fnum >> 10);
-			int fnum = block_fnum & 0x3ff;
-			CH->block_fnum = block_fnum;
-			CH->ksl_base = KSL_TABLE[block_fnum >> 6];
-			CH->fc = OPL->FN_TABLE[fnum] >> blockRv;
-			CH->kcode = CH->block_fnum >> 9;
-			if ((OPL->mode & 0x40) && CH->block_fnum & 0x100)
-				CH->kcode |=1;
-			CALC_FCSLOT(CH,&CH->SLOT[SLOT1]);
-			CALC_FCSLOT(CH,&CH->SLOT[SLOT2]);
-		}
-		return;
-	case 0xc0:
-		/* FB,C */
-		if ((r & 0x0f) > 8)
-			return;
-		CH = &OPL->P_CH[r&0x0f];
-		{
-			int feedback = (v >> 1) & 7;
-			CH->FB = feedback ? (8 + 1) - feedback : 0;
-			CH->CON = v & 1;
-			set_algorythm(CH);
-		}
-		return;
-	case 0xe0: /* wave type */
-		slot = slot_array[r & 0x1f];
-		if (slot == -1)
-			return;
-		CH = &OPL->P_CH[slot>>1];
-		if (OPL->wavesel) {
-			CH->SLOT[slot&1].wavetable = &SIN_TABLE[(v & 0x03) * SIN_ENT];
-		}
-		return;
-	}
-}
-
-/* lock/unlock for common table */
-static int OPL_LockTable(void) {
-	num_lock++;
-	if (num_lock>1)
-		return 0;
-	/* first time */
-	cur_chip = NULL;
-	/* allocate total level table (128kb space) */
-	if (!OPLOpenTable()) {
-		num_lock--;
-		return -1;
-	}
-	return 0;
-}
-
-static void OPL_UnLockTable(void) {
-	if (num_lock)
-		num_lock--;
-	if (num_lock)
-		return;
-	/* last time */
-	cur_chip = NULL;
-	OPLCloseTable();
-}
-
-/*******************************************************************************/
-/*		YM3812 local section                                                   */
-/*******************************************************************************/
-
-/* ---------- update one of chip ----------- */
-void YM3812UpdateOne(FM_OPL *OPL, int16 *buffer, int length) {
-	int i;
-	int data;
-	int16 *buf = buffer;
-	uint amsCnt = OPL->amsCnt;
-	uint vibCnt = OPL->vibCnt;
-	uint8 rythm = OPL->rythm & 0x20;
-	OPL_CH *CH, *R_CH;
-
-
-	if ((void *)OPL != cur_chip) {
-		cur_chip = (void *)OPL;
-		/* channel pointers */
-		S_CH = OPL->P_CH;
-		E_CH = &S_CH[9];
-		/* rythm slot */
-		SLOT7_1 = &S_CH[7].SLOT[SLOT1];
-		SLOT7_2 = &S_CH[7].SLOT[SLOT2];
-		SLOT8_1 = &S_CH[8].SLOT[SLOT1];
-		SLOT8_2 = &S_CH[8].SLOT[SLOT2];
-		/* LFO state */
-		amsIncr = OPL->amsIncr;
-		vibIncr = OPL->vibIncr;
-		ams_table = OPL->ams_table;
-		vib_table = OPL->vib_table;
-	}
-	R_CH = rythm ? &S_CH[6] : E_CH;
-	for (i = 0; i < length; i++) {
-		/*            channel A         channel B         channel C      */
-		/* LFO */
-		ams = ams_table[(amsCnt += amsIncr) >> AMS_SHIFT];
-		vib = vib_table[(vibCnt += vibIncr) >> VIB_SHIFT];
-		outd[0] = 0;
-		/* FM part */
-		for (CH = S_CH; CH < R_CH; CH++)
-			OPL_CALC_CH(CH);
-		/* Rythn part */
-		if (rythm)
-			OPL_CALC_RH(OPL, S_CH);
-		/* limit check */
-		data = CLIP(outd[0], OPL_MINOUT, OPL_MAXOUT);
-		/* store to sound buffer */
-		buf[i] = data >> OPL_OUTSB;
-	}
-
-	OPL->amsCnt = amsCnt;
-	OPL->vibCnt = vibCnt;
-}
-
-/* ---------- reset a chip ---------- */
-void OPLResetChip(FM_OPL *OPL) {
-	int c,s;
-	int i;
-
-	/* reset chip */
-	OPL->mode = 0;	/* normal mode */
-	OPL_STATUS_RESET(OPL, 0x7f);
-	/* reset with register write */
-	OPLWriteReg(OPL, 0x01,0); /* wabesel disable */
-	OPLWriteReg(OPL, 0x02,0); /* Timer1 */
-	OPLWriteReg(OPL, 0x03,0); /* Timer2 */
-	OPLWriteReg(OPL, 0x04,0); /* IRQ mask clear */
-	for (i = 0xff; i >= 0x20; i--)
-		OPLWriteReg(OPL,i,0);
-	/* reset OPerator parameter */
-	for (c = 0; c < OPL->max_ch; c++) {
-		OPL_CH *CH = &OPL->P_CH[c];
-		/* OPL->P_CH[c].PAN = OPN_CENTER; */
-		for (s = 0; s < 2; s++) {
-			/* wave table */
-			CH->SLOT[s].wavetable = &SIN_TABLE[0];
-			/* CH->SLOT[s].evm = ENV_MOD_RR; */
-			CH->SLOT[s].evc = EG_OFF;
-			CH->SLOT[s].eve = EG_OFF + 1;
-			CH->SLOT[s].evs = 0;
-		}
-	}
-}
-
-/* ----------  Create a virtual YM3812 ----------       */
-/* 'rate'  is sampling rate and 'bufsiz' is the size of the  */
-FM_OPL *OPLCreate(int type, int clock, int rate) {
-	char *ptr;
-	FM_OPL *OPL;
-	int state_size;
-	int max_ch = 9; /* normaly 9 channels */
-
-	if (OPL_LockTable() == -1)
-		return NULL;
-	/* allocate OPL state space */
-	state_size  = sizeof(FM_OPL);
-	state_size += sizeof(OPL_CH) * max_ch;
-
-	/* allocate memory block */
-	ptr = (char *)calloc(state_size, 1);
-	if (ptr == NULL)
-		return NULL;
-
-	/* clear */
-	memset(ptr, 0, state_size);
-	OPL       = (FM_OPL *)ptr; ptr += sizeof(FM_OPL);
-	OPL->P_CH = (OPL_CH *)ptr; ptr += sizeof(OPL_CH) * max_ch;
-
-	/* set channel state pointer */
-	OPL->type  = type;
-	OPL->clock = clock;
-	OPL->rate  = rate;
-	OPL->max_ch = max_ch;
-
-	// Init the random source. Note: We use a fixed name for it here.
-	// So if multiple FM_OPL objects exist in parallel, then their
-	// random sources will have an equal name. At least in the
-	// current EventRecorder implementation, this causes no problems;
-	// but this is probably not guaranteed.
-	// Alas, it does not seem worthwhile to bother much with this
-	// at the time, so I am leaving it as it is.
-	OPL->rnd = new Common::RandomSource("mame");
-
-	/* init grobal tables */
-	OPL_initalize(OPL);
-
-	/* reset chip */
-	OPLResetChip(OPL);
-	return OPL;
-}
-
-/* ----------  Destroy one of virtual YM3812 ----------       */
-void OPLDestroy(FM_OPL *OPL) {
-	OPL_UnLockTable();
-	delete OPL->rnd;
-	free(OPL);
-}
-
-/* ----------  Option handlers ----------       */
-void OPLSetTimerHandler(FM_OPL *OPL, OPL_TIMERHANDLER TimerHandler,int channelOffset) {
-	OPL->TimerHandler   = TimerHandler;
-	OPL->TimerParam = channelOffset;
-}
-
-void OPLSetIRQHandler(FM_OPL *OPL, OPL_IRQHANDLER IRQHandler, int param) {
-	OPL->IRQHandler     = IRQHandler;
-	OPL->IRQParam = param;
-}
-
-void OPLSetUpdateHandler(FM_OPL *OPL, OPL_UPDATEHANDLER UpdateHandler,int param) {
-	OPL->UpdateHandler = UpdateHandler;
-	OPL->UpdateParam = param;
-}
-
-/* ---------- YM3812 I/O interface ---------- */
-int OPLWrite(FM_OPL *OPL,int a,int v) {
-	if (!(a & 1)) {	/* address port */
-		OPL->address = v & 0xff;
-	} else {	/* data port */
-		if (OPL->UpdateHandler)
-			OPL->UpdateHandler(OPL->UpdateParam,0);
-		OPLWriteReg(OPL, OPL->address,v);
-	}
-	return OPL->status >> 7;
-}
-
-unsigned char OPLRead(FM_OPL *OPL,int a) {
-	if (!(a & 1)) {	/* status port */
-		return OPL->status & (OPL->statusmask | 0x80);
-	}
-	/* data port */
-	switch (OPL->address) {
-	case 0x05: /* KeyBoard IN */
-		warning("OPL:read unmapped KEYBOARD port");
-		return 0;
-	case 0x19: /* I/O DATA    */
-		warning("OPL:read unmapped I/O port");
-		return 0;
-	case 0x1a: /* PCM-DATA    */
-		return 0;
-	default:
 		break;
 	}
-	return 0;
 }
 
-int OPLTimerOver(FM_OPL *OPL, int c) {
-	if (c) {	/* Timer B */
-		OPL_STATUS_SET(OPL, 0x20);
-	} else {	/* Timer A */
-		OPL_STATUS_SET(OPL, 0x40);
-		/* CSM mode key,TL controll */
-		if (OPL->mode & 0x80) {	/* CSM mode total level latch and auto key on */
-			int ch;
-			if (OPL->UpdateHandler)
-				OPL->UpdateHandler(OPL->UpdateParam,0);
-			for (ch = 0; ch < 9; ch++)
-				CSMKeyControll(&OPL->P_CH[ch]);
+template <Config::OplType TYPE>
+byte OPL<TYPE>::read(const int port) {
+	switch (TYPE) {
+	case Config::kOpl2:
+		return ym3812_read(_opl, port);
+	case Config::kDualOpl2:
+		if (port & kRightChannel) {
+			return ym3812_read(_opl2, port);
+		} else {
+			return ym3812_read(_opl, port);
 		}
+		break;
+	case Config::kOpl3:
+		return ymf262_read(_opl, port);
 	}
-	/* reload timer */
-	if (OPL->TimerHandler)
-		(OPL->TimerHandler)(OPL->TimerParam + c, (double)OPL->T[c] * OPL->TimerBase);
-	return OPL->status >> 7;
 }
 
-FM_OPL *makeAdLibOPL(int rate) {
-	// We need to emulate one YM3812 chip
-	int env_bits = FMOPL_ENV_BITS_HQ;
-	int eg_ent = FMOPL_EG_ENT_HQ;
-#if defined(_WIN32_WCE) || defined(__SYMBIAN32__) || defined(__GP32__) || defined(GP2X) || defined(__MAEMO__) || defined(__DS__) || defined(__MINT__) || defined(__N64__)
-	if (ConfMan.hasKey("FM_high_quality") && ConfMan.getBool("FM_high_quality")) {
-		env_bits = FMOPL_ENV_BITS_HQ;
-		eg_ent = FMOPL_EG_ENT_HQ;
-	} else if (ConfMan.hasKey("FM_medium_quality") && ConfMan.getBool("FM_medium_quality")) {
-		env_bits = FMOPL_ENV_BITS_MQ;
-		eg_ent = FMOPL_EG_ENT_MQ;
-	} else {
-		env_bits = FMOPL_ENV_BITS_LQ;
-		eg_ent = FMOPL_EG_ENT_LQ;
+template <Config::OplType TYPE>
+void OPL<TYPE>::writeReg(int reg, const int value) {
+	switch (TYPE) {
+	case Config::kOpl2: {
+		const int lastReg = _lastReg;
+		write(0x388, reg);
+		write(0x389, value);
+		write(0x388, lastReg);
+		break;
 	}
-#endif
+	case Config::kDualOpl2: {
+		const int lastReg = _lastReg;
+		const int lastReg2 = _lastReg2;
+		write(0x388, reg);
+		write(0x389, value);
+		write(0x220, lastReg);
+		write(0x222, lastReg2);
+		break;
+	}
+	case Config::kOpl3: {
+		int port = 0x388;
+		int lastReg;
+		if (reg & kBank1Selector) {
+			port += kBank1;
+			reg &= ~kBank1Selector;
+			lastReg = _lastReg2;
+		} else {
+			lastReg = _lastReg;
+		}
 
-	OPLBuildTables(env_bits, eg_ent);
-	return OPLCreate(OPL_TYPE_YM3812, 3579545, rate);
+		write(port, reg);
+		write(port + 1, value);
+		write(port, lastReg);
+		break;
+	}
+	}
 }
+
+template <Config::OplType TYPE>
+void OPL<TYPE>::generateSamples(int16 *buffer, int length) {
+	switch (TYPE) {
+	case Config::kOpl2:
+		ym3812_update_one(_opl, buffer, length);
+		break;
+	case Config::kDualOpl2: {
+		assert((length % 2) == 0);
+		int numSamples = length / 2;
+		while (numSamples--) {
+			ym3812_update_one(_opl, buffer++, 1);
+			ym3812_update_one(_opl2, buffer++, 1);
+		}
+		break;
+	}
+	case Config::kOpl3: {
+		assert((length % 2) == 0);
+		int16 ch3_4;
+		int16 *buffers[] = { buffer, buffer + 1, &ch3_4, &ch3_4 };
+		int numSamples = length / 2;
+		while (numSamples--) {
+			ymf262_update_one(_opl, buffers, 1);
+			buffers[0] += 2;
+			buffers[1] += 2;
+		}
+		break;
+	}
+	}
+}
+
+template <Config::OplType TYPE>
+void OPL<TYPE>::shutdown() {
+	if (!_opl) {
+		return;
+	}
+
+	switch (TYPE) {
+	case Config::kDualOpl2:
+		ym3812_shutdown(_opl2);
+		// fall through
+	case Config::kOpl2:
+		ym3812_shutdown(_opl);
+		break;
+	case Config::kOpl3:
+		ymf262_shutdown(_opl);
+		break;
+	}
+}
+
+template class OPL<Config::kOpl2>;
+template class OPL<Config::kDualOpl2>;
+template class OPL<Config::kOpl3>;
 
 } // End of namespace MAME
 } // End of namespace OPL

--- a/audio/softsynth/opl/mame/emu/attotime.cpp
+++ b/audio/softsynth/opl/mame/emu/attotime.cpp
@@ -1,0 +1,160 @@
+// license:BSD-3-Clause
+// copyright-holders:Aaron Giles
+/***************************************************************************
+
+    attotime.c
+
+    Support functions for working with attotime data.
+
+***************************************************************************/
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+#include "emucore.h"
+#include "eminline.h"
+#include "attotime.h"
+#else
+#include "../fake-emu.h"
+#include <stdio.h>
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+const attotime attotime::zero(0, 0);
+const attotime attotime::never(ATTOTIME_MAX_SECONDS, 0);
+
+//**************************************************************************
+//  CORE MATH FUNCTIONS
+//**************************************************************************
+
+//-------------------------------------------------
+//  operator*= - multiply an attotime by a
+//  constant
+//-------------------------------------------------
+
+attotime &attotime::operator*=(u32 factor)
+{
+	// if one of the items is attotime::never, return attotime::never
+	if (m_seconds >= ATTOTIME_MAX_SECONDS)
+		return *this = never;
+
+	// 0 times anything is zero
+	if (factor == 0)
+		return *this = zero;
+
+	// split attoseconds into upper and lower halves which fit into 32 bits
+	u32 attolo;
+	u32 attohi = divu_64x32_rem(m_attoseconds, ATTOSECONDS_PER_SECOND_SQRT, &attolo);
+
+	// scale the lower half, then split into high/low parts
+	u64 temp = mulu_32x32(attolo, factor);
+	u32 reslo;
+	temp = divu_64x32_rem(temp, ATTOSECONDS_PER_SECOND_SQRT, &reslo);
+
+	// scale the upper half, then split into high/low parts
+	temp += mulu_32x32(attohi, factor);
+	u32 reshi;
+	temp = divu_64x32_rem(temp, ATTOSECONDS_PER_SECOND_SQRT, &reshi);
+
+	// scale the seconds
+	temp += mulu_32x32(m_seconds, factor);
+	if (temp >= ATTOTIME_MAX_SECONDS)
+		return *this = never;
+
+	// build the result
+	m_seconds = temp;
+	m_attoseconds = (attoseconds_t)reslo + mul_32x32(reshi, ATTOSECONDS_PER_SECOND_SQRT);
+	return *this;
+}
+
+
+//-------------------------------------------------
+//  operator/= - divide an attotime by a constant
+//-------------------------------------------------
+
+attotime &attotime::operator/=(u32 factor)
+{
+	// if one of the items is attotime::never, return attotime::never
+	if (m_seconds >= ATTOTIME_MAX_SECONDS)
+		return *this = never;
+
+	// ignore divide by zero
+	if (factor == 0)
+		return *this;
+
+	// split attoseconds into upper and lower halves which fit into 32 bits
+	u32 attolo;
+	u32 attohi = divu_64x32_rem(m_attoseconds, ATTOSECONDS_PER_SECOND_SQRT, &attolo);
+
+	// divide the seconds and get the remainder
+	u32 remainder;
+	m_seconds = divu_64x32_rem(m_seconds, factor, &remainder);
+
+	// combine the upper half of attoseconds with the remainder and divide that
+	u64 temp = s64(attohi) + mulu_32x32(remainder, ATTOSECONDS_PER_SECOND_SQRT);
+	u32 reshi = divu_64x32_rem(temp, factor, &remainder);
+
+	// combine the lower half of attoseconds with the remainder and divide that
+	temp = attolo + mulu_32x32(remainder, ATTOSECONDS_PER_SECOND_SQRT);
+	u32 reslo = divu_64x32_rem(temp, factor, &remainder);
+
+	// round based on the remainder
+	m_attoseconds = (attoseconds_t)reslo + mulu_32x32(reshi, ATTOSECONDS_PER_SECOND_SQRT);
+	if (remainder >= factor / 2)
+		if (++m_attoseconds >= ATTOSECONDS_PER_SECOND)
+		{
+			m_attoseconds = 0;
+			m_seconds++;
+		}
+	return *this;
+}
+
+
+//-------------------------------------------------
+//  as_string - return a temporary printable
+//  string describing an attotime
+//-------------------------------------------------
+
+const char *attotime::as_string(int precision) const
+{
+	static char buffers[8][30];
+	static int nextbuf;
+	char *buffer = &buffers[nextbuf++ % 8][0];
+
+	// special case: never
+	if (*this == never)
+		sprintf(buffer, "%-*s", precision, "(never)");
+
+	// case 1: we want no precision; seconds only
+	else if (precision == 0)
+		sprintf(buffer, "%d", m_seconds);
+
+	// case 2: we want 9 or fewer digits of precision
+	else if (precision <= 9)
+	{
+		u32 upper = m_attoseconds / ATTOSECONDS_PER_SECOND_SQRT;
+		int temp = precision;
+		while (temp < 9)
+		{
+			upper /= 10;
+			temp++;
+		}
+		sprintf(buffer, "%d.%0*d", m_seconds, precision, upper);
+	}
+
+	// case 3: more than 9 digits of precision
+	else
+	{
+		u32 lower;
+		u32 upper = divu_64x32_rem(m_attoseconds, ATTOSECONDS_PER_SECOND_SQRT, &lower);
+		int temp = precision;
+		while (temp < 18)
+		{
+			lower /= 10;
+			temp++;
+		}
+		sprintf(buffer, "%d.%09d%0*d", m_seconds, upper, precision - 9, lower);
+	}
+	return buffer;
+}

--- a/audio/softsynth/opl/mame/emu/attotime.h
+++ b/audio/softsynth/opl/mame/emu/attotime.h
@@ -1,0 +1,372 @@
+// license:BSD-3-Clause
+// copyright-holders:Aaron Giles
+/**************************************************************************/
+/**
+ * @file attotime.h
+ * Support functions for working with attotime data.
+ * @defgroup ATTOTIME
+ * @{
+ * Support functions for working with attotime data.
+ *
+ * @class attotime
+ *  Attotime is an attosecond-accurate timing system implemented as
+ *  96-bit integers.
+ *
+ *     1 second      = 1e0 seconds
+ *     1 millisecond = 1e-3 seconds
+ *     1 microsecond = 1e-6 seconds
+ *     1 nanosecond  = 1e-9 seconds
+ *     1 picosecond  = 1e-12 seconds
+ *     1 femtosecond = 1e-15 seconds
+ *     1 attosecond  = 1e-18 seconds
+ *
+ * This may seem insanely accurate, but it has its uses when multiple
+ * clocks in the system are run by independent crystals. It is also
+ * useful to compute the attotime for something small, say 1 clock tick,
+ * and still have it be accurate and useful for scaling.
+ *
+ * Attotime consists of a 32-bit seconds count and a 64-bit attoseconds
+ * count. Because the lower bits are kept as attoseconds and not as a
+ * full 64-bit value, there is headroom to make some operations simpler.
+ */
+/**************************************************************************/
+#ifndef MAME_EMU_ATTOTIME_H
+#define MAME_EMU_ATTOTIME_H
+
+#pragma once
+
+#include <math.h>
+#undef min
+#undef max
+
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+#define constexpr
+#endif
+
+//**************************************************************************
+//  CONSTANTS
+//**************************************************************************
+
+// core components of the attotime structure
+typedef s64 attoseconds_t;
+typedef s32 seconds_t;
+
+// core definitions
+#if defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) || __cplusplus >= 201402L
+const attoseconds_t ATTOSECONDS_PER_SECOND_SQRT = 1'000'000'000;
+const attoseconds_t ATTOSECONDS_PER_SECOND = ATTOSECONDS_PER_SECOND_SQRT * ATTOSECONDS_PER_SECOND_SQRT;
+const attoseconds_t ATTOSECONDS_PER_MILLISECOND = ATTOSECONDS_PER_SECOND / 1'000;
+const attoseconds_t ATTOSECONDS_PER_MICROSECOND = ATTOSECONDS_PER_SECOND / 1'000'000;
+const attoseconds_t ATTOSECONDS_PER_NANOSECOND = ATTOSECONDS_PER_SECOND / 1'000'000'000;
+
+const seconds_t ATTOTIME_MAX_SECONDS = 1000000000;
+#else
+const attoseconds_t ATTOSECONDS_PER_SECOND_SQRT = 1000000000;
+const attoseconds_t ATTOSECONDS_PER_SECOND = ATTOSECONDS_PER_SECOND_SQRT * ATTOSECONDS_PER_SECOND_SQRT;
+const attoseconds_t ATTOSECONDS_PER_MILLISECOND = ATTOSECONDS_PER_SECOND / 1000;
+const attoseconds_t ATTOSECONDS_PER_MICROSECOND = ATTOSECONDS_PER_SECOND / 1000000;
+const attoseconds_t ATTOSECONDS_PER_NANOSECOND = ATTOSECONDS_PER_SECOND / 1000000000;
+
+const seconds_t ATTOTIME_MAX_SECONDS = 1000000000;
+#endif
+
+
+//**************************************************************************
+//  MACROS
+//**************************************************************************
+
+// convert between a double and attoseconds
+inline constexpr double ATTOSECONDS_TO_DOUBLE(attoseconds_t x) { return double(x) * 1e-18; }
+inline constexpr attoseconds_t DOUBLE_TO_ATTOSECONDS(double x) { return attoseconds_t(x * 1e18); }
+
+// convert between hertz (as a double) and attoseconds
+inline constexpr double ATTOSECONDS_TO_HZ(attoseconds_t x) { return double(ATTOSECONDS_PER_SECOND) / double(x); }
+
+#if defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) || __cplusplus >= 201103L
+template <typename T> inline constexpr attoseconds_t HZ_TO_ATTOSECONDS(T &&x) { return attoseconds_t(ATTOSECONDS_PER_SECOND / x); }
+
+// macros for converting other seconds types to attoseconds
+template <typename T> inline constexpr attoseconds_t ATTOSECONDS_IN_SEC(T &&x) { return attoseconds_t(x) * ATTOSECONDS_PER_SECOND; }
+template <typename T> inline constexpr attoseconds_t ATTOSECONDS_IN_MSEC(T &&x) { return attoseconds_t(x) * ATTOSECONDS_PER_MILLISECOND; }
+template <typename T> inline constexpr attoseconds_t ATTOSECONDS_IN_USEC(T &&x) { return attoseconds_t(x) * ATTOSECONDS_PER_MICROSECOND; }
+template <typename T> inline constexpr attoseconds_t ATTOSECONDS_IN_NSEC(T &&x) { return attoseconds_t(x) * ATTOSECONDS_PER_NANOSECOND; }
+#else
+template <typename T> inline constexpr attoseconds_t HZ_TO_ATTOSECONDS(const T &x) { return attoseconds_t(ATTOSECONDS_PER_SECOND / x); }
+
+// macros for converting other seconds types to attoseconds
+template <typename T> inline constexpr attoseconds_t ATTOSECONDS_IN_SEC(const T &x) { return attoseconds_t(x) * ATTOSECONDS_PER_SECOND; }
+template <typename T> inline constexpr attoseconds_t ATTOSECONDS_IN_MSEC(const T &x) { return attoseconds_t(x) * ATTOSECONDS_PER_MILLISECOND; }
+template <typename T> inline constexpr attoseconds_t ATTOSECONDS_IN_USEC(const T &x) { return attoseconds_t(x) * ATTOSECONDS_PER_MICROSECOND; }
+template <typename T> inline constexpr attoseconds_t ATTOSECONDS_IN_NSEC(const T &x) { return attoseconds_t(x) * ATTOSECONDS_PER_NANOSECOND; }
+#endif
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//***************************************************************************/
+
+// the attotime structure itself
+class attotime
+{
+public:
+	// construction/destruction
+	constexpr attotime() : m_seconds(0), m_attoseconds(0) { }
+
+	/** Constructs with @p secs seconds and @p attos attoseconds. */
+	constexpr attotime(seconds_t secs, attoseconds_t attos) : m_seconds(secs), m_attoseconds(attos) { }
+
+	constexpr attotime(const attotime& that) : m_seconds(that.m_seconds), m_attoseconds(that.m_attoseconds) { }
+
+	// assignment
+	attotime& operator=(const attotime& that)
+	{
+		this->m_seconds = that.m_seconds;
+		this->m_attoseconds = that.m_attoseconds;
+		return *this;
+	}
+
+	// queries
+	constexpr bool is_zero() const { return (m_seconds == 0 && m_attoseconds == 0); }
+	/** Test if value is above @ref ATTOTIME_MAX_SECONDS (considered an overflow) */
+	constexpr bool is_never() const { return (m_seconds >= ATTOTIME_MAX_SECONDS); }
+
+	// conversion to other forms
+	constexpr double as_double() const { return double(m_seconds) + ATTOSECONDS_TO_DOUBLE(m_attoseconds); }
+	constexpr attoseconds_t as_attoseconds() const;
+	u64 as_ticks(u32 frequency) const;
+	/** Convert to string using at @p precision */
+	const char *as_string(int precision = 9) const;
+
+	/** @return the attoseconds portion. */
+	constexpr attoseconds_t attoseconds() const { return m_attoseconds; }
+	/** @return the seconds portion. */
+	constexpr seconds_t seconds() const { return m_seconds; }
+
+	static attotime from_double(double _time);
+	static attotime from_ticks(u64 ticks, u32 frequency);
+	/** Create an attotime from a integer count of seconds @seconds */
+	static constexpr attotime from_seconds(s32 seconds) { return attotime(seconds, 0); }
+	/** Create an attotime from a integer count of milliseconds @msec */
+	static constexpr attotime from_msec(s64 msec) { return attotime(msec / 1000, (msec % 1000) * (ATTOSECONDS_PER_SECOND / 1000)); }
+	/** Create an attotime from a integer count of microseconds @usec */
+	static constexpr attotime from_usec(s64 usec) { return attotime(usec / 1000000, (usec % 1000000) * (ATTOSECONDS_PER_SECOND / 1000000)); }
+	/** Create an attotime from a integer count of nanoseconds @nsec */
+	static constexpr attotime from_nsec(s64 nsec) { return attotime(nsec / 1000000000, (nsec % 1000000000) * (ATTOSECONDS_PER_SECOND / 1000000000)); }
+	/** Create an attotime from at the given frequency @frequency */
+	static attotime from_hz(double frequency) { assert(frequency > 0); double d = 1 / frequency; return attotime(floor(d), modf(d, &d) * ATTOSECONDS_PER_SECOND); }
+
+	// math
+	attotime &operator+=(const attotime &right);
+	attotime &operator-=(const attotime &right);
+	attotime &operator*=(u32 factor);
+	attotime &operator/=(u32 factor);
+
+	// members
+	seconds_t       m_seconds;
+	attoseconds_t   m_attoseconds;
+
+	// constants
+	static const attotime never;
+	static const attotime zero;
+};
+/** @} */
+
+
+//**************************************************************************
+//  INLINE FUNCTIONS
+//**************************************************************************
+
+/** handle addition between two attotimes */
+inline attotime operator+(const attotime &left, const attotime &right)
+{
+	attotime result;
+
+	// if one of the items is never, return never
+	if (left.m_seconds >= ATTOTIME_MAX_SECONDS || right.m_seconds >= ATTOTIME_MAX_SECONDS)
+		return attotime::never;
+
+	// add the seconds and attoseconds
+	result.m_attoseconds = left.m_attoseconds + right.m_attoseconds;
+	result.m_seconds = left.m_seconds + right.m_seconds;
+
+	// normalize and return
+	if (result.m_attoseconds >= ATTOSECONDS_PER_SECOND)
+	{
+		result.m_attoseconds -= ATTOSECONDS_PER_SECOND;
+		result.m_seconds++;
+	}
+
+	// overflow
+	if (result.m_seconds >= ATTOTIME_MAX_SECONDS)
+		return attotime::never;
+	return result;
+}
+
+inline attotime &attotime::operator+=(const attotime &right)
+{
+	// if one of the items is never, return never
+	if (this->m_seconds >= ATTOTIME_MAX_SECONDS || right.m_seconds >= ATTOTIME_MAX_SECONDS)
+		return *this = never;
+
+	// add the seconds and attoseconds
+	m_attoseconds += right.m_attoseconds;
+	m_seconds += right.m_seconds;
+
+	// normalize and return
+	if (this->m_attoseconds >= ATTOSECONDS_PER_SECOND)
+	{
+		this->m_attoseconds -= ATTOSECONDS_PER_SECOND;
+		this->m_seconds++;
+	}
+
+	// overflow
+	if (this->m_seconds >= ATTOTIME_MAX_SECONDS)
+		return *this = never;
+	return *this;
+}
+
+
+/** handle subtraction between two attotimes */
+inline attotime operator-(const attotime &left, const attotime &right)
+{
+	attotime result;
+
+	// if time1 is never, return never
+	if (left.m_seconds >= ATTOTIME_MAX_SECONDS)
+		return attotime::never;
+
+	// add the seconds and attoseconds
+	result.m_attoseconds = left.m_attoseconds - right.m_attoseconds;
+	result.m_seconds = left.m_seconds - right.m_seconds;
+
+	// normalize and return
+	if (result.m_attoseconds < 0)
+	{
+		result.m_attoseconds += ATTOSECONDS_PER_SECOND;
+		result.m_seconds--;
+	}
+	return result;
+}
+
+inline attotime &attotime::operator-=(const attotime &right)
+{
+	// if time1 is never, return never
+	if (this->m_seconds >= ATTOTIME_MAX_SECONDS)
+		return *this = never;
+
+	// add the seconds and attoseconds
+	m_attoseconds -= right.m_attoseconds;
+	m_seconds -= right.m_seconds;
+
+	// normalize and return
+	if (this->m_attoseconds < 0)
+	{
+		this->m_attoseconds += ATTOSECONDS_PER_SECOND;
+		this->m_seconds--;
+	}
+	return *this;
+}
+
+
+/** handle multiplication by an integral factor; defined in terms of the assignment operators */
+inline attotime operator*(const attotime &left, u32 factor)
+{
+	attotime result = left;
+	result *= factor;
+	return result;
+}
+
+inline attotime operator*(u32 factor, const attotime &right)
+{
+	attotime result = right;
+	result *= factor;
+	return result;
+}
+
+/** handle division by an integral factor; defined in terms of the assignment operators */
+inline attotime operator/(const attotime &left, u32 factor)
+{
+	attotime result = left;
+	result /= factor;
+	return result;
+}
+
+
+/** handle comparisons between attotimes */
+inline constexpr bool operator==(const attotime &left, const attotime &right)
+{
+	return (left.m_seconds == right.m_seconds && left.m_attoseconds == right.m_attoseconds);
+}
+
+inline constexpr bool operator!=(const attotime &left, const attotime &right)
+{
+	return (left.m_seconds != right.m_seconds || left.m_attoseconds != right.m_attoseconds);
+}
+
+inline constexpr bool operator<(const attotime &left, const attotime &right)
+{
+	return (left.m_seconds < right.m_seconds || (left.m_seconds == right.m_seconds && left.m_attoseconds < right.m_attoseconds));
+}
+
+inline constexpr bool operator<=(const attotime &left, const attotime &right)
+{
+	return (left.m_seconds < right.m_seconds || (left.m_seconds == right.m_seconds && left.m_attoseconds <= right.m_attoseconds));
+}
+
+inline constexpr bool operator>(const attotime &left, const attotime &right)
+{
+	return (left.m_seconds > right.m_seconds || (left.m_seconds == right.m_seconds && left.m_attoseconds > right.m_attoseconds));
+}
+
+inline constexpr bool operator>=(const attotime &left, const attotime &right)
+{
+	return (left.m_seconds > right.m_seconds || (left.m_seconds == right.m_seconds && left.m_attoseconds >= right.m_attoseconds));
+}
+
+
+/** Convert to an attoseconds value, clamping to +/- 1 second */
+inline constexpr attoseconds_t attotime::as_attoseconds() const
+{
+	return
+			(m_seconds == 0) ? m_attoseconds :                              // positive values between 0 and 1 second
+			(m_seconds == -1) ? (m_attoseconds - ATTOSECONDS_PER_SECOND) :  // negative values between -1 and 0 seconds
+			(m_seconds > 0) ? ATTOSECONDS_PER_SECOND :                      // out-of-range positive values
+			-ATTOSECONDS_PER_SECOND;                                        // out-of-range negative values
+}
+
+
+/** as_ticks - convert to ticks at @p frequency */
+inline u64 attotime::as_ticks(u32 frequency) const
+{
+	u32 fracticks = (attotime(0, m_attoseconds) * frequency).m_seconds;
+	return mulu_32x32(m_seconds, frequency) + fracticks;
+}
+
+
+/** Create an attotime from a tick count @ticks at the given frequency @frequency  */
+inline attotime attotime::from_ticks(u64 ticks, u32 frequency)
+{
+	attoseconds_t attos_per_tick = HZ_TO_ATTOSECONDS(frequency);
+
+	if (ticks < frequency)
+		return attotime(0, ticks * attos_per_tick);
+
+	u32 remainder;
+	s32 secs = divu_64x32_rem(ticks, frequency, &remainder);
+	return attotime(secs, u64(remainder) * attos_per_tick);
+}
+
+/** Create an attotime from floating point count of seconds @p _time */
+inline attotime attotime::from_double(double _time)
+{
+	seconds_t secs = floor(_time);
+	_time -= double(secs);
+	attoseconds_t attos = DOUBLE_TO_ATTOSECONDS(_time);
+	return attotime(secs, attos);
+}
+
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+#undef constexpr
+#endif
+
+#endif  // MAME_EMU_ATTOTIME_H

--- a/audio/softsynth/opl/mame/fake-device.h
+++ b/audio/softsynth/opl/mame/fake-device.h
@@ -19,49 +19,25 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#ifndef AUDIO_SOFTSYNTH_OPL_MAME_H
-#define AUDIO_SOFTSYNTH_OPL_MAME_H
+#ifndef AUDIO_SOFTSYNTH_OPL_MAME_FAKE_DEVICE_H
+#define AUDIO_SOFTSYNTH_OPL_MAME_FAKE_DEVICE_H
 
-#include "common/scummsys.h"
+#include "common/textconsole.h"
+#include "common/str.h"
 
-#include "audio/fmopl.h"
-#include "audio/softsynth/opl/mame/fake-device.h"
+struct device_t {
+	void *state;
+	device_t() : state(nullptr) {}
+	void logerror(const char *s, ...) {
+		Common::String output;
+		va_list va;
 
-namespace OPL {
-namespace MAME {
+		va_start(va, s);
+		output = Common::String::vformat(s, va);
+		va_end(va);
 
-template <Config::OplType TYPE>
-class OPL : public ::OPL::EmulatedOPL {
-public:
-	OPL() : _opl(nullptr), _opl2(nullptr) {}
-	~OPL();
-
-	bool init();
-	void reset();
-
-	void write(int port, int value);
-	byte read(int port);
-
-	void writeReg(int reg, int value);
-
-	bool isStereo() const { return TYPE != Config::kOpl2; }
-
-protected:
-	void generateSamples(int16 *buffer, int length);
-
-private:
-	void *_opl, *_opl2;
-	device_t _device, _device2;
-	int _lastReg, _lastReg2;
-
-	void shutdown();
-
-	bool isAddressPort(const int port) const {
-		return (port & 1) == 0;
+		warning("%s", output.c_str());
 	}
 };
 
-} // End of namespace MAME
-} // End of namespace OPL
-
-#endif
+#endif // AUDIO_SOFTSYNTH_OPL_MAME_FAKE_DEVICE_H

--- a/audio/softsynth/opl/mame/fake-emu.h
+++ b/audio/softsynth/opl/mame/fake-emu.h
@@ -1,0 +1,74 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef AUDIO_SOFTSYNTH_OPL_MAME_FAKE_EMU_H
+#define AUDIO_SOFTSYNTH_OPL_MAME_FAKE_EMU_H
+
+#include <stdint.h>
+
+// emu/emucore.h
+#include <assert.h>
+
+#define NAME(x) x, #x
+
+#if __cplusplus < 201103L
+#define constexpr
+#endif
+
+template <typename T, typename U> constexpr T BIT(T x, U n) { return (x >> n) & T(1); }
+
+#if __cplusplus < 201103L
+#undef constexpr
+#endif
+
+// In MAME this is actually 32-bits, but FMOPL generates 16-bit samples anyway
+typedef int16_t stream_sample_t;
+
+// emu/eminline.h
+inline int64_t mul_32x32(int32_t a, int32_t b) {
+	return int64_t(a) * int64_t(b);
+}
+
+inline uint64_t mulu_32x32(uint32_t a, uint32_t b) {
+	return uint64_t(a) * uint64_t(b);
+}
+
+inline uint32_t divu_64x32(uint64_t a, uint32_t b) {
+	return a / uint64_t(b);
+}
+
+inline uint32_t divu_64x32_rem(uint64_t a, uint32_t b, uint32_t *remainder) {
+	uint32_t const res = divu_64x32(a, b);
+	*remainder = a - (uint64_t(b) * res);
+	return res;
+}
+
+// osd/osdcomm.h
+typedef int32_t s32;
+typedef uint32_t u32;
+typedef int64_t s64;
+typedef uint64_t u64;
+
+#include "emu/attotime.h"
+
+#include "fake-device.h"
+
+#endif // AUDIO_SOFTSYNTH_OPL_MAME_EMU_H

--- a/audio/softsynth/opl/mame/fmopl.h
+++ b/audio/softsynth/opl/mame/fmopl.h
@@ -1,0 +1,105 @@
+// license:GPL-2.0+
+// copyright-holders:Jarek Burczynski,Tatsuyuki Satoh
+#ifndef AUDIO_SOFTSYNTH_OPL_MAME_SOUND_FMOPL_H
+#define AUDIO_SOFTSYNTH_OPL_MAME_SOUND_FMOPL_H
+
+#include "audio/softsynth/opl/mame/emu.h"
+
+/* --- select emulation chips --- */
+#define BUILD_YM3812 (1)
+
+/* select output bits size of output : 8 or 16 */
+#define OPL_SAMPLE_BITS 16
+
+typedef stream_sample_t OPLSAMPLE;
+/*
+#if (OPL_SAMPLE_BITS==16)
+typedef int16_t OPLSAMPLE;
+#endif
+#if (OPL_SAMPLE_BITS==8)
+typedef int8_t OPLSAMPLE;
+#endif
+*/
+
+typedef void (*OPL_TIMERHANDLER)(device_t *device,int timer,const attotime &period);
+typedef void (*OPL_IRQHANDLER)(device_t *device,int irq);
+typedef void (*OPL_UPDATEHANDLER)(device_t *device,int min_interval_us);
+typedef void (*OPL_PORTHANDLER_W)(device_t *device,unsigned char data);
+typedef unsigned char (*OPL_PORTHANDLER_R)(device_t *device);
+
+
+#if BUILD_YM3812
+
+void *ym3812_init(device_t *device, uint32_t clock, uint32_t rate);
+void ym3812_clock_changed(void *chip, uint32_t clock, uint32_t rate);
+void ym3812_shutdown(void *chip);
+void ym3812_reset_chip(void *chip);
+int  ym3812_write(void *chip, int a, int v);
+unsigned char ym3812_read(void *chip, int a);
+int  ym3812_timer_over(void *chip, int c);
+void ym3812_update_one(void *chip, OPLSAMPLE *buffer, int length);
+
+void ym3812_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, device_t *device);
+void ym3812_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, device_t *device);
+void ym3812_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, device_t *device);
+
+#endif /* BUILD_YM3812 */
+
+
+#if BUILD_YM3526
+
+/*
+** Initialize YM3526 emulator(s).
+**
+** 'num' is the number of virtual YM3526's to allocate
+** 'clock' is the chip clock in Hz
+** 'rate' is sampling rate
+*/
+void *ym3526_init(device_t *device, uint32_t clock, uint32_t rate);
+void ym3526_clock_changed(void *chip, uint32_t clock, uint32_t rate);
+/* shutdown the YM3526 emulators*/
+void ym3526_shutdown(void *chip);
+void ym3526_reset_chip(void *chip);
+int  ym3526_write(void *chip, int a, int v);
+unsigned char ym3526_read(void *chip, int a);
+int  ym3526_timer_over(void *chip, int c);
+/*
+** Generate samples for one of the YM3526's
+**
+** 'which' is the virtual YM3526 number
+** '*buffer' is the output buffer pointer
+** 'length' is the number of samples that should be generated
+*/
+void ym3526_update_one(void *chip, OPLSAMPLE *buffer, int length);
+
+void ym3526_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, device_t *device);
+void ym3526_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, device_t *device);
+void ym3526_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, device_t *device);
+
+#endif /* BUILD_YM3526 */
+
+
+#if BUILD_Y8950
+
+/* Y8950 port handlers */
+void y8950_set_port_handler(void *chip, OPL_PORTHANDLER_W PortHandler_w, OPL_PORTHANDLER_R PortHandler_r, device_t *device);
+void y8950_set_keyboard_handler(void *chip, OPL_PORTHANDLER_W KeyboardHandler_w, OPL_PORTHANDLER_R KeyboardHandler_r, device_t *device);
+void y8950_set_delta_t_memory(void *chip, void * deltat_mem_ptr, int deltat_mem_size );
+
+void * y8950_init(device_t *device, uint32_t clock, uint32_t rate);
+void y8950_shutdown(void *chip);
+void y8950_reset_chip(void *chip);
+int  y8950_write(void *chip, int a, int v);
+unsigned char y8950_read (void *chip, int a);
+int  y8950_timer_over(void *chip, int c);
+void y8950_update_one(void *chip, OPLSAMPLE *buffer, int length);
+
+void y8950_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, device_t *device);
+void y8950_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, device_t *device);
+void y8950_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, device_t *device);
+
+#endif /* BUILD_Y8950 */
+
+
+#endif // AUDIO_SOFTSYNTH_OPL_MAME_SOUND_FMOPL_H
+

--- a/audio/softsynth/opl/mame/sound/fmopl.cpp
+++ b/audio/softsynth/opl/mame/sound/fmopl.cpp
@@ -1,0 +1,2642 @@
+// license:GPL-2.0+
+// copyright-holders:Jarek Burczynski,Tatsuyuki Satoh
+/*
+**
+** File: fmopl.c - software implementation of FM sound generator
+**                                            types OPL and OPL2
+**
+** Copyright Jarek Burczynski (bujar at mame dot net)
+** Copyright Tatsuyuki Satoh , MultiArcadeMachineEmulator development
+**
+** Version 0.72
+**
+
+Revision History:
+
+04-08-2003 Jarek Burczynski:
+ - removed BFRDY hack. BFRDY is busy flag, and it should be 0 only when the chip
+   handles memory read/write or during the adpcm synthesis when the chip
+   requests another byte of ADPCM data.
+
+24-07-2003 Jarek Burczynski:
+ - added a small hack for Y8950 status BFRDY flag (bit 3 should be set after
+   some (unknown) delay). Right now it's always set.
+
+14-06-2003 Jarek Burczynski:
+ - implemented all of the status register flags in Y8950 emulation
+ - renamed y8950_set_delta_t_memory() parameters from _rom_ to _mem_ since
+   they can be either RAM or ROM
+
+08-10-2002 Jarek Burczynski (thanks to Dox for the YM3526 chip)
+ - corrected ym3526_read() to always set bit 2 and bit 1
+   to HIGH state - identical to ym3812_read (verified on real YM3526)
+
+04-28-2002 Jarek Burczynski:
+ - binary exact Envelope Generator (verified on real YM3812);
+   compared to YM2151: the EG clock is equal to internal_clock,
+   rates are 2 times slower and volume resolution is one bit less
+ - modified interface functions (they no longer return pointer -
+   that's internal to the emulator now):
+    - new wrapper functions for OPLCreate: ym3526_init(), ym3812_init() and y8950_init()
+ - corrected 'off by one' error in feedback calculations (when feedback is off)
+ - enabled waveform usage (credit goes to Vlad Romascanu and zazzal22)
+ - speeded up noise generator calculations (Nicola Salmoria)
+
+03-24-2002 Jarek Burczynski (thanks to Dox for the YM3812 chip)
+ Complete rewrite (all verified on real YM3812):
+ - corrected sin_tab and tl_tab data
+ - corrected operator output calculations
+ - corrected waveform_select_enable register;
+   simply: ignore all writes to waveform_select register when
+   waveform_select_enable == 0 and do not change the waveform previously selected.
+ - corrected KSR handling
+ - corrected Envelope Generator: attack shape, Sustain mode and
+   Percussive/Non-percussive modes handling
+ - Envelope Generator rates are two times slower now
+ - LFO amplitude (tremolo) and phase modulation (vibrato)
+ - rhythm sounds phase generation
+ - white noise generator (big thanks to Olivier Galibert for mentioning Berlekamp-Massey algorithm)
+ - corrected key on/off handling (the 'key' signal is ORed from three sources: FM, rhythm and CSM)
+ - funky details (like ignoring output of operator 1 in BD rhythm sound when connect == 1)
+
+12-28-2001 Acho A. Tang
+ - reflected Delta-T EOS status on Y8950 status port.
+ - fixed subscription range of attack/decay tables
+
+
+    To do:
+        add delay before key off in CSM mode (see CSMKeyControll)
+        verify volume of the FM part on the Y8950
+*/
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+#include "emu.h"
+#else
+#include "../fake-emu.h"
+#include "common/textconsole.h"
+#endif
+#include "ymdeltat.h"
+#include "fmopl.h"
+
+
+
+/* output final shift */
+#if (OPL_SAMPLE_BITS==16)
+	#define FINAL_SH    (0)
+	#define MAXOUT      (+32767)
+	#define MINOUT      (-32768)
+#else
+	#define FINAL_SH    (8)
+	#define MAXOUT      (+127)
+	#define MINOUT      (-128)
+#endif
+
+
+#define FREQ_SH         16  /* 16.16 fixed point (frequency calculations) */
+#define EG_SH           16  /* 16.16 fixed point (EG timing)              */
+#define LFO_SH          24  /*  8.24 fixed point (LFO calculations)       */
+#define TIMER_SH        16  /* 16.16 fixed point (timers calculations)    */
+
+#define FREQ_MASK       ((1<<FREQ_SH)-1)
+
+/* envelope output entries */
+#define ENV_BITS        10
+#define ENV_LEN         (1<<ENV_BITS)
+#define ENV_STEP        (128.0/ENV_LEN)
+
+#define MAX_ATT_INDEX   ((1<<(ENV_BITS-1))-1) /*511*/
+#define MIN_ATT_INDEX   (0)
+
+/* sinwave entries */
+#define SIN_BITS        10
+#define SIN_LEN         (1<<SIN_BITS)
+#define SIN_MASK        (SIN_LEN-1)
+
+#define TL_RES_LEN      (256)   /* 8 bits addressing (real chip) */
+
+
+
+/* register number to channel number , slot offset */
+#define SLOT1 0
+#define SLOT2 1
+
+/* Envelope Generator phases */
+
+#define EG_ATT          4
+#define EG_DEC          3
+#define EG_SUS          2
+#define EG_REL          1
+#define EG_OFF          0
+
+
+/* save output as raw 16-bit sample */
+
+/*#define SAVE_SAMPLE*/
+
+#ifdef SAVE_SAMPLE
+static inline signed int acc_calc(signed int value)
+{
+	if (value>=0)
+	{
+		if (value < 0x0200)
+			return (value & ~0);
+		if (value < 0x0400)
+			return (value & ~1);
+		if (value < 0x0800)
+			return (value & ~3);
+		if (value < 0x1000)
+			return (value & ~7);
+		if (value < 0x2000)
+			return (value & ~15);
+		if (value < 0x4000)
+			return (value & ~31);
+		return (value & ~63);
+	}
+	/*else value < 0*/
+	if (value > -0x0200)
+		return (~abs(value) & ~0);
+	if (value > -0x0400)
+		return (~abs(value) & ~1);
+	if (value > -0x0800)
+		return (~abs(value) & ~3);
+	if (value > -0x1000)
+		return (~abs(value) & ~7);
+	if (value > -0x2000)
+		return (~abs(value) & ~15);
+	if (value > -0x4000)
+		return (~abs(value) & ~31);
+	return (~abs(value) & ~63);
+}
+
+
+static FILE *sample[1];
+	#if 1   /*save to MONO file */
+		#define SAVE_ALL_CHANNELS \
+		{   signed int pom = acc_calc(lt); \
+			fputc((unsigned short)pom&0xff,sample[0]); \
+			fputc(((unsigned short)pom>>8)&0xff,sample[0]); \
+		}
+	#else   /*save to STEREO file */
+		#define SAVE_ALL_CHANNELS \
+		{   signed int pom = lt; \
+			fputc((unsigned short)pom&0xff,sample[0]); \
+			fputc(((unsigned short)pom>>8)&0xff,sample[0]); \
+			pom = rt; \
+			fputc((unsigned short)pom&0xff,sample[0]); \
+			fputc(((unsigned short)pom>>8)&0xff,sample[0]); \
+		}
+	#endif
+#endif
+
+#define OPL_TYPE_WAVESEL   0x01  /* waveform select     */
+#define OPL_TYPE_ADPCM     0x02  /* DELTA-T ADPCM unit  */
+#define OPL_TYPE_KEYBOARD  0x04  /* keyboard interface  */
+#define OPL_TYPE_IO        0x08  /* I/O port            */
+
+/* ---------- Generic interface section ---------- */
+#define OPL_TYPE_YM3526 (0)
+#define OPL_TYPE_YM3812 (OPL_TYPE_WAVESEL)
+#define OPL_TYPE_Y8950  (OPL_TYPE_ADPCM|OPL_TYPE_KEYBOARD|OPL_TYPE_IO)
+
+
+namespace {
+
+// TODO: make these static members
+
+#define RATE_STEPS (8)
+extern const unsigned char eg_rate_shift[16+64+16];
+extern const unsigned char eg_rate_select[16+64+16];
+
+
+struct OPL_SLOT
+{
+	uint32_t  ar;         /* attack rate: AR<<2           */
+	uint32_t  dr;         /* decay rate:  DR<<2           */
+	uint32_t  rr;         /* release rate:RR<<2           */
+	uint8_t   KSR;        /* key scale rate               */
+	uint8_t   ksl;        /* keyscale level               */
+	uint8_t   ksr;        /* key scale rate: kcode>>KSR   */
+	uint8_t   mul;        /* multiple: mul_tab[ML]        */
+
+	/* Phase Generator */
+	uint32_t  Cnt;        /* frequency counter            */
+	uint32_t  Incr;       /* frequency counter step       */
+	uint8_t   FB;         /* feedback shift value         */
+	int32_t   *connect1;  /* slot1 output pointer         */
+	int32_t   op1_out[2]; /* slot1 output for feedback    */
+	uint8_t   CON;        /* connection (algorithm) type  */
+
+	/* Envelope Generator */
+	uint8_t   eg_type;    /* percussive/non-percussive mode */
+	uint8_t   state;      /* phase type                   */
+	uint32_t  TL;         /* total level: TL << 2         */
+	int32_t   TLL;        /* adjusted now TL              */
+	int32_t   volume;     /* envelope counter             */
+	uint32_t  sl;         /* sustain level: sl_tab[SL]    */
+	uint8_t   eg_sh_ar;   /* (attack state)               */
+	uint8_t   eg_sel_ar;  /* (attack state)               */
+	uint8_t   eg_sh_dr;   /* (decay state)                */
+	uint8_t   eg_sel_dr;  /* (decay state)                */
+	uint8_t   eg_sh_rr;   /* (release state)              */
+	uint8_t   eg_sel_rr;  /* (release state)              */
+	uint32_t  key;        /* 0 = KEY OFF, >0 = KEY ON     */
+
+	/* LFO */
+	uint32_t  AMmask;     /* LFO Amplitude Modulation enable mask */
+	uint8_t   vib;        /* LFO Phase Modulation enable flag (active high)*/
+
+	/* waveform select */
+	uint16_t  wavetable;
+
+	void KEYON(uint32_t key_set)
+	{
+		if( !key )
+		{
+			/* restart Phase Generator */
+			Cnt = 0;
+			/* phase -> Attack */
+			state = EG_ATT;
+		}
+		key |= key_set;
+	}
+
+	void KEYOFF(uint32_t key_clr)
+	{
+		if( key )
+		{
+			key &= key_clr;
+
+			if( !key )
+			{
+				/* phase -> Release */
+				if (state>EG_REL)
+					state = EG_REL;
+			}
+		}
+	}
+};
+
+struct OPL_CH
+{
+	OPL_SLOT SLOT[2];
+	/* phase generator state */
+	uint32_t  block_fnum; /* block+fnum                   */
+	uint32_t  fc;         /* Freq. Increment base         */
+	uint32_t  ksl_base;   /* KeyScaleLevel Base step      */
+	uint8_t   kcode;      /* key code (for key scaling)   */
+
+#ifndef SCUMMVM_USE_ORIGINAL_MAME_CODE
+// shadow warning
+#define SLOT FCSLOT
+#endif
+
+	/* update phase increment counter of operator (also update the EG rates if necessary) */
+	void CALC_FCSLOT(OPL_SLOT &SLOT)
+	{
+		/* (frequency) phase increment counter */
+		SLOT.Incr = fc * SLOT.mul;
+		int const ksr = kcode >> SLOT.KSR;
+
+		if( SLOT.ksr != ksr )
+		{
+			SLOT.ksr = ksr;
+
+			/* calculate envelope generator rates */
+			if ((SLOT.ar + SLOT.ksr) < 16+62)
+			{
+				SLOT.eg_sh_ar  = eg_rate_shift [SLOT.ar + SLOT.ksr ];
+				SLOT.eg_sel_ar = eg_rate_select[SLOT.ar + SLOT.ksr ];
+			}
+			else
+			{
+				SLOT.eg_sh_ar  = 0;
+				SLOT.eg_sel_ar = 13*RATE_STEPS;
+			}
+			SLOT.eg_sh_dr  = eg_rate_shift [SLOT.dr + SLOT.ksr ];
+			SLOT.eg_sel_dr = eg_rate_select[SLOT.dr + SLOT.ksr ];
+			SLOT.eg_sh_rr  = eg_rate_shift [SLOT.rr + SLOT.ksr ];
+			SLOT.eg_sel_rr = eg_rate_select[SLOT.rr + SLOT.ksr ];
+		}
+	}
+#ifndef SCUMMVM_USE_ORIGINAL_MAME_CODE
+#undef SLOT
+#endif
+};
+
+/* OPL state */
+struct FM_OPL
+{
+	/* FM channel slots */
+	OPL_CH  P_CH[9];                /* OPL/OPL2 chips have 9 channels*/
+
+	uint32_t  eg_cnt;                 /* global envelope generator counter    */
+	uint32_t  eg_timer;               /* global envelope generator counter works at frequency = chipclock/72 */
+	uint32_t  eg_timer_add;           /* step of eg_timer                     */
+	uint32_t  eg_timer_overflow;      /* envelope generator timer overflows every 1 sample (on real chip) */
+
+	uint8_t   rhythm;                 /* Rhythm mode                  */
+
+	uint32_t  fn_tab[1024];           /* fnumber->increment counter   */
+
+	/* LFO */
+	uint32_t  LFO_AM;
+	int32_t   LFO_PM;
+
+	uint8_t   lfo_am_depth;
+	uint8_t   lfo_pm_depth_range;
+	uint32_t  lfo_am_cnt;
+	uint32_t  lfo_am_inc;
+	uint32_t  lfo_pm_cnt;
+	uint32_t  lfo_pm_inc;
+
+	uint32_t  noise_rng;              /* 23 bit noise shift register  */
+	uint32_t  noise_p;                /* current noise 'phase'        */
+	uint32_t  noise_f;                /* current noise period         */
+
+	uint8_t   wavesel;                /* waveform select enable flag  */
+
+	uint32_t  T[2];                   /* timer counters               */
+	uint8_t   st[2];                  /* timer enable                 */
+
+#if BUILD_Y8950
+	/* Delta-T ADPCM unit (Y8950) */
+
+	YM_DELTAT *deltat;
+
+	/* Keyboard and I/O ports interface */
+	uint8_t   portDirection;
+	uint8_t   portLatch;
+	OPL_PORTHANDLER_R porthandler_r;
+	OPL_PORTHANDLER_W porthandler_w;
+	device_t *  port_param;
+	OPL_PORTHANDLER_R keyboardhandler_r;
+	OPL_PORTHANDLER_W keyboardhandler_w;
+	device_t *  keyboard_param;
+#endif
+
+	/* external event callback handlers */
+	OPL_TIMERHANDLER  timer_handler;    /* TIMER handler                */
+	device_t *TimerParam;                   /* TIMER parameter              */
+	OPL_IRQHANDLER    IRQHandler;   /* IRQ handler                  */
+	device_t *IRQParam;                 /* IRQ parameter                */
+	OPL_UPDATEHANDLER UpdateHandler;/* stream update handler        */
+	device_t *UpdateParam;              /* stream update parameter      */
+
+	uint8_t type;                     /* chip type                    */
+	uint8_t address;                  /* address register             */
+	uint8_t status;                   /* status flag                  */
+	uint8_t statusmask;               /* status mask                  */
+	uint8_t mode;                     /* Reg.08 : CSM,notesel,etc.    */
+
+	uint32_t clock;                   /* master clock  (Hz)           */
+	uint32_t rate;                    /* sampling rate (Hz)           */
+	double freqbase;                /* frequency base               */
+	attotime TimerBase;         /* Timer base time (==sampling time)*/
+	device_t *device;
+
+	signed int phase_modulation;    /* phase modulation input (SLOT 2) */
+	signed int output[1];
+#if BUILD_Y8950
+	int32_t output_deltat[4];     /* for Y8950 DELTA-T, chip is mono, that 4 here is just for safety */
+#endif
+
+
+	/* status set and IRQ handling */
+	void STATUS_SET(int flag)
+	{
+		/* set status flag */
+		status |= flag;
+		if(!(status & 0x80))
+		{
+			if(status & statusmask)
+			{   /* IRQ on */
+				status |= 0x80;
+				/* callback user interrupt handler (IRQ is OFF to ON) */
+				if(IRQHandler) (IRQHandler)(IRQParam,1);
+			}
+		}
+	}
+
+	/* status reset and IRQ handling */
+	void STATUS_RESET(int flag)
+	{
+		/* reset status flag */
+		status &=~flag;
+		if(status & 0x80)
+		{
+			if (!(status & statusmask) )
+			{
+				status &= 0x7f;
+				/* callback user interrupt handler (IRQ is ON to OFF) */
+				if(IRQHandler) (IRQHandler)(IRQParam,0);
+			}
+		}
+	}
+
+	/* IRQ mask set */
+	void STATUSMASK_SET(int flag)
+	{
+		statusmask = flag;
+		/* IRQ handling check */
+		STATUS_SET(0);
+		STATUS_RESET(0);
+	}
+
+
+	/* advance LFO to next sample */
+	void advance_lfo()
+	{
+		/* LFO */
+		lfo_am_cnt += lfo_am_inc;
+		if (lfo_am_cnt >= (uint32_t(LFO_AM_TAB_ELEMENTS) << LFO_SH))  /* lfo_am_table is 210 elements long */
+			lfo_am_cnt -= (uint32_t(LFO_AM_TAB_ELEMENTS) << LFO_SH);
+
+		uint8_t const tmp = lfo_am_table[ lfo_am_cnt >> LFO_SH ];
+
+		LFO_AM = lfo_am_depth ? tmp : tmp >> 2;
+
+		lfo_pm_cnt += lfo_pm_inc;
+		LFO_PM = (lfo_pm_cnt>>LFO_SH & 7) | lfo_pm_depth_range;
+	}
+
+	/* advance to next sample */
+	void advance()
+	{
+		eg_timer += eg_timer_add;
+
+		while (eg_timer >= eg_timer_overflow)
+		{
+			eg_timer -= eg_timer_overflow;
+
+			eg_cnt++;
+
+			for (int i=0; i<9*2; i++)
+			{
+				OPL_CH   &CH  = P_CH[i/2];
+				OPL_SLOT &op  = CH.SLOT[i&1];
+
+				/* Envelope Generator */
+				switch(op.state)
+				{
+				case EG_ATT:        /* attack phase */
+					if ( !(eg_cnt & ((1<<op.eg_sh_ar)-1) ) )
+					{
+						op.volume += (~op.volume *
+													(eg_inc[op.eg_sel_ar + ((eg_cnt>>op.eg_sh_ar)&7)])
+													) >>3;
+
+						if (op.volume <= MIN_ATT_INDEX)
+						{
+							op.volume = MIN_ATT_INDEX;
+							op.state = EG_DEC;
+						}
+
+					}
+					break;
+
+				case EG_DEC:    /* decay phase */
+					if ( !(eg_cnt & ((1<<op.eg_sh_dr)-1) ) )
+					{
+						op.volume += eg_inc[op.eg_sel_dr + ((eg_cnt>>op.eg_sh_dr)&7)];
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+						if ( op.volume >= op.sl )
+#else
+						if ( op.volume >= int32_t(op.sl) )
+#endif
+							op.state = EG_SUS;
+
+					}
+					break;
+
+				case EG_SUS:    /* sustain phase */
+
+					/* this is important behaviour:
+					one can change percusive/non-percussive modes on the fly and
+					the chip will remain in sustain phase - verified on real YM3812 */
+
+					if(op.eg_type)     /* non-percussive mode */
+					{
+										/* do nothing */
+					}
+					else                /* percussive mode */
+					{
+						/* during sustain phase chip adds Release Rate (in percussive mode) */
+						if ( !(eg_cnt & ((1<<op.eg_sh_rr)-1) ) )
+						{
+							op.volume += eg_inc[op.eg_sel_rr + ((eg_cnt>>op.eg_sh_rr)&7)];
+
+							if ( op.volume >= MAX_ATT_INDEX )
+								op.volume = MAX_ATT_INDEX;
+						}
+						/* else do nothing in sustain phase */
+					}
+					break;
+
+				case EG_REL:    /* release phase */
+					if ( !(eg_cnt & ((1<<op.eg_sh_rr)-1) ) )
+					{
+						op.volume += eg_inc[op.eg_sel_rr + ((eg_cnt>>op.eg_sh_rr)&7)];
+
+						if ( op.volume >= MAX_ATT_INDEX )
+						{
+							op.volume = MAX_ATT_INDEX;
+							op.state = EG_OFF;
+						}
+
+					}
+					break;
+
+				default:
+					break;
+				}
+			}
+		}
+
+		for (int i=0; i<9*2; i++)
+		{
+			OPL_CH   &CH  = P_CH[i/2];
+			OPL_SLOT &op  = CH.SLOT[i&1];
+
+			/* Phase Generator */
+			if(op.vib)
+			{
+				unsigned int block_fnum                    = CH.block_fnum;
+				unsigned int const fnum_lfo                = (block_fnum&0x0380) >> 7;
+
+				signed int const lfo_fn_table_index_offset = lfo_pm_table[LFO_PM + 16*fnum_lfo ];
+
+				if (lfo_fn_table_index_offset)  /* LFO phase modulation active */
+				{
+					block_fnum += lfo_fn_table_index_offset;
+					uint8_t const block = (block_fnum&0x1c00) >> 10;
+					op.Cnt += (fn_tab[block_fnum&0x03ff] >> (7-block)) * op.mul;
+				}
+				else    /* LFO phase modulation  = zero */
+				{
+					op.Cnt += op.Incr;
+				}
+			}
+			else    /* LFO phase modulation disabled for this operator */
+			{
+				op.Cnt += op.Incr;
+			}
+		}
+
+		/*  The Noise Generator of the YM3812 is 23-bit shift register.
+		*   Period is equal to 2^23-2 samples.
+		*   Register works at sampling frequency of the chip, so output
+		*   can change on every sample.
+		*
+		*   Output of the register and input to the bit 22 is:
+		*   bit0 XOR bit14 XOR bit15 XOR bit22
+		*
+		*   Simply use bit 22 as the noise output.
+		*/
+
+		noise_p += noise_f;
+		int i = noise_p >> FREQ_SH;        /* number of events (shifts of the shift register) */
+		noise_p &= FREQ_MASK;
+		while (i)
+		{
+			/*
+			uint32_t j;
+			j = ( (noise_rng) ^ (noise_rng>>14) ^ (noise_rng>>15) ^ (noise_rng>>22) ) & 1;
+			noise_rng = (j<<22) | (noise_rng>>1);
+			*/
+
+			/*
+			    Instead of doing all the logic operations above, we
+			    use a trick here (and use bit 0 as the noise output).
+			    The difference is only that the noise bit changes one
+			    step ahead. This doesn't matter since we don't know
+			    what is real state of the noise_rng after the reset.
+			*/
+
+			if (noise_rng & 1) noise_rng ^= 0x800302;
+			noise_rng >>= 1;
+
+			i--;
+		}
+	}
+
+	/* calculate output */
+	void CALC_CH(OPL_CH &CH)
+	{
+		OPL_SLOT *SLOT;
+		unsigned int env;
+		signed int out;
+
+		phase_modulation = 0;
+
+		/* SLOT 1 */
+		SLOT = &CH.SLOT[SLOT1];
+		env  = volume_calc(*SLOT);
+		out  = SLOT->op1_out[0] + SLOT->op1_out[1];
+		SLOT->op1_out[0] = SLOT->op1_out[1];
+		*SLOT->connect1 += SLOT->op1_out[0];
+		SLOT->op1_out[1] = 0;
+		if( env < ENV_QUIET )
+		{
+			if (!SLOT->FB)
+				out = 0;
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+			SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out<<SLOT->FB), SLOT->wavetable );
+#else
+			SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out*(1<<SLOT->FB)), SLOT->wavetable );
+#endif
+		}
+
+		/* SLOT 2 */
+		SLOT++;
+		env = volume_calc(*SLOT);
+		if( env < ENV_QUIET )
+			output[0] += op_calc(SLOT->Cnt, env, phase_modulation, SLOT->wavetable);
+	}
+
+	/*
+	    operators used in the rhythm sounds generation process:
+
+	    Envelope Generator:
+
+	channel  operator  register number   Bass  High  Snare Tom  Top
+	/ slot   number    TL ARDR SLRR Wave Drum  Hat   Drum  Tom  Cymbal
+	 6 / 0   12        50  70   90   f0  +
+	 6 / 1   15        53  73   93   f3  +
+	 7 / 0   13        51  71   91   f1        +
+	 7 / 1   16        54  74   94   f4              +
+	 8 / 0   14        52  72   92   f2                    +
+	 8 / 1   17        55  75   95   f5                          +
+
+	    Phase Generator:
+
+	channel  operator  register number   Bass  High  Snare Tom  Top
+	/ slot   number    MULTIPLE          Drum  Hat   Drum  Tom  Cymbal
+	 6 / 0   12        30                +
+	 6 / 1   15        33                +
+	 7 / 0   13        31                      +     +           +
+	 7 / 1   16        34                -----  n o t  u s e d -----
+	 8 / 0   14        32                                  +
+	 8 / 1   17        35                      +                 +
+
+	channel  operator  register number   Bass  High  Snare Tom  Top
+	number   number    BLK/FNUM2 FNUM    Drum  Hat   Drum  Tom  Cymbal
+	   6     12,15     B6        A6      +
+
+	   7     13,16     B7        A7            +     +           +
+
+	   8     14,17     B8        A8            +           +     +
+
+	*/
+
+	/* calculate rhythm */
+
+	void CALC_RH()
+	{
+		unsigned int const noise = BIT(noise_rng, 0);
+
+		OPL_SLOT *SLOT;
+		signed int out;
+		unsigned int env;
+
+
+		/* Bass Drum (verified on real YM3812):
+		  - depends on the channel 6 'connect' register:
+		      when connect = 0 it works the same as in normal (non-rhythm) mode (op1->op2->out)
+		      when connect = 1 _only_ operator 2 is present on output (op2->out), operator 1 is ignored
+		  - output sample always is multiplied by 2
+		*/
+
+		phase_modulation = 0;
+		/* SLOT 1 */
+		SLOT = &P_CH[6].SLOT[SLOT1];
+		env = volume_calc(*SLOT);
+
+		out = SLOT->op1_out[0] + SLOT->op1_out[1];
+		SLOT->op1_out[0] = SLOT->op1_out[1];
+
+		if (!SLOT->CON)
+			phase_modulation = SLOT->op1_out[0];
+		/* else ignore output of operator 1 */
+
+		SLOT->op1_out[1] = 0;
+		if( env < ENV_QUIET )
+		{
+			if (!SLOT->FB)
+				out = 0;
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+			SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out<<SLOT->FB), SLOT->wavetable );
+#else
+			SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out*(1<<SLOT->FB)), SLOT->wavetable );
+#endif
+		}
+
+		/* SLOT 2 */
+		SLOT++;
+		env = volume_calc(*SLOT);
+		if( env < ENV_QUIET )
+			output[0] += op_calc(SLOT->Cnt, env, phase_modulation, SLOT->wavetable) * 2;
+
+
+		/* Phase generation is based on: */
+		/* HH  (13) channel 7->slot 1 combined with channel 8->slot 2 (same combination as TOP CYMBAL but different output phases) */
+		/* SD  (16) channel 7->slot 1 */
+		/* TOM (14) channel 8->slot 1 */
+		/* TOP (17) channel 7->slot 1 combined with channel 8->slot 2 (same combination as HIGH HAT but different output phases) */
+
+		/* Envelope generation based on: */
+		/* HH  channel 7->slot1 */
+		/* SD  channel 7->slot2 */
+		/* TOM channel 8->slot1 */
+		/* TOP channel 8->slot2 */
+
+
+		/* The following formulas can be well optimized.
+		   I leave them in direct form for now (in case I've missed something).
+		*/
+
+		/* High Hat (verified on real YM3812) */
+		OPL_SLOT const &SLOT7_1 = P_CH[7].SLOT[SLOT1];
+		OPL_SLOT const &SLOT8_2 = P_CH[8].SLOT[SLOT2];
+		env = volume_calc(SLOT7_1);
+		if( env < ENV_QUIET )
+		{
+			/* high hat phase generation:
+			    phase = d0 or 234 (based on frequency only)
+			    phase = 34 or 2d0 (based on noise)
+			*/
+
+			/* base frequency derived from operator 1 in channel 7 */
+			unsigned char const bit7 = BIT(SLOT7_1.Cnt >> FREQ_SH, 7);
+			unsigned char const bit3 = BIT(SLOT7_1.Cnt >> FREQ_SH, 3);
+			unsigned char const bit2 = BIT(SLOT7_1.Cnt >> FREQ_SH, 2);
+
+			unsigned char const res1 = (bit2 ^ bit7) | bit3;
+
+			/* when res1 = 0 phase = 0x000 | 0xd0; */
+			/* when res1 = 1 phase = 0x200 | (0xd0>>2); */
+			uint32_t phase = res1 ? (0x200|(0xd0>>2)) : 0xd0;
+
+			/* enable gate based on frequency of operator 2 in channel 8 */
+			unsigned char const bit5e= BIT(SLOT8_2.Cnt >> FREQ_SH, 5);
+			unsigned char const bit3e= BIT(SLOT8_2.Cnt >> FREQ_SH, 3);
+
+			unsigned char const res2 = bit3e ^ bit5e;
+
+			/* when res2 = 0 pass the phase from calculation above (res1); */
+			/* when res2 = 1 phase = 0x200 | (0xd0>>2); */
+			if (res2)
+				phase = (0x200|(0xd0>>2));
+
+
+			/* when phase & 0x200 is set and noise=1 then phase = 0x200|0xd0 */
+			/* when phase & 0x200 is set and noise=0 then phase = 0x200|(0xd0>>2), ie no change */
+			if (phase&0x200)
+			{
+				if (noise)
+					phase = 0x200|0xd0;
+			}
+			else
+			/* when phase & 0x200 is clear and noise=1 then phase = 0xd0>>2 */
+			/* when phase & 0x200 is clear and noise=0 then phase = 0xd0, ie no change */
+			{
+				if (noise)
+					phase = 0xd0>>2;
+			}
+
+			output[0] += op_calc(phase<<FREQ_SH, env, 0, SLOT7_1.wavetable) * 2;
+		}
+
+		/* Snare Drum (verified on real YM3812) */
+		OPL_SLOT const &SLOT7_2 = P_CH[7].SLOT[SLOT2];
+		env = volume_calc(SLOT7_2);
+		if( env < ENV_QUIET )
+		{
+			/* base frequency derived from operator 1 in channel 7 */
+			unsigned char const bit8 = BIT(SLOT7_1.Cnt >> FREQ_SH, 8);
+
+			/* when bit8 = 0 phase = 0x100; */
+			/* when bit8 = 1 phase = 0x200; */
+			uint32_t phase = bit8 ? 0x200 : 0x100;
+
+			/* Noise bit XOR'es phase by 0x100 */
+			/* when noisebit = 0 pass the phase from calculation above */
+			/* when noisebit = 1 phase ^= 0x100; */
+			/* in other words: phase ^= (noisebit<<8); */
+			if (noise)
+				phase ^= 0x100;
+
+			output[0] += op_calc(phase<<FREQ_SH, env, 0, SLOT7_2.wavetable) * 2;
+		}
+
+		/* Tom Tom (verified on real YM3812) */
+		OPL_SLOT const &SLOT8_1 = P_CH[8].SLOT[SLOT1];
+		env = volume_calc(SLOT8_1);
+		if( env < ENV_QUIET )
+			output[0] += op_calc(SLOT8_1.Cnt, env, 0, SLOT8_1.wavetable) * 2;
+
+		/* Top Cymbal (verified on real YM3812) */
+		env = volume_calc(SLOT8_2);
+		if( env < ENV_QUIET )
+		{
+			/* base frequency derived from operator 1 in channel 7 */
+			unsigned char const bit7 = BIT(SLOT7_1.Cnt >> FREQ_SH, 7);
+			unsigned char const bit3 = BIT(SLOT7_1.Cnt >> FREQ_SH, 3);
+			unsigned char const bit2 = BIT(SLOT7_1.Cnt >> FREQ_SH, 2);
+
+			unsigned char const res1 = (bit2 ^ bit7) | bit3;
+
+			/* when res1 = 0 phase = 0x000 | 0x100; */
+			/* when res1 = 1 phase = 0x200 | 0x100; */
+			uint32_t phase = res1 ? 0x300 : 0x100;
+
+			/* enable gate based on frequency of operator 2 in channel 8 */
+			unsigned char const bit5e= BIT(SLOT8_2.Cnt >> FREQ_SH, 5);
+			unsigned char const bit3e= BIT(SLOT8_2.Cnt >> FREQ_SH, 3);
+
+			unsigned char const res2 = bit3e ^ bit5e;
+			/* when res2 = 0 pass the phase from calculation above (res1); */
+			/* when res2 = 1 phase = 0x200 | 0x100; */
+			if (res2)
+				phase = 0x300;
+
+			output[0] += op_calc(phase<<FREQ_SH, env, 0, SLOT8_2.wavetable) * 2;
+		}
+	}
+
+
+	void initialize();
+
+
+	/* set multi,am,vib,EG-TYP,KSR,mul */
+	void set_mul(int slot, int v)
+	{
+		OPL_CH   &CH   = P_CH[slot/2];
+		OPL_SLOT &SLOT = CH.SLOT[slot&1];
+
+		SLOT.mul     = mul_tab[v&0x0f];
+		SLOT.KSR     = (v & 0x10) ? 0 : 2;
+		SLOT.eg_type = (v & 0x20);
+		SLOT.vib     = (v & 0x40);
+		SLOT.AMmask  = (v & 0x80) ? ~0 : 0;
+		CH.CALC_FCSLOT(SLOT);
+	}
+
+	/* set ksl & tl */
+	void set_ksl_tl(int slot, int v)
+	{
+		OPL_CH   &CH   = P_CH[slot/2];
+		OPL_SLOT &SLOT = CH.SLOT[slot&1];
+
+		SLOT.ksl = ksl_shift[v >> 6];
+		SLOT.TL  = (v&0x3f)<<(ENV_BITS-1-7); /* 7 bits TL (bit 6 = always 0) */
+
+		SLOT.TLL = SLOT.TL + (CH.ksl_base >> SLOT.ksl);
+	}
+
+	/* set attack rate & decay rate  */
+	void set_ar_dr(int slot, int v)
+	{
+		OPL_CH   &CH   = P_CH[slot/2];
+		OPL_SLOT &SLOT = CH.SLOT[slot&1];
+
+		SLOT.ar = (v>>4)  ? 16 + ((v>>4)  <<2) : 0;
+
+		if ((SLOT.ar + SLOT.ksr) < 16+62)
+		{
+			SLOT.eg_sh_ar  = eg_rate_shift [SLOT.ar + SLOT.ksr ];
+			SLOT.eg_sel_ar = eg_rate_select[SLOT.ar + SLOT.ksr ];
+		}
+		else
+		{
+			SLOT.eg_sh_ar  = 0;
+			SLOT.eg_sel_ar = 13*RATE_STEPS;
+		}
+
+		SLOT.dr    = (v&0x0f)? 16 + ((v&0x0f)<<2) : 0;
+		SLOT.eg_sh_dr  = eg_rate_shift [SLOT.dr + SLOT.ksr ];
+		SLOT.eg_sel_dr = eg_rate_select[SLOT.dr + SLOT.ksr ];
+	}
+
+	/* set sustain level & release rate */
+	void set_sl_rr(int slot, int v)
+	{
+		OPL_CH   &CH   = P_CH[slot/2];
+		OPL_SLOT &SLOT = CH.SLOT[slot&1];
+
+		SLOT.sl  = sl_tab[ v>>4 ];
+
+		SLOT.rr  = (v&0x0f)? 16 + ((v&0x0f)<<2) : 0;
+		SLOT.eg_sh_rr  = eg_rate_shift [SLOT.rr + SLOT.ksr ];
+		SLOT.eg_sel_rr = eg_rate_select[SLOT.rr + SLOT.ksr ];
+	}
+
+
+	void WriteReg(int r, int v);
+	void ResetChip();
+	void postload();
+
+
+	/* lock/unlock for common table */
+	static int LockTable(device_t *device)
+	{
+		num_lock++;
+		if(num_lock>1) return 0;
+
+		/* first time */
+
+		/* allocate total level table (128kb space) */
+		if( !init_tables() )
+		{
+			num_lock--;
+			return -1;
+		}
+
+		return 0;
+	}
+
+	static void UnLockTable()
+	{
+		if(num_lock) num_lock--;
+		if(num_lock) return;
+
+		/* last time */
+		CloseTable();
+	}
+
+private:
+	uint32_t volume_calc(OPL_SLOT const &OP) const
+	{
+		return OP.TLL + uint32_t(OP.volume) + (LFO_AM & OP.AMmask);
+	}
+
+	static inline signed int op_calc(uint32_t phase, unsigned int env, signed int pm, unsigned int wave_tab)
+	{
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+		uint32_t const p = (env<<4) + sin_tab[wave_tab + ((((signed int)((phase & ~FREQ_MASK) + (pm<<16))) >> FREQ_SH ) & SIN_MASK) ];
+#else
+		uint32_t const p = (env<<4) + sin_tab[wave_tab + ((((signed int)((phase & ~FREQ_MASK) + (pm*(1<<16)))) >> FREQ_SH ) & SIN_MASK) ];
+#endif
+
+		return (p >= TL_TAB_LEN) ? 0 : tl_tab[p];
+	}
+
+	static inline signed int op_calc1(uint32_t phase, unsigned int env, signed int pm, unsigned int wave_tab)
+	{
+		uint32_t const p = (env<<4) + sin_tab[wave_tab + ((((signed int)((phase & ~FREQ_MASK) + pm      )) >> FREQ_SH ) & SIN_MASK) ];
+
+		return (p >= TL_TAB_LEN) ? 0 : tl_tab[p];
+	}
+
+
+	static int init_tables();
+
+	static void CloseTable()
+	{
+#ifdef SAVE_SAMPLE
+		fclose(sample[0]);
+#endif
+	}
+
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+#define constexpr
+#endif
+
+	static constexpr uint32_t SC(uint32_t db) { return uint32_t(db * (2.0 / ENV_STEP)); }
+
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+#undef constexpr
+#define constexpr const
+	static double DV;
+#else
+	static constexpr double DV = 0.1875 / 2.0;
+#endif
+
+	/*  TL_TAB_LEN is calculated as:
+	*   12 - sinus amplitude bits     (Y axis)
+	*   2  - sinus sign bit           (Y axis)
+	*   TL_RES_LEN - sinus resolution (X axis)
+	*/
+	static constexpr unsigned TL_TAB_LEN = 12 * 2 * TL_RES_LEN;
+	static constexpr unsigned ENV_QUIET = TL_TAB_LEN >> 4;
+
+	static constexpr unsigned LFO_AM_TAB_ELEMENTS = 210;
+
+	static const double ksl_tab[8*16];
+	static const uint32_t ksl_shift[4];
+	static const uint32_t sl_tab[16];
+	static const unsigned char eg_inc[15 * RATE_STEPS];
+
+	static const uint8_t mul_tab[16];
+	static signed int tl_tab[TL_TAB_LEN];
+	static unsigned int sin_tab[SIN_LEN * 4];
+
+	static const uint8_t lfo_am_table[LFO_AM_TAB_ELEMENTS];
+	static const int8_t lfo_pm_table[8 * 8 * 2];
+
+	static int num_lock;
+};
+
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+double FM_OPL::DV = 0.1875 / 2.0;
+#endif
+
+/* mapping of register number (offset) to slot number used by the emulator */
+static const int slot_array[32]=
+{
+		0, 2, 4, 1, 3, 5,-1,-1,
+		6, 8,10, 7, 9,11,-1,-1,
+	12,14,16,13,15,17,-1,-1,
+	-1,-1,-1,-1,-1,-1,-1,-1
+};
+
+/* key scale level */
+/* table is 3dB/octave , DV converts this into 6dB/octave */
+/* 0.1875 is bit 0 weight of the envelope counter (volume) expressed in the 'decibel' scale */
+const double FM_OPL::ksl_tab[8*16]=
+{
+	/* OCT 0 */
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+	/* OCT 1 */
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.750/DV, 1.125/DV, 1.500/DV,
+		1.875/DV, 2.250/DV, 2.625/DV, 3.000/DV,
+	/* OCT 2 */
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 1.125/DV, 1.875/DV, 2.625/DV,
+		3.000/DV, 3.750/DV, 4.125/DV, 4.500/DV,
+		4.875/DV, 5.250/DV, 5.625/DV, 6.000/DV,
+	/* OCT 3 */
+		0.000/DV, 0.000/DV, 0.000/DV, 1.875/DV,
+		3.000/DV, 4.125/DV, 4.875/DV, 5.625/DV,
+		6.000/DV, 6.750/DV, 7.125/DV, 7.500/DV,
+		7.875/DV, 8.250/DV, 8.625/DV, 9.000/DV,
+	/* OCT 4 */
+		0.000/DV, 0.000/DV, 3.000/DV, 4.875/DV,
+		6.000/DV, 7.125/DV, 7.875/DV, 8.625/DV,
+		9.000/DV, 9.750/DV,10.125/DV,10.500/DV,
+		10.875/DV,11.250/DV,11.625/DV,12.000/DV,
+	/* OCT 5 */
+		0.000/DV, 3.000/DV, 6.000/DV, 7.875/DV,
+		9.000/DV,10.125/DV,10.875/DV,11.625/DV,
+		12.000/DV,12.750/DV,13.125/DV,13.500/DV,
+		13.875/DV,14.250/DV,14.625/DV,15.000/DV,
+	/* OCT 6 */
+		0.000/DV, 6.000/DV, 9.000/DV,10.875/DV,
+		12.000/DV,13.125/DV,13.875/DV,14.625/DV,
+		15.000/DV,15.750/DV,16.125/DV,16.500/DV,
+		16.875/DV,17.250/DV,17.625/DV,18.000/DV,
+	/* OCT 7 */
+		0.000/DV, 9.000/DV,12.000/DV,13.875/DV,
+		15.000/DV,16.125/DV,16.875/DV,17.625/DV,
+		18.000/DV,18.750/DV,19.125/DV,19.500/DV,
+		19.875/DV,20.250/DV,20.625/DV,21.000/DV
+};
+
+/* 0 / 3.0 / 1.5 / 6.0 dB/OCT */
+const uint32_t FM_OPL::ksl_shift[4] = { 31, 1, 2, 0 };
+
+
+/* sustain level table (3dB per step) */
+/* 0 - 15: 0, 3, 6, 9,12,15,18,21,24,27,30,33,36,39,42,93 (dB)*/
+const uint32_t FM_OPL::sl_tab[16]={
+	SC( 0),SC( 1),SC( 2),SC( 3),SC( 4),SC( 5),SC( 6),SC( 7),
+	SC( 8),SC( 9),SC(10),SC(11),SC(12),SC(13),SC(14),SC(31)
+};
+
+
+const unsigned char FM_OPL::eg_inc[15*RATE_STEPS]={
+/*cycle:0 1  2 3  4 5  6 7*/
+
+/* 0 */ 0,1, 0,1, 0,1, 0,1, /* rates 00..12 0 (increment by 0 or 1) */
+/* 1 */ 0,1, 0,1, 1,1, 0,1, /* rates 00..12 1 */
+/* 2 */ 0,1, 1,1, 0,1, 1,1, /* rates 00..12 2 */
+/* 3 */ 0,1, 1,1, 1,1, 1,1, /* rates 00..12 3 */
+
+/* 4 */ 1,1, 1,1, 1,1, 1,1, /* rate 13 0 (increment by 1) */
+/* 5 */ 1,1, 1,2, 1,1, 1,2, /* rate 13 1 */
+/* 6 */ 1,2, 1,2, 1,2, 1,2, /* rate 13 2 */
+/* 7 */ 1,2, 2,2, 1,2, 2,2, /* rate 13 3 */
+
+/* 8 */ 2,2, 2,2, 2,2, 2,2, /* rate 14 0 (increment by 2) */
+/* 9 */ 2,2, 2,4, 2,2, 2,4, /* rate 14 1 */
+/*10 */ 2,4, 2,4, 2,4, 2,4, /* rate 14 2 */
+/*11 */ 2,4, 4,4, 2,4, 4,4, /* rate 14 3 */
+
+/*12 */ 4,4, 4,4, 4,4, 4,4, /* rates 15 0, 15 1, 15 2, 15 3 (increment by 4) */
+/*13 */ 8,8, 8,8, 8,8, 8,8, /* rates 15 2, 15 3 for attack */
+/*14 */ 0,0, 0,0, 0,0, 0,0, /* infinity rates for attack and decay(s) */
+};
+
+
+#define O(a) (a*RATE_STEPS)
+
+/*note that there is no O(13) in this table - it's directly in the code */
+const unsigned char eg_rate_select[16+64+16]={   /* Envelope Generator rates (16 + 64 rates + 16 RKS) */
+/* 16 infinite time rates */
+O(14),O(14),O(14),O(14),O(14),O(14),O(14),O(14),
+O(14),O(14),O(14),O(14),O(14),O(14),O(14),O(14),
+
+/* rates 00-12 */
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+
+/* rate 13 */
+O( 4),O( 5),O( 6),O( 7),
+
+/* rate 14 */
+O( 8),O( 9),O(10),O(11),
+
+/* rate 15 */
+O(12),O(12),O(12),O(12),
+
+/* 16 dummy rates (same as 15 3) */
+O(12),O(12),O(12),O(12),O(12),O(12),O(12),O(12),
+O(12),O(12),O(12),O(12),O(12),O(12),O(12),O(12),
+
+};
+#undef O
+
+/*rate  0,    1,    2,    3,   4,   5,   6,  7,  8,  9,  10, 11, 12, 13, 14, 15 */
+/*shift 12,   11,   10,   9,   8,   7,   6,  5,  4,  3,  2,  1,  0,  0,  0,  0  */
+/*mask  4095, 2047, 1023, 511, 255, 127, 63, 31, 15, 7,  3,  1,  0,  0,  0,  0  */
+
+#define O(a) (a*1)
+const unsigned char eg_rate_shift[16+64+16]={    /* Envelope Generator counter shifts (16 + 64 rates + 16 RKS) */
+/* 16 infinite time rates */
+O(0),O(0),O(0),O(0),O(0),O(0),O(0),O(0),
+O(0),O(0),O(0),O(0),O(0),O(0),O(0),O(0),
+
+/* rates 00-12 */
+O(12),O(12),O(12),O(12),
+O(11),O(11),O(11),O(11),
+O(10),O(10),O(10),O(10),
+O( 9),O( 9),O( 9),O( 9),
+O( 8),O( 8),O( 8),O( 8),
+O( 7),O( 7),O( 7),O( 7),
+O( 6),O( 6),O( 6),O( 6),
+O( 5),O( 5),O( 5),O( 5),
+O( 4),O( 4),O( 4),O( 4),
+O( 3),O( 3),O( 3),O( 3),
+O( 2),O( 2),O( 2),O( 2),
+O( 1),O( 1),O( 1),O( 1),
+O( 0),O( 0),O( 0),O( 0),
+
+/* rate 13 */
+O( 0),O( 0),O( 0),O( 0),
+
+/* rate 14 */
+O( 0),O( 0),O( 0),O( 0),
+
+/* rate 15 */
+O( 0),O( 0),O( 0),O( 0),
+
+/* 16 dummy rates (same as 15 3) */
+O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),
+O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),
+
+};
+#undef O
+
+
+/* multiple table */
+#define ML 2
+const uint8_t FM_OPL::mul_tab[16]= {
+/* 1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,10,12,12,15,15 */
+	ML/2, 1*ML, 2*ML, 3*ML, 4*ML, 5*ML, 6*ML, 7*ML,
+	8*ML, 9*ML,10*ML,10*ML,12*ML,12*ML,15*ML,15*ML
+};
+#undef ML
+
+signed int FM_OPL::tl_tab[TL_TAB_LEN];
+
+/* sin waveform table in 'decibel' scale */
+/* four waveforms on OPL2 type chips */
+unsigned int FM_OPL::sin_tab[SIN_LEN * 4];
+
+
+/* LFO Amplitude Modulation table (verified on real YM3812)
+   27 output levels (triangle waveform); 1 level takes one of: 192, 256 or 448 samples
+
+   Length: 210 elements.
+
+    Each of the elements has to be repeated
+    exactly 64 times (on 64 consecutive samples).
+    The whole table takes: 64 * 210 = 13440 samples.
+
+    When AM = 1 data is used directly
+    When AM = 0 data is divided by 4 before being used (losing precision is important)
+*/
+
+const uint8_t FM_OPL::lfo_am_table[LFO_AM_TAB_ELEMENTS] = {
+0,0,0,0,0,0,0,
+1,1,1,1,
+2,2,2,2,
+3,3,3,3,
+4,4,4,4,
+5,5,5,5,
+6,6,6,6,
+7,7,7,7,
+8,8,8,8,
+9,9,9,9,
+10,10,10,10,
+11,11,11,11,
+12,12,12,12,
+13,13,13,13,
+14,14,14,14,
+15,15,15,15,
+16,16,16,16,
+17,17,17,17,
+18,18,18,18,
+19,19,19,19,
+20,20,20,20,
+21,21,21,21,
+22,22,22,22,
+23,23,23,23,
+24,24,24,24,
+25,25,25,25,
+26,26,26,
+25,25,25,25,
+24,24,24,24,
+23,23,23,23,
+22,22,22,22,
+21,21,21,21,
+20,20,20,20,
+19,19,19,19,
+18,18,18,18,
+17,17,17,17,
+16,16,16,16,
+15,15,15,15,
+14,14,14,14,
+13,13,13,13,
+12,12,12,12,
+11,11,11,11,
+10,10,10,10,
+9,9,9,9,
+8,8,8,8,
+7,7,7,7,
+6,6,6,6,
+5,5,5,5,
+4,4,4,4,
+3,3,3,3,
+2,2,2,2,
+1,1,1,1
+};
+
+/* LFO Phase Modulation table (verified on real YM3812) */
+const int8_t FM_OPL::lfo_pm_table[8*8*2] = {
+/* FNUM2/FNUM = 00 0xxxxxxx (0x0000) */
+0, 0, 0, 0, 0, 0, 0, 0, /*LFO PM depth = 0*/
+0, 0, 0, 0, 0, 0, 0, 0, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 00 1xxxxxxx (0x0080) */
+0, 0, 0, 0, 0, 0, 0, 0, /*LFO PM depth = 0*/
+1, 0, 0, 0,-1, 0, 0, 0, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 01 0xxxxxxx (0x0100) */
+1, 0, 0, 0,-1, 0, 0, 0, /*LFO PM depth = 0*/
+2, 1, 0,-1,-2,-1, 0, 1, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 01 1xxxxxxx (0x0180) */
+1, 0, 0, 0,-1, 0, 0, 0, /*LFO PM depth = 0*/
+3, 1, 0,-1,-3,-1, 0, 1, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 10 0xxxxxxx (0x0200) */
+2, 1, 0,-1,-2,-1, 0, 1, /*LFO PM depth = 0*/
+4, 2, 0,-2,-4,-2, 0, 2, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 10 1xxxxxxx (0x0280) */
+2, 1, 0,-1,-2,-1, 0, 1, /*LFO PM depth = 0*/
+5, 2, 0,-2,-5,-2, 0, 2, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 11 0xxxxxxx (0x0300) */
+3, 1, 0,-1,-3,-1, 0, 1, /*LFO PM depth = 0*/
+6, 3, 0,-3,-6,-3, 0, 3, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 11 1xxxxxxx (0x0380) */
+3, 1, 0,-1,-3,-1, 0, 1, /*LFO PM depth = 0*/
+7, 3, 0,-3,-7,-3, 0, 3  /*LFO PM depth = 1*/
+};
+
+
+/* lock level of common table */
+int FM_OPL::num_lock = 0;
+
+
+
+static inline int limit( int val, int max, int min ) {
+	if ( val > max )
+		val = max;
+	else if ( val < min )
+		val = min;
+
+	return val;
+}
+
+
+/* generic table initialize */
+int FM_OPL::init_tables()
+{
+	signed int i,x;
+	signed int n;
+	double o,m;
+
+
+	for (x=0; x<TL_RES_LEN; x++)
+	{
+		m = (1<<16) / pow(2, (x+1) * (ENV_STEP/4.0) / 8.0);
+		m = floor(m);
+
+		/* we never reach (1<<16) here due to the (x+1) */
+		/* result fits within 16 bits at maximum */
+
+		n = (int)m;     /* 16 bits here */
+		n >>= 4;        /* 12 bits here */
+		if (n&1)        /* round to nearest */
+			n = (n>>1)+1;
+		else
+			n = n>>1;
+						/* 11 bits here (rounded) */
+		n <<= 1;        /* 12 bits here (as in real chip) */
+		tl_tab[ x*2 + 0 ] = n;
+		tl_tab[ x*2 + 1 ] = -tl_tab[ x*2 + 0 ];
+
+		for (i=1; i<12; i++)
+		{
+			tl_tab[ x*2+0 + i*2*TL_RES_LEN ] =  tl_tab[ x*2+0 ]>>i;
+			tl_tab[ x*2+1 + i*2*TL_RES_LEN ] = -tl_tab[ x*2+0 + i*2*TL_RES_LEN ];
+		}
+	#if 0
+			logerror("tl %04i", x*2);
+			for (i=0; i<12; i++)
+				logerror(", [%02i] %5i", i*2, tl_tab[ x*2 /*+1*/ + i*2*TL_RES_LEN ] );
+			logerror("\n");
+	#endif
+	}
+	/*logerror("FMOPL.C: TL_TAB_LEN = %i elements (%i bytes)\n",TL_TAB_LEN, (int)sizeof(tl_tab));*/
+
+
+	for (i=0; i<SIN_LEN; i++)
+	{
+		/* non-standard sinus */
+		m = sin( ((i*2)+1) * M_PI / SIN_LEN ); /* checked against the real chip */
+
+		/* we never reach zero here due to ((i*2)+1) */
+
+		if (m>0.0)
+			o = 8*log(1.0/m)/log(2.0);  /* convert to 'decibels' */
+		else
+			o = 8*log(-1.0/m)/log(2.0); /* convert to 'decibels' */
+
+		o = o / (ENV_STEP/4);
+
+		n = (int)(2.0*o);
+		if (n&1)                        /* round to nearest */
+			n = (n>>1)+1;
+		else
+			n = n>>1;
+
+		sin_tab[ i ] = n*2 + (m>=0.0? 0: 1 );
+
+		/*logerror("FMOPL.C: sin [%4i (hex=%03x)]= %4i (tl_tab value=%5i)\n", i, i, sin_tab[i], tl_tab[sin_tab[i]] );*/
+	}
+
+	for (i=0; i<SIN_LEN; i++)
+	{
+		/* waveform 1:  __      __     */
+		/*             /  \____/  \____*/
+		/* output only first half of the sinus waveform (positive one) */
+
+		if (i & (1<<(SIN_BITS-1)) )
+			sin_tab[1*SIN_LEN+i] = TL_TAB_LEN;
+		else
+			sin_tab[1*SIN_LEN+i] = sin_tab[i];
+
+		/* waveform 2:  __  __  __  __ */
+		/*             /  \/  \/  \/  \*/
+		/* abs(sin) */
+
+		sin_tab[2*SIN_LEN+i] = sin_tab[i & (SIN_MASK>>1) ];
+
+		/* waveform 3:  _   _   _   _  */
+		/*             / |_/ |_/ |_/ |_*/
+		/* abs(output only first quarter of the sinus waveform) */
+
+		if (i & (1<<(SIN_BITS-2)) )
+			sin_tab[3*SIN_LEN+i] = TL_TAB_LEN;
+		else
+			sin_tab[3*SIN_LEN+i] = sin_tab[i & (SIN_MASK>>2)];
+
+		/*logerror("FMOPL.C: sin1[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[1*SIN_LEN+i], tl_tab[sin_tab[1*SIN_LEN+i]] );
+		logerror("FMOPL.C: sin2[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[2*SIN_LEN+i], tl_tab[sin_tab[2*SIN_LEN+i]] );
+		logerror("FMOPL.C: sin3[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[3*SIN_LEN+i], tl_tab[sin_tab[3*SIN_LEN+i]] );*/
+	}
+	/*logerror("FMOPL.C: ENV_QUIET= %08x (dec*8=%i)\n", ENV_QUIET, ENV_QUIET*8 );*/
+
+
+#ifdef SAVE_SAMPLE
+	sample[0]=fopen("sampsum.pcm","wb");
+#endif
+
+	return 1;
+}
+
+
+void FM_OPL::initialize()
+{
+	int i;
+
+	/* frequency base */
+	freqbase  = (rate) ? ((double)clock / 72.0) / rate  : 0;
+#if 0
+	rate = (double)clock / 72.0;
+	freqbase  = 1.0;
+#endif
+
+	/*logerror("freqbase=%f\n", freqbase);*/
+
+	/* Timer base time */
+	TimerBase = attotime::from_hz(clock) * 72;
+
+	/* make fnumber -> increment counter table */
+	for( i=0 ; i < 1024 ; i++ )
+	{
+		/* opn phase increment counter = 20bit */
+		fn_tab[i] = (uint32_t)( (double)i * 64 * freqbase * (1<<(FREQ_SH-10)) ); /* -10 because chip works with 10.10 fixed point, while we use 16.16 */
+#if 0
+		logerror("FMOPL.C: fn_tab[%4i] = %08x (dec=%8i)\n",
+					i, fn_tab[i]>>6, fn_tab[i]>>6 );
+#endif
+	}
+
+#if 0
+	for( i=0 ; i < 16 ; i++ )
+	{
+		logerror("FMOPL.C: sl_tab[%i] = %08x\n",
+			i, sl_tab[i] );
+	}
+	for( i=0 ; i < 8 ; i++ )
+	{
+		int j;
+		logerror("FMOPL.C: ksl_tab[oct=%2i] =",i);
+		for (j=0; j<16; j++)
+		{
+			logerror("%08x ", static_cast<uint32_t>(ksl_tab[i*16+j]) );
+		}
+		logerror("\n");
+	}
+#endif
+
+
+	/* Amplitude modulation: 27 output levels (triangle waveform); 1 level takes one of: 192, 256 or 448 samples */
+	/* One entry from LFO_AM_TABLE lasts for 64 samples */
+	lfo_am_inc = (1.0 / 64.0 ) * (1<<LFO_SH) * freqbase;
+
+	/* Vibrato: 8 output levels (triangle waveform); 1 level takes 1024 samples */
+	lfo_pm_inc = (1.0 / 1024.0) * (1<<LFO_SH) * freqbase;
+
+	/*logerror ("lfo_am_inc = %8x ; lfo_pm_inc = %8x\n", lfo_am_inc, lfo_pm_inc);*/
+
+	/* Noise generator: a step takes 1 sample */
+	noise_f = (1.0 / 1.0) * (1<<FREQ_SH) * freqbase;
+
+	eg_timer_add  = (1<<EG_SH)  * freqbase;
+	eg_timer_overflow = ( 1 ) * (1<<EG_SH);
+	/*logerror("OPLinit eg_timer_add=%8x eg_timer_overflow=%8x\n", eg_timer_add, eg_timer_overflow);*/
+}
+
+
+/* write a value v to register r on OPL chip */
+void FM_OPL::WriteReg(int r, int v)
+{
+	OPL_CH *CH;
+	int slot;
+	int block_fnum;
+
+
+	/* adjust bus to 8 bits */
+	r &= 0xff;
+	v &= 0xff;
+
+	switch(r&0xe0)
+	{
+	case 0x00:  /* 00-1f:control */
+		switch(r&0x1f)
+		{
+		case 0x01:  /* waveform select enable */
+			if(type&OPL_TYPE_WAVESEL)
+			{
+				wavesel = v&0x20;
+				/* do not change the waveform previously selected */
+			}
+			break;
+		case 0x02:  /* Timer 1 */
+			T[0] = (256-v)*4;
+			break;
+		case 0x03:  /* Timer 2 */
+			T[1] = (256-v)*16;
+			break;
+		case 0x04:  /* IRQ clear / mask and Timer enable */
+			if(v&0x80)
+			{   /* IRQ flag clear */
+				STATUS_RESET(0x7f-0x08); /* don't reset BFRDY flag or we will have to call deltat module to set the flag */
+			}
+			else
+			{   /* set IRQ mask ,timer enable*/
+				uint8_t st1 = v&1;
+				uint8_t st2 = (v>>1)&1;
+
+				/* IRQRST,T1MSK,t2MSK,EOSMSK,BRMSK,x,ST2,ST1 */
+				STATUS_RESET(v & (0x78-0x08));
+				STATUSMASK_SET((~v) & 0x78);
+
+				/* timer 2 */
+				if(st[1] != st2)
+				{
+					attotime period = st2 ? (TimerBase * T[1]) : attotime::zero;
+					st[1] = st2;
+					if (timer_handler) (timer_handler)(TimerParam,1,period);
+				}
+				/* timer 1 */
+				if(st[0] != st1)
+				{
+					attotime period = st1 ? (TimerBase * T[0]) : attotime::zero;
+					st[0] = st1;
+					if (timer_handler) (timer_handler)(TimerParam,0,period);
+				}
+			}
+			break;
+#if BUILD_Y8950
+		case 0x06:      /* Key Board OUT */
+			if(type&OPL_TYPE_KEYBOARD)
+			{
+				if(keyboardhandler_w)
+					keyboardhandler_w(keyboard_param,v);
+				else
+					device->logerror("Y8950: write unmapped KEYBOARD port\n");
+			}
+			break;
+		case 0x07:  /* DELTA-T control 1 : START,REC,MEMDATA,REPT,SPOFF,x,x,RST */
+			if(type&OPL_TYPE_ADPCM)
+				deltat->ADPCM_Write(r-0x07,v);
+			break;
+#endif
+		case 0x08:  /* MODE,DELTA-T control 2 : CSM,NOTESEL,x,x,smpl,da/ad,64k,rom */
+			mode = v;
+#if BUILD_Y8950
+			if(type&OPL_TYPE_ADPCM)
+				deltat->ADPCM_Write(r-0x07,v&0x0f); /* mask 4 LSBs in register 08 for DELTA-T unit */
+#endif
+			break;
+
+#if BUILD_Y8950
+		case 0x09:      /* START ADD */
+		case 0x0a:
+		case 0x0b:      /* STOP ADD  */
+		case 0x0c:
+		case 0x0d:      /* PRESCALE   */
+		case 0x0e:
+		case 0x0f:      /* ADPCM data write */
+		case 0x10:      /* DELTA-N    */
+		case 0x11:      /* DELTA-N    */
+		case 0x12:      /* ADPCM volume */
+			if(type&OPL_TYPE_ADPCM)
+				deltat->ADPCM_Write(r-0x07,v);
+			break;
+
+		case 0x15:      /* DAC data high 8 bits (F7,F6...F2) */
+		case 0x16:      /* DAC data low 2 bits (F1, F0 in bits 7,6) */
+		case 0x17:      /* DAC data shift (S2,S1,S0 in bits 2,1,0) */
+			device->logerror("FMOPL.C: DAC data register written, but not implemented reg=%02x val=%02x\n",r,v);
+			break;
+
+		case 0x18:      /* I/O CTRL (Direction) */
+			if(type&OPL_TYPE_IO)
+				portDirection = v&0x0f;
+			break;
+		case 0x19:      /* I/O DATA */
+			if(type&OPL_TYPE_IO)
+			{
+				portLatch = v;
+				if(porthandler_w)
+					porthandler_w(port_param,v&portDirection);
+			}
+			break;
+#endif
+		default:
+			device->logerror("FMOPL.C: write to unknown register: %02x\n",r);
+			break;
+		}
+		break;
+	case 0x20:  /* am ON, vib ON, ksr, eg_type, mul */
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+		set_mul(slot,v);
+		break;
+	case 0x40:
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+		set_ksl_tl(slot,v);
+		break;
+	case 0x60:
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+		set_ar_dr(slot,v);
+		break;
+	case 0x80:
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+		set_sl_rr(slot,v);
+		break;
+	case 0xa0:
+		if (r == 0xbd)          /* am depth, vibrato depth, r,bd,sd,tom,tc,hh */
+		{
+			lfo_am_depth = v & 0x80;
+			lfo_pm_depth_range = (v&0x40) ? 8 : 0;
+
+			rhythm  = v&0x3f;
+
+			if(rhythm&0x20)
+			{
+				/* BD key on/off */
+				if(v&0x10)
+				{
+					P_CH[6].SLOT[SLOT1].KEYON(2);
+					P_CH[6].SLOT[SLOT2].KEYON(2);
+				}
+				else
+				{
+					P_CH[6].SLOT[SLOT1].KEYOFF(~2);
+					P_CH[6].SLOT[SLOT2].KEYOFF(~2);
+				}
+				/* HH key on/off */
+				if(v&0x01) P_CH[7].SLOT[SLOT1].KEYON ( 2);
+				else       P_CH[7].SLOT[SLOT1].KEYOFF(~2);
+				/* SD key on/off */
+				if(v&0x08) P_CH[7].SLOT[SLOT2].KEYON ( 2);
+				else       P_CH[7].SLOT[SLOT2].KEYOFF(~2);
+				/* TOM key on/off */
+				if(v&0x04) P_CH[8].SLOT[SLOT1].KEYON ( 2);
+				else       P_CH[8].SLOT[SLOT1].KEYOFF(~2);
+				/* TOP-CY key on/off */
+				if(v&0x02) P_CH[8].SLOT[SLOT2].KEYON ( 2);
+				else       P_CH[8].SLOT[SLOT2].KEYOFF(~2);
+			}
+			else
+			{
+				/* BD key off */
+				P_CH[6].SLOT[SLOT1].KEYOFF(~2);
+				P_CH[6].SLOT[SLOT2].KEYOFF(~2);
+				/* HH key off */
+				P_CH[7].SLOT[SLOT1].KEYOFF(~2);
+				/* SD key off */
+				P_CH[7].SLOT[SLOT2].KEYOFF(~2);
+				/* TOM key off */
+				P_CH[8].SLOT[SLOT1].KEYOFF(~2);
+				/* TOP-CY off */
+				P_CH[8].SLOT[SLOT2].KEYOFF(~2);
+			}
+			return;
+		}
+		/* keyon,block,fnum */
+		if( (r&0x0f) > 8) return;
+		CH = &P_CH[r&0x0f];
+		if(!(r&0x10))
+		{   /* a0-a8 */
+			block_fnum  = (CH->block_fnum&0x1f00) | v;
+		}
+		else
+		{   /* b0-b8 */
+			block_fnum = ((v&0x1f)<<8) | (CH->block_fnum&0xff);
+
+			if(v&0x20)
+			{
+				CH->SLOT[SLOT1].KEYON ( 1);
+				CH->SLOT[SLOT2].KEYON ( 1);
+			}
+			else
+			{
+				CH->SLOT[SLOT1].KEYOFF(~1);
+				CH->SLOT[SLOT2].KEYOFF(~1);
+			}
+		}
+		/* update */
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+		if(CH->block_fnum != block_fnum)
+#else
+		if(CH->block_fnum != uint32_t(block_fnum))
+#endif
+		{
+			uint8_t block  = block_fnum >> 10;
+
+			CH->block_fnum = block_fnum;
+
+			CH->ksl_base = static_cast<uint32_t>(ksl_tab[block_fnum>>6]);
+			CH->fc       = fn_tab[block_fnum&0x03ff] >> (7-block);
+
+			/* BLK 2,1,0 bits -> bits 3,2,1 of kcode */
+			CH->kcode    = (CH->block_fnum&0x1c00)>>9;
+
+				/* the info below is actually opposite to what is stated in the Manuals (verifed on real YM3812) */
+			/* if notesel == 0 -> lsb of kcode is bit 10 (MSB) of fnum  */
+			/* if notesel == 1 -> lsb of kcode is bit 9 (MSB-1) of fnum */
+			if (mode&0x40)
+				CH->kcode |= (CH->block_fnum&0x100)>>8; /* notesel == 1 */
+			else
+				CH->kcode |= (CH->block_fnum&0x200)>>9; /* notesel == 0 */
+
+			/* refresh Total Level in both SLOTs of this channel */
+			CH->SLOT[SLOT1].TLL = CH->SLOT[SLOT1].TL + (CH->ksl_base>>CH->SLOT[SLOT1].ksl);
+			CH->SLOT[SLOT2].TLL = CH->SLOT[SLOT2].TL + (CH->ksl_base>>CH->SLOT[SLOT2].ksl);
+
+			/* refresh frequency counter in both SLOTs of this channel */
+			CH->CALC_FCSLOT(CH->SLOT[SLOT1]);
+			CH->CALC_FCSLOT(CH->SLOT[SLOT2]);
+		}
+		break;
+	case 0xc0:
+		/* FB,C */
+		if( (r&0x0f) > 8) return;
+		CH = &P_CH[r&0x0f];
+		CH->SLOT[SLOT1].FB  = (v>>1)&7 ? ((v>>1)&7) + 7 : 0;
+		CH->SLOT[SLOT1].CON = v&1;
+		CH->SLOT[SLOT1].connect1 = CH->SLOT[SLOT1].CON ? &output[0] : &phase_modulation;
+		break;
+	case 0xe0: /* waveform select */
+		/* simply ignore write to the waveform select register if selecting not enabled in test register */
+		if(wavesel)
+		{
+			slot = slot_array[r&0x1f];
+			if(slot < 0) return;
+			CH = &P_CH[slot/2];
+
+			CH->SLOT[slot&1].wavetable = (v&0x03)*SIN_LEN;
+		}
+		break;
+	}
+}
+
+
+void FM_OPL::ResetChip()
+{
+	eg_timer = 0;
+	eg_cnt   = 0;
+
+	noise_rng = 1; /* noise shift register */
+	mode   = 0;    /* normal mode */
+	STATUS_RESET(0x7f);
+
+	/* reset with register write */
+	WriteReg(0x01,0); /* wavesel disable */
+	WriteReg(0x02,0); /* Timer1 */
+	WriteReg(0x03,0); /* Timer2 */
+	WriteReg(0x04,0); /* IRQ mask clear */
+	for(int i = 0xff ; i >= 0x20 ; i-- ) WriteReg(i,0);
+
+	/* reset operator parameters */
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+	for (size_t i = 0; i < sizeof(P_CH) / sizeof(P_CH[0]); ++i) {
+		OPL_CH &CH = P_CH[i];
+		for (size_t j = 0; j < sizeof(CH.SLOT) / sizeof(CH.SLOT[0]); ++j) {
+			OPL_SLOT &SLOT = CH.SLOT[j];
+#else
+	for(OPL_CH &CH : P_CH)
+	{
+		for(OPL_SLOT &SLOT : CH.SLOT)
+		{
+#endif
+			/* wave table */
+			SLOT.wavetable = 0;
+			SLOT.state     = EG_OFF;
+			SLOT.volume    = MAX_ATT_INDEX;
+		}
+	}
+#if BUILD_Y8950
+	if(type&OPL_TYPE_ADPCM)
+	{
+		YM_DELTAT *DELTAT = deltat;
+
+		DELTAT->freqbase = freqbase;
+		DELTAT->output_pointer = &output_deltat[0];
+		DELTAT->portshift = 5;
+		DELTAT->output_range = 1<<23;
+		DELTAT->ADPCM_Reset(0,YM_DELTAT::EMULATION_MODE_NORMAL,device);
+	}
+#endif
+}
+
+
+void FM_OPL::postload()
+{
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+	for (size_t i = 0; i < sizeof(P_CH) / sizeof(P_CH[0]); ++i) {
+		OPL_CH &CH = P_CH[i];
+#else
+	for(OPL_CH &CH : P_CH)
+	{
+#endif
+		/* Look up key scale level */
+		uint32_t const block_fnum = CH.block_fnum;
+		CH.ksl_base = static_cast<uint32_t>(ksl_tab[block_fnum >> 6]);
+		CH.fc       = fn_tab[block_fnum & 0x03ff] >> (7 - (block_fnum >> 10));
+
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+		for (size_t j = 0; j < sizeof(CH.SLOT) / sizeof(CH.SLOT[0]); ++j) {
+			OPL_SLOT &SLOT = CH.SLOT[j];
+#else
+		for(OPL_SLOT &SLOT : CH.SLOT)
+		{
+#endif
+			/* Calculate key scale rate */
+			SLOT.ksr = CH.kcode >> SLOT.KSR;
+
+			/* Calculate attack, decay and release rates */
+			if ((SLOT.ar + SLOT.ksr) < 16+62)
+			{
+				SLOT.eg_sh_ar  = eg_rate_shift [SLOT.ar + SLOT.ksr ];
+				SLOT.eg_sel_ar = eg_rate_select[SLOT.ar + SLOT.ksr ];
+			}
+			else
+			{
+				SLOT.eg_sh_ar  = 0;
+				SLOT.eg_sel_ar = 13*RATE_STEPS;
+			}
+			SLOT.eg_sh_dr  = eg_rate_shift [SLOT.dr + SLOT.ksr ];
+			SLOT.eg_sel_dr = eg_rate_select[SLOT.dr + SLOT.ksr ];
+			SLOT.eg_sh_rr  = eg_rate_shift [SLOT.rr + SLOT.ksr ];
+			SLOT.eg_sel_rr = eg_rate_select[SLOT.rr + SLOT.ksr ];
+
+			/* Calculate phase increment */
+			SLOT.Incr = CH.fc * SLOT.mul;
+
+			/* Total level */
+			SLOT.TLL = SLOT.TL + (CH.ksl_base >> SLOT.ksl);
+
+			/* Connect output */
+			SLOT.connect1 = SLOT.CON ? &output[0] : &phase_modulation;
+		}
+	}
+#if BUILD_Y8950
+	if ( (type & OPL_TYPE_ADPCM) && (deltat) )
+	{
+		// We really should call the postlod function for the YM_DELTAT, but it's hard without registers
+		// (see the way the YM2610 does it)
+		//deltat->postload(REGS);
+	}
+#endif
+}
+
+} // anonymous namespace
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+static void OPLsave_state_channel(device_t *device, OPL_CH *CH)
+{
+	int slot, ch;
+
+	for( ch=0 ; ch < 9 ; ch++, CH++ )
+	{
+		/* channel */
+		device->save_item(NAME(CH->block_fnum), ch);
+		device->save_item(NAME(CH->kcode), ch);
+		/* slots */
+		for( slot=0 ; slot < 2 ; slot++ )
+		{
+			OPL_SLOT *SLOT = &CH->SLOT[slot];
+
+			device->save_item(NAME(SLOT->ar), ch * 2 + slot);
+			device->save_item(NAME(SLOT->dr), ch * 2 + slot);
+			device->save_item(NAME(SLOT->rr), ch * 2 + slot);
+			device->save_item(NAME(SLOT->KSR), ch * 2 + slot);
+			device->save_item(NAME(SLOT->ksl), ch * 2 + slot);
+			device->save_item(NAME(SLOT->mul), ch * 2 + slot);
+
+			device->save_item(NAME(SLOT->Cnt), ch * 2 + slot);
+			device->save_item(NAME(SLOT->FB), ch * 2 + slot);
+			device->save_item(NAME(SLOT->op1_out), ch * 2 + slot);
+			device->save_item(NAME(SLOT->CON), ch * 2 + slot);
+
+			device->save_item(NAME(SLOT->eg_type), ch * 2 + slot);
+			device->save_item(NAME(SLOT->state), ch * 2 + slot);
+			device->save_item(NAME(SLOT->TL), ch * 2 + slot);
+			device->save_item(NAME(SLOT->volume), ch * 2 + slot);
+			device->save_item(NAME(SLOT->sl), ch * 2 + slot);
+			device->save_item(NAME(SLOT->key), ch * 2 + slot);
+
+			device->save_item(NAME(SLOT->AMmask), ch * 2 + slot);
+			device->save_item(NAME(SLOT->vib), ch * 2 + slot);
+
+			device->save_item(NAME(SLOT->wavetable), ch * 2 + slot);
+		}
+	}
+}
+
+
+/* Register savestate for a virtual YM3812/YM3526Y8950 */
+
+static void OPL_save_state(FM_OPL *OPL, device_t *device)
+{
+	OPLsave_state_channel(device, OPL->P_CH);
+
+	device->save_item(NAME(OPL->eg_cnt));
+	device->save_item(NAME(OPL->eg_timer));
+
+	device->save_item(NAME(OPL->rhythm));
+
+	device->save_item(NAME(OPL->lfo_am_depth));
+	device->save_item(NAME(OPL->lfo_pm_depth_range));
+	device->save_item(NAME(OPL->lfo_am_cnt));
+	device->save_item(NAME(OPL->lfo_pm_cnt));
+
+	device->save_item(NAME(OPL->noise_rng));
+	device->save_item(NAME(OPL->noise_p));
+
+	if( OPL->type & OPL_TYPE_WAVESEL )
+	{
+		device->save_item(NAME(OPL->wavesel));
+	}
+
+	device->save_item(NAME(OPL->T));
+	device->save_item(NAME(OPL->st));
+
+#if BUILD_Y8950
+	if ( (OPL->type & OPL_TYPE_ADPCM) && (OPL->deltat) )
+	{
+		OPL->deltat->savestate(device);
+	}
+
+	if ( OPL->type & OPL_TYPE_IO )
+	{
+		device->save_item(NAME(OPL->portDirection));
+		device->save_item(NAME(OPL->portLatch));
+	}
+#endif
+
+	device->save_item(NAME(OPL->address));
+	device->save_item(NAME(OPL->status));
+	device->save_item(NAME(OPL->statusmask));
+	device->save_item(NAME(OPL->mode));
+
+	device->machine().save().register_postload(save_prepost_delegate(FUNC(FM_OPL::postload), OPL));
+}
+#endif
+
+static void OPL_clock_changed(FM_OPL *OPL, uint32_t clock, uint32_t rate)
+{
+	OPL->clock = clock;
+	OPL->rate  = rate;
+
+	/* init global tables */
+	OPL->initialize();
+}
+
+
+/* Create one of virtual YM3812/YM3526/Y8950 */
+/* 'clock' is chip clock in Hz  */
+/* 'rate'  is sampling rate  */
+static FM_OPL *OPLCreate(device_t *device, uint32_t clock, uint32_t rate, int type)
+{
+	char *ptr;
+	FM_OPL *OPL;
+	int state_size;
+
+	if (FM_OPL::LockTable(device) == -1) return nullptr;
+
+	/* calculate OPL state size */
+	state_size  = sizeof(FM_OPL);
+
+#if BUILD_Y8950
+	if (type&OPL_TYPE_ADPCM) state_size+= sizeof(YM_DELTAT);
+#endif
+
+	/* allocate memory block */
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+	ptr = (char *)auto_alloc_array_clear(device->machine(), uint8_t, state_size);
+#else
+	ptr = (char *)calloc(state_size, sizeof(uint8_t));
+	device->state = ptr;
+#endif
+
+	OPL  = (FM_OPL *)ptr;
+
+	ptr += sizeof(FM_OPL);
+
+#if BUILD_Y8950
+	if (type&OPL_TYPE_ADPCM)
+	{
+		OPL->deltat = (YM_DELTAT *)ptr;
+	}
+	ptr += sizeof(YM_DELTAT);
+#endif
+
+	OPL->device = device;
+	OPL->type  = type;
+	OPL_clock_changed(OPL, clock, rate);
+
+	return OPL;
+}
+
+/* Destroy one of virtual YM3812 */
+static void OPLDestroy(FM_OPL *OPL)
+{
+	FM_OPL::UnLockTable();
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+	auto_free(OPL->device->machine(), OPL);
+#else
+	free(OPL->device->state);
+#endif
+}
+
+/* Optional handlers */
+
+static void OPLSetTimerHandler(FM_OPL *OPL,OPL_TIMERHANDLER timer_handler,device_t *device)
+{
+	OPL->timer_handler   = timer_handler;
+	OPL->TimerParam = device;
+}
+static void OPLSetIRQHandler(FM_OPL *OPL,OPL_IRQHANDLER IRQHandler,device_t *device)
+{
+	OPL->IRQHandler     = IRQHandler;
+	OPL->IRQParam = device;
+}
+static void OPLSetUpdateHandler(FM_OPL *OPL,OPL_UPDATEHANDLER UpdateHandler,device_t *device)
+{
+	OPL->UpdateHandler = UpdateHandler;
+	OPL->UpdateParam = device;
+}
+
+static int OPLWrite(FM_OPL *OPL,int a,int v)
+{
+	if( !(a&1) )
+	{   /* address port */
+		OPL->address = v & 0xff;
+	}
+	else
+	{   /* data port */
+		if(OPL->UpdateHandler) OPL->UpdateHandler(OPL->UpdateParam,0);
+		OPL->WriteReg(OPL->address,v);
+	}
+	return OPL->status>>7;
+}
+
+static unsigned char OPLRead(FM_OPL *OPL,int a)
+{
+	if( !(a&1) )
+	{
+		/* status port */
+
+		#if BUILD_Y8950
+
+		if(OPL->type&OPL_TYPE_ADPCM)    /* Y8950 */
+		{
+			return (OPL->status & (OPL->statusmask|0x80)) | (OPL->deltat->PCM_BSY&1);
+		}
+
+		#endif
+
+		/* OPL and OPL2 */
+		return OPL->status & (OPL->statusmask|0x80);
+	}
+
+#if BUILD_Y8950
+	/* data port */
+	switch(OPL->address)
+	{
+	case 0x05: /* KeyBoard IN */
+		if(OPL->type&OPL_TYPE_KEYBOARD)
+		{
+			if(OPL->keyboardhandler_r)
+				return OPL->keyboardhandler_r(OPL->keyboard_param);
+			else
+				OPL->device->logerror("Y8950: read unmapped KEYBOARD port\n");
+		}
+		return 0;
+
+	case 0x0f: /* ADPCM-DATA  */
+		if(OPL->type&OPL_TYPE_ADPCM)
+		{
+			uint8_t val;
+
+			val = OPL->deltat->ADPCM_Read();
+			/*logerror("Y8950: read ADPCM value read=%02x\n",val);*/
+			return val;
+		}
+		return 0;
+
+	case 0x19: /* I/O DATA    */
+		if(OPL->type&OPL_TYPE_IO)
+		{
+			if(OPL->porthandler_r)
+				return OPL->porthandler_r(OPL->port_param);
+			else
+				OPL->device->logerror("Y8950:read unmapped I/O port\n");
+		}
+		return 0;
+	case 0x1a: /* PCM-DATA    */
+		if(OPL->type&OPL_TYPE_ADPCM)
+		{
+			OPL->device->logerror("Y8950 A/D conversion is accessed but not implemented !\n");
+			return 0x80; /* 2's complement PCM data - result from A/D conversion */
+		}
+		return 0;
+	}
+#endif
+
+	return 0xff;
+}
+
+/* CSM Key Controll */
+static inline void CSMKeyControll(OPL_CH *CH)
+{
+	CH->SLOT[SLOT1].KEYON(4);
+	CH->SLOT[SLOT2].KEYON(4);
+
+	/* The key off should happen exactly one sample later - not implemented correctly yet */
+
+	CH->SLOT[SLOT1].KEYOFF(~4);
+	CH->SLOT[SLOT2].KEYOFF(~4);
+}
+
+
+static int OPLTimerOver(FM_OPL *OPL,int c)
+{
+	if( c )
+	{   /* Timer B */
+		OPL->STATUS_SET(0x20);
+	}
+	else
+	{   /* Timer A */
+		OPL->STATUS_SET(0x40);
+		/* CSM mode key,TL controll */
+		if( OPL->mode & 0x80 )
+		{   /* CSM mode total level latch and auto key on */
+			int ch;
+			if(OPL->UpdateHandler) OPL->UpdateHandler(OPL->UpdateParam,0);
+			for(ch=0; ch<9; ch++)
+				CSMKeyControll( &OPL->P_CH[ch] );
+		}
+	}
+	/* reload timer */
+	if (OPL->timer_handler) (OPL->timer_handler)(OPL->TimerParam,c,OPL->TimerBase * OPL->T[c]);
+	return OPL->status>>7;
+}
+
+
+#define MAX_OPL_CHIPS 2
+
+
+#if (BUILD_YM3812)
+
+void ym3812_clock_changed(void *chip, uint32_t clock, uint32_t rate)
+{
+	OPL_clock_changed((FM_OPL *)chip, clock, rate);
+}
+
+void * ym3812_init(device_t *device, uint32_t clock, uint32_t rate)
+{
+	/* emulator create */
+	FM_OPL *YM3812 = OPLCreate(device,clock,rate,OPL_TYPE_YM3812);
+	if (YM3812)
+	{
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+		OPL_save_state(YM3812, device);
+#endif
+		ym3812_reset_chip(YM3812);
+	}
+	return YM3812;
+}
+
+void ym3812_shutdown(void *chip)
+{
+	FM_OPL *YM3812 = (FM_OPL *)chip;
+
+	/* emulator shutdown */
+	OPLDestroy(YM3812);
+}
+void ym3812_reset_chip(void *chip)
+{
+	FM_OPL *YM3812 = (FM_OPL *)chip;
+	YM3812->ResetChip();
+}
+
+int ym3812_write(void *chip, int a, int v)
+{
+	FM_OPL *YM3812 = (FM_OPL *)chip;
+	return OPLWrite(YM3812, a, v);
+}
+
+unsigned char ym3812_read(void *chip, int a)
+{
+	FM_OPL *YM3812 = (FM_OPL *)chip;
+	/* YM3812 always returns bit2 and bit1 in HIGH state */
+	return OPLRead(YM3812, a) | 0x06 ;
+}
+int ym3812_timer_over(void *chip, int c)
+{
+	FM_OPL *YM3812 = (FM_OPL *)chip;
+	return OPLTimerOver(YM3812, c);
+}
+
+void ym3812_set_timer_handler(void *chip, OPL_TIMERHANDLER timer_handler, device_t *device)
+{
+	FM_OPL *YM3812 = (FM_OPL *)chip;
+	OPLSetTimerHandler(YM3812, timer_handler, device);
+}
+void ym3812_set_irq_handler(void *chip,OPL_IRQHANDLER IRQHandler,device_t *device)
+{
+	FM_OPL *YM3812 = (FM_OPL *)chip;
+	OPLSetIRQHandler(YM3812, IRQHandler, device);
+}
+void ym3812_set_update_handler(void *chip,OPL_UPDATEHANDLER UpdateHandler,device_t *device)
+{
+	FM_OPL *YM3812 = (FM_OPL *)chip;
+	OPLSetUpdateHandler(YM3812, UpdateHandler, device);
+}
+
+
+/*
+** Generate samples for one of the YM3812's
+**
+** 'which' is the virtual YM3812 number
+** '*buffer' is the output buffer pointer
+** 'length' is the number of samples that should be generated
+*/
+void ym3812_update_one(void *chip, OPLSAMPLE *buffer, int length)
+{
+	FM_OPL      *OPL = (FM_OPL *)chip;
+	uint8_t       rhythm = OPL->rhythm&0x20;
+	OPLSAMPLE   *buf = buffer;
+	int i;
+
+	for( i=0; i < length ; i++ )
+	{
+		int lt;
+
+		OPL->output[0] = 0;
+
+		OPL->advance_lfo();
+
+		/* FM part */
+		OPL->CALC_CH(OPL->P_CH[0]);
+		OPL->CALC_CH(OPL->P_CH[1]);
+		OPL->CALC_CH(OPL->P_CH[2]);
+		OPL->CALC_CH(OPL->P_CH[3]);
+		OPL->CALC_CH(OPL->P_CH[4]);
+		OPL->CALC_CH(OPL->P_CH[5]);
+
+		if(!rhythm)
+		{
+			OPL->CALC_CH(OPL->P_CH[6]);
+			OPL->CALC_CH(OPL->P_CH[7]);
+			OPL->CALC_CH(OPL->P_CH[8]);
+		}
+		else        /* Rhythm part */
+		{
+			OPL->CALC_RH();
+		}
+
+		lt = OPL->output[0];
+
+		lt >>= FINAL_SH;
+
+		/* limit check */
+		lt = limit( lt , MAXOUT, MINOUT );
+
+		#ifdef SAVE_SAMPLE
+		if (which==0)
+		{
+			SAVE_ALL_CHANNELS
+		}
+		#endif
+
+		/* store to sound buffer */
+		buf[i] = lt;
+
+		OPL->advance();
+	}
+
+}
+#endif /* BUILD_YM3812 */
+
+
+
+#if (BUILD_YM3526)
+
+void ym3526_clock_changed(void *chip, uint32_t clock, uint32_t rate)
+{
+	OPL_clock_changed((FM_OPL *)chip, clock, rate);
+}
+
+void *ym3526_init(device_t *device, uint32_t clock, uint32_t rate)
+{
+	/* emulator create */
+	FM_OPL *YM3526 = OPLCreate(device,clock,rate,OPL_TYPE_YM3526);
+	if (YM3526)
+	{
+		OPL_save_state(YM3526, device);
+		ym3526_reset_chip(YM3526);
+	}
+	return YM3526;
+}
+
+void ym3526_shutdown(void *chip)
+{
+	FM_OPL *YM3526 = (FM_OPL *)chip;
+	/* emulator shutdown */
+	OPLDestroy(YM3526);
+}
+void ym3526_reset_chip(void *chip)
+{
+	FM_OPL *YM3526 = (FM_OPL *)chip;
+	YM3526->ResetChip();
+}
+
+int ym3526_write(void *chip, int a, int v)
+{
+	FM_OPL *YM3526 = (FM_OPL *)chip;
+	return OPLWrite(YM3526, a, v);
+}
+
+unsigned char ym3526_read(void *chip, int a)
+{
+	FM_OPL *YM3526 = (FM_OPL *)chip;
+	/* YM3526 always returns bit2 and bit1 in HIGH state */
+	return OPLRead(YM3526, a) | 0x06 ;
+}
+int ym3526_timer_over(void *chip, int c)
+{
+	FM_OPL *YM3526 = (FM_OPL *)chip;
+	return OPLTimerOver(YM3526, c);
+}
+
+void ym3526_set_timer_handler(void *chip, OPL_TIMERHANDLER timer_handler, device_t *device)
+{
+	FM_OPL *YM3526 = (FM_OPL *)chip;
+	OPLSetTimerHandler(YM3526, timer_handler, device);
+}
+void ym3526_set_irq_handler(void *chip,OPL_IRQHANDLER IRQHandler,device_t *device)
+{
+	FM_OPL *YM3526 = (FM_OPL *)chip;
+	OPLSetIRQHandler(YM3526, IRQHandler, device);
+}
+void ym3526_set_update_handler(void *chip,OPL_UPDATEHANDLER UpdateHandler,device_t *device)
+{
+	FM_OPL *YM3526 = (FM_OPL *)chip;
+	OPLSetUpdateHandler(YM3526, UpdateHandler, device);
+}
+
+
+/*
+** Generate samples for one of the YM3526's
+**
+** 'which' is the virtual YM3526 number
+** '*buffer' is the output buffer pointer
+** 'length' is the number of samples that should be generated
+*/
+void ym3526_update_one(void *chip, OPLSAMPLE *buffer, int length)
+{
+	FM_OPL      *OPL = (FM_OPL *)chip;
+	uint8_t       rhythm = OPL->rhythm&0x20;
+	OPLSAMPLE   *buf = buffer;
+	int i;
+
+	for( i=0; i < length ; i++ )
+	{
+		int lt;
+
+		OPL->output[0] = 0;
+
+		OPL->advance_lfo();
+
+		/* FM part */
+		OPL->CALC_CH(OPL->P_CH[0]);
+		OPL->CALC_CH(OPL->P_CH[1]);
+		OPL->CALC_CH(OPL->P_CH[2]);
+		OPL->CALC_CH(OPL->P_CH[3]);
+		OPL->CALC_CH(OPL->P_CH[4]);
+		OPL->CALC_CH(OPL->P_CH[5]);
+
+		if(!rhythm)
+		{
+			OPL->CALC_CH(OPL->P_CH[6]);
+			OPL->CALC_CH(OPL->P_CH[7]);
+			OPL->CALC_CH(OPL->P_CH[8]);
+		}
+		else        /* Rhythm part */
+		{
+			OPL->CALC_RH();
+		}
+
+		lt = OPL->output[0];
+
+		lt >>= FINAL_SH;
+
+		/* limit check */
+		lt = limit( lt , MAXOUT, MINOUT );
+
+		#ifdef SAVE_SAMPLE
+		if (which==0)
+		{
+			SAVE_ALL_CHANNELS
+		}
+		#endif
+
+		/* store to sound buffer */
+		buf[i] = lt;
+
+		OPL->advance();
+	}
+
+}
+#endif /* BUILD_YM3526 */
+
+
+
+
+#if BUILD_Y8950
+
+static void Y8950_deltat_status_set(void *chip, uint8_t changebits)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	Y8950->STATUS_SET(changebits);
+}
+static void Y8950_deltat_status_reset(void *chip, uint8_t changebits)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	Y8950->STATUS_RESET(changebits);
+}
+
+void *y8950_init(device_t *device, uint32_t clock, uint32_t rate)
+{
+	/* emulator create */
+	FM_OPL *Y8950 = OPLCreate(device,clock,rate,OPL_TYPE_Y8950);
+	if (Y8950)
+	{
+		Y8950->deltat->status_set_handler = Y8950_deltat_status_set;
+		Y8950->deltat->status_reset_handler = Y8950_deltat_status_reset;
+		Y8950->deltat->status_change_which_chip = Y8950;
+		Y8950->deltat->status_change_EOS_bit = 0x10;        /* status flag: set bit4 on End Of Sample */
+		Y8950->deltat->status_change_BRDY_bit = 0x08;   /* status flag: set bit3 on BRDY (End Of: ADPCM analysis/synthesis, memory reading/writing) */
+
+		/*Y8950->deltat->write_time = 10.0 / clock;*/       /* a single byte write takes 10 cycles of main clock */
+		/*Y8950->deltat->read_time  = 8.0 / clock;*/        /* a single byte read takes 8 cycles of main clock */
+		/* reset */
+		OPL_save_state(Y8950, device);
+		y8950_reset_chip(Y8950);
+	}
+
+	return Y8950;
+}
+
+void y8950_shutdown(void *chip)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	/* emulator shutdown */
+	OPLDestroy(Y8950);
+}
+void y8950_reset_chip(void *chip)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	Y8950->ResetChip();
+}
+
+int y8950_write(void *chip, int a, int v)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	return OPLWrite(Y8950, a, v);
+}
+
+unsigned char y8950_read(void *chip, int a)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	return OPLRead(Y8950, a);
+}
+int y8950_timer_over(void *chip, int c)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	return OPLTimerOver(Y8950, c);
+}
+
+void y8950_set_timer_handler(void *chip, OPL_TIMERHANDLER timer_handler, device_t *device)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	OPLSetTimerHandler(Y8950, timer_handler, device);
+}
+void y8950_set_irq_handler(void *chip,OPL_IRQHANDLER IRQHandler,device_t *device)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	OPLSetIRQHandler(Y8950, IRQHandler, device);
+}
+void y8950_set_update_handler(void *chip,OPL_UPDATEHANDLER UpdateHandler,device_t *device)
+{
+	FM_OPL *Y8950 = (FM_OPL *)chip;
+	OPLSetUpdateHandler(Y8950, UpdateHandler, device);
+}
+
+void y8950_set_delta_t_memory(void *chip, void * deltat_mem_ptr, int deltat_mem_size )
+{
+	FM_OPL      *OPL = (FM_OPL *)chip;
+	OPL->deltat->memory = (uint8_t *)(deltat_mem_ptr);
+	OPL->deltat->memory_size = deltat_mem_size;
+}
+
+/*
+** Generate samples for one of the Y8950's
+**
+** 'which' is the virtual Y8950 number
+** '*buffer' is the output buffer pointer
+** 'length' is the number of samples that should be generated
+*/
+void y8950_update_one(void *chip, OPLSAMPLE *buffer, int length)
+{
+	int i;
+	FM_OPL      *OPL = (FM_OPL *)chip;
+	uint8_t       rhythm  = OPL->rhythm&0x20;
+	YM_DELTAT   *DELTAT = OPL->deltat;
+	OPLSAMPLE   *buf    = buffer;
+
+	for( i=0; i < length ; i++ )
+	{
+		int lt;
+
+		OPL->output[0] = 0;
+		OPL->output_deltat[0] = 0;
+
+		OPL->advance_lfo();
+
+		/* deltaT ADPCM */
+		if( DELTAT->portstate&0x80 )
+			DELTAT->ADPCM_CALC();
+
+		/* FM part */
+		OPL->CALC_CH(OPL->P_CH[0]);
+		OPL->CALC_CH(OPL->P_CH[1]);
+		OPL->CALC_CH(OPL->P_CH[2]);
+		OPL->CALC_CH(OPL->P_CH[3]);
+		OPL->CALC_CH(OPL->P_CH[4]);
+		OPL->CALC_CH(OPL->P_CH[5]);
+
+		if(!rhythm)
+		{
+			OPL->CALC_CH(OPL->P_CH[6]);
+			OPL->CALC_CH(OPL->P_CH[7]);
+			OPL->CALC_CH(OPL->P_CH[8]);
+		}
+		else        /* Rhythm part */
+		{
+			OPL->CALC_RH();
+		}
+
+		lt = OPL->output[0] + (OPL->output_deltat[0]>>11);
+
+		lt >>= FINAL_SH;
+
+		/* limit check */
+		lt = limit( lt , MAXOUT, MINOUT );
+
+		#ifdef SAVE_SAMPLE
+		if (which==0)
+		{
+			SAVE_ALL_CHANNELS
+		}
+		#endif
+
+		/* store to sound buffer */
+		buf[i] = lt;
+
+		OPL->advance();
+	}
+
+}
+
+void y8950_set_port_handler(void *chip,OPL_PORTHANDLER_W PortHandler_w,OPL_PORTHANDLER_R PortHandler_r,device_t *device)
+{
+	FM_OPL      *OPL = (FM_OPL *)chip;
+	OPL->porthandler_w = PortHandler_w;
+	OPL->porthandler_r = PortHandler_r;
+	OPL->port_param = device;
+}
+
+void y8950_set_keyboard_handler(void *chip,OPL_PORTHANDLER_W KeyboardHandler_w,OPL_PORTHANDLER_R KeyboardHandler_r,device_t *device)
+{
+	FM_OPL      *OPL = (FM_OPL *)chip;
+	OPL->keyboardhandler_w = KeyboardHandler_w;
+	OPL->keyboardhandler_r = KeyboardHandler_r;
+	OPL->keyboard_param = device;
+}
+
+#endif

--- a/audio/softsynth/opl/mame/sound/fmopl.h
+++ b/audio/softsynth/opl/mame/sound/fmopl.h
@@ -1,0 +1,114 @@
+// license:GPL-2.0+
+// copyright-holders:Jarek Burczynski,Tatsuyuki Satoh
+#ifndef MAME_SOUND_FMOPL_H
+#define MAME_SOUND_FMOPL_H
+
+#pragma once
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+#include <stdint.h>
+#else
+#include "../fake-emu.h"
+#endif
+
+/* --- select emulation chips --- */
+#define BUILD_YM3812 (1)
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+#define BUILD_YM3526 (1)
+#define BUILD_Y8950  (1)
+#endif
+
+/* select output bits size of output : 8 or 16 */
+#define OPL_SAMPLE_BITS 16
+
+typedef stream_sample_t OPLSAMPLE;
+/*
+#if (OPL_SAMPLE_BITS==16)
+typedef int16_t OPLSAMPLE;
+#endif
+#if (OPL_SAMPLE_BITS==8)
+typedef int8_t OPLSAMPLE;
+#endif
+*/
+
+typedef void (*OPL_TIMERHANDLER)(device_t *device,int timer,const attotime &period);
+typedef void (*OPL_IRQHANDLER)(device_t *device,int irq);
+typedef void (*OPL_UPDATEHANDLER)(device_t *device,int min_interval_us);
+typedef void (*OPL_PORTHANDLER_W)(device_t *device,unsigned char data);
+typedef unsigned char (*OPL_PORTHANDLER_R)(device_t *device);
+
+
+#if BUILD_YM3812
+
+void *ym3812_init(device_t *device, uint32_t clock, uint32_t rate);
+void ym3812_clock_changed(void *chip, uint32_t clock, uint32_t rate);
+void ym3812_shutdown(void *chip);
+void ym3812_reset_chip(void *chip);
+int  ym3812_write(void *chip, int a, int v);
+unsigned char ym3812_read(void *chip, int a);
+int  ym3812_timer_over(void *chip, int c);
+void ym3812_update_one(void *chip, OPLSAMPLE *buffer, int length);
+
+void ym3812_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, device_t *device);
+void ym3812_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, device_t *device);
+void ym3812_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, device_t *device);
+
+#endif /* BUILD_YM3812 */
+
+
+#if BUILD_YM3526
+
+/*
+** Initialize YM3526 emulator(s).
+**
+** 'num' is the number of virtual YM3526's to allocate
+** 'clock' is the chip clock in Hz
+** 'rate' is sampling rate
+*/
+void *ym3526_init(device_t *device, uint32_t clock, uint32_t rate);
+void ym3526_clock_changed(void *chip, uint32_t clock, uint32_t rate);
+/* shutdown the YM3526 emulators*/
+void ym3526_shutdown(void *chip);
+void ym3526_reset_chip(void *chip);
+int  ym3526_write(void *chip, int a, int v);
+unsigned char ym3526_read(void *chip, int a);
+int  ym3526_timer_over(void *chip, int c);
+/*
+** Generate samples for one of the YM3526's
+**
+** 'which' is the virtual YM3526 number
+** '*buffer' is the output buffer pointer
+** 'length' is the number of samples that should be generated
+*/
+void ym3526_update_one(void *chip, OPLSAMPLE *buffer, int length);
+
+void ym3526_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, device_t *device);
+void ym3526_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, device_t *device);
+void ym3526_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, device_t *device);
+
+#endif /* BUILD_YM3526 */
+
+
+#if BUILD_Y8950
+
+/* Y8950 port handlers */
+void y8950_set_port_handler(void *chip, OPL_PORTHANDLER_W PortHandler_w, OPL_PORTHANDLER_R PortHandler_r, device_t *device);
+void y8950_set_keyboard_handler(void *chip, OPL_PORTHANDLER_W KeyboardHandler_w, OPL_PORTHANDLER_R KeyboardHandler_r, device_t *device);
+void y8950_set_delta_t_memory(void *chip, void * deltat_mem_ptr, int deltat_mem_size );
+
+void * y8950_init(device_t *device, uint32_t clock, uint32_t rate);
+void y8950_shutdown(void *chip);
+void y8950_reset_chip(void *chip);
+int  y8950_write(void *chip, int a, int v);
+unsigned char y8950_read (void *chip, int a);
+int  y8950_timer_over(void *chip, int c);
+void y8950_update_one(void *chip, OPLSAMPLE *buffer, int length);
+
+void y8950_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, device_t *device);
+void y8950_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, device_t *device);
+void y8950_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, device_t *device);
+
+#endif /* BUILD_Y8950 */
+
+
+#endif // MAME_SOUND_FMOPL_H

--- a/audio/softsynth/opl/mame/sound/ymdeltat.h
+++ b/audio/softsynth/opl/mame/sound/ymdeltat.h
@@ -1,0 +1,95 @@
+// license:GPL-2.0+
+// copyright-holders:Jarek Burczynski
+#ifndef MAME_SOUND_YMDELTAT_H
+#define MAME_SOUND_YMDELTAT_H
+
+#pragma once
+#ifndef SCUMMVM_USE_ORIGINAL_MAME_CODE
+struct device_t;
+#include <stdint.h>
+#if __cplusplus < 201103L
+#define constexpr const
+#endif
+#endif
+
+typedef void (*STATUS_CHANGE_HANDLER)(void *chip, uint8_t status_bits);
+
+
+/* DELTA-T (adpcm type B) struct */
+struct YM_DELTAT {     /* AT: rearranged and tightened structure */
+	static constexpr int EMULATION_MODE_NORMAL = 0;
+	static constexpr int EMULATION_MODE_YM2610 = 1;
+
+	uint8_t   *memory;
+	int32_t   *output_pointer;/* pointer of output pointers   */
+	int32_t   *pan;           /* pan : &output_pointer[pan]   */
+	double  freqbase;
+#if 0
+	double  write_time;     /* Y8950: 10 cycles of main clock; YM2608: 20 cycles of main clock */
+	double  read_time;      /* Y8950: 8 cycles of main clock;  YM2608: 18 cycles of main clock */
+#endif
+	uint32_t  memory_size;
+	int     output_range;
+	uint32_t  now_addr;       /* current address      */
+	uint32_t  now_step;       /* correct step         */
+	uint32_t  step;           /* step                 */
+	uint32_t  start;          /* start address        */
+	uint32_t  limit;          /* limit address        */
+	uint32_t  end;            /* end address          */
+	uint32_t  delta;          /* delta scale          */
+	int32_t   volume;         /* current volume       */
+	int32_t   acc;            /* shift Measurement value*/
+	int32_t   adpcmd;         /* next Forecast        */
+	int32_t   adpcml;         /* current value        */
+	int32_t   prev_acc;       /* leveling value       */
+	uint8_t   now_data;       /* current rom data     */
+	uint8_t   CPU_data;       /* current data from reg 08 */
+	uint8_t   portstate;      /* port status          */
+	uint8_t   control2;       /* control reg: SAMPLE, DA/AD, RAM TYPE (x8bit / x1bit), ROM/RAM */
+	uint8_t   portshift;      /* address bits shift-left:
+	                        ** 8 for YM2610,
+	                        ** 5 for Y8950 and YM2608 */
+
+	uint8_t   DRAMportshift;  /* address bits shift-right:
+	                        ** 0 for ROM and x8bit DRAMs,
+	                        ** 3 for x1 DRAMs */
+
+	uint8_t   memread;        /* needed for reading/writing external memory */
+
+	/* handlers and parameters for the status flags support */
+	STATUS_CHANGE_HANDLER   status_set_handler;
+	STATUS_CHANGE_HANDLER   status_reset_handler;
+
+	/* note that different chips have these flags on different
+	** bits of the status register
+	*/
+	void *  status_change_which_chip;   /* this chip id */
+	uint8_t   status_change_EOS_bit;      /* 1 on End Of Sample (record/playback/cycle time of AD/DA converting has passed)*/
+	uint8_t   status_change_BRDY_bit;     /* 1 after recording 2 datas (2x4bits) or after reading/writing 1 data */
+	uint8_t   status_change_ZERO_bit;     /* 1 if silence lasts for more than 290 milliseconds on ADPCM recording */
+
+	/* neither Y8950 nor YM2608 can generate IRQ when PCMBSY bit changes, so instead of above,
+	** the statusflag gets ORed with PCM_BSY (below) (on each read of statusflag of Y8950 and YM2608)
+	*/
+	uint8_t   PCM_BSY;        /* 1 when ADPCM is playing; Y8950/YM2608 only */
+
+	uint8_t   reg[16];        /* adpcm registers      */
+	uint8_t   emulation_mode; /* which chip we're emulating */
+	device_t *device;
+
+	/*void BRDY_callback();*/
+
+	uint8_t ADPCM_Read();
+	void ADPCM_Write(int r, int v);
+	void ADPCM_Reset(int panidx, int mode, device_t *dev);
+	void ADPCM_CALC();
+
+	void postload(uint8_t *regs);
+	void savestate(device_t *device);
+};
+
+#if !defined(SCUMMVM_USE_ORIGINAL_MAME_CODE) && __cplusplus < 201103L
+#undef constexpr
+#endif
+
+#endif // MAME_SOUND_YMDELTAT_H

--- a/audio/softsynth/opl/mame/sound/ymf262.cpp
+++ b/audio/softsynth/opl/mame/sound/ymf262.cpp
@@ -1,0 +1,2838 @@
+// license:GPL-2.0+
+// copyright-holders:Jarek Burczynski
+/*
+**
+** File: ymf262.c - software implementation of YMF262
+**                  FM sound generator type OPL3
+**
+** Copyright Jarek Burczynski
+**
+** Version 0.2
+**
+
+Revision History:
+
+03-03-2003: initial release
+ - thanks to Olivier Galibert and Chris Hardy for YMF262 and YAC512 chips
+ - thanks to Stiletto for the datasheets
+
+   Features as listed in 4MF262A6 data sheet:
+    1. Registers are compatible with YM3812 (OPL2) FM sound source.
+    2. Up to six sounds can be used as four-operator melody sounds for variety.
+    3. 18 simultaneous melody sounds, or 15 melody sounds with 5 rhythm sounds (with two operators).
+    4. 6 four-operator melody sounds and 6 two-operator melody sounds, or 6 four-operator melody
+       sounds, 3 two-operator melody sounds and 5 rhythm sounds (with four operators).
+    5. 8 selectable waveforms.
+    6. 4-channel sound output.
+    7. YMF262 compabile DAC (YAC512) is available.
+    8. LFO for vibrato and tremolo effedts.
+    9. 2 programable timers.
+   10. Shorter register access time compared with YM3812.
+   11. 5V single supply silicon gate CMOS process.
+   12. 24 Pin SOP Package (YMF262-M), 48 Pin SQFP Package (YMF262-S).
+
+
+differences between OPL2 and OPL3 not documented in Yamaha datahasheets:
+- sinus table is a little different: the negative part is off by one...
+
+- in order to enable selection of four different waveforms on OPL2
+  one must set bit 5 in register 0x01(test).
+  on OPL3 this bit is ignored and 4-waveform select works *always*.
+  (Don't confuse this with OPL3's 8-waveform select.)
+
+- Envelope Generator: all 15 x rates take zero time on OPL3
+  (on OPL2 15 0 and 15 1 rates take some time while 15 2 and 15 3 rates
+  take zero time)
+
+- channel calculations: output of operator 1 is in perfect sync with
+  output of operator 2 on OPL3; on OPL and OPL2 output of operator 1
+  is always delayed by one sample compared to output of operator 2
+
+
+differences between OPL2 and OPL3 shown in datasheets:
+- YMF262 does not support CSM mode
+
+
+*/
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+#include "emu.h"
+#else
+#include "../fake-emu.h"
+#endif
+#include "ymf262.h"
+
+
+/* output final shift */
+#if (OPL3_SAMPLE_BITS==16)
+	#define FINAL_SH    (0)
+	#define MAXOUT      (+32767)
+	#define MINOUT      (-32768)
+#else
+	#define FINAL_SH    (8)
+	#define MAXOUT      (+127)
+	#define MINOUT      (-128)
+#endif
+
+
+#define FREQ_SH         16  /* 16.16 fixed point (frequency calculations) */
+#define EG_SH           16  /* 16.16 fixed point (EG timing)              */
+#define LFO_SH          24  /*  8.24 fixed point (LFO calculations)       */
+#define TIMER_SH        16  /* 16.16 fixed point (timers calculations)    */
+
+#define FREQ_MASK       ((1<<FREQ_SH)-1)
+
+/* envelope output entries */
+#define ENV_BITS        10
+#define ENV_LEN         (1<<ENV_BITS)
+#define ENV_STEP        (128.0/ENV_LEN)
+
+#define MAX_ATT_INDEX   ((1<<(ENV_BITS-1))-1) /*511*/
+#define MIN_ATT_INDEX   (0)
+
+/* sinwave entries */
+#define SIN_BITS        10
+#define SIN_LEN         (1<<SIN_BITS)
+#define SIN_MASK        (SIN_LEN-1)
+
+#define TL_RES_LEN      (256)   /* 8 bits addressing (real chip) */
+
+
+
+/* register number to channel number , slot offset */
+#define SLOT1 0
+#define SLOT2 1
+
+/* Envelope Generator phases */
+
+#define EG_ATT          4
+#define EG_DEC          3
+#define EG_SUS          2
+#define EG_REL          1
+#define EG_OFF          0
+
+/* Routing connections between slots */
+#define CONN_NULL       0
+#define CONN_CHAN0      1
+#define CONN_PHASEMOD   19
+#define CONN_PHASEMOD2  20
+
+namespace {
+
+/* save output as raw 16-bit sample */
+
+/*#define SAVE_SAMPLE*/
+
+#ifdef SAVE_SAMPLE
+static FILE *sample[1];
+	#if 1   /*save to MONO file */
+		#define SAVE_ALL_CHANNELS \
+		{   signed int pom = a; \
+			fputc((unsigned short)pom&0xff,sample[0]); \
+			fputc(((unsigned short)pom>>8)&0xff,sample[0]); \
+		}
+	#else   /*save to STEREO file */
+		#define SAVE_ALL_CHANNELS \
+		{   signed int pom = a; \
+			fputc((unsigned short)pom&0xff,sample[0]); \
+			fputc(((unsigned short)pom>>8)&0xff,sample[0]); \
+			pom = b; \
+			fputc((unsigned short)pom&0xff,sample[0]); \
+			fputc(((unsigned short)pom>>8)&0xff,sample[0]); \
+		}
+	#endif
+#endif
+
+
+#define OPL3_TYPE_YMF262 (0)    /* 36 operators, 8 waveforms */
+
+
+struct OPL3_SLOT
+{
+	uint32_t  ar;         /* attack rate: AR<<2           */
+	uint32_t  dr;         /* decay rate:  DR<<2           */
+	uint32_t  rr;         /* release rate:RR<<2           */
+	uint8_t   KSR;        /* key scale rate               */
+	uint8_t   ksl;        /* keyscale level               */
+	uint8_t   ksr;        /* key scale rate: kcode>>KSR   */
+	uint8_t   mul;        /* multiple: mul_tab[ML]        */
+
+	/* Phase Generator */
+	uint32_t  Cnt;        /* frequency counter            */
+	uint32_t  Incr;       /* frequency counter step       */
+	uint8_t   FB;         /* feedback shift value         */
+	uint8_t   conn_enum;  /* slot output route            */
+	int32_t   *connect;   /* slot output pointer          */
+	int32_t   op1_out[2]; /* slot1 output for feedback    */
+	uint8_t   CON;        /* connection (algorithm) type  */
+
+	/* Envelope Generator */
+	uint8_t   eg_type;    /* percussive/non-percussive mode */
+	uint8_t   state;      /* phase type                   */
+	uint32_t  TL;         /* total level: TL << 2         */
+	int32_t   TLL;        /* adjusted now TL              */
+	int32_t   volume;     /* envelope counter             */
+	uint32_t  sl;         /* sustain level: sl_tab[SL]    */
+
+	uint32_t  eg_m_ar;    /* (attack state)               */
+	uint8_t   eg_sh_ar;   /* (attack state)               */
+	uint8_t   eg_sel_ar;  /* (attack state)               */
+	uint32_t  eg_m_dr;    /* (decay state)                */
+	uint8_t   eg_sh_dr;   /* (decay state)                */
+	uint8_t   eg_sel_dr;  /* (decay state)                */
+	uint32_t  eg_m_rr;    /* (release state)              */
+	uint8_t   eg_sh_rr;   /* (release state)              */
+	uint8_t   eg_sel_rr;  /* (release state)              */
+
+	uint32_t  key;        /* 0 = KEY OFF, >0 = KEY ON     */
+
+	/* LFO */
+	uint32_t  AMmask;     /* LFO Amplitude Modulation enable mask */
+	uint8_t   vib;        /* LFO Phase Modulation enable flag (active high)*/
+
+	/* waveform select */
+	uint8_t   waveform_number;
+	unsigned int wavetable;
+
+	//unsigned char reserved[128-84];//speedup: pump up the struct size to power of 2
+	unsigned char reserved[128-100];//speedup: pump up the struct size to power of 2
+
+};
+
+struct OPL3_CH
+{
+	OPL3_SLOT SLOT[2];
+
+	uint32_t  block_fnum; /* block+fnum                   */
+	uint32_t  fc;         /* Freq. Increment base         */
+	uint32_t  ksl_base;   /* KeyScaleLevel Base step      */
+	uint8_t   kcode;      /* key code (for key scaling)   */
+
+	/*
+	   there are 12 2-operator channels which can be combined in pairs
+	   to form six 4-operator channel, they are:
+	    0 and 3,
+	    1 and 4,
+	    2 and 5,
+	    9 and 12,
+	    10 and 13,
+	    11 and 14
+	*/
+	uint8_t   extended;   /* set to 1 if this channel forms up a 4op channel with another channel(only used by first of pair of channels, ie 0,1,2 and 9,10,11) */
+
+	unsigned char reserved[512-272];//speedup:pump up the struct size to power of 2
+
+};
+
+/* OPL3 state */
+struct OPL3
+{
+	OPL3_CH P_CH[18];               /* OPL3 chips have 18 channels  */
+
+	uint32_t  pan[18*4];              /* channels output masks (0xffffffff = enable); 4 masks per one channel */
+	uint32_t  pan_ctrl_value[18];     /* output control values 1 per one channel (1 value contains 4 masks) */
+
+	signed int chanout[18];
+	signed int phase_modulation;        /* phase modulation input (SLOT 2) */
+	signed int phase_modulation2;   /* phase modulation input (SLOT 3 in 4 operator channels) */
+
+	uint32_t  eg_cnt;                 /* global envelope generator counter    */
+	uint32_t  eg_timer;               /* global envelope generator counter works at frequency = chipclock/288 (288=8*36) */
+	uint32_t  eg_timer_add;           /* step of eg_timer                     */
+	uint32_t  eg_timer_overflow;      /* envelope generator timer overflows every 1 sample (on real chip) */
+
+	uint32_t  fn_tab[1024];           /* fnumber->increment counter   */
+
+	/* LFO */
+	uint32_t  LFO_AM;
+	int32_t   LFO_PM;
+
+	uint8_t   lfo_am_depth;
+	uint8_t   lfo_pm_depth_range;
+	uint32_t  lfo_am_cnt;
+	uint32_t  lfo_am_inc;
+	uint32_t  lfo_pm_cnt;
+	uint32_t  lfo_pm_inc;
+
+	uint32_t  noise_rng;              /* 23 bit noise shift register  */
+	uint32_t  noise_p;                /* current noise 'phase'        */
+	uint32_t  noise_f;                /* current noise period         */
+
+	uint8_t   OPL3_mode;              /* OPL3 extension enable flag   */
+
+	uint8_t   rhythm;                 /* Rhythm mode                  */
+
+	int     T[2];                   /* timer counters               */
+	uint8_t   st[2];                  /* timer enable                 */
+
+	uint32_t  address;                /* address register             */
+	uint8_t   status;                 /* status flag                  */
+	uint8_t   statusmask;             /* status mask                  */
+
+	uint8_t   nts;                    /* NTS (note select)            */
+
+	/* external event callback handlers */
+	OPL3_TIMERHANDLER timer_handler;
+	device_t *TimerParam;
+	OPL3_IRQHANDLER IRQHandler;
+	device_t *IRQParam;
+	OPL3_UPDATEHANDLER UpdateHandler;
+	device_t *UpdateParam;
+
+	uint8_t type;                     /* chip type                    */
+	int clock;                      /* master clock  (Hz)           */
+	int rate;                       /* sampling rate (Hz)           */
+	double freqbase;                /* frequency base               */
+	attotime TimerBase;         /* Timer base time (==sampling time)*/
+	device_t *device;
+
+#ifndef SCUMMVM_USE_ORIGINAL_MAME_CODE
+// shadow warning
+#define device ddevice
+#endif
+
+	/* Optional handlers */
+	void SetTimerHandler(OPL3_TIMERHANDLER handler, device_t *device)
+	{
+		timer_handler = handler;
+		TimerParam = device;
+	}
+	void SetIRQHandler(OPL3_IRQHANDLER handler, device_t *device)
+	{
+		IRQHandler = handler;
+		IRQParam = device;
+	}
+	void SetUpdateHandler(OPL3_UPDATEHANDLER handler, device_t *device)
+	{
+		UpdateHandler = handler;
+		UpdateParam = device;
+	}
+
+#ifndef SCUMMVM_USE_ORIGINAL_MAME_CODE
+#undef device
+#endif
+
+};
+
+} // anonymous namespace
+
+
+
+/* mapping of register number (offset) to slot number used by the emulator */
+static const int slot_array[32]=
+{
+		0, 2, 4, 1, 3, 5,-1,-1,
+		6, 8,10, 7, 9,11,-1,-1,
+	12,14,16,13,15,17,-1,-1,
+	-1,-1,-1,-1,-1,-1,-1,-1
+};
+
+/* key scale level */
+/* table is 3dB/octave , DV converts this into 6dB/octave */
+/* 0.1875 is bit 0 weight of the envelope counter (volume) expressed in the 'decibel' scale */
+#define DV (0.1875/2.0)
+static const double ksl_tab[8*16]=
+{
+	/* OCT 0 */
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+	/* OCT 1 */
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 0.750/DV, 1.125/DV, 1.500/DV,
+		1.875/DV, 2.250/DV, 2.625/DV, 3.000/DV,
+	/* OCT 2 */
+		0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+		0.000/DV, 1.125/DV, 1.875/DV, 2.625/DV,
+		3.000/DV, 3.750/DV, 4.125/DV, 4.500/DV,
+		4.875/DV, 5.250/DV, 5.625/DV, 6.000/DV,
+	/* OCT 3 */
+		0.000/DV, 0.000/DV, 0.000/DV, 1.875/DV,
+		3.000/DV, 4.125/DV, 4.875/DV, 5.625/DV,
+		6.000/DV, 6.750/DV, 7.125/DV, 7.500/DV,
+		7.875/DV, 8.250/DV, 8.625/DV, 9.000/DV,
+	/* OCT 4 */
+		0.000/DV, 0.000/DV, 3.000/DV, 4.875/DV,
+		6.000/DV, 7.125/DV, 7.875/DV, 8.625/DV,
+		9.000/DV, 9.750/DV,10.125/DV,10.500/DV,
+		10.875/DV,11.250/DV,11.625/DV,12.000/DV,
+	/* OCT 5 */
+		0.000/DV, 3.000/DV, 6.000/DV, 7.875/DV,
+		9.000/DV,10.125/DV,10.875/DV,11.625/DV,
+		12.000/DV,12.750/DV,13.125/DV,13.500/DV,
+		13.875/DV,14.250/DV,14.625/DV,15.000/DV,
+	/* OCT 6 */
+		0.000/DV, 6.000/DV, 9.000/DV,10.875/DV,
+		12.000/DV,13.125/DV,13.875/DV,14.625/DV,
+		15.000/DV,15.750/DV,16.125/DV,16.500/DV,
+		16.875/DV,17.250/DV,17.625/DV,18.000/DV,
+	/* OCT 7 */
+		0.000/DV, 9.000/DV,12.000/DV,13.875/DV,
+		15.000/DV,16.125/DV,16.875/DV,17.625/DV,
+		18.000/DV,18.750/DV,19.125/DV,19.500/DV,
+		19.875/DV,20.250/DV,20.625/DV,21.000/DV
+};
+#undef DV
+
+/* 0 / 3.0 / 1.5 / 6.0 dB/OCT */
+static const uint32_t ksl_shift[4] = { 31, 1, 2, 0 };
+
+
+/* sustain level table (3dB per step) */
+/* 0 - 15: 0, 3, 6, 9,12,15,18,21,24,27,30,33,36,39,42,93 (dB)*/
+#define SC(db) (uint32_t) ( db * (2.0/ENV_STEP) )
+static const uint32_t sl_tab[16]={
+	SC( 0),SC( 1),SC( 2),SC(3 ),SC(4 ),SC(5 ),SC(6 ),SC( 7),
+	SC( 8),SC( 9),SC(10),SC(11),SC(12),SC(13),SC(14),SC(31)
+};
+#undef SC
+
+
+#define RATE_STEPS (8)
+static const unsigned char eg_inc[15*RATE_STEPS]={
+/*cycle:0 1  2 3  4 5  6 7*/
+
+/* 0 */ 0,1, 0,1, 0,1, 0,1, /* rates 00..12 0 (increment by 0 or 1) */
+/* 1 */ 0,1, 0,1, 1,1, 0,1, /* rates 00..12 1 */
+/* 2 */ 0,1, 1,1, 0,1, 1,1, /* rates 00..12 2 */
+/* 3 */ 0,1, 1,1, 1,1, 1,1, /* rates 00..12 3 */
+
+/* 4 */ 1,1, 1,1, 1,1, 1,1, /* rate 13 0 (increment by 1) */
+/* 5 */ 1,1, 1,2, 1,1, 1,2, /* rate 13 1 */
+/* 6 */ 1,2, 1,2, 1,2, 1,2, /* rate 13 2 */
+/* 7 */ 1,2, 2,2, 1,2, 2,2, /* rate 13 3 */
+
+/* 8 */ 2,2, 2,2, 2,2, 2,2, /* rate 14 0 (increment by 2) */
+/* 9 */ 2,2, 2,4, 2,2, 2,4, /* rate 14 1 */
+/*10 */ 2,4, 2,4, 2,4, 2,4, /* rate 14 2 */
+/*11 */ 2,4, 4,4, 2,4, 4,4, /* rate 14 3 */
+
+/*12 */ 4,4, 4,4, 4,4, 4,4, /* rates 15 0, 15 1, 15 2, 15 3 for decay */
+/*13 */ 8,8, 8,8, 8,8, 8,8, /* rates 15 0, 15 1, 15 2, 15 3 for attack (zero time) */
+/*14 */ 0,0, 0,0, 0,0, 0,0, /* infinity rates for attack and decay(s) */
+};
+
+
+#define O(a) (a*RATE_STEPS)
+
+/* note that there is no O(13) in this table - it's directly in the code */
+static const unsigned char eg_rate_select[16+64+16]={   /* Envelope Generator rates (16 + 64 rates + 16 RKS) */
+/* 16 infinite time rates */
+O(14),O(14),O(14),O(14),O(14),O(14),O(14),O(14),
+O(14),O(14),O(14),O(14),O(14),O(14),O(14),O(14),
+
+/* rates 00-12 */
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+O( 0),O( 1),O( 2),O( 3),
+
+/* rate 13 */
+O( 4),O( 5),O( 6),O( 7),
+
+/* rate 14 */
+O( 8),O( 9),O(10),O(11),
+
+/* rate 15 */
+O(12),O(12),O(12),O(12),
+
+/* 16 dummy rates (same as 15 3) */
+O(12),O(12),O(12),O(12),O(12),O(12),O(12),O(12),
+O(12),O(12),O(12),O(12),O(12),O(12),O(12),O(12),
+
+};
+#undef O
+
+/*rate  0,    1,    2,    3,   4,   5,   6,  7,  8,  9,  10, 11, 12, 13, 14, 15 */
+/*shift 12,   11,   10,   9,   8,   7,   6,  5,  4,  3,  2,  1,  0,  0,  0,  0  */
+/*mask  4095, 2047, 1023, 511, 255, 127, 63, 31, 15, 7,  3,  1,  0,  0,  0,  0  */
+
+#define O(a) (a*1)
+static const unsigned char eg_rate_shift[16+64+16]={    /* Envelope Generator counter shifts (16 + 64 rates + 16 RKS) */
+/* 16 infinite time rates */
+O(0),O(0),O(0),O(0),O(0),O(0),O(0),O(0),
+O(0),O(0),O(0),O(0),O(0),O(0),O(0),O(0),
+
+/* rates 00-12 */
+O(12),O(12),O(12),O(12),
+O(11),O(11),O(11),O(11),
+O(10),O(10),O(10),O(10),
+O( 9),O( 9),O( 9),O( 9),
+O( 8),O( 8),O( 8),O( 8),
+O( 7),O( 7),O( 7),O( 7),
+O( 6),O( 6),O( 6),O( 6),
+O( 5),O( 5),O( 5),O( 5),
+O( 4),O( 4),O( 4),O( 4),
+O( 3),O( 3),O( 3),O( 3),
+O( 2),O( 2),O( 2),O( 2),
+O( 1),O( 1),O( 1),O( 1),
+O( 0),O( 0),O( 0),O( 0),
+
+/* rate 13 */
+O( 0),O( 0),O( 0),O( 0),
+
+/* rate 14 */
+O( 0),O( 0),O( 0),O( 0),
+
+/* rate 15 */
+O( 0),O( 0),O( 0),O( 0),
+
+/* 16 dummy rates (same as 15 3) */
+O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),
+O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),O( 0),
+
+};
+#undef O
+
+
+/* multiple table */
+#define ML 2
+static const uint8_t mul_tab[16]= {
+/* 1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,10,12,12,15,15 */
+	ML/2, 1*ML, 2*ML, 3*ML, 4*ML, 5*ML, 6*ML, 7*ML,
+	8*ML, 9*ML,10*ML,10*ML,12*ML,12*ML,15*ML,15*ML
+};
+#undef ML
+
+/*  TL_TAB_LEN is calculated as:
+
+*   (12+1)=13 - sinus amplitude bits     (Y axis)
+*   additional 1: to compensate for calculations of negative part of waveform
+*   (if we don't add it then the greatest possible _negative_ value would be -2
+*   and we really need -1 for waveform #7)
+*   2  - sinus sign bit           (Y axis)
+*   TL_RES_LEN - sinus resolution (X axis)
+*/
+#define TL_TAB_LEN (13*2*TL_RES_LEN)
+static signed int tl_tab[TL_TAB_LEN];
+
+#define ENV_QUIET       (TL_TAB_LEN>>4)
+
+/* sin waveform table in 'decibel' scale */
+/* there are eight waveforms on OPL3 chips */
+static unsigned int sin_tab[SIN_LEN * 8];
+
+
+/* LFO Amplitude Modulation table (verified on real YM3812)
+   27 output levels (triangle waveform); 1 level takes one of: 192, 256 or 448 samples
+
+   Length: 210 elements.
+
+    Each of the elements has to be repeated
+    exactly 64 times (on 64 consecutive samples).
+    The whole table takes: 64 * 210 = 13440 samples.
+
+    When AM = 1 data is used directly
+    When AM = 0 data is divided by 4 before being used (losing precision is important)
+*/
+
+#define LFO_AM_TAB_ELEMENTS 210
+
+static const uint8_t lfo_am_table[LFO_AM_TAB_ELEMENTS] = {
+0,0,0,0,0,0,0,
+1,1,1,1,
+2,2,2,2,
+3,3,3,3,
+4,4,4,4,
+5,5,5,5,
+6,6,6,6,
+7,7,7,7,
+8,8,8,8,
+9,9,9,9,
+10,10,10,10,
+11,11,11,11,
+12,12,12,12,
+13,13,13,13,
+14,14,14,14,
+15,15,15,15,
+16,16,16,16,
+17,17,17,17,
+18,18,18,18,
+19,19,19,19,
+20,20,20,20,
+21,21,21,21,
+22,22,22,22,
+23,23,23,23,
+24,24,24,24,
+25,25,25,25,
+26,26,26,
+25,25,25,25,
+24,24,24,24,
+23,23,23,23,
+22,22,22,22,
+21,21,21,21,
+20,20,20,20,
+19,19,19,19,
+18,18,18,18,
+17,17,17,17,
+16,16,16,16,
+15,15,15,15,
+14,14,14,14,
+13,13,13,13,
+12,12,12,12,
+11,11,11,11,
+10,10,10,10,
+9,9,9,9,
+8,8,8,8,
+7,7,7,7,
+6,6,6,6,
+5,5,5,5,
+4,4,4,4,
+3,3,3,3,
+2,2,2,2,
+1,1,1,1
+};
+
+/* LFO Phase Modulation table (verified on real YM3812) */
+static const int8_t lfo_pm_table[8*8*2] = {
+/* FNUM2/FNUM = 00 0xxxxxxx (0x0000) */
+0, 0, 0, 0, 0, 0, 0, 0, /*LFO PM depth = 0*/
+0, 0, 0, 0, 0, 0, 0, 0, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 00 1xxxxxxx (0x0080) */
+0, 0, 0, 0, 0, 0, 0, 0, /*LFO PM depth = 0*/
+1, 0, 0, 0,-1, 0, 0, 0, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 01 0xxxxxxx (0x0100) */
+1, 0, 0, 0,-1, 0, 0, 0, /*LFO PM depth = 0*/
+2, 1, 0,-1,-2,-1, 0, 1, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 01 1xxxxxxx (0x0180) */
+1, 0, 0, 0,-1, 0, 0, 0, /*LFO PM depth = 0*/
+3, 1, 0,-1,-3,-1, 0, 1, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 10 0xxxxxxx (0x0200) */
+2, 1, 0,-1,-2,-1, 0, 1, /*LFO PM depth = 0*/
+4, 2, 0,-2,-4,-2, 0, 2, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 10 1xxxxxxx (0x0280) */
+2, 1, 0,-1,-2,-1, 0, 1, /*LFO PM depth = 0*/
+5, 2, 0,-2,-5,-2, 0, 2, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 11 0xxxxxxx (0x0300) */
+3, 1, 0,-1,-3,-1, 0, 1, /*LFO PM depth = 0*/
+6, 3, 0,-3,-6,-3, 0, 3, /*LFO PM depth = 1*/
+
+/* FNUM2/FNUM = 11 1xxxxxxx (0x0380) */
+3, 1, 0,-1,-3,-1, 0, 1, /*LFO PM depth = 0*/
+7, 3, 0,-3,-7,-3, 0, 3  /*LFO PM depth = 1*/
+};
+
+
+/* lock level of common table */
+static int num_lock = 0;
+
+/* work table */
+#define SLOT7_1 (&chip->P_CH[7].SLOT[SLOT1])
+#define SLOT7_2 (&chip->P_CH[7].SLOT[SLOT2])
+#define SLOT8_1 (&chip->P_CH[8].SLOT[SLOT1])
+#define SLOT8_2 (&chip->P_CH[8].SLOT[SLOT2])
+
+
+static inline void OPL3_SLOT_CONNECT(OPL3 *chip, OPL3_SLOT *slot) {
+	if (slot->conn_enum == CONN_NULL) {
+		slot->connect = nullptr;
+	} else if (slot->conn_enum >= CONN_CHAN0 && slot->conn_enum < CONN_PHASEMOD) {
+		slot->connect = &chip->chanout[slot->conn_enum];
+	} else if (slot->conn_enum == CONN_PHASEMOD) {
+		slot->connect = &chip->phase_modulation;
+	} else if (slot->conn_enum == CONN_PHASEMOD2) {
+		slot->connect = &chip->phase_modulation2;
+	}
+}
+
+static inline int limit( int val, int max, int min ) {
+	if ( val > max )
+		val = max;
+	else if ( val < min )
+		val = min;
+
+	return val;
+}
+
+
+/* status set and IRQ handling */
+static inline void OPL3_STATUS_SET(OPL3 *chip,int flag)
+{
+	/* set status flag masking out disabled IRQs */
+	chip->status |= (flag & chip->statusmask);
+	if(!(chip->status & 0x80))
+	{
+		if(chip->status & 0x7f)
+		{   /* IRQ on */
+			chip->status |= 0x80;
+			/* callback user interrupt handler (IRQ is OFF to ON) */
+			if(chip->IRQHandler) (chip->IRQHandler)(chip->IRQParam,1);
+		}
+	}
+}
+
+/* status reset and IRQ handling */
+static inline void OPL3_STATUS_RESET(OPL3 *chip,int flag)
+{
+	/* reset status flag */
+	chip->status &= ~flag;
+	if(chip->status & 0x80)
+	{
+		if (!(chip->status & 0x7f))
+		{
+			chip->status &= 0x7f;
+			/* callback user interrupt handler (IRQ is ON to OFF) */
+			if(chip->IRQHandler) (chip->IRQHandler)(chip->IRQParam,0);
+		}
+	}
+}
+
+/* IRQ mask set */
+static inline void OPL3_STATUSMASK_SET(OPL3 *chip,int flag)
+{
+	chip->statusmask = flag;
+	/* IRQ handling check */
+	OPL3_STATUS_SET(chip,0);
+	OPL3_STATUS_RESET(chip,0);
+}
+
+
+/* advance LFO to next sample */
+static inline void advance_lfo(OPL3 *chip)
+{
+	uint8_t tmp;
+
+	/* LFO */
+	chip->lfo_am_cnt += chip->lfo_am_inc;
+	if (chip->lfo_am_cnt >= ((uint32_t)LFO_AM_TAB_ELEMENTS<<LFO_SH) ) /* lfo_am_table is 210 elements long */
+		chip->lfo_am_cnt -= ((uint32_t)LFO_AM_TAB_ELEMENTS<<LFO_SH);
+
+	tmp = lfo_am_table[ chip->lfo_am_cnt >> LFO_SH ];
+
+	if (chip->lfo_am_depth)
+		chip->LFO_AM = tmp;
+	else
+		chip->LFO_AM = tmp>>2;
+
+	chip->lfo_pm_cnt += chip->lfo_pm_inc;
+	chip->LFO_PM = ((chip->lfo_pm_cnt>>LFO_SH) & 7) | chip->lfo_pm_depth_range;
+}
+
+/* advance to next sample */
+static inline void advance(OPL3 *chip)
+{
+	OPL3_CH *CH;
+	OPL3_SLOT *op;
+	int i;
+
+	chip->eg_timer += chip->eg_timer_add;
+
+	while (chip->eg_timer >= chip->eg_timer_overflow)
+	{
+		chip->eg_timer -= chip->eg_timer_overflow;
+
+		chip->eg_cnt++;
+
+		for (i=0; i<9*2*2; i++)
+		{
+			CH  = &chip->P_CH[i/2];
+			op  = &CH->SLOT[i&1];
+#if 1
+			/* Envelope Generator */
+			switch(op->state)
+			{
+			case EG_ATT:    /* attack phase */
+//              if ( !(chip->eg_cnt & ((1<<op->eg_sh_ar)-1) ) )
+				if ( !(chip->eg_cnt & op->eg_m_ar) )
+				{
+					op->volume += (~op->volume *
+												(eg_inc[op->eg_sel_ar + ((chip->eg_cnt>>op->eg_sh_ar)&7)])
+												) >>3;
+
+					if (op->volume <= MIN_ATT_INDEX)
+					{
+						op->volume = MIN_ATT_INDEX;
+						op->state = EG_DEC;
+					}
+
+				}
+			break;
+
+			case EG_DEC:    /* decay phase */
+//              if ( !(chip->eg_cnt & ((1<<op->eg_sh_dr)-1) ) )
+				if ( !(chip->eg_cnt & op->eg_m_dr) )
+				{
+					op->volume += eg_inc[op->eg_sel_dr + ((chip->eg_cnt>>op->eg_sh_dr)&7)];
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+					if ( op->volume >= op->sl )
+#else
+					if ( op->volume >= int32_t(op->sl) )
+#endif
+						op->state = EG_SUS;
+
+				}
+			break;
+
+			case EG_SUS:    /* sustain phase */
+
+				/* this is important behaviour:
+				one can change percusive/non-percussive modes on the fly and
+				the chip will remain in sustain phase - verified on real YM3812 */
+
+				if(op->eg_type)     /* non-percussive mode */
+				{
+									/* do nothing */
+				}
+				else                /* percussive mode */
+				{
+					/* during sustain phase chip adds Release Rate (in percussive mode) */
+//                  if ( !(chip->eg_cnt & ((1<<op->eg_sh_rr)-1) ) )
+					if ( !(chip->eg_cnt & op->eg_m_rr) )
+					{
+						op->volume += eg_inc[op->eg_sel_rr + ((chip->eg_cnt>>op->eg_sh_rr)&7)];
+
+						if ( op->volume >= MAX_ATT_INDEX )
+							op->volume = MAX_ATT_INDEX;
+					}
+					/* else do nothing in sustain phase */
+				}
+			break;
+
+			case EG_REL:    /* release phase */
+//              if ( !(chip->eg_cnt & ((1<<op->eg_sh_rr)-1) ) )
+				if ( !(chip->eg_cnt & op->eg_m_rr) )
+				{
+					op->volume += eg_inc[op->eg_sel_rr + ((chip->eg_cnt>>op->eg_sh_rr)&7)];
+
+					if ( op->volume >= MAX_ATT_INDEX )
+					{
+						op->volume = MAX_ATT_INDEX;
+						op->state = EG_OFF;
+					}
+
+				}
+			break;
+
+			default:
+			break;
+			}
+#endif
+		}
+	}
+
+	for (i=0; i<9*2*2; i++)
+	{
+		CH  = &chip->P_CH[i/2];
+		op  = &CH->SLOT[i&1];
+
+		/* Phase Generator */
+		if(op->vib)
+		{
+			uint8_t block;
+			unsigned int block_fnum = CH->block_fnum;
+
+			unsigned int fnum_lfo   = (block_fnum&0x0380) >> 7;
+
+			signed int lfo_fn_table_index_offset = lfo_pm_table[chip->LFO_PM + 16*fnum_lfo ];
+
+			if (lfo_fn_table_index_offset)  /* LFO phase modulation active */
+			{
+				block_fnum += lfo_fn_table_index_offset;
+				block = (block_fnum&0x1c00) >> 10;
+				op->Cnt += (chip->fn_tab[block_fnum&0x03ff] >> (7-block)) * op->mul;
+			}
+			else    /* LFO phase modulation  = zero */
+			{
+				op->Cnt += op->Incr;
+			}
+		}
+		else    /* LFO phase modulation disabled for this operator */
+		{
+			op->Cnt += op->Incr;
+		}
+	}
+
+	/*  The Noise Generator of the YM3812 is 23-bit shift register.
+	*   Period is equal to 2^23-2 samples.
+	*   Register works at sampling frequency of the chip, so output
+	*   can change on every sample.
+	*
+	*   Output of the register and input to the bit 22 is:
+	*   bit0 XOR bit14 XOR bit15 XOR bit22
+	*
+	*   Simply use bit 22 as the noise output.
+	*/
+
+	chip->noise_p += chip->noise_f;
+	i = chip->noise_p >> FREQ_SH;       /* number of events (shifts of the shift register) */
+	chip->noise_p &= FREQ_MASK;
+	while (i)
+	{
+		/*
+		uint32_t j;
+		j = ( (chip->noise_rng) ^ (chip->noise_rng>>14) ^ (chip->noise_rng>>15) ^ (chip->noise_rng>>22) ) & 1;
+		chip->noise_rng = (j<<22) | (chip->noise_rng>>1);
+		*/
+
+		/*
+		    Instead of doing all the logic operations above, we
+		    use a trick here (and use bit 0 as the noise output).
+		    The difference is only that the noise bit changes one
+		    step ahead. This doesn't matter since we don't know
+		    what is real state of the noise_rng after the reset.
+		*/
+
+		if (chip->noise_rng & 1) chip->noise_rng ^= 0x800302;
+		chip->noise_rng >>= 1;
+
+		i--;
+	}
+}
+
+
+static inline signed int op_calc(uint32_t phase, unsigned int env, signed int pm, unsigned int wave_tab)
+{
+	uint32_t p;
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+	p = (env<<4) + sin_tab[wave_tab + ((((signed int)((phase & ~FREQ_MASK) + (pm<<16))) >> FREQ_SH ) & SIN_MASK) ];
+#else
+	p = (env<<4) + sin_tab[wave_tab + ((((signed int)((phase & ~FREQ_MASK) + (pm*(1<<16)))) >> FREQ_SH ) & SIN_MASK) ];
+#endif
+
+	if (p >= TL_TAB_LEN)
+		return 0;
+	return tl_tab[p];
+}
+
+static inline signed int op_calc1(uint32_t phase, unsigned int env, signed int pm, unsigned int wave_tab)
+{
+	uint32_t p;
+
+	p = (env<<4) + sin_tab[wave_tab + ((((signed int)((phase & ~FREQ_MASK) + pm))>>FREQ_SH) & SIN_MASK)];
+
+	if (p >= TL_TAB_LEN)
+		return 0;
+	return tl_tab[p];
+}
+
+
+#define volume_calc(OP) ((OP)->TLL + ((uint32_t)(OP)->volume) + (chip->LFO_AM & (OP)->AMmask))
+
+/* calculate output of a standard 2 operator channel
+ (or 1st part of a 4-op channel) */
+static inline void chan_calc( OPL3 *chip, OPL3_CH *CH )
+{
+	OPL3_SLOT *SLOT;
+	unsigned int env;
+	signed int out;
+
+	chip->phase_modulation = 0;
+	chip->phase_modulation2= 0;
+
+	/* SLOT 1 */
+	SLOT = &CH->SLOT[SLOT1];
+	env  = volume_calc(SLOT);
+	out  = SLOT->op1_out[0] + SLOT->op1_out[1];
+	SLOT->op1_out[0] = SLOT->op1_out[1];
+	SLOT->op1_out[1] = 0;
+	if (env < ENV_QUIET)
+	{
+		if (!SLOT->FB)
+			out = 0;
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+		SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out<<SLOT->FB), SLOT->wavetable );
+#else
+		SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out*(1<<SLOT->FB)), SLOT->wavetable );
+#endif
+	}
+	if (SLOT->connect) {
+		*SLOT->connect += SLOT->op1_out[1];
+	}
+//logerror("out0=%5i vol0=%4i ", SLOT->op1_out[1], env );
+
+	/* SLOT 2 */
+	SLOT++;
+	env = volume_calc(SLOT);
+	if ((env < ENV_QUIET) && SLOT->connect)
+		*SLOT->connect += op_calc(SLOT->Cnt, env, chip->phase_modulation, SLOT->wavetable);
+
+//logerror("out1=%5i vol1=%4i\n", op_calc(SLOT->Cnt, env, chip->phase_modulation, SLOT->wavetable), env );
+
+}
+
+/* calculate output of a 2nd part of 4-op channel */
+static inline void chan_calc_ext( OPL3 *chip, OPL3_CH *CH )
+{
+	OPL3_SLOT *SLOT;
+	unsigned int env;
+
+	chip->phase_modulation = 0;
+
+	/* SLOT 1 */
+	SLOT = &CH->SLOT[SLOT1];
+	env  = volume_calc(SLOT);
+	if (env < ENV_QUIET && SLOT->connect)
+		*SLOT->connect += op_calc(SLOT->Cnt, env, chip->phase_modulation2, SLOT->wavetable );
+
+	/* SLOT 2 */
+	SLOT++;
+	env = volume_calc(SLOT);
+	if (env < ENV_QUIET && SLOT->connect)
+		*SLOT->connect += op_calc(SLOT->Cnt, env, chip->phase_modulation, SLOT->wavetable);
+
+}
+
+/*
+    operators used in the rhythm sounds generation process:
+
+    Envelope Generator:
+
+channel  operator  register number   Bass  High  Snare Tom  Top
+/ slot   number    TL ARDR SLRR Wave Drum  Hat   Drum  Tom  Cymbal
+ 6 / 0   12        50  70   90   f0  +
+ 6 / 1   15        53  73   93   f3  +
+ 7 / 0   13        51  71   91   f1        +
+ 7 / 1   16        54  74   94   f4              +
+ 8 / 0   14        52  72   92   f2                    +
+ 8 / 1   17        55  75   95   f5                          +
+
+    Phase Generator:
+
+channel  operator  register number   Bass  High  Snare Tom  Top
+/ slot   number    MULTIPLE          Drum  Hat   Drum  Tom  Cymbal
+ 6 / 0   12        30                +
+ 6 / 1   15        33                +
+ 7 / 0   13        31                      +     +           +
+ 7 / 1   16        34                -----  n o t  u s e d -----
+ 8 / 0   14        32                                  +
+ 8 / 1   17        35                      +                 +
+
+channel  operator  register number   Bass  High  Snare Tom  Top
+number   number    BLK/FNUM2 FNUM    Drum  Hat   Drum  Tom  Cymbal
+   6     12,15     B6        A6      +
+
+   7     13,16     B7        A7            +     +           +
+
+   8     14,17     B8        A8            +           +     +
+
+*/
+
+/* calculate rhythm */
+
+static inline void chan_calc_rhythm( OPL3 *chip, OPL3_CH *CH, unsigned int noise )
+{
+	OPL3_SLOT *SLOT;
+	signed int *chanout = chip->chanout;
+	signed int out;
+	unsigned int env;
+
+
+	/* Bass Drum (verified on real YM3812):
+	  - depends on the channel 6 'connect' register:
+	      when connect = 0 it works the same as in normal (non-rhythm) mode (op1->op2->out)
+	      when connect = 1 _only_ operator 2 is present on output (op2->out), operator 1 is ignored
+	  - output sample always is multiplied by 2
+	*/
+
+	chip->phase_modulation = 0;
+
+	/* SLOT 1 */
+	SLOT = &CH[6].SLOT[SLOT1];
+	env = volume_calc(SLOT);
+
+	out = SLOT->op1_out[0] + SLOT->op1_out[1];
+	SLOT->op1_out[0] = SLOT->op1_out[1];
+
+	if (!SLOT->CON)
+		chip->phase_modulation = SLOT->op1_out[0];
+	//else ignore output of operator 1
+
+	SLOT->op1_out[1] = 0;
+	if( env < ENV_QUIET )
+	{
+		if (!SLOT->FB)
+			out = 0;
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+		SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out<<SLOT->FB), SLOT->wavetable );
+#else
+		SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out*(1<<SLOT->FB)), SLOT->wavetable );
+#endif
+	}
+
+	/* SLOT 2 */
+	SLOT++;
+	env = volume_calc(SLOT);
+	if( env < ENV_QUIET )
+		chanout[6] += op_calc(SLOT->Cnt, env, chip->phase_modulation, SLOT->wavetable) * 2;
+
+
+	/* Phase generation is based on: */
+	// HH  (13) channel 7->slot 1 combined with channel 8->slot 2 (same combination as TOP CYMBAL but different output phases)
+	// SD  (16) channel 7->slot 1
+	// TOM (14) channel 8->slot 1
+	// TOP (17) channel 7->slot 1 combined with channel 8->slot 2 (same combination as HIGH HAT but different output phases)
+
+	/* Envelope generation based on: */
+	// HH  channel 7->slot1
+	// SD  channel 7->slot2
+	// TOM channel 8->slot1
+	// TOP channel 8->slot2
+
+
+	/* The following formulas can be well optimized.
+	   I leave them in direct form for now (in case I've missed something).
+	*/
+
+	/* High Hat (verified on real YM3812) */
+	env = volume_calc(SLOT7_1);
+	if( env < ENV_QUIET )
+	{
+		/* high hat phase generation:
+		    phase = d0 or 234 (based on frequency only)
+		    phase = 34 or 2d0 (based on noise)
+		*/
+
+		/* base frequency derived from operator 1 in channel 7 */
+		unsigned char bit7 = ((SLOT7_1->Cnt>>FREQ_SH)>>7)&1;
+		unsigned char bit3 = ((SLOT7_1->Cnt>>FREQ_SH)>>3)&1;
+		unsigned char bit2 = ((SLOT7_1->Cnt>>FREQ_SH)>>2)&1;
+
+		unsigned char res1 = (bit2 ^ bit7) | bit3;
+
+		/* when res1 = 0 phase = 0x000 | 0xd0; */
+		/* when res1 = 1 phase = 0x200 | (0xd0>>2); */
+		uint32_t phase = res1 ? (0x200|(0xd0>>2)) : 0xd0;
+
+		/* enable gate based on frequency of operator 2 in channel 8 */
+		unsigned char bit5e= ((SLOT8_2->Cnt>>FREQ_SH)>>5)&1;
+		unsigned char bit3e= ((SLOT8_2->Cnt>>FREQ_SH)>>3)&1;
+
+		unsigned char res2 = (bit3e ^ bit5e);
+
+		/* when res2 = 0 pass the phase from calculation above (res1); */
+		/* when res2 = 1 phase = 0x200 | (0xd0>>2); */
+		if (res2)
+			phase = (0x200|(0xd0>>2));
+
+
+		/* when phase & 0x200 is set and noise=1 then phase = 0x200|0xd0 */
+		/* when phase & 0x200 is set and noise=0 then phase = 0x200|(0xd0>>2), ie no change */
+		if (phase&0x200)
+		{
+			if (noise)
+				phase = 0x200|0xd0;
+		}
+		else
+		/* when phase & 0x200 is clear and noise=1 then phase = 0xd0>>2 */
+		/* when phase & 0x200 is clear and noise=0 then phase = 0xd0, ie no change */
+		{
+			if (noise)
+				phase = 0xd0>>2;
+		}
+
+		chanout[7] += op_calc(phase<<FREQ_SH, env, 0, SLOT7_1->wavetable) * 2;
+	}
+
+	/* Snare Drum (verified on real YM3812) */
+	env = volume_calc(SLOT7_2);
+	if( env < ENV_QUIET )
+	{
+		/* base frequency derived from operator 1 in channel 7 */
+		unsigned char bit8 = ((SLOT7_1->Cnt>>FREQ_SH)>>8)&1;
+
+		/* when bit8 = 0 phase = 0x100; */
+		/* when bit8 = 1 phase = 0x200; */
+		uint32_t phase = bit8 ? 0x200 : 0x100;
+
+		/* Noise bit XOR'es phase by 0x100 */
+		/* when noisebit = 0 pass the phase from calculation above */
+		/* when noisebit = 1 phase ^= 0x100; */
+		/* in other words: phase ^= (noisebit<<8); */
+		if (noise)
+			phase ^= 0x100;
+
+		chanout[7] += op_calc(phase<<FREQ_SH, env, 0, SLOT7_2->wavetable) * 2;
+	}
+
+	/* Tom Tom (verified on real YM3812) */
+	env = volume_calc(SLOT8_1);
+	if( env < ENV_QUIET )
+		chanout[8] += op_calc(SLOT8_1->Cnt, env, 0, SLOT8_1->wavetable) * 2;
+
+	/* Top Cymbal (verified on real YM3812) */
+	env = volume_calc(SLOT8_2);
+	if( env < ENV_QUIET )
+	{
+		/* base frequency derived from operator 1 in channel 7 */
+		unsigned char bit7 = ((SLOT7_1->Cnt>>FREQ_SH)>>7)&1;
+		unsigned char bit3 = ((SLOT7_1->Cnt>>FREQ_SH)>>3)&1;
+		unsigned char bit2 = ((SLOT7_1->Cnt>>FREQ_SH)>>2)&1;
+
+		unsigned char res1 = (bit2 ^ bit7) | bit3;
+
+		/* when res1 = 0 phase = 0x000 | 0x100; */
+		/* when res1 = 1 phase = 0x200 | 0x100; */
+		uint32_t phase = res1 ? 0x300 : 0x100;
+
+		/* enable gate based on frequency of operator 2 in channel 8 */
+		unsigned char bit5e= ((SLOT8_2->Cnt>>FREQ_SH)>>5)&1;
+		unsigned char bit3e= ((SLOT8_2->Cnt>>FREQ_SH)>>3)&1;
+
+		unsigned char res2 = (bit3e ^ bit5e);
+		/* when res2 = 0 pass the phase from calculation above (res1); */
+		/* when res2 = 1 phase = 0x200 | 0x100; */
+		if (res2)
+			phase = 0x300;
+
+		chanout[8] += op_calc(phase<<FREQ_SH, env, 0, SLOT8_2->wavetable) * 2;
+	}
+
+}
+
+
+/* generic table initialize */
+static int init_tables(void)
+{
+	signed int i,x;
+	signed int n;
+	double o,m;
+
+
+	for (x=0; x<TL_RES_LEN; x++)
+	{
+		m = (1<<16) / pow(2, (x+1) * (ENV_STEP/4.0) / 8.0);
+		m = floor(m);
+
+		/* we never reach (1<<16) here due to the (x+1) */
+		/* result fits within 16 bits at maximum */
+
+		n = (int)m;     /* 16 bits here */
+		n >>= 4;        /* 12 bits here */
+		if (n&1)        /* round to nearest */
+			n = (n>>1)+1;
+		else
+			n = n>>1;
+						/* 11 bits here (rounded) */
+		n <<= 1;        /* 12 bits here (as in real chip) */
+		tl_tab[ x*2 + 0 ] = n;
+		tl_tab[ x*2 + 1 ] = ~tl_tab[ x*2 + 0 ]; /* this *is* different from OPL2 (verified on real YMF262) */
+
+		for (i=1; i<13; i++)
+		{
+			tl_tab[ x*2+0 + i*2*TL_RES_LEN ] =  tl_tab[ x*2+0 ]>>i;
+			tl_tab[ x*2+1 + i*2*TL_RES_LEN ] = ~tl_tab[ x*2+0 + i*2*TL_RES_LEN ];  /* this *is* different from OPL2 (verified on real YMF262) */
+		}
+	#if 0
+			logerror("tl %04i", x*2);
+			for (i=0; i<13; i++)
+				logerror(", [%02i] %5i", i*2, tl_tab[ x*2 +0 + i*2*TL_RES_LEN ] ); /* positive */
+			logerror("\n");
+
+			logerror("tl %04i", x*2);
+			for (i=0; i<13; i++)
+				logerror(", [%02i] %5i", i*2, tl_tab[ x*2 +1 + i*2*TL_RES_LEN ] ); /* negative */
+			logerror("\n");
+	#endif
+	}
+
+	for (i=0; i<SIN_LEN; i++)
+	{
+		/* non-standard sinus */
+		m = sin( ((i*2)+1) * M_PI / SIN_LEN ); /* checked against the real chip */
+
+		/* we never reach zero here due to ((i*2)+1) */
+
+		if (m>0.0)
+			o = 8*log(1.0/m)/log(2.0);  /* convert to 'decibels' */
+		else
+			o = 8*log(-1.0/m)/log(2.0); /* convert to 'decibels' */
+
+		o = o / (ENV_STEP/4);
+
+		n = (int)(2.0*o);
+		if (n&1)                        /* round to nearest */
+			n = (n>>1)+1;
+		else
+			n = n>>1;
+
+		sin_tab[ i ] = n*2 + (m>=0.0? 0: 1 );
+
+		/*logerror("YMF262.C: sin [%4i (hex=%03x)]= %4i (tl_tab value=%5i)\n", i, i, sin_tab[i], tl_tab[sin_tab[i]] );*/
+	}
+
+	for (i=0; i<SIN_LEN; i++)
+	{
+		/* these 'pictures' represent _two_ cycles */
+		/* waveform 1:  __      __     */
+		/*             /  \____/  \____*/
+		/* output only first half of the sinus waveform (positive one) */
+
+		if (i & (1<<(SIN_BITS-1)) )
+			sin_tab[1*SIN_LEN+i] = TL_TAB_LEN;
+		else
+			sin_tab[1*SIN_LEN+i] = sin_tab[i];
+
+		/* waveform 2:  __  __  __  __ */
+		/*             /  \/  \/  \/  \*/
+		/* abs(sin) */
+
+		sin_tab[2*SIN_LEN+i] = sin_tab[i & (SIN_MASK>>1) ];
+
+		/* waveform 3:  _   _   _   _  */
+		/*             / |_/ |_/ |_/ |_*/
+		/* abs(output only first quarter of the sinus waveform) */
+
+		if (i & (1<<(SIN_BITS-2)) )
+			sin_tab[3*SIN_LEN+i] = TL_TAB_LEN;
+		else
+			sin_tab[3*SIN_LEN+i] = sin_tab[i & (SIN_MASK>>2)];
+
+		/* waveform 4:                 */
+		/*             /\  ____/\  ____*/
+		/*               \/      \/    */
+		/* output whole sinus waveform in half the cycle(step=2) and output 0 on the other half of cycle */
+
+		if (i & (1<<(SIN_BITS-1)) )
+			sin_tab[4*SIN_LEN+i] = TL_TAB_LEN;
+		else
+			sin_tab[4*SIN_LEN+i] = sin_tab[i*2];
+
+		/* waveform 5:                 */
+		/*             /\/\____/\/\____*/
+		/*                             */
+		/* output abs(whole sinus) waveform in half the cycle(step=2) and output 0 on the other half of cycle */
+
+		if (i & (1<<(SIN_BITS-1)) )
+			sin_tab[5*SIN_LEN+i] = TL_TAB_LEN;
+		else
+			sin_tab[5*SIN_LEN+i] = sin_tab[(i*2) & (SIN_MASK>>1) ];
+
+		/* waveform 6: ____    ____    */
+		/*                             */
+		/*                 ____    ____*/
+		/* output maximum in half the cycle and output minimum on the other half of cycle */
+
+		if (i & (1<<(SIN_BITS-1)) )
+			sin_tab[6*SIN_LEN+i] = 1;   /* negative */
+		else
+			sin_tab[6*SIN_LEN+i] = 0;   /* positive */
+
+		/* waveform 7:                 */
+		/*             |\____  |\____  */
+		/*                   \|      \|*/
+		/* output sawtooth waveform    */
+
+		if (i & (1<<(SIN_BITS-1)) )
+			x = ((SIN_LEN-1)-i)*16 + 1; /* negative: from 8177 to 1 */
+		else
+			x = i*16;   /*positive: from 0 to 8176 */
+
+		if (x > TL_TAB_LEN)
+			x = TL_TAB_LEN; /* clip to the allowed range */
+
+		sin_tab[7*SIN_LEN+i] = x;
+
+		//logerror("YMF262.C: sin1[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[1*SIN_LEN+i], tl_tab[sin_tab[1*SIN_LEN+i]] );
+		//logerror("YMF262.C: sin2[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[2*SIN_LEN+i], tl_tab[sin_tab[2*SIN_LEN+i]] );
+		//logerror("YMF262.C: sin3[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[3*SIN_LEN+i], tl_tab[sin_tab[3*SIN_LEN+i]] );
+		//logerror("YMF262.C: sin4[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[4*SIN_LEN+i], tl_tab[sin_tab[4*SIN_LEN+i]] );
+		//logerror("YMF262.C: sin5[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[5*SIN_LEN+i], tl_tab[sin_tab[5*SIN_LEN+i]] );
+		//logerror("YMF262.C: sin6[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[6*SIN_LEN+i], tl_tab[sin_tab[6*SIN_LEN+i]] );
+		//logerror("YMF262.C: sin7[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[7*SIN_LEN+i], tl_tab[sin_tab[7*SIN_LEN+i]] );
+	}
+	/*logerror("YMF262.C: ENV_QUIET= %08x (dec*8=%i)\n", ENV_QUIET, ENV_QUIET*8 );*/
+
+#ifdef SAVE_SAMPLE
+	sample[0]=fopen("sampsum.pcm","wb");
+#endif
+
+	return 1;
+}
+
+static void OPLCloseTable( void )
+{
+#ifdef SAVE_SAMPLE
+	fclose(sample[0]);
+#endif
+}
+
+
+
+static void OPL3_initalize(OPL3 *chip)
+{
+	int i;
+
+	/* frequency base */
+	chip->freqbase  = (chip->rate) ? ((double)chip->clock / (8.0*36)) / chip->rate  : 0;
+#if 0
+	chip->rate = (double)chip->clock / (8.0*36);
+	chip->freqbase  = 1.0;
+#endif
+
+	/* logerror("YMF262: freqbase=%f\n", chip->freqbase); */
+
+	/* Timer base time */
+	chip->TimerBase = attotime::from_hz(chip->clock) * (8*36);
+
+	/* make fnumber -> increment counter table */
+	for( i=0 ; i < 1024 ; i++ )
+	{
+		/* opn phase increment counter = 20bit */
+		chip->fn_tab[i] = (uint32_t)( (double)i * 64 * chip->freqbase * (1<<(FREQ_SH-10)) ); /* -10 because chip works with 10.10 fixed point, while we use 16.16 */
+#if 0
+		logerror("YMF262.C: fn_tab[%4i] = %08x (dec=%8i)\n",
+					i, chip->fn_tab[i]>>6, chip->fn_tab[i]>>6 );
+#endif
+	}
+
+#if 0
+	for( i=0 ; i < 16 ; i++ )
+	{
+		logerror("YMF262.C: sl_tab[%i] = %08x\n",
+			i, sl_tab[i] );
+	}
+	for( i=0 ; i < 8 ; i++ )
+	{
+		int j;
+		logerror("YMF262.C: ksl_tab[oct=%2i] =",i);
+		for (j=0; j<16; j++)
+		{
+			logerror("%08x ", static_cast<uint32_t>(ksl_tab[i*16+j]) );
+		}
+		logerror("\n");
+	}
+#endif
+
+
+	/* Amplitude modulation: 27 output levels (triangle waveform); 1 level takes one of: 192, 256 or 448 samples */
+	/* One entry from LFO_AM_TABLE lasts for 64 samples */
+	chip->lfo_am_inc = (1.0 / 64.0 ) * (1<<LFO_SH) * chip->freqbase;
+
+	/* Vibrato: 8 output levels (triangle waveform); 1 level takes 1024 samples */
+	chip->lfo_pm_inc = (1.0 / 1024.0) * (1<<LFO_SH) * chip->freqbase;
+
+	/*logerror ("chip->lfo_am_inc = %8x ; chip->lfo_pm_inc = %8x\n", chip->lfo_am_inc, chip->lfo_pm_inc);*/
+
+	/* Noise generator: a step takes 1 sample */
+	chip->noise_f = (1.0 / 1.0) * (1<<FREQ_SH) * chip->freqbase;
+
+	chip->eg_timer_add  = (1<<EG_SH)  * chip->freqbase;
+	chip->eg_timer_overflow = ( 1 ) * (1<<EG_SH);
+	/*logerror("YMF262init eg_timer_add=%8x eg_timer_overflow=%8x\n", chip->eg_timer_add, chip->eg_timer_overflow);*/
+
+}
+
+static inline void FM_KEYON(OPL3_SLOT *SLOT, uint32_t key_set)
+{
+	if( !SLOT->key )
+	{
+		/* restart Phase Generator */
+		SLOT->Cnt = 0;
+		/* phase -> Attack */
+		SLOT->state = EG_ATT;
+	}
+	SLOT->key |= key_set;
+}
+
+static inline void FM_KEYOFF(OPL3_SLOT *SLOT, uint32_t key_clr)
+{
+	if( SLOT->key )
+	{
+		SLOT->key &= key_clr;
+
+		if( !SLOT->key )
+		{
+			/* phase -> Release */
+			if (SLOT->state>EG_REL)
+				SLOT->state = EG_REL;
+		}
+	}
+}
+
+/* update phase increment counter of operator (also update the EG rates if necessary) */
+static inline void CALC_FCSLOT(OPL3_CH *CH,OPL3_SLOT *SLOT)
+{
+	int ksr;
+
+	/* (frequency) phase increment counter */
+	SLOT->Incr = CH->fc * SLOT->mul;
+	ksr = CH->kcode >> SLOT->KSR;
+
+	if( SLOT->ksr != ksr )
+	{
+		SLOT->ksr = ksr;
+
+		/* calculate envelope generator rates */
+		if ((SLOT->ar + SLOT->ksr) < 16+60)
+		{
+			SLOT->eg_sh_ar  = eg_rate_shift [SLOT->ar + SLOT->ksr ];
+			SLOT->eg_m_ar   = (1<<SLOT->eg_sh_ar)-1;
+			SLOT->eg_sel_ar = eg_rate_select[SLOT->ar + SLOT->ksr ];
+		}
+		else
+		{
+			SLOT->eg_sh_ar  = 0;
+			SLOT->eg_m_ar   = (1<<SLOT->eg_sh_ar)-1;
+			SLOT->eg_sel_ar = 13*RATE_STEPS;
+		}
+		SLOT->eg_sh_dr  = eg_rate_shift [SLOT->dr + SLOT->ksr ];
+		SLOT->eg_m_dr   = (1<<SLOT->eg_sh_dr)-1;
+		SLOT->eg_sel_dr = eg_rate_select[SLOT->dr + SLOT->ksr ];
+		SLOT->eg_sh_rr  = eg_rate_shift [SLOT->rr + SLOT->ksr ];
+		SLOT->eg_m_rr   = (1<<SLOT->eg_sh_rr)-1;
+		SLOT->eg_sel_rr = eg_rate_select[SLOT->rr + SLOT->ksr ];
+	}
+}
+
+/* set multi,am,vib,EG-TYP,KSR,mul */
+static inline void set_mul(OPL3 *chip,int slot,int v)
+{
+	OPL3_CH   *CH   = &chip->P_CH[slot/2];
+	OPL3_SLOT *SLOT = &CH->SLOT[slot&1];
+
+	SLOT->mul     = mul_tab[v&0x0f];
+	SLOT->KSR     = (v&0x10) ? 0 : 2;
+	SLOT->eg_type = (v&0x20);
+	SLOT->vib     = (v&0x40);
+	SLOT->AMmask  = (v&0x80) ? ~0 : 0;
+
+	if (chip->OPL3_mode & 1)
+	{
+		int chan_no = slot/2;
+
+		/* in OPL3 mode */
+		//DO THIS:
+		//if this is one of the slots of 1st channel forming up a 4-op channel
+		//do normal operation
+		//else normal 2 operator function
+		//OR THIS:
+		//if this is one of the slots of 2nd channel forming up a 4-op channel
+		//update it using channel data of 1st channel of a pair
+		//else normal 2 operator function
+		switch(chan_no)
+		{
+		case 0: case 1: case 2:
+		case 9: case 10: case 11:
+			if (CH->extended)
+			{
+				/* normal */
+				CALC_FCSLOT(CH,SLOT);
+			}
+			else
+			{
+				/* normal */
+				CALC_FCSLOT(CH,SLOT);
+			}
+		break;
+		case 3: case 4: case 5:
+		case 12: case 13: case 14:
+			if ((CH-3)->extended)
+			{
+				/* update this SLOT using frequency data for 1st channel of a pair */
+				CALC_FCSLOT(CH-3,SLOT);
+			}
+			else
+			{
+				/* normal */
+				CALC_FCSLOT(CH,SLOT);
+			}
+		break;
+		default:
+				/* normal */
+				CALC_FCSLOT(CH,SLOT);
+		break;
+		}
+	}
+	else
+	{
+		/* in OPL2 mode */
+		CALC_FCSLOT(CH,SLOT);
+	}
+}
+
+/* set ksl & tl */
+static inline void set_ksl_tl(OPL3 *chip,int slot,int v)
+{
+	OPL3_CH   *CH   = &chip->P_CH[slot/2];
+	OPL3_SLOT *SLOT = &CH->SLOT[slot&1];
+
+	SLOT->ksl = ksl_shift[v >> 6];
+	SLOT->TL  = (v&0x3f)<<(ENV_BITS-1-7); /* 7 bits TL (bit 6 = always 0) */
+
+	if (chip->OPL3_mode & 1)
+	{
+		int chan_no = slot/2;
+
+		/* in OPL3 mode */
+		//DO THIS:
+		//if this is one of the slots of 1st channel forming up a 4-op channel
+		//do normal operation
+		//else normal 2 operator function
+		//OR THIS:
+		//if this is one of the slots of 2nd channel forming up a 4-op channel
+		//update it using channel data of 1st channel of a pair
+		//else normal 2 operator function
+		switch(chan_no)
+		{
+		case 0: case 1: case 2:
+		case 9: case 10: case 11:
+			if (CH->extended)
+			{
+				/* normal */
+				SLOT->TLL = SLOT->TL + (CH->ksl_base>>SLOT->ksl);
+			}
+			else
+			{
+				/* normal */
+				SLOT->TLL = SLOT->TL + (CH->ksl_base>>SLOT->ksl);
+			}
+		break;
+		case 3: case 4: case 5:
+		case 12: case 13: case 14:
+			if ((CH-3)->extended)
+			{
+				/* update this SLOT using frequency data for 1st channel of a pair */
+				SLOT->TLL = SLOT->TL + ((CH-3)->ksl_base>>SLOT->ksl);
+			}
+			else
+			{
+				/* normal */
+				SLOT->TLL = SLOT->TL + (CH->ksl_base>>SLOT->ksl);
+			}
+		break;
+		default:
+				/* normal */
+				SLOT->TLL = SLOT->TL + (CH->ksl_base>>SLOT->ksl);
+		break;
+		}
+	}
+	else
+	{
+		/* in OPL2 mode */
+		SLOT->TLL = SLOT->TL + (CH->ksl_base>>SLOT->ksl);
+	}
+
+}
+
+/* set attack rate & decay rate  */
+static inline void set_ar_dr(OPL3 *chip,int slot,int v)
+{
+	OPL3_CH   *CH   = &chip->P_CH[slot/2];
+	OPL3_SLOT *SLOT = &CH->SLOT[slot&1];
+
+	SLOT->ar = (v>>4)  ? 16 + ((v>>4)  <<2) : 0;
+
+	if ((SLOT->ar + SLOT->ksr) < 16+60) /* verified on real YMF262 - all 15 x rates take "zero" time */
+	{
+		SLOT->eg_sh_ar  = eg_rate_shift [SLOT->ar + SLOT->ksr ];
+		SLOT->eg_m_ar   = (1<<SLOT->eg_sh_ar)-1;
+		SLOT->eg_sel_ar = eg_rate_select[SLOT->ar + SLOT->ksr ];
+	}
+	else
+	{
+		SLOT->eg_sh_ar  = 0;
+		SLOT->eg_m_ar   = (1<<SLOT->eg_sh_ar)-1;
+		SLOT->eg_sel_ar = 13*RATE_STEPS;
+	}
+
+	SLOT->dr    = (v&0x0f)? 16 + ((v&0x0f)<<2) : 0;
+	SLOT->eg_sh_dr  = eg_rate_shift [SLOT->dr + SLOT->ksr ];
+	SLOT->eg_m_dr   = (1<<SLOT->eg_sh_dr)-1;
+	SLOT->eg_sel_dr = eg_rate_select[SLOT->dr + SLOT->ksr ];
+}
+
+/* set sustain level & release rate */
+static inline void set_sl_rr(OPL3 *chip,int slot,int v)
+{
+	OPL3_CH   *CH   = &chip->P_CH[slot/2];
+	OPL3_SLOT *SLOT = &CH->SLOT[slot&1];
+
+	SLOT->sl  = sl_tab[ v>>4 ];
+
+	SLOT->rr  = (v&0x0f)? 16 + ((v&0x0f)<<2) : 0;
+	SLOT->eg_sh_rr  = eg_rate_shift [SLOT->rr + SLOT->ksr ];
+	SLOT->eg_m_rr   = (1<<SLOT->eg_sh_rr)-1;
+	SLOT->eg_sel_rr = eg_rate_select[SLOT->rr + SLOT->ksr ];
+}
+
+
+static void update_channels(OPL3 *chip, OPL3_CH *CH)
+{
+	/* update channel passed as a parameter and a channel at CH+=3; */
+	if (CH->extended)
+	{   /* we've just switched to combined 4 operator mode */
+
+	}
+	else
+	{   /* we've just switched to normal 2 operator mode */
+
+	}
+
+}
+
+/* write a value v to register r on OPL chip */
+static void OPL3WriteReg(OPL3 *chip, int r, int v)
+{
+	OPL3_CH *CH;
+	unsigned int ch_offset = 0;
+	int slot;
+	int block_fnum;
+
+	if(r&0x100)
+	{
+		switch(r)
+		{
+		case 0x101: /* test register */
+			return;
+
+		case 0x104: /* 6 channels enable */
+			{
+				uint8_t prev;
+
+				CH = &chip->P_CH[0];    /* channel 0 */
+				prev = CH->extended;
+				CH->extended = (v>>0) & 1;
+				if(prev != CH->extended)
+					update_channels(chip, CH);
+				CH++;                   /* channel 1 */
+				prev = CH->extended;
+				CH->extended = (v>>1) & 1;
+				if(prev != CH->extended)
+					update_channels(chip, CH);
+				CH++;                   /* channel 2 */
+				prev = CH->extended;
+				CH->extended = (v>>2) & 1;
+				if(prev != CH->extended)
+					update_channels(chip, CH);
+
+
+				CH = &chip->P_CH[9];    /* channel 9 */
+				prev = CH->extended;
+				CH->extended = (v>>3) & 1;
+				if(prev != CH->extended)
+					update_channels(chip, CH);
+				CH++;                   /* channel 10 */
+				prev = CH->extended;
+				CH->extended = (v>>4) & 1;
+				if(prev != CH->extended)
+					update_channels(chip, CH);
+				CH++;                   /* channel 11 */
+				prev = CH->extended;
+				CH->extended = (v>>5) & 1;
+				if(prev != CH->extended)
+					update_channels(chip, CH);
+
+			}
+			return;
+
+		case 0x105: /* OPL3 extensions enable register */
+
+			chip->OPL3_mode = v&0x01;   /* OPL3 mode when bit0=1 otherwise it is OPL2 mode */
+
+			/* following behaviour was tested on real YMF262,
+			switching OPL3/OPL2 modes on the fly:
+			 - does not change the waveform previously selected (unless when ....)
+			 - does not update CH.A, CH.B, CH.C and CH.D output selectors (registers c0-c8) (unless when ....)
+			 - does not disable channels 9-17 on OPL3->OPL2 switch
+			 - does not switch 4 operator channels back to 2 operator channels
+			*/
+
+			return;
+
+		default:
+			if (r < 0x120)
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+				chip->device->logerror("YMF262: write to unknown register (set#2): %03x value=%02x\n",r,v);
+#else
+
+#endif
+		break;
+		}
+
+		ch_offset = 9;  /* register page #2 starts from channel 9 (counting from 0) */
+	}
+
+	/* adjust bus to 8 bits */
+	r &= 0xff;
+	v &= 0xff;
+
+
+	switch(r&0xe0)
+	{
+	case 0x00:  /* 00-1f:control */
+		switch(r&0x1f)
+		{
+		case 0x01:  /* test register */
+		break;
+		case 0x02:  /* Timer 1 */
+			chip->T[0] = (256-v)*4;
+		break;
+		case 0x03:  /* Timer 2 */
+			chip->T[1] = (256-v)*16;
+		break;
+		case 0x04:  /* IRQ clear / mask and Timer enable */
+			if(v&0x80)
+			{   /* IRQ flags clear */
+				OPL3_STATUS_RESET(chip,0x60);
+			}
+			else
+			{   /* set IRQ mask ,timer enable */
+				uint8_t st1 = v & 1;
+				uint8_t st2 = (v>>1) & 1;
+
+				/* IRQRST,T1MSK,t2MSK,x,x,x,ST2,ST1 */
+				OPL3_STATUS_RESET(chip, v & 0x60);
+				OPL3_STATUSMASK_SET(chip, (~v) & 0x60 );
+
+				/* timer 2 */
+				if(chip->st[1] != st2)
+				{
+					attotime period = st2 ? chip->TimerBase * chip->T[1] : attotime::zero;
+					chip->st[1] = st2;
+					if (chip->timer_handler) (chip->timer_handler)(chip->TimerParam,1,period);
+				}
+				/* timer 1 */
+				if(chip->st[0] != st1)
+				{
+					attotime period = st1 ? chip->TimerBase * chip->T[0] : attotime::zero;
+					chip->st[0] = st1;
+					if (chip->timer_handler) (chip->timer_handler)(chip->TimerParam,0,period);
+				}
+			}
+		break;
+		case 0x08:  /* x,NTS,x,x, x,x,x,x */
+			chip->nts = v;
+		break;
+
+		default:
+			chip->device->logerror("YMF262: write to unknown register: %02x value=%02x\n",r,v);
+		break;
+		}
+		break;
+	case 0x20:  /* am ON, vib ON, ksr, eg_type, mul */
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+		set_mul(chip, slot + ch_offset*2, v);
+	break;
+	case 0x40:
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+		set_ksl_tl(chip, slot + ch_offset*2, v);
+	break;
+	case 0x60:
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+		set_ar_dr(chip, slot + ch_offset*2, v);
+	break;
+	case 0x80:
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+		set_sl_rr(chip, slot + ch_offset*2, v);
+	break;
+	case 0xa0:
+		if (r == 0xbd)          /* am depth, vibrato depth, r,bd,sd,tom,tc,hh */
+		{
+			if (ch_offset != 0) /* 0xbd register is present in set #1 only */
+				return;
+
+			chip->lfo_am_depth = v & 0x80;
+			chip->lfo_pm_depth_range = (v&0x40) ? 8 : 0;
+
+			chip->rhythm = v&0x3f;
+
+			if(chip->rhythm&0x20)
+			{
+				/* BD key on/off */
+				if(v&0x10)
+				{
+					FM_KEYON (&chip->P_CH[6].SLOT[SLOT1], 2);
+					FM_KEYON (&chip->P_CH[6].SLOT[SLOT2], 2);
+				}
+				else
+				{
+					FM_KEYOFF(&chip->P_CH[6].SLOT[SLOT1],~2);
+					FM_KEYOFF(&chip->P_CH[6].SLOT[SLOT2],~2);
+				}
+				/* HH key on/off */
+				if(v&0x01) FM_KEYON (&chip->P_CH[7].SLOT[SLOT1], 2);
+				else       FM_KEYOFF(&chip->P_CH[7].SLOT[SLOT1],~2);
+				/* SD key on/off */
+				if(v&0x08) FM_KEYON (&chip->P_CH[7].SLOT[SLOT2], 2);
+				else       FM_KEYOFF(&chip->P_CH[7].SLOT[SLOT2],~2);
+				/* TOM key on/off */
+				if(v&0x04) FM_KEYON (&chip->P_CH[8].SLOT[SLOT1], 2);
+				else       FM_KEYOFF(&chip->P_CH[8].SLOT[SLOT1],~2);
+				/* TOP-CY key on/off */
+				if(v&0x02) FM_KEYON (&chip->P_CH[8].SLOT[SLOT2], 2);
+				else       FM_KEYOFF(&chip->P_CH[8].SLOT[SLOT2],~2);
+			}
+			else
+			{
+				/* BD key off */
+				FM_KEYOFF(&chip->P_CH[6].SLOT[SLOT1],~2);
+				FM_KEYOFF(&chip->P_CH[6].SLOT[SLOT2],~2);
+				/* HH key off */
+				FM_KEYOFF(&chip->P_CH[7].SLOT[SLOT1],~2);
+				/* SD key off */
+				FM_KEYOFF(&chip->P_CH[7].SLOT[SLOT2],~2);
+				/* TOM key off */
+				FM_KEYOFF(&chip->P_CH[8].SLOT[SLOT1],~2);
+				/* TOP-CY off */
+				FM_KEYOFF(&chip->P_CH[8].SLOT[SLOT2],~2);
+			}
+			return;
+		}
+
+		/* keyon,block,fnum */
+		if( (r&0x0f) > 8) return;
+		CH = &chip->P_CH[(r&0x0f) + ch_offset];
+
+		if(!(r&0x10))
+		{   /* a0-a8 */
+			block_fnum  = (CH->block_fnum&0x1f00) | v;
+		}
+		else
+		{   /* b0-b8 */
+			block_fnum = ((v&0x1f)<<8) | (CH->block_fnum&0xff);
+
+			if (chip->OPL3_mode & 1)
+			{
+				int chan_no = (r&0x0f) + ch_offset;
+
+				/* in OPL3 mode */
+				//DO THIS:
+				//if this is 1st channel forming up a 4-op channel
+				//ALSO keyon/off slots of 2nd channel forming up 4-op channel
+				//else normal 2 operator function keyon/off
+				//OR THIS:
+				//if this is 2nd channel forming up 4-op channel just do nothing
+				//else normal 2 operator function keyon/off
+				switch(chan_no)
+				{
+				case 0: case 1: case 2:
+				case 9: case 10: case 11:
+					if (CH->extended)
+					{
+						//if this is 1st channel forming up a 4-op channel
+						//ALSO keyon/off slots of 2nd channel forming up 4-op channel
+						if(v&0x20)
+						{
+							FM_KEYON (&CH->SLOT[SLOT1], 1);
+							FM_KEYON (&CH->SLOT[SLOT2], 1);
+							FM_KEYON (&(CH+3)->SLOT[SLOT1], 1);
+							FM_KEYON (&(CH+3)->SLOT[SLOT2], 1);
+						}
+						else
+						{
+							FM_KEYOFF(&CH->SLOT[SLOT1],~1);
+							FM_KEYOFF(&CH->SLOT[SLOT2],~1);
+							FM_KEYOFF(&(CH+3)->SLOT[SLOT1],~1);
+							FM_KEYOFF(&(CH+3)->SLOT[SLOT2],~1);
+						}
+					}
+					else
+					{
+						//else normal 2 operator function keyon/off
+						if(v&0x20)
+						{
+							FM_KEYON (&CH->SLOT[SLOT1], 1);
+							FM_KEYON (&CH->SLOT[SLOT2], 1);
+						}
+						else
+						{
+							FM_KEYOFF(&CH->SLOT[SLOT1],~1);
+							FM_KEYOFF(&CH->SLOT[SLOT2],~1);
+						}
+					}
+				break;
+
+				case 3: case 4: case 5:
+				case 12: case 13: case 14:
+					if ((CH-3)->extended)
+					{
+						//if this is 2nd channel forming up 4-op channel just do nothing
+					}
+					else
+					{
+						//else normal 2 operator function keyon/off
+						if(v&0x20)
+						{
+							FM_KEYON (&CH->SLOT[SLOT1], 1);
+							FM_KEYON (&CH->SLOT[SLOT2], 1);
+						}
+						else
+						{
+							FM_KEYOFF(&CH->SLOT[SLOT1],~1);
+							FM_KEYOFF(&CH->SLOT[SLOT2],~1);
+						}
+					}
+				break;
+
+				default:
+					if(v&0x20)
+					{
+						FM_KEYON (&CH->SLOT[SLOT1], 1);
+						FM_KEYON (&CH->SLOT[SLOT2], 1);
+					}
+					else
+					{
+						FM_KEYOFF(&CH->SLOT[SLOT1],~1);
+						FM_KEYOFF(&CH->SLOT[SLOT2],~1);
+					}
+				break;
+				}
+			}
+			else
+			{
+				if(v&0x20)
+				{
+					FM_KEYON (&CH->SLOT[SLOT1], 1);
+					FM_KEYON (&CH->SLOT[SLOT2], 1);
+				}
+				else
+				{
+					FM_KEYOFF(&CH->SLOT[SLOT1],~1);
+					FM_KEYOFF(&CH->SLOT[SLOT2],~1);
+				}
+			}
+		}
+		/* update */
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+		if(CH->block_fnum != block_fnum)
+#else
+		if(CH->block_fnum != uint32_t(block_fnum))
+#endif
+		{
+			uint8_t block  = block_fnum >> 10;
+
+			CH->block_fnum = block_fnum;
+
+			CH->ksl_base = static_cast<uint32_t>(ksl_tab[block_fnum>>6]);
+			CH->fc       = chip->fn_tab[block_fnum&0x03ff] >> (7-block);
+
+			/* BLK 2,1,0 bits -> bits 3,2,1 of kcode */
+			CH->kcode    = (CH->block_fnum&0x1c00)>>9;
+
+			/* the info below is actually opposite to what is stated in the Manuals (verifed on real YMF262) */
+			/* if notesel == 0 -> lsb of kcode is bit 10 (MSB) of fnum  */
+			/* if notesel == 1 -> lsb of kcode is bit 9 (MSB-1) of fnum */
+			if (chip->nts&0x40)
+				CH->kcode |= (CH->block_fnum&0x100)>>8; /* notesel == 1 */
+			else
+				CH->kcode |= (CH->block_fnum&0x200)>>9; /* notesel == 0 */
+
+			if (chip->OPL3_mode & 1)
+			{
+				int chan_no = (r&0x0f) + ch_offset;
+				/* in OPL3 mode */
+				//DO THIS:
+				//if this is 1st channel forming up a 4-op channel
+				//ALSO update slots of 2nd channel forming up 4-op channel
+				//else normal 2 operator function keyon/off
+				//OR THIS:
+				//if this is 2nd channel forming up 4-op channel just do nothing
+				//else normal 2 operator function keyon/off
+				switch(chan_no)
+				{
+				case 0: case 1: case 2:
+				case 9: case 10: case 11:
+					if (CH->extended)
+					{
+						//if this is 1st channel forming up a 4-op channel
+						//ALSO update slots of 2nd channel forming up 4-op channel
+
+						/* refresh Total Level in FOUR SLOTs of this channel and channel+3 using data from THIS channel */
+						CH->SLOT[SLOT1].TLL = CH->SLOT[SLOT1].TL + (CH->ksl_base>>CH->SLOT[SLOT1].ksl);
+						CH->SLOT[SLOT2].TLL = CH->SLOT[SLOT2].TL + (CH->ksl_base>>CH->SLOT[SLOT2].ksl);
+						(CH+3)->SLOT[SLOT1].TLL = (CH+3)->SLOT[SLOT1].TL + (CH->ksl_base>>(CH+3)->SLOT[SLOT1].ksl);
+						(CH+3)->SLOT[SLOT2].TLL = (CH+3)->SLOT[SLOT2].TL + (CH->ksl_base>>(CH+3)->SLOT[SLOT2].ksl);
+
+						/* refresh frequency counter in FOUR SLOTs of this channel and channel+3 using data from THIS channel */
+						CALC_FCSLOT(CH,&CH->SLOT[SLOT1]);
+						CALC_FCSLOT(CH,&CH->SLOT[SLOT2]);
+						CALC_FCSLOT(CH,&(CH+3)->SLOT[SLOT1]);
+						CALC_FCSLOT(CH,&(CH+3)->SLOT[SLOT2]);
+					}
+					else
+					{
+						//else normal 2 operator function
+						/* refresh Total Level in both SLOTs of this channel */
+						CH->SLOT[SLOT1].TLL = CH->SLOT[SLOT1].TL + (CH->ksl_base>>CH->SLOT[SLOT1].ksl);
+						CH->SLOT[SLOT2].TLL = CH->SLOT[SLOT2].TL + (CH->ksl_base>>CH->SLOT[SLOT2].ksl);
+
+						/* refresh frequency counter in both SLOTs of this channel */
+						CALC_FCSLOT(CH,&CH->SLOT[SLOT1]);
+						CALC_FCSLOT(CH,&CH->SLOT[SLOT2]);
+					}
+				break;
+
+				case 3: case 4: case 5:
+				case 12: case 13: case 14:
+					if ((CH-3)->extended)
+					{
+						//if this is 2nd channel forming up 4-op channel just do nothing
+					}
+					else
+					{
+						//else normal 2 operator function
+						/* refresh Total Level in both SLOTs of this channel */
+						CH->SLOT[SLOT1].TLL = CH->SLOT[SLOT1].TL + (CH->ksl_base>>CH->SLOT[SLOT1].ksl);
+						CH->SLOT[SLOT2].TLL = CH->SLOT[SLOT2].TL + (CH->ksl_base>>CH->SLOT[SLOT2].ksl);
+
+						/* refresh frequency counter in both SLOTs of this channel */
+						CALC_FCSLOT(CH,&CH->SLOT[SLOT1]);
+						CALC_FCSLOT(CH,&CH->SLOT[SLOT2]);
+					}
+				break;
+
+				default:
+					/* refresh Total Level in both SLOTs of this channel */
+					CH->SLOT[SLOT1].TLL = CH->SLOT[SLOT1].TL + (CH->ksl_base>>CH->SLOT[SLOT1].ksl);
+					CH->SLOT[SLOT2].TLL = CH->SLOT[SLOT2].TL + (CH->ksl_base>>CH->SLOT[SLOT2].ksl);
+
+					/* refresh frequency counter in both SLOTs of this channel */
+					CALC_FCSLOT(CH,&CH->SLOT[SLOT1]);
+					CALC_FCSLOT(CH,&CH->SLOT[SLOT2]);
+				break;
+				}
+			}
+			else
+			{
+				/* in OPL2 mode */
+
+				/* refresh Total Level in both SLOTs of this channel */
+				CH->SLOT[SLOT1].TLL = CH->SLOT[SLOT1].TL + (CH->ksl_base>>CH->SLOT[SLOT1].ksl);
+				CH->SLOT[SLOT2].TLL = CH->SLOT[SLOT2].TL + (CH->ksl_base>>CH->SLOT[SLOT2].ksl);
+
+				/* refresh frequency counter in both SLOTs of this channel */
+				CALC_FCSLOT(CH,&CH->SLOT[SLOT1]);
+				CALC_FCSLOT(CH,&CH->SLOT[SLOT2]);
+			}
+		}
+	break;
+
+	case 0xc0:
+		/* CH.D, CH.C, CH.B, CH.A, FB(3bits), C */
+		if( (r&0xf) > 8) return;
+
+		CH = &chip->P_CH[(r&0xf) + ch_offset];
+
+		if( chip->OPL3_mode & 1 )
+		{
+			int base = ((r&0xf) + ch_offset) * 4;
+
+			/* OPL3 mode */
+			chip->pan[ base    ] = (v & 0x10) ? ~0 : 0; /* ch.A */
+			chip->pan[ base +1 ] = (v & 0x20) ? ~0 : 0; /* ch.B */
+			chip->pan[ base +2 ] = (v & 0x40) ? ~0 : 0; /* ch.C */
+			chip->pan[ base +3 ] = (v & 0x80) ? ~0 : 0; /* ch.D */
+		}
+		else
+		{
+			int base = ((r&0xf) + ch_offset) * 4;
+
+			/* OPL2 mode - always enabled */
+			chip->pan[ base    ] = ~0;      /* ch.A */
+			chip->pan[ base +1 ] = ~0;      /* ch.B */
+			chip->pan[ base +2 ] = ~0;      /* ch.C */
+			chip->pan[ base +3 ] = ~0;      /* ch.D */
+		}
+
+		chip->pan_ctrl_value[ (r&0xf) + ch_offset ] = v;    /* store control value for OPL3/OPL2 mode switching on the fly */
+
+		CH->SLOT[SLOT1].FB  = (v>>1)&7 ? ((v>>1)&7) + 7 : 0;
+		CH->SLOT[SLOT1].CON = v&1;
+
+		if( chip->OPL3_mode & 1 )
+		{
+			int chan_no = (r&0x0f) + ch_offset;
+
+			switch(chan_no)
+			{
+			case 0: case 1: case 2:
+			case 9: case 10: case 11:
+				if (CH->extended)
+				{
+					uint8_t conn = (CH->SLOT[SLOT1].CON<<1) | ((CH+3)->SLOT[SLOT1].CON<<0);
+					switch(conn)
+					{
+					case 0:
+						/* 1 -> 2 -> 3 -> 4 - out */
+
+						CH->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						CH->SLOT[SLOT2].conn_enum = CONN_PHASEMOD2;
+						(CH+3)->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						(CH+3)->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no + 3;
+					break;
+					case 1:
+						/* 1 -> 2 -\
+						   3 -> 4 -+- out */
+
+						CH->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no;
+						(CH+3)->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						(CH+3)->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no + 3;
+					break;
+					case 2:
+						/* 1 -----------\
+						   2 -> 3 -> 4 -+- out */
+
+						CH->SLOT[SLOT1].conn_enum = CONN_CHAN0 + chan_no;
+						CH->SLOT[SLOT2].conn_enum = CONN_PHASEMOD2;
+						(CH+3)->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						(CH+3)->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no + 3;
+					break;
+					case 3:
+						/* 1 ------\
+						   2 -> 3 -+- out
+						   4 ------/     */
+						CH->SLOT[SLOT1].conn_enum = CONN_CHAN0 + chan_no;
+						CH->SLOT[SLOT2].conn_enum = CONN_PHASEMOD2;
+						(CH+3)->SLOT[SLOT1].conn_enum = CONN_CHAN0 + chan_no + 3;
+						(CH+3)->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no + 3;
+					break;
+					}
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
+					OPL3_SLOT_CONNECT(chip, &(CH+3)->SLOT[SLOT1]);
+					OPL3_SLOT_CONNECT(chip, &(CH+3)->SLOT[SLOT2]);
+				}
+				else
+				{
+					/* 2 operators mode */
+					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r&0xf)+ch_offset : CONN_PHASEMOD;
+					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r&0xf)+ch_offset;
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
+				}
+			break;
+
+			case 3: case 4: case 5:
+			case 12: case 13: case 14:
+				if ((CH-3)->extended)
+				{
+					uint8_t conn = ((CH-3)->SLOT[SLOT1].CON<<1) | (CH->SLOT[SLOT1].CON<<0);
+					switch(conn)
+					{
+					case 0:
+						/* 1 -> 2 -> 3 -> 4 - out */
+
+						(CH-3)->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						(CH-3)->SLOT[SLOT2].conn_enum = CONN_PHASEMOD2;
+						CH->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no;
+					break;
+					case 1:
+						/* 1 -> 2 -\
+						   3 -> 4 -+- out */
+
+						(CH-3)->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						(CH-3)->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no - 3;
+						CH->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no;
+					break;
+					case 2:
+						/* 1 -----------\
+						   2 -> 3 -> 4 -+- out */
+
+						(CH-3)->SLOT[SLOT1].conn_enum = CONN_CHAN0 + chan_no - 3;
+						(CH-3)->SLOT[SLOT2].conn_enum = CONN_PHASEMOD2;
+						CH->SLOT[SLOT1].conn_enum = CONN_PHASEMOD;
+						CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no;
+					break;
+					case 3:
+						/* 1 ------\
+						   2 -> 3 -+- out
+						   4 ------/     */
+						(CH-3)->SLOT[SLOT1].conn_enum = CONN_CHAN0 + chan_no - 3;
+						(CH-3)->SLOT[SLOT2].conn_enum = CONN_PHASEMOD2;
+						CH->SLOT[SLOT1].conn_enum = CONN_CHAN0 + chan_no;
+						CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + chan_no;
+					break;
+					}
+					OPL3_SLOT_CONNECT(chip, &(CH-3)->SLOT[SLOT1]);
+					OPL3_SLOT_CONNECT(chip, &(CH-3)->SLOT[SLOT2]);
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
+				}
+				else
+				{
+					/* 2 operators mode */
+					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r&0xf)+ch_offset : CONN_PHASEMOD;
+					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r&0xf)+ch_offset;
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
+				}
+			break;
+
+			default:
+					/* 2 operators mode */
+					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r&0xf)+ch_offset : CONN_PHASEMOD;
+					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r&0xf)+ch_offset;
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
+					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
+			break;
+			}
+		}
+		else
+		{
+			/* OPL2 mode - always 2 operators mode */
+			CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r&0xf)+ch_offset : CONN_PHASEMOD;
+			CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r&0xf)+ch_offset;
+			OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
+			OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
+		}
+	break;
+
+	case 0xe0: /* waveform select */
+		slot = slot_array[r&0x1f];
+		if(slot < 0) return;
+
+		slot += ch_offset*2;
+
+		CH = &chip->P_CH[slot/2];
+
+
+		/* store 3-bit value written regardless of current OPL2 or OPL3 mode... (verified on real YMF262) */
+		v &= 7;
+		CH->SLOT[slot&1].waveform_number = v;
+
+		/* ... but select only waveforms 0-3 in OPL2 mode */
+		if( !(chip->OPL3_mode & 1) )
+		{
+			v &= 3; /* we're in OPL2 mode */
+		}
+		CH->SLOT[slot&1].wavetable = v * SIN_LEN;
+	break;
+	}
+}
+
+/* lock/unlock for common table */
+static int OPL3_LockTable(device_t *device)
+{
+	num_lock++;
+	if(num_lock>1) return 0;
+
+	/* first time */
+
+	if( !init_tables() )
+	{
+		num_lock--;
+		return -1;
+	}
+
+	return 0;
+}
+
+static void OPL3_UnLockTable(void)
+{
+	if(num_lock) num_lock--;
+	if(num_lock) return;
+
+	/* last time */
+	OPLCloseTable();
+}
+
+static void OPL3ResetChip(OPL3 *chip)
+{
+	int c,s;
+
+	chip->eg_timer = 0;
+	chip->eg_cnt   = 0;
+
+	chip->noise_rng = 1;    /* noise shift register */
+	chip->nts       = 0;    /* note split */
+	OPL3_STATUS_RESET(chip,0x60);
+
+	/* reset with register write */
+	OPL3WriteReg(chip,0x01,0); /* test register */
+	OPL3WriteReg(chip,0x02,0); /* Timer1 */
+	OPL3WriteReg(chip,0x03,0); /* Timer2 */
+	OPL3WriteReg(chip,0x04,0); /* IRQ mask clear */
+
+
+//FIX IT  registers 101, 104 and 105
+
+
+//FIX IT (dont change CH.D, CH.C, CH.B and CH.A in C0-C8 registers)
+	for(c = 0xff ; c >= 0x20 ; c-- )
+		OPL3WriteReg(chip,c,0);
+//FIX IT (dont change CH.D, CH.C, CH.B and CH.A in C0-C8 registers)
+	for(c = 0x1ff ; c >= 0x120 ; c-- )
+		OPL3WriteReg(chip,c,0);
+
+
+
+	/* reset operator parameters */
+	for( c = 0 ; c < 9*2 ; c++ )
+	{
+		OPL3_CH *CH = &chip->P_CH[c];
+		for(s = 0 ; s < 2 ; s++ )
+		{
+			CH->SLOT[s].state     = EG_OFF;
+			CH->SLOT[s].volume    = MAX_ATT_INDEX;
+		}
+	}
+}
+
+/* Create one of virtual YMF262 */
+/* 'clock' is chip clock in Hz  */
+/* 'rate'  is sampling rate  */
+static OPL3 *OPL3Create(device_t *device, int clock, int rate, int type)
+{
+	OPL3 *chip;
+
+	if (OPL3_LockTable(device) == -1) return nullptr;
+
+	/* allocate memory block */
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+	chip = auto_alloc_clear(device->machine(), <OPL3>());
+#else
+	chip = static_cast<OPL3 *>(calloc(1, sizeof(OPL3)));
+#endif
+
+	chip->device = device;
+	chip->type  = type;
+	chip->clock = clock;
+	chip->rate  = rate;
+
+	/* init global tables */
+	OPL3_initalize(chip);
+
+	/* reset chip */
+	OPL3ResetChip(chip);
+	return chip;
+}
+
+/* Destroy one of virtual YMF262 */
+static void OPL3Destroy(OPL3 *chip)
+{
+	OPL3_UnLockTable();
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+	auto_free(chip->device->machine(), chip);
+#else
+	free(chip);
+#endif
+}
+
+
+/* YMF262 I/O interface */
+static int OPL3Write(OPL3 *chip, int a, int v)
+{
+	/* data bus is 8 bits */
+	v &= 0xff;
+
+
+	switch(a&3)
+	{
+	case 0: /* address port 0 (register set #1) */
+		chip->address = v;
+	break;
+
+	case 1: /* data port - ignore A1 */
+	case 3: /* data port - ignore A1 */
+		if(chip->UpdateHandler) chip->UpdateHandler(chip->UpdateParam,0);
+		OPL3WriteReg(chip,chip->address,v);
+	break;
+
+	case 2: /* address port 1 (register set #2) */
+
+		/* verified on real YMF262:
+		 in OPL3 mode:
+		   address line A1 is stored during *address* write and ignored during *data* write.
+
+		 in OPL2 mode:
+		   register set#2 writes go to register set#1 (ignoring A1)
+		   verified on registers from set#2: 0x01, 0x04, 0x20-0xef
+		   The only exception is register 0x05.
+		*/
+		if( chip->OPL3_mode & 1 )
+		{
+			/* OPL3 mode */
+				chip->address = v | 0x100;
+		}
+		else
+		{
+			/* in OPL2 mode the only accessible in set #2 is register 0x05 */
+			if( v==5 )
+				chip->address = v | 0x100;
+			else
+				chip->address = v;  /* verified range: 0x01, 0x04, 0x20-0xef(set #2 becomes set #1 in opl2 mode) */
+		}
+	break;
+	}
+
+	return chip->status>>7;
+}
+
+static unsigned char OPL3Read(OPL3 *chip,int a)
+{
+	if( a==0 )
+	{
+		/* status port */
+		return chip->status;
+	}
+
+	return 0x00;    /* verified on real YMF262 */
+}
+
+
+
+static int OPL3TimerOver(OPL3 *chip,int c)
+{
+	if( c )
+	{   /* Timer B */
+		OPL3_STATUS_SET(chip,0x20);
+	}
+	else
+	{   /* Timer A */
+		OPL3_STATUS_SET(chip,0x40);
+	}
+	/* reload timer */
+	if (chip->timer_handler) (chip->timer_handler)(chip->TimerParam,c,chip->TimerBase * chip->T[c]);
+	return chip->status>>7;
+}
+
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+static void OPL3_save_state(OPL3 *chip, device_t *device) {
+	for (int ch=0; ch<18; ch++) {
+		OPL3_CH *channel = &chip->P_CH[ch];
+		device->save_item(NAME(channel->block_fnum), ch);
+		device->save_item(NAME(channel->fc), ch);
+		device->save_item(NAME(channel->ksl_base), ch);
+		device->save_item(NAME(channel->kcode), ch);
+		device->save_item(NAME(channel->extended), ch);
+
+		for (int sl=0; sl<2; sl++) {
+			OPL3_SLOT *slot = &channel->SLOT[sl];
+			device->save_item(NAME(slot->ar), ch*2+sl);
+			device->save_item(NAME(slot->dr), ch*2+sl);
+			device->save_item(NAME(slot->rr), ch*2+sl);
+			device->save_item(NAME(slot->KSR), ch*2+sl);
+			device->save_item(NAME(slot->ksl), ch*2+sl);
+			device->save_item(NAME(slot->ksr), ch*2+sl);
+			device->save_item(NAME(slot->mul), ch*2+sl);
+
+			device->save_item(NAME(slot->Cnt), ch*2+sl);
+			device->save_item(NAME(slot->Incr), ch*2+sl);
+			device->save_item(NAME(slot->FB), ch*2+sl);
+			device->save_item(NAME(slot->conn_enum), ch*2+sl);
+			device->save_item(NAME(slot->op1_out), ch*2+sl);
+			device->save_item(NAME(slot->CON), ch*2+sl);
+
+			device->save_item(NAME(slot->eg_type), ch*2+sl);
+			device->save_item(NAME(slot->state), ch*2+sl);
+			device->save_item(NAME(slot->TL), ch*2+sl);
+			device->save_item(NAME(slot->TLL), ch*2+sl);
+			device->save_item(NAME(slot->volume), ch*2+sl);
+			device->save_item(NAME(slot->sl), ch*2+sl);
+
+			device->save_item(NAME(slot->eg_m_ar), ch*2+sl);
+			device->save_item(NAME(slot->eg_sh_ar), ch*2+sl);
+			device->save_item(NAME(slot->eg_sel_ar), ch*2+sl);
+			device->save_item(NAME(slot->eg_m_dr), ch*2+sl);
+			device->save_item(NAME(slot->eg_sh_dr), ch*2+sl);
+			device->save_item(NAME(slot->eg_sel_dr), ch*2+sl);
+			device->save_item(NAME(slot->eg_m_rr), ch*2+sl);
+			device->save_item(NAME(slot->eg_sh_rr), ch*2+sl);
+			device->save_item(NAME(slot->eg_sel_rr), ch*2+sl);
+
+			device->save_item(NAME(slot->key), ch*2+sl);
+
+			device->save_item(NAME(slot->AMmask), ch*2+sl);
+			device->save_item(NAME(slot->vib), ch*2+sl);
+
+			device->save_item(NAME(slot->waveform_number), ch*2+sl);
+			device->save_item(NAME(slot->wavetable), ch*2+sl);
+		}
+	}
+
+	device->save_item(NAME(chip->pan));
+	device->save_item(NAME(chip->pan_ctrl_value));
+
+	device->save_item(NAME(chip->lfo_am_depth));
+	device->save_item(NAME(chip->lfo_pm_depth_range));
+
+	device->save_item(NAME(chip->OPL3_mode));
+	device->save_item(NAME(chip->rhythm));
+
+	device->save_item(NAME(chip->address));
+	device->save_item(NAME(chip->status));
+	device->save_item(NAME(chip->statusmask));
+}
+#endif
+
+void * ymf262_init(device_t *device, int clock, int rate)
+{
+	void *chip = OPL3Create(device,clock,rate,OPL3_TYPE_YMF262);
+#ifdef SCUMMVM_USE_ORIGINAL_MAME_CODE
+	OPL3_save_state((OPL3 *)chip, device);
+#endif
+
+	return chip;
+}
+
+void ymf262_post_load(void *chip) {
+	OPL3 *opl3 = (OPL3 *)chip;
+	for (int ch=0; ch<18; ch++) {
+		for (int sl=0; sl<2; sl++) {
+			OPL3_SLOT_CONNECT(opl3, &(opl3->P_CH[ch].SLOT[sl]));
+		}
+	}
+}
+
+void ymf262_shutdown(void *chip)
+{
+	OPL3Destroy((OPL3 *)chip);
+}
+void ymf262_reset_chip(void *chip)
+{
+	OPL3ResetChip((OPL3 *)chip);
+}
+
+int ymf262_write(void *chip, int a, int v)
+{
+	return OPL3Write((OPL3 *)chip, a, v);
+}
+
+unsigned char ymf262_read(void *chip, int a)
+{
+	/* Note on status register: */
+
+	/* YM3526(OPL) and YM3812(OPL2) return bit2 and bit1 in HIGH state */
+
+	/* YMF262(OPL3) always returns bit2 and bit1 in LOW state */
+	/* which can be used to identify the chip */
+
+	/* YMF278(OPL4) returns bit2 in LOW and bit1 in HIGH state ??? info from manual - not verified */
+
+	return OPL3Read((OPL3 *)chip, a);
+}
+int ymf262_timer_over(void *chip, int c)
+{
+	return OPL3TimerOver((OPL3 *)chip, c);
+}
+
+void ymf262_set_timer_handler(void *chip, OPL3_TIMERHANDLER timer_handler, device_t *device)
+{
+	reinterpret_cast<OPL3 *>(chip)->SetTimerHandler(timer_handler, device);
+}
+void ymf262_set_irq_handler(void *chip, OPL3_IRQHANDLER IRQHandler, device_t *device)
+{
+	reinterpret_cast<OPL3 *>(chip)->SetIRQHandler(IRQHandler, device);
+}
+void ymf262_set_update_handler(void *chip, OPL3_UPDATEHANDLER UpdateHandler, device_t *device)
+{
+	reinterpret_cast<OPL3 *>(chip)->SetUpdateHandler(UpdateHandler, device);
+}
+
+
+/*
+** Generate samples for one of the YMF262's
+**
+** 'which' is the virtual YMF262 number
+** '**buffers' is table of 4 pointers to the buffers: CH.A, CH.B, CH.C and CH.D
+** 'length' is the number of samples that should be generated
+*/
+void ymf262_update_one(void *_chip, OPL3SAMPLE **buffers, int length)
+{
+	int i;
+	OPL3        *chip  = (OPL3 *)_chip;
+	signed int *chanout = chip->chanout;
+	uint8_t       rhythm = chip->rhythm&0x20;
+
+	OPL3SAMPLE  *ch_a = buffers[0];
+	OPL3SAMPLE  *ch_b = buffers[1];
+	OPL3SAMPLE  *ch_c = buffers[2];
+	OPL3SAMPLE  *ch_d = buffers[3];
+
+	for( i=0; i < length ; i++ )
+	{
+		int a,b,c,d;
+
+
+		advance_lfo(chip);
+
+		/* clear channel outputs */
+		memset(chip->chanout, 0, sizeof(chip->chanout));
+
+#if 1
+	/* register set #1 */
+		chan_calc(chip, &chip->P_CH[0]);            /* extended 4op ch#0 part 1 or 2op ch#0 */
+		if (chip->P_CH[0].extended)
+			chan_calc_ext(chip, &chip->P_CH[3]);    /* extended 4op ch#0 part 2 */
+		else
+			chan_calc(chip, &chip->P_CH[3]);        /* standard 2op ch#3 */
+
+
+		chan_calc(chip, &chip->P_CH[1]);            /* extended 4op ch#1 part 1 or 2op ch#1 */
+		if (chip->P_CH[1].extended)
+			chan_calc_ext(chip, &chip->P_CH[4]);    /* extended 4op ch#1 part 2 */
+		else
+			chan_calc(chip, &chip->P_CH[4]);        /* standard 2op ch#4 */
+
+
+		chan_calc(chip, &chip->P_CH[2]);            /* extended 4op ch#2 part 1 or 2op ch#2 */
+		if (chip->P_CH[2].extended)
+			chan_calc_ext(chip, &chip->P_CH[5]);    /* extended 4op ch#2 part 2 */
+		else
+			chan_calc(chip, &chip->P_CH[5]);        /* standard 2op ch#5 */
+
+
+		if(!rhythm)
+		{
+			chan_calc(chip, &chip->P_CH[6]);
+			chan_calc(chip, &chip->P_CH[7]);
+			chan_calc(chip, &chip->P_CH[8]);
+		}
+		else        /* Rhythm part */
+		{
+			chan_calc_rhythm(chip, &chip->P_CH[0], (chip->noise_rng>>0)&1 );
+		}
+
+	/* register set #2 */
+		chan_calc(chip, &chip->P_CH[ 9]);
+		if (chip->P_CH[9].extended)
+			chan_calc_ext(chip, &chip->P_CH[12]);
+		else
+			chan_calc(chip, &chip->P_CH[12]);
+
+
+		chan_calc(chip, &chip->P_CH[10]);
+		if (chip->P_CH[10].extended)
+			chan_calc_ext(chip, &chip->P_CH[13]);
+		else
+			chan_calc(chip, &chip->P_CH[13]);
+
+
+		chan_calc(chip, &chip->P_CH[11]);
+		if (chip->P_CH[11].extended)
+			chan_calc_ext(chip, &chip->P_CH[14]);
+		else
+			chan_calc(chip, &chip->P_CH[14]);
+
+
+		/* channels 15,16,17 are fixed 2-operator channels only */
+		chan_calc(chip, &chip->P_CH[15]);
+		chan_calc(chip, &chip->P_CH[16]);
+		chan_calc(chip, &chip->P_CH[17]);
+#endif
+
+		/* accumulator register set #1 */
+		a =  chanout[0] & chip->pan[0];
+		b =  chanout[0] & chip->pan[1];
+		c =  chanout[0] & chip->pan[2];
+		d =  chanout[0] & chip->pan[3];
+#if 1
+		a += chanout[1] & chip->pan[4];
+		b += chanout[1] & chip->pan[5];
+		c += chanout[1] & chip->pan[6];
+		d += chanout[1] & chip->pan[7];
+		a += chanout[2] & chip->pan[8];
+		b += chanout[2] & chip->pan[9];
+		c += chanout[2] & chip->pan[10];
+		d += chanout[2] & chip->pan[11];
+
+		a += chanout[3] & chip->pan[12];
+		b += chanout[3] & chip->pan[13];
+		c += chanout[3] & chip->pan[14];
+		d += chanout[3] & chip->pan[15];
+		a += chanout[4] & chip->pan[16];
+		b += chanout[4] & chip->pan[17];
+		c += chanout[4] & chip->pan[18];
+		d += chanout[4] & chip->pan[19];
+		a += chanout[5] & chip->pan[20];
+		b += chanout[5] & chip->pan[21];
+		c += chanout[5] & chip->pan[22];
+		d += chanout[5] & chip->pan[23];
+
+		a += chanout[6] & chip->pan[24];
+		b += chanout[6] & chip->pan[25];
+		c += chanout[6] & chip->pan[26];
+		d += chanout[6] & chip->pan[27];
+		a += chanout[7] & chip->pan[28];
+		b += chanout[7] & chip->pan[29];
+		c += chanout[7] & chip->pan[30];
+		d += chanout[7] & chip->pan[31];
+		a += chanout[8] & chip->pan[32];
+		b += chanout[8] & chip->pan[33];
+		c += chanout[8] & chip->pan[34];
+		d += chanout[8] & chip->pan[35];
+
+		/* accumulator register set #2 */
+		a += chanout[9] & chip->pan[36];
+		b += chanout[9] & chip->pan[37];
+		c += chanout[9] & chip->pan[38];
+		d += chanout[9] & chip->pan[39];
+		a += chanout[10] & chip->pan[40];
+		b += chanout[10] & chip->pan[41];
+		c += chanout[10] & chip->pan[42];
+		d += chanout[10] & chip->pan[43];
+		a += chanout[11] & chip->pan[44];
+		b += chanout[11] & chip->pan[45];
+		c += chanout[11] & chip->pan[46];
+		d += chanout[11] & chip->pan[47];
+
+		a += chanout[12] & chip->pan[48];
+		b += chanout[12] & chip->pan[49];
+		c += chanout[12] & chip->pan[50];
+		d += chanout[12] & chip->pan[51];
+		a += chanout[13] & chip->pan[52];
+		b += chanout[13] & chip->pan[53];
+		c += chanout[13] & chip->pan[54];
+		d += chanout[13] & chip->pan[55];
+		a += chanout[14] & chip->pan[56];
+		b += chanout[14] & chip->pan[57];
+		c += chanout[14] & chip->pan[58];
+		d += chanout[14] & chip->pan[59];
+
+		a += chanout[15] & chip->pan[60];
+		b += chanout[15] & chip->pan[61];
+		c += chanout[15] & chip->pan[62];
+		d += chanout[15] & chip->pan[63];
+		a += chanout[16] & chip->pan[64];
+		b += chanout[16] & chip->pan[65];
+		c += chanout[16] & chip->pan[66];
+		d += chanout[16] & chip->pan[67];
+		a += chanout[17] & chip->pan[68];
+		b += chanout[17] & chip->pan[69];
+		c += chanout[17] & chip->pan[70];
+		d += chanout[17] & chip->pan[71];
+#endif
+		a >>= FINAL_SH;
+		b >>= FINAL_SH;
+		c >>= FINAL_SH;
+		d >>= FINAL_SH;
+
+		/* limit check */
+		a = limit( a , MAXOUT, MINOUT );
+		b = limit( b , MAXOUT, MINOUT );
+		c = limit( c , MAXOUT, MINOUT );
+		d = limit( d , MAXOUT, MINOUT );
+
+		#ifdef SAVE_SAMPLE
+		if (which==0)
+		{
+			SAVE_ALL_CHANNELS
+		}
+		#endif
+
+		/* store to sound buffer */
+		ch_a[i] = a;
+		ch_b[i] = b;
+		ch_c[i] = c;
+		ch_d[i] = d;
+
+		advance(chip);
+	}
+
+}

--- a/audio/softsynth/opl/mame/sound/ymf262.h
+++ b/audio/softsynth/opl/mame/sound/ymf262.h
@@ -1,0 +1,40 @@
+// license:GPL-2.0+
+// copyright-holders:Jarek Burczynski
+#ifndef MAME_SOUND_YMF262_H
+#define MAME_SOUND_YMF262_H
+
+#pragma once
+
+/* select number of output bits: 8 or 16 */
+#define OPL3_SAMPLE_BITS 16
+
+typedef stream_sample_t OPL3SAMPLE;
+/*
+#if (OPL3_SAMPLE_BITS==16)
+typedef int16_t OPL3SAMPLE;
+#endif
+#if (OPL3_SAMPLE_BITS==8)
+typedef int8_t OPL3SAMPLE;
+#endif
+*/
+
+typedef void (*OPL3_TIMERHANDLER)(device_t *device,int timer,const attotime &period);
+typedef void (*OPL3_IRQHANDLER)(device_t *device,int irq);
+typedef void (*OPL3_UPDATEHANDLER)(device_t *device,int min_interval_us);
+
+
+void *ymf262_init(device_t *device, int clock, int rate);
+void ymf262_post_load(void *chip);
+void ymf262_shutdown(void *chip);
+void ymf262_reset_chip(void *chip);
+int  ymf262_write(void *chip, int a, int v);
+unsigned char ymf262_read(void *chip, int a);
+int  ymf262_timer_over(void *chip, int c);
+void ymf262_update_one(void *chip, OPL3SAMPLE **buffers, int length);
+
+void ymf262_set_timer_handler(void *chip, OPL3_TIMERHANDLER TimerHandler, device_t *device);
+void ymf262_set_irq_handler(void *chip, OPL3_IRQHANDLER IRQHandler, device_t *device);
+void ymf262_set_update_handler(void *chip, OPL3_UPDATEHANDLER UpdateHandler, device_t *device);
+
+
+#endif // MAME_SOUND_YMF262_H


### PR DESCRIPTION
Based on upstream revision
02a4917f30ace7de14d561ad09e2b4579facaf13.

Fixes Trac#7884.

Obviously, this shouldn’t land until after the release is
branched. 😎

I tried to keep this as updatable as possible by separating
the core ScummVM code (previously everything was just in
mame.cpp), and then making any necessary adjustments within
the MAME code using some obvious #ifdefs. Since MAME uses
C++14 now, I had to do some hacking to make it compile in
C++98 compilers. (I imagine this will become increasingly
difficult as time goes on…)

I tested this very lightly with EcoQuest & PQ3 for dual-OPL2
and IHNM for OPL3. Neither EQ nor PQ3 are quite right, but
they are not quite right in both the MAME and DOSBox OPLs,
so it is probably a SCI bug. (One of the reasons why I
wanted to get this stuff up-to-date was because I’m going to
start on rewriting SCI MIDI stuff soon and want to make sure
the underlying synths are as accurate as possible.)

Please bang on this and report any issues that didn’t
exist before! Thanks!