### PR TITLE
TOON: Add subtitles support for cutscenes

### DIFF
--- a/devtools/create_toon/subtitles/pakdir.py
+++ b/devtools/create_toon/subtitles/pakdir.py
@@ -33,7 +33,7 @@ def generate_index(data_files):
         off += len(fdata)
 
 def create_entry(filename):
-    name, ext = os.path.splitext(os.path.basename(filename))
+    name, _ = os.path.splitext(os.path.basename(filename))
     return name + '.tss', ''.join(sbv2tss(filename)).encode()
 
 if __name__ == "__main__":

--- a/devtools/create_toon/subtitles/pakdir.py
+++ b/devtools/create_toon/subtitles/pakdir.py
@@ -34,7 +34,6 @@ def generate_index(data_files):
 
 def create_entry(filename):
     name, ext = os.path.splitext(os.path.basename(filename))
-    assert ext.lower() == '.sbv', ext.lower()
     return name + '.tss', ''.join(sbv2tss(filename)).encode()
 
 if __name__ == "__main__":

--- a/devtools/create_toon/subtitles/pakdir.py
+++ b/devtools/create_toon/subtitles/pakdir.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+"""
+This script generates subtitles for Toonstrack cutscenes
+in a single SUBTITLES.PAK file from given directory of .SBV subtitles
+
+Usage:
+```
+pakdir.py SUBTITLES_DIR
+````
+"""
+
+import struct
+from itertools import chain
+
+from submaker import sbv2tss
+
+def write_uint32_le(number):
+    return struct.pack('<I', number)
+
+def calculate_index_length(pak_index):
+    return sum(len(write_index_entry(fname, 0)) for fname in pak_index)
+
+def write_index_entry(fname, offset):
+    return write_uint32_le(offset) + fname.encode() + b'\00'
+
+def generate_index(data_files):
+    end = ('\00\00\00\00', b'')
+    pak_index, rdata = zip(*chain(data_files, (end,)))
+    off = calculate_index_length(pak_index)
+    for fname, fdata in zip(pak_index, rdata):
+        yield write_index_entry(fname, off), fdata
+        off += len(fdata)
+
+def create_entry(filename):
+    name, ext = os.path.splitext(os.path.basename(filename))
+    assert ext.lower() == '.sbv', ext.lower()
+    return name + '.tss', ''.join(sbv2tss(filename)).encode()
+
+if __name__ == "__main__":
+    import os
+    import glob
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: pakdir.py SUBTITLES_DIR")
+        exit(1)
+
+    paths = sys.argv[1:]
+    paths = (os.path.join(path, '*.sbv') for path in paths)
+    files = sorted(set(chain.from_iterable(glob.iglob(r) for r in paths)))
+    print(files)
+    index, data = zip(*generate_index(create_entry(filename) for filename in files))
+    with open('SUBTITLES.PAK', 'wb') as output:
+        output.write(b''.join(index))
+        output.write(b''.join(data))

