### PR TITLE
DS: Fix compilation and touch input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ lib*.a
 /*,e1f
 /scummvm-ps3.pkg
 /*.ipk
+/map.txt
+*.elf
+/*.nds
 /.project
 /.cproject
 /.settings
@@ -53,6 +56,7 @@ lib*.a
 /backends/platform/ds/arm7/build
 /backends/platform/ds/arm7/source/libcartreset/*.bak
 /backends/platform/ds/arm7/source/libcartreset/*.d
+/backends/platform/ds/arm9/data/*.h
 /backends/platform/ds/arm9/scummvm-?
 
 /backends/platform/maemo/scummvm

--- a/audio/softsynth/opl/mame.cpp
+++ b/audio/softsynth/opl/mame.cpp
@@ -29,6 +29,10 @@
 #include <stdarg.h>
 #include <math.h>
 
+#if defined(__DS__)
+#include "dsmain.h"
+#endif
+
 #include "mame.h"
 
 #include "audio/mixer.h"
@@ -38,10 +42,6 @@
 
 #if defined(_WIN32_WCE) || defined(__SYMBIAN32__) || defined(__GP32__) || defined(GP2X) || defined(__MAEMO__) || defined(__DS__) || defined(__MINT__) || defined(__N64__)
 #include "common/config-manager.h"
-#endif
-
-#if defined(__DS__)
-#include "dsmain.h"
 #endif
 
 namespace OPL {

--- a/backends/fs/ds/ds-fs-factory.cpp
+++ b/backends/fs/ds/ds-fs-factory.cpp
@@ -24,9 +24,9 @@
 #define FORBIDDEN_SYMBOL_EXCEPTION_FILE
 
 #if defined(__DS__)
+#include "dsmain.h" //for the isGBAMPAvailable() function
 #include "backends/fs/ds/ds-fs-factory.h"
 #include "backends/fs/ds/ds-fs.h"
-#include "dsmain.h" //for the isGBAMPAvailable() function
 
 namespace Common {
 DECLARE_SINGLETON(DSFilesystemFactory);

--- a/backends/fs/ds/ds-fs.cpp
+++ b/backends/fs/ds/ds-fs.cpp
@@ -23,12 +23,12 @@
 // Disable symbol overrides for FILE as that is used in FLAC headers
 #define FORBIDDEN_SYMBOL_EXCEPTION_FILE
 
+#include "dsmain.h"
 #include "common/str.h"
 #include "common/util.h"
 //#include <NDS/ARM9/console.h> //basic print funcionality
 #include "backends/fs/ds/ds-fs.h"
 #include "backends/fs/stdiostream.h"
-#include "dsmain.h"
 #include "fat/gba_nds_fat.h"
 #include "common/bufferedstream.h"
 

--- a/backends/platform/ds/arm7/source/main.cpp
+++ b/backends/platform/ds/arm7/source/main.cpp
@@ -443,11 +443,11 @@ void InterruptTimer3() {
 	  x = p.rawx;
 	  y = p.rawy;
 
-	  xpx = p.px;
-	  ypx = p.py;
+	  //xpx = p.px;
+	  //ypx = p.py;
 
-//      xpx = ( ((SCREEN_WIDTH -60) * x) / TOUCH_WIDTH  ) - TOUCH_OFFSET_X;
-  //    ypx = ( ((SCREEN_HEIGHT-60) * y) / TOUCH_HEIGHT ) - TOUCH_OFFSET_Y;
+      xpx = ( ((SCREEN_WIDTH -60) * x) / TOUCH_WIDTH  ) - TOUCH_OFFSET_X;
+      ypx = ( ((SCREEN_HEIGHT-60) * y) / TOUCH_HEIGHT ) - TOUCH_OFFSET_Y;
 
 //	  xpx = (IPC->touchX - (int16) TOUCH_CAL_X1) * CNTRL_WIDTH  / TOUCH_WIDTH  + (int16) (TOUCH_CNTRL_X1 - 8);
 	//  ypx = (IPC->touchY - (int16) TOUCH_CAL_Y1) * CNTRL_HEIGHT / TOUCH_HEIGHT + (int16) (TOUCH_CNTRL_Y1 - 8);

--- a/backends/platform/ds/arm9/source/cdaudio.cpp
+++ b/backends/platform/ds/arm9/source/cdaudio.cpp
@@ -23,10 +23,10 @@
 // Disable symbol overrides for FILE as that is used in FLAC headers
 #define FORBIDDEN_SYMBOL_EXCEPTION_FILE
 
+#include "dsmain.h"
 #include "cdaudio.h"
 #include "backends/fs/ds/ds-fs.h"
 #include "common/config-manager.h"
-#include "dsmain.h"
 #include "NDS/scummvm_ipc.h"
 
 #define WAV_FORMAT_IMA_ADPCM 0x14

--- a/backends/platform/ds/arm9/source/dsmain.cpp
+++ b/backends/platform/ds/arm9/source/dsmain.cpp
@@ -2499,7 +2499,7 @@ void penUpdate() {
 
 //	if (getKeysHeld() & KEY_L) consolePrintf("%d, %d   penX=%d, penY=%d tz=%d\n", IPC->touchXpx, IPC->touchYpx, penX, penY, IPC->touchZ1);
 
-	bool penDownThisFrame = (IPC->touchZ1 > 0) && (IPC->touchXpx > 0) && (IPC->touchYpx > 0);
+	bool penDownThisFrame = (!(IPC->buttons & 0x40)) && (IPC->touchXpx > 0) && (IPC->touchYpx > 0);
 	static bool moved = false;
 
 	if (( (tapScreenClicks) || getKeyboardEnable() ) && (getIsDisplayMode8Bit())) {
@@ -2626,7 +2626,7 @@ void penUpdate() {
 				penDownSaved = true;
 			}
 
-			if ((IPC->touchZ1 > 0) && (IPC->touchXpx > 0) && (IPC->touchYpx > 0)) {
+			if ((!(IPC->buttons & 0x40)) && (IPC->touchXpx > 0) && (IPC->touchYpx > 0)) {
 				penX = IPC->touchXpx + touchXOffset;
 				penY = IPC->touchYpx + touchYOffset;
 				moved = true;
@@ -2648,7 +2648,7 @@ void penUpdate() {
 
 
 
-	if ((IPC->touchZ1 > 0) || ((penDownFrames == 2)) ) {
+	if ((!(IPC->buttons & 0x40)) || ((penDownFrames == 2)) ) {
 		penDownLastFrame = true;
 		penDownFrames++;
 	} else {

--- a/backends/platform/ds/arm9/source/dsmain.cpp
+++ b/backends/platform/ds/arm9/source/dsmain.cpp
@@ -573,7 +573,7 @@ void initGame() {
 		s_currentGame = &gameList[0];		// Default game
 
 		for (int r = 0; r < NUM_SUPPORTED_GAMES; r++) {
-			if (!stricmp(gameName, gameList[r].gameId)) {
+			if (!scumm_stricmp(gameName, gameList[r].gameId)) {
 				s_currentGame = &gameList[r];
 	//			consolePrintf("Game list num: %d\n", r);
 			}

--- a/backends/platform/ds/arm9/source/dsmain.h
+++ b/backends/platform/ds/arm9/source/dsmain.h
@@ -23,6 +23,8 @@
 #ifndef _DSMAIN_H
 #define _DSMAIN_H
 
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
 #include <nds.h>
 #include "osystem_ds.h"
 

--- a/backends/platform/ds/arm9/source/dsoptions.cpp
+++ b/backends/platform/ds/arm9/source/dsoptions.cpp
@@ -20,8 +20,8 @@
  *
  */
 
