### PR TITLE
GUI: Implement an "Unknown game dialog"

### DIFF
--- a/backends/platform/sdl/macosx/macosx.cpp
+++ b/backends/platform/sdl/macosx/macosx.cpp
@@ -124,6 +124,10 @@ Common::String OSystem_MacOSX::getTextFromClipboard() {
 	return getTextFromClipboardMacOSX();
 }
 
+bool OSystem_MacOSX::setTextInClipboard(const Common::String& text) {
+	return setTextInClipboardMacOSX(text);
+}
+
 bool OSystem_MacOSX::openUrl(const Common::String &url) {
 	CFURLRef urlRef = CFURLCreateWithBytes (NULL, (UInt8*)url.c_str(), url.size(), kCFStringEncodingASCII, NULL);
 	OSStatus err = LSOpenCFURLRef(urlRef, NULL);

--- a/backends/platform/sdl/macosx/macosx.h
+++ b/backends/platform/sdl/macosx/macosx.h
@@ -35,6 +35,7 @@ public:
 
 	virtual bool hasTextInClipboard();
 	virtual Common::String getTextFromClipboard();
+	virtual bool setTextInClipboard(const Common::String&);
 
 	virtual bool openUrl(const Common::String &url);
 

--- a/backends/platform/sdl/macosx/macosx_wrapper.h
+++ b/backends/platform/sdl/macosx/macosx_wrapper.h
@@ -27,6 +27,7 @@
 
 bool hasTextInClipboardMacOSX();
 Common::String getTextFromClipboardMacOSX();
+bool setTextInClipboardMacOSX(const Common::String&);
 Common::String getDesktopPathMacOSX();
 
 #endif

--- a/backends/platform/sdl/macosx/macosx_wrapper.mm
+++ b/backends/platform/sdl/macosx/macosx_wrapper.mm
@@ -49,6 +49,12 @@ Common::String getTextFromClipboardMacOSX() {
 	return Common::String([str cStringUsingEncoding:NSASCIIStringEncoding]);
 }
 
+bool setTextInClipboardMacOSX(const Common::String& text) {
+	NSPasteboard *pb = [NSPasteboard generalPasteboard];
+	[pb declareTypes:[NSArray arrayWithObject:NSStringPboardType] owner:nil];
+	return [pb setString:[NSString stringWithCString:text.c_str() encoding:NSASCIIStringEncoding] forType:NSStringPboardType];
+}
+
 Common::String getDesktopPathMacOSX() {
 	// The recommanded method is to use NSFileManager.
 	// NSUrl *url = [[[NSFileManager defaultManager] URLsForDirectory:NSDesktopDirectory inDomains:NSUserDomainMask] firstObject];

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -33,6 +33,7 @@
 #include "gui/EventRecorder.h"
 #include "common/taskbar.h"
 #include "common/textconsole.h"
+#include "common/translation.h"
 
 #include "backends/saves/default/default-saves.h"
 
@@ -502,11 +503,18 @@ Common::String OSystem_SDL::getTextFromClipboard() {
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	char *text = SDL_GetClipboardText();
+#ifdef USE_TRANSLATION
+	// The string returned by SDL is in UTF-8. Convert to the
+	// current TranslationManager encoding.
+	char *conv_text = SDL_iconv_string(TransMan.getCurrentCharset().c_str(), "UTF-8", text, SDL_strlen(text) + 1);
+	if (conv_text) {
+		SDL_free(text);
+		text = conv_text;
+	}
+#endif
 	Common::String strText = text;
 	SDL_free(text);
 
-	// FIXME: The string returned by SDL is in UTF-8, it is not clear
-	// what encoding should be used for the returned string.
 	return strText;
 #else
 	return "";
@@ -515,7 +523,16 @@ Common::String OSystem_SDL::getTextFromClipboard() {
 
 bool OSystem_SDL::setTextInClipboard(const Common::String& text) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	// FIXME: The string we get from SDL is in UTF-8 and should probably be converted.
+#ifdef USE_TRANSLATION
+	// Assume the encoding is the current TranslationManager encoding
+	// and attempt to convert to UTF-8 (which is what SDL takes).
+	char *utf8_text = SDL_iconv_string("UTF-8", TransMan.getCurrentCharset().c_str(), text.c_str(), text.size() + 1);
+	if (utf8_text) {
+		int status = SDL_SetClipboardText(utf8_text);
+		SDL_free(utf8_text);
+		return status == 0;
+	}
+#endif
 	return SDL_SetClipboardText(text.c_str()) == 0;
 #else
 	return false;

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -513,6 +513,15 @@ Common::String OSystem_SDL::getTextFromClipboard() {
 #endif
 }
 
+bool OSystem_SDL::setTextInClipboard(const Common::String& text) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	// FIXME: The string we get from SDL is in UTF-8 and should probably be converted.
+	return SDL_SetClipboardText(text.c_str()) == 0;
+#else
+	return false;
+#endif
+}
+
 uint32 OSystem_SDL::getMillis(bool skipRecord) {
 	uint32 millis = SDL_GetTicks();
 

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -72,6 +72,7 @@ public:
 	// Clipboard
 	virtual bool hasTextInClipboard();
 	virtual Common::String getTextFromClipboard();
+	virtual bool setTextInClipboard(const Common::String&);
 
 	virtual void setWindowCaption(const char *caption);
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0);

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -514,7 +514,7 @@ GameDescriptor EngineManager::findGameInLoadedPlugins(const Common::String &game
 	return result;
 }
 
-GameList EngineManager::detectGames(const Common::FSList &fslist) const {
+GameList EngineManager::detectGames(const Common::FSList &fslist, bool useUnknownGameDialog) const {
 	GameList candidates;
 	PluginList plugins;
 	PluginList::const_iterator iter;
@@ -524,7 +524,7 @@ GameList EngineManager::detectGames(const Common::FSList &fslist) const {
 		// Iterate over all known games and for each check if it might be
 		// the game in the presented directory.
 		for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
-			candidates.push_back((*iter)->get<MetaEngine>().detectGames(fslist));
+                       candidates.push_back((*iter)->get<MetaEngine>().detectGames(fslist, useUnknownGameDialog));
 		}
 	} while (PluginManager::instance().loadNextPlugin());
 	return candidates;

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -524,7 +524,7 @@ GameList EngineManager::detectGames(const Common::FSList &fslist, bool useUnknow
 		// Iterate over all known games and for each check if it might be
 		// the game in the presented directory.
 		for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
-                       candidates.push_back((*iter)->get<MetaEngine>().detectGames(fslist, useUnknownGameDialog));
+			candidates.push_back((*iter)->get<MetaEngine>().detectGames(fslist, useUnknownGameDialog));
 		}
 	} while (PluginManager::instance().loadNextPlugin());
 	return candidates;

--- a/common/singleton.h
+++ b/common/singleton.h
@@ -59,6 +59,10 @@ public:
 
 
 public:
+	static bool hasInstance() {
+		return _singleton != 0;
+	}
+
 	static T& instance() {
 		// TODO: We aren't thread safe. For now we ignore it since the
 		// only thing using this singleton template is the config manager,

--- a/common/system.h
+++ b/common/system.h
@@ -324,8 +324,8 @@ public:
 		kFeatureDisplayLogFile,
 
 		/**
-		 * The presence of this feature indicates whether the hasTextInClipboard()
-		 * and getTextFromClipboard() calls are supported.
+		 * The presence of this feature indicates whether the hasTextInClipboard(),
+		 * getTextFromClipboard() and setTextInClipboard() calls are supported.
 		 *
 		 * This feature has no associated state.
 		 */
@@ -1334,6 +1334,17 @@ public:
 	 * @return clipboard contents ("" if hasTextInClipboard() == false)
 	 */
 	virtual Common::String getTextFromClipboard() { return ""; }
+
+	/**
+	 * Set the content of the clipboard to the given string.
+	 *
+	 * The kFeatureClipboardSupport feature flag can be used to
+	 * test whether this call has been implemented by the active
+	 * backend.
+	 *
+	 * @return true if the text was properly set in the clipboard, false otherwise
+	 */
+	virtual bool setTextInClipboard(const Common::String&) { return false; }
 
 	/**
 	 * Open the given Url in the default browser (if available on the target

--- a/engines/adl/detection.cpp
+++ b/engines/adl/detection.cpp
@@ -332,7 +332,7 @@ public:
 	int getMaximumSaveSlot() const { return 'O' - 'A'; }
 	SaveStateList listSaves(const char *target) const;
 	void removeSaveState(const char *target, int slot) const;
-	virtual ADGameDescList detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra) const;
+	virtual ADGameDescList detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, bool useUnknownGameDialog = false) const;
 
 	bool addFileProps(const FileMap &allFiles, Common::String fname, ADFilePropertiesMap &filePropsMap) const;
 
@@ -511,9 +511,9 @@ bool AdlMetaEngine::addFileProps(const FileMap &allFiles, Common::String fname, 
 }
 
 // Based on AdvancedMetaEngine::detectGame
-ADGameDescList AdlMetaEngine::detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra) const {
+ADGameDescList AdlMetaEngine::detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, bool useUnknownGameDialog) const {
 	// We run the file-based detector first and then add to the returned list
-	ADGameDescList matched = AdvancedMetaEngine::detectGame(parent, allFiles, language, platform, extra);
+	ADGameDescList matched = AdvancedMetaEngine::detectGame(parent, allFiles, language, platform, extra, useUnknownGameDialog);
 
 	debug(3, "Starting disk image detection in dir '%s'", parent.getPath().c_str());
 
@@ -605,7 +605,7 @@ ADGameDescList AdlMetaEngine::detectGame(const Common::FSNode &parent, const Fil
 	// TODO: This could be improved to handle matched and unknown games together in a single directory
 	if (matched.empty()) {
 		if (!filesProps.empty() && gotAnyMatchesWithAllFiles) {
-			reportUnknown(parent, filesProps, matchedGameIds);
+			reportUnknown(parent, filesProps, matchedGameIds, useUnknownGameDialog);
 		}
 	}
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -374,7 +374,7 @@ void AdvancedMetaEngine::reportUnknown(const Common::FSNode &path, const ADFileP
 
 	// Check if the GUI is running, show the UnknownGameDialog and print the translated unknown game information
 	if (GUI::GuiManager::hasInstance() && g_gui.isActive()) {
-		GUI::UnknownGameDialog dialog(report, reportTranslated, bugtrackerAffectedEngine);
+		UnknownGameDialog dialog(report, reportTranslated, bugtrackerAffectedEngine);
 		dialog.runModal();
 	}
 }

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -358,17 +358,18 @@ void AdvancedMetaEngine::reportUnknown(const Common::FSNode &path, const ADFileP
 	reportTranslated += "\n\n";
 
 	reportTranslated.wordWrap(65);
-
-	for (ADFilePropertiesMap::const_iterator file = filesProps.begin(); file != filesProps.end(); ++file) {
-		report += Common::String::format("  {\"%s\", 0, \"%s\", %d},\n", file->_key.c_str(), file->_value.md5.c_str(), file->_value.size);
-		reportTranslated += Common::String::format("  {\"%s\", 0, \"%s\", %d},\n", file->_key.c_str(), file->_value.md5.c_str(), file->_value.size);
-	}
-	report += "\n";
-	reportTranslated += "\n";
-
-	// Write the original message about the unknown game to the log file
 	Common::String reportLog = report;
 	reportLog.wordWrap(80);
+
+	Common::String unknownFiles;
+	for (ADFilePropertiesMap::const_iterator file = filesProps.begin(); file != filesProps.end(); ++file)
+		unknownFiles += Common::String::format("  {\"%s\", 0, \"%s\", %d},\n", file->_key.c_str(), file->_value.md5.c_str(), file->_value.size);
+
+	report += unknownFiles;
+	reportTranslated += unknownFiles;
+	reportLog += unknownFiles + "\n";
+
+	// Write the original message about the unknown game to the log file
 	g_system->logMessage(LogMessageType::kInfo, reportLog.c_str());
 
 	// Check if the GUI is running, show the UnknownGameDialog and print the translated unknown game information

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -328,9 +328,9 @@ Common::Error AdvancedMetaEngine::createInstance(OSystem *syst, Engine **engine)
 }
 
 void AdvancedMetaEngine::reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps, const ADGameIdList &matchedGameIds) const {
-	const char *reportCommon = "The game in '%s' seems to be an unknown %s engine game " \
-							   "variant.\n\nPlease report the following data to the ScummVM " \
-							   "team at %s along with the name of the game you tried to add and " \
+	const char *reportCommon = "The game in '%s' seems to be an unknown %s engine game "
+							   "variant.\n\nPlease report the following data to the ScummVM "
+							   "team at %s along with the name of the game you tried to add and "
 							   "its version, language, etc.:";
 	Common::String report			= Common::String::format(reportCommon, path.getPath().c_str(), getName(), "https://bugs.scummvm.org/");
 	Common::String reportTranslated = Common::String::format(_(reportCommon), path.getPath().c_str(), getName(), "https://bugs.scummvm.org/");

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -574,7 +574,7 @@ ADGameDescList AdvancedMetaEngine::detectGame(const Common::FSNode &parent, cons
 	// We didn't find a match
 	if (matched.empty()) {
 		if (!filesProps.empty() && gotAnyMatchesWithAllFiles) {
-                       reportUnknown(parent, filesProps, matchedGameIds, useUnknownGameDialog);
+			reportUnknown(parent, filesProps, matchedGameIds, useUnknownGameDialog);
 		}
 
 		// Filename based fallback

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -278,7 +278,7 @@ public:
 
 	virtual GameDescriptor findGame(const char *gameId) const;
 
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 
@@ -313,7 +313,7 @@ protected:
 	 * @param extra		restrict results to specified extra string (only if kADFlagUseExtraAsHint is set)
 	 * @return	list of ADGameDescription pointers corresponding to matched games
 	 */
-	virtual ADGameDescList detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra) const;
+       virtual ADGameDescList detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, bool useUnknownGameDialog = false) const;
 
 	/**
 	 * Iterates over all ADFileBasedFallback records inside fileBasedFallback.
@@ -333,7 +333,7 @@ protected:
 	 * Log and print a report that we found an unknown game variant, together with the file
 	 * names, sizes and MD5 sums.
 	 */
-	void reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps, const ADGameIdList &matchedGameIds = ADGameIdList()) const;
+       void reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps, const ADGameIdList &matchedGameIds = ADGameIdList(), bool useUnknownGameDialog = false) const;
 
 	// TODO
 	void updateGameDescriptor(GameDescriptor &desc, const ADGameDescription *realDesc) const;

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -278,7 +278,7 @@ public:
 
 	virtual GameDescriptor findGame(const char *gameId) const;
 
