### PR TITLE
WINTERMUTE: Implement Game.OpenDocument() method

### DIFF
--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -1657,7 +1657,8 @@ bool BaseGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 	// OpenDocument
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "OpenDocument") == 0) {
-		stack->correctParams(0);
+		stack->correctParams(1);
+		g_system->openUrl(stack->pop()->getString());
 		stack->pushNULL();
 		return STATUS_OK;
 	}


### PR DESCRIPTION
Game.OpenDocument() is used to open links for developer's site or social
account in games like hellavuday, 5ld, etc.