### PR TITLE
SCI32: Fix QFG4 cave tentacle

### DIFF
--- a/engines/sci/engine/workarounds.cpp
+++ b/engines/sci/engine/workarounds.cpp
@@ -87,7 +87,7 @@ const SciWorkaroundEntry arithmeticWorkarounds[] = {
 	{ GID_QFG1VGA,        301,  928,  0,              "Blink", "init",                            NULL,     0,     0, { WORKAROUND_FAKE,   0 } }, // op_div: when entering the inn, gets called with 1 parameter, but 2nd parameter is used for div which happens to be an object
 	{ GID_QFG2,           200,  200,  0,              "astro", "messages",                        NULL,     0,     0, { WORKAROUND_FAKE,   0 } }, // op_lsi: when getting asked for your name by the astrologer - bug #5152
 	{ GID_QFG3,           780,  999,  0,                   "", "export 6",                        NULL,     0,     0, { WORKAROUND_FAKE,   0 } }, // op_add: trying to talk to yourself at the top of the giant tree - bug #6692
-	{ GID_QFG4,           710,64941,  0,          "RandCycle", "doit",                            NULL,     0,     0, { WORKAROUND_FAKE,   1 } }, // op_gt: when the tentacle appears in the third room of the caves
+//	{ GID_QFG4,           710,64941,  0,          "RandCycle", "doit",                            NULL,     0,     0, { WORKAROUND_FAKE,   1 } }, // op_gt: when the tentacle appears in the third room of the caves
 	{ GID_TORIN,        51400,64928,  0,              "Blink", "init",                            NULL,     0,     0, { WORKAROUND_FAKE,   1 } }, // op_div: when Lycentia knocks Torin out after he removes her collar
 	SCI_WORKAROUNDENTRY_TERMINATOR
 };


### PR DESCRIPTION
Fixes wriggling and retraction when hero travels over the pit, bug [#10615](https://bugs.scummvm.org/ticket/10615)

Wriggle
````
// When crossing the cave's tightrope in room 710, a tentacle emerges, and then
// its animation freezes - in ScummVM, not the original interpreter. This
// happens because of an extraneous argument passed to setCycle().
//
// (tentacle setCycle: RandCycle tentacle)
//
// RandCycle can accept an optional arg, but it expects a number, not an
// object. ScummVM doesn't catch the faulty arithmetic and behaves abnormally.
// We remove the bad arg.
````
This supersedes an arithmetic workaround added in commit 259f262.

Fighter
````
// When crossing the cave's tightrope in room 710, a tentacle emerges. The
// tentacle is supposed to reach a state where it waits indefinitely for an
// external cue() to retract. If the speed slider is too high, a fighter
// reaches the other side and sends a cue() before the tentacle is ready to
// receive it. The tentacle never retracts.
//
// The fighter script (crossByHand) drains stamina in state 2 as hero moves
// across. A slower speed would cost extra stamina. We add a delay after that
// part is over, in state 3, just as hero is about to dismount. When state 4
// cues, the tentacle script (sTentacleDeath) will be ready (state 3).
//
// To create that delay we set the "cycles" property for a countdown and remove
// all other advancement mechanisms. State 3 had a cue from say() and a
// self-cue(). The former's "self" arg becomes null. The latter is erased.
//
// Crossing from the left (crossByHandLeft) doesn't require fixing.
````
Mage
````
// As above, mages at high speed can get across the pit in room 710 before
// tentacle is ready to receive a cue().
//
// As luck would have it, hero's speed is cached and restored. Twice actually.
//
// Overview of the mage script (sLevitateOverPit)
//  State 1-3:  Cache hero's slider-based speed.
//              Set a temporary speed as hero unfurls the cloth.
//              Restore the original value.
//              Call handsOn(). Wait for an external cue().
//  State 4:    Call handsOff().
//              If cued by the Levitate spell (script 21), go to 5-7.
//              A plain cue() from anywhere else, leads to state 8.
//  State 5-7:  Move across the pit. Skip to state 9.
//  State 8:    An abort message.
//  State 9-10: Cache hero's speed again.
//              Set a temporary speed as hero folds up the cloth.
//              Restore the original value, and normalize hero. Call handsOn().
//
// Patch 1: We overwrite some derelict code in state 5, caching the
// slider-based speed again, in case the player adjusted it before casting
// Levitate, then setting a fixed speed of our own for the crossing.
//
// Patch 2: Patch 1 already cached and clobbered the speed. We remove the
// original attempt to cache again in state 9.
//
// The result is caching/restoration at the beginning, aborting or caching and
// crossing with our fixed value, and a restoration at the end (whichever value
// was last cached). The added travel time has no side effect for mages.
//
// Mages have no other script to levitate across from left to right. At some
// point in development, the meaning of "register" changed. The derelict
// state 5 code thought 0/1 meant move right/left. Whereas state 4 decides 0/1
// means abort/cross, only ever moving left. The rightward MoveTo never runs.
````

&nbsp;

To test the room at the beginning of the game...
* Teleport to the pit.
  * room 710
* Fighter
  * Click HAND on the rope or stalagmite.
  * Choose "Cross hand-over-hand".
* Mage
  * Acquire the cloth item.
    * send hero get 35
  * Click the cloth on hero.
  * Bring up the spells list (star). Cast Levitate (2nd row, 5th icon).
* Rogue
  * Rogues didn't need patching.
  * Click HAND on the rope, and choose "Walk the tightrope".
  * They have scripts for both directions.

&nbsp;
* Fighters and rogues get a nag when stamina runs out, but they can continue crossing back and forth.
* For mages, it's a one-way trip. The debugger can place them back on the east side.
  * send hero posn 265 46

&nbsp;

As I experimented with different patches, I found I got different results after playing through the first two rooms to get there naturally (or restored a natural savegame). And medium speeds could be symptomatic when fast and slow were fine. I kept adjusting the patches' delay/speed value until I got consistent results.

&nbsp;

To test the room at the end of the game...
* Create a new mage character.
* Set the debug flag.
  * vv g 201 1
* Acquire the cloth.
  * send hero get 35
* Teleport to the pit.
  * room 710
* The pit room will fake an endgame situation, setting flag 101 and spoofing the previous room number.
* There is no tentacle at this point. Instead there's grub-like monster that needs to be pacified.
  * Cast Calm from the spell list (2nd row, 1st icon).

You can then levitate down & up, standing on either side of the pit floor.

Clicking the cloth on hero only works if standing on the upper right.
Casting Levitate while the cloth is unfurled sends hero left.

Using the cloth at any other position yields a generic message, accomplishing nothing.
"You spread out the square of cloth for a moment."