### PR TITLE
SCI: Change sendMidiCommand non-midi error to warn

### DIFF
--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -800,8 +800,15 @@ void SciMusic::sendMidiCommand(uint32 cmd) {
 
 void SciMusic::sendMidiCommand(MusicEntry *pSnd, uint32 cmd) {
 	Common::StackLock lock(_mutex);
-	if (!pSnd->pMidiParser)
-		error("tried to cmdSendMidi on non midi slot (%04x:%04x)", PRINT_REG(pSnd->soundObj));
+	if (!pSnd->pMidiParser) {
+		// FPFP calls kDoSound SendMidi to mute and unmute its gameMusic2 sound
+		//  object but some scenes set this to an audio sample. In Act 2, room
+		//  660 sets this to audio of restaurant customers talking. Walking up
+		//  the hotel stairs from room 500 to 235 calls gameMusic2:mute and
+		//  triggers this if gameMusic2 hasn't changed. Bug #10952
+		warning("tried to cmdSendMidi on non midi slot (%04x:%04x)", PRINT_REG(pSnd->soundObj));
+		return;
+	}
 
 	pSnd->pMidiParser->mainThreadBegin();
 	pSnd->pMidiParser->sendFromScriptToDriver(cmd);


### PR DESCRIPTION
This changes an error() to warning() when SciMusic::cmdSendMidi is called against a non-midi sound as this occurs in FPFP.

FPFP sets its gameMusic2 to an audio sample in at least one scene, and other scenes call gameMusic2:mute which calls kDoSound SendMidi. This occurs in all FPFP versions. Fixes bug #10952

This was promoted from warning() to error() in: https://github.com/scummvm/scummvm/commit/db70d66e4ae872ebdeb2a88ef0870708a30c7667