### PR TITLE
QUEEN: skip talk on right click

### DIFF
--- a/engines/queen/input.cpp
+++ b/engines/queen/input.cpp
@@ -111,6 +111,8 @@ void Input::delay(uint amount) {
 
 			case Common::EVENT_LBUTTONDOWN:
 				_mouseButton |= MOUSE_LBUTTON;
+				if (_dialogueRunning)
+					_talkQuit = true;
 				break;
 
 			case Common::EVENT_RBUTTONDOWN:

--- a/engines/queen/input.cpp
+++ b/engines/queen/input.cpp
@@ -115,11 +115,16 @@ void Input::delay(uint amount) {
 
 			case Common::EVENT_RBUTTONDOWN:
 				_mouseButton |= MOUSE_RBUTTON;
+				if (_dialogueRunning)
+					_talkQuit = true;
 				break;
 			case Common::EVENT_RTL:
 			case Common::EVENT_QUIT:
 				if (_cutawayRunning)
 					_cutawayQuit = true;
+				// Allow using close button while dialogue is running
+				if (_dialogueRunning)
+					_talkQuit = true;
 				return;
 
 			default:

--- a/engines/queen/talk.cpp
+++ b/engines/queen/talk.cpp
@@ -734,8 +734,10 @@ void Talk::defaultAnimation(
 				_vm->update();
 			}
 
-			if (_vm->input()->talkQuit())
+			if (_vm->input()->talkQuit()) {
+				_vm->sound()->stopSpeech();
 				break;
+			}
 
 			if (_vm->logic()->joeWalk() == JWM_SPEAK) {
 				_vm->update();


### PR DESCRIPTION
DOS version of the game allows skip talking on right mouse click,
this commit adds support for this functionality.

Also, when talking the game ignores click on the close button (of the window)
until dialogue is ended. so it applies skip talk on this event as well.

old behaviour:
right click while talking -> wait for talking to end -> do action as if there was right click now
(if meanwhile mouse was moved, it clicks somewhere else).

new behaviour (matches DOS executable):
right click while talking -> skip dialogue -> do action because there was right click now.

Thanks

EDIT:
add skip talk to left click as well to match DOS executable