-       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
+	virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 
@@ -313,7 +313,7 @@ protected:
 	 * @param extra		restrict results to specified extra string (only if kADFlagUseExtraAsHint is set)
 	 * @return	list of ADGameDescription pointers corresponding to matched games
 	 */
-       virtual ADGameDescList detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, bool useUnknownGameDialog = false) const;
+	virtual ADGameDescList detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, bool useUnknownGameDialog = false) const;
 
 	/**
 	 * Iterates over all ADFileBasedFallback records inside fileBasedFallback.
@@ -333,7 +333,7 @@ protected:
 	 * Log and print a report that we found an unknown game variant, together with the file
 	 * names, sizes and MD5 sums.
 	 */
-       void reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps, const ADGameIdList &matchedGameIds = ADGameIdList(), bool useUnknownGameDialog = false) const;
+	void reportUnknown(const Common::FSNode &path, const ADFilePropertiesMap &filesProps, const ADGameIdList &matchedGameIds = ADGameIdList(), bool useUnknownGameDialog = false) const;
 
 	// TODO
 	void updateGameDescriptor(GameDescriptor &desc, const ADGameDescription *realDesc) const;

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -79,7 +79,7 @@ public:
 	 * (possibly empty) list of games supported by the engine which it was able
 	 * to detect amongst the given files.
 	 */
