### PR TITLE
GRAPHICS: Horizontal Screen Shake

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -81,7 +81,7 @@ public:
 	virtual void unlockScreen() = 0;
 	virtual void fillScreen(uint32 col) = 0;
 	virtual void updateScreen() = 0;
-	virtual void setShakePos(int shakeOffset) = 0;
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset) = 0;
 	virtual void setFocusRectangle(const Common::Rect& rect) = 0;
 	virtual void clearFocusRectangle() = 0;
 

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -63,7 +63,7 @@ public:
 	void unlockScreen() override {}
 	void fillScreen(uint32 col) override {}
 	void updateScreen() override {}
-	void setShakePos(int shakeOffset) override {}
+	void setShakePos(int shakeXOffset, int shakeYOffset) override {}
 	void setFocusRectangle(const Common::Rect& rect) override {}
 	void clearFocusRectangle() override {}
 

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -436,7 +436,8 @@ void OpenGLGraphicsManager::initSize(uint width, uint height, const Graphics::Pi
 
 	_currentState.gameWidth = width;
 	_currentState.gameHeight = height;
-	_gameScreenShakeOffset = 0;
+	_gameScreenShakeXOffset = 0;
+	_gameScreenShakeYOffset = 0;
 }
 
 int16 OpenGLGraphicsManager::getWidth() const {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -387,7 +387,8 @@ protected:
 
 	// Shake mode
 	// This is always set to 0 when building with SDL2.
-	int _currentShakePos;
+	int _currentShakeXOffset;
+	int _currentShakeYOffset;
 
 	// Palette data
 	SDL_Color *_currentPalette;

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -44,7 +44,8 @@ public:
 		_windowWidth(0),
 		_windowHeight(0),
 		_overlayVisible(false),
-		_gameScreenShakeOffset(0),
+		_gameScreenShakeXOffset(0),
+		_gameScreenShakeYOffset(0),
 		_forceRedraw(false),
 		_cursorVisible(false),
 		_cursorX(0),
@@ -76,9 +77,10 @@ public:
 		_forceRedraw = true;
 	}
 
