### PR TITLE
ALL: Remove obsolete register keyword

### DIFF
--- a/audio/rate.h
+++ b/audio/rate.h
@@ -46,7 +46,7 @@ enum {
 };
 
 static inline void clampedAdd(int16& a, int b) {
-	register int val;
+	int val;
 #ifdef OUTPUT_UNSIGNED_AUDIO
 	val = (a ^ 0x8000) + b;
 #else

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -313,13 +313,13 @@ void DINGUXSdlGraphicsManager::internUpdateScreen() {
 		dstPitch = _hwScreen->pitch;
 
 		for (r = _dirtyRectList; r != lastRect; ++r) {
-			register int dst_y = r->y + _currentShakePos;
-			register int dst_h = 0;
-			register int dst_w = r->w;
-			register int orig_dst_y = 0;
-			register int dst_x = r->x;
-			register int src_y;
-			register int src_x;
+			int dst_y = r->y + _currentShakePos;
+			int dst_h = 0;
+			int dst_w = r->w;
+			int orig_dst_y = 0;
+			int dst_x = r->x;
+			int src_y;
+			int src_x;
 
 			if (dst_y < height) {
 				dst_h = r->h;

--- a/backends/graphics/gph/gph-graphics.cpp
+++ b/backends/graphics/gph/gph-graphics.cpp
@@ -337,13 +337,13 @@ void GPHGraphicsManager::internUpdateScreen() {
 		dstPitch = _hwScreen->pitch;
 
 		for (r = _dirtyRectList; r != lastRect; ++r) {
-			register int dst_y = r->y + _currentShakePos;
-			register int dst_h = 0;
-			register int dst_w = r->w;
-			register int orig_dst_y = 0;
-			register int dst_x = r->x;
-			register int src_y;
-			register int src_x;
+			int dst_y = r->y + _currentShakePos;
+			int dst_h = 0;
+			int dst_w = r->w;
+			int orig_dst_y = 0;
+			int dst_x = r->x;
+			int src_y;
+			int src_x;
 
 			if (dst_y < height) {
 				dst_h = r->h;

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
@@ -346,13 +346,13 @@ void LinuxmotoSdlGraphicsManager::internUpdateScreen() {
 		dstPitch = _hwscreen->pitch;
 
 		for (r = _dirtyRectList; r != lastRect; ++r) {
-			register int dst_y = r->y + _currentShakePos;
-			register int dst_h = 0;
-			register int dst_w = r->w;
-			register int orig_dst_y = 0;
-			register int dst_x = r->x;
-			register int src_y;
-			register int src_x;
+			int dst_y = r->y + _currentShakePos;
+			int dst_h = 0;
+			int dst_w = r->w;
+			int orig_dst_y = 0;
+			int dst_x = r->x;
+			int src_y;
+			int src_x;
 
 			if (dst_y < height) {
 				dst_h = r->h;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1223,12 +1223,12 @@ void SurfaceSdlGraphicsManager::internUpdateScreen() {
 		dstPitch = _hwScreen->pitch;
 
 		for (r = _dirtyRectList; r != lastRect; ++r) {
-			register int dst_y = r->y + _currentShakePos;
-			register int dst_h = 0;
+			int dst_y = r->y + _currentShakePos;
+			int dst_h = 0;
 #ifdef USE_SCALERS
-			register int orig_dst_y = 0;
+			int orig_dst_y = 0;
 #endif
-			register int rx1 = r->x * scale1;
+			int rx1 = r->x * scale1;
 
 			if (dst_y < height) {
 				dst_h = r->h;

--- a/backends/platform/psp/memory.h
+++ b/backends/platform/psp/memory.h
@@ -33,7 +33,7 @@
 
 // These instructions don't generate automatically but are faster then copying byte by byte
 inline void lwl_copy(byte *dst, const byte *src) {
-	register uint32 data;
+	uint32 data;
 	asm volatile ("lwr %0,0(%1)\n\t"
 		 "lwl %0,3(%1)\n\t"
 		 : "=&r" (data) : "r" (src), "m" (*src));

--- a/backends/platform/psp/trace.cpp
+++ b/backends/platform/psp/trace.cpp
@@ -86,8 +86,8 @@ void PspDebugTrace(bool alsoToScreen, const char *format, ...) {
 //
 void mipsBacktrace(uint32 levels, void **addresses) {
 	// get the current return address
-	register byte *retAddr;
-	register byte *stackPointer;
+	byte *retAddr;
+	byte *stackPointer;
 	GET_RET(retAddr);
 	GET_SP(stackPointer);
 	char string[100];

--- a/backends/platform/symbian/src/portdefs.h
+++ b/backends/platform/symbian/src/portdefs.h
@@ -99,9 +99,9 @@ typedef signed long int int32;
 	/* convert double float to double int (dfdi) */
 	long long inline
 	scumm_fixdfdi (double a1) { // __fixdfdi (double a1)
-	    register union double_long dl1;
-	    register int exp;
-	    register long long l;
+	    union double_long dl1;
+	    int exp;
+	    long long l;
 
 	    dl1.d = a1;
 

--- a/backends/platform/symbian/src/vsnprintf.h
+++ b/backends/platform/symbian/src/vsnprintf.h
@@ -212,17 +212,17 @@
 #endif
 
 #define fast_memcpy(d,s,n) \
-{ register size_t nn = (size_t)(n); \
+{ size_t nn = (size_t)(n); \
     if (nn >= breakeven_point) memcpy((d), (s), nn); \
     else if (nn > 0) { /* proc call overhead is worth only for large strings*/\
-	register char *dd; register const char *ss; \
+	char *dd; const char *ss; \
 for (ss=(s), dd=(d); nn>0; nn--) *dd++ = *ss++; } }
 
 #define fast_memset(d,c,n) \
-{ register size_t nn = (size_t)(n); \
+{ size_t nn = (size_t)(n); \
     if (nn >= breakeven_point) memset((d), (int)(c), nn); \
     else if (nn > 0) { /* proc call overhead is worth only for large strings*/\
-	register char *dd; register const int cc=(int)(c); \
+	char *dd; const int cc=(int)(c); \
 for (dd=(d); nn>0; nn--) *dd++ = cc; } }
 
 

--- a/common/math.h
+++ b/common/math.h
@@ -98,7 +98,7 @@ static const char LogTable256[256] = {
 };
 
 inline int intLog2(uint32 v) {
-	register uint32 t, tt;
+	uint32 t, tt;
 
 	if ((tt = v >> 16))
 		return (t = tt >> 8) ? 24 + LogTable256[t] : 16 + LogTable256[tt];

--- a/engines/agi/sound_sarien.cpp
+++ b/engines/agi/sound_sarien.cpp
@@ -237,7 +237,7 @@ void SoundGenSarien::playSound() {
 }
 
 uint32 SoundGenSarien::mixSound() {
-	register int i, p;
+	int i, p;
 	const int16 *src;
 	int c, b, m;
 

--- a/engines/cge/cge_main.cpp
+++ b/engines/cge/cge_main.cpp
@@ -378,7 +378,7 @@ void CGEEngine::syncGame(Common::SeekableReadStream *readStream, Common::WriteSt
 
 	if (s.isSaving()) {
 		for (int i = 0; i < kPocketNX; i++) {
-			register Sprite *pocSpr = _pocket[i];
+			Sprite *pocSpr = _pocket[i];
 			_pocref[i] = (pocSpr) ? pocSpr->_ref : -1;
 		}
 
@@ -417,7 +417,7 @@ void CGEEngine::syncGame(Common::SeekableReadStream *readStream, Common::WriteSt
 			}
 
 			for (int i = 0; i < kPocketNX; i++) {
-				register int r = _pocref[i];
+				int r = _pocref[i];
 				_pocket[i] = (r < 0) ? NULL : _vga->_spareQ->locate(r);
 			}
 		}

--- a/engines/cge/snail.cpp
+++ b/engines/cge/snail.cpp
@@ -1192,7 +1192,7 @@ void CGEEngine::snFlash(bool on) {
 		if (pal) {
 			memcpy(pal, _vga->_sysPal, kPalSize);
 			for (int i = 0; i < kPalCount; i++) {
-				register int c;
+				int c;
 				c = pal[i]._r << 1;
 				pal[i]._r = (c < 64) ? c : 63;
 				c = pal[i]._g << 1;

--- a/engines/cge2/snail.cpp
+++ b/engines/cge2/snail.cpp
@@ -556,7 +556,7 @@ void CGE2Engine::snFlash(bool on) {
 		if (pal) {
 			memcpy(pal, _vga->_sysPal, kPalSize);
 			for (int i = 0; i < kPalCount; i++) {
-				register int c;
+				int c;
 				c = pal[i]._r << 1;
 				pal[i]._r = (c < 64) ? c : 63;
 				c = pal[i]._g << 1;

--- a/engines/tony/mpal/lzo.cpp
+++ b/engines/tony/mpal/lzo.cpp
@@ -77,10 +77,10 @@ namespace MPAL {
  * Decompresses an LZO compressed resource
  */
 int lzo1x_decompress(const byte *in, uint32 in_len, byte *out, uint32 *out_len) {
-	register byte *op;
-	register const byte *ip;
-	register uint32 t = 0;
-	register const byte *m_pos;
+	byte *op;
+	const byte *ip;
+	uint32 t = 0;
+	const byte *m_pos;
 
 	const byte * const ip_end = in + in_len;
 

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -52,7 +52,7 @@ inline frac_t fp_sqroot(uint32 x) {
 	// decreasing values. By feeding it the sqrt of the previous old x, as well
 	// as the old x, it should be possible to compute the correct sqrt with far
 	// fewer than 23 iterations.
-	register uint32 root, remHI, remLO, testDIV, count;
+	uint32 root, remHI, remLO, testDIV, count;
 
 	root = 0;
 	remHI = 0;
@@ -443,10 +443,10 @@ namespace Graphics {
  */
 template<typename PixelType>
 void colorFill(PixelType *first, PixelType *last, PixelType color) {
-	register int count = (last - first);
+	int count = (last - first);
 	if (!count)
 		return;
-	register int n = (count + 7) >> 3;
+	int n = (count + 7) >> 3;
 	switch (count % 8) {
 	case 0: do {
 				*first++ = color;	// fall through
@@ -466,26 +466,26 @@ void colorFillClip(PixelType *first, PixelType *last, PixelType color, int realX
 	if (realY < clippingArea.top || realY >= clippingArea.bottom)
 		return;
 
-	register int count = (last - first);
+	int count = (last - first);
 
 	if (realX > clippingArea.right || realX + count < clippingArea.left)
 		return;
 
 	if (realX < clippingArea.left) {
-		register int diff = (clippingArea.left - realX);
+		int diff = (clippingArea.left - realX);
 		realX += diff;
 		count -= diff;
 	}
 
 	if (clippingArea.right <= realX + count) {
-		register int diff = (realX + count - clippingArea.right);
+		int diff = (realX + count - clippingArea.right);
 		count -= diff;
 	}
 
 	if (!count)
 		return;
 
-	register int n = (count + 7) >> 3;
+	int n = (count + 7) >> 3;
 	switch (count % 8) {
 	case 0: do {
 		*first++ = color;	// fall through

--- a/graphics/scaler/2xsai.cpp
+++ b/graphics/scaler/2xsai.cpp
@@ -92,7 +92,7 @@ void Super2xSaITemplate(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uin
 			} else if (color5 == color3 && color2 != color6) {
 				product2b = product1b = color5;
 			} else if (color5 == color3 && color2 == color6) {
-				register int r = 0;
+				int r = 0;
 
 				r += GetResult(color6, color5, color1, colorA1);
 				r += GetResult(color6, color5, color4, colorB1);
@@ -227,7 +227,7 @@ void SuperEagleTemplate(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uin
 						product2a = interpolate_1_1(color2, color3);
 					}
 				} else {
-					register int r = 0;
+					int r = 0;
 
 					r += GetResult(color6, color5, color1, colorA1);
 					r += GetResult(color6, color5, color4, colorB1);
@@ -282,8 +282,7 @@ void _2xSaITemplate(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 
 
 		for (int i = 0; i < width; ++i) {
 
-			register unsigned colorA, colorB;
-			unsigned colorC, colorD,
+			unsigned colorA, colorB, colorC, colorD,
 				colorE, colorF, colorG, colorH, colorI, colorJ, colorK, colorL, colorM, colorN, colorO;
 			unsigned product, product1, product2;
 
@@ -347,7 +346,7 @@ void _2xSaITemplate(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 
 					product1 = colorA;
 					product2 = colorA;
 				} else {
-					register int r = 0;
+					int r = 0;
 
 					product1 = interpolate_1_1(colorA, colorC);
 					product = interpolate_1_1(colorA, colorB);

--- a/graphics/scaler/hq2x.cpp
+++ b/graphics/scaler/hq2x.cpp
@@ -103,7 +103,7 @@ extern "C" uint32   *RGBtoYUV;
  */
 template<typename ColorMask>
 static void HQ2x_implementation(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height) {
-	register int w1, w2, w3, w4, w5, w6, w7, w8, w9;
+	int w1, w2, w3, w4, w5, w6, w7, w8, w9;
 
 	const uint32 nextlineSrc = srcPitch / sizeof(uint16);
 	const uint16 *p = (const uint16 *)srcPtr;

--- a/graphics/scaler/hq3x.cpp
+++ b/graphics/scaler/hq3x.cpp
@@ -106,7 +106,7 @@ extern "C" uint32   *RGBtoYUV;
  */
 template<typename ColorMask>
 static void HQ3x_implementation(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height) {
-	register int  w1, w2, w3, w4, w5, w6, w7, w8, w9;
+	int  w1, w2, w3, w4, w5, w6, w7, w8, w9;
 
 	const uint32 nextlineSrc = srcPitch / sizeof(uint16);
 	const uint16 *p = (const uint16 *)srcPtr;

--- a/graphics/scaler/intern.h
+++ b/graphics/scaler/intern.h
@@ -46,8 +46,8 @@ static inline uint32 interpolate32_1_1(uint32 p1, uint32 p2) {
  */
 template<typename ColorMask>
 static inline uint32 interpolate32_3_1(uint32 p1, uint32 p2) {
-	register uint32 x = ((p1 & ColorMask::qhighBits) >> 2) * 3 + ((p2 & ColorMask::qhighBits) >> 2);
-	register uint32 y = ((p1 & ColorMask::qlowBits) * 3 + (p2 & ColorMask::qlowBits)) >> 2;
+	uint32 x = ((p1 & ColorMask::qhighBits) >> 2) * 3 + ((p2 & ColorMask::qhighBits) >> 2);
+	uint32 y = ((p1 & ColorMask::qlowBits) * 3 + (p2 & ColorMask::qlowBits)) >> 2;
 
 	y &= ColorMask::qlowBits;
 	return x + y;

--- a/graphics/yuv_to_rgb.cpp
+++ b/graphics/yuv_to_rgb.cpp
@@ -207,7 +207,7 @@ void convertYUV444ToRGB(byte *dstPtr, int dstPitch, const YUVToRGBLookup *lookup
 
 	for (int h = 0; h < yHeight; h++) {
 		for (int w = 0; w < yWidth; w++) {
-			register const uint32 *L;
+			const uint32 *L;
 
 			int16 cr_r  = Cr_r_tab[*vSrc];
 			int16 crb_g = Cr_g_tab[*vSrc] + Cb_g_tab[*uSrc];
@@ -256,7 +256,7 @@ void convertYUV420ToRGB(byte *dstPtr, int dstPitch, const YUVToRGBLookup *lookup
 
 	for (int h = 0; h < halfHeight; h++) {
 		for (int w = 0; w < halfWidth; w++) {
-			register const uint32 *L;
+			const uint32 *L;
 
 			int16 cr_r  = Cr_r_tab[*vSrc];
 			int16 crb_g = Cr_g_tab[*vSrc] + Cb_g_tab[*uSrc];
@@ -346,7 +346,7 @@ void convertYUV410ToRGB(byte *dstPtr, int dstPitch, const YUVToRGBLookup *lookup
 			// Declare some variables for the following macros
 			byte u, v;
 			int16 cr_r, crb_g, cb_b;
-			register const uint32 *L;
+			const uint32 *L;
 
 			READ_QUAD(uSrc, u);
 			READ_QUAD(vSrc, v);


### PR DESCRIPTION
The register keyword was deprecated from the C++11 standard,
<http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4193.html#809>,
and removed from the C++17 standard,
<http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4340>, so
cannot exist in a well-formed C++17 program.

It has never done anything in GCC
<https://gcc.gnu.org/ml/gcc/2010-05/msg00113.html>
and because of the way it is specified in the standard, it is “as
meaningful as whitespace”
<http://www.drdobbs.com/keywords-that-arent-or-comments-by-anoth/184403859>.

The one remaining use of the register keyword is in the DS backend,
where it is used to create a local register variable using the
non-standard GCC Extended Asm feature.