### PR TITLE
SCI32: Cleanup QFG4 Remove a commented workaround

### DIFF
--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -3487,7 +3487,7 @@ static const SciScriptPatcherEntry lighthouseSignatures[] = {
 // The procedure expects a letter arg and returns no value, so the first call
 // takes its letter and feeds an undefined value to the second call. Thus the
 // kStrCat() within the procedure reads a random pointer and crashes.
-// 
+//
 // We patch all of the 5 doubled local calls (one for each letter typed from
 // "R", "O", "B", "I", "N") to be the same as the English version.
 // Applies to at least: German floppy

--- a/engines/sci/engine/workarounds.cpp
+++ b/engines/sci/engine/workarounds.cpp
@@ -87,7 +87,6 @@ const SciWorkaroundEntry arithmeticWorkarounds[] = {
 	{ GID_QFG1VGA,        301,  928,  0,              "Blink", "init",                            NULL,     0,     0, { WORKAROUND_FAKE,   0 } }, // op_div: when entering the inn, gets called with 1 parameter, but 2nd parameter is used for div which happens to be an object
 	{ GID_QFG2,           200,  200,  0,              "astro", "messages",                        NULL,     0,     0, { WORKAROUND_FAKE,   0 } }, // op_lsi: when getting asked for your name by the astrologer - bug #5152
 	{ GID_QFG3,           780,  999,  0,                   "", "export 6",                        NULL,     0,     0, { WORKAROUND_FAKE,   0 } }, // op_add: trying to talk to yourself at the top of the giant tree - bug #6692
-//	{ GID_QFG4,           710,64941,  0,          "RandCycle", "doit",                            NULL,     0,     0, { WORKAROUND_FAKE,   1 } }, // op_gt: when the tentacle appears in the third room of the caves
 	{ GID_TORIN,        51400,64928,  0,              "Blink", "init",                            NULL,     0,     0, { WORKAROUND_FAKE,   1 } }, // op_div: when Lycentia knocks Torin out after he removes her collar
 	SCI_WORKAROUNDENTRY_TERMINATOR
 };


### PR DESCRIPTION
It was superseded by commit aa9a1ab.

I'd meant to do this in the script cleanup PR, and it got left out.
In fact, it was the original reason I'd gone looking for little things to polish.
I thought to myself, "I can't justify a PR for one comment." XD

Also removes a stray space character I'd left in longbowSignatureShowHandCode's description during the cleanup.