### PR TITLE
SCI32: Fix PQ4 Barbie patch Selector

### DIFF
--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -141,7 +141,7 @@ static const char *const selectorNameTable[] = {
 	"setScale",     // LSL6hires
 	"setScaler",    // LSL6hires
 	"readWord",     // LSL7, Phant1, Torin
-	"flag",         // PQ4
+	"points",       // PQ4
 	"select",       // PQ4
 	"handle",       // RAMA
 	"saveFilePtr",  // RAMA
@@ -214,7 +214,7 @@ enum ScriptPatcherSelectors {
 	SELECTOR_setScale,
 	SELECTOR_setScaler,
 	SELECTOR_readWord,
-	SELECTOR_flag,
+	SELECTOR_points,
 	SELECTOR_select,
 	SELECTOR_handle,
 	SELECTOR_saveFilePtr,
@@ -4644,7 +4644,7 @@ static const uint16 pq4CdSpeechAndSubtitlesPatch[] = {
 // bar earlier in the game, and checks local 3 then, so just check local 3 in
 // both cases to prevent the game from appearing to be in an unwinnable state
 // just because the player interacted in the "wrong" order.
-// Applies to at least: English floppy, German floppy, English CD
+// Applies to at least: English floppy, German floppy, English CD, German CD
 static const uint16 pq4BittyKittyShowBarieRedShoeSignature[] = {
 	// stripper::noun check is for checking, if police badge was shown
 	SIG_MAGICDWORD,
@@ -4652,7 +4652,7 @@ static const uint16 pq4BittyKittyShowBarieRedShoeSignature[] = {
 	0x35, 0x02,                         // ldi 2
 	0x1e,                               // gt?
 	0x30, SIG_UINT16(0x0028),           // bnt [skip 2 points code]
-	0x39, SIG_SELECTOR8(flag),          // pushi $61 (flag)
+	0x39, SIG_SELECTOR8(points),       // pushi $61 (points)
 	SIG_END
 };
 


### PR DESCRIPTION
Fixes [Trac#10392.](https://bugs.scummvm.org/ticket/10392)

Previous version of patch was using a Selector that is
different  then what my disasm of showShoe::changeState
shows (I get "points" Selector instead of "flag"
Selector).

Also "flag" selector is not in selector.h, but Selector
"points" is. I think this is probably why the crash in the
report is happening.

I have played through this part and it work (no crash
and get correct points when giving barbie shoe right
after showing badge).

Here is my disasm output for showShoe::changeState of script 315

0084:0ad6: 89 9a          lsg  	9a		; 154
0084:0ad8: 35 02          ldi  	02
0084:0ada: 1e             gt?  
0084:0adb: 30 28 00       bnt  	0028  [0b06]
0084:0ade: 39 61          pushi	61		; 97, 'a', points

If m_kiewitz really saw the "flag" Selector when he did disasm on the floppy version will my patch signature (using points) not get recognized for a floppy player? As you can see we both agree that the hex value of the selector is 61.