### PR TITLE
GUI: Scroll buttons properly display at edge.

### DIFF
--- a/gui/widgets/tab.cpp
+++ b/gui/widgets/tab.cpp
@@ -71,6 +71,9 @@ void TabWidget::init() {
 	int y = _butTP - _tabHeight;
 	_navLeft = new ButtonWidget(this, x, y, _butW, _butH, "<", nullptr, kCmdLeft);
 	_navRight = new ButtonWidget(this, x + _butW + 2, y, _butW, _butH, ">", nullptr, kCmdRight);
+	_navLeft->setVisible(false);
+	_navRight->setVisible(true);
+
 	_lastRead = -1;
 }
 
@@ -186,14 +189,28 @@ void TabWidget::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 
 	switch (cmd) {
 	case kCmdLeft:
+		if (!_navRight->isVisible()) {
+			_navRight->setVisible(true);
+		}
+
 		if (_firstVisibleTab > 0) {
 			setFirstVisible(_firstVisibleTab - 1);
+		}
+		if (_firstVisibleTab == 0) {
+			_navLeft->setVisible(false);
 		}
 		break;
 
 	case kCmdRight:
+		if (!_navLeft->isVisible()) {
+			_navLeft->setVisible(true);
+		}
+
 		if (_lastVisibleTab + 1 < (int)_tabs.size()) {
 			setFirstVisible(_firstVisibleTab + 1, false);
+		}
+		if (_lastVisibleTab + 1 == (int)_tabs.size()) {
+			_navRight->setVisible(false);
 		}
 		break;
 


### PR DESCRIPTION
Fixes #7123.

Previously the scroll buttons at extreme edges were clickable but did nothing. For example, if it were on the rightmost side, ">" would be clickable but useless. This fix addresses that.