### PR TITLE
AMIGAOS4: amigaos.mk - Fix cp command

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -21,7 +21,7 @@ endif
 # Copy shared library plugins, if available.
 ifdef DYNAMIC_MODULES
 	mkdir -p $(AMIGAOSPATH)/plugins
-	cp $(PLUGINS) -o $(AMIGAOSPATH)/plugins/
+	cp $(PLUGINS) $(AMIGAOSPATH)/plugins/
 endif
 ifdef DIST_FILES_THEMES
 	mkdir -p $(AMIGAOSPATH)/themes


### PR DESCRIPTION
OK, now i´m embarrassed, this obviously won't work :-( 

I was testing
`strip plugins/*`
which produces broken plugins for me and forgot to get rid of the flag.
Doing the stripping locally for now.

Sorry again