### PR TITLE
ALL: Pause Token

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -171,12 +171,11 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 #endif
 	case Common::EVENT_RTL:
 		if (ConfMan.getBool("confirm_exit")) {
+			PauseToken pt;
 			if (g_engine)
-				g_engine->pauseEngine(true);
+				pt = g_engine->pauseEngine();
 			GUI::MessageDialog alert(_("Do you really want to return to the Launcher?"), _("Launcher"), _("Cancel"));
 			forwardEvent = _shouldRTL = (alert.runModal() == GUI::kMessageOK);
-			if (g_engine)
-				g_engine->pauseEngine(false);
 		} else
 			_shouldRTL = true;
 		break;
@@ -193,12 +192,14 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 				break;
 			}
 			_confirmExitDialogActive = true;
-			if (g_engine)
-				g_engine->pauseEngine(true);
-			GUI::MessageDialog alert(_("Do you really want to quit?"), _("Quit"), _("Cancel"));
-			forwardEvent = _shouldQuit = (alert.runModal() == GUI::kMessageOK);
-			if (g_engine)
-				g_engine->pauseEngine(false);
+
+			{
+				PauseToken pt;
+				if (g_engine)
+					pt = g_engine->pauseEngine();
+				GUI::MessageDialog alert(_("Do you really want to quit?"), _("Quit"), _("Cancel"));
+				forwardEvent = _shouldQuit = (alert.runModal() == GUI::kMessageOK);
+			}
 			_confirmExitDialogActive = false;
 		} else {
 			_shouldQuit = true;

--- a/engines/access/debugger.cpp
+++ b/engines/access/debugger.cpp
@@ -59,7 +59,7 @@ void Debugger::postEnter() {
 		_playMovieFile.clear();
 	}
 
-	_vm->pauseEngine(false);
+	GUI::Debugger::postEnter();
 }
 
 /*------------------------------------------------------------------------*/

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -1077,8 +1077,6 @@ public:
 
 	void inGameTimerReset(uint32 newPlayTime = 0);
 	void inGameTimerResetPassedCycles();
-	void inGameTimerPause();
-	void inGameTimerResume();
 	uint32 inGameTimerGet();
 	uint32 inGameTimerGetPassedCycles();
 

