### PR TITLE
COMMON: Add SeekableWriteStream class

### DIFF
--- a/backends/fs/stdiostream.h
+++ b/backends/fs/stdiostream.h
@@ -28,7 +28,7 @@
 #include "common/stream.h"
 #include "common/str.h"
 
-class StdioStream : public Common::SeekableReadStream, public Common::WriteStream, public Common::NonCopyable {
+class StdioStream : public Common::SeekableReadStream, public Common::SeekableWriteStream, public Common::NonCopyable {
 protected:
 	/** File handle to the actual file. */
 	void *_handle;
@@ -43,17 +43,17 @@ public:
 	StdioStream(void *handle);
 	virtual ~StdioStream();
 
-	virtual bool err() const;
-	virtual void clearErr();
-	virtual bool eos() const;
+	virtual bool err() const override;
+	virtual void clearErr() override;
+	virtual bool eos() const override;
 
-	virtual uint32 write(const void *dataPtr, uint32 dataSize);
-	virtual bool flush();
+	virtual uint32 write(const void *dataPtr, uint32 dataSize) override;
+	virtual bool flush() override;
 
-	virtual int32 pos() const;
-	virtual int32 size() const;
-	virtual bool seek(int32 offs, int whence = SEEK_SET);
-	virtual uint32 read(void *dataPtr, uint32 dataSize);
+	virtual int32 pos() const override;
+	virtual int32 size() const override;
+	virtual bool seek(int32 offs, int whence = SEEK_SET) override;
+	virtual uint32 read(void *dataPtr, uint32 dataSize) override;
 };
 
 #endif

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -219,4 +219,14 @@ bool DumpFile::flush() {
 
 int32 DumpFile::pos() const { return _handle->pos(); }
 
+bool DumpFile::seek(int32 offset, int whence) {
+	SeekableWriteStream *ws = dynamic_cast<SeekableWriteStream *>(_handle);
+	return ws ? ws->seek(offset, whence) : -1;
+}
+
+int32 DumpFile::size() const {
+	SeekableWriteStream *ws = dynamic_cast<SeekableWriteStream *>(_handle);
+	return ws ? ws->size() : -1;
+}
+
 } // End of namespace Common

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -221,7 +221,7 @@ int32 DumpFile::pos() const { return _handle->pos(); }
 
 bool DumpFile::seek(int32 offset, int whence) {
 	SeekableWriteStream *ws = dynamic_cast<SeekableWriteStream *>(_handle);
-	return ws ? ws->seek(offset, whence) : -1;
+	return ws ? ws->seek(offset, whence) : false;
 }
 
 int32 DumpFile::size() const {

--- a/common/file.h
+++ b/common/file.h
@@ -134,7 +134,7 @@ public:
  * Some design ideas:
  *  - automatically drop all files into dumps/ dir? Might not be desired in all cases
  */
-class DumpFile : public WriteStream, public NonCopyable {
+class DumpFile : public SeekableWriteStream, public NonCopyable {
 protected:
 	/** File handle to the actual file; 0 if no file is open. */
 	WriteStream *_handle;
@@ -158,11 +158,14 @@ public:
 	bool err() const;
 	void clearErr();
 
-	virtual uint32 write(const void *dataPtr, uint32 dataSize);
+	virtual uint32 write(const void *dataPtr, uint32 dataSize) override;
 
-	virtual bool flush();
+	virtual bool flush() override;
 
-	virtual int32 pos() const;
+	virtual int32 pos() const override;
+
+	virtual bool seek(int32 offset, int whence = SEEK_SET) override;
+	virtual int32 size() const override;
 };
 
 } // End of namespace Common

--- a/common/memstream.h
+++ b/common/memstream.h
@@ -88,7 +88,7 @@ public:
  * Simple memory based 'stream', which implements the WriteStream interface for
  * a plain memory block.
  */
-class MemoryWriteStream : public WriteStream {
+class MemoryWriteStream : public SeekableWriteStream {
 private:
 	const uint32 _bufSize;
 protected:
@@ -111,11 +111,13 @@ public:
 		return dataSize;
 	}
 
-	int32 pos() const { return _pos; }
-	uint32 size() const { return _bufSize; }
+	virtual int32 pos() const override { return _pos; }
+	virtual int32 size() const override { return _bufSize; }
 
-	virtual bool err() const { return _err; }
-	virtual void clearErr() { _err = false; }
+	virtual bool err() const override { return _err; }
+	virtual void clearErr() override { _err = false; }
+
+	virtual bool seek(int32 offset, int whence = SEEK_SET) override { return false; }
 };
 
 /**
@@ -126,7 +128,8 @@ private:
 	byte *_ptrOrig;
 public:
 	SeekableMemoryWriteStream(byte *buf, uint32 len) : MemoryWriteStream(buf, len), _ptrOrig(buf) {}
-	uint32 seek(uint32 offset, int whence = SEEK_SET) {
+
+	virtual bool seek(int32 offset, int whence = SEEK_SET) override {
 		switch (whence) {
 		case SEEK_END:
 			// SEEK_END works just like SEEK_SET, only 'reversed',
@@ -143,11 +146,12 @@ public:
 			break;
 		}
 		// Post-Condition
-		if (_pos > size()) {
+		if ((int32)_pos > size()) {
 			_pos = size();
 			_ptr = _ptrOrig + _pos;
 		}
-		return _pos;
+
+		return true;
 	}
 };
 
@@ -156,7 +160,7 @@ public:
  * A sort of hybrid between MemoryWriteStream and Array classes. A stream
  * that grows as it's written to.
  */
-class MemoryWriteStreamDynamic : public WriteStream {
+class MemoryWriteStreamDynamic : public SeekableWriteStream {
 protected:
 	uint32 _capacity;
 	uint32 _size;
@@ -201,18 +205,18 @@ public:
 		return dataSize;
 	}
 
-	int32 pos() const { return _pos; }
-	uint32 size() const { return _size; }
+	virtual int32 pos() const override { return _pos; }
+	virtual int32 size() const override { return _size; }
 
 	byte *getData() { return _data; }
 
-	bool seek(int32 offset, int whence = SEEK_SET);
+	virtual bool seek(int32 offset, int whence = SEEK_SET) override;
 };
 
 /**
 * MemoryStream based on RingBuffer. Grows if has insufficient buffer size.
 */
-class MemoryReadWriteStream : public SeekableReadStream, public WriteStream {
+class MemoryReadWriteStream : public SeekableReadStream, public SeekableWriteStream {
 private:
 	uint32 _capacity;
 	uint32 _size;
@@ -271,7 +275,7 @@ public:
 		return dataSize;
 	}
 
-	virtual uint32 read(void *dataPtr, uint32 dataSize) {
+	virtual uint32 read(void *dataPtr, uint32 dataSize) override {
 		if (_length < dataSize) {
 			dataSize = _length;
 			_eos = true;
@@ -289,11 +293,11 @@ public:
 		return dataSize;
 	}
 
-	int32 pos() const { return _pos - _length; } // 'read' position in the stream
-	int32 size() const { return _size; } // that's also 'write' position in the stream, as it's append-only
-	bool seek(int32, int) { return false; }
-	bool eos() const { return _eos; }
-	void clearErr() { _eos = false; }
+	virtual int32 pos() const override { return _pos - _length; }
+	virtual int32 size() const override { return _size; }
+	virtual bool seek(int32, int) override { return false; }
+	virtual bool eos() const override { return _eos; }
+	virtual void clearErr() override { _eos = false; }
 
 	byte *getData() { return _data; }
 };

--- a/common/memstream.h
+++ b/common/memstream.h
@@ -210,7 +210,28 @@ public:
 
 	byte *getData() { return _data; }
 
-	virtual bool seek(int32 offset, int whence = SEEK_SET) override;
+	virtual bool seek(int32 offs, int whence = SEEK_SET) override {
+		// Pre-Condition
+		assert(_pos <= _size);
+		switch (whence) {
+		case SEEK_END:
+			// SEEK_END works just like SEEK_SET, only 'reversed', i.e. from the end.
+			offs = _size + offs;
+			// Fall through
+		case SEEK_SET:
+			_ptr = _data + offs;
+			_pos = offs;
+			break;
+
+		case SEEK_CUR:
+			_ptr += offs;
+			_pos += offs;
+			break;
+		}
+
+		assert(_pos <= _size);
+		return true;
+	}
 };
 
 /**

--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -102,31 +102,6 @@ bool MemoryReadStream::seek(int32 offs, int whence) {
 	return true; // FIXME: STREAM REWRITE
 }
 
-bool MemoryWriteStreamDynamic::seek(int32 offs, int whence) {
-	// Pre-Condition
-	assert(_pos <= _size);
-	switch (whence) {
-	case SEEK_END:
-		// SEEK_END works just like SEEK_SET, only 'reversed',
-		// i.e. from the end.
-		offs = _size + offs;
-		// Fall through
-	case SEEK_SET:
-		_ptr = _data + offs;
-		_pos = offs;
-		break;
-
-	case SEEK_CUR:
-		_ptr += offs;
-		_pos += offs;
-		break;
-	}
-	// Post-Condition
-	assert(_pos <= _size);
-
-	return true; // FIXME: STREAM REWRITE
-}
-
 #pragma mark -
 
 enum {

--- a/common/stream.h
+++ b/common/stream.h
@@ -211,6 +211,37 @@ public:
 };
 
 /**
+ * Derived abstract base class for write streams streams that are seekable
+ */
+class SeekableWriteStream : public WriteStream {
+public:
+	/**
+	 * Sets the stream position indicator for the stream. The new position,
+	 * measured in bytes, is obtained by adding offset bytes to the position
+	 * specified by whence. If whence is set to SEEK_SET, SEEK_CUR, or
+	 * SEEK_END, the offset is relative to the start of the file, the current
+	 * position indicator, or end-of-file, respectively. A successful call
+	 * to the seek() method clears the end-of-file indicator for the stream.
+	 *
+	 * @note The semantics of any implementation of this method are
+	 * supposed to match those of ISO C fseek().
+	 *
+	 * @param offset        the relative offset in bytes
+	 * @param whence        the seek reference: SEEK_SET, SEEK_CUR, or SEEK_END
+	 * @return true on success, false in case of a failure
+	 */
+	virtual bool seek(int32 offset, int whence = SEEK_SET) = 0;
+
+	/**
+	 * Obtains the current size of the stream, measured in bytes.
+	 * If this value is unknown or can not be computed, -1 is returned.
+	 *
+	 * @return the size of the stream, or -1 if an error occurred
+	 */
+	virtual int32 size() const = 0;
+};
+
+/**
  * Generic interface for a readable data stream.
  */
 class ReadStream : virtual public Stream {


### PR DESCRIPTION
This introduces a new SeekableWriteStream class to play a similar
role as the SeekableReadStream class, but for write streams.
It add methods for seek and size, and the following classes have
been changed to support it:
1) Memory stream classes
2) DumpFile class
3) StdIOStream class

I tried to have minimal impact on the existing system. Please note
the following:
1) DumpFile still only has a reference to a WriteStream internally. I
didn't want to change it to SeekableWriteStream, since that would
require also converting he file system node methods to return it as
well. And I'm not sure if there are any backends that have their own
custom implementations of files other than StdIOStream. If there are,
they'd eventually need to be updated to use SeekableWriteStream
as well, and we can eventually change all the various methods to
return SeekableWriteStream instead of WriteStream. For now,
DumpFile's seek and size methods try to dynamically cast the handle
to a SeekableWriteStream, and pass on the method if it supports it.

2) SeekableMemoryWriteStream's seek method is changed from
returning an int32 position to the standard bool success/fail. I tried
compiling with the method temporarily set to void without error,
which means there's nothing depending on the old result anyway.
