### PR TITLE
Supernova lang selection

### DIFF
--- a/engines/supernova/detection.cpp
+++ b/engines/supernova/detection.cpp
@@ -62,16 +62,7 @@ static const ADGameDescription gameDescriptions[] = {
 		AD_ENTRY1s("msn_data.000", "f64f16782a86211efa919fbae41e7568", 24163),
 		Common::DE_DEU,
 		Common::kPlatformDOS,
-		ADGF_TESTING,
-		GUIO1(GAMEOPTION_IMPROVED)
-	},
-	{
-		"msn1",
-		nullptr,
-		AD_ENTRY1s("msn_data.000", "f64f16782a86211efa919fbae41e7568", 24163),
-		Common::EN_ANY,
-		Common::kPlatformDOS,
-		ADGF_TESTING,
+		ADGF_TESTING | ADGF_ADDENGLISH | ADGF_DROPLANGUAGE,
 		GUIO1(GAMEOPTION_IMPROVED)
 	},
 	// Mission Supernova 2
@@ -81,16 +72,7 @@ static const ADGameDescription gameDescriptions[] = {
 		AD_ENTRY1s("ms2_data.000", "e595610cba4a6d24a763e428d05cc83f", 24805),
 		Common::DE_DEU,
 		Common::kPlatformDOS,
-		ADGF_TESTING,
-		GUIO1(GAMEOPTION_IMPROVED)
-	},
-	{
-		"msn2",
-		nullptr,
-		AD_ENTRY1s("ms2_data.000", "e595610cba4a6d24a763e428d05cc83f", 24805),
-		Common::EN_ANY,
-		Common::kPlatformDOS,
-		ADGF_TESTING,
+		ADGF_TESTING | ADGF_ADDENGLISH | ADGF_DROPLANGUAGE,
 		GUIO1(GAMEOPTION_IMPROVED)
 	},
 	AD_TABLE_END_MARKER

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -150,8 +150,8 @@ EditGameDialog::EditGameDialog(const String &domain)
 	_descriptionWidget = new EditTextWidget(tab, "GameOptions_Game.Desc", description, _("Full title of the game"));
 
 	// Language popup
-	_langPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.LangPopupDesc", _("Language:"), _("Language of the game. This will not turn your Spanish game version into English"));
-	_langPopUp = new PopUpWidget(tab, "GameOptions_Game.LangPopup", _("Language of the game. This will not turn your Spanish game version into English"));
+	_langPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.LangPopupDesc", _("Language:"), _("Language of the game."));
+	_langPopUp = new PopUpWidget(tab, "GameOptions_Game.LangPopup", _("Language of the game."));
 	_langPopUp->appendEntry(_("<default>"), (uint32)Common::UNK_LANG);
 	_langPopUp->appendEntry("", (uint32)Common::UNK_LANG);
 	const Common::LanguageDescription *l = Common::g_languages;


### PR DESCRIPTION
SUPERNOVA: Use the ADGF_ADDENGLISH flag instead of duplicate game entries.
GUI: Remove incorrect advice

Instead of using duplicate game entries in the detection, allow changing the language in the game settings dialog. This is consistent with how certain SCI games support multiple languages for the same fileset.

Also update the tooltip for the language selection dropdown menu to remove the false "advice" that this does not change the game language.