### PR TITLE
CREATE_PROJECT: Fix missing MSVC x64 defines

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -408,10 +408,18 @@ int main(int argc, char *argv[]) {
 			setup.libraries.push_back("sparkle");
 	}
 
-	if (curlEnabled && projectType == kProjectMSVC)
-		setup.defines.push_back("CURL_STATICLIB");
-	if (sdlnetEnabled && projectType == kProjectMSVC)
-		setup.libraries.push_back("iphlpapi");
+	if (projectType == kProjectMSVC) {
+		if (curlEnabled) {
+			setup.defines.push_back("CURL_STATICLIB");
+			setup.libraries.push_back("ws2_32");
+			setup.libraries.push_back("wldap32");
+			setup.libraries.push_back("crypt32");
+			setup.libraries.push_back("normaliz");
+		}
+		if (sdlnetEnabled) {
+			setup.libraries.push_back("iphlpapi");
+		}
+	}
 
 	setup.defines.push_back("SDL_BACKEND");
 	if (!setup.useSDL2) {

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -25,6 +25,7 @@
 
 #include <fstream>
 #include <algorithm>
+#include <cstring>
 
 namespace CreateProjectTool {
 
@@ -147,17 +148,14 @@ void MSVCProvider::createGlobalProp(const BuildSetup &setup) {
 	if (!properties)
 		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_Global64" + getPropertiesExtension() + "\" for writing");
 
-	// HACK: We must disable the "nasm" feature for x64. To achieve that we must duplicate the feature list and
-	// recreate a define list.
-	FeatureList x64Features = setup.features;
-	setFeatureBuildState("nasm", x64Features, false);
-	StringList x64Defines = getFeatureDefines(x64Features);
-	StringList x64EngineDefines = getEngineDefines(setup.engines);
-	x64Defines.splice(x64Defines.end(), x64EngineDefines);
-
-	// HACK: This definitely should not be here, but otherwise we would not define SDL_BACKEND for x64.
-	x64Defines.push_back("WIN32");
-	x64Defines.push_back("SDL_BACKEND");
+	// HACK: We must disable the "nasm" feature for x64. To achieve that we must recreate the define list.
+	StringList x64Defines = setup.defines;
+	for (FeatureList::const_iterator i = setup.features.begin(); i != setup.features.end(); ++i) {
+		if (i->enable && i->define && i->define[0] && !strcmp(i->name, "nasm")) {
+			x64Defines.remove(i->define);
+			break;
+		}
+	}
 
 	outputGlobalPropFile(setup, properties, 64, x64Defines, convertPathToWin(setup.filePrefix), setup.runBuildEvents);
 }


### PR DESCRIPTION
This addresses the issues brought up in PR #1722 in a more robust way;

To disable nasm from x64, the whole define list was rewritten from scratch using `getFeatureDefines` and `getEngineDefines`. This ended up removing [important defines](https://github.com/scummvm/scummvm/blob/master/devtools/create_project/create_project.cpp#L391) added later in the setup phase, which presumably someone noticed, as they were [poorly re-added](https://github.com/scummvm/scummvm/blob/master/devtools/create_project/msvc.cpp#L158).
Instead, I opted to just find and remove the nasm define for x64. Better one little hack than a whole pile of them. :)

This also adds the new libcurl Win32 dependencies and cleans up the rest so they're only generated for the appropriate targets. More detailed explanations in the commit messages.