### PR TITLE
MOHAWK: MYST: Warn instead of error for missing resources

### DIFF
--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -115,7 +115,9 @@ Common::SeekableReadStream *MohawkEngine_Myst::getResource(uint32 tag, uint16 id
 			return ret;
 		}
 
-	error("Could not find a \'%s\' resource with ID %04x", tag2str(tag), id);
+	// Not all missing resources are fatal, let the caller determine that
+	warning("Could not find a \'%s\' resource with ID %04x", tag2str(tag), id);
+	return nullptr;
 }
 
 Common::Array<uint16> MohawkEngine_Myst::getResourceIDList(uint32 type) const {

--- a/engines/mohawk/myst_sound.cpp
+++ b/engines/mohawk/myst_sound.cpp
@@ -46,10 +46,20 @@ MystSound::~MystSound() {
 }
 
 Audio::RewindableAudioStream *MystSound::makeAudioStream(uint16 id, CueList *cueList) {
-	if (_vm->getFeatures() & GF_ME)
-		return Audio::makeWAVStream(_vm->getResource(ID_MSND, convertMystID(id)), DisposeAfterUse::YES);
-	else
-		return makeMohawkWaveStream(_vm->getResource(ID_MSND, id), cueList);
+	Common::SeekableReadStream *stream = nullptr;
+	Audio::RewindableAudioStream *rwSteam = nullptr;
+
+	if (_vm->getFeatures() & GF_ME) {
+		stream = _vm->getResource(ID_MSND, convertMystID(id));
+		if (stream)
+			rwSteam = Audio::makeWAVStream(stream, DisposeAfterUse::YES);
+	}
+	else {
+		stream = _vm->getResource(ID_MSND, id);
+		if (stream)
+			rwSteam = makeMohawkWaveStream(stream, cueList);
+	}
+	return rwSteam;
 }
 
 void MystSound::playEffect(uint16 id, bool loop) {


### PR DESCRIPTION
Some missing resources are not fatal and the caller can decide
what to do if the resource is missing.

Have MystSound::playEffect skip playing the sound if it
is not present (most missing sound effects should be non-fatal).

It would be preferable to identify missing resources and address
them, but for unknown missing resources this isn't possible so
warning instead of erroring is okay in most cases.