### PR TITLE
GOB: Add workaround for incorrect Goblins 3 CD audio track strings

### DIFF
--- a/engines/gob/sound/sound.cpp
+++ b/engines/gob/sound/sound.cpp
@@ -625,7 +625,13 @@ void Sound::cdPlay(const Common::String &trackName) {
 // name in the scripts, and therefore doesn't play. This fixes the problem.
 	if ((_vm->getGameType() == kGameTypeFascination) && trackName.equalsIgnoreCase("boscle"))
 		_cdrom->startTrack("bosscle");
-	else
+// WORKAROUND - In Goblins 3 CD, in the chess room, a couple of tracks have the wrong name
+// in the scripts, and therefore don't play. This fixes the problem (ticket #11335). 
+	else if ((_vm->getGameType() == kGameTypeGob3) && trackName.matchString("ECHEQUI?")) {
+		char name[] = "ECHIQUI1";
+		name[7] = trackName[7];
+		_cdrom->startTrack(name);
+	} else
 		_cdrom->startTrack(trackName.c_str());
 }
 


### PR DESCRIPTION
Fix for https://bugs.scummvm.org/ticket/11335

Added the fix directly below an existing precedent for this type of issue.

One potential problem might be if there is a version of the game out there in the wild without this bug, but given the naive approach of the aforementioned precedent and the fact that I can't find any other versions of the game to test it...