### PR TITLE
AMIGA: Small rewrite of the readme to amigaguide converter scripts

### DIFF
--- a/dists/amiga/RM2AG.rx
+++ b/dists/amiga/RM2AG.rx
@@ -1,5 +1,5 @@
 /*
-README to .guide converter $VER: RM2AG.rx 0.14 (29.12.2017)
+README to .guide converter $VER: RM2AG.rx 0.15 (25.01.2018)
 
 This script converts the pure ASCII-text based README file of ScummVM to a
 basic Amiga guide file.
@@ -43,59 +43,59 @@ DO WHILE EOF(readme_read) = 0
 	working_line=READLN(readme_read)
 
 	/* Checking if the sub links have been reached and leave the loop, if met */
-	IF POS('°1.0°',working_line) = 1 & x > 1 THEN
+	IF POS('<>1.0<>',working_line) = 1 & x > 1 THEN
 		LEAVE
 
 	/* If no chapter has been found, simply write the line */
-	IF POS('°',working_line) = 0 THEN
+	IF POS('<>',working_line) = 0 THEN
 		WRITELN(guide_write,working_line)
 
 	/* Fix the empty chapters - two chapters (1.0 and 7.8) are empty and consist of only the headlines.
 	    We add them to the following chapter and link both of them to the empty one */
 
 	/* If chapter 1.1 is found add a link node to 1.0 (as chapter 1.0 is empty) */
-	IF POS(' * °1.1°',working_line) = 1 THEN DO
+	IF POS(' * <>1.1<>',working_line) = 1 THEN DO
 		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*°')
+		working_line=COMPRESS(working_line,'*<>')
 		WRITELN(guide_write,'    @{" 1.1 " Link "1.0"} 'working_line)
 	END
 
 	/* If chapter 7.8.1 is found add a link node to 7.8 (as chapter 7.8  is empty) */
-	IF POS(' * * °7.8.1°',working_line) = 1 THEN DO
+	IF POS(' * * <>7.8.1<>',working_line) = 1 THEN DO
 		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*°')
+		working_line=COMPRESS(working_line,'*<>')
 		WRITELN(guide_write,'      @{" 7.8.1 " Link "7.8"} 'working_line)
 	END
 
 	/* If a single number main chapter is found 1.0 upto 9.0), prepare and write the link node */
-	IF POS('.0',working_line) = 3 THEN DO
+	IF POS('.0',working_line) = 4 THEN DO
 		WRITELN(guide_write,' ')
-		WRITELN(guide_write,'  @{" 'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1) '" Link "'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1)'"} 'COMPRESS(working_line,'*°'))
+		WRITELN(guide_write,'  @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(working_line,'*<>'))
 		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*°')
+		working_line=COMPRESS(working_line,'*<>')
 		x=x+1
 	END
 
 	/* If a double number main chapter is found (10.0 ff), prepare and write the link node */
-	IF POS('.0',working_line) = 4 THEN DO
+	IF POS('.0',working_line) = 5 THEN DO
 		WRITELN(guide_write,' ')
-		WRITELN(guide_write,'  @{" 'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1) '" Link "'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1)'"} 'COMPRESS(working_line,'*°'))
+		WRITELN(guide_write,'  @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(working_line,'*<>'))
 		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*°')
+		working_line=COMPRESS(working_line,'*<>')
 	END
 
 	/* If a level one sub chapter is found (i.e. 1.1), prepare and write the link node */
-	IF POS(' * °',working_line) = 1 THEN DO
-		WRITELN(guide_write,'    @{" 'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1) '" Link "'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1)'"} 'COMPRESS(working_line,'*°'))
+	IF POS(' * <>',working_line) = 1 THEN DO
+		WRITELN(guide_write,'    @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(working_line,'*<>'))
 		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*°')
+		working_line=COMPRESS(working_line,'*<>')
 	END
 
 	/* If a level two sub chapter is found (i.e. 1.1.1), prepare and write the link node */
-	IF POS(' * * °',working_line) = 1 THEN DO
-		WRITELN(guide_write,'      @{" 'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1) '" Link "'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1)'"} 'COMPRESS(working_line,'*°'))
+	IF POS(' * * <>',working_line) = 1 THEN DO
+		WRITELN(guide_write,'      @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(working_line,'*<>'))
 		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*°')
+		working_line=COMPRESS(working_line,'*<>')
 	END
 END
 
@@ -109,40 +109,40 @@ WRITELN(guide_write,'-----------------------------------------------------------
 /* Creating the sub links nodes */
 DO WHILE EOF(readme_read) = 0
 	/* If no chapter has been found, simply write the line */
-	IF POS('°',working_line) = 0 THEN
+	IF POS('<>',working_line) = 0 THEN
 		WRITELN(guide_write,working_line)
 
 	/* Fix the empty chapters - two chapters (1.0 and 7.8) are empty and consist of only the Headlines.
 	    We don't close the NODE, rather add the following chapter to the former empty one */
 
 	/* If chapter 1.1 is found don't close the NODE, just write the line */
-	IF POS('°1.1°',working_line) = 1 THEN DO
+	IF POS('<>1.1<>',working_line) = 1 THEN DO
 		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'°')
+		working_line=COMPRESS(working_line,'<>')
 		WRITELN(guide_write,working_line)
 	END
 
 	/* If chapter 7.8.1 is found don't close the NODE, just write the line */
-	IF POS('°7.8.1°',working_line) = 1 THEN DO
+	IF POS('<>7.8.1<>',working_line) = 1 THEN DO
 		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'°')
