### PR TITLE
DIRECTOR: Add Lingo v4 bytecode interpreter

### DIFF
--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -423,10 +423,10 @@ bool RIFXArchive::openStream(Common::SeekableReadStream *stream, uint32 startOff
 				 tag == MKTAG('D', 'I', 'B', ' ') ||
 				 tag == MKTAG('R', 'T', 'E', '0') ||
 				 tag == MKTAG('R', 'T', 'E', '1') ||
-				 tag == MKTAG('R', 'T', 'E', '2') || 
-				 tag == MKTAG('L', 'c', 't', 'x') || 
-				 tag == MKTAG('L', 'n', 'a', 'm') || 
-                 tag == MKTAG('L', 's', 'c', 'r'))
+				 tag == MKTAG('R', 'T', 'E', '2') ||
+				 tag == MKTAG('L', 'c', 't', 'x') ||
+				 tag == MKTAG('L', 'n', 'a', 'm') ||
+				 tag == MKTAG('L', 's', 'c', 'r'))
 			_types[tag][i] = res;
 	}
 

--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -423,7 +423,10 @@ bool RIFXArchive::openStream(Common::SeekableReadStream *stream, uint32 startOff
 				 tag == MKTAG('D', 'I', 'B', ' ') ||
 				 tag == MKTAG('R', 'T', 'E', '0') ||
 				 tag == MKTAG('R', 'T', 'E', '1') ||
-				 tag == MKTAG('R', 'T', 'E', '2'))
+				 tag == MKTAG('R', 'T', 'E', '2') || 
+				 tag == MKTAG('L', 'c', 't', 'x') || 
+				 tag == MKTAG('L', 'n', 'a', 'm') || 
+                 tag == MKTAG('L', 's', 'c', 'r'))
 			_types[tag][i] = res;
 	}
 

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -29,6 +29,7 @@ namespace Director {
 
 BitmapCast::BitmapCast(Common::ReadStreamEndian &stream, uint32 castTag, uint16 version) {
 	if (version < 4) {
+		pitch = 0;
 		flags = stream.readByte();
 		someFlaggyThing = stream.readUint16();
 		initialRect = Score::readRect(stream);
@@ -42,8 +43,8 @@ BitmapCast::BitmapCast(Common::ReadStreamEndian &stream, uint32 castTag, uint16 
 			unk2 = stream.readUint16();
 		}
 	} else if (version == 4) {
-		stream.readByte();
-		stream.readByte();
+		pitch = stream.readUint16();
+		pitch &= 0x0fff;
 
 		flags = 0;
 		someFlaggyThing = 0;
@@ -67,6 +68,7 @@ BitmapCast::BitmapCast(Common::ReadStreamEndian &stream, uint32 castTag, uint16 
 
 		warning("BitmapCast: %d bytes left", tail);
 	} else if (version == 5) {
+		pitch = 0;
 		uint16 count = stream.readUint16();
 		for (uint16 cc = 0; cc < count; cc++)
 			stream.readUint32();

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -65,6 +65,7 @@ class BitmapCast : public Cast {
 public:
 	BitmapCast(Common::ReadStreamEndian &stream, uint32 castTag, uint16 version = 2);
 
+	uint16 pitch;
 	uint16 regX;
 	uint16 regY;
 	uint8 flags;

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -86,6 +86,18 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "vvdinosaur",	"Victor Vector & Yondo: The Last Dinosaur Egg"},
 	{ "warlock", 	"Spaceship Warlock"},
 	{ "ernie",		"Ernie"},
+	{ "id4p1",      "iD4 Mission Disk 1 - Alien Supreme Commander" },
+	{ "id4p2",      "iD4 Mission Disk 2 - Alien Science Officer" },
+	{ "id4p3",      "iD4 Mission Disk 3 - Warrior Alien" },
+	{ "id4p4",      "iD4 Mission Disk 4 - Alien Navigator" },
+	{ "id4p5",      "iD4 Mission Disk 5 - Captain Steve Hiller" },
+	{ "id4p6",      "iD4 Mission Disk 6 - Dave's Computer" },
+	{ "id4p7",      "iD4 Mission Disk 7 - President Whitmore" },
+	{ "id4p8",      "iD4 Mission Disk 8 - Alien Attack Fighter" },
+	{ "id4p9",      "iD4 Mission Disk 9 - FA-18 Fighter Jet" },
+	{ "id4p10",     "iD4 Mission Disk 10 - Alien Bomber" },
+	{ "id4p11",     "iD4 Mission Disk 11 - Area 51" },
+	{ "chopsuey",   "Chop Suey" },
 	{ 0, 0 }
 };
 
@@ -181,6 +193,7 @@ ADDetectedGame DirectorMetaEngine::fallbackDetect(const FileMap &allFiles, const
 		uint32 tag = f.readUint32LE();
 
 		switch (tag) {
+		case MKTAG('P', 'J', '9', '3'):
 		case MKTAG('3', '9', 'J', 'P'):
 			desc->version = 4;
 			break;

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -235,17 +235,17 @@ static const DirectorGameDescription gameDescriptions[] = {
 		5
 	},
 
-	WINGAME("id4p1", "iD4 Mission Disk 1 - Alien Supreme Commander", "SUPREME.EXE", "34dcf97e16d6e105457440670c59e8dc", 1664965, 4),
-	WINGAME("id4p2", "iD4 Mission Disk 2 - Alien Science Officer", "SCIENCE.EXE", "c292846d0e1e6ed097e70b2e6c839743", 1766499, 4),
-	WINGAME("id4p3", "iD4 Mission Disk 3 - Warrior Alien", "WARRIOR.EXE", "16dd439a92eb34013a61e279c9d1e252", 1751593, 4),
-	WINGAME("id4p4", "iD4 Mission Disk 4 - Alien Navigator", "NAV.EXE", "d0c271bf4c51ed1dfcb924d13d47c3ce", 1834037, 4),
-	WINGAME("id4p5", "iD4 Mission Disk 5 - Captain Steve Hiller", "STEVE.EXE", "f871258cf9aeaac98770c7b117802b13", 1797301, 4),
-	WINGAME("id4p6", "iD4 Mission Disk 6 - Dave's Computer", "DAVE.EXE", "71c38258c6b59489b0024b959c7a55f1", 1774167, 4),
-	WINGAME("id4p7", "iD4 Mission Disk 7 - President Whitmore", "PREZ.EXE", "b88abd91f8c78bfb4c46dd1214938a23", 1666293, 4),
-	WINGAME("id4p8", "iD4 Mission Disk 8 - Alien Attack Fighter", "ALIEN_F.EXE", "3539ef55c384275753401454991441d0", 1754975, 4),
-	WINGAME("id4p9", "iD4 Mission Disk 9 - FA-18 Fighter Jet", "F18.EXE", "70ff3dc89e38aa87a460394434837e49", 1691893, 4),
-	WINGAME("id4p10", "iD4 Mission Disk 10 - Alien Bomber", "BOMBER.EXE", "04a0130ea83c80b090d1c52dd4ec9f36", 1844189, 4),
-	WINGAME("id4p11", "iD4 Mission Disk 11 - Area 51", "AREA51.EXE", "8c7a6325ca41b52ce349c9a31bc17526", 1776077, 4),
+	WINGAME("id4p1", "iD4 Mission Disk 1 - Alien Supreme Commander", "SUPREME.EXE", "629eb9a5d991a2dbe380804e8c37043a", 1664965, 4),
+	WINGAME("id4p2", "iD4 Mission Disk 2 - Alien Science Officer", "SCIENCE.EXE", "812a4b81b70e61e547c14dbbd507b402", 1766499, 4),
+	WINGAME("id4p3", "iD4 Mission Disk 3 - Warrior Alien", "WARRIOR.EXE", "387245092ce0583c6fd0c54000b1502a", 1751593, 4),
+	WINGAME("id4p4", "iD4 Mission Disk 4 - Alien Navigator", "NAV.EXE", "29de2d1fd34029b3c97ce852a7fc665e", 1834037, 4),
+	WINGAME("id4p5", "iD4 Mission Disk 5 - Captain Steve Hiller", "STEVE.EXE", "14f19b724dd6361e4bf3cfddbac87d3f", 1797301, 4),
+	WINGAME("id4p6", "iD4 Mission Disk 6 - Dave's Computer", "DAVE.EXE", "237f9db2ea9a38fa6f7292974539f494", 1774167, 4),
+	WINGAME("id4p7", "iD4 Mission Disk 7 - President Whitmore", "PREZ.EXE", "e7d03a6d749d65dbcea7171ec4627e9c", 1666293, 4),
+	WINGAME("id4p8", "iD4 Mission Disk 8 - Alien Attack Fighter", "ALIEN_F.EXE", "ee2eb92900d515ed7872c57f3b89a408", 1754975, 4),
+	WINGAME("id4p9", "iD4 Mission Disk 9 - FA-18 Fighter Jet", "F18.EXE", "7a0292909a5103c89297c40cce1d836c", 1691893, 4),
+	WINGAME("id4p10", "iD4 Mission Disk 10 - Alien Bomber", "BOMBER.EXE", "17758a9f425f7f3e7a926951e6c770f4", 1844189, 4),
+	WINGAME("id4p11", "iD4 Mission Disk 11 - Area 51", "AREA51.EXE", "78be40f9c7e8e1770c388cc16a522aaf", 1776077, 4),
 
 	WINGAME("chopsuey", "Chop Suey", "CHOPSUEY.EXE", "785e26240153a028549e8a66c2e904bf", 772382, 4),
 

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -235,6 +235,20 @@ static const DirectorGameDescription gameDescriptions[] = {
 		5
 	},
 
+	WINGAME("id4p1", "iD4 Mission Disk 1 - Alien Supreme Commander", "SUPREME.EXE", "34dcf97e16d6e105457440670c59e8dc", 1664965, 4),
+	WINGAME("id4p2", "iD4 Mission Disk 2 - Alien Science Officer", "SCIENCE.EXE", "c292846d0e1e6ed097e70b2e6c839743", 1766499, 4),
+	WINGAME("id4p3", "iD4 Mission Disk 3 - Warrior Alien", "WARRIOR.EXE", "16dd439a92eb34013a61e279c9d1e252", 1751593, 4),
+	WINGAME("id4p4", "iD4 Mission Disk 4 - Alien Navigator", "NAV.EXE", "d0c271bf4c51ed1dfcb924d13d47c3ce", 1834037, 4),
+	WINGAME("id4p5", "iD4 Mission Disk 5 - Captain Steve Hiller", "STEVE.EXE", "f871258cf9aeaac98770c7b117802b13", 1797301, 4),
+	WINGAME("id4p6", "iD4 Mission Disk 6 - Dave's Computer", "DAVE.EXE", "71c38258c6b59489b0024b959c7a55f1", 1774167, 4),
+	WINGAME("id4p7", "iD4 Mission Disk 7 - President Whitmore", "PREZ.EXE", "b88abd91f8c78bfb4c46dd1214938a23", 1666293, 4),
+	WINGAME("id4p8", "iD4 Mission Disk 8 - Alien Attack Fighter", "ALIEN_F.EXE", "3539ef55c384275753401454991441d0", 1754975, 4),
+	WINGAME("id4p9", "iD4 Mission Disk 9 - FA-18 Fighter Jet", "F18.EXE", "70ff3dc89e38aa87a460394434837e49", 1691893, 4),
+	WINGAME("id4p10", "iD4 Mission Disk 10 - Alien Bomber", "BOMBER.EXE", "04a0130ea83c80b090d1c52dd4ec9f36", 1844189, 4),
+	WINGAME("id4p11", "iD4 Mission Disk 11 - Area 51", "AREA51.EXE", "8c7a6325ca41b52ce349c9a31bc17526", 1776077, 4),
+
+	WINGAME("chopsuey", "Chop Suey", "CHOPSUEY.EXE", "785e26240153a028549e8a66c2e904bf", 772382, 4),
+
 	{ AD_TABLE_END_MARKER, GID_GENERIC, 0 }
 };
 

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -627,7 +627,7 @@ void Frame::renderSprites(Graphics::ManagedSurface &surface, bool renderTrail) {
 				int y = _sprites[i]->_startPoint.y - regY + rectTop;
 				int height = _sprites[i]->_height;
 				int width = _vm->getVersion() > 4 ? _sprites[i]->_bitmapCast->initialRect.width() : _sprites[i]->_width;
-                warning("drawRect: x=%d, y=%d, w=%d h=%d", x, y, width, height);
+				warning("drawRect: x=%d, y=%d, w=%d h=%d", x, y, width, height);
 				Common::Rect drawRect(x, y, x + width, y + height);
 				addDrawRect(i, drawRect);
 				inkBasedBlit(surface, *(_sprites[i]->_bitmapCast->surface), i, drawRect);

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -618,16 +618,16 @@ void Frame::renderSprites(Graphics::ManagedSurface &surface, bool renderTrail) {
 					continue;
 				}
 
-				uint32 regX = _sprites[i]->_bitmapCast->regX;
-				uint32 regY = _sprites[i]->_bitmapCast->regY;
-				uint32 rectLeft = _sprites[i]->_bitmapCast->initialRect.left;
-				uint32 rectTop = _sprites[i]->_bitmapCast->initialRect.top;
+				int32 regX = _sprites[i]->_bitmapCast->regX;
+				int32 regY = _sprites[i]->_bitmapCast->regY;
+				int32 rectLeft = _sprites[i]->_bitmapCast->initialRect.left;
+				int32 rectTop = _sprites[i]->_bitmapCast->initialRect.top;
 
 				int x = _sprites[i]->_startPoint.x - regX + rectLeft;
 				int y = _sprites[i]->_startPoint.y - regY + rectTop;
 				int height = _sprites[i]->_height;
 				int width = _vm->getVersion() > 4 ? _sprites[i]->_bitmapCast->initialRect.width() : _sprites[i]->_width;
-
+                warning("drawRect: x=%d, y=%d, w=%d h=%d", x, y, width, height);
 				Common::Rect drawRect(x, y, x + width, y + height);
 				addDrawRect(i, drawRect);
 				inkBasedBlit(surface, *(_sprites[i]->_bitmapCast->surface), i, drawRect);

--- a/engines/director/images.cpp
+++ b/engines/director/images.cpp
@@ -205,13 +205,8 @@ bool BITDDecoder::loadStream(Common::SeekableReadStream &stream) {
 * BITD V4+
 ****************************/
 
-BITDDecoderV4::BITDDecoderV4(int w, int h, uint16 bitsPerPixel) {
+BITDDecoderV4::BITDDecoderV4(int w, int h, uint16 bitsPerPixel, uint16 pitch) {
 	_surface = new Graphics::Surface();
-
-	// We make the surface pitch a multiple of 16.
-	int pitch = w;
-	if (w % 16)
-		pitch += 16 - (w % 16);
 
 	Graphics::PixelFormat pf = Graphics::PixelFormat::createFormatCLUT8();
 	switch (bitsPerPixel) {

--- a/engines/director/images.h
+++ b/engines/director/images.h
@@ -83,7 +83,7 @@ private:
 
 class BITDDecoderV4 : public Image::ImageDecoder {
 public:
-	BITDDecoderV4(int w, int h, uint16 bitsPerPixel);
+	BITDDecoderV4(int w, int h, uint16 bitsPerPixel, uint16 pitch);
 	virtual ~BITDDecoderV4();
 
 	// ImageDecoder API

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -237,9 +237,12 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
                 }
 
             } else {
+                // exit condition
+                if (opcode == 0x01) {
+                    offset_list.push_back(_currentScript->size());
+                    g_lingo->code1(STOP);
                 // unimplemented instruction
-
-                if (opcode < 0x40) { // 1 byte instruction
+                } else if (opcode < 0x40) { // 1 byte instruction
                     offset_list.push_back(_currentScript->size());
                     g_lingo->code1(Lingo::c_unk);
                     g_lingo->codeInt(opcode);

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -29,6 +29,7 @@ static struct LingoV4Bytecode {
 	const inst func;
 	const char *proto;
 } lingoV4[] = {
+	{ 0x01, STOP, "" },
 	{ 0x03, Lingo::c_voidpush, "" },
 	{ 0x04, Lingo::c_mul, "" },
 	{ 0x05, Lingo::c_add, "" },
@@ -56,7 +57,6 @@ static struct LingoV4Bytecode {
 	{ 0x1b, Lingo::c_field, "" },
 	{ 0x1c, Lingo::c_tell, "" },
 	{ 0x1d, Lingo::c_telldone, "" },
-	
 	{ 0x41, Lingo::c_intpush, "b" },
 	{ 0, 0, 0 }
 };
@@ -68,9 +68,7 @@ void Lingo::initBytecode() {
 }
 
 
-
-
-void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType type, uint16 id) { 
+void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType type, uint16 id) {
 	debugC(1, kDebugLingoCompile, "Add V4 bytecode for type %s with id %d", scriptType2str(type), id);
 
 	if (_scriptContexts[type].contains(id)) {
@@ -90,116 +88,118 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 	for (uint32 i = 0; i < 0x10; i++) {
 		stream.readByte();
 	}
-	uint16 code_store_offset = stream.readUint16();
+	uint16 codeStoreOffset = stream.readUint16();
 	// unk2
 	for (uint32 i = 0; i < 0x2e; i++) {
 		stream.readByte();
 	}
-	uint16 globals_offset = stream.readUint16();
-	uint16 globals_count = stream.readUint16();
+	uint16 globalsOffset = stream.readUint16();
+	uint16 globalsCount = stream.readUint16();
 	// unk3
 	for (uint32 i = 0; i < 0x4; i++) {
 		stream.readByte();
 	}
-	uint16 functions_count = stream.readUint16();
+	uint16 functionsCount = stream.readUint16();
 	stream.readUint16();
-	uint16 functions_offset = stream.readUint16();
-	uint16 consts_count = stream.readUint16();
+	uint16 functionsOffset = stream.readUint16();
+	uint16 constsCount = stream.readUint16();
 	stream.readUint16();
-	uint16 consts_offset = stream.readUint16();
+	uint16 constsOffset = stream.readUint16();
 	stream.readUint16();
 	stream.readUint16();
 	stream.readUint16();
-	uint16 consts_base = stream.readUint16();
+	uint16 constsBase = stream.readUint16();
 
 	// preload all the constants!
 	// these are stored as a reference table of 6 byte entries, followed by a storage area.
 
 	// copy the storage area first.
-	uint32 consts_store_offset = consts_offset+6*consts_count;
-	uint32 consts_store_size = stream.size()-consts_store_offset;
-	stream.seek(consts_store_offset);
-	byte *const_store = (byte *)malloc(consts_store_size);
-	stream.read(const_store, consts_store_size);
+	uint32 constsStoreOffset = constsOffset + 6 * constsCount;
+	uint32 constsStoreSize = stream.size() - constsStoreOffset;
+	stream.seek(constsStoreOffset);
+	byte *constsStore = (byte *)malloc(constsStoreSize);
+	stream.read(constsStore, constsStoreSize);
 
-	Common::Array<Datum> const_data;
+	Common::Array<Datum> constsData;
 
 	// read each entry in the reference table.
-	stream.seek(consts_offset);
-	for (uint16 i=0; i<consts_count; i++) {
+	stream.seek(constsOffset);
+	for (uint16 i=0; i < constsCount; i++) {
 		Datum constant;
-		uint16 const_type = stream.readUint16();
+		uint16 constType = stream.readUint16();
 		uint32 value = stream.readUint32();
-		switch (const_type) {
-			case 1: { // String type
-				constant.type = STRING;
-				constant.u.s = new Common::String();
-				uint32 pointer = value;
-				while (pointer < consts_store_size) {
-					if (const_store[pointer] == '\r') {
-						constant.u.s += '\n';
-					} else if (const_store[pointer] == '\0') {
-						break;
-					} else {
-						constant.u.s += const_store[pointer];
+		switch (constType) {
+			case 1: // String type
+				{
+					constant.type = STRING;
+					constant.u.s = new Common::String();
+					uint32 pointer = value;
+					while (pointer < constsStoreSize) {
+						if (constsStore[pointer] == '\r') {
+							constant.u.s += '\n';
+						} else if (constsStore[pointer] == '\0') {
+							break;
+						} else {
+							constant.u.s += constsStore[pointer];
+						}
+						pointer += 1;
 					}
-					pointer += 1;
+					if (pointer >= constsStoreSize) {
+						warning("Constant string has no null terminator");
+						break;
+					}
 				}
-				if (pointer >= consts_store_size) {
-					warning("Constant string has no null terminator");
-					break;
-				}
-			}
-			break;
+				break;
 			case 4: // Integer type
 				constant.type = INT;
 				constant.u.i = (int)value;
 				break;
-			case 9: { // Float type
-				constant.type = FLOAT;
-				if (value < consts_store_offset) {
-					warning("Constant float start offset is out of bounds");
-					break;
-				} else if (value+4 > consts_store_size) {
-					warning("Constant float end offset is out of bounds");
-					break;
+			case 9:  // Float type
+				{
+					constant.type = FLOAT;
+					if (value < constsStoreOffset) {
+						warning("Constant float start offset is out of bounds");
+						break;
+					} else if (value + 4 > constsStoreSize) {
+						warning("Constant float end offset is out of bounds");
+						break;
+					}
+					constant.u.f = *(float *)(constsStore + value);
 				}
-				constant.u.f = *(float *)(const_store+value);
-			}
-			break;
+				break;
 			default:
 				warning("Unknown constant type %d", type);
 				break;
 		}
 
-		const_data.push_back(constant);
+		constsData.push_back(constant);
 	}
-	free(const_store);
+	free(constsStore);
 
 	// parse each function!
 	// these are stored as a code storage area, followed by a reference table of 42 byte entries.
 
 	// copy the storage area first.
-	uint32 code_store_size = functions_offset - code_store_offset;
-	stream.seek(code_store_offset);
-	byte *code_store = (byte *)malloc(code_store_size);
-	stream.read(code_store, code_store_size);
+	uint32 codeStoreSize = functionsOffset - codeStoreOffset;
+	stream.seek(codeStoreOffset);
+	byte *codeStore = (byte *)malloc(codeStoreSize);
+	stream.read(codeStore, codeStoreSize);
 
 	// read each entry in the function table.
-	stream.seek(functions_offset);
-	for (uint16 i=0; i<functions_count; i++) {
+	stream.seek(functionsOffset);
+	for (uint16 i=0; i<functionsCount; i++) {
 		_currentScriptFunction = i;
 		_currentScriptContext->functions.push_back(new ScriptData);
 		_currentScript = _currentScriptContext->functions[_currentScriptFunction];
 
-		uint16 name_index = stream.readUint16();
+		uint16 nameIndex = stream.readUint16();
 		stream.readUint16();
 		uint32 length = stream.readUint32();
-		uint32 start_offset = stream.readUint32();
-		uint16 arg_count = stream.readUint16();
-		uint32 arg_offset = stream.readUint32();
-		uint16 var_count = stream.readUint16();
-		uint32 var_names_offset = stream.readUint32();
+		uint32 startOffset = stream.readUint32();
+		uint16 argCount = stream.readUint16();
+		uint32 argOffset = stream.readUint32();
+		uint16 varCount = stream.readUint16();
+		uint32 varNamesOffset = stream.readUint32();
 		stream.readUint16();
 		stream.readUint16();
 		stream.readUint16();
@@ -210,35 +210,35 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 		stream.readUint16();
 		stream.readUint16();
 
-		if (start_offset < code_store_offset) {
+		if (startOffset < codeStoreOffset) {
 			warning("Function %d start offset is out of bounds!", i);
 			continue;
-		} else if (start_offset + length >= code_store_offset + code_store_size) {
+		} else if (startOffset + length >= codeStoreOffset + codeStoreSize) {
 			warning("Function %d end offset is out of bounds", i);
 			continue;
 		}
 
-		uint16 pointer = start_offset-code_store_offset;
-		Common::Array<uint32> offset_list;
-		while (pointer < start_offset+length-code_store_offset) {
-			uint8 opcode = code_store[pointer];
+		uint16 pointer = startOffset - codeStoreOffset;
+		Common::Array<uint32> offsetList;
+		while (pointer < startOffset + length - codeStoreOffset) {
+			uint8 opcode = codeStore[pointer];
 
 			pointer += 1;
 			if (_lingoV4.contains(opcode)) {
-				offset_list.push_back(_currentScript->size());
+				offsetList.push_back(_currentScript->size());
 				g_lingo->code1(_lingoV4[opcode]->func);
 				size_t argc = strlen(_lingoV4[opcode]->proto);
-				for (uint c=0; c<argc; c++) {
+				for (uint c=0; c < argc; c++) {
 					switch (_lingoV4[opcode]->proto[c]) {
 						case 'b':
-							offset_list.push_back(_currentScript->size());
-							g_lingo->codeInt((int8)code_store[pointer]);
+							offsetList.push_back(_currentScript->size());
+							g_lingo->codeInt((int8)codeStore[pointer]);
 							pointer += 1;
 							break;
 						case 'w':
-							offset_list.push_back(_currentScript->size());
-							offset_list.push_back(_currentScript->size());
-							g_lingo->codeInt((int16)READ_UINT16(&code_store[pointer]));
+							offsetList.push_back(_currentScript->size());
+							offsetList.push_back(_currentScript->size());
+							g_lingo->codeInt((int16)READ_UINT16(&codeStore[pointer]));
 							pointer += 2;
 							break;
 						default:
@@ -247,37 +247,33 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 				}
 
 			} else {
-				// exit condition
-				if (opcode == 0x01) {
-					offset_list.push_back(_currentScript->size());
-					g_lingo->code1(STOP);
 				// unimplemented instruction
-				} else if (opcode < 0x40) { // 1 byte instruction
-					offset_list.push_back(_currentScript->size());
+				if (opcode < 0x40) { // 1 byte instruction
+					offsetList.push_back(_currentScript->size());
 					g_lingo->code1(Lingo::c_unk);
 					g_lingo->codeInt(opcode);
 				} else if (opcode < 0x80) { // 2 byte instruction
-					offset_list.push_back(_currentScript->size());
+					offsetList.push_back(_currentScript->size());
 					g_lingo->code1(Lingo::c_unk1);
 					g_lingo->codeInt(opcode);
-					offset_list.push_back(_currentScript->size());
-					g_lingo->codeInt((uint)code_store[pointer]);
+					offsetList.push_back(_currentScript->size());
+					g_lingo->codeInt((uint)codeStore[pointer]);
 					pointer += 1;
 				} else { // 3 byte instruction
-					offset_list.push_back(_currentScript->size());
+					offsetList.push_back(_currentScript->size());
 					g_lingo->code1(Lingo::c_unk2);
 					g_lingo->codeInt(opcode);
-					offset_list.push_back(_currentScript->size());
-					g_lingo->codeInt((uint)code_store[pointer]);
-					offset_list.push_back(_currentScript->size());
-					g_lingo->codeInt((uint)code_store[pointer+1]);
+					offsetList.push_back(_currentScript->size());
+					g_lingo->codeInt((uint)codeStore[pointer]);
+					offsetList.push_back(_currentScript->size());
+					g_lingo->codeInt((uint)codeStore[pointer+1]);
 					pointer += 2;
 				}
 			}
 		}
 
 	}
-	free(code_store);
+	free(codeStore);
 }
 
 

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -25,45 +25,62 @@
 namespace Director {
 
 static struct LingoV4Bytecode {
-    const char opcode;
+    const uint8 opcode;
     const inst func;
+    const char *args;
 } lingoV4[] = {
-    { 0x03, Lingo::c_voidpush },
-    { 0x04, Lingo::c_mul },
-    { 0x05, Lingo::c_add },
-    { 0x06, Lingo::c_sub },
-    { 0x07, Lingo::c_div },
-    { 0x08, Lingo::c_mod },
-    { 0x09, Lingo::c_negate },
-    { 0x0a, Lingo::c_ampersand },
-    { 0x0b, Lingo::c_concat },
-    { 0x0c, Lingo::c_lt },
-    { 0x0d, Lingo::c_le },
-    { 0x0e, Lingo::c_neq },
-    { 0x0f, Lingo::c_eq },
-    { 0x10, Lingo::c_gt },
-    { 0x11, Lingo::c_ge },
-    { 0x12, Lingo::c_and },
-    { 0x13, Lingo::c_or },
-    { 0x14, Lingo::c_not },
-    { 0x15, Lingo::c_contains },
-    { 0x16, Lingo::c_starts },
-    { 0x17, Lingo::c_of },
-    { 0x18, Lingo::c_hilite }, 
-    { 0x19, Lingo::c_intersects },
-    { 0x1a, Lingo::c_within },
-    { 0x1b, Lingo::c_field },
-    { 0x1c, Lingo::c_tell },
-    { 0x1d, Lingo::c_telldone },
+    { 0x03, Lingo::c_voidpush, "" },
+    { 0x04, Lingo::c_mul, "" },
+    { 0x05, Lingo::c_add, "" },
+    { 0x06, Lingo::c_sub, "" },
+    { 0x07, Lingo::c_div, "" },
+    { 0x08, Lingo::c_mod, "" },
+    { 0x09, Lingo::c_negate, "" },
+    { 0x0a, Lingo::c_ampersand, "" },
+    { 0x0b, Lingo::c_concat, "" },
+    { 0x0c, Lingo::c_lt, "" },
+    { 0x0d, Lingo::c_le, "" },
+    { 0x0e, Lingo::c_neq, "" },
+    { 0x0f, Lingo::c_eq, "" },
+    { 0x10, Lingo::c_gt, "" },
+    { 0x11, Lingo::c_ge, "" },
+    { 0x12, Lingo::c_and, "" },
+    { 0x13, Lingo::c_or, "" },
+    { 0x14, Lingo::c_not, "" },
+    { 0x15, Lingo::c_contains, "" },
+    { 0x16, Lingo::c_starts, "" },
+    { 0x17, Lingo::c_of, "" },
+    { 0x18, Lingo::c_hilite, "" },
+    { 0x19, Lingo::c_intersects, "" },
+    { 0x1a, Lingo::c_within, "" },
+    { 0x1b, Lingo::c_field, "" },
+    { 0x1c, Lingo::c_tell, "" },
+    { 0x1d, Lingo::c_telldone, "" },
     
-    { 0x41, Lingo::c_intpush },
-    { 0, 0 }
+    { 0x41, Lingo::c_intpush, "b" },
+    { 0, 0, 0 }
 };
+
+void Lingo::initBytecode() {
+    for (LingoV4Bytecode *op = lingoV4; op->opcode; op++) {
+        _lingoV4[op->opcode] = new Opcode( op->func, op->args );
+    }
+}
 
 
 void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType type, uint16 id) { 
 	debugC(1, kDebugLingoCompile, "Add V4 bytecode for type %s with id %d", scriptType2str(type), id);
 
+	if (_scripts[type].contains(id)) {
+		delete _scripts[type][id];
+	}
+
+	_currentScript = new ScriptData;
+	_currentScriptType = type;
+	_scripts[type][id] = _currentScript;
+	_currentEntityId = id;
+
+    // read the Lscr header!
     // unk1
     for (uint32 i = 0; i < 0x10; i++) {
         stream.readByte();
@@ -88,9 +105,164 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
     uint16 unk6 = stream.readUint16();
     stream.readUint16();
     uint16 consts_base = stream.readUint16();
-    
-    // preload all the constants
+
+    // preload all the constants!
+    // these are stored as a reference table of 6 byte entries, followed by a storage area.
+
+    // copy the storage area first.
+    uint32 consts_store_offset = consts_offset+6*consts_count;
+    uint32 consts_store_size = stream.size()-consts_store_offset;
+    stream.seek(consts_store_offset);
+    byte *const_store = (byte *)malloc(consts_store_size);
+    stream.read(const_store, consts_store_size);
+
+    Common::Array<Datum> const_data;
+
+    // read each entry in the reference table.
     stream.seek(consts_offset);
+    for (uint16 i=0; i<consts_count; i++) {
+        Datum constant;
+        uint16 const_type = stream.readUint16();
+        uint32 value = stream.readUint32();
+        switch (const_type) {
+            case 1: { // String type
+                constant.type = STRING;
+                constant.u.s = new Common::String();
+                if (value < consts_store_offset) {
+                    warning("Constant string start offset is out of bounds!");
+                    break;
+                }
+                uint32 pointer = value - consts_store_offset;
+                while (pointer < consts_store_size) {
+                    if (const_store[pointer] == '\r') {
+                        constant.u.s += '\n';
+                    } else if (const_store[pointer] == '\0') {
+                        break;
+                    } else {
+                        constant.u.s += const_store[pointer];
+                    }
+                    pointer += 1;
+                }
+                if (pointer == consts_store_size) {
+                    warning("Constant string has no null terminator!");
+                    break;
+                }
+            }
+            break;
+            case 4: // Integer type
+                constant.type = INT;
+                constant.u.i = (int)value;
+                break;
+            case 9: { // Float type
+                constant.type = FLOAT;
+                if (value < consts_store_offset) {
+                    warning("Constant float start offset is out of bounds!");
+                    break;
+                } else if (value+4 > consts_store_offset + consts_store_size) {
+                    warning("Constant float end offset is out of bounds!");
+                    break;
+                }
+                constant.u.f = *(float *)(const_store+value-consts_store_offset);
+            }
+            break;
+            default:
+                warning("Unknown constant type %d", type);
+                break;
+        }
+
+        const_data.push_back(constant);
+    }
+    free(const_store);
+
+    // parse each function!
+    // these are stored as a code storage area, followed by a reference table of 42 byte entries.
+
+    // copy the storage area first.
+    uint32 code_store_size = functions_offset - code_store_offset;
+    stream.seek(code_store_offset);
+    byte *code_store = (byte *)malloc(code_store_size);
+    stream.read(code_store, code_store_size);
+
+    // read each entry in the function table.
+    stream.seek(functions_offset);
+    for (uint16 i=0; i<functions_count; i++) {
+        stream.readUint16();
+        stream.readUint16();
+        stream.readUint16();
+        stream.readUint16();
+        stream.readUint16();
+        stream.readUint16();
+        uint16 arg_count = stream.readUint16();
+        stream.readUint16();
+        stream.readUint16();
+        uint16 var_count = stream.readUint16();
+        stream.readUint16();
+        stream.readUint16();
+        uint16 name_index = stream.readUint16();
+        stream.readUint16();
+        stream.readUint16();
+        uint16 length = stream.readUint16();
+        stream.readUint16();
+        uint16 start_offset = stream.readUint16();
+        stream.readUint16();
+        stream.readUint16();
+        uint16 end_offset = stream.readUint16();
+
+        if (start_offset < code_store_offset) {
+            warning("Function %d start offset is out of bounds!", i);
+            continue;
+        } else if (end_offset >= code_store_offset+code_store_size) {
+            warning("Function %d end offset is out of bounds!", i);
+            continue;
+        }
+
+        uint32 pointer = start_offset-code_store_offset;
+        Common::Array<uint32> offset_list;
+        while (pointer < end_offset-code_store_offset) {
+            uint8 opcode = code_store[pointer];
+
+            pointer += 1;
+            if (_lingoV4.contains(opcode)) {
+                offset_list.push_back(_currentScript->size());
+                _currentScript->push_back(_lingoV4[opcode]->func);
+
+            } else {
+                // unimplemented instruction
+                inst op_value = 0;
+                WRITE_UINT32(&op_value, opcode);
+
+                if (opcode < 0x40) {
+                    offset_list.push_back(_currentScript->size());
+                    _currentScript->push_back(Lingo::c_nop);
+                    _currentScript->push_back(op_value);
+                } else if (opcode < 0x80) {
+                    offset_list.push_back(_currentScript->size());
+                    _currentScript->push_back(Lingo::c_nop1);
+                    _currentScript->push_back(op_value);
+                    inst arg1 = 0;
+                    WRITE_UINT32(&arg1, code_store[pointer]);
+                    offset_list.push_back(_currentScript->size());
+                    _currentScript->push_back(arg1);
+                    pointer += 1;
+                } else {
+                    offset_list.push_back(_currentScript->size());
+                    _currentScript->push_back(Lingo::c_nop2);
+                    _currentScript->push_back(op_value);
+                    inst arg1 = 0;
+                    WRITE_UINT32(&arg1, code_store[pointer]);
+                    offset_list.push_back(_currentScript->size());
+                    _currentScript->push_back(arg1);
+                    inst arg2 = 0;
+                    WRITE_UINT32(&arg2, code_store[pointer+1]);
+                    offset_list.push_back(_currentScript->size());
+                    _currentScript->push_back(arg2);
+                    pointer += 2;
+                }
+            }
+        }
+
+    }
+
 }
 
 }

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -93,14 +93,15 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 	for (uint32 i = 0; i < 0x2e; i++) {
 		stream.readByte();
 	}
-	uint16 functions_offset = stream.readUint16();
+	uint16 globals_offset = stream.readUint16();
+	uint16 globals_count = stream.readUint16();
 	// unk3
-	for (uint32 i = 0; i < 0x6; i++) {
+	for (uint32 i = 0; i < 0x4; i++) {
 		stream.readByte();
 	}
 	uint16 functions_count = stream.readUint16();
 	stream.readUint16();
-	stream.readUint16();
+	uint16 functions_offset = stream.readUint16();
 	uint16 consts_count = stream.readUint16();
 	stream.readUint16();
 	uint16 consts_offset = stream.readUint16();

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -25,46 +25,46 @@
 namespace Director {
 
 static struct LingoV4Bytecode {
-    const uint8 opcode;
-    const inst func;
-    const char *proto;
+	const uint8 opcode;
+	const inst func;
+	const char *proto;
 } lingoV4[] = {
-    { 0x03, Lingo::c_voidpush, "" },
-    { 0x04, Lingo::c_mul, "" },
-    { 0x05, Lingo::c_add, "" },
-    { 0x06, Lingo::c_sub, "" },
-    { 0x07, Lingo::c_div, "" },
-    { 0x08, Lingo::c_mod, "" },
-    { 0x09, Lingo::c_negate, "" },
-    { 0x0a, Lingo::c_ampersand, "" },
-    { 0x0b, Lingo::c_concat, "" },
-    { 0x0c, Lingo::c_lt, "" },
-    { 0x0d, Lingo::c_le, "" },
-    { 0x0e, Lingo::c_neq, "" },
-    { 0x0f, Lingo::c_eq, "" },
-    { 0x10, Lingo::c_gt, "" },
-    { 0x11, Lingo::c_ge, "" },
-    { 0x12, Lingo::c_and, "" },
-    { 0x13, Lingo::c_or, "" },
-    { 0x14, Lingo::c_not, "" },
-    { 0x15, Lingo::c_contains, "" },
-    { 0x16, Lingo::c_starts, "" },
-    { 0x17, Lingo::c_of, "" },
-    { 0x18, Lingo::c_hilite, "" },
-    { 0x19, Lingo::c_intersects, "" },
-    { 0x1a, Lingo::c_within, "" },
-    { 0x1b, Lingo::c_field, "" },
-    { 0x1c, Lingo::c_tell, "" },
-    { 0x1d, Lingo::c_telldone, "" },
-    
-    { 0x41, Lingo::c_intpush, "b" },
-    { 0, 0, 0 }
+	{ 0x03, Lingo::c_voidpush, "" },
+	{ 0x04, Lingo::c_mul, "" },
+	{ 0x05, Lingo::c_add, "" },
+	{ 0x06, Lingo::c_sub, "" },
+	{ 0x07, Lingo::c_div, "" },
+	{ 0x08, Lingo::c_mod, "" },
+	{ 0x09, Lingo::c_negate, "" },
+	{ 0x0a, Lingo::c_ampersand, "" },
+	{ 0x0b, Lingo::c_concat, "" },
+	{ 0x0c, Lingo::c_lt, "" },
+	{ 0x0d, Lingo::c_le, "" },
+	{ 0x0e, Lingo::c_neq, "" },
+	{ 0x0f, Lingo::c_eq, "" },
+	{ 0x10, Lingo::c_gt, "" },
+	{ 0x11, Lingo::c_ge, "" },
+	{ 0x12, Lingo::c_and, "" },
+	{ 0x13, Lingo::c_or, "" },
+	{ 0x14, Lingo::c_not, "" },
+	{ 0x15, Lingo::c_contains, "" },
+	{ 0x16, Lingo::c_starts, "" },
+	{ 0x17, Lingo::c_of, "" },
+	{ 0x18, Lingo::c_hilite, "" },
+	{ 0x19, Lingo::c_intersects, "" },
+	{ 0x1a, Lingo::c_within, "" },
+	{ 0x1b, Lingo::c_field, "" },
+	{ 0x1c, Lingo::c_tell, "" },
+	{ 0x1d, Lingo::c_telldone, "" },
+	
+	{ 0x41, Lingo::c_intpush, "b" },
+	{ 0, 0, 0 }
 };
 
 void Lingo::initBytecode() {
-    for (LingoV4Bytecode *op = lingoV4; op->opcode; op++) {
-        _lingoV4[op->opcode] = new Opcode( op->func, op->proto );
-    }
+	for (LingoV4Bytecode *op = lingoV4; op->opcode; op++) {
+		_lingoV4[op->opcode] = new Opcode( op->func, op->proto );
+	}
 }
 
 
@@ -73,208 +73,208 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 
 	if (_scriptContexts[type].contains(id)) {
 		for (size_t j = 0; j < _scriptContexts[type][id]->functions.size(); j++) {
-            delete _scriptContexts[type][id]->functions[j];
-        }
-        delete _scriptContexts[type][id];
+			delete _scriptContexts[type][id]->functions[j];
+		}
+		delete _scriptContexts[type][id];
 	}
 
-    _currentScriptContext = new ScriptContext;
-    _currentScriptType = type;
-    _currentEntityId = id;
-    _scriptContexts[type][id] = _currentScriptContext;
+	_currentScriptContext = new ScriptContext;
+	_currentScriptType = type;
+	_currentEntityId = id;
+	_scriptContexts[type][id] = _currentScriptContext;
 
-    // read the Lscr header!
-    // unk1
-    for (uint32 i = 0; i < 0x10; i++) {
-        stream.readByte();
-    }
-    uint16 code_store_offset = stream.readUint16();
-    // unk2
-    for (uint32 i = 0; i < 0x2e; i++) {
-        stream.readByte();
-    }
-    uint16 functions_offset = stream.readUint16();
-    // unk3
-    for (uint32 i = 0; i < 0x6; i++) {
-        stream.readByte();
-    }
-    uint16 functions_count = stream.readUint16();
-    stream.readUint16();
-    stream.readUint16();
-    uint16 consts_count = stream.readUint16();
-    stream.readUint16();
-    uint16 consts_offset = stream.readUint16();
-    stream.readUint16();
-    stream.readUint16();
-    stream.readUint16();
-    uint16 consts_base = stream.readUint16();
+	// read the Lscr header!
+	// unk1
+	for (uint32 i = 0; i < 0x10; i++) {
+		stream.readByte();
+	}
+	uint16 code_store_offset = stream.readUint16();
+	// unk2
+	for (uint32 i = 0; i < 0x2e; i++) {
+		stream.readByte();
+	}
+	uint16 functions_offset = stream.readUint16();
+	// unk3
+	for (uint32 i = 0; i < 0x6; i++) {
+		stream.readByte();
+	}
+	uint16 functions_count = stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	uint16 consts_count = stream.readUint16();
+	stream.readUint16();
+	uint16 consts_offset = stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	uint16 consts_base = stream.readUint16();
 
-    // preload all the constants!
-    // these are stored as a reference table of 6 byte entries, followed by a storage area.
+	// preload all the constants!
+	// these are stored as a reference table of 6 byte entries, followed by a storage area.
 
-    // copy the storage area first.
-    uint32 consts_store_offset = consts_offset+6*consts_count;
-    uint32 consts_store_size = stream.size()-consts_store_offset;
-    stream.seek(consts_store_offset);
-    byte *const_store = (byte *)malloc(consts_store_size);
-    stream.read(const_store, consts_store_size);
+	// copy the storage area first.
+	uint32 consts_store_offset = consts_offset+6*consts_count;
+	uint32 consts_store_size = stream.size()-consts_store_offset;
+	stream.seek(consts_store_offset);
+	byte *const_store = (byte *)malloc(consts_store_size);
+	stream.read(const_store, consts_store_size);
 
-    Common::Array<Datum> const_data;
+	Common::Array<Datum> const_data;
 
-    // read each entry in the reference table.
-    stream.seek(consts_offset);
-    for (uint16 i=0; i<consts_count; i++) {
-        Datum constant;
-        uint16 const_type = stream.readUint16();
-        uint32 value = stream.readUint32();
-        switch (const_type) {
-            case 1: { // String type
-                constant.type = STRING;
-                constant.u.s = new Common::String();
-                uint32 pointer = value;
-                while (pointer < consts_store_size) {
-                    if (const_store[pointer] == '\r') {
-                        constant.u.s += '\n';
-                    } else if (const_store[pointer] == '\0') {
-                        break;
-                    } else {
-                        constant.u.s += const_store[pointer];
-                    }
-                    pointer += 1;
-                }
-                if (pointer >= consts_store_size) {
-                    warning("Constant string has no null terminator");
-                    break;
-                }
-            }
-            break;
-            case 4: // Integer type
-                constant.type = INT;
-                constant.u.i = (int)value;
-                break;
-            case 9: { // Float type
-                constant.type = FLOAT;
-                if (value < consts_store_offset) {
-                    warning("Constant float start offset is out of bounds");
-                    break;
-                } else if (value+4 > consts_store_size) {
-                    warning("Constant float end offset is out of bounds");
-                    break;
-                }
-                constant.u.f = *(float *)(const_store+value);
-            }
-            break;
-            default:
-                warning("Unknown constant type %d", type);
-                break;
-        }
+	// read each entry in the reference table.
+	stream.seek(consts_offset);
+	for (uint16 i=0; i<consts_count; i++) {
+		Datum constant;
+		uint16 const_type = stream.readUint16();
+		uint32 value = stream.readUint32();
+		switch (const_type) {
+			case 1: { // String type
+				constant.type = STRING;
+				constant.u.s = new Common::String();
+				uint32 pointer = value;
+				while (pointer < consts_store_size) {
+					if (const_store[pointer] == '\r') {
+						constant.u.s += '\n';
+					} else if (const_store[pointer] == '\0') {
+						break;
+					} else {
+						constant.u.s += const_store[pointer];
+					}
+					pointer += 1;
+				}
+				if (pointer >= consts_store_size) {
+					warning("Constant string has no null terminator");
+					break;
+				}
+			}
+			break;
+			case 4: // Integer type
+				constant.type = INT;
+				constant.u.i = (int)value;
+				break;
+			case 9: { // Float type
+				constant.type = FLOAT;
+				if (value < consts_store_offset) {
+					warning("Constant float start offset is out of bounds");
+					break;
+				} else if (value+4 > consts_store_size) {
+					warning("Constant float end offset is out of bounds");
+					break;
+				}
+				constant.u.f = *(float *)(const_store+value);
+			}
+			break;
+			default:
+				warning("Unknown constant type %d", type);
+				break;
+		}
 
-        const_data.push_back(constant);
-    }
-    free(const_store);
+		const_data.push_back(constant);
+	}
+	free(const_store);
 
-    // parse each function!
-    // these are stored as a code storage area, followed by a reference table of 42 byte entries.
+	// parse each function!
+	// these are stored as a code storage area, followed by a reference table of 42 byte entries.
 
-    // copy the storage area first.
-    uint32 code_store_size = functions_offset - code_store_offset;
-    stream.seek(code_store_offset);
-    byte *code_store = (byte *)malloc(code_store_size);
-    stream.read(code_store, code_store_size);
+	// copy the storage area first.
+	uint32 code_store_size = functions_offset - code_store_offset;
+	stream.seek(code_store_offset);
+	byte *code_store = (byte *)malloc(code_store_size);
+	stream.read(code_store, code_store_size);
 
-    // read each entry in the function table.
-    stream.seek(functions_offset);
-    for (uint16 i=0; i<functions_count; i++) {
-        _currentScriptFunction = i;
-        _currentScriptContext->functions.push_back(new ScriptData);
-        _currentScript = _currentScriptContext->functions[_currentScriptFunction];
+	// read each entry in the function table.
+	stream.seek(functions_offset);
+	for (uint16 i=0; i<functions_count; i++) {
+		_currentScriptFunction = i;
+		_currentScriptContext->functions.push_back(new ScriptData);
+		_currentScript = _currentScriptContext->functions[_currentScriptFunction];
 
-        uint16 name_index = stream.readUint16();
-        stream.readUint16();
-        uint32 length = stream.readUint32();
-        uint32 start_offset = stream.readUint32();
-        uint16 arg_count = stream.readUint16();
-        uint32 arg_offset = stream.readUint32();
-        uint16 var_count = stream.readUint16();
-        uint32 var_names_offset = stream.readUint32();
-        stream.readUint16();
-        stream.readUint16();
-        stream.readUint16();
-        stream.readUint16();
-        stream.readUint16();
-        stream.readUint16();
-        stream.readUint16();
-        stream.readUint16();
-        stream.readUint16();
+		uint16 name_index = stream.readUint16();
+		stream.readUint16();
+		uint32 length = stream.readUint32();
+		uint32 start_offset = stream.readUint32();
+		uint16 arg_count = stream.readUint16();
+		uint32 arg_offset = stream.readUint32();
+		uint16 var_count = stream.readUint16();
+		uint32 var_names_offset = stream.readUint32();
+		stream.readUint16();
+		stream.readUint16();
+		stream.readUint16();
+		stream.readUint16();
+		stream.readUint16();
+		stream.readUint16();
+		stream.readUint16();
+		stream.readUint16();
+		stream.readUint16();
 
-        if (start_offset < code_store_offset) {
-            warning("Function %d start offset is out of bounds!", i);
-            continue;
-        } else if (start_offset + length >= code_store_offset + code_store_size) {
-            warning("Function %d end offset is out of bounds", i);
-            continue;
-        }
+		if (start_offset < code_store_offset) {
+			warning("Function %d start offset is out of bounds!", i);
+			continue;
+		} else if (start_offset + length >= code_store_offset + code_store_size) {
+			warning("Function %d end offset is out of bounds", i);
+			continue;
+		}
 
-        uint16 pointer = start_offset-code_store_offset;
-        Common::Array<uint32> offset_list;
-        while (pointer < start_offset+length-code_store_offset) {
-            uint8 opcode = code_store[pointer];
+		uint16 pointer = start_offset-code_store_offset;
+		Common::Array<uint32> offset_list;
+		while (pointer < start_offset+length-code_store_offset) {
+			uint8 opcode = code_store[pointer];
 
-            pointer += 1;
-            if (_lingoV4.contains(opcode)) {
-                offset_list.push_back(_currentScript->size());
-                g_lingo->code1(_lingoV4[opcode]->func);
-                size_t argc = strlen(_lingoV4[opcode]->proto);
-                for (uint c=0; c<argc; c++) {
-                    switch (_lingoV4[opcode]->proto[c]) {
-                        case 'b':
-                            offset_list.push_back(_currentScript->size());
-                            g_lingo->codeInt((int8)code_store[pointer]);
-                            pointer += 1;
-                            break;
-                        case 'w':
-                            offset_list.push_back(_currentScript->size());
-                            offset_list.push_back(_currentScript->size());
-                            g_lingo->codeInt((int16)READ_UINT16(&code_store[pointer]));
-                            pointer += 2;
-                            break;
-                        default:
-                            break;
-                    }
-                }
+			pointer += 1;
+			if (_lingoV4.contains(opcode)) {
+				offset_list.push_back(_currentScript->size());
+				g_lingo->code1(_lingoV4[opcode]->func);
+				size_t argc = strlen(_lingoV4[opcode]->proto);
+				for (uint c=0; c<argc; c++) {
+					switch (_lingoV4[opcode]->proto[c]) {
+						case 'b':
+							offset_list.push_back(_currentScript->size());
+							g_lingo->codeInt((int8)code_store[pointer]);
+							pointer += 1;
+							break;
+						case 'w':
+							offset_list.push_back(_currentScript->size());
+							offset_list.push_back(_currentScript->size());
+							g_lingo->codeInt((int16)READ_UINT16(&code_store[pointer]));
+							pointer += 2;
+							break;
+						default:
+							break;
+					}
+				}
 
-            } else {
-                // exit condition
-                if (opcode == 0x01) {
-                    offset_list.push_back(_currentScript->size());
-                    g_lingo->code1(STOP);
-                // unimplemented instruction
-                } else if (opcode < 0x40) { // 1 byte instruction
-                    offset_list.push_back(_currentScript->size());
-                    g_lingo->code1(Lingo::c_unk);
-                    g_lingo->codeInt(opcode);
-                } else if (opcode < 0x80) { // 2 byte instruction
-                    offset_list.push_back(_currentScript->size());
-                    g_lingo->code1(Lingo::c_unk1);
-                    g_lingo->codeInt(opcode);
-                    offset_list.push_back(_currentScript->size());
-                    g_lingo->codeInt((uint)code_store[pointer]);
-                    pointer += 1;
-                } else { // 3 byte instruction
-                    offset_list.push_back(_currentScript->size());
-                    g_lingo->code1(Lingo::c_unk2);
-                    g_lingo->codeInt(opcode);
-                    offset_list.push_back(_currentScript->size());
-                    g_lingo->codeInt((uint)code_store[pointer]);
-                    offset_list.push_back(_currentScript->size());
-                    g_lingo->codeInt((uint)code_store[pointer+1]);
-                    pointer += 2;
-                }
-            }
-        }
+			} else {
+				// exit condition
+				if (opcode == 0x01) {
+					offset_list.push_back(_currentScript->size());
+					g_lingo->code1(STOP);
+				// unimplemented instruction
+				} else if (opcode < 0x40) { // 1 byte instruction
+					offset_list.push_back(_currentScript->size());
+					g_lingo->code1(Lingo::c_unk);
+					g_lingo->codeInt(opcode);
+				} else if (opcode < 0x80) { // 2 byte instruction
+					offset_list.push_back(_currentScript->size());
+					g_lingo->code1(Lingo::c_unk1);
+					g_lingo->codeInt(opcode);
+					offset_list.push_back(_currentScript->size());
+					g_lingo->codeInt((uint)code_store[pointer]);
+					pointer += 1;
+				} else { // 3 byte instruction
+					offset_list.push_back(_currentScript->size());
+					g_lingo->code1(Lingo::c_unk2);
+					g_lingo->codeInt(opcode);
+					offset_list.push_back(_currentScript->size());
+					g_lingo->codeInt((uint)code_store[pointer]);
+					offset_list.push_back(_currentScript->size());
+					g_lingo->codeInt((uint)code_store[pointer+1]);
+					pointer += 2;
+				}
+			}
+		}
 
-    }
-    free(code_store);
+	}
+	free(code_store);
 }
 
 }

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -126,7 +126,12 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 	stream.seek(constsOffset);
 	for (uint16 i = 0; i < constsCount; i++) {
 		Datum constant;
-		uint16 constType = stream.readUint16();
+		uint32 constType = 0;
+		if (_vm->getVersion() >= 5) {
+			constType = stream.readUint32();
+		} else {
+			constType = (uint32)stream.readUint16();
+		}
 		uint32 value = stream.readUint32();
 		switch (constType) {
 		case 1: // String type

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -124,52 +124,52 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 
 	// read each entry in the reference table.
 	stream.seek(constsOffset);
-	for (uint16 i=0; i < constsCount; i++) {
+	for (uint16 i = 0; i < constsCount; i++) {
 		Datum constant;
 		uint16 constType = stream.readUint16();
 		uint32 value = stream.readUint32();
 		switch (constType) {
-			case 1: // String type
-				{
-					constant.type = STRING;
-					constant.u.s = new Common::String();
-					uint32 pointer = value;
-					while (pointer < constsStoreSize) {
-						if (constsStore[pointer] == '\r') {
-							constant.u.s += '\n';
-						} else if (constsStore[pointer] == '\0') {
-							break;
-						} else {
-							constant.u.s += constsStore[pointer];
-						}
-						pointer += 1;
-					}
-					if (pointer >= constsStoreSize) {
-						warning("Constant string has no null terminator");
+		case 1: // String type
+			{
+				constant.type = STRING;
+				constant.u.s = new Common::String();
+				uint32 pointer = value;
+				while (pointer < constsStoreSize) {
+					if (constsStore[pointer] == '\r') {
+						constant.u.s += '\n';
+					} else if (constsStore[pointer] == '\0') {
 						break;
+					} else {
+						constant.u.s += constsStore[pointer];
 					}
+					pointer += 1;
 				}
-				break;
-			case 4: // Integer type
-				constant.type = INT;
-				constant.u.i = (int)value;
-				break;
-			case 9:  // Float type
-				{
-					constant.type = FLOAT;
-					if (value < constsStoreOffset) {
-						warning("Constant float start offset is out of bounds");
-						break;
-					} else if (value + 4 > constsStoreSize) {
-						warning("Constant float end offset is out of bounds");
-						break;
-					}
-					constant.u.f = *(float *)(constsStore + value);
+				if (pointer >= constsStoreSize) {
+					warning("Constant string has no null terminator");
+					break;
 				}
-				break;
-			default:
-				warning("Unknown constant type %d", type);
-				break;
+			}
+			break;
+		case 4: // Integer type
+			constant.type = INT;
+			constant.u.i = (int)value;
+			break;
+		case 9:  // Float type
+			{
+				constant.type = FLOAT;
+				if (value < constsStoreOffset) {
+					warning("Constant float start offset is out of bounds");
+					break;
+				} else if (value + 4 > constsStoreSize) {
+					warning("Constant float end offset is out of bounds");
+					break;
+				}
+				constant.u.f = *(float *)(constsStore + value);
+			}
+			break;
+		default:
+			warning("Unknown constant type %d", type);
+			break;
 		}
 
 		constsData.push_back(constant);
@@ -187,7 +187,7 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 
 	// read each entry in the function table.
 	stream.seek(functionsOffset);
-	for (uint16 i=0; i<functionsCount; i++) {
+	for (uint16 i = 0; i < functionsCount; i++) {
 		_currentScriptFunction = i;
 		_currentScriptContext->functions.push_back(new ScriptData);
 		_currentScript = _currentScriptContext->functions[_currentScriptFunction];
@@ -228,21 +228,21 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 				offsetList.push_back(_currentScript->size());
 				g_lingo->code1(_lingoV4[opcode]->func);
 				size_t argc = strlen(_lingoV4[opcode]->proto);
-				for (uint c=0; c < argc; c++) {
+				for (uint c = 0; c < argc; c++) {
 					switch (_lingoV4[opcode]->proto[c]) {
-						case 'b':
-							offsetList.push_back(_currentScript->size());
-							g_lingo->codeInt((int8)codeStore[pointer]);
-							pointer += 1;
-							break;
-						case 'w':
-							offsetList.push_back(_currentScript->size());
-							offsetList.push_back(_currentScript->size());
-							g_lingo->codeInt((int16)READ_UINT16(&codeStore[pointer]));
-							pointer += 2;
-							break;
-						default:
-							break;
+					case 'b':
+						offsetList.push_back(_currentScript->size());
+						g_lingo->codeInt((int8)codeStore[pointer]);
+						pointer += 1;
+						break;
+					case 'w':
+						offsetList.push_back(_currentScript->size());
+						offsetList.push_back(_currentScript->size());
+						g_lingo->codeInt((int16)READ_UINT16(&codeStore[pointer]));
+						pointer += 2;
+						break;
+					default:
+						break;
 					}
 				}
 

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -68,6 +68,8 @@ void Lingo::initBytecode() {
 }
 
 
+
+
 void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType type, uint16 id) { 
 	debugC(1, kDebugLingoCompile, "Add V4 bytecode for type %s with id %d", scriptType2str(type), id);
 
@@ -276,6 +278,38 @@ void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType ty
 
 	}
 	free(code_store);
+}
+
+
+void Lingo::addNamesV4(Common::SeekableSubReadStreamEndian &stream) {
+	debugC(1, kDebugLingoCompile, "Add V4 script name index");
+
+	// read the Lnam header!
+	stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	stream.readUint16();
+	uint16 offset = stream.readUint16();
+	uint16 count = stream.readUint16();
+
+	stream.seek(offset);
+
+	_namelist.clear();
+
+	Common::Array<Common::String> names;
+	for (uint32 i = 0; i < count; i++) {
+		uint8 size = stream.readByte();
+		Common::String name;
+		for (uint8 j = 0; j < size; j++) {
+			name += stream.readByte();
+		}
+		_namelist.push_back(name);
+	}
+
 }
 
 }

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -1,0 +1,96 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "director/lingo/lingo.h"
+
+namespace Director {
+
+static struct LingoV4Bytecode {
+    const char opcode;
+    const inst func;
+} lingoV4[] = {
+    { 0x03, Lingo::c_voidpush },
+    { 0x04, Lingo::c_mul },
+    { 0x05, Lingo::c_add },
+    { 0x06, Lingo::c_sub },
+    { 0x07, Lingo::c_div },
+    { 0x08, Lingo::c_mod },
+    { 0x09, Lingo::c_negate },
+    { 0x0a, Lingo::c_ampersand },
+    { 0x0b, Lingo::c_concat },
+    { 0x0c, Lingo::c_lt },
+    { 0x0d, Lingo::c_le },
+    { 0x0e, Lingo::c_neq },
+    { 0x0f, Lingo::c_eq },
+    { 0x10, Lingo::c_gt },
+    { 0x11, Lingo::c_ge },
+    { 0x12, Lingo::c_and },
+    { 0x13, Lingo::c_or },
+    { 0x14, Lingo::c_not },
+    { 0x15, Lingo::c_contains },
+    { 0x16, Lingo::c_starts },
+    { 0x17, Lingo::c_of },
+    { 0x18, Lingo::c_hilite }, 
+    { 0x19, Lingo::c_intersects },
+    { 0x1a, Lingo::c_within },
+    { 0x1b, Lingo::c_field },
+    { 0x1c, Lingo::c_tell },
+    { 0x1d, Lingo::c_telldone },
+    
+    { 0x41, Lingo::c_intpush },
+    { 0, 0 }
+};
+
+
+void Lingo::addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType type, uint16 id) { 
+	debugC(1, kDebugLingoCompile, "Add V4 bytecode for type %s with id %d", scriptType2str(type), id);
+
+    // unk1
+    for (uint32 i = 0; i < 0x10; i++) {
+        stream.readByte();
+    }
+    uint16 code_store_offset = stream.readUint16();
+    // unk2
+    for (uint32 i = 0; i < 0x2e; i++) {
+        stream.readByte();
+    }
+    uint16 functions_offset = stream.readUint16();
+    // unk3
+    for (uint32 i = 0; i < 0x6; i++) {
+        stream.readByte();
+    }
+    uint16 functions_count = stream.readUint16();
+    uint16 unk4 = stream.readUint16();
+    uint16 unk5 = stream.readUint16();
+    uint16 consts_count = stream.readUint16();
+    stream.readUint16();
+    uint16 consts_offset = stream.readUint16();
+    stream.readUint16();
+    uint16 unk6 = stream.readUint16();
+    stream.readUint16();
+    uint16 consts_base = stream.readUint16();
+    
+    // preload all the constants
+    stream.seek(consts_offset);
+}
+
+}

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -206,7 +206,7 @@ void Lingo::c_printtop(void) {
 }
 
 void Lingo::c_intpush() {
-    Datum d;
+	Datum d;
 	inst i = (*g_lingo->_currentScript)[g_lingo->_pc++];
 	d.u.i = READ_UINT32(&i);
 	d.type = INT;

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -60,7 +60,7 @@ static struct FuncDescr {
 	{ Lingo::c_argspush,	"c_argspush",	"i" },
 	{ Lingo::c_arraypush,	"c_arraypush",	"i" },
 	{ Lingo::c_printtop,	"c_printtop",	"" },
-	{ Lingo::c_intpush,	    "c_intpush",	"i" },
+	{ Lingo::c_intpush,	"c_intpush",	"i" },
 	{ Lingo::c_voidpush,	"c_voidpush",	"" },
 	{ Lingo::c_floatpush,	"c_floatpush",	"f" },
 	{ Lingo::c_stringpush,	"c_stringpush",	"s" },
@@ -86,8 +86,8 @@ static struct FuncDescr {
 	{ Lingo::c_starts,		"c_starts",		"" },
 	{ Lingo::c_intersects,	"c_intersects",	"" },
 	{ Lingo::c_within,		"c_within",		"" },
-    { Lingo::c_field,       "c_field",      "" },
-    { Lingo::c_of,		    "c_of",		    "" },	// D9
+	{ Lingo::c_field,       "c_field",      "" },
+	{ Lingo::c_of,		    "c_of",		    "" },	// D9
 	{ Lingo::c_charOf,		"c_charOf",		"" },	// D3
 	{ Lingo::c_charToOf,	"c_charToOf",	"" },	// D3
 	{ Lingo::c_itemOf,		"c_itemOf",		"" },	// D3
@@ -110,8 +110,8 @@ static struct FuncDescr {
 	{ Lingo::c_exitRepeat,	"c_exitRepeat",	"" },
 	{ Lingo::c_ifcode,		"c_ifcode",		"oooi" },
 	{ Lingo::c_tellcode,	"c_tellcode",	"o" },
-    { Lingo::c_tell,        "c_tell",       "" },
-    { Lingo::c_telldone,    "c_telldone",   "" },
+	{ Lingo::c_tell,        "c_tell",       "" },
+	{ Lingo::c_telldone,    "c_telldone",   "" },
 	{ Lingo::c_whencode,	"c_whencode",	"os" },
 	{ Lingo::c_goto,		"c_goto",		"" },
 	{ Lingo::c_gotoloop,	"c_gotoloop",	"" },
@@ -125,12 +125,10 @@ static struct FuncDescr {
 	{ Lingo::c_property,	"c_property",	"s" },
 	{ Lingo::c_instance,	"c_instance",	"s" },
 	{ Lingo::c_open,		"c_open",		"" },
-    { Lingo::c_hilite,      "c_hilite",     "" },
-    { Lingo::c_jump,        "c_jump",       "" },
-    { Lingo::c_jumpif,      "c_jumpif",     "" },
-    { Lingo::c_unk,         "c_unk",        "i" },
-    { Lingo::c_unk1,        "c_unk1",       "ii" },
-    { Lingo::c_unk2,        "c_unk2",       "iii" },
+	{ Lingo::c_hilite,      "c_hilite",     "" },
+	{ Lingo::c_unk,         "c_unk",        "i" },
+	{ Lingo::c_unk1,        "c_unk1",       "ii" },
+	{ Lingo::c_unk2,        "c_unk2",       "iii" },
 	{ 0, 0, 0 }
 };
 
@@ -667,30 +665,30 @@ void Lingo::c_within() {
 }
 
 void Lingo::c_field() {
-    Datum d1 = g_lingo->pop();
+	Datum d1 = g_lingo->pop();
 
-    warning("STUB: c_field: %d", d1.u.i);
+	warning("STUB: c_field: %d", d1.u.i);
 
-    g_lingo->push(d1);
+	g_lingo->push(d1);
 }
 
 void Lingo::c_of() {
-    Datum first_char = g_lingo->pop();
-    Datum last_char = g_lingo->pop();
-    Datum first_word = g_lingo->pop();
-    Datum last_word = g_lingo->pop();
-    Datum first_item = g_lingo->pop();
-    Datum last_item = g_lingo->pop();
-    Datum first_line = g_lingo->pop();
-    Datum last_line = g_lingo->pop();
-    Datum target = g_lingo->pop();
+	Datum first_char = g_lingo->pop();
+	Datum last_char = g_lingo->pop();
+	Datum first_word = g_lingo->pop();
+	Datum last_word = g_lingo->pop();
+	Datum first_item = g_lingo->pop();
+	Datum last_item = g_lingo->pop();
+	Datum first_line = g_lingo->pop();
+	Datum last_line = g_lingo->pop();
+	Datum target = g_lingo->pop();
 
-    warning("STUB: c_of: %d %d %d %d %d %d %d %d %s", 
-                first_char.u.i, last_char.u.i, first_word.u.i, last_word.u.i,
-                first_item.u.i, last_item.u.i, first_line.u.i, last_line.u.i,
-                target.u.s->c_str());
+	warning("STUB: c_of: %d %d %d %d %d %d %d %d %s",
+		first_char.u.i, last_char.u.i, first_word.u.i, last_word.u.i,
+		first_item.u.i, last_item.u.i, first_line.u.i, last_line.u.i,
+		target.u.s->c_str());
 
-    g_lingo->push(target);
+	g_lingo->push(target);
 
 }
 
@@ -1024,7 +1022,7 @@ void Lingo::c_tellcode() {
 }
 
 void Lingo::c_tell() {
-    Datum d1 = g_lingo->pop();
+	Datum d1 = g_lingo->pop();
 	warning("STUB: c_tell %d", d1.u.i);
 }
 
@@ -1251,52 +1249,44 @@ void Lingo::c_open() {
 }
 
 void Lingo::c_hilite() {
-    Datum first_char = g_lingo->pop();
-    Datum last_char = g_lingo->pop();
-    Datum first_word = g_lingo->pop();
-    Datum last_word = g_lingo->pop();
-    Datum first_item = g_lingo->pop();
-    Datum last_item = g_lingo->pop();
-    Datum first_line = g_lingo->pop();
-    Datum last_line = g_lingo->pop();
-    Datum cast_id = g_lingo->pop();
+	Datum first_char = g_lingo->pop();
+	Datum last_char = g_lingo->pop();
+	Datum first_word = g_lingo->pop();
+	Datum last_word = g_lingo->pop();
+	Datum first_item = g_lingo->pop();
+	Datum last_item = g_lingo->pop();
+	Datum first_line = g_lingo->pop();
+	Datum last_line = g_lingo->pop();
+	Datum cast_id = g_lingo->pop();
 
-    warning("STUB: c_hilite: %d %d %d %d %d %d %d %d %d", 
-                first_char.u.i, last_char.u.i, first_word.u.i, last_word.u.i,
-                first_item.u.i, last_item.u.i, first_line.u.i, last_line.u.i,
-                cast_id.u.i);
-}
-
-void Lingo::c_jump() {
-
-}
-
-void Lingo::c_jumpif() {
-    
+	warning("STUB: c_hilite: %d %d %d %d %d %d %d %d %d",
+		first_char.u.i, last_char.u.i, first_word.u.i, last_word.u.i,
+		first_item.u.i, last_item.u.i, first_line.u.i, last_line.u.i,
+		cast_id.u.i);
 }
 
 void Lingo::c_unk() {
-    int savepc = g_lingo->_pc;
-    uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
-    warning("STUB: opcode 0x%02x", opcode);
-    g_lingo->_pc += 1;
+	int savepc = g_lingo->_pc;
+	uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
+	warning("STUB: opcode 0x%02x", opcode);
+	g_lingo->_pc += 1;
 }
 
 void Lingo::c_unk1() {
-    int savepc = g_lingo->_pc;
-    uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
-    uint arg1 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+1]);
-    warning("STUB: opcode 0x%02x (%d)", opcode, arg1);
-    g_lingo->_pc += 2;
+	int savepc = g_lingo->_pc;
+	uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
+	uint arg1 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+1]);
+	warning("STUB: opcode 0x%02x (%d)", opcode, arg1);
+	g_lingo->_pc += 2;
 }
 
 void Lingo::c_unk2() {
-    int savepc = g_lingo->_pc;
-    uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
-    uint arg1 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+1]);
-    uint arg2 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+2]);
-    warning("STUB: opcode 0x%02x (%d, %d)", opcode, arg1, arg2);
-    g_lingo->_pc += 3;
+	int savepc = g_lingo->_pc;
+	uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
+	uint arg1 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+1]);
+	uint arg2 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+2]);
+	warning("STUB: opcode 0x%02x (%d, %d)", opcode, arg1, arg2);
+	g_lingo->_pc += 3;
 }
 
 

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -59,9 +59,9 @@ static struct FuncDescr {
 	{ Lingo::c_xpop,		"c_xpop",		"" },
 	{ Lingo::c_arraypush,	"c_arraypush",		"i" },
 	{ Lingo::c_printtop,	"c_printtop",	"" },
-	{ Lingo::c_constpush,	"c_constpush",	"i" },
+	{ Lingo::c_intpush,	    "c_intpush",	"i" },
 	{ Lingo::c_voidpush,	"c_voidpush",	"" },
-	{ Lingo::c_fconstpush,	"c_fconstpush",	"f" },
+	{ Lingo::c_floatpush,	"c_floatpush",	"f" },
 	{ Lingo::c_stringpush,	"c_stringpush",	"s" },
 	{ Lingo::c_symbolpush,	"c_symbolpush",	"s" },	// D3
 	{ Lingo::c_varpush,		"c_varpush",	"s" },
@@ -196,8 +196,8 @@ void Lingo::c_printtop(void) {
 	}
 }
 
-void Lingo::c_constpush() {
-	Datum d;
+void Lingo::c_intpush() {
+    Datum d;
 	inst i = (*g_lingo->_currentScript)[g_lingo->_pc++];
 	d.u.i = READ_UINT32(&i);
 	d.type = INT;
@@ -211,7 +211,7 @@ void Lingo::c_voidpush() {
 	g_lingo->push(d);
 }
 
-void Lingo::c_fconstpush() {
+void Lingo::c_floatpush() {
 	Datum d;
 	inst i = (*g_lingo->_currentScript)[g_lingo->_pc];
 	d.u.f = *(double *)(&i);
@@ -243,7 +243,7 @@ void Lingo::c_arraypush() {
 	Datum d;
 	inst v = (*g_lingo->_currentScript)[g_lingo->_pc++];
 	int arraySize = READ_UINT32(&v);
-
+`
 	warning("STUB: c_arraypush()");
 
 	for (int i = 0; i < arraySize; i++)

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -128,9 +128,9 @@ static struct FuncDescr {
     { Lingo::c_hilite,      "c_hilite",     "" },
     { Lingo::c_jump,        "c_jump",       "" },
     { Lingo::c_jumpif,      "c_jumpif",     "" },
-    { Lingo::c_nop,         "c_nop",        "i" },
-    { Lingo::c_nop1,        "c_nop1",       "ii" },
-    { Lingo::c_nop2,        "c_nop2",       "iii" },
+    { Lingo::c_unk,         "c_unk",        "i" },
+    { Lingo::c_unk1,        "c_unk1",       "ii" },
+    { Lingo::c_unk2,        "c_unk2",       "iii" },
 	{ 0, 0, 0 }
 };
 
@@ -1275,27 +1275,27 @@ void Lingo::c_jumpif() {
     
 }
 
-void Lingo::c_nop() {
+void Lingo::c_unk() {
     int savepc = g_lingo->_pc;
     uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
-    warning("STUB: c_nop: %d", opcode);
+    warning("STUB: opcode 0x%02x", opcode);
     g_lingo->_pc += 1;
 }
 
-void Lingo::c_nop1() {
+void Lingo::c_unk1() {
     int savepc = g_lingo->_pc;
     uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
     uint arg1 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+1]);
-    warning("STUB: c_nop1: %d %d", opcode, arg1);
+    warning("STUB: opcode 0x%02x (%d)", opcode, arg1);
     g_lingo->_pc += 2;
 }
 
-void Lingo::c_nop2() {
+void Lingo::c_unk2() {
     int savepc = g_lingo->_pc;
     uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
     uint arg1 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+1]);
     uint arg2 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+2]);
-    warning("STUB: c_nop2: %d %d %d", opcode, arg1, arg2);
+    warning("STUB: opcode 0x%02x (%d, %d)", opcode, arg1, arg2);
     g_lingo->_pc += 3;
 }
 

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -85,6 +85,8 @@ static struct FuncDescr {
 	{ Lingo::c_starts,		"c_starts",		"" },
 	{ Lingo::c_intersects,	"c_intersects",	"" },
 	{ Lingo::c_within,		"c_within",		"" },
+    { Lingo::c_field,       "c_field",      "" },
+    { Lingo::c_of,		    "c_of",		    "" },	// D9
 	{ Lingo::c_charOf,		"c_charOf",		"" },	// D3
 	{ Lingo::c_charToOf,	"c_charToOf",	"" },	// D3
 	{ Lingo::c_itemOf,		"c_itemOf",		"" },	// D3
@@ -107,6 +109,8 @@ static struct FuncDescr {
 	{ Lingo::c_exitRepeat,	"c_exitRepeat",	"" },
 	{ Lingo::c_ifcode,		"c_ifcode",		"oooi" },
 	{ Lingo::c_tellcode,	"c_tellcode",	"o" },
+    { Lingo::c_tell,        "c_tell",       "" },
+    { Lingo::c_telldone,    "c_telldone",   "" },
 	{ Lingo::c_whencode,	"c_whencode",	"os" },
 	{ Lingo::c_goto,		"c_goto",		"" },
 	{ Lingo::c_gotoloop,	"c_gotoloop",	"" },
@@ -120,6 +124,7 @@ static struct FuncDescr {
 	{ Lingo::c_property,	"c_property",	"s" },
 	{ Lingo::c_instance,	"c_instance",	"s" },
 	{ Lingo::c_open,		"c_open",		"" },
+    { Lingo::c_hilite,      "c_hilite",     "" },
 	{ 0, 0, 0 }
 };
 
@@ -243,7 +248,7 @@ void Lingo::c_arraypush() {
 	Datum d;
 	inst v = (*g_lingo->_currentScript)[g_lingo->_pc++];
 	int arraySize = READ_UINT32(&v);
-`
+
 	warning("STUB: c_arraypush()");
 
 	for (int i = 0; i < arraySize; i++)
@@ -640,6 +645,34 @@ void Lingo::c_within() {
 	g_lingo->push(d1);
 }
 
+void Lingo::c_field() {
+    Datum d1 = g_lingo->pop();
+
+    warning("STUB: c_field: %d", d1.u.i);
+
+    g_lingo->push(d1);
+}
+
+void Lingo::c_of() {
+    Datum first_char = g_lingo->pop();
+    Datum last_char = g_lingo->pop();
+    Datum first_word = g_lingo->pop();
+    Datum last_word = g_lingo->pop();
+    Datum first_item = g_lingo->pop();
+    Datum last_item = g_lingo->pop();
+    Datum first_line = g_lingo->pop();
+    Datum last_line = g_lingo->pop();
+    Datum target = g_lingo->pop();
+
+    warning("STUB: c_of: %d %d %d %d %d %d %d %d %s", 
+                first_char.u.i, last_char.u.i, first_word.u.i, last_word.u.i,
+                first_item.u.i, last_item.u.i, first_line.u.i, last_line.u.i,
+                target.u.s->c_str());
+
+    g_lingo->push(target);
+
+}
+
 void Lingo::c_charOf() {
 	Datum d2 = g_lingo->pop();
 	Datum d1 = g_lingo->pop();
@@ -969,6 +1002,15 @@ void Lingo::c_tellcode() {
 	warning("STUB: c_tellcode");
 }
 
+void Lingo::c_tell() {
+    Datum d1 = g_lingo->pop();
+	warning("STUB: c_tell %d", d1.u.i);
+}
+
+void Lingo::c_telldone() {
+	warning("STUB: c_telldone");
+}
+
 
 //************************
 // Built-in functions
@@ -1185,6 +1227,23 @@ void Lingo::c_open() {
 	d2.toString();
 
 	warning("STUB: c_open(%s, %s)", d1.u.s->c_str(), d2.u.s->c_str());
+}
+
+void Lingo::c_hilite() {
+    Datum first_char = g_lingo->pop();
+    Datum last_char = g_lingo->pop();
+    Datum first_word = g_lingo->pop();
+    Datum last_word = g_lingo->pop();
+    Datum first_item = g_lingo->pop();
+    Datum last_item = g_lingo->pop();
+    Datum first_line = g_lingo->pop();
+    Datum last_line = g_lingo->pop();
+    Datum cast_id = g_lingo->pop();
+
+    warning("STUB: c_hilite: %d %d %d %d %d %d %d %d %d", 
+                first_char.u.i, last_char.u.i, first_word.u.i, last_word.u.i,
+                first_item.u.i, last_item.u.i, first_line.u.i, last_line.u.i,
+                cast_id.u.i);
 }
 
 }

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -87,7 +87,7 @@ static struct FuncDescr {
 	{ Lingo::c_intersects,	"c_intersects",	"" },
 	{ Lingo::c_within,		"c_within",		"" },
 	{ Lingo::c_field,       "c_field",      "" },
-	{ Lingo::c_of,		    "c_of",		    "" },	// D9
+	{ Lingo::c_of,		    "c_of",		    "" },
 	{ Lingo::c_charOf,		"c_charOf",		"" },	// D3
 	{ Lingo::c_charToOf,	"c_charToOf",	"" },	// D3
 	{ Lingo::c_itemOf,		"c_itemOf",		"" },	// D3

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -57,7 +57,8 @@ static struct FuncDescr {
 } funcDescr[] = {
 	{ 0,					"STOP",			"" },
 	{ Lingo::c_xpop,		"c_xpop",		"" },
-	{ Lingo::c_arraypush,	"c_arraypush",		"i" },
+	{ Lingo::c_argspush,	"c_argspush",	"i" },
+	{ Lingo::c_arraypush,	"c_arraypush",	"i" },
 	{ Lingo::c_printtop,	"c_printtop",	"" },
 	{ Lingo::c_intpush,	    "c_intpush",	"i" },
 	{ Lingo::c_voidpush,	"c_voidpush",	"" },
@@ -125,6 +126,11 @@ static struct FuncDescr {
 	{ Lingo::c_instance,	"c_instance",	"s" },
 	{ Lingo::c_open,		"c_open",		"" },
     { Lingo::c_hilite,      "c_hilite",     "" },
+    { Lingo::c_jump,        "c_jump",       "" },
+    { Lingo::c_jumpif,      "c_jumpif",     "" },
+    { Lingo::c_nop,         "c_nop",        "i" },
+    { Lingo::c_nop1,        "c_nop1",       "ii" },
+    { Lingo::c_nop2,        "c_nop2",       "iii" },
 	{ 0, 0, 0 }
 };
 
@@ -242,6 +248,21 @@ void Lingo::c_symbolpush() {
 
 	// TODO: FIXME: Must push symbol instead of string
 	g_lingo->push(Datum(new Common::String(s)));
+}
+
+void Lingo::c_argspush() {
+	Datum d;
+	inst v = (*g_lingo->_currentScript)[g_lingo->_pc++];
+	int argsSize = READ_UINT32(&v);
+
+	warning("STUB: c_argspush()");
+
+	for (int i = 0; i < argsSize; i++)
+		g_lingo->pop();
+
+	d.u.i = argsSize;
+	d.type = INT;
+	g_lingo->push(d);
 }
 
 void Lingo::c_arraypush() {
@@ -1245,5 +1266,38 @@ void Lingo::c_hilite() {
                 first_item.u.i, last_item.u.i, first_line.u.i, last_line.u.i,
                 cast_id.u.i);
 }
+
+void Lingo::c_jump() {
+
+}
+
+void Lingo::c_jumpif() {
+    
+}
+
+void Lingo::c_nop() {
+    int savepc = g_lingo->_pc;
+    uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
+    warning("STUB: c_nop: %d", opcode);
+    g_lingo->_pc += 1;
+}
+
+void Lingo::c_nop1() {
+    int savepc = g_lingo->_pc;
+    uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
+    uint arg1 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+1]);
+    warning("STUB: c_nop1: %d %d", opcode, arg1);
+    g_lingo->_pc += 2;
+}
+
+void Lingo::c_nop2() {
+    int savepc = g_lingo->_pc;
+    uint opcode = READ_UINT32(&(*g_lingo->_currentScript)[savepc]);
+    uint arg1 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+1]);
+    uint arg2 = READ_UINT32(&(*g_lingo->_currentScript)[savepc+2]);
+    warning("STUB: c_nop2: %d %d %d", opcode, arg1, arg2);
+    g_lingo->_pc += 3;
+}
+
 
 }

--- a/engines/director/lingo/lingo-codegen.cpp
+++ b/engines/director/lingo/lingo-codegen.cpp
@@ -274,8 +274,8 @@ int Lingo::codeFloat(double f) {
 	return _currentScript->size();
 }
 
-int Lingo::codeConst(int val) {
-	int res = g_lingo->code1(g_lingo->c_constpush);
+int Lingo::codeInt(int val) {
+	int res = g_lingo->code1(g_lingo->c_intpush);
 	inst i = 0;
 	WRITE_UINT32(&i, val);
 	g_lingo->code1(i);

--- a/engines/director/lingo/lingo-codegen.cpp
+++ b/engines/director/lingo/lingo-codegen.cpp
@@ -275,21 +275,19 @@ int Lingo::codeFloat(double f) {
 }
 
 int Lingo::codeInt(int val) {
-	int res = g_lingo->code1(g_lingo->c_intpush);
 	inst i = 0;
 	WRITE_UINT32(&i, val);
 	g_lingo->code1(i);
 
-	return res;
+	return _currentScript->size();
 }
 
 int Lingo::codeArray(int arraySize) {
-	int res = g_lingo->code1(g_lingo->c_arraypush);
 	inst i = 0;
 	WRITE_UINT32(&i, arraySize);
 	g_lingo->code1(i);
 
-	return res;
+	return _currentScript->size();
 }
 
 void Lingo::codeArg(Common::String *s) {

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -190,9 +190,9 @@ void Lingo::runMovieScript(LEvent event) {
 	 */
 
 	for (uint i = 0; i < _scripts[kMovieScript].size(); i++) {
-		// processEvent(event,
-		//			 kMovieScript,
-		//			 ?);
+		processEvent(event,
+					 kMovieScript,
+					 i);
 		// TODO: How do know which script handles the message?
 	}
 	debugC(3, kDebugLingoExec, "STUB: processEvent(event, kMovieScript, ?)");
@@ -306,7 +306,7 @@ void Lingo::processEvent(LEvent event, ScriptType st, int entityId) {
 
 		executeScript(st, entityId); // D3 list of scripts.
 	} else {
-		//debugC(3, kDebugLingoExec, "STUB: processEvent(%s) for %d", _eventHandlerTypes[event], entityId);
+		debugC(3, kDebugLingoExec, "STUB: processEvent(%s) for %d", _eventHandlerTypes[event], entityId);
 	}
 }
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -189,7 +189,7 @@ void Lingo::runMovieScript(LEvent event) {
 	 * window [p.81 of D4 docs]
 	 */
 
-	for (uint i = 0; i < _scripts[kMovieScript].size(); i++) {
+	for (uint i = 0; i < _scriptContexts[kMovieScript].size(); i++) {
 		processEvent(event,
 					 kMovieScript,
 					 i);
@@ -301,10 +301,10 @@ void Lingo::processEvent(LEvent event, ScriptType st, int entityId) {
 	if (_handlers.contains(ENTITY_INDEX(event, entityId))) {
 		debugC(1, kDebugEvents, "Lingo::processEvent(%s, %s, %d), _eventHandler", _eventHandlerTypes[event], scriptType2str(st), entityId);
 		call(_eventHandlerTypes[event], 0); // D4+ Events
-	} else if (event == kEventNone && _scripts[st].contains(entityId)) {
+	} else if (event == kEventNone && _scriptContexts[st].contains(entityId)) {
 		debugC(1, kDebugEvents, "Lingo::processEvent(%s, %s, %d), script", _eventHandlerTypes[event], scriptType2str(st), entityId);
 
-		executeScript(st, entityId); // D3 list of scripts.
+		executeScript(st, entityId, 0); // D3 list of scripts.
 	} else {
 		debugC(3, kDebugLingoExec, "STUB: processEvent(%s) for %d", _eventHandlerTypes[event], entityId);
 	}

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -39,11 +39,11 @@ struct EventHandlerType {
 	{ kEventBeginSprite,		"beginSprite" },
 	{ kEventEndSprite,			"endSprite" },
 
-	{ kEventEnterFrame, 		"enterFrame" },			//			D4
-	{ kEventPrepareFrame, 		"prepareFrame" },
+	{ kEventEnterFrame,			"enterFrame" },			//			D4
+	{ kEventPrepareFrame,		"prepareFrame" },
 	{ kEventIdle,				"idle" },
 	{ kEventStepFrame,			"stepFrame"},
-	{ kEventExitFrame, 			"exitFrame" },			//			D4
+	{ kEventExitFrame,			"exitFrame" },			//			D4
 
 	{ kEventActivateWindow,		"activateWindow" },
 	{ kEventDeactivateWindow,	"deactivateWindow" },
@@ -200,7 +200,7 @@ void Lingo::runMovieScript(LEvent event) {
 
 void Lingo::processFrameEvent(LEvent event) {
 	/* [in D4] the enterFrame, exitFrame, idle and timeout messages
-	 * are sent to a frame script and then a movie script.  If the
+	 * are sent to a frame script and then a movie script.	If the
 	 * current frame has no frame script when the event occurs, the
 	 * message goes to movie scripts.
 	 * [p.81 of D4 docs]
@@ -224,8 +224,8 @@ void Lingo::processFrameEvent(LEvent event) {
 			entity = score->_frames[score->getCurrentFrame()]->_actionId;
 		}
 		processEvent(event,
-		             kFrameScript,
-		             entity);
+					 kFrameScript,
+					 entity);
 		runMovieScript(event);
 	}
 }

--- a/engines/director/lingo/lingo-gr.cpp
+++ b/engines/director/lingo/lingo-gr.cpp
@@ -1,14 +1,14 @@
-/* A Bison parser, made by GNU Bison 2.3.  */
+/* A Bison parser, made by GNU Bison 3.4.  */
 
-/* Skeleton implementation for Bison's Yacc-like parsers in C
+/* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
-   Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2019 Free Software Foundation,
+   Inc.
 
-   This program is free software; you can redistribute it and/or modify
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -16,9 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor,
-   Boston, MA 02110-1301, USA.  */
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -43,11 +41,14 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
+
 /* Identify Bison output.  */
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "2.3"
+#define YYBISON_VERSION "3.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -55,201 +56,16 @@
 /* Pure parsers.  */
 #define YYPURE 0
 
-/* Using locations.  */
-#define YYLSP_NEEDED 0
+/* Push parsers.  */
+#define YYPUSH 0
 
-
-
-/* Tokens.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     UNARY = 258,
-     CASTREF = 259,
-     VOID = 260,
-     VAR = 261,
-     POINT = 262,
-     RECT = 263,
-     ARRAY = 264,
-     OBJECT = 265,
-     REFERENCE = 266,
-     INT = 267,
-     THEENTITY = 268,
-     THEENTITYWITHID = 269,
-     FLOAT = 270,
-     BLTIN = 271,
-     BLTINNOARGS = 272,
-     BLTINNOARGSORONE = 273,
-     BLTINONEARG = 274,
-     BLTINARGLIST = 275,
-     TWOWORDBUILTIN = 276,
-     FBLTIN = 277,
-     FBLTINNOARGS = 278,
-     FBLTINONEARG = 279,
-     FBLTINARGLIST = 280,
-     RBLTIN = 281,
-     RBLTINONEARG = 282,
-     ID = 283,
-     STRING = 284,
-     HANDLER = 285,
-     SYMBOL = 286,
-     ENDCLAUSE = 287,
-     tPLAYACCEL = 288,
-     tDOWN = 289,
-     tELSE = 290,
-     tNLELSIF = 291,
-     tEXIT = 292,
-     tFRAME = 293,
-     tGLOBAL = 294,
-     tGO = 295,
-     tIF = 296,
-     tINTO = 297,
-     tLOOP = 298,
-     tMACRO = 299,
-     tMOVIE = 300,
-     tNEXT = 301,
-     tOF = 302,
-     tPREVIOUS = 303,
-     tPUT = 304,
-     tREPEAT = 305,
-     tSET = 306,
-     tTHEN = 307,
-     tTHENNL = 308,
-     tTO = 309,
-     tWHEN = 310,
-     tWITH = 311,
-     tWHILE = 312,
-     tNLELSE = 313,
-     tFACTORY = 314,
-     tMETHOD = 315,
-     tOPEN = 316,
-     tPLAY = 317,
-     tDONE = 318,
-     tINSTANCE = 319,
-     tGE = 320,
-     tLE = 321,
-     tGT = 322,
-     tLT = 323,
-     tEQ = 324,
-     tNEQ = 325,
-     tAND = 326,
-     tOR = 327,
-     tNOT = 328,
-     tMOD = 329,
-     tAFTER = 330,
-     tBEFORE = 331,
-     tCONCAT = 332,
-     tCONTAINS = 333,
-     tSTARTS = 334,
-     tCHAR = 335,
-     tITEM = 336,
-     tLINE = 337,
-     tWORD = 338,
-     tSPRITE = 339,
-     tINTERSECTS = 340,
-     tWITHIN = 341,
-     tTELL = 342,
-     tPROPERTY = 343,
-     tON = 344,
-     tME = 345
-   };
-#endif
-/* Tokens.  */
-#define UNARY 258
-#define CASTREF 259
-#define VOID 260
-#define VAR 261
-#define POINT 262
-#define RECT 263
-#define ARRAY 264
-#define OBJECT 265
-#define REFERENCE 266
-#define INT 267
-#define THEENTITY 268
-#define THEENTITYWITHID 269
-#define FLOAT 270
-#define BLTIN 271
-#define BLTINNOARGS 272
-#define BLTINNOARGSORONE 273
-#define BLTINONEARG 274
-#define BLTINARGLIST 275
-#define TWOWORDBUILTIN 276
-#define FBLTIN 277
-#define FBLTINNOARGS 278
-#define FBLTINONEARG 279
-#define FBLTINARGLIST 280
-#define RBLTIN 281
-#define RBLTINONEARG 282
-#define ID 283
-#define STRING 284
-#define HANDLER 285
-#define SYMBOL 286
-#define ENDCLAUSE 287
-#define tPLAYACCEL 288
-#define tDOWN 289
-#define tELSE 290
-#define tNLELSIF 291
-#define tEXIT 292
-#define tFRAME 293
-#define tGLOBAL 294
-#define tGO 295
-#define tIF 296
-#define tINTO 297
-#define tLOOP 298
-#define tMACRO 299
-#define tMOVIE 300
-#define tNEXT 301
-#define tOF 302
-#define tPREVIOUS 303
-#define tPUT 304
-#define tREPEAT 305
-#define tSET 306
-#define tTHEN 307
-#define tTHENNL 308
-#define tTO 309
-#define tWHEN 310
-#define tWITH 311
-#define tWHILE 312
-#define tNLELSE 313
-#define tFACTORY 314
-#define tMETHOD 315
-#define tOPEN 316
-#define tPLAY 317
-#define tDONE 318
-#define tINSTANCE 319
-#define tGE 320
-#define tLE 321
-#define tGT 322
-#define tLT 323
-#define tEQ 324
-#define tNEQ 325
-#define tAND 326
-#define tOR 327
-#define tNOT 328
-#define tMOD 329
-#define tAFTER 330
-#define tBEFORE 331
-#define tCONCAT 332
-#define tCONTAINS 333
-#define tSTARTS 334
-#define tCHAR 335
-#define tITEM 336
-#define tLINE 337
-#define tWORD 338
-#define tSPRITE 339
-#define tINTERSECTS 340
-#define tWITHIN 341
-#define tTELL 342
-#define tPROPERTY 343
-#define tON 344
-#define tME 345
+/* Pull parsers.  */
+#define YYPULL 1
 
 
 
 
-/* Copy the first part of user declarations.  */
+/* First part of user prologue.  */
 #line 49 "engines/director/lingo/lingo-gr.y"
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
@@ -280,11 +96,19 @@ void checkEnd(Common::String *token, const char *expect, bool required) {
 }
 
 
+#line 100 "engines/director/lingo/lingo-gr.cpp"
 
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 1
-#endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
 
 /* Enabling verbose error messages.  */
 #ifdef YYERROR_VERBOSE
@@ -294,15 +118,120 @@ void checkEnd(Common::String *token, const char *expect, bool required) {
 # define YYERROR_VERBOSE 0
 #endif
 
-/* Enabling the token table.  */
-#ifndef YYTOKEN_TABLE
-# define YYTOKEN_TABLE 0
+/* Use api.header.include to #include this header
+   instead of duplicating it here.  */
+#ifndef YY_YY_ENGINES_DIRECTOR_LINGO_LINGO_GR_HPP_INCLUDED
+# define YY_YY_ENGINES_DIRECTOR_LINGO_LINGO_GR_HPP_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 1
+#endif
+#if YYDEBUG
+extern int yydebug;
 #endif
 
+/* Token type.  */
+#ifndef YYTOKENTYPE
+# define YYTOKENTYPE
+  enum yytokentype
+  {
+    UNARY = 258,
+    CASTREF = 259,
+    VOID = 260,
+    VAR = 261,
+    POINT = 262,
+    RECT = 263,
+    ARRAY = 264,
+    OBJECT = 265,
+    REFERENCE = 266,
+    INT = 267,
+    THEENTITY = 268,
+    THEENTITYWITHID = 269,
+    FLOAT = 270,
+    BLTIN = 271,
+    BLTINNOARGS = 272,
+    BLTINNOARGSORONE = 273,
+    BLTINONEARG = 274,
+    BLTINARGLIST = 275,
+    TWOWORDBUILTIN = 276,
+    FBLTIN = 277,
+    FBLTINNOARGS = 278,
+    FBLTINONEARG = 279,
+    FBLTINARGLIST = 280,
+    RBLTIN = 281,
+    RBLTINONEARG = 282,
+    ID = 283,
+    STRING = 284,
+    HANDLER = 285,
+    SYMBOL = 286,
+    ENDCLAUSE = 287,
+    tPLAYACCEL = 288,
+    tDOWN = 289,
+    tELSE = 290,
+    tNLELSIF = 291,
+    tEXIT = 292,
+    tFRAME = 293,
+    tGLOBAL = 294,
+    tGO = 295,
+    tIF = 296,
+    tINTO = 297,
+    tLOOP = 298,
+    tMACRO = 299,
+    tMOVIE = 300,
+    tNEXT = 301,
+    tOF = 302,
+    tPREVIOUS = 303,
+    tPUT = 304,
+    tREPEAT = 305,
+    tSET = 306,
+    tTHEN = 307,
+    tTHENNL = 308,
+    tTO = 309,
+    tWHEN = 310,
+    tWITH = 311,
+    tWHILE = 312,
+    tNLELSE = 313,
+    tFACTORY = 314,
+    tMETHOD = 315,
+    tOPEN = 316,
+    tPLAY = 317,
+    tDONE = 318,
+    tINSTANCE = 319,
+    tGE = 320,
+    tLE = 321,
+    tGT = 322,
+    tLT = 323,
+    tEQ = 324,
+    tNEQ = 325,
+    tAND = 326,
+    tOR = 327,
+    tNOT = 328,
+    tMOD = 329,
+    tAFTER = 330,
+    tBEFORE = 331,
+    tCONCAT = 332,
+    tCONTAINS = 333,
+    tSTARTS = 334,
+    tCHAR = 335,
+    tITEM = 336,
+    tLINE = 337,
+    tWORD = 338,
+    tSPRITE = 339,
+    tINTERSECTS = 340,
+    tWITHIN = 341,
+    tTELL = 342,
+    tPROPERTY = 343,
+    tON = 344,
+    tME = 345
+  };
+#endif
+
+/* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE
-#line 79 "engines/director/lingo/lingo-gr.y"
+union YYSTYPE
 {
+#line 79 "engines/director/lingo/lingo-gr.y"
+
 	Common::String *s;
 	int i;
 	double f;
@@ -310,22 +239,23 @@ typedef union YYSTYPE
 	int code;
 	int narg;	/* number of arguments */
 	Common::Array<double> *arr;
-}
-/* Line 193 of yacc.c.  */
-#line 316 "engines/director/lingo/lingo-gr.cpp"
-	YYSTYPE;
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
+
+#line 244 "engines/director/lingo/lingo-gr.cpp"
+
+};
+typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
+# define YYSTYPE_IS_DECLARED 1
 #endif
 
 
+extern YYSTYPE yylval;
 
-/* Copy the second part of user declarations.  */
+int yyparse (void);
+
+#endif /* !YY_YY_ENGINES_DIRECTOR_LINGO_LINGO_GR_HPP_INCLUDED  */
 
 
-/* Line 216 of yacc.c.  */
-#line 329 "engines/director/lingo/lingo-gr.cpp"
 
 #ifdef short
 # undef short
@@ -339,23 +269,20 @@ typedef unsigned char yytype_uint8;
 
 #ifdef YYTYPE_INT8
 typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-typedef signed char yytype_int8;
 #else
-typedef short int yytype_int8;
+typedef signed char yytype_int8;
 #endif
 
 #ifdef YYTYPE_UINT16
 typedef YYTYPE_UINT16 yytype_uint16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef unsigned short yytype_uint16;
 #endif
 
 #ifdef YYTYPE_INT16
 typedef YYTYPE_INT16 yytype_int16;
 #else
-typedef short int yytype_int16;
+typedef short yytype_int16;
 #endif
 
 #ifndef YYSIZE_T
@@ -363,12 +290,11 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif ! defined YYSIZE_T
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
@@ -378,38 +304,60 @@ typedef short int yytype_int16;
 # if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#   define YY_(msgid) dgettext ("bison-runtime", msgid)
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
 #  endif
 # endif
 # ifndef YY_
-#  define YY_(msgid) msgid
+#  define YY_(Msgid) Msgid
 # endif
+#endif
+
+#ifndef YY_ATTRIBUTE
+# if (defined __GNUC__                                               \
+      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
+     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
+#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+# else
+#  define YY_ATTRIBUTE(Spec) /* empty */
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_PURE
+# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(e) ((void) (e))
+# define YYUSE(E) ((void) (E))
 #else
-# define YYUSE(e) /* empty */
+# define YYUSE(E) /* empty */
 #endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(n) (n)
+#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+    _Pragma ("GCC diagnostic pop")
 #else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int i)
-#else
-static int
-YYID (i)
-    int i;
+# define YY_INITIAL_VALUE(Value) Value
 #endif
-{
-  return i;
-}
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
 #endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
@@ -428,11 +376,11 @@ YYID (i)
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#     ifndef _STDLIB_H
-#      define _STDLIB_H 1
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
 #     endif
 #    endif
 #   endif
@@ -440,8 +388,8 @@ YYID (i)
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -455,25 +403,23 @@ YYID (i)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
 #   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
 #  endif
-#  if (defined __cplusplus && ! defined _STDLIB_H \
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#   ifndef _STDLIB_H
-#    define _STDLIB_H 1
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
 #   endif
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
@@ -483,14 +429,14 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss;
-  YYSTYPE yyvs;
-  };
+  yytype_int16 yyss_alloc;
+  YYSTYPE yyvs_alloc;
+};
 
 /* The size of the maximum gap between one aligned stack and the next.  */
 # define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
@@ -501,41 +447,45 @@ union yyalloc
      ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
-/* Copy COUNT objects from FROM to TO.  The source and destination do
-   not overlap.  */
-# ifndef YYCOPY
-#  if defined __GNUC__ && 1 < __GNUC__
-#   define YYCOPY(To, From, Count) \
-      __builtin_memcpy (To, From, (Count) * sizeof (*(From)))
-#  else
-#   define YYCOPY(To, From, Count)		\
-      do					\
-	{					\
-	  YYSIZE_T yyi;				\
-	  for (yyi = 0; yyi < (Count); yyi++)	\
-	    (To)[yyi] = (From)[yyi];		\
-	}					\
-      while (YYID (0))
-#  endif
-# endif
+# define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack)					\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack, Stack, yysize);				\
-	Stack = &yyptr->Stack;						\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYSIZE_T yynewbytes;                                            \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / sizeof (*yyptr);                          \
+      }                                                                 \
+    while (0)
 
 #endif
+
+#if defined YYCOPY_NEEDED && YYCOPY_NEEDED
+/* Copy COUNT objects from SRC to DST.  The source and destination do
+   not overlap.  */
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYSIZE_T yyi;                         \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
+#endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  124
@@ -548,17 +498,19 @@ union yyalloc
 #define YYNNTS  43
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  164
-/* YYNRULES -- Number of states.  */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  360
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   345
 
-#define YYTRANSLATE(YYX)						\
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                                \
+  ((unsigned) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -599,122 +551,30 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint16 yyprhs[] =
-{
-       0,     0,     3,     7,     9,    12,    14,    15,    17,    19,
-      21,    26,    31,    36,    41,    46,    51,    57,    62,    67,
-      73,    75,    77,    79,    81,    89,   100,   112,   116,   123,
-     128,   135,   145,   155,   165,   172,   183,   194,   195,   199,
-     202,   204,   207,   209,   216,   218,   225,   227,   231,   235,
-     238,   242,   244,   246,   247,   248,   249,   252,   255,   259,
-     261,   263,   265,   267,   269,   271,   274,   277,   282,   287,
-     289,   291,   294,   296,   300,   304,   308,   312,   316,   320,
-     324,   328,   332,   336,   340,   344,   347,   351,   355,   359,
-     363,   366,   369,   373,   377,   382,   387,   392,   399,   404,
-     411,   416,   423,   428,   435,   438,   441,   443,   445,   448,
-     450,   453,   456,   459,   461,   464,   467,   469,   472,   477,
-     482,   489,   494,   497,   501,   503,   507,   509,   513,   515,
-     519,   522,   525,   528,   531,   535,   538,   541,   543,   547,
-     550,   553,   556,   560,   563,   564,   568,   569,   578,   581,
-     582,   591,   599,   606,   609,   610,   612,   616,   621,   622,
-     625,   626,   628,   632,   634
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int16 yyrhs[] =
-{
-     107,     0,    -1,   107,   108,   109,    -1,   109,    -1,     1,
-     108,    -1,    98,    -1,    -1,   140,    -1,   146,    -1,   112,
-      -1,    49,   129,    42,    28,    -1,    49,   129,    42,   130,
-      -1,    49,   129,    75,   129,    -1,    49,   129,    76,   129,
-      -1,    51,    28,    91,   129,    -1,    51,    13,    91,   129,
-      -1,    51,    14,   129,    91,   129,    -1,    51,    28,    54,
-     129,    -1,    51,    13,    54,   129,    -1,    51,    14,   129,
-      54,   129,    -1,   129,    -1,   131,    -1,   111,    -1,   113,
-      -1,   120,    99,   119,   100,   126,   125,    32,    -1,   121,
-      91,   129,   125,    54,   129,   125,   126,   125,    32,    -1,
-     121,    91,   129,   125,    34,    54,   129,   125,   126,   125,
-      32,    -1,   127,   111,   125,    -1,   128,   129,   108,   126,
-     125,    32,    -1,   128,   129,    54,   129,    -1,   122,   119,
-      53,   126,   125,    32,    -1,   122,   119,    53,   126,   125,
-      58,   126,   125,    32,    -1,   122,   119,    53,   126,   125,
-     124,   115,   125,    32,    -1,   122,   119,    53,   126,   125,
-      58,   124,   111,   125,    -1,   122,   119,    52,   124,   111,
-     125,    -1,   122,   119,    52,   124,   111,   125,    58,   124,
-     111,   125,    -1,   122,   119,    52,   124,   111,   125,   116,
-     125,   114,   125,    -1,    -1,    58,   124,   111,    -1,   115,
-     118,    -1,   118,    -1,   116,   117,    -1,   117,    -1,   123,
-     119,    52,   124,   112,   125,    -1,   116,    -1,   123,   119,
-      52,   124,   126,   125,    -1,   129,    -1,   129,    91,   129,
-      -1,    99,   119,   100,    -1,    50,    57,    -1,    50,    56,
-      28,    -1,    41,    -1,    36,    -1,    -1,    -1,    -1,   126,
-     108,    -1,   126,   112,    -1,    55,    28,    52,    -1,    87,
-      -1,    12,    -1,    15,    -1,    31,    -1,    29,    -1,    23,
-      -1,    24,   129,    -1,    25,   148,    -1,    25,    99,   148,
-     100,    -1,    28,    99,   147,   100,    -1,    28,    -1,    13,
-      -1,    14,   129,    -1,   110,    -1,   129,    93,   129,    -1,
-     129,    94,   129,    -1,   129,    95,   129,    -1,   129,    96,
-     129,    -1,   129,    74,   129,    -1,   129,   101,   129,    -1,
-     129,   102,   129,    -1,   129,    70,   129,    -1,   129,    65,
-     129,    -1,   129,    66,   129,    -1,   129,    71,   129,    -1,
-     129,    72,   129,    -1,    73,   129,    -1,   129,    92,   129,
-      -1,   129,    77,   129,    -1,   129,    78,   129,    -1,   129,
-      79,   129,    -1,    93,   129,    -1,    94,   129,    -1,    99,
-     129,   100,    -1,   103,   147,   104,    -1,    84,   129,    85,
-     129,    -1,    84,   129,    86,   129,    -1,    80,   129,    47,
-     129,    -1,    80,   129,    54,   129,    47,   129,    -1,    81,
-     129,    47,   129,    -1,    81,   129,    54,   129,    47,   129,
-      -1,    82,   129,    47,   129,    -1,    82,   129,    54,   129,
-      47,   129,    -1,    83,   129,    47,   129,    -1,    83,   129,
-      54,   129,    47,   129,    -1,    27,   129,    -1,    49,   129,
-      -1,   135,    -1,   138,    -1,    37,    50,    -1,    37,    -1,
-      39,   132,    -1,    88,   133,    -1,    64,   134,    -1,    17,
-      -1,    19,   129,    -1,    18,   129,    -1,    18,    -1,    20,
-     148,    -1,    20,    99,   148,   100,    -1,    90,    99,    28,
-     100,    -1,    90,    99,    28,   105,   147,   100,    -1,    61,
-     129,    56,   129,    -1,    61,   129,    -1,    21,    28,   147,
-      -1,    28,    -1,   132,   105,    28,    -1,    28,    -1,   133,
-     105,    28,    -1,    28,    -1,   134,   105,    28,    -1,    40,
-      43,    -1,    40,    46,    -1,    40,    48,    -1,    40,   136,
-      -1,    40,   136,   137,    -1,    40,   137,    -1,    38,   129,
-      -1,   129,    -1,    47,    45,   129,    -1,    45,   129,    -1,
-      62,    63,    -1,    62,   136,    -1,    62,   136,   137,    -1,
-      62,   137,    -1,    -1,    33,   139,   147,    -1,    -1,    44,
-      28,   141,   124,   144,   108,   145,   126,    -1,    59,    28,
-      -1,    -1,    60,    28,   142,   124,   144,   108,   145,   126,
-      -1,   143,   124,   144,   108,   145,   126,    32,    -1,   143,
-     124,   144,   108,   145,   126,    -1,    89,    28,    -1,    -1,
-      28,    -1,   144,   105,    28,    -1,   144,   108,   105,    28,
-      -1,    -1,    28,   148,    -1,    -1,   129,    -1,   147,   105,
-     129,    -1,   129,    -1,   148,   105,   129,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
+  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
        0,   119,   119,   120,   121,   124,   129,   130,   131,   132,
-     135,   141,   144,   145,   146,   152,   160,   168,   174,   182,
-     192,   193,   196,   197,   202,   215,   233,   247,   253,   256,
-     261,   271,   283,   295,   305,   315,   325,   337,   338,   341,
-     342,   345,   346,   349,   357,   358,   366,   367,   368,   371,
-     374,   381,   388,   396,   399,   402,   403,   404,   407,   413,
-     417,   418,   421,   424,   427,   430,   433,   434,   435,   438,
-     442,   449,   455,   456,   457,   458,   459,   460,   461,   462,
-     463,   464,   465,   466,   467,   468,   469,   470,   471,   472,
-     473,   474,   475,   476,   477,   478,   479,   480,   481,   482,
-     483,   484,   485,   486,   489,   494,   495,   496,   497,   498,
-     499,   500,   501,   502,   505,   508,   511,   515,   516,   517,
-     518,   519,   520,   521,   524,   525,   528,   529,   532,   533,
-     544,   545,   546,   547,   550,   553,   558,   559,   562,   563,
-     566,   567,   570,   573,   576,   576,   606,   606,   611,   614,
-     614,   619,   627,   634,   636,   637,   638,   639,   642,   646,
-     654,   655,   656,   659,   660
+     135,   141,   144,   145,   146,   152,   159,   165,   171,   178,
+     186,   187,   190,   191,   196,   209,   227,   241,   247,   250,
+     255,   265,   277,   289,   299,   309,   319,   331,   332,   335,
+     336,   339,   340,   343,   351,   352,   360,   361,   362,   365,
+     368,   375,   382,   390,   393,   396,   397,   398,   401,   407,
+     411,   414,   417,   420,   423,   426,   429,   430,   431,   434,
+     438,   446,   452,   453,   454,   455,   456,   457,   458,   459,
+     460,   461,   462,   463,   464,   465,   466,   467,   468,   469,
+     470,   471,   472,   473,   474,   475,   476,   477,   478,   479,
+     480,   481,   482,   483,   486,   491,   492,   493,   494,   495,
+     496,   497,   498,   499,   502,   505,   508,   512,   513,   514,
+     515,   516,   517,   518,   521,   522,   525,   526,   529,   530,
+     541,   542,   543,   544,   548,   552,   558,   559,   562,   563,
+     566,   567,   571,   575,   579,   579,   609,   609,   614,   617,
+     617,   622,   630,   637,   639,   640,   641,   642,   645,   649,
+     657,   658,   659,   662,   663
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || YYTOKEN_TABLE
+#if YYDEBUG || YYERROR_VERBOSE || 0
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
@@ -740,14 +600,14 @@ static const char *const yytname[] =
   "cond", "repeatwhile", "repeatwith", "if", "elseif", "begin", "end",
   "stmtlist", "when", "tell", "expr", "reference", "proc", "globallist",
   "propertylist", "instancelist", "gotofunc", "gotoframe", "gotomovie",
-  "playfunc", "@1", "defn", "@2", "@3", "on", "argdef", "argstore",
-  "macro", "arglist", "nonemptyarglist", 0
+  "playfunc", "$@1", "defn", "$@2", "$@3", "on", "argdef", "argstore",
+  "macro", "arglist", "nonemptyarglist", YY_NULLPTR
 };
 #endif
 
 # ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
+/* YYTOKNUM[NUM] -- (External) token number corresponding to the
+   (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
@@ -764,106 +624,18 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
-{
-       0,   106,   107,   107,   107,   108,   109,   109,   109,   109,
-     110,   110,   110,   110,   110,   110,   110,   110,   110,   110,
-     111,   111,   112,   112,   112,   112,   112,   112,   112,   112,
-     113,   113,   113,   113,   113,   113,   113,   114,   114,   115,
-     115,   116,   116,   117,   118,   118,   119,   119,   119,   120,
-     121,   122,   123,   124,   125,   126,   126,   126,   127,   128,
-     129,   129,   129,   129,   129,   129,   129,   129,   129,   129,
-     129,   129,   129,   129,   129,   129,   129,   129,   129,   129,
-     129,   129,   129,   129,   129,   129,   129,   129,   129,   129,
-     129,   129,   129,   129,   129,   129,   129,   129,   129,   129,
-     129,   129,   129,   129,   130,   131,   131,   131,   131,   131,
-     131,   131,   131,   131,   131,   131,   131,   131,   131,   131,
-     131,   131,   131,   131,   132,   132,   133,   133,   134,   134,
-     135,   135,   135,   135,   135,   135,   136,   136,   137,   137,
-     138,   138,   138,   138,   139,   138,   141,   140,   140,   142,
-     140,   140,   140,   143,   144,   144,   144,   144,   145,   146,
-     147,   147,   147,   148,   148
-};
-
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
-{
-       0,     2,     3,     1,     2,     1,     0,     1,     1,     1,
-       4,     4,     4,     4,     4,     4,     5,     4,     4,     5,
-       1,     1,     1,     1,     7,    10,    11,     3,     6,     4,
-       6,     9,     9,     9,     6,    10,    10,     0,     3,     2,
-       1,     2,     1,     6,     1,     6,     1,     3,     3,     2,
-       3,     1,     1,     0,     0,     0,     2,     2,     3,     1,
-       1,     1,     1,     1,     1,     2,     2,     4,     4,     1,
-       1,     2,     1,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     2,     3,     3,     3,     3,
-       2,     2,     3,     3,     4,     4,     4,     6,     4,     6,
-       4,     6,     4,     6,     2,     2,     1,     1,     2,     1,
-       2,     2,     2,     1,     2,     2,     1,     2,     4,     4,
-       6,     4,     2,     3,     1,     3,     1,     3,     1,     3,
-       2,     2,     2,     2,     3,     2,     2,     1,     3,     2,
-       2,     2,     3,     2,     0,     3,     0,     8,     2,     0,
-       8,     7,     6,     2,     0,     1,     3,     4,     0,     2,
-       0,     1,     3,     1,     3
-};
-
-/* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
-   STATE-NUM when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const yytype_uint8 yydefact[] =
-{
-       0,     0,    60,    70,     0,    61,   113,   116,     0,     0,
-       0,    64,     0,     0,    69,    63,    62,   144,   109,     0,
-       0,    51,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
-       0,     0,     0,     0,     0,   160,     0,     3,    72,    22,
-       9,    23,     0,     0,     0,     0,     0,    20,    21,   106,
-     107,     7,    53,     8,     5,     4,    69,     0,    71,   115,
-     114,     0,   163,   117,   160,    65,     0,    66,   160,   159,
-     160,   108,   124,   110,     0,   130,     0,   131,     0,   132,
-     137,   133,   135,   146,   105,     0,    49,     0,     0,     0,
-       0,   148,   149,   122,   140,   141,   143,   128,   112,    85,
-       0,     0,     0,     0,     0,   126,   111,   153,     0,    90,
-      91,     0,   161,     0,     1,     6,     0,     0,     0,     0,
-      46,    54,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   154,
-     160,     0,   163,     0,     0,   123,     0,   161,     0,   145,
-       0,   136,   139,     0,   134,    53,     0,     0,     0,    50,
-       0,     0,     0,     0,     0,    58,    53,     0,   142,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    92,    93,     0,     2,     0,    54,     0,     0,
-      53,    55,     0,    27,     0,    55,    81,    82,    80,    83,
-      84,    77,    87,    88,    89,    86,    73,    74,    75,    76,
-      78,    79,   155,     0,   118,   164,    67,    68,   125,   138,
-     154,     0,    10,    11,    12,    13,    18,    15,     0,     0,
-      17,    14,   154,   121,   129,    96,     0,    98,     0,   100,
-       0,   102,     0,    94,    95,   127,   119,   160,   162,    55,
-       0,    48,     0,    54,    47,    29,    54,     0,   158,     0,
-     104,    19,    16,     0,     0,     0,     0,     0,     0,    54,
-       0,     0,    54,    56,    57,    53,     0,   156,     0,    55,
-     158,   158,    97,    99,   101,   103,   120,     0,     0,    54,
-      34,    30,    53,     0,    28,   157,   152,    55,    55,    24,
-      54,    55,    52,    53,    54,    42,     0,     0,    54,    54,
-      44,    40,     0,   151,   147,   150,    55,    54,     0,    41,
-      37,     0,    54,     0,    39,     0,     0,    54,     0,    54,
-      53,    54,    53,    33,    31,    32,    53,     0,    25,    35,
-       0,    36,     0,    55,    26,    38,    54,    54,    43,    45
-};
-
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int16 yydefgoto[] =
-{
-      -1,    46,   283,    47,    48,    49,   284,    51,   341,   319,
-     320,   315,   321,   129,    52,    53,    54,   316,   149,   203,
-     263,    55,    56,    57,   233,    58,    83,   116,   108,    59,
-      91,    92,    60,    80,    61,   165,   176,    62,   223,   289,
-      63,   158,    73
-};
-
-/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-   STATE-NUM.  */
 #define YYPACT_NINF -281
+
+#define yypact_value_is_default(Yystate) \
+  (!!((Yystate) == (-281)))
+
+#define YYTABLE_NINF -56
+
+#define yytable_value_is_error(Yytable_value) \
+  0
+
+  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+     STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
      348,   -80,  -281,  -281,  1005,  -281,  -281,  1005,  1005,  1045,
@@ -904,7 +676,50 @@ static const yytype_int16 yypact[] =
      808,  -281,   716,   716,  -281,  -281,  -281,   624,  -281,  -281
 };
 
-/* YYPGOTO[NTERM-NUM].  */
+  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+     Performed when YYTABLE does not specify something else to do.  Zero
+     means the default is an error.  */
+static const yytype_uint8 yydefact[] =
+{
+       0,     0,    60,    70,     0,    61,   113,   116,     0,     0,
+       0,    64,     0,     0,    69,    63,    62,   144,   109,     0,
+       0,    51,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
+       0,     0,     0,     0,     0,   160,     0,     3,    72,    22,
+       9,    23,     0,     0,     0,     0,     0,    20,    21,   106,
+     107,     7,    53,     8,     5,     4,    69,     0,    71,   115,
+     114,     0,   163,   117,   160,    65,     0,    66,   160,   159,
+     160,   108,   124,   110,     0,   130,     0,   131,     0,   132,
+     137,   133,   135,   146,   105,     0,    49,     0,     0,     0,
+       0,   148,   149,   122,   140,   141,   143,   128,   112,    85,
+       0,     0,     0,     0,     0,   126,   111,   153,     0,    90,
+      91,     0,   161,     0,     1,     6,     0,     0,     0,     0,
+      46,    54,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   154,
+     160,     0,   163,     0,     0,   123,     0,   161,     0,   145,
+       0,   136,   139,     0,   134,    53,     0,     0,     0,    50,
+       0,     0,     0,     0,     0,    58,    53,     0,   142,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    92,    93,     0,     2,     0,    54,     0,     0,
+      53,    55,     0,    27,     0,    55,    81,    82,    80,    83,
+      84,    77,    87,    88,    89,    86,    73,    74,    75,    76,
+      78,    79,   155,     0,   118,   164,    67,    68,   125,   138,
+     154,     0,    10,    11,    12,    13,    18,    15,     0,     0,
+      17,    14,   154,   121,   129,    96,     0,    98,     0,   100,
+       0,   102,     0,    94,    95,   127,   119,   160,   162,    55,
+       0,    48,     0,    54,    47,    29,    54,     0,   158,     0,
+     104,    19,    16,     0,     0,     0,     0,     0,     0,    54,
+       0,     0,    54,    56,    57,    53,     0,   156,     0,    55,
+     158,   158,    97,    99,   101,   103,   120,     0,     0,    54,
+      34,    30,    53,     0,    28,   157,   152,    55,    55,    24,
+      54,    55,    52,    53,    54,    42,     0,     0,    54,    54,
+      44,    40,     0,   151,   147,   150,    55,    54,     0,    41,
+      37,     0,    54,     0,    39,     0,     0,    54,     0,    54,
+      53,    54,    53,    33,    31,    32,    53,     0,    25,    35,
+       0,    36,     0,    55,    26,    38,    54,    54,    43,    45
+};
+
+  /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
     -281,  -281,    18,    85,  -281,   -54,     0,  -281,  -281,  -281,
@@ -914,11 +729,19 @@ static const yytype_int16 yypgoto[] =
     -281,   -33,    12
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If zero, do what YYDEFACT says.
-   If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -56
+  /* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int16 yydefgoto[] =
+{
+      -1,    46,   283,    47,    48,    49,   284,    51,   341,   319,
+     320,   315,   321,   129,    52,    53,    54,   316,   149,   203,
+     263,    55,    56,    57,   233,    58,    83,   116,   108,    59,
+      91,    92,    60,    80,    61,   165,   176,    62,   223,   289,
+      63,   158,    73
+};
+
+  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+     positive, shift that token.  If negative, reduce the rule whose
+     number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
       50,   131,   196,   124,   198,    68,   301,   312,    69,    70,
@@ -1287,8 +1110,8 @@ static const yytype_int16 yycheck[] =
       -1,   101,   102
 };
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
+  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
+     symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
        0,     1,    12,    13,    14,    15,    17,    18,    19,    20,
@@ -1329,95 +1152,85 @@ static const yytype_uint8 yystos[] =
      124,   125,   124,   124,    32,   111,   112,   126,   125,   125
 };
 
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
+  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+static const yytype_uint8 yyr1[] =
+{
+       0,   106,   107,   107,   107,   108,   109,   109,   109,   109,
+     110,   110,   110,   110,   110,   110,   110,   110,   110,   110,
+     111,   111,   112,   112,   112,   112,   112,   112,   112,   112,
+     113,   113,   113,   113,   113,   113,   113,   114,   114,   115,
+     115,   116,   116,   117,   118,   118,   119,   119,   119,   120,
+     121,   122,   123,   124,   125,   126,   126,   126,   127,   128,
+     129,   129,   129,   129,   129,   129,   129,   129,   129,   129,
+     129,   129,   129,   129,   129,   129,   129,   129,   129,   129,
+     129,   129,   129,   129,   129,   129,   129,   129,   129,   129,
+     129,   129,   129,   129,   129,   129,   129,   129,   129,   129,
+     129,   129,   129,   129,   130,   131,   131,   131,   131,   131,
+     131,   131,   131,   131,   131,   131,   131,   131,   131,   131,
+     131,   131,   131,   131,   132,   132,   133,   133,   134,   134,
+     135,   135,   135,   135,   135,   135,   136,   136,   137,   137,
+     138,   138,   138,   138,   139,   138,   141,   140,   140,   142,
+     140,   140,   140,   143,   144,   144,   144,   144,   145,   146,
+     147,   147,   147,   148,   148
+};
 
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
+  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+static const yytype_uint8 yyr2[] =
+{
+       0,     2,     3,     1,     2,     1,     0,     1,     1,     1,
+       4,     4,     4,     4,     4,     4,     5,     4,     4,     5,
+       1,     1,     1,     1,     7,    10,    11,     3,     6,     4,
+       6,     9,     9,     9,     6,    10,    10,     0,     3,     2,
+       1,     2,     1,     6,     1,     6,     1,     3,     3,     2,
+       3,     1,     1,     0,     0,     0,     2,     2,     3,     1,
+       1,     1,     1,     1,     1,     2,     2,     4,     4,     1,
+       1,     2,     1,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     2,     3,     3,     3,     3,
+       2,     2,     3,     3,     4,     4,     4,     6,     4,     6,
+       4,     6,     4,     6,     2,     2,     1,     1,     2,     1,
+       2,     2,     2,     1,     2,     2,     1,     2,     4,     4,
+       6,     4,     2,     3,     1,     3,     1,     3,     1,     3,
+       2,     2,     2,     2,     3,     2,     2,     1,     3,     2,
+       2,     2,     3,     2,     0,     3,     0,     8,     2,     0,
+       8,     7,     6,     2,     0,     1,     3,     4,     0,     2,
+       0,     1,     3,     1,     3
+};
 
 
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  */
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+#define YYEMPTY         (-2)
+#define YYEOF           0
 
-#define YYFAIL		goto yyerrlab
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)					\
-do								\
-  if (yychar == YYEMPTY && yylen == 1)				\
-    {								\
-      yychar = (Token);						\
-      yylval = (Value);						\
-      yytoken = YYTRANSLATE (yychar);				\
-      YYPOPSTACK (1);						\
-      goto yybackup;						\
-    }								\
-  else								\
-    {								\
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
+
+/* Error token number */
+#define YYTERROR        1
+#define YYERRCODE       256
 
 
-#define YYTERROR	1
-#define YYERRCODE	256
-
-
-/* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
-   If N is 0, then set CURRENT to the empty location which ends
-   the previous symbol: RHS[0] (always defined).  */
-
-#define YYRHSLOC(Rhs, K) ((Rhs)[K])
-#ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)				\
-    do									\
-      if (YYID (N))                                                    \
-	{								\
-	  (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;	\
-	  (Current).first_column = YYRHSLOC (Rhs, 1).first_column;	\
-	  (Current).last_line    = YYRHSLOC (Rhs, N).last_line;		\
-	  (Current).last_column  = YYRHSLOC (Rhs, N).last_column;	\
-	}								\
-      else								\
-	{								\
-	  (Current).first_line   = (Current).last_line   =		\
-	    YYRHSLOC (Rhs, 0).last_line;				\
-	  (Current).first_column = (Current).last_column =		\
-	    YYRHSLOC (Rhs, 0).last_column;				\
-	}								\
-    while (YYID (0))
-#endif
-
-
-/* YY_LOCATION_PRINT -- Print the location on the stream.
-   This macro was not mandated originally: define only if we know
-   we won't break user code: when these are the locations we know.  */
-
-#ifndef YY_LOCATION_PRINT
-# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-#  define YY_LOCATION_PRINT(File, Loc)			\
-     fprintf (File, "%d.%d-%d.%d",			\
-	      (Loc).first_line, (Loc).first_column,	\
-	      (Loc).last_line,  (Loc).last_column)
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
-
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (YYLEX_PARAM)
-#else
-# define YYLEX yylex ()
-#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
@@ -1427,82 +1240,61 @@ while (YYID (0))
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
-
-
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
-
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
+/* This macro is provided for backward compatibility. */
+#ifndef YY_LOCATION_PRINT
+# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
 #endif
+
+
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Type, Value); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
+
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
+
+static void
+yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
+  FILE *yyoutput = yyo;
+  YYUSE (yyoutput);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
+    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
 # endif
-/*
-  switch (yytype)
-    {
-      default:
-	break;
-    }
-*/
+  YYUSE (yytype);
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-#endif
+yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yytype, yyvaluep);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -1510,66 +1302,54 @@ yy_symbol_print (yyoutput, yytype, yyvaluep)
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_stack_print (yytype_int16 *bottom, yytype_int16 *top)
-#else
-static void
-yy_stack_print (bottom, top)
-    yytype_int16 *bottom;
-    yytype_int16 *top;
-#endif
+yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
-  for (; bottom <= top; ++bottom)
-    YYFPRINTF (stderr, " %d", *bottom);
+  for (; yybottom <= yytop; yybottom++)
+    {
+      int yybot = *yybottom;
+      YYFPRINTF (stderr, " %d", yybot);
+    }
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, int yyrule)
-#else
-static void
-yy_reduce_print (yyvsp, yyrule)
-    YYSTYPE *yyvsp;
-    int yyrule;
-#endif
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
 {
+  unsigned long yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
-      fprintf (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       		       );
-      fprintf (stderr, "\n");
+      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
+      yy_symbol_print (stderr,
+                       yystos[yyssp[yyi + 1 - yynrhs]],
+                       &yyvsp[(yyi + 1) - (yynrhs)]
+                                              );
+      YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, Rule); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, Rule); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
@@ -1583,7 +1363,7 @@ int yydebug;
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -1599,7 +1379,6 @@ int yydebug;
 #endif
 
 
-
 #if YYERROR_VERBOSE
 
 # ifndef yystrlen
@@ -1607,15 +1386,8 @@ int yydebug;
 #   define yystrlen strlen
 #  else
 /* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static YYSIZE_T
 yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
 {
   YYSIZE_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
@@ -1631,16 +1403,8 @@ yystrlen (yystr)
 #  else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static char *
 yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
 {
   char *yyd = yydest;
   const char *yys = yysrc;
@@ -1670,244 +1434,245 @@ yytnamerr (char *yyres, const char *yystr)
       char const *yyp = yystr;
 
       for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
 
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            else
+              goto append;
 
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
+          append:
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
+
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
     do_not_strip_quotes: ;
     }
 
   if (! yyres)
     return yystrlen (yystr);
 
-  return yystpcpy (yyres, yystr) - yyres;
+  return (YYSIZE_T) (yystpcpy (yyres, yystr) - yyres);
 }
 # endif
 
-/* Copy into YYRESULT an error message about the unexpected token
-   YYCHAR while in state YYSTATE.  Return the number of bytes copied,
-   including the terminating null byte.  If YYRESULT is null, do not
-   copy anything; just return the number of bytes that would be
-   copied.  As a special case, return 0 if an ordinary "syntax error"
-   message will do.  Return YYSIZE_MAXIMUM if overflow occurs during
-   size calculation.  */
-static YYSIZE_T
-yysyntax_error (char *yyresult, int yystate, int yychar)
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
+                yytype_int16 *yyssp, int yytoken)
 {
-  int yyn = yypact[yystate];
+  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
+  YYSIZE_T yysize = yysize0;
+  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat. */
+  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
+  /* Number of reported tokens (one for the "unexpected", one per
+     "expected"). */
+  int yycount = 0;
 
-  if (! (YYPACT_NINF < yyn && yyn <= YYLAST))
-    return 0;
-  else
+  /* There are many possibilities here to consider:
+     - If this state is a consistent state with a default action, then
+       the only way this function was invoked is if the default action
+       is an error action.  In that case, don't check for expected
+       tokens because there are none.
+     - The only way there can be no lookahead present (in yychar) is if
+       this state is a consistent state with a default action.  Thus,
+       detecting the absence of a lookahead is sufficient to determine
+       that there is no unexpected or expected token to report.  In that
+       case, just report a simple "syntax error".
+     - Don't assume there isn't a lookahead just because this state is a
+       consistent state with a default action.  There might have been a
+       previous inconsistent state, consistent state with a non-default
+       action, or user semantic action that manipulated yychar.
+     - Of course, the expected token list depends on states to have
+       correct lookahead information, and it depends on the parser not
+       to perform extra reductions after fetching a lookahead from the
+       scanner and before detecting a syntax error.  Thus, state merging
+       (from LALR or IELR) and default reductions corrupt the expected
+       token list.  However, the list is correct for canonical LR with
+       one exception: it will still contain any token that will not be
+       accepted due to an error action in a later state.
+  */
+  if (yytoken != YYEMPTY)
     {
-      int yytype = YYTRANSLATE (yychar);
-      YYSIZE_T yysize0 = yytnamerr (0, yytname[yytype]);
-      YYSIZE_T yysize = yysize0;
-      YYSIZE_T yysize1;
-      int yysize_overflow = 0;
-      enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-      char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-      int yyx;
+      int yyn = yypact[*yyssp];
+      yyarg[yycount++] = yytname[yytoken];
+      if (!yypact_value_is_default (yyn))
+        {
+          /* Start YYX at -YYN if negative to avoid negative indexes in
+             YYCHECK.  In other words, skip the first -YYN actions for
+             this state because they are default actions.  */
+          int yyxbegin = yyn < 0 ? -yyn : 0;
+          /* Stay within bounds of both yycheck and yytname.  */
+          int yychecklim = YYLAST - yyn + 1;
+          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+          int yyx;
 
-# if 0
-      /* This is so xgettext sees the translatable formats that are
-	 constructed on the fly.  */
-      YY_("syntax error, unexpected %s");
-      YY_("syntax error, unexpected %s, expecting %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s");
-# endif
-      char *yyfmt;
-      char const *yyf;
-      static char const yyunexpected[] = "syntax error, unexpected %s";
-      static char const yyexpecting[] = ", expecting %s";
-      static char const yyor[] = " or %s";
-      char yyformat[sizeof yyunexpected
-		    + sizeof yyexpecting - 1
-		    + ((YYERROR_VERBOSE_ARGS_MAXIMUM - 2)
-		       * (sizeof yyor - 1))];
-      char const *yyprefix = yyexpecting;
-
-      /* Start YYX at -YYN if negative to avoid negative indexes in
-	 YYCHECK.  */
-      int yyxbegin = yyn < 0 ? -yyn : 0;
-
-      /* Stay within bounds of both yycheck and yytname.  */
-      int yychecklim = YYLAST - yyn + 1;
-      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-      int yycount = 1;
-
-      yyarg[0] = yytname[yytype];
-      yyfmt = yystpcpy (yyformat, yyunexpected);
-
-      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-	if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
-	  {
-	    if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-	      {
-		yycount = 1;
-		yysize = yysize0;
-		yyformat[sizeof yyunexpected - 1] = '\0';
-		break;
-	      }
-	    yyarg[yycount++] = yytname[yyx];
-	    yysize1 = yysize + yytnamerr (0, yytname[yyx]);
-	    yysize_overflow |= (yysize1 < yysize);
-	    yysize = yysize1;
-	    yyfmt = yystpcpy (yyfmt, yyprefix);
-	    yyprefix = yyor;
-	  }
-
-      yyf = YY_(yyformat);
-      yysize1 = yysize + yystrlen (yyf);
-      yysize_overflow |= (yysize1 < yysize);
-      yysize = yysize1;
-
-      if (yysize_overflow)
-	return YYSIZE_MAXIMUM;
-
-      if (yyresult)
-	{
-	  /* Avoid sprintf, as that infringes on the user's name space.
-	     Don't have undefined behavior even if the translation
-	     produced a string with the wrong number of "%s"s.  */
-	  char *yyp = yyresult;
-	  int yyi = 0;
-	  while ((*yyp = *yyf) != '\0')
-	    {
-	      if (*yyp == '%' && yyf[1] == 's' && yyi < yycount)
-		{
-		  yyp += yytnamerr (yyp, yyarg[yyi++]);
-		  yyf += 2;
-		}
-	      else
-		{
-		  yyp++;
-		  yyf++;
-		}
-	    }
-	}
-      return yysize;
+          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
+                && !yytable_value_is_error (yytable[yyx + yyn]))
+              {
+                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
+                  {
+                    yycount = 1;
+                    yysize = yysize0;
+                    break;
+                  }
+                yyarg[yycount++] = yytname[yyx];
+                {
+                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
+                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+                    yysize = yysize1;
+                  else
+                    return 2;
+                }
+              }
+        }
     }
+
+  switch (yycount)
+    {
+# define YYCASE_(N, S)                      \
+      case N:                               \
+        yyformat = S;                       \
+      break
+    default: /* Avoid compiler warnings. */
+      YYCASE_(0, YY_("syntax error"));
+      YYCASE_(1, YY_("syntax error, unexpected %s"));
+      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
+      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
+      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
+      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
+# undef YYCASE_
+    }
+
+  {
+    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
+    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+      yysize = yysize1;
+    else
+      return 2;
+  }
+
+  if (*yymsg_alloc < yysize)
+    {
+      *yymsg_alloc = 2 * yysize;
+      if (! (yysize <= *yymsg_alloc
+             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
+        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
+      return 1;
+    }
+
+  /* Avoid sprintf, as that infringes on the user's name space.
+     Don't have undefined behavior even if the translation
+     produced a string with the wrong number of "%s"s.  */
+  {
+    char *yyp = *yymsg;
+    int yyi = 0;
+    while ((*yyp = *yyformat) != '\0')
+      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
+        {
+          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyformat += 2;
+        }
+      else
+        {
+          yyp++;
+          yyformat++;
+        }
+  }
+  return 0;
 }
 #endif /* YYERROR_VERBOSE */
-
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-#endif
 {
   YYUSE (yyvaluep);
-
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
-/*
-  switch (yytype)
-    {
-
-      default:
-	break;
-    }
-*/
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/* Prevent warnings from -Wmissing-prototypes.  */
-
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void *YYPARSE_PARAM);
-#else
-int yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void);
-#else
-int yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
 
-
-/* The look-ahead symbol.  */
+/* The lookahead symbol.  */
 int yychar;
 
-/* The semantic value of the look-ahead symbol.  */
+/* The semantic value of the lookahead symbol.  */
 YYSTYPE yylval;
-
 /* Number of syntax errors so far.  */
 int yynerrs;
-
 
 
 /*----------.
 | yyparse.  |
 `----------*/
 
-#ifdef YYPARSE_PARAM
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-int
-yyparse (void *YYPARSE_PARAM)
-#else
-int
-yyparse (YYPARSE_PARAM)
-    void *YYPARSE_PARAM;
-#endif
-#else /* ! YYPARSE_PARAM */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
 yyparse (void)
-#else
-int
-yyparse ()
-
-#endif
-#endif
 {
+    int yystate;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus;
 
-  int yystate;
+    /* The stacks and their tools:
+       'yyss': related to states.
+       'yyvs': related to semantic values.
+
+       Refer to the stacks through separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
+
+    /* The state stack.  */
+    yytype_int16 yyssa[YYINITDEPTH];
+    yytype_int16 *yyss;
+    yytype_int16 *yyssp;
+
+    /* The semantic value stack.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs;
+    YYSTYPE *yyvsp;
+
+    YYSIZE_T yystacksize;
+
   int yyn;
   int yyresult;
-  /* Number of tokens to shift before error messages enabled.  */
-  int yyerrstatus;
-  /* Look-ahead token as an internal (translated) token number.  */
+  /* Lookahead token as an internal (translated) token number.  */
   int yytoken = 0;
+  /* The variables used to return semantic value and location from the
+     action routines.  */
+  YYSTYPE yyval;
+
 #if YYERROR_VERBOSE
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
@@ -1915,156 +1680,127 @@ yyparse ()
   YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
 #endif
 
-  /* Three stacks and their tools:
-     `yyss': related to states,
-     `yyvs': related to semantic values,
-     `yyls': related to locations.
-
-     Refer to the stacks thru separate pointers, to allow yyoverflow
-     to reallocate them elsewhere.  */
-
-  /* The state stack.  */
-  yytype_int16 yyssa[YYINITDEPTH];
-  yytype_int16 *yyss = yyssa;
-  yytype_int16 *yyssp;
-
-  /* The semantic value stack.  */
-  YYSTYPE yyvsa[YYINITDEPTH];
-  YYSTYPE *yyvs = yyvsa;
-  YYSTYPE *yyvsp;
-
-
-
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
-
-  YYSIZE_T yystacksize = YYINITDEPTH;
-
-  /* The variables used to return semantic value and location from the
-     action routines.  */
-  YYSTYPE yyval;
-
 
   /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
+
+  yyssp = yyss = yyssa;
+  yyvsp = yyvs = yyvsa;
+  yystacksize = YYINITDEPTH;
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 
   yystate = 0;
   yyerrstatus = 0;
   yynerrs = 0;
-  yychar = YYEMPTY;		/* Cause a token to be read.  */
-
-  /* Initialize stack pointers.
-     Waste one element of value and location stack
-     so that they stay on the same level as the state stack.
-     The wasted elements are never initialized.  */
-
-  yyssp = yyss;
-  yyvsp = yyvs;
-
+  yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yynewstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  *yyssp = (yytype_int16) yystate;
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    goto yyexhaustedlab;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYSIZE_T yysize = (YYSIZE_T) (yyssp - yyss + 1);
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        YYSTYPE *yyvs1 = yyvs;
+        yytype_int16 *yyss1 = yyss;
 
-
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-
-		    &yystacksize);
-
-	yyss = yyss1;
-	yyvs = yyvs1;
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * sizeof (*yyssp),
+                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        goto yyexhaustedlab;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss);
-	YYSTACK_RELOCATE (yyvs);
-
-#  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        yytype_int16 *yyss1 = yyss;
+        union yyalloc *yyptr =
+          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+        if (! yyptr)
+          goto yyexhaustedlab;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+# undef YYSTACK_RELOCATE
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+                  (unsigned long) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  if (yystate == YYFINAL)
+    YYACCEPT;
 
   goto yybackup;
+
 
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
-     look-ahead token if we need one and don't already have one.  */
+     lookahead token if we need one and don't already have one.  */
 
-  /* First try to decide what to do without reference to look-ahead token.  */
+  /* First try to decide what to do without reference to lookahead token.  */
   yyn = yypact[yystate];
-  if (yyn == YYPACT_NINF)
+  if (yypact_value_is_default (yyn))
     goto yydefault;
 
-  /* Not known => get a look-ahead token if don't already have one.  */
+  /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid look-ahead symbol.  */
+  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
@@ -2086,30 +1822,27 @@ yybackup:
   yyn = yytable[yyn];
   if (yyn <= 0)
     {
-      if (yyn == 0 || yyn == YYTABLE_NINF)
-	goto yyerrlab;
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
       yyn = -yyn;
       goto yyreduce;
     }
-
-  if (yyn == YYFINAL)
-    YYACCEPT;
 
   /* Count tokens shifted since error; after three, turn off error
      status.  */
   if (yyerrstatus)
     yyerrstatus--;
 
-  /* Shift the look-ahead token.  */
+  /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
 
-  /* Discard the shifted token unless it is eof.  */
-  if (yychar != YYEOF)
-    yychar = YYEMPTY;
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
 
   yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
-
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
   goto yynewstate;
 
 
@@ -2124,14 +1857,14 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -2144,9 +1877,10 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 4:
+  case 4:
 #line 121 "engines/director/lingo/lingo-gr.y"
-    { yyerrok; ;}
+    { yyerrok; }
+#line 1884 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 5:
@@ -2154,938 +1888,1086 @@ yyreduce:
     {
 		g_lingo->_linenumber++;
 		g_lingo->_colnumber = 1;
-	;}
+	}
+#line 1893 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 10:
 #line 135 "engines/director/lingo/lingo-gr.y"
     {
 		g_lingo->code1(g_lingo->c_varpush);
-		g_lingo->codeString((yyvsp[(4) - (4)].s)->c_str());
+		g_lingo->codeString((yyvsp[0].s)->c_str());
 		g_lingo->code1(g_lingo->c_assign);
-		(yyval.code) = (yyvsp[(2) - (4)].code);
-		delete (yyvsp[(4) - (4)].s); ;}
+		(yyval.code) = (yyvsp[-2].code);
+		delete (yyvsp[0].s); }
+#line 1904 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 11:
 #line 141 "engines/director/lingo/lingo-gr.y"
     {
 			g_lingo->code1(g_lingo->c_assign);
-			(yyval.code) = (yyvsp[(2) - (4)].code); ;}
+			(yyval.code) = (yyvsp[-2].code); }
+#line 1912 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 12:
 #line 144 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = g_lingo->code1(g_lingo->c_after); ;}
+    { (yyval.code) = g_lingo->code1(g_lingo->c_after); }
+#line 1918 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 13:
 #line 145 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = g_lingo->code1(g_lingo->c_before); ;}
+    { (yyval.code) = g_lingo->code1(g_lingo->c_before); }
+#line 1924 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 14:
 #line 146 "engines/director/lingo/lingo-gr.y"
     {
 		g_lingo->code1(g_lingo->c_varpush);
-		g_lingo->codeString((yyvsp[(2) - (4)].s)->c_str());
+		g_lingo->codeString((yyvsp[-2].s)->c_str());
 		g_lingo->code1(g_lingo->c_assign);
-		(yyval.code) = (yyvsp[(4) - (4)].code);
-		delete (yyvsp[(2) - (4)].s); ;}
+		(yyval.code) = (yyvsp[0].code);
+		delete (yyvsp[-2].s); }
+#line 1935 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 15:
 #line 152 "engines/director/lingo/lingo-gr.y"
     {
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
-		inst e = 0, f = 0;
-		WRITE_UINT32(&e, (yyvsp[(2) - (4)].e)[0]);
-		WRITE_UINT32(&f, (yyvsp[(2) - (4)].e)[1]);
-		g_lingo->code2(e, f);
-		(yyval.code) = (yyvsp[(4) - (4)].code); ;}
+		g_lingo->codeInt((yyvsp[-2].e)[0]);
+		g_lingo->codeInt((yyvsp[-2].e)[1]);
+		(yyval.code) = (yyvsp[0].code); }
+#line 1947 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 16:
-#line 160 "engines/director/lingo/lingo-gr.y"
+#line 159 "engines/director/lingo/lingo-gr.y"
     {
 		g_lingo->code1(g_lingo->c_swap);
 		g_lingo->code1(g_lingo->c_theentityassign);
-		inst e = 0, f = 0;
-		WRITE_UINT32(&e, (yyvsp[(2) - (5)].e)[0]);
-		WRITE_UINT32(&f, (yyvsp[(2) - (5)].e)[1]);
-		g_lingo->code2(e, f);
-		(yyval.code) = (yyvsp[(5) - (5)].code); ;}
+		g_lingo->codeInt((yyvsp[-3].e)[0]);
+		g_lingo->codeInt((yyvsp[-3].e)[1]);
+		(yyval.code) = (yyvsp[0].code); }
+#line 1958 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 17:
-#line 168 "engines/director/lingo/lingo-gr.y"
+#line 165 "engines/director/lingo/lingo-gr.y"
     {
 		g_lingo->code1(g_lingo->c_varpush);
-		g_lingo->codeString((yyvsp[(2) - (4)].s)->c_str());
+		g_lingo->codeString((yyvsp[-2].s)->c_str());
 		g_lingo->code1(g_lingo->c_assign);
-		(yyval.code) = (yyvsp[(4) - (4)].code);
-		delete (yyvsp[(2) - (4)].s); ;}
+		(yyval.code) = (yyvsp[0].code);
+		delete (yyvsp[-2].s); }
+#line 1969 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 18:
-#line 174 "engines/director/lingo/lingo-gr.y"
+#line 171 "engines/director/lingo/lingo-gr.y"
     {
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
-		inst e = 0, f = 0;
-		WRITE_UINT32(&e, (yyvsp[(2) - (4)].e)[0]);
-		WRITE_UINT32(&f, (yyvsp[(2) - (4)].e)[1]);
-		g_lingo->code2(e, f);
-		(yyval.code) = (yyvsp[(4) - (4)].code); ;}
+		g_lingo->codeInt((yyvsp[-2].e)[0]);
+		g_lingo->codeInt((yyvsp[-2].e)[1]);
+		(yyval.code) = (yyvsp[0].code); }
+#line 1981 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 19:
-#line 182 "engines/director/lingo/lingo-gr.y"
+#line 178 "engines/director/lingo/lingo-gr.y"
     {
 		g_lingo->code1(g_lingo->c_swap);
 		g_lingo->code1(g_lingo->c_theentityassign);
-		inst e = 0, f = 0;
-		WRITE_UINT32(&e, (yyvsp[(2) - (5)].e)[0]);
-		WRITE_UINT32(&f, (yyvsp[(2) - (5)].e)[1]);
-		g_lingo->code2(e, f);
-		(yyval.code) = (yyvsp[(5) - (5)].code); ;}
+		g_lingo->codeInt((yyvsp[-3].e)[0]);
+		g_lingo->codeInt((yyvsp[-3].e)[1]);
+		(yyval.code) = (yyvsp[0].code); }
+#line 1992 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 24:
-#line 202 "engines/director/lingo/lingo-gr.y"
+#line 196 "engines/director/lingo/lingo-gr.y"
     {
 		inst body = 0, end = 0;
-		WRITE_UINT32(&body, (yyvsp[(5) - (7)].code) - (yyvsp[(1) - (7)].code));
-		WRITE_UINT32(&end, (yyvsp[(6) - (7)].code) - (yyvsp[(1) - (7)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (7)].code) + 1] = body;	/* body of loop */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (7)].code) + 2] = end;	/* end, if cond fails */
+		WRITE_UINT32(&body, (yyvsp[-2].code) - (yyvsp[-6].code));
+		WRITE_UINT32(&end, (yyvsp[-1].code) - (yyvsp[-6].code));
+		(*g_lingo->_currentScript)[(yyvsp[-6].code) + 1] = body;	/* body of loop */
+		(*g_lingo->_currentScript)[(yyvsp[-6].code) + 2] = end;	/* end, if cond fails */
 
-		checkEnd((yyvsp[(7) - (7)].s), "repeat", true); ;}
+		checkEnd((yyvsp[0].s), "repeat", true); }
+#line 2005 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 25:
-#line 215 "engines/director/lingo/lingo-gr.y"
+#line 209 "engines/director/lingo/lingo-gr.y"
     {
 		inst init = 0, finish = 0, body = 0, end = 0, inc = 0;
-		WRITE_UINT32(&init, (yyvsp[(3) - (10)].code) - (yyvsp[(1) - (10)].code));
-		WRITE_UINT32(&finish, (yyvsp[(6) - (10)].code) - (yyvsp[(1) - (10)].code));
-		WRITE_UINT32(&body, (yyvsp[(8) - (10)].code) - (yyvsp[(1) - (10)].code));
-		WRITE_UINT32(&end, (yyvsp[(9) - (10)].code) - (yyvsp[(1) - (10)].code));
+		WRITE_UINT32(&init, (yyvsp[-7].code) - (yyvsp[-9].code));
+		WRITE_UINT32(&finish, (yyvsp[-4].code) - (yyvsp[-9].code));
+		WRITE_UINT32(&body, (yyvsp[-2].code) - (yyvsp[-9].code));
+		WRITE_UINT32(&end, (yyvsp[-1].code) - (yyvsp[-9].code));
 		WRITE_UINT32(&inc, 1);
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 1] = init;	/* initial count value */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 2] = finish;/* final count value */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 3] = body;	/* body of loop */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 4] = inc;	/* increment */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 5] = end;	/* end, if cond fails */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 1] = init;	/* initial count value */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 2] = finish;/* final count value */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 3] = body;	/* body of loop */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 4] = inc;	/* increment */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 5] = end;	/* end, if cond fails */
 
-		checkEnd((yyvsp[(10) - (10)].s), "repeat", true); ;}
+		checkEnd((yyvsp[0].s), "repeat", true); }
+#line 2024 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 26:
-#line 233 "engines/director/lingo/lingo-gr.y"
+#line 227 "engines/director/lingo/lingo-gr.y"
     {
 		inst init = 0, finish = 0, body = 0, end = 0, inc = 0;
-		WRITE_UINT32(&init, (yyvsp[(3) - (11)].code) - (yyvsp[(1) - (11)].code));
-		WRITE_UINT32(&finish, (yyvsp[(7) - (11)].code) - (yyvsp[(1) - (11)].code));
-		WRITE_UINT32(&body, (yyvsp[(9) - (11)].code) - (yyvsp[(1) - (11)].code));
-		WRITE_UINT32(&end, (yyvsp[(10) - (11)].code) - (yyvsp[(1) - (11)].code));
+		WRITE_UINT32(&init, (yyvsp[-8].code) - (yyvsp[-10].code));
+		WRITE_UINT32(&finish, (yyvsp[-4].code) - (yyvsp[-10].code));
+		WRITE_UINT32(&body, (yyvsp[-2].code) - (yyvsp[-10].code));
+		WRITE_UINT32(&end, (yyvsp[-1].code) - (yyvsp[-10].code));
 		WRITE_UINT32(&inc, (uint32)-1);
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (11)].code) + 1] = init;	/* initial count value */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (11)].code) + 2] = finish;/* final count value */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (11)].code) + 3] = body;	/* body of loop */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (11)].code) + 4] = inc;	/* increment */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (11)].code) + 5] = end;	/* end, if cond fails */
+		(*g_lingo->_currentScript)[(yyvsp[-10].code) + 1] = init;	/* initial count value */
+		(*g_lingo->_currentScript)[(yyvsp[-10].code) + 2] = finish;/* final count value */
+		(*g_lingo->_currentScript)[(yyvsp[-10].code) + 3] = body;	/* body of loop */
+		(*g_lingo->_currentScript)[(yyvsp[-10].code) + 4] = inc;	/* increment */
+		(*g_lingo->_currentScript)[(yyvsp[-10].code) + 5] = end;	/* end, if cond fails */
 
