### PR TITLE
ENGINES: Exposed ConfigDialog

### DIFF
--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -48,19 +48,6 @@
 #include "gui/KeysDialog.h"
 #endif
 
-class ConfigDialog : public GUI::OptionsDialog {
-protected:
-#ifdef GUI_ENABLE_KEYSDIALOG
-	GUI::Dialog		*_keysDialog;
-#endif
-
-public:
-	ConfigDialog(bool subtitleControls);
-	~ConfigDialog() override;
-
-	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
-};
-
 MainMenuDialog::MainMenuDialog(Engine *engine)
 	: GUI::Dialog("GlobalMenu"), _engine(engine) {
 	_backgroundType = GUI::ThemeEngine::kDialogBackgroundSpecial;
@@ -134,7 +121,7 @@ void MainMenuDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint3
 		save();
 		break;
 	case kOptionsCmd: {
-		ConfigDialog configDialog(_engine->hasFeature(Engine::kSupportsSubtitleOptions));
+		GUI::ConfigDialog configDialog(_engine->hasFeature(Engine::kSupportsSubtitleOptions));
 		configDialog.runModal();
 		break;
 	}
@@ -256,6 +243,8 @@ enum {
 	kKeysCmd = 'KEYS'
 };
 
+namespace GUI {
+
 // FIXME: We use the empty string as domain name here. This tells the
 // ConfigManager to use the 'default' domain for all its actions. We do that
 // to get as close as possible to editing the 'active' settings.
@@ -281,9 +270,15 @@ enum {
 // These changes will achieve two things at once: Allow us to get rid of using
 //  "" as value for the domain, and in fact provide a somewhat better user
 // experience at the same time.
-ConfigDialog::ConfigDialog(bool subtitleControls)
-	: GUI::OptionsDialog("", "GlobalConfig") {
+ConfigDialog::ConfigDialog(bool subtitleControls) : GUI::OptionsDialog("", "GlobalConfig") {
+	init(subtitleControls);
+}
 
+ConfigDialog::ConfigDialog() : GUI::OptionsDialog("", "GlobalConfig") {
+	init(g_engine->hasFeature(Engine::kSupportsSubtitleOptions));
+}
+
+void ConfigDialog::init(bool subtitleControls) {
 	// GUI:  Add tab widget
 	GUI::TabWidget *tab = new GUI::TabWidget(this, "GlobalConfig.TabWidget");
 
@@ -362,3 +357,5 @@ void ConfigDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 
 		GUI::OptionsDialog::handleCommand (sender, cmd, data);
 	}
 }
+
+} // End of namespace GUI

--- a/engines/dialogs.h
+++ b/engines/dialogs.h
@@ -24,6 +24,7 @@
 #define GLOBAL_DIALOGS_H
 
 #include "gui/dialog.h"
+#include "gui/options.h"
 
 class Engine;
 
@@ -75,5 +76,25 @@ protected:
 	GUI::SaveLoadChooser *_loadDialog;
 	GUI::SaveLoadChooser *_saveDialog;
 };
+
+namespace GUI {
+
+class ConfigDialog : public OptionsDialog {
+private:
+	void init(bool subtitleControls);
+protected:
+#ifdef GUI_ENABLE_KEYSDIALOG
+	Dialog *_keysDialog;
+#endif
+
+public:
+	ConfigDialog(bool subtitleControls);
+	ConfigDialog();
+	~ConfigDialog() override;
+
+	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
+};
+
+} // End of namespace GUI
 
 #endif

--- a/engines/tsage/dialogs.cpp
+++ b/engines/tsage/dialogs.cpp
@@ -21,11 +21,7 @@
  */
 
 #include "common/translation.h"
-
-#include "gui/dialog.h"
-#include "gui/options.h"
-#include "gui/widget.h"
-
+#include "engines/dialogs.h"
 #include "tsage/tsage.h"
 #include "tsage/core.h"
 #include "tsage/dialogs.h"
@@ -88,29 +84,6 @@ int MessageDialog::show2(const Common::String &message, const Common::String &bt
 
 	delete dlg;
 	return result;
-}
-
-/*--------------------------------------------------------------------------*/
-
-class ConfigDialog : public GUI::OptionsDialog {
-public:
-	ConfigDialog();
-};
-
-ConfigDialog::ConfigDialog() : GUI::OptionsDialog("", "GlobalConfig") {
-	//
-	// Sound controllers
-	//
-
-	addVolumeControls(this, "GlobalConfig.");
-	setVolumeSettingsState(true); // could disable controls by GUI options
-
-	//
-	// Add the buttons
-	//
-
-	new GUI::ButtonWidget(this, "GlobalConfig.Ok", _("~O~K"), 0, GUI::kOKCmd);
-	new GUI::ButtonWidget(this, "GlobalConfig.Cancel", _("~C~ancel"), 0, GUI::kCloseCmd);
 }
 
 /*--------------------------------------------------------------------------*/
@@ -192,7 +165,7 @@ void ModalDialog::drawFrame() {
 /*--------------------------------------------------------------------------*/
 
 void SoundDialog::execute() {
-	ConfigDialog *dlg = new ConfigDialog();
+	GUI::ConfigDialog *dlg = new GUI::ConfigDialog();
 	dlg->runModal();
 	delete dlg;
 	g_globals->_soundManager.syncSounds();

--- a/engines/ultima/ultima8/gumps/menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/menu_gump.cpp
@@ -46,6 +46,7 @@
 #include "ultima/ultima8/filesys/idata_source.h"
 #include "ultima/ultima8/filesys/odata_source.h"
 #include "ultima/ultima8/meta_engine.h"
+#include "engines/dialogs.h"
 
 namespace Ultima {
 namespace Ultima8 {
@@ -229,8 +230,9 @@ void MenuGump::selectEntry(int entry) {
 		U8SaveGump::showLoadSaveGump(this, entry == 3);
 		break;
 	case 4: {
-		// Options
-		// TODO: Show options
+		// Options - show the ScummVM options dialog
+		GUI::ConfigDialog dlg;
+		dlg.runModal();
 	}
 	break;
 	case 5: // Credits


### PR DESCRIPTION
This is a fairly minor change, but since it touches the GMM, I thought it worthwhile doing as a pull request for review.

Essentially, it moves the class declaration of ConfigDialog, used for the GMM Options/keymapper dialog, from the code file to the header file. This lets it be instantiated by engines that have in-game options buttons, but whose settings are all now handled by the ScummVM GUI. As is the case for Ultima VIII. I briefly considered moving the class's code into an entirely new file, but for now it still remains in the engines/dialogs.cpp/.h

Additionally, the TsAGE also used the dialog, but made the mistake of creating it's own sublcass of GUI::OptionsDialog rather than exposing the existing one. Due to various changes over time, this "mini" config dialog is now erroring out. Luckily, the error seems to have previously gone unnoticed up till now. I've removed the custom ConfigDialog from the TsAGE code and changed it to use the now exposed ConfigDialog as well.
