### PR TITLE
NETWORKING: Try loading the CA bundle from DATA_PATH

### DIFF
--- a/backends/networking/curl/connectionmanager.cpp
+++ b/backends/networking/curl/connectionmanager.cpp
@@ -184,20 +184,19 @@ void ConnectionManager::processTransfers() {
 	int messagesInQueue;
 	CURLMsg *curlMsg;
 	while ((curlMsg = curl_multi_info_read(_multi, &messagesInQueue))) {
-		CURL *easyHandle = curlMsg->easy_handle;
-
-		NetworkReadStream *stream;
-		curl_easy_getinfo(easyHandle, CURLINFO_PRIVATE, &stream);
-		if (stream)
-			stream->finished();
-
 		if (curlMsg->msg == CURLMSG_DONE) {
-			debug(9, "ConnectionManager: SUCCESS (%d - %s)", curlMsg->data.result, curl_easy_strerror(curlMsg->data.result));
-		} else {
-			warning("ConnectionManager: FAILURE (CURLMsg (%d))", curlMsg->msg);
-		}
+			CURL *easyHandle = curlMsg->easy_handle;
 
-		curl_multi_remove_handle(_multi, easyHandle);
+			NetworkReadStream *stream = nullptr;
+			curl_easy_getinfo(easyHandle, CURLINFO_PRIVATE, &stream);
+
+			if (stream)
+				stream->finished(curlMsg->data.result);
+
+			curl_multi_remove_handle(_multi, easyHandle);
+		} else {
+			warning("Unknown libcurl message type %d", curlMsg->msg);
+		}
 	}
 }
 

--- a/backends/networking/curl/connectionmanager.cpp
+++ b/backends/networking/curl/connectionmanager.cpp
@@ -26,6 +26,7 @@
 #include "backends/networking/curl/connectionmanager.h"
 #include "backends/networking/curl/networkreadstream.h"
 #include "common/debug.h"
+#include "common/fs.h"
 #include "common/system.h"
 #include "common/timer.h"
 
@@ -96,6 +97,29 @@ Common::String ConnectionManager::urlEncode(Common::String s) const {
 
 uint32 ConnectionManager::getCloudRequestsPeriodInMicroseconds() {
 	return TIMER_INTERVAL * CLOUD_PERIOD;
+}
+
+const char *ConnectionManager::getCaCertPath() {
+#if defined(DATA_PATH)
+	static enum {
+		kNotInitialized,
+		kFileNotFound,
+		kFileExists
+	} state = kNotInitialized;
+
+	if (state == kNotInitialized) {
+		Common::FSNode node(DATA_PATH"/cacert.pem");
+		state = node.exists() ? kFileExists : kFileNotFound;
+	}
+
+	if (state == kFileExists) {
+		return DATA_PATH"/cacert.pem";
+	} else {
+		return nullptr;
+	}
+#else
+	return nullptr;
+#endif
 }
 
 //private goes here:

--- a/backends/networking/curl/connectionmanager.h
+++ b/backends/networking/curl/connectionmanager.h
@@ -118,6 +118,9 @@ public:
 	Common::String urlEncode(Common::String s) const;
 
 	static uint32 getCloudRequestsPeriodInMicroseconds();
+
+	/** Return the path to the CA certificates bundle. */
+	static const char *getCaCertPath();
 };
 
 /** Shortcut for accessing the connection manager. */

--- a/backends/networking/curl/networkreadstream.cpp
+++ b/backends/networking/curl/networkreadstream.cpp
@@ -91,6 +91,11 @@ void NetworkReadStream::init(const char *url, curl_slist *headersList, const byt
 	curl_easy_setopt(_easy, CURLOPT_SSL_VERIFYPEER, 0);
 #endif
 
+	const char *caCertPath = ConnMan.getCaCertPath();
+	if (caCertPath) {
+		curl_easy_setopt(_easy, CURLOPT_CAINFO, caCertPath);
+	}
+
 #if LIBCURL_VERSION_NUM >= 0x072000
 	// CURLOPT_XFERINFOFUNCTION introduced in libcurl 7.32.0
 	// CURLOPT_PROGRESSFUNCTION is used as a backup plan in case older version is used
@@ -148,6 +153,11 @@ void NetworkReadStream::init(const char *url, curl_slist *headersList, Common::H
 #if defined NINTENDO_SWITCH || defined ANDROID_PLAIN_PORT
 	curl_easy_setopt(_easy, CURLOPT_SSL_VERIFYPEER, 0);
 #endif
+
+	const char *caCertPath = ConnMan.getCaCertPath();
+	if (caCertPath) {
+		curl_easy_setopt(_easy, CURLOPT_CAINFO, caCertPath);
+	}
 
 #if LIBCURL_VERSION_NUM >= 0x072000
 	// CURLOPT_XFERINFOFUNCTION introduced in libcurl 7.32.0

--- a/backends/networking/curl/networkreadstream.h
+++ b/backends/networking/curl/networkreadstream.h
@@ -38,6 +38,7 @@ class NetworkReadStream: public Common::ReadStream {
 	CURL *_easy;
 	Common::MemoryReadWriteStream _backingStream;
 	bool _eos, _requestComplete;
+	char *_errorBuffer;
 	const byte *_sendingContentsBuffer;
 	uint32 _sendingContentsSize;
 	uint32 _sendingContentsPos;
@@ -111,7 +112,7 @@ public:
 	 *
 	 * @note It's called on failure too.
 	 */
-	void finished();
+	void finished(uint32 errorCode);
 
 	/**
 	 * Returns HTTP response code from inner CURL handle.


### PR DESCRIPTION
So that platforms where libcurl cannot access the native CA store can ship a CA bundle along with the other ScummVM support files.

Also improve libcurl error handling so warnings are issued for failed requests.