### PR TITLE
SCI: Add parser support for LSL3, SQ3 German Amiga

### DIFF
--- a/engines/sci/engine/kparse.cpp
+++ b/engines/sci/engine/kparse.cpp
@@ -169,7 +169,7 @@ reg_t kSetSynonyms(EngineState *s, int argc, reg_t *argv) {
 	Vocabulary *voc = g_sci->getVocabulary();
 
 	// Only SCI0-SCI1 EGA games had a parser. In newer versions, this is a stub
-	if (getSciVersion() > SCI_VERSION_1_EGA_ONLY)
+	if (!g_sci->hasParser())
 		return s->r_acc;
 
 	voc->clearSynonyms();

--- a/engines/sci/parser/vocabulary.cpp
+++ b/engines/sci/parser/vocabulary.cpp
@@ -60,7 +60,7 @@ Vocabulary::Vocabulary(ResourceManager *resMan, bool foreign) : _resMan(resMan),
 		_resourceIdBranches += 10;
 	}
 
-	if (getSciVersion() <= SCI_VERSION_1_EGA_ONLY && loadParserWords()) {
+	if (g_sci->hasParser() && loadParserWords()) {
 		loadSuffixes();
 		if (loadBranches())
 			// Now build a GNF grammar out of this

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -311,11 +311,7 @@ Common::Error SciEngine::run() {
 	_kernel->init();
 
 	_features = new GameFeatures(segMan, _kernel);
-	// Only SCI0, SCI01 and SCI1 EGA games used a parser
-	_vocabulary = (getSciVersion() <= SCI_VERSION_1_EGA_ONLY) ? new Vocabulary(_resMan, false) : NULL;
-	// Also, XMAS1990 apparently had a parser too. Refer to https://forums.scummvm.org/viewtopic.php?t=9135
-	if (getGameId() == GID_CHRISTMAS1990)
-		_vocabulary = new Vocabulary(_resMan, false);
+	_vocabulary = hasParser() ? new Vocabulary(_resMan, false) : NULL;
 
 	_gamestate = new EngineState(segMan);
 	_guestAdditions = new GuestAdditions(_gamestate, _features, _kernel);
@@ -777,6 +773,13 @@ bool SciEngine::isBE() const{
 	default:
 		return false;
 	}
+}
+
+bool SciEngine::hasParser() const {
+	// Only SCI0, SCI01 and SCI1 EGA games used a parser, along with
+	//  multilingual LSL3 and SQ3 Amiga which are SCI_VERSION_1_MIDDLE
+	return getSciVersion() <= SCI_VERSION_1_EGA_ONLY ||
+			getGameId() == GID_LSL3 || getGameId() == GID_SQ3;
 }
 
 bool SciEngine::hasMacIconBar() const {

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -228,7 +228,7 @@ enum SciVersion {
 	SCI_VERSION_01, // KQ1 and multilingual games (S.old.*)
 	SCI_VERSION_1_EGA_ONLY, // SCI 1 EGA with parser (i.e. QFG2 only)
 	SCI_VERSION_1_EARLY, // KQ5 floppy, SQ4 floppy, XMAS card 1990, Fairy tales, Jones floppy
-	SCI_VERSION_1_MIDDLE, // LSL1, Jones CD
+	SCI_VERSION_1_MIDDLE, // LSL1, Jones CD, LSL3 & SQ3 multilingual Amiga
 	SCI_VERSION_1_LATE, // Dr. Brain 1, EcoQuest 1, Longbow, PQ3, SQ1, LSL5, KQ5 CD
 	SCI_VERSION_1_1, // Dr. Brain 2, EcoQuest 1 CD, EcoQuest 2, KQ6, QFG3, SQ4CD, XMAS 1992 and many more
 	SCI_VERSION_2, // GK1, PQ4 floppy, QFG4 floppy
@@ -283,6 +283,7 @@ public:
 	/** Returns true if the game's original platform is big-endian. */
 	bool isBE() const;
 
+	bool hasParser() const;
 	bool hasMacIconBar() const;
 
 	inline ResourceManager *getResMan() const { return _resMan; }


### PR DESCRIPTION
I recently got a hold of the dual German/English Amiga versions of LSL3 and SQ3. They're unusual in that they were released in 1991 and are SCI_VERSION_1_MIDDLE, making them now the latest known EGA parser games, and breaking some existing version checks.

This updates the parser/vocab version checks so that vocab gets loaded.

I've done some spot-checking of the Amiga interpreter for version 1 middle code to make sure that these versions weren't being misidentified, and they indeed have newer code. For example, they contain the Sound:vol update in UpdateCues (https://github.com/scummvm/scummvm/pull/1536), which wasn't in the first version of SQ4.