### PR TITLE
BLADERUNNER: Ensure the Color256 struct is correctly packed

### DIFF
--- a/engines/bladerunner/color.h
+++ b/engines/bladerunner/color.h
@@ -37,11 +37,15 @@ struct Color {
 	Color(float r_, float g_, float b_) : r(r_), g(g_), b(b_) {}
 };
 
+#include "common/pack-start.h"
+
 struct Color256 {
 	uint8 r;
 	uint8 g;
 	uint8 b;
-};
+} PACKED_STRUCT;
+
+#include "common/pack-end.h"
 
 } // End of namespace BladeRunner
 


### PR DESCRIPTION
This fixes a crash on RISC OS due to the size of the structure being padded to a multiple of 4 bytes, and `ScreenEffects::readVqa()` assuming the structure size is 3 when reading the palette data.