### PR TITLE
DRAGONS: Fix several compiler warnings

### DIFF
--- a/engines/dragons/dragonflg.cpp
+++ b/engines/dragons/dragonflg.cpp
@@ -87,7 +87,7 @@ void Properties::save(uint numberToWrite, Common::WriteStream *out) {
 
 void Properties::print(char *prefix) {
 	char *str = new char[_count + 1];
-	int i = 0;
+	uint i = 0;
 	for (; i < _count; i++) {
 		str[i] = get(i) ? '1' : '0';
 	}

--- a/engines/dragons/font.cpp
+++ b/engines/dragons/font.cpp
@@ -37,7 +37,7 @@ Font::Font(Common::SeekableReadStream &stream, uint32 mapSize, uint32 pixelOffse
 		error("Allocating memory for font map.");
 	}
 
-	for (int i = 0; i < _size; i++) {
+	for (uint i = 0; i < _size; i++) {
 		_map[i] = stream.readUint16LE();
 	}
 
@@ -215,18 +215,18 @@ void FontManager::drawTextDialogBox(uint32 x1, uint32 y1, uint32 x2, uint32 y2) 
 	const uint16 kTileIndexBottomLeft = kTileBaseIndex + 15;
 	const uint16 kTileIndexBottomRight = kTileBaseIndex + 17;
 	// Fill background
-	for (int yc = y1 + 1; yc <= y2 - 1; ++yc) {
-		for (int xc = x1 + 1; xc <= x2 - 1; ++xc) {
+	for (uint yc = y1 + 1; yc <= y2 - 1; ++yc) {
+		for (uint xc = x1 + 1; xc <= x2 - 1; ++xc) {
 			drawBoxChar(xc, yc, kTileIndexBackground);
 		}
 	}
 	// Fill top and bottom rows
-	for (int xc = x1 + 1; xc <= x2 - 1; ++xc) {
+	for (uint xc = x1 + 1; xc <= x2 - 1; ++xc) {
 		drawBoxChar(xc, y1, kTileIndexTop);
 		drawBoxChar(xc, y2, kTileIndexBottom);
 	}
 	// Fill left and right columns
-	for (int yc = y1 + 1; yc <= y2 - 1; ++yc) {
+	for (uint yc = y1 + 1; yc <= y2 - 1; ++yc) {
 		drawBoxChar(x1, yc, kTileIndexLeft);
 		drawBoxChar(x2, yc, kTileIndexRight);
 	}

--- a/engines/dragons/scene.cpp
+++ b/engines/dragons/scene.cpp
@@ -480,7 +480,7 @@ void Scene::drawActorNumber(int16 x, int16 y, uint16 actorId) {
 
 	sprintf(text8, "%d", actorId);
 
-	for (int i = 0; i < strlen(text8); i++) {
+	for (uint i = 0; i < strlen(text8); i++) {
 		text[i] = text8[i];
 	}
 	_vm->_fontManager->addText(x, y, text, strlen(text8), 1);

--- a/engines/dragons/talk.cpp
+++ b/engines/dragons/talk.cpp
@@ -506,7 +506,7 @@ void Talk::displayDialogAroundActor(Actor *actor, uint16 param_2, uint16 *dialog
 }
 
 void Talk::copyTextToBuffer(uint16 *destBuffer, byte *src, uint32 destBufferLength) {
-	for (int i = 0; i < destBufferLength - 1; i++) {
+	for (uint i = 0; i < destBufferLength - 1; i++) {
 		destBuffer[i] = READ_LE_UINT16(src);
 		src += 2;
 		if (destBuffer[i] == 0) {


### PR DESCRIPTION
This PR contains several simple and unrelated commits that address compiler warnings about comparison between signed and unsigned variables.