### PR TITLE
COMMON: Support text wrapping with even width line segments

### DIFF
--- a/graphics/font.h
+++ b/graphics/font.h
@@ -175,8 +175,8 @@ public:
 	 * @param initWidth the starting width of the first line, for partially filled lines (optional)
 	 * @return the maximal width of any of the lines added to lines
 	 */
-	int wordWrapText(const Common::String &str, int maxWidth, Common::Array<Common::String> &lines, int initWidth = 0) const;
-	int wordWrapText(const Common::U32String &str, int maxWidth, Common::Array<Common::U32String> &lines, int initWidth = 0) const;
+	int wordWrapText(const Common::String &str, int maxWidth, Common::Array<Common::String> &lines, int initWidth = 0, bool evenWidthLinesModeEnabled = false, bool wrapOnExplicitNewLines = true) const;
+	int wordWrapText(const Common::U32String &str, int maxWidth, Common::Array<Common::U32String> &lines, int initWidth = 0, bool evenWidthLinesModeEnabled = false, bool wrapOnExplicitNewLines = true) const;
 
 private:
 	Common::String handleEllipsis(const Common::String &str, int w) const;

--- a/graphics/font.h
+++ b/graphics/font.h
@@ -173,6 +173,8 @@ public:
 	 * @param maxWidth  the maximum width a line may have
 	 * @param lines     the string list to which the text lines from str are appended
 	 * @param initWidth the starting width of the first line, for partially filled lines (optional)
+	 * @param evenWidthLinesModeEnabled if enabled, the resulting line segments will be close to the same width (optional)
+	 * @param wrapOnExplicitNewLines if enabled, forces wrapping on new line characters, otherwise treats them as single white space (optional)
 	 * @return the maximal width of any of the lines added to lines
 	 */
 	int wordWrapText(const Common::String &str, int maxWidth, Common::Array<Common::String> &lines, int initWidth = 0, bool evenWidthLinesModeEnabled = false, bool wrapOnExplicitNewLines = true) const;


### PR DESCRIPTION
The new arguments are optional. The lines segments will be close to the same width.

The algorithm is similar to the one we had for Blade Runner but not exactly the same, since that one would wrap a line at a white space after the theoretical split point (quotient of full line text width divided by target lines number)