### PR TITLE
SCI32: Fix kShakeScreen32 parameter count check

### DIFF
--- a/engines/sci/engine/kgraphics32.cpp
+++ b/engines/sci/engine/kgraphics32.cpp
@@ -155,7 +155,17 @@ reg_t kSetCursor32(EngineState *s, int argc, reg_t *argv) {
 }
 
 reg_t kShakeScreen32(EngineState *s, int argc, reg_t *argv) {
-	g_sci->_gfxFrameout->shakeScreen(argv[0].toSint16(), (ShakeDirection)argv[1].toSint16());
+	int16 shakeCount = argv[0].toSint16();
+
+	// SSCI didn't check the parameter count and assumed a direction parameter
+	//  was always passed. This parameter was optional in SCI16 and at least GK1
+	//  and QFG4 scripts continued to not pass it. This would shake in a random
+	//  direction depending on whatever happened to be in memory, or not at all.
+	//  We treat direction as optional with a a vertical default as in SCI16 as
+	//  that's what the scripts expect.
+	ShakeDirection directions = (argc > 1) ? (ShakeDirection)argv[1].toSint16() : kShakeVertical;
+
+	g_sci->_gfxFrameout->shakeScreen(shakeCount, directions);
 	return s->r_acc;
 }
 


### PR DESCRIPTION
kShakeScreen32's kernel signature allows its second parameter to be optional but the implementation doesn't check and always attempts to use it, in which case the shake direction is determined by random memory.

At least GK1 and QFG4 have scripts that don't pass direction. In SCI16 the optional direction parameter defaulted to vertical.

Using random memory is a technically accurate SCI32 implementation! =) I checked the disassembly of GK1 floppy, QFG4 CD, and GK2 and they don't validate parameter count. I tested in DOSBox and indeed these scenes randomly shake vertical, horizontal, diagonal, or not at all. (SCI 3 replaced ShakeScreen with a stub.)

This restores the default vertical parameter value as it was in SCI16, which is what the scripts expect. The alternative would be to make the direction parameter mandatory in the kernel signatures and maintain a workaround table and entry for every call site, but that seems like overkill, especially since you'd always want to just proceed with a vertical shake. I don't know if this was an accidental omission during the c++ conversion or if it was intentional and the script programmers didn't get the memo, but it's the same result.

Interestingly, the one script that does this in GK1 was disabled in the CD version, but only the part that calls ShakeScreen, so maybe the out of bounds read caused a problem at least once.