### PR TITLE
MOHAWK: README: Minor autosave changes and notes for autosaving

### DIFF
--- a/README
+++ b/README
@@ -964,6 +964,9 @@ Space: Pause the game
 Esc: Skip cutscene
 F5: Menu
 
+Myst will autosave to slot 0 if no save or an autosave is present in
+slot 0.
+
 
 3.17) Nippon Safes Inc. Amiga notes:
 ----- ------------------------------
@@ -1009,6 +1012,9 @@ Esc: Skip cutscene
 F5: Menu
 Ctrl-o: Load game
 Ctrl-s: Save game
+
+Riven will autosave to slot 0 if no save or an autosave is present in
+slot 0.
 
 
 3.20) Simon the Sorcerer games notes:
@@ -1985,11 +1991,24 @@ saved games from the old default location, to the new default location.
 
 6.1) Autosaves:
 ---- ----------
-For some games (namely "Beneath a Steel Sky", "Flight of the Amazon
-Queen", all AGI games, and all SCUMM games), ScummVM will by default
-automatically save the current state every five minutes (adjustable via
-the "autosave_period" config setting). For the AGI and SCUMM engines, it
-will save in Slot 0. For the SCUMM engine, this saved game can then be
+For some games ScummVM will by default automatically save the current state
+every five minutes (adjustable via the "autosave_period" config setting).
+The default autosave slot for many engines is slot 0.
+
+The games/engines listed below have autosave support.
+
+AGI games
+Beneath a Steel Sky
+Bud Tucker in Double Trouble
+COMPOSER games
+Flight of the Amazon Queen
+Myst
+Riven
+SCUMM games
+The Legend of Kyrandia I (slot 999)
+ZVISION games
+
+For the SCUMM engine, this saved game can then be
 loaded again via Ctrl-0, or the F5 menu.
 
 

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -259,10 +259,17 @@ bool MystGameState::saveMetadata(int slot) {
 bool MystGameState::isAutoSaveAllowed() {
 	// Open autosave slot and see if it an autosave
 	// Autosaving will be enabled if it is an autosave or if there is no save in that slot
-	Common::String filename = buildMetadataFilename(kAutoSaveSlot);
-	Common::ScopedPtr<Common::InSaveFile> metadataFile(g_system->getSavefileManager()->openForLoading(filename));
-	if (!metadataFile) { // There is no save in the autosave slot, enable autosave
+
+	Common::String dataFilename = buildSaveFilename(kAutoSaveSlot);
+	Common::ScopedPtr<Common::InSaveFile> dataFile(g_system->getSavefileManager()->openForLoading(dataFilename));
+	if (!dataFile) { // Cannot load non-meta file, enable autosave
 		return true;
+	}
+
+	Common::String metaFilename = buildMetadataFilename(kAutoSaveSlot);
+	Common::ScopedPtr<Common::InSaveFile> metadataFile(g_system->getSavefileManager()->openForLoading(metaFilename));
+	if (!metadataFile) { // Can load non-meta file, but not metafile, could be a save from the original, disable autosave
+		return false;
 	}
 
 	Common::Serializer m(metadataFile.get(), nullptr);

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -309,7 +309,8 @@ SaveStateDescriptor MystGameState::querySaveMetaInfos(int slot) {
 	desc.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
 	desc.setSaveTime(metadata.saveHour, metadata.saveMinute);
 	desc.setPlayTime(metadata.totalPlayTime);
-	desc.setDeletableFlag(slot != kAutoSaveSlot);
+	if (metadata.autoSave) // Allow non-saves to be deleted, but not autosaves
+		desc.setDeletableFlag(slot != kAutoSaveSlot);
 
 	Graphics::Surface *thumbnail;
 	if (!Graphics::loadThumbnail(*metadataFile, thumbnail)) {

--- a/engines/mohawk/riven_saveload.cpp
+++ b/engines/mohawk/riven_saveload.cpp
@@ -142,7 +142,8 @@ SaveStateDescriptor RivenSaveLoad::querySaveMetaInfos(const int slot) {
 	descriptor.setPlayTime(metadata.totalPlayTime);
 	descriptor.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
 	descriptor.setSaveTime(metadata.saveHour, metadata.saveMinute);
-	descriptor.setDeletableFlag(slot != kAutoSaveSlot);
+	if (metadata.autoSave) // Allow non-saves to be deleted, but not autosaves
+		descriptor.setDeletableFlag(slot != kAutoSaveSlot);	
 
 	delete metaStream;
 


### PR DESCRIPTION
1. Made the autosave section of the README to be a list of engines and games, added myst, riven, and tucker to it.
2. Prevented myst from autosaving over an original game save since it doesn't have a metadata and the autosave enable check looks at metadata file to determine if autosave should be enabled.
3. Allow non-autosave in slot 0 to be delete-able via the gui in myst and riven. Fixes Trac#10536