### PR TITLE
GUI: Make the tab completion case insensitive in the debug console

### DIFF
--- a/common/str.cpp
+++ b/common/str.cpp
@@ -302,6 +302,23 @@ bool String::hasPrefix(const char *x) const {
 	return *x == 0;
 }
 
+bool String::hasPrefixIgnoreCase(const String &x) const {
+	return hasPrefixIgnoreCase(x.c_str());
+}
+
+bool String::hasPrefixIgnoreCase(const char *x) const {
+	assert(x != nullptr);
+	// Compare x with the start of _str.
+	const char *y = c_str();
+	while (*x && tolower(*x) == tolower(*y)) {
+		++x;
+		++y;
+	}
+	// It's a prefix, if and only if all letters in x are 'used up' before
+	// _str ends.
+	return *x == 0;
+}
+
 bool String::hasSuffix(const String &x) const {
 	return hasSuffix(x.c_str());
 }
@@ -314,6 +331,26 @@ bool String::hasSuffix(const char *x) const {
 		return false;
 	const char *y = c_str() + _size - x_size;
 	while (*x && *x == *y) {
+		++x;
+		++y;
+	}
+	// It's a suffix, if and only if all letters in x are 'used up' before
+	// _str ends.
+	return *x == 0;
+}
+
+bool String::hasSuffixIgnoreCase(const String &x) const {
+	return hasSuffixIgnoreCase(x.c_str());
+}
+
+bool String::hasSuffixIgnoreCase(const char *x) const {
+	assert(x != nullptr);
+	// Compare x with the end of _str.
+	const uint32 x_size = strlen(x);
+	if (x_size > _size)
+		return false;
+	const char *y = c_str() + _size - x_size;
+	while (*x && tolower(*x) == tolower(*y)) {
 		++x;
 		++y;
 	}

--- a/common/str.h
+++ b/common/str.h
@@ -154,9 +154,13 @@ public:
 
 	bool hasSuffix(const String &x) const;
 	bool hasSuffix(const char *x) const;
+	bool hasSuffixIgnoreCase(const String &x) const;
+	bool hasSuffixIgnoreCase(const char *x) const;
 
 	bool hasPrefix(const String &x) const;
 	bool hasPrefix(const char *x) const;
+	bool hasPrefixIgnoreCase(const String &x) const;
+	bool hasPrefixIgnoreCase(const char *x) const;
 
 	bool contains(const String &x) const;
 	bool contains(const char *x) const;

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -470,7 +470,7 @@ bool Debugger::tabComplete(const char *input, Common::String &completion) const 
 
 	CommandsMap::const_iterator i, e = _cmds.end();
 	for (i = _cmds.begin(); i != e; ++i) {
-		if (i->_key.hasPrefix(input)) {
+		if (i->_key.hasPrefixIgnoreCase(input)) {
 			uint commandlen = i->_key.size();
 			if (commandlen == inputlen) { // perfect match, so no tab completion possible
 				return false;


### PR DESCRIPTION
It made little sense for the tab-completion to be case sensitive while command execution itself is case insensitive.