### PR TITLE
BUILD: Reduce GCC warnings

### DIFF
--- a/backends/timer/default/default-timer.cpp
+++ b/backends/timer/default/default-timer.cpp
@@ -35,6 +35,8 @@ struct TimerSlot {
 	uint32 nextFireTimeMicro;	// microseconds part of nextFire
 
 	TimerSlot *next;
+
+	TimerSlot() : callback(nullptr), refCon(nullptr), interval(0), nextFireTime(0), nextFireTimeMicro(0), next(nullptr) {}
 };
 
 void insertPrioQueue(TimerSlot *head, TimerSlot *newSlot) {
@@ -63,7 +65,6 @@ DefaultTimerManager::DefaultTimerManager() :
 	_head(0) {
 
 	_head = new TimerSlot();
-	memset(_head, 0, sizeof(TimerSlot));
 }
 
 DefaultTimerManager::~DefaultTimerManager() {

--- a/engines/agi/agi.cpp
+++ b/engines/agi/agi.cpp
@@ -103,9 +103,9 @@ int AgiEngine::agiInit() {
 
 	// clear view table
 	for (i = 0; i < SCREENOBJECTS_MAX; i++)
-		memset(&_game.screenObjTable[i], 0, sizeof(struct ScreenObjEntry));
+		_game.screenObjTable[i].reset();
 
-	memset(&_game.addToPicView, 0, sizeof(struct ScreenObjEntry));
+	_game.addToPicView.reset();
 
 	_words->clearEgoWords();
 
@@ -360,9 +360,7 @@ AgiEngine::AgiEngine(OSystem *syst, const AGIGameDescription *gameDesc) : AgiBas
 	DebugMan.addDebugChannel(kDebugLevelSavegame, "Savegame", "Saving & restoring game debugging");
 
 
-	memset(&_game, 0, sizeof(struct AgiGame));
 	memset(&_debug, 0, sizeof(struct AgiDebug));
-	memset(&_mouse, 0, sizeof(struct Mouse));
 
 	_game.mouseEnabled = true;
 	_game.mouseHidden = false;

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -232,6 +232,8 @@ struct gameIdList {
 struct Mouse {
 	int button;
 	Common::Point pos;
+
+	Mouse() : button(0) {}
 };
 
 // Used by AGI Mouse protocol 1.0 for v27 (i.e. button pressed -variable).
@@ -491,6 +493,68 @@ struct AgiGame {
 	int16 nonBlockingTextCyclesLeft;
 
 	bool automaticRestoreGame;
+
+	AgiGame() : _vm(nullptr), adjMouseX(0), adjMouseY(0), crc(0), horizon(0),
+		cycleInnerLoopActive(false), cycleInnerLoopType(0), curLogicNr(0),
+		playerControl(false), exitAllLogics(false), pictureShown(false),
+		gameFlags(0), gfxMode(false), numObjects(0), _curLogic(nullptr),
+		automaticSave(false), mouseEnabled(false), mouseHidden(false),
+		testResult(0), max_logics(0), nonBlockingTextShown(false),
+		nonBlockingTextCyclesLeft(0), automaticRestoreGame(false) {
+		execStack.clear();
+		memset(&block, 0, sizeof(block));
+		memset(name, 0, sizeof(name));
+		memset(id, 0, sizeof(id));
+		memset(flags, 0, sizeof(flags));
+		memset(vars, 0, sizeof(vars));
+
+		for (int i = 0; i < ARRAYSIZE(controllerOccured); i++) {
+			controllerOccured[i] = false;
+		}
+
+		for (int i = 0; i < ARRAYSIZE(controllerKeyMapping); i++) {
+			controllerKeyMapping[i].keycode = 0;
+			controllerKeyMapping[i].controllerSlot = false;
+		}
+
+		memset(strings, 0, sizeof(strings));
+
+		for (int i = 0; i < MAX_DIRECTORY_ENTRIES; i++) {
+			memset(&dirLogic[i], 0, sizeof(struct AgiDir));
+			memset(&dirPic[i], 0, sizeof(struct AgiDir));
+			memset(&dirView[i], 0, sizeof(struct AgiDir));
+			memset(&dirSound[i], 0, sizeof(struct AgiDir));
+
+			pictures[i].flen = 0;
+			pictures[i].rdata = nullptr;
+
+			logics[i].data = nullptr;
+			logics[i].size = 0;
+			logics[i].sIP = 0;
+			logics[i].cIP = 0;
+			logics[i].numTexts = 0;
+			logics[i].texts = nullptr;
+
+			views[i].headerStepSize = 0;
+			views[i].headerCycleTime = 0;
+			views[i].description = nullptr;
+			views[i].loopCount = 0;
+			views[i].loop = nullptr;
+
+			sounds[i] = nullptr;
+		}
+
+		_curLogic = nullptr;
+
+		for (int i = 0; i < ARRAYSIZE(screenObjTable); i++) {
+			screenObjTable[i].reset();
+		}
+
+		addToPicView.reset();
+		memset(automaticSaveDescription, 0, sizeof(automaticSaveDescription));
+
+		memset(logic_list, 0, sizeof(logic_list));
+	}
 };
 
 class AgiLoader {

--- a/engines/agi/preagi.cpp
+++ b/engines/agi/preagi.cpp
@@ -48,9 +48,7 @@ PreAgiEngine::PreAgiEngine(OSystem *syst, const AGIGameDescription *gameDesc) : 
 	DebugMan.addDebugChannel(kDebugLevelText, "Text", "Text output debugging");
 	DebugMan.addDebugChannel(kDebugLevelSavegame, "Savegame", "Saving & restoring game debugging");
 
-	memset(&_game, 0, sizeof(struct AgiGame));
 	memset(&_debug, 0, sizeof(struct AgiDebug));
-	memset(&_mouse, 0, sizeof(struct Mouse));
 
 	_speakerHandle = new Audio::SoundHandle();
 }

--- a/engines/agi/view.h
+++ b/engines/agi/view.h
@@ -133,7 +133,47 @@ struct ScreenObjEntry {
 	// end of motion related variables
 	uint8 loop_flag;
 
-	ScreenObjEntry() { memset(this, 0, sizeof(ScreenObjEntry)); }
+	ScreenObjEntry() { reset(); }
+
+	void reset() {
+		objectNr = 0;
+		stepTime = 0;
+		stepTimeCount = 0;
+		xPos = 0;
+		yPos = 0;
+		currentViewNr = 0;
+		viewReplaced = false;
+		viewResource = nullptr;
+		currentLoopNr = 0;
+		loopCount = 0;
+		loopData = nullptr;
+		currentCelNr = 0;
+		celCount = 0;
+		celData = nullptr;
+		xSize = 0;
+		ySize = 0;
+		xPos_prev = 0;
+		yPos_prev = 0;
+		xSize_prev = 0;
+		ySize_prev = 0;
+		stepSize = 0;
+		cycleTime = 0;
+		cycleTimeCount = 0;
+		direction = 0;
+		motionType = kMotionNormal;
+		cycle = kCycleNormal;
+		priority = 0;
+		flags = 0;
+		move_x = 0;
+		move_y = 0;
+		move_stepSize = 0;
+		move_flag = 0;
+		follow_stepSize = 0;
+		follow_flag = 0;
+		follow_count = 0;
+		wander_count = 0;
+		loop_flag = 0;
+	}
 }; // struct vt_entry
 
 } // End of namespace Agi

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -132,7 +132,18 @@ struct VgaSprite {
 	uint16 priority;
 	uint16 windowNum;
 	uint16 zoneNum;
-	VgaSprite() { memset(this, 0, sizeof(*this)); }
+	VgaSprite() { reset(); }
+
+	void reset() {
+		id = 0;
+		image = 0;
+		palette = 0;
+		x = y = 0;
+		flags = 0;
+		priority = 0;
+		windowNum = 0;
+		zoneNum = 0;
+	}
 };
 
 struct VgaSleepStruct {

--- a/engines/agos/vga.cpp
+++ b/engines/agos/vga.cpp
@@ -1083,7 +1083,7 @@ void AGOSEngine::vc27_resetSprite() {
 
 	_lastVgaWaitFor = 0;
 
-	memset(&bak, 0, sizeof(bak));
+	bak.reset();
 
 	vsp = _vgaSprites;
 	while (vsp->id) {

--- a/engines/fullpipe/anihandler.cpp
+++ b/engines/fullpipe/anihandler.cpp
@@ -528,7 +528,7 @@ int AniHandler::seekWay(int idx, int st1idx, int st2idx, bool flip, bool flop) {
 	debugC(2, kDebugPathfinding, "AniHandler::seekWay(%d, %d, %d, %d, %d)", idx, st1idx, st2idx, flip, flop);
 
 	if (st1idx == st2idx) {
-		memset(&item.subItems[subIdx], 0, sizeof(item.subItems[subIdx]));
+		item.subItems[subIdx].reset();
 		return 0;
 	}
 

--- a/engines/fullpipe/anihandler.h
+++ b/engines/fullpipe/anihandler.h
@@ -38,6 +38,15 @@ struct MGMSubItem {
 	int y;
 
 	MGMSubItem();
+
+	void reset() {
+		movement = nullptr;
+		staticsIndex = 0;
+		field_8 = 0;
+		field_C = 0;
+		x = 0;
+		y = 0;
+	}
 };
 
 struct MGMItem {
@@ -63,7 +72,21 @@ struct MakeQueueStruct {
 	int y2;
 	int flags;
 
-	MakeQueueStruct() { memset(this, 0, sizeof(MakeQueueStruct)); }
+	MakeQueueStruct() { reset(); }
+
+	void reset() {
+		ani = nullptr;
+		staticsId1 = 0;
+		staticsId2 = 0;
+		movementId = 0;
+		field_10 = 0;
+		x1 = 0;
+		y1 = 0;
+		field_1C = 0;
+		x2 = 0;
+		y2 = 0;
+		flags = 0;
+	}
 };
 
 class AniHandler : public CObject {

--- a/engines/fullpipe/motion.cpp
+++ b/engines/fullpipe/motion.cpp
@@ -1230,7 +1230,7 @@ MessageQueue *MovGraph::makeWholeQueue(StaticANIObject *ani, MovArr *movarr, int
 
 		MakeQueueStruct mkQueue;
 
-		memset(&mkQueue, 0, sizeof(mkQueue));
+		mkQueue.reset();
 		mkQueue.ani = ani;
 		mkQueue.staticsId2 = id2;
 		mkQueue.staticsId1 = id1;
@@ -1996,7 +1996,7 @@ MessageQueue *MctlGraph::makeWholeQueue(MctlMQ &mctlMQ) {
 			} else {
 				MakeQueueStruct mkQueue;
 
-				memset(&mkQueue, 0, sizeof(mkQueue));
+				mkQueue.reset();
 
 				mkQueue.ani = _items2[mctlMQ.index]._obj;
 				mkQueue.staticsId2 = mg2i->_mov->_staticsObj2->_staticsId;

--- a/engines/fullpipe/scenes/scene04.cpp
+++ b/engines/fullpipe/scenes/scene04.cpp
@@ -645,7 +645,7 @@ MessageQueue *sceneHandler04_kozFly5(StaticANIObject *ani, double phase) {
 
 	MessageQueue *mq1 = aniHandler.makeRunQueue(&mkQueue);
 
-	memset(&mkQueue, 0, sizeof(mkQueue));
+	mkQueue.reset();
 	mkQueue.ani = ani;
 	mkQueue.staticsId1 = ST_KZW_JUMPOUT;
 	mkQueue.staticsId2 = ST_KZW_SIT;

--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -159,7 +159,7 @@ void Actor::initActor(int mode) {
 		memset(_palette, 0, sizeof(_palette));
 		memset(_sound, 0, sizeof(_sound));
 		memset(&_cost, 0, sizeof(CostumeData));
-		memset(&_walkdata, 0, sizeof(ActorWalkData));
+		_walkdata.reset();
 		_walkdata.point3.x = 32000;
 		_walkScript = 0;
 	}

--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -151,6 +151,20 @@ protected:
 		Common::Point point3;
 		int32 deltaXFactor, deltaYFactor;
 		uint16 xfrac, yfrac;
+
+		void reset() {
+			dest.x = dest.y = 0;
+			destbox = 0;
+			destdir = 0;
+			cur.x = cur.y = 0;
+			curbox = 0;
+			next.x = next.y = 0;
+			point3.x = point3.y = 0;
+			deltaXFactor = 0;
+			deltaYFactor = 0;
+			xfrac = 0;
+			yfrac = 0;
+		}
 	};
 
 

--- a/engines/scumm/gfx.h
+++ b/engines/scumm/gfx.h
@@ -53,6 +53,18 @@ struct CameraData {
 	int _leftTrigger, _rightTrigger;
 	byte _follows, _mode;
 	bool _movingToActor;
+
+	void reset() {
+		_cur.x = _cur.y = 0;
+		_dest.x = _dest.y = 0;
+		_accel.x = _accel.y = 0;
+		_last.x = _last.y = 0;
+		_leftTrigger = 0;
+		_rightTrigger = 0;
+		_follows = 0;
+		_mode = 0;
+		_movingToActor = 0;
+	}
 };
 
 /** Virtual screen identifiers */

--- a/engines/scumm/he/floodfill_he.h
+++ b/engines/scumm/he/floodfill_he.h
@@ -32,6 +32,13 @@ struct FloodFillParameters {
 	int32 x;
 	int32 y;
 	int32 flags;
+
+	void reset() {
+		box.top = box.left = box.bottom = box.right = 0;
+		x = 0;
+		y = 0;
+		flags = 0;
+	}
 };
 
 struct FloodFillLine {

--- a/engines/scumm/he/script_v100he.cpp
+++ b/engines/scumm/he/script_v100he.cpp
@@ -906,7 +906,7 @@ void ScummEngine_v100he::o100_floodFill() {
 
 	switch (subOp) {
 	case 0:
-		memset(&_floodFillParams, 0, sizeof(_floodFillParams));
+		_floodFillParams.reset();
 		_floodFillParams.box.left = 0;
 		_floodFillParams.box.top = 0;
 		_floodFillParams.box.right = 639;

--- a/engines/scumm/he/script_v90he.cpp
+++ b/engines/scumm/he/script_v90he.cpp
@@ -1486,7 +1486,7 @@ void ScummEngine_v90he::o90_floodFill() {
 		pop();
 		break;
 	case 57:
-		memset(&_floodFillParams, 0, sizeof(_floodFillParams));
+		_floodFillParams.reset();
 		_floodFillParams.box.left = 0;
 		_floodFillParams.box.top = 0;
 		_floodFillParams.box.right = 639;
@@ -1630,7 +1630,7 @@ void ScummEngine_v90he::o90_getPolygonOverlap() {
 				push(0);
 			} else {
 				WizPolygon wp;
-				memset(&wp, 0, sizeof(wp));
+				wp.reset();
 				wp.numVerts = n1;
 				assert(n1 < ARRAYSIZE(wp.vert));
 				for (int i = 0; i < n1; ++i) {

--- a/engines/scumm/he/sprite_he.cpp
+++ b/engines/scumm/he/sprite_he.cpp
@@ -1086,8 +1086,13 @@ void Sprite::resetGroup(int spriteGroupId) {
 }
 
 void Sprite::resetTables(bool refreshScreen) {
-	memset(_spriteTable, 0, (_varNumSprites + 1) * sizeof(SpriteInfo));
-	memset(_spriteGroups, 0, (_varNumSpriteGroups + 1) * sizeof(SpriteGroup));
+	for (int i = 0; i < _varNumSprites; i++) {
+		_spriteTable[i].reset();
+	}
+	for (int i = 0; i < _varNumSpriteGroups; i++) {
+		_spriteGroups[i].reset();
+	}
+
 	for (int curGrp = 1; curGrp < _varNumSpriteGroups; ++curGrp)
 		resetGroup(curGrp);
 

--- a/engines/scumm/he/sprite_he.h
+++ b/engines/scumm/he/sprite_he.h
@@ -82,6 +82,43 @@ struct SpriteInfo {
 	int32 classFlags;
 	int32 imgFlags;
 	int32 conditionBits;
+
+	void reset() {
+		id = 0;
+		zorder = 0;
+		flags = 0;
+		image = 0;
+		imageState = 0;
+		group = 0;
+		palette = 0;
+		priority = 0;
+		bbox.top = bbox.left = bbox.bottom = bbox.right = 0;
+		dx = 0;
+		dy = 0;
+		pos.x = pos.y = 0;
+		tx = 0;
+		ty = 0;
+		userValue = 0;
+		curImageState = 0;
+		curImage = 0;
+		imglistNum = 0;
+		shadow = 0;
+		imageStateCount = 0;
+		angle = 0;
+		scale = 0;
+		animProgress = 0;
+		curAngle = 0;
+		curScale = 0;
+		curImgFlags = 0;
+		animIndex = 0;
+		animSpeed = 0;
+		sourceImage = 0;
+		maskImage = 0;
+		zbufferImage = 0;
+		classFlags = 0;
+		imgFlags = 0;
+		conditionBits = 0;
+	}
 };
 
 struct SpriteGroup {
@@ -96,6 +133,20 @@ struct SpriteGroup {
 	int32 scale_x_ratio_div;
 	int32 scale_y_ratio_mul;
 	int32 scale_y_ratio_div;
+
+	void reset() {
+		bbox.top = bbox.left = bbox.bottom = bbox.right = 0;
+		priority = 0;
+		flags = 0;
+		tx = 0;
+		ty = 0;
+		image = 0;
+		scaling = 0;
+		scale_x_ratio_mul = 0;
+		scale_x_ratio_div = 0;
+		scale_y_ratio_mul = 0;
+		scale_y_ratio_div = 0;
+	}
 };
 
 class ScummEngine_v90he;

--- a/engines/scumm/he/wiz_he.cpp
+++ b/engines/scumm/he/wiz_he.cpp
@@ -50,7 +50,7 @@ void Wiz::clearWizBuffer() {
 void Wiz::polygonClear() {
 	for (int i = 0; i < ARRAYSIZE(_polygons); i++) {
 		if (_polygons[i].flag == 1)
-			memset(&_polygons[i], 0, sizeof(WizPolygon));
+			_polygons[i].reset();
 	}
 }
 
@@ -173,7 +173,7 @@ void Wiz::polygonCalcBoundBox(Common::Point *vert, int numVerts, Common::Rect &b
 void Wiz::polygonErase(int fromId, int toId) {
 	for (int i = 0; i < ARRAYSIZE(_polygons); i++) {
 		if (_polygons[i].id >= fromId && _polygons[i].id <= toId)
-			memset(&_polygons[i], 0, sizeof(WizPolygon));
+			_polygons[i].reset();
 	}
 }
 

--- a/engines/scumm/he/wiz_he.h
+++ b/engines/scumm/he/wiz_he.h
@@ -33,6 +33,16 @@ struct WizPolygon {
 	int id;
 	int numVerts;
 	bool flag;
+
+	void reset() {
+		for (int i = 0; i < ARRAYSIZE(vert); i++) {
+			vert[i].x = vert[i].y = 0;
+		}
+		bound.top = bound.left = bound.bottom = bound.right = 0;
+		id = 0;
+		numVerts = 0;
+		flag = 0;
+	}
 };
 
 struct WizImage {
@@ -107,6 +117,46 @@ struct WizParameters {
 	int spriteGroup;
 	int conditionBits;
 	WizImage img;
+
+	void reset() {
+		field_0 = 0;
+		memset(filename, 0, sizeof(filename));
+		box.top = box.left = box.bottom = box.right = 0;
+		processFlags = 0;
+		processMode = 0;
+		field_11C = 0;
+		field_120 = 0;
+		field_124 = 0;
+		field_128 = 0;
+		field_12C = 0;
+		field_130 = 0;
+		field_134 = 0;
+		field_138 = 0;
+		compType = 0;
+		fileWriteMode = 0;
+		angle = 0;
+		scale = 0;
+		polygonId1 = 0;
+		polygonId2 = 0;
+		resDefImgW = 0;
+		resDefImgH = 0;
+		sourceImage = 0;
+		params1 = 0;
+		params2 = 0;
+		memset(remapColor, 0, sizeof(remapColor));
+		memset(remapIndex, 0, sizeof(remapIndex));
+		remapNum = 0;
+		dstResNum = 0;
+		fillColor = 0;
+		memset(&fontProperties, 0, sizeof(FontProperties));
+		memset(&ellipseProperties, 0, sizeof(EllipseProperties));
+		box2.left = box2.top = box2.bottom = box2.right = 0;
+		blendFlags = 0;
+		spriteId = 0;
+		spriteGroup = 0;
+		conditionBits = 0;
+		memset(&img, 0, sizeof(WizImage));
+	}
 };
 
 enum WizImageFlags {

--- a/engines/scumm/imuse/imuse_internal.h
+++ b/engines/scumm/imuse/imuse_internal.h
@@ -106,7 +106,15 @@ struct HookDatas {
 
 	int query_param(int param, byte chan);
 	int set(byte cls, byte value, byte chan);
-	HookDatas() { memset(this, 0, sizeof(HookDatas)); }
+	HookDatas() { reset(); }
+	void reset() {
+		_transpose = 0;
+		memset(_jump, 0, sizeof(_jump));
+		memset(_part_onoff, 0, sizeof(_part_onoff));
+		memset(_part_volume, 0, sizeof(_part_volume));
+		memset(_part_program, 0, sizeof(_part_program));
+		memset(_part_transpose, 0, sizeof(_part_transpose));
+	}
 };
 
 struct ParameterFader {

--- a/engines/scumm/imuse/imuse_player.cpp
+++ b/engines/scumm/imuse/imuse_player.cpp
@@ -163,7 +163,7 @@ void Player::clear() {
 }
 
 void Player::hook_clear() {
-	memset(&_hook, 0, sizeof(_hook));
+	_hook.reset();
 }
 
 int Player::start_seq_sound(int sound, bool reset_vars) {

--- a/engines/scumm/imuse_digi/dimuse.cpp
+++ b/engines/scumm/imuse_digi/dimuse.cpp
@@ -55,7 +55,7 @@ IMuseDigital::IMuseDigital(ScummEngine_v7 *scumm, Audio::Mixer *mixer, int fps)
 	for (int l = 0; l < MAX_DIGITAL_TRACKS + MAX_DIGITAL_FADETRACKS; l++) {
 		_track[l] = new Track;
 		assert(_track[l]);
-		memset(_track[l], 0, sizeof(Track));
+		_track[l]->reset();
 		_track[l]->trackId = l;
 	}
 	_vm->getTimerManager()->installTimerProc(timer_handler, 1000000 / _callbackFps, this, "IMuseDigital");
@@ -147,7 +147,7 @@ void IMuseDigital::saveLoadEarly(Common::Serializer &s) {
 	for (int l = 0; l < MAX_DIGITAL_TRACKS + MAX_DIGITAL_FADETRACKS; l++) {
 		Track *track = _track[l];
 		if (s.isLoading()) {
-			memset(track, 0, sizeof(Track));
+			track->reset();
 		}
 		syncWithSerializer(s, *track);
 		if (s.isLoading()) {
@@ -210,7 +210,7 @@ void IMuseDigital::callback() {
 			// mark it as unused.
 			if (!track->stream) {
 				if (!_mixer->isSoundHandleActive(track->mixChanHandle))
-					memset(track, 0, sizeof(Track));
+					track->reset();
 				continue;
 			}
 

--- a/engines/scumm/imuse_digi/dimuse_script.cpp
+++ b/engines/scumm/imuse_digi/dimuse_script.cpp
@@ -180,7 +180,7 @@ void IMuseDigital::flushTrack(Track *track) {
 	}
 
 	if (!_mixer->isSoundHandleActive(track->mixChanHandle)) {
-		memset(track, 0, sizeof(Track));
+		track->reset();
 	}
 }
 
@@ -191,7 +191,7 @@ void IMuseDigital::flushTracks() {
 		Track *track = _track[l];
 		if (track->used && track->toBeRemoved && !_mixer->isSoundHandleActive(track->mixChanHandle)) {
 			debug(5, "flushTracks() - soundId:%d", track->soundId);
-			memset(track, 0, sizeof(Track));
+			track->reset();
 		}
 	}
 }
@@ -438,7 +438,7 @@ void IMuseDigital::stopAllSounds() {
 			}
 
 			// Mark the track as unused
-			memset(track, 0, sizeof(Track));
+			track->reset();
 		}
 	}
 }

--- a/engines/scumm/imuse_digi/dimuse_track.cpp
+++ b/engines/scumm/imuse_digi/dimuse_track.cpp
@@ -67,7 +67,7 @@ int IMuseDigital::allocSlot(int priority) {
 			}
 
 			// Mark it as unused
-			memset(track, 0, sizeof(Track));
+			track->reset();
 
 			debug(5, "IMuseDigital::allocSlot(): Removed sound %d from track %d", _track[trackId]->soundId, trackId);
 		} else {
@@ -93,7 +93,7 @@ void IMuseDigital::startSound(int soundId, const char *soundName, int soundType,
 	Track *track = _track[l];
 
 	// Reset the track
-	memset(track, 0, sizeof(Track));
+	track->reset();
 
 	track->pan = 64;
 	track->vol = volume * 1000;

--- a/engines/scumm/imuse_digi/dimuse_track.h
+++ b/engines/scumm/imuse_digi/dimuse_track.h
@@ -75,7 +75,34 @@ struct Track {
 	Audio::SoundHandle mixChanHandle;					// sound mixer's channel handle
 	Audio::QueuingAudioStream *stream;		// sound mixer's audio stream handle for *.la1 and *.bun
 
-	Track() : soundId(-1), used(false), stream(NULL) {
+	Track() : soundId(-1), used(false), stream(nullptr) {
+	}
+
+	void reset() {
+		trackId = 0;
+		pan = 0;
+		vol = 0;
+		volFadeDest = 0;
+		volFadeStep = 0;
+		volFadeDelay = 0;
+		volFadeUsed = false;
+		soundId = 0;
+		memset(soundName, 0, sizeof(soundName));
+		used = false;
+		toBeRemoved = false;
+		souStreamUsed = false;
+		sndDataExtComp = false;
+		soundPriority = 0;
+		regionOffset = 0;
+		dataOffset = 0;
+		curRegion = 0;
+		curHookId = 0;
+		soundType = 0;
+		feedSize = 0;
+		dataMod12Bit = 0;
+		mixerFlags = 0;
+		soundDesc = nullptr;
+		stream = nullptr;
 	}
 
 	int getPan() const { return (pan != 64) ? 2 * pan - 127 : 0; }

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -245,7 +245,7 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 	_screenHeight = 0;
 	_screenWidth = 0;
 	memset(_virtscr, 0, sizeof(_virtscr));
-	memset(&camera, 0, sizeof(CameraData));
+	camera.reset();
 	memset(_colorCycle, 0, sizeof(_colorCycle));
 	memset(_colorUsedByCycle, 0, sizeof(_colorUsedByCycle));
 	_ENCD_offs = 0;
@@ -331,8 +331,18 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 	_townsPaletteFlags = 0;
 	_townsClearLayerFlag = 1;
 	_townsActiveLayerFlags = 3;
-	memset(&_curStringRect, -1, sizeof(Common::Rect));
-	memset(&_cyclRects, 0, 16 * sizeof(Common::Rect));
+	_curStringRect.top = -1;
+	_curStringRect.left = -1;
+	_curStringRect.bottom = -1;
+	_curStringRect.right = -1;
+
+	for (int i = 0; i < ARRAYSIZE(_cyclRects); i++) {
+		_cyclRects[i].top = 0;
+		_cyclRects[i].left = 0;
+		_cyclRects[i].bottom = 0;
+		_cyclRects[i].right = 0;
+	}
+
 	_numCyclRects = 0;
 #endif
 
@@ -1779,7 +1789,7 @@ void ScummEngine_v90he::resetScumm() {
 	_hePaletteNum = 0;
 
 	_sprite->resetTables(0);
-	memset(&_wizParams, 0, sizeof(_wizParams));
+	_wizParams.reset();
 
 	if (_game.heversion >= 98)
 		_logicHE = LogicHE::makeLogicHE(this);


### PR DESCRIPTION
This is not intended for immediate merge, but as a starting point for further discussion. ScummVM currently produces a lot of warnings when compiling with GCC 8. Possibly earlier versions as well. It would be good to silence the unnecessary compiler warnings, because the real warnings can easily be missed in the noise.

Most of the warnings, at the time I forked, were on the form "void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘...’; use assignment or value-initialization instead [-Wclass-memaccess]", so that's what I've focused on. The main method I've used is adding reset() methods to a number of classes and calling that instead. Is that a good approach? It seems a bit error-prone, since the method has to be updated if further members are added to the class or struct. And of course, I may have accidentally missed some as well.

There are still a couple of warnings remaining. Some of them looked non-trivial, and some were about memcpy() instead of memset(). In some cases, I didn't feel comfortable messing with that particular part of the code at the time.
