### PR TITLE
WINTERMUTE: Fix Split() method of ext_string

### DIFF
--- a/engines/wintermute/base/scriptables/script_ext_string.cpp
+++ b/engines/wintermute/base/scriptables/script_ext_string.cpp
@@ -303,7 +303,7 @@ bool SXString::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 			uint32 ch = (i == str.size()) ? '\0' : str[i];
 			if (ch =='\0' || delims.contains(ch)) {
 				if (i != start) {
-					parts.push_back(WideString(str.c_str() + start, i - start + 1));
+					parts.push_back(WideString(str.c_str() + start, i - start));
 				} else {
 					parts.push_back(WideString());
 				}


### PR DESCRIPTION
It's hard to believe, but this fixes [bug #10432](https://bugs.scummvm.org/ticket/10432) WME Carol Reed
Mysteries hint system not working.

Carol Reed hint system happen to heavily use line.Split(";") results,
which were wrong by 1 byte (delimeter was appended to result while it
shouldn't be).

I started with decompiling Carol Reed source code, reproducing issue
with a stand-alone test project (which worked with WME and showed [null]
with ScummVM). then minimized it to a minimal testcase:

```
var line = new String("New Goal;Visit Christina at the Art
Museum;1;0;S;;");
var ar = line.Split(";");
if((ar[0] == "New Goal")) { var g = ar[1]; }
```