### PR TITLE
agos: mute fix for adlib accolade

### DIFF
--- a/engines/agos/midi.cpp
+++ b/engines/agos/midi.cpp
@@ -28,6 +28,8 @@
 #include "agos/agos.h"
 #include "agos/midi.h"
 
+#include "agos/drivers/accolade/adlib.cpp"
+
 #include "agos/drivers/accolade/mididriver.h"
 #include "agos/drivers/simon1/adlib.h"
 // Miles Audio for Simon 2
@@ -89,7 +91,7 @@ int MidiPlayer::open(int gameType, bool isDemo) {
 	assert(!_driver);
 
 	Common::String accoladeDriverFilename;
-	MusicType musicType = MT_INVALID;
+	musicType = MT_INVALID;
 
 	switch (gameType) {
 	case GType_ELVIRA1:
@@ -159,6 +161,7 @@ int MidiPlayer::open(int gameType, bool isDemo) {
 		switch (musicType) {
 		case MT_ADLIB:
 			_driver = MidiDriver_Accolade_AdLib_create(accoladeDriverFilename);
+			
 			break;
 		case MT_MT32:
 			_driver = MidiDriver_Accolade_MT32_create(accoladeDriverFilename);
@@ -473,6 +476,10 @@ void MidiPlayer::pause(bool b) {
 	_paused = b;
 
 	Common::StackLock lock(_mutex);
+	// if using the driver Accolade_AdLib call setVolume() to turn off\on the volume on all channels
+	if (musicType == MT_ADLIB && _musicMode == kMusicModeAccolade) {
+		static_cast <MidiDriver_Accolade_AdLib*> (_driver)->setVolume(_paused ? 0 : 128);
+	}
 	for (int i = 0; i < 16; ++i) {
 		if (_music.channel[i])
 			_music.channel[i]->volume(_paused ? 0 : (_music.volume[i] * _musicVolume / 255));

--- a/engines/agos/midi.h
+++ b/engines/agos/midi.h
@@ -123,7 +123,8 @@ public:
 
 private:
 	kMusicMode _musicMode;
-
+	MusicType musicType;
+	
 private:
 	Common::SeekableReadStream *simon2SetupExtractFile(const Common::String &requestedFileName);
 };


### PR DESCRIPTION
Work in progress on https://bugs.scummvm.org/ticket/10310
This implements _masterVolume and setVolume in MidiDriver_Accolade_AdLib and uses a cast to call setVolume() in agos/midi.cpp in pause() if AdLib & Accolade are used.
The other drivers mostly seem to not implement channel allocation so I decided to follow TO_DO comment in the MidiDriver_Accolade_AdLib code.
Not in the PR: 
Implementing the same _masterVolume and setVolume in MidiDriver_Simon1_AdLib  and calling that in pause() seems to fix the same defect for Simon 1.
For mt32 using _driver to send control message for volume for all channels seems to fix this for mt32.
Making PR in hopes of getting some input on how to proceed.
