### PR TITLE
SCI: Fix out of bounds issue in getFrameSize

### DIFF
--- a/engines/sci/video/robot_decoder.cpp
+++ b/engines/sci/video/robot_decoder.cpp
@@ -1169,6 +1169,12 @@ bool RobotDecoder::readPartialAudioRecordAndSubmit(const int startFrame, const i
 
 uint16 RobotDecoder::getFrameSize(Common::Rect &outRect) const {
 	assert(_plane != nullptr);
+
+	if (_screenItemList.size() == 0) {
+		outRect.clip(0, 0);
+		return _numFramesTotal;
+	}
+
 	outRect = _screenItemList[0]->getNowSeenRect(*_plane);
 	for (RobotScreenItemList::size_type i = 1; i < _screenItemList.size(); ++i) {
 		ScreenItem &screenItem = *_screenItemList[i];


### PR DESCRIPTION
Right know RAMA (SCI32) is currently broken as it crashes right after the Sierra intro:
```
scummvm: ./common/array.h:197: const T& Common::Array<T>::operator[](Common::Array<T>::size_type) const [with T = Sci::ScreenItem*; Common::Array<T>::size_type = unsigned int]: Assertion `idx < _size' failed.
```

This issue has been introduced by the following commit 9ceb2e858658cac3c7e4d592c3fa6f59a5776b9a trying to fix [#10700](https://bugs.scummvm.org/ticket/10700), because it assumes that there is at least one item in the list.

This PR takes care of the zero item case and returns a (0,0,0,0) Rect instead of crashing (previous behavior).

[#10700](https://bugs.scummvm.org/ticket/10700) should still be fixed, but I cannot test it myself.

For info I'm using the following version of RAMA:
```
        // RAMA - French DOS/Windows CD (from bgK)
        // Executable scanning reports "3.000.000", VERSION file reports "1.000.000"
        {"rama", "", {
                {"resmap.001", 0, "c931947115a69bb4c1760cef04e4018f", 8338},
                {"ressci.001", 0, "2a68edd064e5e4937b5e9c74b38f2082", 70783560},
                {"resmap.002", 0, "2f70519e32dd4d56d0009d127797a444", 12082},
                {"ressci.002", 0, "2a68edd064e5e4937b5e9c74b38f2082", 128724165},
                {"resmap.003", 0, "fd2ce2312084e60b2cc5194a799873d0", 1636},
                {"ressci.003", 0, "2a68edd064e5e4937b5e9c74b38f2082", 6379952},
                AD_LISTEND},
                Common::FR_FRA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_RAMA },
```