### PR TITLE
SCUMM: Ensure pointer returned by getResourceAddress() is usable

### DIFF
--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -45,6 +45,7 @@ void ScummEngine::addObjectToInventory(uint obj, uint room) {
 		idx = getObjectIndex(obj);
 		assert(idx >= 0);
 		ptr = getResourceAddress(rtFlObject, _objs[idx].fl_object_index) + 8;
+		assert(ptr);
 		size = READ_BE_UINT32(ptr + 4);
 	} else {
 		findObjectInRoom(&foir, foCodeHeader, obj, room);
@@ -742,6 +743,7 @@ void ScummEngine::resetRoomObjects() {
 	const CodeHeader *cdhd;
 
 	room = getResourceAddress(rtRoom, _roomResource);
+	assert(room);
 
 	if (_numObjectsInRoom == 0)
 		return;
@@ -756,7 +758,7 @@ void ScummEngine::resetRoomObjects() {
 	assert(searchptr);
 
 	// Load in new room objects
-	ResourceIterator	obcds(searchptr, false);
+	ResourceIterator obcds(searchptr, false);
 	for (i = 0; i < _numObjectsInRoom; i++) {
 		od = &_objs[findLocalObjectSlot()];
 
@@ -784,7 +786,7 @@ void ScummEngine::resetRoomObjects() {
 	}
 
 	searchptr = room;
-	ResourceIterator	obims(room, false);
+	ResourceIterator obims(room, false);
 	for (i = 0; i < _numObjectsInRoom; i++) {
 		ptr = obims.findNext(MKTAG('O','B','I','M'));
 		if (ptr == NULL)
@@ -810,6 +812,7 @@ void ScummEngine_v3old::resetRoomObjects() {
 	const byte *room, *ptr;
 
 	room = getResourceAddress(rtRoom, _roomResource);
+	assert(room);
 
 	if (_numObjectsInRoom == 0)
 		return;
@@ -854,6 +857,7 @@ void ScummEngine_v4::resetRoomObjects() {
 	const byte *room;
 
 	room = getResourceAddress(rtRoom, _roomResource);
+	assert(room);
 
 	if (_numObjectsInRoom == 0)
 		return;
@@ -861,7 +865,7 @@ void ScummEngine_v4::resetRoomObjects() {
 	if (_numObjectsInRoom > _numLocalObjects)
 		error("More than %d objects in room %d", _numLocalObjects, _roomResource);
 
-	ResourceIterator	obcds(room, true);
+	ResourceIterator obcds(room, true);
 	for (i = 0; i < _numObjectsInRoom; i++) {
 		od = &_objs[findLocalObjectSlot()];
 
@@ -878,7 +882,7 @@ void ScummEngine_v4::resetRoomObjects() {
 		}
 	}
 
-	ResourceIterator	obims(room, true);
+	ResourceIterator obims(room, true);
 	for (i = 0; i < _numObjectsInRoom; i++) {
 		// In the PC Engine version of Loom, there aren't image blocks
 		// for all objects.
@@ -979,10 +983,12 @@ void ScummEngine::resetRoomObject(ObjectData *od, const byte *room, const byte *
 	assert(room);
 
 	if (searchptr == NULL) {
-		if (_game.version == 8)
+		if (_game.version == 8) {
 			searchptr = getResourceAddress(rtRoomScripts, _roomResource);
-		else
+			assert(searchptr);
+		} else {
 			searchptr = room;
+		}
 	}
 
 	cdhd = (const CodeHeader *)findResourceData(MKTAG('C','D','H','D'), searchptr + od->OBCDoffset);

--- a/engines/scumm/players/player_ad.cpp
+++ b/engines/scumm/players/player_ad.cpp
@@ -97,6 +97,7 @@ void Player_AD::startSound(int sound) {
 
 	// Query the sound resource
 	const byte *res = _vm->getResourceAddress(rtSound, sound);
+	assert(res);
 
 	if (res[2] == 0x80) {
 		// Stop the current sounds

--- a/engines/scumm/players/player_towns.cpp
+++ b/engines/scumm/players/player_towns.cpp
@@ -236,6 +236,8 @@ void Player_Towns_v1::setMusicVolume(int vol) {
 
 void Player_Towns_v1::startSound(int sound) {
 	uint8 *ptr = _vm->getResourceAddress(rtSound, sound);
+	assert(ptr);
+
 	if (_vm->_game.version != 3)
 		ptr += 2;
 
@@ -620,6 +622,7 @@ int Player_Towns_v2::getSoundStatus(int sound) const {
 
 void Player_Towns_v2::startSound(int sound) {
 	uint8 *ptr = _vm->getResourceAddress(rtSound, sound);
+	assert(ptr);
 
 	if (READ_BE_UINT32(ptr) == MKTAG('T','O','W','S')) {
 		_soundOverride[sound].type = 7;


### PR DESCRIPTION
In some cases the pointer returned is used directly without further
error checking.
As most instances already assert() in this case this commit simply
adds asserts where missing and deemed appropriate.