### PR TITLE
SCI: Add some more SCI11+ features

### DIFF
--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -781,8 +781,9 @@ void Kernel::loadKernelNames(GameFeatures *features) {
 				_kernelNames[0x84] = "ShowMovie";
 		} else if (g_sci->getGameId() == GID_QFG4DEMO) {
 			_kernelNames[0x7b] = "RemapColors"; // QFG4 Demo has this SCI2 function instead of StrSplit
-		} else if (g_sci->getGameId() == GID_CATDATE) {
+		} else if (_resMan->testResource(ResourceId(kResourceTypeVocab, 184))) {
 			_kernelNames[0x7b] = "RemapColorsKawa";
+			_kernelNames[0x88] = "KawaDbugStr";
 			_kernelNames[0x89] = "KawaHacks";
 		}
 

--- a/engines/sci/engine/kernel.h
+++ b/engines/sci/engine/kernel.h
@@ -412,6 +412,7 @@ reg_t kEmpty(EngineState *s, int argc, reg_t *argv);
 reg_t kStub(EngineState *s, int argc, reg_t *argv);
 reg_t kStubNull(EngineState *s, int argc, reg_t *argv);
 reg_t kKawaHacks(EngineState *s, int argc, reg_t *argv);
+reg_t kKawaDbugStr(EngineState *s, int argc, reg_t *argv);
 
 #ifdef ENABLE_SCI32
 // SCI2 Kernel Functions

--- a/engines/sci/engine/kernel_tables.h
+++ b/engines/sci/engine/kernel_tables.h
@@ -866,6 +866,7 @@ static SciKernelMapEntry s_kernelMap[] = {
 	{ MAP_DUMMY(PlayBack),        SIG_EVERYWHERE,           "(.*)",                  NULL,            NULL },
 	{ MAP_DUMMY(DbugStr),         SIG_EVERYWHERE,           "(.*)",                  NULL,            NULL },
 	// Used in Kawa's SCI11+
+	{ MAP_CALL(KawaDbugStr),      SIG_SCI11, SIGFOR_ALL,    "(.*)",                  NULL,            NULL },
 	{ MAP_CALL(KawaHacks),        SIG_SCI11, SIGFOR_ALL,    "(.*)",                  NULL,            NULL },
 
 	// =======================================================================================================

--- a/engines/sci/engine/kmisc.cpp
+++ b/engines/sci/engine/kmisc.cpp
@@ -30,6 +30,7 @@
 #include "sci/engine/kernel.h"
 #include "sci/engine/gc.h"
 #include "sci/graphics/cursor.h"
+#include "sci/graphics/palette.h"
 #ifdef ENABLE_SCI32
 #include "sci/graphics/cursor32.h"
 #endif
@@ -732,16 +733,32 @@ reg_t kKawaHacks(EngineState *s, int argc, reg_t *argv) {
 		showScummVMDialog(s->_segMan->getString(argv[1]));
 		return NULL_REG;
 	}
-	case 1: // ZaWarudo
-		// Unused, would invert the color palette for the specified range.
-		return NULL_REG;
-	case 2: // SetTitleColors
+	case 1: { // ZaWarudo
+		// Invert the color palette for the specified range.
+		uint16 from = argv[1].toUint16();
+		uint16 to = argv[2].toUint16();
+		Palette pal = g_sci->_gfxPalette16->_sysPalette;
+		for (uint16 i = from; i <= to; i++)
+		{
+			pal.colors[i].r = 255 - pal.colors[i].r;
+			pal.colors[i].g = 255 - pal.colors[i].g;
+			pal.colors[i].b = 255 - pal.colors[i].b;
+		}
+		g_sci->_gfxPalette16->set(&pal, true);
+ 		return NULL_REG;
+	}
+ 	case 2: // SetTitleColors
 		// Unused, would change the colors for plain windows' title bars.
 		return NULL_REG;
 	case 3: // IsDebug
-		// Should return 1 if running with an internal debugger, 2 if we have AddMenu support, 3 if both.
-		return TRUE_REG;
+ 		// Return 1 if running with an internal debugger, 2 if we have AddMenu support, 3 if both.
+		return make_reg(0, 3);
 	}
+	return NULL_REG;
+}
+reg_t kKawaDbugStr(EngineState *s, int argc, reg_t *argv)
+{
+	debug(Common::String::format(s->_segMan->getString(argv[0]).c_str(), argc - 1, argv + 1).c_str());
 	return NULL_REG;
 }
 

