### PR TITLE
DIRECTOR: LINGO: handle break from loops

### DIFF
--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1050,6 +1050,12 @@ void LC::c_repeatwithcode(void) {
 		for (uint i = 0; i < arraySize; i++) {
 			g_lingo->varAssign(loop_var, array.u.farr->operator[](i));
 			g_lingo->execute(body + savepc -1);
+			if (g_lingo->_returning) // handle return within the repeat with loop
+				return;
+			if (g_lingo->_exitRepeat) { // handle `exit repeat`
+				g_lingo->_exitRepeat = false;
+				break;
+			}
 		}
 		g_lingo->_pc = end + savepc - 1; /* next stmt */
 		return;


### PR DESCRIPTION
Lingo has two ways to break from loops: `return` and `exit repeat`.
Both are now handled in repeat with VAR in ARRAY.
Example Lingo code:

```
on exitRepeat
  set aList = [1,2,3,4]
  repeat with a in aList
    if a = 3 then
      exit repeat
    end if
  end repeat  
  return a
end exitRepeat

on returnRepeat
  set aList = [1,2,3,4]
  repeat with a in aList
    if a = 3 then
      return a
    end if
  end repeat  
end return

put exitRepeat()
put returnRepeat()
```