### PR TITLE
Sword25: image trace on quick cursor changes fix

### DIFF
--- a/engines/sword25/gfx/renderobjectmanager.cpp
+++ b/engines/sword25/gfx/renderobjectmanager.cpp
@@ -52,7 +52,8 @@ void RenderObjectQueue::add(RenderObject *renderObject) {
 bool RenderObjectQueue::exists(const RenderObjectQueueItem &renderObjectQueueItem) {
 	for (RenderObjectQueue::iterator it = begin(); it != end(); ++it)
 		if ((*it)._renderObject == renderObjectQueueItem._renderObject &&
-			(*it)._version == renderObjectQueueItem._version)
+			(*it)._version == renderObjectQueueItem._version && 
+			(*it)._bbox == renderObjectQueueItem._bbox)
 			return true;
 	return false;
 }


### PR DESCRIPTION
Fix: https://bugs.scummvm.org/ticket/7061
Additional check in RenderObjectQueue::exists() that 
checks if a RenderObject should be 
redrawn. 
After the change RenderObjectManager::render() 
was tested to update 0 objects in the first active scene,
when player does nothing including not moving cursor 
& 2 objects when player moves cursor.
It seems glitch happens when  cursor image
changes from image X to image Y to image X in a short 
time frame leaving image of state Y not re-rendered.
