### PR TITLE
SHERLOCK: Fix misattribution in Rose Tattoo journal

### DIFF
--- a/engines/sherlock/journal.cpp
+++ b/engines/sherlock/journal.cpp
@@ -379,6 +379,8 @@ void Journal::loadJournalFile(bool alreadyLoaded) {
 		journalString += '\n';
 	}
 
+	const int inspectorId = (IS_SERRATED_SCALPEL) ? 2 : 18;
+
 	// If Holmes has something to say first, then take care of it
 	if (!replyOnly) {
 		// Handle the grammar
@@ -391,13 +393,13 @@ void Journal::loadJournalFile(bool alreadyLoaded) {
 			if (asked)
 				journalString += fixedText.getJournalText(kFixedJournalText_HolmesAskedMe);
 			else
-				journalString += fixedText.getJournalText(kFixedJournalText_HolmesSaidToTheInspector);
+				journalString += fixedText.getJournalText(kFixedJournalText_HolmesSaidToMe);
 
-		} else if ((talk._talkTo == 2 && IS_SERRATED_SCALPEL) || (talk._talkTo == 18 && IS_ROSE_TATTOO)) {
+		} else if (talk._talkTo == inspectorId) {
 			if (asked)
 				journalString += fixedText.getJournalText(kFixedJournalText_HolmesAskedTheInspector);
 			else
-				journalString += fixedText.getJournalText(kFixedJournalText_HolmesSaidToMe);
+				journalString += fixedText.getJournalText(kFixedJournalText_HolmesSaidToTheInspector);
 
 		} else {
 			const char *text = nullptr;
@@ -421,7 +423,6 @@ void Journal::loadJournalFile(bool alreadyLoaded) {
 	bool commentFlag = false;
 	bool commentJustPrinted = false;
 	const byte *replyP = (const byte *)statement._reply.c_str();
-	const int inspectorId = (IS_SERRATED_SCALPEL) ? 2 : 18;
 	int beforeLastSpeakerChange = journalString.size();
 	bool justChangedSpeaker = true;
 


### PR DESCRIPTION
Some messages spoken to Watson show up in the journal as if spoken to the inspector. (And, presumably, the other way around, but I haven't gotten that far in playing the game yet.)

Since I couldn't reproduce this in DOSBox, I assume it's a simple cut and paste error.

You should be able to easily reproduce the bug in the attached savegame. Simply exhaust all conversation options with Watson. At least one of them should show up as "the inspector" in the journal afterwards.

[rosetattoo.000.gz](https://github.com/scummvm/scummvm/files/2705906/rosetattoo.000.gz)
