### PR TITLE
TSAGE: Removed "pirated" flag from Spanish fanmade translation

### DIFF
--- a/engines/tsage/detection_tables.h
+++ b/engines/tsage/detection_tables.h
@@ -186,8 +186,7 @@ static const tSageGameDescription gameDescriptions[] = {
 		GF_CD | GF_ALT_REGIONS | GF_DEMO
 	},
 
-	// Return to Ringworld. Spanish fan translation. They provide the entire game for download,
-	// so it's being treated as pirated, and not supported
+	// Return to Ringworld. Spanish fan translation.
 	{
 		{
 			"ringworld2",
@@ -195,7 +194,7 @@ static const tSageGameDescription gameDescriptions[] = {
 			AD_ENTRY1s("r2rw.rlb", "05f9af7b0153a0c5727022dc0122d02b", 47678672),
 			Common::ES_ESP,
 			Common::kPlatformDOS,
-			ADGF_CD | ADGF_PIRATED,
+			ADGF_CD,
 			GUIO0()
 		},
 		GType_Ringworld2,


### PR DESCRIPTION
TSAGE: Removed "pirated" flag from Spanish fanmade translation

I have been talking to the translation team... they didn't mean to distribute any "pirate" version.
At first, they just released the modified files and didn't notice they were releasing all the needed files to run the game... the same way they have done with all other translations in their webpage (http://www.pakolmo.galeon.com), but this time with a fatal result. They have presented their apologies for that

Now they have changed the downladed file to a patch requiring the original game to be applied.
http://www.pakolmo.galeon.com/RingWorld2.htm