### PR TITLE
WII: Fix compilation with devkitPPC r32

### DIFF
--- a/backends/fs/wii/wii-fs-factory.cpp
+++ b/backends/fs/wii/wii-fs-factory.cpp
@@ -24,6 +24,7 @@
 
 #define FORBIDDEN_SYMBOL_EXCEPTION_printf
 #define FORBIDDEN_SYMBOL_EXCEPTION_getcwd
+#define FORBIDDEN_SYMBOL_EXCEPTION_time_h
 
 #include <unistd.h>
 

--- a/backends/platform/wii/main.cpp
+++ b/backends/platform/wii/main.cpp
@@ -52,7 +52,7 @@ extern "C" {
 bool reset_btn_pressed = false;
 bool power_btn_pressed = false;
 
-void reset_cb(void) {
+void reset_cb(u32, void*) {
 #ifdef DEBUG_WII_GDB
 	printf("attach gdb now\n");
 	_break();

--- a/configure
+++ b/configure
@@ -2693,6 +2693,10 @@ case $_host_os in
 			# retarded toolchain patch forces --gc-sections, overwrite it
 			append_var LDFLAGS "-Wl,--no-gc-sections"
 		fi
+		if test -d "$DEVKITPRO/portlibs/ppc" ; then
+			append_var CXXFLAGS "-isystem $DEVKITPRO/portlibs/ppc/include"
+			append_var LDFLAGS "-L$DEVKITPRO/portlibs/ppc/lib"
+		fi
 		;;
 	haiku*)
 		append_var DEFINES "-DSYSTEM_NOT_SUPPORTING_D_TYPE"
@@ -2872,6 +2876,10 @@ case $_host_os in
 		if test "$_dynamic_modules" = "yes" ; then
 			# retarded toolchain patch forces --gc-sections, overwrite it
 			append_var LDFLAGS "-Wl,--no-gc-sections"
+		fi
+		if test -d "$DEVKITPRO/portlibs/ppc" ; then
+			append_var CXXFLAGS "-isystem $DEVKITPRO/portlibs/ppc/include"
+			append_var LDFLAGS "-L$DEVKITPRO/portlibs/ppc/lib"
 		fi
 		;;
 	wince)


### PR DESCRIPTION
This compiles, but has not been tested.
This will probably require a toolchain update on our current buildbot.

See also: devkitpro/libogc#24