### PR TITLE
ULTIMA8: Some minor shape and render cleanups

### DIFF
--- a/engines/ultima/ultima8/convert/convert_shape.cpp
+++ b/engines/ultima/ultima8/convert/convert_shape.cpp
@@ -631,7 +631,7 @@ bool ConvertShape::CheckUnsafe(IDataSource *source, const ConvertShapeFormat *cs
 	bool result = true;
 
 	// Just to be safe
-	int start_pos = source->getPos();
+	const uint32 start_pos = source->getPos();
 
 	// Read the ident
 	if (csf->_bytes_ident)
@@ -739,7 +739,7 @@ bool ConvertShape::CheckUnsafe(IDataSource *source, const ConvertShapeFormat *cs
 void ConvertShape::Write(ODataSource *dest, const ConvertShapeFormat *csf, uint32 &write_len)
 {
 	// Just to be safe
-	uint32 start_pos = dest->getPos();
+	const uint32 start_pos = dest->getPos();
 
 	// Write the ident
 	if (csf->_bytes_ident) dest->write(csf->_ident, csf->_bytes_ident);

--- a/engines/ultima/ultima8/graphics/render_surface.h
+++ b/engines/ultima/ultima8/graphics/render_surface.h
@@ -207,9 +207,6 @@ public:
 	// TODO: virtual void PaintHighlightInvis(CachedShape* s, uint32 frame, int32 x, int32 y, bool trans, bool mirrored, uint32 col32);
 	virtual void PaintHighlightInvis(Shape *s, uint32 frame, int32 x, int32 y, bool trans, bool mirrored, uint32 col32, bool untformed_pal = false) = 0;
 
-	//! Paint a shape masked against destination alpha
-	virtual void PaintMasked(Shape *s, uint32 framenum, int32 x, int32 y, bool trans = false, bool mirrored = false, uint32 col32 = 0, bool untformed_pal = false) = 0;
-
 	//
 	// Basic Line Drawing
 	//

--- a/engines/ultima/ultima8/graphics/shape.h
+++ b/engines/ultima/ultima8/graphics/shape.h
@@ -72,7 +72,7 @@ public:
 
 	ENABLE_CUSTOM_MEMORY_ALLOCATION()
 
-protected:
+private:
 
 	// This will load a u8 style shape 'optimized'.
 	void LoadU8Format(const uint8 *data, uint32 size, const ConvertShapeFormat *format);

--- a/engines/ultima/ultima8/graphics/shape_frame.h
+++ b/engines/ultima/ultima8/graphics/shape_frame.h
@@ -54,7 +54,7 @@ public:
 	uint8 getPixelAtPoint(int32 x, int32 y) const;  // Get the pixel at the point
 
 	void getConvertShapeFrame(ConvertShapeFrame &csf);
-protected:
+private:
 
 	// This will load a u8 style shape 'optimized'.
 	void LoadU8Format(const uint8 *data, uint32 size);

--- a/engines/ultima/ultima8/graphics/soft_render_surface.cpp
+++ b/engines/ultima/ultima8/graphics/soft_render_surface.cpp
@@ -943,35 +943,6 @@ template<class uintX> void SoftRenderSurface<uintX>::PaintHighlightInvis(Shape *
 }
 
 //
-// void SoftRenderSurface::PaintHighlight(Shape* s, uint32 frame, int32 x, int32 y, bool mirrored)
-//
-// Desc: Standard shape drawing functions. Masked against Dest Alpha. Highlights, Clips, and conditionally Flips and Xforms
-//
-
-template<class uintX> void SoftRenderSurface<uintX>::PaintMasked(Shape *s, uint32 framenum, int32 x, int32 y, bool trans, bool mirrored, uint32 col32, bool untformed_pal) {
-#define FLIP_SHAPES
-#define FLIP_CONDITIONAL mirrored
-#define XFORM_SHAPES
-#define XFORM_CONDITIONAL trans
-#define BLEND_SHAPES(src,dst) BlendHighlight(src,cr,cg,cb,ca,255-ca)
-#define DESTALPHA_MASK
-
-	uint32 ca = TEX32_A(col32);
-	uint32 cr = TEX32_R(col32);
-	uint32 cg = TEX32_G(col32);
-	uint32 cb = TEX32_B(col32);
-
-#include "ultima/ultima8/graphics/soft_render_surface.inl"
-
-#undef FLIP_SHAPES
-#undef FLIP_CONDITIONAL
-#undef XFORM_SHAPES
-#undef XFORM_CONDITIONAL
-#undef BLEND_SHAPES
-#undef DESTALPHA_MASK
-}
-
-//
 // Instantiate the SoftRenderSurface Class
 //
 template class SoftRenderSurface<uint16>;

--- a/engines/ultima/ultima8/graphics/soft_render_surface.h
+++ b/engines/ultima/ultima8/graphics/soft_render_surface.h
@@ -106,10 +106,6 @@ public:
 	// TODO: virtual void PaintHighlightInvis(CachedShape* s, uint32 frame, int32 x, int32 y, bool trans, bool mirrored, uint32 col32);
 	void PaintHighlightInvis(Shape *s, uint32 frame, int32 x, int32 y, bool trans, bool mirrored, uint32 col32, bool untformed_pal = false) override;
 
-	// Paint a shape masked against destination alpha
-	void PaintMasked(Shape *s, uint32 framenum, int32 x, int32 y, bool trans, bool mirrored, uint32 col32 = 0, bool untformed_pal = false) override;
-
-
 	//
 	// Basic Line Drawing
 	//

--- a/engines/ultima/ultima8/graphics/soft_render_surface.inl
+++ b/engines/ultima/ultima8/graphics/soft_render_surface.inl
@@ -167,25 +167,13 @@ const int32 neg = (FLIP_CONDITIONAL)?-1:0;
 // The Function
 //
 
-// All the variables we want
-
-	const uint8			*linedata;
-	int32				xpos;
-	sintptr				line; // sintptr for pointer arithmetic
-	int32				dlen;
-
-	uintX				*pixptr;
-	uintX				*endrun;
-	uintX				*line_start;
-	uint32				pix;
-
 	// Sanity check
 	if (framenum >= s->frameCount())
 		return;
 	if (s->getPalette() == 0)
 		return;
 
-	const ShapeFrame	*frame			= s->getFrame(framenum);
+	const ShapeFrame *frame			= s->getFrame(framenum);
 	const uint8		*rle_data		= frame->_rle_data;
 	const uint32	*line_offsets	= frame->_line_offsets;
 	const uint32	*pal			= untformed_pal?
@@ -199,21 +187,19 @@ const int32 neg = (FLIP_CONDITIONAL)?-1:0;
 										&(s->getPalette()->_xform[0]);
 #endif
 
-	int32 width_ = frame->_width;
-	int32 height_ = frame->_height;
+	const int32 width_ = frame->_width;
+	const int32 height_ = frame->_height;
 	x -= XNEG(frame->_xoff);
 	y -= frame->_yoff;
 
 	// Do it this way if compressed
 	if (frame->_compressed) for (int i=0; i<height_; i++)  {
-		xpos = 0;
-		line = y+i;
+		int32 xpos = 0;
+		sintptr line = y+i;
 
 		if (NOT_CLIPPED_Y) {
-
-			linedata = rle_data + line_offsets[i];
-			line_start = reinterpret_cast<uintX *>(static_cast<uint8*>(OFFSET_PIXELS) + _pitch*line);
-
+			const uint8	*linedata = rle_data + line_offsets[i];
+			uintX *line_start = reinterpret_cast<uintX *>(static_cast<uint8*>(OFFSET_PIXELS) + _pitch*line);
 			LINE_END_ASSIGN();
 
 			do {
@@ -221,14 +207,15 @@ const int32 neg = (FLIP_CONDITIONAL)?-1:0;
 			  
 				if (xpos == width_) break;
 
-				dlen = *linedata++;
-				int type = dlen & 1;
+				int32 dlen = *linedata++;
+				const int type = dlen & 1;
 				dlen >>= 1;
 
-				pixptr = line_start+x+XNEG(xpos);
-				endrun = pixptr + XNEG(dlen);
+				uintX *pixptr = line_start+x+XNEG(xpos);
+				uintX *endrun = pixptr + XNEG(dlen);
 				
 				if (!type) {
+					// Identical to the uncompressed case
 					while (pixptr != endrun)  {
 						if (NOT_CLIPPED_X && NOT_DESTINATION_MASKED)  {
 							#ifdef XFORM_SHAPES
@@ -244,17 +231,18 @@ const int32 neg = (FLIP_CONDITIONAL)?-1:0;
 						linedata++;
 					}
 				} else {
+					// a run of the same pixel
 					#ifdef XFORM_SHAPES
-					pix = xform_pal[*linedata];
 					if (USE_XFORM_FUNC) {
+						const uint32 pix = xform_pal[*linedata];
 						while (pixptr != endrun) {
-							if (NOT_CLIPPED_X && NOT_DESTINATION_MASKED) *pixptr = CUSTOM_BLEND(BlendPreModulated(xform_pal[*linedata],*pixptr));
+							if (NOT_CLIPPED_X && NOT_DESTINATION_MASKED) *pixptr = CUSTOM_BLEND(BlendPreModulated(pix,*pixptr));
 							pixptr += XNEG(1);
 						}
 					} else 
 					#endif
 					{
-						pix = pal[*linedata];
+						const uint32 pix = pal[*linedata];
 						while (pixptr != endrun) 
 						{
 							if (NOT_CLIPPED_X && NOT_DESTINATION_MASKED) 
@@ -274,12 +262,12 @@ const int32 neg = (FLIP_CONDITIONAL)?-1:0;
 	}
 	// Uncompressed
 	else for (int i=0; i<height_; i++)  {
-		linedata = rle_data + line_offsets[i];
-		xpos = 0;
-		line = y+i;
+		int32 xpos = 0;
+		sintptr line = y+i;
 
 		if (NOT_CLIPPED_Y) {
-			line_start = reinterpret_cast<uintX *>(static_cast<uint8*>(OFFSET_PIXELS) + _pitch*line);
+			const uint8	*linedata = rle_data + line_offsets[i];
+			uintX *line_start = reinterpret_cast<uintX *>(static_cast<uint8*>(OFFSET_PIXELS) + _pitch*line);
 			LINE_END_ASSIGN();
 
 			do {
@@ -287,10 +275,10 @@ const int32 neg = (FLIP_CONDITIONAL)?-1:0;
 			  
 				if (xpos == width_) break;
 
-				dlen = *linedata++;
+				const int32 dlen = *linedata++;
 
-				pixptr= line_start+x+XNEG(xpos);
-				endrun = pixptr + XNEG(dlen);
+				uintX *pixptr = line_start+x+XNEG(xpos);
+				uintX *endrun = pixptr + XNEG(dlen);
 
 				while (pixptr != endrun) {
 					if (NOT_CLIPPED_X && NOT_DESTINATION_MASKED) {


### PR DESCRIPTION
Some changes to make the code a bit clearer for `Shape` and `SoftRenderSurface`.

This is a first small PR of a longer-term plan I have to unify `Shape` and `Surface` code inside the U8 codebase and get it all a bit more using native ScummVM surfaces.

The rough plan is:
1. Tidy up the shape and render code - remove unused features, make it easier to analyze (this and maybe some other PRs)
1. Remove the in-memory use of RLE shapes - uncompress them on load so that we can remove 1 of the 2 separate render paths.
1. Change shapes internal representation more - from having row-level data to instead use RGBA surfaces so they can be blitted directly to the render surface
1. Change the `SoftRenderSurface` to always be a managed surface and use the line-draw/fill/blit provided by that instead
1. Remove the `ScalerGump` - make it all blt to a single surface 320x200 (tbd: fix the aspect ratio somehow) so that built-in ScummVM scalers can be used.

Looking for input on the overall idea as well as the changes in this PR.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
