### PR TITLE
CONFIGURE: Add compatibility for RPM's configure macro

### DIFF
--- a/configure
+++ b/configure
@@ -1192,6 +1192,19 @@ EOF
 
 for ac_option in $@; do
 	case "$ac_option" in
+	# Silently ignore options valid for Autotools configure.
+	--build=*)                                           ;;
+	--program-prefix=*)                                  ;;
+	--sbindir=*)                                         ;;
+	--sysconfdir=*)                                      ;;
+	--includedir=*)                                      ;;
+	--libexecdir=*)                                      ;;
+	--localstatedir=*)                                   ;;
+	--sharedstatedir=*)                                  ;;
+	--infodir=*)                                         ;;
+	--disable-dependency-tracking)                       ;;
+	--enable-dependency-tracking)                        ;;
+	# End of ignored options.
 	--enable-static)              _static_build=yes      ;;
 	--disable-16bit)              _16bit=no              ;;
 	--enable-highres)             _highres=yes           ;;

--- a/configure
+++ b/configure
@@ -1155,6 +1155,7 @@ Some influential environment variables:
   AR                 archiver command
   AS                 assembler command
   ASFLAGS            assembler flags
+  CONFIGURE_NO_HOST  Ignore the cross-compile target set by the --host= option
   CPPFLAGS           C++ preprocessor flags, e.g. -I<include dir> if you have
                      headers in a nonstandard directory <include dir>
   CXX                C++ compiler command
@@ -1474,7 +1475,11 @@ for ac_option in $@; do
 		_xcodetoolspath=`echo $ac_option | cut -d '=' -f 2`
 		;;
 	--host=*)
-		_host=`echo $ac_option | cut -d '=' -f 2`
+		if test -z "$CONFIGURE_NO_HOST"; then
+			_host=`echo $ac_option | cut -d '=' -f 2`
+		else
+			echo "Ignoring --host option!" >&2
+		fi
 		;;
 	--prefix=*)
 		prefix=`echo $ac_option | cut -d '=' -f 2`


### PR DESCRIPTION
RPM-based distributions come with a configure macro, that sets up the whole build environment.  In order to be able to use this macro, some options, which are valid for the configure script generated by GNU Autotools, should not error-out when preparing the build stage.

Unfortunately the configure script, as used by ScummVM uses the `--host` option to determine the target system it will actually be build for.  Autotools based configure scripts have a `--target` option for such a purpose, and use the `--host` option to determine the system the build is performed on.

For that reason there should be a way to discard the parameters passed to the configure script with the `--host` option.  The easiest approach to achieve this goal, is to have an environment variable, which when set influences the configure script to ignore the parameters of the `--host` option.

Thus we introduced a variable called `CONFIGURE_NO_HOST`, that will when set to anything, but an empty value, before invoking the configure script, have the parameters of the `--host` option take no influence on the configure stage (and the build stage as well).