### PR TITLE
 BACKENDS: Rename and simplify AbstractFSNode::create()

### DIFF
--- a/backends/fs/abstract-fs.h
+++ b/backends/fs/abstract-fs.h
@@ -193,13 +193,11 @@ public:
 	virtual Common::WriteStream *createWriteStream() = 0;
 
 	/**
-	* Creates a file referred by this node.
+	* Creates a directory referred by this node.
 	*
-	* @param isDirectoryFlag true if created file must be a directory
-	*
-	* @return true if file is created successfully
+	* @return true if the directory is created successfully
 	*/
-	virtual bool create(bool isDirectoryFlag) = 0;
+	virtual bool createDirectory() = 0;
 };
 
 

--- a/backends/fs/amigaos4/amigaos4-fs.cpp
+++ b/backends/fs/amigaos4/amigaos4-fs.cpp
@@ -444,8 +444,8 @@ Common::WriteStream *AmigaOSFilesystemNode::createWriteStream() {
 }
 
 bool AmigaOSFilesystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	warning("AmigaOSFilesystemNode::createDirectory(): Not supported");
+	return _bIsValid && _bIsDirectory;
 }
 
 #endif //defined(__amigaos4__)

--- a/backends/fs/amigaos4/amigaos4-fs.cpp
+++ b/backends/fs/amigaos4/amigaos4-fs.cpp
@@ -443,7 +443,7 @@ Common::WriteStream *AmigaOSFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 
-bool AmigaOSFilesystemNode::create(bool isDirectoryFlag) {
+bool AmigaOSFilesystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }

--- a/backends/fs/amigaos4/amigaos4-fs.h
+++ b/backends/fs/amigaos4/amigaos4-fs.h
@@ -116,7 +116,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 };
 
 

--- a/backends/fs/chroot/chroot-fs.cpp
+++ b/backends/fs/chroot/chroot-fs.cpp
@@ -100,7 +100,7 @@ Common::WriteStream *ChRootFilesystemNode::createWriteStream() {
 	return _realNode->createWriteStream();
 }
 
-bool ChRootFilesystemNode::create(bool isDirectoryFlag) {
+bool ChRootFilesystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }

--- a/backends/fs/chroot/chroot-fs.cpp
+++ b/backends/fs/chroot/chroot-fs.cpp
@@ -101,8 +101,7 @@ Common::WriteStream *ChRootFilesystemNode::createWriteStream() {
 }
 
 bool ChRootFilesystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	return _realNode->createDirectory();
 }
 
 Common::String ChRootFilesystemNode::addPathComponent(const Common::String &path, const Common::String &component) {

--- a/backends/fs/chroot/chroot-fs.h
+++ b/backends/fs/chroot/chroot-fs.h
@@ -49,7 +49,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 
 private:
 	static Common::String addPathComponent(const Common::String &path, const Common::String &component);

--- a/backends/fs/ds/ds-fs.cpp
+++ b/backends/fs/ds/ds-fs.cpp
@@ -212,8 +212,7 @@ Common::WriteStream *DSFileSystemNode::createWriteStream() {
 }
 
 bool DSFileSystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	return _isValid && _isDirectory;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -399,8 +398,8 @@ Common::WriteStream *GBAMPFileSystemNode::createWriteStream() {
 }
 
 bool GBAMPFileSystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	warning("GBAMPFileSystemNode::createDirectory(): Not supported");
+	return _isValid && _isDirectory;
 }
 
 

--- a/backends/fs/ds/ds-fs.cpp
+++ b/backends/fs/ds/ds-fs.cpp
@@ -211,7 +211,7 @@ Common::WriteStream *DSFileSystemNode::createWriteStream() {
 	return Common::wrapBufferedWriteStream(stream, WRITE_BUFFER_SIZE);
 }
 
-bool DSFileSystemNode::create(bool isDirectoryFlag) {
+bool DSFileSystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }
@@ -398,7 +398,7 @@ Common::WriteStream *GBAMPFileSystemNode::createWriteStream() {
 	return Common::wrapBufferedWriteStream(stream, WRITE_BUFFER_SIZE);
 }
 
-bool GBAMPFileSystemNode::create(bool isDirectoryFlag) {
+bool GBAMPFileSystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }

