### PR TITLE
MACVENTURE: Fix compiler warnings

### DIFF
--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -335,7 +335,7 @@ public:
 		composeSurface->clear(kColorGreen);
 
 		const Graphics::Font *font = &_gui->getCurrentFont();
-		uint y = target->h - font->getFontHeight();
+		int y = target->h - font->getFontHeight();
 		for (uint i = _scrollPos; i != 0; i--) {
 			font->drawString(target, _lines[i], textOffset, y, font->getStringWidth(_lines[i]), kColorBlack);
 


### PR DESCRIPTION
This PR fixes multiple compiler warnings about comparison between signed and unsigned variables, as it is reported each time this header is included.

The type int should be large enough to handle calculations between uint16 surface height and int font height.