### PR TITLE
Fix launch on recent iOS device (iOS 11.4.1)

### DIFF
--- a/dists/ios7/Info.plist
+++ b/dists/ios7/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>ScummVM</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIcons</key>
 	<dict/>
 	<key>CFBundleIcons~ipad</key>

--- a/dists/ios7/Info.plist.in
+++ b/dists/ios7/Info.plist.in
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>ScummVM</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIcons</key>
 	<dict/>
 	<key>CFBundleIcons~ipad</key>


### PR DESCRIPTION
I just followed the instructions here: http://wiki.scummvm.org/index.php/Compiling_ScummVM/iPhone

But I would get this error at the last step when Xcode was about to launch the app on my iPhone.

![screen shot 2018-09-10 at 0 33 23](https://user-images.githubusercontent.com/278883/45266148-4e32a680-b491-11e8-9521-21f294de0520.png)

Until I fixed it this way. There are probably a lot more that could be dealt with in the Info.plist for recent iOS versions, but anyways.