### PR TITLE
WINTERMUTE: Fix slider bug at 1 1/2 Ritter and Oknytt

### DIFF
--- a/engines/wintermute/ad/ad_game.cpp
+++ b/engines/wintermute/ad/ad_game.cpp
@@ -38,6 +38,7 @@
 #include "engines/wintermute/ad/ad_scene.h"
 #include "engines/wintermute/ad/ad_scene_state.h"
 #include "engines/wintermute/ad/ad_sentence.h"
+#include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/base/base_file_manager.h"
 #include "engines/wintermute/base/font/base_font.h"
 #include "engines/wintermute/base/base_object.h"
@@ -2173,7 +2174,13 @@ bool AdGame::onMouseLeftUp() {
 	_capturedObject = nullptr;
 	_mouseLeftDown = false;
 
-	bool handled = /*_state==GAME_RUNNING &&*/ DID_SUCCEED(applyEvent("LeftRelease"));
+	bool handled;
+	if (BaseEngine::instance().getTargetExecutable() < WME_LITE) {
+		handled = _state==GAME_RUNNING && DID_SUCCEED(applyEvent("LeftRelease"));
+	} else {
+		handled = DID_SUCCEED(applyEvent("LeftRelease"));
+	}
+	
 	if (!handled) {
 		if (_activeObject != nullptr) {
 			_activeObject->applyEvent("LeftRelease");

--- a/engines/wintermute/base/base_engine.h
+++ b/engines/wintermute/base/base_engine.h
@@ -49,6 +49,8 @@ enum WMETargetExecutable {
 	WME_1_8_0,
 	WME_1_8_6,
 	WME_1_9_0,
+	WME_1_9_3, //displayed version of 1.10.1beta is "1.9.3"
+	WME_LITE,
 	LATEST_VERSION
 };
 

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -520,43 +520,44 @@ static const WMEGameDescription gameDescriptions[] = {
 		WME_ENTRY1s("data.dcp", "d230b0b99c0aa77b9ecd094d8ee5573b", 17844056), Common::EN_ANY, ADGF_UNSTABLE, LATEST_VERSION),
 
 	// Oknytt
+	// TODO: Engine version WME_1_9_3 is just a guess, need to check this
 	WME_WINENTRY("oknytt", "Version 1.0",
-		WME_ENTRY1s("data.dcp", "6456cf8f429905c83f07509f9da536dd", 109502959), Common::EN_ANY, ADGF_UNSTABLE, LATEST_VERSION),
+		WME_ENTRY1s("data.dcp", "6456cf8f429905c83f07509f9da536dd", 109502959), Common::EN_ANY, ADGF_UNSTABLE, WME_1_9_3),
 
 	// Oknytt (Version 1.12 English) (These are detected along with d_sounds.dcp to avoid mass-detecting in the languages-subfolder.)
 	WME_WINENTRY("oknytt", "Version 1.12",
 		WME_ENTRY2s("english.dcp", "cea08a6b5c88f40cb9937f77a72dce2e", 293273567,
-					"d_sounds.dcp", "8df683174ef01e6f717e2df926fa0b4a", 154943401), Common::EN_ANY, ADGF_UNSTABLE, LATEST_VERSION),
+					"d_sounds.dcp", "8df683174ef01e6f717e2df926fa0b4a", 154943401), Common::EN_ANY, ADGF_UNSTABLE, WME_1_9_3),
 
 	// Oknytt (Version 1.12 German)
 	WME_WINENTRY("oknytt", "Version 1.12",
 		WME_ENTRY2s("german.dcp", "a4f8e76dd6bec15656e83a871e36920c", 304292572,
-					"d_sounds.dcp", "8df683174ef01e6f717e2df926fa0b4a", 154943401), Common::DE_DEU, ADGF_UNSTABLE, LATEST_VERSION),
+					"d_sounds.dcp", "8df683174ef01e6f717e2df926fa0b4a", 154943401), Common::DE_DEU, ADGF_UNSTABLE, WME_1_9_3),
 
 	// Oknytt (Version 1.12 Russian)
 	WME_WINENTRY("oknytt", "Version 1.12",
 		WME_ENTRY2s("russian.dcp", "82e0ae002dd6a4106cbd1e4f8db9cfe0", 362681666,
-					"d_sounds.dcp", "8df683174ef01e6f717e2df926fa0b4a", 154943401), Common::RU_RUS, ADGF_UNSTABLE, LATEST_VERSION),
+					"d_sounds.dcp", "8df683174ef01e6f717e2df926fa0b4a", 154943401), Common::RU_RUS, ADGF_UNSTABLE, WME_1_9_3),
 
 	// Oknytt (Version 1.13 English) (These are detected along with d_sounds.dcp to avoid mass-detecting in the languages-subfolder.)
 	WME_WINENTRY("oknytt", "Version 1.13",
 		WME_ENTRY2s("english.dcp", "d2afd722c78cfe66b7d4250d11f6ae16", 293274135,
-					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::EN_ANY, ADGF_UNSTABLE, LATEST_VERSION),
+					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::EN_ANY, ADGF_UNSTABLE, WME_1_9_3),
 
 	// Oknytt (Version 1.13 German)
 	WME_WINENTRY("oknytt", "Version 1.13",
 		WME_ENTRY2s("german.dcp", "0fc6401d8d76b04f6da49206ecafa0dc", 304292574,
-					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::DE_DEU, ADGF_UNSTABLE, LATEST_VERSION),
+					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::DE_DEU, ADGF_UNSTABLE, WME_1_9_3),
 
 	// Oknytt (Version 1.13 Russian)
 	WME_WINENTRY("oknytt", "Version 1.13",
 		WME_ENTRY2s("russian.dcp", "dd24a1c0b36a82e2b02fb6c1050d4aad", 362681669,
-					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::RU_RUS, ADGF_UNSTABLE, LATEST_VERSION),
+					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::RU_RUS, ADGF_UNSTABLE, WME_1_9_3),
 
 	// Oknytt (Version 1.13 Spanish)
 	WME_WINENTRY("oknytt", "Version 1.13",
 		WME_ENTRY2s("spanish.dcp", "10c46152cb29581671f3b6b7c229c957", 319406572,
-					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::ES_ESP, ADGF_UNSTABLE, LATEST_VERSION),
+					"d_sounds.dcp", "7d04dff8ca11174486bd4b7a80fdcabb", 154943401), Common::ES_ESP, ADGF_UNSTABLE, WME_1_9_3),
 
 	// One Helluva Day (Demo) (multi-language)
 	WME_WINENTRY("onehelluvaday", "",
@@ -1746,12 +1747,12 @@ static const WMEGameDescription gameDescriptions[] = {
 
 	// 1 1/2 Ritter: Auf der Suche nach der hinreissenden Herzelinde (German)
 	WME_WINENTRY("ritter", "",
-		WME_ENTRY1s("data.dcp", "5ac416cee605d3a30f4d59687b1cdab2", 364260278), Common::DE_DEU, ADGF_UNSTABLE, LATEST_VERSION),
+		WME_ENTRY1s("data.dcp", "5ac416cee605d3a30f4d59687b1cdab2", 364260278), Common::DE_DEU, ADGF_UNSTABLE, WME_1_8_6),
 
 	// 1 1/2 Ritter: Auf der Suche nach der hinreissenden Herzelinde (Russian)
 	WME_WINENTRY("ritter", "",
 		WME_ENTRY2s("data.dcp", "5ac416cee605d3a30f4d59687b1cdab2", 364260278,
-				"string3.tab", "e9d0e6341e8994be5fa6d70d39ac630b", 813982), Common::RU_RUS, ADGF_UNSTABLE, LATEST_VERSION),
+				"string3.tab", "e9d0e6341e8994be5fa6d70d39ac630b", 813982), Common::RU_RUS, ADGF_UNSTABLE, WME_1_8_6),
 
 	// Satan and Son
 	WME_WINENTRY("satanandson", "",
@@ -1763,7 +1764,7 @@ static const WMEGameDescription gameDescriptions[] = {
 
 	// Securanote
 	WME_PLATENTRY("securanote", "",
-		WME_ENTRY1s("data.dcp", "5213d3e59b9e95b7fbd5c56f7de5341a", 2625554), Common::EN_ANY, Common::kPlatformIOS, ADGF_UNSTABLE, LATEST_VERSION),
+		WME_ENTRY1s("data.dcp", "5213d3e59b9e95b7fbd5c56f7de5341a", 2625554), Common::EN_ANY, Common::kPlatformIOS, ADGF_UNSTABLE, WME_LITE),
 
 	// Shaban
 	WME_WINENTRY("shaban", "",

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -1744,9 +1744,14 @@ static const WMEGameDescription gameDescriptions[] = {
 	WME_WINENTRY("rhiannon", "Demo: Chapter 5",
 		WME_ENTRY1s("data.dcp", "88be3fa1389889b2079e54d780803a75", 88644508), Common::EN_ANY, ADGF_UNSTABLE | ADGF_DEMO, LATEST_VERSION),
 
-	// 1 1/2 Ritter: Auf der Suche nach der hinreissenden Herzelinde
+	// 1 1/2 Ritter: Auf der Suche nach der hinreissenden Herzelinde (German)
 	WME_WINENTRY("ritter", "",
 		WME_ENTRY1s("data.dcp", "5ac416cee605d3a30f4d59687b1cdab2", 364260278), Common::DE_DEU, ADGF_UNSTABLE, LATEST_VERSION),
+
+	// 1 1/2 Ritter: Auf der Suche nach der hinreissenden Herzelinde (Russian)
+	WME_WINENTRY("ritter", "",
+		WME_ENTRY2s("data.dcp", "5ac416cee605d3a30f4d59687b1cdab2", 364260278,
+				"string3.tab", "e9d0e6341e8994be5fa6d70d39ac630b", 813982), Common::RU_RUS, ADGF_UNSTABLE, LATEST_VERSION),
 
 	// Satan and Son
 	WME_WINENTRY("satanandson", "",


### PR DESCRIPTION
There is a bug introduced in WME Lite.

Testcase:
1. Download https://github.com/lolbot-iichan/wme_testsuite/tree/master/slider_test/packages
2. Download https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wmelite/wmelite_10_win.zip
3a. Run game.exe -> Slider moves with the mouse while it is pressed and
released when mouse is released
3b. Run wmelite.exe -> Slider is never released
3c. Run ScummVM -> Slider is never released

Related bugs:
https://bugs.scummvm.org/ticket/6567
https://bugs.scummvm.org/ticket/9861

Reason: slider is a button object that changes it's X until "LeftRelease" event is revieved and breaks the endless loop.
Sample code: https://github.com/lolbot-iichan/wme_testsuite/blob/master/slider_test/data/interface/system/speechvolume.script
However, WME Lite does not send "LeftRelease" events to any objects, if Game object can handle such event, even is game is frozen and UI is shown.

Original code: https://github.com/lolbot-iichan/Wintermute-Engine/blob/master/src/engine_core/wme_ad/AdGame.cpp#L2218
Changed in WME Lite: https://github.com/lolbot-iichan/wmelite/blob/master/src/AdGame.cpp#L2120

This behaviour was introduced in SVN period of wmelite, I believe it was
made on purpose for handling some iOS scenarios at commit #37 mentioned
on page https://code.google.com/archive/p/wmelite/source/default/commits

My proposal is to mark iOS apps as WME_LITE and fill exact WME_1_X_X/WME_LITE versions for all known
games. WME_1_X_X can be seen by right-clicking on main executable and seems to be non-empty for almost all existing WME games.