-#include "dsoptions.h"
 #include "dsmain.h"
+#include "dsoptions.h"
 #include "gui/dialog.h"
 #include "gui/gui-manager.h"
 #include "gui/widgets/list.h"

--- a/backends/platform/ds/arm9/source/fat/disc_io.c
+++ b/backends/platform/ds/arm9/source/fat/disc_io.c
@@ -367,7 +367,7 @@ bool disc_setDsSlotInterface (void)
 
 	active_interface = DLDI_GetInterface();
 
-	if (stricmp((char *)(&_dldi_driver_name), "Default (No interface)")) {
+	if (strcasecmp((char *)(&_dldi_driver_name), "Default (No interface)")) {
 		char name[48];
 		memcpy(name, &_dldi_driver_name, 48);
 		name[47] = '\0';

--- a/backends/platform/ds/arm9/source/osystem_ds.cpp
+++ b/backends/platform/ds/arm9/source/osystem_ds.cpp
@@ -23,6 +23,7 @@
 
 // Allow use of stuff in <time.h>
 #define FORBIDDEN_SYMBOL_EXCEPTION_time_h
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
 
 #include "common/scummsys.h"
 #include "common/system.h"

--- a/backends/platform/ds/arm9/source/osystem_ds.h
+++ b/backends/platform/ds/arm9/source/osystem_ds.h
@@ -24,6 +24,8 @@
 #ifndef _OSYSTEM_DS_H_
 #define _OSYSTEM_DS_H_
 
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
 #include "backends/base-backend.h"
 #include "common/events.h"
 #include "nds.h"

--- a/backends/platform/ds/arm9/source/wordcompletion.cpp
+++ b/backends/platform/ds/arm9/source/wordcompletion.cpp
@@ -20,8 +20,8 @@
  *
  */
 
-#include "wordcompletion.h"
 #include "osystem_ds.h"
+#include "wordcompletion.h"
 #include "engines/agi/agi.h"	// Caution for #define for NUM_CHANNELS, causes problems in mixer_intern.h
 
 #ifdef ENABLE_AGI

--- a/backends/platform/ds/arm9/source/zipreader.cpp
+++ b/backends/platform/ds/arm9/source/zipreader.cpp
@@ -23,6 +23,7 @@
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
 #include "common/scummsys.h"
+#include "common/str.h"
 #include "zipreader.h"
 
 ZipFile::ZipFile() {
@@ -193,7 +194,7 @@ bool ZipFile::findFile(const char *search) {
 		}
 
 
-		if (!stricmp(name, searchName)) {
+		if (!scumm_stricmp(name, searchName)) {
 //			consolePrintf("'%s'=='%s'\n", name, searchName);
 			return true;		// Got it!
 		} else {

--- a/backends/platform/ds/ds.mk
+++ b/backends/platform/ds/ds.mk
@@ -146,11 +146,8 @@ dsclean:
 
 # TODO: Add a 'dsdist' target ?
 
-%.bin: %.elf
-	$(OBJCOPY) -S -O binary $< $@
-
-%.nds: %.bin $(ndsdir)/arm7/arm7.bin
-	ndstool -c $@ -9 $< -7 $(ndsdir)/arm7/arm7.bin -b $(srcdir)/$(ndsdir)/$(LOGO) "$(@F);ScummVM $(VERSION);DS Port"
+%.nds: %.elf $(ndsdir)/arm7/arm7.elf
+	ndstool -c $@ -9 $< -7 $(ndsdir)/arm7/arm7.elf -b $(srcdir)/$(ndsdir)/$(LOGO) "$(@F);ScummVM $(VERSION);DS Port"
 
 %.ds.gba: %.nds
 	dsbuild $< -o $@ -l $(srcdir)/$(ndsdir)/arm9/ndsloader.bin
@@ -172,9 +169,6 @@ dsclean:
 # HACK/FIXME: C compiler, for cartreset.c -- we should switch this to use CXX
 # as soon as possible.
 CC := $(DEVKITPRO)/devkitARM/bin/arm-none-eabi-gcc
-
-# HACK/TODO: Pointer to objcopy. This should really be set by configure
-OBJCOPY := $(DEVKITPRO)/devkitARM/bin/arm-none-eabi-objcopy
 
 #
 # Set various flags
@@ -218,10 +212,6 @@ $(ndsdir)/arm7/arm7.elf: \
 	$(ndsdir)/arm7/source/libcartreset/cartreset.o \
 	$(ndsdir)/arm7/source/main.o
 	$(CXX) $(ARM7_LDFLAGS) -specs=ds_arm7.specs $+ -L$(DEVKITPRO)/libnds/lib -lnds7  -o $@
-
-# Rule for creating ARM7 .bin files from .elf files
-$(ndsdir)/arm7/arm7.bin: $(ndsdir)/arm7/arm7.elf
-	$(OBJCOPY) -O binary  $< $@
 
 
 

--- a/backends/platform/ds/ds.mk
+++ b/backends/platform/ds/ds.mk
@@ -75,7 +75,7 @@ endif
 
 
 # Compiler options for files which should be optimised for speed
-OPT_SPEED := -O3 -mno-thumb
+OPT_SPEED := -O3 -marm
 
 # Compiler options for files which should be optimised for space
 OPT_SIZE := -Os -mthumb
@@ -134,7 +134,8 @@ engines/teenagent/actor.o: CXXFLAGS:=$(CXXFLAGS) $(OPT_SPEED)
 #
 #############################################################################
 
-all: scummvm.nds scummvm.ds.gba
+# FIXME: Newer versions of devkitARM don't include dsbuild, which is needed to create scummvm.ds.gba
+all: scummvm.nds # scummvm.ds.gba
 
 clean: dsclean
 
@@ -170,10 +171,10 @@ dsclean:
 
 # HACK/FIXME: C compiler, for cartreset.c -- we should switch this to use CXX
 # as soon as possible.
-CC := $(DEVKITPRO)/devkitARM/bin/arm-eabi-gcc
+CC := $(DEVKITPRO)/devkitARM/bin/arm-none-eabi-gcc
 
 # HACK/TODO: Pointer to objcopy. This should really be set by configure
-OBJCOPY := $(DEVKITPRO)/devkitARM/bin/arm-eabi-objcopy
+OBJCOPY := $(DEVKITPRO)/devkitARM/bin/arm-none-eabi-objcopy
 
 #
 # Set various flags
@@ -194,7 +195,7 @@ ARM7_CFLAGS	:=	-g -Wall -O2\
 
 ARM7_CXXFLAGS	:= $(ARM7_CFLAGS) -fno-exceptions -fno-rtti
 
-ARM7_LDFLAGS	:= -g $(ARM7_ARCH) -mno-fpu
+ARM7_LDFLAGS	:= -g $(ARM7_ARCH) -mfloat-abi=soft
 
 # HACK/FIXME: Define a custom build rule for cartreset.c.
 # We do this because it is a .c file, not a .cpp file and so is outside our

--- a/backends/plugins/ds/ds-provider.cpp
+++ b/backends/plugins/ds/ds-provider.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
 #include "common/scummsys.h"
 
 #if defined(DYNAMIC_MODULES) && defined(__DS__)

--- a/configure
+++ b/configure
@@ -1474,7 +1474,7 @@ dreamcast)
 ds)
 	_host_os=ds
 	_host_cpu=arm
-	_host_alias=arm-eabi
+	_host_alias=arm-none-eabi
 	;;
 gamecube)
 	_host_os=gamecube
@@ -2566,7 +2566,8 @@ case $_host_os in
 		append_var DEFINES "-DARM"
 		append_var DEFINES "-DNONSTANDARD_PORT"
 		append_var CXXFLAGS "-isystem $DEVKITPRO/libnds/include"
-		append_var CXXFLAGS "-isystem $DEVKITPRO/devkitARM/arm-eabi/include"
+		append_var CXXFLAGS "-I$DEVKITPRO/portlibs/nds/include"
+		append_var CXXFLAGS "-I$DEVKITPRO/portlibs/armv5te/include"
 		append_var CXXFLAGS "-mcpu=arm9tdmi"
 		append_var CXXFLAGS "-mtune=arm9tdmi"
 		append_var CXXFLAGS "-fomit-frame-pointer"
@@ -2577,7 +2578,7 @@ case $_host_os in
 		append_var CXXFLAGS "-fuse-cxa-atexit"
 		append_var LDFLAGS "-specs=ds_arm9.specs"
 		append_var LDFLAGS "-mthumb-interwork"
-		append_var LDFLAGS "-mno-fpu"
+		append_var LDFLAGS "-mfloat-abi=soft"
 		append_var LDFLAGS "-Wl,-Map,map.txt"
 		if test "$_dynamic_modules" = no ; then
 			append_var LDFLAGS "-Wl,--gc-sections"
@@ -2587,6 +2588,8 @@ case $_host_os in
 			# append_var LDFLAGS "-Wl,--retain-symbols-file,ds.syms"
 		fi
 		append_var LDFLAGS "-L$DEVKITPRO/libnds/lib"
+		append_var LDFLAGS "-L$DEVKITPRO/portlibs/nds/lib"
+		append_var LDFLAGS "-L$DEVKITPRO/portlibs/armv5te/lib"
 		append_var LIBS "-lnds9"
 		;;
 	freebsd*)
@@ -3726,7 +3729,7 @@ POST_OBJS_FLAGS		:= -Wl,--no-whole-archive
 		append_var DEFINES "-DUNCACHED_PLUGINS"
 		append_var DEFINES "-DELF_NO_MEM_MANAGER"
 _mak_plugins='
-PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/ds/plugin.ld -mthumb-interwork -mno-fpu
+PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/ds/plugin.ld -mthumb-interwork -mfloat-abi=soft
 '
 		;;
 	freebsd*)
