### PR TITLE
PINK: Implement save & load in the menubar

### DIFF
--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -145,8 +145,16 @@ void PinkEngine::executeMenuCommand(uint id) {
 		break;
 	}
 	case kLoadSave:
+		loadGameDialog();
+		break;
+
 	case kSaveAction:
 	case kSaveAsAction:
+		//FIXME: Somehow messes up the pause system causing issues such as
+		//frozen animations and BGM disappearing
+		saveGameDialog();
+		break;
+
 	case kSoundSettingsAction:
 	case kLastSavesAction:
 	case kPauseAction:


### PR DESCRIPTION
Fairly obvious and straightforward implementation.

Seems to expose a bug with the pause logic, scenes don't resume correctly, either freezing entirely or loosing the BGM. #NotMyFault