### PR TITLE
ZVISION: Boost volume for MPEG cutscenes

### DIFF
--- a/audio/decoders/ac3.cpp
+++ b/audio/decoders/ac3.cpp
@@ -67,10 +67,7 @@ private:
 };
 
 AC3Stream::AC3Stream(double decibel = 0.0) : _a52State(0), _frameSize(0), _inBufPtr(0), _flags(0), _sampleRate(0) {
-	if (decibel != 0.0)
-		_audioGain = pow(2, decibel / 6);
-	else
-		_audioGain = 1.0;
+	_audioGain = pow(2, decibel / 6);
 }
 
 AC3Stream::~AC3Stream() {

--- a/audio/decoders/ac3.h
+++ b/audio/decoders/ac3.h
@@ -41,7 +41,7 @@ class PacketizedAudioStream;
  * @param firstPacket  The stream containing the first packet of data
  * @return             A new PacketizedAudioStream, or NULL on error
  */
-PacketizedAudioStream *makeAC3Stream(Common::SeekableReadStream &firstPacket);
+PacketizedAudioStream *makeAC3Stream(Common::SeekableReadStream &firstPacket, double decibel = 0.0);
 
 } // End of namespace Audio
 

--- a/engines/zvision/video/video.cpp
+++ b/engines/zvision/video/video.cpp
@@ -50,96 +50,7 @@ Video::VideoDecoder *ZVision::loadAnimation(const Common::String &fileName) {
 		animation = new ZorkAVIDecoder();
 #if defined(USE_MPEG2) && defined(USE_A52)
 	else if (tmpFileName.hasSuffix(".vob")) {
-		// For some reason, we get much lower volume in the hi-res
-		// videos than in the low-res ones. So we artificially boost
-		// the volume here. This is an approximation, but I've tried
-		// to match the old volumes reasonably well.
-		//
-		// Some of these will cause audio clipping. Hopefully not
-		// enough to be noticeable.
-		double amplification = 0.0;
-		if (tmpFileName == "em00d011.vob") {
-			// The finale.
-			amplification = 10.0;
-		} else if (tmpFileName == "em00d021.vob") {
-			// Jack's escape and arrival at Flathead Mesa.
-			amplification = 9.0;
-		} else if (tmpFileName == "em00d032.vob") {
-			// The Grand Inquisitor's speech.
-			amplification = 11.0;
-		} else if (tmpFileName == "em00d122.vob") {
-			// Jack orders you to the radio tower.
-			amplification = 17.0;
-		} else if (tmpFileName == "em3ed012.vob") {
-			// The Grand Inquisitor gets the Coconut of Quendor.
-			amplification = 12.0;
-		} else if (tmpFileName == "g000d101.vob") {
-			// Griff gets captured.
-			amplification = 11.0;
-		} else if (tmpFileName == "g000d111.vob") {
-			// Brog gets totemized. The music seems to be mixed
-			// much softer in this than in the low-resolution
-			// version.
-			amplification = 12.0;
-		} else if (tmpFileName == "g000d122.vob") {
-			// Lucy gets captured.
-			amplification = 14.0;
-		} else if (tmpFileName == "g000d302.vob") {
-			// The Grand Inquisitor visits Jack in his cell.
-			amplification = 13.0;
-		} else if (tmpFileName == "g000d312.vob") {
-			// You get captured.
-			amplification = 14.0;
-		} else if (tmpFileName == "g000d411.vob") {
-			// Propaganda On Parade. No need to make it as loud as
-			// the low-resolution version.
-			amplification = 11.0;
-		} else if (tmpFileName == "pe1ed012.vob") {
-			// Jack lets you in with the lantern.
-			amplification = 14.0;
-		} else if (tmpFileName.hasPrefix("pe1ed")) {
-			// Jack answers the door. Several different ways.
-			amplification = 17.0;
-		} else if (tmpFileName == "pe5ed052.vob") {
-			// You get killed by the guards
-			amplification = 12.0;
-		} else if (tmpFileName == "pe6ed012.vob") {
-			// Jack gets captured by the guards
-			amplification = 17.0;
-		} else if (tmpFileName == "pp1ed022.vob") {
-			// Jack examines the lantern
-			amplification = 10.0;
-		} else if (tmpFileName == "qb1ed012.vob") {
-			// Lucy gets invited to the back room
-			amplification = 17.0;
-		} else if (tmpFileName.hasPrefix("qe1ed")) {
-			// Floyd answers the door. Several different ways.
-			amplification = 17.0;
-		} else if (tmpFileName == "qs1ed011.vob") {
-			// Jack explains the rules of the game.
-			amplification = 16.0;
-		} else if (tmpFileName == "qs1ed021.vob") {
-			// Jack loses the game.
-			amplification = 14.0;
-		} else if (tmpFileName == "uc1gd012.vob") {
-			// Y'Gael appears.
-			amplification = 12.0;
-		} else if (tmpFileName == "ue1ud012.vob") {
-			// Jack gets totemized... or what?
-			amplification = 12.0;
-		} else if (tmpFileName == "ue2qd012.vob") {
-			// Jack agrees to totemization.
-			amplification = 10.0;
-		} else if (tmpFileName == "g000d981.vob") {
-			// The Enterprise logo. Has no low-res version. Its
-			// volume is louder than the other logo animations.
-			amplification = 6.2;
-		} else if (tmpFileName.hasPrefix("g000d")) {
-			// The Dolby Digital and Activision logos. They have no
-			// low-res versions, but I've used the low-resolution
-			// Activision logo (slightly different) as reference.
-			amplification = 8.5;
-		}
+ 		double amplification = getVobAmplification(tmpFileName);
 		animation = new Video::MPEGPSDecoder(amplification);
 	}
 #endif
@@ -233,6 +144,99 @@ void ZVision::playVideo(Video::VideoDecoder &vid, const Common::Rect &destRect, 
 		scaled->free();
 		delete scaled;
 	}
+}
+
+double ZVision::getVobAmplification(Common::String fileName) const {
+	// For some reason, we get much lower volume in the hi-res videos than
+	// in the low-res ones. So we artificially boost the volume. This is an
+	// approximation, but I've tried to match the old volumes reasonably
+	// well.
+	//
+	// Some of these will cause audio clipping. Hopefully not enough to be
+	// noticeable.
+	double amplification = 0.0;
+	if (fileName == "em00d011.vob") {
+		// The finale.
+		amplification = 10.0;
+	} else if (fileName == "em00d021.vob") {
+		// Jack's escape and arrival at Flathead Mesa.
+		amplification = 9.0;
+	} else if (fileName == "em00d032.vob") {
+		// The Grand Inquisitor's speech.
+		amplification = 11.0;
+	} else if (fileName == "em00d122.vob") {
+		// Jack orders you to the radio tower.
+		amplification = 17.0;
+	} else if (fileName == "em3ed012.vob") {
+		// The Grand Inquisitor gets the Coconut of Quendor.
+		amplification = 12.0;
+	} else if (fileName == "g000d101.vob") {
+		// Griff gets captured.
+		amplification = 11.0;
+	} else if (fileName == "g000d111.vob") {
+		// Brog gets totemized. The music seems to be mixed much softer
+		// in this than in the low-resolution version.
+		amplification = 12.0;
+	} else if (fileName == "g000d122.vob") {
+		// Lucy gets captured.
+		amplification = 14.0;
+	} else if (fileName == "g000d302.vob") {
+		// The Grand Inquisitor visits Jack in his cell.
+		amplification = 13.0;
+	} else if (fileName == "g000d312.vob") {
+		// You get captured.
+		amplification = 14.0;
+	} else if (fileName == "g000d411.vob") {
+		// Propaganda On Parade. No need to make it as loud as the
+		// low-resolution version.
+		amplification = 11.0;
+	} else if (fileName == "pe1ed012.vob") {
+		// Jack lets you in with the lantern.
+		amplification = 14.0;
+	} else if (fileName.hasPrefix("pe1ed")) {
+		// Jack answers the door. Several different ways.
+		amplification = 17.0;
+	} else if (fileName == "pe5ed052.vob") {
+		// You get killed by the guards
+		amplification = 12.0;
+	} else if (fileName == "pe6ed012.vob") {
+		// Jack gets captured by the guards
+		amplification = 17.0;
+	} else if (fileName == "pp1ed022.vob") {
+		// Jack examines the lantern
+		amplification = 10.0;
+	} else if (fileName == "qb1ed012.vob") {
+		// Lucy gets invited to the back room
+		amplification = 17.0;
+	} else if (fileName.hasPrefix("qe1ed")) {
+		// Floyd answers the door. Several different ways.
+		amplification = 17.0;
+	} else if (fileName == "qs1ed011.vob") {
+		// Jack explains the rules of the game.
+		amplification = 16.0;
+	} else if (fileName == "qs1ed021.vob") {
+		// Jack loses the game.
+		amplification = 14.0;
+	} else if (fileName == "uc1gd012.vob") {
+		// Y'Gael appears.
+		amplification = 12.0;
+	} else if (fileName == "ue1ud012.vob") {
+		// Jack gets totemized... or what?
+		amplification = 12.0;
+	} else if (fileName == "ue2qd012.vob") {
+		// Jack agrees to totemization.
+		amplification = 10.0;
+	} else if (fileName == "g000d981.vob") {
+		// The Enterprise logo. Has no low-res version. Its volume is
+		// louder than the other logo animations.
+		amplification = 6.2;
+	} else if (fileName.hasPrefix("g000d")) {
+		// The Dolby Digital and Activision logos. They have no low-res
+		// versions, but I've used the low-resolution Activision logo
+		// (slightly different) as reference.
+		amplification = 8.5;
+	}
+	return amplification;
 }
 
 } // End of namespace ZVision

