### PR TITLE
 VKEYBD: Fallback to SearchMan when loading keyboard packs

### DIFF
--- a/backends/platform/maemo/maemo.cpp
+++ b/backends/platform/maemo/maemo.cpp
@@ -108,8 +108,6 @@ void OSystem_SDL_Maemo::initBackend() {
 		_keymapperDefaultBindings = new Common::KeymapperDefaultBindings();
 #endif
 
-	ConfMan.set("vkeybdpath", DATA_PATH);
-
 	_model = detectModel();
 
 #ifdef ENABLE_KEYMAPPER

--- a/backends/platform/sdl/ps3/ps3.cpp
+++ b/backends/platform/sdl/ps3/ps3.cpp
@@ -59,7 +59,6 @@ void OSystem_PS3::init() {
 
 void OSystem_PS3::initBackend() {
 	ConfMan.set("joystick_num", 0);
-	ConfMan.set("vkeybdpath", PREFIX "/data");
 	ConfMan.registerDefault("fullscreen", true);
 	ConfMan.registerDefault("aspect_ratio", true);
 

--- a/backends/platform/sdl/psp2/psp2.cpp
+++ b/backends/platform/sdl/psp2/psp2.cpp
@@ -73,7 +73,6 @@ void OSystem_PSP2::init() {
 void OSystem_PSP2::initBackend() {
 	
 	ConfMan.set("joystick_num", 0);
-	ConfMan.set("vkeybdpath", PREFIX "/data");
 	ConfMan.registerDefault("fullscreen", true);
 	ConfMan.registerDefault("aspect_ratio", false);
 	ConfMan.registerDefault("gfx_mode", "2x");

--- a/backends/vkeybd/virtual-keyboard.h
+++ b/backends/vkeybd/virtual-keyboard.h
@@ -226,7 +226,7 @@ public:
 protected:
 
 	OSystem *_system;
-	Archive *_fileArchive;
+	DisposablePtr<Archive> _fileArchive;
 
 	friend class VirtualKeyboardGUI;
 	VirtualKeyboardGUI *_kbdGUI;
@@ -237,7 +237,7 @@ protected:
 	VirtualKeyboardParser *_parser;
 
 	void reset();
-	bool openPack(const String &packName, const FSNode &node);
+	bool openPack(const String &packName, Archive *searchPath, DisposeAfterUse::Flag disposeSearchPath);
 	void deleteEvents();
 	bool checkModeResolutions();
 	void switchMode(Mode *newMode);

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -302,6 +302,22 @@ public:
 	bool operator_bool() const { return _pointer != nullptr; }
 
 	/**
+	 * Resets the pointer with the new value. Old object will be destroyed
+	 */
+	void reset(PointerType o, DisposeAfterUse::Flag dispose) {
+		if (_dispose) D()(_pointer);
+		_pointer = o;
+		_dispose = dispose;
+	}
+
+	/**
+	 * Clears the pointer. Old object will be destroyed
+	 */
+	void reset() {
+		reset(nullptr, DisposeAfterUse::NO);
+	}
+
+	/**
 	 * Returns the plain pointer value.
 	 *
 	 * @return the pointer the DisposablePtr manages


### PR DESCRIPTION
Virtual keyboard data files are now searched in the `datadir` provided at configure time.
This allows ports to use the virtual keyboard without custom code or shipping default configuration.