### PR TITLE
SDL: Enable joystick input by default

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -220,6 +220,14 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 		break;
 	}
 
+	case Common::EVENT_INPUT_CHANGED: {
+		Common::HardwareInputSet *inputSet = g_system->getHardwareInputSet();
+		Common::KeymapperDefaultBindings *backendDefaultBindings = g_system->getKeymapperDefaultBindings();
+
+		_keymapper->registerHardwareInputSet(inputSet, backendDefaultBindings);
+		break;
+	}
+
 	default:
 		break;
 	}

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -56,6 +56,9 @@ public:
 	 */
 	void fakeWarpMouse(const int x, const int y);
 
+	/** Returns whether a joystick is currently connected */
+	bool isJoystickConnected() const;
+
 protected:
 	/** Scroll lock state - since SDL doesn't track it */
 	bool _scrollLock;
@@ -131,8 +134,8 @@ protected:
 	virtual bool handleJoyHatMotion(SDL_Event &ev, Common::Event &event);
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	virtual bool handleJoystickAdded(const SDL_JoyDeviceEvent &event);
-	virtual bool handleJoystickRemoved(const SDL_JoyDeviceEvent &device);
+	virtual bool handleJoystickAdded(const SDL_JoyDeviceEvent &device, Common::Event &event);
+	virtual bool handleJoystickRemoved(const SDL_JoyDeviceEvent &device, Common::Event &event);
 	virtual int mapSDLControllerButtonToOSystem(Uint8 sdlButton);
 	virtual bool handleControllerButton(const SDL_Event &ev, Common::Event &event, bool buttonUp);
 	virtual bool handleControllerAxisMotion(const SDL_Event &ev, Common::Event &event);

--- a/backends/keymapper/keymap.h
+++ b/backends/keymapper/keymap.h
@@ -144,7 +144,6 @@ public:
 	/**
 	 * Save this keymap's mappings to the config manager
 	 * @note Changes are *not* flushed to disk, to do so call ConfMan.flushToDisk()
-	 * @note Changes are *not* flushed to disk, to do so call ConfMan.flushToDisk()
 	 */
 	void saveMappings();
 

--- a/backends/keymapper/keymapper.h
+++ b/backends/keymapper/keymapper.h
@@ -52,19 +52,11 @@ public:
 	virtual List<Event> mapEvent(const Event &ev);
 
 	/**
-	 * Registers a HardwareInputSet with the Keymapper
-	 * @note should only be called once (during backend initialisation)
+	 * Registers a HardwareInputSet and platform-specific default mappings with the Keymapper
 	 *
 	 * Transfers ownership to the Keymapper
 	 */
