### PR TITLE
GUI: Fix launcher layout for small widths

### DIFF
--- a/gui/ThemeLayout.cpp
+++ b/gui/ThemeLayout.cpp
@@ -202,18 +202,11 @@ void ThemeLayoutStacked::reflowLayoutVertical() {
 
 		_children[i]->offsetY(curY);
 
-		// Center child if it this has been requested *and* the space permits it.
-		if (_centered && _children[i]->getWidth() < _w && _w != -1) {
-			_children[i]->offsetX((_w >> 1) - (_children[i]->getWidth() >> 1));
-		} else
-			_children[i]->offsetX(curX);
-
 		// Advance the vertical offset by the height of the newest item, plus
 		// the item spacing value.
 		curY += _children[i]->getHeight() + _spacing;
 
-		// Update width and height of this stack layout
-		_w = MAX(_w, (int16)(_children[i]->getWidth() + _padding.left + _padding.right));
+		// Update the height of this stack layout
 		_h += _children[i]->getHeight() + _spacing;
 	}
 
@@ -237,6 +230,21 @@ void ThemeLayoutStacked::reflowLayoutVertical() {
 			for (uint j = resize[i] + 1; j < _children.size(); ++j)
 				_children[j]->offsetY(newh);
 		}
+	}
+
+	// Set stack width from its children if it was not set by its parent
+	if (_w == -1) {
+		for (uint i = 0; i < _children.size(); ++i) {
+			_w = MAX(_w, (int16)(_children[i]->getWidth() + _padding.left + _padding.right));
+		}
+	}
+
+	for (uint i = 0; i < _children.size(); ++i) {
+		// Center child if it this has been requested *and* the space permits it.
+		if (_centered && _children[i]->getWidth() < (_w - _padding.left - _padding.right) && _w != -1) {
+			_children[i]->offsetX((_w >> 1) - (_children[i]->getWidth() >> 1));
+		} else
+			_children[i]->offsetX(curX);
 	}
 }
 
@@ -265,19 +273,12 @@ void ThemeLayoutStacked::reflowLayoutHorizontal() {
 
 		_children[i]->offsetX(curX);
 
-		// Center child if it this has been requested *and* the space permits it.
-		if (_centered && _children[i]->getHeight() < _h && _h != -1)
-			_children[i]->offsetY((_h >> 1) - (_children[i]->getHeight() >> 1));
-		else
-			_children[i]->offsetY(curY);
-
 		// Advance the horizontal offset by the width of the newest item, plus
 		// the item spacing value.
 		curX += (_children[i]->getWidth() + _spacing);
 
-		// Update width and height of this stack layout
+		// Update the width of this stack layout
 		_w += _children[i]->getWidth() + _spacing;
-		_h = MAX(_h, (int16)(_children[i]->getHeight() + _padding.top + _padding.bottom));
 	}
 
 	// If there are any children at all, then we added the spacing value once
@@ -300,6 +301,21 @@ void ThemeLayoutStacked::reflowLayoutHorizontal() {
 			for (uint j = resize[i] + 1; j < _children.size(); ++j)
 				_children[j]->offsetX(neww);
 		}
+	}
+
+	// Set stack height from its children if it was not set by its parent
+	if (_h == -1) {
+		for (uint i = 0; i < _children.size(); ++i) {
+			_h = MAX(_h, (int16)(_children[i]->getHeight() + _padding.top + _padding.bottom));
+		}
+	}
+
+	for (uint i = 0; i < _children.size(); ++i) {
+		// Center child if it this has been requested *and* the space permits it.
+		if (_centered && _children[i]->getHeight() < (_h - _padding.top - _padding.bottom) && _h != -1)
+			_children[i]->offsetY((_h >> 1) - (_children[i]->getHeight() >> 1));
+		else
+			_children[i]->offsetY(curY);
 	}
 }
 


### PR DESCRIPTION
* Testing if a widget can be centered was ignoring the padding.
* Only resize a layout based on its content if it was not explicitly
   sized by its parent. Fixes the logo causing incorrect layout
   computations when the window width is lower than the image width.

Before:
![Capture d’écran de 2019-10-02 19-32-52](https://user-images.githubusercontent.com/52294/66067491-f8bdb180-e54b-11e9-871f-20391dc8ae9f.png)

After:
![Capture d’écran de 2019-10-02 19-31-06](https://user-images.githubusercontent.com/52294/66067486-f6f3ee00-e54b-11e9-918b-63a5c7c5dd51.png)

There are very obvious remaining issues (I have a fix for the wrapping logo planned for another PR), but at least the layout is correct.