### PR TITLE
COMMON: Update RDFT and DCT cos/sin table constructor usage

### DIFF
--- a/common/dct.cpp
+++ b/common/dct.cpp
@@ -30,7 +30,7 @@
 
 namespace Common {
 
-DCT::DCT(int bits, TransformType trans) : _bits(bits), _cos(_bits + 2), _trans(trans), _rdft(nullptr) {
+DCT::DCT(int bits, TransformType trans) : _bits(bits), _cos(1 << (_bits + 2) ), _trans(trans), _rdft(nullptr) {
 	int n = 1 << _bits;
 
 	_tCos = _cos.getTable();

--- a/common/rdft.cpp
+++ b/common/rdft.cpp
@@ -28,7 +28,7 @@
 
 namespace Common {
 
-RDFT::RDFT(int bits, TransformType trans) : _bits(bits), _sin(bits), _cos(bits), _fft(nullptr) {
+RDFT::RDFT(int bits, TransformType trans) : _bits(bits), _sin(1 << bits), _cos(1 << bits), _fft(nullptr) {
 	assert((_bits >= 4) && (_bits <= 16));
 
 	_inverse        = trans == IDFT_C2R || trans == DFT_C2R;


### PR DESCRIPTION
When the constructor for the cos/sin table was changed from
number of bits to number of points all usages thoughout the
code should of been changed, but this was missed in RDFT and DCT.

Fixes Trac#10683.