### PR TITLE
AmigaOS4: Add a version tag to fix shader compiling errors

### DIFF
--- a/backends/graphics/opengl/shader.cpp
+++ b/backends/graphics/opengl/shader.cpp
@@ -80,6 +80,9 @@ const char *const g_lookUpFragmentShader =
 
 // Taken from: https://en.wikibooks.org/wiki/OpenGL_Programming/Modern_OpenGL_Tutorial_03#OpenGL_ES_2_portability
 const char *const g_precisionDefines =
+	#ifdef __amigaos4__
+	"#version 110\n"
+	#endif
 	"#ifdef GL_ES\n"
 	"\t#if defined(GL_FRAGMENT_PRECISION_HIGH) && GL_FRAGMENT_PRECISION_HIGH == 1\n"
 	"\t\tprecision highp float;\n"


### PR DESCRIPTION
On AmigaOS4 i get some compilation errors in shader.cpp on start of the app (see below).
The added version tag prevents them and let me use shaders.

If i did something wrong, please tell.

WARNING: GL ERROR: GL_INVALID_VALUE on glCompileShader(handle) (backends/graphics/opengl/shader.cpp:268)! 
WARNING: Could not compile shader "varying vec2 texCoord; 
varying vec4 blendColor; 

uniform sampler2D texture; 

void main(void) { 
    gl_FragColor = blendColor * texture2D(texture, texCoord); 
} 
": "ERROR: 18:1: 'texture' : can't use function syntax on variable  
ERROR: 20:0: '' : compilation terminated  
ERROR: 2 compilation errors.  No code generated. 

"! 
WARNING: GL ERROR: GL_INVALID_VALUE on glCompileShader(handle) (backends/graphics/opengl/shader.cpp:268)! 
WARNING: Could not compile shader "varying vec2 texCoord; 
varying vec4 blendColor; 

uniform sampler2D texture; 
uniform sampler2D palette; 

const float adjustFactor = 255.0 / 256.0 + 1.0 / (2.0 * 256.0); 
void main(void) { 
    vec4 index = texture2D(texture, texCoord); 
    gl_FragColor = blendColor * texture2D(palette, vec2(index.a * adjustFactor, 0.0)); 
} 
": "ERROR: 20:1: 'texture' : can't use function syntax on variable  
ERROR: 20:1: '=' :  cannot convert from ' const float' to ' temp 4-component vector of float' 
ERROR: 23:0: '' : compilation terminated  
ERROR: 3 compilation errors.  No code generated. 

"! 
WARNING: GL ERROR: GL_INVALID_ENUM on glGetUniformLocation(_program, name) (backends/graphics/opengl/shader.cpp:225)!
WARNING: GL ERROR: GL_INVALID_ENUM on glGetUniformLocation(_program, name) (backends/graphics/opengl/shader.cpp:225)!
WARNING: GL ERROR: GL_INVALID_ENUM on glGetUniformLocation(_program, name) (backends/graphics/opengl/shader.cpp:225)!
WARNING: GL ERROR: GL_INVALID_VALUE on glGetAttribLocation(_program, name) (backends/graphics/opengl/shader.cpp:219)!
WARNING: GL ERROR: GL_INVALID_VALUE on glGetAttribLocation(_program, name) (backends/graphics/opengl/shader.cpp:219)!
WARNING: GL ERROR: GL_INVALID_VALUE on glGetAttribLocation(_program, name) (backends/graphics/opengl/shader.cpp:219)!
assertion "_vertexAttribLocation != -1" failed: file "backends/graphics/opengl/pipelines/shader.cpp", line 36