### PR TITLE
SCI: Fix FPFP CD 'Dummy Msg' message texts

### DIFF
--- a/engines/sci/engine/message.h
+++ b/engines/sci/engine/message.h
@@ -77,7 +77,7 @@ public:
 private:
 	bool getRecord(CursorStack &stack, bool recurse, MessageRecord &record);
 	void outputString(reg_t buf, const Common::String &str);
-	Common::String processString(const char *s);
+	Common::String processString(const char *s, uint32 maxLength);
 	int hexDigitToWrongInt(char h);
 	bool stringHex(Common::String &outStr, const Common::String &inStr, uint &index);
 	bool stringLit(Common::String &outStr, const Common::String &inStr, uint &index);


### PR DESCRIPTION
This fixes 17 message texts in the CD version of FPFP, bug #10964.

This is a new one, the audio is right but the text is in all the wrong places, with strings like "Dummy Msg" in most of them. I'm assuming this is because this game didn't formally offer a text mode in the CD version. The installer didn't even have a No Soundcard option. What's weird is that these three sequences are the only ones like this, everything else seems fine, so I don't expect this to need future updates.

Let me know what you think. I'm not wild about touching processString() for this, but it's const char* on down, and now future workarounds can also trim trailing text by setting MessageRecord::length.