### PR TITLE
PINK: fixed pausing when menu bar disappears

### DIFF
--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -155,8 +155,6 @@ void PinkEngine::executeMenuCommand(uint id) {
 
 	case kSaveAction:
 	case kSaveAsAction:
-		//FIXME: Somehow messes up the pause system causing issues such as
-		//frozen animations and BGM disappearing
 		saveGameDialog();
 		break;
 

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -160,8 +160,14 @@ Common::Error Pink::PinkEngine::run() {
 }
 
 void PinkEngine::pauseEngine(void *engine, bool pause) {
-	PinkEngine *vm = (PinkEngine*)engine;
-	vm->pauseEngineIntern(pause);
+	Engine *vm = (Engine *)engine;
+	if (pause) {
+		vm->pauseEngine(true);
+	} else {
+		while (vm->isPaused()) {
+			vm->pauseEngine(false);
+		}
+	}
 }
 
 void PinkEngine::load(Archive &archive) {


### PR DESCRIPTION
This pull request makes pink panther scenes to resume correctly after using menu bar