### PR TITLE
Improve iOS inputs

### DIFF
--- a/backends/platform/ios7/ios7_common.h
+++ b/backends/platform/ios7/ios7_common.h
@@ -40,7 +40,8 @@ enum InputEvent {
 	kInputApplicationSuspended,
 	kInputApplicationResumed,
 	kInputSwipe,
-	kInputTap
+	kInputTap,
+	kInputMainMenu
 };
 
 enum ScreenOrientation {

--- a/backends/platform/ios7/ios7_keyboard.h
+++ b/backends/platform/ios7/ios7_keyboard.h
@@ -35,6 +35,7 @@
 - (UITextView *)inputView;
 - (void)setInputDelegate:(id)delegate;
 - (void)handleKeyPress:(unichar)c;
+- (void)handleMainMenuKey;
 
 - (void)showKeyboard;
 - (void)hideKeyboard;

--- a/backends/platform/ios7/ios7_keyboard.h
+++ b/backends/platform/ios7/ios7_keyboard.h
@@ -26,9 +26,11 @@
 #include <UIKit/UIKit.h>
 #include <UIKit/UITextView.h>
 
+@class TextInputHandler;
+
 @interface SoftKeyboard : UIView<UITextViewDelegate> {
 	id inputDelegate;
-	UITextView *inputView;
+	TextInputHandler *inputView;
 }
 
 - (id)initWithFrame:(CGRect)frame;

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -64,6 +64,8 @@
 		[[[UIBarButtonItem alloc] initWithTitle:@"\u2630" style:UIBarButtonItemStylePlain target:self action:@selector(mainMenuKey)] autorelease],
 		// Escape key
 		[[[UIBarButtonItem alloc] initWithTitle:@"Esc" style:UIBarButtonItemStylePlain target:self action:@selector(escapeKey)] autorelease],
+		// Tab key
+		[[[UIBarButtonItem alloc] initWithTitle:@"Tab" style:UIBarButtonItemStylePlain target:self action:@selector(tabKey)] autorelease],
 		// Return key
 		[[[UIBarButtonItem alloc] initWithTitle:@"\u23ce" style:UIBarButtonItemStylePlain target:self action:@selector(returnKey)] autorelease],
 		// Function keys
@@ -141,6 +143,10 @@
 
 - (void) escapeKey {
 	[softKeyboard handleKeyPress:Common::KEYCODE_ESCAPE];
+}
+
+- (void) tabKey {
+	[softKeyboard handleKeyPress:Common::KEYCODE_TAB];
 }
 
 - (void) fn1Key {

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -21,6 +21,7 @@
  */
 
 #include "backends/platform/ios7/ios7_keyboard.h"
+#include "common/keyboard.h"
 
 @interface UITextInputTraits
 - (void)setAutocorrectionType:(int)type;
@@ -50,6 +51,66 @@
 	//item.leadingBarButtonGroups = @[];
 	//item.trailingBarButtonGroups = @[];
 
+	UIToolbar *toolbar = [[[UIToolbar alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 0.0f, 0.0f)] autorelease];
+	toolbar.barTintColor = keyboard.backgroundColor;
+	toolbar.tintColor = keyboard.tintColor;
+	toolbar.translucent = NO;
+
+	if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+		toolbar.items = @[
+			// GMM button
+			[[[UIBarButtonItem alloc] initWithTitle:@"\u2630" style:UIBarButtonItemStylePlain target:self action:@selector(mainMenuKey)] autorelease],
+			// Escape key
+			[[[UIBarButtonItem alloc] initWithTitle:@"Esc" style:UIBarButtonItemStylePlain target:self action:@selector(escapeKey)] autorelease],
+			// Return key
+			[[[UIBarButtonItem alloc] initWithTitle:@"\u23ce" style:UIBarButtonItemStylePlain target:self action:@selector(returnKey)] autorelease],
+			// Function keys
+			[[[UIBarButtonItem alloc] initWithTitle:@"F1" style:UIBarButtonItemStylePlain target:self action:@selector(fn1Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F2" style:UIBarButtonItemStylePlain target:self action:@selector(fn2Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F3" style:UIBarButtonItemStylePlain target:self action:@selector(fn3Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F4" style:UIBarButtonItemStylePlain target:self action:@selector(fn4Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F5" style:UIBarButtonItemStylePlain target:self action:@selector(fn5Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F6" style:UIBarButtonItemStylePlain target:self action:@selector(fn6Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F7" style:UIBarButtonItemStylePlain target:self action:@selector(fn7Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F8" style:UIBarButtonItemStylePlain target:self action:@selector(fn8Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F9" style:UIBarButtonItemStylePlain target:self action:@selector(fn9Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F10" style:UIBarButtonItemStylePlain target:self action:@selector(fn10Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F11" style:UIBarButtonItemStylePlain target:self action:@selector(fn11Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F12" style:UIBarButtonItemStylePlain target:self action:@selector(fn12Key)] autorelease],
+			// Arrow keys
+			[[[UIBarButtonItem alloc] initWithTitle:@"\u2190" style:UIBarButtonItemStylePlain target:self action:@selector(leftArrowKey)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"\u2191" style:UIBarButtonItemStylePlain target:self action:@selector(upArrowKey)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"\u2192" style:UIBarButtonItemStylePlain target:self action:@selector(rightArrowKey)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"\u2193" style:UIBarButtonItemStylePlain target:self action:@selector(downArrowKey)] autorelease],
+			// Spacer at the end
+			[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil] autorelease],
+		];
+	} else {
+		// There is less space, so only add buttons for keys for which we do not have getsures
+		toolbar.items = @[
+			// Return key
+			[[[UIBarButtonItem alloc] initWithTitle:@"\u23ce" style:UIBarButtonItemStylePlain target:self action:@selector(returnKey)] autorelease],
+			// Function keys
+			[[[UIBarButtonItem alloc] initWithTitle:@"F1" style:UIBarButtonItemStylePlain target:self action:@selector(fn1Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F2" style:UIBarButtonItemStylePlain target:self action:@selector(fn2Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F3" style:UIBarButtonItemStylePlain target:self action:@selector(fn3Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F4" style:UIBarButtonItemStylePlain target:self action:@selector(fn4Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F5" style:UIBarButtonItemStylePlain target:self action:@selector(fn5Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F6" style:UIBarButtonItemStylePlain target:self action:@selector(fn6Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F7" style:UIBarButtonItemStylePlain target:self action:@selector(fn7Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F8" style:UIBarButtonItemStylePlain target:self action:@selector(fn8Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F9" style:UIBarButtonItemStylePlain target:self action:@selector(fn9Key)] autorelease],
+			[[[UIBarButtonItem alloc] initWithTitle:@"F10" style:UIBarButtonItemStylePlain target:self action:@selector(fn10Key)] autorelease],
+//			[[[UIBarButtonItem alloc] initWithTitle:@"F11" style:UIBarButtonItemStylePlain target:self action:@selector(fn11Key)] autorelease],
+//			[[[UIBarButtonItem alloc] initWithTitle:@"F12" style:UIBarButtonItemStylePlain target:self action:@selector(fn12Key)] autorelease],
+			// Spacer at the end
+			[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil] autorelease],
+		];
+	}
+
+	self.inputAccessoryView = toolbar;
+	[toolbar sizeToFit];
+
 	return self;
 }
 
@@ -62,19 +123,95 @@
 }
 
 - (void) upArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:273];
+	[softKeyboard handleKeyPress:Common::KEYCODE_UP];
 }
 
 - (void) downArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:274];
+	[softKeyboard handleKeyPress:Common::KEYCODE_DOWN];
 }
 
 - (void) leftArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:276];
+	[softKeyboard handleKeyPress:Common::KEYCODE_LEFT];
 }
 
 - (void) rightArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:275];
+	[softKeyboard handleKeyPress:Common::KEYCODE_RIGHT];
+}
+
+- (void) mainMenuKey {
+	[softKeyboard handleMainMenuKey];
+}
+
+- (void) escapeKey {
+	[softKeyboard handleKeyPress:Common::KEYCODE_ESCAPE];
+}
+
+- (void) fn1Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F1];
+}
+
+- (void) fn2Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F2];
+}
+
+- (void) fn3Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F3];
+}
+
+- (void) fn4Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F4];
+}
+
+- (void) fn5Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F5];
+}
+
+- (void) fn6Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F6];
+}
+
+- (void) fn7Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F7];
+}
+
+- (void) fn8Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F8];
+}
+
+- (void) fn9Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F9];
+}
+
+- (void) fn10Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F10];
+}
+
+- (void) fn11Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F11];
+}
+
+- (void) fn12Key {
+	[softKeyboard handleKeyPress:Common::KEYCODE_F12];
+}
+
+- (void) leftArrowKey {
+	[softKeyboard handleKeyPress:Common::KEYCODE_LEFT];
+}
+
+- (void) upArrowKey {
+	[softKeyboard handleKeyPress:Common::KEYCODE_UP];
+}
+
+- (void) rightArrowKey {
+	[softKeyboard handleKeyPress:Common::KEYCODE_RIGHT];
+}
+
+- (void) downArrowKey {
+	[softKeyboard handleKeyPress:Common::KEYCODE_DOWN];
+}
+
+- (void) returnKey {
+	[softKeyboard handleKeyPress:Common::KEYCODE_RETURN];
 }
 
 @end
