### PR TITLE
MOHAWK: MYST: Improve Mechanical Fortress Rotator Direction State

### DIFF
--- a/engines/mohawk/myst_stacks/mechanical.cpp
+++ b/engines/mohawk/myst_stacks/mechanical.cpp
@@ -637,16 +637,7 @@ void Mechanical::o_elevatorTopMovie(uint16 var, const ArgumentsArray &args) {
 }
 
 void Mechanical::o_fortressRotationSetPosition(uint16 var, const ArgumentsArray &args) {
-	VideoEntryPtr gears = _fortressRotationGears->getVideo();
-	uint32 moviePosition = Audio::Timestamp(gears->getTime(), 600).totalNumberOfFrames();
-
-	// Myst ME short movie workaround, explained in o_fortressRotation_init
-	if (_fortressRotationShortMovieWorkaround) {
-		moviePosition += 3600 * _fortressRotationShortMovieCount;
-	}
-
-	_fortressDirection = (moviePosition + 900) / 1800 % 4;
-
+	// The fortress direction is already set in fortressRotation_run() so we don't do it here
 	// Stop the gears video so that it does not play while the elevator is going up
 	_fortressRotationGears->getVideo()->stop();
 }

--- a/engines/mohawk/myst_stacks/mechanical.cpp
+++ b/engines/mohawk/myst_stacks/mechanical.cpp
@@ -815,7 +815,11 @@ void Mechanical::o_fortressRotation_init(uint16 var, const ArgumentsArray &args)
 
 	VideoEntryPtr gears = _fortressRotationGears->playMovie();
 	gears->setLooping(true);
-	gears->seek(Audio::Timestamp(0, 1800 * _fortressDirection, 600));
+	if (!_fortressRotationShortMovieWorkaround) {
+		gears->seek(Audio::Timestamp(0, 1800 * _fortressDirection, 600));
+	} else {
+		gears->seek(Audio::Timestamp(0, 1800 * (_fortressDirection % 2), 600));
+	}
 	gears->setRate(0);
 
 	_fortressRotationSounds[0] = args[0];
@@ -837,8 +841,6 @@ void Mechanical::o_fortressRotation_init(uint16 var, const ArgumentsArray &args)
 	uint32 movieDuration = gears->getDuration().convertToFramerate(600).totalNumberOfFrames();
 	if (movieDuration == 3680) {
 		_fortressRotationShortMovieWorkaround = true;
-		_fortressRotationShortMovieCount = 0;
-		_fortressRotationShortMovieLast = 0;
 	}
 
 	_fortressRotationRunning = true;


### PR DESCRIPTION
1. Hitting the rotator button without locking on will not lock onto a new direction, but the previous direction locked onto will be used
2. Have fortress facing direction be the same when returning to the controls. Previously west direction was resetting to south.