### PR TITLE
TUCKER: Cure Bud's and Billy's seasickness

### DIFF
--- a/engines/tucker/tucker.cpp
+++ b/engines/tucker/tucker.cpp
@@ -496,12 +496,9 @@ void TuckerEngine::mainLoop() {
 			}
 			_currentGfxBackground = _quadBackgroundGfxBuf + (_currentGfxBackgroundCounter / 10) * 44800;
 			if (_fadePaletteCounter < 34 && _locationNum == 22) {
-				_spritesTable[0]._gfxBackgroundOffset = (_currentGfxBackgroundCounter / 10) * 640;
-				_mainSpritesBaseOffset = _currentGfxBackgroundCounter / 10;
-				if (_locationNum == 22 && _currentGfxBackgroundCounter <= 29) {
-					_spritesTable[0]._gfxBackgroundOffset = 640;
-					_mainSpritesBaseOffset = 1;
-				}
+				int offset = (_currentGfxBackgroundCounter > 29 ? 1 : (_currentGfxBackgroundCounter / 10));
+				_spritesTable[0]._gfxBackgroundOffset = offset * 640;
+				_mainSpritesBaseOffset = offset;
 			}
 			_fullRedraw = true;
 		} else {


### PR DESCRIPTION
This ensures that the calculated offsets for Bud and Billy are [0,2] px
and follow the sequence 0px -> 1px -> 2px -> 1px -> 0px as opposed to
the earlier 0px -> 1px -> 2px -> 3px -> 0px which resulted in them
teleporting back to their original location and on top of that being
out of sync with the boat.

Fixes Trac#6643.

/cc @raziel- (you reported this bug)