### PR TITLE
GUI: Show saveload date/time, or playtime even if thumbnail not enabled

### DIFF
--- a/engines/tinsel/detection.cpp
+++ b/engines/tinsel/detection.cpp
@@ -113,7 +113,6 @@ bool TinselMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsDeleteSave) ||
 		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportMetaInfo) ||
-		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate);
 }
 


### PR DESCRIPTION
Previously, if playtime or date/time support was added it would not be displayed
unless thumbnail support was also valid.

Now they will be shown even if the thumbnail is not valid.

No container is shown if only metainfo support is enabled.

Removed thumbnail support from tinsel.

The behavior is the same as before if thumbnail support is enabled.

Currently, Tinsel supports date time, but not playtime nor thumbnail, but it must enable thumbnail to show the date time and it looks like this:
![scummvmdatetimeprev](https://user-images.githubusercontent.com/5838258/42410026-8254703c-81b1-11e8-8b0d-a93624ec27da.png)

After this PR it will look like this:
![scummvmdatetime](https://user-images.githubusercontent.com/5838258/42410030-8ee42496-81b1-11e8-9413-058b5c67acad.png)

And if playtime support is added:
![scummvmdatetimeplay](https://user-images.githubusercontent.com/5838258/42410032-9ad05338-81b1-11e8-95b3-281b54f3a443.png)

For this PR I have kept the container top to be level with the save list.
