### PR TITLE
SCI32: Fix Scaler assert on 1 pixel wide Rects

### DIFF
--- a/engines/sci/graphics/celobj32.cpp
+++ b/engines/sci/graphics/celobj32.cpp
@@ -168,7 +168,7 @@ struct SCALER_Scale {
 	_row(nullptr),
 #ifndef NDEBUG
 	_minX(targetRect.left),
-	_maxX(targetRect.right - 1),
+	_maxX(targetRect.right),
 #endif
 	// The maximum width of the scaled object may not be as wide as the source
 	// data it requires if downscaling, so just always make the reader


### PR DESCRIPTION
This fixes a bug in the SCI32 cel scaling code that fails an assertion in debug builds in the swamp on QFG4 floppy,  bug #10765.

Floppy versions are crashing when drawing cel 0 from any loop in view 535 of hands rising from the swamp.

The cel that's crashing is a 1x1 transparent pixel. Each loop starts with a cel like that.

The reason this has only been happening in floppy is GameFeature::hasEmptyScaleDrawHack():

```
inline bool hasEmptyScaleDrawHack() const {
	// Yes: KQ7 (all), PQ4CD, QFG4CD, SQ6, Phant1
	// No: All SCI2, all SCI3, GK2, LSL6hires, PQ:SWAT, Torin
	// Unknown: Hoyle5, MGDX, Shivers
	const SciGameId &gid = g_sci->getGameId();
	return getSciVersion() > SCI_VERSION_2 &&
		getSciVersion() < SCI_VERSION_2_1_LATE &&
		gid != GID_LSL6HIRES &&
		gid != GID_GK2 &&
		gid != GID_PQSWAT &&
		gid != GID_TORIN;
}

```
This returns true for QFG4 CD and false for floppy. If true then scaling is skipped if the target rectangle's left and right or top and bottom are equal, but it's that condition that the scaling code asserts on, and so hasEmptyScaleDrawHack has masked the bug from the CD version.

From the SCALER_Scale constructor:
```

	_minX(targetRect.left),
	_maxX(targetRect.right - 1),
	
	...
	assert(_minX <= _maxX);
```

Subtracting one makes the assertion fail when left == right, which is the case for 1 pixel wide BR-exclusive Rects like ScummVM's. Subtracting one would be correct for BR-inclusive Rects like Sierra's.

_minX and _maxX are only included in debug builds and only used for this and two other asserts.