### PR TITLE
AMIGAOS4: RM2AG.rexx rewrite

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -10,7 +10,7 @@ amigaosdist: $(EXECUTABLE)
 ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) $(AMIGAOSPATH)/extras/
 endif
-	cat ${srcdir}/README | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
+	cat ${srcdir}/README.md | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
 # AmigaOS's shell is not happy with indented comments, thus don't do it.
 # AREXX seems to have problems when ${srcdir} is '.'. It will break with a
 # "Program not found" error. Therefore we copy the script to the cwd and

--- a/devtools/update-version.pl
+++ b/devtools/update-version.pl
@@ -49,6 +49,7 @@ my @subs_files = qw(
 	dists/gph/README-GPH
 	dists/gph/scummvm.ini
 	dists/riscos/!Boot,feb
+	dists/amiga/RM2AG.rexx
 	backends/platform/psp/README.PSP
 	snapcraft.yaml
 	);

--- a/dists/amiga/RM2AG.rexx
+++ b/dists/amiga/RM2AG.rexx
@@ -30,7 +30,7 @@ OPEN(guide_write,'README.guide','W')
 Prepare the Amiga guide file, add the intro and fixed text.
 */
 WRITELN(guide_write,'@DATABASE ScummVM README.guide')
-WRITELN(guide_write,'@$VER: ScummVM Readme 2.0.0 (12.07.2017)')
+WRITELN(guide_write,'@$VER: ScummVM Readme @VERSION@')
 WRITELN(guide_write,'@(C) by The ScummVM team')
 WRITELN(guide_write,'@AUTHOR The ScummVM team')
 WRITELN(guide_write,'@WORDWRAP')

--- a/dists/amiga/RM2AG.rexx
+++ b/dists/amiga/RM2AG.rexx
@@ -165,8 +165,9 @@ DO WHILE EOF(readme_read) = 0
 	*/
 	IF POS('[here](',working_line) > 0 THEN DO
 		working_line=INSERT('@{"',working_line,POS('[',working_line)-1)
-		working_line=INSERT('" "',working_line,POS(']',working_line))
-		working_line=INSERT('"}',working_line,POS(')',working_line))
+		working_line=INSERT('" link ',working_line,POS(']',working_line))
+		working_line=INSERT('/main}',working_line,POS(')',working_line))
+		working_line=COMPRESS(working_line,'()')
 	END
 
 	/*

--- a/dists/amiga/RM2AG.rexx
+++ b/dists/amiga/RM2AG.rexx
@@ -1,162 +1,254 @@
 /*
-README to .guide converter $VER: RM2AG.rexx 0.15 (25.01.2018)
+README(.md) to .guide converter $VER: RM2AG.rexx 0.20 (18.05.2019)
 
-This script converts the pure ASCII-text based README file of ScummVM to a
-basic Amiga guide file.
-
-More AmigaGuide features being added in the process if feasible.
+This script converts a given markdown README file of ScummVM to a basic
+hypertext Amiga guide file.
 */
 
-PARSE ARG readme_txt
+PARSE ARG readme_md
 
-/* Check if the given file is really the readme */
-/* If a given filename has spaces in it's name, AmigaDOS/AmigaCLI will add extra quotation marks
-to secure a sane working path. We get rid of them to make AREXX find the file */
-readme_txt=COMPRESS(readme_txt,'"')
-OPEN(check_readme,readme_txt,'R')
-IF READCH(check_readme,14) = 'ScummVM README' THEN
+/*
+Check if the given file is really the readme.
+If a given filename has spaces, AmigaDOS/AmigaCLI will add extra
+quotation marks to secure a sane working path. We get rid of them to make
+AREXX find the file.
+*/
+readme_md=COMPRESS(readme_md,'"')
+OPEN(check_readme,readme_md,'R')
+IF READCH(check_readme,18) = '# [ScummVM README]' THEN
 	CLOSE(check_readme)
 ELSE DO
-	SAY "Not the README file. Aborting!"
-	CLOSE(readme_read)
-	EXIT 20
+	SAY "Not the ScummVM README.md file. Aborting!"
+	CLOSE(check_readme)
+	EXIT 0
 END
 
