### PR TITLE
DIRECTOR: LINGO: Specify version 3.1 for commands

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -122,8 +122,8 @@ static struct BuiltinProto {
 		// play																// D2 c
 	{ "playAccel",		LB::b_playAccel,	-1,0, false, 2, BLTIN },	// D2
 		// play done														// D2
-	{ "preLoad",		LB::b_preLoad,		-1,0, false, 3, BLTIN },	//		D3 c
-	{ "preLoadCast",	LB::b_preLoadCast,	-1,0, false, 3, BLTIN },	//		D3 c
+	{ "preLoad",		LB::b_preLoad,		-1,0, false, 3, BLTIN },	//		D3.1 c
+	{ "preLoadCast",	LB::b_preLoadCast,	-1,0, false, 3, BLTIN },	//		D3.1 c
 	{ "quit",			LB::b_quit,			0, 0, false, 2, BLTIN },	// D2 c
 	{ "restart",		LB::b_restart,		0, 0, false, 2, BLTIN },	// D2 c
 	{ "return",			LB::b_return,		0, 1, false, 2, BLTIN },	// D2 function

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -224,7 +224,7 @@ TheEntityField fields[] = {
 
 	// TextCast fields
 	{ kTheCast,		"hilite",		kTheHilite,		2 },// D2 p
-	{ kTheCast,		"size",			kTheSize,		4 },//				D4 p
+	{ kTheCast,		"size",			kTheSize,		3 },//		D3.1 p
 	{ kTheCast,		"text",			kTheText,		2 },// D2 p
 
 	// Field fields


### PR DESCRIPTION
Some versions were mismatched as 3 or 4.

The source for these changes is the book: 'Director for the MACINTOSH: GETTING STARTED & WHAT'S NEW' for Director 3.1.