### PR TITLE
GRAPHICS: Vector renderer clipping rect related cleanups

### DIFF
--- a/graphics/VectorRenderer.cpp
+++ b/graphics/VectorRenderer.cpp
@@ -32,34 +32,7 @@ namespace Graphics {
 /********************************************************************
  * DRAWSTEP handling functions
  ********************************************************************/
-void VectorRenderer::drawStep(const Common::Rect &area, const DrawStep &step, uint32 extra) {
-
-	if (step.bgColor.set)
-		setBgColor(step.bgColor.r, step.bgColor.g, step.bgColor.b);
-
-	if (step.fgColor.set)
-		setFgColor(step.fgColor.r, step.fgColor.g, step.fgColor.b);
-
-	if (step.bevelColor.set)
-		setBevelColor(step.bevelColor.r, step.bevelColor.g, step.bevelColor.b);
-
-	if (step.gradColor1.set && step.gradColor2.set)
-		setGradientColors(step.gradColor1.r, step.gradColor1.g, step.gradColor1.b,
-						  step.gradColor2.r, step.gradColor2.g, step.gradColor2.b);
-
-	setShadowOffset(_disableShadows ? 0 : step.shadow);
-	setBevel(step.bevel);
-	setGradientFactor(step.factor);
-	setStrokeWidth(step.stroke);
-	setFillMode((FillMode)step.fillMode);
-
-	_dynamicData = extra;
-
-	Common::Rect noClip = Common::Rect(0, 0, 0, 0);
-	(this->*(step.drawingCall))(area, step, noClip);
-}
-
-void VectorRenderer::drawStepClip(const Common::Rect &area, const Common::Rect &clip, const DrawStep &step, uint32 extra) {
+void VectorRenderer::drawStep(const Common::Rect &area, const Common::Rect &clip, const DrawStep &step, uint32 extra) {
 
 	if (step.bgColor.set)
 		setBgColor(step.bgColor.r, step.bgColor.g, step.bgColor.b);
@@ -79,10 +52,11 @@ void VectorRenderer::drawStepClip(const Common::Rect &area, const Common::Rect &
 	setGradientFactor(step.factor);
 	setStrokeWidth(step.stroke);
 	setFillMode((FillMode)step.fillMode);
+	setClippingRect(clip);
 
 	_dynamicData = extra;
 
-	(this->*(step.drawingCall))(area, step, clip);
+	(this->*(step.drawingCall))(area, step);
 }
 
 int VectorRenderer::stepGetRadius(const DrawStep &step, const Common::Rect &area) {

--- a/graphics/VectorRenderer.h
+++ b/graphics/VectorRenderer.h
@@ -39,7 +39,7 @@ class VectorRenderer;
 struct DrawStep;
 
 
-typedef void (VectorRenderer::*DrawingFunctionCallback)(const Common::Rect &, const Graphics::DrawStep &, const Common::Rect &);
+typedef void (VectorRenderer::*DrawingFunctionCallback)(const Common::Rect &, const Graphics::DrawStep &);
 
 
 struct DrawStep {
@@ -165,7 +165,6 @@ public:
 	 * @param y2 Vertical (Y) coordinate for the line end
 	 */
 	virtual void drawLine(int x1, int y1, int x2, int y2) = 0;
-	virtual void drawLineClip(int x1, int y1, int x2, int y2, Common::Rect clipping) = 0;
 
 	/**
 	 * Draws a circle centered at (x,y) with radius r.
@@ -175,7 +174,6 @@ public:
 	 * @param r Radius of the circle.
 	 */
 	virtual void drawCircle(int x, int y, int r) = 0;
-	virtual void drawCircleClip(int x, int y, int r, Common::Rect clipping) = 0;
 
 	/**
 	 * Draws a square starting at (x,y) with the given width and height.
@@ -186,7 +184,6 @@ public:
 	 * @param h Height of the square
 	 */
 	virtual void drawSquare(int x, int y, int w, int h) = 0;
-	virtual void drawSquareClip(int x, int y, int w, int h, Common::Rect clipping) = 0;
 
 	/**
 	 * Draws a rounded square starting at (x,y) with the given width and height.
@@ -199,7 +196,6 @@ public:
 	 * @param r Radius of the corners.
 	 */
 	virtual void drawRoundedSquare(int x, int y, int r, int w, int h) = 0;
-	virtual void drawRoundedSquareClip(int x, int y, int r, int w, int h, Common::Rect clipping) = 0;
 
 	/**
 	 * Draws a triangle starting at (x,y) with the given base and height.
@@ -213,7 +209,6 @@ public:
 	 * @param orient Orientation of the triangle.
 	 */
 	virtual void drawTriangle(int x, int y, int base, int height, TriangleOrientation orient) = 0;
-	virtual void drawTriangleClip(int x, int y, int base, int height, TriangleOrientation orient, Common::Rect clipping) = 0;
 
 	/**
 	 * Draws a beveled square like the ones in the Classic GUI themes.
@@ -226,8 +221,7 @@ public:
 	 * @param h Height of the square
 	 * @param bevel Amount of bevel. Must be positive.
 	 */
-	virtual void drawBeveledSquare(int x, int y, int w, int h, int bevel) = 0;
-	virtual void drawBeveledSquareClip(int x, int y, int w, int h, int bevel, Common::Rect clipping) = 0;
+	virtual void drawBeveledSquare(int x, int y, int w, int h) = 0;
 
 	/**
 	 * Draws a tab-like shape, specially thought for the Tab widget.
@@ -241,8 +235,6 @@ public:
 	 * @param r Radius of the corners of the tab (0 for squared tabs).
 	 */
 	virtual void drawTab(int x, int y, int r, int w, int h) = 0;
-	virtual void drawTabClip(int x, int y, int r, int w, int h, Common::Rect clipping) = 0;
-
 
 	/**
 	 * Simple helper function to draw a cross.
@@ -250,11 +242,6 @@ public:
 	virtual void drawCross(int x, int y, int w, int h) {
 		drawLine(x, y, x + w, y + w);
 		drawLine(x + w, y, x, y + h);
-	}
-
-	virtual void drawCrossClip(int x, int y, int w, int h, Common::Rect clipping) {
-		drawLineClip(x, y, x + w, y + w, clipping);
-		drawLineClip(x + w, y, x, y + h, clipping);
 	}
 
 	/**
@@ -320,7 +307,6 @@ public:
 	 * Defaults to using the active Foreground color for filling.
 	 */
 	virtual void fillSurface() = 0;
-	virtual void fillSurfaceClip(Common::Rect clipping) = 0;
 
 	/**
 	 * Clears the active surface.
@@ -384,6 +370,16 @@ public:
 	}
 
 	/**
+	 * Sets the clipping rectangle to be used by draw calls.
+	 *
+	 * Draw calls are restricted to pixels that are inside of the clipping
+	 * rectangle. Pixels outside the clipping rectangle are not modified.
+	 * To disable the clipping rectangle, call this method with a rectangle
+	 * the same size as the target surface.
+	 */
+	virtual void setClippingRect(const Common::Rect &clippingArea) = 0;
+
+	/**
 	 * Translates the position data inside a DrawStep into actual
 	 * screen drawing positions.
 	 */
@@ -398,74 +394,74 @@ public:
 	/**
 	 * DrawStep callback functions for each drawing feature
 	 */
-	void drawCallback_CIRCLE(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_CIRCLE(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h, radius;
 
 		radius = stepGetRadius(step, area);
 		stepGetPositions(step, area, x, y, w, h);
 
-		drawCircleClip(x + radius, y + radius, radius, clip);
+		drawCircle(x + radius, y + radius, radius);
 	}
 
-	void drawCallback_SQUARE(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_SQUARE(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		drawSquareClip(x, y, w, h, clip);
+		drawSquare(x, y, w, h);
 	}
 
-	void drawCallback_LINE(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_LINE(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		drawLineClip(x, y, x + w, y + w, clip);
+		drawLine(x, y, x + w, y + w);
 	}
 
-	void drawCallback_ROUNDSQ(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_ROUNDSQ(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		drawRoundedSquareClip(x, y, stepGetRadius(step, area), w, h, clip);
+		drawRoundedSquare(x, y, stepGetRadius(step, area), w, h);
 	}
 
-	void drawCallback_FILLSURFACE(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
-		fillSurfaceClip(clip);
+	void drawCallback_FILLSURFACE(const Common::Rect &area, const DrawStep &step) {
+		fillSurface();
 	}
 
-	void drawCallback_TRIANGLE(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_TRIANGLE(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		drawTriangleClip(x, y, w, h, (TriangleOrientation)step.extraData, clip);
+		drawTriangle(x, y, w, h, (TriangleOrientation)step.extraData);
 	}
 
-	void drawCallback_BEVELSQ(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_BEVELSQ(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		drawBeveledSquareClip(x, y, w, h, _bevel, clip);
+		drawBeveledSquare(x, y, w, h);
 	}
 
-	void drawCallback_TAB(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_TAB(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		drawTabClip(x, y, stepGetRadius(step, area), w, h, clip);
+		drawTab(x, y, stepGetRadius(step, area), w, h);
 	}
 
-	void drawCallback_BITMAP(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_BITMAP(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		blitKeyBitmapClip(step.blitSrc, Common::Rect(x, y, x + w, y + h), clip);
+		blitKeyBitmap(step.blitSrc, Common::Point(x, y));
 	}
 
-	void drawCallback_ALPHABITMAP(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_ALPHABITMAP(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
 		blitAlphaBitmap(step.blitAlphaSrc, Common::Rect(x, y, x + w, y + h), step.autoscale, step.xAlign, step.yAlign); // TODO
 	}
 
-	void drawCallback_CROSS(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {
+	void drawCallback_CROSS(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		drawCrossClip(x, y, w, h, clip);
+		drawCross(x, y, w, h);
 	}
 
-	void drawCallback_VOID(const Common::Rect &area, const DrawStep &step, const Common::Rect &clip) {}
+	void drawCallback_VOID(const Common::Rect &area, const DrawStep &step) {}
 
 	/**
 	 * Draws the specified draw step on the screen.
@@ -474,8 +470,7 @@ public:
 	 * @param area Zone to paint on
 	 * @param step Pointer to a DrawStep struct.
 	 */
-	virtual void drawStep(const Common::Rect &area, const DrawStep &step, uint32 extra = 0);
-	virtual void drawStepClip(const Common::Rect &area, const Common::Rect &clip, const DrawStep &step, uint32 extra = 0);
+	virtual void drawStep(const Common::Rect &area, const Common::Rect &clip, const DrawStep &step, uint32 extra = 0);
 
 	/**
 	 * Copies the part of the current frame to the system overlay.
@@ -509,17 +504,11 @@ public:
 	virtual void blitSurface(const Graphics::Surface *source, const Common::Rect &r) = 0;
 
 	/**
-	 * Blits a given graphics surface into a small area of the current drawing surface.
-	 *
-	 * Note that the given surface is expected to be smaller than the
-	 * active drawing surface, hence the WHOLE source surface will be
-	 * blitted into the active surface, at the position specified by "r".
+	 * Blits a given graphics surface at the specified position of the current drawing surface.
 	 */
-	virtual void blitSubSurface(const Graphics::Surface *source, const Common::Rect &r) = 0;
-	virtual void blitSubSurfaceClip(const Graphics::Surface *source, const Common::Rect &r, const Common::Rect &clipping) = 0;
+	virtual void blitSubSurface(const Graphics::Surface *source, const Common::Point &p) = 0;
 
-	virtual void blitKeyBitmap(const Graphics::Surface *source, const Common::Rect &r) = 0;
-	virtual void blitKeyBitmapClip(const Graphics::Surface *source, const Common::Rect &r, const Common::Rect &clipping) = 0;
+	virtual void blitKeyBitmap(const Graphics::Surface *source, const Common::Point &p) = 0;
 
 	virtual void blitAlphaBitmap(Graphics::TransparentSurface *source, const Common::Rect &r,
 			GUI::ThemeEngine::AutoScaleMode autoscale = GUI::ThemeEngine::kAutoScaleNone,

--- a/graphics/VectorRendererSpec.h
+++ b/graphics/VectorRendererSpec.h
@@ -51,29 +51,18 @@ public:
 	VectorRendererSpec(PixelFormat format);
 
 	void drawLine(int x1, int y1, int x2, int y2);
-	void drawLineClip(int x1, int y1, int x2, int y2, Common::Rect clipping);
 	void drawCircle(int x, int y, int r);
-	void drawCircleClip(int x, int y, int r, Common::Rect clipping);
 	void drawSquare(int x, int y, int w, int h);
-	void drawSquareClip(int x, int y, int w, int h, Common::Rect clipping);
 	void drawRoundedSquare(int x, int y, int r, int w, int h);
-	void drawRoundedSquareClip(int x, int y, int r, int w, int h, Common::Rect clipping);
 	void drawTriangle(int x, int y, int base, int height, TriangleOrientation orient);
-	void drawTriangleClip(int x, int y, int base, int height, TriangleOrientation orient, Common::Rect clipping);
 	void drawTab(int x, int y, int r, int w, int h);
-	void drawTabClip(int x, int y, int r, int w, int h, Common::Rect clipping);
-	void drawBeveledSquare(int x, int y, int w, int h, int bevel) {
-		drawBevelSquareAlg(x, y, w, h, bevel, _bevelColor, _fgColor, Base::_fillMode != kFillDisabled);
-	}
-	void drawBeveledSquareClip(int x, int y, int w, int h, int bevel, Common::Rect clipping) {
-		bool useClippingVersions = !(clipping.isEmpty() || clipping.contains(Common::Rect(x, y, x + w, y + h)));
+
+	void drawBeveledSquare(int x, int y, int w, int h) {
+		bool useClippingVersions = !_clippingArea.contains(Common::Rect(x, y, x + w, y + h));
 		if (useClippingVersions) {
-			Common::Rect backup = _clippingArea;
-			_clippingArea = clipping;
-			drawBevelSquareAlgClip(x, y, w, h, bevel, _bevelColor, _fgColor, Base::_fillMode != kFillDisabled);
-			_clippingArea = backup;
+			drawBevelSquareAlgClip(x, y, w, h, _bevel, _bevelColor, _fgColor);
 		} else {
-			drawBevelSquareAlg(x, y, w, h, bevel, _bevelColor, _fgColor, Base::_fillMode != kFillDisabled);
+			drawBevelSquareAlg(x, y, w, h, _bevel, _bevelColor, _fgColor);
 		}
 	}
 	void drawString(const Graphics::Font *font, const Common::String &text,
@@ -84,17 +73,15 @@ public:
 	void setBgColor(uint8 r, uint8 g, uint8 b) { _bgColor = _format.RGBToColor(r, g, b); }
 	void setBevelColor(uint8 r, uint8 g, uint8 b) { _bevelColor = _format.RGBToColor(r, g, b); }
 	void setGradientColors(uint8 r1, uint8 g1, uint8 b1, uint8 r2, uint8 g2, uint8 b2);
+	void setClippingRect(const Common::Rect &clippingArea) override { _clippingArea = clippingArea; }
 
 	void copyFrame(OSystem *sys, const Common::Rect &r);
 	void copyWholeFrame(OSystem *sys) { copyFrame(sys, Common::Rect(0, 0, _activeSurface->w, _activeSurface->h)); }
 
 	void fillSurface();
-	void fillSurfaceClip(Common::Rect clipping);
 	void blitSurface(const Graphics::Surface *source, const Common::Rect &r);
-	void blitSubSurface(const Graphics::Surface *source, const Common::Rect &r);
-	void blitSubSurfaceClip(const Graphics::Surface *source, const Common::Rect &r, const Common::Rect &clipping);
-	void blitKeyBitmap(const Graphics::Surface *source, const Common::Rect &r);
-	void blitKeyBitmapClip(const Graphics::Surface *source, const Common::Rect &r, const Common::Rect &clipping);
+	void blitSubSurface(const Graphics::Surface *source, const Common::Point &p);
+	void blitKeyBitmap(const Graphics::Surface *source, const Common::Point &p);
 	void blitAlphaBitmap(Graphics::TransparentSurface *source, const Common::Rect &r,
 			GUI::ThemeEngine::AutoScaleMode autoscale = GUI::ThemeEngine::kAutoScaleNone,
 			Graphics::DrawStep::VectorAlignment xAlign = Graphics::DrawStep::kVectorAlignManual,
@@ -223,10 +210,10 @@ protected:
 	    bool inverted, PixelType color, FillMode fill_m);
 
 	virtual void drawBevelSquareAlg(int x, int y, int w, int h,
-	    int bevel, PixelType top_color, PixelType bottom_color, bool fill);
+	    int bevel, PixelType top_color, PixelType bottom_color);
 
 	virtual void drawBevelSquareAlgClip(int x, int y, int w, int h,
-		int bevel, PixelType top_color, PixelType bottom_color, bool fill);
+		int bevel, PixelType top_color, PixelType bottom_color);
 
 	virtual void drawTabAlg(int x, int y, int w, int h, int r,
 	    PixelType color, VectorRenderer::FillMode fill_m,

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -387,6 +387,11 @@ public:
 	 */
 	Common::Rect swapClipRect(const Common::Rect &newRect);
 
+	/**
+	 * Set the clipping rect to allow rendering on the whole surface.
+	 */
+	void disableClipRect();
+
 	/** @name WIDGET DRAWING METHODS */
 	//@{
 
@@ -395,7 +400,7 @@ public:
 	void drawButton(const Common::Rect &r, const Common::String &str, WidgetStateInfo state = kStateEnabled,
 	                uint16 hints = 0);
 
-	void drawSurface(const Common::Rect &r, const Graphics::Surface &surface, bool themeTrans = false);
+	void drawSurface(const Common::Point &p, const Graphics::Surface &surface, bool themeTrans = false);
 
 	void drawSlider(const Common::Rect &r, int width, WidgetStateInfo state = kStateEnabled);
 
@@ -633,7 +638,6 @@ protected:
 	                bool elipsis, Graphics::TextAlign alignH = Graphics::kTextAlignLeft,
 	                TextAlignVertical alignV = kTextAlignVTop, int deltax = 0,
 	                const Common::Rect &drawableTextArea = Common::Rect(0, 0, 0, 0));
-	void drawBitmap(const Graphics::Surface *bitmap, const Common::Rect &clippingRect, bool alpha);
 
 	/**
 	 * DEBUG: Draws a white square and writes some text next to it.

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -163,6 +163,7 @@ void Dialog::drawDialog(DrawLayer layerToDraw) {
 	if (!isVisible())
 		return;
 
+	g_gui.theme()->disableClipRect();
 	g_gui.theme()->_layerToDraw = layerToDraw;
 	g_gui.theme()->drawDialogBackground(Common::Rect(_x, _y, _x + _w, _y + _h), _backgroundType);
 

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -482,7 +482,7 @@ void PicButtonWidget::drawWidget() {
 		const int x = _x + (_w - gfx->w) / 2;
 		const int y = _y + (_h - gfx->h) / 2;
 
-		g_gui.theme()->drawSurface(Common::Rect(x, y, x + gfx->w, y + gfx->h), *gfx, _transparency);
+		g_gui.theme()->drawSurface(Common::Point(x, y), *gfx, _transparency);
 	}
 }
 
@@ -733,7 +733,7 @@ void GraphicsWidget::drawWidget() {
 		const int x = _x + (_w - _gfx.w) / 2;
 		const int y = _y + (_h - _gfx.h) / 2;
 
-		g_gui.theme()->drawSurface(Common::Rect(x, y, x + _gfx.w, y + _gfx.h), _gfx, _transparency);
+		g_gui.theme()->drawSurface(Common::Point(x, y), _gfx, _transparency);
 	}
 }
 


### PR DESCRIPTION
Selecting whether a clipping variant of a draw call needs to be used is no longer the responsibility to the caller.

Also fix some of the draw calls to (better) apply the clipping rect.