### PR TITLE
SCI: Fix backend events treated as keyboard events

### DIFF
--- a/engines/sci/event.cpp
+++ b/engines/sci/event.cpp
@@ -253,6 +253,11 @@ SciEvent EventManager::getScummVMEvent() {
 		}
 	}
 
+	// Handle keyboard events for the rest of the function
+	if (ev.type != Common::EVENT_KEYDOWN && ev.type != Common::EVENT_KEYUP) {
+		return noEvent;
+	}
+
 	// Check for Control-Shift-D (debug console)
 	if (ev.type == Common::EVENT_KEYDOWN && ev.kbd.hasFlags(Common::KBD_CTRL | Common::KBD_SHIFT) && ev.kbd.keycode == Common::KEYCODE_d) {
 		// Open debug console


### PR DESCRIPTION
This fixes several backend events being misinterpreted as SCI keyboard events.

The most noticeable is EVENT_SCREEN_CHANGED which gets translated as kSciEventKeyDown. For example, toggling fullscreen during the SQ4 intro will cause the game to prompt if you want to skip the intro. (This isn't due to the ALT+ENTER keys as the backend code claims those events.)

EventManager::getScummVMEvent() is a large function that translates an incoming Common::Event to an SciEvent. First it handles a few misc event types, then mouse events, and finally it does a lot of keyboard event mapping, but it doesn't verify that the event type is keyboard and instead assumes it must be. Non-keyboard events that the function doesn't first explicitly handle bounce around the mapping code and come out as effectively random SCI keydown and keyup events that reach the game.

Other examples are EVENT_WHEELUP, EVENT_WHEELDOWN, and the new EVENT_DROP_FILE. My guess is that all these events appeared after this SCI event code was written. Now keyboard event types are explicitly verified.