### PR TITLE
PINK: Set engine playtime to playtime in saved game

### DIFF
--- a/engines/pink/saveload.cpp
+++ b/engines/pink/saveload.cpp
@@ -41,6 +41,7 @@ Common::Error PinkEngine::loadGameState(int slot) {
 	_nextModule = archive.readString();
 	_nextPage = archive.readString();
 	initModule(archive.readString(), "", &archive);
+	setTotalPlayTime(desc.getPlayTimeMSecs());
 
 	delete in;
 	return Common::kNoError;

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -27,12 +27,12 @@
 SaveStateDescriptor::SaveStateDescriptor()
 	// FIXME: default to 0 (first slot) or to -1 (invalid slot) ?
 	: _slot(-1), _description(), _isDeletable(true), _isWriteProtected(false),
-	  _isLocked(false), _saveDate(), _saveTime(), _playTime(), _thumbnail() {
+	  _isLocked(false), _saveDate(), _saveTime(), _playTime(), _playTimeMSecs(0), _thumbnail() {
 }
 
 SaveStateDescriptor::SaveStateDescriptor(int s, const Common::String &d)
 	: _slot(s), _description(d), _isDeletable(true), _isWriteProtected(false),
-	  _isLocked(false), _saveDate(), _saveTime(), _playTime(), _thumbnail() {
+	  _isLocked(false), _saveDate(), _saveTime(), _playTime(), _playTimeMSecs(0), _thumbnail() {
 }
 
 void SaveStateDescriptor::setThumbnail(Graphics::Surface *t) {
@@ -51,10 +51,12 @@ void SaveStateDescriptor::setSaveTime(int hour, int min) {
 }
 
 void SaveStateDescriptor::setPlayTime(int hours, int minutes) {
+	_playTimeMSecs = ((hours * 60 + minutes) * 60) * 1000;
 	_playTime = Common::String::format("%.2d:%.2d", hours, minutes);
 }
 
 void SaveStateDescriptor::setPlayTime(uint32 msecs) {
+	_playTimeMSecs = msecs;
 	uint minutes = msecs / 60000;
 	setPlayTime(minutes / 60, minutes % 60);
 }

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -177,6 +177,14 @@ public:
 	 */
 	const Common::String &getPlayTime() const { return _playTime; }
 
+	/**
+	 * Returns the time the game was played before the save state was created
+	 * in milliseconds.
+	 *
+	 * It defaults to 0.
+	 */
+	uint32 getPlayTimeMSecs() const { return _playTimeMSecs; }
+
 private:
 	/**
 	 * The saveslot id, as it would be passed to the "-x" command line switch.
@@ -218,6 +226,12 @@ private:
 	 * save state was created.
 	 */
 	Common::String _playTime;
+
+	/**
+	 * The time the game was played before the save state was created
+	 * in milliseconds.
+	 */
+	uint32 _playTimeMSecs;
 
 	/**
 	 * The thumbnail of the save state.


### PR DESCRIPTION
1. Add playtime in msecs to SaveStateDescriptor (SaveStateDescriptor is in the Graphics namespace)
2. Use first commit to have pink load playtime from saved game into engine.