### PR TITLE
SDL: Don't use the window size hint for fullscreen

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -244,11 +244,14 @@ bool SdlGraphicsManager::createOrUpdateWindow(int width, int height, const Uint3
 	// resized the game window), or when the launcher is visible (since a user
 	// may change the scaler, which should reset the window size)
 	if (!_window->getSDLWindow() || _lastFlags != flags || _overlayVisible || _allowWindowSizeReset) {
-		if (_hintedWidth) {
-			width = _hintedWidth;
-		}
-		if (_hintedHeight) {
-			height = _hintedHeight;
+		const bool fullscreen = (flags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP)) != 0;
+		if (!fullscreen) {
+			if (_hintedWidth) {
+				width = _hintedWidth;
+			}
+			if (_hintedHeight) {
+				height = _hintedHeight;
+			}
 		}
 
 		if (!_window->createOrUpdateWindow(width, height, flags)) {


### PR DESCRIPTION
This prevents the OpenGL backend from changing mode when entering fullscreen for games with a window size hint.

When in fullscreen with OpenGL, unlike with the Renderer API, SDL2 does not automatically scale the window contents to fit the screen. Which means the window size must be the screen size. Passing windowed mode dimensions to SDL_CreateWindow in that case seems incorrect.

Fixes #10335.