### PR TITLE
 RISCOS: Convert documentation to RISCOS-LATIN1 when packaging

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -242,6 +242,16 @@ dist-src: \
 # Common files
 DIST_FILES_DOCS:=$(addprefix $(srcdir)/,AUTHORS COPYING COPYING.BSD COPYING.LGPL COPYING.FREEFONT COPYRIGHT NEWS README)
 
+DIST_FILES_DOCS_languages=cz da de es fr it no-nb se
+DIST_FILES_DOCS_cz:=$(addprefix $(srcdir)/doc/cz/,PrectiMe)
+DIST_FILES_DOCS_da:=$(addprefix $(srcdir)/doc/da/,HurtigStart)
+DIST_FILES_DOCS_de:=$(addprefix $(srcdir)/doc/de/,LIESMICH NEUES Schnellstart)
+DIST_FILES_DOCS_es:=$(addprefix $(srcdir)/doc/es/,InicioRapido)
+DIST_FILES_DOCS_fr:=$(addprefix $(srcdir)/doc/fr/,DemarrageRapide)
+DIST_FILES_DOCS_it:=$(addprefix $(srcdir)/doc/it/,GuidaRapida)
+DIST_FILES_DOCS_no-nb:=$(addprefix $(srcdir)/doc/no-nb/,HurtigStart)
+DIST_FILES_DOCS_se:=$(addprefix $(srcdir)/doc/se/,LasMig Snabbstart)
+
 # Themes files
 DIST_FILES_THEMES=scummmodern.zip scummclassic.zip
 ifdef USE_TRANSLATION

