### PR TITLE
ANDROIDSDL: Fix build with NDK r15c

### DIFF
--- a/dists/androidsdl/How_to_Build.txt
+++ b/dists/androidsdl/How_to_Build.txt
@@ -1,49 +1,121 @@
-1) At first, for building you need (64bit) linux.
+1) In order to build the androidsdl port you will need a 64-bit Linux OS installation.
+   The following has been tested in lubuntu 64-bit 16.04.6 LTS (xenial), kernel 4.15.0-30-generic.
 
-2) Install Android SDK and NDK (You can unpack them into ~/Android directory), and download required tools.
+2a) This guide assumes that you create an "~/Android" folder inside your home directory to put the Android SDK and NDK.
 
-	https://developer.android.com/studio/index.html (you can download GUI Android Studio with SDK (which installs
-from studio) or download command-line tools)
-    
-At current moment (01.01.2018) latest NDK version r16b not supported by pelya's liBSDL, so you need to use previous version r15c
-    https://developer.android.com/ndk/downloads/older_releases.html
+2b) Install the Android SDK.
 
-Download this:
+   a) Navigate to url: https://developer.android.com/studio/index.html
+      Download the "Command line tools only" packet for Linux ("sdk-tools-linux-4333796.zip" at the time of this writing).
+      Create an "~/Android" folder in your home directory. Then, create a "~/Android/android-sdk" subfolder.
+      Using a shell terminal issue:
+          mkdir ~/Android
+          mkdir ~/Android/android-sdk
 
-	Android SDK Tools
-	Android SDK Platform-tools
-	Android SDL Build tools
-	Android 7.1.1 (API 25) or higher
-	SDK Platform (API 25) or higher
-	Extras/Android Support Repository
+      Unpack the command line tools zip packet inside the "~/Android/android-sdk" folder.
+      This should create a "tools" subfolder.
 
-3) Install JDK. You can do it from apt-get tool or download from official site (in this case you must set envirnoment 
-value to JDK, see guides "How install JDK and set envirnoment values to JDK).
+      Install the required android SDK tools.
+      Using a shell terminal issue:
+          touch ~/.android/repositories.cfg
+          cd ~/Android/android-sdk/tools/bin
+          ./sdk-manager --install "tools"
+          ./sdk-manager --install "build-tools;28.0.2"
+          ./sdk-manager --install "extras;android;m2repository"
+          ./sdk-manager --install "platform-tools"
+          ./sdk-manager --install "platforms;android-25"
 
-Command:
-	sudo apt-get install openjdk-8-jdk
+      Then, using the following command verify that you've installed the correct tools:
+          ./sdk-manager --list
 
-4) Set envirnoment values to Android's tools. For set android environment I create and use simple script setenv-android.sh.
-In this sript you must set your paths and tools versions. If script don't work (see results from command "printenv") - set
-this values manually. Warning: values will be setted for one command-line session.
+      You should see a printout that begins like the following:
 
-Script:
-	#!/bin/sh
+      Path                          | Version   | Description                     | Location
+      -------                       | -------   | -------                         | -------
+      build-tools;28.0.2            | 28.0.2    | Android SDK Build-Tools 28.0.2  | build-tools/28.0.2/
+      extras;android;m2repository   | 47.0.0    | Android Support Repository      | extras/android/m2repository/
+      platform-tools                | 28.0.2    | Android SDK Platform-Tools      | platform-tools/
+      platforms;android-25          | 3         | Android SDK Platform 25         | platforms/android-25/
+      tools                         | 26.1.1    | Android SDK Tools 26.1.1        | tools/
 
-	export ANDROID_HOME=~/Android/android-sdk
-	export ANDROID_NDK_HOME=~/Android/android-ndk-r15c
-    export PATH=$ANDROID_NDK_HOME:$ANDROID_HOME/tools:$PATH
+   b) Alternatively, you could download and install the Android Studio for Linux 64-bit. You can then use sdk-manager GUI tool to install the required additional tools and SDK resources. Use the above list as a guide to what packages you should download and install.
 
-5) Install packages, which needs for build:
+3) Install the r15c (July 2017) version for Android NDK ("android-ndk-r15c-linux-x86_64.zip").
+   Newer versions are currently not supported. The r15c NDK can be found in the following url:
+   https://developer.android.com/ndk/downloads/older_releases.html
 
