### PR TITLE
 BUILD: Modernize default code optimization strategy

### DIFF
--- a/configure
+++ b/configure
@@ -2832,6 +2832,7 @@ case $_host_os in
 		append_var CXXFLAGS "-march=armv3m"
 		append_var CXXFLAGS "-mtune=xscale"
 		append_var LDFLAGS "-static"
+		_optimization_level=-O2
 		append_var CXXFLAGS "-ffunction-sections"
 		append_var CXXFLAGS "-fdata-sections"
 		append_var LDFLAGS "-Wl,--gc-sections"

--- a/configure
+++ b/configure
@@ -3018,10 +3018,6 @@ if test -n "$_host"; then
 			if test "$_release_build" = yes -o "$_debug_build" != yes; then
 				append_var DEFINES "-DNOSERIAL"
 			fi
-			append_var CXXFLAGS "-funroll-loops"
-			append_var CXXFLAGS "-fschedule-insns2"
-			append_var CXXFLAGS "-fomit-frame-pointer"
-			append_var CXXFLAGS "-fdelete-null-pointer-checks"
 			_backend="dc"
 			_build_scalers=no
 			_port_mk="backends/platform/dc/dreamcast.mk"

--- a/configure
+++ b/configure
@@ -196,7 +196,6 @@ _plugin_prefix=
 _plugin_suffix=
 _nasm=auto
 _optimization_level=
-_default_optimization_level=-O2
 _nuked_opl=yes
 # Default commands
 _ranlib=ranlib
@@ -1703,20 +1702,6 @@ else
 	_windres=$_host_alias-windres
 fi
 
-case $_host in
-caanoo | gp2x | gp2xwiz | openpandora | ps2 | psp2)
-	if test "$_debug_build" = auto; then
-		# If you want to debug one of these platforms, use '--disable-optimizations --enable-debug'
-		_debug_build=no
-	fi
-
-	if test "$_optimizations" = auto; then
-		# Enable optimizations by default.
-		_optimizations=yes
-	fi
-	;;
-esac
-
 #
 # Determine extension used for executables
 #
@@ -2414,7 +2399,6 @@ echo_n "Checking hosttype... "
 echo $_host_os
 case $_host_os in
 	3ds)
-		_optimization_level=-O2
 		append_var DEFINES "-D__3DS__"
 		append_var DEFINES "-DARM"
 		append_var DEFINES "-DARM11"
@@ -2507,7 +2491,6 @@ case $_host_os in
 			append_var CXXFLAGS "-fstrict-aliasing"
 		fi
 		append_var CXXFLAGS "-finline-limit=300"
-		_optimization_level=-Os
 
 		if test "$_host" = android -o "$_host" = android-arm; then
 			append_var CXXFLAGS "-mthumb-interwork"
@@ -2705,7 +2688,6 @@ case $_host_os in
 		append_var CXXFLAGS "-I/usr/local/include"
 		;;
 	gamecube)
-		_optimization_level=-Os
 		append_var CXXFLAGS "-mogc"
 		append_var CXXFLAGS "-mcpu=750"
 		append_var CXXFLAGS "-meabi"
@@ -2815,14 +2797,7 @@ case $_host_os in
 		append_var CXXFLAGS "-fno-optimize-sibling-calls"
 		#the next line fixes "branch out of range" error in gob engine when -Os is used
 		append_var CXXFLAGS "-mlong-calls"
-		if test "$_debug_build" = no; then
-		#optimize for smallest file size. This is necessary to prevent a crash on startup
-		#due to the large executable file size when many engines are enabled
-		#for example when --enable-all-engines is used to enable all the unstable engines
-			_optimization_level=-Os
-		fi
 		if test "$_debug_build" = yes; then
-			_optimization_level=-O0
 			append_var DEFINES "-D__PSP2_DEBUG__"
 			append_var LIBS "-lpsp2shell"
 		fi
@@ -2835,7 +2810,6 @@ case $_host_os in
 		fi
 		append_var LDFLAGS "-L$PSPSDK/lib"
 		append_var LDFLAGS "-specs=$_srcdir/backends/platform/psp/psp.spec"
-		_optimization_level=-O3
 		append_var CXXFLAGS "-I$PSPSDK/include"
 		# FIXME: Why is the following in CXXFLAGS and not in DEFINES? Change or document this.
 		append_var CXXFLAGS "-D_PSP_FW_VERSION=150"
@@ -2852,7 +2826,6 @@ case $_host_os in
 		append_var CXXFLAGS "-march=armv3m"
 		append_var CXXFLAGS "-mtune=xscale"
 		append_var LDFLAGS "-static"
