### PR TITLE
PSP: Make the PspTimer class a subclass of DefaultTimerManager

### DIFF
--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -39,7 +39,7 @@
 #include "backends/platform/psp/rtc.h"
 
 #include "backends/saves/default/default-saves.h"
-#include "backends/timer/default/default-timer.h"
+#include "backends/timer/psp/timer.h"
 #include "graphics/surface.h"
 #include "audio/mixer_intern.h"
 
@@ -49,12 +49,6 @@
 #include "backends/platform/psp/trace.h"
 
 #define	SAMPLES_PER_SEC	44100
-
-static int timer_handler(int t) {
-	DefaultTimerManager *tm = (DefaultTimerManager *)g_system->getTimerManager();
-	tm->handler();
-	return t;
-}
 
 OSystem_PSP::~OSystem_PSP() {}
 
@@ -97,12 +91,10 @@ void OSystem_PSP::initBackend() {
 
 	_savefileManager = new DefaultSaveFileManager(PSP_DEFAULT_SAVE_PATH);
 
-	_timerManager = new DefaultTimerManager();
+	_timerManager = new PspTimerManager();
 
 	PSP_DEBUG_PRINT("calling keyboard.load()\n");
 	_keyboard.load();	// Load virtual keyboard files into memory
-
-	setTimerCallback(&timer_handler, 10);
 
 	setupMixer();
 
@@ -356,12 +348,6 @@ uint32 OSystem_PSP::getMillis(bool skipRecord) {
 
 void OSystem_PSP::delayMillis(uint msecs) {
 	PspThread::delayMillis(msecs);
-}
-
-void OSystem_PSP::setTimerCallback(TimerProc callback, int interval) {
-	_pspTimer.setCallback((PspTimer::CallbackFunc)callback);
-	_pspTimer.setIntervalMs(interval);
-	_pspTimer.start();
 }
 
 OSystem::MutexRef OSystem_PSP::createMutex(void) {

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -39,7 +39,6 @@
 #include "backends/platform/psp/display_manager.h"
 #include "backends/platform/psp/input.h"
 #include "backends/platform/psp/audio.h"
-#include "backends/timer/psp/timer.h"
 #include "backends/platform/psp/thread.h"
 
 class OSystem_PSP : public EventsBaseBackend, public PaletteManager {
@@ -57,7 +56,6 @@ private:
 	PSPKeyboard _keyboard;
 	InputHandler _inputHandler;
 	PspAudio _audio;
-	PspTimer _pspTimer;
 	ImageViewer _imageViewer;
 
 public:
@@ -126,10 +124,6 @@ public:
 	// Time
 	uint32 getMillis(bool skipRecord = false);
 	void delayMillis(uint msecs);
-
-	// Timer
-	typedef int (*TimerProc)(int interval);
-	void setTimerCallback(TimerProc callback, int interval);
 
 	// Mutex
 	MutexRef createMutex(void);

--- a/backends/timer/psp/timer.h
+++ b/backends/timer/psp/timer.h
@@ -23,19 +23,16 @@
 #ifndef PSP_TIMER_H
 #define PSP_TIMER_H
 
-class PspTimer {
+#include "backends/timer/default/default-timer.h"
+
+class PspTimerManager : public DefaultTimerManager {
 public:
-	typedef void (* CallbackFunc)(void);
-	PspTimer() : _callback(0), _interval(0), _threadId(-1), _init(false) {}
-	void stop() { _init = false; }
-	bool start();
-	~PspTimer() { stop(); }
-	void setCallback(CallbackFunc cb) { _callback = cb; }
-	void setIntervalMs(uint32 interval) { _interval = interval * 1000; }
+	PspTimerManager(uint32 interval = 10);
+	~PspTimerManager() { _init = false; }
+
 	static int thread(SceSize, void *__this);		// static thread to use as bridge
 	void timerThread();
 private:
-	CallbackFunc _callback;	// pointer to timer callback
 	uint32 _interval;
 	int _threadId;
 	bool _init;


### PR DESCRIPTION
This has been briefly tested using PPSSPP, but has not been tested on real hardware.