### PR TITLE
GUI: Better integrate the unknown game dialog when adding games

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -553,6 +553,7 @@ DetectionResults EngineManager::detectGames(const Common::FSList &fslist) const 
 			for (uint i = 0; i < engineCandidates.size(); i++) {
 				engineCandidates[i].engineName = metaEngine.getName();
 				engineCandidates[i].path = fslist.begin()->getParent().getPath();
+				engineCandidates[i].shortPath = fslist.begin()->getParent().getDisplayName();
 				candidates.push_back(engineCandidates[i]);
 			}
 

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -152,8 +152,16 @@ DetectedGames DetectionResults::listRecognizedGames() const {
 	return candidates;
 }
 
+DetectedGames DetectionResults::listDetectedGames() const {
+	return _detectedGames;
+}
+
 Common::String DetectionResults::generateUnknownGameReport(bool translate, uint32 wordwrapAt) const {
-	assert(!_detectedGames.empty());
+	return ::generateUnknownGameReport(_detectedGames, translate, false, wordwrapAt);
+}
+
+Common::String generateUnknownGameReport(const DetectedGames &detectedGames, bool translate, bool fullPath, uint32 wordwrapAt) {
+	assert(!detectedGames.empty());
 
 	const char *reportStart = _s("The game in '%s' seems to be an unknown game variant.\n\n"
 	                             "Please report the following data to the ScummVM team at %s "
@@ -162,7 +170,8 @@ Common::String DetectionResults::generateUnknownGameReport(bool translate, uint3
 	const char *reportEngineHeader = _s("Matched game IDs for the %s engine:");
 
 	Common::String report = Common::String::format(
-			translate ? _(reportStart) : reportStart, _detectedGames[0].path.c_str(),
+			translate ? _(reportStart) : reportStart,
+			fullPath ? detectedGames[0].path.c_str() : detectedGames[0].shortPath.c_str(),
 			"https://bugs.scummvm.org/"
 	);
 	report += "\n";
@@ -170,8 +179,8 @@ Common::String DetectionResults::generateUnknownGameReport(bool translate, uint3
 	FilePropertiesMap matchedFiles;
 
 	const char *currentEngineName = nullptr;
-	for (uint i = 0; i < _detectedGames.size(); i++) {
-		const DetectedGame &game = _detectedGames[i];
+	for (uint i = 0; i < detectedGames.size(); i++) {
+		const DetectedGame &game = detectedGames[i];
 
 		if (!game.hasUnknownFiles) continue;
 
@@ -215,17 +224,9 @@ Common::String DetectionResults::generateUnknownGameReport(bool translate, uint3
 	return report;
 }
 
-Common::StringArray DetectionResults::getUnknownGameEngines() const {
-	Common::StringArray engines;
-	const char *currentEngineName = nullptr;
-	for (uint i = 0; i < _detectedGames.size(); i++) {
-		const DetectedGame &game = _detectedGames[i];
-		if (!game.hasUnknownFiles)
-			continue;
-		if (!currentEngineName || strcmp(currentEngineName, game.engineName) != 0) {
-			currentEngineName = game.engineName;
-			engines.push_back(Common::String(currentEngineName));
-		}
-	}
-	return engines;
+Common::String generateUnknownGameReport(const DetectedGame &detectedGame, bool translate, bool fullPath, uint32 wordwrapAt) {
+	DetectedGames detectedGames;
+	detectedGames.push_back(detectedGame);
+
+	return generateUnknownGameReport(detectedGames, translate, fullPath, wordwrapAt);
 }

--- a/engines/game.h
+++ b/engines/game.h
@@ -142,6 +142,7 @@ struct DetectedGame {
 	Common::Language language;
 	Common::Platform platform;
 	Common::String path;
+	Common::String shortPath;
 	Common::String extra;
 
 	/**
@@ -202,6 +203,14 @@ public:
 	DetectedGames listRecognizedGames() const;
 
 	/**
+	 * List all the games that were detected
+	 *
+	 * That includes entries that don't have enough information to be added to the
+	 * configuration manager.
+	 */
+	DetectedGames listDetectedGames() const;
+
+	/**
 	 * Were unknown game variants found by the engines?
 	 *
 	 * When unknown game variants are found, an unknown game report can be generated.
@@ -209,21 +218,26 @@ public:
 	bool foundUnknownGames() const;
 
 	/**
-	 * Generate a report that we found an unknown game variant, together with the file
-	 * names, sizes and MD5 sums.
+	 * Generate a report that we found an unknown game variant.
 	 *
-	 * @param translate translate the report to the currently active GUI language
-	 * @param wordwrapAt word wrap the text part of the report after a number of characters
+	 * @see ::generateUnknownGameReport
 	 */
 	Common::String generateUnknownGameReport(bool translate, uint32 wordwrapAt = 0) const;
-
-	/**
-	 * Get the list of engines for which an unknown game variant was found.
-	 */
-	Common::StringArray getUnknownGameEngines() const;
 
 private:
 	DetectedGames _detectedGames;
 };
+
+/**
+ * Generate a report that we found an unknown game variant, together with the file
+ * names, sizes and MD5 sums.
+ *
+ * @param translate translate the report to the currently active GUI language
+ * @param fullPath include the full path where the files are located, otherwise only the name
+ *                 of last component of the path is included
+ * @param wordwrapAt word wrap the text part of the report after a number of characters
+ */
+Common::String generateUnknownGameReport(const DetectedGames &detectedGames, bool translate, bool fullPath, uint32 wordwrapAt = 0);
+Common::String generateUnknownGameReport(const DetectedGame &detectedGame, bool translate, bool fullPath, uint32 wordwrapAt = 0);
 
 #endif

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -563,12 +563,9 @@ bool LauncherDialog::doGameDetection(const Common::String &path) {
 	if (detectionResults.foundUnknownGames()) {
 		Common::String report = detectionResults.generateUnknownGameReport(false, 80);
 		g_system->logMessage(LogMessageType::kInfo, report.c_str());
-
-		UnknownGameDialog dialog(detectionResults);
-		dialog.runModal();
 	}
 
-	Common::Array<DetectedGame> candidates = detectionResults.listRecognizedGames();
+	Common::Array<DetectedGame> candidates = detectionResults.listDetectedGames();
 
 	int idx;
 	if (candidates.empty()) {
@@ -583,16 +580,37 @@ bool LauncherDialog::doGameDetection(const Common::String &path) {
 	} else {
 		// Display the candidates to the user and let her/him pick one
 		StringArray list;
-		for (idx = 0; idx < (int)candidates.size(); idx++)
-			list.push_back(candidates[idx].description);
+		for (idx = 0; idx < (int)candidates.size(); idx++) {
+			Common::String description = candidates[idx].description;
+
+			if (candidates[idx].hasUnknownFiles) {
+				description += " - ";
+				description += _("Unknown variant");
+			}
+
+			list.push_back(description);
+		}
 
 		ChooserDialog dialog(_("Pick the game:"));
 		dialog.setList(list);
 		idx = dialog.runModal();
 	}
+
 	if (0 <= idx && idx < (int)candidates.size()) {
 		const DetectedGame &result = candidates[idx];
 
+		if (result.hasUnknownFiles) {
+			UnknownGameDialog dialog(result);
+
+			bool cancel = dialog.runModal() == -1;
+			if (cancel) {
+				idx = -1;
+			}
+		}
+	}
+
+	if (0 <= idx && idx < (int)candidates.size()) {
+		const DetectedGame &result = candidates[idx];
 		Common::String domain = EngineMan.createTargetForGame(result);
 
 		// Display edit dialog for the new entry

--- a/gui/unknown-game-dialog.h
+++ b/gui/unknown-game-dialog.h
@@ -35,9 +35,9 @@ class ButtonWidget;
 
 class UnknownGameDialog : public Dialog {
 public:
-	UnknownGameDialog(const DetectionResults &detectionResults);
+	UnknownGameDialog(const DetectedGame &detectedGame);
 
-	void handleMouseWheel(int x, int y, int direction);
+	void handleMouseWheel(int x, int y, int direction) override;
 private:
 	void rebuild();
 
@@ -46,14 +46,15 @@ private:
 	void reflowLayout() override;
 
 	Common::String generateBugtrackerURL();
-	Common::String encodeUrlString(const Common::String&);
+	static Common::String encodeUrlString(const Common::String &string);
 
-	const DetectionResults &_detectionResults;
+	const DetectedGame &_detectedGame;
 	ScrollContainerWidget *_textContainer;
 	Common::Array<StaticTextWidget *> _textWidgets;
-	ButtonWidget* _openBugTrackerUrlButton;
-	ButtonWidget* _copyToClipboardButton;
-	ButtonWidget* _closeButton;
+	ButtonWidget *_openBugTrackerUrlButton;
+	ButtonWidget *_copyToClipboardButton;
+	ButtonWidget *_closeButton;
+	ButtonWidget *_addAnywayButton;
 };
 
 } // End of namespace GUI


### PR DESCRIPTION
* The list of candidates now includes unknown variants. When an unknown
variant is selected, the unknown game dialog is shown.
* On the unknown game dialog, users are given the choice to add the game
when that is possible, or to cancel.

The goal of those changes is to make the unknown game dialog less
confusing for users, especially when both known and unknown games
variants are found.

This is meant to supersede #1493.
