### PR TITLE
WINTERMUTE: Add another variant of White Chamber to detection table

### DIFF
--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -585,8 +585,11 @@ static const WMEGameDescription gameDescriptions[] = {
 	// The Trader of Stories
 	WME_WINENTRY("tradestory", "Demo",
 		WME_ENTRY1s("data.dcp", "0a0b51191636cc8ead89b905281c3218", 40401902), Common::EN_ANY, ADGF_UNSTABLE | ADGF_DEMO, LATEST_VERSION),
-	// the white chamber (multi-language)
-	WME_WINENTRY("twc", "",
+	// the white chamber (Version 1.7 - Definitive Edition) (built 2008.06.26) (multi-language)
+	WME_WINENTRY("twc", "Definitive Edition",
+		WME_ENTRY1s("data.dcp", "325abfaeb5fbfcc30d91296f1390a454", 186451273), Common::UNK_LANG, ADGF_UNSTABLE, LATEST_VERSION),
+	// the white chamber (Version 1.7 - Definitive Edition) (built 2008.06.29) (multi-language)
+	WME_WINENTRY("twc", "Definitive Edition",
 		WME_ENTRY1s("data.dcp", "0011d01142547c61e51ba24dc42b579e", 186451273), Common::UNK_LANG, ADGF_UNSTABLE, LATEST_VERSION),
 	// Vsevolod Prologue (Demo)
 	WME_WINENTRY("vsevolod", "Prologue",


### PR DESCRIPTION
Official downloads page for the White Chamber
(http://www.studiotrophis.com/site/downloads) contains 2 links:
1. Download from IndieDB (thewhitechamber1.7SETUP.exe, 376180149 bytes)
(built 2008.06.29, installed game is detectable by ScummVM)
2. Direct Download (thewhitechamber1.7SETUP - Definitive Edition.exe,
376180083 bytes) (built 2008.06.26, installed game is unknown to
ScummVM)

Both version are called "v1.7 - Definitive Edition".
speech.dcp is different: "german/COMPUT050.ogg" was renamed to
"german/COMPUT050.ogg"
data.dcp & language.dcp content is the same for those versions, except
for timestamps (Wed, 25 Jun 2008 21:01:32 GMT vs Sun, 29 Jun 2008
19:36:33 GMT)

Several questions:
1. Is it alright to list those builds as Common::UNK_LANG ? Should we
change this to 9 records for exact langs: Common::EN_ANY,
Common::FR_FRA, Common::IT_ITA, Common::DE_DEU, Common::CZ_CZE,
Common::RU_RUS,
Common::GR_GRE, Common::PT_POR, Common::PL_POL?
2. Should we provide a fix for "german/COMPUT050.ogg" lookup in version
that was built 2008.06.26 or this must be kept as is?