### PR TITLE
GUI: Add copy and paste support to the graphical debugger

### DIFF
--- a/gui/console.h
+++ b/gui/console.h
@@ -174,11 +174,12 @@ protected:
 	void print(const char *str);
 	void updateScrollBuffer();
 	void scrollToCurrent();
+	Common::String getUserInput();
 
 	void defaultKeyDownHandler(Common::KeyState &state);
 
 	// Line editing
-	void specialKeys(int keycode);
+	void specialKeys(Common::KeyCode keycode);
 	void nextLine();
 	void killChar();
 	void killLine();


### PR DESCRIPTION
Ctrl-C copies the input line.
Ctrl-V inserts the clipboard content at the cursor position.