### PR TITLE
COMMON: Use nullptr instead of NULL or 0 where appropriate

### DIFF
--- a/common/EventDispatcher.cpp
+++ b/common/EventDispatcher.cpp
@@ -24,7 +24,7 @@
 
 namespace Common {
 
-EventDispatcher::EventDispatcher() : _autoFreeMapper(false), _mapper(0) {
+EventDispatcher::EventDispatcher() : _autoFreeMapper(false), _mapper(nullptr) {
 }
 
 EventDispatcher::~EventDispatcher() {
@@ -41,7 +41,7 @@ EventDispatcher::~EventDispatcher() {
 	if (_autoFreeMapper) {
 		delete _mapper;
 	}
-	_mapper = 0;
+	_mapper = nullptr;
 }
 
 void EventDispatcher::dispatch() {

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -253,7 +253,7 @@ const ArchiveMemberPtr SearchSet::getMember(const String &name) const {
 
 SeekableReadStream *SearchSet::createReadStreamForMember(const String &name) const {
 	if (name.empty())
-		return 0;
+		return nullptr;
 
 	ArchiveNodeList::const_iterator it = _list.begin();
 	for (; it != _list.end(); ++it) {
@@ -262,7 +262,7 @@ SeekableReadStream *SearchSet::createReadStreamForMember(const String &name) con
 			return stream;
 	}
 
-	return 0;
+	return nullptr;
 }
 
 

--- a/common/array.h
+++ b/common/array.h
@@ -57,7 +57,7 @@ protected:
 	T *_storage;
 
 public:
-	Array() : _capacity(0), _size(0), _storage(0) {}
+	Array() : _capacity(0), _size(0), _storage(nullptr) {}
 
 	/**
 	 * Constructs an array with `count` default-inserted instances of T. No
@@ -77,7 +77,7 @@ public:
 		uninitialized_fill_n(_storage, count, value);
 	}
 
-	Array(const Array<T> &array) : _capacity(array._size), _size(array._size), _storage(0) {
+	Array(const Array<T> &array) : _capacity(array._size), _size(array._size), _storage(nullptr) {
 		if (array._storage) {
 			allocCapacity(_size);
 			uninitialized_copy(array._storage, array._storage + _size, _storage);
@@ -96,7 +96,7 @@ public:
 
 	~Array() {
 		freeStorage(_storage, _size);
-		_storage = 0;
+		_storage = nullptr;
 		_capacity = _size = 0;
 	}
 
@@ -216,7 +216,7 @@ public:
 
 	void clear() {
 		freeStorage(_storage, _size);
-		_storage = 0;
+		_storage = nullptr;
 		_size = 0;
 		_capacity = 0;
 	}
@@ -310,7 +310,7 @@ protected:
 			if (!_storage)
 				::error("Common::Array: failure to allocate %u bytes", capacity * (size_type)sizeof(T));
 		} else {
-			_storage = 0;
+			_storage = nullptr;
 		}
 	}
 

--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -52,7 +52,7 @@ char const *const ConfigManager::kCloudDomain = "cloud";
 #pragma mark -
 
 
-ConfigManager::ConfigManager() : _activeDomain(0) {
+ConfigManager::ConfigManager() : _activeDomain(nullptr) {
 }
 
 void ConfigManager::defragment() {
@@ -386,7 +386,7 @@ const ConfigManager::Domain *ConfigManager::getDomain(const String &domName) con
 	if (_miscDomains.contains(domName))
 		return &_miscDomains[domName];
 
-	return 0;
+	return nullptr;
 }
 
 ConfigManager::Domain *ConfigManager::getDomain(const String &domName) {
@@ -410,7 +410,7 @@ ConfigManager::Domain *ConfigManager::getDomain(const String &domName) {
 	if (_miscDomains.contains(domName))
 		return &_miscDomains[domName];
 
-	return 0;
+	return nullptr;
 }
 
 
@@ -620,7 +620,7 @@ void ConfigManager::registerDefault(const String &key, bool value) {
 
 void ConfigManager::setActiveDomain(const String &domName) {
 	if (domName.empty()) {
-		_activeDomain = 0;
+		_activeDomain = nullptr;
 	} else {
 		assert(isValidDomainName(domName));
 		_activeDomain = &_gameDomains[domName];
@@ -654,7 +654,7 @@ void ConfigManager::removeGameDomain(const String &domName) {
 	assert(isValidDomainName(domName));
 	if (domName == _activeDomainName) {
 		_activeDomainName.clear();
-		_activeDomain = 0;
+		_activeDomain = nullptr;
 	}
 	_gameDomains.erase(domName);
 }

--- a/common/coroutines.h
+++ b/common/coroutines.h
@@ -97,7 +97,7 @@ public:
 	~CoroContextHolder() {
 		if (_ctx && _ctx->_sleep == 0) {
 			delete _ctx;
-			_ctx = 0;
+			_ctx = nullptr;
 		}
 	}
 };
@@ -409,14 +409,14 @@ public:
 	 * If the specified process has already run on this tick, make it run
 	 * again on the current tick.
 	 */
-	void reschedule(PPROCESS pReSchedProc = NULL);
+	void reschedule(PPROCESS pReSchedProc = nullptr);
 
 	/**
 	 * Moves the specified process to the end of the dispatch queue
 	 * allowing it to run again within the current game cycle.
 	 * @param pGiveProc     Which process
 	 */
-	void giveWay(PPROCESS pReSchedProc = NULL);
+	void giveWay(PPROCESS pReSchedProc = nullptr);
 
 	/**
 	 * Continously makes a given process wait for another process to finish or event to signal.
@@ -425,7 +425,7 @@ public:
 	 * @param duration      Duration in milliseconds
 	 * @param expired       If specified, set to true if delay period expired
 	 */
-	void waitForSingleObject(CORO_PARAM, int pid, uint32 duration, bool *expired = NULL);
+	void waitForSingleObject(CORO_PARAM, int pid, uint32 duration, bool *expired = nullptr);
 
 	/**
 	 * Continously makes a given process wait for given prcesses to finished or events to be set
@@ -437,7 +437,7 @@ public:
 	 * @param expired       Set to true if delay period expired
 	 */
 	void waitForMultipleObjects(CORO_PARAM, int nCount, uint32 *pidList, bool bWaitAll,
-	                            uint32 duration, bool *expired = NULL);
+	                            uint32 duration, bool *expired = nullptr);
 
 	/**
 	 * Make the active process sleep for the given duration in milliseconds

--- a/common/dct.cpp
+++ b/common/dct.cpp
@@ -30,7 +30,7 @@
 
 namespace Common {
 
-DCT::DCT(int bits, TransformType trans) : _bits(bits), _cos(_bits + 2), _trans(trans), _rdft(0) {
+DCT::DCT(int bits, TransformType trans) : _bits(bits), _cos(_bits + 2), _trans(trans), _rdft(nullptr) {
 	int n = 1 << _bits;
 
 	_tCos = _cos.getTable();

--- a/common/fft.cpp
+++ b/common/fft.cpp
@@ -51,7 +51,7 @@ FFT::FFT(int bits, int inverse) : _bits(bits), _inverse(inverse) {
 		if (i+4 <= _bits)
 			_cosTables[i] = new Common::CosineTable(i+4);
 		else
-			_cosTables[i] = 0;
+			_cosTables[i] = nullptr;
 	}
 }
 

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -31,7 +31,7 @@
 namespace Common {
 
 File::File()
-	: _handle(0) {
+	: _handle(nullptr) {
 }
 
 File::~File() {
@@ -46,7 +46,7 @@ bool File::open(const String &filename, Archive &archive) {
 	assert(!filename.empty());
 	assert(!_handle);
 
-	SeekableReadStream *stream = 0;
+	SeekableReadStream *stream = nullptr;
 
 	if ((stream = archive.createReadStreamForMember(filename))) {
 		debug(8, "Opening hashed: %s", filename.c_str());
@@ -83,7 +83,7 @@ bool File::open(SeekableReadStream *stream, const String &name) {
 	} else {
 		debug(2, "File::open: opening '%s' failed", name.c_str());
 	}
-	return _handle != NULL;
+	return _handle != nullptr;
 }
 
 
@@ -101,11 +101,11 @@ bool File::exists(const String &filename) {
 
 void File::close() {
 	delete _handle;
-	_handle = NULL;
+	_handle = nullptr;
 }
 
 bool File::isOpen() const {
-	return _handle != NULL;
+	return _handle != nullptr;
 }
 
 bool File::err() const {
@@ -144,7 +144,7 @@ uint32 File::read(void *ptr, uint32 len) {
 }
 
 
-DumpFile::DumpFile() : _handle(0) {
+DumpFile::DumpFile() : _handle(nullptr) {
 }
 
 DumpFile::~DumpFile() {
@@ -182,19 +182,19 @@ bool DumpFile::open(const FSNode &node) {
 
 	_handle = node.createWriteStream();
 
-	if (_handle == NULL)
+	if (_handle == nullptr)
 		debug(2, "File %s not found", node.getName().c_str());
 
-	return _handle != NULL;
+	return _handle != nullptr;
 }
 
 void DumpFile::close() {
 	delete _handle;
-	_handle = NULL;
+	_handle = nullptr;
 }
 
 bool DumpFile::isOpen() const {
-	return _handle != NULL;
+	return _handle != nullptr;
 }
 
 bool DumpFile::err() const {

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -37,7 +37,7 @@ FSNode::FSNode(AbstractFSNode *realNode)
 FSNode::FSNode(const String &p) {
 	assert(g_system);
 	FilesystemFactory *factory = g_system->getFilesystemFactory();
-	AbstractFSNode *tmp = 0;
+	AbstractFSNode *tmp = nullptr;
 
 	if (p.empty() || p == ".")
 		tmp = factory->makeCurrentDirectoryFileNode();
@@ -62,7 +62,7 @@ bool FSNode::exists() const {
 
 FSNode FSNode::getChild(const String &n) const {
 	// If this node is invalid or not a directory, return an invalid node
-	if (_realNode == 0 || !_realNode->isDirectory())
+	if (_realNode == nullptr || !_realNode->isDirectory())
 		return FSNode();
 
 	AbstractFSNode *node = _realNode->getChild(n);
@@ -97,11 +97,11 @@ String FSNode::getName() const {
 }
 
 FSNode FSNode::getParent() const {
-	if (_realNode == 0)
+	if (_realNode == nullptr)
 		return *this;
 
 	AbstractFSNode *node = _realNode->getParent();
-	if (node == 0) {
+	if (node == nullptr) {
 		return *this;
 	} else {
 		return FSNode(node);
@@ -126,27 +126,27 @@ bool FSNode::isWritable() const {
 }
 
 SeekableReadStream *FSNode::createReadStream() const {
-	if (_realNode == 0)
-		return 0;
+	if (_realNode == nullptr)
+		return nullptr;
 
 	if (!_realNode->exists()) {
 		warning("FSNode::createReadStream: '%s' does not exist", getName().c_str());
-		return 0;
+		return nullptr;
 	} else if (_realNode->isDirectory()) {
 		warning("FSNode::createReadStream: '%s' is a directory", getName().c_str());
-		return 0;
+		return nullptr;
 	}
 
 	return _realNode->createReadStream();
 }
 
 WriteStream *FSNode::createWriteStream() const {
-	if (_realNode == 0)
-		return 0;
+	if (_realNode == nullptr)
+		return nullptr;
 
 	if (_realNode->isDirectory()) {
 		warning("FSNode::createWriteStream: '%s' is a directory", getName().c_str());
-		return 0;
+		return nullptr;
 	}
 
 	return _realNode->createWriteStream();
@@ -195,7 +195,7 @@ FSNode *FSDirectory::lookupCache(NodeCache &cache, const String &name) const {
 			return &cache[name];
 	}
 
-	return 0;
+	return nullptr;
 }
 
 bool FSDirectory::hasFile(const String &name) const {
@@ -225,11 +225,11 @@ const ArchiveMemberPtr FSDirectory::getMember(const String &name) const {
 
 SeekableReadStream *FSDirectory::createReadStreamForMember(const String &name) const {
 	if (name.empty() || !_node.isDirectory())
-		return 0;
+		return nullptr;
 
 	FSNode *node = lookupCache(_fileCache, name);
 	if (!node)
-		return 0;
+		return nullptr;
 	SeekableReadStream *stream = node->createReadStream();
 	if (!stream)
 		warning("FSDirectory::createReadStreamForMember: Can't create stream for file '%s'", name.c_str());
@@ -243,11 +243,11 @@ FSDirectory *FSDirectory::getSubDirectory(const String &name, int depth, bool fl
 
 FSDirectory *FSDirectory::getSubDirectory(const String &prefix, const String &name, int depth, bool flat) {
 	if (name.empty() || !_node.isDirectory())
-		return 0;
+		return nullptr;
 
 	FSNode *node = lookupCache(_subDirCache, name);
 	if (!node)
-		return 0;
+		return nullptr;
 
 	return new FSDirectory(prefix, *node, depth, flat);
 }

--- a/common/gui_options.cpp
+++ b/common/gui_options.cpp
@@ -85,7 +85,7 @@ const struct GameOpt {
 	{ GUIO_GAMEOPTIONS10, "gameOptionA" },
 	{ GUIO_GAMEOPTIONS11, "gameOptionB" },
 
-	{ GUIO_NONE, 0 }
+	{ GUIO_NONE, nullptr }
 };
 
 bool checkGameGUIOption(const String &option, const String &str) {

--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -178,16 +178,16 @@ private:
 		IteratorImpl(size_type idx, hashmap_t *hashmap) : _idx(idx), _hashmap(hashmap) {}
 
 		NodeType *deref() const {
-			assert(_hashmap != 0);
+			assert(_hashmap != nullptr);
 			assert(_idx <= _hashmap->_mask);
 			Node *node = _hashmap->_storage[_idx];
-			assert(node != 0);
+			assert(node != nullptr);
 			assert(node != HASHMAP_DUMMY_NODE);
 			return node;
 		}
 
 	public:
-		IteratorImpl() : _idx(0), _hashmap(0) {}
+		IteratorImpl() : _idx(0), _hashmap(nullptr) {}
 		template<class T>
 		IteratorImpl(const IteratorImpl<T> &c) : _idx(c._idx), _hashmap(c._hashmap) {}
 
@@ -201,7 +201,7 @@ private:
 			assert(_hashmap);
 			do {
 				_idx++;
-			} while (_idx <= _hashmap->_mask && (_hashmap->_storage[_idx] == 0 || _hashmap->_storage[_idx] == HASHMAP_DUMMY_NODE));
+			} while (_idx <= _hashmap->_mask && (_hashmap->_storage[_idx] == nullptr || _hashmap->_storage[_idx] == HASHMAP_DUMMY_NODE));
 			if (_idx > _hashmap->_mask)
 				_idx = (size_type)-1;
 
@@ -315,7 +315,7 @@ HashMap<Key, Val, HashFunc, EqualFunc>::HashMap()
 #endif
 	_mask = HASHMAP_MIN_CAPACITY - 1;
 	_storage = new Node *[HASHMAP_MIN_CAPACITY];
-	assert(_storage != NULL);
+	assert(_storage != nullptr);
 	memset(_storage, 0, HASHMAP_MIN_CAPACITY * sizeof(Node *));
 
 	_size = 0;
@@ -370,7 +370,7 @@ template<class Key, class Val, class HashFunc, class EqualFunc>
 void HashMap<Key, Val, HashFunc, EqualFunc>::assign(const HM_t &map) {
 	_mask = map._mask;
 	_storage = new Node *[_mask + 1];
-	assert(_storage != NULL);
+	assert(_storage != nullptr);
 	memset(_storage, 0, (_mask + 1) * sizeof(Node *));
 
 	// Simply clone the map given to us, one by one.
@@ -380,7 +380,7 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::assign(const HM_t &map) {
 		if (map._storage[ctr] == HASHMAP_DUMMY_NODE) {
 			_storage[ctr] = HASHMAP_DUMMY_NODE;
 			_deleted++;
-		} else if (map._storage[ctr] != NULL) {
+		} else if (map._storage[ctr] != nullptr) {
 			_storage[ctr] = allocNode(map._storage[ctr]->_key);
 			_storage[ctr]->_value = map._storage[ctr]->_value;
 			_size++;
@@ -396,7 +396,7 @@ template<class Key, class Val, class HashFunc, class EqualFunc>
 void HashMap<Key, Val, HashFunc, EqualFunc>::clear(bool shrinkArray) {
 	for (size_type ctr = 0; ctr <= _mask; ++ctr) {
 		freeNode(_storage[ctr]);
-		_storage[ctr] = NULL;
+		_storage[ctr] = nullptr;
 	}
 
 #ifdef USE_HASHMAP_MEMORY_POOL
@@ -408,7 +408,7 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::clear(bool shrinkArray) {
 
 		_mask = HASHMAP_MIN_CAPACITY;
 		_storage = new Node *[HASHMAP_MIN_CAPACITY];
-		assert(_storage != NULL);
+		assert(_storage != nullptr);
 		memset(_storage, 0, HASHMAP_MIN_CAPACITY * sizeof(Node *));
 	}
 
@@ -431,12 +431,12 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::expandStorage(size_type newCapacity
 	_deleted = 0;
 	_mask = newCapacity - 1;
 	_storage = new Node *[newCapacity];
-	assert(_storage != NULL);
+	assert(_storage != nullptr);
 	memset(_storage, 0, newCapacity * sizeof(Node *));
 
 	// rehash all the old elements
 	for (size_type ctr = 0; ctr <= old_mask; ++ctr) {
-		if (old_storage[ctr] == NULL || old_storage[ctr] == HASHMAP_DUMMY_NODE)
+		if (old_storage[ctr] == nullptr || old_storage[ctr] == HASHMAP_DUMMY_NODE)
 			continue;
 
 		// Insert the element from the old table into the new table.
@@ -445,7 +445,7 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::expandStorage(size_type newCapacity
 		// don't have to call _equal().
 		const size_type hash = _hash(old_storage[ctr]->_key);
 		size_type idx = hash & _mask;
-		for (size_type perturb = hash; _storage[idx] != NULL && _storage[idx] != HASHMAP_DUMMY_NODE; perturb >>= HASHMAP_PERTURB_SHIFT) {
+		for (size_type perturb = hash; _storage[idx] != nullptr && _storage[idx] != HASHMAP_DUMMY_NODE; perturb >>= HASHMAP_PERTURB_SHIFT) {
 			idx = (5 * idx + perturb + 1) & _mask;
 		}
 
@@ -467,7 +467,7 @@ typename HashMap<Key, Val, HashFunc, EqualFunc>::size_type HashMap<Key, Val, Has
 	const size_type hash = _hash(key);
 	size_type ctr = hash & _mask;
 	for (size_type perturb = hash; ; perturb >>= HASHMAP_PERTURB_SHIFT) {
-		if (_storage[ctr] == NULL)
+		if (_storage[ctr] == nullptr)
 			break;
 		if (_storage[ctr] == HASHMAP_DUMMY_NODE) {
 #ifdef DEBUG_HASH_COLLISIONS
@@ -501,7 +501,7 @@ typename HashMap<Key, Val, HashFunc, EqualFunc>::size_type HashMap<Key, Val, Has
 	size_type first_free = NONE_FOUND;
 	bool found = false;
 	for (size_type perturb = hash; ; perturb >>= HASHMAP_PERTURB_SHIFT) {
-		if (_storage[ctr] == NULL)
+		if (_storage[ctr] == nullptr)
 			break;
 		if (_storage[ctr] == HASHMAP_DUMMY_NODE) {
 #ifdef DEBUG_HASH_COLLISIONS
@@ -535,7 +535,7 @@ typename HashMap<Key, Val, HashFunc, EqualFunc>::size_type HashMap<Key, Val, Has
 		if (_storage[ctr])
 			_deleted--;
 		_storage[ctr] = allocNode(key);
-		assert(_storage[ctr] != NULL);
+		assert(_storage[ctr] != nullptr);
 		_size++;
 
 		// Keep the load factor below a certain threshold.
@@ -546,7 +546,7 @@ typename HashMap<Key, Val, HashFunc, EqualFunc>::size_type HashMap<Key, Val, Has
 			capacity = capacity < 500 ? (capacity * 4) : (capacity * 2);
 			expandStorage(capacity);
 			ctr = lookup(key);
-			assert(_storage[ctr] != NULL);
+			assert(_storage[ctr] != nullptr);
 		}
 	}
 
@@ -557,7 +557,7 @@ typename HashMap<Key, Val, HashFunc, EqualFunc>::size_type HashMap<Key, Val, Has
 template<class Key, class Val, class HashFunc, class EqualFunc>
 bool HashMap<Key, Val, HashFunc, EqualFunc>::contains(const Key &key) const {
 	size_type ctr = lookup(key);
-	return (_storage[ctr] != NULL);
+	return (_storage[ctr] != nullptr);
 }
 
 template<class Key, class Val, class HashFunc, class EqualFunc>
@@ -573,7 +573,7 @@ const Val &HashMap<Key, Val, HashFunc, EqualFunc>::operator[](const Key &key) co
 template<class Key, class Val, class HashFunc, class EqualFunc>
 Val &HashMap<Key, Val, HashFunc, EqualFunc>::getVal(const Key &key) {
 	size_type ctr = lookupAndCreateIfMissing(key);
-	assert(_storage[ctr] != NULL);
+	assert(_storage[ctr] != nullptr);
 	return _storage[ctr]->_value;
 }
 
@@ -585,7 +585,7 @@ const Val &HashMap<Key, Val, HashFunc, EqualFunc>::getVal(const Key &key) const 
 template<class Key, class Val, class HashFunc, class EqualFunc>
 const Val &HashMap<Key, Val, HashFunc, EqualFunc>::getVal(const Key &key, const Val &defaultVal) const {
 	size_type ctr = lookup(key);
-	if (_storage[ctr] != NULL)
+	if (_storage[ctr] != nullptr)
 		return _storage[ctr]->_value;
 	else
 		return defaultVal;
@@ -594,7 +594,7 @@ const Val &HashMap<Key, Val, HashFunc, EqualFunc>::getVal(const Key &key, const 
 template<class Key, class Val, class HashFunc, class EqualFunc>
 void HashMap<Key, Val, HashFunc, EqualFunc>::setVal(const Key &key, const Val &val) {
 	size_type ctr = lookupAndCreateIfMissing(key);
-	assert(_storage[ctr] != NULL);
+	assert(_storage[ctr] != nullptr);
 	_storage[ctr]->_value = val;
 }
 
@@ -619,7 +619,7 @@ template<class Key, class Val, class HashFunc, class EqualFunc>
 void HashMap<Key, Val, HashFunc, EqualFunc>::erase(const Key &key) {
 
 	size_type ctr = lookup(key);
-	if (_storage[ctr] == NULL)
+	if (_storage[ctr] == nullptr)
 		return;
 
 	// If we remove a key, we replace it with a dummy node.

--- a/common/huffman.h
+++ b/common/huffman.h
@@ -47,11 +47,11 @@ public:
 	 *  @param lengths Lengths of the individual codes.
 	 *  @param symbols The symbols. If 0, assume they are identical to the code indices.
 	 */
-	Huffman(uint8 maxLength, uint32 codeCount, const uint32 *codes, const uint8 *lengths, const uint32 *symbols = 0);
+	Huffman(uint8 maxLength, uint32 codeCount, const uint32 *codes, const uint8 *lengths, const uint32 *symbols = nullptr);
 	~Huffman();
 
 	/** Modify the codes' symbols. */
-	void setSymbols(const uint32 *symbols = 0);
+	void setSymbols(const uint32 *symbols = nullptr);
 
 	/** Return the next symbol in the bitstream. */
 	template<class BITSTREAM>

--- a/common/iff_container.cpp
+++ b/common/iff_container.cpp
@@ -34,7 +34,7 @@ IFFParser::~IFFParser() {
 	if (_disposeStream) {
 		delete _stream;
 	}
-	_stream = 0;
+	_stream = nullptr;
 }
 
 void IFFParser::setInputStream(ReadStream *stream) {

--- a/common/iff_container.h
+++ b/common/iff_container.h
@@ -172,7 +172,7 @@ class IFFParser {
 		IFF_ID id;
 		uint32 size;
 
-		IFFChunkNav() : _input(0) {
+		IFFChunkNav() : _input(nullptr) {
 		}
 		void setInputStream(ReadStream *input) {
 			_input = input;

--- a/common/ini-file.cpp
+++ b/common/ini-file.cpp
@@ -249,7 +249,7 @@ void INIFile::removeSection(const String &section) {
 bool INIFile::hasSection(const String &section) const {
 	assert(isValidName(section));
 	const Section *s = getSection(section);
-	return s != 0;
+	return s != nullptr;
 }
 
 void INIFile::renameSection(const String &oldName, const String &newName) {
@@ -341,7 +341,7 @@ INIFile::Section *INIFile::getSection(const String &section) {
 			return &(*i);
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 const INIFile::Section *INIFile::getSection(const String &section) const {
@@ -350,11 +350,11 @@ const INIFile::Section *INIFile::getSection(const String &section) const {
 			return &(*i);
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 bool INIFile::Section::hasKey(const String &key) const {
-	return getKey(key) != 0;
+	return getKey(key) != nullptr;
 }
 
 const INIFile::KeyValue* INIFile::Section::getKey(const String &key) const {
@@ -363,7 +363,7 @@ const INIFile::KeyValue* INIFile::Section::getKey(const String &key) const {
 			return &(*i);
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 void INIFile::Section::setKey(const String &key, const String &value) {

--- a/common/installshield_cab.cpp
+++ b/common/installshield_cab.cpp
@@ -174,7 +174,7 @@ const ArchiveMemberPtr InstallShieldCabinet::getMember(const String &name) const
 
 SeekableReadStream *InstallShieldCabinet::createReadStreamForMember(const String &name) const {
 	if (!_map.contains(name))
-		return 0;
+		return nullptr;
 
 	const FileEntry &entry = _map[name];
 
@@ -195,7 +195,7 @@ SeekableReadStream *InstallShieldCabinet::createReadStreamForMember(const String
 	if (!result) {
 		warning("failed to inflate CAB file '%s'", name.c_str());
 		free(dst);
-		return 0;
+		return nullptr;
 	}
 
 	return new MemoryReadStream(dst, entry.uncompressedSize, DisposeAfterUse::YES);

--- a/common/json.cpp
+++ b/common/json.cpp
@@ -76,17 +76,17 @@ JSON::JSON() {}
 JSONValue *JSON::parse(const char *data) {
 	// Skip any preceding whitespace, end of data = no JSON = fail
 	if (!skipWhitespace(&data))
-		return NULL;
+		return nullptr;
 
 	// We need the start of a value here now...
 	JSONValue *value = JSONValue::parse(&data);
-	if (value == NULL)
-		return NULL;
+	if (value == nullptr)
+		return nullptr;
 
 	// Can be white space now and should be at the end of the string then...
 	if (skipWhitespace(&data)) {
 		delete value;
-		return NULL;
+		return nullptr;
 	}
 
 	// We're now at the end of the string
@@ -103,7 +103,7 @@ JSONValue *JSON::parse(const char *data) {
 * @return String Returns a JSON encoded string representation of the given value
 */
 String JSON::stringify(const JSONValue *value) {
-	if (value != NULL)
+	if (value != nullptr)
 		return value->stringify();
 	else
 		return "";
@@ -276,7 +276,7 @@ JSONValue *JSONValue::parse(const char **data) {
 	if (**data == '"') {
 		String str;
 		if (!JSON::extractString(&(++(*data)), str))
-			return NULL;
+			return nullptr;
 		else
 			return new JSONValue(str);
 	}
@@ -310,7 +310,7 @@ JSONValue *JSONValue::parse(const char **data) {
 		else if (**data >= '1' && **data <= '9')
 			number = integer = JSON::parseInt(data);
 		else
-			return NULL;
+			return nullptr;
 
 		// Could be a decimal now...
 		if (**data == '.') {
@@ -318,7 +318,7 @@ JSONValue *JSONValue::parse(const char **data) {
 
 			// Not get any digits?
 			if (!(**data >= '0' && **data <= '9'))
-				return NULL;
+				return nullptr;
 
 			// Find the decimal and sort the decimal place out
 			// Use ParseDecimal as ParseInt won't work with decimals less than 0.1
@@ -343,7 +343,7 @@ JSONValue *JSONValue::parse(const char **data) {
 
 			// Not get any digits?
 			if (!(**data >= '0' && **data <= '9'))
-				return NULL;
+				return nullptr;
 
 			// Sort the expo out
 			double expo = JSON::parseInt(data);
@@ -371,7 +371,7 @@ JSONValue *JSONValue::parse(const char **data) {
 			// Whitespace at the start?
 			if (!JSON::skipWhitespace(data)) {
 				FREE_OBJECT(object);
-				return NULL;
+				return nullptr;
 			}
 
 			// Special case - empty object
@@ -384,32 +384,32 @@ JSONValue *JSONValue::parse(const char **data) {
 			String name;
 			if (!JSON::extractString(&(++(*data)), name)) {
 				FREE_OBJECT(object);
-				return NULL;
+				return nullptr;
 			}
 
 			// More whitespace?
 			if (!JSON::skipWhitespace(data)) {
 				FREE_OBJECT(object);
-				return NULL;
+				return nullptr;
 			}
 
 			// Need a : now
 			if (*((*data)++) != ':') {
 				FREE_OBJECT(object);
-				return NULL;
+				return nullptr;
 			}
 
 			// More whitespace?
 			if (!JSON::skipWhitespace(data)) {
 				FREE_OBJECT(object);
-				return NULL;
+				return nullptr;
 			}
 
 			// The value is here
 			JSONValue *value = parse(data);
-			if (value == NULL) {
+			if (value == nullptr) {
 				FREE_OBJECT(object);
-				return NULL;
+				return nullptr;
 			}
 
 			// Add the name:value
@@ -420,7 +420,7 @@ JSONValue *JSONValue::parse(const char **data) {
 			// More whitespace?
 			if (!JSON::skipWhitespace(data)) {
 				FREE_OBJECT(object);
-				return NULL;
+				return nullptr;
 			}
 
 			// End of object?
@@ -432,7 +432,7 @@ JSONValue *JSONValue::parse(const char **data) {
 			// Want a , now
 			if (**data != ',') {
 				FREE_OBJECT(object);
-				return NULL;
+				return nullptr;
 			}
 
 			(*data)++;
@@ -440,7 +440,7 @@ JSONValue *JSONValue::parse(const char **data) {
 
 		// Only here if we ran out of data
 		FREE_OBJECT(object);
-		return NULL;
+		return nullptr;
 	}
 
 	// An array?
@@ -453,7 +453,7 @@ JSONValue *JSONValue::parse(const char **data) {
 			// Whitespace at the start?
 			if (!JSON::skipWhitespace(data)) {
 				FREE_ARRAY(array);
-				return NULL;
+				return nullptr;
 			}
 
 			// Special case - empty array
@@ -464,9 +464,9 @@ JSONValue *JSONValue::parse(const char **data) {
 
 			// Get the value
 			JSONValue *value = parse(data);
-			if (value == NULL) {
+			if (value == nullptr) {
 				FREE_ARRAY(array);
-				return NULL;
+				return nullptr;
 			}
 
 			// Add the value
@@ -475,7 +475,7 @@ JSONValue *JSONValue::parse(const char **data) {
 			// More whitespace?
 			if (!JSON::skipWhitespace(data)) {
 				FREE_ARRAY(array);
-				return NULL;
+				return nullptr;
 			}
 
 			// End of array?
@@ -487,7 +487,7 @@ JSONValue *JSONValue::parse(const char **data) {
 			// Want a , now
 			if (**data != ',') {
 				FREE_ARRAY(array);
-				return NULL;
+				return nullptr;
 			}
 
 			(*data)++;
@@ -495,12 +495,12 @@ JSONValue *JSONValue::parse(const char **data) {
 
 		// Only here if we ran out of data
 		FREE_ARRAY(array);
-		return NULL;
+		return nullptr;
 	}
 
 	// Ran out of possibilites, it's bad!
 	else {
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -871,7 +871,7 @@ JSONValue *JSONValue::child(std::size_t index) {
 	if (index < _arrayValue->size()) {
 		return (*_arrayValue)[index];
 	} else {
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -905,7 +905,7 @@ JSONValue *JSONValue::child(const char *name) {
 	if (it != _objectValue->end()) {
 		return it->_value;
 	} else {
-		return NULL;
+		return nullptr;
 	}
 }
 

--- a/common/json.h
+++ b/common/json.h
@@ -65,7 +65,7 @@ static inline bool isinf(double x) {
 
 // Simple function to check a string 's' has at least 'n' characters
 static inline bool simplejson_wcsnlen(const char *s, size_t n) {
-	if (s == 0)
+	if (s == nullptr)
 		return false;
 
 	const char *save = s;

--- a/common/language.cpp
+++ b/common/language.cpp
@@ -52,7 +52,7 @@ const LanguageDescription g_languages[] = {
 	{    "ru", "ru_RU", "Russian", RU_RUS },
 	{    "es", "es_ES", "Spanish", ES_ESP },
 	{    "se", "sv_SE", "Swedish", SE_SWE },
-	{       0,       0, 0, UNK_LANG }
+	{ nullptr, nullptr, nullptr, UNK_LANG }
 };
 
 Language parseLanguage(const String &str) {
@@ -87,7 +87,7 @@ const char *getLanguageCode(Language id) {
 		if (l->id == id)
 			return l->code;
 	}
-	return 0;
+	return nullptr;
 }
 
 const char *getLanguageLocale(Language id) {
@@ -96,7 +96,7 @@ const char *getLanguageLocale(Language id) {
 		if (l->id == id)
 			return l->unixLocale;
 	}
-	return 0;
+	return nullptr;
 }
 
 const char *getLanguageDescription(Language id) {
@@ -105,7 +105,7 @@ const char *getLanguageDescription(Language id) {
 		if (l->id == id)
 			return l->description;
 	}
-	return 0;
+	return nullptr;
 }
 
 bool checkGameGUIOptionLanguage(Language lang, const String &str) {

--- a/common/list_intern.h
+++ b/common/list_intern.h
@@ -55,7 +55,7 @@ namespace ListInternal {
 
 		NodeBase *_node;
 
-		Iterator() : _node(0) {}
+		Iterator() : _node(nullptr) {}
 		explicit Iterator(NodeBase *node) : _node(node) {}
 
 		// Prefix inc
@@ -108,7 +108,7 @@ namespace ListInternal {
 
 		const NodeBase *_node;
 
-		ConstIterator() : _node(0) {}
+		ConstIterator() : _node(nullptr) {}
 		explicit ConstIterator(const NodeBase *node) : _node(node) {}
 		ConstIterator(const Iterator<T> &x) : _node(x._node) {}
 

--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -67,9 +67,9 @@ void MacResManager::close() {
 		delete[] _resLists[i];
 	}
 
-	delete[] _resLists; _resLists = 0;
-	delete[] _resTypes; _resTypes = 0;
-	delete _stream; _stream = 0;
+	delete[] _resLists; _resLists = nullptr;
+	delete[] _resTypes; _resTypes = nullptr;
+	delete _stream; _stream = nullptr;
 	_resMap.numTypes = 0;
 }
 
@@ -463,7 +463,7 @@ bool MacResManager::load(SeekableReadStream &stream) {
 
 SeekableReadStream *MacResManager::getDataFork() {
 	if (!_stream)
-		return NULL;
+		return nullptr;
 
 	if (_mode == kResForkMacBinary) {
 		_stream->seek(MBI_DFLEN);
@@ -476,7 +476,7 @@ SeekableReadStream *MacResManager::getDataFork() {
 		return file;
 	delete file;
 
-	return NULL;
+	return nullptr;
 }
 
 MacResIDArray MacResManager::getResIDArray(uint32 typeID) {
@@ -544,7 +544,7 @@ SeekableReadStream *MacResManager::getResource(uint32 typeID, uint16 resID) {
 		}
 
 	if (typeNum == -1)
-		return NULL;
+		return nullptr;
 
 	for (int i = 0; i < _resTypes[typeNum].items; i++)
 		if (_resLists[typeNum][i].id == resID) {
@@ -553,14 +553,14 @@ SeekableReadStream *MacResManager::getResource(uint32 typeID, uint16 resID) {
 		}
 
 	if (resNum == -1)
-		return NULL;
+		return nullptr;
 
 	_stream->seek(_dataOffset + _resLists[typeNum][resNum].dataOffset);
 	uint32 len = _stream->readUint32BE();
 
 	// Ignore resources with 0 length
 	if (!len)
-		return 0;
+		return nullptr;
 
 	return _stream->readStream(len);
 }
@@ -574,14 +574,14 @@ SeekableReadStream *MacResManager::getResource(const String &fileName) {
 
 				// Ignore resources with 0 length
 				if (!len)
-					return 0;
+					return nullptr;
 
 				return _stream->readStream(len);
 			}
 		}
 	}
 
-	return 0;
+	return nullptr;
 }
 
 SeekableReadStream *MacResManager::getResource(uint32 typeID, const String &fileName) {
@@ -596,14 +596,14 @@ SeekableReadStream *MacResManager::getResource(uint32 typeID, const String &file
 
 				// Ignore resources with 0 length
 				if (!len)
-					return 0;
+					return nullptr;
 
 				return _stream->readStream(len);
 			}
 		}
 	}
 
-	return 0;
+	return nullptr;
 }
 
 void MacResManager::readMap() {
@@ -640,7 +640,7 @@ void MacResManager::readMap() {
 			resPtr->nameOffset = _stream->readUint16BE();
 			resPtr->dataOffset = _stream->readUint32BE();
 			_stream->readUint32BE();
-			resPtr->name = 0;
+			resPtr->name = nullptr;
 
 			resPtr->attr = resPtr->dataOffset >> 24;
 			resPtr->dataOffset &= 0xFFFFFF;

--- a/common/memorypool.cpp
+++ b/common/memorypool.cpp
@@ -43,7 +43,7 @@ static size_t adjustChunkSize(size_t chunkSize) {
 MemoryPool::MemoryPool(size_t chunkSize)
 	: _chunkSize(adjustChunkSize(chunkSize)) {
 
-	_next = NULL;
+	_next = nullptr;
 
 	_chunksPerPage = INITIAL_CHUNKS_PER_PAGE;
 }
@@ -154,7 +154,7 @@ void MemoryPool::freeUnusedPages() {
 
 			::free(_pages[i].start);
 			++freedPagesCount;
-			_pages[i].start = NULL;
+			_pages[i].start = nullptr;
 		}
 	}
 
@@ -163,7 +163,7 @@ void MemoryPool::freeUnusedPages() {
 	// Remove all now unused pages
 	size_t newSize = 0;
 	for (size_t i = 0; i < _pages.size(); ++i) {
-		if (_pages[i].start != NULL) {
+		if (_pages[i].start != nullptr) {
 			if (newSize != i)
 				_pages[newSize] = _pages[i];
 			++newSize;

--- a/common/memstream.h
+++ b/common/memstream.h
@@ -184,7 +184,7 @@ protected:
 		_size = new_len;
 	}
 public:
-	explicit MemoryWriteStreamDynamic(DisposeAfterUse::Flag disposeMemory) : _capacity(0), _size(0), _ptr(0), _data(0), _pos(0), _disposeMemory(disposeMemory) {}
+	explicit MemoryWriteStreamDynamic(DisposeAfterUse::Flag disposeMemory) : _capacity(0), _size(0), _ptr(nullptr), _data(nullptr), _pos(0), _disposeMemory(disposeMemory) {}
 
 	~MemoryWriteStreamDynamic() {
 		if (_disposeMemory)
@@ -247,7 +247,7 @@ private:
 		}
 	}
 public:
-	explicit MemoryReadWriteStream(DisposeAfterUse::Flag disposeMemory) : _capacity(0), _size(0), _data(0), _writePos(0), _readPos(0), _pos(0), _length(0), _disposeMemory(disposeMemory), _eos(false) {}
+	explicit MemoryReadWriteStream(DisposeAfterUse::Flag disposeMemory) : _capacity(0), _size(0), _data(nullptr), _writePos(0), _readPos(0), _pos(0), _length(0), _disposeMemory(disposeMemory), _eos(false) {}
 
 	~MemoryReadWriteStream() {
 		if (_disposeMemory)

--- a/common/mutex.cpp
+++ b/common/mutex.cpp
@@ -62,14 +62,14 @@ StackLock::~StackLock() {
 }
 
 void StackLock::lock() {
-	if (_mutexName != NULL)
+	if (_mutexName != nullptr)
 		debug(6, "Locking mutex %s", _mutexName);
 
 	g_system->lockMutex(_mutex);
 }
 
 void StackLock::unlock() {
-	if (_mutexName != NULL)
+	if (_mutexName != nullptr)
 		debug(6, "Unlocking mutex %s", _mutexName);
 
 	g_system->unlockMutex(_mutex);

--- a/common/mutex.h
+++ b/common/mutex.h
@@ -46,8 +46,8 @@ class StackLock {
 	void lock();
 	void unlock();
 public:
-	explicit StackLock(MutexRef mutex, const char *mutexName = NULL);
-	explicit StackLock(const Mutex &mutex, const char *mutexName = NULL);
+	explicit StackLock(MutexRef mutex, const char *mutexName = nullptr);
+	explicit StackLock(const Mutex &mutex, const char *mutexName = nullptr);
 	~StackLock();
 };
 

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -56,7 +56,7 @@ const PlatformDescription g_platforms[] = {
 	{ "os2", "os2", "os2", "OS/2", kPlatformOS2 },
 	{ "beos", "beos", "beos", "BeOS", kPlatformBeOS },
 
-	{ 0, 0, 0, "Default", kPlatformUnknown }
+	{ nullptr, nullptr, nullptr, "Default", kPlatformUnknown }
 };
 
 Platform parsePlatform(const String &str) {
@@ -88,7 +88,7 @@ const char *getPlatformCode(Platform id) {
 		if (l->id == id)
 			return l->code;
 	}
-	return 0;
+	return nullptr;
 }
 
 const char *getPlatformAbbrev(Platform id) {
@@ -97,7 +97,7 @@ const char *getPlatformAbbrev(Platform id) {
 		if (l->id == id)
 			return l->abbrev;
 	}
-	return 0;
+	return nullptr;
 }
 
 const char *getPlatformDescription(Platform id) {

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -109,7 +109,7 @@ public:
 	typedef T *PointerType;
 	typedef T &ReferenceType;
 
-	SharedPtr() : _refCount(0), _deletion(0), _pointer(0) {}
+	SharedPtr() : _refCount(nullptr), _deletion(nullptr), _pointer(nullptr) {}
 
 	template<class T2>
 	explicit SharedPtr(T2 *p) : _refCount(new RefValue(1)), _deletion(new SharedPtrDeletionImpl<T2>(p)), _pointer(p) {}
@@ -206,9 +206,9 @@ private:
 			if (!*_refCount) {
 				delete _refCount;
 				delete _deletion;
-				_deletion = 0;
-				_refCount = 0;
-				_pointer = 0;
+				_deletion = nullptr;
+				_refCount = nullptr;
+				_pointer = nullptr;
 			}
 		}
 	}

--- a/common/quicktime.cpp
+++ b/common/quicktime.cpp
@@ -45,7 +45,7 @@ namespace Common {
 
 QuickTimeParser::QuickTimeParser() {
 	_beginOffset = 0;
-	_fd = 0;
+	_fd = nullptr;
 	_scaleFactorX = 1;
 	_scaleFactorY = 1;
 	_resFork = new MacResManager();
@@ -166,7 +166,7 @@ void QuickTimeParser::initParseTable() {
 		{ &QuickTimeParser::readSMI,     MKTAG('S', 'M', 'I', ' ') },
 		{ &QuickTimeParser::readDefault, MKTAG('g', 'm', 'h', 'd') },
 		{ &QuickTimeParser::readLeaf,    MKTAG('g', 'm', 'i', 'n') },
-		{ 0, 0 }
+		{ nullptr, 0 }
 	};
 
 	_parseTable = p;
@@ -805,13 +805,13 @@ void QuickTimeParser::close() {
 	if (_disposeFileHandle == DisposeAfterUse::YES)
 		delete _fd;
 
-	_fd = 0;
+	_fd = nullptr;
 }
 
 QuickTimeParser::SampleDesc::SampleDesc(Track *parentTrack, uint32 codecTag) {
 	_parentTrack = parentTrack;
 	_codecTag = codecTag;
-	_extraData = 0;
+	_extraData = nullptr;
 	_objectTypeMP4 = 0;
 }
 
@@ -821,16 +821,16 @@ QuickTimeParser::SampleDesc::~SampleDesc() {
 
 QuickTimeParser::Track::Track() {
 	chunkCount = 0;
-	chunkOffsets = 0;
+	chunkOffsets = nullptr;
 	timeToSampleCount = 0;
-	timeToSample = 0;
+	timeToSample = nullptr;
 	sampleToChunkCount = 0;
-	sampleToChunk = 0;
+	sampleToChunk = nullptr;
 	sampleSize = 0;
 	sampleCount = 0;
-	sampleSizes = 0;
+	sampleSizes = nullptr;
 	keyframeCount = 0;
-	keyframes = 0;
+	keyframes = nullptr;
 	timeScale = 0;
 	width = 0;
 	height = 0;

--- a/common/quicktime.h
+++ b/common/quicktime.h
@@ -79,7 +79,7 @@ public:
 	void setChunkBeginOffset(uint32 offset) { _beginOffset = offset; }
 
 	/** Find out if this parser has an open file handle */
-	bool isOpen() const { return _fd != 0; }
+	bool isOpen() const { return _fd != nullptr; }
 
 protected:
 	// This is the file handle from which data is read from. It can be the actual file handle or a decompressed stream.

--- a/common/rdft.cpp
+++ b/common/rdft.cpp
@@ -28,7 +28,7 @@
 
 namespace Common {
 
-RDFT::RDFT(int bits, TransformType trans) : _bits(bits), _sin(bits), _cos(bits), _fft(0) {
+RDFT::RDFT(int bits, TransformType trans) : _bits(bits), _sin(bits), _cos(bits), _fft(nullptr) {
 	assert((_bits >= 4) && (_bits <= 16));
 
 	_inverse        = trans == IDFT_C2R || trans == DFT_C2R;

--- a/common/rendermode.cpp
+++ b/common/rendermode.cpp
@@ -44,7 +44,7 @@ const RenderModeDescription g_renderModes[] = {
 	{ "2gs", "Apple IIgs", kRenderApple2GS },
 	{ "atari", "Atari ST", kRenderAtariST },
 	{ "macintosh", "Macintosh", kRenderMacintosh },
-	{0, 0, kRenderDefault}
+	{nullptr, nullptr, kRenderDefault}
 };
 
 struct RenderGUIOMapping {
@@ -92,7 +92,7 @@ const char *getRenderModeCode(RenderMode id) {
 		if (l->id == id)
 			return l->code;
 	}
-	return 0;
+	return nullptr;
 }
 
 const char *getRenderModeDescription(RenderMode id) {
@@ -101,7 +101,7 @@ const char *getRenderModeDescription(RenderMode id) {
 		if (l->id == id)
 			return l->description;
 	}
-	return 0;
+	return nullptr;
 }
 
 String renderMode2GUIO(RenderMode id) {

--- a/common/safe-bool.h
+++ b/common/safe-bool.h
@@ -52,7 +52,7 @@ namespace Common {
 	public:
 		operator bool_type() const {
 			return static_cast<const DerivedT *>(this)->operator_bool() ?
-			&impl_t::stub : 0;
+			&impl_t::stub : nullptr;
 		}
 
 		operator bool_type() {

--- a/common/str.cpp
+++ b/common/str.cpp
@@ -28,7 +28,7 @@
 
 namespace Common {
 
-MemoryPool *g_refCountPool = 0; // FIXME: This is never freed right now
+MemoryPool *g_refCountPool = nullptr; // FIXME: This is never freed right now
 
 static uint32 computeCapacity(uint32 len) {
 	// By default, for the capacity we use the next multiple of 32
@@ -36,7 +36,7 @@ static uint32 computeCapacity(uint32 len) {
 }
 
 String::String(const char *str) : _size(0), _str(_storage) {
-	if (str == 0) {
+	if (str == nullptr) {
 		_storage[0] = 0;
 		_size = 0;
 	} else
@@ -64,9 +64,9 @@ void String::initWithCStr(const char *str, uint32 len) {
 	if (len >= _builtinCapacity) {
 		// Not enough internal storage, so allocate more
 		_extern._capacity = computeCapacity(len + 1);
-		_extern._refCount = 0;
+		_extern._refCount = nullptr;
 		_str = new char[_extern._capacity];
-		assert(_str != 0);
+		assert(_str != nullptr);
 	}
 
 	// Copy the string into the storage area
@@ -87,7 +87,7 @@ String::String(const String &str)
 		_extern._capacity = str._extern._capacity;
 		_str = str._str;
 	}
-	assert(_str != 0);
+	assert(_str != nullptr);
 }
 
 String::String(char c)
@@ -165,15 +165,15 @@ void String::ensureCapacity(uint32 new_size, bool keep_old) {
 		// Set the ref count & capacity if we use an external storage.
 		// It is important to do this *after* copying any old content,
 		// else we would override data that has not yet been copied!
-		_extern._refCount = 0;
+		_extern._refCount = nullptr;
 		_extern._capacity = newCapacity;
 	}
 }
 
 void String::incRefCount() const {
 	assert(!isStorageIntern());
-	if (_extern._refCount == 0) {
-		if (g_refCountPool == 0) {
+	if (_extern._refCount == nullptr) {
+		if (g_refCountPool == nullptr) {
 			g_refCountPool = new MemoryPool(sizeof(int));
 			assert(g_refCountPool);
 		}
@@ -290,7 +290,7 @@ bool String::hasPrefix(const String &x) const {
 }
 
 bool String::hasPrefix(const char *x) const {
-	assert(x != 0);
+	assert(x != nullptr);
 	// Compare x with the start of _str.
 	const char *y = c_str();
 	while (*x && *x == *y) {
@@ -307,7 +307,7 @@ bool String::hasSuffix(const String &x) const {
 }
 
 bool String::hasSuffix(const char *x) const {
-	assert(x != 0);
+	assert(x != nullptr);
 	// Compare x with the end of _str.
 	const uint32 x_size = strlen(x);
 	if (x_size > _size)
@@ -323,16 +323,16 @@ bool String::hasSuffix(const char *x) const {
 }
 
 bool String::contains(const String &x) const {
-	return strstr(c_str(), x.c_str()) != NULL;
+	return strstr(c_str(), x.c_str()) != nullptr;
 }
 
 bool String::contains(const char *x) const {
-	assert(x != 0);
-	return strstr(c_str(), x) != NULL;
+	assert(x != nullptr);
+	return strstr(c_str(), x) != nullptr;
 }
 
 bool String::contains(char x) const {
-	return strchr(c_str(), x) != NULL;
+	return strchr(c_str(), x) != nullptr;
 }
 
 uint64 String::asUint64() const {
@@ -610,7 +610,7 @@ bool String::operator==(const String &x) const {
 }
 
 bool String::operator==(const char *x) const {
-	assert(x != 0);
+	assert(x != nullptr);
 	return equals(x);
 }
 
@@ -619,7 +619,7 @@ bool String::operator!=(const String &x) const {
 }
 
 bool String::operator !=(const char *x) const {
-	assert(x != 0);
+	assert(x != nullptr);
 	return !equals(x);
 }
 
@@ -656,7 +656,7 @@ bool String::equals(const String &x) const {
 }
 
 bool String::equals(const char *x) const {
-	assert(x != 0);
+	assert(x != nullptr);
 	return (0 == compareTo(x));
 }
 
@@ -665,7 +665,7 @@ bool String::equalsIgnoreCase(const String &x) const {
 }
 
 bool String::equalsIgnoreCase(const char *x) const {
-	assert(x != 0);
+	assert(x != nullptr);
 	return (0 == compareToIgnoreCase(x));
 }
 
@@ -674,7 +674,7 @@ int String::compareTo(const String &x) const {
 }
 
 int String::compareTo(const char *x) const {
-	assert(x != 0);
+	assert(x != nullptr);
 	return strcmp(c_str(), x);
 }
 
@@ -683,7 +683,7 @@ int String::compareToIgnoreCase(const String &x) const {
 }
 
 int String::compareToIgnoreCase(const char *x) const {
-	assert(x != 0);
+	assert(x != nullptr);
 	return scumm_stricmp(c_str(), x);
 }
 
@@ -815,13 +815,13 @@ bool matchString(const char *str, const char *pat, bool ignoreCase, bool pathMod
 	assert(str);
 	assert(pat);
 
-	const char *p = 0;
-	const char *q = 0;
+	const char *p = nullptr;
+	const char *q = nullptr;
 
 	for (;;) {
 		if (pathMode && *str == '/') {
-			p = 0;
-			q = 0;
+			p = nullptr;
+			q = nullptr;
 			if (*pat == '?')
 				return false;
 		}
@@ -837,8 +837,8 @@ bool matchString(const char *str, const char *pat, bool ignoreCase, bool pathMod
 				// NB: We can't simply check if pat also ended here, because
 				// the pattern might end with any number of *s.
 				++pat;
-				p = 0;
-				q = 0;
+				p = nullptr;
+				q = nullptr;
 			}
 			// If pattern ended with * -> match
 			if (!*pat)

--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -135,7 +135,7 @@ enum {
 };
 
 char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
-	assert(buf != 0 && bufSize > 1);
+	assert(buf != nullptr && bufSize > 1);
 	char *p = buf;
 	size_t len = 0;
 	char c = 0;
@@ -143,7 +143,7 @@ char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
 	// If end-of-file occurs before any characters are read, return NULL
 	// and the buffer contents remain unchanged.
 	if (eos() || err()) {
-		return 0;
+		return nullptr;
 	}
 
 	// Loop as long as there is still free space in the buffer,
@@ -155,7 +155,7 @@ char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
 			// If end-of-file occurs before any characters are read, return
 			// NULL and the buffer contents remain unchanged.
 			if (len == 0)
-				return 0;
+				return nullptr;
 
 			break;
 		}
@@ -163,7 +163,7 @@ char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
 		// If an error occurs, return NULL and the buffer contents
 		// are indeterminate.
 		if (err())
-			return 0;
+			return nullptr;
 
 		// Check for CR or CR/LF
 		// * DOS and Windows use CRLF line breaks
@@ -174,7 +174,7 @@ char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
 			c = readByte();
 
 			if (err()) {
-				return 0; // error: the buffer contents are indeterminate
+				return nullptr; // error: the buffer contents are indeterminate
 			}
 			if (eos()) {
 				// The CR was the last character in the file.
@@ -382,7 +382,7 @@ uint32 BufferedReadStream::read(void *dataPtr, uint32 dataSize) {
 ReadStream *wrapBufferedReadStream(ReadStream *parentStream, uint32 bufSize, DisposeAfterUse::Flag disposeParentStream) {
 	if (parentStream)
 		return new BufferedReadStream(parentStream, bufSize, disposeParentStream);
-	return 0;
+	return nullptr;
 }
 
 #pragma mark -
@@ -459,7 +459,7 @@ bool BufferedSeekableReadStream::seek(int32 offset, int whence) {
 SeekableReadStream *wrapBufferedSeekableReadStream(SeekableReadStream *parentStream, uint32 bufSize, DisposeAfterUse::Flag disposeParentStream) {
 	if (parentStream)
 		return new BufferedSeekableReadStream(parentStream, bufSize, disposeParentStream);
-	return 0;
+	return nullptr;
 }
 
 #pragma mark -
@@ -543,7 +543,7 @@ public:
 WriteStream *wrapBufferedWriteStream(WriteStream *parentStream, uint32 bufSize) {
 	if (parentStream)
 		return new BufferedWriteStream(parentStream, bufSize);
-	return 0;
+	return nullptr;
 }
 
 } // End of namespace Common

--- a/common/system.cpp
+++ b/common/system.cpp
@@ -35,47 +35,47 @@
 #include "backends/fs/fs-factory.h"
 #include "backends/timer/default/default-timer.h"
 
-OSystem *g_system = 0;
+OSystem *g_system = nullptr;
 
 OSystem::OSystem() {
-	_audiocdManager = 0;
-	_eventManager = 0;
-	_timerManager = 0;
-	_savefileManager = 0;
+	_audiocdManager = nullptr;
+	_eventManager = nullptr;
+	_timerManager = nullptr;
+	_savefileManager = nullptr;
 #if defined(USE_TASKBAR)
-	_taskbarManager = 0;
+	_taskbarManager = nullptr;
 #endif
 #if defined(USE_UPDATES)
-	_updateManager = 0;
+	_updateManager = nullptr;
 #endif
-	_fsFactory = 0;
+	_fsFactory = nullptr;
 }
 
 OSystem::~OSystem() {
 	delete _audiocdManager;
-	_audiocdManager = 0;
+	_audiocdManager = nullptr;
 
 	delete _eventManager;
-	_eventManager = 0;
+	_eventManager = nullptr;
 
 	delete _timerManager;
-	_timerManager = 0;
+	_timerManager = nullptr;
 
 #if defined(USE_TASKBAR)
 	delete _taskbarManager;
-	_taskbarManager = 0;
+	_taskbarManager = nullptr;
 #endif
 
 #if defined(USE_UPDATES)
 	delete _updateManager;
-	_updateManager = 0;
+	_updateManager = nullptr;
 #endif
 
 	delete _savefileManager;
-	_savefileManager = 0;
+	_savefileManager = nullptr;
 
 	delete _fsFactory;
-	_fsFactory = 0;
+	_fsFactory = nullptr;
 }
 
 void OSystem::initBackend() {
@@ -138,7 +138,7 @@ Common::SeekableReadStream *OSystem::createConfigReadStream() {
 
 Common::WriteStream *OSystem::createConfigWriteStream() {
 #ifdef __DC__
-	return 0;
+	return nullptr;
 #else
 	Common::FSNode file(getDefaultConfigFileName());
 	return file.createWriteStream();

--- a/common/system.h
+++ b/common/system.h
@@ -587,7 +587,7 @@ public:
 	 * @return a list of supported shaders
 	 */
 	virtual const GraphicsMode *getSupportedShaders() const {
-		static const OSystem::GraphicsMode no_shader[2] = {{"NONE", "Normal (no shader)", 0}, {0, 0, 0}};
+		static const OSystem::GraphicsMode no_shader[2] = {{"NONE", "Normal (no shader)", 0}, {nullptr, nullptr, 0}};
 		return no_shader;
 	}
 
@@ -632,7 +632,7 @@ public:
 	 * @param height	the new virtual screen height
 	 * @param format	the new virtual screen pixel format
 	 */
-	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) = 0;
+	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = nullptr) = 0;
 
 	/**
 	 * Send a list of graphics modes to the backend so it can make a decision
@@ -964,7 +964,7 @@ public:
 	 *                          would be too small to notice otherwise, these are allowed to scale the cursor anyway.
 	 * @param format			pointer to the pixel format which cursor graphic uses (0 means CLUT8)
 	 */
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) = 0;
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr) = 0;
 
 	/**
 	 * Replace the specified range of cursor the palette with new colors.
@@ -1028,7 +1028,7 @@ public:
 	 *
 	 * See keymapper documentation for further reference.
 	 */
-	virtual Common::HardwareInputSet *getHardwareInputSet() { return 0; }
+	virtual Common::HardwareInputSet *getHardwareInputSet() { return nullptr; }
 
 	/**
 	 * Return a platform-specific global keymap
@@ -1041,7 +1041,7 @@ public:
 	 *
 	 * See keymapper documentation for further reference.
 	 */
-	virtual Common::Keymap *getGlobalKeymap() { return 0; }
+	virtual Common::Keymap *getGlobalKeymap() { return nullptr; }
 
 	/**
 	 * Return platform-specific default keybindings
@@ -1052,7 +1052,7 @@ public:
 	 *
 	 * See keymapper documentation for further reference.
 	 */
-	virtual Common::KeymapperDefaultBindings *getKeymapperDefaultBindings() { return 0; }
+	virtual Common::KeymapperDefaultBindings *getKeymapperDefaultBindings() { return nullptr; }
 #endif
 	//@}
 

--- a/common/textconsole.cpp
+++ b/common/textconsole.cpp
@@ -28,13 +28,13 @@
 
 namespace Common {
 
-static OutputFormatter s_errorOutputFormatter = 0;
+static OutputFormatter s_errorOutputFormatter = nullptr;
 
 void setErrorOutputFormatter(OutputFormatter f) {
 	s_errorOutputFormatter = f;
 }
 
-static ErrorHandler s_errorHandler = 0;
+static ErrorHandler s_errorHandler = nullptr;
 
 void setErrorHandler(ErrorHandler handler) {
 	s_errorHandler = handler;

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -46,7 +46,7 @@ bool operator<(const TLanguage &l, const TLanguage &r) {
 	return strcmp(l.name, r.name) < 0;
 }
 
-TranslationManager::TranslationManager() : _currentLang(-1), _charmap(0) {
+TranslationManager::TranslationManager() : _currentLang(-1), _charmap(nullptr) {
 	loadTranslationsInfoDat();
 
 	// Set the default language
@@ -110,7 +110,7 @@ void TranslationManager::setLanguage(const String &lang) {
 }
 
 const char *TranslationManager::getTranslation(const char *message) const {
-	return getTranslation(message, NULL);
+	return getTranslation(message, nullptr);
 }
 
 const char *TranslationManager::getTranslation(const char *message, const char *context) const {
@@ -144,7 +144,7 @@ const char *TranslationManager::getTranslation(const char *message, const char *
 				++rightIndex;
 			}
 			// Find the context we want
-			if (context == NULL || *context == '\0' || leftIndex == rightIndex)
+			if (context == nullptr || *context == '\0' || leftIndex == rightIndex)
 				return _currentTranslationMessages[leftIndex].msgstr.c_str();
 			// We could use again binary search, but there should be only a small number of contexts.
 			while (rightIndex > leftIndex) {
@@ -416,7 +416,7 @@ void TranslationManager::loadLanguageDat(int index) {
 	// Setup the new charset mapping
 	if (charmapNum == -1) {
 		delete[] _charmap;
-		_charmap = 0;
+		_charmap = nullptr;
 	} else {
 		if (!_charmap)
 			_charmap = new uint32[256];

--- a/common/translation.h
+++ b/common/translation.h
@@ -44,7 +44,7 @@ struct TLanguage {
 	const char *name;
 	int id;
 
-	TLanguage() : name(0), id(0) {}
+	TLanguage() : name(nullptr), id(0) {}
 	TLanguage(const char *n, int i) : name(n), id(i) {}
 };
 

--- a/common/unarj.cpp
+++ b/common/unarj.cpp
@@ -95,8 +95,8 @@ class ArjDecoder {
 public:
 	ArjDecoder(const ArjHeader *hdr) {
 		_compsize = hdr->compSize;
-		_compressed = 0;
-		_outstream = 0;
+		_compressed = nullptr;
+		_outstream = nullptr;
 		_bitbuf = 0;
 		_bytebuf = 0;
 		_bitcount = 0;
@@ -251,16 +251,16 @@ ArjHeader *readHeader(SeekableReadStream &stream) {
 	if (header.id != HEADER_ID) {
 		warning("ArjFile::readHeader(): Bad header ID (%x)", header.id);
 
-		return NULL;
+		return nullptr;
 	}
 
 	header.headerSize = stream.readUint16LE();
 	if (header.headerSize == 0)
-		return NULL;			// end of archive
+		return nullptr;			// end of archive
 	if (header.headerSize > HEADERSIZE_MAX) {
 		warning("ArjFile::readHeader(): Bad header");
 
-		return NULL;
+		return nullptr;
 	}
 
 	int rSize = stream.read(headData, header.headerSize);
@@ -270,7 +270,7 @@ ArjHeader *readHeader(SeekableReadStream &stream) {
 	header.headerCrc = stream.readUint32LE();
 	if (CRC32::checksum(headData, header.headerSize) != header.headerCrc) {
 		warning("ArjFile::readHeader(): Bad header CRC");
-		return NULL;
+		return nullptr;
 	}
 
 	header.firstHdrSize = readS.readByte();
@@ -292,7 +292,7 @@ ArjHeader *readHeader(SeekableReadStream &stream) {
 	// static int check_file_size()
 	if (header.origSize < 0 || header.compSize < 0) {
 		warning("ArjFile::readHeader(): Wrong file size");
-		return NULL;
+		return nullptr;
 	}
 
 	strlcpy(header.filename, (const char *)&headData[header.firstHdrSize], ARJ_FILENAME_MAX);
@@ -723,14 +723,14 @@ ArjArchive::ArjArchive(const String &filename) : _arjFilename(filename) {
 		return;
 	}
 
-	ArjHeader *header = NULL;
+	ArjHeader *header = nullptr;
 
 	arjFile.seek(firstHeaderOffset, SEEK_SET);
-	if ((header = readHeader(arjFile)) == NULL)
+	if ((header = readHeader(arjFile)) == nullptr)
 		return;
 	delete header;
 
-	while ((header = readHeader(arjFile)) != NULL) {
+	while ((header = readHeader(arjFile)) != nullptr) {
 		_headers[header->filename] = header;
 		arjFile.seek(header->compSize, SEEK_CUR);
 	}
@@ -771,7 +771,7 @@ const ArchiveMemberPtr ArjArchive::getMember(const String &name) const {
 
 SeekableReadStream *ArjArchive::createReadStreamForMember(const String &name) const {
 	if (!_headers.contains(name)) {
-		return 0;
+		return nullptr;
 	}
 
 	ArjHeader *hdr = _headers[name];

--- a/common/unzip.cpp
+++ b/common/unzip.cpp
@@ -480,7 +480,7 @@ static uLong unzlocal_SearchCentralDir(Common::SeekableReadStream &fin) {
 		uMaxBack = uSizeFile;
 
 	buf = (unsigned char*)malloc(BUFREADCOMMENT+4);
-	if (buf==NULL)
+	if (buf==nullptr)
 		return 0;
 
 	uBackRead = 4;
@@ -528,7 +528,7 @@ static uLong unzlocal_SearchCentralDir(Common::SeekableReadStream &fin) {
 */
 unzFile unzOpen(Common::SeekableReadStream *stream) {
 	if (!stream)
-		return NULL;
+		return nullptr;
 
 	unz_s *us = new unz_s;
 	uLong central_pos,uL;
@@ -597,21 +597,21 @@ unzFile unzOpen(Common::SeekableReadStream *stream) {
 	if (err != UNZ_OK) {
 		delete us->_stream;
 		delete us;
-		return NULL;
+		return nullptr;
 	}
 
 	us->byte_before_the_zipfile = central_pos -
 		                    (us->offset_central_dir+us->size_central_dir);
 	us->central_pos = central_pos;
-	us->pfile_in_zip_read = NULL;
+	us->pfile_in_zip_read = nullptr;
 
 	err = unzGoToFirstFile((unzFile)us);
 
 	while (err == UNZ_OK) {
 		// Get the file details
 		char szCurrentFileName[UNZ_MAXFILENAMEINZIP+1];
-		unzGetCurrentFileInfo(us, NULL, szCurrentFileName, sizeof(szCurrentFileName) - 1,
-							NULL, 0, NULL, 0);
+		unzGetCurrentFileInfo(us, nullptr, szCurrentFileName, sizeof(szCurrentFileName) - 1,
+							nullptr, 0, nullptr, 0);
 
 		// Save details into the hash
 		cached_file_in_zip fe;
@@ -637,11 +637,11 @@ unzFile unzOpen(Common::SeekableReadStream *stream) {
   return UNZ_OK if there is no problem. */
 int unzClose(unzFile file) {
 	unz_s *s;
-	if (file == NULL)
+	if (file == nullptr)
 		return UNZ_PARAMERROR;
 	s = (unz_s *)file;
 
-	if (s->pfile_in_zip_read != NULL)
+	if (s->pfile_in_zip_read != nullptr)
 		unzCloseCurrentFile(file);
 
 	delete s->_stream;
@@ -656,7 +656,7 @@ int unzClose(unzFile file) {
   return UNZ_OK if there is no problem. */
 int unzGetGlobalInfo(unzFile file, unz_global_info *pglobal_info) {
 	unz_s *s;
-	if (file == NULL)
+	if (file == nullptr)
 		return UNZ_PARAMERROR;
 	s = (unz_s *)file;
 	*pglobal_info = s->gi;
@@ -707,7 +707,7 @@ static int unzlocal_GetCurrentFileInfoInternal(unzFile file,
 	uLong uMagic;
 	long lSeek=0;
 
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 	s->_stream->seek(s->pos_in_central_dir+s->byte_before_the_zipfile, SEEK_SET);
@@ -771,7 +771,7 @@ static int unzlocal_GetCurrentFileInfoInternal(unzFile file,
 		err=UNZ_ERRNO;
 
 	lSeek+=file_info.size_filename;
-	if ((err==UNZ_OK) && (szFileName!=NULL)) {
+	if ((err==UNZ_OK) && (szFileName!=nullptr)) {
 		uLong uSizeRead;
 		if (file_info.size_filename<fileNameBufferSize) {
 			*(szFileName+file_info.size_filename)='\0';
@@ -786,7 +786,7 @@ static int unzlocal_GetCurrentFileInfoInternal(unzFile file,
 	}
 
 
-	if ((err==UNZ_OK) && (extraField!=NULL)) {
+	if ((err==UNZ_OK) && (extraField!=nullptr)) {
 		uLong uSizeRead;
 		if (file_info.size_file_extra<extraFieldBufferSize)
 			uSizeRead = file_info.size_file_extra;
@@ -809,7 +809,7 @@ static int unzlocal_GetCurrentFileInfoInternal(unzFile file,
 		lSeek+=file_info.size_file_extra;
 
 
-	if ((err==UNZ_OK) && (szComment!=NULL)) {
+	if ((err==UNZ_OK) && (szComment!=nullptr)) {
 		uLong uSizeRead;
 		if (file_info.size_file_comment<commentBufferSize) {
 			*(szComment+file_info.size_file_comment)='\0';
@@ -831,10 +831,10 @@ static int unzlocal_GetCurrentFileInfoInternal(unzFile file,
 	} else
 		lSeek+=file_info.size_file_comment;
 
-	if ((err==UNZ_OK) && (pfile_info!=NULL))
+	if ((err==UNZ_OK) && (pfile_info!=nullptr))
 		*pfile_info=file_info;
 
-	if ((err==UNZ_OK) && (pfile_info_internal!=NULL))
+	if ((err==UNZ_OK) && (pfile_info_internal!=nullptr))
 		*pfile_info_internal=file_info_internal;
 
 	return err;
@@ -853,7 +853,7 @@ int unzGetCurrentFileInfo(unzFile file,
                                                   void *extraField, uLong extraFieldBufferSize,
                                                   char *szComment,  uLong commentBufferSize)
 {
-	return unzlocal_GetCurrentFileInfoInternal(file,pfile_info,NULL,
+	return unzlocal_GetCurrentFileInfoInternal(file,pfile_info,nullptr,
 												szFileName,fileNameBufferSize,
 												extraField,extraFieldBufferSize,
 												szComment,commentBufferSize);
@@ -866,14 +866,14 @@ int unzGetCurrentFileInfo(unzFile file,
 int unzGoToFirstFile(unzFile file) {
 	int err=UNZ_OK;
 	unz_s* s;
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 	s->pos_in_central_dir=s->offset_central_dir;
 	s->num_file=0;
 	err=unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
 											 &s->cur_file_info_internal,
-											 NULL,0,NULL,0,NULL,0);
+											 nullptr,0,nullptr,0,nullptr,0);
 	s->current_file_ok = (err == UNZ_OK);
 	return err;
 }
@@ -888,7 +888,7 @@ int unzGoToNextFile(unzFile file) {
 	unz_s* s;
 	int err;
 
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 	if (!s->current_file_ok)
@@ -901,7 +901,7 @@ int unzGoToNextFile(unzFile file) {
 	s->num_file++;
 	err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
 											   &s->cur_file_info_internal,
-											   NULL,0,NULL,0,NULL,0);
+											   nullptr,0,nullptr,0,nullptr,0);
 	s->current_file_ok = (err == UNZ_OK);
 	return err;
 }
@@ -917,7 +917,7 @@ int unzGoToNextFile(unzFile file) {
 int unzLocateFile(unzFile file, const char *szFileName, int iCaseSensitivity) {
 	unz_s* s;
 
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 
 	if (strlen(szFileName)>=UNZ_MAXFILENAMEINZIP)
@@ -1047,13 +1047,13 @@ int unzOpenCurrentFile (unzFile file) {
 	uLong offset_local_extrafield;  /* offset of the local extra field */
 	uInt  size_local_extrafield;    /* size of the local extra field */
 
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 	if (!s->current_file_ok)
 		return UNZ_PARAMERROR;
 
-	if (s->pfile_in_zip_read != NULL)
+	if (s->pfile_in_zip_read != nullptr)
 		unzCloseCurrentFile(file);
 
 	if (unzlocal_CheckCurrentFileCoherencyHeader(s,&iSizeVar,
@@ -1062,7 +1062,7 @@ int unzOpenCurrentFile (unzFile file) {
 
 	pfile_in_zip_read_info = (file_in_zip_read_info_s*) malloc(sizeof(file_in_zip_read_info_s));
 
-	if (pfile_in_zip_read_info==NULL)
+	if (pfile_in_zip_read_info==nullptr)
 		return UNZ_INTERNALERROR;
 
 	pfile_in_zip_read_info->read_buffer=(char *)malloc(UNZ_BUFSIZE);
@@ -1070,7 +1070,7 @@ int unzOpenCurrentFile (unzFile file) {
 	pfile_in_zip_read_info->size_local_extrafield = size_local_extrafield;
 	pfile_in_zip_read_info->pos_local_extrafield=0;
 
-	if (pfile_in_zip_read_info->read_buffer==NULL)
+	if (pfile_in_zip_read_info->read_buffer==nullptr)
 	{
 		free(pfile_in_zip_read_info);
 		return UNZ_INTERNALERROR;
@@ -1093,9 +1093,9 @@ int unzOpenCurrentFile (unzFile file) {
 
 	if (!Store) {
 #ifdef USE_ZLIB
-		pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
-		pfile_in_zip_read_info->stream.zfree = (free_func)0;
-		pfile_in_zip_read_info->stream.opaque = (voidpf)0;
+		pfile_in_zip_read_info->stream.zalloc = (alloc_func)nullptr;
+		pfile_in_zip_read_info->stream.zfree = (free_func)nullptr;
+		pfile_in_zip_read_info->stream.opaque = (voidpf)nullptr;
 
 		err=inflateInit2(&pfile_in_zip_read_info->stream, -MAX_WBITS);
 		if (err == Z_OK)
@@ -1140,16 +1140,16 @@ int unzReadCurrentFile(unzFile file, voidp buf, unsigned len) {
 	uInt iRead = 0;
 	unz_s* s;
 	file_in_zip_read_info_s* pfile_in_zip_read_info;
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 	pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info==NULL)
+	if (pfile_in_zip_read_info==nullptr)
 		return UNZ_PARAMERROR;
 
 
-	if (pfile_in_zip_read_info->read_buffer == NULL)
+	if (pfile_in_zip_read_info->read_buffer == nullptr)
 		return UNZ_END_OF_LIST_OF_FILE;
 	if (len==0)
 		return 0;
@@ -1258,12 +1258,12 @@ int unzReadCurrentFile(unzFile file, voidp buf, unsigned len) {
 z_off_t unztell(unzFile file) {
 	unz_s* s;
 	file_in_zip_read_info_s* pfile_in_zip_read_info;
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 	pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info==NULL)
+	if (pfile_in_zip_read_info==nullptr)
 		return UNZ_PARAMERROR;
 
 	return (z_off_t)pfile_in_zip_read_info->stream.total_out;
@@ -1276,12 +1276,12 @@ z_off_t unztell(unzFile file) {
 int unzeof(unzFile file) {
 	unz_s* s;
 	file_in_zip_read_info_s* pfile_in_zip_read_info;
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 	pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info==NULL)
+	if (pfile_in_zip_read_info==nullptr)
 		return UNZ_PARAMERROR;
 
 	if (pfile_in_zip_read_info->rest_read_uncompressed == 0)
@@ -1310,18 +1310,18 @@ int unzGetLocalExtrafield(unzFile file, voidp buf, unsigned len) {
 	uInt read_now;
 	uLong size_to_read;
 
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 	pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info==NULL)
+	if (pfile_in_zip_read_info==nullptr)
 		return UNZ_PARAMERROR;
 
 	size_to_read = (pfile_in_zip_read_info->size_local_extrafield -
 				pfile_in_zip_read_info->pos_local_extrafield);
 
-	if (buf==NULL)
+	if (buf==nullptr)
 		return (int)size_to_read;
 
 	if (len>size_to_read)
@@ -1352,12 +1352,12 @@ int unzCloseCurrentFile(unzFile file) {
 
 	unz_s* s;
 	file_in_zip_read_info_s* pfile_in_zip_read_info;
-	if (file == NULL)
+	if (file == nullptr)
 		return UNZ_PARAMERROR;
 	s = (unz_s*)file;
 	pfile_in_zip_read_info = s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info == NULL)
+	if (pfile_in_zip_read_info == nullptr)
 		return UNZ_PARAMERROR;
 
 
@@ -1374,12 +1374,12 @@ int unzCloseCurrentFile(unzFile file) {
 
 
 	free(pfile_in_zip_read_info->read_buffer);
-	pfile_in_zip_read_info->read_buffer = NULL;
+	pfile_in_zip_read_info->read_buffer = nullptr;
 
 	pfile_in_zip_read_info->stream_initialized = 0;
 	free(pfile_in_zip_read_info);
 
-	s->pfile_in_zip_read=NULL;
+	s->pfile_in_zip_read=nullptr;
 
 	return err;
 }
@@ -1393,7 +1393,7 @@ int unzCloseCurrentFile(unzFile file) {
 int unzGetGlobalComment(unzFile file, char *szComment, uLong uSizeBuf) {
 	unz_s* s;
 	uLong uReadThis;
-	if (file==NULL)
+	if (file==nullptr)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 
@@ -1411,7 +1411,7 @@ int unzGetGlobalComment(unzFile file, char *szComment, uLong uSizeBuf) {
 			return UNZ_ERRNO;
 	}
 
-	if ((szComment != NULL) && (uSizeBuf > s->gi.size_comment))
+	if ((szComment != nullptr) && (uSizeBuf > s->gi.size_comment))
 		*(szComment+s->gi.size_comment)='\0';
 	return (int)uReadThis;
 }
@@ -1487,26 +1487,26 @@ const ArchiveMemberPtr ZipArchive::getMember(const String &name) const {
 
 SeekableReadStream *ZipArchive::createReadStreamForMember(const String &name) const {
 	if (unzLocateFile(_zipFile, name.c_str(), 2) != UNZ_OK)
-		return 0;
+		return nullptr;
 
 	unz_file_info fileInfo;
 	if (unzOpenCurrentFile(_zipFile) != UNZ_OK)
-		return 0;
+		return nullptr;
 
-	if (unzGetCurrentFileInfo(_zipFile, &fileInfo, NULL, 0, NULL, 0, NULL, 0) != UNZ_OK)
-		return 0;
+	if (unzGetCurrentFileInfo(_zipFile, &fileInfo, nullptr, 0, nullptr, 0, nullptr, 0) != UNZ_OK)
+		return nullptr;
 
 	byte *buffer = (byte *)malloc(fileInfo.uncompressed_size);
 	assert(buffer);
 
 	if (unzReadCurrentFile(_zipFile, buffer, fileInfo.uncompressed_size) != (int)fileInfo.uncompressed_size) {
 		free(buffer);
-		return 0;
+		return nullptr;
 	}
 
 	if (unzCloseCurrentFile(_zipFile) != UNZ_OK) {
 		free(buffer);
-		return 0;
+		return nullptr;
 	}
 
 	return new MemoryReadStream(buffer, fileInfo.uncompressed_size, DisposeAfterUse::YES);
@@ -1527,12 +1527,12 @@ Archive *makeZipArchive(const FSNode &node) {
 
 Archive *makeZipArchive(SeekableReadStream *stream) {
 	if (!stream)
-		return 0;
+		return nullptr;
 	unzFile zipFile = unzOpen(stream);
 	if (!zipFile) {
 		// stream gets deleted by unzOpen() call if something
 		// goes wrong.
-		return 0;
+		return nullptr;
 	}
 	return new ZipArchive(zipFile);
 }

--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -34,7 +34,7 @@ static uint32 computeCapacity(uint32 len) {
 }
 
 U32String::U32String(const value_type *str) : _size(0), _str(_storage) {
-	if (str == 0) {
+	if (str == nullptr) {
 		_storage[0] = 0;
 		_size = 0;
 	} else {
@@ -69,7 +69,7 @@ U32String::U32String(const U32String &str)
 		_extern._capacity = str._extern._capacity;
 		_str = str._str;
 	}
-	assert(_str != 0);
+	assert(_str != nullptr);
 }
 
 U32String::~U32String() {
@@ -265,15 +265,15 @@ void U32String::ensureCapacity(uint32 new_size, bool keep_old) {
 		// Set the ref count & capacity if we use an external storage.
 		// It is important to do this *after* copying any old content,
 		// else we would override data that has not yet been copied!
-		_extern._refCount = 0;
+		_extern._refCount = nullptr;
 		_extern._capacity = newCapacity;
 	}
 }
 
 void U32String::incRefCount() const {
 	assert(!isStorageIntern());
-	if (_extern._refCount == 0) {
-		if (g_refCountPool == 0) {
+	if (_extern._refCount == nullptr) {
+		if (g_refCountPool == nullptr) {
 			g_refCountPool = new MemoryPool(sizeof(int));
 			assert(g_refCountPool);
 		}
@@ -317,9 +317,9 @@ void U32String::initWithCStr(const value_type *str, uint32 len) {
 	if (len >= _builtinCapacity) {
 		// Not enough internal storage, so allocate more
 		_extern._capacity = computeCapacity(len + 1);
-		_extern._refCount = 0;
+		_extern._refCount = nullptr;
 		_str = new value_type[_extern._capacity];
-		assert(_str != 0);
+		assert(_str != nullptr);
 	}
 
 	// Copy the string into the storage area

--- a/common/winexe_ne.cpp
+++ b/common/winexe_ne.cpp
@@ -30,7 +30,7 @@
 namespace Common {
 
 NEResources::NEResources() {
-	_exe = 0;
+	_exe = nullptr;
 }
 
 NEResources::~NEResources() {
@@ -40,7 +40,7 @@ NEResources::~NEResources() {
 void NEResources::clear() {
 	if (_exe) {
 		delete _exe;
-		_exe = 0;
+		_exe = nullptr;
 	}
 
 	_resources.clear();
@@ -270,14 +270,14 @@ const NEResources::Resource *NEResources::findResource(const WinResourceID &type
 		if (it->type == type && it->id == id)
 			return &*it;
 
-	return 0;
+	return nullptr;
 }
 
 SeekableReadStream *NEResources::getResource(const WinResourceID &type, const WinResourceID &id) {
 	const Resource *res = findResource(type, id);
 
 	if (!res)
-		return 0;
+		return nullptr;
 
 	_exe->seek(res->offset);
 	return _exe->readStream(res->size);

--- a/common/winexe_pe.cpp
+++ b/common/winexe_pe.cpp
@@ -31,7 +31,7 @@
 namespace Common {
 
 PEResources::PEResources() {
-	_exe = 0;
+	_exe = nullptr;
 }
 
 PEResources::~PEResources() {
@@ -41,7 +41,7 @@ PEResources::~PEResources() {
 void PEResources::clear() {
 	_sections.clear();
 	_resources.clear();
-	delete _exe; _exe = 0;
+	delete _exe; _exe = nullptr;
 }
 
 bool PEResources::loadFromEXE(const String &fileName) {
@@ -224,7 +224,7 @@ SeekableReadStream *PEResources::getResource(const WinResourceID &type, const Wi
 	Array<WinResourceID> langList = getLangList(type, name);
 
 	if (langList.empty())
-		return 0;
+		return nullptr;
 
 	const Resource &resource = _resources[type][name][langList[0]];
 	_exe->seek(resource.offset);
@@ -233,17 +233,17 @@ SeekableReadStream *PEResources::getResource(const WinResourceID &type, const Wi
 
 SeekableReadStream *PEResources::getResource(const WinResourceID &type, const WinResourceID &name, const WinResourceID &lang) {
 	if (!_exe || !_resources.contains(type))
-		return 0;
+		return nullptr;
 
 	const NameMap &nameMap = _resources[type];
 
 	if (!nameMap.contains(name))
-		return 0;
+		return nullptr;
 
 	const LangMap &langMap = nameMap[name];
 
 	if (!langMap.contains(lang))
-		return 0;
+		return nullptr;
 
 	const Resource &resource = langMap[lang];
 	_exe->seek(resource.offset);

--- a/common/xmlparser.cpp
+++ b/common/xmlparser.cpp
@@ -74,7 +74,7 @@ bool XMLParser::loadStream(SeekableReadStream *stream) {
 
 void XMLParser::close() {
 	delete _stream;
-	_stream = 0;
+	_stream = nullptr;
 }
 
 bool XMLParser::parserError(const String &errStr) {
@@ -299,13 +299,13 @@ bool XMLParser::closeKey() {
 }
 
 bool XMLParser::parse() {
-	if (_stream == 0)
+	if (_stream == nullptr)
 		return false;
 
 	// Make sure we are at the start of the stream.
 	_stream->seek(0, SEEK_SET);
 
-	if (_XMLkeys == 0)
+	if (_XMLkeys == nullptr)
 		buildLayout();
 
 	while (!_activeKey.empty())
@@ -378,7 +378,7 @@ bool XMLParser::parse() {
 				node->ignore = false;
 				node->header = activeHeader;
 				node->depth = _activeKey.size();
-				node->layout = 0;
+				node->layout = nullptr;
 				_activeKey.push(node);
 			}
 

--- a/common/xmlparser.h
+++ b/common/xmlparser.h
@@ -92,7 +92,7 @@ public:
 	/**
 	 * Parser constructor.
 	 */
-	XMLParser() : _XMLkeys(0), _stream(0) {}
+	XMLParser() : _XMLkeys(nullptr), _stream(nullptr) {}
 
 	virtual ~XMLParser();
 
@@ -195,7 +195,7 @@ public:
 		if (!_activeKey.empty())
 			return _activeKey.top();
 
-		return 0;
+		return nullptr;
 	}
 
 	/**

--- a/common/zlib.cpp
+++ b/common/zlib.cpp
@@ -71,7 +71,7 @@ bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen,
 		return false;
 
 	// Set the dictionary, if provided
-	if (dict != 0) {
+	if (dict != nullptr) {
 		err = inflateSetDictionary(&stream, const_cast<byte *>(dict), dictLen);
 		if (err != Z_OK)
 			return false;
@@ -168,7 +168,7 @@ protected:
 public:
 
 	GZipReadStream(SeekableReadStream *w, uint32 knownSize = 0) : _wrapped(w), _stream() {
-		assert(w != 0);
+		assert(w != nullptr);
 
 		// Verify file header is correct
 		w->seek(0, SEEK_SET);
@@ -335,7 +335,7 @@ protected:
 
 public:
 	GZipWriteStream(WriteStream *w) : _wrapped(w), _stream(), _pos(0) {
-		assert(w != 0);
+		assert(w != nullptr);
 
 		// Adding 16 to windowBits indicates to zlib that it is supposed to
 		// write gzip headers. This feature was added in zlib 1.2.0.4,
@@ -352,7 +352,7 @@ public:
 		_stream.next_out = _buf;
 		_stream.avail_out = BUFSIZE;
 		_stream.avail_in = 0;
-		_stream.next_in = 0;
+		_stream.next_in = nullptr;
 	}
 
 	~GZipWriteStream() {

--- a/common/zlib.h
+++ b/common/zlib.h
@@ -75,7 +75,7 @@ bool uncompress(byte *dst, unsigned long *dstLen, const byte *src, unsigned long
  *
  * @return true on success (Z_OK or Z_STREAM_END), false otherwise.
  */
-bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen, const byte *dict = 0, uint dictLen = 0);
+bool inflateZlibHeaderless(byte *dst, uint dstLen, const byte *src, uint srcLen, const byte *dict = nullptr, uint dictLen = 0);
 
 /**
  * Wrapper around zlib's inflate functions. This function will call the


### PR DESCRIPTION
Always using nullptr makes the code look more consistent. It's not possible to confuse nullptr with an int. When compiling in C++11 mode, nullptr is strongly typed.

The changes in this commit were generated using clang-tidy. I read them carefully and they look good to me.

If this is approved, I can apply the same transformation to other parts of the codebase.