### PR TITLE
BACKENDS: Refactor mixer manager classes

### DIFF
--- a/backends/base-backend.cpp
+++ b/backends/base-backend.cpp
@@ -40,12 +40,6 @@ void BaseBackend::displayMessageOnOSD(const char *msg) {
 }
 
 void BaseBackend::initBackend() {
-	// Init Event manager
-#ifndef DISABLE_DEFAULT_EVENT_MANAGER
-	if (!_eventManager)
-		_eventManager = new DefaultEventManager(getDefaultEventSource());
-#endif
-
 	// Init audio CD manager
 #ifndef DISABLE_DEFAULT_AUDIOCD_MANAGER
 	if (!_audiocdManager)
@@ -60,4 +54,14 @@ void BaseBackend::fillScreen(uint32 col) {
 	if (screen)
 		screen->fillRect(Common::Rect(screen->w, screen->h), col);
 	unlockScreen();
+}
+
+void EventsBaseBackend::initBackend() {
+	// Init Event manager
+#ifndef DISABLE_DEFAULT_EVENT_MANAGER
+	if (!_eventManager)
+		_eventManager = new DefaultEventManager(this);
+#endif
+
+	BaseBackend::initBackend();
 }

--- a/backends/base-backend.h
+++ b/backends/base-backend.h
@@ -27,8 +27,6 @@
 #include "common/events.h"
 
 class BaseBackend : public OSystem {
-protected:
-	virtual Common::EventSource *getDefaultEventSource() = 0;
 public:
 	virtual void initBackend();
 
@@ -37,10 +35,9 @@ public:
 	virtual void fillScreen(uint32 col);
 };
 
-class EventsBaseBackend : public BaseBackend, Common::EventSource {
-protected:
-	virtual Common::EventSource *getDefaultEventSource() { return this; }
+class EventsBaseBackend : virtual public BaseBackend, Common::EventSource {
 public:
+	virtual void initBackend();
 };
 
 

--- a/backends/events/maemosdl/maemosdl-events.cpp
+++ b/backends/events/maemosdl/maemosdl-events.cpp
@@ -51,9 +51,6 @@ static const KeymapEntry keymapEntries[] = {
 
 bool MaemoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 
-	Model model = Model(((OSystem_SDL_Maemo *)g_system)->getModel());
-	debug(10, "Model: %s %u %s %s", model.hwId, model.modelType, model.hwAlias, model.hasHwKeyboard ? "true" : "false");
-
 	// List of special N810 keys:
 	// SDLK_F4 -> menu
 	// SDLK_F5 -> home

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -426,7 +426,7 @@ bool SdlEventSource::pollEvent(Common::Event &event) {
 #endif
 
 	// If the screen changed, send an Common::EVENT_SCREEN_CHANGED
-	int screenID = ((OSystem_SDL *)g_system)->getGraphicsManager()->getScreenChangeID();
+	int screenID = g_system->getScreenChangeID();
 	if (screenID != _lastScreenID) {
 		_lastScreenID = screenID;
 		event.type = Common::EVENT_SCREEN_CHANGED;
@@ -963,7 +963,7 @@ bool SdlEventSource::handleResizeEvent(Common::Event &event, int w, int h) {
 		_graphicsManager->notifyResize(w, h);
 
 		// If the screen changed, send an Common::EVENT_SCREEN_CHANGED
-		int screenID = ((OSystem_SDL *)g_system)->getGraphicsManager()->getScreenChangeID();
+		int screenID = g_system->getScreenChangeID();
 		if (screenID != _lastScreenID) {
 			_lastScreenID = screenID;
 			event.type = Common::EVENT_SCREEN_CHANGED;

--- a/backends/fs/symbian/symbian-fs.cpp
+++ b/backends/fs/symbian/symbian-fs.cpp
@@ -71,7 +71,7 @@ SymbianFilesystemNode::SymbianFilesystemNode(const Common::String &path) {
 	TPtrC8 ptr((const unsigned char*)_path.c_str(),_path.size());
 	fname.Copy(ptr);
 
-	if (static_cast<OSystem_SDL_Symbian *>(g_system)->FsSession().Entry(fname, fileAttribs) == KErrNone) {
+	if (dynamic_cast<OSystem_SDL_Symbian *>(g_system)->FsSession().Entry(fname, fileAttribs) == KErrNone) {
 		_isValid = true;
 		_isDirectory = fileAttribs.IsDir();
 	} else {
@@ -88,7 +88,7 @@ bool SymbianFilesystemNode::exists() const {
 	TFileName fname;
 	TPtrC8 ptr((const unsigned char*) _path.c_str(), _path.size());
 	fname.Copy(ptr);
-	bool fileExists = BaflUtils::FileExists(static_cast<OSystem_SDL_Symbian *> (g_system)->FsSession(), fname);
+	bool fileExists = BaflUtils::FileExists(dynamic_cast<OSystem_SDL_Symbian *> (g_system)->FsSession(), fname);
 	if (!fileExists) {
 		TParsePtrC parser(fname);
 		if (parser.PathPresent() && parser.Path().Compare(_L("\\")) == KErrNone && !parser.NameOrExtPresent()) {

--- a/backends/fs/symbian/symbianstream.cpp
+++ b/backends/fs/symbian/symbianstream.cpp
@@ -70,22 +70,22 @@ TSymbianFileEntry*	CreateSymbianFileEntry(const char* name, const char* mode) {
 
 		switch (mode[0]) {
 		case 'a':
-			if (fileEntry->_fileHandle.Open(static_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), tempFileName, fileMode) != KErrNone) {
-				if (fileEntry->_fileHandle.Create(static_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), tempFileName, fileMode) != KErrNone) {
+			if (fileEntry->_fileHandle.Open(dynamic_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), tempFileName, fileMode) != KErrNone) {
+				if (fileEntry->_fileHandle.Create(dynamic_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), tempFileName, fileMode) != KErrNone) {
 					delete fileEntry;
 					fileEntry = NULL;
 				}
 			}
 			break;
 		case 'r':
-			if (fileEntry->_fileHandle.Open(static_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), tempFileName, fileMode) != KErrNone) {
+			if (fileEntry->_fileHandle.Open(dynamic_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), tempFileName, fileMode) != KErrNone) {
 				delete fileEntry;
 				fileEntry = NULL;
 			}
 			break;
 
 		case 'w':
-			if (fileEntry->_fileHandle.Replace(static_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), tempFileName, fileMode) != KErrNone) {
+			if (fileEntry->_fileHandle.Replace(dynamic_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), tempFileName, fileMode) != KErrNone) {
 				delete fileEntry;
 				fileEntry = NULL;
 			}

--- a/backends/mixer/mixer.h
+++ b/backends/mixer/mixer.h
@@ -1,0 +1,67 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKENDS_MIXER_ABSTRACT_H
+#define BACKENDS_MIXER_ABSTRACT_H
+
+#include "audio/mixer_intern.h"
+
+/**
+ * Abstract class for mixer manager. Subclasses
+ * implement the real functionality.
+ */
+class MixerManager {
+public:
+	MixerManager() : _mixer(0), _audioSuspended(false) {}
+	virtual ~MixerManager() { delete _mixer; }
+
+	/**
+	 * Initialize and setups the mixer
+	 */
+	virtual void init() = 0;
+
+	/**
+	 * Get the audio mixer implementation
+	 */
+	Audio::Mixer *getMixer() { return (Audio::Mixer *)_mixer; }
+
+	// Used by LinuxMoto Port
+
+	/**
+	 * Pauses the audio system
+	 */
+	virtual void suspendAudio() = 0;
+
+	/**
+	 * Resumes the audio system
+	 */
+	virtual int resumeAudio() = 0;
+
+protected:
+	/** The mixer implementation */
+	Audio::MixerImpl *_mixer;
+
+	/** State of the audio system */
+	bool _audioSuspended;
+};
+
+#endif

--- a/backends/mixer/null/null-mixer.cpp
+++ b/backends/mixer/null/null-mixer.cpp
@@ -26,7 +26,6 @@
 NullMixerManager::NullMixerManager() : MixerManager() {
 	_outputRate = 22050;
 	_callsCounter = 0;
-	_callbackPeriod = 10;
 	_samples = 8192;
 	while (_samples * 16 > _outputRate * 2)
 		_samples >>= 1;
@@ -55,12 +54,12 @@ int NullMixerManager::resumeAudio() {
 	return 0;
 }
 
-void NullMixerManager::update() {
+void NullMixerManager::update(uint8 callbackPeriod) {
 	if (_audioSuspended) {
 		return;
 	}
 	_callsCounter++;
-	if ((_callsCounter % _callbackPeriod) == 0) {
+	if ((_callsCounter % callbackPeriod) == 0) {
 		assert(_mixer);
 		_mixer->mixCallback(_samplesBuf, _samples);
 	}

--- a/backends/mixer/null/null-mixer.cpp
+++ b/backends/mixer/null/null-mixer.cpp
@@ -20,10 +20,10 @@
  *
  */
 
-#include "backends/mixer/nullmixer/nullsdl-mixer.h"
+#include "backends/mixer/null/null-mixer.h"
 #include "common/savefile.h"
 
-NullSdlMixerManager::NullSdlMixerManager() : SdlMixerManager() {
+NullMixerManager::NullMixerManager() : MixerManager() {
 	_outputRate = 22050;
 	_callsCounter = 0;
 	_callbackPeriod = 10;
@@ -33,21 +33,21 @@ NullSdlMixerManager::NullSdlMixerManager() : SdlMixerManager() {
 	_samplesBuf = new uint8[_samples * 4];
 }
 
-NullSdlMixerManager::~NullSdlMixerManager() {
+NullMixerManager::~NullMixerManager() {
 	delete _samplesBuf;
 }
 
-void NullSdlMixerManager::init() {
+void NullMixerManager::init() {
 	_mixer = new Audio::MixerImpl(_outputRate);
 	assert(_mixer);
 	_mixer->setReady(true);
 }
 
-void NullSdlMixerManager::suspendAudio() {
+void NullMixerManager::suspendAudio() {
 	_audioSuspended = true;
 }
 
-int NullSdlMixerManager::resumeAudio() {
+int NullMixerManager::resumeAudio() {
 	if (!_audioSuspended) {
 		return -2;
 	}
@@ -55,21 +55,13 @@ int NullSdlMixerManager::resumeAudio() {
 	return 0;
 }
 
-
-void NullSdlMixerManager::startAudio() {
-}
-
-void NullSdlMixerManager::callbackHandler(byte *samples, int len) {
-	assert(_mixer);
-	_mixer->mixCallback(samples, len);
-}
-
-void NullSdlMixerManager::update() {
+void NullMixerManager::update() {
 	if (_audioSuspended) {
 		return;
 	}
 	_callsCounter++;
 	if ((_callsCounter % _callbackPeriod) == 0) {
-		callbackHandler(_samplesBuf, _samples);
+		assert(_mixer);
+		_mixer->mixCallback(_samplesBuf, _samples);
 	}
 }

--- a/backends/mixer/null/null-mixer.h
+++ b/backends/mixer/null/null-mixer.h
@@ -20,11 +20,10 @@
  *
  */
 
-#ifndef BACKENDS_MIXER_NULLSDL_H
-#define BACKENDS_MIXER_NULLSDL_H
+#ifndef BACKENDS_MIXER_NULL_H
+#define BACKENDS_MIXER_NULL_H
 
-#include "backends/mixer/sdl/sdl-mixer.h"
-#include "common/str.h"
+#include "backends/mixer/mixer.h"
 
 /** Audio mixer which in fact does not output audio.
  *
@@ -35,21 +34,16 @@
  *  users could work without modifications.
  */
 
-class NullSdlMixerManager :	public SdlMixerManager {
+class NullMixerManager : public MixerManager {
 public:
-	NullSdlMixerManager();
-	virtual ~NullSdlMixerManager();
+	NullMixerManager();
+	virtual ~NullMixerManager();
 
 	virtual void init();
 	void update();
 
 	virtual void suspendAudio();
 	virtual int resumeAudio();
-
-protected:
-
-	virtual void startAudio();
-	virtual void callbackHandler(byte *samples, int len);
 
 private:
 	uint32 _outputRate;

--- a/backends/mixer/null/null-mixer.h
+++ b/backends/mixer/null/null-mixer.h
@@ -40,7 +40,7 @@ public:
 	virtual ~NullMixerManager();
 
 	virtual void init();
-	void update();
+	void update(uint8 callbackPeriod = 10);
 
 	virtual void suspendAudio();
 	virtual int resumeAudio();
@@ -48,7 +48,6 @@ public:
 private:
 	uint32 _outputRate;
 	uint32 _callsCounter;
-	uint8  _callbackPeriod;
 	uint32 _samples;
 	uint8 *_samplesBuf;
 };

--- a/backends/mixer/sdl/sdl-mixer.cpp
+++ b/backends/mixer/sdl/sdl-mixer.cpp
@@ -38,21 +38,12 @@
 #define SAMPLES_PER_SEC 44100
 #endif
 
-SdlMixerManager::SdlMixerManager()
-	:
-	_mixer(0),
-	_audioSuspended(false) {
-
-}
-
 SdlMixerManager::~SdlMixerManager() {
 	_mixer->setReady(false);
 
 	SDL_CloseAudio();
 
 	SDL_QuitSubSystem(SDL_INIT_AUDIO);
-
-	delete _mixer;
 }
 
 void SdlMixerManager::init() {

--- a/backends/mixer/sdl/sdl-mixer.h
+++ b/backends/mixer/sdl/sdl-mixer.h
@@ -24,7 +24,7 @@
 #define BACKENDS_MIXER_SDL_H
 
 #include "backends/platform/sdl/sdl-sys.h"
-#include "audio/mixer_intern.h"
+#include "backends/mixer/mixer.h"
 
 /**
  * SDL mixer manager. It wraps the actual implementation
@@ -32,20 +32,14 @@
  * the SDL audio subsystem and the callback for the
  * audio mixer implementation.
  */
-class SdlMixerManager {
+class SdlMixerManager : public MixerManager {
 public:
-	SdlMixerManager();
 	virtual ~SdlMixerManager();
 
 	/**
 	 * Initialize and setups the mixer
 	 */
 	virtual void init();
-
-	/**
-	 * Get the audio mixer implementation
-	 */
-	Audio::Mixer *getMixer() { return (Audio::Mixer *)_mixer; }
 
 	// Used by Event recorder
 
@@ -60,17 +54,11 @@ public:
 	virtual int resumeAudio();
 
 protected:
-	/** The mixer implementation */
-	Audio::MixerImpl *_mixer;
-
 	/**
 	 * The obtained audio specification after opening the
 	 * audio system.
 	 */
 	SDL_AudioSpec _obtained;
-
-	/** State of the audio system */
-	bool _audioSuspended;
 
 	/**
 	 * Returns the desired audio specification

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -22,7 +22,9 @@
 
 #include "backends/modular-backend.h"
 
+#include "backends/audiocd/audiocd.h"
 #include "backends/graphics/graphics.h"
+#include "backends/mixer/mixer.h"
 #include "backends/mutex/mutex.h"
 #include "gui/EventRecorder.h"
 
@@ -247,6 +249,31 @@ void ModularGraphicsBackend::displayMessageOnOSD(const char *msg) {
 
 void ModularGraphicsBackend::displayActivityIconOnOSD(const Graphics::Surface *icon) {
 	_graphicsManager->displayActivityIconOnOSD(icon);
+}
+
+
+ModularMixerBackend::ModularMixerBackend()
+	:
+	_mixerManager(0) {
+
+}
+
+ModularMixerBackend::~ModularMixerBackend() {
+	// _audiocdManager needs to be deleted before _mixerManager to avoid a crash.
+	delete _audiocdManager;
+	_audiocdManager = 0;
+	delete _mixerManager;
+	_mixerManager = 0;
+}
+
+MixerManager *ModularMixerBackend::getMixerManager() {
+	assert(_mixerManager);
+	return _mixerManager;
+}
+
+Audio::Mixer *ModularMixerBackend::getMixer() {
+	assert(_mixerManager);
+	return getMixerManager()->getMixer();
 }
 
 

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -26,23 +26,19 @@
 #include "backends/mutex/mutex.h"
 #include "gui/EventRecorder.h"
 
-#include "audio/mixer.h"
 #include "common/timer.h"
 #include "graphics/pixelformat.h"
 
 ModularBackend::ModularBackend()
 	:
 	_mutexManager(0),
-	_graphicsManager(0),
-	_mixer(0) {
+	_graphicsManager(0) {
 
 }
 
 ModularBackend::~ModularBackend() {
 	delete _graphicsManager;
 	_graphicsManager = 0;
-	delete _mixer;
-	_mixer = 0;
 	// _timerManager needs to be deleted before _mutexManager to avoid a crash.
 	delete _timerManager;
 	_timerManager = 0;
@@ -269,11 +265,6 @@ void ModularBackend::unlockMutex(MutexRef mutex) {
 void ModularBackend::deleteMutex(MutexRef mutex) {
 	assert(_mutexManager);
 	_mutexManager->deleteMutex(mutex);
-}
-
-Audio::Mixer *ModularBackend::getMixer() {
-	assert(_mixer);
-	return (Audio::Mixer *)_mixer;
 }
 
 void ModularBackend::displayMessageOnOSD(const char *msg) {

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -29,153 +29,147 @@
 #include "common/timer.h"
 #include "graphics/pixelformat.h"
 
-ModularBackend::ModularBackend()
+ModularGraphicsBackend::ModularGraphicsBackend()
 	:
-	_mutexManager(0),
 	_graphicsManager(0) {
 
 }
 
-ModularBackend::~ModularBackend() {
+ModularGraphicsBackend::~ModularGraphicsBackend() {
 	delete _graphicsManager;
 	_graphicsManager = 0;
-	// _timerManager needs to be deleted before _mutexManager to avoid a crash.
-	delete _timerManager;
-	_timerManager = 0;
-	delete _mutexManager;
-	_mutexManager = 0;
 }
 
-bool ModularBackend::hasFeature(Feature f) {
+bool ModularGraphicsBackend::hasFeature(Feature f) {
 	return _graphicsManager->hasFeature(f);
 }
 
-void ModularBackend::setFeatureState(Feature f, bool enable) {
+void ModularGraphicsBackend::setFeatureState(Feature f, bool enable) {
 	_graphicsManager->setFeatureState(f, enable);
 }
 
-bool ModularBackend::getFeatureState(Feature f) {
+bool ModularGraphicsBackend::getFeatureState(Feature f) {
 	return _graphicsManager->getFeatureState(f);
 }
 
-GraphicsManager *ModularBackend::getGraphicsManager() {
+GraphicsManager *ModularGraphicsBackend::getGraphicsManager() {
 	assert(_graphicsManager);
 	return (GraphicsManager *)_graphicsManager;
 }
 
-const OSystem::GraphicsMode *ModularBackend::getSupportedGraphicsModes() const {
+const OSystem::GraphicsMode *ModularGraphicsBackend::getSupportedGraphicsModes() const {
 	return _graphicsManager->getSupportedGraphicsModes();
 }
 
-int ModularBackend::getDefaultGraphicsMode() const {
+int ModularGraphicsBackend::getDefaultGraphicsMode() const {
 	return _graphicsManager->getDefaultGraphicsMode();
 }
 
-bool ModularBackend::setGraphicsMode(int mode) {
+bool ModularGraphicsBackend::setGraphicsMode(int mode) {
 	return _graphicsManager->setGraphicsMode(mode);
 }
 
-int ModularBackend::getGraphicsMode() const {
+int ModularGraphicsBackend::getGraphicsMode() const {
 	return _graphicsManager->getGraphicsMode();
 }
 
-const OSystem::GraphicsMode *ModularBackend::getSupportedShaders() const {
+const OSystem::GraphicsMode *ModularGraphicsBackend::getSupportedShaders() const {
 	return _graphicsManager->getSupportedShaders();
 }
 
-int ModularBackend::getDefaultShader() const {
+int ModularGraphicsBackend::getDefaultShader() const {
 	return _graphicsManager->getDefaultShader();
 }
 
-bool ModularBackend::setShader(int id) {
+bool ModularGraphicsBackend::setShader(int id) {
 	return _graphicsManager->setShader(id);
 }
 
-int ModularBackend::getShader() const {
+int ModularGraphicsBackend::getShader() const {
 	return _graphicsManager->getShader();
 }
 
-const OSystem::GraphicsMode *ModularBackend::getSupportedStretchModes() const {
+const OSystem::GraphicsMode *ModularGraphicsBackend::getSupportedStretchModes() const {
 	return _graphicsManager->getSupportedStretchModes();
 }
 
-int ModularBackend::getDefaultStretchMode() const {
+int ModularGraphicsBackend::getDefaultStretchMode() const {
 	return _graphicsManager->getDefaultStretchMode();
 }
 
-bool ModularBackend::setStretchMode(int mode) {
+bool ModularGraphicsBackend::setStretchMode(int mode) {
 	return _graphicsManager->setStretchMode(mode);
 }
 
-int ModularBackend::getStretchMode() const {
+int ModularGraphicsBackend::getStretchMode() const {
 	return _graphicsManager->getStretchMode();
 }
 
-void ModularBackend::resetGraphicsScale() {
+void ModularGraphicsBackend::resetGraphicsScale() {
 	_graphicsManager->resetGraphicsScale();
 }
 
 #ifdef USE_RGB_COLOR
 
-Graphics::PixelFormat ModularBackend::getScreenFormat() const {
+Graphics::PixelFormat ModularGraphicsBackend::getScreenFormat() const {
 	return _graphicsManager->getScreenFormat();
 }
 
-Common::List<Graphics::PixelFormat> ModularBackend::getSupportedFormats() const {
+Common::List<Graphics::PixelFormat> ModularGraphicsBackend::getSupportedFormats() const {
 	return _graphicsManager->getSupportedFormats();
 }
 
 #endif
 
-void ModularBackend::initSize(uint w, uint h, const Graphics::PixelFormat *format ) {
+void ModularGraphicsBackend::initSize(uint w, uint h, const Graphics::PixelFormat *format ) {
 	_graphicsManager->initSize(w, h, format);
 }
 
-void ModularBackend::initSizeHint(const Graphics::ModeList &modes) {
+void ModularGraphicsBackend::initSizeHint(const Graphics::ModeList &modes) {
 	_graphicsManager->initSizeHint(modes);
 }
 
-int ModularBackend::getScreenChangeID() const {
+int ModularGraphicsBackend::getScreenChangeID() const {
 	return _graphicsManager->getScreenChangeID();
 }
 
-void ModularBackend::beginGFXTransaction() {
+void ModularGraphicsBackend::beginGFXTransaction() {
 	_graphicsManager->beginGFXTransaction();
 }
 
-OSystem::TransactionError ModularBackend::endGFXTransaction() {
+OSystem::TransactionError ModularGraphicsBackend::endGFXTransaction() {
 	return _graphicsManager->endGFXTransaction();
 }
 
-int16 ModularBackend::getHeight() {
+int16 ModularGraphicsBackend::getHeight() {
 	return _graphicsManager->getHeight();
 }
 
-int16 ModularBackend::getWidth() {
+int16 ModularGraphicsBackend::getWidth() {
 	return _graphicsManager->getWidth();
 }
 
-PaletteManager *ModularBackend::getPaletteManager() {
+PaletteManager *ModularGraphicsBackend::getPaletteManager() {
 	return _graphicsManager;
 }
 
-void ModularBackend::copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {
+void ModularGraphicsBackend::copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {
 	_graphicsManager->copyRectToScreen(buf, pitch, x, y, w, h);
 }
 
-Graphics::Surface *ModularBackend::lockScreen() {
+Graphics::Surface *ModularGraphicsBackend::lockScreen() {
 	return _graphicsManager->lockScreen();
 }
 
-void ModularBackend::unlockScreen() {
+void ModularGraphicsBackend::unlockScreen() {
 	_graphicsManager->unlockScreen();
 }
 
-void ModularBackend::fillScreen(uint32 col) {
+void ModularGraphicsBackend::fillScreen(uint32 col) {
 	_graphicsManager->fillScreen(col);
 }
 
-void ModularBackend::updateScreen() {
+void ModularGraphicsBackend::updateScreen() {
 #ifdef ENABLE_EVENTRECORDER
 	g_eventRec.preDrawOverlayGui();
 #endif
@@ -187,90 +181,105 @@ void ModularBackend::updateScreen() {
 #endif
 }
 
-void ModularBackend::setShakePos(int shakeXOffset, int shakeYOffset) {
+void ModularGraphicsBackend::setShakePos(int shakeXOffset, int shakeYOffset) {
 	_graphicsManager->setShakePos(shakeXOffset, shakeYOffset);
 }
-void ModularBackend::setFocusRectangle(const Common::Rect& rect) {
+void ModularGraphicsBackend::setFocusRectangle(const Common::Rect& rect) {
 	_graphicsManager->setFocusRectangle(rect);
 }
 
-void ModularBackend::clearFocusRectangle() {
+void ModularGraphicsBackend::clearFocusRectangle() {
 	_graphicsManager->clearFocusRectangle();
 }
 
-void ModularBackend::showOverlay() {
+void ModularGraphicsBackend::showOverlay() {
 	_graphicsManager->showOverlay();
 }
 
-void ModularBackend::hideOverlay() {
+void ModularGraphicsBackend::hideOverlay() {
 	_graphicsManager->hideOverlay();
 }
 
-Graphics::PixelFormat ModularBackend::getOverlayFormat() const {
+Graphics::PixelFormat ModularGraphicsBackend::getOverlayFormat() const {
 	return _graphicsManager->getOverlayFormat();
 }
 
-void ModularBackend::clearOverlay() {
+void ModularGraphicsBackend::clearOverlay() {
 	_graphicsManager->clearOverlay();
 }
 
-void ModularBackend::grabOverlay(void *buf, int pitch) {
+void ModularGraphicsBackend::grabOverlay(void *buf, int pitch) {
 	_graphicsManager->grabOverlay(buf, pitch);
 }
 
-void ModularBackend::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {
+void ModularGraphicsBackend::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {
 	_graphicsManager->copyRectToOverlay(buf, pitch, x, y, w, h);
 }
 
-int16 ModularBackend::getOverlayHeight() {
+int16 ModularGraphicsBackend::getOverlayHeight() {
 	return _graphicsManager->getOverlayHeight();
 }
 
-int16 ModularBackend::getOverlayWidth() {
+int16 ModularGraphicsBackend::getOverlayWidth() {
 	return _graphicsManager->getOverlayWidth();
 }
 
-bool ModularBackend::showMouse(bool visible) {
+bool ModularGraphicsBackend::showMouse(bool visible) {
 	return _graphicsManager->showMouse(visible);
 }
 
-void ModularBackend::warpMouse(int x, int y) {
+void ModularGraphicsBackend::warpMouse(int x, int y) {
 	_eventManager->purgeMouseEvents();
 	_graphicsManager->warpMouse(x, y);
 }
 
-void ModularBackend::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
+void ModularGraphicsBackend::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
 	_graphicsManager->setMouseCursor(buf, w, h, hotspotX, hotspotY, keycolor, dontScale, format);
 }
 
-void ModularBackend::setCursorPalette(const byte *colors, uint start, uint num) {
+void ModularGraphicsBackend::setCursorPalette(const byte *colors, uint start, uint num) {
 	_graphicsManager->setCursorPalette(colors, start, num);
 }
 
-OSystem::MutexRef ModularBackend::createMutex() {
+void ModularGraphicsBackend::displayMessageOnOSD(const char *msg) {
+	_graphicsManager->displayMessageOnOSD(msg);
+}
+
+void ModularGraphicsBackend::displayActivityIconOnOSD(const Graphics::Surface *icon) {
+	_graphicsManager->displayActivityIconOnOSD(icon);
+}
+
+
+ModularMutexBackend::ModularMutexBackend()
+	:
+	_mutexManager(0) {
+
+}
+
+ModularMutexBackend::~ModularMutexBackend() {
+	// _timerManager needs to be deleted before _mutexManager to avoid a crash.
+	delete _timerManager;
+	_timerManager = 0;
+	delete _mutexManager;
+	_mutexManager = 0;
+}
+
+OSystem::MutexRef ModularMutexBackend::createMutex() {
 	assert(_mutexManager);
 	return _mutexManager->createMutex();
 }
 
-void ModularBackend::lockMutex(MutexRef mutex) {
+void ModularMutexBackend::lockMutex(MutexRef mutex) {
 	assert(_mutexManager);
 	_mutexManager->lockMutex(mutex);
 }
 
-void ModularBackend::unlockMutex(MutexRef mutex) {
+void ModularMutexBackend::unlockMutex(MutexRef mutex) {
 	assert(_mutexManager);
 	_mutexManager->unlockMutex(mutex);
 }
 
-void ModularBackend::deleteMutex(MutexRef mutex) {
+void ModularMutexBackend::deleteMutex(MutexRef mutex) {
 	assert(_mutexManager);
 	_mutexManager->deleteMutex(mutex);
-}
-
-void ModularBackend::displayMessageOnOSD(const char *msg) {
-	_graphicsManager->displayMessageOnOSD(msg);
-}
-
-void ModularBackend::displayActivityIconOnOSD(const Graphics::Surface *icon) {
-	_graphicsManager->displayActivityIconOnOSD(icon);
 }

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -26,6 +26,7 @@
 #include "backends/base-backend.h"
 
 class GraphicsManager;
+class MixerManager;
 class MutexManager;
 
 /**
@@ -40,7 +41,6 @@ class MutexManager;
  *   OSystem::getMillis()
  *   OSystem::delayMillis()
  *   OSystem::getTimeAndDate()
- *   OSystem::getMixer()
  *   OSystem::quit()
  *
  * And, it should also initialize all the managers variables
@@ -129,6 +129,28 @@ protected:
 	//@{
 
 	GraphicsManager *_graphicsManager;
+
+	//@}
+};
+
+class ModularMixerBackend : virtual public BaseBackend {
+public:
+	ModularMixerBackend();
+	virtual ~ModularMixerBackend();
+
+	/** @name Sound */
+	//@{
+
+	virtual MixerManager *getMixerManager();
+	virtual Audio::Mixer *getMixer() override final;
+
+	//@}
+
+protected:
+	/** @name Managers variables */
+	//@{
+
+	MixerManager *_mixerManager;
 
 	//@}
 };

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -40,6 +40,7 @@ class MutexManager;
  *   OSystem::getMillis()
  *   OSystem::delayMillis()
  *   OSystem::getTimeAndDate()
+ *   OSystem::getMixer()
  *   OSystem::quit()
  *
  * And, it should also initialize all the managers variables
@@ -125,13 +126,6 @@ public:
 
 	//@}
 
-	/** @name Sound */
-	//@{
-
-	virtual Audio::Mixer *getMixer() override;
-
-	//@}
-
 	/** @name Miscellaneous */
 	//@{
 
@@ -146,7 +140,6 @@ protected:
 
 	MutexManager *_mutexManager;
 	GraphicsManager *_graphicsManager;
-	Audio::Mixer *_mixer;
 
 	//@}
 };

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -29,12 +29,12 @@ class GraphicsManager;
 class MutexManager;
 
 /**
- * Base class for modular backends.
+ * Base classes for modular backends.
  *
- * It wraps most functions to their manager equivalent, but not
+ * They wrap most functions to their manager equivalent, but not
  * all OSystem functions are implemented here.
  *
- * A backend derivated from this class, will need to implement
+ * A backend derivated from these classes, will need to implement
  * these functions on its own:
  *   OSystem::pollEvent()
  *   OSystem::getMillis()
@@ -46,10 +46,10 @@ class MutexManager;
  * And, it should also initialize all the managers variables
  * declared in this class, or override their related functions.
  */
-class ModularBackend : public BaseBackend {
+class ModularGraphicsBackend : virtual public BaseBackend {
 public:
-	ModularBackend();
-	virtual ~ModularBackend();
+	ModularGraphicsBackend();
+	virtual ~ModularGraphicsBackend();
 
 	/** @name Features */
 	//@{
@@ -116,16 +116,6 @@ public:
 
 	//@}
 
-	/** @name Mutex handling */
-	//@{
-
-	virtual MutexRef createMutex() override final;
-	virtual void lockMutex(MutexRef mutex) override final;
-	virtual void unlockMutex(MutexRef mutex) override final;
-	virtual void deleteMutex(MutexRef mutex) override final;
-
-	//@}
-
 	/** @name Miscellaneous */
 	//@{
 
@@ -138,8 +128,31 @@ protected:
 	/** @name Managers variables */
 	//@{
 
-	MutexManager *_mutexManager;
 	GraphicsManager *_graphicsManager;
+
+	//@}
+};
+
+class ModularMutexBackend : virtual public BaseBackend {
+public:
+	ModularMutexBackend();
+	virtual ~ModularMutexBackend();
+
+	/** @name Mutex handling */
+	//@{
+
+	virtual MutexRef createMutex() override final;
+	virtual void lockMutex(MutexRef mutex) override final;
+	virtual void unlockMutex(MutexRef mutex) override final;
+	virtual void deleteMutex(MutexRef mutex) override final;
+
+	//@}
+
+protected:
+	/** @name Managers variables */
+	//@{
+
+	MutexManager *_mutexManager;
 
 	//@}
 };

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -294,6 +294,11 @@ MODULE_OBJS += \
 	fs/n64/romfsstream.o
 endif
 
+ifeq ($(BACKEND),null)
+MODULE_OBJS += \
+	mixer/null/null-mixer.o
+endif
+
 ifeq ($(BACKEND),openpandora)
 MODULE_OBJS += \
 	events/openpandora/op-events.o \

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -338,7 +338,7 @@ endif
 
 ifdef ENABLE_EVENTRECORDER
 MODULE_OBJS += \
-	mixer/nullmixer/nullsdl-mixer.o \
+	mixer/null/null-mixer.o \
 	saves/recorder/recorder-saves.o
 endif
 

--- a/backends/platform/3ds/config.cpp
+++ b/backends/platform/3ds/config.cpp
@@ -74,7 +74,7 @@ void loadConfig() {
 		gspLcdExit();
 	}
 
-	OSystem_3DS *osys = (OSystem_3DS *)g_system;
+	OSystem_3DS *osys = dynamic_cast<OSystem_3DS *>(g_system);
 	osys->updateConfig();
 }
 

--- a/backends/platform/3ds/osystem-audio.cpp
+++ b/backends/platform/3ds/osystem-audio.cpp
@@ -29,7 +29,7 @@ static bool hasAudio = false;
 
 static void audioThreadFunc(void *arg) {
 	Audio::MixerImpl *mixer = (Audio::MixerImpl *)arg;
-	OSystem_3DS *osys = (OSystem_3DS *)g_system;
+	OSystem_3DS *osys = dynamic_cast<OSystem_3DS *>(g_system);
 
 	const int channel = 0;
 	int bufferIndex = 0;

--- a/backends/platform/3ds/osystem-events.cpp
+++ b/backends/platform/3ds/osystem-events.cpp
@@ -91,7 +91,7 @@ static void doJoyEvent(Common::Queue<Common::Event> *queue, u32 keysPressed, u32
 }
 
 static void eventThreadFunc(void *arg) {
-	OSystem_3DS *osys = (OSystem_3DS *)g_system;
+	OSystem_3DS *osys = dynamic_cast<OSystem_3DS *>(g_system);
 	Common::Queue<Common::Event> *eventQueue = (Common::Queue<Common::Event> *)arg;
 
 	uint32 touchStartTime = osys->getMillis();
@@ -206,7 +206,7 @@ static void eventThreadFunc(void *arg) {
 }
 
 static void aptHookFunc(APT_HookType hookType, void *param) {
-	OSystem_3DS *osys = (OSystem_3DS *)g_system;
+	OSystem_3DS *osys = dynamic_cast<OSystem_3DS *>(g_system);
 
 	switch (hookType) {
 		case APTHOOK_ONSUSPEND:

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -368,7 +368,7 @@ void OSystem_Android::initBackend() {
 
 	JNI::setReadyForEvents(true);
 
-	ModularBackend::initBackend();
+	BaseBackend::initBackend();
 }
 
 bool OSystem_Android::hasFeature(Feature f) {
@@ -379,7 +379,7 @@ bool OSystem_Android::hasFeature(Feature f) {
 			f == kFeatureClipboardSupport) {
 		return true;
 	}
-	return ModularBackend::hasFeature(f);
+	return ModularGraphicsBackend::hasFeature(f);
 }
 
 void OSystem_Android::setFeatureState(Feature f, bool enable) {
@@ -399,7 +399,7 @@ void OSystem_Android::setFeatureState(Feature f, bool enable) {
 		JNI::showKeyboardControl(enable);
 		break;
 	default:
-		ModularBackend::setFeatureState(f, enable);
+		ModularGraphicsBackend::setFeatureState(f, enable);
 		break;
 	}
 }
@@ -413,7 +413,7 @@ bool OSystem_Android::getFeatureState(Feature f) {
 	case kFeatureOnScreenControl:
 		return ConfMan.getBool("onscreen_control");
 	default:
-		return ModularBackend::getFeatureState(f);
+		return ModularGraphicsBackend::getFeatureState(f);
 	}
 }
 

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -55,7 +55,7 @@ extern const char *android_log_tag;
 #define ENTER(fmt, args...) do {  } while (false)
 #endif
 
-class OSystem_Android : public ModularBackend, Common::EventSource {
+class OSystem_Android : public ModularMutexBackend, public ModularGraphicsBackend, Common::EventSource {
 private:
 	// passed from the dark side
 	int _audio_sample_rate;

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -80,9 +80,6 @@ private:
 
 	Common::String getSystemProperty(const char *name) const;
 
-protected:
-	virtual Common::EventSource *getDefaultEventSource() { return this; }
-
 public:
 	OSystem_Android(int audio_sample_rate, int audio_buffer_size);
 	virtual ~OSystem_Android();

--- a/backends/platform/androidsdl/androidsdl-main.cpp
+++ b/backends/platform/androidsdl/androidsdl-main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_POSIX *)g_system)->init();
+	g_system->init();
 
 	// Invoke the actual ScummVM main entry point:
 	int res = scummvm_main(argc, argv);

--- a/backends/platform/dingux/main.cpp
+++ b/backends/platform/dingux/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) {
 	g_system = new OSystem_SDL_Dingux();
 	assert(g_system);
 
-	((OSystem_SDL_Dingux *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/ds/arm9/source/wordcompletion.cpp
+++ b/backends/platform/ds/arm9/source/wordcompletion.cpp
@@ -104,7 +104,7 @@ bool findWordCompletions(const char *input) {
 	if (wordBufferPtrPos == 0)
 		return false;
 
-	OSystem_DS *system = (OSystem_DS *) g_system;
+	OSystem_DS *system = dynamic_cast<OSystem_DS *>(g_system);
 	system->clearAutoComplete();
 
 	int start = 0;

--- a/backends/platform/gph/gph-main.cpp
+++ b/backends/platform/gph/gph-main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_GPH *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -353,7 +353,7 @@ void OSystem_iOS7::addSysArchivesToSearchSet(Common::SearchSet &s, int priority)
 }
 
 bool iOS7_touchpadModeEnabled() {
-	OSystem_iOS7 *sys = (OSystem_iOS7 *) g_system;
+	OSystem_iOS7 *sys = dynamic_cast<OSystem_iOS7 *>(g_system);
 	return sys && sys->touchpadModeEnabled();
 }
 

--- a/backends/platform/maemo/main.cpp
+++ b/backends/platform/maemo/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
 	g_system = new Maemo::OSystem_SDL_Maemo();
 	assert(g_system);
 
-	((Maemo::OSystem_SDL_Maemo *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/n64/osys_n64_utilities.cpp
+++ b/backends/platform/n64/osys_n64_utilities.cpp
@@ -24,7 +24,7 @@
 #include "backends/timer/default/default-timer.h"
 
 void checkTimers(void) {
-	OSystem_N64 *osys = (OSystem_N64 *)g_system;
+	OSystem_N64 *osys = dynamic_cast<OSystem_N64 *>(g_system);
 
 	uint32 curTime = osys->getMillis();
 
@@ -46,7 +46,7 @@ void disableAudioPlayback(void) {
 void enableAudioPlayback(void) {
 	static bool _firstRun = true;
 
-	OSystem_N64 *osys = (OSystem_N64 *)g_system;
+	OSystem_N64 *osys = dynamic_cast<OSystem_N64 *>(g_system);
 	Audio::MixerImpl *localmixer = (Audio::MixerImpl *)osys->getMixer();
 
 	uint32 sampleBufferSize = 3072;
@@ -83,7 +83,7 @@ void vblCallback(void) {
 		sndCallback();
 	}
 
-	((OSystem_N64 *)g_system)->readControllerAnalogInput();
+	dynamic_cast<OSystem_N64 *>(g_system)->readControllerAnalogInput();
 }
 
 void sndCallback() {
@@ -95,7 +95,7 @@ void sndCallback() {
 void refillAudioBuffers(void) {
 	if (!_audioEnabled) return;
 
-	OSystem_N64 *osys = (OSystem_N64 *)g_system;
+	OSystem_N64 *osys = dynamic_cast<OSystem_N64 *>(g_system);
 	byte *sndBuf;
 	Audio::MixerImpl *localmixer = (Audio::MixerImpl *)osys->getMixer();
 

--- a/backends/platform/null/null.cpp
+++ b/backends/platform/null/null.cpp
@@ -77,17 +77,21 @@ public:
 	virtual void delayMillis(uint msecs);
 	virtual void getTimeAndDate(TimeDate &t) const;
 
+	virtual Audio::Mixer *getMixer();
+
 	virtual void quit();
 
 	virtual void logMessage(LogMessageType::Type type, const char *message);
 
-#ifdef POSIX
 private:
+	Audio::MixerImpl *_mixer;
+
+#ifdef POSIX
 	timeval _startTime;
 #endif
 };
 
-OSystem_NULL::OSystem_NULL() {
+OSystem_NULL::OSystem_NULL() : _mixer(0) {
 	#if defined(__amigaos4__)
 		_fsFactory = new AmigaOSFilesystemFactory();
 	#elif defined(POSIX)
@@ -102,6 +106,8 @@ OSystem_NULL::OSystem_NULL() {
 }
 
 OSystem_NULL::~OSystem_NULL() {
+	delete _mixer;
+	_mixer = 0;
 }
 
 #ifdef POSIX
@@ -129,7 +135,7 @@ void OSystem_NULL::initBackend() {
 	_graphicsManager = new NullGraphicsManager();
 	_mixer = new Audio::MixerImpl(22050);
 
-	((Audio::MixerImpl *)_mixer)->setReady(false);
+	_mixer->setReady(false);
 
 	// Note that the mixer is useless this way; it needs to be hooked
 	// into the system somehow to be functional. Of course, can't do
@@ -191,6 +197,11 @@ void OSystem_NULL::getTimeAndDate(TimeDate &td) const {
 	td.tm_mon = t.tm_mon;
 	td.tm_year = t.tm_year;
 	td.tm_wday = t.tm_wday;
+}
+
+Audio::Mixer *OSystem_NULL::getMixer() {
+	assert(_mixer);
+	return (Audio::Mixer *)_mixer;
 }
 
 void OSystem_NULL::quit() {

--- a/backends/platform/null/null.cpp
+++ b/backends/platform/null/null.cpp
@@ -63,7 +63,7 @@
 	#include "backends/fs/windows/windows-fs-factory.h"
 #endif
 
-class OSystem_NULL : public ModularBackend, Common::EventSource {
+class OSystem_NULL : public ModularMutexBackend, public ModularGraphicsBackend, Common::EventSource {
 public:
 	OSystem_NULL();
 	virtual ~OSystem_NULL();
@@ -141,7 +141,7 @@ void OSystem_NULL::initBackend() {
 	// into the system somehow to be functional. Of course, can't do
 	// that in a NULL backend :).
 
-	ModularBackend::initBackend();
+	BaseBackend::initBackend();
 }
 
 bool OSystem_NULL::pollEvent(Common::Event &event) {

--- a/backends/platform/null/null.cpp
+++ b/backends/platform/null/null.cpp
@@ -70,7 +70,6 @@ public:
 
 	virtual void initBackend();
 
-	virtual Common::EventSource *getDefaultEventSource() { return this; }
 	virtual bool pollEvent(Common::Event &event);
 
 	virtual uint32 getMillis(bool skipRecord = false);

--- a/backends/platform/openpandora/op-main.cpp
+++ b/backends/platform/openpandora/op-main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_OP *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/samsungtv/main.cpp
+++ b/backends/platform/samsungtv/main.cpp
@@ -40,7 +40,7 @@ extern "C" int Game_Main(char *path, char *) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_POSIX *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/sdl/amigaos/amigaos-main.cpp
+++ b/backends/platform/sdl/amigaos/amigaos-main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre-initialize the backend.
-	((OSystem_AmigaOS *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/sdl/macosx/macosx-main.cpp
+++ b/backends/platform/sdl/macosx/macosx-main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_MacOSX *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/sdl/posix/posix-main.cpp
+++ b/backends/platform/sdl/posix/posix-main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_POSIX *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/sdl/ps3/ps3-main.cpp
+++ b/backends/platform/sdl/ps3/ps3-main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_PS3 *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/sdl/psp2/psp2-main.cpp
+++ b/backends/platform/sdl/psp2/psp2-main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_PSP2 *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/sdl/riscos/riscos-main.cpp
+++ b/backends/platform/sdl/riscos/riscos-main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_RISCOS *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -546,7 +546,7 @@ Audio::Mixer *OSystem_SDL::getMixer() {
 	return getMixerManager()->getMixer();
 }
 
-SdlMixerManager *OSystem_SDL::getMixerManager() {
+MixerManager *OSystem_SDL::getMixerManager() {
 	assert(_mixerManager);
 
 #ifdef ENABLE_EVENTRECORDER

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -81,7 +81,6 @@ OSystem_SDL::OSystem_SDL()
 	_initedSDLnet(false),
 #endif
 	_logger(0),
-	_mixerManager(0),
 	_eventSource(0),
 	_eventSourceWrapper(nullptr),
 	_window(0) {
@@ -539,11 +538,6 @@ void OSystem_SDL::getTimeAndDate(TimeDate &td) const {
 	td.tm_mon = t.tm_mon;
 	td.tm_year = t.tm_year;
 	td.tm_wday = t.tm_wday;
-}
-
-Audio::Mixer *OSystem_SDL::getMixer() {
-	assert(_mixerManager);
-	return getMixerManager()->getMixer();
 }
 
 MixerManager *OSystem_SDL::getMixerManager() {

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -91,7 +91,7 @@ OSystem_SDL::~OSystem_SDL() {
 	SDL_ShowCursor(SDL_ENABLE);
 
 	// Delete the various managers here. Note that the ModularBackend
-	// destructor would also take care of this for us. However, various
+	// destructors would also take care of this for us. However, various
 	// of our managers must be deleted *before* we call SDL_Quit().
 	// Hence, we perform the destruction on our own.
 	delete _savefileManager;
@@ -170,7 +170,7 @@ bool OSystem_SDL::hasFeature(Feature f) {
 	if (f == kFeatureJoystickDeadzone || f == kFeatureKbdMouseSpeed) {
 		return _eventSource->isJoystickConnected();
 	}
-	return ModularBackend::hasFeature(f);
+	return ModularGraphicsBackend::hasFeature(f);
 }
 
 void OSystem_SDL::initBackend() {
@@ -266,7 +266,7 @@ void OSystem_SDL::initBackend() {
 
 	_inited = true;
 
-	ModularBackend::initBackend();
+	BaseBackend::initBackend();
 
 	// We have to initialize the graphics manager before the event manager
 	// so the virtual keyboard can be initialized, but we have to add the
@@ -376,7 +376,7 @@ void OSystem_SDL::fatalError() {
 }
 
 Common::KeymapArray OSystem_SDL::getGlobalKeymaps() {
-	Common::KeymapArray globalMaps = ModularBackend::getGlobalKeymaps();
+	Common::KeymapArray globalMaps = BaseBackend::getGlobalKeymaps();
 
 	SdlGraphicsManager *graphicsManager = dynamic_cast<SdlGraphicsManager *>(_graphicsManager);
 	globalMaps.push_back(graphicsManager->getKeymap());
@@ -447,7 +447,7 @@ Common::String OSystem_SDL::getSystemLanguage() const {
 
 	// Detect the language from the locale
 	if (locale.empty()) {
-		return ModularBackend::getSystemLanguage();
+		return BaseBackend::getSystemLanguage();
 	} else {
 		int length = 0;
 
@@ -465,7 +465,7 @@ Common::String OSystem_SDL::getSystemLanguage() const {
 		return Common::String(locale.c_str(), length);
 	}
 #else // USE_DETECTLANG
-	return ModularBackend::getSystemLanguage();
+	return BaseBackend::getSystemLanguage();
 #endif // USE_DETECTLANG
 }
 
@@ -781,6 +781,6 @@ char *OSystem_SDL::convertEncoding(const char *to, const char *from, const char 
 	SDL_free(result);
 	return finalResult;
 #else
-	return ModularBackend::convertEncoding(to, from, string, length);
+	return BaseBackend::convertEncoding(to, from, string, length);
 #endif // SDL_VERSION_ATLEAST(1, 2, 10)
 }

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -36,7 +36,7 @@
 /**
  * Base OSystem class for all SDL ports.
  */
-class OSystem_SDL : public ModularMutexBackend, public ModularGraphicsBackend {
+class OSystem_SDL : public ModularMutexBackend, public ModularMixerBackend, public ModularGraphicsBackend {
 public:
 	OSystem_SDL();
 	virtual ~OSystem_SDL();
@@ -47,13 +47,6 @@ public:
 	 * created here.
 	 */
 	virtual void init() override;
-
-	/**
-	 * Get the Mixer Manager instance. Not to confuse with getMixer(),
-	 * that returns Audio::Mixer. The Mixer Manager is a SDL wrapper class
-	 * for the Audio::Mixer. Used by other managers.
-	 */
-	virtual MixerManager *getMixerManager();
 
 	virtual bool hasFeature(Feature f) override;
 
@@ -83,7 +76,7 @@ public:
 	virtual uint32 getMillis(bool skipRecord = false) override;
 	virtual void delayMillis(uint msecs) override;
 	virtual void getTimeAndDate(TimeDate &td) const override;
-	virtual Audio::Mixer *getMixer() override;
+	virtual MixerManager *getMixerManager() override;
 	virtual Common::TimerManager *getTimerManager() override;
 	virtual Common::SaveFileManager *getSavefileManager() override;
 
@@ -106,12 +99,6 @@ protected:
 	 * editor; for that, we need it only as a string anyway.
 	 */
 	Common::String _logFilePath;
-
-	/**
-	 * Mixer manager that configures and setups SDL for
-	 * the wrapped Audio::Mixer, the true mixer.
-	 */
-	MixerManager *_mixerManager;
 
 	/**
 	 * The event source we use for obtaining SDL events.

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -36,7 +36,7 @@
 /**
  * Base OSystem class for all SDL ports.
  */
-class OSystem_SDL : public ModularBackend {
+class OSystem_SDL : public ModularMutexBackend, public ModularGraphicsBackend {
 public:
 	OSystem_SDL();
 	virtual ~OSystem_SDL();

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -53,7 +53,7 @@ public:
 	 * that returns Audio::Mixer. The Mixer Manager is a SDL wrapper class
 	 * for the Audio::Mixer. Used by other managers.
 	 */
-	virtual SdlMixerManager *getMixerManager();
+	virtual MixerManager *getMixerManager();
 
 	virtual bool hasFeature(Feature f) override;
 
@@ -111,7 +111,7 @@ protected:
 	 * Mixer manager that configures and setups SDL for
 	 * the wrapped Audio::Mixer, the true mixer.
 	 */
-	SdlMixerManager *_mixerManager;
+	MixerManager *_mixerManager;
 
 	/**
 	 * The event source we use for obtaining SDL events.

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -46,7 +46,7 @@ public:
 	 * instantiating the backend. Early needed managers are
 	 * created here.
 	 */
-	virtual void init();
+	virtual void init() override;
 
 	/**
 	 * Get the Mixer Manager instance. Not to confuse with getMixer(),

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -124,8 +124,6 @@ protected:
 	 */
 	SdlWindow *_window;
 
-	virtual Common::EventSource *getDefaultEventSource() override { return _eventSource; }
-
 	/**
 	 * Initialze the SDL library.
 	 */

--- a/backends/platform/sdl/switch/switch-main.cpp
+++ b/backends/platform/sdl/switch/switch-main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_Switch *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/sdl/win32/win32-main.cpp
+++ b/backends/platform/sdl/win32/win32-main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_Win32 *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/symbian/src/SymbianMain.cpp
+++ b/backends/platform/symbian/src/SymbianMain.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
 	assert(g_system);
 
 	// Pre initialize the backend
-	((OSystem_SDL_Symbian *)g_system)->init();
+	g_system->init();
 
 #ifdef DYNAMIC_MODULES
 	PluginManager::instance().addPluginProvider(new SDLPluginProvider());

--- a/backends/platform/symbian/src/SymbianOS.cpp
+++ b/backends/platform/symbian/src/SymbianOS.cpp
@@ -85,7 +85,7 @@ void OSystem_SDL_Symbian::initBackend() {
 	TFileName fname;
 	TPtrC8 ptr((const unsigned char*)currentPath.c_str(), currentPath.size());
 	fname.Copy(ptr);
-	BaflUtils::EnsurePathExistsL(static_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), fname);
+	BaflUtils::EnsurePathExistsL(dynamic_cast<OSystem_SDL_Symbian *>(g_system)->FsSession(), fname);
 
 	ConfMan.setBool("FM_high_quality", false);
 #if !defined(S60) || defined(S60V3) // S60 has low quality as default

--- a/common/system.h
+++ b/common/system.h
@@ -244,6 +244,11 @@ public:
 	void destroy();
 
 	/**
+	 * The following method should be called once, after g_system is created.
+	 */
+	virtual void init() {}
+
+	/**
 	 * The following method is called once, from main.cpp, after all
 	 * config data (including command line params etc.) are fully loaded.
 	 *

--- a/common/system.h
+++ b/common/system.h
@@ -149,7 +149,7 @@ protected:
 
 	/**
 	 * No default value is provided for _eventManager by OSystem.
-	 * However, BaseBackend::initBackend() does set a default value
+	 * However, EventsBaseBackend::initBackend() does set a default value
 	 * if none has been set before.
 	 *
 	 * @note _eventManager is deleted by the OSystem destructor.

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -260,7 +260,7 @@ Common::String EventRecorder::generateRecordFileName(const Common::String &targe
 
 
 void EventRecorder::init(Common::String recordFileName, RecordMode mode) {
-	_fakeMixerManager = new NullSdlMixerManager();
+	_fakeMixerManager = new NullMixerManager();
 	_fakeMixerManager->init();
 	_fakeMixerManager->suspendAudio();
 	_fakeTimer = 0;

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -31,7 +31,7 @@ DECLARE_SINGLETON(GUI::EventRecorder);
 
 #include "common/debug-channels.h"
 #include "backends/timer/sdl/sdl-timer.h"
-#include "backends/mixer/sdl/sdl-mixer.h"
+#include "backends/mixer/mixer.h"
 #include "common/config-manager.h"
 #include "common/md5.h"
 #include "gui/gui-manager.h"
@@ -349,7 +349,7 @@ bool EventRecorder::checkGameHash(const ADGameDescription *gameDesc) {
 	return true;
 }
 
-void EventRecorder::registerMixerManager(SdlMixerManager *mixerManager) {
+void EventRecorder::registerMixerManager(MixerManager *mixerManager) {
 	_realMixerManager = mixerManager;
 }
 
@@ -362,7 +362,7 @@ void EventRecorder::switchMixer() {
 	}
 }
 
-SdlMixerManager *EventRecorder::getMixerManager() {
+MixerManager *EventRecorder::getMixerManager() {
 	if (_recordMode == kPassthrough) {
 		return _realMixerManager;
 	} else {

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -43,7 +43,7 @@
 #include "common/config-manager.h"
 #include "common/recorderfile.h"
 #include "backends/saves/recorder/recorder-saves.h"
-#include "backends/mixer/nullmixer/nullsdl-mixer.h"
+#include "backends/mixer/null/null-mixer.h"
 #include "backends/saves/default/default-saves.h"
 
 
@@ -190,7 +190,7 @@ private:
 	MixerManager *_realMixerManager;
 	DefaultTimerManager *_timerManager;
 	RecorderSaveFileManager _fakeSaveManager;
-	NullSdlMixerManager *_fakeMixerManager;
+	NullMixerManager *_fakeMixerManager;
 	GUI::OnScreenDialog *_controlPanel;
 	Common::RecorderEvent _nextEvent;
 

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -36,7 +36,7 @@
 #include "common/mutex.h"
 #include "common/array.h"
 #include "common/memstream.h"
-#include "backends/mixer/sdl/sdl-mixer.h"
+#include "backends/mixer/mixer.h"
 #include "common/hashmap.h"
 #include "common/hash-str.h"
 #include "backends/timer/sdl/sdl-timer.h"
@@ -142,10 +142,10 @@ public:
 		_needRedraw = redraw;
 	}
 
-	void registerMixerManager(SdlMixerManager *mixerManager);
+	void registerMixerManager(MixerManager *mixerManager);
 	void registerTimerManager(DefaultTimerManager *timerManager);
 
-	SdlMixerManager *getMixerManager();
+	MixerManager *getMixerManager();
 	DefaultTimerManager *getTimerManager();
 
 	void deleteRecord(const Common::String& fileName);
@@ -187,7 +187,7 @@ private:
 	Common::String _name;
 
 	Common::SaveFileManager *_realSaveManager;
-	SdlMixerManager *_realMixerManager;
+	MixerManager *_realMixerManager;
 	DefaultTimerManager *_timerManager;
 	RecorderSaveFileManager _fakeSaveManager;
 	NullSdlMixerManager *_fakeMixerManager;


### PR DESCRIPTION
Mixer managers can now be used with non-SDL backends.