### PR TITLE
MOHAWK: RIVEN: Delay less for slower systems

### DIFF
--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -216,6 +216,30 @@ void MohawkEngine_Riven::doFrame() {
 		_stack->keyResetAction();
 	}
 
+	processInput();
+
+	_stack->onFrame();
+
+	if (!_scriptMan->runningQueuedScripts()) {
+		// Don't run queued scripts if we are calling from a queued script
+		// otherwise infinite looping will happen.
+		_scriptMan->runQueuedScripts();
+	}
+
+	if (shouldPerformAutoSave(_lastSaveTime)) {
+		tryAutoSaving();
+	}
+
+	_inventory->onFrame();
+
+	// Update the screen once per frame
+	_system->updateScreen();
+
+	// Cut down on CPU usage
+	_system->delayMillis(10);
+}
+
+void MohawkEngine_Riven::processInput() {
 	Common::Event event;
 	while (_eventMan->pollEvent(event)) {
 		switch (event.type) {
@@ -305,26 +329,6 @@ void MohawkEngine_Riven::doFrame() {
 			break;
 		}
 	}
-
-	_stack->onFrame();
-
-	if (!_scriptMan->runningQueuedScripts()) {
-		// Don't run queued scripts if we are calling from a queued script
-		// otherwise infinite looping will happen.
-		_scriptMan->runQueuedScripts();
-	}
-
-	if (shouldPerformAutoSave(_lastSaveTime)) {
-		tryAutoSaving();
-	}
-
-	_inventory->onFrame();
-
-	// Update the screen once per frame
-	_system->updateScreen();
-
-	// Cut down on CPU usage
-	_system->delayMillis(10);
 }
 
 void MohawkEngine_Riven::goToMainMenu() {

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -209,6 +209,7 @@ Common::Error MohawkEngine_Riven::run() {
 
 void MohawkEngine_Riven::doFrame() {
 	// Update background running things
+	uint32 loopStart = _system->getMillis();
 	_sound->updateSLST();
 	_video->updateMovies();
 
@@ -234,9 +235,11 @@ void MohawkEngine_Riven::doFrame() {
 
 	// Update the screen once per frame
 	_system->updateScreen();
+	uint32 loopElapsed = _system->getMillis() - loopStart;
 
 	// Cut down on CPU usage
-	_system->delayMillis(10);
+	if (loopElapsed < 10)
+		_system->delayMillis(10 - loopElapsed);
 }
 
 void MohawkEngine_Riven::processInput() {

--- a/engines/mohawk/riven.h
+++ b/engines/mohawk/riven.h
@@ -106,6 +106,7 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 
 	void doFrame();
+	void processInput();
 
 private:
 	// Datafiles


### PR DESCRIPTION
1. Move input handling from doFrame to another function
2. Delay less if doFrame loop takes longer.