### PR TITLE
3DS: Remove 3dstool dependency

### DIFF
--- a/backends/platform/3ds/3ds.mk
+++ b/backends/platform/3ds/3ds.mk
@@ -53,7 +53,7 @@ $(TARGET).bnr: $(APP_BANNER_IMAGE) $(APP_BANNER_AUDIO)
 	@bannertool makebanner -o $@ -i $(APP_BANNER_IMAGE) -a $(APP_BANNER_AUDIO)
 	@echo built ... $(notdir $@)
 
-$(TARGET).cia: $(EXECUTABLE) $(APP_RSF) $(TARGET).smdh $(TARGET).bnr
+$(TARGET).cia: $(EXECUTABLE) $(APP_RSF) $(TARGET).smdh $(TARGET).bnr romfs
 	@makerom -f cia -target t -exefslogo -o $@ -elf $(EXECUTABLE) -rsf $(APP_RSF) -banner $(TARGET).bnr -icon $(TARGET).smdh -DAPP_ROMFS=romfs/
 	@echo built ... $(notdir $@)
 

--- a/backends/platform/3ds/3ds.mk
+++ b/backends/platform/3ds/3ds.mk
@@ -24,7 +24,6 @@ clean_3ds:
 	$(RM) $(TARGET).smdh
 	$(RM) $(TARGET).3dsx
 	$(RM) $(TARGET).bnr
-	$(RM) $(TARGET).romfs
 	$(RM) $(TARGET).cia
 	$(RM) -rf romfs
 
@@ -54,12 +53,8 @@ $(TARGET).bnr: $(APP_BANNER_IMAGE) $(APP_BANNER_AUDIO)
 	@bannertool makebanner -o $@ -i $(APP_BANNER_IMAGE) -a $(APP_BANNER_AUDIO)
 	@echo built ... $(notdir $@)
 
-$(TARGET).romfs: romfs
-	@3dstool -cvtf romfs $(TARGET).romfs --romfs-dir romfs
-	@echo built ... $(notdir $@)
-
-$(TARGET).cia: $(EXECUTABLE) $(APP_RSF) $(TARGET).smdh $(TARGET).bnr $(TARGET).romfs
-	@makerom -f cia -target t -exefslogo -o $@ -elf $(EXECUTABLE) -rsf $(APP_RSF) -banner $(TARGET).bnr -icon $(TARGET).smdh -romfs $(TARGET).romfs
+$(TARGET).cia: $(EXECUTABLE) $(APP_RSF) $(TARGET).smdh $(TARGET).bnr
+	@makerom -f cia -target t -exefslogo -o $@ -elf $(EXECUTABLE) -rsf $(APP_RSF) -banner $(TARGET).bnr -icon $(TARGET).smdh -DAPP_ROMFS=romfs/
 	@echo built ... $(notdir $@)
 
 #---------------------------------------------------------------------------------

--- a/backends/platform/3ds/README.md
+++ b/backends/platform/3ds/README.md
@@ -217,7 +217,7 @@ Additionally compile to specific formats to be used on the 3DS:
 Assuming everything was successful, you'll be able to find the binary
 files in the root of your scummvm folder.
 
-Note: for the CIA format, you will need the '3dstool', 'makerom' and 'bannertool' tools which are
+Note: for the CIA format, you will need the 'makerom' and 'bannertool' tools which are
 not supplied with devkitPro.
 
 4.3) Warning for build sizes

--- a/backends/platform/3ds/app/scummvm.rsf
+++ b/backends/platform/3ds/app/scummvm.rsf
@@ -7,6 +7,10 @@ TitleInfo:
   Category                : Application
   UniqueId                : 0xFF321
 
+RomFs:
+  # Specifies the root path of the read only file system to include in the ROM.
+  RootPath                : $(APP_ROMFS)
+
 Option:
   UseOnSD                 : true # true if App is to be installed to SD
   FreeProductCode         : true # Removes limitations on ProductCode


### PR DESCRIPTION
This patch alters the way the .cia is build. It removes the need for 3dstool.

Instead of first generating a .romfs file using 3dstool, let makerom generate the romfs while building the .cia.