### PR TITLE
WIN32: Fix ARRAYSIZE redefinition warnings

### DIFF
--- a/backends/audiocd/win32/win32-audiocd.cpp
+++ b/backends/audiocd/win32/win32-audiocd.cpp
@@ -46,7 +46,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#undef ARRAYSIZE // winnt.h defines ARRAYSIZE, but we want our own one...
 
 #include "backends/audiocd/win32/win32-audiocd.h"
 

--- a/backends/cloud/box/boxstorage.cpp
+++ b/backends/cloud/box/boxstorage.cpp
@@ -22,6 +22,7 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/cloud/box/boxstorage.h"
 #include "backends/cloud/box/boxlistdirectorybyidrequest.h"
 #include "backends/cloud/box/boxtokenrefresher.h"
@@ -33,7 +34,6 @@
 #include "common/config-manager.h"
 #include "common/debug.h"
 #include "common/json.h"
-#include <curl/curl.h>
 
 #ifdef ENABLE_RELEASE
 #include "dists/clouds/cloud_keys.h"

--- a/backends/cloud/box/boxtokenrefresher.cpp
+++ b/backends/cloud/box/boxtokenrefresher.cpp
@@ -22,12 +22,12 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/cloud/box/boxtokenrefresher.h"
 #include "backends/cloud/box/boxstorage.h"
 #include "backends/networking/curl/networkreadstream.h"
 #include "common/debug.h"
 #include "common/json.h"
