### PR TITLE
Allow games to specify their pixel aspect ratio - DO NOT MERGE

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -58,7 +58,7 @@ public:
 	virtual Graphics::PixelFormat getScreenFormat() const = 0;
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const = 0;
 #endif
-	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) = 0;
+	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL) = 0;
 	virtual void initSizeHint(const Graphics::ModeList &modes) {}
 	virtual int getScreenChangeID() const = 0;
 

--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -27,7 +27,7 @@
 #include "common/noncopyable.h"
 #include "common/keyboard.h"
 
-#include "graphics/mode.h"
+#include "graphics/video_mode.h"
 #include "graphics/palette.h"
 
 /**
@@ -58,8 +58,8 @@ public:
 	virtual Graphics::PixelFormat getScreenFormat() const = 0;
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const = 0;
 #endif
-	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL) = 0;
-	virtual void initSizeHint(const Graphics::ModeList &modes) {}
+	virtual void initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format = NULL) = 0;
+	virtual void initSizeHint(const Graphics::VideoModeList &modes) {}
 	virtual int getScreenChangeID() const = 0;
 
 	virtual void beginGFXTransaction() = 0;

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -48,7 +48,7 @@ public:
 		list.push_back(Graphics::PixelFormat::createFormatCLUT8());
 		return list;
 	}
-	void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL) override {}
+	void initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format = NULL) override {}
 	virtual int getScreenChangeID() const override { return 0; }
 
 	void beginGFXTransaction() override {}

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -48,7 +48,7 @@ public:
 		list.push_back(Graphics::PixelFormat::createFormatCLUT8());
 		return list;
 	}
-	void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) override {}
+	void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL) override {}
 	virtual int getScreenChangeID() const override { return 0; }
 
 	void beginGFXTransaction() override {}

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -330,7 +330,7 @@ int OpenGLGraphicsManager::getScreenChangeID() const {
 	return _screenChangeID;
 }
 
-void OpenGLGraphicsManager::initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) {
+void OpenGLGraphicsManager::initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format) {
 	Graphics::PixelFormat requestedFormat;
 #ifdef USE_RGB_COLOR
 	if (!format) {

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -241,7 +241,8 @@ OSystem::TransactionError OpenGLGraphicsManager::endGFXTransaction() {
 				if (_oldState.valid && _oldState != _currentState) {
 					// Give some hints on what failed to set up.
 					if (   _oldState.gameWidth  != _currentState.gameWidth
-					    || _oldState.gameHeight != _currentState.gameHeight) {
+					    || _oldState.gameHeight != _currentState.gameHeight
+						|| _oldState.gamePixelAspectRatio != _currentState.gamePixelAspectRatio) {
 						transactionError |= OSystem::kTransactionSizeChangeFailed;
 					}
 
@@ -329,7 +330,7 @@ int OpenGLGraphicsManager::getScreenChangeID() const {
 	return _screenChangeID;
 }
 
-void OpenGLGraphicsManager::initSize(uint width, uint height, const Graphics::PixelFormat *format) {
+void OpenGLGraphicsManager::initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) {
 	Graphics::PixelFormat requestedFormat;
 #ifdef USE_RGB_COLOR
 	if (!format) {
@@ -340,8 +341,9 @@ void OpenGLGraphicsManager::initSize(uint width, uint height, const Graphics::Pi
 	_currentState.gameFormat = requestedFormat;
 #endif
 
-	_currentState.gameWidth = width;
-	_currentState.gameHeight = height;
+	_currentState.gameWidth = mode.width;
+	_currentState.gameHeight = mode.height;
+	_currentState.gamePixelAspectRatio = mode.par;
 	_gameScreenShakeOffset = 0;
 }
 
@@ -1090,17 +1092,11 @@ bool OpenGLGraphicsManager::getGLPixelFormat(const Graphics::PixelFormat &pixelF
 }
 
 bool OpenGLGraphicsManager::gameNeedsAspectRatioCorrection() const {
-	if (_currentState.aspectRatioCorrection) {
-		const uint width = getWidth();
-		const uint height = getHeight();
+	return _currentState.aspectRatioCorrection;
+}
 
-		// In case we enable aspect ratio correction we force a 4/3 ratio.
-		// But just for 320x200 and 640x400 games, since other games do not need
-		// this.
-		return (width == 320 && height == 200) || (width == 640 && height == 400);
-	}
-
-	return false;
+frac_t OpenGLGraphicsManager::gamePixelAspectRatio() const {
+	return _currentState.gamePixelAspectRatio;
 }
 
 void OpenGLGraphicsManager::recalculateDisplayAreas() {

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -218,9 +218,9 @@ OSystem::TransactionError OpenGLGraphicsManager::endGFXTransaction() {
 #endif
 
 	do {
-		const uint desiredAspect = getDesiredGameAspectRatio();
+		const Common::Rational desiredAspect = getDesiredGameAspectRatio();
 		const uint requestedWidth  = _currentState.gameWidth;
-		const uint requestedHeight = intToFrac(requestedWidth) / desiredAspect;
+		const uint requestedHeight = (requestedWidth / desiredAspect).toInt();
 
 		if (!loadVideoMode(requestedWidth, requestedHeight,
 #ifdef USE_RGB_COLOR
@@ -1095,7 +1095,7 @@ bool OpenGLGraphicsManager::gameNeedsAspectRatioCorrection() const {
 	return _currentState.aspectRatioCorrection;
 }
 
-frac_t OpenGLGraphicsManager::gamePixelAspectRatio() const {
+Common::Rational OpenGLGraphicsManager::gamePixelAspectRatio() const {
 	return _currentState.gamePixelAspectRatio;
 }
 

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -80,7 +80,7 @@ public:
 
 	virtual int getScreenChangeID() const override;
 
-	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format) override;
+	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) override;
 
 	virtual int16 getWidth() const override;
 	virtual int16 getHeight() const override;
@@ -167,7 +167,7 @@ protected:
 	// Transaction support
 	//
 	struct VideoState {
-		VideoState() : valid(false), gameWidth(0), gameHeight(0),
+		VideoState() : valid(false), gameWidth(0), gameHeight(0), gamePixelAspectRatio(intToFrac(1)),
 #ifdef USE_RGB_COLOR
 		    gameFormat(),
 #endif
@@ -177,6 +177,7 @@ protected:
 		bool valid;
 
 		uint gameWidth, gameHeight;
+		frac_t gamePixelAspectRatio;
 #ifdef USE_RGB_COLOR
 		Graphics::PixelFormat gameFormat;
 #endif
@@ -186,6 +187,7 @@ protected:
 
 		bool operator==(const VideoState &right) {
 			return gameWidth == right.gameWidth && gameHeight == right.gameHeight
+				&& gamePixelAspectRatio == right.gamePixelAspectRatio
 #ifdef USE_RGB_COLOR
 			    && gameFormat == right.gameFormat
 #endif
@@ -300,6 +302,7 @@ protected:
 	bool getGLPixelFormat(const Graphics::PixelFormat &pixelFormat, GLenum &glIntFormat, GLenum &glFormat, GLenum &glType) const;
 
 	virtual bool gameNeedsAspectRatioCorrection() const override;
+	virtual frac_t gamePixelAspectRatio() const override;
 	virtual void recalculateDisplayAreas() override;
 	virtual void handleResizeImpl(const int width, const int height) override;
 

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -27,7 +27,7 @@
 #include "backends/graphics/opengl/framebuffer.h"
 #include "backends/graphics/windowed.h"
 
-#include "common/frac.h"
+#include "common/rational.h"
 #include "common/mutex.h"
 
 #include "graphics/surface.h"
@@ -167,7 +167,7 @@ protected:
 	// Transaction support
 	//
 	struct VideoState {
-		VideoState() : valid(false), gameWidth(0), gameHeight(0), gamePixelAspectRatio(intToFrac(1)),
+		VideoState() : valid(false), gameWidth(0), gameHeight(0), gamePixelAspectRatio(1, 1),
 #ifdef USE_RGB_COLOR
 		    gameFormat(),
 #endif
@@ -177,7 +177,7 @@ protected:
 		bool valid;
 
 		uint gameWidth, gameHeight;
-		frac_t gamePixelAspectRatio;
+		Common::Rational gamePixelAspectRatio;
 #ifdef USE_RGB_COLOR
 		Graphics::PixelFormat gameFormat;
 #endif
@@ -302,7 +302,7 @@ protected:
 	bool getGLPixelFormat(const Graphics::PixelFormat &pixelFormat, GLenum &glIntFormat, GLenum &glFormat, GLenum &glType) const;
 
 	virtual bool gameNeedsAspectRatioCorrection() const override;
-	virtual frac_t gamePixelAspectRatio() const override;
+	virtual Common::Rational gamePixelAspectRatio() const override;
 	virtual void recalculateDisplayAreas() override;
 	virtual void handleResizeImpl(const int width, const int height) override;
 

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -80,7 +80,7 @@ public:
 
 	virtual int getScreenChangeID() const override;
 
-	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) override;
+	virtual void initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format) override;
 
 	virtual int16 getWidth() const override;
 	virtual int16 getHeight() const override;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -266,7 +266,7 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	}
 }
 
-void OpenGLSdlGraphicsManager::initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) {
+void OpenGLSdlGraphicsManager::initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format) {
 	// HACK: This is stupid but the SurfaceSDL backend defaults to 2x. This
 	// assures that the launcher (which requests 320x200) has a reasonable
 	// size. It also makes small games have a reasonable size (i.e. at least

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -266,19 +266,19 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	}
 }
 
-void OpenGLSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
+void OpenGLSdlGraphicsManager::initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) {
 	// HACK: This is stupid but the SurfaceSDL backend defaults to 2x. This
 	// assures that the launcher (which requests 320x200) has a reasonable
 	// size. It also makes small games have a reasonable size (i.e. at least
 	// 640x400). We follow the same logic here until we have a better way to
 	// give hints to our backend for that.
-	if (w > 320) {
+	if (mode.width > 320) {
 		_graphicsScale = 1;
 	} else {
 		_graphicsScale = 2;
 	}
 
-	return OpenGLGraphicsManager::initSize(w, h, format);
+	return OpenGLGraphicsManager::initSize(mode, format);
 }
 
 #ifdef USE_RGB_COLOR

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -43,7 +43,7 @@ public:
 	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 	virtual bool getFeatureState(OSystem::Feature f) const override;
 
-	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) override;
+	virtual void initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format) override;
 
 #ifdef USE_RGB_COLOR
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override;

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -43,7 +43,7 @@ public:
 	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 	virtual bool getFeatureState(OSystem::Feature f) const override;
 
-	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format) override;
+	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) override;
 
 #ifdef USE_RGB_COLOR
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override;

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -128,7 +128,7 @@ void SdlGraphicsManager::initSizeHint(const Graphics::ModeList &modes) {
 		int16 width = it->width, height = it->height;
 
 		if (ConfMan.getBool("aspect_ratio")) {
-			height = fracToInt(it->height * it->par);
+			height = intToFrac(it->height) / it->par;
 		}
 
 		if (!useDefault || width <= 320) {

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -62,9 +62,9 @@ SdlGraphicsManager::State SdlGraphicsManager::getState() const {
 bool SdlGraphicsManager::setState(const State &state) {
 	beginGFXTransaction();
 #ifdef USE_RGB_COLOR
-		initSize(Graphics::Mode(state.screenWidth, state.screenHeight, state.pixelAspectRatio), &state.pixelFormat);
+		initSize(Graphics::VideoMode(state.screenWidth, state.screenHeight, state.pixelAspectRatio), &state.pixelFormat);
 #else
-		initSize(Graphics::Mode(state.screenWidth, state.screenHeight, state.pixelAspectRatio), nullptr);
+		initSize(Graphics::VideoMode(state.screenWidth, state.screenHeight, state.pixelAspectRatio), nullptr);
 #endif
 		setFeatureState(OSystem::kFeatureAspectRatioCorrection, state.aspectRatio);
 		setFeatureState(OSystem::kFeatureFullscreenMode, state.fullscreen);
@@ -112,7 +112,7 @@ int SdlGraphicsManager::getGraphicsModeIdByName(const Common::String &name) cons
 	return -1;
 }
 
-void SdlGraphicsManager::initSizeHint(const Graphics::ModeList &modes) {
+void SdlGraphicsManager::initSizeHint(const Graphics::VideoModeList &modes) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	const bool useDefault = defaultGraphicsModeConfig();
 
@@ -123,8 +123,8 @@ void SdlGraphicsManager::initSizeHint(const Graphics::ModeList &modes) {
 	}
 
 	int16 bestWidth = 0, bestHeight = 0;
-	const Graphics::ModeList::const_iterator end = modes.end();
-	for (Graphics::ModeList::const_iterator it = modes.begin(); it != end; ++it) {
+	const Graphics::VideoModeList::const_iterator end = modes.end();
+	for (Graphics::VideoModeList::const_iterator it = modes.begin(); it != end; ++it) {
 		int16 width = it->width, height = it->height;
 
 		if (ConfMan.getBool("aspect_ratio")) {

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -49,6 +49,7 @@ SdlGraphicsManager::State SdlGraphicsManager::getState() const {
 
 	state.screenWidth   = getWidth();
 	state.screenHeight  = getHeight();
+	state.pixelAspectRatio = gamePixelAspectRatio();
 	state.aspectRatio   = getFeatureState(OSystem::kFeatureAspectRatioCorrection);
 	state.fullscreen    = getFeatureState(OSystem::kFeatureFullscreenMode);
 	state.cursorPalette = getFeatureState(OSystem::kFeatureCursorPalette);
@@ -61,9 +62,9 @@ SdlGraphicsManager::State SdlGraphicsManager::getState() const {
 bool SdlGraphicsManager::setState(const State &state) {
 	beginGFXTransaction();
 #ifdef USE_RGB_COLOR
-		initSize(state.screenWidth, state.screenHeight, &state.pixelFormat);
+		initSize(Graphics::Mode(state.screenWidth, state.screenHeight, state.pixelAspectRatio), &state.pixelFormat);
 #else
-		initSize(state.screenWidth, state.screenHeight, nullptr);
+		initSize(Graphics::Mode(state.screenWidth, state.screenHeight, state.pixelAspectRatio), nullptr);
 #endif
 		setFeatureState(OSystem::kFeatureAspectRatioCorrection, state.aspectRatio);
 		setFeatureState(OSystem::kFeatureFullscreenMode, state.fullscreen);
@@ -126,13 +127,8 @@ void SdlGraphicsManager::initSizeHint(const Graphics::ModeList &modes) {
 	for (Graphics::ModeList::const_iterator it = modes.begin(); it != end; ++it) {
 		int16 width = it->width, height = it->height;
 
-		// TODO: Normalize AR correction by passing a PAR in the mode list
-		// instead of checking the dimensions here like this, since not all
-		// 320x200/640x400 uses are with non-square pixels (e.g. DreamWeb).
 		if (ConfMan.getBool("aspect_ratio")) {
-			if ((width == 320 && height == 200) || (width == 640 && height == 400)) {
-				height = real2Aspect(height);
-			}
+			height = fracToInt(it->height * it->par);
 		}
 
 		if (!useDefault || width <= 320) {

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -128,7 +128,7 @@ void SdlGraphicsManager::initSizeHint(const Graphics::VideoModeList &modes) {
 		int16 width = it->width, height = it->height;
 
 		if (ConfMan.getBool("aspect_ratio")) {
-			height = intToFrac(it->height) / it->par;
+			height = it->correctedHeight();
 		}
 
 		if (!useDefault || width <= 320) {

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -97,7 +97,7 @@ public:
 	 */
 	struct State {
 		int screenWidth, screenHeight;
-		frac_t pixelAspectRatio;
+		Common::Rational pixelAspectRatio;
 		bool aspectRatio;
 		bool fullscreen;
 		bool cursorPalette;

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -97,6 +97,7 @@ public:
 	 */
 	struct State {
 		int screenWidth, screenHeight;
+		frac_t pixelAspectRatio;
 		bool aspectRatio;
 		bool fullscreen;
 		bool cursorPalette;

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -122,7 +122,7 @@ public:
 	 */
 	SdlWindow *getWindow() const { return _window; }
 
-	virtual void initSizeHint(const Graphics::ModeList &modes) override;
+	virtual void initSizeHint(const Graphics::VideoModeList &modes) override;
 
 protected:
 	virtual int getGraphicsModeScale(int mode) const = 0;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -747,7 +747,7 @@ bool SurfaceSdlGraphicsManager::setShader(int id) {
 	return true;
 }
 
-void SurfaceSdlGraphicsManager::initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format) {
+void SurfaceSdlGraphicsManager::initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format) {
 	assert(_transactionMode == kTransactionActive);
 
 	_newShakePos = 0;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -175,7 +175,7 @@ protected:
 		return _videoMode.aspectRatioCorrection;
 	}
 
-	virtual frac_t gamePixelAspectRatio() const override {
+	virtual Common::Rational gamePixelAspectRatio() const override {
 		return _videoMode.pixelAspectRatio;
 	}
 
@@ -253,7 +253,7 @@ protected:
 		int screenWidth, screenHeight;
 		int overlayWidth, overlayHeight;
 		int hardwareWidth, hardwareHeight;
-		frac_t pixelAspectRatio;
+		Common::Rational pixelAspectRatio;
 #ifdef USE_RGB_COLOR
 		Graphics::PixelFormat format;
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -98,7 +98,7 @@ public:
 	virtual const OSystem::GraphicsMode *getSupportedShaders() const override;
 	virtual int getShader() const override;
 	virtual bool setShader(int id) override;
-	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL) override;
+	virtual void initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format = NULL) override;
 	virtual int getScreenChangeID() const override { return _screenChangeCount; }
 
 	virtual void beginGFXTransaction() override;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -98,7 +98,7 @@ public:
 	virtual const OSystem::GraphicsMode *getSupportedShaders() const override;
 	virtual int getShader() const override;
 	virtual bool setShader(int id) override;
