### PR TITLE
SCI: Fix LONGBOW v1.0 game breaking bugs

### DIFF
--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -905,6 +905,22 @@ Common::String Kernel::lookupText(reg_t address, int index) {
 	int textlen = textres->size();
 	const char *seeker = (const char *)textres->getUnsafeDataAt(0);
 
+	if (g_sci->getGameId() == GID_LONGBOW && address.getOffset() == 1535 && textlen == 2662) {
+		// WORKAROUND: Longbow 1.0's text resource 1535 is missing 8 texts for
+		//  the pub. It appears that only the 5.25 floppy release was affected.
+		//  This was fixed by Sierra's 1.0 patch.
+		if (index >= 41) {
+			// texts 41+ exist but with incorrect offsets
+			index -= 8;
+		} else if (index >= 33) {
+			// texts 33 through 40 are missing. they comprise two sequences of
+			//  four messages. only one of the two can play, and only once in
+			//  the specific circumstance that the player enters the pub as a
+			//  merchant, changes beards, and re-enters.
+			return "** MISSING MESSAGE **";
+		}
+	}
+
 	int _index = index;
 	while (index--)
 		while (textlen-- && *seeker++)

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -387,24 +387,6 @@ Common::Error SciEngine::run() {
 
 	// Show any special warnings for buggy scripts with severe game bugs,
 	// which have been patched by Sierra
-	if (getGameId() == GID_LONGBOW) {
-		// Longbow 1.0 has a buggy script which prevents the game
-		// from progressing during the Green Man riddle sequence.
-		// A patch for this buggy script has been released by Sierra,
-		// and is necessary to complete the game without issues.
-		// The patched script is included in Longbow 1.1.
-		// Refer to bug #3036609.
-		Resource *buggyScript = _resMan->findResource(ResourceId(kResourceTypeScript, 180), 0);
-
-		if (buggyScript && (buggyScript->size() == 12354 || buggyScript->size() == 12362)) {
-			showScummVMDialog(_("A known buggy game script has been detected, which could "
-			                  "prevent you from progressing later on in the game, during "
-			                  "the sequence with the Green Man's riddles. Please, apply "
-			                  "the latest patch for this game by Sierra to avoid possible "
-			                  "problems."));
-		}
-	}
-
 	if (getGameId() == GID_KQ7 && ConfMan.getBool("subtitles")) {
 		showScummVMDialog(_("Subtitles are enabled, but subtitling in King's"
 						  " Quest 7 was unfinished and disabled in the release"


### PR DESCRIPTION
This PR fixes the three game breaking bugs in Longbow version 1.0 that make Sierra's patch practically mandatory. This allows us to remove the warning at startup recommending Sierra's patch.

Endless Green Man riddles & Forest sweep instant-death: 

These two are symptoms of the same script bug that one patch fixes. A global variable is re-used from another scene without being initializing and its random value can break things.

Ordering a drink & other pub actions:

A text resource is missing 8 entries in the 5.25 floppy version. I added a workaround to detect the broken resource, repair the offsets, and return "** MISSING MESSAGE **" for the rest. This isn't perfect but it's an improvement from incorrect messages and a game-ending error. The missing entries are really just a one-time sequence of four texts that only occur when the player does a multi-room sequence of actions I consider unusual. I assume just typing the 8 missing strings myself is not okay. =) (but tell me if it is!)