### PR TITLE
SCI32: Plane id fixes 

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -488,6 +488,9 @@ bool Console::cmdGetVersion(int argc, const char **argv) {
 	debugPrintf("Resource map version: %s\n", g_sci->getResMan()->getMapVersionDesc());
 	debugPrintf("Contains selector vocabulary (vocab.997): %s\n", hasVocab997 ? "yes" : "no");
 	debugPrintf("Has CantBeHere selector: %s\n", g_sci->getKernel()->_selectorCache.cantBeHere != -1 ? "yes" : "no");
+	if (getSciVersion() >= SCI_VERSION_2) {
+		debugPrintf("Plane id base: %d\n", g_sci->_features->detectPlaneIdBase());
+	}
 	debugPrintf("Game version (VERSION file): %s\n", gameVersion.c_str());
 	debugPrintf("\n");
 

--- a/engines/sci/engine/features.cpp
+++ b/engines/sci/engine/features.cpp
@@ -628,6 +628,14 @@ MessageTypeSyncStrategy GameFeatures::getMessageTypeSyncStrategy() const {
 	return kMessageTypeSyncStrategyNone;
 }
 
+int GameFeatures::detectPlaneIdBase() {
+	if (getSciVersion() == SCI_VERSION_2 &&
+	    g_sci->getGameId() != GID_PQ4)
+		return 0;
+	else
+		return 20000;
+}
+	
 bool GameFeatures::autoDetectMoveCountType() {
 	// Look up the script address
 	reg_t addr = getDetectionAddr("Motion", SELECTOR(doit));

--- a/engines/sci/engine/features.h
+++ b/engines/sci/engine/features.h
@@ -228,6 +228,8 @@ public:
 	 */
 	MoveCountType detectMoveCountType();
 
+	int detectPlaneIdBase();
+	
 	bool handleMoveCount() { return detectMoveCountType() == kIncrementMoveCount; }
 
 	bool usesCdTrack() { return _usesCdTrack; }

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -8383,31 +8383,6 @@ static const uint16 qfg4SetScalerPatch[] = {
 	PATCH_END
 };
 
-// When the fortune teller's wagon room is disposed, it attempts to call
-// hero::show(), hero has a null "plane" property, and ScummVM crashes.
-//
-// The problematic line was removed in the CD edition. We remove it, too.
-//
-// Note: This patch is a workaround. The floppy edition SSCI did not crash, and
-// its implementation of AddScreenItem() should be checked to find out why.
-//
-// Applies to at least: English floppy, German floppy
-// Responsible method: rm470::dispose()
-// Fixes bug: #10778
-static const uint16 qfg4MagdaDisposalSignature[] = {
-	0x38, SIG_SELECTOR16(posn),         // posn
-	SIG_ADDTOOFFSET(+8),                // ...
-	SIG_MAGICDWORD,
-	0x81, 0x00,                         // lag global[0] (hero)
-	0x4a, SIG_UINT16(0x000c),           // send 12d (posn: 1000 1000 show:)
-	SIG_END
-};
-
-static const uint16 qfg4MagdaDisposalPatch[] = {
-	0x33, 0x0e,                         // jmp 14d (skip the entire hero send)
-	PATCH_END
-};
-
 // The castle's crest-operated bookshelf has an unconditional HAND message
 // which always says, "you haven't found the trigger yet," even after it's
 // open.
@@ -8595,47 +8570,6 @@ static const uint16 qfg4ConditionalVoidSignature[] = {
 static const uint16 qfg4ConditionalVoidPatch[] = {
 	PATCH_ADDTOOFFSET(+4),              //
 	0x78,                               // push1 (Feed OR a literal 1)
-	PATCH_END
-};
-
-// The copy protection in floppy versions has a script bug which attempts to add
-//  views with no planes to the screen. Our interpreter does not allow this and
-//  treats it as an error. This appears to work in Sierra's interpreter, which
-//  presumably ignores it, although the script bug was fixed in the CD version.
-//
-// When asking Dr. Cranium in room 370 about certain potions the game switches
-//  to a copy protection screen and then back to the conversation. Before the
-//  switch, craniumTalker is disposed, which in turn disposes craniumThumbs and
-//  craniumBrow. Disposing these views clears their planes. After returning from
-//  the protection screen craniumTalker:showAgain is called even though it has
-//  been disposed. This causes kAddScreenItem to be called on views without
-//  planes, which is treated as an error by our interpreter.
-//
-// We work around this by reinitializing craniumTalker after the copy protection
-//  so that showAgain can be safely called. craniumTalker is reinitialized when
-//  navigating through the conversation menus so this is normal behavior.
-//
-// Applies to: English PC Floppy, German PC Floppy
-// Responsible method: delayMsg:changeState(0)
-// Fixes bug: #10773
-static const uint16 qfg4CopyProtectionSignature[] = {
-	0x31, 0x06,                         // bnt 06
-	SIG_MAGICDWORD,
-	0x35, 0x01,                         // ldi 01
-	0x65, 0x24,                         // aTop register
-	SIG_ADDTOOFFSET(+6),
-	0x38, SIG_UINT16(0x0300),           // pushi 0300 [ showAgain, hard-coded for floppy ]
-	SIG_ADDTOOFFSET(+11),
-	0x4a, SIG_UINT16(0x0004),           // send 04 [ craniumTalker: showAgain ]
-	SIG_END
-};
-
-static const uint16 qfg4CopyProtectionPatch[] = {
-	0x65, 0x24,                         // aTop register
-	0x38, PATCH_SELECTOR16(init),       // pushi init
-	0x76,                               // push0
-	PATCH_ADDTOOFFSET(+20),
-	0x4a, PATCH_UINT16(0x0008),         // send 08 [ craniumTalker: init, showAgain ]
 	PATCH_END
 };
 
@@ -9277,9 +9211,7 @@ static const SciScriptPatcherEntry qfg4Signatures[] = {
 	{  true,   270, "fix town gate after a staff dream",           1, qfg4DreamGateSignature,        qfg4DreamGatePatch },
 	{  true,   320, "fix pathfinding at the inn",                  1, qg4InnPathfindingSignature,    qg4InnPathfindingPatch },
 	{  true,   320, "fix talking to absent innkeeper",             1, qfg4AbsentInnkeeperSignature,  qfg4AbsentInnkeeperPatch },
-	{  true,   370, "Floppy: fix copy protection",                 1, qfg4CopyProtectionSignature,   qfg4CopyProtectionPatch },
 	{  true,   440, "fix setLooper calls (1/2)",                   1, qg4SetLooperSignature1,        qg4SetLooperPatch1 },
-	{  true,   470, "fix Magda room disposal",                     1, qfg4MagdaDisposalSignature,    qfg4MagdaDisposalPatch },
 	{  true,   475, "fix tarot 3 queen card",                      1, qfg4Tarot3QueenSignature,      qfg4Tarot3QueenPatch },
 	{  true,   475, "fix tarot 3 death card",                      1, qfg4Tarot3DeathSignature,      qfg4Tarot3DeathPatch },
 	{  true,   475, "fix tarot 3 two of cups placement",           1, qfg4Tarot3TwoOfCupsSignature,  qfg4Tarot3TwoOfCupsPatch },

--- a/engines/sci/graphics/plane32.cpp
+++ b/engines/sci/graphics/plane32.cpp
@@ -44,8 +44,8 @@ void DrawList::add(ScreenItem *screenItem, const Common::Rect &rect) {
 
 #pragma mark -
 #pragma mark Plane
-uint16 Plane::_nextObjectId = 20000;
-uint32 Plane::_nextCreationId = 0;
+uint16 Plane::_nextObjectId; // Will be initialized in Plane::init()
+uint32 Plane::_nextCreationId; // ditto
 
 Plane::Plane(const Common::Rect &gameRect, PlanePictureCodes pictureId) :
 _creationId(_nextCreationId++),
@@ -132,7 +132,7 @@ void Plane::operator=(const Plane &other) {
 }
 
 void Plane::init() {
-	_nextObjectId = 20000;
+	_nextObjectId = g_sci->_features->detectPlaneIdBase();
 	_nextCreationId = 0;
 }
 


### PR DESCRIPTION
This pull request provides a proper fix for bug #10773, #10778 and possibly other bugs that don't have tickets.

SCI32 creates a number of internal planes for various purposes. In most interpreters, these planes have ID numbers starting at 20000. These planes do not have a corresponding script object, and are denoted by (scummvm) in the output of the plane_list command. One such plane (and the only one relevant to GK1 and QfG4) is called initPlane in the scummvm source code. Most memory handles are smallish, so starting at 20000 makes conflicts with script-created planes much less likely (but not impossible). In the early interpreters of GK1 and QfG4 floppy, the numbering actually starts at zero. This means that operations on screen items with plane == 0 will operate on the initPlane implicitly. As more features were implemented that used this kind of plane, conflicts became likely, which probably explains why Sierra changed it. This also explains why they had to fix this bug even though it was asymptomatic in SSCI 2.0: As soon as they rebuilt the game with SCI2.1 for the CD release, the bug would have become symptomatic.
