### PR TITLE
VIDEO: fix rewinding of FLIC files

### DIFF
--- a/video/flic_decoder.cpp
+++ b/video/flic_decoder.cpp
@@ -130,14 +130,13 @@ bool FlicDecoder::FlicVideoTrack::endOfTrack() const {
 }
 
 bool FlicDecoder::FlicVideoTrack::rewind() {
-	_curFrame = -1;
-	_nextFrameStartTime = 0;
-
-	if (endOfTrack() && _fileStream->pos() < _fileStream->size())
+	if (endOfTrack() && _fileStream->pos() < _fileStream->size() && _frameCount != 1)
 		_atRingFrame = true;
 	else
 		_fileStream->seek(_offsetFrame1);
 
+	_curFrame = -1;
+	_nextFrameStartTime = 0;
 	_frameDelay = _startFrameDelay;
 	return true;
 }


### PR DESCRIPTION
This pull request fixes following problems:
1) the decoder will never be at ring frame because curFrame is set to -1 at the begin.
2) if a file has only 1 frame, then it has empty ring frame and probably the wrong offset to the second frame. I have tested this on Pink Panther games. And these games have such files, where the offset is wrong. 