### PR TITLE
WIN32: Fix getting the parent directory of non-existant file nodes

### DIFF
--- a/backends/fs/windows/windows-fs.cpp
+++ b/backends/fs/windows/windows-fs.cpp
@@ -220,8 +220,6 @@ bool WindowsFilesystemNode::getChildren(AbstractFSList &myList, ListMode mode, b
 }
 
 AbstractFSNode *WindowsFilesystemNode::getParent() const {
-	assert(_isValid || _isPseudoRoot);
-
 	if (_isPseudoRoot)
 		return 0;
 


### PR DESCRIPTION
This fixes a regression from commit aca627b.