### PR TITLE
SCI: Fix Mac icon bar crash on restart (KQ6, FPFP)

### DIFF
--- a/engines/sci/engine/kmisc.cpp
+++ b/engines/sci/engine/kmisc.cpp
@@ -503,8 +503,7 @@ reg_t kIconBar(EngineState *s, int argc, reg_t *argv) {
 
 	switch (argv[0].toUint16()) {
 	case 0: // InitIconBar
-		for (int i = 0; i < argv[1].toUint16(); i++)
-			g_sci->_gfxMacIconBar->addIcon(argv[i + 2]);
+		g_sci->_gfxMacIconBar->initIcons(argv[1].toUint16(), &argv[2]);
 		break;
 	case 1: // DisposeIconBar
 		warning("kIconBar(Dispose)");

--- a/engines/sci/graphics/maciconbar.cpp
+++ b/engines/sci/graphics/maciconbar.cpp
@@ -49,6 +49,23 @@ GfxMacIconBar::GfxMacIconBar() {
 }
 
 GfxMacIconBar::~GfxMacIconBar() {
+	freeIcons();
+}
+
+void GfxMacIconBar::initIcons(uint16 count, reg_t *objs) {
+	// free icons and reset state in case game is restarting
+	freeIcons();
+	_iconBarItems.clear();
+	_lastX = 0;
+	_inventoryIcon = 0;
+	_allDisabled = true;
+
+	for (uint16 i = 0; i < count; i++) {
+		addIcon(objs[i]);
+	}
+}
+
+void GfxMacIconBar::freeIcons() {
 	if (_inventoryIcon) {
 		_inventoryIcon->free();
 		delete _inventoryIcon;

--- a/engines/sci/graphics/maciconbar.h
+++ b/engines/sci/graphics/maciconbar.h
@@ -38,7 +38,7 @@ public:
 	GfxMacIconBar();
 	~GfxMacIconBar();
 
-	void addIcon(reg_t obj);
+	void initIcons(uint16 count, reg_t *objs);
 	void drawIcons();
 	void setIconEnabled(int16 index, bool enabled);
 	void setInventoryIcon(int16 icon);
@@ -63,6 +63,8 @@ private:
 	Graphics::Surface *createImage(uint32 iconIndex, bool isSelected);
 	void remapColors(Graphics::Surface *surf, const byte *palette);
 
+	void freeIcons();
+	void addIcon(reg_t obj);
 	void drawIcon(uint16 index, bool selected);
 	void drawSelectedImage(uint16 index);
 	bool isIconEnabled(uint16 index) const;


### PR DESCRIPTION
Add support for reinitializing the mac icon bar when restarting.
Restarting runs the game's init script which calls KPlatform again.
Prior to this, restarting these games would fail an assertion.