### PR TITLE
COMMON: Fix button state desynchronization when warping mouse

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -281,15 +281,32 @@ void DefaultEventManager::purgeMouseEvents() {
 	while (!_eventQueue.empty()) {
 		Common::Event event = _eventQueue.pop();
 		switch (event.type) {
-		case Common::EVENT_MOUSEMOVE:
+		// Update button state even when purging events to avoid desynchronisation with real button state
 		case Common::EVENT_LBUTTONDOWN:
+			_mousePos = event.mouse;
+			_buttonState |= LBUTTON;
+			break;
+
 		case Common::EVENT_LBUTTONUP:
+			_mousePos = event.mouse;
+			_buttonState &= ~LBUTTON;
+			break;
+
 		case Common::EVENT_RBUTTONDOWN:
+			_mousePos = event.mouse;
+			_buttonState |= RBUTTON;
+			break;
+
 		case Common::EVENT_RBUTTONUP:
+			_mousePos = event.mouse;
+			_buttonState &= ~RBUTTON;
+			break;
+
 		case Common::EVENT_WHEELUP:
 		case Common::EVENT_WHEELDOWN:
 		case Common::EVENT_MBUTTONDOWN:
 		case Common::EVENT_MBUTTONUP:
+		case Common::EVENT_MOUSEMOVE:
 			// do nothing
 			break;
 		default:


### PR DESCRIPTION
When warping mouse, if there is a mouse release event in the event queue, it gets eaten by the purgeMouseEvents function and _buttonState gets desynchronized.
This pull request prevents this by updating _buttonState even when purging events.