### PR TITLE
TUCKER: Fix dirty rects drawing bug in drawStringInteger()

### DIFF
--- a/engines/tucker/tucker.cpp
+++ b/engines/tucker/tucker.cpp
@@ -2875,6 +2875,7 @@ void TuckerEngine::updateSprite(int i) {
 }
 
 void TuckerEngine::drawStringInteger(int num, int x, int y, int digits) {
+	const int xStart = x;
 	char numStr[4];
 	assert(num < 1000);
 	sprintf(numStr, "%03d", num);
@@ -2883,7 +2884,7 @@ void TuckerEngine::drawStringInteger(int num, int x, int y, int digits) {
 		Graphics::drawStringChar(_locationBackgroundGfxBuf, _scrollOffset + x, y, 640, numStr[i], 102, _charsetGfxBuf);
 		x += 8;
 	}
-	addDirtyRect(_scrollOffset + x, y, Graphics::_charset._charW * 3, Graphics::_charset._charH);
+	addDirtyRect(_scrollOffset + xStart, y, Graphics::_charset._charW * 3, Graphics::_charset._charH);
 }
 
 void TuckerEngine::drawStringAlt(int x, int y, int color, const uint8 *str, int strLen) {


### PR DESCRIPTION
This fixes a bug in `drawStringInteger()` (used for drawing savegame slots in the original game UI) where the x-coordinate for the dirty rect was wrongly calculated.