### PR TITLE
MSVC: Fix build with recent versions of libcurl

### DIFF
--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -366,6 +366,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	              "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>\n"
 	              "\t\t</ClCompile>\n"
 	              "\t\t<Link>\n"
+	              "\t\t\t<AdditionalDependencies>ws2_32.lib;wldap32.lib;crypt32.lib;normaliz.lib;%(AdditionalDependencies)</AdditionalDependencies>\n"
 	              "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n"
 	              "\t\t\t<SubSystem>Console</SubSystem>\n";
 

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -158,6 +158,7 @@ void MSVCProvider::createGlobalProp(const BuildSetup &setup) {
 	// HACK: This definitely should not be here, but otherwise we would not define SDL_BACKEND for x64.
 	x64Defines.push_back("WIN32");
 	x64Defines.push_back("SDL_BACKEND");
+	x64Defines.push_back("CURL_STATICLIB");
 
 	outputGlobalPropFile(setup, properties, 64, x64Defines, convertPathToWin(setup.filePrefix), setup.runBuildEvents);
 }


### PR DESCRIPTION
The missing CURL_STATICLIB prevents linking with static libcurl.lib
(which is what is used for 32-bit builds)
The missing libraries raise external symbol errors with recent versions
of libcurl due to curl/curl@7921659.
More explanations can be found in curl/curl#2474.