### PR TITLE
 BUILD: Use split-dwarf debug symbol files by default, when available

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -8,6 +8,9 @@
 
 all: $(EXECUTABLE) plugins
 
+ifdef SPLIT_DWARF
+all: $(EXECUTABLE).dwp
+endif
 
 ######################################################################
 # Module settings
@@ -70,6 +73,7 @@ QUIET_AR      = @echo '   ' AR '     ' $@;
 QUIET_RANLIB  = @echo '   ' RANLIB ' ' $@;
 QUIET_PLUGIN  = @echo '   ' PLUGIN ' ' $@;
 QUIET_LINK    = @echo '   ' LINK '   ' $@;
+QUIET_DWP     = @echo '   ' DWP '    ' $@;
 QUIET_WINDRES = @echo '   ' WINDRES '' $@;
 QUIET         = @
 endif
@@ -80,12 +84,20 @@ endif
 $(EXECUTABLE): $(OBJS)
 	$(QUIET_LINK)$(LD) $(LDFLAGS) $(PRE_OBJS_FLAGS) $+ $(POST_OBJS_FLAGS) $(LIBS) -o $@
 
+ifdef SPLIT_DWARF
+$(EXECUTABLE).dwp: $(EXECUTABLE)
+	$(QUIET_DWP)$(DWP) -e $(EXECUTABLE)
+endif
+
 distclean: clean clean-devtools
 	$(RM) config.h config.mk config.log engines/engines.mk engines/plugins_table.h
 
 clean:
 	$(RM_REC) $(DEPDIRS)
 	$(RM) $(OBJS) $(EXECUTABLE)
+ifdef SPLIT_DWARF
+	$(RM) $(EXECUTABLE).dwp
+endif
 
 
 #

--- a/configure
+++ b/configure
@@ -1106,6 +1106,7 @@ Some influential environment variables:
                      headers in a nonstandard directory <include dir>
   CXX                C++ compiler command
   CXXFLAGS           C++ compiler flags
+  DWP                DWARF packing utility command
   LD                 linker command
   LDFLAGS            linker flags, e.g. -L<lib dir> if you have libraries in a
                      nonstandard directory <lib dir>

--- a/configure
+++ b/configure
@@ -35,6 +35,7 @@ SAVED_ASFLAGS=$ASFLAGS
 SAVED_CPPFLAGS=$CPPFLAGS
 SAVED_CXX=$CXX
 SAVED_CXXFLAGS=$CXXFLAGS
+SAVED_DWP=$DWP
 SAVED_LD=$LD
 SAVED_LDFLAGS=$LDFLAGS
 SAVED_PKG_CONFIG_LIBDIR=$PKG_CONFIG_LIBDIR
@@ -202,6 +203,7 @@ _ranlib=ranlib
 _strip=strip
 _ar="ar cru"
 _as="as"
+_dwp=dwp
 _windres=windres
 _stagingpath="staging"
 _win32path="c:/scummvm"
@@ -294,7 +296,7 @@ cc_check_no_clean() {
 }
 
 cc_check_clean() {
-	rm -rf $TMPC $TMPO $TMPO.o $TMPO.dSYM $TMPO$HOSTEXEEXT "$@"
+	rm -rf $TMPC $TMPO $TMPO.o $TMPO.dwo $TMPO.dSYM $TMPO$HOSTEXEEXT "$@"
 }
 
 cc_check() {
@@ -1130,7 +1132,7 @@ cat >> $TMPLOG <<EOF
 Invocation command line was:
 $0 $@
 Saved environment variables:
-AR="$SAVED_AR" AS="$SAVED_AS" ASFLAGS="$SAVED_ASFLAGS" CPPFLAGS="$SAVED_CPPFLAGS" CXX="$SAVED_CXX" CXXFLAGS="$SAVED_CXXFLAGS" LD="$SAVED_LD" LDFLAGS="$SAVED_LDFLAGS" PKG_CONFIG_LIBDIR="$SAVED_PKG_CONFIG_LIBDIR" RANLIB="$SAVED_RANLIB" SDL_CONFIG="$SAVED_SDL_CONFIG" STRIP="$SAVED_STRIP" WINDRES="$SAVED_WINDRES" WINDRESFLAGS="$SAVED_WINDRESFLAGS"
+AR="$SAVED_AR" AS="$SAVED_AS" ASFLAGS="$SAVED_ASFLAGS" CPPFLAGS="$SAVED_CPPFLAGS" CXX="$SAVED_CXX" CXXFLAGS="$SAVED_CXXFLAGS" DWP="$SAVED_DWP" LD="$SAVED_LD" LDFLAGS="$SAVED_LDFLAGS" PKG_CONFIG_LIBDIR="$SAVED_PKG_CONFIG_LIBDIR" RANLIB="$SAVED_RANLIB" SDL_CONFIG="$SAVED_SDL_CONFIG" STRIP="$SAVED_STRIP" WINDRES="$SAVED_WINDRES" WINDRESFLAGS="$SAVED_WINDRESFLAGS"
 EOF
 
 
@@ -1693,12 +1695,9 @@ else
 	_strip=$_host_alias-strip
 	_ar="$_host_alias-ar cru"
 	_as="$_host_alias-as"
+	_dwp=$_host_alias-dwp
 	_windres=$_host_alias-windres
 fi
-
-#
-# Determine extra build flags for debug and/or release builds
-#
 
 case $_host in
 caanoo | gp2x | gp2xwiz | openpandora | ps2 | psp2)
