### PR TITLE
SCUMM: (iMUSE/Amiga) - Fix compiler warning

### DIFF
--- a/engines/scumm/imuse/drivers/amiga.cpp
+++ b/engines/scumm/imuse/drivers/amiga.cpp
@@ -66,7 +66,7 @@ public:
 	void updateLevel();
 	void updateEnvelope();
 
-	uint8 note() const { return _note; }
+	uint8 getNote() const { return _note; }
 	SoundChannel_Amiga *next() const { return _next; }
 
 private:
@@ -504,7 +504,7 @@ void IMusePart_Amiga::send(uint32 b) {
 
 void IMusePart_Amiga::noteOff(byte note) {
 	for (SoundChannel_Amiga *cur = _out; cur; cur = cur->next()) {
-		if (note == cur->note()) {
+		if (note == cur->getNote()) {
 			if (_sustain)
 				cur->ctrl_sustain(true);
 			else


### PR DESCRIPTION
Class SoundChannel_Amiga has a function note() and function noteOn() has a parameter named note. This causes the following compiler warning:

> engines/scumm/imuse/drivers/amiga.cpp:` In member function ‘void Scumm::SoundChannel_Amiga::noteOn(byte, byte, byte, int8, int16)’:
engines/scumm/imuse/drivers/amiga.cpp:251:102: warning: declaration of ‘note’ shadows a member of 'this' [-Wshadow]
void SoundChannel_Amiga::noteOn(byte note, byte volume, byte program, int8 transpose, int16 pitchBend) {

As function note() is just a getter for private member _note and it is only used once,
I renamed it to getNote().

Renaming the function parameter note would also be possible, but this parameter is used more, and then maybe parameter note of function noteOff() should also be renamed to keep them similar.