### PR TITLE
Atan2 table

### DIFF
--- a/common/atan2table.cpp
+++ b/common/atan2table.cpp
@@ -1,0 +1,91 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/scummsys.h"
+#include "common/atan2table.h"
+#include "common/math.h"
+#include "common/util.h"
+
+namespace Common {
+
+Atan2Table::Atan2Table(int nPoints) {
+	assert((nPoints >= 4) && (nPoints <= 1e8));
+	// Create the table values as floats, but compute them using doubles.
+	_nPoints = nPoints;
+	_table = new float[_nPoints];
+	_MPI_2 = M_PI / 2.0f;	
+	double slope;
+	int n;
+	for (n=0; n < _nPoints; n++) {
+		slope = -1.0 + 2.0/(_nPoints-1)*n;
+		_table[n] = atan(slope);
+	}
+}
+
+Atan2Table::~Atan2Table() {
+	delete[] _table;
+}
+
+float Atan2Table::angle(float y,float x) {
+	float slope;
+	float angle;
+	bool xpos  = x >= 0;
+	int ypos   = y >= 0;
+	bool ygx   = y * y > x * x; // Is magnitude of y greater than magnitude of x?
+
+	slope = ygx ? x/y: y/x; // choose slope so that its magnitude is less than 1.
+
+	// Map [-1,1] to [0, _nPoints - 1]
+	// Table has zero index as -1 slope atan value and last value as +1 slope
+	// If round is used to determine tableIndex then the error will be lower on average
+	// for a given _nPoints, but it will also run slower.
+	int tableIndex = (slope + 1.0f) * (_nPoints - 1) / 2;
+
+	tableIndex = CLIP<int>(tableIndex, 0, _nPoints - 1);
+
+	angle = _table[tableIndex];
+
+	// Now we correct the angle calculated based on which part of the unit circle it is in.
+	// This is done by going through each quarter quadrant doing the positive and negative angles 
+	// that are the same distance from the +x axis at the same time.
+
+	if (xpos && !ygx)       // In [-pi/4,+pi/4], the most common case
+		return angle;
+	else if (ygx)           // In [-pi/2,-pi/4), (pi/4,pi/2], [-3/4pi,-pi/2) or (pi/2, 3/4pi]
+		return ypos ? _MPI_2 - angle: -_MPI_2 - angle;
+	else if (!xpos && !ygx) // In [-pi,-3/4pi) or (3/4pi,pi]
+		return ypos ? M_PI + angle: -M_PI + angle;
+	else
+		return 0.0f; // I don't think this can be reached
+}
+
+// same as angle() but return angle is in degrees
+float Atan2Table::angleD(float y,float x) {
+	return rad2deg<float>(angle(y, x));
+}
+
+// compare atan2 radian result
+float Atan2Table::error(float y, float x) {
+	return angle(y, x) - atan2(y, x);
+}
+
+} // End of namespace Common

--- a/common/atan2table.h
+++ b/common/atan2table.h
@@ -1,0 +1,77 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef COMMON_ATAN2TABLE_H
+#define COMMON_ATAN2TABLE_H
+
+namespace Common {
+
+class Atan2Table {
+public:
+
+	// Table below contains:
+	// nPoints | Max degree error | % faster than atan2()
+	// -----------------------------------------
+	// 1e7 | 2.8e-5 | 25%
+	// 1e6 | 1.3e-4 | 40%
+	// 1e5 | 1.2e-3 | 65%
+	// 1e4 | 1.2e-2 | 65%
+	// 1e3 | 1.2e-1 | 65%
+	// 1e2 | 1.15e0 | 65%
+
+	/**
+	 * Construct a float based atan2 table
+	 *
+	 * @param nPoints the number of slope points that the atan will be evaluated at (for domain [-1,1]).
+	 * nPoints can be almost any positive integer.
+	 */
+	Atan2Table(int nPoints = 1e5); // In absense of a choice 1e5 is a good trade off between speed and accuracy
+	~Atan2Table();
+
+	/**
+	 * Evaluate atan2 using this lookup table.
+	 * This function returns the radian angle from the +x axis, 
+	 * positive for counter-clockwise and negative for clockwise.
+	 * The range, [-pi,+pi], and the return values are the same as atan2.
+	 */
+	float angle(float y,float x);
+
+	/**
+	 * Same as angle() but returned angle is in degrees
+	 */
+	float angleD(float y,float x);
+
+	/**
+	 * Compare atan2 and atan2 lookup.
+	 * Comparison is in radians.
+	 */
+	float error(float y, float x);
+
+private:
+	int _nPoints;
+	float *_table;
+	float _MPI_2;
+};
+
+} // End of namespace Common
+
+#endif // COMMON_ATAN2TABLE_H

--- a/common/module.mk
+++ b/common/module.mk
@@ -46,6 +46,7 @@ MODULE_OBJS := \
 	zlib.o
 
 MODULE_OBJS += \
+	atan2table.o \
 	cosinetables.o \
 	dct.o \
 	fft.o \

--- a/engines/titanic/star_control/fvector.cpp
+++ b/engines/titanic/star_control/fvector.cpp
@@ -27,6 +27,8 @@
 
 namespace Titanic {
 
+Common::Atan2Table FVector::_atan2Table = Common::Atan2Table(512);
+
 FVector FVector::swapComponents() const {
 	return FVector(
 		(ABS(_x - _y) < 0.00001 && ABS(_y - _z) < 0.00001 &&
@@ -91,7 +93,7 @@ FVector FVector::getAnglesAsVect() const {
 
 	dest._y = acos(vector._y);	// radian distance/angle that this vector's y component is from the +y axis,
 								// result is restricted to [0,pi]
-	dest._z = atan2(vector._x,vector._z); // result is restricted to [-pi,pi]
+	dest._z = _atan2Table.angle(vector._x,vector._z); // result is restricted to [-pi,pi]
 
 	return dest;
 }

--- a/engines/titanic/star_control/fvector.h
+++ b/engines/titanic/star_control/fvector.h
@@ -25,6 +25,8 @@
 
 #include "titanic/star_control/fpoint.h"
 
+#include "common/atan2table.h"
+
 namespace Titanic {
 
 enum Axis { X_AXIS, Y_AXIS, Z_AXIS };
@@ -169,6 +171,8 @@ public:
 	 * Converts the vector to a string
 	 */
 	Common::String toString() const;
+private:
+	static Common::Atan2Table _atan2Table;
 };
 
 } // End of namespace Titanic


### PR DESCRIPTION
1. Add a float lookup table for atan2, similar to star trek's atan2 lookup, except that one is for a fixed size table and uses ints. This lookup is faster than atan2().
2. Use the table in titanic star control. I tested it as well.

Making a atan2 table based only on ints may also be useful to add.