+		working_line=COMPRESS(working_line,'<>')
 		WRITELN(guide_write,working_line)
 	END
 
-	IF POS('°',working_line) > 0 THEN DO
+	IF POS('<>',working_line) > 0 THEN DO
 		/* Check for link references inside the text and create link nodes for them */
-		IF POS('section °',working_line) > 0 THEN DO
-			working_line=SUBSTR(working_line,1,POS('°',working_line)-1)'@{"'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1)'" Link "'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1)'"}'SUBSTR(working_line,LASTPOS('°',working_line)+1)
+		IF POS('section <>',working_line) > 0 THEN DO
+			working_line=SUBSTR(working_line,1,POS('<>',working_line)-1)'@{"'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"}'SUBSTR(working_line,LASTPOS('<>',working_line)+2)
 			/* Get rid of the markers so the following loops doesn't process them again */
-			WRITELN(guide_write,COMPRESS(working_line,'°'))
+			WRITELN(guide_write,COMPRESS(working_line,'<>'))
 		END
 		ELSE DO
 		/* If a chapter has been found, prepare and write the link */
 		WRITELN(guide_write,'@ENDNODE')
-		WRITELN(guide_write,'@NODE "'SUBSTR(working_line,POS('°',working_line)+1,LASTPOS('°',working_line)-POS('°',working_line)-1)'" "'COMPRESS(working_line,'°')'"')
+		WRITELN(guide_write,'@NODE "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'" "'COMPRESS(working_line,'<>')'"')
 		WRITELN(guide_write,' ')
 		/* Get rid of the markers so the following loops doesn't process them again */
-		WRITELN(guide_write,COMPRESS(working_line,'°'))
+		WRITELN(guide_write,COMPRESS(working_line,'<>'))
 		END
 	END
 

--- a/dists/amiga/convertRM.sed
+++ b/dists/amiga/convertRM.sed
@@ -1,17 +1,17 @@
-# $VER: READMEconverter.sed 1.04 (22.12.2015) © Eugene "sev" Sandulenko
-# Additions by Raziel
+# $VER: READMEconverter.sed 1.05 (25.01.2018) Â© Eugene "sev" Sandulenko
+# Additions and changes by Raziel
 #
-# Preprocessing the README file and adding some landmarks for easier parsing
-# and for converting it to an AmigaGuide Hypertext file later.
+# Preprocessing the README file and adding some markers for easier parsing
+# and later converting it to an AmigaGuide Hypertext file.
 #
 s/http:\/\/[#?=&a-zA-Z0-9_.\/\-]*/@{"&" System "URLOpen &"}/	# Convert all URLs to AmigaGuide format
 s/https:\/\/[#?=&a-zA-Z0-9_.\/\-]*/@{"&" System "URLOpen &"}/	# Convert all secure URLs to AmigaGuide format
-s/[0-9][0-9]*\.[0-9][0-9]*/°&°/								# Convert all chapter numbers to °x°...
-s/°\([0-9][0-9]*\.[0-9][0-9]*\)°\(\.[0-9]\)/°\1\2°/					# ...and all three-digit chapter numbers...
-s/°\([01]\.[0-9][0-9]*\.[0-9][0-9]*\)°/\1/						# ...and restore mentioned version numbers like 1.0.0 and 0.7.0.
-s/of °0\.0°/of 0.0/										# "Fluidsynth's gain setting of 0.0" is not a chapter reference.
-s/through °10\.0°/through 10.0/							# "through 10.0" is not a chapter reference.
-s/ttf-°2\.00.1°/ttf-2.00.1/									# This part of an url link is not a chapter reference.
-s/patch °1\.2°/patch 1.2/									# "Zork patch 1.2" is not a chapter reference.
-s/Mac OS X °10\.2.8°/Mac OS X 10.2.8/						# "Mac OS X 10.2.8" is not a chapter reference.
-s/Mac_OS_X_°10\.2.8°/Mac_OS_X_10.2.8/						# "Mac_OS_X_10.2.8" is not a chapter reference.
+s/[0-9][0-9]*\.[0-9][0-9]*/<>&<>/							# Convert all chapter numbers to <>x<>...
+s/<>\([0-9][0-9]*\.[0-9][0-9]*\)<>\(\.[0-9]\)/<>\1\2<>/			# ...and all three-digit chapter numbers...
+s/<>\([01]\.[0-9][0-9]*\.[0-9][0-9]*\)<>/\1/					# ...and restore mentioned version numbers like 1.0.0 and 0.7.0.
+s/of <>0\.0<>/of 0.0/									# "Fluidsynth's gain setting of 0.0" is not a chapter reference.
+s/through <>10\.0<>/through 10.0/						# "through 10.0" is not a chapter reference.
+s/ttf-<>2\.00.1<>/ttf-2.00.1/								# This part of an url link is not a chapter reference.
+s/patch <>1\.2<>/patch 1.2/								# "Zork patch 1.2" is not a chapter reference.
+s/Mac OS X <>10\.2.8<>/Mac OS X 10.2.8/					# "Mac OS X 10.2.8" is not a chapter reference.
+s/Mac_OS_X_<>10\.2.8<>/Mac_OS_X_10.2.8/					# "Mac_OS_X_10.2.8" is not a chapter reference.


### PR DESCRIPTION
Due to GitHub´s utf-8 converter i´m no longer able to use special chars like "°".
GitHub will add a char in front of it, rendering the following script useless.

(Not sure though if GitHub is the culprit or the sgit program i´m using for fetching or even the font {display} program on my platform)

I changed that special char to another marker which will use "<>" now instead.
This will make updating and keeping tracks of those files easier for me.