--- a/engines/zvision/video/video.cpp
+++ b/engines/zvision/video/video.cpp
@@ -49,8 +49,99 @@ Video::VideoDecoder *ZVision::loadAnimation(const Common::String &fileName) {
 	else if (tmpFileName.hasSuffix(".avi"))
 		animation = new ZorkAVIDecoder();
 #if defined(USE_MPEG2) && defined(USE_A52)
-	else if (tmpFileName.hasSuffix(".vob"))
-		animation = new Video::MPEGPSDecoder();
+	else if (tmpFileName.hasSuffix(".vob")) {
+		// For some reason, we get much lower volume in the hi-res
+		// videos than in the low-res ones. So we artificially boost
+		// the volume here. This is an approximation, but I've tried
+		// to match the old volumes reasonably well.
+		//
+		// Some of these will cause audio clipping. Hopefully not
+		// enough to be noticeable.
+		double amplification = 0.0;
+		if (tmpFileName == "em00d011.vob") {
+			// The finale.
+			amplification = 10.0;
+		} else if (tmpFileName == "em00d021.vob") {
+			// Jack's escape and arrival at Flathead Mesa.
+			amplification = 9.0;
+		} else if (tmpFileName == "em00d032.vob") {
+			// The Grand Inquisitor's speech.
+			amplification = 11.0;
+		} else if (tmpFileName == "em00d122.vob") {
+			// Jack orders you to the radio tower.
+			amplification = 17.0;
+		} else if (tmpFileName == "em3ed012.vob") {
+			// The Grand Inquisitor gets the Coconut of Quendor.
+			amplification = 12.0;
+		} else if (tmpFileName == "g000d101.vob") {
+			// Griff gets captured.
+			amplification = 11.0;
+		} else if (tmpFileName == "g000d111.vob") {
+			// Brog gets totemized. The music seems to be mixed
+			// much softer in this than in the low-resolution
+			// version.
+			amplification = 12.0;
+		} else if (tmpFileName == "g000d122.vob") {
+			// Lucy gets captured.
+			amplification = 14.0;
+		} else if (tmpFileName == "g000d302.vob") {
+			// The Grand Inquisitor visits Jack in his cell.
+			amplification = 13.0;
+		} else if (tmpFileName == "g000d312.vob") {
+			// You get captured.
+			amplification = 14.0;
+		} else if (tmpFileName == "g000d411.vob") {
+			// Propaganda On Parade. No need to make it as loud as
+			// the low-resolution version.
+			amplification = 11.0;
+		} else if (tmpFileName == "pe1ed012.vob") {
+			// Jack lets you in with the lantern.
+			amplification = 14.0;
+		} else if (tmpFileName.hasPrefix("pe1ed")) {
+			// Jack answers the door. Several different ways.
+			amplification = 17.0;
+		} else if (tmpFileName == "pe5ed052.vob") {
+			// You get killed by the guards
+			amplification = 12.0;
+		} else if (tmpFileName == "pe6ed012.vob") {
+			// Jack gets captured by the guards
+			amplification = 17.0;
+		} else if (tmpFileName == "pp1ed022.vob") {
+			// Jack examines the lantern
+			amplification = 10.0;
+		} else if (tmpFileName == "qb1ed012.vob") {
+			// Lucy gets invited to the back room
+			amplification = 17.0;
+		} else if (tmpFileName.hasPrefix("qe1ed")) {
+			// Floyd answers the door. Several different ways.
+			amplification = 17.0;
+		} else if (tmpFileName == "qs1ed011.vob") {
+			// Jack explains the rules of the game.
+			amplification = 16.0;
+		} else if (tmpFileName == "qs1ed021.vob") {
+			// Jack loses the game.
+			amplification = 14.0;
+		} else if (tmpFileName == "uc1gd012.vob") {
+			// Y'Gael appears.
+			amplification = 12.0;
+		} else if (tmpFileName == "ue1ud012.vob") {
+			// Jack gets totemized... or what?
+			amplification = 12.0;
+		} else if (tmpFileName == "ue2qd012.vob") {
+			// Jack agrees to totemization.
+			amplification = 10.0;
+		} else if (tmpFileName == "g000d981.vob") {
+			// The Enterprise logo. Has no low-res version. Its
+			// volume is louder than the other logo animations.
+			amplification = 6.2;
+		} else if (tmpFileName.hasPrefix("g000d")) {
+			// The Dolby Digital and Activision logos. They have no
+			// low-res versions, but I've used the low-resolution
+			// Activision logo (slightly different) as reference.
+			amplification = 8.5;
+		}
+		animation = new Video::MPEGPSDecoder(amplification);
+	}
 #endif
 	else
 		error("Unknown suffix for animation %s", fileName.c_str());

--- a/engines/zvision/zvision.h
+++ b/engines/zvision/zvision.h
@@ -264,6 +264,8 @@ private:
 	void pushKeyToCheatBuf(uint8 key);
 	bool checkCode(const char *code);
 	uint8 getBufferedKey(uint8 pos);
+
+	double getVobAmplification(Common::String fileName) const;
 };
 
 } // End of namespace ZVision

