### PR TITLE
MOHAWK: MYST: Increment y_pos of observatory day slider faster

### DIFF
--- a/engines/mohawk/myst_stacks/myst.cpp
+++ b/engines/mohawk/myst_stacks/myst.cpp
@@ -1701,7 +1701,11 @@ void Myst::observatoryIncrementDay(int16 increment) {
 		_vm->getCard()->redrawArea(74);
 
 		// Update slider
-		_observatoryDaySlider->setPosition(91 + 3 * _state.observatoryDaySetting);
+		// WORKAROUND: Have the day setting increment at 315/100 rather than x3 so that the slider
+		// will reach the bottom spot on day 31st. Only relevant when using the down button and
+		// not dragging the slider. Fixes Trac#10572. The original engine incremented it with x3 
+		// and has this bug, but it is less noticeable.
+		_observatoryDaySlider->setPosition(91 + (_state.observatoryDaySetting * 315) / 100 );
 		_observatoryDaySlider->restoreBackground();
 		_observatoryDaySlider->drawConditionalDataToScreen(2);
 		_state.observatoryDaySlider = _observatoryDaySlider->_pos.y;


### PR DESCRIPTION
Fixes Trac#10572.

The day slider does not go all the way to the bottom (day 31st)
when the down arrow is used to increment the day. This change
increases how much y displacement happens with each change
in the day so that the bottom is reach on day 31st.

This is just a graphical bug and doesn't affect the logic
of the puzzle. The day slider can also be dragged to the bottom
without using the buttons.