### PR TITLE
LAB: Fix thumbnail issues

### DIFF
--- a/engines/lab/lab.h
+++ b/engines/lab/lab.h
@@ -502,7 +502,7 @@ private:
 	void handleTrialWarning();
 };
 
-WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeader &header, bool skipThumbnail = true);
+WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeader &header, bool skipThumbnail = false);
 
 } // End of namespace Lab
 

--- a/engines/lab/savegame.cpp
+++ b/engines/lab/savegame.cpp
@@ -98,10 +98,11 @@ WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeade
 	header._descr.setDescription(saveName);
 
 	// Get the thumbnail
-	Graphics::Surface *thumbnail;
+	Graphics::Surface *thumbnail = nullptr;
 	if (!Graphics::loadThumbnail(*in, thumbnail, skipThumbnail)) {
 		return false;
 	}
+
 	header._descr.setThumbnail(thumbnail);
 
 	uint32 saveDate = in->readUint32BE();


### PR DESCRIPTION
Fixes Trac#10619.

The thumbnail loading for the saved games was defaulting to
disabled so no thumbnail was being loaded and this caused trying
to show the thumbnail to crash scummvm.

So I have set the thumbnail pointer to be null if the thumbnail
doesn't get loaded and I've set the thumnail to not be skipped
so that thumbnails get shown when using the gui.