### PR TITLE
SLUDGE: don't return failure in playMovie [DON'T MERGE]

### DIFF
--- a/engines/sludge/movie.cpp
+++ b/engines/sludge/movie.cpp
@@ -953,7 +953,7 @@ int playMovie(int fileNumber) {
 
 	setPixelCoords(false);
 #endif
-	return 1;
+	return 0;
 }
 
 int stopMovie() {


### PR DESCRIPTION
While playMovie is not implemented yet, it seems a better idea to just skip playing a movie instead of crashing the whole game.