### PR TITLE
SCI: fix bug #9735 by avoiding remap to percussion channel

### DIFF
--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -1203,7 +1203,8 @@ void SciMusic::remapChannels(bool mainThread) {
 		}
 
 		for (int j = _driverLastChannel; j >= _driverFirstChannel; --j) {
-			if (_channelMap[j]._song == 0) {
+			// channel 9 is reserved for percussion, avoiding it to fix bug #9735 (and maybe others...)
+			if (_channelMap[j]._song == 0 && j != 9) {
 				_channelMap[j] = map->_map[i];
 				map->_map[i]._song = 0;
 #ifdef DEBUG_REMAP
@@ -1308,6 +1309,9 @@ ChannelRemapping *SciMusic::determineChannelMap() {
 			// try to find a free channel
 			if (devChannel == -1) {
 				for (int j = 0; j < 16; ++j) {
+					if (j == 9)
+						// reserved for percussion, fixing bug #9735 (and maybe others...)
+						continue;
 					if (map->_map[j] == dc) {
 						// already mapped?! (Can this happen?)
 						devChannel = j;


### PR DESCRIPTION
Channel 9 (in the code, which starts counting from 0; and it's channel 10 in the MIDI spec, which starts counting from 1) is reserved for percussion instruments.
Fixing remapping channel code to avoid remapping to that channel.

This is fixing bug #9735, and probably other sound issues.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
