### PR TITLE
ULTIMA8: Fix apperance of minimap

### DIFF
--- a/engines/ultima/ultima8/gumps/minimap_gump.cpp
+++ b/engines/ultima/ultima8/gumps/minimap_gump.cpp
@@ -62,7 +62,7 @@ void MiniMapGump::PaintThis(RenderSurface *surf, int32 lerp_factor, bool scaled)
 		_lastMapNum = currentmap->getNum();
 	}
 
-	surf->Fill32(0xFFFFAF00, 0, 0, MAP_NUM_CHUNKS * 2 + 1, 1);
+	surf->Fill32(0xFFFFAF00, 0, 0, MAP_NUM_CHUNKS * 2 + 3, 1);
 	surf->Fill32(0xFFFFAF00, 0, 1, 1, MAP_NUM_CHUNKS * 2 + 1);
 	surf->Fill32(0xFFFFAF00, 1, MAP_NUM_CHUNKS * 2 + 1, MAP_NUM_CHUNKS * 2 + 1, 1);
 	surf->Fill32(0xFFFFAF00, MAP_NUM_CHUNKS * 2 + 1, 1, 1, MAP_NUM_CHUNKS * 2 + 1);

--- a/engines/ultima/ultima8/misc/memset_n.h
+++ b/engines/ultima/ultima8/misc/memset_n.h
@@ -55,7 +55,7 @@ inline void memset_32(void *buf, uint32 val, uint32 dwords) {
 		if ((reinterpret_cast<uintptr>(buf) & 1)) {
 			*reinterpret_cast<uint8 *>(buf) = static_cast<uint8>(val & 0xFF);
 			buf = (reinterpret_cast<uint8 *>(buf)) + 1;
-			val = ((val & 0xFF) << 24) || ((val & 0xFFFFFF00) >> 8);
+			val = ((val & 0xFF) << 24) | ((val & 0xFFFFFF00) >> 8);
 			align --;
 		}
 
@@ -63,7 +63,7 @@ inline void memset_32(void *buf, uint32 val, uint32 dwords) {
 		if ((reinterpret_cast<uintptr>(buf) & 2)) {
 			*reinterpret_cast<uint16 *>(buf) = static_cast<uint16>(val & 0xFFFF);
 			buf = (reinterpret_cast<uint16 *>(buf)) + 1;
-			val = ((val & 0xFFFF) << 16) || ((val & 0xFFFF0000) >> 16);
+			val = ((val & 0xFFFF) << 16) | ((val & 0xFFFF0000) >> 16);
 			align -= 2;
 		}
 	}
@@ -73,6 +73,7 @@ inline void memset_32(void *buf, uint32 val, uint32 dwords) {
 
 	// Do the unaligned data
 	if (align) {
+		buf = (reinterpret_cast<uint8 *>(buf)) + dwords * 4;
 		// Ok, shift along by 1 byte
 		if (align == 1) {
 			*reinterpret_cast<uint8 *>(buf) = static_cast<uint8>(val & 0xFF);

--- a/engines/ultima/ultima8/misc/memset_n.h
+++ b/engines/ultima/ultima8/misc/memset_n.h
@@ -98,7 +98,7 @@ inline void memset_16(void *buf, int32 val, uint32 words) {
 	if (words > 1) memset_32(buf, val | val << 16, words>>1);
 
 	// Final word
-	if (words & 1) *(reinterpret_cast<uint16 *>(buf)) = static_cast<uint16>(val & 0xFFFF);
+	if (words & 1) *(reinterpret_cast<uint16 *>(buf) + (words - 1)) = static_cast<uint16>(val & 0xFFFF);
 }
 
 } // End of namespace Ultima8


### PR DESCRIPTION
The minimap appears incorrectly for 2 reasons:
* The memset_{32|16} implementations are buggy - uses a logical or instead
  of a binary or, and it fails to move the buffer pointer after doing
  the aligned section. This becomes more obvious in 16bpp mode.
* The top line is not long enough

This corrects both issues.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
