### PR TITLE
ULTIMA8: Set pitch when configuring a surface texture

### DIFF
--- a/engines/ultima/ultima8/graphics/base_soft_render_surface.cpp
+++ b/engines/ultima/ultima8/graphics/base_soft_render_surface.cpp
@@ -220,6 +220,7 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h) :
 	_rttTex->w = _width;
 	_rttTex->h = _height;
 	_rttTex->_format = TEX_FMT_NATIVE;
+	_rttTex->pitch = _pitch;
 	_rttTex->CalcLOG2s();
 
 	SetPixelsPointer();


### PR DESCRIPTION
This corrects the appearance of the credits.

When the pitch is not configured, effectively the `sy` offset parameter in `_tex->getBasePtr(sx, sy)` (in `SoftRenderSurface<uintX>::Blit`) does nothing, so each credit texture gets stuck at the top of the screen when the y offset is >0.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
