### PR TITLE
COMMON: Refactor the Windows resource classes.

### DIFF
--- a/common/winexe.cpp
+++ b/common/winexe.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include "common/file.h"
+#include "common/memstream.h"
 #include "common/str.h"
 #include "common/winexe.h"
 
@@ -76,6 +78,86 @@ String WinResourceID::toString() const {
 		return String::format("0x%08x", _id);
 
 	return "";
+}
+
+bool WinResources::loadFromEXE(const String &fileName) {
+	if (fileName.empty())
+		return false;
+
+	File *file = new File();
+
+	if (!file->open(fileName)) {
+		delete file;
+		return false;
+	}
+
+	return loadFromEXE(file);
+}
+
+bool WinResources::loadFromCompressedEXE(const String &fileName) {
+	// Based on http://www.cabextract.org.uk/libmspack/doc/szdd_kwaj_format.html
+
+	// TODO: Merge this with with loadFromEXE() so the handling of the compressed
+	// EXE's is transparent
+
+	File file;
+
+	if (!file.open(fileName))
+		return false;
+
+	// First part of the signature
+	if (file.readUint32BE() != MKTAG('S','Z','D','D'))
+		return false;
+
+	// Second part of the signature
+	if (file.readUint32BE() != 0x88F02733)
+		return false;
+
+	// Compression mode must be 'A'
+	if (file.readByte() != 'A')
+		return false;
+
+	file.readByte(); // file name character change
+	uint32 unpackedLength = file.readUint32LE();
+
+	byte *window = new byte[0x1000];
+	int pos = 0x1000 - 16;
+	memset(window, 0x20, 0x1000); // Initialize to all spaces
+
+	byte *unpackedData = (byte *)malloc(unpackedLength);
+	assert(unpackedData);
+	byte *dataPos = unpackedData;
+
+	// Apply simple LZSS decompression
+	for (;;) {
+		byte controlByte = file.readByte();
+
+		if (file.eos())
+			break;
+
+		for (byte i = 0; i < 8; i++) {
+			if (controlByte & (1 << i)) {
+				*dataPos++ = window[pos++] = file.readByte();
+				pos &= 0xFFF;
+			} else {
+				int matchPos = file.readByte();
+				int matchLen = file.readByte();
+				matchPos |= (matchLen & 0xF0) << 4;
+				matchLen = (matchLen & 0xF) + 3;
+				while (matchLen--) {
+					*dataPos++ = window[pos++] = window[matchPos++];
+					pos &= 0xFFF;
+					matchPos &= 0xFFF;
+				}
+			}
+
+		}
+	}
+
+	delete[] window;
+	SeekableReadStream *stream = new MemoryReadStream(unpackedData, unpackedLength);
+
+	return loadFromEXE(stream);
 }
 
 } // End of namespace Common

--- a/common/winexe.cpp
+++ b/common/winexe.cpp
@@ -24,6 +24,8 @@
 #include "common/memstream.h"
 #include "common/str.h"
 #include "common/winexe.h"
+#include "common/winexe_ne.h"
+#include "common/winexe_pe.h"
 
 namespace Common {
 
@@ -158,6 +160,27 @@ bool WinResources::loadFromCompressedEXE(const String &fileName) {
 	SeekableReadStream *stream = new MemoryReadStream(unpackedData, unpackedLength);
 
 	return loadFromEXE(stream);
+}
+
+
+WinResources *WinResources::createFromEXE(const String &fileName) {
+	WinResources *exe;
+
+	// First try loading via the NE code
+	exe = new Common::NEResources();
+	if (exe->loadFromEXE(fileName)) {
+		return exe;
+	}
+	delete exe;
+
+	// Then try loading via the PE code
+	exe = new Common::PEResources();
+	if (exe->loadFromEXE(fileName)) {
+		return exe;
+	}
+	delete exe;
+
+	return nullptr;
 }
 
 } // End of namespace Common

--- a/common/winexe.h
+++ b/common/winexe.h
@@ -128,6 +128,8 @@ public:
 	virtual SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang) {
 		return getResource(type, id);
 	}
+
+	static WinResources *createFromEXE(const String &fileName);
 };
 
 } // End of namespace Common

--- a/common/winexe.h
+++ b/common/winexe.h
@@ -28,6 +28,8 @@
 
 namespace Common {
 
+class SeekableReadStream;
+
 /** The default Windows resources. */
 enum WinResourceType {
 	kWinCursor       = 0x01,
@@ -88,6 +90,44 @@ struct WinResourceID_Hash {
 
 struct WinResourceID_EqualTo {
 	bool operator()(const WinResourceID &id1, const WinResourceID &id2) const { return id1 == id2; }
+};
+
+/**
+ * A class able to load resources from a Windows Executable, such
+ * as cursors, bitmaps, and sounds.
+ */
+class WinResources {
+public:
+	virtual ~WinResources() {};
+
+	/** Clear all information. */
+	virtual void clear() = 0;
+
+	/** Load from an EXE file. */
+	virtual bool loadFromEXE(const String &fileName);
+
+	/** Load from a Windows compressed EXE file. */
+	virtual bool loadFromCompressedEXE(const String &fileName);
+
+	/** Load from a stream. */
+	virtual bool loadFromEXE(SeekableReadStream *stream) = 0;
+
+	/** Return a list of IDs for a given type. */
+	virtual const Array<WinResourceID> getIDList(const WinResourceID &type) const = 0;
+
+	/** Return a list of languages for a given type and ID. */
+	virtual const Array<WinResourceID> getLangList(const WinResourceID &type, const WinResourceID &id) const {
+		Array<WinResourceID> array;
+		return array;
+	}
+
+	/** Return a stream to the specified resource, taking the first language found (or 0 if non-existent). */
+	virtual SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id) = 0;
+
+	/** Return a stream to the specified resource (or 0 if non-existent). */
+	virtual SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang) {
+		return getResource(type, id);
+	}
 };
 
 } // End of namespace Common

--- a/common/winexe_ne.cpp
+++ b/common/winexe_ne.cpp
@@ -21,8 +21,6 @@
  */
 
 #include "common/debug.h"
-#include "common/file.h"
-#include "common/memstream.h"
 #include "common/str.h"
 #include "common/stream.h"
 #include "common/winexe_ne.h"
@@ -46,20 +44,6 @@ void NEResources::clear() {
 	_resources.clear();
 }
 
