### PR TITLE
GUI: Support adding games via Drag and Drop

### DIFF
--- a/backends/events/riscossdl/riscossdl-events.cpp
+++ b/backends/events/riscossdl/riscossdl-events.cpp
@@ -1,0 +1,67 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/scummsys.h"
+
+#if defined(RISCOS) && defined(SDL_BACKEND)
+
+#include "backends/events/riscossdl/riscossdl-events.h"
+#include "backends/platform/sdl/riscos/riscos-utils.h"
+
+#include "common/events.h"
+
+#include <swis.h>
+
+RISCOSSdlEventSource::RISCOSSdlEventSource()
+    : SdlEventSource() {
+	int messages[2];
+	messages[0] = 3; // Message_DataLoad
+	messages[1] = 0;
+	_swix(Wimp_AddMessages, _IN(0), messages);
+
+	SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
+}
+
+bool RISCOSSdlEventSource::handleSysWMEvent(SDL_Event &ev, Common::Event &event) {
+	int eventCode = ev.syswm.msg->eventCode;
+	int pollBlock[64];
+	memcpy(pollBlock, ev.syswm.msg->pollBlock, 64 * sizeof(int));
+
+	if (eventCode == 17 || eventCode == 18) {
+		char *filename;
+		switch (pollBlock[4]) {
+		case 3: // Message_DataLoad
+			filename = (char *)(pollBlock) + 44;
+			event.type = Common::EVENT_DROP_FILE;
+			event.path = RISCOS_Utils::toUnix(Common::String(filename));
+
+			// Acknowledge that the event has been received
+			pollBlock[4] = 4; // Message_DataLoadAck
+			pollBlock[3] = pollBlock[2];
+			_swix(Wimp_SendMessage, _INR(0,2), 19, pollBlock, 0);
+			return true;
+		}
+	}
+	return false;
+}
+
+#endif

--- a/backends/events/riscossdl/riscossdl-events.h
+++ b/backends/events/riscossdl/riscossdl-events.h
@@ -1,0 +1,38 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#if !defined(BACKEND_EVENTS_RISCOS_H) && !defined(DISABLE_DEFAULT_EVENTMANAGER)
+#define BACKEND_EVENTS_RISCOS_H
+
+#include "backends/events/sdl/sdl-events.h"
+
+/**
+ * SDL Events manager for RISC OS.
+ */
+class RISCOSSdlEventSource : public SdlEventSource {
+public:
+	RISCOSSdlEventSource();
+protected:
+	bool handleSysWMEvent(SDL_Event &ev, Common::Event &event) override;
+};
+
+#endif /* BACKEND_EVENTS_RISCOS_H */

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -567,6 +567,8 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		return handleMouseButtonDown(ev, event);
 	case SDL_MOUSEBUTTONUP:
 		return handleMouseButtonUp(ev, event);