-		_optimization_level=-O2
 		append_var CXXFLAGS "-ffunction-sections"
 		append_var CXXFLAGS "-fdata-sections"
 		append_var LDFLAGS "-Wl,--gc-sections"
@@ -2887,7 +2860,6 @@ case $_host_os in
 		_seq_midi=no
 		;;
 	wii)
-		_optimization_level=-Os
 		append_var CXXFLAGS "-mrvl"
 		append_var CXXFLAGS "-mcpu=750"
 		append_var CXXFLAGS "-meabi"
@@ -2908,7 +2880,6 @@ case $_host_os in
 		fi
 		;;
 	wince)
-		_optimization_level=-O3
 		append_var CXXFLAGS "-fno-inline-functions"
 		append_var CXXFLAGS "-march=armv4"
 		append_var CXXFLAGS "-mtune=xscale"
@@ -2973,10 +2944,6 @@ if test -n "$_host"; then
 			;;
 		caanoo)
 			append_var DEFINES "-DCAANOO"
-			if test "$_debug_build" = no; then
-				# Use -O3 on the Caanoo for non-debug builds.
-				_optimization_level=-O3
-			fi
 			append_var CXXFLAGS "-mcpu=arm926ej-s"
 			append_var CXXFLAGS "-mtune=arm926ej-s"
 			_backend="gph"
@@ -3001,7 +2968,6 @@ if test -n "$_host"; then
 			_backend="dingux"
 			_mt32emu=no
 			_nuked_opl=no
-			_optimization_level=-O3
 			# Disable alsa midi to get the port build on OpenDingux toolchain
 			_alsa=no
 			# Disable cloud and SDL_Net due to outdated toolchain
@@ -3052,7 +3018,6 @@ if test -n "$_host"; then
 			if test "$_release_build" = yes -o "$_debug_build" != yes; then
 				append_var DEFINES "-DNOSERIAL"
 			fi
-			_optimization_level=-O3
 			append_var CXXFLAGS "-funroll-loops"
 			append_var CXXFLAGS "-fschedule-insns2"
 			append_var CXXFLAGS "-fomit-frame-pointer"
@@ -3104,7 +3069,6 @@ if test -n "$_host"; then
 			_seq_midi=no
 			_timidity=no
 			_build_scalers=yes
-			_optimization_level=-O3
 			_vkeybd=yes
 			_keymapper=yes
 			_vorbis=no
@@ -3160,7 +3124,6 @@ if test -n "$_host"; then
 			_timidity=no
 			;;
 		maemo)
-			_optimization_level=-Os
 			append_var CXXFLAGS "-mcpu=arm926ej-s"
 			append_var CXXFLAGS "-fomit-frame-pointer"
 			append_var INCLUDES "-I/usr/X11R6/include"
@@ -3249,11 +3212,6 @@ if test -n "$_host"; then
 			append_var DEFINES "-DREDUCE_MEMORY_USAGE"
 			if test "$_release_build" = no; then
 				append_var DEFINES "-DOP_DEBUG"
-			fi
-
-			# Use -O3 on the OpenPandora for optimized builds.
-			if test "$_optimizations" = yes; then
-				_optimization_level=-O3
 			fi
 
 			append_var CXXFLAGS "-march=armv7-a"
@@ -3755,28 +3713,43 @@ echo_n "Checking whether to have a verbose build... "
 echo "$_verbose_build"
 add_to_config_mk_if_yes "$_verbose_build" 'VERBOSE_BUILD = 1'
 
-
-#
-# If a specific optimization level was requested, enable optimizations
-#
-if test -n "$_optimization_level" ; then
-	# Ports will specify an optimization level and expect that to be enabled
-	if test "$_optimizations" != no ; then
-		_optimizations=yes
-	fi
-else
-	_optimization_level=$_default_optimization_level
-fi
-
 #
 # Check whether to enable optimizations
 #
+echo_n "Checking best optimization level... "
+cat > $TMPC << EOF
+int main() { return 0; }
+EOF
 if test "$_optimizations" = yes ; then
-	# Enable optimizations. This also
-	# makes it possible to use -Wuninitialized, so let's do that.
+	if test -z "$_optimization_level" ; then
+		# For pretty much all systems, -Os is the best level if it is supported
+		# by the compiler, since old devices are memory-constrained and (as a
+		# default optimization strategy) new devices are generally fastest when
+		# cache misses are minimized by keeping the code small as well.
+		cc_check_no_clean -Os && _optimization_level=-Os || _optimization_level=-O2
+		echo_n -- "$_optimization_level"
+	else
+		echo_n -- "$_optimization_level (forced)"
+	fi
 	append_var CXXFLAGS "$_optimization_level"