-Commands:
-	sudo apt-get install make
-	sudo apt-get install git-core
+   Extract the zip file you downloaded into the ~/Android folder.
+   This should create a "android-ndk-r15c" subfolder.
 
-6) Create and put keystore (You can use debug version) in ~/.android/debug.keystore
+4) Install the JDK. You can do this using the apt-get tool or by downloading the JDK from Oracle's official site (in the latter case you must set environment variables for JDK; see guides "How install JDK and set environment variables for JDK").
+   Recommended command:
+          sudo apt-get install openjdk-8-jdk
 
-8) Now you can build project
-	cd scummvm/dists/androidsdl
-	./build.sh
+5) Set the environment variables for Android SDK and NDK tools. 
+   For this purpose you can create and use a simple "setenv-android.sh" script.
+   In this script define variables for the paths to your SDK tools and NDK. 
 
-Your apk will be stored in this folder
+   Sample (suggested) Script:
+          #!/bin/sh
+
+          export ANDROID_HOME=~/Android/android-sdk
+          export ANDROID_NDK_HOME=~/Android/android-ndk-r15c
+          export ANDROID_SDK_TOOLS=$ANDROID_HOME/tools
+          export ANDROID_SDK_BTOOLS=$ANDROID_HOME/build-tools/28.0.2
+          export PATH=$ANDROID_NDK_HOME:$ANDROID_SDK_TOOLS:$ANDROID_SDK_BTOOLS:$PATH
+
+   Save the "setenv-android.sh" script in your "~/Android" folder.
+   In order to apply the script run from a shell terminal:
+          source ~/Android/setenv-android.sh
+   Verify that your environmental variables have been set correctly by running:
+          echo $PATH
+   You should see your NDK and SDK paths at the start of the $PATH variable.
+   WARNING: These environmental variables will be set only for that particular command-line session; You will need to re-run this script if you start another shell terminal session.
+
+6) Install the Linux packages that are required for the build:
+   Commands:
+          sudo apt-get install make
+          sudo apt-get install git-core
+          sudo apt-get install build-essential
+          sudo apt-get install zipalign
+
+7) Create and put a keystore (you can use the debug version) in ~/.android/debug.keystore
+   To create a debug key store run from the shell terminal:
+          keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000
+          keytool -importkeystore -srckeystore debug.keystore -destkeystore debug.keystore -deststoretype pkcs12
+   Enter "android" without the quotes when asked for the keystore password.
+
+8) Clone the scummvm repository. This guide assumes that you run the clone command from your home directory:
+          cd ~
+          git clone https://github.com/scummvm/scummvm.git
+   The above command will create a scummvm folder in your home directory.
+
+9) You can now start building the androidsdl port project by issuing the following commands from the terminal session where you have already set the Android NDK and SDK environmental variables:
+          cd ~/scummvm/dists/androidsdl
+          ./build.sh
+
+10) If the process completes successfully, a "scummvm-debug.apk" file will be stored in that folder (~/scummvm/dists/androidsdl).
+    Since this apk is self-signed you will need to enable installation by third-party sources on your Android device in order to install it.
+
+NOTE: You can significantly reduce the build time if you target a specific Android architecture and/or building scummvm for specific game engines only.
+      A) In order to target specific architectures edit the following line from the "~/scummvm/dists/androidsdl/scummvm/AndroidAppSettings.cfg" file:
+         From:
+            MultiABI="armeabi-v7a arm64-v8a x86 x86_64"
+         To:
+            MultiABI="arm64-v8a"
+
+         The above line is only an example; you might have to specify another architecture for your specific use case.
+
+      B) In order to build the scummvm androidsdl port for specific engines only:
+         - Open the "~/scummvm/dists/androidsdl/scummvm/AndroidBuild.sh" file
+         - Find the following line which contains the configure command:
+           $ANDROIDSDL/project/jni/application/setEnvironment-$1.sh sh -c "cd scummvm/bin-$1 && env LIBS='-lflac -lvorbis -logg -lmad -lz -lgcc -ltheora -lpng -lfreetype -lfaad -lgnustl_static' ../configure --host=androidsdl-$1 --enable-zlib --enable-vorbis --enable-mad --enable-flac --enable-png --enable-theoradec --disable-sdlnet --disable-libcurl --disable-cloud --enable-vkeybd --enable-release --enable-mt32emu --disable-readline --disable-nasm --disable-timidity --disable-fluidsynth --datadir=. "
+         - Edit the line and after "../configure"  add "--disable-all-engines --enable-engine=YYYY", where in place of "YYYY" you should specify game engine for which you want to build scummvm.
+           For example (building only for the bladerunner engine):
+           $ANDROIDSDL/project/jni/application/setEnvironment-$1.sh sh -c "cd scummvm/bin-$1 && env LIBS='-lflac -lvorbis -logg -lmad -lz -lgcc -ltheora -lpng -lfreetype -lfaad -lgnustl_static' ../configure --host=androidsdl-$1 --disable-all-engines --enable-engine=bladerunner --enable-zlib --enable-vorbis --enable-mad --enable-flac --enable-png --enable-theoradec --disable-sdlnet --disable-libcurl --disable-cloud --enable-vkeybd --enable-release --enable-mt32emu --disable-readline --disable-nasm --disable-timidity --disable-fluidsynth --datadir=. "
+
+References:
+https://wiki.scummvm.org/index.php/Compiling_ScummVM/Android-SDL
+https://forums.scummvm.org/viewtopic.php?t=14811
+https://forums.scummvm.org/viewtopic.php?t=14516
+http://developer.android.com/tools/publishing/app-signing.html#debugmode

