### PR TITLE
SDL: Use the name of the running target as a base for screenshot files

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -279,12 +279,18 @@ void SdlGraphicsManager::saveScreenshot() {
 	if (sdl_g_system)
 		screenshotsPath = sdl_g_system->getScreenshotsPath();
 
-	for (int n = 0;; n++) {
+	// Use the name of the running target as a base for screenshot file names
+	Common::String currentTarget = ConfMan.getActiveDomainName();
+
 #ifdef USE_PNG
-		filename = Common::String::format("scummvm%05d.png", n);
+	const char *extension = "png";
 #else
-		filename = Common::String::format("scummvm%05d.bmp", n);
+	const char *extension = "bmp";
 #endif
+
+	for (int n = 0;; n++) {
+		filename = Common::String::format("scummvm%s%s-%05d.%s", currentTarget.empty() ? "" : "-",
+		                                  currentTarget.c_str(), n, extension);
 
 		Common::FSNode file = Common::FSNode(screenshotsPath + filename);
 		if (!file.exists()) {


### PR DESCRIPTION
Makes it a bit easier to recognize files in the screenshot folder, IMO.