### PR TITLE
POSIX: Add native file browser via GTK

### DIFF
--- a/backends/dialogs/gtk/gtk-dialogs.cpp
+++ b/backends/dialogs/gtk/gtk-dialogs.cpp
@@ -1,0 +1,98 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
+#define FORBIDDEN_SYMBOL_EXCEPTION_unistd_h
+#define FORBIDDEN_SYMBOL_EXCEPTION_time_h
+#include "common/scummsys.h"
+
+#if defined(POSIX) && defined(USE_SYSDIALOGS) && defined(USE_GTK)
+
+#include "backends/dialogs/gtk/gtk-dialogs.h"
+
+#include "common/config-manager.h"
+#include "common/encoding.h"
+#include "common/translation.h"
+
+#include <gtk/gtk.h>
+
+Common::DialogManager::DialogResult GtkDialogManager::showFileBrowser(const char *title, Common::FSNode &choice, bool isDirBrowser) {
+	if (!gtk_init_check(NULL, NULL))
+		return kDialogError;
+
+	DialogResult result = kDialogCancel;
+
+	// Get current encoding
+	Common::String guiEncoding = "ASCII";
+#ifdef USE_TRANSLATION
+	guiEncoding = TransMan.getCurrentCharset();
+#endif
+	Common::Encoding utf8("utf-8", guiEncoding);
+
+	// Convert labels to UTF-8
+	char *utf8Title = utf8.convert(title, strlen(title));
+	Common::String choose = _("Choose");
+	char *utf8Choose = utf8.convert(choose.c_str(), choose.size());
+	Common::String cancel = _("Cancel");
+	char* utf8Cancel = utf8.convert(cancel.c_str(), cancel.size());
+
+	GtkFileChooserAction action = GTK_FILE_CHOOSER_ACTION_OPEN;
+	if (isDirBrowser) {
+		action = GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER;
+	}
+	GtkFileChooserNative *native = gtk_file_chooser_native_new(utf8Title, NULL, action, utf8Choose, utf8Cancel);
+	GtkFileChooser *chooser = GTK_FILE_CHOOSER(native);
+	free(utf8Cancel);
+	free(utf8Choose);
+	free(utf8Title);
+
+	// Customize dialog
+	gtk_file_chooser_set_show_hidden(chooser, ConfMan.getBool("gui_browser_show_hidden", Common::ConfigManager::kApplicationDomain));
+	if (ConfMan.hasKey("browser_lastpath")) {
+		gtk_file_chooser_set_current_folder(chooser, ConfMan.get("browser_lastpath").c_str());
+	}
+
+	// Show dialog
+	beginDialog();
+	int res = gtk_native_dialog_run(GTK_NATIVE_DIALOG(native));
+	if (res == GTK_RESPONSE_ACCEPT) {
+		// Get the selection from the user
+		char *path = gtk_file_chooser_get_filename(chooser);
+		choice = Common::FSNode(path);
+		result = kDialogOk;
+		g_free(path);
+
+		// Save last path
+		char *last = gtk_file_chooser_get_current_folder(chooser);
+		ConfMan.set("browser_lastpath", last);
+		g_free(last);
+	}
+	
+	g_object_unref(native);
+
+	while (gtk_events_pending())
+		gtk_main_iteration();
+	endDialog();
+	return result;
+}
+
+#endif

--- a/backends/dialogs/gtk/gtk-dialogs.h
+++ b/backends/dialogs/gtk/gtk-dialogs.h
@@ -1,0 +1,38 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKEND_GTK_DIALOGS_H
+#define BACKEND_GTK_DIALOGS_H
+
+#if defined(POSIX) && defined(USE_SYSDIALOGS) && defined(USE_GTK)
+
+#include "common/fs.h"
+#include "common/dialogs.h"
+
+class GtkDialogManager : public Common::DialogManager {
+public:
+	virtual DialogResult showFileBrowser(const char *title, Common::FSNode &choice, bool isDirBrowser);
+};
+
+#endif
+
+#endif // BACKEND_GTK_DIALOGS_H

--- a/backends/dialogs/macosx/macosx-dialogs.mm
+++ b/backends/dialogs/macosx/macosx-dialogs.mm
@@ -29,8 +29,6 @@
 #include "backends/dialogs/macosx/macosx-dialogs.h"
 
 #include "common/config-manager.h"
-#include "common/system.h"
-#include "common/events.h"
 #include "common/algorithm.h"
 #include "common/translation.h"
 
