### PR TITLE
BASE: Default joystick_num to 0 instead of -1

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -270,7 +270,7 @@ void registerDefaults() {
 #endif
 
 	// Miscellaneous
-	ConfMan.registerDefault("joystick_num", -1);
+	ConfMan.registerDefault("joystick_num", 0);
 	ConfMan.registerDefault("confirm_exit", false);
 	ConfMan.registerDefault("disable_sdl_parachute", false);
 


### PR DESCRIPTION
Fixes Trac#10366.

A default value of 0 will allow scummvm to
automatically use a controller that is
plugged in.

Most users that use a controller will like
that this just works and they won't have
to setup the config file.

Users not using a controller will just
get a WARNING: Invalid joystick: 0! in the cmd window.

This default behavior can be overriden
by including joystick_num in the config
file.