### PR TITLE
SHERLOCK: Fix computer aim in Serrated Scalpel's darts game

### DIFF
--- a/engines/sherlock/scalpel/scalpel_darts.cpp
+++ b/engines/sherlock/scalpel/scalpel_darts.cpp
@@ -470,8 +470,8 @@ Common::Point Darts::getComputerDartDest(int playerNum) {
 			--aim;
 		} while (!done);
 
-		target.x = 75 + ((target.x - 75) * 20 / 27);
-		target.y = 75 + ((target.y - 75) * 2 / 3);
+		target.x = 75 + ((pt.x - 75) * 20 / 27);
+		target.y = 75 + ((pt.y - 75) * 2 / 3);
 	}
 
 	// Pick a level of accuracy. The higher the level, the more accurate their throw will be


### PR DESCRIPTION
The computer opponent always aims for the bullseye as long as he needs more than 50 points. After that, he's supposed to aim for the closest score to what he needs to win. But this coordinate was never used, and the computer player would always aim at the same spot outside of the dart board. This, of course, made it practically impossible for it to beat you. This commit fixes that.

I thought at first that this fix wasn't quite right, because the computer won't always hit the score he aims for even if you remove the random inaccuracy from its aim. But I think it still hits near the intended target, so maybe this is good enough?