### PR TITLE
KYRA: Fix Urbish Mines Lobster Monster Crash in LOL.

### DIFF
--- a/engines/kyra/sound_lol.cpp
+++ b/engines/kyra/sound_lol.cpp
@@ -161,7 +161,7 @@ void LoLEngine::snd_playSoundEffect(int track, int volume) {
 		return;
 
 	_lastSfxTrack = track;
-	if (track == -1 || track >= _ingameSoundIndexSize)
+	if (track == -1 || track >= (_ingameSoundIndexSize - 500) / 2)
 		return;
 
 	volume &= 0xFF;


### PR DESCRIPTION
This occurs because of an out of buffer access when trying to play the monster sound effect.

This is from bug Trac #10665.

While this code change is restricted to Kyra's LOL code and thus only that game, and the fix does work to prevent the out of range access, it is not clear that this is the correct solution and will not stop other sound effects from playing. Also, it removes the sound effect from this monster, rather than correcting it to the correct effect... This could do with amendment by someone familar with the KYRA / LOL engine to see if there is a better solution, but if not, then merging this at least prevents LOL from crashing.

