### PR TITLE
ALL: Use deg2rad and rad2deg for degree conversions

### DIFF
--- a/engines/avalanche/avalot.cpp
+++ b/engines/avalanche/avalot.cpp
@@ -29,6 +29,7 @@
 
 #include "avalanche/avalanche.h"
 
+#include "common/math.h"
 #include "common/random.h"
 #include "common/system.h"
 #include "common/config-manager.h"
@@ -1300,7 +1301,7 @@ uint16 AvalancheEngine::bearing(byte whichPed) {
 
 	int16 deltaX = avvy->_x - curPed->_x;
 	int16 deltaY = avvy->_y - curPed->_y;
-	uint16 result = (uint16)(atan((float)(deltaY / deltaX)) * 180 / M_PI);
+	uint16 result = Common::rad2deg<float,uint16>(atan((float)deltaY / (float)deltaX)); // TODO: Would atan2 be preferable?
 	if (avvy->_x < curPed->_x) {
 		return result + 90;
 	} else {

--- a/engines/avalanche/graphics.cpp
+++ b/engines/avalanche/graphics.cpp
@@ -28,6 +28,7 @@
 #include "avalanche/avalanche.h"
 #include "avalanche/graphics.h"
 
+#include "common/math.h"
 #include "common/system.h"
 #include "engines/util.h"
 #include "graphics/palette.h"
@@ -199,7 +200,6 @@ void GraphicManager::drawToolbar() {
 
 Common::Point GraphicManager::drawArc(Graphics::Surface &surface, int16 x, int16 y, int16 stAngle, int16 endAngle, uint16 radius, Color color) {
 	Common::Point endPoint;
-	const float convfac = (float)M_PI / 180.0f;
 
 	int32 xRadius = radius;
 	int32 yRadius = radius * kScreenWidth / (8 * kScreenHeight); // Just don't ask why...
@@ -243,7 +243,7 @@ Common::Point GraphicManager::drawArc(Graphics::Surface &surface, int16 x, int16
 	uint16 deltaEnd = 91;
 
 	// Set the end point.
-	float tempTerm = endAngle * convfac;
+	float tempTerm = Common::deg2rad<float>(endAngle);
 	endPoint.x = (int16)floor(xRadius * cos(tempTerm) + 0.5) + x;
 	endPoint.y = (int16)floor(yRadius * sin(tempTerm + M_PI) + 0.5) + y;
 
@@ -254,7 +254,7 @@ Common::Point GraphicManager::drawArc(Graphics::Surface &surface, int16 x, int16
 		int16 xTemp = xNext;
 		int16 yTemp = yNext;
 		// This is used by both sin and cos.
-		tempTerm = (j + delta) * convfac;
+		tempTerm = Common::deg2rad<float>(j + delta);
 
 		xNext = (int16)floor(xRadius * cos(tempTerm) + 0.5);
 		yNext = (int16)floor(yRadius * sin(tempTerm + M_PI) + 0.5);

--- a/engines/fullpipe/scenes/scene18and19.cpp
+++ b/engines/fullpipe/scenes/scene18and19.cpp
@@ -33,6 +33,7 @@
 #include "fullpipe/interaction.h"
 #include "fullpipe/behavior.h"
 
+#include "common/math.h"
 
 namespace Fullpipe {
 
@@ -48,8 +49,6 @@ struct Swinger {
 	int sfield_24;
 };
 
-
-#define ANGLE(x) ((x) * M_PI / 180)
 
 void scene18_preload() {
 	g_fp->_scene3 = 0;
@@ -149,7 +148,7 @@ void scene18_setupSwingers(StaticANIObject *ani, Scene *sc) {
 	for (int i = 0; i < 8; i++) {
 		swinger = new Swinger;
 
-		swinger->angle = (double)i * ANGLE(45);
+		swinger->angle = (double)i * Common::deg2rad<double>(45.0);
 		swinger->sx = g_vars->scene18_wheelCenterX - (int)(cos(swinger->angle) * -575.0);
 		swinger->sy = g_vars->scene18_wheelCenterY - (int)(sin(swinger->angle) * -575.0) + 87;
 		swinger->ix = swinger->sx;
@@ -555,11 +554,11 @@ void sceneHandler18and19_drawRiders() {
 
 		double oldangle = swinger->angle;
 
-		swinger->angle += ANGLE(1);
+		swinger->angle += Common::deg2rad<double>(1.0);
 
-		if (swinger->angle > ANGLE(360)) {
-			swinger->angle -= ANGLE(360);
-			oldangle -= ANGLE(360);
+		if (swinger->angle > Common::deg2rad<double>(360.0)) {
+			swinger->angle -= Common::deg2rad<double>(360.0);
+			oldangle -= Common::deg2rad<double>(360.0);
 		}
 
 		int ix = g_vars->scene18_wheelCenterX - (int)(cos(swinger->angle) * -575.0);
@@ -568,7 +567,7 @@ void sceneHandler18and19_drawRiders() {
 		if (!g_vars->scene18_rotationCounter) {
 			ix = swinger->sx;
 			iy = swinger->sy;
-			swinger->angle = (double)i * ANGLE(45);
+			swinger->angle = (double)i * Common::deg2rad<double>(45.0);
 		}
 
 		if (swinger->ani->_movement)
@@ -600,27 +599,27 @@ void sceneHandler18and19_drawRiders() {
 		}
 
 		if (g_vars->scene18_wheelIsTurning) {
-			if ((swinger->sflags & 2) && swinger->angle >= ANGLE(160) && oldangle < ANGLE(160)) {
+			if ((swinger->sflags & 2) && swinger->angle >= Common::deg2rad<double>(160.0) && oldangle < Common::deg2rad<double>(160.0)) {
 				swinger->sflags = 8;
 				swinger->ani->changeStatics2(ST_KSL_BOY);
 				swinger->ani->startAnim(MV_KSL_JUMPBOY, 0, -1);
 				g_vars->scene18_kidWheelPos = i;
-			} else if ((swinger->sflags & 4) && swinger->angle >= ANGLE(162) && oldangle < ANGLE(162)) {
+			} else if ((swinger->sflags & 4) && swinger->angle >= Common::deg2rad<double>(162.0) && oldangle < Common::deg2rad<double>(162.0)) {
 				swinger->sflags = 16;
 				swinger->ani->changeStatics2(ST_KSL_GIRL);
 				swinger->ani->startAnim(MV_KSL_JUMPGIRL, 0, -1);
 				g_vars->scene18_kidWheelPos = i;
 			} else if (g_vars->scene18_kidIsOnWheel) {
-				if (g_vars->scene18_boyIsOnWheel > 0 && (swinger->sflags & 1) && swinger->angle >= ANGLE(185) && oldangle < ANGLE(185)) {
+				if (g_vars->scene18_boyIsOnWheel > 0 && (swinger->sflags & 1) && swinger->angle >= Common::deg2rad<double>(185.0) && oldangle < Common::deg2rad<double>(185.0)) {
 					g_vars->scene18_kidWheelPosTo = i;
 					sceneHandler18and19_boyJumpTo();
 				}
-			} else if (g_vars->scene18_girlIsOnWheel > 0 && (swinger->sflags & 1) && swinger->angle >= ANGLE(187) && oldangle < ANGLE(187)) {
+			} else if (g_vars->scene18_girlIsOnWheel > 0 && (swinger->sflags & 1) && swinger->angle >= Common::deg2rad<double>(187.0) && oldangle < Common::deg2rad<double>(187.0)) {
 				g_vars->scene18_kidWheelPosTo = i;
 				sceneHandler18and19_girlJumpTo();
 			}
 
-			if (swinger->angle >= ANGLE(200) && oldangle < ANGLE(200)) {
+			if (swinger->angle >= Common::deg2rad<double>(200.0) && oldangle < Common::deg2rad<double>(200.0)) {
 				if (g_vars->scene18_boyJumpedOff)
 					g_vars->scene18_boyIsOnWheel++;
 
@@ -628,7 +627,7 @@ void sceneHandler18and19_drawRiders() {
 			}
 		}
 
-		if (g_vars->scene18_manIsReady && (swinger->sflags & 1) && swinger->angle >= ANGLE(83) && oldangle < ANGLE(83)) {
+		if (g_vars->scene18_manIsReady && (swinger->sflags & 1) && swinger->angle >= Common::deg2rad<double>(83.0) && oldangle < Common::deg2rad<double>(83.0)) {
 			g_vars->scene18_manWheelPosTo = i;
 			sceneHandler18and19_manStandArmchair();
 		}
@@ -637,18 +636,18 @@ void sceneHandler18and19_drawRiders() {
 			continue;
 
 		if ((int)i == g_vars->scene18_manWheelPosTo) {
-			if (swinger->angle >= ANGLE(170) && oldangle < ANGLE(170)) {
+			if (swinger->angle >= Common::deg2rad<double>(170.0) && oldangle < Common::deg2rad<double>(170.0)) {
 				g_fp->_gameLoader->preloadScene(SC_18, TrubaRight);
-			} else if (swinger->angle >= ANGLE(25) && oldangle < ANGLE(25)) {
+			} else if (swinger->angle >= Common::deg2rad<double>(25.0) && oldangle < Common::deg2rad<double>(25.0)) {
 				g_fp->_gameLoader->preloadScene(SC_19, TrubaRight);
-			} else if (swinger->angle >= ANGLE(270) && oldangle < ANGLE(270)) {
+			} else if (swinger->angle >= Common::deg2rad<double>(270.0) && oldangle < Common::deg2rad<double>(270.0)) {
 				g_fp->_sceneRect.translate(1200, 0);
 			}
 		}
 
 		if (g_vars->scene18_jumpDistance > 0) {
 			if (swinger->sflags & 0x20) {
-				double newa = (double)g_vars->scene18_jumpAngle * ANGLE(1);
+				double newa = (double)g_vars->scene18_jumpAngle * Common::deg2rad<double>(1.0);
 
 				if (newa <= swinger->angle && oldangle < newa) {
 					swinger->ani->changeStatics2(ST_KSL_MAN);

--- a/engines/mohawk/myst_stacks/myst.cpp
+++ b/engines/mohawk/myst_stacks/myst.cpp
@@ -30,6 +30,7 @@
 #include "mohawk/myst_stacks/myst.h"
 
 #include "common/events.h"
+#include "common/math.h"
 #include "common/system.h"
 #include "common/textconsole.h"
 
@@ -3246,9 +3247,9 @@ Common::Point Myst::towerRotationMapComputeCoords(uint16 angle) {
 	Common::Point end;
 
 	// Polar to rect coords
-	double radians = angle * M_PI / 180.0;
-	end.x = (int16)(_towerRotationCenter.x + cos(radians) * 310.0);
-	end.y = (int16)(_towerRotationCenter.y + sin(radians) * 310.0);
+	float radians = Common::deg2rad<uint16,float>(angle);
+	end.x = (int16)(_towerRotationCenter.x + cos(radians) * 310.0f);
+	end.y = (int16)(_towerRotationCenter.y + sin(radians) * 310.0f);
 
 	return end;
 }

--- a/engines/titanic/star_control/fpose.cpp
+++ b/engines/titanic/star_control/fpose.cpp
@@ -24,6 +24,8 @@
 #include "titanic/star_control/matrix_transform.h"
 #include "titanic/star_control/matrix_inv.h"
 
+#include "common/math.h"
+
 namespace Titanic {
 
 // Non-member functions
@@ -91,9 +93,8 @@ void FPose::identity() {
 
 // Source: https://en.wikipedia.org/wiki/Rotation_matrix
 void FPose::setRotationMatrix(Axis axis, float amount) {
-	const float ROTATION = (float)(2 * M_PI / 360.0);
-	float sinVal = sin(amount * ROTATION);
-	float cosVal = cos(amount * ROTATION);
+	float sinVal = sin(Common::deg2rad<float>(amount));
+	float cosVal = cos(Common::deg2rad<float>(amount));
 
 	switch (axis) {
 	case X_AXIS:

--- a/engines/titanic/star_control/fvector.cpp
+++ b/engines/titanic/star_control/fvector.cpp
@@ -22,7 +22,8 @@
 
 #include "titanic/star_control/fvector.h"
 #include "titanic/star_control/fpose.h"
-//#include "common/textconsole.h"
+
+#include "common/math.h"
 
 namespace Titanic {
 
@@ -44,8 +45,8 @@ FVector FVector::crossProduct(const FVector &src) const {
 }
 
 void FVector::rotVectAxisY(float angleDeg) {
-	float sinVal = sin(angleDeg * Deg2Rad);
-	float cosVal = cos(angleDeg * Deg2Rad);
+	float sinVal = sin(Common::deg2rad<double>(angleDeg));
+	float cosVal = cos(Common::deg2rad<double>(angleDeg));
 	float x = cosVal * _x - sinVal * _z;
 	float z = cosVal * _z + sinVal * _x;
 
@@ -115,14 +116,14 @@ FPose FVector::getFrameTransform(const FVector &v) {
 	FPose matrix1, matrix2, matrix3, matrix4;
 
 	FVector vector1 = getAnglesAsVect();
-	matrix1.setRotationMatrix(X_AXIS, vector1._y * Rad2Deg);
-	matrix2.setRotationMatrix(Y_AXIS, vector1._z * Rad2Deg);
+	matrix1.setRotationMatrix(X_AXIS, Common::rad2deg<double>(vector1._y));
+	matrix2.setRotationMatrix(Y_AXIS, Common::rad2deg<double>(vector1._z));
 	fposeProd(matrix1, matrix2, matrix3);
 	matrix4 = matrix3.inverseTransform();
 
 	vector1 = v.getAnglesAsVect();
-	matrix1.setRotationMatrix(X_AXIS, vector1._y * Rad2Deg);
-	matrix2.setRotationMatrix(Y_AXIS, vector1._z * Rad2Deg);
+	matrix1.setRotationMatrix(X_AXIS, Common::rad2deg<double>(vector1._y));
+	matrix2.setRotationMatrix(Y_AXIS, Common::rad2deg<double>(vector1._z));
 	fposeProd(matrix1, matrix2, matrix3);
 	fposeProd(matrix4, matrix3, matrix1);
 
@@ -132,8 +133,8 @@ FPose FVector::getFrameTransform(const FVector &v) {
 FPose FVector::formRotXY() const {
 	FVector v1 = getAnglesAsVect();
 	FPose m1, m2;
-	m1.setRotationMatrix(X_AXIS, v1._y * Rad2Deg);
-	m2.setRotationMatrix(Y_AXIS, v1._z * Rad2Deg);
+	m1.setRotationMatrix(X_AXIS, Common::rad2deg<double>(v1._y));
+	m2.setRotationMatrix(Y_AXIS, Common::rad2deg<double>(v1._z));
 	FPose m3;
 	fposeProd(m1, m2, m3);
 	return m3;

--- a/engines/titanic/star_control/fvector.h
+++ b/engines/titanic/star_control/fvector.h
@@ -27,8 +27,6 @@
 
 namespace Titanic {
 
-const double Rad2Deg = 180.0 / M_PI;
-const double Deg2Rad = 1.0 / Rad2Deg;
 enum Axis { X_AXIS, Y_AXIS, Z_AXIS };
 
 class FPose;

--- a/engines/titanic/star_control/star_closeup.cpp
+++ b/engines/titanic/star_control/star_closeup.cpp
@@ -26,6 +26,8 @@
 #include "titanic/star_control/surface_area.h"
 #include "titanic/titanic.h"
 
+#include "common/math.h"
+
 namespace Titanic {
 
 #define MKTAG_BE(a3,a2,a1,a0) ((uint32)((a3) | ((a2) << 8) | ((a1) << 16) | ((a0) << 24)))
@@ -65,7 +67,6 @@ bool CStarCloseup::setup() {
 }
 
 bool CStarCloseup::setup2(int val1, int val2) {
-	const float FACTOR = 2 * M_PI / 360.0;
 	const int VALUES1[] = { 0x800, 0xC00, 0x1000, 0x1400, 0x1800 };
 	const int VALUES2[] = {
 		0xF95BCD, 0xA505A0, 0xFFAD43, 0x98F4EB, 0xF3EFA5, 0,
@@ -83,7 +84,7 @@ bool CStarCloseup::setup2(int val1, int val2) {
 			e->_pixel3 = 0x40;
 			e->_field8 = g_vm->getRandomNumber(3) + 3;
 			e->_fieldC = g_vm->getRandomNumber(255);
-			e->_field10 = FACTOR * 7.0;
+			e->_field10 = Common::deg2rad<double>(7.0);
 			e->_field14 = 0.0084687499;
 
 			++e;
@@ -93,7 +94,7 @@ bool CStarCloseup::setup2(int val1, int val2) {
 			e->_pixel3 = 0;
 			e->_field8 = g_vm->getRandomNumber(3) + 3;
 			e->_fieldC = g_vm->getRandomNumber(255);
-			e->_field10 = FACTOR * 3.0;
+			e->_field10 = Common::deg2rad<double>(3.0);
 			e->_field14 = 0.021011719;
 
 			++e;
@@ -113,7 +114,7 @@ bool CStarCloseup::setup2(int val1, int val2) {
 			e->_pixel3 = 0;
 			e->_field8 = g_vm->getRandomNumber(3) + 3;
 			e->_fieldC = g_vm->getRandomNumber(255);
-			e->_field10 = FACTOR * 2.0;
+			e->_field10 = Common::deg2rad<double>(2.0);
 			e->_field14 = 0.01178125;
 
 			++e;
@@ -123,7 +124,7 @@ bool CStarCloseup::setup2(int val1, int val2) {
 			e->_pixel3 = 0;
 			e->_field8 = g_vm->getRandomNumber(3) + 3;
 			e->_fieldC = g_vm->getRandomNumber(255);
-			e->_field10 = FACTOR * 1.0;
+			e->_field10 = Common::deg2rad<double>(1.0);
 			e->_field14 = 0.24791406;
 
 			++e;
@@ -133,7 +134,7 @@ bool CStarCloseup::setup2(int val1, int val2) {
 			e->_pixel3 = 0xe6;
 			e->_field8 = g_vm->getRandomNumber(3) + 3;
 			e->_fieldC = g_vm->getRandomNumber(255);
-			e->_field10 = FACTOR * 3.0;
+			e->_field10 = Common::deg2rad<double>(3.0);
 			e->_field14 = 0.20832032;
 
 			++e;
@@ -143,7 +144,7 @@ bool CStarCloseup::setup2(int val1, int val2) {
 			e->_pixel3 = 0x28;
 			e->_field8 = g_vm->getRandomNumber(3) + 3;
 			e->_fieldC = g_vm->getRandomNumber(255);
-			e->_field10 = FACTOR * 1.0;
+			e->_field10 = Common::deg2rad<double>(1.0);
 			e->_field14 = 0.088164061;
 
 			++e;
@@ -153,7 +154,7 @@ bool CStarCloseup::setup2(int val1, int val2) {
 			e->_pixel3 = 0xf0;
 			e->_field8 = g_vm->getRandomNumber(3) + 3;
 			e->_fieldC = g_vm->getRandomNumber(255);
-			e->_field10 = FACTOR * 2.0;
+			e->_field10 = Common::deg2rad<double>(2.0);
 			e->_field14 = 0.084375001;
 
 			++e;
@@ -163,7 +164,7 @@ bool CStarCloseup::setup2(int val1, int val2) {
 			e->_pixel3 = 0x20;
 			e->_field8 = g_vm->getRandomNumber(3) + 3;
 			e->_fieldC = g_vm->getRandomNumber(255);
-			e->_field10 = FACTOR * 17.0;
+			e->_field10 = Common::deg2rad<double>(17.0);
 			e->_field14 = 1 / 256.0;
 		} else {
 			for (int ctr = 0; ctr < 5; ++ctr) {
@@ -174,9 +175,8 @@ bool CStarCloseup::setup2(int val1, int val2) {
 				e->_pixel2 = (val >> 8) & 0xff;
 				e->_pixel3 = (val >> 16) & 0xff;
 				e->_field8 = g_vm->getRandomNumber(3) + 3;
-
 				e->_fieldC = g_vm->getRandomNumber(255);
-				e->_field10 = FACTOR * (float)g_vm->getRandomNumber(15);
+				e->_field10 = Common::deg2rad<double>((double)g_vm->getRandomNumber(15));
 				e->_field14 = ((float)g_vm->getRandomNumber(0xfffffffe)
 					* 50.0 / 65536.0) / 256.0;
 			}
@@ -492,7 +492,6 @@ bool CStarCloseup::setupEntry(int width, int height, int index, float val) {
 	SubEntry &entry = _array[index];
 	entry.clear();
 
-	const float FACTOR = 2.0 * M_PI / 360.0;
 	int d1Count, d2Count, size3, height1;
 	int ctr, ctr2, idx, incr;
 	float vx, vy, yVal, degrees, cosVal, sinVal, angle;
@@ -511,12 +510,12 @@ bool CStarCloseup::setupEntry(int width, int height, int index, float val) {
 
 	for (ctr = height - 2, idx = 1, yVal = vy; ctr > 0; --ctr, yVal += vy) {
 		degrees = 0.0;
-		cosVal = cos(yVal * FACTOR);
-		sinVal = sin(yVal * FACTOR);
+		cosVal = cos(Common::deg2rad<float>(yVal));
+		sinVal = sin(Common::deg2rad<float>(yVal));
 
 		if (width > 0) {
 			for (int xCtr = 0; xCtr < width; ++xCtr, ++idx, degrees += vx) {
-				angle = degrees * FACTOR;
+				angle = Common::deg2rad<float>(degrees);
 
 				FVector &tempV = entry._data2[idx];
 				tempV._x = sin(angle) * sinVal * val;

--- a/engines/titanic/star_control/star_closeup.h
+++ b/engines/titanic/star_control/star_closeup.h
@@ -77,6 +77,7 @@ class CStarCloseup {
 
 	/**
 	 * Maintains a pre-calculated table of sine values
+	 * TODO: May be able to reuse common/sinetables.h
 	 */
 	struct SineTable {
 	private:

--- a/engines/titanic/star_control/star_points1.cpp
+++ b/engines/titanic/star_control/star_points1.cpp
@@ -26,10 +26,11 @@
 #include "titanic/support/files_manager.h"
 #include "titanic/titanic.h"
 
+#include "common/math.h"
+
 namespace Titanic {
 
 #define ARRAY_COUNT 876
-const double FACTOR = 2 * M_PI / 360.0;
 
 CStarPoints1::CStarPoints1() {
 }
@@ -48,8 +49,8 @@ bool CStarPoints1::initialize() {
 		double v2 = stream->readSint32LE();
 		entry._flag = stream->readUint32LE() != 0;
 
-		v1 *= 0.015 * FACTOR;
-		v2 *= 0.0099999998 * FACTOR;
+		v1 *= Common::deg2rad<double>(0.015);
+		v2 *= Common::deg2rad<double>(0.0099999998);
 
 		entry._x = cos(v2) * 3000000.0 * cos(v1);
 		entry._y = sin(v1) * 3000000.0 * cos(v2);

--- a/engines/titanic/star_control/star_points2.cpp
+++ b/engines/titanic/star_control/star_points2.cpp
@@ -26,10 +26,11 @@
 #include "titanic/support/files_manager.h"
 #include "titanic/titanic.h"
 
+#include "common/math.h"
+
 namespace Titanic {
 
 #define ARRAY_COUNT 80
-const double FACTOR = 2 * M_PI / 360.0;
 
 bool CStarPoints2::initialize() {
 	// Get a reference to the starfield points resource
@@ -51,8 +52,8 @@ bool CStarPoints2::initialize() {
 			for (int fctr = 0; fctr < 2; ++fctr) {
 				v1 = stream->readSint32LE();
 				v2 = stream->readSint32LE();
-				v1 *= 0.015 * FACTOR;
-				v2 *= FACTOR / 100.0;
+				v1 *= Common::deg2rad<double>(0.015);
+				v2 *= Common::deg2rad<double>(0.01);
 
 				vectors[fctr]->_x = cos(v1) * 3000000.0 * cos(v2);
 				vectors[fctr]->_y = sin(v1) * 3000000.0 * cos(v2);

--- a/engines/titanic/star_control/viewport.cpp
+++ b/engines/titanic/star_control/viewport.cpp
@@ -26,6 +26,8 @@
 #include "titanic/support/simple_file.h"
 #include "titanic/titanic.h"
 
+#include "common/math.h"
+
 namespace Titanic {
 
 CViewport::CViewport() {
@@ -299,8 +301,8 @@ void CViewport::reset() {
 
 	_center = FPoint((double)_width * 0.5, (double)_height * 0.5);
 	_centerVector._x = MIN(_center._x, _center._y);
-	_centerVector._y = tan(_centerYAngleDegrees * Deg2Rad);
-	_centerVector._z = tan(_centerZAngleDegrees * Deg2Rad);
+	_centerVector._y = tan(Common::deg2rad<double>(_centerYAngleDegrees));
+	_centerVector._z = tan(Common::deg2rad<double>(_centerZAngleDegrees));
 }
 
 const FMatrix &CViewport::getOrientation() const {

--- a/engines/wintermute/base/scriptables/script_ext_math.cpp
+++ b/engines/wintermute/base/scriptables/script_ext_math.cpp
@@ -120,7 +120,7 @@ bool SXMath::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "Cos") == 0) {
 		stack->correctParams(1);
-		stack->pushFloat(cos(degreeToRadian(stack->pop()->getFloat())));
+		stack->pushFloat(cos(Common::deg2rad<double>(stack->pop()->getFloat())));
 		return STATUS_OK;
 	}
 
@@ -129,7 +129,7 @@ bool SXMath::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "Cosh") == 0) {
 		stack->correctParams(1);
-		stack->pushFloat(cosh(degreeToRadian(stack->pop()->getFloat())));
+		stack->pushFloat(cosh(Common::deg2rad<double>(stack->pop()->getFloat())));
 		return STATUS_OK;
 	}
 
@@ -186,7 +186,7 @@ bool SXMath::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "Sin") == 0) {
 		stack->correctParams(1);
-		stack->pushFloat(sin(degreeToRadian(stack->pop()->getFloat())));
+		stack->pushFloat(sin(Common::deg2rad<double>(stack->pop()->getFloat())));
 		return STATUS_OK;
 	}
 
@@ -195,7 +195,7 @@ bool SXMath::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "Sinh") == 0) {
 		stack->correctParams(1);
-		stack->pushFloat(sinh(degreeToRadian(stack->pop()->getFloat())));
+		stack->pushFloat(sinh(Common::deg2rad<double>(stack->pop()->getFloat())));
 		return STATUS_OK;
 	}
 
@@ -204,7 +204,7 @@ bool SXMath::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "Tan") == 0) {
 		stack->correctParams(1);
-		stack->pushFloat(tan(degreeToRadian(stack->pop()->getFloat())));
+		stack->pushFloat(tan(Common::deg2rad<double>(stack->pop()->getFloat())));
 		return STATUS_OK;
 	}
 
@@ -213,7 +213,7 @@ bool SXMath::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "Tanh") == 0) {
 		stack->correctParams(1);
-		stack->pushFloat(tanh(degreeToRadian(stack->pop()->getFloat())));
+		stack->pushFloat(tanh(Common::deg2rad<double>(stack->pop()->getFloat())));
 		return STATUS_OK;
 	}
 
@@ -231,7 +231,7 @@ bool SXMath::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "DegToRad") == 0) {
 		stack->correctParams(1);
-		stack->pushFloat(degreeToRadian(stack->pop()->getFloat()));
+		stack->pushFloat(Common::deg2rad<double>(stack->pop()->getFloat()));
 		return STATUS_OK;
 	}
 
@@ -240,7 +240,7 @@ bool SXMath::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "RadToDeg") == 0) {
 		stack->correctParams(1);
-		stack->pushFloat(radianToDegree(stack->pop()->getFloat()));
+		stack->pushFloat(Common::rad2deg<double>(stack->pop()->getFloat()));
 		return STATUS_OK;
 	} else {
 		return STATUS_FAILED;
@@ -269,18 +269,6 @@ ScValue *SXMath::scGetProperty(const Common::String &name) {
 	} else {
 		return _scValue;
 	}
-}
-
-
-//////////////////////////////////////////////////////////////////////////
-double SXMath::degreeToRadian(double value) {
-	return value * (M_PI / 180.0f);
-}
-
-
-//////////////////////////////////////////////////////////////////////////
-double SXMath::radianToDegree(double value) {
-	return value * (180.0f / M_PI);
 }
 
 

--- a/engines/zvision/graphics/render_table.cpp
+++ b/engines/zvision/graphics/render_table.cpp
@@ -20,9 +20,11 @@
  *
  */
 
-#include "common/scummsys.h"
 #include "zvision/graphics/render_table.h"
+
+#include "common/math.h"
 #include "common/rect.h"
+#include "common/scummsys.h"
 #include "graphics/colormasks.h"
 
 namespace ZVision {
@@ -144,7 +146,7 @@ void RenderTable::generatePanoramaLookupTable() {
 	float halfWidth = (float)_numColumns / 2.0f;
 	float halfHeight = (float)_numRows / 2.0f;
 
-	float fovInRadians = (_panoramaOptions.fieldOfView * M_PI / 180.0f);
+	float fovInRadians = Common::deg2rad<float>(_panoramaOptions.fieldOfView);
 	float cylinderRadius = halfHeight / tan(fovInRadians);
 
 	for (uint x = 0; x < _numColumns; ++x) {
@@ -176,7 +178,7 @@ void RenderTable::generateTiltLookupTable() {
 	float halfWidth = (float)_numColumns / 2.0f;
 	float halfHeight = (float)_numRows / 2.0f;
 
-	float fovInRadians = (_tiltOptions.fieldOfView * M_PI / 180.0f);
+	float fovInRadians = Common::deg2rad<float>(_tiltOptions.fieldOfView);
 	float cylinderRadius = halfWidth / tan(fovInRadians);
 	_tiltOptions.gap = cylinderRadius * atan2((float)(halfHeight / cylinderRadius), 1.0f) * _tiltOptions.linearScale;
 

--- a/graphics/transform_tools.cpp
+++ b/graphics/transform_tools.cpp
@@ -22,12 +22,13 @@
 
 
 #include "graphics/transform_tools.h"
+#include "common/math.h"
 #include <math.h>
 
 namespace Graphics {
 
 FloatPoint TransformTools::transformPoint(FloatPoint point, const float rotate, const Common::Point &zoom, const bool mirrorX, const bool mirrorY) {
-	float rotateRad = rotate * M_PI / 180.0f;
+	float rotateRad = Common::deg2rad<float>(rotate);
 	float x = point.x;
 	float y = point.y;
 	x = (x * zoom.x) / kDefaultZoomX;

--- a/graphics/transparent_surface.cpp
+++ b/graphics/transparent_surface.cpp
@@ -796,8 +796,9 @@ TransparentSurface *TransparentSurface::rotoscaleT(const TransformStruct &transf
 	}
 
 	uint32 invAngle = 360 - (transform._angle % 360);
-	float invCos = cos(invAngle * M_PI / 180.0);
-	float invSin = sin(invAngle * M_PI / 180.0);
+	float invAngleRad = Common::deg2rad<uint32,float>(invAngle);
+	float invCos = cos(invAngleRad);
+	float invSin = sin(invAngleRad);
 
 	int icosx = (int)(invCos * (65536.0f * kDefaultZoomX / transform._zoom.x));
 	int isinx = (int)(invSin * (65536.0f * kDefaultZoomX / transform._zoom.x));


### PR DESCRIPTION
In several engines various M_PI/180.0, its reciprocal, and engine specific functions (radianToDegree...) have been replaced with these degree conversions functions from common math.

In sci I changed a few doubles to floats since the extra precision/expensiveness seemed unnecessary.