### PR TITLE
SCI: Attempt to fix keyboard controls in contained polygons - DO NOT MERGE

### DIFF
--- a/engines/sci/engine/kpathing.cpp
+++ b/engines/sci/engine/kpathing.cpp
@@ -833,7 +833,10 @@ int PathfindingState::findNearPoint(const Common::Point &p, Polygon *polygon, Co
 		new_point.x = p1.x + u * (p2.x - p1.x);
 		new_point.y = p1.y + u * (p2.y - p1.y);
 
-		new_dist = p.sqrDist(new_point.toPoint());
+		//new_dist = p.sqrDist(new_point.toPoint());
+		int diffx = ABS(new_point.x - p.x);
+		int diffy = ABS(new_point.y - p.y);
+		new_dist = uint(diffx * diffx + diffy * diffy);
 
 		if (new_dist < dist) {
 			near_p = new_point;


### PR DESCRIPTION
Just to get people's attention, pretty wild issue with keyboard control.

A lot of rooms in SCI11 games have walkable areas defined with contained access polygons, covering the floor. Others have barred access polygons on the walls. Some games prefer one over the other, sometimes exclusively. The issue is that the former doesn't work right, returning incorrect points when trying to find out which is the closest in a given direction. Some games of course don't allow keyboard control at all, making the walk cursor itself move like the others.

For example, the lobby in Larry 6 has two barred polygons, and keyboard control is allowed. You can press the left or right arrow keys to navigate to either hallway, or go upstairs. These three rooms use contained polygons, and suddenly keyboard controls don't respond as they should, favoring mostly the left edge of the polygon no matter which direction you try to go.

Compare and contrast that with Pharkas, which favors barred polygons for at least the half dozen screens I tested.

I've narrowed it down to `Point::sqrDist` returning 0xFFFFFF for all points considered, because 30,000 is far further away than its cutoff point 4096. Removing this check yields values that are actually different. Different enough that my little test game worked perfectly fine, and Larry 6 was noticeably improved.

It feels like an ugly hack and I am _not_ a mathematically-inclined person, so I don't feel this is _quite_ the right solution. Hence the "do not merge".