### PR TITLE
TUCKER: Print infobar string if no savegame exists

### DIFF
--- a/engines/tucker/saveload.cpp
+++ b/engines/tucker/saveload.cpp
@@ -126,4 +126,9 @@ bool TuckerEngine::canSaveGameStateCurrently() {
 	return !_player && _cursorType < 2;
 }
 
+bool TuckerEngine::existsSavegame() {
+	Common::String pattern = generateGameStateFileName(_targetName.c_str(), 0, true);
+	return !_saveFileMan->listSavefiles(pattern).empty();
+}
+
 } // namespace Tucker

--- a/engines/tucker/tucker.cpp
+++ b/engines/tucker/tucker.cpp
@@ -27,6 +27,7 @@
 #include "common/debug.h"
 #include "common/error.h"
 #include "common/keyboard.h"
+#include "common/savefile.h"
 #include "common/textconsole.h"
 
 #include "engines/util.h"
@@ -1317,13 +1318,19 @@ void TuckerEngine::updateSfxData3_2() {
 }
 
 void TuckerEngine::saveOrLoad() {
+	bool hasSavegame = existsSavegame();
+
 	if (!_leftMouseButtonPressed) {
 		_mouseClick = 0;
 	}
 	if (_currentSaveLoadGameState > 0) {
-		drawSpeechText(_scrollOffset + 120, 170, _infoBarBuf, _saveOrLoadGamePanel + 19, 102);
-		int len = getStringWidth(_saveOrLoadGamePanel + 19, _infoBarBuf);
-		drawStringInteger(_currentSaveLoadGameState, len / 2 + 128, 160, 2);
+		if (_saveOrLoadGamePanel == 0 && !hasSavegame) {
+			drawSpeechText(_scrollOffset + 120, 170, _infoBarBuf, _saveOrLoadGamePanel + 21, 102);
+		} else {
+			drawSpeechText(_scrollOffset + 120, 170, _infoBarBuf, _saveOrLoadGamePanel + 19, 102);
+			int len = getStringWidth(_saveOrLoadGamePanel + 19, _infoBarBuf);
+			drawStringInteger(_currentSaveLoadGameState, len / 2 + 128, 160, 2);
+		}
 	} else {
 		drawSpeechText(_scrollOffset + 120, 170, _infoBarBuf, 21, 102);
 	}
@@ -1351,7 +1358,7 @@ void TuckerEngine::saveOrLoad() {
 		if (_mousePosX > 260 && _mousePosX < 290 && _mousePosY > 152 && _mousePosY < 168) {
 			if (_saveOrLoadGamePanel == 1) {
 				saveGameState(_currentSaveLoadGameState, "");
-			} else if (_currentSaveLoadGameState > 0) {
+			} else if (hasSavegame && _currentSaveLoadGameState > 0) {
 				loadGameState(_currentSaveLoadGameState);
 			}
 			_forceRedrawPanelItems = true;

--- a/engines/tucker/tucker.h
+++ b/engines/tucker/tucker.h
@@ -578,6 +578,7 @@ protected:
 	virtual Common::Error saveGameState(int num, const Common::String &description);
 	virtual bool canLoadGameStateCurrently();
 	virtual bool canSaveGameStateCurrently();
+	virtual bool existsSavegame();
 
 	TuckerConsole *_console;
 


### PR DESCRIPTION
Before, the ingame load dialog pretended to allow loading savegames from all possible slots even if no savegames existed.
This introduces the original interpreter's behavior which instead loads a resource string from `infobar.txt` informing the user that no savegames are available.

Fixes Trac#10417.