@@ -5231,6 +5234,7 @@ cat > config.h << EOF
 $_config_h_data
 
 /* Data types */
+#ifndef SCUMMVM_DONT_DEFINE_TYPES
 typedef unsigned $type_1_byte byte;
 typedef unsigned int uint;
 typedef unsigned $type_1_byte uint8;
@@ -5241,6 +5245,7 @@ typedef signed $type_1_byte int8;
 typedef signed $type_2_byte int16;
 typedef signed $type_4_byte int32;
 typedef signed $type_8_byte int64;
+#endif
 
 typedef $type_ptr  uintptr;
 

--- a/configure
+++ b/configure
@@ -2576,7 +2576,6 @@ case $_host_os in
 		append_var CXXFLAGS "-fdata-sections"
 		append_var CXXFLAGS "-fno-strict-aliasing"
 		append_var CXXFLAGS "-fuse-cxa-atexit"
-		append_var LDFLAGS "-specs=ds_arm9.specs"
 		append_var LDFLAGS "-mthumb-interwork"
 		append_var LDFLAGS "-mfloat-abi=soft"
 		append_var LDFLAGS "-Wl,-Map,map.txt"
@@ -2590,6 +2589,7 @@ case $_host_os in
 		append_var LDFLAGS "-L$DEVKITPRO/libnds/lib"
 		append_var LDFLAGS "-L$DEVKITPRO/portlibs/nds/lib"
 		append_var LDFLAGS "-L$DEVKITPRO/portlibs/armv5te/lib"
