### PR TITLE
MOHAWK: RIVEN: Refresh cursor before transitions

### DIFF
--- a/engines/mohawk/riven_card.cpp
+++ b/engines/mohawk/riven_card.cpp
@@ -928,6 +928,7 @@ RivenHotspot *RivenCard::getCurHotspot() const {
 
 RivenScriptPtr RivenCard::onMouseDown(const Common::Point &mouse) {
 	RivenScriptPtr script = onMouseMove(mouse);
+	updateMouseCursor();
 
 	_pressedHotspot = _hoveredHotspot;
 

--- a/engines/mohawk/riven_graphics.cpp
+++ b/engines/mohawk/riven_graphics.cpp
@@ -29,6 +29,7 @@
 #include "mohawk/riven_video.h"
 
 #include "common/system.h"
+#include "common/memstream.h"
 
 #include "engines/util.h"
 
@@ -354,7 +355,11 @@ RivenGraphics::~RivenGraphics() {
 }
 
 MohawkSurface *RivenGraphics::decodeImage(uint16 id) {
-	MohawkSurface *surface = _bitmapDecoder->decodeImage(_vm->getResource(ID_TBMP, id));
+	Common::SeekableReadStream *resourceStream = _vm->getResource(ID_TBMP, id);
+	Common::SeekableReadStream *memResourceStream = resourceStream->readStream(resourceStream->size());
+	delete resourceStream;
+
+	MohawkSurface *surface = _bitmapDecoder->decodeImage(memResourceStream);surface->convertToTrueColor();
 	surface->convertToTrueColor();
 	return surface;
 }


### PR DESCRIPTION
This fixes a quirk on the 3DS port where touching a transition-triggering hotspot would move the cursor, but not update the cursor image until after the transition finished.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
