### PR TITLE
IPHONE: Disable idle timer while an engine is running

### DIFF
--- a/backends/platform/iphone/iphone_video.h
+++ b/backends/platform/iphone/iphone_video.h
@@ -101,6 +101,9 @@
 
 - (void)deviceOrientationChanged:(UIDeviceOrientation)orientation;
 
+- (void)disableIdleTimer;
+- (void)enableIdleTimer;
+
 - (void)applicationSuspend;
 
 - (void)applicationResume;

--- a/backends/platform/iphone/iphone_video.mm
+++ b/backends/platform/iphone/iphone_video.mm
@@ -778,6 +778,14 @@ const char *iPhone_getDocumentsDir() {
 	return 0;
 }
 
+- (void)disableIdleTimer {
+	[[UIApplication sharedApplication] setIdleTimerDisabled:YES];
+}
+
+- (void)enableIdleTimer {
+	[[UIApplication sharedApplication] setIdleTimerDisabled:NO];
+}
+
 - (void)applicationSuspend {
 	[self addEvent:InternalEvent(kInputApplicationSuspended, 0, 0)];
 }

--- a/backends/platform/iphone/osys_main.h
+++ b/backends/platform/iphone/osys_main.h
@@ -116,6 +116,9 @@ public:
 
 	virtual void initBackend();
 
+	virtual void engineInit();
+	virtual void engineDone();
+
 	virtual bool hasFeature(Feature f);
 	virtual void setFeatureState(Feature f, bool enable);
 	virtual bool getFeatureState(Feature f);

--- a/backends/platform/iphone/osys_video.mm
+++ b/backends/platform/iphone/osys_video.mm
@@ -28,6 +28,18 @@
 
 #include "graphics/conversion.h"
 
+void OSystem_IPHONE::engineInit() {
+	EventsBaseBackend::engineInit();
+	// Prevent the device going to sleep during game play (and in particular cut scenes)
+	[g_iPhoneViewInstance performSelectorOnMainThread:@selector(disableIdleTimer) withObject:nil waitUntilDone: NO];
+}
+
+void OSystem_IPHONE::engineDone() {
+	EventsBaseBackend::engineDone();
+	// Allow the device going to sleep if idle while in the Launcher
+	[g_iPhoneViewInstance performSelectorOnMainThread:@selector(enableIdleTimer) withObject:nil waitUntilDone: NO];
+}
+
 void OSystem_IPHONE::initVideoContext() {
 	_videoContext = [g_iPhoneViewInstance getVideoContext];
 }


### PR DESCRIPTION
This prevents the iOS device from going to sleep when an engine is running, for example while the intro of a game is playing (this happened to me with DOTT for example, and both Scorp and @waltervn mentioned this today in the Discord server).

This changes here are a port of commits 4a94464 and 58f3aac from the iOS7 backend to the old iPhone backend. It replaces the use of `dispatch_async`, that is only present since SDK 4.0, with `performSelectorOnMainThread` that exists since SDK 2.0. This means all the APIs used by the commit here should work with SDK 2.0 or above.

I am however unable to test that it compiles or works, so I am submitting this here for review.