### PR TITLE
KEYMAPPER: Map Joy_X to skip lines by default

### DIFF
--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -95,6 +95,7 @@ Common::KeymapArray MetaEngine::initKeymaps(const char *target) const {
 	act = new Action("SKLI", _("Skip line"));
 	act->setKeyEvent(KeyState(KEYCODE_PERIOD, '.'));
 	act->addDefaultInputMapping("PERIOD");
+	act->addDefaultInputMapping("JOY_X");
 	engineKeyMap->addAction(act);
 
 	act = new Action("PIND", _("Predictive input dialog"));


### PR DESCRIPTION
This maps game controller X button to '.' (skip line of dialog) by default. I don't see a reason not to map it like this, since that is how it used to be before the keymapper, see here: https://wiki.scummvm.org/index.php?title=Nintendo_Switch

