### PR TITLE
BACKENDS: Remove unnecessary implementations of setGraphicsMode(const char *)

### DIFF
--- a/backends/platform/ds/arm9/source/osystem_ds.cpp
+++ b/backends/platform/ds/arm9/source/osystem_ds.cpp
@@ -175,11 +175,6 @@ bool OSystem_DS::setGraphicsMode(int mode) {
 	return true;
 }
 
-bool OSystem_DS::setGraphicsMode(const char *name) {
-	consolePrintf("Set gfx mode %s\n", name);
-	return true;
-}
-
 int OSystem_DS::getGraphicsMode() const {
 	return -1;
 }

--- a/backends/platform/ds/arm9/source/osystem_ds.h
+++ b/backends/platform/ds/arm9/source/osystem_ds.h
@@ -87,7 +87,6 @@ public:
 	virtual const GraphicsMode *getSupportedGraphicsModes() const;
 	virtual int getDefaultGraphicsMode() const;
 	virtual bool setGraphicsMode(int mode);
-	bool setGraphicsMode(const char *name);
 	virtual int getGraphicsMode() const;
 	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format);
 	virtual int16 getHeight();

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -146,7 +146,6 @@ public:
 	virtual bool getFeatureState(Feature f);
 	virtual const GraphicsMode *getSupportedGraphicsModes() const;
 	virtual int getDefaultGraphicsMode() const;
-	bool setGraphicsMode(const char *name);
 	virtual bool setGraphicsMode(int mode);
 	virtual int getGraphicsMode() const;
 	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format);

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -224,22 +224,6 @@ int OSystem_N64::getDefaultGraphicsMode() const {
 	return OVERS_NTSC_340X240;
 }
 
-bool OSystem_N64::setGraphicsMode(const char *mode) {
-	int i = 0;
-	while (s_supportedGraphicsModes[i].name) {
-		if (!scumm_stricmp(s_supportedGraphicsModes[i].name, mode)) {
-			_graphicMode = s_supportedGraphicsModes[i].id;
-
-			switchGraphicModeId(_graphicMode);
-
-			return true;
-		}
-		i++;
-	}
-
-	return true;
-}
-
 bool OSystem_N64::setGraphicsMode(int mode) {
 	_graphicMode = mode;
 	switchGraphicModeId(_graphicMode);

--- a/backends/platform/psp/display_manager.cpp
+++ b/backends/platform/psp/display_manager.cpp
@@ -326,22 +326,6 @@ void DisplayManager::setSizeAndPixelFormat(uint width, uint height, const Graphi
 	calculateScaleParams();
 }
 
-bool DisplayManager::setGraphicsMode(const char *name) {
-	DEBUG_ENTER_FUNC();
-
-	int i = 0;
-
-	while (_supportedModes[i].name) {
-		if (!scumm_stricmp(_supportedModes[i].name, name)) {
-			setGraphicsMode(_supportedModes[i].id);
-			return true;
-		}
-		i++;
-	}
-
-	return false;
-}
-
 bool DisplayManager::setGraphicsMode(int mode) {
 	DEBUG_ENTER_FUNC();
 

--- a/backends/platform/psp/display_manager.h
+++ b/backends/platform/psp/display_manager.h
@@ -116,7 +116,6 @@ public:
 	bool renderAll();	// return true if rendered or nothing dirty. False otherwise
 	void waitUntilRenderFinished();
 	bool setGraphicsMode(int mode);
-	bool setGraphicsMode(const char *name);
 	int getGraphicsMode() const { return _graphicsMode; }
 	uint32 getDefaultGraphicsMode() const { return FIT_TO_SCREEN; }
 	const OSystem::GraphicsMode* getSupportedGraphicsModes() const { return _supportedModes; }

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -150,13 +150,6 @@ bool OSystem_PSP::setGraphicsMode(int mode) {
 	return _displayManager.setGraphicsMode(mode);
 }
 
-bool OSystem_PSP::setGraphicsMode(const char *name) {
-	DEBUG_ENTER_FUNC();
-	_displayManager.waitUntilRenderFinished();
-	_pendingUpdate = false;
-	return _displayManager.setGraphicsMode(name);
-}
-
 int OSystem_PSP::getGraphicsMode() const {
 	DEBUG_ENTER_FUNC();
 	return _displayManager.getGraphicsMode();

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -77,7 +77,6 @@ public:
 	const GraphicsMode *getSupportedGraphicsModes() const;
 	int getDefaultGraphicsMode() const;
 	bool setGraphicsMode(int mode);
-	bool setGraphicsMode(const char *name);
 	int getGraphicsMode() const;
 #ifdef USE_RGB_COLOR
 	virtual Graphics::PixelFormat getScreenFormat() const;

--- a/backends/platform/symbian/src/SymbianOS.cpp
+++ b/backends/platform/symbian/src/SymbianOS.cpp
@@ -161,11 +161,6 @@ void OSystem_SDL_Symbian::checkMappings() {
 	GUI::Actions::Instance()->initInstanceGame();
 }
 
-// make sure we always go to normal, even if the string might be set wrong!
-bool OSystem_SDL_Symbian::setGraphicsMode(const char * /*name*/) {
-	return _graphicsManager->setGraphicsMode(0);
-}
-
 Common::String OSystem_SDL_Symbian::getDefaultConfigFileName() {
 	char configFile[MAXPATHLEN];
 	strcpy(configFile, Symbian::GetExecutablePath());

--- a/backends/platform/symbian/src/SymbianOS.h
+++ b/backends/platform/symbian/src/SymbianOS.h
@@ -37,7 +37,6 @@ public:
 	virtual void quit();
 	virtual void engineInit();
 	virtual void engineDone();
-	virtual bool setGraphicsMode(const char *name);
 	virtual Common::String getDefaultConfigFileName();
 	virtual bool hasFeature(Feature f);
 


### PR DESCRIPTION
* The N64 and PSP implementations are functionally identical to the versions in the base OSystem class, apart from the fact that neither of them recognise "normal" or "default" as values.
* The Symbian implementation ignores the argument passed to it and just uses the first available graphics mode. However, there isn't any reason to do this since attempting to use an unrecognised graphics mode will already be handled gracefully by the backend.
* The DS implementation is just a stub.