-		checkEnd((yyvsp[(11) - (11)].s), "repeat", true); ;}
+		checkEnd((yyvsp[0].s), "repeat", true); }
+#line 2043 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 27:
-#line 247 "engines/director/lingo/lingo-gr.y"
+#line 241 "engines/director/lingo/lingo-gr.y"
     {
 			inst end = 0;
-			WRITE_UINT32(&end, (yyvsp[(3) - (3)].code) - (yyvsp[(1) - (3)].code));
+			WRITE_UINT32(&end, (yyvsp[0].code) - (yyvsp[-2].code));
 			g_lingo->code1(STOP);
-			(*g_lingo->_currentScript)[(yyvsp[(1) - (3)].code) + 1] = end;
-		;}
+			(*g_lingo->_currentScript)[(yyvsp[-2].code) + 1] = end;
+		}
+#line 2054 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 28:
-#line 253 "engines/director/lingo/lingo-gr.y"
+#line 247 "engines/director/lingo/lingo-gr.y"
     {
 			warning("STUB: TELL is not implemented");
-			checkEnd((yyvsp[(6) - (6)].s), "tell", true); ;}
+			checkEnd((yyvsp[0].s), "tell", true); }
+#line 2062 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 29:
-#line 256 "engines/director/lingo/lingo-gr.y"
+#line 250 "engines/director/lingo/lingo-gr.y"
     {
 			warning("STUB: TELL is not implemented");
-		;}
+		}
+#line 2070 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 30:
-#line 261 "engines/director/lingo/lingo-gr.y"
+#line 255 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0, end = 0;
-		WRITE_UINT32(&then, (yyvsp[(4) - (6)].code) - (yyvsp[(1) - (6)].code));
-		WRITE_UINT32(&end, (yyvsp[(5) - (6)].code) - (yyvsp[(1) - (6)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (6)].code) + 1] = then;	/* thenpart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (6)].code) + 3] = end;	/* end, if cond fails */
+		WRITE_UINT32(&then, (yyvsp[-2].code) - (yyvsp[-5].code));
+		WRITE_UINT32(&end, (yyvsp[-1].code) - (yyvsp[-5].code));
+		(*g_lingo->_currentScript)[(yyvsp[-5].code) + 1] = then;	/* thenpart */
+		(*g_lingo->_currentScript)[(yyvsp[-5].code) + 3] = end;	/* end, if cond fails */
 
