### PR TITLE
Discord integration - DO NOT MERGE

### DIFF
--- a/backends/discord/discord.cpp
+++ b/backends/discord/discord.cpp
@@ -1,0 +1,56 @@
+/* ScummVM - Graphic Adventure Engine
+*
+* ScummVM is the legal property of its developers, whose names
+* are too numerous to list here. Please refer to the COPYRIGHT
+* file distributed with this source distribution.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+
+#include <discord_rpc.h>
+#include "backends/discord/discord.h"
+#include "common/str.h"
+
+namespace Discord
+{
+	const char* ApplicationId = "465279538725912579";
+
+	void Init()
+	{
+		DiscordEventHandlers handlers = {};
+		Discord_Initialize(ApplicationId, &handlers, 1, nullptr);
+		UpdateDiscordPresence("In launcher", "scummvm");
+	}
+
+	void UpdateDiscordPresence(Common::String gameName, Common::String gameId)
+	{	
+		DiscordRichPresence discord_presence = {};
+		discord_presence.largeImageKey = gameId.c_str();
+		discord_presence.largeImageText = gameName.c_str();
+		discord_presence.smallImageKey = "scummvm";
+		discord_presence.smallImageText = "ScummVM";
+		discord_presence.details = gameName.c_str();
+		discord_presence.startTimestamp = 0;
+		Discord_UpdatePresence(&discord_presence);
+	}
+
+	void Shutdown()
+	{
+		Discord_ClearPresence();
+		Discord_Shutdown();
+	}	
+
+} // namespace Discord

--- a/backends/discord/discord.h
+++ b/backends/discord/discord.h
@@ -1,0 +1,32 @@
+/* ScummVM - Graphic Adventure Engine
+*
+* ScummVM is the legal property of its developers, whose names
+* are too numerous to list here. Please refer to the COPYRIGHT
+* file distributed with this source distribution.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+
+#pragma once
+#include "common/str.h"
+
+namespace Discord
+{
+	void Init();
+	void UpdateDiscordPresence(Common::String gameName, Common::String gameId);	
+	void Shutdown();
+
+} // namespace Discord

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -58,6 +58,11 @@ MODULE_OBJS += \
 endif
 endif
 
+ifdef USE_DISCORD
+MODULE_OBJS += \
+	discord/discord.o
+endif
+
 ifdef USE_LIBCURL
 MODULE_OBJS += \
 	networking/curl/connectionmanager.o \

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -265,8 +265,8 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 	system.engineInit();
 
     // Tell Discord what game we're running
-  #if defined(USE_DISCORD)
-    // TODO: UpdateDiscord with the caption and game id
+  #if defined(USE_DISCORD)	
+	Discord::UpdateDiscordPresence(caption, ConfMan.get("gameid"));
   #endif
   
 	// Run the engine
@@ -274,7 +274,7 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 
   // Shutdown Discord
   #if defined(USE_DISCORD)
-    // TODO: Shutdown here
+	Discord::Shutdown();
   #endif
 
 	// Inform backend that the engine finished
@@ -511,7 +511,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 #endif
 
 #if defined(USE_DISCORD)
-  //TODO: Initialize Discord integration here
+	Discord::Init();
 #endif
 
 	// Unless a game was specified, show the launcher dialog

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -265,16 +265,17 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 	system.engineInit();
 
     // Tell Discord what game we're running
-  #if defined(USE_DISCORD)	
+  #if defined(USE_DISCORD)
+	
 	Discord::UpdateDiscordPresence(caption, ConfMan.get("gameid"));
   #endif
   
 	// Run the engine
 	Common::Error result = engine->run();
 
-  // Shutdown Discord
+  // Unset Discord game
   #if defined(USE_DISCORD)
-	Discord::Shutdown();
+	Discord::UpdateDiscordPresence("In launcher", "scummvm");	
   #endif
 
 	// Inform backend that the engine finished
@@ -653,6 +654,8 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 #endif
 	EngineManager::destroy();
 	Graphics::YUVToRGBManager::destroy();
-
+#if defined(USE_DISCORD)	
+	Discord::Shutdown();
+#endif
 	return 0;
 }

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -77,6 +77,10 @@
 #endif
 #endif
 
+#ifdef USE_DISCORD
+#include "backends/discord/discord.h"
+#endif
+
 #if defined(_WIN32_WCE)
 #include "backends/platform/wince/CELauncherDialog.h"
 #elif defined(__DC__)
@@ -260,8 +264,18 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 	// Inform backend that the engine is about to be run
 	system.engineInit();
 
+    // Tell Discord what game we're running
+  #if defined(USE_DISCORD)
+    // TODO: UpdateDiscord with the caption and game id
+  #endif
+  
 	// Run the engine
 	Common::Error result = engine->run();
+
+  // Shutdown Discord
+  #if defined(USE_DISCORD)
+    // TODO: Shutdown here
+  #endif
 
 	// Inform backend that the engine finished
 	system.engineDone();
@@ -494,6 +508,10 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)
 	CloudMan.init();
 	CloudMan.syncSaves();
+#endif
+
+#if defined(USE_DISCORD)
+  //TODO: Initialize Discord integration here
 #endif
 
 	// Unless a game was specified, show the launcher dialog

--- a/base/version.cpp
+++ b/base/version.cpp
@@ -155,6 +155,10 @@ const char *gScummVMFeatures = ""
 	"virtual keyboard "
 #endif
 
+#if defined(USE_DISCORD)
+  "discord "
+#endif
+
 #ifdef USE_CLOUD
 	"cloud ("
 #ifdef USE_LIBCURL

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -49,6 +49,7 @@ const CMakeProvider::Library *CMakeProvider::getLibraryFromFeature(const char *f
 		{ "theora",    kSDLVersionAny, 0,              0,          0,                       0,                     "theoradec"  },
 		{ "fluidsynth",kSDLVersionAny, 0,              0,          0,                       0,                     "fluidsynth" },
 		{ "faad",      kSDLVersionAny, 0,              0,          0,                       0,                     "faad"       },
+    { "discord",   kSDLVersionAny, 0,              0,          0,                       0,                     "discord-rpc"},
 		{ "libcurl",   kSDLVersionAny, "FindCURL",     "CURL",     "CURL_INCLUDE_DIRS",     "CURL_LIBRARIES",      0            },
 		{ "sdlnet",    kSDLVersion1,   "FindSDL_net",  "SDL_net",  "SDL_NET_INCLUDE_DIRS",  "SDL_NET_LIBRARIES",   0            },
 		{ "sdlnet",    kSDLVersion2,   0,              0,          0,                       0,                     "SDL2_net"   }

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1051,6 +1051,7 @@ const Feature s_features[] = {
 	{        "opengles",             "USE_GLES",         "", true,  "forced OpenGL ES mode" },
 	{         "taskbar",          "USE_TASKBAR",         "", true,  "Taskbar integration support" },
 	{           "cloud",            "USE_CLOUD",         "", true,  "Cloud integration support" },
+  {          "discord",         "USE_DISCORD",         "", true,  "Discord integration support" },
 	{     "translation",      "USE_TRANSLATION",         "", true,  "Translation support" },
 	{          "vkeybd",        "ENABLE_VKEYBD",         "", false, "Virtual keyboard support"},
 	{       "keymapper",     "ENABLE_KEYMAPPER",         "", false, "Keymapper support"},

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1038,6 +1038,7 @@ const Feature s_features[] = {
 	{"fluidsynth",  "USE_FLUIDSYNTH", "libfluidsynth",    true, "FluidSynth support" },
 	{   "libcurl",     "USE_LIBCURL", "libcurl",          true, "libcurl support" },
 	{    "sdlnet",     "USE_SDL_NET", "SDL_net",          true, "SDL_net support" },
+  {   "discord",     "USE_DISCORD", "discord-rpc",      true, "Discord integration support" },
 
 	// Feature flags
 	{            "bink",             "USE_BINK",         "", true,  "Bink video support" },
@@ -1051,7 +1052,6 @@ const Feature s_features[] = {
 	{        "opengles",             "USE_GLES",         "", true,  "forced OpenGL ES mode" },
 	{         "taskbar",          "USE_TASKBAR",         "", true,  "Taskbar integration support" },
 	{           "cloud",            "USE_CLOUD",         "", true,  "Cloud integration support" },
-  {          "discord",         "USE_DISCORD",         "", true,  "Discord integration support" },
 	{     "translation",      "USE_TRANSLATION",         "", true,  "Translation support" },
 	{          "vkeybd",        "ENABLE_VKEYBD",         "", false, "Virtual keyboard support"},
 	{       "keymapper",     "ENABLE_KEYMAPPER",         "", false, "Keymapper support"},


### PR DESCRIPTION
I've prototyped an integration with Discord RPC, so when you start a game in ScummVM it will set the status and game that the user is playing.

Every game will also display an image in the user profile while they're playing (Right now I only uploaded an image for Day of The Tentacle)

Right now it's fully working in Windows, but I don't know best practices are to integrate this cross platform since the libs are platform specific and the source itself breaks the ScummVM coding conventions.

To get this set up you'll need to download the Discord RPC libs from https://github.com/discordapp/discord-rpc and extract them in your lib/include paths. The feature is enabled by default.

Is there any interest in this?