### PR TITLE
ENGINES: Remove use of C99 math

### DIFF
--- a/engines/bladerunner/script/ai/leon.cpp
+++ b/engines/bladerunner/script/ai/leon.cpp
@@ -455,7 +455,7 @@ void AIScriptLeon::FledCombat() {}
 float AIScriptLeon::sub_446700(int actorId, float x, float y, float z) {
 	float actorX, actorY, actorZ;
 	Actor_Query_XYZ(actorId, &actorX, &actorY, &actorZ);
-	return sqrtf((z - actorZ) * (z - actorZ) + (y - actorY) * (y - actorY) + (x - actorX) * (x - actorX));
+	return sqrt(static_cast<float>((z - actorZ) * (z - actorZ) + (y - actorY) * (y - actorY) + (x - actorX) * (x - actorX)));
 }
 
 } // End of namespace BladeRunner

--- a/engines/bladerunner/script/ai/maggie.cpp
+++ b/engines/bladerunner/script/ai/maggie.cpp
@@ -658,7 +658,7 @@ int AIScriptMaggie::sub_44B260() {
 float AIScriptMaggie::sub_44B200(int actorId, float x, float y, float z) {
 	float actorX, actorY, actorZ;
 	Actor_Query_XYZ(actorId, &actorX, &actorY, &actorZ);
-	return sqrtf((z - actorZ) * (z - actorZ) + (y - actorY) * (y - actorY) + (x - actorX) * (x - actorX));
+	return sqrt(static_cast<float>((z - actorZ) * (z - actorZ) + (y - actorY) * (y - actorY) + (x - actorX) * (x - actorX)));
 }
 
 } // End of namespace BladeRunner

--- a/engines/bladerunner/script/script.cpp
+++ b/engines/bladerunner/script/script.cpp
@@ -358,7 +358,7 @@ int ScriptBase::Actor_Query_Inch_Distance_From_Waypoint(int actorId, int waypoin
 	float distX = actorX - waypointX;
 	float distZ = actorZ - waypointZ;
 
-	return sqrtf(distX * distX + distZ * distZ);
+	return sqrt(distX * distX + distZ * distZ);
 }
 
 bool ScriptBase::Actor_Query_In_Between_Two_Actors(int actorId, int otherActor1Id, int otherActor2Id) {

--- a/engines/bladerunner/slice_renderer.cpp
+++ b/engines/bladerunner/slice_renderer.cpp
@@ -118,9 +118,9 @@ Matrix3x2 SliceRenderer::calculateFacingRotationMatrix() {
 	assert(_sliceFramePtr);
 
 	Vector3 viewPos = _view->_sliceViewMatrix * _position;
-	float dir = atan2f(viewPos.x, viewPos.z) + _facing;
-	float s = sinf(dir);
-	float c = cosf(dir);
+	float dir = atan2(viewPos.x, viewPos.z) + _facing;
+	float s = sin(dir);
+	float c = cos(dir);
 
 	Matrix3x2 mRotation(c, -s, 0.0f,
 	                    s,  c, 0.0f);
@@ -488,11 +488,11 @@ void SliceRenderer::drawOnScreen(int animationId, int animationFrame, int screen
 	loadFrame(animationId, animationFrame);
 
 	float frameHeight = _frameSliceHeight * _frameSliceCount;
-	float frameSize = sqrtf(_frameScale.x * 255.0f * _frameScale.x * 255.0f + _frameScale.y * 255.0f * _frameScale.y * 255.0f);
+	float frameSize = sqrt(_frameScale.x * 255.0f * _frameScale.x * 255.0f + _frameScale.y * 255.0f * _frameScale.y * 255.0f);
 	float size = scale / MAX(frameSize, frameHeight);
 
-	float s = sinf(_facing);
-	float c = cosf(_facing);
+	float s = sin(_facing);
+	float c = cos(_facing);
 
 	Matrix3x2 m_rotation(c, -s, 0.0f,
 	                     s,  c, 0.0f);

--- a/engines/bladerunner/vector.h
+++ b/engines/bladerunner/vector.h
@@ -55,7 +55,7 @@ public:
 
 	Vector3(float ax, float ay, float az) : x(ax), y(ay), z(az) {}
 
-	float length() { return sqrtf(x * x + y * y + z * z); }
+	float length() { return sqrt(x * x + y * y + z * z); }
 	Vector3 normalize() {
 		float len = length();
 		if (len == 0) {

--- a/engines/bladerunner/view.cpp
+++ b/engines/bladerunner/view.cpp
@@ -51,7 +51,7 @@ void View::setFovX(float fovX) {
 
 	_viewportPosition.x = 320.0f;
 	_viewportPosition.y = 240.0f;
-	_viewportPosition.z = 320.0f / tanf(_fovX / 2.0f);
+	_viewportPosition.z = 320.0f / tan(_fovX / 2.0f);
 }
 
 void View::calculateSliceViewMatrix() {

--- a/engines/sword25/math/region.cpp
+++ b/engines/sword25/math/region.cpp
@@ -266,10 +266,10 @@ Vertex Region::findClosestPointOnLine(const Vertex &lineStart, const Vertex &lin
 	float vector1Y = static_cast<float>(point.y - lineStart.y);
 	float vector2X = static_cast<float>(lineEnd.x - lineStart.x);
 	float vector2Y = static_cast<float>(lineEnd.y - lineStart.y);
-	float vector2Length = sqrtf(vector2X * vector2X + vector2Y * vector2Y);
+	float vector2Length = sqrt(vector2X * vector2X + vector2Y * vector2Y);
 	vector2X /= vector2Length;
 	vector2Y /= vector2Length;
-	float distance = sqrtf(static_cast<float>((lineStart.x - lineEnd.x) * (lineStart.x - lineEnd.x) +
+	float distance = sqrt(static_cast<float>((lineStart.x - lineEnd.x) * (lineStart.x - lineEnd.x) +
 	                       (lineStart.y - lineEnd.y) * (lineStart.y - lineEnd.y)));
 	float dot = vector1X * vector2X + vector1Y * vector2Y;
 

--- a/engines/sword25/math/vertex.h
+++ b/engines/sword25/math/vertex.h
@@ -45,10 +45,6 @@
 
 struct lua_State;
 
-#if defined(MACOSX) || defined(SOLARIS) || defined(__MINGW32__)
-#define sqrtf(x)	((float)sqrt(x))
-#endif
-
 namespace Sword25 {
 
 /**
@@ -67,7 +63,7 @@ public:
 	 * @remark              If only distances should be compared, sqrDist() should be used, since it is faster.
 	 */
 	inline int distance(const Vertex &vertex) const {
-		return (int)(sqrtf(static_cast<float>(sqrDist(vertex))) + 0.5);
+		return (int)(sqrt(static_cast<float>(sqrDist(vertex))) + 0.5);
 	}
 
 	static Vertex &luaVertexToVertex(lua_State *L, int StackIndex, Vertex &vertex);


### PR DESCRIPTION
> C++ math functions are overloaded so operate using single-precision
when receiving a float input. The C standard library on FreeMiNT
does not fully support C99 math so use of sqrtf, sinf, etc.
instead of the C++ API does not work.

Originally from PR #1128