### PR TITLE
CLOUD: Treat HTTP headers names case-insensitively and add more verbose error messages

### DIFF
--- a/backends/cloud/box/boxlistdirectorybyidrequest.cpp
+++ b/backends/cloud/box/boxlistdirectorybyidrequest.cpp
@@ -83,7 +83,7 @@ void BoxListDirectoryByIdRequest::responseCallback(Networking::JsonResponse resp
 	if (response.request)
 		_date = response.request->date();
 
-	Networking::ErrorResponse error(this);
+	Networking::ErrorResponse error(this, "BoxListDirectoryByIdRequest::responseCallback: unknown error");
 	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();

--- a/backends/cloud/box/boxtokenrefresher.cpp
+++ b/backends/cloud/box/boxtokenrefresher.cpp
@@ -41,7 +41,7 @@ void BoxTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
 	if (!response.value) {
 		//failed to refresh token, notify user with NULL in original callback
 		warning("BoxTokenRefresher: failed to refresh token");
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "BoxTokenRefresher::tokenRefreshed: failed to refresh token", -1));
 		return;
 	}
 

--- a/backends/cloud/downloadrequest.cpp
+++ b/backends/cloud/downloadrequest.cpp
@@ -73,13 +73,13 @@ void DownloadRequest::streamErrorCallback(Networking::ErrorResponse error) {
 void DownloadRequest::handle() {
 	if (!_localFile) {
 		warning("DownloadRequest: no file to write");
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "DownloadRequest::handle: no file to write into", -1));
 		return;
 	}
 
 	if (!_localFile->isOpen()) {
 		warning("DownloadRequest: failed to open file to write");
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "DownloadRequest::handle: failed to open file to write", -1));
 		return;
 	}
 
@@ -93,7 +93,7 @@ void DownloadRequest::handle() {
 	if (readBytes != 0)
 		if (_localFile->write(_buffer, readBytes) != readBytes) {
 			warning("DownloadRequest: unable to write all received bytes into output file");
-			finishError(Networking::ErrorResponse(this, false, true, "", -1));
+			finishError(Networking::ErrorResponse(this, false, true, "DownloadRequest::handle: failed to write all bytes into a file", -1));
 			return;
 		}
 
@@ -113,7 +113,7 @@ void DownloadRequest::handle() {
 
 void DownloadRequest::restart() {
 	warning("DownloadRequest: can't restart as there are no means to reopen DumpFile");
-	finishError(Networking::ErrorResponse(this, false, true, "", -1));
+	finishError(Networking::ErrorResponse(this, false, true, "DownloadRequest::restart: can't restart as there are no means to reopen DumpFile", -1));
 	//start();
 }
 

--- a/backends/cloud/dropbox/dropboxcreatedirectoryrequest.cpp
+++ b/backends/cloud/dropbox/dropboxcreatedirectoryrequest.cpp
@@ -74,7 +74,7 @@ void DropboxCreateDirectoryRequest::responseCallback(Networking::JsonResponse re
 	}
 	if (response.request) _date = response.request->date();
 
-	Networking::ErrorResponse error(this);
+	Networking::ErrorResponse error(this, "DropboxCreateDirectoryRequest::responseCallback: unknown error");
 	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();

--- a/backends/cloud/dropbox/dropboxinforequest.cpp
+++ b/backends/cloud/dropbox/dropboxinforequest.cpp
@@ -71,7 +71,7 @@ void DropboxInfoRequest::userResponseCallback(Networking::JsonResponse response)
 		return;
 	}
 
-	Networking::ErrorResponse error(this);
+	Networking::ErrorResponse error(this, "DropboxInfoRequest::userResponseCallback: unknown error");
 	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();
@@ -125,7 +125,7 @@ void DropboxInfoRequest::quotaResponseCallback(Networking::JsonResponse response
 		return;
 	}
 
-	Networking::ErrorResponse error(this);
+	Networking::ErrorResponse error(this, "DropboxInfoRequest::quotaResponseCallback: unknown error");
 	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();

--- a/backends/cloud/dropbox/dropboxlistdirectoryrequest.cpp
+++ b/backends/cloud/dropbox/dropboxlistdirectoryrequest.cpp
@@ -84,7 +84,7 @@ void DropboxListDirectoryRequest::responseCallback(Networking::JsonResponse resp
 	if (response.request)
 		_date = response.request->date();
 
-	Networking::ErrorResponse error(this);
+	Networking::ErrorResponse error(this, "DropboxListDirectoryRequest::responseCallback: unknown error");
 	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();

--- a/backends/cloud/dropbox/dropboxuploadrequest.cpp
+++ b/backends/cloud/dropbox/dropboxuploadrequest.cpp
@@ -54,12 +54,12 @@ void DropboxUploadRequest::start() {
 		_workingRequest->finish();
 	if (!_contentsStream) {
 		warning("DropboxUploadRequest: cannot start because stream is invalid");
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "DropboxUploadRequest::start: cannot start because stream is invalid", -1));
 		return;
 	}
 	if (!_contentsStream->seek(0)) {
 		warning("DropboxUploadRequest: cannot restart because stream couldn't seek(0)");
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "DropboxUploadRequest::start: cannot restart because stream couldn't seek(0)", -1));
 		return;
 	}
 	_ignoreCallback = false;

