### PR TITLE
WIN32: Exit when WinSparkle runs installer

### DIFF
--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -117,7 +117,7 @@ void OSystem_Win32::initBackend() {
 
 #if defined(USE_SPARKLE)
 	// Initialize updates manager
-	_updateManager = new Win32UpdateManager();
+	_updateManager = new Win32UpdateManager((SdlWindow_Win32*)_window);
 #endif
 
 	// Initialize text to speech

--- a/backends/updates/win32/win32-updates.h
+++ b/backends/updates/win32/win32-updates.h
@@ -29,9 +29,11 @@
 
 #include "common/updates.h"
 
+class SdlWindow_Win32;
+
 class Win32UpdateManager : public Common::UpdateManager {
 public:
-	Win32UpdateManager();
+	Win32UpdateManager(SdlWindow_Win32 *window);
 	virtual ~Win32UpdateManager();
 
 	virtual void checkForUpdates();
@@ -43,6 +45,10 @@ public:
 	virtual int getUpdateCheckInterval();
 
 	virtual bool getLastUpdateCheckTimeAndDate(TimeDate &t);
+
+private:
+	static int canShutdownCallback();
+	static void shutdownRequestCallback();
 };
 
 #endif


### PR DESCRIPTION
Currently, when WinSparkle runs the downloaded installer, ScummVM remains open and must be manually exited or else the installer will fail. This is awkward since at this point the installer has focus.

WinSparkle has callbacks to handle this, so now ScummVM will exit as soon as WinSparkle runs the downloaded installer. At this point the user has clicked the Install Update button in the WinSparkle dialog so this isn't surprising behavior.

To test this, set SCUMMVM_VERSION to "2.0.0", or patch the version fields in scummvm.rc, and use the Check Now update button. After 2.1.0 downloads click Install Update.

https://bugs.scummvm.org/ticket/10368