### PR TITLE
ULTIMA8: Reset palette when showing menu

### DIFF
--- a/engines/ultima/ultima8/graphics/palette_manager.cpp
+++ b/engines/ultima/ultima8/graphics/palette_manager.cpp
@@ -71,7 +71,8 @@ void PaletteManager::resetTransforms() {
 		Palette *pal = _palettes[i];
 		if (!pal) continue;
 		pal->_transform = Transform_None;
-		for (int j = 0; j < 12; j++) pal->_matrix[j] = matrix[j];
+		for (int j = 0; j < 12; j++)
+			pal->_matrix[j] = matrix[j];
 		_renderSurface->CreateNativePalette(pal); // convert to native format
 	}
 }
@@ -140,7 +141,8 @@ void PaletteManager::transformPalette(PalIndex index, int16 matrix[12]) {
 
 	if (!pal) return;
 
-	for (int i = 0; i < 12; i++) pal->_matrix[i] = matrix[i];
+	for (int i = 0; i < 12; i++)
+		pal->_matrix[i] = matrix[i];
 	_renderSurface->CreateNativePalette(pal); // convert to native format
 }
 
@@ -160,7 +162,8 @@ bool PaletteManager::getTransformMatrix(int16 matrix[12], PalIndex index) {
 
 	if (!pal) return false;
 
-	for (int i = 0; i < 12; i++) matrix[i] = pal->_matrix[i];
+	for (int i = 0; i < 12; i++)
+		matrix[i] = pal->_matrix[i];
 	return true;
 }
 

--- a/engines/ultima/ultima8/graphics/palette_manager.cpp
+++ b/engines/ultima/ultima8/graphics/palette_manager.cpp
@@ -155,6 +155,15 @@ void PaletteManager::untransformPalette(PalIndex index) {
 	transformPalette(index, matrix);
 }
 
+bool PaletteManager::getTransformMatrix(int16 matrix[12], PalIndex index) {
+	Palette *pal = getPalette(index);
+
+	if (!pal) return false;
+
+	for (int i = 0; i < 12; i++) matrix[i] = pal->_matrix[i];
+	return true;
+}
+
 void PaletteManager::getTransformMatrix(int16 matrix[12], PalTransforms trans) {
 	switch (trans) {
 	// Normal untransformed palette

--- a/engines/ultima/ultima8/graphics/palette_manager.h
+++ b/engines/ultima/ultima8/graphics/palette_manager.h
@@ -62,6 +62,9 @@ public:
 	//! reset the transformation matrix of a palette
 	void untransformPalette(PalIndex index);
 
+	//! Get the current TransformMatrix for the given index
+	bool getTransformMatrix(int16 matrix[12], PalIndex index);
+
 	// Get a TransformMatrix from a PalTransforms value (-4.11 fixed)
 	static void getTransformMatrix(int16 matrix[12],
 	                               PalTransforms trans);

--- a/engines/ultima/ultima8/gumps/menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/menu_gump.cpp
@@ -40,6 +40,7 @@
 #include "ultima/ultima8/graphics/fonts/font.h"
 #include "ultima/ultima8/graphics/fonts/rendered_text.h"
 #include "ultima/ultima8/graphics/fonts/font_manager.h"
+#include "ultima/ultima8/graphics/palette_manager.h"
 #include "ultima/ultima8/conf/setting_manager.h"
 #include "ultima/ultima8/audio/music_process.h"
 #include "ultima/ultima8/gumps/widgets/edit_widget.h"
@@ -69,15 +70,21 @@ MenuGump::MenuGump(bool nameEntryMode_)
 	MusicProcess *musicprocess = MusicProcess::get_instance();
 	if (musicprocess) _oldMusicTrack = musicprocess->getTrack();
 	else _oldMusicTrack = 0;
+	// Save old palette transform
+	PaletteManager *palman = PaletteManager::get_instance();
+	palman->getTransformMatrix(_oldPalTransform, PaletteManager::Pal_Game);
+	palman->untransformPalette(PaletteManager::Pal_Game);
 }
 
 MenuGump::~MenuGump() {
 }
 
 void MenuGump::Close(bool no_del) {
-	// Restore old music state
+	// Restore old music state and palette
 	MusicProcess *musicprocess = MusicProcess::get_instance();
 	if (musicprocess) musicprocess->playMusic(_oldMusicTrack);
+	PaletteManager *palman = PaletteManager::get_instance();
+	palman->transformPalette(PaletteManager::Pal_Game, _oldPalTransform);
 
 	Mouse *mouse = Mouse::get_instance();
 	mouse->popMouseCursor();

--- a/engines/ultima/ultima8/gumps/menu_gump.h
+++ b/engines/ultima/ultima8/gumps/menu_gump.h
@@ -56,6 +56,7 @@ public:
 protected:
 	bool _nameEntryMode;
 	int _oldMusicTrack;
+	int16 _oldPalTransform[12];
 
 	virtual void selectEntry(int entry);
 };

--- a/engines/ultima/ultima8/world/actors/avatar_death_process.cpp
+++ b/engines/ultima/ultima8/world/actors/avatar_death_process.cpp
@@ -29,6 +29,7 @@
 #include "ultima/ultima8/kernel/kernel.h"
 #include "ultima/ultima8/gumps/main_menu_process.h"
 #include "ultima/ultima8/gumps/gump_notify_process.h"
+#include "ultima/ultima8/graphics/palette_manager.h"
 #include "ultima/ultima8/audio/music_process.h"
 #include "ultima/ultima8/world/get_object.h"
 
@@ -62,6 +63,9 @@ void AvatarDeathProcess::run() {
 		terminate();
 		return;
 	}
+
+	PaletteManager *palman = PaletteManager::get_instance();
+	palman->untransformPalette(PaletteManager::Pal_Game);
 
 	ReadableGump *gump = new ReadableGump(1, 27, 11,
 	                                      _TL_("HERE LIES*THE AVATAR*REST IN PEACE"));


### PR DESCRIPTION
If the avatar dies while tripping on mushrooms or the menu is opened
when the palette is changed (eg, during a scripted fight with the
guards where the screen blackens) then the tombstone and menu palette
are also changed.

This resets the palette temporarily while showing the menu, and
permanently on avatar death.

I'm not totally sure if this is the cleanest way to do it, there may be some better way I'm missing, or some side-effect of doing it this way I haven't noticed - for now it seems to work well in my testing.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
