### PR TITLE
ANDROID: Update to compile with modern NDKs

### DIFF
--- a/configure
+++ b/configure
@@ -2486,7 +2486,6 @@ case $_host_os in
 				append_var CXXFLAGS "-march=armv5te"
 				append_var CXXFLAGS "-mtune=xscale"
 				append_var CXXFLAGS "-mfloat-abi=softfp"
-				append_var LDFLAGS "-mthumb"
 				ABI="armeabi"
 				;;
 			android-v7a | android-arm-v7a)

--- a/configure
+++ b/configure
@@ -2953,7 +2953,6 @@ if test -n "$_host"; then
 			_port_mk="backends/platform/android/android.mk"
 			_build_scalers=no
 			_seq_midi=no
-			_mt32emu=no
 			_timidity=no
 			;;
 		androidsdl | androidsdl-armeabi | androidsdl-armeabi-v7a | androidsdl-mips | androidsdl-x86 | androidsdl-arm64-v8a | androidsdl-x86_64)

--- a/configure
+++ b/configure
@@ -2480,7 +2480,8 @@ case $_host_os in
 			android | android-arm)
 				append_var CXXFLAGS "-march=armv5te"
 				append_var CXXFLAGS "-mtune=xscale"
-				append_var CXXFLAGS "-msoft-float"
+				append_var CXXFLAGS "-mfloat-abi=softfp"
+				append_var LDFLAGS "-mthumb"
 				ABI="armeabi"
 				ANDROID_PLATFORM=9
 				ANDROID_PLATFORM_ARCH="arm"
@@ -2521,10 +2522,6 @@ case $_host_os in
 				;;
 		esac
 
-		# Setup platform version and arch
-		append_var CXXFLAGS "--sysroot=$ANDROID_NDK/platforms/android-$ANDROID_PLATFORM/arch-$ANDROID_PLATFORM_ARCH"
-		append_var LDFLAGS "--sysroot=$ANDROID_NDK/platforms/android-$ANDROID_PLATFORM/arch-$ANDROID_PLATFORM_ARCH"
-
 		append_var CXXFLAGS "-fpic"
 		append_var CXXFLAGS "-ffunction-sections"
 		append_var CXXFLAGS "-funwind-tables"
@@ -2535,36 +2532,9 @@ case $_host_os in
 			append_var CXXFLAGS "-fomit-frame-pointer"
 			append_var CXXFLAGS "-fstrict-aliasing"
 		fi
-		append_var CXXFLAGS "-finline-limit=300"
 		_optimization_level=-Os
 
-		if test "$_host" = android -o "$_host" = android-arm; then
-			append_var CXXFLAGS "-mthumb-interwork"
-			# FIXME: Why is the following in CXXFLAGS and not in DEFINES? Change or document this.
-			append_var CXXFLAGS "-D__ARM_ARCH_5__"
-			append_var CXXFLAGS "-D__ARM_ARCH_5T__"
-			append_var CXXFLAGS "-D__ARM_ARCH_5E__"
-			append_var CXXFLAGS "-D__ARM_ARCH_5TE__"
-		fi
-
-		# surpress 'mangling of 'va_list' has changed in GCC 4.4' warning
-		append_var CXXFLAGS "-Wno-psabi"
-
-		if test "$_host" = android -o "$_host" = android-arm; then
-			append_var LDFLAGS "-mthumb-interwork"
-		fi
-
-		append_var INCLUDES "-isystem $ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/`$CXX -dumpversion`/include/"
-		append_var INCLUDES "-isystem $ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/`$CXX -dumpversion`/libs/$ABI/include/"
-		append_var LDFLAGS "-L$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/`$CXX -dumpversion`/libs/$ABI/"
-		append_var LIBS "-lsupc++"
 		add_line_to_config_mk "ANDROID_SDK = $ANDROID_SDK"
-		if test -d "$ANDROID_SDK"/build-tools; then
-			_build_tools_version=`cd "$ANDROID_SDK"/build-tools && ls -1 | sort -rn | head -1`
-			add_line_to_config_mk "ANDROID_BTOOLS = build-tools/$_build_tools_version"
-		else
-			add_line_to_config_mk "ANDROID_BTOOLS = platform-tools"
-		fi
 		_seq_midi=no
 		;;
 	beos*)

--- a/configure
+++ b/configure
@@ -1483,6 +1483,11 @@ android | android-arm | android-v7a | android-arm-v7a | ouya)
 	_host_cpu=arm
 	_host_alias=arm-linux-androideabi
 	;;
+android-arm64-v8a)
+	_host_os=android
+	_host_cpu=aarch64
+	_host_alias=aarch64-linux-android
+	;;
 android-mips)
 	_host_os=android
 	_host_cpu=mipsel
@@ -2483,8 +2488,6 @@ case $_host_os in
 				append_var CXXFLAGS "-mfloat-abi=softfp"
 				append_var LDFLAGS "-mthumb"
 				ABI="armeabi"
-				ANDROID_PLATFORM=9
-				ANDROID_PLATFORM_ARCH="arm"
 				;;
 			android-v7a | android-arm-v7a)
 				append_var CXXFLAGS "-march=armv7-a"
@@ -2492,24 +2495,21 @@ case $_host_os in
 				append_var CXXFLAGS "-mfpu=vfp"
 				append_var LDFLAGS "-Wl,--fix-cortex-a8"
 				ABI="armeabi-v7a"
-				ANDROID_PLATFORM=9
-				ANDROID_PLATFORM_ARCH="arm"
+				;;
+			android-arm64-v8a)
+				ABI="arm64-v8a"
 				;;
 			android-mips)
 				append_var CXXFLAGS "-march=mips32"
 				append_var CXXFLAGS "-mtune=mips32"
 				ABI="mips"
 				# Platform version 9 is needed as earlier versions of platform do not support this arch.
-				ANDROID_PLATFORM=9
-				ANDROID_PLATFORM_ARCH="mips"
 				;;
 			android-x86)
 				append_var CXXFLAGS "-march=i686"
 				append_var CXXFLAGS "-mtune=i686"
 				ABI="x86"
 				# Platform version 9 is needed as earlier versions of platform do not support this arch.
-				ANDROID_PLATFORM=9
-				ANDROID_PLATFORM_ARCH="x86"
 				;;
 			ouya)
 				append_var CXXFLAGS "-march=armv7-a"
@@ -2517,8 +2517,6 @@ case $_host_os in
 				append_var CXXFLAGS "-mfloat-abi=softfp"
 				append_var CXXFLAGS "-mfpu=neon"
 				ABI="armeabi-v7a"
-				ANDROID_PLATFORM=16
-				ANDROID_PLATFORM_ARCH="arm"
 				;;
 		esac
 
@@ -2943,7 +2941,7 @@ if test -n "$_host"; then
 			_vorbis=no
 			_port_mk="backends/platform/3ds/3ds.mk"
 			;;
-		android | android-arm | android-v7a | android-arm-v7a | android-mips | android-x86 | ouya)
+		android | android-arm | android-v7a | android-arm-v7a | android-arm64-v8a | android-mips | android-x86 | ouya)
 			# we link a .so as default
 			append_var LDFLAGS "-shared"
 			append_var LDFLAGS "-Wl,-Bsymbolic,--no-undefined"


### PR DESCRIPTION
This will probably require a toolchain update on our current buildbot.

Originally from PR #1128