### PR TITLE
GIT: Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/po/cs_CZ.po encoding=iso-8859-2
+/po/hu_HU.po encoding=iso-8859-2
+/po/pl_PL.po encoding=iso-8859-2
+/po/be_BY.po encoding=iso-8859-5
+/po/ru_RU.po encoding=iso-8859-5
+/po/uk_UA.po encoding=iso-8859-5
+/po/el.po encoding=iso-8859-7
+/po/he.po encoding=iso-8859-8


### PR DESCRIPTION
Currently this specifies the encoding of the `.po` files that use an encoding other than ISO-8859-1.  This allows those files to be displayed in the correct encoding with GUIs that support it.