### PR TITLE
IOS: Hide keyboard when rotating to landscape

### DIFF
--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -870,6 +870,13 @@ uint getSizeNextPOT(uint size) {
 
 - (void)deviceOrientationChanged:(UIDeviceOrientation)orientation {
 	[self addEvent:InternalEvent(kInputOrientationChanged, orientation, 0)];
+
+  BOOL isLandscape = (self.bounds.size.width > self.bounds.size.height);
+  if (isLandscape) {
+    [_keyboardView hideKeyboard];
+  } else {
+    [_keyboardView showKeyboard];
+  }
 }
 
 - (UITouch *)secondTouchOtherTouchThan:(UITouch *)touch in:(NSSet *)set {


### PR DESCRIPTION
On iOS12 at least, the rotation did not force the keyboard to hide. This
fix will force it to be retracted in landscape and restored when
rotating back to the portrait position.