### PR TITLE
iOS: Implement support for kFeatureVirtualKeyboard

### DIFF
--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -171,6 +171,7 @@ bool OSystem_iOS7::hasFeature(Feature f) {
 	switch (f) {
 	case kFeatureCursorPalette:
 	case kFeatureFilteringMode:
+	case kFeatureVirtualKeyboard:
 		return true;
 
 	default:
@@ -193,6 +194,9 @@ void OSystem_iOS7::setFeatureState(Feature f, bool enable) {
 	case kFeatureAspectRatioCorrection:
 		_videoContext->asprectRatioCorrection = enable;
 		break;
+	case kFeatureVirtualKeyboard:
+		setShowKeyboard(enable);
+		break;
 
 	default:
 		break;
@@ -207,6 +211,8 @@ bool OSystem_iOS7::getFeatureState(Feature f) {
 		return _videoContext->filtering;
 	case kFeatureAspectRatioCorrection:
 		return _videoContext->asprectRatioCorrection;
+	case kFeatureVirtualKeyboard:
+		return isKeyboardShown();
 
 	default:
 		return false;

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -209,6 +209,8 @@ public:
 protected:
 	void initVideoContext();
 	void updateOutputSurface();
+	void setShowKeyboard(bool);
+	bool isKeyboardShown() const;
 
 	void internUpdateScreen();
 	void dirtyFullScreen();

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -583,3 +583,23 @@ void OSystem_iOS7::updateMouseTexture() {
 		[[iOS7AppDelegate iPhoneView] updateMouseCursor];
 	});
 }
+
+void OSystem_iOS7::setShowKeyboard(bool show) {
+	if (show) {
+		execute_on_main_thread(^ {
+			[[iOS7AppDelegate iPhoneView] showKeyboard];
+		});
+	} else {
+		// Do not hide the keyboard in portrait mode as it is shown automatically and not
+		// just when asked with the kFeatureVirtualKeyboard.
+		if (_screenOrientation == kScreenOrientationLandscape || _screenOrientation == kScreenOrientationFlippedLandscape) {
+			execute_on_main_thread(^ {
+				[[iOS7AppDelegate iPhoneView] hideKeyboard];
+			});
+		}
+	}
+}
+
+bool OSystem_iOS7::isKeyboardShown() const {
+	return [[iOS7AppDelegate iPhoneView] isKeyboardShown];
+}

--- a/backends/platform/ios7/ios7_video.h
+++ b/backends/platform/ios7/ios7_video.h
@@ -48,6 +48,7 @@ typedef struct {
 	Common::List<InternalEvent> _events;
 	NSLock *_eventLock;
 	SoftKeyboard *_keyboardView;
+	BOOL _keyboardVisible;
 
 	EAGLContext *_context;
 	GLuint _viewRenderbuffer;
@@ -119,6 +120,10 @@ typedef struct {
 - (void)updateMouseCursor;
 
 - (void)deviceOrientationChanged:(UIDeviceOrientation)orientation;
+
+- (void)showKeyboard;
+- (void)hideKeyboard;
+- (BOOL)isKeyboardShown;
 
 - (void)applicationSuspend;
 

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -413,6 +413,7 @@ uint getSizeNextPOT(uint size) {
 #endif
 
 	_keyboardView = nil;
+	_keyboardVisible = NO;
 	_screenTexture = 0;
 	_overlayTexture = 0;
 	_mouseCursorTexture = 0;
@@ -725,7 +726,7 @@ uint getSizeNextPOT(uint size) {
 		[_keyboardView setInputDelegate:self];
 		[self addSubview:[_keyboardView inputView]];
 		[self addSubview: _keyboardView];
-		[_keyboardView showKeyboard];
+		[self showKeyboard];
 	}
 
 	glBindRenderbuffer(GL_RENDERBUFFER, _viewRenderbuffer); printOpenGLError();
@@ -907,10 +908,24 @@ uint getSizeNextPOT(uint size) {
 
   BOOL isLandscape = (self.bounds.size.width > self.bounds.size.height);
   if (isLandscape) {
-    [_keyboardView hideKeyboard];
+    [self hideKeyboard];
   } else {
-    [_keyboardView showKeyboard];
+    [self showKeyboard];
   }
+}
+
+- (void)showKeyboard {
+	[_keyboardView showKeyboard];
+	_keyboardVisible = YES;
+}
+
+- (void)hideKeyboard {
+	[_keyboardView hideKeyboard];
+	_keyboardVisible = NO;
+}
+
+- (BOOL)isKeyboardShown {
+	return _keyboardVisible;
 }
 
 - (UITouch *)secondTouchOtherTouchThan:(UITouch *)touch in:(NSSet *)set {

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -87,12 +87,6 @@ void EditTextWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 	}
 	if (setCaretPos(i))
 		markAsDirty();
-
-#ifdef TIZEN
-	// Display the virtual keypad to allow text entry. Samsung app-store testers expected
-	// the keypad to be displayed when clicking the filter edit control in the laucher gui.
-	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
-#endif
 }
 
 void EditTextWidget::drawWidget() {
@@ -118,12 +112,15 @@ Common::Rect EditTextWidget::getEditRect() const {
 }
 
 void EditTextWidget::receivedFocusWidget() {
+	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
 }
 
 void EditTextWidget::lostFocusWidget() {
 	// If we loose focus, 'commit' the user changes
 	_backupString = _editString;
 	drawCaret(true);
+
+	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, false);
 }
 
 void EditTextWidget::startEditMode() {


### PR DESCRIPTION
This allows showing and hiding the keyboard when starting or ending text editing.

In this implementation I have decided to hide the keyboard when ending text editing only in landscape mode. This is because the keyboard is automatically shown when switching to portrait mode, and not just when starting editing. This way the keyboard remains always shown in portrait mode, whether editing text or not.

I have tested this with by giving/removing focus to the search field in the launcher, and with the save game dialog.

The idea for this came from reviewing PR #1487 and I think complement that PR nicely.