### PR TITLE
SCI: Fix debugger bp_action help message

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -4013,7 +4013,7 @@ bool Console::cmdBreakpointAction(int argc, const char **argv) {
 
 	if (usage) {
 		debugPrintf("Change the action for the breakpoint with the specified index.\n");
-		debugPrintf("Usage: %s <breakpoint index> break|log|bt|inspect|none\n", argv[0]);
+		debugPrintf("Usage: %s <breakpoint index> break|log|bt|inspect|ignore\n", argv[0]);
 		debugPrintf("<index> * will process all breakpoints\n");
 		debugPrintf("Actions: break  : break into debugger\n");
 		debugPrintf("         log    : log without breaking\n");


### PR DESCRIPTION
Fixes the help for bp_action: 'none' arg should be 'ignore'
&nbsp;

[Source](https://github.com/scummvm/scummvm/blob/95b53f3737262929fd5bb87b3949e3acd82884a2/engines/sci/console.cpp#L4015): console.cpp - Console::cmdBreakpointAction()
````
Usage: %s <breakpoint index> break|log|bt|inspect|none
                                                  ^^^^
````

[Source](https://github.com/scummvm/scummvm/blob/95b53f3737262929fd5bb87b3949e3acd82884a2/engines/sci/console.cpp#L3983): console.cpp - stringToBreakpointAction()
````
if (str == "break")
	action = BREAK_BREAK;
else if (str == "log")
	action = BREAK_LOG;
else if (str == "bt")
	action = BREAK_BACKTRACE;
else if (str == "inspect")
	action = BREAK_INSPECT;
else if (str == "ignore")
	action = BREAK_NONE;
````
