### PR TITLE
DISTS: Fix OpenGL renderer for builds with MSYS2

### DIFF
--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -398,6 +398,7 @@ void MSBuildProvider::createBuildProp(const BuildSetup &setup, bool isRelease, b
 	              "\t<PropertyGroup>\n"
 	              "\t\t<_PropertySheetDisplayName>" << setup.projectDescription << "_" << configuration << outputBitness << "</_PropertySheetDisplayName>\n"
 	              "\t\t<LinkIncremental>" << (isRelease ? "false" : "true") << "</LinkIncremental>\n"
+	              "\t\t<GenerateManifest>false</GenerateManifest>\n"
 	              "\t</PropertyGroup>\n"
 	              "\t<ItemDefinitionGroup>\n"
 	              "\t\t<ClCompile>\n";

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -289,6 +289,7 @@ void VisualStudioProvider::createBuildProp(const BuildSetup &setup, bool isRelea
 		              "\t<Tool\n"
 		              "\t\tName=\"VCLinkerTool\"\n"
 		              "\t\tLinkIncremental=\"1\"\n"
+		              "\t\tGenerateManifest=\"false\"\n"
 		              "\t\tIgnoreDefaultLibraryNames=\"\"\n"
 		              "\t\tSetChecksum=\"true\"\n";
 	} else {
@@ -305,6 +306,7 @@ void VisualStudioProvider::createBuildProp(const BuildSetup &setup, bool isRelea
 		              "\t<Tool\n"
 		              "\t\tName=\"VCLinkerTool\"\n"
 		              "\t\tLinkIncremental=\"2\"\n"
+		              "\t\tGenerateManifest=\"false\"\n"
 		              "\t\tGenerateDebugInformation=\"true\"\n"
 		              "\t\tIgnoreDefaultLibraryNames=\"libcmt.lib\"\n";
 	}

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -11,7 +11,9 @@
 #define IDI_ICON  1001
 #define IDI_COUNT 1002
 #define ID_GDF_XML __GDF_XML
+#define IDR_RT_MANIFEST1 1
 
+IDR_RT_MANIFEST1       RT_MANIFEST DISCARDABLE "dists/win32/scummvm.exe.manifest"
 IDI_ICON               ICON    DISCARDABLE     "icons/scummvm.ico"
 IDI_COUNT              ICON    DISCARDABLE     "icons/count.ico"
 
@@ -31,13 +33,13 @@ fonts.dat              FILE    "dists/engine-data/fonts.dat"
 #endif
 
 #if PLUGIN_ENABLED_STATIC(ACCESS)
-access.dat           FILE    "dists/engine-data/access.dat"
+access.dat             FILE    "dists/engine-data/access.dat"
 #endif
 #if PLUGIN_ENABLED_STATIC(CRYO)
 cryo.dat               FILE    "dists/engine-data/cryo.dat"
 #endif
 #if PLUGIN_ENABLED_STATIC(CRYOMNI3D)
-cryomni3d.dat               FILE    "dists/engine-data/cryomni3d.dat"
+cryomni3d.dat          FILE    "dists/engine-data/cryomni3d.dat"
 #endif
 #if PLUGIN_ENABLED_STATIC(DRASCULA)
 drascula.dat           FILE    "dists/engine-data/drascula.dat"
@@ -82,7 +84,7 @@ toon.dat               FILE    "dists/engine-data/toon.dat"
 wintermute.zip         FILE    "dists/engine-data/wintermute.zip"
 #endif
 #if PLUGIN_ENABLED_STATIC(XEEN)
-xeen.ccs         FILE    "dists/engine-data/xeen.ccs"
+xeen.ccs               FILE    "dists/engine-data/xeen.ccs"
 #endif
 #if PLUGIN_ENABLED_STATIC(AGI)
 pred.dic               FILE    "dists/pred.dic"

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -11,9 +11,8 @@
 #define IDI_ICON  1001
 #define IDI_COUNT 1002
 #define ID_GDF_XML __GDF_XML
-#define IDR_RT_MANIFEST1 1
 
-IDR_RT_MANIFEST1       RT_MANIFEST DISCARDABLE "dists/win32/scummvm.exe.manifest"
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "dists/win32/scummvm.exe.manifest"
 IDI_ICON               ICON    DISCARDABLE     "icons/scummvm.ico"
 IDI_COUNT              ICON    DISCARDABLE     "icons/count.ico"
 

--- a/dists/win32/scummvm.exe.manifest
+++ b/dists/win32/scummvm.exe.manifest
@@ -1,0 +1,9 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
DISTS: Fix OpenGL renderer for MSYS2/Mingw(64 or 32)

The issue pertains to MSYS2 adding a default manifest file (default-manifest.o) to the executable

The bug is for PC systems with GPU drivers that were not properly supported for Windows 10 systems, like Intel HD Graphics series 1rst and 2nd generations. In those systems, launching a game in ScummVM (built with MSYS2/Mingw) with the OpenGL renderer would cauase the game screen to be a white blank image, and various warnings would be output to the console eg.
"WARNING: GL ERROR: GL_INVALID_ENUM on glTexSubImage2D(0x0DE1, 0, 0, area.top, src.w, area.height(), _glFormat, _glType, src.gere.cpp:167)!"

This was due to MSYS2/Mingw builds trying to load the (poorly supported) GPU driver, while "advertising" support for Windows 10 in their embedded default Manifest file. Hence, the GPU driver dll (eg ig4icd64.dll for Intel HD graphic series) would be unloaded, causing the bug.

More information is available in the following links:
 * https://github.com/pal1000/save-legacy-intel-graphics

 * https://github.com/LWJGL/lwjgl/issues/119

 * https://github.com/msys2/MSYS2-packages/issues/454

 * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69880


