### PR TITLE
RISCOS: Add a script to open the README file based on the system territory

### DIFF
--- a/backends/platform/sdl/riscos/riscos.mk
+++ b/backends/platform/sdl/riscos/riscos.mk
@@ -21,5 +21,8 @@ ifdef DYNAMIC_MODULES
 endif
 	mkdir -p !ScummVM/docs
 	cp ${srcdir}/dists/riscos/!Help,feb !ScummVM/!Help,feb
+ifdef TOKENIZE
+	$(TOKENIZE) dists/riscos/FindHelp,fd1 -out !ScummVM/FindHelp,ffb
+endif
 	cp $(DIST_FILES_DOCS) !ScummVM/docs
 	cp -r ${srcdir}/doc/* !ScummVM/docs

--- a/configure
+++ b/configure
@@ -1801,6 +1801,12 @@ riscos)
 		echo "Please set GCCSDK_INSTALL_ENV in your environment. export GCCSDK_INSTALL_ENV=<path to GCCSDK_INSTALL_ENV>"
 		exit 1
 	fi
+
+	if test -e "$GCCSDK_INSTALL_ENV/bin/tokenize"; then
+		add_line_to_config_mk "TOKENIZE := $GCCSDK_INSTALL_ENV/bin/tokenize"
+	elif `which tokenize >/dev/null 2>&1`; then
+		add_line_to_config_mk "TOKENIZE := tokenize"
+	fi
 	;;
 tizen)
 	if test -z "$TIZEN_ROOTSTRAP"; then

--- a/dists/riscos/!Help,feb
+++ b/dists/riscos/!Help,feb
@@ -1,1 +1,3 @@
-Filer_Opendir <Obey$Dir>.docs
+Run <Obey$Dir>.!Boot
+Filer_Opendir <ScummVM$Dir>.docs
+IfThere <ScummVM$Dir>.FindHelp Then Run <ScummVM$Dir>.FindHelp

--- a/dists/riscos/FindHelp,fd1
+++ b/dists/riscos/FindHelp,fd1
@@ -1,0 +1,42 @@
+ON ERROR PROCerror
+file$=""
+
+SYS "Territory_Number" TO current_territory%
+REPEAT
+   READ territory%, prefix$, quickstart$, readme$
+   IF territory%=current_territory% OR territory%=-1 THEN
+      IF quickstart$<>"" THEN
+         SYS "OS_File",20,"<ScummVM$Dir>.docs."+prefix$+quickstart$ TO qtype%
+         IF qtype%<>0 THEN
+            file$="<ScummVM$Dir>.docs."+prefix$+quickstart$
+         ENDIF
+      ENDIF
+      IF readme$<>"" THEN
+         SYS "OS_File",20,"<ScummVM$Dir>.docs."+prefix$+readme$ TO rtype%
+         IF rtype%<>0 THEN
+            file$="<ScummVM$Dir>.docs."+prefix$+readme$
+         ENDIF
+      ENDIF
+   ENDIF
+UNTIL territory%=-1 OR file$<>""
+
+IF file$<>"" THEN
+   OSCLI "Filer_Run "+file$
+ENDIF
+END
+
+DEF PROCerror
+   ON ERROR OFF
+   ERROR ERR, REPORT$+" at line "+STR$(ERL)
+ENDPROC
+
+REM Reference: https://www.riscosopen.org/wiki/documentation/show/Territory%20Numbers
+DATA 4,   "it.",    "GuidaRapida",     ""
+DATA 5,   "es.",    "InicioRapido",    ""
+DATA 6,   "fr.",    "DemarrageRapide", ""
+DATA 7,   "de.",    "Schnellstart",    "LIESMICH"
+DATA 11,  "se.",    "Snabbstart",      "LasMig"
+DATA 14,  "da.",    "HurtigStart",     ""
+DATA 15,  "no-nb.", "HurtigStart",     ""
+DATA 134, "cz.",    "",                "PrectiMe"
+DATA -1,  "",       "QuickStart",      "README"


### PR DESCRIPTION
Previously, selecting the "Help" option in the RISC OS Filer menu would simply open the docs directory inside the application. This PR changes it so that it will additionally open the README or QuickStart file, using a translated version if a supported Territory module is installed.

The script is stored in plain text so that changes can be tracked by Git. As such, it needs to be converted using [Tokenize](http://www.stevefryatt.org.uk/software/build/) before it can be used on RISC OS. This is handled automatically by the packaging rules if Tokenize is installed.