### PR TITLE
ANDROID: Add basic keymapper support

### DIFF
--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -113,12 +113,20 @@ private:
 	int _fingersDown;
 	bool _swap_menu_and_back;
 
+#ifdef ENABLE_KEYMAPPER
+	Common::KeymapperDefaultBindings *_keymapperDefaultBindings;
+#endif
+
 	void clipMouse(Common::Point &p);
 	void scaleMouse(Common::Point &p, int x, int y, bool deductDrawRect = true, bool touchpadMode = false);
 
 public:
 	virtual void pushEvent(const Common::Event &event);
 	virtual bool pollEvent(Common::Event &event);
+#ifdef ENABLE_KEYMAPPER
+	virtual Common::KeymapperDefaultBindings *getKeymapperDefaultBindings() { return _keymapperDefaultBindings; }
+#endif
+
 	virtual uint32 getMillis(bool skipRecord = false);
 	virtual void delayMillis(uint msecs);
 

--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -58,6 +58,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 
 	switch (type) {
 	case JE_SYS_KEY:
+#ifndef ENABLE_KEYMAPPER
 		switch (arg1) {
 		case JACTION_DOWN:
 			e.type = Common::EVENT_KEYDOWN;
@@ -125,7 +126,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		default:
 			break;
 		}
-
+#endif
 		// fall through
 
 	case JE_KEY:


### PR DESCRIPTION
This PR reports the actual keycode when buttons are pressed rather than using hard-coded mappings when the keymapper is enabled, and adds default mappings for the Menu and Back buttons. However, it's not possible to activate the remap dialog without a physical keyboard or a third-party virtual keyboard, which limits the usability of the keymapper, but I'm not familiar enough with the GUI code to do much about this. As a result, the keymapper is still disabled by default.