### PR TITLE
WINTERMUTE: Fix fill rect area on endSaveLoad()

### DIFF
--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -576,7 +576,7 @@ void BaseRenderOSystem::endSaveLoad() {
 	_skipThisFrame = true;
 	_lastFrameIter = _renderQueue.end();
 
-	_renderSurface->fillRect(Common::Rect(0, 0, _renderSurface->h, _renderSurface->w), _renderSurface->format.ARGBToColor(255, 0, 0, 0));
+	_renderSurface->fillRect(Common::Rect(0, 0, _renderSurface->w, _renderSurface->h), _renderSurface->format.ARGBToColor(255, 0, 0, 0));
 	g_system->copyRectToScreen((byte *)_renderSurface->getPixels(), _renderSurface->pitch, 0, 0, _renderSurface->w, _renderSurface->h);
 	g_system->updateScreen();
 }


### PR DESCRIPTION
Wintermute fills screen area with black color when save/load process is finished.
There was a misprint in ScummVM's code which caused only left part of the screen go black.