### PR TITLE
QUEEN: Disable load/save until game is properly initialised

### DIFF
--- a/engines/queen/queen.cpp
+++ b/engines/queen/queen.cpp
@@ -50,7 +50,7 @@
 namespace Queen {
 
 QueenEngine::QueenEngine(OSystem *syst)
-	: Engine(syst), _debugger(0), randomizer("queen") {
+	: Engine(syst), _gameStarted(false), _debugger(0), randomizer("queen") {
 }
 
 QueenEngine::~QueenEngine() {
@@ -173,7 +173,7 @@ void QueenEngine::update(bool checkPlayerInput) {
 }
 
 bool QueenEngine::canLoadOrSave() const {
-	return !_input->cutawayRunning() && !(_resource->isDemo() || _resource->isInterview());
+	return !_input->cutawayRunning() && !(_resource->isDemo() || _resource->isInterview()) && _gameStarted;
 }
 
 bool QueenEngine::canLoadGameStateCurrently() {
@@ -368,6 +368,9 @@ Common::Error QueenEngine::run() {
 			_logic->currentRoom(_logic->newRoom());
 			_logic->changeRoom();
 			_display->fullscreen(false);
+			// From this point onwards it is safe to use the load/save
+			// menu, so consider game to be 'started'
+			_gameStarted = true;
 			if (_logic->currentRoom() == _logic->newRoom()) {
 				_logic->newRoom(0);
 			}

--- a/engines/queen/queen.h
+++ b/engines/queen/queen.h
@@ -129,6 +129,7 @@ protected:
 	bool _subtitles;
 	uint32 _lastSaveTime;
 	uint32 _lastUpdateTime;
+	bool _gameStarted;
 
 	BamScene *_bam;
 	BankManager *_bankMan;


### PR DESCRIPTION
Originally from libretro/scummvm#114.

> [The game engine for 'Flight of the Amazon Queen'] allows you to load a previous save before the game is properly initialised. At best, this leads to undefined behaviour. Most of the time it causes a segfault.