-		checkEnd((yyvsp[(6) - (6)].s), "if", true);
+		checkEnd((yyvsp[0].s), "if", true);
 
-		g_lingo->processIf(0, 0); ;}
+		g_lingo->processIf(0, 0); }
+#line 2085 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 31:
-#line 271 "engines/director/lingo/lingo-gr.y"
+#line 265 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0, else1 = 0, end = 0;
-		WRITE_UINT32(&then, (yyvsp[(4) - (9)].code) - (yyvsp[(1) - (9)].code));
-		WRITE_UINT32(&else1, (yyvsp[(7) - (9)].code) - (yyvsp[(1) - (9)].code));
-		WRITE_UINT32(&end, (yyvsp[(8) - (9)].code) - (yyvsp[(1) - (9)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 1] = then;	/* thenpart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 2] = else1;	/* elsepart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 3] = end;	/* end, if cond fails */
+		WRITE_UINT32(&then, (yyvsp[-5].code) - (yyvsp[-8].code));
+		WRITE_UINT32(&else1, (yyvsp[-2].code) - (yyvsp[-8].code));
+		WRITE_UINT32(&end, (yyvsp[-1].code) - (yyvsp[-8].code));
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 1] = then;	/* thenpart */
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 2] = else1;	/* elsepart */
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 3] = end;	/* end, if cond fails */
 
