### PR TITLE
Fix concurrent access to String MemoryPool instance

### DIFF
--- a/backends/platform/3ds/main.cpp
+++ b/backends/platform/3ds/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 // 		res = scummvm_main(argc, argv);
 	scummvm_main(0, nullptr);
 
-	delete dynamic_cast<_3DS::OSystem_3DS*>(g_system);
+	g_system->destroy();
 
 	// Turn on both screen backlights before exiting.
 	if (R_SUCCEEDED(gspLcdInit())) {

--- a/backends/platform/androidsdl/androidsdl-main.cpp
+++ b/backends/platform/androidsdl/androidsdl-main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_ANDROIDSDL *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/dingux/main.cpp
+++ b/backends/platform/dingux/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_SDL_Dingux *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/gph/gph-main.cpp
+++ b/backends/platform/gph/gph-main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete(OSystem_GPH *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/linuxmoto/linuxmoto-main.cpp
+++ b/backends/platform/linuxmoto/linuxmoto-main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_LINUXMOTO *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/maemo/main.cpp
+++ b/backends/platform/maemo/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (Maemo::OSystem_SDL_Maemo *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/null/null.cpp
+++ b/backends/platform/null/null.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
 
 	// Invoke the actual ScummVM main entry point:
 	int res = scummvm_main(argc, argv);
-	delete (OSystem_NULL *)g_system;
+	g_system->destroy();
 	return res;
 }
 

--- a/backends/platform/openpandora/op-main.cpp
+++ b/backends/platform/openpandora/op-main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete(OSystem_OP *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/samsungtv/main.cpp
+++ b/backends/platform/samsungtv/main.cpp
@@ -50,7 +50,7 @@ extern "C" int Game_Main(char *path, char *) {
 	int res = scummvm_main(0, 0);
 
 	// Free OSystem
-	delete (OSystem_SDL_SamsungTV *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/sdl/amigaos/amigaos-main.cpp
+++ b/backends/platform/sdl/amigaos/amigaos-main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_AmigaOS *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/sdl/macosx/macosx-main.cpp
+++ b/backends/platform/sdl/macosx/macosx-main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_MacOSX *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/sdl/posix/posix-main.cpp
+++ b/backends/platform/sdl/posix/posix-main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_POSIX *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/sdl/ps3/ps3-main.cpp
+++ b/backends/platform/sdl/ps3/ps3-main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_PS3 *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/sdl/psp2/psp2-main.cpp
+++ b/backends/platform/sdl/psp2/psp2-main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_PSP2 *)g_system;
+	g_system->destroy();
 
 #ifdef __PSP2_DEBUG__
 	psp2shell_exit();

--- a/backends/platform/sdl/riscos/riscos-main.cpp
+++ b/backends/platform/sdl/riscos/riscos-main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_RISCOS *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/sdl/win32/win32-main.cpp
+++ b/backends/platform/sdl/win32/win32-main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_Win32 *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/symbian/src/SymbianMain.cpp
+++ b/backends/platform/symbian/src/SymbianMain.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_SDL_Symbian *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/webos/main.cpp
+++ b/backends/platform/webos/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem
-	delete (OSystem_SDL_WebOS *)g_system;
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/wince/wince-sdl.cpp
+++ b/backends/platform/wince/wince-sdl.cpp
@@ -237,7 +237,7 @@ int SDL_main(int argc, char **argv) {
 		res = scummvm_main(argc, argv);
 
 		// Free OSystem
-		delete(OSystem_WINCE3 *)g_system;
+		g_system->destroy();
 #if !defined(DEBUG) && !defined(__GNUC__)
 	}
 	__except(handleException(GetExceptionInformation())) {

--- a/common/str.cpp
+++ b/common/str.cpp
@@ -25,10 +25,36 @@
 #include "common/memorypool.h"
 #include "common/str.h"
 #include "common/util.h"
+#include "common/mutex.h"
 
 namespace Common {
 
 MemoryPool *g_refCountPool = nullptr; // FIXME: This is never freed right now
+MutexRef g_refCountPoolMutex = nullptr;
+
+void lockMemoryPoolMutex() {
+	// The Mutex class can only be used once g_system is set and initialized,
+	// but we may use the String class earlier than that (it is for example
+	// used in the OSystem_POSIX constructor). However in those early stages
+	// we can hope we don't have multiple threads either.
+	if (!g_system || !g_system->backendInitialized())
+		return;
+	if (!g_refCountPoolMutex)
+		g_refCountPoolMutex = g_system->createMutex();
+	g_system->lockMutex(g_refCountPoolMutex);
+}
+
+void unlockMemoryPoolMutex() {
+	if (g_refCountPoolMutex)
+		g_system->unlockMutex(g_refCountPoolMutex);
+}
+
+void String::releaseMemoryPoolMutex() {
+	if (g_refCountPoolMutex){
+		g_system->deleteMutex(g_refCountPoolMutex);
+		g_refCountPoolMutex = nullptr;
+	}
+}
 
 static uint32 computeCapacity(uint32 len) {
 	// By default, for the capacity we use the next multiple of 32
@@ -173,12 +199,14 @@ void String::ensureCapacity(uint32 new_size, bool keep_old) {
 void String::incRefCount() const {
 	assert(!isStorageIntern());
 	if (_extern._refCount == nullptr) {
+		lockMemoryPoolMutex();
 		if (g_refCountPool == nullptr) {
 			g_refCountPool = new MemoryPool(sizeof(int));
 			assert(g_refCountPool);
 		}
 
 		_extern._refCount = (int *)g_refCountPool->allocChunk();
+		unlockMemoryPoolMutex();
 		*_extern._refCount = 2;
 	} else {
 		++(*_extern._refCount);
@@ -196,8 +224,10 @@ void String::decRefCount(int *oldRefCount) {
 		// The ref count reached zero, so we free the string storage
 		// and the ref count storage.
 		if (oldRefCount) {
+			lockMemoryPoolMutex();
 			assert(g_refCountPool);
 			g_refCountPool->freeChunk(oldRefCount);
+			unlockMemoryPoolMutex();
 		}
 		delete[] _str;
 

--- a/common/str.h
+++ b/common/str.h
@@ -47,6 +47,8 @@ class String {
 public:
 	static const uint32 npos = 0xFFFFFFFF;
 
+	static void releaseMemoryPoolMutex();
+
 	typedef char          value_type;
 	/**
 	 * Unsigned version of the underlying type. This can be used to cast

--- a/common/system.cpp
+++ b/common/system.cpp
@@ -105,6 +105,7 @@ void OSystem::initBackend() {
 
 void OSystem::destroy() {
 	_backendInitialized = false;
+	Common::String::releaseMemoryPoolMutex();
 	delete this;
 }
 

--- a/common/system.cpp
+++ b/common/system.cpp
@@ -49,6 +49,7 @@ OSystem::OSystem() {
 	_updateManager = nullptr;
 #endif
 	_fsFactory = nullptr;
+	_backendInitialized = false;
 }
 
 OSystem::~OSystem() {
@@ -98,6 +99,13 @@ void OSystem::initBackend() {
 	// set it.
 // 	if (!_fsFactory)
 // 		error("Backend failed to instantiate fs factory");
+
+	_backendInitialized = true;
+}
+
+void OSystem::destroy() {
+	_backendInitialized = false;
+	delete this;
 }
 
 bool OSystem::setGraphicsMode(const char *name) {

--- a/common/system.h
+++ b/common/system.h
@@ -190,9 +190,21 @@ protected:
 	 */
 	FilesystemFactory *_fsFactory;
 
+private:
+	/**
+	 * Indicate if initBackend() has been called.
+	 */
+	bool _backendInitialized;
+
 	//@}
 
 public:
+
+	/**
+	 *
+	 * Destoy this OSystem instance.
+	 */
+	void destroy();
 
 	/**
 	 * The following method is called once, from main.cpp, after all
@@ -203,6 +215,13 @@ public:
 	 *       implementation.
 	 */
 	virtual void initBackend();
+
+	/**
+	 * Return false if initBackend() has not yet been called and true otherwise.
+	 * Some functionalities such as mutexes cannot be used until the backend
+	 * is initialized.
+	 */
+	bool backendInitialized() const { return _backendInitialized; }
 
 	/**
 	 * Allows the backend to perform engine specific init.


### PR DESCRIPTION
The `Common::String` class uses a global MemoryPool instance to allocate and deallocate memory. However when `Common::String` objects are used simultaneously in different threads this results in concurrent access to this MemoryPool and a crash. This notably happens when enabling the Cloud feature.

This PR adds a mutex to protect the access to the MemoryPool. However mutexes are only available once the g_system instance has been set and the backend initialized and only until it is deleted. However Strings are used both too early (for example in the OSystem_POSIX constructor) and too late (for example in the OSystem_SDL destructor when it deletes the logger after deleting the mutex manager). So I had to do more changes than I wanted too to handle those cases.

In the end I am not too happy with what I had to do, but it works (or at least it seems to). Without this change I have a ~50% chance of a random crash when opening and closing the Options dialog just after starting ScummVM when it synchronises the saves with the cloud. I have not been able to reproduce it after making those changes.

This fixes [Bug #10524](https://bugs.scummvm.org/ticket/10524).