-	void registerHardwareInputSet(HardwareInputSet *inputs);
-
-	/**
-	 * Registers platform-specific default mappings for keymap actions
-	 *
-	 * Transfers ownership to the Keymapper
-	 */
-	void registerBackendDefaultBindings(KeymapperDefaultBindings *backendDefaultBindings);
+	void registerHardwareInputSet(HardwareInputSet *inputs, KeymapperDefaultBindings *backendDefaultBindings);
 
 	/**
 	 * Add a keymap to the global domain.
@@ -131,6 +123,7 @@ public:
 	HardwareInput findHardwareInput(const Event &event);
 
 	void initKeymap(Keymap *keymap, ConfigManager::Domain *domain);
+	void reloadKeymapMappings(Keymap *keymap);
 
 private:
 	EventManager *_eventMan;

--- a/backends/keymapper/remap-widget.cpp
+++ b/backends/keymapper/remap-widget.cpp
@@ -93,6 +93,17 @@ bool RemapWidget::save() {
 	return changes;
 }
 
+void RemapWidget::handleInputChanged() {
+	Keymapper *keymapper = g_system->getEventManager()->getKeymapper();
+	assert(keymapper);
+
+	for (uint i = 0; i < _keymapTable.size(); i++) {
+		keymapper->reloadKeymapMappings(_keymapTable[i]);
+	}
+
+	refreshKeymap();
+}
+
 void RemapWidget::reflowActionWidgets() {
 	int buttonHeight = g_gui.xmlEval()->getVar("Globals.Button.Height", 0);
 

--- a/backends/keymapper/remap-widget.h
+++ b/backends/keymapper/remap-widget.h
@@ -51,6 +51,7 @@ public:
 	~RemapWidget() override;
 	void build();
 	bool save();
+	void handleInputChanged();
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 	void handleMouseDown(int x, int y, int button, int clickCount) override;
 	void handleTickle() override;

--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -125,7 +125,6 @@ void OSystem_3DS::quit() {
 
 void OSystem_3DS::initBackend() {
 	loadConfig();
-	ConfMan.set("joystick_num", 0);
 	ConfMan.registerDefault("fullscreen", true);
 	ConfMan.registerDefault("aspect_ratio", true);
 	if (!ConfMan.hasKey("vkeybd_pack_name")) {

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -177,8 +177,7 @@ bool OSystem_SDL::hasFeature(Feature f) {
 	if (f == kFeatureClipboardSupport) return true;
 #endif
 	if (f == kFeatureJoystickDeadzone || f == kFeatureKbdMouseSpeed) {
-		bool joystickSupportEnabled = ConfMan.getInt("joystick_num") >= 0;
-		return joystickSupportEnabled;
+		return _eventSource->isJoystickConnected();
 	}
 	return ModularBackend::hasFeature(f);
 }
@@ -403,8 +402,7 @@ Common::HardwareInputSet *OSystem_SDL::getHardwareInputSet() {
 	inputSet->addHardwareInputSet(new MouseHardwareInputSet(defaultMouseButtons));
 	inputSet->addHardwareInputSet(new KeyboardHardwareInputSet(defaultKeys, defaultModifiers));
 
-	bool joystickSupportEnabled = ConfMan.getInt("joystick_num") >= 0;
-	if (joystickSupportEnabled) {
+	if (_eventSource->isJoystickConnected()) {
 		inputSet->addHardwareInputSet(new JoystickHardwareInputSet(defaultJoystickButtons, defaultJoystickAxes));
 	}
 

--- a/backends/platform/sdl/switch/switch.cpp
+++ b/backends/platform/sdl/switch/switch.cpp
@@ -71,7 +71,6 @@ void OSystem_Switch::init() {
 
 void OSystem_Switch::initBackend() {
 
-	ConfMan.registerDefault("joystick_num", 0);
 	ConfMan.registerDefault("fullscreen", true);
 	ConfMan.registerDefault("aspect_ratio", false);
 	ConfMan.registerDefault("gfx_mode", "2x");
@@ -80,10 +79,8 @@ void OSystem_Switch::initBackend() {
 	ConfMan.registerDefault("touchpad_mouse_mode", false);
 
 	ConfMan.setBool("fullscreen", true);
+	ConfMan.setInt("joystick_num", 0);
 
-	if (!ConfMan.hasKey("joystick_num")) {
-		ConfMan.setInt("joystick_num", 0);
-	}
 	if (!ConfMan.hasKey("aspect_ratio")) {
 		ConfMan.setBool("aspect_ratio", false);
 	}

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -281,7 +281,7 @@ void registerDefaults() {
 #endif
 
 	// Miscellaneous
-	ConfMan.registerDefault("joystick_num", -1);
+	ConfMan.registerDefault("joystick_num", 0);
 	ConfMan.registerDefault("confirm_exit", false);
 	ConfMan.registerDefault("disable_sdl_parachute", false);
 

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -366,8 +366,7 @@ static void setupKeymapper(OSystem &system) {
 	HardwareInputSet *inputSet = system.getHardwareInputSet();
 	KeymapperDefaultBindings *backendDefaultBindings = system.getKeymapperDefaultBindings();
 
-	mapper->registerHardwareInputSet(inputSet);
-	mapper->registerBackendDefaultBindings(backendDefaultBindings);
+	mapper->registerHardwareInputSet(inputSet, backendDefaultBindings);
 
 	Keymap *primaryGlobalKeymap = system.getEventManager()->getGlobalKeymap();
 	if (primaryGlobalKeymap) {

--- a/common/events.h
+++ b/common/events.h
@@ -65,6 +65,10 @@ enum EventType {
 
 	EVENT_QUIT = 10,
 	EVENT_SCREEN_CHANGED = 11,
+
+	/** The input devices have changed, input related configuration needs to be re-applied */
+	EVENT_INPUT_CHANGED  = 35,
+
 	/**
 	 * The backend requests the agi engine's predictive dialog to be shown.
 	 * TODO: Fingolfin suggests that it would be of better value to expand

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -916,6 +916,14 @@ void OptionsDialog::handleTickle() {
 	}
 }
 
+void OptionsDialog::handleOtherEvent(const Common::Event &event) {
+	Dialog::handleOtherEvent(event);
+
+	if (event.type == Common::EVENT_INPUT_CHANGED && _keymapperWidget) {
+		_keymapperWidget->handleInputChanged();
+	}
+}
+
 void OptionsDialog::setGraphicSettingsState(bool enabled) {
 	_enableGraphicSettings = enabled;
 

--- a/gui/options.h
+++ b/gui/options.h
@@ -75,6 +75,7 @@ public:
 	void close() override;
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 	void handleTickle() override;
+	void handleOtherEvent(const Common::Event &event) override;
 
 	const Common::String& getDomain() const { return _domain; }
 


### PR DESCRIPTION
With the keymapper, game controllers are more configurable. I believe it's time to enable them by default in the SDL port. This pull request also includes a change to reload the keymapper's keymaps when a joystick is plugged or unplugged so the the default joystick bindings are picked up if necessary.