### PR TITLE
SCI: Fix inconsistent debugger breakpoint messages

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -4256,6 +4256,8 @@ bool Console::cmdBreakpointFunction(int argc, const char **argv) {
 	_debugState._breakpoints.push_back(bp);
 	_debugState._activeBreakpointTypes |= BREAK_EXPORT;
 
+	printBreakpoint(_debugState._breakpoints.size() - 1, bp);
+
 	return true;
 }
 
@@ -4291,6 +4293,8 @@ bool Console::cmdBreakpointAddress(int argc, const char **argv) {
 
 	_debugState._breakpoints.push_back(bp);
 	_debugState._activeBreakpointTypes |= BREAK_ADDRESS;
+
+	printBreakpoint(_debugState._breakpoints.size() - 1, bp);
 
 	return true;
 }


### PR DESCRIPTION
Fixes bp_function and bp_address not printing the created breakpoint, as
happens with the other bp_ commands.

````
) bp_function 0 4
) bp_method hero::hide
  #1: Execute hero::hide
) bp_kernel RestoreGame
  #2: Kernel call kRestoreGame
) bp_read hero::plane
  #3: Read hero::plane
) bp_write hero::plane
  #4: Write hero::plane
) bp_address 0000:1234
) bp_list
Breakpoint list:
  #0: Execute script 0, export 4
  #1: Execute hero::hide
  #2: Kernel call kRestoreGame
  #3: Read hero::plane
  #4: Write hero::plane
  #5: Execute address 0000:1234
)
````