### PR TITLE
Fix build failure

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -57,7 +57,7 @@ plugins: $(PLUGIN-$(MODULE))
 
 ifdef SPLIT_DWARF
 $(PLUGIN-$(MODULE)).dwp: $(PLUGIN-$(MODULE))
-	$(QUIET_DWP)$(DWP) -e $(PLUGIN-$(MODULE))
+	$(QUIET_DWP)$(DWP) -e $<
 
 plugins: $(PLUGIN-$(MODULE)).dwp
 endif


### PR DESCRIPTION
Only happens when `--enable-plugins` is turned on.

It has to do with `$(PLUGIN-$(MODULE))` not substituting while inside of a make recipe, resulting in `dwp -e` executing with no argument, hence the FTBFS.

Version information:

- GNU make 4.2.1
- GNU dwp version 2.31.1-slack15
- scummvm e97b1e560d4f3a0eed758047e8c40ecc69c98231