### PR TITLE
COMMON: fixed reading ini files with section containing more than one…

### DIFF
--- a/common/ini-file.cpp
+++ b/common/ini-file.cpp
@@ -30,7 +30,7 @@ namespace Common {
 
 bool INIFile::isValidName(const String &name) {
 	const char *p = name.c_str();
-	while (*p && (isAlnum(*p) || *p == '-' || *p == '_' || *p == '.'))
+	while (*p && (isAlnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == ' '))
 		p++;
 	return *p == 0;
 }
@@ -108,7 +108,7 @@ bool INIFile::loadFromStream(SeekableReadStream &stream) {
 			// is, verify that it only consists of alphanumerics,
 			// periods, dashes and underscores). Mohawk Living Books games
 			// can have periods in their section names.
-			while (*p && (isAlnum(*p) || *p == '-' || *p == '_' || *p == '.'))
+			while (*p && (isAlnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == ' '))
 				p++;
 
 			if (*p == '\0')


### PR DESCRIPTION
Current implementation can't read section name that contains more than one word(
e.g
[Part 0]
[Part 2 Chapter 1]

> [The beginning each of section is denoted by a line of the following form: "[section type]" where section type is a series of words](http://www.nongnu.org/chmspec/latest/INI.html)