### PR TITLE
WINTERMUTE: Flush ConfMan to disk on every change

### DIFF
--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -237,6 +237,7 @@ BaseGame::~BaseGame() {
 	LOG(0, "Shutting down...");
 
 	ConfMan.setBool("last_run", true);
+	ConfMan.flushToDisk();
 
 	cleanup();
 
@@ -1255,6 +1256,7 @@ bool BaseGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 		int val = stack->pop()->getInt();
 		Common::String privKey = "priv_" + StringUtil::encodeSetting(key);
 		ConfMan.setInt(privKey, val);
+		ConfMan.flushToDisk();
 		stack->pushNULL();
 		return STATUS_OK;
 	}
@@ -1285,6 +1287,7 @@ bool BaseGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 		Common::String privKey = "wme_" + StringUtil::encodeSetting(key);
 		Common::String privVal = StringUtil::encodeSetting(val);
 		ConfMan.set(privKey, privVal);
+		ConfMan.flushToDisk();
 		stack->pushNULL();
 		return STATUS_OK;
 	}
@@ -3884,7 +3887,6 @@ bool BaseGame::isDoubleClick(int32 buttonIndex) {
 //////////////////////////////////////////////////////////////////////////
 void BaseGame::autoSaveOnExit() {
 	_soundMgr->saveSettings();
-	ConfMan.flushToDisk();
 
 	if (!_autoSaveOnExit) {
 		return;

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -1256,7 +1256,6 @@ bool BaseGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 		int val = stack->pop()->getInt();
 		Common::String privKey = "priv_" + StringUtil::encodeSetting(key);
 		ConfMan.setInt(privKey, val);
-		ConfMan.flushToDisk();
 		stack->pushNULL();
 		return STATUS_OK;
 	}
@@ -1287,7 +1286,6 @@ bool BaseGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 		Common::String privKey = "wme_" + StringUtil::encodeSetting(key);
 		Common::String privVal = StringUtil::encodeSetting(val);
 		ConfMan.set(privKey, privVal);
-		ConfMan.flushToDisk();
 		stack->pushNULL();
 		return STATUS_OK;
 	}

--- a/engines/wintermute/base/saveload.cpp
+++ b/engines/wintermute/base/saveload.cpp
@@ -101,6 +101,7 @@ bool SaveLoad::saveGame(int slot, const char *desc, bool quickSave, BaseGame *ga
 				pm->putDWORD(BaseEngine::instance().getRandomSource()->getSeed());
 				if (DID_SUCCEED(ret = pm->saveFile(filename))) {
 					ConfMan.setInt("most_recent_saveslot", slot);
+					ConfMan.flushToDisk();
 				}
 			}
 		}

--- a/engines/wintermute/base/sound/base_sound_manager.cpp
+++ b/engines/wintermute/base/sound/base_sound_manager.cpp
@@ -73,6 +73,7 @@ bool BaseSoundMgr::cleanup() {
 void BaseSoundMgr::saveSettings() {
 	if (_soundAvailable) {
 		ConfMan.setInt("master_volume_percent", _volumeMasterPercent);
+		ConfMan.flushToDisk();
 	}
 }
 
@@ -181,12 +182,15 @@ bool BaseSoundMgr::setVolume(Audio::Mixer::SoundType type, int volume) {
 	switch (type) {
 	case Audio::Mixer::kSFXSoundType:
 		ConfMan.setInt("sfx_volume", volume);
+		ConfMan.flushToDisk();
 		break;
 	case Audio::Mixer::kSpeechSoundType:
 		ConfMan.setInt("speech_volume", volume);
+		ConfMan.flushToDisk();
 		break;
 	case Audio::Mixer::kMusicSoundType:
 		ConfMan.setInt("music_volume", volume);
+		ConfMan.flushToDisk();
 		break;
 	case Audio::Mixer::kPlainSoundType:
 		error("Plain sound type shouldn't be used in WME");

--- a/engines/wintermute/base/sound/base_sound_manager.cpp
+++ b/engines/wintermute/base/sound/base_sound_manager.cpp
@@ -73,7 +73,6 @@ bool BaseSoundMgr::cleanup() {
 void BaseSoundMgr::saveSettings() {
 	if (_soundAvailable) {
 		ConfMan.setInt("master_volume_percent", _volumeMasterPercent);
-		ConfMan.flushToDisk();
 	}
 }
 
@@ -182,15 +181,12 @@ bool BaseSoundMgr::setVolume(Audio::Mixer::SoundType type, int volume) {
 	switch (type) {
 	case Audio::Mixer::kSFXSoundType:
 		ConfMan.setInt("sfx_volume", volume);
-		ConfMan.flushToDisk();
 		break;
 	case Audio::Mixer::kSpeechSoundType:
 		ConfMan.setInt("speech_volume", volume);
-		ConfMan.flushToDisk();
 		break;
 	case Audio::Mixer::kMusicSoundType:
 		ConfMan.setInt("music_volume", volume);
-		ConfMan.flushToDisk();
 		break;
 	case Audio::Mixer::kPlainSoundType:
 		error("Plain sound type shouldn't be used in WME");


### PR DESCRIPTION
There are 4 use-cases of storing persistent data by WME in ConfMan: registry read/write, remembering MostRecentSaveSlot, storing volume settings, and some "last_run" flag that seems to be never used both by engine and games I know of. However, only writing to ConfMan is implemented for all those cases, without flushing. In master branch of ScummVM the only place where ConfMan.flushToDisk() is called is BaseGame::autoSaveOnExit() that is actually never called (commented at platform_osystem.cpp). This means that all those settings are actually not saved to disk.
https://github.com/scummvm/scummvm/blob/3e34cec7ced19e3a0f91588653b8cf4868db18d6/engines/wintermute/platform_osystem.cpp#L122

Registry read/write is an API that is rarely used in most WME games I decompiled (not used at all by games Four, Hamlet, OpenQuest, Dreamcat Adventures, Rosemary, White Chamber, Trader of Stories; used only for page number at saves menu at Helga Deep in Trouble; used only for volume and subtitles settings in Tanya Grotter series), and effects of those values lost was minor for all those games, that's why this bug existed for years and noone ever noticed it. FoxTail game however use RegWriteNumber() API for dozen of settings which affects gameplay and have unwanted default values re-applied on every game save+quit+start+load loop, which makes this a serious bug.

So, we should either reintroduce autoSaveOnExit of some sort (which I consider risky, as it was removed for some reason I don't know of, and also it is not guaranteed to be called, as game process may crash or devices battery may run out before graceful shutdown of game, causing some data to be lost, which seems to me to be against RegWriteNumber semantics), or we could add flush to every writing to make sure nothing is lost (which causes writing to disk on every change of every parameter, which is a kind of overhead, demonstrated in attached changelist).

I wonder how it is handled in other engines and what should we actually do here. Need feedback.