### PR TITLE
SCI: Handle recursive view loop references

### DIFF
--- a/engines/sci/graphics/view.cpp
+++ b/engines/sci/graphics/view.cpp
@@ -286,10 +286,15 @@ void GfxView::initData(GuiResourceId resourceId) {
 
 			seekEntry = loopData[0];
 			if (seekEntry != 255) {
-				if (seekEntry >= loopCount)
-					error("Bad loop-pointer in sci 1.1 view");
 				_loop[loopNo].mirrorFlag = true;
-				loopData = _resource->subspan(headerSize + (seekEntry * loopSize));
+
+				// use the root loop for mirroring. this handles rare loops that
+				//  mirror loops that mirror loops. (FPFP view 844, bug #10953)
+				do {
+					if (seekEntry >= loopCount)
+						error("Bad loop-pointer in sci 1.1 view");
+					loopData = _resource->subspan(headerSize + (seekEntry * loopSize));
+				} while ((seekEntry = loopData[0]) != 255);
 			} else {
 				_loop[loopNo].mirrorFlag = false;
 			}


### PR DESCRIPTION
This adds support for view loops that mirror loops that mirror loops, and so on. ScummVM only supports one level of loop referencing. Sierra's interpreter loops through all the mirror references until it finds a "real" loop and then mirrors that. FPFP depends on this this when the cook leaves the town in room 200, otherwise ScummVM doesn't populate these loops and fails an assert, bug #10953. 

FPFP View 844's relevant loops:

- 	loop 0: the cook walking to the right
- 	loop 1: mirror of loop 0
- 	loop 3: mirror of loop 1
- 	loop 5: mirror of loop 3

The script uses loops 3 and 5. Since they both trace back to loop 0, they are both loops of the cook walking to the left, just like loop 1. SCI Companion displays loops 3 and 5 backwards as it applies mirroring to the previous loop instead of the root. SCI Viewer doesn't display them at all.
