### PR TITLE
PORTS: Remove the Zaurus and Yopy ports

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -320,17 +320,10 @@ void SdlEventSource::SDLModToOSystemKeyFlags(SDLMod mod, Common::Event &event) {
 
 	event.kbd.flags = 0;
 
-#ifdef LINUPY
-	// Yopy has no ALT key, steal the SHIFT key
-	// (which isn't used much anyway)
-	if (mod & KMOD_SHIFT)
-		event.kbd.flags |= Common::KBD_ALT;
-#else
 	if (mod & KMOD_SHIFT)
 		event.kbd.flags |= Common::KBD_SHIFT;
 	if (mod & KMOD_ALT)
 		event.kbd.flags |= Common::KBD_ALT;
-#endif
 	if (mod & KMOD_CTRL)
 		event.kbd.flags |= Common::KBD_CTRL;
 	if (mod & KMOD_META)
@@ -937,34 +930,6 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 }
 
 bool SdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
-#ifdef LINUPY
-	// On Yopy map the End button to quit
-	if ((ev.key.keysym.sym == 293)) {
-		event.type = Common::EVENT_QUIT;
-		return true;
-	}
-	// Map menu key to f5 (scumm menu)
-	if (ev.key.keysym.sym == 306) {
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = Common::KEYCODE_F5;
-		event.kbd.ascii = mapKey(SDLK_F5, ev.key.keysym.mod, 0);
-		return true;
-	}
-	// Map action key to action
-	if (ev.key.keysym.sym == 291) {
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = Common::KEYCODE_TAB;
-		event.kbd.ascii = mapKey(SDLK_TAB, ev.key.keysym.mod, 0);
-		return true;
-	}
-	// Map OK key to skip cinematic
-	if (ev.key.keysym.sym == 292) {
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = Common::KEYCODE_ESCAPE;
-		event.kbd.ascii = mapKey(SDLK_ESCAPE, ev.key.keysym.mod, 0);
-		return true;
-	}
-#endif
 
 #ifdef QTOPIA
 	// Quit on fn+backspace on zaurus

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -930,41 +930,6 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 }
 
 bool SdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
-
-#ifdef QTOPIA
-	// Quit on fn+backspace on zaurus
-	if (ev.key.keysym.sym == 127) {
-		event.type = Common::EVENT_QUIT;
-		return true;
-	}
-
-	// Map menu key (f11) to f5 (scumm menu)
-	if (ev.key.keysym.sym == SDLK_F11) {
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = Common::KEYCODE_F5;
-		event.kbd.ascii = mapKey(SDLK_F5, ev.key.keysym.mod, 0);
-	}
-	// Map center (space) to tab (default action)
-	// I wanted to map the calendar button but the calendar comes up
-	else if (ev.key.keysym.sym == SDLK_SPACE) {
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = Common::KEYCODE_TAB;
-		event.kbd.ascii = mapKey(SDLK_TAB, ev.key.keysym.mod, 0);
-	}
-	// Since we stole space (pause) above we'll rebind it to the tab key on the keyboard
-	else if (ev.key.keysym.sym == SDLK_TAB) {
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = Common::KEYCODE_SPACE;
-		event.kbd.ascii = mapKey(SDLK_SPACE, ev.key.keysym.mod, 0);
-	} else {
-	// Let the events fall through if we didn't change them, this may not be the best way to
-	// set it up, but i'm not sure how sdl would like it if we let if fall through then redid it though.
-	// and yes i have an huge terminal size so i dont wrap soon enough.
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = ev.key.keysym.sym;
-		event.kbd.ascii = mapKey(ev.key.keysym.sym, ev.key.keysym.mod, ev.key.keysym.unicode);
-	}
-#endif
 	return false;
 }
 

--- a/configure
+++ b/configure
@@ -928,7 +928,6 @@ Special configuration feature:
                                            gp2xwiz for GP2X Wiz
                                            iphone for Apple iPhone (iOS <= 6)
                                            ios7 for Apple iPhone / iPad (iOS >= 7)
-                                           linupy for Yopy PDA
                                            maemo for Nokia Maemo
                                            motoezx for MotoEZX
                                            motomagx for MotoMAGX
@@ -1505,10 +1504,6 @@ ios7)
 	_host_os=iphone
 	_host_cpu=arm
 	_host_alias=arm-apple-darwin11
-	;;
-linupy)
-	_host_os=linux
-	_host_cpu=arm
 	;;
 maemo)
 	_host_os=maemo
@@ -3044,9 +3039,6 @@ if test -n "$_host"; then
 			_build_scalers=no
 			_seq_midi=no
 			_timidity=no
-			;;
-		linupy)
-			append_var DEFINES "-DLINUPY"
 			;;
 		m68k-atari-mint)
 			append_var DEFINES "-DSYSTEM_NOT_SUPPORTING_D_TYPE"

--- a/engines/cge/snail.cpp
+++ b/engines/cge/snail.cpp
@@ -497,7 +497,7 @@ void CGEEngine::snGame(Sprite *spr, int num) {
 		// the test has been restricted to some specific OSes
 		// in order to avoid some obvious issues (like Android, iOS, NDS, N64...)
 		// Not perfect, but at least better than nothing.
-#if defined(WIN32) || defined(UNIX) || defined(MACOSX) || defined(MOTOEZX) || defined(LINUPY) || defined(LINUXMOTO_SDL)
+#if defined(WIN32) || defined(UNIX) || defined(MACOSX) || defined(MOTOEZX) || defined(LINUXMOTO_SDL)
 		if (spr->_ref == 1 && _keyboard->_keyAlt) {
 #else
 		if (spr->_ref == 1 && _gameCase2Cpt > 1) {


### PR DESCRIPTION
* Yopy: https://en.wikipedia.org/wiki/Yopy
Production ceased in 2005. There was never an official release. I can't find traces of an unofficial release.

* Zaurus: https://fr.wikipedia.org/wiki/Zaurus
Production ceased in 2007. There was never an official release. The last unofficial release of ScummVM was 0.6.0.

I'm working on improving the keymapper. They look very obsolete, I'd rather remove them than port them to the new model.