### PR TITLE
ENGINES: Add an engine id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1360,7 +1360,7 @@ arguments -- see the next section.
 
     Usage: scummvm [OPTIONS]... [GAME]
 
-    [GAME]                   Short name of game to load. For example, 'monkey'
+    [GAME]                   Short name of game to load. For example, 'scumm:monkey'
                               for Monkey Island. This can be either a built-in
                               gameid, or a user configured target.
 
@@ -1368,6 +1368,7 @@ arguments -- see the next section.
     -h, --help               Display a brief help text and exit
     -z, --list-games         Display list of supported games and exit
     -t, --list-targets       Display list of configured targets and exit
+    --list-engines           Display list of suppported engines and exit
     --list-saves             Display a list of saved games for the target specified
                               with --game=TARGET, or all targets if none is specified
     -a, --add                Add all games from current or specified directory.
@@ -1461,17 +1462,17 @@ Examples:
   - Win32:
     Running Monkey Island, fullscreen, from a hard disk:
     `C:\Games\LucasArts\scummvm.exe -f -pC:\Games\LucasArts\monkey\
-    monkey`
+    scumm:monkey`
     Running Full Throttle from CD, fullscreen and with subtitles
     enabled:
-    `C:\Games\LucasArts\scummvm.exe -f -n -pD:\resource\ ft`
+    `C:\Games\LucasArts\scummvm.exe -f -n -pD:\resource\ scumm:ft`
 
   - Unix:
     Running Monkey Island, fullscreen, from a hard disk:
-    `/path/to/scummvm -f -p/games/LucasArts/monkey/ monkey`
+    `/path/to/scummvm -f -p/games/LucasArts/monkey/ scumm:monkey`
     Running Full Throttle from CD, fullscreen and with subtitles
     enabled:
-    `/path/to/scummvm -f -n -p/cdrom/resource/ ft`
+    `/path/to/scummvm -f -n -p/cdrom/resource/ scumm:ft`
 
 ### 5.2) Global Menu
 
@@ -1549,7 +1550,7 @@ They are:
 To select a graphics filter, select it in the Launcher, or pass its name
 via the '-g' option to scummvm, for example:
 
-    scummvm -gadvmame2x monkey2
+    scummvm -gadvmame2x scumm:monkey2
 
 Note \#1: Not all backends support all (or even any) of the filters
 listed above; some may support additional ones. The filters listed above
@@ -2114,7 +2115,7 @@ depending on your operating system and configuration.
 To select a sound driver, select it in the Launcher, or pass its name
 via the `-e` option to scummvm, for example:
 
-`scummvm -eadlib monkey2`
+`scummvm -eadlib scumm:monkey2`
 
 ### 7.1) AdLib emulation
 

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -262,7 +262,7 @@ public:
 extern int handleInput(struct mapledev *pad,
 		       int &mouse_x, int &mouse_y,
 		       byte &shiftFlags, Interactive *inter = NULL);
-extern bool selectGame(char *&, char *&, Common::Language &, Common::Platform &, class Icon &);
+extern bool selectGame(char *&, char *&, char *&, Common::Language &, Common::Platform &, class Icon &);
 #ifdef DYNAMIC_MODULES
 extern bool selectPluginDir(Common::String &selection, const Common::FSNode &base);
 #endif

--- a/backends/platform/dc/dcmain.cpp
+++ b/backends/platform/dc/dcmain.cpp
@@ -365,28 +365,31 @@ int main()
 
 int DCLauncherDialog::runModal()
 {
-  char *base = NULL, *dir = NULL;
+  char *engineId = NULL, *gameId = NULL, *dir = NULL;
   Common::Language language = Common::UNK_LANG;
   Common::Platform platform = Common::kPlatformUnknown;
 
-  if (!selectGame(base, dir, language, platform, icon))
+  if (!selectGame(engineId, gameId, dir, language, platform, icon))
     g_system->quit();
 
   // Set the game path.
-  ConfMan.addGameDomain(base);
+  ConfMan.addGameDomain(gameId);
+  ConfMan.set("engineid", engineId, gameId);
+  ConfMan.set("gameid", gameId, gameId);
+
   if (dir != NULL)
-    ConfMan.set("path", dir, base);
+    ConfMan.set("path", dir, gameId);
 
   // Set the game language.
   if (language != Common::UNK_LANG)
-    ConfMan.set("language", Common::getLanguageCode(language), base);
+    ConfMan.set("language", Common::getLanguageCode(language), gameId);
 
   // Set the game platform.
   if (platform != Common::kPlatformUnknown)
-    ConfMan.set("platform", Common::getPlatformCode(platform), base);
+    ConfMan.set("platform", Common::getPlatformCode(platform), gameId);
 
   // Set the target.
-  ConfMan.setActiveDomain(base);
+  ConfMan.setActiveDomain(gameId);
 
   return 0;
 }

--- a/backends/platform/dc/selector.cpp
+++ b/backends/platform/dc/selector.cpp
@@ -137,6 +137,7 @@ void draw_trans_quad(float x1, float y1, float x2, float y2,
 struct Game
 {
   char dir[256];
+  char engine_id[256];
   char filename_base[256];
   char text[256];
   Common::Language language;
@@ -233,6 +234,8 @@ static int findGames(Game *games, int max, bool use_ini)
       }
       if (curr_game < max) {
 	strcpy(games[curr_game].filename_base, (*i)._key.c_str());
+	strncpy(games[curr_game].engine_id, (*i)._value["engineid"].c_str(), 256);
+	games[curr_game].engine_id[255] = '\0';
 	strncpy(games[curr_game].dir, dirs[j].node.getPath().c_str(), 256);
 	games[curr_game].dir[255] = '\0';
 	games[curr_game].language = Common::UNK_LANG;
@@ -278,6 +281,7 @@ static int findGames(Game *games, int max, bool use_ini)
       for (DetectedGames::const_iterator ge = candidates.begin();
 	   ge != candidates.end(); ++ge)
 	if (curr_game < max) {
+	  strcpy(games[curr_game].engine_id, ge->engineId.c_str());
 	  strcpy(games[curr_game].filename_base, ge->gameId.c_str());
 	  strcpy(games[curr_game].dir, dirs[curr_dir-1].name);
 	  games[curr_game].language = ge->language;
@@ -465,7 +469,7 @@ int gameMenu(Game *games, int num_games)
   }
 }
 
-bool selectGame(char *&ret, char *&dir_ret, Common::Language &lang_ret, Common::Platform &plf_ret, Icon &icon)
+bool selectGame(char *&engineId, char *&ret, char *&dir_ret, Common::Language &lang_ret, Common::Platform &plf_ret, Icon &icon)
 {
   Game *games = new Game[MAX_GAMES];
   int selected, num_games;
@@ -510,6 +514,7 @@ bool selectGame(char *&ret, char *&dir_ret, Common::Language &lang_ret, Common::
     chdir("/");
     dir_ret = the_game.dir;
 #endif
+    engineId = the_game.engine_id;
     ret = the_game.filename_base;
     lang_ret = the_game.language;
     plf_ret = the_game.platform;

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -769,6 +769,7 @@ static Common::Error listSaves(const Common::String &target) {
 		const Plugin *plugin = nullptr;
 		PlainGameDescriptor game;
 		if (domain) {
+			EngineMan.upgradeTargetIfNecessary(target);
 			game = EngineMan.findTarget(target, &plugin);
 		} else {
 			game = EngineMan.findGame(target, &plugin);

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -763,22 +763,15 @@ static void listGames() {
 	printf("Game ID                        Full Title                                                 \n"
 	       "------------------------------ -----------------------------------------------------------\n");
 
-	Common::Array<Common::String> games;
-
 	const PluginList &plugins = EngineMan.getPlugins();
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngine &metaengine = (*iter)->get<MetaEngine>();
 
 		PlainGameList list = metaengine.getSupportedGames();
 		for (PlainGameList::const_iterator v = list.begin(); v != list.end(); ++v) {
-			games.push_back(Common::String::format("%-30s %s", buildQualifiedGameName(metaengine.getEngineId(), v->gameId).c_str(), v->description));
+			printf("%-30s %s\n", buildQualifiedGameName(metaengine.getEngineId(), v->gameId).c_str(), v->description);
 		}
 	}
-
-	Common::sort(games.begin(), games.end());
-
-	for (Common::Array<Common::String>::const_iterator i = games.begin(), end = games.end(); i != end; ++i)
-		printf("%s\n", i->c_str());
 }
 
 /** List all supported engines, i.e. all loaded plugins. */
@@ -786,18 +779,11 @@ static void listEngines() {
 	printf("Engine ID       Engine Name                                           \n"
 	       "--------------- ------------------------------------------------------\n");
 
-	Common::Array<Common::String> engines;
-
 	const PluginList &plugins = EngineMan.getPlugins();
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngine &metaEngine = (*iter)->get<MetaEngine>();
-		engines.push_back(Common::String::format("%-15s %s", metaEngine.getEngineId(), metaEngine.getName()));
+		printf("%-15s %s\n", metaEngine.getEngineId(), metaEngine.getName());
 	}
-
-	Common::sort(engines.begin(), engines.end());
-
-	for (Common::Array<Common::String>::const_iterator i = engines.begin(), end = engines.end(); i != end; ++i)
-		printf("%s\n", i->c_str());
 }
 
 /** List all targets which are configured in the config file. */

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -545,6 +545,8 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	while (0 != ConfMan.getActiveDomain()) {
 		saveLastLaunchedTarget(ConfMan.getActiveDomainName());
 
+		EngineMan.upgradeTargetIfNecessary(ConfMan.getActiveDomainName());
+
 		// Try to find a plugin which feels responsible for the specified game.
 		const Plugin *plugin = detectPlugin();
 		if (plugin) {

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -108,37 +108,48 @@ static bool launcherDialog() {
 }
 
 static const Plugin *detectPlugin() {
-	const Plugin *plugin = nullptr;
+	// Figure out the engine ID and game ID
+	Common::String engineId = ConfMan.get("engineid");
+	Common::String gameId = ConfMan.get("gameid");
 
-	// Make sure the gameid is set in the config manager, and that it is lowercase.
-	Common::String gameid(ConfMan.getActiveDomainName());
-	assert(!gameid.empty());
-	if (ConfMan.hasKey("gameid")) {
-		gameid = ConfMan.get("gameid");
+	// Print text saying what's going on
+	printf("User picked target '%s' (engine ID '%s', game ID '%s')...\n", ConfMan.getActiveDomainName().c_str(), engineId.c_str(), gameId.c_str());
 
-		// Set last selected game, that the game will be highlighted
-		// on RTL
-		ConfMan.set("lastselectedgame", ConfMan.getActiveDomainName(), Common::ConfigManager::kApplicationDomain);
-		ConfMan.flushToDisk();
+	// At this point the engine ID and game ID must be known
+	if (engineId.empty()) {
+		warning("The engine ID is not set for target '%s'", ConfMan.getActiveDomainName().c_str());
+		return 0;
 	}
 
-	gameid.toLowercase();
-	ConfMan.set("gameid", gameid);
+	if (gameId.empty()) {
+		warning("The game ID is not set for target '%s'", ConfMan.getActiveDomainName().c_str());
+		return 0;
+	}
 
-	// Query the plugins and find one that will handle the specified gameid
-	printf("User picked target '%s' (gameid '%s')...\n", ConfMan.getActiveDomainName().c_str(), gameid.c_str());
-	printf("  Looking for a plugin supporting this gameid... ");
+	const Plugin *plugin = EngineMan.findPlugin(engineId);
+	if (!plugin) {
+		warning("'%s' is an invalid engine ID. Use the --list-engines command to list supported engine IDs", engineId.c_str());
+		return 0;
+	}
 
-	PlainGameDescriptor game = EngineMan.findGame(gameid, &plugin);
-
-	if (plugin == 0) {
-		printf("failed\n");
-		warning("%s is an invalid gameid. Use the --list-games option to list supported gameid", gameid.c_str());
-	} else {
-		printf("%s\n  Starting '%s'\n", plugin->getName(), game.description);
+	// Query the plugin for the game descriptor
+	printf("   Looking for a plugin supporting this target... %s\n", plugin->getName());
+	PlainGameDescriptor game = plugin->get<MetaEngine>().findGame(gameId.c_str());
+	if (!game.gameId) {
+		warning("'%s' is an invalid game ID for the engine '%s'. Use the --list-games option to list supported game IDs", gameId.c_str(), engineId.c_str());
+		return 0;
 	}
 
 	return plugin;
+}
+
+void saveLastLaunchedTarget(const Common::String &target) {
+	if (ConfMan.hasGameDomain(target)) {
+		// Set the last selected game, so the game will be highlighted next time the user
+		// returns to the launcher.
+		ConfMan.set("lastselectedgame", target, Common::ConfigManager::kApplicationDomain);
+		ConfMan.flushToDisk();
+	}
 }
 
 // TODO: specify the possible return values here
@@ -208,7 +219,7 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 	Common::String caption(ConfMan.get("description"));
 
 	if (caption.empty()) {
-		PlainGameDescriptor game = EngineMan.findGame(ConfMan.get("gameid"));
+		PlainGameDescriptor game = EngineMan.findTarget(ConfMan.getActiveDomainName());
 		if (game.description) {
 			caption = game.description;
 		}
@@ -532,6 +543,8 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	// work as well as it should. In theory everything should be destroyed
 	// cleanly, so this is now enabled to encourage people to fix bits :)
 	while (0 != ConfMan.getActiveDomain()) {
+		saveLastLaunchedTarget(ConfMan.getActiveDomainName());
+
 		// Try to find a plugin which feels responsible for the specified game.
 		const Plugin *plugin = detectPlugin();
 		if (plugin) {

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -219,7 +219,7 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 	Common::String caption(ConfMan.get("description"));
 
 	if (caption.empty()) {
-		PlainGameDescriptor game = EngineMan.findTarget(ConfMan.getActiveDomainName());
+		QualifiedGameDescriptor game = EngineMan.findTarget(ConfMan.getActiveDomainName());
 		if (game.description) {
 			caption = game.description;
 		}

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -675,6 +675,90 @@ PlainGameDescriptor EngineManager::findTarget(const Common::String &target, cons
 	return desc;
 }
 
+void EngineManager::upgradeTargetIfNecessary(const Common::String &target) const {
+	Common::ConfigManager::Domain *domain = ConfMan.getDomain(target);
+	assert(domain);
+
+	if (!domain->contains("engineid")) {
+		upgradeTargetForEngineId(target);
+	}
+}
+
+void EngineManager::upgradeTargetForEngineId(const Common::String &target) const {
+	Common::ConfigManager::Domain *domain = ConfMan.getDomain(target);
+	assert(domain);
+
+	debug("Target '%s' lacks an engine ID, upgrading...", target.c_str());
+
+	Common::String oldGameId = domain->getVal("gameid");
+	Common::String path = domain->getVal("path");
+
+	// At this point the game ID and game path must be known
+	if (oldGameId.empty()) {
+		warning("The game ID is required to upgrade target '%s'", target.c_str());
+		return;
+	}
+	if (path.empty()) {
+		warning("The game path is required to upgrade target '%s'", target.c_str());
+		return;
+	}
+
+	// Game descriptor for the upgraded target
+	Common::String engineId;
+	Common::String newGameId;
+
+	// First, try to update entries for engines that previously used the "single id" system
+	// Search for an engine whose ID is the game ID
+	const Plugin *plugin = findPlugin(oldGameId);
+	if (plugin) {
+		// Run detection on the game path
+		Common::FSNode dir(path);
+		Common::FSList files;
+		if (!dir.getChildren(files, Common::FSNode::kListAll)) {
+			warning("Failed to access path '%s' when upgrading target '%s'", path.c_str(), target.c_str());
+			return;
+		}
+
+		// Take the first detection entry
+		const MetaEngine &metaEngine = plugin->get<MetaEngine>();
+		DetectedGames candidates = metaEngine.detectGames(files);
+		if (candidates.empty()) {
+			warning("No games supported by the engine '%s' were found in path '%s' when upgrading target '%s'",
+			        metaEngine.getEngineId(), path.c_str(), target.c_str());
+			return;
+		}
+
+		engineId = candidates[0].engineId;
+		newGameId = candidates[0].gameId;
+	}
+
+	// Next, try to find an engine with the game ID in its supported games list
+	if (engineId.empty()) {
+		PlainGameDescriptor pgd = findGame(oldGameId, &plugin);
+		if (plugin) {
+			engineId = plugin->get<MetaEngine>().getEngineId();
+			newGameId = pgd.gameId;
+		}
+	}
+
+	if (engineId.empty() || newGameId.empty()) {
+		warning("No matching engine was found when upgrading target '%s'", target.c_str());
+		return;
+	}
+
+	domain->setVal("engineid", engineId);
+	domain->setVal("gameid", newGameId);
+
+	// Save a backup of the pre-upgrade gameId to the config file
+	if (newGameId != oldGameId) {
+		domain->setVal("oldgameid", oldGameId);
+	}
+
+	debug("Upgrade complete (engine ID '%s', game ID '%s')", engineId.c_str(), newGameId.c_str());
+
+	ConfMan.flushToDisk();
+}
+
 // Music plugins
 
 #include "audio/musicplugin.h"

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -315,8 +315,8 @@ public:
 	virtual void init()	{}
 	virtual void loadFirstPlugin() {}
 	virtual bool loadNextPlugin() { return false; }
-	virtual bool loadPluginFromGameId(const Common::String &gameId) { return false; }
-	virtual void updateConfigWithFileName(const Common::String &gameId) {}
+	virtual bool loadPluginFromEngineId(const Common::String &engineId) { return false; }
+	virtual void updateConfigWithFileName(const Common::String &engineId) {}
 
 	// Functions used only by the cached PluginManager
 	virtual void loadAllPlugins();
@@ -345,8 +345,8 @@ public:
 	virtual void init();
 	virtual void loadFirstPlugin();
 	virtual bool loadNextPlugin();
-	virtual bool loadPluginFromGameId(const Common::String &gameId);
-	virtual void updateConfigWithFileName(const Common::String &gameId);
+	virtual bool loadPluginFromEngineId(const Common::String &engineId);
+	virtual void updateConfigWithFileName(const Common::String &engineId);
 
 	virtual void loadAllPlugins() {} 	// we don't allow these
 	virtual void loadAllPluginsOfType(PluginType type) {}

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -14,7 +14,7 @@
 is an interpreter that will play graphic adventure games
 based on a variety of game engines.
 .Pp
-\fIGAME\fR is a short name of game to load. For example, \fImonkey\fR for
+\fIGAME\fR is a short name of game to load. For example, \fIscumm:monkey\fR for
 Monkey Island. This can be either a built-in gameid, or a user configured
 target.
 .Sh OPTIONS
@@ -36,6 +36,8 @@ Display a brief help text and exit.
 Display list of supported games and exit.
 .It Fl t, -list-targets
 Display list of configured targets and exit.
+.It Fl t, -list-engines
+Display list of suppported engines and exit.
 .It Fl -list-saves
 Display a list of saved games for the target specified with
 \fB--game=\fITARGET\fR or all targets if none is specified.
@@ -61,7 +63,7 @@ Use alternate configuration file.
 Path to where the game is installed.
 .It Fl x, -save-slot= Ns Ar [SLOT]
 Saved game slot to load (default: autosave).
-.It Fl f, -fulscreen
+.It Fl f, -fullscreen
 Force full-screen mode.
 .It Fl F, -no-fullscreen
 Force windowed mode.
@@ -296,15 +298,15 @@ Running the builtin game launcher:
 .Pp
 Running Day of the Tentacle specifying the path:
 .Pp
-.Dl $ scummvm -p /usr/local/share/games/tentacle tentacle
+.Dl $ scummvm -p /usr/local/share/games/tentacle scumm:tentacle
 .Pp
 Running The Dig with advmame2x filter with subtitles:
 .Pp
-.Dl $ scummvm -g advmame2x -n dig
+.Dl $ scummvm -g advmame2x -n scumm:dig
 .Pp
 Running the Italian version of Maniac Mansion fullscreen:
 .Pp
-.Dl $ scummvm -q it -f maniac
+.Dl $ scummvm -q it -f scumm:maniac
 .Sh SEE ALSO
 More information can be found in the \fIREADME\fR and on the website
 .Pa https://www.scummvm.org .

--- a/engines/access/detection.cpp
+++ b/engines/access/detection.cpp
@@ -75,7 +75,6 @@ Common::Platform AccessEngine::getPlatform() const {
 } // End of namespace Access
 
 static const PlainGameDescriptor AccessGames[] = {
-	{"Access", "Access"},
 	{"amazon", "Amazon: Guardians of Eden"},
 	{"martian", "Martian Memorandum"},
 	{0, 0}

--- a/engines/access/detection.cpp
+++ b/engines/access/detection.cpp
@@ -89,6 +89,10 @@ public:
 		_maxScanDepth = 3;
 	}
 
+	virtual const char *getEngineId() const {
+		return "access";
+	}
+
 	virtual const char *getName() const {
 		return "Access";
 	}

--- a/engines/adl/detection.cpp
+++ b/engines/adl/detection.cpp
@@ -368,6 +368,10 @@ public:
 		return "ADL";
 	}
 
+	const char *getEngineId() const {
+		return "adl";
+	}
+
 	const char *getOriginalCopyright() const override {
 		return "Copyright (C) Sierra On-Line";
 	}

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -82,8 +82,6 @@ static Common::String generatePreferredTarget(const ADGameDescription *desc) {
 DetectedGame AdvancedMetaEngine::toDetectedGame(const ADDetectedGame &adGame) const {
 	const ADGameDescription *desc = adGame.desc;
 
-	const char *gameId = _singleId ? _singleId : desc->gameId;
-
 	const char *title;
 	const char *extra;
 	if (desc->flags & ADGF_USEEXTRAASTITLE) {
@@ -99,7 +97,7 @@ DetectedGame AdvancedMetaEngine::toDetectedGame(const ADDetectedGame &adGame) co
 		extra = desc->extra;
 	}
 
-	DetectedGame game(gameId, title, desc->language, desc->platform, extra);
+	DetectedGame game(getEngineId(), desc->gameId, title, desc->language, desc->platform, extra);
 	game.hasUnknownFiles = adGame.hasUnknownFiles;
 	game.matchedFiles = adGame.matchedFiles;
 	game.preferredTarget = generatePreferredTarget(desc);
@@ -264,7 +262,7 @@ Common::Error AdvancedMetaEngine::createInstance(OSystem *syst, Engine **engine)
 
 	ADDetectedGame agdDesc;
 	for (uint i = 0; i < matches.size(); i++) {
-		if ((_singleId || matches[i].desc->gameId == gameid) && !matches[i].hasUnknownFiles) {
+		if (matches[i].desc->gameId == gameid && !matches[i].hasUnknownFiles) {
 			agdDesc = matches[i];
 			break;
 		}
@@ -277,7 +275,7 @@ Common::Error AdvancedMetaEngine::createInstance(OSystem *syst, Engine **engine)
 		if (agdDesc.desc) {
 			// Seems we found a fallback match. But first perform a basic
 			// sanity check: the gameid must match.
-			if (!_singleId && agdDesc.desc->gameId != gameid)
+			if (agdDesc.desc->gameId != gameid)
 				agdDesc = ADDetectedGame();
 		}
 	}
@@ -556,21 +554,6 @@ ADDetectedGame AdvancedMetaEngine::detectGameFilebased(const FileMap &allFiles, 
 }
 
 PlainGameList AdvancedMetaEngine::getSupportedGames() const {
-	if (_singleId != NULL) {
-		PlainGameList gl;
-
-		const PlainGameDescriptor *g = _gameIds;
-		while (g->gameId) {
-			if (0 == scumm_stricmp(_singleId, g->gameId)) {
-				gl.push_back(*g);
-
-				return gl;
-			}
-			g++;
-		}
-		error("Engine %s doesn't have its singleid specified in ids list", _singleId);
-	}
-
 	return PlainGameList(_gameIds);
 }
 
@@ -589,7 +572,6 @@ AdvancedMetaEngine::AdvancedMetaEngine(const void *descs, uint descItemSize, con
 	  _extraGuiOptions(extraGuiOptions) {
 
 	_md5Bytes = 5000;
-	_singleId = NULL;
 	_flags = 0;
 	_guiOptions = GUIO_NONE;
 	_maxScanDepth = 1;

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -206,19 +206,6 @@ protected:
 	uint _md5Bytes;
 
 	/**
-	 * Name of single gameid (optional).
-	 *
-	 * Used to override gameid.
-	 * This is a recommended setting to prevent global gameid pollution.
-	 * With this option set, the gameid effectively turns into engineid.
-	 *
-	 * FIXME: This field actually removes a feature (gameid) in order to
-	 * address a more generic problem. We should find a better way to
-	 * disambiguate gameids.
-	 */
-	const char *_singleId;
-
-	/**
 	 * A bitmask of flags which can be used to configure the behavior
 	 * of the AdvancedDetector. Refer to ADFlags for a list of flags
 	 * that can be ORed together and passed here.

--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -206,9 +206,14 @@ public:
 		_guiOptions = GUIO1(GUIO_NOSPEECH);
 	}
 
+	const char *getEngineId() const {
+		return "agi";
+	}
+
 	virtual const char *getName() const {
 		return "AGI preAGI + v2 + v3";
 	}
+
 	virtual const char *getOriginalCopyright() const {
 		return "Sierra AGI Engine (C) Sierra On-Line Software";
 	}

--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -202,7 +202,6 @@ class AgiMetaEngine : public AdvancedMetaEngine {
 
 public:
 	AgiMetaEngine() : AdvancedMetaEngine(Agi::gameDescriptions, sizeof(Agi::AGIGameDescription), agiGames, optionsList) {
-		_singleId = "agi";
 		_guiOptions = GUIO1(GUIO_NOSPEECH);
 	}
 

--- a/engines/agos/detection.cpp
+++ b/engines/agos/detection.cpp
@@ -103,6 +103,10 @@ public:
 		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
+	const char *getEngineId() const {
+		return "agos";
+	}
+
 	virtual const char *getName() const {
 		return "AGOS";
 	}

--- a/engines/avalanche/detection.cpp
+++ b/engines/avalanche/detection.cpp
@@ -78,6 +78,10 @@ public:
 	AvalancheMetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(AvalancheGameDescription), avalancheGames) {
 	}
 
+	const char *getEngineId() const {
+		return "avalanche";
+	}
+
 	const char *getName() const {
 		return "Avalanche";
 	}

--- a/engines/bbvs/detection.cpp
+++ b/engines/bbvs/detection.cpp
@@ -74,6 +74,10 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
+	const char *getEngineId() const {
+		return "bbvs";
+	}
+
 	virtual const char *getName() const {
 		return "MTV's Beavis and Butt-head in Virtual Stupidity";
 	}

--- a/engines/bbvs/detection.cpp
+++ b/engines/bbvs/detection.cpp
@@ -69,7 +69,6 @@ static const char * const directoryGlobs[] = {
 class BbvsMetaEngine : public AdvancedMetaEngine {
 public:
 	BbvsMetaEngine() : AdvancedMetaEngine(Bbvs::gameDescriptions, sizeof(ADGameDescription), bbvsGames) {
-		_singleId = "bbvs";
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/bladerunner/detection.cpp
+++ b/engines/bladerunner/detection.cpp
@@ -78,6 +78,7 @@ class BladeRunnerMetaEngine : public AdvancedMetaEngine {
 public:
 	BladeRunnerMetaEngine();
 
+	const char *getEngineId() const;
 	const char *getName() const override;
 	const char *getOriginalCopyright() const override;
 	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
@@ -95,6 +96,9 @@ BladeRunnerMetaEngine::BladeRunnerMetaEngine()
 		BladeRunner::bladeRunnerGames,
 		BladeRunner::optionsList) {}
 
+const char *BladeRunnerMetaEngine::getEngineId() const {
+	return "bladerunner";
+}
 
 const char *BladeRunnerMetaEngine::getName() const {
 	return "Blade Runner";

--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -115,7 +115,6 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 class CGEMetaEngine : public AdvancedMetaEngine {
 public:
 	CGEMetaEngine() : AdvancedMetaEngine(CGE::gameDescriptions, sizeof(ADGameDescription), CGEGames, optionsList) {
-		_singleId = "soltys";
 	}
 
 	const char *getEngineId() const {

--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -118,6 +118,10 @@ public:
 		_singleId = "soltys";
 	}
 
+	const char *getEngineId() const {
+		return "cge";
+	}
+
 	virtual const char *getName() const {
 		return "CGE";
 	}

--- a/engines/cge2/detection.cpp
+++ b/engines/cge2/detection.cpp
@@ -124,6 +124,10 @@ public:
 		_singleId = "sfinx";
 	}
 
+	const char *getEngineId() const {
+		return "cge2";
+	}
+
 	virtual const char *getName() const {
 		return "CGE2";
 	}

--- a/engines/cge2/detection.cpp
+++ b/engines/cge2/detection.cpp
@@ -121,7 +121,6 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 class CGE2MetaEngine : public AdvancedMetaEngine {
 public:
 	CGE2MetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(ADGameDescription), CGE2Games, optionsList) {
-		_singleId = "sfinx";
 	}
 
 	const char *getEngineId() const {

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -115,7 +115,6 @@ public:
 	ChewyMetaEngine() : AdvancedMetaEngine(Chewy::gameDescriptions, sizeof(Chewy::ChewyGameDescription), chewyGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
-		_singleId = "chewy";
 	}
 
 	const char *getEngineId() const {

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -118,6 +118,10 @@ public:
 		_singleId = "chewy";
 	}
 
+	const char *getEngineId() const {
+		return "chewy";
+	}
+
 	virtual const char *getName() const {
 		return "Chewy: Esc from F5";
 	}

--- a/engines/cine/detection.cpp
+++ b/engines/cine/detection.cpp
@@ -23,7 +23,6 @@
 #include "base/plugins.h"
 
 #include "engines/advancedDetector.h"
-#include "engines/obsolete.h"
 
 #include "common/system.h"
 #include "common/textconsole.h"
@@ -49,16 +48,9 @@ Common::Platform CineEngine::getPlatform() const { return _gameDescription->desc
 } // End of namespace Cine
 
 static const PlainGameDescriptor cineGames[] = {
-	{"cine", "Cinematique evo.1 engine game"},
 	{"fw", "Future Wars"},
 	{"os", "Operation Stealth"},
 	{0, 0}
-};
-
-static const Engines::ObsoleteGameID obsoleteGameIDsTable[] = {
-	{"fw", "cine", Common::kPlatformUnknown},
-	{"os", "cine", Common::kPlatformUnknown},
-	{0, 0, Common::kPlatformUnknown}
 };
 
 #include "cine/detection_tables.h"
@@ -80,12 +72,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 class CineMetaEngine : public AdvancedMetaEngine {
 public:
 	CineMetaEngine() : AdvancedMetaEngine(Cine::gameDescriptions, sizeof(Cine::CINEGameDescription), cineGames, optionsList) {
-		_singleId = "cine";
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GAMEOPTION_ORIGINAL_SAVELOAD);
-	}
-
-	PlainGameDescriptor findGame(const char *gameId) const override {
-		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
 	const char *getEngineId() const {
@@ -101,7 +88,6 @@ public:
 	}
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const {
-		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
 		return AdvancedMetaEngine::createInstance(syst, engine);
 	}
 	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const;

--- a/engines/cine/detection.cpp
+++ b/engines/cine/detection.cpp
@@ -88,6 +88,10 @@ public:
 		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
+	const char *getEngineId() const {
+		return "cine";
+	}
+
 	virtual const char *getName() const {
 		return "Cinematique evo 1";
 	}

--- a/engines/composer/detection.cpp
+++ b/engines/composer/detection.cpp
@@ -55,7 +55,6 @@ Common::Language ComposerEngine::getLanguage() const {
 }
 
 static const PlainGameDescriptor composerGames[] = {
-	{"composer", "Composer Game"},
 	{"babayaga", "Magic Tales: Baba Yaga and the Magic Geese"},
 	{"darby", "Darby the Dragon"},
 	{"gregory", "Gregory and the Hot Air Balloon"},
@@ -480,7 +479,6 @@ static const char *directoryGlobs[] = {
 class ComposerMetaEngine : public AdvancedMetaEngine {
 public:
 	ComposerMetaEngine() : AdvancedMetaEngine(Composer::gameDescriptions, sizeof(Composer::ComposerGameDescription), composerGames) {
-		_singleId = "composer";
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/composer/detection.cpp
+++ b/engines/composer/detection.cpp
@@ -485,6 +485,10 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
+	const char *getEngineId() const {
+		return "composer";
+	}
+
 	virtual const char *getName() const {
 		return "Magic Composer";
 	}

--- a/engines/cruise/detection.cpp
+++ b/engines/cruise/detection.cpp
@@ -48,7 +48,6 @@ Common::Platform CruiseEngine::getPlatform() const {
 }
 
 static const PlainGameDescriptor cruiseGames[] = {
-	{"cruise", "Cinematique evo.2 engine game"},
 	{"cruise", "Cruise for a Corpse"},
 	{0, 0}
 };
@@ -196,7 +195,6 @@ static const CRUISEGameDescription gameDescriptions[] = {
 class CruiseMetaEngine : public AdvancedMetaEngine {
 public:
 	CruiseMetaEngine() : AdvancedMetaEngine(Cruise::gameDescriptions, sizeof(Cruise::CRUISEGameDescription), cruiseGames) {
-		_singleId = "cruise";
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI);
 	}
 

--- a/engines/cruise/detection.cpp
+++ b/engines/cruise/detection.cpp
@@ -200,6 +200,10 @@ public:
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI);
 	}
 
+	const char *getEngineId() const {
+		return "cruise";
+	}
+
 	virtual const char *getName() const {
 		return "Cinematique evo 2";
 	}

--- a/engines/cryo/detection.cpp
+++ b/engines/cryo/detection.cpp
@@ -144,7 +144,7 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const {
-		return "Cryo (C) Cryo Interactive";
+		return "Cryo Engine (C) Cryo Interactive";
 	}
 
 	virtual bool hasFeature(MetaEngineFeature f) const;

--- a/engines/cryo/detection.cpp
+++ b/engines/cryo/detection.cpp
@@ -133,7 +133,6 @@ static const ADGameDescription gameDescriptions[] = {
 class CryoMetaEngine : public AdvancedMetaEngine {
 public:
 	CryoMetaEngine() : AdvancedMetaEngine(Cryo::gameDescriptions, sizeof(ADGameDescription), cryoGames) {
-		_singleId = "losteden";
 	}
 
 	const char *getEngineId() const {

--- a/engines/cryo/detection.cpp
+++ b/engines/cryo/detection.cpp
@@ -136,6 +136,10 @@ public:
 		_singleId = "losteden";
 	}
 
+	const char *getEngineId() const {
+		return "cryo";
+	}
+
 	virtual const char *getName() const {
 		return "Cryo";
 	}

--- a/engines/cryomni3d/detection.cpp
+++ b/engines/cryomni3d/detection.cpp
@@ -129,6 +129,10 @@ public:
 		return detectGameFilebased(allFiles, fslist, CryOmni3D::fileBased);
 	}
 
+	const char *getEngineId() const {
+		return "cryomni3d";
+	}
+
 	virtual const char *getName() const {
 		return "Cryo Omni3D";
 	}

--- a/engines/cryomni3d/detection.cpp
+++ b/engines/cryomni3d/detection.cpp
@@ -104,7 +104,6 @@ class CryOmni3DMetaEngine : public AdvancedMetaEngine {
 public:
 	CryOmni3DMetaEngine() : AdvancedMetaEngine(CryOmni3D::gameDescriptions,
 		        sizeof(CryOmni3DGameDescription), cryomni3DGames, optionsList) {
-		//_singleId = "cryomni3d";
 		_maxScanDepth = 1;
 	}
 

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -104,6 +104,10 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
+	virtual const char *getEngineId() const {
+		return "director";
+	}
+
 	virtual const char *getName() const {
 		return "Macromedia Director";
 	}

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -99,7 +99,6 @@ static const char *directoryGlobs[] = {
 class DirectorMetaEngine : public AdvancedMetaEngine {
 public:
 	DirectorMetaEngine() : AdvancedMetaEngine(Director::gameDescriptions, sizeof(Director::DirectorGameDescription), directorGames) {
-		_singleId = "director";
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/dm/detection.cpp
+++ b/engines/dm/detection.cpp
@@ -98,7 +98,6 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 class DMMetaEngine : public AdvancedMetaEngine {
 public:
 	DMMetaEngine() : AdvancedMetaEngine(DM::gameDescriptions, sizeof(DMADGameDescription), DMGames, optionsList) {
-		_singleId = "dm";
 	}
 
 	virtual const char *getEngineId() const {

--- a/engines/dm/detection.cpp
+++ b/engines/dm/detection.cpp
@@ -101,6 +101,10 @@ public:
 		_singleId = "dm";
 	}
 
+	virtual const char *getEngineId() const {
+		return "dm";
+	}
+
 	virtual const char *getName() const {
 		return "Dungeon Master";
 	}

--- a/engines/draci/detection.cpp
+++ b/engines/draci/detection.cpp
@@ -84,7 +84,6 @@ const ADGameDescription gameDescriptions[] = {
 class DraciMetaEngine : public AdvancedMetaEngine {
 public:
 	DraciMetaEngine() : AdvancedMetaEngine(Draci::gameDescriptions, sizeof(ADGameDescription), draciGames) {
-		_singleId = "draci";
 	}
 
 	const char *getEngineId() const {

--- a/engines/draci/detection.cpp
+++ b/engines/draci/detection.cpp
@@ -87,6 +87,10 @@ public:
 		_singleId = "draci";
 	}
 
+	const char *getEngineId() const {
+		return "draci";
+	}
+
 	virtual const char *getName() const {
 		return "Draci Historie";
 	}

--- a/engines/drascula/detection.cpp
+++ b/engines/drascula/detection.cpp
@@ -339,7 +339,6 @@ SaveStateDescriptor loadMetaData(Common::ReadStream *s, int slot, bool setPlayTi
 class DrasculaMetaEngine : public AdvancedMetaEngine {
 public:
 	DrasculaMetaEngine() : AdvancedMetaEngine(Drascula::gameDescriptions, sizeof(Drascula::DrasculaGameDescription), drasculaGames) {
-		_singleId = "drascula";
 		_guiOptions = GUIO1(GUIO_NOMIDI);
 	}
 

--- a/engines/drascula/detection.cpp
+++ b/engines/drascula/detection.cpp
@@ -343,6 +343,10 @@ public:
 		_guiOptions = GUIO1(GUIO_NOMIDI);
 	}
 
+	const char *getEngineId() const {
+		return "drascula";
+	}
+
 	virtual const char *getName() const {
 		return "Drascula: The Vampire Strikes Back";
 	}

--- a/engines/dreamweb/detection.cpp
+++ b/engines/dreamweb/detection.cpp
@@ -71,7 +71,6 @@ public:
 	AdvancedMetaEngine(DreamWeb::gameDescriptions,
 	sizeof(DreamWeb::DreamWebGameDescription), dreamWebGames,
 	gameGuiOptions) {
-		_singleId = "dreamweb";
 		_guiOptions = GUIO1(GUIO_NOMIDI);
 	}
 

--- a/engines/dreamweb/detection.cpp
+++ b/engines/dreamweb/detection.cpp
@@ -75,6 +75,10 @@ public:
 		_guiOptions = GUIO1(GUIO_NOMIDI);
 	}
 
+	const char *getEngineId() const {
+		return "dreamweb";
+	}
+
 	virtual const char *getName() const {
 		return "DreamWeb";
 	}

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -673,12 +673,7 @@ bool Engine::shouldQuit() {
 
 /*
 EnginePlugin *Engine::getMetaEnginePlugin() const {
-
-	const EnginePlugin *plugin = 0;
-	Common::String gameid = ConfMan.get("gameid");
-	gameid.toLowercase();
-	EngineMan.findGame(gameid, &plugin);
-	return plugin;
+	return EngineMan.findPlugin(ConfMan.get("engineid"));
 }
 
 */

--- a/engines/fullpipe/detection.cpp
+++ b/engines/fullpipe/detection.cpp
@@ -130,7 +130,6 @@ static const ADGameDescription gameDescriptions[] = {
 class FullpipeMetaEngine : public AdvancedMetaEngine {
 public:
 	FullpipeMetaEngine() : AdvancedMetaEngine(Fullpipe::gameDescriptions, sizeof(ADGameDescription), fullpipeGames) {
-		_singleId = "fullpipe";
 	}
 
 	const char *getEngineId() const {

--- a/engines/fullpipe/detection.cpp
+++ b/engines/fullpipe/detection.cpp
@@ -133,6 +133,10 @@ public:
 		_singleId = "fullpipe";
 	}
 
+	const char *getEngineId() const {
+		return "fullpipe";
+	}
+
 	virtual const char *getName() const {
 		return "Full Pipe";
 	}

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -49,6 +49,20 @@ PlainGameDescriptor PlainGameDescriptor::of(const char *gameId, const char *desc
 	return pgd;
 }
 
+QualifiedGameDescriptor::QualifiedGameDescriptor() :
+		PlainGameDescriptor() {
+	engineId    = nullptr;
+	gameId      = nullptr;
+	description = nullptr;
+}
+
+QualifiedGameDescriptor::QualifiedGameDescriptor(const char *engine, const PlainGameDescriptor &pgd) :
+		PlainGameDescriptor() {
+	engineId    = engine;
+	gameId      = pgd.gameId;
+	description = pgd.description;
+}
+
 DetectedGame::DetectedGame() :
 		hasUnknownFiles(false),
 		canBeAdded(true),

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -50,7 +50,6 @@ PlainGameDescriptor PlainGameDescriptor::of(const char *gameId, const char *desc
 }
 
 DetectedGame::DetectedGame() :
-		engineName(nullptr),
 		hasUnknownFiles(false),
 		canBeAdded(true),
 		language(Common::UNK_LANG),
@@ -58,8 +57,8 @@ DetectedGame::DetectedGame() :
 		gameSupportLevel(kStableGame) {
 }
 
-DetectedGame::DetectedGame(const PlainGameDescriptor &pgd) :
-		engineName(nullptr),
+DetectedGame::DetectedGame(const Common::String &engine, const PlainGameDescriptor &pgd) :
+		engineId(engine),
 		hasUnknownFiles(false),
 		canBeAdded(true),
 		language(Common::UNK_LANG),
@@ -71,8 +70,8 @@ DetectedGame::DetectedGame(const PlainGameDescriptor &pgd) :
 	description = pgd.description;
 }
 
-DetectedGame::DetectedGame(const Common::String &id, const Common::String &d, Common::Language l, Common::Platform p, const Common::String &ex) :
-		engineName(nullptr),
+DetectedGame::DetectedGame(const Common::String &engine, const Common::String &id, const Common::String &d, Common::Language l, Common::Platform p, const Common::String &ex) :
+		engineId(engine),
 		hasUnknownFiles(false),
 		canBeAdded(true),
 		gameSupportLevel(kStableGame) {
@@ -178,20 +177,20 @@ Common::String generateUnknownGameReport(const DetectedGames &detectedGames, boo
 
 	FilePropertiesMap matchedFiles;
 
-	const char *currentEngineName = nullptr;
+	Common::String currentEngineId;
 	for (uint i = 0; i < detectedGames.size(); i++) {
 		const DetectedGame &game = detectedGames[i];
 
 		if (!game.hasUnknownFiles) continue;
 
-		if (!currentEngineName || strcmp(currentEngineName, game.engineName) != 0) {
-			currentEngineName = game.engineName;
+		if (currentEngineId.empty() || currentEngineId != game.engineId) {
+			currentEngineId = game.engineId;
 
 			// If the engine is not the same as for the previous entry, print an engine line header
 			report += "\n";
 			report += Common::String::format(
 					translate ? _(reportEngineHeader) : reportEngineHeader,
-					game.engineName
+					game.engineId.c_str()
 			);
 			report += " ";
 

--- a/engines/game.h
+++ b/engines/game.h
@@ -64,6 +64,18 @@ public:
 };
 
 /**
+ * The description of a game supported by an engine
+ */
+struct QualifiedGameDescriptor : public PlainGameDescriptor {
+	const char *engineId;
+
+	QualifiedGameDescriptor();
+	QualifiedGameDescriptor(const char *engine, const PlainGameDescriptor &pgd);
+};
+
+typedef Common::Array<QualifiedGameDescriptor> QualifiedGameList;
+
+/**
  * Ths is an enum to describe how done a game is. This also indicates what level of support is expected.
  */
 enum GameSupportLevel {

--- a/engines/game.h
+++ b/engines/game.h
@@ -98,8 +98,8 @@ typedef Common::HashMap<Common::String, FileProperties, Common::IgnoreCase_Hash,
  */
 struct DetectedGame {
 	DetectedGame();
-	explicit DetectedGame(const PlainGameDescriptor &pgd);
-	DetectedGame(const Common::String &id,
+	DetectedGame(const Common::String &engine, const PlainGameDescriptor &pgd);
+	DetectedGame(const Common::String &engine, const Common::String &id,
 	               const Common::String &description,
 	               Common::Language language = Common::UNK_LANG,
 	               Common::Platform platform = Common::kPlatformUnknown,
@@ -109,10 +109,7 @@ struct DetectedGame {
 	void appendGUIOptions(const Common::String &str);
 	Common::String getGUIOptions() const { return _guiOptions; }
 
-	/**
-	 * The name of the engine supporting the detected game
-	 */
-	const char *engineName;
+	Common::String engineId;
 
 	/**
 	 * A game was detected, but some files were not recognized

--- a/engines/glk/detection.cpp
+++ b/engines/glk/detection.cpp
@@ -104,27 +104,27 @@
 namespace Glk {
 
 GlkDetectedGame::GlkDetectedGame(const char *id, const char *desc, const Common::String &filename) :
-		DetectedGame(id, desc, Common::EN_ANY, Common::kPlatformUnknown) {
+		DetectedGame("glk", id, desc, Common::EN_ANY, Common::kPlatformUnknown) {
 	setGUIOptions(GUIO3(GUIO_NOSPEECH, GUIO_NOMUSIC, GUIO_NOSUBTITLES));
 	addExtraEntry("filename", filename);
 }
 
 GlkDetectedGame::GlkDetectedGame(const char *id, const char *desc, const Common::String &filename,
-		Common::Language lang) : DetectedGame(id, desc, lang, Common::kPlatformUnknown) {
+		Common::Language lang) : DetectedGame("glk", id, desc, lang, Common::kPlatformUnknown) {
 	setGUIOptions(GUIO3(GUIO_NOSPEECH, GUIO_NOMUSIC, GUIO_NOSUBTITLES));
 	addExtraEntry("filename", filename);
 }
 
 GlkDetectedGame::GlkDetectedGame(const char *id, const char *desc, const char *xtra,
 		const Common::String &filename, Common::Language lang) :
-		DetectedGame(id, desc, lang, Common::kPlatformUnknown, xtra) {
+		DetectedGame("glk", id, desc, lang, Common::kPlatformUnknown, xtra) {
 	setGUIOptions(GUIO3(GUIO_NOSPEECH, GUIO_NOMUSIC, GUIO_NOSUBTITLES));
 	addExtraEntry("filename", filename);
 }
 
 GlkDetectedGame::GlkDetectedGame(const char *id, const char *desc, const Common::String &filename,
 		const Common::String &md5, size_t filesize) :
-		DetectedGame(id, desc, Common::UNK_LANG, Common::kPlatformUnknown) {
+		DetectedGame("glk", id, desc, Common::UNK_LANG, Common::kPlatformUnknown) {
 	setGUIOptions(GUIO3(GUIO_NOSPEECH, GUIO_NOMUSIC, GUIO_NOSUBTITLES));
 	addExtraEntry("filename", filename);
 

--- a/engines/glk/detection.h
+++ b/engines/glk/detection.h
@@ -41,6 +41,10 @@ public:
 		return "Glk";
 	}
 
+        const char *getEngineId() const {
+                return "glk";
+        }
+
 	virtual const char *getOriginalCopyright() const {
 		return "Infocom games (C) Infocom\nScott Adams games (C) Scott Adams";
 	}

--- a/engines/glk/frotz/detection.cpp
+++ b/engines/glk/frotz/detection.cpp
@@ -123,7 +123,7 @@ bool FrotzMetaEngine::detectGames(const Common::FSList &fslist, DetectedGames &g
 			gameList.push_back(GlkDetectedGame(desc.gameId, desc.description, filename, md5, filesize));
 		} else {
 			GameDescriptor gameDesc = findGame(p->_gameId);
-			DetectedGame gd = DetectedGame(p->_gameId, gameDesc._description, p->_language, Common::kPlatformUnknown, p->_extra);
+			DetectedGame gd = DetectedGame("glk", p->_gameId, gameDesc._description, p->_language, Common::kPlatformUnknown, p->_extra);
 			gd.setGUIOptions(p->_guiOptions);
 
 			gd.addExtraEntry("filename", filename);

--- a/engines/glk/level9/detection.cpp
+++ b/engines/glk/level9/detection.cpp
@@ -752,7 +752,7 @@ bool Level9MetaEngine::detectGames(const Common::FSList &fslist, DetectedGames &
 			continue;
 
 		// Found the game, add a detection entry
-		DetectedGame gd = DetectedGame(game->gameId, game->name, Common::UNK_LANG,
+		DetectedGame gd = DetectedGame("glk", game->gameId, game->name, Common::UNK_LANG,
 			Common::kPlatformUnknown, game->extra);
 		gd.addExtraEntry("filename", filename);
 		gameList.push_back(gd);

--- a/engines/glk/tads/detection.cpp
+++ b/engines/glk/tads/detection.cpp
@@ -110,7 +110,7 @@ bool TADSMetaEngine::detectGames(const Common::FSList &fslist, DetectedGames &ga
 			gameList.push_back(GlkDetectedGame(desc._gameId, desc._description, filename, md5, filesize));
 		} else {
 			PlainGameDescriptor gameDesc = findGame(p->_gameId);
-			gd = DetectedGame(p->_gameId, gameDesc.description, p->_language, Common::kPlatformUnknown, p->_extra);
+			gd = DetectedGame("glk", p->_gameId, gameDesc.description, p->_language, Common::kPlatformUnknown, p->_extra);
 			gd.addExtraEntry("filename", filename);
 			gameList.push_back(gd);
 		}

--- a/engines/gnap/detection.cpp
+++ b/engines/gnap/detection.cpp
@@ -82,6 +82,10 @@ public:
 		_maxScanDepth = 3;
 	}
 
+	virtual const char *getEngineId() const {
+		return "gnap";
+	}
+
 	virtual const char *getName() const {
 		return "Gnap";
 	}

--- a/engines/gnap/detection.cpp
+++ b/engines/gnap/detection.cpp
@@ -78,7 +78,6 @@ static const ADGameDescription gameDescriptions[] = {
 class GnapMetaEngine : public AdvancedMetaEngine {
 public:
 	GnapMetaEngine() : AdvancedMetaEngine(Gnap::gameDescriptions, sizeof(ADGameDescription), gnapGames) {
-		_singleId = "gnap";
 		_maxScanDepth = 3;
 	}
 

--- a/engines/gob/detection/detection.cpp
+++ b/engines/gob/detection/detection.cpp
@@ -35,6 +35,10 @@ public:
 
 	PlainGameDescriptor findGame(const char *gameId) const override;
 
+	const char *getEngineId() const {
+		return "gob";
+	}
+
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const override;
 
 	virtual const char *getName() const;

--- a/engines/gob/detection/detection.cpp
+++ b/engines/gob/detection/detection.cpp
@@ -22,7 +22,6 @@
 
 #include "base/plugins.h"
 #include "engines/advancedDetector.h"
-#include "engines/obsolete.h"
 
 #include "gob/gob.h"
 #include "gob/dataio.h"
@@ -32,8 +31,6 @@
 class GobMetaEngine : public AdvancedMetaEngine {
 public:
 	GobMetaEngine();
-
-	PlainGameDescriptor findGame(const char *gameId) const override;
 
 	const char *getEngineId() const {
 		return "gob";
@@ -59,12 +56,7 @@ private:
 GobMetaEngine::GobMetaEngine() :
 	AdvancedMetaEngine(Gob::gameDescriptions, sizeof(Gob::GOBGameDescription), gobGames) {
 
-	_singleId   = "gob";
 	_guiOptions = GUIO1(GUIO_NOLAUNCHLOAD);
-}
-
-PlainGameDescriptor GobMetaEngine::findGame(const char *gameId) const {
-	return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 }
 
 ADDetectedGame GobMetaEngine::fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const {
@@ -180,7 +172,6 @@ bool Gob::GobEngine::hasFeature(EngineFeature f) const {
 }
 
 Common::Error GobMetaEngine::createInstance(OSystem *syst, Engine **engine) const {
-	Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
 	return AdvancedMetaEngine::createInstance(syst, engine);
 }
 

--- a/engines/gob/detection/tables.h
+++ b/engines/gob/detection/tables.h
@@ -41,7 +41,6 @@ using namespace Common;
 
 // Game IDs and proper names
 static const PlainGameDescriptor gobGames[] = {
-	{"gob", "Gob engine game"},
 	{"gob1", "Gobliiins"},
 	{"gob1cd", "Gobliiins CD"},
 	{"gob2", "Gobliins 2"},
@@ -79,13 +78,6 @@ static const PlainGameDescriptor gobGames[] = {
 	{"adibou2", "Adibou 2"},
 	{"adibou1", "Adibou 1"},
 	{0, 0}
-};
-
-// Obsolete IDs we don't want anymore
-static const Engines::ObsoleteGameID obsoleteGameIDsTable[] = {
-	{"gob1", "gob", kPlatformUnknown},
-	{"gob2", "gob", kPlatformUnknown},
-	{0, 0, kPlatformUnknown}
 };
 
 namespace Gob {

--- a/engines/groovie/detection.cpp
+++ b/engines/groovie/detection.cpp
@@ -351,6 +351,10 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
+	const char *getEngineId() const {
+		return "groovie";
+	}
+
 	const char *getName() const {
 		return "Groovie";
 	}

--- a/engines/groovie/detection.cpp
+++ b/engines/groovie/detection.cpp
@@ -42,8 +42,6 @@ static const PlainGameDescriptor groovieGames[] = {
 	{"tlc", "Tender Loving Care"},
 #endif
 
-	// Unknown
-	{"groovie", "Groovie engine game"},
 	{0, 0}
 };
 
@@ -333,8 +331,6 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 class GroovieMetaEngine : public AdvancedMetaEngine {
 public:
 	GroovieMetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(GroovieGameDescription), groovieGames, optionsList) {
-		_singleId = "groovie";
-
 		// Use kADFlagUseExtraAsHint in order to distinguish the 11th hour from
 		// its "Making of" as well as the Clandestiny Trailer; they all share
 		// the same MD5.

--- a/engines/hdb/detection.cpp
+++ b/engines/hdb/detection.cpp
@@ -170,6 +170,10 @@ public:
 		_singleId = "hdb";
 	}
 
+	const char *getEngineId() const {
+		return "hdb";
+	}
+
 	virtual const char *getName() const {
 		return "Hyperspace Delivery Boy!";
 	}

--- a/engines/hdb/detection.cpp
+++ b/engines/hdb/detection.cpp
@@ -167,7 +167,6 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 class HDBMetaEngine : public AdvancedMetaEngine {
 public:
 	HDBMetaEngine() : AdvancedMetaEngine(HDB::gameDescriptions, sizeof(ADGameDescription), hdbGames, optionsList) {
-		_singleId = "hdb";
 	}
 
 	const char *getEngineId() const {

--- a/engines/hopkins/detection.cpp
+++ b/engines/hopkins/detection.cpp
@@ -106,6 +106,10 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
+	virtual const char *getEngineId() const {
+		return "hopkins";
+	}
+
 	virtual const char *getName() const {
 		return "Hopkins FBI";
 	}

--- a/engines/hugo/detection.cpp
+++ b/engines/hugo/detection.cpp
@@ -136,6 +136,10 @@ public:
 	HugoMetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(HugoGameDescription), hugoGames) {
 	}
 
+	const char *getEngineId() const {
+		return "hugo";
+	}
+
 	const char *getName() const {
 		return "Hugo";
 	}

--- a/engines/illusions/detection.cpp
+++ b/engines/illusions/detection.cpp
@@ -32,7 +32,6 @@
 #include "graphics/thumbnail.h"
 
 static const PlainGameDescriptor illusionsGames[] = {
-	{ "illusions", "Illusions engine game" },
 	{ "bbdou", "Beavis and Butt-head Do U" },
 	{ "duckman", "Duckman" },
 	{ 0, 0 }
@@ -115,7 +114,6 @@ static const char * const directoryGlobs[] = {
 class IllusionsMetaEngine : public AdvancedMetaEngine {
 public:
 	IllusionsMetaEngine() : AdvancedMetaEngine(Illusions::gameDescriptions, sizeof(Illusions::IllusionsGameDescription), illusionsGames) {
-		_singleId = "illusions";
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/illusions/detection.cpp
+++ b/engines/illusions/detection.cpp
@@ -120,6 +120,10 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
+	const char *getEngineId() const {
+		return "illusions";
+	}
+
 	virtual const char *getName() const {
 		return "Illusions";
 	}

--- a/engines/illusions/menusystem.cpp
+++ b/engines/illusions/menusystem.cpp
@@ -673,14 +673,12 @@ MenuActionLoadGame::MenuActionLoadGame(BaseMenuSystem *menuSystem, uint choiceIn
 }
 
 void MenuActionLoadGame::execute() {
-	const Plugin *plugin = NULL;
-	EngineMan.findGame(ConfMan.get("gameid"), &plugin);
 	GUI::SaveLoadChooser *dialog;
 	Common::String desc;
 	int slot;
 
 	dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
-	slot = dialog->runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
+	slot = dialog->runModalWithCurrentTarget();
 
 	delete dialog;
 
@@ -698,14 +696,12 @@ MenuActionSaveGame::MenuActionSaveGame(BaseMenuSystem *menuSystem, uint choiceIn
 }
 
 void MenuActionSaveGame::execute() {
-	const Plugin *plugin = NULL;
-	EngineMan.findGame(ConfMan.get("gameid"), &plugin);
 	GUI::SaveLoadChooser *dialog;
 	Common::String desc;
 	int slot;
 
 	dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
-	slot = dialog->runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
+	slot = dialog->runModalWithCurrentTarget();
 	desc = dialog->getResultString().c_str();
 
 	delete dialog;

--- a/engines/kyra/detection.cpp
+++ b/engines/kyra/detection.cpp
@@ -156,6 +156,11 @@ public:
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}
+
+	const char *getEngineId() const {
+		return "kyra";
+	}
+
 	const char *getName() const {
 		return "Kyra";
 	}

--- a/engines/lab/detection.cpp
+++ b/engines/lab/detection.cpp
@@ -115,8 +115,6 @@ uint32 LabEngine::getFeatures() const {
 class LabMetaEngine : public AdvancedMetaEngine {
 public:
 	LabMetaEngine() : AdvancedMetaEngine(labDescriptions, sizeof(ADGameDescription), lab_setting) {
-		_singleId = "lab";
-
 		_maxScanDepth = 4;
 		_directoryGlobs = directoryGlobs;
 		_flags = kADFlagUseExtraAsHint;

--- a/engines/lab/detection.cpp
+++ b/engines/lab/detection.cpp
@@ -122,6 +122,10 @@ public:
 		_flags = kADFlagUseExtraAsHint;
 	}
 
+	const char *getEngineId() const {
+		return "lab";
+	}
+
 	virtual const char *getName() const {
 		return "Labyrinth of Time";
 	}

--- a/engines/lastexpress/detection.cpp
+++ b/engines/lastexpress/detection.cpp
@@ -231,6 +231,10 @@ public:
 		_guiOptions = GUIO2(GUIO_NOSUBTITLES, GUIO_NOSFX);
 	}
 
+	const char *getEngineId() const {
+		return "lastexpress";
+	}
+
 	const char *getName() const {
 		return "The Last Express";
 	}

--- a/engines/lastexpress/detection.cpp
+++ b/engines/lastexpress/detection.cpp
@@ -227,7 +227,6 @@ static const ADGameDescription gameDescriptions[] = {
 class LastExpressMetaEngine : public AdvancedMetaEngine {
 public:
 	LastExpressMetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(ADGameDescription), lastExpressGames) {
-		_singleId = "lastexpress";
 		_guiOptions = GUIO2(GUIO_NOSUBTITLES, GUIO_NOSFX);
 	}
 

--- a/engines/lilliput/detection.cpp
+++ b/engines/lilliput/detection.cpp
@@ -126,6 +126,10 @@ public:
 	LilliputMetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(LilliputGameDescription), lilliputGames) {
 	}
 
+	const char *getEngineId() const {
+		return "lilliput";
+	}
+
 	const char *getName() const {
 		return "Lilliput";
 	}

--- a/engines/lure/detection.cpp
+++ b/engines/lure/detection.cpp
@@ -207,7 +207,6 @@ class LureMetaEngine : public AdvancedMetaEngine {
 public:
 	LureMetaEngine() : AdvancedMetaEngine(Lure::gameDescriptions, sizeof(Lure::LureGameDescription), lureGames) {
 		_md5Bytes = 1024;
-		_singleId = "lure";
 
 		// Use kADFlagUseExtraAsHint to distinguish between EGA and VGA versions
 		// of italian Lure when their datafiles sit in the same directory.

--- a/engines/lure/detection.cpp
+++ b/engines/lure/detection.cpp
@@ -215,6 +215,10 @@ public:
 		_guiOptions = GUIO1(GUIO_NOSPEECH);
 	}
 
+	const char *getEngineId() const {
+		return "lure";
+	}
+
 	virtual const char *getName() const {
 		return "Lure of the Temptress";
 	}

--- a/engines/macventure/detection.cpp
+++ b/engines/macventure/detection.cpp
@@ -66,7 +66,16 @@ public:
 	const char *getName() const {
 		return "MacVenture";
 	}
-	const char *getOriginalCopyright() const {
+
+	const char *getEngineId() const override {
+		return "macventure";
+	}
+
+	const char *getName() const override {
+		return "MacVenture";
+	}
+
+	const char *getOriginalCopyright() const override {
 		return "(C) ICOM Simulations";
 	}
 

--- a/engines/macventure/detection.cpp
+++ b/engines/macventure/detection.cpp
@@ -63,10 +63,6 @@ public:
 		_md5Bytes = 5000000; // TODO: Upper limit, adjust it once all games are added
 	}
 
-	const char *getName() const {
-		return "MacVenture";
-	}
-
 	const char *getEngineId() const override {
 		return "macventure";
 	}

--- a/engines/made/detection.cpp
+++ b/engines/made/detection.cpp
@@ -46,7 +46,6 @@ uint16 MadeEngine::getVersion() const {
 }
 
 static const PlainGameDescriptor madeGames[] = {
-	{"made", "MADE engine game"},
 	{"manhole", "The Manhole"},
 	{"rtz", "Return to Zork"},
 	{"lgop2", "Leather Goddesses of Phobos 2"},
@@ -57,7 +56,6 @@ static const PlainGameDescriptor madeGames[] = {
 class MadeMetaEngine : public AdvancedMetaEngine {
 public:
 	MadeMetaEngine() : AdvancedMetaEngine(Made::gameDescriptions, sizeof(Made::MadeGameDescription), madeGames) {
-		_singleId = "made";
 	}
 
 	const char *getEngineId() const {

--- a/engines/made/detection.cpp
+++ b/engines/made/detection.cpp
@@ -60,6 +60,10 @@ public:
 		_singleId = "made";
 	}
 
+	const char *getEngineId() const {
+		return "made";
+	}
+
 	virtual const char *getName() const {
 		return "MADE";
 	}

--- a/engines/mads/detection.cpp
+++ b/engines/mads/detection.cpp
@@ -69,7 +69,6 @@ Common::Platform MADSEngine::getPlatform() const {
 } // End of namespace MADS
 
 static const PlainGameDescriptor MADSGames[] = {
-	{"MADS", "MADS"},
 	{"dragonsphere", "Dragonsphere"},
 	{"nebular", "Rex Nebular and the Cosmic Gender Bender"},
 	{"phantom", "Return of the Phantom"},

--- a/engines/mads/detection.cpp
+++ b/engines/mads/detection.cpp
@@ -144,6 +144,10 @@ public:
 		_maxScanDepth = 3;
 	}
 
+	virtual const char *getEngineId() const {
+		return "mads";
+	}
+
 	virtual const char *getName() const {
 		return "MADS";
 	}

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -284,10 +284,16 @@ public:
 	const PluginList &getPlugins() const;
 
 	/** Find a target */ // TODO: Expand on description
-	PlainGameDescriptor findTarget(const Common::String &target, const Plugin **plugin = NULL) const;
+	QualifiedGameDescriptor findTarget(const Common::String &target, const Plugin **plugin = NULL) const;
 
-	/** Find a game across all plugins */ // TODO: Naming, this should be gameId
-	PlainGameDescriptor findGame(const Common::String &gameName, const Plugin **plugin = NULL) const;
+	/**
+	 * List games matching the specified criteria
+	 *
+	 * If the engine id is not specified, this scans all the plugins,
+	 * loading them from disk if necessary. This is a slow operation on
+	 * some platforms and should not be used for the happy path.
+	 */
+	QualifiedGameList findGamesMatching(const Common::String &engineId, const Common::String &gameId) const;
 
 	/**
 	 * Create a target from the supplied game descriptor
@@ -301,7 +307,7 @@ public:
 
 private:
 	/** Find a game across all loaded plugins */
-	PlainGameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const Plugin **plugin = NULL) const;
+	QualifiedGameList findGameInLoadedPlugins(const Common::String &gameId) const;
 
 	/** Find a loaded plugin with the given engine ID */
 	const Plugin *findLoadedPlugin(const Common::String &engineId) const;

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -283,7 +283,7 @@ public:
 	/** Get the list of all engine plugins */
 	const PluginList &getPlugins() const;
 
-	/** Find a target */ // TODO: Expand on description
+	/** Find a target */
 	QualifiedGameDescriptor findTarget(const Common::String &target, const Plugin **plugin = NULL) const;
 
 	/**

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -65,6 +65,9 @@ class MetaEngine : public PluginObject {
 public:
 	virtual ~MetaEngine() {}
 
+	/** Get the engine ID */
+	virtual const char *getEngineId() const = 0;
+
 	/** Returns some copyright information about the original engine. */
 	virtual const char *getOriginalCopyright() const = 0;
 
@@ -267,10 +270,24 @@ public:
  */
 class EngineManager : public Common::Singleton<EngineManager> {
 public:
-	PlainGameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const Plugin **plugin = NULL) const;
-	PlainGameDescriptor findGame(const Common::String &gameName, const Plugin **plugin = NULL) const;
+	/**
+	 * Given a list of FSNodes in a given directory, detect a set of games contained within
+	 *
+	 * Returns an empty list if none are found.
+	 */
 	DetectionResults detectGames(const Common::FSList &fslist) const;
+
+	/** Find a plugin by its engine ID */
+	const Plugin *findPlugin(const Common::String &engineId) const;
+
+	/** Get the list of all engine plugins */
 	const PluginList &getPlugins() const;
+
+	/** Find a target */ // TODO: Expand on description
+	PlainGameDescriptor findTarget(const Common::String &target, const Plugin **plugin = NULL) const;
+
+	/** Find a game across all plugins */ // TODO: Naming, this should be gameId
+	PlainGameDescriptor findGame(const Common::String &gameName, const Plugin **plugin = NULL) const;
 
 	/**
 	 * Create a target from the supplied game descriptor
@@ -278,6 +295,12 @@ public:
 	 * Returns the created target name.
 	 */
 	Common::String createTargetForGame(const DetectedGame &game);
+private:
+	/** Find a game across all loaded plugins */
+	PlainGameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const Plugin **plugin = NULL) const;
+
+	/** Find a loaded plugin with the given engine ID */
+	const Plugin *findLoadedPlugin(const Common::String &engineId) const;
 };
 
 /** Convenience shortcut for accessing the engine manager. */

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -295,12 +295,19 @@ public:
 	 * Returns the created target name.
 	 */
 	Common::String createTargetForGame(const DetectedGame &game);
+
+	/** Upgrade a target to the current configuration format */
+	void upgradeTargetIfNecessary(const Common::String &target) const;
+
 private:
 	/** Find a game across all loaded plugins */
 	PlainGameDescriptor findGameInLoadedPlugins(const Common::String &gameName, const Plugin **plugin = NULL) const;
 
 	/** Find a loaded plugin with the given engine ID */
 	const Plugin *findLoadedPlugin(const Common::String &engineId) const;
+
+	/** Use heuristics to complete a target lacking an engine ID */
+	void upgradeTargetForEngineId(const Common::String &target) const;
 };
 
 /** Convenience shortcut for accessing the engine manager. */

--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -205,6 +205,10 @@ public:
 		return detectGameFilebased(allFiles, fslist, Mohawk::fileBased);
 	}
 
+	const char *getEngineId() const {
+		return "mohawk";
+	}
+
 	const char *getName() const override {
 		return "Mohawk";
 	}

--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -23,6 +23,7 @@
 #include "base/plugins.h"
 
 #include "engines/advancedDetector.h"
+#include "common/config-manager.h"
 #include "common/savefile.h"
 #include "common/system.h"
 #include "common/textconsole.h"
@@ -260,11 +261,12 @@ SaveStateList MohawkMetaEngine::listSavesForPrefix(const char *prefix, const cha
 }
 
 SaveStateList MohawkMetaEngine::listSaves(const char *target) const {
+	Common::String gameId = ConfMan.get("gameid", target);
 	SaveStateList saveList;
 
 	// Loading games is only supported in Myst/Riven currently.
 #ifdef ENABLE_MYST
-	if (strstr(target, "myst")) {
+	if (gameId == "myst") {
 		saveList = listSavesForPrefix("myst", "mys");
 
 		for (SaveStateList::iterator save = saveList.begin(); save != saveList.end(); ++save) {
@@ -276,7 +278,7 @@ SaveStateList MohawkMetaEngine::listSaves(const char *target) const {
 	}
 #endif
 #ifdef ENABLE_RIVEN
-	if (strstr(target, "riven")) {
+	if (gameId == "riven") {
 		saveList = listSavesForPrefix("riven", "rvn");
 
 		for (SaveStateList::iterator save = saveList.begin(); save != saveList.end(); ++save) {
@@ -292,28 +294,31 @@ SaveStateList MohawkMetaEngine::listSaves(const char *target) const {
 }
 
 void MohawkMetaEngine::removeSaveState(const char *target, int slot) const {
+	Common::String gameId = ConfMan.get("gameid", target);
 
 	// Removing saved games is only supported in Myst/Riven currently.
 #ifdef ENABLE_MYST
-	if (strstr(target, "myst")) {
+	if (gameId == "myst") {
 		Mohawk::MystGameState::deleteSave(slot);
 	}
 #endif
 #ifdef ENABLE_RIVEN
-	if (strstr(target, "riven")) {
+	if (gameId == "riven") {
 		Mohawk::RivenSaveLoad::deleteSave(slot);
 	}
 #endif
 }
 
 SaveStateDescriptor MohawkMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
+	Common::String gameId = ConfMan.get("gameid", target);
+
 #ifdef ENABLE_MYST
-	if (strstr(target, "myst")) {
+	if (gameId == "myst") {
 		return Mohawk::MystGameState::querySaveMetaInfos(slot);
 	}
 #endif
 #ifdef ENABLE_RIVEN
-	if (strstr(target, "riven")) {
+	if (gameId == "riven") {
 		return Mohawk::RivenSaveLoad::querySaveMetaInfos(slot);
 	} else
 #endif

--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -136,7 +136,6 @@ bool MohawkEngine_Riven::hasFeature(EngineFeature f) const {
 } // End of Namespace Mohawk
 
 static const PlainGameDescriptor mohawkGames[] = {
-	{"mohawk", "Mohawk Game"},
 	{"myst", "Myst"},
 	{"makingofmyst", "The Making of Myst"},
 	{"riven", "Riven: The Sequel to Myst"},
@@ -196,7 +195,6 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 class MohawkMetaEngine : public AdvancedMetaEngine {
 public:
 	MohawkMetaEngine() : AdvancedMetaEngine(Mohawk::gameDescriptions, sizeof(Mohawk::MohawkGameDescription), mohawkGames, optionsList) {
-		_singleId = "mohawk";
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/mortevielle/detection.cpp
+++ b/engines/mortevielle/detection.cpp
@@ -55,7 +55,6 @@ public:
 	MortevielleMetaEngine() : AdvancedMetaEngine(Mortevielle::MortevielleGameDescriptions, sizeof(Mortevielle::MortevielleGameDescription),
 		MortevielleGame) {
 		_md5Bytes = 512;
-		_singleId = "mortevielle";
 		// Use kADFlagUseExtraAsHint to distinguish between original and improved versions
 		// (i.e. use or not of the game data file).
 		_flags = kADFlagUseExtraAsHint;

--- a/engines/mortevielle/detection.cpp
+++ b/engines/mortevielle/detection.cpp
@@ -60,6 +60,11 @@ public:
 		// (i.e. use or not of the game data file).
 		_flags = kADFlagUseExtraAsHint;
 	}
+
+	const char *getEngineId() const {
+		return "mortevielle";
+	}
+
 	virtual const char *getName() const {
 		return "Mortville Manor";
 	}

--- a/engines/mutationofjb/detection.cpp
+++ b/engines/mutationofjb/detection.cpp
@@ -92,6 +92,10 @@ public:
 		_directoryGlobs = mutationofjbDirectoryGlobs;
 	}
 
+	const char *getEngineId() const {
+		return "mutationofjb";
+	}
+
 	virtual const char *getName() const override {
 		return "Mutation of J.B.";
 	}

--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -198,7 +198,6 @@ static const ExtraGuiOption neverhoodExtraGuiOption3 = {
 class NeverhoodMetaEngine : public AdvancedMetaEngine {
 public:
 	NeverhoodMetaEngine() : AdvancedMetaEngine(Neverhood::gameDescriptions, sizeof(Neverhood::NeverhoodGameDescription), neverhoodGames) {
-		_singleId = "neverhood";
 		_guiOptions = GUIO2(GUIO_NOSUBTITLES, GUIO_NOMIDI);
 	}
 

--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -202,6 +202,10 @@ public:
 		_guiOptions = GUIO2(GUIO_NOSUBTITLES, GUIO_NOMIDI);
 	}
 
+	const char *getEngineId() const {
+		return "neverhood";
+	}
+
 	virtual const char *getName() const {
 		return "The Neverhood Chronicles";
 	}

--- a/engines/neverhood/menumodule.cpp
+++ b/engines/neverhood/menumodule.cpp
@@ -870,8 +870,6 @@ void SavegameListBox::pageDown() {
 }
 
 int GameStateMenu::scummVMSaveLoadDialog(bool isSave, Common::String &saveDesc) {
-	const Plugin *plugin = nullptr;
-	EngineMan.findGame(ConfMan.get("gameid"), &plugin);
 	GUI::SaveLoadChooser *dialog;
 	Common::String desc;
 	int slot;
@@ -879,7 +877,7 @@ int GameStateMenu::scummVMSaveLoadDialog(bool isSave, Common::String &saveDesc) 
 	if (isSave) {
 		dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 
-		slot = dialog->runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
+		slot = dialog->runModalWithCurrentTarget();
 		desc = dialog->getResultString();
 
 		if (desc.empty())
@@ -891,7 +889,7 @@ int GameStateMenu::scummVMSaveLoadDialog(bool isSave, Common::String &saveDesc) 
 		saveDesc = desc;
 	} else {
 		dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
-		slot = dialog->runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
+		slot = dialog->runModalWithCurrentTarget();
 	}
 
 	delete dialog;

--- a/engines/obsolete.cpp
+++ b/engines/obsolete.cpp
@@ -58,8 +58,7 @@ void upgradeTargetIfNecessary(const ObsoleteGameID *obsoleteList) {
 PlainGameDescriptor findGameID(
 	const char *gameid,
 	const PlainGameDescriptor *gameids,
-	const ObsoleteGameID *obsoleteList
-	) {
+	const ObsoleteGameID *obsoleteList) {
 	// First search the list of supported gameids for a match.
 	const PlainGameDescriptor *g = findPlainGameDescriptor(gameid, gameids);
 	if (g)

--- a/engines/obsolete.h
+++ b/engines/obsolete.h
@@ -69,8 +69,7 @@ void upgradeTargetIfNecessary(const ObsoleteGameID *obsoleteList);
 PlainGameDescriptor findGameID(
 	const char *gameid,
 	const PlainGameDescriptor *gameids,
-	const ObsoleteGameID *obsoleteList = 0
-	);
+	const ObsoleteGameID *obsoleteList = 0);
 
 
 } // End of namespace Engines

--- a/engines/parallaction/detection.cpp
+++ b/engines/parallaction/detection.cpp
@@ -45,7 +45,6 @@ Common::Platform Parallaction::getPlatform() const { return _gameDescription->de
 }
 
 static const PlainGameDescriptor parallactionGames[] = {
-	{"parallaction", "Parallaction engine game"},
 	{"nippon", "Nippon Safes Inc."},
 	{"bra", "The Big Red Adventure"},
 	{0, 0}

--- a/engines/parallaction/detection.cpp
+++ b/engines/parallaction/detection.cpp
@@ -223,6 +223,10 @@ public:
 		_guiOptions = GUIO1(GUIO_NOLAUNCHLOAD);
 	}
 
+	virtual const char *getEngineId() const {
+		return "parallaction";
+	}
+
 	virtual const char *getName() const {
 		return "Parallaction";
 	}

--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -135,7 +135,6 @@ static const PegasusGameDescription gameDescriptions[] = {
 class PegasusMetaEngine : public AdvancedMetaEngine {
 public:
 	PegasusMetaEngine() : AdvancedMetaEngine(Pegasus::gameDescriptions, sizeof(Pegasus::PegasusGameDescription), pegasusGames) {
-		_singleId = "pegasus";
 	}
 
 	virtual const char *getEngineId() const {

--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -138,6 +138,10 @@ public:
 		_singleId = "pegasus";
 	}
 
+	virtual const char *getEngineId() const {
+		return "pegasus";
+	}
+
 	virtual const char *getName() const {
 		return "The Journeyman Project: Pegasus Prime";
 	}

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -354,12 +354,7 @@ void PegasusEngine::runIntro() {
 Common::Error PegasusEngine::showLoadDialog() {
 	GUI::SaveLoadChooser slc(_("Load game:"), _("Load"), false);
 
-	Common::String gameId = ConfMan.get("gameid");
-
-	const Plugin *plugin = nullptr;
-	EngineMan.findGame(gameId, &plugin);
-
-	int slot = slc.runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
+	int slot = slc.runModalWithCurrentTarget();
 
 	Common::Error result;
 
@@ -378,12 +373,7 @@ Common::Error PegasusEngine::showLoadDialog() {
 Common::Error PegasusEngine::showSaveDialog() {
 	GUI::SaveLoadChooser slc(_("Save game:"), _("Save"), true);
 
-	Common::String gameId = ConfMan.get("gameid");
-
-	const Plugin *plugin = nullptr;
-	EngineMan.findGame(gameId, &plugin);
-
-	int slot = slc.runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
+	int slot = slc.runModalWithCurrentTarget();
 
 	if (slot >= 0)
 		return saveGameState(slot, slc.getResultString());

--- a/engines/pink/detection.cpp
+++ b/engines/pink/detection.cpp
@@ -56,6 +56,10 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
+	virtual const char *getEngineId() const {
+		return "pink";
+	}
+
 	virtual const char *getName() const {
 		return "Pink Panther";
 	}

--- a/engines/plumbers/detection.cpp
+++ b/engines/plumbers/detection.cpp
@@ -73,7 +73,6 @@ static const ADGameDescription gameDescriptions[] = {
 class PlumbersMetaEngine : public AdvancedMetaEngine {
 public:
 	PlumbersMetaEngine() : AdvancedMetaEngine(Plumbers::gameDescriptions, sizeof(ADGameDescription), plumbersGames) {
-		_singleId = "plumbers";
 	}
 
 	const char *getEngineId() const {

--- a/engines/plumbers/detection.cpp
+++ b/engines/plumbers/detection.cpp
@@ -76,6 +76,10 @@ public:
 		_singleId = "plumbers";
 	}
 
+	const char *getEngineId() const {
+		return "plumbers";
+	}
+
 	virtual const char *getName() const {
 		return "Plumbers Don't Wear Ties";
 	}

--- a/engines/prince/detection.cpp
+++ b/engines/prince/detection.cpp
@@ -148,7 +148,6 @@ const static char *directoryGlobs[] = {
 class PrinceMetaEngine : public AdvancedMetaEngine {
 public:
 	PrinceMetaEngine() : AdvancedMetaEngine(Prince::gameDescriptions, sizeof(Prince::PrinceGameDescription), princeGames) {
-		_singleId = "prince";
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/prince/detection.cpp
+++ b/engines/prince/detection.cpp
@@ -153,9 +153,13 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-        virtual const char *getName() const {
-                return "The Prince and the Coward";
+        const char *getEngineId() const {
+                return "prince";
         }
+
+	virtual const char *getName() const {
+                return "The Prince and the Coward";
+	}
 
 	virtual const char *getOriginalCopyright() const {
 		return "The Prince and the Coward (C) 1996-97 Metropolis";

--- a/engines/queen/detection.cpp
+++ b/engines/queen/detection.cpp
@@ -482,7 +482,6 @@ static const QueenGameDescription gameDescriptions[] = {
 class QueenMetaEngine : public AdvancedMetaEngine {
 public:
 	QueenMetaEngine() : AdvancedMetaEngine(Queen::gameDescriptions, sizeof(Queen::QueenGameDescription), queenGames, optionsList) {
-		_singleId = "queen";
 	}
 
 	const char *getEngineId() const {

--- a/engines/queen/detection.cpp
+++ b/engines/queen/detection.cpp
@@ -485,6 +485,10 @@ public:
 		_singleId = "queen";
 	}
 
+	const char *getEngineId() const {
+		return "queen";
+	}
+
 	virtual const char *getName() const {
 		return "Flight of the Amazon Queen";
 	}

--- a/engines/saga/detection.cpp
+++ b/engines/saga/detection.cpp
@@ -109,6 +109,10 @@ public:
 		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
+	const char *getEngineId() const {
+		return "saga";
+	}
+
 	virtual const char *getName() const {
 		return "SAGA ["
 

--- a/engines/saga/detection.cpp
+++ b/engines/saga/detection.cpp
@@ -28,7 +28,6 @@
 
 #include "common/config-manager.h"
 #include "engines/advancedDetector.h"
-#include "engines/obsolete.h"
 #include "common/system.h"
 #include "graphics/thumbnail.h"
 
@@ -81,7 +80,6 @@ const ADGameFileDescription *SagaEngine::getFilesDescriptions() const { return _
 }
 
 static const PlainGameDescriptor sagaGames[] = {
-	{"saga", "SAGA Engine game"},
 	{"ite", "Inherit the Earth: Quest for the Orb"},
 	{"ihnm", "I Have No Mouth and I Must Scream"},
 	{"dino", "Dinotopia"},
@@ -89,24 +87,11 @@ static const PlainGameDescriptor sagaGames[] = {
 	{0, 0}
 };
 
-static const Engines::ObsoleteGameID obsoleteGameIDsTable[] = {
-	{"ite", "saga", Common::kPlatformUnknown},
-	{"ihnm", "saga", Common::kPlatformUnknown},
-	{"dino", "saga", Common::kPlatformUnknown},
-	{"fta2", "saga", Common::kPlatformUnknown},
-	{0, 0, Common::kPlatformUnknown}
-};
-
 #include "saga/detection_tables.h"
 
 class SagaMetaEngine : public AdvancedMetaEngine {
 public:
 	SagaMetaEngine() : AdvancedMetaEngine(Saga::gameDescriptions, sizeof(Saga::SAGAGameDescription), sagaGames) {
-		_singleId = "saga";
-	}
-
-	PlainGameDescriptor findGame(const char *gameId) const override {
-		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
 	const char *getEngineId() const {
@@ -142,7 +127,6 @@ public:
 	virtual bool hasFeature(MetaEngineFeature f) const;
 
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine) const {
-		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
 		return AdvancedMetaEngine::createInstance(syst, engine);
 	}
 	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const;

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -558,7 +558,6 @@ static const char *directoryGlobs[] = {
 class SciMetaEngine : public AdvancedMetaEngine {
 public:
 	SciMetaEngine() : AdvancedMetaEngine(Sci::SciGameDescriptions, sizeof(ADGameDescription), s_sciGameTitles, optionsList) {
-		_singleId = "sci";
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 		_matchFullPaths = true;

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -564,6 +564,10 @@ public:
 		_matchFullPaths = true;
 	}
 
+	const char *getEngineId() const {
+		return "sci";
+	}
+
 	virtual const char *getName() const {
 		return "SCI ["
 #ifdef ENABLE_SCI32

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -964,6 +964,10 @@ using namespace Scumm;
 
 class ScummMetaEngine : public MetaEngine {
 public:
+	virtual const char *getEngineId() const {
+		return "scumm";
+	}
+
 	virtual const char *getName() const;
 	virtual const char *getOriginalCopyright() const;
 

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -1049,7 +1049,7 @@ DetectedGames ScummMetaEngine::detectGames(const Common::FSList &fslist) const {
 		const PlainGameDescriptor *g = findPlainGameDescriptor(x->game.gameid, gameDescriptions);
 		assert(g);
 
-		DetectedGame game = DetectedGame(x->game.gameid, g->description, x->language, x->game.platform, x->extra);
+		DetectedGame game = DetectedGame(getEngineId(), x->game.gameid, g->description, x->language, x->game.platform, x->extra);
 
 		// Compute and set the preferred target name for this game.
 		// Based on generateComplexID() in advancedDetector.cpp.

--- a/engines/sherlock/detection.cpp
+++ b/engines/sherlock/detection.cpp
@@ -136,6 +136,10 @@ public:
 	SherlockMetaEngine() : AdvancedMetaEngine(Sherlock::gameDescriptions, sizeof(Sherlock::SherlockGameDescription),
 		sherlockGames, optionsList) {}
 
+	virtual const char *getEngineId() const {
+		return "sherlock";
+	}
+
 	virtual const char *getName() const {
 		return "Sherlock";
 	}

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -189,12 +189,12 @@ DetectedGames SkyMetaEngine::detectGames(const Common::FSList &fslist) const {
 		if (sv->dinnerTableEntries) {
 			Common::String extra = Common::String::format("v0.0%d %s", sv->version, sv->extraDesc);
 
-			DetectedGame game = DetectedGame(skySetting.gameId, skySetting.description, Common::UNK_LANG, Common::kPlatformUnknown, extra);
+			DetectedGame game = DetectedGame(getEngineId(), skySetting.gameId, skySetting.description, Common::UNK_LANG, Common::kPlatformUnknown, extra);
 			game.setGUIOptions(sv->guioptions);
 
 			detectedGames.push_back(game);
 		} else {
-			detectedGames.push_back(DetectedGame(skySetting.gameId, skySetting.description));
+			detectedGames.push_back(DetectedGame(getEngineId(), skySetting.gameId, skySetting.description));
 		}
 	}
 

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -75,6 +75,10 @@ public:
 	virtual const char *getName() const;
 	virtual const char *getOriginalCopyright() const;
 
+	const char *getEngineId() const {
+		return "sky";
+	}
+
 	virtual bool hasFeature(MetaEngineFeature f) const;
 	PlainGameList getSupportedGames() const override;
 	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const;

--- a/engines/sludge/detection.cpp
+++ b/engines/sludge/detection.cpp
@@ -79,7 +79,6 @@ static char s_fallbackFileNameBuffer[51];
 class SludgeMetaEngine : public AdvancedMetaEngine {
 public:
 	SludgeMetaEngine() : AdvancedMetaEngine(Sludge::gameDescriptions, sizeof(Sludge::SludgeGameDescription), sludgeGames) {
-		_singleId = "sludge";
 		_maxScanDepth = 1;
 	}
 

--- a/engines/sludge/detection.cpp
+++ b/engines/sludge/detection.cpp
@@ -83,6 +83,10 @@ public:
 		_maxScanDepth = 1;
 	}
 
+	const char *getEngineId() const {
+		return "sludge";
+	}
+
 	virtual const char *getName() const {
 		return "Sludge";
 	}

--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -324,6 +324,10 @@ public:
 		_singleId = "startrek";
 	}
 
+	const char *getEngineId() const {
+		return "startrek";
+	}
+
 	virtual const char *getName() const {
 		return "Star Trek";
 	}

--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -60,7 +60,6 @@ Common::Language StarTrekEngine::getLanguage() const {
 } // End of Namespace StarTrek
 
 static const PlainGameDescriptor starTrekGames[] = {
-	{"startrek", "Star Trek game"},
 	{"st25", "Star Trek: 25th Anniversary"},
 	{"stjr", "Star Trek: Judgment Rites"},
 	{0, 0}
@@ -321,7 +320,6 @@ static const StarTrekGameDescription gameDescriptions[] = {
 class StarTrekMetaEngine : public AdvancedMetaEngine {
 public:
 	StarTrekMetaEngine() : AdvancedMetaEngine(StarTrek::gameDescriptions, sizeof(StarTrek::StarTrekGameDescription), starTrekGames) {
-		_singleId = "startrek";
 	}
 
 	const char *getEngineId() const {

--- a/engines/supernova/detection.cpp
+++ b/engines/supernova/detection.cpp
@@ -100,7 +100,6 @@ static const ADGameDescription gameDescriptions[] = {
 class SupernovaMetaEngine: public AdvancedMetaEngine {
 public:
 	SupernovaMetaEngine() : AdvancedMetaEngine(Supernova::gameDescriptions, sizeof(ADGameDescription), supernovaGames, optionsList) {
-//		_singleId = "supernova";
 	}
 
 	const char *getEngineId() const {

--- a/engines/supernova/detection.cpp
+++ b/engines/supernova/detection.cpp
@@ -103,6 +103,10 @@ public:
 //		_singleId = "supernova";
 	}
 
+	const char *getEngineId() const {
+		return "supernova";
+	}
+
 	virtual const char *getName() const {
 		return "Mission Supernova";
 	}

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -218,17 +218,17 @@ DetectedGames SwordMetaEngine::detectGames(const Common::FSList &fslist) const {
 
 	DetectedGame game;
 	if (mainFilesFound && pcFilesFound && demoFilesFound)
-		game = DetectedGame(sword1DemoSettings);
+		game = DetectedGame(getEngineId(), sword1DemoSettings);
 	else if (mainFilesFound && pcFilesFound && psxFilesFound)
-		game = DetectedGame(sword1PSXSettings);
+		game = DetectedGame(getEngineId(), sword1PSXSettings);
 	else if (mainFilesFound && pcFilesFound && psxDemoFilesFound)
-		game = DetectedGame(sword1PSXDemoSettings);
+		game = DetectedGame(getEngineId(), sword1PSXDemoSettings);
 	else if (mainFilesFound && pcFilesFound && !psxFilesFound)
-		game = DetectedGame(sword1FullSettings);
+		game = DetectedGame(getEngineId(), sword1FullSettings);
 	else if (mainFilesFound && macFilesFound)
-		game = DetectedGame(sword1MacFullSettings);
+		game = DetectedGame(getEngineId(), sword1MacFullSettings);
 	else if (mainFilesFound && macDemoFilesFound)
-		game = DetectedGame(sword1MacDemoSettings);
+		game = DetectedGame(getEngineId(), sword1MacDemoSettings);
 	else
 		return detectedGames;
 

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -79,6 +79,10 @@ static const char *const g_filesToCheck[NUM_FILES_TO_CHECK] = { // these files h
 
 class SwordMetaEngine : public MetaEngine {
 public:
+	virtual const char *getEngineId() const {
+		return "sword1";
+	}
+
 	virtual const char *getName() const {
 		return "Broken Sword: The Shadow of the Templars";
 	}

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -196,7 +196,7 @@ DetectedGames detectGamesImpl(const Common::FSList &fslist, bool recursion = fal
 						continue;
 
 					// Match found, add to list of candidates, then abort inner loop.
-					DetectedGame game = DetectedGame(g->gameid, g->description);
+					DetectedGame game = DetectedGame("sword2", g->gameid, g->description);
 					game.setGUIOptions(GUIO2(GUIO_NOMIDI, GUIO_NOASPECT));
 
 					detectedGames.push_back(game);

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -84,6 +84,10 @@ static const ExtraGuiOption sword2ExtraGuiOption = {
 
 class Sword2MetaEngine : public MetaEngine {
 public:
+	virtual const char *getEngineId() const {
+		return "sword2";
+	}
+
 	virtual const char *getName() const {
 		return "Broken Sword II: The Smoking Mirror";
 	}

--- a/engines/sword25/detection.cpp
+++ b/engines/sword25/detection.cpp
@@ -56,6 +56,11 @@ public:
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}
+
+	const char *getEngineId() const {
+		return "sword25";
+	}
+
 	virtual const char *getName() const {
 		return "Broken Sword 2.5";
 	}

--- a/engines/teenagent/detection.cpp
+++ b/engines/teenagent/detection.cpp
@@ -91,6 +91,10 @@ public:
 		_singleId = "teenagent";
 	}
 
+	const char *getEngineId() const {
+		return "teenagent";
+	}
+
 	virtual const char *getName() const {
 		return "TeenAgent";
 	}

--- a/engines/teenagent/detection.cpp
+++ b/engines/teenagent/detection.cpp
@@ -88,7 +88,6 @@ enum {
 class TeenAgentMetaEngine : public AdvancedMetaEngine {
 public:
 	TeenAgentMetaEngine() : AdvancedMetaEngine(teenAgentGameDescriptions, sizeof(ADGameDescription), teenAgentGames) {
-		_singleId = "teenagent";
 	}
 
 	const char *getEngineId() const {

--- a/engines/testbed/detection.cpp
+++ b/engines/testbed/detection.cpp
@@ -49,7 +49,6 @@ class TestbedMetaEngine : public AdvancedMetaEngine {
 public:
 	TestbedMetaEngine() : AdvancedMetaEngine(testbedDescriptions, sizeof(ADGameDescription), testbed_setting) {
 		_md5Bytes = 512;
-		_singleId = "testbed";
 	}
 
 	const char *getEngineId() const {

--- a/engines/testbed/detection.cpp
+++ b/engines/testbed/detection.cpp
@@ -52,6 +52,10 @@ public:
 		_singleId = "testbed";
 	}
 
+	const char *getEngineId() const {
+		return "testbed";
+	}
+
 	virtual const char *getName() const {
 		return "TestBed: The Backend Testing Framework";
 	}

--- a/engines/tinsel/detection.cpp
+++ b/engines/tinsel/detection.cpp
@@ -88,6 +88,10 @@ public:
 		_singleId = "tinsel";
 	}
 
+	const char *getEngineId() const {
+		return "tinsel";
+	}
+
 	virtual const char *getName() const {
 		return "Tinsel";
 	}

--- a/engines/tinsel/detection.cpp
+++ b/engines/tinsel/detection.cpp
@@ -74,7 +74,6 @@ bool TinselEngine::isV1CD() const {
 } // End of namespace Tinsel
 
 static const PlainGameDescriptor tinselGames[] = {
-	{"tinsel", "Tinsel engine game"},
 	{"dw", "Discworld"},
 	{"dw2", "Discworld 2: Missing Presumed ...!?"},
 	{0, 0}
@@ -85,7 +84,6 @@ static const PlainGameDescriptor tinselGames[] = {
 class TinselMetaEngine : public AdvancedMetaEngine {
 public:
 	TinselMetaEngine() : AdvancedMetaEngine(Tinsel::gameDescriptions, sizeof(Tinsel::TinselGameDescription), tinselGames) {
-		_singleId = "tinsel";
 	}
 
 	const char *getEngineId() const {

--- a/engines/titanic/detection.cpp
+++ b/engines/titanic/detection.cpp
@@ -62,6 +62,10 @@ public:
 		_maxScanDepth = 3;
 	}
 
+	virtual const char *getEngineId() const {
+		return "titanic";
+	}
+
 	virtual const char *getName() const {
 		return "Starship Titanic";
 	}

--- a/engines/toltecs/detection.cpp
+++ b/engines/toltecs/detection.cpp
@@ -220,7 +220,6 @@ static const ExtraGuiOption toltecsExtraGuiOption = {
 class ToltecsMetaEngine : public AdvancedMetaEngine {
 public:
 	ToltecsMetaEngine() : AdvancedMetaEngine(Toltecs::gameDescriptions, sizeof(Toltecs::ToltecsGameDescription), toltecsGames) {
-		_singleId = "toltecs";
 	}
 
 	const char *getEngineId() const {

--- a/engines/toltecs/detection.cpp
+++ b/engines/toltecs/detection.cpp
@@ -223,6 +223,10 @@ public:
 		_singleId = "toltecs";
 	}
 
+	const char *getEngineId() const {
+		return "toltecs";
+	}
+
 	virtual const char *getName() const {
 		return "3 Skulls of the Toltecs";
 	}

--- a/engines/tony/detection.cpp
+++ b/engines/tony/detection.cpp
@@ -71,6 +71,10 @@ public:
 	TonyMetaEngine() : AdvancedMetaEngine(Tony::gameDescriptions, sizeof(Tony::TonyGameDescription), tonyGames) {
 	}
 
+	virtual const char *getEngineId() const {
+		return "tony";
+	}
+
 	virtual const char *getName() const {
 		return "Tony Tough and the Night of Roasted Moths";
 	}

--- a/engines/toon/detection.cpp
+++ b/engines/toon/detection.cpp
@@ -146,6 +146,10 @@ public:
 		return detectGameFilebased(allFiles, fslist, Toon::fileBasedFallback);
 	}
 
+	const char *getEngineId() const {
+		return "toon";
+	}
+
 	virtual const char *getName() const {
 		return "Toonstruck";
 	}

--- a/engines/toon/detection.cpp
+++ b/engines/toon/detection.cpp
@@ -137,7 +137,6 @@ static const char * const directoryGlobs[] = {
 class ToonMetaEngine : public AdvancedMetaEngine {
 public:
 	ToonMetaEngine() : AdvancedMetaEngine(Toon::gameDescriptions, sizeof(ADGameDescription), toonGames) {
-		_singleId = "toon";
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/touche/detection.cpp
+++ b/engines/touche/detection.cpp
@@ -128,7 +128,6 @@ class ToucheMetaEngine : public AdvancedMetaEngine {
 public:
 	ToucheMetaEngine() : AdvancedMetaEngine(Touche::gameDescriptions, sizeof(ADGameDescription), toucheGames) {
 		_md5Bytes = 4096;
-		_singleId = "touche";
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/touche/detection.cpp
+++ b/engines/touche/detection.cpp
@@ -137,6 +137,10 @@ public:
 		return detectGameFilebased(allFiles, fslist, Touche::fileBasedFallback);
 	}
 
+	const char *getEngineId() const {
+		return "touche";
+	}
+
 	virtual const char *getName() const {
 		return "Touche: The Adventures of the Fifth Musketeer";
 	}

--- a/engines/tsage/detection.cpp
+++ b/engines/tsage/detection.cpp
@@ -58,7 +58,6 @@ Common::String TSageEngine::getPrimaryFilename() const {
 } // End of namespace TsAGE
 
 static const PlainGameDescriptor tSageGameTitles[] = {
-	{ "tsage", "Tsunami TsAGE-based Game" },
 	{ "ringworld", "Ringworld: Revenge of the Patriarch" },
 	{ "blueforce", "Blue Force" },
 	{ "ringworld2", "Return to Ringworld" },
@@ -75,7 +74,6 @@ enum {
 class TSageMetaEngine : public AdvancedMetaEngine {
 public:
 	TSageMetaEngine() : AdvancedMetaEngine(TsAGE::gameDescriptions, sizeof(TsAGE::tSageGameDescription), tSageGameTitles) {
-		_singleId = "tsage";
 	}
 
 	const char *getEngineId() const {

--- a/engines/tsage/detection.cpp
+++ b/engines/tsage/detection.cpp
@@ -78,6 +78,10 @@ public:
 		_singleId = "tsage";
 	}
 
+	const char *getEngineId() const {
+		return "tsage";
+	}
+
 	virtual const char *getName() const {
 		return "TsAGE";
 	}

--- a/engines/tucker/detection.cpp
+++ b/engines/tucker/detection.cpp
@@ -125,7 +125,6 @@ class TuckerMetaEngine : public AdvancedMetaEngine {
 public:
 	TuckerMetaEngine() : AdvancedMetaEngine(tuckerGameDescriptions, sizeof(ADGameDescription), tuckerGames) {
 		_md5Bytes = 512;
-		_singleId = "tucker";
 	}
 
 	const char *getEngineId() const {

--- a/engines/tucker/detection.cpp
+++ b/engines/tucker/detection.cpp
@@ -128,6 +128,10 @@ public:
 		_singleId = "tucker";
 	}
 
+	const char *getEngineId() const {
+		return "tucker";
+	}
+
 	virtual const char *getName() const {
 		return "Bud Tucker in Double Trouble";
 	}

--- a/engines/voyeur/detection.cpp
+++ b/engines/voyeur/detection.cpp
@@ -70,6 +70,10 @@ public:
 		_maxScanDepth = 3;
 	}
 
+	virtual const char *getEngineId() const {
+		return "voyeur";
+	}
+
 	virtual const char *getName() const {
 		return "Voyeur";
 	}

--- a/engines/wage/detection.cpp
+++ b/engines/wage/detection.cpp
@@ -59,6 +59,11 @@ public:
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI);
 	}
 
+	virtual const char *getEngineId() const {
+		return "wage";
+	}
+
+
 	virtual const char *getName() const {
 		return "World Adventure Game Engine";
 	}

--- a/engines/wage/detection.cpp
+++ b/engines/wage/detection.cpp
@@ -55,7 +55,6 @@ class WageMetaEngine : public AdvancedMetaEngine {
 public:
 	WageMetaEngine() : AdvancedMetaEngine(Wage::gameDescriptions, sizeof(ADGameDescription), wageGames) {
 		_md5Bytes = 2 * 1024 * 1024;
-		_singleId = "wage";
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI);
 	}
 

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -88,7 +88,6 @@ static const char *directoryGlobs[] = {
 class WintermuteMetaEngine : public AdvancedMetaEngine {
 public:
 	WintermuteMetaEngine() : AdvancedMetaEngine(Wintermute::gameDescriptions, sizeof(WMEGameDescription), Wintermute::wintermuteGames, gameGuiOptions) {
-		_singleId = "wintermute";
 		_guiOptions = GUIO3(GUIO_NOMIDI, GAMEOPTION_SHOW_FPS, GAMEOPTION_BILINEAR);
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -93,6 +93,11 @@ public:
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}
+
+	const char *getEngineId() const {
+		return "wintermute";
+	}
+
 	virtual const char *getName() const {
 		return "Wintermute";
 	}

--- a/engines/xeen/detection.cpp
+++ b/engines/xeen/detection.cpp
@@ -76,7 +76,6 @@ bool XeenEngine::getIsCD() const {
 } // End of namespace Xeen
 
 static const PlainGameDescriptor XeenGames[] = {
-	{ "xeen", "Xeen" },
 	{ "cloudsofxeen", "Might and Magic IV: Clouds of Xeen" },
 	{ "darksideofxeen", "Might and Magic V: Dark Side of Xeen" },
 	{ "worldofxeen", "Might and Magic: World of Xeen" },

--- a/engines/xeen/detection.cpp
+++ b/engines/xeen/detection.cpp
@@ -121,6 +121,10 @@ public:
 		_maxScanDepth = 3;
 	}
 
+	virtual const char *getEngineId() const {
+		return "xeen";
+	}
+
 	virtual const char *getName() const {
 		return "Xeen";
 	}

--- a/engines/zvision/detection.cpp
+++ b/engines/zvision/detection.cpp
@@ -61,7 +61,6 @@ public:
 	ZVisionMetaEngine() : AdvancedMetaEngine(ZVision::gameDescriptions, sizeof(ZVision::ZVisionGameDescription), ZVision::zVisionGames, ZVision::optionsList) {
 		_maxScanDepth = 2;
 		_directoryGlobs = ZVision::directoryGlobs;
-		_singleId = "zvision";
 	}
 
 	const char *getEngineId() const {

--- a/engines/zvision/detection.cpp
+++ b/engines/zvision/detection.cpp
@@ -64,6 +64,10 @@ public:
 		_singleId = "zvision";
 	}
 
+	const char *getEngineId() const {
+		return "zvision";
+	}
+
 	virtual const char *getName() const {
 		return "Z-Vision";
 	}

--- a/engines/zvision/detection_tables.h
+++ b/engines/zvision/detection_tables.h
@@ -26,7 +26,6 @@
 namespace ZVision {
 
 static const PlainGameDescriptor zVisionGames[] = {
-	{ "zvision", "Z-Vision Game" },
 	{ "znemesis", "Zork Nemesis: The Forbidden Lands" },
 	{ "zgi", "Zork: Grand Inquisitor" },
 	{ 0, 0 }

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -599,7 +599,7 @@ void EventRecorder::setFileHeader() {
 		return;
 	}
 	TimeDate t;
-	PlainGameDescriptor desc = EngineMan.findTarget(ConfMan.getActiveDomainName());
+	QualifiedGameDescriptor desc = EngineMan.findTarget(ConfMan.getActiveDomainName());
 	g_system->getTimeAndDate(t);
 	if (_author.empty()) {
 		setAuthor("Unknown Author");

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -100,6 +100,8 @@ protected:
 
 EditGameDialog::EditGameDialog(const String &domain)
 	: OptionsDialog(domain, "GameOptions") {
+	EngineMan.upgradeTargetIfNecessary(domain);
+
 	// Retrieve all game specific options.
 	const Plugin *plugin = nullptr;
 	// To allow for game domains without a gameid.

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -103,15 +103,11 @@ EditGameDialog::EditGameDialog(const String &domain)
 	EngineMan.upgradeTargetIfNecessary(domain);
 
 	// Retrieve all game specific options.
-	const Plugin *plugin = nullptr;
-	// To allow for game domains without a gameid.
-	// TODO: Is it intentional that this is still supported?
-	String gameId(ConfMan.get("gameid", domain));
-	if (gameId.empty())
-		gameId = domain;
+
 	// Retrieve the plugin, since we need to access the engine's MetaEngine
 	// implementation.
-	PlainGameDescriptor pgd = EngineMan.findGame(gameId, &plugin);
+	const Plugin *plugin = nullptr;
+	QualifiedGameDescriptor qgd = EngineMan.findTarget(domain, &plugin);
 	if (plugin) {
 		_engineOptions = plugin->get<MetaEngine>().getExtraGuiOptions(domain);
 	} else {
@@ -125,8 +121,8 @@ EditGameDialog::EditGameDialog(const String &domain)
 
 	// GAME: Determine the description string
 	String description(ConfMan.get("description", domain));
-	if (description.empty() && pgd.description) {
-		description = pgd.description;
+	if (description.empty() && qgd.description) {
+		description = qgd.description;
 	}
 
 	// GUI:  Add tab widget

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -271,7 +271,7 @@ void LauncherDialog::updateListing() {
 			gameid = iter->_key;
 
 		if (description.empty()) {
-			PlainGameDescriptor g = EngineMan.findTarget(iter->_key);
+			QualifiedGameDescriptor g = EngineMan.findTarget(iter->_key);
 			if (g.description)
 				description = g.description;
 		}

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -481,6 +481,8 @@ void LauncherDialog::loadGame(int item) {
 	String target = _domains[item];
 	target.toLowercase();
 
+	EngineMan.upgradeTargetIfNecessary(target);
+
 	// Look for the plugin
 	const Plugin *plugin = nullptr;
 	EngineMan.findTarget(target, &plugin);

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -269,8 +269,9 @@ void LauncherDialog::updateListing() {
 
 		if (gameid.empty())
 			gameid = iter->_key;
+
 		if (description.empty()) {
-			PlainGameDescriptor g = EngineMan.findGame(gameid);
+			PlainGameDescriptor g = EngineMan.findTarget(iter->_key);
 			if (g.description)
 				description = g.description;
 		}
@@ -416,9 +417,6 @@ void LauncherDialog::editGame(int item) {
 	// This is useful because e.g. MonkeyVGA needs AdLib music to have decent
 	// music support etc.
 	assert(item >= 0);
-	String gameId(ConfMan.get("gameid", _domains[item]));
-	if (gameId.empty())
-		gameId = _domains[item];
 
 	EditGameDialog editDialog(_domains[item]);
 	if (editDialog.runModal() > 0) {
@@ -480,16 +478,12 @@ void LauncherDialog::recordGame(int item) {
 #endif
 
 void LauncherDialog::loadGame(int item) {
-	String gameId = ConfMan.get("gameid", _domains[item]);
-	if (gameId.empty())
-		gameId = _domains[item];
-
-	const Plugin *plugin = nullptr;
-
-	EngineMan.findGame(gameId, &plugin);
-
 	String target = _domains[item];
 	target.toLowercase();
+
+	// Look for the plugin
+	const Plugin *plugin = nullptr;
+	EngineMan.findTarget(target, &plugin);
 
 	if (plugin) {
 		const MetaEngine &metaEngine = plugin->get<MetaEngine>();

--- a/gui/massadd.cpp
+++ b/gui/massadd.cpp
@@ -207,7 +207,7 @@ void MassAddDialog::handleTickle() {
 			while (path != "/" && path.lastChar() == '/')
 				path.deleteLastChar();
 
-			// Check for existing config entries for this path/gameid/lang/platform combination
+			// Check for existing config entries for this path/engineid/gameid/lang/platform combination
 			if (_pathToTargets.contains(path)) {
 				Common::String resultPlatformCode = Common::getPlatformCode(result.platform);
 				Common::String resultLanguageCode = Common::getLanguageCode(result.language);
@@ -215,11 +215,12 @@ void MassAddDialog::handleTickle() {
 				bool duplicate = false;
 				const StringArray &targets = _pathToTargets[path];
 				for (StringArray::const_iterator iter = targets.begin(); iter != targets.end(); ++iter) {
-					// If the gameid, platform and language match -> skip it
+					// If the engineid, gameid, platform and language match -> skip it
 					Common::ConfigManager::Domain *dom = ConfMan.getDomain(*iter);
 					assert(dom);
 
-					if ((*dom)["gameid"] == result.gameId &&
+					if ((*dom)["engineid"] == result.engineId &&
+						(*dom)["gameid"] == result.gameId &&
 					    (*dom)["platform"] == resultPlatformCode &&
 					    (*dom)["language"] == resultLanguageCode) {
 						duplicate = true;

--- a/gui/recorderdialog.cpp
+++ b/gui/recorderdialog.cpp
@@ -166,7 +166,7 @@ void RecorderDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 		break;
 	case kRecordCmd: {
 		TimeDate t;
-		PlainGameDescriptor desc = EngineMan.findTarget(_target);
+		QualifiedGameDescriptor desc = EngineMan.findTarget(_target);
 		g_system->getTimeAndDate(t);
 		EditRecordDialog editDlg(_("Unknown Author"), Common::String::format("%.2d.%.2d.%.4d ", t.tm_mday, t.tm_mon, 1900 + t.tm_year) + desc.description, "");
 		if (editDlg.runModal() != kOKCmd) {

--- a/gui/recorderdialog.cpp
+++ b/gui/recorderdialog.cpp
@@ -166,8 +166,7 @@ void RecorderDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 		break;
 	case kRecordCmd: {
 		TimeDate t;
-		Common::String gameId = ConfMan.get("gameid", _target);
-		PlainGameDescriptor desc = EngineMan.findGame(gameId);
+		PlainGameDescriptor desc = EngineMan.findTarget(_target);
 		g_system->getTimeAndDate(t);
 		EditRecordDialog editDlg(_("Unknown Author"), Common::String::format("%.2d.%.2d.%.4d ", t.tm_mday, t.tm_mon, 1900 + t.tm_year) + desc.description, "");
 		if (editDlg.runModal() != kOKCmd) {

--- a/gui/saveload.cpp
+++ b/gui/saveload.cpp
@@ -76,11 +76,7 @@ Common::String SaveLoadChooser::createDefaultSaveDescription(const int slot) con
 }
 
 int SaveLoadChooser::runModalWithCurrentTarget() {
-	const Common::String gameId = ConfMan.get("gameid");
-
-	const Plugin *plugin = 0;
-	EngineMan.findGame(gameId, &plugin);
-
+	const Plugin *plugin = EngineMan.findPlugin(ConfMan.get("engineid"));
 	return runModalWithPluginAndTarget(plugin, ConfMan.getActiveDomainName());
 }
 

--- a/gui/unknown-game-dialog.cpp
+++ b/gui/unknown-game-dialog.cpp
@@ -193,13 +193,13 @@ Common::String UnknownGameDialog::generateBugtrackerURL() {
 	Common::String report = generateUnknownGameReport(_detectedGame, false, false);
 	report = encodeUrlString(report);
 
-	Common::String engineName = encodeUrlString(_detectedGame.engineName);
+	Common::String engineId = encodeUrlString(_detectedGame.engineId);
 
 	return Common::String::format(
 		"https://www.scummvm.org/unknowngame?"
 		"engine=%s"
 		"&description=%s",
-		engineName.c_str(),
+		engineId.c_str(),
 		report.c_str());
 }
 


### PR DESCRIPTION
Currently games are uniquely identified by their gameId. This is good because a single value can be used to identify a game across all the engines. The gameId is stored in the configuration file under the game target section.

However, as more game engines have been added to ScummVM, the concern of gameId clashes across engines became apparent. A feature was added to the Advanced Detector to work around this issue: singleId. For engines that enable the singleId feature, the gameId is always the same for all the games supported by the engine, allowing to avoid collisions.
However, storing the singleId instead of the gameId in the configuration file is a loss of information that causes a few problems:
* The `--list-games` command line command no longer lists all the games supported by the engines using singleId.
* When multiple games using the same engine are stored in the same folder, ScummVM doesn't know which one to launch, and starts the first one (This is annoying for Myst because both the game and the making of are in the same folder on the game CD).
* In the MetaEngines, in code that is executed before detection happens, it's not possible to know which game the currently active target is for. This is a problem for the Mohawk engine because saved game handling is entirely separate across the games. Currently we have to rely on the target name to detect the game (https://github.com/scummvm/scummvm/blob/61f9398b04a4bce397a8be6ae96491a2015a6da2/engines/mohawk/detection.cpp#L241). This is not robust because the target name is user configurable and could very well not contain the game name.

In this PR, I propose to use a different approach. Engines have a new engineId property that can be used to uniquely identify them. That way, the gameIds for an engine are namespaced by the engineId. This removes the need for the singleId feature which I propose to remove. The engineIds are stored in the configuration file under the game targets sections along with the gameIds.

This pull request contains code allowing to automatically upgrade the game targets to add an engineId and set the appropriate gameId when trying to launch a game (and other operations that require an active game target context such as editing the game options or loading a saved game).

On the command line, I have added the ability to use qualified game names where gameIds were previously used. Qualified game names have the following form: `engineId:gameId`. It is now recommended to say:
`scummvm --path=/my/games/riven mohawk:riven` instead of `scummvm --path=/my/games/riven riven`.
Non-qualified game names still work as long as there are no gameId conflicts but are deprecated. (They are deprecated because looking up a game by its gameId only has become a slow path when using dynamic plugins. This is because the gameId => plugin path cache stored in the configuration file has become a engineId => plugin path cache to allow the now more common operation of looking up an engine by its name to be a fast path.)

On the command line, I have also added a new `--list-engines` command allowing to print the list of compiled engines along with their ids.

Please review.