### PR TITLE
GUI: Minor fixes (scrollbars, tooltips, tabs, EditText)

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -1030,7 +1030,7 @@ void ThemeEngine::drawScrollbar(const Common::Rect &r, int sliderY, int sliderHe
 	drawDD(kDDScrollbarBase, r);
 
 	Common::Rect r2 = r;
-	const int buttonExtra = (r.width() * 120) / 100;
+	const int buttonExtra = r.width() + 1; // scrollbar.cpp's UP_DOWN_BOX_HEIGHT
 
 	r2.bottom = r2.top + buttonExtra;
 	drawDD(scrollState == kScrollbarStateUp ? kDDScrollbarButtonHover : kDDScrollbarButtonIdle, r2,

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -49,8 +49,8 @@ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 	const Graphics::Font *tooltipFont = g_gui.theme()->getFont(ThemeEngine::kFontStyleTooltip);
 
 	_wrappedLines.clear();
-	_w = tooltipFont->wordWrapText(widget->getTooltip(), _maxWidth - 4, _wrappedLines);
-	_h = (tooltipFont->getFontHeight() + 2) * _wrappedLines.size();
+	_w = tooltipFont->wordWrapText(widget->getTooltip(), _maxWidth - 4, _wrappedLines) + 4;
+	_h = (tooltipFont->getFontHeight() + 2) * _wrappedLines.size() + 4;
 
 	_x = MIN<int16>(parent->_x + x + _xdelta, g_gui.getWidth() - _w - 3);
 	_y = MIN<int16>(parent->_y + y + _ydelta, g_gui.getHeight() - _h - 3);
@@ -62,9 +62,11 @@ void Tooltip::drawDialog(DrawLayer layerToDraw) {
 
 	Dialog::drawDialog(layerToDraw);
 
+	int16 textX = _x + 3; // including 2px padding and 1px original code shift
+	int16 textY = _y + 3;
 	for (Common::StringArray::const_iterator i = _wrappedLines.begin(); i != _wrappedLines.end(); ++i, ++num) {
 		g_gui.theme()->drawText(
-			Common::Rect(_x + 1, _y + 1 + num * h, _x + 1 + _w, _y + 1 + (num + 1) * h),
+			Common::Rect(textX, textY + num * h, textX + _w, textY + (num + 1) * h),
 			*i,
 			ThemeEngine::kStateEnabled,
 			Graphics::kTextAlignLeft,

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -100,7 +100,7 @@ void EditTextWidget::drawWidget() {
 	setTextDrawableArea(r);
 
 	g_gui.theme()->drawText(
-			Common::Rect(_x + 2 + _leftPadding, _y + 2, _x + _leftPadding + getEditRect().width() + 2, _y + _h),
+			Common::Rect(_x + 2 + _leftPadding, _y + 1, _x + _leftPadding + getEditRect().width() + 2, _y + _h),
 			_editString, _state, Graphics::kTextAlignLeft, ThemeEngine::kTextInversionNone,
 			-_editScrollOffset, false, _font, ThemeEngine::kFontColorNormal, true, _textDrawableArea);
 }

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -41,7 +41,7 @@ ListWidget::ListWidget(Dialog *boss, const String &name, const char *tooltip, ui
 	// This ensures that _entriesPerPage is properly initialized.
 	reflowLayout();
 
-	_scrollBar = new ScrollBarWidget(this, _w - _scrollBarWidth + 1, 0, _scrollBarWidth, _h);
+	_scrollBar = new ScrollBarWidget(this, _w - _scrollBarWidth, 0, _scrollBarWidth, _h);
 	_scrollBar->setTarget(this);
 
 	setFlags(WIDGET_ENABLED | WIDGET_CLEARBG | WIDGET_RETAIN_FOCUS | WIDGET_WANT_TICKLE);
@@ -72,7 +72,7 @@ ListWidget::ListWidget(Dialog *boss, int x, int y, int w, int h, const char *too
 	// This ensures that _entriesPerPage is properly initialized.
 	reflowLayout();
 
-	_scrollBar = new ScrollBarWidget(this, _w - _scrollBarWidth + 1, 0, _scrollBarWidth, _h);
+	_scrollBar = new ScrollBarWidget(this, _w - _scrollBarWidth, 0, _scrollBarWidth, _h);
 	_scrollBar->setTarget(this);
 
 	setFlags(WIDGET_ENABLED | WIDGET_CLEARBG | WIDGET_RETAIN_FOCUS | WIDGET_WANT_TICKLE);
@@ -658,7 +658,7 @@ void ListWidget::reflowLayout() {
 	assert(_entriesPerPage > 0);
 
 	if (_scrollBar) {
-		_scrollBar->resize(_w - _scrollBarWidth + 1, 0, _scrollBarWidth, _h);
+		_scrollBar->resize(_w - _scrollBarWidth, 0, _scrollBarWidth, _h);
 		scrollBarRecalc();
 		scrollToCurrent();
 	}

--- a/gui/widgets/scrollcontainer.cpp
+++ b/gui/widgets/scrollcontainer.cpp
@@ -80,8 +80,8 @@ void ScrollContainerWidget::recalc() {
 	_verticalScroll->_currentPos = _scrolledY;
 	_verticalScroll->_entriesPerPage = _limitH;
 	_verticalScroll->_singleStep = kLineHeight;
-	_verticalScroll->setPos(_w - scrollbarWidth, _scrolledY+1);
-	_verticalScroll->setSize(scrollbarWidth, _limitH -2);
+	_verticalScroll->setPos(_w - scrollbarWidth, _scrolledY);
+	_verticalScroll->setSize(scrollbarWidth, _limitH-1);
 }
 
 
@@ -147,7 +147,7 @@ void ScrollContainerWidget::reflowLayout() {
 }
 
 void ScrollContainerWidget::drawWidget() {
-	g_gui.theme()->drawDialogBackground(Common::Rect(_x, _y, _x + _w, _y + getHeight() - 1), _backgroundType);
+	g_gui.theme()->drawDialogBackground(Common::Rect(_x, _y, _x + _w, _y + getHeight()), _backgroundType);
 }
 
 bool ScrollContainerWidget::containsWidget(Widget *w) const {
@@ -167,7 +167,7 @@ Widget *ScrollContainerWidget::findWidget(int x, int y) {
 
 Common::Rect ScrollContainerWidget::getClipRect() const {
 	// Make sure the clipping rect contains the scrollbar so it is properly redrawn
-	return Common::Rect(getAbsX(), getAbsY(), getAbsX() + _w, getAbsY() + getHeight());
+	return Common::Rect(getAbsX(), getAbsY(), getAbsX() + _w, getAbsY() + getHeight() - 1); // this -1 is because of container border, which might not be present actually
 }
 
 void ScrollContainerWidget::setBackgroundType(ThemeEngine::DialogBackground backgroundType) {

--- a/gui/widgets/tab.cpp
+++ b/gui/widgets/tab.cpp
@@ -62,7 +62,7 @@ void TabWidget::init() {
 	_bodyLP = g_gui.xmlEval()->getVar("Globals.TabWidget.Body.Padding.Left");
 	_bodyRP = g_gui.xmlEval()->getVar("Globals.TabWidget.Body.Padding.Right");
 
-	_butRP = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButtonPadding.Right", 0);
+	_butRP = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.Padding.Right", 0);
 	_butTP = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.Padding.Top", 0);
 	_butW = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.Width", 10);
 	_butH = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.Height", 10);
@@ -258,9 +258,9 @@ void TabWidget::reflowLayout() {
 	_minTabWidth = g_gui.xmlEval()->getVar("Globals.TabWidget.Tab.Width");
 	_titleVPad = g_gui.xmlEval()->getVar("Globals.TabWidget.Tab.Padding.Top");
 
-	_butRP = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.PaddingRight", 0);
+	_butRP = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.Padding.Right", 0);
 	_butTP = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.Padding.Top", 0);
-	_butW = g_gui.xmlEval()->getVar("GlobalsTabWidget.NavButton.Width", 10);
+	_butW = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.Width", 10);
 	_butH = g_gui.xmlEval()->getVar("Globals.TabWidget.NavButton.Height", 10);
 
 	// If widgets were added or removed in the current tab, without tabs
@@ -375,7 +375,7 @@ Widget *TabWidget::findWidget(int x, int y) {
 void TabWidget::computeLastVisibleTab(bool adjustFirstIfRoom) {
 	int availableWidth = _w;
 	if (_navButtonsVisible)
-		availableWidth -= 2 + _butW * 2;
+		availableWidth -= 2 + _butW * 2 + _butRP;
 
 	_lastVisibleTab = _tabs.size() - 1;
 	for (int i = _firstVisibleTab; i < (int)_tabs.size(); ++i) {


### PR DESCRIPTION
I've been making a custom theme based on Modern Remastered these couple of days (I call it Midnight theme). While I was at it, I locally fixed some things in GUI. Well, some changes are not really fixes, but edits that I thought look better.

These **are not** changes for my theme only, but sometimes they are better illustrated with my theme (scrollbars, for example). Below are pics comparing what was before the fixes and after these in both my theme and Modern Remastered (click to view in full size).

### 15ee60f

- list widget scrollbar is not cropped on the right now:

![01_cropped_scrollbar_in_list_widget fw](https://user-images.githubusercontent.com/1948111/62371364-e41a6880-b55e-11e9-918f-53dc394947bf.png)

.

- scrollbar buttons now take as much space as they should, not overlapping with scrollbar handle:

![02_scrollbar_buttons_size fw](https://user-images.githubusercontent.com/1948111/62371372-ec72a380-b55e-11e9-8a12-3e3080272827.png)

(illustrated in Midnight theme only, because Modern Remastered does not have any background or borders in scrollbar buttons, so you cannot see the overlapping)

### 95b8c99

- scrollbar repositioned in ScrollContainerWidget, and widget itself is now drawn so its bottom border goes lower than clipped contents:

![03_scroll_container fw](https://user-images.githubusercontent.com/1948111/62371457-20e65f80-b55f-11e9-8730-8cf172ea8612.png)

(unfortunately, I couldn't resize scrollbar to have the same height as container  for my Midnight theme, because then in Modern Remastered it overlap tabs not 1px, but 2px. As a result, we can see these "double borders" in Midnight)

(we can see that "tab" drawstep behaves strangely, and draws 2 more pixels where ScrollContainerWidget's area already begins; using "square" drawstep in Midnight theme solves that and looks more tidy)

### be1e8ae

- added 2px padding in tooltip:

![04_tooltip fw](https://user-images.githubusercontent.com/1948111/62371466-26dc4080-b55f-11e9-95d9-7974e2f2cb23.png)

.

- shifted text in EditTextWidget 1px up, so it's more vertical aligned:

![05_edittext fw](https://user-images.githubusercontent.com/1948111/62371485-2cd22180-b55f-11e9-98dd-0a1ffe58394e.png)

### 7dda053

- fixed TabWidget's < and > buttons to use values from the theme:

![06_tab_buttons fw](https://user-images.githubusercontent.com/1948111/62371496-32c80280-b55f-11e9-9667-b44b487a8e3a.png)

.
 
And a long pic for lowres:

![07_lowres fw](https://user-images.githubusercontent.com/1948111/62371520-3e1b2e00-b55f-11e9-9bd5-cbb3b8cb5167.png)

.

So, 15ee60f and 7dda053 are actual fixes (cropped scrollbar, TabWidget typos) and 95b8c99 with be1e8ae are just my edits that look prettier (vertical aligned text in EditText, 2px margin in tooltip, repositioned scrollbar).

P.S. Midnight theme is available [on my site](http://tkachov.ru/scummvm/themes/midnight/)