-       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const = 0;
+	virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const = 0;
 
 	/**
 	 * Tries to instantiate an engine instance based on the settings of
@@ -269,7 +269,7 @@ class EngineManager : public Common::Singleton<EngineManager> {
 public:
 	GameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const Plugin **plugin = NULL) const;
 	GameDescriptor findGame(const Common::String &gameName, const Plugin **plugin = NULL) const;
-       GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
+	GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 	const PluginList &getPlugins() const;
 };
 

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -79,7 +79,7 @@ public:
 	 * (possibly empty) list of games supported by the engine which it was able
 	 * to detect amongst the given files.
 	 */
-	virtual GameList detectGames(const Common::FSList &fslist) const = 0;
+       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const = 0;
 
 	/**
 	 * Tries to instantiate an engine instance based on the settings of
@@ -269,7 +269,7 @@ class EngineManager : public Common::Singleton<EngineManager> {
 public:
 	GameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const Plugin **plugin = NULL) const;
 	GameDescriptor findGame(const Common::String &gameName, const Plugin **plugin = NULL) const;
-	GameList detectGames(const Common::FSList &fslist) const;
+       GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 	const PluginList &getPlugins() const;
 };
 

--- a/engines/module.mk
+++ b/engines/module.mk
@@ -1,13 +1,13 @@
 MODULE := engines
 
 MODULE_OBJS := \
-	unknown-game-dialog.o \
 	advancedDetector.o \
 	dialogs.o \
 	engine.o \
 	game.o \
 	obsolete.o \
-	savestate.o
+	savestate.o \
+	unknown-game-dialog.o \
 
 # Include common rules
 include $(srcdir)/rules.mk

--- a/engines/module.mk
+++ b/engines/module.mk
@@ -1,6 +1,7 @@
 MODULE := engines
 
 MODULE_OBJS := \
+	unknown-game-dialog.o \
 	advancedDetector.o \
 	dialogs.o \
 	engine.o \

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -961,7 +961,7 @@ public:
 	virtual bool hasFeature(MetaEngineFeature f) const;
 	virtual GameList getSupportedGames() const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 
@@ -1026,7 +1026,7 @@ static Common::String generatePreferredTarget(const DetectorResult &x) {
 	return res;
 }
 
-GameList ScummMetaEngine::detectGames(const Common::FSList &fslist) const {
+GameList ScummMetaEngine::detectGames(const Common::FSList &fslist, bool /*useUnknownGameDialog*/) const {
 	GameList detectedGames;
 	Common::List<DetectorResult> results;
 

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -961,7 +961,7 @@ public:
 	virtual bool hasFeature(MetaEngineFeature f) const;
 	virtual GameList getSupportedGames() const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
+	virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -79,7 +79,7 @@ public:
 	virtual GameList getSupportedGames() const;
 	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 
@@ -141,7 +141,7 @@ GameDescriptor SkyMetaEngine::findGame(const char *gameid) const {
 	return GameDescriptor();
 }
 
-GameList SkyMetaEngine::detectGames(const Common::FSList &fslist) const {
+GameList SkyMetaEngine::detectGames(const Common::FSList &fslist, bool /*useUnknownGameDialog*/) const {
 	GameList detectedGames;
 	bool hasSkyDsk = false;
 	bool hasSkyDnr = false;

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -79,7 +79,7 @@ public:
 	virtual GameList getSupportedGames() const;
 	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
+	virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const;
 

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -89,7 +89,7 @@ public:
 	virtual bool hasFeature(MetaEngineFeature f) const;
 	virtual GameList getSupportedGames() const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
+	virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 	virtual SaveStateList listSaves(const char *target) const;
 	virtual int getMaximumSaveSlot() const;
 	virtual void removeSaveState(const char *target, int slot) const;

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -89,7 +89,7 @@ public:
 	virtual bool hasFeature(MetaEngineFeature f) const;
 	virtual GameList getSupportedGames() const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 	virtual SaveStateList listSaves(const char *target) const;
 	virtual int getMaximumSaveSlot() const;
 	virtual void removeSaveState(const char *target, int slot) const;
@@ -175,7 +175,7 @@ void Sword1CheckDirectory(const Common::FSList &fslist, bool *filesFound, bool r
 	}
 }
 
-GameList SwordMetaEngine::detectGames(const Common::FSList &fslist) const {
+GameList SwordMetaEngine::detectGames(const Common::FSList &fslist, bool /*useUnknownGameDialog*/) const {
 	int i, j;
 	GameList detectedGames;
 	bool filesFound[NUM_FILES_TO_CHECK];

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -95,7 +95,7 @@ public:
 	virtual GameList getSupportedGames() const;
 	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-	virtual GameList detectGames(const Common::FSList &fslist) const;
+       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 	virtual SaveStateList listSaves(const char *target) const;
 	virtual int getMaximumSaveSlot() const;
 	virtual void removeSaveState(const char *target, int slot) const;
@@ -223,7 +223,7 @@ GameList detectGamesImpl(const Common::FSList &fslist, bool recursion = false) {
 	return detectedGames;
 }
 
-GameList Sword2MetaEngine::detectGames(const Common::FSList &fslist) const {
+GameList Sword2MetaEngine::detectGames(const Common::FSList &fslist, bool /*useUnknownGameDialog*/) const {
 	return detectGamesImpl(fslist);
 }
 

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -95,7 +95,7 @@ public:
 	virtual GameList getSupportedGames() const;
 	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const;
 	virtual GameDescriptor findGame(const char *gameid) const;
-       virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
+	virtual GameList detectGames(const Common::FSList &fslist, bool useUnknownGameDialog = false) const;
 	virtual SaveStateList listSaves(const char *target) const;
 	virtual int getMaximumSaveSlot() const;
 	virtual void removeSaveState(const char *target, int slot) const;

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -72,10 +72,6 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 	_h =  3 * kLineHeight;
 	_h += lineCount * kLineHeight;
 
-	// Center the dialog
-	_x = (screenW - _w) / 2;
-	_y = (screenH - _h) / 2;
-
 	// Buttons
 	int closeButtonWidth = MAX(buttonWidth, g_gui.getFont().getStringWidth(_("Close")) + 10);
 	int copyToClipboardButtonWidth = MAX(buttonWidth, g_gui.getFont().getStringWidth(_("Copy to clipboard")) + 10);
@@ -112,6 +108,12 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 	}
 
 	y += kLineHeight;
+}
+
+void UnknownGameDialog::reflowLayout() {
+	_x = (g_system->getOverlayWidth() - _w) / 2;
+	_y = (g_system->getOverlayHeight() - _h) / 2;
+	GUI::Dialog::reflowLayout();
 }
 
 void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -48,11 +48,13 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 		_reportTranslated += _("Use the button below to copy the required game information into your clipboard.");
 	}
 
+	#if 0
 	//Check if we have support for opening URLs and expand the reportTranslated message if needed...
 	if (g_system->hasFeature(OSystem::kFeatureOpenUrl)) {
 		_reportTranslated += "\n";
 		_reportTranslated += _("You can also directly report your game to the Bug Tracker!");
 	}
+	#endif
 
 	const int screenW = g_system->getOverlayWidth();
 	const int screenH = g_system->getOverlayHeight();
@@ -94,6 +96,13 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 			openBugtrackerURLButtonPos = copyToClipboardButtonPos;
 	}
 
+	#if 0
+	//Generation of the button for reporting the game directly to the bugtracker
+	//is skipped by now until we find a proper solution for the problem that a change
+	//to our bugtracker system might break the URL generation. The current approach
+	//for solving this is to create some sort of "redirect website" under the .scummvm.org
+	//domain that will accept the URL as a parameter and then forward it to the bugtracker.
+	
 	//Check if we have support for opening URLs
 	if (g_system->hasFeature(OSystem::kFeatureOpenUrl)) {
 		new GUI::ButtonWidget(this, openBugtrackerURLButtonPos, _h - buttonHeight - 8, openBugtrackerURLButtonWidth, buttonHeight, _("Report game"), 0, kOpenBugtrackerURL);
@@ -103,6 +112,7 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 			Common::replace(_bugtrackerGameData, "\n", "%0A");
 		}
 	}
