### PR TITLE
PINK: Add detection entry for Danish "pokus" version

### DIFF
--- a/engines/pink/detection_tables.h
+++ b/engines/pink/detection_tables.h
@@ -257,6 +257,19 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NONE)
 	},
 
+	// Danish
+	// Version 1.0
+	// Contributed by sauravisus in Trac#10919
+	{
+		"pokus",
+		0,
+		AD_ENTRY1s("HPP.orb", "3428dda98c21c4b6cd798750016796ab", 513518023),
+		Common::DA_DAN,
+		Common::kPlatformWindows,
+		ADGF_UNSTABLE | ADGF_DROPPLATFORM,
+		GUIO1(GUIO_NONE)
+	},
+
 	AD_TABLE_END_MARKER
 };
 


### PR DESCRIPTION
Detection information was provided by sauravisus in
https://bugs.scummvm.org/ticket/10919.

@whiterandrek, can you please take a look at this? Since the detection table for the PINK engine doesn't do any "fancy" stuff, the change itself is quite trivial and *should* be ready to go as is.