### PR TITLE
WINTERMUTE: Add temporary debug logs for inspecting bug 6567

### DIFF
--- a/engines/wintermute/ad/ad_game.cpp
+++ b/engines/wintermute/ad/ad_game.cpp
@@ -2134,6 +2134,10 @@ bool AdGame::validMouse() {
 
 //////////////////////////////////////////////////////////////////////////
 bool AdGame::onMouseLeftDown() {
+	if (_debugCursorPos) {
+		LOG(0, "CURSOR: onMouseLeftDown");
+	}
+
 	if (!validMouse()) {
 		return STATUS_OK;
 	}
@@ -2167,6 +2171,10 @@ bool AdGame::onMouseLeftDown() {
 
 //////////////////////////////////////////////////////////////////////////
 bool AdGame::onMouseLeftUp() {
+	if (_debugCursorPos) {
+		LOG(0, "CURSOR: onMouseLeftUp");
+	}
+
 	if (_activeObject) {
 		_activeObject->handleMouse(MOUSE_RELEASE, MOUSE_BUTTON_LEFT);
 	}

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -359,6 +359,12 @@ bool BaseGame::initConfManSettings() {
 		}
 	}
 
+	if (ConfMan.hasKey("debug_cursor")) {
+		_debugCursorPos = ConfMan.getBool("debug_cursor");
+	} else {
+		_debugCursorPos = false;
+	}
+
 	if (ConfMan.hasKey("show_fps")) {
 		_debugShowFPS = ConfMan.getBool("show_fps");
 	} else {
@@ -599,7 +605,11 @@ bool BaseGame::initLoop() {
 	}
 	//_gameRef->LOG(0, "%d", _fps);
 
+	int32 oldX = _mousePos.x;
 	getMousePos(&_mousePos);
+	if (_debugCursorPos && _mousePos.x != oldX) {
+		LOG(0, "CURSOR: initLoop delta X %d: from %d to %d", _mousePos.x - oldX, oldX, _mousePos.x);
+	}
 
 	_focusedWindow = nullptr;
 	for (int i = _windows.size() - 1; i >= 0; i--) {
@@ -2383,7 +2393,12 @@ bool BaseGame::scSetProperty(const char *name, ScValue *value) {
 	// MouseX
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "MouseX") == 0) {
+		int32 oldX = _mousePos.x;
 		_mousePos.x = value->getInt();
+		if (_debugCursorPos && _mousePos.x != oldX) {
+			LOG(0, "CURSOR: scSetProperty delta X %d: from %d to %d", _mousePos.x - oldX, oldX, _mousePos.x);
+		}
+		
 		resetMousePos();
 		return STATUS_OK;
 	}

--- a/engines/wintermute/base/base_game.h
+++ b/engines/wintermute/base/base_game.h
@@ -166,6 +166,7 @@ public:
 	virtual ~BaseGame();
 
 	bool _debugDebugMode;
+	bool _debugCursorPos;
 
 	int32 _sequence;
 	virtual bool loadFile(const char *filename);


### PR DESCRIPTION
For some reason, on Amiga backend, while volume slider is pressed in 1
1/2 Ritter, mouse starts to move to the right slowly. I need additional
logs to see if mouse is moved by system or by game script. Details:
https://bugs.scummvm.org/ticket/6567

Those logs are active only when "debug_cursor" is set to true at
ConfMan, so normal usecases are not affected. However, I plan to revert
this PR once bug is closed.