--- a/backends/cloud/googledrive/googledrivelistdirectorybyidrequest.cpp
+++ b/backends/cloud/googledrive/googledrivelistdirectorybyidrequest.cpp
@@ -81,7 +81,7 @@ void GoogleDriveListDirectoryByIdRequest::responseCallback(Networking::JsonRespo
 	if (response.request)
 		_date = response.request->date();
 
-	Networking::ErrorResponse error(this);
+	Networking::ErrorResponse error(this, "GoogleDriveListDirectoryByIdRequest::responseCallback");
 	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();

--- a/backends/cloud/googledrive/googledrivetokenrefresher.cpp
+++ b/backends/cloud/googledrive/googledrivetokenrefresher.cpp
@@ -41,7 +41,7 @@ void GoogleDriveTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
 	if (!response.value) {
 		//failed to refresh token, notify user with NULL in original callback
 		warning("GoogleDriveTokenRefresher: failed to refresh token");
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "GoogleDriveTokenRefresher::tokenRefreshed: failed to refresh token", -1));
 		return;
 	}
 

--- a/backends/cloud/onedrive/onedrivecreatedirectoryrequest.cpp
+++ b/backends/cloud/onedrive/onedrivecreatedirectoryrequest.cpp
@@ -96,7 +96,7 @@ void OneDriveCreateDirectoryRequest::responseCallback(Networking::JsonResponse r
 	if (response.request)
 		_date = response.request->date();
 
-	Networking::ErrorResponse error(this);
+	Networking::ErrorResponse error(this, "OneDriveCreateDirectoryRequest::responseCallback: unknown error");
 	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();

--- a/backends/cloud/onedrive/onedrivelistdirectoryrequest.cpp
+++ b/backends/cloud/onedrive/onedrivelistdirectoryrequest.cpp
@@ -102,7 +102,7 @@ void OneDriveListDirectoryRequest::listedDirectoryCallback(Networking::JsonRespo
 	if (response.request)
 		_date = response.request->date();
 
-	Networking::ErrorResponse error(this);
+	Networking::ErrorResponse error(this, "OneDriveListDirectoryRequest::listedDirectoryCallback: unknown error");
 	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();

--- a/backends/cloud/onedrive/onedrivetokenrefresher.cpp
+++ b/backends/cloud/onedrive/onedrivetokenrefresher.cpp
@@ -41,7 +41,7 @@ void OneDriveTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
 	if (!response.value) {
 		//failed to refresh token, notify user with NULL in original callback
 		warning("OneDriveTokenRefresher: failed to refresh token");
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "OneDriveTokenRefresher::tokenRefreshed: failed to refresh token", -1));
 		return;
 	}
 

