### PR TITLE
COMPOSER: Don't crash when skipping invalid animations

### DIFF
--- a/engines/composer/graphics.cpp
+++ b/engines/composer/graphics.cpp
@@ -151,8 +151,10 @@ void ComposerEngine::playAnimation(uint16 animId, int16 x, int16 y, int16 eventP
 
 	Animation *anim = NULL;
 	loadAnimation(anim, animId, x, y, eventParam);
-	_anims.push_back(anim);
-	runEvent(kEventAnimStarted, animId, eventParam, 0);
+	if (anim != NULL) {
+		_anims.push_back(anim);
+		runEvent(kEventAnimStarted, animId, eventParam, 0);
+	}
 }
 
 void ComposerEngine::stopAnimation(Animation *anim, bool localOnly, bool pipesOnly) {


### PR DESCRIPTION
Don't try to run a NULL animation. This fixes a segmentation
fault in Gregory and the Hot Air Balloon that sometimes occurs
when making sundaes.