### PR TITLE
GUI: Fix crash when clicking and dragging a tab widget

### DIFF
--- a/gui/widgets/tab.cpp
+++ b/gui/widgets/tab.cpp
@@ -221,7 +221,7 @@ void TabWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 }
 
 void TabWidget::handleMouseMoved(int x, int y, int button) {
-	if (y < _tabHeight)
+	if (y < 0 || y >= _tabHeight)
 		return;
 
 	if (x < 0)

--- a/gui/widgets/tab.cpp
+++ b/gui/widgets/tab.cpp
@@ -221,7 +221,8 @@ void TabWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 }
 
 void TabWidget::handleMouseMoved(int x, int y, int button) {
-	assert(y < _tabHeight);
+	if (y < _tabHeight)
+		return;
 
 	if (x < 0)
 		return;


### PR DESCRIPTION
The crash happens on all platforms, but is very easy to trigger by accident on Android.