### PR TITLE
WINTERMUTE: Do not optimize out alpha blits on rotation

### DIFF
--- a/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
@@ -433,7 +433,8 @@ bool BaseSurfaceOSystem::drawSprite(int x, int y, Rect32 *rect, Rect32 *newRect,
 	// But no checking is in place for that yet.
 
 	// Optimize by not doing alpha-blits if we lack alpha
-	if (_alphaType == Graphics::ALPHA_OPAQUE && !transform._alphaDisable) {
+	// If angle is not 0, then transparent regions are added near the corners
+	if (_alphaType == Graphics::ALPHA_OPAQUE && transform._angle == 0) {
 		transform._alphaDisable = true;
 	}
 

--- a/engines/wintermute/base/gfx/osystem/render_ticket.cpp
+++ b/engines/wintermute/base/gfx/osystem/render_ticket.cpp
@@ -117,6 +117,8 @@ void RenderTicket::drawToSurface(Graphics::Surface *_targetSurface) const {
 	if (_owner) {
 		if (_transform._alphaDisable) {
 			src.setAlphaMode(Graphics::ALPHA_OPAQUE);
+		} else if (_transform._angle) {
+			src.setAlphaMode(Graphics::ALPHA_BINARY);
 		} else {
 			src.setAlphaMode(_owner->getAlphaType());
 		}
@@ -149,6 +151,8 @@ void RenderTicket::drawToSurface(Graphics::Surface *_targetSurface, Common::Rect
 	if (_owner) {
 		if (_transform._alphaDisable) {
 			src.setAlphaMode(Graphics::ALPHA_OPAQUE);
+		} else if (_transform._angle) {
+			src.setAlphaMode(Graphics::ALPHA_BINARY);
 		} else {
 			src.setAlphaMode(_owner->getAlphaType());
 		}

--- a/engines/wintermute/base/gfx/osystem/render_ticket.cpp
+++ b/engines/wintermute/base/gfx/osystem/render_ticket.cpp
@@ -118,7 +118,7 @@ void RenderTicket::drawToSurface(Graphics::Surface *_targetSurface) const {
 		if (_transform._alphaDisable) {
 			src.setAlphaMode(Graphics::ALPHA_OPAQUE);
 		} else if (_transform._angle) {
-			src.setAlphaMode(Graphics::ALPHA_BINARY);
+			src.setAlphaMode(Graphics::ALPHA_FULL);
 		} else {
 			src.setAlphaMode(_owner->getAlphaType());
 		}
@@ -152,7 +152,7 @@ void RenderTicket::drawToSurface(Graphics::Surface *_targetSurface, Common::Rect
 		if (_transform._alphaDisable) {
 			src.setAlphaMode(Graphics::ALPHA_OPAQUE);
 		} else if (_transform._angle) {
-			src.setAlphaMode(Graphics::ALPHA_BINARY);
+			src.setAlphaMode(Graphics::ALPHA_FULL);
 		} else {
 			src.setAlphaMode(_owner->getAlphaType());
 		}


### PR DESCRIPTION
This fixes [defect #10684](https://bugs.scummvm.org/ticket/10684): 1-pixel width sprite becomes a big rectangle
if rotation is applied.

Case was originally reproduced with FoxTail game for WME, then reduced
to testcase
https://github.com/tobiatesan/wme_testsuite/tree/master/time_test/packages