### PR TITLE
ANDROID: Add a pthreads-based mutex manager

### DIFF
--- a/backends/module.mk
+++ b/backends/module.mk
@@ -199,6 +199,11 @@ MODULE_OBJS += \
 	taskbar/win32/win32-taskbar.o
 endif
 
+ifeq ($(BACKEND),android)
+MODULE_OBJS += \
+	mutex/pthread/pthread-mutex.o
+endif
+
 ifeq ($(BACKEND),androidsdl)
 MODULE_OBJS += \
 	events/androidsdl/androidsdl-events.o \

--- a/backends/mutex/pthread/pthread-mutex.cpp
+++ b/backends/mutex/pthread/pthread-mutex.cpp
@@ -1,0 +1,70 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_EXCEPTION_time_h
+
+#include "common/scummsys.h"
+
+#if defined(__ANDROID__) || defined(IPHONE)
+
+#include "backends/mutex/pthread/pthread-mutex.h"
+
+#include <pthread.h>
+
+
+OSystem::MutexRef PthreadMutexManager::createMutex() {
+	pthread_mutexattr_t attr;
+
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+
+	pthread_mutex_t *mutex = new pthread_mutex_t;
+
+	if (pthread_mutex_init(mutex, &attr) != 0) {
+		warning("pthread_mutex_init() failed");
+		delete mutex;
+		return NULL;
+	}
+
+	return (OSystem::MutexRef)mutex;
+}
+
+void PthreadMutexManager::lockMutex(OSystem::MutexRef mutex) {
+	if (pthread_mutex_lock((pthread_mutex_t *)mutex) != 0)
+		warning("pthread_mutex_lock() failed");
+}
+
+void PthreadMutexManager::unlockMutex(OSystem::MutexRef mutex) {
+	if (pthread_mutex_unlock((pthread_mutex_t *)mutex) != 0)
+		warning("pthread_mutex_unlock() failed");
+}
+
+void PthreadMutexManager::deleteMutex(OSystem::MutexRef mutex) {
+	pthread_mutex_t *m = (pthread_mutex_t *)mutex;
+
+	if (pthread_mutex_destroy(m) != 0)
+		warning("pthread_mutex_destroy() failed");
+	else
+		delete m;
+}
+
+#endif

--- a/backends/mutex/pthread/pthread-mutex.h
+++ b/backends/mutex/pthread/pthread-mutex.h
@@ -1,0 +1,40 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKENDS_MUTEX_PTHREAD_H
+#define BACKENDS_MUTEX_PTHREAD_H
+
+#include "backends/mutex/mutex.h"
+
+/**
+ * pthreads mutex manager
+ */
+class PthreadMutexManager : public MutexManager {
+public:
+	virtual OSystem::MutexRef createMutex();
+	virtual void lockMutex(OSystem::MutexRef mutex);
+	virtual void unlockMutex(OSystem::MutexRef mutex);
+	virtual void deleteMutex(OSystem::MutexRef mutex);
+};
+
+
+#endif

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -54,6 +54,7 @@
 #include "common/config-manager.h"
 
 #include "backends/keymapper/keymapper.h"
+#include "backends/mutex/pthread/pthread-mutex.h"
 #include "backends/saves/default/default-saves.h"
 #include "backends/timer/default/default-timer.h"
 
@@ -132,10 +133,11 @@ OSystem_Android::OSystem_Android(int audio_sample_rate, int audio_buffer_size) :
 	_show_mouse(false),
 	_show_overlay(false),
 	_enable_zoning(false),
+	_mutexManager(0),
 	_mixer(0),
 	_shake_offset(0),
 	_queuedEventTime(0),
-	_event_queue_lock(createMutex()),
+	_event_queue_lock(0),
 	_touch_pt_down(),
 	_touch_pt_scroll(),
 	_touch_pt_dt(),
@@ -180,6 +182,9 @@ OSystem_Android::~OSystem_Android() {
 	_timerManager = 0;
 
 	deleteMutex(_event_queue_lock);
+
+	delete _mutexManager;
+	_mutexManager = 0;
 }
 
 void *OSystem_Android::timerThreadFunc(void *arg) {
@@ -366,7 +371,10 @@ void OSystem_Android::initBackend() {
 	// screen. Passing the savepath in this way makes it stick
 	// (via ConfMan.registerDefault)
 	_savefileManager = new DefaultSaveFileManager(ConfMan.get("savepath"));
+	_mutexManager = new PthreadMutexManager();
 	_timerManager = new DefaultTimerManager();
+
+	_event_queue_lock = createMutex();
 
 	gettimeofday(&_startTime, 0);
 
@@ -470,41 +478,23 @@ void OSystem_Android::delayMillis(uint msecs) {
 }
 
 OSystem::MutexRef OSystem_Android::createMutex() {
-	pthread_mutexattr_t attr;
-
-	pthread_mutexattr_init(&attr);
-	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-
-	pthread_mutex_t *mutex = new pthread_mutex_t;
-
-	if (pthread_mutex_init(mutex, &attr) != 0) {
-		warning("pthread_mutex_init() failed");
-
-		delete mutex;
-
-		return 0;
-	}
-
-	return (MutexRef)mutex;
+	assert(_mutexManager);
+	return _mutexManager->createMutex();
 }
 
 void OSystem_Android::lockMutex(MutexRef mutex) {
-	if (pthread_mutex_lock((pthread_mutex_t *)mutex) != 0)
-		warning("pthread_mutex_lock() failed");
+	assert(_mutexManager);
+	_mutexManager->lockMutex(mutex);
 }
 
 void OSystem_Android::unlockMutex(MutexRef mutex) {
-	if (pthread_mutex_unlock((pthread_mutex_t *)mutex) != 0)
-		warning("pthread_mutex_unlock() failed");
+	assert(_mutexManager);
+	_mutexManager->unlockMutex(mutex);
 }
 
 void OSystem_Android::deleteMutex(MutexRef mutex) {
-	pthread_mutex_t *m = (pthread_mutex_t *)mutex;
-
-	if (pthread_mutex_destroy(m) != 0)
-		warning("pthread_mutex_destroy() failed");
-	else
-		delete m;
+	assert(_mutexManager);
+	_mutexManager->deleteMutex(mutex);
 }
 
 void OSystem_Android::quit() {

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -96,6 +96,8 @@ extern void checkGlError(const char *expr, const char *file, int line);
 #define GLTHREADCHECK do {  } while (false)
 #endif
 
+class MutexManager;
+
 class OSystem_Android : public EventsBaseBackend, public PaletteManager {
 private:
 	// passed from the dark side
@@ -145,6 +147,7 @@ private:
 	bool _enable_zoning;
 	bool _virtkeybd_on;
 
+	MutexManager *_mutexManager;
 	Audio::MixerImpl *_mixer;
 	timeval _startTime;
 


### PR DESCRIPTION
This is a first step towards moving the Android backend to use ModularBackend.