### PR TITLE
ULTIMA8: Use ScummVM PixelFormat struct

### DIFF
--- a/engines/ultima/ultima8/graphics/base_soft_render_surface.cpp
+++ b/engines/ultima/ultima8/graphics/base_soft_render_surface.cpp
@@ -51,30 +51,29 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(Graphics::ManagedSurface *s) :
 	_bitsPerPixel = _surface->format.bpp();
 	_bytesPerPixel = _surface->format.bytesPerPixel;
 
-	RenderSurface::_format.s_bpp = _bitsPerPixel;
-	RenderSurface::_format.s_bytes_per_pixel = _bytesPerPixel;
-	RenderSurface::_format.r_loss = _surface->format.rLoss;
-	RenderSurface::_format.g_loss = _surface->format.gLoss;
-	RenderSurface::_format.b_loss = _surface->format.bLoss;
-	RenderSurface::_format.a_loss = _surface->format.aLoss;
-	RenderSurface::_format.r_loss16 = _format.r_loss + 8;
-	RenderSurface::_format.g_loss16 = _format.g_loss + 8;
-	RenderSurface::_format.b_loss16 = _format.b_loss + 8;
-	RenderSurface::_format.a_loss16 = _format.a_loss + 8;
-	RenderSurface::_format.r_shift = _surface->format.rShift;
-	RenderSurface::_format.g_shift = _surface->format.gShift;
-	RenderSurface::_format.b_shift = _surface->format.bShift;
-	RenderSurface::_format.a_shift = _surface->format.aShift;
-	RenderSurface::_format.r_mask = _surface->format.rMax() << _surface->format.rShift;
-	RenderSurface::_format.g_mask = _surface->format.gMax() << _surface->format.gShift;
-	RenderSurface::_format.b_mask = _surface->format.bMax() << _surface->format.bShift;
-	RenderSurface::_format.a_mask = _surface->format.aMax() << _surface->format.aShift;
+	RenderSurface::_format.bytesPerPixel = _bytesPerPixel;
+	RenderSurface::_format.rLoss = _surface->format.rLoss;
+	RenderSurface::_format.gLoss = _surface->format.gLoss;
+	RenderSurface::_format.bLoss = _surface->format.bLoss;
+	RenderSurface::_format.aLoss = _surface->format.aLoss;
+	RenderSurface::_format.rLoss16 = _format.rLoss + 8;
+	RenderSurface::_format.gLoss16 = _format.gLoss + 8;
+	RenderSurface::_format.bLoss16 = _format.bLoss + 8;
+	RenderSurface::_format.aLoss16 = _format.aLoss + 8;
+	RenderSurface::_format.rShift = _surface->format.rShift;
+	RenderSurface::_format.gShift = _surface->format.gShift;
+	RenderSurface::_format.bShift = _surface->format.bShift;
+	RenderSurface::_format.aShift = _surface->format.aShift;
+	RenderSurface::_format.rMask = _surface->format.rMax() << _surface->format.rShift;
+	RenderSurface::_format.gMask = _surface->format.gMax() << _surface->format.gShift;
+	RenderSurface::_format.bMask = _surface->format.bMax() << _surface->format.bShift;
+	RenderSurface::_format.aMask = _surface->format.aMax() << _surface->format.aShift;
 
 	SetPixelsPointer();
 
 	// Trickery to get the alpha channel
-	if (_format.a_mask == 0 && _bytesPerPixel == 4) {
-		uint32 mask = ~(_format.r_mask | _format.g_mask | _format.b_mask);
+	if (_format.aMask == 0 && _bytesPerPixel == 4) {
+		uint32 mask = ~(_format.rMask | _format.gMask | _format.bMask);
 
 		// Using all bits????
 		if (!mask) return;
@@ -103,10 +102,10 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(Graphics::ManagedSurface *s) :
 		if (zero < last) return;
 
 		// Set it
-		_format.a_shift = first;
-		_format.a_loss = 8 - (last + 1 - first);
-		_format.a_loss16 = _format.a_loss + 8;
-		_format.a_mask = mask;
+		_format.aShift = first;
+		_format.aLoss = 8 - (last + 1 - first);
+		_format.aLoss16 = _format.aLoss + 8;
+		_format.aMask = mask;
 	}
 }
 
