### PR TITLE
DIRECTOR: LINGO: Implement repeat with var in array

### DIFF
--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1041,16 +1041,14 @@ void LC::c_repeatwithcode(void) {
 		// Handle repeat with  X in ARRAY
 		g_lingo->execute(init + savepc -1); // eval the list
 		Datum array = g_lingo->pop(); // get the list from the stack
+
+		Datum loop_var;
+		loop_var.type = VAR;
+		loop_var.u.sym = g_lingo->lookupVar(countername.c_str());
+
 		int arraySize = array.u.farr->size();
 		for (uint i = 0; i < arraySize; i++) {
-
-			Datum loop_var;
-			loop_var.type = VAR;
-			loop_var.u.sym = g_lingo->lookupVar(countername.c_str());
-
-			Datum source = (*array.u.farr)[i];
-
-			g_lingo->varAssign(loop_var, source);
+			g_lingo->varAssign(loop_var, array.u.farr->operator[](i));
 			g_lingo->execute(body + savepc -1);
 		}
 		g_lingo->_pc = end + savepc - 1; /* next stmt */

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1038,7 +1038,21 @@ void LC::c_repeatwithcode(void) {
 	Symbol *counter = g_lingo->lookupVar(countername.c_str());
 
 	if (finish == 0 && inc == 0) {
-		warning("STUB: 'repeat with' over list ");
+		// Handle repeat with  X in ARRAY
+		g_lingo->execute(init + savepc -1); // eval the list
+		Datum array = g_lingo->pop(); // get the list from the stack
+		int arraySize = array.u.farr->size();
+		for (uint i = 0; i < arraySize; i++) {
+
+			Datum loop_var;
+			loop_var.type = VAR;
+			loop_var.u.sym = g_lingo->lookupVar(countername.c_str());
+
+			Datum source = (*array.u.farr)[i];
+
+			g_lingo->varAssign(loop_var, source);
+			g_lingo->execute(body + savepc -1);
+		}
 		g_lingo->_pc = end + savepc - 1; /* next stmt */
 		return;
 	}

--- a/engines/director/lingo/lingo-codegen.cpp
+++ b/engines/director/lingo/lingo-codegen.cpp
@@ -63,7 +63,7 @@ void Lingo::execute(uint pc) {
 			printStack("Stack before: ", current);
 
 		if (debugChannelSet(9, kDebugLingoExec)) {
-			debug("Vars after");
+			debug("Vars before");
 			printAllVars();
 		}
 


### PR DESCRIPTION
Lingo implements the for each loop as `repeat with VAR in ARRAY`.
    1) The `ARRAY` is evaluated,
    2) a loop counter is created of size(ARRAY),
    3) consume the loop counter, starting at 0.
    3) the ARRAY[counter] item is assiged to `VAR` and
    4) the loop body executed,
    5) update the loop counter with + 1 and
    6) goto 3 till the loop counter is exhausted.