### PR TITLE
WII: Fix compilation and runtime with latest version of devkitPPC

### DIFF
--- a/backends/fs/wii/wii-fs-factory.cpp
+++ b/backends/fs/wii/wii-fs-factory.cpp
@@ -24,6 +24,7 @@
 
 #define FORBIDDEN_SYMBOL_EXCEPTION_printf
 #define FORBIDDEN_SYMBOL_EXCEPTION_getcwd
+#define FORBIDDEN_SYMBOL_EXCEPTION_time_h
 
 #include <unistd.h>
 

--- a/backends/platform/wii/main.cpp
+++ b/backends/platform/wii/main.cpp
@@ -230,6 +230,9 @@ int main(int argc, char *argv[]) {
 	res = scummvm_main(argc, argv);
 	g_system->quit();
 
+	g_system->destroy();
+	g_system = nullptr;
+
 	printf("shutdown\n");
 
 	SYS_UnregisterResetFunc(&resetinfo);

--- a/backends/platform/wii/main.cpp
+++ b/backends/platform/wii/main.cpp
@@ -33,6 +33,7 @@
 #include "backends/plugins/wii/wii-provider.h"
 
 #include <ogc/machine/processor.h>
+#include <ogc/libversion.h>
 #include <fat.h>
 #ifndef GAMECUBE
 #include <wiiuse/wpad.h>
@@ -52,7 +53,13 @@ extern "C" {
 bool reset_btn_pressed = false;
 bool power_btn_pressed = false;
 
+#if ((_V_MAJOR_ > 1) || \
+        (_V_MAJOR_ == 1 && _V_MINOR_ > 8 ) || \
+        (_V_MAJOR_ == 1 && _V_MINOR_ == 8 && _V_PATCH_ >= 18))
+void reset_cb(u32, void *) {
+#else
 void reset_cb(void) {
+#endif
 #ifdef DEBUG_WII_GDB
 	printf("attach gdb now\n");
 	_break();

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -145,7 +145,16 @@ void OSystem_Wii::initBackend() {
 }
 
 void OSystem_Wii::quit() {
+	/* Delete _timerManager before deinitializing events as it's tied */
+	delete _timerManager;
+	_timerManager = nullptr;
+
 	deinitEvents();
+
+	/* Delete _eventManager before destroying FS to avoid problems when releasing virtual keyboard data */
+	delete _eventManager;
+	_eventManager = nullptr;
+
 	deinitSfx();
 	deinitGfx();
 

--- a/backends/plugins/elf/elf32.h
+++ b/backends/plugins/elf/elf32.h
@@ -236,6 +236,7 @@ typedef struct {
 #define R_ARM_V4BX 			40
 
 // PPC relocation types
+#define R_PPC_NONE			0
 #define R_PPC_ADDR32		1
 #define R_PPC_ADDR16_LO		4
 #define R_PPC_ADDR16_HI		5

--- a/backends/plugins/elf/ppc-loader.cpp
+++ b/backends/plugins/elf/ppc-loader.cpp
@@ -61,6 +61,9 @@ bool PPCDLObject::relocate(Elf32_Off offset, Elf32_Word size, byte *relSegment) 
 		//debug(8, "elfloader: i=%05d %p +0x%04x: (0x%08x) 0x%08x ", i, src, rel[i].r_addend, sym->st_value, *src);
 
 		switch (REL_TYPE(rel[i].r_info)) {
+		case R_PPC_NONE:
+			debug(8, "elfloader: R_PPC_NONE");
+			break;
 		case R_PPC_ADDR32:
 			*src = value;
 			debug(8, "elfloader: R_PPC_ADDR32 -> 0x%08x", *src);

--- a/configure
+++ b/configure
@@ -2811,10 +2811,12 @@ case $_host_os in
 		append_var CXXFLAGS "-fmodulo-sched"
 		append_var CXXFLAGS "-fuse-cxa-atexit"
 		append_var CXXFLAGS "-I$DEVKITPRO/libogc/include"
+		append_var CXXFLAGS "-I$DEVKITPRO/portlibs/ppc/include"
 		# libogc is required to link the cc tests (includes _start())
 		append_var LDFLAGS "-mogc"
 		append_var LDFLAGS "-mcpu=750"
 		append_var LDFLAGS "-L$DEVKITPRO/libogc/lib/cube"
+		append_var LDFLAGS "-L$DEVKITPRO/portlibs/ppc/lib"
 		append_var LDFLAGS "-logc"
 		if test "$_dynamic_modules" = "yes" ; then
 			# retarded toolchain patch forces --gc-sections, overwrite it
@@ -3007,10 +3009,12 @@ case $_host_os in
 		append_var CXXFLAGS "-fmodulo-sched"
 		append_var CXXFLAGS "-fuse-cxa-atexit"
 		append_var CXXFLAGS "-I$DEVKITPRO/libogc/include"
+		append_var CXXFLAGS "-I$DEVKITPRO/portlibs/ppc/include"
 		# libogc is required to link the cc tests (includes _start())
 		append_var LDFLAGS "-mrvl"
 		append_var LDFLAGS "-mcpu=750"
 		append_var LDFLAGS "-L$DEVKITPRO/libogc/lib/wii"
+		append_var LDFLAGS "-L$DEVKITPRO/portlibs/ppc/lib"
 		append_var LDFLAGS "-logc"
 		if test "$_dynamic_modules" = "yes" ; then
 			# retarded toolchain patch forces --gc-sections, overwrite it


### PR DESCRIPTION
This pull request lets ScummVM compile and run with the latest version of devkitPPC.
There are various fixes :
- paths to portlibs directory are added as it's where 3rd party libraries are expected to be installed
- -fpermissive is needed because reset_cb hasn't the expected signature. The proper way would be to fix the callback signature but I don't know how it would behave with an old toolchain.
- time.h is included in recent versions of network.h and must be excluded from forbidden symbols list
- Recent versions of GCC emits NONE relocations which prevents plugins to be loaded. Adding handling of them to elf-loader code make them work (and as it's a no-op it's easy to add).
- Last commit was an attempt to fix a bug which ended up to be in libgxflux. It destroys everything (and close all files) before quitting. It's not really a needed commit to have everything working.

I am not sure we want to include this in next release as I only tested PR on Dolphin Emulator and not on a real hardware. I would also like a second look from someone who knows well the platform.