@@ -127,25 +126,25 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h, int bpp,
 
 	switch (bpp) {
 	case 15:
-		_format.r_loss = 3;
-		_format.g_loss = 3;
-		_format.b_loss = 3;
-		_format.a_loss = 7;
+		_format.rLoss = 3;
+		_format.gLoss = 3;
+		_format.bLoss = 3;
+		_format.aLoss = 7;
 		bpp = 16;
 		break;
 
 	case 16:
-		_format.r_loss = 3;
-		_format.g_loss = 2;
-		_format.b_loss = 3;
-		_format.a_loss = 0;
+		_format.rLoss = 3;
+		_format.gLoss = 2;
+		_format.bLoss = 3;
+		_format.aLoss = 0;
 		break;
 
 	case 32:
-		_format.r_loss = 0;
-		_format.g_loss = 0;
-		_format.b_loss = 0;
-		_format.a_loss = 0;
+		_format.rLoss = 0;
+		_format.gLoss = 0;
+		_format.bLoss = 0;
+		_format.aLoss = 0;
 		break;
 
 	default:
@@ -156,20 +155,19 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h, int bpp,
 	_bitsPerPixel = bpp;
 	_bytesPerPixel = bpp / 8;
 
-	RenderSurface::_format.s_bpp = bpp;
-	RenderSurface::_format.s_bytes_per_pixel = _bytesPerPixel;
-	RenderSurface::_format.r_loss16 = _format.r_loss + 8;
-	RenderSurface::_format.g_loss16 = _format.g_loss + 8;
-	RenderSurface::_format.b_loss16 = _format.b_loss + 8;
-	RenderSurface::_format.a_loss16 = _format.a_loss + 8;
-	RenderSurface::_format.r_shift = rsft;
-	RenderSurface::_format.g_shift = gsft;
-	RenderSurface::_format.b_shift = bsft;
-	RenderSurface::_format.a_shift = asft;
-	RenderSurface::_format.r_mask = (0xFF >> _format.r_loss) << rsft;
-	RenderSurface::_format.g_mask = (0xFF >> _format.g_loss) << gsft;
-	RenderSurface::_format.b_mask = (0xFF >> _format.b_loss) << bsft;
-	RenderSurface::_format.a_mask = (0xFF >> _format.a_loss) << asft;
+	RenderSurface::_format.bytesPerPixel = _bytesPerPixel;
+	RenderSurface::_format.rLoss16 = _format.rLoss + 8;
+	RenderSurface::_format.gLoss16 = _format.gLoss + 8;
+	RenderSurface::_format.bLoss16 = _format.bLoss + 8;
+	RenderSurface::_format.aLoss16 = _format.aLoss + 8;
+	RenderSurface::_format.rShift = rsft;
+	RenderSurface::_format.gShift = gsft;
+	RenderSurface::_format.bShift = bsft;
+	RenderSurface::_format.aShift = asft;
+	RenderSurface::_format.rMask = (0xFF >> _format.rLoss) << rsft;
+	RenderSurface::_format.gMask = (0xFF >> _format.gLoss) << gsft;
+	RenderSurface::_format.bMask = (0xFF >> _format.bLoss) << bsft;
+	RenderSurface::_format.aMask = (0xFF >> _format.aLoss) << asft;
 
 	SetPixelsPointer();
 }
