### PR TITLE
WINTERMUTE: Detect more games

### DIFF
--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -1148,6 +1148,20 @@ public:
 			act->addDefaultInputMapping("F1"); // original keyboard
 			act->addDefaultInputMapping("JOY_LEFT"); // extra joy
 			gameKeyMap->addAction(act);
+		} else if (gameId == "mythguff") {
+			act = new Action("SCRLUP", _("Scroll up"));
+			act->setMouseWheelUpEvent();
+			act->addDefaultInputMapping("MOUSE_WHEEL_UP"); // original mouse
+			act->addDefaultInputMapping("UP"); // extra keyboard
+			act->addDefaultInputMapping("JOY_UP"); // extra joy
+			gameKeyMap->addAction(act);
+
+			act = new Action("SCRLDN", _("Scroll down"));
+			act->setMouseWheelDownEvent();
+			act->addDefaultInputMapping("MOUSE_WHEEL_DOWN"); // original mouse
+			act->addDefaultInputMapping("DOWN"); // extra keyboard
+			act->addDefaultInputMapping("JOY_DOWN"); // extra joy
+			gameKeyMap->addAction(act);
 		} else if (gameId == "oknytt") {
 			act = new Action("INV", _("Show inventory"));
 			act->setKeyEvent(KeyState(KEYCODE_TAB, ASCII_TAB));

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -4646,6 +4646,11 @@ static const WMEGameDescription gameDescriptions[] = {
 	WME_WINENTRY("thelostcrowngha", "",
 		WME_ENTRY1s("theatre.dcp", "01ab6ced306f11e0d0c7d1dfbc7a2658", 78352318), Common::RU_RUS, ADGF_UNSTABLE, WME_1_8_2),
 
+	// The Lost Crown - A Ghost Hunting Adventure (Italian)
+	// NOTE: This is a 2.5D game that is out of ScummVM scope
+	WME_WINENTRY("thelostcrowngha", "",
+		WME_ENTRY1s("theatre.dcp", "4ecf7175f1d7dd6524ff3c0e2cba0a28", 78444724), Common::IT_ITA, ADGF_UNSTABLE, WME_1_8_2),
+
 	// The Lost Crown - A Ghost Hunting Adventure (Steam, Jul 2014) (English)
 	// NOTE: This is a 2.5D game that is out of ScummVM scope
 	WME_WINENTRY("thelostcrowngha", "",

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -96,6 +96,7 @@ static const PlainGameDescriptor wintermuteGames[] = {
 	{"mentalrepairs",   "Mental Repairs Inc"},
 	{"mirage",          "Mirage"},
 	{"msos",            "Monday Starts on Saturday"},
+	{"mythguff",        "Myth: A Guff's Tale"},
 	{"nighttrain",      "Night Train"},
 	{"oknytt",          "Oknytt"},
 	{"one",             "One"},
@@ -1286,6 +1287,10 @@ static const WMEGameDescription gameDescriptions[] = {
 	// Monday Starts on Saturday
 	WME_WINENTRY("msos", "",
 		WME_ENTRY1s("data.dcp", "2aa5ab924b05c9539a5a118bc263c2f8", 1049803074), Common::RU_RUS, ADGF_UNSTABLE, WME_1_9_1),
+
+	// Myth: A Guff's Tale
+	WME_WINENTRY("mythguff", "",
+		WME_ENTRY1s("data.dcp", "ef53dddd2264a7d5b13f3d71da5261e4", 675663078), Common::EN_ANY, ADGF_UNSTABLE, WME_1_9_1),
 
 	// Night Train Demo
 	WME_WINENTRY("nighttrain", "Demo",


### PR DESCRIPTION
1. WINTERMUTE: Add detection for Italian version of thelostcrowngha

Fixes https://bugs.scummvm.org/ticket/11383

2. WINTERMUTE: Add detection and keymap for "Myth: A Guff's Tale"

"Myth: A Guff's Tale" is a cutscene-rich point and click game about a troll fixing a labyrinth in a dreamworld. 
SOLO DESIGN decided to distribute "Myth: A Guff's Tale" for free since game's co-creator Phil Argent passed away...
Download it here: https://www.kartridge.com/games/solodesign/myth-a-guffs-tale
UPD: game can be download without installing Kartridge appstore, see https://www.gameboomers.com/forum/ubbthreads.php/topics/1180355/re-myth-a-guffs-tale#Post1180355 for details