### PR TITLE
COMMON: Add find() method for character to U32String

### DIFF
--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -282,6 +282,16 @@ void U32String::toUppercase() {
 	}
 }
 
+uint32 U32String::find(value_type x, uint32 pos) const {
+	for (uint32 i = pos; i < _size; ++i) {
+		if (_str[i] == x) {
+			return i;
+		}
+	}
+
+	return npos;
+}
+
 uint32 U32String::find(const U32String &str, uint32 pos) const {
 	if (pos >= _size) {
 		return npos;

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -188,6 +188,7 @@ public:
 	 */
 	void toUppercase();
 
+	uint32 find(value_type x, uint32 pos = 0) const;
 	uint32 find(const U32String &str, uint32 pos = 0) const;
 
 	typedef value_type *        iterator;


### PR DESCRIPTION
This is like strchr but for uint32 based strings