@@ -188,7 +186,7 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h, uint8 *buf) :
 	_surface(nullptr), _rttTex(nullptr) {
 	_clipWindow.ResizeAbs(_width = w, _height = h);
 
-	int bpp = RenderSurface::_format.s_bpp;
+	int bpp = RenderSurface::_format.bpp();
 
 	_pitch = w * bpp / 8;
 	_bitsPerPixel = bpp;
@@ -211,7 +209,7 @@ BaseSoftRenderSurface::BaseSoftRenderSurface(int w, int h) :
 	_rttTex(nullptr) {
 	_clipWindow.ResizeAbs(_width = w, _height = h);
 
-	int bpp = RenderSurface::_format.s_bpp;
+	int bpp = RenderSurface::_format.bpp();
 
 	_pitch = w * bpp / 8;
 	_bitsPerPixel = bpp;

--- a/engines/ultima/ultima8/graphics/render_surface.cpp
+++ b/engines/ultima/ultima8/graphics/render_surface.cpp
@@ -30,13 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-RenderSurface::Format   RenderSurface::_format = {
-	0,  0,
-	0,  0,  0,  0,
-	0,  0,  0,  0,
-	0,  0,  0,  0,
-	0,  0,  0,  0
-};
+RenderSurface::U8PixelFormat RenderSurface::_format;
 
 uint8 RenderSurface::_gamma10toGamma22[256];
 uint8 RenderSurface::_gamma22toGamma10[256];
@@ -87,7 +81,7 @@ RenderSurface *RenderSurface::CreateSecondaryRenderSurface(uint32 width, uint32 
 	RenderSurface *surf;
 
 	// TODO: Change this
-	if (_format.s_bpp == 32) surf = new SoftRenderSurface<uint32>(width, height);
+	if (_format.bytesPerPixel == 4) surf = new SoftRenderSurface<uint32>(width, height);
 	else surf = new SoftRenderSurface<uint16>(width, height);
 	return surf;
 }

--- a/engines/ultima/ultima8/graphics/render_surface.h
+++ b/engines/ultima/ultima8/graphics/render_surface.h
@@ -39,13 +39,13 @@ struct Palette;
 struct Rect;
 class Scaler;
 
-#define UNPACK_RGB8(pix,r,g,b) { r = (((pix)&RenderSurface::_format.r_mask)>>RenderSurface::_format.r_shift)<<RenderSurface::_format.r_loss; g = (((pix)&RenderSurface::_format.g_mask)>>RenderSurface::_format.g_shift)<<RenderSurface::_format.g_loss; b = (((pix)&RenderSurface::_format.b_mask)>>RenderSurface::_format.b_shift)<<RenderSurface::_format.b_loss; }
-#define PACK_RGB8(r,g,b) ((((r)>>RenderSurface::_format.r_loss)<<RenderSurface::_format.r_shift) | (((g)>>RenderSurface::_format.g_loss)<<RenderSurface::_format.g_shift) | (((b)>>RenderSurface::_format.b_loss)<<RenderSurface::_format.b_shift))
-#define PACK_RGB16(r,g,b) ((((r)>>RenderSurface::_format.r_loss16)<<RenderSurface::_format.r_shift) | (((g)>>RenderSurface::_format.g_loss16)<<RenderSurface::_format.g_shift) | (((b)>>RenderSurface::_format.b_loss16)<<RenderSurface::_format.b_shift))
+#define UNPACK_RGB8(pix,r,g,b) { r = (((pix)&RenderSurface::_format.rMask)>>RenderSurface::_format.rShift)<<RenderSurface::_format.rLoss; g = (((pix)&RenderSurface::_format.gMask)>>RenderSurface::_format.gShift)<<RenderSurface::_format.gLoss; b = (((pix)&RenderSurface::_format.bMask)>>RenderSurface::_format.bShift)<<RenderSurface::_format.bLoss; }
+#define PACK_RGB8(r,g,b) ((((r)>>RenderSurface::_format.rLoss)<<RenderSurface::_format.rShift) | (((g)>>RenderSurface::_format.gLoss)<<RenderSurface::_format.gShift) | (((b)>>RenderSurface::_format.bLoss)<<RenderSurface::_format.bShift))
+#define PACK_RGB16(r,g,b) ((((r)>>RenderSurface::_format.rLoss16)<<RenderSurface::_format.rShift) | (((g)>>RenderSurface::_format.gLoss16)<<RenderSurface::_format.gShift) | (((b)>>RenderSurface::_format.bLoss16)<<RenderSurface::_format.bShift))
 
-#define UNPACK_RGBA8(pix,r,g,b,a) { r = (((pix)&RenderSurface::_format.r_mask)>>RenderSurface::_format.r_shift)<<RenderSurface::_format.r_loss; g = (((pix)&RenderSurface::_format.g_mask)>>RenderSurface::_format.g_shift)<<RenderSurface::_format.g_loss; b = (((pix)&RenderSurface::_format.b_mask)>>RenderSurface::_format.b_shift)<<RenderSurface::_format.b_loss; ; a = (((pix)&RenderSurface::_format.a_mask)>>RenderSurface::_format.a_shift)<<RenderSurface::_format.a_loss; }
-#define PACK_RGBA8(r,g,b,a) ((((r)>>RenderSurface::_format.r_loss)<<RenderSurface::_format.r_shift) | (((g)>>RenderSurface::_format.g_loss)<<RenderSurface::_format.g_shift) | (((b)>>RenderSurface::_format.b_loss)<<RenderSurface::_format.b_shift) | (((a)>>RenderSurface::_format.a_loss)<<RenderSurface::_format.a_shift))
-#define PACK_RGBA16(r,g,b,a) ((((r)>>RenderSurface::_format.r_loss16)<<RenderSurface::_format.r_shift) | (((g)>>RenderSurface::_format.g_loss16)<<RenderSurface::_format.g_shift) | (((b)>>RenderSurface::_format.b_loss16)<<RenderSurface::_format.b_shift) | (((a)>>RenderSurface::_format.a_loss16)<<RenderSurface::_format.a_shift))
+#define UNPACK_RGBA8(pix,r,g,b,a) { r = (((pix)&RenderSurface::_format.rMask)>>RenderSurface::_format.rShift)<<RenderSurface::_format.rLoss; g = (((pix)&RenderSurface::_format.gMask)>>RenderSurface::_format.gShift)<<RenderSurface::_format.gLoss; b = (((pix)&RenderSurface::_format.bMask)>>RenderSurface::_format.bShift)<<RenderSurface::_format.bLoss; ; a = (((pix)&RenderSurface::_format.aMask)>>RenderSurface::_format.aShift)<<RenderSurface::_format.aLoss; }
+#define PACK_RGBA8(r,g,b,a) ((((r)>>RenderSurface::_format.rLoss)<<RenderSurface::_format.rShift) | (((g)>>RenderSurface::_format.gLoss)<<RenderSurface::_format.gShift) | (((b)>>RenderSurface::_format.bLoss)<<RenderSurface::_format.bShift) | (((a)>>RenderSurface::_format.aLoss)<<RenderSurface::_format.aShift))
+#define PACK_RGBA16(r,g,b,a) ((((r)>>RenderSurface::_format.rLoss16)<<RenderSurface::_format.rShift) | (((g)>>RenderSurface::_format.gLoss16)<<RenderSurface::_format.gShift) | (((b)>>RenderSurface::_format.bLoss16)<<RenderSurface::_format.bShift) | (((a)>>RenderSurface::_format.aLoss16)<<RenderSurface::_format.aShift))
 
 //
 // RenderSurface
@@ -54,17 +54,19 @@ class Scaler;
 //
 class RenderSurface {
 public:
+	struct U8PixelFormat : Graphics::PixelFormat {
+		// Extend with some extra attributes
+		byte  rLoss16, gLoss16, bLoss16, aLoss16;
+		uint32  rMask,   gMask,   bMask,   aMask;
 
-	// Colour shifting values (should these all be uint32???)
-	struct Format {
-		uint32  s_bpp,    s_bytes_per_pixel;
-		uint32  r_loss,   g_loss,   b_loss,   a_loss;
-		uint32  r_loss16, g_loss16, b_loss16, a_loss16;
-		uint32  r_shift,  g_shift,  b_shift,  a_shift;
-		uint32  r_mask,   g_mask,   b_mask,   a_mask;
+		inline U8PixelFormat() : Graphics::PixelFormat(),
+			rLoss16(0), gLoss16(0), bLoss16(0), aLoss16(0),
+			rMask(0), gMask(0), bMask(0), aMask(0)
+		{
+		}
 	};
 
-	static Format _format;
+	static U8PixelFormat _format;
 
 	static uint8 _gamma10toGamma22[256];
 	static uint8 _gamma22toGamma10[256];

--- a/engines/ultima/ultima8/graphics/scaler.h
+++ b/engines/ultima/ultima8/graphics/scaler.h
@@ -81,14 +81,14 @@ public:
 			if (!(scale_bits & (1 << y_factor))) return false;
 		}
 
-		if (RenderSurface::_format.s_bytes_per_pixel == 4) {
+		if (RenderSurface::_format.bytesPerPixel == 4) {
 			if (texture->_format == TEX_FMT_NATIVE || (texture->_format == TEX_FMT_STANDARD &&
-			        RenderSurface::_format.a_mask == TEX32_A_MASK && RenderSurface::_format.r_mask == TEX32_R_MASK &&
-			        RenderSurface::_format.g_mask == TEX32_G_MASK && RenderSurface::_format.b_mask == TEX32_B_MASK)) {
-				if (RenderSurface::_format.a_mask == 0xFF000000) {
+			        RenderSurface::_format.aMask == TEX32_A_MASK && RenderSurface::_format.rMask == TEX32_R_MASK &&
+			        RenderSurface::_format.gMask == TEX32_G_MASK && RenderSurface::_format.bMask == TEX32_B_MASK)) {
+				if (RenderSurface::_format.aMask == 0xFF000000) {
 					if (!Scale32_A888) return false;
 					return Scale32_A888(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
-				} else if (RenderSurface::_format.a_mask == 0x000000FF) {
+				} else if (RenderSurface::_format.aMask == 0x000000FF) {
 					if (!Scale32_888A) return false;
 					return Scale32_888A(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
 				} else {
@@ -100,7 +100,7 @@ public:
 				return Scale32Sta(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);
 			}
 		}
-		if (RenderSurface::_format.s_bytes_per_pixel == 2) {
+		if (RenderSurface::_format.bytesPerPixel == 2) {
 			if (texture->_format == TEX_FMT_NATIVE) {
 				if (!Scale16Nat) return false;
 				return Scale16Nat(texture, sx, sy, sw, sh, pixel, dw, dh, pitch, clamp_src);

--- a/engines/ultima/ultima8/graphics/soft_render_surface.cpp
+++ b/engines/ultima/ultima8/graphics/soft_render_surface.cpp
@@ -181,7 +181,7 @@ template<> void SoftRenderSurface<uint32>::Fill32(uint32 rgb, int32 sx, int32 sy
 
 template<class uintX> void SoftRenderSurface<uintX>::FillAlpha(uint8 alpha, int32 sx, int32 sy, int32 w, int32 h) {
 	_clipWindow.IntersectOther(sx, sy, w, h);
-	if (!w || !h || !RenderSurface::_format.a_mask) return;
+	if (!w || !h || !RenderSurface::_format.aMask) return;
 
 	// An optimization.
 	if ((int)(w * sizeof(uintX)) == _pitch) {
@@ -195,24 +195,24 @@ template<class uintX> void SoftRenderSurface<uintX>::FillAlpha(uint8 alpha, int3
 	uint8 *line_end = pixel + w * sizeof(uintX);
 	int diff = _pitch - w * sizeof(uintX);
 
-	uintX a = (((uintX)alpha) << RenderSurface::_format.a_shift)&RenderSurface::_format.a_mask;
+	uintX a = (((uintX)alpha) << RenderSurface::_format.aShift)&RenderSurface::_format.aMask;
 
 #ifdef CHECK_ALPHA_FILLS
 	uintX c;
 	uintX m;
 	if (a == 0) {
-		c = (RenderSurface::_format.b_mask >> 1)&RenderSurface::_format.b_mask;
-		m = RenderSurface::_format.b_mask;
+		c = (RenderSurface::_format.bMask >> 1)&RenderSurface::_format.bMask;
+		m = RenderSurface::_format.bMask;
 	} else {
-		c = (RenderSurface::_format.r_mask >> 1)&RenderSurface::_format.r_mask;
-		m = RenderSurface::_format.r_mask;
+		c = (RenderSurface::_format.rMask >> 1)&RenderSurface::_format.rMask;
+		m = RenderSurface::_format.rMask;
 	}
 #endif
 
 	while (pixel != end) {
 		while (pixel != line_end) {
 			uintX *dest = reinterpret_cast<uintX *>(pixel);
-			*dest = (*dest & ~RenderSurface::_format.a_mask) | a;
+			*dest = (*dest & ~RenderSurface::_format.aMask) | a;
 #ifdef CHECK_ALPHA_FILLS
 			*dest = (*dest & ~m) | (c + (((*dest & m) >> 1)&m));
 #endif
@@ -254,7 +254,7 @@ template<class uintX> void SoftRenderSurface<uintX>::FillBlended(uint32 rgba, in
 		while (pixel != line_end) {
 			uintX *dest = reinterpret_cast<uintX *>(pixel);
 			uintX d = *dest;
-			*dest = (d & RenderSurface::_format.a_mask) | BlendPreModFast(rgba, d);
+			*dest = (d & RenderSurface::_format.aMask) | BlendPreModFast(rgba, d);
 			pixel += sizeof(uintX);
 		}
 
@@ -637,7 +637,7 @@ template<class uintX> void SoftRenderSurface<uintX>::MaskedBlit(Texture *_tex, i
 					uintX *dest = reinterpret_cast<uintX *>(pixel);
 
 					if (*texel & TEX32_A_MASK) {
-						if (!RenderSurface::_format.a_mask || (*dest & RenderSurface::_format.a_mask)) {
+						if (!RenderSurface::_format.aMask || (*dest & RenderSurface::_format.aMask)) {
 							*dest = static_cast<uintX>(
 								PACK_RGB8(
 									(TEX32_R(*texel) * ia + r) >> 8,
@@ -654,7 +654,7 @@ template<class uintX> void SoftRenderSurface<uintX>::MaskedBlit(Texture *_tex, i
 				while (pixel != line_end) {
 					uintX *dest = reinterpret_cast<uintX *>(pixel);
 
-					if (!RenderSurface::_format.a_mask || (*dest & RenderSurface::_format.a_mask)) {
+					if (!RenderSurface::_format.aMask || (*dest & RenderSurface::_format.aMask)) {
 						uint32 alpha = *texel & TEX32_A_MASK;
 						if (alpha == 0xFF) {
 							*dest = static_cast<uintX>(
@@ -698,7 +698,7 @@ template<class uintX> void SoftRenderSurface<uintX>::MaskedBlit(Texture *_tex, i
 
 				// Uh, not completely supported right now
 				//if ((*texel & RenderSurface::_format.a_mask) && (*dest & RenderSurface::_format.a_mask))
-				if (*dest & RenderSurface::_format.a_mask) {
+				if (*dest & RenderSurface::_format.aMask) {
 					*dest = BlendHighlight(*texel, r, g, b, 1, ia);
 				}
 				pixel += sizeof(uintX);

--- a/engines/ultima/ultima8/graphics/soft_render_surface.inl
+++ b/engines/ultima/ultima8/graphics/soft_render_surface.inl
@@ -155,7 +155,7 @@ const int32 neg = (FLIP_CONDITIONAL)?-1:0;
 //
 #ifdef DESTALPHA_MASK
 
-#define NOT_DESTINATION_MASKED	(*pixptr & RenderSurface::_format.a_mask)
+#define NOT_DESTINATION_MASKED	(*pixptr & RenderSurface::_format.aMask)
 
 #else
 

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -598,7 +598,7 @@ void Ultima8Engine::GraphicSysInit() {
 		_screen->GetSurfaceDims(old_dims);
 		if (width == old_dims.w && height == old_dims.h)
 			return;
-		bpp = RenderSurface::_format.s_bpp;
+		bpp = RenderSurface::_format.bpp();
 
 		delete _screen;
 	}


### PR DESCRIPTION
The Ultima8 engine defined its own `PixelFormat` struct with very similar members to the ScummVM one.  I refactored it to extend that struct instead of redefining it.

This refactor should help the planned changes that I mentioned in #2158.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