--- a/backends/platform/sdl/riscos/riscos.mk
+++ b/backends/platform/sdl/riscos/riscos.mk
@@ -1,3 +1,9 @@
+ifeq ($(shell echo a | iconv --to-code=RISCOS-LATIN1//TRANSLIT >/dev/null 2>&1; echo $$?),0)
+ENCODING=RISCOS-LATIN1//TRANSLIT
+else
+ENCODING=ISO-8859-1//TRANSLIT
+endif
+
 # Special target to create an RISC OS snapshot installation
 riscosdist: scummvm$(EXEEXT)
 	mkdir -p !ScummVM
@@ -24,5 +30,5 @@ endif
 ifdef TOKENIZE
 	$(TOKENIZE) dists/riscos/FindHelp,fd1 -out !ScummVM/FindHelp,ffb
 endif
-	cp $(DIST_FILES_DOCS) !ScummVM/docs
-	cp -r ${srcdir}/doc/* !ScummVM/docs
+	@$(foreach file, $(DIST_FILES_DOCS) $(srcdir)/doc/QuickStart, echo '   ' ICONV '  ' !ScummVM/docs/$(notdir $(file)),fff;iconv --to-code=$(ENCODING) $(file) > !ScummVM/docs/$(notdir $(file)),fff;)
+	@$(foreach lang, $(DIST_FILES_DOCS_languages), mkdir -p !ScummVM/docs/$(lang); $(foreach file, $(DIST_FILES_DOCS_$(lang)), echo '   ' ICONV '  ' !ScummVM/docs/$(lang)/$(notdir $(file)),fff;iconv --to-code=$(ENCODING) $(file) > !ScummVM/docs/$(lang)/$(notdir $(file)),fff;))

--- a/doc/da/HurtigStart
+++ b/doc/da/HurtigStart
@@ -56,7 +56,7 @@ hvert spil virker i ScummVM, ved at kigge på kompatibilitetssiden. Faktisk,
 hvis du søger lidt rundt, vil du måske opdage, at ScummVM endog anvendes 
 kommercielt til genudgivelse af nogle af understøttede spil på moderne 
 platforme. Dette viser, at flere virksomheder er tilfredse med kvaliteten 
-af ​​programmet, og hvor godt det kan køre nogle af spillene.
+af programmet, og hvor godt det kan køre nogle af spillene.
 
 Hvis du har fornøjelse af ScummVM, er du velkommen til at donere ved hjælp 
 af PayPal-knappen på ScummVM's hjemmeside. Dette vil hjælpe os med at købe

--- a/doc/se/Snabbstart
+++ b/doc/se/Snabbstart
@@ -15,11 +15,11 @@ Innehåll:
 
 1.1) Om ScummVM:
 ---- -----------
-ScummVM är ett program som gör det möjligt att spela vissa klassiska peka-och-klicka-äventyrsspel, förutsatt att du redan har de nödvändiga datafilerna. Det finurliga i det hela är att ScummVM ersätter de ursprungliga programfilerna som följde med spelet, vilket låter dig spela dem på operativsystem de aldrig var designade för!
+ScummVM är ett program som gör det möjligt att spela vissa klassiska ”peka-och-klicka”-äventyrsspel, förutsatt att du redan har de nödvändiga datafilerna. Det finurliga i det hela är att ScummVM ersätter de ursprungliga programfilerna som följde med spelet, vilket låter dig spela dem på operativsystem de aldrig var designade för!
 
-Från början var programmet designat för att köra LucasArts SCUMM-spel, till exempel Maniac Mansion, Monkey Island, Day of the Tentacle och Sam and Max. SCUMM står för Script Creation Utility for Maniac Mansion, och just Maniac Mansion var det första spelet där LucasArts använde det här spelsystemet. Mycket senare gav det namn till ScummVM (VM står för Virtual Machine).
+Från början var programmet designat för att köra LucasArts SCUMM-spel, till exempel Maniac Mansion, Monkey Island, Day of the Tentacle och Sam and Max. SCUMM står för ”Script Creation Utility for Maniac Mansion”, och just Maniac Mansion var det första spelet där LucasArts använde det här spelsystemet. Mycket senare gav det namn till ScummVM (”VM” står för ”Virtual Machine”).
 
-Med tiden har stöd lagts till för många spel som inte använder SCUMM-systemet och ScummVM stöder nu även många av Sierras AGI- och SCI-spel (till exempel Kings Quest 1-6, Space Quest 1-5, ...), Discworld 1 och 2, Simon the Sorcerer 1 och 2, Beneath A Steel Sky, Lure of the Temptress, Broken Sword I och II, Flight of the Amazon Queen, Gobliiins 1-3, Legend of Kyrandia-serien, många av Humongous Entertainments barnspel (inklusive Freddi Fish och Putt Putt-spelen) med flera. Du kan se en fullständig lista med delaljer om vilka äventyr som stöds och hur väl de fungerar på kompatibilitetssidan. ScummVM förbättras konstant, så håll ett öga på listan.
+Med tiden har stöd lagts till för många spel som inte använder SCUMM-systemet och ScummVM stöder nu även många av Sierras AGI- och SCI-spel (till exempel King’s Quest 1-6, Space Quest 1-5, ...), Discworld 1 och 2, Simon the Sorcerer 1 och 2, Beneath A Steel Sky, Lure of the Temptress, Broken Sword I och II, Flight of the Amazon Queen, Gobliiins 1-3, Legend of Kyrandia-serien, många av Humongous Entertainments barnspel (inklusive Freddi Fish och Putt Putt-spelen) med flera. Du kan se en fullständig lista med delaljer om vilka äventyr som stöds och hur väl de fungerar på kompatibilitetssidan. ScummVM förbättras konstant, så håll ett öga på listan.
 
 Bland systemen du kan använda för att spela dessa spel räknas vanliga persondatorer (Windows, Linux, Mac OS X, ...) spelkonsoler (Dreamcast, Nintendo DS & Wii, PS2, PSP, ...), smartphones (Android, iPhone, PocketPC, Symbian ...) med flera.
 
@@ -40,32 +40,32 @@ För de otåliga följer här instruktioner för att köra igång ScummVM i fem 
 3. Starta ScummVM.
 
 Om programmet nu visas på engelska istället för svenska, gör såhär för att byta språk:
-- Klicka på Options.
-- Klicka på högerpilen i tab-raden och navigera till Misc-tabben.
-- Välj Svenska i GUI Language-menyn och klicka på OK.
-- Konfirmera meddelandet som visas, klicka på Quit för att avsluta ScummVM och starta sedan om programmet.
+- Klicka på ”Options”.
+- Klicka på högerpilen i tab-raden och navigera till ”Misc”-tabben.
+- Välj ”Svenska” i ”GUI Language”-menyn och klicka på ”OK”.
+- Konfirmera meddelandet som visas, klicka på ”Quit” för att avsluta ScummVM och starta sedan om programmet.
 
-Klicka på Lägg till spel, välj katalogen som innehåller datafilerna (var noga att välja själva filkatalogen - inte datafilerna inuti filkatalogen!) och klicka på Välj.
+Klicka på ”Lägg till spel”, välj katalogen som innehåller datafilerna (var noga att välja själva filkatalogen - inte datafilerna inuti filkatalogen!) och klicka på ”Välj”.
 
 4. Nu visas en dialogruta där du kan ändra diverse inställningar om du vill (det borde vara nog att lämna inställningarna som de är från början). Konfirmera dialogrutan.
 
-5. Välj spelet du vill spela från listan och klicka på Starta.
+5. Välj spelet du vill spela från listan och klicka på ”Starta”.
 
 ScummVM kommer ihåg alla spelen du lägger till, så om du avslutar ScummVM kommer spellistan vid nästa omstart innehålla alla spelen du hittills lagt till. Du kan därför hoppa direkt till steg 5, såtillvida inte du vill läga till fler spel.
 
-Tips: Om du vill lägga till flera spel på en gång, pröva att trycka och hålla ned skift-tangenten när du klickar på Lägg till spel  knappens text ändras nu till Masstillägg och om du klickar på den kommer du åter igen ombedjas att välja en filkatalog, men den här gången söker ScummVM automatiskt igenom alla underkataloger efter stödda spel.
+Tips: Om du vill lägga till flera spel på en gång, pröva att trycka och hålla ned skift-tangenten när du klickar på ”Lägg till spel” – knappens text ändras nu till ”Masstillägg” och om du klickar på den kommer du åter igen ombedjas att välja en filkatalog, men den här gången söker ScummVM automatiskt igenom alla underkataloger efter stödda spel.
 
 2.0) Kontakt:
 ---- --------
-Det enklaste sättet att kontakta ScummVM-teamet är att skicka in bugg-rapporter (se 2.1) eller genom att använda vårt forum på http://forums.scummv.org. Du kan även skriva upp dig för och skicka e-post via vår sändlista (scummvm-devel) eller chatta med oss på IRC (#scummvm på irc.freenode.net) Vi ber dig att inte skicka önskemål på spel som inte stöds av ScummVM  läs avdelningen för vanliga frågor (FAQ) på våran hemsida först. Märk även att det officiella språket för vårt forum, vår sändlista och chatten är engelska och att inga andra språk borde användas där.
+Det enklaste sättet att kontakta ScummVM-teamet är att skicka in bugg-rapporter (se 2.1) eller genom att använda vårt forum på http://forums.scummvm.org. Du kan även skriva upp dig för och skicka e-post via vår sändlista (scummvm-devel) eller chatta med oss på IRC (#scummvm på irc.freenode.net) Vi ber dig att inte skicka önskemål på spel som inte stöds av ScummVM – läs avdelningen för vanliga frågor (FAQ) på våran hemsida först. Märk även att det officiella språket för vårt forum, vår sändlista och chatten är engelska och att inga andra språk borde användas där.
 
 2.1) Att rapportera buggar:
 ---- ----------------------
-För att rapportera en bugg måste du skapa ett konto hos SourceForge och följa Bug Tracker-länken från våran hemsida. Var god se till att buggen kan reproduceras med säkerhet och att den fortfarande är aktiv i den senaste git/Daily build-versionen. Se även till att kontrollera att felet inte redan rapporterats genom att läsa listan av kända fel för spelet på våran kompatibilitetssida:
+För att rapportera en bugg måste du skapa ett konto hos SourceForge och följa ”Bug Tracker”-länken från våran hemsida. Var god se till att buggen kan reproduceras med säkerhet och att den fortfarande är aktiv i den senaste git/Daily build-versionen. Se även till att kontrollera att felet inte redan rapporterats genom att läsa listan av kända fel för spelet på våran kompatibilitetssida:
 
   https://www.scummvm.org/compatibility/
 
-Var god rapportera inte buggar för spel som inte är möjliga att avklara enligt Supported Games-avdelningen, eller i kompatibilitetslistan. Vi vet redan att dessa spel är buggiga.
+Var god rapportera inte buggar för spel som inte är möjliga att avklara enligt ”Supported Games”-avdelningen, eller i kompatibilitetslistan. Vi vet redan att dessa spel är buggiga.
 
 Se till att bifoga följande information:
     - ScummVM version (Var god testa med den senaste git/Daily Build-versionen)


### PR DESCRIPTION
The RISCOS-LATIN1 encoding is provided by libiconv when built with the --enable-extra-encodings option. When using other iconv implementations (such as the one provided by glibc), the similar ISO-8859-1 encoding will be used as a fallback.

Some encoding issues in the various QuickStart files have also been fixed.