### PR TITLE
XEEN: fix result type for readUint32LE()

### DIFF
--- a/engines/xeen/scripts.cpp
+++ b/engines/xeen/scripts.cpp
@@ -48,7 +48,7 @@ uint16 EventParameters::Iterator::readUint16LE() {
 }
 
 uint32 EventParameters::Iterator::readUint32LE() {
-	uint16 result = ((_index + 3) >= _data.size()) ? 0 :
+	uint32 result = ((_index + 3) >= _data.size()) ? 0 :
 		READ_LE_UINT32(&_data[_index]);
 	_index += 4;
 	return result;


### PR DESCRIPTION
uint32 parameters for script commands (e.g. give experience to character) are intermediate stored in a uint16 (`result`), so the 2 high bytes are cut off. This breaks late game behaviour when XP > 65535 is given. The commit corrects the type of the intermediate value.