### PR TITLE
Xeen: add a version of Darkside and some comments

### DIFF
--- a/engines/xeen/detection_tables.h
+++ b/engines/xeen/detection_tables.h
@@ -117,9 +117,8 @@ static const XeenGameDescription gameDescriptions[] = {
 		0
 	},
 
-
 	{
-		// Clouds of Xeen (GOG German)
+		// Clouds of Xeen (GOG, Bestseller Games Magazine #6 German)
 		{
 			"cloudsofxeen",
 			nullptr,

--- a/engines/xeen/detection_tables.h
+++ b/engines/xeen/detection_tables.h
@@ -43,13 +43,14 @@ static const XeenGameDescription gameDescriptions[] = {
 	},
 
 	{
-		// World of Xeen (German)
+		// World of Xeen (Bestseller Games Magazine #6 + #8 German)
 		{
 			"worldofxeen",
 			nullptr,
 			{
 				{"xeen.cc", 0, "f4e4b3ddc43bd102dbe1637f480f1fa1", 13214150},
 				{"dark.cc", 0, "84a86bbbc5f2fe96c0b0325485ed8203", 11173657},
+				{"intro.cc", 0, "e47a7ab0223cf32b2d87eed91d024c35", 8899953},
 				AD_LISTEND
 			},
 			Common::DE_DEU,

--- a/engines/xeen/detection_tables.h
+++ b/engines/xeen/detection_tables.h
@@ -173,6 +173,25 @@ static const XeenGameDescription gameDescriptions[] = {
 	},
 
 	{
+		// Dark Side of Xeen (Bestseller Games Magazine #8 German)
+		{
+			"darksideofxeen",
+			nullptr,
+			{
+				{ "dark.cc", 0, "84a86bbbc5f2fe96c0b0325485ed8203", 11173657},
+				{ "intro.cc", 0, "e47a7ab0223cf32b2d87eed91d024c35", 8899953},
+				AD_LISTEND
+			},
+			Common::DE_DEU,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO2(GAMEOPTION_SHOW_ITEM_COSTS, GAMEOPTION_DURABLE_ARMOR)
+		},
+		GType_DarkSide,
+		0
+	},
+
+	{
 		// Swords of Xeen
 		{
 			"swordsofxeen",


### PR DESCRIPTION
Another German version of "Darkside of Xeen" is added.
This one can be found on the CD of the Bestseller Games Magazine #8.

The same Magazine had "Clouds of Xeen" in issue #6 which seems identical
in filesize and checksum to the version from GOG.com, so a comment is added.

Finally, both set of files form another version of  "World of Xeen",
which had already a detection entry (German), so a comment is added to it.