### PR TITLE
GRAPHICS: Set thumbnail to nullptr when loading the thumbnail is skipped

### DIFF
--- a/engines/lab/detection.cpp
+++ b/engines/lab/detection.cpp
@@ -208,7 +208,7 @@ SaveStateDescriptor LabMetaEngine::querySaveMetaInfos(const char *target, int sl
 	if (in) {
 		Lab::SaveGameHeader header;
 
-		bool successfulRead = Lab::readSaveGameHeader(in, header);
+		bool successfulRead = Lab::readSaveGameHeader(in, header, false);
 		delete in;
 
 		if (successfulRead) {

--- a/engines/lab/lab.h
+++ b/engines/lab/lab.h
@@ -502,7 +502,7 @@ private:
 	void handleTrialWarning();
 };
 
-WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeader &header, bool skipThumbnail = false);
+WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeader &header, bool skipThumbnail = true);
 
 } // End of namespace Lab
 

--- a/graphics/thumbnail.cpp
+++ b/graphics/thumbnail.cpp
@@ -149,6 +149,7 @@ bool skipThumbnail(Common::SeekableReadStream &in) {
 
 bool loadThumbnail(Common::SeekableReadStream &in, Graphics::Surface *&thumbnail, bool skipThumbnail) {
 	if (skipThumbnail) {
+		thumbnail = nullptr;
 		return Graphics::skipThumbnail(in);
 	}
 


### PR DESCRIPTION
Since Graphics::loadThumbnail can return successfully when a thumbnail is skipped
the caller may want to check to the see that the thumbnail is not null before using
it. Setting it to null is just defensive in case the caller didn't do so.