### PR TITLE
 GRAPHICS: Add a function to load TrueType fonts from fonts.dat

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -334,6 +334,9 @@ endif
 ifdef ENABLE_XEEN
 DIST_FILES_ENGINEDATA+=xeen.ccs
 endif
+ifdef USE_FREETYPE2
+DIST_FILES_ENGINEDATA+=fonts.dat
+endif
 DIST_FILES_ENGINEDATA:=$(addprefix $(srcdir)/dists/engine-data/,$(DIST_FILES_ENGINEDATA))
 
 # pred.dic is currently only used for the AGI engine

--- a/backends/platform/maemo/debian/rules
+++ b/backends/platform/maemo/debian/rules
@@ -50,6 +50,7 @@ install: build
 # for optified version we can also add engine datafiles
 	install -m0644 dists/engine-data/access.dat debian/scummvm/opt/scummvm/share
 	install -m0644 dists/engine-data/drascula.dat debian/scummvm/opt/scummvm/share
+	install -m0644 dists/engine-data/fonts.dat debian/scummvm/opt/scummvm/share
 	install -m0644 dists/engine-data/hugo.dat debian/scummvm/opt/scummvm/share
 	install -m0644 dists/engine-data/kyra.dat debian/scummvm/opt/scummvm/share
 	install -m0644 dists/engine-data/lure.dat debian/scummvm/opt/scummvm/share

--- a/backends/platform/symbian/S60v3/scummvm-CVS-SymbianS60v3.pkg
+++ b/backends/platform/symbian/S60v3/scummvm-CVS-SymbianS60v3.pkg
@@ -62,6 +62,7 @@
 
 ; Common datafiles needed for some games
 "..\..\..\..\dists\engine-data\drascula.dat"-"c:\data\scummvm\drascula.dat"
+"..\..\..\..\dists\engine-data\fonts.dat"-"c:\data\scummvm\fonts.dat"
 "..\..\..\..\dists\engine-data\hugo.dat"-"c:\data\scummvm\hugo.dat"
 "..\..\..\..\dists\engine-data\kyra.dat"-"c:\data\scummvm\kyra.dat"
 "..\..\..\..\dists\engine-data\lure.dat"-"c:\data\scummvm\lure.dat"

--- a/backends/platform/symbian/S60v3/scummvm-CVS-SymbianS60v3_split.pkg
+++ b/backends/platform/symbian/S60v3/scummvm-CVS-SymbianS60v3_split.pkg
@@ -67,6 +67,7 @@
 
 ; Common datafiles needed for some games
 "..\..\..\..\dists\engine-data\drascula.dat"-"c:\data\scummvm\drascula.dat"
+"..\..\..\..\dists\engine-data\fonts.dat"-"c:\data\scummvm\fonts.dat"
 "..\..\..\..\dists\engine-data\hugo.dat"-"c:\data\scummvm\hugo.dat"
 "..\..\..\..\dists\engine-data\kyra.dat"-"c:\data\scummvm\kyra.dat"
 "..\..\..\..\dists\engine-data\lure.dat"-"c:\data\scummvm\lure.dat"

--- a/backends/platform/symbian/UIQ3/scummvm-CVS-SymbianUIQ3.pkg
+++ b/backends/platform/symbian/UIQ3/scummvm-CVS-SymbianUIQ3.pkg
@@ -60,6 +60,7 @@
 
 ; Common datafiles needed for some games
 "..\..\..\..\dists\engine-data\drascula.dat"-"c:\shared\scummvm\drascula.dat"
+"..\..\..\..\dists\engine-data\fonts.dat"-"c:\shared\scummvm\fonts.dat"
 "..\..\..\..\dists\engine-data\hugo.dat"-"c:\shared\scummvm\hugo.dat"
 "..\..\..\..\dists\engine-data\kyra.dat"-"c:\shared\scummvm\kyra.dat"
 "..\..\..\..\dists\engine-data\lure.dat"-"c:\shared\scummvm\lure.dat"

--- a/backends/platform/symbian/UIQ3/scummvm-CVS-SymbianUIQ3_split.pkg
+++ b/backends/platform/symbian/UIQ3/scummvm-CVS-SymbianUIQ3_split.pkg
@@ -68,6 +68,7 @@
 
 ; Common datafiles needed for some games
 "..\..\..\..\dists\engine-data\drascula.dat"-"c:\shared\scummvm\drascula.dat"
