### PR TITLE
SCI: Implement full kWait behavior

### DIFF
--- a/engines/sci/engine/kgraphics.cpp
+++ b/engines/sci/engine/kgraphics.cpp
@@ -394,9 +394,9 @@ reg_t kTextSize(EngineState *s, int argc, reg_t *argv) {
 }
 
 reg_t kWait(EngineState *s, int argc, reg_t *argv) {
-	int sleep_time = argv[0].toUint16();
+	uint16 ticks = argv[0].toUint16();
 
-	const int delta = s->wait(sleep_time);
+	const uint16 delta = s->wait(ticks);
 
 	if (g_sci->_guestAdditions->kWaitHook()) {
 		return NULL_REG;

--- a/engines/sci/engine/state.cpp
+++ b/engines/sci/engine/state.cpp
@@ -134,14 +134,26 @@ void EngineState::speedThrottler(uint32 neededSleep) {
 	}
 }
 
-int EngineState::wait(int16 ticks) {
+uint16 EngineState::wait(uint16 ticks) {
 	uint32 time = g_system->getMillis();
-	const int tickDelta = ((long)time - (long)lastWaitTime) * 60 / 1000;
-	lastWaitTime = time;
 
+	uint32 ms = ticks * 1000 / 60;
+	uint32 duration = time - lastWaitTime;
+	if (ms > duration) {
+		uint32 sleepTime = ms - duration;
+		sleepTime *= g_debug_sleeptime_factor;
+		g_sci->sleep(sleepTime);
+		time += sleepTime;
+	}
+
+	uint16 tickDelta = (uint16)(((long)time - lastWaitTime) * 60 / 1000);
+	lastWaitTime = time;
+	return tickDelta;
+}
+
+void EngineState::sleep(uint16 ticks) {
 	ticks *= g_debug_sleeptime_factor;
 	g_sci->sleep(ticks * 1000 / 60);
-	return tickDelta;
 }
 
 void EngineState::initGlobals() {

--- a/engines/sci/engine/state.h
+++ b/engines/sci/engine/state.h
@@ -114,7 +114,8 @@ public:
 	uint32 _screenUpdateTime;	/**< The last time the game updated the screen */
 
 	void speedThrottler(uint32 neededSleep);
-	int wait(int16 ticks);
+	uint16 wait(uint16 ticks);
+	void sleep(uint16 ticks);
 
 #ifdef ENABLE_SCI32
 	uint32 _eventCounter; /**< total times kGetEvent was invoked since the last call to kFrameOut */

--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -1182,14 +1182,14 @@ void GfxFrameout::shakeScreen(int16 numShakes, const ShakeDirection direction) {
 		}
 
 		updateScreen();
-		g_sci->getEngineState()->wait(3);
+		g_sci->getEngineState()->sleep(3);
 
 		if (direction & kShakeVertical) {
 			g_system->setShakePos(0);
 		}
 
 		updateScreen();
-		g_sci->getEngineState()->wait(3);
+		g_sci->getEngineState()->sleep(3);
 	}
 }
 

--- a/engines/sci/graphics/portrait.cpp
+++ b/engines/sci/graphics/portrait.cpp
@@ -301,7 +301,7 @@ void Portrait::doit(Common::Point position, uint16 resourceId, uint16 noun, uint
 		// Wait till syncTime passed, then show specific animation bitmap
 		if (timerPosition > 0) {
 			do {
-				g_sci->getEngineState()->wait(1);
+				g_sci->getEngineState()->sleep(1);
 				curEvent = _event->getSciEvent(kSciEventAny);
 				if (curEvent.type == kSciEventMousePress ||
 					(curEvent.type == kSciEventKeyDown && curEvent.character == kSciKeyEsc) ||
@@ -324,7 +324,7 @@ void Portrait::doit(Common::Point position, uint16 resourceId, uint16 noun, uint
 				timerPositionWithin += raveLipSyncTicks;
 
 				do {
-					g_sci->getEngineState()->wait(1);
+					g_sci->getEngineState()->sleep(1);
 					curEvent = _event->getSciEvent(kSciEventAny);
 					if (curEvent.type == kSciEventMousePress ||
 						(curEvent.type == kSciEventKeyDown && curEvent.character == kSciKeyEsc) ||
@@ -383,7 +383,7 @@ void Portrait::doit(Common::Point position, uint16 resourceId, uint16 noun, uint
 
 		// Wait till syncTime passed, then show specific animation bitmap
 		do {
-			g_sci->getEngineState()->wait(1);
+			g_sci->getEngineState()->sleep(1);
 			curEvent = _event->getSciEvent(kSciEventAny);
 			if (curEvent.type == kSciEventMousePress ||
 				(curEvent.type == kSciEventKeyboard && curEvent.data == kSciKeyEsc) ||

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -608,13 +608,13 @@ void GfxScreen::kernelShakeScreen(uint16 shakeCount, uint16 directions) {
 			setVerticalShakePos(10);
 		// TODO: horizontal shakes
 		g_system->updateScreen();
-		g_sci->getEngineState()->wait(3);
+		g_sci->getEngineState()->sleep(3);
 
 		if (directions & kShakeVertical)
 			setVerticalShakePos(0);
 
 		g_system->updateScreen();
-		g_sci->getEngineState()->wait(3);
+		g_sci->getEngineState()->sleep(3);
 	}
 }
 

--- a/engines/sci/graphics/transitions.cpp
+++ b/engines/sci/graphics/transitions.cpp
@@ -323,7 +323,7 @@ void GfxTransitions::fadeOut() {
 			}
 		}
 		g_system->getPaletteManager()->setPalette(workPalette + 3, 1, tillColorNr);
-		g_sci->getEngineState()->wait(2);
+		g_sci->getEngineState()->sleep(2);
 	}
 }
 
@@ -337,7 +337,7 @@ void GfxTransitions::fadeIn() {
 
 	for (stepNr = 0; stepNr <= 100; stepNr += 10) {
 		_palette->kernelSetIntensity(1, tillColorNr + 1, stepNr, true);
-		g_sci->getEngineState()->wait(2);
+		g_sci->getEngineState()->sleep(2);
 	}
 }
 


### PR DESCRIPTION
This implements kWait's full behavior as in SSCI. This fixes PQ3 bug #11020 where ScummVM adds a half-second delay before every message when a character's portrait is displayed.

kWait is currently implemented as a simple sleep for the specified ticks, but SSCI factors in the last time kWait was called, and doesn't necessarily sleep at all. The specified ticks is the maximum to sleep for. If that many ticks haven't yet elapsed since kWait was last called then that difference is the amount to sleep for.

PQ3 calls kWait 30 before displaying a message after a portrait, and so in the original this would only pause if kWait had been called within the last half a second, which usually wasn't the case. (Script 0, exported function 16)

kWait's work is done in EngineState:wait() which was also being used by internal operations. Those shouldn't influence any of kWait's behavior so I've made a dedicated sleep() method for them to use. wait() is now solely for kWait. This has been a problem before: https://github.com/scummvm/scummvm/commit/2f9967524f610f277c9c5109d1339e3e87957804

I've tested this on a lot of games. Most just use this in their core loop and classes but I've also tested the few that directly call kWait with a significant value.

Could someone with Hoyle5 please test the script patch that resurrects kWait in SCI32 and uses it in a spin loop? I don't have that game, but I've tested other kWait spin loops, and there shouldn't be a problem.