### PR TITLE
GROOVIE: Fix Spaces in Savegame Names

### DIFF
--- a/engines/groovie/saveload.cpp
+++ b/engines/groovie/saveload.cpp
@@ -128,6 +128,7 @@ Common::InSaveFile *SaveLoad::openForLoading(const Common::String &target, int s
 				case 0:
 					break;
 				case 16: // @
+				case 254: // . (generated when pressing space)
 					c = ' ';
 					break;
 				case 244: // $

--- a/engines/groovie/saveload.cpp
+++ b/engines/groovie/saveload.cpp
@@ -128,6 +128,7 @@ Common::InSaveFile *SaveLoad::openForLoading(const Common::String &target, int s
 				case 0:
 					break;
 				case 16: // @
+				// fall through intended
 				case 254: // . (generated when pressing space)
 					c = ' ';
 					break;

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -439,9 +439,11 @@ void Script::savegame(uint slot) {
 	// Cache the saved name
 	for (int i = 0; i < 15; i++) {
 		newchar = _variables[i] + 0x30;
-		if ((newchar < 0x30 || newchar > 0x39) && (newchar < 0x41 || newchar > 0x7A)) {
+		if ((newchar < 0x30 || newchar > 0x39) && (newchar < 0x41 || newchar > 0x7A) && newchar != 0x2E) {
 			save[i] = '\0';
 			break;
+		} else if (newchar == 0x2E) { // '.', generated when space is pressed
+			save[i] = ' ';
 		} else {
 			save[i] = newchar;
 		}


### PR DESCRIPTION
This is a patch originally submitted as part of Trac bug 6276 with minor fixup:
https://bugs.scummvm.org/ticket/6276
