### PR TITLE
XEEN: Add an optional param to CD playback to specify sound type

### DIFF
--- a/README
+++ b/README
@@ -929,17 +929,18 @@ is simpler and more straightforward than moving around using the menu.
 --------------------------------------
 To properly plan the World of Xeen CD Talkie using original discs,
 use LAME or some other MP3 encoder to rip the cd audio tracks to files.
-Name the files track1.mp3 track2.mp3 etc. ScummVM must be compiled with
+Name the files track2.mp3 track3.mp3 etc. ScummVM must be compiled with
 MAD support to use this option. You will need to rip the file from the
 CD as a WAV file, then encode the MP3 files in constant bit rate. This
-can be done with the following LAME command line:
+can be done for each track with a LAME command line like:
 
-  lame -t -q 0 -b 96 track1.wav track1.mp3
+  lame -t -q 0 -b 96 track2.wav track2.mp3
 
 For the GOG Might and Magic 4-5 installation, install the game to your
 computer, and do the following steps:
-* The game1.gog file from the game folder is a CD ISO. Use software like
-Virtual CloneDrive to mount it as a drive.
+* The game1.inst (CUE) and game1.gog (BIN) file from the game folder is a 
+CD image. Use software like Virtual CloneDrive to mount it as a drive.
+Linux and MacOS users can use bchunk to convert it to an ISO.
 * Copy all the .cc files from the subfolder in the mounted drive to a new
 empty game folder that you create for the game.
 * Copy all the music/*.ogg files from the GOG installation to your game

--- a/backends/audiocd/audiocd.h
+++ b/backends/audiocd/audiocd.h
@@ -23,6 +23,7 @@
 #ifndef BACKENDS_AUDIOCD_ABSTRACT_H
 #define BACKENDS_AUDIOCD_ABSTRACT_H
 
+#include "audio/mixer.h"
 #include "common/scummsys.h"
 #include "common/noncopyable.h"
 
@@ -65,10 +66,12 @@ public:
 	 * @param startFrame     the frame at which playback should start (75 frames = 1 second).
 	 * @param duration       the number of frames to play.
 	 * @param onlyEmulate    determines if the track should be emulated only
+	 * @param soundType      What sound type to play as. By default, it's as music
 	 * @note The @c onlyEmulate parameter is deprecated.
 	 * @return @c true if the track started playing, @c false otherwise
 	 */
-	virtual bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false) = 0;
+	virtual bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false,
+		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType) = 0;
 
 	/**
 	 * Get if audio is being played.

--- a/backends/audiocd/default/default-audiocd.cpp
+++ b/backends/audiocd/default/default-audiocd.cpp
@@ -54,7 +54,8 @@ void DefaultAudioCDManager::close() {
 	stop();
 }
 
-bool DefaultAudioCDManager::play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate) {
+bool DefaultAudioCDManager::play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate,
+		Audio::Mixer::SoundType soundType) {
 	stop();
 
 	if (numLoops != 0 || startFrame != 0) {
@@ -84,7 +85,7 @@ bool DefaultAudioCDManager::play(int track, int numLoops, int startFrame, int du
 			repetitions. Finally, -1 means infinitely many
 			*/
 			_emulating = true;
-			_mixer->playStream(Audio::Mixer::kMusicSoundType, &_handle,
+			_mixer->playStream(soundType, &_handle,
 			                        Audio::makeLoopingAudioStream(stream, start, end, (numLoops < 1) ? numLoops + 1 : numLoops), -1, _cd.volume, _cd.balance);
 			return true;
 		}

--- a/backends/audiocd/default/default-audiocd.h
+++ b/backends/audiocd/default/default-audiocd.h
@@ -40,7 +40,8 @@ public:
 
 	virtual bool open();
 	virtual void close();
-	virtual bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false);
+	virtual bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false,
+		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType);
 	virtual void stop();
 	virtual bool isPlaying() const;
 	virtual void setVolume(byte volume);

--- a/backends/audiocd/win32/win32-audiocd.cpp
+++ b/backends/audiocd/win32/win32-audiocd.cpp
@@ -149,13 +149,14 @@ public:
 	Win32AudioCDManager();
 	~Win32AudioCDManager();
 
-	bool open();
-	void close();
-	bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false);
+	virtual bool open();
+	virtual void close();
+	virtual bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false,
+		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType);
 
 protected:
-	bool openCD(int drive);
-	bool openCD(const Common::String &drive);
+	virtual bool openCD(int drive);
+	virtual bool openCD(const Common::String &drive);
 
 private:
 	bool loadTOC();
@@ -254,9 +255,10 @@ void Win32AudioCDManager::close() {
 	_tocEntries.clear();
 }
 
-bool Win32AudioCDManager::play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate) {
+bool Win32AudioCDManager::play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate,
+		Audio::Mixer::SoundType soundType) {
 	// Prefer emulation
-	if (DefaultAudioCDManager::play(track, numLoops, startFrame, duration, onlyEmulate))
+	if (DefaultAudioCDManager::play(track, numLoops, startFrame, duration, onlyEmulate, soundType))
 		return true;
 
 	// If we're set to only emulate, or have no CD drive, return here
@@ -289,7 +291,7 @@ bool Win32AudioCDManager::play(int track, int numLoops, int startFrame, int dura
 	_emulating = true;
 
 	_mixer->playStream(
-	    Audio::Mixer::kMusicSoundType,
+	    soundType,
 	    &_handle,
 	    Audio::makeLoopingAudioStream(audioStream, start, end, (numLoops < 1) ? numLoops + 1 : numLoops),
 	    -1,

--- a/engines/xeen/scripts.cpp
+++ b/engines/xeen/scripts.cpp
@@ -1472,7 +1472,7 @@ bool Scripts::cmdPlayCD(ParamsIterator &params) {
 	int start = params.readUint16LE() * 60 / 75;
 	int finish = params.readUint16LE() * 60 / 75;
 
-	g_system->getAudioCDManager()->play(trackNum, 1, start, finish - start);
+	g_system->getAudioCDManager()->play(trackNum, 1, start, finish - start, false, Audio::Mixer::kSpeechSoundType);
 	return true;
 }
 


### PR DESCRIPTION
The current CD manager play method always internally plays the given track/file using the kMusicSoundType. This is a problem for the World of Xeen 2 CD  Talkie, since for it, the audio tracks are all exclusively voice samples. This would be an exacerbated problem for it, since the game keeps playing background music when the CD voice samples are played. And we don't want the voice playback to be reduced in volume when players try to reduce the music volume so they can hear the speech more clearly.