### PR TITLE
GUI: Predictive dialog box can handle multiple keypad press

### DIFF
--- a/gui/predictivedialog.cpp
+++ b/gui/predictivedialog.cpp
@@ -145,6 +145,8 @@ PredictiveDialog::PredictiveDialog() : Dialog("Predictive") {
 
 	_curPressedButton = kNoAct;
 	_needRefresh = true;
+	_isPressed = false;
+
 }
 
 PredictiveDialog::~PredictiveDialog() {
@@ -196,9 +198,16 @@ void PredictiveDialog::handleKeyUp(Common::KeyState state) {
 		_button[_curPressedButton]->setUnpressedState();
 		processButton(_curPressedButton);
 	}
+
+	_isPressed = false;
 }
 
 void PredictiveDialog::handleKeyDown(Common::KeyState state) {
+	if (_isPressed) {
+		return;
+	}
+
+	_isPressed = true;
 	_curPressedButton = kNoAct;
 	_needRefresh = false;
 

--- a/gui/predictivedialog.h
+++ b/gui/predictivedialog.h
@@ -143,6 +143,8 @@ private:
 
 	bool _navigationWithKeys;
 	bool _needRefresh;
+	bool _isPressed;
+
 private:
 	EditTextWidget *_editText;
 	ButtonWidget   *_button[kButtonCount];


### PR DESCRIPTION
Fixes #7125

The predictive dialog box is unable to handle multiple presses via the keypad. This fixes it, only one press is allowed, and the simultaneous button presses are ignored - only the fastest one is registered.