### PR TITLE
IOS: Call exit(0) when exiting to prevent hanging

### DIFF
--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -414,4 +414,7 @@ void iOS7_main(int argc, char **argv) {
 		//*stderr = NULL;
 		fclose(newfp);
 	}
+
+	// prevents hanging on exit
+	exit(0);
 }


### PR DESCRIPTION
When quitting the ios7 backend, either through the launcher's Quit button or through a game's Quit function, the process always hangs instead of exiting. From the launcher I get a black screen, in the SCI games it hangs on the game frame. At that point I have to force kill the process.

I don't know why it isn't exiting cleanly, but the existing TODO comments suggests this wasn't quite finished. This has always happened to me on my non-jailbroken iphone se throughout its major ios versions. Seems like throwing an exit(0) at it is a good fix until the root cause is discovered, if it even matters. iOS7_main() finishes but UIApplicationMain() isn't returning, and there's no further code after that.

I have an iphone 4 running ios4 with the old 1.5 scummvm on it, and it exited cleanly, so I don't know if this problem was introduced with the ios7 backend or in a new ios version. (In my experience, probably the latter.)