### PR TITLE
HDB: Clean up music playback code

### DIFF
--- a/engines/hdb/sound.cpp
+++ b/engines/hdb/sound.cpp
@@ -1857,11 +1857,15 @@ Audio::AudioStream* Song::createStream(Common::String fileName) {
 #ifdef USE_MAD
 		Audio::SeekableAudioStream* audioStream = Audio::makeMP3Stream(stream, DisposeAfterUse::YES);
 		return new Audio::LoopingAudioStream(audioStream, 0, DisposeAfterUse::YES);
+#else
+		return nullptr;
 #endif
 	} else {
 #ifdef USE_VORBIS
 		Audio::SeekableAudioStream* audioStream = Audio::makeVorbisStream(stream, DisposeAfterUse::YES);
 		return new Audio::LoopingAudioStream(audioStream, 0, DisposeAfterUse::YES);
+#else
+		return nullptr;
 #endif
 	}
 }

--- a/engines/hdb/sound.cpp
+++ b/engines/hdb/sound.cpp
@@ -1789,11 +1789,14 @@ void Song::stop() {
 }
 
 void Song::playSong(SoundType song, bool fadeIn, int ramp) {
-	this->_song = song;
-	this->_playing = true;
 
 	Common::String fileName = getFileName(song);
 	Audio::AudioStream* musicStream = createStream(fileName);
+
+	if (musicStream == nullptr) return;
+
+	this->_song = song;
+	this->_playing = true;
 
 	int initialVolume;
 

--- a/engines/hdb/sound.h
+++ b/engines/hdb/sound.h
@@ -1474,8 +1474,8 @@ struct Song {
 	void update();
 
 private:
-	static Common::String Song::getFileName(SoundType song);
-	Audio::AudioStream* Song::createStream(Common::String fileName);
+	static Common::String getFileName(SoundType song);
+	Audio::AudioStream* createStream(Common::String fileName);
 
 	Audio::SoundHandle handle;
 

--- a/engines/hdb/sound.h
+++ b/engines/hdb/sound.h
@@ -1456,8 +1456,8 @@ struct SoundCache {
 	SoundCache() : loaded(SNDMEM_NOTCACHED), size(0), name(nullptr), luaName(nullptr), ext(SNDTYPE_NONE), data(nullptr) {}
 };
 
-struct Song {
-
+class Song {
+public:
 	Song() : _playing(false), _song(SONG_NONE),
 		fadingOut(false), fadeOutVol(0), fadeOutRamp(0),
 		fadingIn(false), fadeInVol(0), fadeInRamp(0) {}

--- a/engines/hdb/sound.h
+++ b/engines/hdb/sound.h
@@ -1457,9 +1457,30 @@ struct SoundCache {
 };
 
 struct Song {
-	bool playing;
-	SoundType song;
+
+	Song() : _playing(false), _song(SONG_NONE),
+		fadingOut(false), fadeOutVol(0), fadeOutRamp(0),
+		fadingIn(false), fadeInVol(0), fadeInRamp(0) {}
+
+	void playSong(SoundType song, bool fadeIn, int ramp);
+	void fadeOut(int ramp);
+	void stop();
+
+	bool isPlaying() const;
+	SoundType getSong() const;
+
+	void setVolume(int volume);
+
+	void update();
+
+private:
+	static Common::String Song::getFileName(SoundType song);
+	Audio::AudioStream* Song::createStream(Common::String fileName);
+
 	Audio::SoundHandle handle;
+
+	bool _playing;
+	SoundType _song;
 
 	bool fadingOut;
 	int fadeOutVol;
@@ -1468,10 +1489,6 @@ struct Song {
 	bool fadingIn;
 	int	fadeInVol;
 	int	fadeInRamp;
-
-	Song() : playing(false), song(SONG_NONE),
-		fadingOut(false), fadeOutVol(0), fadeOutRamp(0),
-		fadingIn(false), fadeInVol(0), fadeInRamp(0) {}
 };
 
 class Sound {


### PR DESCRIPTION
This moves a bunch of music playback code into the Song class, which makes it easy to DRY out all the repeated code.

Specifically, the code now works with "this" Song and not "song1" or "song2". Additionally, the decoder setup code is factored out to a separate member function, eliminating some quadruple code duplicates.

As a quick bonus, I fixed [bug #11194](https://bugs.scummvm.org/ticket/11194).