### PR TITLE
IOS7: enable home indicator auto-hide on iPhone X and up

### DIFF
--- a/backends/platform/ios7/ios7_scummvm_view_controller.mm
+++ b/backends/platform/ios7/ios7_scummvm_view_controller.mm
@@ -29,4 +29,8 @@
     return YES;
 }
 
+- (BOOL)prefersHomeIndicatorAutoHidden {
+    return YES;
+}
+
 @end


### PR DESCRIPTION
This makes the annoying white line at the bottom of the screen go away on newer (home button-less) iPhones.

![home_indicator](https://user-images.githubusercontent.com/986590/67134657-37589a80-f1e1-11e9-921a-1a553fbb2b98.gif)

See also https://developer.apple.com/documentation/uikit/uiviewcontroller/2887510-prefershomeindicatorautohidden

I tested this on iOS10 to make sure it's backwards compatible.