### PR TITLE
ENGINES: Add optional extra configuration entries when creating new targets

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -580,6 +580,11 @@ Common::String EngineManager::createTargetForGame(const DetectedGame &game) {
 	addStringToConf("extra", game.extra, domain);
 	addStringToConf("guioptions", game.getGUIOptions(), domain);
 
+	// Add any extra configuration keys
+	for (Common::StringMap::iterator i = game._extraConfigEntries.begin();
+			i != game._extraConfigEntries.end(); ++i)
+		addStringToConf((*i)._key, (*i)._value, domain);
+
 	// TODO: Setting the description field here has the drawback
 	// that the user does never notice when we upgrade our descriptions.
 	// It might be nice to leave this field empty, and only set it to

--- a/engines/game.h
+++ b/engines/game.h
@@ -148,6 +148,21 @@ struct DetectedGame {
 	 */
 	GameSupportLevel gameSupportLevel;
 
+	/**
+	 * A list of extra keys to write to the configuration file
+	 */
+	Common::StringMap _extraConfigEntries;
+
+	/**
+	 * Allows adding of extra entries to be saved as part of the detection entry
+	 * in the configuration file.
+	 * @remarks		Any entry added using this should not be relied on being present
+	 *				in the configuration file, since starting games directly from the
+	 *				command line bypasses the game detection code
+	 */
+	void addExtraEntry(const Common::String &key, const Common::String &value) {
+		_extraConfigEntries[key] = value;
+	}
 private:
 	/**
 	 * Update the description string by appending (EXTRA/PLATFORM/LANG) to it.


### PR DESCRIPTION
As per digitall's request, this separate pull request contains the single commit for the change to the engines  to support optional extra entries to be set to be written into the generated section for a game entry.

Background: Since most interactive fiction games are only a single, it'll likely frequently be the case that multiple games will be in the same folder, even potentially multiple versions of the same game. Because of this, when the user selects a detected game entry supported by the Glk engine, it uses this new functionality to additionally store the filename the match was for. This way, when the game starts, it will ensure that the specific file is used.

One of the earlier concerns with this, that running games directly from the command line wouldn't work, has already been resolved. The engine has fallback code that will scan the specified folder for any file that detects as being of the given game Id, and play it. Also, this won't affect adding any non-Glk games, since if the _extraConfigEntries is empty, the createTargetForGame works as it always has.
