### PR TITLE
 IMAGE: Move bitmap writing code out of OpenGLGraphicsManager

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -46,6 +46,8 @@
 
 #ifdef USE_PNG
 #include "image/png.h"
+#else
+#include "image/bmp.h"
 #endif
 
 namespace OpenGL {
@@ -1212,41 +1214,13 @@ bool OpenGLGraphicsManager::saveScreenshot(const Common::String &filename) const
 	pixels.resize(lineSize * height);
 	GL_CALL(glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, &pixels.front()));
 
-#ifdef USE_PNG
 	const Graphics::PixelFormat format(3, 8, 8, 8, 0, 16, 8, 0, 0);
 	Graphics::Surface data;
 	data.init(width, height, lineSize, &pixels.front(), format);
+#ifdef USE_PNG
 	return Image::writePNG(out, data, true);
 #else
-	// BMP stores as BGR. Since we can't assume that GL_BGR is supported we
-	// will swap the components from the RGB we read to BGR on our own.
-	for (uint y = height; y-- > 0;) {
-		uint8 *line = &pixels.front() + y * lineSize;
-
-		for (uint x = width; x > 0; --x, line += 3) {
-			SWAP(line[0], line[2]);
-		}
-	}
-
-	out.writeByte('B');
-	out.writeByte('M');
-	out.writeUint32LE(height * lineSize + 54);
-	out.writeUint32LE(0);
-	out.writeUint32LE(54);
-	out.writeUint32LE(40);
-	out.writeUint32LE(width);
-	out.writeUint32LE(height);
-	out.writeUint16LE(1);
-	out.writeUint16LE(24);
-	out.writeUint32LE(0);
-	out.writeUint32LE(0);
-	out.writeUint32LE(0);
-	out.writeUint32LE(0);
-	out.writeUint32LE(0);
-	out.writeUint32LE(0);
-	out.write(&pixels.front(), pixels.size());
-
-	return true;
+	return Image::writeBMP(out, data, true);
 #endif
 }
 

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -1214,7 +1214,11 @@ bool OpenGLGraphicsManager::saveScreenshot(const Common::String &filename) const
 	pixels.resize(lineSize * height);
 	GL_CALL(glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, &pixels.front()));
 
+#ifdef SCUMM_LITTLE_ENDIAN
+	const Graphics::PixelFormat format(3, 8, 8, 8, 0, 0, 8, 16, 0);
+#else
 	const Graphics::PixelFormat format(3, 8, 8, 8, 0, 16, 8, 0, 0);
+#endif
 	Graphics::Surface data;
 	data.init(width, height, lineSize, &pixels.front(), format);
 #ifdef USE_PNG

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1476,7 +1476,11 @@ bool SurfaceSdlGraphicsManager::saveScreenshot(const char *filename) {
 		return false;
 	}
 
+#ifdef SCUMM_LITTLE_ENDIAN
+	const Graphics::PixelFormat format(3, 8, 8, 8, 0, 0, 8, 16, 0);
+#else
 	const Graphics::PixelFormat format(3, 8, 8, 8, 0, 16, 8, 0, 0);
+#endif
 	Graphics::Surface data;
 	data.init(rgbScreen->w, rgbScreen->h, rgbScreen->pitch, rgbScreen->pixels, format);
 	const bool success = Image::writePNG(out, data);

--- a/common/endian.h
+++ b/common/endian.h
@@ -573,15 +573,31 @@ inline uint32 READ_LE_UINT24(const void *ptr) {
 	return (b[2] << 16) | (b[1] << 8) | (b[0]);
 }
 
+inline void WRITE_LE_UINT24(void *ptr, uint32 value) {
+	uint8 *b = (uint8 *)ptr;
+	b[0] = (uint8)(value >> 0);
+	b[1] = (uint8)(value >> 8);
+	b[2] = (uint8)(value >> 16);
+}
+
 inline uint32 READ_BE_UINT24(const void *ptr) {
 	const uint8 *b = (const uint8 *)ptr;
 	return (b[0] << 16) | (b[1] << 8) | (b[2]);
 }
 
+inline void WRITE_BE_UINT24(void *ptr, uint32 value) {
+	uint8 *b = (uint8 *)ptr;
+	b[0] = (uint8)(value >> 16);
+	b[1] = (uint8)(value >>  8);
+	b[2] = (uint8)(value >>  0);
+}
+
 #ifdef SCUMM_LITTLE_ENDIAN
 #define READ_UINT24(a) READ_LE_UINT24(a)
+#define WRITE_UINT24(a,b) WRITE_LE_UINT24(a,b)
 #else
 #define READ_UINT24(a) READ_BE_UINT24(a)
