### PR TITLE
WIN32: Implement rudimentary portable mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,8 @@ psp2pkg/
 #Ignore gmon.out created by gprof
 gmon.out
 /scummvm_libs_2015
+
+#Ignore files created by running in "portable mode"
+scummvm.ini
+Screenshots/
+Saved games/

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -212,7 +212,7 @@ Common::String OSystem_Win32::getScreenshotsPath() {
 	// assume that we are running in portable mode and create
 	// the screenshotsPath there
 	if (Common::File::exists(DEFAULT_CONFIG_FILE)) {
-	screenshotsPath = "Screenshots\\";
+		screenshotsPath = "Screenshots\\";
 	}
 
 	// If the directory already exists (as it should in most cases),
@@ -265,7 +265,7 @@ Common::String OSystem_Win32::getDefaultConfigFileName() {
 		strcat(configFile, "\\" DEFAULT_CONFIG_FILE);
 	}
 
-	if (Common::File::exists(DEFAULT_CONFIG_FILE)){
+	if (Common::File::exists(DEFAULT_CONFIG_FILE)) {
 		strcpy(configFile, DEFAULT_CONFIG_FILE);
 	}
 	return configFile;

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -38,6 +38,7 @@
 #include "common/config-manager.h"
 #include "common/error.h"
 #include "common/textconsole.h"
+#include "common/file.h"
 
 #include "backends/audiocd/win32/win32-audiocd.h"
 #include "backends/platform/sdl/win32/win32.h"
@@ -205,8 +206,14 @@ Common::String OSystem_Win32::getScreenshotsPath() {
 		warning("Unable to access My Pictures directory");
 		return Common::String();
 	}
-
 	screenshotsPath = Common::String(picturesPath) + "\\ScummVM Screenshots\\";
+	
+	// If a scummvm.ini is present in the current directory,
+	// assume that we are running in portable mode and create
+	// the screenshotsPath there
+	if (Common::File::exists(DEFAULT_CONFIG_FILE)) {
+	screenshotsPath = "Screenshots\\";
+	}
 
 	// If the directory already exists (as it should in most cases),
 	// we don't want to fail, but we need to stop on other errors (such as ERROR_PATH_NOT_FOUND)
@@ -258,6 +265,9 @@ Common::String OSystem_Win32::getDefaultConfigFileName() {
 		strcat(configFile, "\\" DEFAULT_CONFIG_FILE);
 	}
 
+	if (Common::File::exists(DEFAULT_CONFIG_FILE)){
+		strcpy(configFile, DEFAULT_CONFIG_FILE);
+	}
 	return configFile;
 }
 
@@ -275,6 +285,10 @@ Common::WriteStream *OSystem_Win32::createLogFile() {
 		strcat(logFile, "\\Logs");
 		CreateDirectory(logFile, NULL);
 		strcat(logFile, "\\scummvm.log");
+
+		if (Common::File::exists(DEFAULT_CONFIG_FILE)) {
+			strcpy(logFile, "scummvm.log");
+		}
 
 		Common::FSNode file(logFile);
 		Common::WriteStream *stream = file.createWriteStream();

--- a/backends/saves/windows/windows-saves.cpp
+++ b/backends/saves/windows/windows-saves.cpp
@@ -66,7 +66,7 @@ WindowsSaveFileManager::WindowsSaveFileManager() {
 		ConfMan.registerDefault("savepath", defaultSavepath);
 
 	} else {
-			if (!Common::File::exists(DEFAULT_CONFIG_FILE)) {
+		if (!Common::File::exists(DEFAULT_CONFIG_FILE)) {
 			warning("Unable to access application data directory");
 		}
 	}

--- a/backends/saves/windows/windows-saves.cpp
+++ b/backends/saves/windows/windows-saves.cpp
@@ -32,15 +32,25 @@
 
 #include "common/scummsys.h"
 #include "common/config-manager.h"
+#include "common/file.h"
 #include "backends/saves/windows/windows-saves.h"
 #include "backends/platform/sdl/win32/win32_wrapper.h"
+
+#define DEFAULT_CONFIG_FILE "scummvm.ini"
 
 WindowsSaveFileManager::WindowsSaveFileManager() {
 	char defaultSavepath[MAXPATHLEN];
 
+	// If a scummvm.ini file is present in the current directory
+	// store the savegames here
+	if (Common::File::exists(DEFAULT_CONFIG_FILE)) {
+		strcpy(defaultSavepath, "Saved games");
+		CreateDirectory(defaultSavepath, NULL);
+		ConfMan.registerDefault("savepath", defaultSavepath);
+	}
 
 	// Use the Application Data directory of the user profile.
-	if (SHGetFolderPathFunc(NULL, CSIDL_APPDATA, NULL, SHGFP_TYPE_CURRENT, defaultSavepath) == S_OK) {
+	if (!Common::File::exists(DEFAULT_CONFIG_FILE) && (SHGetFolderPathFunc(NULL, CSIDL_APPDATA, NULL, SHGFP_TYPE_CURRENT, defaultSavepath) == S_OK)) {
 		strcat(defaultSavepath, "\\ScummVM");
 		if (!CreateDirectory(defaultSavepath, NULL)) {
 			if (GetLastError() != ERROR_ALREADY_EXISTS)
@@ -54,9 +64,11 @@ WindowsSaveFileManager::WindowsSaveFileManager() {
 		}
 
 		ConfMan.registerDefault("savepath", defaultSavepath);
+
 	} else {
-		warning("Unable to access application data directory");
+			if (!Common::File::exists(DEFAULT_CONFIG_FILE)) {
+			warning("Unable to access application data directory");
+		}
 	}
 }
-
 #endif


### PR DESCRIPTION
ScummVM now checks if a file "scummvm.ini" is present in the
current working directory.

If *not*, e.g. after a fresh installation using InnoSetup, ScummVM will store
it's files in the %appdata% directory as previously. The
user won't notice a difference.

However, *if* an (empty) scummvm.ini is present in the directory
where ScummVM is launched from, it will automatically start
saving the screenshots, logs and savegames directry in the
current ScummVM directory.