### PR TITLE
SCUMM HE: Bug fix for moonbase stack memory corruption

### DIFF
--- a/engines/scumm/he/moonbase/moonbase.cpp
+++ b/engines/scumm/he/moonbase/moonbase.cpp
@@ -175,6 +175,8 @@ void Moonbase::blitT14WizImage(uint8 *dst, int dstw, int dsth, int dstPitch, con
 					}
 					src += 2;
 					pixels++;
+					if (pixels >= cx + sx)
+						break;
 				}
 			} else { // skip
 				if ((code & 1) == 0) {
@@ -184,6 +186,8 @@ void Moonbase::blitT14WizImage(uint8 *dst, int dstw, int dsth, int dstPitch, con
 						if (pixels >= sx)
 							dst1 += 2;
 						pixels++;
+						if (pixels >= cx + sx)
+							break;
 					}
 				} else { // special case
 					if (pixels >= sx) {


### PR DESCRIPTION
What:
The bug is reproducible in the following ways:
1. quiting the game
2. enter challenge mode state 2, when the game starts move mouse around
the menu buttons (choose building or weapons)
Observed behavior: In he/wiz_he.cpp:2839, the function failed to return since
the stack around variable 'color' was corrupted. The game will crash then.

Analysis:
Since other function will modify memory area around local variable 'color',
the bug shoud be caused by memory overwritten. The memory write happens
in this modified file. From the code, it only wants to write a certain amount
of pixels. So I found 2 places where more pixels are written. This causes
stack memory corruption.

Fix:
Add checking. If we have written enough pixels then break.

Testing:
The game UI looks correct. Single player mode game is tested.
Bug no longer observable. Tested for both cases mentioned above.
