### PR TITLE
CONFIGURE: Fix incorrect help text

### DIFF
--- a/configure
+++ b/configure
@@ -1110,7 +1110,7 @@ Optional Libraries:
   --with-sdlnet-prefix=DIR prefix where SDL_Net is installed (optional)
   --disable-sdlnet         disable SDL_Net networking library [autodetect]
 
-  --with-libcurl-prefix=DIR    prefix where libcurl is installed (optional)
+  --with-libcurl-prefix=DIR    prefix where libcurl-config is installed (optional)
   --disable-libcurl        disable libcurl networking library [autodetect]
 
 Some influential environment variables:
@@ -4876,7 +4876,7 @@ echo "$_libunity"
 #
 find_freetype() {
         # Wrapper function which tries to find freetype
-        # either by calling freetype-config or by using
+        # either by callimg freetype-config or by using
         # pkg-config.
         # As of freetype-2.9.1 the freetype-config file
         # no longer gets installed by default.

--- a/configure
+++ b/configure
@@ -4876,7 +4876,7 @@ echo "$_libunity"
 #
 find_freetype() {
         # Wrapper function which tries to find freetype
-        # either by callimg freetype-config or by using
+        # either by calling freetype-config or by using
         # pkg-config.
         # As of freetype-2.9.1 the freetype-config file
         # no longer gets installed by default.


### PR DESCRIPTION
On using the path where libcurl is installed (assuming that the old help text is referring to the actual library, be it static or shared) this will result in libcurl not being found by configure.
Instead, the path should point to where libcurl-config is installed, so it may get picked up and processed properly
(See also --with-freetype-prefix and --with-sdl-prefix)
e.g.
On my SDK installaliton libcurl.a and libcurl.so are placed in /sdk/local/newlib/lib, while libcurl-config is in /sdk/local/newlib/bin.
Using the latter makes configure properly picking up and working with libcurl. The other don´t.


Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
