### PR TITLE
SCI: Update Sound:vol in processUpdateCues

### DIFF
--- a/engines/sci/sound/soundcmd.cpp
+++ b/engines/sci/sound/soundcmd.cpp
@@ -616,6 +616,10 @@ void SoundCommandParser::processUpdateCues(reg_t obj) {
 		writeSelectorValue(_segMan, obj, SELECTOR(min), musicSlot->ticker / 3600);
 		writeSelectorValue(_segMan, obj, SELECTOR(sec), musicSlot->ticker % 3600 / 60);
 		writeSelectorValue(_segMan, obj, SELECTOR(frame), musicSlot->ticker % 60 / 2);
+
+		if (_soundVersion >= SCI_VERSION_1_MIDDLE) {
+			writeSelectorValue(_segMan, obj, SELECTOR(vol), musicSlot->volume);
+		}
 	}
 }
 


### PR DESCRIPTION
Sound:vol is updated when updating cues starting in SCI_VERSION_1_MIDDLE.

Fixes bug #10244. SQ4 localized floppy versions depend on this when getting
in the orange ship, they fade music and wait for the volume to reach zero.

Confirmed against asm that this is not in SQ4 floppy (early) but is in
LSL1VGA (middle) and SQ4 localized floppies and SQ4CD (late).