### PR TITLE
ULTIMA8: Don't save while starting up

### DIFF
--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -38,6 +38,7 @@
 #include "ultima/ultima8/conf/config_file_manager.h"
 #include "ultima/ultima8/kernel/object_manager.h"
 #include "ultima/ultima8/games/game_info.h"
+#include "ultima/ultima8/games/start_u8_process.h"
 #include "ultima/ultima8/graphics/fonts/font_manager.h"
 #include "ultima/ultima8/kernel/memory_manager.h"
 #include "ultima/ultima8/kernel/hid_manager.h"
@@ -977,6 +978,10 @@ void Ultima8Engine::writeSaveInfo(ODataSource *ods) {
 bool Ultima8Engine::canSaveGameStateCurrently(bool isAutosave) {
 	if (_desktopGump->FindGump<ModalGump>())
 		// Can't save when a modal gump is open
+		return false;
+
+	if (_kernel->getRunningProcess()->IsOfType(StartU8Process::ClassType))
+		// Don't save while starting up.
 		return false;
 
 	// Don't allow saving when avatar is dead.


### PR DESCRIPTION
This fixes the direct loading of save games from the ScummVM menu by
blocking autosave during the startup.

There may be some more elegant way to fix this so I'm not sure if this is the nicest solution - it does the job though.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
