### PR TITLE
SCI: fix full view remap effect

### DIFF
--- a/engines/sci/graphics/animate.cpp
+++ b/engines/sci/graphics/animate.cpp
@@ -474,7 +474,7 @@ void GfxAnimate::drawCels() {
 			writeSelector(_s->_segMan, it->object, SELECTOR(underBits), bitsHandle);
 
 			// draw corresponding cel
-			_paint16->drawCel(it->viewId, it->loopNo, it->celNo, it->celRect, it->priority, it->paletteNo, it->scaleX, it->scaleY);
+			_paint16->drawCel(it->viewId, it->loopNo, it->celNo, it->celRect, it->priority, it->paletteNo, it->scaleX, it->scaleY, it->scaleSignal);
 			it->showBitsFlag = true;
 
 			if (it->signal & kSignalRemoveView)

--- a/engines/sci/graphics/view.cpp
+++ b/engines/sci/graphics/view.cpp
@@ -832,8 +832,8 @@ void GfxView::draw(const Common::Rect &rect, const Common::Rect &clipRect, const
 						// SCI16 remapping (QFG4 demo)
 						if (g_sci->_gfxRemap16 && g_sci->_gfxRemap16->isRemapped(outputColor))
 							outputColor = g_sci->_gfxRemap16->remapColor(outputColor, _screen->getVisual(x2, y2));
-						// SCI16+ remapping (Catdate)
-						if ((scaleSignal & 0x200) && g_sci->_gfxRemap16 && !g_sci->_gfxRemap16->isRemapped(outputColor))
+						// SCI11+ remapping (Catdate)
+						if ((scaleSignal & 0x200) && g_sci->_gfxRemap16)
 							outputColor = g_sci->_gfxRemap16->remapColor(253, outputColor);
 						_screen->putPixel(x2, y2, drawMask, outputColor, priority, 0);
 					}
@@ -926,8 +926,8 @@ void GfxView::drawScaled(const Common::Rect &rect, const Common::Rect &clipRect,
 				// SCI16 remapping (QFG4 demo)
 				if (g_sci->_gfxRemap16 && g_sci->_gfxRemap16->isRemapped(outputColor))
 					outputColor = g_sci->_gfxRemap16->remapColor(outputColor, _screen->getVisual(x2, y2));
-				// SCI16+ remapping (Catdate)
-				if ((scaleSignal & 0x200) && g_sci->_gfxRemap16 && !g_sci->_gfxRemap16->isRemapped(outputColor))
+				// SCI11+ remapping (Catdate)
+				if ((scaleSignal & 0x200) && g_sci->_gfxRemap16)
 					outputColor = g_sci->_gfxRemap16->remapColor(253, outputColor);
 				_screen->putPixel(x2, y2, drawMask, outputColor, priority, 0);
 			}


### PR DESCRIPTION
The new stuff added to view.cpp for SCI11+ never actually triggers because I'd neglected to have `GfxAnimate::drawCels()` pass the scaleSignal that the remap effect requires, thus defaulting to zero.

This has been tested and correctly lets the work-in-progress full version of The Dating Pool draw characters standing in shadow.