### PR TITLE
Fix free/delete inconsistencies in OSystem_Win32::convertEncoding

### DIFF
--- a/common/system.h
+++ b/common/system.h
@@ -1541,8 +1541,8 @@ protected:
 	 * @param string The string that should be converted
 	 * @param length Size of the string in bytes
 	 *
-	 * @return Converted string, which must be freed, or nullptr if the conversion
-	 * isn't possible.
+	 * @return Converted string, which must be freed by the caller (using free()
+	 * and not delete[]), or nullptr if the conversion isn't possible.
 	 */
 	virtual char *convertEncoding(const char *to, const char *from, const char *string, size_t length) { return nullptr; }
 };


### PR DESCRIPTION
The current implementation of OSystem_Win32::convertEncoding causes some arrays allocated with `new []` being freed using `free()` and not `delete []`. This is an attempt to fix this.

Since I am not even able to compile the code, not being on Windows, I would appreciate if others could review and try this before this is pushed to master.

This commit also removes what appeared to be an unused variable (`wString`) and adds a sanity check as the result of `Win32::ansiToUnicode` could be null.