--- a/dists/androidsdl/How_to_Build.txt
+++ b/dists/androidsdl/How_to_Build.txt
@@ -1,5 +1,22 @@
-1) In order to build the androidsdl port you will need a 64-bit Linux OS installation.
-   The following has been tested in lubuntu 64-bit 16.04.6 LTS (xenial), kernel 4.15.0-30-generic.
+1a) In order to build the androidsdl port you will need a 64-bit Linux OS installation with an Internet connection.
+    The following has been tested in lubuntu 64-bit 16.04.6 LTS (xenial), kernel 4.15.0-47-generic.
+
+1b) Make sure you have the latest updates for your OS by running from a shell terminal:
+          sudo apt-get update
+          sudo apt-get upgrade
+    After installing any updates, reboot your PC if required.
+    You can also check the Software Updater GUI utility (or similar) for additional pending updates, such as kernel updates or Ubuntu Base updates (for Ubuntu based distributions).
+    Reboot your PC, if you are prompted to.
+
+1c) Install the Linux packages that are required for the build:
+    Commands:
+          sudo apt-get install build-essential
+          sudo apt-get install git
+          sudo apt-get install zipalign
+
+1d) Install the JDK. You can do this using the apt-get tool or by downloading the JDK from Oracle's official site (in the latter case you must set environment variables for JDK; see guides "How install JDK and set environment variables for JDK").
+    Recommended command:
+          sudo apt-get install openjdk-8-jdk
 
 2a) This guide assumes that you create an "~/Android" folder inside your home directory to put the Android SDK and NDK.
 
@@ -7,8 +24,10 @@
 
    a) Navigate to url: https://developer.android.com/studio/index.html
       Download the "Command line tools only" packet for Linux ("sdk-tools-linux-4333796.zip" at the time of this writing).
-      Create an "~/Android" folder in your home directory. Then, create a "~/Android/android-sdk" subfolder.
-      Using a shell terminal issue:
+      Create an "~/.android" and an "~/Android" folder in your home directory.
+      Then, create a "~/Android/android-sdk" subfolder.
+      To do this using a shell terminal issue:
+          mkdir ~/.android
           mkdir ~/Android
           mkdir ~/Android/android-sdk
 
@@ -19,23 +38,24 @@
       Using a shell terminal issue:
           touch ~/.android/repositories.cfg
           cd ~/Android/android-sdk/tools/bin
-          ./sdk-manager --install "tools"
-          ./sdk-manager --install "build-tools;28.0.2"
-          ./sdk-manager --install "extras;android;m2repository"
-          ./sdk-manager --install "platform-tools"
-          ./sdk-manager --install "platforms;android-25"
+          ./sdkmanager --install "platforms;android-26"
+          ./sdkmanager --install "build-tools;26.0.0"
+          ./sdkmanager --install "extras;android;m2repository"
+
+      Accept any license agreement you are prompted with during the above installation process.
+      Also, for good measure, issue the following command, then review and accept any pending license agreements:
+          ./sdkmanager --licenses
 
       Then, using the following command verify that you've installed the correct tools:
-          ./sdk-manager --list
+          ./sdkmanager --list
 
       You should see a printout that begins like the following:
 
       Path                          | Version   | Description                     | Location
       -------                       | -------   | -------                         | -------
