### PR TITLE
GLK: Fix off-by-one memory read

### DIFF
--- a/engines/glk/alan2/alan2.cpp
+++ b/engines/glk/alan2/alan2.cpp
@@ -161,8 +161,11 @@ static void syncEventQueue(Common::Serializer &s) {
 	EvtqElem *arr = eventq;
 
 	if (s.isLoading()) {
-		for (i = 0; arr[i - 1].time != 0; ++i)
+		i = 0;
+		do {
 			arr[i].synchronize(s);
+			i++;
+		} while (arr[i - 1].time != 0);
 		etop = i - 1;
 	} else {
 		// Mark the top


### PR DESCRIPTION
I think this part of code is erroneous as it shouldn't check the previous item on the first iteration of the loop.
Moreover, this code seems to raise an internal compiler error of OpenPandora build. I hope my rewrite will fix it as well.