### PR TITLE
COMI: Fix sound issue in Barbery Coast, Trac #10473.

### DIFF
--- a/engines/scumm/imuse_digi/dimuse_tables.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tables.cpp
@@ -392,7 +392,7 @@ const imuseComiTable _comiSeqMusicTable[] = {
 	{8, 2220, "seqSnakeVomits",  0, 1,    0, ""},
 	{8, 2222, "seqPopBalloon",   0, 1,    0, ""},
 	{3, 2225, "seqDropBalls",    0, 0,   60, "2225-D~1.IMX"},
-	{4, 2232, "seqArriveBarber", 0, 0,   60, "2232-A~1.IMX"},
+	{3, 2232, "seqArriveBarber", 0, 0,   60, "2232-A~1.IMX"},
 	{3, 2233, "seqAtonal",       0, 0,   60, "2233-A~1.IMX"},
 	{3, 2235, "seqShaveHead1",   0, 0,   60, "2235-S~1.IMX"},
 	{2, 2236, "seqShaveHead2",   0, 2,   60, "2235-S~1.IMX"},


### PR DESCRIPTION
Trac#10473 : 

"In the original exe (as you can hear here: ​https://youtu.be/YsLPOrRitz0?t=52m16s ) during the first (automatic) dialog, the iMUSE plays the file 2232-A ~ 1.IMX (cue "ArriveBarber"), and when it finishes it switches to the Barber Shop theme (file 1285-B ~ 1.IMX).
In ScummVM (2.0.0, Windows 10 64-bit, english game) the main Barber Shop theme starts a lot earlier than expected, interrupting the ArriveBarber cue."


Changing the transitionType for seqArriveBarber from 4 to 3 seems to resolve the issue but the debug log outputs:

19337-SwToNeReg(trackId:12) - fadetrack can't go next region, exiting SwToNeReg

so not sure this is the correct way to proceed.