### PR TITLE
VITA: Use activeArea rectangle also on Vita

### DIFF
--- a/backends/graphics/psp2sdl/psp2sdl-graphics.h
+++ b/backends/graphics/psp2sdl/psp2sdl-graphics.h
@@ -40,12 +40,10 @@ protected:
 	virtual bool hotswapGFXMode() override;
 
 	virtual void updateShader() override;
-	virtual void setAspectRatioCorrection(bool enable) override;
 	virtual SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags) override;
 	virtual void SDL_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects) override;
 	void PSP2_UpdateFiltering();
 
-	bool _hardwareAspectRatioCorrection;
 	vita2d_texture *_vitatex_hwscreen;
 	void *_sdlpixels_hwscreen;
 	vita2d_shader *_shaders[6];


### PR DESCRIPTION
This PR changes the Vita graphics manager so that the AR correction and game screen texture scaling is done similarly to other surfaceSDL platforms. However, several issues came to light concerning aspect ratio correction now that Vita does it similarly as other platforms:

- AR doesn't work at all in Dreamweb when using 2x or 1x rendering. I observe this also on latest MacOS nightly. It works using OpenGL on MacOS though.

- AR works just fine in the main menu, and seems to work fine in Monkey Island on first glance. On closer inspection, enabling AR causes dirty rect gfx glitches in Monkey Island when the mouse is moved across the screen (warped) with the analog stick or touch input. When the cursor is close to the top edge of the screen, also significant slowdown occurs, not just flickering of rects.

- AR Is done via software scaling instead of adapting activeArea dimensions. I suspect a historical reason for this but it seems unnecessary and also slower.

These problems only appear when the aspect ratio correction tickbox is on. Otherwise everything seems to work fine.

Thanks to @ccawley2011 for pointing me towards this.
