### PR TITLE
BUILD: Adds -static flag when --enable-static under mingw

### DIFF
--- a/configure
+++ b/configure
@@ -2831,6 +2831,9 @@ case $_host_os in
 		append_var DEFINES "-DWIN32"
 		# append_var DEFINES "-D__USE_MINGW_ANSI_STDIO=0"  # Modern MinGW does not need it
 		append_var LDFLAGS "-static-libgcc -static-libstdc++"
+		if test "$_static_build" = yes ; then
+			append_var LDFLAGS "-static"
+		fi
 		append_var LIBS "-lmingw32 -lwinmm -lgdi32"
 		append_var OBJS "dists/scummvm.o"
 		add_line_to_config_mk 'WIN32 = 1'


### PR DESCRIPTION
System: Win10 Version 1809, WSL (10.0.17763.615), GCC 9.2.0 (mingw), ld 2.32 (mingw)
When I compile scummvm it doesn't statically link the dependent libraries although I set
--enable-static in the configure step. Adding the -static flag to the linker fixes the issue.