### PR TITLE
Auto-hide/show keyboard for non-iPad only (iPhone) + allow show/hide of keyboard using 4-finger swipes

### DIFF
--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -887,15 +887,12 @@ uint getSizeNextPOT(uint size) {
 - (void)deviceOrientationChanged:(UIDeviceOrientation)orientation {
 	[self addEvent:InternalEvent(kInputOrientationChanged, orientation, 0)];
 
-	if (!iOS7_isBigDevice()) {
-		// iPad software keyboard has a close button so don't bother controlling iPads.
-		BOOL isLandscape = (self.bounds.size.width > self.bounds.size.height);
-		if (isLandscape) {
-			[_keyboardView hideKeyboard];
-		} else {
-			[_keyboardView showKeyboard];
-		}
-	}
+  BOOL isLandscape = (self.bounds.size.width > self.bounds.size.height);
+  if (isLandscape) {
+    [_keyboardView hideKeyboard];
+  } else {
+    [_keyboardView showKeyboard];
+  }
 }
 
 - (UITouch *)secondTouchOtherTouchThan:(UITouch *)touch in:(NSSet *)set {

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -349,6 +349,18 @@ uint getSizeNextPOT(uint size) {
 }
 
 - (void)setupGestureRecognizers {
+	UISwipeGestureRecognizer *swipeUpFourFingers = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(fourFingersSwipeUp:)];
+	swipeUpFourFingers.direction = UISwipeGestureRecognizerDirectionUp;
+	swipeUpFourFingers.numberOfTouchesRequired = 4;
+	swipeUpFourFingers.delaysTouchesBegan = NO;
+	swipeUpFourFingers.delaysTouchesEnded = NO;
+	
+	UISwipeGestureRecognizer *swipeDownFourFingers = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(fourFingersSwipeDown:)];
+	swipeDownFourFingers.direction = UISwipeGestureRecognizerDirectionDown;
+	swipeDownFourFingers.numberOfTouchesRequired = 4;
+	swipeDownFourFingers.delaysTouchesBegan = NO;
+	swipeDownFourFingers.delaysTouchesEnded = NO;
+	
 	UISwipeGestureRecognizer *swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeRight:)];
 	swipeRight.direction = UISwipeGestureRecognizerDirectionRight;
 	swipeRight.numberOfTouchesRequired = 2;
@@ -379,12 +391,16 @@ uint getSizeNextPOT(uint size) {
 	doubleTapTwoFingers.delaysTouchesBegan = NO;
 	doubleTapTwoFingers.delaysTouchesEnded = NO;
 
+	[self addGestureRecognizer:swipeUpFourFingers];
+	[self addGestureRecognizer:swipeDownFourFingers];
 	[self addGestureRecognizer:swipeRight];
 	[self addGestureRecognizer:swipeLeft];
 	[self addGestureRecognizer:swipeUp];
 	[self addGestureRecognizer:swipeDown];
 	[self addGestureRecognizer:doubleTapTwoFingers];
 
+	[swipeUpFourFingers release];
+	[swipeDownFourFingers release];
 	[swipeRight release];
 	[swipeLeft release];
 	[swipeUp release];

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -983,6 +983,14 @@ uint getSizeNextPOT(uint size) {
 	_secondTouch = nil;
 }
 
+- (void)fourFingersSwipeUp:(UISwipeGestureRecognizer *)recognizer {
+	[_keyboardView showKeyboard];
+}
+
+- (void)fourFingersSwipeDown:(UISwipeGestureRecognizer *)recognizer {
+	[_keyboardView hideKeyboard];
+}
+
 - (void)twoFingersSwipeRight:(UISwipeGestureRecognizer *)recognizer {
 	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeRight, 2)];
 }

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -871,12 +871,15 @@ uint getSizeNextPOT(uint size) {
 - (void)deviceOrientationChanged:(UIDeviceOrientation)orientation {
 	[self addEvent:InternalEvent(kInputOrientationChanged, orientation, 0)];
 
-  BOOL isLandscape = (self.bounds.size.width > self.bounds.size.height);
-  if (isLandscape) {
-    [_keyboardView hideKeyboard];
-  } else {
-    [_keyboardView showKeyboard];
-  }
+	if (!iOS7_isBigDevice()) {
+		// iPad software keyboard has a close button so don't bother controlling iPads.
+		BOOL isLandscape = (self.bounds.size.width > self.bounds.size.height);
+		if (isLandscape) {
+			[_keyboardView hideKeyboard];
+		} else {
+			[_keyboardView showKeyboard];
+		}
+	}
 }
 
 - (UITouch *)secondTouchOtherTouchThan:(UITouch *)touch in:(NSSet *)set {


### PR DESCRIPTION
I don't think there is a great need to autoshow/hide the keyboard for iPad - the iPad software keyboard has a hide button. So I fixed that.

Also if the user for whatever reason wants to show/hide the keyboard at will, he/she may do so using four-finger swipes up/down. Hopefully this doesn't clash with anything. I don't think there were any "four finger" gestures in the old scumm games... I've been playing through a couple of old scumm games this way and I think it works well. This means you can use keyboard whenever you want, regardless if the device is in landscape or portrait.

Original PR #1332