### PR TITLE
TESTBED: Set the NOLAUNCHLOAD GUI option

### DIFF
--- a/engines/testbed/detection.cpp
+++ b/engines/testbed/detection.cpp
@@ -40,7 +40,7 @@ static const ADGameDescription testbedDescriptions[] = {
 		Common::EN_ANY,
 		Common::kPlatformDOS,
 		ADGF_NO_FLAGS,
-		GUIO0()
+		GUIO1(GUIO_NOLAUNCHLOAD)
 	},
 	AD_TABLE_END_MARKER
 };


### PR DESCRIPTION
This continues the work of #2042 to provide correct metadata for the `testbed` "engine".