### PR TITLE
AUDIO: Fixes Protracker Portamento effect

### DIFF
--- a/audio/mods/protracker.cpp
+++ b/audio/mods/protracker.cpp
@@ -101,15 +101,13 @@ private:
 
 	void doPorta(int track) {
 		if (_track[track].portaToNote && _track[track].portaToNoteSpeed) {
-			if (_track[track].period < _track[track].portaToNote) {
-				_track[track].period += _track[track].portaToNoteSpeed;
-				if (_track[track].period > _track[track].portaToNote)
-					_track[track].period = _track[track].portaToNote;
-			} else if (_track[track].period > _track[track].portaToNote) {
-				_track[track].period -= _track[track].portaToNoteSpeed;
-				if (_track[track].period < _track[track].portaToNote)
-					_track[track].period = _track[track].portaToNote;
-			}
+			int distance = _track[track].period - _track[track].portaToNote;
+			int sign = distance > 0 ? 1 : -1;
+
+			if ((sign * distance) > _track[track].portaToNoteSpeed)
+				_track[track].period -= sign * _track[track].portaToNoteSpeed;
+			else
+				_track[track].period = _track[track].portaToNote;
 		}
 	}
 	void doVibrato(int track) {


### PR DESCRIPTION
Mission Supernova uses the ProtrackerStream to play its intro and outro music.
For some time I noticed sound artifacts but I couldn't find the cause on my side.
So, after some digging I tracked down an overflow in the 'Portamento to note' effect.

Currently agos, gob, hopkins and parallaction are the only engines besides Supernova
that make use of a ProtrackerStream.
I have tested it only on Supernova so far but if anyone is aware of sound glitches in the
mentioned engines, it would be great if you could test it or create a bug report.

EDIT: I uploaded a before/after video [here](https://www.youtube.com/watch?v=9PsFNE_VlnM)