### PR TITLE
3DS: Embed ScummVM's support files in the package

### DIFF
--- a/backends/fs/posix-drives/posix-drives-fs-factory.h
+++ b/backends/fs/posix-drives/posix-drives-fs-factory.h
@@ -20,39 +20,35 @@
  *
  */
 
-#include "osystem.h"
-#include <3ds.h>
+#ifndef POSIX_DRIVES_FILESYSTEM_FACTORY_H
+#define POSIX_DRIVES_FILESYSTEM_FACTORY_H
 
-int main(int argc, char *argv[]) {
-	// Initialize basic libctru stuff
-	gfxInitDefault();
-	cfguInit();
-	romfsInit();
-	osSetSpeedupEnable(true);
-// 	consoleInit(GFX_TOP, NULL);
+#include "backends/fs/fs-factory.h"
 
-	g_system = new _3DS::OSystem_3DS();
-	assert(g_system);
+/**
+ * A FilesystemFactory implementation for filesystems with a special
+ * top-level directory with hard-coded entries but that otherwise
+ * implement the POSIX APIs.
+ *
+ * For used with paths like these:
+ * - 'sdcard:/games/scummvm.ini'
+ * - 'hdd1:/usr/bin'
+ */
+class DrivesPOSIXFilesystemFactory : public FilesystemFactory {
+public:
+	/**
+	 * Add a drive to the top-level directory
+	 */
+	void addDrive(const Common::String &name);
 
-	// Invoke the actual ScummVM main entry point
-// 	if (argc > 2)
-// 		res = scummvm_main(argc-2, &argv[2]);
-// 	else
-// 		res = scummvm_main(argc, argv);
-//	scummvm_main(0, nullptr);
+protected:
+	// FilesystemFactory API
+	AbstractFSNode *makeRootFileNode() const override;
+	AbstractFSNode *makeCurrentDirectoryFileNode() const override;
+	AbstractFSNode *makeFileNodePath(const Common::String &path) const override;
 
-	int res = scummvm_main(argc, argv);
+private:
+	Common::Array<Common::String> _drives;
+};
 
-	g_system->destroy();
-
-	// Turn on both screen backlights before exiting.
-	if (R_SUCCEEDED(gspLcdInit())) {
-		GSPLCD_PowerOnBacklight(GSPLCD_SCREEN_BOTH);
-		gspLcdExit();
-	}
-
-	romfsExit();
-	cfguExit();
-	gfxExit();
-	return res;
-}
+#endif

--- a/backends/fs/posix-drives/posix-drives-fs.cpp
+++ b/backends/fs/posix-drives/posix-drives-fs.cpp
@@ -1,0 +1,136 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#if defined(POSIX)
+
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
+#include "backends/fs/posix-drives/posix-drives-fs.h"
+#include "common/algorithm.h"
+
+#include <dirent.h>
+
+DrivePOSIXFilesystemNode::DrivePOSIXFilesystemNode(const Common::String &path, const DrivesArray &drives) :
+		POSIXFilesystemNode(path),
+		_isPseudoRoot(false),
+		_drives(drives) {
+
+	if (isDrive(path)) {
+		_isDirectory = true;
+		_isValid = true;
+
+		// FIXME: Add a setting for deciding whether drive paths need to end with a slash
+		if (!_path.hasSuffix("/")) {
+			_path += "/";
+		}
+		return;
+	}
+}
+
+DrivePOSIXFilesystemNode::DrivePOSIXFilesystemNode(const DrivesArray &drives) :
+		_isPseudoRoot(true),
+		_drives(drives) {
+	_isDirectory = true;
+	_isValid = false;
+}
+
+AbstractFSNode *DrivePOSIXFilesystemNode::getChild(const Common::String &n) const {
+	if (!_isPseudoRoot) {
+		return POSIXFilesystemNode::getChild(n);
+	}
+
+	// Make sure the string contains no slashes
+	assert(!n.contains('/'));
+
+	Common::String newPath(_path);
+	if (_path.lastChar() != '/')
+		newPath += '/';
+	newPath += n;
+
+	return makeNode(newPath);
+}
+
+bool DrivePOSIXFilesystemNode::getChildren(AbstractFSList &list, AbstractFSNode::ListMode mode, bool hidden) const {
+	assert(_isDirectory);
+
+	if (_isPseudoRoot) {
+		for (uint i = 0; i < _drives.size(); i++) {
+			list.push_back(makeNode(_drives[i]));
+		}
+
+		return true;
+	} else {
+		DIR *dirp = opendir(_path.c_str());
+		struct dirent *dp;
+
+		if (!dirp)
+			return false;
+
+		while ((dp = readdir(dirp)) != nullptr) {
+			// Skip 'invisible' files if necessary
+			if (dp->d_name[0] == '.' && !hidden) {
+				continue;
+			}
+
+			// Skip '.' and '..' to avoid cycles
+			if ((dp->d_name[0] == '.' && dp->d_name[1] == 0) || (dp->d_name[0] == '.' && dp->d_name[1] == '.')) {
+				continue;
+			}
+
+			AbstractFSNode *child = getChild(dp->d_name);
+
+			// Honor the chosen mode
+			if ((mode == Common::FSNode::kListFilesOnly && child->isDirectory()) ||
+				(mode == Common::FSNode::kListDirectoriesOnly && !child->isDirectory())) {
+				delete child;
+				continue;
+			}
+
+			list.push_back(child);
+		}
+
+		closedir(dirp);
+
+		return true;
+	}
+}
+
+AbstractFSNode *DrivePOSIXFilesystemNode::getParent() const {
+	if (_isPseudoRoot) {
+		return nullptr;
+	}
+
+	if (isDrive(_path)) {
+		DrivePOSIXFilesystemNode *root = new DrivePOSIXFilesystemNode(_drives);
+		return root;
+	}
+
+	return POSIXFilesystemNode::getParent();
+}
+
+bool DrivePOSIXFilesystemNode::isDrive(const Common::String &path) const {
+	Common::String normalizedPath = Common::normalizePath(path, '/');
+	DrivesArray::const_iterator drive = Common::find(_drives.begin(), _drives.end(), normalizedPath);
+	return drive != _drives.end();
+}
+
+#endif //#if defined(POSIX)

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -161,6 +161,8 @@ ifdef POSIX
 MODULE_OBJS += \
 	fs/posix/posix-fs.o \
 	fs/posix/posix-fs-factory.o \
