### PR TITLE
FULLPIPE: fix URI

### DIFF
--- a/engines/fullpipe/modal.cpp
+++ b/engines/fullpipe/modal.cpp
@@ -2395,7 +2395,7 @@ bool ModalDemo::init(int counterDiff) {
 	if (_clickedQuit == -1)
 		return true;
 
-	g_system->openUrl("http://www.amazon.de/EuroVideo-Bildprogramm-GmbH-Full-Pipe/dp/B003TO51YE/ref=sr_1_1?ie=UTF8&s=videogames&qid=1279207213&sr=8-1");
+	g_system->openUrl("http://www.amazon.de/EuroVideo-Bildprogramm-GmbH-Full-Pipe/dp/B003TO51YE/ref=sr_1_1");
 
 	g_fp->_gameContinue = false;
 


### PR DESCRIPTION
The previous URI spawns many useless subshells on the POSIX backend
through (harmless) shell command injection.