### PR TITLE
SHERLOCK: Speed up Blackwood cutscene in The Case of the Serrated Sca…

### DIFF
--- a/engines/sherlock/scalpel/scalpel.cpp
+++ b/engines/sherlock/scalpel/scalpel.cpp
@@ -1035,8 +1035,8 @@ void ScalpelEngine::startScene() {
 			// Blackwood's capture
 			_res->addToCache("final2.vda", "epilogue.lib");
 			_res->addToCache("final2.vdx", "epilogue.lib");
-			_animation->play("final1", false, 1, 3, true, 4);
-			_animation->play("final2", false, 1, 0, false, 4);
+			_animation->play("final1", false, 1, 3, true, 2);
+			_animation->play("final2", false, 1, 0, false, 2);
 			break;
 
 		case RESCUE_ANNA:


### PR DESCRIPTION
When capturing Blackwood in The Case of the Serrated Scalpel, the whole scene seems to be running in slow motion. This simply doubles the speed for it. It may still be a tad slow, but at least it fits the music much better I think.

I'm attaching a savegame (gzipped to get around GitHub's filter on unsupported file types) near the cutscene. If I didn't mess up the files, all you need to do to trigger the cutscene is to use the hammer on the door.

[scalpel.004.gz](https://github.com/scummvm/scummvm/files/2682556/scalpel.004.gz)