+		append_var LIBS "-specs=ds_arm9.specs"
 		append_var LIBS "-lnds9"
 		;;
 	freebsd*)

--- a/configure
+++ b/configure
@@ -3557,7 +3557,7 @@ esac
 # Enable High resolution engines (>320x240) support only for backends which support it
 #
 case $_host in
-	gcw0)
+	ds | gcw0)
 		if test "$_highres" = yes ; then
 			_highres=yes
 		else

--- a/gui/predictivedialog.cpp
+++ b/gui/predictivedialog.cpp
@@ -35,7 +35,7 @@
 #include "common/file.h"
 #include "common/savefile.h"
 
-#ifdef __DS__
+#if defined(__DS__) && defined(ENABLE_AGI)
 #include "backends/platform/ds/arm9/source/wordcompletion.h"
 #endif
 
@@ -945,7 +945,7 @@ void PredictiveDialog::loadDictionary(Common::SeekableReadStream *in, Dict &dict
 	while ((ptr = strchr(ptr, '\n'))) {
 		*ptr = 0;
 		ptr++;
-#ifdef __DS__
+#if defined(__DS__) && defined(ENABLE_AGI)
 		// Pass the line on to the DS word list
 		DS::addAutoCompleteLine(dict.dictLine[i - 1]);
 #endif
@@ -960,7 +960,7 @@ void PredictiveDialog::loadDictionary(Common::SeekableReadStream *in, Dict &dict
 	// FIXME: We use binary search on _predictiveDict.dictLine, yet we make no at_tempt
 	// to ever sort this array (except for the DS port). That seems risky, doesn't it?
 
-#ifdef __DS__
+#if defined(__DS__) && defined(ENABLE_AGI)
 	// Sort the DS word completion list, to allow for a binary chop later (in the ds backend)
 	DS::sortAutoCompleteWordList();
 #endif


### PR DESCRIPTION
This continues off of PR #1057.

The commits from there would allow it to build, but the .nds file produced wasn't working; it would whitescreen on load. My first commit tweaked the arguments to ndstool to get it working. I'm not certain why it was using objcopy in the first place, perhaps ndstool itself changed?

The second commit fixed the touch screen, which wasn't working at all. At first I thought it just wasn't working on my 3ds due to the removal of pressure sensitivity from the original DS; but, my original DS had the same issue, so I suppose that wasn't the problem.

There are still some outstanding issues:
* The binaries are larger than the old ScummVM DS releases. I'm not sure if the core is just bigger now or there's some other reason for it. I can't put as many engines into a single build anymore (4MB limit). Some engines might not fit even by themselves...
* Some menus aren't being drawn properly, particularly when you select "edit game" and try to change tabs.

Tested this with the AGI engine, which seems to work fine.