### PR TITLE
QUEEN: fix bellboy dialogue - bug #11272

### DIFF
--- a/engines/queen/input.cpp
+++ b/engines/queen/input.cpp
@@ -111,8 +111,6 @@ void Input::delay(uint amount) {
 
 			case Common::EVENT_LBUTTONDOWN:
 				_mouseButton |= MOUSE_LBUTTON;
-				if (_dialogueRunning)
-					_talkQuit = true;
 				break;
 
 			case Common::EVENT_RBUTTONDOWN:


### PR DESCRIPTION
Quick fix for https://bugs.scummvm.org/ticket/11272.
This undoes https://github.com/scummvm/scummvm/pull/1779
So the behaviour of left click during player's talk now once again does not match DOS executable.