### PR TITLE
SCI: Fix Mac icon bar event handling

### DIFF
--- a/engines/sci/graphics/maciconbar.cpp
+++ b/engines/sci/graphics/maciconbar.cpp
@@ -24,7 +24,6 @@
 #include "sci/engine/kernel.h"
 #include "sci/engine/selector.h"
 #include "sci/engine/state.h"
-#include "sci/event.h"
 #include "sci/graphics/maciconbar.h"
 #include "sci/graphics/palette.h"
 #include "sci/graphics/screen.h"
@@ -259,21 +258,17 @@ bool GfxMacIconBar::pointOnIcon(uint32 iconIndex, Common::Point point) {
 	return _iconBarItems[iconIndex].rect.contains(point);
 }
 
-reg_t GfxMacIconBar::handleEvents() {
-	// Peek event queue for a mouse button press
+bool GfxMacIconBar::handleEvents(SciEvent evt, reg_t &iconObj) {
 	EventManager *evtMgr = g_sci->getEventManager();
-	SciEvent evt = evtMgr->getSciEvent(kSciEventMousePress | kSciEventPeek);
+	iconObj = NULL_REG;
 
-	// No mouse press found
-	if (evt.type == kSciEventNone)
-		return NULL_REG;
+	// Not a mouse press
+	if (evt.type != kSciEventMousePress)
+		return false;
 
 	// If the mouse is not over the icon bar, return
 	if (evt.mousePos.y < g_sci->_gfxScreen->getHeight())
-		return NULL_REG;
-
-	// Remove event from queue
-	evtMgr->getSciEvent(kSciEventMousePress);
+		return false;
 
 	// Mouse press on the icon bar, check the icon rectangles
 	uint iconNr;
@@ -282,9 +277,10 @@ reg_t GfxMacIconBar::handleEvents() {
 			break;
 	}
 
-	// Mouse press not on an icon
+	// Mouse press on the icon bar but not on an enabled icon,
+	// return true to indicate that this mouse press was handled
 	if (iconNr == _iconBarItems.size())
-		return NULL_REG;
+		return true;
 
 	drawIcon(iconNr, true);
 	bool isSelected = true;
@@ -305,9 +301,10 @@ reg_t GfxMacIconBar::handleEvents() {
 
 	// If user moved away from the icon, we do nothing
 	if (pointOnIcon(iconNr, evt.mousePos))
-		return _iconBarItems[iconNr].object;
+		iconObj = _iconBarItems[iconNr].object;
 
-	return NULL_REG;
+	// The mouse press was handled
+	return true;
 }
 
 } // End of namespace Sci

--- a/engines/sci/graphics/maciconbar.h
+++ b/engines/sci/graphics/maciconbar.h
@@ -26,6 +26,7 @@
 #include "common/array.h"
 
 #include "sci/engine/vm.h"
+#include "sci/event.h"
 
 namespace Graphics {
 struct Surface;
@@ -42,7 +43,7 @@ public:
 	void drawIcons();
 	void setIconEnabled(int16 index, bool enabled);
 	void setInventoryIcon(int16 icon);
-	reg_t handleEvents();
+	bool handleEvents(SciEvent evt, reg_t &iconObj);
 
 private:
 	struct IconBarItem {


### PR DESCRIPTION
This fixes two edge cases that allow mouse presses to fall through the icon bar in Mac versions of KQ6 and FPFP. Depending on the cursor this results in unexpected messages or walking to unexpected rooms when clicking an icon.

The problem is that the mac icon bar peeks at the first mouse press event in the queue whenever kGetEvent is called and handle only that message. After this kGetEvent continues to handle whatever is in the queue. This has two problems:

1. If there are two mouse press events in the queue when kGetEvent is called then the mac icon bar will handle the first and kGetEvent will handle the second, even though mac icon bar should have handled both. This is easily reproducible by clicking two mouse buttons at the same time. (Just mash 'em.)

2. If a mouse press event appears in the queue after mac icon bar peeks but before kGetEvent gets the next event then kGetEvent will handle it. This is harder to deliberately reproduce but program speed seems to be a factor. Just try playing either game for a few minutes. On my lower machine it's frequent and when I attach a debugger it's very frequent.

The fix is to remove queue peeking and allow the mac icon bar to handle every before kGetEvent does.