### PR TITLE
MOHAWK: RIVEN: Let credits roll longer

### DIFF
--- a/engines/mohawk/riven_graphics.h
+++ b/engines/mohawk/riven_graphics.h
@@ -58,6 +58,13 @@ enum RivenTransitionMode {
 	kRivenTransitionModeBest     = 5003
 };
 
+enum RivenCreditsImageNumber {
+	kRivenCreditsZeroImage   = 302,
+	kRivenCreditsFirstImage  = 303,
+	kRivenCreditsSecondImage = 304,
+	kRivenCreditsLastImage   = 320
+};
+
 class RivenGraphics : public GraphicsManager {
 public:
 	explicit RivenGraphics(MohawkEngine_Riven *vm);

--- a/engines/mohawk/riven_stack.cpp
+++ b/engines/mohawk/riven_stack.cpp
@@ -237,7 +237,7 @@ void RivenStack::runCredits(uint16 video, uint32 delay, uint32 videoFrameCountOv
 		frameCount = videoPtr->getFrameCount();
 	}
 
-	while (!_vm->hasGameEnded() && _vm->_gfx->getCurCreditsImage() <= 320) {
+	while (!_vm->hasGameEnded() && _vm->_gfx->getCurCreditsImage() <= kRivenCreditsLastImage) {
 		if (videoPtr->getCurFrame() >= frameCount - 1) {
 			if (nextCreditsFrameStart == 0) {
 				videoPtr->disable();
@@ -246,7 +246,7 @@ void RivenStack::runCredits(uint16 video, uint32 delay, uint32 videoFrameCountOv
 			} else if (_vm->getTotalPlayTime() >= nextCreditsFrameStart) {
 				// the first two frames stay on for 4 seconds
 				// the rest of the scroll updates happen at 60Hz
-				if (_vm->_gfx->getCurCreditsImage() < 304)
+				if (_vm->_gfx->getCurCreditsImage() < kRivenCreditsSecondImage)
 					nextCreditsFrameStart = _vm->getTotalPlayTime() + 4000;
 				else
 					nextCreditsFrameStart = _vm->getTotalPlayTime() + 1000 / 60;
@@ -258,6 +258,21 @@ void RivenStack::runCredits(uint16 video, uint32 delay, uint32 videoFrameCountOv
 		_vm->doFrame();
 	}
 
+	// Let the last frame of credits keep scrolling till black
+	uint currFrameTime = _vm->getTotalPlayTime();
+	nextCreditsFrameStart = currFrameTime + 1000 / 60;
+	uint endFrameTime = currFrameTime + 8000; // 8 seconds
+	uint sleepTime = 0;
+
+	while(currFrameTime < endFrameTime) {
+		if (sleepTime > 0)
+			_vm->delay(sleepTime);
+		nextCreditsFrameStart += 1000 / 60;
+		_vm->_gfx->updateCredits();
+		_vm->doFrame();
+		currFrameTime = _vm->getTotalPlayTime();
+		sleepTime = nextCreditsFrameStart - currFrameTime;
+	}
 	_vm->setGameEnded();
 }
 


### PR DESCRIPTION
Fixes Trac#10675.

Previously, the credits ended as soon as the last row was shown
of the final credits image.

Now some more black rows (empty rows) are shown and finally a few
seconds of black. I set it to 8 seconds of wait beyond where
the credits where previously stopping.

In order to do this updateCredits was enhanced to work past the end
of the last credits image (and just keep adding empty rows).

The original game shows a black screen for a longer period than this.

The first and last credit image indices were also assigned to #defines.