### PR TITLE
SCI: Synchronize QFG4 control panel audio settings

### DIFF
--- a/engines/sci/engine/guest_additions.cpp
+++ b/engines/sci/engine/guest_additions.cpp
@@ -847,6 +847,18 @@ void GuestAdditions::syncMessageTypeFromScummVMUsingDefaultStrategy() const {
 		// is no equivalent option in the ScummVM GUI
 		_state->variables[VAR_GLOBAL][kGlobalVarGK1NarratorMode] = NULL_REG;
 	}
+
+	if (g_sci->getGameId() == GID_QFG4) {
+		// QFG4 uses a game flag to control the Audio button's state in the control panel.
+		//  This flag must be kept in sync with the standard global 90 speech bit.
+		uint flagNumber = 400;
+		uint globalNumber = kGlobalVarQFG4Flags + (flagNumber / 16);
+		if (value & kMessageTypeSpeech) {
+			_state->variables[VAR_GLOBAL][globalNumber] |= 0x8000;
+		} else {
+			_state->variables[VAR_GLOBAL][globalNumber] &= ~0x8000;
+		}
+	}
 }
 
 #ifdef ENABLE_SCI32

--- a/engines/sci/engine/vm.h
+++ b/engines/sci/engine/vm.h
@@ -178,6 +178,7 @@ enum GlobalVar {
 	kGlobalVarPhant2MasterVolume   = 236, // 0 to 127
 	kGlobalVarPhant2ControlPanel   = 250,
 	kGlobalVarShivers1Score        = 349,
+	kGlobalVarQFG4Flags            = 500,
 	kGlobalVarHoyle5MusicVolume    = 897,
 	kkGlobalVarHoyle5ResponseTime  = 899
 };


### PR DESCRIPTION
Fixes Audio button in control panel getting out of sync with
the message mode set by ScummVM.