### PR TITLE
WINTERMUTE: Add Simplified and Traditional Chinese flavours

### DIFF
--- a/engines/wintermute/base/base_file_manager.cpp
+++ b/engines/wintermute/base/base_file_manager.cpp
@@ -233,9 +233,14 @@ bool BaseFileManager::registerPackages() {
 					if (_language != Common::EN_ANY) {
 						continue;
 					}
-				// Chinese
-				} else if (fileName == "chinese.dcp" || fileName == "xlanguage_nz.dcp" || fileName == "chinese_language_pack.dcp") {
+				// Simplified Chinese
+				} else if (fileName == "chinese.dcp" || fileName == "xlanguage_nz.dcp" || fileName == "xlanguage_zh_s.dcp" || fileName == "chinese_language_pack.dcp") {
 					if (_language != Common::ZH_CNA) {
+						continue;
+					}
+				// Traditional Chinese
+				} else if (fileName == "xlanguage_zh_t.dcp") {
+					if (_language != Common::ZH_TWN) {
 						continue;
 					}
 				// Czech


### PR DESCRIPTION
Latest Steam updates for Reversion titles include Simplified and Traditional Chinese languages that were not properly identified
