### PR TITLE
SWITCH: Use ScummVM file buffering instead of newlib's implementation

### DIFF
--- a/backends/platform/sdl/switch/switch.cpp
+++ b/backends/platform/sdl/switch/switch.cpp
@@ -28,8 +28,8 @@
 #include "backends/platform/sdl/switch/switch.h"
 #include "backends/events/switchsdl/switchsdl-events.h"
 #include "backends/saves/posix/posix-saves.h"
-#include "backends/fs/posix/posix-fs-factory.h"
-#include "backends/fs/posix/posix-fs.h"
+#include "backends/fs/posix-drives/posix-drives-fs-factory.h"
+#include "backends/fs/posix-drives/posix-drives-fs.h"
 #include "backends/keymapper/hardware-input.h"
 
 static const Common::HardwareInputTableEntry switchJoystickButtons[] = {
@@ -62,8 +62,11 @@ static const Common::AxisTableEntry switchJoystickAxes[] = {
 
 void OSystem_Switch::init() {
 	
-	// Initialze File System Factory
-	_fsFactory = new POSIXFilesystemFactory();
+	DrivesPOSIXFilesystemFactory *fsFactory = new DrivesPOSIXFilesystemFactory();
+	fsFactory->addDrive("sdmc:");
+	fsFactory->configureBuffering(DrivePOSIXFilesystemNode::kBufferingModeScummVM, 2048);
+
+	_fsFactory = fsFactory;
 
 	// Invoke parent implementation of this method
 	OSystem_SDL::init();


### PR DESCRIPTION
Fixes #11384.

 I don't have a Switch, this is untested. Based on my experience with the 3DS, ScummVM's implementation of file buffering has better performance than newlib's when seeks are involved. The buffer size probably needs some tuning.