### PR TITLE
CONFIGURE: Add --enable-all-unstable-engines option

### DIFF
--- a/configure
+++ b/configure
@@ -662,6 +662,16 @@ engine_disable_all() {
 	done
 }
 
+# Enable all unstable engines
+engine_enable_all_unstable() {
+	for engine in $_engines; do
+		engine_build_default=`get_engine_build_default $engine`
+		if test $engine_build_default = no ; then
+			set_var _engine_${engine}_build "yes"
+		fi
+	done
+}
+
 # Disable all unstable engines
 engine_disable_all_unstable() {
 	for engine in $_engines; do
@@ -992,6 +1002,8 @@ Game engines:
   --enable-all-engines     enable all engines, including those which are
                            broken or unsupported
   --disable-all-engines    disable all engines
+  --enable-all-unstable-engines     enable the engines which are
+                                    broken or unsupported
   --disable-all-unstable-engines    disable only the engines which are
                                     broken or unsupported
   --enable-engine=<engine name>[,<engine name>...] enable engine(s) listed
@@ -1455,6 +1467,9 @@ for ac_option in $@; do
 		;;
 	--disable-all-engines)
 		engine_disable_all
+		;;
+	--enable-all-unstable-engines)
+		engine_enable_all_unstable
 		;;
 	--disable-all-unstable-engines)
 		engine_disable_all_unstable


### PR DESCRIPTION
This is useful on RISC OS, as when building on RISC OS, linking fails with a number of `relocation truncated to fit: R_ARM_PC24 against symbol...` errors when the executable size gets too large, so this provides a simple way to split the build.

At some point, I would like to set up a RISC OS builder on the buildbot, if someone else could help with that.