### PR TITLE
BLADERUNNER: Add cos/sine table

### DIFF
--- a/engines/bladerunner/actor.cpp
+++ b/engines/bladerunner/actor.cpp
@@ -622,9 +622,8 @@ bool Actor::tick(bool forceDraw, Common::Rect *screenRect) {
 					positionChange.z = positionChange.z * _actorSpeed.z;
 				}
 
-				float angle = _facing * (M_PI / 512.0f);
-				float sinx = sin(angle);
-				float cosx = cos(angle);
+				float sinx = _vm->_sinTable1024->at(_facing);
+				float cosx = _vm->_cosTable1024->at(_facing);
 
 				float originalX = _position.x;
 				float originalY = _position.y;
@@ -1183,8 +1182,8 @@ bool Actor::walkFindU1(const Vector3 &startPosition, const Vector3 &targetPositi
 	int facing2 = facing;
 	int facing3 = 0;
 	while (true) {
-		float rotatedX = targetPosition.x + size * sin_1024(facing);
-		float rotatedZ = targetPosition.z - size * cos_1024(facing);
+		float rotatedX = targetPosition.x + size * _vm->_sinTable1024->at(facing);
+		float rotatedZ = targetPosition.z - size * _vm->_cosTable1024->at(facing);
 
 		if (!_walkInfo->isXYZEmpty(rotatedX, targetPosition.y, rotatedZ, _id)) {
 			if (_vm->_scene->_set->findWalkbox(rotatedX, rotatedZ) >= 0) {
@@ -1201,8 +1200,8 @@ bool Actor::walkFindU1(const Vector3 &startPosition, const Vector3 &targetPositi
 			facing3 += 20;
 		}
 
-		rotatedX = size * sin_1024(facing2) + targetPosition.x;
-		rotatedZ = size * cos_1024(facing2) + targetPosition.z;
+		rotatedX = size * _vm->_sinTable1024->at(facing2) + targetPosition.x;
+		rotatedZ = size * _vm->_cosTable1024->at(facing2) + targetPosition.z;
 
 		if (!_walkInfo->isXYZEmpty(rotatedX, targetPosition.y, rotatedZ, _id)) {
 			if (_vm->_scene->_set->findWalkbox(rotatedX, rotatedZ) >= 0) {

--- a/engines/bladerunner/actor_walk.cpp
+++ b/engines/bladerunner/actor_walk.cpp
@@ -194,10 +194,8 @@ bool ActorWalk::tick(int actorId, float stepDistance, bool inWalkLoop) {
 		}
 	}
 
-	float angle_rad = _facing / 512.0 * M_PI;
-
-	_current.x += stepDistance * sinf(angle_rad);
-	_current.z -= stepDistance * cosf(angle_rad);
+	_current.x += stepDistance * _vm->_sinTable1024->at(_facing);
+	_current.z -= stepDistance * _vm->_cosTable1024->at(_facing);
 	_current.y = _vm->_scene->_set->getAltitudeAtXZ(_current.x, _current.z, &walkboxFound);
 
 	return false;
@@ -309,8 +307,8 @@ bool ActorWalk::findNearestEmptyPosition(int actorId, const Vector3 &destination
 	out.z = 0.0f;
 
 	for (int facing = 0; facing < 1024; facing += 128) {
-		x = destination.x + sin_1024(facing) * dist;
-		z = destination.z - cos_1024(facing) * dist;
+		x = destination.x + _vm->_sinTable1024->at(facing) * dist;
+		z = destination.z - _vm->_cosTable1024->at(facing) * dist;
 		float distanceBetweenActorAndDestination = distance(x, z, _vm->_actors[actorId]->getX(), _vm->_actors[actorId]->getZ());
 
 		if (minDistance == -1.0f || minDistance > distanceBetweenActorAndDestination) {
@@ -323,15 +321,15 @@ bool ActorWalk::findNearestEmptyPosition(int actorId, const Vector3 &destination
 	int facingRight = facingToMinDistance;
 	int facing = -1024;
 	while (facing < 0) {
-		x = destination.x + sin_1024(facingRight) * dist;
-		z = destination.z - cos_1024(facingRight) * dist;
+		x = destination.x + _vm->_sinTable1024->at(facingRight) * dist;
+		z = destination.z - _vm->_cosTable1024->at(facingRight) * dist;
 
 		if (!_vm->_sceneObjects->existsOnXZ(actorId + kSceneObjectOffsetActors, x, z, true, true) && _vm->_scene->_set->findWalkbox(x, z) >= 0) {
 			break;
 		}
 
-		x = destination.x + sin_1024(facingLeft) * dist;
-		z = destination.z - cos_1024(facingLeft) * dist;
+		x = destination.x + _vm->_sinTable1024->at(facingLeft)  * dist;
+		z = destination.z - _vm->_cosTable1024->at(facingLeft) * dist;
 
 		if (!_vm->_sceneObjects->existsOnXZ(actorId + kSceneObjectOffsetActors, x, z, true, true) && _vm->_scene->_set->findWalkbox(x, z) >= 0) {
 			break;

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -315,6 +315,8 @@ bool BladeRunnerEngine::startup(bool hasSavegames) {
 	// Seed rand
 
 	// TODO: Sine and cosine lookup tables for intervals of 1.0, 4.0, and 12.0
+	_cosTable1024 = new Common::CosineTable(10); // 10-bits = 1024 points for 2*PI;	
+	_sinTable1024 = new Common::SineTable(10);	
 
 	_view = new View();
 
@@ -602,7 +604,8 @@ void BladeRunnerEngine::shutdown() {
 	delete _sceneObjects;
 	_sceneObjects = nullptr;
 
-	// TODO: Delete sine and cosine lookup tables
+	delete _cosTable1024;
+	delete _sinTable1024;
 
 	delete _aiScripts;
 	_aiScripts = nullptr;

--- a/engines/bladerunner/bladerunner.h
+++ b/engines/bladerunner/bladerunner.h
@@ -26,7 +26,9 @@
 #include "bladerunner/archive.h"
 
 #include "common/array.h"
+#include "common/cosinetables.h"
 #include "common/random.h"
+#include "common/sinetables.h"
 #include "common/stream.h"
 
 #include "engines/engine.h"
@@ -174,6 +176,9 @@ public:
 	Common::RandomSource _rnd;
 
 	Debugger *_debugger;
+
+	Common::CosineTable *_cosTable1024;
+	Common::SineTable   *_sinTable1024;
 
 	bool _isWalkingInterruptible;
 	bool _interruptWalking;

--- a/engines/bladerunner/vector.h
+++ b/engines/bladerunner/vector.h
@@ -148,14 +148,6 @@ inline float distance(const Vector3 &v1, const Vector3 &v2) {
 	return distance(v1.x, v1.z, v2.x, v2.z);
 }
 
-inline float cos_1024(int angle1024) {
-	return cos(angle1024 * (M_PI / 512.0f));
-}
-
-inline float sin_1024(int angle1024) {
-	return sin(angle1024 * (M_PI / 512.0f));
-}
-
 inline bool lineIntersection(Vector2 a1, Vector2 a2, Vector2 b1, Vector2 b2, Vector2 *intersection) {
 	Vector2 s1(a2.x - a1.x, a2.y - a1.y);
 	Vector2 s2(b2.x - b1.x, b2.y - b1.y);


### PR DESCRIPTION
This uses the one in Common.

The engine now contains a 10-bit cosine and sine table.
It used mostly for vector math.

This also allows two vector functions to be removed from vector.h.