### PR TITLE
BACKENDS: Handle screen shaking in WindowedGraphicsManager

### DIFF
--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -86,6 +86,8 @@ ScalerProc *DINGUXSdlGraphicsManager::getGraphicsScalerProc(int mode) const {
 void DINGUXSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
 	assert(_transactionMode == kTransactionActive);
 
+	_gameScreenShakeOffset = 0;
+
 #ifdef USE_RGB_COLOR
 	// Avoid redundant format changes
 	Graphics::PixelFormat newFormat;
@@ -216,16 +218,16 @@ void DINGUXSdlGraphicsManager::internUpdateScreen() {
 #endif
 
 	// If the shake position changed, fill the dirty area with blackness
-	if (_currentShakePos != _newShakePos ||
+	if (_currentShakePos != _gameScreenShakeOffset ||
 		(_cursorNeedsRedraw && _mouseBackup.y <= _currentShakePos)) {
-		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_newShakePos * _videoMode.scaleFactor)};
+		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_gameScreenShakeOffset * _videoMode.scaleFactor)};
 
 		if (_videoMode.aspectRatioCorrection && !_overlayVisible)
 			blackrect.h = real2Aspect(blackrect.h - 1) + 1;
 
 		SDL_FillRect(_hwScreen, &blackrect, 0);
 
-		_currentShakePos = _newShakePos;
+		_currentShakePos = _gameScreenShakeOffset;
 
 		_forceRedraw = true;
 	}

