### PR TITLE
WINTERMUTE: Improve Hamlet game support

### DIFF
--- a/common/language.cpp
+++ b/common/language.cpp
@@ -56,6 +56,7 @@ const LanguageDescription g_languages[] = {
 	{    "sk", "sk_SK", "Slovak", SK_SVK },
 	{    "es", "es_ES", "Spanish", ES_ESP },
 	{    "se", "sv_SE", "Swedish", SE_SWE },
+	{    "tr", "tr_TR", "Turkish", TR_TUR },
 	{    "uk", "uk_UA", "Ukrainian", UA_UKR },
 	{ nullptr, nullptr, nullptr, UNK_LANG }
 };

--- a/common/language.h
+++ b/common/language.h
@@ -61,6 +61,7 @@ enum Language {
 	SK_SVK,
 	ES_ESP,
 	SE_SWE,
+	TR_TUR,
 	UA_UKR,
 
 	UNK_LANG = -1	// Use default language (i.e. none specified)

--- a/engines/wintermute/base/base_file_manager.cpp
+++ b/engines/wintermute/base/base_file_manager.cpp
@@ -324,6 +324,9 @@ bool BaseFileManager::hasFile(const Common::String &filename) {
 		int slot = atoi(filename.c_str() + 9);
 		return pm.getSaveExists(slot);
 	}
+	if (sfmFileExists(filename)) {
+		return true;
+	}
 	if (diskFileExists(filename)) {
 		return true;
 	}
@@ -392,6 +395,11 @@ Common::SeekableReadStream *BaseFileManager::openFileRaw(const Common::String &f
 			ret = saveThumbFile->getMemStream();
 		}
 		delete saveThumbFile;
+		return ret;
+	}
+
+	ret = openSfmFile(filename);
+	if (ret) {
 		return ret;
 	}
 

--- a/engines/wintermute/base/base_file_manager.cpp
+++ b/engines/wintermute/base/base_file_manager.cpp
@@ -29,6 +29,7 @@
 #include "engines/wintermute/base/base_file_manager.h"
 #include "engines/wintermute/base/base_persistence_manager.h"
 #include "engines/wintermute/base/file/base_disk_file.h"
+#include "engines/wintermute/base/file/base_savefile_manager_file.h"
 #include "engines/wintermute/base/file/base_save_thumb_file.h"
 #include "engines/wintermute/base/file/base_package.h"
 #include "engines/wintermute/base/base_engine.h"
