### PR TITLE
SCI: using only channels 1-8 on GM devices

### DIFF
--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -452,15 +452,11 @@ void MidiPlayer_Midi::send(uint32 b) {
 // We return 1 for mt32, because if we remap channels to 0 for mt32, those won't get played at all
 // NOTE: SSCI uses channels 1 through 8 for General MIDI as well, in the drivers I checked
 int MidiPlayer_Midi::getFirstChannel() const {
-	if (_mt32Type != kMt32TypeNone)
-		return 1;
-	return 0;
+	return 1;
 }
 
 int MidiPlayer_Midi::getLastChannel() const {
-	if (_mt32Type != kMt32TypeNone)
-		return 8;
-	return 15;
+	return 8;
 }
 
 void MidiPlayer_Midi::setVolume(byte volume) {


### PR DESCRIPTION
There are many situations that GM sounds worse than MT, even for games that were written for GM.
I think this is related to this.

And, there is a note in midi.cpp, added by Walter van Niftrik on his commit from 2010:
```// NOTE: SSCI uses channels 1 through 8 for General MIDI as well, in the drivers I checked```
Thus, I took @waltervn's note and made GM use the same channels as MT-32.

Also, issue #6686 reports that using the "higher" channels causes problem on a real SC-55.

This change solves at least bugs: #6686, #9578, #9735, #10297 and #11012.

Notes:
- I have verified all these bugs, except for #6686, as I don't have SC-55
- On PR #2070 , @sluicebox mentioned that the master volume is changing, but slowly. That's the cause of issues #9578 and #11012 , so it's better to have it fixed.

If we accept this PR, it makes my other PRs: #2070 and #2073 redundant, as it fixes the same issues, and more, with simpler solution.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
