### PR TITLE
XEEN: Fix voice playback from track 31

### DIFF
--- a/engines/xeen/scripts.cpp
+++ b/engines/xeen/scripts.cpp
@@ -1478,7 +1478,7 @@ bool Scripts::cmdPlayCD(ParamsIterator &params) {
 	int finish = params.readUint16LE();
 	debugC(3, kDebugScripts, "cmdPlayCD Track=%d start=%d finish=%d", trackNum, start, finish);
 
-	if (_vm->_files->_ccNum)
+	if (_vm->_files->_ccNum && trackNum < 31)
 		trackNum += 30;
 	assert(trackNum <= 60);
 


### PR DESCRIPTION
Track 31 is on the first cd, but contains speech for Darkside content
(e.g. Ellinger). It is referenced as track 31, so the offset must not
be added.