### PR TITLE
COMMON: Fix conversion to UTF32 for short strings

### DIFF
--- a/common/encoding.cpp
+++ b/common/encoding.cpp
@@ -183,8 +183,8 @@ char *Encoding::convertIconv(const char *to, const char *from, const char *strin
 		return nullptr;
 
 	size_t inSize = length;
-	size_t outSize = inSize;
 	size_t stringSize = inSize > 4 ? inSize : 4;
+	size_t outSize = stringSize;
 
 
 #ifdef ICONV_USES_CONST


### PR DESCRIPTION
Testcase: convert 1-byte encoded single character string (e.g. "=") from 125X to
UTF32.

Expected result: got widestring, first dword contains "=", next dword
contains "\0"

Actual result: got widestring, first dword contains "=", second dword
contains garbage, next dword contains "\0"

Reference implementation:
http://www-personal.umich.edu/~bazald/l/api/_s_d_l__iconv_8c_source.html
, line 887