### PR TITLE
 SCI: Create message workaround system 

### DIFF
--- a/engines/sci/engine/message.cpp
+++ b/engines/sci/engine/message.cpp
@@ -25,6 +25,7 @@
 #include "sci/engine/kernel.h"
 #include "sci/engine/seg_manager.h"
 #include "sci/engine/state.h"
+#include "sci/engine/workarounds.h"
 #include "sci/util.h"
 
 namespace Sci {
@@ -183,10 +184,17 @@ public:
 #endif
 
 bool MessageState::getRecord(CursorStack &stack, bool recurse, MessageRecord &record) {
-	Resource *res = g_sci->getResMan()->findResource(ResourceId(kResourceTypeMessage, stack.getModule()), false);
+	// find a workaround for the requested message and use the prescribed module
+	int module = stack.getModule();
+	MessageTuple &tuple = stack.top();
+	SciMessageWorkaroundSolution workaround = findMessageWorkaround(module, tuple.noun, tuple.verb, tuple.cond, tuple.seq);
+	if (workaround.type != MSG_WORKAROUND_NONE) {
+		module = workaround.module;
+	}
+	Resource *res = g_sci->getResMan()->findResource(ResourceId(kResourceTypeMessage, module), false);
 
 	if (!res) {
-		warning("Failed to open message resource %d", stack.getModule());
+		warning("Failed to open message resource %d", module);
 		return false;
 	}
 
@@ -224,198 +232,51 @@ bool MessageState::getRecord(CursorStack &stack, bool recurse, MessageRecord &re
 		return false;
 	}
 
+	// apply the message workaround
+	if (workaround.type == MSG_WORKAROUND_REMAP) {
+		// remap the request to a different message record.
+		//  this alters the stack, nextMessage() will return the next
+		//  record in the sequence following the returned record.
+		stack.setModule(module);
+		tuple.noun = workaround.noun;
+		tuple.verb = workaround.verb;
+		tuple.cond = workaround.cond;
+		tuple.seq = workaround.seq;
+	} else if (workaround.type == MSG_WORKAROUND_FAKE) {
+		// return a fake message record hard-coded in the workaround.
+		//  this leaves the stack unchanged.
+		record.tuple = stack.top();
+		record.refTuple = MessageTuple();
+		record.string = workaround.text;
+		record.length = strlen(workaround.text);
+		record.talker = workaround.talker;
+		delete reader;
+		return true;
+	} else if (workaround.type == MSG_WORKAROUND_EXTRACT) {
+		// extract and return text from a different message record.
+		//  use the talker provided by the workaround since the correct value
+		//  could be in either, or neither, of the records.
+		//  this leaves the stack unchanged.
+		MessageTuple textTuple(workaround.noun, workaround.verb, workaround.cond, workaround.seq);
+		MessageRecord textRecord;
+		if (reader->findRecord(textTuple, textRecord)) {
+			uint32 textLength = (workaround.substringLength == 0) ? textRecord.length : workaround.substringLength;
+			if (workaround.substringIndex + textLength <= textRecord.length) {
+				record.tuple = stack.top();
+				record.refTuple = MessageTuple();
+				record.string = textRecord.string + workaround.substringIndex;
+				record.length = textLength;
+				record.talker = workaround.talker;
+				delete reader;
+				return true;
+			}
+		}
+	}
+
 	while (1) {
-		MessageTuple &t = stack.top();
+		tuple = stack.top();
 
-		// Fix known incorrect message tuples
-		// TODO: Add a more generic mechanism, like the one we have for
-		// script workarounds, for cases with incorrect sync resources,
-		// like the ones below.
-		if (g_sci->getGameId() == GID_QFG1VGA && stack.getModule() == 322 &&
-			t.noun == 14 && t.verb == 1 && t.cond == 19 && t.seq == 1) {
-			// Talking to Kaspar the shopkeeper - bug #3604944
-			t.verb = 2;
-		}
-
-		if (g_sci->getGameId() == GID_PQ1 && stack.getModule() == 38 &&
-			t.noun == 10 && t.verb == 4 && t.cond == 8 && t.seq == 1) {
-			// Using the hand icon on Keith in the Blue Room - bug #3605654
-			t.cond = 9;
-		}
-
-		if (g_sci->getGameId() == GID_PQ1 && stack.getModule() == 38 &&
-			t.noun == 10 && t.verb == 1 && t.cond == 0 && t.seq == 1) {
-			// Using the eye icon on Keith in the Blue Room - bug #3605654
-			t.cond = 13;
-		}
-
-		if (g_sci->getGameId() == GID_QFG4 && stack.getModule() == 16 &&
-			t.noun == 49 && t.verb == 1 && t.cond == 0 && t.seq == 2) {
-			// Examining the statue inventory item from the monastery - bug #10770
-			// The description says "squid-like monster", yet the icon is
-			// clearly an insect. It turned Chief into "an enormous beetle". We
-			// change the phrase to "monstrous insect".
-			//
-			// Note: The German string contains accented characters.
-			//  0x84 "a with diaeresis"
-			//  0x94 "o with diaeresis"
-			//
-			// Values were pulled from SCI Companion's raw message data. They
-			// are escaped that way here, as encoded bytes.
-			record.tuple = t;
-			record.refTuple = MessageTuple();
-			record.talker = 99;
-			if (g_sci->getSciLanguage() == K_LANG_GERMAN) {
-				record.string = "Die groteske Skulptur eines schrecklichen, monstr\x94sen insekts ist sorgf\x84ltig in die Einkaufstasche eingewickelt.";
-				record.length = 112;
-			} else {
-				record.string = "Carefully wrapped in a shopping bag is the grotesque sculpture of a horrible, monstrous insect.";
-				record.length = 95;
-			}
-			delete reader;
-			return true;
-		}
-
-		if (g_sci->getGameId() == GID_QFG4 && stack.getModule() == 579 &&
-			t.noun == 0 && t.verb == 0 && t.cond == 0 && t.seq == 1) {
-			// Talking with the Leshy and telling him about "bush in goo" - bug #10137
-			t.verb = 1;
-		}
-
-		if (g_sci->getGameId() == GID_QFG4 && g_sci->isCD() && stack.getModule() == 520 &&
-			t.noun == 2 && t.verb == 59 && t.cond == 0) {
-			// The CD edition mangled the Rusalka flowers dialogue. - bug #10849
-			// In the floppy edition, there are 3 lines, the first from
-			// the narrator, then two from Rusalka. The CD edition omits
-			// narration and only has the 3rd text, with the 2nd audio! The
-			// 3rd audio is orphaned but available.
-			//
-			// We only restore Rusalka's lines, providing the correct text
-			// for seq:1 to match the audio. We respond to seq:2 requests
-			// with Rusalka's last text. The orphaned audio (seq:3) has its
-			// tuple adjusted to seq:2 in resource_audio.cpp.
-			if (t.seq == 1) {
-				record.tuple = t;
-				record.refTuple = MessageTuple();
-				record.talker = 28;
-				record.string = "Thank you for the beautiful flowers.  No one has been so nice to me since I can remember.";
-				record.length = 89;
-				delete reader;
-				return true;
-			} else if (t.seq == 2) {
-				// The CD edition ships with this text at seq:1.
-				//  Look it up instead of hardcoding.
-				t.seq = 1;
-				if (!reader->findRecord(t, record)) {
-					delete reader;
-					return false;
-				}
-				t.seq = 2;             // Prevent an endless 2=1 -> 2=1 -> 2=1... loop.
-				record.tuple.seq = 2;  // Make the record seq:2 to get the seq:2 audio.
-				record.refTuple = MessageTuple();
-				delete reader;
-				return true;
-			}
-		}
-
-		if (g_sci->getGameId() == GID_LAURABOW2 && !g_sci->isCD() && stack.getModule() == 1885 &&
-			t.noun == 1 && t.verb == 6 && t.cond == 16 && t.seq == 4 &&
-			(g_sci->getEngineState()->currentRoomNumber() == 350 ||
-			 g_sci->getEngineState()->currentRoomNumber() == 360 ||
-			 g_sci->getEngineState()->currentRoomNumber() == 370)) {
-			// Asking Yvette about Tut in act 2 party - bug #10723
-			// Skip the last two lines of dialogue about a murder that hasn't occurred yet.
-			// Sierra fixed this in cd version by creating a copy of this message without those lines.
-			// Room-specific as the message is used again later where it should display in full.
-			t.seq += 2;
-		}
-
-		// Fill in known missing message tuples
-		if (g_sci->getGameId() == GID_SQ4 && stack.getModule() == 16 &&
-			t.noun == 7 && t.verb == 0 && t.cond == 3 && t.seq == 1) {
-			// This fixes the error message shown when speech and subtitles are
-			// enabled simultaneously in SQ4 - the (very) long dialog when Roger
-			// is talking with the aliens is missing - bug #3538416.
-			record.tuple = t;
-			record.refTuple = MessageTuple();
-			record.talker = 7;	// Roger
-			// The missing text is just too big to fit in one speech bubble, and
-			// if it's added here manually and drawn on screen, it's painted over
-			// the entrance in the back where the Sequel Police enters, so it
-			// looks very ugly. Perhaps this is why this particular text is missing,
-			// as the text shown in this screen is very short (one-liners).
-			// Just output an empty string here instead of showing an error.
-			record.string = "";
-			record.length = 0;
-			delete reader;
-			return true;
-		}
-
-		// FPFP CD has several message sequences where audio and text were left
-		//  out of sync. This is probably because this version didn't formally
-		//  support text mode. Most of these texts just say "Dummy Msg". All the
-		//  real text is there but it's either concatenated or in a different
-		//  tuple. We extract and return the correct text. Fixes #10964
-		if (g_sci->getGameId() == GID_FREDDYPHARKAS && g_sci->isCD() &&
-			g_sci->getLanguage() == Common::EN_ANY && !g_sci->isDemo()) {
-			byte textSeq = 0;
-			uint32 substringIndex = 0;
-			uint32 substringLength = 0;
-
-			// lever brothers' introduction
-			if (stack.getModule() == 220 && t.noun == 24 && t.verb == 0 && t.cond == 0) {
-				switch (t.seq) {
-				case 1: textSeq = 1; substringIndex = 0;   substringLength = 25; break;
-				case 2: textSeq = 1; substringIndex = 26;  substringLength = 20; break;
-				case 3: textSeq = 1; substringIndex = 47;  substringLength = 58; break;
-				case 4: textSeq = 1; substringIndex = 106; substringLength = 34; break;
-				case 5: textSeq = 1; substringIndex = 141; substringLength = 27; break;
-				case 6: textSeq = 1; substringIndex = 169; substringLength = 29; break;
-				case 7: textSeq = 1; substringIndex = 199; substringLength = 52; break;
-				case 8: textSeq = 1; substringIndex = 252; substringLength = 37; break;
-				}
-			}
-
-			// kenny's introduction
-			if (stack.getModule() == 220 && t.noun == 30 && t.verb == 0 && t.cond == 0) {
-				switch (t.seq) {
-				case 3: textSeq = 3; substringIndex = 0;  substringLength = 14;  break;
-				case 4: textSeq = 3; substringIndex = 15; substringLength = 245; break;
-				case 5: textSeq = 4; break;
-				}
-			}
-
-			// helen swatting flies
-			if (stack.getModule() == 660 && t.noun == 35 && t.verb == 0 && t.cond == 0) {
-				switch (t.seq) {
-				case 1: textSeq = 1; substringIndex = 0;   substringLength = 42; break;
-				case 2: textSeq = 1; substringIndex = 43;  substringLength = 93; break;
-				case 3: textSeq = 1; substringIndex = 137; substringLength = 72; break;
-				case 4: textSeq = 2; break;
-				case 5: textSeq = 1; substringIndex = 210; substringLength = 57; break;
-				case 6: textSeq = 3; break;
-				}
-			}
-
-			// find the original message record and the record that contains the
-			//  correct text, then use the correct substring. the original must
-			//  be used to preserve its correct talker and tuple values.
-			if (textSeq != 0 && reader->findRecord(t, record)) {
-				MessageTuple textTuple(t.noun, t.verb, t.cond, textSeq);
-				MessageRecord textRecord;
-				if (reader->findRecord(textTuple, textRecord)) {
-					uint32 textLength = (substringLength == 0) ? textRecord.length : substringLength;
-					if (substringIndex + textLength <= textRecord.length) {
-						record.string = textRecord.string + substringIndex;
-						record.length = textLength;
-						delete reader;
-						return true;
-					}
-				}
-			}
-		}
-
-		if (!reader->findRecord(t, record)) {
+		if (!reader->findRecord(tuple, record)) {
 			// Tuple not found
 			if (recurse && (stack.size() > 1)) {
 				stack.pop();
@@ -430,7 +291,7 @@ bool MessageState::getRecord(CursorStack &stack, bool recurse, MessageRecord &re
 			MessageTuple &ref = record.refTuple;
 
 			if (ref.noun || ref.verb || ref.cond) {
-				t.seq++;
+				tuple.seq++;
 				stack.push(ref);
 				continue;
 			}

--- a/engines/sci/engine/message.h
+++ b/engines/sci/engine/message.h
@@ -56,6 +56,7 @@ public:
 	}
 
 	int getModule() const { return _module; }
+	void setModule(int module) { _module = module; }
 
 private:
 	int _module;

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -11894,54 +11894,6 @@ static const uint16 sq4CdPatchMazeTalkMessage[] = {
 	PATCH_END
 };
 
-// Smelling the sidewalk in room 35 results in a missing message due to not
-//  passing the cond parameter to Sq4GlobalNarrator:say. We pass the parameter
-//  and make room by removing an unused parameter passed to theRoom:doVerb.
-//
-// Applies to: English PC CD
-// Responsible method: sidewalk1:doVerb(6)
-// Fixes bug #10917
-static const uint16 sq4CdSignatureSidewalkSmellMessage[] = {
-	0x31, 0x10,                         // bnt 10
-	SIG_ADDTOOFFSET(+9),
-	SIG_MAGICDWORD,
-	0x76,                               // push0
-	0x81, 0x59,                         // lag 59
-	0x4a, 0x0a,                         // send 0a [ Sq4GlobalNarrator modNum: 25 say: ]
-	0x33, 0x24,                         // jmp 24  [ end of method ]
-	0x3c,                               // dup
-	0x35, 0x09,                         // ldi 09 [ rope ]
-	0x1a,                               // eq?
-	0x31, 0x15,                         // bnt 15
-	0x38, SIG_ADDTOOFFSET(+2),          // pushi doVerb
-	0x7a,                               // push2
-	0x8f, 0x01,                         // lsp 01 [ verb ]
-	0x8f, 0x02,                         // lsp 02 [ unused by theRoom:doVerb ]
-	SIG_ADDTOOFFSET(+9),
-	0x4a, 0x08,                         // send 08 [ theRoom doVerb: verb param2 ]
-	SIG_END
-};
-
-static const uint16 sq4CdPatchSidewalkSmellMessage[] = {
-	0x31, 0x12,                         // bnt 12
-	PATCH_ADDTOOFFSET(+9),
-	0x78,                               // push1
-	0x39, 0x0b,                         // push 0b
-	0x81, 0x59,                         // lag 59
-	0x4a, 0x0c,                         // send 0c [ Sq4GlobalNarrator modNum: 25 say: 11 ]
-	0x33, 0x22,                         // jmp 22  [ end of method ]
-	0x3c,                               // dup
-	0x35, 0x09,                         // ldi 09 [ rope ]
-	0x1a,                               // eq?
-	0x31, 0x13,                         // bnt 13
-	0x38, PATCH_GETORIGINALUINT16(+25), // pushi doVerb
-	0x78,                               // push1
-	0x8f, 0x01,                         // lsp 01 [ verb ]
-	PATCH_ADDTOOFFSET(+9),
-	0x4a, 0x06,                         // send 06 [ theRoom doVerb: verb ]
-	PATCH_END
-};
-
 // Talking to the red shopper in the mall has a 5% chance of a funny message but
 //  this script is broken in the CD version. After the first time the wrong
 //  message tuple is attempted by the narrator as its modNum value is cleared.
@@ -12648,7 +12600,6 @@ static const SciScriptPatcherEntry sq4Signatures[] = {
 	{  true,   376, "Floppy: click atm card on sequel police fix",    1, sq4FloppySignatureClickAtmCardOnSequelPolice,  sq4FloppyPatchClickAtmCardOnSequelPolice },
 	{  true,   376, "Floppy: throw stuff at sequel police fix",       1, sq4FloppySignatureThrowStuffAtSequelPolice,    sq4FloppyPatchThrowStuffAtSequelPolice },
 	{  true,   700, "Floppy: throw stuff at sequel police fix",       1, sq4FloppySignatureThrowStuffAtSequelPolice,    sq4FloppyPatchThrowStuffAtSequelPolice },
-	{  true,    35, "CD: sidewalk smell message fix",                 1, sq4CdSignatureSidewalkSmellMessage,            sq4CdPatchSidewalkSmellMessage },
 	{  true,    45, "CD: walk in from below for room 45 fix",         1, sq4CdSignatureWalkInFromBelowRoom45,           sq4CdPatchWalkInFromBelowRoom45 },
 	{  true,   105, "Floppy: sewer lockup fix",                       1, sq4FloppySignatureSewerLockup,                 sq4FloppyPatchSewerLockup },
 	{  true,   105, "CD: sewer lockup fix",                           1, sq4CDSignatureSewerLockup,                     sq4CDPatchSewerLockup },

--- a/engines/sci/engine/workarounds.cpp
+++ b/engines/sci/engine/workarounds.cpp
@@ -326,6 +326,7 @@ const SciWorkaroundEntry uninitializedReadForParamWorkarounds[] = {
 	{ GID_PHANTASMAGORIA2,-1, 64926,  0,              "Thumb", "action",                          NULL,     1,     1,{ WORKAROUND_FAKE,   0 } }, // When dragging one of the volume sliders and releasing the mouse button over the +/- buttons
 	{ GID_PHANTASMAGORIA2,-1, 63019,  0,     "WynDocTextView", "cue",                             NULL,     2,     2,{ WORKAROUND_FAKE,   0 } }, // When dragging the slider next to an e-mail message
 	{ GID_SHIVERS,        -1, 64918,  0,                "Str", "strip",                           NULL,     1,     1,{ WORKAROUND_FAKE,   0 } }, // When starting a new game and entering a name
+	{ GID_SQ4,            35,   928,  0,           "Narrator", "say",                             NULL,     1,     1,{ WORKAROUND_FAKE,  11 } }, // Clicking smell on sidewalk, fixes message due to missing say parameter in sidewalk1:doVerb(6) - bug #10917
 	SCI_WORKAROUNDENTRY_TERMINATOR
 };
 

--- a/engines/sci/engine/workarounds.cpp
+++ b/engines/sci/engine/workarounds.cpp
@@ -28,6 +28,7 @@
 #include "sci/engine/workarounds.h"
 
 #define SCI_WORKAROUNDENTRY_TERMINATOR { (SciGameId)0, -1, -1, 0, NULL, NULL, NULL, 0, 0, { WORKAROUND_NONE, 0 } }
+#define SCI_MESSAGEWORKAROUNDENTRY_TERMINATOR { (SciGameId)0, (SciMedia)0, (kLanguage)0, -1, -1, 0, 0, 0, 0, { MSG_WORKAROUND_NONE, -1, 0, 0, 0, 0, 0, 0, 0, NULL } }
 
 namespace Sci {
 
@@ -1133,6 +1134,205 @@ SciWorkaroundSolution trackOriginAndFindWorkaround(int index, const SciWorkaroun
 	noneFound.type = WORKAROUND_NONE;
 	noneFound.value = 0;
 	return noneFound;
+}
+
+// Workarounds for known broken messages
+//
+// The most common message bug is a script passing the wrong tuple or a message
+//  having the wrong tuple. This results in a "missing message" message. These
+//  requests just need to be remapped to the right message. In some cases the
+//  message text is incorrect, or missing, in which case it can be extracted
+//  from another record or faked with a hard-coded response.
+//
+// Workarounds can be optionally scoped to media (floppy vs cd), language, and
+//  room number. If a message is remapped, this will also remap any audio36 and
+//  sync36 resources with the same tuple, unless those resources have their own
+//  remapping workarounds due to their tuples being out of sync with their
+//  already broken messages, which we've seen twice.
+//
+// The one kind of broken message that we don't handle yet is when the audio is
+//  completely missing from the game. QFG4 has most of those. In speech-only
+//  mode this means no audio or text and in dual mode the text disappears
+//  quickly as most games use audio length for the message delay. That logic is
+//  in each game's Messager/Narrator/Talker scripts.
+static const SciMessageWorkaroundEntry messageWorkarounds[] = {
+	// game              media             language       room   mod    n    v    c   s    workaround-type          mod    n    v    c   s tlk  idx  len  text
+	// FPFP CD has several message sequences where audio and text were left out of sync - bug #10964
+	//  Some of the texts just say "Dummy Msg" and the real values are concatenated in the first record.
+	// Lever Brothers' intro
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  24,   0,   0,  1, { MSG_WORKAROUND_EXTRACT,  220,  24,   0,   0,  1, 99,   0,  25, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  24,   0,   0,  2, { MSG_WORKAROUND_EXTRACT,  220,  24,   0,   0,  1, 99,  26,  20, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  24,   0,   0,  3, { MSG_WORKAROUND_EXTRACT,  220,  24,   0,   0,  1, 99,  47,  58, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  24,   0,   0,  4, { MSG_WORKAROUND_EXTRACT,  220,  24,   0,   0,  1, 99, 106,  34, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  24,   0,   0,  5, { MSG_WORKAROUND_EXTRACT,  220,  24,   0,   0,  1, 99, 141,  27, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  24,   0,   0,  6, { MSG_WORKAROUND_EXTRACT,  220,  24,   0,   0,  1, 99, 169,  29, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  24,   0,   0,  7, { MSG_WORKAROUND_EXTRACT,  220,  24,   0,   0,  1, 99, 199,  52, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  24,   0,   0,  8, { MSG_WORKAROUND_EXTRACT,  220,  24,   0,   0,  1, 99, 252,  37, NULL } },
+	// Kenny's intro
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  30,   0,   0,  3, { MSG_WORKAROUND_EXTRACT,  220,  30,   0,   0,  3, 99,   0,  14, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  30,   0,   0,  4, { MSG_WORKAROUND_EXTRACT,  220,  30,   0,   0,  3, 99,  15, 245, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  220,  30,   0,   0,  5, { MSG_WORKAROUND_EXTRACT,  220,  30,   0,   0,  4, 99,   0,   0, NULL } },
+	// Helen swatting flies
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  660,  35,   0,   0,  1, { MSG_WORKAROUND_EXTRACT,  660,  35,   0,   0,  1, 53,   0,  42, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  660,  35,   0,   0,  2, { MSG_WORKAROUND_EXTRACT,  660,  35,   0,   0,  1, 53,  43,  93, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  660,  35,   0,   0,  3, { MSG_WORKAROUND_EXTRACT,  660,  35,   0,   0,  1, 53, 137,  72, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  660,  35,   0,   0,  4, { MSG_WORKAROUND_EXTRACT,  660,  35,   0,   0,  2, 53,   0,   0, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  660,  35,   0,   0,  5, { MSG_WORKAROUND_EXTRACT,  660,  35,   0,   0,  1, 53, 210,  57, NULL } },
+	{ GID_FREDDYPHARKAS, SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  660,  35,   0,   0,  6, { MSG_WORKAROUND_EXTRACT,  660,  35,   0,   0,  3, 12,   0,   0, NULL } },
+	// Missing message when clicking flashlight and other items on Magentia in room 290, floppy 1.0 - bug #10782
+	{ GID_GK1,           SCI_MEDIA_FLOPPY, K_LANG_NONE,     -1,  290,   8,   0,  35,  1, { MSG_WORKAROUND_REMAP,    290,   8,   0,   0,  1,  0,   0,   0, NULL } },
+	// Missing message when clicking photocopy of the veve on the artist after giving sketch and original veve in room 410 - bug #10818
+	{ GID_GK1,           SCI_MEDIA_ALL,    K_LANG_NONE,     -1,  410,   3,  48,  31,  1, { MSG_WORKAROUND_REMAP,    410,   3,  24,  31,  1,  0,   0,   0, NULL } },
+	// Missing message when clicking operate on Loreli's right chair in room 420, floppy 1.0 - bug #10820
+	{ GID_GK1,           SCI_MEDIA_FLOPPY, K_LANG_NONE,     -1,  420,   4,   8,   3,  1, { MSG_WORKAROUND_REMAP,    420,   4,   8,   7,  1,  0,   0,   0, NULL } },
+	// Clicking money on Loreli when sitting or dancing in room 420 - bug #10819
+	//  The script transposes sitting vs dancing responses, passes an invalid cond for one of them, and the
+	//  audio36 for the the other has the wrong tuple, which we fix in the audio36 workarounds.
+	{ GID_GK1,           SCI_MEDIA_ALL,    K_LANG_NONE,     -1,  420,   2,  32,   3,  1, { MSG_WORKAROUND_REMAP,    420,   2,  32,   0,  1,  0,   0,   0, NULL } },
+	{ GID_GK1,           SCI_MEDIA_ALL,    K_LANG_NONE,     -1,  420,   2,  32,   0,  1, { MSG_WORKAROUND_REMAP,    420,   2,  32,   2,  1,  0,   0,   0, NULL } },
+	// Asking Yvette about Tut in act 2 party in floppy version - bug #10723
+	//  The last two sequences in this five part message reveal a murder that hasn't occurred yet.
+	//  We skip these as to not spoil the plot, but only in the act 2 rooms, as the message is used
+	//  in later acts where all five parts are appropriate. Sierra fixed this in the CD version by
+	//  creating a new three-sequence message for act 2 to accomplish the same thing.
+	{ GID_LAURABOW2,     SCI_MEDIA_FLOPPY, K_LANG_NONE,    350, 1885,   1,   6,  16,  4, { MSG_WORKAROUND_REMAP,   1885,   1,   6,  16,  6,  0,   0,   0, NULL } },
+	{ GID_LAURABOW2,     SCI_MEDIA_FLOPPY, K_LANG_NONE,    360, 1885,   1,   6,  16,  4, { MSG_WORKAROUND_REMAP,   1885,   1,   6,  16,  6,  0,   0,   0, NULL } },
+	{ GID_LAURABOW2,     SCI_MEDIA_FLOPPY, K_LANG_NONE,    370, 1885,   1,   6,  16,  4, { MSG_WORKAROUND_REMAP,   1885,   1,   6,  16,  6,  0,   0,   0, NULL } },
+	// Missing message when clicking carbon paper on desk lamp in room 550, floppy 1.0 - bug #10706
+	{ GID_LAURABOW2,     SCI_MEDIA_FLOPPY, K_LANG_NONE,     -1,  550,   5,  39,   6,  1, { MSG_WORKAROUND_REMAP,    550,  45,  39,   6,  1,  0,   0,   0, NULL } },
+	// Using the hand icon on Keith in the Blue Room (missing message) - bug #6253
+	{ GID_PQ1,           SCI_MEDIA_ALL,    K_LANG_NONE,     -1,   38,  10,   4,   8,  1, { MSG_WORKAROUND_REMAP,     38,  10,   4,   9,  1,  0,   0,   0, NULL } },
+	// Using the eye icon on Keith in the Blue Room (no message and wrong talker) - bug #6253
+	{ GID_PQ1,           SCI_MEDIA_ALL,    K_LANG_NONE,     -1,   38,  10,   1,   0,  1, { MSG_WORKAROUND_EXTRACT,   38,  10,   1,  13,  1, 99,   0,   0, NULL } },
+	// Talking to Kaspar the shopkeeper - bug #6250
+	{ GID_QFG1VGA,       SCI_MEDIA_ALL,    K_LANG_NONE,     -1,  322,  14,   1,  19,  1, { MSG_WORKAROUND_REMAP,    322,  14,   2,  19,  1,  0,   0,   0, NULL } },
+	// Talking with the Leshy and telling him about "bush in goo" - bug #10137
+	{ GID_QFG4,          SCI_MEDIA_ALL,    K_LANG_NONE,     -1,  579,   0,   0,   0,  1, { MSG_WORKAROUND_REMAP,    579,   0,   1,   0,  1,  0,   0,   0, NULL } },
+	// Examining the statue inventory item from the monastery - bug #10770
+	// The description says "squid-like monster", yet the icon is
+	// clearly an insect. It turned Chief into "an enormous beetle". We
+	// change the phrase to "monstrous insect". This message is text-only.
+	// Note: The German string contains accented characters.
+	//  0x84 "a with diaeresis"
+	//  0x94 "o with diaeresis"
+	{ GID_QFG4,          SCI_MEDIA_ALL,    K_LANG_ENGLISH,  -1,   16,  49,   1,   0,  2, { MSG_WORKAROUND_FAKE,      16,  49,   1,   0,  2, 99,   0,   0, "Carefully wrapped in a shopping bag is the grotesque sculpture of a horrible, monstrous insect." } },
+	{ GID_QFG4,          SCI_MEDIA_ALL,    K_LANG_GERMAN,   -1,   16,  49,   1,   0,  2, { MSG_WORKAROUND_FAKE,      16,  49,   1,   0,  2, 99,   0,   0, "Die groteske Skulptur eines schrecklichen, monstr\x94sen insekts ist sorgf\x84ltig in die Einkaufstasche eingewickelt." } },
+	// The CD edition mangled the Rusalka flowers dialogue. - bug #10849
+	// In the floppy edition, there are 3 lines, the first from
+	// the narrator, then two from Rusalka. The CD edition omits
+	// narration and only has the 3rd text, with the 2nd audio! The
+	// 3rd audio is orphaned but available.
+	// We only restore Rusalka's lines, providing the correct text
+	// for seq:1 to match the audio. We respond to seq:2 requests
+	// with Rusalka's last text. The orphaned audio (seq:3) has its
+	// tuple remapped to seq:2 in an audio workaround below.
+	{ GID_QFG4,          SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  520,   2,  59,   0,  1, { MSG_WORKAROUND_FAKE,     520,   2,  59,   0,  1, 28,   0,   0, "Thank you for the beautiful flowers.  No one has been so nice to me since I can remember." } },
+	{ GID_QFG4,          SCI_MEDIA_CD,     K_LANG_ENGLISH,  -1,  520,   2,  59,   0,  2, { MSG_WORKAROUND_EXTRACT,  520,   2,  59,   0,  1, 28,   0,   0, NULL } },
+	// This fixes the error message shown when speech and subtitles are
+	// enabled simultaneously in SQ4 - the (very) long dialog when Roger
+	// is talking with the aliens is missing - bug #6067.
+	// The missing text is just too big to fit in one speech bubble, and
+	// if it's added here manually and drawn on screen, it's painted over
+	// the entrance in the back where the Sequel Police enters, so it
+	// looks very ugly. Perhaps this is why this particular text is missing,
+	// as the text shown in this screen is very short (one-liners).
+	// Just output an empty string here instead of showing an error.
+	{ GID_SQ4,           SCI_MEDIA_CD,     K_LANG_NONE,     -1,   16,   7,   0,   3,  1, { MSG_WORKAROUND_FAKE,      16,   7,   0,   3,  1,  7,   0,   0, "" } },
+	// Missing message when clicking talk in room 520 - bug #10915
+	{ GID_SQ4,           SCI_MEDIA_CD,     K_LANG_NONE,     -1,  510,  99,   0,   3,  1, { MSG_WORKAROUND_REMAP,    500,  99,   0,   3,  1,  0,   0,   0, NULL } },
+	SCI_MESSAGEWORKAROUNDENTRY_TERMINATOR
+};
+
+// Audio36 workarounds are for when an audio36 resource's tuple is out of sync
+//  with its corresponding message, in which case it can be remapped. Any sync36
+//  resource with the same tuple will also be remapped. Remapping is the only
+//  workaround type available to this table. If a tuple is remapped both here
+//  and in message workarounds, this remapping is used.
+static const SciMessageWorkaroundEntry audio36Workarounds[] = {
+	// game              media             language       room   mod    n    v    c   s    workaround-type          mod    n    v    c   s tlk  idx  len  text
+	// Clicking money on Lorelei when dancing - bug #10819 (see message workarounds above)
+	{ GID_GK1,           SCI_MEDIA_CD,     K_LANG_NONE,     -1,  420,   2,  32,   0,  1, { MSG_WORKAROUND_REMAP,    420,   2,  32,   3,  1,  0,   0,   0, NULL } },
+	// Clicking Look on floor grate in room 510 - bug #10848
+	{ GID_QFG4,          SCI_MEDIA_CD,     K_LANG_NONE,     -1,  510,  23,   1,   0,  1, { MSG_WORKAROUND_REMAP,    510, 199,   1,   0,  1,  0,   0,   0, NULL } },
+	// Clicking flowers on Rusalka - bug #10849 (see message workarounds above)
+	{ GID_QFG4,          SCI_MEDIA_CD,     K_LANG_NONE,     -1,  520,   2,  59,   0,  2, { MSG_WORKAROUND_REMAP,    520,   2,  59,   0,  3,  0,   0,   0, NULL } },
+	SCI_MESSAGEWORKAROUNDENTRY_TERMINATOR
+};
+
+// Sync36 workarounds are for when a sync36 resource's tuple is out of sync with
+//  its corresponding message, in which case it can be remapped. This hasn't
+//  been encountered yet, but remapping solves a similar LB2 sync bug.
+static const SciMessageWorkaroundEntry sync36Workarounds[] = {
+	// game              media             language       room   mod    n    v    c   s    workaround-type          mod    n    v    c   s tlk  idx  len  text
+	// Asking yvette about tut in act 2 is missing a sync resource but a duplicate message has a sync resource - bug #9956
+	{ GID_LAURABOW2,     SCI_MEDIA_CD,     K_LANG_NONE,     -1, 1885,   1,   6,  30,  2, { MSG_WORKAROUND_REMAP,   1885,   1,   6,  10,  2,  0,   0,   0, NULL } },
+	SCI_MESSAGEWORKAROUNDENTRY_TERMINATOR
+};
+
+static SciMessageWorkaroundSolution findMessageWorkaround(int module, byte noun, byte verb, byte cond, byte seq, const SciMessageWorkaroundEntry *workaroundList) {
+	const SciMessageWorkaroundEntry *workaround = workaroundList;
+	while (workaround->solution.type != MSG_WORKAROUND_NONE) {
+		if (workaround->gameId == g_sci->getGameId() &&
+			(workaround->media == SCI_MEDIA_ALL ||
+			(workaround->media == SCI_MEDIA_FLOPPY && !g_sci->isCD()) ||
+			(workaround->media == SCI_MEDIA_CD && g_sci->isCD())) &&
+			(workaround->language == K_LANG_NONE ||
+			workaround->language == g_sci->getSciLanguage()) &&
+			(workaround->roomNumber == -1 ||
+			workaround->roomNumber == g_sci->getEngineState()->currentRoomNumber()) &&
+			workaround->module == module &&
+			workaround->noun == noun &&
+			workaround->verb == verb &&
+			workaround->cond == cond &&
+			workaround->seq == seq) {
+			break;
+		}
+		workaround++;
+	}
+	return workaround->solution;
+}
+
+SciMessageWorkaroundSolution findMessageWorkaround(int module, byte noun, byte verb, byte cond, byte seq) {
+	return findMessageWorkaround(module, noun, verb, cond, seq, messageWorkarounds);
+}
+
+ResourceId remapAudio36ResourceId(const ResourceId &resourceId) {
+	int module = resourceId.getNumber();
+	byte noun = resourceId.getTuple() >> 24;
+	byte verb = (resourceId.getTuple() >> 16) & 0xff;
+	byte cond = (resourceId.getTuple() >> 8) & 0xff;
+	byte seq = resourceId.getTuple() & 0xff;
+
+	SciMessageWorkaroundSolution workaround = findMessageWorkaround(module, noun, verb, cond, seq, audio36Workarounds);
+	if (workaround.type != MSG_WORKAROUND_REMAP) {
+		workaround = findMessageWorkaround(module, noun, verb, cond, seq, messageWorkarounds);
+	}
+
+	if (workaround.type == MSG_WORKAROUND_REMAP) {
+		return ResourceId(resourceId.getType(), workaround.module, workaround.noun, workaround.verb, workaround.cond, workaround.seq);
+	}
+	return resourceId;
+}
+
+ResourceId remapSync36ResourceId(const ResourceId &resourceId) {
+	int module = resourceId.getNumber();
+	byte noun = resourceId.getTuple() >> 24;
+	byte verb = (resourceId.getTuple() >> 16) & 0xff;
+	byte cond = (resourceId.getTuple() >> 8) & 0xff;
+	byte seq = resourceId.getTuple() & 0xff;
+
+	SciMessageWorkaroundSolution workaround = findMessageWorkaround(module, noun, verb, cond, seq, sync36Workarounds);
+	if (workaround.type != MSG_WORKAROUND_REMAP) {
+		workaround = findMessageWorkaround(module, noun, verb, cond, seq, audio36Workarounds);
+	}
+	if (workaround.type != MSG_WORKAROUND_REMAP) {
+		workaround = findMessageWorkaround(module, noun, verb, cond, seq, messageWorkarounds);
+	}
+
+	if (workaround.type == MSG_WORKAROUND_REMAP) {
+		return ResourceId(resourceId.getType(), workaround.module, workaround.noun, workaround.verb, workaround.cond, workaround.seq);
+	}
+	return resourceId;
 }
 
 } // End of namespace Sci

--- a/engines/sci/engine/workarounds.h
+++ b/engines/sci/engine/workarounds.h
@@ -113,6 +113,49 @@ extern const SciWorkaroundEntry kScrollWindowAdd_workarounds[];
 
 extern SciWorkaroundSolution trackOriginAndFindWorkaround(int index, const SciWorkaroundEntry *workaroundList, SciCallOrigin *trackOrigin);
 
+enum SciMessageWorkaroundType {
+	MSG_WORKAROUND_NONE,        // only used by terminator or when no workaround was found
+	MSG_WORKAROUND_REMAP,       // use a different tuple instead
+	MSG_WORKAROUND_FAKE,        // use a hard-coded response
+	MSG_WORKAROUND_EXTRACT      // use text from a different record, optionally a substring
+};
+
+enum SciMedia {
+	SCI_MEDIA_ALL,
+	SCI_MEDIA_FLOPPY,
+	SCI_MEDIA_CD
+};
+
+struct SciMessageWorkaroundSolution {
+	SciMessageWorkaroundType type;
+	int module;
+	byte noun;
+	byte verb;
+	byte cond;
+	byte seq;
+	byte talker;
+	uint32 substringIndex;
+	uint32 substringLength;
+	const char *text;
+};
+
+struct SciMessageWorkaroundEntry {
+	SciGameId gameId;
+	SciMedia media;
+	kLanguage language;
+	int roomNumber;
+	int module;
+	byte noun;
+	byte verb;
+	byte cond;
+	byte seq;
+	SciMessageWorkaroundSolution solution;
+};
+
+extern SciMessageWorkaroundSolution findMessageWorkaround(int module, byte noun, byte verb, byte cond, byte seq);
+extern ResourceId remapAudio36ResourceId(const ResourceId &resourceId);
+extern ResourceId remapSync36ResourceId(const ResourceId &resourceId);
+
 } // End of namespace Sci
 
 #endif // SCI_ENGINE_WORKAROUNDS_H

--- a/engines/sci/resource.cpp
+++ b/engines/sci/resource.cpp
@@ -31,6 +31,7 @@
 #include "common/memstream.h"
 #endif
 
+#include "sci/engine/workarounds.h"
 #include "sci/parser/vocabulary.h"
 #include "sci/resource.h"
 #include "sci/resource_intern.h"
@@ -1134,6 +1135,12 @@ Common::List<ResourceId> ResourceManager::listResources(ResourceType type, int m
 }
 
 Resource *ResourceManager::findResource(ResourceId id, bool lock) {
+	// remap known incorrect audio36 and sync36 resource ids
+	if (id.getType() == kResourceTypeAudio36) {
+		id = remapAudio36ResourceId(id);
+	} else if (id.getType() == kResourceTypeSync36) {
+		id = remapSync36ResourceId(id);
+	}
 	Resource *retval = testResource(id);
 
 	if (!retval)

--- a/engines/sci/resource_audio.cpp
+++ b/engines/sci/resource_audio.cpp
@@ -455,28 +455,6 @@ int ResourceManager::readAudioMapSCI11(IntMapResourceSource *map) {
 				break;
 			}
 
-			// GK1CD has a message whose audio36 resource has the wrong tuple and never plays.
-			//  The message tuple is 420 2 32 0 1 but the audio36 tuple is 420 2 32 3 1. bug #10819
-			if (g_sci->getGameId() == GID_GK1 && g_sci->isCD() &&
-				map->_mapNumber == 420 && n == 0x02200301) {
-				n = 0x02200001;
-			}
-
-			// QFG4CD has a message whose audio36 resource has the wrong tuple and never plays.
-			//  The message tuple is 510 23 1 0 1 but the audio36 tuple is 510 199 1 0 1. bug #10848
-			if (g_sci->getGameId() == GID_QFG4 && g_sci->isCD() &&
-				map->_mapNumber == 510 && n == 0xc7010001) {
-				n = 0x17010001;
-			}
-
-			// QFG4CD has an orphaned audio36 resource that additionally has the wrong tuple.
-			//  The audio36 tuple is 520 2 59 0 3. The message would be 520 2 59 0 2. bug #10849
-			//  We restore the missing message in message.cpp.
-			if (g_sci->getGameId() == GID_QFG4 && g_sci->isCD() &&
-				map->_mapNumber == 520 && n == 0x023b0003) {
-				n = 0x023b0002;
-			}
-
 			if (isEarly) {
 				offset = ptr.getUint32LE();
 				ptr += 4;
@@ -492,14 +470,6 @@ int ResourceManager::readAudioMapSCI11(IntMapResourceSource *map) {
 				// FIXME: The sync36 resource seems to be two bytes too big in KQ6CD
 				// (bytes taken from the RAVE resource right after it)
 				if (syncSize > 0) {
-					// TODO: Add a mechanism to handle cases with missing resources like the ones below
-					//
-					// LB2CD is missing the sync resource for message 1885 1 6 30 2 but it's a duplicate
-					//  of 1885 1 6 16 2 which does have a sync resource so use that for both. bug #9956
-					if (g_sci->getGameId() == GID_LAURABOW2 && map->_mapNumber == 1885 && n == 0x01061002) {
-						addResource(ResourceId(kResourceTypeSync36, map->_mapNumber, 0x01061e02), src, offset, syncSize, map->getLocationName());
-					}
-
 					addResource(ResourceId(kResourceTypeSync36, map->_mapNumber, n & 0xffffff3f), src, offset, syncSize, map->getLocationName());
 				}
 			}


### PR DESCRIPTION
Adds a new workaround system for known broken messages and their
corresponding audio and sync resources. This replaces all special
cases in c++ and several script patches with data structures and
generic handling.

Common message bugs:
- Wrong tuple requested by game script
- Wrong tuple in message resource
- Wrong message text that exists in another record
- Missing message text
- Audio or sync resource with different tuple than message

Some notes:
- I've tested each workaround (whew!)
- The first commit is for a message script patch of mine that should have been an uninitialized parameter workaround from the start. Oops!
- The existing c++ workarounds in getRecord() wouldn't have worked on CD versions since they didn't remap audio tuples, but they happened to all be for floppy versions. Audio remapping is now handled automatically.
- I have a few obscure missing-message bugs that I couldn't justify the c++ or script patches for but I'll happily add them once this is in place
- If there's anything to be done about the KQ7 unfinished messages, this scheme should be flexible enough to use