### PR TITLE
dists: enforce SDL_MOUSE_RELATIVE=0 on XDG systems

### DIFF
--- a/dists/scummvm.desktop
+++ b/dists/scummvm.desktop
@@ -7,7 +7,7 @@ Comment[he]=פרשן למספר משחקי הרפתקאות
 Comment[de]=Interpreter für diverse Abenteuerspiele
 Comment[es]=Intérprete para varias aventuras gráficas
 Comment[ca]=Intèrpret per diverses aventures gràfiques
-Exec=scummvm
+Exec=env SDL_MOUSE_RELATIVE=0 scummvm
 Icon=scummvm
 Terminal=false
 Type=Application


### PR DESCRIPTION
Mouse is very sensitive when ScummVM is fullscreen. This fixes that problem.

This probably won't get accepted in this form, setting some option set in SDL frontend probably will be more appropriate.