### PR TITLE
LURE: Enable the optional use of TTS to read descriptions as a narrator in "Lure of the Temptress"

### DIFF
--- a/engines/lure/detection.cpp
+++ b/engines/lure/detection.cpp
@@ -25,7 +25,8 @@
 #include "engines/advancedDetector.h"
 #include "engines/engine.h"
 #include "common/savefile.h"
-
+#include "common/system.h"
+#include "common/translation.h"
 #include "lure/lure.h"
 
 namespace Lure {
@@ -62,6 +63,23 @@ static const PlainGameDescriptor lureGames[] = {
 };
 
 
+#ifdef USE_TTS
+#define GAMEOPTION_TTS_NARRATOR 	GUIO_GAMEOPTIONS1
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+
+                GAMEOPTION_TTS_NARRATOR,
+		{
+			_s("TTS Narrator"),
+			_s("Use TTS to read the descriptions (if TTS is available)"),
+			"tts_narrator",
+			false
+		}
+
+};
+
+#endif
+
 namespace Lure {
 
 static const LureGameDescription gameDescriptions[] = {
@@ -73,7 +91,11 @@ static const LureGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
+                        #ifdef USE_TTS
+                        GUIO1(GAMEOPTION_TTS_NARRATOR)
+			#else
 			GUIO0()
+			#endif
 		},
 		GF_FLOPPY,
 	},
@@ -86,7 +108,12 @@ static const LureGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
+			#ifdef USE_TTS
+                        GUIO1(GAMEOPTION_TTS_NARRATOR)
+			#else
 			GUIO0()
+			#endif
+
 		},
 		GF_FLOPPY | GF_EGA,
 	},
