### PR TITLE
CRYO: EDEN: Move graphics into a separate class

### DIFF
--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -42,6 +42,7 @@
 #include "cryo/cryolib.h"
 #include "cryo/eden.h"
 #include "cryo/sound.h"
+#include "cryo/eden_graphics.h"
 
 namespace Cryo {
 
@@ -62,28 +63,26 @@ EdenGame::EdenGame(CryoEngine *vm) : _vm(vm), kMaxMusicSize(2200000) {
 		{ 0x81, 0x90,    1, 0x10}
 	};
 
+	_graphics = nullptr;
+
 	_adamMapMarkPos = Common::Point(-1, -1);
 
 	_scrollPos = _oldScrollPos = 0;
 	_frescoTalk = false;
 	_torchCursor = false;
 	_curBankNum = 0;
-	_glowH = _glowW = _glowY = _glowX = 0;
 	_paletteUpdateRequired = false;
 	_cursorSaved = false;
-	_showBlackBars = false;
 	_backgroundSaved = false;
 	_bankData = nullptr;
 	_tyranPtr = nullptr;
 	_lastAnimFrameNumb = _curAnimFrameNumb = 0;
 	_lastAnimTicks = 0;
-	_curCharacterRect = nullptr;
 	_numAnimFrames = _maxPersoDesc = _numImgDesc = 0;
 	_restartAnimation = _animationActive = false;
 	_animationDelay = _animationIndex = _lastAnimationIndex = 0;
 	dword_30724 = dword_30728 = _mouthAnimations = _animationTable = nullptr;
 	_characterBankData = nullptr;
-	_savedUnderSubtitles = false;
 	_numTextLines = 0;
 	_textOutPtr = textout = nullptr;
 	_curSpecialObject = nullptr;
@@ -94,7 +93,7 @@ EdenGame::EdenGame(CryoEngine *vm) : _vm(vm), kMaxMusicSize(2200000) {
 	_lastPhrasesFile = 0;
 	_dialogSkipFlags = 0;
 	_voiceSamplesBuffer = nullptr;
-	_needToFade = false;
+	
 	_mainBankBuf = nullptr;
 	_musicBuf = nullptr;
 	_gameLipsync = nullptr;
@@ -115,7 +114,6 @@ EdenGame::EdenGame(CryoEngine *vm) : _vm(vm), kMaxMusicSize(2200000) {
 	_musicChannel = _voiceChannel = nullptr;
 	_hnmSoundChannel = nullptr;
 	_voiceSound = nullptr;
-	_view2 = _underSubtitlesView = _subtitlesView = _underBarsView = _mainView = _hnmView = nullptr;
 	_cirsorPanX = 0;
 	_inventoryScrollDelay = 0;
 	_cursorPosY = _cursorPosX = 0;
@@ -123,7 +121,6 @@ EdenGame::EdenGame(CryoEngine *vm) : _vm(vm), kMaxMusicSize(2200000) {
 	_currSpot = _curSpot2 = nullptr;
 	_mouseHeld = false;
 	_normalCursor = false;
-	_showVideoSubtitle = false;
 	_specialTextMode = false;
 	_voiceSamplesSize = 0;
 	_animateTalking = false;
@@ -172,21 +169,24 @@ EdenGame::EdenGame(CryoEngine *vm) : _vm(vm), kMaxMusicSize(2200000) {
 	_cursCenter = 11;
 }
 
+EdenGame::~EdenGame() {
+}
+
 void EdenGame::removeConsole() {
 }
 
 void EdenGame::scroll() {
 	restoreFriezes();
-	_mainView->_normal._srcLeft = _scrollPos;
-	_mainView->_zoom._srcLeft = _scrollPos;
+	_graphics->getMainView()->_normal._srcLeft = _scrollPos;
+	_graphics->getMainView()->_zoom._srcLeft = _scrollPos;
 }
 
 void EdenGame::resetScroll() {
 	_oldScrollPos = _scrollPos;
 	_scrollPos = 0;
 	restoreFriezes();   //TODO: inlined scroll() ?
-	_mainView->_normal._srcLeft = 0;
-	_mainView->_zoom._srcLeft = 0;
+	_graphics->getMainView()->_normal._srcLeft = 0;
+	_graphics->getMainView()->_zoom._srcLeft = 0;
 }
 
 void EdenGame::scrollFrescoes() {
@@ -199,18 +199,27 @@ void EdenGame::scrollFrescoes() {
 	scroll();
 }
 
+bool EdenGame::animationIsActive() {
+	return _animationActive;
+}
+
 // Original name: afffresques
 void EdenGame::displayFrescoes() {
 	useBank(_globals->_frescoeImgBank);
-	drawSprite(0, 0, 16);
+	_graphics->drawSprite(0, 0, 16);
 	useBank(_globals->_frescoeImgBank + 1);
-	drawSprite(0, 320, 16);
+	_graphics->drawSprite(0, 320, 16);
 	_paletteUpdateRequired = true;
+}
+
+void EdenGame::setVolume(uint16 vol) {
+	_hnmSoundChannel->setVolumeLeft(vol);
+	_hnmSoundChannel->setVolumeRight(vol);
 }
 
 void EdenGame::gametofresques() {
 	_frescoTalk = false;
-	rundcurs();
+	_graphics->rundcurs();
 	saveFriezes();
 	displayFrescoes();
 	_globals->_displayFlags = DisplayFlags::dfFrescoes;
@@ -220,8 +229,8 @@ void EdenGame::gametofresques() {
 void EdenGame::doFrescoes() {
 	_cursorSaved = false;
 	_torchCursor = true;
-	_glowX = -1;
-	_glowY = -1;
+	_graphics->setGlowX(-1);
+	_graphics->setGlowY(-1);
 	_globals->_gameFlags |= GameFlags::gfFlag20;
 	_globals->_varD4 = 0;
 	_globals->_curObjectId = 0;
@@ -275,7 +284,7 @@ void EdenGame::scrollPanel() {
 // Original name: affsuiveur
 void EdenGame::displayFollower(Follower *follower, int16 x, int16 y) {
 	useBank(follower->_spriteBank);
-	drawSprite(follower->_spriteNum, x, y + 16);
+	_graphics->drawSprite(follower->_spriteNum, x, y + 16);
 }
 
 // Original name: persoinmiroir
@@ -331,7 +340,7 @@ void EdenGame::characterInMirror() {
 // Original name: gametomiroir
 void EdenGame::gameToMirror(byte arg1) {
 	if (_globals->_displayFlags != DisplayFlags::dfFlag2) {
-		rundcurs();
+		_graphics->rundcurs();
 		restoreFriezes();
 		drawTopScreen();
 		showObjects();
@@ -343,9 +352,9 @@ void EdenGame::gameToMirror(byte arg1) {
 			resNum = 2487;				// PCIMG.HSQ
 
 	useBank(resNum);
-	drawSprite(0, 0, 16);
+	_graphics->drawSprite(0, 0, 16);
 	useBank(resNum + 1);
-	drawSprite(0, 320, 16);
+	_graphics->drawSprite(0, 320, 16);
 	characterInMirror();
 	_paletteUpdateRequired = true;
 	_globals->_iconsIndex = 16;
@@ -359,7 +368,7 @@ void EdenGame::flipMode() {
 		endCharacterSpeech();
 		if (_globals->_displayFlags == DisplayFlags::dfPerson) {
 			if (_globals->_characterPtr == &_persons[PER_TAU] && _globals->_phaseNum >= 80)
-				displaySubtitles();
+				_graphics->displaySubtitles();
 			else {
 				getDataSync();
 				loadCurrCharacter();
@@ -368,7 +377,7 @@ void EdenGame::flipMode() {
 				animCharacter();
 			}
 		} else
-			displaySubtitles();
+			_graphics->displaySubtitles();
 		persovox();
 	} else {
 		if (_globals->_displayFlags != DisplayFlags::dfFrescoes && _globals->_displayFlags != DisplayFlags::dfFlag2) {
@@ -390,7 +399,7 @@ void EdenGame::flipMode() {
 
 // Original name: quitmiroir
 void EdenGame::quitMirror() {
-	rundcurs();
+	_graphics->rundcurs();
 	display();
 	resetScroll();
 	saveFriezes();
@@ -414,7 +423,7 @@ void EdenGame::actionClickValleyPlan() {
 	if (_globals->_roomNum == 8 || _globals->_roomNum < 16)
 		return;
 
-	rundcurs();
+	_graphics->rundcurs();
 	display();
 	if (_globals->_displayFlags == DisplayFlags::dfMirror)
 		quitMirror();
@@ -438,9 +447,9 @@ void EdenGame::gotoPlace(Goto *go) {
 			closeCharacterScreen();
 	}
 	if (go->_enterVideoNum) {
-		hideBars();
-		playHNM(go->_enterVideoNum);
-		_needToFade = true;
+		_graphics->hideBars();
+		_graphics->playHNM(go->_enterVideoNum);
+		_graphics->setFade(true);
 	}
 	initPlace(_globals->_newRoomNum);
 	specialoutside();
@@ -543,7 +552,7 @@ void EdenGame::move(Direction dir) {
 	int16 roomNum = _globals->_roomNum;
 	debug("move: from room %4X", roomNum);
 	char newLoc = 0;
-	rundcurs();
+	_graphics->rundcurs();
 	display();
 	_globals->_prevLocation = roomNum & 0xFF;
 	switch (dir) {
@@ -589,8 +598,8 @@ void EdenGame::move2(Direction dir) {
 // Original name: dinosoufle
 void EdenGame::actionDinoBlow() {
 	if (_globals->_curObjectId == 0) {
-		hideBars();
-		playHNM(148);
+		_graphics->hideBars();
+		_graphics->playHNM(148);
 		maj2();
 	}
 }
@@ -600,9 +609,9 @@ void EdenGame::actionPlateMonk() {
 	if (_globals->_curObjectId != 0) {
 		if (_globals->_curObjectId == Objects::obPrism) {
 			loseObject(Objects::obPrism);
-			hideBars();
+			_graphics->hideBars();
 			_specialTextMode = true;
-			playHNM(89);
+			_graphics->playHNM(89);
 			// CHECKME: Unused code
 			// word_2F514 |= 0x8000;
 			maj2();
@@ -610,8 +619,8 @@ void EdenGame::actionPlateMonk() {
 			showEvents();
 		}
 	} else {
-		hideBars();
-		playHNM(7);
+		_graphics->hideBars();
+		_graphics->playHNM(7);
 		maj2();
 		_globals->_eventType = EventType::etEvent4;
 		showEvents();
@@ -722,7 +731,7 @@ void EdenGame::handleDinaDialog() {
 			bool res = dialoscansvmas((Dialog *)getElem(_gameDialogs, num));
 			_frescoTalk = false;
 			if (res) {
-				restoreUnderSubtitles();
+				_graphics->restoreUnderSubtitles();
 				_frescoTalk = true;
 				persovox();
 			}
@@ -731,6 +740,22 @@ void EdenGame::handleDinaDialog() {
 		} else
 			actionEndFrescoes();
 	}
+}
+
+int16 EdenGame::getCurPosX() {
+	return _cursorPosX;
+}
+
+int16 EdenGame::getCurPosY() {
+	return _cursorPosY;
+}
+
+void EdenGame::setCurPosX(int16 xpos) {
+	_cursorPosX = xpos;
+}
+
+void EdenGame::setCurPosY(int16 ypos) {
+	_cursorPosY = ypos;
 }
 
 // Original name: roiparle
@@ -743,8 +768,8 @@ void EdenGame::handleKingDialog() {
 void EdenGame::actionKingDialog1() {
 	if (_globals->_curObjectId == Objects::obSword) {
 		_globals->_gameFlags |= GameFlags::gfFlag80;
-		hideBars();
-		playHNM(76);
+		_graphics->hideBars();
+		_graphics->playHNM(76);
 		move2(kCryoNorth);
 	} else {
 		_globals->_frescoNumber = 1;
@@ -863,8 +888,8 @@ void EdenGame::actionGetTablet() {
 	_gameIcons[16]._cursorId |= 0x8000;
 	showObjects();
 	_gameRooms[131]._video = 0;
-	hideBars();
-	playHNM(149);
+	_graphics->hideBars();
+	_graphics->playHNM(149);
 	_globals->_varF1 = RoomFlags::rf04;
 	_globals->_drawFlags = DrawFlags::drDrawFlag20;
 	_normalCursor = true;
@@ -893,8 +918,8 @@ void EdenGame::actionLookLake() {
 		room->_id = 3;
 	}
 	debug("sea monster: room = %X, d0 = %X\n", _globals->_roomNum, _globals->_roomImgBank);
-	hideBars();
-	playHNM(vid);
+	_graphics->hideBars();
+	_graphics->playHNM(vid);
 	updateRoom(_globals->_roomNum);           //TODO: getting memory trashed here?
 	if (_globals->_curObjectId == Objects::obApple)
 		loseObject(Objects::obApple);
@@ -935,7 +960,7 @@ void EdenGame::actionGotoFullNest() {
 // Original name: gotoval
 void EdenGame::actionGotoVal() {
 	uint16 target = _globals->_roomNum;
-	rundcurs();
+	_graphics->rundcurs();
 	display();
 	_scrollPos = 0;
 	char obj = _curSpot2->_objectId - 14;    //TODO
@@ -945,8 +970,8 @@ void EdenGame::actionGotoVal() {
 
 // Original name: visiter
 void EdenGame::actionVisit() {
-	hideBars();
-	playHNM(144);
+	_graphics->hideBars();
+	_graphics->playHNM(144);
 	_globals->_varF1 = RoomFlags::rf04;
 	maj2();
 }
@@ -956,10 +981,10 @@ void EdenGame::actionFinal() {
 	if (_globals->_curObjectId != 0)
 		return;
 
-	hideBars();
+	_graphics->hideBars();
 	*(int16 *)(_gameRooms + 0x6DC) = 319; //TODO
 	_globals->_roomImgBank = 319;
-	playHNM(97);
+	_graphics->playHNM(97);
 	maj2();
 	_globals->_eventType = EventType::etEvent12;
 	showEvents();
@@ -995,14 +1020,14 @@ void EdenGame::display() {
 	if (!_globals->_mirrorEffect && !_globals->_var103) {
 		if (_paletteUpdateRequired) {
 			_paletteUpdateRequired = false;
-			CLPalette_Send2Screen(_globalPalette, 0, 256);
+			_graphics->SendPalette2Screen(256);
 		}
-		CLBlitter_CopyView2Screen(_mainView);
+		CLBlitter_CopyView2Screen(_graphics->getMainView());
 	} else {
 		if (_globals->_mirrorEffect)
-			displayEffect3();
+			_graphics->displayEffect3();
 		else
-			displayEffect2();
+			_graphics->displayEffect2();
 
 		_globals->_var103 = 0;
 		_globals->_mirrorEffect = 0;
@@ -1011,57 +1036,35 @@ void EdenGame::display() {
 
 void EdenGame::afficher128() {
 	if (_globals->_updatePaletteFlag == 16) {
-		CLPalette_Send2Screen(_globalPalette, 0, 129);
-		CLBlitter_CopyView2Screen(_mainView);
+		_graphics->SendPalette2Screen(129);
+		CLBlitter_CopyView2Screen(_graphics->getMainView());
 		_globals->_updatePaletteFlag = 0;
 	} else {
-		clearScreen();
-		fadeToBlackLowPalette(1);
-		if (_showBlackBars)
-			drawBlackBars();
-		CLBlitter_CopyView2Screen(_mainView);
-		fadeFromBlackLowPalette(1);
+		_graphics->clearScreen();
+		_graphics->fadeToBlackLowPalette(1);
+		if (_graphics->getShowBlackBars())
+			_graphics->drawBlackBars();
+		CLBlitter_CopyView2Screen(_graphics->getMainView());
+		_graphics->fadeFromBlackLowPalette(1);
 	}
 }
 
 // Original name: sauvefrises
 void EdenGame::saveFriezes() {
-	saveTopFrieze(0);
-	saveBottomFrieze();
-}
-
-// Original name: sauvefriseshaut
-void EdenGame::saveTopFrieze(int16 x) { // Save top bar
-	_underTopBarScreenRect = Common::Rect(x, 0, x + 320 - 1, 15);
-	_underTopBarBackupRect = Common::Rect(0, 0, 320 - 1, 15);
-	CLBlitter_CopyViewRect(_mainView, _underBarsView, &_underTopBarScreenRect, &_underTopBarBackupRect);
-}
-
-// Original name: sauvefrisesbas
-void EdenGame::saveBottomFrieze() {         // Save bottom bar
-	_underBottomBarScreenRect.left = 0;
-	_underBottomBarScreenRect.right = 320 - 1;
-	CLBlitter_CopyViewRect(_mainView, _underBarsView, &_underBottomBarScreenRect, &_underBottomBarBackupRect);
+	_graphics->saveTopFrieze(0);
+	_graphics->saveBottomFrieze();
 }
 
 // Original name: restaurefrises
 void EdenGame::restoreFriezes() {
-	restoreTopFrieze();
-	restoreBottomFrieze();
+	_graphics->restoreTopFrieze();
+	_graphics->restoreBottomFrieze();
 }
 
-// Original name: restaurefriseshaut
-void EdenGame::restoreTopFrieze() {
-	_underTopBarScreenRect.left = _scrollPos;
-	_underTopBarScreenRect.right = _scrollPos + 320 - 1;
-	CLBlitter_CopyViewRect(_underBarsView, _mainView, &_underTopBarBackupRect, &_underTopBarScreenRect);
-}
 
-// Original name: restaurefrisesbas
-void EdenGame::restoreBottomFrieze() {
-	_underBottomBarScreenRect.left = _scrollPos;
-	_underBottomBarScreenRect.right = _scrollPos + 320 - 1;
-	CLBlitter_CopyViewRect(_underBarsView, _mainView, &_underBottomBarBackupRect, &_underBottomBarScreenRect);
+
+byte * EdenGame::getBankData() {
+	return _bankData;
 }
 
 void EdenGame::useMainBank() {
@@ -1085,68 +1088,15 @@ void EdenGame::useBank(int16 bank) {
 	}
 }
 
-void EdenGame::readPalette(byte *ptr) {
-	bool doit = true;
-	color3_t pal_entry;
-	while (doit) {
-		uint16 idx = *ptr++;
-		if (idx != 0xFF) {
-			uint16 cnt = *ptr++;
-			while (cnt--) {
-				if (idx == 0) {
-					pal_entry.r = 0;
-					pal_entry.g = 0;
-					pal_entry.b = 0;
-					ptr += 3;
-				} else {
-					pal_entry.r = *ptr++ << 10;
-					pal_entry.g = *ptr++ << 10;
-					pal_entry.b = *ptr++ << 10;
-				}
-				CLPalette_SetRGBColor(_globalPalette, idx, &pal_entry);
-				idx++;
-			}
-		} else
-			doit = false;
-	}
-}
-
-// Original name: sauvefondbouche
-void EdenGame::saveMouthBackground() {
-	rect_src.left = _curCharacterRect->left;
-	rect_src.top = _curCharacterRect->top;
-	rect_src.right = _curCharacterRect->right;
-	rect_src.bottom = _curCharacterRect->bottom;
-	rect_dst.left = _curCharacterRect->left + 320;
-	rect_dst.top = _curCharacterRect->top;
-	rect_dst.right = _curCharacterRect->right + 320;
-	rect_dst.bottom = _curCharacterRect->bottom;
-	CLBlitter_CopyViewRect(_mainView, _mainView, &rect_src, &rect_dst);
-	_backgroundSaved = true;
-}
-
-// Original name: restaurefondbouche
-void EdenGame::restoreMouthBackground() {
-	rect_src.left = _curCharacterRect->left;
-	rect_src.top = _curCharacterRect->top;
-	rect_src.right = _curCharacterRect->right;
-	rect_src.bottom = _curCharacterRect->bottom;
-	rect_dst.left = _curCharacterRect->left + 320;
-	rect_dst.top = _curCharacterRect->top;
-	rect_dst.right = _curCharacterRect->right + 320;
-	rect_dst.bottom = _curCharacterRect->bottom;
-	CLBlitter_CopyViewRect(_mainView, _mainView, &rect_dst, &rect_src);
-}
-
 void EdenGame::drawTopScreen() {  // Draw  top bar (location / party / map)
 	_globals->_drawFlags &= ~DrawFlags::drDrawTopScreen;
 	useBank(314);
-	drawSprite(36, 83, 0);
-	drawSprite(_globals->_areaPtr->_num - 1, 0, 0);
-	drawSprite(23, 145, 0);
+	_graphics->drawSprite(36, 83, 0);
+	_graphics->drawSprite(_globals->_areaPtr->_num - 1, 0, 0);
+	_graphics->drawSprite(23, 145, 0);
 	for (perso_t *perso = &_persons[PER_DINA]; perso != &_persons[PER_UNKN_156]; perso++) {
 		if ((perso->_flags & PersonFlags::pfInParty) && !(perso->_flags & PersonFlags::pf80))
-			drawSprite(perso->_targetLoc + 18, perso->_lastLoc + 120, 0);
+			_graphics->drawSprite(perso->_targetLoc + 18, perso->_lastLoc + 120, 0);
 	}
 	_adamMapMarkPos.x = -1;
 	_adamMapMarkPos.y = -1;
@@ -1157,7 +1107,7 @@ void EdenGame::drawTopScreen() {  // Draw  top bar (location / party / map)
 // Original name: affplanval
 void EdenGame::displayValleyMap() { // Draw mini-map
 	if (_globals->_areaPtr->_type == AreaType::atValley) {
-		drawSprite(_globals->_areaPtr->_num + 9, 266, 1);
+		_graphics->drawSprite(_globals->_areaPtr->_num + 9, 266, 1);
 		for (perso_t *perso = &_persons[PER_UNKN_18C]; perso->_roomNum != 0xFFFF; perso++) {
 			if (((perso->_roomNum >> 8) == _globals->_areaNum)
 			        && !(perso->_flags & PersonFlags::pf80) && (perso->_flags & PersonFlags::pf20))
@@ -1165,20 +1115,20 @@ void EdenGame::displayValleyMap() { // Draw mini-map
 		}
 		if (_globals->_areaPtr->_citadelLevel)
 			displayMapMark(34, _globals->_areaPtr->_citadelRoomPtr->_location);
-		saveTopFrieze(0);
+		_graphics->saveTopFrieze(0);
 		int16 loc = _globals->_roomNum & 0xFF;
 		if (loc >= 16)
 			displayAdamMapMark(loc);
-		restoreTopFrieze();
+		_graphics->restoreTopFrieze();
 	} else {
-		saveTopFrieze(0);
-		restoreTopFrieze();
+		_graphics->saveTopFrieze(0);
+		_graphics->restoreTopFrieze();
 	}
 }
 
 // Original name: affrepere
 void EdenGame::displayMapMark(int16 index, int16 location) {
-	drawSprite(index, 269 + location % 16 * 4, 2 + (location - 16) / 16 * 3);
+	_graphics->drawSprite(index, 269 + location % 16 * 4, 2 + (location - 16) / 16 * 3);
 }
 
 // Original name: affrepereadam
@@ -1190,8 +1140,8 @@ void EdenGame::displayAdamMapMark(int16 location) {
 		x += (location & 15) * 4;
 		y += ((location - 16) >> 4) * 3;
 		saveAdamMapMark(x, y);
-		byte *pix = _underBarsView->_bufferPtr;
-		int16 w = _underBarsView->_width;
+		byte *pix = _graphics->getUnderBarsView()->_bufferPtr;
+		int16 w = _graphics->getUnderBarsView()->_width;
 		pix += x + w * y;
 		pix[1] = 0xC3;
 		pix[2] = 0xC3;
@@ -1213,8 +1163,8 @@ void EdenGame::restoreAdamMapMark() {
 
 	int16 x = _adamMapMarkPos.x;
 	int16 y = _adamMapMarkPos.y;
-	byte *pix = _underBarsView->_bufferPtr;
-	int16 w = _underBarsView->_width;
+	byte *pix = _graphics->getUnderBarsView()->_bufferPtr;
+	int16 w = _graphics->getUnderBarsView()->_width;
 	pix += x + w * y;
 	pix[1] = _oldPix[0];
 	pix[2] = _oldPix[1];
@@ -1232,8 +1182,8 @@ void EdenGame::restoreAdamMapMark() {
 void EdenGame::saveAdamMapMark(int16 x, int16 y) {
 	_adamMapMarkPos.x = x;
 	_adamMapMarkPos.y = y;
-	byte *pix = _underBarsView->_bufferPtr;
-	int16 w = _underBarsView->_width;
+	byte *pix = _graphics->getUnderBarsView()->_bufferPtr;
+	int16 w = _graphics->getUnderBarsView()->_width;
 	pix += x + w * y;
 	_oldPix[0] = pix[1];
 	_oldPix[1] = pix[2];
@@ -1440,6 +1390,10 @@ void EdenGame::evolveCitadel(int16 level) {
 		if ((perso->_roomNum >> 8) == _globals->_citadelAreaNum && perso->_targetLoc == loc)
 			perso->_speed = speed;
 	}
+}
+
+int16 EdenGame::getCurBankNum() {
+	return _curBankNum;
 }
 
 // Original name: citacapoute
@@ -1807,11 +1761,15 @@ void EdenGame::addTime(int16 t) {
 	}
 }
 
+byte *EdenGame::getImageDesc() {
+	return _imageDesc;
+}
+
 // Original name: anim_perso
 void EdenGame::animCharacter() {
 	if (_curBankNum != _globals->_characterImageBank)
 		loadCharacter(_globals->_characterPtr);
-	restoreUnderSubtitles();
+	_graphics->restoreUnderSubtitles();
 	if (_restartAnimation) {
 		_lastAnimTicks = _vm->_timerTicks;
 		_restartAnimation = false;
@@ -1830,7 +1788,7 @@ void EdenGame::animCharacter() {
 		_mouthAnimations = _imageDesc + 200;
 		removeMouthSprite();
 		if (*_mouthAnimations)
-			displayImage();
+			_graphics->displayImage();
 		_animationDelay--;
 		if (!_animationDelay) {
 			_globals->_animationFlags = 1;
@@ -1846,8 +1804,10 @@ void EdenGame::animCharacter() {
 	if (_animateTalking) {
 		if (!_animationTable) {
 			_animationTable = _gameLipsync + 7262;    //TODO: fix me
-			if (!_backgroundSaved)
-				saveMouthBackground();
+			if (!_backgroundSaved) {
+				_graphics->saveMouthBackground();
+				_backgroundSaved = true;
+			}
 		}
 		if (!_personTalking)
 			_curAnimFrameNumb = _numAnimFrames - 1;
@@ -1856,16 +1816,16 @@ void EdenGame::animCharacter() {
 			_animateTalking = false;
 		else if (_animationIndex != _lastAnimationIndex) {
 			useCharacterBank();
-			restoreMouthBackground();
+			_graphics->restoreMouthBackground();
 //			debug("perso spr %d", animationIndex);
 			setCharacterSprite(_globals->_persoSpritePtr2 + _animationIndex * 2);  //TODO: int16s?
 			_mouthAnimations = _imageDesc + 200;
 			if (*_mouthAnimations)
-				displayImage();
+				_graphics->displayImage();
 			_lastAnimationIndex = _animationIndex;
 		}
 	}
-	displaySubtitles();
+	_graphics->displaySubtitles();
 }
 
 void EdenGame::getanimrnd() {
@@ -1900,7 +1860,7 @@ void EdenGame::addanim() {
 	if (_globals->_characterPtr->_id != PersonId::pidCabukaOfCantura && _globals->_characterPtr->_targetLoc != 7) //TODO: targetLoc is minisprite idx
 		removeMouthSprite();
 	if (*_mouthAnimations)
-		displayImage();
+		_graphics->displayImage();
 }
 
 // Original name: virespritebouche
@@ -1969,7 +1929,7 @@ void EdenGame::setCharacterSprite(byte *spr) {
 // Original name: af_perso1
 void EdenGame::displayCharacter1() {
 	setCharacterSprite(_globals->_persoSpritePtr + READ_LE_UINT16(_globals->_persoSpritePtr));
-	displayImage();
+	_graphics->displayImage();
 }
 
 // Original name: af_perso
@@ -1989,7 +1949,7 @@ void EdenGame::loadCharacter(perso_t *perso) {
 		return;
 
 	if (perso->_spriteBank != _globals->_characterImageBank) {
-		_curCharacterRect = &_characterRects[perso->_id];   //TODO: array of int16?
+		_graphics->setCurCharRect(&_characterRects[perso->_id]); //TODO: array of int16?
 		dword_30728 = _characterArray[perso->_id];
 		ef_perso();
 		_globals->_characterImageBank = perso->_spriteBank;
@@ -2044,9 +2004,9 @@ void EdenGame::no_perso() {
 void EdenGame::closeCharacterScreen() {
 	endCharacterSpeech();
 	if (_globals->_displayFlags == DisplayFlags::dfPerson && _globals->_characterPtr->_id != PersonId::pidNarrator && _globals->_eventType != EventType::etEventE) {
-		rundcurs();
-		_savedUnderSubtitles = true;
-		restoreUnderSubtitles();
+		_graphics->rundcurs();
+		_graphics->setSavedUnderSubtitles(true);
+		_graphics->restoreUnderSubtitles();
 		display();
 		_globals->_var103 = 16;
 	}
@@ -2096,7 +2056,7 @@ void EdenGame::displayBackgroundFollower() {
 			if (follower->sx >= 320)
 				bank = 327;
 			useBank(bank + _globals->_roomBackgroundBankNum);
-			drawSprite(0, 0, 16, true);
+			_graphics->drawSprite(0, 0, 16, true);
 			break;
 		}
 	}
@@ -2106,10 +2066,18 @@ void EdenGame::displayNoFollower(int16 bank) {
 	if (bank) {
 		useBank(bank);
 		if (_globals->_characterPtr == &_persons[PER_UNKN_156])
-			drawSprite(0, 0, 16, true);
+			_graphics->drawSprite(0, 0, 16, true);
 		else
-			drawSprite(0, 0, 16);
+			_graphics->drawSprite(0, 0, 16);
 	}
+}
+
+int16 EdenGame::getGameIconX(int16 index) {
+	return _gameIcons[index].sx;
+}
+
+int16 EdenGame::getGameIconY(int16 index) {
+	return _gameIcons[index].sy;
 }
 
 // Original name: af_fondperso1
@@ -2193,11 +2161,11 @@ void EdenGame::showCharacter() {
 			setCharacterIcon();
 			displayCharacterBackground();
 			if (perso == &_persons[PER_TAU] && _globals->_curObjectId == Objects::obShell) {
-				displaySubtitles();
+				_graphics->displaySubtitles();
 				updateCursor();
 				_paletteUpdateRequired = true;
 				display();
-				rundcurs();
+				_graphics->rundcurs();
 				return;
 			}
 		}
@@ -2205,7 +2173,7 @@ void EdenGame::showCharacter() {
 		addanim();
 		if (!_globals->_curCharacterAnimPtr) {
 			displayCharacter();
-			displaySubtitles();
+			_graphics->displaySubtitles();
 		}
 		_restartAnimation = true;
 		animCharacter();
@@ -2213,11 +2181,11 @@ void EdenGame::showCharacter() {
 			updateCursor();
 		_paletteUpdateRequired = true;
 		if (perso != &_persons[PER_UNKN_156])
-			rundcurs();
+			_graphics->rundcurs();
 		display();
 	} else {
 		displayPlace();
-		displaySubtitles();
+		_graphics->displaySubtitles();
 	}
 }
 
@@ -2228,7 +2196,7 @@ void EdenGame::displayCharacterPanel() {
 	addanim();
 	if (!_globals->_curCharacterAnimPtr) {
 		displayCharacter();
-		displaySubtitles();
+		_graphics->displaySubtitles();
 	}
 	_restartAnimation = true;
 	_paletteUpdateRequired = true;
@@ -2239,7 +2207,7 @@ void EdenGame::displayCharacterPanel() {
 		updateCursor();
 	display();
 	if (perso != &_persons[PER_UNKN_156])
-		rundcurs();
+		_graphics->rundcurs();
 	_globals->_drawFlags |= DrawFlags::drDrawFlag8;
 	_globals->_iconsIndex = 112;
 }
@@ -2291,6 +2259,10 @@ void EdenGame::waitEndSpeak() {
 				_mouseHeld = false;
 	}
 	_mouseHeld = true;
+}
+
+int16 EdenGame::getNumTextLines() {
+	return _numTextLines;
 }
 
 void EdenGame::my_bulle() {
@@ -2402,19 +2374,31 @@ void EdenGame::my_bulle() {
 		byte x = *icons++;
 		byte y = *icons++;
 		byte s = *icons++;
-		drawSprite(52, x + _subtitlesXCenter, y - 1, false, true);
-		drawSprite(s + 9, x + _subtitlesXCenter + 1, y, false, true);
+		_graphics->drawSprite(52, x + _subtitlesXCenter, y - 1, false, true);
+		_graphics->drawSprite(s + 9, x + _subtitlesXCenter + 1, y, false, true);
 	}
 }
 
+int16 EdenGame::getScrollPos() {
+	return _scrollPos;
+}
+
+bool EdenGame::getSpecialTextMode() {
+	return _specialTextMode;
+}
+
+void EdenGame::setSpecialTextMode(bool value) {
+	_specialTextMode = value;
+}
+
 void EdenGame::my_pr_bulle() {
-	CLBlitter_FillView(_subtitlesView, 0);
+	CLBlitter_FillView(_graphics->getSubtitlesView(), 0);
 	if (_globals->_prefLanguage == 0)
 		return;
 
 	byte *coo = _sentenceCoordsBuffer;
 	bool done = false;
-	textout = _subtitlesViewBuf;
+	textout = _graphics->getSubtitlesViewBuf();
 	byte *textPtr = _sentenceBuffer;
 	int16 lines = 1;
 	while (!done) {
@@ -2480,41 +2464,6 @@ void EdenGame::drawSubtitleChar(byte c, byte color, int16 width) {
 			mask >>= 1;
 		}
 		_textOutPtr += _subtitlesXWidth - width;
-	}
-}
-
-// Original name: sauvefondbulle
-void EdenGame::saveUnderSubtitles(int16 y) {
-	_underSubtitlesScreenRect.top = y - _numTextLines * FONT_HEIGHT;
-	_underSubtitlesScreenRect.left = _scrollPos + _subtitlesXScrMargin;
-	_underSubtitlesScreenRect.right = _scrollPos + _subtitlesXScrMargin + _subtitlesXWidth - 1;
-	_underSubtitlesScreenRect.bottom = y;
-	_underSubtitlesBackupRect.top = 0;
-	_underSubtitlesBackupRect.bottom = _numTextLines * FONT_HEIGHT;
-	CLBlitter_CopyViewRect(_mainView, _underSubtitlesView, &_underSubtitlesScreenRect, &_underSubtitlesBackupRect);
-	_savedUnderSubtitles = true;
-}
-
-// Original name: restaurefondbulle
-void EdenGame::restoreUnderSubtitles() {
-	if (!_savedUnderSubtitles)
-		return;
-	CLBlitter_CopyViewRect(_underSubtitlesView, _mainView, &_underSubtitlesBackupRect, &_underSubtitlesScreenRect);
-	_savedUnderSubtitles = false;
-}
-
-// Original name: af_subtitlehnm
-void EdenGame::displayHNMSubtitle() {
-	byte *src = _subtitlesViewBuf;
-	byte *dst = _hnmViewBuf + _subtitlesXScrMargin + (158 - _numTextLines * FONT_HEIGHT) * 320;
-	for (int16 y = 0; y < _numTextLines * FONT_HEIGHT; y++) {
-		for (int16 x = 0; x < _subtitlesXWidth; x++) {
-			char c = *src++;
-			if (c)
-				*dst = c;
-			dst++;
-		}
-		dst += 320 - _subtitlesXWidth;
 	}
 }
 
@@ -2706,7 +2655,7 @@ void EdenGame::handleCharacterDialog(int16 pers) {
 	uint16 idx = perso->_id * 8 | _globals->_dialogType;
 	dialoscansvmas((Dialog *)getElem(_gameDialogs, idx));
 	displayPlace();
-	displaySubtitles();
+	_graphics->displaySubtitles();
 	persovox();
 	_globals->_varCA = 0;
 	_globals->_dialogType = DialogType::dtTalk;
@@ -2939,12 +2888,12 @@ void EdenGame::actionAdam() {
 		int16 vid = 84;
 		if (!object->_count)
 			vid = *objvid;
-		hideBars();
+		_graphics->hideBars();
 		_specialTextMode = true;
-		playHNM(vid);
+		_graphics->playHNM(vid);
 		_paletteUpdateRequired = true;
 		_globals->_mirrorEffect = 16; // CHECKME: Verify the value
-		showBars();
+		_graphics->showBars();
 		gameToMirror(0);
 		}
 		break;
@@ -3480,6 +3429,10 @@ bool EdenGame::dialoscansvmas(Dialog *dial) {
 	return res;
 }
 
+byte *EdenGame::getGameDialogs() {
+	return _gameDialogs;
+}
+
 // Original name: dialo_even
 bool EdenGame::dialogEvent(perso_t *perso) {
 	_globals->_characterPtr = perso;
@@ -3500,12 +3453,12 @@ void EdenGame::characterStayHere() {
 
 // Original name: mort
 void EdenGame::endDeath(int16 vid) {
-	hideBars();
-	playHNM(vid);
-	fadeToBlack(2);
+	_graphics->hideBars();
+	_graphics->playHNM(vid);
+	_graphics->fadeToBlack(2);
 	CLBlitter_FillScreenView(0);
-	CLBlitter_FillView(_mainView, 0);
-	showBars();
+	CLBlitter_FillView(_graphics->getMainView(), 0);
+	_graphics->showBars();
 	_globals->_narratorSequence = 51;
 	_globals->_newMusicType = MusicType::mtNormal;
 	musique();
@@ -3773,26 +3726,11 @@ void EdenGame::initGlobals() {
 	_globals->_persoSpritePtr = nullptr;
 	_globals->_numGiveObjs = 0;
 
-	initRects();
+	_graphics->initRects();
 
-	_underSubtitlesScreenRect.top = 0;
-	_underSubtitlesScreenRect.left = _subtitlesXScrMargin;
-	_underSubtitlesScreenRect.right = _subtitlesXScrMargin + _subtitlesXWidth - 1;
-	_underSubtitlesScreenRect.bottom = 176 - 1;
+	_graphics->initGlobals();
 
-	_underSubtitlesBackupRect.top = 0;
-	_underSubtitlesBackupRect.left = _subtitlesXScrMargin;
-	_underSubtitlesBackupRect.right = _subtitlesXScrMargin + _subtitlesXWidth - 1;
-	_underSubtitlesBackupRect.bottom = 60 - 1;
-
-	_savedUnderSubtitles = false;
-}
-
-void EdenGame::initRects() {
-	_underTopBarScreenRect = Common::Rect(0, 0, 320 - 1, 16 - 1);
-	_underTopBarBackupRect = Common::Rect(0, 0, 320 - 1, 16 - 1);
-	_underBottomBarScreenRect = Common::Rect(0, 176, 320 - 1, 200 - 1);  //TODO: original bug? this cause crash in copyrect (this, underBottomBarBackupRect)
-	_underBottomBarBackupRect = Common::Rect(0, 16, 320 - 1, 40 - 1);
+	_graphics->setSavedUnderSubtitles(false);
 }
 
 // Original name: closesalle
@@ -3811,7 +3749,7 @@ void EdenGame::displayPlace() {
 		_globals->_autoDialog = false;
 	}
 	_globals->_nextRoomIcon = &_gameIcons[_roomIconsBase];
-	displayRoom();
+	_graphics->displayRoom();
 	_paletteUpdateRequired = true;
 }
 
@@ -3821,6 +3759,14 @@ void EdenGame::loadPlace(int16 num) {
 		return;
 	_globals->_lastPlaceNum = num;
 	loadRawFile(num + 419, _placeRawBuf);
+}
+
+byte EdenGame::getActionCursor(byte value) {
+	return _actionCursors[value];
+}
+
+byte *EdenGame::getPlaceRawBuf() {
+	return _placeRawBuf;
 }
 
 void EdenGame::specialoutside() {
@@ -3870,8 +3816,8 @@ void EdenGame::specialin() {
 	if (_globals->_roomNum == 3075 && _globals->_phaseNum == 546) {
 		incPhase();
 		if (_globals->_curItemsMask & 0x2000) { // Morkus' tablet
-			hideBars();
-			playHNM(92);
+			_graphics->hideBars();
+			_graphics->playHNM(92);
 			_gameRooms[129]._exits[0] = 0;
 			_gameRooms[129]._exits[2] = 1;
 			_globals->_roomNum = 3074;
@@ -3907,13 +3853,13 @@ void EdenGame::animpiece() {
 	if (_globals->_roomVidNum && _globals->_var100 != 0xFF) {
 		if (_globals->_valleyVidNum || !room->_level || (room->_flags & RoomFlags::rfHasCitadel)
 		        || room->_level == _globals->_var100) {
-			hideBars();
+			_graphics->hideBars();
 			_globals->_updatePaletteFlag = 16;
 			if (!(_globals->_narratorSequence & 0x80)) //TODO: bug? !() @ 100DC
 				_globals->_mirrorEffect = 0;
-			if (!_needToFade)
-				_needToFade = room->_flags & RoomFlags::rf02;
-			playHNM(_globals->_roomVidNum);
+			if (!_graphics->getFade())
+				_graphics->setFade(room->_flags & RoomFlags::rf02);
+			_graphics->playHNM(_globals->_roomVidNum);
 			return;
 		}
 	}
@@ -4029,16 +3975,16 @@ void EdenGame::maj2() {
 	if (_globals->_mirrorEffect || _globals->_var103)
 		display();
 	else if (_globals->_varF1 == (RoomFlags::rf40 | RoomFlags::rf04 | RoomFlags::rf01)) {
-		drawBlackBars();
-		displayEffect1();
+		_graphics->drawBlackBars();
+		_graphics->displayEffect1();
 	} else if (_globals->_varF1 && !(_globals->_varF1 & RoomFlags::rf04) && !r30) {
 		if (!(_globals->_displayFlags & DisplayFlags::dfPanable))
-			drawBlackBars();
+			_graphics->drawBlackBars();
 		else if (_globals->_valleyVidNum)
-			drawBlackBars();
-		displayEffect1();
+			_graphics->drawBlackBars();
+		_graphics->displayEffect1();
 	} else if (r30 && !(_globals->_varF1 & RoomFlags::rf04))
-		effetpix();
+		_graphics->effetpix();
 	else
 		afficher128();
 	musique();
@@ -4046,7 +3992,7 @@ void EdenGame::maj2() {
 		drawTopScreen();
 		showObjects();
 	}
-	showBars();
+	_graphics->showBars();
 	showEvents();
 	_globals->_labyrinthDirections = 0;
 	specialin();
@@ -4112,6 +4058,10 @@ void EdenGame::EmergencyExit() {
 	SysBeep(1);
 }
 
+void EdenGame::stopMusic() {
+	_musicChannel->stop();
+}
+
 void EdenGame::run() {
 	_invIconsCount = (_vm->getPlatform() == Common::kPlatformMacintosh) ? 9 : 11;
 	_roomIconsBase = _invIconsBase + _invIconsCount;
@@ -4127,10 +4077,12 @@ void EdenGame::run() {
 
 	_musicChannel = new CSoundChannel(_vm->_mixer, 11025, false);
 	_voiceChannel = new CSoundChannel(_vm->_mixer, 11025, false);
+	_graphics = new EdenGraphics(this,_vm->_video);
+	_graphics->setSavedUnderSubtitles(false);
 
 	allocateBuffers();
 	openbigfile();
-	openWindow();
+	_graphics->openWindow();
 	loadpermfiles();
 
 	if (!_bufferAllocationErrorFl) {
@@ -4145,16 +4097,16 @@ void EdenGame::run() {
 			_quitFlag3 = false;
 			_normalCursor = true;
 			_torchCursor = false;
-			_cursKeepPos = Common::Point(-1, -1);
+			_graphics->setCursKeepPos(-1,-1);
 			if (!_gameLoaded)
 				intro();
 			edmain();
 			startmusique(1);
-			drawBlackBars();
+			_graphics->drawBlackBars();
 			display();
-			fadeToBlack(3);
-			clearScreen();
-			playHNM(95);
+			_graphics->fadeToBlack(3);
+			_graphics->clearScreen();
+			_graphics->playHNM(95);
 			if (_globals->_endGameFlag == 50) {
 				loadrestart();
 				_gameLoaded = false;
@@ -4167,10 +4119,12 @@ void EdenGame::run() {
 		// LostEdenMac_SavePrefs();
 	}
 
+	_graphics->fadeToBlack(4);
+
 	delete _voiceChannel;
 	delete _musicChannel;
+	delete _graphics;
 
-	fadeToBlack(4);
 	closebigfile();
 	freebuf();
 	CRYOLib_ManagersDone();
@@ -4184,12 +4138,12 @@ void EdenGame::edmain() {
 			// if in demo mode, reset game after a while
 			_demoCurrentTicks = _vm->_timerTicks;
 			if (_demoCurrentTicks - _demoStartTicks > 3000) {
-				rundcurs();
+				_graphics->rundcurs();
 				display();
 				fademusica0(2);
-				fadeToBlack(3);
+				_graphics->fadeToBlack(3);
 				CLBlitter_FillScreenView(0);
-				CLBlitter_FillView(_mainView, 0);
+				CLBlitter_FillView(_graphics->getMainView(), 0);
 				_musicChannel->stop();
 				_musicPlayingFlag = false;
 				_musicEnabledFlag = false;
@@ -4197,7 +4151,7 @@ void EdenGame::edmain() {
 				enterGame();
 			}
 		}
-		rundcurs();
+		_graphics->rundcurs();
 		musicspy();
 		FRDevents();
 		handleNarrator();
@@ -4228,28 +4182,28 @@ void EdenGame::intro() {
 		_vm->_video->closeSound();
 		_vm->_video->setupSound(22050, false, true);
 		_hnmSoundChannel = _vm->_video->getSoundChannel();
-		playHNM(2012);
-		playHNM(171);
+		_graphics->playHNM(2012);
+		_graphics->playHNM(171);
 		CLBlitter_FillScreenView(0);
 		_specialTextMode = false;
-		playHNM(2001);
+		_graphics->playHNM(2001);
 		_hnmSoundChannel->stop();
 		_vm->_video->closeSound();
 		_vm->_video->setupSound(11025, false, false);
 		_hnmSoundChannel = _vm->_video->getSoundChannel();
 	} else {
 		if (_vm->isDemo()) {
-			playHNM(171);	// Virgin logo
-			playHNM(98);	// Cryo logo
+			_graphics->playHNM(171);	// Virgin logo
+			_graphics->playHNM(98);	// Cryo logo
 		}
 		else {
-			playHNM(98);	// Cryo logo
-			playHNM(171);	// Virgin logo
+			_graphics->playHNM(98);	// Cryo logo
+			_graphics->playHNM(171);	// Virgin logo
 		}
 		CLBlitter_FillScreenView(0);
 		_specialTextMode = false;
 		startmusique(2);	// INTRO.MUS is played during intro video
-		playHNM(170);	// Intro video
+		_graphics->playHNM(170);	// Intro video
 	}
 }
 
@@ -4278,7 +4232,7 @@ void EdenGame::enterGame() {
 	showObjects();
 	drawTopScreen();
 	saveFriezes();
-	_showBlackBars = true;
+	_graphics->setShowBlackBars(true);
 	_globals->_mirrorEffect = 1;
 	updateRoom(_globals->_roomNum);
 	if (flag) {
@@ -4336,14 +4290,14 @@ void EdenGame::FRDevents() {
 		_curSpot2 = _currSpot;
 	if (_globals->_displayFlags & DisplayFlags::dfFrescoes) {
 		if (_frescoTalk)
-			restoreUnderSubtitles();
+			_graphics->restoreUnderSubtitles();
 		if (_currCursor == 9 && !_torchCursor) {
-			rundcurs();
+			_graphics->rundcurs();
 			_torchCursor = true;
-			_glowX = -1;
+			_graphics->setGlowX(-1);
 		}
 		if (_currCursor != 9 && _torchCursor) {
-			unglow();
+			_graphics->unglow();
 			_torchCursor = false;
 			_cursorSaved = false;
 		}
@@ -4417,24 +4371,24 @@ void EdenGame::updateCursor() {
 
 	if (!_torchCursor) {
 		useMainBank();
-		sundcurs(_cursorPosX + _scrollPos, _cursorPosY);
+		_graphics->sundcurs(_cursorPosX + _scrollPos, _cursorPosY);
 		if (_currCursor != 53 && _currCursor < 10) { //TODO: cond
 			if (_vm->getPlatform() == Common::kPlatformMacintosh)
 				engineMac();
 			else
 				enginePC();
 		} else
-			drawSprite(_currCursor, _cursorPosX + _scrollPos, _cursorPosY);
-		_glowX = 1;
+			_graphics->drawSprite(_currCursor, _cursorPosX + _scrollPos, _cursorPosY);
+		_graphics->setGlowX(1);
 	} else {
 		useBank(117);
 		if (_cursorPosX > 294)
 			_cursorPosX = 294;
-		unglow();
-		glow(_glowIndex);
-		drawSprite(_torchCurIndex, _cursorPosX + _scrollPos, _cursorPosY);
+		_graphics->unglow();
+		_graphics->glow(_glowIndex);
+		_graphics->drawSprite(_torchCurIndex, _cursorPosX + _scrollPos, _cursorPosY);
 		if (_frescoTalk)
-			displaySubtitles();
+			_graphics->displaySubtitles();
 	}
 }
 
@@ -4829,9 +4783,38 @@ void EdenGame::persovox() {
 	_lastAnimTicks = _vm->_timerTicks;
 }
 
+bool EdenGame::personIsTalking() {
+	return _personTalking;
+}
+
+perso_t *EdenGame::personSubtitles() {
+	perso_t *perso = nullptr;
+	switch (_globals->_curVideoNum) {
+	case 170:
+		perso = &_persons[PER_UNKN_156];
+		break;
+	case 83:
+		perso = &_persons[PER_MORKUS];
+		break;
+	case 88:
+		perso = &_persons[PER_MORKUS];
+		break;
+	case 89:
+		perso = &_persons[PER_MORKUS];
+		break;
+	case 94:
+		perso = &_persons[PER_MORKUS];
+		break;
+	default:
+		return perso;
+	}
+	return perso;
+}
+
+
 // Original name: endpersovox
 void EdenGame::endCharacterSpeech() {
-	restoreUnderSubtitles();
+	_graphics->restoreUnderSubtitles();
 	if (_personTalking) {
 		_voiceChannel->stop();
 		_personTalking = false;
@@ -4935,21 +4918,32 @@ void EdenGame::showObjects() {
 			icon->_cursorId |= 0x8000;
 	}
 	useMainBank();
-	drawSprite(55, 0, 176);
+	_graphics->drawSprite(55, 0, 176);
 	icon = &_gameIcons[_invIconsBase];
 	total = _globals->_objCount;
 	int16 index = _globals->_inventoryScrollPos;
 	for (int16 i = _invIconsCount; total-- && i--; icon++) {
 		char obj = _ownObjects[index++];
 		icon->_objectId = obj;
-		drawSprite(obj + 9, icon->sx, 178);
+		_graphics->drawSprite(obj + 9, icon->sx, 178);
 	}
 	_paletteUpdateRequired = true;
 	if ((_globals->_displayFlags & DisplayFlags::dfMirror) || (_globals->_displayFlags & DisplayFlags::dfPanable)) {
-		saveBottomFrieze();
+		_graphics->saveBottomFrieze();
 		scroll();
 	}
 }
+
+
+byte * EdenGame::getGlowBuffer() {
+	return _glowBuffer;
+}
+
+void EdenGame::setMusicFade(byte value) {
+	_musicFadeFlag = value;
+}
+
+
 
 void EdenGame::winObject(int16 id) {
 	object_t *object = getObjectPtr(id);
@@ -5162,13 +5156,29 @@ void EdenGame::gotoPanel() {
 	_globals->_displayFlags = DisplayFlags::dfFlag2;
 	_globals->_menuFlags = 0;
 	displayPanel();
-	fadeToBlack(3);
+	_graphics->fadeToBlack(3);
 	displayTopPanel();
-	CLBlitter_CopyView2Screen(_mainView);
-	CLPalette_Send2Screen(_globalPalette, 0, 256);
+	CLBlitter_CopyView2Screen(_graphics->getMainView());
+	_graphics->SendPalette2Screen(256);
 	_cursorPosX = 320 / 2;
 	_cursorPosY = 200 / 2;
 	_vm->setMousePosition(_mouseCenterX, _mouseCenterY);
+}
+
+void EdenGame::setMouseCenterX(uint16 xpos) {
+	_mouseCenterX = xpos;
+}
+
+void EdenGame::setMouseCenterY(uint16 ypos) {
+	_mouseCenterY = ypos;
+}
+
+uint16 EdenGame::getMouseCenterX() {
+	return _mouseCenterX;
+}
+
+uint16 EdenGame::getMouseCenterY() {
+	return _mouseCenterY;
 }
 
 void EdenGame::noclicpanel() {
@@ -5216,12 +5226,12 @@ skip:
 }
 
 void EdenGame::generique() {
-	drawBlackBars();
+	_graphics->drawBlackBars();
 	display();
-	fadeToBlack(3);
-	clearScreen();
+	_graphics->fadeToBlack(3);
+	_graphics->clearScreen();
 	int oldmusic = _globals->_currMusicNum;
-	playHNM(95);
+	_graphics->playHNM(95);
 	displayPanel();
 	displayTopPanel();
 	_paletteUpdateRequired = true;
@@ -5236,14 +5246,30 @@ void EdenGame::cancel2() {
 	gameToMirror(1);
 }
 
+byte *EdenGame::getCurKeepBuf() {
+	return _cursKeepBuf;
+}
+
+bool EdenGame::isMouseHeld() {
+	return _mouseHeld;
+}
+
+void EdenGame::setMouseHeld() {
+	_mouseHeld = true;
+}
+
+void EdenGame::setMouseNotHeld() {
+	_mouseHeld = false;
+}
+
 void EdenGame::testvoice() {
 	_globals->_frescoNumber = 0;
 	_globals->_characterPtr = _persons;
 	_globals->_dialogType = DialogType::dtInspect;
 	int16 num = (_persons[PER_KING]._id << 3) | _globals->_dialogType;
 	dialoscansvmas((Dialog *)getElem(_gameDialogs, num));
-	restoreUnderSubtitles();
-	displaySubtitles();
+	_graphics->restoreUnderSubtitles();
+	_graphics->displaySubtitles();
 	persovox();
 	waitEndSpeak();
 	endCharacterSpeech();
@@ -5266,7 +5292,7 @@ void EdenGame::load() {
 	}
 	_vm->hideMouse();
 	CLBlitter_FillScreenView(0xFFFFFFFF);
-	fadeToBlack(3);
+	_graphics->fadeToBlack(3);
 	CLBlitter_FillScreenView(0);
 	if (!_gameLoaded) {
 		_musicFadeFlag = 3;
@@ -5284,9 +5310,9 @@ void EdenGame::load() {
 	}
 	bool talk = _globals->_autoDialog;    //TODO check me
 	initafterload();
-	fadeToBlack(3);
+	_graphics->fadeToBlack(3);
 	CLBlitter_FillScreenView(0);
-	CLBlitter_FillView(_mainView, 0);
+	CLBlitter_FillView(_graphics->getMainView(), 0);
 	drawTopScreen();
 	_globals->_inventoryScrollPos = 0;
 	showObjects();
@@ -5334,7 +5360,7 @@ void EdenGame::save() {
 	saveGame(name);
 	_vm->hideMouse();
 	CLBlitter_FillScreenView(0xFFFFFFFF);
-	fadeToBlack(3);
+	_graphics->fadeToBlack(3);
 	CLBlitter_FillScreenView(0);
 	_musicFadeFlag = 3;
 	musicspy();
@@ -5342,7 +5368,7 @@ void EdenGame::save() {
 }
 
 void EdenGame::desktopcolors() {
-	fadeToBlack(3);
+	_graphics->fadeToBlack(3);
 	CLBlitter_FillScreenView(0xFFFFFFFF);
 	CLPalette_BeSystem();
 	_vm->showMouse();
@@ -5380,13 +5406,13 @@ void EdenGame::panelrestart() {
 		_globals->_currMusicNum = 0;
 		startmusique(curmus);
 	}
-	fadeToBlack(3);
+	_graphics->fadeToBlack(3);
 	CLBlitter_FillScreenView(0);
-	CLBlitter_FillView(_mainView, 0);
+	CLBlitter_FillView(_graphics->getMainView(), 0);
 	drawTopScreen();
 	showObjects();
 	saveFriezes();
-	_showBlackBars = true;
+	_graphics->setShowBlackBars(true);
 	updateRoom(_globals->_roomNum);
 }
 
@@ -5400,7 +5426,7 @@ void EdenGame::confirmer(char mode, char yesId) {
 	_gameIcons[119]._objectId = yesId;
 	_confirmMode = mode;
 	useBank(65);
-	drawSprite(12, 117, 74);
+	_graphics->drawSprite(12, 117, 74);
 	_cursorPosX = 156;
 	if (_vm->shouldQuit())
 		_cursorPosX = 136;
@@ -5442,7 +5468,7 @@ void EdenGame::choseSubtitleOption() {
 	if (lang > 5)
 		return;
 	_globals->_prefLanguage = lang;
-	langbuftopanel();
+	_graphics->langbuftopanel();
 	displayLanguage();
 }
 
@@ -5467,7 +5493,7 @@ void EdenGame::changervol() {
 		newvol(_curSliderValuePtr, delta);
 		if (_globals->_menuFlags & MenuFlags::mfFlag2)
 			newvol(_curSliderValuePtr + 1, delta);
-		cursbuftopanel();
+		_graphics->cursbuftopanel();
 		displayCursors();
 		_curSliderY = _cursorPosY;
 	} else
@@ -5560,16 +5586,28 @@ void EdenGame::moveTapeCursor() {
 		_globals->_menuFlags &= ~MenuFlags::mfFlag4;
 }
 
+void EdenGame::setCursorSaved(bool cursorSaved) {
+	_cursorSaved = cursorSaved;
+}
+
+bool EdenGame::getCursorSaved() {
+	return _cursorSaved;
+}
+
+bool EdenGame::getNoPalette() {
+	return _noPalette;
+}
+
 // Original name: affcurstape
 void EdenGame::displayTapeCursor() {
 	if (_globals->_drawFlags & DrawFlags::drDrawFlag8)
 		_noPalette = true;
 	useBank(65);
-	drawSprite(2, 0, 176);
+	_graphics->drawSprite(2, 0, 176);
 	int x = (_globals->_tapePtr - _tapes) * 8 + 97;
 	_gameIcons[112].sx = x - 3;
 	_gameIcons[112].ex = x + 3;
-	drawSprite(5, x, 179);
+	_graphics->drawSprite(5, x, 179);
 	_noPalette = false;
 }
 
@@ -5601,29 +5639,11 @@ void EdenGame::clickTapeCursor() {
 	_globals->_menuFlags |= MenuFlags::mfFlag4;
 }
 
-void EdenGame::paneltobuf() {
-	setSrcRect(0, 16, 320 - 1, 169 - 1);
-	setDestRect(320, 16, 640 - 1, 169 - 1);
-	CLBlitter_CopyViewRect(_mainView, _mainView, &rect_src, &rect_dst);
-}
-
-void EdenGame::cursbuftopanel() {
-	setSrcRect(434, 40, 525 - 1, 111 - 1);
-	setDestRect(114, 40, 205 - 1, 111 - 1);
-	CLBlitter_CopyViewRect(_mainView, _mainView, &rect_src, &rect_dst);
-}
-
-void EdenGame::langbuftopanel() {
-	setSrcRect(328, 42, 407 - 1, 97 - 1);
-	setDestRect(8, 42,  87 - 1, 97 - 1);
-	CLBlitter_CopyViewRect(_mainView, _mainView, &rect_src, &rect_dst);
-}
-
 // Original name: affpanel
 void EdenGame::displayPanel() {
 	useBank(65);
-	drawSprite(0, 0, 16);
-	paneltobuf();
+	_graphics->drawSprite(0, 0, 16);
+	_graphics->paneltobuf();
 	displayLanguage();
 	displayCursors();
 	displayTapeCursor();
@@ -5634,8 +5654,8 @@ void EdenGame::displayLanguage() {
 	useBank(65);
 	if (_globals->_prefLanguage > 5)
 		return;
-	drawSprite(6,  8, _globals->_prefLanguage * 9 + 43);  //TODO: * FONT_HEIGHT
-	drawSprite(7, 77, _globals->_prefLanguage * 9 + 44);
+	_graphics->drawSprite(6,  8, _globals->_prefLanguage * 9 + 43);  //TODO: * FONT_HEIGHT
+	_graphics->drawSprite(7, 77, _globals->_prefLanguage * 9 + 44);
 }
 
 // Original name: affcursvol
@@ -5643,11 +5663,11 @@ void EdenGame::displayVolCursor(int16 x, int16 vol1, int16 vol2) {
 	int16 slider = 3;
 	if (_lastMenuItemIdLo && (_lastMenuItemIdLo & 9) != 1) //TODO check me
 		slider = 4;
-	drawSprite(slider, x, 104 - vol1);
+	_graphics->drawSprite(slider, x, 104 - vol1);
 	slider = 3;
 	if ((_lastMenuItemIdLo & 9) != 0)
 		slider = 4;
-	drawSprite(slider, x + 12, 104 - vol2);
+	_graphics->drawSprite(slider, x + 12, 104 - vol2);
 }
 
 // Original name: affcurseurs
@@ -5672,17 +5692,17 @@ void EdenGame::selectCursor(int itemId) {
 
 // Original name: afftoppano
 void EdenGame::displayTopPanel() {
-	drawSprite(1, 0, 0);
+	_graphics->drawSprite(1, 0, 0);
 }
 
 // Original name: affresult
 void EdenGame::displayResult() {
-	restoreUnderSubtitles();
+	_graphics->restoreUnderSubtitles();
 	_globals->_characterPtr = &_persons[19];
 	_globals->_dialogType = DialogType::dtInspect;
 	int16 num = (_persons[PER_UNKN_156]._id << 3) | _globals->_dialogType;
 	if (dialoscansvmas((Dialog *)getElem(_gameDialogs, num)))
-		displaySubtitles();
+		_graphics->displaySubtitles();
 	_globals->_varCA = 0;
 	_globals->_dialogType = DialogType::dtTalk;
 	_globals->_characterPtr = nullptr;
@@ -7128,14 +7148,7 @@ void EdenGame::loadMap(int file_id, byte *buffer) {
 	if (_vm->getPlatform() == Common::kPlatformMacintosh) {
 		loadpartoffile(file_id, buffer, 32, 256 * 3);
 
-		for (int i = 0; i < 256; i++) {
-			color3_t color;
-			color.r = buffer[i * 3] << 8;
-			color.g = buffer[i * 3 + 1] << 8;
-			color.b = buffer[i * 3 + 2] << 8;
-			CLPalette_SetRGBColor(_globalPalette, i, &color);
-		}
-		CLPalette_Send2Screen(_globalPalette, 0, 256);
+		_graphics->setPaletteColor(buffer);
 
 		loadpartoffile(file_id, buffer, 32 + 256 * 3, 0x4000);
 	} else {
@@ -7382,7 +7395,7 @@ void EdenGame::displayPolygoneMapping(Cube *cubep, CubeFace *face) {
 	ymin = MIN(r31, ymin);
 	ymax = MAX(r31, ymax);
 	drawMappingLine(r20, r30, r26, r31, r19, r18, r25, r24, _lines);
-	displayMappingLine(ymin, ymax, _mainView->_bufferPtr, face->_texturePtr);
+	displayMappingLine(ymin, ymax, _graphics->getMainView()->_bufferPtr, face->_texturePtr);
 }
 
 // Original name: trace_ligne_mapping
@@ -7445,7 +7458,7 @@ void EdenGame::drawMappingLine(int16 r3, int16 r4, int16 r5, int16 r6, int16 r7,
 // Original name: affiche_ligne_mapping
 void EdenGame::displayMappingLine(int16 r3, int16 r4, byte *target, byte *texture) {
 	int16 height = r4 - r3;
-	byte *trg_line = _mainView->_bufferPtr + r3 * 640;    //TODO: target??
+	byte *trg_line = _graphics->getMainView()->_bufferPtr + r3 * 640;    //TODO: target??
 	int16 *line = &_lines[r3 * 8];
 	//	debug("curs: beg draw %d - %d", r3, r4);
 	for (int r22 = height; r22; r22--, line += 8, trg_line += 640) {
@@ -7694,17 +7707,17 @@ void EdenGame::renderCube() {
 
 	const int xshift = -5;		// TODO: temporary fix to decrease left margin
 	unsigned char *cur = _cursor;
-	unsigned char *scr = _mainView->_bufferPtr + _cursorPosX + _scrollPos  + xshift + _cursorPosY * _mainView->_pitch;
+	unsigned char *scr = _graphics->getMainView()->_bufferPtr + _cursorPosX + _scrollPos  + xshift + _cursorPosY * _graphics->getMainView()->_pitch;
 
 	for (int y = 0; y < 40; y++) {
 		for (int x = 0; x < 40; x++) {
-			if (x + _cursorPosX + _scrollPos + xshift < _mainView->_pitch && y + _cursorPosY < _mainView->_height)
+			if (x + _cursorPosX + _scrollPos + xshift < _graphics->getMainView()->_pitch && y + _cursorPosY < _graphics->getMainView()->_height)
 				if (*cur)
 					*scr = *cur;
 			scr++;
 			cur++;
 		}
-		scr += _mainView->_pitch - 40;
+		scr += _graphics->getMainView()->_pitch - 40;
 	}
 }
 

--- a/engines/cryo/eden.h
+++ b/engines/cryo/eden.h
@@ -40,17 +40,80 @@ enum Direction {
 namespace Cryo {
 
 class CryoEngine;
+class EdenGraphics;
 
 class EdenGame {
 private:
-	CryoEngine *_vm;
+	
+	EdenGraphics *_graphics;
 
 public:
 	EdenGame(CryoEngine *vm);
+	~EdenGame();
 
 	void run();
 	object_t *getObjectPtr(int16 id);
 	void showObjects();
+	void saveFriezes();
+	void useBank(int16 bank);
+	void musicspy();
+	void fademusica0(int16 delay);
+	void wait(int howlong);
+	bool isObjectHere(int16 id);
+	void display();
+
+	void setMouseCenterX(uint16 xpos);
+	void setMouseCenterY(uint16 ypos);
+
+	void stopMusic();
+
+	void setVolume(uint16 vol);
+
+	uint16 getMouseCenterX();
+	uint16 getMouseCenterY();
+
+	bool dialoscansvmas(Dialog *dial);
+	void musique();
+	void preloadDialogs(int16 vid);
+	void loadHnm(uint16 num);
+	bool personIsTalking();
+	bool animationIsActive();
+	byte *getImageDesc();
+	byte *getPlaceRawBuf();
+	byte getActionCursor(byte value);
+	int16 getNumTextLines();
+	int16 getScrollPos();
+	/* 
+	 * Identify person based on current video number
+	 */
+	perso_t *personSubtitles();
+
+	int16 getGameIconY(int16 index);
+	int16 getGameIconX(int16 index);
+
+	byte *getGameDialogs();
+
+	bool getSpecialTextMode();
+	void setSpecialTextMode(bool value);
+
+	void setCursorSaved(bool cursorSaved);
+	bool getCursorSaved();
+	bool getNoPalette();
+	int16 getCurBankNum();
+	byte *getCurKeepBuf();
+	byte *getBankData();
+	int16 getCurPosX();
+	void setCurPosX(int16 xpos);
+	int16 getCurPosY();
+	void setCurPosY(int16 ypos);
+	byte *getGlowBuffer();
+	void setMusicFade(byte value);
+	bool isMouseHeld();
+	void setMouseHeld();
+	void setMouseNotHeld();
+
+	global_t *_globals; // TODO: Make private and use getters
+	CryoEngine *_vm;
 
 private:
 	void removeConsole();
@@ -110,29 +173,15 @@ private:
 	void actionMoveEast();
 	void actionMoveSouth();
 	void actionMoveWest();
-	void display();
+
 	void afficher128();
-	void saveFriezes();
-	void saveTopFrieze(int16 x);
-	void saveBottomFrieze();
+
+
 	void restoreFriezes();
-	void restoreTopFrieze();
-	void restoreBottomFrieze();
+
 	void useMainBank();
 	void useCharacterBank();
-	void useBank(int16 bank);
-	void sundcurs(int16 x, int16 y);
-	void rundcurs();
-	void drawSprite(int16 index, int16 x, int16 y, bool withBlack = false, bool onSubtitle = false);
-	void getglow(int16 x, int16 y, int16 w, int16 h);
-	void unglow();
-	void glow(int16 index);
-	void readPalette(byte *ptr);
-	void hideBars();
-	void showBars();
-	void saveMouthBackground();
-	void restoreMouthBackground();
-	void drawBlackBars();
+
 	void drawTopScreen();
 	void displayValleyMap();
 	void displayMapMark(int16 index, int16 location);
@@ -170,7 +219,6 @@ private:
 	void removeMouthSprite();
 	void AnimEndCharacter();
 	void setCharacterSprite(byte *spr);
-	void displayImage();
 	void displayCharacter1();
 	void displayCharacter();
 	void ef_perso();
@@ -192,10 +240,7 @@ private:
 	void my_bulle();
 	void my_pr_bulle();
 	void drawSubtitleChar(byte c, byte color, int16 width);
-	void displaySubtitles();
-	void saveUnderSubtitles(int16 y);
-	void restoreUnderSubtitles();
-	void displayHNMSubtitle();
+	
 	void patchSentence();
 	void vavapers();
 	void citadelle();
@@ -258,34 +303,20 @@ private:
 	void actionGotoMap();
 	void record();
 	bool dial_scan(Dialog *dial);
-	bool dialoscansvmas(Dialog *dial);
+
 	bool dialogEvent(perso_t *perso);
 	void characterStayHere();
 	void endDeath(int16 vid);
 	void chronoEvent();
 	void setChrono(int16 t);
-	void preloadDialogs(int16 vid);
-	void displayEffect1();
-	void displayEffect2();
-	void displayEffect3();
-	void displayEffect4();
-	void clearScreen();
-	void colimacon(int16 pattern[16]);
-	void fadeToBlack(int delay);
-	void fadeToBlackLowPalette(int delay);
-	void fadeFromBlackLowPalette(int delay);
-	void blackRect32();
-	void setSrcRect(int16 sx, int16 sy, int16 ex, int16 ey);
-	void setDestRect(int16 sx, int16 sy, int16 ex, int16 ey);
-	void wait(int howlong);
-	void effetpix();
+
+
 	void verifh(byte *ptr);
 	void openbigfile();
 	void closebigfile();
 	void loadRawFile(uint16 num, byte *buffer);
 	void loadIconFile(uint16 num, Icon *buffer);
 	void loadRoomFile(uint16 num, Room *buffer);
-	void loadHnm(uint16 num);
 	int loadSound(uint16 num);
 	void convertMacToPC();
 	void loadpermfiles();
@@ -299,10 +330,8 @@ private:
 	void removeInfo(byte info);
 	void updateInfoList();
 	void initGlobals();
-	void initRects();
+
 	void closeRoom();
-	void displaySingleRoom(Room *room);
-	void displayRoom();
 	void displayPlace();
 	void loadPlace(int16 num);
 	void specialoutside();
@@ -317,7 +346,6 @@ private:
 	void updateRoom(uint16 roomNum);
 	void allocateBuffers();
 	void freebuf();
-	void openWindow();
 	void EmergencyExit();
 	void edmain();
 	void intro();
@@ -327,22 +355,19 @@ private:
 	Icon *scan_icon_list(int16 x, int16 y, int16 index);
 	void updateCursor();
 	void mouse();
-	void showMovie(char arg1);
-	void playHNM(int16 num);
-	void handleHNMSubtitles();
-	void musique();
+
 	void startmusique(byte num);
-	void musicspy();
+
 	int loadmusicfile(int16 num);
 	void persovox();
 	void endCharacterSpeech();
 	void fademusicup();
-	void fademusica0(int16 delay);
+
 	void countObjects();
 	void winObject(int16 id);
 	void loseObject(int16 id);
 	void lostObject();
-	bool isObjectHere(int16 id);
+
 	void objectmain(int16 id);
 	void getObject(int16 id);
 	void putObject();
@@ -381,9 +406,6 @@ private:
 	void forwardTape();
 	void stopTape();
 	void clickTapeCursor();
-	void paneltobuf();
-	void cursbuftopanel();
-	void langbuftopanel();
 	void displayPanel();
 	void displayLanguage();
 	void displayVolCursor(int16 x, int16 vol1, int16 vol2);
@@ -557,24 +579,16 @@ private:
 	byte  _oldPix[8];
 	Common::Point _adamMapMarkPos;
 	byte  _cursKeepBuf[2500];
-	Common::Point _cursKeepPos;
 	bool  _torchCursor;
 	int16 _curBankNum;
-	int16 _glowX;
-	int16 _glowY;
-	int16 _glowW;
-	int16 _glowH;
 	bool  _paletteUpdateRequired;
 	bool  _cursorSaved;
-	bool  _showBlackBars;
 	bool  _backgroundSaved;
 	byte *_bankData;
-	color_t _globalPalette[256];    //TODO palette_t
 	perso_t *_tyranPtr;
 	int   _lastAnimFrameNumb;
 	int   _curAnimFrameNumb;
 	int   _lastAnimTicks;
-	Common::Rect *_curCharacterRect;
 	int16 _numAnimFrames;
 	int16 _maxPersoDesc;
 	int16 _numImgDesc;
@@ -590,7 +604,6 @@ private:
 	byte *_animationTable;
 	byte  _imageDesc[512];
 	byte *_characterBankData;
-	bool  _savedUnderSubtitles;
 	int16 _numTextLines;
 	byte  _sentenceBuffer[400];
 	byte   phraseIconsBuffer[10];
@@ -607,14 +620,9 @@ private:
 	char            _lastPhrasesFile;
 	byte _dialogSkipFlags;
 
-	color3_t        newColor;
-	color_t         oldPalette[256];    // TODO palette_t ?
-	color_t         newPalette[256];
-	Common::Rect          rect_dst, rect_src;
 	byte *_voiceSamplesBuffer;    //TODO: sound sample buffer
 	Common::File _bigfile;
 	byte  _infoList[16];
-	bool  _needToFade;
 	byte *_mainBankBuf;
 	byte *_musicBuf;
 	byte *_gameLipsync;
@@ -627,12 +635,9 @@ private:
 	Room *_gameRooms;
 	PakHeaderNode *_bigfileHeader;
 	byte *_glowBuffer;
-	byte *_mainViewBuf;
-	byte *_view2Buf;
+
 	byte *_gameFont;  //TODO: rename to font?
-	byte *_subtitlesViewBuf;
-	byte *_underSubtitlesViewBuf; // CHECKME: Useless?
-	global_t *_globals;
+
 	uint16 _mouseCenterX;
 	uint16 _mouseCenterY;
 	bool _bufferAllocationErrorFl;
@@ -646,18 +651,6 @@ private:
 	CSoundChannel *_hnmSoundChannel;
 	Sound        *_voiceSound;
 
-	View  *_view2;
-	View  *_underSubtitlesView;
-	View  *_subtitlesView;
-	View  *_underBarsView;
-	View  *_mainView;
-	View  *_hnmView;
-	Common::Rect _underSubtitlesBackupRect;
-	Common::Rect _underSubtitlesScreenRect;
-	Common::Rect _underBottomBarBackupRect;
-	Common::Rect _underBottomBarScreenRect;
-	Common::Rect _underTopBarBackupRect;
-	Common::Rect _underTopBarScreenRect;
 	int   _demoCurrentTicks;
 	int   _demoStartTicks;
 	int   _currentTime;
@@ -670,11 +663,8 @@ private:
 	Icon *_curSpot2;
 	bool  _mouseHeld;
 	bool  _normalCursor;
-	byte *_hnmViewBuf;
-	bool  _showVideoSubtitle;
-	bool  _videoCanceledFlag;  //TODO: hnm_canceled
+
 	bool  _specialTextMode;
-	int   _hnmFrameNum;
 	int   _voiceSamplesSize;   //TODO: perso vox sample data len
 	int16 _musicRightVol;
 	int16 _musicLeftVol;

--- a/engines/cryo/eden_graphics.h
+++ b/engines/cryo/eden_graphics.h
@@ -1,0 +1,244 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef CRYO_EDEN_GRAPHICS_H
+#define CRYO_EDEN_GRAPHICS_H
+
+#include "cryo/defs.h" // Room
+
+namespace Cryo {
+
+class EdenGame;
+class HnmPlayer;
+
+class EdenGraphics {
+public:
+	EdenGraphics(EdenGame *game, HnmPlayer *video);
+
+	// Original name: noclipax
+	void drawSprite(int16 index, int16 x, int16 y, bool withBlack = false, bool onSubtitle = false);
+
+	// Original name: af_subtitle
+	void displaySubtitles();
+
+	// Original name: bars_in
+	void showBars();
+
+	void sundcurs(int16 x, int16 y);
+
+	void rundcurs();
+
+	void unglow();
+
+	void glow(int16 index);
+
+	void setGlowX(int16 value);
+
+	void setGlowY(int16 value);	
+
+	// Original name : blackbars
+	void drawBlackBars();
+
+	// Original name: bars_out
+	void hideBars();
+
+	// Original name: afsalle
+	void displayRoom();
+
+	// Original name: af_image
+	void displayImage();
+
+	void effetpix();
+
+	// Original name: effet1
+	void displayEffect1();
+
+	// Original name: effet2
+	void displayEffect2();
+
+	void setShowBlackBars(bool value);
+
+	bool getShowBlackBars();
+
+	void paneltobuf();
+
+	void cursbuftopanel();
+
+	void langbuftopanel();
+
+	View *getSubtitlesView();
+
+	View *getMainView();
+
+	byte *getHnmViewBuf();
+
+	void setCurCharRect(Common::Rect *charRect);
+
+	void setPaletteColor(byte *buffer);
+
+	// Original name: sauvefondbouche
+	void saveMouthBackground();
+
+	// Original name: restaurefondbouche
+	void restoreMouthBackground();
+
+	void openWindow();
+
+	bool _savedUnderSubtitles;
+
+	void setSavedUnderSubtitles(bool value);
+
+	byte *getSubtitlesViewBuf();
+
+	View *getUnderBarsView();
+
+	void SendPalette2Screen(int16 value);
+
+	void setFade(bool value);
+
+	bool getFade();
+
+	// Original name: effet3
+	void displayEffect3();
+
+	void setDestRect(int16 sx, int16 sy, int16 ex, int16 ey);
+
+	void setSrcRect(int16 sx, int16 sy, int16 ex, int16 ey);
+
+	void fadeToBlack(int delay);
+
+	// Original name: fadetoblack128
+	void fadeToBlackLowPalette(int delay);
+
+	// Original name: fadefromblack128
+	void fadeFromBlackLowPalette(int delay);
+
+	void clearScreen();
+
+	void playHNM(int16 num);
+
+	void setCursKeepPos(int16 x, int16 y);
+
+	void restoreUnderSubtitles();
+
+	void initRects();
+
+	void initGlobals();
+
+	void saveTopFrieze(int16 x);
+
+	void saveBottomFrieze();
+
+	void restoreTopFrieze();
+
+	void restoreBottomFrieze();
+
+private:
+	EdenGame *_game;
+	HnmPlayer *_video;
+
+	int16 _glowX;
+	int16 _glowY;
+	int16 _glowW;
+	int16 _glowH;
+
+	bool  _showVideoSubtitle;
+
+	Common::Point _cursKeepPos;
+
+	View  *_mainView;
+	View  *_underSubtitlesView;
+	View  *_subtitlesView;
+	View  *_underBarsView;
+
+	Common::Rect _underSubtitlesScreenRect;
+	Common::Rect _underSubtitlesBackupRect;	
+
+	Common::Rect _underTopBarScreenRect;
+	Common::Rect _underBottomBarBackupRect;
+	Common::Rect _underBottomBarScreenRect;
+	Common::Rect _underTopBarBackupRect;
+
+	byte *_underSubtitlesViewBuf; // CHECKME: Useless?	
+
+	byte *_mainViewBuf;	
+
+	View  *_hnmView;
+	byte *_hnmViewBuf;
+	byte *_view2Buf;
+
+	Common::Rect *_curCharacterRect;
+
+	Common::Rect _rect_dst, _rect_src;
+
+	View  *_view2;	
+
+	int _hnmFrameNum;
+
+	bool  _videoCanceledFlag;  //TODO: hnm_canceled
+
+	color_t _globalPalette[256];    //TODO palette_t
+
+	byte *_subtitlesViewBuf;
+
+	bool _needToFade;
+
+	color3_t _newColor;
+	color_t  _oldPalette[256];    // TODO palette_t ?
+	color_t  _newPalette[256];
+
+	bool _showBlackBars;	
+
+	void saveUnderSubtitles(int16 y);
+
+
+
+	void displayHNMSubtitle();
+
+	void readPalette(byte *ptr);
+
+	void getglow(int16 x, int16 y, int16 w, int16 h);
+
+	void loadMouthRectFromCurChar();
+
+	// Original name afsalle1
+	void displaySingleRoom(Room *room);
+
+	// Original name: effet4
+	void displayEffect4();
+
+	void colimacon(int16 pattern[]);
+
+	// Original name: rectanglenoir32
+	void blackRect32();
+
+	////// film.c
+	// Original name: showfilm
+	void showMovie(char arg1);
+
+	// Original name bullehnm
+	void handleHNMSubtitles();
+};
+
+}   // namespace Cryo
+
+#endif // CRYO_EDEN_GRAPHICS_H

--- a/engines/cryo/module.mk
+++ b/engines/cryo/module.mk
@@ -6,7 +6,7 @@ MODULE_OBJS = \
 	debugger.o \
 	detection.o \
 	eden.o \
-	graphics.o \
+	eden_graphics.o \
 	resource.o \
 	sound.o \
 	video.o


### PR DESCRIPTION
Eden game object now contains a graphics object with which to
delegate graphics operations and store states of the graphics.

Before all the graphics and eden code where together.

Much of the video playing is done in the graphics class
so I have moved a lot of the video state into there.

Some graphics related variables were moved out of eden and into
graphics, but many are still in eden.

Since they are still coupled there are lots of getters and setters.
For example both eden_graphics and eden share a handle to the same
video object.

I have made a few more things public than desirable.

I changed graphics to eden_graphics since it is specialized to eden
and not just cryo.