### PR TITLE
COMMON: Style guide update for rad2Deg and deg2Rad 

### DIFF
--- a/common/math.h
+++ b/common/math.h
@@ -110,20 +110,20 @@ inline int intLog2(uint32 v) {
 // Convert radians to degrees
 // Input and Output type can be different
 // Upconvert everything to floats
-template <class inputT, class outputT> 
-inline outputT rad2deg(inputT rad) {
-	return (outputT)( (float)rad * (float)57.2957795130823); // 180.0/M_PI = 57.2957795130823
+template<class InputT, class OutputT> 
+inline OutputT rad2deg(InputT rad) {
+	return (OutputT)( (float)rad * (float)57.2957795130823); // 180.0/M_PI = 57.2957795130823
 }
 
 // Handle the case differently when the input type is double
-template <class outputT> 
-inline outputT rad2deg(double rad) {
-	return (outputT)( rad * 57.2957795130823);
+template<class OutputT> 
+inline OutputT rad2deg(double rad) {
+	return (OutputT)( rad * 57.2957795130823);
 }
 
 // Convert radians to degrees
 // Input and Output type are the same
-template <class T> 
+template<class T> 
 inline T rad2deg(T rad) {
 	return rad2deg<T,T>(rad);
 }
@@ -131,20 +131,20 @@ inline T rad2deg(T rad) {
 // Convert degrees to radians
 // Input and Output type can be different
 // Upconvert everything to floats
-template <class inputT, class outputT> 
-inline outputT deg2rad(inputT deg) {
-	return (outputT)( (float)deg * (float)0.0174532925199433); // M_PI/180.0 = 0.0174532925199433
+template<class InputT, class OutputT> 
+inline OutputT deg2rad(InputT deg) {
+	return (OutputT)( (float)deg * (float)0.0174532925199433); // M_PI/180.0 = 0.0174532925199433
 }
 
 // Handle the case differently when the input type is double
-template <class outputT> 
-inline outputT deg2rad(double deg) {
-	return (outputT)( deg * 0.0174532925199433);
+template<class OutputT> 
+inline OutputT deg2rad(double deg) {
+	return (OutputT)( deg * 0.0174532925199433);
 }
 
 // Convert degrees to radians
 // Input and Output type are the same
-template <class T> 
+template<class T> 
 inline T deg2rad(T deg) {
 	return deg2rad<T,T>(deg);
 }


### PR DESCRIPTION
This should of been included in PR1175.

I've changed naming and spaces to matched what is stated or implied in the style guide.

Let me know if I missed any other coding conventions.