### PR TITLE
 SDL: Initial implementation of joystick events

### DIFF
--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -142,6 +142,7 @@ protected:
 	virtual bool handleJoyButtonDown(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyButtonUp(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyAxisMotion(SDL_Event &ev, Common::Event &event);
+	virtual bool handleJoyHatMotion(SDL_Event &ev, Common::Event &event);
 	virtual void updateKbdMouse();
 	virtual bool handleKbdMouse(Common::Event &event);
 
@@ -222,6 +223,8 @@ protected:
 	 * window is not focused).
 	 */
 	Common::Event _fakeMouseMove;
+
+	uint8 _lastHatPosition;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/**

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -138,6 +138,7 @@ protected:
 	virtual bool handleMouseButtonDown(SDL_Event &ev, Common::Event &event);
 	virtual bool handleMouseButtonUp(SDL_Event &ev, Common::Event &event);
 	virtual bool handleSysWMEvent(SDL_Event &ev, Common::Event &event);
+	virtual int mapSDLJoystickButtonToOSystem(Uint8 sdlButton);
 	virtual bool handleJoyButtonDown(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyButtonUp(SDL_Event &ev, Common::Event &event);
 	virtual bool handleJoyAxisMotion(SDL_Event &ev, Common::Event &event);
@@ -147,9 +148,12 @@ protected:
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	virtual bool handleJoystickAdded(const SDL_JoyDeviceEvent &event);
 	virtual bool handleJoystickRemoved(const SDL_JoyDeviceEvent &device);
+	virtual int mapSDLControllerButtonToOSystem(Uint8 sdlButton);
 	virtual bool handleControllerButton(const SDL_Event &ev, Common::Event &event, bool buttonUp);
 	virtual bool handleControllerAxisMotion(const SDL_Event &ev, Common::Event &event);
 #endif
+
+	bool shouldGenerateMouseEvents();
 
 	//@}
 

--- a/common/EventMapper.cpp
+++ b/common/EventMapper.cpp
@@ -73,6 +73,12 @@ List<Event> DefaultEventMapper::mapEvent(const Event &ev, EventSource *source) {
 #endif
 	}
 
+	if (ev.type == EVENT_JOYBUTTON_DOWN) {
+		if (ev.joystick.button == JOYSTICK_BUTTON_START || ev.joystick.button == JOYSTICK_BUTTON_GUIDE) {
+			mappedEvent.type = EVENT_MAINMENU;
+		}
+	}
+
 	// if it didn't get mapped, just pass it through
 	if (mappedEvent.type == EVENT_INVALID)
 		mappedEvent = ev;

--- a/common/events.h
+++ b/common/events.h
@@ -86,7 +86,52 @@ enum EventType {
 	EVENT_VIRTUAL_KEYBOARD = 20,
 #endif
 
-	EVENT_DROP_FILE = 23
+	EVENT_DROP_FILE = 23,
+
+	EVENT_JOYAXIS_MOTION = 24,
+	EVENT_JOYBUTTON_DOWN = 25,
+	EVENT_JOYBUTTON_UP = 26
+};
+
+const int16 JOYAXIS_MIN = -32768;
+const int16 JOYAXIS_MAX = 32767;
+
+/**
+ * Data structure for joystick events
+ */
+struct JoystickState {
+	/** The axis for EVENT_JOYAXIS_MOTION events */
+	byte axis;
+	/** The new axis position for EVENT_JOYAXIS_MOTION events */
+	int16 position;
+	/**
+	 * The button index for EVENT_JOYBUTTON_DOWN/UP events
+	 *
+	 * Some of the button indices match well-known game controller
+	 * buttons. See JoystickButton.
+	 */
+	byte button;
+};
+
+/**
+ *  The list named buttons available from a joystick
+ */
+enum JoystickButton {
+	JOYSTICK_BUTTON_A,
+	JOYSTICK_BUTTON_B,
+	JOYSTICK_BUTTON_X,
+	JOYSTICK_BUTTON_Y,
+	JOYSTICK_BUTTON_BACK,
+	JOYSTICK_BUTTON_GUIDE,
+	JOYSTICK_BUTTON_START,
+	JOYSTICK_BUTTON_LEFT_STICK,
+	JOYSTICK_BUTTON_RIGHT_STICK,
+	JOYSTICK_BUTTON_LEFT_SHOULDER,
+	JOYSTICK_BUTTON_RIGHT_SHOULDER,
+	JOYSTICK_BUTTON_DPAD_UP,
+	JOYSTICK_BUTTON_DPAD_DOWN,
+	JOYSTICK_BUTTON_DPAD_LEFT,
+	JOYSTICK_BUTTON_DPAD_RIGHT
 };
 
 typedef uint32 CustomEventType;
@@ -129,6 +174,12 @@ struct Event {
 
 	/* The path of the file or directory dragged to the ScummVM window */
 	Common::String path;
+
+	/**
+	 * Joystick data; only valid for joystick events (EVENT_JOYAXIS_MOTION,
+	 * EVENT_JOYBUTTON_DOWN and EVENT_JOYBUTTON_UP).
+	 */
+	JoystickState joystick;
 
 	Event() : type(EVENT_INVALID), kbdRepeat(false) {
 #ifdef ENABLE_KEYMAPPER

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -132,7 +132,15 @@ public:
 		 * If this feature is supported, then the corresponding MetaEngine *must*
 		 * support the kSupportsListSaves feature.
 		 */
-		kSupportsSavingDuringRuntime
+		kSupportsSavingDuringRuntime,
+
+		/**
+		 * Engine must receive joystick events because the game uses them.
+		 * For engines which have not this feature, joystick events are converted
+		 * to mouse events.
+		 */
+		kSupportsJoystick
+
 	};
 
 

--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -43,7 +43,8 @@ bool PegasusEngine::hasFeature(EngineFeature f) const {
 	return
 		(f == kSupportsRTL)
 		|| (f == kSupportsLoadingDuringRuntime)
-		|| (f == kSupportsSavingDuringRuntime);
+		|| (f == kSupportsSavingDuringRuntime)
+		|| (f == kSupportsJoystick);
 }
 
 bool PegasusEngine::isDemo() const {

--- a/engines/pegasus/input.cpp
+++ b/engines/pegasus/input.cpp
@@ -190,7 +190,7 @@ uint InputDeviceManager::convertJoystickToKey(uint joybutton) {
 		return Common::KEYCODE_TILDE; // Open Inventory Panel
 	case Common::JOYSTICK_BUTTON_RIGHT_SHOULDER:
 		return Common::KEYCODE_KP_MULTIPLY; // Open Biochip Panel
-	case Common::JOYSTICK_BUTTON_START:
+	case Common::JOYSTICK_BUTTON_BACK:
 		return Common::KEYCODE_p; // Pause
 	case Common::JOYSTICK_BUTTON_DPAD_UP:
 		return Common::KEYCODE_UP;

--- a/engines/pegasus/input.cpp
+++ b/engines/pegasus/input.cpp
@@ -175,6 +175,35 @@ void InputDeviceManager::waitInput(const InputBits filter) {
 	}
 }
 
+uint InputDeviceManager::convertJoystickToKey(uint joybutton) {
+	switch (joybutton) {
+	case Common::JOYSTICK_BUTTON_A:
+		return Common::KEYCODE_RETURN; // Action
+	case Common::JOYSTICK_BUTTON_B:
+		// nothing
+		break;
+	case Common::JOYSTICK_BUTTON_X:
+		return Common::KEYCODE_i; // Display Object Info
+	case Common::JOYSTICK_BUTTON_Y:
+		return Common::KEYCODE_t; // Toggle Data Display
+	case Common::JOYSTICK_BUTTON_LEFT_SHOULDER:
+		return Common::KEYCODE_TILDE; // Open Inventory Panel
+	case Common::JOYSTICK_BUTTON_RIGHT_SHOULDER:
+		return Common::KEYCODE_KP_MULTIPLY; // Open Biochip Panel
+	case Common::JOYSTICK_BUTTON_START:
+		return Common::KEYCODE_p; // Pause
+	case Common::JOYSTICK_BUTTON_DPAD_UP:
+		return Common::KEYCODE_UP;
+	case Common::JOYSTICK_BUTTON_DPAD_DOWN:
+		return Common::KEYCODE_DOWN;
+	case Common::JOYSTICK_BUTTON_DPAD_LEFT:
+		return Common::KEYCODE_LEFT;
+	case Common::JOYSTICK_BUTTON_DPAD_RIGHT:
+		return Common::KEYCODE_RIGHT;
+	}
+	return 0;
+}
+
 bool InputDeviceManager::notifyEvent(const Common::Event &event) {
 	if (GUI::GuiManager::instance().isActive()) {
 		// For some reason, the engine hooks in the event system using an EventObserver.
@@ -214,6 +243,16 @@ bool InputDeviceManager::notifyEvent(const Common::Event &event) {
 		// Set the key to up if we have it
 		if (_keyMap.contains(event.kbd.keycode))
 			_keyMap[event.kbd.keycode] = false;
+		break;
+	case Common::EVENT_JOYAXIS_MOTION:
+		break;
+	case Common::EVENT_JOYBUTTON_DOWN:
+		if (_keyMap.contains(convertJoystickToKey(event.joystick.button)))
+			_keyMap[convertJoystickToKey(event.joystick.button)] = true;
+		break;
+	case Common::EVENT_JOYBUTTON_UP:
+		if (_keyMap.contains(convertJoystickToKey(event.joystick.button)))
+			_keyMap[convertJoystickToKey(event.joystick.button)] = false;
 		break;
 	default:
 		break;

--- a/engines/pegasus/input.h
+++ b/engines/pegasus/input.h
@@ -52,6 +52,8 @@ public:
 
 	void pumpEvents();
 
+	uint convertJoystickToKey(uint joybutton);
+
 protected:
 	friend class Common::Singleton<SingletonBaseType>;
 

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -1279,6 +1279,7 @@ void PegasusEngine::showTempScreen(const Common::String &fileName) {
 			case Common::EVENT_LBUTTONUP:
 			case Common::EVENT_RBUTTONUP:
 			case Common::EVENT_KEYDOWN:
+			case Common::EVENT_JOYBUTTON_DOWN:
 				done = true;
 				break;
 			default:


### PR DESCRIPTION
This PR provides the option for engines to receive joystick events from the backend. It's based ResidualVM's joystick handling.

Currently this implements joystick support for The Journeyman Project: Pegasus Prime. The joystick mapping is based on the on the [PlayStation](https://www.giantbomb.com/images/1300-2609821) and [Pippin](https://www.giantbomb.com/images/1300-2609822) versions, with some changes.

All games with joystick support will open the main menu when the start button is pressed.

This PR is not 100% complete. The most notable thing missing is proper handling for analog sticks. Since Pegasus Prime simply uses the analog stick to simulate mouse input, I simply opted to disable passing axis events and let the backend handle it. In the long term though, the joystick to mouse code should be moved into Common, so that it can be used by engines that need it, and the analog stick can still be used for games that need it for other purposes, such as movement in RPGs, or if it's used by the game's scripts, like it is with GrimE. (Plus it means the joystick to mouse code can be shared between backends).

I haven't implemented joystick support for games like Lands of Lore, Eye of the Beholder or Worlds of Xeen since I don't have any of them, however I've decided to open this PR anyway in case any engine authors wanted to take a look.