### PR TITLE
Revert "COMMON: Implement FSNode::createDirectoryRecursive()"

### DIFF
--- a/backends/saves/default/default-saves.cpp
+++ b/backends/saves/default/default-saves.cpp
@@ -63,7 +63,7 @@ DefaultSaveFileManager::DefaultSaveFileManager(const Common::String &defaultSave
 void DefaultSaveFileManager::checkPath(const Common::FSNode &dir) {
 	clearError();
 	if (!dir.exists()) {
-		if (!dir.createDirectoryRecursive()) {
+		if (!dir.createDirectory()) {
 			setError(Common::kPathDoesNotExist, "Failed to create directory '"+dir.getPath()+"'");
 		}
 	} else if (!dir.isDirectory()) {

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -155,10 +155,24 @@ bool DumpFile::open(const String &filename, bool createPath) {
 	assert(!filename.empty());
 	assert(!_handle);
 
-	FSNode node(filename);
-	if (createPath)
-		node.getParent().createDirectoryRecursive();
+	if (createPath) {
+		for (uint32 i = 0; i < filename.size(); ++i) {
+			if (filename[i] == '/' || filename[i] == '\\') {
+				Common::String subpath = filename;
+				subpath.erase(i);
+				if (subpath.empty()) continue;
+				AbstractFSNode *node = g_system->getFilesystemFactory()->makeFileNodePath(subpath);
+				if (node->exists()) {
+					delete node;
+					continue;
+				}
+				if (!node->createDirectory()) warning("DumpFile: unable to create directories from path prefix");
+				delete node;
+			}
+		}
+	}
 
+	FSNode node(filename);
 	return open(node);
 }
 

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -168,27 +168,6 @@ bool FSNode::createDirectory() const {
 	return _realNode->createDirectory();
 }
 
-bool FSNode::createDirectoryRecursive() const {
-	if (_realNode == nullptr)
-		return false;
-
-	if (_realNode->exists()) {
-		if (!_realNode->isDirectory()) {
-			warning("FSNode::createDirectoryRecursive: '%s' is a file", _realNode->getName().c_str());
-			return false;
-		} else {
-			return true;
-		}
-	}
-
-	FSNode parent = getParent();
-	assert(parent.getPath() != _realNode->getPath());
-	if (!parent.createDirectoryRecursive())
-		return false;
-
-	return _realNode->createDirectory();
-}
-
 FSDirectory::FSDirectory(const FSNode &node, int depth, bool flat)
   : _node(node), _cached(false), _depth(depth), _flat(flat) {
 }

--- a/common/fs.h
+++ b/common/fs.h
@@ -239,14 +239,6 @@ public:
 	 * @return true if the directory was created, false otherwise.
 	 */
 	bool createDirectory() const;
-
-	/**
-	 * Creates a directory referred by this node. The parent directory
-	 * will also be created if it doesn't exist.
-	 *
-	 * @return true if the directory was created, false otherwise.
-	 */
-	bool createDirectoryRecursive() const;
 };
 
 /**


### PR DESCRIPTION
Fixing this is a lot more complicated than I had anticipated, so for now it's best to just revert this commit so that cloud saves work again.