### PR TITLE
POSIX: Fix compiler warning

### DIFF
--- a/backends/fs/posix-drives/posix-drives-fs.cpp
+++ b/backends/fs/posix-drives/posix-drives-fs.cpp
@@ -53,7 +53,7 @@ DrivePOSIXFilesystemNode::DrivePOSIXFilesystemNode(const DrivesArray &drives) :
 	_isValid = false;
 }
 
-DrivePOSIXFilesystemNode *DrivePOSIXFilesystemNode::getChildWithKnownType(const Common::String &n, bool isDirectory) const {
+DrivePOSIXFilesystemNode *DrivePOSIXFilesystemNode::getChildWithKnownType(const Common::String &n, bool isDirectoryFlag) const {
 	assert(_isDirectory);
 
 	// Make sure the string contains no slashes
@@ -68,7 +68,7 @@ DrivePOSIXFilesystemNode *DrivePOSIXFilesystemNode::getChildWithKnownType(const 
 	child->_path = newPath;
 	child->_isValid = true;
 	child->_isPseudoRoot = false;
-	child->_isDirectory = isDirectory;
+	child->_isDirectory = isDirectoryFlag;
 	child->_displayName = n;
 
 	return child;

--- a/backends/fs/posix-drives/posix-drives-fs.h
+++ b/backends/fs/posix-drives/posix-drives-fs.h
@@ -50,7 +50,7 @@ private:
 	bool _isPseudoRoot;
 	const DrivesArray &_drives;
 
-	DrivePOSIXFilesystemNode *getChildWithKnownType(const Common::String &n, bool isDirectory) const;
+	DrivePOSIXFilesystemNode *getChildWithKnownType(const Common::String &n, bool isDirectoryFlag) const;
 	bool isDrive(const Common::String &path) const;
 };
 


### PR DESCRIPTION
Parameter name isDirectory shadowed a method with same name.
The new name isDirectoryFlag has been also used elsewhere in similar situations.