### PR TITLE
DIRECTOR: LINGO: Add numberofwords implementation

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1807,7 +1807,7 @@ void LB::b_numberoflines(int nargs) {
 
 	d.toString();
 	int numberoflines = 1;
-	Common::String contents = d.u.s->c_str();
+	Common::String contents = *d.u.s;
 	for (uint32 i = 0; i < d.u.s->size(); i++) {
 		if (contents[i] == '\n')
 			numberoflines++;
@@ -1823,9 +1823,19 @@ void LB::b_numberoflines(int nargs) {
 void LB::b_numberofwords(int nargs) {
 	Datum d = g_lingo->pop();
 
-	warning("STUB: b_numberofwords");
-	d.toInt();
-	d.u.i = 0;
+	d.toString();
+	int numberofwords = 0;
+	Common::String contents = *d.u.s;
+	for (uint32 i = 1; i < d.u.s->size(); i++) {
+		if (Common::isSpace(contents[i]) && !Common::isSpace(contents[i - 1]))
+			numberofwords++;
+	}
+	// Count the last word
+	if (!Common::isSpace(contents[d.u.s->size() - 1]))
+		numberofwords++;
+
+	d.u.i = numberofwords;
+	d.type = INT;
 
 	g_lingo->push(d);
 }


### PR DESCRIPTION
We check of the current char in a string is a space,
if so check if the previous one wasn't a space, then count it as a word.
And count the last word when the text doesn't end in a space.
This is to prevent off by one errors.
    
Director 4 counts everything non-space (i.e. \n, \t, etc) as a
word separator. A word can be a single '.'.