--- a/backends/fs/ds/ds-fs.h
+++ b/backends/fs/ds/ds-fs.h
@@ -91,7 +91,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 
 	/**
 	 * Returns the zip file this node points to.
@@ -157,7 +157,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 };
 
 struct fileHandle {

--- a/backends/fs/n64/n64-fs.cpp
+++ b/backends/fs/n64/n64-fs.cpp
@@ -160,7 +160,7 @@ Common::WriteStream *N64FilesystemNode::createWriteStream() {
 	return RomfsStream::makeFromPath(getPath(), true);
 }
 
-bool N64FilesystemNode::create(bool isDirectoryFlag) {
+bool N64FilesystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }

--- a/backends/fs/n64/n64-fs.cpp
+++ b/backends/fs/n64/n64-fs.cpp
@@ -161,8 +161,7 @@ Common::WriteStream *N64FilesystemNode::createWriteStream() {
 }
 
 bool N64FilesystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	return _isValid && _isDirectory;
 }
 
 #endif //#ifdef __N64__

--- a/backends/fs/n64/n64-fs.h
+++ b/backends/fs/n64/n64-fs.h
@@ -73,7 +73,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 };
 
 #endif

--- a/backends/fs/posix/posix-fs.cpp
+++ b/backends/fs/posix/posix-fs.cpp
@@ -299,33 +299,11 @@ Common::WriteStream *POSIXFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 
-bool POSIXFilesystemNode::create(bool isDirectoryFlag) {
-	bool success;
-
-	if (isDirectoryFlag) {
-		success = mkdir(_path.c_str(), 0755) == 0;
-	} else {
-		int fd = open(_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0755);
-		success = fd >= 0;
-
-		if (fd >= 0) {
-			close(fd);
-		}
-	}
-
-	if (success) {
+bool POSIXFilesystemNode::createDirectory() {
+	if (mkdir(_path.c_str(), 0755) == 0)
 		setFlags();
-		if (_isValid) {
-			if (_isDirectory != isDirectoryFlag) warning("failed to create %s: got %s", isDirectoryFlag ? "directory" : "file", _isDirectory ? "directory" : "file");
-			return _isDirectory == isDirectoryFlag;
-		}
 
-		warning("POSIXFilesystemNode: %s() was a success, but stat indicates there is no such %s",
-			isDirectoryFlag ? "mkdir" : "creat", isDirectoryFlag ? "directory" : "file");
-		return false;
-	}
-
-	return false;
+	return _isValid && _isDirectory;
 }
 
 namespace Posix {

--- a/backends/fs/posix/posix-fs.h
+++ b/backends/fs/posix/posix-fs.h
@@ -68,7 +68,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 
 private:
 	/**

--- a/backends/fs/ps2/ps2-fs.cpp
+++ b/backends/fs/ps2/ps2-fs.cpp
@@ -443,7 +443,7 @@ Common::WriteStream *Ps2FilesystemNode::createWriteStream() {
 	return PS2FileStream::makeFromPath(getPath(), true);
 }
 
-bool Ps2FilesystemNode::create(bool isDirectoryFlag) {
+bool Ps2FilesystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }

--- a/backends/fs/ps2/ps2-fs.cpp
+++ b/backends/fs/ps2/ps2-fs.cpp
@@ -444,8 +444,8 @@ Common::WriteStream *Ps2FilesystemNode::createWriteStream() {
 }
 
 bool Ps2FilesystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	warning("Ps2FilesystemNode::createDirectory(): Not supported");
+	return _isHere && _isDirectory;
 }
 
 #endif

--- a/backends/fs/ps2/ps2-fs.h
+++ b/backends/fs/ps2/ps2-fs.h
@@ -96,7 +96,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 
 	int getDev() { return 0; }
 };

--- a/backends/fs/psp/psp-fs.cpp
+++ b/backends/fs/psp/psp-fs.cpp
@@ -240,8 +240,8 @@ Common::WriteStream *PSPFilesystemNode::createWriteStream() {
 }
 
 bool PSPFilesystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	warning("PSPFilesystemNode::createDirectory(): Not supported");
+	return _isValid && _isDirectory;
 }
 
 #endif //#ifdef __PSP__

--- a/backends/fs/psp/psp-fs.cpp
+++ b/backends/fs/psp/psp-fs.cpp
@@ -239,7 +239,7 @@ Common::WriteStream *PSPFilesystemNode::createWriteStream() {
 	return Common::wrapBufferedWriteStream(stream, WRITE_BUFFER_SIZE);
 }
 
-bool PSPFilesystemNode::create(bool isDirectoryFlag) {
+bool PSPFilesystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }

--- a/backends/fs/psp/psp-fs.h
+++ b/backends/fs/psp/psp-fs.h
@@ -65,7 +65,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 };
 
 #endif

--- a/backends/fs/riscos/riscos-fs.h
+++ b/backends/fs/riscos/riscos-fs.h
@@ -67,7 +67,12 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
+private:
+	/**
+	 * Tests and sets the _isValid and _isDirectory flags, using OS_File 20.
+	 */
+	virtual void setFlags();
 };
 
 namespace Riscos {

--- a/backends/fs/symbian/symbian-fs.cpp
+++ b/backends/fs/symbian/symbian-fs.cpp
@@ -233,8 +233,8 @@ Common::WriteStream *SymbianFilesystemNode::createWriteStream() {
 }
 
 bool SymbianFilesystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	warning("SymbianFilesystemNode::createDirectory(): Not supported");
+	return _isValid && _isDirectory;
 }
 
 #endif //#if defined(__SYMBIAN32__)

