### PR TITLE
SDL: Add a separate function for setting the hardware size

### DIFF
--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.cpp
@@ -425,7 +425,7 @@ void DINGUXSdlGraphicsManager::hideOverlay() {
 	SurfaceSdlGraphicsManager::hideOverlay();
 }
 
-bool DINGUXSdlGraphicsManager::loadGFXMode() {
+void DINGUXSdlGraphicsManager::setupHardwareSize() {
 	debug("Game ScreenMode = %d*%d", _videoMode.screenWidth, _videoMode.screenHeight);
 
 	// Forcefully disable aspect ratio correction for games
@@ -450,24 +450,14 @@ bool DINGUXSdlGraphicsManager::loadGFXMode() {
 	if ((_videoMode.mode == GFX_HALF) && !_overlayVisible) {
 		_videoMode.overlayWidth = _videoMode.screenWidth / 2;
 		_videoMode.overlayHeight = _videoMode.screenHeight / 2;
+
+		_videoMode.hardwareWidth = _videoMode.screenWidth / 2;
+		_videoMode.hardwareHeight = _videoMode.screenHeight / 2;
+
 		_videoMode.fullscreen = true;
 	} else {
-		_videoMode.overlayWidth = _videoMode.screenWidth * _videoMode.scaleFactor;
-		_videoMode.overlayHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
-
-		if (_videoMode.screenHeight != 200 && _videoMode.screenHeight != 400)
-			_videoMode.aspectRatioCorrection = false;
-
-		_videoMode.hardwareWidth = _videoMode.screenWidth * _videoMode.scaleFactor;
-		_videoMode.hardwareHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
-
-		if (_videoMode.aspectRatioCorrection) {
-			_videoMode.overlayHeight = real2Aspect(_videoMode.overlayHeight);
-			_videoMode.hardwareHeight = real2Aspect(_videoMode.hardwareHeight);
-		}
+		SurfaceSdlGraphicsManager::setupHardwareSize();
 	}
-
-	return SurfaceSdlGraphicsManager::loadGFXMode();
 }
 
 bool DINGUXSdlGraphicsManager::hasFeature(OSystem::Feature f) const {

--- a/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
+++ b/backends/graphics/dinguxsdl/dinguxsdl-graphics.h
@@ -48,12 +48,14 @@ public:
 	void internUpdateScreen() override;
 	void showOverlay() override;
 	void hideOverlay() override;
-	bool loadGFXMode() override;
 	void drawMouse() override;
 	void undrawMouse() override;
 	void warpMouse(int x, int y) override;
 
 	virtual void transformMouseCoordinates(Common::Point &point);
+
+protected:
+	void setupHardwareSize() override;
 };
 
 #endif /* BACKENDS_GRAPHICS_SDL_DINGUX_H */

--- a/backends/graphics/gph/gph-graphics.cpp
+++ b/backends/graphics/gph/gph-graphics.cpp
@@ -421,8 +421,7 @@ void GPHGraphicsManager::hideOverlay() {
 	SurfaceSdlGraphicsManager::hideOverlay();
 }
 
-bool GPHGraphicsManager::loadGFXMode() {
-
+void GPHGraphicsManager::setupHardwareSize() {
 	// We don't offer anything other than fullscreen on GPH devices so let's not even pretend.
 	_videoMode.fullscreen = true;
 
@@ -450,13 +449,16 @@ bool GPHGraphicsManager::loadGFXMode() {
 		if (_videoMode.aspectRatioCorrection)
 			_videoMode.overlayHeight = real2Aspect(_videoMode.overlayHeight);
 	}
-	SurfaceSdlGraphicsManager::loadGFXMode();
+}
+
+bool GPHGraphicsManager::loadGFXMode() {
+	bool success = SurfaceSdlGraphicsManager::loadGFXMode();
 
 	// The old GP2X hacked SDL needs this after any call to SDL_SetVideoMode
 	// and it does not hurt other devices.
 	SDL_ShowCursor(SDL_DISABLE);
 
-	return true;
+	return success;
 }
 
 bool GPHGraphicsManager::hasFeature(OSystem::Feature f) const {

--- a/backends/graphics/gph/gph-graphics.h
+++ b/backends/graphics/gph/gph-graphics.h
@@ -53,6 +53,9 @@ public:
 	void warpMouse(int x, int y) override;
 
 	virtual void transformMouseCoordinates(Common::Point &point);
+
+protected:
+	void setupHardwareSize() override;
 };
 
 #endif /* BACKENDS_GRAPHICS_GPH_H */

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -902,10 +902,7 @@ static void fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &w
 	height = bestH;
 }
 
-bool SurfaceSdlGraphicsManager::loadGFXMode() {
-	_forceRedraw = true;
-
-#if !defined(__MAEMO__) && !defined(DINGUX) && !defined(GPH_DEVICE)
+void SurfaceSdlGraphicsManager::setupHardwareSize() {
 	_videoMode.overlayWidth = _videoMode.screenWidth * _videoMode.scaleFactor;
 	_videoMode.overlayHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
 
@@ -919,12 +916,12 @@ bool SurfaceSdlGraphicsManager::loadGFXMode() {
 		_videoMode.overlayHeight = real2Aspect(_videoMode.overlayHeight);
 		_videoMode.hardwareHeight = real2Aspect(_videoMode.hardwareHeight);
 	}
+}
 
-// On GPH devices ALL the _videoMode.hardware... are setup in GPHGraphicsManager::loadGFXMode()
-#elif !defined(GPH_DEVICE)
-	_videoMode.hardwareWidth = _videoMode.overlayWidth;
-	_videoMode.hardwareHeight = _videoMode.overlayHeight;
-#endif
+bool SurfaceSdlGraphicsManager::loadGFXMode() {
+	_forceRedraw = true;
+
+	setupHardwareSize();
 
 	//
 	// Create the surface that contains the 8 bit game data

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -187,6 +187,8 @@ protected:
 	virtual int getGraphicsModeScale(int mode) const override;
 	virtual ScalerProc *getGraphicsScalerProc(int mode) const;
 
+	virtual void setupHardwareSize();
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/* SDL2 features a different API for 2D graphics. We create a wrapper
 	 * around this API to keep the code paths as close as possible. */


### PR DESCRIPTION
This removes the need for platform specific `#ifdef`s in `loadGFXMode()`.