### PR TITLE
MOHAWK: RIVEN: Don't allow GMM saving at the main menu

### DIFF
--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -795,7 +795,8 @@ bool MohawkEngine_Riven::canLoadGameStateCurrently() {
 }
 
 bool MohawkEngine_Riven::canSaveGameStateCurrently() {
-	return canLoadGameStateCurrently();
+	return canLoadGameStateCurrently() && 
+	       !(_stack->getId() == kStackAspit && _card->getId() == 1);
 }
 
 bool MohawkEngine_Riven::hasGameEnded() const {


### PR DESCRIPTION
Currently, the game can be saved as soon as the game has started
at the main menu.

This change prevents that and other times that the menu is opened.
The game can still be saved via the main menu once a game has
been started (not using the gmm).

GMM saving still works where it used to outside of the main menu.