### PR TITLE
SAGA: Don't show paws message in saved thumbnail

### DIFF
--- a/engines/saga/detection.cpp
+++ b/engines/saga/detection.cpp
@@ -234,7 +234,7 @@ SaveStateDescriptor SagaMetaEngine::querySaveMetaInfos(const char *target, int s
 		SaveStateDescriptor desc(slot, name);
 
 		// Some older saves were not written in an endian safe fashion.
-		// We try to detect this here by checking for extremly high version values.
+		// We try to detect this here by checking for extremely high version values.
 		// If found, we retry with the data swapped.
 		if (version > 0xFFFFFF) {
 			warning("This savegame is not endian safe, retrying with the data swapped");

--- a/engines/saga/saveload.cpp
+++ b/engines/saga/saveload.cpp
@@ -191,6 +191,7 @@ void SagaEngine::save(const char *fileName, const char *saveName) {
 	// Thumbnail
 	// First draw scene without save dialog
 	int oldMode = _interface->getMode();
+	_render->clearFlag(RF_RENDERPAUSE); // Don't show paused game message in saved thumbnail
 	_interface->setMode(kPanelMain);
 	_render->drawScene();
 


### PR DESCRIPTION
Fixes Trac#10008. 

Previously, the game would show a paused game message in the thumbnail when the
game was saved using the gmm.