### PR TITLE
Fix broken compilation on up-to-date msys2/mingw-w64

### DIFF
--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -31,15 +31,8 @@
 
 #include "common/scummsys.h"
 
-// Remove FILE override from common/forbidden.h, and replace
-// it with an alternate slightly less unfriendly override.
 #if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_FILE)
 #undef FILE
-// Solaris has typedef __FILE FILE in several places already
-#if !defined(__sun)
-typedef struct { int FAKE; } FAKE_FILE;
-#define FILE FAKE_FILE
-#endif   // (__sun)
 #endif
 
 #if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_strcasecmp)


### PR DESCRIPTION
It’s questionable that the SDL backend code is trying so hard to
maintain forbidden symbols at all since backend code is exactly
where such things are allowed, and it is a game of whack-a-mole
to keep system API changes from breaking this fragile system of
symbol redefinitions. Probably this should all just get replaced
with a FORBIDDEN_SYMBOL_ALLOW_ALL, but for the time being this at
least gets builds working again on up-to-date msys2/mingw-w64
compilers.

Fixes Trac#10405.