### PR TITLE
SCI32: Fix GK1 ego speed bugs

### DIFF
--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -125,6 +125,8 @@ static const char *const selectorNameTable[] = {
 	"test",         // Torin
 	"get",          // Torin, GK1
 	"has",          // GK1
+	"newRoom",      // GK1
+	"normalize",    // GK1
 	"set",          // Torin
 	"clear",        // Torin
 	"masterVolume", // SCI2 master volume reset
@@ -198,6 +200,8 @@ enum ScriptPatcherSelectors {
 	SELECTOR_test,
 	SELECTOR_get,
 	SELECTOR_has,
+	SELECTOR_newRoom,
+	SELECTOR_normalize,
 	SELECTOR_set,
 	SELECTOR_clear,
 	SELECTOR_masterVolume,
@@ -1515,6 +1519,134 @@ static const uint16 gk1Day5MoselyVevePointsPatch[] = {
 	PATCH_END
 };
 
+// When entering the police station (room 230) sGabeEnters sets ego speed
+//  to 4 for the door animation but fails to restore it to the game speed
+//  by calling GKEgo:normalize. This leaves ego at 75% speed until doing
+//  something that does call normalize.
+//
+// We fix this by calling GKEgo:normalize after Gabriel finishes walking
+//  through the door in sGabeEnters:changeState(5). This requires overwriting
+//  the instructions in state 4 which set GKEgo:ignoreActors to 0 but that's
+//  okay because normalize does that.
+//
+// There are two versions of this patch due to two significantly different
+//  versions of this script. The first is in english pc floppy prior to
+//  Sierra's 1.0b patch and the second is in cd and localized floppies. The
+//  script was restructured and the compiler used different sized instructions.
+//
+// Applies to: All PC Floppy and CD versions. TODO: Test Mac, should apply
+// Responsible method: sGabeEnters:changeState
+// Fixes bug #10780
+static const uint16 gk1PoliceEgoSpeedFixV1Signature[] = {
+	0x31, 0x1f,                         // bnt 1f [ state 5 ]
+	SIG_ADDTOOFFSET(+19),
+	0x38, SIG_SELECTOR16(ignoreActors), // pushi ignoreActors
+	0x78,                               // push1
+	0x76,                               // push0
+	0x81, 0x00,                         // lag 0
+	0x4a, SIG_UINT16(0x000c),           // send c [ GKEgo:setPri: -1, ignoreActors: 0 ]
+	0x33, 0x45,                         // jmp 45 [ end of method ]
+	SIG_MAGICDWORD,
+	0x3c,                               // dup
+	0x35, 0x05,                         // ldi 5
+	0x1a,                               // eq?
+	0x31, 0x3f,                         // bnt 3f [ end of method ]
+	SIG_END
+};
+
+static const uint16 gk1PoliceEgoSpeedFixV1Patch[] = {
+	0x31, 0x1b,                         // bnt 1b [ state 5 ]
+	SIG_ADDTOOFFSET(+19),
+	0x81, 0x00,                         // lag 0
+	0x4a, PATCH_UINT16(0x0006),         // send 6 [ GKEgo:setPri: -1 ]
+	0x3a,                               // toss
+	0x48,                               // ret
+	0x33, 0x00,                         // jmp 0 [ waste 2 bytes ]
+	0x38, PATCH_SELECTOR16(normalize),  // pushi normalize
+	0x76,                               // push0
+	0x81, 0x00,                         // lag 0
+	0x4a, PATCH_UINT16(0x0004),         // send 4 [ GKEgo:normalize ]
+	PATCH_END
+};
+
+// cd / localized floppy / floppy 1.0b version of the above signature/patch
+static const uint16 gk1PoliceEgoSpeedFixV2Signature[] = {
+	0x31, 0x27,                         // bnt 27 [ state 5 ]
+	SIG_ADDTOOFFSET(+26),
+	0x38, SIG_SELECTOR16(ignoreActors), // pushi ignoreActors
+	0x78,                               // push1
+	0x76,                               // push0
+	0x81, 0x00,                         // lag 0
+	0x4a, SIG_UINT16(0x000c),           // send c [ GKEgo:setPri: -1, ignoreActors: 0 ]
+	0x32, SIG_UINT16(0x004c),           // jmp 004c [ end of method ]
+	SIG_MAGICDWORD,
+	0x3c,                               // dup
+	0x35, 0x05,                         // ldi 5
+	0x1a,                               // eq?
+	0x31, 0x46,                         // bnt 46 [ end of method ]
+	SIG_END
+};
+
+static const uint16 gk1PoliceEgoSpeedFixV2Patch[] = {
+	0x31, 0x24,                         // bnt 24 [ state 5 ]
+	SIG_ADDTOOFFSET(+26),
+	0x81, 0x00,                         // lag 0
+	0x4a, PATCH_UINT16(0x0006),         // send 6 [ GKEgo:setPri: -1 ]
+	0x3a,                               // toss
+	0x48,                               // ret
+	0x32, PATCH_UINT16(0x0000),         // jmp 0 [ waste 3 bytes ]
+	0x38, PATCH_SELECTOR16(normalize),  // pushi 0300 [ normalize ]
+	0x76,                               // push0
+	0x81, 0x00,                         // lag 0
+	0x4a, PATCH_UINT16(0x0004),         // send 4 [ GKEgo:normalize ]
+	PATCH_END
+};
+
+// When exiting the drugstore (room 250) egoExits sets ego speed to 15
+//  (slowest) for the door animation but fails to restore it to game
+//  speed by calling GKEgo:normalize. This leaves ego slow until doing
+//  something that does call normalize.
+//
+// We fix this by calling GKEgo:normalize after the door animation.
+//
+// Applies to: All PC Floppy and CD versions. TODO: Test Mac, should apply
+// Responsible method: egoExits:changeState
+// Fixes bug #10780
+static const uint16 gk1DrugStoreEgoSpeedFixSignature[] = {
+	0x30, SIG_UINT16(0x003f),           // bnt 003f [ state 1 ]
+	SIG_ADDTOOFFSET(+60),
+	SIG_MAGICDWORD,
+	0x32, SIG_UINT16(0x0012),           // jmp 12 [ end of method ]
+	0x3c,                               // dup
+	0x35, 0x01,                         // ldi 1
+	0x1a,                               // eq?
+	0x31, 0x0c,                         // bnt c [ end of method ]
+	0x38, SIG_SELECTOR16(newRoom),      // pushi newRoom
+	0x78,                               // push1
+	0x38, SIG_UINT16(0x00c8),           // pushi 00c8 [ map ]
+	0x81, 0x02,                         // lag 2
+	0x4a, SIG_UINT16(0x0006),           // send 6 [ rm250:newRoom = map ]
+	0x3a,                               // toss
+	SIG_END
+};
+
+static const uint16 gk1DrugStoreEgoSpeedFixPatch[] = {
+	0x3a,                               // toss
+	0x31, 0x3d,                         // bnt 3d [ state 1 ]
+	PATCH_ADDTOOFFSET(+60),
+	0x48,                               // ret
+	0x38, PATCH_SELECTOR16(normalize),  // pushi normalize
+	0x76,                               // push0
+	0x81, 0x00,                         // lag 0
+	0x4a, PATCH_UINT16(0x0004),         // send 4 [ GKEgo:normalize ]
+	0x38, PATCH_SELECTOR16(newRoom),    // pushi newRoom
+	0x78,                               // push1
+	0x38, PATCH_UINT16(0x00c8),         // pushi 00c8 [ map ]
+	0x81, 0x02,                         // lag 2
+	0x4a, PATCH_UINT16(0x0006),         // send 6 [ rm250:newRoom = map ]
+	PATCH_END
+};
+
 //          script, description,                                      signature                         patch
 static const SciScriptPatcherEntry gk1Signatures[] = {
 	{  true,    51, "fix interrogation bug",                       1, gk1InterrogationBugSignature,     gk1InterrogationBugPatch },
@@ -1523,7 +1655,10 @@ static const SciScriptPatcherEntry gk1Signatures[] = {
 	{  true,   230, "fix day 6 police beignet timer issue (1/2)",  1, gk1Day6PoliceBeignetSignature1,   gk1Day6PoliceBeignetPatch1 },
 	{  true,   230, "fix day 6 police beignet timer issue (2/2)",  1, gk1Day6PoliceBeignetSignature2,   gk1Day6PoliceBeignetPatch2 },
 	{  true,   230, "fix day 6 police sleep timer issue",          1, gk1Day6PoliceSleepSignature,      gk1Day6PoliceSleepPatch },
+	{  true,   230, "fix police station ego speed (version 1)",    1, gk1PoliceEgoSpeedFixV1Signature,  gk1PoliceEgoSpeedFixV1Patch },
+	{  true,   230, "fix police station ego speed (version 2)",    1, gk1PoliceEgoSpeedFixV2Signature,  gk1PoliceEgoSpeedFixV2Patch },
 	{  true,   240, "fix day 5 mosely veve missing points",        1, gk1Day5MoselyVevePointsSignature, gk1Day5MoselyVevePointsPatch },
+	{  true,   250, "fix ego speed when exiting drug store",       1, gk1DrugStoreEgoSpeedFixSignature, gk1DrugStoreEgoSpeedFixPatch },
 	{  true,   280, "fix pathfinding in Madame Cazanoux's house",  1, gk1CazanouxPathfindingSignature,  gk1CazanouxPathfindingPatch },
 	{  true,   710, "fix day 9 vine swing speech playing",         1, gk1Day9VineSwingSignature,        gk1Day9VineSwingPatch },
 	{  true,   800, "fix day 10 honfour unlock door lockup",       1, gk1HonfourUnlockDoorSignature,    gk1HonfourUnlockDoorPatch },


### PR DESCRIPTION
Fixes ego speed bugs in the original game, bug #10780

I made two versions of the police station patch because there are two significantly different versions of that room's script. Please take a look and see if they can be rewritten as one that applies to both. The big obstacle is that in the second version the compiler switched from a 2 byte jmp instruction to a 3 byte one right in the middle of the section being patched.