### PR TITLE
GUI: Add editable path in "Add Game" tab

### DIFF
--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -95,7 +95,7 @@ void BrowserDialog::open() {
 void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	switch (cmd) {
 	//Search for typed-in directory
-	case _ExitTxtCmd:
+	case kExitTxtCmd:
 		_node = Common::FSNode(_currentPath->getEditString());
 		updateListing();
 		break;

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -21,9 +21,9 @@
  */
 
 #include "gui/browser.h"
+#include "gui/widgets/edittext.h"
 #include "gui/gui-manager.h"
 #include "gui/widgets/list.h"
-#include "gui/widgets/edittext.h"
 
 #include "common/config-manager.h"
 #include "common/system.h"
@@ -94,11 +94,12 @@ void BrowserDialog::open() {
 
 void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	switch (cmd) {
-	//Search by text input
+	//Search for typed-in directory
 	case _ExitTxtCmd:
 		_node = Common::FSNode(_currentPath->getEditString());
 		updateListing();
 		break;
+	//Search by text input
 	case kChooseCmd:
 		if (_isDirBrowser) {
 			// If nothing is selected in the list widget, choose the current dir.

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -23,6 +23,7 @@
 #include "gui/browser.h"
 #include "gui/gui-manager.h"
 #include "gui/widgets/list.h"
+#include "gui/widgets/edittext.h"
 
 #include "common/config-manager.h"
 #include "common/system.h"
@@ -53,10 +54,9 @@ BrowserDialog::BrowserDialog(const char *title, bool dirBrowser)
 	_showHidden = false;
 
 	// Headline - TODO: should be customizable during creation time
-	new StaticTextWidget(this, "Browser.Headline", title);
-
+	
 	// Current path - TODO: handle long paths ?
-	_currentPath = new StaticTextWidget(this, "Browser.Path", "DUMMY");
+	_currentPath = new EditTextWidget(this, "Browser.Path", "DUMMY");
 
 	// Add file list
 	_fileList = new ListWidget(this, "Browser.List");
@@ -94,6 +94,11 @@ void BrowserDialog::open() {
 
 void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	switch (cmd) {
+	//Search by text input
+	case _ExitTxtCmd:
+		_node = Common::FSNode(_currentPath->getEditString());
+		updateListing();
+		break;
 	case kChooseCmd:
 		if (_isDirBrowser) {
 			// If nothing is selected in the list widget, choose the current dir.
@@ -157,7 +162,7 @@ void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 
 void BrowserDialog::updateListing() {
 	// Update the path display
-	_currentPath->setLabel(_node.getPath());
+	_currentPath->setEditString(_node.getPath());
 
 	// We memorize the last visited path.
 	ConfMan.set("browser_lastpath", _node.getPath());

--- a/gui/browser.h
+++ b/gui/browser.h
@@ -29,7 +29,7 @@
 namespace GUI {
 
 class ListWidget;
-class StaticTextWidget;
+class EditTextWidget;
 class CheckboxWidget;
 class CommandSender;
 
@@ -54,7 +54,7 @@ protected:
 	const void *_chooseRef;
 #else
 	ListWidget		*_fileList;
-	StaticTextWidget	*_currentPath;
+	EditTextWidget	*_currentPath;
 	Common::FSNode	_node;
 	Common::FSList			_nodeContent;
 	bool _showHidden;

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -132,7 +132,7 @@ void EditTextWidget::startEditMode() {
 void EditTextWidget::endEditMode() {
 	releaseFocus();
 	
-	sendCommand(_ExitTxtCmd, 0);
+	sendCommand(kExitTxtCmd, 0);
 	sendCommand(_finishCmd, 0);
 }
 
@@ -143,7 +143,7 @@ void EditTextWidget::abortEditMode() {
 	releaseFocus();
 }
 
-Common::String EditTextWidget::getEditString(){
+Common::String EditTextWidget::getEditString() {
 	return _backupString;
 }
 

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -64,7 +64,6 @@ void EditTextWidget::reflowLayout() {
 	EditableWidget::reflowLayout();
 }
 
-
 void EditTextWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 	if (!isEnabled())
 		return;
@@ -132,14 +131,20 @@ void EditTextWidget::startEditMode() {
 
 void EditTextWidget::endEditMode() {
 	releaseFocus();
-
+	
+	sendCommand(_ExitTxtCmd, 0);
 	sendCommand(_finishCmd, 0);
 }
 
 void EditTextWidget::abortEditMode() {
 	setEditString(_backupString);
 	sendCommand(_cmd, 0);
+	
 	releaseFocus();
+}
+
+Common::String EditTextWidget::getEditString(){
+	return _backupString;
 }
 
 } // End of namespace GUI

--- a/gui/widgets/edittext.h
+++ b/gui/widgets/edittext.h
@@ -30,7 +30,7 @@
 namespace GUI {
 
 enum {
-	_ExitTxtCmd = 'TXTE'
+	kExitTxtCmd = 'TXTE'
 };
 
 /* EditTextWidget */

--- a/gui/widgets/edittext.h
+++ b/gui/widgets/edittext.h
@@ -25,8 +25,13 @@
 
 #include "gui/widgets/editable.h"
 #include "common/str.h"
+#include "gui/dialog.h"
 
 namespace GUI {
+
+enum {
+	_ExitTxtCmd = 'TXTE'
+};
 
 /* EditTextWidget */
 class EditTextWidget : public EditableWidget {
@@ -43,12 +48,15 @@ public:
 	EditTextWidget(GuiObject *boss, const String &name, const String &text, const char *tooltp = 0, uint32 cmd = 0, uint32 finishCmd = 0);
 
 	void setEditString(const String &str);
+	
+	String getEditString();
 
 	virtual void handleMouseDown(int x, int y, int button, int clickCount);
-
+	
 	virtual bool wantsFocus() { return true; }
 
 	virtual void reflowLayout();
+
 
 protected:
 	void drawWidget();
@@ -58,6 +66,7 @@ protected:
 	void startEditMode();
 	void endEditMode();
 	void abortEditMode();
+	
 
 	Common::Rect getEditRect() const;
 


### PR DESCRIPTION
Allows users to type-in target path when adding a game . I wasn't sure what to do with invalid paths (e.g. pop-up notifying the user), as it currently silently returns an empty directory.