### PR TITLE
COMMON: Dedicated function for in buffer check

### DIFF
--- a/common/str.cpp
+++ b/common/str.cpp
@@ -284,7 +284,7 @@ String &String::operator=(char c) {
 }
 
 String &String::operator+=(const char *str) {
-	if (_str <= str && str <= _str + _size)
+	if (pointerInOwnBuffer(str))
 		return operator+=(String(str));
 
 	int len = strlen(str);
@@ -295,6 +295,16 @@ String &String::operator+=(const char *str) {
 		_size += len;
 	}
 	return *this;
+}
+
+bool String::pointerInOwnBuffer(const char *str) const {
+	//compared pointers must be in the same array or UB
+	//cast to intptr however is IB
+	//which includes comparision of the values
+	uintptr ownBuffStart = (uintptr)_str;
+	uintptr ownBuffEnd = (uintptr)(_str + _size);
+	uintptr candidateAddr = (uintptr)str;
+	return ownBuffStart <= candidateAddr && candidateAddr <= ownBuffEnd;
 }
 
 String &String::operator+=(const String &str) {

--- a/common/str.h
+++ b/common/str.h
@@ -398,6 +398,8 @@ protected:
 	void decRefCount(int *oldRefCount);
 	void initWithCStr(const char *str, uint32 len);
 
+	bool pointerInOwnBuffer(const char *str) const;
+
 	void decodeUTF8(U32String &dst) const;
 	void decodeOneByte(U32String &dst, CodePage page) const;
 };


### PR DESCRIPTION
It's UB to compare pointers that aren't from the same array. Cast to uintptr_t to reduce the issue to IB.
