### PR TITLE
WIN32: Fix embedding disabled engine files

### DIFF
--- a/base/internal_plugins.h
+++ b/base/internal_plugins.h
@@ -1,0 +1,19 @@
+#if !defined(INCLUDED_FROM_BASE_PLUGINS_H) && !defined(RC_INVOKED)
+#error This file may only be included by base/plugins.h or dists/scummvm.rc
+#endif
+
+// plugin macros are defined in this simple internal header so that scummvm.rc
+//  can include them without causing problems for Windows resource compilers.
+
+#define STATIC_PLUGIN 1
+#define DYNAMIC_PLUGIN 2
+
+#define PLUGIN_ENABLED_STATIC(ID) \
+	(ENABLE_##ID && !PLUGIN_ENABLED_DYNAMIC(ID))
+
+#ifdef DYNAMIC_MODULES
+	#define PLUGIN_ENABLED_DYNAMIC(ID) \
+		(ENABLE_##ID && (ENABLE_##ID == DYNAMIC_PLUGIN))
+#else
+	#define PLUGIN_ENABLED_DYNAMIC(ID) 0
+#endif

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -28,6 +28,10 @@
 #include "common/str.h"
 #include "backends/plugins/elf/version.h"
 
+#define INCLUDED_FROM_BASE_PLUGINS_H
+#include "base/internal_plugins.h"
+#undef INCLUDED_FROM_BASE_PLUGINS_H
+
 
 /**
  * @page pagePlugins An overview of the ScummVM plugin system
@@ -72,19 +76,6 @@ extern int pluginTypeVersions[PLUGIN_TYPE_MAX];
 
 
 // Plugin linking
-
-#define STATIC_PLUGIN 1
-#define DYNAMIC_PLUGIN 2
-
-#define PLUGIN_ENABLED_STATIC(ID) \
-	(ENABLE_##ID && !PLUGIN_ENABLED_DYNAMIC(ID))
-
-#ifdef DYNAMIC_MODULES
-	#define PLUGIN_ENABLED_DYNAMIC(ID) \
-		(ENABLE_##ID && (ENABLE_##ID == DYNAMIC_PLUGIN))
-#else
-	#define PLUGIN_ENABLED_DYNAMIC(ID) 0
-#endif
 
 // see comments in backends/plugins/elf/elf-provider.cpp
 #if defined(USE_ELF_LOADER) && defined(ELF_LOADER_CXA_ATEXIT)

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -4,6 +4,7 @@
 #include "config.h"
 #endif
 
+#include "base/internal_plugins.h" // for PLUGIN_ENABLED_STATIC
 #include "base/internal_version.h"
 
 #define FILE 256
@@ -28,58 +29,58 @@ wwwroot.zip            FILE    "dists/networking/wwwroot.zip"
 fonts.dat              FILE    "dists/engine-data/fonts.dat"
 #endif
 
-#if ENABLE_ACCESS   == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(ACCESS)
 access.dat           FILE    "dists/engine-data/access.dat"
 #endif
-#if ENABLE_CRYO       == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(CRYO)
 cryo.dat               FILE    "dists/engine-data/cryo.dat"
 #endif
-#if ENABLE_DRASCULA   == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(DRASCULA)
 drascula.dat           FILE    "dists/engine-data/drascula.dat"
 #endif
-#if ENABLE_HUGO       == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(HUGO)
 hugo.dat               FILE    "dists/engine-data/hugo.dat"
 #endif
-#if ENABLE_KYRA       == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(KYRA)
 kyra.dat               FILE    "dists/engine-data/kyra.dat"
 #endif
-#if ENABLE_LURE       == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(LURE)
 lure.dat               FILE    "dists/engine-data/lure.dat"
 #endif
-#if ENABLE_MORTEVIELLE == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(MORTEVIELLE)
 mort.dat               FILE    "dists/engine-data/mort.dat"
 #endif
-#if ENABLE_NEVERHOOD  == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(NEVERHOOD)
 neverhood.dat          FILE    "dists/engine-data/neverhood.dat"
 #endif
-#if ENABLE_QUEEN      == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(QUEEN)
 queen.tbl              FILE    "dists/engine-data/queen.tbl"
 #endif
-#if ENABLE_SKY        == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(SKY)
 sky.cpt                FILE    "dists/engine-data/sky.cpt"
 #endif
-#if ENABLE_SUPERNOVA  == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(SUPERNOVA)
 supernova.dat          FILE    "dists/engine-data/supernova.dat"
 #endif
-#if ENABLE_TEENAGENT  == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(TEENAGENT)
 teenagent.dat          FILE    "dists/engine-data/teenagent.dat"
 #endif
-#if ENABLE_TITANIC    == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(TITANIC)
 titanic.dat            FILE    "dists/engine-data/titanic.dat"
 #endif
-#if ENABLE_TONY       == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(TONY)
 tony.dat               FILE    "dists/engine-data/tony.dat"
 #endif
-#if ENABLE_TOON       == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(TOON)
 toon.dat               FILE    "dists/engine-data/toon.dat"
 #endif
-#if ENABLE_WINTERMUTE == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(WINTERMUTE)
 wintermute.zip         FILE    "dists/engine-data/wintermute.zip"
 #endif
-#if ENABLE_XEEN == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(XEEN)
 xeen.ccs         FILE    "dists/engine-data/xeen.ccs"
 #endif
-#if ENABLE_AGI        == STATIC_PLUGIN
+#if PLUGIN_ENABLED_STATIC(AGI)
 pred.dic               FILE    "dists/pred.dic"
 #endif
 


### PR DESCRIPTION
Fix Windows builds (msvc and mingw) including data files from disabled
engines as embedded resources in executable. Bug #10878