--- a/backends/graphics/gph/gph-graphics.cpp
+++ b/backends/graphics/gph/gph-graphics.cpp
@@ -78,6 +78,8 @@ ScalerProc *GPHGraphicsManager::getGraphicsScalerProc(int mode) const {
 void GPHGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
 	assert(_transactionMode == kTransactionActive);
 
+	_gameScreenShakeOffset = 0;
+
 #ifdef USE_RGB_COLOR
 	// Avoid redundant format changes
 	Graphics::PixelFormat newFormat;
@@ -216,16 +218,16 @@ void GPHGraphicsManager::internUpdateScreen() {
 #endif
 
 	// If the shake position changed, fill the dirty area with blackness
-	if (_currentShakePos != _newShakePos ||
-	        (_cursorNeedsRedraw && _mouseBackup.y <= _currentShakePos)) {
-		SDL_Rect blackrect = {0, 0, _videoMode.screenWidth *_videoMode.scaleFactor, _newShakePos *_videoMode.scaleFactor};
+	if (_currentShakePos != _gameScreenShakeOffset ||
+		(_cursorNeedsRedraw && _mouseBackup.y <= _currentShakePos)) {
+		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_gameScreenShakeOffset * _videoMode.scaleFactor)};
 
 		if (_videoMode.aspectRatioCorrection && !_overlayVisible)
 			blackrect.h = real2Aspect(blackrect.h - 1) + 1;
 
 		SDL_FillRect(_hwScreen, &blackrect, 0);
 
-		_currentShakePos = _newShakePos;
+		_currentShakePos = _gameScreenShakeOffset;
 
 		_forceRedraw = true;
 	}

--- a/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
+++ b/backends/graphics/linuxmotosdl/linuxmotosdl-graphics.cpp
@@ -88,6 +88,8 @@ ScalerProc *LinuxmotoSdlGraphicsManager::getGraphicsScalerProc(int mode) const {
 void LinuxmotoSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
 	assert(_transactionMode == kTransactionActive);
 
+	_gameScreenShakeOffset = 0;
+
 #ifdef USE_RGB_COLOR
 	// Avoid redundant format changes
 	Graphics::PixelFormat newFormat;
@@ -247,15 +249,16 @@ void LinuxmotoSdlGraphicsManager::internUpdateScreen() {
 #endif
 
 	// If the shake position changed, fill the dirty area with blackness
-	if (_currentShakePos != _newShakePos) {
-		SDL_Rect blackrect = {0, 0, _videoMode.screenWidth * _videoMode.scaleFactor, _newShakePos * _videoMode.scaleFactor};
+	if (_currentShakePos != _gameScreenShakeOffset ||
+		(_cursorNeedsRedraw && _mouseBackup.y <= _currentShakePos)) {
+		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_gameScreenShakeOffset * _videoMode.scaleFactor)};
 
 		if (_videoMode.aspectRatioCorrection && !_overlayVisible)
 			blackrect.h = real2Aspect(blackrect.h - 1) + 1;
 
 		SDL_FillRect(_hwscreen, &blackrect, 0);
 
-		_currentShakePos = _newShakePos;
+		_currentShakePos = _gameScreenShakeOffset;
 
 		_forceFull = true;
 	}

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -93,8 +93,6 @@ public:
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override;
 	virtual void fillScreen(uint32 col) override;
 
-	virtual void setShakePos(int shakeOffset) override;
-
 	virtual void updateScreen() override;
 
 	virtual Graphics::Surface *lockScreen() override;
@@ -332,11 +330,6 @@ protected:
 	 * The game palette if in CLUT8 mode.
 	 */
 	byte _gamePalette[3 * 256];
-
-	/**
-	 * The offset by which the screen is moved vertically.
-	 */
-	int _gameScreenShakeOffset;
 
 	//
 	// Overlay

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -154,7 +154,7 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 	_scalerProc(0), _screenChangeCount(0),
 	_mouseData(nullptr), _mouseSurface(nullptr),
 	_mouseOrigSurface(nullptr), _cursorDontScale(false), _cursorPaletteDisabled(true),
-	_currentShakePos(0), _newShakePos(0),
+	_currentShakePos(0),
 	_paletteDirtyStart(0), _paletteDirtyEnd(0),
 	_screenIsLocked(false),
 	_graphicsMutex(0),
@@ -824,7 +824,7 @@ int SurfaceSdlGraphicsManager::getStretchMode() const {
 void SurfaceSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
 	assert(_transactionMode == kTransactionActive);
 
-	_newShakePos = 0;
+	_gameScreenShakeOffset = 0;
 
 #ifdef USE_RGB_COLOR
 	//avoid redundant format changes
@@ -1204,20 +1204,24 @@ void SurfaceSdlGraphicsManager::internUpdateScreen() {
 	ScalerProc *scalerProc;
 	int scale1;
 
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
 	// If the shake position changed, fill the dirty area with blackness
-	if (_currentShakePos != _newShakePos ||
+	// When building with SDL2, the shake offset is added to the active rect instead,
+	// so this isn't needed there.
+	if (_currentShakePos != _gameScreenShakeOffset ||
 		(_cursorNeedsRedraw && _mouseBackup.y <= _currentShakePos)) {
-		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_newShakePos * _videoMode.scaleFactor)};
+		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_gameScreenShakeOffset * _videoMode.scaleFactor)};
 
 		if (_videoMode.aspectRatioCorrection && !_overlayVisible)
 			blackrect.h = real2Aspect(blackrect.h - 1) + 1;
 
 		SDL_FillRect(_hwScreen, &blackrect, 0);
 
-		_currentShakePos = _newShakePos;
+		_currentShakePos = _gameScreenShakeOffset;
 
 		_forceRedraw = true;
 	}
+#endif
 
 	// Check whether the palette was changed in the meantime and update the
 	// screen surface accordingly.
@@ -1751,12 +1755,6 @@ void SurfaceSdlGraphicsManager::setCursorPalette(const byte *colors, uint start,
 
 	_cursorPaletteDisabled = false;
 	blitCursor();
-}
-
-void SurfaceSdlGraphicsManager::setShakePos(int shake_pos) {
-	assert(_transactionMode == kTransactionNone);
-
-	_newShakePos = shake_pos;
 }
 
 void SurfaceSdlGraphicsManager::setFocusRectangle(const Common::Rect &rect) {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -126,7 +126,6 @@ public:
 	virtual void unlockScreen() override;
 	virtual void fillScreen(uint32 col) override;
 	virtual void updateScreen() override;
-	virtual void setShakePos(int shakeOffset) override;
 	virtual void setFocusRectangle(const Common::Rect& rect) override;
 	virtual void clearFocusRectangle() override;
 
@@ -348,8 +347,8 @@ protected:
 	};
 
 	// Shake mode
+	// This is always set to 0 when building with SDL2.
 	int _currentShakePos;
-	int _newShakePos;
 
 	// Palette data
 	SDL_Color *_currentPalette;

--- a/backends/graphics/wincesdl/wincesdl-graphics.cpp
+++ b/backends/graphics/wincesdl/wincesdl-graphics.cpp
@@ -498,12 +498,17 @@ void WINCESdlGraphicsManager::internUpdateScreen() {
 	}
 
 	// If the shake position changed, fill the dirty area with blackness
-	if (_currentShakePos != _newShakePos) {
-		SDL_Rect blackrect = {0, 0, _videoMode.screenWidth *_scaleFactorXm / _scaleFactorXd, _newShakePos *_scaleFactorYm / _scaleFactorYd};
+	if (_currentShakePos != _gameScreenShakeOffset ||
+		(_cursorNeedsRedraw && _mouseBackup.y <= _currentShakePos)) {
+		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _scaleFactorXm / _scaleFactorXd), (Uint16)(_gameScreenShakeOffset * _scaleFactorYm / _scaleFactorYd)};
+
 		if (_videoMode.aspectRatioCorrection)
 			blackrect.h = real2Aspect(blackrect.h - 1) + 1;
+
 		SDL_FillRect(_hwScreen, &blackrect, 0);
-		_currentShakePos = _newShakePos;
+
+		_currentShakePos = _gameScreenShakeOffset;
+
 		_forceRedraw = true;
 	}
 

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -43,6 +43,7 @@ public:
 		_windowWidth(0),
 		_windowHeight(0),
 		_overlayVisible(false),
