### PR TITLE
WINTERMUTE: Fixed normalizeAngle's output range from 0-360 to 0-359.

### DIFF
--- a/engines/wintermute/utils/utils.cpp
+++ b/engines/wintermute/utils/utils.cpp
@@ -44,7 +44,7 @@ void BaseUtils::swap(int *a, int *b) {
 
 //////////////////////////////////////////////////////////////////////////
 float BaseUtils::normalizeAngle(float angle) {
-	while (angle > 360) {
+	while (angle > 359) {
 		angle -= 360;
 	}
 	while (angle < 0) {


### PR DESCRIPTION
```
WINTERMUTE: Fixed normalizeAngle's output range from 0-360 to 0-359.

When normalizing an angle, we expect the number to be between 0 and
359 (since 360 is 0), this changes the util so 360 is transformed to 0.

Technically this is change makes the range [0, 360) instead of [0, 360], floating
numbers (such as 359.8) would not be returned as negative thanks to the
following `while` loop.
```
