### PR TITLE
PEGASUS:  DVD detection

### DIFF
--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -92,6 +92,18 @@ static const PegasusGameDescription gameDescriptions[] = {
 	{
 		{
 			"pegasus",
+			"DVD",
+			AD_ENTRY1s("JMP PP Resources", "d13a602d2498010d720a6534f097f88b", 2075337),
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_MACRESFORK|GF_DVD,
+			GUIO0()
+		},
+	},	
+
+	{
+		{
+			"pegasus",
 			"Demo",
 			AD_ENTRY1s("JMP PP Resources", "d13a602d2498010d720a6534f097f88b", 360129),
 			Common::EN_ANY,

--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -125,18 +125,6 @@ static const PegasusGameDescription gameDescriptions[] = {
 		},
 	},
 
-		{
-		{
-			"pegasus",
-			"DVD Demo",
-			AD_ENTRY1s("JMP PP Resources", "d0fcda50dc75c7a81ae314e6a813f4d2", 93495),
-			Common::EN_ANY,
-			Common::kPlatformWindows,
-			ADGF_MACRESFORK | ADGF_DEMO | GF_DVD,
-			GUIO1(GUIO_NOLAUNCHLOAD)
-		},
-	},
-
 	{ AD_TABLE_END_MARKER }
 };
 


### PR DESCRIPTION
1. Adds detection for the DVD version of pegasus prime. Fixes #Trac10347.
2. This removes a duplicate detection entry for a demo version of pegasus prime