### PR TITLE
ULTIMA8: Avoid calling erase on empty string in credits

### DIFF
--- a/engines/ultima/ultima8/gumps/credits_gump.cpp
+++ b/engines/ultima/ultima8/gumps/credits_gump.cpp
@@ -98,18 +98,17 @@ void CreditsGump::Close(bool no_del) {
 
 void CreditsGump::extractLine(Std::string &text_,
                               char &modifier, Std::string &line) {
-	if (text_.empty()) {
-		line = "";
-		modifier = 0;
-		return;
-	}
-
-	if (text_[0] == '+' || text_[0] == '&' || text_[0] == '}' || text_[0] == '~' ||
-	        text_[0] == '@') {
+	if (!text_.empty() and (text_[0] == '+' || text_[0] == '&' || text_[0] == '}' ||
+							text_[0] == '~' || text_[0] == '@')) {
 		modifier = text_[0];
 		text_.erase(0, 1);
 	} else {
 		modifier = 0;
+	}
+
+	if (text_.empty()) {
+		line = "";
+		return;
 	}
 
 	Std::string::size_type starpos = text_.find('*');


### PR DESCRIPTION
If a line contains only a modifier, the function continues and then tries to erase from an empty string.  This avoids that.

The credits are still broken in other ways out of scope for this change :)

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
