### PR TITLE
BACKENDS: Remove the directory creation functionality

### DIFF
--- a/backends/fs/abstract-fs.h
+++ b/backends/fs/abstract-fs.h
@@ -191,15 +191,6 @@ public:
 	 * @return pointer to the stream object, 0 in case of a failure
 	 */
 	virtual Common::WriteStream *createWriteStream() = 0;
-
-	/**
-	* Creates a file referred by this node.
-	*
-	* @param isDirectoryFlag true if created file must be a directory
-	*
-	* @return true if file is created successfully
-	*/
-	virtual bool create(bool isDirectoryFlag) = 0;
 };
 
 

--- a/backends/fs/amigaos4/amigaos4-fs.cpp
+++ b/backends/fs/amigaos4/amigaos4-fs.cpp
@@ -443,9 +443,4 @@ Common::WriteStream *AmigaOSFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 
-bool AmigaOSFilesystemNode::create(bool isDirectoryFlag) {
-	error("Not supported");
-	return false;
-}
-
 #endif //defined(__amigaos4__)

--- a/backends/fs/amigaos4/amigaos4-fs.h
+++ b/backends/fs/amigaos4/amigaos4-fs.h
@@ -116,7 +116,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 };
 
 

--- a/backends/fs/chroot/chroot-fs.cpp
+++ b/backends/fs/chroot/chroot-fs.cpp
@@ -100,11 +100,6 @@ Common::WriteStream *ChRootFilesystemNode::createWriteStream() {
 	return _realNode->createWriteStream();
 }
 