-/* If it's the proper file, lets start converting */
-OPEN(readme_read,readme_txt,'R')
+OPEN(readme_read,readme_md,'R')
 OPEN(guide_write,'README.guide','W')
 
-/* Prepare the Amiga guide file, add the intro and fixed text */
+/*
+Prepare the Amiga guide file, add the intro and fixed text.
+*/
 WRITELN(guide_write,'@DATABASE ScummVM README.guide')
+WRITELN(guide_write,'@$VER: ScummVM Readme 2.0.0 (12.07.2017)')
+WRITELN(guide_write,'@(C) by The ScummVM team')
+WRITELN(guide_write,'@AUTHOR The ScummVM team')
 WRITELN(guide_write,'@WORDWRAP')
 WRITELN(guide_write,'@NODE "main" "ScummVM README Guide"')
-WRITELN(guide_write,' ')
 WRITELN(guide_write,'@{b}')
-WRITELN(guide_write,READLN(readme_read))
+WRITELN(guide_write,SUBSTR(READLN(readme_read),4,14))
 WRITELN(guide_write,'@{ub}')
 
-/* Creating the main link nodes */
-x=1
+/*
+Creating the main (TOC) link nodes.
+*/
 
 DO WHILE EOF(readme_read) = 0
-	/* Read in the line */
 	working_line=READLN(readme_read)
 
-	/* Checking if the sub links have been reached and leave the loop, if met */
-	IF POS('<>1.0<>',working_line) = 1 & x > 1 THEN
+	/*
+	Check for the start of actual the content and, if found, leave the
+	TOC link loop.
+	*/
+	IF POS('## <>1.0<>)',working_line) = 1 THEN
 		LEAVE
 
-	/* If no chapter has been found, simply write the line */
-	IF POS('<>',working_line) = 0 THEN
+	/*
+	Check for any "rolled over" lines, if found, read in the rest (on the
+	following line) and rejoin them again, before processing any further.
+	e.g.	- [<>3.6.3<>) Broken Sword games
+		cutscenes](#363-broken-sword-games-cutscenes)
+	*/
+	IF POS('- [<>',working_line) > 0 THEN DO
+		IF POS('(#',working_line) = 0 THEN DO
+			rejoin_line=COMPRESS(READLN(readme_read),' ')
+			working_line=working_line rejoin_line
+		END
+	END
+
+	/*
+	If no chapter has been found, simply write the line and skip the rest.
+	*/
+	IF POS('- [',working_line) = 0 THEN
 		WRITELN(guide_write,working_line)
+	ELSE DO
+		/*
+		Fix the empty chapters:
+		Two chapters (1.0 and 7.8) are "empty", consisting of only it's
+		chapter names. We link them to their respective sub chapters
+		(1.1 and 7.8.1), so we don't end up displaying a blank page.
+		
+		 If chapter 1.0 is found, add a link node to chapter 1.1.
+		*/
+		IF POS('  - [<>1.0<>)',working_line) = 1 THEN DO
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'-[<>')
+			WRITELN(guide_write,'  @{" 1.0 " Link "1.1"} 'SUBSTR(working_line,1,LASTPOS(']',working_line)-1))
+		END
 
-	/* Fix the empty chapters - two chapters (1.0 and 7.8) are empty and consist of only the headlines.
-	    We add them to the following chapter and link both of them to the empty one */
+		/*
+		If chapter 7.8 is found, add a link node to 7.8.1.
+		*/
+		IF POS('      - [<>7.8<>)',working_line) = 1 THEN DO
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'-[<>')
+			WRITELN(guide_write,'    @{" 7.8 " Link "7.8.1"} 'SUBSTR(working_line,1,LASTPOS(']',working_line)-1))
+		END
 
