### PR TITLE
ANDROID: Implement clipboard support

### DIFF
--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -405,7 +405,8 @@ bool OSystem_Android::hasFeature(Feature f) {
 			f == kFeatureVirtualKeyboard ||
 			f == kFeatureOverlaySupportsAlpha ||
 			f == kFeatureOpenUrl ||
-			f == kFeatureTouchpadMode);
+			f == kFeatureTouchpadMode ||
+			f == kFeatureClipboardSupport);
 }
 
 void OSystem_Android::setFeatureState(Feature f, bool enable) {
@@ -598,6 +599,18 @@ Common::String OSystem_Android::getSystemLanguage() const {
 
 bool OSystem_Android::openUrl(const Common::String &url) {
 	return JNI::openUrl(url.c_str());
+}
+
+bool OSystem_Android::hasTextInClipboard() {
+	return JNI::hasTextInClipboard();
+}
+
+Common::String OSystem_Android::getTextFromClipboard() {
+	return JNI::getTextFromClipboard();
+}
+
+bool OSystem_Android::setTextInClipboard(const Common::String &text) {
+	return JNI::setTextInClipboard(text);
 }
 
 Common::String OSystem_Android::getSystemProperty(const char *name) const {

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -286,6 +286,9 @@ public:
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s,
 											int priority = 0);
 	virtual bool openUrl(const Common::String &url);
+	virtual bool hasTextInClipboard();
+	virtual Common::String getTextFromClipboard();
+	virtual bool setTextInClipboard(const Common::String &text);
 	virtual Common::String getSystemLanguage() const;
 };
 

--- a/backends/platform/android/jni.cpp
+++ b/backends/platform/android/jni.cpp
@@ -45,6 +45,7 @@
 #include "common/config-manager.h"
 #include "common/error.h"
 #include "common/textconsole.h"
+#include "common/translation.h"
 #include "engines/engine.h"
 
 #include "backends/platform/android/android.h"
@@ -77,6 +78,9 @@ bool JNI::_ready_for_events = 0;
 jmethodID JNI::_MID_getDPI = 0;
 jmethodID JNI::_MID_displayMessageOnOSD = 0;
 jmethodID JNI::_MID_openUrl = 0;
+jmethodID JNI::_MID_hasTextInClipboard = 0;
+jmethodID JNI::_MID_getTextFromClipboard = 0;
+jmethodID JNI::_MID_setTextInClipboard = 0;
 jmethodID JNI::_MID_isConnectionLimited = 0;
 jmethodID JNI::_MID_setWindowCaption = 0;
 jmethodID JNI::_MID_showVirtualKeyboard = 0;
@@ -109,7 +113,9 @@ const JNINativeMethod JNI::_natives[] = {
 	{ "enableZoning", "(Z)V",
 		(void *)JNI::enableZoning },
 	{ "setPause", "(Z)V",
-		(void *)JNI::setPause }
+		(void *)JNI::setPause },
+	{ "getCurrentCharset", "()Ljava/lang/String;",
+		(void *)JNI::getCurrentCharset }
 };
 
 JNI::JNI() {
@@ -250,6 +256,66 @@ bool JNI::openUrl(const char *url) {
 	}
 
 	env->DeleteLocalRef(javaUrl);
+	return success;
+}
+
+bool JNI::hasTextInClipboard() {
+	bool hasText = false;
+	JNIEnv *env = JNI::getEnv();
+	hasText = env->CallBooleanMethod(_jobj, _MID_hasTextInClipboard);
+
+	if (env->ExceptionCheck()) {
+		LOGE("Failed to check the contents of the clipboard");
+
+		env->ExceptionDescribe();
+		env->ExceptionClear();
+		hasText = true;
+	}
+
+	return hasText;
+}
+
+Common::String JNI::getTextFromClipboard() {
+	JNIEnv *env = JNI::getEnv();
+
+	jbyteArray javaText = (jbyteArray)env->CallObjectMethod(_jobj, _MID_getTextFromClipboard);
+
+	if (env->ExceptionCheck()) {
+		LOGE("Failed to retrieve text from the clipboard");
+
+		env->ExceptionDescribe();
+		env->ExceptionClear();
+
+		return Common::String();
+	}
+
+	int len = env->GetArrayLength(javaText);
+	char* buf = new char[len];
+	env->GetByteArrayRegion(javaText, 0, len, reinterpret_cast<jbyte*>(buf));
+	Common::String text(buf, len);
+	delete[] buf;
+
+	return text;
+}
+
+bool JNI::setTextInClipboard(const Common::String &text) {
+	bool success = true;
+	JNIEnv *env = JNI::getEnv();
+
+	jbyteArray javaText = env->NewByteArray(text.size());
+	env->SetByteArrayRegion(javaText, 0, text.size(), reinterpret_cast<const jbyte*>(text.c_str()));
+
+	success = env->CallBooleanMethod(_jobj, _MID_setTextInClipboard, javaText);
+
+	if (env->ExceptionCheck()) {
+		LOGE("Failed to add text to the clipboard");
+
+		env->ExceptionDescribe();
+		env->ExceptionClear();
+		success = false;
+	}
+
+	env->DeleteLocalRef(javaText);
 	return success;
 }
 
