### PR TITLE
SURFACESDL: Respect filtering setting when performing aspect ratio correction

### DIFF
--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -372,7 +372,7 @@ void DINGUXSdlGraphicsManager::internUpdateScreen() {
 
 #ifdef USE_SCALERS
 			if (_videoMode.aspectRatioCorrection && orig_dst_y < height && !_overlayVisible)
-				r->h = stretch200To240((uint8 *) _hwScreen->pixels, dstPitch, r->w, r->h, r->x, r->y, orig_dst_y * scale1);
+				r->h = stretch200To240((uint8 *) _hwScreen->pixels, dstPitch, r->w, r->h, r->x, r->y, orig_dst_y * scale1, _videoMode.filtering);
 #endif
 		}
 		SDL_UnlockSurface(srcSurf);

--- a/backends/graphics/gph/gph-graphics.cpp
+++ b/backends/graphics/gph/gph-graphics.cpp
@@ -395,7 +395,7 @@ void GPHGraphicsManager::internUpdateScreen() {
 
 #ifdef USE_SCALERS
 			if (_videoMode.aspectRatioCorrection && orig_dst_y < height && !_overlayVisible)
-				r->h = stretch200To240((uint8 *) _hwScreen->pixels, dstPitch, r->w, r->h, r->x, r->y, orig_dst_y * scale1);
+				r->h = stretch200To240((uint8 *) _hwScreen->pixels, dstPitch, r->w, r->h, r->x, r->y, orig_dst_y * scale1, _videoMode.filtering);
 #endif
 		}
 		SDL_UnlockSurface(srcSurf);

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
@@ -406,7 +406,7 @@ void LinuxmotoSdlGraphicsManager::internUpdateScreen() {
 
 #ifdef USE_SCALERS
 			if (_videoMode.aspectRatioCorrection && orig_dst_y < height && !_overlayVisible)
-				r->h = stretch200To240((uint8 *) _hwscreen->pixels, dstPitch, r->w, r->h, r->x, r->y, orig_dst_y * scale1);
+				r->h = stretch200To240((uint8 *) _hwscreen->pixels, dstPitch, r->w, r->h, r->x, r->y, orig_dst_y * scale1, _videoMode.filtering);
 #endif
 		}
 		SDL_UnlockSurface(srcSurf);

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -248,9 +248,9 @@ protected:
 		bool fullscreen;
 		bool aspectRatioCorrection;
 		AspectRatio desiredAspectRatio;
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		bool filtering;
+		
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 		int stretchMode;
 #endif
 
@@ -381,9 +381,7 @@ protected:
 	virtual bool hotswapGFXMode();
 
 	virtual void setAspectRatioCorrection(bool enable);
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	void setFilteringMode(bool enable);
-#endif
 
 	virtual bool saveScreenshot(const char *filename);
 	virtual void setGraphicsModeIntern();

--- a/graphics/scaler/aspect.h
+++ b/graphics/scaler/aspect.h
@@ -43,18 +43,20 @@ FORCEINLINE int aspect2Real(int y) {
 /**
  * TODO: explain
  */
-void makeRectStretchable(int &x, int &y, int &w, int &h);
+void makeRectStretchable(int &x, int &y, int &w, int &h, bool interpolate);
 
 /**
  * TODO: explain
  */
+                    
 int stretch200To240(uint8 *buf,
                     uint32 pitch,
                     int width,
                     int height,
                     int srcX,
                     int srcY,
-                    int origSrcY);
+                    int origSrcY,
+                    bool interpolate);
 
 
 /**


### PR DESCRIPTION
This change is related to the discussion in http://forums.scummvm.org/viewtopic.php?t=14733

The idea is to do a nearest neighbour aspect ratio correction when filtering is turned off instead of the usual bilinear filtering aspect ratio correction.

I am not sure what others think of this change, so I am putting it here for comments.

I have tested the change with both SDL 1.2 and SDL 2.0.7 on macOS.
SDL 1.2 was not previously supporting the filtering feature, so this is added by this commit to allow to control which aspect ratio correction we want.