### PR TITLE
LILLIPUT: Fix narrowing conversion compiler errors on psp2 build

### DIFF
--- a/engines/lilliput/lilliput.cpp
+++ b/engines/lilliput/lilliput.cpp
@@ -1510,11 +1510,11 @@ void LilliputEngine::sub1693A_chooseDirections(int index) {
 byte LilliputEngine::sub16A76(int indexb, int indexs) {
 	debugC(2, kDebugEngine, "sub16A76(%d, %d)", indexb, indexs);
 
-	static const char _array16A6C[4] = {1, 0, 0, -1};
-	static const char _array16A70[4] = {0, -1, 1, 0};
+	static const int8 _array16A6C[4] = {1, 0, 0, -1};
+	static const int8 _array16A70[4] = {0, -1, 1, 0};
 
-	char var1h = _word16937Pos.x + _array16A6C[indexb];
-	char var1l = _word16937Pos.y + _array16A70[indexb];
+	int8 var1h = _word16937Pos.x + _array16A6C[indexb];
+	int8 var1l = _word16937Pos.y + _array16A70[indexb];
 
 	int16 var2 = findHotspot(Common::Point(var1h, var1l));
 	if (var2 == -1)

--- a/engines/lilliput/script.cpp
+++ b/engines/lilliput/script.cpp
@@ -2671,8 +2671,8 @@ void LilliputScript::OC_scrollAwayFromCharacter() {
 	if (_vm->_currentScriptCharacter != _viewportCharacterTarget)
 		return;
 
-	static const char speedX[] = {-1, -3, -3, -6};
-	static const char speedY[] = {-3, -6, -1, -3};
+	static const int8 speedX[] = {-1, -3, -3, -6};
+	static const int8 speedY[] = {-3, -6, -1, -3};
 
 	int cx = speedX[_vm->_characterDirectionArray[_vm->_currentScriptCharacter]];
 	int cy = speedY[_vm->_characterDirectionArray[_vm->_currentScriptCharacter]];
@@ -2797,8 +2797,8 @@ void LilliputScript::OC_scrollViewPort() {
 
 	int direction = _currScript->readUint16LE();
 
-	static const char scrollValX[] = { 6, 0, 0, -6 };
-	static const char scrollValY[] = { 0, -6, 6, 0 };
+	static const int8 scrollValX[] = { 6, 0, 0, -6 };
+	static const int8 scrollValY[] = { 0, -6, 6, 0 };
 
 	int x = _viewportPos.x + scrollValX[direction];
 	int y = _viewportPos.y + scrollValY[direction];


### PR DESCRIPTION
conversion from int to char causes psp2 build to fail, see log here:
http://buildbot.scummvm.org/builders/master-psp2/builds/2356/steps/compile/logs/stdio

This is my attempt at fixing that problem
