### PR TITLE
GRAPHICS: Fix fully transparent pixel blit

### DIFF
--- a/graphics/transparent_surface.cpp
+++ b/graphics/transparent_surface.cpp
@@ -177,14 +177,17 @@ void doBlitAlphaBlend(byte *ino, byte *outo, uint32 width, uint32 height, uint32
 			for (uint32 j = 0; j < width; j++) {
 
 				uint32 ina = in[kAIndex] * ca >> 8;
-				out[kAIndex] = 255;
-				out[kBIndex] = (out[kBIndex] * (255 - ina) >> 8);
-				out[kGIndex] = (out[kGIndex] * (255 - ina) >> 8);
-				out[kRIndex] = (out[kRIndex] * (255 - ina) >> 8);
 
-				out[kBIndex] = out[kBIndex] + (in[kBIndex] * ina * cb >> 16);
-				out[kGIndex] = out[kGIndex] + (in[kGIndex] * ina * cg >> 16);
-				out[kRIndex] = out[kRIndex] + (in[kRIndex] * ina * cr >> 16);
+				if (ina != 0) {
+					out[kAIndex] = 255;
+					out[kBIndex] = (out[kBIndex] * (255 - ina) >> 8);
+					out[kGIndex] = (out[kGIndex] * (255 - ina) >> 8);
+					out[kRIndex] = (out[kRIndex] * (255 - ina) >> 8);
+
+					out[kBIndex] = out[kBIndex] + (in[kBIndex] * ina * cb >> 16);
+					out[kGIndex] = out[kGIndex] + (in[kGIndex] * ina * cg >> 16);
+					out[kRIndex] = out[kRIndex] + (in[kRIndex] * ina * cr >> 16);
+				}
 
 				in += inStep;
 				out += 4;


### PR DESCRIPTION
This fixes [defect #10686](https://bugs.scummvm.org/ticket/10686), which was first reproduced with an actual game FoxTail on WME, then reduced to a WME testcase https://github.com/tobiatesan/wme_testsuite/tree/master/light_test/packages (you can try it with ScummVM nightly)

In BLEND_NORMAL mode with color != 0xffffffff, blending fully
transparent pixel was resulted in slightly modifying some background
colors, because old value X was a bit different from new value (X*255>>8). This pull request provides a workaround by doing nothing on transparent pixels.

It also raises larger question if it is alright to do other shifts like "in[kAIndex] * ca >> 8", "in[kRIndex] * ina * cr >> 16", "((in[kGIndex] * cg  * (out[kGIndex]) * in[kAIndex]) >> 24" instead of devision by 255, 65025 and ‭16581375‬ in various BLEND_SOMETHING modes.