-	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL) override;
+	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL) override;
 	virtual int getScreenChangeID() const override { return _screenChangeCount; }
 
 	virtual void beginGFXTransaction() override;
@@ -175,6 +175,10 @@ protected:
 		return _videoMode.aspectRatioCorrection;
 	}
 
+	virtual frac_t gamePixelAspectRatio() const override {
+		return _videoMode.pixelAspectRatio;
+	}
+
 	virtual void handleResizeImpl(const int width, const int height) override;
 
 	virtual int getGraphicsModeScale(int mode) const override;
@@ -249,6 +253,7 @@ protected:
 		int screenWidth, screenHeight;
 		int overlayWidth, overlayHeight;
 		int hardwareWidth, hardwareHeight;
+		frac_t pixelAspectRatio;
 #ifdef USE_RGB_COLOR
 		Graphics::PixelFormat format;
 #endif

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -72,6 +72,11 @@ protected:
 	virtual bool gameNeedsAspectRatioCorrection() const = 0;
 
 	/**
+	 * @return the game pixel aspect ratio.
+	 */
+	virtual frac_t gamePixelAspectRatio() const = 0;
+
+	/**
 	 * Backend-specific implementation for updating internal surfaces that need
 	 * to reflect the new window size.
 	 */
@@ -128,8 +133,11 @@ protected:
 	 * @returns the desired aspect ratio of the game surface.
 	 */
 	frac_t getDesiredGameAspectRatio() const {
-		if (getHeight() == 0 || gameNeedsAspectRatioCorrection()) {
+		if (getHeight() == 0) {
 			return intToFrac(4) / 3;
+		} else if (gameNeedsAspectRatioCorrection()) {
+			// Assume that the display pixels are square
+			return intToFrac(getWidth()) / fracToInt(getHeight() * gamePixelAspectRatio());
 		}
 
 		return intToFrac(getWidth()) / getHeight();

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -24,7 +24,7 @@
 #define BACKENDS_GRAPHICS_WINDOWED_H
 
 #include "backends/graphics/graphics.h"
-#include "common/frac.h"
+#include "common/rational.h"
 #include "common/rect.h"
 #include "common/textconsole.h"
 #include "graphics/scaler/aspect.h"
@@ -74,7 +74,7 @@ protected:
 	/**
 	 * @return the game pixel aspect ratio.
 	 */
-	virtual frac_t gamePixelAspectRatio() const = 0;
+	virtual Common::Rational gamePixelAspectRatio() const = 0;
 
 	/**
 	 * Backend-specific implementation for updating internal surfaces that need
@@ -132,15 +132,15 @@ protected:
 	/**
 	 * @returns the desired aspect ratio of the game surface.
 	 */
-	frac_t getDesiredGameAspectRatio() const {
+	Common::Rational getDesiredGameAspectRatio() const {
 		if (getHeight() == 0) {
-			return intToFrac(4) / 3;
+			return Common::Rational(4, 3);
 		} else if (gameNeedsAspectRatioCorrection()) {
 			// Assume that the display pixels are square
-			return intToFrac(getWidth()) / (intToFrac(getHeight()) / gamePixelAspectRatio());
+			return Common::Rational(getWidth(), getHeight()) * gamePixelAspectRatio();
 		}
 
-		return intToFrac(getWidth()) / getHeight();
+		return Common::Rational(getWidth(), getHeight());
 	}
 
 	/**
@@ -164,12 +164,12 @@ protected:
 			return;
 		}
 
-		const frac_t outputAspect = intToFrac(_windowWidth) / _windowHeight;
+		const Common::Rational outputAspect(_windowWidth, _windowHeight);
 
 		populateDisplayAreaDrawRect(getDesiredGameAspectRatio(), outputAspect, _gameDrawRect);
 
 		if (getOverlayHeight()) {
-			const frac_t overlayAspect = intToFrac(getOverlayWidth()) / getOverlayHeight();
+			const Common::Rational overlayAspect(getOverlayWidth(), getOverlayHeight());
 			populateDisplayAreaDrawRect(overlayAspect, outputAspect, _overlayDrawRect);
 		}
 
@@ -324,15 +324,15 @@ protected:
 	int _cursorX, _cursorY;
 
 private:
-	void populateDisplayAreaDrawRect(const frac_t inputAspect, const frac_t outputAspect, Common::Rect &drawRect) const {
+	void populateDisplayAreaDrawRect(const Common::Rational &inputAspect, const Common::Rational &outputAspect, Common::Rect &drawRect) const {
 		int width = _windowWidth;
 		int height = _windowHeight;
 
 		// Maintain aspect ratios
 		if (outputAspect < inputAspect) {
-			height = intToFrac(width) / inputAspect;
+			height = (width / inputAspect).toInt();
 		} else if (outputAspect > inputAspect) {
-			width = fracToInt(height * inputAspect);
+			width = (height * inputAspect).toInt();
 		}
 
 		drawRect.left = (_windowWidth - width) / 2;

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -137,7 +137,7 @@ protected:
 			return intToFrac(4) / 3;
 		} else if (gameNeedsAspectRatioCorrection()) {
 			// Assume that the display pixels are square
-			return intToFrac(getWidth()) / fracToInt(getHeight() * gamePixelAspectRatio());
+			return intToFrac(getWidth()) / (intToFrac(getHeight()) / gamePixelAspectRatio());
 		}
 
 		return intToFrac(getWidth()) / getHeight();

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -109,11 +109,11 @@ Common::List<Graphics::PixelFormat> ModularBackend::getSupportedFormats() const 
 
 #endif
 
-void ModularBackend::initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format ) {
+void ModularBackend::initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format ) {
 	_graphicsManager->initSize(mode, format);
 }
 
-void ModularBackend::initSizeHint(const Graphics::ModeList &modes) {
+void ModularBackend::initSizeHint(const Graphics::VideoModeList &modes) {
 	_graphicsManager->initSizeHint(modes);
 }
 

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -109,8 +109,8 @@ Common::List<Graphics::PixelFormat> ModularBackend::getSupportedFormats() const 
 
 #endif
 
-void ModularBackend::initSize(uint w, uint h, const Graphics::PixelFormat *format ) {
-	_graphicsManager->initSize(w, h, format);
+void ModularBackend::initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format ) {
+	_graphicsManager->initSize(mode, format);
 }
 
 void ModularBackend::initSizeHint(const Graphics::ModeList &modes) {

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -74,7 +74,7 @@ public:
 	virtual Graphics::PixelFormat getScreenFormat() const;
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const;
 #endif
-	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL);
+	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL);
 	virtual void initSizeHint(const Graphics::ModeList &modes) override;
 	virtual int getScreenChangeID() const;
 

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -74,8 +74,8 @@ public:
 	virtual Graphics::PixelFormat getScreenFormat() const;
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const;
 #endif
-	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL);
-	virtual void initSizeHint(const Graphics::ModeList &modes) override;
+	virtual void initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format = NULL);
+	virtual void initSizeHint(const Graphics::VideoModeList &modes) override;
 	virtual int getScreenChangeID() const;
 
 	virtual void beginGFXTransaction();

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -288,7 +288,7 @@ static void setupGraphics(OSystem &system) {
 		// Set the user specified graphics mode (if any).
 		system.setGraphicsMode(ConfMan.get("gfx_mode").c_str());
 
-		system.initSize(320, 200);
+		system.initSize(Graphics::Mode(320, 200));
 
 		if (ConfMan.hasKey("aspect_ratio"))
 			system.setFeatureState(OSystem::kFeatureAspectRatioCorrection, ConfMan.getBool("aspect_ratio"));

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -288,7 +288,7 @@ static void setupGraphics(OSystem &system) {
 		// Set the user specified graphics mode (if any).
 		system.setGraphicsMode(ConfMan.get("gfx_mode").c_str());
 
-		system.initSize(Graphics::Mode(320, 200));
+		system.initSize(Graphics::VideoMode(320, 200));
 
 		if (ConfMan.hasKey("aspect_ratio"))
 			system.setFeatureState(OSystem::kFeatureAspectRatioCorrection, ConfMan.getBool("aspect_ratio"));

--- a/common/system.h
+++ b/common/system.h
@@ -27,7 +27,7 @@
 #include "common/noncopyable.h"
 #include "common/list.h" // For OSystem::getSupportedFormats()
 #include "graphics/pixelformat.h"
-#include "graphics/mode.h"
+#include "graphics/video_mode.h"
 
 namespace Audio {
 class Mixer;
@@ -631,10 +631,10 @@ public:
 	 * @param mode		the new virtual screen size
 	 * @param format	the new virtual screen pixel format
 	 */
-	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL) = 0;
+	virtual void initSize(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format = NULL) = 0;
 
 	/**
-	 * Send a list of graphics modes to the backend so it can make a decision
+	 * Send a list of graphics video modes to the backend so it can make a decision
 	 * about the best way to set up the display hardware.
 	 *
 	 * Engines that switch between different virtual screen sizes during a game
@@ -643,7 +643,7 @@ public:
 	 *
 	 * @param modes the list of graphics modes the engine will probably use.
 	 */
-	virtual void initSizeHint(const Graphics::ModeList &modes) {}
+	virtual void initSizeHint(const Graphics::VideoModeList &modes) {}
 
 	/**
 	 * Return an int value which is changed whenever any screen

--- a/common/system.h
+++ b/common/system.h
@@ -628,11 +628,10 @@ public:
 	 * a backend may perform color lookup of 8-bit graphics before pushing
 	 * a screen to hardware, or correct the ARGB color order.
 	 *
-	 * @param width		the new virtual screen width
-	 * @param height	the new virtual screen height
+	 * @param mode		the new virtual screen size
 	 * @param format	the new virtual screen pixel format
 	 */
-	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) = 0;
+	virtual void initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL) = 0;
 
 	/**
 	 * Send a list of graphics modes to the backend so it can make a decision

--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -681,7 +681,7 @@ void AdlEngine::gameLoop() {
 }
 
 Common::Error AdlEngine::run() {
-	initGraphics(DISPLAY_WIDTH * 2, DISPLAY_HEIGHT * 2);
+	initGraphics(Graphics::Mode(DISPLAY_WIDTH * 2, DISPLAY_HEIGHT * 2, intToFrac(32) / 35));
 
 	_console = new Console(this);
 	_display = new Display();

--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -681,7 +681,7 @@ void AdlEngine::gameLoop() {
 }
 
 Common::Error AdlEngine::run() {
-	initGraphics(Graphics::Mode(DISPLAY_WIDTH * 2, DISPLAY_HEIGHT * 2, intToFrac(32) / 35));
+	initGraphics(Graphics::VideoMode(DISPLAY_WIDTH * 2, DISPLAY_HEIGHT * 2, intToFrac(32) / 35));
 
 	_console = new Console(this);
 	_display = new Display();

--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -681,7 +681,7 @@ void AdlEngine::gameLoop() {
 }
 
 Common::Error AdlEngine::run() {
-	initGraphics(Graphics::VideoMode(DISPLAY_WIDTH * 2, DISPLAY_HEIGHT * 2, intToFrac(32) / 35));
+	initGraphics(Graphics::VideoMode(DISPLAY_WIDTH * 2, DISPLAY_HEIGHT * 2, Common::Rational(32, 35)));
 
 	_console = new Console(this);
 	_display = new Display();

--- a/engines/cine/cine.cpp
+++ b/engines/cine/cine.cpp
@@ -94,10 +94,10 @@ void CineEngine::syncSoundSettings() {
 }
 
 Common::Error CineEngine::run() {
-	Graphics::ModeList modes;
-	modes.push_back(Graphics::Mode(320, 200));
+	Graphics::VideoModeList modes;
+	modes.push_back(Graphics::VideoMode(320, 200));
 	if (g_cine->getGameType() == GType_FW && (g_cine->getFeatures() & GF_CD)) {
-		modes.push_back(Graphics::Mode(640, 480));
+		modes.push_back(Graphics::VideoMode(640, 480));
 		initGraphicsModes(modes);
 		showSplashScreen();
 	} else {

--- a/engines/dreamweb/stubs.cpp
+++ b/engines/dreamweb/stubs.cpp
@@ -565,7 +565,7 @@ void DreamWebEngine::dreamweb() {
 	}
 
 	Graphics::VideoModeList modes;
-	modes.push_back(Graphics::VideoMode(320, 200, intToFrac(1)));
+	modes.push_back(Graphics::VideoMode(320, 200, Common::Rational(1, 1)));
 	modes.push_back(Graphics::VideoMode(640, 480));
 	initGraphicsModes(modes);
 

--- a/engines/dreamweb/stubs.cpp
+++ b/engines/dreamweb/stubs.cpp
@@ -565,7 +565,7 @@ void DreamWebEngine::dreamweb() {
 	}
 
 	Graphics::ModeList modes;
-	modes.push_back(Graphics::Mode(320, 200));
+	modes.push_back(Graphics::Mode(320, 200, intToFrac(1)));
 	modes.push_back(Graphics::Mode(640, 480));
 	initGraphicsModes(modes);
 

--- a/engines/dreamweb/stubs.cpp
+++ b/engines/dreamweb/stubs.cpp
@@ -564,9 +564,9 @@ void DreamWebEngine::dreamweb() {
 		break;
 	}
 
-	Graphics::ModeList modes;
-	modes.push_back(Graphics::Mode(320, 200, intToFrac(1)));
-	modes.push_back(Graphics::Mode(640, 480));
+	Graphics::VideoModeList modes;
+	modes.push_back(Graphics::VideoMode(320, 200, intToFrac(1)));
+	modes.push_back(Graphics::VideoMode(640, 480));
 	initGraphicsModes(modes);
 
 	allocateBuffers();

--- a/engines/dreamweb/vgagrafx.cpp
+++ b/engines/dreamweb/vgagrafx.cpp
@@ -151,7 +151,7 @@ void DreamWebEngine::doShake() {
 
 void DreamWebEngine::setMode() {
 	waitForVSync();
-	initGraphics(Graphics::Mode(kScreenwidth, kScreenheight, intToFrac(1)));
+	initGraphics(Graphics::VideoMode(kScreenwidth, kScreenheight, intToFrac(1)));
 }
 
 void DreamWebEngine::showPCX(const Common::String &suffix) {

--- a/engines/dreamweb/vgagrafx.cpp
+++ b/engines/dreamweb/vgagrafx.cpp
@@ -151,7 +151,7 @@ void DreamWebEngine::doShake() {
 
 void DreamWebEngine::setMode() {
 	waitForVSync();
-	initGraphics(Graphics::VideoMode(kScreenwidth, kScreenheight, intToFrac(1)));
+	initGraphics(Graphics::VideoMode(kScreenwidth, kScreenheight, Common::Rational(1, 1)));
 }
 
 void DreamWebEngine::showPCX(const Common::String &suffix) {

--- a/engines/dreamweb/vgagrafx.cpp
+++ b/engines/dreamweb/vgagrafx.cpp
@@ -151,7 +151,7 @@ void DreamWebEngine::doShake() {
 
 void DreamWebEngine::setMode() {
 	waitForVSync();
-	initGraphics(kScreenwidth, kScreenheight);
+	initGraphics(Graphics::Mode(kScreenwidth, kScreenheight, intToFrac(1)));
 }
 
 void DreamWebEngine::showPCX(const Common::String &suffix) {

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -276,20 +276,19 @@ void initGraphicsModes(const Graphics::ModeList &modes) {
 	g_system->initSizeHint(modes);
 }
 
-void initGraphics(int width, int height, const Graphics::PixelFormat *format) {
-
+void initGraphics(const Graphics::Mode &mode, const Graphics::PixelFormat *format) {
 	g_system->beginGFXTransaction();
 
 		initCommonGFX();
 #ifdef USE_RGB_COLOR
 		if (format)
-			g_system->initSize(width, height, format);
+			g_system->initSize(mode, format);
 		else {
 			Graphics::PixelFormat bestFormat = g_system->getSupportedFormats().front();
-			g_system->initSize(width, height, &bestFormat);
+			g_system->initSize(mode, &bestFormat);
 		}
 #else
-		g_system->initSize(width, height);
+		g_system->initSize(mode);
 #endif
 
 	OSystem::TransactionError gfxError = g_system->endGFXTransaction();
@@ -303,7 +302,7 @@ void initGraphics(int width, int height, const Graphics::PixelFormat *format) {
 	// Error out on size switch failure
 	if (gfxError & OSystem::kTransactionSizeChangeFailed) {
 		Common::String message;
-		message = Common::String::format("Could not switch to resolution: '%dx%d'.", width, height);
+		message = Common::String::format("Could not switch to resolution: '%dx%d'.", mode.width, mode.height);
 
 		GUIErrorMessage(message);
 		error("%s", message.c_str());
@@ -366,20 +365,32 @@ inline Graphics::PixelFormat findCompatibleFormat(const Common::List<Graphics::P
 
 
 void initGraphics(int width, int height, const Common::List<Graphics::PixelFormat> &formatList) {
-	Graphics::PixelFormat format = findCompatibleFormat(g_system->getSupportedFormats(), formatList);
-	initGraphics(width, height, &format);
+	initGraphics(Graphics::Mode(width, height), formatList);
 }
 
 void initGraphics(int width, int height) {
+	initGraphics(Graphics::Mode(width, height));
+}
+
+void initGraphics(int width, int height, const Graphics::PixelFormat *format) {
+	initGraphics(Graphics::Mode(width, height), format);
+}
+
+void initGraphics(const Graphics::Mode &mode, const Common::List<Graphics::PixelFormat> &formatList) {
+	Graphics::PixelFormat format = findCompatibleFormat(g_system->getSupportedFormats(), formatList);
+	initGraphics(mode, &format);
+}
+
+void initGraphics(const Graphics::Mode &mode) {
 	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
-	initGraphics(width, height, &format);
+	initGraphics(mode, &format);
 }
 
 void GUIErrorMessage(const Common::String &msg) {
 	g_system->setWindowCaption("Error");
 	g_system->beginGFXTransaction();
 		initCommonGFX();
-		g_system->initSize(320, 200);
+	g_system->initSize(Graphics::Mode(320, 200));
 	if (g_system->endGFXTransaction() == OSystem::kTransactionSuccess) {
 		GUI::MessageDialog dialog(msg);
 		dialog.runModal();

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -272,11 +272,11 @@ void splashScreen() {
 	splash = true;
 }
 
-void initGraphicsModes(const Graphics::ModeList &modes) {
+void initGraphicsModes(const Graphics::VideoModeList &modes) {
 	g_system->initSizeHint(modes);
 }
 
-void initGraphics(const Graphics::Mode &mode, const Graphics::PixelFormat *format) {
+void initGraphics(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format) {
 	g_system->beginGFXTransaction();
 
 		initCommonGFX();
@@ -365,23 +365,23 @@ inline Graphics::PixelFormat findCompatibleFormat(const Common::List<Graphics::P
 
 
 void initGraphics(int width, int height, const Common::List<Graphics::PixelFormat> &formatList) {
-	initGraphics(Graphics::Mode(width, height), formatList);
+	initGraphics(Graphics::VideoMode(width, height), formatList);
 }
 
 void initGraphics(int width, int height) {
-	initGraphics(Graphics::Mode(width, height));
+	initGraphics(Graphics::VideoMode(width, height));
 }
 
 void initGraphics(int width, int height, const Graphics::PixelFormat *format) {
-	initGraphics(Graphics::Mode(width, height), format);
+	initGraphics(Graphics::VideoMode(width, height), format);
 }
 
-void initGraphics(const Graphics::Mode &mode, const Common::List<Graphics::PixelFormat> &formatList) {
+void initGraphics(const Graphics::VideoMode &mode, const Common::List<Graphics::PixelFormat> &formatList) {
 	Graphics::PixelFormat format = findCompatibleFormat(g_system->getSupportedFormats(), formatList);
 	initGraphics(mode, &format);
 }
 
-void initGraphics(const Graphics::Mode &mode) {
+void initGraphics(const Graphics::VideoMode &mode) {
 	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
 	initGraphics(mode, &format);
 }
@@ -390,7 +390,7 @@ void GUIErrorMessage(const Common::String &msg) {
 	g_system->setWindowCaption("Error");
 	g_system->beginGFXTransaction();
 		initCommonGFX();
-	g_system->initSize(Graphics::Mode(320, 200));
+	g_system->initSize(Graphics::VideoMode(320, 200));
 	if (g_system->endGFXTransaction() == OSystem::kTransactionSuccess) {
 		GUI::MessageDialog dialog(msg);
 		dialog.runModal();

--- a/engines/gob/gob.cpp
+++ b/engines/gob/gob.cpp
@@ -709,10 +709,10 @@ Common::Error GobEngine::initGraphics() {
 		_mode   = 0x14;
 	}
 
-	Graphics::ModeList modes;
-	modes.push_back(Graphics::Mode(_width, _height));
+	Graphics::VideoModeList modes;
+	modes.push_back(Graphics::VideoMode(_width, _height));
 	if (getGameType() == kGameTypeLostInTime) {
-		modes.push_back(Graphics::Mode(640, 400));
+		modes.push_back(Graphics::VideoMode(640, 400));
 	}
 	initGraphicsModes(modes);
 

--- a/engines/sherlock/scalpel/scalpel.cpp
+++ b/engines/sherlock/scalpel/scalpel.cpp
@@ -259,14 +259,14 @@ void ScalpelEngine::setupGraphics() {
 		// First try for a 640x400 mode
 		g_system->beginGFXTransaction();
 		initCommonGFX();
-		g_system->initSize(640, 400, &pixelFormatRGB565);
+		g_system->initSize(Graphics::Mode(640, 400), &pixelFormatRGB565);
 		OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
 		if (gfxError == OSystem::kTransactionSuccess) {
 			_isScreenDoubled = true;
 		} else {
 			// System doesn't support it, so fall back on 320x200 mode
-			initGraphics(320, 200, &pixelFormatRGB565);
+			initGraphics(Graphics::Mode(320, 200), &pixelFormatRGB565);
 		}
 	}
 }

--- a/engines/sherlock/scalpel/scalpel.cpp
+++ b/engines/sherlock/scalpel/scalpel.cpp
@@ -259,14 +259,14 @@ void ScalpelEngine::setupGraphics() {
 		// First try for a 640x400 mode
 		g_system->beginGFXTransaction();
 		initCommonGFX();
-		g_system->initSize(Graphics::Mode(640, 400), &pixelFormatRGB565);
+		g_system->initSize(Graphics::VideoMode(640, 400), &pixelFormatRGB565);
 		OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
 		if (gfxError == OSystem::kTransactionSuccess) {
 			_isScreenDoubled = true;
 		} else {
 			// System doesn't support it, so fall back on 320x200 mode
-			initGraphics(Graphics::Mode(320, 200), &pixelFormatRGB565);
+			initGraphics(Graphics::VideoMode(320, 200), &pixelFormatRGB565);
 		}
 	}
 }

--- a/engines/supernova/supernova.cpp
+++ b/engines/supernova/supernova.cpp
@@ -135,9 +135,9 @@ SupernovaEngine::~SupernovaEngine() {
 }
 
 Common::Error SupernovaEngine::run() {
-	Graphics::ModeList modes;
-	modes.push_back(Graphics::Mode(320, 200));
-	modes.push_back(Graphics::Mode(640, 480));
+	Graphics::VideoModeList modes;
+	modes.push_back(Graphics::VideoMode(320, 200));
+	modes.push_back(Graphics::VideoMode(640, 480));
 	initGraphicsModes(modes);
 	initGraphics(_screenWidth, _screenHeight);
 

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -912,7 +912,7 @@ TestExitStatus GFXtests::scaledCursors() {
 		g_system->beginGFXTransaction();
 
 		bool isGFXModeSet = g_system->setGraphicsMode(gfxMode->id);
-		g_system->initSize(320, 200);
+		g_system->initSize(Graphics::Mode(320, 200));
 
 		OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
@@ -948,7 +948,7 @@ TestExitStatus GFXtests::scaledCursors() {
 	// Restore Original State
 	g_system->beginGFXTransaction();
 	bool isGFXModeSet = g_system->setGraphicsMode(currGFXMode);
-	g_system->initSize(320, 200);
+	g_system->initSize(Graphics::Mode(320, 200));
 
 	if (isAspectRatioCorrected) {
 		g_system->setFeatureState(OSystem::kFeatureAspectRatioCorrection, true);
@@ -1226,7 +1226,7 @@ TestExitStatus GFXtests::pixelFormats() {
 
 		// Switch to that pixel Format
 		g_system->beginGFXTransaction();
-		g_system->initSize(320, 200, &(*iter));
+		g_system->initSize(Graphics::Mode(320, 200), &(*iter));
 		g_system->endGFXTransaction();
 		Testsuite::clearScreen(true);
 
@@ -1272,7 +1272,7 @@ TestExitStatus GFXtests::pixelFormats() {
 
 	// Revert back to 8bpp
 	g_system->beginGFXTransaction();
-	g_system->initSize(320, 200);
+	g_system->initSize(Graphics::Mode(320, 200));
 	g_system->endGFXTransaction();
 	GFXTestSuite::setCustomColor(255, 0, 0);
 	initMousePalette();

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -912,7 +912,7 @@ TestExitStatus GFXtests::scaledCursors() {
 		g_system->beginGFXTransaction();
 
 		bool isGFXModeSet = g_system->setGraphicsMode(gfxMode->id);
-		g_system->initSize(Graphics::Mode(320, 200));
+		g_system->initSize(Graphics::VideoMode(320, 200));
 
 		OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
@@ -948,7 +948,7 @@ TestExitStatus GFXtests::scaledCursors() {
 	// Restore Original State
 	g_system->beginGFXTransaction();
 	bool isGFXModeSet = g_system->setGraphicsMode(currGFXMode);
-	g_system->initSize(Graphics::Mode(320, 200));
+	g_system->initSize(Graphics::VideoMode(320, 200));
 
 	if (isAspectRatioCorrected) {
 		g_system->setFeatureState(OSystem::kFeatureAspectRatioCorrection, true);
@@ -1226,7 +1226,7 @@ TestExitStatus GFXtests::pixelFormats() {
 
 		// Switch to that pixel Format
 		g_system->beginGFXTransaction();
-		g_system->initSize(Graphics::Mode(320, 200), &(*iter));
+		g_system->initSize(Graphics::VideoMode(320, 200), &(*iter));
 		g_system->endGFXTransaction();
 		Testsuite::clearScreen(true);
 
@@ -1272,7 +1272,7 @@ TestExitStatus GFXtests::pixelFormats() {
 
 	// Revert back to 8bpp
 	g_system->beginGFXTransaction();
-	g_system->initSize(Graphics::Mode(320, 200));
+	g_system->initSize(Graphics::VideoMode(320, 200));
 	g_system->endGFXTransaction();
 	GFXTestSuite::setCustomColor(255, 0, 0);
 	initMousePalette();

--- a/engines/util.h
+++ b/engines/util.h
@@ -61,4 +61,8 @@ void initGraphics(int width, int height);
 void initGraphics(int width, int height, const Graphics::PixelFormat *format);
 void initGraphics(int width, int height, const Common::List<Graphics::PixelFormat> &formatList);
 
+void initGraphics(const Graphics::Mode &mode);
+void initGraphics(const Graphics::Mode &mode, const Graphics::PixelFormat *format);
+void initGraphics(const Graphics::Mode &mode, const Common::List<Graphics::PixelFormat> &formatList);
+
 #endif

--- a/engines/util.h
+++ b/engines/util.h
@@ -27,7 +27,7 @@
 #include "common/scummsys.h"
 #include "common/list.h"
 #include "graphics/pixelformat.h"
-#include "graphics/mode.h"
+#include "graphics/video_mode.h"
 
 /**
  * Setup the backend's graphics mode.
@@ -42,7 +42,7 @@ void initCommonGFX();
  * should call this function prior to any call to initGraphics. Engines that use
  * only a single screen size do not need to call this function.
  */
