### PR TITLE
JANITORIAL: Fix MSVC warnings

### DIFF
--- a/audio/decoders/adpcm_intern.h
+++ b/audio/decoders/adpcm_intern.h
@@ -68,7 +68,7 @@ public:
 
 	virtual bool rewind();
 	virtual bool seek(const Timestamp &where) { return false; }
-	virtual Timestamp getLength() const { return -1; }
+	virtual Timestamp getLength() const { return Timestamp(); }
 
 	/**
 	 * This table is used by some ADPCM variants (IMA and OKI) to adjust the

--- a/audio/softsynth/mt32/FileStream.cpp
+++ b/audio/softsynth/mt32/FileStream.cpp
@@ -21,6 +21,10 @@
 
 #include "internals.h"
 
+// Disable MSVC STL exceptions
+#ifdef _MSC_VER
+#define _HAS_EXCEPTIONS 0
+#endif
 #include "FileStream.h"
 
 namespace MT32Emu {

--- a/backends/cloud/cloudicon.cpp
+++ b/backends/cloud/cloudicon.cpp
@@ -27,9 +27,9 @@
 
 namespace Cloud {
 
-const float CloudIcon::ALPHA_SPEED = 0.0005;
-const float CloudIcon::ALPHA_MAX = 1;
-const float CloudIcon::ALPHA_MIN = 0.6;
+const float CloudIcon::ALPHA_SPEED = 0.0005f;
+const float CloudIcon::ALPHA_MAX = 1.f;
+const float CloudIcon::ALPHA_MIN = 0.6f;
 
 CloudIcon::CloudIcon() {
 	initIcons();

--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -144,7 +144,11 @@
 #include <SDL.h>
 #endif
 
+// Ignore warnings from system headers pulled by SDL
+#pragma warning(push)
+#pragma warning(disable:4121) // alignment of a member was sensitive to packing
 #include <SDL_syswm.h>
+#pragma warning(pop)
 
 // Restore the forbidden exceptions from the hack above
 #if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && defined(_MSC_VER)

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -184,7 +184,7 @@ void outputMessage(j_common_ptr cinfo) {
 }
 
 J_COLOR_SPACE fromScummvmPixelFormat(const Graphics::PixelFormat &format) {
-#if defined(JCS_EXTENSIONS) or defined(JCS_ALPHA_EXTENSIONS)
+#if defined(JCS_EXTENSIONS) || defined(JCS_ALPHA_EXTENSIONS)
 	struct PixelFormatMapping {
 		Graphics::PixelFormat pixelFormat;
 		J_COLOR_SPACE bigEndianColorSpace;
@@ -200,7 +200,7 @@ J_COLOR_SPACE fromScummvmPixelFormat(const Graphics::PixelFormat &format) {
 		{ Graphics::PixelFormat(3, 8, 8, 8, 0, 16,  8,  0,  0), JCS_EXT_RGB,  JCS_EXT_BGR  },
 		{ Graphics::PixelFormat(3, 8, 8, 8, 0,  0,  8, 16,  0), JCS_EXT_BGR,  JCS_EXT_RGB  }
 #endif
-#if defined(JCS_EXTENSIONS) and defined(JCS_ALPHA_EXTENSIONS)
+#if defined(JCS_EXTENSIONS) && defined(JCS_ALPHA_EXTENSIONS)
 		,
 #endif
 #ifdef JCS_ALPHA_EXTENSIONS


### PR DESCRIPTION
Fixes MSVC warnings in the common ScummVM code. More details are in the commit messages.