### PR TITLE
Proposed Fix for PSP Aspect Ratio Preservation in 4:3

### DIFF
--- a/backends/platform/psp/display_manager.h
+++ b/backends/platform/psp/display_manager.h
@@ -106,6 +106,7 @@ public:
 	enum GraphicsModeID {			///> Possible output formats onscreen
 		ORIGINAL_RESOLUTION,
 		KEEP_ASPECT_RATIO,
+		ASPECT_RATIO_CORRECTION,
 		STRETCHED_FULL_SCREEN
 	};
 	DisplayManager() : _screen(0), _cursor(0), _overlay(0), _keyboard(0),
@@ -118,7 +119,7 @@ public:
 	bool setGraphicsMode(int mode);
 	bool setGraphicsMode(const char *name);
 	int getGraphicsMode() const { return _graphicsMode; }
-	uint32 getDefaultGraphicsMode() const { return STRETCHED_FULL_SCREEN; }
+	uint32 getDefaultGraphicsMode() const { return KEEP_ASPECT_RATIO; }
 	const OSystem::GraphicsMode* getSupportedGraphicsModes() const { return _supportedModes; }
 
 	// Setters for pointers


### PR DESCRIPTION
This patch is derived from dam-soft's information on bug #10239 "PSP port incorrect 4:3 aspect radio":
https://bugs.scummvm.org/ticket/10239

This should be reviewed by the PSP porter prior to merging.