### PR TITLE
Revert "WIN32: Fix getting the parent directory of non-existant file nodes"

### DIFF
--- a/backends/fs/windows/windows-fs.cpp
+++ b/backends/fs/windows/windows-fs.cpp
@@ -220,6 +220,8 @@ bool WindowsFilesystemNode::getChildren(AbstractFSList &myList, ListMode mode, b
 }
 
 AbstractFSNode *WindowsFilesystemNode::getParent() const {
+	assert(_isValid || _isPseudoRoot);
+
 	if (_isPseudoRoot)
 		return 0;
 


### PR DESCRIPTION
As this commit didn't fix anything, I think we should revert it just in case, and keep this assert().