### PR TITLE
ENGINE: Show unknown games if there is no recognized one

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -553,15 +553,15 @@ bool LauncherDialog::doGameDetection(const Common::String &path) {
 	// could be contained in the specified directory.
 	DetectionResults detectionResults = EngineMan.detectGames(files);
 
-	if (detectionResults.foundUnknownGames()) {
+	Common::Array<DetectedGame> candidates = detectionResults.listRecognizedGames();
+
+	if (candidates.size() == 0 && detectionResults.foundUnknownGames()) {
 		Common::String report = detectionResults.generateUnknownGameReport(false, 80);
 		g_system->logMessage(LogMessageType::kInfo, report.c_str());
 
 		UnknownGameDialog dialog(detectionResults);
 		dialog.runModal();
 	}
-
-	Common::Array<DetectedGame> candidates = detectionResults.listRecognizedGames();
 
 	int idx;
 	if (candidates.empty()) {


### PR DESCRIPTION
Prevents some recognized games to trigger the unknown game dialog as well.

For instance, Myst Masterpiece Edition is detected as an unknown variant of AGOS or TONY because of its data1.cab file, even if it is also properly detected as Myst:
```
The game in '/home/jc/ScummVM/Games/Myst_ME' seems to be an unknown game
variant.

Please report the following data to the ScummVM team at
https://bugs.scummvm.org/ along with the name of the game you tried to add and
its version, language, etc.:

Matched game IDs for the AGOS engine: feeble-win, dimp-win, jumble-win,
puzzle-win, swampy-win
Matched game IDs for the Tony Tough and the Night of Roasted Moths engine:
tony-win

  {"data1.cab", 0, "79006d2c70761dbec747e95953e636d2", 451220},
```
This means that the user first sees the unknown game dialog asking to report the game to the ScummVM team before seeing the proper add game dialog for Myst.

This has been tested with the following version of Myst ME:
```
        // Myst Masterpiece Edition
        // English Windows
        // From clone2727
        {
                {
                        "myst",
                        "Masterpiece Edition",
                        AD_ENTRY1("myst.dat", "c4cae9f143b5947262e6cb2397e1617e"),
                        Common::EN_ANY,
                        Common::kPlatformWindows,
                        ADGF_NO_FLAGS,
                        GUI_OPTIONS_MYST_ME
                },
                GType_MYST,
                GF_ME,
                0,
        },
```