--- a/backends/cloud/onedrive/onedriveuploadrequest.cpp
+++ b/backends/cloud/onedrive/onedriveuploadrequest.cpp
@@ -56,12 +56,12 @@ void OneDriveUploadRequest::start() {
 		_workingRequest->finish();
 	if (_contentsStream == nullptr) {
 		warning("OneDriveUploadRequest: cannot restart because no stream given");
-		finishError(Networking::ErrorResponse(this, false, true, "No stream given", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "OneDriveUploadRequest::start: can't restart, because no stream given", -1));
 		return;
 	}
 	if (!_contentsStream->seek(0)) {
 		warning("OneDriveUploadRequest: cannot restart because stream couldn't seek(0)");
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "OneDriveUploadRequest::start: can't restart, because seek(0) didn't work", -1));
 		return;
 	}
 	_ignoreCallback = false;

--- a/backends/cloud/savessyncrequest.cpp
+++ b/backends/cloud/savessyncrequest.cpp
@@ -72,7 +72,7 @@ void SavesSyncRequest::start() {
 		new Common::Callback<SavesSyncRequest, Storage::ListDirectoryResponse>(this, &SavesSyncRequest::directoryListedCallback),
 		new Common::Callback<SavesSyncRequest, Networking::ErrorResponse>(this, &SavesSyncRequest::directoryListedErrorCallback)
 	);
-	if (!_workingRequest) finishError(Networking::ErrorResponse(this));
+	if (!_workingRequest) finishError(Networking::ErrorResponse(this, "SavesSyncRequest::start: Storage couldn't create Request to list directory"));
 }
 
 void SavesSyncRequest::directoryListedCallback(Storage::ListDirectoryResponse response) {
@@ -235,7 +235,7 @@ void SavesSyncRequest::directoryListedErrorCallback(Networking::ErrorResponse er
 		new Common::Callback<SavesSyncRequest, Networking::ErrorResponse>(this, &SavesSyncRequest::directoryCreatedErrorCallback)
 	);
 	if (!_workingRequest)
-		finishError(Networking::ErrorResponse(this));
+		finishError(Networking::ErrorResponse(this, "SavesSyncRequest::directoryListedErrorCallback: Storage couldn't create Request to create remote directory"));
 }
 
 void SavesSyncRequest::directoryCreatedCallback(Storage::BoolResponse response) {
@@ -245,7 +245,7 @@ void SavesSyncRequest::directoryCreatedCallback(Storage::BoolResponse response) 
 
 	//stop syncing if failed to create saves directory
 	if (!response.value) {
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "SavesSyncRequest::directoryCreatedCallback: failed to create remote directory", -1));
 		return;
 	}
 
@@ -284,7 +284,7 @@ void SavesSyncRequest::downloadNextFile() {
 		new Common::Callback<SavesSyncRequest, Networking::ErrorResponse>(this, &SavesSyncRequest::fileDownloadedErrorCallback)
 	);
 	if (!_workingRequest)
