### PR TITLE
ULTIMA8: Many small improvements to const correctness

### DIFF
--- a/engines/ultima/ultima8/audio/audio_process.cpp
+++ b/engines/ultima/ultima8/audio/audio_process.cpp
@@ -322,7 +322,7 @@ void AudioProcess::setVolumeSFX(int sfxNum, uint8 volume) {
 // Speech
 //
 
-bool AudioProcess::playSpeech(Std::string &barked, int shapeNum, ObjId objId, uint32 pitchShift, uint16 volume) {
+bool AudioProcess::playSpeech(const Std::string &barked, int shapeNum, ObjId objId, uint32 pitchShift, uint16 volume) {
 	SpeechFlex *speechflex = GameData::get_instance()->getSpeechFlex(shapeNum);
 
 	if (!speechflex) return false;
@@ -366,7 +366,7 @@ bool AudioProcess::playSpeech(Std::string &barked, int shapeNum, ObjId objId, ui
 	return true;
 }
 
-uint32 AudioProcess::getSpeechLength(Std::string &barked, int shapenum) const {
+uint32 AudioProcess::getSpeechLength(const Std::string &barked, int shapenum) const {
 	SpeechFlex *speechflex = GameData::get_instance()->getSpeechFlex(shapenum);
 	if (!speechflex) return 0;
 
@@ -374,7 +374,7 @@ uint32 AudioProcess::getSpeechLength(Std::string &barked, int shapenum) const {
 }
 
 
-void AudioProcess::stopSpeech(Std::string &barked, int shapenum, ObjId objId) {
+void AudioProcess::stopSpeech(const Std::string &barked, int shapenum, ObjId objId) {
 	AudioMixer *mixer = AudioMixer::get_instance();
 
 	Std::list<SampleInfo>::iterator it;
@@ -389,7 +389,7 @@ void AudioProcess::stopSpeech(Std::string &barked, int shapenum, ObjId objId) {
 	}
 }
 
-bool AudioProcess::isSpeechPlaying(Std::string &barked, int shapeNum) {
+bool AudioProcess::isSpeechPlaying(const Std::string &barked, int shapeNum) {
 	Std::list<SampleInfo>::iterator it;
 	for (it = _sampleInfo.begin(); it != _sampleInfo.end(); ++it) {
 		if (it->_sfxNum == -1 && it->_priority == shapeNum &&

--- a/engines/ultima/ultima8/audio/audio_process.h
+++ b/engines/ultima/ultima8/audio/audio_process.h
@@ -53,8 +53,8 @@ public:
 		SampleInfo(int32 s, int32 p, ObjId o, int32 l, int32 c, uint32 ps, uint16 v, int16 lv, int16 rv) :
 			_sfxNum(s), _priority(p), _objId(o), _loops(l), _channel(c),
 			_pitchShift(ps), _volume(v), _lVol(lv), _rVol(rv) { }
-		SampleInfo(Std::string &b, int32 shpnum, ObjId o, int32 c,
-		           uint32 s, uint32 e, uint32 ps, uint16 v, int16 lv, int16 rv) :
+		SampleInfo(const Std::string &b, int32 shpnum, ObjId o, int32 c,
+				   uint32 s, uint32 e, uint32 ps, uint16 v, int16 lv, int16 rv) :
 			_sfxNum(-1), _priority(shpnum), _objId(o), _loops(0), _channel(c), _barked(b),
 			_curSpeechStart(s), _curSpeechEnd(e), _pitchShift(ps), _volume(v),
 			_lVol(lv), _rVol(rv) { }
@@ -82,12 +82,12 @@ public:
 	void run() override;
 
 	void playSFX(int sfxNum, int priority, ObjId objId, int loops,
-	             bool no_duplicates, uint32 pitchShift,
-	             uint16 volume, int16 lVol, int16 rVol);
+				 bool no_duplicates, uint32 pitchShift,
+				 uint16 volume, int16 lVol, int16 rVol);
 
 	void playSFX(int sfxNum, int priority, ObjId objId, int loops,
-	             bool no_duplicates = false, uint32 pitchShift = 0x10000,
-	             uint16 volume = 0x80) {
+				 bool no_duplicates = false, uint32 pitchShift = 0x10000,
+				 uint16 volume = 0x80) {
 		playSFX(sfxNum, priority, objId, loops, no_duplicates, pitchShift, volume, -1, -1);
 	}
 
@@ -95,18 +95,18 @@ public:
 	bool isSFXPlaying(int sfxNum);
 	void setVolumeSFX(int sfxNum, uint8 volume);
 
-	bool playSpeech(Std::string &barked, int shapenum, ObjId objId,
-	                uint32 pitchShift = 0x10000, uint16 volume = 256);
-	void stopSpeech(Std::string &barked, int shapenum, ObjId objId);
-	bool isSpeechPlaying(Std::string &barked, int shapenum);
+	bool playSpeech(const Std::string &barked, int shapenum, ObjId objId,
+					uint32 pitchShift = 0x10000, uint16 volume = 256);
+	void stopSpeech(const Std::string &barked, int shapenum, ObjId objId);
+	bool isSpeechPlaying(const Std::string &barked, int shapenum);
 
 	//! get length (in milliseconds) of speech
-	uint32 getSpeechLength(Std::string &barked, int shapenum) const;
+	uint32 getSpeechLength(const Std::string &barked, int shapenum) const;
 
 	//! play a sample (without storing a SampleInfo)
 	//! returns channel sample is played on, or -1
 	int playSample(AudioSample *sample, int priority, int loops,
-		uint32 pitchShift = 0x10000, int16 lVol = 256, int16 rVol = 256);
+				   uint32 pitchShift = 0x10000, int16 lVol = 256, int16 rVol = 256);
 
 	//! pause all currently playing samples
 	void pauseAllSamples();

--- a/engines/ultima/ultima8/audio/audio_sample.cpp
+++ b/engines/ultima/ultima8/audio/audio_sample.cpp
@@ -26,7 +26,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-AudioSample::AudioSample(uint8 *buffer, uint32 size) :
+AudioSample::AudioSample(const uint8 *buffer, uint32 size) :
 	_sampleRate(0), _bits(0), _stereo(false),
 	_frameSize(0), _decompressorSize(0), _length(0),
 	_bufferSize(size), _buffer(buffer) {

--- a/engines/ultima/ultima8/audio/audio_sample.h
+++ b/engines/ultima/ultima8/audio/audio_sample.h
@@ -38,10 +38,10 @@ protected:
 	uint32  _length;
 
 	uint32  _bufferSize;
-	uint8   *_buffer;
+	uint8   const *_buffer;
 
 public:
-	AudioSample(uint8 *buffer, uint32 size);
+	AudioSample(const uint8 *buffer, uint32 size);
 	virtual ~AudioSample(void);
 
 	inline uint32 getRate() const {

--- a/engines/ultima/ultima8/audio/music_flex.cpp
+++ b/engines/ultima/ultima8/audio/music_flex.cpp
@@ -68,7 +68,7 @@ void MusicFlex::uncache(uint32 index) {
 	// Caching not currently supported
 }
 
-bool MusicFlex::isCached(uint32 index) {
+bool MusicFlex::isCached(uint32 index) const {
 	if (index >= _count) return false;
 	if (!_songs) return false;
 
@@ -77,13 +77,13 @@ bool MusicFlex::isCached(uint32 index) {
 
 IDataSource *MusicFlex::getAdlibTimbres() {
 	uint32 size;
-	uint8 *data = getRawObject(259, &size);
+	const uint8 *data = getRawObject(259, &size);
 	return new IBufferDataSource(data, size, false, true);
 }
 
 void MusicFlex::loadSongInfo() {
 	uint32 size;
-	uint8 *buf = getRawObject(0, &size);
+	const uint8 *buf = getRawObject(0, &size);
 
 	if (!buf || !size) {
 		error("Unable to load song _info from sound/music.flx");

--- a/engines/ultima/ultima8/audio/music_flex.h
+++ b/engines/ultima/ultima8/audio/music_flex.h
@@ -66,7 +66,7 @@ public:
 
 	void cache(uint32 index) override;
 	void uncache(uint32 index) override;
-	bool isCached(uint32 index) override;
+	bool isCached(uint32 index) const override;
 
 	uint8 *getRawObject(uint32 index, uint32 *sizep = 0) {
 		return Archive::getRawObject(index, sizep);

--- a/engines/ultima/ultima8/audio/raw_audio_sample.cpp
+++ b/engines/ultima/ultima8/audio/raw_audio_sample.cpp
@@ -27,7 +27,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-RawAudioSample::RawAudioSample(uint8 *buffer_, uint32 size, uint32 rate,
+RawAudioSample::RawAudioSample(const uint8 *buffer_, uint32 size, uint32 rate,
                                bool signedData, bool stereo)
 	: AudioSample(buffer_, size), _signedData(signedData) {
 	_sampleRate = rate;

--- a/engines/ultima/ultima8/audio/raw_audio_sample.h
+++ b/engines/ultima/ultima8/audio/raw_audio_sample.h
@@ -30,7 +30,7 @@ namespace Ultima8 {
 
 class RawAudioSample : public AudioSample {
 public:
-	RawAudioSample(uint8 *buffer, uint32 size,
+	RawAudioSample(const uint8 *buffer, uint32 size,
 	               uint32 rate, bool signeddata, bool stereo);
 	~RawAudioSample() override;
 

--- a/engines/ultima/ultima8/audio/sonarc_audio_sample.cpp
+++ b/engines/ultima/ultima8/audio/sonarc_audio_sample.cpp
@@ -30,7 +30,7 @@ namespace Ultima8 {
 bool SonarcAudioSample::_generatedOneTable = false;
 int SonarcAudioSample::_oneTable[256];
 
-SonarcAudioSample::SonarcAudioSample(uint8 *buffer, uint32 size) :
+SonarcAudioSample::SonarcAudioSample(uint8 const *buffer, uint32 size) :
 	AudioSample(buffer, size), _srcOffset(0x20) {
 	if (!_generatedOneTable) GenerateOneTable();
 

--- a/engines/ultima/ultima8/audio/sonarc_audio_sample.h
+++ b/engines/ultima/ultima8/audio/sonarc_audio_sample.h
@@ -40,16 +40,16 @@ class SonarcAudioSample : public AudioSample {
 	static void GenerateOneTable();
 
 	static void decode_EC(int mode, int samplecount,
-	                      const uint8 *source, int sourcesize,
-	                      uint8 *dest);
+						  const uint8 *source, int sourcesize,
+						  uint8 *dest);
 	static void decode_LPC(int order, int nsamples,
-	                       uint8 *dest, const uint8 *factors);
+						   uint8 *dest, const uint8 *factors);
 	static int audio_decode(const uint8 *source, uint8 *dest);
 
 	uint32      _srcOffset;
 
 public:
-	SonarcAudioSample(uint8 *buffer, uint32 size);
+	SonarcAudioSample(const uint8 *buffer, uint32 size);
 	~SonarcAudioSample(void) override;
 
 	void initDecompressor(void *DecompData) const override;

--- a/engines/ultima/ultima8/audio/sound_flex.cpp
+++ b/engines/ultima/ultima8/audio/sound_flex.cpp
@@ -68,7 +68,7 @@ void SoundFlex::uncache(uint32 index) {
 	_samples[index] = 0;
 }
 
-bool SoundFlex::isCached(uint32 index) {
+bool SoundFlex::isCached(uint32 index) const {
 	if (index >= _count) return false;
 	if (!_samples) return false;
 

--- a/engines/ultima/ultima8/audio/sound_flex.h
+++ b/engines/ultima/ultima8/audio/sound_flex.h
@@ -47,7 +47,7 @@ public:
 
 	void cache(uint32 index) override;
 	void uncache(uint32 index) override;
-	bool isCached(uint32 index) override;
+	bool isCached(uint32 index) const override;
 
 private:
 	AudioSample **_samples;

--- a/engines/ultima/ultima8/audio/speech_flex.cpp
+++ b/engines/ultima/ultima8/audio/speech_flex.cpp
@@ -33,9 +33,9 @@ DEFINE_RUNTIME_CLASSTYPE_CODE(SpeechFlex, SoundFlex)
 
 SpeechFlex::SpeechFlex(IDataSource *ds) : SoundFlex(ds) {
 	uint32 size = getRawSize(0);
-	uint8 *buf = getRawObject(0);
+	const uint8 *buf = getRawObject(0);
 
-	istring strings(reinterpret_cast<char *>(buf), size);
+	istring strings(reinterpret_cast<const char *>(buf), size);
 	Std::vector<istring> s;
 	SplitString(strings, 0, s);
 

--- a/engines/ultima/ultima8/filesys/archive.cpp
+++ b/engines/ultima/ultima8/filesys/archive.cpp
@@ -101,14 +101,14 @@ uint8 *Archive::getRawObject(uint32 index, uint32 *sizep) {
 	return f->getObject(index, sizep);
 }
 
-uint32 Archive::getRawSize(uint32 index) {
+uint32 Archive::getRawSize(uint32 index) const {
 	ArchiveFile *f = findArchiveFile(index);
 	if (!f) return 0;
 
 	return f->getSize(index);
 }
 
-ArchiveFile *Archive::findArchiveFile(uint32 index) {
+ArchiveFile *Archive::findArchiveFile(uint32 index) const {
 	unsigned int n = _sources.size();
 	for (unsigned int i = 1; i <= n; ++i) {
 		if (_sources[n - i]->exists(index))

--- a/engines/ultima/ultima8/filesys/archive.h
+++ b/engines/ultima/ultima8/filesys/archive.h
@@ -74,7 +74,7 @@ public:
 	virtual void uncache(uint32 index) = 0;
 
 	//! Check if an object is cached
-	virtual bool isCached(uint32 index) = 0;
+	virtual bool isCached(uint32 index) const = 0;
 
 	uint32 getCount() const {
 		return _count;
@@ -84,12 +84,12 @@ protected:
 	uint32 _count;
 
 	uint8 *getRawObject(uint32 index, uint32 *sizep = 0);
-	uint32 getRawSize(uint32 index);
+	uint32 getRawSize(uint32 index) const;
 
 private:
 	Std::vector<ArchiveFile *> _sources;
 
-	ArchiveFile *findArchiveFile(uint32 index);
+	ArchiveFile *findArchiveFile(uint32 index) const;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/filesys/archive_file.h
+++ b/engines/ultima/ultima8/filesys/archive_file.h
@@ -73,12 +73,12 @@ public:
 	//! Get size of object; returns zero if index is invalid.
 	//! See also exists(uint32 index)
 	//! \param index index of object to get size of
-	virtual uint32 getSize(uint32 index) = 0;
+	virtual uint32 getSize(uint32 index) const = 0;
 
 	//! Get size of named object; returns zero if name is invalid
 	//! See also exists(Std::string name)
 	//! \param index index of object to get size of
-	virtual uint32 getSize(const Std::string &name) = 0;
+	virtual uint32 getSize(const Std::string &name) const = 0;
 
 	//! Get object as an IDataSource
 	//! Delete the IDataSource afterwards; that will delete the data as well
@@ -91,12 +91,12 @@ public:
 	//! Get upper bound for number of objects.
 	//! In an indexed file this is (probably) the highest index plus one,
 	//! while in a named file it's (probably) the actual count
-	virtual uint32 getCount() = 0;
+	virtual uint32 getCount() const = 0;
 
 	//! Get the highest index in the file
 	//! Guaranteed to be sufficiently large for a vector that needs to
 	//!  store the indexed entries of this file
-	virtual uint32 getIndexCount() = 0;
+	virtual uint32 getIndexCount() const = 0;
 
 	//! is archive indexed?
 	virtual bool isIndexed() const = 0;

--- a/engines/ultima/ultima8/filesys/flex_file.cpp
+++ b/engines/ultima/ultima8/filesys/flex_file.cpp
@@ -88,7 +88,7 @@ uint8 *FlexFile::getObject(uint32 index, uint32 *sizep) {
 	return object;
 }
 
-uint32 FlexFile::getSize(uint32 index) {
+uint32 FlexFile::getSize(uint32 index) const {
 	if (index >= _count) return 0;
 
 	_ds->seek(0x84 + 8 * index);
@@ -97,7 +97,7 @@ uint32 FlexFile::getSize(uint32 index) {
 	return length;
 }
 
-bool FlexFile::nameToIndex(const Std::string &name, uint32 &index) {
+bool FlexFile::nameToIndex(const Std::string &name, uint32 &index) const {
 	return extractIndexFromName(name, index);
 }
 

--- a/engines/ultima/ultima8/filesys/flex_file.h
+++ b/engines/ultima/ultima8/filesys/flex_file.h
@@ -61,8 +61,8 @@ public:
 	}
 
 
-	uint32 getSize(uint32 index) override;
-	uint32 getSize(const Std::string &name) override {
+	uint32 getSize(uint32 index) const override;
+	uint32 getSize(const Std::string &name) const override {
 		uint32 index;
 		if (nameToIndex(name, index))
 			return getSize(index);
@@ -70,11 +70,11 @@ public:
 			return 0;
 	}
 
-	uint32 getCount() override {
+	uint32 getCount() const override {
 		return _count;
 	}
 
-	uint32 getIndexCount() override {
+	uint32 getIndexCount() const override {
 		return _count;
 	}
 
@@ -88,7 +88,7 @@ public:
 	static bool isFlexFile(IDataSource *ds);
 
 protected:
-	bool nameToIndex(const Std::string &name, uint32 &index);
+	bool nameToIndex(const Std::string &name, uint32 &index) const;
 
 	IDataSource *_ds;
 	uint32 _count;

--- a/engines/ultima/ultima8/filesys/named_archive_file.h
+++ b/engines/ultima/ultima8/filesys/named_archive_file.h
@@ -49,16 +49,16 @@ public:
 	}
 	uint8 *getObject(const Std::string &name, uint32 *size = 0) override = 0;
 
-	uint32 getSize(uint32 index) override {
+	uint32 getSize(uint32 index) const override {
 		Std::string name;
 		if (!indexToName(index, name)) return 0;
 		return getSize(name);
 	}
-	uint32 getSize(const Std::string &name) override = 0;
+	uint32 getSize(const Std::string &name) const override = 0;
 
-	uint32 getCount() override = 0;
+	uint32 getCount() const override = 0;
 
-	uint32 getIndexCount() override {
+	uint32 getIndexCount() const override {
 		return _indexCount;
 	}
 
@@ -70,8 +70,8 @@ public:
 	}
 
 protected:
-	bool indexToName(uint32 index, Std::string &name) {
-		Std::map<uint32, Std::string>::iterator iter;
+	bool indexToName(uint32 index, Std::string &name) const {
+		Std::map<uint32, Std::string>::const_iterator iter;
 		iter = _indexedNames.find(index);
 		if (iter == _indexedNames.end()) return false;
 		name = iter->_value;

--- a/engines/ultima/ultima8/filesys/raw_archive.cpp
+++ b/engines/ultima/ultima8/filesys/raw_archive.cpp
@@ -54,7 +54,7 @@ void RawArchive::uncache(uint32 index) {
 	}
 }
 
-bool RawArchive::isCached(uint32 index) {
+bool RawArchive::isCached(uint32 index) const {
 	if (index >= _count) return false;
 	if (_objects.empty()) return false;
 

--- a/engines/ultima/ultima8/filesys/raw_archive.h
+++ b/engines/ultima/ultima8/filesys/raw_archive.h
@@ -44,7 +44,7 @@ public:
 
 	void cache(uint32 index) override;
 	void uncache(uint32 index) override;
-	bool isCached(uint32 index) override;
+	bool isCached(uint32 index) const override;
 
 	//! return object. DON'T delete or modify!
 	virtual const uint8 *get_object_nodel(uint32 index);

--- a/engines/ultima/ultima8/filesys/u8_save_file.cpp
+++ b/engines/ultima/ultima8/filesys/u8_save_file.cpp
@@ -77,8 +77,8 @@ bool U8SaveFile::readMetadata() {
 	return true;
 }
 
-bool U8SaveFile::findIndex(const Std::string &name, uint32 &index) {
-	Std::map<Common::String, uint32>::iterator iter;
+bool U8SaveFile::findIndex(const Std::string &name, uint32 &index) const {
+	Std::map<Common::String, uint32>::const_iterator iter;
 	iter = _indices.find(name);
 	if (iter == _indices.end()) return false;
 	index = iter->_value;
@@ -109,7 +109,7 @@ uint8 *U8SaveFile::getObject(const Std::string &name, uint32 *sizep) {
 }
 
 
-uint32 U8SaveFile::getSize(const Std::string &name) {
+uint32 U8SaveFile::getSize(const Std::string &name) const {
 	uint32 index;
 	if (!findIndex(name, index)) return 0;
 

--- a/engines/ultima/ultima8/filesys/u8_save_file.h
+++ b/engines/ultima/ultima8/filesys/u8_save_file.h
@@ -45,9 +45,9 @@ public:
 
 	uint8 *getObject(const Std::string &name, uint32 *size = 0) override;
 
-	uint32 getSize(const Std::string &name) override;
+	uint32 getSize(const Std::string &name) const override;
 
-	uint32 getCount() override {
+	uint32 getCount() const override {
 		return _count;
 	}
 
@@ -63,7 +63,7 @@ protected:
 
 private:
 	bool readMetadata();
-	bool findIndex(const Std::string &name, uint32 &index);
+	bool findIndex(const Std::string &name, uint32 &index) const;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/games/remorse_game.cpp
+++ b/engines/ultima/ultima8/games/remorse_game.cpp
@@ -120,7 +120,7 @@ void RemorseGame::writeSaveInfo(ODataSource *ods) {
 	MainActor *av = getMainActor();
 	int32 x, y, z;
 
-	Std::string avname = av->getName();
+	const Std::string &avname = av->getName();
 	uint8 namelength = static_cast<uint8>(avname.size());
 	ods->write1(namelength);
 	for (unsigned int i = 0; i < namelength; ++i)
@@ -143,8 +143,8 @@ void RemorseGame::writeSaveInfo(ODataSource *ods) {
 	ods->write2(av->getTotalWeight());
 
 	for (unsigned int i = 1; i <= 6; i++) {
-		uint16 objid = av->getEquip(i);
-		Item *item = getItem(objid);
+		const uint16 objid = av->getEquip(i);
+		const Item *item = getItem(objid);
 		if (item) {
 			ods->write4(item->getShape());
 			ods->write4(item->getFrame());

--- a/engines/ultima/ultima8/games/treasure_loader.cpp
+++ b/engines/ultima/ultima8/games/treasure_loader.cpp
@@ -52,7 +52,7 @@ void TreasureLoader::loadDefaults() {
 
 }
 
-bool TreasureLoader::parse(Std::string desc,
+bool TreasureLoader::parse(const Std::string &desc,
                            Std::vector<TreasureInfo> &treasure) {
 	treasure.clear();
 
@@ -72,7 +72,7 @@ bool TreasureLoader::parse(Std::string desc,
 	return true;
 }
 
-bool TreasureLoader::internalParse(Std::string desc, TreasureInfo &ti,
+bool TreasureLoader::internalParse(const Std::string &desc, TreasureInfo &ti,
                                    bool loadingDefault) {
 	ti._special = "";
 	ti._chance = 1;
@@ -143,8 +143,9 @@ bool TreasureLoader::internalParse(Std::string desc, TreasureInfo &ti,
 	return true;
 }
 
-bool TreasureLoader::parseUInt32Vector(Std::string val,
+bool TreasureLoader::parseUInt32Vector(const Std::string &val_,
                                        Std::vector<uint32> &vec) {
+	Std::string val = val_;
 	vec.clear();
 
 	Std::string::size_type pos;
@@ -173,7 +174,7 @@ bool TreasureLoader::parseUInt32Vector(Std::string val,
 	return true;
 }
 
-bool TreasureLoader::parseUIntRange(Std::string val,
+bool TreasureLoader::parseUIntRange(const Std::string &val,
                                     unsigned int &min, unsigned int &max) {
 	Std::string::size_type pos = val.find('-');
 	if (pos == 0 || pos == Std::string::npos || pos + 1 >= val.size())
@@ -189,13 +190,13 @@ bool TreasureLoader::parseUIntRange(Std::string val,
 	return ok;
 }
 
-bool TreasureLoader::parseDouble(Std::string val, double &d) {
+bool TreasureLoader::parseDouble(const Std::string &val, double &d) {
 	// TODO: error checking
 	d = Std::atof(val.c_str());
 	return true;
 }
 
-bool TreasureLoader::parseInt(Std::string val, int &i) {
+bool TreasureLoader::parseInt(const Std::string &val, int &i) {
 	// TODO: error checking
 	i = Std::strtol(val.c_str(), 0, 0);
 	return true;

--- a/engines/ultima/ultima8/games/treasure_loader.h
+++ b/engines/ultima/ultima8/games/treasure_loader.h
@@ -37,17 +37,17 @@ public:
 	void loadDefaults();
 
 	//! parse treasure string into vector of TreasureInfo objects
-	bool parse(Std::string, Std::vector<TreasureInfo> &treasure);
+	bool parse(const Std::string &, Std::vector<TreasureInfo> &treasure);
 
 private:
 	TreasureMap _defaultTreasure;
 
-	bool internalParse(Std::string desc, TreasureInfo &ti, bool loadingDefault);
+	bool internalParse(const Std::string &desc, TreasureInfo &ti, bool loadingDefault);
 
-	bool parseUInt32Vector(Std::string val, Std::vector<uint32> &vec);
-	bool parseUIntRange(Std::string val, unsigned int &min, unsigned int &max);
-	bool parseDouble(Std::string val, double &d);
-	bool parseInt(Std::string val, int &i);
+	bool parseUInt32Vector(const Std::string &val, Std::vector<uint32> &vec);
+	bool parseUIntRange(const Std::string &val, unsigned int &min, unsigned int &max);
+	bool parseDouble(const Std::string &val, double &d);
+	bool parseInt(const Std::string &val, int &i);
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/games/u8_game.cpp
+++ b/engines/ultima/ultima8/games/u8_game.cpp
@@ -239,8 +239,8 @@ void U8Game::writeSaveInfo(ODataSource *ods) {
 	MainActor *av = getMainActor();
 	int32 x, y, z;
 
-	Std::string avname = av->getName();
-	uint8 namelength = static_cast<uint8>(avname.size());
+	const Std::string &avname = av->getName();
+	const uint8 namelength = static_cast<uint8>(avname.size());
 	ods->write1(namelength);
 	for (unsigned int i = 0; i < namelength; ++i)
 		ods->write1(static_cast<uint8>(avname[i]));

--- a/engines/ultima/ultima8/graphics/fonts/fixed_width_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/fixed_width_font.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-FixedWidthFont *FixedWidthFont::Create(Std::string iniroot) {
+FixedWidthFont *FixedWidthFont::Create(const Std::string &iniroot) {
 	ConfigFileManager *config = ConfigFileManager::get_instance();
 	FileSystem *filesys = FileSystem::get_instance();
 

--- a/engines/ultima/ultima8/graphics/fonts/fixed_width_font.h
+++ b/engines/ultima/ultima8/graphics/fonts/fixed_width_font.h
@@ -41,7 +41,7 @@ struct FixedWidthFont {
 
 	~FixedWidthFont();
 
-	static FixedWidthFont *Create(Std::string iniroot);
+	static FixedWidthFont *Create(const Std::string &iniroot);
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/graphics/fonts/font_manager.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font_manager.cpp
@@ -91,7 +91,7 @@ Font *FontManager::getTTFont(unsigned int fontnum) {
 }
 
 
-Graphics::Font *FontManager::getTTF_Font(Std::string filename, int pointsize) {
+Graphics::Font *FontManager::getTTF_Font(const Std::string &filename, int pointsize) {
 	TTFId id;
 	id._filename = filename;
 	id._pointSize = pointsize;
@@ -139,7 +139,7 @@ void FontManager::setOverride(unsigned int fontnum, Font *newFont) {
 }
 
 
-bool FontManager::addTTFOverride(unsigned int fontnum, Std::string filename,
+bool FontManager::addTTFOverride(unsigned int fontnum, const Std::string &filename,
                                  int pointsize, uint32 rgb, int bordersize,
                                  bool SJIS) {
 	Graphics::Font *f = getTTF_Font(filename, pointsize);
@@ -194,7 +194,7 @@ bool FontManager::addJPOverride(unsigned int fontnum,
 }
 
 
-bool FontManager::loadTTFont(unsigned int fontnum, Std::string filename,
+bool FontManager::loadTTFont(unsigned int fontnum, const Std::string &filename,
                              int pointsize, uint32 rgb, int bordersize) {
 	Graphics::Font *f = getTTF_Font(filename, pointsize);
 	if (!f)

--- a/engines/ultima/ultima8/graphics/fonts/font_manager.h
+++ b/engines/ultima/ultima8/graphics/fonts/font_manager.h
@@ -69,7 +69,7 @@ private:
 
 	//! Get a (possibly cached) TTF_Font structure for filename/pointsize,
 	//! loading it if necessary.
-	Graphics::Font *getTTF_Font(Std::string filename, int pointsize);
+	Graphics::Font *getTTF_Font(const Std::string &filename, int pointsize);
 
 	//! Override fontnum with specified font
 	void setOverride(unsigned int fontnum, Font *newFont);
@@ -103,7 +103,7 @@ public:
 	//! \param rgb the color to use for the font
 	//! \param bordersize the size of the black border to add
 	//! \param SJIS true for a Japanese game font
-	bool addTTFOverride(unsigned int fontnum, Std::string filename,
+	bool addTTFOverride(unsigned int fontnum, const Std::string &filename,
 	                    int pointsize, uint32 rgb, int bordersize,
 	                    bool SJIS = false);
 
@@ -114,7 +114,7 @@ public:
 	bool addJPOverride(unsigned int fontnum, unsigned int jpfont, uint32 rgb);
 
 	//! load a TTF (for non-game fonts)
-	bool loadTTFont(unsigned int ttfnum, Std::string filename,
+	bool loadTTFont(unsigned int ttfnum, const Std::string &filename,
 	                int pointsize, uint32 rgb, int bordersize);
 
 	// Reset the game fonts

--- a/engines/ultima/ultima8/graphics/fonts/rendered_text.h
+++ b/engines/ultima/ultima8/graphics/fonts/rendered_text.h
@@ -47,7 +47,7 @@ public:
 	//! Get dimensions.
 	//! \param x Returns the width
 	//! \param y Returns the height
-	virtual void getSize(int &x, int &y) {
+	virtual void getSize(int &x, int &y) const {
 		x = _width;
 		y = _height;
 	}

--- a/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.cpp
@@ -32,7 +32,7 @@ namespace Ultima8 {
 DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeRenderedText, RenderedText)
 
 
-ShapeRenderedText::ShapeRenderedText(Std::list<PositionedText> &lines,
+ShapeRenderedText::ShapeRenderedText(const Std::list<PositionedText> &lines,
                                      int width, int height, int vLead,
                                      ShapeFont *font)
 	: _lines(lines), _font(font) {

--- a/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.h
+++ b/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.h
@@ -34,7 +34,7 @@ class ShapeFont;
 
 class ShapeRenderedText : public RenderedText {
 public:
-	ShapeRenderedText(Std::list<PositionedText> &lines,
+	ShapeRenderedText(const Std::list<PositionedText> &lines,
 	                  int width, int height, int vlead, ShapeFont *font);
 	~ShapeRenderedText() override;
 

--- a/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
@@ -150,7 +150,7 @@ RenderedText *TTFont::renderText(const Std::string &text, unsigned int &remainin
 	texture->_width = resultWidth;
 	texture->_height = resultHeight;
 
-	Std::list<PositionedText>::iterator iter;
+	Std::list<PositionedText>::const_iterator iter;
 	for (iter = lines.begin(); iter != lines.end(); ++iter) {
 		// convert to unicode
 		Common::U32String unicodeText;

--- a/engines/ultima/ultima8/graphics/point_scaler.cpp
+++ b/engines/ultima/ultima8/graphics/point_scaler.cpp
@@ -236,7 +236,7 @@ public:
 				do {
 					pos_y = dst_y;
 
-					uintX p = Manip::copy(*texel);
+					const uintX p = Manip::copy(*texel);
 
 					//
 					// Inner loops

--- a/engines/ultima/ultima8/graphics/shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/shape_archive.cpp
@@ -80,7 +80,7 @@ void ShapeArchive::uncache(uint32 shapenum) {
 	_shapes[shapenum] = 0;
 }
 
-bool ShapeArchive::isCached(uint32 shapenum) {
+bool ShapeArchive::isCached(uint32 shapenum) const {
 	if (shapenum >= _count) return false;
 	if (_shapes.empty()) return false;
 

--- a/engines/ultima/ultima8/graphics/shape_archive.h
+++ b/engines/ultima/ultima8/graphics/shape_archive.h
@@ -53,7 +53,7 @@ public:
 
 	void cache(uint32 shapenum) override;
 	void uncache(uint32 shapenum) override;
-	bool isCached(uint32 shapenum) override;
+	bool isCached(uint32 shapenum) const override;
 
 protected:
 	uint16 _id;

--- a/engines/ultima/ultima8/graphics/type_flags.cpp
+++ b/engines/ultima/ultima8/graphics/type_flags.cpp
@@ -176,9 +176,9 @@ void TypeFlags::loadWeaponInfo() {
 	// load weapons
 	Std::vector<istring> weaponkeys;
 	weaponkeys = config->listSections("weapons", true);
-	for (Std::vector<istring>::iterator iter = weaponkeys.begin();
+	for (Std::vector<istring>::const_iterator iter = weaponkeys.begin();
 	        iter != weaponkeys.end(); ++iter) {
-		istring k = *iter;
+		const istring &k = *iter;
 		WeaponInfo *wi = new WeaponInfo;
 
 		int val;
@@ -228,9 +228,9 @@ void TypeFlags::loadArmourInfo() {
 	// load armour
 	Std::vector<istring> armourkeys;
 	armourkeys = config->listSections("armour", true);
-	for (Std::vector<istring>::iterator iter = armourkeys.begin();
+	for (Std::vector<istring>::const_iterator iter = armourkeys.begin();
 	        iter != armourkeys.end(); ++iter) {
-		istring k = *iter;
+		const istring &k = *iter;
 		ArmourInfo ai;
 
 		int val;
@@ -285,9 +285,9 @@ void TypeFlags::loadMonsterInfo() {
 	// load monsters
 	Std::vector<istring> monsterkeys;
 	monsterkeys = config->listSections("monsters", true);
-	for (Std::vector<istring>::iterator iter = monsterkeys.begin();
+	for (Std::vector<istring>::const_iterator iter = monsterkeys.begin();
 	        iter != monsterkeys.end(); ++iter) {
-		istring k = *iter;
+		const istring k = *iter;
 		MonsterInfo *mi = new MonsterInfo;
 
 		int val;

--- a/engines/ultima/ultima8/gumps/book_gump.cpp
+++ b/engines/ultima/ultima8/gumps/book_gump.cpp
@@ -47,7 +47,7 @@ BookGump::BookGump()
 
 }
 
-BookGump::BookGump(ObjId owner_, Std::string msg) :
+BookGump::BookGump(ObjId owner_, const Std::string &msg) :
 	ModalGump(0, 0, 100, 100, owner_), _text(msg) {
 }
 

--- a/engines/ultima/ultima8/gumps/book_gump.h
+++ b/engines/ultima/ultima8/gumps/book_gump.h
@@ -38,7 +38,7 @@ public:
 	ENABLE_RUNTIME_CLASSTYPE()
 
 	BookGump();
-	BookGump(ObjId owner_, Std::string msg);
+	BookGump(ObjId owner_, const Std::string &msg);
 	~BookGump() override;
 
 	// Go to the next page on mouse click

--- a/engines/ultima/ultima8/gumps/controls_gump.cpp
+++ b/engines/ultima/ultima8/gumps/controls_gump.cpp
@@ -74,7 +74,7 @@ void ControlEntryGump::init() {
 	Std::list<Gump *>::iterator it;
 	for (it = _children.begin(); it != _children.end(); ++it) {
 		Gump *g = *it;
-		if (! g->IsClosing())
+		if ( !g->IsClosing())
 			g->Close();
 	}
 

--- a/engines/ultima/ultima8/gumps/game_map_gump.cpp
+++ b/engines/ultima/ultima8/gumps/game_map_gump.cpp
@@ -111,14 +111,14 @@ void GameMapGump::PaintThis(RenderSurface *surf, int32 lerp_factor, bool scaled)
 		// Check roof
 		//!! This is _not_ the right place for this...
 		int32 ax, ay, az, axd, ayd, azd;
-		Actor *av = getMainActor();
+		const Actor *av = getMainActor();
 		av->getLocation(ax, ay, az);
 		av->getFootpadWorld(axd, ayd, azd);
 		map->isValidPosition(ax, ay, az, 32, 32, 8, 0, 1, 0, &roofid);
 	} else
 		roofid = camera->FindRoof(lerp_factor);
 
-	Item *roof = getItem(roofid);
+	const Item *roof = getItem(roofid);
 	if (roof) {
 		zlimit = roof->getZ();
 	}

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -752,7 +752,7 @@ bool Gump::OnTextInput(int unicode) {
 	return handled;
 }
 
-bool Gump::mustSave(bool toplevel) {
+bool Gump::mustSave(bool toplevel) const {
 	// DONT_SAVE flag
 	if (_flags & FLAG_DONT_SAVE)
 		return false;

--- a/engines/ultima/ultima8/gumps/gump.h
+++ b/engines/ultima/ultima8/gumps/gump.h
@@ -233,7 +233,7 @@ public:
 	//
 
 	//! Get the _dims
-	virtual void GetDims(Rect &d) {
+	virtual void GetDims(Rect &d) const {
 		d = _dims;
 	}
 
@@ -373,7 +373,7 @@ public:
 	void SetIndex(int32 i) {
 		_index = i;
 	}
-	int32 GetIndex() {
+	int32 GetIndex() const {
 		return _index;
 	}
 
@@ -431,10 +431,10 @@ public:
 		                      // (only for ItemRelativeGumps)
 	};
 
-	inline bool IsHidden() {
+	inline bool IsHidden() const {
 		return (_flags & FLAG_HIDDEN) || (_parent && _parent->IsHidden());
 	}
-	bool IsDraggable() {
+	bool IsDraggable() const {
 		return _flags & FLAG_DRAGGABLE;
 	}
 	virtual void HideGump() {
@@ -444,7 +444,7 @@ public:
 		_flags &= ~FLAG_HIDDEN;
 	}
 
-	bool mustSave(bool toplevel);
+	bool mustSave(bool toplevel) const;
 
 	//
 	// Gump Layers

--- a/engines/ultima/ultima8/gumps/gump_notify_process.cpp
+++ b/engines/ultima/ultima8/gumps/gump_notify_process.cpp
@@ -69,7 +69,7 @@ void GumpNotifyProcess::terminate() {
 void GumpNotifyProcess::run() {
 }
 
-void GumpNotifyProcess::dumpInfo() {
+void GumpNotifyProcess::dumpInfo() const {
 	Process::dumpInfo();
 	pout << " gump: " << _gump << Std::endl;
 }

--- a/engines/ultima/ultima8/gumps/gump_notify_process.h
+++ b/engines/ultima/ultima8/gumps/gump_notify_process.h
@@ -52,7 +52,7 @@ public:
 
 	void run() override;
 
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 protected:

--- a/engines/ultima/ultima8/gumps/menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/menu_gump.cpp
@@ -131,7 +131,7 @@ void MenuGump::InitGump(Gump *newparent, bool take_focus) {
 			y_ += 14;
 		}
 
-		MainActor *av = getMainActor();
+		const MainActor *av = getMainActor();
 		Std::string name;
 		if (av)
 			name = av->getName();

--- a/engines/ultima/ultima8/kernel/delay_process.cpp
+++ b/engines/ultima/ultima8/kernel/delay_process.cpp
@@ -45,7 +45,7 @@ void DelayProcess::run() {
 		terminate();
 }
 
-void DelayProcess::dumpInfo() {
+void DelayProcess::dumpInfo() const {
 	Process::dumpInfo();
 	pout << "Frames left: " << _count << Std::endl;
 }

--- a/engines/ultima/ultima8/kernel/delay_process.h
+++ b/engines/ultima/ultima8/kernel/delay_process.h
@@ -42,7 +42,7 @@ public:
 
 	void run() override;
 
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 protected:

--- a/engines/ultima/ultima8/kernel/kernel.cpp
+++ b/engines/ultima/ultima8/kernel/kernel.cpp
@@ -335,7 +335,7 @@ bool Kernel::load(IDataSource *ids, uint32 version) {
 
 	if (!_pIDs->load(ids, version)) return false;
 
-	uint32 pcount = ids->read4();
+	const uint32 pcount = ids->read4();
 
 	for (unsigned int i = 0; i < pcount; ++i) {
 		Process *p = loadProcess(ids, version);
@@ -347,7 +347,7 @@ bool Kernel::load(IDataSource *ids, uint32 version) {
 }
 
 Process *Kernel::loadProcess(IDataSource *ids, uint32 version) {
-	uint16 classlen = ids->read2();
+	const uint16 classlen = ids->read2();
 	char *buf = new char[classlen + 1];
 	ids->read(buf, classlen);
 	buf[classlen] = 0;

--- a/engines/ultima/ultima8/kernel/mouse.cpp
+++ b/engines/ultima/ultima8/kernel/mouse.cpp
@@ -136,7 +136,7 @@ void Mouse::popAllCursors() {
 	CursorMan.popAllCursors();
 }
 
-bool Mouse::isMouseDownEvent(Shared::MouseButton button) {
+bool Mouse::isMouseDownEvent(Shared::MouseButton button) const {
 	return (_mouseButton[button]._state & MBS_DOWN);
 }
 

--- a/engines/ultima/ultima8/kernel/mouse.h
+++ b/engines/ultima/ultima8/kernel/mouse.h
@@ -129,7 +129,7 @@ public:
 	//! set current mouse cursor location
 	void setMouseCoords(int mx, int my);
 
-	bool isMouseDownEvent(Shared::MouseButton button);
+	bool isMouseDownEvent(Shared::MouseButton button) const;
 
 	//! remove all existing cursors
 	void popAllCursors();

--- a/engines/ultima/ultima8/kernel/object.cpp
+++ b/engines/ultima/ultima8/kernel/object.cpp
@@ -59,7 +59,7 @@ void Object::clearObjId() {
 	_objId = 0xFFFF;
 }
 
-void Object::dumpInfo() {
+void Object::dumpInfo() const {
 	g_debugger->debugPrintf("Object %d (class %s)\n", getObjId(), GetClassType()._className);
 }
 
@@ -76,7 +76,7 @@ void Object::save(ODataSource *ods) {
 	saveData(ods); // virtual
 }
 
-void Object::writeObjectHeader(ODataSource *ods) {
+void Object::writeObjectHeader(ODataSource *ods) const {
 	const char *cname = GetClassType()._className; // note: virtual
 	uint16 clen = strlen(cname);
 

--- a/engines/ultima/ultima8/kernel/object.h
+++ b/engines/ultima/ultima8/kernel/object.h
@@ -57,7 +57,7 @@ public:
 	virtual void clearObjId();
 
 	//! dump some info about this object to pout
-	virtual void dumpInfo();
+	virtual void dumpInfo() const;
 
 	//! save this object
 	void save(ODataSource *ods);
@@ -76,7 +76,7 @@ public:
 
 protected:
 	//! write the Object savegame header (mainly consisting of the classname)
-	void writeObjectHeader(ODataSource *ods);
+	void writeObjectHeader(ODataSource *ods) const;
 
 	//! save the actual Object data
 	virtual void saveData(ODataSource *ods);

--- a/engines/ultima/ultima8/kernel/pool.h
+++ b/engines/ultima/ultima8/kernel/pool.h
@@ -39,12 +39,12 @@ public:
 	virtual void *allocate(size_t size) = 0;
 	virtual void deallocate(void *ptr) = 0;
 
-	virtual bool isFull() = 0;
-	virtual bool isEmpty() = 0;
+	virtual bool isFull() const = 0;
+	virtual bool isEmpty() const = 0;
 
-	virtual bool inPool(void *ptr) = 0;
+	virtual bool inPool(void *ptr) const = 0;
 
-	virtual void printInfo() = 0;
+	virtual void printInfo() const = 0;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/kernel/process.cpp
+++ b/engines/ultima/ultima8/kernel/process.cpp
@@ -95,7 +95,7 @@ void Process::suspend() {
 	_flags |= PROC_SUSPENDED;
 }
 
-void Process::dumpInfo() {
+void Process::dumpInfo() const {
 	Common::String info = Common::String::format(
 		"Process %d class %s, item %d, type %x, status ",
 		getPid(), GetClassType()._className, _itemNum, _type);
@@ -108,7 +108,7 @@ void Process::dumpInfo() {
 	if (_flags & PROC_RUNPAUSED) info += "R";
 	if (!_waiting.empty()) {
 		info += ", notify: ";
-		for (Std::vector<ProcId>::iterator i = _waiting.begin(); i != _waiting.end(); ++i) {
+		for (Std::vector<ProcId>::const_iterator i = _waiting.begin(); i != _waiting.end(); ++i) {
 			if (i != _waiting.begin()) info += ", ";
 			info += *i;
 		}

--- a/engines/ultima/ultima8/kernel/process.h
+++ b/engines/ultima/ultima8/kernel/process.h
@@ -103,7 +103,7 @@ public:
 	}
 
 	//! dump some info about this process to pout
-	virtual void dumpInfo();
+	virtual void dumpInfo() const;
 
 	//! save this process
 	void save(ODataSource *ods);

--- a/engines/ultima/ultima8/kernel/segmented_pool.cpp
+++ b/engines/ultima/ultima8/kernel/segmented_pool.cpp
@@ -153,7 +153,7 @@ void SegmentedPool::deallocate(void *ptr) {
 	}
 }
 
-void SegmentedPool::printInfo() {
+void SegmentedPool::printInfo() const {
 	uint16 i;
 	size_t max, min, total;
 	SegmentedPoolNode *node;

--- a/engines/ultima/ultima8/kernel/segmented_pool.h
+++ b/engines/ultima/ultima8/kernel/segmented_pool.h
@@ -51,20 +51,20 @@ public:
 	void *allocate(size_t size) override;
 	void deallocate(void *ptr) override;
 
-	bool isFull() override {
+	bool isFull() const override {
 		return _freeNodeCount == 0;
 	}
-	bool isEmpty() override {
+	bool isEmpty() const override {
 		return _freeNodeCount == _nodes;
 	}
 
-	bool inPool(void *ptr) override {
+	bool inPool(void *ptr) const override {
 		return (ptr > _startOfPool && ptr < _endOfPool);
 	}
 
-	void printInfo() override;
+	void printInfo() const override;
 
-	size_t getNodeCapacity() {
+	size_t getNodeCapacity() const {
 		return _nodeCapacity;
 	}
 

--- a/engines/ultima/ultima8/misc/p_dynamic_cast.h
+++ b/engines/ultima/ultima8/misc/p_dynamic_cast.h
@@ -44,17 +44,17 @@ struct RunTimeClassType {
 //
 #define ENABLE_RUNTIME_CLASSTYPE()                                              \
 	static const RunTimeClassType   ClassType;                                  \
-	virtual bool IsOfType(const RunTimeClassType & type) override;              \
-	virtual bool IsOfType(const char * type) override;                          \
-	template<class Type> inline bool IsOfType() { return IsOfType(Type::ClassType); }   \
-	virtual const RunTimeClassType & GetClassType() override { return ClassType; }
+	virtual bool IsOfType(const RunTimeClassType & type) const override;        \
+	virtual bool IsOfType(const char * type) const override;                    \
+	template<class Type> inline bool IsOfType() const { return IsOfType(Type::ClassType); }   \
+	virtual const RunTimeClassType & GetClassType() const override { return ClassType; }
 
 #define ENABLE_RUNTIME_CLASSTYPE_BASE()                                         \
 	static const RunTimeClassType   ClassType;                                  \
-	virtual bool IsOfType(const RunTimeClassType & type);                       \
-	virtual bool IsOfType(const char * type);                                   \
-	template<class Type> inline bool IsOfType() { return IsOfType(Type::ClassType); }   \
-	virtual const RunTimeClassType & GetClassType() { return ClassType; }
+	virtual bool IsOfType(const RunTimeClassType & type) const;                 \
+	virtual bool IsOfType(const char * type) const;                             \
+	template<class Type> inline bool IsOfType() const { return IsOfType(Type::ClassType); }   \
+	virtual const RunTimeClassType & GetClassType() const { return ClassType; }
 
 
 
@@ -66,13 +66,13 @@ struct RunTimeClassType {
 	#Classname                                                      \
     };                                                                  \
 	\
-	bool Classname::IsOfType(const RunTimeClassType &classType)         \
+	bool Classname::IsOfType(const RunTimeClassType &classType) const   \
 	{                                                                   \
 		if (classType == ClassType) return true;                        \
 		return false;                                                   \
 	}                                                                   \
 	\
-	bool Classname::IsOfType(const char *classType)                     \
+	bool Classname::IsOfType(const char *classType) const               \
 	{                                                                   \
 		if (!Std::strcmp(classType,ClassType._className)) return true;  \
 		return false;                                                   \
@@ -87,13 +87,13 @@ struct RunTimeClassType {
 	                                                                    #Classname                                                      \
 	                                              };                                                                  \
 	\
-	bool Classname::IsOfType(const RunTimeClassType & classType)        \
+	bool Classname::IsOfType(const RunTimeClassType & classType) const  \
 	{                                                                   \
 		if (classType == ClassType) return true;                        \
 		return ParentClassname::IsOfType(classType);                    \
 	}                                                                   \
 	\
-	bool Classname::IsOfType(const char *typeName)                      \
+	bool Classname::IsOfType(const char *typeName) const                \
 	{                                                                   \
 		if (!Std::strcmp(typeName,ClassType._className)) return true;   \
 		return ParentClassname::IsOfType(typeName);                     \
@@ -109,7 +109,7 @@ struct RunTimeClassType {
 	                                                                        #Classname                                                          \
 	                                              };                                                                      \
 	\
-	bool Classname::IsOfType(const RunTimeClassType &type)                  \
+	bool Classname::IsOfType(const RunTimeClassType &type) const            \
 	{                                                                       \
 		typedef Parent1 P1;                                                 \
 		typedef Parent2 P2;                                                 \
@@ -119,7 +119,7 @@ struct RunTimeClassType {
 		return P2::IsOfType(type);                                          \
 	}                                                                       \
 	\
-	bool Classname::IsOfType(const char * type)                             \
+	bool Classname::IsOfType(const char * type) const                       \
 	{                                                                       \
 		typedef Parent1 P1;                                                 \
 		typedef Parent2 P2;                                                 \

--- a/engines/ultima/ultima8/usecode/bit_set.cpp
+++ b/engines/ultima/ultima8/usecode/bit_set.cpp
@@ -55,7 +55,7 @@ void BitSet::setSize(unsigned int size) {
 		_data[i] = 0;
 }
 
-uint32 BitSet::getBits(unsigned int pos, unsigned int n) {
+uint32 BitSet::getBits(unsigned int pos, unsigned int n) const {
 	assert(n <= 32);
 	assert(pos + n <= _size);
 	if (n == 0) return 0;

--- a/engines/ultima/ultima8/usecode/bit_set.h
+++ b/engines/ultima/ultima8/usecode/bit_set.h
@@ -43,7 +43,7 @@ public:
 	//! \param pos zero-based position (in bits)
 	//! \param n number of bits (no greater than 32)
 	//! \return the value these bits represent
-	uint32 getBits(unsigned int pos, unsigned int n);
+	uint32 getBits(unsigned int pos, unsigned int n) const;
 
 	//! set a value
 	//! \param pos zero-based position (in bits)

--- a/engines/ultima/ultima8/usecode/uc_list.cpp
+++ b/engines/ultima/ultima8/usecode/uc_list.cpp
@@ -30,11 +30,11 @@
 namespace Ultima {
 namespace Ultima8 {
 
-uint16 UCList::getStringIndex(uint32 index) {
+uint16 UCList::getStringIndex(uint32 index) const {
 	return _elements[index * 2] + (_elements[index * 2 + 1] << 8);
 }
 
-Std::string &UCList::getString(uint32 index) {
+const Std::string &UCList::getString(uint32 index) const {
 	uint16 sindex = getStringIndex(index);
 	return UCMachine::get_instance()->getString(sindex);
 }
@@ -47,7 +47,7 @@ void UCList::freeStrings() {
 	free();
 }
 
-void UCList::copyStringList(UCList &l) {
+void UCList::copyStringList(const UCList &l) {
 	UCMachine *ucm = UCMachine::get_instance();
 	freeStrings();
 	for (unsigned int i = 0; i < l._size; i++) {
@@ -74,12 +74,12 @@ void UCList::unionStringList(UCList &l) {
 	l.free(); // NB: do _not_ free the strings in l, since they're in this one
 }
 
-void UCList::substractStringList(UCList &l) {
+void UCList::substractStringList(const UCList &l) {
 	for (unsigned int i = 0; i < l._size; i++)
 		removeString(l.getStringIndex(i));
 }
 
-bool UCList::stringInList(uint16 s) {
+bool UCList::stringInList(uint16 s) const {
 	Std::string str = UCMachine::get_instance()->getString(s);
 	for (unsigned int i = 0; i < _size; i++)
 		if (getString(i) == str)
@@ -100,7 +100,7 @@ void UCList::assignString(uint32 index, uint16 str) {
 void UCList::removeString(uint16 s, bool nodel) {
 	// do we need to erase all occurences of str or just the first one?
 	// (deleting all, currently)
-	Std::string str = UCMachine::get_instance()->getString(s);
+	const Std::string &str = UCMachine::get_instance()->getString(s);
 	for (unsigned int i = 0; i < _size; i++) {
 		if (getString(i) == str) {
 			// free string

--- a/engines/ultima/ultima8/usecode/uc_list.h
+++ b/engines/ultima/ultima8/usecode/uc_list.h
@@ -61,12 +61,12 @@ public:
 		free();
 	}
 
-	const uint8 *operator[](uint32 index) {
+	const uint8 *operator[](uint32 index) const {
 		// check that index isn't out of bounds...
 		return &(_elements[index * _elementSize]);
 	}
 
-	uint16 getuint16(uint32 index) {
+	uint16 getuint16(uint32 index) const {
 		assert(_elementSize == 2);
 		uint16 t = _elements[index * _elementSize];
 		t += _elements[index * _elementSize + 1] << 8;
@@ -96,7 +96,7 @@ public:
 		}
 	}
 
-	bool inList(const uint8 *e) {
+	bool inList(const uint8 *e) const {
 		for (unsigned int i = 0; i < _size; i++) {
 			bool equal = true;
 			for (unsigned int j = 0; j < _elementSize && equal; j++)
@@ -107,21 +107,21 @@ public:
 		return false;
 	}
 
-	void appendList(UCList &l) {
+	void appendList(const UCList &l) {
 		// need to check if elementsizes match...
 		_elements.reserve(_elementSize * (_size + l._size));
 		unsigned int lsize = l._size;
 		for (unsigned int i = 0; i < lsize; i++)
 			append(l[i]);
 	}
-	void unionList(UCList &l) { // like append, but remove duplicates
+	void unionList(const UCList &l) { // like append, but remove duplicates
 		// need to check if elementsizes match...
 		_elements.reserve(_elementSize * (_size + l._size));
 		for (unsigned int i = 0; i < l._size; i++)
 			if (!inList(l[i]))
 				append(l[i]);
 	}
-	void substractList(UCList &l) {
+	void substractList(const UCList &l) {
 		for (unsigned int i = 0; i < l._size; i++)
 			remove(l[i]);
 	}
@@ -143,26 +143,26 @@ public:
 			_elements[index * _elementSize + i] = e[i];
 	}
 
-	void copyList(UCList &l) { // deep copy for list
+	void copyList(const UCList &l) { // deep copy for list
 		free();
 		appendList(l);
 	}
 
 	void freeStrings();
-	void copyStringList(UCList &l);
+	void copyStringList(const UCList &l) ;
 	void unionStringList(UCList &l);
-	void substractStringList(UCList &l);
-	bool stringInList(uint16 str);
+	void substractStringList(const UCList &l);
+	bool stringInList(uint16 str) const;
 	void assignString(uint32 index, uint16 str);
 	void removeString(uint16 str, bool nodel = false);
 
-	uint16 getStringIndex(uint32 index);
+	uint16 getStringIndex(uint32 index) const;
 
 	void save(ODataSource *ods);
 	bool load(IDataSource *ids, uint32 version);
 
 private:
-	Std::string &getString(uint32 index);
+	const Std::string &getString(uint32 index) const;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/usecode/uc_machine.cpp
+++ b/engines/ultima/ultima8/usecode/uc_machine.cpp
@@ -1969,10 +1969,11 @@ void UCMachine::execProcess(UCProcess *p) {
 }
 
 
-Std::string &UCMachine::getString(uint16 str) {
+const Std::string &UCMachine::getString(uint16 str) const {
 	static Std::string emptystring("");
 
-	Std::map<uint16, Std::string>::iterator iter = _stringHeap.find(str);
+	Std::map<uint16, Std::string>::const_iterator iter =
+            _stringHeap.find(str);
 
 	if (iter != _stringHeap.end())
 		return iter->_value;
@@ -2311,6 +2312,7 @@ uint32 UCMachine::I_dummyProcess(const uint8 * /*args*/, unsigned int /*argsize*
 uint32 UCMachine::I_getName(const uint8 * /*args*/, unsigned int /*argsize*/) {
 	UCMachine *uc = UCMachine::get_instance();
 	MainActor *av = getMainActor();
+	// FIXME: This could be bad, we're keeping the reference to a string.c_str
 	return uc->assignString(av->getName().c_str());
 }
 

--- a/engines/ultima/ultima8/usecode/uc_machine.h
+++ b/engines/ultima/ultima8/usecode/uc_machine.h
@@ -54,7 +54,7 @@ public:
 
 	void execProcess(UCProcess *proc);
 
-	Std::string &getString(uint16 str);
+	const Std::string &getString(uint16 str) const;
 	UCList *getList(uint16 l);
 
 	void freeString(uint16 s);
@@ -132,7 +132,7 @@ private:
 	}
 
 public:
-	bool trace_event() {
+	bool trace_event() const {
 		return (_tracingEnabled && (_traceAll || _traceEvents));
 	}
 #endif

--- a/engines/ultima/ultima8/usecode/uc_process.cpp
+++ b/engines/ultima/ultima8/usecode/uc_process.cpp
@@ -148,7 +148,7 @@ void UCProcess::terminate() {
 	Process::terminate();
 }
 
-void UCProcess::dumpInfo() {
+void UCProcess::dumpInfo() const {
 	Process::dumpInfo();
 
 	if (_classId == 0xFFFF) {

--- a/engines/ultima/ultima8/usecode/uc_process.h
+++ b/engines/ultima/ultima8/usecode/uc_process.h
@@ -58,7 +58,7 @@ public:
 	}
 
 	//! dump some info about this process to pout
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 protected:

--- a/engines/ultima/ultima8/world/actors/actor.cpp
+++ b/engines/ultima/ultima8/world/actors/actor.cpp
@@ -385,10 +385,10 @@ bool Actor::setEquip(Item *item, bool checkwghtvol) {
 	return true;
 }
 
-uint16 Actor::getEquip(uint32 type) {
+uint16 Actor::getEquip(uint32 type) const {
 	const unsigned int backpack_shape = 529; //!! *cough* constant
 
-	Std::list<Item *>::iterator iter;
+	Std::list<Item *>::const_iterator iter;
 	for (iter = _contents.begin(); iter != _contents.end(); ++iter) {
 		uint32 cet = (*iter)->getShapeInfo()->_equipType;
 		bool cbackpack = ((*iter)->getShape() == backpack_shape);
@@ -531,31 +531,31 @@ uint16 Actor::cSetActivity(int activity) {
 	return 0;
 }
 
-uint32 Actor::getArmourClass() {
-	ShapeInfo *si = getShapeInfo();
+uint32 Actor::getArmourClass() const {
+	const ShapeInfo *si = getShapeInfo();
 	if (si->_monsterInfo)
 		return si->_monsterInfo->_armourClass;
 	else
 		return 0;
 }
 
-uint16 Actor::getDefenseType() {
-	ShapeInfo *si = getShapeInfo();
+uint16 Actor::getDefenseType() const {
+	const ShapeInfo *si = getShapeInfo();
 	if (si->_monsterInfo)
 		return si->_monsterInfo->_defenseType;
 	else
 		return 0;
 }
 
-int16 Actor::getDefendingDex() {
+int16 Actor::getDefendingDex() const {
 	return getDex();
 }
 
-int16 Actor::getAttackingDex() {
+int16 Actor::getAttackingDex() const {
 	return getDex();
 }
 
-uint16 Actor::getDamageType() {
+uint16 Actor::getDamageType() const {
 	ShapeInfo *si = getShapeInfo();
 	if (si->_monsterInfo)
 		return si->_monsterInfo->_damageType;
@@ -564,8 +564,8 @@ uint16 Actor::getDamageType() {
 }
 
 
-int Actor::getDamageAmount() {
-	ShapeInfo *si = getShapeInfo();
+int Actor::getDamageAmount() const {
+	const ShapeInfo *si = getShapeInfo();
 	if (si->_monsterInfo) {
 
 		int min = static_cast<int>(si->_monsterInfo->_minDmg);
@@ -1062,7 +1062,7 @@ Actor *Actor::createActor(uint32 shape, uint32 frame) {
 }
 
 
-void Actor::dumpInfo() {
+void Actor::dumpInfo() const {
 	Container::dumpInfo();
 
 	pout << "hp: " << _hitPoints << ", mp: " << _mana << ", str: " << _strength

--- a/engines/ultima/ultima8/world/actors/actor.h
+++ b/engines/ultima/ultima8/world/actors/actor.h
@@ -152,15 +152,15 @@ public:
 	uint16 schedule(uint32 time);
 
 	bool setEquip(Item *item, bool checkwghtvol = false);
-	uint16 getEquip(uint32 type);
+	uint16 getEquip(uint32 type) const;
 
-	virtual uint32 getArmourClass();
-	virtual uint16 getDefenseType();
-	virtual int16 getAttackingDex();
-	virtual int16 getDefendingDex();
+	virtual uint32 getArmourClass() const;
+	virtual uint16 getDefenseType() const;
+	virtual int16 getAttackingDex() const;
+	virtual int16 getDefendingDex() const;
 
-	uint16 getDamageType() override;
-	virtual int getDamageAmount();
+	uint16 getDamageType() const override;
+	virtual int getDamageAmount() const;
 
 	//! calculate the damage an attack against this Actor does.
 	//! \param other the attacker (can be zero)
@@ -214,7 +214,7 @@ public:
 
 	uint16 assignObjId() override; // assign an NPC objid
 
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 

--- a/engines/ultima/ultima8/world/actors/actor_anim_process.cpp
+++ b/engines/ultima/ultima8/world/actors/actor_anim_process.cpp
@@ -630,7 +630,7 @@ void ActorAnimProcess::terminate() {
 	Process::terminate();
 }
 
-void ActorAnimProcess::dumpInfo() {
+void ActorAnimProcess::dumpInfo() const {
 	Process::dumpInfo();
 	pout << "_action: " << _action << ", _dir: " << _dir << Std::endl;
 }

--- a/engines/ultima/ultima8/world/actors/actor_anim_process.h
+++ b/engines/ultima/ultima8/world/actors/actor_anim_process.h
@@ -48,7 +48,7 @@ public:
 
 	void terminate() override;
 
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	Animation::Sequence getAction() const {
 		return _action;

--- a/engines/ultima/ultima8/world/actors/animation_tracker.cpp
+++ b/engines/ultima/ultima8/world/actors/animation_tracker.cpp
@@ -101,7 +101,7 @@ bool AnimationTracker::init(Actor *actor_, Animation::Sequence action_,
 	return true;
 }
 
-unsigned int AnimationTracker::getNextFrame(unsigned int frame) {
+unsigned int AnimationTracker::getNextFrame(unsigned int frame) const {
 	frame++;
 
 	if (frame == _endFrame)
@@ -290,7 +290,7 @@ bool AnimationTracker::step() {
 		// If it succeeded, we proceed as usual
 	}
 
-	Item *support;
+	const Item *support;
 	bool targetok = cm->isValidPosition(tx, ty, tz,
 	                                    _startX, _startY, _startZ,
 	                                    xd, yd, zd,
@@ -409,7 +409,7 @@ bool AnimationTracker::step() {
 	return true;
 }
 
-AnimFrame *AnimationTracker::getAnimFrame() {
+AnimFrame *AnimationTracker::getAnimFrame() const {
 	return &_animAction->frames[_dir][_currentFrame];
 }
 
@@ -452,7 +452,7 @@ void AnimationTracker::setTargetedMode(int32 x_, int32 y_, int32 z_) {
 void AnimationTracker::checkWeaponHit() {
 	int range = _animAction->frames[_dir][_currentFrame].attack_range();
 
-	Actor *a = getActor(_actor);
+	const Actor *a = getActor(_actor);
 	assert(a);
 
 
@@ -542,7 +542,7 @@ void AnimationTracker::updateActorFlags() {
 }
 
 void AnimationTracker::getInterpolatedPosition(int32 &x_, int32 &y_,
-        int32 &z_, int fc) {
+                                               int32 &z_, int fc) const {
 	int32 dx = _x - _prevX;
 	int32 dy = _y - _prevY;
 	int32 dz = _z - _prevZ;
@@ -552,7 +552,7 @@ void AnimationTracker::getInterpolatedPosition(int32 &x_, int32 &y_,
 	z_ = _prevZ + (dz * fc) / (_animAction->_frameRepeat + 1);
 }
 
-void AnimationTracker::getSpeed(int32 &dx, int32 &dy, int32 &dz) {
+void AnimationTracker::getSpeed(int32 &dx, int32 &dy, int32 &dz) const {
 	dx = _x - _prevX;
 	dy = _y - _prevY;
 	dz = _z - _prevZ;

--- a/engines/ultima/ultima8/world/actors/animation_tracker.h
+++ b/engines/ultima/ultima8/world/actors/animation_tracker.h
@@ -67,29 +67,30 @@ public:
 	void updateActorFlags();
 
 	//! get the current position
-	void getPosition(int32 &x, int32 &y, int32 &z) {
+	void getPosition(int32 &x, int32 &y, int32 &z) const {
 		x = _x;
 		y = _y;
 		z = _z;
 	}
 
-	void getInterpolatedPosition(int32 &x_, int32 &y_, int32 &z_, int fc);
+	void getInterpolatedPosition(int32 &x_, int32 &y_, int32 &z_, int fc)
+            const;
 
 	//! get the difference between current position and previous position
-	void getSpeed(int32 &dx, int32 &dy, int32 &dz);
+	void getSpeed(int32 &dx, int32 &dy, int32 &dz) const;
 
 	//! get the current (shape)frame
-	uint32 getFrame() {
+	uint32 getFrame() const {
 		return _shapeFrame;
 	}
 
 	//! get the current AnimAction
-	AnimAction *getAnimAction() {
+	AnimAction *getAnimAction() const {
 		return _animAction;
 	}
 
 	//! get the current AnimFrame
-	AnimFrame *getAnimFrame();
+	AnimFrame *getAnimFrame() const;
 
 	void setTargetedMode(int32 x_, int32 y_, int32 z_);
 
@@ -115,7 +116,7 @@ private:
 		TargetMode
 	};
 
-	unsigned int getNextFrame(unsigned int frame);
+	unsigned int getNextFrame(unsigned int frame) const;
 	void checkWeaponHit();
 
 	unsigned int _startFrame, _endFrame;

--- a/engines/ultima/ultima8/world/actors/combat_process.cpp
+++ b/engines/ultima/ultima8/world/actors/combat_process.cpp
@@ -324,7 +324,7 @@ void CombatProcess::waitForTarget() {
 	}
 }
 
-void CombatProcess::dumpInfo() {
+void CombatProcess::dumpInfo() const {
 	Process::dumpInfo();
 	pout << "Target: " << _target << Std::endl;
 }

--- a/engines/ultima/ultima8/world/actors/combat_process.h
+++ b/engines/ultima/ultima8/world/actors/combat_process.h
@@ -46,7 +46,7 @@ public:
 	void setTarget(ObjId target_);
 	ObjId seekTarget();
 
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 protected:

--- a/engines/ultima/ultima8/world/actors/main_actor.cpp
+++ b/engines/ultima/ultima8/world/actors/main_actor.cpp
@@ -166,10 +166,10 @@ void MainActor::teleport(int mapNum_, int teleport_id) {
 	_justTeleported = true;
 }
 
-uint16 MainActor::getDefenseType() {
+uint16 MainActor::getDefenseType() const {
 	uint16 type = 0;
 
-	Std::list<Item *>::iterator iter;
+	Std::list<Item *>::const_iterator iter;
 	for (iter = _contents.begin(); iter != _contents.end(); ++iter) {
 		uint32 frameNum = (*iter)->getFrame();
 		ShapeInfo *si = (*iter)->getShapeInfo();
@@ -181,10 +181,10 @@ uint16 MainActor::getDefenseType() {
 	return type;
 }
 
-uint32 MainActor::getArmourClass() {
+uint32 MainActor::getArmourClass() const {
 	uint32 armour = 0;
 
-	Std::list<Item *>::iterator iter;
+	Std::list<Item *>::const_iterator iter;
 	for (iter = _contents.begin(); iter != _contents.end(); ++iter) {
 		uint32 frameNum = (*iter)->getFrame();
 		ShapeInfo *si = (*iter)->getShapeInfo();
@@ -199,7 +199,7 @@ uint32 MainActor::getArmourClass() {
 	return armour;
 }
 
-int16 MainActor::getDefendingDex() {
+int16 MainActor::getDefendingDex() const {
 	int16 dex = getDex();
 
 	Item *weapon = getItem(getEquip(ShapeInfo::SE_WEAPON));
@@ -214,7 +214,7 @@ int16 MainActor::getDefendingDex() {
 	return dex;
 }
 
-int16 MainActor::getAttackingDex() {
+int16 MainActor::getAttackingDex() const {
 	int16 dex = getDex();
 
 	Item *weapon = getItem(getEquip(ShapeInfo::SE_WEAPON));
@@ -227,13 +227,13 @@ int16 MainActor::getAttackingDex() {
 	return dex;
 }
 
-uint16 MainActor::getDamageType() {
+uint16 MainActor::getDamageType() const {
 	Item *weapon = getItem(getEquip(ShapeInfo::SE_WEAPON));
 
 	if (weapon) {
 		// weapon equipped?
 
-		ShapeInfo *si = weapon->getShapeInfo();
+		const ShapeInfo *si = weapon->getShapeInfo();
 		assert(si->_weaponInfo);
 
 		return si->_weaponInfo->_damageType;
@@ -242,7 +242,7 @@ uint16 MainActor::getDamageType() {
 	return Actor::getDamageType();
 }
 
-int MainActor::getDamageAmount() {
+int MainActor::getDamageAmount() const {
 	int damage = 0;
 
 	if (getLastAnim() == Animation::kick) {

--- a/engines/ultima/ultima8/world/actors/main_actor.h
+++ b/engines/ultima/ultima8/world/actors/main_actor.h
@@ -70,20 +70,20 @@ public:
 	//! Get the GravityProcess of this Item, creating it if necessary
 	GravityProcess *ensureGravityProcess() override;
 
-	uint32 getArmourClass() override;
-	uint16 getDefenseType() override;
-	int16 getAttackingDex() override;
-	int16 getDefendingDex() override;
+	uint32 getArmourClass() const override;
+	uint16 getDefenseType() const override;
+	int16 getAttackingDex() const override;
+	int16 getDefendingDex() const override;
 
-	uint16 getDamageType() override;
-	int getDamageAmount() override;
+	uint16 getDamageType() const override;
+	int getDamageAmount() const override;
 
 	void setInCombat() override;
 	void clearInCombat() override;
 
 	ProcId die(uint16 DamageType) override;
 
-	Std::string getName() {
+	const Std::string &getName() const {
 		return _name;
 	}
 	void setName(const Std::string &name) {

--- a/engines/ultima/ultima8/world/actors/pathfinder.cpp
+++ b/engines/ultima/ultima8/world/actors/pathfinder.cpp
@@ -48,7 +48,7 @@ struct PathNode {
 // NOTE: this is just to keep some statistics
 static unsigned int expandednodes = 0;
 
-void PathfindingState::load(Actor *_actor) {
+void PathfindingState::load(const Actor *_actor) {
 	_actor->getLocation(_x, _y, _z);
 	_lastAnim = _actor->getLastAnim();
 	_direction = _actor->getDir();
@@ -58,12 +58,12 @@ void PathfindingState::load(Actor *_actor) {
 }
 
 bool PathfindingState::checkPoint(int32 x_, int32 y_, int32 z_,
-                                  int range) {
+                                  int range) const {
 	int distance = (_x - x_) * (_x - x_) + (_y - y_) * (_y - y_) + (_z - z_) * (_z - z_);
 	return distance < range * range;
 }
 
-bool PathfindingState::checkItem(Item *item, int xyRange, int zRange) {
+bool PathfindingState::checkItem(const Item *item, int xyRange, int zRange) const {
 	int32 itemX, itemY, itemZ;
 	int32 itemXd, itemYd, itemZd;
 	int32 itemXmin, itemYmin;
@@ -89,7 +89,7 @@ bool PathfindingState::checkItem(Item *item, int xyRange, int zRange) {
 	return (range <= xyRange);
 }
 
-bool PathfindingState::checkHit(Actor *_actor, Actor *target) {
+bool PathfindingState::checkHit(Actor *_actor, const Actor *target) {
 #if 0
 	pout << "Trying hit in _direction " << _actor->getDirToItemCentre(*target) << Std::endl;
 #endif
@@ -109,7 +109,7 @@ bool PathfindingState::checkHit(Actor *_actor, Actor *target) {
 	return false;
 }
 
-bool PathNodeCmp::operator()(PathNode *n1, PathNode *n2) {
+bool PathNodeCmp::operator()(const PathNode *n1, const PathNode *n2) const {
 	return (n1->heuristicTotalCost < n2->heuristicTotalCost);
 }
 
@@ -172,10 +172,10 @@ bool Pathfinder::canReach() {
 	return pathfind(path);
 }
 
-bool Pathfinder::alreadyVisited(int32 x, int32 y, int32 z) {
+bool Pathfinder::alreadyVisited(int32 x, int32 y, int32 z) const {
 	//! this may need optimization
 
-	Std::list<PathfindingState>::iterator iter;
+	Std::list<PathfindingState>::const_iterator iter;
 
 	for (iter = _visited.begin(); iter != _visited.end(); ++iter)
 		if (iter->checkPoint(x, y, z, 8))
@@ -243,7 +243,7 @@ unsigned int Pathfinder::costHeuristic(PathNode *node) {
 // FIXME: these functions assume that we're using a 2x scaler...
 // (and the whole system is generally a very big hack...)
 
-static void drawbox(Item *item) {
+static void drawbox(const Item *item) {
 	RenderSurface *screen = Ultima8Engine::get_instance()->getRenderScreen();
 	int32 cx, cy, cz;
 
@@ -449,9 +449,9 @@ void Pathfinder::expandNode(PathNode *node) {
 		tracker.evaluateMaxAnimTravel(max_endx, max_endy, dir);
 		if (alreadyVisited(max_endx, max_endy, state._z)) continue;
 		int sqrddist;
-		int x_travel = ABS(max_endx - state._x);
+		const int x_travel = ABS(max_endx - state._x);
 		int xy_maxtravel = x_travel;    // don't have the max(a,b) macro...
-		int y_travel = ABS(max_endy - state._y);
+		const int y_travel = ABS(max_endy - state._y);
 		if (y_travel > xy_maxtravel) xy_maxtravel = y_travel;
 
 		sqrddist = x_travel * x_travel + y_travel * y_travel;

--- a/engines/ultima/ultima8/world/actors/pathfinder.h
+++ b/engines/ultima/ultima8/world/actors/pathfinder.h
@@ -41,10 +41,10 @@ struct PathfindingState {
 	bool _firstStep;
 	bool _combat;
 
-	void load(Actor *actor);
-	bool checkPoint(int32 x_, int32 y_, int32 z_, int range);
-	bool checkItem(Item *item, int xyRange, int zRange);
-	bool checkHit(Actor *actor, Actor *target);
+	void load(const Actor *actor);
+	bool checkPoint(int32 x_, int32 y_, int32 z_, int range) const;
+	bool checkItem(const Item *item, int xyRange, int zRange) const;
+	bool checkHit(Actor *actor, const Actor *target);
 };
 
 struct PathfindingAction {
@@ -57,7 +57,7 @@ struct PathNode;
 
 class PathNodeCmp {
 public:
-	bool operator()(PathNode *n1, PathNode *n2);
+	bool operator()(const PathNode *n1, const PathNode *n2) const;
 };
 
 class Pathfinder {
@@ -95,8 +95,9 @@ protected:
 
 	Std::list<PathNode *> _nodeList;
 
-	bool alreadyVisited(int32 x, int32 y, int32 z);
-	void newNode(PathNode *oldnode, PathfindingState &state, unsigned int steps);
+	bool alreadyVisited(int32 x, int32 y, int32 z) const;
+	void newNode(PathNode *oldnode, PathfindingState &state,
+				 unsigned int steps);
 	void expandNode(PathNode *node);
 	unsigned int costHeuristic(PathNode *node);
 	bool checkTarget(PathNode *node);

--- a/engines/ultima/ultima8/world/container.cpp
+++ b/engines/ultima/ultima8/world/container.cpp
@@ -232,7 +232,7 @@ void Container::destroy(bool delnow) {
 	Item::destroy(delnow);
 }
 
-uint32 Container::getTotalWeight() {
+uint32 Container::getTotalWeight() const {
 	uint32 weight = Item::getTotalWeight();
 
 	// CONSTANT!
@@ -247,7 +247,7 @@ uint32 Container::getTotalWeight() {
 		weight = 300;
 	}
 
-	Std::list<Item *>::iterator iter;
+	Std::list<Item *>::const_iterator iter;
 
 	for (iter = _contents.begin(); iter != _contents.end(); ++iter) {
 		weight += (*iter)->getTotalWeight();
@@ -256,16 +256,16 @@ uint32 Container::getTotalWeight() {
 	return weight;
 }
 
-uint32 Container::getCapacity() {
+uint32 Container::getCapacity() const {
 	uint32 volume = getShapeInfo()->_volume;
 
 	return (volume == 0) ? 32 : volume;
 }
 
-uint32 Container::getContentVolume() {
+uint32 Container::getContentVolume() const {
 	uint32 volume = 0;
 
-	Std::list<Item *>::iterator iter;
+	Std::list<Item *>::const_iterator iter;
 
 	for (iter = _contents.begin(); iter != _contents.end(); ++iter) {
 		volume += (*iter)->getVolume();
@@ -297,7 +297,7 @@ void Container::containerSearch(UCList *itemlist, const uint8 *loopscript,
 	}
 }
 
-void Container::dumpInfo() {
+void Container::dumpInfo() const {
 	Item::dumpInfo();
 
 	pout << "Volume: " << getContentVolume() << "/" << getCapacity()

--- a/engines/ultima/ultima8/world/container.h
+++ b/engines/ultima/ultima8/world/container.h
@@ -88,13 +88,13 @@ public:
 
 	//! Get the weight of the container and its contents
 	//! \return weight
-	uint32 getTotalWeight() override;
+	uint32 getTotalWeight() const override;
 
 	//! Get the container's capacity
-	virtual uint32 getCapacity();
+	virtual uint32 getCapacity() const;
 
 	//! Get the total volume used up by the container's current contents
-	virtual uint32 getContentVolume();
+	virtual uint32 getContentVolume() const;
 
 	//! Assign self and contents an objID
 	//! \return the assiged ID
@@ -106,7 +106,7 @@ public:
 	//! Destroy self
 	void destroy(bool delnow = false) override;
 
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 

--- a/engines/ultima/ultima8/world/current_map.cpp
+++ b/engines/ultima/ultima8/world/current_map.cpp
@@ -453,7 +453,7 @@ void CurrentMap::unsetChunkFast(int32 cx, int32 cy) {
 }
 
 void CurrentMap::areaSearch(UCList *itemlist, const uint8 *loopscript,
-                            uint32 scriptsize, Item *check, uint16 range,
+                            uint32 scriptsize, const Item *check, uint16 range,
                             bool recurse, int32 x, int32 y) {
 	int32 z;
 	int32 xd = 0, yd = 0, zd = 0;
@@ -480,11 +480,11 @@ void CurrentMap::areaSearch(UCList *itemlist, const uint8 *loopscript,
 
 	for (int cx = minx; cx <= maxx; cx++) {
 		for (int cy = miny; cy <= maxy; cy++) {
-			item_list::iterator iter;
+			item_list::const_iterator iter;
 			for (iter = _items[cx][cy].begin();
 			        iter != _items[cx][cy].end(); ++iter) {
 
-				Item *item = *iter;
+				const Item *item = *iter;
 
 				if (item->getExtFlags() & Item::EXT_SPRITE) continue;
 
@@ -492,7 +492,7 @@ void CurrentMap::areaSearch(UCList *itemlist, const uint8 *loopscript,
 				int32 ix, iy, iz;
 				item->getLocation(ix, iy, iz);
 
-				ShapeInfo *info = item->getShapeInfo();
+				const ShapeInfo *info = item->getShapeInfo();
 				int32 ixd, iyd;
 
 				//!! constants
@@ -530,8 +530,8 @@ void CurrentMap::areaSearch(UCList *itemlist, const uint8 *loopscript,
 }
 
 void CurrentMap::surfaceSearch(UCList *itemlist, const uint8 *loopscript,
-                               uint32 scriptsize, Item *check, bool above, bool below,
-                               bool recurse) {
+                               uint32 scriptsize, const Item *check,
+							   bool above, bool below, bool recurse) {
 	int32 origin[3];
 	int32 dims[3];
 	check->getLocationAbsolute(origin[0], origin[1], origin[2]);
@@ -629,9 +629,10 @@ TeleportEgg *CurrentMap::findDestination(uint16 id) {
 
 bool CurrentMap::isValidPosition(int32 x, int32 y, int32 z,
                                  uint32 shape,
-                                 ObjId item, Item **support, uint16 *roof) {
+                                 ObjId item, const Item **support,
+                                 ObjId *roof) const {
 	int xd, yd, zd;
-	ShapeInfo *si = GameData::get_instance()->
+	const ShapeInfo *si = GameData::get_instance()->
 	                getMainShapes()->getShapeInfo(shape);
 	//!! constants
 	xd = si->_x * 32;
@@ -647,7 +648,8 @@ bool CurrentMap::isValidPosition(int32 x, int32 y, int32 z,
 bool CurrentMap::isValidPosition(int32 x, int32 y, int32 z,
                                  int xd, int yd, int zd,
                                  uint32 shapeflags,
-                                 ObjId item_, Item **support_, uint16 *roof_) {
+                                 ObjId item_, const Item **support_,
+                                 ObjId *roof_) const {
 	return isValidPosition(x, y, z,
 	                       INT_MAX_VALUE / 2, INT_MAX_VALUE / 2, INT_MAX_VALUE / 2,
 	                       xd, yd, zd,
@@ -659,13 +661,14 @@ bool CurrentMap::isValidPosition(int32 x, int32 y, int32 z,
                                  int32 startx, int32 starty, int32 startz,
                                  int xd, int yd, int zd,
                                  uint32 shapeflags,
-                                 ObjId item_, Item **support_, uint16 *roof_) {
+                                 ObjId item_, const Item **support_,
+                                 ObjId *roof_) const {
 	const uint32 flagmask = (ShapeInfo::SI_SOLID | ShapeInfo::SI_DAMAGING |
 	                         ShapeInfo::SI_ROOF);
 	const uint32 blockflagmask = (ShapeInfo::SI_SOLID | ShapeInfo::SI_DAMAGING);
 
 	bool valid = true;
-	Item *support = 0;
+	const Item *support = 0;
 	ObjId roof = 0;
 	int32 roofz = 1 << 24; //!! semi-constant
 
@@ -682,10 +685,10 @@ bool CurrentMap::isValidPosition(int32 x, int32 y, int32 z,
 
 	for (int cx = minx; cx <= maxx; cx++) {
 		for (int cy = miny; cy <= maxy; cy++) {
-			item_list::iterator iter;
+			item_list::const_iterator iter;
 			for (iter = _items[cx][cy].begin();
 			        iter != _items[cx][cy].end(); ++iter) {
-				Item *item = *iter;
+				const Item *item = *iter;
 				if (item->getObjId() == item_) continue;
 				if (item->getExtFlags() & Item::EXT_SPRITE) continue;
 

--- a/engines/ultima/ultima8/world/current_map.h
+++ b/engines/ultima/ultima8/world/current_map.h
@@ -85,13 +85,13 @@ public:
 	//! \param x x coordinate of search center if item is 0.
 	//! \param y y coordinate of search center if item is 0.
 	void areaSearch(UCList *itemlist, const uint8 *loopscript,
-	                uint32 scriptsize, Item *item, uint16 range, bool recurse,
-	                int32 x = 0, int32 y = 0);
+	                uint32 scriptsize, const Item *item, uint16 range,
+					bool recurse, int32 x = 0, int32 y = 0);
 
 	// Surface search: Search above and below an item.
 	void surfaceSearch(UCList *itemlist, const uint8 *loopscript,
-	                   uint32 scriptsize, Item *item, bool above, bool below,
-	                   bool recurse = false);
+	                   uint32 scriptsize, const Item *item, bool above,
+					   bool below, bool recurse = false);
 
 	// Surface search: Search above and below an item.
 	void surfaceSearch(UCList *itemlist, const uint8 *loopscript,
@@ -111,19 +111,20 @@ public:
 	                     int32 startx, int32 starty, int32 startz,
 	                     int xd, int yd, int zd, uint32 shapeflags,
 	                     ObjId item,
-	                     Item **support = 0, ObjId *roof = 0);
+	                     const Item **support = 0, ObjId *roof = 0) const;
 
 	// Note that this version of isValidPosition does not look for start
 	// position collisions.
 	bool isValidPosition(int32 x, int32 y, int32 z,
 	                     int xd, int yd, int zd, uint32 shapeflags,
 	                     ObjId item,
-	                     Item **support = 0, ObjId *roof = 0);
+	                     const Item **support = 0, ObjId *roof = 0) const;
 
 	// Note that this version of isValidPosition can not take 'flipped'
 	// into account!
 	bool isValidPosition(int32 x, int32 y, int32 z, uint32 shape,
-	                     ObjId item, Item **support = 0, ObjId *roof = 0);
+	                     ObjId item, const Item **support = 0,
+                         ObjId *roof = 0) const;
 
 	//! Scan for a valid position for item in directions orthogonal to movedir
 	bool scanForValidPosition(int32 x, int32 y, int32 z, Item *item,

--- a/engines/ultima/ultima8/world/egg.cpp
+++ b/engines/ultima/ultima8/world/egg.cpp
@@ -48,7 +48,7 @@ uint16 Egg::hatch() {
 	return callUsecodeEvent_hatch();
 }
 
-void Egg::dumpInfo() {
+void Egg::dumpInfo() const {
 	Item::dumpInfo();
 	pout << "range: " << getXRange() << "," << getYRange()
 	     << ", hatched=" << _hatched << Std::endl;

--- a/engines/ultima/ultima8/world/egg.h
+++ b/engines/ultima/ultima8/world/egg.h
@@ -63,7 +63,7 @@ public:
 		_hatched = false;
 	}
 
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 

--- a/engines/ultima/ultima8/world/gravity_process.cpp
+++ b/engines/ultima/ultima8/world/gravity_process.cpp
@@ -340,7 +340,7 @@ void GravityProcess::fallStopped() {
 	}
 }
 
-void GravityProcess::dumpInfo() {
+void GravityProcess::dumpInfo() const {
 	Process::dumpInfo();
 
 	pout << "_gravity: " << _gravity << ", speed: (" << _xSpeed << ","

--- a/engines/ultima/ultima8/world/gravity_process.h
+++ b/engines/ultima/ultima8/world/gravity_process.h
@@ -47,7 +47,7 @@ public:
 	void run() override;
 	void terminate() override;
 
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 protected:

--- a/engines/ultima/ultima8/world/item.cpp
+++ b/engines/ultima/ultima8/world/item.cpp
@@ -81,7 +81,7 @@ Item::Item()
 Item::~Item() {
 }
 
-void Item::dumpInfo() {
+void Item::dumpInfo() const {
 	pout << "Item " << getObjId() << " (class "
 	     << GetClassType()._className << ", _shape "
 	     << getShape() << ", " << getFrame() << ", (";
@@ -508,13 +508,13 @@ bool Item::isOn(Item &item2) const {
 
 bool Item::canExistAt(int32 x_, int32 y_, int32 z_, bool needsupport) const {
 	CurrentMap *cm = World::get_instance()->getCurrentMap();
-	Item *support;
+	const Item *support;
 	bool valid = cm->isValidPosition(x_, y_, z_, getShape(), getObjId(),
 	                                 &support, 0);
 	return valid && (!needsupport || support);
 }
 
-int Item::getDirToItemCentre(Item &item2) const {
+int Item::getDirToItemCentre(const Item &item2) const {
 	int32 xv, yv, zv;
 	getCentre(xv, yv, zv);
 
@@ -524,7 +524,7 @@ int Item::getDirToItemCentre(Item &item2) const {
 	return Get_WorldDirection(i2y - yv, i2x - xv);
 }
 
-int Item::getRange(Item &item2, bool checkz) const {
+int Item::getRange(const Item &item2, bool checkz) const {
 	int32 thisX, thisY, thisZ;
 	int32 otherX, otherY, otherZ;
 	int32 thisXd, thisYd, thisZd;
@@ -572,11 +572,11 @@ Shape *Item::getShapeObject() const {
 	return _cachedShape;
 }
 
-uint16 Item::getFamily() {
+uint16 Item::getFamily() const {
 	return static_cast<uint16>(getShapeInfo()->_family);
 }
 
-uint32 Item::getWeight() {
+uint32 Item::getWeight() const {
 	uint32 weight = getShapeInfo()->_weight;
 
 	switch (getShapeInfo()->_family) {
@@ -589,11 +589,11 @@ uint32 Item::getWeight() {
 	}
 }
 
-uint32 Item::getTotalWeight() {
+uint32 Item::getTotalWeight() const {
 	return getWeight();
 }
 
-uint32 Item::getVolume() {
+uint32 Item::getVolume() const {
 	// invisible items (trap markers and such) don't take up volume
 	if (getFlags() & FLG_INVISIBLE) return 0;
 
@@ -1537,7 +1537,7 @@ void Item::explode() {
 	}
 }
 
-uint16 Item::getDamageType() {
+uint16 Item::getDamageType() const {
 	ShapeInfo *si = getShapeInfo();
 	if (si->_weaponInfo) {
 		return si->_weaponInfo->_damageType;

--- a/engines/ultima/ultima8/world/item.h
+++ b/engines/ultima/ultima8/world/item.h
@@ -238,7 +238,7 @@ public:
 
 	//! Get the family of the shape number of this Item. (This is a
 	//! member of the ShapeInfo object.)
-	uint16 getFamily();
+	uint16 getFamily() const;
 
 	//! Check if we can merge with another item.
 	bool canMergeWith(Item *other);
@@ -271,11 +271,11 @@ public:
 
 	//! Get direction from centre to another item's centre.
 	//! Undefined if either item is contained or equipped.
-	int getDirToItemCentre(Item &item2) const;
+	int getDirToItemCentre(const Item &item2) const;
 
 	//! get 'distance' to other item. This is the maximum of the differences
 	//! between the x, y (and possibly z) coordinates of the items.
-	int getRange(Item &item2, bool checkz = false) const;
+	int getRange(const Item &item2, bool checkz = false) const;
 
 	//! Check if this item can reach another item. (This includes LoS.)
 	//! \param other item to be reached
@@ -337,19 +337,19 @@ public:
 	virtual GravityProcess *ensureGravityProcess();
 
 	//! Get the weight of this Item
-	virtual uint32 getWeight();
+	virtual uint32 getWeight() const;
 
 	//! Get the weight of this Item and its contents, if any
-	virtual uint32 getTotalWeight();
+	virtual uint32 getTotalWeight() const;
 
 	//! Get the volume this item takes up in a container
-	virtual uint32 getVolume();
+	virtual uint32 getVolume() const;
 
 	//! explode
 	void explode();
 
 	//! get the damage type this object does when hitting something
-	virtual uint16 getDamageType();
+	virtual uint16 getDamageType() const;
 
 	//! receive a hit
 	//! \param other The item delivering the hit
@@ -440,7 +440,7 @@ public:
 	virtual void leaveFastArea();
 
 	//! dump some info about this item to pout
-	void dumpInfo() override;
+	void dumpInfo() const override;
 
 	bool loadData(IDataSource *ids, uint32 version);
 

--- a/engines/ultima/ultima8/world/world.cpp
+++ b/engines/ultima/ultima8/world/world.cpp
@@ -313,7 +313,7 @@ void World::loadItemCachNPCData(IDataSource *itemcach, IDataSource *npcdata) {
 }
 
 
-void World::worldStats() {
+void World::worldStats() const {
 	unsigned int i, mapcount = 0;
 
 	for (i = 0; i < _maps.size(); i++) {
@@ -324,7 +324,7 @@ void World::worldStats() {
 	g_debugger->debugPrintf("World memory stats:\n");
 	g_debugger->debugPrintf("Maps       : %u/256\n", mapcount);
 
-	Actor *av = getMainActor();
+	const Actor *av = getMainActor();
 	g_debugger->debugPrintf("Avatar pos.: ");
 	if (av) {
 		g_debugger->debugPrintf("map %d, (", av->getMapNum());

--- a/engines/ultima/ultima8/world/world.h
+++ b/engines/ultima/ultima8/world/world.h
@@ -111,12 +111,12 @@ public:
 	}
 
 	//! check if the the ethereal void is empty
-	bool etherealEmpty() {
+	bool etherealEmpty() const {
 		return _ethereal.empty();
 	}
 
 	//! return (but don't remove) the top item from the ethereal void
-	ObjId etherealPeek() {
+	ObjId etherealPeek() const {
 		return _ethereal.front();
 	}
 
@@ -126,7 +126,7 @@ public:
 	}
 
 	//! output some statistics about the world
-	void worldStats();
+	void worldStats() const;
 
 	//! save the Maps in World.
 	void saveMaps(ODataSource *ods);


### PR DESCRIPTION
The U8 engine code isn't very const-correct.  This is an attempt to constify things wherever it makes sense.

Sorry for the size of this patch. It's almost entirely adding `const` in different places and changing copies to references at the same time.  This should reduce copies a bit inside the U8 engine and also give the compiler some additional things to optimize (although that's not the motivating reason).

I didn't make any copy->reference changes where I couldn't constify at the same time, so it should be safe behavior-wise.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
