### PR TITLE
GROOVIE: Disable loading saves during runtime

### DIFF
--- a/engines/groovie/groovie.cpp
+++ b/engines/groovie/groovie.cpp
@@ -350,8 +350,11 @@ Common::Platform GroovieEngine::getPlatform() const {
 bool GroovieEngine::hasFeature(EngineFeature f) const {
 	return
 		(f == kSupportsRTL) ||
-		(f == kSupportsSavingDuringRuntime) ||
-		(f == kSupportsLoadingDuringRuntime);
+		(f == kSupportsSavingDuringRuntime);
+		// Game will crash during loading at a few puzzles.
+		// So don't enable until thats been figured out.
+		// See Trac#10664.
+		//(f == kSupportsLoadingDuringRuntime);
 }
 
 void GroovieEngine::syncSoundSettings() {


### PR DESCRIPTION
There is currently a crash that will happen when loading another save
during some puzzles. So we just disable loading at runtime.

Saving during runtime works just fine so we keep that.

See Trac#10664.