### PR TITLE
BUILD: Fix Appcast XML location

### DIFF
--- a/backends/updates/win32/win32-updates.cpp
+++ b/backends/updates/win32/win32-updates.cpp
@@ -51,7 +51,7 @@
  *
  */
 Win32UpdateManager::Win32UpdateManager() {
-    const char *appcastUrl = "https://www.scummvm.org/appcasts/macosx/release.xml";
+    const char *appcastUrl = "https://www.scummvm.org/appcast.xml";
 
     win_sparkle_set_appcast_url(appcastUrl);
     win_sparkle_init();

--- a/dists/macosx/Info.plist
+++ b/dists/macosx/Info.plist
@@ -53,7 +53,7 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>
-	<string>https://www.scummvm.org/appcasts/macosx/release.xml</string>
+	<string>https://www.scummvm.org/appcast.xml</string>
 	<key>NSDockTilePlugIn</key>
 	<string>scummvm.docktileplugin</string>
 	<key>SUPublicDSAKeyFile</key>

--- a/dists/macosx/Info.plist.in
+++ b/dists/macosx/Info.plist.in
@@ -53,7 +53,7 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>
-	<string>https://www.scummvm.org/appcasts/macosx/release.xml</string>
+	<string>https://www.scummvm.org/appcast.xml</string>
 	<key>NSDockTilePlugIn</key>
 	<string>scummvm.docktileplugin</string>
 	<key>SUPublicDSAKeyFile</key>

--- a/dists/macosx/scummvm_appcast.xml
+++ b/dists/macosx/scummvm_appcast.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<channel>
 		<title>ScummVM Changelog</title>
-		<link>https://www.scummvm.org/appcasts/macosx/release.xml</link>
+		<link>https://www.scummvm.org/appcast.xml</link>
 		<description>Most recent changes with links to updates.</description>
 		<language>en</language>
 		<item>

--- a/ports.mk
+++ b/ports.mk
@@ -437,7 +437,7 @@ osxsnap: bundle
 	rm -rf ScummVM-snapshot
 
 publish-appcast:
-	scp dists/macosx/scummvm_appcast.xml www.scummvm.org:/var/www/html/appcasts/macosx/release.xml
+	scp dists/macosx/scummvm_appcast.xml www.scummvm.org:/var/www/scummvm-web/public_html/appcast.xml
 
 
 #


### PR DESCRIPTION
Appcast was never pointing at the right location. This PR fixes that and just simplifies the naming to /appcast.xml
