### PR TITLE
3DS: Set 'scummvm.romfs' to be removed by 3ds_clean in 3ds.mk

### DIFF
--- a/backends/platform/3ds/3ds.mk
+++ b/backends/platform/3ds/3ds.mk
@@ -24,6 +24,7 @@ clean_3ds:
 	$(RM) $(TARGET).smdh
 	$(RM) $(TARGET).3dsx
 	$(RM) $(TARGET).bnr
+	$(RM) $(TARGET).romfs
 	$(RM) $(TARGET).cia
 	$(RM) -rf romfs
 


### PR DESCRIPTION
Set 'scummvm.romfs' to be removed in cleaning, as it is a byproduct of "make scummvm.cia".