### PR TITLE
BLADERUNNER: Show saved game creation date and add play time

### DIFF
--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -254,7 +254,7 @@ Common::Error BladeRunnerEngine::loadGameState(int slot) {
 	if (!BladeRunner::SaveFileManager::readHeader(*saveFile, header)) {
 		error("Invalid savegame");
 	}
-
+	setTotalPlayTime(header._playTime);
 	loadGame(*saveFile);
 
 	delete saveFile;
@@ -284,6 +284,7 @@ Common::Error BladeRunnerEngine::saveGameState(int slot, const Common::String &d
 
 	BladeRunner::SaveFileHeader header;
 	header._name = desc;
+	header._playTime = getTotalPlayTime();
 
 	BladeRunner::SaveFileManager::writeHeader(*saveFile, header);
 	_time->pause();

--- a/engines/bladerunner/detection.cpp
+++ b/engines/bladerunner/detection.cpp
@@ -108,6 +108,8 @@ bool BladeRunnerMetaEngine::hasFeature(MetaEngineFeature f) const {
 		f == kSupportsDeleteSave ||
 		f == kSavesSupportMetaInfo ||
 		f == kSavesSupportThumbnail ||
+		f == kSavesSupportCreationDate ||
+		f == kSavesSupportPlayTime ||
 		f == kSimpleSavesNames;
 }
 

--- a/engines/bladerunner/savefile.cpp
+++ b/engines/bladerunner/savefile.cpp
@@ -79,6 +79,7 @@ SaveStateDescriptor SaveFileManager::queryMetaInfos(const Common::String &target
 	desc.setThumbnail(header._thumbnail);
 	desc.setSaveDate(header._year, header._month, header._day);
 	desc.setSaveTime(header._hour, header._minute);
+	desc.setPlayTime(header._playTime);
 	return desc;
 }
 
@@ -105,7 +106,7 @@ bool SaveFileManager::readHeader(Common::SeekableReadStream &in, SaveFileHeader 
 	}
 
 	header._version = s.readByte();
-	if (header._version != kVersion) {
+	if (header._version > kVersion) {
 		warning("Unsupported version of save file %u, supported is %u", header._version, kVersion);
 		return false;
 	}
@@ -117,6 +118,11 @@ bool SaveFileManager::readHeader(Common::SeekableReadStream &in, SaveFileHeader 
 	header._day    = s.readUint16LE();
 	header._hour   = s.readUint16LE();
 	header._minute = s.readUint16LE();
+
+	header._playTime = 0;
+	if (header._version >= 2) {
+		header._playTime = s.readUint32LE();
+	}
 
 	header._thumbnail = nullptr;
 
@@ -166,6 +172,8 @@ bool SaveFileManager::writeHeader(Common::WriteStream &out, SaveFileHeader &head
 	s.writeUint16LE(td.tm_mday);
 	s.writeUint16LE(td.tm_hour);
 	s.writeUint16LE(td.tm_min);
+
+	s.writeUint32LE(header._playTime);
 
 	return true;
 }

--- a/engines/bladerunner/savefile.h
+++ b/engines/bladerunner/savefile.h
@@ -53,13 +53,14 @@ struct SaveFileHeader {
 	int                _day;
 	int                _hour;
 	int                _minute;
+	uint32             _playTime;
 	Graphics::Surface *_thumbnail;
 };
 
 class SaveFileManager {
 private:
 	static const uint32 kTag = MKTAG('B', 'R', 'S', 'V');
-	static const uint32 kVersion = 1;
+	static const uint32 kVersion = 2;
 
 public:
 	static const uint32 kNameLength = 32;

--- a/engines/bladerunner/ui/kia_section_save.cpp
+++ b/engines/bladerunner/ui/kia_section_save.cpp
@@ -407,6 +407,7 @@ void KIASectionSave::save() {
 
 	BladeRunner::SaveFileHeader header;
 	header._name = _inputBox->getText();
+	header._playTime = _vm->getTotalPlayTime();
 
 	BladeRunner::SaveFileManager::writeHeader(*saveFile, header);
 


### PR DESCRIPTION
Bumped saved game version to 2 to add play time.

Can load version 1 saves and save/load version 2 saves.