### PR TITLE
Add ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,11 +71,14 @@ matrix:
 dist: xenial
 
 script:
+  - ccache --show-stats > /tmp/ccache_before
   - export PATH="/usr/local/opt/ccache/libexec:/usr/lib/ccache:$PATH"
   - ./configure --enable-all-engines --enable-opl2lpt
   - make -j 2
   - make test
   - make devtools
+  - ccache --show-stats > /tmp/ccache_after
+  - diff -U999 /tmp/ccache_before /tmp/ccache_after || true
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
       before_cache:
         - brew cleanup
 
-dist: trusty
+dist: xenial
 
 script:
   - ./configure --enable-all-engines --enable-opl2lpt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   apt:
     packages:
     - g++ make
+    - ccache
     - libsdl2-dev
     - libsdl2-net-dev
     - libcurl4-openssl-dev
@@ -27,6 +28,7 @@ addons:
     - libunity-dev
   homebrew:
     packages:
+    - ccache
     - sdl2
     - sdl2_net
     - curl
@@ -47,16 +49,17 @@ addons:
     - jack
     update: true
 
-branches:
- only:
-   - master
-
 matrix:
   include:
     - os: linux
       compiler: gcc
+      cache: ccache
     - os: linux
       compiler: clang
+      cache: ccache
+      before_script:
+        - sudo ln -s $(which ccache) /usr/lib/ccache/clang
+        - sudo ln -s $(which ccache) /usr/lib/ccache/clang++
     - os: osx
       compiler: clang
       cache:
@@ -68,6 +71,7 @@ matrix:
 dist: xenial
 
 script:
+  - export PATH="/usr/local/opt/ccache/libexec:/usr/lib/ccache:$PATH"
   - ./configure --enable-all-engines --enable-opl2lpt
   - make -j 2
   - make test


### PR DESCRIPTION
This enables ccache on all the Travis jobs.

Note that Trusty ships with ccache 3.1.9, which is not sufficient due to https://bugzilla.samba.org/show_bug.cgi?id=10005. I took that opportunity to update the Travis CI job to use a supported distro, that also ships with updated ccache.

Addressing https://github.com/scummvm/scummvm/pull/1946 will improve direct hit rates.