-		checkEnd((yyvsp[(9) - (9)].s), "if", true);
+		checkEnd((yyvsp[0].s), "if", true);
 
-		g_lingo->processIf(0, 0); ;}
+		g_lingo->processIf(0, 0); }
+#line 2102 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 32:
-#line 283 "engines/director/lingo/lingo-gr.y"
+#line 277 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0, else1 = 0, end = 0;
-		WRITE_UINT32(&then, (yyvsp[(4) - (9)].code) - (yyvsp[(1) - (9)].code));
-		WRITE_UINT32(&else1, (yyvsp[(6) - (9)].code) - (yyvsp[(1) - (9)].code));
-		WRITE_UINT32(&end, (yyvsp[(8) - (9)].code) - (yyvsp[(1) - (9)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 1] = then;	/* thenpart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 2] = else1;	/* elsepart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 3] = end;	/* end, if cond fails */
+		WRITE_UINT32(&then, (yyvsp[-5].code) - (yyvsp[-8].code));
+		WRITE_UINT32(&else1, (yyvsp[-3].code) - (yyvsp[-8].code));
+		WRITE_UINT32(&end, (yyvsp[-1].code) - (yyvsp[-8].code));
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 1] = then;	/* thenpart */
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 2] = else1;	/* elsepart */
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 3] = end;	/* end, if cond fails */
 
