### PR TITLE
MSVC: Don't overwrite version.h if it hasn't changed

### DIFF
--- a/devtools/create_project/scripts/revision.vbs
+++ b/devtools/create_project/scripts/revision.vbs
@@ -128,8 +128,9 @@ End Sub
 
 ' Output revision header file
 Sub OutputRevisionHeader(str)
-	FSO.CopyFile rootFolder & "\\base\\internal_revision.h.in", targetFolder & "\\internal_revision.h"
-	FindReplaceInFile targetFolder & "\\internal_revision.h", "@REVISION@", str
+	FSO.CopyFile rootFolder & "\\base\\internal_revision.h.in", targetFolder & "\\internal_revision.h.tmp"
+	FindReplaceInFile targetFolder & "\\internal_revision.h.tmp", "@REVISION@", str
+	CompareFileAndReplace targetFolder & "\\internal_revision.h.tmp", targetFolder & "\\internal_revision.h"
 End Sub
 
 Function DetermineTortoiseSVNVersion()
@@ -481,4 +482,21 @@ Sub FindReplaceInFile(filename, to_find, replacement)
 	Set file = FSO.CreateTextFile(filename, -1, 0)
 	file.Write data
 	file.Close
+End Sub
+
+Sub CompareFileAndReplace(src_filename, dst_filename)
+	Dim file, src_data, dst_data
+	Set file = FSO.OpenTextFile(src_filename, 1, 0, 0)
+	src_data = file.ReadAll
+	file.Close
+	Set file = FSO.OpenTextFile(dst_filename, 1, 0, 0)
+	dst_data = file.ReadAll
+	file.Close
+	If StrComp(src_data, dst_data, vbBinaryCompare) = 0 Then
+		' Files are the same, just remove the source
+		FSO.DeleteFile src_filename
+	Else
+		' Files are different, overwrite the destination
+		FSO.MoveFile src_filename, dst_filename
+	End If
 End Sub


### PR DESCRIPTION
That avoids superfluous recompilation and linkage of project when nothing
has changed.