### PR TITLE
SWORD2: fixed compiler warning with gcc 8.2

### DIFF
--- a/engines/sword2/screen.cpp
+++ b/engines/sword2/screen.cpp
@@ -1118,7 +1118,7 @@ void Screen::rollCredits() {
 			} else if (creditsLines[i]->top < scrollPos + 400) {
 				if (!creditsLines[i]->sprite) {
 					debug(2, "Creating line %d: '%s'", i, creditsLines[i]->str.c_str());
-					creditsLines[i]->sprite = _vm->_fontRenderer->makeTextSprite((byte *)creditsLines[i]->str.c_str(), 600, 14, _vm->_speechFontId, 0);
+					creditsLines[i]->sprite = _vm->_fontRenderer->makeTextSprite((const byte *)creditsLines[i]->str.c_str(), 600, 14, _vm->_speechFontId, 0);
 				}
 
 				FrameHeader frame;


### PR DESCRIPTION
```
engines/sword2/screen.cpp: In member function ‘void Sword2::Screen::rollCredits()’:
engines/sword2/screen.cpp:1121:102: warning: cast from type ‘const char*’ to type ‘byte*’ {aka ‘unsigned char*’} casts away qualifiers [-Wcast-qual]
      creditsLines[i]->sprite = _vm->_fontRenderer->makeTextSprite((byte *)creditsLines[i]->str.c_str(), 600, 14, _vm->_speechFontId, 0);
```