-bool ChRootFilesystemNode::create(bool isDirectoryFlag) {
-	error("Not supported");
-	return false;
-}
-
 Common::String ChRootFilesystemNode::addPathComponent(const Common::String &path, const Common::String &component) {
 	const char sep = '/';
 	if (path.lastChar() == sep && component.firstChar() == sep) {

--- a/backends/fs/chroot/chroot-fs.h
+++ b/backends/fs/chroot/chroot-fs.h
@@ -49,7 +49,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 
 private:
 	static Common::String addPathComponent(const Common::String &path, const Common::String &component);

--- a/backends/fs/ds/ds-fs.cpp
+++ b/backends/fs/ds/ds-fs.cpp
@@ -211,11 +211,6 @@ Common::WriteStream *DSFileSystemNode::createWriteStream() {
 	return Common::wrapBufferedWriteStream(stream, WRITE_BUFFER_SIZE);
 }
 
-bool DSFileSystemNode::create(bool isDirectoryFlag) {
-	error("Not supported");
-	return false;
-}
-
 //////////////////////////////////////////////////////////////////////////
 // GBAMPFileSystemNode - File system using GBA Movie Player and CF card //
 //////////////////////////////////////////////////////////////////////////

--- a/backends/fs/ds/ds-fs.h
+++ b/backends/fs/ds/ds-fs.h
@@ -91,7 +91,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 
 	/**
 	 * Returns the zip file this node points to.

--- a/backends/fs/n64/n64-fs.cpp
+++ b/backends/fs/n64/n64-fs.cpp
@@ -160,9 +160,4 @@ Common::WriteStream *N64FilesystemNode::createWriteStream() {
 	return RomfsStream::makeFromPath(getPath(), true);
 }
 
-bool N64FilesystemNode::create(bool isDirectoryFlag) {
-	error("Not supported");
-	return false;
-}
-
 #endif //#ifdef __N64__

--- a/backends/fs/n64/n64-fs.h
+++ b/backends/fs/n64/n64-fs.h
@@ -73,7 +73,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 };
 
 #endif

--- a/backends/fs/posix/posix-fs.cpp
+++ b/backends/fs/posix/posix-fs.cpp
@@ -299,35 +299,6 @@ Common::WriteStream *POSIXFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 
-bool POSIXFilesystemNode::create(bool isDirectoryFlag) {
-	bool success;
-
-	if (isDirectoryFlag) {
-		success = mkdir(_path.c_str(), 0755) == 0;
-	} else {
-		int fd = open(_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0755);
-		success = fd >= 0;
-
-		if (fd >= 0) {
-			close(fd);
-		}
-	}
-
-	if (success) {
-		setFlags();
-		if (_isValid) {
-			if (_isDirectory != isDirectoryFlag) warning("failed to create %s: got %s", isDirectoryFlag ? "directory" : "file", _isDirectory ? "directory" : "file");
-			return _isDirectory == isDirectoryFlag;
-		}
-
-		warning("POSIXFilesystemNode: %s() was a success, but stat indicates there is no such %s",
-			isDirectoryFlag ? "mkdir" : "creat", isDirectoryFlag ? "directory" : "file");
-		return false;
-	}
-
-	return false;
-}
-
 namespace Posix {
 
 bool assureDirectoryExists(const Common::String &dir, const char *prefix) {

--- a/backends/fs/posix/posix-fs.h
+++ b/backends/fs/posix/posix-fs.h
@@ -68,7 +68,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 
 private:
 	/**

--- a/backends/fs/ps2/ps2-fs.cpp
+++ b/backends/fs/ps2/ps2-fs.cpp
@@ -443,9 +443,4 @@ Common::WriteStream *Ps2FilesystemNode::createWriteStream() {
 	return PS2FileStream::makeFromPath(getPath(), true);
 }
 
-bool Ps2FilesystemNode::create(bool isDirectoryFlag) {
-	error("Not supported");
-	return false;
-}
-
 #endif

--- a/backends/fs/ps2/ps2-fs.h
+++ b/backends/fs/ps2/ps2-fs.h
@@ -96,7 +96,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 
 	int getDev() { return 0; }
 };

--- a/backends/fs/psp/psp-fs.cpp
+++ b/backends/fs/psp/psp-fs.cpp
@@ -239,9 +239,4 @@ Common::WriteStream *PSPFilesystemNode::createWriteStream() {
 	return Common::wrapBufferedWriteStream(stream, WRITE_BUFFER_SIZE);
 }
 
-bool PSPFilesystemNode::create(bool isDirectoryFlag) {
-	error("Not supported");
-	return false;
-}
-
 #endif //#ifdef __PSP__

--- a/backends/fs/psp/psp-fs.h
+++ b/backends/fs/psp/psp-fs.h
@@ -65,7 +65,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 };
 
 #endif

--- a/backends/fs/riscos/riscos-fs.cpp
+++ b/backends/fs/riscos/riscos-fs.cpp
@@ -198,35 +198,6 @@ Common::WriteStream *RISCOSFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 
-bool RISCOSFilesystemNode::create(bool isDirectoryFlag) {
-	bool success;
-
-	if (isDirectoryFlag) {
-		success = _swix(OS_File, _INR(0,1), 8, RISCOS_Utils::toRISCOS(_path).c_str()) == NULL;
-	} else {
-		int fd = open(_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0755);
-		success = fd >= 0;
-
-		if (fd >= 0) {
-			close(fd);
-		}
-	}
-
-	if (success) {
-		if (exists()) {
-			_isDirectory = _swi(OS_File, _INR(0,1)|_RETURN(0), 20, RISCOS_Utils::toRISCOS(_path).c_str()) == 2;
-			if (_isDirectory != isDirectoryFlag) warning("failed to create %s: got %s", isDirectoryFlag ? "directory" : "file", _isDirectory ? "directory" : "file");
-			return _isDirectory == isDirectoryFlag;
-		}
-
-		warning("RISCOSFilesystemNode: Attempting to create a %s was a success, but access indicates there is no such %s",
-			isDirectoryFlag ? "directory" : "file", isDirectoryFlag ? "directory" : "file");
-		return false;
-	}
-
-	return false;
-}
-
 namespace Riscos {
 
 bool assureDirectoryExists(const Common::String &dir, const char *prefix) {

--- a/backends/fs/riscos/riscos-fs.h
+++ b/backends/fs/riscos/riscos-fs.h
@@ -67,7 +67,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 };
 
 namespace Riscos {

--- a/backends/fs/symbian/symbian-fs.cpp
+++ b/backends/fs/symbian/symbian-fs.cpp
@@ -232,9 +232,4 @@ Common::WriteStream *SymbianFilesystemNode::createWriteStream() {
 	return SymbianStdioStream::makeFromPath(getPath(), true);
 }
 
-bool SymbianFilesystemNode::create(bool isDirectoryFlag) {
-	error("Not supported");
-	return false;
-}
-
 #endif //#if defined(__SYMBIAN32__)

--- a/backends/fs/symbian/symbian-fs.h
+++ b/backends/fs/symbian/symbian-fs.h
@@ -66,7 +66,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 };
 
 #endif

--- a/backends/fs/wii/wii-fs.cpp
+++ b/backends/fs/wii/wii-fs.cpp
@@ -213,9 +213,4 @@ Common::WriteStream *WiiFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 
-bool WiiFilesystemNode::create(bool isDirectoryFlag) {
-	error("Not supported");
-	return false;
-}
-
 #endif //#if defined(__WII__)

--- a/backends/fs/wii/wii-fs.h
+++ b/backends/fs/wii/wii-fs.h
@@ -69,7 +69,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 };
 
 #endif

--- a/backends/fs/windows/windows-fs.cpp
+++ b/backends/fs/windows/windows-fs.cpp
@@ -244,36 +244,4 @@ Common::WriteStream *WindowsFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 
-bool WindowsFilesystemNode::create(bool isDirectoryFlag) {
-	bool success;
-
-	if (isDirectoryFlag) {
-		success = CreateDirectory(toUnicode(_path.c_str()), NULL) != 0;
-	} else {
-		success = CreateFile(toUnicode(_path.c_str()), GENERIC_READ|GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL) != INVALID_HANDLE_VALUE;
-	}
-
-	if (success) {
-		//this piece is copied from constructor, it checks that file exists and detects whether it's a directory
-		DWORD fileAttribs = GetFileAttributes(toUnicode(_path.c_str()));
-		if (fileAttribs != INVALID_FILE_ATTRIBUTES) {
-			_isDirectory = ((fileAttribs & FILE_ATTRIBUTE_DIRECTORY) != 0);
-			_isValid = true;
-			// Add a trailing slash, if necessary.
-			if (_isDirectory && _path.lastChar() != '\\') {
-				_path += '\\';
-			}
-
-			if (_isDirectory != isDirectoryFlag) warning("failed to create %s: got %s", isDirectoryFlag ? "directory" : "file", _isDirectory ? "directory" : "file");
-			return _isDirectory == isDirectoryFlag;
-		}
-
-		warning("WindowsFilesystemNode: Create%s() was a success, but GetFileAttributes() indicates there is no such %s",
-			    isDirectoryFlag ? "Directory" : "File", isDirectoryFlag ? "directory" : "file");
-		return false;
-	}
-
-	return false;
-}
-
 #endif //#ifdef WIN32

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -84,7 +84,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
 
 private:
 	/**

--- a/backends/networking/sdl_net/handlers/createdirectoryhandler.cpp
+++ b/backends/networking/sdl_net/handlers/createdirectoryhandler.cpp
@@ -99,11 +99,8 @@ void CreateDirectoryHandler::handle(Client &client) {
 			return;
 		}
 	} else {
-		// create the <directory_name> in <path>
-		if (!node->create(true)) {
-			handleError(client, _("Failed to create the directory!"));
-			return;
-		}
+		handleError(client, _("Directory does not exist!"));
+		return;
 	}
 
 	// if json requested, respond with it

--- a/backends/platform/dc/dc-fs.cpp
+++ b/backends/platform/dc/dc-fs.cpp
@@ -57,7 +57,6 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream() { return 0; }
-	virtual bool create(bool isDirectoryFlag) { return false; }
 
 	static AbstractFSNode *makeFileNodePath(const Common::String &path);
 };

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -166,8 +166,8 @@ bool DumpFile::open(const String &filename, bool createPath) {
 					delete node;
 					continue;
 				}
-				if (!node->create(true)) warning("DumpFile: unable to create directories from path prefix");
 				delete node;
+				error("DumpFile: directory does not exist");
 			}
 		}
 	}


### PR DESCRIPTION
It's a poorly supported feature (only 3 backend file system implementations support it, and 8 don't), and it's only used in two places in the codebase, where it can be disabled.

This is a different approach than the one taken in pull request #1727: the directory creation feature is removed, as it's poorly supported in the different file system implementations (only 3 support it, and 8 don't)