### PR TITLE
SCI: Implement early GetLongest() behavior, bug #10000

### DIFF
--- a/engines/sci/engine/features.cpp
+++ b/engines/sci/engine/features.cpp
@@ -774,4 +774,54 @@ PseudoMouseAbilityType GameFeatures::detectPseudoMouseAbility() {
 	return _pseudoMouseAbility;
 }
 
+// GetLongest(), which calculates the number of characters in a string that can fit
+//  within a width, had two subtle changes which started to appear in interpreters
+//  in late 1990. An off-by-one bug was fixed where the character that exceeds the
+//  width would be applied to the result if a space character hadn't been reached.
+//  The pixel width test was also changed from a greater than or equals to greater
+//  than, but again only if a space character hadn't been reached.
+//
+// The notebook in LB1 (bug #10000) is currently the only known script that depended
+//  on the original behavior. This appears to be an isolated fix to an interpreter
+//  edge case, a corresponding script change to allow autodetection hasn't been found.
+//
+// The Japanese interpreters have their own versions of GetLongest() to support
+//  double byte characters which seems to be how QFG1 Japanese reintroduced it
+//  even though its interpreter is later than SQ3/LSL3 multilingual versions.
+bool GameFeatures::useEarlyGetLongestTextCalculations() const {
+	switch (getSciVersion()) {
+
+	// All SCI0, confirmed:
+	// - LSL2 English PC 1.000.011
+	// - LB1 PC 1.000.046
+	// - ICEMAN PC 1.033
+	// - SQ3 English PC 1.018
+	// - PQ2 Japanese 1.000.052
+	case SCI_VERSION_0_EARLY:
+	case SCI_VERSION_0_LATE:
+		return true;
+
+	// SCI01: confirmed KQ1 and QFG1 Japanese,
+	// fixed in SQ3 and LSL3 multilingual PC
+	case SCI_VERSION_01:
+		return (g_sci->getGameId() == GID_KQ1 || g_sci->getGameId() == GID_QFG1);
+
+	// QFG2, confirmed 1.000 and 1.105 (first and last versions)
+	case SCI_VERSION_1_EGA_ONLY:
+		return true;
+
+	// SCI1 Early: just KQ5 English PC versions,
+	// confirmed fixed in:
+	// - LSL1 Demo
+	// - XMAS1990 EGA
+	// - SQ4 1.052
+	case SCI_VERSION_1_EARLY:
+		return (g_sci->getGameId() == GID_KQ5);
+
+	// Fixed in all other versions
+	default:
+		return false;
+	}
+}
+
 } // End of namespace Sci

--- a/engines/sci/engine/features.h
+++ b/engines/sci/engine/features.h
@@ -245,6 +245,8 @@ public:
 	 */
 	PseudoMouseAbilityType detectPseudoMouseAbility();
 
+	bool useEarlyGetLongestTextCalculations() const;
+
 private:
 	reg_t getDetectionAddr(const Common::String &objName, Selector slc, int methodNum = -1);
 

--- a/engines/sci/graphics/text16.h
+++ b/engines/sci/graphics/text16.h
@@ -90,6 +90,8 @@ private:
 	int _codeColorsCount;
 	uint16 *_codeColors;
 
+	bool _useEarlyGetLongestTextCalculations;
+
 	Common::Rect _codeRefTempRect;
 	CodeRefRectArray _codeRefRects;
 };


### PR DESCRIPTION
This implements an off-by-one bug and comparison change in text length calculations that was in all SCI interpreters until late 1990. This fixes bug #10000 (mwahahaha)

On the notebook screen at the end of LB1, the last "E" in the word "INCOMPLETE" is wrapped onto the next line in ScummVM. It's a script bug, but thanks to the interpreter bug it accidentally works in the original.

GetLongest() returns the number of characters that can be displayed in a given width. "INCOMPLETE" is 52 pixels but the script specifies a width of 50. GetLongest() should return 9 and set the string pointer to "E" but in SSCI when a string exceeds the width before a space character is reached, the exceeding character was originally applied to the result. Normally this isn't a scenario that a script should be in, you'd be in trouble if the first word in your string was longer than your maximum width, so this bug might only affect buggy scripts.

Sierra eventually fixed the bug and at the same time changed the width comparison from greater than or equals to greater than. I've added both behaviors for games that contained them. To test this I patched the LB1 script to pass kDisplay a yellow background instead of transparent to see what SSCI was really drawing, then patched the width to various values to see the wrapping behavior and confirm that SSCI and ScummVM now do the same thing.

Versions with the original behavior:
* All SCI0
* Some SCI01: KQ1 and QFG1 Japanese but not multilingual SQ3 and LSL3
* QFG2
* Only the first SCI1 early game: KQ5 English DOS floppy versions
	
Every other SCI1 game I've looked at has the fix. By the interpreter version numbers, the fix in the SCI1 timeline starts with LSL1 Demo.

To locate this in any DOS SCI16 interpreter, search for these unique instructions in the text width function:

```
8a d8    mov bl, al
32 ff    xor bh, bh
```
	
The function that calls it the most, 4 or 5 times, is GetLongest(). Versions with the bug increment the character counter and string pointer prior to testing the text width and returning.

