### PR TITLE
OPENGL: Ensure surfaces created by saveScreenshot are the right way up

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -1323,10 +1323,12 @@ bool OpenGLGraphicsManager::saveScreenshot(const Common::String &filename) const
 #endif
 	Graphics::Surface data;
 	data.init(width, height, lineSize, &pixels.front(), format);
+	data.flipVertical(Common::Rect(width, height));
+
 #ifdef USE_PNG
-	return Image::writePNG(out, data, true);
+	return Image::writePNG(out, data);
 #else
-	return Image::writeBMP(out, data, true);
+	return Image::writeBMP(out, data);
 #endif
 }
 

--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -354,6 +354,20 @@ void Surface::move(int dx, int dy, int height) {
 	}
 }
 
+void Surface::flipVertical(const Common::Rect &r) {
+	const int width = r.width() * format.bytesPerPixel;
+	byte *temp = new byte[width];
+	for (int y = r.top; y < r.bottom / 2; y++) {
+		byte *row1 = (byte *)getBasePtr(r.left, y);
+		byte *row2 = (byte *)getBasePtr(r.left, r.bottom - y - 1);
+
+		memcpy(temp, row1, width);
+		memcpy(row1, row2, width);
+		memcpy(row2, temp, width);
+	}
+	delete[] temp;
+}
+
 void Surface::convertToInPlace(const PixelFormat &dstFormat, const byte *palette) {
 	// Do not convert to the same format and ignore empty surfaces.
 	if (format == dstFormat || pixels == 0) {

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -327,6 +327,13 @@ public:
 
 	// See comment in graphics/surface.cpp about it
 	void move(int dx, int dy, int height);
+
+	/**
+	 * Flip the specified rect vertically.
+	 *
+	 * @param r Rect to flip
+	 */
+	void flipVertical(const Common::Rect &r);
 };
 
 /**

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -132,7 +132,7 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	return true;
 }
 
-bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp) {
+bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input) {
 #ifdef SCUMM_LITTLE_ENDIAN
 	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
 #else
@@ -170,16 +170,9 @@ bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const bo
 	out.writeUint32LE(0);
 
 
-	if (bottomUp) {
-		for (uint y = 0; y < surface->h; ++y) {
-			out.write((const void *)surface->getBasePtr(0, y), dstPitch);
-			out.write(&padding, extraDataLength);
-		}
-	} else {
-		for (uint y = surface->h; y-- > 0;) {
-			out.write((const void *)surface->getBasePtr(0, y), dstPitch);
-			out.write(&padding, extraDataLength);
-		}
+	for (uint y = surface->h; y-- > 0;) {
+		out.write((const void *)surface->getBasePtr(0, y), dstPitch);
+		out.write(&padding, extraDataLength);
 	}
 
 	// free tmp surface

--- a/image/bmp.h
+++ b/image/bmp.h
@@ -69,11 +69,8 @@ private:
 
 /**
  * Outputs an uncompressed BMP stream of the given input surface.
- *
- * @param bottomUp Flip the vertical axis so pixel data is drawn from the
- * bottom up, instead of from the top down.
  */
-bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp = false);
+bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input);
 
 } // End of namespace Image
 

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -255,7 +255,7 @@ bool PNGDecoder::loadStream(Common::SeekableReadStream &stream) {
 #endif
 }
 
-bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp) {
+bool writePNG(Common::WriteStream &out, const Graphics::Surface &input) {
 #ifdef USE_PNG
 #ifdef SCUMM_LITTLE_ENDIAN
 	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 0, 8, 16, 0);
@@ -300,14 +300,8 @@ bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const bo
 
 	Common::Array<const uint8 *> rows;
 	rows.reserve(surface->h);
-	if (bottomUp) {
-		for (uint y = surface->h; y-- > 0;) {
-			rows.push_back((const uint8 *)surface->getBasePtr(0, y));
-		}
-	} else {
-		for (uint y = 0; y < surface->h; ++y) {
-			rows.push_back((const uint8 *)surface->getBasePtr(0, y));
-		}
+	for (uint y = 0; y < surface->h; ++y) {
+		rows.push_back((const uint8 *)surface->getBasePtr(0, y));
 	}
 
 	png_set_rows(pngPtr, infoPtr, const_cast<uint8 **>(&rows.front()));

--- a/image/png.h
+++ b/image/png.h
@@ -78,11 +78,8 @@ private:
 
 /**
  * Outputs a compressed PNG stream of the given input surface.
- *
- * @param bottomUp Flip the vertical axis so pixel data is drawn from the
- * bottom up, instead of from the top down.
  */
-bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp = false);
+bool writePNG(Common::WriteStream &out, const Graphics::Surface &input);
 
 } // End of namespace Image
 


### PR DESCRIPTION
This removes the need to flip surfaces the right way up in `writePNG()` or `writeBMP()`.