### PR TITLE
BLADERUNNER: Skip videos with Esc key only

### DIFF
--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -1164,7 +1164,7 @@ void BladeRunnerEngine::handleKeyUp(Common::Event &event) {
 		return;
 	}
 
-	if (_vqaIsPlaying && event.kbd.keycode == Common::KEYCODE_ESCAPE) {
+	if (_vqaIsPlaying && (event.kbd.keycode == Common::KEYCODE_ESCAPE || (event.kbd.keycode == Common::KEYCODE_RETURN && event.kbd.flags == 0))) {
 		_vqaStopIsRequested = true;
 		_vqaIsPlaying = false;
 

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -1164,7 +1164,7 @@ void BladeRunnerEngine::handleKeyUp(Common::Event &event) {
 		return;
 	}
 
-	if (_vqaIsPlaying) {
+	if (_vqaIsPlaying && event.kbd.keycode == Common::KEYCODE_ESCAPE) {
 		_vqaStopIsRequested = true;
 		_vqaIsPlaying = false;
 


### PR DESCRIPTION
Previously any keyup event skipped the intro videos (including Shift)