### PR TITLE
QUEEN: Remove a bad detection entry

### DIFF
--- a/engines/queen/detection.cpp
+++ b/engines/queen/detection.cpp
@@ -209,19 +209,6 @@ static const QueenGameDescription gameDescriptions[] = {
 		},
 	},
 
-	// DOS Floppy - Russian
-	{
-		{
-			"queen",
-			"Floppy",
-			AD_ENTRY1s("queen.1", "0d1c10d5c3a1bd90bc0b3859a3258093", 22677657),
-			Common::RU_RUS,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
-		},
-	},
-
 	// DOS Floppy - Russian (From Bugreport #6946)
 	{
 		{


### PR DESCRIPTION
QUEEN: Remove a bad detection entry

This is a bad entry: *DOS Floppy - Russian*
> "queen.1","0d1c10d5c3a1bd90bc0b3859a3258093",22677657

The proper one is already documented in the entry: *DOS Floppy - Russian (From Bugreport #6946)*
> "queen.1", "f5e827645d3c887be3bdf4729d847756", 22677657

The removed entry matched the MD5 hash values for the ***full*** original file:
> File : QUEEN.1
> Size : 22677657
> Hashes for the full file (22677657 bytes)
>   * CRC32: 3c266e5f
>   * MD5  : 0d1c10d5c3a1bd90bc0b3859a3258093
>   * SHA1 : c5ec968e926702efc3a58fff6bddc1e193ca890e

> Hashes for the first 5000 bytes
>   * CRC32: 28a15ba1
>   * MD5  : f5e827645d3c887be3bdf4729d847756

The proper entry (marked as *"DOS Floppy - Russian (From Bugreport #6946)"*) matches the right hash value for ***the first 5000bytes of the same file***
