### PR TITLE
DINGUX: Remove dead code

### DIFF
--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -117,24 +117,6 @@ void DINGUXSdlGraphicsManager::setGraphicsModeIntern() {
 	blitCursor();
 }
 
-void DINGUXSdlGraphicsManager::initSize(uint w, uint h) {
-	assert(_transactionMode == kTransactionActive);
-
-	// Avoid redundant res changes
-	if ((int)w == _videoMode.screenWidth && (int)h == _videoMode.screenHeight)
-		return;
-
-	_videoMode.screenWidth = w;
-	_videoMode.screenHeight = h;
-	if (w > 320 || h > 240) {
-		setGraphicsMode(GFX_HALF);
-		setGraphicsModeIntern();
-		_window->toggleMouseGrab();
-	}
-
-	_transactionDetails.sizeChanged = true;
-}
-
 void DINGUXSdlGraphicsManager::drawMouse() {
 	if (!_cursorVisible || !_mouseSurface) {
 		_mouseBackup.x = _mouseBackup.y = _mouseBackup.w = _mouseBackup.h = 0;

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
@@ -41,9 +41,7 @@ public:
 	bool getFeatureState(OSystem::Feature f) const override;
 	int getDefaultGraphicsMode() const override;
 
-	void initSize(uint w, uint h) override;
 	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
-	bool setGraphicsMode(const char *name) override;
 	bool setGraphicsMode(int mode) override;
 	void setGraphicsModeIntern() override;
 	void internUpdateScreen() override;


### PR DESCRIPTION
> When compiled with C++11, it was revealed that initSize has the
wrong method signature so has not been overriding initSize
and so has not been doing anything. Apparently this is OK, since
nobody has complained about it, so just get rid of it.
>
> The setGraphicsMode(const char *) signature was also wrong, and
has no implementation code anyway.

Originally from PR #1128