### PR TITLE
ENGINES: Allow overriding the splash screen

### DIFF
--- a/configure
+++ b/configure
@@ -182,6 +182,7 @@ _no_pragma_pack=no
 _bink=yes
 _cloud=auto
 _pandoc=no
+_splashoverride=no
 # Default vkeybd/keymapper/eventrec options
 _vkeybd=no
 _keymapper=no
@@ -1019,6 +1020,8 @@ Optional Features:
   --enable-text-console    use text console instead of graphical console
   --enable-verbose-build   enable regular echoing of commands during build
                            process
+  --enable-splash-override allow overriding the default splash screen with
+                           a custom image (requires PNG support)
   --disable-bink           don't build with Bink video support
   --opengl-mode=MODE       OpenGL (ES) mode to use for OpenGL output [auto]
                            available modes: auto for autodetection
@@ -1221,6 +1224,7 @@ for ac_option in $@; do
 	--disable-libunity)       _libunity=no    ;;
 	--enable-bink)            _bink=yes       ;;
 	--disable-bink)           _bink=no        ;;
+	--enable-splash-override) _splashoverride=yes;;
 	--opengl-mode=*)
 		_opengl_mode=`echo $ac_option | cut -d '=' -f 2`
 		;;
@@ -5260,6 +5264,26 @@ if test "$_updates" = yes; then
 else
 	echo "$_updates"
 fi
+
+#
+# Check whether to build splash screen overriding support
+#
+
+echo_n "Building custom splash screen support... "
+if test "$_splashoverride" = no; then
+	echo "no"
+else
+	if test "$_png" = yes; then
+		_splashoverride=yes
+		echo "yes"
+	else
+		_splashoverride=no
+		echo "skipped"
+		echo
+	fi
+fi
+define_in_config_if_yes $_splashoverride 'ENABLE_SPLASH_OVERRIDE'
+
 
 #
 # Figure out installation directories


### PR DESCRIPTION
This patch allows overwriting the splash screen that appears when a game is started directly without using the Launcher with a custom .png file.

The original idea and patch was proposed by Karl Johnson from Cyan, Inc. during the development of their 25th Anniversary Collection of the Myst series.

This change provides publishers that bundle their game with ScummVM a less "intrusive" way of showing their game is powered by ScummVM.

I know that we currently propose not to alter the splash screen at all. However, if a, well, "less" friendly publisher wants, he still can remove the splash screen completely. This new method provide a good solution in my opinion. I added a comment to the source code that first recommends the user not to change the splash screen and only recommend the new methods afterwards.

To protect our brand, a custom splash screen will include a hardcoded "powered by ScummVM $version" at the bottom of the screen. Additionally, it's recommended that publishers include our logo into their splash screen.

Example:
![splashdemo](https://user-images.githubusercontent.com/11882577/56469651-a9237780-643c-11e9-8b82-5e37520e7379.png)

Currently, the new feature is disabled by default. You have to run the configure script with --enable-splash-override in order to enable it.

I know that this change might be controversal and I fully understand if the team decides to dismiss this PR. However, I hope you can follow the points I mentioned above.