### PR TITLE
ZVISION: Fix initial out-of-bounds condition in clock.

### DIFF
--- a/engines/zvision/core/clock.cpp
+++ b/engines/zvision/core/clock.cpp
@@ -30,7 +30,7 @@ namespace ZVision {
 
 Clock::Clock(OSystem *system)
 	: _system(system),
-	  _lastTime(0),
+	  _lastTime(system->getMillis()),
 	  _deltaTime(0),
 	  _pausedTime(0),
 	  _paused(false) {


### PR DESCRIPTION
This fixes an out-of-bounds condition when the clock is queried for the first time. Without this patch, Zork Nemesis crashes on my iPad after the initial cut scene.