### PR TITLE
CONFIGURE: fix documentation for '--with-sdl-prefix' and indent subengines

### DIFF
--- a/configure
+++ b/configure
@@ -771,7 +771,7 @@ show_engine_help() {
 show_subengine_help() {
 	name=`get_engine_name $1`
 	parent=`get_engine_name $2`
-	option_help "${1}" "${name} in ${parent} engine" "  "
+	option_help "- ${1}" "${name} in ${parent} engine" "  "
 }
 
 # Prepare the strings about the engines to build

--- a/configure
+++ b/configure
@@ -1118,8 +1118,11 @@ Optional Libraries:
   --disable-osx-dock-plugin    disable the NSDockTilePlugin support
                                [Mac OS X only - autodetect]
 
-  --with-sdl-prefix=DIR    prefix where the sdl-config script is
-                           installed (optional)
+  --with-sdl-prefix=DIR    prefix where the SDL package is installed (optional)
+                           e.g., if sdl-config script is at:
+                           /opt/mxe/usr/i686-w64-mingw32.static/bin/sdl2-config
+                           then you should pass:
+                           '--with-sdl-prefix=/opt/mxe/usr/i686-w64-mingw32.static'
 
   --with-freetype2-prefix=DIR  prefix where the freetype-config script is
                                installed (optional)


### PR DESCRIPTION
_(I accidentally deleted PR #2033. These are the same commits)_

- CONFIGURE: fix documentation for `--with-sdl-prefix` flag
- CONFIGURE: --help: indent subengines
Instead of showing subengines directly under their parent engine, like:
```
	kyra                   Kyra engine
	lol                    Lands of Lore in Kyra engine
	eob                    Eye of the Beholder in Kyra engine
	lab                    Labyrinth of Time engine
```
Show them slightliy indented, like:
```
	kyra                   Kyra engine
	- lol                  Lands of Lore in Kyra engine
	- eob                  Eye of the Beholder in Kyra engine
	lab                    Labyrinth of Time engine
```
It keeps the list sorted, and makes it easier to skim through it.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
