### PR TITLE
ZVISION: Add workaround for ZGI bug #10605

### DIFF
--- a/engines/zvision/scripting/scr_file_handling.cpp
+++ b/engines/zvision/scripting/scr_file_handling.cpp
@@ -205,6 +205,28 @@ bool ScriptManager::parseCriteria(Common::SeekableReadStream &stream, Common::Li
 			entry.argumentIsAKey = false;
 		}
 
+		// WORKAROUND for a script bug in Zork: Grand Inquisitor. If the
+		// fire timer is killed (e.g. by the inventory screen) with less
+		// than 10 units left, it will get stuck and never time out. We
+		// work around that by changing the condition from "greater than
+		// 10" to "greater than 0 but not 2 (the magic time-out value)".
+		//
+		// I have a sneaking suspicion that there may be other timer
+		// glitches like this, but this one makes the game unplayable
+		// and is easy to trigger.
+		if (_engine->getGameId() == GID_GRANDINQUISITOR && key == 17162) {
+			Puzzle::CriteriaEntry entry0;
+			entry0.key = 17161; // pe_fire
+			entry0.criteriaOperator = Puzzle::GREATER_THAN;
+			entry0.argumentIsAKey = false;
+			entry0.argument = 0;
+
+			criteriaList.back().push_back(entry0);
+
+			entry.criteriaOperator = Puzzle::NOT_EQUAL_TO;
+			entry.argument = 2;
+		}
+
 		criteriaList.back().push_back(entry);
 
 		line = stream.readLine();


### PR DESCRIPTION
This is one possible way of working around ZGI bug #10605. It was possible for the "Fire! Fire!" timer to get stuck if you brought up the inventory screen before it had timed out. (Unless you brought it up _very_ quickly so that there was still more than 10 units left on the clock.)

I have a sneaking suspicion that there may be other timer-related script bugs, but I haven't looked for them. See the bug report for some further thoughts.