### PR TITLE
AMIGAOS4: Fix NULL pointer access on using plugins

### DIFF
--- a/backends/fs/amigaos4/amigaos4-fs.cpp
+++ b/backends/fs/amigaos4/amigaos4-fs.cpp
@@ -69,12 +69,12 @@ AmigaOSFilesystemNode::AmigaOSFilesystemNode() {
 AmigaOSFilesystemNode::AmigaOSFilesystemNode(const Common::String &p) {
 	ENTER();
 
-	// We need to explicitely open dos.library and it's IDOS interface.
-	// Otherwise we will hit an IDOS NULL pointer after compiling a shared
-	// binary with (shared) plugins.
+	// We need to explicitly open dos.library and its IDOS interface.
+	// Otherwise we will hit an IDOS NULL pointer after compiling a
+	// shared binary with (shared) plugins.
 	// The hit will happen on loading a game from any engine, if more
-	// than one engine/plugin is available.
-	DOSBase=IExec->OpenLibrary("dos.library",0);
+	// than one engine/(shared) plugin is available.
+	DOSBase = IExec->OpenLibrary("dos.library", 0);
 	IDOS = (struct DOSIFace *)IExec->GetInterface(DOSBase, "main", 1, NULL);
 	
 	int offset = p.size();
@@ -113,7 +113,7 @@ AmigaOSFilesystemNode::AmigaOSFilesystemNode(const Common::String &p) {
 		IDOS->FreeDosObject(DOS_EXAMINEDATA, pExd);
 	}
 
-	// Close dos.library and it's IDOS interface again.
+	// Close dos.library and its IDOS interface again.
 	IExec->DropInterface((struct Interface *)IDOS);
 	IExec->CloseLibrary(DOSBase);
 

--- a/backends/fs/amigaos4/amigaos4-fs.cpp
+++ b/backends/fs/amigaos4/amigaos4-fs.cpp
@@ -69,6 +69,10 @@ AmigaOSFilesystemNode::AmigaOSFilesystemNode() {
 AmigaOSFilesystemNode::AmigaOSFilesystemNode(const Common::String &p) {
 	ENTER();
 
+	// WORKAROUND:
+	// This is a bug in AmigaOS4 newlib.library 53.30 and lower.
+	// It will be removed once a fixed version is available to public.
+	// DESCRIPTION:
 	// We need to explicitly open dos.library and its IDOS interface.
 	// Otherwise we will hit an IDOS NULL pointer after compiling a
 	// shared binary with (shared) plugins.
@@ -113,6 +117,7 @@ AmigaOSFilesystemNode::AmigaOSFilesystemNode(const Common::String &p) {
 		IDOS->FreeDosObject(DOS_EXAMINEDATA, pExd);
 	}
 
+	// WORKAROUND:
 	// Close dos.library and its IDOS interface again.
 	IExec->DropInterface((struct Interface *)IDOS);
 	IExec->CloseLibrary(DOSBase);

--- a/backends/fs/amigaos4/amigaos4-fs.cpp
+++ b/backends/fs/amigaos4/amigaos4-fs.cpp
@@ -70,7 +70,7 @@ AmigaOSFilesystemNode::AmigaOSFilesystemNode(const Common::String &p) {
 	ENTER();
 
 	// We need to explicitely open dos.library and it's IDOS interface.
-	// Otherwise we'll hit an IDOS NULL pointer after compiling a shared
+	// Otherwise we will hit an IDOS NULL pointer after compiling a shared
 	// binary with (shared) plugins.
 	// The hit will happen on loading a game from any engine, if more
 	// than one engine/plugin is available.


### PR DESCRIPTION
We need to explicitely open dos.library and it's IDOS interface.
Otherwise we will hit an IDOS NULL pointer after compiling a shared binary with (shared) plugins.
The hit will happen on loading a game from any engine, if more than one engine/plugin is available.