### PR TITLE
COMPOSER: Added MD5 for the German version of Imo and the King

### DIFF
--- a/engines/composer/detection.cpp
+++ b/engines/composer/detection.cpp
@@ -140,6 +140,20 @@ static const ComposerGameDescription gameDescriptions[] = {
 		GType_ComposerV1
 	},
 
+	// Magic Tales: Imo and the King German - from bug #10199
+	{
+		{
+			"imoking",
+			"",
+			AD_ENTRY1s("book.ini", "5925c6d4bf85d89b17208be4fcace5e8", 3274),
+			Common::DE_DEU,
+			Common::kPlatformWindows,
+			ADGF_NO_FLAGS,
+			GUIO1(GUIO_NOASPECT)
+		},
+		GType_ComposerV1
+	},
+
 	// Magic Tales: The Little Samurai - from bug #3485018
 	{
 		{


### PR DESCRIPTION
Fixes bug [10199](https://bugs.scummvm.org/ticket/10199)