### PR TITLE
I18N: Correct Portuguese (Portugual) metadata

### DIFF
--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -16,9 +16,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.9\n"
-"X-Language-name: Portuguese (Portugal)\n"
+"X-Language-name: Portugues (Portugal)\n"
 
 #: gui/about.cpp:94
 #, c-format


### PR DESCRIPTION
Fixes the Portuguese language name displayed by ScummVM and the plural rule (not sure if ScummVM uses plurals but can't hurt).