### PR TITLE
SCI: Fix broken speech after starting in text mode

### DIFF
--- a/engines/sci/engine/guest_additions.cpp
+++ b/engines/sci/engine/guest_additions.cpp
@@ -919,6 +919,9 @@ void GuestAdditions::syncMessageTypeToScummVMUsingDefaultStrategy(const int inde
 
 		ConfMan.setBool("subtitles", value.toSint16() & kMessageTypeSubtitles);
 		ConfMan.setBool("speech_mute", !(value.toSint16() & kMessageTypeSpeech));
+
+		// need to update sound mixer volumes so that speech_mute will take effect
+		g_sci->updateSoundMixerVolumes();
 	}
 }
 


### PR DESCRIPTION
Fixes bug #10924 where starting or restoring in text mode and then
changing to speech mode within a game results in muted speech.

This is a regression introduced between 1.9 and 2.0, probably as part
of the synchronization refactor that created GuestAdditions.