### PR TITLE
Fix building when selected engines don't have their own debugger

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -27,9 +27,9 @@ MODULES := test devtools base $(MODULES)
 
 # After the game specific modules follow the shared modules
 MODULES += \
+	engines \
 	gui \
 	backends \
-	engines \
 	video \
 	image \
 	graphics \


### PR DESCRIPTION
In this case, the linker optimizes out Debugger which get required
later by Engine due to @dreammaster rework. Building with all engines
prevents optimization because several engines subclass Debugger and they
are included before gui.a in linker command line