### PR TITLE
MACOSX: Put documentation links in Help menu

### DIFF
--- a/backends/platform/sdl/macosx/appmenu_osx.h
+++ b/backends/platform/sdl/macosx/appmenu_osx.h
@@ -26,6 +26,7 @@
 #if defined(MACOSX)
 
 void replaceApplicationMenuItems();
+void releaseMenu();
 
 #endif // MACOSX
 

--- a/backends/platform/sdl/macosx/appmenu_osx.mm
+++ b/backends/platform/sdl/macosx/appmenu_osx.mm
@@ -81,7 +81,7 @@ static void openFromBundle(NSString *file) {
 }
 
 - (void)openLicense {
-	openFromBundle(@"COPYING");
+	openFromBundle(@"COPYING-COMBINED");
 }
 
 - (void)openNews {

--- a/backends/platform/sdl/macosx/appmenu_osx.mm
+++ b/backends/platform/sdl/macosx/appmenu_osx.mm
@@ -35,6 +35,10 @@
 #define NSEventModifierFlagOption  NSAlternateKeyMask
 #endif
 
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_10
+#define NSEventModifierFlags NSUInteger
+#endif
+
 // Apple added setAppleMenu in 10.5 and removed it in 10.6.
 // But as the method still exists we declare it ourselves here.
 // Yes, this works :)

--- a/backends/platform/sdl/macosx/appmenu_osx.mm
+++ b/backends/platform/sdl/macosx/appmenu_osx.mm
@@ -104,7 +104,7 @@ static void openFromBundle(NSString *file) {
 }
 
 - (void)openUserManual {
-	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://www.scummvm.org/manual"]];
+	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://www.scummvm.org/documentation"]];
 }
 
 - (void)openCredits {

--- a/backends/platform/sdl/macosx/appmenu_osx.mm
+++ b/backends/platform/sdl/macosx/appmenu_osx.mm
@@ -69,7 +69,10 @@ static void openFromBundle(NSString *file) {
 @interface ScummVMMenuHandler : NSObject {
 }
 - (void) openReadme;
-- (void) openLicense;
+- (void) openLicenseGPL;
+- (void) openLicenseLGPL;
+- (void) openLicenseFreefont;
+- (void) openLicenseBSD;
 - (void) openNews;
 - (void) openUserManual;
 - (void) openCredits;
@@ -80,8 +83,20 @@ static void openFromBundle(NSString *file) {
 	openFromBundle(@"README");
 }
 
-- (void)openLicense {
-	openFromBundle(@"COPYING-COMBINED");
+- (void)openLicenseGPL {
+	openFromBundle(@"COPYING");
+}
+
+- (void)openLicenseLGPL {
+	openFromBundle(@"COPYING-LGPL");
+}
+
+- (void)openLicenseFreefont {
+	openFromBundle(@"COPYING-FREEFONT");
+}
+
+- (void)openLicenseBSD {
+	openFromBundle(@"COPYING-BSD");
 }
 
 - (void)openNews {
@@ -183,7 +198,11 @@ void replaceApplicationMenuItems() {
 	addMenuItem(_("What's New in ScummVM"), stringEncoding, delegate, @selector(openNews), @"", helpMenu);
 	[helpMenu addItem:[NSMenuItem separatorItem]];
 	addMenuItem(_("Credits"), stringEncoding, delegate, @selector(openCredits), @"", helpMenu);
-	addMenuItem(_("Licensing Information"), stringEncoding, delegate, @selector(openLicense), @"", helpMenu);
+	addMenuItem(_("GPL License"), stringEncoding, delegate, @selector(openLicenseGPL), @"", helpMenu);
+	addMenuItem(_("LGPL License"), stringEncoding, delegate, @selector(openLicenseLGPL), @"", helpMenu);
+	addMenuItem(_("Freefont License"), stringEncoding, delegate, @selector(openLicenseFreefont), @"", helpMenu);
+	addMenuItem(_("BSD License"), stringEncoding, delegate, @selector(openLicenseBSD), @"", helpMenu);
+
 
 	[appleMenu release];
 	[windowMenu release];

--- a/backends/platform/sdl/macosx/macosx-compat.h
+++ b/backends/platform/sdl/macosx/macosx-compat.h
@@ -29,6 +29,10 @@
 #define MAC_OS_X_VERSION_10_5    1050
 #endif
 
+#ifndef MAC_OS_X_VERSION_10_10
+#define MAC_OS_X_VERSION_10_10 101000
+#endif
+
 #ifndef MAC_OS_X_VERSION_10_12
 #define MAC_OS_X_VERSION_10_12 101200
 #endif

--- a/backends/platform/sdl/macosx/macosx.cpp
+++ b/backends/platform/sdl/macosx/macosx.cpp
@@ -47,6 +47,10 @@ OSystem_MacOSX::OSystem_MacOSX()
 	OSystem_POSIX("Library/Preferences/ScummVM Preferences") {
 }
 
+OSystem_MacOSX::~OSystem_MacOSX() {
+	releaseMenu();
+}
+
 void OSystem_MacOSX::init() {
 	// Use an iconless window on OS X, as we use a nicer external icon there.
 	_window = new SdlIconlessWindow();

--- a/backends/platform/sdl/macosx/macosx.h
+++ b/backends/platform/sdl/macosx/macosx.h
@@ -28,6 +28,7 @@
 class OSystem_MacOSX : public OSystem_POSIX {
 public:
 	OSystem_MacOSX();
+	~OSystem_MacOSX();
 
 	virtual bool hasFeature(Feature f);
 

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -767,6 +767,13 @@ XcodeProvider::ValueList& XcodeProvider::getResourceFiles() const {
 		files.push_back("dists/engine-data/xeen.ccs");
 		files.push_back("dists/pred.dic");
 		files.push_back("icons/scummvm.icns");
+		files.push_back("AUTHORS");
+		files.push_back("COPYING");
+		files.push_back("COPYING.LGPL");
+		files.push_back("COPYING.BSD");
+		files.push_back("COPYING.FREEFONT");
+		files.push_back("NEWS");
+		files.push_back("README");
 	}
 	return files;
 }

--- a/ports.mk
+++ b/ports.mk
@@ -121,10 +121,10 @@ ifdef DIST_FILES_ENGINEDATA
 endif
 	$(srcdir)/devtools/credits.pl --rtf > $(bundle_name)/Contents/Resources/AUTHORS.rtf
 	rm $(bundle_name)/Contents/Resources/AUTHORS
-	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.LGPL >> $(bundle_name)/Contents/Resources/COPYING
-	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.FREEFONT >> $(bundle_name)/Contents/Resources/COPYING
-	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.BSD >> $(bundle_name)/Contents/Resources/COPYING
-	rm $(bundle_name)/Contents/Resources/COPYING.LGPL $(bundle_name)/Contents/Resources/COPYING.FREEFONT $(bundle_name)/Contents/Resources/COPYING.BSD
+	cp $(bundle_name)/Contents/Resources/COPYING $(bundle_name)/Contents/Resources/COPYING-COMBINED
+	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.LGPL >> $(bundle_name)/Contents/Resources/COPYING-COMBINED
+	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.FREEFONT >> $(bundle_name)/Contents/Resources/COPYING-COMBINED
+	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.BSD >> $(bundle_name)/Contents/Resources/COPYING-COMBINED
 	chmod 644 $(bundle_name)/Contents/Resources/*
 	cp scummvm-static $(bundle_name)/Contents/MacOS/scummvm
 	chmod 755 $(bundle_name)/Contents/MacOS/scummvm

--- a/ports.mk
+++ b/ports.mk
@@ -111,7 +111,7 @@ ifdef USE_SPARKLE
 	cp -R $(SPARKLEPATH)/Sparkle.framework $(bundle_name)/Contents/Frameworks/
 endif
 	cp $(srcdir)/icons/scummvm.icns $(bundle_name)/Contents/Resources/
-	cp $(DIST_FILES_DOCS) $(bundle_name)/
+	cp $(DIST_FILES_DOCS) $(bundle_name)/Contents/Resources/
 	cp $(DIST_FILES_THEMES) $(bundle_name)/Contents/Resources/
 ifdef DIST_FILES_NETWORKING
 	cp $(DIST_FILES_NETWORKING) $(bundle_name)/Contents/Resources/
@@ -119,7 +119,8 @@ endif
 ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) $(bundle_name)/Contents/Resources/
 endif
-	$(srcdir)/devtools/credits.pl --rtf > $(bundle_name)/Contents/Resources/Credits.rtf
+	$(srcdir)/devtools/credits.pl --rtf > $(bundle_name)/Contents/Resources/AUTHORS.rtf
+	rm $(bundle_name)/Contents/Resources/AUTHORS
 	chmod 644 $(bundle_name)/Contents/Resources/*
 	cp scummvm-static $(bundle_name)/Contents/MacOS/scummvm
 	chmod 755 $(bundle_name)/Contents/MacOS/scummvm

--- a/ports.mk
+++ b/ports.mk
@@ -121,10 +121,9 @@ ifdef DIST_FILES_ENGINEDATA
 endif
 	$(srcdir)/devtools/credits.pl --rtf > $(bundle_name)/Contents/Resources/AUTHORS.rtf
 	rm $(bundle_name)/Contents/Resources/AUTHORS
-	cp $(bundle_name)/Contents/Resources/COPYING $(bundle_name)/Contents/Resources/COPYING-COMBINED
-	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.LGPL >> $(bundle_name)/Contents/Resources/COPYING-COMBINED
-	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.FREEFONT >> $(bundle_name)/Contents/Resources/COPYING-COMBINED
-	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.BSD >> $(bundle_name)/Contents/Resources/COPYING-COMBINED
+	cp $(bundle_name)/Contents/Resources/COPYING.LGPL $(bundle_name)/Contents/Resources/COPYING-LGPL
+	cp $(bundle_name)/Contents/Resources/COPYING.FREEFONT $(bundle_name)/Contents/Resources/COPYING-FREEFONT
+	cp $(bundle_name)/Contents/Resources/COPYING.BSD $(bundle_name)/Contents/Resources/COPYING-BSD
 	chmod 644 $(bundle_name)/Contents/Resources/*
 	cp scummvm-static $(bundle_name)/Contents/MacOS/scummvm
 	chmod 755 $(bundle_name)/Contents/MacOS/scummvm

--- a/ports.mk
+++ b/ports.mk
@@ -121,6 +121,10 @@ ifdef DIST_FILES_ENGINEDATA
 endif
 	$(srcdir)/devtools/credits.pl --rtf > $(bundle_name)/Contents/Resources/AUTHORS.rtf
 	rm $(bundle_name)/Contents/Resources/AUTHORS
+	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.LGPL >> $(bundle_name)/Contents/Resources/COPYING
+	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.FREEFONT >> $(bundle_name)/Contents/Resources/COPYING
+	echo "\n---\n" | cat - $(bundle_name)/Contents/Resources/COPYING.BSD >> $(bundle_name)/Contents/Resources/COPYING
+	rm $(bundle_name)/Contents/Resources/COPYING.LGPL $(bundle_name)/Contents/Resources/COPYING.FREEFONT $(bundle_name)/Contents/Resources/COPYING.BSD
 	chmod 644 $(bundle_name)/Contents/Resources/*
 	cp scummvm-static $(bundle_name)/Contents/MacOS/scummvm
 	chmod 755 $(bundle_name)/Contents/MacOS/scummvm


### PR DESCRIPTION
> The local documents are not currently internationalised simply
because the internationalised resources are not put into the right
places (NSBundle will handle this automatically when they are);
Trac#10464 is a tracking bug for this outstanding issue.

Originally from PR #1296.