-void initGraphicsModes(const Graphics::ModeList &modes);
+void initGraphicsModes(const Graphics::VideoModeList &modes);
 
 /**
  * Sets up the backend's screen size and graphics mode.
@@ -61,8 +61,8 @@ void initGraphics(int width, int height);
 void initGraphics(int width, int height, const Graphics::PixelFormat *format);
 void initGraphics(int width, int height, const Common::List<Graphics::PixelFormat> &formatList);
 
-void initGraphics(const Graphics::Mode &mode);
-void initGraphics(const Graphics::Mode &mode, const Graphics::PixelFormat *format);
-void initGraphics(const Graphics::Mode &mode, const Common::List<Graphics::PixelFormat> &formatList);
+void initGraphics(const Graphics::VideoMode &mode);
+void initGraphics(const Graphics::VideoMode &mode, const Graphics::PixelFormat *format);
+void initGraphics(const Graphics::VideoMode &mode, const Common::List<Graphics::PixelFormat> &formatList);
 
 #endif

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -125,7 +125,7 @@ bool BaseRenderOSystem::initRenderer(int width, int height, bool windowed) {
 
 	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
 	g_system->beginGFXTransaction();
-	g_system->initSize(Graphics::Mode(_width, _height), &format);
+	g_system->initSize(Graphics::VideoMode(_width, _height), &format);
 	OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
 	if (gfxError != OSystem::kTransactionSuccess) {

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -125,7 +125,7 @@ bool BaseRenderOSystem::initRenderer(int width, int height, bool windowed) {
 
 	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
 	g_system->beginGFXTransaction();
-	g_system->initSize(_width, _height, &format);
+	g_system->initSize(Graphics::Mode(_width, _height), &format);
 	OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
 	if (gfxError != OSystem::kTransactionSuccess) {

--- a/graphics/mode.h
+++ b/graphics/mode.h
@@ -34,13 +34,13 @@ namespace Graphics {
 struct Mode {
 	int16 width;  ///< The width in pixels
 	int16 height; ///< The height in pixels
-	frac_t par;   ///< The pixel aspect ratio (pixel height / pixel width)
+	frac_t par;   ///< The pixel aspect ratio (pixel width / pixel height)
 
 	Mode(const int16 w, const int16 h) :
 		width(w),
 		height(h) {
 			if ((w == 320 && h == 200) || (w == 640 && h == 400))
-				par = intToFrac(6) / 5;
+				par = intToFrac(5) / 6;
 			else
 				par = intToFrac(1);
 		}

--- a/graphics/mode.h
+++ b/graphics/mode.h
@@ -24,6 +24,7 @@
 #define GRAPHICS_MODE_H
 
 #include "common/array.h"
+#include "common/frac.h"
 
 namespace Graphics {
 
@@ -31,13 +32,36 @@ namespace Graphics {
  * Represents a hardware video mode.
  */
 struct Mode {
-	int16 width; ///< The width in pixels
+	int16 width;  ///< The width in pixels
 	int16 height; ///< The height in pixels
+	frac_t par;   ///< The pixel aspect ratio (pixel height / pixel width)
 
 	Mode(const int16 w, const int16 h) :
 		width(w),
-		height(h) {}
+		height(h) {
+			if ((w == 320 && h == 200) || (w == 640 && h == 400))
+				par = intToFrac(6) / 5;
+			else
+				par = intToFrac(1);
+		}
+	Mode(const int16 w, const int16 h, const frac_t ar) :
+		width(w),
+		height(h),
+		par(ar) {}
 
+	int16 correctedHeight() const {
+		return fracToInt(height * par);
+	}
+
+	/// Return a Mode with height scaled by the pixel aspect ratio correction (and the par set to 1).
+	/// This can for example be used to compare two corrected modes.
+	Mode corrected() const {
+		return Mode(width, correctedHeight(), intToFrac(1));
+	}
+
+	/// Compare two modes. Return true if both the width and the height of this mode are smaller than
+	/// the width and height of the other mode. The pixel aspect ratio is not applied to do this
+	/// comparison. See corrected() if you want to compare corrected modes.
 	bool operator<(const Mode &other) const {
 		return width < other.width && height < other.height;
 	}

--- a/graphics/mode.h
+++ b/graphics/mode.h
@@ -58,13 +58,6 @@ struct Mode {
 	Mode corrected() const {
 		return Mode(width, correctedHeight(), intToFrac(1));
 	}
-
-	/// Compare two modes. Return true if both the width and the height of this mode are smaller than
-	/// the width and height of the other mode. The pixel aspect ratio is not applied to do this
-	/// comparison. See corrected() if you want to compare corrected modes.
-	bool operator<(const Mode &other) const {
-		return width < other.width && height < other.height;
-	}
 };
 
 typedef Common::Array<Mode> ModeList;

--- a/graphics/mode.h
+++ b/graphics/mode.h
@@ -36,6 +36,9 @@ struct Mode {
 	int16 height; ///< The height in pixels
 	frac_t par;   ///< The pixel aspect ratio (pixel width / pixel height)
 
+	/// Obsolete constructor that guesses the pixel aspect ratio from the dimension.
+	/// It is present to help the transition to the PAR aware Graphics::Mode, but
+	/// the other constructor should be preferred.
 	Mode(const int16 w, const int16 h) :
 		width(w),
 		height(h) {
@@ -44,6 +47,9 @@ struct Mode {
 			else
 				par = intToFrac(1);
 		}
+
+	/// Construct a Garphics::Mode with the given dimension and pixel aspect ratio.
+	/// The pixel aspect ratio is given as pixel width / pixel height.
 	Mode(const int16 w, const int16 h, const frac_t ar) :
 		width(w),
 		height(h),

--- a/graphics/video_mode.h
+++ b/graphics/video_mode.h
@@ -24,7 +24,7 @@
 #define GRAPHICS_VIDEO_MODE_H
 
 #include "common/array.h"
-#include "common/frac.h"
+#include "common/rational.h"
 
 namespace Graphics {
 
@@ -34,7 +34,7 @@ namespace Graphics {
 struct VideoMode {
 	int16 width;  ///< The width in pixels
 	int16 height; ///< The height in pixels
-	frac_t par;   ///< The pixel aspect ratio (pixel width / pixel height)
+	Common::Rational par; ///< The pixel aspect ratio (pixel width / pixel height)
 
 	/// Obsolete constructor that guesses the pixel aspect ratio from the dimension.
 	/// It is present to help the transition to the PAR aware Graphics::VideoMode, but
@@ -43,26 +43,26 @@ struct VideoMode {
 		width(w),
 		height(h) {
 			if ((w == 320 && h == 200) || (w == 640 && h == 400))
-				par = intToFrac(5) / 6;
+				par = Common::Rational(5, 6);
 			else
-				par = intToFrac(1);
+				par = Common::Rational(1, 1);
 		}
 
 	/// Construct a Garphics::Mode with the given dimension and pixel aspect ratio.
 	/// The pixel aspect ratio is given as pixel width / pixel height.
-	VideoMode(const int16 w, const int16 h, const frac_t ar) :
+	VideoMode(const int16 w, const int16 h, const Common::Rational &ar) :
 		width(w),
 		height(h),
 		par(ar) {}
 
 	int16 correctedHeight() const {
-		return fracToInt(height * par);
+		return (height / par).toInt();
 	}
 
 	/// Return a Mode with height scaled by the pixel aspect ratio correction (and the par set to 1).
 	/// This can for example be used to compare two corrected modes.
 	VideoMode corrected() const {
-		return VideoMode(width, correctedHeight(), intToFrac(1));
+		return VideoMode(width, correctedHeight(), Common::Rational());
 	}
 };
 

--- a/graphics/video_mode.h
+++ b/graphics/video_mode.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef GRAPHICS_MODE_H
-#define GRAPHICS_MODE_H
+#ifndef GRAPHICS_VIDEO_MODE_H
+#define GRAPHICS_VIDEO_MODE_H
 
 #include "common/array.h"
 #include "common/frac.h"
@@ -31,15 +31,15 @@ namespace Graphics {
 /**
  * Represents a hardware video mode.
  */
-struct Mode {
+struct VideoMode {
 	int16 width;  ///< The width in pixels
 	int16 height; ///< The height in pixels
 	frac_t par;   ///< The pixel aspect ratio (pixel width / pixel height)
 
 	/// Obsolete constructor that guesses the pixel aspect ratio from the dimension.
-	/// It is present to help the transition to the PAR aware Graphics::Mode, but
+	/// It is present to help the transition to the PAR aware Graphics::VideoMode, but
 	/// the other constructor should be preferred.
-	Mode(const int16 w, const int16 h) :
+	VideoMode(const int16 w, const int16 h) :
 		width(w),
 		height(h) {
 			if ((w == 320 && h == 200) || (w == 640 && h == 400))
@@ -50,7 +50,7 @@ struct Mode {
 
 	/// Construct a Garphics::Mode with the given dimension and pixel aspect ratio.
 	/// The pixel aspect ratio is given as pixel width / pixel height.
-	Mode(const int16 w, const int16 h, const frac_t ar) :
+	VideoMode(const int16 w, const int16 h, const frac_t ar) :
 		width(w),
 		height(h),
 		par(ar) {}
@@ -61,12 +61,12 @@ struct Mode {
 
 	/// Return a Mode with height scaled by the pixel aspect ratio correction (and the par set to 1).
 	/// This can for example be used to compare two corrected modes.
-	Mode corrected() const {
-		return Mode(width, correctedHeight(), intToFrac(1));
+	VideoMode corrected() const {
+		return VideoMode(width, correctedHeight(), intToFrac(1));
 	}
 };
 
-typedef Common::Array<Mode> ModeList;
+typedef Common::Array<VideoMode> VideoModeList;
 
 }
 


### PR DESCRIPTION
**DO NOT MERGE**: This pull request is incomplete and is here to ask for feedback.

The way the aspect ratio correction works in ScummVM is currently too restrictive for some games. Backends hardcode a 6:5 correction designed to go from 320x200 to 320x240 or 640x400 to 640x480. When aspect ratio correction is on, the SDL backends (both surface and OpenGL) for example systematically apply this 6:5 correction when the game original resolution is either 320x200 or 640x400 and do no correction otherwise.

Here are some cases where it fails:
  - Dreamweb, despite having a resolution of 320x200, was designed with square pixels in mind (as can be seen with the circle  in the introduction, or with the rotating fan in Eden's bedroom).
  - ADL games with an original resolution of 560x384 need to be corrected to 560x420, which means a 35:32 correction (see conversation starting at 07:47 at http://logs.scummvm.org/log.php?log=scummvm.log.21Jun2017).
  - Some mac SCI games have a native resolution of 320x190 and apparently need to be corrected to 320x228 (see http://forums.scummvm.org/viewtopic.php?t=14303)

The approach that I have taken here is to modify Graphics::Mode to contain a pixel aspect ratio in addition to the width and height of the game. I then modified `OSystem::initSize(int width, int height, const Graphics::PixelFormat *format = NULL)` to `OSystem::initSize(const Graphics::Mode &mode, const Graphics::PixelFormat *format = NULL)` and adapted the OpenGL and SurfaceSdl graphics backend as well as the dreamweb and ADL engines.

All other backends are broken since I did not report the change in the OSystem API to them yet.

Another limitation of this pull request is that the SurfaceSdl backend only supports 1:1 or 6:5 corrections. So any other correction is ignored. To test those currently you have to use the OpenGL mode.

Note that in theory this approach allows the backend to choose the correction based on the given game pixel aspect ratio and the current display device (i.e screen) pixel aspect ratio. In the changes I made the backends assume the display uses square pixel when doing the correction. 

At this points this allows to see that the approach works. Before I continue further I would like some feedback:
- Does this approach look good to you? Do you have a better suggestion?
- Currently the aspect ratio is stored as a frac_t, which has some precision issue. See commit 109b772. Should Common::Rational be used instead?
- At some point while working on this I got confused between `OSystem::GraphicsMode` and `Graphics::Mode`. Maybe the later should be renamed?
- The aspect correction code for the SurfaceSdl backend, which is in [graphics/scaler/aspect.cpp](https://github.com/scummvm/scummvm/blob/master/graphics/scaler/aspect.cpp) assumes a 6:5 correction. Rewriting this code seems like a big task. Maybe we could let SDL2 do the scaling (I think it can do it? And it might even use hardware acceleration?) ? But then what of SDL 1? Can the support be dropped? Can we just leave it with the current code and no correction other than 6:5? Do you have any other suggestion?