+	#endif
 
 	// Each line is represented by one static text item.
 	uint y = 10;

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -117,8 +117,7 @@ void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 
 	case kCopyToClipboard:
 	{
 		g_system->setTextInClipboard(_reportData);
-		MessageDialog dialog(_("All necessary information about your game has been copied into the clipboard"), _("OK"));
-		dialog.runModal();
+		g_system->displayMessageOnOSD(_("All necessary information about your game has been copied into the clipboard"));
 		break;
 	}
 	case kClose:
@@ -132,7 +131,7 @@ void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 
 		"https://bugs.scummvm.org/newticket?"
 		"summary=[UNK] Unknown game for engine %s:"
 		"&description=%s"
-		"&component=Engine0A%s"
+		"&component=Engine%3A%s"
 		"&type=enhancement"
 		"&keywords=unknown-game,%s"),
 		_bugtrackerAffectedEngine.c_str(), _bugtrackerGameData.c_str(), _bugtrackerAffectedEngine.c_str(), _bugtrackerAffectedEngine.c_str());

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -29,8 +29,6 @@
 #include "engines/unknown-game-dialog.h"
 #include "backends/platform/sdl/sdl.h"
 
-namespace GUI {
-
 enum {
 	kCopyToClipboard = 'cpcl',
 	kOpenBugtrackerURL = 'ourl',
@@ -85,11 +83,12 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 	int closeButtonPos = _w - closeButtonWidth - 10;
 	int copyToClipboardButtonPos = _w - copyToClipboardButtonWidth - closeButtonWidth - 15;
 	int openBugtrackerURLButtonPos = _w - copyToClipboardButtonWidth - closeButtonWidth - openBugtrackerURLButtonWidth - 20;
-	_closeButton = new ButtonWidget(this, closeButtonPos, _h - buttonHeight - 8, buttonWidth, buttonHeight, _("Close"), 0, kClose);
+
+	new GUI::ButtonWidget(this, closeButtonPos, _h - buttonHeight - 8, buttonWidth, buttonHeight, _("Close"), 0, kClose);
 
 	//Check if we have clipboard functionality
 	if (g_system->hasFeature(OSystem::kFeatureClipboardSupport)) {
-		new ButtonWidget(this, copyToClipboardButtonPos, _h - buttonHeight - 8, copyToClipboardButtonWidth, buttonHeight, _("Copy to clipboard"), 0, kCopyToClipboard);
+		new GUI::ButtonWidget(this, copyToClipboardButtonPos, _h - buttonHeight - 8, copyToClipboardButtonWidth, buttonHeight, _("Copy to clipboard"), 0, kCopyToClipboard);
 	} else {
 			//Set the bug tracker position to the one of the disabled copy-to-clipboard button
 			openBugtrackerURLButtonPos = copyToClipboardButtonPos;
@@ -97,7 +96,7 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 
 	//Check if we have support for opening URLs
 	if (g_system->hasFeature(OSystem::kFeatureOpenUrl)) {
-		new ButtonWidget(this, openBugtrackerURLButtonPos, _h - buttonHeight - 8, openBugtrackerURLButtonWidth, buttonHeight, _("Report game"), 0, kOpenBugtrackerURL);
+		new GUI::ButtonWidget(this, openBugtrackerURLButtonPos, _h - buttonHeight - 8, openBugtrackerURLButtonWidth, buttonHeight, _("Report game"), 0, kOpenBugtrackerURL);
 		//Formatting the reportData for bugtracker submission [replace line breaks]...
 		_bugtrackerGameData = _reportData;
 		while (_bugtrackerGameData.contains("\n")) {
@@ -108,7 +107,7 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 	// Each line is represented by one static text item.
 	uint y = 10;
 	for (uint i = 0; i < lines.size(); i++) {
-		new StaticTextWidget(this, 10, y, _w, kLineHeight,
+		new GUI::StaticTextWidget(this, 10, y, _w, kLineHeight,
 								lines[i], Graphics::kTextAlignLeft);
 		y += kLineHeight;
 	}
@@ -133,7 +132,7 @@ Common::String UnknownGameDialog::generateBugtrackerURL() {
 		_bugtrackerAffectedEngine.c_str(), _bugtrackerGameData.c_str(), _bugtrackerAffectedEngine.c_str(), _bugtrackerAffectedEngine.c_str());
 }
 
-void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
+void UnknownGameDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) {
 	switch(cmd) {
 	case kCopyToClipboard:
 	{
@@ -157,4 +156,3 @@ void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 
 	}
 }
 }
-} //End of namespace GUI

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -1,0 +1,144 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/translation.h"
+#include "common/str-array.h"
+#include "gui/gui-manager.h"
+#include "gui/message.h"
+#include "gui/ThemeEval.h"
+#include "gui/widgets/popup.h"
+#include "engines/unknown-game-dialog.h"
+#include "backends/platform/sdl/sdl.h"
+
+namespace GUI {
+
+enum {
+	kCopyToClipboard = 'cpcl',
+	kOpenBugtrackerURL = 'ourl',
+	kClose = 'clse'
+};
+
+UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Common::String &reportTranslated, const Common::String &bugtrackerAffectedEngine)
+	: Dialog(30, 20, 260, 124) {
+
+	_reportData = reportData;
+	_reportTranslated = reportTranslated;
+	_bugtrackerAffectedEngine = bugtrackerAffectedEngine;
+
+	//Check if we have clipboard functionality and expand the reportTranslated message if needed...
+	if (g_system->hasFeature(OSystem::kFeatureClipboardSupport)) {
+		_reportTranslated += _("Use the button below to copy the required game information into your clipboard. \n");
+	}
+
+	//Check if we have support for opening URLs and expand the reportTranslated message if needed...
+	if (g_system->hasFeature(OSystem::kFeatureOpenUrl)) {
+		_reportTranslated += _("You can also directly report your game to the Bug Tracker!");
+	}
+
+	const int screenW = g_system->getOverlayWidth();
+	const int screenH = g_system->getOverlayHeight();
+
+	int buttonWidth = g_gui.xmlEval()->getVar("Globals.Button.Width", 0);
+	int buttonHeight = g_gui.xmlEval()->getVar("Globals.Button.Height", 0);
+
+	//Calculate the size the dialog needs
+	Common::Array<Common::String> lines;
+	int maxlineWidth = g_gui.getFont().wordWrapText(_reportTranslated, screenW - 2 * 20, lines);
+
+	_w = MAX(MAX(maxlineWidth, 0), (2 * buttonWidth) + 10) + 20;
+	int lineCount = lines.size() + 1;
+
+	_h =  3 * kLineHeight;
+	_h += lineCount * kLineHeight;
+
+	// Center the dialog
+	_x = (screenW - _w) / 2;
+	_y = (screenH - _h) / 2;
+
+	// Buttons
+	int closeButtonWidth = MAX(buttonWidth, g_gui.getFont().getStringWidth(_("Close")) + 10);
+	int copyToClipboardButtonWidth = MAX(buttonWidth, g_gui.getFont().getStringWidth(_("Copy to clipboard")) + 10);
+	int openBugtrackerURLButtonWidth = MAX(buttonWidth, g_gui.getFont().getStringWidth(_("Report game")) + 10);
+	int closeButtonPos = _w - closeButtonWidth - 10;
+	int copyToClipboardButtonPos = _w - copyToClipboardButtonWidth - closeButtonWidth - 15;
+	int openBugtrackerURLButtonPos = _w - copyToClipboardButtonWidth - closeButtonWidth - openBugtrackerURLButtonWidth - 20;
+	_closeButton = new ButtonWidget(this, closeButtonPos, _h - buttonHeight - 8, buttonWidth, buttonHeight, _("Close"), 0, kClose);
+
+	//Check if we have clipboard functionality
+	if (g_system->hasFeature(OSystem::kFeatureClipboardSupport)) {
+		new ButtonWidget(this, copyToClipboardButtonPos, _h - buttonHeight - 8, copyToClipboardButtonWidth, buttonHeight, _("Copy to clipboard"), 0, kCopyToClipboard);
+	} else {
+			//Set the bug tracker position to the one of the disabled copy-to-clipboard button
+			openBugtrackerURLButtonPos = copyToClipboardButtonPos;
+	}
+
+	//Check if we have support for opening URLs
+	if (g_system->hasFeature(OSystem::kFeatureOpenUrl)) {
+		new ButtonWidget(this, openBugtrackerURLButtonPos, _h - buttonHeight - 8, openBugtrackerURLButtonWidth, buttonHeight, _("Report game"), 0, kOpenBugtrackerURL);
+		//Formatting the reportData for bugtracker submission [replace line breaks]...
+		_bugtrackerGameData = _reportData;
+		while (_bugtrackerGameData.contains("\n")) {
+			replace(_bugtrackerGameData, "\n", "%0A");
+		}
+	}
+
+	// Each line is represented by one static text item.
+	uint y = 10;
+	for (uint i = 0; i < lines.size(); i++) {
+		new StaticTextWidget(this, 10, y, _w, kLineHeight,
+								lines[i], Graphics::kTextAlignLeft);
+		y += kLineHeight;
+	}
+
+	y += kLineHeight;
+}
+
+void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
+	switch(cmd) {
+	case kCopyToClipboard:
+	{
+		g_system->setTextInClipboard(_reportData);
+		MessageDialog dialog(_("All necessary information about your game has been copied into the clipboard"), _("OK"));
+		dialog.runModal();
+		break;
+	}
+	case kClose:
+	{
+		close();
+		break;
+	}
+	case kOpenBugtrackerURL:
+	{
+		Common::String bugtrackerURL = Common::String::format((
+		"https://bugs.scummvm.org/newticket?"
+		"summary=[UNK] Unknown game for engine %s:"
+		"&description=%s"
+		"&component=Engine0A%s"
+		"&type=enhancement"
+		"&keywords=unknown-game,%s"),
+		_bugtrackerAffectedEngine.c_str(), _bugtrackerGameData.c_str(), _bugtrackerAffectedEngine.c_str(), _bugtrackerAffectedEngine.c_str());
+		g_system->openUrl(bugtrackerURL);
+		break;
+	}
+}
+}
+} //End of namespace GUI

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -121,7 +121,11 @@ void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 
 	case kCopyToClipboard:
 	{
 		g_system->setTextInClipboard(_reportData);
-		g_system->displayMessageOnOSD(_("All necessary information about your game has been copied into the clipboard"));
+		if (g_system->setTextInClipboard(_reportData)) {
+			g_system->displayMessageOnOSD(_("All necessary information about your game has been copied into the clipboard"));
+		} else {
+			g_system->displayMessageOnOSD(_("Copying the game information to the clipboard has failed!"));
+		}
 		break;
 	}
 	case kClose:

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -116,6 +116,17 @@ void UnknownGameDialog::reflowLayout() {
 	GUI::Dialog::reflowLayout();
 }
 
+Common::String UnknownGameDialog::generateBugtrackerURL() {
+		return Common::String::format((
+		"https://bugs.scummvm.org/newticket?"
+		"summary=[UNK] Unknown game for engine %s:"
+		"&description=%s"
+		"&component=Engine%3A%s"
+		"&type=enhancement"
+		"&keywords=unknown-game,%s"),
+		_bugtrackerAffectedEngine.c_str(), _bugtrackerGameData.c_str(), _bugtrackerAffectedEngine.c_str(), _bugtrackerAffectedEngine.c_str());
+}
+
 void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	switch(cmd) {
 	case kCopyToClipboard:
@@ -135,15 +146,7 @@ void UnknownGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 
 	}
 	case kOpenBugtrackerURL:
 	{
-		Common::String bugtrackerURL = Common::String::format((
-		"https://bugs.scummvm.org/newticket?"
-		"summary=[UNK] Unknown game for engine %s:"
-		"&description=%s"
-		"&component=Engine%3A%s"
-		"&type=enhancement"
-		"&keywords=unknown-game,%s"),
-		_bugtrackerAffectedEngine.c_str(), _bugtrackerGameData.c_str(), _bugtrackerAffectedEngine.c_str(), _bugtrackerAffectedEngine.c_str());
-		g_system->openUrl(bugtrackerURL);
+		g_system->openUrl(generateBugtrackerURL());
 		break;
 	}
 }

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -65,8 +65,6 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 	//Calculate the size the dialog needs
 	Common::Array<Common::String> lines;
 	int maxlineWidth = g_gui.getFont().wordWrapText(_reportTranslated, screenW - 2 * 20, lines);