-		checkEnd((yyvsp[(9) - (9)].s), "if", true);
+		checkEnd((yyvsp[0].s), "if", true);
 
-		g_lingo->processIf(0, (yyvsp[(8) - (9)].code) - (yyvsp[(1) - (9)].code)); ;}
+		g_lingo->processIf(0, (yyvsp[-1].code) - (yyvsp[-8].code)); }
+#line 2119 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 33:
-#line 295 "engines/director/lingo/lingo-gr.y"
+#line 289 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0, else1 = 0, end = 0;
-		WRITE_UINT32(&then, (yyvsp[(4) - (9)].code) - (yyvsp[(1) - (9)].code));
-		WRITE_UINT32(&else1, (yyvsp[(7) - (9)].code) - (yyvsp[(1) - (9)].code));
-		WRITE_UINT32(&end, (yyvsp[(9) - (9)].code) - (yyvsp[(1) - (9)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 1] = then;	/* thenpart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 2] = else1;	/* elsepart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (9)].code) + 3] = end;	/* end, if cond fails */
+		WRITE_UINT32(&then, (yyvsp[-5].code) - (yyvsp[-8].code));
+		WRITE_UINT32(&else1, (yyvsp[-2].code) - (yyvsp[-8].code));
+		WRITE_UINT32(&end, (yyvsp[0].code) - (yyvsp[-8].code));
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 1] = then;	/* thenpart */
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 2] = else1;	/* elsepart */
+		(*g_lingo->_currentScript)[(yyvsp[-8].code) + 3] = end;	/* end, if cond fails */
 
