### PR TITLE
MSVC: Use determinstic UUIDs for project files

### DIFF
--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -581,7 +581,24 @@ protected:
 	 */
 	std::string createUUID() const;
 
+	/**
+	 * Creates a name-based UUID and returns it in string representation.
+	 *
+	 * @param name Unique name to hash.
+	 * @return A new UUID as string.
+	 */
+	std::string createUUID(const std::string &name) const;
+
 private:
+
+	/**
+	 * Returns the string representation of an existing UUID.
+	 *
+	 * @param uuid 128-bit array.
+	 * @return Existing UUID as string.
+	 */
+	std::string UUIDToString(unsigned char *uuid) const;
+
 	/**
 	 * This creates the engines/plugins_table.h file required for building
 	 * ScummVM.

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -46,7 +46,7 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 	const std::string svmProjectUUID = svmUUID->second;
 	assert(!svmProjectUUID.empty());
 
-	std::string solutionUUID = createUUID();
+	std::string solutionUUID = createUUID(setup.projectName + ".sln");
 
 	std::ofstream solution((setup.outputDir + '/' + setup.projectName + ".sln").c_str());
 	if (!solution)


### PR DESCRIPTION
Do you dread everytime you run create_project, watching as MSVC has to reload the whole solution from scratch, probably messing up your workspace state and losing your open files?

Well, dread no more! This updates create_project so that the project UUIDs are deterministic (instead of changing everytime) between regenerations, so that MSVC can more effectively cache and reload the workspace.

This is done by replacing them with MD5 hashes of the project names, which are effectively unique across the solution, but consistent everytime. I used the Win32 APIs to do it since this is only applicable to MSVC so I didn't think it's worth pulling in a whole md5.cpp for it.