### PR TITLE
SAGA: Deduplicate kScriptTimeTicksPerSecond constant

### DIFF
--- a/engines/saga/saga.h
+++ b/engines/saga/saga.h
@@ -311,7 +311,6 @@ enum GameObjectTypes {
 
 enum ScriptTimings {
 	kScriptTimeTicksPerSecond = (728L/10L),
-	kScriptTimeTicksPerSecondIHNM = 72,
 	kRepeatSpeedTicks = (728L/10L)/3,
 	kNormalFadeDuration = 320, // 64 steps, 5 msec each
 	kQuickFadeDuration = 64,  // 64 steps, 1 msec each
@@ -586,10 +585,7 @@ public:
 	}
 
 	inline int ticksToMSec(int tick) const {
-		if (getGameId() == GID_ITE)
-			return tick * 1000 / kScriptTimeTicksPerSecond;
-		else
-			return tick * 1000 / kScriptTimeTicksPerSecondIHNM;
+		return tick * 1000 / kScriptTimeTicksPerSecond;
 	}
 
  private:


### PR DESCRIPTION
The underlying type of an enum cannot be a float so the following doesn't really make sense:

    enum ScriptTimings {
        kScriptTimeTicksPerSecond = (728L/10L),
        kScriptTimeTicksPerSecondIHNM = 72,
        kRepeatSpeedTicks = (728L/10L)/3,
        [...]
    };

Because of that, `kScriptTimeTicksPerSecond ` gets truncated to `72` and is therefore identical to `kScriptTimeTicksPerSecondIHNM`.

This commit removes `kScriptTimeTicksPerSecondIHNM`, but if the engine actually requires a higher precision then this is not correct and the constant(s) need(s) to be made floating point.

If it's OK to truncate I suggest adding a comment to the enum.