### PR TITLE
SCI: Change workaround for PalVary / Animate race condition

### DIFF
--- a/engines/sci/graphics/animate.cpp
+++ b/engines/sci/graphics/animate.cpp
@@ -650,6 +650,11 @@ void GfxAnimate::animateShowPic() {
 }
 
 void GfxAnimate::kernelAnimate(reg_t listReference, bool cycle, int argc, reg_t *argv) {
+	// If necessary, delay this kAnimate for a running PalVary.
+	// See delayForPalVaryWorkaround() for details.
+	if (_screen->_picNotValid)
+		_palette->delayForPalVaryWorkaround();
+
 	byte old_picNotValid = _screen->_picNotValid;
 
 	if (getSciVersion() >= SCI_VERSION_1_1)

--- a/engines/sci/graphics/palette.h
+++ b/engines/sci/graphics/palette.h
@@ -88,6 +88,8 @@ public:
 	void palVaryPrepareForTransition();
 	void palVaryProcess(int signal, bool setPalette);
 
+	void delayForPalVaryWorkaround();
+
 	Palette _sysPalette;
 
 	void saveLoadWithSerializer(Common::Serializer &s);
@@ -122,6 +124,7 @@ protected:
 	uint16 _palVaryTicks;
 	int _palVaryPaused;
 	int _palVarySignal;
+	bool _palVaryZeroTick;
 	uint16 _totalScreenColors;
 
 	void loadMacIconBarPalette();


### PR DESCRIPTION
The new approach is to delay kAnimate briefly (with a 100ms timeout)
while there is a zero-tick PalVary running, so that it has time to
trigger.

The previous workaround would immediately process a zero-tick
PalVaryInit/PalVaryReverse. This caused problems in QfG3 (bug #10304)
where it interfered with PalVaryPause.

The previous workaround could also be modified to handle pause/resume,
but this new approach should be closer to SSCI's behaviour, which used a
timer for a zero-tick PalVary too.

This fixes bug #10304, and keeps #5298 fixed too.