### PR TITLE
VIDEO: fixed decoding byteRun when there is more than 255 packets on line

### DIFF
--- a/video/flic_decoder.cpp
+++ b/video/flic_decoder.cpp
@@ -265,9 +265,9 @@ void FlicDecoder::FlicVideoTrack::copyFrame(uint8 *data) {
 
 void FlicDecoder::FlicVideoTrack::decodeByteRun(uint8 *data) {
 	byte *ptr = (byte *)_surface->getPixels();
-	while ((int32)(ptr - (byte *)_surface->getPixels()) < (getWidth() * getHeight())) {
-		int chunks = *data++;
-		while (chunks--) {
+	for (int i = 0; i < getHeight(); ++i) {
+		data++;
+		for (int j = 0; j < getWidth();) {
 			int count = (int8)*data++;
 			if (count > 0) {
 				memset(ptr, *data++, count);
@@ -277,6 +277,7 @@ void FlicDecoder::FlicVideoTrack::decodeByteRun(uint8 *data) {
 				data += count;
 			}
 			ptr += count;
+			j += count;
 		}
 	}
 


### PR DESCRIPTION
We shouldn't rely on chunks count in FLC files. Instead, we should rely on width of the frame.

From https://www.compuphase.com/flic.htm
> Each line of the image is compressed separately, starting from the top of the image. The first byte of each line is the packet count. It is a holdover from the FLI format and it should be ignored, because it is now possible to have more than 255 packets on a line (for FLC files). Instead, the width of the frame image now is the criterion for decoding: continue decompressing until the number of uncompressed pixels becomes equal to the image width. 