### PR TITLE
SCI32: fix bug #9752 (for all games)

### DIFF
--- a/engines/sci/engine/kfile.cpp
+++ b/engines/sci/engine/kfile.cpp
@@ -1331,6 +1331,11 @@ reg_t kGetSaveFiles(EngineState *s, int argc, reg_t *argv) {
 #ifdef ENABLE_SCI32
 
 reg_t kSaveGame32(EngineState *s, int argc, reg_t *argv) {
+	// fix bug #9752 - make sure that control panel (in case of QFG4),
+	// keyboard (in case of Shivers), or any other obstacle (in other unknown SCI32 games...)
+	// will be hidden before saving
+	kFrameOut(s, 0, NULL);
+
 	const Common::String gameName = s->_segMan->getString(argv[0]);
 	int16 saveNo = argv[1].toSint16();
 	Common::String saveDescription = argv[2].isNull() ? "" : s->_segMan->getString(argv[2]);


### PR DESCRIPTION
Some SCI32 games have an issue that the saved games thumbnails is useless because it's hidden
by the configuration panel (QFG4) or by the keyboard (Shivers).
Maybe this problems appears on other SCI32 games as well, should be checked.

We avoid that by keeping the thumbnail everytime the menu bar is hidden,
and when time comes to save the game, we use that thumbnail instead of taking
a new one (which would be with the control panel/keyboard).

This fix is for QfG4 only.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
