### PR TITLE
IMAGE: Explicitly initialize CinePak codebooks

### DIFF
--- a/image/codecs/cinepak.cpp
+++ b/image/codecs/cinepak.cpp
@@ -405,8 +405,13 @@ const Graphics::Surface *CinepakDecoder::decodeFrame(Common::SeekableReadStream 
 	_curFrame.height = stream.readUint16BE();
 	_curFrame.stripCount = stream.readUint16BE();
 
-	if (!_curFrame.strips)
+	if (!_curFrame.strips) {
 		_curFrame.strips = new CinepakStrip[_curFrame.stripCount];
+		for (uint16 i = 0; i < _curFrame.stripCount; i++) {
+			initializeCodebook(i, 1);
+			initializeCodebook(i, 4);
+		}
+	}
 
 	debug(4, "Cinepak Frame: Width = %d, Height = %d, Strip Count = %d", _curFrame.width, _curFrame.height, _curFrame.stripCount);
 
@@ -498,6 +503,19 @@ const Graphics::Surface *CinepakDecoder::decodeFrame(Common::SeekableReadStream 
 	}
 
 	return _curFrame.surface;
+}
+
+void CinepakDecoder::initializeCodebook(uint16 strip, byte codebookType) {
+	CinepakCodebook *codebook = (codebookType == 1) ? _curFrame.strips[strip].v1_codebook : _curFrame.strips[strip].v4_codebook;
+
+	for (uint16 i = 0; i < 256; i++) {
+		memset(codebook[i].y, 0, 4);
+		codebook[i].u = 0;
+		codebook[i].v = 0;
+
+		if (_ditherType == kDitherTypeQT)
+			ditherCodebookQT(strip, codebookType, i);
+	}
 }
 
 void CinepakDecoder::loadCodebook(Common::SeekableReadStream &stream, uint16 strip, byte codebookType, byte chunkID, uint32 chunkSize) {

--- a/image/codecs/cinepak.h
+++ b/image/codecs/cinepak.h
@@ -94,6 +94,7 @@ private:
 	byte *_colorMap;
 	DitherType _ditherType;
 
+	void initializeCodebook(uint16 strip, byte codebookType);
 	void loadCodebook(Common::SeekableReadStream &stream, uint16 strip, byte codebookType, byte chunkID, uint32 chunkSize);
 	void decodeVectors(Common::SeekableReadStream &stream, uint16 strip, byte chunkID, uint32 chunkSize);
 


### PR DESCRIPTION
I noticed that Starship Titanic produces lots of "uninitialized value" warnings when turning right at the very beginning. This appears to be because the very first frame of the CinePak movie uses codebooks that haven't been explicitly loaded.

This pull request works on the assumption that all codebook data should be initialized with 0 before the decoding starts.