### PR TITLE
DIRECTOR: LINGO: Debug print before string fix

### DIFF
--- a/engines/director/lingo/lingo-codegen.cpp
+++ b/engines/director/lingo/lingo-codegen.cpp
@@ -63,7 +63,7 @@ void Lingo::execute(uint pc) {
 			printStack("Stack before: ", current);
 
 		if (debugChannelSet(9, kDebugLingoExec)) {
-			debug("Vars after");
+			debug("Vars before");
 			printAllVars();
 		}
 


### PR DESCRIPTION
Debug print statement that ran before the stack showed 'after', should be before.
