### PR TITLE
COMMON: added support for reading ini files with different 8bit encod…

### DIFF
--- a/common/ini-file.cpp
+++ b/common/ini-file.cpp
@@ -29,10 +29,16 @@
 namespace Common {
 
 bool INIFile::isValidName(const String &name) const {
+	if (_allowNonEnglishCharacters)
+		return true;
 	const char *p = name.c_str();
 	while (*p && (isAlnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == ' '))
 		p++;
 	return *p == 0;
+}
+
+INIFile::INIFile() {
+	_allowNonEnglishCharacters = false;
 }
 
 void INIFile::clear() {
@@ -102,7 +108,7 @@ bool INIFile::loadFromStream(SeekableReadStream &stream) {
 			// is, verify that it only consists of alphanumerics,
 			// periods, dashes and underscores). Mohawk Living Books games
 			// can have periods in their section names.
-			while (*p && (isAlnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == ' '))
+			while (*p && ((_allowNonEnglishCharacters && *p != ']') || isAlnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == ' '))
 				p++;
 
 			if (*p == '\0')
@@ -433,6 +439,10 @@ void INIFile::Section::removeKey(const String &key) {
 			return;
 		}
 	}
+}
+
+void INIFile::allowNonEnglishCharacters() {
+	_allowNonEnglishCharacters = true;
 }
 
 } // End of namespace Common

--- a/common/ini-file.h
+++ b/common/ini-file.h
@@ -77,7 +77,7 @@ public:
 	typedef List<Section> SectionList;
 
 public:
-	INIFile() {}
+	INIFile();
 	~INIFile() {}
 
 	// TODO: Maybe add a copy constructor etc.?
@@ -115,8 +115,11 @@ public:
 
 	void listKeyValues(StringMap &kv);
 
+	void allowNonEnglishCharacters();
+
 private:
 	SectionList _sections;
+	bool _allowNonEnglishCharacters;
 
 	Section *getSection(const String &section);
 	const Section *getSection(const String &section) const;


### PR DESCRIPTION
This pull request adds support for reading ini files with encodings like CP-1250, CP-1251, CP-1252, etc.
Currently, those ini files can't be read because isAlnum function returns zero for chars which are not standard ASCII characterts.