-		finishError(Networking::ErrorResponse(this));
+		finishError(Networking::ErrorResponse(this, "SavesSyncRequest::downloadNextFile: Storage couldn't create Request to download a file"));
 }
 
 void SavesSyncRequest::fileDownloadedCallback(Storage::BoolResponse response) {
@@ -296,7 +296,7 @@ void SavesSyncRequest::fileDownloadedCallback(Storage::BoolResponse response) {
 	if (!response.value) {
 		//delete the incomplete file
 		g_system->getSavefileManager()->removeSavefile(_currentDownloadingFile.name());
-		finishError(Networking::ErrorResponse(this, false, true, "", -1));
+		finishError(Networking::ErrorResponse(this, false, true, "SavesSyncRequest::fileDownloadedCallback: failed to download a file", -1));
 		return;
 	}
 
@@ -343,7 +343,7 @@ void SavesSyncRequest::uploadNextFile() {
 			new Common::Callback<SavesSyncRequest, Networking::ErrorResponse>(this, &SavesSyncRequest::fileUploadedErrorCallback)
 		);
 	}
-	if (!_workingRequest) finishError(Networking::ErrorResponse(this));
+	if (!_workingRequest) finishError(Networking::ErrorResponse(this, "SavesSyncRequest::uploadNextFile: Storage couldn't create Request to upload a file"));
 }
 
 void SavesSyncRequest::fileUploadedCallback(Storage::UploadResponse response) {

--- a/backends/networking/curl/curlrequest.cpp
+++ b/backends/networking/curl/curlrequest.cpp
@@ -53,7 +53,7 @@ void CurlRequest::handle() {
 	if (_stream && _stream->eos()) {
 		if (_stream->httpResponseCode() != 200) {
 			warning("CurlRequest: HTTP response code is not 200 OK (it's %ld)", _stream->httpResponseCode());
-			ErrorResponse error(this, false, true, "", _stream->httpResponseCode());
+			ErrorResponse error(this, false, true, "HTTP response code is not 200 OK", _stream->httpResponseCode());
 			finishError(error);
 			return;
 		}

--- a/backends/networking/curl/curlrequest.cpp
+++ b/backends/networking/curl/curlrequest.cpp
@@ -71,20 +71,9 @@ void CurlRequest::restart() {
 
 Common::String CurlRequest::date() const {
 	if (_stream) {
-		Common::String headers = _stream->responseHeaders();
-		const char *cstr = headers.c_str();
-		const char *position = strstr(cstr, "Date: ");
-
-		if (position) {
-			Common::String result = "";
-			char c;
-			for (const char *i = position + 6; c = *i, c != 0; ++i) {
-				if (c == '\n' || c == '\r')
-					break;
-				result += c;
-			}
-			return result;
-		}
+		Common::HashMap<Common::String, Common::String> headers = _stream->responseHeadersMap();
+		if (headers.contains("date"))
+			return headers["date"];
 	}
 	return "";
 }

--- a/backends/networking/curl/networkreadstream.h
+++ b/backends/networking/curl/networkreadstream.h
@@ -136,6 +136,14 @@ public:
 	*/
 	Common::String responseHeaders() const;
 
+	/**
+	* Return response headers as HashMap. All header names in
+	* it are lowercase.
+	*
+	* @note This method should be called when eos() == true.
+	*/
+	Common::HashMap<Common::String, Common::String> responseHeadersMap() const;
+
 	/** Returns a number in range [0, 1], where 1 is "complete". */
 	double getProgress() const;
 

--- a/backends/networking/curl/request.cpp
+++ b/backends/networking/curl/request.cpp
@@ -24,8 +24,8 @@
 
 namespace Networking {
 
-ErrorResponse::ErrorResponse(Request *rq):
-	request(rq), interrupted(false), failed(true), response(""), httpResponseCode(-1) {}
+ErrorResponse::ErrorResponse(Request *rq, Common::String resp):
+	request(rq), interrupted(false), failed(true), response(resp), httpResponseCode(-1) {}
 
 ErrorResponse::ErrorResponse(Request *rq, bool interrupt, bool failure, Common::String resp, long httpCode):
 	request(rq), interrupted(interrupt), failed(failure), response(resp), httpResponseCode(httpCode) {}
@@ -50,7 +50,7 @@ void Request::handleRetry() {
 void Request::pause() { _state = PAUSED; }
 
 void Request::finish() {
-	ErrorResponse error(this, true, false, "", -1);
+	ErrorResponse error(this, true, false, "Request::finish() was called (i.e. interrupted)", -1);
 	finishError(error);
 }
 

--- a/backends/networking/curl/request.h
+++ b/backends/networking/curl/request.h
@@ -78,7 +78,7 @@ struct ErrorResponse {
 	Common::String response;
 	long httpResponseCode;
 
-	ErrorResponse(Request *rq);
+	ErrorResponse(Request *rq, Common::String resp);
 	ErrorResponse(Request *rq, bool interrupt, bool failure, Common::String resp, long httpCode);
 };
 


### PR DESCRIPTION
wolfgangr had an issue with Google Drive he told me on IRC. We spent a couple hours debugging and found out that his machine (Debian x64, though it's probably not the reason) gets HTTP headers in lowercase (while I always seen them coming in titlecase). So, as Google Drive file uploading routine in ScummVM expected header in titlecase, it didn't work in his environment. Empty error messages along with 200 OK HTTP code were not helping too.

So, I've added a new method to handle HTTP headers case-insensitively (more or less matching RFC) and updated all places that had empty error messages to provide at least some information.