### PR TITLE
CRYO: Stop packing struct containing pointers

### DIFF
--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -3126,13 +3126,11 @@ void EdenGame::tyranDies(perso_t *perso) {
 }
 
 void EdenGame::specialObjects(perso_t *perso, char objid) {
-#pragma pack(push, 1)
 	struct SpecialObject {
 		int8  _characterType;
 		int8  _objectId;
 		void  (EdenGame::*dispFct)(perso_t *perso);
 	};
-#pragma pack(pop)
 
 	static SpecialObject kSpecialObjectActions[] = {
 		//    persoType, objectId, dispFct


### PR DESCRIPTION
This struct packing causes the pointer-to-member-function to become
unaligned, and does not seem necessary in any way.

This was added in commit 7bf6e1e8502 by @Strangerke, and I asked
about this a few weeks ago but received no more information, so
I’m opening this as a reminder (and also as a friendly threat 😇)
that I’ll go ahead with removing the pragma soon unless more
clarity can be added around why it is needed. Thanks!