### PR TITLE
SAGA: Fix potential crash when talking to Sist (bug #10365)

### DIFF
--- a/engines/saga/sfuncs.cpp
+++ b/engines/saga/sfuncs.cpp
@@ -735,6 +735,7 @@ void Script::sfSwapActors(SCRIPTFUNC_PARAMS) {
 	ActorData *actor2 = _vm->_actor->getActor(actorId2);
 
 	SWAP(actor1->_location, actor2->_location);
+	SWAP(actor1->_lastZone, actor2->_lastZone);
 
 	if (actor1->_flags & kProtagonist) {
 		actor1->_flags &= ~kProtagonist;


### PR DESCRIPTION
This is my attempt at fixing bug #10365 - SAGA: ITE: Crash when talking to Sist

Thanks to dafioram, there is an easily reproducable test case. Unfortunately it involves navigating through the rat maze, but it could be worse.

This is what appears to happen:

When Rif puts on the rat disguise, he is swapped out for a different actor. When he takes off the disguise, after reaching Sist's office, the old actor is swapped back in again.

At that point, original Rif's actor will have a _lastZone pointer which not only is for the wrong room, it was deleted when Rif in disguise left the room.

My fix for this is to also have the actors swap their _lastZone pointers. This seems to work fine in this case, but I don't know if sfSwapActors() is used anywhere else in the game. At the very least, I think the swapped-in actor should get _lastZone from the swapped out actor. I'm less sure if the swapped out actor should get the swapped in actor's _lastZone, but I figured that if that's a problem it will be fixed when that actor is swapped back in again.
