### PR TITLE
ENGINES: Savegame code simplifications

### DIFF
--- a/engines/cge/POTFILES
+++ b/engines/cge/POTFILES
@@ -1,3 +1,0 @@
-engines/cge/detection.cpp
-engines/cge/events.cpp
-

--- a/engines/cge/events.cpp
+++ b/engines/cge/events.cpp
@@ -28,7 +28,6 @@
 #include "gui/saveload.h"
 #include "common/config-manager.h"
 #include "common/events.h"
-#include "common/translation.h"
 #include "engines/advancedDetector.h"
 #include "cge/events.h"
 #include "cge/events.h"
@@ -68,25 +67,10 @@ bool Keyboard::getKey(Common::Event &event) {
 			_vm->_commandHandler->addCommand(kCmdInf, 1, kShowScummVMVersion + i, NULL);
 		return false;
 	case Common::KEYCODE_F5:
-		if (_vm->canSaveGameStateCurrently()) {
-			GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
-			int16 savegameId = dialog->runModalWithCurrentTarget();
-			Common::String savegameDescription = dialog->getResultString();
-			delete dialog;
-
-			if (savegameId != -1)
-				_vm->saveGameState(savegameId, savegameDescription);
-			}
+		_vm->saveGameDialog();
 		return false;
 	case Common::KEYCODE_F7:
-		if (_vm->canLoadGameStateCurrently()) {
-			GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
-			int16 savegameId = dialog->runModalWithCurrentTarget();
-			delete dialog;
-
-			if (savegameId != -1)
-				_vm->loadGameState(savegameId);
-		}
+		_vm->loadGameDialog();
 		return false;
 	case Common::KEYCODE_d:
 		if (event.kbd.flags & Common::KBD_CTRL) {

--- a/engines/cge2/POTFILES
+++ b/engines/cge2/POTFILES
@@ -1,2 +1,0 @@
-engines/cge2/detection.cpp
-engines/cge2/events.cpp

--- a/engines/cge2/events.cpp
+++ b/engines/cge2/events.cpp
@@ -60,25 +60,10 @@ bool Keyboard::getKey(Common::Event &event) {
 			_vm->_commandHandler->addCommand(kCmdInf, 1, kShowScummVMVersion + i, NULL);
 		return false;
 	case Common::KEYCODE_F5:
-		if (_vm->canSaveGameStateCurrently()) {
-			GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
-			int16 savegameId = dialog->runModalWithCurrentTarget();
-			Common::String savegameDescription = dialog->getResultString();
-			delete dialog;
-
-			if (savegameId != -1)
-				_vm->saveGameState(savegameId, savegameDescription);
-		}
+		_vm->saveGameDialog();
 		return false;
 	case Common::KEYCODE_F7:
-		if (_vm->canLoadGameStateCurrently()) {
-			GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
-			int16 savegameId = dialog->runModalWithCurrentTarget();
-			delete dialog;
-
-			if (savegameId != -1)
-				_vm->loadGameState(savegameId);
-		}
+		_vm->loadGameDialog();
 		return false;
 	case Common::KEYCODE_d:
 		if (event.kbd.flags & Common::KBD_CTRL) {

--- a/engines/cruise/POTFILES
+++ b/engines/cruise/POTFILES
@@ -1,1 +1,0 @@
-engines/cruise/menu.cpp

--- a/engines/cruise/menu.cpp
+++ b/engines/cruise/menu.cpp
@@ -27,7 +27,6 @@
 #include "engines/metaengine.h"
 #include "gui/saveload.h"
 #include "common/system.h"
-#include "common/translation.h"
 
 namespace Cruise {
 
@@ -207,29 +206,10 @@ int processMenu(menuStruct *pMenu) {
 }
 
 static void handleSaveLoad(bool saveFlag) {
-	GUI::SaveLoadChooser *dialog;
 	if (saveFlag)
-		dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
+		_vm->saveGameDialog();
 	else
-		dialog = new GUI::SaveLoadChooser(_("Load game:"), _("Load"), false);
-
-	int slot = dialog->runModalWithCurrentTarget();
-
-	if (slot >= 0) {
-		if (!saveFlag)
-			_vm->loadGameState(slot);
-		else {
-			Common::String result(dialog->getResultString());
-			if (result.empty()) {
-				// If the user was lazy and entered no save name, come up with a default name.
-				result = Common::String::format("Save %d", slot + 1);
-			}
-
-			_vm->saveGameState(slot, result);
-		}
-	}
-
-	delete dialog;
+		_vm->loadGameDialog();
 }
 
 int playerMenu(int menuX, int menuY) {

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -661,12 +661,16 @@ bool Engine::canLoadGameStateCurrently() {
 }
 
 Common::Error Engine::saveGameState(int slot, const Common::String &desc) {
+	return saveGameState(slot, desc, false);
+}
+
+Common::Error Engine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *saveFile = _saveFileMan->openForSaving(getSaveStateName(slot));
 
 	if (!saveFile)
 		return Common::kWritingFailed;
 
-	Common::Error result = saveGameStream(saveFile);
+	Common::Error result = saveGameStream(saveFile, isAutosave);
 	if (result.getCode() == Common::kNoError) {
 		MetaEngine::appendExtendedSave(saveFile, getTotalPlayTime() / 1000, desc);
 
@@ -677,7 +681,7 @@ Common::Error Engine::saveGameState(int slot, const Common::String &desc) {
 	return result;
 }
 
-Common::Error Engine::saveGameStream(Common::WriteStream *stream) {
+Common::Error Engine::saveGameStream(Common::WriteStream *stream, bool isAutosave) {
 	// Default to returning an error when not implemented
 	return Common::kWritingFailed;
 }

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -693,8 +693,7 @@ bool Engine::canSaveGameStateCurrently() {
 
 bool Engine::loadGameDialog() {
 	if (!canLoadGameStateCurrently()) {
-		GUI::MessageDialog dialog(_("Loading game is currently unavailable"));
-		dialog.runModal();
+		g_system->displayMessageOnOSD(_("Loading game is currently unavailable"));
 		return false;
 	}
 
@@ -712,8 +711,7 @@ bool Engine::loadGameDialog() {
 
 bool Engine::saveGameDialog() {
 	if (!canSaveGameStateCurrently()) {
-		GUI::MessageDialog dialog(_("Saving game is currently unavailable"));
-		dialog.runModal();
+		g_system->displayMessageOnOSD(_("Saving game is currently unavailable"));
 		return false;
 	}
 

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -692,8 +692,11 @@ bool Engine::canSaveGameStateCurrently() {
 }
 
 bool Engine::loadGameDialog() {
-	if (!canLoadGameStateCurrently())
+	if (!canLoadGameStateCurrently()) {
+		GUI::MessageDialog dialog(_("Loading game is currently unavailable"));
+		dialog.runModal();
 		return false;
+	}
 
 	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Load game:"), _("Load"), false);
 	pauseEngine(true);
@@ -708,8 +711,11 @@ bool Engine::loadGameDialog() {
 }
 
 bool Engine::saveGameDialog() {
-	if (!canSaveGameStateCurrently())
+	if (!canSaveGameStateCurrently()) {
+		GUI::MessageDialog dialog(_("Saving game is currently unavailable"));
+		dialog.runModal();
 		return false;
+	}
 
 	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 	pauseEngine(true);

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -56,6 +56,7 @@
 #include "gui/debugger.h"
 #include "gui/dialog.h"
 #include "gui/message.h"
+#include "gui/saveload.h"
 
 #include "audio/mixer.h"
 
@@ -683,6 +684,43 @@ Common::Error Engine::saveGameStream(Common::WriteStream *stream) {
 
 bool Engine::canSaveGameStateCurrently() {
 	// Do not allow saving by default
+	return false;
+}
+
+bool Engine::loadGameDialog() {
+	if (!canLoadGameStateCurrently())
+		return false;
+
+	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Load game:"), _("Load"), false);
+	pauseEngine(true);
+	int slotNum = dialog->runModalWithCurrentTarget();
+	pauseEngine(false);
+	delete dialog;
+
+	if (slotNum != -1)
+		return loadGameState(slotNum).getCode() == Common::kNoError;
+
+	return false;
+}
+
+bool Engine::saveGameDialog() {
+	if (!canSaveGameStateCurrently())
+		return false;
+
+	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
+	pauseEngine(true);
+	int slotNum = dialog->runModalWithCurrentTarget();
+	pauseEngine(false);
+
+	Common::String desc = dialog->getResultString();
+	if (desc.empty())
+		desc = dialog->createDefaultSaveDescription(slotNum);
+
+	delete dialog;
+
+	if (slotNum != -1)
+		return saveGameState(slotNum, desc).getCode() == Common::kNoError;
+
 	return false;
 }
 

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -41,6 +41,8 @@ class EventManager;
 class SaveFileManager;
 class TimerManager;
 class FSNode;
+class SeekableReadStream;
+class WriteStream;
 }
 namespace GUI {
 class Debugger;
@@ -203,11 +205,25 @@ public:
 	virtual void flipMute();
 
 	/**
+	 * Generates the savegame filename
+	 */
+	virtual Common::String getSaveStateName(int slot) const {
+		return Common::String::format("%s.%03d", _targetName.c_str(), slot);
+	}
+
+	/**
 	 * Load a game state.
 	 * @param slot	the slot from which a savestate should be loaded
 	 * @return returns kNoError on success, else an error code.
 	 */
 	virtual Common::Error loadGameState(int slot);
+
+	/**
+	 * Load a game state.
+	 * @param stream	the stream to load the savestate from
+	 * @return returns kNoError on success, else an error code.
+	 */
+	virtual Common::Error loadGameStream(Common::SeekableReadStream *stream);
 
 	/**
 	 * Sets the game slot for a savegame to be loaded after global
@@ -230,6 +246,13 @@ public:
 	 * @return returns kNoError on success, else an error code.
 	 */
 	virtual Common::Error saveGameState(int slot, const Common::String &desc);
+
+	/**
+	 * Save a game state.
+	 * @param stream	The write stream to save the savegame data to
+	 * @return returns kNoError on success, else an error code.
+	 */
+	virtual Common::Error saveGameStream(Common::WriteStream *stream);
 
 	/**
 	 * Indicates whether a game state can be saved.

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -249,10 +249,20 @@ public:
 
 	/**
 	 * Save a game state.
-	 * @param stream	The write stream to save the savegame data to
+	 * @param slot	the slot into which the savestate should be stored
+	 * @param desc	a description for the savestate, entered by the user
+	 * @param isAutosave	Expected to be true if an autosave is being created
 	 * @return returns kNoError on success, else an error code.
 	 */
-	virtual Common::Error saveGameStream(Common::WriteStream *stream);
+	virtual Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave);
+
+	/**
+	 * Save a game state.
+	 * @param stream	The write stream to save the savegame data to
+	 * @param isAutosave	Expected to be true if an autosave is being created
+	 * @return returns kNoError on success, else an error code.
+	 */
+	virtual Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false);
 
 	/**
 	 * Indicates whether a game state can be saved.

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -259,6 +259,16 @@ public:
 	 */
 	virtual bool canSaveGameStateCurrently();
 
+	/**
+	 * Shows the ScummVM save dialog, allowing users to save their game
+	 */
+	bool saveGameDialog();
+
+	/**
+	 * Shows the ScummVM Restore dialog, allowing users to load a game
+	 */
+	bool loadGameDialog();
+
 protected:
 
 	/**

--- a/engines/griffon/POTFILES
+++ b/engines/griffon/POTFILES
@@ -1,0 +1,1 @@
+engines/griffon/griffon.cpp

--- a/engines/griffon/detection.cpp
+++ b/engines/griffon/detection.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "base/plugins.h"
+#include "common/config-manager.h"
 #include "engines/advancedDetector.h"
 
 #include "griffon/griffon.h"
@@ -59,7 +60,9 @@ public:
 		return "Griffon Engine";
 	}
 
-	virtual int getMaximumSaveSlot() const { return 3; }
+	virtual int getMaximumSaveSlot() const {
+		return ConfMan.getInt("autosave_period") ? 4 : 3;
+	}
 
 	virtual const char *getOriginalCopyright() const {
 		return "The Griffon Legend (c) 2005 Syn9 (Daniel Kennedy)";

--- a/engines/griffon/dialogs.cpp
+++ b/engines/griffon/dialogs.cpp
@@ -630,7 +630,7 @@ void GriffonEngine::saveLoadNew() {
 						}
 					}
 					if (lowerLock && tickPause < _ticks) {
-						if ((curCol == 1) && saveGameState(curRow - 1, "").getCode() == Common::kNoError) {
+						if ((curCol == 1) && saveGameState(curRow - 1, "", false).getCode() == Common::kNoError) {
 							_secStart += _secsInGame;
 							_secsInGame = 0;
 							lowerLock = false;

--- a/engines/griffon/dialogs.cpp
+++ b/engines/griffon/dialogs.cpp
@@ -630,7 +630,7 @@ void GriffonEngine::saveLoadNew() {
 						}
 					}
 					if (lowerLock && tickPause < _ticks) {
-						if ((curCol == 1) && saveState(curRow - 1)) {
+						if ((curCol == 1) && saveGameState(curRow - 1, "").getCode() == Common::kNoError) {
 							_secStart += _secsInGame;
 							_secsInGame = 0;
 							lowerLock = false;
@@ -638,7 +638,7 @@ void GriffonEngine::saveLoadNew() {
 							curRow = 0;
 
 							renderSaveStates();
-						} else if ((curCol == 2) && loadState(curRow - 1)) {
+						} else if ((curCol == 2) && loadGameState(curRow - 1).getCode() == Common::kNoError) {
 
 							return;
 						}

--- a/engines/griffon/engine.cpp
+++ b/engines/griffon/engine.cpp
@@ -97,6 +97,7 @@ void GriffonEngine::mainLoop() {
 
 		checkTrigger();
 		checkInputs();
+		autoSaveCheck();
 
 		if (!_forcePause)
 			handleWalking();

--- a/engines/griffon/griffon.cpp
+++ b/engines/griffon/griffon.cpp
@@ -40,6 +40,7 @@
 #include "common/file.h"
 #include "common/fs.h"
 #include "common/system.h"
+#include "common/translation.h"
 #include "graphics/pixelformat.h"
 
 #include "engines/util.h"
@@ -60,6 +61,7 @@ GriffonEngine::GriffonEngine(OSystem *syst) : Engine(syst) {
 
 	_shouldQuit = false;
 	_gameMode = kGameModeIntro;
+	_lastAutosaveTime = g_system->getMillis();
 
 	_musicChannel = -1;
 	_menuChannel = -1;
@@ -181,6 +183,13 @@ Common::Error GriffonEngine::run() {
 	}
 
 	return Common::kNoError;
+}
+
+void GriffonEngine::autoSaveCheck() {
+	if (shouldPerformAutoSave(_lastAutosaveTime) && canSaveGameStateCurrently()) {
+		saveGameState(4, _("Autosave"), true);
+		_lastAutosaveTime = g_system->getMillis();
+	}
 }
 
 }

--- a/engines/griffon/griffon.h
+++ b/engines/griffon/griffon.h
@@ -340,6 +340,7 @@ private:
 	Common::RandomSource *_rnd;
 	bool _shouldQuit;
 	int _gameMode;
+	uint32 _lastAutosaveTime;
 
 	Console *_console;
 
@@ -416,9 +417,10 @@ private:
 	virtual Common::String getSaveStateName(int slot) const override;
 	int loadPlayer(int slotnum);
 	virtual Common::Error loadGameState(int slot) override;
-	virtual Common::Error saveGameState(int slot, const Common::String &desc) override;
+	virtual Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave) override;
 	virtual Common::Error loadGameStream(Common::SeekableReadStream *file) override;
-	virtual Common::Error saveGameStream(Common::WriteStream *file, bool autoSave) override;
+	virtual Common::Error saveGameStream(Common::WriteStream *file, bool isAutosave) override;
+	void autoSaveCheck();
 
 	// sound.cpp
 	void setChannelVolume(int channel, int volume);

--- a/engines/griffon/griffon.h
+++ b/engines/griffon/griffon.h
@@ -418,7 +418,7 @@ private:
 	virtual Common::Error loadGameState(int slot) override;
 	virtual Common::Error saveGameState(int slot, const Common::String &desc) override;
 	virtual Common::Error loadGameStream(Common::SeekableReadStream *file) override;
-	virtual Common::Error saveGameStream(Common::WriteStream *file) override;
+	virtual Common::Error saveGameStream(Common::WriteStream *file, bool autoSave) override;
 
 	// sound.cpp
 	void setChannelVolume(int channel, int volume);

--- a/engines/griffon/griffon.h
+++ b/engines/griffon/griffon.h
@@ -413,10 +413,12 @@ private:
 	void loadObjectDB();
 
 	// saveload.cpp
-	Common::String makeSaveGameName(int slot);
-	int loadState(int slotnum);
+	virtual Common::String getSaveStateName(int slot) const override;
 	int loadPlayer(int slotnum);
-	int saveState(int slotnum);
+	virtual Common::Error loadGameState(int slot) override;
+	virtual Common::Error saveGameState(int slot, const Common::String &desc) override;
+	virtual Common::Error loadGameStream(Common::SeekableReadStream *file) override;
+	virtual Common::Error saveGameStream(Common::WriteStream *file) override;
 
 	// sound.cpp
 	void setChannelVolume(int channel, int volume);
@@ -428,13 +430,6 @@ private:
 	bool isSoundChannelPlaying(int channel);
 	void setupAudio();
 	void updateMusic();
-
-	Common::Error loadGameState(int slot) {
-		return loadState(slot) ? Common::kNoError : Common::kUnknownError;
-	}
-	Common::Error saveGameState(int slot, const Common::String &description) {
-		return saveState(slot) ? Common::kNoError : Common::kUnknownError;
-	}
 
 	virtual bool canLoadGameStateCurrently() { return true; }
 	virtual bool canSaveGameStateCurrently() { return _gameMode == kGameModePlay; }

--- a/engines/griffon/saveload.cpp
+++ b/engines/griffon/saveload.cpp
@@ -193,7 +193,7 @@ int GriffonEngine::loadPlayer(int slotnum) {
 	return 0; // fail
 }
 
-Common::Error GriffonEngine::saveGameStream(Common::WriteStream *file) {
+Common::Error GriffonEngine::saveGameStream(Common::WriteStream *file, bool) {
 	PRINT("%i", _player.level);
 
 	if (_player.level > 0) {

--- a/engines/griffon/saveload.cpp
+++ b/engines/griffon/saveload.cpp
@@ -69,9 +69,9 @@ Common::Error GriffonEngine::loadGameState(int slot) {
 	return result;
 }
 
-Common::Error GriffonEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error GriffonEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String saveDesc = Common::String::format("Level: %d Map: %d", _player.level, _curMap);
-	return Engine::saveGameState(slot, saveDesc);
+	return Engine::saveGameState(slot, isAutosave ? desc : saveDesc, isAutosave);
 }
 
 Common::Error GriffonEngine::loadGameStream(Common::SeekableReadStream *file) {

--- a/engines/titanic/main_game_window.cpp
+++ b/engines/titanic/main_game_window.cpp
@@ -359,10 +359,10 @@ void CMainGameWindow::keyDown(Common::KeyState keyState) {
 
 	} else if (keyState.keycode == Common::KEYCODE_F5) {
 		// Show the GMM save dialog
-		g_vm->showScummVMSaveDialog();
+		g_vm->saveGameDialog();
 	} else if (keyState.keycode == Common::KEYCODE_F7) {
 		// Show the GMM load dialog
-		g_vm->showScummVMRestoreDialog();
+		g_vm->loadGameDialog();
 	} else if (_inputAllowed) {
 		_gameManager->_inputTranslator.keyDown(keyState);
 	}

--- a/engines/titanic/titanic.cpp
+++ b/engines/titanic/titanic.cpp
@@ -46,7 +46,6 @@
 #include "common/debug-channels.h"
 #include "common/events.h"
 #include "common/scummsys.h"
-#include "common/translation.h"
 #include "engines/util.h"
 #include "graphics/scaler.h"
 #include "graphics/screen.h"
@@ -274,49 +273,6 @@ void TitanicEngine::syncSoundSettings() {
 			pet->syncSoundSettings();
 		}
 	}
-}
-
-
-void TitanicEngine::showScummVMSaveDialog() {
-	if (!canSaveGameStateCurrently())
-		return;
-
-	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
-
-	pauseEngine(true);
-	int slot = dialog->runModalWithCurrentTarget();
-	pauseEngine(false);
-
-	if (slot >= 0) {
-		Common::String desc = dialog->getResultString();
-
-		if (desc.empty()) {
-			// create our own description for the saved game, the user didn't enter it
-			desc = dialog->createDefaultSaveDescription(slot);
-		}
-
-		// Save the game
-		saveGameState(slot, desc);
-	}
-
-	delete dialog;
-}
-
-void TitanicEngine::showScummVMRestoreDialog() {
-	if (!canLoadGameStateCurrently())
-		return;
-
-	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
-
-	pauseEngine(true);
-	int slot = dialog->runModalWithCurrentTarget();
-	pauseEngine(false);
-
-	if (slot >= 0) {
-		loadGameState(slot);
-	}
-
-	delete dialog;
 }
 
 } // End of namespace Titanic

--- a/engines/titanic/titanic.h
+++ b/engines/titanic/titanic.h
@@ -194,16 +194,6 @@ public:
 	 * and if it exists, returns it's description
 	 */
 	CString getSavegameName(int slot);
-
-	/**
-	 * Shows the ScummVM GMM save dialog
-	 */
-	void showScummVMSaveDialog();
-
-	/**
-	 * Shows the ScummVM GMM load dialog
-	 */
-	void showScummVMRestoreDialog();
 };
 
 extern TitanicEngine *g_vm;

--- a/engines/ultima/nuvie/keybinding/key_actions.cpp
+++ b/engines/ultima/nuvie/keybinding/key_actions.cpp
@@ -313,7 +313,7 @@ void ActionPartyMode(int const *params) {
 }
 
 void ActionSaveDialog(int const *params) {
-	g_engine->saveGame();
+	g_engine->saveGameDialog();
 }
 
 void ActionLoadLatestSave(int const *params) {

--- a/engines/ultima/nuvie/menus/game_menu_dialog.cpp
+++ b/engines/ultima/nuvie/menus/game_menu_dialog.cpp
@@ -146,9 +146,9 @@ GUI_status GameMenuDialog::callback(uint16 msg, GUI_CallBack *caller, void *data
 	if (caller == this) {
 		close_dialog();
 	} else if (caller == save_button) {
-		g_engine->saveGame();
+		g_engine->saveGameDialog();
 	} else if (caller == load_button) {
-		g_engine->loadGame();
+		g_engine->loadGameDialog();
 	} else if (caller == video_button) {
 		GUI_Widget *video_dialog;
 		video_dialog = (GUI_Widget *) new VideoDialog(this);

--- a/engines/ultima/shared/early/ultima_early.cpp
+++ b/engines/ultima/shared/early/ultima_early.cpp
@@ -125,33 +125,17 @@ Game *UltimaEarlyEngine::createGame() const {
 	}
 }
 
-Common::Error UltimaEarlyEngine::loadGameState(int slot) {
-	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(
-		Common::String::format("%s.%.3d", _targetName.c_str(), slot));
-	if (!saveFile)
-		return Common::kReadingFailed;
-
+Common::Error UltimaEarlyEngine::loadGameStream(Common::SeekableReadStream *stream) {
 	// Read in the game's data
-	Common::Serializer s(saveFile, nullptr);
+	Common::Serializer s(stream, nullptr);
 	_game->synchronize(s);
-
-	delete saveFile;
 	return Common::kNoError;
 }
 
-Common::Error UltimaEarlyEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(
-		Common::String::format("%s.%.3d", _targetName.c_str(), slot));
-	if (!saveFile)
-		return Common::kCreatingFileFailed;
-
+Common::Error UltimaEarlyEngine::saveGameStream(Common::WriteStream *stream, bool) {
 	// Write out the game's data
-	Common::Serializer s(nullptr, saveFile);
+	Common::Serializer s(nullptr, stream);
 	_game->synchronize(s);
-
-	saveFile->finalize();
-	delete saveFile;
-
 	return Common::kNoError;
 }
 

--- a/engines/ultima/shared/early/ultima_early.h
+++ b/engines/ultima/shared/early/ultima_early.h
@@ -120,16 +120,12 @@ public:
 	/**
 	 * Load a savegame
 	 */
-	virtual Common::Error loadGameState(int slot) override;
+	virtual Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 
 	/**
 	 * Save a game state.
-	 * @param slot	the slot into which the savestate should be stored
-	 * @param desc	a description for the savestate, entered by the user
-	 * @param isAutosave If true, autosave is being created
-	 * @return returns kNoError on success, else an error code.
 	 */
-	virtual Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave) override;
+	virtual Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
 
 	/*
 	 * Creates a new hierarchy for the game, that contains all the logic for playing that particular game.

--- a/engines/ultima/shared/engine/ultima.cpp
+++ b/engines/ultima/shared/engine/ultima.cpp
@@ -28,7 +28,6 @@
 #include "common/debug-channels.h"
 #include "common/file.h"
 #include "common/translation.h"
-#include "gui/saveload.h"
 
 namespace Ultima {
 namespace Shared {
@@ -105,35 +104,6 @@ GameId UltimaEngine::getGameId() const {
 
 Common::FSNode UltimaEngine::getGameDirectory() const {
 	return Common::FSNode(ConfMan.get("path"));
-}
-
-bool UltimaEngine::loadGame() {
-	if (!canLoadGameStateCurrently())
-		return false;
-
-	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Load game:"), _("Load"), false);
-	int slotNum = dialog->runModalWithCurrentTarget();
-	delete dialog;
-
-	if (slotNum != -1)
-		return loadGameState(slotNum).getCode() == Common::kNoError;
-
-	return false;
-}
-
-bool UltimaEngine::saveGame() {
-	if (!canSaveGameStateCurrently())
-		return false;
-
-	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
-	int slotNum = dialog->runModalWithCurrentTarget();
-	Common::String saveName = dialog->getResultString();
-	delete dialog;
-
-	if (slotNum != -1)
-		return saveGameState(slotNum, saveName).getCode() == Common::kNoError;
-
-	return false;
 }
 
 UltimaMetaEngine *UltimaEngine::getMetaEngine() const {

--- a/engines/ultima/shared/engine/ultima.h
+++ b/engines/ultima/shared/engine/ultima.h
@@ -174,26 +174,6 @@ public:
 	virtual bool canSaveGameStateCurrently() override {
 		return canSaveGameStateCurrently(false);
 	}
-
-	/**
-	 * Save a game state.
-	 * @param slot	the slot into which the savestate should be stored
-	 * @param desc	a description for the savestate, entered by the user
-	 * @param isAutosave If true, autosave is being created
-	 * @return returns kNoError on success, else an error code.
-	 */
-	virtual Common::Error saveGameState(int slot, const Common::String &desc) override {
-		return saveGameState(slot, desc, false);
-	}
-
-	/**
-	 * Save a game state.
-	 * @param slot	the slot into which the savestate should be stored
-	 * @param desc	a description for the savestate, entered by the user
-	 * @param isAutosave If true, autosave is being created
-	 * @return returns kNoError on success, else an error code.
-	 */
-	virtual Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave) = 0;
 };
 
 extern UltimaEngine *g_ultima;

--- a/engines/ultima/shared/engine/ultima.h
+++ b/engines/ultima/shared/engine/ultima.h
@@ -150,16 +150,6 @@ public:
 	Common::FSNode getGameDirectory() const;
 
 	/**
-	 * Shows the ScummVM save dialog, allowing users to save their game
-	 */
-	virtual bool saveGame();
-
-	/**
-	 * Shows the ScummVM Restore dialog, allowing users to restore a game
-	 */
-	virtual bool loadGame();
-
-	/**
 	 * Indicates whether a game state can be loaded.
 	 * @param isAutosave	Flags whether it's an autosave check
 	 */

--- a/engines/ultima/ultima1/actions/quit.cpp
+++ b/engines/ultima/ultima1/actions/quit.cpp
@@ -37,7 +37,7 @@ END_MESSAGE_MAP()
 bool Quit::QuitMsg(CQuitMsg &msg) {
 	Ultima1Game *game = static_cast<Ultima1Game *>(getGame());
 	addInfoMsg(game->_res->ACTION_NAMES[16]);
-	g_vm->saveGame();
+	g_vm->saveGameDialog();
 
 	return true;
 }

--- a/engines/ultima/ultima1/u1gfx/view_char_gen.cpp
+++ b/engines/ultima/ultima1/u1gfx/view_char_gen.cpp
@@ -398,7 +398,7 @@ bool ViewCharacterGeneration::save() {
 	_character->_armour[1]->_quantity = 1;			// Leather armour
 	_character->_equippedSpell = 0;
 
-	return g_vm->saveGame();
+	return g_vm->saveGameDialog();
 }
 
 } // End of namespace U1Gfx

--- a/engines/ultima/ultima1/u1gfx/view_title.cpp
+++ b/engines/ultima/ultima1/u1gfx/view_title.cpp
@@ -304,7 +304,7 @@ bool ViewTitle::KeypressMsg(CKeypressMsg &msg) {
 			if (msg._keyState.keycode == Common::KEYCODE_a) {
 				setView("CharGen");
 			} else {
-				if (!g_vm->loadGame())
+				if (!g_vm->loadGameDialog())
 					textCursor->setVisible(true);
 			}
 		}

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -1291,33 +1291,6 @@ void Ultima8Engine::writeSaveInfo(ODataSource *ods) {
 	game->writeSaveInfo(ods);
 }
 
-bool Ultima8Engine::saveGame() {
-	if (!canSaveGameStateCurrently(false))
-		return false;
-
-	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
-	bool result = false;
-
-	pauseEngine(true);
-	int slot = dialog->runModalWithCurrentTarget();
-	pauseEngine(false);
-
-	if (slot >= 0) {
-		Common::String desc = dialog->getResultString();
-
-		if (desc.empty()) {
-			// create our own description for the saved game, the user didn't enter it
-			desc = dialog->createDefaultSaveDescription(slot);
-		}
-
-		// Save the game
-		result = saveGameState(slot, desc, false).getCode() == Common::kNoError;
-	}
-
-	delete dialog;
-	return result;
-}
-
 bool Ultima8Engine::canSaveGameStateCurrently(bool isAutosave) {
 	if (desktopGump->FindGump<ModalGump>())
 		// Can't save when a modal gump is open
@@ -1561,25 +1534,6 @@ void Ultima8Engine::syncSoundSettings() {
 	MidiPlayer *midiPlayer = audioMixer ? audioMixer->getMidiPlayer() : nullptr;
 	if (midiPlayer)
 		midiPlayer->setVolume(_mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType));
-}
-
-bool Ultima8Engine::loadGame() {
-	if (!canLoadGameStateCurrently())
-		return false;
-
-	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
-	bool result = false;
-
-	pauseEngine(true);
-	int slot = dialog->runModalWithCurrentTarget();
-	pauseEngine(false);
-
-	if (slot >= 0) {
-		result = loadGameState(slot).getCode() == Common::kNoError;
-	}
-
-	delete dialog;
-	return result;
 }
 
 Common::Error Ultima8Engine::loadGameState(int slot) {
@@ -1849,7 +1803,7 @@ void Ultima8Engine::ConCmd_saveGame(const Console::ArgvType &argv) {
 		// Save a game with the given name into the quicksave slot
 		Ultima8Engine::get_instance()->saveGame("@save/1", argv[1]);
 	} else {
-		Ultima8Engine::get_instance()->saveGame();
+		Ultima8Engine::get_instance()->saveGameDialog();
 	}
 }
 
@@ -1859,7 +1813,7 @@ void Ultima8Engine::ConCmd_loadGame(const Console::ArgvType &argv) {
 		// it just needs to be present to differentiate from showing the GUI load dialog
 		Ultima8Engine::get_instance()->loadGame("@save/1");
 	} else {
-		Ultima8Engine::get_instance()->loadGame();
+		Ultima8Engine::get_instance()->loadGameDialog();
 	}
 }
 

--- a/engines/ultima/ultima8/ultima8.h
+++ b/engines/ultima/ultima8/ultima8.h
@@ -337,15 +337,11 @@ public:
 	 */
 	virtual Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave) override;
 
-	bool saveGame() override;
-
 	//! save a game
 	//! \param filename the file to save to
 	//! \return true if succesful
 	bool saveGame(Std::string filename, Std::string desc,
 	              bool ignore_modals = false);
-
-	bool loadGame() override;
 
 	//! load a game
 	//! \param filename the savegame to load


### PR DESCRIPTION
This pull request aims to simply provide some simplification and improvements for the savegame code, particularly going forward for new engines added in the future. It consists of:

1. Showing the save/load dialogs due to in-game actions
A common feature of a lot of the existing games is that they need to trigger showing the save/restore dialogs from in-game buttons, menus, etc., in addition to from the GMM. As such, engines have gotten into the habit of continuously repeating code copied from the GMM to instantiate the dialog, get the result, and call saveGameState/loadGameState. Two new methods are added to the Engine class - loadGameDialog and saveGameDialog. I've also converted several of the engines to use the new methods rather than their own code. I wasn't pedantic about it.. some engines I wasn't familiar with, or had extra code directly in their save/load methods. It could perhaps be a future task for GSOC applicants to identify other existing engines that could be similarly simplified.

2. Simplified integration of the new extended savegame headers for future engines
Recently adding support for the new extended savegame format to Nuvie and Pentagram, I found it a bit cumbersome to properly integrate. I had to get help to find out the method to call to add the extra info to the savegame, and afterwards I only coincidentally noticed a problem with total play time resetting because I wasn't calling setTotalPlayTime in the load code.

So, to combat this, I've added several new methods to the base Engine class, and changed the implementation of loadGameState and saveGameState. First of all, this shouldn't affect any of the existing engines, since they all override loadGameState and saveGameState, so they'll remain unaffected. When not overridden, the assumption is that new engines will be using the new extended savegame code. The loadGameState and saveGameState methods now contain the code for:
* Opening up the savefiles
* Calling new methods readGameStream/writeGameStream which new engines would now override instead of loadGameState/saveGameState. These methods take in the already opened savefile streams, so there's no need for the engines to provide their own code anymore.
* Finally, either appending the extended savegame info for saving, or setting total play time for loading.

3. Autosaves
Many games have logic for when a save is done, such as displaying a "saved" message of some sort. To facilitate this, the saveGameStream method has an isAutoSave parameter to indicate if the game was being saved due to autosave kicking in, or via a player action. New engines will thus be able to do whatever UI notification they want in the method, and have it be done for saves done both via the GMM, or if the game itself manually called the saveGameDialog method.

Speaking of autosaves, I think this is something that should really be considered for being moved into the core as well. My latest commit added autosave support for Griffon, but it occurred to me that that's somewhat inefficient. Currently, not even a quarter of the engines call the "shouldPerformAutoSave" method. I was thinking maybe we could do the checks in the events managers - it could access the global engine pointer to call the method as well as canSaveGameStateCurrently, and maintain the last autosave time. That way, we could do away with engines having to do it themselves. Thoughts?