-		g_lingo->processIf(0, (yyvsp[(9) - (9)].code) - (yyvsp[(1) - (9)].code)); ;}
+		g_lingo->processIf(0, (yyvsp[0].code) - (yyvsp[-8].code)); }
+#line 2134 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 34:
-#line 305 "engines/director/lingo/lingo-gr.y"
+#line 299 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0, else1 = 0, end = 0;
-		WRITE_UINT32(&then, (yyvsp[(4) - (6)].code) - (yyvsp[(1) - (6)].code));
+		WRITE_UINT32(&then, (yyvsp[-2].code) - (yyvsp[-5].code));
 		WRITE_UINT32(&else1, 0);
-		WRITE_UINT32(&end, (yyvsp[(6) - (6)].code) - (yyvsp[(1) - (6)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (6)].code) + 1] = then;	/* thenpart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (6)].code) + 2] = else1;	/* elsepart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (6)].code) + 3] = end; 	/* end, if cond fails */
+		WRITE_UINT32(&end, (yyvsp[0].code) - (yyvsp[-5].code));
+		(*g_lingo->_currentScript)[(yyvsp[-5].code) + 1] = then;	/* thenpart */
+		(*g_lingo->_currentScript)[(yyvsp[-5].code) + 2] = else1;	/* elsepart */
+		(*g_lingo->_currentScript)[(yyvsp[-5].code) + 3] = end; 	/* end, if cond fails */
 
-		g_lingo->processIf(0, 0); ;}
+		g_lingo->processIf(0, 0); }
+#line 2149 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 35:
-#line 315 "engines/director/lingo/lingo-gr.y"
+#line 309 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0, else1 = 0, end = 0;
-		WRITE_UINT32(&then, (yyvsp[(4) - (10)].code) - (yyvsp[(1) - (10)].code));
-		WRITE_UINT32(&else1, (yyvsp[(8) - (10)].code) - (yyvsp[(1) - (10)].code));
-		WRITE_UINT32(&end, (yyvsp[(10) - (10)].code) - (yyvsp[(1) - (10)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 1] = then;	/* thenpart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 2] = else1;	/* elsepart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 3] = end; 	/* end, if cond fails */
+		WRITE_UINT32(&then, (yyvsp[-6].code) - (yyvsp[-9].code));
+		WRITE_UINT32(&else1, (yyvsp[-2].code) - (yyvsp[-9].code));
+		WRITE_UINT32(&end, (yyvsp[0].code) - (yyvsp[-9].code));
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 1] = then;	/* thenpart */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 2] = else1;	/* elsepart */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 3] = end; 	/* end, if cond fails */
 
-		g_lingo->processIf(0, 0); ;}
+		g_lingo->processIf(0, 0); }
+#line 2164 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 36:
-#line 325 "engines/director/lingo/lingo-gr.y"
+#line 319 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0, else1 = 0, end = 0;
-		WRITE_UINT32(&then, (yyvsp[(4) - (10)].code) - (yyvsp[(1) - (10)].code));
-		WRITE_UINT32(&else1, (yyvsp[(6) - (10)].code) - (yyvsp[(1) - (10)].code));
-		WRITE_UINT32(&end, (yyvsp[(10) - (10)].code) - (yyvsp[(1) - (10)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 1] = then;	/* thenpart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 2] = else1;	/* elsepart */
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (10)].code) + 3] = end; 	/* end, if cond fails */
+		WRITE_UINT32(&then, (yyvsp[-6].code) - (yyvsp[-9].code));
+		WRITE_UINT32(&else1, (yyvsp[-4].code) - (yyvsp[-9].code));
+		WRITE_UINT32(&end, (yyvsp[0].code) - (yyvsp[-9].code));
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 1] = then;	/* thenpart */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 2] = else1;	/* elsepart */
+		(*g_lingo->_currentScript)[(yyvsp[-9].code) + 3] = end; 	/* end, if cond fails */
 
-		g_lingo->processIf(0, (yyvsp[(10) - (10)].code) - (yyvsp[(1) - (10)].code)); ;}
+		g_lingo->processIf(0, (yyvsp[0].code) - (yyvsp[-9].code)); }
+#line 2179 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 37:
-#line 337 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = 0; ;}
+#line 331 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = 0; }
+#line 2185 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 38:
-#line 338 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = (yyvsp[(2) - (3)].code); ;}
+#line 332 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = (yyvsp[-1].code); }
+#line 2191 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 43:
-#line 349 "engines/director/lingo/lingo-gr.y"
+#line 343 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0;
-		WRITE_UINT32(&then, (yyvsp[(4) - (6)].code) - (yyvsp[(1) - (6)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (6)].code) + 1] = then;	/* thenpart */
+		WRITE_UINT32(&then, (yyvsp[-2].code) - (yyvsp[-5].code));
+		(*g_lingo->_currentScript)[(yyvsp[-5].code) + 1] = then;	/* thenpart */
 
-		g_lingo->codeLabel((yyvsp[(1) - (6)].code)); ;}
+		g_lingo->codeLabel((yyvsp[-5].code)); }
+#line 2202 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 45:
-#line 358 "engines/director/lingo/lingo-gr.y"
+#line 352 "engines/director/lingo/lingo-gr.y"
     {
 		inst then = 0;
-		WRITE_UINT32(&then, (yyvsp[(5) - (6)].code) - (yyvsp[(1) - (6)].code));
-		(*g_lingo->_currentScript)[(yyvsp[(1) - (6)].code) + 1] = then;	/* thenpart */
+		WRITE_UINT32(&then, (yyvsp[-1].code) - (yyvsp[-5].code));
+		(*g_lingo->_currentScript)[(yyvsp[-5].code) + 1] = then;	/* thenpart */
 
-		g_lingo->codeLabel((yyvsp[(1) - (6)].code)); ;}
+		g_lingo->codeLabel((yyvsp[-5].code)); }
+#line 2213 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 46:
-#line 366 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(STOP); ;}
+#line 360 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(STOP); }
+#line 2219 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 47:
-#line 367 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code2(g_lingo->c_eq, STOP); ;}
+#line 361 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code2(g_lingo->c_eq, STOP); }
+#line 2225 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 49:
-#line 371 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = g_lingo->code3(g_lingo->c_repeatwhilecode, STOP, STOP); ;}
+#line 365 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = g_lingo->code3(g_lingo->c_repeatwhilecode, STOP, STOP); }
+#line 2231 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 50:
-#line 374 "engines/director/lingo/lingo-gr.y"
+#line 368 "engines/director/lingo/lingo-gr.y"
     {
 		(yyval.code) = g_lingo->code3(g_lingo->c_repeatwithcode, STOP, STOP);
 		g_lingo->code3(STOP, STOP, STOP);
-		g_lingo->codeString((yyvsp[(3) - (3)].s)->c_str());
-		delete (yyvsp[(3) - (3)].s); ;}
+		g_lingo->codeString((yyvsp[0].s)->c_str());
+		delete (yyvsp[0].s); }
+#line 2241 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 51:
-#line 381 "engines/director/lingo/lingo-gr.y"
+#line 375 "engines/director/lingo/lingo-gr.y"
     {
 		(yyval.code) = g_lingo->code1(g_lingo->c_ifcode);
 		g_lingo->code3(STOP, STOP, STOP);
 		g_lingo->code1(0);  // Do not skip end
-		g_lingo->codeLabel(0); ;}
+		g_lingo->codeLabel(0); }
+#line 2251 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 52:
-#line 388 "engines/director/lingo/lingo-gr.y"
+#line 382 "engines/director/lingo/lingo-gr.y"
     {
 		inst skipEnd;
 		WRITE_UINT32(&skipEnd, 1); // We have to skip end to avoid multiple executions
 		(yyval.code) = g_lingo->code1(g_lingo->c_ifcode);
 		g_lingo->code3(STOP, STOP, STOP);
-		g_lingo->code1(skipEnd); ;}
+		g_lingo->code1(skipEnd); }
+#line 2262 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 53:
-#line 396 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = g_lingo->_currentScript->size(); ;}
+#line 390 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = g_lingo->_currentScript->size(); }
+#line 2268 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 54:
-#line 399 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(STOP); (yyval.code) = g_lingo->_currentScript->size(); ;}
+#line 393 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(STOP); (yyval.code) = g_lingo->_currentScript->size(); }
+#line 2274 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 55:
-#line 402 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = g_lingo->_currentScript->size(); ;}
+#line 396 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = g_lingo->_currentScript->size(); }
+#line 2280 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 58:
-#line 407 "engines/director/lingo/lingo-gr.y"
+#line 401 "engines/director/lingo/lingo-gr.y"
     {
 		(yyval.code) = g_lingo->code1(g_lingo->c_whencode);
 		g_lingo->code1(STOP);
-		g_lingo->codeString((yyvsp[(2) - (3)].s)->c_str());
-		delete (yyvsp[(2) - (3)].s); ;}
+		g_lingo->codeString((yyvsp[-1].s)->c_str());
+		delete (yyvsp[-1].s); }
+#line 2290 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 59:
-#line 413 "engines/director/lingo/lingo-gr.y"
+#line 407 "engines/director/lingo/lingo-gr.y"
     {
 		(yyval.code) = g_lingo->code1(g_lingo->c_tellcode);
-		g_lingo->code1(STOP); ;}
+		g_lingo->code1(STOP); }
+#line 2298 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 60:
-#line 417 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = g_lingo->codeInt((yyvsp[(1) - (1)].i)); ;}
+#line 411 "engines/director/lingo/lingo-gr.y"
+    {
+		(yyval.code) = g_lingo->code1(g_lingo->c_intpush);
+		g_lingo->codeInt((yyvsp[0].i)); }
+#line 2306 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 61:
-#line 418 "engines/director/lingo/lingo-gr.y"
+#line 414 "engines/director/lingo/lingo-gr.y"
     {
 		(yyval.code) = g_lingo->code1(g_lingo->c_floatpush);
-		g_lingo->codeFloat((yyvsp[(1) - (1)].f)); ;}
+		g_lingo->codeFloat((yyvsp[0].f)); }
+#line 2314 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 62:
-#line 421 "engines/director/lingo/lingo-gr.y"
+#line 417 "engines/director/lingo/lingo-gr.y"
     {											// D3
 		(yyval.code) = g_lingo->code1(g_lingo->c_symbolpush);
-		g_lingo->codeString((yyvsp[(1) - (1)].s)->c_str()); ;}
+		g_lingo->codeString((yyvsp[0].s)->c_str()); }
+#line 2322 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 63:
-#line 424 "engines/director/lingo/lingo-gr.y"
+#line 420 "engines/director/lingo/lingo-gr.y"
     {
 		(yyval.code) = g_lingo->code1(g_lingo->c_stringpush);
-		g_lingo->codeString((yyvsp[(1) - (1)].s)->c_str()); ;}
+		g_lingo->codeString((yyvsp[0].s)->c_str()); }
+#line 2330 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 64:
-#line 427 "engines/director/lingo/lingo-gr.y"
+#line 423 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeFunc((yyvsp[(1) - (1)].s), 0);
-		delete (yyvsp[(1) - (1)].s); ;}
+		g_lingo->codeFunc((yyvsp[0].s), 0);
+		delete (yyvsp[0].s); }
+#line 2338 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 65:
-#line 430 "engines/director/lingo/lingo-gr.y"
+#line 426 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeFunc((yyvsp[(1) - (2)].s), 1);
-		delete (yyvsp[(1) - (2)].s); ;}
+		g_lingo->codeFunc((yyvsp[-1].s), 1);
+		delete (yyvsp[-1].s); }
+#line 2346 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 66:
-#line 433 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeFunc((yyvsp[(1) - (2)].s), (yyvsp[(2) - (2)].narg)); ;}
+#line 429 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeFunc((yyvsp[-1].s), (yyvsp[0].narg)); }
+#line 2352 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 67:
-#line 434 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeFunc((yyvsp[(1) - (4)].s), (yyvsp[(3) - (4)].narg)); ;}
+#line 430 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeFunc((yyvsp[-3].s), (yyvsp[-1].narg)); }
+#line 2358 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 68:
-#line 435 "engines/director/lingo/lingo-gr.y"
+#line 431 "engines/director/lingo/lingo-gr.y"
     {
-		(yyval.code) = g_lingo->codeFunc((yyvsp[(1) - (4)].s), (yyvsp[(3) - (4)].narg));
-		delete (yyvsp[(1) - (4)].s); ;}
+		(yyval.code) = g_lingo->codeFunc((yyvsp[-3].s), (yyvsp[-1].narg));
+		delete (yyvsp[-3].s); }
+#line 2366 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 69:
-#line 438 "engines/director/lingo/lingo-gr.y"
+#line 434 "engines/director/lingo/lingo-gr.y"
     {
 		(yyval.code) = g_lingo->code1(g_lingo->c_eval);
-		g_lingo->codeString((yyvsp[(1) - (1)].s)->c_str());
-		delete (yyvsp[(1) - (1)].s); ;}
+		g_lingo->codeString((yyvsp[0].s)->c_str());
+		delete (yyvsp[0].s); }
+#line 2375 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 70:
-#line 442 "engines/director/lingo/lingo-gr.y"
+#line 438 "engines/director/lingo/lingo-gr.y"
     {
-		(yyval.code) = g_lingo->codeInt(0); // Put dummy id
+		(yyval.code) = g_lingo->code1(g_lingo->c_intpush);
+		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentitypush);
 		inst e = 0, f = 0;