--- a/engines/sci/graphics/view.cpp
+++ b/engines/sci/graphics/view.cpp
@@ -833,7 +833,7 @@ void GfxView::draw(const Common::Rect &rect, const Common::Rect &clipRect, const
 						if (g_sci->_gfxRemap16 && g_sci->_gfxRemap16->isRemapped(outputColor))
 							outputColor = g_sci->_gfxRemap16->remapColor(outputColor, _screen->getVisual(x2, y2));
 						// SCI11+ remapping (Catdate)
-						if ((scaleSignal & 0xFF00) && _resMan->testResource(ResourceId(kResourceTypeVocab, 184))) {
+						if ((scaleSignal & 0xFF00) && g_sci->_gfxRemap16 && _resMan->testResource(ResourceId(kResourceTypeVocab, 184))) {
 							if ((scaleSignal >> 8) == 1) // all black
 								outputColor = 0;
 							else if ((scaleSignal >> 8) == 2) // darken
@@ -933,7 +933,7 @@ void GfxView::drawScaled(const Common::Rect &rect, const Common::Rect &clipRect,
 				if (g_sci->_gfxRemap16 && g_sci->_gfxRemap16->isRemapped(outputColor))
 					outputColor = g_sci->_gfxRemap16->remapColor(outputColor, _screen->getVisual(x2, y2));
 				// SCI11+ remapping (Catdate)
-				if ((scaleSignal & 0xFF00) && _resMan->testResource(ResourceId(kResourceTypeVocab, 184))) {
+				if ((scaleSignal & 0xFF00) && g_sci->_gfxRemap16 && _resMan->testResource(ResourceId(kResourceTypeVocab, 184))) {
 					if ((scaleSignal >> 8) == 1) // all black
 						outputColor = 0;
 					else if ((scaleSignal >> 8) == 2) // darken

--- a/engines/sci/graphics/view.cpp
+++ b/engines/sci/graphics/view.cpp
@@ -833,8 +833,14 @@ void GfxView::draw(const Common::Rect &rect, const Common::Rect &clipRect, const
 						if (g_sci->_gfxRemap16 && g_sci->_gfxRemap16->isRemapped(outputColor))
 							outputColor = g_sci->_gfxRemap16->remapColor(outputColor, _screen->getVisual(x2, y2));
 						// SCI11+ remapping (Catdate)
-						if ((scaleSignal & 0x200) && g_sci->_gfxRemap16)
-							outputColor = g_sci->_gfxRemap16->remapColor(253, outputColor);
+						if ((scaleSignal & 0xFF00) && _resMan->testResource(ResourceId(kResourceTypeVocab, 184))) {
+							if ((scaleSignal >> 8) == 1) // all black
+								outputColor = 0;
+							else if ((scaleSignal >> 8) == 2) // darken
+								outputColor = g_sci->_gfxRemap16->remapColor(253, outputColor);
+							else if ((scaleSignal >> 8) == 3) // shadow
+								outputColor = g_sci->_gfxRemap16->remapColor(253, _screen->getVisual(x2, y2));
+						}
 						_screen->putPixel(x2, y2, drawMask, outputColor, priority, 0);
 					}
 				}
@@ -927,8 +933,14 @@ void GfxView::drawScaled(const Common::Rect &rect, const Common::Rect &clipRect,
 				if (g_sci->_gfxRemap16 && g_sci->_gfxRemap16->isRemapped(outputColor))
 					outputColor = g_sci->_gfxRemap16->remapColor(outputColor, _screen->getVisual(x2, y2));
 				// SCI11+ remapping (Catdate)
-				if ((scaleSignal & 0x200) && g_sci->_gfxRemap16)
-					outputColor = g_sci->_gfxRemap16->remapColor(253, outputColor);
+				if ((scaleSignal & 0xFF00) && _resMan->testResource(ResourceId(kResourceTypeVocab, 184))) {
+					if ((scaleSignal >> 8) == 1) // all black
+						outputColor = 0;
+					else if ((scaleSignal >> 8) == 2) // darken
+						outputColor = g_sci->_gfxRemap16->remapColor(253, outputColor);
+					else if ((scaleSignal >> 8) == 3) // shadow
+						outputColor = g_sci->_gfxRemap16->remapColor(253, _screen->getVisual(x2, y2));
+				}
 				_screen->putPixel(x2, y2, drawMask, outputColor, priority, 0);
 			}
 		}

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -614,7 +614,7 @@ void SciEngine::initGraphics() {
 	} else {
 #endif
 		_gfxPalette16 = new GfxPalette(_resMan, _gfxScreen);
-		if (getGameId() == GID_QFG4DEMO || getGameId() == GID_CATDATE)
+		if (getGameId() == GID_QFG4DEMO || _resMan->testResource(ResourceId(kResourceTypeVocab, 184)))
 			_gfxRemap16 = new GfxRemap(_gfxPalette16);
 #ifdef ENABLE_SCI32
 	}


### PR DESCRIPTION
I've been sitting on this for a while, uncertain if I should bother making a PR. I feel like using the text-mode end screen resource's presence instead of the game ID to gate the SCI11+ features might inspire fangame creators as they wouldn't need to get their work added to the detection tables, but on the other hand there are a bunch of interesting SCI11+ features left out of this PR that even The Dating Pool doesn't use. And frankly, one of those features scares me.

No other SCI games use vocab 184 for anything.

So... do what you want, really.