### PR TITLE
Fix Dreamcast crt0 link order

### DIFF
--- a/configure
+++ b/configure
@@ -5037,7 +5037,7 @@ else
 int main(void) { setlocale(LC_ALL, ""); return 0; }
 EOF
 		_detectlang=no
-		cc_check $LDFLAGS $CXXFLAGS && _detectlang=yes
+		cc_check && _detectlang=yes
 	fi
 
 	define_in_config_h_if_yes $_detectlang 'USE_DETECTLANG'

--- a/configure
+++ b/configure
@@ -3424,12 +3424,14 @@ case $_backend in
 		append_var LDFLAGS "-Wl,-Ttext,0x8c010000"
 		append_var LDFLAGS "-nostartfiles"
 		append_var LDFLAGS "-L$RONINDIR/lib"
-		append_var LIBS "$RONINDIR/lib/crt0.o"
+		append_var LDFLAGS "$RONINDIR/lib/crt0.o"
 		# Enable serial debugging output only when --enable-debug is passed
 		if test "$_release_build" = yes -o "$_debug_build" != yes; then
 			append_var LIBS "-lronin-noserial -lm"
+			append_var LDFLAGS "-lronin-noserial -lm"
 		else
 			append_var LIBS "-lronin -lm"
+			append_var LDFLAGS "-lronin -lm"
 		fi
 		;;
 	dingux)


### PR DESCRIPTION
This fixes a regression that has been preventing the Dreamcast builds from booting for the past couple of months.  Only SCUMMVM.BIN (not scummvm.elf) was affected.  The problem and fix are described in more detail in the commit messages, but please let me know if you have any questions.