### PR TITLE
SDL: Can load game controller DB file + joystick button for virtual keyboard

### DIFF
--- a/README
+++ b/README
@@ -2630,6 +2630,10 @@ The following keywords are recognized:
     cdrom              number   Number of CD-ROM unit to use for audio. If
                                 negative, don't even try to access the CD-ROM.
     joystick_num       number   Number of joystick device to use for input
+    controller_map_db  string   A custom controller mapping file to load to 
+                                complete default database (SDL backend only).
+                                Otherwise, file gamecontrollerdb.txt will be
+                                loaded from extrapath.
     music_driver       string   The music engine to use.
     opl_driver         string   The AdLib (OPL) emulator to use.
     output_rate        number   The output sample rate to use, in Hz. Sensible

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -73,8 +73,8 @@ static uint32 convUTF8ToUTF32(const char *src) {
 
 void SdlEventSource::loadGameControllerMappingFile() {
 	bool loaded = false;
-	if (ConfMan.hasKey("gcdbfile")) {
-		Common::FSNode file = Common::FSNode(ConfMan.get("gcdbfile"));
+	if (ConfMan.hasKey("controller_map_db")) {
+		Common::FSNode file = Common::FSNode(ConfMan.get("controller_map_db"));
 		if (file.exists()) {
 			if (SDL_GameControllerAddMappingsFromFile(file.getPath().c_str()) < 0)
 				error("File %s not valid: %s", file.getPath().c_str(), SDL_GetError());	
@@ -82,7 +82,8 @@ void SdlEventSource::loadGameControllerMappingFile() {
 				loaded = true;
 				debug("Game controller DB file loaded: %s", file.getPath().c_str());
 			}
-		}
+		} else
+			warning("Game controller DB file not found: %s", file.getPath().c_str());
 	}
 	if (!loaded && ConfMan.hasKey("extrapath")) {
 		Common::FSNode dir = Common::FSNode(ConfMan.get("extrapath"));
@@ -117,8 +118,7 @@ SdlEventSource::SdlEventSource()
 		if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) == -1) {
 			error("Could not initialize SDL: %s", SDL_GetError());
 		}
-		else
-			loadGameControllerMappingFile();
+		loadGameControllerMappingFile();
 #endif
 
 		openJoystick(joystick_num);

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -94,6 +94,11 @@ protected:
 	SdlGraphicsManager *_graphicsManager;
 
 	/**
+	 * Search for a game controller db file and load it.
+	 */
+	void loadGameControllerMappingFile();
+
+	/**
 	 * Open the SDL joystick with the specified index
 	 *
 	 * After this function completes successfully, SDL sends events for the device.


### PR DESCRIPTION
1) Allow to load a custom game controller mapping file 
- Either define a "gcdbfile" property in your configuration file (pointing to desired file)
- Or copy a file named "gamecontrollerdb.txt" in your extra path
This file completes the standard SDL one to support more game controllers.
Can be found here, for instance: https://github.com/gabomdq/SDL_GameControllerDB

2) Add a specific joystick button to open virtual keyboard (button 7), only for joysticks with no game controller support or SDL1