### PR TITLE
SCI: Wait for MIDI commands to be sent on exit

### DIFF
--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -1219,6 +1219,7 @@ void MidiPlayer_Midi::close() {
 		sendMt32SysEx(0x200000, SciSpan<const byte>(_goodbyeMsg, 20), true);
 	}
 
+	_driver->setTimerCallback(NULL, NULL);
 	_driver->close();
 }
 


### PR DESCRIPTION
This fixes https://bugs.scummvm.org/ticket/10374 where the Windows version randomly fails an assertion when exiting an SCI game. The bug isn't Windows-only, it's just that the Windows code has an assertion that revealed the bug.

Certain platforms/MIDI-configurations use a background timer thread to send MIDI commands from a queue populated by the main thread. The bug is that SCI makes no attempt at thread synchronization with these commands when exiting. It doesn't attempt to clear them, it doesn't attempt to wait on them, it just proceeds to shut down even though the timer thread might be in the middle of sending a queued command. The assertion failure occurs when SciMusic's destructor is deep in the middle of destruction while its own timer attempts to send queued commands.

I've opted to wait for all commands to be sent, rather than clear them, since SciEngine::exitGame() calls SciMusic::clearPlayList() to kill all the sounds and that action queues more commands. Clearing the queue would be simpler but it seems like that could lead to hanging notes.

Call stacks when the timer thread asserts:

```
Timer thread
scummvm.exe!MidiDriver_WIN::send(unsigned int b=31679) Line 95
scummvm.exe!MidiDriver_BASE::send(unsigned char status='¿', unsigned char firstOp='{', unsigned char secondOp='\0') Line 107
scummvm.exe!Sci::MidiPlayer_Midi::controlChange(int channel=15, int control=123, int value=0) Line 353
scummvm.exe!Sci::MidiPlayer_Midi::send(unsigned int b=31679) Line 436
scummvm.exe!Sci::SciMusic::sendMidiCommandsFromQueue() Line 231
scummvm.exe!Sci::SciMusic::onTimer() Line 206
scummvm.exe!Sci::SciMusic::miditimerCallback(void * p=0x036f81e0) Line 198
scummvm.exe!DefaultTimerManager::handler() Line 106
scummvm.exe!timer_handler(unsigned int interval=10, void * param=0x036ddab8) Line 34


Main thread
scummvm.exe!SdlMutexManager::lockMutex(OpaqueMutex * mutex=0x002daa80) Line 36
scummvm.exe!ModularBackend::lockMutex(OpaqueMutex * mutex=0x002daa80) Line 253
scummvm.exe!Common::StackLock::lock() Line 68
scummvm.exe!Common::StackLock::StackLock(const Common::Mutex & mutex={...}, const char * mutexName=0x00000000) Line 58
scummvm.exe!DefaultTimerManager::removeTimerProc(void(*)(void *) callback=0x00dc2b1f) Line 148
scummvm.exe!MidiDriver_MPU401::close() Line 110
scummvm.exe!MidiDriver_WIN::close() Line 89
scummvm.exe!Sci::MidiPlayer_Midi::close() Line 1222
scummvm.exe!Sci::SciMusic::~SciMusic() Line 61
scummvm.exe!Sci::SciMusic::`scalar deleting destructor'(unsigned int)
scummvm.exe!Sci::SoundCommandParser::~SoundCommandParser() Line 58
scummvm.exe!Sci::SoundCommandParser::`scalar deleting destructor'(unsigned int)
scummvm.exe!Sci::SciEngine::~SciEngine() Line 239
scummvm.exe!Sci::SciEngine::`scalar deleting destructor'(unsigned int)
scummvm.exe!runGame(const Plugin * plugin=0x004e2098, OSystem & system={...}, const Common::String & edebuglevels={...}) Line 308
scummvm.exe!scummvm_main(int argc=2, const char * const * argv=0x004adf90) Line 562
scummvm.exe!SDL_main(int argc=2, char * * argv=0x004adf90) Line 71
scummvm.exe!WinMain(HINSTANCE__ * __formal=0x00990000, HINSTANCE__ * __formal=0x00000000, char * __formal=0x00486961, int __formal=10) Line 54
scummvm.exe!invoke_main() Line 99
scummvm.exe!__scrt_common_main_seh() Line 253
scummvm.exe!__scrt_common_main() Line 296
scummvm.exe!WinMainCRTStartup() Line 17
```
