### PR TITLE
SCI: Fix segfault when some game data isn't found

### DIFF
--- a/engines/sci/resource.cpp
+++ b/engines/sci/resource.cpp
@@ -2918,6 +2918,9 @@ Common::String ResourceManager::findSierraGameId(const bool isBE) {
 		heap = findResource(ResourceId(kResourceTypeScript, 0), false);
 
 		Resource *vocab = findResource(ResourceId(kResourceTypeVocab, VOCAB_RESOURCE_SELECTORS), false);
+		if (!vocab)
+			return "";
+
 		const uint16 numSelectors = isBE ? vocab->getUint16BEAt(0) : vocab->getUint16LEAt(0);
 		for (uint16 i = 0; i < numSelectors; ++i) {
 			uint16 selectorOffset;


### PR DESCRIPTION
Note: I don't expect the game to be supported, but it certainly shouldn't segfault when it tries to read from it.

Seen when attempting to detect and/or run the Shivers 2 demo. The game data used can be downloaded from archive.org [here](https://archive.org/download/s2demozp/s2demozp.exe).

Steps to reproduce:

1. Download s2demozp.exe from the link above.
2. Extract the data using `7z x s2demozp.exe`
3. Run `scummvm -p . sci`

gdb backtrace:

    ~/downloads/s2demozp $ gdb ./scummvm/scummvm
    GNU gdb (GDB) 8.0.1
    [...]
    Reading symbols from ./scummvm/scummvm...done.
    (gdb) run -p . sci
    Starting program: /home/h3xx/downloads/svm/s2demozp/scummvm/scummvm -p . sci
    [Thread debugging using libthread_db enabled]
    Using host libthread_db library "/lib64/libthread_db.so.1".
    [New Thread 0x7fffec03b700 (LWP 12730)]
    [New Thread 0x7fffeab3d700 (LWP 12731)]
    [New Thread 0x7fffea33c700 (LWP 12732)]
    ALSA lib pcm.c:8323:(snd_pcm_recover) underrun occurred
    User picked target 'sci' (gameid 'sci')...
      Looking for a plugin supporting this gameid... SCI [SCI0, SCI01, SCI10, SCI11, SCI32]
      Starting 'Sierra SCI Game'
    The game in '/home/h3xx/downloads/svm/s2demozp' seems to be an unknown SCI
    [SCI0, SCI01, SCI10, SCI11, SCI32] engine game variant.

    Please report the following data to the ScummVM team at
    https://bugs.scummvm.org/ along with the name of the game you tried to add and
    its version, language, etc.:

    Matched game IDs: gk2, hoyle5, lsl7, lighthouse, mothergoosehires,
    phantasmagoria, phantasmagoria2, pqswat, shivers, torin

      {"ressci.000", 0, "7fbac0807a044c9543e8ac376d200e59", 4925003},
      {"resmap.000", 0, "d8659188b84beaef076bd869837cd530", 634},

    WARNING: Map version not detected, but volume version has been detected. Setting map version to volume version!

    Thread 1 "scummvm" received signal SIGSEGV, Segmentation fault.
    0x000000000042fad8 in Common::SpanBase<unsigned char const, Sci::SciSpan>::checkInvalidBounds (deltaInBytes=2, index=0, this=<optimized out>) at ./common/span.h:529
    529                     return index > impl().size() || deltaInBytes > (difference_type)impl().byteSize() || maxByteOffset > impl().byteSize();
    (gdb)

Seen in 6e2c702badcba7e3f16342d61436036353453f24, but also as far back as 866419fa71d398edcf087e67f7367deeadd04f14.