### PR TITLE
ALL: Replace use of strdup with Common::String

### DIFF
--- a/audio/softsynth/fluidsynth.cpp
+++ b/audio/softsynth/fluidsynth.cpp
@@ -88,26 +88,15 @@ MidiDriver_FluidSynth::MidiDriver_FluidSynth(Audio::Mixer *mixer)
 }
 
 void MidiDriver_FluidSynth::setInt(const char *name, int val) {
-	char *name2 = strdup(name);
-
-	fluid_settings_setint(_settings, name2, val);
-	free(name2);
+	fluid_settings_setint(_settings, name, val);
 }
 
 void MidiDriver_FluidSynth::setNum(const char *name, double val) {
-	char *name2 = strdup(name);
-
-	fluid_settings_setnum(_settings, name2, val);
-	free(name2);
+	fluid_settings_setnum(_settings, name, val);
 }
 
 void MidiDriver_FluidSynth::setStr(const char *name, const char *val) {
-	char *name2 = strdup(name);
-	char *val2 = strdup(val);
-
-	fluid_settings_setstr(_settings, name2, val2);
-	free(name2);
-	free(val2);
+	fluid_settings_setstr(_settings, name, val);
 }
 
 int MidiDriver_FluidSynth::open() {

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -111,7 +111,7 @@ OSystem_iOS7::OSystem_iOS7() :
 	_screenOrientation(kScreenOrientationFlippedLandscape), _mouseClickAndDragEnabled(false),
 	_gestureStartX(-1), _gestureStartY(-1), _fullScreenIsDirty(false), _fullScreenOverlayIsDirty(false),
 	_mouseDirty(false), _timeSuspended(0), _lastDragPosX(-1), _lastDragPosY(-1), _screenChangeCount(0),
-	_lastErrorMessage(NULL), _mouseCursorPaletteEnabled(false), _gfxTransactionError(kTransactionSuccess) {
+	_mouseCursorPaletteEnabled(false), _gfxTransactionError(kTransactionSuccess) {
 	_queuedInputEvent.type = Common::EVENT_INVALID;
 	_touchpadModeEnabled = !iOS7_isBigDevice();
 #ifdef IPHONE_SANDBOXED
@@ -352,8 +352,7 @@ void OSystem_iOS7::logMessage(LogMessageType::Type type, const char *message) {
 		output = stderr;
 
 	if (type == LogMessageType::kError) {
-		free(_lastErrorMessage);
-		_lastErrorMessage = strdup(message);
+		_lastErrorMessage = message;
 	}
 
 	fputs(message, output);

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -27,6 +27,7 @@
 #include "backends/platform/ios7/ios7_common.h"
 #include "backends/base-backend.h"
 #include "common/events.h"
+#include "common/str.h"
 #include "audio/mixer_intern.h"
 #include "backends/fs/posix/posix-fs-factory.h"
 #include "graphics/colormasks.h"
@@ -109,7 +110,7 @@ protected:
 	bool _fullScreenOverlayIsDirty;
 	int _screenChangeCount;
 
-	char *_lastErrorMessage;
+	Common::String _lastErrorMessage;
 
 #ifdef IPHONE_SANDBOXED
 	Common::String _chrootBasePath;

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -52,8 +52,8 @@ static void displayAlert(void *ctx) {
 }
 
 void OSystem_iOS7::fatalError() {
-	if (_lastErrorMessage) {
-		dispatch_async_f(dispatch_get_main_queue(), _lastErrorMessage, displayAlert);
+	if (_lastErrorMessage.size()) {
+		dispatch_async_f(dispatch_get_main_queue(), (void *)_lastErrorMessage.c_str(), displayAlert);
 		for(;;);
 	}
 	else {

--- a/common/forbidden.h
+++ b/common/forbidden.h
@@ -459,6 +459,10 @@
 #define strncasecmp(a,b,c)	FORBIDDEN_SYMBOL_REPLACEMENT
 #endif
 
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_strdup
+#undef strdup
+#define strdup(a)	FORBIDDEN_SYMBOL_REPLACEMENT
+#endif
 
 /*
  * We also would like to disable the following symbols;

--- a/common/str.cpp
+++ b/common/str.cpp
@@ -1058,3 +1058,13 @@ int scumm_strnicmp(const char *s1, const char *s2, uint n) {
 	} while (l1 == l2 && l1 != 0);
 	return l1 - l2;
 }
+
+//  Portable implementation of strdup.
+char *scumm_strdup(const char *in) {
+	const size_t len = strlen(in) + 1;
+	char *out = new char[len];
+	if (out) {
+		strcpy(out, in);
+	}
+	return out;
+}

--- a/common/str.h
+++ b/common/str.h
@@ -482,5 +482,6 @@ size_t strnlen(const char *src, size_t maxSize);
 
 extern int scumm_stricmp(const char *s1, const char *s2);
 extern int scumm_strnicmp(const char *s1, const char *s2, uint n);
+extern char *scumm_strdup(const char *in);
 
 #endif

--- a/engines/agi/agi.cpp
+++ b/engines/agi/agi.cpp
@@ -214,7 +214,7 @@ int AgiEngine::agiDeinit() {
 	agiUnloadResources();    // unload resources in memory
 	_loader->unloadResource(RESOURCETYPE_LOGIC, 0);
 	ec = _loader->deinit();
-	unloadObjects();
+	_objects.clear();
 	_words->unloadDictionary();
 
 	clearImageStack();
@@ -385,8 +385,6 @@ AgiEngine::AgiEngine(OSystem *syst, const AGIGameDescription *gameDesc) : AgiBas
 	_intobj = NULL;
 
 	memset(&_stringdata, 0, sizeof(struct StringData));
-
-	_objects = NULL;
 
 	_restartGame = false;
 

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -31,6 +31,7 @@
 #include "common/rect.h"
 #include "common/rendermode.h"
 #include "common/stack.h"
+#include "common/str.h"
 #include "common/system.h"
 
 #include "engines/engine.h"
@@ -354,7 +355,7 @@ struct AgiControllerKeyMapping {
 
 struct AgiObject {
 	int location;
-	char *name;
+	Common::String name;
 };
 
 struct AgiDir {
@@ -763,7 +764,7 @@ private:
 	int _firstSlot;
 
 public:
-	AgiObject *_objects;    // objects in the game
+	Common::Array<AgiObject> _objects;    // objects in the game
 
 	StringData _stringdata;
 
@@ -852,14 +853,12 @@ public:
 	int showObjects();
 	int loadObjects(const char *fname);
 	int loadObjects(Common::File &fp);
-	void unloadObjects();
 	const char *objectName(uint16 objectNr);
 	int objectGetLocation(uint16 objectNr);
 	void objectSetLocation(uint16 objectNr, int);
 private:
 	int decodeObjects(uint8 *mem, uint32 flen);
 	int readObjects(Common::File &fp, int flen);
-	int allocObjects(int);
 
 	// Logic
 public:

--- a/engines/agi/objects.cpp
+++ b/engines/agi/objects.cpp
@@ -26,20 +26,12 @@
 
 namespace Agi {
 
-int AgiEngine::allocObjects(int n) {
-	if ((_objects = (AgiObject *)calloc(n, sizeof(struct AgiObject))) == NULL)
-		return errNotEnoughMemory;
-
-	return errOK;
-}
-
 int AgiEngine::decodeObjects(uint8 *mem, uint32 flen) {
 	unsigned int i, so, padsize, spos;
 
 	padsize = _game.gameFlags & ID_AMIGA ? 4 : 3;
 
 	_game.numObjects = 0;
-	_objects = NULL;
 
 	// check if first pointer exceeds file size
 	// if so, its encrypted, else it is not
@@ -60,8 +52,7 @@ int AgiEngine::decodeObjects(uint8 *mem, uint32 flen) {
 	_game.numObjects = READ_LE_UINT16(mem) / padsize;
 	debugC(5, kDebugLevelResources, "num_objects = %d (padsize = %d)", _game.numObjects, padsize);
 
-	if (allocObjects(_game.numObjects) != errOK)
-		return errNotEnoughMemory;
+	_objects.resize(_game.numObjects);
 
 	// build the object list
 	spos = getVersion() >= 0x2000 ? padsize : 0;
@@ -72,15 +63,15 @@ int AgiEngine::decodeObjects(uint8 *mem, uint32 flen) {
 		offset = READ_LE_UINT16(mem + so) + spos;
 
 		if ((uint) offset < flen) {
-			_objects[i].name = (char *)strdup((const char *)mem + offset);
+			_objects[i].name = (const char *)mem + offset;
 		} else {
 			warning("object %i name beyond object filesize (%04x > %04x)", i, offset, flen);
-			_objects[i].name = strdup("");
+			_objects[i].name.clear();
 		}
 
 		// Don't show the invalid "?" object in ego's inventory in the fanmade
 		// game Beyond the Titanic 2 (bug #3116541).
-		if (!strcmp(_objects[i].name, "?") && _objects[i].location == EGO_OWNED)
+		if (_objects[i].name == "?" && _objects[i].location == EGO_OWNED)
 			_objects[i].location = 0;
 	}
 	debug(0, "Reading objects: %d objects read.", _game.numObjects);
@@ -131,19 +122,6 @@ int AgiEngine::readObjects(Common::File &fp, int flen) {
 	return errOK;
 }
 
-void AgiEngine::unloadObjects() {
-	unsigned int i;
-
-	if (_objects != NULL) {
-		for (i = 0; i < _game.numObjects; i++) {
-			free(_objects[i].name);
-			_objects[i].name = NULL;
-		}
-		free(_objects);
-		_objects = NULL;
-	}
-}
-
 void AgiEngine::objectSetLocation(uint16 objectNr, int i) {
 	if (objectNr >= _game.numObjects) {
 		warning("AgiEngine::objectSetLocation: Can't access object %d.\n", objectNr);
@@ -165,7 +143,7 @@ const char *AgiEngine::objectName(uint16 objectNr) {
 		warning("AgiEngine::objectName: Can't access object %d.\n", objectNr);
 		return "";
 	}
-	return _objects[objectNr].name;
+	return _objects[objectNr].name.c_str();
 }
 
 } // End of namespace Agi

--- a/engines/gob/demos/demoplayer.cpp
+++ b/engines/gob/demos/demoplayer.cpp
@@ -130,19 +130,18 @@ void DemoPlayer::clearScreen() {
 
 void DemoPlayer::playVideo(const char *fileName) {
 	uint32 waitTime = 0;
-	char *file, *filePtr;
-
-	file = filePtr = strdup(fileName);
+	Common::String filePtr(fileName);
+	Common::String::iterator file = filePtr.begin();
 
 	// Trimming spaces front
 	while (*file == ' ')
 		file++;
 
-	char *spaceBack = strchr(file, ' ');
-	if (spaceBack) {
-		char *nextSpace = strchr(spaceBack, ' ');
+	Common::String::iterator spaceBack = Common::find(file, filePtr.end(), ' ');
+	if (spaceBack != filePtr.end()) {
+		Common::String::iterator nextSpace = Common::find(spaceBack, filePtr.end(), ' ');
 
-		if (nextSpace)
+		if (nextSpace != filePtr.end())
 			*nextSpace = '\0';
 
 		*spaceBack++ = '\0';
@@ -180,9 +179,6 @@ void DemoPlayer::playVideo(const char *fileName) {
 		if (waitTime > 0)
 			_vm->_util->longDelay(waitTime);
 	}
-
-
-	free(filePtr);
 }
 
 void DemoPlayer::playADL(const char *params) {

--- a/engines/lure/room.cpp
+++ b/engines/lure/room.cpp
@@ -491,18 +491,17 @@ void Room::update() {
 		if (_hotspotId != 0)
 			s.writeString(0, 0, _hotspotName, false);
 	} else {
-		// Word wrap (if necessary) the status line and dispaly it
-		char *statusLineCopy = strdup(_statusLine);
+		// Word wrap (if necessary) the status line and display it
+		Common::String statusLineCopy(_statusLine);
 		char **lines;
 		uint8 numLines;
 		int16 yPos = 0;
-		s.wordWrap(statusLineCopy, s.width(), lines, numLines);
+		s.wordWrap(statusLineCopy.begin(), s.width(), lines, numLines);
 		for (int lineNum = 0; lineNum < numLines; ++lineNum) {
 			s.writeString(0, yPos, lines[lineNum], false, white);
 			yPos += FONT_HEIGHT;
 		}
 		Memory::dealloc(lines);
-		Memory::dealloc(statusLineCopy);
 	}
 
 	// Debug - if the bottle object is on layer 0FEh, then display it's surface

--- a/engines/lure/surface.cpp
+++ b/engines/lure/surface.cpp
@@ -479,16 +479,15 @@ Surface *Surface::newDialog(uint16 width, uint8 numLines, const char **lines, bo
 
 Surface *Surface::newDialog(uint16 width, const char *line, int color) {
 	char **lines;
-	char *lineCopy = strdup(line);
+	Common::String lineCopy(line);
 	uint8 numLines;
-	wordWrap(lineCopy, width - (Surface::textX() * 2), lines, numLines);
+	wordWrap(lineCopy.begin(), width - (Surface::textX() * 2), lines, numLines);
 
 	// Create the dialog
 	Surface *result = newDialog(width, numLines, const_cast<const char **>(lines), true, color);
 
 	// Deallocate used resources
 	free(lines);
-	free(lineCopy);
 
 	return result;
 }

--- a/engines/parallaction/exec_br.cpp
+++ b/engines/parallaction/exec_br.cpp
@@ -72,7 +72,7 @@ typedef Common::Functor1Mem<ProgramContext&, void, ProgramExec_br> OpcodeV2;
 
 extern const char *_instructionNamesRes_br[];
 
-void Parallaction_br::setupSubtitles(char *s, char *s2, int y) {
+void Parallaction_br::setupSubtitles(const char *s, const char *s2, int y) {
 	debugC(5, kDebugExec, "setupSubtitles(%s, %s, %i)", s, s2, y);
 
 	clearSubtitles();
@@ -123,7 +123,7 @@ DECLARE_COMMAND_OPCODE(location) {
 	_vm->_location._followerStartPosition = ctxt._cmd->_startPos2;
 	_vm->_location._followerStartFrame = 0;
 
-	_vm->scheduleLocationSwitch(ctxt._cmd->_string);
+	_vm->scheduleLocationSwitch(ctxt._cmd->_string.c_str());
 }
 
 
@@ -172,8 +172,8 @@ DECLARE_COMMAND_OPCODE(stop) {
 
 
 DECLARE_COMMAND_OPCODE(character) {
-	debugC(9, kDebugExec, "Parallaction_br::cmdOp_character(%s)", ctxt._cmd->_string);
-	_vm->changeCharacter(ctxt._cmd->_string);
+	debugC(9, kDebugExec, "Parallaction_br::cmdOp_character(%s)", ctxt._cmd->_string.c_str());
+	_vm->changeCharacter(ctxt._cmd->_string.c_str());
 }
 
 
@@ -291,7 +291,7 @@ DECLARE_COMMAND_OPCODE(give) {
 
 
 DECLARE_COMMAND_OPCODE(text) {
-	_vm->setupSubtitles(ctxt._cmd->_string, ctxt._cmd->_string2, ctxt._cmd->_zeta0);
+	_vm->setupSubtitles(ctxt._cmd->_string.c_str(), ctxt._cmd->_string2.c_str(), ctxt._cmd->_zeta0);
 }
 
 
@@ -492,7 +492,7 @@ DECLARE_INSTRUCTION_OPCODE(print) {
 
 DECLARE_INSTRUCTION_OPCODE(text) {
 	InstructionPtr inst = ctxt._inst;
-	_vm->setupSubtitles(inst->_text, inst->_text2, inst->_y);
+	_vm->setupSubtitles(inst->_text.c_str(), inst->_text2.c_str(), inst->_y);
 }
 
 

--- a/engines/parallaction/exec_ns.cpp
+++ b/engines/parallaction/exec_ns.cpp
@@ -234,7 +234,7 @@ DECLARE_COMMAND_OPCODE(get) {
 
 
 DECLARE_COMMAND_OPCODE(location) {
-	_vm->scheduleLocationSwitch(ctxt._cmd->_string);
+	_vm->scheduleLocationSwitch(ctxt._cmd->_string.c_str());
 }
 
 

--- a/engines/parallaction/gfxbase.cpp
+++ b/engines/parallaction/gfxbase.cpp
@@ -31,20 +31,12 @@
 namespace Parallaction {
 
 GfxObj::GfxObj(uint objType, Frames *frames, const char* name) :
-	_frames(frames), x(0), y(0), z(0), _prog(0), _flags(0),
+	_name(name), _frames(frames), x(0), y(0), z(0), _prog(0), _flags(0),
 	type(objType), frame(0), layer(3), scale(100), _hasMask(false), _hasPath(false),
-	transparentKey(0), _maskId(0), _pathId(0) {
-
-	if (name) {
-		_name = strdup(name);
-	} else {
-		_name = 0;
-	}
-}
+	transparentKey(0), _maskId(0), _pathId(0) {}
 
 GfxObj::~GfxObj() {
 	delete _frames;
-	free(_name);
 }
 
 void GfxObj::release() {
@@ -53,7 +45,7 @@ void GfxObj::release() {
 }
 
 const char *GfxObj::getName() const {
-	return _name;
+	return _name.c_str();
 }
 
 uint GfxObj::getNum() {

--- a/engines/parallaction/graphics.h
+++ b/engines/parallaction/graphics.h
@@ -27,6 +27,7 @@
 #include "common/rect.h"
 #include "common/hashmap.h"
 #include "common/hash-str.h"
+#include "common/str.h"
 #include "common/stream.h"
 #include "common/array.h"
 
@@ -286,7 +287,7 @@ enum {
 };
 
 class GfxObj {
-	char *_name;
+	Common::String _name;
 	Frames *_frames;
 
 public:

--- a/engines/parallaction/objects.cpp
+++ b/engines/parallaction/objects.cpp
@@ -36,7 +36,6 @@ Command::Command() {
 	_valid = false;
 
 	_flags = 0;
-	_string = 0;
 	_callable = 0;
 	_object = 0;
 	_counterValue = 0;
@@ -44,26 +43,17 @@ Command::Command() {
 	_zeta1 = 0;
 	_zeta2 = 0;
 	_characterId = 0;
-	_string2 = 0;
 	_musicCommand = 0;
 	_musicParm = 0;
 }
 
-Command::~Command() {
-	free(_string);
-	free(_string2);
-}
-
-
 Animation::Animation() {
 	gfxobj = NULL;
-	_scriptName = 0;
 	_frame = 0;
 	_z = 0;
 }
 
 Animation::~Animation() {
-	free(_scriptName);
 	if (gfxobj) {
 		gfxobj->release();
 	}
@@ -307,14 +297,7 @@ Instruction::Instruction() {
 	_endif = 0;
 
 	// BRA specific
-	_text = 0;
-	_text2 = 0;
 	_y = 0;
-}
-
-Instruction::~Instruction() {
-	free(_text);
-	free(_text2);
 }
 
 int16 ScriptVar::getValue() {
@@ -415,8 +398,9 @@ void Table::addData(const char* s) {
 	if (!(_used < _size))
 		error("Table overflow");
 
-	_data[_used++] = strdup(s);
-
+	char *data = (char *)malloc(strlen(s) + 1);
+	strcpy(data, s);
+	_data[_used++] = data;
 }
 
 uint16 Table::lookup(const char* s) {

--- a/engines/parallaction/objects.h
+++ b/engines/parallaction/objects.h
@@ -112,13 +112,12 @@ struct Command {
 	bool			_valid;
 
 	Command();
-	~Command();
 
 	// Common fields
 	uint32			_flags;
 	ZonePtr			_zone;
 	Common::String	_zoneName;
-	char*			_string;
+	Common::String	_string;
 	uint16			_callable;
 	uint16			_object;
 	Common::Point	 _move;
@@ -132,7 +131,7 @@ struct Command {
 	int				_zeta1;
 	int				_zeta2;
 	int				_characterId;
-	char*			_string2;
+	Common::String	_string2;
 	int				_musicCommand;
 	int				_musicParm;
 };
@@ -428,14 +427,12 @@ struct Instruction {
 	// BRA specific
 	byte		_colors[3];
 	ScriptVar	_opC;
-	char		*_text;
-	char		*_text2;
+	Common::String _text;
+	Common::String _text2;
 	int			_y;
 	uint32		_endif;
 
 	Instruction();
-	~Instruction();
-
 };
 
 enum {
@@ -474,7 +471,7 @@ protected:
 public:
 
 	GfxObj		*gfxobj;
-	char		*_scriptName;
+	Common::String _scriptName;
 
 	Animation();
 	virtual ~Animation();

--- a/engines/parallaction/parallaction.h
+++ b/engines/parallaction/parallaction.h
@@ -526,7 +526,7 @@ public:
 	virtual DialogueManager *createDialogueManager(ZonePtr z);
 	virtual bool processGameEvent(int event);
 
-	void setupSubtitles(char *s, char *s2, int y);
+	void setupSubtitles(const char *s, const char *s2, int y);
 	void clearSubtitles();
 
 	void testCounterCondition(const Common::String &name, int op, int value);

--- a/engines/parallaction/parallaction_br.cpp
+++ b/engines/parallaction/parallaction_br.cpp
@@ -430,8 +430,8 @@ void Parallaction_br::parseLocation(const char *filename) {
 		restoreOrSaveZoneFlags(*ait, visited);
 
 		// load the script
-		if ((*ait)->_scriptName) {
-			loadProgram(*ait, (*ait)->_scriptName);
+		if (!(*ait)->_scriptName.empty()) {
+			loadProgram(*ait, (*ait)->_scriptName.c_str());
 		}
 	}
 

--- a/engines/parallaction/parallaction_ns.cpp
+++ b/engines/parallaction/parallaction_ns.cpp
@@ -46,17 +46,12 @@ class LocationName {
 
 	bool _hasCharacter;
 	bool _hasSlide;
-	char *_buf;
+	Common::String _buf;
 
 public:
 	LocationName() {
-		_buf = 0;
 		_hasSlide = false;
 		_hasCharacter = false;
-	}
-
-	~LocationName() {
-		free(_buf);
 	}
 
 	void bind(const char*);
@@ -82,7 +77,7 @@ public:
 	}
 
 	const char *c_str() const {
-		return _buf;
+		return _buf.c_str();
 	}
 };
 
@@ -106,15 +101,12 @@ public:
 	is commented out, and would definitely crash the current implementation.
 */
 void LocationName::bind(const char *s) {
-
-	free(_buf);
-
-	_buf = strdup(s);
+	_buf = s;
 	_hasSlide = false;
 	_hasCharacter = false;
 
 	Common::StringArray list;
-	char *tok = strtok(_buf, ".");
+	char *tok = strtok(_buf.begin(), ".");
 	while (tok) {
 		list.push_back(tok);
 		tok = strtok(NULL, ".");
@@ -139,8 +131,7 @@ void LocationName::bind(const char *s) {
 	}
 
 	_location = list[0];
-
-	strcpy(_buf, s);		// kept as reference
+	_buf = s;		// kept as reference
 }
 
 Parallaction_ns::Parallaction_ns(OSystem* syst, const PARALLACTIONGameDescription *gameDesc) : Parallaction(syst, gameDesc),
@@ -454,8 +445,8 @@ void Parallaction_ns::parseLocation(const char *filename) {
 	// this loads animation scripts
 	AnimationList::iterator it = _location._animations.begin();
 	for ( ; it != _location._animations.end(); ++it) {
-		if ((*it)->_scriptName) {
-			loadProgram(*it, (*it)->_scriptName);
+		if (!(*it)->_scriptName.empty()) {
+			loadProgram(*it, (*it)->_scriptName.c_str());
 		}
 	}
 

--- a/engines/parallaction/parser_br.cpp
+++ b/engines/parallaction/parser_br.cpp
@@ -519,7 +519,7 @@ DECLARE_COMMAND_PARSER(location)  {
 
 	createCommand(_parser->_lookup);
 
-	ctxt.cmd->_string = strdup(_tokens[1]);
+	ctxt.cmd->_string = _tokens[1];
 	ctxt.nextToken++;
 
 	ctxt.cmd->_startPos.x = -1000;
@@ -550,7 +550,7 @@ DECLARE_COMMAND_PARSER(string)  {
 
 	createCommand(_parser->_lookup);
 
-	ctxt.cmd->_string = strdup(_tokens[1]);
+	ctxt.cmd->_string = _tokens[1];
 	ctxt.nextToken++;
 
 	parseCommandFlags();
@@ -685,11 +685,11 @@ DECLARE_COMMAND_PARSER(text)  {
 		ctxt.cmd->_zeta0 = -1;
 	}
 
-	ctxt.cmd->_string = strdup(_tokens[ctxt.nextToken]);
+	ctxt.cmd->_string = _tokens[ctxt.nextToken];
 	ctxt.nextToken++;
 
 	if (_tokens[ctxt.nextToken][0] != '\0' && scumm_stricmp("flags", _tokens[ctxt.nextToken])) {
-		ctxt.cmd->_string2 = strdup(_tokens[ctxt.nextToken]);
+		ctxt.cmd->_string2 = _tokens[ctxt.nextToken];
 		ctxt.nextToken++;
 	}
 
@@ -1011,11 +1011,11 @@ DECLARE_INSTRUCTION_PARSER(text)  {
 		ctxt.inst->_y = -1;
 	}
 
-	ctxt.inst->_text = strdup(_tokens[_si]);
+	ctxt.inst->_text = _tokens[_si];
 	_si++;
 
 	if (_tokens[_si][0] != '\0' && scumm_stricmp("flags", _tokens[_si])) {
-		ctxt.inst->_text2 = strdup(_tokens[_si]);
+		ctxt.inst->_text2 = _tokens[_si];
 	}
 	ctxt.inst->_index = _parser->_lookup;
 

--- a/engines/parallaction/parser_ns.cpp
+++ b/engines/parallaction/parser_ns.cpp
@@ -195,7 +195,7 @@ void LocationParser_ns::warning_unexpected() {
 DECLARE_ANIM_PARSER(script)  {
 	debugC(7, kDebugParser, "ANIM_PARSER(script) ");
 
-	ctxt.a->_scriptName = strdup(_tokens[1]);
+	ctxt.a->_scriptName = _tokens[1];
 }
 
 
@@ -643,7 +643,7 @@ DECLARE_COMMAND_PARSER(location)  {
 
 	createCommand(_parser->_lookup);
 
-	ctxt.cmd->_string = strdup(_tokens[ctxt.nextToken]);
+	ctxt.cmd->_string = _tokens[ctxt.nextToken];
 	ctxt.nextToken++;
 
 	parseCommandFlags();

--- a/engines/parallaction/walk.cpp
+++ b/engines/parallaction/walk.cpp
@@ -585,7 +585,7 @@ void PathWalker_BR::doWalk(State &s) {
 
 	if (s._walkDelay > 0) {
 		s._walkDelay--;
-		if (s._walkDelay == 0 && s._a->_scriptName) {
+		if (s._walkDelay == 0 && !s._a->_scriptName.empty()) {
 			// stop script and reset
 			s._a->_flags &= ~kFlagsActing;
 //			_vm->_programExec->resetProgram(s._a->_scriptName);

--- a/engines/scumm/smush/smush_font.cpp
+++ b/engines/scumm/smush/smush_font.cpp
@@ -22,6 +22,7 @@
 
 
 #include "common/file.h"
+#include "common/str.h"
 #include "scumm/scumm.h"
 #include "scumm/util.h"
 
@@ -226,11 +227,11 @@ void SmushFont::drawStringWrap(const char *str, byte *buffer, int dst_width, int
 	debugC(DEBUG_SMUSH, "SmushFont::drawStringWrap(%s, %d, %d, %d, %d, %d)", str, x, y, left, right, center);
 
 	const int width = right - left;
-	char *s = strdup(str);
+	Common::String s(str);
 	char *words[MAX_WORDS];
 	int word_count = 0;
 
-	char *tmp = s;
+	Common::String::iterator tmp = s.begin();
 	while (tmp) {
 		assert(word_count < MAX_WORDS);
 		words[word_count++] = tmp;
@@ -293,8 +294,6 @@ void SmushFont::drawStringWrap(const char *str, byte *buffer, int dst_width, int
 			y += getStringHeight(substrings[i]);
 		}
 	}
-
-	free(s);
 }
 
 } // End of namespace Scumm

--- a/engines/sword2/maketext.cpp
+++ b/engines/sword2/maketext.cpp
@@ -83,7 +83,7 @@ namespace Sword2 {
  *         error-signal character (chequered flag)
  */
 
-byte *FontRenderer::makeTextSprite(byte *sentence, uint16 maxWidth, uint8 pen, uint32 fontRes, uint8 border) {
+byte *FontRenderer::makeTextSprite(const byte *sentence, uint16 maxWidth, uint8 pen, uint32 fontRes, uint8 border) {
 	debug(5, "makeTextSprite(\"%s\", maxWidth=%u)", sentence, maxWidth);
 
 	_borderPen = border;
@@ -123,7 +123,7 @@ byte *FontRenderer::makeTextSprite(byte *sentence, uint16 maxWidth, uint8 pen, u
 	return textSprite;
 }
 
-uint16 FontRenderer::analyzeSentence(byte *sentence, uint16 maxWidth, uint32 fontRes, LineInfo *line) {
+uint16 FontRenderer::analyzeSentence(const byte *sentence, uint16 maxWidth, uint32 fontRes, LineInfo *line) {
 	// joinWidth = how much extra space is needed to append a word to a
 	// line. NB. SPACE requires TWICE the '_charSpacing' to join a word
 	// to line
@@ -207,7 +207,7 @@ uint16 FontRenderer::analyzeSentence(byte *sentence, uint16 maxWidth, uint32 fon
  *         error-signal character (chequered flag)
  */
 
-byte *FontRenderer::buildTextSprite(byte *sentence, uint32 fontRes, uint8 pen, LineInfo *line, uint16 noOfLines) {
+byte *FontRenderer::buildTextSprite(const byte *sentence, uint32 fontRes, uint8 pen, LineInfo *line, uint16 noOfLines) {
 	uint16 i;
 
 	// Find the width of the widest line in the output text

--- a/engines/sword2/maketext.h
+++ b/engines/sword2/maketext.h
@@ -91,8 +91,8 @@ private:
 				// each line - negative for overlap
 	uint8 _borderPen;	// output pen color of character borders
 
-	uint16 analyzeSentence(byte *sentence, uint16 maxWidth, uint32 fontRes, LineInfo *line);
-	byte *buildTextSprite(byte *sentence, uint32 fontRes, uint8 pen, LineInfo *line, uint16 noOfLines);
+	uint16 analyzeSentence(const byte *sentence, uint16 maxWidth, uint32 fontRes, LineInfo *line);
+	byte *buildTextSprite(const byte *sentence, uint32 fontRes, uint8 pen, LineInfo *line, uint16 noOfLines);
 	uint16 charWidth(byte ch, uint32 fontRes);
 	uint16 charHeight(uint32 fontRes);
 	byte *findChar(byte ch, byte *charSet);
@@ -109,7 +109,7 @@ public:
 			free(_blocList[i].text_mem);
 	}
 
-	byte *makeTextSprite(byte *sentence, uint16 maxWidth, uint8 pen, uint32 fontRes, uint8 border = BORDER_PEN);
+	byte *makeTextSprite(const byte *sentence, uint16 maxWidth, uint8 pen, uint32 fontRes, uint8 border = BORDER_PEN);
 
 	void killTextBloc(uint32 bloc_number);
 	void printTextBlocs();

--- a/engines/sword2/screen.cpp
+++ b/engines/sword2/screen.cpp
@@ -845,22 +845,18 @@ enum {
 };
 
 struct CreditsLine {
-	char *str;
+	Common::String str;
 	byte type;
 	int top;
 	int height;
 	byte *sprite;
 
 	CreditsLine() {
-		str = NULL;
 		sprite = NULL;
 	}
 
 	~CreditsLine() {
-		free(str);
 		free(sprite);
-		str = NULL;
-		sprite = NULL;
 	}
 };
 
@@ -1036,7 +1032,7 @@ void Screen::rollCredits() {
 				creditsLines[lineCount]->top = lineTop;
 				creditsLines[lineCount]->height = CREDITS_FONT_HEIGHT;
 				creditsLines[lineCount]->type = LINE_LEFT;
-				creditsLines[lineCount]->str = strdup(line);
+				creditsLines[lineCount]->str = line;
 
 				lineCount++;
 				*center_mark = '^';
@@ -1063,7 +1059,7 @@ void Screen::rollCredits() {
 			lineTop += CREDITS_LINE_SPACING;
 		}
 
-		creditsLines[lineCount]->str = strdup(line);
+		creditsLines[lineCount]->str = line;
 		lineCount++;
 	}
 
@@ -1113,7 +1109,7 @@ void Screen::rollCredits() {
 			// Free any sprites that have scrolled off the screen
 
 			if (creditsLines[i]->top + creditsLines[i]->height < scrollPos) {
-				debug(2, "Freeing line %d: '%s'", i, creditsLines[i]->str);
+				debug(2, "Freeing line %d: '%s'", i, creditsLines[i]->str.c_str());
 
 				delete creditsLines[i];
 				creditsLines[i] = NULL;
@@ -1121,8 +1117,8 @@ void Screen::rollCredits() {
 				startLine = i + 1;
 			} else if (creditsLines[i]->top < scrollPos + 400) {
 				if (!creditsLines[i]->sprite) {
-					debug(2, "Creating line %d: '%s'", i, creditsLines[i]->str);
-					creditsLines[i]->sprite = _vm->_fontRenderer->makeTextSprite((byte *)creditsLines[i]->str, 600, 14, _vm->_speechFontId, 0);
+					debug(2, "Creating line %d: '%s'", i, creditsLines[i]->str.c_str());
+					creditsLines[i]->sprite = _vm->_fontRenderer->makeTextSprite((byte *)creditsLines[i]->str.c_str(), 600, 14, _vm->_speechFontId, 0);
 				}
 
 				FrameHeader frame;
@@ -1143,7 +1139,7 @@ void Screen::rollCredits() {
 					spriteInfo.x = RENDERWIDE / 2 + 5;
 					break;
 				case LINE_CENTER:
-					if (strcmp(creditsLines[i]->str, "@") == 0) {
+					if (strcmp(creditsLines[i]->str.c_str(), "@") == 0) {
 						spriteInfo.data = logoData;
 						spriteInfo.x = (RENDERWIDE - logoWidth) / 2;
 						spriteInfo.w = logoWidth;

--- a/graphics/fonts/bdf.cpp
+++ b/graphics/fonts/bdf.cpp
@@ -411,8 +411,8 @@ BdfFont *BdfFont::loadFont(Common::SeekableReadStream &stream) {
 				boxes[encoding] = box;
 			}
 		} else if (line.hasPrefix("FAMILY_NAME \"")) {
-			familyName = new char[line.size()]; // We will definitely fit here
-			Common::strlcpy(familyName, &line.c_str()[13], line.size());
+			familyName = new char[line.size()];
+			Common::strlcpy(familyName, line.c_str() + 13, line.size() - 13);
 			char *p = &familyName[strlen(familyName)];
 			while (p != familyName && *p != '"')
 				p--;
@@ -428,8 +428,8 @@ BdfFont *BdfFont::loadFont(Common::SeekableReadStream &stream) {
 			}
 			*p = '\0'; // Remove last quote
 		} else if (line.hasPrefix("SLANT \"")) {
-			slant = new char[line.size()]; // We will definitely fit here
-			Common::strlcpy(slant, &line.c_str()[7], line.size());
+			slant = new char[line.size()];
+			Common::strlcpy(slant, line.c_str() + 7, line.size() - 7);
 			char *p = &slant[strlen(slant)];
 			while (p != slant && *p != '"')
 				p--;

--- a/graphics/fonts/bdf.cpp
+++ b/graphics/fonts/bdf.cpp
@@ -700,6 +700,15 @@ BdfFont *BdfFont::loadFromCache(Common::SeekableReadStream &stream) {
 	return new BdfFont(data, DisposeAfterUse::YES);
 }
 
+static char *new_strdup(const char *in) {
+	const size_t len = strlen(in) + 1;
+	char *out = new char[len];
+	if (out) {
+		strcpy(out, in);
+	}
+	return out;
+}
+
 BdfFont *BdfFont::scaleFont(BdfFont *src, int newSize) {
 	if (!src) {
 		warning("Empty font reference in scale font");
@@ -725,8 +734,8 @@ BdfFont *BdfFont::scaleFont(BdfFont *src, int newSize) {
 	data.firstCharacter = src->_data.firstCharacter;
 	data.defaultCharacter = src->_data.defaultCharacter;
 	data.numCharacters = src->_data.numCharacters;
-	data.familyName = strdup(src->_data.familyName);
-	data.slant = strdup(src->_data.slant);
+	data.familyName = new_strdup(src->_data.familyName);
+	data.slant = new_strdup(src->_data.slant);
 
 	BdfBoundingBox *boxes = new BdfBoundingBox[data.numCharacters];
 	for (int i = 0; i < data.numCharacters; ++i) {

--- a/graphics/fonts/bdf.cpp
+++ b/graphics/fonts/bdf.cpp
@@ -700,15 +700,6 @@ BdfFont *BdfFont::loadFromCache(Common::SeekableReadStream &stream) {
 	return new BdfFont(data, DisposeAfterUse::YES);
 }
 
-static char *new_strdup(const char *in) {
-	const size_t len = strlen(in) + 1;
-	char *out = new char[len];
-	if (out) {
-		strcpy(out, in);
-	}
-	return out;
-}
-
 BdfFont *BdfFont::scaleFont(BdfFont *src, int newSize) {
 	if (!src) {
 		warning("Empty font reference in scale font");
@@ -734,8 +725,8 @@ BdfFont *BdfFont::scaleFont(BdfFont *src, int newSize) {
 	data.firstCharacter = src->_data.firstCharacter;
 	data.defaultCharacter = src->_data.defaultCharacter;
 	data.numCharacters = src->_data.numCharacters;
-	data.familyName = new_strdup(src->_data.familyName);
-	data.slant = new_strdup(src->_data.slant);
+	data.familyName = scumm_strdup(src->_data.familyName);
+	data.slant = scumm_strdup(src->_data.slant);
 
 	BdfBoundingBox *boxes = new BdfBoundingBox[data.numCharacters];
 	for (int i = 0; i < data.numCharacters; ++i) {

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -51,7 +51,6 @@ namespace GUI {
 Debugger::Debugger() {
 	_frameCountdown = 0;
 	_isActive = false;
-	_errStr = NULL;
 	_firstTime = true;
 #ifndef USE_TEXT_CONSOLE_FOR_DEBUGGER
 	_debuggerDialog = new GUI::ConsoleDialog(1.0f, 0.67f);
@@ -159,8 +158,7 @@ void Debugger::attach(const char *entry) {
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
 
 	// Set error string (if any)
-	free(_errStr);
-	_errStr = entry ? strdup(entry) : 0;
+	_errStr = entry ? entry : "";
 
 	// Reset frame countdown (i.e. attach immediately)
 	_frameCountdown = 1;
@@ -224,10 +222,9 @@ void Debugger::enter() {
 		_firstTime = false;
 	}
 
-	if (_errStr) {
-		debugPrintf("ERROR: %s\n\n", _errStr);
-		free(_errStr);
-		_errStr = NULL;
+	if (_errStr.size()) {
+		debugPrintf("ERROR: %s\n\n", _errStr.c_str());
+		_errStr.clear();
 	}
 
 	_debuggerDialog->runModal();
@@ -293,19 +290,16 @@ bool Debugger::parseCommand(const char *inputOrig) {
 	const char *param[256];
 
 	// Parse out any params
-	// One of the rare occasions using strdup is OK, since splitCommands needs to modify it
-	char *input = strdup(inputOrig);
+	Common::String input(inputOrig);
 	splitCommand(input, num_params, &param[0]);
 
 	if (num_params == 0) {
-		free(input);
 		return true;
 	}
 
 	// Handle commands first
 	bool result;
 	if (handleCommand(num_params, param, result)) {
-		free(input);
 		return result;
 	}
 
@@ -390,23 +384,21 @@ bool Debugger::parseCommand(const char *inputOrig) {
 				}
 			}
 
-			free(input);
 			return true;
 		}
 	}
 
 	debugPrintf("Unknown command or variable\n");
-	free(input);
 	return true;
 }
 
-void Debugger::splitCommand(char *input, int &argc, const char **argv) {
+void Debugger::splitCommand(Common::String &input, int &argc, const char **argv) {
 	byte c;
 	enum states { DULL, IN_WORD, IN_STRING } state = DULL;
 	const char *paramStart = nullptr;
 
 	argc = 0;
-	for (char *p = input; *p; ++p) {
+	for (Common::String::iterator p = input.begin(); *p; ++p) {
 		c = (byte)*p;
 
 		switch (state) {

--- a/gui/debugger.h
+++ b/gui/debugger.h
@@ -28,6 +28,7 @@
 #include "common/hashmap.h"
 #include "common/hash-str.h"
 #include "common/array.h"
+#include "common/str.h"
 #include "common/str-array.h"
 
 namespace GUI {
@@ -161,7 +162,7 @@ private:
 	 */
 	bool _isActive;
 
-	char *_errStr;
+	Common::String _errStr;
 
 	/**
 	 * Initially true, set to false when Debugger::enter is called
@@ -208,7 +209,7 @@ private:
 	 * Splits up the input into individual parameters
 	 * @remarks		Adapted from code provided by torek on StackOverflow
 	 */
-	void splitCommand(char *input, int &argc, const char **argv);
+	void splitCommand(Common::String &input, int &argc, const char **argv);
 
 	bool parseCommand(const char *input);
 	bool tabComplete(const char *input, Common::String &completion) const;


### PR DESCRIPTION
>strdup is a POSIX API, not an ANSI C API. It is not available with
-std=c++11 on newlib-based systems, and VS 2015 will throw errors
unless it is #defined to alias to _strdup or unless deprecation
warnings are turned off (which is not a good idea in general).
Common::String is a safer and potentially faster (due to small
string optimisation) alternative, so prefer it instead.


Originally from PR #1128