### PR TITLE
SLUDGE: fix background position not taking camera into account

### DIFF
--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -367,7 +367,7 @@ void GraphicsManager::drawBackDrop() {
 		return;
 	// draw backdrop
 	Graphics::TransparentSurface tmp(_backdropSurface, false);
-	tmp.blit(_renderSurface, 0, 0);
+	tmp.blit(_renderSurface, -_cameraX, -_cameraY);
 }
 
 bool GraphicsManager::loadLightMap(int v) {


### PR DESCRIPTION
When a game sets camera position with aimCamera, the background should move together with all the objects above it.