### PR TITLE
MSVC: Update project generation

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -710,7 +710,7 @@ void displayHelp(const char *exe) {
 	        "                           The default is \"12\", thus \"Visual Studio 2013\"\n"
 	        " --build-events           Run custom build events as part of the build\n"
 	        "                          (default: false)\n"
-	        " --installer              Create NSIS installer after the build (implies --build-events)\n"
+	        " --installer              Create installer after the build (implies --build-events)\n"
 	        "                          (default: false)\n"
 	        " --tools                  Create project files for the devtools\n"
 	        "                          (ignores --build-events and --installer, as well as engine settings)\n"

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -245,7 +245,7 @@ struct BuildSetup {
 	bool devTools;         ///< Generate project files for the tools
 	bool tests;            ///< Generate project files for the tests
 	bool runBuildEvents;   ///< Run build events as part of the build (generate revision number and copy engine/theme data & needed files to the build folder
-	bool createInstaller;  ///< Create NSIS installer after the build
+	bool createInstaller;  ///< Create installer after the build
 	bool useSDL2;          ///< Whether to use SDL2 or not.
 
 	BuildSetup() {

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -405,6 +405,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	properties << "\t\t</Link>\n"
 	              "\t\t<ResourceCompile>\n"
 	              "\t\t\t<AdditionalIncludeDirectories>" << prefix << ";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
+	              "\t\t\t<PreprocessorDefinitions>" << definesList << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
 	              "\t\t</ResourceCompile>\n"
 	              "\t</ItemDefinitionGroup>\n"
 	              "</Project>\n";

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -190,8 +190,8 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 		project << "\t</ItemGroup>\n";
 	}
 
-	// Visual Studio 2015 automatically imports natvis files that are part of the project
-	if (name == PROJECT_NAME && _version == 14) {
+	// Visual Studio 2015 and up automatically import natvis files that are part of the project
+	if (name == PROJECT_NAME && _version >= 14) {
 		project << "\t<ItemGroup>\n";
 		project << "\t\t<None Include=\"" << setup.srcDir << "/devtools/create_project/scripts/scummvm.natvis\" />\n";
 		project << "\t</ItemGroup>\n";

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -393,6 +393,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	properties << "\t\t\t<WarningLevel>Level4</WarningLevel>\n"
 	              "\t\t\t<TreatWarningAsError>false</TreatWarningAsError>\n"
 	              "\t\t\t<CompileAs>Default</CompileAs>\n"
+	              "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>\n"
 	              "\t\t</ClCompile>\n"
 	              "\t\t<Link>\n"
 	              "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n"
@@ -450,7 +451,6 @@ void MSBuildProvider::createBuildProp(const BuildSetup &setup, bool isRelease, b
 	} else {
 		properties << "\t\t\t<Optimization>Disabled</Optimization>\n"
 		              "\t\t\t<PreprocessorDefinitions>WIN32;" << (configuration == "LLVM" ? "_CRT_SECURE_NO_WARNINGS;" : "") << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
-		              "\t\t\t<MinimalRebuild>true</MinimalRebuild>\n"
 		              "\t\t\t<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>\n"
 		              "\t\t\t<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>\n"
 		              "\t\t\t<FunctionLevelLinking>true</FunctionLevelLinking>\n"

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -380,7 +380,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	              "\t\t<ClCompile>\n"
 	              "\t\t\t<DisableLanguageExtensions>true</DisableLanguageExtensions>\n"
 	              "\t\t\t<DisableSpecificWarnings>" << warnings << ";%(DisableSpecificWarnings)</DisableSpecificWarnings>\n"
-	              "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";" << prefix << "\\engines;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "$(TargetDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
+	              "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";" << prefix << "\\engines;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
 	              "\t\t\t<PreprocessorDefinitions>" << definesList << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
 	              "\t\t\t<ExceptionHandling>" << ((setup.devTools || setup.tests) ? "Sync" : "") << "</ExceptionHandling>\n";
 
@@ -404,7 +404,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 
 	properties << "\t\t</Link>\n"
 	              "\t\t<ResourceCompile>\n"
-	              "\t\t\t<AdditionalIncludeDirectories>" << prefix << ";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
+	              "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
 	              "\t\t\t<PreprocessorDefinitions>" << definesList << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
 	              "\t\t</ResourceCompile>\n"
 	              "\t</ItemDefinitionGroup>\n"

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -339,7 +339,7 @@ void MSBuildProvider::outputProjectSettings(std::ofstream &project, const std::s
 			// Copy data files to the build folder
 			project << "\t\t<PostBuildEvent>\n"
 					   "\t\t\t<Message>Copy data files to the build folder</Message>\n"
-					   "\t\t\t<Command>" << getPostBuildEvent(isWin32, setup.createInstaller) << "</Command>\n"
+					   "\t\t\t<Command>" << getPostBuildEvent(isWin32, setup) << "</Command>\n"
 					   "\t\t</PostBuildEvent>\n";
 		} else if (setup.tests) {
 			project << "\t\t<PreBuildEvent>\n"

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -185,7 +185,7 @@ std::string MSVCProvider::getTestPreBuildEvent(const BuildSetup &setup) const {
 	for (StringList::const_iterator it = setup.testDirs.begin(); it != setup.testDirs.end(); ++it)
 		target += " $(SolutionDir)" + *it + "*.h";
 
-	return "&quot;$(SolutionDir)../../test/cxxtest/cxxtestgen.py&quot; --runner=ParenPrinter --no-std --no-eh -o $(SolutionDir)test_runner.cpp" + target;
+	return "&quot;$(SolutionDir)../../test/cxxtest/cxxtestgen.py&quot; --runner=ParenPrinter --no-std --no-eh -o &quot;$(SolutionDir)test_runner.cpp&quot;" + target;
 }
 
 std::string MSVCProvider::getPostBuildEvent(bool isWin32, bool createInstaller) const {
@@ -198,7 +198,7 @@ std::string MSVCProvider::getPostBuildEvent(bool isWin32, bool createInstaller) 
 
 	cmdLine += (isWin32) ? "x86" : "x64";
 
-	cmdLine += " %" LIBS_DEFINE "% ";
+	cmdLine += " &quot;%" LIBS_DEFINE "%&quot; ";
 
 	// Specify if installer needs to be built or not
 	cmdLine += (createInstaller ? "1" : "0");

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -188,7 +188,7 @@ std::string MSVCProvider::getTestPreBuildEvent(const BuildSetup &setup) const {
 	return "&quot;$(SolutionDir)../../test/cxxtest/cxxtestgen.py&quot; --runner=ParenPrinter --no-std --no-eh -o &quot;$(SolutionDir)test_runner.cpp&quot;" + target;
 }
 
-std::string MSVCProvider::getPostBuildEvent(bool isWin32, bool createInstaller) const {
+std::string MSVCProvider::getPostBuildEvent(bool isWin32, const BuildSetup &setup) const {
 	std::string cmdLine = "";
 
 	cmdLine = "@echo off\n"
@@ -196,12 +196,14 @@ std::string MSVCProvider::getPostBuildEvent(bool isWin32, bool createInstaller) 
 	          "echo.\n"
 	          "@call &quot;$(SolutionDir)../../devtools/create_project/scripts/postbuild.cmd&quot; &quot;$(SolutionDir)/../..&quot; &quot;$(OutDir)&quot; ";
 
-	cmdLine += (isWin32) ? "x86" : "x64";
+	cmdLine += (setup.useSDL2) ? "SDL2" : "SDL";
 
-	cmdLine += " &quot;%" LIBS_DEFINE "%&quot; ";
+	cmdLine += " &quot;%" LIBS_DEFINE "%/lib/";
+	cmdLine += (isWin32) ? "x86" : "x64";
+	cmdLine += "/$(Configuration)&quot; ";
 
 	// Specify if installer needs to be built or not
-	cmdLine += (createInstaller ? "1" : "0");
+	cmdLine += (setup.createInstaller ? "1" : "0");
 
 	cmdLine += "\n"
 	           "EXIT /B0";

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -172,7 +172,7 @@ std::string MSVCProvider::getPreBuildEvent() const {
 	cmdLine = "@echo off\n"
 	          "echo Executing Pre-Build script...\n"
 	          "echo.\n"
-	          "@call &quot;$(SolutionDir)../../devtools/create_project/scripts/prebuild.cmd&quot; &quot;$(SolutionDir)/../..&quot;  &quot;$(TargetDir)&quot;\n"
+	          "@call &quot;$(SolutionDir)../../devtools/create_project/scripts/prebuild.cmd&quot; &quot;$(SolutionDir)/../..&quot; &quot;$(SolutionDir)&quot;\n"
 	          "EXIT /B0";
 
 	return cmdLine;

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -105,7 +105,7 @@ protected:
 	 * Get the command line for copying data files to the build directory.
 	 *
 	 * @param	isWin32		   	Bitness of property file.
-	 * @param	createInstaller	true to NSIS create installer
+	 * @param	createInstaller	true to create installer
 	 *
 	 * @return	The post build event.
 	 */

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -104,12 +104,12 @@ protected:
 	/**
 	 * Get the command line for copying data files to the build directory.
 	 *
-	 * @param	isWin32		   	Bitness of property file.
-	 * @param	createInstaller	true to create installer
+	 * @param	isWin32	Bitness of property file.
+	 * @param	setup	Description of the desired build setup.
 	 *
 	 * @return	The post build event.
 	 */
-	std::string getPostBuildEvent(bool isWin32, bool createInstaller) const;
+	std::string getPostBuildEvent(bool isWin32, const BuildSetup &setup) const;
 };
 
 } // End of CreateProjectTool namespace

--- a/devtools/create_project/msvc10/create_project.vcxproj
+++ b/devtools/create_project/msvc10/create_project.vcxproj
@@ -50,7 +50,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
-      <DisableSpecificWarnings>4003;4512;4127;4100</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4003;4512;4127;4100;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/devtools/create_project/msvc11/create_project.vcxproj
+++ b/devtools/create_project/msvc11/create_project.vcxproj
@@ -53,7 +53,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
-      <DisableSpecificWarnings>4003;4512;4127;4100</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4003;4512;4127;4100;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/devtools/create_project/msvc12/create_project.vcxproj
+++ b/devtools/create_project/msvc12/create_project.vcxproj
@@ -52,7 +52,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
-      <DisableSpecificWarnings>4003;4512;4127;4100</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4003;4512;4127;4100;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/devtools/create_project/msvc14/create_project.vcxproj
+++ b/devtools/create_project/msvc14/create_project.vcxproj
@@ -76,7 +76,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
-      <DisableSpecificWarnings>4003;4512;4127;4100</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4003;4512;4127;4100;4244</DisableSpecificWarnings>
       <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>

--- a/devtools/create_project/msvc15/create_project.vcxproj
+++ b/devtools/create_project/msvc15/create_project.vcxproj
@@ -70,13 +70,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
-      <DisableSpecificWarnings>4003;4512;4127;4100</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4003;4512;4127;4100;4244</DisableSpecificWarnings>
       <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>

--- a/devtools/create_project/msvc9/create_project.vcproj
+++ b/devtools/create_project/msvc9/create_project.vcproj
@@ -45,7 +45,7 @@
 				RuntimeLibrary="3"
 				WarningLevel="4"
 				DebugInformationFormat="4"
-				DisableSpecificWarnings="4003;4512;4127;4100"
+				DisableSpecificWarnings="4003;4512;4127;4100;4244"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"

--- a/devtools/create_project/scripts/postbuild.cmd
+++ b/devtools/create_project/scripts/postbuild.cmd
@@ -4,27 +4,27 @@ REM ---------------------------------------------------------------
 REM -- Post-Build Script
 REM ---------------------------------------------------------------
 REM
-REM Copy engine data, themes, translation and required dlls to the
+REM Copy engine data and required dlls to the
 REM output folder and optionally create an installer
 REM
 REM Expected parameters
 REM    Root folder
 REM    Output folder
-REM    Architecture
+REM    SDL version
 REM    Libs folder
 REM    Installer ("1" to build, "0" to skip)
 
 if "%~1"=="" goto error_root
 if "%~2"=="" goto error_output
-if "%~3"=="" goto error_arch
+if "%~3"=="" goto error_sdl
 if "%~4"=="" goto error_libs
 if "%~5"=="" goto error_installer
 
 echo Copying data files
 echo.
 
-xcopy /F /Y "%~4/lib/%~3/SDL.dll"                          "%~2" 1>NUL 2>&1
-xcopy /F /Y "%~4/lib/%~3/freetype6.dll"                    "%~2" 1>NUL 2>&1
+xcopy /F /Y "%~4/%~3.dll"                                  "%~2" 1>NUL 2>&1
+xcopy /F /Y "%~4/WinSparkle.dll"                           "%~2" 1>NUL 2>&1
 xcopy /F /Y "%~1/backends/vkeybd/packs/vkeybd_default.zip" "%~2" 1>NUL 2>&1
 xcopy /F /Y "%~1/backends/vkeybd/packs/vkeybd_small.zip"   "%~2" 1>NUL 2>&1
 
@@ -33,7 +33,7 @@ if "%~5"=="0" goto done
 
 echo Running installer script
 echo.
-@call cscript "%~1/devtools/create_project/scripts/installer.vbs" "%~1" "%~2" "%~3" 1>NUL
+@call cscript "%~1/devtools/create_project/scripts/installer.vbs" "%~1" "%~2" 1>NUL
 if not %errorlevel% == 0 goto error_script
 goto done
 
@@ -45,8 +45,8 @@ goto done
 echo Invalid output folder (%~2)!
 goto done
 
-:error_arch
-echo Invalid arch parameter (was: %~3, allowed: x86, x64)!
+:error_sdl
+echo Invalid SDL parameter (was: %~3, allowed: SDL, SDL2)!
 goto done
 
 :error_libs

--- a/devtools/create_project/scripts/postbuild.cmd
+++ b/devtools/create_project/scripts/postbuild.cmd
@@ -27,7 +27,6 @@ xcopy /F /Y "%~4/lib/%~3/SDL.dll"                          "%~2" 1>NUL 2>&1
 xcopy /F /Y "%~4/lib/%~3/freetype6.dll"                    "%~2" 1>NUL 2>&1
 xcopy /F /Y "%~1/backends/vkeybd/packs/vkeybd_default.zip" "%~2" 1>NUL 2>&1
 xcopy /F /Y "%~1/backends/vkeybd/packs/vkeybd_small.zip"   "%~2" 1>NUL 2>&1
-xcopy /F /Y "%~1/gui/themes/translations.dat"              "%~2" 1>NUL 2>&1
 
 
 if "%~5"=="0" goto done

--- a/devtools/create_project/scripts/scummvm.natvis
+++ b/devtools/create_project/scripts/scummvm.natvis
@@ -20,6 +20,9 @@
       </Synthetic>
       <Item Name="[channels]" Condition="format.bytesPerPixel==1">1</Item>
       <Item Name="[channels]" Condition="format.bytesPerPixel==2">2</Item>
+      <Synthetic Name="[channels]" Condition="format.bytesPerPixel==3">
+        <DisplayString>RGB</DisplayString>
+      </Synthetic>
       <Synthetic Name="[channels]" Condition="format.bytesPerPixel==4">
         <DisplayString>RGBA</DisplayString>
       </Synthetic>
@@ -31,7 +34,7 @@
   </Type>
 
   <Type Name="Common::Array&lt;*&gt;">
-    <DisplayString>{{size = {_size}}}</DisplayString>
+    <DisplayString>{{ size={_size} }}</DisplayString>
     <Expand>
       <Item Name="[size]">_size</Item>
       <Item Name="[capacity]">_capacity</Item>
@@ -43,7 +46,7 @@
   </Type>
 
   <Type Name="Common::HashMap&lt;*,*,*,*&gt;">
-    <DisplayString>{{ size = {_size} }}</DisplayString>
+    <DisplayString>{{ size={_size} }}</DisplayString>
     <Expand>
       <Item Name="[size]">_size</Item>
       <Item Name="[capacity]">_mask + 1</Item>
@@ -81,8 +84,8 @@
   </Type>
 
   <Type Name="Common::String">
-    <DisplayString>{_str,[_size]}</DisplayString>
-    <StringView>_str,[_size]</StringView>
+    <DisplayString>{_str,na}</DisplayString>
+    <StringView>_str,na</StringView>
     <Expand>
       <Item Name="[size]">_size</Item>
       <Item Condition="_str != _storage" Name="[capacity]">_extern._capacity</Item>

--- a/devtools/create_project/scripts/scummvm.natvis
+++ b/devtools/create_project/scripts/scummvm.natvis
@@ -4,12 +4,6 @@
     Debug visualizers for a few common ScummVM types for Visual Studio 2012 and up.
 
     To use, copy this file into Documents\Visual Studio 20xx\Visualizers.
-
-    Known issues:
-
-    * Lists appear to be infinite (the same elements repeat over and over again).
-      Unfortunately, Lists don't store length information, and it's not possible to
-      detect whether a Node is the last one by the Node itself.
 -->
 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
@@ -74,11 +68,15 @@
     <DisplayString Condition="&amp;_anchor == _anchor._next">{{ empty }}</DisplayString>
     <DisplayString Condition="&amp;_anchor != _anchor._next">{{ non-empty }}</DisplayString>
     <Expand>
-      <LinkedListItems Condition="&amp;_anchor != _anchor._next">
-        <HeadPointer>_anchor._next</HeadPointer>
-        <NextPointer>_next</NextPointer>
-        <ValueNode>((Common::ListInternal::Node&lt;$T1&gt;*)this)->_data</ValueNode>
-      </LinkedListItems>
+      <CustomListItems Condition="&amp;_anchor != _anchor._next">
+        <Variable Name="head" InitialValue="&amp;_anchor"/>
+        <Variable Name="iter" InitialValue="_anchor._next"/>
+        <Loop>
+          <Break Condition="iter == head"/>
+          <Item>((Common::ListInternal::Node&lt;$T1&gt;*)iter)->_data</Item>
+          <Exec>iter = iter->_next</Exec>
+        </Loop>
+      </CustomListItems>
     </Expand>
   </Type>
 

--- a/devtools/create_project/scripts/scummvm.natvis
+++ b/devtools/create_project/scripts/scummvm.natvis
@@ -67,6 +67,13 @@
     <DisplayString>{_value}</DisplayString>
   </Type>
 
+  <Type Name="Common::HashMap&lt;*,*,*,*&gt;::IteratorImpl&lt;*&gt;">
+    <DisplayString>{_hashmap->_storage[_idx],na}</DisplayString>
+    <Expand>
+      <Item Name="[ptr]">_hashmap->_storage[_idx]</Item>
+    </Expand>
+  </Type>
+
   <Type Name="Common::List&lt;*&gt;">
     <DisplayString Condition="&amp;_anchor == _anchor._next">{{ empty }}</DisplayString>
     <DisplayString Condition="&amp;_anchor != _anchor._next">{{ non-empty }}</DisplayString>
@@ -83,6 +90,18 @@
     </Expand>
   </Type>
 
+  <Type Name="Common::ListInternal::Node&lt;*&gt;">
+    <DisplayString>{_data}</DisplayString>
+  </Type>
+
+  <Type Name="Common::ListInternal::Iterator&lt;*&gt;">
+    <AlternativeType Name="Common::ListInternal::ConstIterator&lt;*&gt;" />
+    <DisplayString>{((Common::ListInternal::Node&lt;$T1&gt;*)_node)->_data}</DisplayString>
+    <Expand>
+      <Item Name="[ptr]">((Common::ListInternal::Node&lt;$T1&gt;*)_node)->_data</Item>
+    </Expand>
+  </Type>
+
   <Type Name="Common::String">
     <DisplayString>{_str,na}</DisplayString>
     <StringView>_str,na</StringView>
@@ -94,6 +113,15 @@
         <Size>_size</Size>
         <ValuePointer>_str</ValuePointer>
       </ArrayItems>
+    </Expand>
+  </Type>
+
+  <Type Name="Common::SharedPtr&lt;*&gt;">
+    <DisplayString Condition="_pointer == 0">nullptr</DisplayString>
+    <DisplayString Condition="_pointer != 0">{*_pointer}</DisplayString>
+    <Expand>
+      <Item Condition="_pointer != 0" Name="[ptr]">_pointer</Item>
+      <Item Condition="_refCount != 0" Name="[refCount]">*_refCount</Item>
     </Expand>
   </Type>
 </AutoVisualizer>

--- a/devtools/create_project/scripts/scummvm.natvis
+++ b/devtools/create_project/scripts/scummvm.natvis
@@ -10,8 +10,6 @@
     * Lists appear to be infinite (the same elements repeat over and over again).
       Unfortunately, Lists don't store length information, and it's not possible to
       detect whether a Node is the last one by the Node itself.
-
-    * In HashMaps, missing and dummy nodes are shown along with the useful ones.
 -->
 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
@@ -56,11 +54,20 @@
       <Item Name="[size]">_size</Item>
       <Item Name="[capacity]">_mask + 1</Item>
       <Item Name="[deleted]">_deleted</Item>
-      <IndexListItems>
-        <Size>_mask + 1</Size>
-        <ValueNode Condition="_storage[$i] &amp;&amp; _storage[$i] != (Common::HashMap&lt;$T1,$T2,$T3,$T4&gt;::Node *)1">*_storage[$i]</ValueNode>
-      </IndexListItems>
+      <CustomListItems MaxItemsPerView="5000" ExcludeView="Test">
+        <Variable Name="ctr" InitialValue="0" />
+        <Size>_size</Size>
+        <Loop>
+          <Break Condition="ctr &gt; _mask" />
+          <Item Condition="_storage[ctr] &gt; 1" Name="[{_storage[ctr]->_key}]">*_storage[ctr],view(MapHelper)</Item>
+          <Exec>ctr++</Exec>
+        </Loop>
+      </CustomListItems>
     </Expand>
+  </Type>
+
+  <Type Name="Common::HashMap&lt;*,*,*,*&gt;::Node" IncludeView="MapHelper">
+    <DisplayString>{_value}</DisplayString>
   </Type>
 
   <Type Name="Common::List&lt;*&gt;">

--- a/devtools/create_project/scripts/scummvm.natvis
+++ b/devtools/create_project/scripts/scummvm.natvis
@@ -108,7 +108,21 @@
     <Expand>
       <Item Name="[size]">_size</Item>
       <Item Condition="_str != _storage" Name="[capacity]">_extern._capacity</Item>
-      <Item Condition="_str != _storage" Name="[refCount]">*_extern._refCount</Item>
+      <Item Condition="_str != _storage &amp;&amp; _extern._refCount != 0" Name="[refCount]">*_extern._refCount</Item>
+      <ArrayItems>
+        <Size>_size</Size>
+        <ValuePointer>_str</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <Type Name="Common::U32String">
+    <DisplayString>{_str,s32}</DisplayString>
+    <StringView>_str,s32</StringView>
+    <Expand>
+      <Item Name="[size]">_size</Item>
+      <Item Condition="_str != _storage" Name="[capacity]">_extern._capacity</Item>
+      <Item Condition="_str != _storage &amp;&amp; _extern._refCount != 0" Name="[refCount]">*_extern._refCount</Item>
       <ArrayItems>
         <Size>_size</Size>
         <ValuePointer>_str</ValuePointer>

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -171,7 +171,7 @@ void VisualStudioProvider::outputBuildEvents(std::ostream &project, const BuildS
 		           "\t\t\t\tCommandLine=\"" << getPreBuildEvent() << "\"\n"
 		           "\t\t\t/>\n"
 		           "\t\t\t<Tool\tName=\"VCPostBuildEventTool\"\n"
-		           "\t\t\t\tCommandLine=\"" << getPostBuildEvent(isWin32, setup.createInstaller) << "\"\n"
+		           "\t\t\t\tCommandLine=\"" << getPostBuildEvent(isWin32, setup) << "\"\n"
 		           "\t\t\t/>\n";
 	}
 

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -259,6 +259,7 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 	              "\t<Tool\n"
 	              "\t\tName=\"VCResourceCompilerTool\"\n"
 	              "\t\tAdditionalIncludeDirectories=\"" << prefix << "\"\n"
+	              "\t\tPreprocessorDefinitions=\"" << definesList << "\"\n"
 	              "\t/>\n"
 	              "</VisualStudioPropertySheet>\n";
 

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -228,7 +228,7 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 	              "\t\tName=\"VCCLCompilerTool\"\n"
 	              "\t\tDisableLanguageExtensions=\"" << (setup.devTools ? "false" : "true") << "\"\n"
 	              "\t\tDisableSpecificWarnings=\"" << warnings << "\"\n"
-	              "\t\tAdditionalIncludeDirectories=\".\\;" << prefix << ";" << prefix << "\\engines;$(" << LIBS_DEFINE << ")\\include;$(" << LIBS_DEFINE << ")\\include\\SDL;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "$(TargetDir)\"\n"
+	              "\t\tAdditionalIncludeDirectories=\".\\;" << prefix << ";" << prefix << "\\engines;$(" << LIBS_DEFINE << ")\\include;$(" << LIBS_DEFINE << ")\\include\\SDL;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "\"\n"
 	              "\t\tPreprocessorDefinitions=\"" << definesList << "\"\n"
 	              "\t\tExceptionHandling=\"" << ((setup.devTools || setup.tests || _version == 14) ? "1" : "0") << "\"\n";
 
@@ -258,7 +258,7 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 	              "\t/>\n"
 	              "\t<Tool\n"
 	              "\t\tName=\"VCResourceCompilerTool\"\n"
-	              "\t\tAdditionalIncludeDirectories=\"" << prefix << "\"\n"
+	              "\t\tAdditionalIncludeDirectories=\".\\;" << prefix << "\"\n"
 	              "\t\tPreprocessorDefinitions=\"" << definesList << "\"\n"
 	              "\t/>\n"
 	              "</VisualStudioPropertySheet>\n";

--- a/ports.mk
+++ b/ports.mk
@@ -468,6 +468,10 @@ endif
 	@cd $(srcdir)/dists/msvc11 && ../../devtools/create_project/create_project ../.. --msvc --msvc-version 11 >/dev/null && git add -f engines/plugins_table.h *.sln *.vcxproj *.vcxproj.filters *.props
 	@echo Creating MSVC12 project files...
 	@cd $(srcdir)/dists/msvc12 && ../../devtools/create_project/create_project ../.. --msvc --msvc-version 12 >/dev/null && git add -f engines/plugins_table.h *.sln *.vcxproj *.vcxproj.filters *.props
+	@echo Creating MSVC14 project files...
+	@cd $(srcdir)/dists/msvc14 && ../../devtools/create_project/create_project ../.. --msvc --msvc-version 14 >/dev/null && git add -f engines/plugins_table.h *.sln *.vcxproj *.vcxproj.filters *.props
+	@echo Creating MSVC15 project files...
+	@cd $(srcdir)/dists/msvc15 && ../../devtools/create_project/create_project ../.. --msvc --msvc-version 15 >/dev/null && git add -f engines/plugins_table.h *.sln *.vcxproj *.vcxproj.filters *.props
 	@echo
 	@echo All is done.
 	@echo Now run


### PR DESCRIPTION
For the few of us actually building ScummVM with Visual Studio. 😉 

- Clean up `create_project` warnings. They were caused by the implicit casts when using `tolower`/`toupper` so I think they're fine silenced.
- Improve compile times by replacing the [/Gm flag](https://docs.microsoft.com/en-us/cpp/build/reference/gm-enable-minimal-rebuild) with the [/MP flag](https://docs.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes) which is better suited for large projects (shaved a whole minute off a clean build).
- Fix natvis known issues and add new classes.
- Fix `missing translations.dat` error when not using build events.
- Update build event scripts (old DLLs, old installer, etc).
- Update `ideprojects` target.