--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -50,7 +50,8 @@ enum {
 	kStartCodePrivateStream2 = 0x1BF
 };
 
-MPEGPSDecoder::MPEGPSDecoder() {
+MPEGPSDecoder::MPEGPSDecoder(double decibel) {
+	_decibel = decibel;
 	_demuxer = new MPEGPSDemuxer();
 }
 
@@ -104,7 +105,7 @@ MPEGPSDecoder::MPEGStream *MPEGPSDecoder::getStream(uint32 startCode, Common::Se
 
 #ifdef USE_A52
 				handled = true;
-				AC3AudioTrack *ac3Track = new AC3AudioTrack(*packet, getSoundType());
+				AC3AudioTrack *ac3Track = new AC3AudioTrack(*packet, _decibel, getSoundType());
 				stream = ac3Track;
 				_streamMap[startCode] = ac3Track;
 				addTrack(ac3Track);
@@ -704,9 +705,9 @@ Audio::AudioStream *MPEGPSDecoder::MPEGAudioTrack::getAudioStream() const {
 
 #ifdef USE_A52
 
-MPEGPSDecoder::AC3AudioTrack::AC3AudioTrack(Common::SeekableReadStream &firstPacket, Audio::Mixer::SoundType soundType) :
+MPEGPSDecoder::AC3AudioTrack::AC3AudioTrack(Common::SeekableReadStream &firstPacket, double decibel, Audio::Mixer::SoundType soundType) :
 		AudioTrack(soundType) {
-	_audStream = Audio::makeAC3Stream(firstPacket);
+	_audStream = Audio::makeAC3Stream(firstPacket, decibel);
 	if (!_audStream)
 		error("Could not create AC-3 stream");
 }

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -54,7 +54,7 @@ namespace Video {
  */
 class MPEGPSDecoder : public VideoDecoder {
 public:
-	MPEGPSDecoder();
+	MPEGPSDecoder(double decibel = 0.0);
 	virtual ~MPEGPSDecoder();
 
 	bool loadStream(Common::SeekableReadStream *stream);
@@ -166,7 +166,7 @@ private:
 #ifdef USE_A52
 	class AC3AudioTrack : public AudioTrack, public MPEGStream {
 	public:
-		AC3AudioTrack(Common::SeekableReadStream &firstPacket, Audio::Mixer::SoundType soundType);
+		AC3AudioTrack(Common::SeekableReadStream &firstPacket, double decibel, Audio::Mixer::SoundType soundType);
 		~AC3AudioTrack();
 
 		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts);
@@ -199,6 +199,8 @@ private:
 	// A map from stream types to stream handlers
 	typedef Common::HashMap<int, MPEGStream *> StreamMap;
 	StreamMap _streamMap;
+
+	double _decibel;
 };
 
 } // End of namespace Video


### PR DESCRIPTION
The high-resolution videos play back at much lower volume than the original ones. This adds hard-coded values for how much to amplify each cutscene. It's all done by ear, and it does introduce some
clipping, but I think it should be acceptable. 

Of course, it could also be a problem with the audio decoder, so this may be the wrong approach entirely.