### PR TITLE
POSIX: Set the default screenshots path to the XDG Pictures directory

### DIFF
--- a/README
+++ b/README
@@ -2896,6 +2896,8 @@ The default location, when no screenshot path is defined in the config file,
 depends on the OS:
   Windows: In Users\username\My Pictures\ScummVM Screenshots.
   macOS X: On the Desktop.
+  Other unices: In the XDG Pictures user directory,
+                 e.g. ~/Pictures/ScummVM Screenshots.
   Any other OS: In the current directory.
 
 

--- a/backends/platform/sdl/posix/posix.h
+++ b/backends/platform/sdl/posix/posix.h
@@ -42,6 +42,8 @@ public:
 
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0);
 
+	Common::String getScreenshotsPath() override;
+
 protected:
 	/**
 	 * Base string for creating the default path and filename for the
@@ -63,6 +65,8 @@ protected:
 	virtual Common::String getDefaultConfigFileName();
 
 	virtual Common::WriteStream *createLogFile();
+
+	Common::String getXdgUserDir(const char *name);
 
 	virtual AudioCDManager *createAudioCDManager();
 


### PR DESCRIPTION
The screenshots are written to `$XDG_PICTURES_DIR/ScummVM Screenshots` as defined in the XDG user directories specification (https://www.freedesktop.org/wiki/Software/xdg-user-dirs/).

With this change the screenshots are saved to a user writable path by default on Linux when ScummVM is installed through a package manager.