+"..\..\..\..\dists\engine-data\fonts.dat"-"c:\shared\scummvm\fonts.dat"
 "..\..\..\..\dists\engine-data\hugo.dat"-"c:\shared\scummvm\hugo.dat"
 "..\..\..\..\dists\engine-data\kyra.dat"-"c:\shared\scummvm\kyra.dat"
 "..\..\..\..\dists\engine-data\lure.dat"-"c:\shared\scummvm\lure.dat"

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -765,6 +765,7 @@ XcodeProvider::ValueList& XcodeProvider::getResourceFiles() const {
 		files.push_back("dists/engine-data/access.dat");
 		files.push_back("dists/engine-data/cryo.dat");
 		files.push_back("dists/engine-data/drascula.dat");
+		files.push_back("dists/engine-data/fonts.dat");
 		files.push_back("dists/engine-data/hugo.dat");
 		files.push_back("dists/engine-data/kyra.dat");
 		files.push_back("dists/engine-data/lure.dat");

--- a/dists/irix/scummvm.idb
+++ b/dists/irix/scummvm.idb
@@ -6,6 +6,7 @@ f 0644 root sys usr/ScummVM/README README scummvm.man.readme
 f 0755 root sys usr/ScummVM/scummvm scummvm scummvm.sw.eoe tag('0x5260dbec')
 f 0644 root sys usr/ScummVM/share/pixmaps/scummvm.xpm scummvm.xpm scummvm.sw.eoe
 f 0644 root sys usr/ScummVM/share/scummvm/drascula.dat drascula.dat scummvm.sw.eoe
+f 0644 root sys usr/ScummVM/share/scummvm/fonts.dat fonts.dat scummvm.sw.eoe
 f 0644 root sys usr/ScummVM/share/scummvm/kyra.dat kyra.dat scummvm.sw.eoe
 f 0644 root sys usr/ScummVM/share/scummvm/lure.dat lure.dat scummvm.sw.eoe
 f 0644 root sys usr/ScummVM/share/scummvm/pred.dic pred.dic scummvm.sw.eoe

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -24,6 +24,9 @@ translations.dat       FILE    "gui/themes/translations.dat"
 #ifdef USE_SDL_NET
 wwwroot.zip            FILE    "dists/networking/wwwroot.zip"
 #endif
+#ifdef USE_FREETYPE2
+fonts.dat              FILE    "dists/engine-data/fonts.dat"
+#endif
 
 #if ENABLE_ACCESS   == STATIC_PLUGIN
 access.dat           FILE    "dists/engine-data/access.dat"
@@ -33,9 +36,6 @@ cryo.dat               FILE    "dists/engine-data/cryo.dat"
 #endif
 #if ENABLE_DRASCULA   == STATIC_PLUGIN
 drascula.dat           FILE    "dists/engine-data/drascula.dat"
-#endif
-#if ENABLE_GLK        == STATIC_PLUGIN
-fonts.dat              FILE   "dists/engine-data/fonts.dat"
 #endif
 #if ENABLE_HUGO       == STATIC_PLUGIN
 hugo.dat               FILE    "dists/engine-data/hugo.dat"

--- a/engines/wintermute/base/font/base_font_truetype.cpp
+++ b/engines/wintermute/base/font/base_font_truetype.cpp
@@ -38,7 +38,6 @@
 #include "graphics/fonts/ttf.h"
 #include "graphics/fontman.h"
 #include "common/unzip.h"
-#include "common/config-manager.h" // For Scummmodern.zip
 #include <limits.h>
 
 namespace Wintermute {
@@ -587,35 +586,10 @@ bool BaseFontTT::initFont() {
 		file = nullptr;
 	}
 
-	// Fallback2: Try to find ScummModern.zip, and get the font from there:
+	// Fallback2: Try load the font from the common fonts archive:
 	if (!_font) {
-		Common::SeekableReadStream *themeFile = nullptr;
-		if (ConfMan.hasKey("themepath")) {
-			Common::FSNode themePath(ConfMan.get("themepath"));
-			if (themePath.exists()) {
-				Common::FSNode scummModern = themePath.getChild("scummmodern.zip");
-				if (scummModern.exists()) {
-					themeFile = scummModern.createReadStream();
-				}
-			}
-		}
-		if (!themeFile) { // Fallback 2.5: Search for ScummModern.zip in SearchMan.
-			themeFile = SearchMan.createReadStreamForMember("scummmodern.zip");
-		}
-		if (themeFile) {
-			Common::Archive *themeArchive = Common::makeZipArchive(themeFile);
-			if (themeArchive->hasFile(fallbackFilename)) {
-				file = nullptr;
-				file = themeArchive->createReadStreamForMember(fallbackFilename);
-				_deletableFont = Graphics::loadTTFFont(*file, _fontHeight, Graphics::kTTFSizeModeCharacter, 96); // Use the same dpi as WME (96 vs 72).
-				_font = _deletableFont;
-			}
-			// We're not using BaseFileManager, so clean up after ourselves:
-			delete file;
-			file = nullptr;
-			delete themeArchive;
-			themeArchive = nullptr;
-		}
+		_deletableFont = Graphics::loadTTFFontFromArchive(fallbackFilename, _fontHeight, Graphics::kTTFSizeModeCharacter, 96); // Use the same dpi as WME (96 vs 72).
+		_font = _deletableFont;
 	}
 
 	// Fallback3: Try to ask FontMan for the FreeSans.ttf ScummModern.zip uses:

--- a/engines/zvision/text/truetype_font.cpp
+++ b/engines/zvision/text/truetype_font.cpp
@@ -118,12 +118,15 @@ bool StyledTTFont::loadFont(const Common::String &fontName, int32 point, uint st
 	bool sharp = (_style & TTF_STYLE_SHARP) == TTF_STYLE_SHARP;
 
 	Common::File file;
+	Graphics::Font *newFont;
 	if (!file.open(newFontName) && !_engine->getSearchManager()->openFile(file, newFontName) &&
 		!file.open(liberationFontName) && !_engine->getSearchManager()->openFile(file, liberationFontName) &&
-		!file.open(freeFontName) && !_engine->getSearchManager()->openFile(file, freeFontName))
-		error("Unable to open font file %s (Liberation Font alternative: %s, FreeFont alternative: %s)", newFontName.c_str(), liberationFontName.c_str(), freeFontName.c_str());
+		!file.open(freeFontName) && !_engine->getSearchManager()->openFile(file, freeFontName)) {
+		newFont = Graphics::loadTTFFontFromArchive(freeFontName, point, Graphics::kTTFSizeModeCell, 0, (sharp ? Graphics::kTTFRenderModeMonochrome : Graphics::kTTFRenderModeNormal));
+	} else {
+		newFont = Graphics::loadTTFFont(file, point, Graphics::kTTFSizeModeCell, 0, (sharp ? Graphics::kTTFRenderModeMonochrome : Graphics::kTTFRenderModeNormal));
+	}
 
-	Graphics::Font *newFont = Graphics::loadTTFFont(file, point, Graphics::kTTFSizeModeCell, 0, (sharp ? Graphics::kTTFRenderModeMonochrome : Graphics::kTTFRenderModeNormal));
 	if (newFont == nullptr) {
 		return false;
 	}

--- a/engines/zvision/zvision.cpp
+++ b/engines/zvision/zvision.cpp
@@ -285,7 +285,8 @@ Common::Error ZVision::run() {
 
 			if (!Common::File::exists(fontName) && !_searchManager->hasFile(fontName) &&
 				!Common::File::exists(liberationFontName) && !_searchManager->hasFile(liberationFontName) &&
-				!Common::File::exists(freeFontName) && !_searchManager->hasFile(freeFontName)) {
+				!Common::File::exists(freeFontName) && !_searchManager->hasFile(freeFontName) &&
+				!Common::File::exists("fonts.dat") && !_searchManager->hasFile("fonts.dat")) {
 				foundAllFonts = false;
 				break;
 			}

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -31,11 +31,13 @@
 #include "graphics/font.h"
 #include "graphics/surface.h"
 
+#include "common/file.h"
 #include "common/singleton.h"
 #include "common/stream.h"
 #include "common/memstream.h"
 #include "common/hashmap.h"
 #include "common/ptr.h"
+#include "common/unzip.h"
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -663,6 +665,23 @@ Font *loadTTFFont(Common::SeekableReadStream &stream, int size, TTFSizeMode size
 		return 0;
 	}
 
+	return font;
+}
+
+Font *loadTTFFontFromArchive(const Common::String &filename, int size, TTFSizeMode sizeMode, uint dpi, TTFRenderMode renderMode, const uint32 *mapping) {
+	Common::Archive *archive;
+	if (!Common::File::exists("fonts.dat") || (archive = Common::makeZipArchive("fonts.dat")) == nullptr) {
+		return 0;
+	}
+
+	Common::File f;
+	if (!f.open(filename, *archive)) {
+		return 0;
+	}
+
+	Font *font = loadTTFFont(f, size, sizeMode, dpi, renderMode, mapping);
+
+	delete archive;
 	return font;
 }
 

--- a/graphics/fonts/ttf.h
+++ b/graphics/fonts/ttf.h
@@ -95,6 +95,25 @@ enum TTFSizeMode {
  */
 Font *loadTTFFont(Common::SeekableReadStream &stream, int size, TTFSizeMode sizeMode = kTTFSizeModeCharacter, uint dpi = 0, TTFRenderMode renderMode = kTTFRenderModeLight, const uint32 *mapping = 0);
 
+/**
+ * Loads a TTF font file from the common fonts archive.
+ *
+ * @param filename   The name of the font to load.
+ * @param size       The point size to load.
+ * @param sizeMode   The point size definition used for the size parameter.
+ * @param dpi        The dpi to use for size calculations, by default 72dpi
+ *                   are used.
+ * @param renderMode FreeType2 mode used to render glyphs. @see TTFRenderMode
+ * @param mapping    A mapping from code points 0-255 into UTF-32 code points.
+ *                   This can be used to support various 8bit character sets.
+ *                   In case the msb of the UTF-32 code point is set the font
+ *                   loading fails in case no glyph for it is found. When this
+ *                   is non-null only characters given in the mapping are
+ *                   supported.
+ * @return 0 in case loading fails, otherwise a pointer to the Font object.
+ */
+Font *loadTTFFontFromArchive(const Common::String &filename, int size, TTFSizeMode sizeMode = kTTFSizeModeCharacter, uint dpi = 0, TTFRenderMode renderMode = kTTFRenderModeLight, const uint32 *mapping = 0);
+
 void shutdownTTF();
 
 } // End of namespace Graphics

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -1466,6 +1466,11 @@ DrawData ThemeEngine::parseDrawDataId(const Common::String &name) const {
 
 const Graphics::Font *ThemeEngine::loadScalableFont(const Common::String &filename, const Common::String &charset, const int pointsize, Common::String &name) {
 #ifdef USE_FREETYPE2
+#ifdef USE_TRANSLATION
+	const uint32 *mapping = TransMan.getCharsetMapping();
+#else
+	const uint32 *mapping = 0;
+#endif
 	name = Common::String::format("%s-%s@%d", filename.c_str(), charset.c_str(), pointsize);
 
 	// Try already loaded fonts.
@@ -1479,19 +1484,18 @@ const Graphics::Font *ThemeEngine::loadScalableFont(const Common::String &filena
 	for (Common::ArchiveMemberList::const_iterator i = members.begin(), end = members.end(); i != end; ++i) {
 		Common::SeekableReadStream *stream = (*i)->createReadStream();
 		if (stream) {
-			font = Graphics::loadTTFFont(*stream, pointsize, Graphics::kTTFSizeModeCharacter, 0, Graphics::kTTFRenderModeLight,
-#ifdef USE_TRANSLATION
-			                             TransMan.getCharsetMapping()
-#else
-			                             0
-#endif
-			                             );
+			font = Graphics::loadTTFFont(*stream, pointsize, Graphics::kTTFSizeModeCharacter, 0, Graphics::kTTFRenderModeLight, mapping);
 			delete stream;
 
 			if (font)
 				return font;
 		}
 	}
+
+	// Try loading the font from the common fonts archive.
+	font = Graphics::loadTTFFontFromArchive(filename, pointsize, Graphics::kTTFSizeModeCharacter, 0, Graphics::kTTFRenderModeLight, mapping);
+	if (font)
+		return font;
 #endif
 	return 0;
 }


### PR DESCRIPTION
This PR implements common support for loading fonts from the fonts.dat datafile introduced in PR #1393. Currently it's used by the Wintermute and ZVision engines, as well as by the GUI.

The PR does not include fonts.dat in order to avoid conflicting with PR #1393, however, it will need to contain `FreeMonoBold.ttf`, `FreeSans.ttf` and `FreeSansBold.ttf` from `gui/themes/fonts`.
