### PR TITLE
BUILD: Remove .dwo files on clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*.swp
 .*.swo
 *.o
+*.dwo
 lib*.a
 .deps
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -96,6 +96,7 @@ clean:
 	$(RM_REC) $(DEPDIRS)
 	$(RM) $(OBJS) $(EXECUTABLE)
 ifdef SPLIT_DWARF
+	$(RM) $(OBJS:.o=.dwo)
 	$(RM) $(EXECUTABLE).dwp
 endif
 

--- a/rules.mk
+++ b/rules.mk
@@ -98,5 +98,8 @@ endif # TOOL_EXECUTABLE
 clean: clean-$(MODULE)
 clean-$(MODULE): clean-% :
 	-$(RM) $(MODULE_OBJS-$*) $(MODULE_LIB-$*) $(PLUGIN-$*) $(TOOL-$*)
+ifdef SPLIT_DWARF
+	-$(RM) $(MODULE_OBJS-$*:.o=.dwo)
+endif
 
 .PHONY: clean-$(MODULE) $(MODULE)


### PR DESCRIPTION
I noticed that the ScummVM build process creates .dwo files in addition to the .o files when -gsplit-dwarf is used. This pull request is my attempt to remove them on "make clean". I'm rather rusty on Makefile syntax, but I _hope_ it's correct.