### PR TITLE
WIN32: Add scummvm.exe.manifest file and disable HiDPI scaling (on hold)

### DIFF
--- a/devtools/update-version.pl
+++ b/devtools/update-version.pl
@@ -49,6 +49,7 @@ my @subs_files = qw(
 	dists/gph/README-GPH
 	dists/gph/scummvm.ini
 	dists/riscos/!Boot,feb
+	dists/win32/scummvm.exe.manifest
 	backends/platform/psp/README.PSP
 	snapcraft.yaml
 	);

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -15,6 +15,7 @@
 IDI_ICON               ICON    DISCARDABLE     "icons/scummvm.ico"
 IDI_COUNT              ICON    DISCARDABLE     "icons/count.ico"
 
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "dists/win32/scummvm.exe.manifest"
 ID_GDF_XML             DATA    "dists/win32/scummvm.gdf.xml"
 
 scummclassic.zip       FILE    "gui/themes/scummclassic.zip"
@@ -106,7 +107,7 @@ BEGIN
             VALUE "FileDescription", "ScummVM: A free implementation of various adventure game engines\0"
             VALUE "FileVersion", SCUMMVM_VERSION "\0"
             VALUE "InternalName", "scummvm\0"
-            VALUE "LegalCopyright", "Copyright © 2001-2019 The ScummVM Team\0"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2001-2019 The ScummVM Team\0"
             VALUE "LegalTrademarks", "'SCUMM', and all SCUMM games are a TM of LucasArts. Simon The Sorcerer is a TM of AdventureSoft. Beneath a Steel Sky and Broken Sword are a TM of Revolution. Flight of the Amazon Queen is a TM of John Passfield and Steve Stamatiadis. \0"
             VALUE "OriginalFilename", "scummvm.exe\0"
             VALUE "ProductName", "ScummVM\0"

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -107,7 +107,7 @@ BEGIN
             VALUE "FileDescription", "ScummVM: A free implementation of various adventure game engines\0"
             VALUE "FileVersion", SCUMMVM_VERSION "\0"
             VALUE "InternalName", "scummvm\0"
-            VALUE "LegalCopyright", "Copyright ï¿½ 2001-2019 The ScummVM Team\0"
+            VALUE "LegalCopyright", "Copyright © 2001-2019 The ScummVM Team\0"
             VALUE "LegalTrademarks", "'SCUMM', and all SCUMM games are a TM of LucasArts. Simon The Sorcerer is a TM of AdventureSoft. Beneath a Steel Sky and Broken Sword are a TM of Revolution. Flight of the Amazon Queen is a TM of John Passfield and Steve Stamatiadis. \0"
             VALUE "OriginalFilename", "scummvm.exe\0"
             VALUE "ProductName", "ScummVM\0"

--- a/dists/win32/scummvm.exe.manifest
+++ b/dists/win32/scummvm.exe.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity type="win32" name="ScummVM" version="2.1.0.0" processorArchitecture="amd64"/>
+    <assemblyIdentity type="win32" name="ScummVM" version="2.1.0.0"/>
     <asmv3:application>
         <asmv3:windowsSettings>
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>

--- a/dists/win32/scummvm.exe.manifest
+++ b/dists/win32/scummvm.exe.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity type="win32" name="ScummVM" version="2.1.0.0" processorArchitecture="amd64"/>
+    <asmv3:application>
+        <asmv3:windowsSettings>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>

--- a/dists/win32/scummvm.exe.manifest.in
+++ b/dists/win32/scummvm.exe.manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity type="win32" name="ScummVM" version="@VER_MAJOR@.@VER_MINOR@.@VER_PATCH@.0" processorArchitecture="amd64"/>
+    <assemblyIdentity type="win32" name="ScummVM" version="@VER_MAJOR@.@VER_MINOR@.@VER_PATCH@.0"/>
     <asmv3:application>
         <asmv3:windowsSettings>
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>

--- a/dists/win32/scummvm.exe.manifest.in
+++ b/dists/win32/scummvm.exe.manifest.in
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity type="win32" name="ScummVM" version="@VER_MAJOR@.@VER_MINOR@.@VER_PATCH@.0" processorArchitecture="amd64"/>
+    <asmv3:application>
+        <asmv3:windowsSettings>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>


### PR DESCRIPTION
This PR adds an Windows Application Manifest file that Windows XP+ uses for setting various options during the execution of the program.

This manifest file disables the HiDPI scaling on Windows 7+, to fix the blurry output on HiDPI displays. This is currently most noticable when using the GUI and adds a slight blur to the games.

By declaring ScummVM as "DPI aware", we permit Windows do perform it's own scaling. Disabling scaling by the OS is already the default on Linux, maybe @criezy can comment on the macOS side of things.

A test build is available through https://cloud.serra.network/index.php/s/jsJCjs7X6dnsBwa/download.

In this screenshot, the upper screenshot shows the current behavior on a HiDPI display (look at the GUI scaling), where the lower screenshot shows the behavior with this manifest file on the exact same machine.
![scummvm-hidpi-scaling](https://user-images.githubusercontent.com/11882577/54600249-a0eeab80-4a3c-11e9-8630-9cc051f4ba92.PNG)

The screenshots give you a vague representation, on a real HiDPI display the difference is quite obvious.