### PR TITLE
WINTERMUTE: Add workaround for sprite glitch at Rosemary game

### DIFF
--- a/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
@@ -26,6 +26,7 @@
  * Copyright (c) 2011 Jan Nedoma
  */
 
+#include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/base/base_file_manager.h"
 #include "engines/wintermute/base/base_game.h"
 #include "engines/wintermute/base/gfx/osystem/base_surface_osystem.h"
@@ -186,6 +187,25 @@ bool BaseSurfaceOSystem::finishLoad() {
 
 	delete image;
 
+	// Bug #6572 WME: Rosemary - Sprite flaw on going upwards
+	// Some Rosemary sprites have non-fully transparent pixels
+	// In original WME it wasn't seen because sprites were downscaled
+	// Let's set alpha to 0 if it is smaller then some treshold
+	if (BaseEngine::instance().getGameId() == "rosemary" && _filename.hasPrefix("actors") && _surface->format.bytesPerPixel == 4) {
+		uint8 treshold = 16;
+		for (int x = 0; x < _surface->w; x++) {
+			for (int y = 0; y < _surface->h; y++) {
+				uint32 pixel = getPixelAt(_surface, x, y);
+				uint8 r, g, b, a;
+				_surface->format.colorToARGB(pixel, a, r, g, b);
+				if (a > 0 && a < treshold) {
+					uint32 *p = (uint32 *)_surface->getBasePtr(x, y);
+					*p = _surface->format.ARGBToColor(0, 0, 0, 0);
+				}
+			}
+		}
+	}
+
 	_loaded = true;
 
 	return true;
@@ -240,7 +260,6 @@ void BaseSurfaceOSystem::genAlphaMask(Graphics::Surface *surface) {
 
 //////////////////////////////////////////////////////////////////////////
 uint32 BaseSurfaceOSystem::getPixelAt(Graphics::Surface *surface, int x, int y) {
-	warning("BaseSurfaceOSystem::GetPixel - Not ported yet");
 	int bpp = surface->format.bytesPerPixel;
 	/* Here p is the address to the pixel we want to retrieve */
 	uint8 *p = (uint8 *)surface->getBasePtr(x, y);


### PR DESCRIPTION
This kind of fixes https://bugs.scummvm.org/ticket/6572 WME: Rosemary -
Sprite flaw on going upwards

Some Rosemary sprites have non-fully transparent background pixels,
sprites of walking up has LOTS of them. Testing Rosemary walking
character in a test WME game demonstrates some glitches with original
WME as well. However, character sprite is downscaled most of time, and
with original WME it isn't that seen when sprite is downscaled.

This pull request provides a workaround for this case instead of
changing downscaling algorithms:
* if game ID is "rosemary"
* if loaded sprite is from "actors" folder
* if bytesPerPixel is 4
* if some pixel's alpha is between 1 and 15
* set this pixel's alpha to 0