### PR TITLE
ENGINES: Standardization of autosaves

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ For a more comprehensive changelog of the latest experimental code, see:
 #### 2.2.0 (XXXX-XX-XX)
 
 General:
+   - Autosaves are now supported for all the engines
    - Errors are more likely to open the debugger, and be displayed, then just crash ScummVM
 
  Dreamweb:

--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -89,6 +89,10 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 		handleKeyRepeat();
 	}
 
+	if (g_engine)
+		// Handle autosaves if enabled
+		g_engine->handleAutoSave();
+
 	if (_eventQueue.empty()) {
 		return false;
 	}

--- a/engines/access/access.cpp
+++ b/engines/access/access.cpp
@@ -457,7 +457,7 @@ void AccessEngine::freeChar() {
 
 Common::Error AccessEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
-		generateSaveName(slot));
+		getSaveStateName(slot));
 	if (!out)
 		return Common::kCreatingFileFailed;
 
@@ -476,7 +476,7 @@ Common::Error AccessEngine::saveGameState(int slot, const Common::String &desc, 
 
 Common::Error AccessEngine::loadGameState(int slot) {
 	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(
-		generateSaveName(slot));
+		getSaveStateName(slot));
 	if (!saveFile)
 		return Common::kReadingFailed;
 
@@ -497,10 +497,6 @@ Common::Error AccessEngine::loadGameState(int slot) {
 	_events->clearEvents();
 
 	return Common::kNoError;
-}
-
-Common::String AccessEngine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
 }
 
 bool AccessEngine::canLoadGameStateCurrently() {

--- a/engines/access/access.cpp
+++ b/engines/access/access.cpp
@@ -455,7 +455,7 @@ void AccessEngine::freeChar() {
 	_animation->freeAnimationData();
 }
 
-Common::Error AccessEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error AccessEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
 		generateSaveName(slot));
 	if (!out)

--- a/engines/access/access.h
+++ b/engines/access/access.h
@@ -111,12 +111,6 @@ protected:
 	void doRoom();
 
 	/**
-	* Support method that generates a savegame name
-	* @param slot		Slot number
-	*/
-	Common::String generateSaveName(int slot);
-
-	/**
 	 * Play back an entire video
 	 */
 	void playVideo(int videoNum, const Common::Point &pt);

