### PR TITLE
SCI: Cleanup for all script patches

### DIFF
--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -952,14 +952,14 @@ static const uint16 hoyle5PatchSpinLoop[] = {
 // This is the same issue as with LSL6 hires.
 static const uint16 hoyle5SetScaleSignature[] = {
 	SIG_MAGICDWORD,
-	0x38, SIG_SELECTOR16(setScale), // pushi $14b (setScale)
+	0x38, SIG_SELECTOR16(setScale), // pushi setScale ($14b)
 	0x38, SIG_UINT16(0x05),         // pushi 5
-	0x51, 0x2c,                     // class 2c (Scaler)
+	0x51, 0x2c,                     // class Scaler
 	SIG_END
 };
 
 static const uint16 hoyle5PatchSetScale[] = {
-	0x38, PATCH_SELECTOR16(setScaler), // pushi $14f (setScaler)
+	0x38, PATCH_SELECTOR16(setScaler), // pushi setScaler ($14f)
 	PATCH_END
 };
 

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -2155,13 +2155,13 @@ static const uint16 gk1EgoPhonePositionSignature[] = {
 	SIG_MAGICDWORD,
 	0x39, 0x68,                         // pushi 68 [ x: 104 ]
 	0x39, 0x7e,                         // pushi 7e [ y: 126 ]
-	SIG_END,
+	SIG_END
 };
 
 static const uint16 gk1EgoPhonePositionPatch[] = {
 	0x39, 0x6b,                         // pushi 6b [ x: 107 ]
 	0x39, 0x7c,                         // pushi 7c [ y: 124 ]
-	PATCH_END,
+	PATCH_END
 };
 
 //          script, description,                                      signature                         patch
@@ -6854,16 +6854,17 @@ static const SciScriptPatcherEntry qfg1egaSignatures[] = {
 //  script 215 of qfg1vga pointBox::doit actually processes button-presses
 //   during fighting with monsters. It strangely also calls kGetEvent. Because
 //   the main User::doit also calls kGetEvent it's pure luck, where the event
-//   will hit. It's the same issue as in freddy pharkas and if you turn dos-box
+//   will hit. It's the same issue as in freddy pharkas and if you turn DOSBox
 //   to max cycles, sometimes clicks also won't get registered. Strangely it's
 //   not nearly as bad as in our sci, but these differences may be caused by
 //   timing.
 //   We just reuse the active event, thus removing the duplicate kGetEvent call.
 // Applies to at least: English floppy
 // Responsible method: pointBox::doit
+// Fixes bug: #5038
 static const uint16 qfg1vgaSignatureFightEvents[] = {
 	0x39, SIG_MAGICDWORD,
-	SIG_SELECTOR8(new),                 // pushi "new"
+	SIG_SELECTOR8(new),                 // pushi new
 	0x76,                               // push0
 	0x51, 0x07,                         // class Event
 	0x4a, 0x04,                         // send 04 - call Event::new
@@ -6883,7 +6884,7 @@ static const uint16 qfg1vgaSignatureFightEvents[] = {
 };
 
 static const uint16 qfg1vgaPatchFightEvents[] = {
-	0x38, PATCH_SELECTOR16(curEvent), // pushi 15a (selector curEvent)
+	0x38, PATCH_SELECTOR16(curEvent), // pushi curEvent (15a)
 	0x76,                            // push0
 	0x81, 0x50,                      // lag global[50]
 	0x4a, 0x04,                      // send 04 - read User::curEvent -> needs one byte more than previous code
@@ -6914,7 +6915,7 @@ static const uint16 qfg1vgaPatchFightEvents[] = {
 static const uint16 qfg1vgaSignatureTempSpace[] = {
 	SIG_MAGICDWORD,
 	0x3f, 0xba,                         // link 0xba
-	0x87, 0x00,                         // lap 0
+	0x87, 0x00,                         // lap param[0]
 	SIG_END
 };
 
@@ -6983,7 +6984,7 @@ static const uint16 qfg1vgaPatchMoveToCrusher[] = {
 //
 // Applies to: PC Floppy
 // Responsible method: rm331:doit
-// Fixes bug #10826
+// Fixes bug: #10826
 static const uint16 qfg1vgaSignatureCrusherCardGame[] = {
 	SIG_MAGICDWORD,
 	0x63, 0x12,                         // pToa script
@@ -6991,12 +6992,12 @@ static const uint16 qfg1vgaSignatureCrusherCardGame[] = {
 	0x33, 0x28,                         // jmp 28 [ card table location tests ]
 	0x38, SIG_SELECTOR16(script),       // pushi script
 	0x76,                               // push0
-	0x81, 0x00,                         // lag 00
+	0x81, 0x00,                         // lag global[0]
 	0x4a, 0x04,                         // send 4 [ ego:script? ]
 	0x31, 0x04,                         // bnt 04
 	0x35, 0x00,                         // ldi 00 [ does nothing ]
 	0x33, 0x1a,                         // jmp 1a [ card table location tests ]
-	SIG_ADDTOOFFSET(0x71),
+	SIG_ADDTOOFFSET(+113),
 	0x39, SIG_SELECTOR8(doit),          // pushi doit [ pc version only ]
 	SIG_END
 };
@@ -7004,7 +7005,7 @@ static const uint16 qfg1vgaSignatureCrusherCardGame[] = {
 static const uint16 qfg1vgaPatchCrusherCardGame[] = {
 	0x38, PATCH_SELECTOR16(script),     // pushi script
 	0x76,                               // push0
-	0x81, 0x00,                         // lag 00
+	0x81, 0x00,                         // lag global[0]
 	0x4a, 0x04,                         // send 4 [ ego:script? ]
 	0x31, 0x06,                         // bnt 06
 	0x74, PATCH_UINT16(0x0ee4),         // lofss cardScript
@@ -7049,13 +7050,13 @@ static const uint16 qfg1vgaPatchMoveToCastleGate[] = {
 // The code treats both monster types the same.
 // Applies to at least: English floppy
 // Responsible method: smallMonster::doVerb
-// Fixes bug #6249
+// Fixes bug: #6249
 static const uint16 qfg1vgaSignatureCheetaurDescription[] = {
 	SIG_MAGICDWORD,
 	0x34, SIG_UINT16(0x01b8),           // ldi 01b8
 	0x1a,                               // eq?
 	0x31, 0x16,                         // bnt 16
-	0x38, SIG_SELECTOR16(say),          // pushi 0127h (selector "say")
+	0x38, SIG_SELECTOR16(say),          // pushi say (0127h)
 	0x39, 0x06,                         // pushi 06
 	0x39, 0x03,                         // pushi 03
 	0x78,                               // push1
@@ -7072,36 +7073,36 @@ static const uint16 qfg1vgaPatchCheetaurDescription[] = {
 // In the "funny" room (Yorick's room) in QfG1 VGA, pulling the chain and
 //  then pressing the button on the right side of the room results in
 //  a broken game. This also happens in SSCI.
-// Problem is that the Sierra programmers forgot to disable the door, that
+// Problem is that the Sierra programmers forgot to disable the door that
 //  gets opened by pulling the chain. So when ego falls down and then
 //  rolls through the door, one method thinks that the player walks through
 //  it and acts that way and the other method is still doing the roll animation.
-// Local 5 of that room is a timer, that closes the door (object door11).
-// Setting it to 1 during happyFace::changeState(0) stops door11::doit from
-//  calling goTo6::init, so the whole issue is stopped from happening.
+// The timer that closes the door (door11) is local[5]. Setting it to 1 during
+//  happyFace::changeState(0) stops door11::doit from calling goTo6::init, so
+//  the whole issue is stopped from happening.
 //
 // Applies to at least: English floppy
 // Responsible method: happyFace::changeState, door11::doit
-// Fixes bug #6181
+// Fixes bug: #6181
 static const uint16 qfg1vgaSignatureFunnyRoomFix[] = {
 	0x65, 0x14,                         // aTop 14 (state)
 	0x36,                               // push
 	0x3c,                               // dup
 	0x35, 0x00,                         // ldi 00
 	0x1a,                               // eq?
-	0x30, SIG_UINT16(0x0025),           // bnt 0025 [-> next state]
+	0x30, SIG_UINT16(0x0025),           // bnt 0025 [next state]
 	SIG_MAGICDWORD,
 	0x35, 0x01,                         // ldi 01
-	0xa3, 0x4e,                         // sal 4e
+	0xa3, 0x4e,                         // sal local[4e]
 	SIG_END
 };
 
 static const uint16 qfg1vgaPatchFunnyRoomFix[] = {
 	PATCH_ADDTOOFFSET(+3),
-	0x2e, PATCH_UINT16(0x0029),         // bt 0029 [-> next state] - saves 4 bytes
+	0x2e, PATCH_UINT16(0x0029),         // bt 0029 [next state] - saves 4 bytes
 	0x35, 0x01,                         // ldi 01
-	0xa3, 0x4e,                         // sal 4e
-	0xa3, 0x05,                         // sal 05 (sets local 5 to 1)
+	0xa3, 0x4e,                         // sal local[4e]
+	0xa3, 0x05,                         // sal local[5] (set to 1)
 	0xa3, 0x05,                         // and again to make absolutely sure (actually to waste 2 bytes)
 	PATCH_END
 };
@@ -7117,18 +7118,18 @@ static const uint16 qfg1vgaPatchFunnyRoomFix[] = {
 //
 // Applies to at least: English floppy
 // Responsible method: cueItScript::changeState
-// Fixes bug #6706
+// Fixes bug: #6706
 static const uint16 qfg1vgaSignatureHealerHutNoDelay[] = {
 	0x65, 0x14,                         // aTop 14 (state)
 	0x36,                               // push
 	0x3c,                               // dup
 	0x35, 0x00,                         // ldi 00
 	0x1a,                               // eq?
-	0x31, 0x07,                         // bnt 07 [-> next state]
+	0x31, 0x07,                         // bnt 07 [next state]
 	SIG_MAGICDWORD,
 	0x35, 0x3c,                         // ldi 3c (60 ticks)
 	0x65, 0x20,                         // aTop ticks
-	0x32,                               // jmp [-> end of method]
+	0x32,                               // jmp [end of method]
 	SIG_END
 };
 
@@ -7138,13 +7139,14 @@ static const uint16 qfg1vgaPatchHealerHutNoDelay[] = {
 	PATCH_END
 };
 
-// When following the white stag, you can actually enter the 2nd room from the mushroom/fairy location,
-//  which results in ego entering from the top. When you then throw a dagger at the stag, one animation
-//  frame will stay on screen, because of a script bug.
+// When following the white stag, you can actually enter the 2nd room from the
+//  mushroom/fairy location, which results in ego entering from the top. When
+//  you then throw a dagger at the stag, one animation frame will stay on
+//  screen, because of a script bug.
 //
 // Applies to at least: English floppy, Mac floppy
 // Responsible method: stagHurt::changeState
-// Fixes bug #6135
+// Fixes bug: #6135
 static const uint16 qfg1vgaSignatureWhiteStagDagger[] = {
 	0x87, 0x01,                         // lap param[1]
 	0x65, 0x14,                         // aTop state
@@ -7154,9 +7156,9 @@ static const uint16 qfg1vgaSignatureWhiteStagDagger[] = {
 	0x1a,                               // eq?
 	0x31, 0x16,                         // bnt [next parameter check]
 	0x76,                               // push0
-	0x45, 0x02, 0x00,                   // callb export 2 from script 0, 0
+	0x45, 0x02, 0x00,                   // callb [export 2 of script 0], 0
 	SIG_MAGICDWORD,
-	0x38, SIG_SELECTOR16(say),          // pushi 0127h (selector "say")
+	0x38, SIG_SELECTOR16(say),          // pushi say (0127h)
 	0x39, 0x05,                         // pushi 05
 	0x39, 0x03,                         // pushi 03
 	0x39, 0x51,                         // pushi 51h
@@ -7165,11 +7167,11 @@ static const uint16 qfg1vgaSignatureWhiteStagDagger[] = {
 	0x7c,                               // pushSelf
 	0x81, 0x5b,                         // lag global[5Bh] -> qg1Messager
 	0x4a, 0x0e,                         // send 0Eh -> qg1Messager::say(3, 51h, 0, 0, stagHurt)
-	0x33, 0x12,                         // jmp -> [ret]
+	0x33, 0x12,                         // jmp [end of method]
 	0x3c,                               // dup
 	0x35, 0x01,                         // ldi 1
 	0x1a,                               // eq?
-	0x31, 0x0c,                         // bnt [ret]
+	0x31, 0x0c,                         // bnt [end of method]
 	0x38,                               // pushi...
 	SIG_ADDTOOFFSET(+11),
 	0x3a,                               // toss
@@ -7190,8 +7192,8 @@ static const uint16 qfg1vgaPatchWhiteStagDagger[] = {
 	0x31, 0x16,                         // bnt [state = 2 code]
 	// state = 1 code
 	0x76,                               // push0
-	0x45, 0x02, 0x00,                   // callb export 2 from script 0, 0
-	0x38, PATCH_SELECTOR16(say),        // pushi 0127h (selector "say")
+	0x45, 0x02, 0x00,                   // callb [export 2 of script 0], 0
+	0x38, PATCH_SELECTOR16(say),        // pushi say (0127h)
 	0x39, 0x05,                         // pushi 05
 	0x39, 0x03,                         // pushi 03
 	0x39, 0x51,                         // pushi 51h
@@ -7207,31 +7209,33 @@ static const uint16 qfg1vgaPatchWhiteStagDagger[] = {
 	PATCH_END
 };
 
-// The dagger range has a script bug that can freeze the game or cause Brutus to kill you even after you've killed him.
-// This is a bug in the original game.
+// The dagger range has a script bug that can freeze the game or cause Brutus
+// to kill hero even after Brutus dies.
 //
-// When Bruno leaves, a 300 tick countdown starts. If you kill Brutus or leave room 73 within those 300 ticks then
-// the game is left in a broken state. For the rest of the game, if you ever return to the dagger range from the
-// east or west during the first half of the day then the game will freeze or Brutus will come back to life
-// and kill you, even if you already killed him.
+// When Bruno leaves, a 300 tick countdown starts. If hero kills Brutus or
+// leaves room 73 within those 300 ticks, then the game is left in a broken
+// state. For the rest of the game, if hero ever returns to the dagger range
+// from the east or west during the first half of the day, then the game will
+// freeze or Brutus, dead or not, will kill hero.
 //
-// Special thanks, credits and kudos to sluicebox, who did a ton of research on this and even found this game bug originally.
+// Special thanks, credits and kudos to sluicebox, who did a ton of research on
+// this and even found this game bug originally.
 //
 // Applies to at least: English floppy, Mac floppy
 // Responsible method: brutusWaits::changeState
-// Fixes bug #9558
+// Fixes bug: #9558
 static const uint16 qfg1vgaSignatureBrutusScriptFreeze[] = {
 	0x78,                               // push1
-	0x38, SIG_UINT16(0x144),            // pushi 144h (324d)
-	0x45, 0x05, 0x02,                   // call export 5 of script 0
+	0x38, SIG_UINT16(0x0144),           // pushi 144h (324d)
+	0x45, 0x05, 0x02,                   // callb [export 5 of script 0], 2
 	SIG_MAGICDWORD,
-	0x34, SIG_UINT16(0x12c),            // ldi 12Ch (300d)
+	0x34, SIG_UINT16(0x012c),           // ldi 12Ch (300d)
 	0x65, 0x20,                         // aTop ticks
 	SIG_END
 };
 
 static const uint16 qfg1vgaPatchBrutusScriptFreeze[] = {
-	0x34, PATCH_UINT16(0),              // ldi 0 (waste 7 bytes)
+	0x34, PATCH_UINT16(0x0000),         // ldi 0 (waste 7 bytes)
 	0x35, 0x00,                         // ldi 0
 	0x35, 0x00,                         // ldi 0
 	PATCH_END
@@ -7244,9 +7248,9 @@ static const uint16 qfg1vgaPatchBrutusScriptFreeze[] = {
 // Method changed: speedTest::changeState
 static const uint16 qfg1vgaSignatureSpeedTest[] = {
 	0x76,                               // push0
-	0x43, 0x42, 0x00,                   // callk GetTime 0
+	0x43, 0x42, 0x00,                   // callk GetTime, 0
 	SIG_MAGICDWORD,
-	0xa3, 0x01,                         // sal 1
+	0xa3, 0x01,                         // sal local[1]
 	0x35, 0x32,                         // ldi 50
 	0x65, 0x1a,                         // aTop cycles
 	SIG_END
@@ -7272,17 +7276,17 @@ static const uint16 qfg1vgaPatchSpeedTest[] = {
 //  causes ours to fail an assertion due to constructing an invalid Rect.
 //
 // We fix both problems by not allowing antwerps south of 180 so that they
-//  remain on screen and can't block ego's exit. This is consistent with room 85
-//  where they also appear but without a southern exit. The Wander motion is
-//  only used by antwerps and the sparkles above Yorick in room 96 so it can be
-//  safely patched to enforce a southern limit. We make room for this patch by
-//  replacing Wander's calculations with their known results, since the default
-//  Wander:distance of 30 is always used, and by overwriting Wander:onTarget
-//  which no script calls and just returns zero.
+//  remain on screen and can't block ego's exit. This is consistent with
+//  room 85 where they also appear but without a southern exit. The Wander
+//  motion is only used by antwerps and the sparkles above Yorick in room 96,
+//  so it can be safely patched to enforce a southern limit. We make room for
+//  this patch by replacing Wander's calculations with their known results,
+//  since the default Wander:distance of 30 is always used, and by overwriting
+//  Wander:onTarget which no script calls and just returns zero.
 //
 // Applies to: PC Floppy, Mac Floppy
 // Responsible method: Wander:setTarget
-// Fixes bug #9564
+// Fixes bug: #9564
 static const uint16 qfg1vgaSignatureAntwerpWander[] = {
 	SIG_MAGICDWORD,
 	0x3f, 0x01,                             // link 01
@@ -7297,12 +7301,12 @@ static const uint16 qfg1vgaSignatureAntwerpWander[] = {
 	0x67, 0x30,                             // pTos distance
 	0x35, 0x02,                             // ldi 02
 	0x06,                                   // mul
-	0xa5, 0x00,                             // sat 00 [ temp0 = distance * 2 ]
+	0xa5, 0x00,                             // sat temp[0] [ distance * 2 ]
 	0x36,                                   // push
-	0x43, 0x3c, 0x04,                       // callk Random 4
+	0x43, 0x3c, 0x04,                       // callk Random, 4
 	0x04,                                   // sub
 	0x02,                                   // add
-	0x65, 0x16,                             // aTop x [ x = client:x + (distance - Random(0, temp0)) ]
+	0x65, 0x16,                             // aTop x [ x = client:x + (distance - Random(0, temp[0])) ]
 	0x76,                                   // push0
 	0x76,                                   // push0
 	0x63, 0x12,                             // pToa client
@@ -7311,11 +7315,11 @@ static const uint16 qfg1vgaSignatureAntwerpWander[] = {
 	0x67, 0x30,                             // pTos distance
 	0x7a,                                   // push2
 	0x76,                                   // push0
-	0x8d, 0x00,                             // lst 00
-	0x43, 0x3c, 0x04,                       // callk Random 4
+	0x8d, 0x00,                             // lst temp[0]
+	0x43, 0x3c, 0x04,                       // callk Random, 4
 	0x04,                                   // sub
 	0x02,                                   // add
-	0x65, 0x18,                             // aTop y [ y = client:y + (distance - Random(0, temp0)) ]
+	0x65, 0x18,                             // aTop y [ y = client:y + (distance - Random(0, temp[0])) ]
 	0x48,                                   // ret
 	0x35, 0x00,                             // ldi 00 [ start of Wander:onTarget, returns 0 and isn't called ]
 	SIG_END
@@ -7331,7 +7335,7 @@ static const uint16 qfg1vgaPatchAntwerpWander[] = {
 	0x7a,                                   // push2
 	0x76,                                   // push0
 	0x39, 0x3c,                             // pushi 3c
-	0x43, 0x3c, 0x04,                       // callk Random 4
+	0x43, 0x3c, 0x04,                       // callk Random, 4
 	0x04,                                   // sub
 	0x02,                                   // add
 	0x65, 0x16,                             // aTop x [ x = client:x + (30d - Random(0, 60d)) ]
@@ -7344,13 +7348,13 @@ static const uint16 qfg1vgaPatchAntwerpWander[] = {
 	0x7a,                                   // push2
 	0x76,                                   // push0
 	0x39, 0x3c,                             // pushi 3c
-	0x43, 0x3c, 0x04,                       // callk Random 4
+	0x43, 0x3c, 0x04,                       // callk Random, 4
 	0x04,                                   // sub
 	0x02,                                   // add
 	0x7a,                                   // push2
 	0x36,                                   // push
 	0x38, PATCH_UINT16(0x00b4),             // pushi 00b4
-	0x46, PATCH_UINT16(0x03e7),             // calle proc999_2 4 [ Min ]
+	0x46, PATCH_UINT16(0x03e7),             // calle [export 2 of script 999], 4 [ Min ]
 	      PATCH_UINT16(0x0002), 0x04,
 	0x65, 0x18,                             // aTop y [ y = Min(client:y + (30d - Random(0, 60d))), 180d) ]
 	PATCH_END
@@ -7359,20 +7363,21 @@ static const uint16 qfg1vgaPatchAntwerpWander[] = {
 // QFG1VGA Mac disables all controls when the antwerp falls in room 78, killing
 //  the player by not allowing them to defend themselves.
 //
-// The antwerp falls in rooms 78 and 85 and the only way to survive is to hold
+// The antwerp falls in rooms 78 and 85, and the only way to survive is to hold
 //  up a weapon. These two antwerp scripts were identical in the PC version and
 //  enabled all menu icons even though most of them couldn't really be used.
-//  Sierra attempted to improve this in Mac by only enabling the inventory icons
-//  but instead disabled everything in room 78 by not calling the enable procedure.
+//  Sierra attempted to improve this in Mac by only enabling the inventory
+//  icons but instead disabled everything in room 78 by not calling the enable
+//  procedure.
 //
 // We fix this by calling the enable procedure like the script in room 85 does.
 //
 // Applies to: Mac Floppy
 // Responsible method: antwerped:changeState(1)
-// Fixes bug #10856
+// Fixes bug: #10856
 static const uint16 qfg1vgaSignatureMacAntwerpControls[] = {
 	0x30, SIG_UINT16(0x0033),               // bnt 0033 [ state 1 ]
-	SIG_ADDTOOFFSET(+0x30),
+	SIG_ADDTOOFFSET(+48),
 	SIG_MAGICDWORD,
 	0x32, SIG_UINT16(0x014e),               // jmp 014e [ end of method ]
 	0x3c,                                   // dup
@@ -7385,13 +7390,13 @@ static const uint16 qfg1vgaSignatureMacAntwerpControls[] = {
 
 static const uint16 qfg1vgaPatchMacAntwerpControls[] = {
 	0x30, PATCH_UINT16(0x0030),             // bnt 0030 [ state 1 ]
-	PATCH_ADDTOOFFSET(+0x30),
+	PATCH_ADDTOOFFSET(+48),
 	0x3c,                                   // dup
 	0x35, 0x01,                             // ldi 01
 	0x1a,                                   // eq?
 	0x31, 0x37,                             // bnt 37 [ state 2 ]
 	0x76,                                   // push0
-	0x45, 0x03, 0x00,                       // callb proc0_3 [ enable all input ]
+	0x45, 0x03, 0x00,                       // callb [export 3 of script 0], 00 [ enable all input ]
 	PATCH_END
 };
 

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -10530,10 +10530,10 @@ static const uint16 ramaBenchmarkPatch[] = {
 // own numbers, as it tries to do here in `SaveManager::readWord`.
 static const uint16 ramaSerializeRegTSignature1[] = {
 	SIG_MAGICDWORD,
-	0x38, SIG_SELECTOR16(newWith), // pushi $10b (newWith)
+	0x38, SIG_SELECTOR16(newWith), // pushi newWith ($10b)
 	0x7a,                          // push2
 	0x7a,                          // push2
-	0x72, SIG_UINT16(0x00),        // lofsa ""
+	0x72, SIG_UINT16(0x0000),      // lofsa ""
 	0x36,                          // push
 	0x51, 0x0f,                    // class Str
 	SIG_END
@@ -10543,7 +10543,7 @@ static const uint16 ramaSerializeRegTPatch1[] = {
 	0x38, PATCH_SELECTOR16(readWord),    // pushi readWord
 	0x76,                                // push0
 	0x62, PATCH_SELECTOR16(saveFilePtr), // pToa saveFilePtr
-	0x4a, PATCH_UINT16(0x04),            // send 4
+	0x4a, PATCH_UINT16(0x0004),          // send 4
 	0x48,                                // ret
 	PATCH_END
 };
@@ -10556,33 +10556,34 @@ static const uint16 ramaSerializeRegTPatch1[] = {
 // uninitialised param reads to 0 so the game was following the wrong path and
 // breaking.
 // Applies to at least: US English
+// Fixes bug: #10263
 static const uint16 ramaNukeTimerSignature[] = {
 	0x7e, SIG_ADDTOOFFSET(+2),              // line whatever
 	SIG_MAGICDWORD,
-	0x38, SIG_SELECTOR16(getSubscriberObj), // pushi $3ca (getSubscriberObj)
+	0x38, SIG_SELECTOR16(getSubscriberObj), // pushi getSubscriberObj ($3ca)
 	0x76,                                   // push0
-	0x54, SIG_UINT16(0x04),                 // self 4
+	0x54, SIG_UINT16(0x0004),               // self 4
 	SIG_END
 };
 
 static const uint16 ramaNukeTimerPatch[] = {
-	0x38, PATCH_SELECTOR16(getSubscriberObj), // pushi $3ca (getSubscriberObj)
+	0x38, PATCH_SELECTOR16(getSubscriberObj), // pushi getSubscriberObj ($3ca)
 	0x78,                                     // push1
-	0x38, PATCH_UINT16(0x01),                 // pushi 1 (wasting bytes)
-	0x54, PATCH_UINT16(0x06),                 // self 6
+	0x38, PATCH_UINT16(0x0001),               // pushi 1 (wasting bytes)
+	0x54, PATCH_UINT16(0x0006),               // self 6
 	PATCH_END
 };
 
 // When opening a datacube on the pocket computer, `DocReader::init` will try
-// to perform arithmetic on a pointer to `thighComputer::plane` and then use the
+// to perform arithmetic on a pointer to `thighComputer::plane` then use the
 // resulting value as the priority for the DocReader. This happened to work in
 // SSCI because the plane pointer would just be a high numeric value, but
 // ScummVM needs an actual number, not a pointer.
 // Applies to at least: US English
 static const uint16 ramaDocReaderInitSignature[] = {
-	0x39, SIG_SELECTOR8(priority), // pushi $1a (priority)
+	0x39, SIG_SELECTOR8(priority), // pushi priority ($1a)
 	0x78,                          // push1
-	0x39, SIG_SELECTOR8(plane),    // pushi $19 (plane)
+	0x39, SIG_SELECTOR8(plane),    // pushi plane ($19)
 	0x76,                          // push0
 	0x7a,                          // push2
 	SIG_MAGICDWORD,
@@ -10598,16 +10599,16 @@ static const uint16 ramaDocReaderInitPatch[] = {
 	PATCH_END
 };
 
-// It is not possible to change the directory for ScummVM save games, so disable
-// the "change directory" button in the RAMA save dialogue
+// It is not possible to change the directory for ScummVM save games, so
+// disable the "change directory" button in the RAMA save dialog.
 static const uint16 ramaChangeDirSignature[] = {
 	SIG_MAGICDWORD,
-	0x7e, SIG_UINT16(0x64),     // line 100
-	0x39, SIG_SELECTOR8(state), // pushi $1d (state)
+	0x7e, SIG_UINT16(0x0064),   // line 100
+	0x39, SIG_SELECTOR8(state), // pushi state ($1d)
 	0x78,                       // push1
 	0x39, 0x03,                 // pushi 3
 	0x72, SIG_ADDTOOFFSET(+2),  // lofsa changeDirI
-	0x4a, SIG_UINT16(0x0e),     // send 14
+	0x4a, SIG_UINT16(0x000e),   // send 14
 	SIG_END
 };
 
@@ -10646,9 +10647,9 @@ static const uint16 shiversEventSuperCallSignature[] = {
 	SIG_MAGICDWORD,
 	0x38, SIG_SELECTOR16(handleEvent), // pushi handleEvent
 	0x78,                              // push1
-	0x8f, 0x01,                        // lsp 1
+	0x8f, 0x01,                        // lsp param[1]
 	0x59, 0x02,                        // &rest 2
-	0x57, 0x7f, SIG_UINT16(0x06),      // super ShiversProp[7f], 6
+	0x57, 0x7f, SIG_UINT16(0x0006),    // super ShiversProp[7f], 6
 	SIG_END
 };
 
@@ -10668,13 +10669,13 @@ static const uint16 shiversEventSuperCallPatch[] = {
 // Applies to at least: English CD
 static const uint16 shiversGodsIxupiPlaySoundSignature[] = {
 	SIG_MAGICDWORD,
-	0x39, SIG_SELECTOR8(play), // pushi $33
-	0x38, SIG_UINT16(0x06),    // pushi 6
+	0x39, SIG_SELECTOR8(play), // pushi play ($33)
+	0x38, SIG_UINT16(0x0006),  // pushi 6
 	SIG_END
 };
 
 static const uint16 shiversGodsIxupiPlaySoundPatch[] = {
-	0x38, PATCH_SELECTOR16(fade), // pushi $f3
+	0x38, PATCH_SELECTOR16(fade), // pushi fade ($f3)
 	0x39, 0x06,                   // pushi 6
 	PATCH_END
 };

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -3386,11 +3386,11 @@ static const SciScriptPatcherEntry kq7Signatures[] = {
 #pragma mark -
 #pragma mark Lighthouse
 
-// When going to room 5 (the sierra logo & menu room) from room 380 (the credits
-// room), the game tries to clear flags from 0 (global 116 bit 0) to 1423
-// (global 204 bit 15), but global 201 is not a flag global (it holds a
-// reference to theInvisCursor). This patch stops clearing after 1359 (global
-// 200 bit 15). Hopefully that is good enough to not break the game.
+// When going to room 5 (sierra logo & menu room) from room 380 (the credits
+// room), the game tries to clear flags from 0 (global[116] bit 0) to 1423
+// (global[204] bit 15), but global[201] is not a flag global (it holds a
+// reference to theInvisCursor). This patch stops clearing after flag 1359
+// (global[200] bit 15). Hopefully that is good enough to not break the game.
 // Applies to at least: English 1.0c & 2.0a
 static const uint16 lighthouseFlagResetSignature[] = {
 	SIG_MAGICDWORD,
@@ -3412,24 +3412,23 @@ static const uint16 lighthouseFlagResetPatch[] = {
 // Applies to at least: US English 1.0c
 static const uint16 lighthouseMemoryCountSignature[] = {
 	SIG_MAGICDWORD,
-	0x8d, 0x02,             // lst 2
+	0x8d, 0x02,             // lst temp[2]
 	0x35, 0x0a,             // ldi 10
 	0x24,                   // le?
 	0x31, 0x3b,             // bnt [to second digit overflow]
 	SIG_ADDTOOFFSET(+4),    // ldi, sat
-	0x8d, 0x03,             // lst 3
+	0x8d, 0x03,             // lst temp[3]
 	0x35, 0x0a,             // ldi 10
 	SIG_END
 };
 
 static const uint16 lighthouseMemoryCountPatch[] = {
-	PATCH_ADDTOOFFSET(+2), // lst 2
+	PATCH_ADDTOOFFSET(+2), // lst temp[2]
 	0x35, 0x02,            // ldi 2
 	PATCH_ADDTOOFFSET(+9), // le?, bnt, ldi, sat, lst
 	0x35, 0x02,            // ldi 2
 	PATCH_END
 };
-
 
 //          script, description,                                      signature                         patch
 static const SciScriptPatcherEntry lighthouseSignatures[] = {

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -264,10 +264,10 @@ enum ScriptPatcherSelectors {
 // the "change directory" button in the standard save dialogue
 static const uint16 sci2ChangeDirSignature[] = {
 	0x72, SIG_ADDTOOFFSET(+2), // lofsa changeDirI
-	0x4a, SIG_UINT16(0x04),    // send 4
+	0x4a, SIG_UINT16(0x0004),  // send 4
 	SIG_MAGICDWORD,
 	0x36,                      // push
-	0x35, 0xF7,                // ldi $f7
+	0x35, 0xf7,                // ldi $f7
 	0x12,                      // and
 	0x36,                      // push
 	SIG_END
@@ -321,7 +321,7 @@ static const uint16 sci21IntArraySignature[] = {
 	SIG_MAGICDWORD,
 	0x36,                          // push
 	0x51, 0x0b,                    // class IntArray
-	0x4a, 0x8,                     // send $8
+	0x4a, 0x08,                    // send $8
 	SIG_END
 };
 
@@ -367,13 +367,13 @@ static const uint16 sci2VolumeResetSignature[] = {
 	0x38, SIG_SELECTOR16(masterVolume), // pushi masterVolume
 	0x78,                               // push1
 	0x39, SIG_ADDTOOFFSET(+1),          // pushi [default volume]
-	0x81, 0x01,                         // lag 1
-	0x4a, SIG_UINT16(0x06),             // send 6
+	0x81, 0x01,                         // lag global[1]
+	0x4a, SIG_UINT16(0x0006),           // send 6
 	SIG_END
 };
 
 static const uint16 sci2VolumeResetPatch[] = {
-	0x32, PATCH_UINT16(8), // jmp 8 [past volume reset]
+	0x32, PATCH_UINT16(0x0008),         // jmp 8 [past volume reset]
 	PATCH_END
 };
 
@@ -388,12 +388,12 @@ static const uint16 sci2BrokenStrStripSignature[] = {
 	0x85, 0x06,                         // lat temp[6]
 	0x31, 0x10,                         // bnt [jump to code that passes 2 parameters]
 	0x38, SIG_UINT16(0x00c2),           // pushi 00c2 (callKernel)
-	0x38, SIG_UINT16(3),                // pushi 03
+	0x38, SIG_UINT16(0x0003),           // pushi 03
 	0x39, 0x0e,                         // pushi 0e
 	0x8d, 0x0b,                         // lst temp[0b]
 	0x36,                               // push
 	0x54, SIG_UINT16(0x000a),           // self 0a
-	0x33, 0x0b,                         // jmp to [ret]
+	0x33, 0x0b,                         // jmp [ret]
 	// 2 parameter code
 	0x38, SIG_UINT16(0x00c2),           // pushi 00c2
 	0x7a,                               // push2
@@ -417,7 +417,6 @@ static const uint16 sci2BrokenStrStripPatch[] = {
 	0x48,                               // ret
 	PATCH_END
 };
-
 
 // Torin/LSL7-specific version of sci2NumSavesSignature1/2
 // Applies to at least: English CD

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -683,14 +683,13 @@ static const SciScriptPatcherEntry ecoquest2Signatures[] = {
 // Fan-made games
 // Attention: Try to make script patches as specific as possible
 
-// CascadeQuest::autosave in script 994 is called various times to auto-save the game.
-// The script use a fixed slot "999" for this purpose. This doesn't work in ScummVM, because we do not let
-//  scripts save directly into specific slots, but instead use virtual slots / detect scripts wanting to
-//  create a new slot.
-//
-// For this game we patch the code to use slot 99 instead. kSaveGame also checks for Cascade Quest,
-//  will then check, if slot 99 is asked for and will then use the actual slot 0, which is the official
-//  ScummVM auto-save slot.
+// CascadeQuest::autosave in script 994 is called various times to auto-save.
+//  It uses a fixed slot (999) for this purpose. This doesn't work in ScummVM,
+//  because we do not let scripts save directly into specific slots, but
+//  instead use virtual slots / detect scripts wanting to create a new slot.
+// We patch the code to use slot 99 instead. kSaveGame also checks for Cascade
+//  Quest, and if slot 99 is asked for, it will then use the actual slot 0,
+//  which is the official ScummVM auto-save slot.
 //
 // Responsible method: CascadeQuest::autosave
 // Fixes bug: #7007
@@ -698,7 +697,7 @@ static const uint16 fanmadeSignatureCascadeQuestFixAutoSaving[] = {
 	SIG_MAGICDWORD,
 	0x38, SIG_UINT16(0x03e7),        // pushi 3E7 (999d) -> save game slot 999
 	0x74, SIG_UINT16(0x06f8),        // lofss "AutoSave"
-	0x89, 0x1e,                      // lsg global[1E]
+	0x89, 0x1e,                      // lsg global[1e]
 	0x43, 0x2d, 0x08,                // callk SaveGame
 	SIG_END
 };
@@ -716,7 +715,7 @@ static const uint16 fanmadePatchCascadeQuestFixAutoSaving[] = {
 static const uint16 fanmadeSignatureDemoQuestInfiniteLoop[] = {
 	0x38, SIG_UINT16(0x004c),        // pushi 004c
 	0x39, 0x00,                      // pushi 00
-	0x87, 0x01,                      // lap 01
+	0x87, 0x01,                      // lap param[1]
 	0x4b, 0x04,                      // send 04
 	SIG_MAGICDWORD,
 	0x18,                            // not

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -504,14 +504,14 @@ static const uint16 ecoquest1SignatureStayAndHelp[] = {
 	0x1a,                            // eq?
 	0x31, 0x1c,                      // bnt [next state]
 	0x76,                            // push0
-	0x45, 0x01, 0x00,                // callb export1 from script 0 (switching control off)
+	0x45, 0x01, 0x00,                // callb [export 1 of script 0], 00 (switching control off)
 	SIG_MAGICDWORD,
 	0x38, SIG_UINT16(0x0122),        // pushi 0122
 	0x78,                            // push1
 	0x76,                            // push0
 	0x81, 0x00,                      // lag global[0]
 	0x4a, 0x06,                      // send 06 - call ego::setMotion(0)
-	0x39, SIG_SELECTOR8(init),       // pushi "init"
+	0x39, SIG_SELECTOR8(init),       // pushi init
 	0x39, 0x04,                      // pushi 04
 	0x76,                            // push0
 	0x76,                            // push0
@@ -529,13 +529,13 @@ static const uint16 ecoquest1PatchStayAndHelp[] = {
 	0x36,                            // push
 	0x2f, 0x22,                      // bt [next state] (this optimization saves 6 bytes)
 	0x39, 0x00,                      // pushi 0 (wasting 1 byte here)
-	0x45, 0x01, 0x00,                // callb export1 from script 0 (switching control off)
+	0x45, 0x01, 0x00,                // callb [export 1 of script 0], 00 (switching control off)
 	0x38, PATCH_UINT16(0x0122),      // pushi 0122
 	0x78,                            // push1
 	0x76,                            // push0
 	0x81, 0x00,                      // lag global[0]
 	0x4a, 0x06,                      // send 06 - call ego::setMotion(0)
-	0x39, PATCH_SELECTOR8(init),     // pushi "init"
+	0x39, PATCH_SELECTOR8(init),     // pushi init
 	0x39, 0x06,                      // pushi 06
 	0x39, 0x02,                      // pushi 02 (additional 2 bytes)
 	0x76,                            // push0
@@ -573,10 +573,10 @@ static const uint16 ecoquest2SignatureEcorder[] = {
 	0x39, 0x66,                      // pushi 66
 	0x39, 0x17,                      // pushi 17
 	0x39, 0x69,                      // pushi 69
-	0x38, PATCH_UINT16(0x2631),      // pushi 2631
+	0x38, SIG_UINT16(0x2631),        // pushi 2631
 	0x39, 0x6a,                      // pushi 6a
 	0x39, 0x64,                      // pushi 64
-	0x43, 0x1b, 0x14,                // call kDisplay
+	0x43, 0x1b, 0x14,                // callk Display
 	0x35, 0x0a,                      // ldi 0a
 	0x65, 0x20,                      // aTop ticks
 	0x33,                            // jmp [end]
@@ -589,29 +589,28 @@ static const uint16 ecoquest2SignatureEcorder[] = {
 };
 
 static const uint16 ecoquest2PatchEcorder[] = {
-	0x2f, 0x02,                      // bt [to pushi 07]
+	0x2f, 0x02,                      // bt [to pushi 7]
 	0x3a,                            // toss
 	0x48,                            // ret
-	0x38, PATCH_UINT16(0x0007),      // pushi 07 (parameter count) (waste 1 byte)
-	0x39, 0x0b,                      // push (FillBoxAny)
+	0x38, PATCH_UINT16(0x0007),      // pushi 7d (parameter count) (waste 1 byte)
+	0x39, 0x0b,                      // pushi 11d (FillBoxAny)
 	0x39, 0x1d,                      // pushi 29d
 	0x39, 0x73,                      // pushi 115d
 	0x39, 0x5e,                      // pushi 94d
 	0x38, PATCH_UINT16(0x00d7),      // pushi 215d
 	0x78,                            // push1 (visual screen)
-	0x38, PATCH_UINT16(0x0017),      // pushi 17 (color) (waste 1 byte)
-	0x43, 0x6c, 0x0e,                // call kGraph
-	0x38, PATCH_UINT16(0x0005),      // pushi 05 (parameter count) (waste 1 byte)
+	0x38, PATCH_UINT16(0x0017),      // pushi 23d (color) (waste 1 byte)
+	0x43, 0x6c, 0x0e,                // callk Graph
+	0x38, PATCH_UINT16(0x0005),      // pushi 5d (parameter count) (waste 1 byte)
 	0x39, 0x0c,                      // pushi 12d (UpdateBox)
 	0x39, 0x1d,                      // pushi 29d
 	0x39, 0x73,                      // pushi 115d
 	0x39, 0x5e,                      // pushi 94d
 	0x38, PATCH_UINT16(0x00d7),      // pushi 215d
-	0x43, 0x6c, 0x0a,                // call kGraph
+	0x43, 0x6c, 0x0a,                // callk Graph
 	PATCH_END
 };
 
-// ===========================================================================
 // Same patch as above for the ecorder introduction.
 // Two workarounds are needed for this patch in workarounds.cpp (when calling
 // kGraphFillBoxAny and kGraphUpdateBox), as there isn't enough space to patch
@@ -632,7 +631,7 @@ static const uint16 ecoquest2SignatureEcorderTutorial[] = {
 	0x38, SIG_UINT16(0x2631),        // pushi 2631
 	0x39, 0x6a,                      // pushi 6a
 	0x39, 0x64,                      // pushi 64
-	0x43, 0x1b, 0x14,                // call kDisplay
+	0x43, 0x1b, 0x14,                // callk Display
 	0x35, 0x1e,                      // ldi 1e
 	0x65, 0x20,                      // aTop ticks
 	0x32,                            // jmp [end]
@@ -645,31 +644,31 @@ static const uint16 ecoquest2PatchEcorderTutorial[] = {
 	// The parameter count below should be 7, but we're out of bytes
 	// to patch! A workaround has been added because of this
 	0x78,                            // push1 (parameter count)
-	//0x39, 0x07,                    // pushi 07 (parameter count)
-	0x39, 0x0b,                      // push (FillBoxAny)
+	//0x39, 0x07,                    // pushi 7d (parameter count)
+	0x39, 0x0b,                      // pushi 11d (FillBoxAny)
 	0x39, 0x1d,                      // pushi 29d
 	0x39, 0x73,                      // pushi 115d
 	0x39, 0x5e,                      // pushi 94d
 	0x38, PATCH_UINT16(0x00d7),      // pushi 215d
 	0x78,                            // push1 (visual screen)
-	0x39, 0x17,                      // pushi 17 (color)
-	0x43, 0x6c, 0x0e,                // call kGraph
+	0x39, 0x17,                      // pushi 23d (color)
+	0x43, 0x6c, 0x0e,                // callk Graph
 	// The parameter count below should be 5, but we're out of bytes
 	// to patch! A workaround has been added because of this
 	0x78,                            // push1 (parameter count)
-	//0x39, 0x05,                    // pushi 05 (parameter count)
+	//0x39, 0x05,                    // pushi 5d (parameter count)
 	0x39, 0x0c,                      // pushi 12d (UpdateBox)
 	0x39, 0x1d,                      // pushi 29d
 	0x39, 0x73,                      // pushi 115d
 	0x39, 0x5e,                      // pushi 94d
 	0x38, PATCH_UINT16(0x00d7),      // pushi 215d
-	0x43, 0x6c, 0x0a,                // call kGraph
+	0x43, 0x6c, 0x0a,                // callk Graph
 	// We are out of bytes to patch at this point,
-	// so we skip 494 (0x1EE) bytes to reuse this code:
+	// so we skip 494 (0x1ee) bytes to reuse this code:
 	// ldi 1e
 	// aTop 20
 	// jmp 030e (jump to end)
-	0x32, PATCH_UINT16(0x01ee),      // skip 494 (0x1EE) bytes
+	0x32, PATCH_UINT16(0x01ee),      // jmp 494d
 	PATCH_END
 };
 

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -447,8 +447,8 @@ static const uint16 torinLarry7NumSavesPatch[] = {
 //  get an "Oops" message in Sierra SCI.
 //
 // This is caused by peepingTom in script 169 not getting properly initialized.
-// peepingTom calls the object behind global b9h. This global variable is
-//  properly initialized, when walking there manually (method fawaz::doit).
+// peepingTom calls the object behind global[b9h]. This global variable is
+//  properly initialized when walking there manually (method fawaz::doit).
 // When you instead walk there automatically (method fawaz::handleEvent), that
 //  global isn't initialized, which then results in the Oops-message in Sierra SCI
 //  and an error message in ScummVM/SCI.
@@ -458,16 +458,16 @@ static const uint16 torinLarry7NumSavesPatch[] = {
 // Fixes bug: #6402
 static const uint16 camelotSignaturePeepingTom[] = {
 	0x72, SIG_MAGICDWORD, SIG_UINT16(0x077e), // lofsa fawaz <-- start of proper initializion code
-	0xa1, 0xb9,                      // sag b9h
-	SIG_ADDTOOFFSET(+571),           // skip 571 bytes
+	0xa1, 0xb9,                      // sag global[b9h]
+	SIG_ADDTOOFFSET(+571),           // ...
 	0x39, 0x7a,                      // pushi 7a <-- initialization code when walking automatically
 	0x78,                            // push1
 	0x7a,                            // push2
-	0x38, SIG_UINT16(0x00a9), // + 0xa9, 0x00,   // pushi 00a9 - script 169
+	0x38, SIG_UINT16(0x00a9),        // pushi 00a9 - script 169
 	0x78,                            // push1
-	0x43, 0x02, 0x04,                // call kScriptID
+	0x43, 0x02, 0x04,                // callk ScriptID
 	0x36,                            // push
-	0x81, 0x00,                      // lag 00
+	0x81, 0x00,                      // lag global[0]
 	0x4a, 0x06,                      // send 06
 	0x32, SIG_UINT16(0x0520),        // jmp [end of fawaz::handleEvent]
 	SIG_END
@@ -475,7 +475,7 @@ static const uint16 camelotSignaturePeepingTom[] = {
 
 static const uint16 camelotPatchPeepingTom[] = {
 	PATCH_ADDTOOFFSET(+576),
-	0x32, PATCH_UINT16(0xfdbd),      // jmp to fawaz::doit / properly init peepingTom code
+	0x32, PATCH_UINT16(0xfdbd),      // jmp [to fawaz::doit] (properly init peepingTom code)
 	PATCH_END
 };
 

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -5621,10 +5621,10 @@ static const uint16 mothergoose256SignatureReplay[] = {
 	0x36,                            // push
 	0x35, 0x20,                      // ldi 20
 	0x04,                            // sub
-	0xa1, SIG_ADDTOOFFSET(+1),       // sag global[57h] -> FM-Towns [9Dh]
+	0xa1, SIG_ADDTOOFFSET(+1),       // sag global[57h], for FM-Towns: sag global[9Dh]
 	// 35 bytes
 	0x39, 0x03,                      // pushi 03
-	0x89, SIG_ADDTOOFFSET(+1),       // lsg global[1Dh] -> FM-Towns [1Eh]
+	0x89, SIG_ADDTOOFFSET(+1),       // lsg global[1Dh], for FM-Towns: lsg global[1Eh]
 	0x76,                            // push0
 	0x7a,                            // push2
 	0x5b, 0x00, 0xbe,                // lea global[BEh]
@@ -5638,7 +5638,7 @@ static const uint16 mothergoose256SignatureReplay[] = {
 	0x43, 0x62, 0x06,                // callk StrAt
 	// 22 bytes
 	0x7a,                            // push2
-	0x5b, 0x00, 0xbe,                // lea global[BE]
+	0x5b, 0x00, 0xbe,                // lea global[BEh]
 	0x36,                            // push
 	0x39, 0x03,                      // pushi 03
 	0x43, 0x62, 0x04,                // callk StrAt
@@ -5646,7 +5646,7 @@ static const uint16 mothergoose256SignatureReplay[] = {
 	0x36,                            // push
 	0x35, SIG_MAGICDWORD, 0x20,      // ldi 20
 	0x04,                            // sub
-	0xa1, 0xb3,                      // sag global[b3]
+	0xa1, 0xb3,                      // sag global[B3h]
 	// 6 bytes
 	SIG_END
 };
@@ -5677,8 +5677,8 @@ static const uint16 mothergoose256PatchReplay[] = {
 	0x39, 0x0c,                      // pushi 0Ch
 	0x76,                            // push0
 	0x76,                            // push0
-	0x38, PATCH_UINT16(200),         // push 200
-	0x38, PATCH_UINT16(320),         // push 320
+	0x38, PATCH_UINT16(200),         // pushi 200
+	0x38, PATCH_UINT16(320),         // pushi 320
 	0x78,                            // push1
 	0x43, 0x6c, 0x0c,                // callk Graph -> send everything to screen
 	// 16 bytes
@@ -5738,11 +5738,11 @@ static const SciScriptPatcherEntry mothergoose256Signatures[] = {
 // Applies to at least: English CD from King's Quest Collection
 // Responsible method: sShowLogo::changeState
 static const uint16 mothergooseHiresLogoSignature[] = {
-	0x38, SIG_SELECTOR16(init),      // pushi $8e (init)
+	0x38, SIG_SELECTOR16(init),      // pushi init ($8e)
 	SIG_MAGICDWORD,
 	0x76,                            // push0
-	0x72, SIG_UINT16(0x82),          // lofsa logo[82]
-	0x4a, SIG_UINT16(0x04),          // send $4
+	0x72, SIG_UINT16(0x0082),        // lofsa logo[82]
+	0x4a, SIG_UINT16(0x0004),        // send $4
 	SIG_END
 };
 
@@ -5760,14 +5760,14 @@ static const uint16 mothergooseHiresLogoPatch[] = {
 // Responsible method: rhymeScript::changeState
 static const uint16 mothergooseHiresHorseSignature[] = {
 	SIG_MAGICDWORD,
-	0x39, SIG_SELECTOR8(setPri), // pushi $4a (setPri)
+	0x39, SIG_SELECTOR8(setPri), // pushi setPri ($4a)
 	0x78,                        // push1
-	0x38, SIG_UINT16(0xb7),      // pushi $b7
+	0x38, SIG_UINT16(0x00b7),    // pushi $b7
 	SIG_END
 };
 
 static const uint16 mothergooseHiresHorsePatch[] = {
-	PATCH_ADDTOOFFSET(3),     // pushi setPri, push1
+	PATCH_ADDTOOFFSET(+3),    // pushi setPri, push1
 	0x38, PATCH_UINT16(0x59), // pushi $59
 	PATCH_END
 };

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -2207,10 +2207,11 @@ static const SciScriptPatcherEntry gk1Signatures[] = {
 // button's delta instead of 1 in 'ScrollButton::track'.
 //
 // Applies to at least: English CD 1.00, English Steam 1.01
+// Fixes bug: #9648
 static const uint16 gk2InvScrollSignature[] = {
-	0x7e, SIG_ADDTOOFFSET(2),               // line whatever
+	0x7e, SIG_ADDTOOFFSET(+2),              // line whatever
 	SIG_MAGICDWORD,
-	0x38, SIG_SELECTOR16(scrollSelections), // pushi $2c3
+	0x38, SIG_SELECTOR16(scrollSelections), // pushi scrollSelections ($2c3)
 	0x78,                                   // push1
 	0x78,                                   // push1
 	0x63, 0x98,                             // pToa $98
@@ -2219,12 +2220,12 @@ static const uint16 gk2InvScrollSignature[] = {
 };
 
 static const uint16 gk2InvScrollPatch[] = {
-	0x38, PATCH_SELECTOR16(scrollSelections), // pushi $2c3
+	0x38, PATCH_SELECTOR16(scrollSelections), // pushi scrollSelections ($2c3)
 	0x78,                                     // push1
 	0x67, 0x9a,                               // pTos $9a (delta)
 	0x63, 0x98,                               // pToa $98
 	0x4a, PATCH_UINT16(0x06),                 // send 6
-	0x18, 0x18,                               // waste bytes
+	0x18, 0x18,                               // (waste bytes)
 	PATCH_END
 };
 
@@ -2232,10 +2233,11 @@ static const uint16 gk2InvScrollPatch[] = {
 // the music volume to 63, but the game should always use the volume stored in
 // ScummVM.
 // Applies to at least: English 1.00 CD
+// Fixes bug: #9700
 static const uint16 gk2VolumeResetSignature[] = {
 	SIG_MAGICDWORD,
 	0x35, 0x3f, // ldi $3f
-	0xa1, 0x4c, // sag $4c (music volume)
+	0xa1, 0x4c, // sag global[$4c] (music volume)
 	SIG_END
 };
 
@@ -2253,10 +2255,10 @@ static const uint16 gk2BenchmarkSignature[] = {
 	0x76,                      // push0
 	0x51, SIG_ADDTOOFFSET(+1), // class Actor
 	0x4a, SIG_UINT16(0x04),    // send 4
-	0xa5, 0x00,                // sat 0
+	0xa5, 0x00,                // sat temp[0]
 	0x7e, SIG_ADDTOOFFSET(+2), // line
 	0x7e, SIG_ADDTOOFFSET(+2), // line
-	0x39, SIG_SELECTOR8(view), // pushi $e (view)
+	0x39, SIG_SELECTOR8(view), // pushi view ($e)
 	SIG_MAGICDWORD,
 	0x78,                      // push1
 	0x38, SIG_UINT16(0xfdd4),  // pushi 64980
@@ -2266,9 +2268,9 @@ static const uint16 gk2BenchmarkSignature[] = {
 static const uint16 gk2BenchmarkPatch[] = {
 	0x38, PATCH_SELECTOR16(detailLevel), // pushi detailLevel
 	0x78,                                // push1
-	0x38, PATCH_UINT16(399),             // pushi 10000 / 25 - 1
-	0x81, 0x01,                          // lag 1
-	0x4a, PATCH_UINT16(0x06),            // send 6
+	0x38, PATCH_UINT16(399),             // pushi 399 (10000 / 25 - 1)
+	0x81, 0x01,                          // lag global[1]
+	0x4a, PATCH_UINT16(0x0006),          // send 6
 	0x34, PATCH_UINT16(10000),           // ldi 10000
 	0x48,                                // ret
 	PATCH_END

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -9836,29 +9836,32 @@ static const uint16 sq4FloppyPatchEndlessFlight[] = {
 	PATCH_END
 };
 
-// Floppy-only: When the player tries to throw something at the sequel police in Space Quest X (zero g zone),
-//   the game will first show a textbox and then cause a signature mismatch in ScummVM/
-//   crash the whole game in Sierra SCI/display garbage (the latter when the Sierra "patch" got applied).
+// Floppy-only: When the player tries to throw something at the sequel police
+//   in Space Quest X (zero g zone), the game will first show a textbox and
+//   then cause a signature mismatch in ScummVM. In Sierra SCI, it'd crash the
+//   whole game - or, when the Sierra "patch" got applied, display garbage.
 //
-// All of this is caused by a typo in the script. Right after the code for showing the textbox,
-//  there is more similar code for showing another textbox, but without a pointer to the text.
-//  This has to be a typo, because there is no unused text to be found within that script.
+// All of this is caused by a typo in the script. Right after the code for
+//  showing the textbox, there is similar code for showing another textbox, but
+//  without a pointer to the text. This has to be a typo, because there is no
+//  unused text to be found within that script.
 //
-// Sierra's "patch" didn't include a proper fix (as in a modified script). Instead they shipped a dummy
-//  text resource, which somewhat "solved" the issue in Sierra SCI, but it still showed another textbox
-//  with garbage in it. Funnily Sierra must have known that, because that new text resource contains:
-//  "Hi! This is a kludge!"
+// Sierra's "patch" didn't include a proper fix (as in a modified script).
+//  Instead they shipped a dummy text resource, which somewhat "solved" the
+//  issue in Sierra SCI, but it still showed another textbox with garbage in
+//  it. Funnily Sierra must have known that, because that new text resource
+//  contains: "Hi! This is a kludge!"
 //
 // We properly fix it by removing the faulty code.
 // Applies to at least: English Floppy
 // Responsible method: sp1::doVerb
 // Fixes bug: found by SCI developer
 static const uint16 sq4FloppySignatureThrowStuffAtSequelPoliceBug[] = {
-	0x47, 0xff, 0x00, 0x02,             // call export 255_0, 2
+	0x47, 0xff, 0x00, 0x02,             // calle [export 0 of script 255], 2
 	0x3a,                               // toss
 	SIG_MAGICDWORD,
 	0x36,                               // push
-	0x47, 0xff, 0x00, 0x02,             // call export 255_0, 2
+	0x47, 0xff, 0x00, 0x02,             // calle [export 0 of script 255], 2
 	SIG_END
 };
 
@@ -9890,7 +9893,7 @@ static const uint16 sq4CdSignatureWalkInFromBelowRoom45[] = {
 	0x38, SIG_UINT16(0x00bd),           // pushi 00BDh
 	0x38, SIG_ADDTOOFFSET(+2),          // pushi [setMotion selector]
 	0x39, 0x03,                         // pushi 3
-	0x51, SIG_ADDTOOFFSET(+1),          // class [MoveTo]
+	0x51, SIG_ADDTOOFFSET(+1),          // class MoveTo
 	0x36,                               // push
 	0x78,                               // push1
 	0x76,                               // push0
@@ -9929,18 +9932,18 @@ static const uint16 sq4CdSignatureMissingAudioUniversalRemote[] = {
 	0x35, 0x01,                         // ldi 01
 	0x1a,                               // eq?
 	0x30, SIG_UINT16(0x0021),           // bnt [skip over substate 1 code]
-	0x39, SIG_SELECTOR8(number),        // pushi (number)
+	0x39, SIG_SELECTOR8(number),        // pushi number
 	0x78,                               // push1
 	0x7a,                               // push2
 	0x38, SIG_UINT16(0x0188),           // pushi 188h
 	0x38, SIG_UINT16(0x018b),           // pushi 18Bh
-	0x43, 0x3C, 0x04,                   // call kRandom, 4
+	0x43, 0x3c, 0x04,                   // callk Random, 4
 	0x36,                               // push
-	0x39, SIG_SELECTOR8(play),          // pushi (play)
+	0x39, SIG_SELECTOR8(play),          // pushi play
 	0x76,                               // push0
 	0x81, 0x64,                         // lag global[64h]
 	0x4a, 0x0a,                         // send 0Ah
-	0x38, SIG_SELECTOR16(setScript),    // pushi (setScript)
+	0x38, SIG_SELECTOR16(setScript),    // pushi setScript
 	0x78,                               // push1
 	0x72, SIG_UINT16(0x0488),           // lofsa startTerminal
 	0x36,                               // push
@@ -9954,7 +9957,7 @@ static const uint16 sq4CdSignatureMissingAudioUniversalRemote[] = {
 	0x1a,                               // eq?
 	0x31, 0x0e,                         // bnt [skip last state and toss/ret]
 	0x35, 0x1d,                         // ldi 1Dh
-	0x38, SIG_SELECTOR16(setScript),    // pushi (setScript)
+	0x38, SIG_SELECTOR16(setScript),    // pushi setScript
 	0x78,                               // push1
 	0x72, SIG_UINT16(0x0488),           // lofsa startTerminal
 	0x36,                               // push
@@ -9966,20 +9969,20 @@ static const uint16 sq4CdSignatureMissingAudioUniversalRemote[] = {
 };
 
 static const uint16 sq4CdPatchMissingAudioUniversalRemote[] = {
-	0x30, SIG_UINT16(0x00b7),           // bnt [now directly to last state code, saving 6 bytes]
-	0x32, PATCH_UINT16(+154),           // jmp [to our new code]
+	0x30, PATCH_UINT16(0x00b7),         // bnt [directly to last state code, saving 6 bytes]
+	0x32, PATCH_UINT16(0x009a),         // jmp 154d [to our new code]
 	// 1 not used byte here
-	SIG_ADDTOOFFSET(+128),              // skip over to substate 1 code of state 1Ch code
+	PATCH_ADDTOOFFSET(+128),            // skip over to substate 1 code of state 1Ch code
 	0x32, PATCH_UINT16(0x003f),         // substate 0 code, jumping to toss/ret
 	// directly start with substate 1 code, saving 7 bytes
-	0x39, PATCH_SELECTOR8(number),      // pushi 28h (number)
+	0x39, PATCH_SELECTOR8(number),      // pushi number
 	0x78,                               // push1
 	0x7a,                               // push2
 	0x38, PATCH_UINT16(0x0188),         // pushi 188h
 	0x38, PATCH_UINT16(0x018b),         // pushi 18Bh
-	0x43, 0x3C, 0x04,                   // call kRandom, 4
+	0x43, 0x3c, 0x04,                   // callk Random, 4
 	0x36,                               // push
-	0x39, PATCH_SELECTOR8(play),        // pushi (play)
+	0x39, PATCH_SELECTOR8(play),        // pushi play
 	0x76,                               // push0
 	0x81, 0x64,                         // lag global[64h]
 	0x4a, 0x0a,                         // send 0Ah
@@ -9989,7 +9992,7 @@ static const uint16 sq4CdPatchMissingAudioUniversalRemote[] = {
 	0x35, 0x01,                         // ldi 1
 	0x1c,                               // ne?
 	0x31, 0x0b,                         // bnt [skip play audio]
-	0x38, PATCH_SELECTOR16(say),        // pushi 0123h (say)
+	0x38, PATCH_SELECTOR16(say),        // pushi say (0123h)
 	0x78,                               // push1
 	0x39, 0x14,                         // pushi 14h
 	0x72, PATCH_UINT16(0x0850),         // lofsa newRob
@@ -10000,22 +10003,21 @@ static const uint16 sq4CdPatchMissingAudioUniversalRemote[] = {
 	PATCH_END
 };
 
-// It seems that Sierra forgot to set a script flag, when cleaning out the bank account
-// in Space Quest 4 CD. This was probably caused by the whole bank account interaction
-// getting a rewrite and polish in the CD version.
+// It seems that Sierra forgot to set a script flag when cleaning out the bank
+// account in Space Quest 4 CD. This was probably caused by the whole bank
+// account interaction getting a rewrite and polish in the CD version.
 //
-// Because of this bug, points for changing back clothes will not get awarded, which
-// makes it impossible to get a perfect point score in the CD version of the game.
-// The points are awarded by rm371::doit in script 371.
+// Because of this bug, points for changing back clothes will not get awarded,
+// which makes it impossible to get a perfect point score in the CD version of
+// the game. The points are awarded by rm371::doit in script 371.
 //
-// We fix this. Bug also happened, when using the original interpreter.
-// Bug does not happen for PC floppy.
+// We fix this. PC floppy does not have this bug.
 //
-// Attention: Some Let's Plays on youtube show that points are in fact awarded. Which is true.
-//            But those Let's Plays were actually created by playing a hacked Space Quest 4 version
-//            (which is part Floppy, part CD version - we consider it to be effectively pirated)
-//            and not the actual CD version of Space Quest 4.
-//            It's easy to identify - talkie + store called "Radio Shack" -> is hacked version.
+// Note: Some Let's Plays on YouTube show points are in fact awarded. But those
+//  Let's Plays were of a hacked Space Quest 4 version. It was part Floppy,
+//  part CD version. We consider it to be effectively pirated and not a
+//  canonical CD version of Space Quest 4. It's easy to identify for having
+//  both voices and a store called "Radio Shock" instead of "Hz. So Good".
 //
 // Applies to at least: English PC CD
 // Responsible method: but2Script::changeState(2)
@@ -10046,8 +10048,8 @@ static const uint16 sq4CdPatchGetPointsForChangingBackClothes[] = {
 	0x33, 0x39,                         // jmp [end of state 2, set cycles code]
 	PATCH_ADDTOOFFSET(+51),
 	0x78,                               // push1
-	0x39, 0x1d,                         // ldi 1Dh
-	0x45, 0x07, 0x02,                   // call export 7 of script 0 (set flag) -> effectively sets global 73h, bit 2
+	0x39, 0x1d,                         // pushi 1Dh
+	0x45, 0x07, 0x02,                   // callb [export 7 of script 0], 02 (set flag 1Dh - located at global[73h] bit 2)
 	0x35, 0x02,                         // ldi 02
 	0x65, 0x1c,                         // aTop cycles
 	0x33, 0x05,                         // jmp [toss/ret]
@@ -10055,14 +10057,14 @@ static const uint16 sq4CdPatchGetPointsForChangingBackClothes[] = {
 	PATCH_END
 };
 
-
-// For Space Quest 4 CD, Sierra added a pick up animation for Roger, when he picks up the rope.
+// For Space Quest 4 CD, Sierra added a pick up animation for Roger when he
+// picks up the rope.
 //
-// When the player is detected by the zombie right at the start of the game, while picking up the rope,
-// scripts bomb out. This also happens, when using the original interpreter.
+// When the player is detected by the zombie right at the start of the game,
+// while picking up the rope, scripts bomb out.
 //
-// This is caused by code, that's supposed to make Roger face the arriving drone.
-// We fix it, by checking if ego::cycler is actually set before calling that code.
+// This is caused by code intended to make Roger face the arriving drone. We
+// fix it by checking if ego::cycler is actually set before calling that code.
 //
 // Applies to at least: English PC CD
 // Responsible method: droidShoots::changeState(3)
@@ -10077,7 +10079,7 @@ static const uint16 sq4CdSignatureGettingShotWhileGettingRope[] = {
 	0x1a,                               // eq?
 	0x31, 0x0b,                         // bnt [state 3 check]
 	0x76,                               // push0
-	0x45, 0x02, 0x00,                   // call export 2 of script 0 -> disable controls
+	0x45, 0x02, 0x00,                   // callb [export 2 of script 0], 00 (disable controls)
 	0x35, 0x02,                         // ldi 02
 	0x65, 0x1a,                         // aTop cycles
 	0x32, SIG_UINT16(0x02e9),           // jmp [end]
@@ -10086,12 +10088,12 @@ static const uint16 sq4CdSignatureGettingShotWhileGettingRope[] = {
 	0x1a,                               // eq?
 	0x31, 0x1e,                         // bnt [state 4 check]
 	0x76,                               // push0
-	0x45, 0x02, 0x00,                   // call export 2 of script 0 -> disable controls again??
+	0x45, 0x02, 0x00,                   // callb [export 2 of script 0], 00 (disable controls again??)
 	0x7a,                               // push2
 	0x89, 0x00,                         // lsg global[0]
 	0x72, SIG_UINT16(0x0242),           // lofsa deathDroid
 	0x36,                               // push
-	0x45, 0x0d, 0x04,                   // call export 13 of script 0 -> set heading of ego to face droid
+	0x45, 0x0d, 0x04,                   // callb [export 13 of script 0], 04 (set heading of ego to face droid)
 	SIG_END
 };
 
@@ -10106,25 +10108,26 @@ static const uint16 sq4CdPatchGettingShotWhileGettingRope[] = {
 	0x31, 0x29,                         // bnt [state 4 check]
 	// new state 3 code
 	0x76,                               // push0
-	0x45, 0x02, 0x00,                   // call export 2 of script 0 (disable controls, actually not needed)
+	0x45, 0x02, 0x00,                   // callb [export 2 of script 0], 00 (disable controls, actually not needed)
 	0x38, PATCH_SELECTOR16(cycler),     // pushi cycler
 	0x76,                               // push0
 	0x81, 0x00,                         // lag global[0]
 	0x4a, 0x04,                         // send 04 (get ego::cycler)
-	0x30, PATCH_UINT16(10),             // bnt [jump over heading call]
+	0x30, PATCH_UINT16(0x000a),         // bnt [skip the heading call]
 	PATCH_END
 };
 
 // The scripts in SQ4CD support simultaneous playing of speech and subtitles,
 // but this was not available as an option. The following two patches enable
 // this functionality in the game's GUI options dialog.
+//
 // Patch 1: iconTextSwitch::show, called when the text options button is shown.
-// This is patched to add the "Both" text resource (i.e. we end up with
-// "Speech", "Text" and "Both")
+//   This is patched to add the "Both" text resource (i.e. we end up with
+//   "Speech", "Text" and "Both")
 static const uint16 sq4CdSignatureTextOptionsButton[] = {
 	SIG_MAGICDWORD,
 	0x35, 0x01,                         // ldi 0x01
-	0xa1, 0x53,                         // sag 0x53
+	0xa1, 0x53,                         // sag global[0x53]
 	0x39, 0x03,                         // pushi 0x03
 	0x78,                               // push1
 	0x39, 0x09,                         // pushi 0x09
@@ -10138,48 +10141,51 @@ static const uint16 sq4CdPatchTextOptionsButton[] = {
 	PATCH_END
 };
 
-// Patch 2: Adjust a check in babbleIcon::init, which handles the babble icon
-// (e.g. the two guys from Andromeda) shown when dying/quitting.
+// Patch 2: Adjust a check in babbleIcon::init (the two guys from Andromeda),
+//  shown when dying/quitting.
+//
+// Responsible method: babbleIcon::init
 // Fixes bug: #6068
 static const uint16 sq4CdSignatureBabbleIcon[] = {
 	SIG_MAGICDWORD,
-	0x89, 0x5a,                         // lsg 5a
+	0x89, 0x5a,                         // lsg global[5a]
 	0x35, 0x02,                         // ldi 02
 	0x1a,                               // eq?
-	0x31, 0x26,                         // bnt 26  [02a7]
+	0x31, 0x26,                         // bnt 26 [02a7]
 	SIG_END
 };
 
 static const uint16 sq4CdPatchBabbleIcon[] = {
-	0x89, 0x5a,                         // lsg 5a
+	0x89, 0x5a,                         // lsg global[5a]
 	0x35, 0x01,                         // ldi 01
 	0x1a,                               // eq?
-	0x2f, 0x26,                         // bt 26  [02a7]
+	0x2f, 0x26,                         // bt 26 [02a7]
 	PATCH_END
 };
 
-// Patch 3: Add the ability to toggle among the three available options,
-// when the text options button is clicked: "Speech", "Text" and "Both".
-// Refer to the patch above for additional details.
-// iconTextSwitch::doit (called when the text options button is clicked)
+// Patch 3: Add the ability to toggle among the three available options
+//  when the text options button is clicked: "Speech", "Text" and "Both".
+//  Refer to the patch above for additional details.
+//
+// Responsible method: iconTextSwitch::doit
 static const uint16 sq4CdSignatureTextOptions[] = {
 	SIG_MAGICDWORD,
-	0x89, 0x5a,                         // lsg 0x5a (load global 90 to stack)
+	0x89, 0x5a,                         // lsg global[90]
 	0x3c,                               // dup
 	0x35, 0x01,                         // ldi 0x01
-	0x1a,                               // eq? (global 90 == 1)
+	0x1a,                               // eq?
 	0x31, 0x06,                         // bnt 0x06 (0x0691)
 	0x35, 0x02,                         // ldi 0x02
-	0xa1, 0x5a,                         // sag 0x5a (save acc to global 90)
+	0xa1, 0x5a,                         // sag global[90]
 	0x33, 0x0a,                         // jmp 0x0a (0x69b)
 	0x3c,                               // dup
 	0x35, 0x02,                         // ldi 0x02
-	0x1a,                               // eq? (global 90 == 2)
+	0x1a,                               // eq?
 	0x31, 0x04,                         // bnt 0x04 (0x069b)
 	0x35, 0x01,                         // ldi 0x01
-	0xa1, 0x5a,                         // sag 0x5a (save acc to global 90)
+	0xa1, 0x5a,                         // sag global[90]
 	0x3a,                               // toss
-	0x38, SIG_SELECTOR16(show),         // pushi 0x00d9
+	0x38, SIG_SELECTOR16(show),         // pushi show (0x00d9)
 	0x76,                               // push0
 	0x54, 0x04,                         // self 0x04
 	0x48,                               // ret
@@ -10187,17 +10193,17 @@ static const uint16 sq4CdSignatureTextOptions[] = {
 };
 
 static const uint16 sq4CdPatchTextOptions[] = {
-	0x89, 0x5a,                         // lsg 0x5a (load global 90 to stack)
+	0x89, 0x5a,                         // lsg global[90]
 	0x3c,                               // dup
 	0x35, 0x03,                         // ldi 0x03 (acc = 3)
-	0x1a,                               // eq? (global 90 == 3)
+	0x1a,                               // eq? (global[90] == 3)
 	0x2f, 0x07,                         // bt 0x07
-	0x89, 0x5a,                         // lsg 0x5a (load global 90 to stack again)
+	0x89, 0x5a,                         // lsg global[90]
 	0x35, 0x01,                         // ldi 0x01 (acc = 1)
-	0x02,                               // add: acc = global 90 (on stack) + 1 (previous acc value)
+	0x02,                               // add (acc = global[90] + 1)
 	0x33, 0x02,                         // jmp 0x02
 	0x35, 0x01,                         // ldi 0x01 (reset acc to 1)
-	0xa1, 0x5a,                         // sag 0x5a (save acc to global 90)
+	0xa1, 0x5a,                         // sag global[90]
 	0x33, 0x03,                         // jmp 0x03 (jump over the wasted bytes below)
 	0x34, PATCH_UINT16(0x0000),         // ldi 0x0000 (waste 3 bytes)
 	0x3a,                               // toss
@@ -10232,7 +10238,7 @@ static const SciScriptPatcherEntry sq4Signatures[] = {
 // Responsible method: robotIntoShip::changeState(9)
 static const uint16 sq1vgaSignatureUlenceFlatsTimepodGfxGlitch[] = {
 	0x39,
-	SIG_MAGICDWORD, SIG_SELECTOR8(cel), // pushi "cel"
+	SIG_MAGICDWORD, SIG_SELECTOR8(cel), // pushi cel
 	0x78,                               // push1
 	0x39, 0x0a,                         // pushi 0x0a (set ship::cel to 10)
 	0x38, SIG_UINT16(0x00a0),           // pushi 0x00a0 (ship::setLoop)
@@ -10246,18 +10252,20 @@ static const uint16 sq1vgaPatchUlenceFlatsTimepodGfxGlitch[] = {
 };
 
 // In Ulence Flats, there is a space ship, that you will use at some point.
-//  Near that space ship are 2 force field generators.
-//  When you look at the top of those generators, the game will crash.
-//  This happens also in Sierra SCI. It's caused by a jump, that goes out of bounds.
-//  We currently do not know if this was caused by a compiler glitch or if it was a developer error.
-//  Anyway we patch this glitchy code, so that the game won't crash anymore.
+//  Near that space ship are 2 force field generators. When you look at the top
+//  of those generators, the game will crash. This happens also in Sierra SCI.
+//  It's caused by a jump, that goes out of bounds.
+//
+// We currently do not know if this was caused by a compiler glitch or if it
+//  was a developer error. Anyway we patch this glitchy code, so that the game
+//  won't crash anymore.
 //
 // Applies to at least: English Floppy
 // Responsible method: radar1::doVerb
 // Fixes bug: #6816
 static const uint16 sq1vgaSignatureUlenceFlatsGeneratorGlitch[] = {
 	SIG_MAGICDWORD, 0x1a,               // eq?
-	0x30, SIG_UINT16(0xcdf4),           // bnt absolute 0xf000
+	0x30, SIG_UINT16(0xcdf4),           // bnt [absolute 0xf000]
 	SIG_END
 };
 
@@ -10270,9 +10278,9 @@ static const uint16 sq1vgaPatchUlenceFlatsGeneratorGlitch[] = {
 // No documentation for this patch (TODO)
 static const uint16 sq1vgaSignatureEgoShowsCard[] = {
 	SIG_MAGICDWORD,
-	0x38, SIG_SELECTOR16(timesShownID), // push "timesShownID"
+	0x38, SIG_SELECTOR16(timesShownID), // pushi timesShownID
 	0x78,                               // push1
-	0x38, SIG_SELECTOR16(timesShownID), // push "timesShownID"
+	0x38, SIG_SELECTOR16(timesShownID), // pushi timesShownID
 	0x76,                               // push0
 	0x51, 0x7c,                         // class DeltaurRegion
 	0x4a, 0x04,                         // send 0x04 (get timesShownID)
@@ -10291,7 +10299,7 @@ static const uint16 sq1vgaSignatureEgoShowsCard[] = {
 // Note that this script patch is merely a reordering of the
 // instructions in the original script.
 static const uint16 sq1vgaPatchEgoShowsCard[] = {
-	0x38, PATCH_SELECTOR16(timesShownID), // push "timesShownID"
+	0x38, PATCH_SELECTOR16(timesShownID), // pushi timesShownID
 	0x76,                               // push0
 	0x51, 0x7c,                         // class DeltaurRegion
 	0x4a, 0x04,                         // send 0x04 (get timesShownID)
@@ -10299,7 +10307,7 @@ static const uint16 sq1vgaPatchEgoShowsCard[] = {
 	0x35, 0x01,                         // ldi 1
 	0x02,                               // add
 	0x36,                               // push (this push corresponds to the wrong one above)
-	0x38, PATCH_SELECTOR16(timesShownID), // push "timesShownID"
+	0x38, PATCH_SELECTOR16(timesShownID), // pushi timesShownID
 	0x78,                               // push1
 	0x36,                               // push
 	0x51, 0x7c,                         // class DeltaurRegion
@@ -10327,38 +10335,38 @@ static const uint16 sq1vgaSignatureSpiderDroidTiming[] = {
 	0x38, SIG_UINT16(0x0088),           // pushi 0088h (script)
 	0x76,                               // push0
 	0x81, 0x02,                         // lag global[2] (current room)
-	0x4a, 0x04,                         // send 04 (get [current room].script)
+	0x4a, 0x04,                         // send 04 (get room script)
 	0x30, SIG_UINT16(0x0005),           // bnt [further method code]
 	0x35, 0x00,                         // ldi 00
 	0x32, SIG_UINT16(0x0052),           // jmp [super-call]
-	0x89, 0xa6,                         // lsg global[a6] <-- flag gets set to 1 when ego went up the skeleton tail, when going down it's set to 2
+	0x89, 0xa6,                         // lsg global[a6] (set to 1 when ego went up the skeleton tail, set to 2 when going down)
 	0x35, 0x01,                         // ldi 01
 	0x1a,                               // eq?
-	0x30, SIG_UINT16(0x0012),           // bnt [PChase set code], in case global A6 <> 1
+	0x30, SIG_UINT16(0x0012),           // bnt [PChase set code] (when global[A6] != 1)
 	0x81, 0xb5,                         // lag global[b5]
-	0x30, SIG_UINT16(0x000d),           // bnt [PChase set code], in case global B5 == 0
+	0x30, SIG_UINT16(0x000d),           // bnt [PChase set code] (when global[B5] == 0)
 	0x38, SIG_UINT16(0x008c),           // pushi 008c
 	0x78,                               // push1
-	0x72, SIG_UINT16(0x1cb6),           // lofsa 1CB6 (moveToPath)
+	0x72, SIG_UINT16(0x1cb6),           // lofsa moveToPath
 	0x36,                               // push
 	0x54, 0x06,                         // self 06
 	0x32, SIG_UINT16(0x0038),           // jmp [super-call]
 	// PChase set call
 	0x81, 0xb5,                         // lag global[B5]
 	0x18,                               // not
-	0x30, SIG_UINT16(0x0032),           // bnt [super-call], in case global B5 <> 0
+	0x30, SIG_UINT16(0x0032),           // bnt [super-call] (when global[B5] != 0)
 	// followed by:
 	// is spider in current room
-	// is global A6h == 2? -> set PChase
+	// is global[A6h] == 2? -> set PChase
 	SIG_END
 }; // 58 bytes)
 
-// Global A6h <> 1 (did NOT went up the skeleton)
-//  Global B5h = 0 -> set PChase
-//  Global B5h <> 0 -> do not do anything
-// Global A6h = 1 (did went up the skeleton)
-//  Global B5h = 0 -> set PChase
-//  Global B5h <> 0 -> set moveToPath
+// global[A6h] != 1 (did NOT went up the skeleton)
+//  global[B5h] = 0 -> set PChase
+//  global[B5h] != 0 -> do not do anything
+// global[A6h] = 1 (did went up the skeleton)
+//  global[B5h] = 0 -> set PChase
+//  global[B5h] != 0 -> set moveToPath
 
 static const uint16 sq1vgaPatchSpiderDroidTiming[] = {
 	0x63, 0x4e,                         // pToa script
@@ -10379,7 +10387,7 @@ static const uint16 sq1vgaPatchSpiderDroidTiming[] = {
 	0x35, 0x03,                         // ldi 03
 	0x0c,                               // shr
 	0x02,                               // add --> egoMoveSpeed + (egoMoveSpeed >> 3)
-	0x39, 0x01,                         // push 01 (waste 1 byte)
+	0x39, 0x01,                         // pushi 01 (waste 1 byte)
 	0x02,                               // add --> egoMoveSpeed++
 	0x65, 0x4c,                         // aTop cycleSpeed
 	0x65, 0x5e,                         // aTop moveSpeed
@@ -10411,23 +10419,21 @@ static const SciScriptPatcherEntry sq1vgaSignatures[] = {
 
 // ===========================================================================
 // The toolbox in sq5 is buggy. When you click on the upper part of the "put
-//  in inventory"-button (some items only - for example the hole puncher - at the
-//  upper left), points will get awarded correctly and the item will get put into
-//  the player's inventory, but you will then get a "not here" message and the
-//  item will also remain to be the current mouse cursor.
-// The bug report also says that items may get lost. I wasn't able to reproduce
-//  that part.
+//  in inventory" button (some items only - for example the hole puncher at the
+//  upper left), points will get awarded correctly, and the item will get put
+//  into the player's inventory, but you will then get a "not here" message,
+//  and the item will also remain as the current mouse cursor.
+// The bug report says items may get lost when exiting the toolbox screen,
+//  That was not reproduced.
 // This is caused by the mouse-click event getting reprocessed (which wouldn't
-//  be a problem by itself) and during this reprocessing coordinates are not
-//  processed the same as during the first click (script 226 includes a local
-//  subroutine, which checks coordinates in a hardcoded way w/o port-adjustment).
-// Because of this, the hotspot for the button is lower than it should be, which
-//  then results in the game thinking that the user didn't click on the button
-//  and also results in the previously mentioned message.
-// This happened in Sierra SCI as well (of course).
+//  be a problem by itself). Reprocessing treats coordinates differently from
+//  the first click (script 226 includes a local subroutine, which checks
+//  coordinates in a hardcoded way w/o port-adjustment).
+// Because of this, the hotspot for the button is lower than it should be,
+//  which results in the game thinking the user didn't click on the button and
+//  also results in the "not here" message.
 // We fix it by combining state 0 + 1 of takeTool::changeState and so stopping
-//  the event to get reprocessed. This was the only way possible, because everything
-//  else is done in SCI system scripts and I don't want to touch those.
+//  the event from being reprocessed... without touching SCI system scripts.
 // Applies to at least: English/German/French PC floppy
 // Responsible method: takeTool::changeState
 // Fixes bug: #6457
@@ -10441,9 +10447,9 @@ static const uint16 sq5SignatureToolboxFix[] = {
 	0x39, 0x03,                    // pushi 03
 	0x76,                          // push0
 	0x7c,                          // pushSelf
-	0x81, 0x5b,                    // lag 5b
+	0x81, 0x5b,                    // lag global[5b]
 	0x4a, 0x0e,                    // send 0e
-	0x32, SIG_UINT16(0x0088),      // jmp [end-of-method]
+	0x32, SIG_UINT16(0x0088),      // jmp [end of method]
 	0x3c,                          // dup
 	0x35, 0x01,                    // ldi 01
 	0x1a,                          // eq?
@@ -10474,7 +10480,7 @@ static const uint16 sq5PatchToolboxFix[] = {
 //
 // Applies to: PC Floppy
 // Responsible method: sEnterFromHall:changeState(0)
-// Fixes bug #7155
+// Fixes bug: #7155
 static const uint16 sq5SignatureDriveBayPathfindingFix[] = {
 	SIG_MAGICDWORD,
 	0x39, 0x0e,                     // pushi 0e [ x = 14d ]

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -8062,6 +8062,7 @@ static const SciScriptPatcherEntry qfg3Signatures[] = {
 #pragma mark -
 #pragma mark Quest for Glory 4
 
+// ===========================================================================
 // Cranium's TRAP screen in room 380 incorrectly creates an int array for
 // string data.
 //
@@ -8104,14 +8105,14 @@ static const uint16 qfg4BenchmarkSignature[] = {
 };
 
 static const uint16 qfg4BenchmarkPatch[] = {
-	0x35, 0x01,                         // ldi 0
+	0x35, 0x01,                         // ldi 1
 	0xa1, 0xbf,                         // sag global[191]
 	0x48,                               // ret
 	PATCH_END
 };
 
-// Right at the start of the game inside room 800, when automatically sliding down a slope
-// an error may happen inside Grooper::doit caused by a timing issue.
+// In room 800, at the start of the game, when automatically sliding down a
+// slope an error may happen inside Grooper::doit caused by a timing issue.
 //
 // We delay a bit, so that hero::cycler should always be set.
 //
@@ -8250,14 +8251,15 @@ static const uint16 qfg4InnPathfindingPatch[] = {
 // Fixes bug: #10758
 static const uint16 qfg4AutosaveSignature[] = {
 	0x30, SIG_ADDTOOFFSET(+2),          // bnt ?? [end the loop]
-	0x78,                               // push1
+	0x78,                               // push1 (1 call arg)
+                                        //
 	0x39, SIG_SELECTOR8(data),          // pushi data
 	0x76,                               // push0
-	SIG_ADDTOOFFSET(+2),                // CD="lag global[29]", floppy="lat temp[6]"
+	SIG_ADDTOOFFSET(+2),                // (CD="lag global[29]", floppy="lat temp[6]")
 	0x4a, SIG_UINT16(0x0004),           // send 4d
 	0x36,                               // push
 	SIG_MAGICDWORD,
-	0x43, 0x3f, SIG_UINT16(0x0002),     // callk 2d (CheckFreeSpace)
+	0x43, 0x3f, SIG_UINT16(0x0002),     // callk CheckFreeSpace, 2d
 	0x18,                               // not
 	0x2f, 0x05,                         // bt 05 [skip other OR condition]
 	0x8d, 0x09,                         // lst temp[9] (savegame file count)
@@ -8320,12 +8322,13 @@ static const uint16 qfg4SetLooperSignature2[] = {
 	SIG_MAGICDWORD,
 	0x38, SIG_SELECTOR16(setLoop),      // pushi setLoop
 	0x78,                               // push1
-	0x7a,                               // push2
+	0x7a,                               // push2 (2 call args)
 	0x39, 0x1c,                         // pushi 28d
 	0x78,                               // push1
-	0x43, 0x02, SIG_UINT16(0x0004),     // callk 4d (ScriptID 28 1)
+	0x43, 0x02, SIG_UINT16(0x0004),     // callk ScriptID, 4d (ScriptID 28 1)
 	SIG_END
 };
+
 static const uint16 qfg4SetLooperPatch2[] = {
 	0x38, PATCH_SELECTOR16(setLooper),  // pushi setLooper
 	PATCH_END
@@ -8357,6 +8360,7 @@ static const uint16 qfg4MoonriseSignature[] = {
 	0xc5, 0x00,                         // +at temp[0]
 	SIG_END
 };
+
 static const uint16 qfg4MoonrisePatch[] = {
 	0x35, 0x00,                         // ldi 0 (reset the is-night var)
 	0xa3, 0x05,                         // sal local[5]
@@ -8405,11 +8409,11 @@ static const uint16 qfg4AbsentInnkeeperSignature[] = {
 	0x24,                               // le?
                                         // (~~ junk begins ~~)
 	0x2f, 0x0f,                         // bt 15d [after the calle]
-	0x39, 0x03,                         // pushi 3d
-	0x89, 0x7b,                         // lsg global[123]
-	0x39, 0x04,                         // pushi 4d
+	0x39, 0x03,                         // pushi 3d (3 call args)
+	0x89, 0x7b,                         // lsg global[123] (needle value)
+	0x39, 0x04,                         // pushi 4d (haystack values...)
 	0x39, 0x05,                         // pushi 5d
-	0x46, SIG_UINT16(0xfde7), SIG_UINT16(0x0005), SIG_UINT16(0x0006), // calle 6d (proc64999_5(global[123], 4, 5))
+	0x46, SIG_UINT16(0xfde7), SIG_UINT16(0x0005), SIG_UINT16(0x0006), // calle [export 5 of script 64999], 6d (is needle in haystack?))
                                         // (~~ junk ends ~~)
 	0x31, 0x04,                         // bnt 4d [block 11]
 	0x35, 0x0a,                         // ldi 10d
@@ -8419,7 +8423,7 @@ static const uint16 qfg4AbsentInnkeeperSignature[] = {
 	SIG_ADDTOOFFSET(+14),               // (...block 12...)
 	SIG_ADDTOOFFSET(+2),                // (...else 0...)
 	0xa3, 0x02,                         // sal local[2] (all blocks set acc and jmp here)
-	PATCH_END
+	SIG_END
 };
 
 static const uint16 qfg4AbsentInnkeeperPatch[] = {
@@ -8444,13 +8448,13 @@ static const uint16 qfg4AbsentInnkeeperPatch[] = {
 	0x24,                               // le?
 	0x31, 0x19,                         // bnt 25d [block 12]
                                         // (block 11, original ops shift up)
-	0x78,                               // push1
+	0x78,                               // push1 (1 call arg)
 	0x38, PATCH_UINT16(0x0084),         // pushi 132d
-	0x45, 0x04, PATCH_UINT16(0x0002),   // callb 2d (proc0_4(132))
+	0x45, 0x04, PATCH_UINT16(0x0002),   // callb [export 4 of script 0], 2d (test flag 132)
 	0x31, 0x0f,                         // bnt 15d [next block]
-	0x78,                               // push1
+	0x78,                               // push1 (1 call arg)
 	0x38, PATCH_UINT16(0x0086),         // pushi 134d
-	0x45, 0x04, PATCH_UINT16(0x0002),   // callb 2d (proc0_4(134))
+	0x45, 0x04, PATCH_UINT16(0x0002),   // callb [export 4 of script 0], 2d (test flag 134)
 	0x18,                               // not
 	0x31, 0x04,                         // bnt 4d [block 12]
 	0x35, 0x0b,                         // ldi 11d
@@ -8631,7 +8635,7 @@ static const uint16 qfg4CrestBookshelfMotionPatch[] = {
 	0x51, PATCH_GETORIGINALBYTEADJUST(+1, +6), // class PolyPath
 	PATCH_END
 };
- 
+
 // The castle's great hall (630) has a doorMat region that intermittently sends
 // hero back to the room they just left (barrel room) the instant they arrive.
 //
@@ -8684,7 +8688,7 @@ static const uint16 qfg4GreatHallEntryPatch[] = {
 // Whether a lucky confusion or ugly hack, the wrapped void IF condition works.
 // When an object leaks into the accumulator. SSCI doesn't mind OR'ing it, too.
 // ScummVM detects unsafe arithmetic and crashes. ScummVM needs proper numbers.
-// 
+//
 // "Invalid arithmetic operation (bitwise OR - params: 002e:1694 and 0000:0001)"
 //
 // We leave the OR wrapper. When the call returns, we manually feed the OR a
@@ -8705,7 +8709,7 @@ static const uint16 qfg4GreatHallEntryPatch[] = {
 // Fixes bug: #10138, #10419, #10710, #10814
 static const uint16 qfg4ConditionalVoidSignature[] = {
 	SIG_MAGICDWORD,
-	0x43, 0x0a, SIG_UINT16(0x00002),    // callk 2d (SetNowSeen(stackedView))
+	0x43, 0x0a, SIG_UINT16(0x0002),     // callk SetNowSeen, 2d (update bounds for a stacked View)
 	0x36,                               // push (void func didn't set acc!)
 	0x35, 0x01,                         // ldi 1d
 	0x14,                               // or (whatever that was, make it non-zero)
@@ -8769,7 +8773,7 @@ static const uint16 qfg4GraveyardRopePatch2[] = {
 	PATCH_UINT16(0x6001),               // signal = 0x6001
 	PATCH_END
 };
-  
+
 // Rooms 622 and 623 play an extra door sound when entering. They both
 // delegate to script 645. It schedules sEnter, which indeed has an extra
 // sound. The CD edition removed the line. We remove it, too.
@@ -8812,9 +8816,9 @@ static const uint16 qfg4DoubleDoorSoundPatch[] = {
 // Fixes bug: #10829
 static const uint16 qfg4SafeDoorEastSignature[] = {
 	SIG_MAGICDWORD,                     // (else block, right door)
-	0x78,                               // push1
-	0x38, SIG_UINT16(0x00d7),           // pushi 215d
-	0x45, 0x04, SIG_UINT16(0x0002),     // callb 2d (proc0_4(215), test right door oiled flag)
+	0x78,                               // push1 (1 call arg)
+	0x38, SIG_UINT16(0x00d7),           // pushi 215d (right door oiled flag)
+	0x45, 0x04, SIG_UINT16(0x0002),     // callb [export 4 of script 0], 2d (test flag 215)
 	0x18,                               // not
 	0x31, SIG_ADDTOOFFSET(+1),          // bnt ?? [end the else block]
                                         //
@@ -8827,9 +8831,9 @@ static const uint16 qfg4SafeDoorEastPatch[] = {
 	0x35, 0x00,                         // ldi 0
 	0xa3, 0x02,                         // sal local[2]
                                         //
-	0x78,                               // push1
-	0x38, PATCH_UINT16(0x00d7),         // pushi 215d
-	0x45, 0x04, PATCH_UINT16(0x0002),   // callb 2d (proc0_4(215))
+	0x78,                               // push1 (1 call arg)
+	0x38, PATCH_UINT16(0x00d7),         // pushi 215d (right door oiled flag)
+	0x45, 0x04, PATCH_UINT16(0x0002),   // callb [export 4 of script 0], 2d (test flag 215)
 	0x18,                               // not
 	0x31, PATCH_GETORIGINALBYTEADJUST(10, -4), // bnt ?? [end the else block]
 	PATCH_END
@@ -8846,15 +8850,15 @@ static const uint16 qfg4SafeDoorOilSignature[] = {
 	0x35, 0x20,                         // ldi 32d (vBackDoor::doVerb(oil), right door)
 	SIG_ADDTOOFFSET(+5),                // ...
 	SIG_MAGICDWORD,
-	0x38, SIG_UINT16(0x00d6),           // pushi 214d
-	0x45, 0x02, SIG_UINT16(0x0002),     // callb 2d (proc0_2(214), set left oiled flag!?)
+	0x38, SIG_UINT16(0x00d6),           // pushi 214d (left oiled flag!?)
+	0x45, 0x02, SIG_UINT16(0x0002),     // callb [export 2 of script 0], 2d (set flag 214)
 
 	SIG_ADDTOOFFSET(+152),              // ...
 
 	0x35, 0x20,                         // ldi 32d (vLeftDoor::doVerb(oil), left door)
 	SIG_ADDTOOFFSET(+5),                // ...
-	0x38, SIG_UINT16(0x00d7),           // pushi 215d
-	0x45, 0x02, SIG_UINT16(0x0002),     // callb 2d (proc0_2(215), set right oiled flag!?)
+	0x38, SIG_UINT16(0x00d7),           // pushi 215d (right oiled flag!?)
+	0x45, 0x02, SIG_UINT16(0x0002),     // callb [export 2 of script 0], 2d (set flag 215)
 	SIG_END
 };
 
@@ -8991,8 +8995,8 @@ static const uint16 qfg4RestartPatch[] = {
 	0x06,                               // mul
 	0x36,                               // push (temp[0] * 45)
 	0xc5, 0x00,                         // +at temp[0]
-	0xb1, 0x90,                         // sagi global[144]
-	0x33, 0xed,                         // jmp [-19] (loop)
+	0xb1, 0x90,                         // sagi (global[144 + temp[0]])
+	0x33, 0xed,                         // jmp -19d (loop)
                                         // (that loop freed +30 bytes)
 
 	0x35, 0x14,                         // ldi 20d (leave this assignment as-is)
@@ -9029,8 +9033,8 @@ static const uint16 qfg4RestartPatch[] = {
 	0x20,                               // ge?
 	0x31, 0x07,                         // bnt 7d [end the loop]
 	0x85, 0x00,                         // lat temp[0]
-	0xb8, PATCH_UINT16(0x016f),         // ssgi 367d (global[367 + n] = pop())
-	0x33, 0xf2,                         // jmp [-14] (loop)
+	0xb8, PATCH_UINT16(0x016f),         // ssgi (global[367 + n] = pop())
+	0x33, 0xf2,                         // jmp -14d (loop)
                                         // (that loop freed +52 bytes)
 
                                         // (reset properties for a few items)
@@ -9058,19 +9062,19 @@ static const uint16 qfg4RestartPatch[] = {
 	0x39, 0x1c,                         // pushi 28d (thePiePan)
 	0x7a,                               // push2 (loop)
 	0x39, 0x0a,                         // pushi 10d (cel)
-	0x40, PATCH_UINT16(0xffd5), PATCH_UINT16(0x0006), // call 6d [-43]
+	0x40, PATCH_UINT16(0xffd5), PATCH_UINT16(0x0006), // call [-43], 6d
 
 	0x39, 0x03,                         // pushi 3d (call has 3 args)
 	0x39, 0x27,                         // pushi 39d (theBroom)
 	0x39, 0x0a,                         // pushi 10d (loop)
 	0x76,                               // push0 (cel)
-	0x40, PATCH_UINT16(0xffc9), PATCH_UINT16(0x0006), // call 6d [-55]
+	0x40, PATCH_UINT16(0xffc9), PATCH_UINT16(0x0006), // call [-55], 6d
 
 	0x39, 0x03,                         // pushi 3d (call has 3 args)
 	0x39, 0x2c,                         // pushi 44d (theTorch)
 	0x39, 0x08,                         // pushi 8d (loop)
 	0x39, 0x09,                         // pushi 9d (cel)
-	0x40, PATCH_UINT16(0xffbc), PATCH_UINT16(0x0006), // call 6d [-68]
+	0x40, PATCH_UINT16(0xffbc), PATCH_UINT16(0x0006), // call [-68], 6d
 
 	0x33, 0x0a,                         // jmp 10d [skip waste bytes]
 	PATCH_END
@@ -9249,7 +9253,7 @@ static const uint16 qfg4Tarot3TwoOfCupsPatch[] = {
 	0x33, 0x02,                         // jmp 2d [to the call]
 	0x39, 0x6e,                         // pushi 110d (setMotion, regular y arg)
                                         //
-	0x41, 0xb0, PATCH_UINT16(0x0006),   // call 6d [-80]
+	0x41, 0xb0, PATCH_UINT16(0x0006),   // call [-80], 6d
 	0x33, 0x13,                         // jmp 19d [end the local[2] switch]
 
 	0x3c,                               // dup
@@ -9260,7 +9264,7 @@ static const uint16 qfg4Tarot3TwoOfCupsPatch[] = {
 	0x39, 0x32,                         // pushi 50d (setScalar, arg 5)
 	0x38, PATCH_UINT16(0x0090),         // pushi 144d (setMotion, x arg)
 	0x39, 0x32,                         // pushi 50d (setMotion, y arg)
-	0x41, 0x9b, PATCH_UINT16(0x0006),   // call 6d [-101]
+	0x41, 0x9b, PATCH_UINT16(0x0006),   // call [-101], 6d
 
 	0x33, 0x0c,                         // jmp 12d [skip to the original toss that ends this switch]
 	PATCH_END
@@ -9478,7 +9482,7 @@ static const uint16 qfg4PitRopeMageSignature1[] = {
 
 	0x38, SIG_SELECTOR16(setMotion),    // pushi setMotion (move right)
 	0x38, SIG_UINT16(0x0004),           // pushi 4d
-	0x51, SIG_ADDTOOFFSET(1),           // class MoveTo
+	0x51, SIG_ADDTOOFFSET(+1),          // class MoveTo
 	0x36,                               // push
 	SIG_MAGICDWORD,
 	0x38, SIG_UINT16(0x00da),           // pushi 218d
@@ -9494,17 +9498,17 @@ static const uint16 qfg4PitRopeMagePatch1[] = {
 	0x34, PATCH_UINT16(0x0000),         // ldi 0 (erase the branch)
 	PATCH_ADDTOOFFSET(+20),             // ...
 
-	0x38, SIG_SELECTOR16(cycleSpeed),   // pushi cycleSpeed
+	0x38, PATCH_SELECTOR16(cycleSpeed), // pushi cycleSpeed
 	0x76,                               // push0
 	0x81, 0x00,                         // lag global[0] (hero)
-	0x4a, SIG_UINT16(0x0004),           // send 4d
+	0x4a, PATCH_UINT16(0x0004),         // send 4d
 	0xa3, 0x02,                         // sal local[2] (cache again)
                                         //
-	0x38, SIG_SELECTOR16(setSpeed),     // pushi setSpeed
+	0x38, PATCH_SELECTOR16(setSpeed),   // pushi setSpeed
 	0x78,                               // push1
 	0x39, 0x08,                         // pushi 8d (set our fixed speed)
 	0x81, 0x00,                         // lag global[0] (hero)
-	0x4a, SIG_UINT16(0x0006),           // send 6d
+	0x4a, PATCH_UINT16(0x0006),         // send 6d
 	0x5c,                               // selfID (erase 1 byte to keep disasm aligned)
 	PATCH_END
 };
@@ -9648,7 +9652,7 @@ static const uint16 qfg4EffectDisposalSignature[] = {
 	0x31, 0x0a,                         // bnt 10d [skip super::dispose()]
 	0x38, SIG_SELECTOR16(dispose),      // pushi dispose
 	0x76,                               // push0
-	0x57, SIG_ADDTOOFFSET(+1), SIG_UINT16(0x0004), // super 4d (Prop)
+	0x57, SIG_ADDTOOFFSET(+1), SIG_UINT16(0x0004), // super Prop, 4d
 	0x33, 0x04,                         // jmp 4d [ret]
 
 	0x35, 0x01,                         // ldi 1d (enable normal disposal)
@@ -9683,13 +9687,13 @@ static const uint16 qfg4EffectDisposalPatch[] = {
 // Fixes bug: #10871
 static const uint16 qfg4DungeonGateSignature[] = {
 	0x39, 0x05,                         // pushi 5d (5 call args)
-	0x89, 0x0c,                         // lsg global[12]
+	0x89, 0x0c,                         // lsg global[12] (needle value)
 	SIG_MAGICDWORD,
 	0x38, SIG_UINT16(0x029e),           // pushi 670 (Dungeon)
 	0x38, SIG_UINT16(0x032a),           // pushi 810 (Combat)
 	0x38, SIG_UINT16(0x0262),           // pushi 610 (Castle entrance)
 	0x38, SIG_UINT16(0x0276),           // pushi 630 (Great hall)
-	0x46, SIG_UINT16(0xfde7), SIG_UINT16(0x0005), SIG_UINT16(0x000a), // calle 10d (proc64999_5(...))
+	0x46, SIG_UINT16(0xfde7), SIG_UINT16(0x0005), SIG_UINT16(0x000a), // calle [export 5 of script 64999], 10d (is needle in haystack?)
 	SIG_END
 };
 
@@ -9698,7 +9702,7 @@ static const uint16 qfg4DungeonGatePatch[] = {
 	PATCH_ADDTOOFFSET(+2),              // ...
 	0x34, PATCH_UINT16(0x0000),         // ldi 0 (erase the Dungeon arg)
 	PATCH_ADDTOOFFSET(+9),              // ...
-	0x46, PATCH_UINT16(0xfde7), PATCH_UINT16(0x0005), PATCH_UINT16(0x0008), // calle 8d (proc64999_5(...))
+	0x46, PATCH_UINT16(0xfde7), PATCH_UINT16(0x0005), PATCH_UINT16(0x0008), // calle [export 5 of script 64999], 8d (is needle in haystack?)
 	PATCH_END
 };
 
@@ -9727,7 +9731,7 @@ static const uint16 qfg4StuckDoorSignature[] = {
 	0x81, 0x5b,                         // lag global[91]
 	0x4a, SIG_UINT16(0x0010),           // send 16d
 	SIG_ADDTOOFFSET(+89),               // ...
-	0x57, SIG_ADDTOOFFSET(+1), SIG_UINT16(0x0004), // super 4d (Teller)
+	0x57, SIG_ADDTOOFFSET(+1), SIG_UINT16(0x0004), // super Teller, 4d
 	SIG_END
 };
 
@@ -9738,7 +9742,7 @@ static const uint16 qfg4StuckDoorPatch[] = {
 	0x39, 0x06,                         // pushi 6d
 	0x39, 0x09,                         // pushi 9d
 	0x59, 0x01,                         // &rest 1d
-	0x57, PATCH_GETORIGINALBYTE(112), PATCH_UINT16(0x000a), // super 10d (Teller)
+	0x57, PATCH_GETORIGINALBYTE(112), PATCH_UINT16(0x000a), // super Teller, 10d
 	0x32, PATCH_UINT16(0x0003),         // jmp 3d [skip waste bytes]
 	PATCH_END
 };

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -4287,14 +4287,14 @@ static const SciScriptPatcherEntry larry7Signatures[] = {
 // This is only broken in the PC version. It was fixed for Amiga + Atari ST.
 //
 // Credits to OmerMor, for finding it.
-
+//
 // Applies to at least: English PC Floppy
 // Responsible method: room4::init
 static const uint16 laurabow1SignatureEasterEggViewFix[] = {
 	0x78,                               // push1
 	0x76,                               // push0
 	SIG_MAGICDWORD,
-	0x38, SIG_SELECTOR16(setLoop),      // pushi "setLoop"
+	0x38, SIG_SELECTOR16(setLoop),      // pushi setLoop
 	0x78,                               // push1
 	0x39, 0x03,                         // pushi 3 (loop 3, view only has 3 loops)
 	SIG_END
@@ -4302,25 +4302,28 @@ static const uint16 laurabow1SignatureEasterEggViewFix[] = {
 
 static const uint16 laurabow1PatchEasterEggViewFix[] = {
 	PATCH_ADDTOOFFSET(+7),
-	0x02,                            // change loop to 2
+	0x02,                               // (change loop to 2)
 	PATCH_END
 };
 
-// When oiling the armor or opening the visor of the armor, the scripts
-//  first check if Laura/ego is near the armor and if she is not, they will move her
-//  to the armor. After that further code is executed.
+// When oiling the armor or opening the visor of the armor, the scripts first
+//  check if Laura/ego is near the armor and if she is not, they will move her
+//  to the armor. After that, further code is executed.
 //
 // The current location is checked by a ego::inRect() call.
 //
-// The given rect for the inRect call inside openVisor::changeState was made larger for Atari ST/Amiga versions.
-//  We change the PC version to use the same rect.
+// The given rect for the inRect call inside openVisor::changeState was made
+//  larger for Atari ST/Amiga versions. We change the PC version to use the
+//  same rect.
 //
-// Additionally the coordinate, that Laura is moved to, is 152, 107 and may not be reachable depending on where
-//  Laura/ego was, when "use oil on helmet of armor" / "open visor of armor" got entered.
-//  Bad coordinates are for example 82, 110, which then cause collisions and effectively an endless loop.
-//  Game will effectively "freeze" and the user is only able to restore a previous game.
-//  This also happened, when using the original interpreter.
-//  We change the destination coordinate to 152, 110, which seems to be reachable all the time.
+// Additionally, the coordinate that Laura is moved to (152, 107) may not be
+//  reachable depending on where Laura was when "use oil on helmet of armor"
+//  or "open visor of armor" got entered. Bad coordinates such as (82, 110),
+//  cause collisions and effectively an endless loop, effectively freezing the
+//  game. The user is only able to restore a previous game.
+//
+//  We change the destination coordinate to (152, 110), which seems to be
+//   reachable all the time.
 //
 // The following patch fixes the rect for the PC version of the game.
 //
@@ -4331,18 +4334,18 @@ static const uint16 laurabow1SignatureArmorOpenVisorFix[] = {
 	0x39, 0x04,                         // pushi 04
 	SIG_MAGICDWORD,
 	0x39, 0x6a,                         // pushi 6a (106d)
-	0x38, SIG_UINT16(0x96),             // pushi 0096 (150d)
+	0x38, SIG_UINT16(0x0096),           // pushi 0096 (150d)
 	0x39, 0x6c,                         // pushi 6c (108d)
-	0x38, SIG_UINT16(0x98),             // pushi 0098 (152d)
+	0x38, SIG_UINT16(0x0098),           // pushi 0098 (152d)
 	SIG_END
 };
 
 static const uint16 laurabow1PatchArmorOpenVisorFix[] = {
 	PATCH_ADDTOOFFSET(+2),
 	0x39, 0x68,                         // pushi 68 (104d)   (-2)
-	0x38, SIG_UINT16(0x94),             // pushi 0094 (148d) (-2)
+	0x38, PATCH_UINT16(0x0094),         // pushi 0094 (148d) (-2)
 	0x39, 0x6f,                         // pushi 6f (111d)   (+3)
-	0x38, SIG_UINT16(0x9a),             // pushi 009a (154d) (+2)
+	0x38, PATCH_UINT16(0x009a),         // pushi 009a (154d) (+2)
 	PATCH_END
 };
 
@@ -4367,13 +4370,15 @@ static const uint16 laurabow1PatchArmorMoveToFix[] = {
 	PATCH_END
 };
 
-// In some cases like for example when the player oils the arm of the armor, command input stays
-// disabled, even when the player exits fast enough, so that Laura doesn't die.
+// In some cases like for example when the player oils the arm of the armor,
+// command input stays disabled, even when the player exits fast enough, so
+// that Laura doesn't die.
 //
-// This is caused by the scripts only enabling control (directional movement), but do not enable command input as well.
+// This is caused by the scripts only enabling control (directional movement),
+// but do not enable command input as well.
 //
-// This bug also happens, when using the original interpreter.
-// And it was fixed for the Atari ST + Amiga versions of the game.
+// This bug also happens, when using the original interpreter. It was fixed for
+// the Atari ST + Amiga versions of the game.
 //
 // Applies to at least: English PC Floppy
 // Responsible method: 2nd subroutine in script 37, called by oiling::changeState(7)
@@ -4419,19 +4424,19 @@ static const uint16 laurabow1PatchArmorOilingArmFix[] = {
 	0x3c,                               // dup
 	// saves a total of 6 bytes
 	0x76,                               // push0
-	0x72, SIG_UINT16(0x1a59),           // lofsa "Can"
+	0x72, PATCH_UINT16(0x1a59),         // lofsa "Can"
 	0x4a, 0x04,                         // send 04
 	0x76,                               // push0
-	0x72, SIG_UINT16(0x19a1),           // lofsa "Visor"
+	0x72, PATCH_UINT16(0x19a1),         // lofsa "Visor"
 	0x4a, 0x04,                         // send 04
 	0x76,                               // push0
-	0x72, SIG_UINT16(0x194d),           // lofsa "note"
+	0x72, PATCH_UINT16(0x194d),         // lofsa "note"
 	0x4a, 0x04,                         // send 04
 	0x76,                               // push0
-	0x72, SIG_UINT16(0x18f9),           // lofsa "valve" 18f3
+	0x72, PATCH_UINT16(0x18f9),         // lofsa "valve" 18f3
 	0x4a, 0x04,                         // send 04
 	// new code to enable input as well, needs 9 spare bytes
-	0x38, SIG_UINT16(0x00e2),           // canInput
+	0x38, PATCH_UINT16(0x00e2),         // pushi canInput
 	0x78,                               // push1
 	0x78,                               // push1
 	0x51, 0x2b,                         // class User
@@ -4458,17 +4463,17 @@ static const uint16 laurabow1PatchArmorOilingArmFix[] = {
 //  lit when re-entering until the next act. This is due to Room58:init
 //  incorrectly testing the global variable that tracks Jeeves' act 2 state.
 //
-// We fix this by changing the test from if global155 equals 11, which it
+// We fix this by changing the test from if global[155] equals 11, which it
 //  never does, to if it's greater than 11. The global is set to 12 in
 //  lightCandles:changeState(11) and it continues to increment as Jeeves'
 //  chore sequence progresses, ending with 17.
 //
 // Applies to: DOS, Amiga, Atari ST
 // Responsible method: Room58:init
-// Fixes bug #10743
+// Fixes bug: #10743
 static const uint16 laurabow1SignatureChapelCandlesPersistence[] = {
 	SIG_MAGICDWORD,
-	0x89, 0x9b,                         // lsg global155 [ Jeeves' act 2 state ]
+	0x89, 0x9b,                         // lsg global[155] [ Jeeves' act 2 state ]
 	0x35, 0x0b,                         // ldi b
 	0x1a,                               // eq?
 	SIG_END
@@ -4482,18 +4487,18 @@ static const uint16 laurabow1PatchChapelCandlesPersistence[] = {
 
 // LB1 DOS doesn't acknowledge Lillian's presence in room 44 when she's sitting
 //  on the bed in act 4. Look, talk, etc respond that she's not there.
-//  This is due to not setting global 195 which tracks who is in the room.
+//  This is due to not setting global[195] which tracks who is in the room.
 //  We fix this by setting the global as Amiga and Atari ST versions do.
 //
 // Applies to: DOS only
 // Responsible method: Room44:init
-// Fixes bug #10742
+// Fixes bug: #10742
 static const uint16 laurabow1SignatureLillianBedFix[] = {
 	SIG_MAGICDWORD,
 	0x72, SIG_UINT16(0x10f8),           // lofsa suit2 [ only matches DOS version ]
 	0x4a, 0x14,                         // send 14
 	SIG_ADDTOOFFSET(+8),
-	0x89, 0x76,                         // lsg global118
+	0x89, 0x76,                         // lsg global[118]
 	0x35, 0x02,                         // ldi 2
 	0x12,                               // and
 	0x30, SIG_UINT16(0x000d),           // bnt d [ haven't seen Lillian in study ]
@@ -4503,30 +4508,33 @@ static const uint16 laurabow1SignatureLillianBedFix[] = {
 
 static const uint16 laurabow1PatchLillianBedFix[] = {
 	PATCH_ADDTOOFFSET(+13),
-	0x81, 0x76,                         // lag global118
+	0x81, 0x76,                         // lag global[118]
 	0x7a,                               // push2
 	0x12,                               // and
 	0x31, 0x0f,                         // bnt f [ haven't seen Lillian in study ]
 	0x35, 0x20,                         // ldi 20 [ Lillian ]
-	0xa1, 0xc3,                         // sag global195 [ set Lillian as in the room ]
+	0xa1, 0xc3,                         // sag global[195] [ set Lillian as in the room ]
 	PATCH_END
 };
 
-// When you tell Lilly about Gertie in room 35, Lilly will then walk to the left and off the screen.
-// In case Laura (ego) is in the way, the whole game will basically block and you won't be able
-// to do anything except saving + restoring the game.
+// When you tell Lilly about Gertie in room 35, Lilly will then walk to the
+// left and off the screen. If Laura (ego) is in the way, the whole game will
+// basically block and you won't be able to do anything except saving or
+// restoring the game.
 //
-// If this happened already, the player can enter
-// "send Lillian ignoreActors 1" inside the debugger to fix this situation.
+// If this happened already, the player can enter "send Lillian ignoreActors 1"
+// inside the debugger to fix this situation.
 //
-// This issue is very difficult to solve, because Lilly also walks diagonally after walking to the left right
-// under the kitchen table. This means that even if we added a few more rectangle checks, there could still be
-// spots, where the game would block.
+// This issue is very difficult to solve, because Lilly also walks diagonally
+// after walking to the left right under the kitchen table. This means that
+// even if we added a few more rectangle checks, there could still be spots,
+// where the game would block.
 //
-// Also the mover "PathOut" is used for Lillian instead of the regular "MoveTo", which would avoid other
-// actors by itself.
+// Also the mover "PathOut" is used for Lillian instead of the regular
+// "MoveTo", which would avoid other actors by itself.
 //
-// So instead we set Lilly to ignore other actors during that cutscene, which is the least invasive solution.
+// So instead we set Lilly to ignore other actors during that cutscene, which
+// is the least invasive solution.
 //
 // Applies to at least: English PC Floppy, English Amiga Floppy, English Atari ST Floppy
 // Responsible method: goSee::changeState(1) in script 236
@@ -4536,7 +4544,7 @@ static const uint16 laurabow1SignatureTellLillyAboutGerieBlockingFix1[] = {
 	SIG_MAGICDWORD,
 	0x38, SIG_UINT16(0x00c1),           // pushi 00C1h
 	0x38, SIG_UINT16(0x008f),           // pushi 008Fh
-	0x38, SIG_SELECTOR16(ignoreActors), // pushi (ignoreActors)
+	0x38, SIG_SELECTOR16(ignoreActors), // pushi ignoreActors
 	0x78,                               // push1
 	0x76,                               // push0
 	SIG_END
@@ -4554,10 +4562,10 @@ static const uint16 laurabow1SignatureTellLillyAboutGerieBlockingFix2[] = {
 	0x35, 0x09,                         // ldi 09
 	0x1a,                               // eq?
 	0x30, SIG_UINT16(0x003f),           // bnt [ret]
-	0x39, SIG_ADDTOOFFSET(+1),          // pushi (view)
+	0x39, SIG_ADDTOOFFSET(+1),          // pushi view
 	0x78,                               // push1
 	0x38, SIG_UINT16(0x0203),           // pushi 203h (515d)
-	0x38, SIG_ADDTOOFFSET(+2),          // pushi (posn)
+	0x38, SIG_ADDTOOFFSET(+2),          // pushi posn
 	0x7a,                               // push2
 	0x38, SIG_UINT16(0x00c9),           // pushi C9h (201d)
 	SIG_MAGICDWORD,
@@ -4568,7 +4576,7 @@ static const uint16 laurabow1SignatureTellLillyAboutGerieBlockingFix2[] = {
 };
 
 static const uint16 laurabow1PatchTellLillyAboutGertieBlockingFix2[] = {
-	0x38, PATCH_SELECTOR16(ignoreActors), // pushi (ignoreActors)
+	0x38, PATCH_SELECTOR16(ignoreActors), // pushi ignoreActors
 	0x78,                                 // push1
 	0x76,                                 // push0
 	0x33, 0x00,                           // ldi 00 (waste 2 bytes)
@@ -4602,7 +4610,7 @@ static const uint16 laurabow1PatchTellLillyAboutGertieBlockingFix2[] = {
 
 // Applies to: DOS, Amiga, Atari ST and occurs in Sierra's interpreter.
 // Responsible method: Act:setMotion
-// Fixes bug #10733
+// Fixes bug: #10733
 static const uint16 laurabow1SignatureObstacleCollisionLockupsFix[] = {
 	SIG_MAGICDWORD,
 	0x30, SIG_UINT16(0x002f),           // bnt 2f
@@ -4611,7 +4619,7 @@ static const uint16 laurabow1SignatureObstacleCollisionLockupsFix[] = {
 	0x54, 0x04,                         // self 4
 	0x7a,                               // push2 [ -info- ]
 	0x76,                               // push0
-	0x87, 0x01,                         // lap param1
+	0x87, 0x01,                         // lap param[1]
 	0x4a, 0x04,                         // send 4
 	0x36,                               // push
 	0x34, SIG_UINT16(0x8000),           // ldi 8000
@@ -4619,10 +4627,10 @@ static const uint16 laurabow1SignatureObstacleCollisionLockupsFix[] = {
 	0x30, SIG_UINT16(0x000a),           // bnt a
 	0x39, 0x56,                         // pushi 56 [ new ]
 	0x76,                               // push0
-	0x87, 0x01,                         // lap param1
+	0x87, 0x01,                         // lap param[1]
 	0x4a, 0x04,                         // send 4
 	0x32, SIG_UINT16(0x0002),           // jmp 2
-	0x87, 0x01,                         // lap param1
+	0x87, 0x01,                         // lap param[1]
 	0x65, 0x4c,                         // aTop mover
 	0x39, 0x57,                         // pushi 57 [ init ]
 	0x78,                               // push1
@@ -4648,17 +4656,17 @@ static const uint16 laurabow1PatchObstacleCollisionLockupsFix[] = {
 	0x54, 0x04,                         // self 4
 	0x7a,                               // push2 [ -info- ]
 	0x76,                               // push0
-	0x87, 0x01,                         // lap param1
+	0x87, 0x01,                         // lap param[1]
 	0x4a, 0x04,                         // send 4
 	0x38, PATCH_UINT16(0x8000),         // pushi 8000 [ save 1 byte ]
 	0x12,                               // and
 	0x31, 0x09,                         // bnt 9 [ save 1 byte ]
 	0x39, 0x56,                         // pushi 56 [ new ]
 	0x76,                               // push0
-	0x87, 0x01,                         // lap param1
+	0x87, 0x01,                         // lap param[1]
 	0x4a, 0x04,                         // send 4
 	0x33, 0x02,                         // jmp 2 [ save 1 byte ]
-	0x87, 0x01,                         // lap param1
+	0x87, 0x01,                         // lap param[1]
 	0x65, 0x4c,                         // aTop mover
 	0x39, 0x57,                         // pushi 57 [ init ]
 	0x78,                               // push1
@@ -4683,12 +4691,12 @@ static const uint16 laurabow1PatchObstacleCollisionLockupsFix[] = {
 //
 // Applies to: DOS, Amiga, Atari ST
 // Responsible method: Room47:doit
-// Fixes bug #9949
+// Fixes bug: #9949
 static const uint16 laurabow1SignatureAtticStairsLockupFix[] = {
 	SIG_MAGICDWORD,
 	0x39, SIG_SELECTOR8(loop),          // pushi loop
 	0x76,                               // push0
-	0x81, 0x00,                         // lag 00
+	0x81, 0x00,                         // lag global[0]
 	0x4a, 0x04,                         // send 4 [ ego:loop? ]
 	0x36,                               // push
 	0x35, 0x03,                         // ldi 03 [ facing north ]
@@ -4698,7 +4706,7 @@ static const uint16 laurabow1SignatureAtticStairsLockupFix[] = {
 
 static const uint16 laurabow1PatchAtticStairsLockupFix[] = {
 	PATCH_ADDTOOFFSET(+8),
-	0x35, 0x2,                          // ldi 02 [ facing south ]
+	0x35, 0x02,                         // ldi 02 [ facing south ]
 	0x1c,                               // ne?
 	PATCH_END
 };

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -6352,7 +6352,7 @@ static const SciScriptPatcherEntry phantasmagoria2Signatures[] = {
 // Fixes bug: #5865
 static const uint16 pq1vgaSignatureBriefingGettingStuck[] = {
 	0x76,                                // push0
-	0x45, 0x02, 0x00,                    // call export 2 of script 0 (disable control)
+	0x45, 0x02, 0x00,                    // callb [export 2 of script 0], 00 (disable control)
 	0x38, SIG_ADDTOOFFSET(+2),           // pushi notify
 	0x76,                                // push0
 	0x81, 0x02,                          // lag global[2] (get current room)
@@ -6365,7 +6365,7 @@ static const uint16 pq1vgaSignatureBriefingGettingStuck[] = {
 };
 
 static const uint16 pq1vgaPatchBriefingGettingStuck[] = {
-	0x33, 0x0a,                      // jmp to lsl local[2], skip over export 2 and ::notify
+	0x33, 0x0a,                      // jmp [to lsl local[2], skip over export 2 and ::notify]
 	PATCH_END                        // rm015::notify would try to make ego walk to the chair
 };
 
@@ -6379,26 +6379,26 @@ static const uint16 pq1vgaPatchBriefingGettingStuck[] = {
 //  when the 2 seconds have passed and the locker got closed.
 // Applies to at least: English floppy
 // Responsible method: putGun::changeState (script 341)
-// Fixes bug: #5705 / #6400
+// Fixes bug: #5705, #6400
 static const uint16 pq1vgaSignaturePutGunInLockerBug[] = {
 	0x35, 0x00,                      // ldi 00
 	0x1a,                            // eq?
 	0x31, 0x25,                      // bnt [next state check]
 	SIG_ADDTOOFFSET(+22),            // [skip 22 bytes]
 	SIG_MAGICDWORD,
-	0x38, SIG_SELECTOR16(put),       // pushi "put"
+	0x38, SIG_SELECTOR16(put),       // pushi put
 	0x78,                            // push1
 	0x76,                            // push0
-	0x81, 0x00,                      // lag 00
+	0x81, 0x00,                      // lag global[0]
 	0x4a, 0x06,                      // send 06 - ego::put(0)
 	0x35, 0x02,                      // ldi 02
 	0x65, 0x1c,                      // aTop 1c (set timer to 2 seconds)
 	0x33, 0x0e,                      // jmp [end of method]
-	0x3c,                            // dup --- next state check target
+	0x3c,                            // dup (state check)
 	0x35, 0x01,                      // ldi 01
 	0x1a,                            // eq?
 	0x31, 0x08,                      // bnt [end of method]
-	0x39, SIG_SELECTOR8(dispose),    // pushi "dispose"
+	0x39, SIG_SELECTOR8(dispose),    // pushi dispose
 	0x76,                            // push0
 	0x72, SIG_UINT16(0x0088),        // lofsa 0088
 	0x4a, 0x04,                      // send 04 - locker::dispose
@@ -6412,14 +6412,14 @@ static const uint16 pq1vgaPatchPutGunInLockerBug[] = {
 	0x35, 0x02,                      // ldi 02
 	0x65, 0x1c,                      // aTop 1c (set timer to 2 seconds)
 	0x33, 0x17,                      // jmp [end of method]
-	0x3c,                            // dup --- next state check target
+	0x3c,                            // dup (state check)
 	0x35, 0x01,                      // ldi 01
 	0x1a,                            // eq?
 	0x31, 0x11,                      // bnt [end of method]
-	0x38, PATCH_SELECTOR16(put),     // pushi "put"
+	0x38, PATCH_SELECTOR16(put),     // pushi put
 	0x78,                            // push1
 	0x76,                            // push0
-	0x81, 0x00,                      // lag 00
+	0x81, 0x00,                      // lag global[0]
 	0x4a, 0x06,                      // send 06 - ego::put(0)
 	PATCH_END
 };
@@ -6441,16 +6441,16 @@ static const uint16 pq1vgaSignatureMapSaveRestoreBug[] = {
 	0x38, 0x64, 0x80,                    // pushi 8064
 	0x76,                                // push0
 	0x89, 0x28,                          // lsg global[28]
-	0x43, 0x08, 0x08,                    // kDrawPic (8)
+	0x43, 0x08, 0x08,                    // callk DrawPic, 8
 	SIG_END
 };
 
 static const uint16 pq1vgaPatchMapSaveRestoreBug[] = {
-	0x38, PATCH_SELECTOR16(overlay), // pushi "overlay"
+	0x38, PATCH_SELECTOR16(overlay), // pushi overlay
 	0x7a,                            // push2
 	0x89, 0xf9,                      // lsg global[f9]
 	0x39, 0x64,                      // pushi 64 (no transition)
-	0x81, 0x02,                      // lag global[02] (current room object)
+	0x81, 0x02,                      // lag global[2] (current room object)
 	0x4a, 0x08,                      // send 08
 	0x18,                            // not (waste byte)
 	PATCH_END
@@ -6463,7 +6463,6 @@ static const SciScriptPatcherEntry pq1vgaSignatures[] = {
 	{  true,   500, "map save/restore bug",                           2, pq1vgaSignatureMapSaveRestoreBug,    pq1vgaPatchMapSaveRestoreBug },
 	SCI_SIGNATUREENTRY_TERMINATOR
 };
-
 
 // ===========================================================================
 // Police Quest 3
@@ -6510,7 +6509,7 @@ static const uint16 pq3PatchGiveLocketPoints[] = {
 	0x7a,                                // push2
 	0x38, PATCH_UINT16(0x00ff),          // pushi 0x00ff - using last flag slot, seems to be unused
 	0x39, 0x0a,                          // pushi 10d - 10 points
-	0x45, 0x06, 0x04,                    // callb export000_6, 4
+	0x45, 0x06, 0x04,                    // callb [export 6 of script 0], 4
 	// original code
 	0x39, 0x20,                          // pushi 20h (state)
 	0x78,                                // push1
@@ -6561,21 +6560,21 @@ static const uint16 pq4CdSpeechAndSubtitlesSignature[] = {
 	0x76,                         // push0
 	0x43, 0x22, SIG_UINT16(0x00), // callk IsHiRes
 	SIG_ADDTOOFFSET(+45),         // skip over the remaining code
-	0x38, SIG_SELECTOR16(init),   // pushi $93 (init)
+	0x38, SIG_SELECTOR16(init),   // pushi init ($93)
 	0x76,                         // push0
 	0x59, 0x01,                   // &rest 01
-	0x57, 0x8f, SIG_UINT16(0x04), // super GCItem
+	0x57, 0x8f, SIG_UINT16(0x04), // super GCItem, 4
 	0x48,                         // ret
 
 	// iconText::select
-	0x38, SIG_SELECTOR16(select), // pushi $1c4 (select)
+	0x38, SIG_SELECTOR16(select), // pushi select ($1c4)
 	0x76,                         // push0
 	0x59, 0x01,                   // &rest 01
 	0x57, 0x8f, SIG_UINT16(0x04), // super GCItem, 4
 	0x89, 0x5a,                   // lsg global[$5a]
 	0x35, 0x02,                   // ldi 2
 	0x12,                         // and
-	0x30, SIG_UINT16(0x1f),       // bnt [jump to currently-in-text-mode code]
+	0x30, SIG_UINT16(0x001f),     // bnt [to currently-in-text-mode code]
 	SIG_ADDTOOFFSET(+67),         // skip over the rest
 	0x48,                         // ret
 	SIG_END
@@ -6615,31 +6614,34 @@ static const uint16 pq4CdSpeechAndSubtitlesPatch[] = {
 
 	// iconText::select
 	PATCH_ADDTOOFFSET(+10),         // skip over the super code
-	0xc1, 0x5a,                     // +ag $5a
-	0xa1, 0x5a,                     // sag $5a
+	0xc1, 0x5a,                     // +ag global[$5a]
+	0xa1, 0x5a,                     // sag global[$5a]
 	0x36,                           // push
 	0x35, 0x04,                     // ldi 4
 	0x28,                           // uge?
 	0x31, 0x03,                     // bnt [skip over follow up code]
 	0x78,                           // push1
-	0xa9, 0x5a,                     // ssg $5a
+	0xa9, 0x5a,                     // ssg global[$5a]
 	0x76,                           // push0
 	0x41, 0x99, PATCH_UINT16(0x00), // call [our new subroutine which sets view+loop+cel, effectively -103], 0
 	0x33, 0x2f,                     // jmp [to end of original select, show call]
 	PATCH_END
 };
 
-// When showing the red shoe to Barbie after showing the police badge but before
-// exhausting the normal dialogue tree, the game plays the expected dialogue but
-// fails to award points or set an internal flag indicating this interaction has
-// occurred (which is needed to progress in the game). This is because the game
-// checks global $9a (dialogue progress flag) instead of local 3 (badge shown
-// flag) when interacting with Barbie. The game uses the same
-// `shoeShoe::changeState(0)` method for showing the shoe to the young woman at the
-// bar earlier in the game, and checks local 3 then, so just check local 3 in
-// both cases to prevent the game from appearing to be in an unwinnable state
-// just because the player interacted in the "wrong" order.
+// When showing the red shoe to Barbie, after showing the police badge but
+// before exhausting the normal dialogue tree, the game plays the expected
+// dialogue but fails to award points or set an internal flag indicating this
+// interaction has occurred (which is needed to progress in the game).
+//
+// This is because the game checks global[$9a] (dialogue progress flag) instead
+// of local[3] (badge shown flag) when interacting with Barbie. The game uses
+// the same `shoeShoe::changeState(0)` method for showing the shoe to the young
+// woman at the bar earlier in the game, and checks local[3] then, so just
+// check local[3] in both cases to prevent the game from appearing to be in an
+// unwinnable state just because the player interacted in the "wrong" order.
+//
 // Applies to at least: English floppy, German floppy, English CD, German CD
+// Fixes bug: #9849
 static const uint16 pq4BittyKittyShowBarieRedShoeSignature[] = {
 	// stripper::noun check is for checking, if police badge was shown
 	SIG_MAGICDWORD,
@@ -6647,14 +6649,14 @@ static const uint16 pq4BittyKittyShowBarieRedShoeSignature[] = {
 	0x35, 0x02,                         // ldi 2
 	0x1e,                               // gt?
 	0x30, SIG_UINT16(0x0028),           // bnt [skip 2 points code]
-	0x39, SIG_SELECTOR8(points),       // pushi $61 (points)
+	0x39, SIG_SELECTOR8(points),        // pushi points ($61)
 	SIG_END
 };
 
 static const uint16 pq4BittyKittyShowBarbieRedShoePatch[] = {
 	0x83, 0x03,                         // lal local[3]
 	0x30, PATCH_UINT16(0x002b),         // bnt [skip 2 points code]
-	0x33, 1,                            // jmp 1 (waste some bytes)
+	0x33, 0x01,                         // jmp 1 (waste some bytes)
 	PATCH_END
 };
 
@@ -6670,42 +6672,43 @@ static const uint16 pq4BittyKittyShowBarbieRedShoePatch[] = {
 // be less than one second if the timer is set in between hardware clock
 // seconds, so the values are increased slightly from their equivalent tick
 // values to compensate for this.
+//
+// TODO: The object structure changed in PQ4CD so ticks moved from 0x20 to 0x22.
+// Additional signatures/patches will need to be added for CD version.
+//
 // Applies to at least: English Floppy, German floppy
 // Responsible method: metzAttack::changeState(2) - 120 ticks (player needs to draw gun)
 //                     stickScr::changeState(0) - 180 ticks (player needs to tell enemy to drop gun)
 //                     dropStick::changeState(5) - 120 ticks (player needs to tell enemy to turn around)
 //                     turnMetz::changeState(5) - 600/420 ticks (player needs to cuff Metz)
 //                     all in script 390
-//
-// TODO: The object structure changed in PQ4CD so ticks moved from 0x20 to 0x22.
-// Additional signatures/patches will need to be added for CD version.
 static const uint16 pq4FloppyCityHallDrawGunTimerSignature[] = {
 	SIG_MAGICDWORD,
 	0x4a, SIG_UINT16(0x08), // send 8
 	0x32,                   // jmp [ret]
 	SIG_ADDTOOFFSET(+8),    // skip over some code
-	0x35, 0x78,             // pushi $78 (120)
+	0x35, 0x78,             // ldi $78 (120)
 	0x65, 0x20,             // aTop ticks
 	SIG_END
 };
 
 static const uint16 pq4FloppyCityHallDrawGunTimerPatch[] = {
 	PATCH_ADDTOOFFSET(+12), // send 8, jmp, skip over some code
-	0x35, 0x05,             // pushi 4 (120t/2s -> 4s)
+	0x35, 0x05,             // ldi 5 (120t/2s -> 5s)
 	0x65, 0x1c,             // aTop seconds
 	PATCH_END
 };
 
 static const uint16 pq4FloppyCityHallTellEnemyDropWeaponTimerSignature[] = {
 	SIG_MAGICDWORD,
-	0x34, SIG_UINT16(0xb4), // pushi $b4 (180)
+	0x34, SIG_UINT16(0xb4), // ldi $b4 (180)
 	0x65, 0x20,             // aTop ticks
-	0x32, SIG_UINT16(0x5e), // jmp to ret
+	0x32, SIG_UINT16(0x5e), // jmp [to ret]
 	SIG_END
 };
 
 static const uint16 pq4FloppyCityHallTellEnemyDropWeaponTimerPatch[] = {
-	0x34, PATCH_UINT16(0x05), // pushi 5 (180t/3s -> 5s)
+	0x34, PATCH_UINT16(0x05), // ldi 5 (180t/3s -> 5s)
 	0x65, 0x1c,               // aTop seconds
 	PATCH_END
 };
@@ -6713,50 +6716,51 @@ static const uint16 pq4FloppyCityHallTellEnemyDropWeaponTimerPatch[] = {
 static const uint16 pq4FloppyCityHallTellEnemyTurnAroundTimerSignature[] = {
 	SIG_MAGICDWORD,
 	0x4a, SIG_UINT16(0x04), // send 4
-	0x35, 0x78,             // pushi $78 (120)
+	0x35, 0x78,             // ldi $78 (120)
 	0x65, 0x20,             // aTop ticks
 	SIG_END
 };
 
 static const uint16 pq4FloppyCityHallTellEnemyTurnAroundTimerPatch[] = {
 	PATCH_ADDTOOFFSET(+3), // send 4
-	0x35, 0x03,            // pushi 3 (120t/2s -> 3s)
+	0x35, 0x03,            // ldi 3 (120t/2s -> 3s)
 	0x65, 0x1c,            // aTop seconds
 	PATCH_END
 };
 
 static const uint16 pq4FloppyCityHallCuffEnemyTimerSignature[] = {
 	SIG_MAGICDWORD,
-	0x34, SIG_UINT16(0x258), // pushi $258 (600)
-	0x65, 0x20,              // aTop ticks
+	0x34, SIG_UINT16(0x0258), // ldi $258 (600)
+	0x65, 0x20,               // aTop ticks
 	SIG_ADDTOOFFSET(+3),
-	0x34, SIG_UINT16(0x1a4), // pushi $1a4 (420)
-	0x65, 0x20,              // aTop ticks
+	0x34, SIG_UINT16(0x01a4), // ldi $1a4 (420)
+	0x65, 0x20,               // aTop ticks
 	SIG_END
 };
 
 static const uint16 pq4FloppyCityHallCuffEnemyTimerPatch[] = {
-	0x34, PATCH_UINT16(0x0a), // pushi 10 (600t/10s)
+	0x34, PATCH_UINT16(0x0a), // ldi 10 (600t/10s)
 	0x65, 0x1c,               // aTop seconds
 	PATCH_ADDTOOFFSET(+3),
-	0x34, SIG_UINT16(0x07),   // pushi 7 (420t/7s)
+	0x34, PATCH_UINT16(0x07), // ldi 7 (420t/7s)
 	0x65, 0x1c,               // aTop seconds
 	PATCH_END
 };
 
 // The end game action sequence also uses ticks instead of seconds. See the
 // description of city hall action sequence issues for more information.
+//
 // Applies to at least: English Floppy, German floppy, English CD
 // Responsible method: comeInLast::changeState(11)
 static const uint16 pq4LastActionHeroTimerSignature[] = {
 	SIG_MAGICDWORD,
-	0x34, SIG_UINT16(0x12c),   // pushi $12c (300)
+	0x34, SIG_UINT16(0x012c),  // ldi $12c (300)
 	0x65, SIG_ADDTOOFFSET(+1), // aTop ticks ($20 for floppy, $22 for CD)
 	SIG_END
 };
 
 static const uint16 pq4LastActionHeroTimerPatch[] = {
-	0x34, PATCH_UINT16(0x05),                 // pushi 5 (300t/5s)
+	0x34, PATCH_UINT16(0x0005),               // ldi 5 (300t/5s)
 	0x65, PATCH_GETORIGINALBYTEADJUST(4, -4), // aTop seconds
 	PATCH_END
 };
@@ -6785,17 +6789,18 @@ static const SciScriptPatcherEntry pq4Signatures[] = {
 // master sound volume to 127, but the game should always use the volume stored
 // in ScummVM.
 // Applies to at least: English CD
+// Fixes bug: #9700
 static const uint16 pqSwatVolumeResetSignature[] = {
 	SIG_MAGICDWORD,
 	0x38, SIG_SELECTOR16(masterVolume), // pushi masterVolume
 	0x78,                               // push1
-	0x39, 0x7f,                         // push $7f
-	0x54, SIG_UINT16(0x06),             // self 6
+	0x39, 0x7f,                         // pushi $7f
+	0x54, SIG_UINT16(0x0006),           // self 6
 	SIG_END
 };
 
 static const uint16 pqSwatVolumeResetPatch[] = {
-	0x32, PATCH_UINT16(6), // jmp 6 [past volume reset]
+	0x32, PATCH_UINT16(0x0006),         // jmp 6 [past volume reset]
 	PATCH_END
 };
 

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -3212,19 +3212,19 @@ static const SciScriptPatcherEntry kq6Signatures[] = {
 // Applies to at least: PC CD 1.4 English, 1.51 English, 1.51 German, 2.00 English
 static const uint16 kq7SubtitleFixSignature1[] = {
 	SIG_MAGICDWORD,
-	0x39, SIG_SELECTOR8(fore), // pushi $25 (fore)
+	0x39, SIG_SELECTOR8(fore), // pushi fore ($25)
 	0x78,                      // push1
 	0x39, 0x06,                // pushi 6 - sets fore to 6
-	0x39, SIG_SELECTOR8(back), // pushi $26 (back)
+	0x39, SIG_SELECTOR8(back), // pushi back ($26)
 	0x78,                      // push1
 	0x78,                      // push1 - sets back to 1
-	0x39, SIG_SELECTOR8(font), // pushi $2a (font)
+	0x39, SIG_SELECTOR8(font), // pushi font ($2a)
 	0x78,                      // push1
 	0x89, 0x16,                // lsg global[$16] - sets font to global[$16]
 	0x7a,                      // push2 (y)
 	0x78,                      // push1
 	0x76,                      // push0 - sets y to 0
-	0x54, SIG_UINT16(0x18),    // self $18
+	0x54, SIG_UINT16(0x0018),  // self $18
 	SIG_END
 };
 
@@ -3243,7 +3243,7 @@ static const uint16 kq7SubtitleFixSignature2[] = {
 	0x38, SIG_SELECTOR16(masterVolume), // pushi masterVolume (0212h for 2.00, 0219h for 1.51)
 	0x76,                               // push0
 	0x81, 0x01,                         // lag global[1]
-	0x4a, SIG_UINT16(0x04),             // send 4
+	0x4a, SIG_UINT16(0x0004),           // send 4
 	0x65, 0x32,                         // aTop curVolume
 	0x38, SIG_SELECTOR16(masterVolume), // pushi masterVolume (0212h for 2.00, 0219h for 1.51)
 	0x78,                               // push1
@@ -3255,7 +3255,7 @@ static const uint16 kq7SubtitleFixSignature2[] = {
 	0x08,                               // div
 	0x36,                               // push
 	0x81, 0x01,                         // lag global[1]
-	0x4a, SIG_UINT16(0x06),             // send 6
+	0x4a, SIG_UINT16(0x0006),           // send 6
 	// end of volume code
 	0x35, 0x01,                         // ldi 1
 	0x65, 0x28,                         // aTop initialized
@@ -3290,7 +3290,7 @@ static const uint16 kq7SubtitleFixSignature3[] = {
 	0x31, 0x07,                 // bnt [skip init code]
 	0x38, SIG_SELECTOR16(init), // pushi init ($8e for 2.00, $93 for 1.51)
 	0x76,                       // push0
-	0x54, SIG_UINT16(0x04),     // self 4
+	0x54, SIG_UINT16(0x0004),   // self 4
 	// end of init code
 	0x8f, 0x00,                 // lsp param[0]
 	0x35, 0x01,                 // ldi 1
@@ -3306,22 +3306,21 @@ static const uint16 kq7SubtitleFixSignature3[] = {
 };
 
 static const uint16 kq7SubtitleFixPatch3[] = {
-	PATCH_ADDTOOFFSET(+2),       // skip over "pToa initialized code"
-	0x2f, 0x0c,                  // bt [skip init code] - saved 1 byte
-	0x38,
-	PATCH_GETORIGINALUINT16(+6), // pushi (init)
-	0x76,                        // push0
-	0x54, PATCH_UINT16(0x04),    // self 4
+	PATCH_ADDTOOFFSET(+2),              // skip over "pToa initialized code"
+	0x2f, 0x0c,                         // bt [skip init code] - saved 1 byte
+	0x38, PATCH_GETORIGINALUINT16(+6),  // pushi init
+	0x76,                               // push0
+	0x54, PATCH_UINT16(0x0004),         // self 4
 	// additionally set background color here (5 bytes)
-	0x34, PATCH_UINT16(0xFF),    // pushi 255
-	0x65, 0x2e,                  // aTop back
+	0x34, PATCH_UINT16(0x00ff),         // ldi 255
+	0x65, 0x2e,                         // aTop back
 	// end of init code
-	0x8f, 0x00,                  // lsp param[0]
-	0x35, 0x01,                  // ldi 1 - this may get optimized to get another byte
-	0x1e,                        // gt?
-	0x31, 0x04,                  // bnt [set acc to 0]
-	0x87, 0x02,                  // lap param[2]
-	0x2f, 0x02,                  // bt [over set acc to 0 code]
+	0x8f, 0x00,                         // lsp param[0]
+	0x35, 0x01,                         // ldi 1 (this may get optimized to get another byte)
+	0x1e,                               // gt?
+	0x31, 0x04,                         // bnt [set acc to 0]
+	0x87, 0x02,                         // lap param[2]
+	0x2f, 0x02,                         // bt [over set acc to 0 code]
 	PATCH_END
 };
 
@@ -3331,9 +3330,9 @@ static const uint16 kq7BenchmarkSignature[] = {
 	0x38, SIG_SELECTOR16(new), // pushi new
 	0x76,                      // push0
 	0x51, SIG_ADDTOOFFSET(+1), // class Actor
-	0x4a, SIG_UINT16(0x04),    // send 4
-	0xa5, 0x00,                // sat 0
-	0x39, SIG_SELECTOR8(view), // pushi $e (view)
+	0x4a, SIG_UINT16(0x0004),  // send 4
+	0xa5, 0x00,                // sat temp[0]
+	0x39, SIG_SELECTOR8(view), // pushi view ($e)
 	SIG_MAGICDWORD,
 	0x78,                      // push1
 	0x38, SIG_UINT16(0xfdd4),  // pushi 64980
@@ -3347,16 +3346,20 @@ static const uint16 kq7BenchmarkPatch[] = {
 };
 
 // When attempting to use an inventory item on an object that does not interact
-// with that item, the game temporarily displays an X cursor, but does this by
-// spinning for 90000 cycles inside 'KQ7CD::pragmaFail', which make the duration
-// dependent on CPU speed, maxes out the CPU for no reason, and keeps the engine
-// from polling for events (which may make the window appear nonresponsive to the OS)
+// with that item, the game briefly displays an X cursor. It does this by
+// spinning for 90000 cycles, which makes the duration dependent on CPU speed,
+// maxes out the CPU for no reason, and keeps the engine from polling for
+// events (which may make the window appear nonresponsive to the OS).
+//
+// We replace the loop with a call to kWait().
+//
 // Applies to at least: KQ7 English 2.00b
+// Responsible method: KQ7CD::pragmaFail in script 0
 static const uint16 kq7PragmaFailSpinSignature[] = {
 	0x35, 0x00,               // ldi 0
-	0xa5, 0x02,               // sat 2
+	0xa5, 0x02,               // sat temp[2]
 	SIG_MAGICDWORD,
-	0x8d, 0x02,               // lst 2
+	0x8d, 0x02,               // lst temp[2]
 	0x35, 0x03,               // ldi 3
 	0x22,                     // lt?
 	SIG_END
@@ -3366,14 +3369,14 @@ static const uint16 kq7PragmaFailSpinPatch[] = {
 	0x78,                                     // push1
 	0x39, 0x12,                               // pushi 18 (~300ms)
 	0x43, kScummVMWaitId, PATCH_UINT16(0x02), // callk Wait, 2
-	0x33, 0x16,                               // jmp to setCursor
+	0x33, 0x16,                               // jmp [to setCursor]
 	PATCH_END
 };
 
 //          script, description,                                      signature                                 patch
 static const SciScriptPatcherEntry kq7Signatures[] = {
 	{  true,     0, "disable video benchmarking",                  1, kq7BenchmarkSignature,                    kq7BenchmarkPatch },
-	{  true,     0, "remove hardcoded spinloop",                   1, kq7PragmaFailSpinSignature,               kq7PragmaFailSpinPatch },
+	{  true,     0, "remove hardcoded spin loop",                  1, kq7PragmaFailSpinSignature,               kq7PragmaFailSpinPatch },
 	{  true,    31, "enable subtitles (1/3)",                      1, kq7SubtitleFixSignature1,                 kq7SubtitleFixPatch1 },
 	{  true, 64928, "enable subtitles (2/3)",                      1, kq7SubtitleFixSignature2,                 kq7SubtitleFixPatch2 },
 	{  true, 64928, "enable subtitles (3/3)",                      1, kq7SubtitleFixSignature3,                 kq7SubtitleFixPatch3 },


### PR DESCRIPTION
* Corrected opcode comments.
* Corrected SIG macros in patches and vice versa.
* Added some ticket numbers to descriptions.
* Named & bracketed indices for [ global | local | temp | param ] vars.
  * Indices themselves are left in each author's markup.
* Some description revision and word wrapping.
* Lowered uppercase hex bytes. Padded single-digit hex bytes.
  * Space-padded decimal bytes so their lack of 0x prefix stands out among the regular hex bytes.
* Removed stray whitespace characters.
* Parenthesizd any hex values where selector macros are present, since they've become reminders.
* Four digit uint16 macros. An afterthought. Not exhaustively enforced.
* Removed a workaround I'd commented away and forgotten about.

These should be innocuous changes.
