### PR TITLE
BACKENDS: Simplify setGraphicsMode on GPH, Dingux and LinuxMoto

### DIFF
--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -51,39 +51,20 @@ int DINGUXSdlGraphicsManager::getDefaultGraphicsMode() const {
 	return GFX_NORMAL;
 }
 
-bool DINGUXSdlGraphicsManager::setGraphicsMode(int mode) {
-	Common::StackLock lock(_graphicsMutex);
-
-	assert(_transactionMode == kTransactionActive);
-
-	if (_oldVideoMode.setup && _oldVideoMode.mode == mode)
-		return true;
-
-	int newScaleFactor = 1;
-
+int DINGUXSdlGraphicsManager::getGraphicsModeScale(int mode) const {
+	int scale;
 	switch (mode) {
 	case GFX_NORMAL:
-		newScaleFactor = 1;
-		break;
 #ifdef USE_SCALERS
 	case GFX_HALF:
-		newScaleFactor = 1;
-		break;
 #endif
+		scale = 1;
+		break;
 	default:
-		warning("unknown gfx mode %d", mode);
-		return false;
+		scale = -1;
 	}
 
-	if (_oldVideoMode.setup && _oldVideoMode.scaleFactor != newScaleFactor)
-		_transactionDetails.needHotswap = true;
-
-	_transactionDetails.needUpdatescreen = true;
-
-	_videoMode.mode = mode;
-	_videoMode.scaleFactor = newScaleFactor;
-
-	return true;
+	return scale;
 }
 
 void DINGUXSdlGraphicsManager::setGraphicsModeIntern() {

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
@@ -43,7 +43,7 @@ public:
 
 	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL) override;
 	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
-	bool setGraphicsMode(int mode) override;
+	int getGraphicsModeScale(int mode) const override;
 	void setGraphicsModeIntern() override;
 	void internUpdateScreen() override;
 	void showOverlay() override;

--- a/backends/graphics/gph/gph-graphics.cpp
+++ b/backends/graphics/gph/gph-graphics.cpp
@@ -47,37 +47,18 @@ int GPHGraphicsManager::getDefaultGraphicsMode() const {
 	return GFX_NORMAL;
 }
 
-bool GPHGraphicsManager::setGraphicsMode(int mode) {
-	Common::StackLock lock(_graphicsMutex);
-
-	assert(_transactionMode == kTransactionActive);
-
-	if (_oldVideoMode.setup && _oldVideoMode.mode == mode)
-		return true;
-
-	int newScaleFactor = 1;
-
+int GPHGraphicsManager::getGraphicsModeScale(int mode) const {
+	int scale;
 	switch (mode) {
 	case GFX_NORMAL:
-		newScaleFactor = 1;
-		break;
 	case GFX_HALF:
-		newScaleFactor = 1;
+		scale = 1;
 		break;
 	default:
-		warning("unknown gfx mode %d", mode);
-		return false;
+		scale = -1;
 	}
 
-	if (_oldVideoMode.setup && _oldVideoMode.scaleFactor != newScaleFactor)
-		_transactionDetails.needHotswap = true;
-
-	_transactionDetails.needUpdatescreen = true;
-
-	_videoMode.mode = mode;
-	_videoMode.scaleFactor = newScaleFactor;
-
-	return true;
+	return scale;
 }
 
 void GPHGraphicsManager::setGraphicsModeIntern() {

--- a/backends/graphics/gph/gph-graphics.h
+++ b/backends/graphics/gph/gph-graphics.h
@@ -42,8 +42,7 @@ public:
 
 	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL) override;
 	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
-	bool setGraphicsMode(const char *name) override;
-	bool setGraphicsMode(int mode) override;
+	int getGraphicsModeScale(int mode) const override;
 	void setGraphicsModeIntern() override;
 	void internUpdateScreen() override;
 	void showOverlay() override;

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
@@ -57,37 +57,18 @@ int LinuxmotoSdlGraphicsManager::getDefaultGraphicsMode() const {
 	return GFX_NORMAL;
 }
 
-bool LinuxmotoSdlGraphicsManager::setGraphicsMode(int mode) {
-	Common::StackLock lock(_graphicsMutex);
-
-	assert(_transactionMode == kTransactionActive);
-
-	if (_oldVideoMode.setup && _oldVideoMode.mode == mode)
-		return true;
-
-	int newScaleFactor = 1;
-
+int LinuxmotoSdlGraphicsManager::getGraphicsModeScale(int mode) const {
+	int scale;
 	switch (mode) {
 	case GFX_NORMAL:
-		newScaleFactor = 1;
-		break;
 	case GFX_HALF:
-		newScaleFactor = 1;
+		scale = 1;
 		break;
 	default:
-		warning("unknown gfx mode %d", mode);
-		return false;
+		scale = -1;
 	}
 
-	if (_oldVideoMode.setup && _oldVideoMode.scaleFactor != newScaleFactor)
-		_transactionDetails.needHotswap = true;
-
-	_transactionDetails.needUpdatescreen = true;
-
-	_videoMode.mode = mode;
-	_videoMode.scaleFactor = newScaleFactor;
-
-	return true;
+	return scale;
 }
 
 void LinuxmotoSdlGraphicsManager::setGraphicsModeIntern() {

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.h
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.h
@@ -31,7 +31,7 @@ public:
 
 	virtual void initSize(uint w, uint h) override;
 	virtual void setGraphicsModeIntern() override;
-	virtual bool setGraphicsMode(int mode) override;
+	virtual int getGraphicsModeScale(int mode) const override;
 	virtual void internUpdateScreen() override;
 	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
 	virtual int getDefaultGraphicsMode() const override;


### PR DESCRIPTION
By moving the switch into `getGraphicsModeScale`, the function becomes identical to the parent function, meaning that it can be removed.