### PR TITLE
SCI: Use LarryScale in games that support it, not just LSL7

### DIFF
--- a/engines/sci/graphics/celobj32.cpp
+++ b/engines/sci/graphics/celobj32.cpp
@@ -33,6 +33,7 @@
 #include "sci/util.h"
 #include "graphics/larryScale.h"
 #include "common/config-manager.h"
+#include "common/gui_options.h"
 
 namespace Sci {
 #pragma mark CelScaler
@@ -202,7 +203,7 @@ struct SCALER_Scale {
 
 		const CelScalerTable &table = CelObj::_scaler->getScalerTable(scaleX, scaleY);
 
-		const bool useLarryScale = (g_sci->getGameId() == GID_LSL7) && ConfMan.getBool("enable_larryscale");
+		const bool useLarryScale = Common::checkGameGUIOption(GAMEOPTION_LARRYSCALE, ConfMan.get("guioptions")) && ConfMan.getBool("enable_larryscale");
 		if (useLarryScale) {
 			// LarryScale is an alternative, high-quality cel scaler implemented
 			// for ScummVM. Due to the nature of smooth upscaling, it does *not*


### PR DESCRIPTION
This is the solution discussed in bug #10568 ("SCI: PHANT1: Crash on startup"). A temporary-maybe-permanent fix was committed recently (fab1894f21, "ISCI32: Only enable larry scaler for LSL7") but I believe that this is the correct solution, and that ScummVM will do the right thing... but I'm not 100% sure.

The idea is that since games can declare that they will use an engine-specific setting (in this case the Larry scaler), it's better to test for that than to just assume that only LSL7 will ever use it.