### PR TITLE
GUI: Flush debugger prompts on text console

### DIFF
--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -257,6 +257,7 @@ void Debugger::enter() {
 
 	do {
 		printf("debug> ");
+		::fflush(stdout);
 		if (!fgets(buf, sizeof(buf), stdin))
 			return;
 


### PR DESCRIPTION
When built with enable-text-console and disable-readline, flushing output
immediately after printing the debugger prompt, before waiting for input,
ensures that external tools can spawn ScummVM, detect the prompt, and pipe
in automated responses (e.g., [expect scripts](https://en.wikipedia.org/wiki/Expect)).

Explicit flushing was necessary at least on Windows, where support for
automating terminal input is less sophisticated. Otherwise, the prompt
string doesn't make it through the pipe, and both the script and ScummVM
get stuck waiting for input.

&nbsp;

Readline wasn't flushing for me on Windows, and I couldn't find a way to
make it do so. I imagine the readline lib works better on Linux inside
pseudoterminals.