### PR TITLE
IOS: Restore and fix one-touch swipes to emulate arrow keys

### DIFF
--- a/backends/platform/ios7/ios7_osys_events.cpp
+++ b/backends/platform/ios7/ios7_osys_events.cpp
@@ -443,61 +443,22 @@ void  OSystem_iOS7::handleEvent_keyPressed(Common::Event &event, int keyPressed)
 bool OSystem_iOS7::handleEvent_swipe(Common::Event &event, int direction, int touches) {
 	if (touches == 1) {
 		Common::KeyCode keycode = Common::KEYCODE_INVALID;
-		switch (_screenOrientation) {
-		case kScreenOrientationPortrait:
-			switch ((UIViewSwipeDirection)direction) {
-				case kUIViewSwipeUp:
-					keycode = Common::KEYCODE_UP;
-					break;
-				case kUIViewSwipeDown:
-					keycode = Common::KEYCODE_DOWN;
-					break;
-				case kUIViewSwipeLeft:
-					keycode = Common::KEYCODE_LEFT;
-					break;
-				case kUIViewSwipeRight:
-					keycode = Common::KEYCODE_RIGHT;
-					break;
-				default:
-					return false;
-			}
-			break;
-		case kScreenOrientationLandscape:
-			switch ((UIViewSwipeDirection)direction) {
-				case kUIViewSwipeUp:
-					keycode = Common::KEYCODE_LEFT;
-					break;
-				case kUIViewSwipeDown:
-					keycode = Common::KEYCODE_RIGHT;
-					break;
-				case kUIViewSwipeLeft:
-					keycode = Common::KEYCODE_DOWN;
-					break;
-				case kUIViewSwipeRight:
-					keycode = Common::KEYCODE_UP;
-					break;
-				default:
-					return false;
-			}
-			break;
-		case kScreenOrientationFlippedLandscape:
-			switch ((UIViewSwipeDirection)direction) {
-				case kUIViewSwipeUp:
-					keycode = Common::KEYCODE_RIGHT;
-					break;
-				case kUIViewSwipeDown:
-					keycode = Common::KEYCODE_LEFT;
-					break;
-				case kUIViewSwipeLeft:
-					keycode = Common::KEYCODE_UP;
-					break;
-				case kUIViewSwipeRight:
-					keycode = Common::KEYCODE_DOWN;
-					break;
-				default:
-					return false;
-			}
-			break;
+
+		switch ((UIViewSwipeDirection)direction) {
+			case kUIViewSwipeUp:
+				keycode = Common::KEYCODE_UP;
+				break;
+			case kUIViewSwipeDown:
+				keycode = Common::KEYCODE_DOWN;
+				break;
+			case kUIViewSwipeLeft:
+				keycode = Common::KEYCODE_LEFT;
+				break;
+			case kUIViewSwipeRight:
+				keycode = Common::KEYCODE_RIGHT;
+				break;
+			default:
+				return false;
 		}
 
 		event.kbd.keycode = _queuedInputEvent.kbd.keycode = keycode;

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -349,29 +349,39 @@ uint getSizeNextPOT(uint size) {
 }
 
 - (void)setupGestureRecognizers {
-	UISwipeGestureRecognizer *swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeRight:)];
-	swipeRight.direction = UISwipeGestureRecognizerDirectionRight;
-	swipeRight.numberOfTouchesRequired = 2;
-	swipeRight.delaysTouchesBegan = NO;
-	swipeRight.delaysTouchesEnded = NO;
+	for (NSUInteger numberOfTouchesRequired = 1; numberOfTouchesRequired <= 2; numberOfTouchesRequired++) {
+		UISwipeGestureRecognizer *swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(swipeRight:)];
+		swipeRight.direction = UISwipeGestureRecognizerDirectionRight;
+		swipeRight.numberOfTouchesRequired = numberOfTouchesRequired;
+		swipeRight.delaysTouchesBegan = NO;
+		swipeRight.delaysTouchesEnded = NO;
+		[self addGestureRecognizer:swipeRight];
+		[swipeRight release];
 
-	UISwipeGestureRecognizer *swipeLeft = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeLeft:)];
-	swipeLeft.direction = UISwipeGestureRecognizerDirectionLeft;
-	swipeLeft.numberOfTouchesRequired = 2;
-	swipeLeft.delaysTouchesBegan = NO;
-	swipeLeft.delaysTouchesEnded = NO;
+		UISwipeGestureRecognizer *swipeLeft = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(swipeLeft:)];
+		swipeLeft.direction = UISwipeGestureRecognizerDirectionLeft;
+		swipeLeft.numberOfTouchesRequired = numberOfTouchesRequired;
+		swipeLeft.delaysTouchesBegan = NO;
+		swipeLeft.delaysTouchesEnded = NO;
+		[self addGestureRecognizer:swipeLeft];
+		[swipeLeft release];
 
-	UISwipeGestureRecognizer *swipeUp = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeUp:)];
-	swipeUp.direction = UISwipeGestureRecognizerDirectionUp;
-	swipeUp.numberOfTouchesRequired = 2;
-	swipeUp.delaysTouchesBegan = NO;
-	swipeUp.delaysTouchesEnded = NO;
+		UISwipeGestureRecognizer *swipeUp = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(swipeUp:)];
+		swipeUp.direction = UISwipeGestureRecognizerDirectionUp;
+		swipeUp.numberOfTouchesRequired = numberOfTouchesRequired;
+		swipeUp.delaysTouchesBegan = NO;
+		swipeUp.delaysTouchesEnded = NO;
+		[self addGestureRecognizer:swipeUp];
+		[swipeUp release];
 
