### PR TITLE
BLADERUNNER: Make the Moraji encounter easier on easy

### DIFF
--- a/engines/bladerunner/script/ai/moraji.cpp
+++ b/engines/bladerunner/script/ai/moraji.cpp
@@ -47,7 +47,10 @@ bool AIScriptMoraji::Update() {
 	 && !Game_Flag_Query(kFlagDR05BombActivated)
 	) {
 		AI_Countdown_Timer_Reset(kActorMoraji, kActorTimerAIScriptCustomTask2);
-		AI_Countdown_Timer_Start(kActorMoraji, kActorTimerAIScriptCustomTask2, 30);
+		int bombTime = 30; // Original value
+		if (_vm->_cutContent && Query_Difficulty_Level() == kGameDifficultyEasy)
+			bombTime += 10; // Extend the bomb timer duration when in Dermo Design (where Moraji is chained)
+		AI_Countdown_Timer_Start(kActorMoraji, kActorTimerAIScriptCustomTask2, bombTime);
 		Game_Flag_Set(kFlagDR05BombActivated);
 		return true;
 	}

--- a/engines/bladerunner/script/scene/dr04.cpp
+++ b/engines/bladerunner/script/scene/dr04.cpp
@@ -203,7 +203,10 @@ bool SceneScriptDR04::ClickedOn2DRegion(int region) {
 bool SceneScriptDR04::farEnoughFromExplosion() {
 	float x, y, z;
 	Actor_Query_XYZ(kActorMcCoy, &x, &y, &z);
-	return (x + 1089.94f) * (x + 1089.94f) + (z - 443.49f) * (z - 443.49f) >= (360.0f * 360.0f);
+	float blastRadius = 360.0f; // Original blast radius
+	if (_vm->_cutContent && Query_Difficulty_Level() == kGameDifficultyEasy)
+		blastRadius = 290.0f; // Allow the player to survive the bomb closer to the Dermo Design entrance
+	return (x + 1089.94f) * (x + 1089.94f) + (z - 443.49f) * (z - 443.49f) >= (blastRadius * blastRadius);
 }
 
 void SceneScriptDR04::SceneFrameAdvanced(int frame) {


### PR DESCRIPTION
This extending the bomb duration by 10secs while Moraji
is chained.

It extends the bomb from blowing up by 1.1 secs after Moraji
is freed.

Finally, the blast radius is decreased so that the player may survive closer.

All of this only happens on the uncut version when playing on easy.

I picked 1.1 sec for the post-freed time because if it is longer
Moraji will continue to run in place when he reaches his destination
outside Dermo Design (If its the path where he falls after the bomb
blows).