### PR TITLE
SDL: Fix compiler warning and joystick handling

### DIFF
--- a/common/events.h
+++ b/common/events.h
@@ -110,7 +110,7 @@ struct JoystickState {
 	 * Some of the button indices match well-known game controller
 	 * buttons. See JoystickButton.
 	 */
-	byte button;
+	int8 button;
 };
 
 /**


### PR DESCRIPTION
Fixes the following compiler warning:

> backends/events/sdl/sdl-events.cpp: In member function ‘virtual bool SdlEventSource::handleControllerButton(const SDL_Event&, Common::Event&, bool)’:
backends/events/sdl/sdl-events.cpp:1194:33: warning: comparison is always false due to limited range of data type [-Wtype-limits]
   if (event.joystick.button == -1)

Quote of code segment;

`event.joystick.button = mapSDLControllerButtonToOSystem(ev.cbutton.button);`
`if (event.joystick.button == -1)
				return false;`
`	return true;`

As comparison will always fail as joystick.button is of type byte (unsigned char), it can also return true with invalid number 255 as the joystick.button.

This happens when `mapSDLControllerButtonToOSystem()` can not find a button mapping, as it returns -1 in this case.

Simplest workaround implemented by changing joystick.button type from byte to int8 that can support negative numbers.

Please review and test this before accepting. It could also be avoided with a temporary variable.