### PR TITLE
MOHAWK: Myst: Selentic receiver improvements

### DIFF
--- a/engines/mohawk/myst_stacks/selenitic.cpp
+++ b/engines/mohawk/myst_stacks/selenitic.cpp
@@ -1023,7 +1023,7 @@ uint16 Selenitic::soundReceiverCurrentSound(uint16 source, uint16 position) {
 	if (sourceEnabled) {
 		if (position == solution) {
 			soundId = soundIdGood;
-		} else if (position > solution && position <= solution + 50) {
+		} else if (position > solution && position < solution + 50) {
 			_soundReceiverNearBlinkCounter++;
 			if (_soundReceiverNearBlinkCounter % 2) {
 				_soundReceiverLeftButton->drawConditionalDataToScreen(2);
@@ -1031,7 +1031,7 @@ uint16 Selenitic::soundReceiverCurrentSound(uint16 source, uint16 position) {
 				_soundReceiverLeftButton->drawConditionalDataToScreen(0);
 			}
 			soundId = soundIdNear;
-		} else if (position < solution && position >= solution - 50) {
+		} else if (position < solution && position > solution - 50) {
 			_soundReceiverNearBlinkCounter++;
 			if (_soundReceiverNearBlinkCounter % 2) {
 				_soundReceiverRightButton->drawConditionalDataToScreen(2);

--- a/engines/mohawk/myst_stacks/selenitic.cpp
+++ b/engines/mohawk/myst_stacks/selenitic.cpp
@@ -970,13 +970,13 @@ void Selenitic::soundReceiver_run() {
 void Selenitic::soundReceiverIncreaseSpeed() {
 	switch (_soundReceiverSpeed) {
 	case 1:
-		_soundReceiverSpeed = 10;
+		_soundReceiverSpeed = 5; // The original has this at 10
+		break;
+	case 5:
+		_soundReceiverSpeed = 10; // The original has this at 50 too fast!
 		break;
 	case 10:
-		_soundReceiverSpeed = 50;
-		break;
-	case 50:
-		_soundReceiverSpeed = 100;
+		_soundReceiverSpeed = 13; // The original has this at 100, way too fast!
 		break;
 	}
 }


### PR DESCRIPTION
1. Slow down sound receiver turn rate at maximum speed so it can actually be possible to stop close to a desired angle.
2. The receiver direction hint is now given when < 5 degrees away rather than when <= 5 degrees away. This has it line up with the original.

I think the sound receiver rotating could probably be improved further as it is jumpy, but at least now it is more usable. 

I've also seen the directional hint behavior sporadic and I will try to see if I can repo that. Sometimes the hint stop blinking and such.