### PR TITLE
WINTERMUTE: Fix handling of EVENT_WHEELDOWN

### DIFF
--- a/engines/wintermute/platform_osystem.cpp
+++ b/engines/wintermute/platform_osystem.cpp
@@ -111,7 +111,7 @@ void BasePlatform::handleEvent(Common::Event *event) {
 	case Common::EVENT_WHEELUP:
 	case Common::EVENT_WHEELDOWN:
 		if (_gameRef) {
-			_gameRef->handleMouseWheel(event->mouse.y);
+			_gameRef->handleMouseWheel(event->type == Common::EVENT_WHEELUP ? 1 : -1);
 		}
 		break;
 	case Common::EVENT_SCREEN_CHANGED:


### PR DESCRIPTION
"MouseWheelUp" event was generated instead of "MouseWheelDown" event on
Common::EVENT_WHEELDOWN.

Affected 2D games: FoxTail, Looky, Helga Deep in Trouble, Carol Reed
series, Reversion 2, James Peris, Vsevolod