### PR TITLE
BASE: Enable aspect ratio correction by default

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -210,7 +210,7 @@ void registerDefaults() {
 	// Graphics
 	ConfMan.registerDefault("fullscreen", false);
 	ConfMan.registerDefault("filtering", false);
-	ConfMan.registerDefault("aspect_ratio", false);
+	ConfMan.registerDefault("aspect_ratio", true);
 	ConfMan.registerDefault("gfx_mode", "normal");
 	ConfMan.registerDefault("render_mode", "default");
 	ConfMan.registerDefault("desired_screen_aspect_ratio", "auto");


### PR DESCRIPTION
Currently, the aspect ratio correction is disabled by default.

I hereby propose to enable it by default instead, since I suspect that the vast majority of the users use this function anyway. However, feel free to discard this PR if you think we shouldn't change this.