### PR TITLE
PSP: Implement AbstractFSNode::createDirectory()

### DIFF
--- a/backends/fs/psp/psp-fs.cpp
+++ b/backends/fs/psp/psp-fs.cpp
@@ -240,7 +240,21 @@ Common::WriteStream *PSPFilesystemNode::createWriteStream() {
 }
 
 bool PSPFilesystemNode::createDirectory() {
-	warning("PSPFilesystemNode::createDirectory(): Not supported");
+	DEBUG_ENTER_FUNC();
+
+	if (PowerMan.beginCriticalSection() == PowerManager::Blocked)
+		PSP_DEBUG_PRINT_FUNC("Suspended\n");	// Make sure to block in case of suspend
+
+	PSP_DEBUG_PRINT_FUNC("path [%s]\n", _path.c_str());
+
+	if (sceIoMkdir(_path.c_str(), 0777) == 0) {
+		struct stat st;
+		_isValid = (0 == stat(_path.c_str(), &st));
+		_isDirectory = S_ISDIR(st.st_mode);
+	}
+
+	PowerMan.endCriticalSection();
+
 	return _isValid && _isDirectory;
 }
 


### PR DESCRIPTION
Originally from PR #1727. This change has not been tested.