### PR TITLE
GROOVIE: Allow saving via GMM and increase save slots to 25

### DIFF
--- a/engines/groovie/groovie.cpp
+++ b/engines/groovie/groovie.cpp
@@ -350,6 +350,7 @@ Common::Platform GroovieEngine::getPlatform() const {
 bool GroovieEngine::hasFeature(EngineFeature f) const {
 	return
 		(f == kSupportsRTL) ||
+		(f == kSupportsSavingDuringRuntime) ||
 		(f == kSupportsLoadingDuringRuntime);
 }
 
@@ -372,11 +373,29 @@ void GroovieEngine::syncSoundSettings() {
 
 bool GroovieEngine::canLoadGameStateCurrently() {
 	// TODO: verify the engine has been initialized
-	return true;
+	if (_script)
+		return true;
+	else
+		return false;
+}
+
+bool GroovieEngine::canSaveGameStateCurrently() {
+	// TODO: verify the engine has been initialized
+	if (_script)
+		return true;
+	else
+		return false;
 }
 
 Common::Error GroovieEngine::loadGameState(int slot) {
 	_script->directGameLoad(slot);
+
+	// TODO: Use specific error codes
+	return Common::kNoError;
+}
+
+Common::Error GroovieEngine::saveGameState(int slot, const Common::String &desc) {
+	_script->directGameSave(slot,desc);
 
 	// TODO: Use specific error codes
 	return Common::kNoError;

--- a/engines/groovie/groovie.h
+++ b/engines/groovie/groovie.h
@@ -84,6 +84,8 @@ enum GameSpeed {
 	kGroovieSpeedFast
 };
 
+#define MAX_SAVES 25
+
 struct GroovieGameDescription;
 
 class GroovieEngine : public Engine {
@@ -101,7 +103,9 @@ protected:
 	virtual bool hasFeature(EngineFeature f) const;
 
 	virtual bool canLoadGameStateCurrently();
+	virtual bool canSaveGameStateCurrently();
 	virtual Common::Error loadGameState(int slot);
+	virtual Common::Error saveGameState(int slot, const Common::String &desc);
 	virtual void syncSoundSettings();
 
 	virtual Debugger *getDebugger() { return _debugger; }

--- a/engines/groovie/saveload.cpp
+++ b/engines/groovie/saveload.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "groovie/saveload.h"
+#include "groovie/groovie.h"
 
 #include "common/system.h"
 #include "common/substream.h"
@@ -32,7 +33,7 @@
 namespace Groovie {
 
 int SaveLoad::getMaximumSlot() {
-	return 9;
+	return MAX_SAVES - 1;
 }
 
 bool SaveLoad::isSlotValid(int slot) {
@@ -40,14 +41,15 @@ bool SaveLoad::isSlotValid(int slot) {
 }
 
 Common::String SaveLoad::getSlotSaveName(const Common::String &target, int slot) {
-	return target + ".00" + ('0' + slot);
+	Common::String fileName = Common::String::format("%s.%03d", target.c_str(), slot);
+	return fileName;
 }
 
 SaveStateList SaveLoad::listValidSaves(const Common::String &target) {
 	SaveStateList list;
 
 	// Get the list of savefiles
-	Common::String pattern = target + ".00?";
+	Common::String pattern = Common::String::format("%s.0##", target.c_str());
 	Common::StringArray savefiles = g_system->getSavefileManager()->listSavefiles(pattern);
 
 	// Sort the list of filenames
@@ -56,7 +58,15 @@ SaveStateList SaveLoad::listValidSaves(const Common::String &target) {
 	// Fill the information for the existing savegames
 	Common::StringArray::iterator it = savefiles.begin();
 	while (it != savefiles.end()) {
-		int slot = it->lastChar() - '0';
+		const char *ext = strrchr(it->c_str(), '.');
+		if (!ext)
+			continue;
+
+		int slot = atoi(ext + 1);
+
+		if (!isSlotValid(slot))
+			continue;
+
 		SaveStateDescriptor descriptor;
 		Common::InSaveFile *file = SaveLoad::openForLoading(target, slot, &descriptor);
 		if (file) {
@@ -73,14 +83,14 @@ SaveStateList SaveLoad::listValidSaves(const Common::String &target) {
 Common::InSaveFile *SaveLoad::openForLoading(const Common::String &target, int slot, SaveStateDescriptor *descriptor) {
 	// Validate the slot number
 	if (!isSlotValid(slot)) {
-		return NULL;
+		return nullptr;
 	}
 
 	// Open the savefile
 	Common::String savename = getSlotSaveName(target, slot);
 	Common::InSaveFile *savefile = g_system->getSavefileManager()->openForLoading(savename);
 	if (!savefile) {
-		return NULL;
+		return nullptr;
 	}
 
 	// Read the savefile version
@@ -145,14 +155,14 @@ Common::InSaveFile *SaveLoad::openForLoading(const Common::String &target, int s
 Common::OutSaveFile *SaveLoad::openForSaving(const Common::String &target, int slot) {
 	// Validate the slot number
 	if (!isSlotValid(slot)) {
-		return NULL;
+		return nullptr;
 	}
 
 	// Open the savefile
 	Common::String savename = getSlotSaveName(target, slot);
 	Common::OutSaveFile *savefile = g_system->getSavefileManager()->openForSaving(savename);
 	if (!savefile) {
-		return NULL;
+		return nullptr;
 	}
 
 	// Write the savefile version

--- a/engines/groovie/saveload.h
+++ b/engines/groovie/saveload.h
@@ -40,7 +40,7 @@ public:
 	static SaveStateList listValidSaves(const Common::String &target);
 
 	// Opening savefiles
-	static Common::InSaveFile *openForLoading(const Common::String &target, int slot, SaveStateDescriptor *descriptor = NULL);
+	static Common::InSaveFile *openForLoading(const Common::String &target, int slot, SaveStateDescriptor *descriptor = nullptr);
 	static Common::OutSaveFile *openForSaving(const Common::String &target, int slot);
 };
 

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -26,7 +26,6 @@
 #include "groovie/cell.h"
 #include "groovie/cursor.h"
 #include "groovie/graphics.h"
-#include "groovie/groovie.h"
 #include "groovie/music.h"
 #include "groovie/player.h"
 #include "groovie/resource.h"
@@ -172,7 +171,7 @@ bool Script::loadScript(Common::String filename) {
 
 void Script::directGameLoad(int slot) {
 	// Reject invalid slots
-	if (slot < 0 || slot > 9) {
+	if (slot < 0 || slot > MAX_SAVES - 1) {
 		return;
 	}
 
@@ -395,6 +394,17 @@ void Script::loadgame(uint slot) {
 
 	// Hide the mouse cursor
 	_vm->_grvCursorMan->show(false);
+}
+
+void Script::directGameSave(int slot, const Common::String &desc) {
+	if (slot < 0 || slot > MAX_SAVES - 1) {
+		return;
+	}
+	const char *saveName = desc.c_str();
+	for (int i = 0; i < 15; i++) {
+		_variables[i] = saveName[i] - 0x30;
+	}
+	savegame(slot);
 }
 
 void Script::savegame(uint slot) {
@@ -1368,7 +1378,7 @@ void Script::o_checkvalidsaves() {
 	debugC(1, kDebugScript, "CHECKVALIDSAVES");
 
 	// Reset the array of valid saves and the savegame names cache
-	for (int i = 0; i < 10; i++) {
+	for (int i = 0; i < MAX_SAVES; i++) {
 		setVariable(i, 0);
 		_saveNames[i] = "E M P T Y";
 	}

--- a/engines/groovie/script.h
+++ b/engines/groovie/script.h
@@ -23,6 +23,8 @@
 #ifndef GROOVIE_SCRIPT_H
 #define GROOVIE_SCRIPT_H
 
+#include "groovie/groovie.h"
+
 #include "common/random.h"
 #include "common/rect.h"
 
@@ -43,7 +45,6 @@ enum EngineVersion {
 
 class CellGame;
 class Debugger;
-class GroovieEngine;
 
 class Script {
 	friend class Debugger;
@@ -59,6 +60,7 @@ public:
 
 	bool loadScript(Common::String scriptfile);
 	void directGameLoad(int slot);
+	void directGameSave(int slot, const Common::String &desc);
 	void step();
 
 	void setMouseClick(uint8 button);
@@ -81,7 +83,7 @@ private:
 	Common::String _savedScriptFile;
 
 	// Save names
-	Common::String _saveNames[10];
+	Common::String _saveNames[MAX_SAVES];
 
 	// Code
 	byte *_code;


### PR DESCRIPTION
If the user enters in an invalid description for the save then it will be
simplified by the saved name cache process in Script::savegame.

I checked this with t7g, but not with the 11th guest or any other Groovie game.

The original in-game loading/saving can still only access the first 10 save
slots (0-9).

Its possible to saving via the GMM when the game is interactive.

Loading a game saved via the gui using the original in-game load menu
works fine.

Saving via the GMM with timestamp works, but only only saves the characters
up to the first non-alpha non-letter characer.