### PR TITLE
ENGINES: Disable event polling while splash screen is shown

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -270,7 +270,6 @@ void splashScreen() {
 	uint time0 = g_system->getMillis();
 	Common::Event event;
 	while (time0 + 600 > g_system->getMillis()) {
-		(void)g_system->getEventManager()->pollEvent(event);
 		g_system->delayMillis(10);
 	}
 	g_system->hideOverlay();


### PR DESCRIPTION
Originally from libretro/scummvm#113.

> The core has always had an infuriating little bug - if you try to open the main ScummVM menu while the initial splash screen is shown, it generates a segfault. This is very easy to trigger - if you are continuing a game and just want to load your last save, it is natural to try and open the menu as soon as the game itself loads... which causes it to crash.
>
> I had a look, and it seems there's some stupidity in the splash screen code. While the screen is shown, it sits in a wait loop polling for events - which I imagine was intended to allow a quick response if the user were to 'exit' (i.e. close the window in ScummVM standalone). The problem is that this wait loop occurs at a very early stage of initialisation, when most of the game engines haven't created half their objects. When a 'show menu' event is registered, the game engines typically call some prep functions (e.g. pause audio) that access these objects - if they don't exist, you get a segfault...
>
> This pull request avoids the issue by disabling event polling while the splash screen is shown. I really can't see any downside to this - the only negative I can find is that the user may have to wait up to 600 ms if they close the core the instant the splash screen is displayed (which I don't think would bother anyone!).