### PR TITLE
GRAPHICS: When compiling for 3DS, use RGBA8 ColorMask instead of ARGB8

### DIFF
--- a/graphics/colormasks.h
+++ b/graphics/colormasks.h
@@ -276,10 +276,17 @@ struct ColorMasks<8888> {
 		kGreenBits  = 8,
 		kBlueBits   = 8,
 
+#ifdef __3DS__ // 3DS uses RGBA8 rather than ARGB8
+		kAlphaShift = 0,
+		kRedShift   = kGreenBits+kBlueBits+kAlphaBits,
+		kGreenShift = kBlueBits+kAlphaBits,
+		kBlueShift  = kAlphaBits,
+#else
 		kAlphaShift = kRedBits+kGreenBits+kBlueBits,
 		kRedShift   = kGreenBits+kBlueBits,
 		kGreenShift = kBlueBits,
 		kBlueShift  = 0,
+#endif
 
 		kAlphaMask = ((1 << kAlphaBits) - 1) << kAlphaShift,
 		kRedMask   = ((1 << kRedBits) - 1) << kRedShift,


### PR DESCRIPTION
Because the 3DS hardware supports RGBA8 textures but not ARGB8 textures, adjust colormasks.h accordingly at compile time.

Source: [libctru documentation](https://smealum.github.io/ctrulib/enums_8h.html#a63bb2f7fceb0f356549f0be235a0f99f).