+		_gameScreenShakeOffset(0),
 		_forceRedraw(false),
 		_cursorVisible(false),
 		_cursorX(0),
@@ -70,6 +71,14 @@ public:
 		_activeArea.height = getHeight();
 		_overlayVisible = false;
 		_forceRedraw = true;
+	}
+
+	virtual void setShakePos(int shakeOffset) override {
+		if (_gameScreenShakeOffset != shakeOffset) {
+			_gameScreenShakeOffset = shakeOffset;
+			recalculateDisplayAreas();
+			_cursorNeedsRedraw = true;
+		}
 	}
 
 protected:
@@ -194,6 +203,7 @@ protected:
 			_activeArea.height = getHeight();
 		}
 	}
+
 	/**
 	 * Sets the position of the hardware mouse cursor in the host system,
 	 * relative to the window.
@@ -269,6 +279,11 @@ protected:
 	 * is visible or not.
 	 */
 	bool _overlayVisible;
+
+	/**
+	 * The offset by which the screen is moved vertically.
+	 */
+	int _gameScreenShakeOffset;
 
 	/**
 	 * The scaled draw rectangle for the game surface within the window.
@@ -367,8 +382,8 @@ private:
 			}
 		}
 
-		drawRect.left = (_windowWidth - width) / 2;
-		drawRect.top = (_windowHeight - height) / 2;
+		drawRect.left = ((_windowWidth - width) / 2);
+		drawRect.top = ((_windowHeight - height) / 2) + _gameScreenShakeOffset;
 		drawRect.setWidth(width);
 		drawRect.setHeight(height);
 	}


### PR DESCRIPTION
Note that the Vita backend appears to ignore the active DisplayArea, meaning that screen shaking is unlikely to work on the Vita with this PR.