-	/* If chapter 1.1 is found add a link node to 1.0 (as chapter 1.0 is empty) */
-	IF POS(' * <>1.1<>',working_line) = 1 THEN DO
-		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*<>')
-		WRITELN(guide_write,'    @{" 1.1 " Link "1.0"} 'working_line)
-	END
+		/*
+		If a single number main chapter is found (1.0 upto 9.0), prepare
+		and write the link node.
+		Just for the record:
+		A "\" (backslash) is treated as escape character in AmigaGuides.
+		Thus we remove it from the node links.
+		*/
+		IF POS('- [<>',working_line) = 3 THEN DO
+			WRITELN(guide_write,' ')
+			WRITELN(guide_write,'  @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(SUBSTR(working_line,1,LASTPOS(']',working_line)-1),'*<>[]\'))
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'-[<>')
+		END
 
-	/* If chapter 7.8.1 is found add a link node to 7.8 (as chapter 7.8  is empty) */
-	IF POS(' * * <>7.8.1<>',working_line) = 1 THEN DO
-		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*<>')
-		WRITELN(guide_write,'      @{" 7.8.1 " Link "7.8"} 'working_line)
-	END
+		/*
+		If a single number level one sub chapter is found
+		(i.e. 1.1, 1.2 etc.), prepare and write the link node.
+		*/
+		IF POS('- [<>',working_line) = 7 THEN DO
+			WRITELN(guide_write,'    @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(SUBSTR(working_line,1,LASTPOS(']',working_line)-1),'*<>[]\'))
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'.[<>')
+		END
 
