### PR TITLE
BACKENDS: Fix using fillScreen in non-paletted screen modes

### DIFF
--- a/backends/base-backend.cpp
+++ b/backends/base-backend.cpp
@@ -57,7 +57,7 @@ void BaseBackend::initBackend() {
 
 void BaseBackend::fillScreen(uint32 col) {
 	Graphics::Surface *screen = lockScreen();
-	if (screen && screen->getPixels())
-		memset(screen->getPixels(), col, screen->h * screen->pitch);
+	if (screen)
+		screen->fillRect(Common::Rect(screen->w, screen->h), col);
 	unlockScreen();
 }

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -452,11 +452,6 @@ void OpenGLGraphicsManager::copyRectToScreen(const void *buf, int pitch, int x, 
 }
 
 void OpenGLGraphicsManager::fillScreen(uint32 col) {
-	// FIXME: This does not conform to the OSystem specs because fillScreen
-	// is always taking CLUT8 color values and use color indexed mode. This is,
-	// however, plain odd and probably was a forgotten when we introduced
-	// RGB support. Thus, we simply do the "sane" thing here and hope OSystem
-	// gets fixed one day.
 	_gameScreen->fill(col);
 }
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1610,8 +1610,8 @@ void SurfaceSdlGraphicsManager::unlockScreen() {
 
 void SurfaceSdlGraphicsManager::fillScreen(uint32 col) {
 	Graphics::Surface *screen = lockScreen();
-	if (screen && screen->getPixels())
-		memset(screen->getPixels(), col, screen->h * screen->pitch);
+	if (screen)
+		screen->fillRect(Common::Rect(screen->w, screen->h), col);
 	unlockScreen();
 }
 

--- a/common/system.h
+++ b/common/system.h
@@ -900,10 +900,6 @@ public:
 
 	/**
 	 * Fills the screen with a given color value.
-	 *
-	 * @note We are using uint32 here even though currently
-	 * we only support 8bpp indexed mode. Thus the value should
-	 * be always inside [0, 255] for now.
 	 */
 	virtual void fillScreen(uint32 col) = 0;
 


### PR DESCRIPTION
The OpenGL graphics manager already uses `Graphics::Surface::fillRect` to implement `fillScreen`, so this changes the other backends to match.