### PR TITLE
WIN32: Move the Windows-specific packaging rules into a separate file

### DIFF
--- a/backends/platform/sdl/win32/win32.mk
+++ b/backends/platform/sdl/win32/win32.mk
@@ -1,0 +1,71 @@
+#
+# Windows specific
+#
+
+scummvmwinres.o: $(srcdir)/icons/scummvm.ico $(DIST_FILES_THEMES) $(DIST_FILES_NETWORKING) $(DIST_FILES_ENGINEDATA) $(srcdir)/dists/scummvm.rc
+	$(QUIET_WINDRES)$(WINDRES) -DHAVE_CONFIG_H $(WINDRESFLAGS) $(DEFINES) -I. -I$(srcdir) $(srcdir)/dists/scummvm.rc scummvmwinres.o
+
+# Special target to create a win32 snapshot binary (for Inno Setup)
+win32dist: all
+	mkdir -p $(WIN32PATH)
+	mkdir -p $(WIN32PATH)/graphics
+	mkdir -p $(WIN32PATH)/doc
+	mkdir -p $(WIN32PATH)/doc/cz
+	mkdir -p $(WIN32PATH)/doc/da
+	mkdir -p $(WIN32PATH)/doc/de
+	mkdir -p $(WIN32PATH)/doc/es
+	mkdir -p $(WIN32PATH)/doc/fr
+	mkdir -p $(WIN32PATH)/doc/it
+	mkdir -p $(WIN32PATH)/doc/no-nb
+	mkdir -p $(WIN32PATH)/doc/se
+	$(STRIP) $(EXECUTABLE) -o $(WIN32PATH)/$(EXECUTABLE)
+	cp $(srcdir)/AUTHORS $(WIN32PATH)/AUTHORS.txt
+	cp $(srcdir)/COPYING $(WIN32PATH)/COPYING.txt
+	cp $(srcdir)/COPYING.BSD $(WIN32PATH)/COPYING.BSD.txt
+	cp $(srcdir)/COPYING.LGPL $(WIN32PATH)/COPYING.LGPL.txt
+	cp $(srcdir)/COPYING.FREEFONT $(WIN32PATH)/COPYING.FREEFONT.txt
+	cp $(srcdir)/COPYRIGHT $(WIN32PATH)/COPYRIGHT.txt
+	cp $(srcdir)/NEWS $(WIN32PATH)/NEWS.txt
+	cp $(srcdir)/doc/cz/PrectiMe $(WIN32PATH)/doc/cz/PrectiMe.txt
+	cp $(srcdir)/doc/de/NEUES $(WIN32PATH)/doc/de/NEUES.txt
+	cp $(srcdir)/doc/QuickStart $(WIN32PATH)/doc/QuickStart.txt
+	cp $(srcdir)/doc/es/InicioRapido $(WIN32PATH)/doc/es/InicioRapido.txt
+	cp $(srcdir)/doc/fr/DemarrageRapide $(WIN32PATH)/doc/fr/DemarrageRapide.txt
+	cp $(srcdir)/doc/it/GuidaRapida $(WIN32PATH)/doc/it/GuidaRapida.txt
+	cp $(srcdir)/doc/no-nb/HurtigStart $(WIN32PATH)/doc/no-nb/HurtigStart.txt
+	cp $(srcdir)/doc/da/HurtigStart $(WIN32PATH)/doc/da/HurtigStart.txt
+	cp $(srcdir)/doc/de/Schnellstart $(WIN32PATH)/doc/de/Schnellstart.txt
+	cp $(srcdir)/doc/se/Snabbstart $(WIN32PATH)/doc/se/Snabbstart.txt
+	cp $(srcdir)/README $(WIN32PATH)/README.txt
+	cp $(WIN32SDLDOCPATH)/README-SDL.txt $(WIN32PATH)/README-SDL.txt
+	cp $(srcdir)/doc/de/LIESMICH $(WIN32PATH)/doc/de/LIESMICH.txt
+	cp $(srcdir)/doc/se/LasMig $(WIN32PATH)/doc/se/LasMig.txt
+	cp $(WIN32SDLPATH)/SDL2.dll $(WIN32PATH)
+	cp $(srcdir)/dists/win32/graphics/left.bmp $(WIN32PATH)/graphics
+	cp $(srcdir)/dists/win32/graphics/scummvm-install.ico $(WIN32PATH)/graphics
+	cp $(srcdir)/dists/win32/graphics/scummvm-install.bmp $(WIN32PATH)/graphics
+	cp $(srcdir)/dists/win32/migration.bat $(WIN32PATH)
+	cp $(srcdir)/dists/win32/migration.txt $(WIN32PATH)
+	cp $(srcdir)/dists/win32/ScummVM.iss $(WIN32PATH)
+ifdef USE_SDL_NET
+	cp $(WIN32SDLPATH)/SDL2_net.dll $(WIN32PATH)
+	sed -e '/SDL2_net\.dll/ s/^;//' -i $(WIN32PATH)/ScummVM.iss
+endif
+ifdef USE_SPARKLE
+	cp $(WIN32SPARKLEPATH)/WinSparkle.dll $(WIN32PATH)
+	sed -e '/WinSparkle\.dll/ s/^;//' -i $(WIN32PATH)/ScummVM.iss
+endif
+	unix2dos $(WIN32PATH)/*.txt
+	unix2dos $(WIN32PATH)/doc/*.txt
+	unix2dos $(WIN32PATH)/doc/cz/*.txt
+	unix2dos $(WIN32PATH)/doc/da/*.txt
+	unix2dos $(WIN32PATH)/doc/de/*.txt
+	unix2dos $(WIN32PATH)/doc/es/*.txt
+	unix2dos $(WIN32PATH)/doc/fr/*.txt
+	unix2dos $(WIN32PATH)/doc/it/*.txt
+	unix2dos $(WIN32PATH)/doc/no-nb/*.txt
+	unix2dos $(WIN32PATH)/doc/se/*.txt
+
+.PHONY: win32dist
+
+include $(srcdir)/ports.mk

--- a/configure
+++ b/configure
@@ -2765,6 +2765,7 @@ case $_host_os in
 		append_var LIBS "-lmingw32 -lwinmm -lgdi32"
 		append_var OBJS "scummvmwinres.o"
 		add_line_to_config_mk 'WIN32 = 1'
+		_port_mk="backends/platform/sdl/win32/win32.mk"
 		;;
 	mint*)
 		append_var DEFINES "-DSYSTEM_NOT_SUPPORTING_D_TYPE"

--- a/ports.mk
+++ b/ports.mk
@@ -518,13 +518,6 @@ endif
 	unix2dos $(WIN32PATH)/doc/no-nb/*.txt
 	unix2dos $(WIN32PATH)/doc/se/*.txt
 
-# Special target to create a win32 NSIS installer
-win32setup: $(EXECUTABLE)
-	mkdir -p $(srcdir)/$(STAGINGPATH)
-	$(STRIP) $(EXECUTABLE) -o $(srcdir)/$(STAGINGPATH)/$(EXECUTABLE)
-	cp /usr/local/bin/SDL.dll $(srcdir)/$(STAGINGPATH)
-	makensis -V2 -Dtop_srcdir="../.." -Dstaging_dir="../../$(STAGINGPATH)" -Darch=$(ARCH) $(srcdir)/dists/win32/scummvm.nsi
-
 
 #
 # Special target to generate project files for various IDEs

--- a/ports.mk
+++ b/ports.mk
@@ -450,74 +450,6 @@ osxsnap: bundle
 publish-appcast:
 	scp dists/macosx/scummvm_appcast.xml www.scummvm.org:/var/www/html/appcasts/macosx/release.xml
 
-#
-# Windows specific
-#
-
-scummvmwinres.o: $(srcdir)/icons/scummvm.ico $(DIST_FILES_THEMES) $(DIST_FILES_NETWORKING) $(DIST_FILES_ENGINEDATA) $(srcdir)/dists/scummvm.rc
-	$(QUIET_WINDRES)$(WINDRES) -DHAVE_CONFIG_H $(WINDRESFLAGS) $(DEFINES) -I. -I$(srcdir) $(srcdir)/dists/scummvm.rc scummvmwinres.o
-
-# Special target to create a win32 snapshot binary (for Inno Setup)
-win32dist: all
-	mkdir -p $(WIN32PATH)
-	mkdir -p $(WIN32PATH)/graphics
-	mkdir -p $(WIN32PATH)/doc
-	mkdir -p $(WIN32PATH)/doc/cz
-	mkdir -p $(WIN32PATH)/doc/da
-	mkdir -p $(WIN32PATH)/doc/de
-	mkdir -p $(WIN32PATH)/doc/es
-	mkdir -p $(WIN32PATH)/doc/fr
-	mkdir -p $(WIN32PATH)/doc/it
-	mkdir -p $(WIN32PATH)/doc/no-nb
-	mkdir -p $(WIN32PATH)/doc/se
-	$(STRIP) $(EXECUTABLE) -o $(WIN32PATH)/$(EXECUTABLE)
-	cp $(srcdir)/AUTHORS $(WIN32PATH)/AUTHORS.txt
-	cp $(srcdir)/COPYING $(WIN32PATH)/COPYING.txt
-	cp $(srcdir)/COPYING.BSD $(WIN32PATH)/COPYING.BSD.txt
-	cp $(srcdir)/COPYING.LGPL $(WIN32PATH)/COPYING.LGPL.txt
-	cp $(srcdir)/COPYING.FREEFONT $(WIN32PATH)/COPYING.FREEFONT.txt
-	cp $(srcdir)/COPYRIGHT $(WIN32PATH)/COPYRIGHT.txt
-	cp $(srcdir)/NEWS $(WIN32PATH)/NEWS.txt
-	cp $(srcdir)/doc/cz/PrectiMe $(WIN32PATH)/doc/cz/PrectiMe.txt
-	cp $(srcdir)/doc/de/NEUES $(WIN32PATH)/doc/de/NEUES.txt
-	cp $(srcdir)/doc/QuickStart $(WIN32PATH)/doc/QuickStart.txt
-	cp $(srcdir)/doc/es/InicioRapido $(WIN32PATH)/doc/es/InicioRapido.txt
-	cp $(srcdir)/doc/fr/DemarrageRapide $(WIN32PATH)/doc/fr/DemarrageRapide.txt
-	cp $(srcdir)/doc/it/GuidaRapida $(WIN32PATH)/doc/it/GuidaRapida.txt
-	cp $(srcdir)/doc/no-nb/HurtigStart $(WIN32PATH)/doc/no-nb/HurtigStart.txt
-	cp $(srcdir)/doc/da/HurtigStart $(WIN32PATH)/doc/da/HurtigStart.txt
-	cp $(srcdir)/doc/de/Schnellstart $(WIN32PATH)/doc/de/Schnellstart.txt
-	cp $(srcdir)/doc/se/Snabbstart $(WIN32PATH)/doc/se/Snabbstart.txt
-	cp $(srcdir)/README $(WIN32PATH)/README.txt
-	cp $(WIN32SDLDOCPATH)/README-SDL.txt $(WIN32PATH)/README-SDL.txt
-	cp $(srcdir)/doc/de/LIESMICH $(WIN32PATH)/doc/de/LIESMICH.txt
-	cp $(srcdir)/doc/se/LasMig $(WIN32PATH)/doc/se/LasMig.txt
-	cp $(WIN32SDLPATH)/SDL2.dll $(WIN32PATH)
-	cp $(srcdir)/dists/win32/graphics/left.bmp $(WIN32PATH)/graphics
-	cp $(srcdir)/dists/win32/graphics/scummvm-install.ico $(WIN32PATH)/graphics
-	cp $(srcdir)/dists/win32/graphics/scummvm-install.bmp $(WIN32PATH)/graphics	
-	cp $(srcdir)/dists/win32/migration.bat $(WIN32PATH)
-	cp $(srcdir)/dists/win32/migration.txt $(WIN32PATH)
-	cp $(srcdir)/dists/win32/ScummVM.iss $(WIN32PATH)
-ifdef USE_SDL_NET
-	cp $(WIN32SDLPATH)/SDL2_net.dll $(WIN32PATH)
-	sed -e '/SDL2_net\.dll/ s/^;//' -i $(WIN32PATH)/ScummVM.iss
-endif
-ifdef USE_SPARKLE
-	cp $(WIN32SPARKLEPATH)/WinSparkle.dll $(WIN32PATH)
-	sed -e '/WinSparkle\.dll/ s/^;//' -i $(WIN32PATH)/ScummVM.iss
-endif
-	unix2dos $(WIN32PATH)/*.txt
-	unix2dos $(WIN32PATH)/doc/*.txt
-	unix2dos $(WIN32PATH)/doc/cz/*.txt
-	unix2dos $(WIN32PATH)/doc/da/*.txt
-	unix2dos $(WIN32PATH)/doc/de/*.txt
-	unix2dos $(WIN32PATH)/doc/es/*.txt
-	unix2dos $(WIN32PATH)/doc/fr/*.txt
-	unix2dos $(WIN32PATH)/doc/it/*.txt
-	unix2dos $(WIN32PATH)/doc/no-nb/*.txt
-	unix2dos $(WIN32PATH)/doc/se/*.txt
-
 
 #
 # Special target to generate project files for various IDEs
@@ -561,4 +493,4 @@ raspberrypi_dist:
 	rm -f -R scummvm-rpi
 
 # Mark special targets as phony
-.PHONY: deb bundle osxsnap win32dist install uninstall
+.PHONY: deb bundle osxsnap install uninstall


### PR DESCRIPTION
Also removed the now-unused win32setup rule.