### PR TITLE
KYRA: (EOB) - on touchscreens, swap left and right licks in active item slots

### DIFF
--- a/engines/kyra/gui_eob.cpp
+++ b/engines/kyra/gui_eob.cpp
@@ -32,6 +32,7 @@
 #include "backends/keymapper/keymapper.h"
 #include "common/system.h"
 #include "common/savefile.h"
+#include "common/config-manager.h"
 #include "graphics/scaler.h"
 
 namespace Kyra {
@@ -873,10 +874,21 @@ int EoBCoreEngine::clickedWeaponSlot(Button *button) {
 	static const uint8 sY[] = { 27, 27, 79, 79, 131, 131 };
 	int slot = sY[button->arg] > _mouseY ? 0 : 1;
 
-	if ((_gui->_flagsMouseLeft & 0x7F) == 1)
+	bool useItem = (_gui->_flagsMouseLeft & 0x7F) != 1;
+	// Do not swap buttons if there's an item held by mouse. Then we probably 
+	// want to put it in hand, not to attack with that hand.
+	bool itemInMouse = _itemInHand != 0;
+	if (??? && !itemInMouse) {
+		// Otherwise, whenever I fight, I end up taking swords 
+		// from my characters’ hands instead of hitting enemies with them.
+		useItem = !useItem;
+	}
+
+	if (useItem) {
 		gui_processWeaponSlotClickLeft(button->arg, slot);
-	else
+	} else {
 		gui_processWeaponSlotClickRight(button->arg, slot);
+	}
 
 	return 1;
 }


### PR DESCRIPTION
Using in-hand item, e.g. sword (now a single tap) is a much more frequent action than removing them (now a 2-finger right-click emulation).

Otherwise, whenever I fight, I end up taking swords from my characters’ hands instead of hitting enemies with them.

I find that I'm not the only one to have [problems playing EoB on touchscreens](https://forums.scummvm.org/viewtopic.php?f=17&t=14042&p=86826#p86826).

Probably this needs a documentation update too?
Criticism is welcome.