### PR TITLE
COMMON: Fix compiler warning

### DIFF
--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -207,7 +207,7 @@ bool U32String::equals(const String &x) const {
 		return false;
 
 	for (size_t idx = 0; idx < _size; ++idx)
-		if (_str[idx] != x[idx])
+		if (_str[idx] != (value_type)x[idx])
 			return false;
 
 	return true;


### PR DESCRIPTION
Compiling emits the following warning:
`comparison between signed and unsigned integer expressions`

Cast the string character type to native type for comparison to fix it.