### PR TITLE
MOHAWK: MYST: Make Dini/Atrus endings an enum

### DIFF
--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -568,7 +568,7 @@ void MohawkEngine_Myst::changeToStack(uint16 stack, uint16 card, uint16 linkSrcS
 		_scriptParser = new MystStacks::Demo(this);
 		break;
 	case kDniStack:
-		_gameState->_globals.currentAge = kDini;
+		_gameState->_globals.currentAge = kDni;
 		_scriptParser = new MystStacks::Dni(this);
 		break;
 	case kIntroStack:

--- a/engines/mohawk/myst_stacks/credits.cpp
+++ b/engines/mohawk/myst_stacks/credits.cpp
@@ -83,7 +83,7 @@ uint16 Credits::getVar(uint16 var) {
 	case 0: // Credits Image Control
 		return _curImage;
 	case 1: // Credits Music Control (Good / bad ending)
-		return _globals.ending != 4;
+		return _globals.ending != kBooksDestroyed;
 	default:
 		return MystScriptParser::getVar(var);
 	}

--- a/engines/mohawk/myst_stacks/dni.cpp
+++ b/engines/mohawk/myst_stacks/dni.cpp
@@ -80,16 +80,16 @@ void Dni::runPersistentScripts() {
 uint16 Dni::getVar(uint16 var) {
 	switch(var) {
 	case 0: // Atrus Gone (from across room)
-		return _globals.ending == 2;
+		return _globals.ending == kAtrusLeaves;
 	case 1: // Myst Book Status
-		if (_globals.ending != 4)
-			return _globals.ending == 3;
+		if (_globals.ending != kBooksDestroyed)
+			return _globals.ending == kForgotPage;
 		else
 			return 2; // Linkable
 	case 2: // Music Type
 		if (_notSeenAtrus) {
 			_notSeenAtrus = false;
-			return _globals.ending != 4 && _globals.heldPage != kWhitePage;
+			return _globals.ending != kBooksDestroyed && _globals.heldPage != kWhitePage;
 		} else
 			return 2;
 	default:
@@ -104,8 +104,8 @@ void Dni::o_handPage(uint16 var, const ArgumentsArray &args) {
 	VideoEntryPtr atrus = _vm->findVideo(_video, kDniStack);
 
 	// Good ending and Atrus asked to give page
-	if (_globals.ending == 1 && atrus && atrus->getTime() > (uint)Audio::Timestamp(0, 6801, 600).msecs()) {
-		_globals.ending = 2;
+	if (_globals.ending == kAtrusWantsPage && atrus && atrus->getTime() > (uint)Audio::Timestamp(0, 6801, 600).msecs()) {
+		_globals.ending = kAtrusLeaves;
 		_globals.heldPage = kNoPage;
 		_vm->setMainCursor(kDefaultMystCursor);
 
@@ -132,7 +132,7 @@ void Dni::atrusLeft_run() {
 		_loopEnd = 98000;
 
 		// Good ending
-		_globals.ending = 4;
+		_globals.ending = kBooksDestroyed;
 		_globals.bluePagesInBook = 63;
 		_globals.redPagesInBook = 63;
 
@@ -152,10 +152,10 @@ void Dni::loopVideo_run() {
 }
 
 void Dni::atrus_run() {
-	if (_globals.ending == 2) {
+	if (_globals.ending == kAtrusLeaves) {
 		// Wait for atrus to come back
 		_atrusLeft = true;
-	} else if (_globals.ending == 1) {
+	} else if (_globals.ending == kAtrusWantsPage) {
 		// Atrus asking for page
 		if (!_vm->_video->isVideoPlaying()) {
 			_video = "atr1page";
@@ -165,7 +165,7 @@ void Dni::atrus_run() {
 			atrus->setLooping(true);
 			atrus->setBounds(Audio::Timestamp(0, 7388, 600), Audio::Timestamp(0, 14700, 600));
 		}
-	} else if (_globals.ending != 3 && _globals.ending != 4) {
+	} else if (_globals.ending != kForgotPage && _globals.ending != kBooksDestroyed) {
 		if (_globals.heldPage == kWhitePage) {
 			_video = "atr1page";
 			_videoPos = Common::Point(215, 76);
@@ -178,7 +178,7 @@ void Dni::atrus_run() {
 			_loopEnd = 14700;
 
 			// Wait for page
-			_globals.ending = 1;
+			_globals.ending = kAtrusWantsPage;
 
 		} else {
 			_video = "atr1nopg";
@@ -192,7 +192,7 @@ void Dni::atrus_run() {
 			_loopEnd = 46175;
 
 			// Bad ending
-			_globals.ending = 3;
+			_globals.ending = kForgotPage;
 		}
 	} else if (!_vm->_video->isVideoPlaying()) {
 		VideoEntryPtr atrus = _vm->playMovie("atrwrite", kDniStack);

--- a/engines/mohawk/myst_stacks/myst.cpp
+++ b/engines/mohawk/myst_stacks/myst.cpp
@@ -406,7 +406,7 @@ uint16 Myst::getVar(uint16 var) {
 	case 0: // Myst Library Bookcase Closed
 		return _state.libraryBookcaseDoor;
 	case 1:
-		if (_globals.ending != 4)
+		if (_globals.ending != kBooksDestroyed)
 			return _state.libraryBookcaseDoor != 1;
 		else if (_state.libraryBookcaseDoor == 1)
 			return 2;
@@ -487,12 +487,12 @@ uint16 Myst::getVar(uint16 var) {
 				&& _fireplaceLines[4] == 204
 				&& _fireplaceLines[5] == 250;
 	case 24: // Fireplace Blue Page Present
-		if (_globals.ending != 4)
+		if (_globals.ending != kBooksDestroyed)
 			return !(_globals.bluePagesInBook & 32) && (_globals.heldPage != kBlueFirePlacePage);
 		else
 			return 0;
 	case 25: // Fireplace Red Page Present
-		if (_globals.ending != 4)
+		if (_globals.ending != kBooksDestroyed)
 			return !(_globals.redPagesInBook & 32) && (_globals.heldPage != kRedFirePlacePage);
 		else
 			return 0;
@@ -706,12 +706,12 @@ uint16 Myst::getVar(uint16 var) {
 	case 99: // Cabin Boiler Gas Valve Position
 		return _state.cabinValvePosition % 6;
 	case 102: // Red page
-		if (_globals.ending != 4)
+		if (_globals.ending != kBooksDestroyed)
 			return !(_globals.redPagesInBook & 1) && (_globals.heldPage != kRedLibraryPage);
 		else
 			return 0;
 	case 103: // Blue page
-		if (_globals.ending != 4)
+		if (_globals.ending != kBooksDestroyed)
 			return !(_globals.bluePagesInBook & 1) && (_globals.heldPage != kBlueLibraryPage);
 		else
 			return 0;
@@ -770,7 +770,7 @@ void Myst::toggleVar(uint16 var) {
 		_state.rocketshipMarkerSwitch = (_state.rocketshipMarkerSwitch + 1) % 2;
 		break;
 	case 24: // Fireplace Blue Page
-		if (_globals.ending != 4 && !(_globals.bluePagesInBook & 32)) {
+		if (_globals.ending != kBooksDestroyed && !(_globals.bluePagesInBook & 32)) {
 			if (_globals.heldPage == kBlueFirePlacePage)
 				_globals.heldPage = kNoPage;
 			else
@@ -778,7 +778,7 @@ void Myst::toggleVar(uint16 var) {
 		}
 		break;
 	case 25: // Fireplace Red page
-		if (_globals.ending != 4 && !(_globals.redPagesInBook & 32)) {
+		if (_globals.ending != kBooksDestroyed && !(_globals.redPagesInBook & 32)) {
 			if (_globals.heldPage == kRedFirePlacePage)
 				_globals.heldPage = kNoPage;
 			else
@@ -802,7 +802,7 @@ void Myst::toggleVar(uint16 var) {
 		}
 		break;
 	case 41: // Vault white page
-		if (_globals.ending != 4) {
+		if (_globals.ending != kBooksDestroyed) {
 			if (_dockVaultState == 1) {
 				_dockVaultState = 2;
 				_globals.heldPage = kNoPage;
@@ -813,7 +813,7 @@ void Myst::toggleVar(uint16 var) {
 		}
 		break;
 	case 102: // Red page
-		if (_globals.ending != 4 && !(_globals.redPagesInBook & 1)) {
+		if (_globals.ending != kBooksDestroyed && !(_globals.redPagesInBook & 1)) {
 			if (_globals.heldPage == kRedLibraryPage)
 				_globals.heldPage = kNoPage;
 			else
@@ -821,7 +821,7 @@ void Myst::toggleVar(uint16 var) {
 		}
 		break;
 	case 103: // Blue page
-		if (_globals.ending != 4 && !(_globals.bluePagesInBook & 1)) {
+		if (_globals.ending != kBooksDestroyed && !(_globals.bluePagesInBook & 1)) {
 			if (_globals.heldPage == kBlueLibraryPage)
 				_globals.heldPage = kNoPage;
 			else
@@ -1095,7 +1095,7 @@ void Myst::o_dockVaultOpen(uint16 var, const ArgumentsArray &args) {
 		(_state.observatoryMarkerSwitch == 1) &&
 		(_state.poolMarkerSwitch == 1) &&
 		(_state.rocketshipMarkerSwitch == 1)) {
-		if (_globals.heldPage != kWhitePage && _globals.ending != 4)
+		if (_globals.heldPage != kWhitePage && _globals.ending != kBooksDestroyed)
 			_dockVaultState = 2;
 		else
 			_dockVaultState = 1;
@@ -3718,7 +3718,7 @@ void Myst::greenBook_run() {
 		VideoEntryPtr book = _vm->playMovie(videoName, kMystStack);
 		book->moveTo(314, 76);
 
-		if (_globals.ending != 4) {
+		if (_globals.ending != kBooksDestroyed) {
 			_tempVar = 2;
 		} else {
 			book->setBounds(Audio::Timestamp(0, loopStart, 600), Audio::Timestamp(0, loopEnd, 600));

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -79,7 +79,9 @@ MystGameState::MystGameState(MohawkEngine_Myst *vm, Common::SaveFileManager *sav
 	_globals.u0 = 2;
 	// Current Age / Stack - Start in Myst
 	_globals.currentAge = kMystStart;
+	_globals.heldPage = kNoPage;
 	_globals.u1 = 1;
+	_globals.ending = kDniNotVisited;
 
 	// Library Bookcase Door - Default to Up
 	_myst.libraryBookcaseDoor = 1;

--- a/engines/mohawk/myst_state.h
+++ b/engines/mohawk/myst_state.h
@@ -79,11 +79,21 @@ enum ActiveAge {
 	kMechanical    = 3,
 	kChannelwood   = 4,
 	kIntro         = 5,
-	kDini          = 6,
+	kDni           = 6,
 	kMystStart     = 7,
 	kCredits       = 8,
 	kSirrusEnding  = 9,
 	kAchenarEnding = 10
+};
+
+// Various states that Atrus can be in when in Dni
+enum DniEnding {
+	kDniNotVisited    = 0, // Player hasn't been to Dni/K'veer yet
+	kAtrusWantsPage   = 1, // Player is in Dni with the white page
+	kAtrusLeaves      = 2, // Atrus leaves Dni after receiving the white page
+	kForgotPage       = 3, // Player has entered Dni without bringing the white page
+	kBooksDestroyed   = 4  // Atrus returns to Dni after previously leaving 
+						   // and destroying the books of his sons
 };
 
 class MystGameState {
@@ -120,7 +130,7 @@ public:
 		uint16 zipMode;
 		uint16 redPagesInBook;
 		uint16 bluePagesInBook;
-		uint16 ending;
+		DniEnding ending;
 	} _globals;
 
 	/* 50 Myst Specific Variables :


### PR DESCRIPTION
The global variable "ending" tracks various
states that Atrus can be in.

This variable determines what video of
Atrus will be playing and if the brother
books have been destroyed.

Despite this variable being called ending
there are other endings not captured by
this variable (like the brother endings).

Additionally, the enum could also be called DiniState. 

I originally had the 4rth enum called kAtrusReturns since that state is also associated with him returning, but because of it usage in places like Myst::toggleVar were the brother book states were being checked it made sense to give it the kBooksDestroyed name. So I could have a 5th enum value that is called kAtrusReturns and just map that to kBooksDestroyed so that when it is more clear to use one form, kAtrusReturns in Dini, and, kBooksDestroyed in the myst library.