### PR TITLE
TTS: Link libpthread explicitly on Linux platform

### DIFF
--- a/configure
+++ b/configure
@@ -5504,7 +5504,7 @@ else
 		echo "linux"
 		_tts=yes
 		define_in_config_if_yes $_tts 'USE_SPEECH_DISPATCHER'
-		append_var LIBS '-lspeechd'
+		append_var LIBS '-lspeechd -lpthread'
 		;;
 	mingw*)
 		echo "win32"


### PR DESCRIPTION
When building scummvm with TTS support for the Linux platform, the final linking of the scummvm binary fails since libpthread is not linked:

<pre>
g++  -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -fuse-ld=gold -Wl,--gdb-index -Wl,-export-dynamic -Wl,-whole-archive backends/platform/sdl/sdl.o backends/platform/sdl/sdl-window.o backends/platform/sdl/posix/posix-main.o backends/platform/sdl/posix/posix.o base/libbase.a gui/libgui.a backends/libbackends.a engines/libengines.a video/libvideo.a image/libimage.a graphics/libgraphics.a audio/libaudio.a common/libcommon.a audio/softsynth/mt32/libmt32.a -Wl,-no-whole-archive  -lSDL2 -ldl -lm  -lvorbisfile -lvorbis  -lFLAC  -logg  -lmad  -lasound  -ljpeg -lpng16 -lz   -ltheoradec -lz  -lmpeg2 -lcurl -lfluidsynth  -lreadline -lfreetype   -lspeechd -o scummvm
backends/text-to-speech/linux/linux-text-to-speech.cpp:272: error: undefined reference to 'pthread_join'
backends/text-to-speech/linux/linux-text-to-speech.cpp:133: error: undefined reference to 'pthread_join'
backends/text-to-speech/linux/linux-text-to-speech.cpp:154: error: undefined reference to 'pthread_create'
backends/text-to-speech/linux/linux-text-to-speech.cpp:152: error: undefined reference to 'pthread_join'
backends/libbackends.a(linux-text-to-speech.o)(.debug_addr+0xbb8): error: undefined reference to 'pthread_join'
backends/libbackends.a(linux-text-to-speech.o)(.debug_addr+0x10c0): error: undefined reference to 'pthread_create'
collect2: error: ld returned 1 exit status
make: *** [Makefile.common:90: scummvm] Error 1
</pre>

Since the TTS backend directly uses functions from libpthread, it should also link it explicitly.

This issue is hidden if any other used library provides "-lpthread" in their respective "Libs" section of its pkgconfig file.