### PR TITLE
WINTERMUTE: Fix language selection regression bug for Reversion

### DIFF
--- a/engines/wintermute/base/base_file_manager.cpp
+++ b/engines/wintermute/base/base_file_manager.cpp
@@ -228,38 +228,60 @@ bool BaseFileManager::registerPackages() {
 			// TODO: Select based on the gameDesc.
 			if (_language != Common::UNK_LANG) {
 				// English
-				if (_language != Common::EN_ANY && (fileName == "english.dcp" || fileName == "xlanguage_en.dcp" || fileName == "english_language_pack.dcp")) {
-					continue;
+				if (fileName == "english.dcp" || fileName == "xlanguage_en.dcp" || fileName == "english_language_pack.dcp") {
+					if (_language != Common::EN_ANY) {
+						continue;
+					}
 				// Chinese
-				} else if (_language != Common::ZH_CNA && (fileName == "chinese.dcp" || fileName == "xlanguage_nz.dcp" || fileName == "chinese_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "chinese.dcp" || fileName == "xlanguage_nz.dcp" || fileName == "chinese_language_pack.dcp") {
+					if (_language != Common::ZH_CNA) {
+						continue;
+					}
 				// Czech
-				} else if (_language != Common::CZ_CZE && (fileName == "czech.dcp" || fileName == "xlanguage_cz.dcp" || fileName == "czech_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "czech.dcp" || fileName == "xlanguage_cz.dcp" || fileName == "czech_language_pack.dcp") {
+					if (_language != Common::CZ_CZE) {
+						continue;
+					}
 				// French
-				} else if (_language != Common::FR_FRA && (fileName == "french.dcp" || fileName == "xlanguage_fr.dcp" || fileName == "french_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "french.dcp" || fileName == "xlanguage_fr.dcp" || fileName == "french_language_pack.dcp") {
+					if (_language != Common::FR_FRA) {
+						continue;
+					}
 				// German
-				} else if (_language != Common::DE_DEU && (fileName == "german.dcp" || fileName == "xlanguage_de.dcp" || fileName == "german_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "german.dcp" || fileName == "xlanguage_de.dcp" || fileName == "german_language_pack.dcp") {
+					if (_language != Common::DE_DEU) {
+						continue;
+					}
 				// Italian
-				} else if (_language != Common::IT_ITA && (fileName == "italian.dcp" || fileName == "xlanguage_it.dcp" || fileName == "italian_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "italian.dcp" || fileName == "xlanguage_it.dcp" || fileName == "italian_language_pack.dcp") {
+					if (_language != Common::IT_ITA) {
+						continue;
+					}
 				// Latvian
-				} else if (_language != Common::LV_LAT && (fileName == "latvian.dcp" || fileName == "xlanguage_lv.dcp" || fileName == "latvian_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "latvian.dcp" || fileName == "xlanguage_lv.dcp" || fileName == "latvian_language_pack.dcp") {
+					if (_language != Common::LV_LAT) {
+						continue;
+					}
 				// Polish
-				} else if (_language != Common::PL_POL && (fileName == "polish.dcp" || fileName == "xlanguage_pl.dcp" || fileName == "polish_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "polish.dcp" || fileName == "xlanguage_pl.dcp" || fileName == "polish_language_pack.dcp") {
+					if (_language != Common::PL_POL) {
+						continue;
+					}
 				// Portuguese
-				} else if (_language != Common::PT_BRA && (fileName == "portuguese.dcp" || fileName == "xlanguage_pt.dcp" || fileName == "portuguese_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "portuguese.dcp" || fileName == "xlanguage_pt.dcp" || fileName == "portuguese_language_pack.dcp") {
+					if (_language != Common::PT_BRA) {
+						continue;
+					}
 				// Russian
-				} else if (_language != Common::RU_RUS && (fileName == "russian.dcp" || fileName == "xlanguage_ru.dcp" || fileName == "russian_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "russian.dcp" || fileName == "xlanguage_ru.dcp" || fileName == "russian_language_pack.dcp") {
+					if (_language != Common::RU_RUS) {
+						continue;
+					}
 				// Spanish
-				} else if (_language != Common::ES_ESP && (fileName == "spanish.dcp" || fileName == "xlanguage_es.dcp" || fileName == "spanish_language_pack.dcp")) {
-					continue;
+				} else if (fileName == "spanish.dcp" || fileName == "xlanguage_es.dcp" || fileName == "spanish_language_pack.dcp") {
+					if (_language != Common::ES_ESP) {
+						continue;
+					}
 				// generic
 				} else if (fileName.hasPrefix("xlanguage_")) {
 					warning("Unknown language package: %s", fileName.c_str());

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -82,7 +82,7 @@ static const PlainGameDescriptor wintermuteGames[] = {
 	{"juliastars",      "J.U.L.I.A.: Among the Stars"},
 	{"juliastarshd",    "J.U.L.I.A.: Among the Stars HD"},
 	{"juliauntold",     "J.U.L.I.A.: Untold"},
-	{"mentelrepairs",   "Mental Repairs Inc"},
+	{"mentalrepairs",   "Mental Repairs Inc"},
 	{"mirage",          "Mirage"},
 	{"nighttrain",      "Night Train"},
 	{"oknytt",          "Oknytt"},
@@ -779,13 +779,13 @@ static const WMEGameDescription gameDescriptions[] = {
 
 	// Mental Repairs Inc (English)
 	// NOTE: This is a 2.5D game that is out of ScummVM scope
-	WME_WINENTRY("mentelrepairs", "",
+	WME_WINENTRY("mentalrepairs", "",
 		WME_ENTRY2s("data.dcp", "414d423bbff697f22fb38932f030e897", 59518068,
 					"english.dcp", "7573eb584e662adbc5fa3b1448e56106", 3160232), Common::EN_ANY, ADGF_UNSTABLE, WME_1_8_6),
 
 	// Mental Repairs Inc (German)
 	// NOTE: This is a 2.5D game that is out of ScummVM scope
-	WME_WINENTRY("mentelrepairs", "",
+	WME_WINENTRY("mentalrepairs", "",
 		WME_ENTRY2s("data.dcp", "414d423bbff697f22fb38932f030e897", 59518068,
 					"german.dcp", "af59a05ef29768e7fced3794a7a380a3", 3249142), Common::DE_DEU, ADGF_UNSTABLE, WME_1_8_6),
 


### PR DESCRIPTION
Ooops. Latest refactoring of those if/else blocks was wrong, as a result
Reversion 1&2 ignored all the xlanguage packages. Fixed.