### PR TITLE
Improve command line --list-saves command

### DIFF
--- a/README
+++ b/README
@@ -1463,7 +1463,8 @@ arguments -- see the next section.
   -h, --help               Display a brief help text and exit
   -z, --list-games         Display list of supported games and exit
   -t, --list-targets       Display list of configured targets and exit
-  --list-saves             Display a list of saved games for the target specified with --game=TARGET
+  --list-saves             Display a list of saved games for the target specified
+                           with --game=TARGET, or all targets if none is specified
   -a, --add                Add all games from current or specified directory.
                            If --game=ID is passed only the game with id ID is
                            added. See also --detect.
@@ -2009,7 +2010,8 @@ Where 'xxx' is exact the saved game slot (i.e., 001) under ScummVM
 --list-saves:
 
    This switch may be used to display a list of the current saved games
-   of the specified target game and their corresponding save slots.
+   of the specified target game and their corresponding save slots. If no
+   target is specified, it lists saved games for all known target.
 
    Usage: --list-saves --game=[TARGET], where [TARGET] is the target game.
 

--- a/README
+++ b/README
@@ -1463,7 +1463,7 @@ arguments -- see the next section.
   -h, --help               Display a brief help text and exit
   -z, --list-games         Display list of supported games and exit
   -t, --list-targets       Display list of configured targets and exit
-  --list-saves=TARGET      Display a list of saved games for the game (TARGET) specified
+  --list-saves             Display a list of saved games for the target specified with --game=TARGET
   -a, --add                Add all games from current or specified directory.
                            If --game=ID is passed only the game with id ID is
                            added. See also --detect.
@@ -2011,7 +2011,7 @@ Where 'xxx' is exact the saved game slot (i.e., 001) under ScummVM
    This switch may be used to display a list of the current saved games
    of the specified target game and their corresponding save slots.
 
-   Usage: --list-saves=[TARGET], where [TARGET] is the target game.
+   Usage: --list-saves --game=[TARGET], where [TARGET] is the target game.
 
    Engines which currently support --list-saves are:
 


### PR DESCRIPTION
This include two changes:
- Change the syntax of the command to use `--game=TARGET` to specify the target, and thus be consistent with other commands.
- Allow listing save games for all known targets (when no target is specified by the user).