### PR TITLE
WINTERMUTE: Printable flag fix, more keyboard mapping, array index check at vKeyToKeyCode()

### DIFF
--- a/engines/wintermute/base/base_keyboard_state.cpp
+++ b/engines/wintermute/base/base_keyboard_state.cpp
@@ -32,6 +32,8 @@
 #include "common/system.h"
 #include "common/keyboard.h"
 
+#define KEYSTATES_ARRAY_SIZE (Common::KEYCODE_UNDO + 1) // Hardcoded size for the common/keyboard.h enum
+
 namespace Wintermute {
 
 IMPLEMENT_PERSISTENT(BaseKeyboardState, false)
@@ -46,8 +48,8 @@ BaseKeyboardState::BaseKeyboardState(BaseGame *inGame) : BaseScriptable(inGame) 
 	_currentAlt = false;
 	_currentControl = false;
 
-	_keyStates = new uint8[323]; // Hardcoded size for the common/keyboard.h enum
-	for (int i = 0; i < 323; i++) {
+	_keyStates = new uint8[KEYSTATES_ARRAY_SIZE];
+	for (int i = 0; i < KEYSTATES_ARRAY_SIZE; i++) {
 		_keyStates[i] = false;
 	}
 }
@@ -499,7 +501,7 @@ Common::KeyCode BaseKeyboardState::vKeyToKeyCode(uint32 vkey) {
 		return Common::KEYCODE_SCROLLOCK;
 	default:
 		warning("Unknown VKEY: %d", vkey);
-		return (Common::KeyCode)vkey;
+		return (Common::KeyCode)(vkey < KEYSTATES_ARRAY_SIZE ? vkey : 0);
 		break;
 	}
 

--- a/engines/wintermute/base/base_keyboard_state.cpp
+++ b/engines/wintermute/base/base_keyboard_state.cpp
@@ -297,18 +297,24 @@ bool BaseKeyboardState::isCurrentPrintable() const {
 enum VKeyCodes {
 	kVkBack       = 8,  //printable
 	kVkTab        = 9,  //printable
+	kVkClear      = 12,
 	kVkReturn     = 13, //printable
 	kVkPause      = 19,
+	kVkCapital    = 20,
 	kVkEscape     = 27, //printable
 	kVkSpace      = 32, //printable
 
+	kVkPrior      = 33,
+	kVkNext       = 34,
 	kVkEnd        = 35,
 	kVkHome       = 36,
 	kVkLeft       = 37,
 	kVkUp         = 38,
 	kVkRight      = 39,
 	kVkDown       = 40,
+	kVkPrint      = 42,
 	kVkInsert     = 45,
+	kVkDelete     = 46,
 
 	kVkF1         = 112,
 	kVkF2         = 113,
@@ -321,27 +327,41 @@ enum VKeyCodes {
 	kVkF9         = 120,
 	kVkF10        = 121,
 	kVkF11        = 122,
-	kVkF12        = 123
+	kVkF12        = 123,
 
+	kVkNumLock    = 144,
+	kVkScroll     = 145
+
+    //TODO: shift, ctrl, menu, etc...
 };
 
 //////////////////////////////////////////////////////////////////////////
 uint32 BaseKeyboardState::keyCodeToVKey(Common::Event *event) {
-	// todo
 	switch (event->kbd.keycode) {
 	case Common::KEYCODE_BACKSPACE:
 		return kVkBack;
 	case Common::KEYCODE_TAB:
 		return kVkTab;
+	case Common::KEYCODE_CLEAR:
+	case Common::KEYCODE_KP5:
+		return kVkClear;
 	case Common::KEYCODE_RETURN:
 	case Common::KEYCODE_KP_ENTER:
 		return kVkReturn;
 	case Common::KEYCODE_PAUSE:
 		return kVkPause;
+	case Common::KEYCODE_CAPSLOCK:
+		return kVkCapital;
 	case Common::KEYCODE_ESCAPE:
 		return kVkEscape;
 	case Common::KEYCODE_SPACE:
 		return kVkSpace;
+	case Common::KEYCODE_KP9:
+	case Common::KEYCODE_PAGEUP:
+		return kVkPrior;
+	case Common::KEYCODE_KP3:
+	case Common::KEYCODE_PAGEDOWN:
+		return kVkNext;
 	case Common::KEYCODE_END:
 	case Common::KEYCODE_KP1:
 		return kVkEnd;
@@ -360,9 +380,14 @@ uint32 BaseKeyboardState::keyCodeToVKey(Common::Event *event) {
 	case Common::KEYCODE_DOWN:
 	case Common::KEYCODE_KP2:
 		return kVkDown;
+	case Common::KEYCODE_PRINT:
+		return kVkPrint;
 	case Common::KEYCODE_INSERT:
 	case Common::KEYCODE_KP0:
 		return kVkInsert;
+	case Common::KEYCODE_DELETE:
+	case Common::KEYCODE_KP_PERIOD:
+		return kVkDelete;
 	case Common::KEYCODE_F1:
 		return kVkF1;
 	case Common::KEYCODE_F2:
@@ -387,6 +412,10 @@ uint32 BaseKeyboardState::keyCodeToVKey(Common::Event *event) {
 		return kVkF11;
 	case Common::KEYCODE_F12:
 		return kVkF12;
+	case Common::KEYCODE_NUMLOCK:
+		return kVkNumLock;
+	case Common::KEYCODE_SCROLLOCK:
+		return kVkScroll;
 	default:
 		// check if any non-sticky keys were used, otherwise key is unknown to us
 		if ((event->kbd.flags & Common::KBD_NON_STICKY) == 0) {
@@ -401,14 +430,31 @@ uint32 BaseKeyboardState::keyCodeToVKey(Common::Event *event) {
 
 //////////////////////////////////////////////////////////////////////////
 Common::KeyCode BaseKeyboardState::vKeyToKeyCode(uint32 vkey) {
-	// todo
 	switch (vkey) {
+	case kVkBack:
+		return Common::KEYCODE_BACKSPACE;
+	case kVkTab:
+		return Common::KEYCODE_TAB;
+	case kVkClear:
+		return Common::KEYCODE_CLEAR;
+	case kVkReturn:
+		return Common::KEYCODE_RETURN;
+	case kVkPause:
+		return Common::KEYCODE_PAUSE;
+	case kVkCapital:
+		return Common::KEYCODE_CAPSLOCK;
 	case kVkEscape:
 		return Common::KEYCODE_ESCAPE;
 	case kVkSpace:
 		return Common::KEYCODE_SPACE;
+	case kVkPrior:
+		return Common::KEYCODE_PAGEUP;
+	case kVkNext:
+		return Common::KEYCODE_PAGEDOWN;
 	case kVkHome:
 		return Common::KEYCODE_HOME;
+	case kVkEnd:
+		return Common::KEYCODE_END;
 	case kVkLeft:
 		return Common::KEYCODE_LEFT;
 	case kVkRight:
@@ -417,6 +463,12 @@ Common::KeyCode BaseKeyboardState::vKeyToKeyCode(uint32 vkey) {
 		return Common::KEYCODE_UP;
 	case kVkDown:
 		return Common::KEYCODE_DOWN;
+	case kVkPrint:
+		return Common::KEYCODE_PRINT;
+	case kVkInsert:
+		return Common::KEYCODE_INSERT;
+	case kVkDelete:
+		return Common::KEYCODE_DELETE;
 	case kVkF1:
 		return Common::KEYCODE_F1;
 	case kVkF2:
@@ -441,6 +493,10 @@ Common::KeyCode BaseKeyboardState::vKeyToKeyCode(uint32 vkey) {
 		return Common::KEYCODE_F11;
 	case kVkF12:
 		return Common::KEYCODE_F12;
+	case kVkNumLock:
+		return Common::KEYCODE_NUMLOCK;
+	case kVkScroll:
+		return Common::KEYCODE_SCROLLOCK;
 	default:
 		warning("Unknown VKEY: %d", vkey);
 		return (Common::KeyCode)vkey;


### PR DESCRIPTION
1. _currentPrintable was set depending on _currentCharCode, which is 112
for both F1 and 'p' keys, fixed after detailed research on which keys
should be considered printable
2. some keypresses was producing warnings because was not listed in
mappings, added
3. vKeyToKeyCode was not safe if vkey > KEYSTATES_ARRAY_SIZE was
provided, fixed