-	virtual void setShakePos(int shakeOffset) override {
-		if (_gameScreenShakeOffset != shakeOffset) {
-			_gameScreenShakeOffset = shakeOffset;
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset) override {
+		if (_gameScreenShakeXOffset != shakeXOffset || _gameScreenShakeYOffset != shakeYOffset) {
+			_gameScreenShakeXOffset = shakeXOffset;
+			_gameScreenShakeYOffset = shakeYOffset;
 			recalculateDisplayAreas();
 			_cursorNeedsRedraw = true;
 		}
@@ -291,9 +293,14 @@ protected:
 	bool _overlayVisible;
 
 	/**
-	 * The offset by which the screen is moved vertically.
+	 * The offset by which the screen is moved horizontally.
 	 */
-	int _gameScreenShakeOffset;
+	int _gameScreenShakeXOffset;
+
+	/**
+	* The offset by which the screen is moved vertically.
+	*/
+	int _gameScreenShakeYOffset;
 
 	/**
 	 * The scaled draw rectangle for the game surface within the window.
@@ -400,7 +407,7 @@ private:
 		}
 
 		drawRect.left = ((_windowWidth - width) / 2);
-		drawRect.top = ((_windowHeight - height) / 2) + _gameScreenShakeOffset;
+		drawRect.top = ((_windowHeight - height) / 2) + _gameScreenShakeYOffset;
 		drawRect.setWidth(width);
 		drawRect.setHeight(height);
 	}

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -406,7 +406,7 @@ private:
 			}
 		}
 
-		drawRect.left = ((_windowWidth - width) / 2);
+		drawRect.left = ((_windowWidth - width) / 2) + _gameScreenShakeXOffset;
 		drawRect.top = ((_windowHeight - height) / 2) + _gameScreenShakeYOffset;
 		drawRect.setWidth(width);
 		drawRect.setHeight(height);

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -185,8 +185,8 @@ void ModularBackend::updateScreen() {
 #endif
 }
 
-void ModularBackend::setShakePos(int shakeOffset) {
-	_graphicsManager->setShakePos(shakeOffset);
+void ModularBackend::setShakePos(int shakeXOffset, int shakeYOffset) {
+	_graphicsManager->setShakePos(shakeXOffset, shakeYOffset);
 }
 void ModularBackend::setFocusRectangle(const Common::Rect& rect) {
 	_graphicsManager->setFocusRectangle(rect);

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -93,7 +93,7 @@ public:
 	virtual void unlockScreen() override;
 	virtual void fillScreen(uint32 col) override;
 	virtual void updateScreen() override;
-	virtual void setShakePos(int shakeOffset) override;
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset) override;
 	virtual void setFocusRectangle(const Common::Rect& rect) override;
 	virtual void clearFocusRectangle() override;
 

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -370,8 +370,12 @@ void OSystem_3DS::setShakePos(int shakeXOffset, int shakeYOffset) {
 	// TODO: implement this in overlay, top screen, and mouse too
 	_screenShakeXOffset = shakeXOffset;
 	_screenShakeYOffset = shakeYOffset;
-	_gameTopTexture.setPosition(_gameTopX, _gameTopY + _gameTopTexture.getScaleY() * shakeYOffset);
-	_gameBottomTexture.setPosition(_gameBottomX, _gameBottomY + _gameBottomTexture.getScaleY() * shakeYOffset);
+	int topX = _gameTopX + (_gameTopTexture.getScaleX() * shakeXOffset);
+	int topY = _gameTopY + (_gameTopTexture.getScaleY() * shakeYOffset);
+	_gameTopTexture.setPosition(topX, topY);
+	int bottomX = _gameBottomX + (_gameBottomTexture.getScaleX() * shakeXOffset);
+	int bottomY = _gameBottomY + (_gameBottomTexture.getScaleY() * shakeYOffset);
+	_gameBottomTexture.setPosition(bottomX, bottomY);
 }
 
 void OSystem_3DS::setFocusRectangle(const Common::Rect &rect) {

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -366,11 +366,12 @@ void OSystem_3DS::updateScreen() {
 	C3D_FrameEnd(0);
 }
 
-void OSystem_3DS::setShakePos(int shakeOffset) {
+void OSystem_3DS::setShakePos(int shakeXOffset, int shakeYOffset) {
 	// TODO: implement this in overlay, top screen, and mouse too
-	_screenShakeOffset = shakeOffset;
-	_gameTopTexture.setPosition(_gameTopX, _gameTopY + _gameTopTexture.getScaleY() * shakeOffset);
-	_gameBottomTexture.setPosition(_gameBottomX, _gameBottomY + _gameBottomTexture.getScaleY() * shakeOffset);
+	_screenShakeXOffset = shakeXOffset;
+	_screenShakeYOffset = shakeYOffset;
+	_gameTopTexture.setPosition(_gameTopX, _gameTopY + _gameTopTexture.getScaleY() * shakeYOffset);
+	_gameBottomTexture.setPosition(_gameBottomX, _gameBottomY + _gameBottomTexture.getScaleY() * shakeYOffset);
 }
 
 void OSystem_3DS::setFocusRectangle(const Common::Rect &rect) {

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -119,7 +119,7 @@ public:
 	Graphics::Surface *lockScreen();
 	void unlockScreen();
 	void updateScreen();
-	void setShakePos(int shakeOffset);
+	void setShakePos(int shakeXOffset, int shakeYOffset);
 	void setFocusRectangle(const Common::Rect &rect);
 	void clearFocusRectangle();
 	void showOverlay();
@@ -200,7 +200,8 @@ private:
 	};
 	uint32 _osdMessageEndTime;
 
-	int _screenShakeOffset;
+	int _screenShakeXOffset;
+	int _screenShakeYOffset;
 	bool _overlayVisible;
 	int _screenChangeId;
 

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -145,7 +145,7 @@ public:
   void setCursorPalette(const byte *colors, uint start, uint num);
 
   // Shaking is used in SCUMM. Set current shake position.
-  void setShakePos(int shake_pos);
+  void setShakePos(int shake_x_pos, int shake_y_pos);
 
   // Get the number of milliseconds since the program was started.
   uint32 getMillis(bool skipRecord = false);
@@ -201,7 +201,7 @@ public:
 
   int _ms_cur_x, _ms_cur_y, _ms_cur_w, _ms_cur_h, _ms_old_x, _ms_old_y;
   int _ms_hotspot_x, _ms_hotspot_y, _ms_visible, _devpoll, _last_screen_refresh;
-  int _current_shake_pos, _screen_w, _screen_h;
+  int _current_shake_x_pos, _current_shake_y_pos, _screen_w, _screen_h;
   int _overlay_x, _overlay_y;
   unsigned char *_ms_buf;
   uint32 _ms_keycolor;

--- a/backends/platform/dc/dcmain.cpp
+++ b/backends/platform/dc/dcmain.cpp
@@ -42,7 +42,7 @@ const char *gGameName;
 OSystem_Dreamcast::OSystem_Dreamcast()
   : _devpoll(0), screen(NULL), mouse(NULL), overlay(NULL), _softkbd(this),
     _ms_buf(NULL), _mixer(NULL),
-    _current_shake_pos(0), _aspect_stretch(false), _softkbd_on(false),
+    _current_shake_x_pos(0), _current_shake_y_pos(0), _aspect_stretch(false), _softkbd_on(false),
     _softkbd_motion(0), _enable_cursor_palette(false), _screenFormat(0)
 {
   memset(screen_tx, 0, sizeof(screen_tx));

--- a/backends/platform/dc/display.cpp
+++ b/backends/platform/dc/display.cpp
@@ -35,6 +35,7 @@
 #define OVL_H 200
 #define OVL_TXSTRIDE 512
 
+#define LEFT_OFFSET (_xscale*_current_shake_x_pos)
 #define TOP_OFFSET (_top_offset+_yscale*_current_shake_y_pos)
 
 static const struct {
@@ -407,7 +408,7 @@ void OSystem_Dreamcast::updateScreenPolygons(void)
   myvertex.u = 0.0;
   myvertex.v = 0.0;
 
-  myvertex.x = 0.0;
+  myvertex.x = LEFT_OFFSET;
   myvertex.y = TOP_OFFSET;
   ta_commit_list(&myvertex);
 
@@ -462,7 +463,7 @@ void OSystem_Dreamcast::updateScreenPolygons(void)
     myvertex.u = 0.0;
     myvertex.v = 0.0;
 
-    myvertex.x = _overlay_x*_xscale;
+    myvertex.x = _overlay_x*_xscale+LEFT_OFFSET;
     myvertex.y = _overlay_y*_yscale+TOP_OFFSET;
     ta_commit_list(&myvertex);
 
@@ -601,7 +602,7 @@ void OSystem_Dreamcast::drawMouse(int xdraw, int ydraw, int w, int h,
   myvertex.u = 0.0;
   myvertex.v = 0.0;
 
-  myvertex.x = (xdraw-_ms_hotspot_x)*_xscale;
+  myvertex.x = (xdraw-_ms_hotspot_x)*_xscale + LEFT_OFFSET;
   myvertex.y = (ydraw-_ms_hotspot_y)*_yscale + TOP_OFFSET;
   ta_commit_list(&myvertex);
 
@@ -624,7 +625,7 @@ void OSystem_Dreamcast::drawMouse(int xdraw, int ydraw, int w, int h,
 void OSystem_Dreamcast::mouseToSoftKbd(int x, int y, int &rx, int &ry) const
 {
   if (_softkbd_motion) {
-    rx = (int)(x*_xscale - (330.0*sin(0.013*_softkbd_motion) - 320.0));
+    rx = (int)(x*_xscale - (330.0*sin(0.013*_softkbd_motion) + LEFT_OFFSET - 320.0));
     ry = (int)(y*_yscale + TOP_OFFSET - 200.0);
   } else {
     rx = -1;

--- a/backends/platform/dc/display.cpp
+++ b/backends/platform/dc/display.cpp
@@ -35,7 +35,7 @@
 #define OVL_H 200
 #define OVL_TXSTRIDE 512
 
-#define TOP_OFFSET (_top_offset+_yscale*_current_shake_pos)
+#define TOP_OFFSET (_top_offset+_yscale*_current_shake_y_pos)
 
 static const struct {
   Graphics::PixelFormat pixelFormat;
@@ -320,9 +320,10 @@ void OSystem_Dreamcast::setMouseCursor(const void *buf, uint w, uint h,
   memcpy(_ms_buf, buf, w * h);
 }
 
-void OSystem_Dreamcast::setShakePos(int shake_pos)
+void OSystem_Dreamcast::setShakePos(int shake_x_pos, int shake_y_pos)
 {
-  _current_shake_pos = shake_pos;
+  _current_shake_x_pos = shake_x_pos;
+  _current_shake_y_pos = shake_y_pos;
 }
 
 void OSystem_Dreamcast::updateScreenTextures(void)

--- a/backends/platform/ds/arm9/source/dsmain.cpp
+++ b/backends/platform/ds/arm9/source/dsmain.cpp
@@ -2097,6 +2097,7 @@ void VBlankHandler(void) {
 	} else {
 		SUB_BG3_CX = subScX + 64;
 	}
+	SUB_BG3_CX += (s_shakeXOffset << 8)
 
 	SUB_BG3_CY = subScY + (s_shakeYOffset << 8);*/
 
@@ -2230,7 +2231,7 @@ void VBlankHandler(void) {
 			setZoomedScreenScale(subScreenWidth, ((subScreenHeight * (256 << 8)) / 192) >> 8);
 
 
-			setMainScreenScroll(scX << 8, (scY << 8) + (s_shakeYOffset << 8));
+			setMainScreenScroll((scX << 8) + (s_shakeXOffset << 8), (scY << 8) + (s_shakeYOffset << 8));
 			setMainScreenScale(256, 256);		// 1:1 scale
 
 		} else {
@@ -2246,7 +2247,7 @@ void VBlankHandler(void) {
 			setZoomedScreenScroll(subScX, subScY, (subScreenWidth != 256) && (subScreenWidth != 128));
 			setZoomedScreenScale(subScreenWidth, ((subScreenHeight * (256 << 8)) / 192) >> 8);
 
-			setMainScreenScroll(64, (scY << 8) + (s_shakeYOffset << 8));
+			setMainScreenScroll(64 + (s_shakeXOffset << 8), (scY << 8) + (s_shakeYOffset << 8));
 			setMainScreenScale(320, 256);		// 1:1 scale
 
 		}

--- a/backends/platform/ds/arm9/source/dsmain.cpp
+++ b/backends/platform/ds/arm9/source/dsmain.cpp
@@ -260,7 +260,8 @@ static SpriteEntry spritesMain[128];
 static int tweak;
 
 // Shake
-static int s_shakePos = 0;
+static int s_shakeXOffset = 0;
+static int s_shakeYOffset = 0;
 
 // Keyboard
 static bool keyboardEnable = false;
@@ -1016,8 +1017,9 @@ void displayMode16BitFlipBuffer() {
 	#endif
 }
 
-void setShakePos(int shakePos) {
-	s_shakePos = shakePos;
+void setShakePos(int shakeXOffset, int shakeYOffset) {
+	s_shakeXOffset = shakeXOffset;
+	s_shakeYOffset = shakeYOffset;
 }
 
 
@@ -2096,7 +2098,7 @@ void VBlankHandler(void) {
 		SUB_BG3_CX = subScX + 64;
 	}
 
-	SUB_BG3_CY = subScY + (s_shakePos << 8);*/
+	SUB_BG3_CY = subScY + (s_shakeYOffset << 8);*/
 
 	/*SUB_BG3_XDX = (int) (subScreenWidth / 256.0f * 256);
 	SUB_BG3_XDY = 0;
@@ -2228,7 +2230,7 @@ void VBlankHandler(void) {
 			setZoomedScreenScale(subScreenWidth, ((subScreenHeight * (256 << 8)) / 192) >> 8);
 
 
-			setMainScreenScroll(scX << 8, (scY << 8) + (s_shakePos << 8));
+			setMainScreenScroll(scX << 8, (scY << 8) + (s_shakeYOffset << 8));
 			setMainScreenScale(256, 256);		// 1:1 scale
 
 		} else {
@@ -2244,7 +2246,7 @@ void VBlankHandler(void) {
 			setZoomedScreenScroll(subScX, subScY, (subScreenWidth != 256) && (subScreenWidth != 128));
 			setZoomedScreenScale(subScreenWidth, ((subScreenHeight * (256 << 8)) / 192) >> 8);
 
-			setMainScreenScroll(64, (scY << 8) + (s_shakePos << 8));
+			setMainScreenScroll(64, (scY << 8) + (s_shakeYOffset << 8));
 			setMainScreenScale(320, 256);		// 1:1 scale
 
 		}

--- a/backends/platform/ds/arm9/source/dsmain.h
+++ b/backends/platform/ds/arm9/source/dsmain.h
@@ -112,7 +112,7 @@ void	setShowCursor(bool enable);
 void	setMouseCursorVisible(bool visible);
 
 // Shake
-void 	setShakePos(int shakePos);
+void 	setShakePos(int shakeXOffset, int shakeYOffset);
 
 // Reports
 void 	memoryReport();

--- a/backends/platform/ds/arm9/source/osystem_ds.cpp
+++ b/backends/platform/ds/arm9/source/osystem_ds.cpp
@@ -495,8 +495,8 @@ void OSystem_DS::updateScreen() {
 	}
 }
 
-void OSystem_DS::setShakePos(int shakeOffset) {
-	DS::setShakePos(shakeOffset);
+void OSystem_DS::setShakePos(int shakeXOffset, int shakeYOffset) {
+	DS::setShakePos(shakeXOffset, shakeYOffset);
 }
 
 void OSystem_DS::showOverlay() {

--- a/backends/platform/ds/arm9/source/osystem_ds.h
+++ b/backends/platform/ds/arm9/source/osystem_ds.h
@@ -104,7 +104,7 @@ public:
 
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h);
 	virtual void updateScreen();
-	virtual void setShakePos(int shakeOffset);
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 
 	virtual void showOverlay();
 	virtual void hideOverlay();

--- a/backends/platform/ios7/ios7_common.h
+++ b/backends/platform/ios7/ios7_common.h
@@ -80,7 +80,8 @@ struct VideoContext {
 	VideoContext() : asprectRatioCorrection(), screenWidth(), screenHeight(), overlayVisible(false),
 	                 overlayWidth(), overlayHeight(), mouseX(), mouseY(),
 	                 mouseHotspotX(), mouseHotspotY(), mouseWidth(), mouseHeight(),
-	                 mouseIsVisible(), graphicsMode(kGraphicsModeNone), filtering(false), shakeOffsetY() {
+	                 mouseIsVisible(), graphicsMode(kGraphicsModeNone), filtering(false),
+	                 shakeXOffset(), shakeYOffset() {
 	}
 
 	// Game screen state
@@ -103,7 +104,8 @@ struct VideoContext {
 	// Misc state
 	GraphicsModes graphicsMode;
 	bool filtering;
-	int shakeOffsetY;
+	int shakeXOffset;
+	int shakeYOffset;
 };
 
 struct InternalEvent {

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -161,7 +161,7 @@ public:
 	virtual void updateScreen();
 	virtual Graphics::Surface *lockScreen();
 	virtual void unlockScreen();
-	virtual void setShakePos(int shakeOffset);
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 
 	virtual void showOverlay();
 	virtual void hideOverlay();

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -138,7 +138,8 @@ void OSystem_iOS7::initSize(uint width, uint height, const Graphics::PixelFormat
 
 	_videoContext->screenWidth = width;
 	_videoContext->screenHeight = height;
-	_videoContext->shakeOffsetY = 0;
+	_videoContext->shakeXOffset = 0;
+	_videoContext->shakeYOffset = 0;
 
 	// In case we use the screen texture as frame buffer we reset the pixels
 	// pointer here to avoid freeing the screen texture.
@@ -354,9 +355,10 @@ void OSystem_iOS7::unlockScreen() {
 	dirtyFullScreen();
 }
 
-void OSystem_iOS7::setShakePos(int shakeOffset) {
-	//printf("setShakePos(%i)\n", shakeOffset);
-	_videoContext->shakeOffsetY = shakeOffset;
+void OSystem_iOS7::setShakePos(int shakeXOffset, int shakeYOffset) {
+	//printf("setShakePos(%i, %i)\n", shakeXOffset, shakeYOffset);
+	_videoContext->shakeXOffset = shakeXOffset;
+	_videoContext->shakeYOffset = shakeYOffset;
 	execute_on_main_thread(^ {
 		[[iOS7AppDelegate iPhoneView] setViewTransformation];
 	});

--- a/backends/platform/ios7/ios7_video.h
+++ b/backends/platform/ios7/ios7_video.h
@@ -64,7 +64,8 @@ typedef struct {
 
 	GLuint _screenSizeSlot;
 	GLuint _textureSlot;
-	GLuint _shakeSlot;
+	GLuint _shakeXSlot;
+	GLuint _shakeYSlot;
 
 	GLuint _positionSlot;
 	GLuint _textureCoordSlot;

--- a/backends/platform/ios7/ios7_video.h
+++ b/backends/platform/ios7/ios7_video.h
@@ -84,7 +84,8 @@ typedef struct {
 	GLint _mouseWidth, _mouseHeight;
 	GLfloat _mouseScaleX, _mouseScaleY;
 
-	int _scaledShakeOffsetY;
+	int _scaledShakeXOffset;
+	int _scaledShakeYOffset;
 
 	UITouch *_firstTouch;
 	UITouch *_secondTouch;

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -454,7 +454,8 @@ uint getSizeNextPOT(uint size) {
 	_overlayTexture = 0;
 	_mouseCursorTexture = 0;
 
-	_scaledShakeOffsetY = 0;
+	_scaledShakeXOffset = 0;
+	_scaledShakeYOffset = 0;
 
 	_firstTouch = NULL;
 	_secondTouch = NULL;
@@ -868,9 +869,9 @@ uint getSizeNextPOT(uint size) {
 - (void)setViewTransformation {
 	// Scale the shake offset according to the overlay size. We need this to
 	// adjust the overlay mouse click coordinates when an offset is set.
-	_scaledShakeOffsetY = (int)(_videoContext.shakeOffsetY / (GLfloat)_videoContext.screenHeight * CGRectGetHeight(_overlayRect));
+	_scaledShakeYOffset = (int)(_videoContext.shakeYOffset / (GLfloat)_videoContext.screenHeight * CGRectGetHeight(_overlayRect));
 
-	glUniform1f(_shakeSlot, _scaledShakeOffsetY);
+	glUniform1f(_shakeSlot, _scaledShakeYOffset);
 }
 
 - (void)clearColorBuffer {
@@ -914,12 +915,12 @@ uint getSizeNextPOT(uint size) {
 		area = &_overlayRect;
 		width = _videoContext.overlayWidth;
 		height = _videoContext.overlayHeight;
-		offsetY = _scaledShakeOffsetY;
+		offsetY = _scaledShakeYOffset;
 	} else {
 		area = &_gameScreenRect;
 		width = _videoContext.screenWidth;
 		height = _videoContext.screenHeight;
-		offsetY = _videoContext.shakeOffsetY;
+		offsetY = _videoContext.shakeYOffset;
 	}
 
 	point.x = (point.x - CGRectGetMinX(*area)) / CGRectGetWidth(*area);

--- a/backends/platform/iphone/iphone_common.h
+++ b/backends/platform/iphone/iphone_common.h
@@ -61,7 +61,8 @@ struct VideoContext {
 	VideoContext() : asprectRatioCorrection(), screenWidth(), screenHeight(), overlayVisible(false),
 	                 overlayWidth(), overlayHeight(), mouseX(), mouseY(),
 	                 mouseHotspotX(), mouseHotspotY(), mouseWidth(), mouseHeight(),
-	                 mouseIsVisible(), graphicsMode(kGraphicsModeLinear), shakeOffsetY() {
+	                 mouseIsVisible(), graphicsMode(kGraphicsModeLinear),
+	                 shakeXOffset(), shakeYOffset() {
 	}
 
 	// Game screen state
@@ -83,7 +84,8 @@ struct VideoContext {
 
 	// Misc state
 	GraphicsModes graphicsMode;
-	int shakeOffsetY;
+	int shakeXOffset;
+	int shakeYOffset;
 };
 
 struct InternalEvent {

--- a/backends/platform/iphone/iphone_video.h
+++ b/backends/platform/iphone/iphone_video.h
@@ -69,7 +69,8 @@
 	GLint _mouseWidth, _mouseHeight;
 	GLfloat _mouseScaleX, _mouseScaleY;
 
-	int _scaledShakeOffsetY;
+	int _scaledShakeXOffset;
+	int _scaledShakeYOffset;
 	CGFloat _contentScaleFactor;
 
 	UITouch *_firstTouch;

--- a/backends/platform/iphone/iphone_video.mm
+++ b/backends/platform/iphone/iphone_video.mm
@@ -568,10 +568,11 @@ const char *iPhone_getDocumentsDir() {
 
 	// Scale the shake offset according to the overlay size. We need this to
 	// adjust the overlay mouse click coordinates when an offset is set.
+	_scaledShakeXOffset = (int)(_videoContext.shakeXOffset / (GLfloat)_videoContext.screenWidth * CGRectGetWidth(_overlayRect));
 	_scaledShakeYOffset = (int)(_videoContext.shakeYOffset / (GLfloat)_videoContext.screenHeight * CGRectGetHeight(_overlayRect));
 
 	// Apply the shaking to the output screen.
-	glTranslatef(0, -_scaledShakeYOffset, 0);
+	glTranslatef(_scaledShakeXOffset, -_scaledShakeYOffset, 0);
 }
 
 - (void)clearColorBuffer {
@@ -637,23 +638,25 @@ const char *iPhone_getDocumentsDir() {
 		return false;
 
 	CGRect *area;
-	int width, height, offsetY;
+	int width, height, offsetX, offsetY;
 	if (_videoContext.overlayVisible) {
 		area = &_overlayRect;
 		width = _videoContext.overlayWidth;
 		height = _videoContext.overlayHeight;
+		offsetX = _scaledShakeXOffset;
 		offsetY = _scaledShakeYOffset;
 	} else {
 		area = &_gameScreenRect;
 		width = _videoContext.screenWidth;
 		height = _videoContext.screenHeight;
+		offsetX = _videoContext.shakeXOffset;
 		offsetY = _videoContext.shakeYOffset;
 	}
 
 	point.x = (point.x - CGRectGetMinX(*area)) / CGRectGetWidth(*area);
 	point.y = (point.y - CGRectGetMinY(*area)) / CGRectGetHeight(*area);
 
-	*x = (int)(point.x * width);
+	*x = (int)(point.x * width + offsetX);
 	// offsetY describes the translation of the screen in the upward direction,
 	// thus we need to add it here.
 	*y = (int)(point.y * height + offsetY);

--- a/backends/platform/iphone/iphone_video.mm
+++ b/backends/platform/iphone/iphone_video.mm
@@ -191,7 +191,8 @@ const char *iPhone_getDocumentsDir() {
 	_overlayTexture = 0;
 	_mouseCursorTexture = 0;
 
-	_scaledShakeOffsetY = 0;
+	_scaledShakeXOffset = 0;
+	_scaledShakeYOffset = 0;
 
 	_firstTouch = NULL;
 	_secondTouch = NULL;
@@ -567,10 +568,10 @@ const char *iPhone_getDocumentsDir() {
 
 	// Scale the shake offset according to the overlay size. We need this to
 	// adjust the overlay mouse click coordinates when an offset is set.
-	_scaledShakeOffsetY = (int)(_videoContext.shakeOffsetY / (GLfloat)_videoContext.screenHeight * CGRectGetHeight(_overlayRect));
+	_scaledShakeYOffset = (int)(_videoContext.shakeYOffset / (GLfloat)_videoContext.screenHeight * CGRectGetHeight(_overlayRect));
 
-	// Apply the shakeing to the output screen.
-	glTranslatef(0, -_scaledShakeOffsetY, 0);
+	// Apply the shaking to the output screen.
+	glTranslatef(0, -_scaledShakeYOffset, 0);
 }
 
 - (void)clearColorBuffer {
@@ -641,12 +642,12 @@ const char *iPhone_getDocumentsDir() {
 		area = &_overlayRect;
 		width = _videoContext.overlayWidth;
 		height = _videoContext.overlayHeight;
-		offsetY = _scaledShakeOffsetY;
+		offsetY = _scaledShakeYOffset;
 	} else {
 		area = &_gameScreenRect;
 		width = _videoContext.screenWidth;
 		height = _videoContext.screenHeight;
-		offsetY = _videoContext.shakeOffsetY;
+		offsetY = _videoContext.shakeYOffset;
 	}
 
 	point.x = (point.x - CGRectGetMinX(*area)) / CGRectGetWidth(*area);

--- a/backends/platform/iphone/osys_main.h
+++ b/backends/platform/iphone/osys_main.h
@@ -147,7 +147,7 @@ public:
 	virtual void updateScreen();
 	virtual Graphics::Surface *lockScreen();
 	virtual void unlockScreen();
-	virtual void setShakePos(int shakeOffset);
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 
 	virtual void showOverlay();
 	virtual void hideOverlay();

--- a/backends/platform/iphone/osys_video.mm
+++ b/backends/platform/iphone/osys_video.mm
@@ -72,7 +72,8 @@ void OSystem_IPHONE::initSize(uint width, uint height, const Graphics::PixelForm
 
 	_videoContext->screenWidth = width;
 	_videoContext->screenHeight = height;
-	_videoContext->shakeOffsetY = 0;
+	_videoContext->shakeXOffset = 0;
+	_videoContext->shakeYOffset = 0;
 
 	// In case we use the screen texture as frame buffer we reset the pixels
 	// pointer here to avoid freeing the screen texture.
@@ -282,9 +283,10 @@ void OSystem_IPHONE::unlockScreen() {
 	dirtyFullScreen();
 }
 
-void OSystem_IPHONE::setShakePos(int shakeOffset) {
-	//printf("setShakePos(%i)\n", shakeOffset);
-	_videoContext->shakeOffsetY = shakeOffset;
+void OSystem_IPHONE::setShakePos(int shakeXOffset, int shakeYOffset) {
+	//printf("setShakePos(%i, %i)\n", shakeXOffset, shakeYOffset);
+	_videoContext->shakeXOffset = shakeXOffset;
+	_videoContext->shakeYOffset = shakeYOffset;
 	[g_iPhoneViewInstance performSelectorOnMainThread:@selector(setViewTransformation) withObject:nil waitUntilDone: YES];
 	// HACK: We use this to force a redraw.
 	_mouseDirty = true;

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -97,7 +97,8 @@ protected:
 	uint8 _offscrPixels; // Pixels to skip on each line before start drawing, used to center image
 	uint8 _maxFps; // Max frames-per-second which can be shown on screen
 
-	int _shakeOffset;
+	int _shakeXOffset;
+	int _shakeYOffset;
 
 	uint8 *_cursor_pal; // Cursor buffer, palettized
 	uint16 *_cursor_hic; // Cursor buffer, 16bit
@@ -164,7 +165,7 @@ public:
 	virtual void updateScreen();
 	virtual Graphics::Surface *lockScreen();
 	virtual void unlockScreen();
-	virtual void setShakePos(int shakeOffset);
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 
 	virtual void showOverlay();
 	virtual void hideOverlay();

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -90,7 +90,8 @@ OSystem_N64::OSystem_N64() {
 
 	_overlayVisible = false;
 
-	_shakeOffset = 0;
+	_shakeXOffset = 0;
+	_shakeYOffset = 0;
 
 	// Allocate memory for offscreen buffers
 	_offscreen_hic = (uint16 *)memalign(8, _screenWidth * _screenHeight * 2);
@@ -528,8 +529,8 @@ void OSystem_N64::updateScreen() {
 	// Copy the game buffer to screen
 	if (!_overlayVisible) {
 		tmpDst = game_framebuffer;
-		tmpSrc = _offscreen_hic + (_shakeOffset * _screenWidth);
-		for (currentHeight = _shakeOffset; currentHeight < _gameHeight; currentHeight++) {
+		tmpSrc = _offscreen_hic + (_shakeYOffset * _screenWidth);
+		for (currentHeight = _shakeYOffset; currentHeight < _gameHeight; currentHeight++) {
 			uint64 *game_dest = (uint64 *)(tmpDst + skip_pixels + _offscrPixels);
 			uint64 *game_src = (uint64 *)tmpSrc;
 
@@ -541,7 +542,7 @@ void OSystem_N64::updateScreen() {
 			tmpSrc += _screenWidth;
 		}
 
-		uint16 _clearLines = _shakeOffset; // When shaking we must take care of remaining lines to clear
+		uint16 _clearLines = _shakeYOffset; // When shaking we must take care of remaining lines to clear
 		while (_clearLines--) {
 			memset(tmpDst + skip_pixels + _offscrPixels, 0, _screenWidth * 2);
 			tmpDst += _frameBufferWidth;
@@ -615,13 +616,14 @@ void OSystem_N64::unlockScreen() {
 	_dirtyOffscreen = true;
 }
 
-void OSystem_N64::setShakePos(int shakeOffset) {
+void OSystem_N64::setShakePos(int shakeXOffset, int shakeYOffset) {
 
 	// If a rumble pak is plugged in and screen shakes, rumble!
-	if (shakeOffset && _controllerHasRumble) rumblePakEnable(1, _controllerPort);
-	else if (!shakeOffset && _controllerHasRumble) rumblePakEnable(0, _controllerPort);
+	if (shakeYOffset && _controllerHasRumble) rumblePakEnable(1, _controllerPort);
+	else if (!shakeYOffset && _controllerHasRumble) rumblePakEnable(0, _controllerPort);
 
-	_shakeOffset = shakeOffset;
+	_shakeXOffset = shakeXOffset;
+	_shakeYOffset = shakeYOffset;
 	_dirtyOffscreen = true;
 
 	return;
@@ -670,8 +672,8 @@ void OSystem_N64::clearOverlay() {
 	uint8 skip_pixels = (_screenWidth - _gameWidth) / 2; // Center horizontally the image
 
 	uint16 *tmpDst = _overlayBuffer + (_overlayWidth * skip_lines * 2);
-	uint16 *tmpSrc = _offscreen_hic + (_shakeOffset * _screenWidth);
-	for (uint16 currentHeight = _shakeOffset; currentHeight < _gameHeight; currentHeight++) {
+	uint16 *tmpSrc = _offscreen_hic + (_shakeYOffset * _screenWidth);
+	for (uint16 currentHeight = _shakeYOffset; currentHeight < _gameHeight; currentHeight++) {
 		memcpy((tmpDst + skip_pixels), tmpSrc, _gameWidth * 2);
 		tmpDst += _overlayWidth;
 		tmpSrc += _screenWidth;

--- a/backends/platform/ps2/Gs2dScreen.cpp
+++ b/backends/platform/ps2/Gs2dScreen.cpp
@@ -680,8 +680,11 @@ int16 Gs2dScreen::getOverlayHeight(void) {
 }
 
 void Gs2dScreen::setShakePos(int shakeXOffset, int shakeYOffset) {
+	_shakeXOffset = (shakeXOffset * _mouseScaleX) >> 8;
 	_shakeYOffset = (shakeYOffset * _mouseScaleY) >> 8;
+	_blitCoords[0].x = SCALE(_shakeXOffset) + ORIGIN_X;
 	_blitCoords[0].y = SCALE(_shakeYOffset) + ORIGIN_Y;
+	_blitCoords[1].x = SCALE(_tvWidth + _shakeXOffset) + ORIGIN_X;
 	_blitCoords[1].y = SCALE(_tvHeight + _shakeYOffset) + ORIGIN_Y;
 }
 

--- a/backends/platform/ps2/Gs2dScreen.cpp
+++ b/backends/platform/ps2/Gs2dScreen.cpp
@@ -309,7 +309,8 @@ Gs2dScreen::Gs2dScreen(uint16 width, uint16 height) {
 	_mouseScaleY = (_tvHeight << 8) / _height;
 	setMouseXy(_width / 2, _height / 2);
 	_mTraCol = 255;
-	_shakePos = 0;
+	_shakeXOffset = 0;
+	_shakeYOffset = 0;
 
 	_overlayFormat.bytesPerPixel = 2;
 
@@ -678,10 +679,10 @@ int16 Gs2dScreen::getOverlayHeight(void) {
 	return _height; // _videoMode.overlayHeight;
 }
 
-void Gs2dScreen::setShakePos(int shake) {
-	_shakePos = (shake * _mouseScaleY) >> 8;
-	_blitCoords[0].y = SCALE(_shakePos) + ORIGIN_Y;
-	_blitCoords[1].y = SCALE(_tvHeight + _shakePos) + ORIGIN_Y;
+void Gs2dScreen::setShakePos(int shakeXOffset, int shakeYOffset) {
+	_shakeYOffset = (shakeYOffset * _mouseScaleY) >> 8;
+	_blitCoords[0].y = SCALE(_shakeYOffset) + ORIGIN_Y;
+	_blitCoords[1].y = SCALE(_tvHeight + _shakeYOffset) + ORIGIN_Y;
 }
 
 void Gs2dScreen::copyPrintfOverlay(const uint8 *buf) {

--- a/backends/platform/ps2/Gs2dScreen.h
+++ b/backends/platform/ps2/Gs2dScreen.h
@@ -76,7 +76,7 @@ public:
 	void setMouseOverlay(const uint8 *buf, uint16 width, uint16 height, uint16 hotSpotX, uint16 hotSpotY, uint8 transpCol);
 	void showMouse(bool show);
 	void setMouseXy(int16 x, int16 y);
-	void setShakePos(int shake);
+	void setShakePos(int shakeXOffset, int shakeYOffset);
 
 	void playAnim(void);
 	void wantAnim(bool runIt);
@@ -123,7 +123,8 @@ private:
 	uint32 _mouseScaleX, _mouseScaleY;
 	uint8  _mTraCol;
 
-	int _shakePos;
+	int _shakeXOffset;
+	int _shakeYOffset;
 
 	bool _showMouse, _showOverlay, _screenChanged, _overlayChanged, _clutChanged;
 	uint16 *_overlayBuf;

--- a/backends/platform/ps2/systemps2.cpp
+++ b/backends/platform/ps2/systemps2.cpp
@@ -731,8 +731,8 @@ FilesystemFactory *OSystem_PS2::getFilesystemFactory() {
 	return &Ps2FilesystemFactory::instance();
 }
 
-void OSystem_PS2::setShakePos(int shakeOffset) {
-	_screen->setShakePos(shakeOffset);
+void OSystem_PS2::setShakePos(int shakeXOffset, int shakeYOffset) {
+	_screen->setShakePos(shakeXOffset, shakeYOffset);
 }
 
 bool OSystem_PS2::showMouse(bool visible) {

--- a/backends/platform/ps2/systemps2.h
+++ b/backends/platform/ps2/systemps2.h
@@ -65,7 +65,7 @@ protected:
 public:
 
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h);
-	virtual void setShakePos(int shakeOffset);
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 	virtual Graphics::Surface *lockScreen();
 	virtual void unlockScreen();
 	virtual void updateScreen();

--- a/backends/platform/psp/default_display_client.cpp
+++ b/backends/platform/psp/default_display_client.cpp
@@ -160,7 +160,7 @@ void Screen::init() {
 void Screen::setShakePos(int shakeXOffset, int shakeYOffset) {
 	_shakeXOffset = shakeXOffset;
 	_shakeYOffset = shakeYOffset;
-	_renderer.setOffsetOnScreen(0, shakeYOffset);
+	_renderer.setOffsetOnScreen(shakeXOffset, shakeYOffset);
 	setDirty();
 }
 

--- a/backends/platform/psp/default_display_client.cpp
+++ b/backends/platform/psp/default_display_client.cpp
@@ -157,9 +157,10 @@ void Screen::init() {
 	_renderer.setFullScreen(true);
 }
 
-void Screen::setShakePos(int pos) {
-	_shakePos = pos;
-	_renderer.setOffsetOnScreen(0, pos);
+void Screen::setShakePos(int shakeXOffset, int shakeYOffset) {
+	_shakeXOffset = shakeXOffset;
+	_shakeYOffset = shakeYOffset;
+	_renderer.setOffsetOnScreen(0, shakeYOffset);
 	setDirty();
 }
 

--- a/backends/platform/psp/default_display_client.h
+++ b/backends/platform/psp/default_display_client.h
@@ -78,14 +78,14 @@ public:
  */
 class Screen : public DefaultDisplayClient {
 public:
-	Screen() : _shakePos(0) {
+	Screen() : _shakeXOffset(0), _shakeYOffset(0) {
 		memset(&_pixelFormat, 0, sizeof(_pixelFormat));
 		memset(&_frameBuffer, 0, sizeof(_frameBuffer));
 	}
 
 	void init();
 	bool allocate();
-	void setShakePos(int pos);
+	void setShakePos(int shakeXOffset, int shakeYOffset);
 	void setScummvmPixelFormat(const Graphics::PixelFormat *format);
 	const Graphics::PixelFormat &getScummvmPixelFormat() const { return _pixelFormat; }
 	Graphics::Surface *lockAndGetForEditing();
@@ -93,7 +93,8 @@ public:
 	void setSize(uint32 width, uint32 height);
 
 private:
-	uint32 _shakePos;
+	uint32 _shakeXOffset;
+	uint32 _shakeYOffset;
 	Graphics::PixelFormat _pixelFormat;
 	Graphics::Surface _frameBuffer;
 };

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -238,11 +238,11 @@ void OSystem_PSP::updateScreen() {
 	_pendingUpdate = !_displayManager.renderAll();	// if we didn't update, we have a pending update
 }
 
-void OSystem_PSP::setShakePos(int shakeOffset) {
+void OSystem_PSP::setShakePos(int shakeXOffset, int shakeYOffset) {
 	DEBUG_ENTER_FUNC();
 	_displayManager.waitUntilRenderFinished();
 	_pendingUpdate = false;
-	_screen.setShakePos(shakeOffset);
+	_screen.setShakePos(shakeXOffset, shakeYOffset);
 }
 
 void OSystem_PSP::showOverlay() {

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -103,7 +103,7 @@ public:
 	Graphics::Surface *lockScreen();
 	void unlockScreen();
 	void updateScreen();
-	void setShakePos(int shakeOffset);
+	void setShakePos(int shakeXOffset, int shakeYOffset);
 
 	// Overlay related
 	void showOverlay();

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -173,7 +173,7 @@ public:
 	virtual void updateScreen();
 	virtual Graphics::Surface *lockScreen();
 	virtual void unlockScreen();
-	virtual void setShakePos(int shakeOffset);
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 
 	virtual void showOverlay();
 	virtual void hideOverlay();

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -544,9 +544,9 @@ void OSystem_Wii::unlockScreen() {
 	_gameDirty = true;
 }
 
-void OSystem_Wii::setShakePos(int shakeOffset) {
+void OSystem_Wii::setShakePos(int shakeXOffset, int shakeYOffset) {
 	gfx_coords(&_coordsGame, &_texGame, GFX_COORD_FULLSCREEN);
-	_coordsGame.y -= f32(shakeOffset) * _currentYScale;
+	_coordsGame.y -= f32(shakeYOffset) * _currentYScale;
 }
 
 void OSystem_Wii::showOverlay() {

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -546,6 +546,7 @@ void OSystem_Wii::unlockScreen() {
 
 void OSystem_Wii::setShakePos(int shakeXOffset, int shakeYOffset) {
 	gfx_coords(&_coordsGame, &_texGame, GFX_COORD_FULLSCREEN);
+	_coordsGame.x -= f32(shakeXOffset) * _currentXScale;
 	_coordsGame.y -= f32(shakeYOffset) * _currentYScale;
 }
 

--- a/common/system.h
+++ b/common/system.h
@@ -922,11 +922,13 @@ public:
 	 * not cause any graphic data to be lost - that is, to restore the original
 	 * view, the game engine only has to call this method again with offset
 	 * equal to zero. No calls to copyRectToScreen are necessary.
-	 * @param shakeOffset	the shake offset
+	 * @param shakeXOffset	the shake x offset
+	 * @param shakeYOffset	the shake y offset
 	 *
-	 * @note This is currently used in the SCUMM, QUEEN and KYRA engines.
+	 * @note This is currently used in the SCUMM, QUEEN, KYRA, SCI, DREAMWEB,
+	 * SUPERNOVA, TEENAGENT, and TOLTECS engines.
 	 */
-	virtual void setShakePos(int shakeOffset) = 0;
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset) = 0;
 
 	/**
 	 * Sets the area of the screen that has the focus.  For example, when a character

--- a/engines/dreamweb/dreamweb.h
+++ b/engines/dreamweb/dreamweb.h
@@ -138,7 +138,7 @@ public:
 
 	Common::String getSavegameFilename(int slot) const;
 
-	void setShakePos(int pos) { _system->setShakePos(pos); }
+	void setShakePos(int pos) { _system->setShakePos(0, pos); }
 	void printUnderMonitor();
 
 	void quit();

--- a/engines/kyra/graphics/screen.cpp
+++ b/engines/kyra/graphics/screen.cpp
@@ -3223,9 +3223,9 @@ void Screen::shakeScreen(int times) {
 	while (times--) {
 		// seems to be 1 line (320 pixels) offset in the original
 		// 4 looks more like dosbox though, maybe check this again
-		_system->setShakePos(4);
+		_system->setShakePos(0, 4);
 		_system->updateScreen();
-		_system->setShakePos(0);
+		_system->setShakePos(0, 0);
 		_system->updateScreen();
 	}
 }

--- a/engines/queen/display.cpp
+++ b/engines/queen/display.cpp
@@ -1082,7 +1082,7 @@ void Display::drawBox(int16 x1, int16 y1, int16 x2, int16 y2, uint8 col) {
 }
 
 void Display::shake(bool reset) {
-	_system->setShakePos(reset ? 0 : 3);
+	_system->setShakePos(0, reset ? 0 : 3);
 }
 
 void Display::blankScreen() {

--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -1201,14 +1201,14 @@ void GfxFrameout::shakeScreen(int16 numShakes, const ShakeDirection direction) {
 		}
 
 		if (direction & kShakeVertical) {
-			g_system->setShakePos(_isHiRes ? 8 : 4);
+			g_system->setShakePos(0, _isHiRes ? 8 : 4);
 		}
 
 		updateScreen();
 		g_sci->getEngineState()->sleep(3);
 
 		if (direction & kShakeVertical) {
-			g_system->setShakePos(0);
+			g_system->setShakePos(0, 0);
 		}
 
 		updateScreen();

--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -1189,27 +1189,27 @@ void GfxFrameout::throttle() {
 }
 
 void GfxFrameout::shakeScreen(int16 numShakes, const ShakeDirection direction) {
-	if (direction & kShakeHorizontal) {
-		// Used by QFG4 room 750
-		warning("TODO: Horizontal shake not implemented");
-		return;
-	}
-
 	while (numShakes--) {
 		if (g_engine->shouldQuit()) {
 			break;
 		}
 
-		if (direction & kShakeVertical) {
-			g_system->setShakePos(0, _isHiRes ? 8 : 4);
+		int shakeXOffset = 0;
+		if (direction & kShakeHorizontal) {
+			shakeXOffset = _isHiRes ? 8 : 4;
 		}
+
+		int shakeYOffset = 0;
+		if (direction & kShakeVertical) {
+			shakeYOffset = _isHiRes ? 8 : 4;
+		}
+
+		g_system->setShakePos(shakeXOffset, shakeYOffset);
 
 		updateScreen();
 		g_sci->getEngineState()->sleep(3);
 
-		if (direction & kShakeVertical) {
-			g_system->setShakePos(0, 0);
-		}
+		g_system->setShakePos(0, 0);
 
 		updateScreen();
 		g_sci->getEngineState()->sleep(3);

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -604,14 +604,23 @@ void GfxScreen::setShakePos(uint16 shakeXOffset, uint16 shakeYOffset) {
 
 void GfxScreen::kernelShakeScreen(uint16 shakeCount, uint16 directions) {
 	while (shakeCount--) {
-		if (directions & kShakeVertical)
-			setShakePos(0, 10);
-		// TODO: horizontal shakes
+
+		uint16 shakeXOffset = 0;
+		if (directions & kShakeHorizontal) {
+			shakeXOffset = 10;
+		}
+
+		uint16 shakeYOffset = 0;
+		if (directions & kShakeVertical) {
+			shakeYOffset = 10;
+		}
+
+		setShakePos(shakeXOffset, shakeYOffset);
+
 		g_system->updateScreen();
 		g_sci->getEngineState()->sleep(3);
 
-		if (directions & kShakeVertical)
-			setShakePos(0, 0);
+		setShakePos(0, 0);
 
 		g_system->updateScreen();
 		g_sci->getEngineState()->sleep(3);

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -595,23 +595,23 @@ void GfxScreen::bitsRestoreDisplayScreen(Common::Rect rect, byte *&memoryPtr) {
 	}
 }
 
-void GfxScreen::setVerticalShakePos(uint16 shakePos) {
+void GfxScreen::setShakePos(uint16 shakeXOffset, uint16 shakeYOffset) {
 	if (!_upscaledHires)
-		g_system->setShakePos(shakePos);
+		g_system->setShakePos(shakeXOffset, shakeYOffset);
 	else
-		g_system->setShakePos(_upscaledHeightMapping[shakePos]);
+		g_system->setShakePos(_upscaledWidthMapping[shakeXOffset], _upscaledHeightMapping[shakeYOffset]);
 }
 
 void GfxScreen::kernelShakeScreen(uint16 shakeCount, uint16 directions) {
 	while (shakeCount--) {
 		if (directions & kShakeVertical)
-			setVerticalShakePos(10);
+			setShakePos(0, 10);
 		// TODO: horizontal shakes
 		g_system->updateScreen();
 		g_sci->getEngineState()->sleep(3);
 
 		if (directions & kShakeVertical)
-			setVerticalShakePos(0);
+			setShakePos(0, 0);
 
 		g_system->updateScreen();
 		g_sci->getEngineState()->sleep(3);

--- a/engines/sci/graphics/screen.h
+++ b/engines/sci/graphics/screen.h
@@ -157,7 +157,7 @@ private:
 	void bitsSaveScreen(Common::Rect rect, byte *screen, uint16 screenWidth, byte *&memoryPtr);
 	void bitsSaveDisplayScreen(Common::Rect rect, byte *&memoryPtr);
 
-	void setVerticalShakePos(uint16 shakePos);
+	void setShakePos(uint16 shakeXOffset, uint16 shakeYOffset);
 
 	/**
 	 * If this flag is true, undithering is enabled, otherwise disabled.

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -523,10 +523,10 @@ void ScummEngine::drawDirtyScreenParts() {
 	// Handle shaking
 	if (_shakeEnabled) {
 		_shakeFrame = (_shakeFrame + 1) % NUM_SHAKE_POSITIONS;
-		_system->setShakePos(shake_positions[_shakeFrame]);
+		_system->setShakePos(0, shake_positions[_shakeFrame]);
 	} else if (!_shakeEnabled &&_shakeFrame != 0) {
 		_shakeFrame = 0;
-		_system->setShakePos(0);
+		_system->setShakePos(0, 0);
 	}
 }
 
@@ -1519,7 +1519,7 @@ void ScummEngine::setShake(int mode) {
 
 	_shakeEnabled = mode != 0;
 	_shakeFrame = 0;
-	_system->setShakePos(0);
+	_system->setShakePos(0, 0);
 }
 
 #pragma mark -

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -1147,7 +1147,7 @@ void ScummEngine::saveLoadWithSerializer(Common::Serializer &s) {
 
 	// When loading, reset the ShakePos. Fixes one part of bug #7141
 	if (s.isLoading() && s.getVersion() >= VER(10))
-		_system->setShakePos(0);
+		_system->setShakePos(0, 0);
 
 	// When loading, move the mouse to the saved mouse position.
 	if (s.isLoading() && s.getVersion() >= VER(20)) {

--- a/engines/supernova/game-manager.cpp
+++ b/engines/supernova/game-manager.cpp
@@ -804,9 +804,9 @@ void GameManager::saveTime() {
 
 void GameManager::screenShake() {
 	for (int i = 0; i < 12; ++i) {
-		_vm->_system->setShakePos(8);
+		_vm->_system->setShakePos(0, 8);
 		wait(1);
-		_vm->_system->setShakePos(0);
+		_vm->_system->setShakePos(0, 0);
 		wait(1);
 	}
 }

--- a/engines/teenagent/scene.cpp
+++ b/engines/teenagent/scene.cpp
@@ -1111,19 +1111,19 @@ bool Scene::processEventQueue() {
 
 		case SceneEvent::kEffect:
 			_vm->_system->delayMillis(80); // 2 vsyncs
-			_vm->_system->setShakePos(8);
+			_vm->_system->setShakePos(0, 8);
 			_vm->_system->updateScreen();
 
 			_vm->_system->delayMillis(80); // 2 vsyncs
-			_vm->_system->setShakePos(0);
+			_vm->_system->setShakePos(0, 0);
 			_vm->_system->updateScreen();
 
 			_vm->_system->delayMillis(80); // 2 vsyncs
-			_vm->_system->setShakePos(4);
+			_vm->_system->setShakePos(0, 4);
 			_vm->_system->updateScreen();
 
 			_vm->_system->delayMillis(80); // 2 vsyncs
-			_vm->_system->setShakePos(0);
+			_vm->_system->setShakePos(0, 0);
 			_vm->_system->updateScreen();
 
 			currentEvent.clear();

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -981,10 +981,10 @@ TestExitStatus GFXtests::shakingEffect() {
 	Testsuite::writeOnScreen("If Shaking Effect works, this should shake!", pt);
 	int times = 15;
 	while (times--) {
-		g_system->setShakePos(25);
+		g_system->setShakePos(25, 25);
 		g_system->delayMillis(50);
 		g_system->updateScreen();
-		g_system->setShakePos(0);
+		g_system->setShakePos(0, 0);
 		g_system->delayMillis(50);
 		g_system->updateScreen();
 	}
@@ -1187,12 +1187,12 @@ TestExitStatus GFXtests::cursorTrails() {
 		return kTestSkipped;
 	}
 	TestExitStatus passed = kTestFailed;
-	g_system->setShakePos(25);
+	g_system->setShakePos(25, 25);
 	g_system->updateScreen();
 	if (Testsuite::handleInteractiveInput("Does the cursor leaves trails while moving?", "Yes", "No", kOptionRight)) {
 		passed = kTestPassed;
 	}
-	g_system->setShakePos(0);
+	g_system->setShakePos(0, 0);
 	g_system->updateScreen();
 	return passed;
 }

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -977,23 +977,48 @@ TestExitStatus GFXtests::shakingEffect() {
 		return kTestSkipped;
 	}
 
+	// test vertical, horizontal, and diagonal
 	Common::Point pt(0, 100);
-	Testsuite::writeOnScreen("If Shaking Effect works, this should shake!", pt);
-	int times = 15;
-	while (times--) {
-		g_system->setShakePos(25, 25);
-		g_system->delayMillis(50);
-		g_system->updateScreen();
-		g_system->setShakePos(0, 0);
-		g_system->delayMillis(50);
-		g_system->updateScreen();
-	}
-	g_system->delayMillis(1500);
+	for (int i = 0; i < 3; ++i) {
+		Common::String direction;
+		int shakeXOffset;
+		int shakeYOffset;
+		switch (i) {
+		case 0:
+			direction = "vertical";
+			shakeXOffset = 0;
+			shakeYOffset = 25;
+			break;
+		case 1:
+			direction = "horizontal";
+			shakeXOffset = 25;
+			shakeYOffset = 0;
+			break;
+		default:
+			direction = "diagonal";
+			shakeXOffset = 25;
+			shakeYOffset = 25;
+			break;
+		}
 
-	if (Testsuite::handleInteractiveInput("Did the Shaking test worked as you were expecting?", "Yes", "No", kOptionRight)) {
-		Testsuite::logDetailedPrintf("Shaking Effect didn't worked");
-		return kTestFailed;
+		Testsuite::writeOnScreen(Common::String::format("If Shaking Effect works, this should shake %s", direction.c_str()), pt);
+		int times = 15;
+		while (times--) {
+			g_system->setShakePos(shakeXOffset, shakeYOffset);
+			g_system->delayMillis(50);
+			g_system->updateScreen();
+			g_system->setShakePos(0, 0);
+			g_system->delayMillis(50);
+			g_system->updateScreen();
+		}
+		g_system->delayMillis(1500);
+
+		if (Testsuite::handleInteractiveInput("Did the Shaking test work as you were expecting?", "Yes", "No", kOptionRight)) {
+			Testsuite::logDetailedPrintf("Shaking Effect didn't work");
+			return kTestFailed;
+		}
 	}
+
 	return kTestPassed;
 }
 

--- a/engines/toltecs/screen.cpp
+++ b/engines/toltecs/screen.cpp
@@ -159,7 +159,7 @@ void Screen::startShakeScreen(int16 shakeCounter) {
 
 void Screen::stopShakeScreen() {
 	_shakeActive = false;
-	_vm->_system->setShakePos(0);
+	_vm->_system->setShakePos(0, 0);
 }
 
 bool Screen::updateShakeScreen() {
@@ -170,7 +170,7 @@ bool Screen::updateShakeScreen() {
 		if (_shakeCounter == 0) {
 			_shakeCounter = _shakeCounterInit;
 			_shakePos ^= 8;
-			_vm->_system->setShakePos(_shakePos);
+			_vm->_system->setShakePos(0, _shakePos);
 			return true;
 		}
 	}


### PR DESCRIPTION
:notes: I feel the Earth... Move... Under my feat :notes:

This PR adds horizontal screen shaking to most backends and the SCI engine. Setting both horizontal and vertical shake positions causes diagonal shaking, which SCI games gleefully employ. There's... a lot of falling.

I implemented this in all the backends except for N64. That touches the critical rendering code which is too much for me to change without being able to test. An expert can add that now that the interface is in place.

Please take a close look at the changes to the SDL code because I shouldn't be let anywhere near there.

I tested SDL2, SDL1, OpenGL and IOS7.

Sample game scenes with horizontal shaking:

- FPFP: Walking off the cliff in room 200, diagonal
- LB1: Intro room 781 when boat bumps dock, horizontal
- SQ5: Intro (horizontal), when WD40 attacks ship (diagonal), really every blast
- ECO1: Solving the column puzzle in room 160 (horizontal)
- QFG1VGA: Trying to force open the Brigand's gate in room 93, horizontal
- KQ6: Fall off the cliffs in room 320, horizontal
- SQ3: Walk into the walls in room 90, horizontal
- CAMELOT: Get hit during jousting in room 110, horizontal
- The testbed engine now shakes diagonally

In the process I noticed some minor shake regressions that occurred between versions 2.0 and 2.1. The shake offset set by the engines is no longer scaled in SDL2 when shifting the image. Since it's not scaled, the shake effect is smaller the higher the window resolution. Another symptom is that the cursor shakes differently from the screen, or not at all, depending on where it's placed.