### PR TITLE
MOHAWK: RIVEN: Return to main menu after the credits

### DIFF
--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -94,6 +94,12 @@ MohawkEngine_Riven::MohawkEngine_Riven(OSystem *syst, const MohawkGameDescriptio
 	SearchMan.addSubDirectoryMatching(gameDataDir, "program");
 }
 
+void MohawkEngine_Riven::restart() {
+	startNewGame();
+	_menuTumbnail.reset();
+	goToMainMenu(false);
+}
+
 MohawkEngine_Riven::~MohawkEngine_Riven() {
 	delete _card;
 	delete _stack;
@@ -334,9 +340,14 @@ void MohawkEngine_Riven::processInput() {
 	}
 }
 
-void MohawkEngine_Riven::goToMainMenu() {
-	_menuSavedStack = _stack->getId();
-	_menuSavedCard = _card->getId();
+void MohawkEngine_Riven::goToMainMenu(bool allowResume) {
+	if (allowResume) {
+		_menuSavedStack = _stack->getId();
+		_menuSavedCard = _card->getId();
+	} else {
+		_menuSavedStack = -1;
+		_menuSavedCard = -1;
+	}
 
 	// If we are already in menu, do not call again
 	if (_menuSavedStack == kStackAspit && _menuSavedCard == 1) {

--- a/engines/mohawk/riven.h
+++ b/engines/mohawk/riven.h
@@ -106,6 +106,7 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 
 	void doFrame();
+	void restart(); //restart the game and go to the main menu
 	void processInput();
 
 private:
@@ -178,7 +179,7 @@ public:
 	void setGameEnded();
 
 	// Main menu handling
-	void goToMainMenu();
+	void goToMainMenu(bool allowResume = true);
 	void resumeFromMainMenu();
 	bool isGameStarted() const;
 	void startNewGame();

--- a/engines/mohawk/riven_graphics.cpp
+++ b/engines/mohawk/riven_graphics.cpp
@@ -656,6 +656,9 @@ void RivenGraphics::beginCredits() {
 	// Clear the old cache
 	clearCache();
 
+	_creditsImage = kRivenCreditsZeroImage;
+	_creditsPos = 0;
+
 	// Now cache all the credits images
 	for (uint16 i = kRivenCreditsZeroImage; i <= kRivenCreditsLastImage; i++) {
 		MohawkSurface *surface = _bitmapDecoder->decodeImage(_vm->getExtrasResource(ID_TBMP, i));

--- a/engines/mohawk/riven_stack.cpp
+++ b/engines/mohawk/riven_stack.cpp
@@ -258,7 +258,9 @@ void RivenStack::runCredits(uint16 video, uint32 delay, uint32 videoFrameCountOv
 		_vm->doFrame();
 	}
 
-	_vm->setGameEnded();
+	videoPtr->stop();
+	_vm->_cursor->showCursor();
+	_vm->restart();
 }
 
 void RivenStack::installCardTimer() {

--- a/engines/mohawk/riven_stacks/ospit.cpp
+++ b/engines/mohawk/riven_stacks/ospit.cpp
@@ -142,7 +142,6 @@ void OSpit::xbookclick(const ArgumentArray &args) {
 	// use the trap book, he will shoot the player. Dead on arrival.
 	// Run the credits from here.
 	if (_vm->_vars["agehn"] == 3) {
-		_vm->_scriptMan->stopAllScripts();
 		runCredits(args[0], 5000, 995);
 		return;
 	}


### PR DESCRIPTION
Like the original, the game now returns to main menu upon the
credits finishing. The game cannot be resumed.

The states have been reset so combos are changed and puzzles are reset.