-	UISwipeGestureRecognizer *swipeDown = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeDown:)];
-	swipeDown.direction = UISwipeGestureRecognizerDirectionDown;
-	swipeDown.numberOfTouchesRequired = 2;
-	swipeDown.delaysTouchesBegan = NO;
-	swipeDown.delaysTouchesEnded = NO;
+		UISwipeGestureRecognizer *swipeDown = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(swipeDown:)];
+		swipeDown.direction = UISwipeGestureRecognizerDirectionDown;
+		swipeDown.numberOfTouchesRequired = numberOfTouchesRequired;
+		swipeDown.delaysTouchesBegan = NO;
+		swipeDown.delaysTouchesEnded = NO;
+		[self addGestureRecognizer:swipeDown];
+		[swipeDown release];
+	}
 
 	UITapGestureRecognizer *doubleTapTwoFingers = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersDoubleTap:)];
 	doubleTapTwoFingers.numberOfTapsRequired = 2;
@@ -379,16 +389,8 @@ uint getSizeNextPOT(uint size) {
 	doubleTapTwoFingers.delaysTouchesBegan = NO;
 	doubleTapTwoFingers.delaysTouchesEnded = NO;
 
-	[self addGestureRecognizer:swipeRight];
-	[self addGestureRecognizer:swipeLeft];
-	[self addGestureRecognizer:swipeUp];
-	[self addGestureRecognizer:swipeDown];
 	[self addGestureRecognizer:doubleTapTwoFingers];
 
-	[swipeRight release];
-	[swipeLeft release];
-	[swipeUp release];
-	[swipeDown release];
 	[doubleTapTwoFingers release];
 }
 
@@ -998,20 +1000,20 @@ uint getSizeNextPOT(uint size) {
 	_secondTouch = nil;
 }
 
-- (void)twoFingersSwipeRight:(UISwipeGestureRecognizer *)recognizer {
-	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeRight, 2)];
+- (void)swipeRight:(UISwipeGestureRecognizer *)recognizer {
+	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeRight, recognizer.numberOfTouchesRequired)];
 }
 
-- (void)twoFingersSwipeLeft:(UISwipeGestureRecognizer *)recognizer {
-	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeLeft, 2)];
+- (void)swipeLeft:(UISwipeGestureRecognizer *)recognizer {
+	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeLeft, recognizer.numberOfTouchesRequired)];
 }
 
-- (void)twoFingersSwipeUp:(UISwipeGestureRecognizer *)recognizer {
-	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeUp, 2)];
+- (void)swipeUp:(UISwipeGestureRecognizer *)recognizer {
+	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeUp, recognizer.numberOfTouchesRequired)];
 }
 
-- (void)twoFingersSwipeDown:(UISwipeGestureRecognizer *)recognizer {
-	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeDown, 2)];
+- (void)swipeDown:(UISwipeGestureRecognizer *)recognizer {
+	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeDown, recognizer.numberOfTouchesRequired)];
 }
 
 - (void)twoFingersDoubleTap:(UITapGestureRecognizer *)recognizer {

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -355,6 +355,7 @@ uint getSizeNextPOT(uint size) {
 		swipeRight.numberOfTouchesRequired = numberOfTouchesRequired;
 		swipeRight.delaysTouchesBegan = NO;
 		swipeRight.delaysTouchesEnded = NO;
+		swipeRight.cancelsTouchesInView = NO;
 		[self addGestureRecognizer:swipeRight];
 		[swipeRight release];
 
@@ -363,6 +364,7 @@ uint getSizeNextPOT(uint size) {
 		swipeLeft.numberOfTouchesRequired = numberOfTouchesRequired;
 		swipeLeft.delaysTouchesBegan = NO;
 		swipeLeft.delaysTouchesEnded = NO;
+		swipeLeft.cancelsTouchesInView = NO;
 		[self addGestureRecognizer:swipeLeft];
 		[swipeLeft release];
 
@@ -371,6 +373,7 @@ uint getSizeNextPOT(uint size) {
 		swipeUp.numberOfTouchesRequired = numberOfTouchesRequired;
 		swipeUp.delaysTouchesBegan = NO;
 		swipeUp.delaysTouchesEnded = NO;
+		swipeUp.cancelsTouchesInView = NO;
 		[self addGestureRecognizer:swipeUp];
 		[swipeUp release];
 
@@ -379,6 +382,7 @@ uint getSizeNextPOT(uint size) {
 		swipeDown.numberOfTouchesRequired = numberOfTouchesRequired;
 		swipeDown.delaysTouchesBegan = NO;
 		swipeDown.delaysTouchesEnded = NO;
+		swipeDown.cancelsTouchesInView = NO;
 		[self addGestureRecognizer:swipeDown];
 		[swipeDown release];
 	}


### PR DESCRIPTION
See "Controls" on http://wiki.scummvm.org/index.php/IPhone
Fixes https://bugs.scummvm.org/ticket/5914
    
The first commit restores the functionality that was already implemented once upon a time, but only works in portrait orientation.  The existing code attempts to compensate for the device orientation; I assume that this was necessary once upon a time, but no longer.  Removing that is in a separate commit, in case it has some context where it is required that I am not aware of.