+
+	if cc_check_no_clean $_optimization_level -ftree-vectorize; then
+		echo_n " with auto-vectorization"
+		append_var CXXFLAGS "-ftree-vectorize"
+	fi
+	echo ""
+
+	# Enabling optimizations also makes it possible to use -Wuninitialized, so
+	# let's do that.
 	append_var CXXFLAGS "-Wuninitialized"
+elif test "$_optimizations" != no && cc_check_no_clean -Og; then
+	echo "-Og"
+	append_var CXXFLAGS "-Og"
+	append_var CXXFLAGS "-Wuninitialized"
+else
+	echo "none"
 fi
+cc_check_clean
 
 #
 # Check whether plugin support is requested and possible

--- a/configure
+++ b/configure
@@ -988,6 +988,7 @@ Optional Features:
                            optimizations)
   --enable-release-mode    enable building in release mode (without optimizations)
   --enable-optimizations   enable optimizations
+  --enable-optimizations=FLAG enable a specific optimization level (e.g. -O2)
   --enable-profiling       enable profiling
   --enable-plugins         enable the support for dynamic plugins
   --default-dynamic        make plugins dynamic by default
@@ -1354,6 +1355,11 @@ for ac_option in $@; do
 		;;
 	--disable-optimizations)
 		_optimizations=no
+		;;
+	--enable-optimizations=*)
+		arg=`echo $ac_option | cut -d '=' -f 2`
+		_optimizations=yes
+		_optimization_level=$arg
 		;;
 	--enable-profiling)
 		_enable_prof=yes
@@ -3724,16 +3730,16 @@ if test "$_optimizations" = yes ; then
 		# cache misses are minimized by keeping the code small as well.
 		cc_check_no_clean -Os && _optimization_level=-Os || _optimization_level=-O2
 		echo_n -- "$_optimization_level"
+
+		if cc_check_no_clean $_optimization_level -ftree-vectorize; then
+			echo_n " with auto-vectorization"
+			append_var CXXFLAGS "-ftree-vectorize"
+		fi
 	else
 		echo_n -- "$_optimization_level (forced)"
 	fi
-	append_var CXXFLAGS "$_optimization_level"
-
-	if cc_check_no_clean $_optimization_level -ftree-vectorize; then
-		echo_n " with auto-vectorization"
-		append_var CXXFLAGS "-ftree-vectorize"
-	fi
 	echo ""
+	append_var CXXFLAGS "$_optimization_level"
 
 	# Enabling optimizations also makes it possible to use -Wuninitialized, so
 	# let's do that.

--- a/configure
+++ b/configure
@@ -2132,9 +2132,7 @@ esac
 # If possible, we want to use -Wglobal-constructors
 # However, not all compilers support that, so check whether the active one does.
 echocheck "whether C++ compiler accepts -Wglobal-constructors"
-cat > $TMPC << EOF
-int main() { return 0; }
-EOF
+echo "int main() { return 0; }" > $TMPC
 cc_check -Wglobal-constructors -Werror && _global_constructors=yes
 
 if test "$_global_constructors" = yes; then
@@ -2149,9 +2147,7 @@ echo $_global_constructors
 # Note: we check the -Wundefined-var-template as gcc does not error out on unknown
 # -Wno-xxx flags.
 echocheck "whether C++ compiler accepts -Wno-undefined-var-template"
-cat > $TMPC << EOF
-int main() { return 0; }
-EOF
+echo "int main() { return 0; }" > $TMPC
 cc_check -Wundefined-var-template -Werror && _no_undefined_var_template=yes
 
 if test "$_no_undefined_var_template" = yes; then
@@ -3720,9 +3716,7 @@ add_to_config_mk_if_yes "$_verbose_build" 'VERBOSE_BUILD = 1'
 # Check whether to enable optimizations
 #
 echo_n "Checking best optimization level... "
-cat > $TMPC << EOF
-int main() { return 0; }
-EOF
+echo "int main() { return 0; }" > $TMPC
 if test "$_optimizations" = yes ; then
 	if test -z "$_optimization_level" ; then
 		# For pretty much all systems, -Os is the best level if it is supported


### PR DESCRIPTION
> This new strategy eliminates platform-specific optimization flags
and replaces them with -Os or -O2 (plus auto-vectorization where
supported), which should provide the best balance of performance
and memory usage across pretty much all devices. It also
eliminates forced optimizations to ensure that the build system
operates in a consistent manner.
>
> When optimization is auto, the newer -Og flag will be used when
available to get "free" optimizations that don't impact debugging.

Originally from PR #1128