@@ -147,13 +145,7 @@ Common::DialogManager::DialogResult MacOSXDialogManager::showFileBrowser(const c
 	CFStringRef titleRef = CFStringCreateWithCString(0, title, stringEncoding);
 	CFStringRef chooseRef = CFStringCreateWithCString(0, _("Choose"), stringEncoding);
 
-	// If in fullscreen mode, switch to windowed mode
-	bool wasFullscreen = g_system->getFeatureState(OSystem::kFeatureFullscreenMode);
-	if (wasFullscreen) {
-		g_system->beginGFXTransaction();
-		g_system->setFeatureState(OSystem::kFeatureFullscreenMode, false);
-		g_system->endGFXTransaction();
-	}
+	beginDialog();
 
 	// Temporarily show the real mouse
 	CGDisplayShowCursor(kCGDirectMainDisplay);
@@ -185,20 +177,7 @@ Common::DialogManager::DialogResult MacOSXDialogManager::showFileBrowser(const c
 	CFRelease(titleRef);
 	CFRelease(chooseRef);
 
-	// While the native macOS file browser is open, any input events (e.g. keypresses) are
-	// still received by the NSApplication. With SDL backend for example this results in the
-	// events beeing queued and processed after we return, thus dispatching events that were
-	// intended for the native file browser. For example: pressing Esc to cancel the native
-	// macOS file browser would cause the application to quit in addition to closing the
-	// file browser. To avoid this happening clear all pending events.
-	g_system->getEventManager()->getEventDispatcher()->clearEvents();
-
-	// If we were in fullscreen mode, switch back
-	if (wasFullscreen) {
-		g_system->beginGFXTransaction();
-		g_system->setFeatureState(OSystem::kFeatureFullscreenMode, true);
-		g_system->endGFXTransaction();
-	}
+	endDialog();
 
 	return result;
 }

--- a/backends/dialogs/win32/win32-dialogs.cpp
+++ b/backends/dialogs/win32/win32-dialogs.cpp
@@ -67,8 +67,6 @@
 #include "backends/platform/sdl/win32/win32-window.h"
 
 #include "common/config-manager.h"
-#include "common/system.h"
-#include "common/events.h"
 #include "common/translation.h"
 
 Win32DialogManager::Win32DialogManager(SdlWindow_Win32 *window) : _window(window) {
@@ -117,13 +115,7 @@ Common::DialogManager::DialogResult Win32DialogManager::showFileBrowser(const ch
 		reinterpret_cast<void **> (&(dialog)));
 
 	if (SUCCEEDED(hr)) {
-		// If in fullscreen mode, switch to windowed mode
-		bool wasFullscreen = g_system->getFeatureState(OSystem::kFeatureFullscreenMode);
-		if (wasFullscreen) {
-			g_system->beginGFXTransaction();
-			g_system->setFeatureState(OSystem::kFeatureFullscreenMode, false);
-			g_system->endGFXTransaction();
-		}
+		beginDialog();
 
 		// Customize dialog
 		bool showHidden = ConfMan.getBool("gui_browser_show_hidden", Common::ConfigManager::kApplicationDomain);
@@ -191,12 +183,7 @@ Common::DialogManager::DialogResult Win32DialogManager::showFileBrowser(const ch
 
 		dialog->Release();
 
-		// If we were in fullscreen mode, switch back
-		if (wasFullscreen) {
-			g_system->beginGFXTransaction();
-			g_system->setFeatureState(OSystem::kFeatureFullscreenMode, true);
-			g_system->endGFXTransaction();
-		}
+		endDialog();
 	}
 
 	return result;

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -170,7 +170,8 @@ MODULE_OBJS += \
 	fs/chroot/chroot-fs.o \
 	plugins/posix/posix-provider.o \
 	saves/posix/posix-saves.o \
-	taskbar/unity/unity-taskbar.o
+	taskbar/unity/unity-taskbar.o \
+	dialogs/gtk/gtk-dialogs.o
 
 ifdef USE_SPEECH_DISPATCHER
 ifdef USE_TTS

--- a/backends/platform/sdl/posix/posix.cpp
+++ b/backends/platform/sdl/posix/posix.cpp
@@ -38,6 +38,7 @@
 #include "backends/fs/posix/posix-fs-factory.h"
 #include "backends/fs/posix/posix-fs.h"
 #include "backends/taskbar/unity/unity-taskbar.h"
+#include "backends/dialogs/gtk/gtk-dialogs.h"
 
 #ifdef USE_LINUXCD
 #include "backends/audiocd/linux/linux-audiocd.h"
@@ -69,6 +70,11 @@ void OSystem_POSIX::init() {
 	_taskbarManager = new UnityTaskbarManager();
 #endif
 
+#if defined(USE_SYSDIALOGS) && defined(USE_GTK)
+	// Initialize dialog manager
+	_dialogManager = new GtkDialogManager();
+#endif
+
 	// Invoke parent implementation of this method
 	OSystem_SDL::init();
 }
@@ -97,6 +103,10 @@ bool OSystem_POSIX::hasFeature(Feature f) {
 		return true;
 #ifdef HAS_POSIX_SPAWN
 	if (f == kFeatureOpenUrl)
+		return true;
+#endif
+#if defined(USE_SYSDIALOGS) && defined(USE_GTK)
+	if (f == kFeatureSystemBrowserDialog)
 		return true;
 #endif
 	return OSystem_SDL::hasFeature(f);

--- a/configure
+++ b/configure
@@ -167,6 +167,7 @@ _libunity=auto
 _dialogs=auto
 _iconv=auto
 _tts=auto
+_gtk=auto
 # Default option behavior yes/no
 _debug_build=auto
 _release_build=auto
@@ -1137,6 +1138,9 @@ Optional Libraries:
   --with-libunity-prefix=DIR   prefix where libunity is installed (optional)
   --disable-libunity       disable Unity launcher integration [autodetect]
 
+  --with-gtk-prefix=DIR   prefix where gtk is installed (optional)
+  --disable-gtk       disable GTK dialog integration [autodetect]
+
   --with-sndio-prefix=DIR  prefix where sndio is installed (optional)
   --disable-sndio          disable sndio MIDI driver [autodetect]
 
@@ -1272,6 +1276,8 @@ for ac_option in $@; do
 	--disable-libunity)           _libunity=no           ;;
 	--enable-tts)                 _tts=yes               ;;
 	--disable-tts)                _tts=no                ;;
+	--enable-gtk)                 _gtk=yes               ;;
+	--disable-gtk)                _gtk=no                ;;
 	--enable-bink)                _bink=yes              ;;
 	--disable-bink)               _bink=no               ;;
 	--opengl-mode=*)
