### PR TITLE
GRAPHICS: Display Mac monochrome cursor inverted pixels

### DIFF
--- a/engines/sci/graphics/cursor.cpp
+++ b/engines/sci/graphics/cursor.cpp
@@ -508,7 +508,10 @@ void GfxCursor::kernelSetMacCursor(GuiResourceId viewNum, int loopNum, int celNu
 	Common::MemoryReadStream resStream(resource->toStream());
 	Graphics::MacCursor *macCursor = new Graphics::MacCursor();
 
-	if (!macCursor->readFromStream(resStream)) {
+	// use black for mac monochrome inverted pixels so that cursor
+	//  features in FPFP and KQ6 Mac are displayed, bug #7050
+	byte macMonochromeInvertedPixelColor = 0;
+	if (!macCursor->readFromStream(resStream, false, macMonochromeInvertedPixelColor)) {
 		warning("Failed to load Mac cursor %d", viewNum);
 		delete macCursor;
 		return;

--- a/graphics/maccursor.h
+++ b/graphics/maccursor.h
@@ -63,11 +63,11 @@ public:
 	uint16 getPaletteCount() const { return 256; }
 
 	/** Read the cursor's data out of a stream. */
-	bool readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome = false);
+	bool readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome = false, byte monochromeInvertedPixelColor = 0xff);
 
 private:
-	bool readFromCURS(Common::SeekableReadStream &stream);
-	bool readFromCRSR(Common::SeekableReadStream &stream, bool forceMonochrome);
+	bool readFromCURS(Common::SeekableReadStream &stream, byte monochromeInvertedPixelColor);
+	bool readFromCRSR(Common::SeekableReadStream &stream, bool forceMonochrome, byte monochromeInvertedPixelColor);
 
 	byte *_surface;
 	byte _palette[256 * 3];


### PR DESCRIPTION
This adds limited support for Macintosh monochrome cursors that have inverted pixels. Currently ScummvM treats these as transparent and so FPFP and KQ6 are missing cursor features, bug #7050.

Mac monochrome cursors have a 1 bit per pixel image and mask. Bits that are set in the image but not the mask are a fourth color other than black, white, or transparent: the underlying target pixel would be inverted. The knob on the classic mac watch cursor is an example of this:

![watch](https://user-images.githubusercontent.com/22204938/63396560-51f6ca80-c37c-11e9-9ec5-413ab242c306.png)

The Waiting cursor from FPFP also does this:

![fpfp_wait](https://user-images.githubusercontent.com/22204938/63396573-5cb15f80-c37c-11e9-8a29-5e31d35f7bca.png)

This PR does not add inversion. That would change the cursor interface layers, and as I understand it, require implementing inversion in each backend. That's a lot of files to touch to make a handful of mac cursors look better and I wouldn't be able to test most of those changes.

Instead, this small change to MacCursor allows an engine to specify an optional color to use for monochrome inverted pixels. For SCI that's black. FPFP and KQ6 are the only two SCI games I'm aware of that have mac monochrome cursors. Of those, only ten cursor even contain inverted pixels and most just have one or two pixels so it's indistinguishable either way, but the rest are improved by restoring their missing features:

![curs](https://user-images.githubusercontent.com/22204938/63396672-b31e9e00-c37c-11e9-86e2-b9836cc7389f.png)

This is opt-in behavior, this PR doesn't change other engines. The full inversion effect could be added later now that the issue is known.