### PR TITLE
AGI: Fix black box in bottom-right corner

### DIFF
--- a/engines/agi/text.cpp
+++ b/engines/agi/text.cpp
@@ -59,6 +59,7 @@ TextMgr::TextMgr(AgiEngine *vm, Words *words, GfxMgr *gfx) {
 
 	_inputEditEnabled = false;
 	_inputCursorChar = 0;
+	_inputCursorCharDrawn = false;
 
 	_statusEnabled = false;
 	_statusRow = 0;
@@ -629,8 +630,9 @@ bool TextMgr::inputGetEditStatus() {
 void TextMgr::inputEditOn() {
 	if (!_inputEditEnabled) {
 		_inputEditEnabled = true;
-		if (_inputCursorChar) {
+		if (_inputCursorCharDrawn) {
 			displayCharacter(0x08); // backspace
+			_inputCursorCharDrawn = false;
 		}
 	}
 }
@@ -640,6 +642,7 @@ void TextMgr::inputEditOff() {
 		_inputEditEnabled = false;
 		if (_inputCursorChar) {
 			displayCharacter(_inputCursorChar);
+			_inputCursorCharDrawn = true;
 		}
 	}
 }
@@ -887,7 +890,7 @@ void TextMgr::stringEdit(int16 stringMaxLen) {
 	_inputStringRow = _textPos.row;
 	_inputStringColumn = _textPos.column;
 
-	if (_inputCursorChar) {
+	if (_inputCursorCharDrawn) {
 		// Cursor character is shown, which means we are one beyond the start of the input
 		// Adjust the column for predictive input dialog
 		_inputStringColumn--;

--- a/engines/agi/text.h
+++ b/engines/agi/text.h
@@ -162,6 +162,7 @@ public:
 
 	bool  _inputEditEnabled;
 	byte  _inputCursorChar;
+	bool  _inputCursorCharDrawn;
 
 	bool  _optionCommandPromptWindow;
 


### PR DESCRIPTION
Future GSoC applicant here with a bugfix.

This fixes a minor bug in Space Quest 1 AGI, probably other AGI games; when you load a savegame after dying (or presumably anytime when the text cursor is not shown), a black square appears on the bottom right of the screen.

![sq1_bug](https://user-images.githubusercontent.com/3671681/36338692-bd44c3fa-1383-11e8-9a2d-d4b6231c3416.png)

This was caused by the text engine "forgetting" that there is no cursor being displayed; it then proceeds to try to delete the cursor, causing the text to leak onto the previous line.

Interestingly, there is a similar bug in the DOS version, but it only occurs if you type some text after dying. ScummVM had the exact opposite problem - it only occured if you didn't type any text...