### PR TITLE
SCI: Fix disassembler crash on invalid property

### DIFF
--- a/engines/sci/engine/scriptdebug.cpp
+++ b/engines/sci/engine/scriptdebug.cpp
@@ -218,7 +218,11 @@ reg_t disassemble(EngineState *s, reg_t pos, const Object *obj, bool printBWTag,
 					if (obj != nullptr) {
 						const Object *const super = obj->getClass(s->_segMan);
 						assert(super);
-						selectorName = kernel->getSelectorName(super->getVarSelector(param_value / 2)).c_str();
+						if (param_value / 2 < super->getVarCount()) {
+							selectorName = kernel->getSelectorName(super->getVarSelector(param_value / 2)).c_str();
+						} else {
+							selectorName = "<invalid>";
+						}
 					} else {
 						selectorName = "<unavailable>";
 					}


### PR DESCRIPTION
Fixes debugger crash when disassembling an instruction whose operand
is an invalid property. This occurs in LB2 floppy 1.0 script 720 in
sGetUp:changeState and sStepOnNail:changeState.