### PR TITLE
GUI: Allow GUI background colors other than black in Classic Theme

### DIFF
--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -2422,10 +2422,10 @@ drawBevelSquareAlgClip(int x, int y, int w, int h, int bevel, PixelType top_colo
 			++ptr_y;
 		}
 	} else {
-					while (i-- ) {
-						blendFillClip(ptr_left, ptr_left + w, ptr_x, ptr_y, _bgColor, 200);
-						ptr_left += pitch;
-					}
+		while (i-- ) {
+			blendFillClip(ptr_left, ptr_left + w, ptr_x, ptr_y, _bgColor, 200);
+			ptr_left += pitch;
+		}
 	}
 
 	x = MAX(x - bevel, 0);

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -2353,7 +2353,6 @@ drawBevelSquareAlg(int x, int y, int w, int h, int bevel, PixelType top_color, P
 	ptr_left = (PixelType *)_activeSurface->getBasePtr(x, y);
 	i = h;
 	if (fill) {
-		assert((_bgColor & ~_alphaMask) == 0); // only support black
 		while (i--) {
 			darkenFill(ptr_left, ptr_left + w);
 			ptr_left += pitch;
@@ -2410,7 +2409,6 @@ drawBevelSquareAlgClip(int x, int y, int w, int h, int bevel, PixelType top_colo
 	ptr_x = x; ptr_y = y;
 	i = h;
 	if (fill) {
-		assert((_bgColor & ~_alphaMask) == 0); // only support black
 		while (i--) {
 			darkenFillClip(ptr_left, ptr_left + w, ptr_x, ptr_y);
 			ptr_left += pitch;

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -2352,9 +2352,15 @@ drawBevelSquareAlg(int x, int y, int w, int h, int bevel, PixelType top_color, P
 	// Fill Background
 	ptr_left = (PixelType *)_activeSurface->getBasePtr(x, y);
 	i = h;
-	if (fill) {
+	// Optimize rendering in case the background color is black
+	if ((_bgColor & ~_alphaMask) == 0) {
 		while (i--) {
 			darkenFill(ptr_left, ptr_left + w);
+			ptr_left += pitch;
+		}
+	} else {
+		while (i--) {
+			blendFill(ptr_left, ptr_left + w, _bgColor, 200);
 			ptr_left += pitch;
 		}
 	}
@@ -2408,12 +2414,18 @@ drawBevelSquareAlgClip(int x, int y, int w, int h, int bevel, PixelType top_colo
 	ptr_left = (PixelType *)_activeSurface->getBasePtr(x, y);
 	ptr_x = x; ptr_y = y;
 	i = h;
-	if (fill) {
+	// Optimize rendering in case the background color is black
+	if ((_bgColor & ~_alphaMask) == 0) {
 		while (i--) {
 			darkenFillClip(ptr_left, ptr_left + w, ptr_x, ptr_y);
 			ptr_left += pitch;
 			++ptr_y;
 		}
+	} else {
+					while (i-- ) {
+						blendFillClip(ptr_left, ptr_left + w, ptr_x, ptr_y, _bgColor, 200);
+						ptr_left += pitch;
+					}
 	}
 
 	x = MAX(x - bevel, 0);


### PR DESCRIPTION
I am currently working on a "Classic Mode" theme that uses another background color than the default block.

For "unknown" reasons (at least they are unknown to me), the current code throws an assertion failure when the background color in the theme is not set to black. I almost assume that this is a leftover from previous times, but since I'm not absolutely sure if this will break something else, I'm submitting this as a PR.