### PR TITLE
AMIGAOS4: Further update amigaos.mk and fix shared plugins workaround

### DIFF
--- a/backends/fs/amigaos4/amigaos4-fs.cpp
+++ b/backends/fs/amigaos4/amigaos4-fs.cpp
@@ -69,6 +69,15 @@ AmigaOSFilesystemNode::AmigaOSFilesystemNode() {
 AmigaOSFilesystemNode::AmigaOSFilesystemNode(const Common::String &p) {
 	ENTER();
 
+	int offset = p.size();
+
+	//assert(offset > 0);
+
+	if (offset <= 0) {
+		debug(6, "Bad offset");
+		return;
+	}
+
 	// WORKAROUND:
 	// This is a bug in AmigaOS4 newlib.library 53.30 and lower.
 	// It will be removed once a fixed version is available to public.
@@ -80,15 +89,6 @@ AmigaOSFilesystemNode::AmigaOSFilesystemNode(const Common::String &p) {
 	// than one engine/(shared) plugin is available.
 	DOSBase = IExec->OpenLibrary("dos.library", 0);
 	IDOS = (struct DOSIFace *)IExec->GetInterface(DOSBase, "main", 1, NULL);
-	
-	int offset = p.size();
-
-	//assert(offset > 0);
-
-	if (offset <= 0) {
-		debug(6, "Bad offset");
-		return;
-	}
 
 	_sPath = p;
 	_sDisplayName = ::lastPathComponent(_sPath);

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -1,13 +1,12 @@
 # Special target to create an AmigaOS snapshot installation.
+# AmigaOS shell doesn't like indented comments.
 amigaosdist: $(EXECUTABLE)
 	mkdir -p $(AMIGAOSPATH)
-	mkdir -p $(AMIGAOSPATH)/themes
 	mkdir -p $(AMIGAOSPATH)/extras
-	$(STRIP) $(EXECUTABLE) -o $(AMIGAOSPATH)/$(EXECUTABLE)
-	cp ${srcdir}/icons/scummvm_drawer.info $(AMIGAOSPATH).info
-	cp ${srcdir}/icons/scummvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info
-	cp $(DIST_FILES_THEMES) $(AMIGAOSPATH)/themes/
+	cp ${srcdir}/dists/amiga/scummvm_drawer.info $(AMIGAOSPATH).info
+	cp ${srcdir}/dists/amiga/scummvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info
 ifdef DIST_FILES_DOCS
+	cp -r $(srcdir)/doc/ $(AMIGAOSPATH)
 	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)/doc/
 endif
 ifdef DIST_FILES_ENGINEDATA
@@ -19,12 +18,21 @@ endif
 ifdef DIST_FILES_VKEYBD
 	cp $(DIST_FILES_VKEYBD) $(AMIGAOSPATH)/extras/
 endif
-# AmigaOS shell is not happy with indented comments, thus don't do it.
+# Copy shared library plugins, if available.
+ifdef DYNAMIC_MODULES
+	mkdir -p $(AMIGAOSPATH)/plugins
+	cp $(PLUGINS) -o $(AMIGAOSPATH)/plugins/
+endif
+ifdef DIST_FILES_THEMES
+	mkdir -p $(AMIGAOSPATH)/themes
+	cp $(DIST_FILES_THEMES) $(AMIGAOSPATH)/themes/
+endif
+	$(STRIP) $(EXECUTABLE) -o $(AMIGAOSPATH)/$(EXECUTABLE)
 # Prepare README.md for AmigaGuide conversion.
 	cat ${srcdir}/README.md | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
-# AREXX seems to have a problem if ${srcdir} is '.'. It will break with
-# a "Program not found" error. Therefore we copy the script to cwd and
-# remove it again, once it has finished.
+# AmigaOS AREXX has a problem when ${srcdir} is '.'.
+# It will break with a "Program not found" error.
+# We copy the script to cwd first and, once it has finished, remove it again.
 	cp ${srcdir}/dists/amiga/RM2AG.rexx .
 	rx RM2AG.rexx README.conv
 	cp README.guide $(AMIGAOSPATH)


### PR DESCRIPTION
I have a request to make, since i can't do it on my own.

Would someone please be so nice and move
scummvm_drawer.info
scummvm.info
from icons/
to
dists/amiga

Otherwise the amigaos.mk changes will break due to the wrong path.

Thank you very much

Reason is, that everyone with it's own platform (except windows if i see that right?) dists has their icons in their own subdir and i think it looks much more cleaner that way too. (Also amiga has it´s dists subdir aswell)