### PR TITLE
DIRECTOR: LINGO: Fix compiler warning

### DIFF
--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -513,7 +513,7 @@ Common::String *Datum::toString() {
 	case ARRAY:
 		*s = "[";
 
-		for (int i = 0; i < u.farr->size(); i++) {
+		for (uint i = 0; i < u.farr->size(); i++) {
 			if (i > 0)
 				*s += ", ";
 			*s += *u.farr->operator[](i).toString();


### PR DESCRIPTION
Fixes a compiler warning about comparing signed and unsigned variables