### PR TITLE
GLK: FROTZ: Disable typographic niceties for Beyond Zork font

### DIFF
--- a/engines/glk/frotz/processor.cpp
+++ b/engines/glk/frotz/processor.cpp
@@ -22,6 +22,7 @@
 
 #include "glk/frotz/processor.h"
 #include "glk/frotz/frotz.h"
+#include "glk/conf.h"
 
 namespace Glk {
 namespace Frotz {
@@ -197,6 +198,11 @@ void Processor::initialize() {
 		op0_opcodes[9] = &Processor::z_catch;
 		op1_opcodes[15] = &Processor::z_call_n;
 	}
+
+	PropFontInfo &pi = g_conf->_propInfo;
+	_quotes = pi._quotes;
+	_dashes = pi._quotes;
+	_spaces = pi._spaces;
 }
 
 void Processor::load_operand(zbyte type) {

--- a/engines/glk/frotz/processor.h
+++ b/engines/glk/frotz/processor.h
@@ -95,6 +95,10 @@ private:
 	bool istream_replay;
 	bool message;
 	Common::FixedStack<Redirect, MAX_NESTING> _redirect;
+
+	int _quotes;
+	int _dashes;
+	int _spaces;
 protected:
 	/**
 	 * \defgroup General support methods

--- a/engines/glk/frotz/processor_screen.cpp
+++ b/engines/glk/frotz/processor_screen.cpp
@@ -22,6 +22,7 @@
 
 #include "glk/frotz/processor.h"
 #include "glk/frotz/frotz.h"
+#include "glk/conf.h"
 #include "glk/events.h"
 
 namespace Glk {
@@ -381,6 +382,20 @@ void Processor::z_set_font() {
 	default:           // unavailable
 		store(0);
 		break;
+	}
+
+	PropFontInfo &pi = g_conf->_propInfo;
+	if (curr_font == GRAPHICS_FONT) {
+		_quotes = pi._quotes;
+		_dashes = pi._dashes;
+		_spaces = pi._spaces;
+		pi._quotes = 0;
+		pi._dashes = 0;
+		pi._spaces = 0;
+	} else {
+		pi._quotes = _quotes;
+		pi._dashes = _dashes;
+		pi._spaces = _spaces;
 	}
 }
 


### PR DESCRIPTION
The Beyond Zork graphics font doesn't support Unicode, so allowing it to convert things like straight quotes into curly ones can cause ScummVM to crash. Disable these conversions while the Beyond Zork graphics font is used to avoid that. This fixes bug #10865.
