### PR TITLE
BACKENDS: add Fit to window (4:3) stretch mode to SDL2 backend

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -76,6 +76,7 @@ const OSystem::GraphicsMode s_supportedStretchModes[] = {
 	{"pixel-perfect", _s("Pixel-perfect scaling"), STRETCH_INTEGRAL},
 	{"fit", _s("Fit to window"), STRETCH_FIT},
 	{"stretch", _s("Stretch to window"), STRETCH_STRETCH},
+	{"fit_force_aspect", _s("Fit to window (4:3)"), STRETCH_FIT_FORCE_ASPECT},
 	{nullptr, nullptr, 0}
 };
 #endif

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -34,7 +34,8 @@ enum {
 	STRETCH_CENTER = 0,
 	STRETCH_INTEGRAL = 1,
 	STRETCH_FIT = 2,
-	STRETCH_STRETCH = 3
+	STRETCH_STRETCH = 3,
+	STRETCH_FIT_FORCE_ASPECT = 4
 };
 
 class WindowedGraphicsManager : virtual public GraphicsManager {
@@ -341,6 +342,7 @@ private:
 		// Mode Integral = scale by an integral amount.
 		// Mode Fit      = scale to fit the window while respecting the aspect ratio
 		// Mode Stretch  = scale and stretch to fit the window without respecting the aspect ratio
+		// Mode Fit Force Aspect = scale to fit the window while forcing a 4:3 aspect ratio
 
 		int width = 0, height = 0;
 		if (mode == STRETCH_CENTER || mode == STRETCH_INTEGRAL) {
@@ -359,7 +361,13 @@ private:
 			frac_t windowAspect = intToFrac(_windowWidth) / _windowHeight;
 			width = _windowWidth;
 			height = _windowHeight;
-			if (mode != STRETCH_STRETCH) {
+			if (mode == STRETCH_FIT_FORCE_ASPECT) {
+				frac_t ratio = intToFrac(4) / 3;
+				if (windowAspect < ratio)
+					height = intToFrac(width) / ratio;
+				else if (windowAspect > ratio)
+					width = fracToInt(height * ratio);
+			} else if (mode != STRETCH_STRETCH) {
 				if (windowAspect < displayAspect)
 					height = intToFrac(width) / displayAspect;
 				else if (windowAspect > displayAspect)


### PR DESCRIPTION
This simple PR adds a fourth stretch mode to the SDL2 backend, called "Fit to window (4:3)". It fits the screen to the window similar to the existing "Fit to window" stretch mode, but enforces a 4:3 aspect ratio.

Using this stretch mode and unticking the "aspect ratio correction" does hardware aspect ratio correction on all SDL2 platforms, making use of the SDL2 scaler. This is similar to what has always been done on Vita.

This method is faster and often better looking than the software aspect ratio correction that can be enabled with the checkbox.

One downside compared to checking the "aspect ratio correction" tick mark is that the menu and user interface will also be hardware-scaled just like the game screen. This means the menu font, mouse pointer and buttons will look slightly stretched. But that is just the same as with all other stretch modes.