### PR TITLE
SCI: Add detection entry for debug version of Codename: Iceman

### DIFF
--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -323,7 +323,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		AD_LISTEND},
 		Common::EN_ANY, Common::kPlatformDOS, 0, GUIO_STD16_UNDITHER	},
 
-	// Codename: Icmeman - English DOS Debug build, Version 1.009
+	// Codename: Iceman - English DOS Debug build, Version 1.009
 	// This is a special debug build Clint Basinger ("LGR") salvaged
 	// from a IBM PCjr previously owned by Ken Williams himself.
 	// It contains some additional shortcuts to help the original

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -323,6 +323,25 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		AD_LISTEND},
 		Common::EN_ANY, Common::kPlatformDOS, 0, GUIO_STD16_UNDITHER	},
 
+	// Codename: Icmeman - English DOS Debug build, Version 1.009
+	// This is a special debug build Clint Basinger ("LGR") salvaged
+	// from a IBM PCjr previously owned by Ken Williams himself.
+	// It contains some additional shortcuts to help the original
+	// developers debugging the game.
+	// More information: https://www.youtube.com/watch?v=Z-VBITW94zI
+	{"iceman", "Debug Build", {
+		{"resource.000", 0, "6be3ab7d8caba5b1df9035bdfbe8cd71", 76934},
+		{"resource.001", 0, "ede1d50e33d87c613c80269d01ddc78d", 82352},
+		{"resource.map", 0, "fe502e0aa91cc9b1a6c00a4d1fc40da4", 6480},
+		{"resource.002", 0, "40f3fa2071dbe2ade614ed5d973e2c10", 270289},
+		{"resource.003", 0, "bd25e8e73c5cbc7d922a3c383a188efe", 270148},
+		{"resource.004", 0, "cf4f3a19feaa4d453f11cdaf65db3275", 276896},
+		{"resource.005", 0, "088c4ee2dcd4df1e60c629ee2fb96cad", 281861},
+		{"resource.006", 0, "7a2eebdba905f24c2828f749a38060db", 276073},
+		{"resource.007", 0, "00a71915aeacc15358fe12837c785e76", 281152},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformDOS, 0, GUIO_STD16_UNDITHER	},
+
 	// Conquests of Camelot - English Amiga (from www.back2roots.org)
 	// Executable scanning reports "1.002.030"
 	// SCI interpreter version 0.000.685
@@ -3594,7 +3613,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 
 	// Police Quest 3 EGA
 	// Reported by musiclyinspired in bug report #3046573
-	{"pq3", "EGA", {
+	{"pq3", "", {
 		{"resource.map", 0, "1341f7c9643947414a8e238b88f68d82", 5901},
 		{"resource.000", 0, "7659713720d61d9465a59091b7ee63ea", 402208},
 		{"resource.001", 0, "0284ca44341fbc3cb7a047e49d230234", 703373},


### PR DESCRIPTION
This special debug build was salvaged by Clint Basinger ("LGR") from an IBM PCjr that was previously owned by Ken Williams from Sierra On-Line.

The story of this particular PC is pretty wild. Clint got it from a PC warehouse/thrift store and the most interesting stuff at the beginning was the pretty rare hard drive expansion. Later it was revealed that the PC was previously owned by Sierra On-Line. Later Ken Williams confirmed that the PC was previously owned by himself.

Clint managed to copy the files from the (almost dead) hard drive that only occasionally even started and uploaded them to archive.org.

Full video: https://www.youtube.com/watch?v=Z-VBITW94zI

Screenshots taken with ScummVM:
![scummvm00023](https://user-images.githubusercontent.com/11882577/61995924-ba5ccf80-b08e-11e9-83a5-cb7fe8a33d46.png)
![scummvm00024](https://user-images.githubusercontent.com/11882577/61995925-ba5ccf80-b08e-11e9-937f-5d22f7111996.png)
![scummvm00025](https://user-images.githubusercontent.com/11882577/61995926-ba5ccf80-b08e-11e9-968a-e72bb18782d0.png)
![scummvm00026](https://user-images.githubusercontent.com/11882577/61995927-baf56600-b08e-11e9-8798-1a08cad35222.png)
![scummvm00027](https://user-images.githubusercontent.com/11882577/61995928-baf56600-b08e-11e9-87f0-e61eead262f2.png)
