### PR TITLE
ULTIMA8: Fix blends to SDL surface (corrects lamps, smoke, etc)

### DIFF
--- a/engines/ultima/ultima8/graphics/base_soft_render_surface.cpp
+++ b/engines/ultima/ultima8/graphics/base_soft_render_surface.cpp
@@ -65,10 +65,10 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(Graphics::ManagedSurface *s) :
 	RenderSurface::format.g_shift = _sdlSurf->format.gShift;
 	RenderSurface::format.b_shift = _sdlSurf->format.bShift;
 	RenderSurface::format.a_shift = _sdlSurf->format.aShift;
-	RenderSurface::format.r_mask = _sdlSurf->format.rMax();
-	RenderSurface::format.g_mask = _sdlSurf->format.gMax();
-	RenderSurface::format.b_mask = _sdlSurf->format.bMax();
-	RenderSurface::format.a_mask = _sdlSurf->format.aMax();
+	RenderSurface::format.r_mask = _sdlSurf->format.rMax() << _sdlSurf->format.rShift;
+	RenderSurface::format.g_mask = _sdlSurf->format.gMax() << _sdlSurf->format.gShift;
+	RenderSurface::format.b_mask = _sdlSurf->format.bMax() << _sdlSurf->format.bShift;
+	RenderSurface::format.a_mask = _sdlSurf->format.aMax() << _sdlSurf->format.aShift;
 
 	SetPixelsPointer();
 


### PR DESCRIPTION
As part of the porting work from Pentagram, the format masks used during blend
operations are not set correctly, resulting in grey shadows under lamps (rather
than lighting the underlying surface).  This sets the masks correctly so lamps
now look right.

attn @dreammaster to save you trying to find this.