### PR TITLE
MIDI/SCI/KYRA: Add support for Roland GS drumkits

### DIFF
--- a/audio/mididrv.cpp
+++ b/audio/mididrv.cpp
@@ -56,6 +56,29 @@ const byte MidiDriver::_gmToMt32[128] = {
 	101, 103, 100, 120, 117, 113,  99, 128, 128, 128, 128, 124, 123, 128, 128, 128, // 7x
 };
 
+// This is the drum map for the Roland Sound Canvas SC-55 v1.xx. It had a fallback mechanism 
+// to correct invalid drumkit selections. Some games rely on this mechanism to select the 
+// correct Roland GS drumkit. Use this map to emulate this mechanism.
+// E.g. correct invalid drumkit 50: _gsDrumkitFallbackMap[50] == 48
+const uint8 MidiDriver::_gsDrumkitFallbackMap[128] = {
+	 0,  0,  0,  0,  0,  0,  0,  0, // STANDARD
+	 8,  8,  8,  8,  8,  8,  8,  8, // ROOM
+	16, 16, 16, 16, 16, 16, 16, 16, // POWER
+	24, 25, 24, 24, 24, 24, 24, 24, // ELECTRONIC; TR-808 (25)
+	32, 32, 32, 32, 32, 32, 32, 32, // JAZZ
+	40, 40, 40, 40, 40, 40, 40, 40, // BRUSH
+	48, 48, 48, 48, 48, 48, 48, 48, // ORCHESTRA
+	56, 56, 56, 56, 56, 56, 56, 56, // SFX
+	 0,  0,  0,  0,  0,  0,  0,  0, // No drumkit defined (fall back to STANDARD)
+	 0,  0,  0,  0,  0,  0,  0,  0, // No drumkit defined
+	 0,  0,  0,  0,  0,  0,  0,  0, // No drumkit defined
+	 0,  0,  0,  0,  0,  0,  0,  0, // No drumkit defined
+	 0,  0,  0,  0,  0,  0,  0,  0, // No drumkit defined
+	 0,  0,  0,  0,  0,  0,  0,  0, // No drumkit defined
+	 0,  0,  0,  0,  0,  0,  0,  0, // No drumkit defined
+	 0,  0,  0,  0,  0,  0,  0, 127 // No drumkit defined; CM-64/32L (127)
+};
+
 static const struct {
 	uint32      type;
 	const char *guio;

--- a/audio/mididrv.h
+++ b/audio/mididrv.h
@@ -179,6 +179,8 @@ public:
 
 	static const byte _mt32ToGm[128];
 	static const byte _gmToMt32[128];
+	// Map for correcting Roland GS drumkit numbers.
+	static const uint8 _gsDrumkitFallbackMap[128];
 
 	/**
 	 * Error codes returned by open.

--- a/engines/kyra/sound/drivers/midi.cpp
+++ b/engines/kyra/sound/drivers/midi.cpp
@@ -174,18 +174,20 @@ void MidiOutput::send(uint32 b) {
 }
 
 void MidiOutput::sendIntern(const byte event, const byte channel, byte param1, const byte param2) {
+	byte param1ToSend = param1;
 	if (event == 0xC0) {
 		// MT32 -> GM conversion
 		if (!_isMT32 && _defaultMT32)
-			param1 = MidiDriver::_mt32ToGm[param1];
+			param1ToSend = MidiDriver::_mt32ToGm[param1];
 		// Program change on rhythm channel (drumkit selection)
 		else if (!_isMT32 && channel == 0x09) {
 			// Apply GS drumkit fallback to correct invalid drumkit numbers.
-			param1 = MidiDriver::_gsDrumkitFallbackMap[param1];
+			param1ToSend = MidiDriver::_gsDrumkitFallbackMap[param1];
+			debugC(kDebugLevelSound, "[Midi] Selected drumkit %i (requested %i)", param1ToSend, param1);
 		}
 	}
 
-	_output->send(event | channel, param1, param2);
+	_output->send(event | channel, param1ToSend, param2);
 }
 
 void MidiOutput::sysEx(const byte *msg, uint16 length) {

--- a/engines/kyra/sound/drivers/midi.cpp
+++ b/engines/kyra/sound/drivers/midi.cpp
@@ -183,7 +183,7 @@ void MidiOutput::sendIntern(const byte event, const byte channel, byte param1, c
 		else if (!_isMT32 && channel == 0x09) {
 			// Apply GS drumkit fallback to correct invalid drumkit numbers.
 			param1ToSend = MidiDriver::_gsDrumkitFallbackMap[param1];
-			debugC(kDebugLevelSound, "[Midi] Selected drumkit %i (requested %i)", param1ToSend, param1);
+			debugC(7, kDebugLevelSound, "[Midi] Selected drumkit %i (requested %i)", param1ToSend, param1);
 		}
 	}
 

--- a/engines/kyra/sound/drivers/midi.cpp
+++ b/engines/kyra/sound/drivers/midi.cpp
@@ -178,6 +178,11 @@ void MidiOutput::sendIntern(const byte event, const byte channel, byte param1, c
 		// MT32 -> GM conversion
 		if (!_isMT32 && _defaultMT32)
 			param1 = MidiDriver::_mt32ToGm[param1];
+		// Program change on rhythm channel (drumkit selection)
+		else if (!_isMT32 && channel == 0x09) {
+			// Apply GS drumkit fallback to correct invalid drumkit numbers.
+			param1 = MidiDriver::_gsDrumkitFallbackMap[param1];
+		}
 	}
 
 	_output->send(event | channel, param1, param2);

--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -124,26 +124,6 @@ static const byte defaultSci32GMPatch[] = {
 };
 #endif
 
-static const uint8 gsDrumkitFallbackMap[] = {
-	 0,  0,  0,  0,  0,  0,  0,  0, // STANDARD
-	 8,  8,  8,  8,  8,  8,  8,  8, // ROOM
-	16, 16, 16, 16, 16, 16, 16, 16, // POWER
-	24, 25, 24, 24, 24, 24, 24, 24, // ELECTRONIC; TR-808 (25)
-	32, 32, 32, 32, 32, 32, 32, 32, // JAZZ
-	40, 40, 40, 40, 40, 40, 40, 40, // BRUSH
-	48, 48, 48, 48, 48, 48, 48, 48, // ORCHESTRA
-	56, 56, 56, 56, 56, 56, 56, 56, // SFX
-	 0,  0,  0,  0,  0,  0,  0,  0, // No drum kit defined (fall back to STANDARD)
-	 0,  0,  0,  0,  0,  0,  0,  0, // No drum kit defined
-	 0,  0,  0,  0,  0,  0,  0,  0, // No drum kit defined
-	 0,  0,  0,  0,  0,  0,  0,  0, // No drum kit defined
-	 0,  0,  0,  0,  0,  0,  0,  0, // No drum kit defined
-	 0,  0,  0,  0,  0,  0,  0,  0, // No drum kit defined
-	 0,  0,  0,  0,  0,  0,  0,  0, // No drum kit defined
-	 0,  0,  0,  0,  0,  0,  0,  0, // No drum kit defined
-	 0,  0,  0,  0,  0,  0,  0, 127 // No drum kit defined; CM-64/32L (127)
-};
-
 Mt32ToGmMapList *Mt32dynamicMappings = NULL;
 
 class MidiPlayer_Midi : public MidiPlayer {
@@ -377,7 +357,9 @@ void MidiPlayer_Midi::setPatch(int channel, int patch) {
 
 	assert(channel <= 15);
 
-	if ((this->_mt32Type != kMt32TypeNone && channel == MIDI_RHYTHM_CHANNEL) || (_channels[channel].patch == patch))
+	// No need to do anything if a patch change is sent on the rhythm channel of an MT-32
+	// or if the requested patch is the same as the current patch.
+	if ((_mt32Type != kMt32TypeNone && channel == MIDI_RHYTHM_CHANNEL) || (_channels[channel].patch == patch))
 		return;
 
 	int patchToSend;
@@ -418,9 +400,13 @@ void MidiPlayer_Midi::setPatch(int channel, int patch) {
 		if (bendRange != MIDI_UNMAPPED)
 			_driver->setPitchBendRange(channel, bendRange);
 	} else {
-		// Apply drumkit fallback to correct invalid drumkit numbers
-		patchToSend = gsDrumkitFallbackMap[patch];
+		// A patch change on the rhythm channel of a Roland GS device indicates a drumkit change.
+		// Some GM devices support the GS drumkits as well.
+
+		// Apply drumkit fallback to correct invalid drumkit numbers.
+		patchToSend = patch < 128 ? _driver->_gsDrumkitFallbackMap[patch] : 0;
 		_channels[channel].patch = patchToSend;
+		debugC(kDebugLevelSound, "[Midi] Selected drumkit %i (requested %i)", patchToSend, patch);
 	}
 
 	_driver->send(0xc0 | channel, patchToSend, 0);


### PR DESCRIPTION
MIDI/SCI/KYRA: Add support for Roland GS drumkits

This PR adds support for the alternate drumkits in Roland GS devices (also present in various GM devices). These are used in the MIDI data of Quest for Glory 3, Space Quest 5, Pepper's Adventures in Time and Lands of Lore.

Most of these games contain invalid drumkit numbers; they relied on a feature of the Roland SC-55 which corrected this. Later devices do not include this feature and drumkit selection would not work. This PR contains code to emulate the correction feature to make the drumkit selections work on later devices.

SCI did not send program changes on the rhythm channel. This has been added as well as the invalid drumkit number correction.
KYRA did already send program changes on the rhythm channel; invalid drumkit correction has been added.

I've tested this on a Roland SC-55mkII as well as FluidSynth with a GS compatible soundfont.