### PR TITLE
SCI: Fix diskdump patch file headers

### DIFF
--- a/engines/sci/resource.cpp
+++ b/engines/sci/resource.cpp
@@ -224,10 +224,14 @@ void Resource::unalloc() {
 }
 
 void Resource::writeToStream(Common::WriteStream *stream) const {
-	stream->writeByte(getType() | 0x80); // 0x80 is required by old Sierra SCI, otherwise it wont accept the patch file
-	stream->writeByte(_headerSize);
-	if (_headerSize > 0)
+	if (_headerSize == 0) {
+		// create patch file header
+		stream->writeByte(getType() | 0x80); // 0x80 is required by old Sierra SCI, otherwise it wont accept the patch file
+		stream->writeByte(_headerSize);
+	} else {
+		// use existing patch file header
 		stream->write(_header, _headerSize);
+	}
 	stream->write(_data, _size);
 }
 


### PR DESCRIPTION
This fixes a bug in the 'diskdump' debugging command that creates an additional patch file header when dumping resources that were loaded from a patch file instead of a volume. This would corrupt the dumped patch file.

The code would always create and write a new header, even if it was about to write an existing one that was read in from a patch file. Now it's either one or the other.