-bool NEResources::loadFromEXE(const String &fileName) {
-	if (fileName.empty())
-		return false;
-
-	File *file = new File();
-
-	if (!file->open(fileName)) {
-		delete file;
-		return false;
-	}
-
-	return loadFromEXE(file);
-}
-
 bool NEResources::loadFromEXE(SeekableReadStream *stream) {
 	clear();
 
@@ -78,72 +62,6 @@ bool NEResources::loadFromEXE(SeekableReadStream *stream) {
 		return false;
 
 	return true;
-}
-
-bool NEResources::loadFromCompressedEXE(const String &fileName) {
-	// Based on http://www.cabextract.org.uk/libmspack/doc/szdd_kwaj_format.html
-
-	// TODO: Merge this with with loadFromEXE() so the handling of the compressed
-	// EXE's is transparent
-
-	File file;
-
-	if (!file.open(fileName))
-		return false;
-
-	// First part of the signature
-	if (file.readUint32BE() != MKTAG('S','Z','D','D'))
-		return false;
-
-	// Second part of the signature
-	if (file.readUint32BE() != 0x88F02733)
-		return false;
-
-	// Compression mode must be 'A'
-	if (file.readByte() != 'A')
-		return false;
-
-	file.readByte(); // file name character change
-	uint32 unpackedLength = file.readUint32LE();
-
-	byte *window = new byte[0x1000];
-	int pos = 0x1000 - 16;
-	memset(window, 0x20, 0x1000); // Initialize to all spaces
-
-	byte *unpackedData = (byte *)malloc(unpackedLength);
-	assert(unpackedData);
-	byte *dataPos = unpackedData;
-
-	// Apply simple LZSS decompression
-	for (;;) {
-		byte controlByte = file.readByte();
-
-		if (file.eos())
-			break;
-
-		for (byte i = 0; i < 8; i++) {
-			if (controlByte & (1 << i)) {
-				*dataPos++ = window[pos++] = file.readByte();
-				pos &= 0xFFF;
-			} else {
-				int matchPos = file.readByte();
-				int matchLen = file.readByte();
-				matchPos |= (matchLen & 0xF0) << 4;
-				matchLen = (matchLen & 0xF) + 3;
-				while (matchLen--) {
-					*dataPos++ = window[pos++] = window[matchPos++];
-					pos &= 0xFFF;
-					matchPos &= 0xFFF;
-				}
-			}
-
-		}
-	}
-
-	delete[] window;
-	SeekableReadStream *stream = new MemoryReadStream(unpackedData, unpackedLength);
-
-	return loadFromEXE(stream);
 }
 
 uint32 NEResources::getResourceTableOffset() {

--- a/common/winexe_ne.h
+++ b/common/winexe_ne.h
@@ -38,7 +38,7 @@ class SeekableReadStream;
  *
  * See http://en.wikipedia.org/wiki/New_Executable for more info.
  */
-class NEResources {
+class NEResources : public WinResources {
 public:
 	NEResources();
 	~NEResources();
@@ -47,10 +47,7 @@ public:
 	void clear();
 
 	/** Load from an EXE file. */
-	bool loadFromEXE(const String &fileName);
-
-	/** Load from a Windows compressed EXE file. */
-	bool loadFromCompressedEXE(const String &fileName);
+	using WinResources::loadFromEXE;
 
 	/** Load from a stream. */
 	bool loadFromEXE(SeekableReadStream *stream);

--- a/common/winexe_pe.cpp
+++ b/common/winexe_pe.cpp
@@ -23,7 +23,6 @@
 #include "common/array.h"
 #include "common/debug.h"
 #include "common/endian.h"
-#include "common/file.h"
 #include "common/str.h"
 #include "common/stream.h"
 #include "common/winexe_pe.h"
@@ -42,20 +41,6 @@ void PEResources::clear() {
 	_sections.clear();
 	_resources.clear();
 	delete _exe; _exe = nullptr;
-}
-
-bool PEResources::loadFromEXE(const String &fileName) {
-	if (fileName.empty())
-		return false;
-
-	File *file = new File();
-
-	if (!file->open(fileName)) {
-		delete file;
-		return false;
-	}
-
-	return loadFromEXE(file);
 }
 
 bool PEResources::loadFromEXE(SeekableReadStream *stream) {

--- a/common/winexe_pe.cpp
+++ b/common/winexe_pe.cpp
@@ -151,7 +151,7 @@ void PEResources::parseResourceLevel(Section &section, uint32 offset, int level)
 		if (level == 0)
 			_curType = id;
 		else if (level == 1)
-			_curName = id;
+			_curID = id;
 		else if (level == 2)
 			_curLang = id;
 
@@ -166,9 +166,9 @@ void PEResources::parseResourceLevel(Section &section, uint32 offset, int level)
 			resource.size = _exe->readUint32LE();
 
 			debug(4, "Found resource '%s' '%s' '%s' at %d of size %d", _curType.toString().c_str(),
-					_curName.toString().c_str(), _curLang.toString().c_str(), resource.offset, resource.size);
+					_curID.toString().c_str(), _curLang.toString().c_str(), resource.offset, resource.size);
 
-			_resources[_curType][_curName][_curLang] = resource;
+			_resources[_curType][_curID][_curLang] = resource;
 		}
 
 		_exe->seek(lastOffset);
@@ -187,32 +187,32 @@ const Array<WinResourceID> PEResources::getTypeList() const {
 	return array;
 }
 
-const Array<WinResourceID> PEResources::getNameList(const WinResourceID &type) const {
+const Array<WinResourceID> PEResources::getIDList(const WinResourceID &type) const {
 	Array<WinResourceID> array;
 
 	if (!_exe || !_resources.contains(type))
 		return array;
 
-	const NameMap &nameMap = _resources[type];
+	const IDMap &idMap = _resources[type];
 
-	for (NameMap::const_iterator it = nameMap.begin(); it != nameMap.end(); it++)
+	for (IDMap::const_iterator it = idMap.begin(); it != idMap.end(); it++)
 		array.push_back(it->_key);
 
 	return array;
 }
 
-const Array<WinResourceID> PEResources::getLangList(const WinResourceID &type, const WinResourceID &name) const {
+const Array<WinResourceID> PEResources::getLangList(const WinResourceID &type, const WinResourceID &id) const {
 	Array<WinResourceID> array;
 
 	if (!_exe || !_resources.contains(type))
 		return array;
 
-	const NameMap &nameMap = _resources[type];
+	const IDMap &idMap = _resources[type];
 
-	if (!nameMap.contains(name))
+	if (!idMap.contains(id))
 		return array;
 
-	const LangMap &langMap = nameMap[name];
+	const LangMap &langMap = idMap[id];
 
 	for (LangMap::const_iterator it = langMap.begin(); it != langMap.end(); it++)
 		array.push_back(it->_key);
@@ -220,27 +220,27 @@ const Array<WinResourceID> PEResources::getLangList(const WinResourceID &type, c
 	return array;
 }
 
-SeekableReadStream *PEResources::getResource(const WinResourceID &type, const WinResourceID &name) {
-	Array<WinResourceID> langList = getLangList(type, name);
+SeekableReadStream *PEResources::getResource(const WinResourceID &type, const WinResourceID &id) {
+	Array<WinResourceID> langList = getLangList(type, id);
 
 	if (langList.empty())
 		return nullptr;
 
-	const Resource &resource = _resources[type][name][langList[0]];
+	const Resource &resource = _resources[type][id][langList[0]];
 	_exe->seek(resource.offset);
 	return _exe->readStream(resource.size);
 }
 
-SeekableReadStream *PEResources::getResource(const WinResourceID &type, const WinResourceID &name, const WinResourceID &lang) {
+SeekableReadStream *PEResources::getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang) {
 	if (!_exe || !_resources.contains(type))
 		return nullptr;
 
-	const NameMap &nameMap = _resources[type];
+	const IDMap &idMap = _resources[type];
 
-	if (!nameMap.contains(name))
+	if (!idMap.contains(id))
 		return nullptr;
 
-	const LangMap &langMap = nameMap[name];
+	const LangMap &langMap = idMap[id];
 
 	if (!langMap.contains(lang))
 		return nullptr;

--- a/common/winexe_pe.h
+++ b/common/winexe_pe.h
@@ -37,7 +37,7 @@ class SeekableReadStream;
  * A class able to load resources from a Windows Portable Executable, such
  * as cursors, bitmaps, and sounds.
  */
-class PEResources {
+class PEResources : public WinResources {
 public:
 	PEResources();
 	~PEResources();
@@ -46,7 +46,7 @@ public:
 	void clear();
 
 	/** Load from an EXE file. */
-	bool loadFromEXE(const String &fileName);
+	using WinResources::loadFromEXE;
 
 	/** Load from a stream. */
 	bool loadFromEXE(SeekableReadStream *stream);

--- a/common/winexe_pe.h
+++ b/common/winexe_pe.h
@@ -54,17 +54,17 @@ public:
 	/** Return a list of resource types. */
 	const Array<WinResourceID> getTypeList() const;
 
-	/** Return a list of names for a given type. */
-	const Array<WinResourceID> getNameList(const WinResourceID &type) const;
+	/** Return a list of IDs for a given type. */
+	const Array<WinResourceID> getIDList(const WinResourceID &type) const;
 
-	/** Return a list of languages for a given type and name. */
-	const Array<WinResourceID> getLangList(const WinResourceID &type, const WinResourceID &name) const;
+	/** Return a list of languages for a given type and ID. */
+	const Array<WinResourceID> getLangList(const WinResourceID &type, const WinResourceID &id) const;
 
 	/** Return a stream to the specified resource, taking the first language found (or 0 if non-existent). */
-	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &name);
+	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id);
 
 	/** Return a stream to the specified resource (or 0 if non-existent). */
-	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &name, const WinResourceID &lang);
+	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang);
 
 private:
 	struct Section {
@@ -78,7 +78,7 @@ private:
 	SeekableReadStream *_exe;
 
 	void parseResourceLevel(Section &section, uint32 offset, int level);
-	WinResourceID _curType, _curName, _curLang;
+	WinResourceID _curType, _curID, _curLang;
 
 	struct Resource {
 		uint32 offset;
@@ -86,8 +86,8 @@ private:
 	};
 
 	typedef HashMap<WinResourceID, Resource, WinResourceID_Hash, WinResourceID_EqualTo> LangMap;
-	typedef HashMap<WinResourceID,  LangMap, WinResourceID_Hash, WinResourceID_EqualTo> NameMap;
-	typedef HashMap<WinResourceID,  NameMap, WinResourceID_Hash, WinResourceID_EqualTo> TypeMap;
+	typedef HashMap<WinResourceID,  LangMap, WinResourceID_Hash, WinResourceID_EqualTo> IDMap;
+	typedef HashMap<WinResourceID,    IDMap, WinResourceID_Hash, WinResourceID_EqualTo> TypeMap;
 
 	TypeMap _resources;
 };

--- a/devtools/create_titanic/winexe.cpp
+++ b/devtools/create_titanic/winexe.cpp
@@ -80,4 +80,18 @@ String WinResourceID::toString() const {
 	return "";
 }
 
+bool WinResources::loadFromEXE(const String &fileName) {
+	if (fileName.empty())
+		return false;
+
+	File *file = new File();
+
+	if (!file->open(fileName.c_str())) {
+		delete file;
+		return false;
+	}
+
+	return loadFromEXE(file);
+}
+
 } // End of namespace Common

--- a/devtools/create_titanic/winexe.h
+++ b/devtools/create_titanic/winexe.h
@@ -23,6 +23,7 @@
 #ifndef COMMON_WINEXE_H
 #define COMMON_WINEXE_H
 
+#include "file.h"
 #include "hash-str.h"
 #include "str.h"
 
@@ -88,6 +89,40 @@ struct WinResourceID_Hash {
 
 struct WinResourceID_EqualTo {
 	bool operator()(const WinResourceID &id1, const WinResourceID &id2) const { return id1 == id2; }
+};
+
+/**
+ * A class able to load resources from a Windows Executable, such
+ * as cursors, bitmaps, and sounds.
+ */
+class WinResources {
+public:
+	virtual ~WinResources() {}
+
+	/** Clear all information. */
+	virtual void clear() = 0;
+
+	/** Load from an EXE file. */
+	virtual bool loadFromEXE(const String &fileName);
+
+	virtual bool loadFromEXE(File *stream) = 0;
+
+	/** Return a list of IDs for a given type. */
+	virtual const Array<WinResourceID> getIDList(const WinResourceID &type) const = 0;
+
+	/** Return a list of languages for a given type and ID. */
+	virtual const Array<WinResourceID> getLangList(const WinResourceID &type, const WinResourceID &id) const {
+		Array<WinResourceID> array;
+		return array;
+	};
+
+	/** Return a stream to the specified resource, taking the first language found (or 0 if non-existent). */
+	virtual File *getResource(const WinResourceID &type, const WinResourceID &id) = 0;
+
+	/** Return a stream to the specified resource (or 0 if non-existent). */
+	virtual File *getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang) {
+		return getResource(type, id);
+	}
 };
 
 } // End of namespace Common

--- a/devtools/create_titanic/winexe_pe.cpp
+++ b/devtools/create_titanic/winexe_pe.cpp
@@ -44,20 +44,6 @@ void PEResources::clear() {
 	delete _exe; _exe = 0;
 }
 
-bool PEResources::loadFromEXE(const String &fileName) {
-	if (fileName.empty())
-		return false;
-
-	File *file = new File();
-
-	if (!file->open(fileName.c_str())) {
-		delete file;
-		return false;
-	}
-
-	return loadFromEXE(file);
-}
-
 bool PEResources::loadFromEXE(File *stream) {
 	clear();
 

--- a/devtools/create_titanic/winexe_pe.cpp
+++ b/devtools/create_titanic/winexe_pe.cpp
@@ -151,7 +151,7 @@ void PEResources::parseResourceLevel(Section &section, uint32 offset, int level)
 		if (level == 0)
 			_curType = id;
 		else if (level == 1)
-			_curName = id;
+			_curID = id;
 		else if (level == 2)
 			_curLang = id;
 
@@ -165,7 +165,7 @@ void PEResources::parseResourceLevel(Section &section, uint32 offset, int level)
 			resource.offset = _exe->readUint32LE() + section.offset - section.virtualAddress;
 			resource.size = _exe->readUint32LE();
 
-			_resources[_curType][_curName][_curLang] = resource;
+			_resources[_curType][_curID][_curLang] = resource;
 		}
 
 		_exe->seek(lastOffset);
@@ -184,32 +184,32 @@ const Array<WinResourceID> PEResources::getTypeList() const {
 	return array;
 }
 
-const Array<WinResourceID> PEResources::getNameList(const WinResourceID &type) const {
+const Array<WinResourceID> PEResources::getIDList(const WinResourceID &type) const {
 	Array<WinResourceID> array;
 
 	if (!_exe || !_resources.contains(type))
 		return array;
 
-	const NameMap &nameMap = _resources[type];
+	const IDMap &idMap = _resources[type];
 
-	for (NameMap::const_iterator it = nameMap.begin(); it != nameMap.end(); it++)
+	for (IDMap::const_iterator it = idMap.begin(); it != idMap.end(); it++)
 		array.push_back(it->_key);
 
 	return array;
 }
 
-const Array<WinResourceID> PEResources::getLangList(const WinResourceID &type, const WinResourceID &name) const {
+const Array<WinResourceID> PEResources::getLangList(const WinResourceID &type, const WinResourceID &id) const {
 	Array<WinResourceID> array;
 
 	if (!_exe || !_resources.contains(type))
 		return array;
 
-	const NameMap &nameMap = _resources[type];
+	const IDMap &idMap = _resources[type];
 
-	if (!nameMap.contains(name))
+	if (!idMap.contains(id))
 		return array;
 
-	const LangMap &langMap = nameMap[name];
+	const LangMap &langMap = idMap[id];
 
 	for (LangMap::const_iterator it = langMap.begin(); it != langMap.end(); it++)
 		array.push_back(it->_key);
@@ -217,13 +217,13 @@ const Array<WinResourceID> PEResources::getLangList(const WinResourceID &type, c
 	return array;
 }
 
-File *PEResources::getResource(const WinResourceID &type, const WinResourceID &name) {
-	Array<WinResourceID> langList = getLangList(type, name);
+File *PEResources::getResource(const WinResourceID &type, const WinResourceID &id) {
+	Array<WinResourceID> langList = getLangList(type, id);
 
 	if (langList.empty())
 		return 0;
 
-	const Resource &resource = _resources[type][name][langList[0]];
+	const Resource &resource = _resources[type][id][langList[0]];
 	byte *data = (byte *)malloc(resource.size);
 	_exe->seek(resource.offset);
 	_exe->read(data, resource.size);
@@ -233,16 +233,16 @@ File *PEResources::getResource(const WinResourceID &type, const WinResourceID &n
 	return file;
 }
 
-File *PEResources::getResource(const WinResourceID &type, const WinResourceID &name, const WinResourceID &lang) {
+File *PEResources::getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang) {
 	if (!_exe || !_resources.contains(type))
 		return 0;
 
-	const NameMap &nameMap = _resources[type];
+	const IDMap &idMap = _resources[type];
 
-	if (!nameMap.contains(name))
+	if (!idMap.contains(id))
 		return 0;
 
-	const LangMap &langMap = nameMap[name];
+	const LangMap &langMap = idMap[id];
 
 	if (!langMap.contains(lang))
 		return 0;

--- a/devtools/create_titanic/winexe_pe.h
+++ b/devtools/create_titanic/winexe_pe.h
@@ -54,17 +54,17 @@ public:
 	/** Return a list of resource types. */
 	const Array<WinResourceID> getTypeList() const;
 
-	/** Return a list of names for a given type. */
-	const Array<WinResourceID> getNameList(const WinResourceID &type) const;
+	/** Return a list of IDs for a given type. */
+	const Array<WinResourceID> getIDList(const WinResourceID &type) const;
 
-	/** Return a list of languages for a given type and name. */
-	const Array<WinResourceID> getLangList(const WinResourceID &type, const WinResourceID &name) const;
+	/** Return a list of languages for a given type and ID. */
+	const Array<WinResourceID> getLangList(const WinResourceID &type, const WinResourceID &id) const;
 
 	/** Return a stream to the specified resource, taking the first language found (or 0 if non-existent). */
-	File *getResource(const WinResourceID &type, const WinResourceID &name);
+	File *getResource(const WinResourceID &type, const WinResourceID &id);
 
 	/** Return a stream to the specified resource (or 0 if non-existent). */
-	File *getResource(const WinResourceID &type, const WinResourceID &name, const WinResourceID &lang);
+	File *getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang);
 
 	/** Returns true if the resources is empty */
 	bool empty() const { return _sections.empty(); }
@@ -80,7 +80,7 @@ private:
 	File *_exe;
 
 	void parseResourceLevel(Section &section, uint32 offset, int level);
-	WinResourceID _curType, _curName, _curLang;
+	WinResourceID _curType, _curID, _curLang;
 
 	struct Resource {
 		uint32 offset;
@@ -88,8 +88,8 @@ private:
 	};
 
 	typedef HashMap<WinResourceID, Resource, WinResourceID_Hash, WinResourceID_EqualTo> LangMap;
-	typedef HashMap<WinResourceID,  LangMap, WinResourceID_Hash, WinResourceID_EqualTo> NameMap;
-	typedef HashMap<WinResourceID,  NameMap, WinResourceID_Hash, WinResourceID_EqualTo> TypeMap;
+	typedef HashMap<WinResourceID,  LangMap, WinResourceID_Hash, WinResourceID_EqualTo> IDMap;
+	typedef HashMap<WinResourceID,    IDMap, WinResourceID_Hash, WinResourceID_EqualTo> TypeMap;
 
 	TypeMap _resources;
 };

--- a/devtools/create_titanic/winexe_pe.h
+++ b/devtools/create_titanic/winexe_pe.h
@@ -38,7 +38,7 @@ class SeekableReadStream;
  * A class able to load resources from a Windows Portable Executable, such
  * as cursors, bitmaps, and sounds.
  */
-class PEResources {
+class PEResources : WinResources {
 public:
 	PEResources();
 	~PEResources();
@@ -47,7 +47,7 @@ public:
 	void clear();
 
 	/** Load from an EXE file. */
-	bool loadFromEXE(const String &fileName);
+	using WinResources::loadFromEXE;
 
 	bool loadFromEXE(File *stream);
 

--- a/engines/bbvs/bbvs.h
+++ b/engines/bbvs/bbvs.h
@@ -32,8 +32,6 @@
 #include "common/str.h"
 #include "common/substream.h"
 #include "common/system.h"
-#include "common/winexe.h"
-#include "common/winexe_pe.h"
 #include "engines/engine.h"
 
 struct ADGameDescription;

--- a/engines/gnap/gnap.cpp
+++ b/engines/gnap/gnap.cpp
@@ -30,6 +30,9 @@
 #include "common/config-manager.h"
 #include "common/debug-channels.h"
 #include "common/timer.h"
+#include "common/winexe_pe.h"
+
+#include "graphics/wincursor.h"
 
 #include "engines/util.h"
 

--- a/engines/gnap/gnap.cpp
+++ b/engines/gnap/gnap.cpp
@@ -544,7 +544,7 @@ void GnapEngine::setVerbCursor(int verbCursor) {
 void GnapEngine::setCursor(int cursorIndex) {
 	if (_cursorIndex != cursorIndex) {
 		const char *cursorName = kCursorNames[cursorIndex];
-		Graphics::WinCursorGroup *cursorGroup = Graphics::WinCursorGroup::createCursorGroup(*_exe, Common::WinResourceID(cursorName));
+		Graphics::WinCursorGroup *cursorGroup = Graphics::WinCursorGroup::createCursorGroup(_exe, Common::WinResourceID(cursorName));
 		if (cursorGroup) {
 			Graphics::Cursor *cursor = cursorGroup->cursors[0].cursor;
 			CursorMan.replaceCursor(cursor);

--- a/engines/gnap/gnap.h
+++ b/engines/gnap/gnap.h
@@ -33,11 +33,8 @@
 #include "common/str.h"
 #include "common/substream.h"
 #include "common/system.h"
-#include "common/winexe.h"
-#include "common/winexe_pe.h"
 #include "engines/engine.h"
 #include "graphics/pixelformat.h"
-#include "graphics/wincursor.h"
 #include "graphics/fontman.h"
 #include "graphics/font.h"
 #include "graphics/fonts/ttf.h"
@@ -49,6 +46,10 @@
 #include "gnap/music.h"
 
 struct ADGameDescription;
+
+namespace Common {
+class PEResources;
+}
 
 namespace Gnap {
 

--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -181,7 +181,7 @@ void Inter_v7::o7_loadCursor() {
 
 	// Load the cursor file and cursor group
 	if (loadCursorFile())
-		cursorGroup = Graphics::WinCursorGroup::createCursorGroup(*_cursors, Common::WinResourceID(cursorName));
+		cursorGroup = Graphics::WinCursorGroup::createCursorGroup(_cursors, Common::WinResourceID(cursorName));
 
 	// If the requested cursor does not exist, create a default one
 	const Graphics::Cursor *cursor = 0;

--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -22,7 +22,6 @@
 
 #include "common/endian.h"
 #include "common/archive.h"
-#include "common/winexe.h"
 #include "common/winexe_pe.h"
 
 #include "graphics/cursorman.h"

--- a/engines/hdb/gfx.cpp
+++ b/engines/hdb/gfx.cpp
@@ -25,7 +25,6 @@
 #include "common/random.h"
 #include "common/memstream.h"
 #include "graphics/cursor.h"
-#include "graphics/wincursor.h"
 #include "graphics/cursorman.h"
 
 #include "hdb/hdb.h"

--- a/engines/illusions/illusions.h
+++ b/engines/illusions/illusions.h
@@ -34,8 +34,6 @@
 #include "common/str.h"
 #include "common/substream.h"
 #include "common/system.h"
-#include "common/winexe.h"
-#include "common/winexe_pe.h"
 #include "engines/engine.h"
 #include "graphics/surface.h"
 

--- a/engines/mohawk/cursors.cpp
+++ b/engines/mohawk/cursors.cpp
@@ -157,7 +157,7 @@ NECursorManager::~NECursorManager() {
 
 void NECursorManager::setCursor(uint16 id) {
 	if (_exe) {
-		Graphics::WinCursorGroup *cursorGroup = Graphics::WinCursorGroup::createCursorGroup(*_exe, id);
+		Graphics::WinCursorGroup *cursorGroup = Graphics::WinCursorGroup::createCursorGroup(_exe, id);
 
 		if (cursorGroup) {
 			Graphics::Cursor *cursor = cursorGroup->cursors[0].cursor;
@@ -253,7 +253,7 @@ PECursorManager::PECursorManager(const Common::String &appName) {
 	_cursors.resize(cursorGroups.size());
 	for (uint i = 0; i < cursorGroups.size(); i++) {
 		_cursors[i].id = cursorGroups[i].getID();
-		_cursors[i].cursorGroup = Graphics::WinCursorGroup::createCursorGroup(*exe, cursorGroups[i]);
+		_cursors[i].cursorGroup = Graphics::WinCursorGroup::createCursorGroup(exe, cursorGroups[i]);
 	}
 
 	delete exe;

--- a/engines/mohawk/cursors.cpp
+++ b/engines/mohawk/cursors.cpp
@@ -248,7 +248,7 @@ PECursorManager::PECursorManager(const Common::String &appName) {
 		return;
 	}
 
-	const Common::Array<Common::WinResourceID> cursorGroups = exe->getNameList(Common::kWinGroupCursor);
+	const Common::Array<Common::WinResourceID> cursorGroups = exe->getIDList(Common::kWinGroupCursor);
 
 	_cursors.resize(cursorGroups.size());
 	for (uint i = 0; i < cursorGroups.size(); i++) {

--- a/engines/mohawk/cursors.cpp
+++ b/engines/mohawk/cursors.cpp
@@ -141,36 +141,6 @@ void MystCursorManager::setDefaultCursor() {
 
 #endif
 
-NECursorManager::NECursorManager(const Common::String &appName) {
-	_exe = new Common::NEResources();
-
-	if (!_exe->loadFromEXE(appName)) {
-		// Not all have cursors anyway, so this is not a problem
-		delete _exe;
-		_exe = nullptr;
-	}
-}
-
-NECursorManager::~NECursorManager() {
-	delete _exe;
-}
-
-void NECursorManager::setCursor(uint16 id) {
-	if (_exe) {
-		Graphics::WinCursorGroup *cursorGroup = Graphics::WinCursorGroup::createCursorGroup(_exe, id);
-
-		if (cursorGroup) {
-			Graphics::Cursor *cursor = cursorGroup->cursors[0].cursor;
-			CursorMan.replaceCursor(cursor);
-			delete cursorGroup;
-			return;
-		}
-	}
-
-	// Last resort (not all have cursors)
-	setDefaultCursor();
-}
-
 MacCursorManager::MacCursorManager(const Common::String &appName) {
 	if (!appName.empty()) {
 		_resFork = new Common::MacResManager();
@@ -241,13 +211,31 @@ void LivingBooksCursorManager_v2::setCursor(const Common::String &name) {
 		setCursor(id);
 }
 
+NECursorManager::NECursorManager(const Common::String &appName) {
+	Common::NEResources *exe = new Common::NEResources();
+	if (exe->loadFromEXE(appName)) {
+		// Not all have cursors anyway, so it's not a problem if this fails
+		loadCursors(exe);
+	}
+	delete exe;
+}
+
 PECursorManager::PECursorManager(const Common::String &appName) {
 	Common::PEResources *exe = new Common::PEResources();
-	if (!exe->loadFromEXE(appName)) {
-		// Not all have cursors anyway, so this is not a problem
-		return;
+	if (exe->loadFromEXE(appName)) {
+		// Not all have cursors anyway, so it's not a problem if this fails
+		loadCursors(exe);
 	}
+	delete exe;
+}
 
+WinCursorManager::~WinCursorManager() {
+	for (uint i = 0; i < _cursors.size(); i++) {
+		delete _cursors[i].cursorGroup;
+	}
+}
+
+void WinCursorManager::loadCursors(Common::WinResources *exe) {
 	const Common::Array<Common::WinResourceID> cursorGroups = exe->getIDList(Common::kWinGroupCursor);
 
 	_cursors.resize(cursorGroups.size());
@@ -255,17 +243,9 @@ PECursorManager::PECursorManager(const Common::String &appName) {
 		_cursors[i].id = cursorGroups[i].getID();
 		_cursors[i].cursorGroup = Graphics::WinCursorGroup::createCursorGroup(exe, cursorGroups[i]);
 	}
-
-	delete exe;
 }
 
-PECursorManager::~PECursorManager() {
-	for (uint i = 0; i < _cursors.size(); i++) {
-		delete _cursors[i].cursorGroup;
-	}
-}
-
-void PECursorManager::setCursor(uint16 id) {
+void WinCursorManager::setCursor(uint16 id) {
 	for (uint i = 0; i < _cursors.size(); i++) {
 		if (_cursors[i].id == id) {
 			Graphics::Cursor *cursor = _cursors[i].cursorGroup->cursors[0].cursor;

--- a/engines/mohawk/cursors.h
+++ b/engines/mohawk/cursors.h
@@ -27,7 +27,7 @@
 
 namespace Common {
 class MacResManager;
-class NEResources;
+class WinResources;
 class SeekableReadStream;
 class String;
 }
@@ -125,19 +125,6 @@ private:
 
 #endif // ENABLE_MYST
 
-// The cursor manager for NE EXE's
-class NECursorManager : public CursorManager {
-public:
-	explicit NECursorManager(const Common::String &appName);
-	~NECursorManager() override;
-
-	void setCursor(uint16 id) override;
-	bool hasSource() const override { return _exe != nullptr; }
-
-private:
-	Common::NEResources *_exe;
-};
-
 // The cursor manager for Mac applications
 class MacCursorManager : public CursorManager {
 public:
@@ -166,14 +153,16 @@ private:
 	MohawkArchive *_sysArchive;
 };
 
-// The cursor manager for PE EXE's
-class PECursorManager : public CursorManager {
+// The cursor manager for Windows EXE's
+class WinCursorManager : public CursorManager {
 public:
-	explicit PECursorManager(const Common::String &appName);
-	~PECursorManager() override;
+	~WinCursorManager() override;
 
 	void setCursor(uint16 id) override;
 	bool hasSource() const override { return !_cursors.empty(); }
+
+protected:
+	void loadCursors(Common::WinResources *exe);
 
 private:
 	struct CursorItem {
@@ -182,6 +171,18 @@ private:
 	};
 
 	Common::Array<CursorItem> _cursors;
+};
+
+// The cursor manager for NE EXE's
+class NECursorManager : public WinCursorManager {
+public:
+	explicit NECursorManager(const Common::String &appName);
+};
+
+// The cursor manager for PE EXE's
+class PECursorManager : public WinCursorManager {
+public:
+	explicit PECursorManager(const Common::String &appName);
 };
 
 } // End of namespace Mohawk

--- a/engines/pink/cursor_mgr.h
+++ b/engines/pink/cursor_mgr.h
@@ -25,8 +25,6 @@
 
 #include "common/rect.h"
 
-#include "graphics/wincursor.h"
-
 #include "pink/objects/object.h"
 
 namespace Pink {

--- a/engines/pink/director.h
+++ b/engines/pink/director.h
@@ -30,10 +30,6 @@
 #include "graphics/macgui/macwindowmanager.h"
 #include "graphics/screen.h"
 
-namespace Common {
-	class PEResources;
-}
-
 namespace Graphics {
 	class MacMenu;
 }

--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -129,7 +129,7 @@ static void menuCommandsCallback(int action, Common::U32String &, void *data) {
 	engine->executeMenuCommand(action);
 }
 
-void PinkEngine::initMenu(Common::PEResources &exeResources) {
+void PinkEngine::initMenu(Common::PEResources *exeResources) {
 	_director->getWndManager().setEnginePauseCallback(this, &pauseEngine);
 
 	_menu = Graphics::MacMenu::createMenuFromPEexe(exeResources, &_director->getWndManager());

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -40,7 +40,7 @@
 namespace Pink {
 
 PinkEngine::PinkEngine(OSystem *system, const ADGameDescription *desc)
-	: Engine(system), _console(nullptr), _rnd("pink"),
+	: Engine(system), _console(nullptr), _rnd("pink"), _exeResources(nullptr),
 	_desc(desc), _bro(nullptr), _menu(nullptr), _actor(nullptr),
 	_module(nullptr), _director(nullptr), _pdaMgr(this) {
 
@@ -56,6 +56,7 @@ PinkEngine::PinkEngine(OSystem *system, const ADGameDescription *desc)
 
 PinkEngine::~PinkEngine() {
 	delete _console;
+	delete _exeResources;
 	delete _bro;
 	_pdaMgr.close();
 	for (uint i = 0; i < _modules.size(); ++i) {
@@ -72,16 +73,16 @@ Common::Error PinkEngine::init() {
 	debugC(10, kPinkDebugGeneral, "PinkEngine init");
 	initGraphics(640, 480);
 
-	Common::PEResources exeResources;
+	_exeResources = new Common::PEResources();
 	Common::String fileName = isPeril() ? "pptp.exe" : "hpp.exe";
-	if (!exeResources.loadFromEXE(fileName)) {
+	if (!_exeResources->loadFromEXE(fileName)) {
 		return Common::kNoGameDataFoundError;
 	}
 
 	_console = new Console(this);
 	_director = new Director();
 
-	initMenu(exeResources);
+	initMenu(_exeResources);
 
 	Common::String orbName;
 	Common::String broName;
@@ -96,7 +97,7 @@ Common::Error PinkEngine::init() {
 	if (!_orb.open(orbName) || (_bro && !_bro->open(broName) && _orb.getTimestamp() == _bro->getTimestamp()))
 		return Common::kNoGameDataFoundError;
 
-	if (!loadCursors(exeResources))
+	if (!loadCursors(_exeResources))
 		return Common::kNoGameDataFoundError;
 
 	setCursor(kLoadingCursor);
@@ -233,7 +234,7 @@ bool PinkEngine::checkValueOfVariable(Common::String &variable, Common::String &
 	return _variables[variable] == value;
 }
 
-bool PinkEngine::loadCursors(Common::PEResources &exeResources) {
+bool PinkEngine::loadCursors(Common::PEResources *exeResources) {
 	bool isPokus = !isPeril();
 
 	_cursors.reserve(kCursorsCount);

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -30,6 +30,7 @@
 #include "graphics/cursorman.h"
 #include "graphics/thumbnail.h"
 #include "graphics/surface.h"
+#include "graphics/wincursor.h"
 
 #include "pink/pink.h"
 #include "pink/console.h"

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -62,6 +62,10 @@
 
 struct ADGameDescription;
 
+namespace Common {
+	class PEResources;
+}
+
 namespace Graphics {
 class MacMenu;
 }
@@ -132,9 +136,9 @@ public:
 private:
 	Common::Error init();
 
-	void initMenu(Common::PEResources &exeResources);
+	void initMenu(Common::PEResources *exeResources);
 
-	bool loadCursors(Common::PEResources &exeResources);
+	bool loadCursors(Common::PEResources *exeResources);
 
 	void initModule(const Common::String &moduleName, const Common::String &pageName, Archive *saveFile);
 	void addModule(const Common::String &moduleName);
@@ -147,6 +151,8 @@ private:
 
 	Common::String _nextModule;
 	Common::String _nextPage;
+
+	Common::PEResources *_exeResources;
 
 	OrbFile  _orb;
 	BroFile *_bro;

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -29,8 +29,6 @@
 #include "engines/engine.h"
 #include "engines/savestate.h"
 
-#include "graphics/wincursor.h"
-
 #include "gui/debugger.h"
 
 #include "pink/constants.h"
@@ -68,6 +66,7 @@ namespace Common {
 
 namespace Graphics {
 class MacMenu;
+class WinCursorGroup;
 }
 
 namespace Pink {

--- a/engines/scumm/he/moonbase/moonbase.cpp
+++ b/engines/scumm/he/moonbase/moonbase.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include "common/winexe_pe.h"
+
 #include "scumm/he/intern_he.h"
 #include "scumm/he/moonbase/moonbase.h"
 #include "scumm/he/moonbase/ai_main.h"

--- a/engines/scumm/he/moonbase/moonbase.cpp
+++ b/engines/scumm/he/moonbase/moonbase.cpp
@@ -30,6 +30,8 @@
 namespace Scumm {
 
 Moonbase::Moonbase(ScummEngine_v100he *vm) : _vm(vm) {
+	_exe = new Common::PEResources();
+
 	initFOW();
 
 	_ai = new AI(_vm);
@@ -39,6 +41,7 @@ Moonbase::Moonbase(ScummEngine_v100he *vm) : _vm(vm) {
 }
 
 Moonbase::~Moonbase() {
+	delete _exe;
 	delete _ai;
 #ifdef USE_LIBCURL
 	delete _net;

--- a/engines/scumm/he/moonbase/moonbase.h
+++ b/engines/scumm/he/moonbase/moonbase.h
@@ -25,7 +25,9 @@
 
 #ifdef ENABLE_HE
 
-#include "common/winexe_pe.h"
+namespace Common {
+class PEResources;
+}
 
 namespace Scumm {
 

--- a/engines/scumm/he/moonbase/moonbase.h
+++ b/engines/scumm/he/moonbase/moonbase.h
@@ -106,7 +106,7 @@ private:
 
 	int32 _fowRenderTable[32768];
 
-	Common::PEResources _exe;
+	Common::PEResources *_exe;
 	Common::String _fileName;
 };
 

--- a/engines/scumm/he/moonbase/moonbase_fow.cpp
+++ b/engines/scumm/he/moonbase/moonbase_fow.cpp
@@ -99,11 +99,11 @@ bool Moonbase::setFOWImage(int image) {
 			if (_fileName.empty()) { // We are running for the first time
 				_fileName = _vm->generateFilename(-3);
 
-				if (!_exe.loadFromEXE(_fileName))
+				if (!_exe->loadFromEXE(_fileName))
 					error("Cannot open file %s", _fileName.c_str());
 			}
 
-			Common::SeekableReadStream *stream = _exe.getResource(Common::kWinRCData, resId);
+			Common::SeekableReadStream *stream = _exe->getResource(Common::kWinRCData, resId);
 
 			if (stream->size()) {
 				_fowImage = (uint8 *)malloc(stream->size());

--- a/engines/scumm/he/moonbase/moonbase_fow.cpp
+++ b/engines/scumm/he/moonbase/moonbase_fow.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "common/config-manager.h"
+#include "common/winexe_pe.h"
 
 #include "scumm/he/intern_he.h"
 #include "scumm/he/moonbase/moonbase.h"

--- a/engines/scumm/he/resource_he.cpp
+++ b/engines/scumm/he/resource_he.cpp
@@ -114,13 +114,18 @@ void ResExtractor::setCursor(int id) {
 
 
 Win32ResExtractor::Win32ResExtractor(ScummEngine_v70he *scumm) : ResExtractor(scumm) {
+	_exe = new Common::PEResources();
+}
+
+Win32ResExtractor::~Win32ResExtractor() {
+	delete _exe;
 }
 
 bool Win32ResExtractor::extractResource(int id, CachedCursor *cc) {
 	if (_fileName.empty()) { // We are running for the first time
 		_fileName = _vm->generateFilename(-3);
 
-		if (!_exe.loadFromEXE(_fileName))
+		if (!_exe->loadFromEXE(_fileName))
 			error("Cannot open file %s", _fileName.c_str());
 	}
 

--- a/engines/scumm/he/resource_he.cpp
+++ b/engines/scumm/he/resource_he.cpp
@@ -35,6 +35,7 @@
 #include "common/archive.h"
 #include "common/memstream.h"
 #include "common/system.h"
+#include "common/winexe_pe.h"
 
 namespace Scumm {
 

--- a/engines/scumm/he/resource_he.h
+++ b/engines/scumm/he/resource_he.h
@@ -68,10 +68,10 @@ private:
 class Win32ResExtractor : public ResExtractor {
 public:
 	Win32ResExtractor(ScummEngine_v70he *scumm);
-	~Win32ResExtractor() {}
+	~Win32ResExtractor();
 
 private:
-	Common::PEResources _exe;
+	Common::PEResources *_exe;
 
 	bool extractResource(int id, CachedCursor *cc);
 };

--- a/engines/scumm/he/resource_he.h
+++ b/engines/scumm/he/resource_he.h
@@ -24,7 +24,10 @@
 #define SCUMM_HE_RESOURCE_HE_H
 
 #include "common/macresman.h"
-#include "common/winexe_pe.h"
+
+namespace Common {
+class PEResources;
+}
 
 namespace Scumm {
 

--- a/engines/titanic/true_talk/title_engine.h
+++ b/engines/titanic/true_talk/title_engine.h
@@ -24,7 +24,6 @@
 #define TITANIC_TITLE_ENGINE_H
 
 #include "common/stream.h"
-#include "common/winexe_pe.h"
 #include "titanic/support/string.h"
 #include "titanic/true_talk/script_handler.h"
 #include "titanic/true_talk/tt_response.h"

--- a/graphics/fonts/winfont.cpp
+++ b/graphics/fonts/winfont.cpp
@@ -86,15 +86,18 @@ bool WinFont::loadFromFON(const Common::String &fileName, const WinFontDirEntry 
 }
 
 bool WinFont::loadFromNE(const Common::String &fileName, const WinFontDirEntry &dirEntry) {
-	Common::NEResources exe;
+	Common::NEResources *exe = new Common::NEResources();
 
-	if (!exe.loadFromEXE(fileName))
+	if (!exe->loadFromEXE(fileName)) {
+		delete exe;
 		return false;
+	}
 
 	// Let's pull out the font directory
-	Common::SeekableReadStream *fontDirectory = exe.getResource(Common::kWinFontDir, Common::String("FONTDIR"));
+	Common::SeekableReadStream *fontDirectory = exe->getResource(Common::kWinFontDir, Common::String("FONTDIR"));
 	if (!fontDirectory) {
 		warning("No font directory in '%s'", fileName.c_str());
+		delete exe;
 		return false;
 	}
 
@@ -105,18 +108,21 @@ bool WinFont::loadFromNE(const Common::String &fileName, const WinFontDirEntry &
 	// Couldn't match the face name
 	if (fontId == 0xffffffff) {
 		warning("Could not find face '%s' in '%s'", dirEntry.faceName.c_str(), fileName.c_str());
+		delete exe;
 		return false;
 	}
 
 	// Actually go get our font now...
-	Common::SeekableReadStream *fontStream = exe.getResource(Common::kWinFont, fontId);
+	Common::SeekableReadStream *fontStream = exe->getResource(Common::kWinFont, fontId);
 	if (!fontStream) {
 		warning("Could not find font %d in %s", fontId, fileName.c_str());
+		delete exe;
 		return false;
 	}
 
 	bool ok = loadFromFNT(*fontStream);
 	delete fontStream;
+	delete exe;
 	return ok;
 }
 

--- a/graphics/fonts/winfont.cpp
+++ b/graphics/fonts/winfont.cpp
@@ -77,27 +77,13 @@ static WinFontDirEntry readDirEntry(Common::SeekableReadStream &stream) {
 }
 
 bool WinFont::loadFromFON(const Common::String &fileName, const WinFontDirEntry &dirEntry) {
-	Common::WinResources *exe;
+	Common::WinResources *exe = Common::WinResources::createFromEXE(fileName);
+	if (!exe)
+		return false;
 
-	// First try loading via the NE code
-	exe = new Common::NEResources();
-	if (exe->loadFromEXE(fileName)) {
-		bool ok = loadFromEXE(exe, fileName, dirEntry);
-		delete exe;
-		return ok;
-	}
+	bool ok = loadFromEXE(exe, fileName, dirEntry);
 	delete exe;
-
-	// Then try loading via the PE code
-	exe = new Common::PEResources();
-	if (exe->loadFromEXE(fileName)) {
-		bool ok = loadFromEXE(exe, fileName, dirEntry);
-		delete exe;
-		return ok;
-	}
-	delete exe;
-
-	return false;
+	return ok;
 }
 
 bool WinFont::loadFromEXE(Common::WinResources *exe, const Common::String &fileName, const WinFontDirEntry &dirEntry) {

--- a/graphics/fonts/winfont.h
+++ b/graphics/fonts/winfont.h
@@ -28,6 +28,7 @@
 
 namespace Common {
 class SeekableReadStream;
+class WinResources;
 }
 
 namespace Graphics {
@@ -67,8 +68,7 @@ public:
 	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
 
 private:
-	bool loadFromPE(const Common::String &fileName, const WinFontDirEntry &dirEntry);
-	bool loadFromNE(const Common::String &fileName, const WinFontDirEntry &dirEntry);
+	bool loadFromEXE(Common::WinResources *exe, const Common::String &fileName, const WinFontDirEntry &dirEntry);
 
 	uint32 getFontIndex(Common::SeekableReadStream &stream, const WinFontDirEntry &dirEntry);
 	bool loadFromFNT(Common::SeekableReadStream &stream);

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -24,6 +24,7 @@
 #include "common/stack.h"
 #include "common/keyboard.h"
 #include "common/macresman.h"
+#include "common/winexe_pe.h"
 
 #include "graphics/primitives.h"
 #include "graphics/font.h"
@@ -200,8 +201,8 @@ static Common::U32String readUnicodeString(Common::SeekableReadStream *stream) {
 }
 
 
-MacMenu *MacMenu::createMenuFromPEexe(Common::PEResources &exe, MacWindowManager *wm) {
-	Common::SeekableReadStream *menuData = exe.getResource(Common::kWinMenu, 128);
+MacMenu *MacMenu::createMenuFromPEexe(Common::PEResources *exe, MacWindowManager *wm) {
+	Common::SeekableReadStream *menuData = exe->getResource(Common::kWinMenu, 128);
 	if (!menuData)
 		return nullptr;
 

--- a/graphics/macgui/macmenu.h
+++ b/graphics/macgui/macmenu.h
@@ -24,11 +24,11 @@
 #define GRAPHICS_MACGUI_MACMENU_H
 
 #include "common/str-array.h"
-#include "common/winexe_pe.h"
 
 namespace Common {
 class U32String;
 class MacResManager;
+class PEResources;
 }
 
 namespace Graphics {
@@ -51,7 +51,7 @@ public:
 	~MacMenu();
 
 	static Common::StringArray *readMenuFromResource(Common::SeekableReadStream *res);
-	static MacMenu *createMenuFromPEexe(Common::PEResources &exe, MacWindowManager *wm);
+	static MacMenu *createMenuFromPEexe(Common::PEResources *exe, MacWindowManager *wm);
 
 	void setCommandsCallback(void (*callback)(int, Common::String &, void *), void *data) { _ccallback = callback; _cdata = data; }
 	void setCommandsCallback(void (*callback)(int, Common::U32String &, void *), void *data) { _unicodeccallback = callback; _cdata = data; }

--- a/graphics/wincursor.cpp
+++ b/graphics/wincursor.cpp
@@ -23,8 +23,6 @@
 #include "common/ptr.h"
 #include "common/stream.h"
 #include "common/textconsole.h"
-#include "common/winexe_ne.h"
-#include "common/winexe_pe.h"
 
 #include "graphics/wincursor.h"
 
@@ -242,63 +240,7 @@ WinCursorGroup::~WinCursorGroup() {
 		delete cursors[i].cursor;
 }
 
-WinCursorGroup *WinCursorGroup::createCursorGroup(Common::NEResources *exe, const Common::WinResourceID &id) {
-	Common::ScopedPtr<Common::SeekableReadStream> stream(exe->getResource(Common::kWinGroupCursor, id));
-
-	if (!stream || stream->size() <= 6)
-		return 0;
-
-	stream->skip(4);
-	uint32 cursorCount = stream->readUint16LE();
-	if ((uint32)stream->size() < (6 + cursorCount * 14))
-		return 0;
-
-	WinCursorGroup *group = new WinCursorGroup();
-	group->cursors.reserve(cursorCount);
-
-	for (uint32 i = 0; i < cursorCount; i++) {
-		stream->readUint16LE(); // width
-		stream->readUint16LE(); // height
-
-		// Plane count
-		if (stream->readUint16LE() != 1) {
-			delete group;
-			return 0;
-		}
-
-		// Bits per pixel
-		// NE cursors can only be 1bpp
-		if (stream->readUint16LE() != 1) {
-			delete group;
-			return 0;
-		}
-
-		stream->readUint32LE(); // data size
-		uint32 cursorId = stream->readUint16LE();
-
-		Common::ScopedPtr<Common::SeekableReadStream> cursorStream(exe->getResource(Common::kWinCursor, cursorId));
-		if (!cursorStream) {
-			delete group;
-			return 0;
-		}
-
-		WinCursor *cursor = new WinCursor();
-		if (!cursor->readFromStream(*cursorStream)) {
-			delete cursor;
-			delete group;
-			return 0;
-		}
-
-		CursorItem item;
-		item.id = cursorId;
-		item.cursor = cursor;
-		group->cursors.push_back(item);
-	}
-
-	return group;
-}
-
-WinCursorGroup *WinCursorGroup::createCursorGroup(Common::PEResources *exe, const Common::WinResourceID &id) {
+WinCursorGroup *WinCursorGroup::createCursorGroup(Common::WinResources *exe, const Common::WinResourceID &id) {
 	Common::ScopedPtr<Common::SeekableReadStream> stream(exe->getResource(Common::kWinGroupCursor, id));
 
 	if (!stream || stream->size() <= 6)

--- a/graphics/wincursor.cpp
+++ b/graphics/wincursor.cpp
@@ -242,8 +242,8 @@ WinCursorGroup::~WinCursorGroup() {
 		delete cursors[i].cursor;
 }
 
-WinCursorGroup *WinCursorGroup::createCursorGroup(Common::NEResources &exe, const Common::WinResourceID &id) {
-	Common::ScopedPtr<Common::SeekableReadStream> stream(exe.getResource(Common::kWinGroupCursor, id));
+WinCursorGroup *WinCursorGroup::createCursorGroup(Common::NEResources *exe, const Common::WinResourceID &id) {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(exe->getResource(Common::kWinGroupCursor, id));
 
 	if (!stream || stream->size() <= 6)
 		return 0;
@@ -276,7 +276,7 @@ WinCursorGroup *WinCursorGroup::createCursorGroup(Common::NEResources &exe, cons
 		stream->readUint32LE(); // data size
 		uint32 cursorId = stream->readUint16LE();
 
-		Common::ScopedPtr<Common::SeekableReadStream> cursorStream(exe.getResource(Common::kWinCursor, cursorId));
+		Common::ScopedPtr<Common::SeekableReadStream> cursorStream(exe->getResource(Common::kWinCursor, cursorId));
 		if (!cursorStream) {
 			delete group;
 			return 0;
@@ -298,8 +298,8 @@ WinCursorGroup *WinCursorGroup::createCursorGroup(Common::NEResources &exe, cons
 	return group;
 }
 
-WinCursorGroup *WinCursorGroup::createCursorGroup(Common::PEResources &exe, const Common::WinResourceID &id) {
-	Common::ScopedPtr<Common::SeekableReadStream> stream(exe.getResource(Common::kWinGroupCursor, id));
+WinCursorGroup *WinCursorGroup::createCursorGroup(Common::PEResources *exe, const Common::WinResourceID &id) {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(exe->getResource(Common::kWinGroupCursor, id));
 
 	if (!stream || stream->size() <= 6)
 		return 0;
@@ -325,7 +325,7 @@ WinCursorGroup *WinCursorGroup::createCursorGroup(Common::PEResources &exe, cons
 		stream->readUint32LE(); // data size
 		uint32 cursorId = stream->readUint16LE();
 
-		Common::ScopedPtr<Common::SeekableReadStream> cursorStream(exe.getResource(Common::kWinCursor, cursorId));
+		Common::ScopedPtr<Common::SeekableReadStream> cursorStream(exe->getResource(Common::kWinCursor, cursorId));
 		if (!cursorStream) {
 			delete group;
 			return 0;

--- a/graphics/wincursor.h
+++ b/graphics/wincursor.h
@@ -29,8 +29,6 @@
 #include "graphics/cursor.h"
 
 namespace Common {
-class NEResources;
-class PEResources;
 class SeekableReadStream;
 }
 
@@ -56,10 +54,8 @@ struct WinCursorGroup {
 
 	Common::Array<CursorItem> cursors;
 
-	/** Create a cursor group from an NE EXE, returns 0 on failure */
-	static WinCursorGroup *createCursorGroup(Common::NEResources *exe, const Common::WinResourceID &id);
-	/** Create a cursor group from an PE EXE, returns 0 on failure */
-	static WinCursorGroup *createCursorGroup(Common::PEResources *exe, const Common::WinResourceID &id);
+	/** Create a cursor group from an EXE, returns 0 on failure */
+	static WinCursorGroup *createCursorGroup(Common::WinResources *exe, const Common::WinResourceID &id);
 };
 
 /**

--- a/graphics/wincursor.h
+++ b/graphics/wincursor.h
@@ -57,9 +57,9 @@ struct WinCursorGroup {
 	Common::Array<CursorItem> cursors;
 
 	/** Create a cursor group from an NE EXE, returns 0 on failure */
-	static WinCursorGroup *createCursorGroup(Common::NEResources &exe, const Common::WinResourceID &id);
+	static WinCursorGroup *createCursorGroup(Common::NEResources *exe, const Common::WinResourceID &id);
 	/** Create a cursor group from an PE EXE, returns 0 on failure */
-	static WinCursorGroup *createCursorGroup(Common::PEResources &exe, const Common::WinResourceID &id);
+	static WinCursorGroup *createCursorGroup(Common::PEResources *exe, const Common::WinResourceID &id);
 };
 
 /**


### PR DESCRIPTION
The main change that this PR makes is that the `NEResources` and `PEResources` classes now have a common base class, which means that a single code path can be used for both 16-bit and 32-bit executables.