### PR TITLE
GROOVIE: Fix GMM loads, block saves in a puzzle

### DIFF
--- a/engines/groovie/groovie.cpp
+++ b/engines/groovie/groovie.cpp
@@ -382,7 +382,7 @@ bool GroovieEngine::canLoadGameStateCurrently() {
 bool GroovieEngine::canSaveGameStateCurrently() {
 	// TODO: verify the engine has been initialized
 	if (_script)
-		return true;
+		return _script->canDirectSave();
 	else
 		return false;
 }

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -175,7 +175,15 @@ void Script::directGameLoad(int slot) {
 		return;
 	}
 
-	// TODO: Return to the main script, likely reusing most of o_returnscript()
+	// Return to the main script if required
+	if (_savedCode) {
+		// Returning the correct spot, dealing with _savedVariables, etc
+		// is not needed as game state is getting nuked anyway
+		delete[] _code;
+		_code = _savedCode;
+		_codeSize = _savedCodeSize;
+		_savedCode = nullptr;
+	}
 
 	// HACK: We set the slot to load in the appropriate variable, and set the
 	// current instruction to the one that actually loads the saved game
@@ -394,6 +402,11 @@ void Script::loadgame(uint slot) {
 
 	// Hide the mouse cursor
 	_vm->_grvCursorMan->show(false);
+}
+
+bool Script::canDirectSave() const {
+	// Disallow when running a subscript
+	return _savedCode == nullptr;
 }
 
 void Script::directGameSave(int slot, const Common::String &desc) {

--- a/engines/groovie/script.h
+++ b/engines/groovie/script.h
@@ -61,6 +61,7 @@ public:
 	bool loadScript(Common::String scriptfile);
 	void directGameLoad(int slot);
 	void directGameSave(int slot, const Common::String &desc);
+	bool canDirectSave() const;
 	void step();
 
 	void setMouseClick(uint8 button);


### PR DESCRIPTION
As per discussion in #1306. This patch blocks GMM saves within a puzzle (we can't guarantee valid save state) and handles properly loading by properly jumping back into the base game script.