### PR TITLE
GRAPHICS: MACGUI: Fix compiler warning

### DIFF
--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -259,7 +259,7 @@ private:
 
 	MacPatterns _patterns;
 	byte *_palette;
-	int _paletteSize;
+	uint _paletteSize;
 
 	MacMenu *_menu;
 	uint32 _menuDelay;


### PR DESCRIPTION
Change variable to unsigned to fix a compiler warning about
comparison between signed and unsigned integer expressions.