@@ -1713,26 +1712,6 @@ caanoo | gp2x | gp2xwiz | openpandora | ps2 | psp2)
 	fi
 	;;
 esac
-
-if test "$_debug_build" != no; then
-	# debug mode not explicitly disabled -> compile with debug information
-	case $_host_os in
-	amigaos*)
-		# AmigaOS debugger uses plain stabs, with no gdb extensions.
-		append_var CXXFLAGS "-gstabs"
-	;;
-	*)
-		# Use the system default format for debug info.
-		append_var CXXFLAGS "-g"
-	esac
-fi
-
-if test "$_release_build" = yes; then
-	# Add a define, which indicates we are doing
-	# an build for a release version.
-	append_var DEFINES "-DRELEASE_BUILD"
-fi
-
 
 #
 # Determine extension used for executables
@@ -1916,6 +1895,10 @@ if test -n "$AS"; then
 	_as=$AS
 fi
 
+if test -n "$DWP"; then
+	_dwp=$DWP
+fi
+
 if test -n "$WINDRES"; then
 	_windres=$WINDRES
 fi
@@ -2090,6 +2073,44 @@ if test "$_use_cxx11" = "yes" ; then
 	append_var CXXFLAGS "-std=c++11"
 fi
 echo $_use_cxx11
+
+#
+# Determine extra build flags for debug and/or release builds
+#
+if test "$_debug_build" != no; then
+	# debug mode not explicitly disabled -> compile with debug information
+	echo_n "Checking best debug mode... "
+
+	debug_mode=-g
+	test "$_host_os" = amigaos && debug_mode=-gstabs
+	append_var CXXFLAGS "$debug_mode"
+	echo_n -- "$debug_mode"
+
+	echo "int main() { return 0; }" > $TMPC
+	if `which $_dwp >/dev/null 2>&1` && cc_check_no_clean $debug_mode -gsplit-dwarf && `$_dwp -e $TMPO -o /dev/null >/dev/null 2>&1`; then
+		append_var CXXFLAGS "-gsplit-dwarf"
+		add_line_to_config_mk "SPLIT_DWARF = 1"
+		echo_n -- " + split DWARF"
+		if cc_check_no_clean $debug_mode -gsplit-dwarf -fuse-ld=gold -Wl,--gdb-index; then
+			append_var LDFLAGS "-fuse-ld=gold"
+			append_var LDFLAGS "-Wl,--gdb-index"
+			echo_n -- " + Gold"
+		fi
+	fi
+
+	if cc_check_no_clean $debug_mode -fvar-tracking-assignments; then
+		append_var CXXFLAGS "-fvar-tracking-assignments"
+		echo_n -- " + var tracking"
+	fi
+	cc_check_clean
+	echo ""
+fi
+
+if test "$_release_build" = yes; then
+	# Add a define, which indicates we are doing
+	# an build for a release version.
+	append_var DEFINES "-DRELEASE_BUILD"
+fi
 
 # By default, we add -pedantic to the CXXFLAGS to catch some potentially
 # non-portable constructs, like use of GNU extensions.
@@ -5423,6 +5444,7 @@ STRIP := $_strip
 AR := $_ar
 AS := $_as
 ASFLAGS := $ASFLAGS
+DWP := $_dwp
 WINDRES := $_windres
 WINDRESFLAGS := $WINDRESFLAGS
 STAGINGPATH=$_stagingpath
@@ -5472,6 +5494,7 @@ SAVED_ASFLAGS           := $SAVED_ASFLAGS
 SAVED_CPPFLAGS          := $SAVED_CPPFLAGS
 SAVED_CXX               := $SAVED_CXX
 SAVED_CXXFLAGS          := $SAVED_CXXFLAGS
+SAVED_DWP               := $SAVED_DWP
 SAVED_LD                := $SAVED_LD
 SAVED_LDFLAGS           := $SAVED_LDFLAGS
 SAVED_PKG_CONFIG_LIBDIR := $SAVED_PKG_CONFIG_LIBDIR

--- a/rules.mk
+++ b/rules.mk
@@ -55,6 +55,13 @@ PLUGIN:=
 # Add to "plugins" target
 plugins: $(PLUGIN-$(MODULE))
 
+ifdef SPLIT_DWARF
+$(PLUGIN-$(MODULE)).dwp: $(PLUGIN-$(MODULE))
+	$(QUIET_DWP)$(DWP) -e $(PLUGIN-$(MODULE))
+
+plugins: $(PLUGIN-$(MODULE)).dwp
+endif
+
 # Add to the PLUGINS variable
 PLUGINS += $(PLUGIN-$(MODULE))
 


### PR DESCRIPTION
> This should improve linker time as well as reduce the size of the
built binaries (though this does not affect runtime memory usage
since the debug segments are not loaded into memory except by a
debugger) whilst still giving debug information.

Originally from PR #1128