### PR TITLE
BUILD: Disable updates if no Sparkle implementation is available

### DIFF
--- a/configure
+++ b/configure
@@ -5572,6 +5572,7 @@ if test "$_updates" = yes; then
 	if test "$_sparkle" = yes; then
 		echo "Sparkle"
 	else
+		_updates=no;
 		echo "$_updates"
 	fi
 else

--- a/configure
+++ b/configure
@@ -5567,7 +5567,6 @@ echo "$_bink"
 # Check whether to build updates support
 #
 echo_n "Building updates support... "
-define_in_config_if_yes $_updates 'USE_UPDATES'
 if test "$_updates" = yes; then
 	if test "$_sparkle" = yes; then
 		echo "Sparkle"
@@ -5578,6 +5577,7 @@ if test "$_updates" = yes; then
 else
 	echo "$_updates"
 fi
+define_in_config_if_yes $_updates 'USE_UPDATES'
 
 #
 # Figure out installation directories


### PR DESCRIPTION
Currently, --enable-release always enables updates even on unsupported platforms.
This additional check disables updates entirely if no proper sparkle implementation
is found.

Fixes #11217.

I tested this with a current Fedora installation and a mingw-w64 build and everything works as expected. Could somebody please check if it doesn't break macOS?