-		WRITE_UINT32(&e, (yyvsp[(1) - (1)].e)[0]);
-		WRITE_UINT32(&f, (yyvsp[(1) - (1)].e)[1]);
-		g_lingo->code2(e, f); ;}
+		WRITE_UINT32(&e, (yyvsp[0].e)[0]);
+		WRITE_UINT32(&f, (yyvsp[0].e)[1]);
+		g_lingo->code2(e, f); }
+#line 2388 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 71:
-#line 449 "engines/director/lingo/lingo-gr.y"
+#line 446 "engines/director/lingo/lingo-gr.y"
     {
 		(yyval.code) = g_lingo->code1(g_lingo->c_theentitypush);
 		inst e = 0, f = 0;
-		WRITE_UINT32(&e, (yyvsp[(1) - (2)].e)[0]);
-		WRITE_UINT32(&f, (yyvsp[(1) - (2)].e)[1]);
-		g_lingo->code2(e, f); ;}
+		WRITE_UINT32(&e, (yyvsp[-1].e)[0]);
+		WRITE_UINT32(&f, (yyvsp[-1].e)[1]);
+		g_lingo->code2(e, f); }
+#line 2399 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 73:
-#line 456 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_add); ;}
+#line 453 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_add); }
+#line 2405 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 74:
-#line 457 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_sub); ;}
+#line 454 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_sub); }
+#line 2411 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 75:
-#line 458 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_mul); ;}
+#line 455 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_mul); }
+#line 2417 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 76:
-#line 459 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_div); ;}
+#line 456 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_div); }
+#line 2423 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 77:
-#line 460 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_mod); ;}
+#line 457 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_mod); }
+#line 2429 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 78:
-#line 461 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_gt); ;}
+#line 458 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_gt); }
+#line 2435 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 79:
-#line 462 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_lt); ;}
+#line 459 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_lt); }
+#line 2441 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 80:
-#line 463 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_neq); ;}
+#line 460 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_neq); }
+#line 2447 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 81:
-#line 464 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_ge); ;}
+#line 461 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_ge); }
+#line 2453 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 82:
-#line 465 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_le); ;}
+#line 462 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_le); }
+#line 2459 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 83:
-#line 466 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_and); ;}
+#line 463 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_and); }
+#line 2465 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 84:
-#line 467 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_or); ;}
+#line 464 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_or); }
+#line 2471 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 85:
-#line 468 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_not); ;}
+#line 465 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_not); }
+#line 2477 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 86:
-#line 469 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_ampersand); ;}
+#line 466 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_ampersand); }
+#line 2483 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 87:
-#line 470 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_concat); ;}
+#line 467 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_concat); }
+#line 2489 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 88:
-#line 471 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_contains); ;}
+#line 468 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_contains); }
+#line 2495 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 89:
-#line 472 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_starts); ;}
+#line 469 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_starts); }
+#line 2501 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 90:
-#line 473 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = (yyvsp[(2) - (2)].code); ;}
+#line 470 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = (yyvsp[0].code); }
+#line 2507 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 91:
-#line 474 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = (yyvsp[(2) - (2)].code); g_lingo->code1(g_lingo->c_negate); ;}
+#line 471 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = (yyvsp[0].code); g_lingo->code1(g_lingo->c_negate); }
+#line 2513 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 92:
-#line 475 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = (yyvsp[(2) - (3)].code); ;}
+#line 472 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = (yyvsp[-1].code); }
+#line 2519 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 93:
-#line 476 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = g_lingo->codeArray((yyvsp[(2) - (3)].narg)); ;}
+#line 473 "engines/director/lingo/lingo-gr.y"
+    { (yyval.code) = g_lingo->code1(g_lingo->c_arraypush); g_lingo->codeArray((yyvsp[-1].narg)); }
+#line 2525 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 94:
-#line 477 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_intersects); ;}
+#line 474 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_intersects); }
+#line 2531 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 95:
-#line 478 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_within); ;}
+#line 475 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_within); }
+#line 2537 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 96:
-#line 479 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_charOf); ;}
+#line 476 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_charOf); }
+#line 2543 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 97:
-#line 480 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_charToOf); ;}
+#line 477 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_charToOf); }
+#line 2549 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 98:
-#line 481 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_itemOf); ;}
+#line 478 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_itemOf); }
+#line 2555 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 99:
-#line 482 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_itemToOf); ;}
+#line 479 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_itemToOf); }
+#line 2561 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 100:
-#line 483 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_lineOf); ;}
+#line 480 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_lineOf); }
+#line 2567 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 101:
-#line 484 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_lineToOf); ;}
+#line 481 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_lineToOf); }
+#line 2573 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 102:
-#line 485 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_wordOf); ;}
+#line 482 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_wordOf); }
+#line 2579 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 103:
-#line 486 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_wordToOf); ;}
+#line 483 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_wordToOf); }
+#line 2585 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 104:
-#line 489 "engines/director/lingo/lingo-gr.y"
+#line 486 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeFunc((yyvsp[(1) - (2)].s), 1);
-		delete (yyvsp[(1) - (2)].s); ;}
+		g_lingo->codeFunc((yyvsp[-1].s), 1);
+		delete (yyvsp[-1].s); }
+#line 2593 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 105:
-#line 494 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_printtop); ;}
+#line 491 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_printtop); }
+#line 2599 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 108:
-#line 497 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_exitRepeat); ;}
+#line 494 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_exitRepeat); }
+#line 2605 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 109:
-#line 498 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_procret); ;}
+#line 495 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_procret); }
+#line 2611 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 113:
-#line 502 "engines/director/lingo/lingo-gr.y"
+#line 499 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeFunc((yyvsp[(1) - (1)].s), 0);
-		delete (yyvsp[(1) - (1)].s); ;}
+		g_lingo->codeFunc((yyvsp[0].s), 0);
+		delete (yyvsp[0].s); }
+#line 2619 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 114:
-#line 505 "engines/director/lingo/lingo-gr.y"
+#line 502 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeFunc((yyvsp[(1) - (2)].s), 1);
-		delete (yyvsp[(1) - (2)].s); ;}
+		g_lingo->codeFunc((yyvsp[-1].s), 1);
+		delete (yyvsp[-1].s); }
+#line 2627 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 115:
-#line 508 "engines/director/lingo/lingo-gr.y"
+#line 505 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeFunc((yyvsp[(1) - (2)].s), 1);
-		delete (yyvsp[(1) - (2)].s); ;}
+		g_lingo->codeFunc((yyvsp[-1].s), 1);
+		delete (yyvsp[-1].s); }
+#line 2635 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 116:
-#line 511 "engines/director/lingo/lingo-gr.y"
+#line 508 "engines/director/lingo/lingo-gr.y"
     {
 		g_lingo->code1(g_lingo->c_voidpush);
-		g_lingo->codeFunc((yyvsp[(1) - (1)].s), 1);
-		delete (yyvsp[(1) - (1)].s); ;}
+		g_lingo->codeFunc((yyvsp[0].s), 1);
+		delete (yyvsp[0].s); }
+#line 2644 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 117:
-#line 515 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeFunc((yyvsp[(1) - (2)].s), (yyvsp[(2) - (2)].narg)); ;}
+#line 512 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeFunc((yyvsp[-1].s), (yyvsp[0].narg)); }
+#line 2650 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 118:
-#line 516 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeFunc((yyvsp[(1) - (4)].s), (yyvsp[(3) - (4)].narg)); ;}
+#line 513 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeFunc((yyvsp[-3].s), (yyvsp[-1].narg)); }
+#line 2656 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 119:
-#line 517 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeMe((yyvsp[(3) - (4)].s), 0); ;}
+#line 514 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeMe((yyvsp[-1].s), 0); }
+#line 2662 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 120:
-#line 518 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeMe((yyvsp[(3) - (6)].s), (yyvsp[(5) - (6)].narg)); ;}
+#line 515 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeMe((yyvsp[-3].s), (yyvsp[-1].narg)); }
+#line 2668 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 121:
-#line 519 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_open); ;}
+#line 516 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_open); }
+#line 2674 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 122:
-#line 520 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code2(g_lingo->c_voidpush, g_lingo->c_open); ;}
+#line 517 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code2(g_lingo->c_voidpush, g_lingo->c_open); }
+#line 2680 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 123:
-#line 521 "engines/director/lingo/lingo-gr.y"
-    { Common::String s(*(yyvsp[(1) - (3)].s)); s += '-'; s += *(yyvsp[(2) - (3)].s); g_lingo->codeFunc(&s, (yyvsp[(3) - (3)].narg)); ;}
+#line 518 "engines/director/lingo/lingo-gr.y"
+    { Common::String s(*(yyvsp[-2].s)); s += '-'; s += *(yyvsp[-1].s); g_lingo->codeFunc(&s, (yyvsp[0].narg)); }
+#line 2686 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 124:
-#line 524 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_global); g_lingo->codeString((yyvsp[(1) - (1)].s)->c_str()); delete (yyvsp[(1) - (1)].s); ;}
+#line 521 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_global); g_lingo->codeString((yyvsp[0].s)->c_str()); delete (yyvsp[0].s); }
+#line 2692 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 125:
-#line 525 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_global); g_lingo->codeString((yyvsp[(3) - (3)].s)->c_str()); delete (yyvsp[(3) - (3)].s); ;}
+#line 522 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_global); g_lingo->codeString((yyvsp[0].s)->c_str()); delete (yyvsp[0].s); }
+#line 2698 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 126:
-#line 528 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_property); g_lingo->codeString((yyvsp[(1) - (1)].s)->c_str()); delete (yyvsp[(1) - (1)].s); ;}
+#line 525 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_property); g_lingo->codeString((yyvsp[0].s)->c_str()); delete (yyvsp[0].s); }
+#line 2704 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 127:
-#line 529 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_property); g_lingo->codeString((yyvsp[(3) - (3)].s)->c_str()); delete (yyvsp[(3) - (3)].s); ;}
+#line 526 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_property); g_lingo->codeString((yyvsp[0].s)->c_str()); delete (yyvsp[0].s); }
+#line 2710 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 128:
-#line 532 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_instance); g_lingo->codeString((yyvsp[(1) - (1)].s)->c_str()); delete (yyvsp[(1) - (1)].s); ;}
+#line 529 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_instance); g_lingo->codeString((yyvsp[0].s)->c_str()); delete (yyvsp[0].s); }
+#line 2716 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 129:
-#line 533 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_instance); g_lingo->codeString((yyvsp[(3) - (3)].s)->c_str()); delete (yyvsp[(3) - (3)].s); ;}
+#line 530 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_instance); g_lingo->codeString((yyvsp[0].s)->c_str()); delete (yyvsp[0].s); }
+#line 2722 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 130:
-#line 544 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_gotoloop); ;}
+#line 541 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_gotoloop); }
+#line 2728 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 131:
-#line 545 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_gotonext); ;}
+#line 542 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_gotonext); }
+#line 2734 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 132:
-#line 546 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_gotoprevious); ;}
+#line 543 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->code1(g_lingo->c_gotoprevious); }
+#line 2740 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 133:
-#line 547 "engines/director/lingo/lingo-gr.y"
+#line 544 "engines/director/lingo/lingo-gr.y"
     {
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(1);
-		g_lingo->code1(g_lingo->c_goto); ;}
+		g_lingo->code1(g_lingo->c_goto); }
+#line 2749 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 134:
-#line 550 "engines/director/lingo/lingo-gr.y"
+#line 548 "engines/director/lingo/lingo-gr.y"
     {
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(3);
-		g_lingo->code1(g_lingo->c_goto); ;}
+		g_lingo->code1(g_lingo->c_goto); }
+#line 2758 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 135:
-#line 553 "engines/director/lingo/lingo-gr.y"
+#line 552 "engines/director/lingo/lingo-gr.y"
     {
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(2);
-		g_lingo->code1(g_lingo->c_goto); ;}
+		g_lingo->code1(g_lingo->c_goto); }
+#line 2767 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 140:
 #line 566 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->code1(g_lingo->c_playdone); ;}
+    { g_lingo->code1(g_lingo->c_playdone); }
+#line 2773 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 141:
 #line 567 "engines/director/lingo/lingo-gr.y"
     {
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(1);
-		g_lingo->code1(g_lingo->c_play); ;}
+		g_lingo->code1(g_lingo->c_play); }
+#line 2782 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 142:
-#line 570 "engines/director/lingo/lingo-gr.y"
+#line 571 "engines/director/lingo/lingo-gr.y"
     {
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(3);
-		g_lingo->code1(g_lingo->c_play); ;}
+		g_lingo->code1(g_lingo->c_play); }
+#line 2791 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 143:
-#line 573 "engines/director/lingo/lingo-gr.y"
+#line 575 "engines/director/lingo/lingo-gr.y"
     {
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(2);
-		g_lingo->code1(g_lingo->c_play); ;}
+		g_lingo->code1(g_lingo->c_play); }
+#line 2800 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 144:
-#line 576 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeSetImmediate(true); ;}
+#line 579 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeSetImmediate(true); }
+#line 2806 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 145:
-#line 576 "engines/director/lingo/lingo-gr.y"
+#line 579 "engines/director/lingo/lingo-gr.y"
     {
 		g_lingo->codeSetImmediate(false);
-		g_lingo->codeFunc((yyvsp[(1) - (3)].s), (yyvsp[(3) - (3)].narg)); ;}
+		g_lingo->codeFunc((yyvsp[-2].s), (yyvsp[0].narg)); }
+#line 2814 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 146:
-#line 606 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->_indef = true; g_lingo->_currentFactory.clear(); ;}
+#line 609 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->_indef = true; g_lingo->_currentFactory.clear(); }
+#line 2820 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 147:
-#line 607 "engines/director/lingo/lingo-gr.y"
+#line 610 "engines/director/lingo/lingo-gr.y"
     {
 			g_lingo->code1(g_lingo->c_procret);
-			g_lingo->define(*(yyvsp[(2) - (8)].s), (yyvsp[(4) - (8)].code), (yyvsp[(5) - (8)].narg));
-			g_lingo->_indef = false; ;}
+			g_lingo->define(*(yyvsp[-6].s), (yyvsp[-4].code), (yyvsp[-3].narg));
+			g_lingo->_indef = false; }
+#line 2829 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 148:
-#line 611 "engines/director/lingo/lingo-gr.y"
+#line 614 "engines/director/lingo/lingo-gr.y"
     {
-			g_lingo->codeFactory(*(yyvsp[(2) - (2)].s));
-		;}
+			g_lingo->codeFactory(*(yyvsp[0].s));
+		}
+#line 2837 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 149:
-#line 614 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->_indef = true; ;}
+#line 617 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->_indef = true; }
+#line 2843 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 150:
-#line 615 "engines/director/lingo/lingo-gr.y"
+#line 618 "engines/director/lingo/lingo-gr.y"
     {
 			g_lingo->code1(g_lingo->c_procret);
-			g_lingo->define(*(yyvsp[(2) - (8)].s), (yyvsp[(4) - (8)].code), (yyvsp[(5) - (8)].narg) + 1, &g_lingo->_currentFactory);
-			g_lingo->_indef = false; ;}
+			g_lingo->define(*(yyvsp[-6].s), (yyvsp[-4].code), (yyvsp[-3].narg) + 1, &g_lingo->_currentFactory);
+			g_lingo->_indef = false; }
+#line 2852 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 151:
-#line 619 "engines/director/lingo/lingo-gr.y"
+#line 622 "engines/director/lingo/lingo-gr.y"
     {	// D3
 				g_lingo->code1(g_lingo->c_procret);
-				g_lingo->define(*(yyvsp[(1) - (7)].s), (yyvsp[(2) - (7)].code), (yyvsp[(3) - (7)].narg));
+				g_lingo->define(*(yyvsp[-6].s), (yyvsp[-5].code), (yyvsp[-4].narg));
 				g_lingo->_indef = false;
 				g_lingo->_ignoreMe = false;
 
-				checkEnd((yyvsp[(7) - (7)].s), (yyvsp[(1) - (7)].s)->c_str(), false);
-			;}
+				checkEnd((yyvsp[0].s), (yyvsp[-6].s)->c_str(), false);
+			}
+#line 2865 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 152:
-#line 627 "engines/director/lingo/lingo-gr.y"
+#line 630 "engines/director/lingo/lingo-gr.y"
     {	// D4. No 'end' clause
 				g_lingo->code1(g_lingo->c_procret);
-				g_lingo->define(*(yyvsp[(1) - (6)].s), (yyvsp[(2) - (6)].code), (yyvsp[(3) - (6)].narg));
+				g_lingo->define(*(yyvsp[-5].s), (yyvsp[-4].code), (yyvsp[-3].narg));
 				g_lingo->_indef = false;
 				g_lingo->_ignoreMe = false;
-			;}
+			}
+#line 2876 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 153:
-#line 634 "engines/director/lingo/lingo-gr.y"
-    { (yyval.s) = (yyvsp[(2) - (2)].s); g_lingo->_indef = true; g_lingo->_currentFactory.clear(); g_lingo->_ignoreMe = true; ;}
+#line 637 "engines/director/lingo/lingo-gr.y"
+    { (yyval.s) = (yyvsp[0].s); g_lingo->_indef = true; g_lingo->_currentFactory.clear(); g_lingo->_ignoreMe = true; }
+#line 2882 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 154:
-#line 636 "engines/director/lingo/lingo-gr.y"
-    { (yyval.narg) = 0; ;}
+#line 639 "engines/director/lingo/lingo-gr.y"
+    { (yyval.narg) = 0; }
+#line 2888 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 155:
-#line 637 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeArg((yyvsp[(1) - (1)].s)); (yyval.narg) = 1; ;}
+#line 640 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeArg((yyvsp[0].s)); (yyval.narg) = 1; }
+#line 2894 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 156:
-#line 638 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeArg((yyvsp[(3) - (3)].s)); (yyval.narg) = (yyvsp[(1) - (3)].narg) + 1; ;}
+#line 641 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeArg((yyvsp[0].s)); (yyval.narg) = (yyvsp[-2].narg) + 1; }
+#line 2900 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 157:
-#line 639 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeArg((yyvsp[(4) - (4)].s)); (yyval.narg) = (yyvsp[(1) - (4)].narg) + 1; ;}
+#line 642 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeArg((yyvsp[0].s)); (yyval.narg) = (yyvsp[-3].narg) + 1; }
+#line 2906 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 158:
-#line 642 "engines/director/lingo/lingo-gr.y"
-    { g_lingo->codeArgStore(); ;}
+#line 645 "engines/director/lingo/lingo-gr.y"
+    { g_lingo->codeArgStore(); }
+#line 2912 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 159:
-#line 646 "engines/director/lingo/lingo-gr.y"
+#line 649 "engines/director/lingo/lingo-gr.y"
     {
 		g_lingo->code1(g_lingo->c_call);
-		g_lingo->codeString((yyvsp[(1) - (2)].s)->c_str());
+		g_lingo->codeString((yyvsp[-1].s)->c_str());
 		inst numpar = 0;
-		WRITE_UINT32(&numpar, (yyvsp[(2) - (2)].narg));
-		g_lingo->code1(numpar); ;}
+		WRITE_UINT32(&numpar, (yyvsp[0].narg));
+		g_lingo->code1(numpar); }
+#line 2923 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 160:
-#line 654 "engines/director/lingo/lingo-gr.y"
-    { (yyval.narg) = 0; ;}
+#line 657 "engines/director/lingo/lingo-gr.y"
+    { (yyval.narg) = 0; }
+#line 2929 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 161:
-#line 655 "engines/director/lingo/lingo-gr.y"
-    { (yyval.narg) = 1; ;}
+#line 658 "engines/director/lingo/lingo-gr.y"
+    { (yyval.narg) = 1; }
+#line 2935 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 162:
-#line 656 "engines/director/lingo/lingo-gr.y"
-    { (yyval.narg) = (yyvsp[(1) - (3)].narg) + 1; ;}
+#line 659 "engines/director/lingo/lingo-gr.y"
+    { (yyval.narg) = (yyvsp[-2].narg) + 1; }
+#line 2941 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 163:
-#line 659 "engines/director/lingo/lingo-gr.y"
-    { (yyval.narg) = 1; ;}
+#line 662 "engines/director/lingo/lingo-gr.y"
+    { (yyval.narg) = 1; }
+#line 2947 "engines/director/lingo/lingo-gr.cpp"
     break;
 
   case 164:
-#line 660 "engines/director/lingo/lingo-gr.y"
-    { (yyval.narg) = (yyvsp[(1) - (3)].narg) + 1; ;}
+#line 663 "engines/director/lingo/lingo-gr.y"
+    { (yyval.narg) = (yyvsp[-2].narg) + 1; }
+#line 2953 "engines/director/lingo/lingo-gr.cpp"
     break;
 
 
-/* Line 1267 of yacc.c.  */
-#line 3083 "engines/director/lingo/lingo-gr.cpp"
+#line 2957 "engines/director/lingo/lingo-gr.cpp"
+
       default: break;
     }
+  /* User semantic actions sometimes alter yychar, and that requires
+     that yytoken be updated with the new translation.  We take the
+     approach of translating immediately before every use of yytoken.
+     One alternative is translating here after every semantic action,
+     but that translation would be missed if the semantic action invokes
+     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+     incorrect destructor might then be invoked immediately.  In the
+     case of YYERROR or YYBACKUP, subsequent parser actions might lead
+     to an incorrect destructor call or verbose syntax error message
+     before the lookahead is translated.  */
   YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
@@ -3094,26 +2976,28 @@ yyreduce:
 
   *++yyvsp = yyval;
 
-
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
+  /* Make sure we have latest lookahead translation.  See comments at
+     user semantic actions for why this is necessary.  */
+  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
@@ -3121,37 +3005,36 @@ yyerrlab:
 #if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
 #else
+# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
+                                        yyssp, yytoken)
       {
-	YYSIZE_T yysize = yysyntax_error (0, yystate, yychar);
-	if (yymsg_alloc < yysize && yymsg_alloc < YYSTACK_ALLOC_MAXIMUM)
-	  {
-	    YYSIZE_T yyalloc = 2 * yysize;
-	    if (! (yysize <= yyalloc && yyalloc <= YYSTACK_ALLOC_MAXIMUM))
-	      yyalloc = YYSTACK_ALLOC_MAXIMUM;
-	    if (yymsg != yymsgbuf)
-	      YYSTACK_FREE (yymsg);
-	    yymsg = (char *) YYSTACK_ALLOC (yyalloc);
-	    if (yymsg)
-	      yymsg_alloc = yyalloc;
-	    else
-	      {
-		yymsg = yymsgbuf;
-		yymsg_alloc = sizeof yymsgbuf;
-	      }
-	  }
-
-	if (0 < yysize && yysize <= yymsg_alloc)
-	  {
-	    (void) yysyntax_error (yymsg, yystate, yychar);
-	    yyerror (yymsg);
-	  }
-	else
-	  {
-	    yyerror (YY_("syntax error"));
-	    if (yysize != 0)
-	      goto yyexhaustedlab;
-	  }
+        char const *yymsgp = YY_("syntax error");
+        int yysyntax_error_status;
+        yysyntax_error_status = YYSYNTAX_ERROR;
+        if (yysyntax_error_status == 0)
+          yymsgp = yymsg;
+        else if (yysyntax_error_status == 1)
+          {
+            if (yymsg != yymsgbuf)
+              YYSTACK_FREE (yymsg);
+            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
+            if (!yymsg)
+              {
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = 2;
+              }
+            else
+              {
+                yysyntax_error_status = YYSYNTAX_ERROR;
+                yymsgp = yymsg;
+              }
+          }
+        yyerror (yymsgp);
+        if (yysyntax_error_status == 2)
+          goto yyexhaustedlab;
       }
+# undef YYSYNTAX_ERROR
 #endif
     }
 
@@ -3159,24 +3042,24 @@ yyerrlab:
 
   if (yyerrstatus == 3)
     {
-      /* If just tried and failed to reuse look-ahead token after an
-	 error, discard it.  */
+      /* If just tried and failed to reuse lookahead token after an
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval);
+          yychar = YYEMPTY;
+        }
     }
 
-  /* Else will try to reuse look-ahead token after shifting the error
+  /* Else will try to reuse lookahead token after shifting the error
      token.  */
   goto yyerrlab1;
 
@@ -3185,14 +3068,12 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
 
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
-
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -3205,38 +3086,37 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
   for (;;)
     {
       yyn = yypact[yystate];
-      if (yyn != YYPACT_NINF)
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+      if (!yypact_value_is_default (yyn))
+        {
+          yyn += YYTERROR;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
 
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp);
+                  yystos[yystate], yyvsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
     }
 
-  if (yyn == YYFINAL)
-    YYACCEPT;
-
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
 
   /* Shift the error token.  */
@@ -3253,6 +3133,7 @@ yyacceptlab:
   yyresult = 0;
   goto yyreturn;
 
+
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
@@ -3260,7 +3141,8 @@ yyabortlab:
   yyresult = 1;
   goto yyreturn;
 
-#ifndef yyoverflow
+
+#if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
@@ -3270,18 +3152,27 @@ yyexhaustedlab:
   /* Fall through.  */
 #endif
 
+
+/*-----------------------------------------------------.
+| yyreturn -- parsing is finished, return the result.  |
+`-----------------------------------------------------*/
 yyreturn:
-  if (yychar != YYEOF && yychar != YYEMPTY)
-     yydestruct ("Cleanup: discarding lookahead",
-		 yytoken, &yylval);
-  /* Do not reclaim the symbols of the rule which action triggered
+  if (yychar != YYEMPTY)
+    {
+      /* Make sure we have latest lookahead translation.  See comments at
+         user semantic actions for why this is necessary.  */
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval);
+    }
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp);
+                  yystos[*yyssp], yyvsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -3292,11 +3183,7 @@ yyreturn:
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
 #endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+  return yyresult;
 }
-
-
-#line 663 "engines/director/lingo/lingo-gr.y"
-
+#line 666 "engines/director/lingo/lingo-gr.y"
 

--- a/engines/director/lingo/lingo-gr.cpp
+++ b/engines/director/lingo/lingo-gr.cpp
@@ -2197,7 +2197,7 @@ yyreduce:
   case 15:
 #line 152 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeConst(0); // Put dummy id
+		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, (yyvsp[(2) - (4)].e)[0]);
@@ -2231,7 +2231,7 @@ yyreduce:
   case 18:
 #line 174 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeConst(0); // Put dummy id
+		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, (yyvsp[(2) - (4)].e)[0]);
@@ -2532,13 +2532,13 @@ yyreduce:
 
   case 60:
 #line 417 "engines/director/lingo/lingo-gr.y"
-    { (yyval.code) = g_lingo->codeConst((yyvsp[(1) - (1)].i)); ;}
+    { (yyval.code) = g_lingo->codeInt((yyvsp[(1) - (1)].i)); ;}
     break;
 
   case 61:
 #line 418 "engines/director/lingo/lingo-gr.y"
     {
-		(yyval.code) = g_lingo->code1(g_lingo->c_fconstpush);
+		(yyval.code) = g_lingo->code1(g_lingo->c_floatpush);
 		g_lingo->codeFloat((yyvsp[(1) - (1)].f)); ;}
     break;
 
@@ -2598,7 +2598,7 @@ yyreduce:
   case 70:
 #line 442 "engines/director/lingo/lingo-gr.y"
     {
-		(yyval.code) = g_lingo->codeConst(0); // Put dummy id
+		(yyval.code) = g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentitypush);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, (yyvsp[(1) - (1)].e)[0]);
@@ -2905,21 +2905,21 @@ yyreduce:
   case 133:
 #line 547 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeConst(1);
+		g_lingo->codeInt(1);
 		g_lingo->code1(g_lingo->c_goto); ;}
     break;
 
   case 134:
 #line 550 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeConst(3);
+		g_lingo->codeInt(3);
 		g_lingo->code1(g_lingo->c_goto); ;}
     break;
 
   case 135:
 #line 553 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeConst(2);
+		g_lingo->codeInt(2);
 		g_lingo->code1(g_lingo->c_goto); ;}
     break;
 
@@ -2931,21 +2931,21 @@ yyreduce:
   case 141:
 #line 567 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeConst(1);
+		g_lingo->codeInt(1);
 		g_lingo->code1(g_lingo->c_play); ;}
     break;
 
   case 142:
 #line 570 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeConst(3);
+		g_lingo->codeInt(3);
 		g_lingo->code1(g_lingo->c_play); ;}
     break;
 
   case 143:
 #line 573 "engines/director/lingo/lingo-gr.y"
     {
-		g_lingo->codeConst(2);
+		g_lingo->codeInt(2);
 		g_lingo->code1(g_lingo->c_play); ;}
     break;
 

--- a/engines/director/lingo/lingo-gr.y
+++ b/engines/director/lingo/lingo-gr.y
@@ -150,7 +150,7 @@ asgn: tPUT expr tINTO ID 		{
 		$$ = $4;
 		delete $2; }
 	| tSET THEENTITY '=' expr	{
-		g_lingo->codeConst(0); // Put dummy id
+		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, $2[0]);
@@ -172,7 +172,7 @@ asgn: tPUT expr tINTO ID 		{
 		$$ = $4;
 		delete $2; }
 	| tSET THEENTITY tTO expr	{
-		g_lingo->codeConst(0); // Put dummy id
+		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, $2[0]);
@@ -414,9 +414,9 @@ tell:	  tTELL				{
 		$$ = g_lingo->code1(g_lingo->c_tellcode);
 		g_lingo->code1(STOP); }
 
-expr: INT		{ $$ = g_lingo->codeConst($1); }
+expr: INT		{ $$ = g_lingo->codeInt($1); }
 	| FLOAT		{
-		$$ = g_lingo->code1(g_lingo->c_fconstpush);
+		$$ = g_lingo->code1(g_lingo->c_floatpush);
 		g_lingo->codeFloat($1); }
 	| SYMBOL	{											// D3
 		$$ = g_lingo->code1(g_lingo->c_symbolpush);
@@ -440,7 +440,7 @@ expr: INT		{ $$ = g_lingo->codeConst($1); }
 		g_lingo->codeString($1->c_str());
 		delete $1; }
 	| THEENTITY	{
-		$$ = g_lingo->codeConst(0); // Put dummy id
+		$$ = g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentitypush);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, $1[0]);
@@ -545,13 +545,13 @@ gotofunc: tGO tLOOP				{ g_lingo->code1(g_lingo->c_gotoloop); }
 	| tGO tNEXT					{ g_lingo->code1(g_lingo->c_gotonext); }
 	| tGO tPREVIOUS				{ g_lingo->code1(g_lingo->c_gotoprevious); }
 	| tGO gotoframe 			{
-		g_lingo->codeConst(1);
+		g_lingo->codeInt(1);
 		g_lingo->code1(g_lingo->c_goto); }
 	| tGO gotoframe gotomovie	{
-		g_lingo->codeConst(3);
+		g_lingo->codeInt(3);
 		g_lingo->code1(g_lingo->c_goto); }
 	| tGO gotomovie				{
-		g_lingo->codeConst(2);
+		g_lingo->codeInt(2);
 		g_lingo->code1(g_lingo->c_goto); }
 	;
 
