### PR TITLE
WINTERMUTE: Fix backspace handling on text input

### DIFF
--- a/engines/wintermute/base/base_keyboard_state.cpp
+++ b/engines/wintermute/base/base_keyboard_state.cpp
@@ -26,6 +26,7 @@
  * Copyright (c) 2011 Jan Nedoma
  */
 
+#include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/base/base_keyboard_state.h"
 #include "engines/wintermute/base/scriptables/script_value.h"
 #include "engines/wintermute/base/scriptables/script_stack.h"
@@ -227,7 +228,7 @@ bool BaseKeyboardState::readKey(Common::Event *event) {
 
 	// use ASCII value if key pressed is an alphanumeric or punctuation key
 	// keys pressed on numpad are handled in next 2 blocks
-	else if (code > Common::KEYCODE_SPACE && code < Common::KEYCODE_DELETE) {
+	else if (code >= Common::KEYCODE_SPACE && code < Common::KEYCODE_DELETE) {
 		_currentCharCode = event->kbd.ascii;
 		_currentPrintable = true;
 	}
@@ -246,18 +247,22 @@ bool BaseKeyboardState::readKey(Common::Event *event) {
 	}
 
 	// use keyCodeToVKey mapping for all other events
-	// some keys are printable from those keys
-	else {
+	// in WME 1.x some of those keys are printable
+	else if (BaseEngine::instance().getTargetExecutable() < WME_LITE) {
 		_currentCharCode = keyCodeToVKey(event);
 		_currentPrintable = code == Common::KEYCODE_BACKSPACE || 
-		                    code == Common::KEYCODE_TAB || 
-		                    code == Common::KEYCODE_RETURN || 
-		                    code == Common::KEYCODE_KP_ENTER || 
-		                    code == Common::KEYCODE_ESCAPE || 
-		                    code == Common::KEYCODE_SPACE;
+							code == Common::KEYCODE_TAB || 
+							code == Common::KEYCODE_RETURN || 
+							code == Common::KEYCODE_KP_ENTER || 
+							code == Common::KEYCODE_ESCAPE;
 	}
 
-	//_currentKeyData = KeyData;
+	// use keyCodeToVKey mapping for all other events
+	// in WME_LITE all of those key are not printable
+	else {
+		_currentCharCode = keyCodeToVKey(event);
+		_currentPrintable = false;
+	}
 
 	_currentControl = isControlDown();
 	_currentAlt     = isAltDown();
@@ -417,8 +422,6 @@ uint32 BaseKeyboardState::keyCodeToVKey(Common::Event *event) {
 		return kVkCapital;
 	case Common::KEYCODE_ESCAPE:
 		return kVkEscape;
-	case Common::KEYCODE_SPACE:
-		return kVkSpace;
 	case Common::KEYCODE_KP9:
 	case Common::KEYCODE_PAGEUP:
 		return kVkPrior;

--- a/engines/wintermute/ui/ui_edit.cpp
+++ b/engines/wintermute/ui/ui_edit.cpp
@@ -740,116 +740,93 @@ bool UIEdit::display(int offsetX, int offsetY) {
 
 //////////////////////////////////////////////////////////////////////////
 bool UIEdit::handleKeypress(Common::Event *event, bool printable) {
-	bool handled = false;
+	if (event->type != Common::EVENT_KEYDOWN) {
+		return false;
+	}
 
-	if (event->type == Common::EVENT_KEYDOWN && !printable) {
-		switch (event->kbd.keycode) {
-		case Common::KEYCODE_ESCAPE:
-		case Common::KEYCODE_TAB:
-		case Common::KEYCODE_RETURN:
-			return false;
+	switch (event->kbd.keycode) {
 
-			// ctrl+A
-		case Common::KEYCODE_a:
-			if (BaseKeyboardState::isControlDown()) {
-				_selStart = 0;
-				_selEnd = strlen(_text);
-				handled = true;
-			}
-			break;
+	// Those keys are 'printable' in WME 1.x, let's ignore them
+	case Common::KEYCODE_ESCAPE:
+	case Common::KEYCODE_TAB:
+	case Common::KEYCODE_KP_ENTER:
+	case Common::KEYCODE_RETURN:
+		return false;
 
-		case Common::KEYCODE_BACKSPACE:
-			if (_selStart == _selEnd) {
-				if (_gameRef->_textRTL) {
-					deleteChars(_selStart, _selStart + 1);
-				} else {
-					deleteChars(_selStart - 1, _selStart);
-				}
-			} else {
-				deleteChars(_selStart, _selEnd);
-			}
-			if (_selEnd >= _selStart) {
-				_selEnd -= MAX<int32>(1, _selEnd - _selStart);
-			}
-			_selStart = _selEnd;
-
-			handled = true;
-			break;
-
-		case Common::KEYCODE_LEFT:
-		case Common::KEYCODE_UP:
+	// Movement keys are controlling _selEnd and _selStart
+	case Common::KEYCODE_HOME:
+	case Common::KEYCODE_END:
+	case Common::KEYCODE_LEFT:
+	case Common::KEYCODE_UP:
+	case Common::KEYCODE_RIGHT:
+	case Common::KEYCODE_DOWN:
+		if (event->kbd.keycode == Common::KEYCODE_HOME) {
+			_selEnd = _gameRef->_textRTL ? strlen(_text) : 0;
+		} else if (event->kbd.keycode == Common::KEYCODE_END) {
+			_selEnd = _gameRef->_textRTL ? 0 : strlen(_text);
+		} else if (event->kbd.keycode == Common::KEYCODE_LEFT ||
+				   event->kbd.keycode == Common::KEYCODE_UP) {
 			_selEnd--;
-			if (!BaseKeyboardState::isShiftDown()) {
-				_selStart = _selEnd;
-			}
-			handled = true;
-			break;
-
-		case Common::KEYCODE_RIGHT:
-		case Common::KEYCODE_DOWN:
+		} else {
 			_selEnd++;
-			if (!BaseKeyboardState::isShiftDown()) {
-				_selStart = _selEnd;
-			}
-			handled = true;
-			break;
-
-		case Common::KEYCODE_HOME:
-			if (_gameRef->_textRTL) {
-				_selEnd = strlen(_text);
-				if (!BaseKeyboardState::isShiftDown()) {
-					_selStart = _selEnd;
-				}
-			} else {
-				_selEnd = 0;
-				if (!BaseKeyboardState::isShiftDown()) {
-					_selStart = _selEnd;
-				}
-			}
-			handled = true;
-			break;
-
-		case Common::KEYCODE_END:
-			if (_gameRef->_textRTL) {
-				_selEnd = 0;
-				if (!BaseKeyboardState::isShiftDown()) {
-					_selStart = _selEnd;
-				}
-			} else {
-				_selEnd = strlen(_text);
-				if (!BaseKeyboardState::isShiftDown()) {
-					_selStart = _selEnd;
-				}
-			}
-			handled = true;
-			break;
-
-		case Common::KEYCODE_DELETE:
-			if (_selStart == _selEnd) {
-				if (_gameRef->_textRTL) {
-					deleteChars(_selStart - 1, _selStart);
-					_selEnd--;
-					if (_selEnd < 0) {
-						_selEnd = 0;
-					}
-				} else {
-					deleteChars(_selStart, _selStart + 1);
-				}
-			} else {
-				deleteChars(_selStart, _selEnd);
-			}
-			if (_selEnd > _selStart) {
-				_selEnd -= (_selEnd - _selStart);
-			}
-
-			_selStart = _selEnd;
-			handled = true;
-			break;
-		default:
-			break;
 		}
-		return handled;
-	} else if (event->type == Common::EVENT_KEYDOWN && printable) {
+			
+		if (!BaseKeyboardState::isShiftDown()) {
+			_selStart = _selEnd;
+		}
+		return true;
+
+	// Delete right
+	case Common::KEYCODE_DELETE:
+		if (_selStart == _selEnd) {
+			if (_gameRef->_textRTL) {
+				deleteChars(_selStart - 1, _selStart);
+				_selEnd--;
+				if (_selEnd < 0) {
+					_selEnd = 0;
+				}
+			} else {
+				deleteChars(_selStart, _selStart + 1);
+			}
+		} else {
+			deleteChars(_selStart, _selEnd);
+		}
+		if (_selEnd > _selStart) {
+			_selEnd -= (_selEnd - _selStart);
+		}
+		_selStart = _selEnd;
+		return true;
+
+	// Delete left
+	case Common::KEYCODE_BACKSPACE:
+		if (_selStart == _selEnd) {
+			if (_gameRef->_textRTL) {
+				deleteChars(_selStart, _selStart + 1);
+			} else {
+				deleteChars(_selStart - 1, _selStart);
+			}
+		} else {
+			deleteChars(_selStart, _selEnd);
+		}
+		if (_selEnd >= _selStart) {
+			_selEnd -= MAX<int32>(1, _selEnd - _selStart);
+		}
+		_selStart = _selEnd;
+		return true;
+
+	default:
+		break;
+	}
+
+	// Ctrl+A = Select All
+	if (BaseKeyboardState::isControlDown() && event->kbd.keycode == Common::KEYCODE_a) {
+		_selStart = 0;
+		_selEnd = strlen(_text);
+		return true;
+	}
+
+	// Those are actually printable characters
+	else if (printable) {
 		if (_selStart != _selEnd) {
 			deleteChars(_selStart, _selEnd);
 		}


### PR DESCRIPTION
WINTERMUTE: Refactor UIEdit::handleKeypress()

This fixes https://bugs.scummvm.org/ticket/11033

Removed checking printable property for system keys.
Refactored whole function to make it a bit more readable.

Reference implementations:
https://github.com/retrowork/wmelite/blob/master/src/UIEdit.cpp#L724
https://github.com/retrowork/Wintermute-Engine/blob/master/src/engine_core/wme_base/UIEdit.cpp#L708

WINTERMUTE: Handle isCurrentPrintable property for WME 1.x and WME Lite

Moved KEYCODE_SPACE to "alphanumeric or punctuation" group.
Splited "else" into before and after WME_LITE.