### PR TITLE
DRAGONS: Fix compiler warnings

### DIFF
--- a/engines/dragons/dragonimg.h
+++ b/engines/dragons/dragonimg.h
@@ -42,7 +42,7 @@ class BigfileArchive;
 
 class DragonImg {
 private:
-	int16 _count;
+	uint16 _count;
 	Img *_imgObjects;
 	byte *_imgData;
 

--- a/engines/dragons/dragonrms.h
+++ b/engines/dragons/dragonrms.h
@@ -42,7 +42,7 @@ class DragonOBD;
 
 class DragonRMS {
 private:
-	int16 _count;
+	uint16 _count;
 	RMS *_rmsObjects;
 	DragonOBD *_dragonOBD;
 public:


### PR DESCRIPTION
This PR contains two commits to fix compiler warnings about signed vs unsigned variables.

In both files/classes, the private member variable  _count is of type int16, but it does not need negative values so it is changed to type uint16.