-      build-tools;28.0.2            | 28.0.2    | Android SDK Build-Tools 28.0.2  | build-tools/28.0.2/
+      build-tools;26.0.0            | 26.0.0    | Android SDK Build-Tools 26.0.0  | build-tools/26.0.0/
       extras;android;m2repository   | 47.0.0    | Android Support Repository      | extras/android/m2repository/
-      platform-tools                | 28.0.2    | Android SDK Platform-Tools      | platform-tools/
-      platforms;android-25          | 3         | Android SDK Platform 25         | platforms/android-25/
+      platforms;android-26          | 2         | Android SDK Platform 26         | platforms/android-26/
       tools                         | 26.1.1    | Android SDK Tools 26.1.1        | tools/
 
    b) Alternatively, you could download and install the Android Studio for Linux 64-bit. You can then use sdk-manager GUI tool to install the required additional tools and SDK resources. Use the above list as a guide to what packages you should download and install.
@@ -44,24 +64,21 @@
    Newer versions are currently not supported. The r15c NDK can be found in the following url:
    https://developer.android.com/ndk/downloads/older_releases.html
 
-   Extract the zip file you downloaded into the ~/Android folder.
+   Extract the zip file you downloaded into the "~/Android" folder.
    This should create a "android-ndk-r15c" subfolder.
 
-4) Install the JDK. You can do this using the apt-get tool or by downloading the JDK from Oracle's official site (in the latter case you must set environment variables for JDK; see guides "How install JDK and set environment variables for JDK").
-   Recommended command:
-          sudo apt-get install openjdk-8-jdk
-
-5) Set the environment variables for Android SDK and NDK tools. 
+4) Set the environment variables for Android SDK and NDK tools. 
    For this purpose you can create and use a simple "setenv-android.sh" script.
    In this script define variables for the paths to your SDK tools and NDK. 
 
-   Sample (suggested) Script:
+   Sample (suggested) script:
           #!/bin/sh
 
           export ANDROID_HOME=~/Android/android-sdk
+          export ANDROID_SDK_ROOT=~/Android/android-sdk
           export ANDROID_NDK_HOME=~/Android/android-ndk-r15c
           export ANDROID_SDK_TOOLS=$ANDROID_HOME/tools
-          export ANDROID_SDK_BTOOLS=$ANDROID_HOME/build-tools/28.0.2
+          export ANDROID_SDK_BTOOLS=$ANDROID_HOME/build-tools/26.0.0
           export PATH=$ANDROID_NDK_HOME:$ANDROID_SDK_TOOLS:$ANDROID_SDK_BTOOLS:$PATH
 
    Save the "setenv-android.sh" script in your "~/Android" folder.
@@ -70,32 +87,29 @@
    Verify that your environmental variables have been set correctly by running:
           echo $PATH
    You should see your NDK and SDK paths at the start of the $PATH variable.
-   WARNING: These environmental variables will be set only for that particular command-line session; You will need to re-run this script if you start another shell terminal session.
 
-6) Install the Linux packages that are required for the build:
-   Commands:
-          sudo apt-get install make
-          sudo apt-get install git-core
-          sudo apt-get install build-essential
-          sudo apt-get install zipalign
+   WARNING: These environmental variables will be set only for that particular command-line session;
+            You will need to re-run this script if you start another shell terminal session.
+            You should not re-run this script within the same shell terminal session.
 
-7) Create and put a keystore (you can use the debug version) in ~/.android/debug.keystore
+5) Create and put a keystore (you can use the debug version) in "~/.android/debug.keystore".
    To create a debug key store run from the shell terminal:
-          keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000
-          keytool -importkeystore -srckeystore debug.keystore -destkeystore debug.keystore -deststoretype pkcs12
+          keytool -genkey -v -keystore ~/.android/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000
+          keytool -importkeystore -srckeystore ~/.android/debug.keystore -destkeystore ~/.android/debug.keystore -deststoretype pkcs12   
    Enter "android" without the quotes when asked for the keystore password.
 
-8) Clone the scummvm repository. This guide assumes that you run the clone command from your home directory:
+6) Clone the ScummVM repository. This guide assumes that you run the clone command from your home directory:
           cd ~
           git clone https://github.com/scummvm/scummvm.git
-   The above command will create a scummvm folder in your home directory.
+   The above command will create a "scummvm" folder in your home directory.
 
