### PR TITLE
SCI32: Fix QFG4 forest pathfinding

### DIFF
--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -9473,6 +9473,35 @@ static const uint16 qfg4PitRopeMagePatch2[] = {
 	PATCH_END
 };
 
+// WORKAROUND: Script needed, because of differences in our pathfinding
+// algorithm.
+// When entering forest room 557 from the east (563), hero is supposed to move
+// only a short distance into the room. ScummVM's pathfinding sends hero off
+// course, to the middle of the room and back.
+//
+// There's an unwalkable stream in the SE corner, and hero's coords were within
+// its polygon. We lower the top two points to keep hero on the outside.
+//
+// Applies to at least: English CD, English floppy, German floppy
+// Responsible method: rm557::init() in script 557
+// Fixes bug: #10857
+static const uint16 qfg4Forest557PathfindingSignature[] = {
+	SIG_MAGICDWORD,
+	0x38, SIG_UINT16(0x0119),           // pushi 281d (point 3)
+	0x38, SIG_UINT16(0x0087),           // pushi 135d
+	0x38, SIG_UINT16(0x013f),           // pushi 319d (point 4)
+	0x38, SIG_UINT16(0x0087),           // pushi 135d
+	SIG_END
+};
+
+static const uint16 qfg4Forest557PathfindingPatch[] = {
+	PATCH_ADDTOOFFSET(+3),
+	0x38, PATCH_UINT16(0x0089),         // pushi 137d
+	PATCH_ADDTOOFFSET(+3),
+	0x38, PATCH_UINT16(0x0089),         // pushi 137d
+	PATCH_END
+};
+
 //          script, description,                                     signature                      patch
 static const SciScriptPatcherEntry qfg4Signatures[] = {
 	{  true,     0, "prevent autosave from deleting save games",   1, qfg4AutosaveSignature,         qfg4AutosavePatch },
@@ -9501,6 +9530,7 @@ static const SciScriptPatcherEntry qfg4Signatures[] = {
 	{  true,   542, "fix setLooper calls (1/2)",                   5, qfg4SetLooperSignature1,       qfg4SetLooperPatch1 },
 	{  true,   543, "fix setLooper calls (1/2)",                   5, qfg4SetLooperSignature1,       qfg4SetLooperPatch1 },
 	{  true,   545, "fix setLooper calls (1/2)",                   5, qfg4SetLooperSignature1,       qfg4SetLooperPatch1 },
+	{  true,   557, "fix forest 557 entry from east",              1, qfg4Forest557PathfindingSignature, qfg4Forest557PathfindingPatch },
 	{  true,   630, "fix great hall entry from barrel room",       1, qfg4GreatHallEntrySignature,   qfg4GreatHallEntryPatch },
 	{  true,   633, "fix stairway pathfinding",                    1, qfg4StairwayPathfindingSignature, qfg4StairwayPathfindingPatch },
 	{  true,   643, "fix iron safe's east door sending hero west", 1, qfg4SafeDoorEastSignature,     qfg4SafeDoorEastPatch },


### PR DESCRIPTION
Adds workarounds for odd detours during entry

[#10857](https://bugs.scummvm.org/ticket/10857) - Script patch
````
// When entering forest room 557 from the east (563), hero is supposed to move
// only a short distance into the room. ScummVM's pathfinding sends hero off
// course, to the middle of the room and back.
//
// There's an unwalkable stream in the SE corner, and hero's coords were within
// its polygon. We lower the top two points to keep hero on the outside.
````
Side note: Hand decompiled code for the forest::init() is attached there, in case in case anyone is curious about random encounters and pre-combat setup. It's shared across all the forest rooms.

&nbsp;

[#10858](https://bugs.scummvm.org/ticket/10858) - AStar() workaround

ScummVM's pathfinding has a penalty that discourages travel to vertices on a screen edge. 
QFG1VGA already had a boolean to exempt one room.
I reformatted it in a way that can add additional rooms.
````
// WORKAROUND: This check is needed in SCI1.1 games, such as LB2. Until our
// algorithm matches better what SSCI is doing, we exempt certain rooms where
// the check fails.
bool penaltyWorkaround =
	// QFG1VGA room 81 - Hero gets stuck when walking to the SE corner (bug #6140).
	(g_sci->getGameId() == GID_QFG1VGA && g_sci->getEngineState()->currentRoomNumber() == 81) ||
#ifdef ENABLE_SCI32
	// QFG4 room 563 - Hero zig-zags into the room (bug #10858).
	// Entering from the south (564) off-screen behind an obstacle, hero
	// fails to turn at a point on the screen edge, passes the poly's corner,
	// then approaches the destination from deeper in the room.
	(g_sci->getGameId() == GID_QFG4 && g_sci->getEngineState()->currentRoomNumber() == 563) ||
#endif
	false;

if (s->pointOnScreenBorder(vertex->v) && !penaltyWorkaround)
	new_dist += 10000;
````

&nbsp;

Both tickets have images of the polygons and hero's start/end coords.