### PR TITLE
WIN32: Fix building outside the source directory

### DIFF
--- a/configure
+++ b/configure
@@ -5651,6 +5651,7 @@ vpath %.mm \$(srcdir)
 vpath %.asm \$(srcdir)
 vpath %.s \$(srcdir)
 vpath %.S \$(srcdir)
+vpath %.rc \$(srcdir)
 include \$(srcdir)/Makefile
 EOF
 


### PR DESCRIPTION
I'm unable to test this at the moment, however this should hopefully fix the buildbot.