### PR TITLE
ULTIMA8: Ignore opcode which could cause crash closing backpack

### DIFF
--- a/engines/ultima/ultima8/usecode/uc_machine.cpp
+++ b/engines/ultima/ultima8/usecode/uc_machine.cpp
@@ -1090,10 +1090,15 @@ void UCMachine::execProcess(UCProcess *p) {
 //				error = true;
 			} else {
 				if (ui32b) {
-					uint16 s = getList(ui16b)->getStringIndex(ui16a);
+					uint16 s = l->getStringIndex(ui16a);
 					p->_stack.push2(duplicateString(s));
 				} else {
-					p->_stack.push((*getList(ui16b))[ui16a], ui32a);
+					if (ui16a < l->getSize()) {
+						p->_stack.push((*l)[ui16a], ui32a);
+					} else {
+						perr << "Warning: ignore 0x44 request to push " << ui16a <<
+								" from list len " << l->getSize() << Std::endl;
+					}
 				}
 			}
 			LOGPF(("push element\t%02X slist==%02X\n", ui32a, ui32b));


### PR DESCRIPTION
After using the keyring to unlock a chest, occasionally opcode 0x44
references a value higher than the length of the source list. The
simple workaround is to ignore this opcode in this case.  It's not
a proper fix but it prevents a crash and I haven't found any
side-effect of doing it.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
