### PR TITLE
SLUDGE: fix data file handling with custom encoding setting

### DIFF
--- a/engines/sludge/savedata.cpp
+++ b/engines/sludge/savedata.cpp
@@ -118,7 +118,7 @@ bool CustomSaveHelper::fileToStack(const Common::String &filename, StackHandler 
 
 	if (_saveEncoding) {
 		checker = readStringEncoded(fp);
-		if (checker == UTF8_CHECKER) {
+		if (checker != UTF8_CHECKER) {
 			delete fp;
 			return fatal(LOAD_ERROR "The current file encoding setting does not match the encoding setting used when this file was created:", filename);
 		}


### PR DESCRIPTION
The check was inverted - it failed when everything was alright and succeeded on error...