### PR TITLE
DINGUX: Fix dinguxsdl graphics backend

### DIFF
--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
@@ -43,7 +43,6 @@ public:
 
 	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL) override;
 	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
-	bool setGraphicsMode(const char *name) override;
 	bool setGraphicsMode(int mode) override;
 	void setGraphicsModeIntern() override;
 	void internUpdateScreen() override;


### PR DESCRIPTION
The dingux backend port will not compile anymore (bool setGraphicsMode(const char *name) no longer exists it seems) so removing it allows GCC to compile it.
There's also an issue with ScummVM's cursor being drawn in-game, this affects games like Gabriel.
Mainline SDL code fixed this but the Dingux port was not brought up to par so fixing that of course.

(On a side note, i did notice that some other backends similar to this one (GPH, MotoSDL etc...) can suffer from the same issues)
