### PR TITLE
WIN32: Make use of the window handle when calling ShellExecute.

### DIFF
--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -136,7 +136,7 @@ bool OSystem_Win32::displayLogFile() {
 
 	// Try opening the log file with the default text editor
 	// log files should be registered as "txtfile" by default and thus open in the default text editor
-	HINSTANCE shellExec = ShellExecute(NULL, NULL, _logFilePath.c_str(), NULL, NULL, SW_SHOWNORMAL);
+	HINSTANCE shellExec = ShellExecute(getHwnd(), NULL, _logFilePath.c_str(), NULL, NULL, SW_SHOWNORMAL);
 	if ((intptr_t)shellExec > 32)
 		return true;
 
@@ -169,7 +169,7 @@ bool OSystem_Win32::displayLogFile() {
 }
 
 bool OSystem_Win32::openUrl(const Common::String &url) {
-	HINSTANCE result = ShellExecute(NULL, NULL, /*(wchar_t*)nativeFilePath.utf16()*/url.c_str(), NULL, NULL, SW_SHOWNORMAL);
+	HINSTANCE result = ShellExecute(getHwnd(), NULL, /*(wchar_t*)nativeFilePath.utf16()*/url.c_str(), NULL, NULL, SW_SHOWNORMAL);
 	// ShellExecute returns a value greater than 32 if successful
 	if ((intptr_t)result <= 32) {
 		warning("ShellExecute failed: error = %p", (void*)result);

--- a/backends/platform/sdl/win32/win32.h
+++ b/backends/platform/sdl/win32/win32.h
@@ -24,6 +24,7 @@
 #define PLATFORM_SDL_WIN32_H
 
 #include "backends/platform/sdl/sdl.h"
+#include "backends/platform/sdl/win32/win32-window.h"
 
 class OSystem_Win32 : public OSystem_SDL {
 public:
@@ -61,6 +62,8 @@ protected:
 	// Override createAudioCDManager() to get our Mac-specific
 	// version.
 	virtual AudioCDManager *createAudioCDManager();
+	
+	HWND getHwnd() { return ((SdlWindow_Win32*)_window)->getHwnd(); }
 };
 
 #endif


### PR DESCRIPTION
It's generally good practice to provide the window handle when you have one.