### PR TITLE
iOS: Make arrow keys (e.g. from external keyboard) work on iOS

### DIFF
--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -53,6 +53,30 @@
 	return self;
 }
 
+- (NSArray *)keyCommands {
+	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
+	UIKeyCommand *downArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputDownArrow modifierFlags: 0 action: @selector(downArrow:)];
+	UIKeyCommand *leftArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow modifierFlags: 0 action: @selector(leftArrow:)];
+	UIKeyCommand *rightArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow modifierFlags: 0 action: @selector(rightArrow:)];
+	return [[NSArray alloc] initWithObjects: upArrow, downArrow, leftArrow, rightArrow, nil];
+}
+
+- (void) upArrow: (UIKeyCommand *) keyCommand {
+	[softKeyboard handleKeyPress:273];
+}
+
+- (void) downArrow: (UIKeyCommand *) keyCommand {
+	[softKeyboard handleKeyPress:274];
+}
+
+- (void) leftArrow: (UIKeyCommand *) keyCommand {
+	[softKeyboard handleKeyPress:276];
+}
+
+- (void) rightArrow: (UIKeyCommand *) keyCommand {
+	[softKeyboard handleKeyPress:275];
+}
+
 @end
 
 

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -66,30 +66,6 @@
 	return self;
 }
 
-- (NSArray *)keyCommands {
-	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
-	UIKeyCommand *downArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputDownArrow modifierFlags: 0 action: @selector(downArrow:)];
-	UIKeyCommand *leftArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow modifierFlags: 0 action: @selector(leftArrow:)];
-	UIKeyCommand *rightArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow modifierFlags: 0 action: @selector(rightArrow:)];
-	return [[NSArray alloc] initWithObjects: upArrow, downArrow, leftArrow, rightArrow, nil];
-}
-
-- (void) upArrow: (UIKeyCommand *) keyCommand {
-	[self handleKeyPress:273];
-}
-
-- (void) downArrow: (UIKeyCommand *) keyCommand {
-	[self handleKeyPress:274];
-}
-
-- (void) leftArrow: (UIKeyCommand *) keyCommand {
-	[self handleKeyPress:276];
-}
-
-- (void) rightArrow: (UIKeyCommand *) keyCommand {
-	[self handleKeyPress:275];
-}
-
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
 	unichar c;
 	if (text.length) {

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -986,27 +986,27 @@ uint getSizeNextPOT(uint size) {
 }
 
 - (NSArray *)keyCommands {
-    UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
-    UIKeyCommand *downArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputDownArrow modifierFlags: 0 action: @selector(downArrow:)];
-    UIKeyCommand *leftArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow modifierFlags: 0 action: @selector(leftArrow:)];
-    UIKeyCommand *rightArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow modifierFlags: 0 action: @selector(rightArrow:)];
-    return [[NSArray alloc] initWithObjects: upArrow, downArrow, leftArrow, rightArrow, nil];
+	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
+	UIKeyCommand *downArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputDownArrow modifierFlags: 0 action: @selector(downArrow:)];
+	UIKeyCommand *leftArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow modifierFlags: 0 action: @selector(leftArrow:)];
+	UIKeyCommand *rightArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow modifierFlags: 0 action: @selector(rightArrow:)];
+	return [[NSArray alloc] initWithObjects: upArrow, downArrow, leftArrow, rightArrow, nil];
 }
 
 - (void) upArrow: (UIKeyCommand *) keyCommand {
-    [_keyboardView handleKeyPress:273];
+	[_keyboardView handleKeyPress:273];
 }
 
 - (void) downArrow: (UIKeyCommand *) keyCommand {
-    [_keyboardView handleKeyPress:274];
+	[_keyboardView handleKeyPress:274];
 }
 
 - (void) leftArrow: (UIKeyCommand *) keyCommand {
-    [_keyboardView handleKeyPress:276];
+	[_keyboardView handleKeyPress:276];
 }
 
 - (void) rightArrow: (UIKeyCommand *) keyCommand {
-    [_keyboardView handleKeyPress:275];
+	[_keyboardView handleKeyPress:275];
 }
 
 - (void)applicationSuspend {

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -985,6 +985,30 @@ uint getSizeNextPOT(uint size) {
 	}
 }
 
+- (NSArray *)keyCommands {
+    UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
+    UIKeyCommand *downArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputDownArrow modifierFlags: 0 action: @selector(downArrow:)];
+    UIKeyCommand *leftArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow modifierFlags: 0 action: @selector(leftArrow:)];
+    UIKeyCommand *rightArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow modifierFlags: 0 action: @selector(rightArrow:)];
+    return [[NSArray alloc] initWithObjects: upArrow, downArrow, leftArrow, rightArrow, nil];
+}
+
+- (void) upArrow: (UIKeyCommand *) keyCommand {
+    [_keyboardView handleKeyPress:273];
+}
+
+- (void) downArrow: (UIKeyCommand *) keyCommand {
+    [_keyboardView handleKeyPress:274];
+}
+
+- (void) leftArrow: (UIKeyCommand *) keyCommand {
+    [_keyboardView handleKeyPress:276];
+}
+
+- (void) rightArrow: (UIKeyCommand *) keyCommand {
+    [_keyboardView handleKeyPress:275];
+}
+
 - (void)applicationSuspend {
 	[self addEvent:InternalEvent(kInputApplicationSuspended, 0, 0)];
 }

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -985,30 +985,6 @@ uint getSizeNextPOT(uint size) {
 	}
 }
 
-- (NSArray *)keyCommands {
-	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
-	UIKeyCommand *downArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputDownArrow modifierFlags: 0 action: @selector(downArrow:)];
-	UIKeyCommand *leftArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow modifierFlags: 0 action: @selector(leftArrow:)];
-	UIKeyCommand *rightArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow modifierFlags: 0 action: @selector(rightArrow:)];
-	return [[NSArray alloc] initWithObjects: upArrow, downArrow, leftArrow, rightArrow, nil];
-}
-
-- (void) upArrow: (UIKeyCommand *) keyCommand {
-	[_keyboardView handleKeyPress:273];
-}
-
-- (void) downArrow: (UIKeyCommand *) keyCommand {
-	[_keyboardView handleKeyPress:274];
-}
-
-- (void) leftArrow: (UIKeyCommand *) keyCommand {
-	[_keyboardView handleKeyPress:276];
-}
-
-- (void) rightArrow: (UIKeyCommand *) keyCommand {
-	[_keyboardView handleKeyPress:275];
-}
-
 - (void)applicationSuspend {
 	[self addEvent:InternalEvent(kInputApplicationSuspended, 0, 0)];
 }


### PR DESCRIPTION
Move keyCommands to iPhoneView (ios7_video.mm); here keyCommands is indeed being triggered, when it was in SoftKeyboard (ios7_keyboard.mm), it was never being called.

I only loosely understand why this should help.  Hopefully someone has more experience and can comment?