### PR TITLE
 RISCOS: Don't list RISC OS as a POSIX platform

### DIFF
--- a/backends/platform/null/null.cpp
+++ b/backends/platform/null/null.cpp
@@ -47,6 +47,8 @@
 	#include "backends/fs/amigaos4/amigaos4-fs-factory.h"
 #elif defined(POSIX)
 	#include "backends/fs/posix/posix-fs-factory.h"
+#elif defined(RISCOS)
+	#include "backends/fs/riscos/riscos-fs-factory.h"
 #elif defined(WIN32)
 	#include "backends/fs/windows/windows-fs-factory.h"
 #endif
@@ -73,6 +75,8 @@ OSystem_NULL::OSystem_NULL() {
 		_fsFactory = new AmigaOSFilesystemFactory();
 	#elif defined(POSIX)
 		_fsFactory = new POSIXFilesystemFactory();
+	#elif defined(RISCOS)
+		_fsFactory = new RISCOSFilesystemFactory();
 	#elif defined(WIN32)
 		_fsFactory = new WindowsFilesystemFactory();
 	#else

--- a/backends/platform/sdl/posix/posix-main.cpp
+++ b/backends/platform/sdl/posix/posix-main.cpp
@@ -22,7 +22,7 @@
 
 #include "common/scummsys.h"
 
-#if defined(POSIX) && !defined(MACOSX) && !defined(SAMSUNGTV) && !defined(MAEMO) && !defined(WEBOS) && !defined(LINUXMOTO) && !defined(GPH_DEVICE) && !defined(GP2X) && !defined(DINGUX) && !defined(OPENPANDORA) && !defined(PLAYSTATION3) && !defined(PSP2) && !defined(ANDROIDSDL) && !defined(RISCOS)
+#if defined(POSIX) && !defined(MACOSX) && !defined(SAMSUNGTV) && !defined(MAEMO) && !defined(WEBOS) && !defined(LINUXMOTO) && !defined(GPH_DEVICE) && !defined(GP2X) && !defined(DINGUX) && !defined(OPENPANDORA) && !defined(PLAYSTATION3) && !defined(PSP2) && !defined(ANDROIDSDL)
 
 #include "backends/platform/sdl/posix/posix.h"
 #include "backends/plugins/sdl/sdl-provider.h"

--- a/configure
+++ b/configure
@@ -2844,8 +2844,6 @@ if test -n "$_host"; then
 		arm-linux|arm*-linux-gnueabi|arm-*-linux)
 			;;
 		arm-*riscos)
-			_seq_midi=no
-			_timidity=no
 			_opengl_mode=none
 			_build_hq_scalers=no
 			# toolchain binaries prefixed by host
@@ -3608,10 +3606,10 @@ esac
 #
 echo_n "Checking if host is POSIX compliant... "
 case $_host_os in
-	amigaos* | cygwin* | dreamcast | ds | gamecube | mingw* | n64 | ps2 | ps3 | psp2 | psp | wii | wince)
+	amigaos* | cygwin* | dreamcast | ds | gamecube | mingw* | n64 | ps2 | ps3 | psp2 | psp | riscos | wii | wince)
 		_posix=no
 		;;
-	3ds | android | androidsdl | beos* | bsd* | darwin* | freebsd* | gnu* | gph-linux | haiku* | hpux* | iphone | ios7 | irix*| k*bsd*-gnu* | linux* | maemo | mint* | netbsd* | openbsd* | riscos | solaris* | sunos* | uclinux* | webos)
+	3ds | android | androidsdl | beos* | bsd* | darwin* | freebsd* | gnu* | gph-linux | haiku* | hpux* | iphone | ios7 | irix*| k*bsd*-gnu* | linux* | maemo | mint* | netbsd* | openbsd* | solaris* | sunos* | uclinux* | webos)
 		_posix=yes
 		;;
 	os2-emx*)


### PR DESCRIPTION
Listing RISC OS as a POSIX platform initially allowed me to use the POSIX filesystem classes, however once the RISC OS filesystem classes were introduced, the RISC OS port no longer makes any meaningful use of ScummVM's POSIX functionality, with some exceptions.

This disables the POSIX-specific code in Networking for now, this is something I'll address in a separate PR.
The key combination has also changed from Ctrl-Q to Ctrl-Z. I'm not sure what to do about this at the moment - neither combination is standard on RISC OS (although I've seen at least one program use Ctrl-Q). Thoughts?