+	fs/posix-drives/posix-drives-fs.o \
+	fs/posix-drives/posix-drives-fs-factory.o \
 	fs/chroot/chroot-fs-factory.o \
 	fs/chroot/chroot-fs.o \
 	plugins/posix/posix-provider.o \

--- a/backends/platform/3ds/3ds.mk
+++ b/backends/platform/3ds/3ds.mk
@@ -21,21 +21,40 @@ clean: clean_3ds
 clean_3ds:
 	$(RM) $(TARGET).3dsx
 	$(RM) $(TARGET).cia
+	$(RM) -rf romfs
+
+romfs: $(DIST_FILES_THEMES) $(DIST_FILES_ENGINEDATA) $(DIST_FILES_NETWORKING) $(DIST_FILES_VKEYBD)
+	@rm -rf romfs
+	@mkdir -p romfs
+	@cp $(DIST_FILES_THEMES) romfs/
+ifdef DIST_FILES_ENGINEDATA
+	@cp $(DIST_FILES_ENGINEDATA) romfs/
+endif
+ifdef DIST_FILES_NETWORKING
+	@cp $(DIST_FILES_NETWORKING) romfs/
+endif
+ifdef DIST_FILES_VKEYBD
+	@cp $(DIST_FILES_VKEYBD) romfs/
+endif
 
 $(TARGET).smdh: $(APP_ICON)
 	@smdhtool --create "$(APP_TITLE)" "$(APP_DESCRIPTION)" "$(APP_AUTHOR)" $(APP_ICON) $@
 	@echo built ... $(notdir $@)
 
-$(TARGET).3dsx: $(EXECUTABLE) $(TARGET).smdh
-	@3dsxtool $< $@ --smdh=$(TARGET).smdh
+$(TARGET).3dsx: $(EXECUTABLE) $(TARGET).smdh romfs
+	@3dsxtool $< $@ --smdh=$(TARGET).smdh --romfs=romfs
 	@echo built ... $(notdir $@)
 	
 $(TARGET).bnr: $(APP_BANNER_IMAGE) $(APP_BANNER_AUDIO)
 	@bannertool makebanner -o $@ -i $(APP_BANNER_IMAGE) -a $(APP_BANNER_AUDIO)
 	@echo built ... $(notdir $@)
-	
-$(TARGET).cia: $(EXECUTABLE) $(APP_RSF) $(TARGET).smdh $(TARGET).bnr
-	@makerom -f cia -target t -exefslogo -o $@ -elf $(EXECUTABLE) -rsf $(APP_RSF) -banner $(TARGET).bnr -icon $(TARGET).smdh
+
+$(TARGET).romfs: romfs
+	@3dstool -cvtf romfs $(TARGET).romfs --romfs-dir romfs
+	@echo built ... $(notdir $@)
+
+$(TARGET).cia: $(EXECUTABLE) $(APP_RSF) $(TARGET).smdh $(TARGET).bnr $(TARGET).romfs
+	@makerom -f cia -target t -exefslogo -o $@ -elf $(EXECUTABLE) -rsf $(APP_RSF) -banner $(TARGET).bnr -icon $(TARGET).smdh -romfs $(TARGET).romfs
 	@echo built ... $(notdir $@)
 
 #---------------------------------------------------------------------------------