@@ -449,6 +515,9 @@ void JNI::create(JNIEnv *env, jobject self, jobject asset_manager,
 	FIND_METHOD(, getDPI, "([F)V");
 	FIND_METHOD(, displayMessageOnOSD, "(Ljava/lang/String;)V");
 	FIND_METHOD(, openUrl, "(Ljava/lang/String;)V");
+	FIND_METHOD(, hasTextInClipboard, "()Z");
+	FIND_METHOD(, getTextFromClipboard, "()[B");
+	FIND_METHOD(, setTextInClipboard, "([B)Z");
 	FIND_METHOD(, isConnectionLimited, "()Z");
 	FIND_METHOD(, showVirtualKeyboard, "(Z)V");
 	FIND_METHOD(, getSysArchives, "()[Ljava/lang/String;");
@@ -609,6 +678,15 @@ void JNI::setPause(JNIEnv *env, jobject self, jboolean value) {
 		for (uint i = 0; i < 3; ++i)
 			sem_post(&pause_sem);
 	}
+}
+
+jstring JNI::getCurrentCharset(JNIEnv *env, jobject self) {
+#ifdef USE_TRANSLATION
+	if (TransMan.getCurrentCharset() != "ASCII") {
+		return env->NewStringUTF(TransMan.getCurrentCharset().c_str());
+	}
+#endif
+	return env->NewStringUTF("ISO-8859-1");
 }
 
 #endif

--- a/backends/platform/android/jni.h
+++ b/backends/platform/android/jni.h
@@ -59,6 +59,9 @@ public:
 	static void getDPI(float *values);
 	static void displayMessageOnOSD(const char *msg);
 	static bool openUrl(const char *url);
+	static bool hasTextInClipboard();
+	static Common::String getTextFromClipboard();
+	static bool setTextInClipboard(const Common::String &text);
 	static bool isConnectionLimited();
 	static void showVirtualKeyboard(bool enable);
 	static void addSysArchivesToSearchSet(Common::SearchSet &s, int priority);
@@ -92,6 +95,9 @@ private:
 	static jmethodID _MID_getDPI;
 	static jmethodID _MID_displayMessageOnOSD;
 	static jmethodID _MID_openUrl;
+	static jmethodID _MID_hasTextInClipboard;
+	static jmethodID _MID_getTextFromClipboard;
+	static jmethodID _MID_setTextInClipboard;
 	static jmethodID _MID_isConnectionLimited;
 	static jmethodID _MID_setWindowCaption;
 	static jmethodID _MID_showVirtualKeyboard;
@@ -127,6 +133,8 @@ private:
 	static void enableZoning(JNIEnv *env, jobject self, jboolean enable);
 
 	static void setPause(JNIEnv *env, jobject self, jboolean value);
+
+	static jstring getCurrentCharset(JNIEnv *env, jobject self);
 };
 
 inline bool JNI::haveSurface() {

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -49,11 +49,15 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 	// Feed an event to ScummVM.  Safe to call from other threads.
 	final public native void pushEvent(int type, int arg1, int arg2, int arg3,
 										int arg4, int arg5);
+	final public native String getCurrentCharset();
 
 	// Callbacks from C++ peer instance
 	abstract protected void getDPI(float[] values);
 	abstract protected void displayMessageOnOSD(String msg);
 	abstract protected void openUrl(String url);
+	abstract protected boolean hasTextInClipboard();
+	abstract protected byte[] getTextFromClipboard();
+	abstract protected boolean setTextInClipboard(byte[] text);
 	abstract protected boolean isConnectionLimited();
 	abstract protected void setWindowCaption(String caption);
 	abstract protected void showVirtualKeyboard(boolean enable);

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -12,6 +12,7 @@ import android.net.wifi.WifiInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.text.ClipboardManager;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.SurfaceView;
@@ -26,6 +27,8 @@ public class ScummVMActivity extends Activity {
 
 	/* Establish whether the hover events are available */
 	private static boolean _hoverAvailable;
+
+	private ClipboardManager _clipboard;
 
 	static {
 		try {
@@ -81,6 +84,42 @@ public class ScummVMActivity extends Activity {
 		@Override
 		protected void openUrl(String url) {
 			startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+		}
+
+		@Override
+		protected boolean hasTextInClipboard() {
+			return _clipboard.hasText();
+		}
+
+		@Override
+		protected byte[] getTextFromClipboard() {
+			CharSequence text = _clipboard.getText();
+			if (text != null) {
+				String encoding = getCurrentCharset();
+				byte[] out;
+				Log.d(LOG_TAG, String.format("Converting from UTF-8 to %s", encoding));
+				try {
+					out = text.toString().getBytes(encoding);
+				} catch (java.io.UnsupportedEncodingException e) {
+					out = text.toString().getBytes();
+				}
+				return out;
+			}
+			return null;
+		}
+
+		@Override
+		protected boolean setTextInClipboard(byte[] text) {
+			String encoding = getCurrentCharset();
+			String out;
+			Log.d(LOG_TAG, String.format("Converting from %s to UTF-8", encoding));
+			try {
+				out = new String(text, encoding);
+			} catch (java.io.UnsupportedEncodingException e) {
+				out = new String(text);
+			}
+			_clipboard.setText(out);
+			return true;
 		}
 
 		@Override
@@ -166,6 +205,8 @@ public class ScummVMActivity extends Activity {
 			// If it doesn't work, resort to the internal app path.
 			savePath = getDir("saves", MODE_WORLD_READABLE).getPath();
 		}
+
+		_clipboard = (ClipboardManager)getSystemService(CLIPBOARD_SERVICE);
 
 		// Start ScummVM
 		_scummvm = new MyScummVM(main_surface.getHolder());


### PR DESCRIPTION
This uses the older [android.text.ClipboardManager](https://developer.android.com/reference/android/text/ClipboardManager) API rather than the newer [android.content.ClipboardManager](https://developer.android.com/reference/android/content/ClipboardManager) in order to maintain compatibility with older Android versions.