### PR TITLE
COMMON: Add CJK encodings to Common::CodePage

### DIFF
--- a/common/str-enc.h
+++ b/common/str-enc.h
@@ -29,14 +29,18 @@ class String;
 class U32String;
 
 enum CodePage {
-	kUtf8,
+	kCodePageInvalid = -1,
+	kUtf8 = 0,
 	kWindows1250,
 	kWindows1251,
 	kWindows1252,
 	kWindows1253,
 	kWindows1254,
 	kWindows1255,
-	kWindows1257
+	kWindows1257,
+	kWindows932,
+	kWindows949,
+	kWindows950
 };
 
 U32String convertUtf8ToUtf32(const String &str);


### PR DESCRIPTION
It uses Encoding::convert to do the conversion first and try old method if it fails.
This also adds an invalid encoding which can be used when encoding is unknown (yet).
In this case encode and decode fail.