### PR TITLE
ULTIMA8: Fix some holes in the North Road map

### DIFF
--- a/engines/ultima/ultima8/world/map.cpp
+++ b/engines/ultima/ultima8/world/map.cpp
@@ -81,10 +81,27 @@ static void shiftCoordsToZ(int32 &x, int32 &y, int32 &z, int32 newz) {
 void Map::loadFixed(IDataSource *ds) {
 	loadFixedFormatObjects(_fixedItems, ds, Item::EXT_FIXED);
 
-
 	// U8 hack for missing ground tiles on map 25. See docs/u8bugs.txt
 	if (GAME_IS_U8 && _mapNum == 25) {
 		// TODO
+	}
+
+	// U8 hack for missing ground tiles on map 3 (north road).
+	if (GAME_IS_U8 && _mapNum == 7) {
+		Item *item = ItemFactory::createItem(301, 1, 0, 0, 0, 0,
+											 Item::EXT_FIXED, false);
+		item->setLocation(2815, 25727, 8);
+		_fixedItems.push_back(item);
+
+		item = ItemFactory::createItem(301, 1, 0, 0, 0, 0,
+									   Item::EXT_FIXED, false);
+		item->setLocation(9983, 21157, 8);
+		_fixedItems.push_back(item);
+
+		item = ItemFactory::createItem(301, 1, 0, 0, 0, 0,
+									   Item::EXT_FIXED, false);
+		item->setLocation(13183, 16511, 8);
+		_fixedItems.push_back(item);
 	}
 
 	// U8 hack for missing ground/wall tiles on map 62. See docs/u8bugs.txt


### PR DESCRIPTION
I found a few holes in the North Road (aka Herdsman's Valley) map, some of which you can fall into. The most noticeable one is in the tunnel entrance to the northern end, which can be seen after moving the rubble aside.  The other two are behind cliffs so can't be seen.

As a FYI note, I learned while debugging this that the current map tiles are stored as objects in the savegame, so for these map patches to take effect you can't check with a savegame in that map (or you need to leave that map and go back).

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
