### PR TITLE
PINK: Mark stuff const

### DIFF
--- a/engines/pink/cel_decoder.cpp
+++ b/engines/pink/cel_decoder.cpp
@@ -54,21 +54,21 @@ bool CelDecoder::loadStream(Common::SeekableReadStream *stream) {
 }
 
 
-uint16 CelDecoder::getTransparentColourIndex() {
+uint16 CelDecoder::getTransparentColourIndex() const {
 	CelVideoTrack *track = (CelVideoTrack *)getTrack(0);
 	if (!track)
 		return 0;
 	return track->getTransparentColourIndex();
 }
 
-const Graphics::Surface *CelDecoder::getCurrentFrame() {
+const Graphics::Surface *CelDecoder::getCurrentFrame() const {
 	CelVideoTrack *track = (CelVideoTrack *)getTrack(0);
 	if (!track)
 		return 0;
 	return track->getCurrentFrame();
 }
 
-Common::Point CelDecoder::getCenter() {
+Common::Point CelDecoder::getCenter() const {
 	CelVideoTrack *track = (CelVideoTrack *)getTrack(0);
 	if (!track)
 		return Common::Point(0, 0);
@@ -135,15 +135,15 @@ void CelDecoder::CelVideoTrack::readHeader() {
 	_fileStream->seek(_offsetFrame1);
 }
 
-uint16 CelDecoder::CelVideoTrack::getTransparentColourIndex() {
+uint16 CelDecoder::CelVideoTrack::getTransparentColourIndex() const {
 	return _transparentColourIndex;
 }
 
-const Graphics::Surface *CelDecoder::CelVideoTrack::getCurrentFrame() {
+const Graphics::Surface *CelDecoder::CelVideoTrack::getCurrentFrame() const {
 	return _surface;
 }
 
-Common::Point CelDecoder::CelVideoTrack::getCenter() {
+Common::Point CelDecoder::CelVideoTrack::getCenter() const {
 	return _center;
 }
 

--- a/engines/pink/cel_decoder.h
+++ b/engines/pink/cel_decoder.h
@@ -31,10 +31,10 @@ class CelDecoder : public Video::FlicDecoder {
 public:
 	bool loadStream(Common::SeekableReadStream *stream) override;
 
-	uint16 getTransparentColourIndex();
+	uint16 getTransparentColourIndex() const;
 
-	Common::Point getCenter();
-	const Graphics::Surface *getCurrentFrame();
+	Common::Point getCenter() const;
+	const Graphics::Surface *getCurrentFrame() const;
 	void skipFrame();
 
 	void setEndOfTrack();
@@ -45,14 +45,14 @@ protected:
 		CelVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height, bool skipHeader = false);
 		void readHeader() override;
 
-		uint16 getTransparentColourIndex();
+		uint16 getTransparentColourIndex() const;
 
 		// Hack. Pink needs so that Track needed an update after lastFrame delay ends
 		void setEndOfTrack() { _curFrame = _frameCount; }
 		bool endOfTrack() const override { return getCurFrame() >= getFrameCount(); }
 
-		Common::Point getCenter();
-		const Graphics::Surface *getCurrentFrame();
+		Common::Point getCenter() const;
+		const Graphics::Surface *getCurrentFrame() const;
 
 		void skipFrame();
 

--- a/engines/pink/objects/actions/action_hide.cpp
+++ b/engines/pink/objects/actions/action_hide.cpp
@@ -27,7 +27,7 @@
 
 namespace Pink {
 
-void ActionHide::toConsole() {
+void ActionHide::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tActionHide: _name = %s", _name.c_str());
 }
 

--- a/engines/pink/objects/actions/action_hide.h
+++ b/engines/pink/objects/actions/action_hide.h
@@ -29,7 +29,7 @@ namespace Pink {
 
 class ActionHide : public Action {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 
 	void start() override;
 	void end() override;

--- a/engines/pink/objects/actions/action_loop.cpp
+++ b/engines/pink/objects/actions/action_loop.cpp
@@ -48,7 +48,7 @@ void ActionLoop::deserialize(Archive &archive) {
 	}
 }
 
-void ActionLoop::toConsole() {
+void ActionLoop::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tActionLoop: _name = %s, _fileName = %s, z = %u, _startFrame = %u,"
 				  " _endFrame = %d, _intro = %u, _style = %u",
 		  _name.c_str(), _fileName.c_str(), _z, _startFrame, _stopFrame, _intro, _style);

--- a/engines/pink/objects/actions/action_loop.h
+++ b/engines/pink/objects/actions/action_loop.h
@@ -31,7 +31,7 @@ class ActionLoop : public ActionPlay {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void update() override;
 

--- a/engines/pink/objects/actions/action_play.cpp
+++ b/engines/pink/objects/actions/action_play.cpp
@@ -35,7 +35,7 @@ void ActionPlay::deserialize(Archive &archive) {
 	_stopFrame = archive.readDWORD();
 }
 
-void ActionPlay::toConsole() {
+void ActionPlay::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tActionPlay: _name = %s, _fileName = %s, z = %u, _startFrame = %u,"
 				  " _endFrame = %d", _name.c_str(), _fileName.c_str(), _z, _startFrame, _stopFrame);
 }

--- a/engines/pink/objects/actions/action_play.h
+++ b/engines/pink/objects/actions/action_play.h
@@ -31,7 +31,7 @@ class ActionPlay : public ActionStill {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void end() override;
 

--- a/engines/pink/objects/actions/action_play_with_sfx.cpp
+++ b/engines/pink/objects/actions/action_play_with_sfx.cpp
@@ -43,7 +43,7 @@ void ActionPlayWithSfx::deserialize(Pink::Archive &archive) {
 	_sfxArray.deserialize(archive);
 }
 
-void ActionPlayWithSfx::toConsole() {
+void ActionPlayWithSfx::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tActionPlayWithSfx: _name = %s, _fileName = %s, z = %u, _startFrame = %u,"
 				  " _endFrame = %d, _isLoop = %u", _name.c_str(), _fileName.c_str(), _z, _startFrame, _stopFrame, _isLoop);
 	for (uint i = 0; i < _sfxArray.size(); ++i) {
@@ -91,7 +91,7 @@ void ActionSfx::deserialize(Pink::Archive &archive) {
 	_sprite = (ActionPlayWithSfx *)archive.readObject();
 }
 
-void ActionSfx::toConsole() {
+void ActionSfx::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tActionSfx: _sfx = %s, _volume = %u, _frame = %u", _sfxName.c_str(), _volume, _frame);
 }
 

--- a/engines/pink/objects/actions/action_play_with_sfx.h
+++ b/engines/pink/objects/actions/action_play_with_sfx.h
@@ -38,7 +38,7 @@ public:
 
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void update() override;
 
@@ -58,7 +58,7 @@ class ActionSfx : public Object {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void play();
 	void end();

--- a/engines/pink/objects/actions/action_sound.cpp
+++ b/engines/pink/objects/actions/action_sound.cpp
@@ -45,7 +45,7 @@ void ActionSound::deserialize(Archive &archive) {
 	_isBackground = (bool)archive.readDWORD();
 }
 
-void ActionSound::toConsole() {
+void ActionSound::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tActionSound: _name = %s, _fileName = %s, _volume = %u, _isLoop = %u,"
 				  " _isBackground = %u", _name.c_str(), _fileName.c_str(), _volume, _isLoop, _isBackground);
 }

--- a/engines/pink/objects/actions/action_sound.h
+++ b/engines/pink/objects/actions/action_sound.h
@@ -33,7 +33,7 @@ public:
 	~ActionSound() override;
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void start() override;
 	void end() override;

--- a/engines/pink/objects/actions/action_still.cpp
+++ b/engines/pink/objects/actions/action_still.cpp
@@ -35,7 +35,7 @@ void ActionStill::deserialize(Archive &archive) {
 	_startFrame = archive.readDWORD();
 }
 
-void ActionStill::toConsole() {
+void ActionStill::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tActionStill: _name = %s, _fileName = %s, _z =%u _startFrame = %u",
 		  _name.c_str(), _fileName.c_str(), _z, _startFrame);
 }

--- a/engines/pink/objects/actions/action_still.h
+++ b/engines/pink/objects/actions/action_still.h
@@ -31,7 +31,7 @@ class ActionStill : public ActionCEL {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void end() override;
 

--- a/engines/pink/objects/actions/action_talk.cpp
+++ b/engines/pink/objects/actions/action_talk.cpp
@@ -35,7 +35,7 @@ void ActionTalk::deserialize(Archive &archive) {
 	_vox = archive.readString();
 }
 
-void ActionTalk::toConsole() {
+void ActionTalk::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tActionTalk: _name = %s, _fileName = %s, z = %u, _startFrame = %u,"
 				  " _endFrame = %d, _intro = %u, _style = %u, _vox = %s",
 		  _name.c_str(), _fileName.c_str(), _z, _startFrame, _stopFrame, _intro, _style, _vox.c_str());

--- a/engines/pink/objects/actions/action_talk.h
+++ b/engines/pink/objects/actions/action_talk.h
@@ -33,7 +33,7 @@ class ActionTalk : public ActionLoop {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void update() override;
 

--- a/engines/pink/objects/actions/action_text.cpp
+++ b/engines/pink/objects/actions/action_text.cpp
@@ -69,7 +69,7 @@ void ActionText::deserialize(Archive &archive) {
 	_backgroundRGB = archive.readDWORD();
 }
 
-void ActionText::toConsole() {
+void ActionText::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tActionText: _name = %s, _fileName = %s, "
 				  "_xLeft = %u, _yTop = %u, _xRight = %u, _yBottom = %u _centered = %u, _scrollBar = %u, _textColor = %u _backgroundColor = %u",
 		  _name.c_str(), _fileName.c_str(), _xLeft, _yTop, _xRight, _yBottom, _centered, _scrollBar, _textRGB, _backgroundRGB);

--- a/engines/pink/objects/actions/action_text.h
+++ b/engines/pink/objects/actions/action_text.h
@@ -39,7 +39,7 @@ public:
 	~ActionText() override;
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void start() override;
 	void end() override;

--- a/engines/pink/objects/actions/walk_action.cpp
+++ b/engines/pink/objects/actions/walk_action.cpp
@@ -34,7 +34,7 @@ void WalkAction::deserialize(Archive &archive) {
 	_toCalcFramePositions = calcFramePositions;
 }
 
-void WalkAction::toConsole() {
+void WalkAction::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tWalkAction: _name = %s, _fileName = %s, _calcFramePositions = %u",
 		  _name.c_str(), _fileName.c_str(), _toCalcFramePositions);
 }

--- a/engines/pink/objects/actions/walk_action.h
+++ b/engines/pink/objects/actions/walk_action.h
@@ -31,7 +31,7 @@ class WalkAction : public ActionCEL {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void update() override;
 

--- a/engines/pink/objects/actors/actor.cpp
+++ b/engines/pink/objects/actors/actor.cpp
@@ -80,7 +80,7 @@ bool Actor::initPalette(Director *director) {
 	return false;
 }
 
-void Actor::toConsole() {
+void Actor::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "Actor: _name = %s", _name.c_str());
 	for (uint i = 0; i < _actions.size(); ++i) {
 		_actions[i]->toConsole();

--- a/engines/pink/objects/actors/actor.h
+++ b/engines/pink/objects/actors/actor.h
@@ -52,16 +52,16 @@ public:
 
 	void toConsole() override;
 
-	bool isPlaying() { return !_isActionEnded; }
+	bool isPlaying() const { return !_isActionEnded; }
 	virtual void pause(bool paused);
 
 	void endAction() { _isActionEnded = true; }
 
-	virtual bool isSupporting() { return false; }
-	virtual bool isCursor() { return false; }
+	virtual bool isSupporting() const { return false; }
+	virtual bool isCursor() const { return false; }
 
-	virtual bool isLeftClickHandlers() { return false; }
-	virtual bool isUseClickHandlers(InventoryItem *item) { return false; }
+	virtual bool isLeftClickHandlers() const { return false; }
+	virtual bool isUseClickHandlers(InventoryItem *item) const { return false; }
 
 	virtual void onMouseOver(const Common::Point point, CursorMgr *mgr);
 	virtual void onMouseOverWithItem(const Common::Point point, const Common::String &itemName, CursorMgr *cursorMgr);
@@ -72,8 +72,10 @@ public:
 
 	Action *findAction(const Common::String &name);
 
-	Action *getAction() const { return _action; }
-	Page *getPage() const { return _page; }
+	Action *getAction() { return _action; }
+	const Action *getAction() const { return _action; }
+	Page *getPage() { return _page; }
+	const Page *getPage() const { return _page; }
 
 	InventoryMgr *getInventoryMgr() const;
 

--- a/engines/pink/objects/actors/actor.h
+++ b/engines/pink/objects/actors/actor.h
@@ -50,7 +50,7 @@ public:
 	virtual void init(bool paused);
 	bool initPalette(Director *director);
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	bool isPlaying() const { return !_isActionEnded; }
 	virtual void pause(bool paused);

--- a/engines/pink/objects/actors/audio_info_pda_button.cpp
+++ b/engines/pink/objects/actors/audio_info_pda_button.cpp
@@ -27,7 +27,7 @@
 
 namespace Pink {
 
-void AudioInfoPDAButton::toConsole()  {
+void AudioInfoPDAButton::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "AudioInfoPDAButton: _name = %s", _name.c_str());
 	for (uint i = 0; i < _actions.size(); ++i) {
 		_actions[i]->toConsole();

--- a/engines/pink/objects/actors/audio_info_pda_button.h
+++ b/engines/pink/objects/actors/audio_info_pda_button.h
@@ -34,7 +34,7 @@ namespace Pink {
 
 class AudioInfoPDAButton : public Actor {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 
 	void onMouseOver(const Common::Point point, CursorMgr *mgr) override;
 	void onMouseOverWithItem(const Common::Point point, const Common::String &itemName, CursorMgr *cursorMgr) override;

--- a/engines/pink/objects/actors/cursor_actor.h
+++ b/engines/pink/objects/actors/cursor_actor.h
@@ -33,7 +33,7 @@ namespace Pink {
 
 class CursorActor : public Actor {
 public:
-	void toConsole() override {
+	void toConsole() const override {
 		debugC(6, kPinkDebugLoadingObjects, "CursorActor: _name = %s", _name.c_str());
 		for (uint i = 0; i < _actions.size(); ++i) {
 			_actions[i]->toConsole();

--- a/engines/pink/objects/actors/cursor_actor.h
+++ b/engines/pink/objects/actors/cursor_actor.h
@@ -40,7 +40,7 @@ public:
 		}
 	}
 
-	bool isCursor() override {
+	bool isCursor() const override {
 		return true;
 	}
 

--- a/engines/pink/objects/actors/inventory_actor.h
+++ b/engines/pink/objects/actors/inventory_actor.h
@@ -32,7 +32,7 @@ namespace Pink {
 
 class InventoryActor : public Actor {
 public:
-	void toConsole() override {
+	void toConsole() const override {
 		debugC(6, kPinkDebugLoadingObjects, "InventoryActor: _name = %s", _name.c_str());
 		for (uint i = 0; i < _actions.size(); ++i) {
 			_actions[i]->toConsole();

--- a/engines/pink/objects/actors/lead_actor.cpp
+++ b/engines/pink/objects/actors/lead_actor.cpp
@@ -321,7 +321,7 @@ void LeadActor::onPDAClose() {
 		_page->pause(0);
 }
 
-bool LeadActor::isInteractingWith(Actor *actor) {
+bool LeadActor::isInteractingWith(const Actor *actor) const {
 	if (!_isHaveItem)
 		return actor->isLeftClickHandlers();
 

--- a/engines/pink/objects/actors/lead_actor.cpp
+++ b/engines/pink/objects/actors/lead_actor.cpp
@@ -47,7 +47,7 @@ void LeadActor::deserialize(Archive &archive) {
 	_sequencer = static_cast<Sequencer *>(archive.readObject());
 }
 
-void LeadActor::toConsole() {
+void LeadActor::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "LeadActor: _name = %s", _name.c_str());
 	for (uint i = 0; i < _actions.size(); ++i) {
 		_actions[i]->toConsole();
@@ -434,7 +434,7 @@ Actor *LeadActor::findActor(const Common::String &name) {
 	return _page->findActor(name);
 }
 
-void ParlSqPink::toConsole() {
+void ParlSqPink::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "ParlSqPink: _name = %s", _name.c_str());
 	for (uint i = 0; i < _actions.size(); ++i) {
 		_actions[i]->toConsole();
@@ -448,7 +448,7 @@ WalkLocation *ParlSqPink::getWalkDestination() {
 	return LeadActor::getWalkDestination();
 }
 
-void PubPink::toConsole() {
+void PubPink::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "PubPink: _name = %s", _name.c_str());
 	for (uint i = 0; i < _actions.size(); ++i) {
 		_actions[i]->toConsole();

--- a/engines/pink/objects/actors/lead_actor.h
+++ b/engines/pink/objects/actors/lead_actor.h
@@ -55,7 +55,7 @@ public:
 
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void loadState(Archive &archive);
 	void saveState(Archive &archive);
@@ -130,7 +130,7 @@ protected:
 
 class ParlSqPink : public LeadActor {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 
 protected:
 	WalkLocation *getWalkDestination() override;
@@ -138,7 +138,7 @@ protected:
 
 class PubPink : public LeadActor {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 
 	void onLeftClickMessage() override;
 	void onVariableSet() override;

--- a/engines/pink/objects/actors/lead_actor.h
+++ b/engines/pink/objects/actors/lead_actor.h
@@ -84,7 +84,7 @@ public:
 	void onWalkEnd(const Common::String &stopName);
 	void onPDAClose();
 
-	bool isInteractingWith(Actor *actor);
+	bool isInteractingWith(const Actor *actor) const;
 
 	void setNextExecutors(const Common::String &nextModule, const Common::String &nextPage);
 

--- a/engines/pink/objects/actors/pda_button_actor.cpp
+++ b/engines/pink/objects/actors/pda_button_actor.cpp
@@ -56,7 +56,7 @@ void PDAButtonActor::deserialize(Archive &archive) {
 	_command.arg = archive.readString();
 }
 
-void PDAButtonActor::toConsole() {
+void PDAButtonActor::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "PDAButtonActor: _name = %s, _x = %u _y = %u _hideOnStop = %u, _opaque = %u, _commandType = %u, _arg = %s",
 		  _name.c_str(), _x, _y, _hideOnStop, _opaque, (int)_command.type, _command.arg.c_str());
 }

--- a/engines/pink/objects/actors/pda_button_actor.cpp
+++ b/engines/pink/objects/actors/pda_button_actor.cpp
@@ -74,7 +74,7 @@ void PDAButtonActor::onMouseOver(const Common::Point point, CursorMgr *mgr) {
 		mgr->setCursor(kPDAClickableFirstFrameCursor, point, Common::String());
 }
 
-bool PDAButtonActor::isActive() {
+bool PDAButtonActor::isActive() const {
 	return _action && _action->getName() != "Inactive";
 }
 

--- a/engines/pink/objects/actors/pda_button_actor.h
+++ b/engines/pink/objects/actors/pda_button_actor.h
@@ -52,7 +52,7 @@ class PDAButtonActor : public Actor {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	void init(bool paused) override;
 

--- a/engines/pink/objects/actors/pda_button_actor.h
+++ b/engines/pink/objects/actors/pda_button_actor.h
@@ -61,7 +61,7 @@ public:
 	void onLeftClickMessage() override;
 
 private:
-	bool isActive();
+	bool isActive() const;
 
 	Command _command;
 

--- a/engines/pink/objects/actors/supporting_actor.cpp
+++ b/engines/pink/objects/actors/supporting_actor.cpp
@@ -38,7 +38,7 @@ void SupportingActor::deserialize(Archive &archive) {
 	_handlerMgr.deserialize(archive);
 }
 
-void SupportingActor::toConsole() {
+void SupportingActor::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "SupportingActor: _name = %s, _location=%s, _pdaLink=%s, _cursor=%s",
 		  _name.c_str(), _location.c_str(), _pdaLink.c_str(), _cursor.c_str());
 	for (uint i = 0; i < _actions.size(); ++i) {

--- a/engines/pink/objects/actors/supporting_actor.cpp
+++ b/engines/pink/objects/actors/supporting_actor.cpp
@@ -47,11 +47,11 @@ void SupportingActor::toConsole() {
 	_handlerMgr.toConsole();
 }
 
-bool SupportingActor::isLeftClickHandlers() {
+bool SupportingActor::isLeftClickHandlers() const {
 	return _handlerMgr.isLeftClickHandler(this);
 }
 
-bool SupportingActor::isUseClickHandlers(InventoryItem *item) {
+bool SupportingActor::isUseClickHandlers(InventoryItem *item) const {
 	return _handlerMgr.isUseClickHandler(this, item->getName());
 }
 

--- a/engines/pink/objects/actors/supporting_actor.h
+++ b/engines/pink/objects/actors/supporting_actor.h
@@ -35,7 +35,7 @@ class SupportingActor : public Actor {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	bool isSupporting() const override { return true; }
 

--- a/engines/pink/objects/actors/supporting_actor.h
+++ b/engines/pink/objects/actors/supporting_actor.h
@@ -37,10 +37,10 @@ public:
 
 	void toConsole() override;
 
-	bool isSupporting() override { return true; }
+	bool isSupporting() const override { return true; }
 
-	bool isLeftClickHandlers() override;
-	bool isUseClickHandlers(InventoryItem *item) override;
+	bool isLeftClickHandlers() const override;
+	bool isUseClickHandlers(InventoryItem *item) const override;
 
 	void onMouseOver(const Common::Point point, CursorMgr *mgr) override;
 	void onMouseOverWithItem(const Common::Point point, const Common::String &itemName, CursorMgr *cursorMgr) override;

--- a/engines/pink/objects/condition.cpp
+++ b/engines/pink/objects/condition.cpp
@@ -33,7 +33,7 @@ void ConditionVariable::deserialize(Archive &archive) {
 	_value = archive.readString();
 }
 
-bool ConditionGameVariable::evaluate(Actor *actor) {
+bool ConditionGameVariable::evaluate(const Actor *actor) const {
 	return actor->getPage()->getModule()->getGame()->checkValueOfVariable(_name, _value);
 }
 
@@ -41,7 +41,7 @@ void ConditionGameVariable::toConsole() {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionGameVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
-bool ConditionModuleVariable::evaluate(Actor *actor) {
+bool ConditionModuleVariable::evaluate(const Actor *actor) const {
 	return actor->getPage()->getModule()->checkValueOfVariable(_name, _value);
 }
 
@@ -49,7 +49,7 @@ void ConditionModuleVariable::toConsole() {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionModuleVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
-bool ConditionNotModuleVariable::evaluate(Actor *actor) {
+bool ConditionNotModuleVariable::evaluate(const Actor *actor) const {
 	return !ConditionModuleVariable::evaluate(actor);
 }
 
@@ -57,7 +57,7 @@ void ConditionNotModuleVariable::toConsole() {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionNotModuleVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
-bool ConditionPageVariable::evaluate(Actor *actor) {
+bool ConditionPageVariable::evaluate(const Actor *actor) const {
 	return actor->getPage()->checkValueOfVariable(_name, _value);
 }
 
@@ -65,7 +65,7 @@ void ConditionPageVariable::toConsole() {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionPageVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
-bool ConditionNotPageVariable::evaluate(Actor *actor) {
+bool ConditionNotPageVariable::evaluate(const Actor *actor) const {
 	return !ConditionPageVariable::evaluate(actor);
 }
 
@@ -78,7 +78,7 @@ void ConditionInventoryItemOwner::deserialize(Archive &archive) {
 	_owner = archive.readString();
 }
 
-bool ConditionInventoryItemOwner::evaluate(Actor *actor) {
+bool ConditionInventoryItemOwner::evaluate(const Actor *actor) const {
 	InventoryMgr *mgr = actor->getInventoryMgr();
 	InventoryItem *item = mgr->findInventoryItem(_item);
 	if (item)
@@ -90,7 +90,7 @@ void ConditionInventoryItemOwner::toConsole() {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionInventoryItemOwner: _item=%s, _owner=%s", _item.c_str(), _owner.c_str());
 }
 
-bool ConditionNotInventoryItemOwner::evaluate(Actor *actor) {
+bool ConditionNotInventoryItemOwner::evaluate(const Actor *actor) const {
 	return !ConditionInventoryItemOwner::evaluate(actor);
 }
 

--- a/engines/pink/objects/condition.cpp
+++ b/engines/pink/objects/condition.cpp
@@ -37,7 +37,7 @@ bool ConditionGameVariable::evaluate(const Actor *actor) const {
 	return actor->getPage()->getModule()->getGame()->checkValueOfVariable(_name, _value);
 }
 
-void ConditionGameVariable::toConsole() {
+void ConditionGameVariable::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionGameVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
@@ -45,7 +45,7 @@ bool ConditionModuleVariable::evaluate(const Actor *actor) const {
 	return actor->getPage()->getModule()->checkValueOfVariable(_name, _value);
 }
 
-void ConditionModuleVariable::toConsole() {
+void ConditionModuleVariable::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionModuleVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
@@ -53,7 +53,7 @@ bool ConditionNotModuleVariable::evaluate(const Actor *actor) const {
 	return !ConditionModuleVariable::evaluate(actor);
 }
 
-void ConditionNotModuleVariable::toConsole() {
+void ConditionNotModuleVariable::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionNotModuleVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
@@ -61,7 +61,7 @@ bool ConditionPageVariable::evaluate(const Actor *actor) const {
 	return actor->getPage()->checkValueOfVariable(_name, _value);
 }
 
-void ConditionPageVariable::toConsole() {
+void ConditionPageVariable::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionPageVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
@@ -69,7 +69,7 @@ bool ConditionNotPageVariable::evaluate(const Actor *actor) const {
 	return !ConditionPageVariable::evaluate(actor);
 }
 
-void ConditionNotPageVariable::toConsole() {
+void ConditionNotPageVariable::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionNotPageVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
@@ -86,7 +86,7 @@ bool ConditionInventoryItemOwner::evaluate(const Actor *actor) const {
 	return false;
 }
 
-void ConditionInventoryItemOwner::toConsole() {
+void ConditionInventoryItemOwner::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionInventoryItemOwner: _item=%s, _owner=%s", _item.c_str(), _owner.c_str());
 }
 
@@ -94,7 +94,7 @@ bool ConditionNotInventoryItemOwner::evaluate(const Actor *actor) const {
 	return !ConditionInventoryItemOwner::evaluate(actor);
 }
 
-void ConditionNotInventoryItemOwner::toConsole() {
+void ConditionNotInventoryItemOwner::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tConditionNotInventoryItemOwner: _item=%s, _owner=%s", _item.c_str(), _owner.c_str());
 }
 

--- a/engines/pink/objects/condition.h
+++ b/engines/pink/objects/condition.h
@@ -32,14 +32,14 @@ class Actor;
 class Condition : public Object {
 public:
 	void deserialize(Archive &archive) override = 0;
-	virtual bool evaluate(Actor *actor) = 0;
+	virtual bool evaluate(const Actor *actor) const = 0;
 };
 
 class ConditionVariable : public Condition {
 public:
 
 	void deserialize(Archive &archive) override;
-	bool evaluate(Actor *actor) override = 0;
+	bool evaluate(const Actor *actor) const override = 0;
 
 protected:
 	Common::String _name;
@@ -49,7 +49,7 @@ protected:
 class ConditionGameVariable : public ConditionVariable {
 public:
 	void toConsole() override;
-	bool evaluate(Actor *actor) override;
+	bool evaluate(const Actor *actor) const override;
 };
 
 /*
@@ -62,32 +62,32 @@ class ConditionNotGameVariable : public ConditionGameVariable {
 class ConditionModuleVariable : public ConditionVariable {
 public:
 	void toConsole() override;
-	bool evaluate(Actor *actor) override;
+	bool evaluate(const Actor *actor) const override;
 };
 
 class ConditionNotModuleVariable : public ConditionModuleVariable {
 public:
 	void toConsole() override;
-	bool evaluate(Actor *actor) override;
+	bool evaluate(const Actor *actor) const override;
 };
 
 class ConditionPageVariable : public ConditionVariable {
 public:
 	void toConsole() override;
-	bool evaluate(Actor *actor) override;
+	bool evaluate(const Actor *actor) const override;
 };
 
 class ConditionNotPageVariable : public ConditionPageVariable {
 public:
 	void toConsole() override;
-	bool evaluate(Actor *actor) override;
+	bool evaluate(const Actor *actor) const override;
 };
 
 class ConditionInventoryItemOwner : public Condition {
 public:
 	void toConsole() override;
 	void deserialize(Archive &archive) override;
-	bool evaluate(Actor *actor) override;
+	bool evaluate(const Actor *actor) const override;
 
 protected:
 	Common::String _item;
@@ -97,7 +97,7 @@ protected:
 class ConditionNotInventoryItemOwner : public ConditionInventoryItemOwner {
 public:
 	void toConsole() override;
-	bool evaluate(Actor *actor) override;
+	bool evaluate(const Actor *actor) const override;
 };
 
 } // End of namespace Pink

--- a/engines/pink/objects/condition.h
+++ b/engines/pink/objects/condition.h
@@ -48,7 +48,7 @@ protected:
 
 class ConditionGameVariable : public ConditionVariable {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	bool evaluate(const Actor *actor) const override;
 };
 
@@ -61,31 +61,31 @@ class ConditionNotGameVariable : public ConditionGameVariable {
 
 class ConditionModuleVariable : public ConditionVariable {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	bool evaluate(const Actor *actor) const override;
 };
 
 class ConditionNotModuleVariable : public ConditionModuleVariable {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	bool evaluate(const Actor *actor) const override;
 };
 
 class ConditionPageVariable : public ConditionVariable {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	bool evaluate(const Actor *actor) const override;
 };
 
 class ConditionNotPageVariable : public ConditionPageVariable {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	bool evaluate(const Actor *actor) const override;
 };
 
 class ConditionInventoryItemOwner : public Condition {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	void deserialize(Archive &archive) override;
 	bool evaluate(const Actor *actor) const override;
 
@@ -96,7 +96,7 @@ protected:
 
 class ConditionNotInventoryItemOwner : public ConditionInventoryItemOwner {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	bool evaluate(const Actor *actor) const override;
 };
 

--- a/engines/pink/objects/handlers/handler.cpp
+++ b/engines/pink/objects/handlers/handler.cpp
@@ -37,7 +37,7 @@ void Handler::deserialize(Archive &archive) {
 	_sideEffects.deserialize(archive);
 }
 
-bool Handler::isSuitable(Actor *actor) {
+bool Handler::isSuitable(const Actor *actor) const {
 	for (uint i = 0; i < _conditions.size(); ++i) {
 		if (!_conditions[i]->evaluate(actor))
 			return false;

--- a/engines/pink/objects/handlers/handler.cpp
+++ b/engines/pink/objects/handlers/handler.cpp
@@ -90,7 +90,7 @@ void HandlerStartPage::execute(Sequence *sequence) {
 	sequence->allowSkipping();
 }
 
-void HandlerStartPage::toConsole() {
+void HandlerStartPage::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "HandlerStartPage:");
 
 	debugC(6, kPinkDebugLoadingObjects, "\tSideEffects:");
@@ -109,7 +109,7 @@ void HandlerStartPage::toConsole() {
 	}
 }
 
-void HandlerLeftClick::toConsole() {
+void HandlerLeftClick::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "HandlerLeftClick:");
 
 	debugC(6, kPinkDebugLoadingObjects, "\tSideEffects:");
@@ -134,7 +134,7 @@ void HandlerUseClick::deserialize(Archive &archive) {
 	_recepient = archive.readString();
 }
 
-void HandlerUseClick::toConsole() {
+void HandlerUseClick::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "HandlerUseClick: _inventoryItem=%s, _recepient=%s", _inventoryItem.c_str(), _recepient.c_str());
 	debugC(6, kPinkDebugLoadingObjects, "\tSideEffects:");
 	for (uint i = 0; i < _sideEffects.size(); ++i) {

--- a/engines/pink/objects/handlers/handler.h
+++ b/engines/pink/objects/handlers/handler.h
@@ -63,7 +63,7 @@ protected:
 
 class HandlerStartPage : public HandlerSequences {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 
 private:
 	void execute(Sequence *sequence) override;
@@ -71,7 +71,7 @@ private:
 
 class HandlerLeftClick : public HandlerSequences {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 
 private:
 	void execute(Sequence *sequence) override {}
@@ -80,7 +80,7 @@ private:
 class HandlerUseClick : public HandlerSequences {
 public:
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 
 	const Common::String &getInventoryItem() const { return _inventoryItem; }
 	const Common::String &getRecepient() const { return _recepient; }

--- a/engines/pink/objects/handlers/handler.h
+++ b/engines/pink/objects/handlers/handler.h
@@ -39,7 +39,7 @@ public:
 	~Handler() override;
 	void deserialize(Archive &archive) override;
 	virtual void handle(Actor *actor);
-	bool isSuitable(Actor *actor);
+	bool isSuitable(const Actor *actor) const;
 
 protected:
 	void executeSideEffects(Actor *actor);

--- a/engines/pink/objects/handlers/handler_mgr.cpp
+++ b/engines/pink/objects/handlers/handler_mgr.cpp
@@ -47,7 +47,7 @@ void HandlerMgr::toConsole() {
 	}
 }
 
-bool HandlerMgr::isLeftClickHandler(Actor *actor) {
+bool HandlerMgr::isLeftClickHandler(const Actor *actor) const {
 	for (uint i = 0; i < _leftClickHandlers.size(); ++i) {
 		if (_leftClickHandlers[i]->isSuitable(actor))
 			return true;
@@ -56,7 +56,7 @@ bool HandlerMgr::isLeftClickHandler(Actor *actor) {
 	return false;
 }
 
-bool HandlerMgr::isUseClickHandler(Actor *actor, const Common::String &itemName) {
+bool HandlerMgr::isUseClickHandler(const Actor *actor, const Common::String &itemName) const {
 	for (uint i = 0; i < _useClickHandlers.size(); ++i) {
 		if (itemName == _useClickHandlers[i]->getInventoryItem() &&
 			_useClickHandlers[i]->isSuitable(actor))

--- a/engines/pink/objects/handlers/handler_mgr.cpp
+++ b/engines/pink/objects/handlers/handler_mgr.cpp
@@ -34,7 +34,7 @@ void HandlerMgr::deserialize(Archive &archive) {
 	_timerHandlers.deserialize(archive);
 }
 
-void HandlerMgr::toConsole() {
+void HandlerMgr::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "HandlerMgr:");
 	for (uint i = 0; i < _leftClickHandlers.size(); ++i) {
 		_leftClickHandlers[i]->toConsole();

--- a/engines/pink/objects/handlers/handler_mgr.h
+++ b/engines/pink/objects/handlers/handler_mgr.h
@@ -42,7 +42,7 @@ public:
 	~HandlerMgr() override;
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	bool isLeftClickHandler(const Actor *actor) const;
 	bool isUseClickHandler(const Actor *actor, const Common::String &itemName) const;

--- a/engines/pink/objects/handlers/handler_mgr.h
+++ b/engines/pink/objects/handlers/handler_mgr.h
@@ -44,8 +44,8 @@ public:
 
 	void toConsole() override;
 
-	bool isLeftClickHandler(Actor *actor);
-	bool isUseClickHandler(Actor *actor, const Common::String &itemName);
+	bool isLeftClickHandler(const Actor *actor) const;
+	bool isUseClickHandler(const Actor *actor, const Common::String &itemName) const;
 
 	void onTimerMessage(Actor *actor);
 	void onLeftClickMessage(Actor *actor);

--- a/engines/pink/objects/handlers/handler_timer.cpp
+++ b/engines/pink/objects/handlers/handler_timer.cpp
@@ -39,7 +39,7 @@ void HandlerTimerActions::deserialize(Archive &archive) {
 	_actions.deserialize(archive);
 }
 
-void HandlerTimerActions::toConsole() {
+void HandlerTimerActions::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "HandlerTimerActions:");
 
 	debugC(6, kPinkDebugLoadingObjects, "\tSideEffects:");
@@ -69,7 +69,7 @@ void HandlerTimerActions::handle(Actor *actor) {
 	}
 }
 
-void HandlerTimerSequences::toConsole() {
+void HandlerTimerSequences::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "HandlerTimerSequences:");
 
 	debugC(6, kPinkDebugLoadingObjects, "\tSideEffects:");

--- a/engines/pink/objects/handlers/handler_timer.h
+++ b/engines/pink/objects/handlers/handler_timer.h
@@ -39,7 +39,7 @@ class HandlerTimer : public Handler {
 //in Peril this is HandlerTimer
 class HandlerTimerActions : public Handler {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	void deserialize(Archive &archive) override;
 	void handle(Actor *actor) override;
 
@@ -50,7 +50,7 @@ private:
 //appear in HokusPokus
 class HandlerTimerSequences : public HandlerSequences { //originally it was inherited from HandlerTimer
 public:
-	void toConsole() override;
+	void toConsole() const override;
 
 	void handle(Actor *actor) override;
 

--- a/engines/pink/objects/inventory.cpp
+++ b/engines/pink/objects/inventory.cpp
@@ -34,7 +34,7 @@ namespace Pink {
 
 InventoryMgr::InventoryMgr()
 	: _lead(nullptr), _window(nullptr), _itemActor(nullptr),
-	_rightArrow(nullptr), _leftArrow(nullptr), _item(nullptr),
+	_rightArrow(nullptr), _leftArrow(nullptr), _currentItem(nullptr),
 	_state(kIdle), _isClickedOnItem(false) {}
 
 void InventoryItem::deserialize(Archive &archive) {
@@ -74,12 +74,12 @@ void InventoryMgr::toConsole() const {
 }
 
 bool InventoryMgr::isPinkOwnsAnyItems() {
-	if (_item)
+	if (_currentItem)
 		return true;
 
 	for (uint i = 0; i < _items.size(); ++i) {
 		if (_items[i]->getCurrentOwner() == _lead->getName()) {
-			_item = _items[i];
+			_currentItem = _items[i];
 			return true;
 		}
 	}
@@ -91,10 +91,10 @@ void InventoryMgr::setItemOwner(const Common::String &owner, InventoryItem *item
 	if (owner == item->getCurrentOwner())
 		return;
 
-	if (item == _item && _lead->getName() != owner)
-		_item = nullptr;
+	if (item == _currentItem && _lead->getName() != owner)
+		_currentItem = nullptr;
 	else if (_lead->getName() == owner)
-		_item = item;
+		_currentItem = item;
 
 	item->_currentOwner = owner;
 }
@@ -123,7 +123,7 @@ void InventoryMgr::update() {
 	switch (_state) {
 	case kOpening:
 		_state = kReady;
-		_itemActor->setAction(_item->getName());
+		_itemActor->setAction(_currentItem->getName());
 		_window->setAction(kShowAction);
 		_leftArrow->setAction(kShowAction);
 		_rightArrow->setAction(kShowAction);
@@ -173,7 +173,7 @@ void InventoryMgr::close() {
 void InventoryMgr::showNextItem(bool direction) {
 	int index = 0;
 	for (uint i = 0; i < _items.size(); ++i) {
-		if (_item == _items[i]) {
+		if (_currentItem == _items[i]) {
 			index = i + _items.size();
 			break;
 		}
@@ -181,9 +181,9 @@ void InventoryMgr::showNextItem(bool direction) {
 
 	for (uint i = 0; i < _items.size(); ++i) {
 		index = (direction == kLeft) ? index - 1 : index + 1;
-		if (_items[index % _items.size()]->getCurrentOwner() == _item->getCurrentOwner()) {
-			_item = _items[index % _items.size()];
-			_itemActor->setAction(_item->getName());
+		if (_items[index % _items.size()]->getCurrentOwner() == _currentItem->getCurrentOwner()) {
+			_currentItem = _items[index % _items.size()];
+			_itemActor->setAction(_currentItem->getName());
 			break;
 		}
 	}
@@ -199,10 +199,10 @@ void InventoryMgr::loadState(Archive &archive) {
 
 	const Common::String currItemName = archive.readString();
 	if (currItemName.empty()) {
-		_item = nullptr;
+		_currentItem = nullptr;
 		_isClickedOnItem = 0;
 	} else {
-		_item = findInventoryItem(currItemName);
+		_currentItem = findInventoryItem(currItemName);
 	}
 }
 
@@ -214,8 +214,8 @@ void InventoryMgr::saveState(Archive &archive) {
 		archive.writeString(_items[i]->_currentOwner);
 	}
 
-	if (_item)
-		archive.writeString(_item->getName());
+	if (_currentItem)
+		archive.writeString(_currentItem->getName());
 	else
 		archive.writeString(Common::String());
 }

--- a/engines/pink/objects/inventory.cpp
+++ b/engines/pink/objects/inventory.cpp
@@ -43,7 +43,7 @@ void InventoryItem::deserialize(Archive &archive) {
 	_currentOwner = _initialOwner;
 }
 
-void InventoryItem::toConsole() {
+void InventoryItem::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tInventoryItem: _initialOwner=%s _currentOwner=%s", _initialOwner.c_str(), _currentOwner.c_str());
 }
 
@@ -66,7 +66,7 @@ InventoryItem *InventoryMgr::findInventoryItem(const Common::String &name) {
 	return nullptr;
 }
 
-void InventoryMgr::toConsole() {
+void InventoryMgr::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "InventoryMgr:");
 	for (uint i = 0; i < _items.size(); ++i) {
 		_items[i]->toConsole();

--- a/engines/pink/objects/inventory.h
+++ b/engines/pink/objects/inventory.h
@@ -35,7 +35,7 @@ public:
 
 	void toConsole() override;
 
-	const Common::String &getCurrentOwner() { return _currentOwner; }
+	const Common::String &getCurrentOwner() const { return _currentOwner; }
 
 	friend class InventoryMgr;
 private:

--- a/engines/pink/objects/inventory.h
+++ b/engines/pink/objects/inventory.h
@@ -67,7 +67,7 @@ public:
 	bool isPinkOwnsAnyItems();
 	void setItemOwner(const Common::String &owner, InventoryItem *item);
 
-	InventoryItem *getCurrentItem() { return _item; }
+	InventoryItem *getCurrentItem() { return _currentItem; }
 
 	friend class Console;
 
@@ -85,7 +85,7 @@ private:
 	Actor *_rightArrow;
 	Actor *_leftArrow;
 
-	InventoryItem *_item;
+	InventoryItem *_currentItem;
 	Array<InventoryItem *> _items;
 
 	enum State {

--- a/engines/pink/objects/inventory.h
+++ b/engines/pink/objects/inventory.h
@@ -33,7 +33,7 @@ class InventoryItem : public NamedObject {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	const Common::String &getCurrentOwner() const { return _currentOwner; }
 
@@ -51,7 +51,7 @@ public:
 	InventoryMgr();
 	~InventoryMgr() override;
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 
 	void loadState(Archive &archive);
 	void saveState(Archive &archive);

--- a/engines/pink/objects/module.cpp
+++ b/engines/pink/objects/module.cpp
@@ -77,7 +77,7 @@ GamePage *Module::findPage(const Common::String &pageName) const {
 	return nullptr;
 }
 
-bool Module::checkValueOfVariable(Common::String &variable, Common::String &value) {
+bool Module::checkValueOfVariable(const Common::String &variable, const Common::String &value) const {
 	if (!_variables.contains(variable))
 		return value == kUndefinedValue;
 	return _variables[variable] == value;

--- a/engines/pink/objects/module.h
+++ b/engines/pink/objects/module.h
@@ -55,11 +55,13 @@ public:
 
 	PinkEngine *getGame() const { return _game; }
 	InventoryMgr *getInventoryMgr() { return &_invMgr; }
+	const InventoryMgr *getInventoryMgr() const { return &_invMgr; }
 
-	bool checkValueOfVariable(Common::String &variable, Common::String &value);
+	bool checkValueOfVariable(const Common::String &variable, const Common::String &value) const;
 	void setVariable(Common::String &variable, Common::String &value) { _variables[variable] = value; }
 
 	GamePage *getPage() { return _page; }
+	const GamePage *getPage() const { return _page; }
 
 	friend class Console;
 

--- a/engines/pink/objects/object.cpp
+++ b/engines/pink/objects/object.cpp
@@ -28,6 +28,6 @@ void Object::load(Archive &) {}
 
 void Object::deserialize(Archive &) {}
 
-void Object::toConsole() {}
+void Object::toConsole() const {}
 
 } // End of namespace Pink

--- a/engines/pink/objects/object.h
+++ b/engines/pink/objects/object.h
@@ -35,7 +35,7 @@ public:
 
 	virtual void load(Archive &);
 	virtual void deserialize(Archive &);
-	virtual void toConsole();
+	virtual void toConsole() const;
 };
 
 class NamedObject : public Object {

--- a/engines/pink/objects/pages/game_page.cpp
+++ b/engines/pink/objects/pages/game_page.cpp
@@ -118,7 +118,7 @@ void GamePage::loadManagers() {
 	}
 }
 
-bool GamePage::checkValueOfVariable(const Common::String &variable, const Common::String &value) {
+bool GamePage::checkValueOfVariable(const Common::String &variable, const Common::String &value) const {
 	if (!_variables.contains(variable))
 		return value == kUndefinedValue;
 	return _variables[variable] == value;

--- a/engines/pink/objects/pages/game_page.cpp
+++ b/engines/pink/objects/pages/game_page.cpp
@@ -39,7 +39,7 @@ GamePage::~GamePage() {
 	delete _memFile;
 }
 
-void GamePage::toConsole() {
+void GamePage::toConsole() const {
 	Page::toConsole();
 	_walkMgr->toConsole();
 	_sequencer->toConsole();

--- a/engines/pink/objects/pages/game_page.h
+++ b/engines/pink/objects/pages/game_page.h
@@ -36,7 +36,7 @@ class GamePage : public Page {
 public:
 	GamePage();
 	~GamePage() override;
-	void toConsole() override;
+	void toConsole() const override;
 	void deserialize(Archive &archive) override;
 
 	void loadState(Archive &archive);

--- a/engines/pink/objects/pages/game_page.h
+++ b/engines/pink/objects/pages/game_page.h
@@ -50,8 +50,9 @@ public:
 	Sequencer *getSequencer() override { return _sequencer; }
 	WalkMgr *getWalkMgr() override { return _walkMgr; }
 	Module *getModule() override { return _module; }
+	const Module *getModule() const override { return _module; }
 
-	bool checkValueOfVariable(const Common::String &variable, const Common::String &value) override;
+	bool checkValueOfVariable(const Common::String &variable, const Common::String &value) const override;
 	void setVariable(Common::String &variable, Common::String &value) override;
 
 	void clear() override;

--- a/engines/pink/objects/pages/page.cpp
+++ b/engines/pink/objects/pages/page.cpp
@@ -48,7 +48,7 @@ Actor *Page::findActor(const Common::String &name) {
 	return nullptr;
 }
 
-void Page::toConsole() {
+void Page::toConsole() const {
 	for (uint i = 0; i < _actors.size(); ++i) {
 		_actors[i]->toConsole();
 	}

--- a/engines/pink/objects/pages/page.h
+++ b/engines/pink/objects/pages/page.h
@@ -37,7 +37,7 @@ class Sequencer;
 class Page : public NamedObject {
 public:
 	~Page() override;
-	void toConsole() override;
+	void toConsole() const override;
 
 	void load(Archive &archive) override;
 	void init();

--- a/engines/pink/objects/pages/page.h
+++ b/engines/pink/objects/pages/page.h
@@ -56,8 +56,9 @@ public:
 	virtual Sequencer *getSequencer() { return nullptr; }
 	virtual WalkMgr *getWalkMgr() { return nullptr; }
 	virtual Module *getModule()  { return nullptr; }
+	virtual const Module *getModule() const { return nullptr; }
 
-	virtual bool checkValueOfVariable(const Common::String &variable, const Common::String &value) { return 0; }
+	virtual bool checkValueOfVariable(const Common::String &variable, const Common::String &value) const { return 0; }
 	virtual void setVariable(Common::String &variable, Common::String &value) {}
 
 protected:

--- a/engines/pink/objects/sequences/seq_timer.cpp
+++ b/engines/pink/objects/sequences/seq_timer.cpp
@@ -42,7 +42,7 @@ void SeqTimer::deserialize(Archive &archive) {
 	_sequencer = static_cast<Sequencer *>(archive.readObject());
 }
 
-void SeqTimer::toConsole() {
+void SeqTimer::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tSeqTimer: _actor=%s _period=%u _range=%u", _actor.c_str(), _period, _range);
 }
 

--- a/engines/pink/objects/sequences/seq_timer.h
+++ b/engines/pink/objects/sequences/seq_timer.h
@@ -34,7 +34,7 @@ public:
 	SeqTimer();
 
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 
 	void update();
 

--- a/engines/pink/objects/sequences/sequence.cpp
+++ b/engines/pink/objects/sequences/sequence.cpp
@@ -49,7 +49,7 @@ void Sequence::deserialize(Archive &archive) {
 	_items.deserialize(archive);
 }
 
-void Sequence::toConsole() {
+void Sequence::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tSequence %s", _name.c_str());
 	debugC(6, kPinkDebugLoadingObjects, "\t\t\tItems:");
 	for (uint i = 0; i < _items.size(); ++i) {
@@ -132,7 +132,7 @@ void SequenceAudio::deserialize(Archive &archive) {
 	_soundName = archive.readString();
 }
 
-void SequenceAudio::toConsole() {
+void SequenceAudio::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tSequenceAudio %s : _sound = %s", _name.c_str(), _soundName.c_str());
 	debugC(6, kPinkDebugLoadingObjects, "\t\t\tItems:");
 	for (uint i = 0; i < _items.size(); ++i) {

--- a/engines/pink/objects/sequences/sequence.h
+++ b/engines/pink/objects/sequences/sequence.h
@@ -38,7 +38,7 @@ public:
 	~Sequence() override;
 
 	void deserialize(Archive &archive) override ;
-	void toConsole() override;
+	void toConsole() const override;
 
 public:
 	virtual void init(bool loadingSave);
@@ -76,7 +76,7 @@ public:
 		: _leader(nullptr) {}
 
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 
 	void init(bool loadingSave) override;
 	void start(bool loadingSave) override;

--- a/engines/pink/objects/sequences/sequence_item.cpp
+++ b/engines/pink/objects/sequences/sequence_item.cpp
@@ -39,7 +39,7 @@ void SequenceItem::deserialize(Archive &archive) {
 	_action = archive.readString();
 }
 
-void SequenceItem::toConsole() {
+void SequenceItem::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\t\t\tSequenceItem: _actor=%s, _action=%s", _actor.c_str(), _action.c_str());
 }
 
@@ -68,7 +68,7 @@ bool SequenceItemLeader::isLeader() {
 	return true;
 }
 
-void SequenceItemLeader::toConsole() {
+void SequenceItemLeader::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\t\t\tSequenceItemLeader: _actor=%s, _action=%s", _actor.c_str(), _action.c_str());
 }
 
@@ -78,7 +78,7 @@ void SequenceItemLeaderAudio::deserialize(Archive &archive) {
 	_sample = archive.readDWORD();
 }
 
-void SequenceItemLeaderAudio::toConsole() {
+void SequenceItemLeaderAudio::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\t\t\tSequenceItemLeaderAudio: _actor=%s, _action=%s _sample=%d", _actor.c_str(), _action.c_str(), _sample);
 }
 
@@ -89,7 +89,7 @@ bool SequenceItemDefaultAction::execute(uint segment, Sequence *sequence, bool l
 	return true;
 }
 
-void SequenceItemDefaultAction::toConsole() {
+void SequenceItemDefaultAction::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\t\t\tSequenceItemDefaultAction: _actor=%s, _action=%s", _actor.c_str(), _action.c_str());
 }
 

--- a/engines/pink/objects/sequences/sequence_item.h
+++ b/engines/pink/objects/sequences/sequence_item.h
@@ -33,7 +33,7 @@ class SequenceItem : public Object {
 public:
 	void deserialize(Archive &archive) override;
 
-	void toConsole() override;
+	void toConsole() const override;
 
 	virtual bool execute(uint segment, Sequence *sequence, bool loadingSave);
 	virtual bool isLeader();
@@ -48,7 +48,7 @@ protected:
 
 class SequenceItemLeader : public SequenceItem {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	bool isLeader() override;
 };
 
@@ -58,7 +58,7 @@ public:
 		: _sample(0) {}
 
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 
 	uint32 getSample() { return _sample; }
 
@@ -68,7 +68,7 @@ private:
 
 class SequenceItemDefaultAction : public SequenceItem {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 
 	bool execute(uint segment, Sequence *sequence, bool loadingSave) override;
 	void skip(Sequence *sequence) override;

--- a/engines/pink/objects/sequences/sequencer.cpp
+++ b/engines/pink/objects/sequences/sequencer.cpp
@@ -99,7 +99,7 @@ void Sequencer::authorParallelSequence(Sequence *sequence, bool loadingSave) {
 }
 
 
-void Sequencer::toConsole() {
+void Sequencer::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "Sequencer:");
 	for (uint i = 0; i < _sequences.size(); ++i) {
 		_sequences[i]->toConsole();

--- a/engines/pink/objects/sequences/sequencer.h
+++ b/engines/pink/objects/sequences/sequencer.h
@@ -39,7 +39,7 @@ public:
 	Sequencer(GamePage *page);
 	~Sequencer() override;
 
-	void toConsole() override;
+	void toConsole() const override;
 	void deserialize(Archive &archive) override;
 
 public:

--- a/engines/pink/objects/side_effect.cpp
+++ b/engines/pink/objects/side_effect.cpp
@@ -41,7 +41,7 @@ void SideEffectExit::execute(Actor *actor) {
 	actor->getPage()->getLeadActor()->setNextExecutors(_nextModule, _nextPage);
 }
 
-void SideEffectExit::toConsole() {
+void SideEffectExit::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tSideEffectExit: _nextModule=%s, _nextPage=%s", _nextModule.c_str(), _nextPage.c_str());
 }
 
@@ -56,7 +56,7 @@ void SideEffectLocation::execute(Actor *actor) {
 		mgr->setCurrentWayPoint(location);
 }
 
-void SideEffectLocation::toConsole() {
+void SideEffectLocation::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tSideEffectLocation: _location=%s", _location.c_str());
 }
 
@@ -71,7 +71,7 @@ void SideEffectInventoryItemOwner::execute(Actor *actor) {
 	mgr->setItemOwner(_owner, item);
 }
 
-void SideEffectInventoryItemOwner::toConsole() {
+void SideEffectInventoryItemOwner::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tSideEffectInventoryItemOwner: _item=%s, _owner=%s", _item.c_str(), _owner.c_str());
 }
 
@@ -84,7 +84,7 @@ void SideEffectGameVariable::execute(Actor *actor) {
 	actor->getPage()->getGame()->setVariable(_name, _value);
 }
 
-void SideEffectGameVariable::toConsole() {
+void SideEffectGameVariable::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tSideEffectGameVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
@@ -92,7 +92,7 @@ void SideEffectModuleVariable::execute(Actor *actor) {
 	actor->getPage()->getModule()->setVariable(_name, _value);
 }
 
-void SideEffectModuleVariable::toConsole() {
+void SideEffectModuleVariable::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tSideEffectModuleVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
@@ -100,7 +100,7 @@ void SideEffectPageVariable::execute(Actor *actor) {
 	actor->getPage()->setVariable(_name, _value);
 }
 
-void SideEffectPageVariable::toConsole() {
+void SideEffectPageVariable::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\t\tSideEffectPageVariable: _name=%s, _value=%s", _name.c_str(), _value.c_str());
 }
 
@@ -118,7 +118,7 @@ void SideEffectRandomPageVariable::execute(Actor *actor) {
 	actor->getPage()->setVariable(_name, _values[index]);
 }
 
-void SideEffectRandomPageVariable::toConsole() {
+void SideEffectRandomPageVariable::toConsole() const {
 	Common::String values("{");
 	for (uint i = 0; i < _values.size(); ++i) {
 		values += _values[i];

--- a/engines/pink/objects/side_effect.h
+++ b/engines/pink/objects/side_effect.h
@@ -39,7 +39,7 @@ public:
 class SideEffectExit : public SideEffect {
 public:
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 	void execute(Actor *actor) override;
 
 private:
@@ -51,7 +51,7 @@ class SideEffectLocation : public SideEffect {
 public:
 	void deserialize(Archive &archive) override;
 	void execute(Actor *actor) override;
-	void toConsole() override;
+	void toConsole() const override;
 
 private:
 	Common::String _location;
@@ -61,7 +61,7 @@ class SideEffectInventoryItemOwner : public SideEffect {
 public:
 	void deserialize(Archive &archive) override;
 	void execute(Actor *actor) override;
-	void toConsole() override;
+	void toConsole() const override;
 
 private:
 	Common::String _item;
@@ -80,26 +80,26 @@ protected:
 
 class SideEffectGameVariable : public SideEffectVariable {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	void execute(Actor *actor) override;
 };
 
 class SideEffectModuleVariable : public SideEffectVariable {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	void execute(Actor *actor) override;
 };
 
 class SideEffectPageVariable : public SideEffectVariable {
 public:
-	void toConsole() override;
+	void toConsole() const override;
 	void execute(Actor *actor) override;
 };
 
 class SideEffectRandomPageVariable : public SideEffect {
 public:
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 	void execute(Actor *actor) override;
 
 private:

--- a/engines/pink/objects/walk/walk_location.cpp
+++ b/engines/pink/objects/walk/walk_location.cpp
@@ -33,7 +33,7 @@ void WalkLocation::deserialize(Pink::Archive &archive) {
 	_neighbors.deserialize(archive);
 }
 
-void WalkLocation::toConsole() {
+void WalkLocation::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "\tWalkLocation: _name =%s", _name.c_str());
 	debugC(6, kPinkDebugLoadingObjects, "\tNeighbors:");
 	for (uint i = 0; i < _neighbors.size(); ++i) {

--- a/engines/pink/objects/walk/walk_location.h
+++ b/engines/pink/objects/walk/walk_location.h
@@ -29,7 +29,7 @@ namespace Pink {
 class WalkLocation : public NamedObject {
 public:
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 	Common::StringArray &getNeigbors() { return _neighbors;}
 
 private:

--- a/engines/pink/objects/walk/walk_mgr.cpp
+++ b/engines/pink/objects/walk/walk_mgr.cpp
@@ -52,7 +52,7 @@ WalkLocation *WalkMgr::findLocation(const Common::String &name) {
 	return nullptr;
 }
 
-void WalkMgr::toConsole() {
+void WalkMgr::toConsole() const {
 	debugC(6, kPinkDebugLoadingObjects, "WalkMgr:");
 	for (uint i = 0; i < _locations.size(); ++i) {
 		_locations[i]->toConsole();

--- a/engines/pink/objects/walk/walk_mgr.h
+++ b/engines/pink/objects/walk/walk_mgr.h
@@ -45,7 +45,7 @@ public:
 	WalkMgr();
 	~WalkMgr() override;
 	void deserialize(Archive &archive) override;
-	void toConsole() override;
+	void toConsole() const override;
 
 	WalkLocation *findLocation(const Common::String &name);
 	void start(WalkLocation *destination);

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -229,7 +229,7 @@ void PinkEngine::setVariable(Common::String &variable, Common::String &value) {
 	_variables[variable] = value;
 }
 
-bool PinkEngine::checkValueOfVariable(Common::String &variable, Common::String &value) {
+bool PinkEngine::checkValueOfVariable(const Common::String &variable, const Common::String &value) const {
 	if (!_variables.contains(variable))
 		return value == kUndefinedValue;
 	return _variables[variable] == value;
@@ -302,7 +302,7 @@ void PinkEngine::pauseEngineIntern(bool pause) {
 	_director->pause(pause);
 }
 
-bool PinkEngine::isPeril() {
+bool PinkEngine::isPeril() const {
 	return !strcmp(_desc->gameId, kPeril);
 }
 

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -114,10 +114,10 @@ public:
 
 	void changeScene();
 
-	bool isPeril();
+	bool isPeril() const;
 
 	void setVariable(Common::String &variable, Common::String &value);
-	bool checkValueOfVariable(Common::String &variable, Common::String &value);
+	bool checkValueOfVariable(const Common::String &variable, const Common::String &value) const;
 
 	void executeMenuCommand(uint id);
 

--- a/engines/pink/sound.h
+++ b/engines/pink/sound.h
@@ -42,13 +42,13 @@ public:
 
 	void play(Common::SafeSeekableSubReadStream *stream, Audio::Mixer::SoundType type, byte volume = 100, int8 balance = 0, bool isLoop = false);
 
-	bool isPlaying() { return g_system->getMixer()->isSoundHandleActive(_handle); }
+	bool isPlaying() const { return g_system->getMixer()->isSoundHandleActive(_handle); }
 
 	void stop() { g_system->getMixer()->stopHandle(_handle); }
 
 	void pause(bool paused) { g_system->getMixer()->pauseHandle(_handle, paused); }
 
-	uint64 getCurrentSample() { return (uint64)g_system->getMixer()->getElapsedTime(_handle).msecs() * kSampleRate / 1000; }
+	uint64 getCurrentSample() const { return (uint64)g_system->getMixer()->getElapsedTime(_handle).msecs() * kSampleRate / 1000; }
 
 private:
 	Audio::SoundHandle _handle;


### PR DESCRIPTION
Const correctness for a bit of everything in the engine.

Notably `InventoryMgr::isPinkOwnsAnyItems` is not const, because it has a side effect that will cause a crash if removed.