-9) You can now start building the androidsdl port project by issuing the following commands from the terminal session where you have already set the Android NDK and SDK environmental variables:
+7) You can now start building the androidsdl port project by issuing the following commands from the terminal session where you have already set the Android NDK and SDK environmental variables:
           cd ~/scummvm/dists/androidsdl
           ./build.sh
 
-10) If the process completes successfully, a "scummvm-debug.apk" file will be stored in that folder (~/scummvm/dists/androidsdl).
+8) If the process completes successfully, a "scummvm-debug.apk" file will be stored in that folder (~/scummvm/dists/androidsdl).
     Since this apk is self-signed you will need to enable installation by third-party sources on your Android device in order to install it.
+
 
 NOTE: You can significantly reduce the build time if you target a specific Android architecture and/or building scummvm for specific game engines only.
       A) In order to target specific architectures edit the following line from the "~/scummvm/dists/androidsdl/scummvm/AndroidAppSettings.cfg" file:
@@ -114,7 +128,9 @@ NOTE: You can significantly reduce the build time if you target a specific Andro
            For example (building only for the bladerunner engine):
            $ANDROIDSDL/project/jni/application/setEnvironment-$1.sh sh -c "cd scummvm/bin-$1 && env LIBS='-lflac -lvorbis -logg -lmad -lz -lgcc -ltheora -lpng -lfreetype -lfaad -lgnustl_static' ../configure --host=androidsdl-$1 --disable-all-engines --enable-engine=bladerunner --enable-zlib --enable-vorbis --enable-mad --enable-flac --enable-png --enable-theoradec --disable-sdlnet --disable-libcurl --disable-cloud --enable-vkeybd --enable-release --enable-mt32emu --disable-readline --disable-nasm --disable-timidity --disable-fluidsynth --datadir=. "
 
+
 References:
+
 https://wiki.scummvm.org/index.php/Compiling_ScummVM/Android-SDL
 https://forums.scummvm.org/viewtopic.php?t=14811
 https://forums.scummvm.org/viewtopic.php?t=14516

--- a/dists/androidsdl/How_to_Build.txt
+++ b/dists/androidsdl/How_to_Build.txt
@@ -12,7 +12,6 @@
     Commands:
           sudo apt-get install build-essential
           sudo apt-get install git
-          sudo apt-get install zipalign
 
 1d) Install the JDK. You can do this using the apt-get tool or by downloading the JDK from Oracle's official site (in the latter case you must set environment variables for JDK; see guides "How install JDK and set environment variables for JDK").
     Recommended command:

--- a/dists/androidsdl/build.sh
+++ b/dists/androidsdl/build.sh
@@ -9,7 +9,9 @@ if [ \! -d ../../../androidsdl ] ; then
    cd androidsdl
    git submodule update --init project/jni/iconv/src
    git checkout d378ee692f2e380a0ab0635c1df2eb6941b5bf58
-   cd ../scummvm/dists/androidsdl
+   cd project/jni/iconv/src
+   git checkout 07bead221ed4fa61cc8d880db3d9a5e704866097
+   cd ../../../../../scummvm/dists/androidsdl
 fi
 
 if [ \! -d scummvm/scummvm ] ; then

--- a/dists/androidsdl/build.sh
+++ b/dists/androidsdl/build.sh
@@ -10,6 +10,7 @@ if [ \! -d ../../../androidsdl ] ; then
    git submodule update --init project/jni/iconv/src
    git checkout d378ee692f2e380a0ab0635c1df2eb6941b5bf58
    cd project/jni/iconv/src
+# checkout a specific version of iconv that allows building with the specific version (d378ee692f2e380a0ab0635c1df2eb6941b5bf58) of androidsdl 
    git checkout 07bead221ed4fa61cc8d880db3d9a5e704866097
    cd ../../../../../scummvm/dists/androidsdl
 fi

--- a/dists/androidsdl/scummvm/AndroidAppSettings.cfg
+++ b/dists/androidsdl/scummvm/AndroidAppSettings.cfg
@@ -185,7 +185,8 @@ DeleteFilesOnUpgrade="%"
 # Optional shared libraries to compile - removing some of them will save space
 # MP3 support by libMAD is encumbered by patents and libMAD is GPL-ed
 # Available libraries: mad (GPL-ed!) sdl_mixer sdl_image sdl_ttf sdl_net sdl_blitpool sdl_gfx sdl_sound intl xml2 lua jpeg png ogg flac tremor vorbis freetype xerces curl theora fluidsynth lzma lzo2 mikmod openal timidity zzip bzip2 yaml-cpp python boost_date_time boost_filesystem boost_iostreams boost_program_options boost_regex boost_signals boost_system boost_thread glu avcodec avdevice avfilter avformat avresample avutil swscale swresample bzip2 
