### PR TITLE
WINTERMUTE: Return Common::kUnsupportedColorMode if the required screen format is unavailable

### DIFF
--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -118,7 +118,7 @@ Common::Error WintermuteEngine::run() {
 		initGraphics(800, 600, &format);
 	}
 	if (g_system->getScreenFormat() != format) {
-		error("Wintermute currently REQUIRES 32bpp");
+		return Common::kUnsupportedColorMode;
 	}
 
 	// Create debugger console. It requires GFX to be initialized


### PR DESCRIPTION
Now, the GUI will display a message box if the required screen format is unavailable, whereas previously, ScummVM would simply quit without warning if that happens.