+	case SDL_SYSWMEVENT:
+		return handleSysWMEvent(ev, event);
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	case SDL_MOUSEWHEEL: {
@@ -858,6 +860,10 @@ bool SdlEventSource::handleMouseButtonUp(SDL_Event &ev, Common::Event &event) {
 	_km.y = ev.button.y * MULTIPLIER;
 
 	return processMouseEvent(event, ev.button.x, ev.button.y);
+}
+
+bool SdlEventSource::handleSysWMEvent(SDL_Event &ev, Common::Event &event) {
+	return false;
 }
 
 void SdlEventSource::openJoystick(int joystickIndex) {

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -640,6 +640,12 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 
 	case SDL_JOYDEVICEREMOVED:
 		return handleJoystickRemoved(ev.jdevice);
+
+	case SDL_DROPFILE:
+		event.type = Common::EVENT_DROP_FILE;
+		event.path = Common::String(ev.drop.file);
+		SDL_free(ev.drop.file);
+		return true;
 #else
 	case SDL_VIDEOEXPOSE:
 		if (_graphicsManager)

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -137,6 +137,7 @@ protected:
 	virtual bool handleMouseMotion(SDL_Event &ev, Common::Event &event);
 	virtual bool handleMouseButtonDown(SDL_Event &ev, Common::Event &event);
 	virtual bool handleMouseButtonUp(SDL_Event &ev, Common::Event &event);
+	virtual bool handleSysWMEvent(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyButtonDown(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyButtonUp(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyAxisMotion(SDL_Event &ev, Common::Event &event);

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -214,6 +214,7 @@ endif
 
 ifdef RISCOS
 MODULE_OBJS += \
+	events/riscossdl/riscossdl-events.o \
 	fs/riscos/riscos-fs.o \
 	fs/riscos/riscos-fs-factory.o \
 	platform/sdl/riscos/riscos-utils.o

--- a/backends/platform/sdl/riscos/riscos.cpp
+++ b/backends/platform/sdl/riscos/riscos.cpp
@@ -26,6 +26,7 @@
 
 #include "backends/platform/sdl/riscos/riscos.h"
 #include "backends/saves/default/default-saves.h"
+#include "backends/events/riscossdl/riscossdl-events.h"
 #include "backends/fs/riscos/riscos-fs-factory.h"
 #include "backends/fs/riscos/riscos-fs.h"
 
@@ -50,6 +51,10 @@ void OSystem_RISCOS::init() {
 
 void OSystem_RISCOS::initBackend() {
 	ConfMan.registerDefault("enable_reporter", false);
+
+	// Create the events manager
+	if (_eventSource == 0)
+		_eventSource = new RISCOSSdlEventSource();
 
 	// Create the savefile manager
 	if (_savefileManager == 0) {

--- a/common/events.h
+++ b/common/events.h
@@ -72,21 +72,21 @@ enum EventType {
 	 * use events to ask for the save game dialog or to pause the engine.
 	 * An associated enumerated type can accomplish this.
 	 **/
-	EVENT_PREDICTIVE_DIALOG = 12
+	EVENT_PREDICTIVE_DIALOG = 12,
 
 #ifdef ENABLE_KEYMAPPER
-	,
 	// IMPORTANT NOTE: This is part of the WIP Keymapper. If you plan to use
 	// this, please talk to tsoliman and/or LordHoto.
 	EVENT_CUSTOM_BACKEND_ACTION = 18,
 	EVENT_CUSTOM_BACKEND_HARDWARE = 21,
 	EVENT_GUI_REMAP_COMPLETE_ACTION = 22,
-	EVENT_KEYMAPPER_REMAP = 19
+	EVENT_KEYMAPPER_REMAP = 19,
 #endif
 #ifdef ENABLE_VKEYBD
-	,
-	EVENT_VIRTUAL_KEYBOARD = 20
+	EVENT_VIRTUAL_KEYBOARD = 20,
 #endif
+
+	EVENT_DROP_FILE = 23
 };
 
 typedef uint32 CustomEventType;
@@ -126,6 +126,9 @@ struct Event {
 	// this, please talk to tsoliman and/or LordHoto.
 	CustomEventType customType;
 #endif
+
+	/* The path of the file or directory dragged to the ScummVM window */
+	Common::String path;
 
 	Event() : type(EVENT_INVALID), kbdRepeat(false) {
 #ifdef ENABLE_KEYMAPPER

--- a/dists/macosx/Info.plist
+++ b/dists/macosx/Info.plist
@@ -6,6 +6,20 @@
 	<string>English</string>
 	<key>CFBundleDisplayName</key>
 	<string>ScummVM</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>All Files</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>scummvm</string>
 	<key>CFBundleGetInfoString</key>

--- a/dists/macosx/Info.plist.in
+++ b/dists/macosx/Info.plist.in
@@ -6,6 +6,20 @@
 	<string>English</string>
 	<key>CFBundleDisplayName</key>
 	<string>ScummVM</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>All Files</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>scummvm</string>
 	<key>CFBundleGetInfoString</key>

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -21,10 +21,7 @@
  */
 
 #include "common/rect.h"
-
-#ifdef ENABLE_KEYMAPPER
 #include "common/events.h"
-#endif
 
 #include "gui/gui-manager.h"
 #include "gui/dialog.h"
@@ -359,9 +356,8 @@ void Dialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	}
 }
 
-#ifdef ENABLE_KEYMAPPER
 void Dialog::handleOtherEvent(Common::Event evt) { }
-#endif
+
 /*
  * Determine the widget at location (x,y) if any. Assumes the coordinates are
  * in the local coordinate system, i.e. relative to the top left of the dialog.

--- a/gui/dialog.h
+++ b/gui/dialog.h
@@ -30,11 +30,9 @@
 #include "gui/object.h"
 #include "gui/ThemeEngine.h"
 
-#ifdef ENABLE_KEYMAPPER
 namespace Common {
 struct Event;
 }
-#endif
 
 namespace GUI {
 
@@ -105,9 +103,7 @@ protected:
 	virtual void handleKeyUp(Common::KeyState state);
 	virtual void handleMouseMoved(int x, int y, int button);
 	virtual void handleCommand(CommandSender *sender, uint32 cmd, uint32 data);
-#ifdef ENABLE_KEYMAPPER
 	virtual void handleOtherEvent(Common::Event evt);
-#endif
 
 	Widget *findWidget(int x, int y); // Find the widget at pos x,y if any
 	Widget *findWidget(const char *name);

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -597,9 +597,7 @@ void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDi
 		screenChange();
 		break;
 	default:
-	#ifdef ENABLE_KEYMAPPER
 		activeDialog->handleOtherEvent(event);
-	#endif
 		break;
 	}
 }

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -528,6 +528,13 @@ void LauncherDialog::handleKeyUp(Common::KeyState state) {
 	updateButtons();
 }
 
+void LauncherDialog::handleOtherEvent(Common::Event evt) {
+	Dialog::handleOtherEvent(evt);
+	if (evt.type == Common::EVENT_DROP_FILE) {
+		doGameDetection(evt.path);
+	}
+}
+
 bool LauncherDialog::doGameDetection(const Common::String &path) {
 	// Allow user to add a new game to the list.
 	// 2) try to auto detect which game is in the directory, if we cannot

--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -51,6 +51,7 @@ public:
 
 	virtual void handleKeyDown(Common::KeyState state);
 	virtual void handleKeyUp(Common::KeyState state);
+	virtual void handleOtherEvent(Common::Event evt);
 	bool doGameDetection(const Common::String &path);
 protected:
 	EditTextWidget  *_searchWidget;


### PR DESCRIPTION
This PR allows adding games by dragging them to the ScummVM window from an external filer window. Currently this is only implemented with SDL2, although I might consider implementing it on RISC OS as well using `SDL_SYSWMEVENT` events if there's enough demand, since RISC OS applications typically make greater use of drag and drop compared to other OSes.