### PR TITLE
NEVERHOOD: Graceful shutdown of the engine

### DIFF
--- a/engines/neverhood/neverhood.cpp
+++ b/engines/neverhood/neverhood.cpp
@@ -182,9 +182,6 @@ void NeverhoodEngine::mainLoop() {
 			case Common::EVENT_WHEELDOWN:
 				_gameModule->handleWheelDown();
 				break;
-			case Common::EVENT_QUIT:
-				_system->quit();
-				break;
 			default:
 				break;
 			}


### PR DESCRIPTION
Currently the Neverhood-Engine kills the mainprocess instead of breaking the gameloop on shutdown. The WII throws an dsi error after closing the game.
