### PR TITLE
SURFACESDL: Properly distinguish between 555 and 565 modes

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1062,7 +1062,7 @@ bool SurfaceSdlGraphicsManager::loadGFXMode() {
 		error("allocating _tmpscreen2 failed");
 
 	// Distinguish 555 and 565 mode
-	if (_hwScreen->format->Rmask == 0x7C00)
+	if (_hwScreen->format->Gmask == 0x3E0)
 		InitScalers(555);
 	else
 		InitScalers(565);

--- a/backends/graphics/wincesdl/wincesdl-graphics.cpp
+++ b/backends/graphics/wincesdl/wincesdl-graphics.cpp
@@ -884,7 +884,7 @@ bool WINCESdlGraphicsManager::loadGFXMode() {
 
 	// Create the surface used for the graphics in 16 bit before scaling, and also the overlay
 	// Distinguish 555 and 565 mode
-	if (_hwScreen->format->Rmask == 0x7C00)
+	if (_hwScreen->format->Gmask == 0x3E0)
 		InitScalers(555);
 	else
 		InitScalers(565);


### PR DESCRIPTION
The previous check would incorrectly treat BGR555 as a 565 mode. Previously, scalers would produce incorrect results on RISC OS as a result, however the issue went away for me due to an SDL change adding support for the additional pixel formats introduced in RISC OS 5.21, however the issue is still likely to still be present for users of older RISC OS versions. I haven't been able to personally check this on such a system, though.