@@ -355,6 +356,17 @@ Common::SeekableReadStream *BaseFileManager::openFile(const Common::String &file
 
 
 //////////////////////////////////////////////////////////////////////////
+Common::WriteStream *BaseFileManager::openFileForWrite(const Common::String &filename) {
+	if (strcmp(filename.c_str(), "") == 0) {
+		return nullptr;
+	}
+	debugC(kWintermuteDebugFileAccess, "Open file %s for write", filename.c_str());
+
+	return openFileForWriteRaw(filename);
+}
+
+
+//////////////////////////////////////////////////////////////////////////
 bool BaseFileManager::closeFile(Common::SeekableReadStream *File) {
 	for (uint32 i = 0; i < _openFiles.size(); i++) {
 		if (_openFiles[i] == File) {
@@ -396,6 +408,19 @@ Common::SeekableReadStream *BaseFileManager::openFileRaw(const Common::String &f
 	if (!_detectionMode) {
 		ret = _resources->createReadStreamForMember(filename);
 	}
+	if (ret) {
+		return ret;
+	}
+
+	debugC(kWintermuteDebugFileAccess ,"BFileManager::OpenFileRaw - Failed to open %s", filename.c_str());
+	return nullptr;
+}
+
+//////////////////////////////////////////////////////////////////////////
+Common::WriteStream *BaseFileManager::openFileForWriteRaw(const Common::String &filename) {
+	Common::WriteStream *ret = nullptr;
+
+	ret = openSfmFileForWrite(filename);
 	if (ret) {
 		return ret;
 	}

--- a/engines/wintermute/base/base_file_manager.h
+++ b/engines/wintermute/base/base_file_manager.h
@@ -44,6 +44,7 @@ public:
 	bool hasFile(const Common::String &filename);
 	int listMatchingMembers(Common::ArchiveMemberList &list, const Common::String &pattern);
 	Common::SeekableReadStream *openFile(const Common::String &filename, bool absPathWarning = true, bool keepTrackOf = true);
+	Common::WriteStream *openFileForWrite(const Common::String &filename);
 	byte *readWholeFile(const Common::String &filename, uint32 *size = nullptr, bool mustExist = true);
 
 	BaseFileManager(Common::Language lang, bool detectionMode = false);
@@ -62,6 +63,7 @@ private:
 	bool registerPackages();
 	void initResources();
 	Common::SeekableReadStream *openFileRaw(const Common::String &filename);
+	Common::WriteStream *openFileForWriteRaw(const Common::String &filename);
 	Common::SeekableReadStream *openPkgFile(const Common::String &filename);
 	Common::FSList _packagePaths;
 	bool registerPackage(Common::FSNode package, const Common::String &filename = "", bool searchSignature = false);

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -2297,7 +2297,7 @@ ScValue *BaseGame::scGetProperty(const Common::String &name) {
 	// SaveDirectory (RO)
 	//////////////////////////////////////////////////////////////////////////
 	else if (name == "SaveDirectory") {
-		AnsiString dataDir = "saves/";	// TODO: This is just to avoid telling the engine actual paths.
+		AnsiString dataDir = "saves"; // See also: SXDirectory::scGetProperty("TempDirectory")
 		_scValue->setString(dataDir.c_str());
 		return _scValue;
 	}

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -105,6 +105,7 @@ BaseGame::BaseGame(const Common::String &targetName) : BaseObject(this), _target
 	_keyboardState = nullptr;
 
 	_mathClass = nullptr;
+	_directoryClass = nullptr;
 
 	_debugLogFile = nullptr;
 	_debugDebugMode = false;
@@ -244,6 +245,7 @@ BaseGame::~BaseGame() {
 	delete _cachedThumbnail;
 
 	delete _mathClass;
+	delete _directoryClass;
 
 	delete _transMgr;
 	delete _scEngine;
@@ -261,6 +263,7 @@ BaseGame::~BaseGame() {
 	_cachedThumbnail = nullptr;
 
 	_mathClass = nullptr;
+	_directoryClass = nullptr;
 
 	_transMgr = nullptr;
 	_scEngine = nullptr;
@@ -415,6 +418,11 @@ bool BaseGame::initialize1() {
 			break;
 		}
 
+		_directoryClass = makeSXDirectory(this);
+		if (_directoryClass == nullptr) {
+			break;
+		}
+
 #if EXTENDED_DEBUGGER_ENABLED
 		_scEngine = new DebuggableScEngine(this);
 #else
@@ -451,6 +459,7 @@ bool BaseGame::initialize1() {
 		return STATUS_OK;
 	} else {
 		delete _mathClass;
+		delete _directoryClass;
 		delete _keyboardState;
 		delete _transMgr;
 		delete _surfaceStorage;
@@ -2743,6 +2752,16 @@ bool BaseGame::externalCall(ScScript *script, ScStack *stack, ScStack *thisStack
 		thisObj = thisStack->getTop();
 
 		thisObj->setNative(makeSXFile(_gameRef,  stack));
+		stack->pushNULL();
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Directory
+	//////////////////////////////////////////////////////////////////////////
+	else if (strcmp(name, "Directory") == 0) {
+		thisObj = thisStack->getTop();
+
+		thisObj->setNative(makeSXDirectory(_gameRef));
 		stack->pushNULL();
 	}
 

--- a/engines/wintermute/base/base_game.h
+++ b/engines/wintermute/base/base_game.h
@@ -60,6 +60,7 @@ class BaseKeyboardState;
 class BaseGameSettings;
 class ScEngine;
 class SXMath;
+class SXDirectory;
 class UIWindow;
 class VideoPlayer;
 class VideoTheoraPlayer;
@@ -158,6 +159,7 @@ public:
 	ScEngine *_scEngine;
 #endif
 	BaseScriptable *_mathClass;
+	BaseScriptable *_directoryClass;
 	BaseSurfaceStorage *_surfaceStorage;
 	BaseFontStorage *_fontStorage;
 	BaseGame(const Common::String &targetName);

--- a/engines/wintermute/base/base_scriptable.h
+++ b/engines/wintermute/base/base_scriptable.h
@@ -73,6 +73,7 @@ public:
 BaseScriptable *makeSXArray(BaseGame *inGame, ScStack *stack);
 BaseScriptable *makeSXDate(BaseGame *inGame, ScStack *stack);
 BaseScriptable *makeSXFile(BaseGame *inGame, ScStack *stack);
+BaseScriptable *makeSXDirectory(BaseGame *inGame);
 BaseScriptable *makeSXMath(BaseGame *inGame);
 BaseScriptable *makeSXMemBuffer(BaseGame *inGame, ScStack *stack);
 BaseScriptable *makeSXObject(BaseGame *inGame, ScStack *stack);

--- a/engines/wintermute/base/file/base_savefile_manager_file.cpp
+++ b/engines/wintermute/base/file/base_savefile_manager_file.cpp
@@ -1,0 +1,53 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+#include "engines/wintermute/base/file/base_savefile_manager_file.h"
+#include "engines/wintermute/base/base_file_manager.h"
+#include "engines/wintermute/base/base_engine.h"
+#include "common/system.h"
+#include "common/savefile.h"
+
+
+namespace Wintermute {
+
+Common::String makeSfmFilename(const Common::String &filename) {
+	Common::String smFilename = filename;
+	for (size_t i = 0; i < smFilename.size(); i++) {
+		if (smFilename[i] == '/' || smFilename[i] == '\\') {
+			smFilename.setChar('_', i);
+		}
+	}
+	return BaseEngine::instance().getGameTargetName() + "." + smFilename;
+}
+
+Common::SeekableReadStream *openSfmFile(const Common::String &filename) {
+	Common::String smFilename = makeSfmFilename(filename);
+	return g_system->getSavefileManager()->openRawFile(smFilename);
+}
+
+} // End of namespace Wintermute

--- a/engines/wintermute/base/file/base_savefile_manager_file.cpp
+++ b/engines/wintermute/base/file/base_savefile_manager_file.cpp
@@ -45,9 +45,19 @@ Common::String makeSfmFilename(const Common::String &filename) {
 	return BaseEngine::instance().getGameTargetName() + "." + smFilename;
 }
 
+bool sfmFileExists(const Common::String &filename) {
+	Common::String smFilename = makeSfmFilename(filename);
+	return g_system->getSavefileManager()->listSavefiles(smFilename).size() > 0;
+}
+
 Common::SeekableReadStream *openSfmFile(const Common::String &filename) {
 	Common::String smFilename = makeSfmFilename(filename);
 	return g_system->getSavefileManager()->openRawFile(smFilename);
+}
+
+Common::WriteStream *openSfmFileForWrite(const Common::String &filename) {
+	Common::String smFilename = makeSfmFilename(filename);
+	return g_system->getSavefileManager()->openForSaving(smFilename, false);
 }
 
 } // End of namespace Wintermute

--- a/engines/wintermute/base/file/base_savefile_manager_file.h
+++ b/engines/wintermute/base/file/base_savefile_manager_file.h
@@ -1,0 +1,40 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+#ifndef WINTERMUTE_BASE_SAVEFILEMANAGERFILE_H
+#define WINTERMUTE_BASE_SAVEFILEMANAGERFILE_H
+
+#include "common/stream.h"
+
+namespace Wintermute {
+
+Common::WriteStream *openSfmFileForWrite(const Common::String &filename);
+
+} // End of namespace Wintermute
+
+#endif

--- a/engines/wintermute/base/file/base_savefile_manager_file.h
+++ b/engines/wintermute/base/file/base_savefile_manager_file.h
@@ -33,7 +33,9 @@
 
 namespace Wintermute {
 
+Common::SeekableReadStream *openSfmFile(const Common::String &filename);
 Common::WriteStream *openSfmFileForWrite(const Common::String &filename);
+bool sfmFileExists(const Common::String &filename);
 
 } // End of namespace Wintermute
 

--- a/engines/wintermute/base/scriptables/script_engine.cpp
+++ b/engines/wintermute/base/scriptables/script_engine.cpp
@@ -67,6 +67,13 @@ ScEngine::ScEngine(BaseGame *inGame) : BaseClass(inGame) {
 		_globals->setProp("Math", &val);
 	}
 
+	// register 'Directory' as global variable
+	if (!_globals->propExists("Directory")) {
+		ScValue val(_gameRef);
+		val.setNative(_gameRef->_directoryClass, true);
+		_globals->setProp("Directory", &val);
+	}
+
 	// prepare script cache
 	for (int i = 0; i < MAX_CACHED_SCRIPTS; i++) {
 		_cachedScripts[i] = nullptr;

--- a/engines/wintermute/base/scriptables/script_ext_directory.cpp
+++ b/engines/wintermute/base/scriptables/script_ext_directory.cpp
@@ -29,6 +29,7 @@
 #include "engines/wintermute/base/scriptables/script_ext_directory.h"
 #include "engines/wintermute/base/scriptables/script_stack.h"
 #include "engines/wintermute/base/scriptables/script_value.h"
+#include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/persistent.h"
 
 namespace Wintermute {
@@ -65,9 +66,14 @@ bool SXDirectory::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisSt
 		stack->correctParams(1);
 		const char *path = stack->pop()->getString();
 
-		warning("Directory.Create is not implemented! Returning false...");
+		if (BaseEngine::instance().getGameId() == "hamlet") {
+			// No need to actually create anything since "gamelet.save" is stored at SavefileManager
+			stack->pushBool(true);
+		} else {
+			warning("Directory.Create is not implemented! Returning false...");
+			stack->pushBool(false);
+		}
 
-		stack->pushBool(false);
 		return STATUS_OK;
 	}
 

--- a/engines/wintermute/base/scriptables/script_ext_directory.cpp
+++ b/engines/wintermute/base/scriptables/script_ext_directory.cpp
@@ -1,0 +1,170 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+#include "engines/wintermute/base/scriptables/script_ext_directory.h"
+#include "engines/wintermute/base/scriptables/script_stack.h"
+#include "engines/wintermute/base/scriptables/script_value.h"
+#include "engines/wintermute/persistent.h"
+
+namespace Wintermute {
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction
+//////////////////////////////////////////////////////////////////////
+
+
+IMPLEMENT_PERSISTENT(SXDirectory, true)
+
+BaseScriptable *makeSXDirectory(BaseGame *inGame) {
+	return new SXDirectory(inGame);
+}
+
+//////////////////////////////////////////////////////////////////////////
+SXDirectory::SXDirectory(BaseGame *inGame) : BaseScriptable(inGame) {
+
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+SXDirectory::~SXDirectory() {
+
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+bool SXDirectory::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, const char *name) {
+	//////////////////////////////////////////////////////////////////////////
+	// Create
+	//////////////////////////////////////////////////////////////////////////
+	if (strcmp(name, "Create") == 0) {
+		stack->correctParams(1);
+		const char *path = stack->pop()->getString();
+
+		warning("Directory.Create is not implemented! Returning false...");
+
+		stack->pushBool(false);
+		return STATUS_OK;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Delete
+	//////////////////////////////////////////////////////////////////////////
+	else if (strcmp(name, "Delete") == 0) {
+		stack->correctParams(1);
+		const char *path = stack->pop()->getString();
+
+		warning("Directory.Delete is not implemented! Returning false...");
+
+		stack->pushBool(false);
+		return STATUS_OK;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// GetFiles / GetDirectories
+	//////////////////////////////////////////////////////////////////////////
+	else if (strcmp(name, "GetFiles") == 0 || strcmp(name, "GetDirectories") == 0) {
+		stack->correctParams(2);
+		const char *path = stack->pop()->getString();
+		const char *mask = stack->pop()->getString();
+
+		stack->pushInt(0);
+		BaseScriptable *array = makeSXArray(_gameRef, stack);
+
+		warning("Directory.%s is not implemented! Returning empty array...", name);
+
+ 		stack->pushNative(array, false);
+ 		return STATUS_OK;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// GetDrives
+	//////////////////////////////////////////////////////////////////////////
+	else if (strcmp(name, "GetDrives") == 0) {
+		stack->correctParams(0);
+
+		warning("Directory.GetDrives is not implemented! Returning empty array...");
+
+		stack->pushInt(0);
+ 		stack->pushNative(makeSXArray(_gameRef, stack), false);
+ 		return STATUS_OK;
+	} else {
+		return STATUS_FAILED;
+	}
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+ScValue *SXDirectory::scGetProperty(const Common::String &name) {
+	_scValue->setNULL();
+
+	//////////////////////////////////////////////////////////////////////////
+	// Type
+	//////////////////////////////////////////////////////////////////////////
+	if (name == "Type") {
+		_scValue->setString("directory");
+		return _scValue;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// PathSeparator
+	//////////////////////////////////////////////////////////////////////////
+	else if (name == "PathSeparator") {
+		_scValue->setString("\\");
+		return _scValue;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// CurrentDirectory
+	//////////////////////////////////////////////////////////////////////////
+	else if (name == "CurrentDirectory") {
+		warning("Directory.CurrentDirectory is not implemented! Returning 'saves'...");
+		_scValue->setString(""); // See also: BaseGame::scGetProperty("SaveDirectory")
+		return _scValue;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// TempDirectory
+	//////////////////////////////////////////////////////////////////////////
+	else if (name == "TempDirectory") {
+		warning("Directory.TempDirectory is not implemented! Returning 'saves'...");
+		_scValue->setString("temp"); // See also: BaseGame::scGetProperty("SaveDirectory")
+		return _scValue;
+	} else {
+		return _scValue;
+	}
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+bool SXDirectory::persist(BasePersistenceManager *persistMgr) {
+
+	BaseScriptable::persist(persistMgr);
+	return STATUS_OK;
+}
+
+} // End of namespace Wintermute

--- a/engines/wintermute/base/scriptables/script_ext_directory.h
+++ b/engines/wintermute/base/scriptables/script_ext_directory.h
@@ -1,0 +1,48 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+#ifndef WINTERMUTE_SXDIRECTORY_H
+#define WINTERMUTE_SXDIRECTORY_H
+
+
+#include "engines/wintermute/base/base_scriptable.h"
+
+namespace Wintermute {
+
+class SXDirectory : public BaseScriptable {
+public:
+	DECLARE_PERSISTENT(SXDirectory, BaseScriptable)
+	SXDirectory(BaseGame *inGame);
+	virtual ~SXDirectory();
+	virtual ScValue *scGetProperty(const Common::String &name);
+	virtual bool scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, const char *name);
+};
+
+} // End of namespace Wintermute
+
+#endif

--- a/engines/wintermute/base/scriptables/script_ext_file.cpp
+++ b/engines/wintermute/base/scriptables/script_ext_file.cpp
@@ -815,9 +815,8 @@ bool SXFile::persist(BasePersistenceManager *persistMgr) {
 	return STATUS_OK;
 }
 
-// Should replace fopen(..., "wb+") and fopen(..., "w+")
 Common::WriteStream *SXFile::openForWrite(const Common::String &filename, bool binary) {
-	error("SXFile::openForWrite - WriteFiles not supported");
+	return BaseFileManager::getEngineInstance()->openFileForWrite(_filename);
 }
 
 // Should replace fopen(..., "ab+") and fopen(..., "a+")

--- a/engines/wintermute/base/scriptables/script_ext_file.cpp
+++ b/engines/wintermute/base/scriptables/script_ext_file.cpp
@@ -346,7 +346,6 @@ bool SXFile::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 			writeLine = Common::String::format("%s", line);
 		}
 		_writeFile->writeString(writeLine);
-		_writeFile->writeByte(0);
 		stack->pushBool(true);
 
 		return STATUS_OK;

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -500,13 +500,57 @@ static const WMEGameDescription gameDescriptions[] = {
 	WME_WINENTRY("ghostsheet", "Demo",
 		WME_ENTRY1s("data.dcp", "dc1f6595f412ac25a52eaf47dad4ab81", 169083), Common::EN_ANY, ADGF_UNSTABLE | ADGF_DEMO, WME_1_8_0),
 
-	// Hamlet or the last game without MMORPG features, shaders and product placement
+	// Hamlet or the last game without MMORPG features, shaders and product placement (English)
 	WME_WINENTRY("hamlet", "",
 		WME_ENTRY1s("data.dcp", "f624add957a77c9930529fb28cc2450f", 88183022), Common::EN_ANY, ADGF_UNSTABLE, WME_1_9_1),
 
-	// Hamlet or the last game without MMORPG features, shaders and product placement
-	WME_WINENTRY("hamlet", "",
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (English)
+	WME_WINENTRY("hamlet", "v1.03",
 		WME_ENTRY1s("data.dcp", "74130d3c13f4a8caa2aafb9ee23f2639", 88184289), Common::EN_ANY, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (French)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "5facdd153473cd3dafd4c6cfd5c683c6", 88145395), Common::FR_FRA, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (German)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "fbd9ff90d8cc695b4a1524873792471d", 88204928), Common::DE_DEU, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Hungarian)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "8eb59bb531d3dbfe1d6800b2e82f5613", 88284666), Common::HU_HUN, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Italian)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "ed16bdedc212c2a754b065ded5d91f00", 88259077), Common::IT_ITA, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Japanese)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "06200da35604641c676c363babecb498", 88252762), Common::JA_JPN, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Koreana)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "29b8a8fcb4d50533571125be65c0fb93", 88093017), Common::KO_KOR, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Polish)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "b1f993e048cded6902630343fbc14fe2", 88295172), Common::PL_POL, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Portuguese)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "f55674e17df2816145d3473401081f05", 88245004), Common::PT_POR, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Russian)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "22cb24e8d37201e49bd2a76c33a1b98d", 88326328), Common::RU_RUS, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Spanish)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "262c84ebabc473a678b8e3a18b57fa89", 88332992), Common::ES_ESP, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Hamlet or the last game without MMORPG features, shaders and product placement (Steam) (Turkish)
+	WME_WINENTRY("hamlet", "v1.03",
+		WME_ENTRY1s("data.dcp", "5c9deef7e072f75081165b9c519f5b69", 88239961), Common::TR_TUR, ADGF_UNSTABLE, WME_1_9_1),
 
 	// Helga Deep In Trouble (Czech)
 	WME_WINENTRY("helga", "",

--- a/engines/wintermute/module.mk
+++ b/engines/wintermute/module.mk
@@ -46,6 +46,7 @@ MODULE_OBJS := \
 	base/file/base_file_entry.o \
 	base/file/base_package.o \
 	base/file/base_save_thumb_file.o \
+	base/file/base_savefile_manager_file.o \
 	base/font/base_font_bitmap.o \
 	base/font/base_font_truetype.o \
 	base/font/base_font.o \

--- a/engines/wintermute/module.mk
+++ b/engines/wintermute/module.mk
@@ -35,6 +35,7 @@ MODULE_OBJS := \
 	base/scriptables/script_value.o \
 	base/scriptables/script_ext_array.o \
 	base/scriptables/script_ext_date.o \
+	base/scriptables/script_ext_directory.o \
 	base/scriptables/script_ext_file.o \
 	base/scriptables/script_ext_math.o \
 	base/scriptables/script_ext_object.o \

--- a/engines/wintermute/persistent.cpp
+++ b/engines/wintermute/persistent.cpp
@@ -75,6 +75,7 @@
 #include "engines/wintermute/base/scriptables/script_value.h"
 #include "engines/wintermute/base/scriptables/script_ext_array.h"
 #include "engines/wintermute/base/scriptables/script_ext_date.h"
+#include "engines/wintermute/base/scriptables/script_ext_directory.h"
 #include "engines/wintermute/base/scriptables/script_ext_file.h"
 #include "engines/wintermute/base/scriptables/script_ext_math.h"
 #include "engines/wintermute/base/scriptables/script_ext_mem_buffer.h"
@@ -149,6 +150,7 @@ void SystemClassRegistry::registerClasses() {
 	REGISTER_CLASS(ScValue, false)
 	REGISTER_CLASS(SXArray, false)
 	REGISTER_CLASS(SXDate, false)
+	REGISTER_CLASS(SXDirectory, true)
 	REGISTER_CLASS(SXFile, false)
 	REGISTER_CLASS(SXMath, true)
 	REGISTER_CLASS(SXMemBuffer, false)


### PR DESCRIPTION
COMMON changes:
1. Add Turkish to language table
2. Add createDirectory() method to Common::FSNode

WINTERMUTE changes:
1. Add detection for all 12 languages that Hamlet supports (featuring Turkish, that never had ScummVM-playable games before). Hamlet does not use True Type Fonts, so this works allright.
2. Implement File and Directory methods required for Hamlet autosave code (see details in commit messages)

Hamlet is now fully completable with ScummVM.