### PR TITLE
WIN32: Try to attach to the parent console early in the initialization

### DIFF
--- a/backends/platform/sdl/win32/win32.mk
+++ b/backends/platform/sdl/win32/win32.mk
@@ -55,6 +55,9 @@ ifdef USE_SPARKLE
 	cp $(WIN32SPARKLEPATH)/WinSparkle.dll $(WIN32PATH)
 	sed -e '/WinSparkle\.dll/ s/^;//' -i $(WIN32PATH)/ScummVM.iss
 endif
+ifdef ENABLE_CONSOLE_WINDOW
+	sed -e '/--no-console/ s/^;//g' -i $(WIN32PATH)/ScummVM.iss
+endif
 	unix2dos $(WIN32PATH)/*.txt
 	unix2dos $(WIN32PATH)/doc/*.txt
 	unix2dos $(WIN32PATH)/doc/cz/*.txt

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -81,7 +81,7 @@ static const char HELP_STRING[] =
 	"  --auto-detect            Display a list of games from current or specified directory\n"
 	"                           and start the first one. Use --path=PATH to specify a directory.\n"
 	"  --recursive              In combination with --add or --detect recurse down all subdirectories\n"
-#if defined(WIN32) && !defined(_WIN32_WCE) && !defined(__SYMBIAN32__)
+#if defined(WIN32) && defined(ENABLE_CONSOLE_WINDOW) && !defined(_WIN32_WCE) && !defined(__SYMBIAN32__)
 	"  --console                Enable the console window (default:enabled)\n"
 #endif
 	"\n"
@@ -665,7 +665,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			END_OPTION
 #endif
 
-#if defined(WIN32) && !defined(_WIN32_WCE) && !defined(__SYMBIAN32__)
+#if defined(WIN32) && defined(ENABLE_CONSOLE_WINDOW) && !defined(_WIN32_WCE) && !defined(__SYMBIAN32__)
 			// Optional console window on Windows (default: enabled)
 			DO_LONG_OPTION_BOOL("console")
 			END_OPTION

--- a/configure
+++ b/configure
@@ -170,6 +170,7 @@ _optimizations=auto
 _use_cxx11=no
 _verbose_build=no
 _text_console=no
+_console_window=yes
 _mt32emu=yes
 _build_scalers=yes
 _build_hq_scalers=yes
@@ -1009,6 +1010,7 @@ Optional Features:
   --disable-eventrecorder  disable event recording functionality
   --enable-updates         build support for updates
   --enable-text-console    use text console instead of graphical console
+  --disable-console-window disable the console window (Windows only)
   --enable-verbose-build   enable regular echoing of commands during build
                            process
   --disable-bink           don't build with Bink video support
@@ -1229,6 +1231,8 @@ for ac_option in $@; do
 	--disable-eventrecorder)  _eventrec=no   ;;
 	--enable-text-console)    _text_console=yes ;;
 	--disable-text-console)   _text_console=no ;;
+	--enable-console-window)  _console_window=yes ;;
+	--disable-console-window) _console_window=no  ;;
 	--with-fluidsynth-prefix=*)
 		arg=`echo $ac_option | cut -d '=' -f 2`
 		FLUIDSYNTH_CFLAGS="-I$arg/include"
@@ -3614,6 +3618,12 @@ case $_backend in
 		else
 			append_var LIBS "`$_sdlconfig --prefix="$_sdlpath" --libs`"
 		fi
+
+		# On Windows, sdl-config adds -mwindows to the linker flags.
+		# We remove it here as we want ScummVM to decide by itself which
+		# subsystem it is targeting.
+		LIBS=$(echo $LIBS | sed 's/-mwindows//g')
+
 		append_var DEFINES "-DSDL_BACKEND"
 		add_line_to_config_mk "SDL_BACKEND = 1"
 
@@ -5134,6 +5144,37 @@ fi
 define_in_config_if_yes $_taskbar 'USE_TASKBAR'
 
 #
+# Check whether to enable the console window on Windows
+#
+case $_host_os in
+	mingw*)
+		# When the console window option is enabled, the main executable is
+		# built as a Console subsystem program so that Windows opens a console
+		# on startup. The program is blocking when started by cmd.exe.
+		# The --no-console runtime command line argument allows to hide the
+		# console window as soon as possible, but it remains visible for a
+		# small amount of time.
+		#
+		# When the console window is disabled, the main executable is built as
+		# a Windows subsystem program. Windows does not open a console window.
+		# ScummVM attaches to the parent console output stream when possible,
+		# but the output is mixed with the output of subsequent commands.
+		# It is not possible to create a console window using command line
+		# arguments.
+		if test "$_console_window" = yes; then
+			append_var LIBS "-mconsole"
+		else
+			append_var LIBS "-mwindows"
+		fi
+
+		define_in_config_if_yes $_console_window 'ENABLE_CONSOLE_WINDOW'
+		;;
+	*)
+		_console_window=no
+		;;
+esac
+
+#
 # Check whether to build Bink video support
 #
 echo_n "Building Bink video support... "
@@ -5240,6 +5281,10 @@ fi
 
 if test "$_text_console" = yes ; then
 	echo_n ", text console"
+fi
+
+if test "$_console_window" = yes ; then
+	echo_n ", console window"
 fi
 
 if test "$_vkeybd" = yes ; then

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -305,8 +305,7 @@ int main(int argc, char *argv[]) {
 	for (EngineDescList::const_iterator i = setup.engines.begin(); i != setup.engines.end(); ++i) {
 		if (i->enable) {
 			for (StringList::const_iterator ef = i->requiredFeatures.begin(); ef != i->requiredFeatures.end(); ++ef) {
-				FeatureList::iterator feature = std::find(setup.features.begin(), setup.features.end(), *ef);
-				if (feature != setup.features.end() && !feature->enable) {
+				if (!isFeatureEnabled(*ef, setup.features)) {
 					setEngineBuildState(i->name, setup.engines, false);
 					break;
 				}
@@ -1040,24 +1039,25 @@ const Feature s_features[] = {
 	{    "sdlnet",     "USE_SDL_NET", "SDL_net",          true, "SDL_net support" },
 
 	// Feature flags
-	{            "bink",             "USE_BINK",         "", true,  "Bink video support" },
-	{         "scalers",          "USE_SCALERS",         "", true,  "Scalers" },
-	{       "hqscalers",       "USE_HQ_SCALERS",         "", true,  "HQ scalers" },
-	{           "16bit",        "USE_RGB_COLOR",         "", true,  "16bit color support" },
-	{         "highres",          "USE_HIGHRES",         "", true,  "high resolution" },
-	{         "mt32emu",          "USE_MT32EMU",         "", true,  "integrated MT-32 emulator" },
-	{            "nasm",             "USE_NASM",         "", true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
-	{          "opengl",           "USE_OPENGL",         "", true,  "OpenGL support" },
-	{        "opengles",             "USE_GLES",         "", true,  "forced OpenGL ES mode" },
-	{         "taskbar",          "USE_TASKBAR",         "", true,  "Taskbar integration support" },
-	{           "cloud",            "USE_CLOUD",         "", true,  "Cloud integration support" },
-	{     "translation",      "USE_TRANSLATION",         "", true,  "Translation support" },
-	{          "vkeybd",        "ENABLE_VKEYBD",         "", false, "Virtual keyboard support"},
-	{       "keymapper",     "ENABLE_KEYMAPPER",         "", false, "Keymapper support"},
-	{   "eventrecorder", "ENABLE_EVENTRECORDER",         "", false, "Event recorder support"},
-	{         "updates",          "USE_UPDATES",         "", false, "Updates support"},
-	{      "langdetect",       "USE_DETECTLANG",         "", true,  "System language detection support" } // This feature actually depends on "translation", there
-	                                                                                                      // is just no current way of properly detecting this...
+	{            "bink",              "USE_BINK",         "", true,  "Bink video support" },
+	{         "scalers",           "USE_SCALERS",         "", true,  "Scalers" },
+	{       "hqscalers",        "USE_HQ_SCALERS",         "", true,  "HQ scalers" },
+	{           "16bit",         "USE_RGB_COLOR",         "", true,  "16bit color support" },
+	{         "highres",           "USE_HIGHRES",         "", true,  "high resolution" },
+	{         "mt32emu",           "USE_MT32EMU",         "", true,  "integrated MT-32 emulator" },
+	{            "nasm",              "USE_NASM",         "", true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
+	{          "opengl",            "USE_OPENGL",         "", true,  "OpenGL support" },
+	{        "opengles",              "USE_GLES",         "", true,  "forced OpenGL ES mode" },
+	{         "taskbar",           "USE_TASKBAR",         "", true,  "Taskbar integration support" },
+	{           "cloud",             "USE_CLOUD",         "", true,  "Cloud integration support" },
+	{     "translation",       "USE_TRANSLATION",         "", true,  "Translation support" },
+	{          "vkeybd",         "ENABLE_VKEYBD",         "", false, "Virtual keyboard support"},
+	{       "keymapper",      "ENABLE_KEYMAPPER",         "", false, "Keymapper support"},
+	{   "eventrecorder",  "ENABLE_EVENTRECORDER",         "", false, "Event recorder support"},
+	{  "console-window", "ENABLE_CONSOLE_WINDOW",         "", true,  "Console window"},
+	{         "updates",           "USE_UPDATES",         "", false, "Updates support"},
+	{      "langdetect",        "USE_DETECTLANG",         "", true,  "System language detection support" } // This feature actually depends on "translation", there
+	                                                                                                       // is just no current way of properly detecting this...
 };
 
 const Tool s_tools[] = {
@@ -1115,6 +1115,15 @@ bool setFeatureBuildState(const std::string &name, FeatureList &features, bool e
 	if (i != features.end()) {
 		i->enable = enable;
 		return true;
+	} else {
+		return false;
+	}
+}
+
+bool isFeatureEnabled(const std::string &name, const FeatureList &features) {
+	FeatureList::const_iterator i = std::find(features.begin(), features.end(), name);
+	if (i != features.end()) {
+		return i->enable;
 	} else {
 		return false;
 	}

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -212,6 +212,15 @@ StringList getFeatureLibraries(const FeatureList &features);
 bool setFeatureBuildState(const std::string &name, FeatureList &features, bool enable);
 
 /**
+ * Retrieve the build state of a feature
+ *
+ * @param name Name of the feature.
+ * @param features List of features to operate on.
+ * @return "true", when the feature is enabled, "false" otherwise.
+ */
+bool isFeatureEnabled(const std::string &name, const FeatureList &features);
+
+/**
  * Structure to describe a build setup.
  *
  * This includes various information about which engines to

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -390,13 +390,15 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	properties << "\t\t\t<RuntimeTypeInfo>false</RuntimeTypeInfo>\n";
 #endif
 
+	const bool windowsSubsystem = !isFeatureEnabled("console-window", setup.features) && !setup.devTools && !setup.tests;
+
 	properties << "\t\t\t<WarningLevel>Level4</WarningLevel>\n"
 	              "\t\t\t<TreatWarningAsError>false</TreatWarningAsError>\n"
 	              "\t\t\t<CompileAs>Default</CompileAs>\n"
 	              "\t\t</ClCompile>\n"
 	              "\t\t<Link>\n"
 	              "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n"
-	              "\t\t\t<SubSystem>Console</SubSystem>\n";
+	              "\t\t\t<SubSystem>" << (windowsSubsystem ? "Windows" : "Console") << "</SubSystem>\n";
 
 	if (!setup.devTools && !setup.tests)
 		properties << "\t\t\t<EntryPointSymbol>WinMainCRTStartup</EntryPointSymbol>\n";

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -238,6 +238,8 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 	properties << "\t\tRuntimeTypeInfo=\"false\"\n";
 #endif
 
+	const bool windowsSubsystem = !isFeatureEnabled("console-window", setup.features) && !setup.devTools && !setup.tests;
+
 	properties << "\t\tWarningLevel=\"4\"\n"
 	              "\t\tWarnAsError=\"false\"\n"
 	              "\t\tCompileAs=\"0\"\n"
@@ -249,7 +251,7 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 	              "\t<Tool\n"
 	              "\t\tName=\"VCLinkerTool\"\n"
 	              "\t\tIgnoreDefaultLibraryNames=\"\"\n"
-	              "\t\tSubSystem=\"1\"\n";
+	              "\t\tSubSystem=\"" << (windowsSubsystem ? "2" : "1") << "\"\n";
 
 	if (!setup.devTools && !setup.tests)
 		properties << "\t\tEntryPointSymbol=\"WinMainCRTStartup\"\n";

--- a/dists/win32/ScummVM.iss
+++ b/dists/win32/ScummVM.iss
@@ -201,8 +201,8 @@ Name: "{userdesktop}\ScummVM"; Filename: "{app}\scummvm.exe"; Tasks: desktopicon
 ; General
 Name: {group}\{cm:UninstallProgram, ScummVM}; Filename: {uninstallexe}
 Name: {group}\ScummVM; Filename: {app}\scummvm.exe; WorkingDir: {app}; Comment: scummvm; Flags: createonlyiffileexists; IconIndex: 0
-Name: {group}\ScummVM (noconsole); Filename: {app}\scummvm.exe; Parameters: "--no-console"; WorkingDir: {app}; Comment: scummvm; Flags: createonlyiffileexists; IconIndex: 0; Languages: not german
-Name: {group}\ScummVM (ohne Konsolenfenster); Filename: {app}\scummvm.exe; Parameters: "--no-console"; WorkingDir: {app}; Comment: scummvm; Flags: createonlyiffileexists; IconIndex:0; Languages: german
+; Name: {group}\ScummVM (noconsole); Filename: {app}\scummvm.exe; Parameters: "--no-console"; WorkingDir: {app}; Comment: scummvm; Flags: createonlyiffileexists; IconIndex: 0; Languages: not german
+; Name: {group}\ScummVM (ohne Konsolenfenster); Filename: {app}\scummvm.exe; Parameters: "--no-console"; WorkingDir: {app}; Comment: scummvm; Flags: createonlyiffileexists; IconIndex:0; Languages: german
 Name: {group}\Saved Games\Saved Games; Filename: {userappdata}\ScummVM\Saved Games; WorkingDir: {userappdata}\ScummVM\Saved Games; Comment: Saved Games; IconIndex: 0; MinVersion: 0, 1; Languages: not german
 Name: {group}\Spielst�nde\Spielst�nde; Filename: {userappdata}\ScummVM\Saved Games; WorkingDir: {userappdata}\ScummVM\Saved Games; Comment: Spielst�nde; IconIndex: 0; MinVersion: 0, 1; Languages: german
 Name: {group}\Saved Games\Saved Games (old default); Filename: {app}; WorkingDir: {app}; Comment: Saved Games (old default); IconIndex: 0; MinVersion: 0, 1; Languages: not german


### PR DESCRIPTION
Don't create a new console if our parent process has one or has already initialized standard input / output for us.

This fixes the command line output not being visible. It also prevents us from opening of a new console window when starting ScummVM from a console.