### PR TITLE
CONFIGURE: Fix missing option

### DIFF
--- a/configure
+++ b/configure
@@ -1217,6 +1217,7 @@ for ac_option in $@; do
 	--enable-cloud)               _cloud=yes             ;;
 	--disable-cloud)              _cloud=no              ;;
 	--enable-updates)             _updates=yes           ;;
+	--disable-updates)            _updates=no            ;;
 	--enable-libunity)            _libunity=yes          ;;
 	--disable-libunity)           _libunity=no           ;;
 	--enable-bink)                _bink=yes              ;;


### PR DESCRIPTION
--disable-updates was omitted from the supported options during the reformat (b3d5bb34ae52063abb23175de9bd4d6d525145e1).