### PR TITLE
SDL: Fix build for ancient SDL versions

### DIFF
--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -760,6 +760,7 @@ int SDL_SetColorKey_replacement(SDL_Surface *surface, Uint32 flag, Uint32 key) {
 #endif
 
 char *OSystem_SDL::convertEncoding(const char *to, const char *from, const char *string, size_t length) {
+#ifdef USE_ENCODING
 	int zeroBytes = 1;
 	if (Common::String(from).hasPrefixIgnoreCase("utf-16"))
 		zeroBytes = 2;
@@ -800,5 +801,8 @@ char *OSystem_SDL::convertEncoding(const char *to, const char *from, const char 
 	memcpy(finalResult, result, newLength + zeroBytes);
 	SDL_free(result);
 	return finalResult;
+#else
+	return nullptr;
+#endif
 }
 

--- a/configure
+++ b/configure
@@ -184,6 +184,7 @@ _no_undefined_var_template=no
 _no_pragma_pack=no
 _bink=yes
 _cloud=auto
+_encoding=yes
 _pandoc=no
 # Default vkeybd/keymapper/eventrec options
 _vkeybd=no
@@ -1051,6 +1052,7 @@ Optional Features:
   --enable-tts			   build support for text to speech
   --disable-tts			   don't build support for text to speech
   --disable-bink           don't build with Bink video support
+  --disable-encoding       don't build support for encoding conversion
   --opengl-mode=MODE       OpenGL (ES) mode to use for OpenGL output [auto]
                            available modes: auto for autodetection
                                             none for disabling any OpenGL usage
@@ -1257,6 +1259,8 @@ for ac_option in $@; do
 	--disable-tts)                _tts=no                ;;
 	--enable-bink)                _bink=yes              ;;
 	--disable-bink)               _bink=no               ;;
+	--enable-encoding)            _encoding=yes          ;;
+	--disable-encoding)           _encoding=no           ;;
 	--opengl-mode=*)
 		_opengl_mode=`echo $ac_option | cut -d '=' -f 2`
 		;;
@@ -5511,6 +5515,13 @@ define_in_config_if_yes $_tts 'USE_TTS'
 echo_n "Building Bink video support... "
 define_in_config_if_yes $_bink 'USE_BINK'
 echo "$_bink"
+
+#
+# Check whether to build encoding conversion support
+#
+echo_n "Building encoding conversion support... "
+define_in_config_if_yes $_encoding 'USE_ENCODING'
+echo "$_encoding"
 
 #
 # Check whether to build updates support


### PR DESCRIPTION
This fixes a Maemo build failure that was introduced in commit 6dba0bbfd421121056fba0d348794ead2928c662.

The ancient custom SDL 1.2.8 in the Maemo SDK doesn't have `SDL_iconv_string()`.

I had 3 options (from easy to hard):
* Drop Maemo support
* Surround the new code with a new `#ifdef` and a configure option
* Port the Maemo SDL customizations to the latest SDL 1.2.x

I figured it won't hurt to add yet another configure option.