### PR TITLE
BLADERUNNER: Add flag to disable sewer bridge breaking

### DIFF
--- a/engines/bladerunner/script/ai/free_slot_a.cpp
+++ b/engines/bladerunner/script/ai/free_slot_a.cpp
@@ -541,6 +541,10 @@ void AIScriptFreeSlotA::FledCombat() {
 }
 
 void AIScriptFreeSlotA::checkIfOnBridge() {
+	if (_vm->_cutContent && Query_Difficulty_Level() == kGameDifficultyEasy) {
+		// Make the bridge indestructible on easy mode for the enhanced version
+		return;
+	}
 	float x, y, z;
 	Actor_Query_XYZ(kActorFreeSlotA, &x, &y, &z);
 	// bug? this should probably check if McCoy is close enough because bridge will break long after rat died and player tries to walk through

--- a/engines/bladerunner/script/scene/ug15.cpp
+++ b/engines/bladerunner/script/scene/ug15.cpp
@@ -40,7 +40,8 @@ void SceneScriptUG15::InitializeScene() {
 	} else {
 		Setup_Scene_Information(-238.0f, 48.07f,  222.0f, 180);
 		if (Game_Flag_Query(kFlagUG15RatShot)
-		 && Random_Query(1, 10) == 10
+		 && (Random_Query(1, 10) == 10)
+		 && !(_vm->_cutContent && Query_Difficulty_Level() == kGameDifficultyEasy)
 		) {
 			Game_Flag_Reset(kFlagUG15RatShot);
 		}


### PR DESCRIPTION
This will make that part less frustrating. The rat can still get you.