### PR TITLE
LASTEXPRESS: fixed warnings with gcc 8.2

### DIFF
--- a/engines/lastexpress/entities/alexei.cpp
+++ b/engines/lastexpress/entities/alexei.cpp
@@ -769,7 +769,7 @@ IMPLEMENT_FUNCTION(22, Alexei, standingAtWindow)
 		if (getState()->time > kTime1138500) {
 			params->param3 = kTimeInvalid;
 		} else {
-			if (!getEntities()->isInSalon(kEntityPlayer) && !getEntities()->isInRestaurant(kEntityPlayer) || !params->param3)
+			if ((!getEntities()->isInSalon(kEntityPlayer) && !getEntities()->isInRestaurant(kEntityPlayer)) || !params->param3)
 				params->param3 = (uint)getState()->time;
 
 			if (params->param3 >= getState()->time)

--- a/engines/lastexpress/entities/august.cpp
+++ b/engines/lastexpress/entities/august.cpp
@@ -689,8 +689,7 @@ label_continue:
 				setup_playSound(getProgress().eventMetAugust ? "AUG1128F" : "AUG1128H");
 				return;
 			}
-			// Fallback to next case
-
+			// fall through
 		case 9:
 		case 10:
 		case 11:


### PR DESCRIPTION
```
engines/lastexpress/entities/alexei.cpp: In member function ‘void LastExpress::Alexei::standingAtWindow(const LastExpress::SavePoint&)’:
engines/lastexpress/entities/alexei.cpp:772:49: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    C++      engines/lastexpress/entities/chapters.o
engines/lastexpress/entities/august.cpp: In member function ‘void LastExpress::August::function21(const LastExpress::SavePoint&)’:
engines/lastexpress/entities/august.cpp:672:4: warning: this statement may fall through [-Wimplicit-fallthrough=]
    switch(params->param5) {
    ^~~~~~
engines/lastexpress/entities/august.cpp:694:3: note: here
   case 9:
   ^~~~
```