### PR TITLE
CREATE_PROJECT: Split non engine code into additional projects

### DIFF
--- a/devtools/create_project/codeblocks.cpp
+++ b/devtools/create_project/codeblocks.cpp
@@ -44,7 +44,7 @@ void CodeBlocksProvider::createWorkspace(const BuildSetup &setup) {
 	writeReferences(setup, workspace);
 
 	// Note we assume that the UUID map only includes UUIDs for enabled engines!
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _engineProjects.begin(); i != _engineProjects.end(); ++i) {
 		if (i->first == setup.projectName)
 			continue;
 
@@ -130,7 +130,7 @@ void CodeBlocksProvider::createProjectFile(const std::string &name, const std::s
 		for (StringList::const_iterator i = setup.libraries.begin(); i != setup.libraries.end(); ++i)
 			project << "\t\t\t\t\t<Add library=\"" << processLibraryName(*i) << "\" />\n";
 
-		for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+		for (UUIDMap::const_iterator i = _engineProjects.begin(); i != _engineProjects.end(); ++i) {
 			if (i->first == setup.projectName)
 				continue;
 
@@ -254,7 +254,7 @@ void CodeBlocksProvider::writeFileListToProject(const FileNode &dir, std::ofstre
 void CodeBlocksProvider::writeReferences(const BuildSetup &setup, std::ofstream &output) {
 	output << "\t\t<Project filename=\"" << setup.projectName << ".cbp\" active=\"1\">\n";
 
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _engineProjects.begin(); i != _engineProjects.end(); ++i) {
 		if (i->first == " << PROJECT_NAME << ")
 			continue;
 

--- a/devtools/create_project/config.h
+++ b/devtools/create_project/config.h
@@ -29,7 +29,7 @@
 #define REVISION_DEFINE "SCUMMVM_INTERNAL_REVISION"
 #define FIRST_ENGINE "scumm"             // Name of the engine which should be sorted as first element
 
-#define ENABLE_LANGUAGE_EXTENSIONS ""    // Comma separated list of projects that need language extensions
+#define ENABLE_LANGUAGE_EXTENSIONS "Backend,Common"    // Comma separated list of projects that need language extensions
 #define DISABLE_EDIT_AND_CONTINUE "tinsel,tony,scummvm"     // Comma separated list of projects that need Edit&Continue to be disabled for co-routine support (the main project is automatically added)
 
 //#define ADDITIONAL_LIBRARY ""            // Add a single library to the list of externally linked libraries

--- a/devtools/create_project/config.h
+++ b/devtools/create_project/config.h
@@ -30,7 +30,7 @@
 #define FIRST_ENGINE "scumm"             // Name of the engine which should be sorted as first element
 
 #define ENABLE_LANGUAGE_EXTENSIONS "Backend,Common"    // Comma separated list of projects that need language extensions
-#define DISABLE_EDIT_AND_CONTINUE "tinsel,tony,scummvm"     // Comma separated list of projects that need Edit&Continue to be disabled for co-routine support (the main project is automatically added)
+#define DISABLE_EDIT_AND_CONTINUE "tinsel,tony,scummvm,Common"     // Comma separated list of projects that need Edit&Continue to be disabled for co-routine support (the main project is automatically added)
 
 //#define ADDITIONAL_LIBRARY ""            // Add a single library to the list of externally linked libraries
 #define NEEDS_RTTI 1                     // Enable RTTI globally

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1504,33 +1504,20 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 	std::string targetFolder;
 
 	if (setup.devTools) {
-		_uuidMap = createToolsUUIDMap();
+		_engineProjects = createToolsUUIDMap();
 		targetFolder = "/devtools/";
 	} else if (!setup.tests) {
-		_uuidMap = createUUIDMap(setup);
+		_engineProjects = createUUIDMap(setup);
 		targetFolder = "/engines/";
 	}
 
 	// We also need to add the UUID of the main project file.
-	const std::string svmUUID = _uuidMap[setup.projectName] = createUUID(setup.projectName);
+	const std::string svmUUID = _engineProjects[setup.projectName] = createUUID(setup.projectName);
 
 
 	StringList in, ex;
 
-	// Create project files
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
-		if (i->first == setup.projectName)
-			continue;
-		// Retain the files between engines if we're creating a single project
-		in.clear(); ex.clear();
-
-		const std::string moduleDir = setup.srcDir + targetFolder + i->first;
-
-		createModuleList(moduleDir, setup.defines, setup.testDirs, in, ex);
-		createProjectFile(i->first, i->second, setup, moduleDir, in, ex);
-	}
-
-#define addUUID(x) _uuidMap[x] = createUUID(createUUID(x)) 
+#define addCommonProjectUUID(x) _commonProjects[x] = createUUID(createUUID(x)) 
 
 	if (setup.tests) {
 		// Create the main project file.
@@ -1549,31 +1536,31 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 	} else if (!setup.devTools) {
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/video", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("Video", addUUID("Video"), setup, setup.srcDir + "/video", in, ex);
+		createProjectFile("Video", addCommonProjectUUID("Video"), setup, setup.srcDir + "/video", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/backends", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/backends/platform/sdl", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("Backend", addUUID("Backend"), setup, setup.srcDir + "/backends", in, ex);
+		createProjectFile("Backend", addCommonProjectUUID("Backend"), setup, setup.srcDir + "/backends", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/common", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/engines", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("Common", addUUID("Common"), setup, setup.srcDir + "/common", in, ex);
+		createProjectFile("Common", addCommonProjectUUID("Common"), setup, setup.srcDir, in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/graphics", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/image", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("Graphics", addUUID("Graphics"), setup, setup.srcDir + "/graphics", in, ex);
+		createProjectFile("Graphics", addCommonProjectUUID("Graphics"), setup, setup.srcDir, in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/audio", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/audio/softsynth/mt32", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("Audio", addUUID("Audio"), setup, setup.srcDir + "/audio", in, ex);
+		createProjectFile("Audio", addCommonProjectUUID("Audio"), setup, setup.srcDir + "/audio", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/gui", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("Gui", addUUID("Gui"), setup, setup.srcDir + "/gui", in, ex);
+		createProjectFile("Gui", addCommonProjectUUID("Gui"), setup, setup.srcDir + "/gui", in, ex);
 
 		// Last but not least create the main project file.
 		in.clear(); ex.clear();
@@ -1597,6 +1584,19 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 
 		// Create the main project file.
 		createProjectFile(setup.projectName, svmUUID, setup, setup.srcDir, in, ex);
+	}
+
+	// Create engine project files
+	for (UUIDMap::const_iterator i = _engineProjects.begin(); i != _engineProjects.end(); ++i) {
+		if (i->first == setup.projectName)
+			continue;
+		// Retain the files between engines if we're creating a single project
+		in.clear(); ex.clear();
+
+		const std::string moduleDir = setup.srcDir + targetFolder + i->first;
+
+		createModuleList(moduleDir, setup.defines, setup.testDirs, in, ex);
+		createProjectFile(i->first, i->second, setup, moduleDir, in, ex);
 	}
 
 	createWorkspace(setup);

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1546,20 +1546,38 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 
 		createProjectFile(setup.projectName, svmUUID, setup, setup.srcDir, in, ex);
 	} else if (!setup.devTools) {
+		in.clear(); ex.clear();
+		createModuleList(setup.srcDir + "/video", setup.defines, setup.testDirs, in, ex);
+		createProjectFile("Video", createUUID("Video"), setup, setup.srcDir + "/video", in, ex);
+
+		in.clear(); ex.clear();
+		createModuleList(setup.srcDir + "/backends", setup.defines, setup.testDirs, in, ex);
+		createModuleList(setup.srcDir + "/backends/platform/sdl", setup.defines, setup.testDirs, in, ex);
+		createProjectFile("backend", createUUID("Backend"), setup, setup.srcDir + "/backends", in, ex);
+
+		in.clear(); ex.clear();
+		createModuleList(setup.srcDir + "/common", setup.defines, setup.testDirs, in, ex);
+		createModuleList(setup.srcDir + "/engines", setup.defines, setup.testDirs, in, ex);
+		createProjectFile("common", createUUID("Common"), setup, setup.srcDir + "/common", in, ex);
+
+		in.clear(); ex.clear();
+		createModuleList(setup.srcDir + "/graphics", setup.defines, setup.testDirs, in, ex);
+		createModuleList(setup.srcDir + "/image", setup.defines, setup.testDirs, in, ex);
+		createProjectFile("graphics", createUUID("Graphics"), setup, setup.srcDir + "/graphics", in, ex);
+
+		in.clear(); ex.clear();
+		createModuleList(setup.srcDir + "/audio", setup.defines, setup.testDirs, in, ex);
+		createModuleList(setup.srcDir + "/audio/softsynth/mt32", setup.defines, setup.testDirs, in, ex);
+		createProjectFile("audio", createUUID("Audio"), setup, setup.srcDir + "/audio", in, ex);
+
+		in.clear(); ex.clear();
+		createModuleList(setup.srcDir + "/gui", setup.defines, setup.testDirs, in, ex);
+		createProjectFile("gui", createUUID("Gui"), setup, setup.srcDir + "/gui", in, ex);
+
 		// Last but not least create the main project file.
 		in.clear(); ex.clear();
 		// File list for the Project file
-		createModuleList(setup.srcDir + "/backends", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/backends/platform/sdl", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/base", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/common", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/engines", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/graphics", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/gui", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/audio", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/audio/softsynth/mt32", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/video", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/image", setup.defines, setup.testDirs, in, ex);
 
 		// Resource files
 		addResourceFiles(setup, in, ex);

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1514,7 +1514,6 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 	// We also need to add the UUID of the main project file.
 	const std::string svmUUID = _uuidMap[setup.projectName] = createUUID(setup.projectName);
 
-	createWorkspace(setup);
 
 	StringList in, ex;
 
@@ -1530,6 +1529,8 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 		createModuleList(moduleDir, setup.defines, setup.testDirs, in, ex);
 		createProjectFile(i->first, i->second, setup, moduleDir, in, ex);
 	}
+
+#define addUUID(x) _uuidMap[x] = createUUID(createUUID(x)) 
 
 	if (setup.tests) {
 		// Create the main project file.
@@ -1548,31 +1549,31 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 	} else if (!setup.devTools) {
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/video", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("Video", createUUID("Video"), setup, setup.srcDir + "/video", in, ex);
+		createProjectFile("Video", addUUID("Video"), setup, setup.srcDir + "/video", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/backends", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/backends/platform/sdl", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("backend", createUUID("Backend"), setup, setup.srcDir + "/backends", in, ex);
+		createProjectFile("backend", addUUID("Backend"), setup, setup.srcDir + "/backends", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/common", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/engines", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("common", createUUID("Common"), setup, setup.srcDir + "/common", in, ex);
+		createProjectFile("common", addUUID("Common"), setup, setup.srcDir + "/common", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/graphics", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/image", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("graphics", createUUID("Graphics"), setup, setup.srcDir + "/graphics", in, ex);
+		createProjectFile("graphics", addUUID("Graphics"), setup, setup.srcDir + "/graphics", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/audio", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/audio/softsynth/mt32", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("audio", createUUID("Audio"), setup, setup.srcDir + "/audio", in, ex);
+		createProjectFile("audio", addUUID("Audio"), setup, setup.srcDir + "/audio", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/gui", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("gui", createUUID("Gui"), setup, setup.srcDir + "/gui", in, ex);
+		createProjectFile("gui", addUUID("Gui"), setup, setup.srcDir + "/gui", in, ex);
 
 		// Last but not least create the main project file.
 		in.clear(); ex.clear();
@@ -1597,6 +1598,8 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 		// Create the main project file.
 		createProjectFile(setup.projectName, svmUUID, setup, setup.srcDir, in, ex);
 	}
+
+	createWorkspace(setup);
 
 	// Create other misc. build files
 	createOtherBuildFiles(setup);

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1554,26 +1554,26 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/backends", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/backends/platform/sdl", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("backend", addUUID("Backend"), setup, setup.srcDir + "/backends", in, ex);
+		createProjectFile("Backend", addUUID("Backend"), setup, setup.srcDir + "/backends", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/common", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/engines", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("common", addUUID("Common"), setup, setup.srcDir + "/common", in, ex);
+		createProjectFile("Common", addUUID("Common"), setup, setup.srcDir + "/common", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/graphics", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/image", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("graphics", addUUID("Graphics"), setup, setup.srcDir + "/graphics", in, ex);
+		createProjectFile("Graphics", addUUID("Graphics"), setup, setup.srcDir + "/graphics", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/audio", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/audio/softsynth/mt32", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("audio", addUUID("Audio"), setup, setup.srcDir + "/audio", in, ex);
+		createProjectFile("Audio", addUUID("Audio"), setup, setup.srcDir + "/audio", in, ex);
 
 		in.clear(); ex.clear();
 		createModuleList(setup.srcDir + "/gui", setup.defines, setup.testDirs, in, ex);
-		createProjectFile("gui", addUUID("Gui"), setup, setup.srcDir + "/gui", in, ex);
+		createProjectFile("Gui", addUUID("Gui"), setup, setup.srcDir + "/gui", in, ex);
 
 		// Last but not least create the main project file.
 		in.clear(); ex.clear();

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -468,7 +468,8 @@ protected:
 	StringList &_globalWarnings;                             ///< Global warnings
 	std::map<std::string, StringList> &_projectWarnings;     ///< Per-project warnings
 
-	UUIDMap _uuidMap;                                        ///< List of (project name, UUID) pairs
+	UUIDMap _commonProjects;                                        ///< List of (project name, UUID) pairs
+	UUIDMap _engineProjects;                                        ///< List of (project name, UUID) pairs
 
 	/**
 	 *  Create workspace/solution file

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -260,7 +260,7 @@ void MSBuildProvider::writeReferences(const BuildSetup& setup, std::ofstream& ou
 	output << "\t</ItemGroup>\n";
 }
 
-void MSBuildProvider::writeReference(std::ofstream& output, std::string name, std::string uuid)
+void MSBuildProvider::writeReference(std::ofstream& output, const std::string& name, const std::string& uuid)
 {
 	output << "\t<ProjectReference Include=\"" << name << ".vcxproj\">\n"
 		"\t\t<Project>{" << uuid << "}</Project>\n"

--- a/devtools/create_project/msbuild.h
+++ b/devtools/create_project/msbuild.h
@@ -42,7 +42,7 @@ protected:
 
 	void writeReferences(const BuildSetup& setup, std::ofstream& output, UUIDMap& projects);
 
-	void writeReference(std::ofstream& output, std::string name, std::string uuid);
+	void writeReference(std::ofstream& output, const std::string& name, const std::string& uuid);
 
 	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, int bits, const StringList &defines, const std::string &prefix, bool runBuildEvents);
 

--- a/devtools/create_project/msbuild.h
+++ b/devtools/create_project/msbuild.h
@@ -40,7 +40,9 @@ protected:
 	void writeFileListToProject(const FileNode &dir, std::ofstream &projectFile, const int indentation,
 	                            const StringList &duplicate, const std::string &objPrefix, const std::string &filePrefix);
 
-	void writeReferences(const BuildSetup &setup, std::ofstream &output);
+	void writeReferences(const BuildSetup& setup, std::ofstream& output, UUIDMap& projects);
+
+	void writeReference(std::ofstream& output, std::string name, std::string uuid);
 
 	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, int bits, const StringList &defines, const std::string &prefix, bool runBuildEvents);
 

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -39,6 +39,10 @@ protected:
 
 	void createWorkspace(const BuildSetup &setup);
 
+	void writeSolutionConfigurationEntry(std::ofstream& solution, const std::string& projectUUID);
+
+	void writeProjectEntry(std::ofstream& solution, const std::string& solutionUUID, const std::string& projectName, const std::string& projectUUID);
+
 	void createOtherBuildFiles(const BuildSetup &setup);
 
 	void addResourceFiles(const BuildSetup &setup, StringList &includeList, StringList &excludeList);

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -183,7 +183,7 @@ void VisualStudioProvider::outputBuildEvents(std::ostream &project, const BuildS
 void VisualStudioProvider::writeReferences(const BuildSetup &setup, std::ofstream &output) {
 	output << "\tProjectSection(ProjectDependencies) = postProject\n";
 
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _engineProjects.begin(); i != _engineProjects.end(); ++i) {
 		if (i->first == setup.projectName)
 			continue;
 


### PR DESCRIPTION
This moves code files out from the main scummvm project and into new projects.

Specifically, it uses these new projects:
* Audio
* Graphics
* Video
* Common
* Backend
* Gui