--- a/engines/access/access.h
+++ b/engines/access/access.h
@@ -289,7 +289,7 @@ public:
 	/**
 	 * Save the game
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	/**
 	 * Returns true if a savegame can currently be loaded

--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -924,7 +924,7 @@ void AdlEngine::saveState(Common::WriteStream &stream) {
 		stream.writeByte(_state.vars[i]);
 }
 
-Common::Error AdlEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error AdlEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String fileName = Common::String::format("%s.s%02d", _targetName.c_str(), slot);
 	Common::OutSaveFile *outFile = getSaveFileManager()->openForSaving(fileName);
 

--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -924,8 +924,12 @@ void AdlEngine::saveState(Common::WriteStream &stream) {
 		stream.writeByte(_state.vars[i]);
 }
 
+Common::String AdlEngine::getSaveStateName(int slot) const {
+	return Common::String::format("%s.s%02d", _targetName.c_str(), slot);
+}
+
 Common::Error AdlEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	Common::String fileName = Common::String::format("%s.s%02d", _targetName.c_str(), slot);
+	Common::String fileName = getSaveStateName(slot);
 	Common::OutSaveFile *outFile = getSaveFileManager()->openForSaving(fileName);
 
 	if (!outFile) {

--- a/engines/adl/adl.h
+++ b/engines/adl/adl.h
@@ -252,6 +252,7 @@ protected:
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
+	virtual Common::String getSaveStateName(int slot) const override;
 
 	Common::String getDiskImageName(byte volume) const { return Adl::getDiskImageName(*_gameDescription, volume); }
 	GameType getGameType() const { return Adl::getGameType(*_gameDescription); }

--- a/engines/adl/adl.h
+++ b/engines/adl/adl.h
@@ -250,7 +250,7 @@ protected:
 
 	// Engine
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 
 	Common::String getDiskImageName(byte volume) const { return Adl::getDiskImageName(*_gameDescription, volume); }

--- a/engines/agi/agi.cpp
+++ b/engines/agi/agi.cpp
@@ -399,8 +399,6 @@ AgiEngine::AgiEngine(OSystem *syst, const AGIGameDescription *gameDesc) : AgiBas
 
 	_setVolumeBrokenFangame = false; // for further study see AgiEngine::setVolumeViaScripts()
 
-	_lastSaveTime = 0;
-
 	_playTimeInSecondsAdjust = 0;
 	_lastUsedPlayTimeInCycles = 0;
 	_lastUsedPlayTimeInSeconds = 0;
@@ -484,8 +482,6 @@ void AgiEngine::initialize() {
 	_text->charAttrib_Set(15, 0);
 
 	_game.name[0] = '\0';
-
-	_lastSaveTime = 0;
 
 	debugC(2, kDebugLevelMain, "Detect game");
 

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -849,7 +849,7 @@ public:
 	bool promptIsEnabled() override;
 
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 
 private:
 	int _keyQueue[KEY_QUEUE_SIZE];

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -840,8 +840,6 @@ protected:
 
 	void initialize() override;
 
-	uint32 _lastSaveTime;
-
 public:
 	AgiEngine(OSystem *syst, const AGIGameDescription *gameDesc);
 	~AgiEngine() override;
@@ -870,7 +868,6 @@ public:
 	StringData _stringdata;
 
 	SavedGameSlotIdArray getSavegameSlotIds();
-	Common::String getSavegameFilename(int16 slotId) const;
 	bool getSavegameInformation(int16 slotId, Common::String &saveDescription, uint32 &saveDate, uint32 &saveTime, bool &saveIsValid);
 
 	int saveGame(const Common::String &fileName, const Common::String &descriptionString);

--- a/engines/agi/cycle.cpp
+++ b/engines/agi/cycle.cpp
@@ -449,10 +449,6 @@ int AgiEngine::playGame() {
 			setVar(VM_VAR_KEY, 0);
 		}
 
-		if (shouldPerformAutoSave(_lastSaveTime)) {
-			saveGame(getSavegameFilename(0), "Autosave");
-		}
-
 	} while (!(shouldQuit() || _restartGame));
 
 	_sound->stopSound();

--- a/engines/agi/saveload.cpp
+++ b/engines/agi/saveload.cpp
@@ -1083,7 +1083,7 @@ Common::Error AgiEngine::loadGameState(int slot) {
 	}
 }
 
-Common::Error AgiEngine::saveGameState(int slot, const Common::String &description) {
+Common::Error AgiEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	Common::String saveLoadSlot = getSavegameFilename(slot);
 	if (saveGame(saveLoadSlot, description) == errOK)
 		return Common::kNoError;

--- a/engines/agi/saveload.cpp
+++ b/engines/agi/saveload.cpp
@@ -332,8 +332,6 @@ int AgiEngine::saveGame(const Common::String &fileName, const Common::String &de
 	delete out;
 	debugC(3, kDebugLevelMain | kDebugLevelSavegame, "Closed %s", fileName.c_str());
 
-	_lastSaveTime = _system->getMillis();
-
 	return result;
 }
 
@@ -787,7 +785,7 @@ int AgiEngine::scummVMSaveLoadDialog(bool isSave) {
 }
 
 int AgiEngine::doSave(int slot, const Common::String &desc) {
-	Common::String fileName = getSavegameFilename(slot);
+	Common::String fileName = getSaveStateName(slot);
 	debugC(8, kDebugLevelMain | kDebugLevelResources, "file is [%s]", fileName.c_str());
 
 	// Make sure all graphics was blitted to screen. This fixes bug
@@ -799,7 +797,7 @@ int AgiEngine::doSave(int slot, const Common::String &desc) {
 }
 
 int AgiEngine::doLoad(int slot, bool showMessages) {
-	Common::String fileName = getSavegameFilename(slot);
+	Common::String fileName = getSaveStateName(slot);
 	debugC(8, kDebugLevelMain | kDebugLevelResources, "file is [%s]", fileName.c_str());
 
 	_sprites->eraseSprites();
@@ -847,15 +845,9 @@ SavedGameSlotIdArray AgiEngine::getSavegameSlotIds() {
 	return slotIdArray;
 }
 
-Common::String AgiEngine::getSavegameFilename(int16 slotId) const {
-	Common::String saveLoadSlot = _targetName;
-	saveLoadSlot += Common::String::format(".%.3d", slotId);
-	return saveLoadSlot;
-}
-
 bool AgiEngine::getSavegameInformation(int16 slotId, Common::String &saveDescription, uint32 &saveDate, uint32 &saveTime, bool &saveIsValid) {
 	Common::InSaveFile *in;
-	Common::String fileName = getSavegameFilename(slotId);
+	Common::String fileName = getSaveStateName(slotId);
 	char saveGameDescription[31];
 	int16 curPos = 0;
 	byte  saveVersion = 0;
@@ -1056,7 +1048,7 @@ void AgiEngine::releaseImageStack() {
 
 void AgiEngine::checkQuickLoad() {
 	if (ConfMan.hasKey("save_slot")) {
-		Common::String saveNameBuffer = getSavegameFilename(ConfMan.getInt("save_slot"));
+		Common::String saveNameBuffer = getSaveStateName(ConfMan.getInt("save_slot"));
 
 		_sprites->eraseSprites();
 		_sound->stopSound();
@@ -1069,7 +1061,7 @@ void AgiEngine::checkQuickLoad() {
 }
 
 Common::Error AgiEngine::loadGameState(int slot) {
-	Common::String saveLoadSlot = getSavegameFilename(slot);
+	Common::String saveLoadSlot = getSaveStateName(slot);
 
 	_sprites->eraseSprites();
 	_sound->stopSound();
@@ -1084,7 +1076,7 @@ Common::Error AgiEngine::loadGameState(int slot) {
 }
 
 Common::Error AgiEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
-	Common::String saveLoadSlot = getSavegameFilename(slot);
+	Common::String saveLoadSlot = getSaveStateName(slot);
 	if (saveGame(saveLoadSlot, description) == errOK)
 		return Common::kNoError;
 	else

--- a/engines/agi/systemui.cpp
+++ b/engines/agi/systemui.cpp
@@ -745,7 +745,7 @@ void SystemUI::drawSavedGameSlotSelector(bool active) {
 bool SystemUI::askForSavedGameVerification(const char *verifyText, const char *verifyButton1, const char *verifyButton2, const char *actualDescription, int16 slotId) {
 	char displayDescription[SYSTEMUI_SAVEDGAME_DISPLAYTEXT_LEN + 1];
 	Common::String userActionVerify;
-	Common::String savedGameFilename = _vm->getSavegameFilename(slotId);
+	Common::String savedGameFilename = _vm->getSaveStateName(slotId);
 
 	createSavedGameDisplayText(displayDescription, actualDescription, slotId, false);
 	userActionVerify = Common::String::format(verifyText, displayDescription, savedGameFilename.c_str());

--- a/engines/avalanche/avalanche.cpp
+++ b/engines/avalanche/avalanche.cpp
@@ -336,7 +336,7 @@ Common::Error AvalancheEngine::saveGameState(int slot, const Common::String &des
 }
 
 bool AvalancheEngine::saveGame(const int16 slot, const Common::String &desc) {
-	Common::String fileName = getSaveFileName(slot);
+	Common::String fileName = getSaveStateName(slot);
 	Common::OutSaveFile *f = g_system->getSavefileManager()->openForSaving(fileName);
 	if (!f) {
 		warning("Can't create file '%s', game not saved.", fileName.c_str());
@@ -368,10 +368,6 @@ bool AvalancheEngine::saveGame(const int16 slot, const Common::String &desc) {
 	return true;
 }
 
-Common::String AvalancheEngine::getSaveFileName(const int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
-}
-
 bool AvalancheEngine::canLoadGameStateCurrently() {
 	return (_animationsEnabled);
 }
@@ -381,7 +377,7 @@ Common::Error AvalancheEngine::loadGameState(int slot) {
 }
 
 bool AvalancheEngine::loadGame(const int16 slot) {
-	Common::String fileName = getSaveFileName(slot);
+	Common::String fileName = getSaveStateName(slot);
 	Common::InSaveFile *f = g_system->getSavefileManager()->openForLoading(fileName);
 	if (!f)
 		return false;

--- a/engines/avalanche/avalanche.cpp
+++ b/engines/avalanche/avalanche.cpp
@@ -331,7 +331,7 @@ bool AvalancheEngine::canSaveGameStateCurrently() {
 	return (_animationsEnabled && _alive);
 }
 
-Common::Error AvalancheEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error AvalancheEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return (saveGame(slot, desc) ? Common::kNoError : Common::kWritingFailed);
 }
 

--- a/engines/avalanche/avalanche.h
+++ b/engines/avalanche/avalanche.h
@@ -110,7 +110,7 @@ public:
 
 	void synchronize(Common::Serializer &sz);
 	bool canSaveGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool saveGame(const int16 slot, const Common::String &desc);
 	Common::String getSaveFileName(const int slot);
 	bool canLoadGameStateCurrently() override;

--- a/engines/avalanche/avalanche.h
+++ b/engines/avalanche/avalanche.h
@@ -112,7 +112,6 @@ public:
 	bool canSaveGameStateCurrently() override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool saveGame(const int16 slot, const Common::String &desc);
-	Common::String getSaveFileName(const int slot);
 	bool canLoadGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	bool loadGame(const int16 slot);

--- a/engines/bbvs/bbvs.h
+++ b/engines/bbvs/bbvs.h
@@ -412,7 +412,6 @@ public:
 	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 	void savegame(const char *filename, const char *description);
 	void loadgame(const char *filename);
-	const char *getSavegameFilename(int num);
 	bool existsSavegame(int num);
 	static Common::String getSavegameFilename(const Common::String &target, int num);
 	WARN_UNUSED_RESULT static kReadSaveHeaderError readSaveHeader(Common::SeekableReadStream *in, SaveHeader &header, bool skipThumbnail = true);

--- a/engines/bbvs/bbvs.h
+++ b/engines/bbvs/bbvs.h
@@ -409,7 +409,7 @@ public:
 	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
 	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 	void savegame(const char *filename, const char *description);
 	void loadgame(const char *filename);
 	const char *getSavegameFilename(int num);

--- a/engines/bbvs/saveload.cpp
+++ b/engines/bbvs/saveload.cpp
@@ -187,7 +187,7 @@ Common::Error BbvsEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error BbvsEngine::saveGameState(int slot, const Common::String &description) {
+Common::Error BbvsEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	const char *fileName = getSavegameFilename(slot);
 	savegame(fileName, description.c_str());
 	return Common::kNoError;

--- a/engines/bbvs/saveload.cpp
+++ b/engines/bbvs/saveload.cpp
@@ -182,21 +182,15 @@ void BbvsEngine::loadgame(const char *filename) {
 }
 
 Common::Error BbvsEngine::loadGameState(int slot) {
-	const char *fileName = getSavegameFilename(slot);
-	loadgame(fileName);
+	Common::String fileName = getSaveStateName(slot);
+	loadgame(fileName.c_str());
 	return Common::kNoError;
 }
 
 Common::Error BbvsEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
-	const char *fileName = getSavegameFilename(slot);
-	savegame(fileName, description.c_str());
+	Common::String fileName = getSaveStateName(slot);
+	savegame(fileName.c_str(), description.c_str());
 	return Common::kNoError;
-}
-
-const char *BbvsEngine::getSavegameFilename(int num) {
-	static Common::String filename;
-	filename = getSavegameFilename(_targetName, num);
-	return filename.c_str();
 }
 
 Common::String BbvsEngine::getSavegameFilename(const Common::String &target, int num) {

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -283,7 +283,7 @@ bool BladeRunnerEngine::canSaveGameStateCurrently() {
 		!_elevator->isOpen();
 }
 
-Common::Error BladeRunnerEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error BladeRunnerEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *saveFile = BladeRunner::SaveFileManager::openForSaving(_targetName, slot);
 	if (saveFile == nullptr || saveFile->err()) {
 		delete saveFile;

--- a/engines/bladerunner/bladerunner.h
+++ b/engines/bladerunner/bladerunner.h
@@ -257,7 +257,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	bool canSaveGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void pauseEngineIntern(bool pause) override;
 
 	Common::Error run() override;

--- a/engines/cge/cge.h
+++ b/engines/cge/cge.h
@@ -133,7 +133,6 @@ private:
 	void writeSavegameHeader(Common::OutSaveFile *out, SavegameHeader &header);
 	void syncGame(Common::SeekableReadStream *readStream, Common::WriteStream *writeStream, bool tiny);
 	bool savegameExists(int slotNumber);
-	Common::String generateSaveName(int slot);
 public:
 	CGEEngine(OSystem *syst, const ADGameDescription *gameDescription);
 	~CGEEngine() override;

--- a/engines/cge/cge.h
+++ b/engines/cge/cge.h
@@ -141,7 +141,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	static const int _maxSceneArr[5];
 	bool _quitFlag;

--- a/engines/cge/cge_main.cpp
+++ b/engines/cge/cge_main.cpp
@@ -298,7 +298,7 @@ void CGEEngine::resetGame() {
 	_commandHandler->reset();
 }
 
-Common::Error CGEEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error CGEEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	sceneDown();
 	_hero->park();
 	_oldLev = _lev;

--- a/engines/cge/cge_main.cpp
+++ b/engines/cge/cge_main.cpp
@@ -206,7 +206,7 @@ bool CGEEngine::loadGame(int slotNumber, SavegameHeader *header, bool tiny) {
 
 	} else {
 		// Open up the savegame file
-		Common::String slotName = generateSaveName(slotNumber);
+		Common::String slotName = getSaveStateName(slotNumber);
 		Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(slotName);
 
 		// Read the data into a data buffer
@@ -257,20 +257,12 @@ bool CGEEngine::loadGame(int slotNumber, SavegameHeader *header, bool tiny) {
  * Returns true if a given savegame exists
  */
 bool CGEEngine::savegameExists(int slotNumber) {
-	Common::String slotName = generateSaveName(slotNumber);
+	Common::String slotName = getSaveStateName(slotNumber);
 
 	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(slotName);
 	bool result = saveFile != NULL;
 	delete saveFile;
 	return result;
-}
-
-/**
- * Support method that generates a savegame name
- * @param slot		Slot number
- */
-Common::String CGEEngine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
 }
 
 Common::Error CGEEngine::loadGameState(int slot) {
@@ -323,7 +315,7 @@ Common::Error CGEEngine::saveGameState(int slot, const Common::String &desc, boo
 
 void CGEEngine::saveGame(int slotNumber, const Common::String &desc) {
 	// Set up the serializer
-	Common::String slotName = generateSaveName(slotNumber);
+	Common::String slotName = getSaveStateName(slotNumber);
 	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(slotName);
 
 	// Write out the ScummVM savegame header

--- a/engines/cge2/cge2.h
+++ b/engines/cge2/cge2.h
@@ -158,7 +158,7 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 	bool canSaveGameStateCurrently() override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error run() override;
 

--- a/engines/cge2/cge2.h
+++ b/engines/cge2/cge2.h
@@ -146,7 +146,6 @@ private:
 	void init();
 	void deinit();
 
-	Common::String generateSaveName(int slot);
 	void writeSavegameHeader(Common::OutSaveFile *out, SavegameHeader &header);
 	void saveGame(int slotNumber, const Common::String &desc);
 	bool loadGame(int slotNumber);

--- a/engines/cge2/saveload.cpp
+++ b/engines/cge2/saveload.cpp
@@ -56,7 +56,7 @@ Common::Error CGE2Engine::saveGameState(int slot, const Common::String &desc, bo
 
 void CGE2Engine::saveGame(int slotNumber, const Common::String &desc) {
 	// Set up the serializer
-	Common::String slotName = generateSaveName(slotNumber);
+	Common::String slotName = getSaveStateName(slotNumber);
 	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(slotName);
 
 	// Write out the ScummVM savegame header
@@ -93,7 +93,7 @@ bool CGE2Engine::loadGame(int slotNumber) {
 	Common::MemoryReadStream *readStream;
 
 	// Open up the savegame file
-	Common::String slotName = generateSaveName(slotNumber);
+	Common::String slotName = getSaveStateName(slotNumber);
 	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(slotName);
 
 	// Read the data into a data buffer
@@ -276,14 +276,6 @@ void CGE2Engine::syncHeader(Common::Serializer &s) {
 		if (checksum != kSavegameCheckSum)
 			error("%s", _text->getText(kBadSVG));
 	}
-}
-
-/**
-* Support method that generates a savegame name
-* @param slot		Slot number
-*/
-Common::String CGE2Engine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
 }
 
 } // End of namespace CGE2

--- a/engines/cge2/saveload.cpp
+++ b/engines/cge2/saveload.cpp
@@ -47,7 +47,7 @@ bool CGE2Engine::canSaveGameStateCurrently() {
 		_commandHandler->idle() && (_soundStat._wait == nullptr);
 }
 
-Common::Error CGE2Engine::saveGameState(int slot, const Common::String &desc) {
+Common::Error CGE2Engine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	storeHeroPos();
 	saveGame(slot, desc);
 	sceneUp(_now);

--- a/engines/cine/cine.h
+++ b/engines/cine/cine.h
@@ -127,7 +127,7 @@ public:
 	int modifyGameSpeed(int speedChange);
 	int getTimerDelay() const;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 

--- a/engines/cine/cine.h
+++ b/engines/cine/cine.h
@@ -128,6 +128,7 @@ public:
 	int getTimerDelay() const;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+	virtual Common::String getSaveStateName(int slot) const override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 

--- a/engines/cine/detection.cpp
+++ b/engines/cine/detection.cpp
@@ -223,7 +223,7 @@ Common::Error CineEngine::loadGameState(int slot) {
 	return gameLoaded ? Common::kNoError : Common::kUnknownError;
 }
 
-Common::Error CineEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error CineEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	// Load savegame descriptions from index file
 	loadSaveDirectory();
 

--- a/engines/cine/detection.cpp
+++ b/engines/cine/detection.cpp
@@ -216,9 +216,7 @@ void CineMetaEngine::removeSaveState(const char *target, int slot) const {
 namespace Cine {
 
 Common::Error CineEngine::loadGameState(int slot) {
-	char saveNameBuffer[256];
-	sprintf(saveNameBuffer, "%s.%1d", _targetName.c_str(), slot);
-	bool gameLoaded = makeLoad(saveNameBuffer);
+	bool gameLoaded = makeLoad(getSaveStateName(slot));
 
 	return gameLoaded ? Common::kNoError : Common::kUnknownError;
 }
@@ -244,13 +242,15 @@ Common::Error CineEngine::saveGameState(int slot, const Common::String &desc, bo
 	delete fHandle;
 
 	// Save game
-	char saveFileName[256];
-	sprintf(saveFileName, "%s.%1d", _targetName.c_str(), slot);
-	makeSave(saveFileName);
+	makeSave(getSaveStateName(slot));
 
 	checkDataDisk(-1);
 
 	return Common::kNoError;
+}
+
+Common::String CineEngine::getSaveStateName(int slot) const {
+	return Common::String::format("%s.%1d", _targetName.c_str(), slot);
 }
 
 bool CineEngine::canLoadGameStateCurrently() {

--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -123,7 +123,6 @@ Common::Error ComposerEngine::run() {
 	else
 		warning("FPS in book.ini is zero. Defaulting to 8...");
 	uint32 lastDrawTime = 0;
-	_lastSaveTime = _system->getMillis();
 
 	bool loadFromLauncher = ConfMan.hasKey("save_slot");
 
@@ -179,8 +178,7 @@ Common::Error ComposerEngine::run() {
 			loadGameState(ConfMan.getInt("save_slot"));
 			loadFromLauncher = false;
 		}
-		if (shouldPerformAutoSave(_lastSaveTime))
-			saveGameState(0, "Autosave");
+
 		while (_eventMan->pollEvent(event)) {
 			switch (event.type) {
 			case Common::EVENT_LBUTTONDOWN:

--- a/engines/composer/composer.h
+++ b/engines/composer/composer.h
@@ -169,7 +169,7 @@ protected:
 	bool canLoadGameStateCurrently() override { return true; }
 	Common::Error loadGameState(int slot) override;
 	bool canSaveGameStateCurrently() override { return true; }
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 public:
 	ComposerEngine(OSystem *syst, const ComposerGameDescription *gameDesc);

--- a/engines/composer/composer.h
+++ b/engines/composer/composer.h
@@ -230,7 +230,7 @@ private:
 	uint16 _mouseSpriteId;
 	Common::Point _mouseOffset;
 
-	Common::String makeSaveGameName(int slot);
+	virtual Common::String getSaveStateName(int slot) const override;
 	Common::String getStringFromConfig(const Common::String &section, const Common::String &key);
 	Common::String getFilename(const Common::String &section, uint id);
 	Common::String mangleFilename(Common::String filename);

--- a/engines/composer/composer.h
+++ b/engines/composer/composer.h
@@ -193,7 +193,7 @@ private:
 	Audio::QueuingAudioStream *_audioStream;
 	uint16 _currSoundPriority;
 
-	uint32 _currentTime, _lastTime, _timeDelta, _lastSaveTime;
+	uint32 _currentTime, _lastTime, _timeDelta;
 
 	bool _needsUpdate;
 	Common::Array<Common::Rect> _dirtyRects;

--- a/engines/composer/saveload.cpp
+++ b/engines/composer/saveload.cpp
@@ -366,17 +366,12 @@ Common::Error ComposerEngine::loadGameState(int slot) {
 	if (!_mixer->isSoundHandleActive(_soundHandle))
 		_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundHandle, _audioStream);
 
-
-	// Reset autosave duration on load
-	_lastSaveTime = _system->getMillis();
-
 	return Common::kNoError;
 }
 
 Common::Error ComposerEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String filename = makeSaveGameName(slot);
 	Common::OutSaveFile *out;
-	_lastSaveTime = _system->getMillis();
 	if (!(out = _saveFileMan->openForSaving(filename)))
 		return Common::kWritingFailed;
 

--- a/engines/composer/saveload.cpp
+++ b/engines/composer/saveload.cpp
@@ -373,7 +373,7 @@ Common::Error ComposerEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error ComposerEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error ComposerEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String filename = makeSaveGameName(slot);
 	Common::OutSaveFile *out;
 	_lastSaveTime = _system->getMillis();

--- a/engines/composer/saveload.cpp
+++ b/engines/composer/saveload.cpp
@@ -266,12 +266,13 @@ void ComposerEngine::sync<Sprite>(Common::Serializer &ser, Sprite &data, Common:
 		}
 
 }
-Common::String ComposerEngine::makeSaveGameName(int slot) {
-	return (_targetName + Common::String::format(".%02d", slot));
+
+Common::String ComposerEngine::getSaveStateName(int slot) const {
+	return Common::String::format("%s.%02d", _targetName.c_str(), slot);
 }
 
 Common::Error ComposerEngine::loadGameState(int slot) {
-	Common::String filename = makeSaveGameName(slot);
+	Common::String filename = getSaveStateName(slot);
 	Common::InSaveFile *in;
 	if (!(in = _saveFileMan->openForLoading(filename)))
 		return Common::kPathNotFile;
@@ -370,7 +371,7 @@ Common::Error ComposerEngine::loadGameState(int slot) {
 }
 
 Common::Error ComposerEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	Common::String filename = makeSaveGameName(slot);
+	Common::String filename = getSaveStateName(slot);
 	Common::OutSaveFile *out;
 	if (!(out = _saveFileMan->openForSaving(filename)))
 		return Common::kWritingFailed;

--- a/engines/cruise/cruise.cpp
+++ b/engines/cruise/cruise.cpp
@@ -205,7 +205,7 @@ bool CruiseEngine::canLoadGameStateCurrently() {
 	return playerMenuEnabled != 0;
 }
 
-Common::Error CruiseEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error CruiseEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return saveSavegameData(slot, desc);
 }
 

--- a/engines/cruise/cruise.h
+++ b/engines/cruise/cruise.h
@@ -93,7 +93,7 @@ public:
 	static const char *getSavegameFile(int saveGameIdx);
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 	void syncSoundSettings() override;
 

--- a/engines/cruise/cruise.h
+++ b/engines/cruise/cruise.h
@@ -95,6 +95,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
+	Common::String getSaveStateName(int slot) const override { return getSavegameFile(slot); }
 	void syncSoundSettings() override;
 
 	const CRUISEGameDescription *_gameDescription;

--- a/engines/cryomni3d/versailles/engine.h
+++ b/engines/cryomni3d/versailles/engine.h
@@ -233,6 +233,7 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+	Common::String getSaveStateName(int slot) const override;
 
 	Common::String prepareFileName(const Common::String &baseName, const char *extension) const {
 		const char *const extensions[] = { extension, nullptr };

--- a/engines/cryomni3d/versailles/engine.h
+++ b/engines/cryomni3d/versailles/engine.h
@@ -232,7 +232,7 @@ public:
 
 	bool hasFeature(EngineFeature f) const override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	Common::String prepareFileName(const Common::String &baseName, const char *extension) const {
 		const char *const extensions[] = { extension, nullptr };

--- a/engines/cryomni3d/versailles/saveload.cpp
+++ b/engines/cryomni3d/versailles/saveload.cpp
@@ -36,7 +36,7 @@ Common::Error CryOmni3DEngine_Versailles::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error CryOmni3DEngine_Versailles::saveGameState(int slot, const Common::String &desc) {
+Common::Error CryOmni3DEngine_Versailles::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	saveGame(_isVisiting, slot + 1, desc);
 	return Common::kNoError;
 }

--- a/engines/cryomni3d/versailles/saveload.cpp
+++ b/engines/cryomni3d/versailles/saveload.cpp
@@ -45,6 +45,10 @@ Common::String CryOmni3DEngine_Versailles::getSaveFileName(bool visit, uint save
 	return Common::String::format("%s%s.%04u", _targetName.c_str(), visit ? "_visit" : "", saveNum);
 }
 
+Common::String CryOmni3DEngine_Versailles::getSaveStateName(int slot) const {
+	return Common::String::format("%s.%04u", _targetName.c_str(), slot);
+}
+
 bool CryOmni3DEngine_Versailles::canVisit() const {
 	return Common::File::exists("game0001.sav");
 }

--- a/engines/draci/draci.cpp
+++ b/engines/draci/draci.cpp
@@ -468,7 +468,7 @@ bool DraciEngine::canLoadGameStateCurrently() {
 		(_game->getLoopSubstatus() == kOuterLoop);
 }
 
-Common::Error DraciEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error DraciEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return saveSavegameData(slot, desc, *this);
 }
 

--- a/engines/draci/draci.h
+++ b/engines/draci/draci.h
@@ -70,7 +70,7 @@ public:
 	static Common::String getSavegameFile(int saveGameIdx);
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 
 	Screen *_screen;

--- a/engines/draci/draci.h
+++ b/engines/draci/draci.h
@@ -68,6 +68,7 @@ public:
 	void handleEvents();
 
 	static Common::String getSavegameFile(int saveGameIdx);
+	Common::String getSaveStateName(int slot) const override { return getSavegameFile(slot); }
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;

--- a/engines/drascula/drascula.h
+++ b/engines/drascula/drascula.h
@@ -330,7 +330,7 @@ public:
 
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 
 	Common::RandomSource *_rnd;

--- a/engines/drascula/saveload.cpp
+++ b/engines/drascula/saveload.cpp
@@ -199,7 +199,7 @@ bool DrasculaEngine::canLoadGameStateCurrently() {
 	return _canSaveLoad;
 }
 
-Common::Error DrasculaEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error DrasculaEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	saveGame(slot, desc);
 	return Common::kNoError;
 }

--- a/engines/drascula/saveload.cpp
+++ b/engines/drascula/saveload.cpp
@@ -229,7 +229,7 @@ void DrasculaEngine::saveGame(int slot, const Common::String &desc) {
 	Common::OutSaveFile *out;
 	int l;
 
-	Common::String saveFileName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
+	Common::String saveFileName = getSaveStateName(slot);
 	if (!(out = _saveFileMan->openForSaving(saveFileName))) {
 		error("Unable to open the file");
 	}
@@ -271,7 +271,7 @@ bool DrasculaEngine::loadGame(int slot) {
 	if (currentChapter != 1)
 		clearRoom();
 
-	Common::String saveFileName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
+	Common::String saveFileName = getSaveStateName(slot);
 	if (!(in = _saveFileMan->openForLoading(saveFileName))) {
 		error("missing savegame file %s", saveFileName.c_str());
 	}

--- a/engines/dreamweb/detection.cpp
+++ b/engines/dreamweb/detection.cpp
@@ -239,7 +239,7 @@ Common::Error DreamWebEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error DreamWebEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error DreamWebEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return Common::kNoError;
 }
 

--- a/engines/dreamweb/dreamweb.h
+++ b/engines/dreamweb/dreamweb.h
@@ -114,7 +114,7 @@ public:
 	void waitForVSync();
 
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -707,7 +707,7 @@ Common::Error Engine::saveGameState(int slot, const Common::String &desc, bool i
 
 	Common::Error result = saveGameStream(saveFile, isAutosave);
 	if (result.getCode() == Common::kNoError) {
-		MetaEngine::appendExtendedSave(saveFile, getTotalPlayTime() / 1000, desc);
+		MetaEngine::appendExtendedSave(saveFile, getTotalPlayTime() / 1000, desc, isAutosave);
 
 		saveFile->finalize();
 	}

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -148,7 +148,9 @@ Engine::Engine(OSystem *syst)
 		_saveSlotToLoad(-1),
 		_engineStartTime(_system->getMillis()),
 		_mainMenuDialog(NULL),
-		_debugger(NULL) {
+		_debugger(NULL),
+		_autosaveInterval(ConfMan.getInt("autosave_period")),
+		_lastAutosaveTime(_system->getMillis()) {
 
 	g_engine = this;
 	Common::setErrorOutputFormatter(defaultOutputFormatter);
@@ -482,10 +484,16 @@ void Engine::checkCD() {
 #endif
 }
 
-bool Engine::shouldPerformAutoSave(int lastSaveTime) {
-	const int diff = _system->getMillis() - lastSaveTime;
-	const int autosavePeriod = ConfMan.getInt("autosave_period");
-	return autosavePeriod != 0 && diff > autosavePeriod * 1000;
+void Engine::handleAutoSave() {
+	const int diff = _system->getMillis() - _lastAutosaveTime;
+
+	if (_autosaveInterval != 0 && diff > (_autosaveInterval * 1000)) {
+		// Save the autosave
+		saveGameState(getAutosaveSlot(), _("Autosave"), true);
+
+		// Reset the last autosave time
+		_lastAutosaveTime = _system->getMillis();
+	}
 }
 
 void Engine::errorString(const char *buf1, char *buf2, int size) {

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -489,7 +489,8 @@ void Engine::handleAutoSave() {
 
 	if (_autosaveInterval != 0 && diff > (_autosaveInterval * 1000)) {
 		// Save the autosave
-		saveGameState(getAutosaveSlot(), _("Autosave"), true);
+		if (canSaveAutosaveCurrently())
+			saveGameState(getAutosaveSlot(), _("Autosave"), true);
 
 		// Reset the last autosave time
 		_lastAutosaveTime = _system->getMillis();

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -498,9 +498,12 @@ void Engine::saveAutosaveIfEnabled() {
 		bool canSave = canSaveAutosaveCurrently();
 
 		if (!canSave || saveGameState(getAutosaveSlot(), _("Autosave"), true).getCode() != Common::kNoError) {
-			// Couldn't autosave at the designated time. Rather than wait until
-			// the next autosave interval, which may be some time, set the next
-			// interval to be in five minutes time
+			// Couldn't autosave at the designated time
+			if (!canSave)
+				g_system->displayMessageOnOSD(_("Error occurred making autosave"));
+
+			// Set the next autosave interval to be in 5 minutes, rather than whatever
+			// full autosave interval the user has selected
 			_lastAutosaveTime = _system->getMillis() + (5 * 60 * 1000) - _autosaveInterval;
 			return;
 		}

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -489,12 +489,16 @@ void Engine::handleAutoSave() {
 
 	if (_autosaveInterval != 0 && diff > (_autosaveInterval * 1000)) {
 		// Save the autosave
-		if (canSaveAutosaveCurrently())
-			saveGameState(getAutosaveSlot(), _("Autosave"), true);
-
-		// Reset the last autosave time
-		_lastAutosaveTime = _system->getMillis();
+		saveAutosaveIfEnabled();
 	}
+}
+
+void Engine::saveAutosaveIfEnabled() {
+	if (_autosaveInterval != 0 && canSaveAutosaveCurrently())
+		saveGameState(getAutosaveSlot(), _("Autosave"), true);
+
+	// Reset the last autosave time
+	_lastAutosaveTime = _system->getMillis();
 }
 
 void Engine::errorString(const char *buf1, char *buf2, int size) {
@@ -645,6 +649,9 @@ void Engine::flipMute() {
 }
 
 Common::Error Engine::loadGameState(int slot) {
+	// In case autosaves are on, do a save first before loading the new save
+	saveAutosaveIfEnabled();
+
 	Common::InSaveFile *saveFile = _saveFileMan->openForLoading(getSaveStateName(slot));
 
 	if (!saveFile)

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -496,16 +496,15 @@ void Engine::handleAutoSave() {
 void Engine::saveAutosaveIfEnabled() {
 	if (_autosaveInterval != 0) {
 		bool saveFlag = canSaveAutosaveCurrently();
-		Common::String saveName = _("Autosave");
 
 		if (saveFlag) {
 			// First check for an existing savegame in the slot, and if present, if it's an autosave
 			SaveStateDescriptor desc = getMetaEngine().querySaveMetaInfos(
 				_targetName.c_str(), getAutosaveSlot());
-			saveFlag = desc.getSaveSlot() == -1 || desc.getDescription() == saveName;
+			saveFlag = desc.getSaveSlot() == -1 || desc.isAutosave();
 		}
 
-		if (saveFlag && saveGameState(getAutosaveSlot(), saveName, true).getCode() != Common::kNoError) {
+		if (saveFlag && saveGameState(getAutosaveSlot(), _("Autosave"), true).getCode() != Common::kNoError) {
 			// Couldn't autosave at the designated time
 			g_system->displayMessageOnOSD(_("Error occurred making autosave"));
 			saveFlag = false;

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -662,10 +662,6 @@ bool Engine::canLoadGameStateCurrently() {
 	return false;
 }
 
-Common::Error Engine::saveGameState(int slot, const Common::String &desc) {
-	return saveGameState(slot, desc, false);
-}
-
 Common::Error Engine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *saveFile = _saveFileMan->openForSaving(getSaveStateName(slot));
 

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -494,8 +494,17 @@ void Engine::handleAutoSave() {
 }
 
 void Engine::saveAutosaveIfEnabled() {
-	if (_autosaveInterval != 0 && canSaveAutosaveCurrently())
-		saveGameState(getAutosaveSlot(), _("Autosave"), true);
+	if (_autosaveInterval != 0) {
+		bool canSave = canSaveAutosaveCurrently();
+
+		if (!canSave || saveGameState(getAutosaveSlot(), _("Autosave"), true).getCode() != Common::kNoError) {
+			// Couldn't autosave at the designated time. Rather than wait until
+			// the next autosave interval, which may be some time, set the next
+			// interval to be in five minutes time
+			_lastAutosaveTime = _system->getMillis() + (5 * 60 * 1000) - _autosaveInterval;
+			return;
+		}
+	}
 
 	// Reset the last autosave time
 	_lastAutosaveTime = _system->getMillis();

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -31,6 +31,7 @@
 #include "common/singleton.h"
 
 class OSystem;
+class MetaEngine;
 
 namespace Audio {
 class Mixer;
@@ -322,6 +323,8 @@ public:
 	 * launcher.
 	 */
 	static bool shouldQuit();
+
+	static MetaEngine &getMetaEngine();
 
 	/**
 	 * Pause or resume the engine. This should stop/resume any audio playback

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -92,6 +92,16 @@ private:
 	int32 _engineStartTime;
 
 	/**
+	 * Autosave interval
+	 */
+	const int _autosaveInterval;
+
+	/**
+	 * The last time an autosave was done
+	 */
+	int _lastAutosaveTime;
+
+	/**
 	 * Save slot selected via global main menu.
 	 * This slot will be loaded after main menu execution (not from inside
 	 * the menu loop, to avoid bugs like #2822778).
@@ -290,7 +300,6 @@ public:
 	bool loadGameDialog();
 
 protected:
-
 	/**
 	 * Actual implementation of pauseEngine by subclasses. See there
 	 * for details.
@@ -367,17 +376,27 @@ public:
 	inline Common::SaveFileManager *getSaveFileManager() { return _saveFileMan; }
 
 public:
-
 	/** On some systems, check if the game appears to be run from CD. */
 	void checkCD();
 
-protected:
 
 	/**
-	 * Indicate whether an autosave should be performed.
+	 * Checks for whether it's time to do an autosave, and if so, does it.
 	 */
-	bool shouldPerformAutoSave(int lastSaveTime);
+	void handleAutoSave();
 
+	/**
+	 * Returns the slot that should be used for autosaves
+	 */
+	virtual int getAutosaveSlot() const {
+		return 0;
+	}
+
+	bool shouldPerformAutoSave(int lastSaveTime) {
+		// TODO: Remove deprecated method once all engines are refactored
+		// to no longer do autosaves directly themselves
+		return false;
+	}
 };
 
 // Chained games

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -399,6 +399,7 @@ public:
 
 	/**
 	 * Returns the slot that should be used for autosaves
+	 * @note	This should match the meta engine getAutosaveSlot() method
 	 */
 	virtual int getAutosaveSlot() const {
 		return 0;

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -261,18 +261,10 @@ public:
 	 * Save a game state.
 	 * @param slot	the slot into which the savestate should be stored
 	 * @param desc	a description for the savestate, entered by the user
-	 * @return returns kNoError on success, else an error code.
-	 */
-	virtual Common::Error saveGameState(int slot, const Common::String &desc);
-
-	/**
-	 * Save a game state.
-	 * @param slot	the slot into which the savestate should be stored
-	 * @param desc	a description for the savestate, entered by the user
 	 * @param isAutosave	Expected to be true if an autosave is being created
 	 * @return returns kNoError on success, else an error code.
 	 */
-	virtual Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave);
+	virtual Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false);
 
 	/**
 	 * Save a game state.

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -386,6 +386,11 @@ public:
 	void handleAutoSave();
 
 	/**
+	 * Does an autosave immediately if autosaves are turned on
+	 */
+	void saveAutosaveIfEnabled();
+
+	/**
 	 * Indicates whether an autosave can currently be saved.
 	 */
 	virtual bool canSaveAutosaveCurrently() {

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -386,6 +386,13 @@ public:
 	void handleAutoSave();
 
 	/**
+	 * Indicates whether an autosave can currently be saved.
+	 */
+	virtual bool canSaveAutosaveCurrently() {
+		return canSaveGameStateCurrently();
+	}
+
+	/**
 	 * Returns the slot that should be used for autosaves
 	 */
 	virtual int getAutosaveSlot() const {

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -246,6 +246,9 @@ Common::Error FullpipeEngine::saveGameState(int slot, const Common::String &desc
 		return Common::kUnknownError;
 }
 
+Common::String FullpipeEngine::getSaveStateName(int slot) const {
+	return Common::String::format("fullpipe.s%02d", slot);
+}
 
 Common::Error FullpipeEngine::run() {
 	const Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);

--- a/engines/fullpipe/fullpipe.cpp
+++ b/engines/fullpipe/fullpipe.cpp
@@ -239,7 +239,7 @@ Common::Error FullpipeEngine::loadGameState(int slot) {
 		return Common::kUnknownError;
 }
 
-Common::Error FullpipeEngine::saveGameState(int slot, const Common::String &description) {
+Common::Error FullpipeEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	if (_gameLoader->writeSavegame(_currentScene, getSavegameFile(slot), description))
 		return Common::kNoError;
 	else

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -356,7 +356,7 @@ public:
 	bool _isSaveAllowed;
 
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 
 	bool canLoadGameStateCurrently() override { return true; }
 	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }

--- a/engines/fullpipe/fullpipe.h
+++ b/engines/fullpipe/fullpipe.h
@@ -357,6 +357,7 @@ public:
 
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
+	virtual Common::String getSaveStateName(int slot) const override;
 
 	bool canLoadGameStateCurrently() override { return true; }
 	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }

--- a/engines/glk/frotz/frotz.cpp
+++ b/engines/glk/frotz/frotz.cpp
@@ -129,7 +129,7 @@ Common::Error Frotz::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error Frotz::saveGameState(int slot, const Common::String &desc) {
+Common::Error Frotz::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String msg;
 	FileReference ref(slot, desc, fileusage_BinaryMode | fileusage_SavedGame);
 

--- a/engines/glk/frotz/frotz.h
+++ b/engines/glk/frotz/frotz.h
@@ -79,7 +79,7 @@ public:
 	/**
 	 * Save the game to a given slot
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	/**
 	 * Loading method not used for Frotz sub-engine

--- a/engines/glk/glk.cpp
+++ b/engines/glk/glk.cpp
@@ -228,7 +228,7 @@ Common::Error GlkEngine::loadGameState(int slot) {
 	return errCode;
 }
 
-Common::Error GlkEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error GlkEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String msg;
 	FileReference ref(slot, desc, fileusage_BinaryMode | fileusage_SavedGame);
 

--- a/engines/glk/glk.h
+++ b/engines/glk/glk.h
@@ -201,7 +201,7 @@ public:
 	/**
 	 * Save the game to a given slot
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	/**
 	 * Load a savegame from the passed Quetzal file chunk stream

--- a/engines/gnap/gnap.h
+++ b/engines/gnap/gnap.h
@@ -317,7 +317,6 @@ public:
 	int loadSavegame(int savegameNum);
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
-	Common::String generateSaveName(int slot);
 	void synchronize(Common::Serializer &s);
 	void writeSavegameHeader(Common::OutSaveFile *out, GnapSavegameHeader &header);
 	WARN_UNUSED_RESULT static bool readSavegameHeader(Common::InSaveFile *in, GnapSavegameHeader &header, bool skipThumbnail = true);

--- a/engines/gnap/gnap.h
+++ b/engines/gnap/gnap.h
@@ -315,7 +315,7 @@ public:
 
 	int readSavegameDescription(int savegameNum, Common::String &description);
 	int loadSavegame(int savegameNum);
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
 	Common::String generateSaveName(int slot);
 	void synchronize(Common::Serializer &s);

--- a/engines/gnap/menu.cpp
+++ b/engines/gnap/menu.cpp
@@ -527,7 +527,7 @@ void GnapEngine::updateMenuStatusMainMenu() {
 #endif
 }
 
-Common::Error GnapEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error GnapEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
 		generateSaveName(slot));
 	if (!out)

--- a/engines/gnap/menu.cpp
+++ b/engines/gnap/menu.cpp
@@ -529,7 +529,7 @@ void GnapEngine::updateMenuStatusMainMenu() {
 
 Common::Error GnapEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
-		generateSaveName(slot));
+		getSaveStateName(slot));
 	if (!out)
 		return Common::kCreatingFileFailed;
 
@@ -630,7 +630,7 @@ WARN_UNUSED_RESULT bool GnapEngine::readSavegameHeader(Common::InSaveFile *in, G
 
 Common::Error GnapEngine::loadGameState(int slot) {
 	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(
-		generateSaveName(slot));
+		getSaveStateName(slot));
 	if (!saveFile)
 		return Common::kReadingFailed;
 
@@ -651,10 +651,6 @@ Common::Error GnapEngine::loadGameState(int slot) {
 
 	_loadGameSlot = slot;
 	return Common::kNoError;
-}
-
-Common::String GnapEngine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
 }
 
 void GnapEngine::updateMenuStatusSaveGame() {

--- a/engines/griffon/detection.cpp
+++ b/engines/griffon/detection.cpp
@@ -69,6 +69,10 @@ public:
 	}
 
 	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+
+	virtual int getAutosaveSlot() const override {
+		return 4;
+	}
 };
 
 bool Griffon::GriffonEngine::hasFeature(EngineFeature f) const {

--- a/engines/griffon/engine.cpp
+++ b/engines/griffon/engine.cpp
@@ -97,7 +97,6 @@ void GriffonEngine::mainLoop() {
 
 		checkTrigger();
 		checkInputs();
-		autoSaveCheck();
 
 		if (!_forcePause)
 			handleWalking();

--- a/engines/griffon/griffon.cpp
+++ b/engines/griffon/griffon.cpp
@@ -61,7 +61,6 @@ GriffonEngine::GriffonEngine(OSystem *syst) : Engine(syst) {
 
 	_shouldQuit = false;
 	_gameMode = kGameModeIntro;
-	_lastAutosaveTime = g_system->getMillis();
 
 	_musicChannel = -1;
 	_menuChannel = -1;
@@ -185,13 +184,6 @@ Common::Error GriffonEngine::run() {
 	}
 
 	return Common::kNoError;
-}
-
-void GriffonEngine::autoSaveCheck() {
-	if (shouldPerformAutoSave(_lastAutosaveTime) && canSaveGameStateCurrently()) {
-		saveGameState(4, _("Autosave"), true);
-		_lastAutosaveTime = g_system->getMillis();
-	}
 }
 
 }

--- a/engines/griffon/griffon.h
+++ b/engines/griffon/griffon.h
@@ -340,7 +340,6 @@ private:
 	Common::RandomSource *_rnd;
 	bool _shouldQuit;
 	int _gameMode;
-	uint32 _lastAutosaveTime;
 
 	Console *_console;
 
@@ -420,7 +419,6 @@ private:
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameStream(Common::SeekableReadStream *file) override;
 	Common::Error saveGameStream(Common::WriteStream *file, bool isAutosave) override;
-	void autoSaveCheck();
 
 	// sound.cpp
 	void setChannelVolume(int channel, int volume);
@@ -435,6 +433,7 @@ private:
 
 	bool canLoadGameStateCurrently() override { return true; }
 	bool canSaveGameStateCurrently() override { return _gameMode == kGameModePlay; }
+	int getAutosaveSlot() const override { return 4; }
 	bool hasFeature(EngineFeature f) const override;
 
 private:

--- a/engines/griffon/griffon.h
+++ b/engines/griffon/griffon.h
@@ -417,7 +417,7 @@ private:
 	Common::String getSaveStateName(int slot) const override;
 	int loadPlayer(int slotnum);
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameStream(Common::SeekableReadStream *file) override;
 	Common::Error saveGameStream(Common::WriteStream *file, bool isAutosave) override;
 	void autoSaveCheck();

--- a/engines/groovie/groovie.cpp
+++ b/engines/groovie/groovie.cpp
@@ -391,7 +391,7 @@ Common::Error GroovieEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error GroovieEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error GroovieEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	_script->directGameSave(slot,desc);
 
 	// TODO: Use specific error codes

--- a/engines/groovie/groovie.h
+++ b/engines/groovie/groovie.h
@@ -105,7 +105,7 @@ protected:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void syncSoundSettings() override;
 
 public:

--- a/engines/hdb/hdb.h
+++ b/engines/hdb/hdb.h
@@ -195,7 +195,7 @@ public:
 		_changeLevel = true;
 	}
 
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;

--- a/engines/hdb/saveload.cpp
+++ b/engines/hdb/saveload.cpp
@@ -36,7 +36,7 @@ bool HDBGame::canSaveGameStateCurrently() {
 	return (_gameState == GAME_PLAY && !_ai->cinematicsActive());
 }
 
-Common::Error HDBGame::saveGameState(int slot, const Common::String &desc) {
+Common::Error HDBGame::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 
 	// If no map is loaded, don't try to save
 	if (!g_hdb->_map->isLoaded())

--- a/engines/hopkins/hopkins.cpp
+++ b/engines/hopkins/hopkins.cpp
@@ -106,7 +106,7 @@ Common::Error HopkinsEngine::loadGameState(int slot) {
 /**
  * Save the game to the given slot index, and with the given name
  */
-Common::Error HopkinsEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error HopkinsEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return _saveLoad->saveGame(slot, desc);
 }
 

--- a/engines/hopkins/hopkins.cpp
+++ b/engines/hopkins/hopkins.cpp
@@ -77,10 +77,6 @@ HopkinsEngine::~HopkinsEngine() {
 	delete _animMan;
 }
 
-Common::String HopkinsEngine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
-}
-
 /**
  * Returns true if it is currently okay to restore a game
  */

--- a/engines/hopkins/hopkins.h
+++ b/engines/hopkins/hopkins.h
@@ -165,8 +165,10 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+
 	int _startGameSlot;
+
 	/**
 	 * Run the introduction sequence
 	 */

--- a/engines/hopkins/hopkins.h
+++ b/engines/hopkins/hopkins.h
@@ -161,7 +161,6 @@ public:
 	const Common::String &getTargetName() const;
 
 	int getRandomNumber(int maxNumber);
-	Common::String generateSaveName(int slotNumber);
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;

--- a/engines/hopkins/saveload.cpp
+++ b/engines/hopkins/saveload.cpp
@@ -150,7 +150,8 @@ Common::Error SaveLoadManager::saveGame(int slot, const Common::String &saveName
 	_vm->_globals->_saveData->_mapCarPosY = _vm->_objectsMan->_mapCarPosY;
 
 	/* Create the savegame */
-	Common::OutSaveFile *savefile = g_system->getSavefileManager()->openForSaving(_vm->generateSaveName(slot));
+	Common::OutSaveFile *savefile = g_system->getSavefileManager()->openForSaving(
+		_vm->getSaveStateName(slot));
 	if (!savefile)
 		return Common::kCreatingFileFailed;
 
@@ -176,7 +177,7 @@ Common::Error SaveLoadManager::saveGame(int slot, const Common::String &saveName
 Common::Error SaveLoadManager::loadGame(int slot) {
 	// Try and open the save file for reading
 	Common::InSaveFile *savefile = g_system->getSavefileManager()->openForLoading(
-		_vm->generateSaveName(slot));
+		_vm->getSaveStateName(slot));
 	if (!savefile)
 		return Common::kReadingFailed;
 
@@ -214,7 +215,7 @@ Common::Error SaveLoadManager::loadGame(int slot) {
 WARN_UNUSED_RESULT bool SaveLoadManager::readSavegameHeader(int slot, hopkinsSavegameHeader &header, bool skipThumbnail) {
 	// Try and open the save file for reading
 	Common::InSaveFile *savefile = g_system->getSavefileManager()->openForLoading(
-		_vm->generateSaveName(slot));
+		_vm->getSaveStateName(slot));
 	if (!savefile)
 		return false;
 

--- a/engines/hugo/file.cpp
+++ b/engines/hugo/file.cpp
@@ -311,7 +311,7 @@ bool FileManager::saveGame(const int16 slot, const Common::String &descrip) {
 	if (savegameId < 0)                             // dialog aborted
 		return false;
 
-	Common::String savegameFile = _vm->getSavegameFilename(savegameId);
+	Common::String savegameFile = _vm->getSaveStateName(savegameId);
 	Common::SaveFileManager *saveMan = g_system->getSavefileManager();
 	Common::OutSaveFile *out = saveMan->openForSaving(savegameFile);
 
@@ -407,7 +407,7 @@ bool FileManager::restoreGame(const int16 slot) {
 	if (savegameId < 0)                             // dialog aborted
 		return false;
 
-	Common::String savegameFile = _vm->getSavegameFilename(savegameId);
+	Common::String savegameFile = _vm->getSaveStateName(savegameId);
 	Common::SaveFileManager *saveMan = g_system->getSavefileManager();
 	Common::InSaveFile *in = saveMan->openForLoading(savegameFile);
 

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -176,7 +176,7 @@ void HugoEngine::setMaxScore(const int newScore) {
 	_maxscore = newScore;
 }
 
-Common::Error HugoEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error HugoEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return (_file->saveGame(slot, desc) ? Common::kWritingFailed : Common::kNoError);
 }
 

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -742,10 +742,8 @@ void HugoEngine::syncSoundSettings() {
 	_sound->syncVolume();
 }
 
-Common::String HugoEngine::getSavegameFilename(int slot) {
+Common::String HugoEngine::getSaveStateName(int slot) const {
 	return _targetName + Common::String::format("-%02d.SAV", slot);
 }
-
-
 
 } // End of namespace Hugo

--- a/engines/hugo/hugo.h
+++ b/engines/hugo/hugo.h
@@ -283,7 +283,7 @@ public:
 	void adjustScore(const int adjustment);
 	int getMaxScore() const;
 	void setMaxScore(const int newScore);
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
 	bool hasFeature(EngineFeature f) const override;
 	const char *getCopyrightString() const;

--- a/engines/hugo/hugo.h
+++ b/engines/hugo/hugo.h
@@ -288,7 +288,7 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 	const char *getCopyrightString() const;
 
-	Common::String getSavegameFilename(int slot);
+	virtual Common::String getSaveStateName(int slot) const override;
 	uint16 **loadLongArray(Common::SeekableReadStream &in);
 
 	FileManager *_file;

--- a/engines/illusions/illusions.h
+++ b/engines/illusions/illusions.h
@@ -226,7 +226,7 @@ public:
 	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
 	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error removeGameState(int slot);
 	bool savegame(const char *filename, const char *description);
 	bool loadgame(const char *filename);

--- a/engines/illusions/saveload.cpp
+++ b/engines/illusions/saveload.cpp
@@ -133,7 +133,7 @@ Common::Error IllusionsEngine::loadGameState(int slot) {
 	_savegameSlotNum = slot;
 	return Common::kNoError;
 }
-
+ 
 Common::Error IllusionsEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	const char *fileName = getSavegameFilename(slot);
 	if (!savegame(fileName, description.c_str()))

--- a/engines/illusions/saveload.cpp
+++ b/engines/illusions/saveload.cpp
@@ -134,7 +134,7 @@ Common::Error IllusionsEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error IllusionsEngine::saveGameState(int slot, const Common::String &description) {
+Common::Error IllusionsEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	const char *fileName = getSavegameFilename(slot);
 	if (!savegame(fileName, description.c_str()))
 		return Common::kWritingFailed;

--- a/engines/kyra/detection.cpp
+++ b/engines/kyra/detection.cpp
@@ -183,6 +183,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
+	virtual int getAutosaveSlot() const override { return 999; }
 };
 
 bool KyraMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/kyra/engine/eobcommon.cpp
+++ b/engines/kyra/engine/eobcommon.cpp
@@ -560,9 +560,6 @@ Common::Error EoBCoreEngine::init() {
 	memset(_monsterStoneOverlay, (_flags.platform == Common::kPlatformAmiga) ? guiSettings()->colors.guiColorWhite : 0x0D, 16 * sizeof(uint8));
 	_monsterFlashOverlay[0] = _monsterStoneOverlay[0] = 0;
 
-	// Prevent autosave on game startup
-	_lastAutosave = _system->getMillis();
-
 	return Common::kNoError;
 }
 

--- a/engines/kyra/engine/kyra_v1.cpp
+++ b/engines/kyra/engine/kyra_v1.cpp
@@ -194,9 +194,6 @@ Common::Error KyraEngine_v1::init() {
 
 	setupKeyMap();
 
-	// Prevent autosave on game startup
-	_lastAutosave = _system->getMillis();
-
 	return Common::kNoError;
 }
 
@@ -250,9 +247,6 @@ int KyraEngine_v1::checkInput(Button *buttonList, bool mainLoop, int eventFlag) 
 	_isSaveAllowed = mainLoop;
 	updateInput();
 	_isSaveAllowed = false;
-
-	if (mainLoop)
-		checkAutosave();
 
 	int keys = 0;
 	int8 mouseWheel = 0;

--- a/engines/kyra/gui/gui_hof.cpp
+++ b/engines/kyra/gui/gui_hof.cpp
@@ -961,8 +961,6 @@ int GUI_HoF::gameOptionsTalkie(Button *caller) {
 		_vm->saveGameStateIntern(999, "Autosave", &thumb);
 		thumb.free();
 
-		_vm->_lastAutosave = _vm->_system->getMillis();
-
 		_vm->loadCCodeBuffer("C_CODE.XXX");
 		if (_vm->_flags.isTalkie)
 			_vm->loadOptionsBuffer("OPTIONS.XXX");

--- a/engines/kyra/gui/gui_mr.cpp
+++ b/engines/kyra/gui/gui_mr.cpp
@@ -1341,8 +1341,6 @@ int GUI_MR::gameOptions(Button *caller) {
 		_vm->saveGameStateIntern(999, "Autosave", &thumb);
 		thumb.free();
 
-		_vm->_lastAutosave = _vm->_system->getMillis();
-
 		if (!_vm->loadLanguageFile("ITEMS.", _vm->_itemFile))
 			error("Couldn't load ITEMS");
 		if (!_vm->loadLanguageFile("SCORE.", _vm->_scoreFile))

--- a/engines/kyra/gui/saveload.cpp
+++ b/engines/kyra/gui/saveload.cpp
@@ -254,13 +254,6 @@ bool KyraEngine_v1::saveFileLoadable(int slot) {
 	return false;
 }
 
-void KyraEngine_v1::checkAutosave() {
-	if (shouldPerformAutoSave(_lastAutosave)) {
-		saveGameStateIntern(999, "Autosave", 0);
-		_lastAutosave = _system->getMillis();
-	}
-}
-
 void KyraEngine_v1::loadGameStateCheck(int slot) {
 	// FIXME: Instead of throwing away the error returned by
 	// loadGameState, we should use it / augment it.

--- a/engines/kyra/kyra_v1.h
+++ b/engines/kyra/kyra_v1.h
@@ -424,7 +424,9 @@ protected:
 
 	void loadGameStateCheck(int slot);
 	Common::Error loadGameState(int slot) override = 0;
-	Common::Error saveGameState(int slot, const Common::String &desc) override { return saveGameStateIntern(slot, desc.c_str(), 0); }
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override {
+		return saveGameStateIntern(slot, desc.c_str(), 0);
+	}
 	virtual Common::Error saveGameStateIntern(int slot, const char *saveName, const Graphics::Surface *thumbnail) = 0;
 
 	Common::SeekableReadStream *openSaveForReading(const char *filename, SaveHeader &header, bool checkID = true);

--- a/engines/kyra/kyra_v1.h
+++ b/engines/kyra/kyra_v1.h
@@ -388,13 +388,11 @@ protected:
 	// save/load
 	int _gameToLoad;
 
-	uint32 _lastAutosave;
-	void checkAutosave();
-
 	bool _isSaveAllowed;
 
 	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
 	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
+	virtual int getAutosaveSlot() const override { return 999; }
 
 	const char *getSavegameFilename(int num);
 	Common::String _savegameFilename;

--- a/engines/lab/lab.cpp
+++ b/engines/lab/lab.cpp
@@ -178,10 +178,6 @@ Common::Error LabEngine::run() {
 	return Common::kNoError;
 }
 
-Common::String LabEngine::generateSaveFileName(uint slot) {
-	return Common::String::format("%s.%03u", _targetName.c_str(), slot);
-}
-
 void LabEngine::drawStaticMessage(byte index) {
 	_graphics->drawMessage(_resource->getStaticText((StaticText)index), false);
 }

--- a/engines/lab/lab.cpp
+++ b/engines/lab/lab.cpp
@@ -216,7 +216,7 @@ Common::Error LabEngine::loadGameState(int slot) {
 	return (result) ? Common::kNoError : Common::kUserCanceled;
 }
 
-Common::Error LabEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error LabEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	bool result = saveGame(slot, desc);
 	return (result) ? Common::kNoError : Common::kUserCanceled;
 }

--- a/engines/lab/lab.h
+++ b/engines/lab/lab.h
@@ -227,7 +227,7 @@ public:
 	void waitTOF();
 
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 

--- a/engines/lab/lab.h
+++ b/engines/lab/lab.h
@@ -212,7 +212,6 @@ public:
 	uint32 getFeatures() const;
 
 	bool hasFeature(EngineFeature f) const override;
-	Common::String generateSaveFileName(uint slot);
 
 	void changeVolume(int delta);
 	uint16 getDirection() { return _direction; }

--- a/engines/lab/savegame.cpp
+++ b/engines/lab/savegame.cpp
@@ -126,7 +126,7 @@ WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeade
 }
 
 bool LabEngine::saveGame(int slot, const Common::String desc) {
-	Common::String fileName = generateSaveFileName(slot);
+	Common::String fileName = getSaveStateName(slot);
 	Common::SaveFileManager *saveFileManager = _system->getSavefileManager();
 	Common::OutSaveFile *file = saveFileManager->openForSaving(fileName);
 
@@ -171,7 +171,7 @@ bool LabEngine::saveGame(int slot, const Common::String desc) {
 }
 
 bool LabEngine::loadGame(int slot) {
-	Common::String fileName = generateSaveFileName(slot);
+	Common::String fileName = getSaveStateName(slot);
 	Common::SaveFileManager *saveFileManager = _system->getSavefileManager();
 	Common::InSaveFile *file = saveFileManager->openForLoading(fileName);
 

--- a/engines/lure/lure.h
+++ b/engines/lure/lure.h
@@ -121,7 +121,7 @@ public:
 	Common::Error loadGameState(int slot) override {
 		return loadGame(slot) ? Common::kNoError : Common::kReadingFailed;
 	}
-	Common::Error saveGameState(int slot, const Common::String &desc) override {
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override {
 		Common::String s(desc);
 		return saveGame(slot, s) ? Common::kNoError : Common::kReadingFailed;
 	}

--- a/engines/macventure/macventure.h
+++ b/engines/macventure/macventure.h
@@ -200,7 +200,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void newGame();
 	void setInitialFlags();
 	void setNewGameState();

--- a/engines/macventure/saveload.cpp
+++ b/engines/macventure/saveload.cpp
@@ -139,7 +139,7 @@ void writeMetaData(Common::OutSaveFile *file, Common::String desc) {
 }
 
 Common::Error MacVentureEngine::loadGameState(int slot) {
-	Common::String saveFileName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
+	Common::String saveFileName = getSaveStateName(slot);
 	Common::InSaveFile *file;
 	if(!(file = getSaveFileManager()->openForLoading(saveFileName))) {
 		error("ENGINE: Missing savegame file %s", saveFileName.c_str());
@@ -150,7 +150,7 @@ Common::Error MacVentureEngine::loadGameState(int slot) {
 }
 
 Common::Error MacVentureEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	Common::String saveFileName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
+	Common::String saveFileName = getSaveStateName(slot);
 	Common::SaveFileManager *manager = getSaveFileManager();
 	// HACK Get a real name!
 	Common::OutSaveFile *file = manager->openForSaving(saveFileName);

--- a/engines/macventure/saveload.cpp
+++ b/engines/macventure/saveload.cpp
@@ -149,7 +149,7 @@ Common::Error MacVentureEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error MacVentureEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error MacVentureEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String saveFileName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
 	Common::SaveFileManager *manager = getSaveFileManager();
 	// HACK Get a real name!

--- a/engines/mads/game.cpp
+++ b/engines/mads/game.cpp
@@ -476,7 +476,7 @@ void Game::synchronize(Common::Serializer &s, bool phase1) {
 
 void Game::loadGame(int slotNumber) {
 	_saveFile = g_system->getSavefileManager()->openForLoading(
-		_vm->generateSaveName(slotNumber));
+		_vm->getSaveStateName(slotNumber));
 
 	Common::Serializer s(_saveFile, nullptr);
 
@@ -505,7 +505,7 @@ void Game::loadGame(int slotNumber) {
 
 void Game::saveGame(int slotNumber, const Common::String &saveName) {
 	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
-		_vm->generateSaveName(slotNumber));
+		_vm->getSaveStateName(slotNumber));
 
 	MADSSavegameHeader header;
 	header._saveName = saveName;

--- a/engines/mads/mads.cpp
+++ b/engines/mads/mads.cpp
@@ -200,14 +200,6 @@ void MADSEngine::syncSoundSettings() {
 	loadOptions();
 }
 
-/**
-* Support method that generates a savegame name
-* @param slot		Slot number
-*/
-Common::String MADSEngine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
-}
-
 Common::Error MADSEngine::loadGameState(int slot) {
 	_game->_loadGameSlot = slot;
 	_game->_scene._currentSceneId = -1;

--- a/engines/mads/mads.cpp
+++ b/engines/mads/mads.cpp
@@ -215,7 +215,7 @@ Common::Error MADSEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error MADSEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error MADSEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	_game->saveGame(slot, desc);
 	return Common::kNoError;
 }

--- a/engines/mads/mads.h
+++ b/engines/mads/mads.h
@@ -137,12 +137,6 @@ public:
 	bool canSaveGameStateCurrently() override;
 
 	/**
-	* Support method that generates a savegame name
-	* @param slot		Slot number
-	*/
-	Common::String generateSaveName(int slot);
-
-	/**
 	 * Handles loading a game via the GMM
 	 */
 	Common::Error loadGameState(int slot) override;

--- a/engines/mads/mads.h
+++ b/engines/mads/mads.h
@@ -150,7 +150,7 @@ public:
 	/**
 	 * Handles saving the game via the GMM
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	/**
 	 * Handles updating sound settings after they're changed in the GMM dialog

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -61,7 +61,7 @@ struct ExtraGuiOption {
 
 typedef Common::Array<ExtraGuiOption> ExtraGuiOptions;
 
-#define EXTENDED_SAVE_VERSION 3
+#define EXTENDED_SAVE_VERSION 4
 
 struct ExtendedSavegameHeader {
 	char id[6];
@@ -72,6 +72,7 @@ struct ExtendedSavegameHeader {
 	uint16 time;
 	uint32 playtime;
 	Graphics::Surface *thumbnail;
+	bool isAutosave;
 
 	ExtendedSavegameHeader() {
 		memset(id, 0, 6);
@@ -80,6 +81,7 @@ struct ExtendedSavegameHeader {
 		time = 0;
 		playtime = 0;
 		thumbnail = nullptr;
+		isAutosave = false;
 	}
 };
 
@@ -340,7 +342,8 @@ public:
 	 */
 	virtual bool hasFeature(MetaEngineFeature f) const;
 
-	static void appendExtendedSave(Common::OutSaveFile *saveFile, uint32 playtime, Common::String desc);
+	static void appendExtendedSave(Common::OutSaveFile *saveFile, uint32 playtime,
+		Common::String desc, bool isAutosave);
 	static void parseSavegameHeader(ExtendedSavegameHeader *header, SaveStateDescriptor *desc);
 	static void fillDummyHeader(ExtendedSavegameHeader *header);
 	static WARN_UNUSED_RESULT bool readSavegameHeader(Common::InSaveFile *in, ExtendedSavegameHeader *header, bool skipThumbnail = true);

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -152,6 +152,26 @@ public:
 	virtual SaveStateList listSaves(const char *target) const;
 
 	/**
+	 * Return a list of all save states associated with the given target.
+	 *
+	 * This is a wrapper around the basic listSaves virtual method, but which
+	 * has some extra logic for autosave handling
+	 *
+	 * @param target	name of a config manager target
+	 * @param saveMode	If true, getting the list for a save dialog
+	 * @return			a list of save state descriptors
+	 */
+	SaveStateList listSaves(const char *target, bool saveMode) const;
+
+	/**
+	 * Returns the slot number being used for autosaves.
+	 * @note	This should match the engine getAutosaveSlot() method
+	 */
+	virtual int getAutosaveSlot() const {
+		return 0;
+	}
+
+	/**
 	 * Return a list of extra GUI options for the specified target.
 	 * If no target is specified, all of the available custom GUI options are
 	 * Returned for the plugin (used to set default values).

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -967,7 +967,7 @@ Common::Error MohawkEngine_Myst::saveGameState(int slot, const Common::String &d
 		thumbnail = _gfx->getThumbnailForMainMenu();
 	}
 
-	return _gameState->save(slot, desc, thumbnail, false) ? Common::kNoError : Common::kUnknownError;
+	return _gameState->save(slot, desc, thumbnail, isAutosave) ? Common::kNoError : Common::kUnknownError;
 }
 
 bool MohawkEngine_Myst::canSaveAutosaveCurrently() {

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -624,6 +624,11 @@ void MohawkEngine_Myst::doFrame() {
 				break;
 			}
 			break;
+		case Common::EVENT_QUIT:
+		case Common::EVENT_RTL:
+			// Attempt to autosave before exiting
+			saveAutosaveIfEnabled();
+			break;
 		default:
 			break;
 		}

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -968,7 +968,7 @@ Common::Error MohawkEngine_Myst::loadGameState(int slot) {
 	return Common::kUnknownError;
 }
 
-Common::Error MohawkEngine_Myst::saveGameState(int slot, const Common::String &desc) {
+Common::Error MohawkEngine_Myst::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	const Graphics::Surface *thumbnail = nullptr;
 	if (_stack->getStackId() == kMenuStack) {
 		thumbnail = _gfx->getThumbnailForMainMenu();

--- a/engines/mohawk/myst.h
+++ b/engines/mohawk/myst.h
@@ -189,6 +189,9 @@ public:
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+	Common::String getSaveStateName(int slot) const override {
+		return Common::String::format("myst-%03d.mys", slot);
+	}
 	virtual bool canSaveAutosaveCurrently() override;
 
 	bool hasFeature(EngineFeature f) const override;

--- a/engines/mohawk/myst.h
+++ b/engines/mohawk/myst.h
@@ -189,7 +189,8 @@ public:
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	void tryAutoSaving();
+	virtual bool canSaveAutosaveCurrently() override;
+
 	bool hasFeature(EngineFeature f) const override;
 	static Common::Array<Common::Keymap *> initKeymaps(const char *target);
 
@@ -207,7 +208,6 @@ private:
 
 	MystCardPtr _card;
 	MystCardPtr _prevCard;
-	uint32 _lastSaveTime;
 
 	bool hasGameSaveSupport() const;
 	void pauseEngineIntern(bool pause) override;

--- a/engines/mohawk/myst.h
+++ b/engines/mohawk/myst.h
@@ -188,7 +188,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void tryAutoSaving();
 	bool hasFeature(EngineFeature f) const override;
 	static Common::Array<Common::Keymap *> initKeymaps(const char *target);

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -320,10 +320,12 @@ SaveStateDescriptor MystGameState::querySaveMetaInfos(int slot) {
 	}
 
 	// Set the save description
+	desc.setSaveSlot(slot);
 	desc.setDescription(metadata.saveDescription);
 	desc.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
 	desc.setSaveTime(metadata.saveHour, metadata.saveMinute);
 	desc.setPlayTime(metadata.totalPlayTime);
+	desc.setAutosave(metadata.autoSave);
 	if (metadata.autoSave) // Allow non-saves to be deleted, but not autosaves
 		desc.setDeletableFlag(slot != kAutoSaveSlot);
 

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -748,7 +748,8 @@ void MohawkEngine_Riven::saveGameStateAndDisplayError(int slot, const Common::St
 }
 
 bool MohawkEngine_Riven::canSaveAutosaveCurrently() {
-	return canSaveGameStateCurrently() && !_gameEnded;
+	return canSaveGameStateCurrently() && !_gameEnded &&
+		_saveLoad->isAutoSaveAllowed();
 }
 
 void MohawkEngine_Riven::addZipVisitedCard(uint16 cardId, uint16 cardNameId) {

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -229,10 +229,6 @@ void MohawkEngine_Riven::doFrame() {
 		_scriptMan->runQueuedScripts();
 	}
 
-	if (shouldPerformAutoSave(_lastSaveTime)) {
-		tryAutoSaving();
-	}
-
 	_inventory->onFrame();
 
 	// Update the screen once per frame
@@ -314,7 +310,6 @@ void MohawkEngine_Riven::processInput() {
 		case Common::EVENT_QUIT:
 		case Common::EVENT_RTL:
 			// Attempt to autosave before exiting
-			tryAutoSaving();
 			break;
 		default:
 			break;
@@ -751,22 +746,9 @@ void MohawkEngine_Riven::saveGameStateAndDisplayError(int slot, const Common::St
 	}
 }
 
-void MohawkEngine_Riven::tryAutoSaving() {
-	if (!canSaveGameStateCurrently() || _gameEnded) {
-		return; // Can't save right now, try again on the next frame
-	}
-
-	_lastSaveTime = _system->getMillis();
-
-	if (!_saveLoad->isAutoSaveAllowed()) {
-		return; // Can't autosave ever, try again after the next autosave delay
-	}
-
-	Common::Error saveError = saveGameState(RivenSaveLoad::kAutoSaveSlot, "Autosave", true);
-	if (saveError.getCode() != Common::kNoError)
-		warning("Attempt to autosave has failed.");
+bool MohawkEngine_Riven::canSaveAutosaveCurrently() {
+	return canSaveGameStateCurrently() && !_gameEnded;
 }
-
 
 void MohawkEngine_Riven::addZipVisitedCard(uint16 cardId, uint16 cardNameId) {
 	Common::String cardName = getStack()->getName(kCardNames, cardNameId);
@@ -844,7 +826,6 @@ void MohawkEngine_Riven::runOptionsDialog() {
 
 	if (hasGameEnded()) {
 		// Attempt to autosave before exiting
-		tryAutoSaving();
 	}
 
 	_gfx->setTransitionMode((RivenTransitionMode) _vars["transitionmode"]);

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -723,18 +723,14 @@ void MohawkEngine_Riven::loadGameStateAndDisplayError(int slot) {
 	}
 }
 
-Common::Error MohawkEngine_Riven::saveGameState(int slot, const Common::String &desc) {
-	return saveGameState(slot, desc, false);
-}
-
-Common::Error MohawkEngine_Riven::saveGameState(int slot, const Common::String &desc, bool autosave) {
+Common::Error MohawkEngine_Riven::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	if (_menuSavedStack != -1) {
 		_vars["CurrentStackID"] = _menuSavedStack;
 		_vars["CurrentCardID"] = _menuSavedCard;
 	}
 
 	const Graphics::Surface *thumbnail = _menuSavedStack != -1 ? _menuThumbnail.get() : nullptr;
-	Common::Error error = _saveLoad->saveGame(slot, desc, thumbnail, autosave);
+	Common::Error error = _saveLoad->saveGame(slot, desc, thumbnail, isAutosave);
 
 	if (_menuSavedStack != -1) {
 		_vars["CurrentStackID"] = 1;

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -310,6 +310,7 @@ void MohawkEngine_Riven::processInput() {
 		case Common::EVENT_QUIT:
 		case Common::EVENT_RTL:
 			// Attempt to autosave before exiting
+			saveAutosaveIfEnabled();
 			break;
 		default:
 			break;
@@ -826,6 +827,7 @@ void MohawkEngine_Riven::runOptionsDialog() {
 
 	if (hasGameEnded()) {
 		// Attempt to autosave before exiting
+		saveAutosaveIfEnabled();
 	}
 
 	_gfx->setTransitionMode((RivenTransitionMode) _vars["transitionmode"]);

--- a/engines/mohawk/riven.h
+++ b/engines/mohawk/riven.h
@@ -104,7 +104,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool hasFeature(EngineFeature f) const override;
 	static Common::Array<Common::Keymap *> initKeymaps(const char *target);
 
@@ -168,7 +168,6 @@ public:
 	void runSaveDialog();
 	void tryAutoSaving();
 	void loadGameStateAndDisplayError(int slot);
-	Common::Error saveGameState(int slot, const Common::String &desc, bool autosave) override;
 	void saveGameStateAndDisplayError(int slot, const Common::String &desc);
 
 	/**

--- a/engines/mohawk/riven.h
+++ b/engines/mohawk/riven.h
@@ -166,7 +166,7 @@ public:
 	// Save / Load
 	void runLoadDialog();
 	void runSaveDialog();
-	void tryAutoSaving();
+	virtual bool canSaveAutosaveCurrently() override;
 	void loadGameStateAndDisplayError(int slot);
 	void saveGameStateAndDisplayError(int slot, const Common::String &desc);
 

--- a/engines/mohawk/riven.h
+++ b/engines/mohawk/riven.h
@@ -105,6 +105,9 @@ public:
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+	Common::String getSaveStateName(int slot) const override {
+		return Common::String::format("riven-%03d.rvn", slot);
+	}
 	bool hasFeature(EngineFeature f) const override;
 	static Common::Array<Common::Keymap *> initKeymaps(const char *target);
 

--- a/engines/mohawk/riven_saveload.cpp
+++ b/engines/mohawk/riven_saveload.cpp
@@ -60,8 +60,6 @@ bool RivenSaveMetadata::sync(Common::Serializer &s) {
 	return true;
 }
 
-const int RivenSaveLoad::kAutoSaveSlot = 0;
-
 RivenSaveLoad::RivenSaveLoad(MohawkEngine_Riven *vm, Common::SaveFileManager *saveFileMan) : _vm(vm), _saveFileMan(saveFileMan) {
 }
 
@@ -110,7 +108,6 @@ SaveStateDescriptor RivenSaveLoad::querySaveMetaInfos(const int slot) {
 	Common::String filename = buildSaveFilename(slot);
 	Common::InSaveFile *loadFile = g_system->getSavefileManager()->openForLoading(filename);
 	SaveStateDescriptor descriptor;
-	descriptor.setWriteProtectedFlag(slot == kAutoSaveSlot);
 
 	if (!loadFile) {
 		return descriptor;
@@ -142,8 +139,6 @@ SaveStateDescriptor RivenSaveLoad::querySaveMetaInfos(const int slot) {
 	descriptor.setPlayTime(metadata.totalPlayTime);
 	descriptor.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
 	descriptor.setSaveTime(metadata.saveHour, metadata.saveMinute);
-	if (metadata.autoSave) // Allow non-saves to be deleted, but not autosaves
-		descriptor.setDeletableFlag(slot != kAutoSaveSlot);	
 
 	delete metaStream;
 
@@ -171,7 +166,7 @@ bool RivenSaveLoad::isAutoSaveAllowed() {
 	// Open autosave slot and see if it an autosave
 	// Autosaving will be enabled if it is an autosave or if there is no save in that slot
 
-	Common::String filename = buildSaveFilename(kAutoSaveSlot);
+	Common::String filename = buildSaveFilename(_vm->getAutosaveSlot());
 	Common::InSaveFile *loadFile = g_system->getSavefileManager()->openForLoading(filename);
 	if (!loadFile) {
 		return true; // There is no save in the autosave slot, enable autosave

--- a/engines/mohawk/riven_saveload.cpp
+++ b/engines/mohawk/riven_saveload.cpp
@@ -135,10 +135,12 @@ SaveStateDescriptor RivenSaveLoad::querySaveMetaInfos(const int slot) {
 		return descriptor;
 	}
 
+	descriptor.setSaveSlot(slot);
 	descriptor.setDescription(metadata.saveDescription);
 	descriptor.setPlayTime(metadata.totalPlayTime);
 	descriptor.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
 	descriptor.setSaveTime(metadata.saveHour, metadata.saveMinute);
+	descriptor.setAutosave(metadata.autoSave);
 
 	delete metaStream;
 

--- a/engines/mohawk/riven_saveload.h
+++ b/engines/mohawk/riven_saveload.h
@@ -59,8 +59,6 @@ struct RivenSaveMetadata {
 
 class RivenSaveLoad {
 public:
-	static const int kAutoSaveSlot;
-
 	RivenSaveLoad(MohawkEngine_Riven*, Common::SaveFileManager*);
 	~RivenSaveLoad();
 

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -433,7 +433,7 @@ Common::Error MortevielleEngine::run() {
 	adzon();
 	resetVariables();
 	if (loadSlot != 0)
-		_savegameManager->loadSavegame(generateSaveFilename(loadSlot));
+		_savegameManager->loadSavegame(getSaveStateName(loadSlot));
 
 	// Run the main game loop
 	mainGame();

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -203,7 +203,7 @@ Common::Error MortevielleEngine::loadGameState(int slot) {
 /**
  * Save the current game
  */
-Common::Error MortevielleEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error MortevielleEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	if (slot == 0)
 		return Common::kWritingFailed;
 

--- a/engines/mortevielle/mortevielle.h
+++ b/engines/mortevielle/mortevielle.h
@@ -442,7 +442,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error run() override;
 	void pauseEngineIntern(bool pause) override;
 	uint32 getGameFlags() const;

--- a/engines/mortevielle/mortevielle.h
+++ b/engines/mortevielle/mortevielle.h
@@ -450,7 +450,9 @@ public:
 	Common::Language getOriginalLanguage() const;
 	bool useOriginalData() const;
 	static Common::String generateSaveFilename(const Common::String &target, int slot);
-	Common::String generateSaveFilename(int slot) { return generateSaveFilename(_targetName, slot); }
+	Common::String getSaveStateName(int slot) const override {
+		return generateSaveFilename(_targetName, slot);
+	}
 
 	int getChar();
 	bool keyPressed();

--- a/engines/mortevielle/saveload.cpp
+++ b/engines/mortevielle/saveload.cpp
@@ -147,7 +147,7 @@ Common::Error SavegameManager::saveGame(int n, const Common::String &saveName) {
 	if (g_vm->_saveStruct._currPlace == ROOM26)
 		g_vm->_saveStruct._currPlace = LANDING;
 
-	Common::String filename = _vm->generateSaveFilename(n);
+	Common::String filename = _vm->getSaveStateName(n);
 	f = g_system->getSavefileManager()->openForSaving(filename);
 
 	// Write out the savegame header
@@ -172,11 +172,11 @@ Common::Error SavegameManager::saveGame(int n, const Common::String &saveName) {
 }
 
 Common::Error SavegameManager::loadGame(int slot) {
-	return loadGame(_vm->generateSaveFilename(slot));
+	return loadGame(_vm->getSaveStateName(slot));
 }
 
 Common::Error SavegameManager::saveGame(int slot) {
-	return saveGame(slot, _vm->generateSaveFilename(slot));
+	return saveGame(slot, _vm->getSaveStateName(slot));
 }
 
 void SavegameManager::writeSavegameHeader(Common::OutSaveFile *out, const Common::String &saveName) {

--- a/engines/mutationofjb/mutationofjb.cpp
+++ b/engines/mutationofjb/mutationofjb.cpp
@@ -125,7 +125,7 @@ bool MutationOfJBEngine::canLoadGameStateCurrently() {
 }
 
 Common::Error MutationOfJBEngine::loadGameState(int slot) {
-	const Common::String saveName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
+	const Common::String saveName = getSaveStateName(slot);
 	Common::InSaveFile *const saveFile = g_system->getSavefileManager()->openForLoading(saveName);
 	if (!saveFile)
 		return Common::kReadingFailed;
@@ -148,8 +148,8 @@ bool MutationOfJBEngine::canSaveGameStateCurrently() {
 }
 
 Common::Error MutationOfJBEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	const Common::String saveName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
-	Common::OutSaveFile *const saveFile = g_system->getSavefileManager()->openForSaving(saveName);
+	Common::OutSaveFile *const saveFile = g_system->getSavefileManager()->openForSaving(
+		getSaveStateName(slot));
 	if (!saveFile)
 		return Common::kWritingFailed;
 

--- a/engines/mutationofjb/mutationofjb.cpp
+++ b/engines/mutationofjb/mutationofjb.cpp
@@ -147,7 +147,7 @@ bool MutationOfJBEngine::canSaveGameStateCurrently() {
 	return _game->loadSaveAllowed();
 }
 
-Common::Error MutationOfJBEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error MutationOfJBEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	const Common::String saveName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
 	Common::OutSaveFile *const saveFile = g_system->getSavefileManager()->openForSaving(saveName);
 	if (!saveFile)

--- a/engines/mutationofjb/mutationofjb.h
+++ b/engines/mutationofjb/mutationofjb.h
@@ -69,7 +69,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	bool canSaveGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	const ADGameDescription *getGameDescription() const;
 

--- a/engines/neverhood/neverhood.h
+++ b/engines/neverhood/neverhood.h
@@ -121,7 +121,7 @@ public:
 	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
 
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 	Common::Error removeGameState(int slot);
 	bool savegame(const char *filename, const char *description);
 	bool loadgame(const char *filename);

--- a/engines/neverhood/neverhood.h
+++ b/engines/neverhood/neverhood.h
@@ -125,7 +125,7 @@ public:
 	Common::Error removeGameState(int slot);
 	bool savegame(const char *filename, const char *description);
 	bool loadgame(const char *filename);
-	const char *getSavegameFilename(int num);
+	Common::String getSaveStateName(int slot) const override;
 	static Common::String getSavegameFilename(const Common::String &target, int num);
 	WARN_UNUSED_RESULT static kReadSaveHeaderError readSaveHeader(Common::SeekableReadStream *in, SaveHeader &header, bool skipThumbnail = true);
 

--- a/engines/neverhood/saveload.cpp
+++ b/engines/neverhood/saveload.cpp
@@ -130,15 +130,15 @@ bool NeverhoodEngine::loadgame(const char *filename) {
 }
 
 Common::Error NeverhoodEngine::loadGameState(int slot) {
-	const char *fileName = getSavegameFilename(slot);
-	if (!loadgame(fileName))
+	Common::String fileName = getSaveStateName(slot);
+	if (!loadgame(fileName.c_str()))
 		return Common::kReadingFailed;
 	return Common::kNoError;
 }
 
 Common::Error NeverhoodEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
-	const char *fileName = getSavegameFilename(slot);
-	if (!savegame(fileName, description.c_str()))
+	Common::String fileName = getSaveStateName(slot);
+	if (!savegame(fileName.c_str(), description.c_str()))
 		return Common::kWritingFailed;
 	return Common::kNoError;
 }
@@ -150,10 +150,8 @@ Common::Error NeverhoodEngine::removeGameState(int slot) {
 	return Common::kNoError;
 }
 
-const char *NeverhoodEngine::getSavegameFilename(int num) {
-	static Common::String filename;
-	filename = getSavegameFilename(_targetName, num);
-	return filename.c_str();
+Common::String NeverhoodEngine::getSaveStateName(int slot) const {
+	return getSavegameFilename(_targetName, slot);
 }
 
 Common::String NeverhoodEngine::getSavegameFilename(const Common::String &target, int num) {

--- a/engines/neverhood/saveload.cpp
+++ b/engines/neverhood/saveload.cpp
@@ -136,7 +136,7 @@ Common::Error NeverhoodEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error NeverhoodEngine::saveGameState(int slot, const Common::String &description) {
+Common::Error NeverhoodEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	const char *fileName = getSavegameFilename(slot);
 	if (!savegame(fileName, description.c_str()))
 		return Common::kWritingFailed;

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -696,7 +696,7 @@ static bool isValidSaveFileName(const Common::String &desc) {
 	return true;
 }
 
-Common::Error PegasusEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error PegasusEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	if (!isValidSaveFileName(desc))
 		return Common::Error(Common::kCreatingFileFailed, _("Invalid file name for saving"));
 

--- a/engines/pegasus/pegasus.h
+++ b/engines/pegasus/pegasus.h
@@ -82,6 +82,7 @@ public:
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+
 	static Common::Array<Common::Keymap *> initKeymaps();
 
 	// Base classes

--- a/engines/pegasus/pegasus.h
+++ b/engines/pegasus/pegasus.h
@@ -81,7 +81,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	static Common::Array<Common::Keymap *> initKeymaps();
 
 	// Base classes

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -99,7 +99,7 @@ public:
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
 
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 
 	static void pauseEngine(void *engine, bool pause); // for MacWndMgr

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -101,6 +101,9 @@ public:
 
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
+	virtual Common::String getSaveStateName(int slot) const override {
+		return Common::String::format("%s.s%02d", _targetName.c_str(), slot);
+	}
 
 	static void pauseEngine(void *engine, bool pause); // for MacWndMgr
 

--- a/engines/pink/saveload.cpp
+++ b/engines/pink/saveload.cpp
@@ -49,7 +49,7 @@ Common::Error PinkEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error PinkEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error PinkEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *out = _saveFileMan->openForSaving(generateSaveName(slot, _targetName.c_str()));
 	if (!out)
 		return Common::kUnknownError;

--- a/engines/prince/prince.h
+++ b/engines/prince/prince.h
@@ -291,7 +291,6 @@ public:
 	void playVideo(Common::String videoFilename);
 
 	WARN_UNUSED_RESULT static bool readSavegameHeader(Common::InSaveFile *in, SavegameHeader &header, bool skipThumbnail = true);
-	Common::String generateSaveName(int slot);
 	void writeSavegameHeader(Common::OutSaveFile *out, SavegameHeader &header);
 	void syncGame(Common::SeekableReadStream *readStream, Common::WriteStream *writeStream);
 	bool loadGame(int slotNumber);

--- a/engines/prince/prince.h
+++ b/engines/prince/prince.h
@@ -285,7 +285,7 @@ public:
 	void pauseEngineIntern(bool pause) override;
 	bool canSaveGameStateCurrently() override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
 
 	void playVideo(Common::String videoFilename);

--- a/engines/prince/saveload.cpp
+++ b/engines/prince/saveload.cpp
@@ -146,7 +146,7 @@ bool PrinceEngine::canLoadGameStateCurrently() {
 
 Common::Error PrinceEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	// Set up the serializer
-	Common::String slotName = generateSaveName(slot);
+	Common::String slotName = getSaveStateName(slot);
 	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(slotName);
 
 	// Write out the ScummVM savegame header
@@ -163,10 +163,6 @@ Common::Error PrinceEngine::saveGameState(int slot, const Common::String &desc, 
 	delete saveFile;
 
 	return Common::kNoError;
-}
-
-Common::String PrinceEngine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
 }
 
 void PrinceEngine::writeSavegameHeader(Common::OutSaveFile *out, SavegameHeader &header) {
@@ -435,7 +431,7 @@ bool PrinceEngine::loadGame(int slotNumber) {
 	Common::MemoryReadStream *readStream;
 
 	// Open up the savegame file
-	Common::String slotName = generateSaveName(slotNumber);
+	Common::String slotName = getSaveStateName(slotNumber);
 	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(slotName);
 
 	// Read the data into a data buffer

--- a/engines/prince/saveload.cpp
+++ b/engines/prince/saveload.cpp
@@ -144,7 +144,7 @@ bool PrinceEngine::canLoadGameStateCurrently() {
 	return false;
 }
 
-Common::Error PrinceEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error PrinceEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	// Set up the serializer
 	Common::String slotName = generateSaveName(slot);
 	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(slotName);

--- a/engines/queen/detection.cpp
+++ b/engines/queen/detection.cpp
@@ -501,6 +501,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 99; }
 	void removeSaveState(const char *target, int slot) const override;
+	int getAutosaveSlot() const override { return 99; }
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const override;
 };

--- a/engines/queen/queen.cpp
+++ b/engines/queen/queen.cpp
@@ -182,7 +182,7 @@ bool QueenEngine::canSaveGameStateCurrently() {
 	return canLoadOrSave();
 }
 
-Common::Error QueenEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error QueenEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	debug(3, "Saving game to slot %d", slot);
 	char name[20];
 	Common::Error err = Common::kNoError;

--- a/engines/queen/queen.cpp
+++ b/engines/queen/queen.cpp
@@ -154,10 +154,6 @@ void QueenEngine::update(bool checkPlayerInput) {
 			_input->quickLoadReset();
 			loadGameState(SLOT_QUICKSAVE);
 		}
-		if (shouldPerformAutoSave(_lastSaveTime)) {
-			saveGameState(SLOT_AUTOSAVE, "Autosave");
-			_lastSaveTime = _system->getMillis();
-		}
 	}
 	if (!_input->cutawayRunning()) {
 		if (checkPlayerInput) {
@@ -274,15 +270,20 @@ Common::InSaveFile *QueenEngine::readGameStateHeader(int slot, GameStateHeader *
 	return file;
 }
 
-void QueenEngine::makeGameStateName(int slot, char *buf) const {
+Common::String QueenEngine::getSaveStateName(int slot) const {
 	if (slot == SLOT_LISTPREFIX) {
-		strcpy(buf, "queen.s??");
+		return "queen.s??";
 	} else if (slot == SLOT_AUTOSAVE) {
-		strcpy(buf, "queen.asd");
-	} else {
-		assert(slot >= 0);
-		sprintf(buf, "queen.s%02d", slot);
+		slot = getAutosaveSlot();
 	}
+
+	assert(slot >= 0);
+	return Common::String::format("queen.s%02d", slot);
+}
+
+void QueenEngine::makeGameStateName(int slot, char *buf) const {
+	Common::String name = getSaveStateName(slot);
+	strcpy(buf, name.c_str());
 }
 
 int QueenEngine::getGameStateSlot(const char *filename) const {
@@ -354,7 +355,6 @@ Common::Error QueenEngine::run() {
 	if (ConfMan.hasKey("save_slot") && canLoadOrSave()) {
 		loadGameState(ConfMan.getInt("save_slot"));
 	}
-	_lastSaveTime = _lastUpdateTime = _system->getMillis();
 
 	while (!shouldQuit()) {
 		if (_logic->newRoom() > 0) {

--- a/engines/queen/queen.h
+++ b/engines/queen/queen.h
@@ -96,7 +96,7 @@ public:
 	bool canLoadOrSave() const;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
 	void makeGameStateName(int slot, char *buf) const;
 	int getGameStateSlot(const char *filename) const;

--- a/engines/queen/queen.h
+++ b/engines/queen/queen.h
@@ -98,6 +98,8 @@ public:
 	bool canSaveGameStateCurrently() override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
+	virtual int getAutosaveSlot() const { return 99; }
+	virtual Common::String getSaveStateName(int slot) const override;
 	void makeGameStateName(int slot, char *buf) const;
 	int getGameStateSlot(const char *filename) const;
 	void findGameStateDescriptions(char descriptions[100][32]);
@@ -126,7 +128,6 @@ protected:
 
 	int _talkSpeed;
 	bool _subtitles;
-	uint32 _lastSaveTime;
 	uint32 _lastUpdateTime;
 	bool _gameStarted;
 

--- a/engines/saga/detection.cpp
+++ b/engines/saga/detection.cpp
@@ -334,7 +334,7 @@ Common::Error SagaEngine::loadGameState(int slot) {
 	return Common::kNoError;	// TODO: return success/failure
 }
 
-Common::Error SagaEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error SagaEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	save(calcSaveFileName((uint)slot), desc.c_str());
 	return Common::kNoError;	// TODO: return success/failure
 }

--- a/engines/saga/saga.h
+++ b/engines/saga/saga.h
@@ -628,7 +628,7 @@ public:
 
 	const Common::Rect &getDisplayClip() const { return _displayClip;}
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	const GameDisplayInfo &getDisplayInfo();

--- a/engines/saga/saga.h
+++ b/engines/saga/saga.h
@@ -481,6 +481,9 @@ public:
 	}
 	void fillSaveList();
 	char *calcSaveFileName(uint slotNumber);
+	virtual Common::String getSaveStateName(int slot) const override {
+		return Common::String::format("%s.s%02u", _targetName.c_str(), slot);
+	}
 
 	SaveFileData *getSaveFile(uint idx);
 	uint getNewSaveSlotNumber() const;

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -23,16 +23,19 @@
 #include "engines/savestate.h"
 #include "graphics/surface.h"
 #include "common/textconsole.h"
+#include "common/translation.h"
 
 SaveStateDescriptor::SaveStateDescriptor()
 	// FIXME: default to 0 (first slot) or to -1 (invalid slot) ?
 	: _slot(-1), _description(), _isDeletable(true), _isWriteProtected(false),
-	  _isLocked(false), _saveDate(), _saveTime(), _playTime(), _playTimeMSecs(0), _thumbnail() {
+	  _isLocked(false), _saveDate(), _saveTime(), _playTime(), _playTimeMSecs(0),
+	_thumbnail(), _saveType(kSaveTypeUndetermined) {
 }
 
 SaveStateDescriptor::SaveStateDescriptor(int s, const Common::String &d)
 	: _slot(s), _description(d), _isDeletable(true), _isWriteProtected(false),
-	  _isLocked(false), _saveDate(), _saveTime(), _playTime(), _playTimeMSecs(0), _thumbnail() {
+	  _isLocked(false), _saveDate(), _saveTime(), _playTime(), _playTimeMSecs(0),
+	_thumbnail(), _saveType(kSaveTypeUndetermined) {
 }
 
 void SaveStateDescriptor::setThumbnail(Graphics::Surface *t) {
@@ -59,4 +62,16 @@ void SaveStateDescriptor::setPlayTime(uint32 msecs) {
 	_playTimeMSecs = msecs;
 	uint minutes = msecs / 60000;
 	setPlayTime(minutes / 60, minutes % 60);
+}
+
+void SaveStateDescriptor::setAutosave(bool autosave) {
+	_saveType = autosave ? kSaveTypeAutosave : kSaveTypeRegular;
+}
+
+bool SaveStateDescriptor::isAutosave() const {
+	if (_saveType != kSaveTypeUndetermined) {
+		return _saveType == kSaveTypeAutosave;
+	} else {
+		return _description == _("Autosave");
+	}
 }

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -43,6 +43,12 @@ struct Surface;
  * Saves are writable and deletable by default.
  */
 class SaveStateDescriptor {
+private:
+	enum SaveType {
+		kSaveTypeUndetermined,
+		kSaveTypeRegular,
+		kSaveTypeAutosave
+	};
 public:
 	SaveStateDescriptor();
 	SaveStateDescriptor(int s, const Common::String &d);
@@ -185,6 +191,15 @@ public:
 	 */
 	uint32 getPlayTimeMSecs() const { return _playTimeMSecs; }
 
+	/**
+	 * Sets whether the save is an autosave
+	 */
+	void setAutosave(bool autosave);
+
+	/**
+	 * Returns true whether the save is an autosave
+	 */
+	bool isAutosave() const;
 private:
 	/**
 	 * The saveslot id, as it would be passed to the "-x" command line switch.
@@ -237,6 +252,11 @@ private:
 	 * The thumbnail of the save state.
 	 */
 	Common::SharedPtr<Graphics::Surface> _thumbnail;
+
+	/**
+	 * Save file type
+	 */
+	SaveType _saveType;
 };
 
 /** List of savestates. */

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -937,7 +937,7 @@ Common::Error SciEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error SciEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error SciEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String fileName = Common::String::format("%s.%03d", _targetName.c_str(), slot);
 	Common::SaveFileManager *saveFileMan = g_engine->getSaveFileManager();
 	Common::OutSaveFile *out = saveFileMan->openForSaving(fileName);

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -260,7 +260,7 @@ public:
 	void severeError();
 	Console *getSciDebugger();
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	void syncSoundSettings() override; ///< from ScummVM to the game

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -102,7 +102,7 @@ bool ScummEngine::canLoadGameStateCurrently() {
 	return (VAR_MAINMENU_KEY == 0xFF || VAR(VAR_MAINMENU_KEY) != 0);
 }
 
-Common::Error ScummEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error ScummEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	requestSave(slot, desc);
 	return Common::kNoError;
 }

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -434,7 +434,7 @@ public:
 
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 
 	void pauseEngineIntern(bool pause) override;

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -436,6 +436,10 @@ public:
 	bool canLoadGameStateCurrently() override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
+	bool canSaveAutosaveCurrently() override {
+		// Keep base engine autosave code disabled in favour of engine's autosave code
+		return false;
+	}
 
 	void pauseEngineIntern(bool pause) override;
 

--- a/engines/sherlock/sherlock.cpp
+++ b/engines/sherlock/sherlock.cpp
@@ -279,7 +279,7 @@ Common::Error SherlockEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error SherlockEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error SherlockEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	_saves->saveGame(slot, desc);
 	return Common::kNoError;
 }

--- a/engines/sherlock/sherlock.h
+++ b/engines/sherlock/sherlock.h
@@ -162,7 +162,7 @@ public:
 	/**
 	 * Called by the GMM to save the game
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	/**
 	 * Called by the engine when sound settings are updated

--- a/engines/sky/control.h
+++ b/engines/sky/control.h
@@ -185,12 +185,11 @@ public:
 	void doLoadSavePanel();
 	void restartGame();
 	void showGameQuitMsg();
-	void doAutoSave();
 	uint16 quickXRestore(uint16 slot);
 	bool loadSaveAllowed();
 
 	uint16 _selectedGame;
-	uint16 saveGameToFile(bool fromControlPanel, const char *filename = 0);
+	uint16 saveGameToFile(bool fromControlPanel, const char *filename = 0, bool isAutosave = false);
 
 	void loadDescriptions(Common::StringArray &list);
 	void saveDescriptions(const Common::StringArray &list);

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -317,7 +317,7 @@ Common::Error SkyEngine::loadGameState(int slot) {
 	return (result == GAME_RESTORED) ? Common::kNoError : Common::kUnknownError;
 }
 
-Common::Error SkyEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error SkyEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	if (slot == 0)
 		return Common::kWritePermissionDenied;	// we can't overwrite the auto save
 

--- a/engines/sky/sky.cpp
+++ b/engines/sky/sky.cpp
@@ -186,17 +186,8 @@ Common::Error SkyEngine::go() {
 		}
 	}
 
-	_lastSaveTime = _system->getMillis();
-
 	uint32 delayCount = _system->getMillis();
 	while (!shouldQuit()) {
-		if (shouldPerformAutoSave(_lastSaveTime)) {
-			if (_skyControl->loadSaveAllowed()) {
-				_lastSaveTime = _system->getMillis();
-				_skyControl->doAutoSave();
-			} else
-				_lastSaveTime += 30 * 1000; // try again in 30 secs
-		}
 		_skySound->checkFxQueue();
 		_skyMouse->mouseEngine();
 		handleKey();

--- a/engines/sky/sky.h
+++ b/engines/sky/sky.h
@@ -90,6 +90,9 @@ public:
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
+	virtual Common::String getSaveStateName(int slot) const override {
+		return Common::String::format("SKY-VM.%03d", slot);
+	}
 
 	static void *fetchItem(uint32 num);
 	static void *_itemList[300];
@@ -114,8 +117,6 @@ protected:
 
 	void delay(int32 amount);
 	void handleKey();
-
-	uint32 _lastSaveTime;
 
 	void initItemList();
 

--- a/engines/sky/sky.h
+++ b/engines/sky/sky.h
@@ -87,7 +87,7 @@ public:
 	static bool isCDVersion();
 
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 

--- a/engines/supernova/supernova.cpp
+++ b/engines/supernova/supernova.cpp
@@ -691,6 +691,15 @@ bool SupernovaEngine::deserialize(Common::ReadStream *in, int version) {
 	return true;
 }
 
+Common::String SupernovaEngine::getSaveStateName(int slot) const {
+	if (_MSPart == 1)
+		return Common::String::format("msn_save.%03d", slot);
+	else if (_MSPart == 2)
+		return Common::String::format("ms2_save.%03d", slot);
+
+	return "";
+}
+
 bool SupernovaEngine::loadGame(int slot) {
 	if (slot < 0)
 		return false;
@@ -713,11 +722,7 @@ bool SupernovaEngine::loadGame(int slot) {
 		// continue to try to load it from there.
 	}
 
-	Common::String filename;
-	if (_MSPart == 1)
-		filename = Common::String::format("msn_save.%03d", slot);
-	else if (_MSPart == 2)
-		filename = Common::String::format("ms2_save.%03d", slot);
+	Common::String filename = getSaveStateName(slot);
 	Common::InSaveFile *savefile = _saveFileMan->openForLoading(filename);
 	if (!savefile)
 		return false;
@@ -780,12 +785,7 @@ bool SupernovaEngine::saveGame(int slot, const Common::String &description) {
 		return true;
 	}
 
-	Common::String filename;
-	if (_MSPart == 1)
-		filename = Common::String::format("msn_save.%03d", slot);
-	else if (_MSPart == 2)
-		filename = Common::String::format("ms2_save.%03d", slot);
-
+	Common::String filename = getSaveStateName(slot);
 	Common::OutSaveFile *savefile = _saveFileMan->openForSaving(filename);
 	if (!savefile)
 		return false;

--- a/engines/supernova/supernova.cpp
+++ b/engines/supernova/supernova.cpp
@@ -666,7 +666,7 @@ bool SupernovaEngine::canSaveGameStateCurrently() {
 	return _allowSaveGame && _gm->canSaveGameStateCurrently();
 }
 
-Common::Error SupernovaEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error SupernovaEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return (saveGame(slot, desc) ? Common::kNoError : Common::kWritingFailed);
 }
 

--- a/engines/supernova/supernova.h
+++ b/engines/supernova/supernova.h
@@ -90,6 +90,7 @@ public:
 
 	Common::Error loadGameStrings();
 	void init();
+	virtual Common::String getSaveStateName(int slot) const override;
 	bool loadGame(int slot);
 	bool saveGame(int slot, const Common::String &description);
 	bool serialize(Common::WriteStream *out);

--- a/engines/supernova/supernova.h
+++ b/engines/supernova/supernova.h
@@ -67,7 +67,7 @@ public:
 	Common::Error run() override;
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 	bool hasFeature(EngineFeature f) const override;
 	void pauseEngineIntern(bool pause) override;

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -366,7 +366,7 @@ bool SwordEngine::canLoadGameStateCurrently() {
 	return (mouseIsActive() && !_control->isPanelShown()); // Disable GMM loading when game panel is shown
 }
 
-Common::Error SwordEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error SwordEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	_control->setSaveDescription(slot, desc.c_str());
 	_control->saveGameToFile(slot);
 	return Common::kNoError;    // TODO: return success/failure

--- a/engines/sword1/sword1.h
+++ b/engines/sword1/sword1.h
@@ -112,7 +112,9 @@ protected:
 	bool canLoadGameStateCurrently() override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
-
+	virtual Common::String getSaveStateName(int slot) const override {
+		return Common::String::format("sword1.%03d", slot);
+	}
 private:
 	void delay(int32 amount);
 

--- a/engines/sword1/sword1.h
+++ b/engines/sword1/sword1.h
@@ -110,7 +110,7 @@ protected:
 
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 
 private:

--- a/engines/sword2/saveload.cpp
+++ b/engines/sword2/saveload.cpp
@@ -49,8 +49,8 @@
 
 namespace Sword2 {
 
-Common::String Sword2Engine::getSaveFileName(uint16 slotNo) {
-	return Common::String::format("%s.%.3d", _targetName.c_str(), slotNo);
+Common::String Sword2Engine::getSaveStateName(int slot) const {
+	return Common::String::format("%s.%.3d", _targetName.c_str(), slot);
 }
 
 /**
@@ -125,7 +125,7 @@ uint32 Sword2Engine::saveGame(uint16 slotNo, const byte *desc) {
 }
 
 uint32 Sword2Engine::saveData(uint16 slotNo, byte *buffer, uint32 bufferSize) {
-	Common::String saveFileName = getSaveFileName(slotNo);
+	Common::String saveFileName = getSaveStateName(slotNo);
 
 	Common::OutSaveFile *out;
 
@@ -203,7 +203,7 @@ uint32 Sword2Engine::restoreGame(uint16 slotNo) {
 }
 
 uint32 Sword2Engine::restoreData(uint16 slotNo, byte *buffer, uint32 bufferSize) {
-	Common::String saveFileName = getSaveFileName(slotNo);
+	Common::String saveFileName = getSaveStateName(slotNo);
 
 	Common::InSaveFile *in;
 
@@ -370,7 +370,7 @@ uint32 Sword2Engine::restoreFromBuffer(byte *buffer, uint32 size) {
  */
 
 uint32 Sword2Engine::getSaveDescription(uint16 slotNo, byte *description) {
-	Common::String saveFileName = getSaveFileName(slotNo);
+	Common::String saveFileName = getSaveStateName(slotNo);
 
 	Common::InSaveFile *in;
 
@@ -393,7 +393,7 @@ bool Sword2Engine::saveExists() {
 }
 
 bool Sword2Engine::saveExists(uint16 slotNo) {
-	Common::String saveFileName = getSaveFileName(slotNo);
+	Common::String saveFileName = getSaveStateName(slotNo);
 	Common::InSaveFile *in;
 
 	if (!(in = _saveFileMan->openForLoading(saveFileName))) {

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -824,7 +824,7 @@ uint32 Sword2Engine::getMillis() {
 	return _system->getMillis();
 }
 
-Common::Error Sword2Engine::saveGameState(int slot, const Common::String &desc) {
+Common::Error Sword2Engine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	uint32 saveVal = saveGame(slot, (const byte *)desc.c_str());
 
 	if (saveVal == SR_OK)

--- a/engines/sword2/sword2.h
+++ b/engines/sword2/sword2.h
@@ -223,7 +223,7 @@ public:
 	bool saveExists();
 	bool saveExists(uint16 slotNo);
 	uint32 restoreFromBuffer(byte *buffer, uint32 size);
-	Common::String getSaveFileName(uint16 slotNo);
+	virtual Common::String getSaveStateName(int slot) const override;
 	uint32 findBufferSize();
 
 	void startGame();

--- a/engines/sword2/sword2.h
+++ b/engines/sword2/sword2.h
@@ -163,7 +163,7 @@ public:
 	void setSubtitles(bool b) { _useSubtitles = b; }
 
 	// GMM Loading/Saving
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;

--- a/engines/sword25/sword25.h
+++ b/engines/sword25/sword25.h
@@ -80,7 +80,7 @@ protected:
 // 	void pauseEngineIntern(bool pause);	// TODO: Implement this!!!
 // 	void syncSoundSettings();	// TODO: Implement this!!!
 // 	Common::Error loadGameState(int slot);	// TODO: Implement this?
-// 	Common::Error saveGameState(int slot, const Common::String &desc);	// TODO: Implement this?
+// 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false);	// TODO: Implement this?
 // 	bool canLoadGameStateCurrently();	// TODO: Implement this?
 // 	bool canSaveGameStateCurrently();	// TODO: Implement this?
 

--- a/engines/teenagent/teenagent.cpp
+++ b/engines/teenagent/teenagent.cpp
@@ -263,7 +263,7 @@ Common::Error TeenAgentEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error TeenAgentEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error TeenAgentEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	debug(0, "saving to slot %d", slot);
 	Common::ScopedPtr<Common::OutSaveFile> out(_saveFileMan->openForSaving(Common::String::format("teenagent.%02d", slot)));
 	if (!out)

--- a/engines/teenagent/teenagent.cpp
+++ b/engines/teenagent/teenagent.cpp
@@ -225,7 +225,8 @@ void TeenAgentEngine::init() {
 
 Common::Error TeenAgentEngine::loadGameState(int slot) {
 	debug(0, "loading from slot %d", slot);
-	Common::ScopedPtr<Common::InSaveFile> in(_saveFileMan->openForLoading(Common::String::format("teenagent.%02d", slot)));
+	Common::ScopedPtr<Common::InSaveFile> in(_saveFileMan->openForLoading(
+		getSaveStateName(slot)));
 	if (!in)
 		in.reset(_saveFileMan->openForLoading(Common::String::format("teenagent.%d", slot)));
 
@@ -263,9 +264,14 @@ Common::Error TeenAgentEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
+Common::String TeenAgentEngine::getSaveStateName(int slot) const {
+	return Common::String::format("teenagent.%02d", slot);
+}
+
 Common::Error TeenAgentEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	debug(0, "saving to slot %d", slot);
-	Common::ScopedPtr<Common::OutSaveFile> out(_saveFileMan->openForSaving(Common::String::format("teenagent.%02d", slot)));
+	Common::ScopedPtr<Common::OutSaveFile> out(_saveFileMan->openForSaving(
+		getSaveStateName(slot)));
 	if (!out)
 		return Common::kWritingFailed;
 

--- a/engines/teenagent/teenagent.h
+++ b/engines/teenagent/teenagent.h
@@ -88,7 +88,7 @@ public:
 
 	Common::Error run() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canLoadGameStateCurrently() override { return true; }
 	bool canSaveGameStateCurrently() override { return !_sceneBusy; }
 	bool hasFeature(EngineFeature f) const override;

--- a/engines/teenagent/teenagent.h
+++ b/engines/teenagent/teenagent.h
@@ -84,9 +84,10 @@ const uint16 kScreenHeight = 200;
 class TeenAgentEngine : public Engine {
 public:
 	TeenAgentEngine(OSystem *system, const ADGameDescription *gd);
-	~TeenAgentEngine() override;
+	~TeenAgentEngine();
 
 	Common::Error run() override;
+	Common::String getSaveStateName(int slot) const override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canLoadGameStateCurrently() override { return true; }

--- a/engines/tinsel/detection.cpp
+++ b/engines/tinsel/detection.cpp
@@ -440,7 +440,7 @@ Common::Error TinselEngine::loadGameState(int slot) {
 }
 
 #if 0
-Common::Error TinselEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error TinselEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String saveName = _vm->getSavegameFilename((int16)(slot + 1));
 	char saveDesc[SG_DESC_LEN];
 	Common::strlcpy(saveDesc, desc, SG_DESC_LEN);

--- a/engines/tinsel/tinsel.h
+++ b/engines/tinsel/tinsel.h
@@ -164,7 +164,7 @@ protected:
 	bool hasFeature(EngineFeature f) const override;
 	Common::Error loadGameState(int slot) override;
 #if 0
-	Common::Error saveGameState(int slot, const Common::String &desc);
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false);
 #endif
 	bool canLoadGameStateCurrently() override;
 #if 0

--- a/engines/titanic/core/project_item.cpp
+++ b/engines/titanic/core/project_item.cpp
@@ -178,7 +178,7 @@ void CProjectItem::loadGame(int slotId) {
 	// Open either an existing savegame slot or the new game template
 	if (slotId >= 0) {
 		Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(
-			g_vm->generateSaveName(slotId));
+			g_vm->getSaveStateName(slotId));
 		file.open(saveFile);
 	} else {
 		Common::File *newFile = new Common::File();
@@ -222,7 +222,7 @@ void CProjectItem::loadGame(int slotId) {
 void CProjectItem::saveGame(int slotId, const CString &desc) {
 	CompressedFile file;
 	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(
-		g_vm->generateSaveName(slotId), false);
+		g_vm->getSaveStateName(slotId), false);
 	file.open(saveFile);
 
 	// Signal the game is being saved

--- a/engines/titanic/pet_control/pet_load_save.cpp
+++ b/engines/titanic/pet_control/pet_load_save.cpp
@@ -122,7 +122,7 @@ void CPetLoadSave::resetSlots() {
 
 		// Try and open up the savegame for access
 		Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(
-			g_vm->generateSaveName(idx));
+			g_vm->getSaveStateName(idx));
 
 		if (in) {
 			// Read in the savegame header data

--- a/engines/titanic/titanic.cpp
+++ b/engines/titanic/titanic.cpp
@@ -236,14 +236,10 @@ Common::Error TitanicEngine::saveGameState(int slot, const Common::String &desc,
 	return Common::kNoError;
 }
 
-CString TitanicEngine::generateSaveName(int slot) {
-	return CString::format("%s.%03d", _targetName.c_str(), slot);
-}
-
 CString TitanicEngine::getSavegameName(int slot) {
 	// Try and open up the savegame for access
 	Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(
-		generateSaveName(slot));
+		getSaveStateName(slot));
 
 	if (in) {
 		// Read in the savegame header data

--- a/engines/titanic/titanic.cpp
+++ b/engines/titanic/titanic.cpp
@@ -231,7 +231,7 @@ Common::Error TitanicEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error TitanicEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error TitanicEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	_window->_project->saveGame(slot, desc);
 	return Common::kNoError;
 }

--- a/engines/titanic/titanic.h
+++ b/engines/titanic/titanic.h
@@ -182,12 +182,6 @@ public:
 	double getRandomFloat() { return getRandomNumber(0xfffffffe) * 0.00001525855623540901; } // fffffffe=4294967294 and 0.00001525855623540901 ~= 1/65537.0
 
 	/**
-	 * Support method that generates a savegame name
-	 * @param slot		Slot number
-	 */
-	CString generateSaveName(int slot);
-
-	/**
 	 * Checks whether a savegame exists for the given slot,
 	 * and if it exists, returns it's description
 	 */

--- a/engines/titanic/titanic.h
+++ b/engines/titanic/titanic.h
@@ -149,7 +149,7 @@ public:
 	/**
 	 * Called by the GMM to save the game
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	/**
 	 * Handles updates to the sound levels

--- a/engines/toltecs/saveload.cpp
+++ b/engines/toltecs/saveload.cpp
@@ -205,7 +205,7 @@ Common::Error ToltecsEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error ToltecsEngine::saveGameState(int slot, const Common::String &description) {
+Common::Error ToltecsEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	const char *fileName = getSavegameFilename(slot);
 	savegame(fileName, description.c_str());
 	return Common::kNoError;

--- a/engines/toltecs/toltecs.h
+++ b/engines/toltecs/toltecs.h
@@ -215,7 +215,7 @@ public:
 	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
 	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 	void savegame(const char *filename, const char *description);
 	void loadgame(const char *filename);
 

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -543,6 +543,10 @@ Common::String TonyEngine::getSaveStateFileName(int n) {
 	return Common::String::format("tony.%03d", n);
 }
 
+Common::String TonyEngine::getSaveStateName(int slot) const {
+	return getSaveStateFileName(slot);
+}
+
 void TonyEngine::autoSave(CORO_PARAM) {
 	CORO_BEGIN_CONTEXT;
 	Common::String buf;

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -752,7 +752,7 @@ Common::Error TonyEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error TonyEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error TonyEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	if (!GLOBALS._gfxEngine)
 		return Common::kUnknownError;
 

--- a/engines/tony/tony.h
+++ b/engines/tony/tony.h
@@ -216,6 +216,7 @@ public:
 	void saveState(int n, const char *name);
 	void loadState(CORO_PARAM, int n);
 	static Common::String getSaveStateFileName(int n);
+	virtual Common::String getSaveStateName(int slot) const override;
 
 	/**
 	 * Get a thumbnail

--- a/engines/tony/tony.h
+++ b/engines/tony/tony.h
@@ -165,7 +165,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	void play();
 	void close();

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -317,7 +317,7 @@ public:
 		return _shouldQuit;
 	}
 
-	Common::Error saveGameState(int slot, const Common::String &desc) override {
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override {
 		return (saveGame(slot, desc) ? Common::kNoError : Common::kWritingFailed);
 	}
 

--- a/engines/touche/saveload.cpp
+++ b/engines/touche/saveload.cpp
@@ -319,7 +319,7 @@ void ToucheEngine::loadGameStateData(Common::ReadStream *stream) {
 	debug(0, "Loaded state, current episode %d", _currentEpisodeNum);
 }
 
-Common::Error ToucheEngine::saveGameState(int num, const Common::String &description) {
+Common::Error ToucheEngine::saveGameState(int num, const Common::String &description, bool isAutosave) {
 	bool saveOk = false;
 	Common::String gameStateFileName = generateGameStateFileName(_targetName.c_str(), num);
 	Common::OutSaveFile *f = _saveFileMan->openForSaving(gameStateFileName);

--- a/engines/touche/touche.h
+++ b/engines/touche/touche.h
@@ -604,7 +604,7 @@ protected:
 
 	void saveGameStateData(Common::WriteStream *stream);
 	void loadGameStateData(Common::ReadStream *stream);
-	Common::Error saveGameState(int num, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int num) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;

--- a/engines/touche/touche.h
+++ b/engines/touche/touche.h
@@ -604,10 +604,13 @@ protected:
 
 	void saveGameStateData(Common::WriteStream *stream);
 	void loadGameStateData(Common::ReadStream *stream);
-	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+	Common::Error saveGameState(int num, const Common::String &description, bool isAutosave = false) override;
 	Common::Error loadGameState(int num) override;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
+	Common::String getSaveStateName(int slot) const override {
+		return Common::String::format("%s.%d", _targetName.c_str(), slot);
+	}
 
 	void setupOpcodes();
 	void op_nop();

--- a/engines/tsage/blue_force/blueforce_logic.cpp
+++ b/engines/tsage/blue_force/blueforce_logic.cpp
@@ -48,7 +48,7 @@ void BlueForceGame::start() {
 	// Check for a savegame to load straight from the launcher
 	if (ConfMan.hasKey("save_slot")) {
 		slot = ConfMan.getInt("save_slot");
-		Common::String file = g_vm->generateSaveName(slot);
+		Common::String file = g_vm->getSaveStateName(slot);
 		Common::InSaveFile *in = g_vm->_system->getSavefileManager()->openForLoading(file);
 		if (in)
 			delete in;

--- a/engines/tsage/ringworld/ringworld_logic.cpp
+++ b/engines/tsage/ringworld/ringworld_logic.cpp
@@ -442,7 +442,7 @@ void RingworldGame::start() {
 
 	if (ConfMan.hasKey("save_slot")) {
 		slot = ConfMan.getInt("save_slot");
-		Common::String file = g_vm->generateSaveName(slot);
+		Common::String file = g_vm->getSaveStateName(slot);
 		Common::InSaveFile *in = g_vm->_system->getSavefileManager()->openForLoading(file);
 		if (in)
 			delete in;

--- a/engines/tsage/ringworld2/ringworld2_logic.cpp
+++ b/engines/tsage/ringworld2/ringworld2_logic.cpp
@@ -1130,7 +1130,7 @@ void Ringworld2Game::start() {
 
 	if (ConfMan.hasKey("save_slot")) {
 		slot = ConfMan.getInt("save_slot");
-		Common::String file = g_vm->generateSaveName(slot);
+		Common::String file = g_vm->getSaveStateName(slot);
 		Common::InSaveFile *in = g_vm->_system->getSavefileManager()->openForLoading(file);
 		if (in)
 			delete in;

--- a/engines/tsage/saveload.cpp
+++ b/engines/tsage/saveload.cpp
@@ -131,7 +131,8 @@ Common::Error Saver::save(int slot, const Common::String &saveName) {
 	_macroSaveFlag = true;
 
 	// Try and create the save file
-	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(g_vm->generateSaveName(slot));
+	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(
+		g_vm->getSaveStateName(slot));
 	if (!saveFile)
 		return Common::kCreatingFileFailed;
 
@@ -181,7 +182,8 @@ Common::Error Saver::restore(int slot) {
 	_unresolvedPtrs.clear();
 
 	// Set up the serializer
-	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(g_vm->generateSaveName(slot));
+	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(
+		g_vm->getSaveStateName(slot));
 	if (!saveFile)
 		return Common::kReadingFailed;
 
@@ -352,7 +354,7 @@ void Saver::removeObject(SavedObject *obj) {
  * Returns true if any savegames exist
  */
 bool Saver::savegamesExist() const {
-	Common::String slot1Name = g_vm->generateSaveName(1);
+	Common::String slot1Name = g_vm->getSaveStateName(1);
 
 	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(slot1Name);
 	bool result = saveFile != NULL;

--- a/engines/tsage/tsage.cpp
+++ b/engines/tsage/tsage.cpp
@@ -172,14 +172,6 @@ Common::Error TSageEngine::saveGameState(int slot, const Common::String &desc, b
 	return g_saver->save(slot, desc);
 }
 
-/**
- * Support method that generates a savegame name
- * @param slot		Slot number
- */
-Common::String TSageEngine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
-}
-
 void TSageEngine::syncSoundSettings() {
 	Engine::syncSoundSettings();
 

--- a/engines/tsage/tsage.cpp
+++ b/engines/tsage/tsage.cpp
@@ -168,7 +168,7 @@ Common::Error TSageEngine::loadGameState(int slot) {
 /**
  * Save the game to the given slot index, and with the given name
  */
-Common::Error TSageEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error TSageEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return g_saver->save(slot, desc);
 }
 

--- a/engines/tsage/tsage.h
+++ b/engines/tsage/tsage.h
@@ -79,7 +79,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void syncSoundSettings() override;
 	Common::String generateSaveName(int slot);
 

--- a/engines/tsage/tsage.h
+++ b/engines/tsage/tsage.h
@@ -81,7 +81,6 @@ public:
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void syncSoundSettings() override;
-	Common::String generateSaveName(int slot);
 
 	void initialize();
 	void deinitialize();

--- a/engines/tucker/detection.cpp
+++ b/engines/tucker/detection.cpp
@@ -206,6 +206,10 @@ public:
 		return Tucker::kLastSaveSlot;
 	}
 
+	virtual int getAutosaveSlot() const override {
+		return Tucker::kAutoSaveSlot;
+	}
+
 	void removeSaveState(const char *target, int slot) const override {
 		Common::String filename = Tucker::generateGameStateFileName(target, slot);
 		g_system->getSavefileManager()->removeSavefile(filename);

--- a/engines/tucker/saveload.cpp
+++ b/engines/tucker/saveload.cpp
@@ -234,7 +234,7 @@ TuckerEngine::SavegameError TuckerEngine::writeSavegameHeader(Common::OutSaveFil
 	return (file->err() ? kSavegameIoError : kSavegameNoError);
 }
 
-Common::Error TuckerEngine::saveGameState(int slot, const Common::String &description) {
+Common::Error TuckerEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	return writeSavegame(slot, description, false);
 }
 

--- a/engines/tucker/saveload.cpp
+++ b/engines/tucker/saveload.cpp
@@ -93,7 +93,7 @@ TuckerEngine::SavegameError TuckerEngine::saveOrLoadGameStateData(S &s) {
 }
 
 Common::Error TuckerEngine::loadGameState(int slot) {
-	Common::String fileName = generateGameStateFileName(_targetName.c_str(), slot);
+	Common::String fileName = getSaveStateName(slot);
 	Common::InSaveFile *file = _saveFileMan->openForLoading(fileName);
 
 	if (!file) {
@@ -235,11 +235,7 @@ TuckerEngine::SavegameError TuckerEngine::writeSavegameHeader(Common::OutSaveFil
 }
 
 Common::Error TuckerEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
-	return writeSavegame(slot, description, false);
-}
-
-Common::Error TuckerEngine::writeSavegame(int slot, const Common::String &description, bool autosave) {
-	Common::String fileName = generateGameStateFileName(_targetName.c_str(), slot);
+	Common::String fileName = getSaveStateName(slot);
 	Common::OutSaveFile *file = _saveFileMan->openForSaving(fileName);
 	SavegameHeader header;
 	SavegameError savegameError = kSavegameNoError;
@@ -249,7 +245,7 @@ Common::Error TuckerEngine::writeSavegame(int slot, const Common::String &descri
 
 	if (!savegameError) {
 		// savegame flags
-		if (autosave)
+		if (isAutosave)
 			header.flags |= kSavegameFlagAutosave;
 
 		// description
@@ -274,7 +270,7 @@ Common::Error TuckerEngine::writeSavegame(int slot, const Common::String &descri
 	return Common::kNoError;
 }
 
-bool TuckerEngine::isAutosaveAllowed() {
+bool TuckerEngine::canSaveAutosaveCurrently() {
 	return isAutosaveAllowed(_targetName.c_str());
 }
 
@@ -282,24 +278,6 @@ bool TuckerEngine::isAutosaveAllowed(const char *target) {
 	SavegameHeader savegameHeader;
 	SavegameError savegameError = readSavegameHeader(target, kAutoSaveSlot, savegameHeader);
 	return (savegameError == kSavegameNotFoundError || (savegameHeader.flags & kSavegameFlagAutosave));
-}
-
-void TuckerEngine::writeAutosave() {
-	if (canSaveGameStateCurrently()) {
-		// unconditionally reset last autosave timestamp so we don't start
-		// hammering the disk in case we can't/don't actually write the file
-		_lastSaveTime = _system->getMillis();
-
-		if (!isAutosaveAllowed()) {
-			warning("Refusing to overwrite non-autosave savegame in slot %i, skipping autosave", kAutoSaveSlot);
-			return;
-		}
-
-		if (writeSavegame(kAutoSaveSlot, "Autosave", true).getCode() != Common::kNoError) {
-			warning("Can't create autosave in slot %i, game not saved", kAutoSaveSlot);
-			return;
-		}
-	}
 }
 
 bool TuckerEngine::canLoadOrSave() const {

--- a/engines/tucker/tucker.cpp
+++ b/engines/tucker/tucker.cpp
@@ -350,8 +350,6 @@ void TuckerEngine::resetVariables() {
 	_updateLocationFlag = false;
 	_updateLocation70StringLen = 0;
 	memset(_updateLocation70String, 0, sizeof(_updateLocation70String));
-
-	_lastSaveTime = _system->getMillis();
 }
 
 void TuckerEngine::mainLoop() {
@@ -617,14 +615,10 @@ void TuckerEngine::mainLoop() {
 			handleCreditsSequence();
 			_quitGame = true;
 		}
-
-		if (shouldPerformAutoSave(_lastSaveTime)) {
-			writeAutosave();
-		}
 	} while (!_quitGame && _flagsTable[100] == 0);
 
 	// auto save on quit
-	writeAutosave();
+	saveAutosaveIfEnabled();
 
 	if (_flagsTable[100] == 1) {
 		handleCongratulationsSequence();

--- a/engines/tucker/tucker.h
+++ b/engines/tucker/tucker.h
@@ -743,7 +743,7 @@ protected:
 
 	template<class S> SavegameError saveOrLoadGameStateData(S &s);
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error writeSavegame(int slot, const Common::String &description, bool autosave = false);
 	SavegameError writeSavegameHeader(Common::OutSaveFile *file, SavegameHeader &header);
 	void writeAutosave();

--- a/engines/tucker/tucker.h
+++ b/engines/tucker/tucker.h
@@ -453,7 +453,8 @@ public:
 
 	WARN_UNUSED_RESULT static SavegameError readSavegameHeader(Common::InSaveFile *file, SavegameHeader &header, bool skipThumbnail = true);
 	WARN_UNUSED_RESULT static SavegameError readSavegameHeader(const char *target, int slot, SavegameHeader &header);
-	bool isAutosaveAllowed();
+	virtual bool canSaveAutosaveCurrently() override;
+
 	static bool isAutosaveAllowed(const char *target);
 protected:
 
@@ -744,9 +745,12 @@ protected:
 	template<class S> SavegameError saveOrLoadGameStateData(S &s);
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	Common::Error writeSavegame(int slot, const Common::String &description, bool autosave = false);
 	SavegameError writeSavegameHeader(Common::OutSaveFile *file, SavegameHeader &header);
-	void writeAutosave();
+	virtual int getAutosaveSlot() const override { return kAutoSaveSlot; }
+	virtual Common::String getSaveStateName(int slot) const {
+		return Common::String::format("%s.%d", _targetName.c_str(), slot);
+	}
+
 	bool canLoadOrSave() const;
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
@@ -795,7 +799,6 @@ protected:
 	Common::Language _gameLang;
 	uint32 _gameFlags;
 	int _startSlot;
-	uint32 _lastSaveTime;
 
 	bool _quitGame;
 	bool _fastMode;

--- a/engines/ultima/detection.cpp
+++ b/engines/ultima/detection.cpp
@@ -52,22 +52,11 @@ static const PlainGameDescriptor ULTIMA_GAMES[] = {
 
 #include "ultima/detection_tables.h"
 
-namespace Ultima {
-UltimaMetaEngine *g_metaEngine;
-} // End of namespace Ultima
-
-
 UltimaMetaEngine::UltimaMetaEngine() : AdvancedMetaEngine(Ultima::GAME_DESCRIPTIONS,
 	        sizeof(Ultima::UltimaGameDescription), Ultima::ULTIMA_GAMES) {
-	Ultima::g_metaEngine = this;
-
 	static const char *const DIRECTORY_GLOBS[2] = { "usecode", 0 };
 	_maxScanDepth = 2;
 	_directoryGlobs = DIRECTORY_GLOBS;
-}
-
-UltimaMetaEngine::~UltimaMetaEngine() {
-	Ultima::g_metaEngine = nullptr;
 }
 
 bool UltimaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {

--- a/engines/ultima/detection.h
+++ b/engines/ultima/detection.h
@@ -61,7 +61,7 @@ struct UltimaGameDescription {
 class UltimaMetaEngine : public AdvancedMetaEngine {
 public:
 	UltimaMetaEngine();
-	~UltimaMetaEngine() override;
+	~UltimaMetaEngine() override {}
 
 	const char *getEngineId() const override {
 		return "ultima";
@@ -86,9 +86,5 @@ public:
 	 */
 	SaveStateList listSaves(const char *target) const override;
 };
-
-namespace Ultima {
-extern UltimaMetaEngine *g_metaEngine;
-} // End of namespace Ultima
 
 #endif

--- a/engines/ultima/nuvie/files/nuvie_io_file.cpp
+++ b/engines/ultima/nuvie/files/nuvie_io_file.cpp
@@ -154,7 +154,7 @@ void NuvieIOFileWrite::close() {
 	if (_saveFile) {
 		// Writing using savefile interface, so flush out data
 		_saveFile->write(_saveFileData.getData(), _saveFileData.size());
-		MetaEngine::appendExtendedSave(_saveFile, Shared::g_ultima->getTotalPlayTime(), _description);
+		MetaEngine::appendExtendedSave(_saveFile, Shared::g_ultima->getTotalPlayTime(), _description, false);
 
 		_saveFile->finalize();
 		delete _saveFile;

--- a/engines/ultima/nuvie/files/nuvie_io_file.h
+++ b/engines/ultima/nuvie/files/nuvie_io_file.h
@@ -80,6 +80,7 @@ private:
 	Common::OutSaveFile *_saveFile;
 	Common::MemoryWriteStreamDynamic _saveFileData;
 	Common::String _description;
+	bool _isAutosave;
 protected:
 	bool isOpen() const {
 		return _file != nullptr;
@@ -88,6 +89,7 @@ public:
 	NuvieIOFileWrite();
 	~NuvieIOFileWrite() override;
 	bool open(const Common::String &filename) override;
+	bool open(const Common::String &filename, bool isAutosave);
 	void close() override;
 	void seek(uint32 new_pos) override;
 

--- a/engines/ultima/nuvie/nuvie.cpp
+++ b/engines/ultima/nuvie/nuvie.cpp
@@ -313,7 +313,7 @@ Common::Error NuvieEngine::loadGameState(int slot) {
 
 Common::Error NuvieEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::String filename = getSaveStateName(slot);
-	if (_savegame->save(filename, desc)) {
+	if (_savegame->save(filename, desc, isAutosave)) {
 		if (!isAutosave) {
 			// Store which savegame was most recently saved
 			ConfMan.setInt("latest_save", slot);

--- a/engines/ultima/nuvie/nuvie.cpp
+++ b/engines/ultima/nuvie/nuvie.cpp
@@ -293,7 +293,7 @@ bool NuvieEngine::canSaveGameStateCurrently(bool isAutosave) {
 }
 
 Common::Error NuvieEngine::loadGameState(int slot) {
-	Common::String filename = getSaveFilename(slot);
+	Common::String filename = getSaveStateName(slot);
 
 	if (slot == ORIGINAL_SAVE_SLOT) {
 		// For Nuvie, unless a savegame is already present for the slot,
@@ -312,7 +312,7 @@ Common::Error NuvieEngine::loadGameState(int slot) {
 }
 
 Common::Error NuvieEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	Common::String filename = getSaveFilename(slot);
+	Common::String filename = getSaveStateName(slot);
 	if (_savegame->save(filename, desc)) {
 		if (!isAutosave) {
 			// Store which savegame was most recently saved

--- a/engines/ultima/nuvie/save/save_game.cpp
+++ b/engines/ultima/nuvie/save/save_game.cpp
@@ -359,7 +359,7 @@ bool SaveGame::load(const Common::String &filename) {
 	return true;
 }
 
-bool SaveGame::save(const Common::String &filename, const Common::String &save_description) {
+bool SaveGame::save(const Common::String &filename, const Common::String &save_description, bool isAutosave) {
 	uint8 i;
 	NuvieIOFileWrite saveFile;
 	GameId gameType = g_engine->getGameId();
@@ -372,7 +372,7 @@ bool SaveGame::save(const Common::String &filename, const Common::String &save_d
 		config->write();
 	}
 
-	saveFile.open(filename);
+	saveFile.open(filename, isAutosave);
 
 	saveFile.write2(SAVE_VERSION);
 	saveFile.write2(GAME_ID(gameType));

--- a/engines/ultima/nuvie/save/save_game.h
+++ b/engines/ultima/nuvie/save/save_game.h
@@ -81,7 +81,7 @@ public:
 
 	bool check_version(NuvieIOFileRead *loadfile, uint16 gameType);
 
-	bool save(const Common::String &filename, const Common::String &save_description);
+	bool save(const Common::String &filename, const Common::String &save_description, bool isAutosave);
 };
 
 } // End of namespace Nuvie

--- a/engines/ultima/shared/engine/events.cpp
+++ b/engines/ultima/shared/engine/events.cpp
@@ -33,8 +33,8 @@ namespace Ultima {
 namespace Shared {
 
 EventsManager::EventsManager(EventsCallback *callback) : _callback(callback), _playTime(0),
-		_gameCounter(0), _frameCounter(0), _priorFrameCounterTime(0), _lastAutosaveTime(0),
-		_buttonsDown(0), _specialButtons(0) {
+		_gameCounter(0), _frameCounter(0), _priorFrameCounterTime(0), _buttonsDown(0),
+		_specialButtons(0) {
 }
 
 void EventsManager::showCursor() {
@@ -57,11 +57,6 @@ bool EventsManager::pollEvent(Common::Event &event) {
 		_priorFrameCounterTime = timer;
 		nextFrame();
 	}
-
-	// Handle auto saves
-	if (!_lastAutosaveTime)
-		_lastAutosaveTime = timer;
-	_callback->autoSaveCheck(_lastAutosaveTime);
 
 	// Event handling
 	if (g_system->getEventManager()->pollEvent(event)) {

--- a/engines/ultima/shared/engine/events.h
+++ b/engines/ultima/shared/engine/events.h
@@ -129,11 +129,6 @@ public:
 	 */
 	virtual ~EventsCallback() {}
 
-    /**
-     * Checks if an auto save should be done, and if so, takes care of it
-     */
-	virtual bool autoSaveCheck(int lastSaveTime) = 0;
-
 	/**
 	 * Get the screen
 	 */
@@ -149,7 +144,6 @@ private:
 	uint32 _frameCounter;
 	uint32 _priorFrameTime;
 	uint32 _priorFrameCounterTime;
-	uint32 _lastAutosaveTime;
 	uint32 _gameCounter;
 	uint32 _playTime;
 	Point _mousePos;

--- a/engines/ultima/shared/engine/ultima.cpp
+++ b/engines/ultima/shared/engine/ultima.cpp
@@ -97,9 +97,5 @@ Common::FSNode UltimaEngine::getGameDirectory() const {
 	return Common::FSNode(ConfMan.get("path"));
 }
 
-UltimaMetaEngine *UltimaEngine::getMetaEngine() const {
-	return g_metaEngine;
-}
-
 } // End of namespace Shared
 } // End of namespace Ultima

--- a/engines/ultima/shared/engine/ultima.cpp
+++ b/engines/ultima/shared/engine/ultima.cpp
@@ -74,15 +74,6 @@ void UltimaEngine::GUIError(const Common::String &msg) {
 	GUIErrorMessage(msg);
 }
 
-bool UltimaEngine::autoSaveCheck(int lastSaveTime) {
-	if (shouldPerformAutoSave(lastSaveTime) && canSaveGameStateCurrently(true)) {
-		saveGameState(0, _("Autosave"), true);
-		return true;
-	}
-
-	return false;
-}
-
 bool UltimaEngine::hasFeature(EngineFeature f) const {
 	return
 		(f == kSupportsRTL) ||

--- a/engines/ultima/shared/engine/ultima.h
+++ b/engines/ultima/shared/engine/ultima.h
@@ -62,10 +62,6 @@ protected:
 		return false;
 	}
 
-	/**
-	 * Returns the Ultima meta engine
-	 */
-	UltimaMetaEngine *getMetaEngine() const;
 public:
 	EventsManager *_events;
 public:
@@ -98,13 +94,6 @@ public:
 	 */
 	bool isEnhanced() const {
 		return getFeatures() & GF_VGA_ENHANCED;
-	}
-
-	/**
-	 * Returns the filename for a savegame given it's slot
-	 */
-	Common::String getSaveFilename(int slotNumber) {
-		return getMetaEngine()->getSavegameFile(slotNumber, _targetName.c_str());
 	}
 
 	/**

--- a/engines/ultima/shared/engine/ultima.h
+++ b/engines/ultima/shared/engine/ultima.h
@@ -132,11 +132,6 @@ public:
 	}
 
 	/**
-	 * Checks if an auto save should be done, and if so, takes care of it
-	 */
-	bool autoSaveCheck(int lastSaveTime) override;
-
-	/**
 	 * Returns a file system node for the game directory
 	 */
 	Common::FSNode getGameDirectory() const;

--- a/engines/ultima/ultima8/filesys/file_system.cpp
+++ b/engines/ultima/ultima8/filesys/file_system.cpp
@@ -99,7 +99,7 @@ bool FileSystem::rawOpen(Common::SeekableReadStream *&in, const string &fname) {
 	// Handle opening savegames
 	if (name.hasPrefix("@save/")) {
 		int slotNumber = Std::atoi(name.c_str() + 6);
-		Std::string saveFilename = Ultima8Engine::get_instance()->getSaveFilename(slotNumber);
+		Std::string saveFilename = Ultima8Engine::get_instance()->getSaveStateName(slotNumber);
 
 		in = g_system->getSavefileManager()->openForLoading(saveFilename);
 		return in != 0;
@@ -131,7 +131,7 @@ bool FileSystem::rawOpen(Common::WriteStream *&out,  const string &fname) {
 
 	if (name.hasPrefix("@save/")) {
 		int slotNumber = Std::atoi(name.c_str() + 6);
-		Std::string saveFilename = Ultima8Engine::get_instance()->getSaveFilename(slotNumber);
+		Std::string saveFilename = Ultima8Engine::get_instance()->getSaveStateName(slotNumber);
 
 		out = g_system->getSavefileManager()->openForSaving(saveFilename, false);
 		return out != 0;

--- a/engines/voyeur/voyeur.cpp
+++ b/engines/voyeur/voyeur.cpp
@@ -806,7 +806,7 @@ void VoyeurEngine::loadGame(int slot) {
 /**
  * Save the game to the given slot index, and with the given name
  */
-Common::Error VoyeurEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error VoyeurEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	// Open the save file for writing
 	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(generateSaveName(slot));
 	if (!saveFile)

--- a/engines/voyeur/voyeur.cpp
+++ b/engines/voyeur/voyeur.cpp
@@ -746,10 +746,6 @@ void VoyeurEngine::showEndingNews() {
 
 /*------------------------------------------------------------------------*/
 
-Common::String VoyeurEngine::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
-}
-
 /**
  * Returns true if it is currently okay to restore a game
  */
@@ -774,7 +770,7 @@ Common::Error VoyeurEngine::loadGameState(int slot) {
 
 void VoyeurEngine::loadGame(int slot) {
 	// Open up the save file
-	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(generateSaveName(slot));
+	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(getSaveStateName(slot));
 	if (!saveFile)
 		return;
 
@@ -808,7 +804,7 @@ void VoyeurEngine::loadGame(int slot) {
  */
 Common::Error VoyeurEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	// Open the save file for writing
-	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(generateSaveName(slot));
+	Common::OutSaveFile *saveFile = g_system->getSavefileManager()->openForSaving(getSaveStateName(slot));
 	if (!saveFile)
 		return Common::kCreatingFileFailed;
 

--- a/engines/voyeur/voyeur.h
+++ b/engines/voyeur/voyeur.h
@@ -209,7 +209,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void loadGame(int slot);
 
 	void playRL2Video(const Common::String &filename);

--- a/engines/voyeur/voyeur.h
+++ b/engines/voyeur/voyeur.h
@@ -205,7 +205,6 @@ public:
 	bool getIsDemo() const;
 
 	int getRandomNumber(int maxNumber);
-	Common::String generateSaveName(int slotNumber);
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;

--- a/engines/wage/saveload.cpp
+++ b/engines/wage/saveload.cpp
@@ -734,7 +734,7 @@ Common::Error WageEngine::loadGameState(int slot) {
 		return Common::kUnknownError;
 }
 
-Common::Error WageEngine::saveGameState(int slot, const Common::String &description) {
+Common::Error WageEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
 	Common::String saveLoadSlot = getSavegameFilename(slot);
 	if (saveGame(saveLoadSlot, description) == 0)
 		return Common::kNoError;

--- a/engines/wage/saveload.cpp
+++ b/engines/wage/saveload.cpp
@@ -377,7 +377,7 @@ int WageEngine::saveGame(const Common::String &fileName, const Common::String &d
 
 int WageEngine::loadGame(int slotId) {
 	Common::InSaveFile *data;
-	Common::String fileName = getSavegameFilename(slotId);
+	Common::String fileName = getSaveStateName(slotId);
 
 	debug(9, "WageEngine::loadGame(%d)", slotId);
 	if (!(data = _saveFileMan->openForLoading(fileName))) {
@@ -721,12 +721,6 @@ int WageEngine::loadGame(int slotId) {
 	return 0;
 }
 
-Common::String WageEngine::getSavegameFilename(int16 slotId) const {
-	Common::String saveLoadSlot = _targetName;
-	saveLoadSlot += Common::String::format(".%.3d", slotId);
-	return saveLoadSlot;
-}
-
 Common::Error WageEngine::loadGameState(int slot) {
 	if (loadGame(slot) == 0)
 		return Common::kNoError;
@@ -735,7 +729,7 @@ Common::Error WageEngine::loadGameState(int slot) {
 }
 
 Common::Error WageEngine::saveGameState(int slot, const Common::String &description, bool isAutosave) {
-	Common::String saveLoadSlot = getSavegameFilename(slot);
+	Common::String saveLoadSlot = getSaveStateName(slot);
 	if (saveGame(saveLoadSlot, description) == 0)
 		return Common::kNoError;
 	else

--- a/engines/wage/wage.h
+++ b/engines/wage/wage.h
@@ -211,7 +211,7 @@ public:
 	void saveGame();
 
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &description) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool scummVMSaveLoadDialog(bool isSave);
 
 private:

--- a/engines/wage/wage.h
+++ b/engines/wage/wage.h
@@ -223,7 +223,6 @@ private:
 	Scene *getSceneByOffset(int offset) const;
 	int saveGame(const Common::String &fileName, const Common::String &descriptionString);
 	int loadGame(int slotId);
-	Common::String getSavegameFilename(int16 slotId) const;
 
 private:
 	const ADGameDescription *_gameDescription;

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -322,7 +322,7 @@ Common::Error WintermuteEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-Common::Error WintermuteEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error WintermuteEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	BaseEngine::instance().getGameRef()->saveGame(slot, desc.c_str(), false);
 	return Common::kNoError;
 }

--- a/engines/wintermute/wintermute.h
+++ b/engines/wintermute/wintermute.h
@@ -65,7 +65,7 @@ public:
 	Common::SaveFileManager *getSaveFileMan() { return _saveFileMan; }
 	Common::Error loadGameState(int slot) override;
 	bool canLoadGameStateCurrently() override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
 	// For detection-purposes:
 	static bool getGameInfo(const Common::FSList &fslist, Common::String &name, Common::String &caption);

--- a/engines/xeen/events.cpp
+++ b/engines/xeen/events.cpp
@@ -32,7 +32,7 @@
 namespace Xeen {
 
 EventsManager::EventsManager(XeenEngine *vm) : _vm(vm), _playTime(0), _gameCounter(0),
-		_frameCounter(0), _priorFrameCounterTime(0), _priorScreenRefreshTime(0), _lastAutosaveTime(0),
+		_frameCounter(0), _priorFrameCounterTime(0), _priorScreenRefreshTime(0),
 		_mousePressed(false), _sprites("mouse.icn") {
 	Common::fill(&_gameCounters[0], &_gameCounters[6], 0);
 }
@@ -75,11 +75,6 @@ void EventsManager::pollEvents() {
 		_priorFrameCounterTime = timer;
 		nextFrame();
 	}
-
-	// Handle auto saves
-	if (!_lastAutosaveTime)
-		_lastAutosaveTime = timer;
-	g_vm->autoSaveCheck(_lastAutosaveTime);
 
 	// Event handling
 	Common::Event event;

--- a/engines/xeen/events.h
+++ b/engines/xeen/events.h
@@ -63,7 +63,6 @@ private:
 	uint32 _frameCounter;
 	uint32 _priorFrameCounterTime;
 	uint32 _priorScreenRefreshTime;
-	int _lastAutosaveTime;
 	uint32 _gameCounter;
 	uint32 _gameCounters[6];
 	uint32 _playTime;

--- a/engines/xeen/saves.cpp
+++ b/engines/xeen/saves.cpp
@@ -115,7 +115,7 @@ void SavesManager::writeSavegameHeader(Common::OutSaveFile *out, XeenSavegameHea
 	out->writeUint32LE(events.playTime());
 }
 
-Common::Error SavesManager::saveGameState(int slot, const Common::String &desc) {
+Common::Error SavesManager::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
 		generateSaveName(slot));
 	if (!out)

--- a/engines/xeen/saves.cpp
+++ b/engines/xeen/saves.cpp
@@ -116,8 +116,7 @@ void SavesManager::writeSavegameHeader(Common::OutSaveFile *out, XeenSavegameHea
 }
 
 Common::Error SavesManager::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
-		generateSaveName(slot));
+	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(g_vm->getSaveStateName(slot));
 	if (!out)
 		return Common::kCreatingFileFailed;
 
@@ -159,7 +158,7 @@ Common::Error SavesManager::loadGameState(int slot) {
 	Party &party = *g_vm->_party;
 
 	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(
-		generateSaveName(slot));
+		g_vm->getSaveStateName(slot));
 	if (!saveFile)
 		return Common::kReadingFailed;
 
@@ -206,10 +205,6 @@ Common::Error SavesManager::loadGameState(int slot) {
 
 	delete saveFile;
 	return Common::kNoError;
-}
-
-Common::String SavesManager::generateSaveName(int slot) {
-	return Common::String::format("%s.%03d", _targetName.c_str(), slot);
 }
 
 void SavesManager::newGame() {

--- a/engines/xeen/saves.h
+++ b/engines/xeen/saves.h
@@ -50,12 +50,6 @@ private:
 	Common::String _targetName;
 private:
 	/**
-	 * Support method that generates a savegame name
-	 * @param slot		Slot number
-	 */
-	Common::String generateSaveName(int slot);
-
-	/**
 	 * Initializes a new savegame
 	 */
 	void reset();

--- a/engines/xeen/saves.h
+++ b/engines/xeen/saves.h
@@ -84,7 +84,7 @@ public:
 	/**
 	 * Save the game
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc);
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false);
 
 	/**
 	 * Does an autosave

--- a/engines/xeen/xeen.cpp
+++ b/engines/xeen/xeen.cpp
@@ -184,7 +184,7 @@ int XeenEngine::getRandomNumber(int minNumber, int maxNumber) {
 	return getRandomNumber(maxNumber - minNumber) + minNumber;
 }
 
-Common::Error XeenEngine::saveGameState(int slot, const Common::String &desc) {
+Common::Error XeenEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	return _saves->saveGameState(slot, desc);
 }
 

--- a/engines/xeen/xeen.cpp
+++ b/engines/xeen/xeen.cpp
@@ -202,6 +202,11 @@ bool XeenEngine::canSaveGameStateCurrently() {
 		&& (_map->mazeData()._mazeFlags & RESTRICTION_SAVE) == 0;
 }
 
+bool XeenEngine::canSaveAutosaveCurrently() {
+	return canSaveGameStateCurrently() &&
+		(_map && !(_map->mazeData()._mazeFlags & RESTRICTION_SAVE));
+}
+
 void XeenEngine::playGame() {
 	_files->setGameCc(0);
 	_sound->stopAllAudio();
@@ -325,14 +330,6 @@ void XeenEngine::saveSettings() {
 
 void XeenEngine::GUIError(const Common::String &msg) {
 	GUIErrorMessage(msg);
-}
-
-void XeenEngine::autoSaveCheck(int &lastSaveTime) {
-	if (shouldPerformAutoSave(lastSaveTime) && canSaveGameStateCurrently() &&
-			(_map && !(_map->mazeData()._mazeFlags & RESTRICTION_SAVE))) {
-		_saves->doAutosave();
-		lastSaveTime = g_system->getMillis();
-	}
 }
 
 } // End of namespace Xeen

--- a/engines/xeen/xeen.h
+++ b/engines/xeen/xeen.h
@@ -264,7 +264,7 @@ public:
 	/**
 	 * Save the game
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	/**
 	 * Updates sound settings

--- a/engines/xeen/xeen.h
+++ b/engines/xeen/xeen.h
@@ -282,6 +282,11 @@ public:
 	bool canSaveGameStateCurrently() override;
 
 	/**
+	* Returns true if an autosave can be created
+	*/
+	virtual bool canSaveAutosaveCurrently() override;
+
+	/**
 	 * Show a cutscene
 	 * @param name		Name of cutscene
 	 * @param status	For World of Xeen, Goober status
@@ -309,11 +314,6 @@ public:
 	 * Show an error message in a GUI dialog
 	 */
 	void GUIError(const Common::String &msg);
-
-	/**
-	 * Checks if an auto save should be done, and if so, takes care of it
-	 */
-	void autoSaveCheck(int &lastSaveTime);
 };
 
 extern XeenEngine *g_vm;

--- a/engines/zvision/detection.cpp
+++ b/engines/zvision/detection.cpp
@@ -106,7 +106,7 @@ Common::Error ZVision::ZVision::loadGameState(int slot) {
 	return _saveManager->loadGame(slot);
 }
 
-Common::Error ZVision::ZVision::saveGameState(int slot, const Common::String &desc) {
+Common::Error ZVision::ZVision::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	_saveManager->saveGame(slot, desc, false);
 	return Common::kNoError;
 }

--- a/engines/zvision/file/save_manager.cpp
+++ b/engines/zvision/file/save_manager.cpp
@@ -82,7 +82,7 @@ void SaveManager::saveGame(uint slot, const Common::String &saveName, bool useSa
 		return;
 
 	Common::SaveFileManager *saveFileManager = g_system->getSavefileManager();
-	Common::OutSaveFile *file = saveFileManager->openForSaving(_engine->generateSaveFileName(slot));
+	Common::OutSaveFile *file = saveFileManager->openForSaving(_engine->getSaveStateName(slot));
 
 	writeSaveGameHeader(file, saveName, useSaveBuffer);
 
@@ -252,7 +252,7 @@ bool SaveManager::readSaveGameHeader(Common::InSaveFile *in, SaveGameHeader &hea
 }
 
 Common::SeekableReadStream *SaveManager::getSlotFile(uint slot) {
-	Common::SeekableReadStream *saveFile = g_system->getSavefileManager()->openForLoading(_engine->generateSaveFileName(slot));
+	Common::SeekableReadStream *saveFile = g_system->getSavefileManager()->openForLoading(_engine->getSaveStateName(slot));
 	if (saveFile == NULL) {
 		// Try to load standard save file
 		Common::String filename;

--- a/engines/zvision/file/save_manager.cpp
+++ b/engines/zvision/file/save_manager.cpp
@@ -100,10 +100,6 @@ void SaveManager::saveGame(uint slot, const Common::String &saveName, bool useSa
 	_lastSaveTime = g_system->getMillis();
 }
 
-void SaveManager::autoSave() {
-	saveGame(0, "Auto save", false);
-}
-
 void SaveManager::writeSaveGameHeader(Common::OutSaveFile *file, const Common::String &saveName, bool useSaveBuffer) {
 	file->writeUint32BE(SAVEGAME_ID);
 

--- a/engines/zvision/file/save_manager.h
+++ b/engines/zvision/file/save_manager.h
@@ -73,11 +73,6 @@ private:
 
 public:
 	/**
-	 * Called every room change. Saves the state of the room just before
-	 * the room changes.
-	 */
-	void autoSave();
-	/**
 	 * Copies the data from the last auto-save into a new save file. We
 	 * can't use the current state data because the save menu *IS* a room.
 	 * The file is named using ZVision::generateSaveFileName(slot)

--- a/engines/zvision/zvision.cpp
+++ b/engines/zvision/zvision.cpp
@@ -348,10 +348,6 @@ Common::Error ZVision::run() {
 			delay >>= 1;
 		}
 
-		if (canSaveGameStateCurrently() && shouldPerformAutoSave(_saveManager->getLastSaveTime())) {
-			_saveManager->autoSave();
-		}
-
 		_system->delayMillis(delay);
 	}
 

--- a/engines/zvision/zvision.cpp
+++ b/engines/zvision/zvision.cpp
@@ -364,10 +364,6 @@ void ZVision::pauseEngineIntern(bool pause) {
 	}
 }
 
-Common::String ZVision::generateSaveFileName(uint slot) {
-	return Common::String::format("%s.%03u", _targetName.c_str(), slot);
-}
-
 void ZVision::setRenderDelay(uint delay) {
 	_frameRenderDelay = delay;
 }

--- a/engines/zvision/zvision.h
+++ b/engines/zvision/zvision.h
@@ -220,8 +220,6 @@ public:
 	void playVideo(Video::VideoDecoder &videoDecoder, const Common::Rect &destRect = Common::Rect(0, 0, 0, 0), bool skippable = true, Subtitle *sub = NULL);
 	Video::VideoDecoder *loadAnimation(const Common::String &fileName);
 
-	Common::String generateSaveFileName(uint slot);
-
 	void setRenderDelay(uint);
 	bool canRender();
 	static void fpsTimerCallback(void *refCon);

--- a/engines/zvision/zvision.h
+++ b/engines/zvision/zvision.h
@@ -242,7 +242,7 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	Common::Error loadGameState(int slot) override;
-	Common::Error saveGameState(int slot, const Common::String &desc) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 private:
 	void initialize();

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -298,7 +298,7 @@ void SaveLoadChooserDialog::updateSaveList() {
 
 void SaveLoadChooserDialog::listSaves() {
 	if (!_metaEngine) return; //very strange
-	_saveList = _metaEngine->listSaves(_target.c_str());
+	_saveList = _metaEngine->listSaves(_target.c_str(), _saveMode);
 
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)
 	//if there is Cloud support, add currently synced files as "locked" saves in the list
@@ -572,7 +572,8 @@ void SaveLoadChooserSimple::updateSelection(bool redraw) {
 		SaveStateDescriptor desc = (_saveList[selItem].getLocked() ? _saveList[selItem] : _metaEngine->querySaveMetaInfos(_target.c_str(), _saveList[selItem].getSaveSlot()));
 
 		isDeletable = desc.getDeletableFlag() && _delSupport;
-		isWriteProtected = desc.getWriteProtectedFlag();
+		isWriteProtected = desc.getWriteProtectedFlag() ||
+			_saveList[selItem].getWriteProtectedFlag();
 		isLocked = desc.getLocked();
 
 		// Don't allow the user to change the description of write protected games


### PR DESCRIPTION
This pull request is intended to help deal with the fact that the bulk of engines don't implement autosaves, by making it part of the standard base Engine class. There are several provisios, which I'll discuss below:

* First, and foremost, the new autosave functionality relies on an engine implementing savegames via the saveGameState method. This means that even with this, engines like DreamWeb and Tinsel which don't allow saving via the GMM won't benefit from this.

* As a requirement for autosaves to work with the existing engines, I had to standardize saveGameState to always have the extra isAutosave parameter, whereas before in my previous pull request for extended save improvements, there was a separate overloaded version of saveGameState to the existing one. This will slightly affect any existing engines that implement saveGameState and aren't yet merged into master, such as the Blazing Dragons engine. Luckily it'll be easy to simply add in the extra needed parameter to the method, even if unused.

* At it's core, the changes work by adding a new "handleAutosave" method to the base engine class, which the DefaultEventManager's pollEvent method now calls. This seemed the best place, and the method was already accessing the engine via g_engine anyway (for EVENT_MAINMENU handling), so it fits in well. Now, as engines regularly call pollEvent, when the autosave point is reached, it will trigger an autosave, so long as the engine's canSaveGameStateCurrently method returns true.

* To avoid clashes, I removed existing autosave code from the engines, with the exception of scumm.. it's autosaving handling seems somewhat more complicated, so to be on the safe side I left it intact, and instead flag to the Engine that it's autosaves should be turned off. I've added a new method canSaveAutosaveCurrently, which by default simply calls canSaveGameStateCurrently.

* I also added a method getAutosaveSlot for engines to specify which slot is for autosaves. One engine had it in slot 99, and another in slot 999. Griffon, for example, I put the autosave in slot 4, since the engine (based on the in-game save dialog) was previously limited to 4 slots (0-3). Most of the existing engines already supporting autosaves, however, use slot 0, which is the default.

* Some of the engines, already with autosaves in mind, map in-game saves to start at slot 1 so there's no chance of overlap. But since some don't, I've added some logic to mark slot 0 as write protected.. which some engines were also doing already. I also did a minor change to the save load chooser to call a new overloaded listSaves method in the Meta Engine that takes in a 'saveMode' parameter. When in save mode, if autosaves are turned on and there isn't yet a save in the autosave slot, then it will show a dummy 'Autosave' entry that is marked as read only (slots can't be marked as write protected without having an entry for that slot). This won't show in Load mode to avoid confusion. However, obviously, there may still be an outstanding problem if an in-game/origional save dialog puts the first save as slot 0.. potentially they could end up saving a game quickly that later gets overwritten by autosaves.

For the above, one thing I'd like to do is use the querySaveMetaInfos method of the meta engine to generically get the basic information of any existing save, and only save the autosave if the slot is empty, or the description of an existing save matches "Autosave". This would prevent existing saves accidentally getting overwritten. However, I'm not sure how to cleanly get a reference to the meta engine in the engine's saveAutosaveIfEnabled method. The SaveLoadChooser has a lot of code for finding plugins based on engine ids, and getting the meta engine from there.. I'm wondering if there's any existing methods accessible to the engine that simplifies/abstracts the process.

For that matter, I currently have a duplication of getAutosaveSlot in both the engine and meta engine base classes. If there's an easy standardized way for an engine to access the meta engine that launched it, I could do away with the duplication.
