### PR TITLE
SCUMM: Remove dead code

### DIFF
--- a/engines/scumm/he/wiz_he.cpp
+++ b/engines/scumm/he/wiz_he.cpp
@@ -2577,8 +2577,6 @@ void Wiz::processWizImage(const WizParameters *params) {
 					if (f->read(p, size) != size) {
 						_vm->_res->nukeResource(rtImage, params->img.resNum);
 						error("i/o error when reading '%s'", params->filename);
-						_vm->VAR(_vm->VAR_GAME_LOADED) = -2;
-						_vm->VAR(119) = -2;
 					} else {
 						_vm->_res->setModified(rtImage, params->img.resNum);
 						_vm->VAR(_vm->VAR_GAME_LOADED) = 0;
@@ -2616,7 +2614,6 @@ void Wiz::processWizImage(const WizParameters *params) {
 					uint32 size = READ_BE_UINT32(p + 4);
 					if (f->write(p, size) != size) {
 						error("i/o error when writing '%s'", params->filename);
-						_vm->VAR(119) = -2;
 					} else {
 						_vm->VAR(119) = 0;
 					}

--- a/engines/scumm/imuse/imuse_player.cpp
+++ b/engines/scumm/imuse/imuse_player.cpp
@@ -359,10 +359,8 @@ void Player::send(uint32 b) {
 	default:
 		if (!_scanning) {
 			error("Player::send(): Invalid command %d", cmd);
-			clear();
 		}
 	}
-	return;
 }
 
 void Player::sysEx(const byte *p, uint16 len) {

--- a/engines/scumm/imuse_digi/dimuse_codecs.cpp
+++ b/engines/scumm/imuse_digi/dimuse_codecs.cpp
@@ -645,8 +645,6 @@ int32 decompressCodec(int32 codec, byte *compInput, byte *compOutput, int32 inpu
 
 	default:
 		error("BundleCodecs::decompressCodec() Unknown codec %d", (int)codec);
-		outputSize = 0;
-		break;
 	}
 
 	return outputSize;

--- a/engines/scumm/imuse_digi/dimuse_sndmgr.cpp
+++ b/engines/scumm/imuse_digi/dimuse_sndmgr.cpp
@@ -216,8 +216,6 @@ void ImuseDigiSndMgr::prepareSound(byte *ptr, SoundDesc *sound) {
 				break;
 			default:
 				error("Invalid code in VOC file : %d", code);
-				quit = true;
-				break;
 			}
 			offset += len;
 		}

--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -152,10 +152,6 @@ void ScummEngine::setOwnerOf(int obj, int owner) {
 		if (ss->where == WIO_INVENTORY) {
 			if (ss->number < _numInventory && _inventory[ss->number] == obj) {
 				error("Odd setOwnerOf case #1: Please report to Fingolfin where you encountered this");
-				putOwner(obj, 0);
-				runInventoryScript(arg);
-				stopObjectCode();
-				return;
 			}
 			if (ss->number == obj)
 				error("Odd setOwnerOf case #2: Please report to Fingolfin where you encountered this");

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -776,7 +776,6 @@ void ScummEngine_v5::o5_divide() {
 	a = getVarOrDirectWord(PARAM_1);
 	if (a == 0) {
 		error("Divide by zero");
-		setResult(0);
 	} else
 		setResult(readVar(_resultVarNumber) / a);
 }

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -1304,8 +1304,6 @@ int ScummEngine::readSoundResource(ResId idx) {
 
 		if (!dmuFile.open(buffer)) {
 			error("Can't open music file %s", buffer);
-			_res->_types[rtSound][idx]._roomoffs = RES_INVALID_OFFSET;
-			return 0;
 		}
 		dmuFile.seek(4, SEEK_SET);
 		total_size = dmuFile.readUint32BE();


### PR DESCRIPTION
Clang optionally warns about this dead code. If there is
some reason not to delete it all outright (which is why I
open this as a PR instead of just committing this deletion
directly), `#if 0` should be added around the dead code to
suppress the warning.