### PR TITLE
SDL: Use a non-const string for SDL_iconv_string

### DIFF
--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -774,6 +774,17 @@ char *OSystem_SDL::convertEncoding(const char *to, const char *from, const char 
 		zeroBytes = 2;
 	if (Common::String(from).hasPrefixIgnoreCase("utf-32"))
 		zeroBytes = 4;
+
+	// SDL_iconv_string() takes char * instead of const char * as it's third parameter
+	// with some older versions of SDL.
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	return SDL_iconv_string(to, from, string, length + zeroBytes);
+#else
+	char *stringCopy = (char *) calloc(sizeof(char), length + zeroBytes);
+	memcpy(stringCopy, string, length);
+	char *result = SDL_iconv_string(to, from, stringCopy, length + zeroBytes);
+	free(stringCopy);
+	return result;
+#endif
 }
 


### PR DESCRIPTION
With some older versions of SDL1, the SDL_iconv_string takes char * instead of const char * as it's argument. This should fix the build issue with gp2xwiz.