### PR TITLE
SCUMM: Fix stack overflows

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -768,7 +768,7 @@ void Actor::startWalkAnim(int cmd, int angle) {
 	 * work as usual
 	 */
 	if (_walkScript) {
-		int args[16];
+		int args[NUM_SCRIPT_LOCAL];
 		memset(args, 0, sizeof(args));
 		args[0] = _number;
 		args[1] = cmd;

--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -2844,7 +2844,7 @@ void Actor::runActorTalkScript(int f) {
 
 	if (_talkScript) {
 		int script = _talkScript;
-		int args[16];
+		int args[NUM_SCRIPT_LOCAL];
 		memset(args, 0, sizeof(args));
 		args[1] = f;
 		args[0] = _number;


### PR DESCRIPTION
These two fixes should be good to go as-is, but I wanted
to open this as a PR anyway since I don’t think these are the
only two places where there is a stack overflow in SCUMM, didn’t
want to commit these and not check all the other places first,
but I don’t have the time right now to do research on all the
other places where I found some `int args[N]` in the codebase.
So maybe someone else can look for me? It could be an interesting
small project taking an hour or two, and I would appreciate it.