+#define WRITE_UINT24(a,b) WRITE_BE_UINT24(a,b)
 #endif
 
 inline int16 READ_LE_INT16(const void *ptr) {

--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -434,8 +434,8 @@ Graphics::Surface *Surface::convertTo(const PixelFormat &dstFormat, const byte *
 	if (format.bytesPerPixel == 0 || format.bytesPerPixel > 4)
 		error("Surface::convertTo(): Can only convert from 1Bpp, 2Bpp, 3Bpp, and 4Bpp");
 
-	if (dstFormat.bytesPerPixel != 2 && dstFormat.bytesPerPixel != 4)
-		error("Surface::convertTo(): Can only convert to 2Bpp and 4Bpp");
+	if (dstFormat.bytesPerPixel < 2 && dstFormat.bytesPerPixel > 4)
+		error("Surface::convertTo(): Can only convert to 2Bpp, 3Bpp and 4Bpp");
 
 	surface->create(w, h, dstFormat);
 
@@ -457,6 +457,8 @@ Graphics::Surface *Surface::convertTo(const PixelFormat &dstFormat, const byte *
 
 				if (dstFormat.bytesPerPixel == 2)
 					*((uint16 *)dstRow) = color;
+				else if (dstFormat.bytesPerPixel == 3)
+					WRITE_UINT24(dstRow, color);
 				else
 					*((uint32 *)dstRow) = color;
 
@@ -487,6 +489,8 @@ Graphics::Surface *Surface::convertTo(const PixelFormat &dstFormat, const byte *
 
 				if (dstFormat.bytesPerPixel == 2)
 					*((uint16 *)dstRow) = color;
+				else if (dstFormat.bytesPerPixel == 3)
+					WRITE_UINT24(dstRow, color);
 				else
 					*((uint32 *)dstRow) = color;
 

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -133,7 +133,11 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 }
 
 bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp) {
+#ifdef SCUMM_LITTLE_ENDIAN
+	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
+#else
 	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 0, 8, 16, 0);
+#endif
 
 	Graphics::Surface *tmp = NULL;
 	const Graphics::Surface *surface;

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -132,4 +132,59 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	return true;
 }
 
+bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp) {
+	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 0, 8, 16, 0);
+
+	Graphics::Surface *tmp = NULL;
+	const Graphics::Surface *surface;
+
+	if (input.format == requiredFormat_3byte) {
+		surface = &input;
+	} else {
+		surface = tmp = input.convertTo(requiredFormat_3byte);
+	}
+
+	int dstPitch = surface->w * 3;
+	int extraDataLength = (dstPitch % 4) ? 4 - (dstPitch % 4) : 0;
+	int padding = 0;
+
+	out.writeByte('B');
+	out.writeByte('M');
+	out.writeUint32LE(surface->h * dstPitch + 54);
+	out.writeUint32LE(0);
+	out.writeUint32LE(54);
+	out.writeUint32LE(40);
+	out.writeUint32LE(surface->w);
+	out.writeUint32LE(surface->h);
+	out.writeUint16LE(1);
+	out.writeUint16LE(24);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+
+
+	if (bottomUp) {
+		for (uint y = 0; y < surface->h; ++y) {
+			out.write((const void *)surface->getBasePtr(0, y), dstPitch);
+			out.write(&padding, extraDataLength);
+		}
+	} else {
+		for (uint y = surface->h; y-- > 0;) {
+			out.write((const void *)surface->getBasePtr(0, y), dstPitch);
+			out.write(&padding, extraDataLength);
+		}
+	}
+
+	// free tmp surface
+	if (tmp) {
+		tmp->free();
+		delete tmp;
+	}
+
+	return true;
+}
+
 } // End of namespace Image

--- a/image/bmp.h
+++ b/image/bmp.h
@@ -37,6 +37,7 @@
 
 namespace Common {
 class SeekableReadStream;
+class WriteStream;
 }
 
 namespace Graphics {
@@ -65,6 +66,14 @@ private:
 	byte *_palette;
 	uint16 _paletteColorCount;
 };
+
+/**
+ * Outputs an uncompressed BMP stream of the given input surface.
+ *
+ * @param bottomUp Flip the vertical axis so pixel data is drawn from the
+ * bottom up, instead of from the top down.
+ */
+bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp = false);
 
 } // End of namespace Image
 

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -244,8 +244,13 @@ bool PNGDecoder::loadStream(Common::SeekableReadStream &stream) {
 
 bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp) {
 #ifdef USE_PNG
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
+#ifdef SCUMM_LITTLE_ENDIAN
+	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 0, 8, 16, 0);
 	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 0, 8, 16, 24);
+#else
+	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
+	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
+#endif
 
 	if (input.format.bytesPerPixel == 3) {
 		if (input.format != requiredFormat_3byte) {


### PR DESCRIPTION
This hasn't been tested on big endian machines, although I suspect additional changes will be needed.