-
-	_w = MAX(MAX(maxlineWidth, 0), (2 * buttonWidth) + 10) + 20;
 	int lineCount = lines.size() + 1;
 
 	_h =  3 * kLineHeight;
@@ -76,6 +74,14 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 	int closeButtonWidth = MAX(buttonWidth, g_gui.getFont().getStringWidth(_("Close")) + 10);
 	int copyToClipboardButtonWidth = MAX(buttonWidth, g_gui.getFont().getStringWidth(_("Copy to clipboard")) + 10);
 	int openBugtrackerURLButtonWidth = MAX(buttonWidth, g_gui.getFont().getStringWidth(_("Report game")) + 10);
+	int totalButtonWidth = closeButtonWidth;
+	if (g_system->hasFeature(OSystem::kFeatureClipboardSupport))
+		totalButtonWidth += 10 + copyToClipboardButtonWidth;
+	if (g_system->hasFeature(OSystem::kFeatureOpenUrl))
+		totalButtonWidth += 10 + openBugtrackerURLButtonWidth;
+
+	_w = MAX(MAX(maxlineWidth, 0), totalButtonWidth) + 20;
+
 	int closeButtonPos = _w - closeButtonWidth - 10;
 	int copyToClipboardButtonPos = _w - copyToClipboardButtonWidth - closeButtonWidth - 15;
 	int openBugtrackerURLButtonPos = _w - copyToClipboardButtonWidth - closeButtonWidth - openBugtrackerURLButtonWidth - 20;

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -99,7 +99,7 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 		//Formatting the reportData for bugtracker submission [replace line breaks]...
 		_bugtrackerGameData = _reportData;
 		while (_bugtrackerGameData.contains("\n")) {
-			replace(_bugtrackerGameData, "\n", "%0A");
+			Common::replace(_bugtrackerGameData, "\n", "%0A");
 		}
 	}
 

