### PR TITLE
TESTBED: Provide correct engine feature implementation data

### DIFF
--- a/engines/testbed/detection.cpp
+++ b/engines/testbed/detection.cpp
@@ -69,6 +69,9 @@ public:
 		return true;
 	}
 
+	virtual bool hasFeature(MetaEngineFeature f) const override {
+		return false;
+	}
 };
 
 #if PLUGIN_ENABLED_DYNAMIC(TESTBED)


### PR DESCRIPTION
The testbed "engine" doesn't do any of the possible engine features, mark it as such.