--- a/devtools/create_toon/subtitles/submaker.py
+++ b/devtools/create_toon/subtitles/submaker.py
@@ -12,7 +12,6 @@ submaker.py INFILE.sbv OUTFILE.tss
 Subtitles format:
 <start frame> <end frame> <subtitle text>
 '''
-import io
 import sys
 
 from datetime import datetime

--- a/devtools/create_toon/subtitles/submaker.py
+++ b/devtools/create_toon/subtitles/submaker.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+'''
+This script generates subtitles for Toonstrack cutscenes
+from .SBV subtitiles.
+
+Usage:
+```
+submaker.py INFILE.sbv OUTFILE.tss
+````
+
+Subtitles format:
+<start frame> <end frame> <subtitle text>
+'''
+import io
+import sys
+
+from datetime import datetime
+
+TIME_FORMAT = '%H:%M:%S.%f'
+BASETIME = datetime(1900, 1, 1)
+FPS = 15
+
+def time2frame(time, fps=FPS):
+    return round(fps * (datetime.strptime('0' + time + '000', TIME_FORMAT) - BASETIME).total_seconds())
+
+def sbv2tss(infile, fps=FPS):
+    with open(infile, 'r') as sub_file:
+        lines = sub_file.read().split('\n\n')
+
+    # ignore empty lines
+    lines = [line for line in lines if line]
+
+    for line in lines:
+        time_window, text = line.split('\n')[:2]
+        start, end = time_window.split(',')
+        start = time2frame(start, fps=fps)
+        end = time2frame(end[:-1], fps=fps)
+
+        yield '{start} {end} {line}\n'.format(start=start, end=end, line=text)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print('Usage: toon_submaker.py INFILE.sbv OUTFILE.tss')
+        exit(1)
+
+    infile = sys.argv[1]
+    outfile = sys.argv[2]
+
+    with open(outfile, 'w') as sub_file:
+        for line in sbv2tss(infile):
+            sub_file.write(line)

--- a/engines/toon/font.cpp
+++ b/engines/toon/font.cpp
@@ -191,7 +191,7 @@ void FontRenderer::setFontColor(int32 fontColor1, int32 fontColor2, int32 fontCo
 	_currentFontColor[3] = fontColor3;
 }
 
-void FontRenderer::renderMultiLineText(int16 x, int16 y, const Common::String &origText, int32 mode, Graphics::Surface& frame) {
+void FontRenderer::renderMultiLineText(int16 x, int16 y, const Common::String &origText, int32 mode, Graphics::Surface &frame) {
 	debugC(5, kDebugFont, "renderMultiLineText(%d, %d, %s, %d)", x, y, origText.c_str(), mode);
 
 	// divide the text in several lines

--- a/engines/toon/font.cpp
+++ b/engines/toon/font.cpp
@@ -191,7 +191,7 @@ void FontRenderer::setFontColor(int32 fontColor1, int32 fontColor2, int32 fontCo
 	_currentFontColor[3] = fontColor3;
 }
 
-void FontRenderer::renderMultiLineText(int16 x, int16 y, const Common::String &origText, int32 mode) {
+void FontRenderer::renderMultiLineText(int16 x, int16 y, const Common::String &origText, int32 mode, Graphics::Surface& frame) {
 	debugC(5, kDebugFont, "renderMultiLineText(%d, %d, %s, %d)", x, y, origText.c_str(), mode);
 
 	// divide the text in several lines
@@ -289,7 +289,7 @@ void FontRenderer::renderMultiLineText(int16 x, int16 y, const Common::String &o
 
 		while (*line) {
 			byte curChar = textToFont(*line);
-			if (curChar != 32) _currentFont->drawFontFrame(_vm->getMainSurface(), curChar, curX + _vm->state()->_currentScrollValue, curY, _currentFontColor);
+			if (curChar != 32) _currentFont->drawFontFrame(frame, curChar, curX + _vm->state()->_currentScrollValue, curY, _currentFontColor);
 			curX = curX + MAX<int32>(_currentFont->getFrameWidth(curChar) - 2, 0);
 			//height = MAX(height, _currentFont->getFrameHeight(curChar));
 			line++;

--- a/engines/toon/font.h
+++ b/engines/toon/font.h
@@ -35,7 +35,7 @@ public:
 	void setFont(Animation *font);
 	void computeSize(const Common::String &origText, int16 *retX, int16 *retY);
 	void renderText(int16 x, int16 y, const Common::String &origText, int32 mode);
-	void renderMultiLineText(int16 x, int16 y, const Common::String &origText, int32 mode, Graphics::Surface& frame);
+	void renderMultiLineText(int16 x, int16 y, const Common::String &origText, int32 mode, Graphics::Surface &frame);
 	void setFontColorByCharacter(int32 characterId);
 	void setFontColor(int32 fontColor1, int32 fontColor2, int32 fontColor3);
 protected:

--- a/engines/toon/module.mk
+++ b/engines/toon/module.mk
@@ -20,7 +20,8 @@ MODULE_OBJS := \
 	state.o \
 	text.o \
 	tools.o \
-	toon.o
+	toon.o \
+	subtitles.o
 
 # This module can be built as a plugin
 ifeq ($(ENABLE_TOON), DYNAMIC_PLUGIN)

--- a/engines/toon/module.mk
+++ b/engines/toon/module.mk
@@ -18,10 +18,10 @@ MODULE_OBJS := \
 	script.o \
 	script_func.o \
 	state.o \
+	subtitles.o \
 	text.o \
 	tools.o \
-	toon.o \
-	subtitles.o
+	toon.o
 
 # This module can be built as a plugin
 ifeq ($(ENABLE_TOON), DYNAMIC_PLUGIN)

--- a/engines/toon/movie.cpp
+++ b/engines/toon/movie.cpp
@@ -124,7 +124,7 @@ void Movie::playVideo(bool isFirstIntroVideo) {
 					int len = frame->w * frame->h;
 					byte pixels[310000] = {0};
 					memcpy(pixels, frame->getPixels(), len);
-					for (byte i = 1; i < 256; i++) 
+					for (int i = 1; i < 256; i++) 
 					{
 						int j;
 						for (j = 0; j < len; j++) {

--- a/engines/toon/movie.cpp
+++ b/engines/toon/movie.cpp
@@ -122,17 +122,17 @@ void Movie::playVideo(bool isFirstIntroVideo) {
 					int32 currentFrame = _decoder->getCurFrame();
 
 					// find unused color key to replace with subtitles color
-					int len = frame->w * frame->h;
-					const byte* pixels = (const byte *)frame->getPixels();
-					byte counts[256];
-					memset(counts, 0, sizeof(counts));
-					for (int i = 0; i < len; i++) {
-						counts[pixels[i]] = 1;
+					uint len = frame->w * frame->h;
+					const byte *pixels = (const byte *)frame->getPixels();
+					bool counts[256];
+					memset(counts, false, sizeof(counts));
+					for (uint i = 0; i < len; i++) {
+						counts[pixels[i]] = true;
 					}
 
 					// 0 is already used for the border color and should not be used here, so it can be skipped over.
 					for (int j = 1; j < 256; j++) {
-						if (counts[j] == 0) {
+						if (!counts[j]) {
 							unused = j;
 							break;
 						}

--- a/engines/toon/movie.h
+++ b/engines/toon/movie.h
@@ -28,6 +28,8 @@
 
 namespace Toon {
 
+class SubtitleRenderer;
+
 class ToonstruckSmackerDecoder : public Video::SmackerDecoder {
 public:
 	ToonstruckSmackerDecoder();
@@ -57,6 +59,7 @@ protected:
 	ToonEngine *_vm;
 	ToonstruckSmackerDecoder *_decoder;
 	bool _playing;
+	SubtitleRenderer *_subtitle;
 };
 
 } // End of namespace Toon

--- a/engines/toon/subtitles.cpp
+++ b/engines/toon/subtitles.cpp
@@ -72,8 +72,7 @@ bool SubtitleRenderer::load(const Common::String &video) {
 	Common::String ext("tss");
 	subfile.replace(subfile.size() - ext.size(), ext.size(), ext);
 
-	Common::SeekableReadStream *file;
-	file = _vm->resources()->openFile(subfile);
+	Common::SeekableReadStream *file = _vm->resources()->openFile(subfile);
 	if (!file) {
 		return false;
 	}

--- a/engines/toon/subtitles.cpp
+++ b/engines/toon/subtitles.cpp
@@ -72,6 +72,7 @@ bool SubtitleRenderer::load(const Common::String &video) {
 
     char srtfile[20] = {0};
     strcpy(srtfile, video.c_str());
+    srtfile[19] = '\0';
     int ln = strlen(srtfile);
     srtfile[ln - 3] = 't';
     srtfile[ln - 2] = 's';

--- a/engines/toon/subtitles.cpp
+++ b/engines/toon/subtitles.cpp
@@ -53,7 +53,7 @@ void SubtitleRenderer::render(const Graphics::Surface &frame, uint32 frameNumber
 		if (_index > _last) {
 			return;
 		}
-		_currentLine = (char*)_fileData + _tw[_index].foffset;
+		_currentLine = (char *)_fileData + _tw[_index].foffset;
 	}
 
 	if (frameNumber < _tw[_index].fstart) {

--- a/engines/toon/subtitles.cpp
+++ b/engines/toon/subtitles.cpp
@@ -65,7 +65,7 @@ void SubtitleRenderer::render(const Graphics::Surface &frame, uint32 frameNumber
 }
 
 bool SubtitleRenderer::load(const Common::String &video) {
-	warning(video.c_str());
+	// warning(video.c_str());
 
 	_hasSubtitles = false;
 	_index = 0;

--- a/engines/toon/subtitles.cpp
+++ b/engines/toon/subtitles.cpp
@@ -28,71 +28,67 @@
 
 namespace Toon {
 SubtitleRenderer::SubtitleRenderer(ToonEngine *vm) : _vm(vm) {
-    _subSurface = new Graphics::Surface();
+	_subSurface = new Graphics::Surface();
 	_subSurface->create(TOON_SCREEN_WIDTH, TOON_SCREEN_HEIGHT, Graphics::PixelFormat::createFormatCLUT8());
-    _hasSubtitles = false;
+	_hasSubtitles = false;
 }
 
 SubtitleRenderer::~SubtitleRenderer() {
 }
 
 
-void SubtitleRenderer::render(const Graphics::Surface& frame, uint32 frameNumber, char color) {
-    if (!_hasSubtitles || _index > _last) {
-        return;
-    }
+void SubtitleRenderer::render(const Graphics::Surface &frame, uint32 frameNumber, byte color) {
+	if (!_hasSubtitles || _index > _last) {
+		return;
+	}
 
-    _subSurface->copyFrom(frame);
-    // char strf[384] = {0};
-    // sprintf(strf, "Time passed: %d", frameNumber);
-    // _vm->drawCostumeLine(0, 0, strf, _subSurface);
-    // _vm->_system->copyRectToScreen(_subSurface->getBasePtr(0, 0), _subSurface->pitch, 0, 0, _subSurface->w,  _subSurface->h);
+	_subSurface->copyFrom(frame);
+	// char strf[384] = {0};
+	// sprintf(strf, "Time passed: %d", frameNumber);
+	// _vm->drawCostumeLine(0, 0, strf, _subSurface);
+	// _vm->_system->copyRectToScreen(_subSurface->getBasePtr(0, 0), _subSurface->pitch, 0, 0, _subSurface->w,  _subSurface->h);
 
-    if (frameNumber > _tw[_index].fend) {
-        _index++;
-        if (_index > _last) {
-            return;
-        }
-        _currentLine = (char*)_fileData + _tw[_index].foffset;
-    }
+	if (frameNumber > _tw[_index].fend) {
+		_index++;
+		if (_index > _last) {
+			return;
+		}
+		_currentLine = (char*)_fileData + _tw[_index].foffset;
+	}
 
-    if (frameNumber < _tw[_index].fstart) {
-        return;
-    }
+	if (frameNumber < _tw[_index].fstart) {
+		return;
+	}
 
-    _vm->drawCustomText(TOON_SCREEN_WIDTH / 2, TOON_SCREEN_HEIGHT, _currentLine, _subSurface, color);
-    _vm->_system->copyRectToScreen(_subSurface->getBasePtr(0, 0), _subSurface->pitch, 0, 0, _subSurface->w,  _subSurface->h);
+	_vm->drawCustomText(TOON_SCREEN_WIDTH / 2, TOON_SCREEN_HEIGHT, _currentLine, _subSurface, color);
+	_vm->_system->copyRectToScreen(_subSurface->getBasePtr(0, 0), _subSurface->pitch, 0, 0, _subSurface->w,  _subSurface->h);
 }
 
 bool SubtitleRenderer::load(const Common::String &video) {
-    warning(video.c_str());
+	warning(video.c_str());
 
-    _hasSubtitles = false;
-    _index = 0;
+	_hasSubtitles = false;
+	_index = 0;
 
-    char srtfile[20] = {0};
-    strcpy(srtfile, video.c_str());
-    srtfile[19] = '\0';
-    int ln = strlen(srtfile);
-    srtfile[ln - 3] = 't';
-    srtfile[ln - 2] = 's';
-    srtfile[ln - 1] = 's';
+	Common::String subfile(video);
+	Common::String ext("tss");
+	subfile.replace(subfile.size() - ext.size(), ext.size(), ext);
 
-    uint32 fileSize = 0;
-	uint8 *fileData = _vm->resources()->getFileData(srtfile, &fileSize);
+	uint32 fileSize = 0;
+	uint8 *fileData = _vm->resources()->getFileData(subfile, &fileSize);
 	if (!fileData) {
-	 	return false;
-    }
+		return false;
+	}
 
-    uint32 numOflines = *((uint32*) fileData);
-    uint32 idx_size = numOflines * sizeof(TimeWindow);
-    memcpy(_tw, sizeof(numOflines) + fileData, idx_size);
-    _fileData = sizeof(numOflines) + fileData + idx_size;
-    _last = numOflines - 1;
+	uint32 numOflines = *((uint32 *) fileData);
+	uint32 idx_size = numOflines * sizeof(TimeWindow);
+	memcpy(_tw, sizeof(numOflines) + fileData, idx_size);
+	_fileData = sizeof(numOflines) + fileData + idx_size;
+	_last = numOflines - 1;
 
-    _currentLine = (char*)_fileData + _tw[0].foffset;
-    _hasSubtitles = true;
-    return _hasSubtitles;
+	_currentLine = (char *)_fileData + _tw[0].foffset;
+	_hasSubtitles = true;
+	return _hasSubtitles;
 }
 
 }

--- a/engines/toon/subtitles.cpp
+++ b/engines/toon/subtitles.cpp
@@ -1,0 +1,97 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/debug.h"
+#include "common/rect.h"
+#include "common/system.h"
+
+#include "toon/subtitles.h"
+
+namespace Toon {
+SubtitleRenderer::SubtitleRenderer(ToonEngine *vm) : _vm(vm) {
+    _subSurface = new Graphics::Surface();
+	_subSurface->create(TOON_SCREEN_WIDTH, TOON_SCREEN_HEIGHT, Graphics::PixelFormat::createFormatCLUT8());
+    _hasSubtitles = false;
+}
+
+SubtitleRenderer::~SubtitleRenderer() {
+}
+
+
+void SubtitleRenderer::render(const Graphics::Surface& frame, uint32 frameNumber, char color) {
+    if (!_hasSubtitles || _index > _last) {
+        return;
+    }
+
+    _subSurface->copyFrom(frame);
+    // char strf[384] = {0};
+    // sprintf(strf, "Time passed: %d", frameNumber);
+    // _vm->drawCostumeLine(0, 0, strf, _subSurface);
+    // _vm->_system->copyRectToScreen(_subSurface->getBasePtr(0, 0), _subSurface->pitch, 0, 0, _subSurface->w,  _subSurface->h);
+
+    if (frameNumber > _tw[_index].fend) {
+        _index++;
+        if (_index > _last) {
+            return;
+        }
+        _currentLine = (char*)_fileData + _tw[_index].foffset;
+    }
+
+    if (frameNumber < _tw[_index].fstart) {
+        return;
+    }
+
+    _vm->drawCustomText(TOON_SCREEN_WIDTH / 2, TOON_SCREEN_HEIGHT, _currentLine, _subSurface, color);
+    _vm->_system->copyRectToScreen(_subSurface->getBasePtr(0, 0), _subSurface->pitch, 0, 0, _subSurface->w,  _subSurface->h);
+}
+
+bool SubtitleRenderer::load(const Common::String &video) {
+    warning(video.c_str());
+
+    _hasSubtitles = false;
+    _index = 0;
+
+    char srtfile[20] = {0};
+    strcpy(srtfile, video.c_str());
+    int ln = strlen(srtfile);
+    srtfile[ln - 3] = 't';
+    srtfile[ln - 2] = 's';
+    srtfile[ln - 1] = 's';
+
+    uint32 fileSize = 0;
+	uint8 *fileData = _vm->resources()->getFileData(srtfile, &fileSize);
+	if (!fileData) {
+	 	return false;
+    }
+
+    uint32 numOflines = *((uint32*) fileData);
+    uint32 idx_size = numOflines * sizeof(TimeWindow);
+    memcpy(_tw, sizeof(numOflines) + fileData, idx_size);
+    _fileData = sizeof(numOflines) + fileData + idx_size;
+    _last = numOflines - 1;
+
+    _currentLine = (char*)_fileData + _tw[0].foffset;
+    _hasSubtitles = true;
+    return _hasSubtitles;
+}
+
+}

--- a/engines/toon/subtitles.h
+++ b/engines/toon/subtitles.h
@@ -28,11 +28,11 @@
 
 namespace Toon {
 
-typedef struct {
+struct TimeWindow {
 	uint32 fstart;
 	uint32 fend;
 	uint32 foffset;
-} TimeWindow;
+};
 
 class SubtitleRenderer {
 public:

--- a/engines/toon/subtitles.h
+++ b/engines/toon/subtitles.h
@@ -28,10 +28,16 @@
 
 namespace Toon {
 
-struct TimeWindow {
-	uint32 fstart;
-	uint32 fend;
-	uint32 foffset;
+class TimeWindow {
+public:
+	uint16 _startFrame;
+	uint16 _endFrame;
+	Common::String _text;
+	TimeWindow(int startFrame, int endFrame, const Common::String &text) {
+		_startFrame = startFrame;
+		_endFrame = endFrame;
+		_text = text;
+	}
 };
 
 class SubtitleRenderer {
@@ -45,12 +51,7 @@ protected:
 	ToonEngine *_vm;
 	Graphics::Surface *_subSurface;
 	bool _hasSubtitles;
-	char *_lines[384];
-	TimeWindow _tw[384];
-	uint8 *_fileData;
-	uint16 _index;
-	uint16 _last;
-	char *_currentLine;
+	Common::List<TimeWindow> _tw;
 };
 
 } // End of namespace Toon

--- a/engines/toon/subtitles.h
+++ b/engines/toon/subtitles.h
@@ -20,29 +20,38 @@
  *
  */
 
-#ifndef TOON_FONT_H
-#define TOON_FONT_H
+#ifndef TOON_SUBTITLES_H
+#define TOON_SUBTITLES_H
 
 #include "toon/toon.h"
+#include "graphics/surface.h"
 
 namespace Toon {
 
-class FontRenderer {
-public:
-	FontRenderer(ToonEngine *vm);
-	~FontRenderer();
+typedef struct {
+    uint32 fstart;
+    uint32 fend;
+    uint32 foffset;
+} TimeWindow;
 
-	void setFont(Animation *font);
-	void computeSize(const Common::String &origText, int16 *retX, int16 *retY);
-	void renderText(int16 x, int16 y, const Common::String &origText, int32 mode);
-	void renderMultiLineText(int16 x, int16 y, const Common::String &origText, int32 mode, Graphics::Surface& frame);
-	void setFontColorByCharacter(int32 characterId);
-	void setFontColor(int32 fontColor1, int32 fontColor2, int32 fontColor3);
+class SubtitleRenderer {
+public:
+	SubtitleRenderer(ToonEngine *vm);
+	~SubtitleRenderer();
+
+    bool load(const Common::String &video);
+    void render(const Graphics::Surface& frame, uint32 frameNumber, char color);
 protected:
-	Animation *_currentFont;
 	ToonEngine *_vm;
-	byte _currentFontColor[4];
-	byte textToFont(byte c);
+    Graphics::Surface* _subSurface;
+    bool _hasSubtitles;
+
+    char* _lines[384];
+    TimeWindow _tw[384];
+    uint8 *_fileData;
+    uint16 _index;
+    uint16 _last;
+    char* _currentLine;
 };
 
 } // End of namespace Toon

--- a/engines/toon/subtitles.h
+++ b/engines/toon/subtitles.h
@@ -29,9 +29,9 @@
 namespace Toon {
 
 typedef struct {
-    uint32 fstart;
-    uint32 fend;
-    uint32 foffset;
+	uint32 fstart;
+	uint32 fend;
+	uint32 foffset;
 } TimeWindow;
 
 class SubtitleRenderer {
@@ -39,19 +39,18 @@ public:
 	SubtitleRenderer(ToonEngine *vm);
 	~SubtitleRenderer();
 
-    bool load(const Common::String &video);
-    void render(const Graphics::Surface& frame, uint32 frameNumber, char color);
+	bool load(const Common::String &video);
+	void render(const Graphics::Surface &frame, uint32 frameNumber, byte color);
 protected:
 	ToonEngine *_vm;
-    Graphics::Surface* _subSurface;
-    bool _hasSubtitles;
-
-    char* _lines[384];
-    TimeWindow _tw[384];
-    uint8 *_fileData;
-    uint16 _index;
-    uint16 _last;
-    char* _currentLine;
+	Graphics::Surface *_subSurface;
+	bool _hasSubtitles;
+	char *_lines[384];
+	TimeWindow _tw[384];
+	uint8 *_fileData;
+	uint16 _index;
+	uint16 _last;
+	char *_currentLine;
 };
 
 } // End of namespace Toon

--- a/engines/toon/subtitles.h
+++ b/engines/toon/subtitles.h
@@ -23,8 +23,8 @@
 #ifndef TOON_SUBTITLES_H
 #define TOON_SUBTITLES_H
 
-#include "toon/toon.h"
 #include "graphics/surface.h"
+#include "toon/toon.h"
 
 namespace Toon {
 

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -3293,7 +3293,7 @@ void ToonEngine::drawConversationLine() {
 	}
 }
 
-void ToonEngine::drawCustomText(int16 x, int16 y, char *line, Graphics::Surface *frame, char color) {
+void ToonEngine::drawCustomText(int16 x, int16 y, char *line, Graphics::Surface *frame, byte color) {
 	if (line) {
 		byte col = color; // 0xce
 		_fontRenderer->setFontColor(0, col, col);

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -3286,7 +3286,18 @@ void ToonEngine::drawConversationLine() {
 	if (_currentTextLine && _showConversationText) {
 		_fontRenderer->setFontColorByCharacter(_currentTextLineCharacterId);
 		_fontRenderer->setFont(_currentFont);
-		_fontRenderer->renderMultiLineText(_currentTextLineX, _currentTextLineY, _currentTextLine, 0);
+		_fontRenderer->renderMultiLineText(_currentTextLineX, _currentTextLineY, _currentTextLine, 0, *_mainSurface);
+	}
+}
+
+void ToonEngine::drawCustomText(int16 x, int16 y, char* line, Graphics::Surface* frame, char color) {
+	if (line) {
+		byte col = color; // 0xce
+		_fontRenderer->setFontColor(0, col, col);
+		//_fontRenderer->setFontColorByCharacter(_currentTextLineCharacterId);
+		_gameState->_currentScrollValue = 0;
+		_fontRenderer->setFont(_currentFont);
+		_fontRenderer->renderMultiLineText(x, y, line, 0, *frame);
 	}
 }
 

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -3290,7 +3290,7 @@ void ToonEngine::drawConversationLine() {
 	}
 }
 
-void ToonEngine::drawCustomText(int16 x, int16 y, char* line, Graphics::Surface* frame, char color) {
+void ToonEngine::drawCustomText(int16 x, int16 y, char *line, Graphics::Surface *frame, char color) {
 	if (line) {
 		byte col = color; // 0xce
 		_fontRenderer->setFontColor(0, col, col);

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -1430,7 +1430,7 @@ void ToonEngine::updateAnimationSceneScripts(int32 timeElapsed) {
 
 	do {
 		if (_sceneAnimationScripts[_lastProcessedSceneScript]._lastTimer <= _system->getMillis() &&
-		        !_sceneAnimationScripts[_lastProcessedSceneScript]._frozen && !_sceneAnimationScripts[_lastProcessedSceneScript]._frozenForConversation) {
+				!_sceneAnimationScripts[_lastProcessedSceneScript]._frozen && !_sceneAnimationScripts[_lastProcessedSceneScript]._frozenForConversation) {
 			_animationSceneScriptRunFlag = true;
 
 			while (_animationSceneScriptRunFlag && _sceneAnimationScripts[_lastProcessedSceneScript]._lastTimer <= _system->getMillis() && !_shouldQuit) {
@@ -2988,8 +2988,8 @@ int32 ToonEngine::showInventory() {
 				int32 x = 57 * (i % 7) + 114;
 				int32 y = ((9 * (i % 7)) & 0xf) + 56 * (i / 7) + 80;
 				if (_mouseX >= (_gameState->_currentScrollValue + x - 6) &&
-				        _mouseX <= (_gameState->_currentScrollValue + x + 44 + 7) &&
-				        _mouseY >= y - 6 && _mouseY <= y + 50) {
+						_mouseX <= (_gameState->_currentScrollValue + x + 44 + 7) &&
+						_mouseY >= y - 6 && _mouseY <= y + 50) {
 					foundObj = i;
 					break;
 				}
@@ -3293,7 +3293,7 @@ void ToonEngine::drawConversationLine() {
 	}
 }
 
-void ToonEngine::drawCustomText(int16 x, int16 y, char *line, Graphics::Surface *frame, byte color) {
+void ToonEngine::drawCustomText(int16 x, int16 y, const char *line, Graphics::Surface *frame, byte color) {
 	if (line) {
 		byte col = color; // 0xce
 		_fontRenderer->setFontColor(0, col, col);

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -106,6 +106,9 @@ void ToonEngine::init() {
 	resources()->openPackage("ONETIME.PAK");
 	resources()->openPackage("DREW.PAK");
 
+	// load subtitles if available (if fails to load it only return false, so there's no need to check)
+	resources()->openPackage("SUBTITLES.PAK");
+
 	for (int32 i = 0; i < 32; i++)
 		_characters[i] = NULL;
 

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -212,9 +212,7 @@ public:
 	void playRoomMusic();
 	void waitForScriptStep();
 	void doMagnifierEffect();
-
-	void drawCustomText(int16 x, int16 y, char* line, Graphics::Surface* frame, char color);
-
+	void drawCustomText(int16 x, int16 y, char *line, Graphics::Surface *frame, char color);
 	bool canSaveGameStateCurrently();
 	bool canLoadGameStateCurrently();
 	void pauseEngineIntern(bool pause);

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -211,7 +211,7 @@ public:
 	void playRoomMusic();
 	void waitForScriptStep();
 	void doMagnifierEffect();
-	void drawCustomText(int16 x, int16 y, char *line, Graphics::Surface *frame, byte color);
+	void drawCustomText(int16 x, int16 y, const char *line, Graphics::Surface *frame, byte color);
 	bool canSaveGameStateCurrently();
 	bool canLoadGameStateCurrently();
 	void pauseEngineIntern(bool pause);

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -33,6 +33,7 @@
 #include "toon/state.h"
 #include "toon/picture.h"
 #include "toon/anim.h"
+#include "toon/subtitles.h"
 #include "toon/movie.h"
 #include "toon/font.h"
 #include "toon/text.h"
@@ -211,6 +212,8 @@ public:
 	void playRoomMusic();
 	void waitForScriptStep();
 	void doMagnifierEffect();
+
+	void drawCustomText(int16 x, int16 y, char* line, Graphics::Surface* frame, char color);
 
 	bool canSaveGameStateCurrently();
 	bool canLoadGameStateCurrently();

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -33,7 +33,6 @@
 #include "toon/state.h"
 #include "toon/picture.h"
 #include "toon/anim.h"
-#include "toon/subtitles.h"
 #include "toon/movie.h"
 #include "toon/font.h"
 #include "toon/text.h"
@@ -212,7 +211,7 @@ public:
 	void playRoomMusic();
 	void waitForScriptStep();
 	void doMagnifierEffect();
-	void drawCustomText(int16 x, int16 y, char *line, Graphics::Surface *frame, char color);
+	void drawCustomText(int16 x, int16 y, char *line, Graphics::Surface *frame, byte color);
 	bool canSaveGameStateCurrently();
 	bool canLoadGameStateCurrently();
 	void pauseEngineIntern(bool pause);


### PR DESCRIPTION
This allows subtitles during cutscenes in Toonstruck.
Attaching subtitles file for first part of intro cutscene - should be extracted to `MISC` directory
[209_1M.zip](https://github.com/scummvm/scummvm/files/3721733/209_1M.zip)

Subtitles rendered using the same text draw method from the game so they look consistent.
text color changes with the palette of the cutscene.

The original game does not have subtitles in cutscenes (new feature),
I also could not find a transcript of the cutscenes' texts.
so the hard work of transcribing and timing the subtitles is still ahead.

Subtitles files are stored  in custom simple format (`tss` for Toonstruck Subtitles) consists of:
index - start frame, end frame, text offset
texts - null terminated strings

subtitles files should have the same name as matching cutscene files (minus the extension).
for example: 209_1M.SMK (cutscene) -> 209_1M.tss (subtitles).
(When all subtitles are done, I think of putting them all under a single `SUBTITLES.PAK` file)

(I have a simple python script to convert `sbv` to `tss`... I would like to add it to `devtools`.
need explanation about those `module.mk` files, though)
