### PR TITLE
XEEN: fix crashes in "Clouds of Xeen" while resting

### DIFF
--- a/engines/xeen/interface.cpp
+++ b/engines/xeen/interface.cpp
@@ -1056,7 +1056,7 @@ void Interface::rest() {
 			party.changeTime(map._isOutdoors ? 380 : 470);
 		}
 
-		if (_vm->getRandomNumber(1, 20) == 1)
+		if (_vm->getGameID() != GType_Clouds && _vm->getRandomNumber(1, 20) == 1)
 			_vm->dream();
 
 		party.resetTemps();


### PR DESCRIPTION
When dreamsequences are triggerd in "Clouds of Xeen", some files are missing
("scene1.raw", "dreams2.voc") and the engine exits.

If there are dreamsequences in "Clouds of Xeen", then this fix is not the right thing.