### PR TITLE
SCI: fix MasterVolume to modify music volume, fixing #11012 for KQ6

### DIFF
--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -469,9 +469,18 @@ void MidiPlayer_Midi::setVolume(byte volume) {
 	if (!_playSwitch)
 		return;
 
-	for (uint i = 1; i < 10; i++) {
-		if (_channels[i].volume != 0xff)
-			controlChange(i, 0x07, _channels[i].volume & 0x7f);
+	if (_mt32Type == kMt32TypeNone) {
+		// the per channel volume change doesn't work for GM - therefore bug #11012
+		// (which is more problematic than reported - the "volume" slider doesn't affect music at all!)
+		// I don't really understand why. However, using GM "MasterVolume" function solves it
+		byte shiftedMasterVoluem = volume << 3;
+		byte msg[6] = {0x7f, 0x7f, 0x04, 0x01, 0x0, shiftedMasterVoluem};
+		_driver->sysEx(msg, 6);
+	} else {
+		for (uint i = 1; i < 10; i++) {
+			if (_channels[i].volume != 0xff)
+				controlChange(i, 0x07, _channels[i].volume & 0x7f);
+		}
 	}
 }
 


### PR DESCRIPTION
Issue #11012 reports that Music volume isn't reduced when characters are speaking.
But it's worse than that. The "Volume" slider didn't affect music at all, for GM.

This is fixing the latter issue, and fixes also original #11012 for KQ6.
Strangely, it doesn't fix KQ7 as well...
It has yet to be investigated.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
