### PR TITLE
MOHAWK: MYST: Autosave to Slot 0

### DIFF
--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -283,7 +283,8 @@ void MohawkMetaEngine::removeSaveState(const char *target, int slot) const {
 SaveStateDescriptor MohawkMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
 #ifdef ENABLE_MYST
 	if (strstr(target, "myst")) {
-		return Mohawk::MystGameState::querySaveMetaInfos(slot);
+		SaveStateDescriptor desc = Mohawk::MystGameState::querySaveMetaInfos(slot);
+		return desc;
 	}
 #endif
 #ifdef ENABLE_RIVEN

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -72,6 +72,7 @@ MohawkEngine_Myst::MohawkEngine_Myst(OSystem *syst, const MohawkGameDescription 
 	_showResourceRects = false;
 	_curStack = 0;
 	_curCard = 0;
+	_lastSaveTime = 0;
 
 	_hoverResource = nullptr;
 	_activeResource = nullptr;
@@ -395,6 +396,11 @@ void MohawkEngine_Myst::doFrame() {
 		_waitingOnBlockingOperation = false;
 	}
 
+	if (shouldPerformAutoSave(_lastSaveTime) && canSaveGameStateCurrently() && _gameState->isAutoSaveAllowed()) {
+		autoSave();
+		_lastSaveTime = _system->getMillis();
+	}
+
 	Common::Event event;
 	while (_system->getEventManager()->pollEvent(event)) {
 		switch (event.type) {
@@ -446,6 +452,9 @@ void MohawkEngine_Myst::doFrame() {
 						}
 
 						if (_needsShowCredits) {
+							if (canSaveGameStateCurrently() && _gameState->isAutoSaveAllowed())
+								// Attempt to autosave before exiting
+								autoSave();
 							if (isInteractive()) {
 								_cursor->hideCursor();
 								changeToStack(kCreditsStack, 10000, 0, 0);
@@ -1159,6 +1168,11 @@ Common::Error MohawkEngine_Myst::loadGameState(int slot) {
 
 Common::Error MohawkEngine_Myst::saveGameState(int slot, const Common::String &desc) {
 	return _gameState->save(slot, desc) ? Common::kNoError : Common::kUnknownError;
+}
+
+void MohawkEngine_Myst::autoSave() {
+	if (!_gameState->save(Mohawk::kAutoSaveSlot, Mohawk::kAutoSaveName))
+		warning("Attempt to autosave has failed.");
 }
 
 bool MohawkEngine_Myst::hasGameSaveSupport() const {

--- a/engines/mohawk/myst.h
+++ b/engines/mohawk/myst.h
@@ -96,6 +96,8 @@ enum TransitionType {
 };
 
 const uint16 kMasterpieceOnly = 0xFFFF;
+const int kAutoSaveSlot = 0;
+const Common::String kAutoSaveName = "Autosave";
 
 struct MystCondition {
 	uint16 var;
@@ -247,6 +249,7 @@ public:
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	void autoSave();
 	bool hasFeature(EngineFeature f) const override;
 
 private:
@@ -258,6 +261,7 @@ private:
 
 	uint16 _curStack;
 	uint16 _curCard;
+	uint32 _lastSaveTime;
 	MystView _view;
 
 	bool _runExitScript;

--- a/engines/mohawk/myst_state.h
+++ b/engines/mohawk/myst_state.h
@@ -47,6 +47,8 @@ struct MystSaveMetadata {
 
 	uint32 totalPlayTime;
 
+	bool autoSave;
+
 	Common::String saveDescription;
 
 	MystSaveMetadata();
@@ -106,6 +108,7 @@ public:
 
 	bool load(int slot);
 	bool save(int slot, const Common::String &desc);
+	bool isAutoSaveAllowed();
 	static void deleteSave(int slot);
 
 	void addZipDest(uint16 stack, uint16 view);
@@ -340,7 +343,7 @@ private:
 	bool loadState(int slot);
 	void loadMetadata(int slot);
 	bool saveState(int slot);
-	void updateMetadateForSaving(const Common::String &desc);
+	void updateMetadateForSaving(const Common::String &desc, bool autosave);
 	bool saveMetadata(int slot);
 
 	// The values in these regions are lists of VIEW resources


### PR DESCRIPTION
The game will autosave to slot 0 if the
player quits using F5. It will not autosave
if the player quits using ctrl+q, ctrl+F5,
or closes the ScummVM window.

This will override any saves the player
puts in save slot 0. It would be preferable
to have slot 0 blocked out when the player
tries to save. I'm not sure how to do that
without also blocking the save from being
loadable.

It would also be good to label the autosave
in the description when the save slots are
pulled up for loading and their is no save
in slot 0.

Its possible the player may quit at a bad spot
and the game will save a bad state. Possibly
more conditions could be added to autoSave()
so that it would not autosave when a bad state
is detected.

It would be even better to add more Autosaves,
but the conditions would be more complicated.
E.x., Autosave 1 could be a save right before
the player went to the next age. Autosave 2
could be a save at the beginning of an Age.