### PR TITLE
SCI32: Fix QFG4 forest 580 pathfinding

### DIFF
--- a/engines/sci/engine/kpathing.cpp
+++ b/engines/sci/engine/kpathing.cpp
@@ -1419,6 +1419,10 @@ static void AStar(PathfindingState *s) {
 				// fails to turn at a point on the screen edge, passes the poly's corner,
 				// then approaches the destination from deeper in the room.
 				(g_sci->getGameId() == GID_QFG4 && g_sci->getEngineState()->currentRoomNumber() == 563) ||
+
+				// QFG4 room 580 - Hero zig-zags into the room (bug #10870).
+				// Entering from the south (581) off-screen behind an obstacle, as above.
+				(g_sci->getGameId() == GID_QFG4 && g_sci->getEngineState()->currentRoomNumber() == 580) ||
 #endif
 				false;
 


### PR DESCRIPTION
Adds a penalty workaround for room 580 entry from the south, bug [#10870](https://bugs.scummvm.org/ticket/10870)

The ticket has an image of the polygon and hero's start/end coords.