### PR TITLE
SCUMM: Improve 'imuse play' debugger command error handling

### DIFF
--- a/engines/scumm/debugger.cpp
+++ b/engines/scumm/debugger.cpp
@@ -145,8 +145,8 @@ bool ScummDebugger::Cmd_IMuse(int argc, const char **argv) {
 					debugPrintf("Selecting from %d songs...\n", _vm->_numSounds);
 					sound = _vm->_rnd.getRandomNumber(_vm->_numSounds);
 				}
-				_vm->ensureResourceLoaded(rtSound, sound);
-				_vm->_musicEngine->startSound(sound);
+				if (_vm->getResourceAddress(rtSound, sound))
+					_vm->_musicEngine->startSound(sound);
 
 				debugPrintf("Attempted to start music %d.\n", sound);
 			} else {

--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -887,7 +887,7 @@ void ResourceManager::setHeapThreshold(int min, int max) {
 
 bool ResourceManager::validateResource(const char *str, ResType type, ResId idx) const {
 	if (type < rtFirst || type > rtLast || (uint)idx >= (uint)_types[type].size()) {
-		error("%s Illegal Glob type %s (%d) num %d", str, nameOfResType(type), type, idx);
+		warning("%s Illegal Glob type %s (%d) num %d", str, nameOfResType(type), type, idx);
 		return false;
 	}
 	return true;

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -1321,8 +1321,9 @@ int ScummEngine::readSoundResource(ResId idx) {
 			//dumpResource("sound-", idx, ptr);
 			return 1;
 		}
-		error("Unrecognized base tag 0x%08x in sound %d", basetag, idx);
 	}
+
+	warning("Unrecognized base tag 0x%08x in sound %d", basetag, idx);
 	_res->_types[rtSound][idx]._roomoffs = RES_INVALID_OFFSET;
 	return 0;
 }


### PR DESCRIPTION
This commit introduces the following (seemingly non-invasive) changes
to make the 'imuse play' debugger command more useful (i.e. don't crash
when trying to load the wrong kind of (sound) resource.

* ScummEngine::readSoundResource()
  Instead of fatally error()'ing upon hitting a non-sound resource type,
  e.g. a room header (0x524d4844 aka RMHD), we now only issue a warning().
  This enables the already existing dead code which properly returns 0
  (aka no resource loaded).

* ResourceManager::validateResource()
  Instead of fatally error()'ing upon hitting an illegal glob type we now
  only issue a warning() and return false (also existing dead code).
  All methods calling validateResource() check its return value so this
  seems like the right thing to do anyway.

* ScummDebugger::Cmd_IMuse()
  Instead of directly calling ensureResourceLoaded() we now call
  getResourceAddress() instead (which in turn calls ensureResourceLoaded()
  and handles other edge cases) and only attempt to play a sound if the
  returned pointer actually is valid.

Fixes Trac#10527.