### PR TITLE
BUILD: Fix Version Define Being Added to All Code Objects

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -136,6 +136,10 @@ ifdef CXX_UPDATE_DEP_FLAG
 	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
 	$(QUIET_AS)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(ASFLAGS) -c $(<) -o $*.o
 
+base/version.o: base/version.cpp
+	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
+	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CXXFLAGS) $(VERFLAGS) $(CPPFLAGS) -c $(<) -o $*.o
+
 else
 
 # Dumb compile rule, for C++ compilers that don't allow dependency tracking or
@@ -149,6 +153,9 @@ else
 	$(QUIET)$(MKDIR) $(*D)
 	$(QUIET_AS)$(CXX) $(ASFLAGS) -c $(<) -o $*.o
 
+base/version.o: base/version.cpp
+	$(QUIET)$(MKDIR) $(*D)
+	$(QUIET_CXX)$(CXX) $(CXXFLAGS) $(VERFLAGS) $(CPPFLAGS) -c $(<) -o $*.o
 endif
 
 # Build rule for assembler files
@@ -192,7 +199,7 @@ VER_EXTRA = $(shell echo $(VERSION) | cut -d. -f 3 | cut -c2-)
 ifdef AMIGAOS
 # Amiga needs date in specific format for the version cookie
 AMIGA_DATE = $(shell gdate '+%d.%m.%Y')
-base/version.o: CXXFLAGS:=$(CXXFLAGS) -DAMIGA_DATE=\"$(AMIGA_DATE)\"
+VERFLAGS += -DAMIGA_DATE=\"$(AMIGA_DATE)\"
 endif
 
 ######################################################################
@@ -214,7 +221,7 @@ endif
 # Define the Subversion revision if available, either autodetected or
 # specified by the user, but only for base/version.cpp.
 ifneq ($(origin VER_REV), undefined)
-base/version.o: CXXFLAGS:=$(CXXFLAGS) -DSCUMMVM_REVISION=\"$(VER_REV)\"
+VERFLAGS += -DSCUMMVM_REVISION=\"$(VER_REV)\"
 endif
 
 ######################################################################


### PR DESCRIPTION
Due to a quirk of target specific make variables which means they
are added to all pre-requisities, this resulted in the defines which
were meant to be applied only to the version module being applied to
most of the codebase.

This did not cause any direct issues, but was untidy and unexpected
behaviour which was reported in Pull Request 1946 by janisozaur.

Fix it by defining a special rule for version.o with own flags
instead of using template rule.

Signed-off-by: Yauheni Kaliuta <yauheni.kaliuta@redhat.com>


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
