### PR TITLE
SDL: Clip mouse range in convertWindowToVirtual

### DIFF
--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -120,8 +120,11 @@ protected:
 		x = CLIP<int>(x, sourceX, sourceMaxX);
 		y = CLIP<int>(y, sourceY, sourceMaxY);
 
-		return Common::Point(((x - sourceX) * targetWidth + sourceWidth / 2) / sourceWidth,
-		                     ((y - sourceY) * targetHeight + sourceHeight / 2) / sourceHeight);
+		int virtualX = ((x - sourceX) * targetWidth + sourceWidth / 2) / sourceWidth;
+		int virtualY = ((y - sourceY) * targetHeight + sourceHeight / 2) / sourceHeight;
+
+		return Common::Point(CLIP<int>(virtualX, 0, targetWidth - 1),
+				             CLIP<int>(virtualY, 0, targetHeight - 1));
 	}
 
 	/**

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -94,8 +94,11 @@ protected:
 			error("convertVirtualToWindow called without a valid draw rect");
 		}
 
-		return Common::Point(targetX + (x * targetWidth + sourceWidth / 2) / sourceWidth,
-		                     targetY + (y * targetHeight + sourceHeight / 2) / sourceHeight);
+		int windowX = targetX + (x * targetWidth + sourceWidth / 2) / sourceWidth;
+		int windowY = targetY + (y * targetHeight + sourceHeight / 2) / sourceHeight;
+
+		return Common::Point(CLIP<int>(windowX, targetX, targetX + targetWidth - 1),
+		                     CLIP<int>(windowY, targetY, targetY + targetHeight - 1));
 	}
 
 	/**
@@ -124,7 +127,7 @@ protected:
 		int virtualY = ((y - sourceY) * targetHeight + sourceHeight / 2) / sourceHeight;
 
 		return Common::Point(CLIP<int>(virtualX, 0, targetWidth - 1),
-				             CLIP<int>(virtualY, 0, targetHeight - 1));
+		                     CLIP<int>(virtualY, 0, targetHeight - 1));
 	}
 
 	/**


### PR DESCRIPTION
When the graphics scale was 2x or higher, it was possible for the mouse to go too far right or down. If the game's resolution was 320x200, it could range from 0-320 or 0-200, giving it a 321x201 range; it should really range from 0-319 or 0-199, which is what this does.

It looks like only the SDL backend uses this function.