### PR TITLE
ULTIMA8: Add short fade in/out around menu items to match original game

### DIFF
--- a/engines/ultima/module.mk
+++ b/engines/ultima/module.mk
@@ -361,6 +361,7 @@ MODULE_OBJS := \
 	ultima8/graphics/anim_dat.o \
 	ultima8/graphics/base_soft_render_surface.o \
 	ultima8/graphics/frame_id.o \
+	ultima8/graphics/fade_to_modal_process.o \
 	ultima8/graphics/gump_shape_archive.o \
 	ultima8/graphics/inverter_process.o \
 	ultima8/graphics/main_shape_archive.o \

--- a/engines/ultima/ultima8/audio/music_process.cpp
+++ b/engines/ultima/ultima8/audio/music_process.cpp
@@ -47,8 +47,8 @@ MusicProcess::MusicProcess(MidiPlayer *player) : _midiPlayer(player),
 	Std::memset(_songBranches, (byte)-1, 128 * sizeof(int));
 
 	_theMusicProcess = this;
-	_flags |= PROC_RUNPAUSED;
 	_type = 1; // persistent
+	setRunPaused();
 }
 
 MusicProcess::~MusicProcess() {

--- a/engines/ultima/ultima8/games/game.cpp
+++ b/engines/ultima/ultima8/games/game.cpp
@@ -69,7 +69,7 @@ uint32 Game::I_playEndgame(const uint8 *args, unsigned int /*argsize*/) {
 	Process *menuproc = new MainMenuProcess();
 	Kernel::get_instance()->addProcess(menuproc);
 
-	ProcId moviepid = Game::get_instance()->playEndgameMovie();
+	ProcId moviepid = Game::get_instance()->playEndgameMovie(false);
 	Process *movieproc = Kernel::get_instance()->getProcess(moviepid);
 	if (movieproc) {
 		menuproc->waitFor(movieproc);

--- a/engines/ultima/ultima8/games/game.h
+++ b/engines/ultima/ultima8/games/game.h
@@ -52,8 +52,8 @@ public:
 	//! write game-specific savegame info (avatar stats, equipment, ...)
 	virtual void writeSaveInfo(ODataSource *ods) = 0;
 
-	virtual ProcId playIntroMovie() = 0;
-	virtual ProcId playEndgameMovie() = 0;
+	virtual ProcId playIntroMovie(bool fade) = 0;
+	virtual ProcId playEndgameMovie(bool fade) = 0;
 	virtual void playCredits() = 0;
 	virtual void playQuotes() = 0;
 

--- a/engines/ultima/ultima8/games/remorse_game.cpp
+++ b/engines/ultima/ultima8/games/remorse_game.cpp
@@ -107,11 +107,11 @@ bool RemorseGame::startInitialUsecode(int saveSlot) {
 }
 
 
-ProcId RemorseGame::playIntroMovie() {
+ProcId RemorseGame::playIntroMovie(bool fade) {
 	return 0;
 }
 
-ProcId RemorseGame::playEndgameMovie() {
+ProcId RemorseGame::playEndgameMovie(bool fade) {
 	return 0;
 }
 

--- a/engines/ultima/ultima8/games/remorse_game.h
+++ b/engines/ultima/ultima8/games/remorse_game.h
@@ -45,8 +45,8 @@ public:
 	//! write game-specific savegame info (avatar stats, equipment, ...)
 	void writeSaveInfo(ODataSource *ods) override;
 
-	ProcId playIntroMovie() override;
-	ProcId playEndgameMovie() override;
+	ProcId playIntroMovie(bool fade) override;
+	ProcId playEndgameMovie(bool fade) override;
 	void playCredits() override;
 	void playQuotes() override { };
 

--- a/engines/ultima/ultima8/games/start_u8_process.cpp
+++ b/engines/ultima/ultima8/games/start_u8_process.cpp
@@ -53,7 +53,7 @@ StartU8Process::StartU8Process(int saveSlot) : Process(),
 void StartU8Process::run() {
 	if (!_skipStart && !_init) {
 		_init = true;
-		ProcId moviepid = Game::get_instance()->playIntroMovie();
+		ProcId moviepid = Game::get_instance()->playIntroMovie(false);
 		Process *movieproc = Kernel::get_instance()->getProcess(moviepid);
 		if (movieproc) {
 			waitFor(movieproc);

--- a/engines/ultima/ultima8/games/u8_game.cpp
+++ b/engines/ultima/ultima8/games/u8_game.cpp
@@ -25,6 +25,7 @@
 #include "ultima/ultima8/games/u8_game.h"
 
 #include "ultima/ultima8/graphics/palette_manager.h"
+#include "ultima/ultima8/graphics/fade_to_modal_process.h"
 #include "ultima/ultima8/filesys/idata_source.h"
 #include "ultima/ultima8/filesys/file_system.h"
 #include "ultima/ultima8/games/game_data.h"
@@ -153,7 +154,7 @@ bool U8Game::startInitialUsecode(int saveSlot) {
 }
 
 
-ProcId U8Game::playIntroMovie() {
+ProcId U8Game::playIntroMovie(bool fade) {
 	GameInfo *gameinfo = CoreApp::get_instance()->getGameInfo();
 	char langletter = gameinfo->getLanguageFileLetter();
 	if (!langletter) {
@@ -173,10 +174,10 @@ ProcId U8Game::playIntroMovie() {
 	}
 
 	RawArchive *flex = new RawArchive(skf);
-	return MovieGump::U8MovieViewer(flex, true);
+	return MovieGump::U8MovieViewer(flex, fade, true);
 }
 
-ProcId U8Game::playEndgameMovie() {
+ProcId U8Game::playEndgameMovie(bool fade) {
 	Std::string filename = "@game/static/endgame.skf";
 	FileSystem *filesys = FileSystem::get_instance();
 	IDataSource *skf = filesys->ReadFile(filename);
@@ -186,7 +187,7 @@ ProcId U8Game::playEndgameMovie() {
 	}
 
 	RawArchive *flex = new RawArchive(skf);
-	return MovieGump::U8MovieViewer(flex);
+	return MovieGump::U8MovieViewer(flex, fade);
 }
 
 void U8Game::playCredits() {
@@ -213,9 +214,9 @@ void U8Game::playCredits() {
 	if (musicproc) musicproc->playMusic(51); // CONSTANT!
 
 	CreditsGump *gump = new CreditsGump(text);
-	gump->InitGump(0);
 	gump->SetFlagWhenFinished("quotes");
-	gump->setRelativePosition(Gump::CENTER);
+	FadeToModalProcess *p = new FadeToModalProcess(gump);
+	Kernel::get_instance()->addProcess(p);
 }
 
 void U8Game::playQuotes() {
@@ -233,9 +234,9 @@ void U8Game::playQuotes() {
 	MusicProcess *musicproc = MusicProcess::get_instance();
 	if (musicproc) musicproc->playMusic(113); // CONSTANT!
 
-	Gump *gump = new CreditsGump(text, 80);
-	gump->InitGump(0);
-	gump->setRelativePosition(Gump::CENTER);
+	CreditsGump *gump = new CreditsGump(text, 80);
+	FadeToModalProcess *p = new FadeToModalProcess(gump);
+	Kernel::get_instance()->addProcess(p);
 }
 
 

--- a/engines/ultima/ultima8/graphics/fade_to_modal_process.cpp
+++ b/engines/ultima/ultima8/graphics/fade_to_modal_process.cpp
@@ -1,0 +1,100 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "ultima/ultima8/misc/pent_include.h"
+#include "ultima/ultima8/graphics/palette_fader_process.h"
+#include "ultima/ultima8/graphics/fade_to_modal_process.h"
+#include "ultima/ultima8/kernel/kernel.h"
+#include "ultima/ultima8/gumps/modal_gump.h"
+#include "ultima/ultima8/gumps/gump_notify_process.h"
+
+namespace Ultima {
+namespace Ultima8 {
+
+// p_dynamic_class stuff
+DEFINE_RUNTIME_CLASSTYPE_CODE(FadeToModalProcess, Process)
+
+
+FadeToModalProcess::FadeToModalProcess(ModalGump *modal)
+	: _modal(modal), _nextState(FS_OpenFadeOut), _fader(nullptr)
+{
+	setRunPaused();
+}
+
+FadeToModalProcess::~FadeToModalProcess(void) {
+}
+
+void FadeToModalProcess::onWakeUp() {
+	if (_nextState == FS_CloseFadeIn) {
+		// Jump in now and make sure the fade in is started (ie, we go to black)
+		// before the modal is closed, otherwise a single frame of the thing
+		// behind it will be shown first.
+		_fader = new PaletteFaderProcess(0x00000000, true, 0x7FFF, 30, false);
+		_fader->run();
+	}
+}
+
+void FadeToModalProcess::run() {
+	switch (_nextState) {
+		case FS_OpenFadeOut:
+		{
+			_fader = new PaletteFaderProcess(0x00000000, false, 0x7FFF, 30, true);
+			Kernel::get_instance()->addProcess(_fader);
+			_fader->setRunPaused();
+			_nextState = FS_ShowGump;
+			waitFor(_fader);
+			break;
+		}
+		case FS_ShowGump:
+		{
+			// kernel will delete the fader object for us
+			_fader = nullptr;
+			_modal->InitGump(0);
+			_modal->setRelativePosition(Gump::CENTER);
+			_modal->CreateNotifier();
+			// Reset the palette before showing the modal
+			PaletteManager::get_instance()->untransformPalette(PaletteManager::Pal_Game);
+			_nextState = FS_CloseFadeIn;
+			waitFor(_modal->GetNotifyProcess());
+			break;
+		}
+		case FS_CloseFadeIn:
+		{
+			// Already created a new fader in onWakeUp..
+			Kernel::get_instance()->addProcess(_fader);
+			_fader->setRunPaused();
+			_nextState = FS_Finshed;
+			waitFor(_fader);
+			break;
+		}
+		case FS_Finshed:
+		{
+			// kernel will delete the fader object for us
+			_fader = nullptr;
+			terminate();
+			break;
+		}
+	}
+}
+
+} // End of namespace Ultima8
+} // End of namespace Ultima

--- a/engines/ultima/ultima8/graphics/fade_to_modal_process.h
+++ b/engines/ultima/ultima8/graphics/fade_to_modal_process.h
@@ -20,40 +20,40 @@
  *
  */
 
-#ifndef ULTIMA8_GAMES_U8GAME_H
-#define ULTIMA8_GAMES_U8GAME_H
+#ifndef ULTIMA8_GRAPHICS_FADETOMODALPROCESS_H
+#define ULTIMA8_GRAPHICS_FADETOMODALPROCESS_H
 
-#include "ultima/ultima8/games/game.h"
+#include "ultima/ultima8/kernel/process.h"
+#include "ultima/ultima8/gumps/modal_gump.h"
+#include "ultima/ultima8/misc/p_dynamic_cast.h"
 
 namespace Ultima {
 namespace Ultima8 {
 
-class IDataSource;
+class PaletteFaderProcess;
 
-class U8Game: public Game {
+class FadeToModalProcess : public Process {
+
+	enum FadeToModalState {
+		FS_OpenFadeOut,
+		FS_ShowGump,
+		FS_CloseFadeIn,
+		FS_Finshed
+	} _nextState;
+
+	ModalGump * _modal;
+	PaletteFaderProcess * _fader;
+
 public:
-	U8Game();
-	~U8Game() override;
+	// p_dynamic_class stuff
+	ENABLE_RUNTIME_CLASSTYPE()
+	FadeToModalProcess(ModalGump *modal);
+	~FadeToModalProcess(void) override;
 
-	//! load/init game's data files
-	bool loadFiles() override;
+	void onWakeUp() override;
 
-	//! initialize new game
-	bool startGame() override;
+	void run() override;
 
-	//! start initial usecode
-	bool startInitialUsecode(int saveSlot) override;
-
-	//! write game-specific savegame info (avatar stats, equipment, ...)
-	void writeSaveInfo(ODataSource *ods) override;
-
-	ProcId playIntroMovie(bool fade) override;
-	ProcId playEndgameMovie(bool fade) override;
-	void playCredits() override;
-	void playQuotes() override;
-
-protected:
-	Std::string getCreditText(IDataSource *ids);
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/graphics/palette_fader_process.cpp
+++ b/engines/ultima/ultima8/graphics/palette_fader_process.cpp
@@ -31,15 +31,12 @@
 namespace Ultima {
 namespace Ultima8 {
 
-#define PALETTEFADER_COUNTER    30
-
 PaletteFaderProcess *PaletteFaderProcess::_fader = nullptr;
 
 // p_dynamic_class stuff
 DEFINE_RUNTIME_CLASSTYPE_CODE(PaletteFaderProcess, Process)
 
 PaletteFaderProcess::PaletteFaderProcess() : Process() {
-
 }
 
 PaletteFaderProcess::PaletteFaderProcess(PalTransforms trans,

--- a/engines/ultima/ultima8/gumps/menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/menu_gump.cpp
@@ -223,7 +223,7 @@ void MenuGump::selectEntry(int entry) {
 
 	switch (entry) {
 	case 1: // Intro
-		Game::get_instance()->playIntroMovie();
+		Game::get_instance()->playIntroMovie(true);
 		break;
 	case 2:
 	case 3: // Read/Write Diary
@@ -245,7 +245,7 @@ void MenuGump::selectEntry(int entry) {
 		if (quotes) Game::get_instance()->playQuotes();
 		break;
 	case 8: // End Game
-		if (endgame) Game::get_instance()->playEndgameMovie();
+		if (endgame) Game::get_instance()->playEndgameMovie(true);
 		break;
 	default:
 		break;

--- a/engines/ultima/ultima8/gumps/movie_gump.cpp
+++ b/engines/ultima/ultima8/gumps/movie_gump.cpp
@@ -25,7 +25,9 @@
 
 #include "ultima/ultima8/filesys/raw_archive.h"
 #include "ultima/ultima8/graphics/skf_player.h"
+#include "ultima/ultima8/graphics/fade_to_modal_process.h"
 #include "ultima/ultima8/ultima8.h"
+#include "ultima/ultima8/kernel/kernel.h"
 #include "ultima/ultima8/gumps/desktop_gump.h"
 #include "ultima/ultima8/gumps/gump_notify_process.h"
 
@@ -94,12 +96,20 @@ bool MovieGump::OnKeyDown(int key, int mod) {
 }
 
 //static
-ProcId MovieGump::U8MovieViewer(RawArchive *movie, bool introMusicHack) {
-	Gump *gump = new MovieGump(320, 200, movie, introMusicHack);
-	gump->InitGump(0);
-	gump->setRelativePosition(CENTER);
-	gump->CreateNotifier();
-	return gump->GetNotifyProcess()->getPid();
+ProcId MovieGump::U8MovieViewer(RawArchive *movie, bool fade, bool introMusicHack) {
+	ModalGump *gump = new MovieGump(320, 200, movie, introMusicHack);
+	if (fade) {
+		FadeToModalProcess *p = new FadeToModalProcess(gump);
+		Kernel::get_instance()->addProcess(p);
+		return p->getPid();
+	}
+	else
+	{
+		gump->InitGump(0);
+		gump->setRelativePosition(CENTER);
+		gump->CreateNotifier();
+		return gump->GetNotifyProcess()->getPid();
+	}
 }
 
 bool MovieGump::loadData(IDataSource *ids) {

--- a/engines/ultima/ultima8/gumps/movie_gump.h
+++ b/engines/ultima/ultima8/gumps/movie_gump.h
@@ -52,7 +52,7 @@ public:
 
 	bool OnKeyDown(int key, int mod) override;
 
-	static ProcId U8MovieViewer(RawArchive *skf, bool introMusicHack = false);
+	static ProcId U8MovieViewer(RawArchive *skf, bool fade, bool introMusicHack = false);
 
 	bool loadData(IDataSource *ids);
 protected:

--- a/engines/ultima/ultima8/kernel/process.cpp
+++ b/engines/ultima/ultima8/kernel/process.cpp
@@ -69,6 +69,8 @@ void Process::wakeUp(uint32 result_) {
 	_flags &= ~PROC_SUSPENDED;
 
 	Kernel::get_instance()->setNextProcess(this);
+
+	onWakeUp();
 }
 
 void Process::waitFor(ProcId pid_) {

--- a/engines/ultima/ultima8/kernel/process.h
+++ b/engines/ultima/ultima8/kernel/process.h
@@ -74,6 +74,11 @@ public:
 		_flags |= PROC_TERM_DEFERRED;
 	}
 
+	//! run even when paused
+	void setRunPaused() {
+		_flags |= PROC_RUNPAUSED;
+	};
+
 	//! suspend until process '_pid' returns. If _pid is 0, suspend indefinitely
 	void waitFor(ProcId _pid);
 
@@ -83,7 +88,11 @@ public:
 	//! suspend process
 	void suspend();
 
+	//! Wake up when the process we were waiting for has finished
 	void wakeUp(uint32 result);
+
+	//! A hook to add aditional behavior on wakeup, before anything else happens
+	virtual void onWakeUp() {};
 
 	void setItemNum(ObjId it) {
 		_itemNum = it;

--- a/engines/ultima/ultima8/misc/debugger.cpp
+++ b/engines/ultima/ultima8/misc/debugger.cpp
@@ -1438,7 +1438,7 @@ bool Debugger::cmdPlayMovie(int argc, const char **argv) {
 	}
 
 	RawArchive *flex = new RawArchive(skf);
-	MovieGump::U8MovieViewer(flex);
+	MovieGump::U8MovieViewer(flex, false);
 	return false;
 }
 


### PR DESCRIPTION
This adds a palette fade out / in when opening the credits, intro movie, etc from the menu.

In hindsight it's quite a bit of code for a pretty minor thing, but it makes it behave more like the original game so it made me happy 😅 

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
