### PR TITLE
 BUILD: Add commands for retrieving calculated binaries & dist files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,4 +117,4 @@ print-dists:
 	@echo $(foreach V, $(filter DIST_FILES_%, $(.VARIABLES)), $($V))
 
 print-executables:
-	@echo $(EXECUTABLE) $(PLUGINS)
+	@echo $(if $(DIST_EXECUTABLES),$(DIST_EXECUTABLES),$(EXECUTABLE) $(PLUGINS))

--- a/Makefile
+++ b/Makefile
@@ -111,3 +111,10 @@ config.mk engines/plugins_table.h engines/engines.mk: config.h
 ifneq ($(origin port_mk), undefined)
 include $(srcdir)/$(port_mk)
 endif
+
+.PHONY: print-dists print-executables
+print-dists:
+	@echo $(foreach V, $(filter DIST_FILES_%, $(.VARIABLES)), $($V))
+
+print-executables:
+	@echo $(EXECUTABLE) $(PLUGINS)

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ endif
 
 .PHONY: print-dists print-executables
 print-dists:
-	@echo $(foreach V, $(filter DIST_FILES_%, $(.VARIABLES)), $($V))
+	@echo $(DIST_FILES_DOCS) $(DIST_FILES_THEMES) $(DIST_FILES_NETWORKING) $(DIST_FILES_ENGINEDATA) $(srcdir)/doc
 
 print-executables:
 	@echo $(if $(DIST_EXECUTABLES),$(DIST_EXECUTABLES),$(EXECUTABLE) $(PLUGINS))

--- a/backends/platform/psp/psp.mk
+++ b/backends/platform/psp/psp.mk
@@ -3,6 +3,7 @@ PSP_EBOOT = EBOOT.PBP
 PSP_EBOOT_SFO = param.sfo
 PSP_EBOOT_TITLE = ScummVM-PSP
 DATE = $(shell date +%Y%m%d)
+DIST_EXECUTABLES=$(PSP_EBOOT) $(PLUGINS)
 
 MKSFO = mksfoex -d MEMSIZE=1
 PACK_PBP = pack-pbp


### PR DESCRIPTION
> Instead of hard-coding these lists into the CI system's packaging
code, expose them from Make so that everything is sourced off the
same one list.

Originally from PR #1128