### PR TITLE
 BACKENDS: Rename and simplify AbstractFSNode::create()

### DIFF
--- a/backends/saves/default/default-saves.cpp
+++ b/backends/saves/default/default-saves.cpp
@@ -63,7 +63,7 @@ DefaultSaveFileManager::DefaultSaveFileManager(const Common::String &defaultSave
 void DefaultSaveFileManager::checkPath(const Common::FSNode &dir) {
 	clearError();
 	if (!dir.exists()) {
-		if (!dir.createDirectory()) {
+		if (!dir.createDirectoryRecursive()) {
 			setError(Common::kPathDoesNotExist, "Failed to create directory '"+dir.getPath()+"'");
 		}
 	} else if (!dir.isDirectory()) {

--- a/backends/saves/default/default-saves.cpp
+++ b/backends/saves/default/default-saves.cpp
@@ -63,7 +63,9 @@ DefaultSaveFileManager::DefaultSaveFileManager(const Common::String &defaultSave
 void DefaultSaveFileManager::checkPath(const Common::FSNode &dir) {
 	clearError();
 	if (!dir.exists()) {
-		setError(Common::kPathDoesNotExist, "The savepath '"+dir.getPath()+"' does not exist");
+		if (!dir.createDirectory()) {
+			setError(Common::kPathDoesNotExist, "Failed to create directory '"+dir.getPath()+"'");
+		}
 	} else if (!dir.isDirectory()) {
 		setError(Common::kPathNotDirectory, "The savepath '"+dir.getPath()+"' is not a directory");
 	}

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -155,24 +155,10 @@ bool DumpFile::open(const String &filename, bool createPath) {
 	assert(!filename.empty());
 	assert(!_handle);
 
-	if (createPath) {
-		for (uint32 i = 0; i < filename.size(); ++i) {
-			if (filename[i] == '/' || filename[i] == '\\') {
-				Common::String subpath = filename;
-				subpath.erase(i);
-				if (subpath.empty()) continue;
-				AbstractFSNode *node = g_system->getFilesystemFactory()->makeFileNodePath(subpath);
-				if (node->exists()) {
-					delete node;
-					continue;
-				}
-				if (!node->createDirectory()) warning("DumpFile: unable to create directories from path prefix");
-				delete node;
-			}
-		}
-	}
-
 	FSNode node(filename);
+	if (createPath)
+		node.getParent().createDirectoryRecursive();
+
 	return open(node);
 }
 

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -157,6 +157,11 @@ bool FSNode::createDirectory() const {
 		return false;
 
 	if (_realNode->exists()) {
+		if (_realNode->isDirectory()) {
+			warning("FSNode::createDirectory: '%s' already exists", getName().c_str());
+		} else {
+			warning("FSNode::createDirectory: '%s' is a file", getName().c_str());
+		}
 		return false;
 	}
 

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -168,6 +168,27 @@ bool FSNode::createDirectory() const {
 	return _realNode->createDirectory();
 }
 
+bool FSNode::createDirectoryRecursive() const {
+	if (_realNode == nullptr)
+		return false;
+
+	if (_realNode->exists()) {
+		if (!_realNode->isDirectory()) {
+			warning("FSNode::createDirectoryRecursive: '%s' is a file", _realNode->getName().c_str());
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	FSNode parent = getParent();
+	assert(parent.getPath() != _realNode->getPath());
+	if (!parent.createDirectoryRecursive())
+		return false;
+
+	return _realNode->createDirectory();
+}
+
 FSDirectory::FSDirectory(const FSNode &node, int depth, bool flat)
   : _node(node), _cached(false), _depth(depth), _flat(flat) {
 }

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -152,6 +152,17 @@ WriteStream *FSNode::createWriteStream() const {
 	return _realNode->createWriteStream();
 }
 
+bool FSNode::createDirectory() const {
+	if (_realNode == nullptr)
+		return false;
+
+	if (_realNode->exists()) {
+		return false;
+	}
+
+	return _realNode->createDirectory();
+}
+
 FSDirectory::FSDirectory(const FSNode &node, int depth, bool flat)
   : _node(node), _cached(false), _depth(depth), _flat(flat) {
 }

--- a/common/fs.h
+++ b/common/fs.h
@@ -230,6 +230,15 @@ public:
 	 * @return pointer to the stream object, 0 in case of a failure
 	 */
 	WriteStream *createWriteStream() const;
+
+	/**
+	 * Creates a directory referred by this node. This assumes that this
+	 * node refers to non-existing directory. If this is not the case,
+	 * false is returned.
+	 *
+	 * @return true if the directory was created, false otherwise.
+	 */
+	bool createDirectory() const;
 };
 
 /**

--- a/common/fs.h
+++ b/common/fs.h
@@ -239,6 +239,14 @@ public:
 	 * @return true if the directory was created, false otherwise.
 	 */
 	bool createDirectory() const;
+
+	/**
+	 * Creates a directory referred by this node. The parent directory
+	 * will also be created if it doesn't exist.
+	 *
+	 * @return true if the directory was created, false otherwise.
+	 */
+	bool createDirectoryRecursive() const;
 };
 
 /**

--- a/engines/testbed/fs.cpp
+++ b/engines/testbed/fs.cpp
@@ -172,6 +172,35 @@ TestExitStatus FStests::testWriteFile() {
 }
 
 
+/**
+ * This test creates a directory testbed.dir, and confirms if the directory is created successfully
+ */
+TestExitStatus FStests::testCreateDir() {
+	const Common::String &path = ConfMan.get("path");
+	Common::FSNode gameRoot(path);
+	if (!gameRoot.exists()) {
+		Testsuite::logPrintf("Couldn't open the game data directory %s", path.c_str());
+		 return kTestFailed;
+	}
+
+	Common::FSNode dirToCreate = gameRoot.getChild("testbed.dir");
+
+	// TODO: Delete the directory after creating it
+	if (dirToCreate.exists()) {
+		Testsuite::logDetailedPrintf("Directory already exists in game data dir\n");
+		return kTestSkipped;
+	}
+
+	if (!dirToCreate.createDirectory()) {
+		Testsuite::logDetailedPrintf("Can't create directory in game data dir\n");
+		return kTestFailed;
+	}
+
+	Testsuite::logDetailedPrintf("Directory created successfully\n");
+	return kTestPassed;
+}
+
+
 
 FSTestSuite::FSTestSuite() {
 	// FS tests depend on Game Data files.
@@ -187,6 +216,7 @@ FSTestSuite::FSTestSuite() {
 	}
 	addTest("ReadingFile", &FStests::testReadFile, false);
 	addTest("WritingFile", &FStests::testWriteFile, false);
+	addTest("CreateDir",   &FStests::testCreateDir, false);
 }
 
 void FSTestSuite::enable(bool flag) {

--- a/engines/testbed/fs.h
+++ b/engines/testbed/fs.h
@@ -41,6 +41,7 @@ bool readDataFromFile(Common::FSDirectory *directory, const char *file);
 // will contain function declarations for FS tests
 TestExitStatus testReadFile();
 TestExitStatus testWriteFile();
+TestExitStatus testCreateDir();
 TestExitStatus testOpeningSaveFile();
 // add more here
 


### PR DESCRIPTION
Nothing ever used `create()` to create files, and the same effect could be achieved using `createReadStream()`, so `create()`  has been simplified to only create directories. In addition, `createDirectory()` will return true if the directory already exists, and the check for existence is done by the calling code.

The changes to `Common::FSNode` are originally from PR #1720.

The PSP and chroot changes have not been tested.