### PR TITLE
MOHAWK: RIVEN: Modify cursor preloading to resolve crashing on 3DS

### DIFF
--- a/engines/mohawk/cursors.cpp
+++ b/engines/mohawk/cursors.cpp
@@ -242,18 +242,20 @@ void LivingBooksCursorManager_v2::setCursor(const Common::String &name) {
 }
 
 PECursorManager::PECursorManager(const Common::String &appName) {
-	Common::PEResources exe;
-	if (!exe.loadFromEXE(appName)) {
+	_exe = new Common::PEResources();
+	if (!_exe->loadFromEXE(appName)) {
 		// Not all have cursors anyway, so this is not a problem
 		return;
 	}
 
-	const Common::Array<Common::WinResourceID> cursorGroups = exe.getNameList(Common::kWinGroupCursor);
+	if(_exe) {
+		const Common::Array<Common::WinResourceID> cursorGroups = _exe->getNameList(Common::kWinGroupCursor);
 
-	_cursors.resize(cursorGroups.size());
-	for (uint i = 0; i < cursorGroups.size(); i++) {
-		_cursors[i].id = cursorGroups[i].getID();
-		_cursors[i].cursorGroup = Graphics::WinCursorGroup::createCursorGroup(exe, cursorGroups[i]);
+		_cursors.resize(cursorGroups.size());
+		for (uint i = 0; i < cursorGroups.size(); i++) {
+			_cursors[i].id = cursorGroups[i].getID();
+			_cursors[i].cursorGroup = Graphics::WinCursorGroup::createCursorGroup(*_exe, cursorGroups[i]);
+		}
 	}
 }
 

--- a/engines/mohawk/cursors.cpp
+++ b/engines/mohawk/cursors.cpp
@@ -242,21 +242,21 @@ void LivingBooksCursorManager_v2::setCursor(const Common::String &name) {
 }
 
 PECursorManager::PECursorManager(const Common::String &appName) {
-	_exe = new Common::PEResources();
-	if (!_exe->loadFromEXE(appName)) {
+	Common::PEResources *exe = new Common::PEResources();
+	if (!exe->loadFromEXE(appName)) {
 		// Not all have cursors anyway, so this is not a problem
 		return;
 	}
 
-	if(_exe) {
-		const Common::Array<Common::WinResourceID> cursorGroups = _exe->getNameList(Common::kWinGroupCursor);
+	const Common::Array<Common::WinResourceID> cursorGroups = exe->getNameList(Common::kWinGroupCursor);
 
-		_cursors.resize(cursorGroups.size());
-		for (uint i = 0; i < cursorGroups.size(); i++) {
-			_cursors[i].id = cursorGroups[i].getID();
-			_cursors[i].cursorGroup = Graphics::WinCursorGroup::createCursorGroup(*_exe, cursorGroups[i]);
-		}
+	_cursors.resize(cursorGroups.size());
+	for (uint i = 0; i < cursorGroups.size(); i++) {
+		_cursors[i].id = cursorGroups[i].getID();
+		_cursors[i].cursorGroup = Graphics::WinCursorGroup::createCursorGroup(*exe, cursorGroups[i]);
 	}
+
+	delete exe;
 }
 
 PECursorManager::~PECursorManager() {

--- a/engines/mohawk/cursors.h
+++ b/engines/mohawk/cursors.h
@@ -28,6 +28,7 @@
 namespace Common {
 class MacResManager;
 class NEResources;
+class PEResources;
 class SeekableReadStream;
 class String;
 }
@@ -182,6 +183,7 @@ private:
 	};
 
 	Common::Array<CursorItem> _cursors;
+	Common::PEResources *_exe;
 };
 
 } // End of namespace Mohawk

--- a/engines/mohawk/cursors.h
+++ b/engines/mohawk/cursors.h
@@ -28,7 +28,6 @@
 namespace Common {
 class MacResManager;
 class NEResources;
-class PEResources;
 class SeekableReadStream;
 class String;
 }
@@ -183,7 +182,6 @@ private:
 	};
 
 	Common::Array<CursorItem> _cursors;
-	Common::PEResources *_exe;
 };
 
 } // End of namespace Mohawk


### PR DESCRIPTION
On 3DS builds of ScummVM, attempting to start Riven results in an instant crash due to the way cursor preloading is coded. This commit resolves that issue.