### PR TITLE
TTS: Fix crashing and freezing when compiled with msvc

### DIFF
--- a/backends/text-to-speech/windows/windows-text-to-speech.cpp
+++ b/backends/text-to-speech/windows/windows-text-to-speech.cpp
@@ -231,18 +231,16 @@ bool WindowsTextToSpeechManager::stop() {
 		resume();
 	_audio->SetState(SPAS_STOP, 0);
 	WaitForSingleObject(_speechMutex, INFINITE);
+	// Delete the speech queue
 	while (!_speechQueue.empty()) {
 		if (_speechQueue.front() != NULL)
 			free(_speechQueue.front());
 		_speechQueue.pop_front();
 	}
-	_speechQueue.push_back(NULL);
+	// Stop the current speech
+	_voice->Speak(NULL, SPF_PURGEBEFORESPEAK | SPF_ASYNC, 0);
+	_speechState = READY;
 	ReleaseMutex(_speechMutex);
-	if (_thread != NULL) {
-		WaitForSingleObject(_thread, INFINITE);
-		CloseHandle(_thread);
-		_thread = NULL;
-	}
 	_audio->SetState(SPAS_RUN, 0);
 	return false;
 }

--- a/backends/text-to-speech/windows/windows-text-to-speech.cpp
+++ b/backends/text-to-speech/windows/windows-text-to-speech.cpp
@@ -128,6 +128,7 @@ DWORD WINAPI startSpeech(LPVOID parameters) {
 		WaitForSingleObject(*params->mutex, INFINITE);
 		// check again, when we have exclusive access to the queue
 		if (params->queue->empty() || *(params->state) == WindowsTextToSpeechManager::PAUSED) {
+			ReleaseMutex(*params->mutex);
 			break;
 		}
 		WCHAR *currentSpeech = params->queue->front();

--- a/common/encoding.cpp
+++ b/common/encoding.cpp
@@ -499,4 +499,20 @@ uint32 *Encoding::transliterateUTF32(const uint32 *string, size_t length) {
 	return result;
 }
 
+size_t Encoding::stringLength(const char *string, const String &encoding) {
+	if (encoding.hasPrefixIgnoreCase("UTF-16")) {
+		const uint16 *i = (const uint16 *) string;
+		for (;*i != 0; i++) {}
+		return (const char *) i - string;
+	} else if (encoding.hasPrefixIgnoreCase("UTF-32")) {
+		const uint32 *i = (const uint32 *) string;
+		for (;*i != 0; i++) {}
+		return (const char *) i - string;
+	} else {
+		const char *i = string;
+		for (;*i != 0; i++) {}
+		return i - string;
+	}
+}
+
 }

--- a/common/encoding.h
+++ b/common/encoding.h
@@ -108,6 +108,18 @@ class Encoding {
 		 * @return Array of characters with the opposite endianity
 		 */
 		static char *switchEndian(const char *string, int length, int bitCount);
+
+		/**
+		 * Computes length (in bytes) of a string in a given encoding. 
+		 * The string must be zero ended. Similar to strlen
+		 * (could be used instead of strlen).
+		 *
+		 * @param string String, which size should be computed.
+		 * @param encoding Encoding of the string.
+		 *
+		 * @return Size of the string in bytes.
+		 */
+		static size_t stringLength(const char *string, const String &encoding);
 	
 	private:
 		/** The encoding, which is currently being converted to */


### PR DESCRIPTION
This pull request resolves crashing when compiling with msvc and using text to speech. The crashes were actualy caused by Common::Encoding, that returned a converted string from SDL_iconv_string(), which couldn't be freed by free(), while strings returned by Common::Encoding should be freed by free().

This also fixes the freezing caused by waiting on a thread while trying to stop speech (the freeze could last up to multiple seconds). There still is a barely noticable lag when using TTS in the GUI and moving fast with the cursor between multiple GUI widgets and thus starting and stoping multiple speeches too quickly. This is caused by a call to ISpVoice->Speak() inside the stop() method. I haven't found a better solution to stopping the speech yet, but the lag shouldn't be noticable with TTS in games (like in Mortevielle) and people with reduced sight (which should be the people, that will be using the TTS in GUI) also shouldn't notice.