@@ -112,6 +249,10 @@
 
 - (void)handleKeyPress:(unichar)c {
 	[inputDelegate handleKeyPress:c];
+}
+
+- (void)handleMainMenuKey {
+	[inputDelegate handleMainMenuKey];
 }
 
 - (void)showKeyboard {

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -31,9 +31,12 @@
 
 @interface TextInputHandler : UITextView {
 	SoftKeyboard *softKeyboard;
+	UIToolbar *toolbar;
+	UIScrollView *scrollView;
 }
 
 - (id)initWithKeyboard:(SoftKeyboard *)keyboard;
+- (void)updateToolbarSize;
 
 @end
 
@@ -51,67 +54,61 @@
 	//item.leadingBarButtonGroups = @[];
 	//item.trailingBarButtonGroups = @[];
 
-	UIToolbar *toolbar = [[[UIToolbar alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 0.0f, 0.0f)] autorelease];
+	toolbar = [[[UIToolbar alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 0.0f, 0.0f)] autorelease];
 	toolbar.barTintColor = keyboard.backgroundColor;
 	toolbar.tintColor = keyboard.tintColor;
 	toolbar.translucent = NO;
 
-	if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-		toolbar.items = @[
-			// GMM button
-			[[[UIBarButtonItem alloc] initWithTitle:@"\u2630" style:UIBarButtonItemStylePlain target:self action:@selector(mainMenuKey)] autorelease],
-			// Escape key
-			[[[UIBarButtonItem alloc] initWithTitle:@"Esc" style:UIBarButtonItemStylePlain target:self action:@selector(escapeKey)] autorelease],
-			// Return key
-			[[[UIBarButtonItem alloc] initWithTitle:@"\u23ce" style:UIBarButtonItemStylePlain target:self action:@selector(returnKey)] autorelease],
-			// Function keys
-			[[[UIBarButtonItem alloc] initWithTitle:@"F1" style:UIBarButtonItemStylePlain target:self action:@selector(fn1Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F2" style:UIBarButtonItemStylePlain target:self action:@selector(fn2Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F3" style:UIBarButtonItemStylePlain target:self action:@selector(fn3Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F4" style:UIBarButtonItemStylePlain target:self action:@selector(fn4Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F5" style:UIBarButtonItemStylePlain target:self action:@selector(fn5Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F6" style:UIBarButtonItemStylePlain target:self action:@selector(fn6Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F7" style:UIBarButtonItemStylePlain target:self action:@selector(fn7Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F8" style:UIBarButtonItemStylePlain target:self action:@selector(fn8Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F9" style:UIBarButtonItemStylePlain target:self action:@selector(fn9Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F10" style:UIBarButtonItemStylePlain target:self action:@selector(fn10Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F11" style:UIBarButtonItemStylePlain target:self action:@selector(fn11Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F12" style:UIBarButtonItemStylePlain target:self action:@selector(fn12Key)] autorelease],
-			// Arrow keys
-			[[[UIBarButtonItem alloc] initWithTitle:@"\u2190" style:UIBarButtonItemStylePlain target:self action:@selector(leftArrowKey)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"\u2191" style:UIBarButtonItemStylePlain target:self action:@selector(upArrowKey)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"\u2192" style:UIBarButtonItemStylePlain target:self action:@selector(rightArrowKey)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"\u2193" style:UIBarButtonItemStylePlain target:self action:@selector(downArrowKey)] autorelease],
-			// Spacer at the end
-			[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil] autorelease],
-		];
-	} else {
-		// There is less space, so only add buttons for keys for which we do not have getsures
-		toolbar.items = @[
-			// Return key
-			[[[UIBarButtonItem alloc] initWithTitle:@"\u23ce" style:UIBarButtonItemStylePlain target:self action:@selector(returnKey)] autorelease],
-			// Function keys
-			[[[UIBarButtonItem alloc] initWithTitle:@"F1" style:UIBarButtonItemStylePlain target:self action:@selector(fn1Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F2" style:UIBarButtonItemStylePlain target:self action:@selector(fn2Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F3" style:UIBarButtonItemStylePlain target:self action:@selector(fn3Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F4" style:UIBarButtonItemStylePlain target:self action:@selector(fn4Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F5" style:UIBarButtonItemStylePlain target:self action:@selector(fn5Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F6" style:UIBarButtonItemStylePlain target:self action:@selector(fn6Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F7" style:UIBarButtonItemStylePlain target:self action:@selector(fn7Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F8" style:UIBarButtonItemStylePlain target:self action:@selector(fn8Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F9" style:UIBarButtonItemStylePlain target:self action:@selector(fn9Key)] autorelease],
-			[[[UIBarButtonItem alloc] initWithTitle:@"F10" style:UIBarButtonItemStylePlain target:self action:@selector(fn10Key)] autorelease],
-//			[[[UIBarButtonItem alloc] initWithTitle:@"F11" style:UIBarButtonItemStylePlain target:self action:@selector(fn11Key)] autorelease],
-//			[[[UIBarButtonItem alloc] initWithTitle:@"F12" style:UIBarButtonItemStylePlain target:self action:@selector(fn12Key)] autorelease],
-			// Spacer at the end
-			[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil] autorelease],
-		];
-	}
+	toolbar.items = @[
+		// GMM button
+		[[[UIBarButtonItem alloc] initWithTitle:@"\u2630" style:UIBarButtonItemStylePlain target:self action:@selector(mainMenuKey)] autorelease],
+		// Escape key
+		[[[UIBarButtonItem alloc] initWithTitle:@"Esc" style:UIBarButtonItemStylePlain target:self action:@selector(escapeKey)] autorelease],
+		// Return key
+		[[[UIBarButtonItem alloc] initWithTitle:@"\u23ce" style:UIBarButtonItemStylePlain target:self action:@selector(returnKey)] autorelease],
+		// Function keys
+		[[[UIBarButtonItem alloc] initWithTitle:@"F1" style:UIBarButtonItemStylePlain target:self action:@selector(fn1Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F2" style:UIBarButtonItemStylePlain target:self action:@selector(fn2Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F3" style:UIBarButtonItemStylePlain target:self action:@selector(fn3Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F4" style:UIBarButtonItemStylePlain target:self action:@selector(fn4Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F5" style:UIBarButtonItemStylePlain target:self action:@selector(fn5Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F6" style:UIBarButtonItemStylePlain target:self action:@selector(fn6Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F7" style:UIBarButtonItemStylePlain target:self action:@selector(fn7Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F8" style:UIBarButtonItemStylePlain target:self action:@selector(fn8Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F9" style:UIBarButtonItemStylePlain target:self action:@selector(fn9Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F10" style:UIBarButtonItemStylePlain target:self action:@selector(fn10Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F11" style:UIBarButtonItemStylePlain target:self action:@selector(fn11Key)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"F12" style:UIBarButtonItemStylePlain target:self action:@selector(fn12Key)] autorelease],
+		// Arrow keys
+		[[[UIBarButtonItem alloc] initWithTitle:@"\u2190" style:UIBarButtonItemStylePlain target:self action:@selector(leftArrowKey)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"\u2191" style:UIBarButtonItemStylePlain target:self action:@selector(upArrowKey)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"\u2192" style:UIBarButtonItemStylePlain target:self action:@selector(rightArrowKey)] autorelease],
+		[[[UIBarButtonItem alloc] initWithTitle:@"\u2193" style:UIBarButtonItemStylePlain target:self action:@selector(downArrowKey)] autorelease],
+		// Spacer at the end
+		[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil] autorelease],
+	];
 
 	self.inputAccessoryView = toolbar;
 	[toolbar sizeToFit];
 
+	scrollView = [[UIScrollView alloc] init];
+	scrollView.frame = toolbar.frame;
+	scrollView.bounds = toolbar.bounds;
+	scrollView.autoresizingMask = toolbar.autoresizingMask;
+	scrollView.showsVerticalScrollIndicator = false;
+	scrollView.showsHorizontalScrollIndicator = false;
+	toolbar.autoresizingMask = UIViewAutoresizingNone;
+	[scrollView addSubview:toolbar];
+	self.inputAccessoryView = scrollView;
+
 	return self;
+}
+
+- (void)updateToolbarSize {
+	// We need at least a width of 768 pt for the toolbar. If we add more buttons this may need to be increased.
+	toolbar.frame = CGRectMake(0, 0, MAX(768, [[UIScreen mainScreen] bounds].size.width), toolbar.frame.size.height);
+	toolbar.bounds = toolbar.frame;
+	scrollView.contentSize = toolbar.frame.size;
 }
 
 - (NSArray *)keyCommands {
@@ -256,6 +253,7 @@
 }
 
 - (void)showKeyboard {
+	[inputView updateToolbarSize];
 	[inputView becomeFirstResponder];
 }
 

--- a/backends/platform/ios7/ios7_osys_events.cpp
+++ b/backends/platform/ios7/ios7_osys_events.cpp
@@ -389,54 +389,6 @@ void  OSystem_iOS7::handleEvent_keyPressed(Common::Event &event, int keyPressed)
 	int ascii = keyPressed;
 	//printf("key: %i\n", keyPressed);
 
-	// We remap some of the iPhone keyboard keys.
-	// The first ten here are the row of symbols below the numeric keys.
-	switch (keyPressed) {
-	case 45:
-		keyPressed = Common::KEYCODE_F1;
-		ascii = Common::ASCII_F1;
-		break;
-	case 47:
-		keyPressed = Common::KEYCODE_F2;
-		ascii = Common::ASCII_F2;
-		break;
-	case 58:
-		keyPressed = Common::KEYCODE_F3;
-		ascii = Common::ASCII_F3;
-		break;
-	case 59:
-		keyPressed = Common::KEYCODE_F4;
-		ascii = Common::ASCII_F4;
-		break;
-	case 40:
-		keyPressed = Common::KEYCODE_F5;
-		ascii = Common::ASCII_F5;
-		break;
-	case 41:
-		keyPressed = Common::KEYCODE_F6;
-		ascii = Common::ASCII_F6;
-		break;
-	case 36:
-		keyPressed = Common::KEYCODE_F7;
-		ascii = Common::ASCII_F7;
-		break;
-	case 38:
-		keyPressed = Common::KEYCODE_F8;
-		ascii = Common::ASCII_F8;
-		break;
-	case 64:
-		keyPressed = Common::KEYCODE_F9;
-		ascii = Common::ASCII_F9;
-		break;
-	case 34:
-		keyPressed = Common::KEYCODE_F10;
-		ascii = Common::ASCII_F10;
-		break;
-	case 10:
-		keyPressed = Common::KEYCODE_RETURN;
-		ascii = Common::ASCII_RETURN;
-		break;
-	}
 	event.type = Common::EVENT_KEYDOWN;
 	_queuedInputEvent.type = Common::EVENT_KEYUP;
 

--- a/backends/platform/ios7/ios7_osys_events.cpp
+++ b/backends/platform/ios7/ios7_osys_events.cpp
@@ -106,6 +106,12 @@ bool OSystem_iOS7::pollEvent(Common::Event &event) {
 				return false;
 			break;
 
+		case kInputMainMenu:
+			event.type = Common::EVENT_MAINMENU;
+			_queuedInputEvent.type = Common::EVENT_INVALID;
+			_queuedEventTime = getMillis() + kQueuedInputEventDelay;
+			break;
+
 		default:
 			break;
 		}

--- a/backends/platform/ios7/ios7_osys_events.cpp
+++ b/backends/platform/ios7/ios7_osys_events.cpp
@@ -399,63 +399,23 @@ void  OSystem_iOS7::handleEvent_keyPressed(Common::Event &event, int keyPressed)
 }
 
 bool OSystem_iOS7::handleEvent_swipe(Common::Event &event, int direction, int touches) {
-	if (touches == 1) {
+	if (touches == 3) {
 		Common::KeyCode keycode = Common::KEYCODE_INVALID;
-		switch (_screenOrientation) {
-		case kScreenOrientationPortrait:
-			switch ((UIViewSwipeDirection)direction) {
-				case kUIViewSwipeUp:
-					keycode = Common::KEYCODE_UP;
-					break;
-				case kUIViewSwipeDown:
-					keycode = Common::KEYCODE_DOWN;
-					break;
-				case kUIViewSwipeLeft:
-					keycode = Common::KEYCODE_LEFT;
-					break;
-				case kUIViewSwipeRight:
-					keycode = Common::KEYCODE_RIGHT;
-					break;
-				default:
-					return false;
-			}
-			break;
-		case kScreenOrientationLandscape:
-			switch ((UIViewSwipeDirection)direction) {
-				case kUIViewSwipeUp:
-					keycode = Common::KEYCODE_LEFT;
-					break;
-				case kUIViewSwipeDown:
-					keycode = Common::KEYCODE_RIGHT;
-					break;
-				case kUIViewSwipeLeft:
-					keycode = Common::KEYCODE_DOWN;
-					break;
-				case kUIViewSwipeRight:
-					keycode = Common::KEYCODE_UP;
-					break;
-				default:
-					return false;
-			}
-			break;
-		case kScreenOrientationFlippedLandscape:
-			switch ((UIViewSwipeDirection)direction) {
-				case kUIViewSwipeUp:
-					keycode = Common::KEYCODE_RIGHT;
-					break;
-				case kUIViewSwipeDown:
-					keycode = Common::KEYCODE_LEFT;
-					break;
-				case kUIViewSwipeLeft:
-					keycode = Common::KEYCODE_UP;
-					break;
-				case kUIViewSwipeRight:
-					keycode = Common::KEYCODE_DOWN;
-					break;
-				default:
-					return false;
-			}
-			break;
+		switch ((UIViewSwipeDirection)direction) {
+			case kUIViewSwipeUp:
+				keycode = Common::KEYCODE_UP;
+				break;
+			case kUIViewSwipeDown:
+				keycode = Common::KEYCODE_DOWN;
+				break;
+			case kUIViewSwipeLeft:
+				keycode = Common::KEYCODE_LEFT;
+				break;
+			case kUIViewSwipeRight:
+				keycode = Common::KEYCODE_RIGHT;
+				break;
+			default:
+				return false;
 		}
 
 		event.kbd.keycode = _queuedInputEvent.kbd.keycode = keycode;

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -1066,6 +1066,10 @@ uint getSizeNextPOT(uint size) {
 	}
 }
 
+- (void)handleMainMenuKey {
+	[self addEvent:InternalEvent(kInputMainMenu, 0, 0)];
+}
+
 - (void)applicationSuspend {
 	[self addEvent:InternalEvent(kInputApplicationSuspended, 0, 0)];
 }

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -349,18 +349,7 @@ uint getSizeNextPOT(uint size) {
 }
 
 - (void)setupGestureRecognizers {
-	const NSUInteger KEYBOARDSWIPETOUCHCOUNT = 3;
-	UISwipeGestureRecognizer *swipeUpKeyboard = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(keyboardSwipeUp:)];
-	swipeUpKeyboard.direction = UISwipeGestureRecognizerDirectionUp;
-	swipeUpKeyboard.numberOfTouchesRequired = KEYBOARDSWIPETOUCHCOUNT;
-	swipeUpKeyboard.delaysTouchesBegan = NO;
-	swipeUpKeyboard.delaysTouchesEnded = NO;
-
-	UISwipeGestureRecognizer *swipeDownKeyboard = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(keyboardSwipeDown:)];
-	swipeDownKeyboard.direction = UISwipeGestureRecognizerDirectionDown;
-	swipeDownKeyboard.numberOfTouchesRequired = KEYBOARDSWIPETOUCHCOUNT;
-	swipeDownKeyboard.delaysTouchesBegan = NO;
-	swipeDownKeyboard.delaysTouchesEnded = NO;
+	UIPinchGestureRecognizer *pinchKeyboard = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(keyboardPinch:)];
 
 	UISwipeGestureRecognizer *swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeRight:)];
 	swipeRight.direction = UISwipeGestureRecognizerDirectionRight;
@@ -386,26 +375,56 @@ uint getSizeNextPOT(uint size) {
 	swipeDown.delaysTouchesBegan = NO;
 	swipeDown.delaysTouchesEnded = NO;
 
+	UISwipeGestureRecognizer *swipeRight3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeRight:)];
+	swipeRight3.direction = UISwipeGestureRecognizerDirectionRight;
+	swipeRight3.numberOfTouchesRequired = 3;
+	swipeRight3.delaysTouchesBegan = NO;
+	swipeRight3.delaysTouchesEnded = NO;
+
+	UISwipeGestureRecognizer *swipeLeft3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeLeft:)];
+	swipeLeft3.direction = UISwipeGestureRecognizerDirectionLeft;
+	swipeLeft3.numberOfTouchesRequired = 3;
+	swipeLeft3.delaysTouchesBegan = NO;
+	swipeLeft3.delaysTouchesEnded = NO;
+
+	UISwipeGestureRecognizer *swipeUp3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeUp:)];
+	swipeUp3.direction = UISwipeGestureRecognizerDirectionUp;
+	swipeUp3.numberOfTouchesRequired = 3;
+	swipeUp3.delaysTouchesBegan = NO;
+	swipeUp3.delaysTouchesEnded = NO;
+
+	UISwipeGestureRecognizer *swipeDown3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeDown:)];
+	swipeDown3.direction = UISwipeGestureRecognizerDirectionDown;
+	swipeDown3.numberOfTouchesRequired = 3;
+	swipeDown3.delaysTouchesBegan = NO;
+	swipeDown3.delaysTouchesEnded = NO;
+
 	UITapGestureRecognizer *doubleTapTwoFingers = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersDoubleTap:)];
 	doubleTapTwoFingers.numberOfTapsRequired = 2;
 	doubleTapTwoFingers.numberOfTouchesRequired = 2;
 	doubleTapTwoFingers.delaysTouchesBegan = NO;
 	doubleTapTwoFingers.delaysTouchesEnded = NO;
 
-	[self addGestureRecognizer:swipeUpKeyboard];
-	[self addGestureRecognizer:swipeDownKeyboard];
+	[self addGestureRecognizer:pinchKeyboard];
 	[self addGestureRecognizer:swipeRight];
 	[self addGestureRecognizer:swipeLeft];
 	[self addGestureRecognizer:swipeUp];
 	[self addGestureRecognizer:swipeDown];
+	[self addGestureRecognizer:swipeRight3];
+	[self addGestureRecognizer:swipeLeft3];
+	[self addGestureRecognizer:swipeUp3];
+	[self addGestureRecognizer:swipeDown3];
 	[self addGestureRecognizer:doubleTapTwoFingers];
 
-	[swipeUpKeyboard release];
-	[swipeDownKeyboard release];
+	[pinchKeyboard release];
 	[swipeRight release];
 	[swipeLeft release];
 	[swipeUp release];
 	[swipeDown release];
+	[swipeRight3 release];
+	[swipeLeft3 release];
+	[swipeUp3 release];
+	[swipeDown3 release];
 	[doubleTapTwoFingers release];
 }
 
@@ -1030,12 +1049,11 @@ uint getSizeNextPOT(uint size) {
 	_secondTouch = nil;
 }
 
-- (void)keyboardSwipeUp:(UISwipeGestureRecognizer *)recognizer {
-	[self showKeyboard];
-}
-
-- (void)keyboardSwipeDown:(UISwipeGestureRecognizer *)recognizer {
-	[self hideKeyboard];
+- (void)keyboardPinch:(UIPinchGestureRecognizer *)recognizer {
+	if ([recognizer scale] < 0.8)
+		[self showKeyboard];
+	else if ([recognizer scale] > 1.25)
+		[self hideKeyboard];
 }
 
 - (void)twoFingersSwipeRight:(UISwipeGestureRecognizer *)recognizer {
@@ -1052,6 +1070,22 @@ uint getSizeNextPOT(uint size) {
 
 - (void)twoFingersSwipeDown:(UISwipeGestureRecognizer *)recognizer {
 	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeDown, 2)];
+}
+
+- (void)threeFingersSwipeRight:(UISwipeGestureRecognizer *)recognizer {
+	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeRight, 3)];
+}
+
+- (void)threeFingersSwipeLeft:(UISwipeGestureRecognizer *)recognizer {
+	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeLeft, 3)];
+}
+
+- (void)threeFingersSwipeUp:(UISwipeGestureRecognizer *)recognizer {
+	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeUp, 3)];
+}
+
+- (void)threeFingersSwipeDown:(UISwipeGestureRecognizer *)recognizer {
+	[self addEvent:InternalEvent(kInputSwipe, kUIViewSwipeDown, 3)];
 }
 
 - (void)twoFingersDoubleTap:(UITapGestureRecognizer *)recognizer {


### PR DESCRIPTION
I am submitting this as a Pull Request to see if others have feedback before I merge this. I am in particular looking for feedback from iPhone users since I only have an iPad, and was only able to test iPhone using the simulator. I am planning to leave it open for one week and then merge.

The first commit adds an input accessory view to the keyboard, which allows to add one row of buttons. <del>Due to widths limitation, less buttons are added on iPhone than iPad.</del> _A scrollview is used so that we can have more buttons than fits the screen._
* iPad _and iPhone_
  * Main Menu button
  * Escape key
  * _Tab key_
  * Return key
  * F1 to F12 keys
  * Arrow keys
* <del>iPhone</del>
  * <del>Return key</del>
  * <del>F1 to F10 keys</del>

Here is a screenshot for iPad:
![ipad_keyboard](https://user-images.githubusercontent.com/552105/59982454-a85cbc80-960a-11e9-8b86-32ea6f717dec.png)

The second commit removes the mapping of some keys to the return and F1 to F10 keys since those are now available in the keyboard. In particular this removes the mapping of the `dash` character to `F1` and fixes [bug #10314: LSL7: Unable to open Xqwsts’ locker on iOS](https://bugs.scummvm.org/ticket/10314).

The third commit change the gesture to show and hide the keyboard from a three finger swipe up/down to a pinch in/out. This allows to map the three finger swipes gesture to arrow keys instead. This fixes [bug #5914: swipe to simulate arrow keys doesn't work](https://bugs.scummvm.org/ticket/5914). One finger swipes are not available as this conflicts with moving the cursor in touchpad mode.