### PR TITLE
BUILD: Fix Version Define Being Added to All Code Objects

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -56,15 +56,6 @@ CPPFLAGS := $(DEFINES) $(INCLUDES)
 DEPDIRS = $(addsuffix $(DEPDIR),$(MODULE_DIRS))
 DEPFILES =
 
-# Make base/version.o depend on all other object files. This way if anything is
-# changed, it causes version.cpp to be recompiled. This in turn ensures that
-# the build date in gScummVMBuildDate is correct.
-base/version.o: $(filter-out base/libbase.a,$(OBJS))
-
-ifdef USE_ELF_LOADER
-backends/plugins/elf/version.o: $(filter-out base/libbase.a,$(filter-out backends/libbackends.a,$(OBJS)))
-endif
-
 # Replace regular output with quiet messages
 ifneq ($(findstring $(MAKEFLAGS),s),s)
 ifneq ($(VERBOSE_BUILD),1)
@@ -215,6 +206,11 @@ endif
 # specified by the user, but only for base/version.cpp.
 ifneq ($(origin VER_REV), undefined)
 base/version.o: CXXFLAGS:=$(CXXFLAGS) -DSCUMMVM_REVISION=\"$(VER_REV)\"
+base/version.o: .FORCE
+endif
+
+ifdef USE_ELF_LOADER
+backends/plugins/elf/version.o: .FORCE
 endif
 
 ######################################################################
@@ -378,3 +374,5 @@ DIST_FILES_ENGINEDATA+=$(srcdir)/dists/pred.dic
 endif
 
 .PHONY: all clean distclean plugins dist-src
+
+.FORCE:


### PR DESCRIPTION
Due to a quirk of target specific make variables which means they are
added to all pre-requisities, this resulted in the defines which were
meant to be applied only to the version module being applied to most
of the codebase.

This did not cause any direct issues, but was untidy and unexpected
behaviour which was reported in Pull Request 1946 by janisozaur.

Various fixes were tried, but this fix is from bgK and removes the
pre-requisities of the version object and instead builds it in all
cases using .FORCE.

However, this does cause a rebuild of the executable in all cases,
even if no source code change has occurred which is not perfect.

Better suggestions for a fix for these issues would be welcome.


Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
