### PR TITLE
SCUMM: use reliable types in fake bidi

### DIFF
--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1214,7 +1214,7 @@ protected:
 	virtual void CHARSET_1();
 	bool newLine();
 	void drawString(int a, const byte *msg);
-	void fakeBidiString(char *ltext, bool ignoreVerb);
+	void fakeBidiString(byte *ltext, bool ignoreVerb);
 	void debugMessage(const byte *msg);
 	void showMessageDialog(const byte *msg);
 

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -503,7 +503,7 @@ void ScummEngine::fakeBidiString(byte *ltext, bool ignoreVerb) {
 			// Reverse string on current line (between start and ipos).
 			int32 sthead = 0;
 			byte last = 0;
-			for (int j = 0; j < ipos; j++) {
+			for (int32 j = 0; j < ipos; j++) {
 				byte *curr = text + start + ipos - j - 1;
 				// Special cases to preserve original ordering (numbers).
 				if (Common::isDigit(*curr) ||


### PR DESCRIPTION
Fix fake BiDi (from #1989 ) issues with systems in which char is unsigned by default (e.g. Android).
By using types explicitly defined by ScummVM.