### PR TITLE
COMMON: Fix return value of String::findLastNotOf

### DIFF
--- a/common/str.cpp
+++ b/common/str.cpp
@@ -767,7 +767,7 @@ size_t String::findFirstNotOf(const char *chars, size_t pos) const {
 size_t String::findLastNotOf(char c) const {
 	for (int idx = (int)_size - 1; idx >= 0; --idx) {
 		if ((*this)[idx] != c)
-			return c;
+			return idx;
 	}
 
 	return npos;


### PR DESCRIPTION
The `Common::String::findLastNotOf(char c)` function returns the char it's looking for, rather than the index of that char (compare this with `findLastNotOf(*chars)` which returns `idx`).  I think this is probably wrong.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
