### PR TITLE
Revert "WAGE: Fix crashes for poorly initialized objects"

### DIFF
--- a/engines/wage/entities.h
+++ b/engines/wage/entities.h
@@ -125,7 +125,7 @@ public:
 
 	void setDesignBounds(Common::Rect *bounds);
 
-	Common::String toString() { if (!this) return "<NULL>"; return _name; }
+	Common::String toString() { return _name; }
 };
 
 class Chr : public Designed {

--- a/engines/wage/entities.h
+++ b/engines/wage/entities.h
@@ -125,7 +125,7 @@ public:
 
 	void setDesignBounds(Common::Rect *bounds);
 
-	Common::String toString() { return _name; }
+	Common::String toString() const { return _name; }
 };
 
 class Chr : public Designed {

--- a/engines/wage/script.cpp
+++ b/engines/wage/script.cpp
@@ -56,6 +56,13 @@
 
 namespace Wage {
 
+static Common::String toString(const Designed *d) {
+	if (!d)
+		return "<NULL>";
+	else
+		return d->toString();
+}
+
 Common::String Script::Operand::toString() {
 	switch(_type) {
 	case NUMBER:
@@ -64,13 +71,13 @@ Common::String Script::Operand::toString() {
 	case TEXT_INPUT:
 		return *_value.string;
 	case OBJ:
-		return _value.obj->toString();
+		return Wage::toString(_value.obj);
 	case CHR:
-		return _value.chr->toString();
+		return Wage::toString(_value.chr);
 	case SCENE:
-		return _value.scene->toString();
+		return Wage::toString(_value.scene);
 	case CLICK_INPUT:
-		return _value.inputClick->toString();
+		return Wage::toString(_value.inputClick);
 	default:
 		error("Unhandled operand type: _type");
 	}

--- a/engines/wage/script.cpp
+++ b/engines/wage/script.cpp
@@ -63,13 +63,24 @@ static Common::String toString(const Designed *d) {
 		return d->toString();
 }
 
-Common::String Script::Operand::toString() {
+static Common::String toString(const Common::String *d) {
+	if (!d)
+		return "<NULL>";
+	else
+		return *d;
+}
+
+static Common::String toString(int16 val) {
+	return Common::String::format("%d", val);
+}
+
+Common::String Script::Operand::toString() const {
 	switch(_type) {
 	case NUMBER:
-		return Common::String::format("%d", _value.number);
+		return Wage::toString(_value.number);
 	case STRING:
 	case TEXT_INPUT:
-		return *_value.string;
+		return Wage::toString(_value.string);
 	case OBJ:
 		return Wage::toString(_value.obj);
 	case CHR:

--- a/engines/wage/script.cpp
+++ b/engines/wage/script.cpp
@@ -90,7 +90,7 @@ Common::String Script::Operand::toString() const {
 	case CLICK_INPUT:
 		return Wage::toString(_value.inputClick);
 	default:
-		error("Unhandled operand type: _type");
+		error("Unhandled operand type: %d", (int)_type);
 	}
 }
 

--- a/engines/wage/script.h
+++ b/engines/wage/script.h
@@ -119,7 +119,7 @@ private:
 				delete _value.string;
 		}
 
-		Common::String toString();
+		Common::String toString() const;
 	};
 
 	struct ScriptText {


### PR DESCRIPTION
This reverts commit ea0fb987e042a86b8da683cafa7b9cf04d1636e6.

This issue was discovered during a full build of ScummVM using Clang 5,
which was generating a warning about this code since it is not valid.

It is UB to call a null pointer. Whatever caller is trying to do so needs
to be fixed instead.

My opinion is that keeping this workaround in the codebase instead of
fixing the bad calls runs the risk of allowing more bad calls to slip in
during development of the engine, and may make it more difficult (if it
is not already very difficult already since this engine has not been
worked on for a while) remember what the condition was where this invalid
call happened and fix it.