### PR TITLE
SCUMM: really implement lipsync

### DIFF
--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -448,14 +448,15 @@ void Sound::processSfxQueues() {
 			finished = !isSoundRunning(1);
 		} else {
 			finished = !_mixer->isSoundHandleActive(*_talkChannelHandle);
+			// calculate speech sound position simulating increment at 60FPS
+			_curSoundPos = (_mixer->getSoundElapsedTime(*_talkChannelHandle) * 60) / 1000;
 		}
 
 		if ((uint) act < 0x80 && ((_vm->_game.version == 8) || (_vm->_game.version <= 7 && !_vm->_string[0].no_talk_anim))) {
 			a = _vm->derefActor(act, "processSfxQueues");
 			if (a->isInCurrentRoom()) {
-				if (isMouthSyncOff(_curSoundPos) && !_mouthSyncMode) {
-					if (!_endOfMouthSync)
-						a->runActorTalkScript(a->_talkStopFrame);
+				if (isMouthSyncOff(_curSoundPos) && _mouthSyncMode) {
+					a->runActorTalkScript(a->_talkStopFrame);
 					_mouthSyncMode = 0;
 				} else  if (isMouthSyncOff(_curSoundPos) == 0 && !_mouthSyncMode) {
 					a->runActorTalkScript(a->_talkStartFrame);


### PR DESCRIPTION
It looks like the code was there, but it was never fully implemented
because _curSoundPos was never being incremented. Experimentally,
it looks like it works if it is a 60FPS counter.