--- a/backends/platform/3ds/README.md
+++ b/backends/platform/3ds/README.md
@@ -49,19 +49,7 @@ Not having this file will cause many problems with games that need audio, someti
 even crashing, so this is NOT considered optional.
 
 Using any CIA installation software (search elsewhere for that), you need to install
-the `scummvm.cia` file. Then, just like what is done with the 3DSX installation, you
-need to extract all ScummVM 3DS files (`scummvm.cia` excluded) to the root of your SD
-card so that all files reside in the `/3ds/scummvm/` directory.
-
-1.3) Additional files
----------------------
-In order to use the Virtual Keyboard, you need to get the:
-`backends/vkeybd/packs/vkeybd_small.zip` file from ScummVM's repository, and
-place it on your SD card, in the `/3ds/scummvm/kb` folder.
-
-In case you want a translated GUI, you need to get the:
-`scummvm/gui/themes/translations.dat` file from ScummVM's repository, and place
-it on your SD card, in the `/3ds/scummvm/themes` folder.
+the `scummvm.cia` file.
 
 2.0) Controls
 -------------
@@ -229,7 +217,7 @@ Additionally compile to specific formats to be used on the 3DS:
 Assuming everything was successful, you'll be able to find the binary
 files in the root of your scummvm folder.
 
-Note: for the CIA format, you will need the 'makerom' and 'bannertool' tools which are
+Note: for the CIA format, you will need the '3dstool', 'makerom' and 'bannertool' tools which are
 not supplied with devkitPro.
 
 4.3) Warning for build sizes

--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -36,8 +36,8 @@
 #include "common/str.h"
 #include "config.h"
 
-#include "backends/fs/posix/posix-fs-factory.h"
-#include "backends/fs/posix/posix-fs.h"
+#include "backends/fs/posix-drives/posix-drives-fs-factory.h"
+#include "backends/fs/posix-drives/posix-drives-fs.h"
 #include <unistd.h>
 #include <time.h>
 
@@ -77,7 +77,12 @@ OSystem_3DS::OSystem_3DS():
 	sleeping(false)
 {
 	chdir("sdmc:/");
-	_fsFactory = new POSIXFilesystemFactory();
+
+	DrivesPOSIXFilesystemFactory *fsFactory = new DrivesPOSIXFilesystemFactory();
+	fsFactory->addDrive("sdmc:");
+	fsFactory->addDrive("romfs:");
+	_fsFactory = fsFactory;
+
 	Posix::assureDirectoryExists("/3ds/scummvm/saves/");
 }
 
@@ -101,15 +106,11 @@ void OSystem_3DS::initBackend() {
 	ConfMan.registerDefault("aspect_ratio", true);
 	if (!ConfMan.hasKey("vkeybd_pack_name"))
 		ConfMan.set("vkeybd_pack_name", "vkeybd_small");
-	if (!ConfMan.hasKey("vkeybdpath"))
-		ConfMan.set("vkeybdpath", "/3ds/scummvm/kb");
-	if (!ConfMan.hasKey("themepath"))
-		ConfMan.set("themepath", "/3ds/scummvm");
 	if (!ConfMan.hasKey("gui_theme"))
 		ConfMan.set("gui_theme", "builtin");
 
 	_timerManager = new DefaultTimerManager();
-	_savefileManager = new DefaultSaveFileManager("/3ds/scummvm/saves/");
+	_savefileManager = new DefaultSaveFileManager("sdmc:/3ds/scummvm/saves/");
 
 	initGraphics();
 	initAudio();
@@ -125,7 +126,11 @@ void OSystem_3DS::updateConfig() {
 }
 
 Common::String OSystem_3DS::getDefaultConfigFileName() {
-	return "/3ds/scummvm/scummvm.ini";
+	return "sdmc:/3ds/scummvm/scummvm.ini";
+}
+
+void OSystem_3DS::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
+	s.add("RomFS", new Common::FSDirectory("romfs:/"), priority);
 }
 
 uint32 OSystem_3DS::getMillis(bool skipRecord) {

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -88,6 +88,7 @@ public:
 	virtual void quit();
 
 	virtual Common::String getDefaultConfigFileName();
+	void addSysArchivesToSearchSet(Common::SearchSet &s, int priority) override;
 
 	// Graphics
 	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const;


### PR DESCRIPTION
So users don't have to copy them to the SD card.

Also introduce a `FilesystemFactory` implementation for filesystems using the POSIX API but with a hard-coded list of drives at the top-level.
(@rsn8887 maybe you'll want to use that for the Vita) 