### PR TITLE
COMPOSER: Make unload library error a warning

### DIFF
--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -535,7 +535,8 @@ void ComposerEngine::unloadLibrary(uint id) {
 		return;
 	}
 
-	error("tried to unload library %d, which isn't loaded", id);
+	warning("tried to unload library %d, which isn't loaded", id);
+	return;
 }
 
 bool ComposerEngine::hasResource(uint32 tag, uint16 id) {


### PR DESCRIPTION
This fixes Gregory and the Hot Air Balloon. See bug #11021.

This is just a quick and lazy fix. I have not looked into the underlying reason 
why the game tries to unload a library which isn't loaded in the first place,
but making it a warning does not seem to have any adverse effects.
