### PR TITLE
BLADERUNNER: Fix compiler warning

### DIFF
--- a/engines/bladerunner/framelimiter.cpp
+++ b/engines/bladerunner/framelimiter.cpp
@@ -55,9 +55,9 @@ void Framelimiter::wait() {
 	uint32 timeNow = _vm->_time->currentSystem();
 	uint32 frameDuration = timeNow - _timeFrameStart;
 	if (frameDuration < _speedLimitMs) {
-		uint32 wait = _speedLimitMs - frameDuration;
-		_vm->_system->delayMillis(wait);
-		timeNow += wait;
+		uint32 waittime = _speedLimitMs - frameDuration;
+		_vm->_system->delayMillis(waittime);
+		timeNow += waittime;
 	}
 	// debug("frametime %i ms", timeNow - _timeFrameStart);
 	// using _vm->_time->currentSystem() here is slower and causes some shutters


### PR DESCRIPTION
Changed variable name from `time` to `waittime`.

Fixes the following compiler warning:

> engines/bladerunner/framelimiter.cpp: In member function ‘void BladeRunner::Framelimiter::wait()’:
engines/bladerunner/framelimiter.cpp:58:10: warning: declaration of ‘wait’ shadows a member of 'this' [-Wshadow]
   uint32 wait = _speedLimitMs - frameDuration;
          ^
