### PR TITLE
HDB: Fix compiler warning

### DIFF
--- a/engines/hdb/ai-funcs.cpp
+++ b/engines/hdb/ai-funcs.cpp
@@ -88,7 +88,7 @@ AIEntity *AI::spawn(AIType type, AIDir dir, int x, int y, const char *funcInit, 
 	return e;
 }
 
-bool AI::cacheEntGfx(AIEntity *e, bool init) {
+bool AI::cacheEntGfx(AIEntity *e, bool initFlag) {
 	int i = 0;
 	while (true) {
 		if (aiEntList[i].type == END_AI_TYPES)
@@ -425,7 +425,7 @@ bool AI::cacheEntGfx(AIEntity *e, bool init) {
 
 			e->aiInit = aiEntList[i].initFunc;
 			e->aiInit2 = aiEntList[i].initFunc2;
-			if (init) {
+			if (initFlag) {
 				e->aiInit(e);
 				if (e->aiInit2)
 					e->aiInit2(e);


### PR DESCRIPTION
Change function parameter name as there is a method with same name.
Fixes the following compiler warning:
`engines/hdb/ai-funcs.cpp:91:44: warning: declaration of ‘init’ shadows a member of 'this' [-Wshadow]
`
