### PR TITLE
ULTIMA8: Fix OOB access to arrays for HID events

### DIFF
--- a/engines/ultima/ultima8/ultima8.h
+++ b/engines/ultima/ultima8/ultima8.h
@@ -128,8 +128,8 @@ private:
 	int32 _timeOffset;
 	bool _hasCheated;
 	bool _cheatsEnabled;
-	uint32 _lastDown[HID_LAST];
-	bool _down[HID_LAST];
+	uint32 _lastDown[HID_LAST+1];
+	bool _down[HID_LAST+1];
 	unsigned int _inversion;
 private:
 	/**


### PR DESCRIPTION
For an unknown key, it's possible for `key` to be `HID_LAST` when recording the down state and last-down timestamp, which results in accesses off the end of the arrays. The simplest  fix is to just extend the arrays by 1 - in practice we never care about the down state or last down timestamp for unknown keys so this is a harmless fix as far as I can tell.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
