### PR TITLE
BUILD: Fix GCC bogus warning by removing const

### DIFF
--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -114,7 +114,7 @@ private:
 #endif
 
 	/** Default value, returned by the const getVal. */
-	const Val _defaultVal;
+	Val _defaultVal;
 
 	Node **_storage;	///< hashtable of size arrsize.
 	size_type _mask;		///< Capacity of the HashMap minus one; must be a power of two of minus one


### PR DESCRIPTION
GCC emits "warning: type qualifiers ignored on cast result type" when
some types are used for HashMap because of the const modifier.
This applies especially to pointer-to-member-functions.
The const there is not really useful as it only prevents unfortunate
object editions.