-CompiledLibraries="mad vorbis flac ogg jpeg png theora freetype faad curl sdl_net"
+#CompiledLibraries="mad vorbis flac ogg jpeg png theora freetype faad curl sdl_net"
+CompiledLibraries="mad vorbis flac ogg jpeg png theora freetype faad"
 
 # Application uses custom build script AndroidBuild.sh instead of Android.mk (y) or (n)
 CustomBuildScript=y

--- a/dists/androidsdl/scummvm/AndroidAppSettings.cfg.in
+++ b/dists/androidsdl/scummvm/AndroidAppSettings.cfg.in
@@ -185,7 +185,8 @@ DeleteFilesOnUpgrade="%"
 # Optional shared libraries to compile - removing some of them will save space
 # MP3 support by libMAD is encumbered by patents and libMAD is GPL-ed
 # Available libraries: mad (GPL-ed!) sdl_mixer sdl_image sdl_ttf sdl_net sdl_blitpool sdl_gfx sdl_sound intl xml2 lua jpeg png ogg flac tremor vorbis freetype xerces curl theora fluidsynth lzma lzo2 mikmod openal timidity zzip bzip2 yaml-cpp python boost_date_time boost_filesystem boost_iostreams boost_program_options boost_regex boost_signals boost_system boost_thread glu avcodec avdevice avfilter avformat avresample avutil swscale swresample bzip2 
-CompiledLibraries="mad vorbis flac ogg jpeg png theora freetype faad curl sdl_net"
+#CompiledLibraries="mad vorbis flac ogg jpeg png theora freetype faad curl sdl_net"
+CompiledLibraries="mad vorbis flac ogg jpeg png theora freetype faad"
 
 # Application uses custom build script AndroidBuild.sh instead of Android.mk (y) or (n)
 CustomBuildScript=y

--- a/dists/androidsdl/scummvm/AndroidBuild.sh
+++ b/dists/androidsdl/scummvm/AndroidBuild.sh
@@ -14,7 +14,7 @@ ln -sf libglshim.a $ANDROIDSDL/project/obj/local/$1/libGL.a
 mkdir -p scummvm/bin-$1
 
 if [ \! -f scummvm/bin-$1/config.mk ] ; then
-	$ANDROIDSDL/project/jni/application/setEnvironment-$1.sh sh -c "cd scummvm/bin-$1 && env LIBS='-lflac -lvorbis -logg -lmad -lz -lgcc -ltheora -lpng -lfreetype -lfaad -lgnustl_static' ../configure --host=androidsdl-$1 --enable-zlib --enable-vorbis --enable-mad --enable-flac --enable-png --enable-theoradec --enable-sdlnet --enable-libcurl --enable-vkeybd --enable-release --enable-mt32emu --disable-readline --disable-nasm --disable-timidity --disable-fluidsynth --datadir=. "
+	$ANDROIDSDL/project/jni/application/setEnvironment-$1.sh sh -c "cd scummvm/bin-$1 && env LIBS='-lflac -lvorbis -logg -lmad -lz -lgcc -ltheora -lpng -lfreetype -lfaad -lgnustl_static' ../configure --host=androidsdl-$1 --enable-zlib --enable-vorbis --enable-mad --enable-flac --enable-png --enable-theoradec --disable-sdlnet --disable-libcurl --disable-cloud --enable-vkeybd --enable-release --enable-mt32emu --disable-readline --disable-nasm --disable-timidity --disable-fluidsynth --datadir=. "
 fi
 $ANDROIDSDL/project/jni/application/setEnvironment-$1.sh make -j4 -C scummvm/bin-$1
 make -C scummvm/bin-$1 androidsdl


### PR DESCRIPTION
This will disable cloud support (libcurl, sdl-net and cloud are disabled in the configure command).
I will also update the wiki page (https://wiki.scummvm.org/index.php/Compiling_ScummVM/Android-SDL) if or when this PR is merged. The info there should reflect the contents of the updated How_to_Build.txt