### PR TITLE
ENGINES: Keep track of the unavailable files in AdvancedDetector

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -399,22 +399,25 @@ ADDetectedGames AdvancedMetaEngine::detectGame(const Common::FSNode &parent, con
 
 	debug(3, "Starting detection in dir '%s'", parent.getPath().c_str());
 
-	// Check which files are included in some ADGameDescription *and* are present.
-	// Compute MD5s and file sizes for these files.
+	// Check which files are included in some ADGameDescription *and* whether
+	// they are present. Compute MD5s and file sizes for the available files.
 	for (descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
 		g = (const ADGameDescription *)descPtr;
 
 		for (fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
 			Common::String fname = fileDesc->fileName;
-			FileProperties tmp;
 
 			if (filesProps.contains(fname))
 				continue;
 
+			FileProperties tmp;
 			if (getFileProperties(parent, allFiles, *g, fname, tmp)) {
 				debug(3, "> '%s': '%s'", fname.c_str(), tmp.md5.c_str());
-				filesProps[fname] = tmp;
 			}
+
+			// Both positive and negative results are cached to avoid
+			// repeatedly checking for files.
+			filesProps[fname] = tmp;
 		}
 	}
 
@@ -445,7 +448,7 @@ ADDetectedGames AdvancedMetaEngine::detectGame(const Common::FSNode &parent, con
 		for (fileDesc = game.desc->filesDescriptions; fileDesc->fileName; fileDesc++) {
 			Common::String tstr = fileDesc->fileName;
 
-			if (!filesProps.contains(tstr)) {
+			if (!filesProps.contains(tstr) || filesProps[tstr].size == -1) {
 				allFilesPresent = false;
 				break;
 			}


### PR DESCRIPTION
Checking if a file exists is somewhat costly on the 3DS. Remembering which files do not exist instead of repeatedly checking for them reduces the time it takes to detect games from ~1 minute to ~10 seconds in some cases.