### PR TITLE
MOHAWK: MYST: Turn held page state into an enum

### DIFF
--- a/engines/mohawk/dialogs.cpp
+++ b/engines/mohawk/dialogs.cpp
@@ -204,7 +204,7 @@ MystOptionsDialog::~MystOptionsDialog() {
 void MystOptionsDialog::open() {
 	MohawkOptionsDialog::open();
 
-	_dropPageButton->setEnabled(_vm->_gameState->_globals.heldPage != 0);
+	_dropPageButton->setEnabled(_vm->_gameState->_globals.heldPage != kNoPage);
 
 	if (_showMapButton)
 		_showMapButton->setEnabled(_vm->_scriptParser &&

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -1196,8 +1196,8 @@ bool MohawkEngine_Myst::canSaveGameStateCurrently() {
 }
 
 void MohawkEngine_Myst::dropPage() {
-	uint16 page = _gameState->_globals.heldPage;
-	bool whitePage = page == 13;
+	HeldPage page = _gameState->_globals.heldPage;
+	bool whitePage = page == kWhitePage;
 	bool bluePage = page - 1 < 6;
 	bool redPage = page - 7 < 6;
 
@@ -1205,24 +1205,24 @@ void MohawkEngine_Myst::dropPage() {
 	_sound->playEffect(800);
 
 	// Drop page
-	_gameState->_globals.heldPage = 0;
+	_gameState->_globals.heldPage = kNoPage;
 
 	// Redraw page area
 	if (whitePage && _gameState->_globals.currentAge == 2) {
 		_scriptParser->toggleVar(41);
 		redrawArea(41);
 	} else if (bluePage) {
-		if (page == 6) {
+		if (page == kBlueFirePlacePage) {
 			if (_gameState->_globals.currentAge == 2)
 				redrawArea(24);
 		} else {
 			redrawArea(103);
 		}
 	} else if (redPage) {
-		if (page == 12) {
+		if (page == kRedFirePlacePage) {
 			if (_gameState->_globals.currentAge == 2)
 				redrawArea(25);
-		} else if (page == 10) {
+		} else if (page == kRedStoneshipPage) { //TODO: Should this also happen for the blue page above?
 			if (_gameState->_globals.currentAge == 1)
 				redrawArea(35);
 		} else {

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -1222,7 +1222,7 @@ void MohawkEngine_Myst::dropPage() {
 		if (page == kRedFirePlacePage) {
 			if (_gameState->_globals.currentAge == 2)
 				redrawArea(25);
-		} else if (page == kRedStoneshipPage) { //TODO: Should this also happen for the blue page above?
+		} else if (page == kRedStoneshipPage) {
 			if (_gameState->_globals.currentAge == 1)
 				redrawArea(35);
 		} else {

--- a/engines/mohawk/myst_scripts.cpp
+++ b/engines/mohawk/myst_scripts.cpp
@@ -378,7 +378,7 @@ void MystScriptParser::o_takePage(uint16 var, const ArgumentsArray &args) {
 			cursorId = kDefaultMystCursor;
 	}
 
-	uint16 oldPage = _globals.heldPage;
+	HeldPage oldPage = _globals.heldPage;
 
 	// Take / drop page
 	toggleVar(var);
@@ -388,7 +388,7 @@ void MystScriptParser::o_takePage(uint16 var, const ArgumentsArray &args) {
 		_vm->redrawArea(var);
 
 		// Set new cursor
-		if (_globals.heldPage)
+		if (_globals.heldPage != kNoPage)
 			_vm->setMainCursor(cursorId);
 		else
 			_vm->setMainCursor(kDefaultMystCursor);

--- a/engines/mohawk/myst_stacks/channelwood.cpp
+++ b/engines/mohawk/myst_stacks/channelwood.cpp
@@ -187,7 +187,7 @@ uint16 Channelwood::getVar(uint16 var) {
 		}
 	case 102: // Sirrus's Desk Drawer / Red Page State
 		if (_siriusDrawerState) {
-			if(!(_globals.redPagesInBook & 16) && (_globals.heldPage != 11))
+			if(!(_globals.redPagesInBook & 16) && (_globals.heldPage != kRedChannelwoodPage))
 				return 2; // Drawer Open, Red Page Present
 			else
 				return 1; // Drawer Open, Red Page Taken
@@ -195,7 +195,7 @@ uint16 Channelwood::getVar(uint16 var) {
 			return 0; // Drawer Closed
 		}
 	case 103: // Blue Page Present
-		return !(_globals.bluePagesInBook & 16) && (_globals.heldPage != 5);
+		return !(_globals.bluePagesInBook & 16) && (_globals.heldPage != kBlueChannelwoodPage);
 	default:
 		return MystScriptParser::getVar(var);
 	}
@@ -214,18 +214,18 @@ void Channelwood::toggleVar(uint16 var) {
 		break;
 	case 102: // Red page
 		if (!(_globals.redPagesInBook & 16)) {
-			if (_globals.heldPage == 11)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kRedChannelwoodPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 11;
+				_globals.heldPage = kRedChannelwoodPage;
 		}
 		break;
 	case 103: // Blue page
 		if (!(_globals.bluePagesInBook & 16)) {
-			if (_globals.heldPage == 5)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kBlueChannelwoodPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 5;
+				_globals.heldPage = kBlueChannelwoodPage;
 		}
 		break;
 	default:

--- a/engines/mohawk/myst_stacks/dni.cpp
+++ b/engines/mohawk/myst_stacks/dni.cpp
@@ -89,7 +89,7 @@ uint16 Dni::getVar(uint16 var) {
 	case 2: // Music Type
 		if (_notSeenAtrus) {
 			_notSeenAtrus = false;
-			return _globals.ending != 4 && _globals.heldPage != 13;
+			return _globals.ending != 4 && _globals.heldPage != kWhitePage;
 		} else
 			return 2;
 	default:
@@ -106,7 +106,7 @@ void Dni::o_handPage(uint16 var, const ArgumentsArray &args) {
 	// Good ending and Atrus asked to give page
 	if (_globals.ending == 1 && atrus && atrus->getTime() > (uint)Audio::Timestamp(0, 6801, 600).msecs()) {
 		_globals.ending = 2;
-		_globals.heldPage = 0;
+		_globals.heldPage = kNoPage;
 		_vm->setMainCursor(kDefaultMystCursor);
 
 		// Play movie end (atrus leaving)
@@ -166,7 +166,7 @@ void Dni::atrus_run() {
 			atrus->setBounds(Audio::Timestamp(0, 7388, 600), Audio::Timestamp(0, 14700, 600));
 		}
 	} else if (_globals.ending != 3 && _globals.ending != 4) {
-		if (_globals.heldPage == 13) {
+		if (_globals.heldPage == kWhitePage) {
 			_video = "atr1page";
 			_videoPos = Common::Point(215, 76);
 			VideoEntryPtr atrus = _vm->playMovie(_video, kDniStack);

--- a/engines/mohawk/myst_stacks/mechanical.cpp
+++ b/engines/mohawk/myst_stacks/mechanical.cpp
@@ -170,12 +170,12 @@ uint16 Mechanical::getVar(uint16 var) {
 		return _state.sirrusPanelState;
 	case 2: // Achenar's Secret Room Crate Lid Open and Blue Page Present
 		if (_state.achenarCrateOpened) {
-			if (_globals.bluePagesInBook & 4 || _globals.heldPage == 3)
+			if (_globals.bluePagesInBook & 4 || _globals.heldPage == kBlueMechanicalPage)
 				return 2;
 			else
 				return 3;
 		} else {
-			return _globals.bluePagesInBook & 4 || _globals.heldPage == 3;
+			return _globals.bluePagesInBook & 4 || _globals.heldPage == kBlueMechanicalPage;
 		}
 	case 3: // Achenar's Secret Room Crate State
 		return _state.achenarCrateOpened;
@@ -223,9 +223,9 @@ uint16 Mechanical::getVar(uint16 var) {
 	case 22: // Crystal Lit Flag - Red
 		return _crystalLit == 2;
 	case 102: // Red page
-		return !(_globals.redPagesInBook & 4) && (_globals.heldPage != 9);
+		return !(_globals.redPagesInBook & 4) && (_globals.heldPage != kRedMechanicalPage);
 	case 103: // Blue page
-		return !(_globals.bluePagesInBook & 4) && (_globals.heldPage != 3);
+		return !(_globals.bluePagesInBook & 4) && (_globals.heldPage != kBlueMechanicalPage);
 	default:
 		return MystScriptParser::getVar(var);
 	}
@@ -259,18 +259,18 @@ void Mechanical::toggleVar(uint16 var) {
 		break;
 	case 102: // Red page
 		if (!(_globals.redPagesInBook & 4)) {
-			if (_globals.heldPage == 9)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kRedMechanicalPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 9;
+				_globals.heldPage = kRedMechanicalPage;
 		}
 		break;
 	case 103: // Blue page
 		if (!(_globals.bluePagesInBook & 4)) {
-			if (_globals.heldPage == 3)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kBlueMechanicalPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 3;
+				_globals.heldPage = kBlueMechanicalPage;
 		}
 		break;
 	default:

--- a/engines/mohawk/myst_stacks/myst.cpp
+++ b/engines/mohawk/myst_stacks/myst.cpp
@@ -1138,16 +1138,14 @@ void Myst::o_bookGivePage(uint16 var, const ArgumentsArray &args) {
 	debugC(kDebugScript, "Card Id (Book Cover): %d", cardIdBookCover);
 	debugC(kDebugScript, "SoundId (Add Page): %d", soundIdAddPage);
 
-	// No page or white page
-	if (_globals.heldPage == kNoPage || _globals.heldPage == kWhitePage) {
-		_vm->changeToCard(cardIdBookCover, kTransitionDissolve);
-		return;
-	}
-
 	uint16 bookVar = 101;
 	uint16 mask = 0;
 
 	switch (_globals.heldPage) {
+	case kNoPage:
+	case kWhitePage:
+		_vm->changeToCard(cardIdBookCover, kTransitionDissolve);
+		return;
 	case kRedLibraryPage:
 		bookVar = 100;
 		// fallthrough

--- a/engines/mohawk/myst_stacks/myst.cpp
+++ b/engines/mohawk/myst_stacks/myst.cpp
@@ -487,12 +487,12 @@ uint16 Myst::getVar(uint16 var) {
 				&& _fireplaceLines[5] == 250;
 	case 24: // Fireplace Blue Page Present
 		if (_globals.ending != 4)
-			return !(_globals.bluePagesInBook & 32) && (_globals.heldPage != 6);
+			return !(_globals.bluePagesInBook & 32) && (_globals.heldPage != kBlueFirePlacePage);
 		else
 			return 0;
 	case 25: // Fireplace Red Page Present
 		if (_globals.ending != 4)
-			return !(_globals.redPagesInBook & 32) && (_globals.heldPage != 12);
+			return !(_globals.redPagesInBook & 32) && (_globals.heldPage != kRedFirePlacePage);
 		else
 			return 0;
 	case 26: // Courtyard Image Box - Cross
@@ -706,12 +706,12 @@ uint16 Myst::getVar(uint16 var) {
 		return _state.cabinValvePosition % 6;
 	case 102: // Red page
 		if (_globals.ending != 4)
-			return !(_globals.redPagesInBook & 1) && (_globals.heldPage != 7);
+			return !(_globals.redPagesInBook & 1) && (_globals.heldPage != kRedLibraryPage);
 		else
 			return 0;
 	case 103: // Blue page
 		if (_globals.ending != 4)
-			return !(_globals.bluePagesInBook & 1) && (_globals.heldPage != 1);
+			return !(_globals.bluePagesInBook & 1) && (_globals.heldPage != kBlueLibraryPage);
 		else
 			return 0;
 	case 300: // Rocket Ship Music Puzzle Slider State
@@ -770,18 +770,18 @@ void Myst::toggleVar(uint16 var) {
 		break;
 	case 24: // Fireplace Blue Page
 		if (_globals.ending != 4 && !(_globals.bluePagesInBook & 32)) {
-			if (_globals.heldPage == 6)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kBlueFirePlacePage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 6;
+				_globals.heldPage = kBlueFirePlacePage;
 		}
 		break;
 	case 25: // Fireplace Red page
 		if (_globals.ending != 4 && !(_globals.redPagesInBook & 32)) {
-			if (_globals.heldPage == 12)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kRedFirePlacePage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 12;
+				_globals.heldPage = kRedFirePlacePage;
 		}
 		break;
 	case 26: // Courtyard Image Box - Cross
@@ -804,27 +804,27 @@ void Myst::toggleVar(uint16 var) {
 		if (_globals.ending != 4) {
 			if (_dockVaultState == 1) {
 				_dockVaultState = 2;
-				_globals.heldPage = 0;
+				_globals.heldPage = kNoPage;
 			} else if (_dockVaultState == 2) {
 				_dockVaultState = 1;
-				_globals.heldPage = 13;
+				_globals.heldPage = kWhitePage;
 			}
 		}
 		break;
 	case 102: // Red page
 		if (_globals.ending != 4 && !(_globals.redPagesInBook & 1)) {
-			if (_globals.heldPage == 7)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kRedLibraryPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 7;
+				_globals.heldPage = kRedLibraryPage;
 		}
 		break;
 	case 103: // Blue page
 		if (_globals.ending != 4 && !(_globals.bluePagesInBook & 1)) {
-			if (_globals.heldPage == 1)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kBlueLibraryPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 1;
+				_globals.heldPage = kBlueLibraryPage;
 		}
 		break;
 	default:
@@ -1095,7 +1095,7 @@ void Myst::o_dockVaultOpen(uint16 var, const ArgumentsArray &args) {
 		(_state.observatoryMarkerSwitch == 1) &&
 		(_state.poolMarkerSwitch == 1) &&
 		(_state.rocketshipMarkerSwitch == 1)) {
-		if (_globals.heldPage != 13 && _globals.ending != 4)
+		if (_globals.heldPage != kWhitePage && _globals.ending != 4)
 			_dockVaultState = 2;
 		else
 			_dockVaultState = 1;
@@ -1139,7 +1139,7 @@ void Myst::o_bookGivePage(uint16 var, const ArgumentsArray &args) {
 	debugC(kDebugScript, "SoundId (Add Page): %d", soundIdAddPage);
 
 	// No page or white page
-	if (!_globals.heldPage || _globals.heldPage == 13) {
+	if (_globals.heldPage == kNoPage || _globals.heldPage == kWhitePage) {
 		_vm->changeToCard(cardIdBookCover, kTransitionDissolve);
 		return;
 	}
@@ -1148,40 +1148,40 @@ void Myst::o_bookGivePage(uint16 var, const ArgumentsArray &args) {
 	uint16 mask = 0;
 
 	switch (_globals.heldPage) {
-	case 7:
+	case kRedLibraryPage:
 		bookVar = 100;
 		// fallthrough
-	case 1:
+	case kBlueLibraryPage:
 		mask = 1;
 		break;
-	case 8:
+	case kRedSeleniticPage:
 		bookVar = 100;
 		// fallthrough
-	case 2:
+	case kBlueSeleniticPage:
 		mask = 2;
 		break;
-	case 9:
+	case kRedMechanicalPage:
 		bookVar = 100;
 		// fallthrough
-	case 3:
+	case kBlueMechanicalPage:
 		mask = 4;
 		break;
-	case 10:
+	case kRedStoneshipPage:
 		bookVar = 100;
 		// fallthrough
-	case 4:
+	case kBlueStoneshipPage:
 		mask = 8;
 		break;
-	case 11:
+	case kRedChannelwoodPage:
 		bookVar = 100;
 		// fallthrough
-	case 5:
+	case kBlueChannelwoodPage:
 		mask = 16;
 		break;
-	case 12:
+	case kRedFirePlacePage:
 		bookVar = 100;
 		// fallthrough
-	case 6:
+	case kBlueFirePlacePage:
 		mask = 32;
 		break;
 	}
@@ -1203,7 +1203,7 @@ void Myst::o_bookGivePage(uint16 var, const ArgumentsArray &args) {
 		_globals.bluePagesInBook |= mask;
 
 	// Remove page from hand
-	_globals.heldPage = 0;
+	_globals.heldPage = kNoPage;
 
 	_vm->_cursor->showCursor();
 

--- a/engines/mohawk/myst_stacks/selenitic.cpp
+++ b/engines/mohawk/myst_stacks/selenitic.cpp
@@ -190,9 +190,9 @@ uint16 Selenitic::getVar(uint16 var) {
 	case 33: // Maze runner at entry
 		return _mazeRunnerPosition != 288;
 	case 102: // Red page
-		return !(_globals.redPagesInBook & 2) && (_globals.heldPage != 8);
+		return !(_globals.redPagesInBook & 2) && (_globals.heldPage != kRedSeleniticPage);
 	case 103: // Blue page
-		return !(_globals.bluePagesInBook & 2) && (_globals.heldPage != 2);
+		return !(_globals.bluePagesInBook & 2) && (_globals.heldPage != kBlueSeleniticPage);
 	default:
 		return MystScriptParser::getVar(var);
 	}
@@ -223,18 +223,18 @@ void Selenitic::toggleVar(uint16 var) {
 		break;
 	case 102: // Red page
 		if (!(_globals.redPagesInBook & 2)) {
-			if (_globals.heldPage == 8)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kRedSeleniticPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 8;
+				_globals.heldPage = kRedSeleniticPage;
 		}
 		break;
 	case 103: // Blue page
 		if (!(_globals.bluePagesInBook & 2)) {
-			if (_globals.heldPage == 2)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kBlueSeleniticPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 2;
+				_globals.heldPage = kBlueSeleniticPage;
 		}
 		break;
 	default:

--- a/engines/mohawk/myst_stacks/stoneship.cpp
+++ b/engines/mohawk/myst_stacks/stoneship.cpp
@@ -280,9 +280,9 @@ uint16 Stoneship::getVar(uint16 var) {
 			return 0; // Closed
 		}
 	case 102: // Red page
-		return !(_globals.redPagesInBook & 8) && (_globals.heldPage != 10);
+		return !(_globals.redPagesInBook & 8) && (_globals.heldPage != kRedStoneshipPage);
 	case 103: // Blue page
-		return !(_globals.bluePagesInBook & 8) && (_globals.heldPage != 4);
+		return !(_globals.bluePagesInBook & 8) && (_globals.heldPage != kBlueStoneshipPage);
 	default:
 		return MystScriptParser::getVar(var);
 	}
@@ -334,18 +334,18 @@ void Stoneship::toggleVar(uint16 var) {
 		break;
 	case 102: // Red page
 		if (!(_globals.redPagesInBook & 8)) {
-			if (_globals.heldPage == 10)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kRedStoneshipPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 10;
+				_globals.heldPage = kRedStoneshipPage;
 		}
 		break;
 	case 103: // Blue page
 		if (!(_globals.bluePagesInBook & 8)) {
-			if (_globals.heldPage == 4)
-				_globals.heldPage = 0;
+			if (_globals.heldPage == kBlueStoneshipPage)
+				_globals.heldPage = kNoPage;
 			else
-				_globals.heldPage = 4;
+				_globals.heldPage = kBlueStoneshipPage;
 		}
 		break;
 	default:

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -121,13 +121,13 @@ bool MystGameState::load(int slot) {
 
 	// Set our default cursor
 	_vm->_cursor->showCursor();
-	if (_globals.heldPage == 0 || _globals.heldPage > 13)
+	if (_globals.heldPage == kNoPage || _globals.heldPage > kWhitePage) // TODO: This second condition can never happen
 		_vm->setMainCursor(kDefaultMystCursor);
-	else if (_globals.heldPage < 7)
+	else if (_globals.heldPage < kRedLibraryPage) //A blue page is held
 		_vm->setMainCursor(kBluePageCursor);
-	else if (_globals.heldPage < 13)
+	else if (_globals.heldPage < kWhitePage) //A red page is held
 		_vm->setMainCursor(kRedPageCursor);
-	else // if (globals.heldPage == 13)
+	else
 		_vm->setMainCursor(kWhitePageCursor);
 
 	return true;

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -121,7 +121,7 @@ bool MystGameState::load(int slot) {
 
 	// Set our default cursor
 	_vm->_cursor->showCursor();
-	if (_globals.heldPage == kNoPage || _globals.heldPage > kWhitePage) // TODO: This second condition can never happen
+	if (_globals.heldPage == kNoPage)
 		_vm->setMainCursor(kDefaultMystCursor);
 	else if (_globals.heldPage < kRedLibraryPage) //A blue page is held
 		_vm->setMainCursor(kBluePageCursor);

--- a/engines/mohawk/myst_state.h
+++ b/engines/mohawk/myst_state.h
@@ -53,6 +53,24 @@ struct MystSaveMetadata {
 	bool sync(Common::Serializer &s);
 };
 
+// Page being held
+enum HeldPage {
+	kNoPage              = 0,
+	kBlueLibraryPage     = 1,
+	kBlueSeleniticPage   = 2,
+	kBlueMechanicalPage  = 3,
+	kBlueStoneshipPage   = 4,
+	kBlueChannelwoodPage = 5,
+	kBlueFirePlacePage   = 6,
+	kRedLibraryPage      = 7,
+	kRedSeleniticPage    = 8,
+	kRedMechanicalPage   = 9,
+	kRedStoneshipPage    = 10,
+	kRedChannelwoodPage  = 11,
+	kRedFirePlacePage    = 12,
+	kWhitePage           = 13
+};
+
 class MystGameState {
 public:
 	MystGameState(MohawkEngine_Myst*, Common::SaveFileManager*);
@@ -81,7 +99,7 @@ public:
 	struct Globals {
 		uint16 u0;
 		uint16 currentAge;
-		uint16 heldPage;
+		HeldPage heldPage;
 		uint16 u1;
 		uint16 transitions;
 		uint16 zipMode;


### PR DESCRIPTION
Previously, the held page stage was an unsigned int 16
with values 0-13. The enum will make its state more clear.

Because enums are implicitly ints in c++03 and _global->heldPage
is an uint16 I have to typecast to uint16 when ever I compare
the enum. This is not ideal, but I still think the enum with
the cast is more clear.

I have also noted interesting behavior as TODO's.