### PR TITLE
QUEEN: Prevent hang when closing core during dialog

### DIFF
--- a/engines/queen/sound.cpp
+++ b/engines/queen/sound.cpp
@@ -289,7 +289,9 @@ void PCSound::playSound(const char *base, bool isSpeech) {
 	}
 	strcat(name, ".SB");
 	if (isSpeech) {
-		while (_mixer->isSoundHandleActive(_speechHandle)) {
+		// Add _vm->shouldQuit() check here, otherwise game gets stuck
+		// in an infinite loop if we try to quit while a sound is playing...
+		while (_mixer->isSoundHandleActive(_speechHandle) && !_vm->shouldQuit()) {
 			_vm->input()->delay(10);
 		}
 	} else {


### PR DESCRIPTION
Originally from libretro/scummvm#114.

> If you try to close the core while a dialogue is in progress, it gets stuck in an infinite loop and hangs RetroArch indefinitely.