@@ -565,13 +565,13 @@ gotomovie: tOF tMOVIE expr
 
 playfunc: tPLAY tDONE			{ g_lingo->code1(g_lingo->c_playdone); }
 	| tPLAY gotoframe 			{
-		g_lingo->codeConst(1);
+		g_lingo->codeInt(1);
 		g_lingo->code1(g_lingo->c_play); }
 	| tPLAY gotoframe gotomovie	{
-		g_lingo->codeConst(3);
+		g_lingo->codeInt(3);
 		g_lingo->code1(g_lingo->c_play); }
 	| tPLAY gotomovie				{
-		g_lingo->codeConst(2);
+		g_lingo->codeInt(2);
 		g_lingo->code1(g_lingo->c_play); }
 	| tPLAYACCEL { g_lingo->codeSetImmediate(true); } arglist	{
 		g_lingo->codeSetImmediate(false);

--- a/engines/director/lingo/lingo-gr.y
+++ b/engines/director/lingo/lingo-gr.y
@@ -153,18 +153,14 @@ asgn: tPUT expr tINTO ID 		{
 		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
-		inst e = 0, f = 0;
-		WRITE_UINT32(&e, $2[0]);
-		WRITE_UINT32(&f, $2[1]);
-		g_lingo->code2(e, f);
+		g_lingo->codeInt($2[0]);
+		g_lingo->codeInt($2[1]);
 		$$ = $4; }
 	| tSET THEENTITYWITHID expr '=' expr	{
 		g_lingo->code1(g_lingo->c_swap);
 		g_lingo->code1(g_lingo->c_theentityassign);
-		inst e = 0, f = 0;
-		WRITE_UINT32(&e, $2[0]);
-		WRITE_UINT32(&f, $2[1]);
-		g_lingo->code2(e, f);
+		g_lingo->codeInt($2[0]);
+		g_lingo->codeInt($2[1]);
 		$$ = $5; }
 	| tSET ID tTO expr			{
 		g_lingo->code1(g_lingo->c_varpush);
@@ -176,18 +172,14 @@ asgn: tPUT expr tINTO ID 		{
 		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
-		inst e = 0, f = 0;
-		WRITE_UINT32(&e, $2[0]);
-		WRITE_UINT32(&f, $2[1]);
-		g_lingo->code2(e, f);
+		g_lingo->codeInt($2[0]);
+		g_lingo->codeInt($2[1]);
 		$$ = $4; }
 	| tSET THEENTITYWITHID expr tTO expr	{
 		g_lingo->code1(g_lingo->c_swap);
 		g_lingo->code1(g_lingo->c_theentityassign);
-		inst e = 0, f = 0;
-		WRITE_UINT32(&e, $2[0]);
-		WRITE_UINT32(&f, $2[1]);
-		g_lingo->code2(e, f);
+		g_lingo->codeInt($2[0]);
+		g_lingo->codeInt($2[1]);
 		$$ = $5; }
 	;
 

--- a/engines/director/lingo/lingo-gr.y
+++ b/engines/director/lingo/lingo-gr.y
@@ -150,7 +150,8 @@ asgn: tPUT expr tINTO ID 		{
 		$$ = $4;
 		delete $2; }
 	| tSET THEENTITY '=' expr	{
-		g_lingo->codeInt(0); // Put dummy id
+		g_lingo->code1(g_lingo->c_intpush);
+        g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, $2[0]);
@@ -172,6 +173,7 @@ asgn: tPUT expr tINTO ID 		{
 		$$ = $4;
 		delete $2; }
 	| tSET THEENTITY tTO expr	{
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
 		inst e = 0, f = 0;
@@ -414,7 +416,9 @@ tell:	  tTELL				{
 		$$ = g_lingo->code1(g_lingo->c_tellcode);
 		g_lingo->code1(STOP); }
 
-expr: INT		{ $$ = g_lingo->codeInt($1); }
+expr: INT		{ 
+		$$ = g_lingo->code1(g_lingo->c_intpush);
+        g_lingo->codeInt($1); }
 	| FLOAT		{
 		$$ = g_lingo->code1(g_lingo->c_floatpush);
 		g_lingo->codeFloat($1); }
@@ -440,7 +444,8 @@ expr: INT		{ $$ = g_lingo->codeInt($1); }
 		g_lingo->codeString($1->c_str());
 		delete $1; }
 	| THEENTITY	{
-		$$ = g_lingo->codeInt(0); // Put dummy id
+		$$ = g_lingo->code1(g_lingo->c_intpush);
+		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentitypush);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, $1[0]);
@@ -473,7 +478,7 @@ expr: INT		{ $$ = g_lingo->codeInt($1); }
 	| '+' expr  %prec UNARY		{ $$ = $2; }
 	| '-' expr  %prec UNARY		{ $$ = $2; g_lingo->code1(g_lingo->c_negate); }
 	| '(' expr ')'				{ $$ = $2; }
-	| '[' arglist ']'			{ $$ = g_lingo->codeArray($2); }
+	| '[' arglist ']'			{ $$ = g_lingo->code1(g_lingo->c_arraypush); g_lingo->codeArray($2); }
 	| tSPRITE expr tINTERSECTS expr 	{ g_lingo->code1(g_lingo->c_intersects); }
 	| tSPRITE expr tWITHIN expr		 	{ g_lingo->code1(g_lingo->c_within); }
 	| tCHAR expr tOF expr				{ g_lingo->code1(g_lingo->c_charOf); }
@@ -545,12 +550,15 @@ gotofunc: tGO tLOOP				{ g_lingo->code1(g_lingo->c_gotoloop); }
 	| tGO tNEXT					{ g_lingo->code1(g_lingo->c_gotonext); }
 	| tGO tPREVIOUS				{ g_lingo->code1(g_lingo->c_gotoprevious); }
 	| tGO gotoframe 			{
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(1);
 		g_lingo->code1(g_lingo->c_goto); }
 	| tGO gotoframe gotomovie	{
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(3);
 		g_lingo->code1(g_lingo->c_goto); }
 	| tGO gotomovie				{
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(2);
 		g_lingo->code1(g_lingo->c_goto); }
 	;
@@ -565,12 +573,15 @@ gotomovie: tOF tMOVIE expr
 
 playfunc: tPLAY tDONE			{ g_lingo->code1(g_lingo->c_playdone); }
 	| tPLAY gotoframe 			{
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(1);
 		g_lingo->code1(g_lingo->c_play); }
 	| tPLAY gotoframe gotomovie	{
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(3);
 		g_lingo->code1(g_lingo->c_play); }
 	| tPLAY gotomovie				{
+		g_lingo->code1(g_lingo->c_intpush);
 		g_lingo->codeInt(2);
 		g_lingo->code1(g_lingo->c_play); }
 	| tPLAYACCEL { g_lingo->codeSetImmediate(true); } arglist	{

--- a/engines/director/lingo/lingo-gr.y
+++ b/engines/director/lingo/lingo-gr.y
@@ -151,7 +151,7 @@ asgn: tPUT expr tINTO ID 		{
 		delete $2; }
 	| tSET THEENTITY '=' expr	{
 		g_lingo->code1(g_lingo->c_intpush);
-        g_lingo->codeInt(0); // Put dummy id
+		g_lingo->codeInt(0); // Put dummy id
 		g_lingo->code1(g_lingo->c_theentityassign);
 		inst e = 0, f = 0;
 		WRITE_UINT32(&e, $2[0]);
@@ -416,9 +416,9 @@ tell:	  tTELL				{
 		$$ = g_lingo->code1(g_lingo->c_tellcode);
 		g_lingo->code1(STOP); }
 
-expr: INT		{ 
+expr: INT		{
 		$$ = g_lingo->code1(g_lingo->c_intpush);
-        g_lingo->codeInt($1); }
+		g_lingo->codeInt($1); }
 	| FLOAT		{
 		$$ = g_lingo->code1(g_lingo->c_floatpush);
 		g_lingo->codeFloat($1); }

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -73,7 +73,7 @@ Lingo::Lingo(DirectorEngine *vm) : _vm(vm) {
 
 	initBuiltIns();
 	initFuncs();
-    initBytecode();
+	initBytecode();
 	initTheEntities();
 
 	warning("Lingo Inited");
@@ -221,7 +221,7 @@ void Lingo::executeScript(ScriptType type, uint16 id, uint16 function) {
 	debugC(1, kDebugLingoExec, "Executing script type: %s, id: %d, function: %d", scriptType2str(type), id, function);
 
 	_currentScriptContext = _scriptContexts[type][id];
-    _currentScript = _currentScriptContext->functions[function];
+	_currentScript = _currentScriptContext->functions[function];
 	_pc = 0;
 	_returning = false;
 
@@ -237,11 +237,11 @@ void Lingo::restartLingo() {
 
 	for (int i = 0; i <= kMaxScriptType; i++) {
 		for (ScriptContextHash::iterator it = _scriptContexts[i].begin(); it != _scriptContexts[i].end(); ++it) {
-            for (size_t j = 0; j < it->_value->functions.size(); j++) {
-                delete it->_value->functions[j];
-            }
+			for (size_t j = 0; j < it->_value->functions.size(); j++) {
+				delete it->_value->functions[j];
+			}
 			delete it->_value;
-        }
+		}
 
 		_scriptContexts[i].clear();
 	}

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -123,6 +123,9 @@ void Lingo::addCode(const char *code, ScriptType type, uint16 id) {
 	debugC(1, kDebugLingoCompile, "Add code \"%s\" for type %s with id %d", code, scriptType2str(type), id);
 
 	if (_scriptContexts[type].contains(id)) {
+		for (size_t j = 0; j < _scriptContexts[type][id]->functions.size(); j++) {
+			delete _scriptContexts[type][id]->functions[j];
+		}
 		delete _scriptContexts[type][id];
 	}
 

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -73,6 +73,7 @@ Lingo::Lingo(DirectorEngine *vm) : _vm(vm) {
 
 	initBuiltIns();
 	initFuncs();
+    initBytecode();
 	initTheEntities();
 
 	warning("Lingo Inited");

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -333,9 +333,6 @@ public:
 	static void c_open();
 	static void c_hilite();
 
-	static void c_jump();
-	static void c_jumpif();
-
 	// stubs for unknown instructions
 	static void c_unk();
 	static void c_unk1();

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -148,7 +148,11 @@ struct Builtin {
 	Builtin(void (*func1)(void), int nargs1) : func(func1), nargs(nargs1) {}
 };
 
-typedef Common::HashMap<int32, ScriptData *> ScriptHash;
+struct ScriptContext {
+    Common::Array<ScriptData *> functions;
+};
+
+typedef Common::HashMap<int32, ScriptContext *> ScriptContextHash;
 typedef Common::Array<Datum> StackData;
 typedef Common::HashMap<Common::String, Symbol *, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> SymbolHash;
 typedef Common::HashMap<Common::String, Builtin *, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> BuiltinHash;
@@ -172,7 +176,7 @@ public:
 
 	void addCode(const char *code, ScriptType type, uint16 id);
 	void addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType type, uint16 id);
-	void executeScript(ScriptType type, uint16 id);
+	void executeScript(ScriptType type, uint16 id, uint16 function);
 	void printStack(const char *s);
 	Common::String decodeInstruction(uint pc, uint *newPC = NULL);
 
@@ -532,9 +536,11 @@ public:
 	Datum getTheCast(Datum &id, int field);
 
 public:
-	ScriptData *_currentScript;
 	ScriptType _currentScriptType;
 	uint16 _currentEntityId;
+	ScriptContext *_currentScriptContext;
+	uint16 _currentScriptFunction;
+	ScriptData *_currentScript;
 	bool _returning;
 	bool _indef;
 	bool _ignoreMe;
@@ -575,7 +581,7 @@ private:
 	Common::HashMap<Common::String, uint32> _eventHandlerTypeIds;
 	Common::HashMap<Common::String, Audio::AudioStream *> _audioAliases;
 
-	ScriptHash _scripts[kMaxScriptType + 1];
+	ScriptContextHash _scriptContexts[kMaxScriptType + 1];
 
 	SymbolHash _globalvars;
 	SymbolHash *_localvars;

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -208,7 +208,7 @@ public:
 	int code3(inst code_1, inst code_2, inst code_3) { int o = code1(code_1); code1(code_2); code1(code_3); return o; }
 	int codeString(const char *s);
 	void codeLabel(int label);
-	int codeConst(int val);
+	int codeInt(int val);
 	int codeArray(int arraySize);
 
 	int calcStringAlignment(const char *s) {
@@ -261,9 +261,9 @@ public:
 	static void c_wordOf();
 	static void c_wordToOf();
 
-	static void c_constpush();
+	static void c_intpush();
 	static void c_voidpush();
-	static void c_fconstpush();
+	static void c_floatpush();
 	static void c_stringpush();
 	static void c_symbolpush();
 	static void c_varpush();

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -331,9 +331,10 @@ public:
     static void c_jump();
     static void c_jumpif();
 
-    static void c_nop();
-    static void c_nop1();
-    static void c_nop2();
+    // stubs for unknown instructions
+    static void c_unk();
+    static void c_unk1();
+    static void c_unk2();
 
 	void printSTUBWithArglist(const char *funcname, int nargs, const char *prefix = "STUB:");
 	void convertVOIDtoString(int arg, int nargs);

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -176,6 +176,7 @@ public:
 
 	void addCode(const char *code, ScriptType type, uint16 id);
 	void addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType type, uint16 id);
+	void addNamesV4(Common::SeekableSubReadStreamEndian &stream);
 	void executeScript(ScriptType type, uint16 id, uint16 function);
 	void printStack(const char *s);
 	Common::String decodeInstruction(uint pc, uint *newPC = NULL);
@@ -551,6 +552,7 @@ public:
 	TheEntityHash _theEntities;
 	TheEntityFieldHash _theEntityFields;
 	Common::Array<int> _labelstack;
+	Common::Array<Common::String> _namelist;
 
 	SymbolHash _builtins;
 	Common::HashMap<Common::String, bool> _twoWordBuiltins;

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -163,6 +163,7 @@ public:
 	void restartLingo();
 
 	void addCode(const char *code, ScriptType type, uint16 id);
+	void addCodeV4(Common::SeekableSubReadStreamEndian &stream, ScriptType type, uint16 id);
 	void executeScript(ScriptType type, uint16 id);
 	void printStack(const char *s);
 	Common::String decodeInstruction(uint pc, uint *newPC = NULL);
@@ -252,6 +253,8 @@ public:
 
 	static void c_intersects();
 	static void c_within();
+    static void c_field();
+    static void c_of();
 	static void c_charOf();
 	static void c_charToOf();
 	static void c_itemOf();
@@ -283,6 +286,8 @@ public:
 	static void c_ifcode();
 	static void c_whencode();
 	static void c_tellcode();
+	static void c_tell();
+	static void c_telldone();
 	static void c_exitRepeat();
 	static void c_eq();
 	static void c_neq();
@@ -310,6 +315,7 @@ public:
 	static void c_playdone();
 
 	static void c_open();
+    static void c_hilite();
 
 	void printSTUBWithArglist(const char *funcname, int nargs, const char *prefix = "STUB:");
 	void convertVOIDtoString(int arg, int nargs);

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -90,10 +90,10 @@ struct FuncDesc {
 typedef Common::HashMap<void *, FuncDesc *> FuncHash;
 
 struct Opcode {
-    inst func;
-    const char *proto;
+	inst func;
+	const char *proto;
 
-    Opcode(inst f, const char *p) { func = f; proto = p; }
+	Opcode(inst f, const char *p) { func = f; proto = p; }
 };
 typedef Common::HashMap<int, Opcode *> OpcodeHash;
 
@@ -149,7 +149,7 @@ struct Builtin {
 };
 
 struct ScriptContext {
-    Common::Array<ScriptData *> functions;
+	Common::Array<ScriptData *> functions;
 };
 
 typedef Common::HashMap<int32, ScriptContext *> ScriptContextHash;
@@ -182,7 +182,7 @@ public:
 
 	void initBuiltIns();
 	void initFuncs();
-    void initBytecode();
+	void initBytecode();
 	void initTheEntities();
 
 	void runTests();
@@ -267,8 +267,8 @@ public:
 
 	static void c_intersects();
 	static void c_within();
-    static void c_field();
-    static void c_of();
+	static void c_field();
+	static void c_of();
 	static void c_charOf();
 	static void c_charToOf();
 	static void c_itemOf();
@@ -330,15 +330,15 @@ public:
 	static void c_playdone();
 
 	static void c_open();
-    static void c_hilite();
+	static void c_hilite();
 
-    static void c_jump();
-    static void c_jumpif();
+	static void c_jump();
+	static void c_jumpif();
 
-    // stubs for unknown instructions
-    static void c_unk();
-    static void c_unk1();
-    static void c_unk2();
+	// stubs for unknown instructions
+	static void c_unk();
+	static void c_unk1();
+	static void c_unk2();
 
 	void printSTUBWithArglist(const char *funcname, int nargs, const char *prefix = "STUB:");
 	void convertVOIDtoString(int arg, int nargs);
@@ -588,7 +588,7 @@ private:
 
 	FuncHash _functions;
 
-    OpcodeHash _lingoV4;
+	OpcodeHash _lingoV4;
 
 	uint _pc;
 

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -89,6 +89,14 @@ struct FuncDesc {
 
 typedef Common::HashMap<void *, FuncDesc *> FuncHash;
 
+struct Opcode {
+    inst func;
+    const char *proto;
+
+    Opcode(inst f, const char *p) { func = f; proto = p; }
+};
+typedef Common::HashMap<int, Opcode *> OpcodeHash;
+
 struct Symbol {	/* symbol table entry */
 	Common::String name;
 	int type;
@@ -170,6 +178,7 @@ public:
 
 	void initBuiltIns();
 	void initFuncs();
+    void initBytecode();
 	void initTheEntities();
 
 	void runTests();
@@ -207,6 +216,7 @@ public:
 	int code1(inst code) { _currentScript->push_back(code); return _currentScript->size() - 1; }
 	int code2(inst code_1, inst code_2) { int o = code1(code_1); code1(code_2); return o; }
 	int code3(inst code_1, inst code_2, inst code_3) { int o = code1(code_1); code1(code_2); code1(code_3); return o; }
+	int code4(inst code_1, inst code_2, inst code_3, inst code_4) { int o = code1(code_1); code1(code_2); code1(code_3); code1(code_4); return o; }
 	int codeString(const char *s);
 	void codeLabel(int label);
 	int codeInt(int val);
@@ -270,6 +280,7 @@ public:
 	static void c_stringpush();
 	static void c_symbolpush();
 	static void c_varpush();
+	static void c_argspush();
 	static void c_arraypush();
 	static void c_assign();
 	bool verify(Symbol *s);
@@ -316,6 +327,13 @@ public:
 
 	static void c_open();
     static void c_hilite();
+
+    static void c_jump();
+    static void c_jumpif();
+
+    static void c_nop();
+    static void c_nop1();
+    static void c_nop2();
 
 	void printSTUBWithArglist(const char *funcname, int nargs, const char *prefix = "STUB:");
 	void convertVOIDtoString(int arg, int nargs);
@@ -562,6 +580,8 @@ private:
 	SymbolHash *_localvars;
 
 	FuncHash _functions;
+
+    OpcodeHash _lingoV4;
 
 	uint _pc;
 

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -20,6 +20,7 @@ MODULE_OBJS = \
 	lingo/lingo-gr.o \
 	lingo/lingo.o \
 	lingo/lingo-builtins.o \
+	lingo/lingo-bytecode.o \
 	lingo/lingo-code.o \
 	lingo/lingo-codegen.o \
 	lingo/lingo-events.o \

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -266,7 +266,7 @@ void Score::loadSpriteImages(bool isSharedCast) {
 				if (_vm->getVersion() < 4) {
 					img = new BITDDecoder(w, h);
 				} else if (_vm->getVersion() < 6) {
-					img = new BITDDecoderV4(w, h, bitmapCast->bitsPerPixel);
+					img = new BITDDecoderV4(w, h, bitmapCast->bitsPerPixel, bitmapCast->pitch);
 				} else {
 					img = new Image::BitmapDecoder();
 				}

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -181,7 +181,7 @@ void Score::loadArchive() {
 	loadSpriteImages(false);
 
 	// Try to load script name lists
-	if (_vm->getVersion() == 4) {
+	if (_vm->getVersion() >= 4) {
 		Common::Array<uint16> lnam =  _movieArchive->getResourceIDList(MKTAG('L','n','a','m'));
 		if (lnam.size() > 0) {
 			debugC(2, kDebugLoading, "****** Loading %d Lnam resources", lnam.size());
@@ -193,7 +193,7 @@ void Score::loadArchive() {
 	}
 
 	// Try to load compiled Lingo scripts
-	if (_vm->getVersion() == 4) {
+	if (_vm->getVersion() >= 4) {
 		Common::Array<uint16> lscr =  _movieArchive->getResourceIDList(MKTAG('L','s','c','r'));
 		if (lscr.size() > 0) {
 			debugC(2, kDebugLoading, "****** Loading %d Lscr resources", lscr.size());
@@ -897,7 +897,7 @@ bool Score::processImmediateFrameScript(Common::String s, int id) {
 }
 
 void Score::loadLingoNames(Common::SeekableSubReadStreamEndian &stream) {
-	if (_vm->getVersion() == 4) {
+	if (_vm->getVersion() >= 4) {
 		_lingo->addNamesV4(stream);
 	} else {
 		error("Score::loadLingoNames: unsuported Director version (%d)", _vm->getVersion());
@@ -905,7 +905,7 @@ void Score::loadLingoNames(Common::SeekableSubReadStreamEndian &stream) {
 }
 
 void Score::loadLingoScript(Common::SeekableSubReadStreamEndian &stream) {
-	if (_vm->getVersion() == 4) {
+	if (_vm->getVersion() >= 4) {
 		_lingo->addCodeV4(stream, kMovieScript, _movieScriptCount);
 	} else {
 		error("Score::loadLingoScript: unsuported Director version (%d)", _vm->getVersion());

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -180,18 +180,29 @@ void Score::loadArchive() {
 	setSpriteCasts();
 	loadSpriteImages(false);
 
-    // Try to load compiled Lingo scripts
-    if (_vm->getVersion() == 4) {
-        Common::Array<uint16> lscr =  _movieArchive->getResourceIDList(MKTAG('L','s','c','r'));
-        if (lscr.size() > 0) {
-            debugC(2, kDebugLoading, "****** Loading %d Lscr resources", lscr.size());
-            
-            for (Common::Array<uint16>::iterator iterator = lscr.begin(); iterator != lscr.end(); ++iterator) {
+	// Try to load script name lists
+	if (_vm->getVersion() == 4) {
+		Common::Array<uint16> lnam =  _movieArchive->getResourceIDList(MKTAG('L','n','a','m'));
+		if (lnam.size() > 0) {
+			debugC(2, kDebugLoading, "****** Loading %d Lnam resources", lnam.size());
+
+			for (Common::Array<uint16>::iterator iterator = lnam.begin(); iterator != lnam.end(); ++iterator) {
+				loadLingoNames(*_movieArchive->getResource(MKTAG('L','n','a','m'), *iterator));
+			}
+		}
+	}
+
+	// Try to load compiled Lingo scripts
+	if (_vm->getVersion() == 4) {
+		Common::Array<uint16> lscr =  _movieArchive->getResourceIDList(MKTAG('L','s','c','r'));
+		if (lscr.size() > 0) {
+			debugC(2, kDebugLoading, "****** Loading %d Lscr resources", lscr.size());
+
+			for (Common::Array<uint16>::iterator iterator = lscr.begin(); iterator != lscr.end(); ++iterator) {
 				loadLingoScript(*_movieArchive->getResource(MKTAG('L','s','c','r'), *iterator));
 			}
-        }
-
-    }
+		}
+	}
 
 	// Try to load movie script, it sits in resource A11
 	if (_vm->getVersion() <= 3) {
@@ -885,15 +896,21 @@ bool Score::processImmediateFrameScript(Common::String s, int id) {
 	return false;
 }
 
-void Score::loadLingoScript(Common::SeekableSubReadStreamEndian &stream) {
-    if (_vm->getVersion() == 4) {
+void Score::loadLingoNames(Common::SeekableSubReadStreamEndian &stream) {
+	if (_vm->getVersion() == 4) {
+		_lingo->addNamesV4(stream);
+	} else {
+		error("Score::loadLingoNames: unsuported Director version (%d)", _vm->getVersion());
+	}
+}
 
-        _lingo->addCodeV4(stream, kMovieScript, _movieScriptCount);
-    
-    } else {
-        error("Score::loadLingoScript: unsuported Director version (%d)", _vm->getVersion());
-    }
-    _movieScriptCount++;
+void Score::loadLingoScript(Common::SeekableSubReadStreamEndian &stream) {
+	if (_vm->getVersion() == 4) {
+		_lingo->addCodeV4(stream, kMovieScript, _movieScriptCount);
+	} else {
+		error("Score::loadLingoScript: unsuported Director version (%d)", _vm->getVersion());
+	}
+	_movieScriptCount++;
 }
 
 void Score::loadScriptText(Common::SeekableSubReadStreamEndian &stream) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -180,6 +180,19 @@ void Score::loadArchive() {
 	setSpriteCasts();
 	loadSpriteImages(false);
 
+    // Try to load compiled Lingo scripts
+    if (_vm->getVersion() == 4) {
+        Common::Array<uint16> lscr =  _movieArchive->getResourceIDList(MKTAG('L','s','c','r'));
+        if (lscr.size() > 0) {
+            debugC(2, kDebugLoading, "****** Loading %d Lscr resources", lscr.size());
+            
+            for (Common::Array<uint16>::iterator iterator = lscr.begin(); iterator != lscr.end(); ++iterator) {
+				loadLingoScript(*_movieArchive->getResource(MKTAG('L','s','c','r'), *iterator));
+			}
+        }
+
+    }
+
 	// Try to load movie script, it sits in resource A11
 	if (_vm->getVersion() <= 3) {
 		Common::Array<uint16> stxt = _movieArchive->getResourceIDList(MKTAG('S','T','X','T'));
@@ -870,6 +883,17 @@ bool Score::processImmediateFrameScript(Common::String s, int id) {
 	}
 
 	return false;
+}
+
+void Score::loadLingoScript(Common::SeekableSubReadStreamEndian &stream) {
+    if (_vm->getVersion() == 4) {
+
+        _lingo->addCodeV4(stream, kMovieScript, _movieScriptCount);
+    
+    } else {
+        error("Score::loadLingoScript: unsuported Director version (%d)", _vm->getVersion());
+    }
+    _movieScriptCount++;
 }
 
 void Score::loadScriptText(Common::SeekableSubReadStreamEndian &stream) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -597,28 +597,33 @@ void Score::loadCastData(Common::SeekableSubReadStreamEndian &stream, uint16 id,
 		for (uint child = 0; child < res->children.size(); child++)
 			_loadedBitmaps->getVal(id)->children.push_back(res->children[child]);
 		_castTypes[id] = kCastBitmap;
+		debugC(3, kDebugLoading, "Score::loadCastData(): loaded kCastBitmap (%d)", res->children.size());
 		break;
 	case kCastText:
 		_loadedText->setVal(id, new TextCast(castStream, _vm->getVersion()));
 		for (uint child = 0; child < res->children.size(); child++)
 			_loadedText->getVal(id)->children.push_back(res->children[child]);
 		_castTypes[id] = kCastText;
+		debugC(3, kDebugLoading, "Score::loadCastData(): loaded kCastText (%d)", res->children.size());
 		break;
 	case kCastShape:
 		_loadedShapes->setVal(id, new ShapeCast(castStream, _vm->getVersion()));
 		for (uint child = 0; child < res->children.size(); child++)
 			_loadedShapes->getVal(id)->children.push_back(res->children[child]);
 		_castTypes[id] = kCastShape;
+		debugC(3, kDebugLoading, "Score::loadCastData(): loaded kCastShape (%d)", res->children.size());
 		break;
 	case kCastButton:
 		_loadedButtons->setVal(id, new ButtonCast(castStream, _vm->getVersion()));
 		for (uint child = 0; child < res->children.size(); child++)
 			_loadedButtons->getVal(id)->children.push_back(res->children[child]);
 		_castTypes[id] = kCastButton;
+		debugC(3, kDebugLoading, "Score::loadCastData(): loaded kCastButton (%d)", res->children.size());
 		break;
 	case kCastLingoScript:
 		_loadedScripts->setVal(id, new ScriptCast(castStream, _vm->getVersion()));
 		_castTypes[id] = kCastLingoScript;
+		debugC(3, kDebugLoading, "Score::loadCastData(): loaded kCastLingoScript");
 		break;
 	case kCastRTE:
 		//TODO: Actually load RTEs correctly, don't just make fake STXT.
@@ -635,6 +640,31 @@ void Score::loadCastData(Common::SeekableSubReadStreamEndian &stream, uint16 id,
 				_loadedText->getVal(id)->importRTE(buffer);
 			}
 		}
+		debugC(3, kDebugLoading, "Score::loadCastData(): loaded kCastRTE (%d)", res->children.size());
+		break;
+	case kCastFilmLoop:
+		warning("STUB: Score::loadCastData(): kCastFilmLoop (%d)", res->children.size());
+		size2 = 0;
+		break;
+	case kCastPalette:
+		warning("STUB: Score::loadCastData(): kCastPalette (%d)", res->children.size());
+		size2 = 0;
+		break;
+	case kCastPicture:
+		warning("STUB: Score::loadCastData(): kCastPicture (%d)", res->children.size());
+		size2 = 0;
+		break;
+	case kCastSound:
+		warning("STUB: Score::loadCastData(): kCastSound (%d)", res->children.size());
+		size2 = 0;
+		break;
+	case kCastMovie:
+		warning("STUB: Score::loadCastData(): kCastMovie (%d)", res->children.size());
+		size2 = 0;
+		break;
+	case kCastDigitalVideo:
+		warning("STUB: Score::loadCastData(): kCastDigitalVideo (%d)", res->children.size());
+		size2 = 0;
 		break;
 	default:
 		warning("Score::loadCastData(): Unhandled cast type: %d [%s]", castType, tag2str(castType));

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -70,7 +70,7 @@ Score::Score(DirectorEngine *vm) {
 
 	// FIXME: TODO: Check whether the original truely does it
 	if (_vm->getVersion() <= 3) {
-		_lingo->executeScript(kMovieScript, 0);
+		_lingo->executeScript(kMovieScript, 0, 0);
 	}
 	_movieScriptCount = 0;
 	_labels = NULL;

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -101,6 +101,7 @@ private:
 	void loadFrames(Common::SeekableSubReadStreamEndian &stream);
 	void loadLabels(Common::SeekableSubReadStreamEndian &stream);
 	void loadActions(Common::SeekableSubReadStreamEndian &stream);
+	void loadLingoScript(Common::SeekableSubReadStreamEndian &stream);
 	void loadScriptText(Common::SeekableSubReadStreamEndian &stream);
 	void loadFileInfo(Common::SeekableSubReadStreamEndian &stream);
 	void loadFontMap(Common::SeekableSubReadStreamEndian &stream);

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -101,6 +101,7 @@ private:
 	void loadFrames(Common::SeekableSubReadStreamEndian &stream);
 	void loadLabels(Common::SeekableSubReadStreamEndian &stream);
 	void loadActions(Common::SeekableSubReadStreamEndian &stream);
+	void loadLingoNames(Common::SeekableSubReadStreamEndian &stream);
 	void loadLingoScript(Common::SeekableSubReadStreamEndian &stream);
 	void loadScriptText(Common::SeekableSubReadStreamEndian &stream);
 	void loadFileInfo(Common::SeekableSubReadStreamEndian &stream);


### PR DESCRIPTION
This patch adds the foundations of a bytecode interpreter for Director v4 Lingo scripts, using the same execution framework as the Lingo parser. 

There's still quite a lot of work to be done, especially with respect to context management, script invocation, event callbacks, etc.