### PR TITLE
DIRECTOR: implement transformColor function

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -285,7 +285,7 @@ ShapeCast::ShapeCast(Common::ReadStreamEndian &stream, uint16 version) {
 		_shapeType = static_cast<ShapeType>(stream.readByte());
 		_initialRect = Score::readRect(stream);
 		_pattern = stream.readUint16BE();
-		_fgCol = (127 - stream.readByte()) & 0xff; // -128 -> 0, 127 -> 256
+		_fgCol = (127 - stream.readByte()) & 0xff; // -128 ... 127 -> 255 ... 0
 		_bgCol = (127 - stream.readByte()) & 0xff;
 		_fillType = stream.readByte();
 		_ink = static_cast<InkType>(_fillType & 0x3f);

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -114,6 +114,7 @@ public:
 	void loadSharedCastsFrom(Common::String filename);
 	void clearSharedCast();
 	void loadPatterns();
+	byte transformColor(byte color);
 	Graphics::MacPatterns &getPatterns();
 
 	void loadInitialMovie(const Common::String movie);

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -202,10 +202,10 @@ void Frame::readChannels(Common::ReadStreamEndian *stream) {
 			sprite._spriteType = stream->readByte();
 			sprite._enabled = sprite._spriteType != 0;
 			if (_vm->getVersion() >= 4) {
-				sprite._foreColor = 0xff - (uint8)stream->readByte();
-				sprite._backColor = 0xff - (uint8)stream->readByte();
+				sprite._foreColor = _vm->transformColor((uint8)stream->readByte());
+				sprite._backColor = _vm->transformColor((uint8)stream->readByte());
 			} else {
-				sprite._foreColor = (127 - stream->readByte()) & 0xff; // -128 -> 0, 127 -> 256
+				sprite._foreColor = (127 - stream->readByte()) & 0xff; // -128 ... 127 -> 255 ... 0
 				sprite._backColor = (127 - stream->readByte()) & 0xff;
 			}
 
@@ -947,7 +947,7 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	}
 
 	Graphics::ManagedSurface textWithFeatures(width + (borderSize * 2) + boxShadow + textShadow, height + borderSize + boxShadow + textShadow);
-	textWithFeatures.fillRect(Common::Rect(textWithFeatures.w, textWithFeatures.h), 255 - _vm->getCurrentScore()->getStageColor());
+	textWithFeatures.fillRect(Common::Rect(textWithFeatures.w, textWithFeatures.h), _vm->getCurrentScore()->getStageColor());
 
 	if (textRect == NULL && boxShadow > 0) {
 		textWithFeatures.fillRect(Common::Rect(boxShadow, boxShadow, textWithFeatures.w + boxShadow, textWithFeatures.h), 0);
@@ -1063,7 +1063,7 @@ void Frame::drawReverseSprite(Graphics::ManagedSurface &target, const Graphics::
 		for (int j = 0; j < srcRect.width(); j++) {
 			if ((getSpriteIDFromPos(Common::Point(drawRect.left + j, drawRect.top + ii)) != 0)) {
 				if (*src != skipColor) {
-					*dst = 0xff - *src;
+					*dst = _vm->transformColor(*src);
 				}
 			} else if (*src != skipColor) {
 				*dst = *src;

--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -699,6 +699,16 @@ static byte director3QuickDrawPatterns[][8] = {
 	{ 0xFF, 0x2A, 0xFF, 0xC8, 0xFF, 0x65, 0xFF, 0x9D }
 };
 
+
+/**
+ * The sprites colors are in reverse order with respect to the ids in director.
+ * To make loading images easier we the palette is in reverse order.
+ * All other color ids can be converted with: 255 - colorId.
+ */
+byte DirectorEngine::transformColor(byte color){
+	return 255 - color;
+}
+
 void DirectorEngine::loadPatterns() {
 	for (int i = 0; i < ARRAYSIZE(director3Patterns); i++)
 		_director3Patterns.push_back(director3Patterns[i]);
@@ -785,7 +795,7 @@ void DirectorEngine::testFontScaling() {
 
 			for (x = x1; x < x1 + 6; x++)
 				for (y = y1; y < y1 + 6; y++)
-					*((byte *)surface.getBasePtr(x, y)) = 255 - (i * 16 + j);
+					*((byte *)surface.getBasePtr(x, y)) = transformColor(i * 16 + j);
 		}
 	}
 

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -570,7 +570,7 @@ void Score::loadConfig(Common::SeekableSubReadStreamEndian &stream) {
 	uint16 commentFont = stream.readUint16();
 	uint16 commentSize = stream.readUint16();
 	uint16 commentStyle = stream.readUint16();
-	_stageColor = stream.readUint16();
+	_stageColor = _vm->transformColor(stream.readUint16());
 	uint16 bitdepth = stream.readUint16();
 	byte color = stream.readByte();	// boolean, color = 1, B/W = 0
 	uint16 stageColorR = stream.readUint16();
@@ -639,7 +639,7 @@ void Score::loadCastDataVWCR(Common::SeekableSubReadStreamEndian &stream) {
 			break;
 		case kCastText:
 			debugC(3, kDebugLoading, "Score::loadCastDataVWCR(): CastTypes id: %d(%s) TextCast", id, numToCastNum(id));
-			_loadedCast->setVal(id, new TextCast(stream, _vm->getVersion(), 255 - _stageColor));
+			_loadedCast->setVal(id, new TextCast(stream, _vm->getVersion(), _stageColor));
 			break;
 		case kCastShape:
 			debugC(3, kDebugLoading, "Score::loadCastDataVWCR(): CastTypes id: %d(%s) ShapeCast", id, numToCastNum(id));
@@ -743,7 +743,7 @@ void Score::loadCastData(Common::SeekableSubReadStreamEndian &stream, uint16 id,
 		break;
 	case kCastText:
 		debugC(3, kDebugLoading, "Score::loadCastData(): loading kCastText (%d children)", res->children.size());
-		_loadedCast->setVal(id, new TextCast(castStream, _vm->getVersion(), 255 - _stageColor));
+		_loadedCast->setVal(id, new TextCast(castStream, _vm->getVersion(), _stageColor));
 		break;
 	case kCastShape:
 		debugC(3, kDebugLoading, "Score::loadCastData(): loading kCastShape (%d children)", res->children.size());
@@ -759,7 +759,7 @@ void Score::loadCastData(Common::SeekableSubReadStreamEndian &stream, uint16 id,
 		break;
 	case kCastRTE:
 		debugC(3, kDebugLoading, "Score::loadCastData(): loading kCastRTE (%d children)", res->children.size());
-		_loadedCast->setVal(id, new RTECast(castStream, _vm->getVersion(), 255 - _stageColor));
+		_loadedCast->setVal(id, new RTECast(castStream, _vm->getVersion(), _stageColor));
 		break;
 	case kCastFilmLoop:
 		warning("STUB: Score::loadCastData(): kCastFilmLoop (%d children)", res->children.size());
@@ -1410,7 +1410,7 @@ void Score::startLoop() {
 
 	g_director->_wm->setScreen(_surface);
 
-	_trailSurface->clear(255 - _stageColor);
+	_trailSurface->clear(_stageColor);
 
 	_currentFrame = 0;
 	_stopPlay = false;
@@ -1489,7 +1489,7 @@ void Score::update() {
 
 	debugC(1, kDebugImages, "******************************  Current frame: %d", _currentFrame);
 
-	_surface->clear(255 - _stageColor);
+	_surface->clear(_stageColor);
 	_surface->copyFrom(*_trailSurface);
 
 	_lingo->executeImmediateScripts(_frames[_currentFrame]);


### PR DESCRIPTION
The palettes are reversed by default. This is useful when rendering
sprites, as they use reversed ids as well.
When a color is read directly as an int, it is in the original
unreversed order.
So, reverse it by hand when it's coming from lingo or other sources.
This was done in multiple places by subtracting the color id from 255.
The function transformColor handles this now.

Reversing the color means: 255 - color_id.