### PR TITLE
OPENGL: Use premultiplied alpha for color-keyed cursors

### DIFF
--- a/backends/graphics/opengl/framebuffer.cpp
+++ b/backends/graphics/opengl/framebuffer.cpp
@@ -28,7 +28,7 @@ namespace OpenGL {
 
 Framebuffer::Framebuffer()
     : _viewport(), _projectionMatrix(), _isActive(false), _clearColor(),
-      _blendState(false), _scissorTestState(false), _scissorBox() {
+      _blendState(kBlendModeDisabled), _scissorTestState(false), _scissorBox() {
 }
 
 void Framebuffer::activate() {
@@ -62,8 +62,8 @@ void Framebuffer::setClearColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
 	}
 }
 
-void Framebuffer::enableBlend(bool enable) {
-	_blendState = enable;
+void Framebuffer::enableBlend(BlendMode mode) {
+	_blendState = mode;
 
 	// Directly apply changes when we are active.
 	if (isActive()) {
@@ -105,10 +105,18 @@ void Framebuffer::applyClearColor() {
 }
 
 void Framebuffer::applyBlendState() {
-	if (_blendState) {
-		GL_CALL(glEnable(GL_BLEND));
-	} else {
-		GL_CALL(glDisable(GL_BLEND));
+	switch (_blendState) {
+		case kBlendModeDisabled:
+			GL_CALL(glDisable(GL_BLEND));
+			break;
+		case kBlendModeTraditionalTransparency:
+			GL_CALL(glEnable(GL_BLEND));
+			GL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+			break;
+		case kBlendModePremultipliedTransparency:
+			GL_CALL(glEnable(GL_BLEND));
+			GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+			break;
 	}
 }
 

--- a/backends/graphics/opengl/framebuffer.h
+++ b/backends/graphics/opengl/framebuffer.h
@@ -37,6 +37,29 @@ public:
 	virtual ~Framebuffer() {};
 
 public:
+	enum BlendMode {
+		/**
+		 * Newly drawn pixels overwrite the existing contents of the framebuffer
+		 * without mixing with them
+		 */
+		kBlendModeDisabled,
+
+		/**
+		 * Newly drawn pixels mix with the framebuffer based on their alpha value
+		 * for transparency.
+		 */
+		kBlendModeTraditionalTransparency,
+
+		/**
+		 * Newly drawn pixels mix with the framebuffer based on their alpha value
+		 * for transparency.
+		 *
+		 * Requires the image data being drawn to have its color values pre-multipled
+		 * with the alpha value.
+		 */
+		kBlendModePremultipliedTransparency
+	};
+
 	/**
 	 * Set the clear color of the framebuffer.
 	 */
@@ -45,7 +68,7 @@ public:
 	/**
 	 * Enable/disable GL_BLEND.
 	 */
-	void enableBlend(bool enable);
+	void enableBlend(BlendMode mode);
 
 	/**
 	 * Enable/disable GL_SCISSOR_TEST.
@@ -102,7 +125,7 @@ private:
 	GLfloat _clearColor[4];
 	void applyClearColor();
 
-	bool _blendState;
+	BlendMode _blendState;
 	void applyBlendState();
 
 	bool _scissorTestState;

--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -344,16 +344,16 @@ Graphics::PixelFormat TextureCLUT8::getFormat() const {
 }
 
 void TextureCLUT8::setColorKey(uint colorKey) {
-	// We remove all alpha bits from the palette entry of the color key.
-	// This makes sure its properly handled as color key.
-	const uint32 aMask = (0xFF >> _format.aLoss) << _format.aShift;
-
+	// The key color is set to black so the color value is pre-multiplied with the alpha value
+	// to avoid color fringes due to filtering.
+	// Erasing the color data is not a problem as the palette is always fully re-initialized
+	// before setting the key color.
 	if (_format.bytesPerPixel == 2) {
 		uint16 *palette = (uint16 *)_palette + colorKey;
-		*palette &= ~aMask;
+		*palette = 0;
 	} else if (_format.bytesPerPixel == 4) {
 		uint32 *palette = (uint32 *)_palette + colorKey;
-		*palette &= ~aMask;
+		*palette = 0;
 	} else {
 		warning("TextureCLUT8::setColorKey: Unsupported pixel depth %d", _format.bytesPerPixel);
 	}
@@ -581,6 +581,13 @@ Graphics::PixelFormat TextureCLUT8GPU::getFormat() const {
 }
 
 void TextureCLUT8GPU::setColorKey(uint colorKey) {
+	// The key color is set to black so the color value is pre-multiplied with the alpha value
+	// to avoid color fringes due to filtering.
+	// Erasing the color data is not a problem as the palette is always fully re-initialized
+	// before setting the key color.
+	_palette[colorKey * 4    ] = 0x00;
+	_palette[colorKey * 4 + 1] = 0x00;
+	_palette[colorKey * 4 + 2] = 0x00;
 	_palette[colorKey * 4 + 3] = 0x00;
 
 	_paletteDirty = true;


### PR DESCRIPTION
This fixes colour fringing on keyed cursors when using filtering.

Before:
![screenshot from 2018-08-23 19-10-06](https://user-images.githubusercontent.com/52294/44540798-5c01d100-a708-11e8-87fe-88770694f72b.png)

After:
![screenshot from 2018-08-23 19-06-51](https://user-images.githubusercontent.com/52294/44540794-573d1d00-a708-11e8-8f0c-ae4a5efcb31f.png)

I have tested this with:
* Classic Myst (color-keyed 8-bits cursors)
* Myst ME (color-keyed 32-bits cursors)
* Riven (color-keyed 16-bits cursors)
* Starship Titanic (alpha-blended 32-bits cursors)