### PR TITLE
ULTIMA8: Fix buggy UCList.remove

### DIFF
--- a/engines/ultima/ultima8/usecode/uc_list.h
+++ b/engines/ultima/ultima8/usecode/uc_list.h
@@ -86,8 +86,8 @@ public:
 		for (unsigned int i = 0; i < _size; i++) {
 			bool equal = true;
 			for (unsigned int j = 0; j < _elementSize && equal; j++)
-				equal = (_elements[i * _elementSize + j] == e[j]);
-			if (!equal) {
+				equal = equal && (_elements[i * _elementSize + j] == e[j]);
+			if (equal) {
 				_elements.erase(_elements.begin() + i * _elementSize,
 				               _elements.begin() + (i + 1)*_elementSize);
 				_size--;


### PR DESCRIPTION
The code for `UCList.remove` is buggy in 2 ways:
* The loop resets the value of `equal` for each byte
* The removal check is reversed, removing items which are `!equal`

In practice this function is only called from `substractList` for engine opcode `0x1B`.  The comment in `uc_engine.cpp` says `0x1B` only happens in Crusader, so this code is probably never called in U8 but it feels better to fix it anyway and match the behavior of `substractStringList`.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
