### PR TITLE
WINTERMUTE: Increase window title viewport height by 1 for "5 Lethal Demons" game

### DIFF
--- a/engines/wintermute/ui/ui_window.cpp
+++ b/engines/wintermute/ui/ui_window.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "engines/wintermute/base/base_game.h"
+#include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/base/base_parser.h"
 #include "engines/wintermute/base/base_active_rect.h"
 #include "engines/wintermute/base/base_dynamic_buffer.h"
@@ -602,6 +603,13 @@ bool UIWindow::loadBuffer(char *buffer, bool complete) {
 	if (cmd == PARSERR_GENERIC) {
 		_gameRef->LOG(0, "Error loading WINDOW definition");
 		return STATUS_FAILED;
+	}
+
+	// HACK: Increase window title height by 1 for "5 Lethal Demons" game
+	// For some reason getFontHeight() is off-by-one comparing to height set in TITLE_RECT,
+	// Which made text being bigger then title rect and drawing was skipped.
+	if (BaseEngine::instance().getGameId() == "5ld" && !_titleRect.isRectEmpty() && _text) {
+		_titleRect.bottom ++;
 	}
 
 	correctSize();


### PR DESCRIPTION
For some reason getFontHeight() is off-by-one comparing to height set in
TITLE_RECT, which made text being bigger then title rect and drawing was
skipped.

Which means, either game author was wrong by 1 and original Wintermute was more tolerant to off-by-one errors, or something is wrong with getFontHeight(). As there are no reports of bugs related to wrong font height, I believe the issue is with this one game, not the graphics\fonts\ttf.cpp.

So, let's provide a quick workaround for this game.

This fixes https://bugs.scummvm.org/ticket/6501