### PR TITLE
ILLUSIONS: Fix wide text handling logic for big endian systems. (#11236)

### DIFF
--- a/engines/illusions/illusions.cpp
+++ b/engines/illusions/illusions.cpp
@@ -61,17 +61,25 @@
 
 namespace Illusions {
 
-char *debugW2I(byte *wstr) {
+char *debugW2I(uint16 *wstr) {
 	static char buf[65];
 	char *p = buf;
 	uint i = 0;
 	while (*wstr != 0 && i < sizeof(buf) - 1) {
-		*p++ = *wstr;
-		wstr += 2;
+		*p++ = (byte)*wstr;
+		wstr++;
 		i++;
 	}
 	*p = 0;
 	return buf;
+}
+
+void swapBytesInWideString(byte * wstr) {
+#if defined(SCUMM_BIG_ENDIAN)
+	for (byte *ptr = wstr; *ptr != 0; ptr += 2) {
+		WRITE_UINT16(ptr, SWAP_BYTES_16(READ_UINT16(ptr)));
+	}
+#endif
 }
 
 IllusionsEngine::IllusionsEngine(OSystem *syst, const IllusionsGameDescription *gd) :

--- a/engines/illusions/illusions.cpp
+++ b/engines/illusions/illusions.cpp
@@ -74,7 +74,7 @@ char *debugW2I(uint16 *wstr) {
 	return buf;
 }
 
-void swapBytesInWideString(byte * wstr) {
+void swapBytesInWideString(byte *wstr) {
 #if defined(SCUMM_BIG_ENDIAN)
 	for (byte *ptr = wstr; *ptr != 0; ptr += 2) {
 		WRITE_UINT16(ptr, SWAP_BYTES_16(READ_UINT16(ptr)));

--- a/engines/illusions/illusions.h
+++ b/engines/illusions/illusions.h
@@ -39,7 +39,8 @@
 
 namespace Illusions {
 
-char *debugW2I(byte *wstr);
+char *debugW2I(uint16 *wstr);
+void swapBytesInWideString(byte * wstr);
 
 #define ILLUSIONS_SAVEGAME_VERSION 0
 

--- a/engines/illusions/resources/scriptresource.cpp
+++ b/engines/illusions/resources/scriptresource.cpp
@@ -225,7 +225,8 @@ SceneInfo::~SceneInfo() {
 void SceneInfo::load(byte *dataStart, Common::SeekableReadStream &stream) {
 	_id = stream.readUint16LE();
 	_unk = stream.readUint16LE();
-	_name = dataStart + stream.pos();
+	_name = (uint16 *)(dataStart + stream.pos());
+	swapBytesInWideString((byte *)_name);
 	stream.skip(128);
 	_triggerObjectsCount = stream.readUint16LE();
 	_resourcesCount = stream.readUint16LE();

--- a/engines/illusions/resources/scriptresource.h
+++ b/engines/illusions/resources/scriptresource.h
@@ -104,7 +104,7 @@ public:
 protected:
 	uint16 _id;
 	uint16 _unk;
-	byte *_name;
+	uint16 *_name;
 	uint _triggerObjectsCount;
 	TriggerObject *_triggerObjects;
 	uint _resourcesCount;

--- a/engines/illusions/resources/talkresource.cpp
+++ b/engines/illusions/resources/talkresource.cpp
@@ -45,11 +45,18 @@ void TalkEntry::load(byte *dataStart, Common::SeekableReadStream &stream) {
 	uint32 textOffs = stream.readUint32LE();
 	uint32 tblOffs = stream.readUint32LE();
 	uint32 voiceNameOffs = stream.readUint32LE();
-	_text = dataStart + textOffs;
+	_text = (uint16 *)(dataStart + textOffs);
 	_tblPtr = dataStart + tblOffs;
 	_voiceName = dataStart + voiceNameOffs;
 	debug(0, "TalkEntry::load() _talkId: %08X; textOffs: %08X; tblOffs: %08X; voiceNameOffs: %08X",
 		_talkId, textOffs, tblOffs, voiceNameOffs);
+
+#if defined(SCUMM_BIG_ENDIAN)
+	for (byte *ptr = (byte *)_text; ptr != _tblPtr; ptr += 2) {
+		WRITE_UINT16(ptr, SWAP_BYTES_16(READ_UINT16(ptr)));
+	}
+#endif
+
 }
 
 // TalkResource

--- a/engines/illusions/resources/talkresource.h
+++ b/engines/illusions/resources/talkresource.h
@@ -43,7 +43,7 @@ protected:
 struct TalkEntry {
 	uint32 _talkId;
 	//field_4 dd
-	byte *_text;
+	uint16 *_text;
 	byte *_tblPtr;
 	byte *_voiceName;
 	void load(byte *dataStart, Common::SeekableReadStream &stream);

--- a/engines/illusions/threads/talkthread.cpp
+++ b/engines/illusions/threads/talkthread.cpp
@@ -399,9 +399,9 @@ int TalkThread::insertText() {
 	WidthHeight dimensions;
 	_vm->getDefaultTextDimensions(dimensions);
 	uint16 *outTextPtr;
-	_vm->_screenText->insertText((uint16*)_currEntryText, 0x120001, dimensions,
+	_vm->_screenText->insertText(_currEntryText, 0x120001, dimensions,
 		Common::Point(0, 0), TEXT_FLAG_CENTER_ALIGN, 0, 0, 0, 0, 0, outTextPtr);
-	_entryText = (byte*)outTextPtr;
+	_entryText = outTextPtr;
 	Common::Point pt;
 	_vm->getDefaultTextPosition(pt);
 	_vm->_screenText->updateTextInfoPosition(pt);

--- a/engines/illusions/threads/talkthread.h
+++ b/engines/illusions/threads/talkthread.h
@@ -64,8 +64,8 @@ public:
 	uint32 _sequenceId1;
 	uint32 _sequenceId2;
 	byte *_entryTblPtr;
-	byte *_entryText;
-	byte *_currEntryText;
+	uint16 *_entryText;
+	uint16 *_currEntryText;
 	//field30 dd
 	uint32 _namedPointId;
 	uint32 _voiceStartTime;

--- a/engines/illusions/threads/talkthread_duckman.cpp
+++ b/engines/illusions/threads/talkthread_duckman.cpp
@@ -301,9 +301,9 @@ int TalkThread_Duckman::insertText() {
 	WidthHeight dimensions;
 	_vm->getDefaultTextDimensions(dimensions);
 	uint16 *outTextPtr;
-	_vm->_screenText->insertText((uint16*)_currEntryText, 0x120001, dimensions,
+	_vm->_screenText->insertText(_currEntryText, 0x120001, dimensions,
 		Common::Point(0, 0), TEXT_FLAG_CENTER_ALIGN, 0, 0, _color.r, _color.g, _color.b, outTextPtr);
-	_entryText = (byte*)outTextPtr;
+	_entryText = outTextPtr;
 	Common::Point pt;
 	_vm->getDefaultTextPosition(pt);
 	_vm->_screenText->updateTextInfoPosition(pt);

--- a/engines/illusions/threads/talkthread_duckman.h
+++ b/engines/illusions/threads/talkthread_duckman.h
@@ -66,8 +66,8 @@ public:
 	uint32 _namedPointId1;
 	uint32 _namedPointId2;
 	byte *_entryTblPtr;
-	byte *_entryText;
-	byte *_currEntryText;
+	uint16 *_entryText;
+	uint16 *_currEntryText;
 	//field30 dd
 	uint32 _voiceStartTime;
 	uint32 _voiceEndTime;


### PR DESCRIPTION
This should fix the issue with wide text processing on big endian systems.

Could someone try this on a big endian system for me to see if I've fixed it.
