### PR TITLE
MOHAWK: RIVEN: Change Ytram catch video behavior

### DIFF
--- a/engines/mohawk/riven_stacks/bspit.cpp
+++ b/engines/mohawk/riven_stacks/bspit.cpp
@@ -286,12 +286,6 @@ void BSpit::checkYtramCatch(bool playSound) {
 		return;
 	}
 
-	// Increment the movie per catch (max = 3)
-	uint32 &ytramMovie = _vm->_vars["bytram"];
-	ytramMovie++;
-	if (ytramMovie > 3)
-		ytramMovie = 3;
-
 	// Reset variables
 	_vm->_vars["bytrapped"] = 1;
 	_vm->_vars["bbait"] = 0;
@@ -335,27 +329,22 @@ void BSpit::xbait(const ArgumentArray &args) {
 
 void BSpit::xbfreeytram(const ArgumentArray &args) {
 	// Play a random Ytram movie after freeing it
-	uint16 mlstId;
 
-	switch (_vm->_vars["bytram"]) {
-		case 1:
-			mlstId = 11;
-			break;
-		case 2:
-			mlstId = 12;
-			break;
-		default:
-			// The original did rand(13, 14)
-			mlstId = _vm->_rnd->getRandomNumberRng(13, 15);
-			break;
-	}
+	// The original had the first two catches be 11 and 12 for the first
+	// video and then had all subsequent catches be rand(13, 14).
+	// Don't do 15 because 20 (15 + 5) has a graphical bug
 
-	// Play the video
+	// Previously, it used switch (_vm->_vars["bytram"]).
+	// _vars["bytram"] stores the number of catches
+	// Now it is just done randomly for all catches	
+	uint16 mlstId = _vm->_rnd->getRandomNumberRng(11, 14);
+
+	// Play the video (the trap opening)
 	_vm->getCard()->playMovie(mlstId);
 	RivenVideo *first = _vm->_video->openSlot(11);
 	first->playBlocking();
 
-	// Now play the second movie
+	// Now play the second movie (the Ytram moving)
 	_vm->getCard()->playMovie(mlstId + 5);
 	RivenVideo *second = _vm->_video->openSlot(12);
 	second->playBlocking();


### PR DESCRIPTION
1. Don't allow video 20 to play (it is paired with video 15).
This is because 20 has a graphical glitch.

2. Make the video that gets played be random for each catch.
This makes more sense to me and is simplier.
The original had the first two catches not be random then
subsequent catches played 2 other catch videos randomly.

For testing consider setting the random wait time for bspit.cpp#L264 to be something shorter/ not random. You may want to hard code the mlstId to one of the videos (bspit.cpp#L340).