### PR TITLE
 SWORD25: LUA: Remove direct use of ctype.h functions

### DIFF
--- a/common/util.cpp
+++ b/common/util.cpp
@@ -20,17 +20,7 @@
  *
  */
 
-#define FORBIDDEN_SYMBOL_EXCEPTION_isalnum
-#define FORBIDDEN_SYMBOL_EXCEPTION_isalpha
-#define FORBIDDEN_SYMBOL_EXCEPTION_isdigit
-#define FORBIDDEN_SYMBOL_EXCEPTION_isxdigit
-#define FORBIDDEN_SYMBOL_EXCEPTION_isnumber
-#define FORBIDDEN_SYMBOL_EXCEPTION_islower
-#define FORBIDDEN_SYMBOL_EXCEPTION_isspace
-#define FORBIDDEN_SYMBOL_EXCEPTION_isupper
-#define FORBIDDEN_SYMBOL_EXCEPTION_isprint
-#define FORBIDDEN_SYMBOL_EXCEPTION_ispunct
-
+#define FORBIDDEN_SYMBOL_EXCEPTION_ctype_h
 
 #include "common/util.h"
 #include "common/debug.h"
@@ -161,6 +151,16 @@ bool isPrint(int c) {
 bool isPunct(int c) {
 	ENSURE_ASCII_CHAR(c);
 	return ispunct((byte)c);
+}
+
+bool isCntrl(int c) {
+	ENSURE_ASCII_CHAR(c);
+	return iscntrl((byte)c);
+}
+
+bool isGraph(int c) {
+	ENSURE_ASCII_CHAR(c);
+	return isgraph((byte)c);
 }
 
 } // End of namespace Common

--- a/common/util.h
+++ b/common/util.h
@@ -195,15 +195,30 @@ bool isUpper(int c);
  */
 bool isPrint(int c);
 
-
 /**
  * Test whether the given character is a punctuation character,
- * (i.e not alphanumeric.
+ * (i.e. not alphanumeric).
  *
  * @param c		the character to test
  * @return		true if the character is punctuation, false otherwise.
  */
 bool isPunct(int c);
+
+/**
+ * Test whether the given character is a control character.
+ *
+ * @param c		the character to test
+ * @return		true if the character is a control character, false otherwise.
+ */
+bool isCntrl(int c);
+
+/**
+ * Test whether the given character has a graphical representation.
+ *
+ * @param c		the character to test
+ * @return		true if the character is a graphic, false otherwise.
+ */
+bool isGraph(int c);
 
 } // End of namespace Common
 

--- a/engines/sword25/util/lua/llex.cpp
+++ b/engines/sword25/util/lua/llex.cpp
@@ -4,9 +4,6 @@
 ** See Copyright Notice in lua.h
 */
 
-// FIXME: Do not directly use iscntrl from ctype.h.
-#define FORBIDDEN_SYMBOL_EXCEPTION_iscntrl
-
 #include "common/util.h"
 
 #define llex_c
@@ -78,7 +75,7 @@ void luaX_init (lua_State *L) {
 const char *luaX_token2str (LexState *ls, int token) {
   if (token < FIRST_RESERVED) {
     lua_assert(token == cast(unsigned char, token));
-    return (iscntrl(token)) ? luaO_pushfstring(ls->L, "char(%d)", token) :
+    return (Common::isCntrl(token)) ? luaO_pushfstring(ls->L, "char(%d)", token) :
                               luaO_pushfstring(ls->L, "%c", token);
   }
   else

--- a/engines/sword25/util/lua/lstrlib.cpp
+++ b/engines/sword25/util/lua/lstrlib.cpp
@@ -4,8 +4,7 @@
 ** See Copyright Notice in lua.h
 */
 
-
-#define FORBIDDEN_SYMBOL_EXCEPTION_ctype_h
+#include "common/util.h"
 
 #define lstrlib_c
 #define LUA_LIB
@@ -221,19 +220,19 @@ static const char *classend (MatchState *ms, const char *p) {
 static int match_class (int c, int cl) {
   int res;
   switch (tolower(cl)) {
-    case 'a' : res = isalpha(c); break;
-    case 'c' : res = iscntrl(c); break;
-    case 'd' : res = isdigit(c); break;
-    case 'l' : res = islower(c); break;
-    case 'p' : res = ispunct(c); break;
-    case 's' : res = isspace(c); break;
-    case 'u' : res = isupper(c); break;
-    case 'w' : res = isalnum(c); break;
-    case 'x' : res = isxdigit(c); break;
+    case 'a' : res = Common::isAlpha(c); break;
+    case 'c' : res = Common::isCntrl(c); break;
+    case 'd' : res = Common::isDigit(c); break;
+    case 'l' : res = Common::isLower(c); break;
+    case 'p' : res = Common::isPunct(c); break;
+    case 's' : res = Common::isSpace(c); break;
+    case 'u' : res = Common::isUpper(c); break;
+    case 'w' : res = Common::isAlnum(c); break;
+    case 'x' : res = Common::isXDigit(c); break;
     case 'z' : res = (c == 0); break;
     default: return (cl == c);
   }
-  return (islower(cl) ? res : !res);
+  return (Common::isLower(cl) ? res : !res);
 }
 
 
@@ -389,7 +388,7 @@ static const char *match (MatchState *ms, const char *s, const char *p) {
           p=ep; goto init;  /* else return match(ms, s, ep); */
         }
         default: {
-          if (isdigit(uchar(*(p+1)))) {  /* capture results (%0-%9)? */
+          if (Common::isDigit(uchar(*(p+1)))) {  /* capture results (%0-%9)? */
             s = match_capture(ms, s, uchar(*(p+1)));
             if (s == NULL) return NULL;
             p+=2; goto init;  /* else return match(ms, s, p+2) */
@@ -591,7 +590,7 @@ static void add_s (MatchState *ms, luaL_Buffer *b, const char *s,
       luaL_addchar(b, news[i]);
     else {
       i++;  /* skip ESC */
-      if (!isdigit(uchar(news[i])))
+      if (!Common::isDigit(uchar(news[i])))
         luaL_addchar(b, news[i]);
       else if (news[i] == '0')
           luaL_addlstring(b, s, e - s);
@@ -722,14 +721,14 @@ static const char *scanformat (lua_State *L, const char *strfrmt, char *form) {
   while (*p != '\0' && strchr(FLAGS, *p) != NULL) p++;  /* skip flags */
   if ((size_t)(p - strfrmt) >= sizeof(FLAGS))
     luaL_error(L, "invalid format (repeated flags)");
-  if (isdigit(uchar(*p))) p++;  /* skip width */
-  if (isdigit(uchar(*p))) p++;  /* (2 digits at most) */
+  if (Common::isDigit(uchar(*p))) p++;  /* skip width */
+  if (Common::isDigit(uchar(*p))) p++;  /* (2 digits at most) */
   if (*p == '.') {
     p++;
-    if (isdigit(uchar(*p))) p++;  /* skip precision */
-    if (isdigit(uchar(*p))) p++;  /* (2 digits at most) */
+    if (Common::isDigit(uchar(*p))) p++;  /* skip precision */
+    if (Common::isDigit(uchar(*p))) p++;  /* (2 digits at most) */
   }
-  if (isdigit(uchar(*p)))
+  if (Common::isDigit(uchar(*p)))
     luaL_error(L, "invalid format (width or precision too long)");
   *(form++) = '%';
   strncpy(form, strfrmt, p - strfrmt + 1);


### PR DESCRIPTION
Note that this PR conflicts with PR #1566.