### PR TITLE
SCI32: Fix QFG4 Rusalka flowers dialogue

### DIFF
--- a/engines/sci/resource_audio.cpp
+++ b/engines/sci/resource_audio.cpp
@@ -468,6 +468,14 @@ int ResourceManager::readAudioMapSCI11(IntMapResourceSource *map) {
 				n = 0x17010001;
 			}
 
+			// QFG4CD has an orphaned audio36 resource that additionally has the wrong tuple.
+			//  The audio36 tuple is 520 2 59 0 3. The message would be 520 2 59 0 2. bug #10849
+			//  We restore the missing message in message.cpp.
+			if (g_sci->getGameId() == GID_QFG4 && g_sci->isCD() &&
+				map->_mapNumber == 520 && n == 0x023b0003) {
+				n = 0x023b0002;
+			}
+
 			if (isEarly) {
 				offset = ptr.getUint32LE();
 				ptr += 4;


### PR DESCRIPTION
Fixes mixed up text/audio when giving her flowers, bug [#10849](https://bugs.scummvm.org/ticket/10849)

````
// The CD edition mangled the Rusalka flowers dialogue.
// In the floppy edition, there are 3 lines, the first from
// the narrator, then two from Rusalka. The CD edition omits
// narration and only has the 3rd text, with the 2nd audio! The
// 3rd audio is orphaned but available.
//
// We only restore Rusalka's lines, providing the correct text
// for seq:1 to match the audio. We respond to seq:2 requests
// with Rusalka's last text. The orphaned audio (seq:3) has its
// tuple adjusted to seq:2 in resource_audio.cpp.
````

To test...
* Restore or create a character.
* Acquire flowers.
    * send hero get 40
* Teleport to the lake.
    * room 520
* Click the flowers on Rusalka.
