### PR TITLE
AGOS: Add in game loading/Saving via GMM

### DIFF
--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -216,6 +216,10 @@ protected:
 	virtual bool hasFeature(EngineFeature f) const;
 	virtual void syncSoundSettings();
 	virtual void pauseEngineIntern(bool pause);
+	virtual bool canLoadGameStateCurrently() { return true; };
+	virtual bool canSaveGameStateCurrently() { return true; };
+	virtual Common::Error loadGameState(int slot);
+	virtual Common::Error saveGameState(int slot, const Common::String &desc);
 
 	virtual void setupOpcodes();
 	uint16 _numOpcodes, _opcode;
@@ -240,6 +244,10 @@ public:
 	Common::Language getLanguage() const;
 	Common::Platform getPlatform() const;
 	const char *getFileName(int type) const;
+	/*
+	** Return the save file prefix name given the target
+	*/
+	static Common::String savenamePrefix(const char *target);
 
 protected:
 	void playSting(uint16 a);

--- a/engines/agos/saveload.cpp
+++ b/engines/agos/saveload.cpp
@@ -32,6 +32,34 @@
 
 namespace AGOS {
 
+Common::String AGOSEngine::savenamePrefix(const char *target) {
+	Common::String prefix = target;
+	if (prefix.contains("simon1")) {
+		prefix = "simon1";
+	} else if (prefix.contains("simon2")) {
+		prefix = "simon2";
+	} else if (prefix.contains("pn")) {
+		prefix = "pn";
+	} else if (prefix.contains("waxworks")) {
+		prefix = "waxworks-pc"; // dos only support not amiga
+	} else if (prefix.contains("elvira1")) {
+		prefix = "elvira1";
+	} else if (prefix.contains("elvira2")) {
+		prefix = "elvira2-pc"; // dos only support not amiga
+	} else if (prefix.contains("feeble")) {
+		prefix = "feeble";
+	} else if (prefix.contains("dimp")) {
+		prefix = "dimp";
+	} else if (prefix.contains("jumble") || 
+	           prefix.contains("puzzle") ||
+	           prefix.contains("swampy")) {
+		prefix = "swampy";
+	} else {
+		warning("Unknown target %s",target);
+	}
+
+	return prefix;
+}
 
 // FIXME: This code counts savegames, but callers in many cases assume
 // that the return value + 1 indicates an empty slot.
@@ -202,7 +230,6 @@ void AGOSEngine::quickLoadOrSave() {
 		buf = Common::String::format(_("Successfully saved game in file:\n\n%s"), filename.c_str());
 		GUI::TimedMessageDialog dialog(buf, 1500);
 		dialog.runModal();
-
 	}
 
 	_saveLoadType = 0;


### PR DESCRIPTION
Once the engine has been started and the game is at a safe place to
save/load (as determined by quickLoadOrSave()) the player can save/load
their game using the GMM.

Currently, the save descriptor shown in the listsaves is the filename,
but the actual correct descriptor is correct in the save when saving via
the GMM. The descriptor saved using the GMM can be seen using the original
game save/load menus. The displaying of the correct  descriptor can be added
later.

The filenames shown by listsaves is generated from the input target
which can be one of several games. Most of them are just the basename so
the target simon2-cd-win is just simon2.xxx for the savefile, but for
waxworks and elvira2 they differ on whether the platform is dos
or amiga. Since the target does not contain this information I am
currently not differentiating the two, so I defaulted it to generate
names based on the dos version. This can also be changed later. For
amiga waxworks and elvira2 this has the effect that saved games cannot
be loaded/seen using listsaves. They will be correctly saved when saving via
the GMM since that does not use the savefile name generated from the target.

I've tested this with waxworks dos, simon1 dos and simon2 dos.