--- a/engines/agi/global.cpp
+++ b/engines/agi/global.cpp
@@ -213,12 +213,6 @@ void AgiEngine::inGameTimerReset(uint32 newPlayTime) {
 void AgiEngine::inGameTimerResetPassedCycles() {
 	_passedPlayTimeCycles = 0;
 }
-void AgiEngine::inGameTimerPause() {
-	pauseEngine(true);
-}
-void AgiEngine::inGameTimerResume() {
-	pauseEngine(false);
-}
 uint32 AgiEngine::inGameTimerGet() {
 	return getTotalPlayTime();
 }

--- a/engines/agi/keyboard.cpp
+++ b/engines/agi/keyboard.cpp
@@ -549,9 +549,7 @@ bool AgiEngine::handleController(uint16 key) {
 bool AgiEngine::showPredictiveDialog() {
 	GUI::PredictiveDialog predictiveDialog;
 
-	inGameTimerPause();
-	predictiveDialog.runModal();
-	inGameTimerResume();
+	runDialog(predictiveDialog);
 
 	Common::String predictiveResult(predictiveDialog.getResult());
 	uint16 predictiveResultLen = predictiveResult.size();

--- a/engines/agi/op_cmd.cpp
+++ b/engines/agi/op_cmd.cpp
@@ -750,20 +750,17 @@ void cmdSaveGame(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 		state->_vm->_sound->stopSound();
 	}
 
-	vm->inGameTimerPause();
+	PauseToken pt = vm->pauseEngine();
 
 	if (state->automaticSave) {
 		if (vm->saveGameAutomatic()) {
 			// automatic save succeded
-			vm->inGameTimerResume();
 			return;
 		}
 		// fall back to regular dialog otherwise
 	}
 
 	vm->saveGameDialog();
-
-	vm->inGameTimerResume();
 }
 
 void cmdLoadGame(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
@@ -772,20 +769,17 @@ void cmdLoadGame(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 		state->_vm->_sound->stopSound();
 	}
 
-	vm->inGameTimerPause();
+	PauseToken pt = vm->pauseEngine();
 
 	if (state->automaticSave) {
 		if (vm->loadGameAutomatic()) {
 			// automatic restore succeded
-			vm->inGameTimerResume();
 			return;
 		}
 		// fall back to regular dialog otherwise
 	}
 
 	vm->loadGameDialog();
-
-	vm->inGameTimerResume();
 }
 
 void cmdInitDisk(AgiGame *state, AgiEngine *vm, uint8 *parameter) {             // do nothing
@@ -1746,11 +1740,9 @@ void cmdSetGameID(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 
 void cmdPause(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	// Show pause message box
-	vm->inGameTimerPause();
+	PauseToken pt = vm->pauseEngine();
 
 	state->_vm->_systemUI->pauseDialog();
-
-	vm->inGameTimerResume();
 }
 
 void cmdSetMenu(AgiGame *state, AgiEngine *vm, uint8 *parameter) {

--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -992,12 +992,12 @@ void AGOSEngine::pauseEngineIntern(bool pauseIt) {
 }
 
 void AGOSEngine::pause() {
-	pauseEngine(true);
+	PauseToken pt = pauseEngine();
 
 	while (_pause && !shouldQuit()) {
 		delay(1);
 		if (_keyPressed.keycode == Common::KEYCODE_PAUSE) {
-			pauseEngine(false);
+			pt.clear();
 			_keyPressed.reset();
 		}
 	}

--- a/engines/cruise/cruise.cpp
+++ b/engines/cruise/cruise.cpp
@@ -178,9 +178,8 @@ bool CruiseEngine::loadLanguageStrings() {
 }
 
 void CruiseEngine::pauseEngine(bool pause) {
-	Engine::pauseEngine(pause);
-
 	if (pause) {
+		_gamePauseToken = Engine::pauseEngine();
 		// Draw the 'Paused' message
 		drawSolidBox(64, 100, 256, 117, 0);
 		drawString(10, 100, langString(ID_PAUSED), gfxModuleData.pPage00, itemColor, 300);
@@ -189,6 +188,7 @@ void CruiseEngine::pauseEngine(bool pause) {
 		_savedCursor = currentCursor;
 		changeCursor(CURSOR_NOMOUSE);
 	} else {
+		_gamePauseToken.clear();
 		processAnimation();
 		flipScreen();
 		changeCursor(_savedCursor);

--- a/engines/cruise/cruise.h
+++ b/engines/cruise/cruise.h
@@ -62,6 +62,7 @@ private:
 	uint32 _lastTick;
 	int _gameSpeed;
 	bool _speedFlag;
+	PauseToken _gamePauseToken;
 
 	void initialize();
 	void deinitialize();

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -863,3 +863,17 @@ PauseToken::~PauseToken() {
 		_engine->resumeEngine();
 	}
 }
+
+#if __cplusplus >= 201103L
+PauseToken::PauseToken(PauseToken &&t2) : _engine(t2._engine) {
+	t2._engine = nullptr;
+}
+
+void PauseToken::operator=(PauseToken &&t2) {
+	if (_engine) {
+		error("Tried to assign to an already busy PauseToken");
+	}
+	_engine = t2._engine;
+	t2._engine = nullptr;
+}
+#endif

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -836,12 +836,8 @@ PauseToken::PauseToken() : _engine(nullptr) {}
 PauseToken::PauseToken(Engine *engine) : _engine(engine) {}
 
 void PauseToken::operator=(const PauseToken &t2) {
-	if (t2._engine == _engine) {
-		return;
-	}
-
 	if (_engine) {
-		_engine->resumeEngine();
+		error("Tried to assign to an already busy PauseToken");
 	}
 	_engine = t2._engine;
 	if (_engine) {

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -852,9 +852,10 @@ PauseToken::PauseToken(const PauseToken &t2) : _engine(t2._engine) {
 }
 
 void PauseToken::clear() {
-	if (_engine) {
-		_engine->resumeEngine();
+	if (!_engine) {
+		error("Tried to clear an already cleared PauseToken");
 	}
+	_engine->resumeEngine();
 	_engine = nullptr;
 }
 

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -855,6 +855,13 @@ PauseToken::PauseToken(const PauseToken &t2) : _engine(t2._engine) {
 	}
 }
 
+void PauseToken::clear() {
+	if (_engine) {
+		_engine->resumeEngine();
+	}
+	_engine = nullptr;
+}
+
 PauseToken::~PauseToken() {
 	if (_engine) {
 		_engine->resumeEngine();

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -65,6 +65,7 @@ public:
 	~PauseToken();
 
 	void operator=(const PauseToken &);
+	void clear();
 private:
 	PauseToken(Engine *);
 

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -56,6 +56,22 @@ class Dialog;
 void GUIErrorMessage(const Common::String &msg);
 void GUIErrorMessageFormat(const char *fmt, ...) GCC_PRINTF(1, 2);
 
+class Engine;
+
+class PauseToken {
+public:
+	PauseToken();
+	PauseToken(const PauseToken &);
+	~PauseToken();
+
+	void operator=(const PauseToken &);
+private:
+	PauseToken(Engine *);
+
+	Engine *_engine;
+
+	friend class Engine;
+};
 
 class Engine {
 public:
@@ -343,13 +359,16 @@ public:
 	 * and other stuff. Called right before the system runs a global dialog
 	 * (like a global pause, main menu, options or 'confirm exit' dialog).
 	 *
-	 * This is a convenience tracker which automatically keeps track on how
-	 * often the engine has been paused, ensuring that after pausing an engine
-	 * e.g. twice, it has to be unpaused twice before actuallying resuming.
-	 *
-	 * @param pause		true to pause the engine, false to resume it
+	 * Returns a PauseToken. Multiple pause tokens may exist. The engine will
+	 * be resumed when all associated pause tokens reach the end of their lives.
 	 */
-	void pauseEngine(bool pause);
+	PauseToken pauseEngine();
+	private:
+		void resumeEngine();
+
+		friend class PauseToken;
+
+	public:
 
 	/**
 	 * Return whether the engine is currently paused or not.

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -58,13 +58,27 @@ void GUIErrorMessageFormat(const char *fmt, ...) GCC_PRINTF(1, 2);
 
 class Engine;
 
+
+/**
+* Manages pausing by Engine::pauseEngine handing out tokens that
+* each represent one requested level of pause.
+*/
 class PauseToken {
 public:
 	PauseToken();
 	PauseToken(const PauseToken &);
+#if __cplusplus >= 201103L
+	PauseToken(PauseToken &&);
+#endif
 	~PauseToken();
 
 	void operator=(const PauseToken &);
+#if __cplusplus >= 201103L
+	void operator=(PauseToken &&);
+#endif
+	/** Manually releases the PauseToken. Only allowed if the token
+	* currently represents a pause request.
+	*/
 	void clear();
 private:
 	PauseToken(Engine *);
@@ -356,7 +370,7 @@ public:
 	static MetaEngine &getMetaEngine();
 
 	/**
-	 * Pause or resume the engine. This should stop/resume any audio playback
+	 * Pause the engine. This should stop any audio playback
 	 * and other stuff. Called right before the system runs a global dialog
 	 * (like a global pause, main menu, options or 'confirm exit' dialog).
 	 *
@@ -364,12 +378,17 @@ public:
 	 * be resumed when all associated pause tokens reach the end of their lives.
 	 */
 	PauseToken pauseEngine();
-	private:
-		void resumeEngine();
+private:
+	/** Resume the engine. This should resume any audio playback and other stuff.
+	*
+	* Only PauseToken is allowed to call this member function. Use the PauseToken
+	* that you got from pauseEngine to resume the engine.
+	*/
+	void resumeEngine();
 
-		friend class PauseToken;
+	friend class PauseToken;
 
-	public:
+public:
 
 	/**
 	 * Return whether the engine is currently paused or not.

--- a/engines/mohawk/console.cpp
+++ b/engines/mohawk/console.cpp
@@ -328,7 +328,7 @@ bool MystConsole::Cmd_Resources(int argc, const char **argv) {
 }
 
 bool MystConsole::Cmd_QuickTest(int argc, const char **argv) {
-	_vm->pauseEngine(false);
+	_debugPauseToken.clear();
 
 	// Go through all the ages, all the views and click random stuff
 	for (uint i = 0; i < ARRAYSIZE(mystStackNames); i++) {
@@ -366,7 +366,7 @@ bool MystConsole::Cmd_QuickTest(int argc, const char **argv) {
 		}
 	}
 
-	_vm->pauseEngine(true);
+	_debugPauseToken = _vm->pauseEngine();
 	return true;
 }
 
@@ -690,7 +690,7 @@ bool RivenConsole::Cmd_SliderState(int argc, const char **argv) {
 }
 
 bool RivenConsole::Cmd_QuickTest(int argc, const char **argv) {
-	_vm->pauseEngine(false);
+	_debugPauseToken.clear();
 
 	// Go through all the stacks, all the cards and click random stuff
 	for (uint16 stackId = kStackFirst; stackId <= kStackLast; stackId++) {
@@ -744,7 +744,7 @@ bool RivenConsole::Cmd_QuickTest(int argc, const char **argv) {
 		}
 	}
 
-	_vm->pauseEngine(true);
+	_debugPauseToken = _vm->pauseEngine();
 	return true;
 }
 

--- a/engines/mohawk/myst_stacks/menu.cpp
+++ b/engines/mohawk/myst_stacks/menu.cpp
@@ -108,7 +108,7 @@ uint16 Menu::getVar(uint16 var) {
 }
 
 void Menu::o_menuInit(uint16 var, const ArgumentsArray &args) {
-	_vm->pauseEngine(true);
+	_pauseToken = _vm->pauseEngine();
 
 	if (_inGame) {
 		_wasCursorVisible = CursorMan.isVisible();
@@ -330,7 +330,7 @@ void Menu::o_menuExit(uint16 var, const ArgumentsArray &args) {
 
 	CursorMan.showMouse(_wasCursorVisible);
 
-	_vm->pauseEngine(false);
+	_pauseToken.clear();
 }
 
 void Menu::o_playIntroMovies(uint16 var, const ArgumentsArray &args) {

--- a/engines/mohawk/myst_stacks/menu.h
+++ b/engines/mohawk/myst_stacks/menu.h
@@ -89,6 +89,8 @@ private:
 	const char **getButtonCaptions() const;
 	void resetButtons();
 
+	PauseToken _pauseToken;
+
 };
 
 } // End of namespace MystStacks

--- a/engines/parallaction/debug.cpp
+++ b/engines/parallaction/debug.cpp
@@ -51,12 +51,12 @@ Debugger::Debugger(Parallaction *vm)
 
 void Debugger::preEnter() {
 	_mouseState = _vm->_input->getMouseState();
-	_vm->pauseEngine(true);
+	GUI::Debugger::preEnter();
 }
 
 
 void Debugger::postEnter() {
-	_vm->pauseEngine(false);
+	GUI::Debugger::postEnter();
 	_vm->_input->setMouseState(_mouseState);
 	_vm->_input->setArrowCursor();	// unselects the active item, if any
 }

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -2121,13 +2121,13 @@ void PegasusEngine::setAmbienceLevel(uint16 ambientLevel) {
 
 void PegasusEngine::pauseMenu(bool menuUp) {
 	if (menuUp) {
-		pauseEngine(true);
+		_menuPauseToken = pauseEngine();
 		_screenDimmer.startDisplaying();
 		_screenDimmer.show();
 		_gfx->updateDisplay();
 		useMenu(new PauseMenu());
 	} else {
-		pauseEngine(false);
+		_menuPauseToken.clear();
 		_screenDimmer.hide();
 		_screenDimmer.stopDisplaying();
 		useMenu(0);

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -1018,14 +1018,12 @@ void PegasusEngine::handleInput(const Input &input, const Hotspot *cursorSpot) {
 
 		// Can only save during a game and not in the demo
 		if (g_neighborhood && !isDemo()) {
-			pauseEngine(true);
+			PauseToken pt = pauseEngine();
 
 			Common::Error result = showSaveDialog();
 
 			if (result.getCode() != Common::kNoError && result.getCode() != Common::kUserCanceled)
 				showSaveFailedDialog(result);
-
-			pauseEngine(false);
 		}
 	}
 
@@ -1040,7 +1038,7 @@ void PegasusEngine::handleInput(const Input &input, const Hotspot *cursorSpot) {
 		// Just use the pause menu's restore button since it's there for that
 		// for you to load anyway.
 		if (!isDemo() && !(_gameMenu && _gameMenu->getObjectID() == kPauseMenuID)) {
-			pauseEngine(true);
+			PauseToken pt = pauseEngine();
 
 			if (g_neighborhood) {
 				makeContinuePoint();
@@ -1062,8 +1060,6 @@ void PegasusEngine::handleInput(const Input &input, const Hotspot *cursorSpot) {
 					resetIntroTimer();
 				}
 			}
-
-			pauseEngine(false);
 		}
 	}
 }

--- a/engines/pegasus/pegasus.h
+++ b/engines/pegasus/pegasus.h
@@ -278,6 +278,7 @@ private:
 	void doInterfaceOverview();
 	ScreenDimmer _screenDimmer;
 	void pauseMenu(bool menuUp);
+	PauseToken _menuPauseToken;
 
 	// Energy
 	int32 _savedEnergyValue;

--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -132,7 +132,7 @@ static void menuCommandsCallback(int action, Common::U32String &, void *data) {
 }
 
 void PinkEngine::initMenu() {
-	_director->getWndManager().setEnginePauseCallback(this, &pauseEngine);
+	_director->getWndManager().setEnginePauseCallback(this);
 
 	_menu = Graphics::MacMenu::createMenuFromPEexe(_exeResources, &_director->getWndManager());
 	_menu->calcDimensions();

--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -132,7 +132,7 @@ static void menuCommandsCallback(int action, Common::U32String &, void *data) {
 }
 
 void PinkEngine::initMenu() {
-	_director->getWndManager().setEnginePauseCallback(this);
+	_director->getWndManager().setEngine(this);
 
 	_menu = Graphics::MacMenu::createMenuFromPEexe(_exeResources, &_director->getWndManager());
 	_menu->calcDimensions();

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -159,17 +159,6 @@ Common::Error Pink::PinkEngine::run() {
 	return Common::kNoError;
 }
 
-void PinkEngine::pauseEngine(void *engine, bool pause) {
-	Engine *vm = (Engine *)engine;
-	if (pause) {
-		vm->pauseEngine(true);
-	} else {
-		while (vm->isPaused()) {
-			vm->pauseEngine(false);
-		}
-	}
-}
-
 void PinkEngine::load(Archive &archive) {
 	archive.skipString();
 	archive.skipString();

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -105,8 +105,6 @@ public:
 		return Common::String::format("%s.s%02d", _targetName.c_str(), slot);
 	}
 
-	static void pauseEngine(void *engine, bool pause); // for MacWndMgr
-
 	friend class Console;
 
 protected:

--- a/engines/queen/debug.cpp
+++ b/engines/queen/debug.cpp
@@ -50,11 +50,11 @@ Debugger::Debugger(QueenEngine *vm)
 Debugger::~Debugger() {} // we need this here for __SYMBIAN32__
 
 void Debugger::preEnter() {
-	_vm->pauseEngine(true);
+	GUI::Debugger::preEnter();
 }
 
 void Debugger::postEnter() {
-	_vm->pauseEngine(false);
+	GUI::Debugger::postEnter();
 	_vm->graphics()->setupMouseCursor();
 }
 

--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -271,7 +271,7 @@ void Console::attach(const char *entry) {
 }
 
 void Console::preEnter() {
-	_engine->pauseEngine(true);
+	GUI::Debugger::preEnter();
 }
 
 extern void playVideo(Video::VideoDecoder &videoDecoder);
@@ -299,7 +299,7 @@ void Console::postEnter() {
 		_videoFrameDelay = 0;
 	}
 
-	_engine->pauseEngine(false);
+	GUI::Debugger::postEnter();
 }
 
 bool Console::cmdHelp(int argc, const char **argv) {

--- a/engines/sci/graphics/controls32.cpp
+++ b/engines/sci/graphics/controls32.cpp
@@ -913,8 +913,9 @@ int16 GfxControls32::showMessageBox(const Common::String &message, const char *c
 }
 
 reg_t GfxControls32::kernelMessageBox(const Common::String &message, const Common::String &title, const uint16 style) {
+	PauseToken pt;
 	if (g_engine) {
-		g_engine->pauseEngine(true);
+		pt = g_engine->pauseEngine();
 	}
 
 	int16 result;
@@ -928,10 +929,6 @@ reg_t GfxControls32::kernelMessageBox(const Common::String &message, const Commo
 	break;
 	default:
 		error("Unsupported MessageBox style 0x%x", style & 0xF);
-	}
-
-	if (g_engine) {
-		g_engine->pauseEngine(false);
 	}
 
 	return make_reg(0, result);

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -195,7 +195,7 @@ bool ScummEngine::saveState(Common::WriteStream *out, bool writeHeader) {
 bool ScummEngine::saveState(int slot, bool compat, Common::String &filename) {
 	bool saveFailed = false;
 
-	pauseEngine(true);
+	PauseToken pt = pauseEngine();
 
 	Common::WriteStream *out = openSaveFileForWriting(slot, compat, filename);
 	if (!out) {
@@ -214,8 +214,6 @@ bool ScummEngine::saveState(int slot, bool compat, Common::String &filename) {
 		debug(1, "State save as '%s' FAILED", filename.c_str());
 	else
 		debug(1, "State saved as '%s'", filename.c_str());
-
-	pauseEngine(false);
 
 	return !saveFailed;
 }

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2790,26 +2790,15 @@ void ScummEngine::pauseEngineIntern(bool pause) {
 	}
 }
 
-int ScummEngine::runDialog(Dialog &dialog) {
-	// Pause engine
-	pauseEngine(true);
-
-	// Open & run the dialog
-	int result = dialog.runModal();
-
-	// Resume engine
-	pauseEngine(false);
-
-	// Return the result
-	return result;
-}
-
 #ifdef ENABLE_SCUMM_7_8
-int ScummEngine_v7::runDialog(Dialog &dialog) {
-	_splayer->pause();
-	int result = ScummEngine::runDialog(dialog);
-	_splayer->unpause();
-	return result;
+void ScummEngine_v7::pauseEngineIntern(bool pause) {
+	if (pause) {
+		_splayer->pause();
+	} else {
+		_splayer->unpause();
+	}
+
+	ScummEngine::pauseEngineIntern(pause);
 }
 #endif
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -497,7 +497,6 @@ protected:
 	Dialog *_messageDialog;
 	Dialog *_versionDialog;
 
-	int runDialog(Dialog &dialog) override;
 	void confirmExitDialog();
 	void confirmRestartDialog();
 	void pauseDialog();

--- a/engines/scumm/scumm_v7.h
+++ b/engines/scumm/scumm_v7.h
@@ -98,7 +98,6 @@ public:
 	bool isSmushActive() { return _smushActive; }
 
 protected:
-	int runDialog(Dialog &dialog) override;
 
 	void scummLoop_handleSound() override;
 	void scummLoop_handleDrawing() override;
@@ -131,6 +130,8 @@ protected:
 	void playSpeech(const byte *ptr);
 
 	void drawVerb(int verb, int mode) override;
+
+	void pauseEngineIntern(bool pause) override;
 
 
 	void o6_kernelSetFunctions() override;

--- a/engines/sherlock/debugger.cpp
+++ b/engines/sherlock/debugger.cpp
@@ -57,7 +57,7 @@ void Debugger::postEnter() {
 		_3doPlayMovieFile.clear();
 	}
 
-	_vm->pauseEngine(false);
+	GUI::Debugger::postEnter();
 }
 
 int Debugger::strToInt(const char *s) {

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -546,9 +546,9 @@ Common::Error Sword2Engine::run() {
 				case Common::KEYCODE_p:
 					if (isPaused()) {
 						_screen->dimPalette(false);
-						pauseEngine(false);
+						_gamePauseToken.clear();
 					} else {
-						pauseEngine(true);
+						_gamePauseToken = pauseEngine();
 						_screen->dimPalette(true);
 					}
 					break;

--- a/engines/sword2/sword2.h
+++ b/engines/sword2/sword2.h
@@ -140,6 +140,8 @@ private:
 	// Original game platform (PC/PSX)
 	static Common::Platform _platform;
 
+	PauseToken _gamePauseToken;
+
 protected:
 	// Engine APIs
 	Common::Error run() override;

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1087,9 +1087,7 @@ bool MacMenu::mouseMove(int x, int y) {
 	} else if ((_wm->_mode & kWMModeAutohideMenu) && !_bbox.contains(x, y)) {
 		_isVisible = false;
 		if (_wm->_mode & kWMModalMenuMode) {
-			_wm->pauseEngine(false);
-			*_wm->_screen = *_wm->_screenCopy; // restore screen
-			g_system->copyRectToScreen(_wm->_screenCopy->getBasePtr(0, 0), _wm->_screenCopy->pitch, 0, 0, _wm->_screenCopy->w, _wm->_screenCopy->h);
+			_wm->disableScreenCopy();
 		}
 	}
 
@@ -1119,9 +1117,7 @@ bool MacMenu::mouseRelease(int x, int y) {
 			_isVisible = false;
 
 		if (_wm->_mode & kWMModalMenuMode) {
-			_wm->pauseEngine(false);
-			*_wm->_screen = *_wm->_screenCopy; // restore screen
-			g_system->copyRectToScreen(_wm->_screenCopy->getBasePtr(0, 0), _wm->_screenCopy->pitch, 0, 0, _wm->_screenCopy->w, _wm->_screenCopy->h);
+			_wm->disableScreenCopy();
 		}
 
 		if (_activeItem != -1 && _activeSubItem != -1 && _menustack.back()->items[_activeSubItem]->enabled) {

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -635,7 +635,7 @@ PauseToken MacWindowManager::pauseEngine() {
 	return _engineP->pauseEngine();
 }
 
-void MacWindowManager::setEnginePauseCallback(Engine *engine) {
+void MacWindowManager::setEngine(Engine *engine) {
 	_engineP = engine;
 }
 

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -31,6 +31,8 @@
 #include "graphics/fontman.h"
 #include "graphics/macgui/macwindow.h"
 
+#include "engines/engine.h"
+
 namespace Graphics {
 
 namespace MacGUIConstants {
@@ -152,6 +154,9 @@ public:
 
 	void activateMenu();
 
+	void activateScreenCopy();
+	void disableScreenCopy();
+
 	bool isMenuActive();
 
 	/**
@@ -231,11 +236,11 @@ public:
 	void pushCustomCursor(const Graphics::Cursor *cursor);
 	void popCursor();
 
-	void pauseEngine(bool pause);
+	PauseToken pauseEngine();
 
 	void setMode(uint32 mode);
 
-	void setEnginePauseCallback(void *engine, void (*pauseCallback)(void *engine, bool pause));
+	void setEnginePauseCallback(Engine *engine);
 	void setEngineRedrawCallback(void *engine, void (*redrawCallback)(void *engine));
 
 	void passPalette(const byte *palette, uint size);
@@ -282,14 +287,15 @@ private:
 	MacMenu *_menu;
 	uint32 _menuDelay;
 
-	void *_engineP;
+	Engine *_engineP;
 	void *_engineR;
-	void (*_pauseEngineCallback)(void *engine, bool pause);
 	void (*_redrawEngineCallback)(void *engine);
 
 	bool _cursorIsArrow;
 
 	MacWidget *_activeWidget;
+
+	PauseToken _screenCopyPauseToken;
 };
 
 } // End of namespace Graphics

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -240,7 +240,7 @@ public:
 
 	void setMode(uint32 mode);
 
-	void setEnginePauseCallback(Engine *engine);
+	void setEngine(Engine *engine);
 	void setEngineRedrawCallback(void *engine, void (*redrawCallback)(void *engine));
 
 	void passPalette(const byte *palette, uint size);

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -147,11 +147,11 @@ void Debugger::debugPrintColumns(const Common::StringArray &list) {
 }
 
 void Debugger::preEnter() {
-	g_engine->pauseEngine(true);
+	_debugPauseToken = g_engine->pauseEngine();
 }
 
 void Debugger::postEnter() {
-	g_engine->pauseEngine(false);
+	_debugPauseToken.clear();
 }
 
 void Debugger::attach(const char *entry) {

--- a/gui/debugger.h
+++ b/gui/debugger.h
@@ -31,6 +31,8 @@
 #include "common/str.h"
 #include "common/str-array.h"
 
+#include "engine.h"
+
 namespace GUI {
 
 #ifndef USE_TEXT_CONSOLE_FOR_DEBUGGER
@@ -171,6 +173,9 @@ private:
 	 * time.
 	 */
 	bool _firstTime;
+
+protected:
+	PauseToken _debugPauseToken;
 
 #ifndef USE_TEXT_CONSOLE_FOR_DEBUGGER
 	GUI::ConsoleDialog *_debuggerDialog;


### PR DESCRIPTION
This PR introduces a new system for managing the pause counter in engines. By using RAII errors with forgotten or duplicate calls to `Engine::pause` wont happen.

In particular, this appears to solve the issue in PINK where opening the save and load dialogs from the menu fails to correctly resume the engine.