-	/* If a single number main chapter is found 1.0 upto 9.0), prepare and write the link node */
-	IF POS('.0',working_line) = 4 THEN DO
-		WRITELN(guide_write,' ')
-		WRITELN(guide_write,'  @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(working_line,'*<>'))
-		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*<>')
-		x=x+1
-	END
-
-	/* If a double number main chapter is found (10.0 ff), prepare and write the link node */
-	IF POS('.0',working_line) = 5 THEN DO
-		WRITELN(guide_write,' ')
-		WRITELN(guide_write,'  @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(working_line,'*<>'))
-		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*<>')
-	END
-
-	/* If a level one sub chapter is found (i.e. 1.1), prepare and write the link node */
-	IF POS(' * <>',working_line) = 1 THEN DO
-		WRITELN(guide_write,'    @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(working_line,'*<>'))
-		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*<>')
-	END
-
-	/* If a level two sub chapter is found (i.e. 1.1.1), prepare and write the link node */
-	IF POS(' * * <>',working_line) = 1 THEN DO
-		WRITELN(guide_write,'      @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(working_line,'*<>'))
-		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'*<>')
+		/*
+		If a level two sub chapter is found (i.e. 3.6.1, 3.6.2 etc.),
+		prepare and write the link node.
+		*/
+		IF POS('- [<>',working_line) = 11 THEN DO
+			WRITELN(guide_write,'      @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(SUBSTR(working_line,1,LASTPOS(']',working_line)-1),'*<>[]\'))
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'.[<>')
+		END
 	END
 END
 
-/* Finish the TOC, hardcoded due the outro text getting read in last, but needs to be read/written after the TOC creation */
-WRITELN(guide_write,'------------------------------------------------------------------------')
+/*
+Finish the TOC (Hardcoded due the outro text would be read in last, but
+needs to be written after the TOC creation).
+*/
+WRITELN(guide_write,'-----')
+WRITELN(guide_write,' ')
 WRITELN(guide_write,'Good Luck and Happy Adventuring!')
 WRITELN(guide_write,'The ScummVM team.')
 WRITELN(guide_write,'@{"https://www.scummvm.org/" System "URLOpen https://www.scummvm.org/"}')
-WRITELN(guide_write,'------------------------------------------------------------------------')
 
-/* Creating the sub links nodes */
+/*
+Creating the sub link nodes.
+*/
 DO WHILE EOF(readme_read) = 0
-	/* If no chapter has been found, simply write the line */
+	/*
+	Change the html/markdown links to AmigaGuide ones
+	*/
+	IF POS('[here](',working_line) > 0 THEN DO
+		working_line=INSERT('@{"',working_line,POS('[',working_line)-1)
+		working_line=INSERT('" "',working_line,POS(']',working_line))
+		working_line=INSERT('"}',working_line,POS(')',working_line))
+	END
+
+	/*
+	If no chapter has been found, simply write the line and skip the rest.
+	*/
 	IF POS('<>',working_line) = 0 THEN
 		WRITELN(guide_write,working_line)
+	ELSE DO
+		/*
+		Fix empty chapters:
+		Two chapters (1.0 and 7.8) are "empty", consisting of only it's
+		chapter names. We link them to their respective sub chapters
+		(1.1 and 7.8.1), so we don't end up displaying a blank page.
 
-	/* Fix the empty chapters - two chapters (1.0 and 7.8) are empty and consist of only the Headlines.
-	    We don't close the NODE, rather add the following chapter to the former empty one */
-
-	/* If chapter 1.1 is found don't close the NODE, just write the line */
-	IF POS('<>1.1<>',working_line) = 1 THEN DO
-		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'<>')
-		WRITELN(guide_write,working_line)
-	END
-
-	/* If chapter 7.8.1 is found don't close the NODE, just write the line */
-	IF POS('<>7.8.1<>',working_line) = 1 THEN DO
-		/* Get rid of the markers so the following loops doesn't process them again */
-		working_line=COMPRESS(working_line,'<>')
-		WRITELN(guide_write,working_line)
-	END
-
-	IF POS('<>',working_line) > 0 THEN DO
-		/* Check for link references inside the text and create link nodes for them */
-		IF POS('section <>',working_line) > 0 THEN DO
-			working_line=SUBSTR(working_line,1,POS('<>',working_line)-1)'@{"'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"}'SUBSTR(working_line,LASTPOS('<>',working_line)+2)
-			/* Get rid of the markers so the following loops doesn't process them again */
+		If chapter 1.1 is found don't close the NODE, just write the line.
+		*/
+		IF POS('<>1.1<>',working_line) = 1 THEN DO
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
 			WRITELN(guide_write,COMPRESS(working_line,'<>'))
 		END
-		ELSE DO
-		/* If a chapter has been found, prepare and write the link */
-		WRITELN(guide_write,'@ENDNODE')
-		WRITELN(guide_write,'@NODE "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'" "'COMPRESS(working_line,'<>')'"')
-		WRITELN(guide_write,' ')
-		/* Get rid of the markers so the following loops doesn't process them again */
-		WRITELN(guide_write,COMPRESS(working_line,'<>'))
+
+		/*
+		If chapter 7.8.1 is found don't close the NODE, just write the
+		line.
+		*/
+		IF POS('<>7.8.1<>',working_line) = 1 THEN DO
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			WRITELN(guide_write,COMPRESS(working_line,'<>'))
+		END
+
+		IF POS('<>',working_line) > 0 THEN DO
+			/*
+			Check for link references inside the text and create link
+			nodes for them.
+			*/
+			IF POS('section <>',working_line) > 0 THEN DO
+				working_line=SUBSTR(working_line,1,POS('<>',working_line)-1)'@{"'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"}'SUBSTR(working_line,LASTPOS('<>',working_line)+2)
+				/*
+				Get rid of the markers, so the following loops won't
+				process them again.
+				*/
+				WRITELN(guide_write,COMPRESS(working_line,'<>'))
+			END
+			ELSE DO
+				/*
+				If a chapter has been found, prepare and write the link.
+				*/
+				WRITELN(guide_write,'@ENDNODE')
+				WRITELN(guide_write,'@NODE "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'" "'COMPRESS(working_line,'<>#')'"')
+				WRITELN(guide_write,' ')
+				/*
+				Get rid of the markers, so the following loops won't process
+				them again.
+				*/
+				WRITELN(guide_write,COMPRESS(working_line,'<>'))
+			END
 		END
 	END
-
-	/* Read in the line at the end of the second loop, as the first line to work with was already read in on the end of the first loop */
+	/*
+	Read in the line at the end of the second loop, as the first line to
+	work with was already read in on the end of the first loop.
+	*/
 	working_line=READLN(readme_read)
 
-	/* If the outtro text is found, leave the loop and prepare for closing */
-	IF POS('------------------------------------------------------------------------',working_line) > 0 THEN
+	/*
+	If the outtro text is found, leave the loop and prepare for closing.
+	*/
+	IF POS('-----',working_line,1) =1 THEN
 		LEAVE
 END
 
 WRITELN(guide_write,'@ENDNODE')
 
-/* Closing the guide and cleaning up */
+/*
+Close the guide and clean up.
+*/
 WRITELN(guide_write,'@ENDNODE')
 
 CLOSE(readme_read)

--- a/dists/amiga/RM2AG.rexx
+++ b/dists/amiga/RM2AG.rexx
@@ -30,7 +30,7 @@ OPEN(guide_write,'README.guide','W')
 Prepare the Amiga guide file, add the intro and fixed text.
 */
 WRITELN(guide_write,'@DATABASE ScummVM README.guide')
-WRITELN(guide_write,'@$VER: ScummVM Readme @VERSION@')
+WRITELN(guide_write,'@$VER: ScummVM Readme 2.0.0 (17.12.2017)')
 WRITELN(guide_write,'@(C) by The ScummVM team')
 WRITELN(guide_write,'@AUTHOR The ScummVM team')
 WRITELN(guide_write,'@WORDWRAP')

--- a/dists/amiga/RM2AG.rexx.in
+++ b/dists/amiga/RM2AG.rexx.in
@@ -1,0 +1,256 @@
+/*
+README(.md) to .guide converter $VER: RM2AG.rexx 0.20 (18.05.2019)
+This script converts a given markdown README file of ScummVM to a basic
+hypertext Amiga guide file.
+*/
+
+PARSE ARG readme_md
+
+/*
+Check if the given file is really the readme.
+If a given filename has spaces, AmigaDOS/AmigaCLI will add extra
+quotation marks to secure a sane working path. We get rid of them to make
+AREXX find the file.
+*/
+readme_md=COMPRESS(readme_md,'"')
+OPEN(check_readme,readme_md,'R')
+IF READCH(check_readme,18) = '# [ScummVM README]' THEN
+	CLOSE(check_readme)
+ELSE DO
+	SAY "Not the ScummVM README.md file. Aborting!"
+	CLOSE(check_readme)
+	EXIT 0
+END
+
+OPEN(readme_read,readme_md,'R')
+OPEN(guide_write,'README.guide','W')
+
+/*
+Prepare the Amiga guide file, add the intro and fixed text.
+*/
+WRITELN(guide_write,'@DATABASE ScummVM README.guide')
+WRITELN(guide_write,'@$VER: ScummVM Readme @VERSION@')
+WRITELN(guide_write,'@(C) by The ScummVM team')
+WRITELN(guide_write,'@AUTHOR The ScummVM team')
+WRITELN(guide_write,'@WORDWRAP')
+WRITELN(guide_write,'@NODE "main" "ScummVM README Guide"')
+WRITELN(guide_write,'@{b}')
+WRITELN(guide_write,SUBSTR(READLN(readme_read),4,14))
+WRITELN(guide_write,'@{ub}')
+
+/*
+Creating the main (TOC) link nodes.
+*/
+
+DO WHILE EOF(readme_read) = 0
+	working_line=READLN(readme_read)
+
+	/*
+	Check for the start of actual the content and, if found, leave the
+	TOC link loop.
+	*/
+	IF POS('## <>1.0<>)',working_line) = 1 THEN
+		LEAVE
+
+	/*
+	Check for any "rolled over" lines, if found, read in the rest (on the
+	following line) and rejoin them again, before processing any further.
+	e.g.	- [<>3.6.3<>) Broken Sword games
+		cutscenes](#363-broken-sword-games-cutscenes)
+	*/
+	IF POS('- [<>',working_line) > 0 THEN DO
+		IF POS('(#',working_line) = 0 THEN DO
+			rejoin_line=COMPRESS(READLN(readme_read),' ')
+			working_line=working_line rejoin_line
+		END
+	END
+
+	/*
+	If no chapter has been found, simply write the line and skip the rest.
+	*/
+	IF POS('- [',working_line) = 0 THEN
+		WRITELN(guide_write,working_line)
+	ELSE DO
+		/*
+		Fix the empty chapters:
+		Two chapters (1.0 and 7.8) are "empty", consisting of only it's
+		chapter names. We link them to their respective sub chapters
+		(1.1 and 7.8.1), so we don't end up displaying a blank page.
+		
+		 If chapter 1.0 is found, add a link node to chapter 1.1.
+		*/
+		IF POS('  - [<>1.0<>)',working_line) = 1 THEN DO
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'-[<>')
+			WRITELN(guide_write,'  @{" 1.0 " Link "1.1"} 'SUBSTR(working_line,1,LASTPOS(']',working_line)-1))
+		END
+
+		/*
+		If chapter 7.8 is found, add a link node to 7.8.1.
+		*/
+		IF POS('      - [<>7.8<>)',working_line) = 1 THEN DO
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'-[<>')
+			WRITELN(guide_write,'    @{" 7.8 " Link "7.8.1"} 'SUBSTR(working_line,1,LASTPOS(']',working_line)-1))
+		END
+
+		/*
+		If a single number main chapter is found (1.0 upto 9.0), prepare
+		and write the link node.
+		Just for the record:
+		A "\" (backslash) is treated as escape character in AmigaGuides.
+		Thus we remove it from the node links.
+		*/
+		IF POS('- [<>',working_line) = 3 THEN DO
+			WRITELN(guide_write,' ')
+			WRITELN(guide_write,'  @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(SUBSTR(working_line,1,LASTPOS(']',working_line)-1),'*<>[]\'))
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'-[<>')
+		END
+
+		/*
+		If a single number level one sub chapter is found
+		(i.e. 1.1, 1.2 etc.), prepare and write the link node.
+		*/
+		IF POS('- [<>',working_line) = 7 THEN DO
+			WRITELN(guide_write,'    @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(SUBSTR(working_line,1,LASTPOS(']',working_line)-1),'*<>[]\'))
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'.[<>')
+		END
+
+		/*
+		If a level two sub chapter is found (i.e. 3.6.1, 3.6.2 etc.),
+		prepare and write the link node.
+		*/
+		IF POS('- [<>',working_line) = 11 THEN DO
+			WRITELN(guide_write,'      @{" 'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2) '" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"} 'COMPRESS(SUBSTR(working_line,1,LASTPOS(']',working_line)-1),'*<>[]\'))
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			working_line=COMPRESS(working_line,'.[<>')
+		END
+	END
+END
+
+/*
+Finish the TOC (Hardcoded due the outro text would be read in last, but
+needs to be written after the TOC creation).
+*/
+WRITELN(guide_write,'-----')
+WRITELN(guide_write,' ')
+WRITELN(guide_write,'Good Luck and Happy Adventuring!')
+WRITELN(guide_write,'The ScummVM team.')
+WRITELN(guide_write,'@{"https://www.scummvm.org/" System "URLOpen https://www.scummvm.org/"}')
+
+/*
+Creating the sub link nodes.
+*/
+DO WHILE EOF(readme_read) = 0
+	/*
+	Change the html/markdown links to AmigaGuide ones
+	*/
+	IF POS('[here](',working_line) > 0 THEN DO
+		working_line=INSERT('@{"',working_line,POS('[',working_line)-1)
+		working_line=INSERT('" link ',working_line,POS(']',working_line))
+		working_line=INSERT('/main}',working_line,POS(')',working_line))
+		working_line=COMPRESS(working_line,'()')
+	END
+
+	/*
+	If no chapter has been found, simply write the line and skip the rest.
+	*/
+	IF POS('<>',working_line) = 0 THEN
+		WRITELN(guide_write,working_line)
+	ELSE DO
+		/*
+		Fix empty chapters:
+		Two chapters (1.0 and 7.8) are "empty", consisting of only it's
+		chapter names. We link them to their respective sub chapters
+		(1.1 and 7.8.1), so we don't end up displaying a blank page.
+		If chapter 1.1 is found don't close the NODE, just write the line.
+		*/
+		IF POS('<>1.1<>',working_line) = 1 THEN DO
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			WRITELN(guide_write,COMPRESS(working_line,'<>'))
+		END
+
+		/*
+		If chapter 7.8.1 is found don't close the NODE, just write the
+		line.
+		*/
+		IF POS('<>7.8.1<>',working_line) = 1 THEN DO
+			/*
+			Get rid of the markers, so the following loops won't process
+			them again.
+			*/
+			WRITELN(guide_write,COMPRESS(working_line,'<>'))
+		END
+
+		IF POS('<>',working_line) > 0 THEN DO
+			/*
+			Check for link references inside the text and create link
+			nodes for them.
+			*/
+			IF POS('section <>',working_line) > 0 THEN DO
+				working_line=SUBSTR(working_line,1,POS('<>',working_line)-1)'@{"'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'" Link "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'"}'SUBSTR(working_line,LASTPOS('<>',working_line)+2)
+				/*
+				Get rid of the markers, so the following loops won't
+				process them again.
+				*/
+				WRITELN(guide_write,COMPRESS(working_line,'<>'))
+			END
+			ELSE DO
+				/*
+				If a chapter has been found, prepare and write the link.
+				*/
+				WRITELN(guide_write,'@ENDNODE')
+				WRITELN(guide_write,'@NODE "'SUBSTR(working_line,POS('<>',working_line)+2,LASTPOS('<>',working_line)-POS('<>',working_line)-2)'" "'COMPRESS(working_line,'<>#')'"')
+				WRITELN(guide_write,' ')
+				/*
+				Get rid of the markers, so the following loops won't process
+				them again.
+				*/
+				WRITELN(guide_write,COMPRESS(working_line,'<>'))
+			END
+		END
+	END
+	/*
+	Read in the line at the end of the second loop, as the first line to
+	work with was already read in on the end of the first loop.
+	*/
+	working_line=READLN(readme_read)
+
+	/*
+	If the outtro text is found, leave the loop and prepare for closing.
+	*/
+	IF POS('-----',working_line,1) =1 THEN
+		LEAVE
+END
+
+WRITELN(guide_write,'@ENDNODE')
+
+/*
+Close the guide and clean up.
+*/
+WRITELN(guide_write,'@ENDNODE')
+
+CLOSE(readme_read)
+CLOSE(guide_write)
+
+EXIT 0


### PR DESCRIPTION
Complete rewrite of the (AmigaOS4-only) RM2AG.rexx script to cover the change to markdown.

I´d like to ask for review and some questions before it gets merged.

- Is there some kind of list where someone could add this file regarding "automatic" version updates?
I have added a version information (line 33) to the script (amongst other things) but would refrain from doing a manual change everytime a new version appears.

There are of course other options:
1) I could drop the whole line.
2) I could stick with the scripts version (0.20 right now e.g.)

- Lines 163-166 add a conversion from the markdown/html in-readme link (of the files NEWS.md and AUTHORS) to an AmigaGuide specific one, which will open the given files locally from within the installed archive (if available).
I don´t really like the solution i have now, i´d rather do it in the sed conversion script beforehand, but i´ve got no idea whatsoever how to achieve that. I don´t speak sed.
So, if anyone can lend me a hand and help me find the correct sed syntax to change the following lines, i´d be grateful.

I want to change
Please refer to our extensive Changelog [here](NEWS.md).
to
Please refer to our extensive Changelog {@"[here]" link NEWS.md/main}.
and
Please refer to our extensive Credits list [here](AUTHORS).
to
Please refer to our extensive Credits list {@"[here]" link AUTHORS/main}.

- For some reason neither README.md nor NEWS.md gets copied on a full installation build.
I do have cp $(DIST_FILES_DOCS) $(AMIGAOSPATH) in amigaos.mk, but they doesn´t seem to get picked up?

Thank you and sorry for the mistakes i surely made and the noise