### PR TITLE
CONFIGURE: Add amigaos to the plugins family

### DIFF
--- a/configure
+++ b/configure
@@ -3928,6 +3928,18 @@ _mak_plugins=
 if test "$_dynamic_modules" = yes ; then
 	echo_n "Checking whether building plugins is supported... "
 	case $_host_os in
+	amigaos)
+		_plugin_prefix="lib"
+		_plugin_suffix=".so"
+		append_var CXXFLAGS "-fPIC"
+		append_var LIBS "-use-dynld"
+_mak_plugins='
+PLUGIN_EXTRA_DEPS =
+PLUGIN_LDFLAGS  += -shared
+PRE_OBJS_FLAGS  := -Wl,-export-dynamic -Wl,-whole-archive
+POST_OBJS_FLAGS := -Wl,-no-whole-archive
+'
+		;;
 	android)
 		_plugin_prefix="lib"
 		_plugin_suffix=".so"


### PR DESCRIPTION
I would have used the linux entry, but -ldl does not exist on amigaos4 and i still need -use-dyn-ld