### PR TITLE
BLADERUNNER: Remove use of C99 math functions

### DIFF
--- a/common/math.h
+++ b/common/math.h
@@ -107,6 +107,20 @@ inline int intLog2(uint32 v) {
 }
 #endif
 
+// Round a number towards zero
+// Input and Output type can be different
+template<class InputT, class OutputT>
+inline OutputT trunc(InputT x) {
+    return (x > 0) ? floor(x) : ceil(x);
+}
+
+// Round a number towards zero
+// Input and Output type are the same
+template<class T>
+inline T trunc(T x) {
+	return trunc<T,T>(x);
+}
+
 // Convert radians to degrees
 // Input and Output type can be different
 // Upconvert everything to floats

--- a/engines/bladerunner/rect_float.h
+++ b/engines/bladerunner/rect_float.h
@@ -24,6 +24,7 @@
 #define BLADERUNNER_RECT_FLOAT_H
 
 #include "common/debug.h"
+#include "common/math.h"
 #include "common/types.h"
 #include "common/util.h"
 
@@ -50,10 +51,10 @@ struct RectFloat {
 	}
 
 	void trunc_2_decimals() {
-		x0 = truncf(x0 * 100.0f) / 100.0f;
-		y0 = truncf(y0 * 100.0f) / 100.0f;
-		x1 = truncf(x1 * 100.0f) / 100.0f;
-		y1 = truncf(y1 * 100.0f) / 100.0f;
+		x0 = Common::trunc(x0 * 100.0f) / 100.0f;
+		y0 = Common::trunc(y0 * 100.0f) / 100.0f;
+		x1 = Common::trunc(x1 * 100.0f) / 100.0f;
+		y1 = Common::trunc(y1 * 100.0f) / 100.0f;
 	}
 };
 

--- a/engines/bladerunner/slice_renderer.cpp
+++ b/engines/bladerunner/slice_renderer.cpp
@@ -614,9 +614,9 @@ void SliceRenderer::drawShadowInWorld(int transparency, Graphics::Surface &surfa
 		0.0f, 0.0f, 1.0f, _position.z);
 
 	Matrix4x3 mRotation(
-		cosf(_facing), -sinf(_facing), 0.0f, 0.0f,
-		sinf(_facing),  cosf(_facing), 0.0f, 0.0f,
-		          0.0f,          0.0f, 1.0f, 0.0f);
+		cos(_facing), -sin(_facing), 0.0f, 0.0f,
+		sin(_facing),  cos(_facing), 0.0f, 0.0f,
+		        0.0f,          0.0f, 1.0f, 0.0f);
 
 	Matrix4x3 mScale(
 		_frameScale.x,          0.0f,              0.0f, 0.0f,


### PR DESCRIPTION
This is a follow-up to PR #1295.
