### PR TITLE
CLOUD: Remove the saves sync finished OSD message

### DIFF
--- a/backends/cloud/storage.cpp
+++ b/backends/cloud/storage.cpp
@@ -229,7 +229,6 @@ void Storage::savesSyncDefaultCallback(BoolResponse response) {
 
 	if (!response.value)
 		warning("SavesSyncRequest called success callback with `false` argument");
-	Common::OSDMessageQueue::instance().addMessage(_("Saved games sync complete."));
 }
 
 void Storage::savesSyncDefaultErrorCallback(Networking::ErrorResponse error) {


### PR DESCRIPTION
When using the cloud save sync features, It seems to me there are too many user interface elements, I feel a bit overwhelmed. There is a blinking overlay icon indicating network activity, OSD messages indicating success or failure, and a progress dialog when the save / load dialog is open.

With this PR, I propose removing the OSD message indicating the save sync finished successfully. For me, it breaks the experience when it appears while in-game after the engine autosaved. IMO, the overlay icon disappearing is a good enough indication that the saves synchronized.
