### PR TITLE
LINGO: fixed warning with gcc 8.2

### DIFF
--- a/engines/director/lingo/lingo-funcs.cpp
+++ b/engines/director/lingo/lingo-funcs.cpp
@@ -191,7 +191,7 @@ void Lingo::func_goto(Datum &frame, Datum &movie) {
 
 			for (const byte *p = (const byte *)movieFilename.c_str(); *p; p++)
 				if (*p >= 0x20 && *p <= 0x7f)
-					cleanedFilename += (const char) *p;
+					cleanedFilename += (char) *p;
 
 			if (resMan.open(movieFilename)) {
 				fileExists = true;


### PR DESCRIPTION
```
engines/director/lingo/lingo-funcs.cpp: In member function ‘void Director::Lingo::func_goto(Director::Datum&, Director::Datum&)’:
engines/director/lingo/lingo-funcs.cpp:194:39: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
      cleanedFilename += (const char) *p;
```