### PR TITLE
ILLUSIONS: DUCKMAN: Fix endless SFX bug #11161

### DIFF
--- a/engines/illusions/duckman/illusions_duckman.cpp
+++ b/engines/illusions/duckman/illusions_duckman.cpp
@@ -931,6 +931,7 @@ bool IllusionsEngine_Duckman::changeScene(uint32 sceneId, uint32 threadId, uint3
 	uint32 currSceneId = getCurrentScene();
 	if (currSceneId != 0x10003)
 		dumpCurrSceneFiles(currSceneId, callerThreadId);
+	_soundMan->stopLoopingSounds(); //Fix for global looping sound not stopping in falling scene.
 	_threads->terminateThreads(callerThreadId);
 	_controls->destroyControls();
 	_resSys->unloadSceneResources(0x10003, 0x10001);

--- a/engines/illusions/sound.cpp
+++ b/engines/illusions/sound.cpp
@@ -342,6 +342,10 @@ bool Sound::isPlaying() {
 	return g_system->getMixer()->isSoundHandleActive(_soundHandle);
 }
 
+bool Sound::isLooping() {
+	return _looping;
+}
+
 // SoundMan
 
 SoundMan::SoundMan(IllusionsEngine *vm)
@@ -448,6 +452,15 @@ void SoundMan::stopSound(uint32 soundEffectId) {
 	Sound *sound = getSound(soundEffectId);
 	if (sound)
 		sound->stop();
+}
+
+void SoundMan::stopLoopingSounds() {
+	for (SoundListIterator it = _sounds.begin(); it != _sounds.end(); ++it) {
+		Sound *sound = *it;
+		if (sound->isPlaying() && sound->isLooping()) {
+			sound->stop();
+		}
+	}
 }
 
 void SoundMan::unloadSounds(uint32 soundGroupId) {

--- a/engines/illusions/sound.h
+++ b/engines/illusions/sound.h
@@ -103,6 +103,7 @@ public:
 	void play(int16 volume, int16 pan);
 	void stop();
 	bool isPlaying();
+	bool isLooping();
 public:
 	uint32 _soundEffectId;
 	uint32 _soundGroupId;
@@ -159,6 +160,7 @@ public:
 	void loadSound(uint32 soundEffectId, uint32 soundGroupId, bool looping);
 	void playSound(uint32 soundEffectId, int16 volume, int16 pan);
 	void stopSound(uint32 soundEffectId);
+	void stopLoopingSounds();
 	void unloadSounds(uint32 soundGroupId);
 
 protected:


### PR DESCRIPTION
The sfx in this scene is from the global sfx resource which doesn't get unloaded on scene change. I've added some logic to stop looping sfx when changing scenes.

