### PR TITLE
COMMON: Last character of some TTF texts was cropped (do not merge)

### DIFF
--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -62,9 +62,10 @@ Common::Rect getBoundingBoxImpl(const Font &font, const StringType &str, int x, 
 		last = cur;
 
 		Common::Rect charBox = font.getBoundingBox(cur);
-		if (x + charBox.right > rightX)
+		int charWidth = font.getCharWidth(cur);
+		if (x + charWidth > rightX)
 			break;
-		if (x + charBox.right >= leftX) {
+		if (x + charWidth >= leftX) {
 			charBox.translate(x, y);
 			if (first) {
 				bbox = charBox;
@@ -74,7 +75,7 @@ Common::Rect getBoundingBoxImpl(const Font &font, const StringType &str, int x, 
 			}
 		}
 
-		x += font.getCharWidth(cur);
+		x += charWidth;
 	}
 
 	return bbox;
@@ -115,13 +116,13 @@ void drawStringImpl(const Font &font, Surface *dst, const StringType &str, int x
 		x += font.getKerningOffset(last, cur);
 		last = cur;
 
-		Common::Rect charBox = font.getBoundingBox(cur);
-		if (x + charBox.right > rightX)
+		int charWidth = font.getCharWidth(cur);
+		if (x + charWidth > rightX)
 			break;
-		if (x + charBox.right >= leftX)
+		if (x + charWidth >= leftX)
 			font.drawChar(dst, cur, x, y, color);
 
-		x += font.getCharWidth(cur);
+		x += charWidth;
 	}
 }
 


### PR DESCRIPTION
This fixes https://bugs.scummvm.org/ticket/11007 and some other
Wintermute games.

Issue is an off-by-one error caused by a loop pattern, with inconsistent
pair of increment and break-condition: `x += font.getCharWidth(cur)` and
`if (x + charBox.right > rightX) break;`, while char width was unequal
to char box width (it's ok for base Font class, but wrong for child
class TTFFont).

I *think* that maybe it's the right way to fix it, since bug 11007 is
not reproduced with this code and rendering seems fine at the first
glance, but I really want someone from COMMON maintainers to hardly
review this since this may affect rendering all fonts in all games. I
just don't get how this couldn't affect other engines - maybe
Wintermute's `BaseFontTT::measureText` is wrong and we should use some
other font methods instead of `textWidth =
_font->getStringWidth(text)`???