### PR TITLE
SLUDGE: fix crash in ResourceManager::readResourceNames

### DIFF
--- a/engines/sludge/fileset.cpp
+++ b/engines/sludge/fileset.cpp
@@ -224,8 +224,7 @@ void ResourceManager::readResourceNames(Common::SeekableReadStream *readStream) 
 	_allResourceNames.reserve(numResourceNames);
 
 	for (int fn = 0; fn < numResourceNames; fn++) {
-		_allResourceNames[fn].clear();
-		_allResourceNames[fn] = readString(readStream);
+		_allResourceNames.push_back(readString(readStream));
 		debugC(2, kSludgeDebugDataLoad, "Resource %i: %s", fn, _allResourceNames[fn].c_str());
 	}
 }


### PR DESCRIPTION
```
scummvm: ./common/array.h:192: T& Common::Array<T>::operator[](Common::Array<T>::size_type) [with T = Common::String; Common::Array<T>::size_type = unsigned int]: Assertion `idx < _size' failed.

Thread 1 "scummvm" received signal SIGABRT, Aborted.
0x00007ffff642082f in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff642082f in raise () from /usr/lib/libc.so.6
#1  0x00007ffff640b672 in abort () from /usr/lib/libc.so.6
#2  0x00007ffff640b548 in __assert_fail_base.cold.0 () from /usr/lib/libc.so.6
#3  0x00007ffff6418db6 in __assert_fail () from /usr/lib/libc.so.6
warning: Could not find DWO CU engines/sludge/fileset.dwo(0x9165f29a3fab4d8b) referenced by CU at offset 0x1d65c [in module /usr/bin/scummvm]
#4  0x0000555556c9cc08 in Sludge::ResourceManager::readResourceNames(Common::SeekableReadStream*) () at ./common/array.h:191
warning: Could not find DWO CU engines/sludge/sludger.dwo(0x3d12850526a74514) referenced by CU at offset 0x1d8f4 [in module /usr/bin/scummvm]
#5  0x0000555556ca7db0 in Sludge::initSludge(Common::String const&) () at engines/sludge/sludger.cpp:208
warning: Could not find DWO CU engines/sludge/main_loop.dwo(0xf58b5f383e162178) referenced by CU at offset 0x1d7a8 [in module /usr/bin/scummvm]
#6  0x0000555556ca248c in Sludge::main_loop(Common::String) () at engines/sludge/main_loop.cpp:52
warning: Could not find DWO CU engines/sludge/sludge.dwo(0x6d27872931ca201e) referenced by CU at offset 0x1d4a4 [in module /usr/bin/scummvm]
warning: (Internal error: pc 0x555556c955ab in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555556c95540 in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555556c955ab in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555556c955ab in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555556c955ab in read in CU, but not in symtab.)
#7  0x0000555556c955ac in Sludge::SludgeEngine::run() () at engines/sludge/sludge.cpp:148
warning: (Internal error: pc 0x555556c955ab in read in CU, but not in symtab.)
warning: Could not find DWO CU base/main.dwo(0xac58331e9f286191) referenced by CU at offset 0xd4 [in module /usr/bin/scummvm]
warning: (Internal error: pc 0x555555a2658e in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a257a0 in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a2658e in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a2658e in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a2658e in read in CU, but not in symtab.)
#8  0x0000555555a2658f in runGame(Plugin const*, OSystem&, Common::String const&) () at base/main.cpp:273
warning: (Internal error: pc 0x555555a2658e in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a27d78 in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a27d78 in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a27180 in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a27d78 in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a27d78 in read in CU, but not in symtab.)
warning: (Internal error: pc 0x555555a27d78 in read in CU, but not in symtab.)
#9  0x0000555555a27d79 in scummvm_main () at base/main.cpp:545
warning: (Internal error: pc 0x555555a27d78 in read in CU, but not in symtab.)
#10 0x0000555555a205c3 in main () at backends/platform/sdl/posix/posix-main.cpp:45
```