--- a/engines/unknown-game-dialog.cpp
+++ b/engines/unknown-game-dialog.cpp
@@ -46,11 +46,13 @@ UnknownGameDialog::UnknownGameDialog(const Common::String &reportData, const Com
 
 	//Check if we have clipboard functionality and expand the reportTranslated message if needed...
 	if (g_system->hasFeature(OSystem::kFeatureClipboardSupport)) {
-		_reportTranslated += _("Use the button below to copy the required game information into your clipboard. \n");
+		_reportTranslated += "\n";
+		_reportTranslated += _("Use the button below to copy the required game information into your clipboard.");
 	}
 
 	//Check if we have support for opening URLs and expand the reportTranslated message if needed...
 	if (g_system->hasFeature(OSystem::kFeatureOpenUrl)) {
+		_reportTranslated += "\n";
 		_reportTranslated += _("You can also directly report your game to the Bug Tracker!");
 	}
 

--- a/engines/unknown-game-dialog.h
+++ b/engines/unknown-game-dialog.h
@@ -32,6 +32,7 @@ class UnknownGameDialog : public Dialog {
 public:
 	UnknownGameDialog(const Common::String &reportData, const Common::String &reportTranslated, const Common::String &bugtrackerAffectedEngine);
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
+	virtual Common::String generateBugtrackerURL();
 	virtual void reflowLayout();
 
 private:

--- a/engines/unknown-game-dialog.h
+++ b/engines/unknown-game-dialog.h
@@ -1,0 +1,46 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "gui/dialog.h"
+
+namespace GUI {
+
+class ButtonWidget;
+class StaticTextWidget;
+class CommandSender;
+
+class UnknownGameDialog : public Dialog {
+public:
+	UnknownGameDialog(const Common::String &reportData, const Common::String &reportTranslated, const Common::String &bugtrackerAffectedEngine);
+	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
+
+private:
+	Common::String _reportData;
+	Common::String _reportTranslated;
+	Common::String _bugtrackerGameData;
+	Common::String _bugtrackerAffectedEngine;
+	ButtonWidget *_copyToClipboardButton;
+	ButtonWidget *_openBugtrackerURLButton;
+	ButtonWidget *_closeButton;
+};
+
+} // End of namespace GUI 

--- a/engines/unknown-game-dialog.h
+++ b/engines/unknown-game-dialog.h
@@ -22,16 +22,14 @@
 
 #include "gui/dialog.h"
 
-namespace GUI {
-
 class ButtonWidget;
 class StaticTextWidget;
 class CommandSender;
 
-class UnknownGameDialog : public Dialog {
+class UnknownGameDialog : public GUI::Dialog {
 public:
 	UnknownGameDialog(const Common::String &reportData, const Common::String &reportTranslated, const Common::String &bugtrackerAffectedEngine);
-	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
+	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data);
 	virtual Common::String generateBugtrackerURL();
 	virtual void reflowLayout();
 
@@ -44,5 +42,3 @@ private:
 	ButtonWidget *_openBugtrackerURLButton;
 	ButtonWidget *_closeButton;
 };
-
-} // End of namespace GUI 

--- a/engines/unknown-game-dialog.h
+++ b/engines/unknown-game-dialog.h
@@ -32,6 +32,7 @@ class UnknownGameDialog : public Dialog {
 public:
 	UnknownGameDialog(const Common::String &reportData, const Common::String &reportTranslated, const Common::String &bugtrackerAffectedEngine);
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
+	virtual void reflowLayout();
 
 private:
 	Common::String _reportData;

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -573,7 +573,7 @@ bool LauncherDialog::doGameDetection(const Common::String &path) {
 
 	// ...so let's determine a list of candidates, games that
 	// could be contained in the specified directory.
-       GameList candidates(EngineMan.detectGames(files, true));
+	GameList candidates(EngineMan.detectGames(files, true));
 
 	int idx;
 	if (candidates.empty()) {

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -573,7 +573,7 @@ bool LauncherDialog::doGameDetection(const Common::String &path) {
 
 	// ...so let's determine a list of candidates, games that
 	// could be contained in the specified directory.
-	GameList candidates(EngineMan.detectGames(files));
+       GameList candidates(EngineMan.detectGames(files, true));
 
 	int idx;
 	if (candidates.empty()) {

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -200,6 +200,15 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 		}
 		break;
 
+	case Common::KEYCODE_c:
+		if (g_system->hasFeature(OSystem::kFeatureClipboardSupport) && state.flags & Common::KBD_CTRL) {
+			if (!getEditString().empty())
+				g_system->setTextInClipboard(getEditString());
+		} else {
+			defaultKeyDownHandler(state, dirty, forcecaret, handled);
+		}
+		break;
+
 #ifdef MACOSX
 	// Let ctrl-a / ctrl-e move the caret to the start / end of the line.
 	//

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -35,6 +35,7 @@ common/updates.cpp
 engines/advancedDetector.cpp
 engines/dialogs.cpp
 engines/engine.cpp
+engines/unknown-game-dialog.cpp
 
 audio/adlib.cpp
 audio/fmopl.cpp


### PR DESCRIPTION
Thanks to the great help of @criezy, here's my implementation of an GUI dialog that appears when an unknown game is detected.

Features:
 - Allows copying the data collected by game detector to the clipboard
 - Allows opening the bug tracker in the default web browser and pre-fills the form fiels

Feedback is greatly appreciated! As I'm still learning how to C++ and have little experience, don't hesitate to tell me if I did something awfully stupid. :)

@wjp: The option to automatically report the collected data unfortunately will fail ungracefully if the user is not logged in to ScummVM's Trac instance. There's also something wrong with https://bugs.scummvm.org/login which to my understanding would handle this case by a redirect. 

![scummvm-unknown-game-dialog](https://user-images.githubusercontent.com/11882577/38820517-7230d400-419e-11e8-8f3e-8cdb3427ec14.PNG)
![scummvm-unknown-game-dialog-bugtracker](https://user-images.githubusercontent.com/11882577/38820524-74508d52-419e-11e8-9f7a-02f76619dd46.PNG)

This closes https://bugs.scummvm.org/ticket/10435.