### PR TITLE
IOS: Add support for three finger swipes up/down for showing/hiding so…

### DIFF
--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -349,17 +349,18 @@ uint getSizeNextPOT(uint size) {
 }
 
 - (void)setupGestureRecognizers {
-	UISwipeGestureRecognizer *swipeUpFourFingers = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(fourFingersSwipeUp:)];
-	swipeUpFourFingers.direction = UISwipeGestureRecognizerDirectionUp;
-	swipeUpFourFingers.numberOfTouchesRequired = 4;
-	swipeUpFourFingers.delaysTouchesBegan = NO;
-	swipeUpFourFingers.delaysTouchesEnded = NO;
+	const NSUInteger KEYBOARDSWIPETOUCHCOUNT = 3;
+	UISwipeGestureRecognizer *swipeUpKeyboard = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(keyboardSwipeUp:)];
+	swipeUpKeyboard.direction = UISwipeGestureRecognizerDirectionUp;
+	swipeUpKeyboard.numberOfTouchesRequired = KEYBOARDSWIPETOUCHCOUNT;
+	swipeUpKeyboard.delaysTouchesBegan = NO;
+	swipeUpKeyboard.delaysTouchesEnded = NO;
 	
-	UISwipeGestureRecognizer *swipeDownFourFingers = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(fourFingersSwipeDown:)];
-	swipeDownFourFingers.direction = UISwipeGestureRecognizerDirectionDown;
-	swipeDownFourFingers.numberOfTouchesRequired = 4;
-	swipeDownFourFingers.delaysTouchesBegan = NO;
-	swipeDownFourFingers.delaysTouchesEnded = NO;
+	UISwipeGestureRecognizer *swipeDownKeyboard = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(keyboardSwipeDown:)];
+	swipeDownKeyboard.direction = UISwipeGestureRecognizerDirectionDown;
+	swipeDownKeyboard.numberOfTouchesRequired = KEYBOARDSWIPETOUCHCOUNT;
+	swipeDownKeyboard.delaysTouchesBegan = NO;
+	swipeDownKeyboard.delaysTouchesEnded = NO;
 	
 	UISwipeGestureRecognizer *swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeRight:)];
 	swipeRight.direction = UISwipeGestureRecognizerDirectionRight;
@@ -391,16 +392,16 @@ uint getSizeNextPOT(uint size) {
 	doubleTapTwoFingers.delaysTouchesBegan = NO;
 	doubleTapTwoFingers.delaysTouchesEnded = NO;
 
-	[self addGestureRecognizer:swipeUpFourFingers];
-	[self addGestureRecognizer:swipeDownFourFingers];
+	[self addGestureRecognizer:swipeUpKeyboard];
+	[self addGestureRecognizer:swipeDownKeyboard];
 	[self addGestureRecognizer:swipeRight];
 	[self addGestureRecognizer:swipeLeft];
 	[self addGestureRecognizer:swipeUp];
 	[self addGestureRecognizer:swipeDown];
 	[self addGestureRecognizer:doubleTapTwoFingers];
 
-	[swipeUpFourFingers release];
-	[swipeDownFourFingers release];
+	[swipeUpKeyboard release];
+	[swipeDownKeyboard release];
 	[swipeRight release];
 	[swipeLeft release];
 	[swipeUp release];
@@ -980,11 +981,11 @@ uint getSizeNextPOT(uint size) {
 	_secondTouch = nil;
 }
 
-- (void)fourFingersSwipeUp:(UISwipeGestureRecognizer *)recognizer {
+- (void)keyboardSwipeUp:(UISwipeGestureRecognizer *)recognizer {
 	[_keyboardView showKeyboard];
 }
 
-- (void)fourFingersSwipeDown:(UISwipeGestureRecognizer *)recognizer {
+- (void)keyboardSwipeDown:(UISwipeGestureRecognizer *)recognizer {
 	[_keyboardView hideKeyboard];
 }
 

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -349,6 +349,18 @@ uint getSizeNextPOT(uint size) {
 }
 
 - (void)setupGestureRecognizers {
+	UISwipeGestureRecognizer *swipeUpFourFingers = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(fourFingersSwipeUp:)];
+	swipeUpFourFingers.direction = UISwipeGestureRecognizerDirectionUp;
+	swipeUpFourFingers.numberOfTouchesRequired = 4;
+	swipeUpFourFingers.delaysTouchesBegan = NO;
+	swipeUpFourFingers.delaysTouchesEnded = NO;
+	
+	UISwipeGestureRecognizer *swipeDownFourFingers = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(fourFingersSwipeDown:)];
+	swipeDownFourFingers.direction = UISwipeGestureRecognizerDirectionDown;
+	swipeDownFourFingers.numberOfTouchesRequired = 4;
+	swipeDownFourFingers.delaysTouchesBegan = NO;
+	swipeDownFourFingers.delaysTouchesEnded = NO;
+	
 	UISwipeGestureRecognizer *swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeRight:)];
 	swipeRight.direction = UISwipeGestureRecognizerDirectionRight;
 	swipeRight.numberOfTouchesRequired = 2;
@@ -379,12 +391,16 @@ uint getSizeNextPOT(uint size) {
 	doubleTapTwoFingers.delaysTouchesBegan = NO;
 	doubleTapTwoFingers.delaysTouchesEnded = NO;
 
+	[self addGestureRecognizer:swipeUpFourFingers];
+	[self addGestureRecognizer:swipeDownFourFingers];
 	[self addGestureRecognizer:swipeRight];
 	[self addGestureRecognizer:swipeLeft];
 	[self addGestureRecognizer:swipeUp];
 	[self addGestureRecognizer:swipeDown];
 	[self addGestureRecognizer:doubleTapTwoFingers];
 
+	[swipeUpFourFingers release];
+	[swipeDownFourFingers release];
 	[swipeRight release];
 	[swipeLeft release];
 	[swipeUp release];
@@ -962,6 +978,14 @@ uint getSizeNextPOT(uint size) {
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
 	_firstTouch = nil;
 	_secondTouch = nil;
+}
+
+- (void)fourFingersSwipeUp:(UISwipeGestureRecognizer *)recognizer {
+	[_keyboardView showKeyboard];
+}
+
+- (void)fourFingersSwipeDown:(UISwipeGestureRecognizer *)recognizer {
+	[_keyboardView hideKeyboard];
 }
 
 - (void)twoFingersSwipeRight:(UISwipeGestureRecognizer *)recognizer {


### PR DESCRIPTION
Also if the user for whatever reason wants to show/hide the keyboard at will, he/she may do so using <s>four</s>three-finger swipes up/down. Hopefully this doesn't clash with anything. I don't think there were any "<s>four</s>three finger" gestures in the old scumm games... I've been playing through a couple of old scumm games this way and I think it works well. This means you can use keyboard whenever you want, regardless if the device is in landscape or portrait.

Original PR #1358 