### PR TITLE
TITANIC: Address readSavegameHeader compiler warning

### DIFF
--- a/engines/titanic/core/project_item.cpp
+++ b/engines/titanic/core/project_item.cpp
@@ -189,7 +189,8 @@ void CProjectItem::loadGame(int slotId) {
 
 	// Load the savegame header in
 	TitanicSavegameHeader header;
-	readSavegameHeader(&file, header);
+	if (!readSavegameHeader(&file, header))
+		error("Failed to read save game header");
 
 	g_vm->_events->setTotalPlayTicks(header._totalFrames);
 


### PR DESCRIPTION
A function had a bool return that was not being used
now it is checked and an error is issued if the call fails.