### PR TITLE
SKY: Fix unaligned pointer dereferences

### DIFF
--- a/engines/sky/compact.cpp
+++ b/engines/sky/compact.cpp
@@ -311,24 +311,47 @@ const char *SkyCompact::nameForType(uint16 type) {
 		return _typeNames[type];
 }
 
-uint16 *SkyCompact::getSub(Compact *cpt, uint16 mode) {
+uint16 SkyCompact::getSub(Compact *cpt, uint16 mode) {
 	switch (mode) {
 	case 0:
-		return &(cpt->baseSub);
+		return cpt->baseSub;
 	case 2:
-		return &(cpt->baseSub_off);
+		return cpt->baseSub_off;
 	case 4:
-		return &(cpt->actionSub);
+		return cpt->actionSub;
 	case 6:
-		return &(cpt->actionSub_off);
+		return cpt->actionSub_off;
 	case 8:
-		return &(cpt->getToSub);
+		return cpt->getToSub;
 	case 10:
-		return &(cpt->getToSub_off);
+		return cpt->getToSub_off;
 	case 12:
-		return &(cpt->extraSub);
+		return cpt->extraSub;
 	case 14:
-		return &(cpt->extraSub_off);
+		return cpt->extraSub_off;
+	default:
+		error("Invalid Mode (%d)", mode);
+	}
+}
+
+void SkyCompact::setSub(Compact *cpt, uint16 mode, uint16 value) {
+	switch (mode) {
+	case 0:
+		cpt->baseSub = value;
+	case 2:
+		cpt->baseSub_off = value;
+	case 4:
+		cpt->actionSub = value;
+	case 6:
+		cpt->actionSub_off = value;
+	case 8:
+		cpt->getToSub = value;
+	case 10:
+		cpt->getToSub_off = value;
+	case 12:
+		cpt->extraSub = value;
+	case 14:
+		cpt->extraSub_off = value;
 	default:
 		error("Invalid Mode (%d)", mode);
 	}

--- a/engines/sky/compact.h
+++ b/engines/sky/compact.h
@@ -62,7 +62,8 @@ public:
 	~SkyCompact();
 	Compact *fetchCpt(uint16 cptId);
 	Compact *fetchCptInfo(uint16 cptId, uint16 *elems = NULL, uint16 *type = NULL, char *name = NULL);
-	static uint16 *getSub(Compact *cpt, uint16 mode);
+	static uint16 getSub(Compact *cpt, uint16 mode);
+	static void setSub(Compact *cpt, uint16 mode, uint16 value);
 	static MegaSet *getMegaSet(Compact *cpt);
 	uint16 *getGrafixPtr(Compact *cpt);
 	uint16 *getTurnTable(Compact *cpt, uint16 dir);


### PR DESCRIPTION
Dereferencing an unaligned pointer will cause a memory fault on
at least older ARM and SPARC architectures, and is warned about
starting in Clang 4.