### PR TITLE
ULTIMA8: Avoid left shifts of -ve numbers (undefined in c spec)

### DIFF
--- a/engines/ultima/ultima8/audio/sonarc_audio_sample.cpp
+++ b/engines/ultima/ultima8/audio/sonarc_audio_sample.cpp
@@ -117,8 +117,8 @@ void SonarcAudioSample::decode_EC(int mode, int samplecount,
 			if (ones == 0) {
 				data >>= 1; // strip zero
 				// low byte contains (mode+1) _bits of the sample
-				int8 sample = data & 0xFF;
-				sample <<= (7 - mode);
+				const uint8 usample = data & 0xFF;
+				int8 sample = usample << (7 - mode);
 				sample >>= (7 - mode); // sign extend
 				*dest++ = (uint8)(sample + 0x80);
 				data >>= mode + 1;
@@ -126,8 +126,8 @@ void SonarcAudioSample::decode_EC(int mode, int samplecount,
 			} else if (ones < 7 - mode) {
 				data >>= ones + 1; // strip ones and zero
 				// low byte contains (mode+ones) _bits of the sample
-				int8 sample = data & 0xFF;
-				sample <<= (7 - mode - ones);
+				const uint8 usample = data & 0xFF;
+				int8 sample = usample << (7 - mode - ones);
 				sample &= 0x7F;
 				if (!(sample & 0x40))
 					sample |= 0x80; // reconstruct sign bit


### PR DESCRIPTION
In practice it probably does the expected thing on every platform, but
it's an easy fix and better to be safe.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
