### PR TITLE
TRAVIS: Re-enable Mac OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,26 @@ addons:
     - libieee1284-3-dev
     - libsndio-dev
     - libunity-dev
-
-before_install:
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'osx' ]; then brew update; fi"
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'osx' ]; then brew install sdl2 sdl2_net libvorbis flac mad theora faad2 libmpeg2; fi"
-
+  homebrew:
+    packages:
+    - sdl2
+    - sdl2_net
+    - curl-openssl
+    - jpeg-turbo
+    - libmpeg2
+    - a52dec
+    - libogg
+    - libvorbis
+    - flac
+    - mad
+    - libpng
+    - theora
+    - faad2
+    - fluid-synth
+    - freetype
+    - zlib
+    - pandoc
+    update: true
 
 branches:
  only:
@@ -41,6 +56,7 @@ compiler:
 
 os:
   - linux
+  - osx
 
 dist: trusty
 


### PR DESCRIPTION
Mac OS X builds were previously disabled in commit 41ee643 due to the build machines at the time being unreliable, however that was over a year ago, so it's likely that things have changed since then.

Currently, this only builds with `configure`, as it did before, however in the future it would be a good idea to also build with `create_project` and Xcode as well, since that's something that can't be done on the buildbot.