### PR TITLE
ULTIMA8: Fix guardian speech events

### DIFF
--- a/engines/ultima/ultima8/audio/speech_flex.cpp
+++ b/engines/ultima/ultima8/audio/speech_flex.cpp
@@ -35,17 +35,21 @@ SpeechFlex::SpeechFlex(IDataSource *ds) : SoundFlex(ds) {
 	uint32 size = getRawSize(0);
 	const uint8 *buf = getRawObject(0);
 
-	istring strings(reinterpret_cast<const char *>(buf), size);
-	Std::vector<istring> s;
-	SplitString(strings, 0, s);
+	const char *cbuf = reinterpret_cast<const char *>(buf);
 
-	for (unsigned int i = 0; i < s.size(); ++i) {
-		TabsToSpaces(s[i], 1);
-		TrimSpaces(s[i]);
+	// Note: SplitString doesn't work here because Std::string can't
+	// hold multiple null-terminated strings.
+	unsigned int off = 0;
+	while (off < size) {
+		istring str(cbuf + off);
+		off += str.size() + 1;
 
-//		pout << "Found string: \"" << s[i] << "\"" << Std::endl;
+		TabsToSpaces(str, 1);
+		TrimSpaces(str);
 
-		_phrases.push_back(s[i]);
+		// pout << "Found string: \"" << str << "\"" << Std::endl;
+
+		_phrases.push_back(str);
 	}
 
 	delete [] buf;

--- a/engines/ultima/ultima8/games/game_data.cpp
+++ b/engines/ultima/ultima8/games/game_data.cpp
@@ -49,14 +49,14 @@ namespace Ultima8 {
 
 GameData *GameData::_gameData = nullptr;
 
-
 GameData::GameData(GameInfo *gameInfo)
 	: _fixed(nullptr), _mainShapes(nullptr), _mainUsecode(nullptr), _globs(),
 	  _fonts(nullptr), _gumps(nullptr), _mouse(nullptr), _music(nullptr),
-	  _weaponOverlay(nullptr), _soundFlex(nullptr), _speech(1024), _gameInfo(gameInfo) {
+	  _weaponOverlay(nullptr), _soundFlex(nullptr), _gameInfo(gameInfo) {
 	debugN(MM_INFO, "Creating GameData...\n");
 
 	_gameData = this;
+	_speech.resize(1024);
 }
 
 GameData::~GameData() {


### PR DESCRIPTION
Speech wasn't working because of a couple of behavior differences with the Std string and vector:

* Initializing with an int sets capacity but not size (so the `_speech` vector size was 0)
* Initializing a string with a buffer including nulls will stop at the first null, so it doesn't split correctly using `SplitString`

Fixed both and now the guardian speech works.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
