### PR TITLE
COMMON: Expand cosine and sine table features

### DIFF
--- a/common/cosinetables.cpp
+++ b/common/cosinetables.cpp
@@ -32,17 +32,35 @@ CosineTable::CosineTable(int bitPrecision) {
 
 	_bitPrecision = bitPrecision;
 
-	int m = 1 << _bitPrecision;
-	double freq = 2 * M_PI / m;
-	_table = new float[m / 2];
+	_nPoints = 1 << _bitPrecision;
+	_radResolution = 2.0 * M_PI / _nPoints;
+	_refSize = _nPoints / 4;
+	_table = new float[_nPoints / 2];
 
-	// Table contains cos(2*pi*i/m) for 0<=i<m/4,
-	// followed by 3m/4<=i<m
-	for (int i = 0; i <= m / 4; i++)
-		_table[i] = cos(i * freq);
+	// Table contains cos(2*pi*i/_nPoints) for 0<=i<=_nPoints/4,
+	// followed by 3_nPoints/4<=i<_nPoints
+	for (int i = 0; i <= _nPoints / 4; i++)
+		_table[i] = cos(i * _radResolution);
 
-	for (int i = 1; i < m / 4; i++)
-		_table[m / 2 - i] = _table[i];
+	for (int i = 1; i < _nPoints / 4; i++)
+		_table[_nPoints / 2 - i] = _table[i];
+}
+
+float CosineTable::at(int index) const {
+	assert((index >= 0) && (index < _nPoints));
+	if (index < _refSize)
+		// [0,pi/2)
+		return _table[index];
+	if ((index > _refSize) && (index < 2 * _refSize))
+		// (pi/2,pi)
+		return -_table[2 * _refSize - index];
+	if ((index >= 2 * _refSize) && (index < 3 * _refSize))
+		// [pi,3/2pi)
+		return -_table[index - 2 * _refSize];
+	if ((index > 3 * _refSize) && (index < _nPoints))
+		// (3/2pi,2pi)
+		return _table[_nPoints - index];
+	return 0.0f; // cos(pi/2) and cos(3pi/2) = 0
 }
 
 CosineTable::~CosineTable() {

--- a/common/cosinetables.h
+++ b/common/cosinetables.h
@@ -39,22 +39,32 @@ public:
 	 * Get pointer to table.
 	 *
 	 * This table contains 2^bitPrecision/2 entries.
+	 * Prefer to use at()
 	 * The layout of this table is as follows:
-	 * - Entries 0 up to (excluding) 2^bitPrecision/4:
-	 *           cos(0) till (excluding) cos(1/2*pi)
-	 * - Entries 2^bitPrecision/4 up to (excluding) 2^bitPrecision/2:
-	 *           cos(3/2*pi) till (excluding) cos(2*pi)
+	 * - Entries 0 up to (including) 2^bitPrecision/4:
+	 *           cos(0) till (including) cos(1/2*pi)
+	 * - Entries (excluding) 2^bitPrecision/4 up to 2^bitPrecision/2:
+	 *           (excluding) cos(3/2*pi) till (excluding) cos(2*pi)
 	 */
 	const float *getTable() { return _table; }
 
 	/**
-	 * Get pointer to table
+	 * Returns cos(2*pi * index / 2^bitPrecision )
+	 * Index must be in range [0,2^bitPrecision-1]
 	 */
-	int getPrecision() { return _bitPrecision; }
+	float at(int index) const;
+
+	/**
+	 * Get bit precision
+	 */
+	int getBitPrecision() { return _bitPrecision; }
 
 private:
 	float *_table;
 	int _bitPrecision;
+	double _radResolution; // Smallest radian increment
+	int _refSize; // _nPoints / 4
+	int _nPoints; // range of operator[]
 };
 
 } // End of namespace Common

--- a/common/sinetables.h
+++ b/common/sinetables.h
@@ -39,22 +39,32 @@ public:
 	 * Get pointer to table
 	 *
 	 * This table contains 2^bitPrecision/2 entries.
+	 * Prefer to use at()
 	 * The layout of this table is as follows:
 	 * - Entries 0 up to (excluding) 2^bitPrecision/4:
 	 *           sin(0) till (excluding) sin(1/2*pi)
-	 * - Entries 2^bitPrecision/4 up to (excluding) 2^bitPrecision/2:
+	 * - Entries 2^bitPrecision/4 up to 2^bitPrecision/2:
 	 *           sin(pi) till (excluding) sin(3/2*pi)
 	 */
 	const float *getTable() { return _table; }
 
 	/**
-	 * Get pointer to table
+	 * Returns sin(2*pi * index / 2^bitPrecision )
+	 * Index must be in range [0,2^bitPrecision-1]
 	 */
-	int getPrecision() { return _bitPrecision; }
+	float at(int index) const;
+
+	/**
+	 * Get bit precision
+	 */
+	int getBitPrecision() { return _bitPrecision; }
 
 private:
 	float *_table;
 	int _bitPrecision;
+	double _radResolution; // Smallest radian increment
+	int _refSize; // _nPoints / 4
+	int _nPoints; // range of operator[]
 };
 
 } // End of namespace Common


### PR DESCRIPTION
The cos/sin table class now has its array index operator
overridden so that it can be indexed rather than have
the internal table indexed directly.

This allows the checking and computing of the correct
indexes to be done internally.

The indexing in allows cos/sine of 0 to 2pi to be
obtained. Internally, cos/sine values of only 0 to pi/2
are computed.

An alternate way can have all 0 to 2pi cos/sine values
stored in memory, which will duplcate values, but require
less if checks for the correct index in operator[].

getByValue also allows the cosine/sine value
that is closests to the radian value returned.
Which is an approximation to cos and sine.

I am not sure why the current cosine Table only generates
cos values at angles where the cosine is positive.

If we feel good about the current cosineTable usage in dct, fft, and similar
and mine is too much of a deviation maybe we can have both classes and
rename the current one eosCosineTable or similar.

bladerunner and titanic both use a sine/cosine table so that is a good
case for a modified common cosine/sine table like this,