### PR TITLE
COMMON: fix wrong size assignment in HashMap

### DIFF
--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -406,7 +406,7 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::clear(bool shrinkArray) {
 	if (shrinkArray && _mask >= HASHMAP_MIN_CAPACITY) {
 		delete[] _storage;
 
-		_mask = HASHMAP_MIN_CAPACITY;
+		_mask = HASHMAP_MIN_CAPACITY - 1;
 		_storage = new Node *[HASHMAP_MIN_CAPACITY];
 		assert(_storage != nullptr);
 		memset(_storage, 0, HASHMAP_MIN_CAPACITY * sizeof(Node *));


### PR DESCRIPTION
Calling clear(1) makes the size of hashMap wrong
Examples:
```

Common::StringMap map;
Common::StringMap mapTest;

map.setVal("CabinOnGround1", "FALSE");
map.setVal("CabinOnGround3", "FALSE");
map.setVal("CabinOnGround2", "FALSE");
map.setVal("CabinOnGround5", "FALSE");
map.setVal("CabinOnGround4", "FALSE");
map.setVal("CabinOnGround6", "FALSE");
map.setVal("VSInSS", "FALSE");
map.setVal("SetSummer", "TRUE");
map.setVal("BNWelcomed", "TRUE");
map.setVal("SSEmptied", "TRUE");
map.setVal("IsWinter", "FALSE");

mapTest = map;
map.clear(1);

// 1 test
for (auto it = mapTest.begin(); it != mapTest.end(); ++it) {
		map.setVal(it->_key, it->_value); // endless execution
}

// 2 test
map = mapTest; // SIGSEGV 

```