### PR TITLE
BASE: Don't set fullscreen on Return to Launcher

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -282,7 +282,7 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 	return result;
 }
 
-static void setupGraphics(OSystem &system) {
+static void setupGraphics(OSystem &system, bool isInitialSetup) {
 
 	system.beginGFXTransaction();
 		// Set the user specified graphics mode (if any).
@@ -292,7 +292,7 @@ static void setupGraphics(OSystem &system) {
 
 		if (ConfMan.hasKey("aspect_ratio"))
 			system.setFeatureState(OSystem::kFeatureAspectRatioCorrection, ConfMan.getBool("aspect_ratio"));
-		if (ConfMan.hasKey("fullscreen"))
+		if (isInitialSetup && ConfMan.hasKey("fullscreen"))
 			system.setFeatureState(OSystem::kFeatureFullscreenMode, ConfMan.getBool("fullscreen"));
 		if (ConfMan.hasKey("filtering"))
 			system.setFeatureState(OSystem::kFeatureFilteringMode, ConfMan.getBool("filtering"));
@@ -459,7 +459,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	if (settings.contains("disable-display")) {
 		ConfMan.setInt("disable-display", 1, Common::ConfigManager::kTransientDomain);
 	}
-	setupGraphics(system);
+	setupGraphics(system, true);
 
 	// Init the different managers that are used by the engines.
 	// Do it here to prevent fragmentation later
@@ -601,7 +601,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 		}
 
 		// reset the graphics to default
-		setupGraphics(system);
+		setupGraphics(system, false);
 		if (0 == ConfMan.getActiveDomain()) {
 			launcherDialog();
 		}


### PR DESCRIPTION
Return to Launcher currently resets kFeatureFullscreenMode. This undoes
switching to/from fullscreen through a hotkey. This happens if the
"fullscreen" config setting exists, which it doesn't on a fresh install,
which means that Return to Launcher's out-of-the-box behavior changes 
once a user visits Options and clicks OK, no matter what they enter and
even if they don't change anything.

This makes Return to Launcher not change kFeatureFullscreenMode, which
seems preferable, and makes behavior before and after saving Options
consistent. Issue #10810