### PR TITLE
BACKENDS: Allow compiling certain backends for standard Linux platforms

### DIFF
--- a/backends/events/gph/gph-events.cpp
+++ b/backends/events/gph/gph-events.cpp
@@ -145,6 +145,40 @@ enum {
 	BUTTON_HELP2        = 54
 };
 
+#else
+
+/* Main Joystick Button Mappings */
+enum {
+	/* Joystick Buttons */
+	BUTTON_A            = 0,
+	BUTTON_B            = 1,
+	BUTTON_X            = 2,
+	BUTTON_Y            = 3,
+	BUTTON_L            = 4,
+	BUTTON_R            = 5,
+	BUTTON_SELECT       = 6,
+	BUTTON_MENU         = 7,
+	BUTTON_CLICK        = 8    // Stick Click
+};
+
+enum {
+	/* Unused Joystick Buttons */
+	BUTTON_VOLUP        = 51,
+	BUTTON_VOLDOWN      = 52,
+	BUTTON_UP           = 53,
+	BUTTON_UPLEFT       = 54,
+	BUTTON_LEFT         = 55,
+	BUTTON_DOWNLEFT     = 56,
+	BUTTON_DOWN         = 57,
+	BUTTON_DOWNRIGHT    = 58,
+	BUTTON_RIGHT        = 59,
+	BUTTON_UPRIGHT      = 60,
+	BUTTON_HOME         = 61,    // Home
+	BUTTON_HOLD         = 62,    // Hold (on Power)
+	BUTTON_HELP         = 63,    // Help I
+	BUTTON_HELP2        = 64     // Help II
+};
+
 #endif
 
 enum {

--- a/backends/platform/gph/gph-backend.cpp
+++ b/backends/platform/gph/gph-backend.cpp
@@ -153,6 +153,7 @@ void OSystem_GPH::initBackend() {
 }
 
 void OSystem_GPH::initSDL() {
+#ifdef SDL_INIT_EVENTTHREAD
 	// Check if SDL has not been initialized
 	if (!_initedSDL) {
 
@@ -166,6 +167,8 @@ void OSystem_GPH::initSDL() {
 
 		_initedSDL = true;
 	}
+#endif
+	OSystem_SDL::initSDL();
 }
 
 void OSystem_GPH::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {

--- a/backends/platform/maemo/maemo.cpp
+++ b/backends/platform/maemo/maemo.cpp
@@ -30,6 +30,7 @@
 #include "backends/platform/maemo/maemo.h"
 #include "backends/events/maemosdl/maemosdl-events.h"
 #include "backends/graphics/maemosdl/maemosdl-graphics.h"
+#include "backends/keymapper/action.h"
 #include "backends/keymapper/keymapper.h"
 #include "backends/keymapper/keymapper-defaults.h"
 #include "common/textconsole.h"

--- a/backends/platform/openpandora/op-backend.cpp
+++ b/backends/platform/openpandora/op-backend.cpp
@@ -141,6 +141,7 @@ void OSystem_OP::initBackend() {
 }
 
 void OSystem_OP::initSDL() {
+#ifdef SDL_INIT_EVENTTHREAD
 	// Check if SDL has not been initialized
 	if (!_initedSDL) {
 
@@ -154,6 +155,8 @@ void OSystem_OP::initSDL() {
 
 		_initedSDL = true;
 	}
+#endif
+	OSystem_SDL::initSDL();
 }
 
 void OSystem_OP::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {

--- a/configure
+++ b/configure
@@ -2858,9 +2858,6 @@ case $_host_os in
 			append_var CXXFLAGS "`getconf LFS_CFLAGS 2>/dev/null`"
 		fi
 		;;
-	maemo)
-		append_var DEFINES "-DMAEMO"
-		;;
 	mingw*)
 		append_var DEFINES "-DWIN32"
 		# append_var DEFINES "-D__USE_MINGW_ANSI_STDIO=0"  # Modern MinGW does not need it
@@ -3108,7 +3105,6 @@ if test -n "$_host"; then
 			_strip=$_host-strip
 			;;
 		dingux)
-			append_var DEFINES "-DDINGUX"
 			append_var DEFINES "-DDISABLE_DOSBOX_OPL"
 			append_var DEFINES "-DREDUCE_MEMORY_USAGE"
 			append_var CXXFLAGS "-msoft-float"
@@ -3215,7 +3211,7 @@ if test -n "$_host"; then
 		gcw0)
 			_sysroot=`$CXX --print-sysroot`
 			_sdlpath=$_sysroot/usr/bin
-			append_var DEFINES "-DDINGUX -DGCW0"
+			append_var DEFINES "-DGCW0"
 			append_var DEFINES "-DREDUCE_MEMORY_USAGE"
 			append_var CXXFLAGS "-mips32"
 			_backend="dingux"
@@ -3227,7 +3223,6 @@ if test -n "$_host"; then
 			_optimization_level=-O3
 			_vkeybd=yes
 			_vorbis=no
-			_sdlconfig=sdl-config
 			_port_mk="backends/platform/dingux/dingux.mk"
 			;;
 		gp2x)
@@ -3282,7 +3277,6 @@ if test -n "$_host"; then
 			append_var CXXFLAGS "-mcpu=arm926ej-s"
 			append_var CXXFLAGS "-fomit-frame-pointer"
 			append_var INCLUDES "-I/usr/X11R6/include"
-			append_var LIBS "-lX11"
 			append_var LIBS "-L/usr/lib"
 
 			_backend="maemo"
@@ -3341,12 +3335,6 @@ if test -n "$_host"; then
 			_mt32emu=no
 			;;
 		openpandora)
-			append_var DEFINES "-DOPENPANDORA"
-			append_var DEFINES "-DREDUCE_MEMORY_USAGE"
-			if test "$_release_build" = no; then
-				append_var DEFINES "-DOP_DEBUG"
-			fi
-
 			# Use -O3 on the OpenPandora for optimized builds.
 			if test "$_optimizations" = yes; then
 				_optimization_level=-O3
@@ -3538,6 +3526,7 @@ case $_backend in
 		;;
 	dingux)
 		append_var DEFINES "-DDINGUX"
+		_sdlconfig=sdl-config
 		_sdl=auto
 		;;
 	ds)
@@ -3553,6 +3542,7 @@ case $_backend in
 		if test "$_debug_build" = yes; then
 			append_var DEFINES "-DGPH_DEBUG"
 		fi
+		_sdlconfig=sdl-config
 		_sdl=auto
 		;;
 	iphone)
@@ -3575,6 +3565,8 @@ case $_backend in
 		;;
 	maemo)
 		append_var DEFINES "-DMAEMO"
+		append_var LIBS "-lX11"
+		_sdlconfig=sdl-config
 		_sdl=auto
 		;;
 	n64)
@@ -3589,6 +3581,11 @@ case $_backend in
 		append_var DEFINES "-DUSE_NULL_DRIVER"
 		;;
 	openpandora)
+		append_var DEFINES "-DOPENPANDORA"
+		append_var DEFINES "-DREDUCE_MEMORY_USAGE"
+		if test "$_release_build" = no; then
+			append_var DEFINES "-DOP_DEBUG"
+		fi
 		_sdl=auto
 		;;
 	ps2)


### PR DESCRIPTION
This is useful for testing changes to the relevant backends, particularly with regards to downscaling or event handling. It isn't a perfect way of testing compared to using actual hardware, but it's better than nothing.

This affects the GPH, Dingux, LinuxMoto, Maemo and OpenPandora backends.