### PR TITLE
TRAVIS: Don't build with gcc on Mac OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,14 @@ branches:
  only:
    - master
 
-compiler:
-  - gcc
-  - clang
-
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      compiler:
+        - gcc
+        - clang
+    - os: osx
+      compiler: clang
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ branches:
 matrix:
   include:
     - os: linux
-      compiler:
-        - gcc
-        - clang
+      compiler: gcc
+    - os: linux
+      compiler: clang
     - os: osx
       compiler: clang
 


### PR DESCRIPTION
gcc on Mac OS X is just a frontend for LLVM.
