### PR TITLE
GRIFFON: Game uses vorbis, not midi, for the music.

### DIFF
--- a/engines/griffon/detection.cpp
+++ b/engines/griffon/detection.cpp
@@ -39,7 +39,7 @@ static const ADGameDescription gameDescriptions[] = {
 		Common::EN_ANY,
 		Common::kPlatformWindows,
 		ADGF_UNSTABLE | ADGF_DROPPLATFORM,
-		GUIO1(GUIO_NONE)
+		GUIO1(GUIO_NOMIDI)
 	},
 
 	AD_TABLE_END_MARKER


### PR DESCRIPTION
Yet another engine that doesn't use MIDI.