### PR TITLE
AUDIO: (opl2lpt) add OPL3LPT support

### DIFF
--- a/audio/fmopl.cpp
+++ b/audio/fmopl.cpp
@@ -45,7 +45,7 @@ namespace ALSA {
 
 #ifdef ENABLE_OPL2LPT
 namespace OPL2LPT {
-	OPL *create();
+	OPL *create(Config::OplType type);
 } // End of namespace OPL2LPT
 #endif // ENABLE_OPL2LPT
 
@@ -57,7 +57,8 @@ enum OplEmulator {
 	kDOSBox = 2,
 	kALSA = 3,
 	kNuked = 4,
-	kOPL2LPT = 5
+	kOPL2LPT = 5,
+	kOPL3LPT = 6
 };
 
 OPL::OPL() {
@@ -79,7 +80,8 @@ const Config::EmulatorDescription Config::_drivers[] = {
 	{ "alsa", _s("ALSA Direct FM"), kALSA, kFlagOpl2 | kFlagDualOpl2 | kFlagOpl3 },
 #endif
 #ifdef ENABLE_OPL2LPT
-	{ "opl2lpt", _s("OPL2LPT"), kOPL2LPT, kFlagOpl2 },
+	{ "opl2lpt", _s("OPL2LPT"), kOPL2LPT, kFlagOpl2},
+	{ "opl3lpt", _s("OPL3LPT"), kOPL3LPT, kFlagOpl2 | kFlagOpl3 },
 #endif
 	{ 0, 0, 0, 0 }
 };
@@ -205,10 +207,18 @@ OPL *Config::create(DriverId driver, OplType type) {
 
 #ifdef ENABLE_OPL2LPT
 	case kOPL2LPT:
-		if (type == kOpl2)
-			return OPL2LPT::create();
-		else
-			warning("OPL2LPT only supports OPL2");
+		if (type == kOpl2) {
+			return OPL2LPT::create(type);
+		}
+
+		warning("OPL2LPT only supprts OPL2");
+		return 0;
+	case kOPL3LPT:
+		if (type == kOpl2 || type == kOpl3) {
+			return OPL2LPT::create(type);
+		}
+
+		warning("OPL3LPT does not support dual OPL2");
 		return 0;
 #endif
 


### PR DESCRIPTION
The OPL3LPT is like the OPL2LPT with an OPL3 chip.  Add OPL3 support to the existing OPL2LPT driver.

There is no auto-detection of OPL3 capability. The user is required to explicitly select OPL3LPT as their OPL device.

Tested with Sam & Max Hit the Road.