### PR TITLE
SCI32: Fix Mirrored Pic Drawing

### DIFF
--- a/engines/sci/graphics/screen_item32.cpp
+++ b/engines/sci/graphics/screen_item32.cpp
@@ -377,8 +377,7 @@ void ScreenItem::calcRects(const Plane &plane) {
 				}
 				temp.translate((celObjPic->_relativePosition.x * scriptToScreenX).toInt() - originX, 0);
 
-				// TODO: This is weird.
-				int deltaX = plane._planeRect.width() - temp.right - 1 - temp.left;
+				int deltaX = plane._planeRect.width() - temp.right - temp.left;
 
 				_scaledPosition.x += deltaX;
 				_screenItemRect.translate(deltaX, 0);
@@ -424,8 +423,7 @@ void ScreenItem::calcRects(const Plane &plane) {
 				}
 				temp.translate(celObjPic->_relativePosition.x - (originX * scaleX).toInt(), celObjPic->_relativePosition.y - (celObj._origin.y * scaleY).toInt());
 
-				// TODO: This is weird.
-				int deltaX = plane._gameRect.width() - temp.right - 1 - temp.left;
+				int deltaX = plane._gameRect.width() - temp.right - temp.left;
 
 				_scaledPosition.x += deltaX;
 				_screenItemRect.translate(deltaX, 0);


### PR DESCRIPTION
This fixes an off by one error in our SCI32 mirrored pic drawing. This can be seen in any room with style property bit $0400. The pic is drawn one coordinate to the left of where it should be and leaves a line of garbage on the right or left edge of the screen, depending on the compiler.

This fixes at least QFG4, which has many mirrored rooms such as 551, and LSL6 Hi Res rooms 305, 640, and 680.

Confirmed in disassembly. Fixes bug #10748