### PR TITLE
MOHAWK: RIVEN: Only use x mouse position to move dome sliders

### DIFF
--- a/engines/mohawk/riven_stacks/domespit.h
+++ b/engines/mohawk/riven_stacks/domespit.h
@@ -43,7 +43,7 @@ protected:
 	void checkSliderCursorChange(uint16 startHotspot);
 	void dragDomeSlider(uint16 startHotspot);
 	void drawDomeSliders(uint16 startHotspot);
-	int16 getSliderSlotAtPos(uint16 startHotspot, const Common::Point &pos) const;
+	int16 getSliderSlotClosestToPos(uint16 startHotspot, const Common::Point &pos) const;
 	bool isSliderAtSlot(int16 slot) const;
 	Common::String buildCardResourceName(const Common::String &name) const;
 


### PR DESCRIPTION
Fixes Trac#10642.

The original engine will move the dome sliders whenever the player is
dragging a dome slider to the left or right regardless of y position.

In ScummVM the dome slider position would only change to the players x
mouse position when the y value was also in the slider hotspot. This
change removes the y check by making the point to be checked always
have a y value in the hotspot rect.