### PR TITLE
SLUDGE: fix crash in FloorManager::setFloorNull

### DIFF
--- a/engines/sludge/floor.cpp
+++ b/engines/sludge/floor.cpp
@@ -116,6 +116,7 @@ void FloorManager::setFloorNull() {
 			delete[] _currentFloor->polygon[i].vertexID;
 			delete[] _currentFloor->matrix[i];
 		}
+		_currentFloor->numPolygons = 0;
 		delete[] _currentFloor->polygon;
 		_currentFloor->polygon = nullptr;
 		delete[] _currentFloor->vertex;


### PR DESCRIPTION
numPolygons wasn't getting reset to 0, so the next invocation was trying to delete non-existent polygons.