### PR TITLE
ULTIMA: Split and center text when too large

### DIFF
--- a/engines/ultima/nuvie/fonts/font.h
+++ b/engines/ultima/nuvie/fonts/font.h
@@ -85,6 +85,7 @@ public:
 	}
 
 protected:
+	uint16 drawStringCentered(Screen *screen, const char *str, uint16 string_len, uint16 x, uint16 y, uint8 color, uint8 highlight_color);
 
 	uint8 get_char_num(uint8 c);
 


### PR DESCRIPTION
Character creation screens on Martian Dream are larger than the screen.
The text needs to be split into multiple lines.

I tried to be conservative to not accidentally break anything. It falls back to
the original core if it is shorter than the screen size.