### PR TITLE
ULTIMA8: Free the correct pointer in ~OAutoBufferDataSource

### DIFF
--- a/engines/ultima/ultima8/filesys/odata_source.h
+++ b/engines/ultima/ultima8/filesys/odata_source.h
@@ -359,7 +359,7 @@ public:
 	}
 
 	~OAutoBufferDataSource() override {
-		delete [] _bufPtr;
+		delete [] _buf;
 	}
 
 	void write1(uint32 val) override {

--- a/test/engines/ultima/ultima8/filesys/odata_source.h
+++ b/test/engines/ultima/ultima8/filesys/odata_source.h
@@ -1,0 +1,74 @@
+#include <cxxtest/TestSuite.h>
+#include "engines/ultima/ultima8/filesys/odata_source.h"
+/**
+ * Test suite for the functions in engines/ultima/ultima8/filesys/odata_source.h
+ */
+
+class U8ODataSourceTestSuite : public CxxTest::TestSuite {
+	public:
+	U8ODataSourceTestSuite() {
+	}
+
+	void test_autobuffer_source() {
+		Ultima::Ultima8::OAutoBufferDataSource source(12);
+		TS_ASSERT_EQUALS(source.getSize(), 0);
+		TS_ASSERT_EQUALS(source.getPos(), 0);
+
+		source.write1(0xBEEF);
+		TS_ASSERT_EQUALS(source.getSize(), 1);
+		TS_ASSERT_EQUALS(source.getPos(), 1);
+
+		for (int i = 0; i < 10; i++) {
+			source.write4(0x8088C0DE);
+		}
+		TS_ASSERT_EQUALS(source.getSize(), 41);
+		TS_ASSERT_EQUALS(source.getPos(), 41);
+		source.skip(0);
+		TS_ASSERT_EQUALS(source.getSize(), 41);
+		TS_ASSERT_EQUALS(source.getPos(), 41);
+		// Check trying to skip past the end
+		source.skip(2);
+		TS_ASSERT_EQUALS(source.getSize(), 41);
+		TS_ASSERT_EQUALS(source.getPos(), 41);
+		source.skip(-2);
+		TS_ASSERT_EQUALS(source.getPos(), 39);
+		source.write1(0x99);
+		TS_ASSERT_EQUALS(source.getSize(), 41);
+		TS_ASSERT_EQUALS(source.getPos(), 40);
+		source.seek(2);
+		TS_ASSERT_EQUALS(source.getSize(), 41);
+		TS_ASSERT_EQUALS(source.getPos(), 2);
+
+		const uint8* buf = source.getBuf();
+		TS_ASSERT_EQUALS(buf[0], 0xEF);
+		TS_ASSERT_EQUALS(buf[1], 0xDE);
+		TS_ASSERT_EQUALS(buf[2], 0xC0);
+		TS_ASSERT_EQUALS(buf[3], 0x88);
+		TS_ASSERT_EQUALS(buf[23], 0x88);
+		TS_ASSERT_EQUALS(buf[24], 0x80);
+		TS_ASSERT_EQUALS(buf[35], 0x88);
+		TS_ASSERT_EQUALS(buf[36], 0x80);
+
+		source.clear();
+		TS_ASSERT_EQUALS(source.getSize(), 0);
+		TS_ASSERT_EQUALS(source.getPos(), 0);
+
+		source.write1(0x04030201);
+		source.write2(0x08070605);
+		source.write3(0x0C0B0A09);
+		source.write4(0x100F0E0D);
+
+		buf = source.getBuf();
+		TS_ASSERT_EQUALS(buf[0], 0x01);
+		TS_ASSERT_EQUALS(buf[1], 0x05);
+		TS_ASSERT_EQUALS(buf[2], 0x06);
+		TS_ASSERT_EQUALS(buf[3], 0x09);
+		TS_ASSERT_EQUALS(buf[4], 0x0A);
+		TS_ASSERT_EQUALS(buf[5], 0x0B);
+		TS_ASSERT_EQUALS(buf[6], 0x0D);
+		TS_ASSERT_EQUALS(buf[7], 0x0E);
+		TS_ASSERT_EQUALS(buf[8], 0x0F);
+		TS_ASSERT_EQUALS(buf[9], 0x10);
+	}
+
+};


### PR DESCRIPTION
Also add a unit test for the class to make sure the problem
is fixed.
The unit test doesn't directly detect the problem, it just exercises the class - but it will show this sort of error:
```
Running 282 tests...........................................................................................................................................................................................................................................................................runner(58520,0x113aac5c0) malloc: *** error for object 0x7f8f094004ca: pointer being freed was not allocated
runner(58520,0x113aac5c0) malloc: *** set a breakpoint in malloc_error_break to debug
make: *** [test] Abort trap: 6
```

`~OAutoBufferDataSource()` is freeing the wrong pointer - `bufPtr` is the moving pointer to the next byte to write, but `buf` is the pointer to the start of the range.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
