### PR TITLE
CREDITS: mark Vicent Marti as retired

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -419,7 +419,7 @@ ScummVM Team
 
     GUI:
        Max Horn                     - (retired)
-       Vicent Marti
+       Vicent Marti                 - (retired)
        Eugene Sandulenko
        Johannes Schickel            - (retired)
 

--- a/devtools/credits.pl
+++ b/devtools/credits.pl
@@ -1039,7 +1039,7 @@ begin_credits("Credits");
 
 			begin_section("GUI");
 				add_person("Max Horn", "Fingolfin", "(retired)");
-				add_person("Vicent Marti", "tanoku", "");
+				add_person("Vicent Marti", "tanoku", "(retired)");
 				add_person("Eugene Sandulenko", "sev", "");
 				add_person("Johannes Schickel", "LordHoto", "(retired)");
 			end_section();

--- a/gui/credits.h
+++ b/gui/credits.h
@@ -512,6 +512,7 @@ static const char *credits[] = {
 "C0""Max Horn",
 "C2""(retired)",
 "C0""Vicent Marti",
+"C2""(retired)",
 "C0""Eugene Sandulenko",
 "C0""Johannes Schickel",
 "C2""(retired)",


### PR DESCRIPTION
He was last active in 2009 and has long moved on to work on other things.

Thank you for merging my PR from yesterday so quickly. I just realized that Vicent's entry should also be updated.

Perhaps also further people should be given credit for the GUI? Here's the top 10 of people who modified the GUI C++ source code (to filter out i18n changes; of course one may also want to credit people who worked on the themes
```
$ git shortlog -sn gui/*.cpp gui/*.h gui/*/*.cpp gui/*/*.h  | head -n 10
   580	Max Horn
   297	Eugene Sandulenko
   290	Johannes Schickel
   118	Vicent Marti
   114	Alexander Tkachev
   105	Thierry Crozat
    98	Torbjörn Andersson
    41	Filippos Karapetis
    39	Bastien Bouclet
    29	Willem Jan Palenstijn
```
