### PR TITLE
XEEN: Add support for OPL to map to music sound type

### DIFF
--- a/audio/fmopl.cpp
+++ b/audio/fmopl.cpp
@@ -191,9 +191,9 @@ OPL *Config::create(DriverId driver, OplType type) {
 	}
 }
 
-void OPL::start(TimerCallback *callback, int timerFrequency) {
+void OPL::start(TimerCallback *callback, int timerFrequency, Audio::Mixer::SoundType soundType) {
 	_callback.reset(callback);
-	startCallbacks(timerFrequency);
+	startCallbacks(timerFrequency, soundType);
 }
 
 void OPL::stop() {
@@ -219,7 +219,7 @@ void RealOPL::setCallbackFrequency(int timerFrequency) {
 	startCallbacks(timerFrequency);
 }
 
-void RealOPL::startCallbacks(int timerFrequency) {
+void RealOPL::startCallbacks(int timerFrequency, Audio::Mixer::SoundType soundType) {
 	_baseFreq = timerFrequency;
 	assert(_baseFreq > 0);
 
@@ -308,9 +308,9 @@ int EmulatedOPL::getRate() const {
 	return g_system->getMixer()->getOutputRate();
 }
 
-void EmulatedOPL::startCallbacks(int timerFrequency) {
+void EmulatedOPL::startCallbacks(int timerFrequency, Audio::Mixer::SoundType soundType) {
 	setCallbackFrequency(timerFrequency);
-	g_system->getMixer()->playStream(Audio::Mixer::kPlainSoundType, _handle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	g_system->getMixer()->playStream(soundType, _handle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
 }
 
 void EmulatedOPL::stopCallbacks() {

--- a/audio/fmopl.h
+++ b/audio/fmopl.h
@@ -24,6 +24,7 @@
 #define AUDIO_FMOPL_H
 
 #include "audio/audiostream.h"
+#include "audio/mixer.h"
 
 #include "common/func.h"
 #include "common/ptr.h"
@@ -163,7 +164,7 @@ public:
 	/**
 	 * Start the OPL with callbacks.
 	 */
-	void start(TimerCallback *callback, int timerFrequency = kDefaultCallbackFrequency);
+	void start(TimerCallback *callback, int timerFrequency = kDefaultCallbackFrequency, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
 
 	/**
 	 * Stop the OPL
@@ -187,7 +188,7 @@ protected:
 	/**
 	 * Start the callbacks.
 	 */
-	virtual void startCallbacks(int timerFrequency) = 0;
+	virtual void startCallbacks(int timerFrequency, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType) = 0;
 
 	/**
 	 * Stop the callbacks.
@@ -216,7 +217,7 @@ public:
 
 protected:
 	// OPL API
-	void startCallbacks(int timerFrequency);
+	virtual void startCallbacks(int timerFrequency, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
 	void stopCallbacks();
 
 private:
@@ -252,7 +253,7 @@ public:
 
 protected:
 	// OPL API
-	void startCallbacks(int timerFrequency);
+	virtual void startCallbacks(int timerFrequency, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
 	void stopCallbacks();
 
 	/**

--- a/engines/xeen/music.cpp
+++ b/engines/xeen/music.cpp
@@ -268,7 +268,8 @@ AdlibMusicDriver::AdlibMusicDriver() : _field180(0), _field181(0), _field182(0),
 
 	_opl = OPL::Config::create();
 	_opl->init();
-	_opl->start(new Common::Functor0Mem<void, AdlibMusicDriver>(this, &AdlibMusicDriver::onTimer), CALLBACKS_PER_SECOND);
+	_opl->start(new Common::Functor0Mem<void, AdlibMusicDriver>(this, &AdlibMusicDriver::onTimer),
+		CALLBACKS_PER_SECOND, Audio::Mixer::kMusicSoundType);
 	initialize();
 }
 


### PR DESCRIPTION
I'd like opinions on this before I merge it into master. Basically, World of Xeen has SFX using raw data files that can be passed directly to playStream, and a complicated music system that uses the ScummVM OPL. The default FMOPL implementation, though, is hardcoded to use the kPlainSoundType for the resultant audio stream. This commits adds in an optional sound type parameter to the start method, which allows the Xeen engine to specify it to output to a music stream, whose volume is then automatically properly controlled by the music volume slider.