@@ -1389,6 +1395,11 @@ for ac_option in $@; do
 		arg=`echo $ac_option | cut -d '=' -f 2`
 		LIBUNITY_CFLAGS="-I$arg/include"
 		LIBUNITY_LIBS="-L$arg/lib"
+		;;
+	--with-gtk-prefix=*)
+		arg=`echo $ac_option | cut -d '=' -f 2`
+		GTK_CFLAGS="-I$arg/include"
+		GTK_LIBS="-L$arg/lib"
 		;;
 	--with-sdlnet-prefix=*)
 		arg=`echo $ac_option | cut -d '=' -f 2`
@@ -5030,6 +5041,47 @@ fi
 echo "$_libunity"
 
 #
+# Check for GTK if system dialogs are enabled
+#
+echocheck "gtk"
+if test "$_unix" = no || test "$_dialogs" = no || test "$_pkg_config" = no; then
+	_gtk=no
+else
+if test "$_gtk" = auto ; then
+	case $_host_os in
+		mingw*)
+			# pkgconfig and gtk are not supported on mingw
+			_gtk=no
+			;;
+		*)
+			# GTK has a lots of dependencies, update the libs and cflags var with them
+			GTK_LIBS="$GTK_LIBS `$_pkgconfig --libs gtk+-3.0 2>> "$TMPLOG"`"
+			GTK_CFLAGS="$GTK_CFLAGS `$_pkgconfig --cflags gtk+-3.0 2>> "$TMPLOG"`"
+			_gtk=no
+			cat > $TMPC << EOF
+#include <gtk/gtk.h>
+int main(void) {
+	gtk_init_check(NULL, NULL);
+	return 0;
+}
+EOF
+			cc_check $GTK_CFLAGS $GTK_LIBS && _gtk=yes
+			;;
+	esac
+fi
+if test "$_gtk" = yes ; then
+	if test "$GTK_CFLAGS" = "" || test "$GTK_LIBS" = ""; then
+		GTK_LIBS="$GTK_LIBS `$_pkgconfig --libs gtk+-3.0 2>> "$TMPLOG"`"
+		GTK_CFLAGS="$GTK_CFLAGS `$_pkgconfig --cflags gtk+-3.0 2>> "$TMPLOG"`"
+	fi
+	append_var LIBS "$GTK_LIBS"
+	append_var CXXFLAGS "$GTK_CFLAGS"
+fi
+define_in_config_h_if_yes "$_gtk" 'USE_GTK'
+fi
+echo "$_gtk"
+
+#
 # Check for FreeType2 to be present
 #
 find_freetype() {
@@ -5486,8 +5538,13 @@ else
 		_dialogs=yes
 		;;
 	*)
-		echo "no"
-		_dialogs=no
+		if test "$_gtk" = yes; then
+			echo "gtk"
+			_dialogs=yes
+		else
+			echo "no"
+			_dialogs=no
+		fi
 		;;
 	esac
 fi

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -51,6 +51,7 @@ audio/softsynth/sid.cpp
 
 backends/cloud/cloudmanager.cpp
 backends/cloud/storage.cpp
+backends/dialogs/gtk/gtk-dialogs.cpp
 backends/dialogs/macosx/macosx-dialogs.mm
 backends/dialogs/win32/win32-dialogs.cpp
 backends/events/default/default-events.cpp


### PR DESCRIPTION
Suggested by @lotharsm 

Building on #1414, this adds a native file browser to Linux-based distros that support the GTK3 GUI, falling back to the ScummVM GUI when not available.

![File browser on Debian](https://i.imgur.com/PXBvvfh.png)

This is only enabled if the "system dialogs" feature is active and libgtk3-dev is present, similar to the current Ubuntu taskbar feature, so it shouldn't disrupt builds.

I'd appreciate testing on various distros to make sure it works correctly across GUIs and buildsystems.