### PR TITLE
SDL: Include cursorman.h if OpenGL is disabled

### DIFF
--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -45,8 +45,8 @@
 #include "backends/graphics/surfacesdl/surfacesdl-graphics.h"
 #ifdef USE_OPENGL
 #include "backends/graphics/openglsdl/openglsdl-graphics.h"
-#include "graphics/cursorman.h"
 #endif
+#include "graphics/cursorman.h"
 
 #include <time.h>	// for getTimeAndDate()
 


### PR DESCRIPTION
Currently, the SDL backend only includes cursorman.h if we use OpenGL.
However, the engines that use CursorMan as well as main.ccp and
launcher.cpp include cursorman.h without having OpenGL enabled.

Since cursorman.h doesn't seem to include anything specific to OpenGL
and to improve consistency, this commit disables the check for OpenGL
before including graphics/cursorman.h in the SDL backend.