@@ -205,7 +232,11 @@ static const LureGameDescription gameDescriptions[] = {
 
 class LureMetaEngine : public AdvancedMetaEngine {
 public:
-	LureMetaEngine() : AdvancedMetaEngine(Lure::gameDescriptions, sizeof(Lure::LureGameDescription), lureGames) {
+	LureMetaEngine() : AdvancedMetaEngine(Lure::gameDescriptions, sizeof(Lure::LureGameDescription), lureGames
+			#ifdef USE_TTS
+			, optionsList
+                        #endif
+			) {
 		_md5Bytes = 1024;
 
 		// Use kADFlagUseExtraAsHint to distinguish between EGA and VGA versions

--- a/engines/lure/detection.cpp
+++ b/engines/lure/detection.cpp
@@ -91,10 +91,10 @@ static const LureGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-                        #ifdef USE_TTS
-                        GUIO1(GAMEOPTION_TTS_NARRATOR)
+			#ifdef USE_TTS
+				GUIO1(GAMEOPTION_TTS_NARRATOR)
 			#else
-			GUIO0()
+				GUIO0()
 			#endif
 		},
 		GF_FLOPPY,
@@ -109,9 +109,9 @@ static const LureGameDescription gameDescriptions[] = {
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
 			#ifdef USE_TTS
-                        GUIO1(GAMEOPTION_TTS_NARRATOR)
+				GUIO1(GAMEOPTION_TTS_NARRATOR)
 			#else
-			GUIO0()
+				GUIO0()
 			#endif
 
 		},
@@ -235,7 +235,7 @@ public:
 	LureMetaEngine() : AdvancedMetaEngine(Lure::gameDescriptions, sizeof(Lure::LureGameDescription), lureGames
 			#ifdef USE_TTS
 			, optionsList
-                        #endif
+			#endif
 			) {
 		_md5Bytes = 1024;
 

--- a/engines/lure/surface.cpp
+++ b/engines/lure/surface.cpp
@@ -472,16 +472,14 @@ Surface *Surface::newDialog(uint16 width, uint8 numLines, const char **lines, bo
 
 	Surface *s = new Surface(width, size.y);
 	s->createDialog();
-	#ifdef USE_TTS	
-	char *text = (char*) malloc(1024*sizeof(char));
-	memset(text, 0, 1024);
+	#ifdef USE_TTS
+	Common::String text;
 	#endif
 
 	uint16 yP = Surface::textY();
 	for (uint8 ctr = 0; ctr < numLines; ++ctr) {
 		#ifdef USE_TTS
-		if (strlen(text) + strlen(lines[ctr]) < 1024)	
-			strcat(text, lines[ctr]);
+		text += lines[ctr];
 		#endif
 		s->writeString(Surface::textX(), yP, lines[ctr], true, color, varLength);
 		yP += squashedLines ? FONT_HEIGHT - 1 : FONT_HEIGHT;
@@ -492,9 +490,8 @@ Surface *Surface::newDialog(uint16 width, uint8 numLines, const char **lines, bo
 	if (ConfMan.getBool("tts_narrator")) {
 		Common::TextToSpeechManager *_ttsMan = g_system->getTextToSpeechManager();
 		_ttsMan->stop();
-		_ttsMan->say(text);
+		_ttsMan->say(text.c_str());
 	}
-	free(text);
 	#endif 
 
 	return s;

--- a/engines/lure/surface.cpp
+++ b/engines/lure/surface.cpp
@@ -472,30 +472,30 @@ Surface *Surface::newDialog(uint16 width, uint8 numLines, const char **lines, bo
 
 	Surface *s = new Surface(width, size.y);
 	s->createDialog();
-        #ifdef USE_TTS	
+	#ifdef USE_TTS	
 	char *text = (char*) malloc(1024*sizeof(char));
 	memset(text, 0, 1024);
-        #endif
+	#endif
 
 	uint16 yP = Surface::textY();
 	for (uint8 ctr = 0; ctr < numLines; ++ctr) {
-                #ifdef USE_TTS
-                if (strlen(text) + strlen(lines[ctr]) < 1024)	
-		    strcat(text, lines[ctr]);
+		#ifdef USE_TTS
+		if (strlen(text) + strlen(lines[ctr]) < 1024)	
+			strcat(text, lines[ctr]);
 		#endif
 		s->writeString(Surface::textX(), yP, lines[ctr], true, color, varLength);
 		yP += squashedLines ? FONT_HEIGHT - 1 : FONT_HEIGHT;
 	}
 
 
-        #ifdef USE_TTS
+	#ifdef USE_TTS
 	if (ConfMan.getBool("tts_narrator")) {
-            Common::TextToSpeechManager *_ttsMan = g_system->getTextToSpeechManager();
-            _ttsMan->stop();
-            _ttsMan->say(text);
+		Common::TextToSpeechManager *_ttsMan = g_system->getTextToSpeechManager();
+		_ttsMan->stop();
+		_ttsMan->say(text);
 	}
 	free(text);
-        #endif 
+	#endif 
 
 	return s;
 }

--- a/engines/lure/surface.cpp
+++ b/engines/lure/surface.cpp
@@ -30,6 +30,11 @@
 #include "lure/strings.h"
 #include "lure/surface.h"
 #include "common/endian.h"
+#include "common/config-manager.h"
+
+#ifdef USE_TTS
+#include "common/text-to-speech.h"
+#endif
 
 namespace Lure {
 
@@ -467,12 +472,30 @@ Surface *Surface::newDialog(uint16 width, uint8 numLines, const char **lines, bo
 
 	Surface *s = new Surface(width, size.y);
 	s->createDialog();
+        #ifdef USE_TTS	
+	char *text = (char*) malloc(1024*sizeof(char));
+	memset(text, 0, 1024);
+        #endif
 
 	uint16 yP = Surface::textY();
 	for (uint8 ctr = 0; ctr < numLines; ++ctr) {
+                #ifdef USE_TTS
+                if (strlen(text) + strlen(lines[ctr]) < 1024)	
+		    strcat(text, lines[ctr]);
+		#endif
 		s->writeString(Surface::textX(), yP, lines[ctr], true, color, varLength);
 		yP += squashedLines ? FONT_HEIGHT - 1 : FONT_HEIGHT;
 	}
+
+
+        #ifdef USE_TTS
+	if (ConfMan.getBool("tts_narrator")) {
+            Common::TextToSpeechManager *_ttsMan = g_system->getTextToSpeechManager();
+            _ttsMan->stop();
+            _ttsMan->say(text);
+	}
+	free(text);
+        #endif 
 
 	return s;
 }


### PR DESCRIPTION
LURE: Enable the optional use of TTS to read descriptions as a narrator in Lure of the Temptress

Added an option to use TTS to read descriptions in Lure of the Temptress.
Following the discussion in #1953, this option will only appear if the user
compiles with TTS support. It will read scene and object descriptions but
omit any character dialog.