### PR TITLE
3DS: Improve cursor behavior in Drag Mode

### DIFF
--- a/backends/platform/3ds/osystem-events.cpp
+++ b/backends/platform/3ds/osystem-events.cpp
@@ -159,7 +159,7 @@ static void eventThreadFunc(void *arg) {
 				pushEventQueue(eventQueue, event);
 			}
 
-			if ((inputMode == MODE_DRAG) & !isDragHeld) {
+			if ((inputMode == MODE_DRAG) & (!isDragHeld)) {
 				if (osys->getMillis() - touchStartTime >= 50) {
 					isDragHeld = true;
 					event.type = Common::EVENT_LBUTTONDOWN;

--- a/backends/platform/3ds/osystem-events.cpp
+++ b/backends/platform/3ds/osystem-events.cpp
@@ -159,7 +159,7 @@ static void eventThreadFunc(void *arg) {
 				pushEventQueue(eventQueue, event);
 			}
 
-			if (inputMode == MODE_DRAG & !isDragHeld) {
+			if ((inputMode == MODE_DRAG) & !isDragHeld) {
 				if (osys->getMillis() - touchStartTime >= 50) {
 					isDragHeld = true;
 					event.type = Common::EVENT_LBUTTONDOWN;


### PR DESCRIPTION
Some games such as Riven perform an action when a mouse button is pressed but update the cursor when the mouse button is released. As a result, the way touch controls are coded in the 3DS port can result in the cursor image updating too late. Continuing with the Riven example, performing a touch screen click on a hotspot in Drag Mode will not update the cursor image until after the scene transition completes, when the cursor update should occur BEFORE the scene transition. In Hover Mode, however, the cursor updates before the scene transition as desired.

The reason for this is that, in Drag Mode, a touch screen press immediately sends an EVENT_LBUTTONDOWN event, while an EVENT_LBUTTONUP event is only sent once the touch screen is released. This allows the Riven subengine of Mohawk to schedule a scene transition between the EVENT_LBUTTONDOWN and EVENT_LBUTTONUP events, thus causing the cursor update to happen after the transition has occurred.

This commit makes changes to how touch screen events happen in Drag Mode. Instead of immediately sending an EVENT_LBUTTONDOWN when the touch screen is pressed, a 50 millisecond grace period is set in place which allows the backend to differentiate between clicks and drags. If the touch screen is released during the 50ms period, the touch is registered as a click and a 3-event sequence is sent (MOUSEMOVE, LBUTTONDOWN, and LBUTTONUP), not allowing game engines to interrupt that sequence. If the touch screen is still being held once the 50ms has elapsed, the touch is registered as a drag, and an EVENT_LBUTTONDOWN is sent, with an EVENT_LBUTTONUP sent when the touch screen is released.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
