### PR TITLE
SCI: Add back necessary two-phase Kernel initialization

### DIFF
--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -33,12 +33,8 @@
 
 namespace Sci {
 
-Kernel::Kernel(ResourceManager *resMan, SegManager *segMan)	:
-	_resMan(resMan),
-	_segMan(segMan),
-	_invalid("<invalid>") {
-	loadSelectorNames();
-	mapSelectors();
+Kernel::Kernel(ResourceManager *resMan, SegManager *segMan)
+	: _resMan(resMan), _segMan(segMan), _invalid("<invalid>") {
 }
 
 Kernel::~Kernel() {
@@ -53,6 +49,11 @@ Kernel::~Kernel() {
 		}
 		delete[] it->signature;
 	}
+}
+
+void Kernel::init() {
+	loadSelectorNames();
+	mapSelectors();      // Map a few special selectors for later use
 }
 
 uint Kernel::getSelectorNamesSize() const {

--- a/engines/sci/engine/kernel.h
+++ b/engines/sci/engine/kernel.h
@@ -153,6 +153,8 @@ public:
 	Kernel(ResourceManager *resMan, SegManager *segMan);
 	~Kernel();
 
+	void init();
+
 	uint getSelectorNamesSize() const;
 	const Common::String &getSelectorName(uint selector);
 	int findKernelFuncPos(Common::String kernelFuncName);

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -308,6 +308,8 @@ Common::Error SciEngine::run() {
 	}
 
 	_kernel = new Kernel(_resMan, segMan);
+	_kernel->init();
+
 	_features = new GameFeatures(segMan, _kernel);
 	_vocabulary = hasParser() ? new Vocabulary(_resMan, false) : NULL;
 


### PR DESCRIPTION
Fixes a seggy when attempting to start LSL1 SCI demo (available [here](https://archive.org/details/SierraOn-line)).

This reverts commit 9551e64bdfc05954f41b665a3ae706f46304347e. Found via bisect.