### PR TITLE
BUILD: Remove manual configuration of Raspberry Pi compiler

### DIFF
--- a/configure
+++ b/configure
@@ -2990,28 +2990,6 @@ if test -n "$_host"; then
 			_port_mk="backends/platform/dingux/dingux.mk"
 			;;
 		raspberrypi)
-			# This is needed because the official cross compiler doesn't have multiarch enabled
-			# but Raspbian does.
-			# Be careful as it's the linker (LDFLAGS) which must know about sysroot.
-			# These are needed to build against Raspbian's libSDL.
-			append_var LDFLAGS "--sysroot=$RPI_ROOT"
-			append_var LDFLAGS "-B$RPI_ROOT/usr/lib/arm-linux-gnueabihf"
-			append_var LDFLAGS "-Xlinker --rpath-link=$RPI_ROOT/usr/lib/arm-linux-gnueabihf"
-			append_var LDFLAGS "-Xlinker --rpath-link=$RPI_ROOT/lib/arm-linux-gnueabihf"
-			append_var LDFLAGS "-Xlinker --rpath-link=$RPI_ROOT/opt/vc/lib"
-			append_var LDFLAGS "-L$RPI_ROOT/opt/vc/lib"
-			# This is so optional OpenGL ES includes are found.
-			append_var CXXFLAGS "-I$RPI_ROOT/opt/vc/include"
-			_savegame_timestamp=no
-			_eventrec=no
-			_build_scalers=no
-			_build_hq_scalers=no
-			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
-			# since SDL2 manages dispmanx/GLES2 very well internally.
-			# SDL1 is bit-rotten on this platform.
-			_sdlconfig=sdl2-config
-			# OpenGL ES support is mature enough as to be the best option on
-			# the Raspberry Pi, so it's enabled by default.
 			# The Raspberry Pi always supports OpenGL ES 2.0 contexts, thus we
 			# take advantage of those.
 			_opengl_mode=gles2


### PR DESCRIPTION
I'm not entirely sure this is a desirable change, especially since the [buildbot worker](https://github.com/csnover/scummvm-buildbot/blob/master/workers/raspberrypi/Dockerfile) uses the default Debian armhf toolchain rather than the dedicated RPI toolchain specified in the [compilation instructions](http://wiki.scummvm.org/index.php/Compiling_ScummVM/RPI), but it has been included for completeness

Originally from PR #1128