### PR TITLE
ULTIMA8: Remove a bit of redundant logic for getFootpadWorld

### DIFF
--- a/engines/ultima/ultima8/world/current_map.cpp
+++ b/engines/ultima/ultima8/world/current_map.cpp
@@ -698,7 +698,7 @@ bool CurrentMap::isValidPosition(int32 x, int32 y, int32 z,
 					continue; // not an interesting item
 
 				int32 ix, iy, iz, ixd, iyd, izd;
-				si->getFootpadWorld(ixd, iyd, izd, item->getFlags() & Item::FLG_FLIPPED);
+				item->getFootpadWorld(ixd, iyd, izd);
 				item->getLocation(ix, iy, iz);
 
 #if 0
@@ -1016,6 +1016,7 @@ bool CurrentMap::sweepTest(const int32 start[3], const int32 end[3],
 					continue;
 				}
 
+				// Make oext the distance to midpoint in each dim
 				oext[0] /= 2;
 				oext[1] /= 2;
 				oext[2] /= 2;

--- a/engines/ultima/ultima8/world/item.h
+++ b/engines/ultima/ultima8/world/item.h
@@ -611,7 +611,7 @@ inline ShapeInfo *Item::getShapeInfo() const {
 }
 
 inline void Item::getFootpadData(int32 &X, int32 &Y, int32 &Z) const {
-	ShapeInfo *si = getShapeInfo();
+	const ShapeInfo *si = getShapeInfo();
 	Z = si->_z;
 
 	if (_flags & Item::FLG_FLIPPED) {
@@ -625,16 +625,8 @@ inline void Item::getFootpadData(int32 &X, int32 &Y, int32 &Z) const {
 
 // like getFootpadData, but scaled to world coordinates
 inline void Item::getFootpadWorld(int32 &X, int32 &Y, int32 &Z) const {
-	ShapeInfo *si = getShapeInfo();
-	Z = si->_z * 8;
-
-	if (_flags & Item::FLG_FLIPPED) {
-		X = si->_y * 32;
-		Y = si->_x * 32;
-	} else {
-		X = si->_x * 32;
-		Y = si->_y * 32;
-	}
+	const ShapeInfo *si = getShapeInfo();
+	si->getFootpadWorld(X, Y, Z, _flags & Item::FLG_FLIPPED);
 }
 
 inline void Item::getLocation(int32 &X, int32 &Y, int32 &Z) const {


### PR DESCRIPTION
While debugging this code I got lost because there are a few places that calculate exactly the same thing.  This removes a bit of redundancy.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
