### PR TITLE
AUDIO: Optimise default fluidsynth configuration paramenters

### DIFF
--- a/audio/softsynth/fluidsynth.cpp
+++ b/audio/softsynth/fluidsynth.cpp
@@ -160,7 +160,7 @@ int MidiDriver_FluidSynth::open() {
 
 		double reverbRoomSize = (double)ConfMan.getInt("fluidsynth_reverb_roomsize") / 100.0;
 		double reverbDamping = (double)ConfMan.getInt("fluidsynth_reverb_damping") / 100.0;
-		int reverbWidth = ConfMan.getInt("fluidsynth_reverb_width");
+		double reverbWidth = (double)ConfMan.getInt("fluidsynth_reverb_width") / 100.0;
 		double reverbLevel = (double)ConfMan.getInt("fluidsynth_reverb_level") / 100.0;
 
 		fluid_synth_set_reverb(_synth, reverbRoomSize, reverbDamping, reverbWidth, reverbLevel);

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -293,16 +293,16 @@ void registerDefaults() {
 	// their appropriate values.
 	ConfMan.registerDefault("fluidsynth_chorus_activate", true);
 	ConfMan.registerDefault("fluidsynth_chorus_nr", 3);
-	ConfMan.registerDefault("fluidsynth_chorus_level", 100);
+	ConfMan.registerDefault("fluidsynth_chorus_level", 120);
 	ConfMan.registerDefault("fluidsynth_chorus_speed", 30);
 	ConfMan.registerDefault("fluidsynth_chorus_depth", 80);
 	ConfMan.registerDefault("fluidsynth_chorus_waveform", "sine");
 
 	ConfMan.registerDefault("fluidsynth_reverb_activate", true);
-	ConfMan.registerDefault("fluidsynth_reverb_roomsize", 20);
-	ConfMan.registerDefault("fluidsynth_reverb_damping", 0);
-	ConfMan.registerDefault("fluidsynth_reverb_width", 1);
-	ConfMan.registerDefault("fluidsynth_reverb_level", 90);
+	ConfMan.registerDefault("fluidsynth_reverb_roomsize", 61);
+	ConfMan.registerDefault("fluidsynth_reverb_damping", 23);
+	ConfMan.registerDefault("fluidsynth_reverb_width", 76);
+	ConfMan.registerDefault("fluidsynth_reverb_level", 57);
 
 	ConfMan.registerDefault("fluidsynth_misc_interpolation", "4th");
 #endif

--- a/gui/fluidsynth-dialog.cpp
+++ b/gui/fluidsynth-dialog.cpp
@@ -72,31 +72,31 @@ FluidSynthSettingsDialog::FluidSynthSettingsDialog()
 
 	_reverbRoomSizeDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.RoomSizeText", _("Room:"));
 	_reverbRoomSizeSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Reverb.RoomSizeSlider", 0, kReverbRoomSizeChangedCmd);
-	// 0.00 - 1.20, Default: 0.20
+	// 0.00 - 1.20, Default: 0.61
 	_reverbRoomSizeSlider->setMinValue(0);
 	_reverbRoomSizeSlider->setMaxValue(120);
-	_reverbRoomSizeLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.RoomSizeLabel", "20");
+	_reverbRoomSizeLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.RoomSizeLabel", "61");
 
 	_reverbDampingDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.DampingText", _("Damp:"));
 	_reverbDampingSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Reverb.DampingSlider", 0, kReverbDampingChangedCmd);
-	// 0.00 - 1.00, Default: 0.00
+	// 0.00 - 1.00, Default: 0.23
 	_reverbDampingSlider->setMinValue(0);
 	_reverbDampingSlider->setMaxValue(100);
-	_reverbDampingLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.DampingLabel", "0");
+	_reverbDampingLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.DampingLabel", "23");
 
 	_reverbWidthDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.WidthText", _("Width:"));
 	_reverbWidthSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Reverb.WidthSlider", 0, kReverbWidthChangedCmd);
-	// 0 - 100, Default: 1
+	// 0.00 - 1.00, Default: 0.76
 	_reverbWidthSlider->setMinValue(0);
 	_reverbWidthSlider->setMaxValue(100);
-	_reverbWidthLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.WidthLabel", "1");
+	_reverbWidthLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.WidthLabel", "76");
 
 	_reverbLevelDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.LevelText", _("Level:"));
 	_reverbLevelSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Reverb.LevelSlider", 0, kReverbLevelChangedCmd);
-	// 0.00 - 1.00, Default: 0.90
+	// 0.00 - 1.00, Default: 0.57
 	_reverbLevelSlider->setMinValue(0);
 	_reverbLevelSlider->setMaxValue(100);
-	_reverbLevelLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.LevelLabel", "90");
+	_reverbLevelLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.LevelLabel", "57");
 
 	_tabWidget->addTab(_("Chorus"));
 
@@ -111,10 +111,10 @@ FluidSynthSettingsDialog::FluidSynthSettingsDialog()
 
 	_chorusLevelDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.LevelText", _("Level:"));
 	_chorusLevelSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Chorus.LevelSlider", 0, kChorusLevelChangedCmd);
-	// 0.00 - 1.00, Default: 1.00
+	// 0.00 - 2.00, Default: 1.20
 	_chorusLevelSlider->setMinValue(0);
-	_chorusLevelSlider->setMaxValue(100);
-	_chorusLevelLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.LevelLabel", "100");
+	_chorusLevelSlider->setMaxValue(200);
+	_chorusLevelLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.LevelLabel", "120");
 
 	_chorusSpeedDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.SpeedText", _("Speed:"));
 	_chorusSpeedSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Chorus.SpeedSlider", 0, kChorusSpeedChangedCmd);


### PR DESCRIPTION
Originally from libretro/scummvm#108

> Regarding the FluidSynth changes, I got the new values from here: https://forums.scummvm.org/viewtopic.php?t=11632
> 
> To quote the forum post:
> 
> ```
> The FluidSynth reverb, while not as good as the old Live!/Audigy hardware reverbs (which were quite good), can still sound decent with the right settings. I have no idea how to change this in ScummVM, but I have found the following FluidSynth settings to sound much better:
> 
> Reverb:
> 
> Room: 0.61
> Damp: 0.23
> Width: 0.76
> Level: 0.57
> 
> Chorus:
> 
> N: 3
> Level: 1.2
> Speed: 0.3
> Depth: 8
> 
> This gives a much more spacious sound, as opposed to the "stuffy room" that seems to be FluidSynth's default.
> ```
> 
> I basically tested these settings with every (!) game, and it was indeed a huge improvement.
> 
> In addition, the `reverbWidth` setting in ScummVM master is handled internally as an `int`. This is a bug, which means the value can never be adjusted correctly - it should be a `double`, like all the other parameters.