### PR TITLE
TTS: Enable in Mingw-w64 builds

### DIFF
--- a/backends/text-to-speech/windows/sphelper-scummvm.h
+++ b/backends/text-to-speech/windows/sphelper-scummvm.h
@@ -15,6 +15,7 @@
 //       crtdbg.h
 //       SPDebug.h
 //       atlbase.h
+//       sapiddk.h
 //
 // 3. Include got added
 //       cwtype
@@ -43,10 +44,6 @@
 
 #ifndef __sapi_h__
 #include <sapi.h>
-#endif
-
-#ifndef __sapiddk_h__
-#include <sapiddk.h>
 #endif
 
 #ifndef SPError_h

--- a/backends/text-to-speech/windows/windows-text-to-speech.cpp
+++ b/backends/text-to-speech/windows/windows-text-to-speech.cpp
@@ -29,6 +29,17 @@
 #include <basetyps.h>
 #include <windows.h>
 #include <Servprov.h>
+
+// Mingw-w64 is missing symbols for two guids declared in sapi.h which are used
+//  by sphelper-scummvm.h. Mingw32 doesn't include any sapi headers or libraries
+//  so the only way to currently build there is to manually use Microsoft's, in
+//  which case the guids will be defined by their library.
+#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#include <initguid.h>
+DEFINE_GUID(SPDFID_Text, 0x7ceef9f9, 0x3d13, 0x11d2, 0x9e, 0xe7, 0x00, 0xc0, 0x4f, 0x79, 0x73, 0x96);
+DEFINE_GUID(SPDFID_WaveFormatEx, 0xc31adbae, 0x527f, 0x4ff5, 0xa2, 0x30, 0xf6, 0x2b, 0xb6, 0x1f, 0xf7, 0x0c);
+#endif
+
 #include <sapi.h>
 #include "backends/text-to-speech/windows/sphelper-scummvm.h"
 #include "backends/platform/sdl/win32/win32_wrapper.h"

--- a/configure
+++ b/configure
@@ -4239,6 +4239,15 @@ echocheck "TTS libraries"
 if test "$_tts" = auto ; then
 	_tts=no
 	case $_host_os in
+		mingw*)
+			cat > $TMPC << EOF
+#include <windows.h>
+#include <Servprov.h>
+#include <sapi.h>
+int main(void) { return 0; }
+EOF
+			cc_check -lsapi -lole32 && _tts=yes
+			;;
 		linux*)
 			cat > $TMPC << EOF
 #include <speech-dispatcher/libspeechd.h>


### PR DESCRIPTION
This PR gets Text To Speech working in default Mingw-w64 environments.

- Removes reference to sapiddk.h which isn't used and isn't in Mingw-w64
- Defines guids whose symbols are missing from Mingw-w64
- Restores TTS detection to configure script

With these changes, TTS works out of the box in Mingw-w64 environments. Mingw32 doesn't include speech api headers or libraries and so configure still correctly detects that TTS is unavailable there.