### PR TITLE
ULTIMA8: Make mouse length better match original game

### DIFF
--- a/engines/ultima/ultima8/kernel/mouse.cpp
+++ b/engines/ultima/ultima8/kernel/mouse.cpp
@@ -146,28 +146,29 @@ int Mouse::getMouseLength(int mx, int my) {
 	screen->GetSurfaceDims(dims);
 
 	// For now, reference point is (near) the center of the screen
-	int dx = mx - dims.w / 2;
-	int dy = (dims.h / 2 + 14) - my; //! constant
+	int dx = abs(mx - dims.w / 2);
+	int dy = abs((dims.h / 2 + (dims.h * 14 / 200)) - my); //! constant
 
-	int shortsq = (dims.w / 8);
-	if (dims.h / 6 < shortsq)
-		shortsq = (dims.h / 6);
-	shortsq = shortsq * shortsq;
-
-	int mediumsq = ((dims.w * 4) / 10);
-	if (((dims.h * 4) / 10) < mediumsq)
-		mediumsq = ((dims.h * 4) / 10);
-	mediumsq = mediumsq * mediumsq;
-
-	int dsq = dx * dx + dy * dy;
+	//
+	// The original game switches cursors from small -> medium -> large on
+	// rectangles - in x, ~30px and ~130px away from the avatar (center) on
+	// the 320px screen, and approximately the same proportions in y.
+	//
+	// Modern players may be in a window so give them a little bit more
+	// space to make the large cursor without having to hit the edge.
+	//
+	int xshort = (dims.w * 30 / 320);
+	int xmed = (dims.w * 100 / 320);
+	int yshort = (dims.h * 30 / 320);
+	int ymed = (dims.h * 100 / 320);
 
 	// determine length of arrow
-	if (dsq <= shortsq) {
-		return 0;
-	} else if (dsq <= mediumsq) {
+	if (dx > xmed || dy > ymed) {
+		return 2;
+	} else if (dx > xshort || dy > yshort) {
 		return 1;
 	} else {
-		return 2;
+		return 0;
 	}
 }
 
@@ -178,7 +179,7 @@ int Mouse::getMouseDirection(int mx, int my) {
 
 	// For now, reference point is (near) the center of the screen
 	int dx = mx - dims.w / 2;
-	int dy = (dims.h / 2 + 14) - my; //! constant
+	int dy = (dims.h / 2 + (dims.h * 14 / 200)) - my; //! constant
 
 	return ((Get_direction(dy * 2, dx)) + 1) % 8;
 }


### PR DESCRIPTION
In the original game, the mouse length is determined by some simple rectangles.  The Pentagram version significantly adjusted these, making it harder to walk slowly and too easy to accidentally run.  This mostly restores the original behavior.

I also fixed a bug where the mouse direction would not swivel exactly under the avatar's feet, because the fixed offset (14px) was not scaled with resolution.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
