### PR TITLE
SCUMM: Implement original V0-V2 flashlight shape and size for MM/Zak

### DIFF
--- a/engines/scumm/costume.cpp
+++ b/engines/scumm/costume.cpp
@@ -1213,7 +1213,7 @@ byte V0CostumeRenderer::drawLimb(const Actor *a, int limb) {
 		palette[1] = 10;
 		palette[2] = actorV0Colors[_actorID];
 	} else {
-		palette[2] = 11;
+		palette[2] = (_vm->getCurrentLights() & LIGHTMODE_flashlight_on) ?  actorV0Colors[_actorID] : 11;
 		palette[3] = 11;
 	}
 
@@ -1378,7 +1378,7 @@ byte V0CostumeLoader::increaseAnim(Actor *a, int limb) {
 			// Use the previous frame
 			--a0->_cost.curpos[limb];
 
-			// Reset the comstume command
+			// Reset the costume command
 			a0->_costCommandNew = 0xFF;
 			a0->_costCommand = 0xFF;
 

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -1460,27 +1460,32 @@ void ScummEngine_v5::drawFlashlight() {
 
 	blit(_flashlight.buffer, vs->pitch, bgbak, vs->pitch, _flashlight.w, _flashlight.h, vs->format.bytesPerPixel);
 
-	// Round the corners. To do so, we simply hard-code a set of nicely
-	// rounded corners.
-	static const int corner_data[] = { 8, 6, 4, 3, 2, 2, 1, 1 };
-	int minrow = 0;
-	int maxcol = (_flashlight.w - 1) * vs->format.bytesPerPixel;
-	int maxrow = (_flashlight.h - 1) * vs->pitch;
+	// C64 MM and the V1 Zak do not round the flashlight
+	if (_game.version >= 1 && !(_game.version == 1 && _game.id == GID_ZAK)) {
 
-	for (i = 0; i < 8; i++, minrow += vs->pitch, maxrow -= vs->pitch) {
-		int d = corner_data[i];
+		// Round the corners. To do so, we simply hard-code a set of nicely
+		// rounded corners.
+		static const int corner_data[] = { 8, 6, 4, 3, 2, 2, 1, 1 };
+		int minrow = 0;
+		int maxcol = (_flashlight.w - 1) * vs->format.bytesPerPixel;
+		int maxrow = (_flashlight.h - 1) * vs->pitch;
 
-		for (j = 0; j < d; j++) {
-			if (vs->format.bytesPerPixel == 2) {
-				WRITE_UINT16(&_flashlight.buffer[minrow + 2 * j], 0);
-				WRITE_UINT16(&_flashlight.buffer[minrow + maxcol - 2 * j], 0);
-				WRITE_UINT16(&_flashlight.buffer[maxrow + 2 * j], 0);
-				WRITE_UINT16(&_flashlight.buffer[maxrow + maxcol - 2 * j], 0);
-			} else {
-				_flashlight.buffer[minrow + j] = 0;
-				_flashlight.buffer[minrow + maxcol - j] = 0;
-				_flashlight.buffer[maxrow + j] = 0;
-				_flashlight.buffer[maxrow + maxcol - j] = 0;
+		for (i = 0; i < 8; i++, minrow += vs->pitch, maxrow -= vs->pitch) {
+			int d = corner_data[i];
+
+			for (j = 0; j < d; j++) {
+				if (vs->format.bytesPerPixel == 2) {
+					WRITE_UINT16(&_flashlight.buffer[minrow + 2 * j], 0);
+					WRITE_UINT16(&_flashlight.buffer[minrow + maxcol - 2 * j], 0);
+					WRITE_UINT16(&_flashlight.buffer[maxrow + 2 * j], 0);
+					WRITE_UINT16(&_flashlight.buffer[maxrow + maxcol - 2 * j], 0);
+				}
+				else {
+					_flashlight.buffer[minrow + j] = 0;
+					_flashlight.buffer[minrow + maxcol - j] = 0;
+					_flashlight.buffer[maxrow + j] = 0;
+					_flashlight.buffer[maxrow + maxcol - j] = 0;
+				}
 			}
 		}
 	}

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -1460,8 +1460,8 @@ void ScummEngine_v5::drawFlashlight() {
 
 	blit(_flashlight.buffer, vs->pitch, bgbak, vs->pitch, _flashlight.w, _flashlight.h, vs->format.bytesPerPixel);
 
-	// C64 MM and the V1 Zak do not round the flashlight
-	if (_game.version >= 1 && !(_game.version == 1 && _game.id == GID_ZAK)) {
+	// C64 does not round the flashlight
+	if (_game.platform != Common::kPlatformC64) {
 
 		// Round the corners. To do so, we simply hard-code a set of nicely
 		// rounded corners.

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -68,7 +68,7 @@ struct SaveInfoSection {
 
 #define SaveInfoSectionSize (4+4+4 + 4+4 + 4+2)
 
-#define CURRENT_VER 98
+#define CURRENT_VER 99
 #define INFOSECTION_VERSION 2
 
 #pragma mark -
@@ -1518,6 +1518,9 @@ void ScummEngine_v2::saveLoadWithSerializer(Common::Serializer &s) {
 	if (s.getVersion() < VER(79) && s.isLoading()) {
 		_inventoryOffset = 0;
 	}
+
+	s.syncAsByte(_flashlight.xStrips, VER(99));
+	s.syncAsByte(_flashlight.yStrips, VER(99));
 }
 
 void ScummEngine_v5::saveLoadWithSerializer(Common::Serializer &s) {

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -705,6 +705,8 @@ ScummEngine_v2::ScummEngine_v2(OSystem *syst, const DetectorResult &dr)
 	: ScummEngine_v3old(syst, dr) {
 
 	_inventoryOffset = 0;
+	_flashlight.xStrips = 6;
+	_flashlight.yStrips = 4;
 
 	VAR_SENTENCE_VERB = 0xFF;
 	VAR_SENTENCE_OBJECT1 = 0xFF;


### PR DESCRIPTION
Fix to use the correct shape/size of the flashlight used by the original engine, covers [10951](https://bugs.scummvm.org/ticket/10951) and [10947](https://bugs.scummvm.org/ticket/10947) 


C64 MM
![image](https://user-images.githubusercontent.com/1327406/56959627-5f9c0080-6b91-11e9-8c3c-e341d16e63ad.png)

V1
![image](https://user-images.githubusercontent.com/1327406/56959651-72aed080-6b91-11e9-8568-4dafca0f9d1f.png)

V2
![image](https://user-images.githubusercontent.com/1327406/56959702-aa1d7d00-6b91-11e9-9301-2a4dd8320151.png)

Zak C64
![image](https://user-images.githubusercontent.com/1327406/56959717-ba355c80-6b91-11e9-9f17-0579bf374492.png)

Zak V1
![image](https://user-images.githubusercontent.com/1327406/56959737-d0431d00-6b91-11e9-8225-58d2dabf01a1.png)

Zak V2
![image](https://user-images.githubusercontent.com/1327406/56959753-dfc26600-6b91-11e9-80ff-ffae8e62d5fa.png)
