### PR TITLE
OPENGL: Implement stretch mode Fit to window (4:3)

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -236,6 +236,7 @@ const OSystem::GraphicsMode glStretchModes[] = {
 	{"pixel-perfect", _s("Pixel-perfect scaling"), STRETCH_INTEGRAL},
 	{"fit", _s("Fit to window"), STRETCH_FIT},
 	{"stretch", _s("Stretch to window"), STRETCH_STRETCH},
+	{"fit_force_aspect", _s("Fit to window (4:3)"), STRETCH_FIT_FORCE_ASPECT},
 	{nullptr, nullptr, 0}
 };
 


### PR DESCRIPTION
This implements the hardware stretch mode "Fit to Window (4:3)" as an alternative to the aspect ratio correction option.

- No existing functionality is being removed, this is just an additional option the user might select.

- One benefit why users might want to select this stretch mode is that the scaling is done via hardware scaling. This is fast on platforms with slow cpu, and uses a hardware scaling algorithm which can look better on some platforms than the software-based stretch.

- A second benefit why users might want to select this mode is that it allows to stretch ANY game to 4:3, even games that do not respect the aspect ratio correction option, like Dreamweb for example, or games that run in other resolutions or engines that are not covered by the aspect ratio correction option. 

- A third benefit is that with this option, everything is stretched to 4:3 including mouse pointer and GUI etc. after it is all rendered. So the same hardware scaling algorithm that the platform uses for any other scaling is used for the whole image including mouse pointer etc. For most platforms, this will be bilinear if video smoothing is turned on, or point filtering if video smoothing is turned off. This can potentially look better and more consistent for some games.