### PR TITLE
ULTIMA8: Replace 0s with nullptr where applicable

### DIFF
--- a/engines/ultima/ultima8/audio/audio_channel.cpp
+++ b/engines/ultima/ultima8/audio/audio_channel.cpp
@@ -42,7 +42,7 @@ namespace Ultima8 {
 #define RANGE_REDUX(x)  (((x) * 27) >> 5)
 
 AudioChannel::AudioChannel(Audio::Mixer *mixer, uint32 sampleRate, bool stereo) :
-		_mixer(mixer), _decompressorSize(0), _frameSize(0), _loop(0), _sample(0),
+		_mixer(mixer), _decompressorSize(0), _frameSize(0), _loop(0), _sample(nullptr),
 		_frameEvenOdd(0), _paused(false), _priority(0) {
 }
 
@@ -102,14 +102,14 @@ void AudioChannel::playSample(AudioSample *sample, int loop, int priority, bool 
 
 bool AudioChannel::isPlaying() {
 	if (!_mixer->isSoundHandleActive(_soundHandle))
-		_sample = 0;
+		_sample = nullptr;
 
-	return _sample != 0;
+	return _sample != nullptr;
 }
 
 void AudioChannel::stop() {
 	_mixer->stopHandle(_soundHandle);
-	_sample = 0;
+	_sample = nullptr;
 }
 
 void AudioChannel::setPaused(bool paused) {

--- a/engines/ultima/ultima8/audio/audio_mixer.cpp
+++ b/engines/ultima/ultima8/audio/audio_mixer.cpp
@@ -33,9 +33,9 @@
 namespace Ultima {
 namespace Ultima8 {
 
-AudioMixer *AudioMixer::_audioMixer = 0;
+AudioMixer *AudioMixer::_audioMixer = nullptr;
 
-AudioMixer::AudioMixer(Audio::Mixer *mixer) : _mixer(mixer), _midiPlayer(0) {
+AudioMixer::AudioMixer(Audio::Mixer *mixer) : _mixer(mixer), _midiPlayer(nullptr) {
 	_audioMixer = this;
 	
 	_channels.resize(CHANNEL_COUNT);

--- a/engines/ultima/ultima8/audio/audio_process.cpp
+++ b/engines/ultima/ultima8/audio/audio_process.cpp
@@ -42,7 +42,7 @@ namespace Ultima8 {
 // p_dynamic_class stuff
 DEFINE_RUNTIME_CLASSTYPE_CODE(AudioProcess, Process)
 
-AudioProcess *AudioProcess::_theAudioProcess = 0;
+AudioProcess *AudioProcess::_theAudioProcess = nullptr;
 
 AudioProcess::AudioProcess(void) : _paused(0) {
 	_theAudioProcess = this;
@@ -50,7 +50,7 @@ AudioProcess::AudioProcess(void) : _paused(0) {
 }
 
 AudioProcess::~AudioProcess(void) {
-	_theAudioProcess = 0;
+	_theAudioProcess = nullptr;
 }
 
 bool AudioProcess::calculateSoundVolume(ObjId objId, int16 &lVol, int16 &rVol) const {

--- a/engines/ultima/ultima8/audio/music_flex.cpp
+++ b/engines/ultima/ultima8/audio/music_flex.cpp
@@ -32,7 +32,7 @@ DEFINE_RUNTIME_CLASSTYPE_CODE(MusicFlex, Archive)
 
 
 MusicFlex::MusicFlex(IDataSource *ds) : Archive(ds) {
-	_songs = 0;
+	_songs = nullptr;
 	Std::memset(_info, 0, sizeof(SongInfo *) * 128);
 	loadSongInfo();
 }
@@ -56,8 +56,21 @@ MusicFlex::SongInfo::SongInfo() : _numMeasures(0), _loopJump(0) {
 MusicFlex::SongInfo::~SongInfo() {
 	for (int i = 0; i < 128; i++) {
 		delete [] _transitions[i];
-		_transitions[i] = 0;
+		_transitions[i] = nullptr;
 	}
+}
+
+XMidiFile *MusicFlex::getXMidi(uint32 index) {
+	if (index >= _count)
+		return nullptr;
+	cache(index);
+	return _songs[index];
+}
+
+const MusicFlex::SongInfo *MusicFlex::getSongInfo(uint32 index) const {
+	if (index > 127)
+		return nullptr;
+	return _info[index];
 }
 
 void MusicFlex::cache(uint32 index) {
@@ -72,7 +85,7 @@ bool MusicFlex::isCached(uint32 index) const {
 	if (index >= _count) return false;
 	if (!_songs) return false;
 
-	return (_songs[index] != 0);
+	return (_songs[index] != nullptr);
 }
 
 IDataSource *MusicFlex::getAdlibTimbres() {

--- a/engines/ultima/ultima8/audio/music_flex.h
+++ b/engines/ultima/ultima8/audio/music_flex.h
@@ -49,17 +49,10 @@ public:
 	~MusicFlex() override;
 
 	//! Get an xmidi
-	XMidiFile *getXMidi(uint32 index) {
-		if (index >= _count) return 0;
-		cache(index);
-		return _songs[index];
-	}
+	XMidiFile *getXMidi(uint32 index);
 
 	//! Get song info
-	const SongInfo *getSongInfo(uint32 index) const {
-		if (index > 127) return 0;
-		return _info[index];
-	}
+	const SongInfo *getSongInfo(uint32 index) const;
 
 	//! Get the Adlib Timbres (index 259)
 	IDataSource *getAdlibTimbres();

--- a/engines/ultima/ultima8/audio/music_process.cpp
+++ b/engines/ultima/ultima8/audio/music_process.cpp
@@ -35,9 +35,9 @@ namespace Ultima8 {
 // p_dynamic_cast stuff
 DEFINE_RUNTIME_CLASSTYPE_CODE(MusicProcess, Process)
 
-MusicProcess *MusicProcess::_theMusicProcess = 0;
+MusicProcess *MusicProcess::_theMusicProcess = nullptr;
 
-MusicProcess::MusicProcess() : _midiPlayer(0), _state(PLAYBACK_NORMAL),
+MusicProcess::MusicProcess() : _midiPlayer(nullptr), _state(PLAYBACK_NORMAL),
 		_currentTrack(0), _combatMusicActive(false) {
 	Std::memset(_songBranches, (byte)-1, 128 * sizeof(int));
 }
@@ -53,7 +53,7 @@ MusicProcess::MusicProcess(MidiPlayer *player) : _midiPlayer(player),
 
 MusicProcess::~MusicProcess() {
 	_midiPlayer->stop();
-	_theMusicProcess = 0;
+	_theMusicProcess = nullptr;
 }
 
 void MusicProcess::playMusic(int track) {

--- a/engines/ultima/ultima8/audio/sound_flex.cpp
+++ b/engines/ultima/ultima8/audio/sound_flex.cpp
@@ -32,13 +32,19 @@ namespace Ultima8 {
 DEFINE_RUNTIME_CLASSTYPE_CODE(SoundFlex, Archive)
 
 
-SoundFlex::SoundFlex(IDataSource *ds) : Archive(ds) {
-	_samples = 0;
+SoundFlex::SoundFlex(IDataSource *ds) : Archive(ds), _samples(nullptr) {
 }
 
 SoundFlex::~SoundFlex() {
 	Archive::uncache();
 	delete [] _samples;
+}
+
+AudioSample *SoundFlex::getSample(uint32 index) {
+	if (index >= _count)
+		return nullptr;
+	cache(index);
+	return _samples[index];
 }
 
 void SoundFlex::cache(uint32 index) {
@@ -65,14 +71,14 @@ void SoundFlex::uncache(uint32 index) {
 	if (!_samples) return;
 
 	delete _samples[index];
-	_samples[index] = 0;
+	_samples[index] = nullptr;
 }
 
 bool SoundFlex::isCached(uint32 index) const {
 	if (index >= _count) return false;
 	if (!_samples) return false;
 
-	return (_samples[index] != 0);
+	return (_samples[index] != nullptr);
 }
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/audio/sound_flex.h
+++ b/engines/ultima/ultima8/audio/sound_flex.h
@@ -39,11 +39,7 @@ public:
 	~SoundFlex() override;
 
 	//! Get an audiosample
-	AudioSample *getSample(uint32 index) {
-		if (index >= _count) return 0;
-		cache(index);
-		return _samples[index];
-	}
+	AudioSample *getSample(uint32 index);
 
 	void cache(uint32 index) override;
 	void uncache(uint32 index) override;

--- a/engines/ultima/ultima8/conf/config_file_manager.cpp
+++ b/engines/ultima/ultima8/conf/config_file_manager.cpp
@@ -30,7 +30,7 @@ namespace Ultima8 {
 
 using Std::string;
 
-ConfigFileManager *ConfigFileManager::_configFileManager = 0;
+ConfigFileManager *ConfigFileManager::_configFileManager = nullptr;
 
 ConfigFileManager::ConfigFileManager() {
 	debugN(MM_INFO, "Creating ConfigFileManager...\n");
@@ -43,7 +43,7 @@ ConfigFileManager::~ConfigFileManager() {
 
 	ConfMan.flushToDisk();
 	clear();
-	_configFileManager = 0;
+	_configFileManager = nullptr;
 }
 
 bool ConfigFileManager::readConfigFile(string fname, istring root,
@@ -106,7 +106,7 @@ void ConfigFileManager::clearRoot(istring root) {
 }
 
 bool ConfigFileManager::exists(istring key) {
-	return ConfMan.hasKey(key) || (findKeyINI(key) != 0);
+	return ConfMan.hasKey(key) || (findKeyINI(key) != nullptr);
 }
 
 bool ConfigFileManager::get(istring key, string &ret) {
@@ -275,7 +275,7 @@ INIFile *ConfigFileManager::findKeyINI(istring key) {
 			return (*i);
 	}
 
-	return 0;
+	return nullptr;
 }
 
 INIFile *ConfigFileManager::findWriteINI(istring key) {
@@ -285,7 +285,7 @@ INIFile *ConfigFileManager::findWriteINI(istring key) {
 			return (*i);
 	}
 
-	return 0;
+	return nullptr;
 }
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/conf/ini_file.cpp
+++ b/engines/ultima/ultima8/conf/ini_file.cpp
@@ -45,7 +45,7 @@ INIFile::~INIFile() {
 }
 
 bool INIFile::Section::hasKey(istring key) {
-	return (getKey(key) != 0);
+	return (getKey(key) != nullptr);
 }
 
 INIFile::KeyValue *INIFile::Section::getKey(istring key) {
@@ -55,7 +55,7 @@ INIFile::KeyValue *INIFile::Section::getKey(istring key) {
 			return &(*i);
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 void INIFile::Section::setKey(istring key, string value) {
@@ -322,7 +322,7 @@ INIFile::Section *INIFile::getSection(istring section) {
 			return &(*i);
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 bool INIFile::splitKey(istring key, istring &section, istring &sectionkey) {
@@ -340,7 +340,7 @@ bool INIFile::splitKey(istring key, istring &section, istring &sectionkey) {
 bool INIFile::hasSection(istring section) {
 	if (!stripRoot(section)) return false;
 
-	return (getSection(section) != 0);
+	return (getSection(section) != nullptr);
 }
 
 bool INIFile::hasKey(istring key) {

--- a/engines/ultima/ultima8/conf/setting_manager.cpp
+++ b/engines/ultima/ultima8/conf/setting_manager.cpp
@@ -28,7 +28,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-SettingManager *SettingManager::_settingManager = 0;
+SettingManager *SettingManager::_settingManager = nullptr;
 
 SettingManager::SettingManager() {
 	debugN(MM_INFO, "Creating SettingManager...\n");
@@ -45,7 +45,7 @@ SettingManager::SettingManager() {
 SettingManager::~SettingManager() {
 	debugN(MM_INFO, "Destroying SettingManager...\n");
 
-	_settingManager = 0;
+	_settingManager = nullptr;
 }
 
 bool SettingManager::readConfigFile(Std::string fname, bool readonly) {

--- a/engines/ultima/ultima8/convert/convert_shape.cpp
+++ b/engines/ultima/ultima8/convert/convert_shape.cpp
@@ -34,6 +34,29 @@ namespace Ultima8 {
 extern int shapenum;
 #endif
 
+void ConvertShapeFrame::Free() {
+	delete [] _line_offsets;
+	_line_offsets = nullptr;
+
+	delete [] _rle_data;
+	_rle_data = nullptr;
+}
+
+ConvertShape::ConvertShape() : _num_frames(0), _frames(nullptr)
+{
+}
+
+void ConvertShape::Free()
+{
+	if (_frames)
+		for(uint32 i = 0; i < _num_frames; ++i)
+			_frames[i].Free();
+
+	delete [] _frames;
+	_frames = nullptr;
+	_num_frames = 0;
+}
+
 void ConvertShape::Read(IDataSource *source, const ConvertShapeFormat *csf, uint32 real_len)
 {
 	// Just to be safe
@@ -195,19 +218,19 @@ void ConvertShapeFrame::Read(IDataSource *source, const ConvertShapeFormat *csf,
 		
 #endif
 	} else 
-		_line_offsets = 0;
+		_line_offsets = nullptr;
 
 	// Read the RLE Data
 	if (_bytes_rle) {
 		_rle_data = new uint8[_bytes_rle];
 		source->read(_rle_data, _bytes_rle);
 	} else 
-		_rle_data = 0;
+		_rle_data = nullptr;
 }
 
 void ConvertShapeFrame::ReadCmpFrame(IDataSource *source, const ConvertShapeFormat *csf, const uint8 special[256], ConvertShapeFrame *prev)
 {
-	static OAutoBufferDataSource *rlebuf = 0;
+	static OAutoBufferDataSource *rlebuf = nullptr;
 	uint8 outbuf[512];
 
 	// Read unknown

--- a/engines/ultima/ultima8/convert/convert_shape.h
+++ b/engines/ultima/ultima8/convert/convert_shape.h
@@ -79,13 +79,7 @@ struct ConvertShapeFrame {
 	int32				_bytes_rle;			// Number of bytes of RLE Data
 	uint8				*_rle_data;
 
-	void Free() {
-		delete [] _line_offsets;
-		_line_offsets = 0;
-
-		delete [] _rle_data;
-		_rle_data = 0;
-	}
+	void Free();
 
 	void Read(IDataSource *source, const ConvertShapeFormat *csf, uint32 frame_length);
 
@@ -104,26 +98,14 @@ class ConvertShape
 	ConvertShapeFrame	*_frames;
 
 public:
-	ConvertShape() : _num_frames(0), _frames(0)
-	{
-	}
+	ConvertShape();
 
 	~ConvertShape()
 	{
 		Free();
 	}
 
-	void Free()
-	{
-		if (_frames)
-			for(uint32 i = 0; i < _num_frames; ++i)
-				_frames[i].Free();
-		
-		delete [] _frames;
-		_frames = 0;
-		_num_frames = 0;
-	}
-
+	void Free();
 
 	void Read(IDataSource *source, const ConvertShapeFormat *csf, uint32 real_len);
 	void Write(ODataSource *source, const ConvertShapeFormat *csf, uint32 &write_len);

--- a/engines/ultima/ultima8/convert/u8/convert_usecode_u8.h
+++ b/engines/ultima/ultima8/convert/u8/convert_usecode_u8.h
@@ -52,7 +52,7 @@ public:
 	void readOpGeneric(TempOp &, IDataSource *, uint32 &, Std::vector<DebugSymbol> &,
 		bool &, const bool ) { }
 	Node *readOpGeneric(IDataSource *, uint32 &, Std::vector<DebugSymbol> &,
-		bool &, const bool ) { return 0; }
+		bool &, const bool ) { return nullptr; }
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/filesys/archive.cpp
+++ b/engines/ultima/ultima8/filesys/archive.cpp
@@ -65,7 +65,7 @@ bool Archive::addSource(ArchiveFile *af) {
 }
 
 bool Archive::addSource(IDataSource *ids) {
-	ArchiveFile *s = 0;
+	ArchiveFile *s = nullptr;
 
 	if (!ids) return false;
 
@@ -96,7 +96,8 @@ void Archive::uncache() {
 
 uint8 *Archive::getRawObject(uint32 index, uint32 *sizep) {
 	ArchiveFile *f = findArchiveFile(index);
-	if (!f) return 0;
+	if (!f)
+		return nullptr;
 
 	return f->getObject(index, sizep);
 }
@@ -115,7 +116,7 @@ ArchiveFile *Archive::findArchiveFile(uint32 index) const {
 			return _sources[n - i];
 	}
 
-	return 0;
+	return nullptr;
 }
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/filesys/archive_file.cpp
+++ b/engines/ultima/ultima8/filesys/archive_file.cpp
@@ -53,7 +53,8 @@ IDataSource *ArchiveFile::getDataSource(uint32 index, bool is_text) {
 	uint32 size;
 	uint8 *buf = getObject(index, &size);
 
-	if (!buf) return 0;
+	if (!buf)
+		return nullptr;
 
 	return new IBufferDataSource(buf, size, is_text, true);
 }
@@ -62,7 +63,8 @@ IDataSource *ArchiveFile::getDataSource(const Std::string &name, bool is_text) {
 	uint32 size;
 	uint8 *buf = getObject(name, &size);
 
-	if (!buf) return 0;
+	if (!buf)
+		return nullptr;
 
 	return new IBufferDataSource(buf, size, is_text, true);
 }

--- a/engines/ultima/ultima8/filesys/file_system.cpp
+++ b/engines/ultima/ultima8/filesys/file_system.cpp
@@ -33,7 +33,7 @@ namespace Ultima8 {
 
 using Std::string;
 
-FileSystem *FileSystem::_fileSystem = 0;
+FileSystem *FileSystem::_fileSystem = nullptr;
 
 FileSystem::FileSystem(bool noforced)
 	: _noForcedVPaths(noforced), _allowDataOverride(true) {
@@ -46,7 +46,7 @@ FileSystem::FileSystem(bool noforced)
 FileSystem::~FileSystem() {
 	debugN(MM_INFO, "Destroying FileSystem...\n");
 
-	_fileSystem = 0;
+	_fileSystem = nullptr;
 }
 
 
@@ -62,7 +62,7 @@ IDataSource *FileSystem::ReadFile(const string &vfn, bool is_text) {
 
 	Common::SeekableReadStream *readStream;
 	if (!rawOpen(readStream, filename))
-		return 0;
+		return nullptr;
 
 	return new IFileDataSource(readStream);
 }
@@ -73,7 +73,7 @@ ODataSource *FileSystem::WriteFile(const string &vfn, bool is_text) {
 	Common::WriteStream *writeStream;
 
 	if (!rawOpen(writeStream, filename))
-		return 0;
+		return nullptr;
 
 	return new OFileDataSource(writeStream);
 }
@@ -102,7 +102,7 @@ bool FileSystem::rawOpen(Common::SeekableReadStream *&in, const string &fname) {
 		Std::string saveFilename = Ultima8Engine::get_instance()->getSaveStateName(slotNumber);
 
 		in = g_system->getSavefileManager()->openForLoading(saveFilename);
-		return in != 0;
+		return in != nullptr;
 	}
 
 	if (!rewrite_virtual_path(name))
@@ -134,7 +134,7 @@ bool FileSystem::rawOpen(Common::WriteStream *&out,  const string &fname) {
 		Std::string saveFilename = Ultima8Engine::get_instance()->getSaveStateName(slotNumber);
 
 		out = g_system->getSavefileManager()->openForSaving(saveFilename, false);
-		return out != 0;
+		return out != nullptr;
 	} else {
 		return false;
 	}
@@ -263,7 +263,7 @@ IDataSource *FileSystem::checkBuiltinData(const Std::string &vfn, bool is_text) 
 		return new IBufferDataSource(mf->_value->_data,
 		                             mf->_value->_len, is_text);
 
-	return 0;
+	return nullptr;
 }
 
 bool FileSystem::rewrite_virtual_path(string &vfn) {

--- a/engines/ultima/ultima8/filesys/file_system.h
+++ b/engines/ultima/ultima8/filesys/file_system.h
@@ -51,13 +51,13 @@ public:
 	//! Open a file as readable. Streamed.
 	//! \param vfn the (virtual) filename
 	//! \param is_text open in text mode?
-	//! \return 0 on failure
+	//! \return nullptr on failure
 	IDataSource *ReadFile(const Std::string &vfn, bool is_text = false);
 
 	//! Open a file as writable. Streamed.
 	//! \param vfn the (virtual) filename
 	//! \param is_text open in text mode?
-	//! \return 0 on failure
+	//! \return nullptr on failure
 	ODataSource *WriteFile(const Std::string &vfn, bool is_text = false);
 
 	//! Mount a virtual path
@@ -111,7 +111,7 @@ private:
 	Std::map<Common::String, Std::string> _virtualPaths;
 
 	//! Check if the given file is a builtin data file.
-	//! If so, return an IDataSource for it. If not, return 0.
+	//! If so, return an IDataSource for it. If not, return nullptr.
 	IDataSource *checkBuiltinData(const Std::string &vfn, bool is_text = false);
 
 	struct MemoryFile {

--- a/engines/ultima/ultima8/filesys/flex_file.cpp
+++ b/engines/ultima/ultima8/filesys/flex_file.cpp
@@ -72,10 +72,12 @@ uint32 FlexFile::getOffset(uint32 index) {
 }
 
 uint8 *FlexFile::getObject(uint32 index, uint32 *sizep) {
-	if (index >= _count) return 0;
+	if (index >= _count)
+		return nullptr;
 
 	uint32 size = getSize(index);
-	if (size == 0) return 0;
+	if (size == 0)
+		return nullptr;
 
 	uint8 *object = new uint8[size];
 	uint32 offset = getOffset(index);

--- a/engines/ultima/ultima8/filesys/flex_file.h
+++ b/engines/ultima/ultima8/filesys/flex_file.h
@@ -51,13 +51,13 @@ public:
 			return false;
 	}
 
-	uint8 *getObject(uint32 index, uint32 *size = 0) override;
-	uint8 *getObject(const Std::string &name, uint32 *size = 0) override {
+	uint8 *getObject(uint32 index, uint32 *size = nullptr) override;
+	uint8 *getObject(const Std::string &name, uint32 *size = nullptr) override {
 		uint32 index;
 		if (nameToIndex(name, index))
 			return getObject(index, size);
 		else
-			return 0;
+			return nullptr;
 	}
 
 

--- a/engines/ultima/ultima8/filesys/idata_source.h
+++ b/engines/ultima/ultima8/filesys/idata_source.h
@@ -110,7 +110,7 @@ public:
 	virtual bool eof() const = 0;
 
 	virtual Common::SeekableReadStream *GetRawStream() {
-		return 0;
+		return nullptr;
 	}
 };
 
@@ -206,7 +206,7 @@ public:
 	IBufferDataSource(const void *data, unsigned int len, bool is_text = false,
 	                  bool delete_data = false) {
 		assert(!is_text);
-		assert(data != 0 || len == 0);
+		assert(data != nullptr || len == 0);
 		_buf = _bufPtr = static_cast<const uint8 *>(data);
 		_size = len;
 		_freeBuffer = delete_data;
@@ -218,9 +218,9 @@ public:
 		if (_freeBuffer && _buf)
 			delete[] const_cast<uint8 *>(_buf);
 		_freeBuffer = false;
-		_buf = _bufPtr = 0;
+		_buf = _bufPtr = nullptr;
 
-		assert(data != 0 || len == 0);
+		assert(data != nullptr || len == 0);
 		_buf = _bufPtr = static_cast<const uint8 *>(data);
 		_size = len;
 		_freeBuffer = delete_data;
@@ -230,7 +230,7 @@ public:
 		if (_freeBuffer && _buf)
 			delete[] const_cast<uint8 *>(_buf);
 		_freeBuffer = false;
-		_buf = _bufPtr = 0;
+		_buf = _bufPtr = nullptr;
 	}
 
 	uint8 read1() override {

--- a/engines/ultima/ultima8/filesys/named_archive_file.h
+++ b/engines/ultima/ultima8/filesys/named_archive_file.h
@@ -44,14 +44,16 @@ public:
 
 	uint8 *getObject(uint32 index, uint32 *size = 0) override {
 		Std::string name;
-		if (!indexToName(index, name)) return 0;
+		if (!indexToName(index, name))
+			return nullptr;
 		return getObject(name, size);
 	}
 	uint8 *getObject(const Std::string &name, uint32 *size = 0) override = 0;
 
 	uint32 getSize(uint32 index) const override {
 		Std::string name;
-		if (!indexToName(index, name)) return 0;
+		if (!indexToName(index, name))
+			return 0;
 		return getSize(name);
 	}
 	uint32 getSize(const Std::string &name) const override = 0;

--- a/engines/ultima/ultima8/filesys/odata_source.h
+++ b/engines/ultima/ultima8/filesys/odata_source.h
@@ -54,7 +54,7 @@ public:
 	}
 
 	virtual Common::WriteStream *GetRawStream() {
-		return 0;
+		return nullptr;
 	}
 
 	virtual void seek(uint32 pos) = 0;

--- a/engines/ultima/ultima8/filesys/raw_archive.cpp
+++ b/engines/ultima/ultima8/filesys/raw_archive.cpp
@@ -50,7 +50,7 @@ void RawArchive::uncache(uint32 index) {
 
 	if (_objects[index]) {
 		delete[] _objects[index];
-		_objects[index] = 0;
+		_objects[index] = nullptr;
 	}
 }
 
@@ -58,22 +58,25 @@ bool RawArchive::isCached(uint32 index) const {
 	if (index >= _count) return false;
 	if (_objects.empty()) return false;
 
-	return (_objects[index] != 0);
+	return (_objects[index] != nullptr);
 }
 
 const uint8 *RawArchive::get_object_nodel(uint32 index) {
-	if (index >= _count) return 0;
+	if (index >= _count)
+		return nullptr;
 	cache(index);
 	return _objects[index];
 }
 
 uint8 *RawArchive::get_object(uint32 index) {
-	if (index >= _count) return 0;
+	if (index >= _count)
+		return nullptr;
 
 	if (index < _objects.size() && _objects[index]) {
 		// already cached
 		uint32 size = getRawSize(index);
-		if (size == 0) return 0;
+		if (size == 0)
+			return nullptr;
 		uint8 *object = new uint8[size];
 		Std::memcpy(object, _objects[index], size);
 		return object;
@@ -83,15 +86,18 @@ uint8 *RawArchive::get_object(uint32 index) {
 }
 
 uint32 RawArchive::get_size(uint32 index) {
-	if (index >= _count) return 0;
+	if (index >= _count)
+		return 0;
 	return getRawSize(index);
 }
 
 IDataSource *RawArchive::get_datasource(uint32 index) {
-	if (index >= _count) return 0;
+	if (index >= _count)
+		return nullptr;
 	cache(index);
 
-	if (!_objects[index]) return 0;
+	if (!_objects[index])
+		return nullptr;
 
 	return new IBufferDataSource(_objects[index], getRawSize(index));
 }

--- a/engines/ultima/ultima8/filesys/u8_save_file.cpp
+++ b/engines/ultima/ultima8/filesys/u8_save_file.cpp
@@ -92,10 +92,12 @@ bool U8SaveFile::exists(const Std::string &name) {
 
 uint8 *U8SaveFile::getObject(const Std::string &name, uint32 *sizep) {
 	uint32 index;
-	if (!findIndex(name, index)) return 0;
+	if (!findIndex(name, index))
+		return nullptr;
 
 	uint32 size = _sizes[index];
-	if (size == 0) return 0;
+	if (size == 0)
+		return nullptr;
 
 	uint8 *object = new uint8[size];
 	uint32 offset = _offsets[index];
@@ -111,7 +113,8 @@ uint8 *U8SaveFile::getObject(const Std::string &name, uint32 *sizep) {
 
 uint32 U8SaveFile::getSize(const Std::string &name) const {
 	uint32 index;
-	if (!findIndex(name, index)) return 0;
+	if (!findIndex(name, index))
+		return 0;
 
 	return _sizes[index];
 }

--- a/engines/ultima/ultima8/games/game.cpp
+++ b/engines/ultima/ultima8/games/game.cpp
@@ -32,7 +32,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-Game *Game::_game = 0;
+Game *Game::_game = nullptr;
 
 Game::Game() {
 	_game = this;
@@ -40,7 +40,7 @@ Game::Game() {
 
 Game::~Game() {
 	assert(_game == this);
-	_game = 0;
+	_game = nullptr;
 }
 
 
@@ -55,7 +55,7 @@ Game *Game::createGame(GameInfo *info) {
 		CANT_HAPPEN_MSG("createGame: invalid _game");
 	}
 
-	return 0;
+	return nullptr;
 }
 
 uint32 Game::I_playEndgame(const uint8 *args, unsigned int /*argsize*/) {

--- a/engines/ultima/ultima8/games/game_data.cpp
+++ b/engines/ultima/ultima8/games/game_data.cpp
@@ -47,12 +47,13 @@
 namespace Ultima {
 namespace Ultima8 {
 
-GameData *GameData::_gameData = 0;
+GameData *GameData::_gameData = nullptr;
 
 
 GameData::GameData(GameInfo *gameInfo)
-	: _fixed(0), _mainShapes(0), _mainUsecode(0), _globs(), _fonts(0), _gumps(0),
-	  _mouse(0), _music(0), _weaponOverlay(0), _soundFlex(0), _speech(1024), _gameInfo(gameInfo) {
+	: _fixed(nullptr), _mainShapes(nullptr), _mainUsecode(nullptr), _globs(),
+	  _fonts(nullptr), _gumps(nullptr), _mouse(nullptr), _music(nullptr),
+	  _weaponOverlay(nullptr), _soundFlex(nullptr), _speech(1024), _gameInfo(gameInfo) {
 	debugN(MM_INFO, "Creating GameData...\n");
 
 	_gameData = this;
@@ -62,37 +63,37 @@ GameData::~GameData() {
 	debugN(MM_INFO, "Destroying GameData...\n");
 
 	delete _fixed;
-	_fixed = 0;
+	_fixed = nullptr;
 
 	delete _mainShapes;
-	_mainShapes = 0;
+	_mainShapes = nullptr;
 
 	delete _mainUsecode;
-	_mainUsecode = 0;
+	_mainUsecode = nullptr;
 
 	for (unsigned int i = 0; i < _globs.size(); ++i)
 		delete _globs[i];
 	_globs.clear();
 
 	delete _fonts;
-	_fonts = 0;
+	_fonts = nullptr;
 
 	delete _gumps;
-	_gumps = 0;
+	_gumps = nullptr;
 
 	delete _mouse;
-	_mouse = 0;
+	_mouse = nullptr;
 
 	delete _music;
-	_music = 0;
+	_music = nullptr;
 
 	delete _weaponOverlay;
-	_weaponOverlay = 0;
+	_weaponOverlay = nullptr;
 
 	delete _soundFlex;
-	_soundFlex = 0;
+	_soundFlex = nullptr;
 
-	_gameData = 0;
+	_gameData = nullptr;
 
 	for (unsigned int i = 0; i < _speech.size(); ++i) {
 		SpeechFlex **s = _speech[i];
@@ -106,7 +107,7 @@ MapGlob *GameData::getGlob(uint32 glob) const {
 	if (glob < _globs.size())
 		return _globs[glob];
 	else
-		return 0;
+		return nullptr;
 }
 
 ShapeArchive *GameData::getShapeFlex(uint16 flexId) const {
@@ -118,19 +119,21 @@ ShapeArchive *GameData::getShapeFlex(uint16 flexId) const {
 	default:
 		break;
 	};
-	return 0;
+	return nullptr;
 }
 
 Shape *GameData::getShape(FrameID f) const {
 	ShapeArchive *sf = getShapeFlex(f._flexId);
-	if (!sf) return 0;
+	if (!sf)
+		return nullptr;
 	Shape *shape = sf->getShape(f._shapeNum);
 	return shape;
 }
 
 ShapeFrame *GameData::getFrame(FrameID f) const {
 	Shape *shape = getShape(f);
-	if (!shape) return 0;
+	if (!shape)
+		return nullptr;
 	ShapeFrame *frame = shape->getFrame(f._frameNum);
 	return frame;
 }
@@ -436,13 +439,14 @@ void GameData::setupTTFOverrides(const char *configkey, bool SJIS) {
 }
 
 SpeechFlex *GameData::getSpeechFlex(uint32 shapeNum) {
-	if (shapeNum >= _speech.size()) return 0;
+	if (shapeNum >= _speech.size())
+		return nullptr;
 
 	SpeechFlex **s = _speech[shapeNum];
 	if (s) return *s;
 
 	s = new SpeechFlex*;
-	*s = 0;
+	*s = nullptr;
 
 	FileSystem *filesystem = FileSystem::get_instance();
 
@@ -453,7 +457,8 @@ SpeechFlex *GameData::getSpeechFlex(uint32 shapeNum) {
 	char langletter = _gameInfo->getLanguageFileLetter();
 	if (!langletter) {
 		perr << "GameData::getSpeechFlex: Unknown language." << Std::endl;
-		return 0;
+		// FIXME: This leaks s
+		return nullptr;
 	}
 
 	IDataSource *sflx = filesystem->ReadFile(u8_sound_ + langletter + num_flx);
@@ -594,7 +599,7 @@ void GameData::loadRemorseData() {
 #endif
 
 	IDataSource *dummyds = filesystem->ReadFile("@data/empty.flx");
-	_music = 0; //new MusicFlex(dummyds);
+	_music = nullptr; //new MusicFlex(dummyds);
 	delete dummyds;
 #if 0
 	IDataSource *mf = filesystem->ReadFile("@game/sound/_music.flx");

--- a/engines/ultima/ultima8/graphics/anim_dat.cpp
+++ b/engines/ultima/ultima8/graphics/anim_dat.cpp
@@ -43,14 +43,17 @@ AnimDat::~AnimDat() {
 }
 
 ActorAnim *AnimDat::getAnim(uint32 shape) const {
-	if (shape >= _anims.size()) return 0;
+	if (shape >= _anims.size())
+		return nullptr;
 
 	return _anims[shape];
 }
 
 AnimAction *AnimDat::getAnim(uint32 shape, uint32 action) const {
-	if (shape >= _anims.size()) return 0;
-	if (_anims[shape] == 0) return 0;
+	if (shape >= _anims.size())
+		return nullptr;
+	if (_anims[shape] == 0)
+		return nullptr;
 
 	return _anims[shape]->getAction(action);
 }
@@ -71,7 +74,7 @@ void AnimDat::load(IDataSource *ds) {
 		uint32 offset = ds->read4();
 
 		if (offset == 0) {
-			_anims[shape] = 0;
+			_anims[shape] = nullptr;
 			continue;
 		}
 

--- a/engines/ultima/ultima8/graphics/base_soft_render_surface.cpp
+++ b/engines/ultima/ultima8/graphics/base_soft_render_surface.cpp
@@ -41,11 +41,11 @@ namespace Ultima8 {
 // Desc: Constructor for BaseSoftRenderSurface from a managed surface
 //
 BaseSoftRenderSurface::BaseSoftRenderSurface(Graphics::ManagedSurface *s) :
-	_pixels(0), _pixels00(0), _zBuffer(0), _zBuffer00(0),
-	_bytesPerPixel(0), _bitsPerPixel(0), _formatType(0),
+	_pixels(nullptr), _pixels00(nullptr), _zBuffer(nullptr),
+	_zBuffer00(nullptr), _bytesPerPixel(0), _bitsPerPixel(0), _formatType(0),
 	_ox(0), _oy(0), _width(0), _height(0), _pitch(0), _zPitch(0),
 	_flipped(false), _clipWindow(0, 0, 0, 0), _lockCount(0),
-	_surface(s), _rttTex(0) {
+	_surface(s), _rttTex(nullptr) {
 	_clipWindow.ResizeAbs(_width = _surface->w, _height = _surface->h);
 	_pitch = _surface->pitch;
 	_bitsPerPixel = _surface->format.bpp();
@@ -118,10 +118,11 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(Graphics::ManagedSurface *s) :
 //
 BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h, int bpp,
         int rsft, int gsft, int bsft, int asft) :
-	_pixels(0), _pixels00(0), _zBuffer(0), _zBuffer00(0),
-	_bytesPerPixel(0), _bitsPerPixel(0), _formatType(0),
+	_pixels(nullptr), _pixels00(nullptr), _zBuffer(nullptr),
+	_zBuffer00(nullptr), _bytesPerPixel(0), _bitsPerPixel(0), _formatType(0),
 	_ox(0), _oy(0), _width(0), _height(0), _pitch(0), _zPitch(0),
-	_flipped(false), _clipWindow(0, 0, 0, 0), _lockCount(0), _surface(0), _rttTex(0) {
+	_flipped(false), _clipWindow(0, 0, 0, 0), _lockCount(0), _surface(nullptr),
+	_rttTex(nullptr) {
 	_clipWindow.ResizeAbs(_width = w, _height = h);
 
 	switch (bpp) {
@@ -180,10 +181,11 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h, int bpp,
 // Desc: Constructor for Generic BaseSoftRenderSurface which matches screen params
 //
 BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h, uint8 *buf) :
-	_pixels(0), _pixels00(0), _zBuffer(0), _zBuffer00(0),
-	_bytesPerPixel(0), _bitsPerPixel(0), _formatType(0),
+	_pixels(nullptr), _pixels00(nullptr), _zBuffer(nullptr),
+	_zBuffer00(nullptr), _bytesPerPixel(0), _bitsPerPixel(0), _formatType(0),
 	_ox(0), _oy(0), _width(0), _height(0), _pitch(0), _zPitch(0),
-	_flipped(false), _clipWindow(0, 0, 0, 0), _lockCount(0), _surface(0), _rttTex(0) {
+	_flipped(false), _clipWindow(0, 0, 0, 0), _lockCount(0),
+	_surface(nullptr), _rttTex(nullptr) {
 	_clipWindow.ResizeAbs(_width = w, _height = h);
 
 	int bpp = RenderSurface::_format.s_bpp;
@@ -202,10 +204,11 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h, uint8 *buf) :
 // Desc: Constructor for Generic BaseSoftRenderSurface which matches screen params
 //
 BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h) :
-	_pixels(0), _pixels00(0), _zBuffer(0), _zBuffer00(0),
+	_pixels(nullptr), _pixels00(nullptr), _zBuffer(nullptr), _zBuffer00(nullptr),
 	_bytesPerPixel(0), _bitsPerPixel(0), _formatType(0),
 	_ox(0), _oy(0), _width(0), _height(0), _pitch(0), _zPitch(0),
-	_flipped(false), _clipWindow(0, 0, 0, 0), _lockCount(0), _surface(0), _rttTex(0) {
+	_flipped(false), _clipWindow(0, 0, 0, 0), _lockCount(0), _surface(nullptr),
+	_rttTex(nullptr) {
 	_clipWindow.ResizeAbs(_width = w, _height = h);
 
 	int bpp = RenderSurface::_format.s_bpp;
@@ -235,13 +238,13 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h) :
 BaseSoftRenderSurface::~BaseSoftRenderSurface() {
 	if (_rttTex) {
 		delete _rttTex;
-		_rttTex = 0;
+		_rttTex = nullptr;
 
 		delete [] _pixels00;
-		_pixels00 = 0;
+		_pixels00 = nullptr;
 
 		delete [] _zBuffer00;
-		_zBuffer00 = 0;
+		_zBuffer00 = nullptr;
 	}
 }
 
@@ -270,7 +273,7 @@ ECode BaseSoftRenderSurface::BeginPainting() {
 
 	_lockCount++;
 
-	if (_pixels00 == 0) {
+	if (_pixels00 == nullptr) {
 		// TODO: SetLastError(GR_SOFT_ERROR_LOCKED_NULL_PIXELS, "Surface Locked with NULL BaseSoftRenderSurface::_pixels pointer!");
 		perr << "Error: Surface Locked with NULL BaseSoftRenderSurface::_pixels pointer!" << Std::endl;
 		return GR_SOFT_ERROR_LOCKED_NULL_PIXELS;

--- a/engines/ultima/ultima8/graphics/fonts/fixed_width_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/fixed_width_font.cpp
@@ -37,21 +37,22 @@ FixedWidthFont *FixedWidthFont::Create(const Std::string &iniroot) {
 	Std::string filename;
 	if (!config->get(iniroot + "/font/path", filename)) {
 		perr << "Error: 'path' key not found in font ini" << Std::endl;
-		return 0;
+		return nullptr;
 	}
 
 	IDataSource *ds = filesys->ReadFile(filename);
 
 	if (!ds) {
 		perr << "Error: Unable to open file " << filename << Std::endl;
-		return 0;
+		return nullptr;
 	}
 
 	Texture *fonttex = Texture::Create(ds, filename.c_str());
 
 	if (!fonttex) {
 		perr << "Error: Unable to read texture " << filename << Std::endl;
-		return 0;
+		// FIXME: This leaks ds
+		return nullptr;
 	}
 
 	delete ds;

--- a/engines/ultima/ultima8/graphics/fonts/font_manager.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font_manager.cpp
@@ -40,7 +40,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-FontManager *FontManager::_fontManager = 0;
+FontManager *FontManager::_fontManager = nullptr;
 
 FontManager::FontManager(bool ttf_antialiasing_) : _ttfAntialiasing(ttf_antialiasing_) {
 	debugN(MM_INFO, "Creating Font Manager...\n");
@@ -66,7 +66,7 @@ FontManager::~FontManager() {
 	_ttfFonts.clear();
 
 	assert(_fontManager == this);
-	_fontManager = 0;
+	_fontManager = nullptr;
 }
 
 // Reset the font manager
@@ -86,7 +86,7 @@ Font *FontManager::getGameFont(unsigned int fontnum,
 
 Font *FontManager::getTTFont(unsigned int fontnum) {
 	if (fontnum >= _ttFonts.size())
-		return 0;
+		return nullptr;
 	return _ttFonts[fontnum];
 }
 
@@ -106,7 +106,7 @@ Graphics::Font *FontManager::getTTF_Font(const Std::string &filename, int points
 	fontids = FileSystem::get_instance()->ReadFile("@data/" + filename);
 	if (!fontids) {
 		perr << "Failed to open TTF: @data/" << filename << Std::endl;
-		return 0;
+		return nullptr;
 	}
 
 	// open font using ScummVM TTF API
@@ -116,7 +116,7 @@ Graphics::Font *FontManager::getTTF_Font(const Std::string &filename, int points
 
 	if (!font) {
 		perr << "Failed to open TTF: @data/" << filename << Std::endl;
-		return 0;
+		return nullptr;
 	}
 
 	_ttfFonts[id] = font;

--- a/engines/ultima/ultima8/graphics/gump_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/gump_shape_archive.cpp
@@ -51,7 +51,8 @@ void GumpShapeArchive::loadGumpage(IDataSource *ds) {
 }
 
 Rect *GumpShapeArchive::getGumpItemArea(uint32 shapenum) {
-	if (shapenum >= _gumpItemArea.size()) return 0;
+	if (shapenum >= _gumpItemArea.size())
+		return nullptr;
 	return _gumpItemArea[shapenum];
 }
 

--- a/engines/ultima/ultima8/graphics/inverter_process.cpp
+++ b/engines/ultima/ultima8/graphics/inverter_process.cpp
@@ -44,7 +44,7 @@ static unsigned int states[] = { 0, 8, 63, 211, 493, 945, 1594, 2459, 3552,
                                  64591, 65042, 65324, 65472, 65528, 65536
                                };
 
-InverterProcess *InverterProcess::_inverter = 0;
+InverterProcess *InverterProcess::_inverter = nullptr;
 
 // p_dynamic_class stuff
 DEFINE_RUNTIME_CLASSTYPE_CODE(InverterProcess, Process)
@@ -61,7 +61,7 @@ InverterProcess::InverterProcess(unsigned int target)
 
 InverterProcess::~InverterProcess(void) {
 	if (_inverter == this)
-		_inverter = 0;
+		_inverter = nullptr;
 }
 
 void InverterProcess::run() {

--- a/engines/ultima/ultima8/graphics/main_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/main_shape_archive.cpp
@@ -35,19 +35,19 @@ DEFINE_RUNTIME_CLASSTYPE_CODE(MainShapeArchive, ShapeArchive)
 MainShapeArchive::~MainShapeArchive() {
 	if (_typeFlags) {
 		delete _typeFlags;
-		_typeFlags = 0;
+		_typeFlags = nullptr;
 	}
 
 	if (_animDat) {
 		delete _animDat;
-		_animDat = 0;
+		_animDat = nullptr;
 	}
 }
 
 void MainShapeArchive::loadTypeFlags(IDataSource *ds) {
 	if (_typeFlags) {
 		delete _typeFlags;
-		_typeFlags = 0;
+		_typeFlags = nullptr;
 	}
 
 	_typeFlags = new TypeFlags;
@@ -63,7 +63,7 @@ ShapeInfo *MainShapeArchive::getShapeInfo(uint32 shapenum) {
 void MainShapeArchive::loadAnimDat(IDataSource *ds) {
 	if (_animDat) {
 		delete _animDat;
-		_animDat = 0;
+		_animDat = nullptr;
 	}
 
 	_animDat = new AnimDat;

--- a/engines/ultima/ultima8/graphics/palette_fader_process.cpp
+++ b/engines/ultima/ultima8/graphics/palette_fader_process.cpp
@@ -33,7 +33,7 @@ namespace Ultima8 {
 
 #define PALETTEFADER_COUNTER    30
 
-PaletteFaderProcess *PaletteFaderProcess::_fader = 0;
+PaletteFaderProcess *PaletteFaderProcess::_fader = nullptr;
 
 // p_dynamic_class stuff
 DEFINE_RUNTIME_CLASSTYPE_CODE(PaletteFaderProcess, Process)
@@ -82,7 +82,7 @@ PaletteFaderProcess::PaletteFaderProcess(int16 from[12], int16 to[12],
 
 PaletteFaderProcess::~PaletteFaderProcess(void) {
 	if (_fader == this)
-		_fader = 0;
+		_fader = nullptr;
 }
 
 void PaletteFaderProcess::run() {

--- a/engines/ultima/ultima8/graphics/palette_manager.cpp
+++ b/engines/ultima/ultima8/graphics/palette_manager.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-PaletteManager *PaletteManager::_paletteManager = 0;
+PaletteManager *PaletteManager::_paletteManager = nullptr;
 
 PaletteManager::PaletteManager(RenderSurface *rs)
 	: _renderSurface(rs) {
@@ -42,7 +42,7 @@ PaletteManager::PaletteManager(RenderSurface *rs)
 PaletteManager::~PaletteManager() {
 	reset();
 	debugN(MM_INFO, "Destroying PaletteManager...\n");
-	_paletteManager = 0;
+	_paletteManager = nullptr;
 }
 
 // Reset the Palette Manager
@@ -131,7 +131,7 @@ void PaletteManager::duplicate(PalIndex src, PalIndex dest) {
 
 Palette *PaletteManager::getPalette(PalIndex index) {
 	if (static_cast<unsigned int>(index) >= _palettes.size())
-		return 0;
+		return nullptr;
 
 	return _palettes[index];
 }

--- a/engines/ultima/ultima8/graphics/point_scaler.cpp
+++ b/engines/ultima/ultima8/graphics/point_scaler.cpp
@@ -134,7 +134,7 @@ public:
 			uint32 pos_y;
 			uint32 end_y = dh;
 			uint32 dst_y = 0;
-			uint8 *next_block = 0;
+			uint8 *next_block = nullptr;
 
 			// Src Loop Y
 			do {
@@ -179,7 +179,7 @@ public:
 			uint32 pos_y;
 			uint32 end_y = dh;
 			uint32 dst_y = 0;
-			uint8 *next_block = 0;
+			uint8 *next_block = nullptr;
 
 			// Src Loop Y
 			do {
@@ -222,8 +222,8 @@ public:
 			uint32 pos_y = 0, pos_x = 0;
 			uint32 end_y = dh;
 			uint32 dst_y = 0;
-			uint8 *blockline_start = 0;
-			uint8 *next_block = 0;
+			uint8 *blockline_start = nullptr;
+			uint8 *next_block = nullptr;
 
 			// Src Loop Y
 			do {
@@ -242,7 +242,7 @@ public:
 					// Inner loops
 					//
 					blockline_start = next_block;
-					next_block = 0;
+					next_block = nullptr;
 
 					// Dest Loop Y
 					while (pos_y < end_y) {

--- a/engines/ultima/ultima8/graphics/scaler.h
+++ b/engines/ultima/ultima8/graphics/scaler.h
@@ -86,26 +86,26 @@ public:
 			        RenderSurface::_format.a_mask == TEX32_A_MASK && RenderSurface::_format.r_mask == TEX32_R_MASK &&
 			        RenderSurface::_format.g_mask == TEX32_G_MASK && RenderSurface::_format.b_mask == TEX32_B_MASK)) {
 				if (RenderSurface::_format.a_mask == 0xFF000000) {
-					if (!Scale32_A888) return 0;
+					if (!Scale32_A888) return false;
 					return Scale32_A888(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
 				} else if (RenderSurface::_format.a_mask == 0x000000FF) {
-					if (!Scale32_888A) return 0;
+					if (!Scale32_888A) return false;
 					return Scale32_888A(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
 				} else {
-					if (!Scale32Nat) return 0;
+					if (!Scale32Nat) return false;
 					return Scale32Nat(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
 				}
 			} else if (texture->_format == TEX_FMT_STANDARD) {
-				if (!Scale32Sta) return 0;
+				if (!Scale32Sta) return false;
 				return Scale32Sta(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
 			}
 		}
 		if (RenderSurface::_format.s_bytes_per_pixel == 2) {
 			if (texture->_format == TEX_FMT_NATIVE) {
-				if (!Scale16Nat) return 0;
+				if (!Scale16Nat) return false;
 				return Scale16Nat(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
 			} else if (texture->_format == TEX_FMT_STANDARD) {
-				if (!Scale16Sta) return 0;
+				if (!Scale16Sta) return false;
 				return Scale16Sta(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
 			}
 		}

--- a/engines/ultima/ultima8/graphics/shape.cpp
+++ b/engines/ultima/ultima8/graphics/shape.cpp
@@ -42,7 +42,7 @@ Shape::Shape(const uint8 *data_, uint32 size_, const ConvertShapeFormat *format,
 
 	this->_data = data_;
 	this->_size = size_;
-	this->_palette = 0;
+	this->_palette = nullptr;
 
 	if (!format) format = DetectShapeFormat(data_, size_);
 
@@ -69,7 +69,7 @@ Shape::Shape(IDataSource *src, const ConvertShapeFormat *format)
 	uint8 *d = new uint8[this->_size];
 	this->_data = d;
 	src->read(d, this->_size);
-	this->_palette = 0;
+	this->_palette = nullptr;
 
 	if (!format)
 		format = DetectShapeFormat(_data, _size);
@@ -193,7 +193,7 @@ void Shape::LoadGenericFormat(const uint8 *data, uint32 size, const ConvertShape
 		if (format->_bytes_frame_length) framesize = ds.readX(format->_bytes_frame_length) + format->_bytes_frame_length_kludge;
 		else framesize = size - frameoffset;
 
-		ConvertShapeFrame *prev = 0, p;
+		ConvertShapeFrame *prev = nullptr, p;
 
 		if (format->_bytes_special && i > 0) {
 			prev = &p;
@@ -211,7 +211,7 @@ const ConvertShapeFormat *Shape::DetectShapeFormat(const uint8 *data, uint32 siz
 }
 
 const ConvertShapeFormat *Shape::DetectShapeFormat(IDataSource *ds, uint32 size_) {
-	const ConvertShapeFormat *ret = 0;
+	const ConvertShapeFormat *ret = nullptr;
 
 	if (ConvertShape::CheckUnsafe(ds, &PentagramShapeFormat, size_))
 		ret = &PentagramShapeFormat;
@@ -260,6 +260,14 @@ void Shape::getTotalDimensions(int32 &w, int32 &h, int32 &x, int32 &y) const {
 	x = -minx;
 	y = -miny;
 }
+
+ShapeFrame *Shape::getFrame(unsigned int frame) {
+	if (frame < _frames.size())
+		return _frames[frame];
+	else
+		return nullptr;
+}
+
 
 } // End of namespace Ultima8
 } // End of namespace Ultima

--- a/engines/ultima/ultima8/graphics/shape.h
+++ b/engines/ultima/ultima8/graphics/shape.h
@@ -60,10 +60,7 @@ public:
 	//! (x,y) = coordinates of origin relative to top-left point of rectangle
 	void getTotalDimensions(int32 &w, int32 &h, int32 &x, int32 &y) const;
 
-	ShapeFrame *getFrame(unsigned int frame) {
-		if (frame < _frames.size()) return _frames[frame];
-		else return 0;
-	}
+	ShapeFrame *getFrame(unsigned int frame);
 
 	void getShapeId(uint16 &flexId, uint32 &shapenum);
 

--- a/engines/ultima/ultima8/graphics/shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/shape_archive.cpp
@@ -37,7 +37,8 @@ ShapeArchive::~ShapeArchive() {
 }
 
 Shape *ShapeArchive::getShape(uint32 shapenum) {
-	if (shapenum >= _count) return 0;
+	if (shapenum >= _count)
+		return nullptr;
 	cache(shapenum);
 
 	return _shapes[shapenum];
@@ -77,14 +78,14 @@ void ShapeArchive::uncache(uint32 shapenum) {
 	if (_shapes.empty()) return;
 
 	delete _shapes[shapenum];
-	_shapes[shapenum] = 0;
+	_shapes[shapenum] = nullptr;
 }
 
 bool ShapeArchive::isCached(uint32 shapenum) const {
 	if (shapenum >= _count) return false;
 	if (_shapes.empty()) return false;
 
-	return (_shapes[shapenum] != 0);
+	return (_shapes[shapenum] != nullptr);
 }
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/graphics/shape_info.h
+++ b/engines/ultima/ultima8/graphics/shape_info.h
@@ -151,7 +151,8 @@ public:
 		_flags(0), _x(0), _y(0), _z(0),
 		_family(0), _equipType(0), _animType(0), _animData(0),
 		_unknown(0), _weight(0), _volume(0),
-		_weaponInfo(0), _armourInfo(0), _monsterInfo(0) { }
+		_weaponInfo(nullptr), _armourInfo(nullptr),
+		_monsterInfo(nullptr) { }
 
 	~ShapeInfo() {
 		delete _weaponInfo;

--- a/engines/ultima/ultima8/graphics/skf_player.cpp
+++ b/engines/ultima/ultima8/graphics/skf_player.cpp
@@ -68,8 +68,9 @@ static const int FADESTEPS = 16; // HACK: half speed
 SKFPlayer::SKFPlayer(RawArchive *movie, int width, int height, bool introMusicHack)
 	: _width(width), _height(height), _skf(movie),
 	  _curFrame(0), _curObject(0), _curAction(0), _curEvent(0), _playing(false),
-	  _timer(0), _frameRate(15), _fadeColour(0), _fadeLevel(0), _buffer(0), _subs(0),
-	  _introMusicHack(introMusicHack), _lastUpdate(0), _subtitleY(0) {
+	  _timer(0), _frameRate(15), _fadeColour(0), _fadeLevel(0), _buffer(nullptr),
+	  _subs(nullptr), _introMusicHack(introMusicHack), _lastUpdate(0),
+	  _subtitleY(0) {
 	IDataSource *eventlist = _skf->get_datasource(0);
 	if (!eventlist) {
 		perr << "No eventlist found in SKF" << Std::endl;
@@ -253,7 +254,7 @@ void SKFPlayer::run() {
 		case SKF_ClearSubs:
 //			pout << "ClearSubs" << Std::endl;
 			delete _subs;
-			_subs = 0;
+			_subs = nullptr;
 			break;
 		default:
 			pout << "Unknown action" << Std::endl;

--- a/engines/ultima/ultima8/graphics/texture.cpp
+++ b/engines/ultima/ultima8/graphics/texture.cpp
@@ -32,6 +32,10 @@
 namespace Ultima {
 namespace Ultima8 {
 
+
+Texture::Texture() : _format(TEX_FMT_STANDARD), _glTex(0), _next(nullptr) {
+}
+
 //
 // Destructor
 //
@@ -46,7 +50,7 @@ Texture::~Texture() {
 	/* If read failed, delete the texture. */   \
 	if (!tex->Read(ds)) {                       \
 		delete tex;                             \
-		tex = 0;                                \
+		tex = nullptr;                          \
 	}                                           \
 	else {                                      \
 		/* Worked so return it */               \
@@ -87,7 +91,7 @@ Texture *Texture::Create(IDataSource *ds, const char *filename) {
 	TRY_TYPE(TextureTarga);
 
 	// Couldn't find it
-	return 0;
+	return nullptr;
 }
 
 void Texture::loadSurface(const Graphics::Surface *surf) {

--- a/engines/ultima/ultima8/graphics/texture.h
+++ b/engines/ultima/ultima8/graphics/texture.h
@@ -103,8 +103,7 @@ public:
 		return Graphics::PixelFormat(4, 8, 8, 8, 8, TEX32_R_SHIFT, TEX32_G_SHIFT, TEX32_B_SHIFT, TEX32_A_SHIFT);
 	}
 
-	Texture() : _format(TEX_FMT_STANDARD), _glTex(0), _next(0) {
-	}
+	Texture();
 
 	virtual ~Texture();
 

--- a/engines/ultima/ultima8/graphics/type_flags.cpp
+++ b/engines/ultima/ultima8/graphics/type_flags.cpp
@@ -46,7 +46,7 @@ ShapeInfo *TypeFlags::getShapeInfo(uint32 shapenum) {
 	if (shapenum < _shapeInfo.size())
 		return &(_shapeInfo[shapenum]);
 	else
-		return 0;
+		return nullptr;
 }
 
 
@@ -149,8 +149,8 @@ void TypeFlags::load(IDataSource *ds) {
 
 		}
 
-		si._weaponInfo = 0;
-		si._armourInfo = 0;
+		si._weaponInfo = nullptr;
+		si._armourInfo = nullptr;
 
 		_shapeInfo[i] = si;
 	}

--- a/engines/ultima/ultima8/graphics/wpn_ovlay_dat.cpp
+++ b/engines/ultima/ultima8/graphics/wpn_ovlay_dat.cpp
@@ -44,15 +44,18 @@ WpnOvlayDat::~WpnOvlayDat() {
 }
 
 const AnimWeaponOverlay *WpnOvlayDat::getAnimOverlay(uint32 action) const {
-	if (action >= _overlay.size()) return 0;
+	if (action >= _overlay.size())
+		return nullptr;
 	return _overlay[action];
 }
 
 const WeaponOverlayFrame *WpnOvlayDat::getOverlayFrame(uint32 action, int type,
         int direction,
         int frame) const {
-	if (action >= _overlay.size()) return 0;
-	if (!_overlay[action]) return 0;
+	if (action >= _overlay.size())
+		return nullptr;
+	if (!_overlay[action])
+		return nullptr;
 	return _overlay[action]->getFrame(type, direction, frame);
 }
 
@@ -67,7 +70,7 @@ void WpnOvlayDat::load(RawArchive *overlaydat) {
 
 	for (unsigned int action = 0; action < _overlay.size(); action++) {
 		IDataSource *ds = overlaydat->get_datasource(action);
-		_overlay[action] = 0;
+		_overlay[action] = nullptr;
 
 		if (ds && ds->getSize()) {
 			// get Avatar's animation

--- a/engines/ultima/ultima8/gumps/ask_gump.cpp
+++ b/engines/ultima/ultima8/gumps/ask_gump.cpp
@@ -138,7 +138,7 @@ bool AskGump::loadData(IDataSource *ids, uint32 version) {
 
 	for (unsigned int i = 0; i < _answers->getSize(); ++i) {
 
-		ButtonWidget *child = 0;
+		ButtonWidget *child = nullptr;
 
 		Std::list<Gump *>::iterator it;
 		for (it = _children.begin(); it != _children.end(); ++it) {

--- a/engines/ultima/ultima8/gumps/container_gump.cpp
+++ b/engines/ultima/ultima8/gumps/container_gump.cpp
@@ -165,7 +165,8 @@ uint16 ContainerGump::TraceObjId(int32 mx, int32 my) {
 
 	Container *c = getContainer(_owner);
 
-	if (!c) return 0; // Container gone!?
+	if (!c)
+		return 0; // Container gone!?
 
 	bool paintEditorItems = Ultima8Engine::get_instance()->isPaintEditorItems();
 
@@ -285,14 +286,14 @@ Container *ContainerGump::getTargetContainer(Item *item, int mx, int my) {
 	Container *targetcontainer = getContainer(TraceObjId(px, py));
 
 	if (targetcontainer && targetcontainer->getObjId() == item->getObjId())
-		targetcontainer = 0;
+		targetcontainer = nullptr;
 
 	if (targetcontainer) {
 		ShapeInfo *targetinfo = targetcontainer->getShapeInfo();
 		if ((targetcontainer->getObjId() == item->getObjId()) ||
 		        targetinfo->is_land() ||
 		        (targetcontainer->getFlags() & Item::FLG_IN_NPC_LIST)) {
-			targetcontainer = 0;
+			targetcontainer = nullptr;
 		}
 	}
 
@@ -311,7 +312,7 @@ Gump *ContainerGump::OnMouseDown(int button, int32 mx, int32 my) {
 	if (button == Shared::BUTTON_LEFT)
 		return this;
 
-	return 0;
+	return nullptr;
 }
 
 void ContainerGump::OnMouseClick(int button, int32 mx, int32 my) {
@@ -452,7 +453,7 @@ void ContainerGump::DropItem(Item *item, int mx, int my) {
 	        item->getQuality() > 1) {
 		// more than one, so see if we should ask if we should split it up
 
-		Item *splittarget = 0;
+		Item *splittarget = nullptr;
 
 		// also try to combine
 		if (targetitem && item->canMergeWith(targetitem)) {
@@ -504,7 +505,7 @@ void ContainerGump::DropItem(Item *item, int mx, int my) {
 
 			// combined, so delete item
 			item->destroy();
-			item = 0;
+			item = nullptr;
 			return;
 		}
 	}

--- a/engines/ultima/ultima8/gumps/credits_gump.cpp
+++ b/engines/ultima/ultima8/gumps/credits_gump.cpp
@@ -49,8 +49,8 @@ CreditsGump::CreditsGump(const Std::string &text, int parskip,
 	_parSkip = parskip;
 
 	_timer = 0;
-	_title = 0;
-	_nextTitle = 0;
+	_title = nullptr;
+	_nextTitle = nullptr;
 	_state = CS_PLAYING;
 }
 
@@ -211,7 +211,7 @@ void CreditsGump::run() {
 
 				if (!_title) {
 					_title = _nextTitle;
-					_nextTitle = 0;
+					_nextTitle = nullptr;
 				} else {
 					_nextTitleSurf = nextblock;
 					_scrollHeight[nextblock] = 160; // skip some space
@@ -336,7 +336,7 @@ void CreditsGump::run() {
 		if (_nextTitle && _currentSurface == _nextTitleSurf) {
 			delete _title;
 			_title = _nextTitle;
-			_nextTitle = 0;
+			_nextTitle = nullptr;
 		}
 	}
 }

--- a/engines/ultima/ultima8/gumps/game_map_gump.cpp
+++ b/engines/ultima/ultima8/gumps/game_map_gump.cpp
@@ -296,7 +296,7 @@ Gump *GameMapGump::OnMouseDown(int button, int32 mx, int32 my) {
 		return this;
 	}
 
-	return 0;
+	return nullptr;
 }
 
 void GameMapGump::OnMouseUp(int button, int32 mx, int32 my) {

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -40,22 +40,22 @@ namespace Ultima8 {
 
 DEFINE_RUNTIME_CLASSTYPE_CODE(Gump, Object)
 
-Gump::Gump() : Object(), _parent(0), _children() {
+Gump::Gump() : Object(), _parent(nullptr), _children() {
 }
 
 Gump::Gump(int inX, int inY, int width, int height, uint16 inOwner,
            uint32 inFlags, int32 inLayer) :
-	Object(), _owner(inOwner), _parent(0), _x(inX), _y(inY),
+	Object(), _owner(inOwner), _parent(nullptr), _x(inX), _y(inY),
 	_dims(0, 0, width, height), _flags(inFlags), _layer(inLayer), _index(-1),
-	_shape(0), _frameNum(0), _children(), _focusChild(0), _notifier(0),
-	_processResult(0) {
+	_shape(nullptr), _frameNum(0), _children(), _focusChild(nullptr),
+	_notifier(0), _processResult(0) {
 	assignObjId(); // gumps always get an objid
 }
 
 Gump::~Gump() {
 	// Get rid of focus
 	if (_focusChild) _focusChild->OnFocus(false);
-	_focusChild = 0;
+	_focusChild = nullptr;
 
 	// Delete all children
 	Std::list<Gump *>::iterator it = _children.begin();
@@ -335,7 +335,7 @@ void Gump::PaintComposited(RenderSurface * /*surf*/, int32 /*lerp_factor*/, int3
 Gump *Gump::FindGump(int mx, int my) {
 	int32 gx = mx, gy = my;
 	ParentToGump(gx, gy);
-	Gump *gump = 0;
+	Gump *gump = nullptr;
 
 	// Iterate all children
 	Std::list<Gump *>::reverse_iterator it = _children.rbegin();
@@ -348,12 +348,14 @@ Gump *Gump::FindGump(int mx, int my) {
 	}
 
 	// it's over a child
-	if (gump) return gump;
+	if (gump)
+		return gump;
 
 	// it's over this gump
-	if (PointOnGump(mx, my)) return this;
+	if (PointOnGump(mx, my))
+		return this;
 
-	return 0;
+	return nullptr;
 }
 
 void Gump::setRelativePosition(Gump::Position pos, int xoffset, int yoffset) {
@@ -529,8 +531,10 @@ bool Gump::GetLocationOfItem(uint16 itemid, int32 &gx, int32 &gy,
 Gump *Gump::FindGump(const RunTimeClassType &t, bool recursive,
                      bool no_inheritance) {
 	// If that is our type, then return us!
-	if (GetClassType() == t) return this;
-	else if (!no_inheritance && IsOfType(t)) return this;
+	if (GetClassType() == t)
+		return this;
+	else if (!no_inheritance && IsOfType(t))
+		return this;
 
 	// Iterate all children
 	Std::list<Gump *>::iterator  it = _children.begin();
@@ -540,13 +544,17 @@ Gump *Gump::FindGump(const RunTimeClassType &t, bool recursive,
 		Gump *g = *it;
 
 		// Not if closing
-		if (g->_flags & FLAG_CLOSING) continue;
+		if (g->_flags & FLAG_CLOSING)
+			continue;
 
-		if (g->GetClassType() == t) return g;
-		else if (!no_inheritance && g->IsOfType(t)) return g;
+		if (g->GetClassType() == t)
+			return g;
+		else if (!no_inheritance && g->IsOfType(t))
+			return g;
 	}
 
-	if (!recursive) return 0;
+	if (!recursive)
+		return nullptr;
 
 	// Recursive Iterate all children
 	it = _children.begin();
@@ -556,14 +564,16 @@ Gump *Gump::FindGump(const RunTimeClassType &t, bool recursive,
 		Gump *g = (*it);
 
 		// Not if closing
-		if (g->_flags & FLAG_CLOSING) continue;
+		if (g->_flags & FLAG_CLOSING)
+			continue;
 
 		g = g->FindGump(t, recursive, no_inheritance);
 
-		if (g) return g;
+		if (g)
+			return g;
 	}
 
-	return 0;
+	return nullptr;
 }
 
 // Makes this gump the focus
@@ -577,8 +587,9 @@ void Gump::MakeFocus() {
 }
 
 void Gump::FindNewFocusChild() {
-	if (_focusChild) _focusChild->OnFocus(false);
-	_focusChild = 0;
+	if (_focusChild)
+		_focusChild->OnFocus(false);
+	_focusChild = nullptr;
 
 	// Now add the gump to use as the new focus
 	Std::list<Gump *>::reverse_iterator	it = _children.rbegin();
@@ -634,7 +645,7 @@ void Gump::RemoveChild(Gump *gump) {
 
 	// Remove it
 	_children.remove(gump);
-	gump->_parent = 0;
+	gump->_parent = nullptr;
 
 	// Remove focus, the give upper most gump the focus
 	if (gump == _focusChild) {
@@ -686,7 +697,7 @@ Gump *Gump::OnMouseDown(int button, int32 mx, int32 my) {
 	// Convert to local coords
 	ParentToGump(mx, my);
 
-	Gump *handled = 0;
+	Gump *handled = nullptr;
 
 	// Iterate children backwards
 	Std::list<Gump *>::reverse_iterator it;
@@ -709,7 +720,7 @@ Gump *Gump::OnMouseMotion(int32 mx, int32 my) {
 	// Convert to local coords
 	ParentToGump(mx, my);
 
-	Gump *handled = 0;
+	Gump *handled = nullptr;
 
 	// Iterate children backwards
 	Std::list<Gump *>::reverse_iterator it;
@@ -829,7 +840,7 @@ bool Gump::loadData(IDataSource *ids, uint32 version) {
 	_layer = static_cast<int32>(ids->read4());
 	_index = static_cast<int32>(ids->read4());
 
-	_shape = 0;
+	_shape = nullptr;
 	ShapeArchive *flex = GameData::get_instance()->getShapeFlex(ids->read2());
 	uint32 shapenum = ids->read4();
 	if (flex) {
@@ -838,7 +849,7 @@ bool Gump::loadData(IDataSource *ids, uint32 version) {
 
 	_frameNum = ids->read4();
 	uint16 focusid = ids->read2();
-	_focusChild = 0;
+	_focusChild = nullptr;
 	_notifier = ids->read2();
 	_processResult = ids->read4();
 

--- a/engines/ultima/ultima8/gumps/inverter_gump.cpp
+++ b/engines/ultima/ultima8/gumps/inverter_gump.cpp
@@ -34,7 +34,7 @@ DEFINE_RUNTIME_CLASSTYPE_CODE(InverterGump, DesktopGump)
 
 InverterGump::InverterGump(int32 x, int32 y, int32 width, int32 height)
 	: DesktopGump(x, y, width, height) {
-	_buffer = 0;
+	_buffer = nullptr;
 }
 
 InverterGump::~InverterGump() {

--- a/engines/ultima/ultima8/gumps/item_relative_gump.cpp
+++ b/engines/ultima/ultima8/gumps/item_relative_gump.cpp
@@ -111,10 +111,10 @@ void ItemRelativeGump::GumpToParent(int32 &gx, int32 &gy, PointRoundDir r) {
 }
 
 void ItemRelativeGump::GetItemLocation(int32 lerp_factor) {
-	Item *it = 0;
-	Item *next = 0;
-	Item *prev = 0;
-	Gump *gump = 0;
+	Item *it = nullptr;
+	Item *next = nullptr;
+	Item *prev = nullptr;
+	Gump *gump = nullptr;
 
 	it = getItem(_owner);
 
@@ -125,7 +125,7 @@ void ItemRelativeGump::GetItemLocation(int32 lerp_factor) {
 		return;
 	}
 
-	while ((next = it->getParentAsContainer()) != 0) {
+	while ((next = it->getParentAsContainer()) != nullptr) {
 		prev = it;
 		it = next;
 		gump = getGump(it->getGump());

--- a/engines/ultima/ultima8/gumps/mini_stats_gump.cpp
+++ b/engines/ultima/ultima8/gumps/mini_stats_gump.cpp
@@ -117,7 +117,7 @@ Gump *MiniStatsGump::OnMouseDown(int button, int32 mx, int32 my) {
 	if (button == Shared::BUTTON_LEFT)
 		return this;
 
-	return 0;
+	return nullptr;
 }
 
 void MiniStatsGump::OnMouseDouble(int button, int32 mx, int32 my) {

--- a/engines/ultima/ultima8/gumps/paged_gump.cpp
+++ b/engines/ultima/ultima8/gumps/paged_gump.cpp
@@ -36,7 +36,8 @@ DEFINE_RUNTIME_CLASSTYPE_CODE(PagedGump, ModalGump)
 
 PagedGump::PagedGump(int left, int right, int top, int shape):
 	ModalGump(0, 0, 5, 5), _leftOff(left), _rightOff(right), _topOff(top),
-	_gumpShape(shape), _nextButton(0), _prevButton(0), _buttonsEnabled(true) {
+	_gumpShape(shape), _nextButton(nullptr), _prevButton(nullptr),
+	_buttonsEnabled(true) {
 	_current = _gumps.end();
 }
 

--- a/engines/ultima/ultima8/gumps/paperdoll_gump.cpp
+++ b/engines/ultima/ultima8/gumps/paperdoll_gump.cpp
@@ -102,7 +102,7 @@ PaperdollGump::PaperdollGump(Shape *shape_, uint32 frameNum, uint16 owner,
 PaperdollGump::~PaperdollGump() {
 	for (int i = 0; i < 14; ++i) { // ! constant
 		delete _cachedText[i];
-		_cachedText[i] = 0;
+		_cachedText[i] = nullptr;
 	}
 }
 
@@ -232,7 +232,8 @@ uint16 PaperdollGump::TraceObjId(int32 mx, int32 my) {
 
 	Actor *a = getActor(_owner);
 
-	if (!a) return 0; // Container gone!?
+	if (!a)
+		return 0; // Container gone!?
 
 	for (int i = 1; i <= 6; ++i) {
 		Item *item = getItem(a->getEquip(i));

--- a/engines/ultima/ultima8/gumps/scaler_gump.cpp
+++ b/engines/ultima/ultima8/gumps/scaler_gump.cpp
@@ -36,8 +36,10 @@ DEFINE_RUNTIME_CLASSTYPE_CODE(ScalerGump, DesktopGump)
 
 ScalerGump::ScalerGump(int32 x, int32 y, int32 width, int32 height) :
 		DesktopGump(x, y, width, height),
-		_swidth1(width), _sheight1(height), _scaler1(0), _buffer1(0),
-		_swidth2(width), _sheight2(height), _scaler2(0), _buffer2(0),
+		_swidth1(width), _sheight1(height),
+		_scaler1(nullptr), _buffer1(nullptr),
+		_swidth2(width), _sheight2(height),
+		_scaler2(nullptr), _buffer2(nullptr),
 		_width(width), _height(height) {
 
 	setupScaling();

--- a/engines/ultima/ultima8/gumps/shape_viewer_gump.cpp
+++ b/engines/ultima/ultima8/gumps/shape_viewer_gump.cpp
@@ -53,7 +53,8 @@ namespace Ultima8 {
 DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeViewerGump, ModalGump)
 
 ShapeViewerGump::ShapeViewerGump()
-	: ModalGump(), _curFlex(0), _flex(0), _curShape(0), _curFrame(0), _background(0) {
+	: ModalGump(), _curFlex(0), _flex(nullptr), _curShape(0),
+	_curFrame(0), _background(0) {
 
 }
 
@@ -65,7 +66,7 @@ ShapeViewerGump::ShapeViewerGump(int width, int height,
 	if (_flexes.size())
 		_flex = _flexes[0].second;
 	else
-		_flex = 0;
+		_flex = nullptr;
 }
 
 ShapeViewerGump::~ShapeViewerGump() {

--- a/engines/ultima/ultima8/gumps/slider_gump.cpp
+++ b/engines/ultima/ultima8/gumps/slider_gump.cpp
@@ -42,16 +42,14 @@ namespace Ultima8 {
 
 DEFINE_RUNTIME_CLASSTYPE_CODE(SliderGump, ModalGump)
 
-SliderGump::SliderGump() : ModalGump() {
-	_renderedText = 0;
+SliderGump::SliderGump() : ModalGump(), _renderedText(nullptr) {
 }
 
 
 SliderGump::SliderGump(int x, int y, int16 min, int16 max,
                        int16 value_, int16 delta)
-	: ModalGump(x, y, 5, 5), _min(min), _max(max), _delta(delta), _value(value_) {
-	_usecodeNotifyPID = 0;
-	_renderedText = 0;
+	: ModalGump(x, y, 5, 5), _min(min), _max(max), _delta(delta), _value(value_),
+	  _usecodeNotifyPID(0), _renderedText(nullptr) {
 }
 
 SliderGump::~SliderGump() {

--- a/engines/ultima/ultima8/gumps/u8_save_gump.cpp
+++ b/engines/ultima/ultima8/gumps/u8_save_gump.cpp
@@ -328,7 +328,8 @@ Gump *U8SaveGump::showLoadSaveGump(Gump *parent, bool save) {
 		// can't _save if game over
 		// FIXME: this check should probably be in Game or GUIApp
 		MainActor *av = getMainActor();
-		if (!av || (av->getActorFlags() & Actor::ACT_DEAD)) return 0;
+		if (!av || (av->getActorFlags() & Actor::ACT_DEAD))
+			return nullptr;
 	}
 
 	PagedGump *gump = new PagedGump(34, -38, 3, 35);

--- a/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
@@ -38,14 +38,14 @@ namespace Ultima8 {
 // p_dynamic_class stuff
 DEFINE_RUNTIME_CLASSTYPE_CODE(ButtonWidget, Gump)
 
-ButtonWidget::ButtonWidget() : Gump(), _shapeUp(0), _shapeDown(0), _mouseOver(false),
-		_origW(0), _origH(0) {
+ButtonWidget::ButtonWidget() : Gump(), _shapeUp(nullptr), _shapeDown(nullptr),
+		_mouseOver(false), _origW(0), _origH(0) {
 }
 
 ButtonWidget::ButtonWidget(int x, int y, Std::string txt, bool gamefont,
                            int font, uint32 mouseOverBlendCol,
                            int w, int h, int32 layer) :
-	Gump(x, y, w, h, 0, 0, layer), _shapeUp(0), _shapeDown(0),
+	Gump(x, y, w, h, 0, 0, layer), _shapeUp(nullptr), _shapeDown(nullptr),
 	_mouseOver(false), _origW(w), _origH(h) {
 	TextWidget *widget = new TextWidget(0, 0, txt, gamefont, font, w, h);
 	_textWidget = widget->getObjId();
@@ -76,8 +76,8 @@ void ButtonWidget::InitGump(Gump *newparent, bool take_focus) {
 		widget->GetDims(_dims); // transfer child dimension to self
 		widget->Move(0, _dims.y); // move it to the correct height
 	} else {
-		assert(_shapeUp != 0);
-		assert(_shapeDown != 0);
+		assert(_shapeUp != nullptr);
+		assert(_shapeDown != nullptr);
 
 		_shape = _shapeUp;
 		_frameNum = _frameNumUp;
@@ -115,7 +115,8 @@ bool ButtonWidget::PointOnGump(int mx, int my) {
 
 Gump *ButtonWidget::OnMouseDown(int button, int32 mx, int32 my) {
 	Gump *ret = Gump::OnMouseDown(button, mx, my);
-	if (ret) return ret;
+	if (ret)
+		return ret;
 	if (button == Shared::BUTTON_LEFT) {
 		// CHECKME: change dimensions or not?
 		if (!_mouseOver) {
@@ -124,7 +125,7 @@ Gump *ButtonWidget::OnMouseDown(int button, int32 mx, int32 my) {
 		}
 		return this;
 	}
-	return 0;
+	return nullptr;
 }
 
 uint16 ButtonWidget::TraceObjId(int32 mx, int32 my) {
@@ -228,7 +229,7 @@ void ButtonWidget::saveData(ODataSource *ods) {
 bool ButtonWidget::loadData(IDataSource *ids, uint32 version) {
 	if (!Gump::loadData(ids, version)) return false;
 
-	_shapeUp = 0;
+	_shapeUp = nullptr;
 	ShapeArchive *flex = GameData::get_instance()->getShapeFlex(ids->read2());
 	uint32 shapenum = ids->read4();
 	if (flex) {
@@ -236,7 +237,7 @@ bool ButtonWidget::loadData(IDataSource *ids, uint32 version) {
 	}
 	_frameNumUp = ids->read4();
 
-	_shapeDown = 0;
+	_shapeDown = nullptr;
 	flex = GameData::get_instance()->getShapeFlex(ids->read2());
 	shapenum = ids->read4();
 	if (flex) {

--- a/engines/ultima/ultima8/gumps/widgets/edit_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/edit_widget.cpp
@@ -42,13 +42,13 @@ EditWidget::EditWidget(int x, int y, Std::string txt, bool gamefont_, int font,
                        int w, int h, unsigned int maxlength_, bool multiline_)
 	: Gump(x, y, w, h), _text(txt), _gameFont(gamefont_), _fontNum(font),
 	  _maxLength(maxlength_), _multiLine(multiline_),
-	  _cursorChanged(0), _cursorVisible(true), _cachedText(0) {
+	  _cursorChanged(0), _cursorVisible(true), _cachedText(nullptr) {
 	_cursor = _text.size();
 }
 
 EditWidget::~EditWidget(void) {
 	delete _cachedText;
-	_cachedText = 0;
+	_cachedText = nullptr;
 }
 
 // Init the gump, call after construction
@@ -184,7 +184,7 @@ void EditWidget::PaintComposited(RenderSurface *surf, int32 lerp_factor, int32 s
 
 // don't handle any mouse motion events, so let parent handle them for us.
 Gump *EditWidget::OnMouseMotion(int32 mx, int32 my) {
-	return 0;
+	return nullptr;
 }
 
 bool EditWidget::OnKeyDown(int key, int mod) {

--- a/engines/ultima/ultima8/gumps/widgets/text_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/text_widget.cpp
@@ -40,19 +40,19 @@ DEFINE_RUNTIME_CLASSTYPE_CODE(TextWidget, Gump)
 
 TextWidget::TextWidget() : Gump(), _gameFont(false), _fontNum(0), _blendColour(0),
 		_tx(0), _ty(0), _currentStart(0), _currentEnd(0), _targetWidth(0), _targetHeight(0),
-		_cachedText(0), _textAlign(Font::TEXT_LEFT) {
+		_cachedText(nullptr), _textAlign(Font::TEXT_LEFT) {
 }
 
 TextWidget::TextWidget(int x, int y, const Std::string &txt, bool gamefont_, int font,
                        int w, int h, Font::TextAlign align) :
 	Gump(x, y, w, h), _text(txt), _gameFont(gamefont_), _fontNum(font),
 	_blendColour(0), _currentStart(0), _currentEnd(0),
-	_targetWidth(w), _targetHeight(h), _cachedText(0), _textAlign(align) {
+	_targetWidth(w), _targetHeight(h), _cachedText(nullptr), _textAlign(align) {
 }
 
 TextWidget::~TextWidget(void) {
 	delete _cachedText;
-	_cachedText = 0;
+	_cachedText = nullptr;
 }
 
 // Init the gump, call after construction
@@ -129,7 +129,7 @@ bool TextWidget::setupNextText() {
 	_currentEnd = _currentStart + remaining;
 
 	delete _cachedText;
-	_cachedText = 0;
+	_cachedText = nullptr;
 
 	if (_gameFont) {
 		Font *fontP = getFont();
@@ -211,7 +211,7 @@ void TextWidget::PaintComposited(RenderSurface *surf, int32 lerp_factor, int32 s
 
 // don't handle any mouse motion events, so let parent handle them for us.
 Gump *TextWidget::OnMouseMotion(int32 mx, int32 my) {
-	return 0;
+	return nullptr;
 }
 
 

--- a/engines/ultima/ultima8/kernel/core_app.cpp
+++ b/engines/ultima/ultima8/kernel/core_app.cpp
@@ -38,11 +38,11 @@ using Std::string;
 // p_dynamic_cast stuff
 DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(CoreApp)
 
-CoreApp *CoreApp::_application = 0;
+CoreApp *CoreApp::_application = nullptr;
 
 CoreApp::CoreApp(const Ultima::UltimaGameDescription *gameDesc)
-		: _gameDesc(gameDesc), _isRunning(false), _gameInfo(0), _fileSystem(0),
-		_configFileMan(0), _settingMan(0) {
+		: _gameDesc(gameDesc), _isRunning(false), _gameInfo(nullptr), _fileSystem(nullptr),
+		_configFileMan(nullptr), _settingMan(nullptr) {
 	_application = this;
 }
 
@@ -57,7 +57,7 @@ CoreApp::~CoreApp() {
 	FORGET_OBJECT(_configFileMan);
 	FORGET_OBJECT(_gameInfo);
 
-	_application = 0;
+	_application = nullptr;
 }
 
 void CoreApp::startup() {
@@ -66,7 +66,7 @@ void CoreApp::startup() {
 }
 
 void CoreApp::sysInit() {
-	_gameInfo = 0;
+	_gameInfo = nullptr;
 
 	_fileSystem = new FileSystem;
 
@@ -163,7 +163,7 @@ GameInfo *CoreApp::getDefaultGame() {
 		     << Std::endl
 		     << "or set pentagram/defaultgame in pentagram.ini"
 		     << Std::endl;  // FIXME - report more useful error message
-		return 0;
+		return nullptr;
 	}
 
 	pout << "Default game: " << gamename << Std::endl;
@@ -209,7 +209,7 @@ void CoreApp::killGame() {
 	_configFileMan->clearRoot("game");
 	_settingMan->setCurrentDomain(SettingManager::DOM_GLOBAL);
 
-	_gameInfo = 0;
+	_gameInfo = nullptr;
 }
 
 
@@ -318,7 +318,7 @@ GameInfo *CoreApp::getGameInfo(istring game) const {
 	if (i != _games.end())
 		return i->_value;
 	else
-		return 0;
+		return nullptr;
 }
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/kernel/core_app.h
+++ b/engines/ultima/ultima8/kernel/core_app.h
@@ -115,7 +115,7 @@ protected:
 	void setupGameList();
 
 	//! return default game
-	//! \return 0 if no default game (implies go to Pentagram Menu)
+	//! \return nullptr if no default game (implies go to Pentagram Menu)
 	GameInfo *getDefaultGame();
 
 	//! Setup up a game

--- a/engines/ultima/ultima8/kernel/kernel.cpp
+++ b/engines/ultima/ultima8/kernel/kernel.cpp
@@ -32,7 +32,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-Kernel *Kernel::_kernel = 0;
+Kernel *Kernel::_kernel = nullptr;
 
 Kernel::Kernel() : _loading(false) {
 	debugN(MM_INFO, "Creating Kernel...\n");
@@ -42,7 +42,7 @@ Kernel::Kernel() : _loading(false) {
 	current_process = _processes.end();
 	_frameNum = 0;
 	_paused = 0;
-	_runningProcess = 0;
+	_runningProcess = nullptr;
 	_frameByFrame = false;
 }
 
@@ -50,7 +50,7 @@ Kernel::~Kernel() {
 	reset();
 	debugN(MM_INFO, "Destroying Kernel...\n");
 
-	_kernel = 0;
+	_kernel = nullptr;
 
 	delete _pIDs;
 }
@@ -67,7 +67,7 @@ void Kernel::reset() {
 	_pIDs->clearAll();
 
 	_paused = 0;
-	_runningProcess = 0;
+	_runningProcess = nullptr;
 
 	// if we're in frame-by-frame mode, reset to a _paused state
 	if (_frameByFrame) _paused = 1;
@@ -185,7 +185,7 @@ void Kernel::runProcesses() {
 			if (!_runningProcess)
 				return; // If this happens then the list was reset so leave NOW!
 
-			_runningProcess = 0;
+			_runningProcess = nullptr;
 		}
 		if (!_paused && (p->_flags & Process::PROC_TERMINATED)) {
 			// process is killed, so remove it from the list
@@ -234,7 +234,7 @@ Process *Kernel::getProcess(ProcId pid) {
 		if (p->_pid == pid)
 			return p;
 	}
-	return 0;
+	return nullptr;
 }
 
 void Kernel::kernelStats() {
@@ -285,7 +285,7 @@ Process *Kernel::findProcess(ObjId objid, uint16 processtype) {
 		}
 	}
 
-	return 0;
+	return nullptr;
 }
 
 
@@ -360,7 +360,7 @@ Process *Kernel::loadProcess(IDataSource *ids, uint32 version) {
 
 	if (iter == _processLoaders.end()) {
 		perr << "Unknown Process class: " << classname << Std::endl;
-		return 0;
+		return nullptr;
 	}
 
 

--- a/engines/ultima/ultima8/kernel/kernel.h
+++ b/engines/ultima/ultima8/kernel/kernel.h
@@ -150,22 +150,6 @@ private:
 	static Kernel *_kernel;
 };
 
-// a bit of a hack to prevent having to write a load function for
-// every process
-template<class T>
-struct ProcessLoader {
-	static Process *load(IDataSource *ids, uint32 version) {
-		T *p = new T();
-		bool ok = p->loadData(ids, version);
-		if (!ok) {
-			delete p;
-			p = 0;
-		}
-		return p;
-	}
-};
-
-
 extern uint getRandom();
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/kernel/mouse.cpp
+++ b/engines/ultima/ultima8/kernel/mouse.cpp
@@ -39,7 +39,7 @@ namespace Ultima8 {
 
 Mouse *Mouse::_instance;
 
-Mouse::Mouse() : _flashingCursorTime(0), _mouseOverGump(0), _defaultMouse(0),
+Mouse::Mouse() : _flashingCursorTime(0), _mouseOverGump(0), _defaultMouse(nullptr),
 		_dragging(DRAG_NOT), _dragging_objId(0), _draggingItem_startGump(0),
 		_draggingItem_lastGump(0) {
 	_instance = this;

--- a/engines/ultima/ultima8/kernel/object_manager.cpp
+++ b/engines/ultima/ultima8/kernel/object_manager.cpp
@@ -52,7 +52,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-ObjectManager *ObjectManager::_objectManager = 0;
+ObjectManager *ObjectManager::_objectManager = nullptr;
 
 
 // a template class  to prevent having to write a load function for
@@ -64,7 +64,7 @@ struct ObjectLoader {
 		bool ok = p->loadData(ids, version);
 		if (!ok) {
 			delete p;
-			p = 0;
+			p = nullptr;
 		}
 		return p;
 	}
@@ -88,7 +88,7 @@ ObjectManager::~ObjectManager() {
 	reset();
 	debugN(MM_INFO, "Destroying ObjectManager...\n");
 
-	_objectManager = 0;
+	_objectManager = nullptr;
 
 	delete _objIDs;
 	delete _actorIDs;
@@ -128,11 +128,11 @@ void ObjectManager::objectStats() {
 
 	//!constants
 	for (i = 1; i < 256; i++) {
-		if (_objects[i] != 0)
+		if (_objects[i] != nullptr)
 			npccount++;
 	}
 	for (i = 256; i < _objects.size(); i++) {
-		if (_objects[i] != 0)
+		if (_objects[i] != nullptr)
 			objcount++;
 	}
 
@@ -199,7 +199,7 @@ void ObjectManager::clearObjId(ObjId objid) {
 	else
 		_actorIDs->clearID(objid);
 
-	_objects[objid] = 0;
+	_objects[objid] = nullptr;
 }
 
 Object *ObjectManager::getObject(ObjId objid) const {
@@ -309,14 +309,14 @@ Object *ObjectManager::loadObject(IDataSource *ids, Std::string classname,
 
 	if (iter == _objectLoaders.end()) {
 		perr << "Unknown Object class: " << classname << Std::endl;
-		return 0;
+		return nullptr;
 	}
 
 	Object *obj = (*(iter->_value))(ids, version);
 
 	if (!obj) {
 		perr << "Error loading object of type " << classname << Std::endl;
-		return 0;
+		return nullptr;
 	}
 	uint16 objid = obj->getObjId();
 
@@ -330,7 +330,7 @@ Object *ObjectManager::loadObject(IDataSource *ids, Std::string classname,
 		if (!used) {
 			perr << "Error: object ID " << objid
 			     << " used but marked available. " << Std::endl;
-			return 0;
+			return nullptr;
 		}
 	}
 

--- a/engines/ultima/ultima8/kernel/segmented_allocator.cpp
+++ b/engines/ultima/ultima8/kernel/segmented_allocator.cpp
@@ -49,7 +49,7 @@ void *SegmentedAllocator::allocate(size_t size) {
 	SegmentedPool *p;
 
 	if (size > _nodeCapacity)
-		return 0;
+		return nullptr;
 
 	for (i = _pools.begin(); i != _pools.end(); ++i) {
 		if (!(*i)->isFull())
@@ -67,7 +67,7 @@ void *SegmentedAllocator::allocate(size_t size) {
 	}
 
 	// fail
-	return 0;
+	return nullptr;
 }
 
 Pool *SegmentedAllocator::findPool(void *ptr) {
@@ -76,7 +76,7 @@ Pool *SegmentedAllocator::findPool(void *ptr) {
 		if ((*i)->inPool(ptr))
 			return *i;
 	}
-	return 0;
+	return nullptr;
 }
 
 void SegmentedAllocator::freeResources() {

--- a/engines/ultima/ultima8/kernel/segmented_pool.cpp
+++ b/engines/ultima/ultima8/kernel/segmented_pool.cpp
@@ -102,20 +102,20 @@ void *SegmentedPool::allocate(size_t size) {
 	SegmentedPoolNode *node;
 
 	if (isFull() || size > _nodeCapacity)
-		return 0;
+		return nullptr;
 
 	--_freeNodeCount;
 	node = _firstFree;
 	node->size = size;
 
 	if (isFull()) {
-		_firstFree = 0;
-		_lastFree = 0;
+		_firstFree = nullptr;
+		_lastFree = nullptr;
 	} else {
 		_firstFree = _firstFree->nextFree;
 	}
 
-	node->nextFree = 0;
+	node->nextFree = nullptr;
 
 //	debugN"Allocating Node 0x%08X\n", node);
 	uint8 *p = reinterpret_cast<uint8 *>(node) +

--- a/engines/ultima/ultima8/kernel/segmented_pool.h
+++ b/engines/ultima/ultima8/kernel/segmented_pool.h
@@ -39,7 +39,7 @@ struct SegmentedPoolNode;
  * A pool with memory broken into even length segments.
  * SegmentedPool only allocate memory one segment at a time.
  * If the requested memory is larger than a segment, allocation will fail
- * and return 0.
+ * and return nullptr.
  */
 class SegmentedPool: public Pool {
 public:

--- a/engines/ultima/ultima8/misc/debugger.cpp
+++ b/engines/ultima/ultima8/misc/debugger.cpp
@@ -324,13 +324,13 @@ bool Debugger::cmdMemberVar(int argc, const char **argv) {
 	Ultima8Engine *g = Ultima8Engine::get_instance();
 
 	// Set the pointer to the correct type
-	bool *b = 0;
-	int *i = 0;
-	Std::string *str = 0;
-	istring *istr = 0;
+	bool *b = nullptr;
+	int *i = nullptr;
+	Std::string *str = nullptr;
+	istring *istr = nullptr;
 
 	// ini entry name if supported
-	const char *ini = 0;
+	const char *ini = nullptr;
 
 	if (!scumm_stricmp(argv[1], "_frameLimit")) {
 		b = &g->_frameLimit;

--- a/engines/ultima/ultima8/misc/p_dynamic_cast.h
+++ b/engines/ultima/ultima8/misc/p_dynamic_cast.h
@@ -29,7 +29,7 @@ namespace Ultima8 {
 // The Pentagram dynamic cast
 template<class A, class B> inline A p_dynamic_cast(B *object) {
 	if (object && object->IsOfType(static_cast<A>(0)->ClassType)) return static_cast<A>(object);
-	return 0;
+	return nullptr;
 }
 
 // This is just a 'type' used to differentiate each class.

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -115,16 +115,32 @@ namespace Ultima8 {
 
 using Std::string;
 
+// a bit of a hack to prevent having to write a load function for
+// every process
+template<class T>
+struct ProcessLoader {
+	static Process *load(IDataSource *ids, uint32 version) {
+		T *p = new T();
+		bool ok = p->loadData(ids, version);
+		if (!ok) {
+			delete p;
+			p = nullptr;
+		}
+		return p;
+	}
+};
+
 DEFINE_RUNTIME_CLASSTYPE_CODE(Ultima8Engine, CoreApp)
 
 Ultima8Engine::Ultima8Engine(OSystem *syst, const Ultima::UltimaGameDescription *gameDesc) :
-		Shared::UltimaEngine(syst, gameDesc), CoreApp(gameDesc), _saveCount(0), _game(0),
-		_kernel(0), _objectManager(0), _mouse(0), _ucMachine(0), _screen(0),
-		_fontManager(0), _paletteManager(0), _gameData(0), _world(0), _desktopGump(0),
-		_gameMapGump(0), _avatarMoverProcess(0), _frameSkip(false), _frameLimit(true),
-		_interpolate(true), _animationRate(100), _avatarInStasis(false), _paintEditorItems(false),
-		_inversion(0), _painting(false), _showTouching(false), _timeOffset(0), _hasCheated(false),
-		_cheatsEnabled(false), _ttfOverrides(false), _audioMixer(0) {
+		Shared::UltimaEngine(syst, gameDesc), CoreApp(gameDesc), _saveCount(0), _game(nullptr),
+		_kernel(nullptr), _objectManager(nullptr), _mouse(nullptr), _ucMachine(nullptr),
+		_screen(nullptr), _fontManager(nullptr), _paletteManager(nullptr), _gameData(nullptr),
+		_world(nullptr), _desktopGump(nullptr), _gameMapGump(nullptr), _avatarMoverProcess(nullptr),
+		_frameSkip(false), _frameLimit(true), _interpolate(true), _animationRate(100),
+		_avatarInStasis(false), _paintEditorItems(false), _inversion(0), _painting(false),
+		_showTouching(false), _timeOffset(0), _hasCheated(false), _cheatsEnabled(false),
+		_ttfOverrides(false), _audioMixer(0) {
 	_application = this;
 
 	for (uint16 key = 0; key < HID_LAST; ++key) {
@@ -364,10 +380,10 @@ void Ultima8Engine::shutdownGame(bool reloading) {
 		_audioMixer->reset();
 	}
 
-	_desktopGump = 0;
-	_gameMapGump = 0;
-	_scalerGump = 0;
-	_inverterGump = 0;
+	_desktopGump = nullptr;
+	_gameMapGump = nullptr;
+	_scalerGump = nullptr;
+	_inverterGump = nullptr;
 
 	_timeOffset = -(int32)Kernel::get_instance()->getFrameNum();
 	_saveCount = 0;
@@ -586,7 +602,7 @@ void Ultima8Engine::GraphicSysInit() {
 
 		delete _screen;
 	}
-	_screen = 0;
+	_screen = nullptr;
 
 	// Set Screen Resolution
 	debugN(MM_INFO, "Setting Video Mode %dx%dx%d...\n", width, height, bpp);
@@ -780,7 +796,7 @@ void Ultima8Engine::handleEvent(const Common::Event &event) {
 	}
 
 	// Text mode input. A few hacks here
-	Gump *gump = 0;
+	Gump *gump = nullptr;
 
 	if (!_textModes.empty()) {
 		while (!_textModes.empty()) {
@@ -1075,10 +1091,10 @@ void Ultima8Engine::resetEngine() {
 	_paletteManager->resetTransforms();
 
 	// Reset thet gumps
-	_desktopGump = 0;
-	_gameMapGump = 0;
-	_scalerGump = 0;
-	_inverterGump = 0;
+	_desktopGump = nullptr;
+	_gameMapGump = nullptr;
+	_scalerGump = nullptr;
+	_inverterGump = nullptr;
 
 	_textModes.clear();
 

--- a/engines/ultima/ultima8/usecode/bit_set.cpp
+++ b/engines/ultima/ultima8/usecode/bit_set.cpp
@@ -29,12 +29,11 @@
 namespace Ultima {
 namespace Ultima8 {
 
-BitSet::BitSet() : _size(0), _bytes(0), _data(0) {
+BitSet::BitSet() : _size(0), _bytes(0), _data(nullptr) {
 }
 
 
-BitSet::BitSet(unsigned int size) {
-	_data = 0;
+BitSet::BitSet(unsigned int size) : _data(nullptr) {
 	setSize(size);
 }
 

--- a/engines/ultima/ultima8/usecode/uc_machine.cpp
+++ b/engines/ultima/ultima8/usecode/uc_machine.cpp
@@ -79,7 +79,7 @@ enum UCSegments {
 	SEG_GLOBAL     = 0x8003
 };
 
-UCMachine *UCMachine::_ucMachine = 0;
+UCMachine *UCMachine::_ucMachine = nullptr;
 
 UCMachine::UCMachine(Intrinsic *iset, unsigned int icount) {
 	debugN(MM_INFO, "Creating UCMachine...\n");
@@ -104,16 +104,16 @@ UCMachine::UCMachine(Intrinsic *iset, unsigned int icount) {
 
 UCMachine::~UCMachine() {
 	debugN(MM_INFO, "Destroying UCMachine...\n");
-	_ucMachine = 0;
+	_ucMachine = nullptr;
 
 	delete _globals;
-	_globals = 0;
+	_globals = nullptr;
 	delete _convUse;
-	_convUse = 0;
+	_convUse = nullptr;
 	delete _listIDs;
-	_listIDs = 0;
+	_listIDs = nullptr;
 	delete _stringIDs;
-	_stringIDs = 0;
+	_stringIDs = nullptr;
 }
 
 void UCMachine::reset() {
@@ -1987,7 +1987,7 @@ UCList *UCMachine::getList(uint16 l) {
 	if (iter != _listHeap.end())
 		return iter->_value;
 
-	return 0;
+	return nullptr;
 }
 
 

--- a/engines/ultima/ultima8/usecode/usecode_flex.cpp
+++ b/engines/ultima/ultima8/usecode/usecode_flex.cpp
@@ -44,7 +44,7 @@ const char *UsecodeFlex::get_class_name(uint32 classid) {
 		const uint8 *name_object = get_object_nodel(1);
 		return reinterpret_cast<const char *>(name_object + 4 + (13 * classid));
 	} else {
-		return 0;
+		return nullptr;
 	}
 }
 

--- a/engines/ultima/ultima8/world/actors/actor.cpp
+++ b/engines/ultima/ultima8/world/actors/actor.cpp
@@ -93,7 +93,7 @@ uint16 Actor::getMaxHP() const {
 
 bool Actor::loadMonsterStats() {
 	ShapeInfo *shapeinfo = getShapeInfo();
-	MonsterInfo *mi = 0;
+	MonsterInfo *mi = nullptr;
 	if (shapeinfo) mi = shapeinfo->_monsterInfo;
 	if (!mi)
 		return false;
@@ -122,7 +122,7 @@ bool Actor::loadMonsterStats() {
 bool Actor::giveTreasure() {
 	MainShapeArchive *mainshapes = GameData::get_instance()->getMainShapes();
 	ShapeInfo *shapeinfo = getShapeInfo();
-	MonsterInfo *mi = 0;
+	MonsterInfo *mi = nullptr;
 	if (shapeinfo) mi = shapeinfo->_monsterInfo;
 	if (!mi)
 		return false;
@@ -750,7 +750,7 @@ ProcId Actor::die(uint16 damageType) {
 	giveTreasure();
 
 	ShapeInfo *shapeinfo = getShapeInfo();
-	MonsterInfo *mi = 0;
+	MonsterInfo *mi = nullptr;
 	if (shapeinfo) mi = shapeinfo->_monsterInfo;
 
 	if (mi && mi->_resurrection && !(damageType & WeaponInfo::DMG_FIRE)) {
@@ -965,7 +965,8 @@ int Actor::calculateAttackDamage(uint16 other, int damage, uint16 damage_type) {
 
 CombatProcess *Actor::getCombatProcess() {
 	Process *p = Kernel::get_instance()->findProcess(_objId, 0xF2); // CONSTANT!
-	if (!p) return 0;
+	if (!p)
+		return nullptr;
 	CombatProcess *cp = p_dynamic_cast<CombatProcess *>(p);
 	assert(cp);
 
@@ -975,7 +976,7 @@ CombatProcess *Actor::getCombatProcess() {
 void Actor::setInCombat() {
 	if ((_actorFlags & ACT_INCOMBAT) != 0) return;
 
-	assert(getCombatProcess() == 0);
+	assert(getCombatProcess() == nullptr);
 
 	// kill any processes belonging to this actor
 	Kernel::get_instance()->killProcesses(getObjId(), 6, true);
@@ -1043,7 +1044,7 @@ Actor *Actor::createActor(uint32 shape, uint32 frame) {
 	                  Item::FLG_IN_NPC_LIST,
 	                  0, 0, 0, true);
 	if (!newactor)
-		return 0;
+		return nullptr;
 	uint16 objID = newactor->getObjId();
 
 	// set stats

--- a/engines/ultima/ultima8/world/actors/actor_anim.h
+++ b/engines/ultima/ultima8/world/actors/actor_anim.h
@@ -39,7 +39,8 @@ public:
 	}
 
 	AnimAction *getAction(unsigned int n) {
-		if (n >= _actions.size()) return 0;
+		if (n >= _actions.size())
+			return nullptr;
 		return _actions[n];
 	}
 

--- a/engines/ultima/ultima8/world/actors/actor_anim_process.cpp
+++ b/engines/ultima/ultima8/world/actors/actor_anim_process.cpp
@@ -62,22 +62,18 @@ static const int watchactor = WATCHACTOR;
 // p_dynamic_cast stuff
 DEFINE_RUNTIME_CLASSTYPE_CODE(ActorAnimProcess, Process)
 
-ActorAnimProcess::ActorAnimProcess() : Process(), _tracker(0) {
+ActorAnimProcess::ActorAnimProcess() : Process(), _tracker(nullptr) {
 
 }
 
 ActorAnimProcess::ActorAnimProcess(Actor *actor_, Animation::Sequence action_,
-                                   uint32 dir_, uint32 steps_) {
+                                   uint32 dir_, uint32 steps_) :
+		_dir(dir_), _action(action_), _steps(steps_), _tracker(nullptr),
+		_firstFrame(true), _currentStep(0) {
 	assert(actor_);
 	_itemNum = actor_->getObjId();
-	_dir = dir_;
-	_action = action_;
-	_steps = steps_;
 
 	_type = 0x00F0; // CONSTANT !
-	_firstFrame = true;
-	_tracker = 0;
-	_currentStep = 0;
 }
 
 bool ActorAnimProcess::init() {
@@ -117,7 +113,7 @@ bool ActorAnimProcess::init() {
 	_tracker = new AnimationTracker();
 	if (!_tracker->init(actor, _action, _dir)) {
 		delete _tracker;
-		_tracker = 0;
+		_tracker = nullptr;
 		return false;
 	}
 
@@ -372,7 +368,7 @@ void ActorAnimProcess::doSpecial() {
 
 	// ghosts
 	if (a->getShape() == 0x19b) {
-		Actor *hostile = 0;
+		Actor *hostile = nullptr;
 		if (_action == Animation::attack) {
 			// fireball on attack
 			unsigned int skullcount = a->countNearby(0x19d, 6 * 256);
@@ -669,7 +665,7 @@ bool ActorAnimProcess::loadData(IDataSource *ids, uint32 version) {
 	_repeatCounter = ids->read2();
 	_currentStep = ids->read2();
 
-	assert(_tracker == 0);
+	assert(_tracker == nullptr);
 	if (ids->read1() != 0) {
 		_tracker = new AnimationTracker();
 		if (!_tracker->load(ids, version))

--- a/engines/ultima/ultima8/world/actors/animation_tracker.cpp
+++ b/engines/ultima/ultima8/world/actors/animation_tracker.cpp
@@ -618,7 +618,7 @@ bool AnimationTracker::load(IDataSource *ids, uint32 version) {
 	uint32 shapenum = ids->read4();
 	uint32 action = ids->read4();
 	if (shapenum == 0) {
-		_animAction = 0;
+		_animAction = nullptr;
 	} else {
 		_animAction = GameData::get_instance()->getMainShapes()->
 		             getAnim(shapenum, action);

--- a/engines/ultima/ultima8/world/actors/combat_process.cpp
+++ b/engines/ultima/ultima8/world/actors/combat_process.cpp
@@ -278,7 +278,7 @@ void CombatProcess::turnToDirection(int direction) {
 bool CombatProcess::inAttackRange() {
 	Actor *a = getActor(_itemNum);
 	ShapeInfo *shapeinfo = a->getShapeInfo();
-	MonsterInfo *mi = 0;
+	MonsterInfo *mi = nullptr;
 	if (shapeinfo) mi = shapeinfo->_monsterInfo;
 
 	if (mi && mi->_ranged)
@@ -301,7 +301,7 @@ bool CombatProcess::inAttackRange() {
 void CombatProcess::waitForTarget() {
 	Actor *a = getActor(_itemNum);
 	ShapeInfo *shapeinfo = a->getShapeInfo();
-	MonsterInfo *mi = 0;
+	MonsterInfo *mi = nullptr;
 	if (shapeinfo) mi = shapeinfo->_monsterInfo;
 
 	if (mi && mi->_shifter && a->getMapNum() != 43 && (getRandom() % 2) == 0) {

--- a/engines/ultima/ultima8/world/actors/main_actor.cpp
+++ b/engines/ultima/ultima8/world/actors/main_actor.cpp
@@ -61,7 +61,7 @@ MainActor::~MainActor() {
 }
 
 GravityProcess *MainActor::ensureGravityProcess() {
-	AvatarGravityProcess *p = 0;
+	AvatarGravityProcess *p = nullptr;
 	if (_gravityPid) {
 		p = p_dynamic_cast<AvatarGravityProcess *>(
 		        Kernel::get_instance()->getProcess(_gravityPid));

--- a/engines/ultima/ultima8/world/actors/pathfinder.cpp
+++ b/engines/ultima/ultima8/world/actors/pathfinder.cpp
@@ -530,7 +530,7 @@ bool Pathfinder::pathfind(Std::vector<PathfindingAction> &path) {
 	PathNode *startnode = new PathNode();
 	startnode->state = _start;
 	startnode->cost = 0;
-	startnode->parent = 0;
+	startnode->parent = nullptr;
 	startnode->depth = 0;
 	startnode->stepsfromparent = 0;
 	_nodeList.push_back(startnode);

--- a/engines/ultima/ultima8/world/actors/weapon_overlay.h
+++ b/engines/ultima/ultima8/world/actors/weapon_overlay.h
@@ -51,13 +51,16 @@ struct AnimWeaponOverlay {
 	//! \param type the overlay type
 	//! \param direction the direction
 	//! \param frame the animation frame
-	//! \return 0 if invalid, or pointer to a frame; don't delete it.
+	//! \return nullptr if invalid, or pointer to a frame; don't delete it.
 	const WeaponOverlayFrame *getFrame(unsigned int type,
 	                                   unsigned int direction,
 	                                   unsigned int frame) const {
-		if (type >= _overlay.size()) return 0;
-		if (direction >= _overlay[type]._dirCount) return 0;
-		if (frame >= _overlay[type]._frames[direction].size()) return 0;
+		if (type >= _overlay.size())
+			return nullptr;
+		if (direction >= _overlay[type]._dirCount)
+			return nullptr;
+		if (frame >= _overlay[type]._frames[direction].size())
+			return nullptr;
 		return &(_overlay[type]._frames[direction][frame]);
 	}
 

--- a/engines/ultima/ultima8/world/camera_process.cpp
+++ b/engines/ultima/ultima8/world/camera_process.cpp
@@ -43,7 +43,7 @@ DEFINE_RUNTIME_CLASSTYPE_CODE(CameraProcess, Process)
 //
 // Statics
 //
-CameraProcess *CameraProcess::_camera = 0;
+CameraProcess *CameraProcess::_camera = nullptr;
 int32 CameraProcess::_earthquake = 0;
 int32 CameraProcess::_eqX = 0;
 int32 CameraProcess::_eqY = 0;
@@ -53,7 +53,7 @@ CameraProcess::CameraProcess() : Process() {
 
 CameraProcess::~CameraProcess() {
 	if (_camera == this)
-		_camera = 0;
+		_camera = nullptr;
 }
 
 uint16 CameraProcess::SetCameraProcess(CameraProcess *cam) {
@@ -65,7 +65,7 @@ uint16 CameraProcess::SetCameraProcess(CameraProcess *cam) {
 
 void CameraProcess::ResetCameraProcess() {
 	if (_camera) _camera->terminate();
-	_camera = 0;
+	_camera = nullptr;
 }
 
 void CameraProcess::GetCameraLocation(int32 &x, int32 &y, int32 &z) {

--- a/engines/ultima/ultima8/world/container.cpp
+++ b/engines/ultima/ultima8/world/container.cpp
@@ -100,7 +100,7 @@ bool Container::CanAddItem(Item *item, bool checkwghtvol) {
 		do {
 			if (p == c)
 				return false;
-		} while ((p = p->getParentAsContainer()) != 0);
+		} while ((p = p->getParentAsContainer()) != nullptr);
 	}
 
 	if (checkwghtvol) {

--- a/engines/ultima/ultima8/world/current_map.cpp
+++ b/engines/ultima/ultima8/world/current_map.cpp
@@ -96,7 +96,7 @@ void CurrentMap::clear() {
 	}
 
 	_fastXMin =  _fastYMin = _fastXMax = _fastYMax = -1;
-	_currentMap = 0;
+	_currentMap = nullptr;
 
 	Process *ehp = Kernel::get_instance()->getProcess(_eggHatcher);
 	if (ehp)
@@ -105,7 +105,7 @@ void CurrentMap::clear() {
 }
 
 uint32 CurrentMap::getNum() const {
-	if (_currentMap == 0)
+	if (_currentMap == nullptr)
 		return 0;
 
 	return _currentMap->_mapNum;
@@ -190,7 +190,7 @@ void CurrentMap::loadItems(list<Item *> itemlist, bool callCacheIn) {
 
 void CurrentMap::loadMap(Map *map) {
 	// don't call the cachein events at startup or when loading a savegame
-	bool callCacheIn = (_currentMap != 0);
+	bool callCacheIn = (_currentMap != nullptr);
 
 	_currentMap = map;
 
@@ -639,8 +639,15 @@ TeleportEgg *CurrentMap::findDestination(uint16 id) {
 			}
 		}
 	}
-	return 0;
+	return nullptr;
 }
+
+const Std::list<Item *> *CurrentMap::getItemList(int32 gx, int32 gy) const {
+	if (gx < 0 || gy < 0 || gx >= MAP_NUM_CHUNKS || gy >= MAP_NUM_CHUNKS)
+		return nullptr;
+	return &_items[gx][gy];
+}
+
 
 bool CurrentMap::isValidPosition(int32 x, int32 y, int32 z,
                                  uint32 shape,
@@ -683,7 +690,7 @@ bool CurrentMap::isValidPosition(int32 x, int32 y, int32 z,
 	const uint32 blockflagmask = (ShapeInfo::SI_SOLID | ShapeInfo::SI_DAMAGING);
 
 	bool valid = true;
-	const Item *support = 0;
+	const Item *support = nullptr;
 	ObjId roof = 0;
 	int32 roofz = 1 << 24; //!! semi-constant
 
@@ -1189,7 +1196,7 @@ bool CurrentMap::sweepTest(const int32 start[3], const int32 end[3],
 
 
 Item *CurrentMap::traceTopItem(int32 x, int32 y, int32 ztop, int32 zbot, ObjId ignore, uint32 shflags) {
-	Item *top = 0;
+	Item *top = nullptr;
 
 	if (ztop < zbot) {
 		int32 temp = ztop;
@@ -1241,7 +1248,7 @@ Item *CurrentMap::traceTopItem(int32 x, int32 y, int32 ztop, int32 zbot, ObjId i
 					top->getLocation(tix, tiy, tiz);
 					top->getFootpadWorld(tixd, tiyd, tizd);
 
-					if ((tiz + tizd) < (iz + izd)) top = 0;
+					if ((tiz + tizd) < (iz + izd)) top = nullptr;
 				}
 
 				if (!top) top = item;

--- a/engines/ultima/ultima8/world/current_map.h
+++ b/engines/ultima/ultima8/world/current_map.h
@@ -185,12 +185,7 @@ public:
 	TeleportEgg *findDestination(uint16 id);
 
 	// Not allowed to modify the list. Remember to use const_iterator
-	const Std::list<Item *> *getItemList(int32 gx, int32 gy) {
-		// CONSTANTS!
-		if (gx < 0 || gy < 0 || gx >= MAP_NUM_CHUNKS || gy >= MAP_NUM_CHUNKS)
-			return 0;
-		return &_items[gx][gy];
-	}
+	const Std::list<Item *> *getItemList(int32 gx, int32 gy) const;
 
 	bool isChunkFast(int32 cx, int32 cy) {
 		// CONSTANTS!

--- a/engines/ultima/ultima8/world/gravity_process.cpp
+++ b/engines/ultima/ultima8/world/gravity_process.cpp
@@ -43,12 +43,10 @@ GravityProcess::GravityProcess()
 }
 
 GravityProcess::GravityProcess(Item *item, int gravity)
-	: _xSpeed(0), _ySpeed(0), _zSpeed(0) {
+	: _xSpeed(0), _ySpeed(0), _zSpeed(0), _gravity(gravity) {
 	assert(item);
 
-	_gravity = gravity;
 	_itemNum = item->getObjId();
-
 	_type = 0x203; // CONSTANT!
 }
 

--- a/engines/ultima/ultima8/world/item.cpp
+++ b/engines/ultima/ultima8/world/item.cpp
@@ -73,8 +73,8 @@ Item::Item()
 	: _shape(0), _frame(0), _x(0), _y(0), _z(0),
 	  _flags(0), _quality(0), _npcNum(0), _mapNum(0),
 	  _extendedFlags(0), _parent(0),
-	  _cachedShape(0), _cachedShapeInfo(0), _gump(0), _gravityPid(0),
-	  _lastSetup(0) {
+	  _cachedShape(nullptr), _cachedShapeInfo(nullptr),
+	  _gump(0), _gravityPid(0), _lastSetup(0) {
 }
 
 
@@ -102,7 +102,8 @@ void Item::dumpInfo() const {
 
 Container *Item::getParentAsContainer() const {
 	// No _parent, no container
-	if (!_parent) return 0;
+	if (!_parent)
+		return nullptr;
 
 	Container *p = getContainer(_parent);
 
@@ -439,6 +440,12 @@ Box Item::getWorldBox() const {
 	int32 xd, yd, zd;
 	getFootpadWorld(xd, yd, zd);
 	return Box(_x, _y, _z, xd, yd, zd);
+}
+
+void Item::setShape(uint32 shape_) {
+	_shape = shape_;
+	_cachedShapeInfo = nullptr;
+	_cachedShape = nullptr;
 }
 
 bool Item::overlaps(Item &item2) const {
@@ -1445,7 +1452,7 @@ int32 Item::ascend(int delta) {
 }
 
 GravityProcess *Item::ensureGravityProcess() {
-	GravityProcess *p = 0;
+	GravityProcess *p = nullptr;
 	if (_gravityPid) {
 		p = p_dynamic_cast<GravityProcess *>(
 		        Kernel::get_instance()->getProcess(_gravityPid));

--- a/engines/ultima/ultima8/world/item.h
+++ b/engines/ultima/ultima8/world/item.h
@@ -177,11 +177,7 @@ public:
 	}
 
 	//! Set this Item's shape number
-	void setShape(uint32 shape_) {
-		_shape = shape_;
-		_cachedShapeInfo = 0;
-		_cachedShape = 0;
-	}
+	void setShape(uint32 shape_);
 
 	//! Get this Item's frame number
 	uint32 getFrame() const {

--- a/engines/ultima/ultima8/world/item_factory.cpp
+++ b/engines/ultima/ultima8/world/item_factory.cpp
@@ -67,7 +67,7 @@ static Item *getItemForFamily(uint32 family) {
 		return new TeleportEgg();
 	}
 
-	return 0;
+	return nullptr;
 }
 
 Item *ItemFactory::createItem(uint32 shape, uint32 frame, uint16 quality,
@@ -76,8 +76,8 @@ Item *ItemFactory::createItem(uint32 shape, uint32 frame, uint16 quality,
 	// check what class to create
 	ShapeInfo *info = GameData::get_instance()->getMainShapes()->
 	                  getShapeInfo(shape);
-	if (info == 0)
-		return 0;
+	if (info == nullptr)
+		return nullptr;
 
 	// New item, no lerping
 	extendedflags |= Item::EXT_LERP_NOPREV;
@@ -115,7 +115,7 @@ Actor *ItemFactory::createActor(uint32 shape, uint32 frame, uint16 quality,
 	/*
 	    // This makes it rather hard to create new NPCs...
 	    if (npcnum == 0) // or do monsters have npcnum 0? we'll see...
-	        return 0;
+	        return nullptr;
 	*/
 	// New actor, no lerping
 	extendedflags |= Item::EXT_LERP_NOPREV;

--- a/engines/ultima/ultima8/world/item_sorter.cpp
+++ b/engines/ultima/ultima8/world/item_sorter.cpp
@@ -42,7 +42,8 @@ namespace Ultima8 {
 
 // This does NOT need to be in the header
 struct SortItem {
-	SortItem(SortItem *n) : _next(n), _prev(0), _itemNum(0), _shape(0), _order(-1), _depends() { }
+	SortItem(SortItem *n) : _next(n), _prev(nullptr), _itemNum(0),
+			_shape(nullptr), _order(-1), _depends() { }
 
 	SortItem                *_next;
 	SortItem                *_prev;
@@ -117,7 +118,7 @@ struct SortItem {
 			Node        *_next;
 			Node        *_prev;
 			SortItem    *val;
-			Node() : _next(0), _prev(0), val(0) { }
+			Node() : _next(nullptr), _prev(nullptr), val(nullptr) { }
 		};
 
 		Node *list;
@@ -143,15 +144,15 @@ struct SortItem {
 			return iterator(list);
 		}
 		iterator end() {
-			return iterator(0);
+			return iterator(nullptr);
 		}
 
 		void clear() {
 			if (tail) {
 				tail->_next = unused;
 				unused = list;
-				tail = 0;
-				list = 0;
+				tail = nullptr;
+				list = nullptr;
 			}
 		}
 
@@ -164,7 +165,7 @@ struct SortItem {
 			// Put it at the end
 			if (tail) tail->_next = nn;
 			if (!list) list = nn;
-			nn->_next = 0;
+			nn->_next = nullptr;
 			nn->_prev = tail;
 			tail = nn;
 		}
@@ -175,7 +176,7 @@ struct SortItem {
 			unused = unused->_next;
 			nn->val = other;
 
-			for (Node *n = list; n != 0; n = n->_next) {
+			for (Node *n = list; n != nullptr; n = n->_next) {
 				// Get the insert point... which is before the first item that has higher z than us
 				if (other->ListLessThan(n->val)) {
 					nn->_next = n;
@@ -190,12 +191,12 @@ struct SortItem {
 			// No suitable, so put at end
 			if (tail) tail->_next = nn;
 			if (!list) list = nn;
-			nn->_next = 0;
+			nn->_next = nullptr;
 			nn->_prev = tail;
 			tail = nn;
 		}
 
-		DependsList() : list(0), tail(0), unused(0) { }
+		DependsList() : list(nullptr), tail(nullptr), unused(nullptr) { }
 
 		~DependsList() {
 			clear();
@@ -596,7 +597,8 @@ inline bool SortItem::operator<<(const SortItem &si2) const {
 //
 
 ItemSorter::ItemSorter() :
-	_shapes(0), _surf(0), _items(0), _itemsTail(0), _itemsUnused(0), _sortLimit(0) {
+	_shapes(nullptr), _surf(nullptr), _items(nullptr), _itemsTail(nullptr),
+	_itemsUnused(nullptr), _sortLimit(0) {
 	int i = 2048;
 	while (i--) _itemsUnused = new SortItem(_itemsUnused);
 }
@@ -607,8 +609,8 @@ ItemSorter::~ItemSorter() {
 		_itemsTail->_next = _itemsUnused;
 		_itemsUnused = _items;
 	}
-	_items = 0;
-	_itemsTail = 0;
+	_items = nullptr;
+	_itemsTail = nullptr;
 
 	while (_itemsUnused) {
 		SortItem *_next = _itemsUnused->_next;
@@ -629,8 +631,8 @@ void ItemSorter::BeginDisplayList(RenderSurface *rs,
 		_itemsTail->_next = _itemsUnused;
 		_itemsUnused = _items;
 	}
-	_items = 0;
-	_itemsTail = 0;
+	_items = nullptr;
+	_itemsTail = nullptr;
 
 	// Set the RenderSurface, and reset the item list
 	_surf = rs;
@@ -764,8 +766,8 @@ void ItemSorter::AddItem(int32 x, int32 y, int32 z, uint32 shapeNum, uint32 fram
 	// Iterate the list and compare _shapes
 
 	// Ok,
-	SortItem *addpoint = 0;
-	for (SortItem *si2 = _items; si2 != 0; si2 = si2->_next) {
+	SortItem *addpoint = nullptr;
+	for (SortItem *si2 = _items; si2 != nullptr; si2 = si2->_next) {
 		// Get the insert point... which is before the first item that has higher z than us
 		if (!addpoint && si->ListLessThan(si2)) addpoint = si2;
 
@@ -807,7 +809,7 @@ void ItemSorter::AddItem(int32 x, int32 y, int32 z, uint32 shapeNum, uint32 fram
 	else {
 		if (_itemsTail) _itemsTail->_next = si;
 		if (!_items) _items = si;
-		si->_next = 0;
+		si->_next = nullptr;
 		si->_prev = _itemsTail;
 		_itemsTail = si;
 	}
@@ -941,8 +943,8 @@ void ItemSorter::AddItem(Item *add) {
 	// Iterate the list and compare _shapes
 
 	// Ok,
-	SortItem *addpoint = 0;
-	for (SortItem *si2 = _items; si2 != 0; si2 = si2->_next) {
+	SortItem *addpoint = nullptr;
+	for (SortItem *si2 = _items; si2 != nullptr; si2 = si2->_next) {
 		// Get the insert point... which is before the first item that has higher z than us
 		if (!addpoint && si->ListLessThan(si2)) addpoint = si2;
 
@@ -984,7 +986,7 @@ void ItemSorter::AddItem(Item *add) {
 	else {
 		if (_itemsTail) _itemsTail->_next = si;
 		if (!_items) _items = si;
-		si->_next = 0;
+		si->_next = nullptr;
 		si->_prev = _itemsTail;
 		_itemsTail = si;
 	}
@@ -994,9 +996,9 @@ void ItemSorter::AddItem(Item *add) {
 SortItem *_prev = 0;
 
 void ItemSorter::PaintDisplayList(bool item_highlight) {
-	_prev = 0;
+	_prev = nullptr;
 	SortItem *it = _items;
-	SortItem *end = 0;
+	SortItem *end = nullptr;
 	_orderCounter = 0;  // Reset the _orderCounter
 	while (it != end) {
 		if (it->_order == -1) if (PaintSortItem(it)) return;
@@ -1070,7 +1072,7 @@ bool ItemSorter::PaintSortItem(SortItem *si) {
 	// FIXME: use highlight/invisibility, also add to Trace() ?
 	if (si->_shapeNum == 1 && si->_itemNum == 1) {
 		MainActor *av = getMainActor();
-		const WeaponOverlayFrame *wo_frame = 0;
+		const WeaponOverlayFrame *wo_frame = nullptr;
 		uint32 wo_shapenum;
 		av->getWeaponOverlay(wo_frame, wo_shapenum);
 		if (wo_frame) {
@@ -1135,7 +1137,7 @@ uint16 ItemSorter::Trace(int32 x, int32 y, HitFace *face, bool item_highlight) {
 	if (!_orderCounter) { // If no _orderCounter we need to sort the _items
 		it = _items;
 		_orderCounter = 0;  // Reset the _orderCounter
-		while (it != 0) {
+		while (it != nullptr) {
 			if (it->_order == -1) if (NullPaintSortItem(it)) break;
 
 			it = it->_next;
@@ -1143,13 +1145,12 @@ uint16 ItemSorter::Trace(int32 x, int32 y, HitFace *face, bool item_highlight) {
 	}
 
 	// Firstly, we check for highlighted _items
-	selected = 0;
+	selected = nullptr;
 
 	if (item_highlight) {
-		it = _itemsTail;
-		selected = 0;
+		selected = nullptr;
 
-		for (it = _itemsTail; it != 0; it = it->_prev) {
+		for (it = _itemsTail; it != nullptr; it = it->_prev) {
 			if (!(it->_flags & (Item::FLG_DISPOSABLE | Item::FLG_FAST_ONLY)) && !it->_fixed) {
 
 				if (!it->_itemNum) continue;
@@ -1179,7 +1180,7 @@ uint16 ItemSorter::Trace(int32 x, int32 y, HitFace *face, bool item_highlight) {
 	// We then check to see if the item has a point where the trace goes.
 	// Finally we then set the selected SortItem if it's '_order' is highest
 
-	if (!selected) for (it = _items; it != 0; it = it->_next) {
+	if (!selected) for (it = _items; it != nullptr; it = it->_next) {
 			if (!it->_itemNum) continue;
 
 			// Doesn't Overlap

--- a/engines/ultima/ultima8/world/split_item_process.cpp
+++ b/engines/ultima/ultima8/world/split_item_process.cpp
@@ -75,7 +75,7 @@ void SplitItemProcess::run() {
 		targetitem->callUsecodeEvent_combine();
 	} else {
 		targetitem->destroy();
-		targetitem = 0;
+		targetitem = nullptr;
 	}
 
 	if (origcount > 0) {
@@ -83,7 +83,7 @@ void SplitItemProcess::run() {
 		original->callUsecodeEvent_combine();
 	} else {
 		original->destroy(); // note: this terminates us
-		original = 0;
+		original = nullptr;
 	}
 
 	_result = 0;

--- a/engines/ultima/ultima8/world/world.cpp
+++ b/engines/ultima/ultima8/world/world.cpp
@@ -48,9 +48,9 @@ namespace Ultima8 {
 
 //#define DUMP_ITEMS
 
-World *World::_world = 0;
+World *World::_world = nullptr;
 
-World::World() : _currentMap(0) {
+World::World() : _currentMap(nullptr) {
 	debugN(MM_INFO, "Creating World...\n");
 
 	_world = this;
@@ -61,7 +61,7 @@ World::~World() {
 	debugN(MM_INFO, "Destroying World...\n");
 	clear();
 
-	_world = 0;
+	_world = nullptr;
 }
 
 
@@ -78,7 +78,7 @@ void World::clear() {
 
 	if (_currentMap)
 		delete _currentMap;
-	_currentMap = 0;
+	_currentMap = nullptr;
 }
 
 void World::reset() {
@@ -107,7 +107,7 @@ bool World::switchMap(uint32 newmap) {
 	if (_currentMap->getNum() == newmap)
 		return true;
 
-	if (newmap >= _maps.size() || _maps[newmap] == 0)
+	if (newmap >= _maps.size() || _maps[newmap] == nullptr)
 		return false; // no such map
 
 	// Map switching procedure:
@@ -156,7 +156,7 @@ bool World::switchMap(uint32 newmap) {
 	if (oldmap != 0) {
 		perr << "Unloading map " << oldmap << Std::endl;
 
-		assert(oldmap < _maps.size() && _maps[oldmap] != 0);
+		assert(oldmap < _maps.size() && _maps[oldmap] != nullptr);
 
 		_currentMap->writeback();
 
@@ -195,7 +195,7 @@ void World::loadNonFixed(IDataSource *ds) {
 		// items in this map?
 		if (f->getSize(i) > 0) {
 			assert(_maps.size() > i);
-			assert(_maps[i] != 0);
+			assert(_maps[i] != nullptr);
 
 			IDataSource *items = f->getDataSource(i);
 
@@ -317,7 +317,7 @@ void World::worldStats() const {
 	unsigned int i, mapcount = 0;
 
 	for (i = 0; i < _maps.size(); i++) {
-		if (_maps[i] != 0 && !_maps[i]->isEmpty())
+		if (_maps[i] != nullptr && !_maps[i]->isEmpty())
 			mapcount++;
 	}
 


### PR DESCRIPTION
The U8 engine mixes item IDs with pointers, so it's often hard to know what I'm looking at when code sets or compares something to 0.  I went through and replaced all `0` literals which actually meant null pointer with the `nullptr` literal - I think I got most of them.

Sorry for the monster patch.  There are a couple of instances of whitespace fixes and me moving things from constructors to initializer lists, so it's not a totally "pure" patch.  I can go back and pull those out if they bother you.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
