### PR TITLE
GRAPHICS: Fix ManagedSurface::copyFrom memory and rectangles handling

### DIFF
--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -124,6 +124,17 @@ void ManagedSurface::free() {
 	_offsetFromOwner = Common::Point(0, 0);
 }
 
+void ManagedSurface::copyFrom(const ManagedSurface &surf) {
+	// Surface::copyFrom free pixel pointer so let's free up ManagedSurface to be coherent
+	free();
+
+	_innerSurface.copyFrom(surf._innerSurface);
+	clearDirtyRects();
+
+	// Pixels data is now owned by us
+	_disposeAfterUse = DisposeAfterUse::YES;
+}
+
 bool ManagedSurface::clip(Common::Rect &srcBounds, Common::Rect &destBounds) {
 	if (destBounds.left >= this->w || destBounds.top >= this->h ||
 			destBounds.right <= 0 || destBounds.bottom <= 0)

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -129,7 +129,7 @@ void ManagedSurface::copyFrom(const ManagedSurface &surf) {
 	free();
 
 	_innerSurface.copyFrom(surf._innerSurface);
-	clearDirtyRects();
+	markAllDirty();
 
 	// Pixels data is now owned by us
 	_disposeAfterUse = DisposeAfterUse::YES;

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -307,10 +307,7 @@ public:
 	 * Copy the data from another Surface, reinitializing the
 	 * surface to match the dimensions of the passed surface
 	 */
-	void copyFrom(const ManagedSurface &surf) {
-		clearDirtyRects();
-		_innerSurface.copyFrom(surf._innerSurface);
-	}
+	void copyFrom(const ManagedSurface &surf);
 
 	/**
 	 * Draw a line.


### PR DESCRIPTION
When calling ``ManagedSurface::copyFrom()``, ``_disposeAfterUse`` should be set to
``DisposeAfterUse::YES`` because inner surface frees up old pixels array and creates a new one.

If you don't do this, creating an empty ``ManagedSurface`` through default constructor and then using ``copyFrom()`` on it will lead to memory leak when the ``ManagedSurface`` will be destroyed because it won't call ``Surface::free()`` on it.

In addition I fix a bug on ``copyFrom()`` which should use ``addDirtyRect()`` like ``create()`` does instead of ``clearDirtyRects()``.

I don't think this will break any engine but, in doubt, the engines using ``ManagedSurface::copyFrom()`` seems to be: director, cryomni3d, xeen and access.