--- a/backends/fs/symbian/symbian-fs.cpp
+++ b/backends/fs/symbian/symbian-fs.cpp
@@ -232,7 +232,7 @@ Common::WriteStream *SymbianFilesystemNode::createWriteStream() {
 	return SymbianStdioStream::makeFromPath(getPath(), true);
 }
 
-bool SymbianFilesystemNode::create(bool isDirectoryFlag) {
+bool SymbianFilesystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }

--- a/backends/fs/symbian/symbian-fs.h
+++ b/backends/fs/symbian/symbian-fs.h
@@ -66,7 +66,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 };
 
 #endif

--- a/backends/fs/wii/wii-fs.cpp
+++ b/backends/fs/wii/wii-fs.cpp
@@ -214,8 +214,8 @@ Common::WriteStream *WiiFilesystemNode::createWriteStream() {
 }
 
 bool WiiFilesystemNode::createDirectory() {
-	error("Not supported");
-	return false;
+	warning("WiiFilesystemNode::createDirectory(): Not supported");
+	return _exists && _isDirectory;
 }
 
 #endif //#if defined(__WII__)

--- a/backends/fs/wii/wii-fs.cpp
+++ b/backends/fs/wii/wii-fs.cpp
@@ -213,7 +213,7 @@ Common::WriteStream *WiiFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 
-bool WiiFilesystemNode::create(bool isDirectoryFlag) {
+bool WiiFilesystemNode::createDirectory() {
 	error("Not supported");
 	return false;
 }

--- a/backends/fs/wii/wii-fs.h
+++ b/backends/fs/wii/wii-fs.h
@@ -69,7 +69,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 };
 
 #endif

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -84,7 +84,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream();
-	virtual bool create(bool isDirectoryFlag);
+	virtual bool createDirectory();
 
 private:
 	/**
@@ -114,6 +114,11 @@ private:
 	 * @return str in Unicode format.
 	 */
 	static const TCHAR* toUnicode(const char *str);
+
+	/**
+	 * Tests and sets the _isValid and _isDirectory flags, using the GetFileAttributes() function.
+	 */
+	virtual void setFlags();
 };
 
 #endif

--- a/backends/networking/sdl_net/handlers/createdirectoryhandler.cpp
+++ b/backends/networking/sdl_net/handlers/createdirectoryhandler.cpp
@@ -100,7 +100,7 @@ void CreateDirectoryHandler::handle(Client &client) {
 		}
 	} else {
 		// create the <directory_name> in <path>
-		if (!node->create(true)) {
+		if (!node->createDirectory()) {
 			handleError(client, _("Failed to create the directory!"));
 			return;
 		}

--- a/backends/platform/dc/dc-fs.cpp
+++ b/backends/platform/dc/dc-fs.cpp
@@ -71,6 +71,7 @@ public:
 	virtual AbstractFSNode *getChild(const Common::String &n) const;
 	virtual bool getChildren(AbstractFSList &list, ListMode mode, bool hidden) const;
 	virtual Common::SeekableReadStream *createReadStream() { return 0; }
+	virtual bool createDirectory() { return true; }
 };
 
 /* A file/directory which does not exist */

--- a/backends/platform/dc/dc-fs.cpp
+++ b/backends/platform/dc/dc-fs.cpp
@@ -57,7 +57,7 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream();
 	virtual Common::WriteStream *createWriteStream() { return 0; }
-	virtual bool create(bool isDirectoryFlag) { return false; }
+	virtual bool createDirectory() { return false; }
 
 	static AbstractFSNode *makeFileNodePath(const Common::String &path);
 };

--- a/backends/platform/tizen/fs.cpp
+++ b/backends/platform/tizen/fs.cpp
@@ -439,3 +439,8 @@ Common::WriteStream *TizenFilesystemNode::createWriteStream() {
 	}
 	return result;
 }
+
+bool TizenFilesystemNode::createDirectory() {
+	warning("TizenFilesystemNode::createDirectory(): Not supported");
+	return _isValid && isDirectory();
+}

--- a/backends/platform/tizen/fs.h
+++ b/backends/platform/tizen/fs.h
@@ -83,6 +83,7 @@ public:
 
 	Common::SeekableReadStream *createReadStream();
 	Common::WriteStream *createWriteStream();
+	bool createDirectory();
 
 protected:
 	TizenFilesystemNode(const Common::String &root, const Common::String &p);

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -166,7 +166,7 @@ bool DumpFile::open(const String &filename, bool createPath) {
 					delete node;
 					continue;
 				}
-				if (!node->create(true)) warning("DumpFile: unable to create directories from path prefix");
+				if (!node->createDirectory()) warning("DumpFile: unable to create directories from path prefix");
 				delete node;
 			}
 		}


### PR DESCRIPTION
This PR includes only the changes from PR #1727 related to AbstractFSNode. Merging this PR should allow implementations of `createDirectory()` to be worked on independently of PR #1727.