### PR TITLE
GUI: Unify clip and non-clip draw calls

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -211,8 +211,6 @@ ThemeEngine::ThemeEngine(Common::String id, GraphicsMode mode) :
 	_cursorWidth = _cursorHeight = 0;
 	_cursorPalSize = 0;
 
-	_needPaletteUpdates = false;
-
 	// We prefer files in archive bundles over the common search paths.
 	_themeFiles.add("default", &SearchMan, 0, false);
 }
@@ -853,38 +851,9 @@ void ThemeEngine::drawDD(DrawData type, const Common::Rect &r, uint32 dynamic, b
 		extendedRect.bottom += drawData->_shadowOffset - drawData->_backgroundOffset;
 	}
 
-	if (forceRestore || drawData->_layer == kDrawLayerBackground)
-		restoreBackground(extendedRect);
-
-	if (drawData->_layer == _layerToDraw) {
-		Common::List<Graphics::DrawStep>::const_iterator step;
-		for (step = drawData->_steps.begin(); step != drawData->_steps.end(); ++step)
-			_vectorRenderer->drawStep(area, *step, dynamic);
-
-		addDirtyRect(extendedRect);
+	if (!_clip.isEmpty()) {
+		extendedRect.clip(_clip);
 	}
-}
-
-void ThemeEngine::drawDDClip(DrawData type, const Common::Rect &r, const Common::Rect &clippingRect, uint32 dynamic,
-                             bool forceRestore) {
-	WidgetDrawData *drawData = _widgets[type];
-
-	if (!drawData)
-		return;
-
-	if (kDrawDataDefaults[type].parent != kDDNone && kDrawDataDefaults[type].parent != type)
-		drawDDClip(kDrawDataDefaults[type].parent, r, clippingRect);
-
-	Common::Rect area = r;
-	area.clip(_screen.w, _screen.h);
-
-	Common::Rect extendedRect = area;
-	extendedRect.grow(kDirtyRectangleThreshold + drawData->_backgroundOffset);
-	if (drawData->_shadowOffset > drawData->_backgroundOffset) {
-		extendedRect.right += drawData->_shadowOffset - drawData->_backgroundOffset;
-		extendedRect.bottom += drawData->_shadowOffset - drawData->_backgroundOffset;
-	}
-	extendedRect.clip(clippingRect);
 
 	if (forceRestore || drawData->_layer == kDrawLayerBackground)
 		restoreBackground(extendedRect);
@@ -892,7 +861,7 @@ void ThemeEngine::drawDDClip(DrawData type, const Common::Rect &r, const Common:
 	if (drawData->_layer == _layerToDraw) {
 		Common::List<Graphics::DrawStep>::const_iterator step;
 		for (step = drawData->_steps.begin(); step != drawData->_steps.end(); ++step) {
-			_vectorRenderer->drawStepClip(area, clippingRect, *step, dynamic);
+			_vectorRenderer->drawStepClip(area, _clip, *step, dynamic);
 		}
 
 		addDirtyRect(extendedRect);
@@ -913,31 +882,9 @@ void ThemeEngine::drawDDText(TextData type, TextColor color, const Common::Rect 
 	if (dirty.isEmpty()) dirty = area;
 	else dirty.clip(area);
 
-	if (restoreBg)
-		restoreBackground(dirty);
-
-	_vectorRenderer->setFgColor(_textColors[color]->r, _textColors[color]->g, _textColors[color]->b);
-	_vectorRenderer->drawString(_texts[type]->_fontPtr, text, area, alignH, alignV, deltax, ellipsis, drawableTextArea);
-
-	addDirtyRect(dirty);
-}
-
-void ThemeEngine::drawDDTextClip(TextData type, TextColor color, const Common::Rect &r,
-                                 const Common::Rect &clippingArea, const Common::String &text, bool restoreBg,
-                                 bool ellipsis, Graphics::TextAlign alignH, TextAlignVertical alignV, int deltax,
-                                 const Common::Rect &drawableTextArea) {
-
-	if (type == kTextDataNone || !_texts[type] || _layerToDraw == kDrawLayerBackground)
-		return;
-
-	Common::Rect area = r;
-	area.clip(_screen.w, _screen.h);
-
-	Common::Rect dirty = drawableTextArea;
-	if (dirty.isEmpty()) dirty = area;
-	else dirty.clip(area);
-
-	dirty.clip(clippingArea);
+	if (!_clip.isEmpty()) {
+		dirty.clip(_clip);
+	}
 
 	// HACK: One small pixel should be invisible enough
 	if (dirty.isEmpty()) dirty = Common::Rect(0, 0, 1, 1);
@@ -959,27 +906,12 @@ void ThemeEngine::drawBitmap(const Graphics::Surface *bitmap, const Common::Rect
 	area.clip(_screen.w, _screen.h);
 
 	if (alpha)
-		_vectorRenderer->blitKeyBitmap(bitmap, r);
+		_vectorRenderer->blitKeyBitmapClip(bitmap, area, _clip);
 	else
-		_vectorRenderer->blitSubSurface(bitmap, r);
-
-	addDirtyRect(r);
-}
-
-void ThemeEngine::drawBitmapClip(const Graphics::Surface *bitmap, const Common::Rect &r, const Common::Rect &clip, bool alpha) {
-	if (_layerToDraw == kDrawLayerBackground)
-		return;
-
-	Common::Rect area = r;
-	area.clip(_screen.w, _screen.h);
-
-	if (alpha)
-		_vectorRenderer->blitKeyBitmapClip(bitmap, area, clip);
-	else
-		_vectorRenderer->blitSubSurfaceClip(bitmap, area, clip);
+		_vectorRenderer->blitSubSurfaceClip(bitmap, area, _clip);
 
 	Common::Rect dirtyRect = area;
-	dirtyRect.clip(clip);
+	dirtyRect.clip(_clip);
 	addDirtyRect(dirtyRect);
 }
 
@@ -1002,40 +934,15 @@ void ThemeEngine::drawButton(const Common::Rect &r, const Common::String &str, W
 		dd = kDDButtonPressed;
 
 	drawDD(dd, r, 0, hints & WIDGET_CLEARBG);
-	drawDDText(getTextData(dd), getTextColor(dd), r, str, false, true, _widgets[dd]->_textAlignH, _widgets[dd]->_textAlignV);
+	drawDDText(getTextData(dd), getTextColor(dd), r, str, false, true, _widgets[dd]->_textAlignH,
+	           _widgets[dd]->_textAlignV);
 }
 
-void ThemeEngine::drawButtonClip(const Common::Rect &r, const Common::Rect &clippingRect, const Common::String &str, WidgetStateInfo state, uint16 hints) {
-	if (!ready())
-		return;
-
-	DrawData dd = kDDButtonIdle;
-
-	if (state == kStateEnabled)
-		dd = kDDButtonIdle;
-	else if (state == kStateHighlight)
-		dd = kDDButtonHover;
-	else if (state == kStateDisabled)
-		dd = kDDButtonDisabled;
-	else if (state == kStatePressed)
-		dd = kDDButtonPressed;
-
-	drawDDClip(dd, r, clippingRect, 0, hints & WIDGET_CLEARBG);
-	drawDDTextClip(getTextData(dd), getTextColor(dd), r, clippingRect, str, false, true, _widgets[dd]->_textAlignH, _widgets[dd]->_textAlignV);
-}
-
-void ThemeEngine::drawLineSeparator(const Common::Rect &r, WidgetStateInfo state) {
+void ThemeEngine::drawLineSeparator(const Common::Rect &r) {
 	if (!ready())
 		return;
 
 	drawDD(kDDSeparator, r);
-}
-
-void ThemeEngine::drawLineSeparatorClip(const Common::Rect &r, const Common::Rect &clippingRect, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	drawDDClip(kDDSeparator, r, clippingRect);
 }
 
 void ThemeEngine::drawCheckbox(const Common::Rect &r, const Common::String &str, bool checked, WidgetStateInfo state) {
@@ -1061,33 +968,8 @@ void ThemeEngine::drawCheckbox(const Common::Rect &r, const Common::String &str,
 	r2.left = r2.right + checkBoxSize;
 	r2.right = r.right;
 
-	drawDDText(getTextData(dd), getTextColor(dd), r2, str, true, false, _widgets[kDDCheckboxDefault]->_textAlignH, _widgets[dd]->_textAlignV);
-}
-
-void ThemeEngine::drawCheckboxClip(const Common::Rect &r, const Common::Rect &clip, const Common::String &str, bool checked, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	Common::Rect r2 = r;
-	DrawData dd = kDDCheckboxDefault;
-
-	if (checked)
-		dd = kDDCheckboxSelected;
-
-	if (state == kStateDisabled)
-		dd = kDDCheckboxDisabled;
-
-	const int checkBoxSize = MIN((int)r.height(), getFontHeight());
-
-	r2.bottom = r2.top + checkBoxSize;
-	r2.right = r2.left + checkBoxSize;
-
-	drawDDClip(dd, r2, clip);
-
-	r2.left = r2.right + checkBoxSize;
-	r2.right = r.right;
-
-	drawDDTextClip(getTextData(dd), getTextColor(dd), r2, clip, str, true, false, _widgets[kDDCheckboxDefault]->_textAlignH, _widgets[dd]->_textAlignV);
+	drawDDText(getTextData(dd), getTextColor(dd), r2, str, true, false, _widgets[kDDCheckboxDefault]->_textAlignH,
+	           _widgets[dd]->_textAlignV);
 }
 
 void ThemeEngine::drawRadiobutton(const Common::Rect &r, const Common::String &str, bool checked, WidgetStateInfo state) {
@@ -1111,35 +993,10 @@ void ThemeEngine::drawRadiobutton(const Common::Rect &r, const Common::String &s
 	drawDD(dd, r2);
 
 	r2.left = r2.right + checkBoxSize;
-	r2.right = r.right;
-
-	drawDDText(getTextData(dd), getTextColor(dd), r2, str, true, false, _widgets[kDDRadiobuttonDefault]->_textAlignH, _widgets[dd]->_textAlignV);
-}
-
-void ThemeEngine::drawRadiobuttonClip(const Common::Rect &r, const Common::Rect &clippingRect, const Common::String &str, bool checked, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	Common::Rect r2 = r;
-	DrawData dd = kDDRadiobuttonDefault;
-
-	if (checked)
-		dd = kDDRadiobuttonSelected;
-
-	if (state == kStateDisabled)
-		dd = kDDRadiobuttonDisabled;
-
-	const int checkBoxSize = MIN((int)r.height(), getFontHeight());
-
-	r2.bottom = r2.top + checkBoxSize;
-	r2.right = r2.left + checkBoxSize;
-
-	drawDDClip(dd, r2, clippingRect);
-
-	r2.left = r2.right + checkBoxSize;
 	r2.right = MAX(r2.left, r.right);
 
-	drawDDTextClip(getTextData(dd), getTextColor(dd), r2, clippingRect, str, true, false, _widgets[kDDRadiobuttonDefault]->_textAlignH, _widgets[dd]->_textAlignV);
+	drawDDText(getTextData(dd), getTextColor(dd), r2, str, true, false, _widgets[kDDRadiobuttonDefault]->_textAlignH,
+	           _widgets[dd]->_textAlignV);
 }
 
 void ThemeEngine::drawSlider(const Common::Rect &r, int width, WidgetStateInfo state) {
@@ -1155,34 +1012,14 @@ void ThemeEngine::drawSlider(const Common::Rect &r, int width, WidgetStateInfo s
 
 	Common::Rect r2 = r;
 	r2.setWidth(MIN((int16)width, r.width()));
-//	r2.top++; r2.bottom--; r2.left++; r2.right--;
+	//	r2.top++; r2.bottom--; r2.left++; r2.right--;
 
-	drawWidgetBackground(r, 0, kWidgetBackgroundSlider, kStateEnabled);
+	drawWidgetBackground(r, 0, kWidgetBackgroundSlider);
 
 	drawDD(dd, r2);
 }
 
-void ThemeEngine::drawSliderClip(const Common::Rect &r, const Common::Rect &clip, int width, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	DrawData dd = kDDSliderFull;
-
-	if (state == kStateHighlight)
-		dd = kDDSliderHover;
-	else if (state == kStateDisabled)
-		dd = kDDSliderDisabled;
-
-	Common::Rect r2 = r;
-	r2.setWidth(MIN((int16)width, r.width()));
-	//	r2.top++; r2.bottom--; r2.left++; r2.right--;
-
-	drawWidgetBackgroundClip(r, clip, 0, kWidgetBackgroundSlider, kStateEnabled);
-
-	drawDDClip(dd, r2, clip);
-}
-
-void ThemeEngine::drawScrollbar(const Common::Rect &r, int sliderY, int sliderHeight, ScrollbarState scrollState, WidgetStateInfo state) {
+void ThemeEngine::drawScrollbar(const Common::Rect &r, int sliderY, int sliderHeight, ScrollbarState scrollState) {
 	if (!ready())
 		return;
 
@@ -1192,46 +1029,22 @@ void ThemeEngine::drawScrollbar(const Common::Rect &r, int sliderY, int sliderHe
 	const int buttonExtra = (r.width() * 120) / 100;
 
 	r2.bottom = r2.top + buttonExtra;
-	drawDD(scrollState == kScrollbarStateUp ? kDDScrollbarButtonHover : kDDScrollbarButtonIdle, r2, Graphics::VectorRenderer::kTriangleUp);
+	drawDD(scrollState == kScrollbarStateUp ? kDDScrollbarButtonHover : kDDScrollbarButtonIdle, r2,
+	       Graphics::VectorRenderer::kTriangleUp);
 
 	r2.translate(0, r.height() - r2.height());
-	drawDD(scrollState == kScrollbarStateDown ? kDDScrollbarButtonHover : kDDScrollbarButtonIdle, r2, Graphics::VectorRenderer::kTriangleDown);
+	drawDD(scrollState == kScrollbarStateDown ? kDDScrollbarButtonHover : kDDScrollbarButtonIdle, r2,
+	       Graphics::VectorRenderer::kTriangleDown);
 
 	r2 = r;
 	r2.left += 1;
 	r2.right -= 1;
 	r2.top += sliderY;
 	r2.bottom = r2.top + sliderHeight;
-
-	//r2.top += r.width() / 5;
-	//r2.bottom -= r.width() / 5;
 	drawDD(scrollState == kScrollbarStateSlider ? kDDScrollbarHandleHover : kDDScrollbarHandleIdle, r2);
 }
 
-void ThemeEngine::drawScrollbarClip(const Common::Rect &r, const Common::Rect &clippingRect, int sliderY, int sliderHeight, ScrollbarState scrollState, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	drawDDClip(kDDScrollbarBase, r, clippingRect);
-
-	Common::Rect r2 = r;
-	const int buttonExtra = (r.width() * 120) / 100;
-
-	r2.bottom = r2.top + buttonExtra;
-	drawDDClip(scrollState == kScrollbarStateUp ? kDDScrollbarButtonHover : kDDScrollbarButtonIdle, r2, clippingRect, Graphics::VectorRenderer::kTriangleUp);
-
-	r2.translate(0, r.height() - r2.height());
-	drawDDClip(scrollState == kScrollbarStateDown ? kDDScrollbarButtonHover : kDDScrollbarButtonIdle, r2, clippingRect, Graphics::VectorRenderer::kTriangleDown);
-
-	r2 = r;
-	r2.left += 1;
-	r2.right -= 1;
-	r2.top += sliderY;
-	r2.bottom = r2.top + sliderHeight;
-	drawDDClip(scrollState == kScrollbarStateSlider ? kDDScrollbarHandleHover : kDDScrollbarHandleIdle, r2, clippingRect);
-}
-
-void ThemeEngine::drawDialogBackground(const Common::Rect &r, DialogBackground bgtype, WidgetStateInfo state) {
+void ThemeEngine::drawDialogBackground(const Common::Rect &r, DialogBackground bgtype) {
 	if (!ready())
 		return;
 
@@ -1256,41 +1069,12 @@ void ThemeEngine::drawDialogBackground(const Common::Rect &r, DialogBackground b
 		drawDD(kDDDefaultBackground, r);
 		break;
 	case kDialogBackgroundNone:
-		break;
-	}
-}
-
-void ThemeEngine::drawDialogBackgroundClip(const Common::Rect &r, const Common::Rect &clip, DialogBackground bgtype, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	switch (bgtype) {
-	case kDialogBackgroundMain:
-		drawDDClip(kDDMainDialogBackground, r, clip);
-		break;
-
-	case kDialogBackgroundSpecial:
-		drawDDClip(kDDSpecialColorBackground, r, clip);
-		break;
-
-	case kDialogBackgroundPlain:
-		drawDDClip(kDDPlainColorBackground, r, clip);
-		break;
-
-	case kDialogBackgroundTooltip:
-		drawDDClip(kDDTooltipBackground, r, clip);
-		break;
-
-	case kDialogBackgroundDefault:
-		drawDDClip(kDDDefaultBackground, r, clip);
-		break;
-	case kDialogBackgroundNone:
 		// no op
 		break;
 	}
 }
 
-void ThemeEngine::drawCaret(const Common::Rect &r, bool erase, WidgetStateInfo state) {
+void ThemeEngine::drawCaret(const Common::Rect &r, bool erase) {
 	if (!ready())
 		return;
 
@@ -1300,17 +1084,7 @@ void ThemeEngine::drawCaret(const Common::Rect &r, bool erase, WidgetStateInfo s
 		drawDD(kDDCaret, r);
 }
 
-void ThemeEngine::drawCaretClip(const Common::Rect &r, const Common::Rect &clip, bool erase, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	if (erase) {
-		restoreBackground(r);
-	} else
-		drawDDClip(kDDCaret, r, clip);
-}
-
-void ThemeEngine::drawPopUpWidget(const Common::Rect &r, const Common::String &sel, int deltax, WidgetStateInfo state, Graphics::TextAlign align) {
+void ThemeEngine::drawPopUpWidget(const Common::Rect &r, const Common::String &sel, int deltax, WidgetStateInfo state) {
 	if (!ready())
 		return;
 
@@ -1325,48 +1099,21 @@ void ThemeEngine::drawPopUpWidget(const Common::Rect &r, const Common::String &s
 
 	drawDD(dd, r);
 
-	if (!sel.empty()) {
-		Common::Rect text(r.left + 3, r.top + 1, r.right - 10, r.bottom);
-		drawDDText(getTextData(dd), getTextColor(dd), text, sel, true, false, _widgets[dd]->_textAlignH, _widgets[dd]->_textAlignV, deltax);
-	}
-}
-
-void ThemeEngine::drawPopUpWidgetClip(const Common::Rect &r, const Common::Rect &clip, const Common::String &sel, int deltax, WidgetStateInfo state, Graphics::TextAlign align) {
-	if (!ready())
-		return;
-
-	DrawData dd = kDDPopUpIdle;
-
-	if (state == kStateEnabled)
-		dd = kDDPopUpIdle;
-	else if (state == kStateHighlight)
-		dd = kDDPopUpHover;
-	else if (state == kStateDisabled)
-		dd = kDDPopUpDisabled;
-
-	drawDDClip(dd, r, clip);
-
 	if (!sel.empty() && r.width() >= 13 && r.height() >= 1) {
 		Common::Rect text(r.left + 3, r.top + 1, r.right - 10, r.bottom);
-		drawDDTextClip(getTextData(dd), getTextColor(dd), text, clip, sel, true, false, _widgets[dd]->_textAlignH, _widgets[dd]->_textAlignV, deltax);
+		drawDDText(getTextData(dd), getTextColor(dd), text, sel, true, false, _widgets[dd]->_textAlignH,
+		           _widgets[dd]->_textAlignV, deltax);
 	}
 }
 
-void ThemeEngine::drawSurface(const Common::Rect &r, const Graphics::Surface &surface, WidgetStateInfo state, int alpha, bool themeTrans) {
+void ThemeEngine::drawSurface(const Common::Rect &r, const Graphics::Surface &surface, bool themeTrans) {
 	if (!ready())
 		return;
 
 	drawBitmap(&surface, r, themeTrans);
 }
 
-void ThemeEngine::drawSurfaceClip(const Common::Rect &r, const Common::Rect &clip, const Graphics::Surface &surface, WidgetStateInfo state, int alpha, bool themeTrans) {
-	if (!ready())
-		return;
-
-	drawBitmapClip(&surface, r, clip, themeTrans);
-}
-
-void ThemeEngine::drawWidgetBackground(const Common::Rect &r, uint16 hints, WidgetBackground background, WidgetStateInfo state) {
+void ThemeEngine::drawWidgetBackground(const Common::Rect &r, uint16 hints, WidgetBackground background) {
 	if (!ready())
 		return;
 
@@ -1389,64 +1136,14 @@ void ThemeEngine::drawWidgetBackground(const Common::Rect &r, uint16 hints, Widg
 	}
 }
 
-void ThemeEngine::drawWidgetBackgroundClip(const Common::Rect &r, const Common::Rect &clip, uint16 hints, WidgetBackground background, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	switch (background) {
-	case kWidgetBackgroundBorderSmall:
-		drawDDClip(kDDWidgetBackgroundSmall, r, clip);
-		break;
-
-	case kWidgetBackgroundEditText:
-		drawDDClip(kDDWidgetBackgroundEditText, r, clip);
-		break;
-
-	case kWidgetBackgroundSlider:
-		drawDDClip(kDDWidgetBackgroundSlider, r, clip);
-		break;
-
-	default:
-		drawDDClip(kDDWidgetBackgroundDefault, r, clip);
-		break;
-	}
-}
-
-void ThemeEngine::drawTab(const Common::Rect &r, int tabHeight, int tabWidth, const Common::Array<Common::String> &tabs, int active, uint16 hints, int titleVPad, WidgetStateInfo state) {
-	if (!ready())
-		return;
-
-	drawDD(kDDTabBackground, Common::Rect(r.left, r.top, r.right, r.top + tabHeight));
-
-	for (int i = 0; i < (int)tabs.size(); ++i) {
-		if (i == active)
-			continue;
-
-		if (r.left + i * tabWidth > r.right || r.left + (i + 1) * tabWidth > r.right)
-			continue;
-
-		Common::Rect tabRect(r.left + i * tabWidth, r.top, r.left + (i + 1) * tabWidth, r.top + tabHeight);
-		drawDD(kDDTabInactive, tabRect);
-		drawDDText(getTextData(kDDTabInactive), getTextColor(kDDTabInactive), tabRect, tabs[i], false, false, _widgets[kDDTabInactive]->_textAlignH, _widgets[kDDTabInactive]->_textAlignV);
-	}
-
-	if (active >= 0 &&
-	        (r.left + active * tabWidth < r.right) && (r.left + (active + 1) * tabWidth < r.right)) {
-		Common::Rect tabRect(r.left + active * tabWidth, r.top, r.left + (active + 1) * tabWidth, r.top + tabHeight);
-		const uint16 tabLeft = active * tabWidth;
-		const uint16 tabRight =  MAX(r.right - tabRect.right, 0);
-		drawDD(kDDTabActive, tabRect, (tabLeft << 16) | (tabRight & 0xFFFF));
-		drawDDText(getTextData(kDDTabActive), getTextColor(kDDTabActive), tabRect, tabs[active], false, false, _widgets[kDDTabActive]->_textAlignH, _widgets[kDDTabActive]->_textAlignV);
-	}
-}
-
-void ThemeEngine::drawTabClip(const Common::Rect &r, const Common::Rect &clip, int tabHeight, const Common::Array<int> &tabWidths, const Common::Array<Common::String> &tabs, int active, uint16 hints, int titleVPad, WidgetStateInfo state) {
+void ThemeEngine::drawTab(const Common::Rect &r, int tabHeight, const Common::Array<int> &tabWidths,
+                          const Common::Array<Common::String> &tabs, int active) {
 	if (!ready())
 		return;
 
 	assert(tabs.size() == tabWidths.size());
 
-	drawDDClip(kDDTabBackground, Common::Rect(r.left, r.top, r.right, r.top + tabHeight), clip);
+	drawDD(kDDTabBackground, Common::Rect(r.left, r.top, r.right, r.top + tabHeight));
 
 	int width = 0;
 	int activePos = -1;
@@ -1461,20 +1158,24 @@ void ThemeEngine::drawTabClip(const Common::Rect &r, const Common::Rect &clip, i
 
 
 		Common::Rect tabRect(r.left + width, r.top, r.left + width + tabWidths[i], r.top + tabHeight);
-		drawDDClip(kDDTabInactive, tabRect, clip);
-		drawDDTextClip(getTextData(kDDTabInactive), getTextColor(kDDTabInactive), tabRect, clip, tabs[i], false, false, _widgets[kDDTabInactive]->_textAlignH, _widgets[kDDTabInactive]->_textAlignV);
+		drawDD(kDDTabInactive, tabRect);
+		drawDDText(getTextData(kDDTabInactive), getTextColor(kDDTabInactive), tabRect, tabs[i], false, false,
+		           _widgets[kDDTabInactive]->_textAlignH, _widgets[kDDTabInactive]->_textAlignV);
 	}
 
 	if (activePos >= 0) {
 		Common::Rect tabRect(r.left + activePos, r.top, r.left + activePos + tabWidths[active], r.top + tabHeight);
 		const uint16 tabLeft = activePos;
 		const uint16 tabRight = MAX(r.right - tabRect.right, 0);
-		drawDDClip(kDDTabActive, tabRect, clip, (tabLeft << 16) | (tabRight & 0xFFFF));
-		drawDDTextClip(getTextData(kDDTabActive), getTextColor(kDDTabActive), tabRect, clip, tabs[active], false, false, _widgets[kDDTabActive]->_textAlignH, _widgets[kDDTabActive]->_textAlignV);
+		drawDD(kDDTabActive, tabRect, (tabLeft << 16) | (tabRight & 0xFFFF));
+		drawDDText(getTextData(kDDTabActive), getTextColor(kDDTabActive), tabRect, tabs[active], false, false,
+		           _widgets[kDDTabActive]->_textAlignH, _widgets[kDDTabActive]->_textAlignV);
 	}
 }
 
-void ThemeEngine::drawText(const Common::Rect &r, const Common::String &str, WidgetStateInfo state, Graphics::TextAlign align, TextInversionState inverted, int deltax, bool useEllipsis, FontStyle font, FontColor color, bool restore, const Common::Rect &drawableTextArea) {
+void ThemeEngine::drawText(const Common::Rect &r, const Common::String &str, WidgetStateInfo state,
+                           Graphics::TextAlign align, TextInversionState inverted, int deltax, bool useEllipsis,
+                           FontStyle font, FontColor color, bool restore, const Common::Rect &drawableTextArea) {
 	if (!ready())
 		return;
 
@@ -1547,80 +1248,7 @@ void ThemeEngine::drawText(const Common::Rect &r, const Common::String &str, Wid
 	drawDDText(textId, colorId, r, str, restore, useEllipsis, align, kTextAlignVCenter, deltax, drawableTextArea);
 }
 
-void ThemeEngine::drawTextClip(const Common::Rect &r, const Common::Rect &clippingArea, const Common::String &str, WidgetStateInfo state, Graphics::TextAlign align, TextInversionState inverted, int deltax, bool useEllipsis, FontStyle font, FontColor color, bool restore, const Common::Rect &drawableTextArea) {
-	if (!ready())
-		return;
-
-	TextColor colorId = kTextColorMAX;
-
-	switch (color) {
-	case kFontColorNormal:
-		if (inverted) {
-			colorId = kTextColorNormalInverted;
-		} else {
-			switch (state) {
-			case kStateDisabled:
-				colorId = kTextColorNormalDisabled;
-				break;
-
-			case kStateHighlight:
-				colorId = kTextColorNormalHover;
-				break;
-
-			case kStateEnabled:
-			case kStatePressed:
-				colorId = kTextColorNormal;
-				break;
-			}
-		}
-		break;
-
-	case kFontColorAlternate:
-		if (inverted) {
-			colorId = kTextColorAlternativeInverted;
-		} else {
-			switch (state) {
-			case kStateDisabled:
-				colorId = kTextColorAlternativeDisabled;
-				break;
-
-			case kStateHighlight:
-				colorId = kTextColorAlternativeHover;
-				break;
-
-			case kStateEnabled:
-			case kStatePressed:
-				colorId = kTextColorAlternative;
-				break;
-			}
-		}
-		break;
-
-	default:
-		return;
-	}
-
-	TextData textId = fontStyleToData(font);
-
-	switch (inverted) {
-	case kTextInversion:
-		drawDDClip(kDDTextSelectionBackground, r, clippingArea);
-		restore = false;
-		break;
-
-	case kTextInversionFocus:
-		drawDDClip(kDDTextSelectionFocusBackground, r, clippingArea);
-		restore = false;
-		break;
-
-	default:
-		break;
-	}
-
-	drawDDTextClip(textId, colorId, r, clippingArea, str, restore, useEllipsis, align, kTextAlignVCenter, deltax, drawableTextArea);
-}
-
-void ThemeEngine::drawChar(const Common::Rect &r, byte ch, const Graphics::Font *font, WidgetStateInfo state, FontColor color) {
+void ThemeEngine::drawChar(const Common::Rect &r, byte ch, const Graphics::Font *font, FontColor color) {
 	if (!ready())
 		return;
 
@@ -1629,20 +1257,7 @@ void ThemeEngine::drawChar(const Common::Rect &r, byte ch, const Graphics::Font 
 
 	uint32 rgbColor = _overlayFormat.RGBToColor(_textColors[color]->r, _textColors[color]->g, _textColors[color]->b);
 
-	restoreBackground(charArea);
-	font->drawChar(&_screen, ch, charArea.left, charArea.top, rgbColor);
-	addDirtyRect(charArea);
-}
-
-void ThemeEngine::drawCharClip(const Common::Rect &r, const Common::Rect &clip, byte ch, const Graphics::Font *font, WidgetStateInfo state, FontColor color) {
-	if (!ready())
-		return;
-
-	Common::Rect charArea = r;
-	charArea.clip(_screen.w, _screen.h);
-	if (!clip.isEmpty()) charArea.clip(clip);
-
-	uint32 rgbColor = _overlayFormat.RGBToColor(_textColors[color]->r, _textColors[color]->g, _textColors[color]->b);
+	// TODO: Handle clipping when drawing chars
 
 	restoreBackground(charArea);
 	font->drawChar(&_screen, ch, charArea.left, charArea.top, rgbColor);
@@ -2261,6 +1876,12 @@ void ThemeEngine::drawToBackbuffer() {
 
 void ThemeEngine::drawToScreen() {
 	_vectorRenderer->setSurface(&_screen);
+}
+
+Common::Rect ThemeEngine::swapClipRect(const Common::Rect &newRect) {
+	Common::Rect oldRect = _clip;
+	_clip = newRect;
+	return oldRect;
 }
 
 } // End of namespace GUI.

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -966,18 +966,6 @@ void ThemeEngine::drawBitmap(const Graphics::Surface *bitmap, const Common::Rect
 	addDirtyRect(r);
 }
 
-void ThemeEngine::drawABitmap(Graphics::TransparentSurface *bitmap, const Common::Rect &r, AutoScaleMode autoscale, int alpha) {
-	if (_layerToDraw == kDrawLayerBackground)
-		return;
-
-	Common::Rect area = r;
-	area.clip(_screen.w, _screen.h);
-
-	_vectorRenderer->blitAlphaBitmap(bitmap, area, autoscale, Graphics::DrawStep::kVectorAlignManual, Graphics::DrawStep::kVectorAlignManual, alpha);
-
-	addDirtyRect(area);
-}
-
 void ThemeEngine::drawBitmapClip(const Graphics::Surface *bitmap, const Common::Rect &r, const Common::Rect &clip, bool alpha) {
 	if (_layerToDraw == kDrawLayerBackground)
 		return;
@@ -1369,13 +1357,6 @@ void ThemeEngine::drawSurface(const Common::Rect &r, const Graphics::Surface &su
 		return;
 
 	drawBitmap(&surface, r, themeTrans);
-}
-
-void ThemeEngine::drawASurface(const Common::Rect &r, Graphics::TransparentSurface &surface, AutoScaleMode autoscale, int alpha) {
-	if (!ready())
-		return;
-
-	drawABitmap(&surface, r, autoscale, alpha);
 }
 
 void ThemeEngine::drawSurfaceClip(const Common::Rect &r, const Common::Rect &clip, const Graphics::Surface &surface, WidgetStateInfo state, int alpha, bool themeTrans) {

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -395,7 +395,6 @@ public:
 	void drawSurfaceClip(const Common::Rect &r, const Common::Rect &clippingRect, const Graphics::Surface &surface,
 		WidgetStateInfo state = kStateEnabled, int alpha = 255, bool themeTrans = false);
 
-	void drawASurface(const Common::Rect &r, Graphics::TransparentSurface &surface, AutoScaleMode autoscale, int alpha);
 
 	void drawSlider(const Common::Rect &r, int width,
 	                WidgetStateInfo state = kStateEnabled);
@@ -671,7 +670,6 @@ protected:
 	void drawBitmap(const Graphics::Surface *bitmap, const Common::Rect &r, bool alpha);
 	void drawBitmapClip(const Graphics::Surface *bitmap, const Common::Rect &clippingRect, const Common::Rect &r,
 	                    bool alpha);
-	void drawABitmap(Graphics::TransparentSurface *bitmap, const Common::Rect &r, AutoScaleMode autoscale, int alpha);
 
 	/**
 	 * DEBUG: Draws a white square and writes some text next to it.

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -376,74 +376,56 @@ public:
 
 	//@}
 
+	/**
+	 * Set the clipping rect to be used by the widget drawing methods defined below.
+	 *
+	 * Widgets are not drawn outside of the clipping rect. Widgets that overlap the
+	 * clipping rect are drawn partially.
+	 *
+	 * @param newRect The new clipping rect
+	 * @return The previous clipping rect
+	 */
+	Common::Rect swapClipRect(const Common::Rect &newRect);
 
 	/** @name WIDGET DRAWING METHODS */
 	//@{
 
-	void drawWidgetBackground(const Common::Rect &r, uint16 hints,
-	                          WidgetBackground background = kWidgetBackgroundPlain, WidgetStateInfo state = kStateEnabled);
-	void drawWidgetBackgroundClip(const Common::Rect &r, const Common::Rect &clippingArea, uint16 hints,
-								WidgetBackground background = kWidgetBackgroundPlain, WidgetStateInfo state = kStateEnabled);
+	void drawWidgetBackground(const Common::Rect &r, uint16 hints, WidgetBackground background = kWidgetBackgroundPlain);
 
-	void drawButton(const Common::Rect &r, const Common::String &str,
-	                WidgetStateInfo state = kStateEnabled, uint16 hints = 0);
-	void drawButtonClip(const Common::Rect &r, const Common::Rect &clippingRect, const Common::String &str,
-		WidgetStateInfo state = kStateEnabled, uint16 hints = 0);
+	void drawButton(const Common::Rect &r, const Common::String &str, WidgetStateInfo state = kStateEnabled,
+	                uint16 hints = 0);
 
-	void drawSurface(const Common::Rect &r, const Graphics::Surface &surface,
-	                 WidgetStateInfo state = kStateEnabled, int alpha = 255, bool themeTrans = false);
-	void drawSurfaceClip(const Common::Rect &r, const Common::Rect &clippingRect, const Graphics::Surface &surface,
-		WidgetStateInfo state = kStateEnabled, int alpha = 255, bool themeTrans = false);
+	void drawSurface(const Common::Rect &r, const Graphics::Surface &surface, bool themeTrans = false);
 
+	void drawSlider(const Common::Rect &r, int width, WidgetStateInfo state = kStateEnabled);
 
-	void drawSlider(const Common::Rect &r, int width,
-	                WidgetStateInfo state = kStateEnabled);
-	void drawSliderClip(const Common::Rect &r, const Common::Rect &clippingRect, int width,
-					WidgetStateInfo state = kStateEnabled);
+	void drawCheckbox(const Common::Rect &r, const Common::String &str, bool checked,
+	                  WidgetStateInfo state = kStateEnabled);
 
-	void drawCheckbox(const Common::Rect &r, const Common::String &str,
-	                  bool checked, WidgetStateInfo state = kStateEnabled);
-	void drawCheckboxClip(const Common::Rect &r, const Common::Rect &clippingRect, const Common::String &str,
-					  bool checked, WidgetStateInfo state = kStateEnabled);
+	void drawRadiobutton(const Common::Rect &r, const Common::String &str, bool checked,
+	                     WidgetStateInfo state = kStateEnabled);
 
-	void drawRadiobutton(const Common::Rect &r, const Common::String &str,
-	                     bool checked, WidgetStateInfo state = kStateEnabled);
-	void drawRadiobuttonClip(const Common::Rect &r, const Common::Rect &clippingRect, const Common::String &str,
-						 bool checked, WidgetStateInfo state = kStateEnabled);
+	void drawTab(const Common::Rect &r, int tabHeight, const Common::Array<int> &tabWidths,
+	             const Common::Array<Common::String> &tabs, int active);
 
-	void drawTab(const Common::Rect &r, int tabHeight, int tabWidth,
-	             const Common::Array<Common::String> &tabs, int active, uint16 hints,
-	             int titleVPad, WidgetStateInfo state = kStateEnabled);
-	void drawTabClip(const Common::Rect &r, const Common::Rect &clippingRect, int tabHeight, const Common::Array<int> &tabWidths,
-				 const Common::Array<Common::String> &tabs, int active, uint16 hints,
-				 int titleVPad, WidgetStateInfo state = kStateEnabled);
+	void drawScrollbar(const Common::Rect &r, int sliderY, int sliderHeight, ScrollbarState scrollState);
 
-	void drawScrollbar(const Common::Rect &r, int sliderY, int sliderHeight,
-	                   ScrollbarState, WidgetStateInfo state = kStateEnabled);
-	void drawScrollbarClip(const Common::Rect &r, const Common::Rect &clippingRect, int sliderY, int sliderHeight,
-					   ScrollbarState scrollState, WidgetStateInfo state = kStateEnabled);
+	void drawPopUpWidget(const Common::Rect &r, const Common::String &sel, int deltax,
+	                     WidgetStateInfo state = kStateEnabled);
 
-	void drawPopUpWidget(const Common::Rect &r, const Common::String &sel,
-	                     int deltax, WidgetStateInfo state = kStateEnabled, Graphics::TextAlign align = Graphics::kTextAlignLeft);
-	void drawPopUpWidgetClip(const Common::Rect &r, const Common::Rect &clippingArea, const Common::String &sel,
-							int deltax, WidgetStateInfo state = kStateEnabled, Graphics::TextAlign align = Graphics::kTextAlignLeft);
+	void drawCaret(const Common::Rect &r, bool erase);
 
-	void drawCaret(const Common::Rect &r, bool erase,
-	               WidgetStateInfo state = kStateEnabled);
-	void drawCaretClip(const Common::Rect &r, const Common::Rect &clip, bool erase,
-		WidgetStateInfo state = kStateEnabled);
+	void drawLineSeparator(const Common::Rect &r);
 
-	void drawLineSeparator(const Common::Rect &r, WidgetStateInfo state = kStateEnabled);
-	void drawLineSeparatorClip(const Common::Rect &r, const Common::Rect &clippingArea, WidgetStateInfo state = kStateEnabled);
+	void drawDialogBackground(const Common::Rect &r, DialogBackground type);
 
-	void drawDialogBackground(const Common::Rect &r, DialogBackground type, WidgetStateInfo state = kStateEnabled);
-	void drawDialogBackgroundClip(const Common::Rect &r, const Common::Rect &clip, DialogBackground type, WidgetStateInfo state = kStateEnabled);
+	void drawText(const Common::Rect &r, const Common::String &str, WidgetStateInfo state = kStateEnabled,
+	              Graphics::TextAlign align = Graphics::kTextAlignCenter,
+	              TextInversionState inverted = kTextInversionNone, int deltax = 0, bool useEllipsis = true,
+	              FontStyle font = kFontStyleBold, FontColor color = kFontColorNormal, bool restore = true,
+	              const Common::Rect &drawableTextArea = Common::Rect(0, 0, 0, 0));
 
-	void drawText(const Common::Rect &r, const Common::String &str, WidgetStateInfo state = kStateEnabled, Graphics::TextAlign align = Graphics::kTextAlignCenter, TextInversionState inverted = kTextInversionNone, int deltax = 0, bool useEllipsis = true, FontStyle font = kFontStyleBold, FontColor color = kFontColorNormal, bool restore = true, const Common::Rect &drawableTextArea = Common::Rect(0, 0, 0, 0));
-	void drawTextClip(const Common::Rect &r, const Common::Rect &clippingArea, const Common::String &str, WidgetStateInfo state = kStateEnabled, Graphics::TextAlign align = Graphics::kTextAlignCenter, TextInversionState inverted = kTextInversionNone, int deltax = 0, bool useEllipsis = true, FontStyle font = kFontStyleBold, FontColor color = kFontColorNormal, bool restore = true, const Common::Rect &drawableTextArea = Common::Rect(0, 0, 0, 0));
-
-	void drawChar(const Common::Rect &r, byte ch, const Graphics::Font *font, WidgetStateInfo state = kStateEnabled, FontColor color = kFontColorNormal);
-	void drawCharClip(const Common::Rect &r, const Common::Rect &clippingArea, byte ch, const Graphics::Font *font, WidgetStateInfo state = kStateEnabled, FontColor color = kFontColorNormal);
+	void drawChar(const Common::Rect &r, byte ch, const Graphics::Font *font, FontColor color = kFontColorNormal);
 
 	//@}
 
@@ -605,15 +587,6 @@ public:
 	int getGraphicsMode() const { return _graphicsMode; }
 
 protected:
-	/**
-	 * Initializes the drawing screen surfaces, _screen and _backBuffer.
-	 * If the surfaces already exist, they are cleared and re-initialized.
-	 *
-	 * @param backBuffer Sets whether the _backBuffer surface should be initialized.
-	 * @template PixelType C type which specifies the size of each pixel.
-	 *                     Defaults to uint16 (2 BPP for the surfaces)
-	 */
-	template<typename PixelType> void screenInit(bool backBuffer = true);
 
 	/**
 	 * Loads the given theme into the ThemeEngine.
@@ -656,20 +629,11 @@ protected:
 	 * These functions are called from all the Widget drawing methods.
 	 */
 	void drawDD(DrawData type, const Common::Rect &r, uint32 dynamic = 0, bool forceRestore = false);
-	void drawDDClip(DrawData type, const Common::Rect &r, const Common::Rect &clippingRect, uint32 dynamic = 0,
-	                bool forceRestore = false);
 	void drawDDText(TextData type, TextColor color, const Common::Rect &r, const Common::String &text, bool restoreBg,
 	                bool elipsis, Graphics::TextAlign alignH = Graphics::kTextAlignLeft,
 	                TextAlignVertical alignV = kTextAlignVTop, int deltax = 0,
 	                const Common::Rect &drawableTextArea = Common::Rect(0, 0, 0, 0));
-	void drawDDTextClip(TextData type, TextColor color, const Common::Rect &r, const Common::Rect &clippingRect,
-	                    const Common::String &text, bool restoreBg,
-	                    bool elipsis, Graphics::TextAlign alignH = Graphics::kTextAlignLeft,
-	                    TextAlignVertical alignV = kTextAlignVTop, int deltax = 0,
-	                    const Common::Rect &drawableTextArea = Common::Rect(0, 0, 0, 0));
-	void drawBitmap(const Graphics::Surface *bitmap, const Common::Rect &r, bool alpha);
-	void drawBitmapClip(const Graphics::Surface *bitmap, const Common::Rect &clippingRect, const Common::Rect &r,
-	                    bool alpha);
+	void drawBitmap(const Graphics::Surface *bitmap, const Common::Rect &clippingRect, bool alpha);
 
 	/**
 	 * DEBUG: Draws a white square and writes some text next to it.
@@ -730,7 +694,6 @@ protected:
 	GraphicsMode _graphicsMode;
 
 	/** Font info. */
-	Common::String _fontName;
 	const Graphics::Font *_font;
 
 	/**
@@ -771,10 +734,11 @@ protected:
 		MAX_CURS_COLORS = 255
 	};
 	byte *_cursor;
-	bool _needPaletteUpdates;
 	uint _cursorWidth, _cursorHeight;
 	byte _cursorPal[3 * MAX_CURS_COLORS];
 	byte _cursorPalSize;
+
+	Common::Rect _clip;
 };
 
 } // End of namespace GUI.

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -64,7 +64,8 @@ void Tooltip::drawDialog(DrawLayer layerToDraw) {
 
 	for (Common::StringArray::const_iterator i = _wrappedLines.begin(); i != _wrappedLines.end(); ++i, ++num) {
 		g_gui.theme()->drawText(
-			Common::Rect(_x + 1, _y + 1 + num * h, _x + 1 +_w, _y + 1+ (num + 1) * h), *i,
+			Common::Rect(_x + 1, _y + 1 + num * h, _x + 1 + _w, _y + 1 + (num + 1) * h),
+			*i,
 			ThemeEngine::kStateEnabled,
 			Graphics::kTextAlignLeft,
 			ThemeEngine::kTextInversionNone,

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -242,7 +242,9 @@ void AboutDialog::drawDialog(DrawLayer layerToDraw) {
 				str++;
 
 		if (*str)
-			g_gui.theme()->drawText(Common::Rect(_x + _xOff, y, _x + _w - _xOff, y + g_gui.theme()->getFontHeight()), str, state, align, ThemeEngine::kTextInversionNone, 0, false, ThemeEngine::kFontStyleBold, ThemeEngine::kFontColorNormal, true, _textDrawableArea);
+			g_gui.theme()->drawText(Common::Rect(_x + _xOff, y, _x + _w - _xOff, y + g_gui.theme()->getFontHeight()),
+			                        str, state, align, ThemeEngine::kTextInversionNone, 0, false,
+			                        ThemeEngine::kFontStyleBold, ThemeEngine::kFontColorNormal, true, _textDrawableArea);
 		y += _lineHeight;
 	}
 }

--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -712,7 +712,7 @@ void ConsoleDialog::drawCaret(bool erase) {
 	int y = _y + _topPadding + displayLine * kConsoleLineHeight;
 
 	_caretVisible = !erase;
-	g_gui.theme()->drawCaret(Common::Rect(x, y, x+1, y+kConsoleLineHeight), erase);
+	g_gui.theme()->drawCaret(Common::Rect(x, y, x + 1, y + kConsoleLineHeight), erase);
 }
 
 void ConsoleDialog::scrollToCurrent() {

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -167,7 +167,7 @@ void Dialog::drawDialog(DrawLayer layerToDraw) {
 		return;
 
 	g_gui.theme()->_layerToDraw = layerToDraw;
-	g_gui.theme()->drawDialogBackground(Common::Rect(_x, _y, _x+_w, _y+_h), _backgroundType);
+	g_gui.theme()->drawDialogBackground(Common::Rect(_x, _y, _x + _w, _y + _h), _backgroundType);
 
 	markWidgetsAsDirty();
 	drawWidgets();

--- a/gui/object.cpp
+++ b/gui/object.cpp
@@ -67,4 +67,8 @@ void GuiObject::removeWidget(Widget *del) {
 	}
 }
 
+Common::Rect GuiObject::getClipRect() const {
+	return Common::Rect(getAbsX(), getAbsY(), getAbsX() + getWidth(), getAbsY() + getHeight());
+}
+
 } // End of namespace GUI

--- a/gui/object.h
+++ b/gui/object.h
@@ -95,6 +95,11 @@ public:
 		return (x >= _x && x < (_x + _w) && (y >= _y) && (y < _y + _h));
 	}
 
+	/**
+	 * Returns the clipping rect to be used when drawing the children widgets of this object
+	 */
+	virtual Common::Rect getClipRect() const;
+
 protected:
 	virtual void	releaseFocus() = 0;
 };

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -411,19 +411,17 @@ void ButtonWidget::setUnpressedState() {
 
 PicButtonWidget::PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, const char *tooltip, uint32 cmd, uint8 hotkey)
 	: ButtonWidget(boss, x, y, w, h, "", tooltip, cmd, hotkey),
-	  _alpha(255), _transparency(false), _showButton(true), _isAlpha(false) {
+	  _alpha(255), _transparency(false), _showButton(true) {
 
 	setFlags(WIDGET_ENABLED/* | WIDGET_BORDER*/ | WIDGET_CLEARBG);
 	_type = kButtonWidget;
-	_mode = ThemeEngine::kAutoScaleNone;
 }
 
 PicButtonWidget::PicButtonWidget(GuiObject *boss, const Common::String &name, const char *tooltip, uint32 cmd, uint8 hotkey)
 	: ButtonWidget(boss, name, "", tooltip, cmd, hotkey),
-	  _alpha(255), _transparency(false), _showButton(true), _isAlpha(false) {
+	  _alpha(255), _transparency(false), _showButton(true) {
 	setFlags(WIDGET_ENABLED/* | WIDGET_BORDER*/ | WIDGET_CLEARBG);
 	_type = kButtonWidget;
-	_mode = ThemeEngine::kAutoScaleNone;
 }
 
 PicButtonWidget::~PicButtonWidget() {
@@ -451,23 +449,6 @@ void PicButtonWidget::setGfx(const Graphics::Surface *gfx, int statenum) {
 	_gfx[statenum].copyFrom(*gfx);
 }
 
-void PicButtonWidget::setAGfx(const Graphics::TransparentSurface *gfx, int statenum, ThemeEngine::AutoScaleMode mode) {
-	_agfx[statenum].free();
-
-	if (!gfx || !gfx->getPixels())
-		return;
-
-	if (gfx->format.bytesPerPixel == 1) {
-		warning("PicButtonWidget::setGfx got paletted surface passed");
-		return;
-	}
-
-	_agfx[statenum].copyFrom(*gfx);
-
-	_isAlpha = true;
-	_mode = mode;
-}
-
 void PicButtonWidget::setGfx(int w, int h, int r, int g, int b, int statenum) {
 	if (w == -1)
 		w = _w;
@@ -483,62 +464,34 @@ void PicButtonWidget::setGfx(int w, int h, int r, int g, int b, int statenum) {
 
 void PicButtonWidget::drawWidget() {
 	if (_showButton)
-		g_gui.theme()->drawButtonClip(Common::Rect(_x, _y, _x + _w, _y + _h), getBossClipRect(), "", _state, getFlags());
+		g_gui.theme()->drawButton(Common::Rect(_x, _y, _x + _w, _y + _h), "", _state, getFlags());
 
-	if (!_isAlpha) {
-		Graphics::Surface *gfx;
+	Graphics::Surface *gfx;
 
-		if (_state == ThemeEngine::kStateHighlight)
-			gfx = &_gfx[kPicButtonHighlight];
-		else if (_state == ThemeEngine::kStateDisabled)
-			gfx = &_gfx[kPicButtonStateDisabled];
-		else if (_state == ThemeEngine::kStatePressed)
-			gfx = &_gfx[kPicButtonStatePressed];
-		else
-			gfx = &_gfx[kPicButtonStateEnabled];
+	if (_state == ThemeEngine::kStateHighlight)
+		gfx = &_gfx[kPicButtonHighlight];
+	else if (_state == ThemeEngine::kStateDisabled)
+		gfx = &_gfx[kPicButtonStateDisabled];
+	else if (_state == ThemeEngine::kStatePressed)
+		gfx = &_gfx[kPicButtonStatePressed];
+	else
+		gfx = &_gfx[kPicButtonStateEnabled];
 
-		if (!gfx->getPixels())
-			gfx = &_gfx[kPicButtonStateEnabled];
+	if (!gfx->getPixels())
+		gfx = &_gfx[kPicButtonStateEnabled];
 
-		if (gfx->getPixels()) {
+	if (gfx->getPixels()) {
 		// Check whether the set up surface needs to be converted to the GUI
 		// color format.
-			const Graphics::PixelFormat &requiredFormat = g_gui.theme()->getPixelFormat();
-			if (gfx->format != requiredFormat) {
-				gfx->convertToInPlace(requiredFormat);
-			}
-
-			const int x = _x + (_w - gfx->w) / 2;
-			const int y = _y + (_h - gfx->h) / 2;
-
-			g_gui.theme()->drawSurfaceClip(Common::Rect(x, y, x + gfx->w,  y + gfx->h), getBossClipRect(), *gfx, _state, _alpha, _transparency);
+		const Graphics::PixelFormat &requiredFormat = g_gui.theme()->getPixelFormat();
+		if (gfx->format != requiredFormat) {
+			gfx->convertToInPlace(requiredFormat);
 		}
-	} else {
-		Graphics::TransparentSurface *gfx;
 
-		if (_state == ThemeEngine::kStateHighlight)
-			gfx = &_agfx[kPicButtonHighlight];
-		else if (_state == ThemeEngine::kStateDisabled)
-			gfx = &_agfx[kPicButtonStateDisabled];
-		else if (_state == ThemeEngine::kStatePressed)
-			gfx = &_agfx[kPicButtonStatePressed];
-		else
-			gfx = &_agfx[kPicButtonStateEnabled];
+		const int x = _x + (_w - gfx->w) / 2;
+		const int y = _y + (_h - gfx->h) / 2;
 
-		if (!gfx->getPixels())
-			gfx = &_agfx[kPicButtonStateEnabled];
-
-		if (gfx->getPixels()) {
-			if (_mode == GUI::ThemeEngine::kAutoScaleNone) {
-				const int x = _x + (_w - gfx->w) / 2;
-				const int y = _y + (_h - gfx->h) / 2;
-
-				g_gui.theme()->drawASurface(Common::Rect(x, y, x + gfx->w,  y + gfx->h), *gfx, _mode, _alpha);
-
-			} else {
-				g_gui.theme()->drawASurface(Common::Rect(_x, _y, _x + _w,  _y + _h), *gfx, _mode, _alpha);
-			}
-		}
+		g_gui.theme()->drawSurfaceClip(Common::Rect(x, y, x + gfx->w,  y + gfx->h), getBossClipRect(), *gfx, _state, _alpha, _transparency);
 	}
 }
 
@@ -764,26 +717,6 @@ void GraphicsWidget::setGfx(const Graphics::Surface *gfx) {
 	_gfx.copyFrom(*gfx);
 }
 
-void GraphicsWidget::setAGfx(const Graphics::TransparentSurface *gfx, ThemeEngine::AutoScaleMode mode) {
-	_agfx.free();
-
-	if (!gfx || !gfx->getPixels())
-		return;
-
-	if (gfx->format.bytesPerPixel == 1) {
-		warning("GraphicsWidget::setGfx got paletted surface passed");
-		return;
-	}
-
-	if ((gfx->w > _w || gfx->h > _h) && mode == ThemeEngine::kAutoScaleNone) {
-		warning("GraphicsWidget has size %dx%d, but a surface with %dx%d is to be set", _w, _h, gfx->w, gfx->h);
-		return;
-	}
-
-	_agfx.copyFrom(*gfx);
-	_mode = mode;
-}
-
 void GraphicsWidget::setGfx(int w, int h, int r, int g, int b) {
 	if (w == -1)
 		w = _w;
@@ -810,23 +743,6 @@ void GraphicsWidget::drawWidget() {
 		const int y = _y + (_h - _gfx.h) / 2;
 
 		g_gui.theme()->drawSurfaceClip(Common::Rect(x, y, x + _gfx.w,  y + _gfx.h), getBossClipRect(), _gfx, _state, _alpha, _transparency);
-	} else if (_agfx.getPixels()) {
-		// Check whether the set up surface needs to be converted to the GUI
-		// color format.
-		const Graphics::PixelFormat &requiredFormat = g_gui.theme()->getPixelFormat();
-		if (_agfx.format != requiredFormat) {
-			_agfx.convertToInPlace(requiredFormat);
-		}
-
-		if (_mode == GUI::ThemeEngine::kAutoScaleNone) {
-			const int x = _x + (_w - _agfx.w) / 2;
-			const int y = _y + (_h - _agfx.h) / 2;
-
-			g_gui.theme()->drawASurface(Common::Rect(x, y, x + _agfx.w,  y + _agfx.h), _agfx, _mode, _alpha);
-
-		} else {
-			g_gui.theme()->drawASurface(Common::Rect(_x, _y, _x + _w,  _y + _h), _agfx, _mode, _alpha);
-		}
 	}
 }
 

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -240,7 +240,6 @@ public:
 	~PicButtonWidget();
 
 	void setGfx(const Graphics::Surface *gfx, int statenum = kPicButtonStateEnabled);
-	void setAGfx(const Graphics::TransparentSurface *gfx, int statenum = kPicButtonStateEnabled, ThemeEngine::AutoScaleMode mode = ThemeEngine::kAutoScaleNone);
 	void setGfx(int w, int h, int r, int g, int b, int statenum = kPicButtonStateEnabled);
 
 	void useAlpha(int alpha) { _alpha = alpha; }
@@ -251,12 +250,9 @@ protected:
 	void drawWidget();
 
 	Graphics::Surface _gfx[kPicButtonStateMax + 1];
-	Graphics::TransparentSurface _agfx[kPicButtonStateMax + 1];
 	int _alpha;
 	bool _transparency;
 	bool _showButton;
-	bool _isAlpha;
-	ThemeEngine::AutoScaleMode _mode;
 };
 
 /* CheckboxWidget */
@@ -375,7 +371,6 @@ public:
 
 	void setGfx(const Graphics::Surface *gfx);
 	void setGfx(int w, int h, int r, int g, int b);
-	void setAGfx(const Graphics::TransparentSurface *gfx, ThemeEngine::AutoScaleMode mode = ThemeEngine::kAutoScaleNone);
 
 	void useAlpha(int alpha) { _alpha = alpha; }
 	void useThemeTransparency(bool enable) { _transparency = enable; }
@@ -384,10 +379,8 @@ protected:
 	void drawWidget();
 
 	Graphics::Surface _gfx;
-	Graphics::TransparentSurface _agfx;
 	int _alpha;
 	bool _transparency;
-	ThemeEngine::AutoScaleMode _mode;
 };
 
 /* ContainerWidget */

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -123,7 +123,6 @@ public:
 
 	virtual int16	getAbsX() const	{ return _x + _boss->getChildX(); }
 	virtual int16	getAbsY() const	{ return _y + _boss->getChildY(); }
-	virtual Common::Rect getBossClipRect() const;
 
 	virtual void setPos(int x, int y) { _x = x; _y = y; }
 	virtual void setSize(int w, int h) { _w = w; _h = h; }

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -289,7 +289,7 @@ void EditableWidget::drawCaret(bool erase) {
 	x += getAbsX();
 	y += getAbsY();
 
-	g_gui.theme()->drawCaretClip(Common::Rect(x, y, x + 1, y + editRect.height()), getBossClipRect(), erase);
+	g_gui.theme()->drawCaret(Common::Rect(x, y, x + 1, y + editRect.height()), erase);
 
 	if (erase) {
 		GUI::EditableWidget::String character;
@@ -318,7 +318,9 @@ void EditableWidget::drawCaret(bool erase) {
 		// possible glitches due to different methods used.
 		width = MIN(editRect.width() - caretOffset, width);
 		if (width > 0) {
-			g_gui.theme()->drawTextClip(Common::Rect(x, y, x + width, y + editRect.height()), getBossClipRect(), character, _state, Graphics::kTextAlignLeft, _inversion, 0, false, _font, ThemeEngine::kFontColorNormal, true, _textDrawableArea);
+			g_gui.theme()->drawText(Common::Rect(x, y, x + width, y + editRect.height()), character,
+			                        _state, Graphics::kTextAlignLeft, _inversion, 0, false, _font,
+			                        ThemeEngine::kFontColorNormal, true, _textDrawableArea);
 		}
 	}
 

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -97,7 +97,8 @@ void EditTextWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 }
 
 void EditTextWidget::drawWidget() {
-	g_gui.theme()->drawWidgetBackgroundClip(Common::Rect(_x, _y, _x+_w, _y+_h), getBossClipRect(), 0, ThemeEngine::kWidgetBackgroundEditText);
+	g_gui.theme()->drawWidgetBackground(Common::Rect(_x, _y, _x + _w, _y + _h), 0,
+	                                    ThemeEngine::kWidgetBackgroundEditText);
 
 	// Draw the text
 	adjustOffset();
@@ -105,7 +106,10 @@ void EditTextWidget::drawWidget() {
 	const Common::Rect &r = Common::Rect(_x + 2 + _leftPadding, _y + 2, _x + _leftPadding + getEditRect().width() + 8, _y + _h);
 	setTextDrawableArea(r);
 
-	g_gui.theme()->drawTextClip(Common::Rect(_x + 2 + _leftPadding, _y + 2, _x + _leftPadding + getEditRect().width() + 2, _y + _h), getBossClipRect(), _editString, _state, Graphics::kTextAlignLeft, ThemeEngine::kTextInversionNone, -_editScrollOffset, false, _font, ThemeEngine::kFontColorNormal, true, _textDrawableArea);
+	g_gui.theme()->drawText(
+			Common::Rect(_x + 2 + _leftPadding, _y + 2, _x + _leftPadding + getEditRect().width() + 2, _y + _h),
+			_editString, _state, Graphics::kTextAlignLeft, ThemeEngine::kTextInversionNone,
+			-_editScrollOffset, false, _font, ThemeEngine::kFontColorNormal, true, _textDrawableArea);
 }
 
 Common::Rect EditTextWidget::getEditRect() const {

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -495,7 +495,8 @@ void ListWidget::drawWidget() {
 	Common::String buffer;
 
 	// Draw a thin frame around the list.
-	g_gui.theme()->drawWidgetBackgroundClip(Common::Rect(_x, _y, _x + _w, _y + _h), getBossClipRect(), 0, ThemeEngine::kWidgetBackgroundBorder);
+	g_gui.theme()->drawWidgetBackground(Common::Rect(_x, _y, _x + _w, _y + _h), 0,
+	                                    ThemeEngine::kWidgetBackgroundBorder);
 
 	// Draw the list items
 	for (i = 0, pos = _currentPos; i < _entriesPerPage && pos < len; i++, pos++) {
@@ -513,8 +514,8 @@ void ListWidget::drawWidget() {
 		// If in numbering mode, we first print a number prefix
 		if (_numberingMode != kListNumberingOff) {
 			buffer = Common::String::format("%2d. ", (pos + _numberingMode));
-			g_gui.theme()->drawTextClip(Common::Rect(_x + _hlLeftPadding, y, _x + r.left + _leftPadding, y + fontHeight - 2),
-			                            getBossClipRect(), buffer, _state, Graphics::kTextAlignLeft, inverted, _leftPadding, true);
+			g_gui.theme()->drawText(Common::Rect(_x + _hlLeftPadding, y, _x + r.left + _leftPadding, y + fontHeight - 2),
+			                        buffer, _state, Graphics::kTextAlignLeft, inverted, _leftPadding, true);
 			pad = 0;
 		}
 
@@ -531,14 +532,12 @@ void ListWidget::drawWidget() {
 			buffer = _editString;
 			color = _editColor;
 			adjustOffset();
-			g_gui.theme()->drawTextClip(Common::Rect(_x + r.left, y, _x + r.right, y + fontHeight - 2),
-			                            getBossClipRect(), buffer, _state,
-			                            Graphics::kTextAlignLeft, inverted, pad, true, ThemeEngine::kFontStyleBold, color);
+			g_gui.theme()->drawText(Common::Rect(_x + r.left, y, _x + r.right, y + fontHeight - 2), buffer, _state,
+			                        Graphics::kTextAlignLeft, inverted, pad, true, ThemeEngine::kFontStyleBold, color);
 		} else {
 			buffer = _list[pos];
-			g_gui.theme()->drawTextClip(Common::Rect(_x + r.left, y, _x + r.right, y + fontHeight - 2),
-			                            getBossClipRect(), buffer, _state,
-			                            Graphics::kTextAlignLeft, inverted, pad, true, ThemeEngine::kFontStyleBold, color);
+			g_gui.theme()->drawText(Common::Rect(_x + r.left, y, _x + r.right, y + fontHeight - 2), buffer, _state,
+			                        Graphics::kTextAlignLeft, inverted, pad, true, ThemeEngine::kFontStyleBold, color);
 		}
 	}
 }

--- a/gui/widgets/popup.cpp
+++ b/gui/widgets/popup.cpp
@@ -151,7 +151,7 @@ void PopUpDialog::drawDialog(DrawLayer layerToDraw) {
 	Dialog::drawDialog(layerToDraw);
 
 	// Draw the menu border
-	g_gui.theme()->drawWidgetBackground(Common::Rect(_x, _y, _x+_w, _y+_h), 0);
+	g_gui.theme()->drawWidgetBackground(Common::Rect(_x, _y, _x + _w, _y + _h), 0);
 
 	/*if (_twoColumns)
 		g_gui.vLine(_x + _w / 2, _y, _y + _h - 2, g_gui._color);*/
@@ -367,10 +367,10 @@ void PopUpDialog::drawMenuEntry(int entry, bool hilite) {
 
 	if (name.size() == 0) {
 		// Draw a separator
-		g_gui.theme()->drawLineSeparator(Common::Rect(x, y, x+w, y+kLineHeight));
+		g_gui.theme()->drawLineSeparator(Common::Rect(x, y, x + w, y + kLineHeight));
 	} else {
 		g_gui.theme()->drawText(
-			Common::Rect(x+1, y+2, x+w, y+2+kLineHeight),
+			Common::Rect(x + 1, y + 2, x + w, y + 2 + kLineHeight),
 			name, hilite ? ThemeEngine::kStateHighlight : ThemeEngine::kStateEnabled,
 			Graphics::kTextAlignLeft, ThemeEngine::kTextInversionNone, _leftPadding
 		);
@@ -478,10 +478,7 @@ void PopUpWidget::drawWidget() {
 	Common::String sel;
 	if (_selectedItem >= 0)
 		sel = _entries[_selectedItem].name;
-	g_gui.theme()->drawPopUpWidgetClip(
-		Common::Rect(_x, _y, _x + _w, _y + _h), getBossClipRect(),
-		sel, _leftPadding, _state, Graphics::kTextAlignLeft
-	);
+	g_gui.theme()->drawPopUpWidget(Common::Rect(_x, _y, _x + _w, _y + _h), sel, _leftPadding, _state);
 }
 
 } // End of namespace GUI

--- a/gui/widgets/scrollbar.cpp
+++ b/gui/widgets/scrollbar.cpp
@@ -203,11 +203,7 @@ void ScrollBarWidget::drawWidget() {
 		state = ThemeEngine::kScrollbarStateSlider;
 	}
 
-	Common::Rect clipRect = getBossClipRect();
-	//scrollbar is not a usual child of ScrollContainerWidget, so it gets this special treatment
-	if (dynamic_cast<ScrollContainerWidget *>(_boss))
-		clipRect.right += _w;
-	g_gui.theme()->drawScrollbarClip(Common::Rect(_x, _y, _x+_w, _y+_h), clipRect, _sliderPos, _sliderHeight, state, _state);
+	g_gui.theme()->drawScrollbar(Common::Rect(_x, _y, _x + _w, _y + _h), _sliderPos, _sliderHeight, state);
 }
 
 } // End of namespace GUI

--- a/gui/widgets/scrollcontainer.cpp
+++ b/gui/widgets/scrollcontainer.cpp
@@ -140,7 +140,8 @@ void ScrollContainerWidget::reflowLayout() {
 }
 
 void ScrollContainerWidget::drawWidget() {
-	g_gui.theme()->drawDialogBackgroundClip(Common::Rect(_x, _y, _x + _w, _y + getHeight() - 1), getBossClipRect(), ThemeEngine::kDialogBackgroundDefault);
+	g_gui.theme()->drawDialogBackground(Common::Rect(_x, _y, _x + _w, _y + getHeight() - 1),
+	                                    ThemeEngine::kDialogBackgroundDefault);
 }
 
 bool ScrollContainerWidget::containsWidget(Widget *w) const {
@@ -153,6 +154,11 @@ Widget *ScrollContainerWidget::findWidget(int x, int y) {
 	if (_verticalScroll->isVisible() && x >= _w - _verticalScroll->getWidth())
 		return _verticalScroll;
 	return Widget::findWidgetInChain(_firstWidget, x + _scrolledX, y + _scrolledY);
+}
+
+Common::Rect ScrollContainerWidget::getClipRect() const {
+	// Make sure the clipping rect contains the scrollbar so it is properly redrawn
+	return Common::Rect(getAbsX(), getAbsY(), getAbsX() + _w, getAbsY() + getHeight());
 }
 
 } // End of namespace GUI

--- a/gui/widgets/scrollcontainer.h
+++ b/gui/widgets/scrollcontainer.h
@@ -48,6 +48,8 @@ public:
 
 	virtual bool containsWidget(Widget *) const;
 
+	Common::Rect getClipRect() const override;
+
 protected:
 	// We overload getChildY to make sure child widgets are positioned correctly.
 	// Essentially this compensates for the space taken up by the tab title header.

--- a/gui/widgets/tab.cpp
+++ b/gui/widgets/tab.cpp
@@ -320,9 +320,12 @@ void TabWidget::drawWidget() {
 		tabs.push_back(_tabs[i].title);
 		widths.push_back(_tabs[i]._tabWidth);
 	}
-	g_gui.theme()->drawDialogBackgroundClip(Common::Rect(_x + _bodyLP, _y + _bodyTP, _x+_w-_bodyRP, _y+_h-_bodyBP+_tabHeight), getBossClipRect(), _bodyBackgroundType);
+	g_gui.theme()->drawDialogBackground(
+			Common::Rect(_x + _bodyLP, _y + _bodyTP, _x + _w - _bodyRP, _y + _h - _bodyBP + _tabHeight),
+			_bodyBackgroundType);
 
-	g_gui.theme()->drawTabClip(Common::Rect(_x, _y, _x+_w, _y+_h), getBossClipRect(), _tabHeight, widths, tabs, _activeTab - _firstVisibleTab, 0, _titleVPad);
+	g_gui.theme()->drawTab(Common::Rect(_x, _y, _x + _w, _y + _h), _tabHeight, widths, tabs,
+	                       _activeTab - _firstVisibleTab);
 }
 
 void TabWidget::draw() {


### PR DESCRIPTION
This is a clean up for the GUI code. The main change is that the draw clipping rect is now part of the ThemeEngine state, allowing to unify the clip and non-clip variants methods, reducing code duplication.

This also contains some unused code removal.