### PR TITLE
CONFIGURE: Remove the 'u' flag from 'ar' in mingw32

### DIFF
--- a/configure
+++ b/configure
@@ -3228,7 +3228,7 @@ if test -n "$_host"; then
 		*mingw32*)
 			_sdlconfig=$_host-sdl-config
 			_windres=$_host-windres
-			_ar="$_host-ar cru"
+			_ar="$_host-ar cr"
 			_ranlib=$_host-ranlib
 			;;
 		mips-sgi*)


### PR DESCRIPTION
This patch silences the warnings about the (outdated?) 'u'
flag that appears at least when building and linking ScummVM
statically on mingw32:

"`u' modifier ignored since `D' is the default (see `U')"

The cause for this appears to be a bug in recent versions of
libtool that most likely will also appear when building on
Linux. However, since I have not tested this yet, this patch
only disables it for mingw32.

The only downside from this patch is that building a non-clean
build will take (slightly?) longer since we are no longer
just updating (that's what the 'u' is for) changed libraries
during the linking stage, but linking all .a files again.