### PR TITLE
MADE: Remove unused variable

### DIFF
--- a/engines/made/made.cpp
+++ b/engines/made/made.cpp
@@ -56,8 +56,6 @@ static const GameSettings madeSettings[] = {
 
 MadeEngine::MadeEngine(OSystem *syst, const MadeGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc) {
 
-	const GameSettings *g;
-
 	_eventNum = 0;
 	_eventMouseX = _eventMouseY = 0;
 	_eventKey = 0;


### PR DESCRIPTION
Use of this variable was removed previously in commit 9ba6b7.

Removes the following compiler warning:

> engines/made/made.cpp: In constructor ‘Made::MadeEngine::MadeEngine(OSystem*, const Made::MadeGameDescription*)’:
engines/made/made.cpp:59:22: warning: unused variable ‘g’ [-Wunused-variable]
  const GameSettings *g;