-#include <curl/curl.h>
 
 namespace Cloud {
 namespace Box {

--- a/backends/cloud/dropbox/dropboxstorage.cpp
+++ b/backends/cloud/dropbox/dropboxstorage.cpp
@@ -22,6 +22,7 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/cloud/dropbox/dropboxstorage.h"
 #include "backends/cloud/dropbox/dropboxcreatedirectoryrequest.h"
 #include "backends/cloud/dropbox/dropboxinforequest.h"
@@ -33,7 +34,6 @@
 #include "common/config-manager.h"
 #include "common/debug.h"
 #include "common/json.h"
-#include <curl/curl.h>
 
 #ifdef ENABLE_RELEASE
 #include "dists/clouds/cloud_keys.h"

--- a/backends/cloud/googledrive/googledrivestorage.cpp
+++ b/backends/cloud/googledrive/googledrivestorage.cpp
@@ -22,6 +22,7 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/cloud/googledrive/googledrivestorage.h"
 #include "backends/cloud/cloudmanager.h"
 #include "backends/cloud/googledrive/googledrivetokenrefresher.h"
@@ -34,7 +35,6 @@
 #include "common/debug.h"
 #include "common/json.h"
 #include "common/debug.h"
-#include <curl/curl.h>
 
 #ifdef ENABLE_RELEASE
 #include "dists/clouds/cloud_keys.h"

--- a/backends/cloud/googledrive/googledrivetokenrefresher.cpp
+++ b/backends/cloud/googledrive/googledrivetokenrefresher.cpp
@@ -22,12 +22,12 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/cloud/googledrive/googledrivetokenrefresher.h"
 #include "backends/cloud/googledrive/googledrivestorage.h"
 #include "backends/networking/curl/networkreadstream.h"
 #include "common/debug.h"
 #include "common/json.h"
-#include <curl/curl.h>
 
 namespace Cloud {
 namespace GoogleDrive {

--- a/backends/cloud/onedrive/onedrivestorage.cpp
+++ b/backends/cloud/onedrive/onedrivestorage.cpp
@@ -22,6 +22,7 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/cloud/onedrive/onedrivestorage.h"
 #include "backends/cloud/cloudmanager.h"
 #include "backends/cloud/onedrive/onedrivecreatedirectoryrequest.h"
@@ -34,7 +35,6 @@
 #include "common/config-manager.h"
 #include "common/debug.h"
 #include "common/json.h"
-#include <curl/curl.h>
 
 #ifdef ENABLE_RELEASE
 #include "dists/clouds/cloud_keys.h"

--- a/backends/cloud/onedrive/onedrivetokenrefresher.cpp
+++ b/backends/cloud/onedrive/onedrivetokenrefresher.cpp
@@ -22,12 +22,12 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/cloud/onedrive/onedrivetokenrefresher.h"
 #include "backends/cloud/onedrive/onedrivestorage.h"
 #include "backends/networking/curl/networkreadstream.h"
 #include "common/debug.h"
 #include "common/json.h"
-#include <curl/curl.h>
 
 namespace Cloud {
 namespace OneDrive {

--- a/backends/dialogs/win32/win32-dialogs.cpp
+++ b/backends/dialogs/win32/win32-dialogs.cpp
@@ -56,9 +56,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#if defined(ARRAYSIZE)
-#undef ARRAYSIZE
-#endif
 #endif
 
 #include <shlobj.h>

--- a/backends/fs/windows/windows-fs-factory.cpp
+++ b/backends/fs/windows/windows-fs-factory.cpp
@@ -25,8 +25,8 @@
 // Disable symbol overrides so that we can use system headers.
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
-#include "backends/fs/windows/windows-fs-factory.h"
 #include "backends/fs/windows/windows-fs.h"
+#include "backends/fs/windows/windows-fs-factory.h"
 
 AbstractFSNode *WindowsFilesystemFactory::makeRootFileNode() const {
 	return new WindowsFilesystemNode();

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -23,12 +23,13 @@
 #ifndef WINDOWS_FILESYSTEM_H
 #define WINDOWS_FILESYSTEM_H
 
-#include "backends/fs/abstract-fs.h"
-
 #include <windows.h>
 #ifdef _WIN32_WCE
 #undef GetCurrentDirectory
 #endif
+
+#include "backends/fs/abstract-fs.h"
+
 #include <io.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -25,12 +25,7 @@
 
 #include "backends/fs/abstract-fs.h"
 
-#if defined(ARRAYSIZE)
-#undef ARRAYSIZE
-#endif
 #include <windows.h>
-// winnt.h defines ARRAYSIZE, but we want our own one...
-#undef ARRAYSIZE
 #ifdef _WIN32_WCE
 #undef GetCurrentDirectory
 #endif

--- a/backends/midi/windows.cpp
+++ b/backends/midi/windows.cpp
@@ -29,8 +29,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-// winnt.h defines ARRAYSIZE, but we want our own one...
-#undef ARRAYSIZE
 
 #include "audio/musicplugin.h"
 #include "audio/mpu401.h"

--- a/backends/networking/curl/connectionmanager.cpp
+++ b/backends/networking/curl/connectionmanager.cpp
@@ -22,12 +22,12 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/networking/curl/connectionmanager.h"
 #include "backends/networking/curl/networkreadstream.h"
 #include "common/debug.h"
 #include "common/system.h"
 #include "common/timer.h"
-#include <curl/curl.h>
 
 namespace Common {
 

--- a/backends/networking/curl/curljsonrequest.cpp
+++ b/backends/networking/curl/curljsonrequest.cpp
@@ -22,12 +22,12 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/networking/curl/curljsonrequest.h"
 #include "backends/networking/curl/connectionmanager.h"
 #include "backends/networking/curl/networkreadstream.h"
 #include "common/debug.h"
 #include "common/json.h"
-#include <curl/curl.h>
 
 namespace Networking {
 

--- a/backends/networking/curl/curlrequest.cpp
+++ b/backends/networking/curl/curlrequest.cpp
@@ -22,11 +22,11 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/networking/curl/curlrequest.h"
 #include "backends/networking/curl/connectionmanager.h"
 #include "backends/networking/curl/networkreadstream.h"
 #include "common/textconsole.h"
-#include <curl/curl.h>
 
 namespace Networking {
 

--- a/backends/networking/curl/networkreadstream.cpp
+++ b/backends/networking/curl/networkreadstream.cpp
@@ -22,10 +22,10 @@
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#include <curl/curl.h>
 #include "backends/networking/curl/networkreadstream.h"
 #include "backends/networking/curl/connectionmanager.h"
 #include "base/version.h"
-#include <curl/curl.h>
 
 namespace Networking {
 

--- a/backends/platform/sdl/win32/win32-main.cpp
+++ b/backends/platform/sdl/win32/win32-main.cpp
@@ -33,7 +33,6 @@
 // "ARRAYSIZE" for example.
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#undef ARRAYSIZE // winnt.h defines ARRAYSIZE, but we want our own one...
 
 #include "backends/platform/sdl/win32/win32.h"
 #include "backends/plugins/sdl/sdl-provider.h"

--- a/backends/platform/sdl/win32/win32-window.cpp
+++ b/backends/platform/sdl/win32/win32-window.cpp
@@ -29,7 +29,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#undef ARRAYSIZE // winnt.h defines ARRAYSIZE, but we want our own one...
 
 void SdlWindow_Win32::setupIcon() {
 	HMODULE handle = GetModuleHandle(NULL);

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -27,7 +27,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#undef ARRAYSIZE // winnt.h defines ARRAYSIZE, but we want our own one...
 #include <shellapi.h>
 #if defined(__GNUC__) && defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
 // required for SHGFP_TYPE_CURRENT in shlobj.h

--- a/backends/saves/windows/windows-saves.cpp
+++ b/backends/saves/windows/windows-saves.cpp
@@ -22,12 +22,8 @@
 
 #if defined(WIN32) && !defined(_WIN32_WCE) && !defined(DISABLE_DEFAULT_SAVEFILEMANAGER)
 
-#if defined(ARRAYSIZE)
-#undef ARRAYSIZE
-#endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#undef ARRAYSIZE // winnt.h defines ARRAYSIZE, but we want our own one...
 #if defined(__GNUC__) && defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
  // required for SHGFP_TYPE_CURRENT in shlobj.h
 #define _WIN32_IE 0x500

--- a/backends/taskbar/win32/win32-taskbar.cpp
+++ b/backends/taskbar/win32/win32-taskbar.cpp
@@ -55,9 +55,6 @@
 	#define _WIN32_WINNT _WIN32_WINNT_WIN7
 
 	#include <windows.h>
-	#if defined(ARRAYSIZE)
-		#undef ARRAYSIZE
-	#endif
 #endif
 
 #include <shlobj.h>

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -117,11 +117,6 @@
 
 		#endif
 
-		#if defined(ARRAYSIZE)
-		// VS2005beta2 introduces new stuff in winnt.h
-		#undef ARRAYSIZE
-		#endif
-
 	#endif
 
 	#if defined(__QNXNTO__)

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -23,8 +23,6 @@
 #if defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-// winnt.h defines ARRAYSIZE, but we want our own one... - this is needed before including util.h
-#undef ARRAYSIZE
 #endif
 
 #define TRANSLATIONS_DAT_VER 3

--- a/common/util.h
+++ b/common/util.h
@@ -56,6 +56,10 @@ template<typename T> inline T CLIP(T v, T amin, T amax)
  */
 template<typename T> inline void SWAP(T &a, T &b) { T tmp = a; a = b; b = tmp; }
 
+#ifdef ARRAYSIZE
+#undef ARRAYSIZE
+#endif
+
 /**
  * Macro which determines the number of entries in a fixed size array.
  */

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -26,8 +26,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <direct.h>
-// winnt.h defines ARRAYSIZE, but we want our own one...
-#undef ARRAYSIZE
 #endif
 
 #include "engines/engine.h"


### PR DESCRIPTION
Windows headers define `ARRAYSIZE` as well as ScummVM, raining down `warning C4005: 'ARRAYSIZE': macro redefinition` everywhere.

Instead of trying to undef the Windows macro everytime it's included, I decided to undef it directly in `util.h` (same as other macros like `MIN` and `MAX`) before the macro is redefined. This works as long as `windows.h` is included before `util.h`, so I reordered includes where this wasn't the case.