### PR TITLE
IOS: Add Keyboard and UI Fixes for Smartkeyboard on IPad Pro.

### DIFF
--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -46,6 +46,9 @@
 	[self setAutocorrectionType:UITextAutocorrectionTypeNo];
 	[self setAutocapitalizationType:UITextAutocapitalizationTypeNone];
 	[self setEnablesReturnKeyAutomatically:NO];
+	UITextInputAssistantItem* item = [self inputAssistantItem];
+	item.leadingBarButtonGroups = @[];
+	item.trailingBarButtonGroups = @[];
 
 	return self;
 }
@@ -61,6 +64,31 @@
 	inputView = [[TextInputHandler alloc] initWithKeyboard:self];
 	inputView.delegate = self;
 	return self;
+}
+
+- (NSArray *)keyCommands {
+	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
+	UIKeyCommand *downArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputDownArrow modifierFlags: 0 action: @selector(downArrow:)];
+	UIKeyCommand *leftArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow modifierFlags: 0 action: @selector(leftArrow:)];
+	UIKeyCommand *rightArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow modifierFlags: 0 action: @selector(rightArrow:)];
+	return [[NSArray alloc] initWithObjects: upArrow, downArrow, leftArrow, rightArrow, nil];
+}
+
+- (void) upArrow: (UIKeyCommand *) keyCommand {
+//	[self resignFirstResponder];
+	[softKeyboard handleKeyPress:273];
+}
+
+- (void) downArrow: (UIKeyCommand *) keyCommand {
+	[softKeyboard handleKeyPress:274];
+}
+
+- (void) leftArrow: (UIKeyCommand *) keyCommand {
+	[softKeyboard handleKeyPress:276];
+}
+
+- (void) rightArrow: (UIKeyCommand *) keyCommand {
+	[softKeyboard handleKeyPress:275];
 }
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -720,6 +720,14 @@ uint getSizeNextPOT(uint size) {
 		screenHeight = MAX(_renderBufferWidth, _renderBufferHeight);
 	}
 
+	if (_keyboardView == nil) {
+		_keyboardView = [[SoftKeyboard alloc] initWithFrame:CGRectZero];
+		[_keyboardView setInputDelegate:self];
+		[self addSubview:[_keyboardView inputView]];
+		[self addSubview: _keyboardView];
+		[_keyboardView showKeyboard];
+	}
+
 	glBindRenderbuffer(GL_RENDERBUFFER, _viewRenderbuffer); printOpenGLError();
 
 	[self clearColorBuffer];
@@ -761,8 +769,6 @@ uint getSizeNextPOT(uint size) {
 			yOffset = (screenHeight - rectHeight) / 2;
 		}
 
-		[_keyboardView hideKeyboard];
-
 		//printf("Rect: %i, %i, %i, %i\n", xOffset, yOffset, rectWidth, rectHeight);
 		_gameScreenRect = CGRectMake(xOffset, yOffset, rectWidth, rectHeight);
 		overlayPortraitRatio = 1.0f;
@@ -772,15 +778,6 @@ uint getSizeNextPOT(uint size) {
 		//printf("Making rect (%u, %u)\n", screenWidth, height);
 		_gameScreenRect = CGRectMake(0, 0, screenWidth, height);
 
-		CGRect keyFrame = CGRectMake(0.0f, 0.0f, 0.0f, 0.0f);
-		if (_keyboardView == nil) {
-			_keyboardView = [[SoftKeyboard alloc] initWithFrame:keyFrame];
-			[_keyboardView setInputDelegate:self];
-			[self addSubview:[_keyboardView inputView]];
-			[self addSubview: _keyboardView];
-		}
-
-		[_keyboardView showKeyboard];
 		overlayPortraitRatio = (_videoContext.overlayHeight * ratio) / _videoContext.overlayWidth;
 	}
 	_overlayRect = CGRectMake(0, 0, screenWidth, screenHeight * overlayPortraitRatio);
@@ -981,7 +978,11 @@ uint getSizeNextPOT(uint size) {
 }
 
 - (void)handleKeyPress:(unichar)c {
-	[self addEvent:InternalEvent(kInputKeyPressed, c, 0)];
+	if (c == '`') {
+		[self addEvent:InternalEvent(kInputKeyPressed, '\E', 0)];
+	} else {
+		[self addEvent:InternalEvent(kInputKeyPressed, c, 0)];
+	}
 }
 
 - (void)applicationSuspend {


### PR DESCRIPTION
These have not been compiled or otherwise tested, but are cleaned up
version of code changes from forum user "dottostring" in thread:
http://forums.scummvm.org/viewtopic.php?t=14524

This should add Fake ESC key support replacing the '`' key and add full
support for the Arrow keys.