### PR TITLE
SCI: Fix kDrawPic palette validation

### DIFF
--- a/engines/sci/graphics/picture.cpp
+++ b/engines/sci/graphics/picture.cpp
@@ -424,7 +424,6 @@ void GfxPicture::drawVectorData(const SciSpan<const byte> &data) {
 	byte pic_priority = 255, pic_control = 255;
 	int16 x = 0, y = 0, oldx, oldy;
 	byte EGApalettes[PIC_EGAPALETTE_TOTALSIZE] = {0};
-	byte *EGApalette = &EGApalettes[_EGApaletteNo * PIC_EGAPALETTE_SIZE];
 	byte EGApriority[PIC_EGAPRIORITY_SIZE] = {0};
 	bool isEGA = false;
 	uint curPos = 0;
@@ -438,8 +437,10 @@ void GfxPicture::drawVectorData(const SciSpan<const byte> &data) {
 
 	memset(&palette, 0, sizeof(palette));
 
-	if (_EGApaletteNo >= PIC_EGAPALETTE_COUNT)
+	if (_EGApaletteNo >= PIC_EGAPALETTE_COUNT) {
 		_EGApaletteNo = 0;
+	}
+	byte *EGApalette = &EGApalettes[_EGApaletteNo * PIC_EGAPALETTE_SIZE];
 
 	if (_resMan->getViewType() == kViewEga) {
 		isEGA = true;


### PR DESCRIPTION
This fixes kDrawPic's palette validation, fixing Camelot bug #11024.

Camelot calls kDrawPic 112 2 1 4 in the aqueduct to paint a black screen, but four is an invalid palette number.

GfxPicture::drawVectorData validates _EGApaletteNo by resetting it to zero if it's greater than three, the max legal value, but it does this after _EGApaletteNo has already been used to read from the array EGApalettes and set the pointer *EGApalette, and it doesn't reset the pointer, so it continues to read out of bounds values.

Visual Studio debug builds expose this, causing the pic to be drawn pink instead of black.
