### PR TITLE
BASE: Only reload engine plugins after return to launcher

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -605,7 +605,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 				ConfMan.setActiveDomain("");
 			}
 
-			PluginManager::instance().loadAllPlugins(); // only for cached manager
+			PluginManager::instance().loadAllPluginsOfType(PLUGIN_TYPE_ENGINE); // only for cached manager
 		} else {
 			GUI::displayErrorDialog(_("Could not find any engine capable of running the selected game"));
 

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -379,6 +379,30 @@ void PluginManager::loadAllPlugins() {
 	}
 }
 
+void PluginManager::loadAllPluginsOfType(PluginType type) {
+	for (ProviderList::iterator pp = _providers.begin();
+	                            pp != _providers.end();
+	                            ++pp) {
+		PluginList pl((*pp)->getPlugins());
+		for (PluginList::iterator p = pl.begin();
+				                  p != pl.end();
+								  ++p) {
+			if ((*p)->loadPlugin()) {
+				if ((*p)->getType() == type) {
+					addToPluginsInMemList((*p));
+				} else {
+					// Plugin is wrong type
+					(*p)->unloadPlugin();
+					delete (*p);
+				}
+			} else {
+				// Plugin did not load
+				delete (*p);
+			}
+		}
+	}
+}
+
 void PluginManager::unloadAllPlugins() {
 	for (int i = 0; i < PLUGIN_TYPE_MAX; i++)
 		unloadPluginsExcept((PluginType)i, NULL);

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -320,6 +320,7 @@ public:
 
 	// Functions used only by the cached PluginManager
 	virtual void loadAllPlugins();
+	virtual void loadAllPluginsOfType(PluginType type);
 	void unloadAllPlugins();
 
 	void unloadPluginsExcept(PluginType type, const Plugin *plugin, bool deletePlugin = true);
@@ -347,7 +348,8 @@ public:
 	virtual bool loadPluginFromGameId(const Common::String &gameId);
 	virtual void updateConfigWithFileName(const Common::String &gameId);
 
-	virtual void loadAllPlugins() {} 	// we don't allow this
+	virtual void loadAllPlugins() {} 	// we don't allow these
+	virtual void loadAllPluginsOfType(PluginType type) {}
 };
 
 #endif


### PR DESCRIPTION
> The other plugins do not need to be reloaded. Reloading
the scaler plugins breaks the graphics.

Originally from PR #271