### PR TITLE
WIN32: Fix leaked handles in CreateProcess

### DIFF
--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -145,8 +145,11 @@ bool OSystem_Win32::displayLogFile() {
 	                            NULL,
 	                            &startupInfo,
 	                            &processInformation);
-	if (result)
+	if (result) {
+		CloseHandle(processInformation.hProcess);
+		CloseHandle(processInformation.hThread);
 		return true;
+	}
 
 	return false;
 }


### PR DESCRIPTION
Make sure to close handles created by `CreateProcess` as per https://docs.microsoft.com/en-us/windows/desktop/ProcThread/creating-processes

(closing them doesn't affect the running process)