### PR TITLE
MOHAWK: MYST: Make global currentAge an enum

### DIFF
--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -550,18 +550,18 @@ void MohawkEngine_Myst::changeToStack(uint16 stack, uint16 card, uint16 linkSrcS
 
 	switch (_curStack) {
 	case kChannelwoodStack:
-		_gameState->_globals.currentAge = 4;
+		_gameState->_globals.currentAge = kChannelwood;
 		_scriptParser = new MystStacks::Channelwood(this);
 		break;
 	case kCreditsStack:
 		_scriptParser = new MystStacks::Credits(this);
 		break;
 	case kDemoStack:
-		_gameState->_globals.currentAge = 0;
+		_gameState->_globals.currentAge = kSelenitic;
 		_scriptParser = new MystStacks::Demo(this);
 		break;
 	case kDniStack:
-		_gameState->_globals.currentAge = 6;
+		_gameState->_globals.currentAge = kDini;
 		_scriptParser = new MystStacks::Dni(this);
 		break;
 	case kIntroStack:
@@ -571,26 +571,26 @@ void MohawkEngine_Myst::changeToStack(uint16 stack, uint16 card, uint16 linkSrcS
 		_scriptParser = new MystStacks::MakingOf(this);
 		break;
 	case kMechanicalStack:
-		_gameState->_globals.currentAge = 3;
+		_gameState->_globals.currentAge = kMechanical;
 		_scriptParser = new MystStacks::Mechanical(this);
 		break;
 	case kMystStack:
-		_gameState->_globals.currentAge = 2;
+		_gameState->_globals.currentAge = kMystLibrary;
 		_scriptParser = new MystStacks::Myst(this);
 		break;
 	case kDemoPreviewStack:
 		_scriptParser = new MystStacks::Preview(this);
 		break;
 	case kSeleniticStack:
-		_gameState->_globals.currentAge = 0;
+		_gameState->_globals.currentAge = kSelenitic;
 		_scriptParser = new MystStacks::Selenitic(this);
 		break;
 	case kDemoSlidesStack:
-		_gameState->_globals.currentAge = 1;
+		_gameState->_globals.currentAge = kStoneship;
 		_scriptParser = new MystStacks::Slides(this);
 		break;
 	case kStoneshipStack:
-		_gameState->_globals.currentAge = 1;
+		_gameState->_globals.currentAge = kStoneship;
 		_scriptParser = new MystStacks::Stoneship(this);
 		break;
 	default:
@@ -690,7 +690,7 @@ void MohawkEngine_Myst::changeToCard(uint16 card, TransitionType transition) {
 
 	// The demo resets the cursor at each card change except when in the library
 	if (getFeatures() & GF_DEMO
-			&& _gameState->_globals.currentAge != 2) {
+			&& _gameState->_globals.currentAge != kMystLibrary) {
 		_cursor->setDefaultCursor();
 	}
 
@@ -1208,22 +1208,22 @@ void MohawkEngine_Myst::dropPage() {
 	_gameState->_globals.heldPage = kNoPage;
 
 	// Redraw page area
-	if (whitePage && _gameState->_globals.currentAge == 2) {
+	if (whitePage && _gameState->_globals.currentAge == kMystLibrary) {
 		_scriptParser->toggleVar(41);
 		redrawArea(41);
 	} else if (bluePage) {
 		if (page == kBlueFirePlacePage) {
-			if (_gameState->_globals.currentAge == 2)
+			if (_gameState->_globals.currentAge == kMystLibrary)
 				redrawArea(24);
 		} else {
 			redrawArea(103);
 		}
 	} else if (redPage) {
 		if (page == kRedFirePlacePage) {
-			if (_gameState->_globals.currentAge == 2)
+			if (_gameState->_globals.currentAge == kMystLibrary)
 				redrawArea(25);
 		} else if (page == kRedStoneshipPage) {
-			if (_gameState->_globals.currentAge == 1)
+			if (_gameState->_globals.currentAge == kStoneship)
 				redrawArea(35);
 		} else {
 			redrawArea(102);

--- a/engines/mohawk/myst_stacks/intro.cpp
+++ b/engines/mohawk/myst_stacks/intro.cpp
@@ -71,7 +71,7 @@ void Intro::runPersistentScripts() {
 uint16 Intro::getVar(uint16 var) {
 	switch(var) {
 	case 0:
-		if (_globals.currentAge == 9 || _globals.currentAge == 10)
+		if (_globals.currentAge == kSirrusEnding || _globals.currentAge == kAchenarEnding)
 			return 2;
 		else
 			return _globals.currentAge;

--- a/engines/mohawk/myst_stacks/myst.cpp
+++ b/engines/mohawk/myst_stacks/myst.cpp
@@ -1208,9 +1208,9 @@ void Myst::o_bookGivePage(uint16 var, const ArgumentsArray &args) {
 	if (mask == 32) {
 		// You lose!
 		if (var == 100)
-			_globals.currentAge = 9;
+			_globals.currentAge = kSirrusEnding;
 		else
-			_globals.currentAge = 10;
+			_globals.currentAge = kAchenarEnding;
 
 		_vm->changeToCard(cardIdLose, kTransitionDissolve);
 	} else {

--- a/engines/mohawk/myst_stacks/preview.cpp
+++ b/engines/mohawk/myst_stacks/preview.cpp
@@ -93,7 +93,7 @@ void Preview::o_stayHere(uint16 var, const ArgumentsArray &args) {
 void Preview::o_speechStop(uint16 var, const ArgumentsArray &args) {
 	_vm->_sound->stopSpeech();
 	_speechRunning = false;
-	_globals.currentAge = 2;
+	_globals.currentAge = kMystLibrary;
 }
 
 void Preview::speechUpdateCue() {
@@ -205,7 +205,7 @@ void Preview::speech_run() {
 		_vm->changeToCard(4329, kTransitionDissolve);
 
 		_speechRunning = false;
-		_globals.currentAge = 2;
+		_globals.currentAge = kMystLibrary;
 
 		_vm->_cursor->showCursor();
 		break;

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -78,7 +78,7 @@ MystGameState::MystGameState(MohawkEngine_Myst *vm, Common::SaveFileManager *sav
 	// Unknown
 	_globals.u0 = 2;
 	// Current Age / Stack - Start in Myst
-	_globals.currentAge = 7;
+	_globals.currentAge = kMystStart;
 	_globals.u1 = 1;
 
 	// Library Bookcase Door - Default to Up

--- a/engines/mohawk/myst_state.h
+++ b/engines/mohawk/myst_state.h
@@ -71,6 +71,21 @@ enum HeldPage {
 	kWhitePage           = 13
 };
 
+// Age the player is in
+enum ActiveAge {
+	kSelenitic     = 0,
+	kStoneship     = 1,
+	kMystLibrary   = 2,
+	kMechanical    = 3,
+	kChannelwood   = 4,
+	kIntro         = 5,
+	kDini          = 6,
+	kMystStart     = 7,
+	kCredits       = 8,
+	kSirrusEnding  = 9,
+	kAchenarEnding = 10
+};
+
 class MystGameState {
 public:
 	MystGameState(MohawkEngine_Myst*, Common::SaveFileManager*);
@@ -98,7 +113,7 @@ public:
 	*/
 	struct Globals {
 		uint16 u0;
-		uint16 currentAge;
+		ActiveAge currentAge;
 		HeldPage heldPage;
 		uint16 u1;
 		uint16 transitions;


### PR DESCRIPTION
This global basically tracks what age/book/stack
the player is in.

E.x., instead of _global.currentAge = 2
now _global.currentAge = kMystLibrary.

Interestingly, two integer values (5,8) are
never used.

Also two of the endings are considered Ages
instead of being apart of _global.ending.