### PR TITLE
AmigaOS4: Exclude platform from a SDL1/2 keyboard fix that breaks numpad usage

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -170,8 +170,10 @@ int SdlEventSource::mapKey(SDLKey sdlKey, SDLMod mod, Uint16 unicode) {
 	if (key >= Common::KEYCODE_F1 && key <= Common::KEYCODE_F9) {
 		return key - Common::KEYCODE_F1 + Common::ASCII_F1;
 	} else if (key >= Common::KEYCODE_KP0 && key <= Common::KEYCODE_KP9) {
-		if ((mod & KMOD_NUM) == 0)
-			return 0; // In case Num-Lock is NOT enabled, return 0 for ascii, so that directional keys on numpad work
+		#ifndef __amigaos4__ // Exclude AmigaOS4 due to it breaking the numpad fighting on said platform completely. This fixes bug #10558.
+			if ((mod & KMOD_NUM) == 0)
+				return 0; // In case Num-Lock is NOT enabled, return 0 for ascii, so that directional keys on numpad work
+		#endif
 		return key - Common::KEYCODE_KP0 + '0';
 	} else if (key >= Common::KEYCODE_UP && key <= Common::KEYCODE_PAGEDOWN) {
 		return key;

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -170,7 +170,11 @@ int SdlEventSource::mapKey(SDLKey sdlKey, SDLMod mod, Uint16 unicode) {
 	if (key >= Common::KEYCODE_F1 && key <= Common::KEYCODE_F9) {
 		return key - Common::KEYCODE_F1 + Common::ASCII_F1;
 	} else if (key >= Common::KEYCODE_KP0 && key <= Common::KEYCODE_KP9) {
-		#ifndef __amigaos4__ // Exclude AmigaOS4 due to it breaking the numpad fighting on said platform completely. This fixes bug #10558.
+		// WORKAROUND:  Disable this change for AmigaOS4 as it is breaking numpad usage ("fighting") on that platform.
+		// This fixes bug #10558.
+		// The actual issue here is that the SCUMM engine uses ASCII codes instead of keycodes for input.
+		// See also the relevant FIXME in SCUMM's input.cpp.
+		#ifndef __amigaos4__
 			if ((mod & KMOD_NUM) == 0)
 				return 0; // In case Num-Lock is NOT enabled, return 0 for ascii, so that directional keys on numpad work
 		#endif


### PR DESCRIPTION
*reset .ascii to 0, when Num-Lock is NOT enabled and keypad directional keys are pressed* (original description) is causing the numpad to play dead completely on AmigaOS4 (no matter if numlock is active or not), so i´m excluding the platform from this change.

Please see here for reference:
https://github.com/scummvm/scummvm/commit/f5ed14e93d85b638c8e49468b2885c1278d56d20
@m-kiewitz talks about fixing the engine if it causes problems.
quote
The latter shouldn't cause issues, but in case it does, the
affected engine should get fixed and use keycodes instead.
/quote
So i´m not really sure if this is the correct approach, but since no one else seems to have problems after all the time the change is in place i´d believe it may be(?) It doesn´t change anything for any other platform, does it?

This fixes bug #10558:
https://bugs.scummvm.org/ticket/10558

Tested with both SDL1 and 2 on AmigaOS4 and with both Indiana Jones games.

Please advise
on changes or something else i have broken and on what needs to be changed in this PR.