### PR TITLE
TESTBED: Allow forbidden symbols

### DIFF
--- a/common/encoding.h
+++ b/common/encoding.h
@@ -23,15 +23,19 @@
 #ifndef COMMON_ENCODING_H
 #define COMMON_ENCODING_H
 
-#include "common/scummsys.h"
-#include "common/str.h"
-#include "common/system.h"
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
 
 #ifdef USE_ICONV
 #include <iconv.h>
 #else
 typedef void* iconv_t;
 #endif // USE_ICONV
+
+#include "common/scummsys.h"
+#include "common/str.h"
+#include "common/system.h"
 
 #ifdef WIN32
 #include "backends/platform/sdl/win32/win32.h"

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
 #include "common/debug-channels.h"
 #include "common/scummsys.h"
 #include "common/archive.h"


### PR DESCRIPTION
Since Testbed now uses backend code to test conversions, it needs to allow
forbidden symbols.

See the following comment for the rationale on why the backend code is used: https://github.com/scummvm/scummvm/pull/1809#issuecomment-522120233
