### PR TITLE
XEEN: Fix typo

### DIFF
--- a/devtools/create_xeen/constants.cpp
+++ b/devtools/create_xeen/constants.cpp
@@ -1308,7 +1308,7 @@ const char *const ARMOR_NAMES[14] = {
 };
 
 const char *const ACCESSORY_NAMES[11] = {
-	nullptr, "ring ", "belt ", "broach ", "medal ", "charm ", "cameo ",
+	nullptr, "ring ", "belt ", "brooch ", "medal ", "charm ", "cameo ",
 	"scarab ", "pendant ", "necklace ", "amulet "
 };
 


### PR DESCRIPTION
This fixes a small typo in the `create_xeen` tool.