### PR TITLE
Setting revision define is applied to all sources, not just version.cpp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
 dist: trusty
 
 script:
-  - ./configure --enable-all-engines --enable-opl2lpt
+  - ./configure --enable-all-engines --enable-opl2lpt --enable-verbose-build
   - make -j 2
   - make test
   - make devtools


### PR DESCRIPTION
https://github.com/scummvm/scummvm/blob/79d636ba8a34a3dd5942cd61933940bbc4c87541/Makefile.common#L214-L218
This line should apply the revision define to just version.cpp, but as you will see in the logs produced, it is done to all the sources instead.