### PR TITLE
BUILD: Apply LDFLAGS on modules/plugins

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -47,7 +47,7 @@ ifdef PLUGIN
 PLUGIN-$(MODULE) := plugins/$(PLUGIN_PREFIX)$(notdir $(MODULE))$(PLUGIN_SUFFIX)
 $(PLUGIN-$(MODULE)): $(MODULE_OBJS-$(MODULE)) $(PLUGIN_EXTRA_DEPS)
 	$(QUIET)$(MKDIR) plugins
-	$(QUIET_PLUGIN)$(CXX) $(filter-out $(PLUGIN_EXTRA_DEPS),$+) $(PLUGIN_LDFLAGS) -o $@
+	$(QUIET_PLUGIN)$(CXX) $(LDFLAGS) $(filter-out $(PLUGIN_EXTRA_DEPS),$+) $(PLUGIN_LDFLAGS) -o $@
 
 # Reset PLUGIN var
 PLUGIN:=


### PR DESCRIPTION
Some distributions populate their build environment with special linker flags, e.g. for hardening purposes such as immediate binding and/or read-only relocations.

Those flags should be honored when linking dynamic libraries.