### PR TITLE
Common: Fix Encoding building

### DIFF
--- a/common/encoding.h
+++ b/common/encoding.h
@@ -23,19 +23,15 @@
 #ifndef COMMON_ENCODING_H
 #define COMMON_ENCODING_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif // HAVE_CONFIG_H
+#include "common/scummsys.h"
+#include "common/str.h"
+#include "common/system.h"
 
 #ifdef USE_ICONV
 #include <iconv.h>
 #else
 typedef void* iconv_t;
 #endif // USE_ICONV
-
-#include "common/scummsys.h"
-#include "common/str.h"
-#include "common/system.h"
 
 #ifdef WIN32
 #include "backends/platform/sdl/win32/win32.h"

--- a/configure
+++ b/configure
@@ -5240,6 +5240,20 @@ fi
 if test "$_iconv" = yes ; then
 	append_var LIBS "$ICONV_LIBS -liconv"
 	append_var INCLUDES "$ICONV_CFLAGS"
+
+# check if iconv uses const char** as it's second parameter
+	cat > $TMPC << EOF
+#include <iconv.h>
+int main(void) {
+	iconv_t conv = iconv_open("UTF-8//IGNORE", "CP850");
+	const char **inbuf = 0;
+	iconv(conv, inbuf, 0, 0, 0);
+	return 0;
+}
+EOF
+		_iconv_uses_const=no
+		cc_check $ICONV_CFLAGS $ICONV_LIBS -liconv && _iconv_uses_const=yes
+		define_in_config_if_yes "$_iconv_uses_const" 'ICONV_USES_CONST'
 fi
 define_in_config_if_yes "$_iconv" 'USE_ICONV'
 echo "$_iconv"


### PR DESCRIPTION
This should fix issues with building on the ds and osx_intel.

I tryed to include config.h, so I have the USE_ICONV define available and can include iconv.h before including the scummsys.h, thinking, that forbidden.h wouldn't allow me to include the iconv.h. This wasn't necessary and it broke the ds build, so I don't do that anymore.

I looked at how the ResidualVM works with iconv when implementing Encoding. They use a define ICONV_USES_CONST to determine the signature of iconv() function. I thought this is defined in iconv.h and used it. Now I noticed, they test this in their configure and define it by themselves. I added this test and define to configure. This should fix the osx_intel build.