### PR TITLE
ULTIMA8: Make ShapeFrame pointers const

### DIFF
--- a/engines/ultima/ultima8/games/game_data.cpp
+++ b/engines/ultima/ultima8/games/game_data.cpp
@@ -130,11 +130,11 @@ Shape *GameData::getShape(FrameID f) const {
 	return shape;
 }
 
-ShapeFrame *GameData::getFrame(FrameID f) const {
-	Shape *shape = getShape(f);
+const ShapeFrame *GameData::getFrame(FrameID f) const {
+	const Shape *shape = getShape(f);
 	if (!shape)
 		return nullptr;
-	ShapeFrame *frame = shape->getFrame(f._frameNum);
+	const ShapeFrame *frame = shape->getFrame(f._frameNum);
 	return frame;
 }
 

--- a/engines/ultima/ultima8/games/game_data.h
+++ b/engines/ultima/ultima8/games/game_data.h
@@ -89,7 +89,7 @@ public:
 
 	ShapeArchive *getShapeFlex(uint16 flexId) const;
 	Shape *getShape(FrameID frameid) const;
-	ShapeFrame *getFrame(FrameID frameid) const;
+	const ShapeFrame *getFrame(FrameID frameid) const;
 
 	Std::string translate(Std::string text);
 	FrameID translate(FrameID frame);

--- a/engines/ultima/ultima8/graphics/shape.cpp
+++ b/engines/ultima/ultima8/graphics/shape.cpp
@@ -261,7 +261,7 @@ void Shape::getTotalDimensions(int32 &w, int32 &h, int32 &x, int32 &y) const {
 	y = -miny;
 }
 
-ShapeFrame *Shape::getFrame(unsigned int frame) {
+const ShapeFrame *Shape::getFrame(unsigned int frame) const {
 	if (frame < _frames.size())
 		return _frames[frame];
 	else

--- a/engines/ultima/ultima8/graphics/shape.h
+++ b/engines/ultima/ultima8/graphics/shape.h
@@ -60,7 +60,7 @@ public:
 	//! (x,y) = coordinates of origin relative to top-left point of rectangle
 	void getTotalDimensions(int32 &w, int32 &h, int32 &x, int32 &y) const;
 
-	ShapeFrame *getFrame(unsigned int frame);
+	const ShapeFrame *getFrame(unsigned int frame) const;
 
 	void getShapeId(uint16 &flexId, uint32 &shapenum);
 

--- a/engines/ultima/ultima8/graphics/shape_frame.cpp
+++ b/engines/ultima/ultima8/graphics/shape_frame.cpp
@@ -236,7 +236,7 @@ uint8 ShapeFrame::getPixelAtPoint(int32 x, int32 y) const {
 	return 0xFF;
 }
 
-void ShapeFrame::getConvertShapeFrame(ConvertShapeFrame &csf, bool need_bytes_rle) {
+void ShapeFrame::getConvertShapeFrame(ConvertShapeFrame &csf) {
 	csf._compression = _compressed;
 	csf._width = _width;
 	csf._height = _height;

--- a/engines/ultima/ultima8/graphics/shape_frame.h
+++ b/engines/ultima/ultima8/graphics/shape_frame.h
@@ -53,7 +53,7 @@ public:
 
 	uint8 getPixelAtPoint(int32 x, int32 y) const;  // Get the pixel at the point
 
-	void getConvertShapeFrame(ConvertShapeFrame &csf, bool need_bytes_rle = false);
+	void getConvertShapeFrame(ConvertShapeFrame &csf);
 protected:
 
 	// This will load a u8 style shape 'optimized'.

--- a/engines/ultima/ultima8/graphics/soft_render_surface.inl
+++ b/engines/ultima/ultima8/graphics/soft_render_surface.inl
@@ -185,7 +185,7 @@ const int32 neg = (FLIP_CONDITIONAL)?-1:0;
 	if (s->getPalette() == 0)
 		return;
 
-	ShapeFrame		*frame			= s->getFrame(framenum);
+	const ShapeFrame	*frame			= s->getFrame(framenum);
 	const uint8		*rle_data		= frame->_rle_data;
 	const uint32	*line_offsets	= frame->_line_offsets;
 	const uint32	*pal			= untformed_pal?

--- a/engines/ultima/ultima8/gumps/book_gump.cpp
+++ b/engines/ultima/ultima8/gumps/book_gump.cpp
@@ -74,7 +74,7 @@ void BookGump::InitGump(Gump *newparent, bool take_focus) {
 
 	SetShape(shapeP, 0);
 
-	ShapeFrame *sf = shapeP->getFrame(0);
+	const ShapeFrame *sf = shapeP->getFrame(0);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/gumps/container_gump.cpp
+++ b/engines/ultima/ultima8/gumps/container_gump.cpp
@@ -66,7 +66,7 @@ ContainerGump::~ContainerGump() {
 }
 
 void ContainerGump::InitGump(Gump *newparent, bool take_focus) {
-	ShapeFrame *sf = _shape->getFrame(_frameNum);
+	const ShapeFrame *sf = _shape->getFrame(_frameNum);
 	assert(sf);
 
 	_dims.w = sf->_width;
@@ -181,9 +181,9 @@ uint16 ContainerGump::TraceObjId(int32 mx, int32 my) {
 
 		int32 itemx, itemy;
 		getItemCoords(item, itemx, itemy);
-		Shape *s = item->getShapeObject();
+		const Shape *s = item->getShapeObject();
 		assert(s);
-		ShapeFrame *frame = s->getFrame(item->getFrame());
+		const ShapeFrame *frame = s->getFrame(item->getFrame());
 
 		if (frame->hasPoint(mx - itemx, my - itemy)) {
 			// found it
@@ -407,9 +407,9 @@ bool ContainerGump::DraggingItem(Item *item, int mx, int my) {
 	_draggingX = mx - _itemArea.x - dox;
 	_draggingY = my - _itemArea.y - doy;
 
-	Shape *sh = item->getShapeObject();
+	const Shape *sh = item->getShapeObject();
 	assert(sh);
-	ShapeFrame *fr = sh->getFrame(_draggingFrame);
+	const ShapeFrame *fr = sh->getFrame(_draggingFrame);
 	assert(fr);
 
 	if (_draggingX - fr->_xoff < 0 ||

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -82,7 +82,7 @@ void Gump::SetShape(FrameID frame, bool adjustsize) {
 	_frameNum = frame._frameNum;
 
 	if (adjustsize && _shape) {
-		ShapeFrame *sf = _shape->getFrame(_frameNum);
+		const ShapeFrame *sf = _shape->getFrame(_frameNum);
 		_dims.w = sf->_width;
 		_dims.h = sf->_height;
 	}
@@ -406,7 +406,7 @@ bool Gump::PointOnGump(int mx, int my) {
 		return true;
 	}
 
-	ShapeFrame *sf = _shape->getFrame(_frameNum);
+	const ShapeFrame *sf = _shape->getFrame(_frameNum);
 	assert(sf);
 	if (sf->hasPoint(gx, gy)) {
 		return true;

--- a/engines/ultima/ultima8/gumps/menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/menu_gump.cpp
@@ -108,7 +108,7 @@ void MenuGump::InitGump(Gump *newparent, bool take_focus) {
 	ModalGump::InitGump(newparent, take_focus);
 
 	_shape = GameData::get_instance()->getGumps()->getShape(gumpShape);
-	ShapeFrame *sf = _shape->getFrame(0);
+	const ShapeFrame *sf = _shape->getFrame(0);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/gumps/mini_stats_gump.cpp
+++ b/engines/ultima/ultima8/gumps/mini_stats_gump.cpp
@@ -66,7 +66,7 @@ void MiniStatsGump::InitGump(Gump *newparent, bool take_focus) {
 	Gump::InitGump(newparent, take_focus);
 
 	_shape = GameData::get_instance()->getGumps()->getShape(gumpshape);
-	ShapeFrame *sf = _shape->getFrame(0);
+	const ShapeFrame *sf = _shape->getFrame(0);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/gumps/minimap_gump.cpp
+++ b/engines/ultima/ultima8/gumps/minimap_gump.cpp
@@ -154,11 +154,11 @@ uint32 MiniMapGump::sampleAtPoint(int x, int y, CurrentMap *currentmap) {
 		ix -= x;
 		iy -= y;
 
-		Shape *sh = item->getShapeObject();
+		const Shape *sh = item->getShapeObject();
 		if (!sh)
 			return 0;
 
-		ShapeFrame *frame = sh->getFrame(item->getFrame());
+		const ShapeFrame *frame = sh->getFrame(item->getFrame());
 		if (!frame)
 			return 0;
 

--- a/engines/ultima/ultima8/gumps/paged_gump.cpp
+++ b/engines/ultima/ultima8/gumps/paged_gump.cpp
@@ -60,7 +60,7 @@ void PagedGump::InitGump(Gump *newparent, bool take_focus) {
 	ModalGump::InitGump(newparent, take_focus);
 
 	_shape = GameData::get_instance()->getGumps()->getShape(_gumpShape);
-	ShapeFrame *sf = _shape->getFrame(0);
+	const ShapeFrame *sf = _shape->getFrame(0);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/gumps/paperdoll_gump.cpp
+++ b/engines/ultima/ultima8/gumps/paperdoll_gump.cpp
@@ -243,9 +243,9 @@ uint16 PaperdollGump::TraceObjId(int32 mx, int32 my) {
 		itemy = equipcoords[i].y;
 		itemx += _itemArea.x;
 		itemy += _itemArea.y;
-		Shape *s = item->getShapeObject();
+		const Shape *s = item->getShapeObject();
 		assert(s);
-		ShapeFrame *frame = s->getFrame(item->getFrame() + 1);
+		const ShapeFrame *frame = s->getFrame(item->getFrame() + 1);
 
 		if (frame->hasPoint(mx - itemx, my - itemy)) {
 			// found it
@@ -298,9 +298,9 @@ bool PaperdollGump::StartDraggingItem(Item *item, int mx, int my) {
 	bool ret = ContainerGump::StartDraggingItem(item, mx, my);
 
 	// set dragging offset to center of item
-	Shape *s = item->getShapeObject();
+	const Shape *s = item->getShapeObject();
 	assert(s);
-	ShapeFrame *frame = s->getFrame(item->getFrame());
+	const ShapeFrame *frame = s->getFrame(item->getFrame());
 	assert(frame);
 
 	Mouse::get_instance()->setDraggingOffset(frame->_width / 2 - frame->_xoff,

--- a/engines/ultima/ultima8/gumps/quit_gump.cpp
+++ b/engines/ultima/ultima8/gumps/quit_gump.cpp
@@ -57,7 +57,7 @@ void QuitGump::InitGump(Gump *newparent, bool take_focus) {
 	ModalGump::InitGump(newparent, take_focus);
 
 	_shape = GameData::get_instance()->getGumps()->getShape(gumpShape);
-	ShapeFrame *sf = _shape->getFrame(0);
+	const ShapeFrame *sf = _shape->getFrame(0);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/gumps/readable_gump.cpp
+++ b/engines/ultima/ultima8/gumps/readable_gump.cpp
@@ -63,7 +63,7 @@ void ReadableGump::InitGump(Gump *newparent, bool take_focus) {
 
 	SetShape(shape_, 0);
 
-	ShapeFrame *sf = shape_->getFrame(0);
+	const ShapeFrame *sf = shape_->getFrame(0);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/gumps/scroll_gump.cpp
+++ b/engines/ultima/ultima8/gumps/scroll_gump.cpp
@@ -67,7 +67,7 @@ void ScrollGump::InitGump(Gump *newparent, bool take_focus) {
 
 	SetShape(shape_, 0);
 
-	ShapeFrame *sf = shape_->getFrame(0);
+	const ShapeFrame *sf = shape_->getFrame(0);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/gumps/slider_gump.cpp
+++ b/engines/ultima/ultima8/gumps/slider_gump.cpp
@@ -125,7 +125,7 @@ void SliderGump::InitGump(Gump *newparent, bool take_focus) {
 	ModalGump::InitGump(newparent, take_focus);
 
 	_shape = GameData::get_instance()->getGumps()->getShape(gumpshape);
-	ShapeFrame *sf = _shape->getFrame(0);
+	const ShapeFrame *sf = _shape->getFrame(0);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/gumps/u8_save_gump.cpp
+++ b/engines/ultima/ultima8/gumps/u8_save_gump.cpp
@@ -69,7 +69,7 @@ void U8SaveGump::InitGump(Gump *newparent, bool take_focus) {
 
 	Shape *entryShape;
 	entryShape = GameData::get_instance()->getShape(entry_id);
-	ShapeFrame *sf = entryShape->getFrame(entry_id._frameNum);
+	const ShapeFrame *sf = entryShape->getFrame(entry_id._frameNum);
 	int entrywidth = sf->_width;
 	int entryheight = sf->_height;
 

--- a/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
@@ -82,7 +82,7 @@ void ButtonWidget::InitGump(Gump *newparent, bool take_focus) {
 		_shape = _shapeUp;
 		_frameNum = _frameNumUp;
 
-		ShapeFrame *sf = _shape->getFrame(_frameNum);
+		const ShapeFrame *sf = _shape->getFrame(_frameNum);
 		assert(sf);
 		_dims.w = sf->_width;
 		_dims.h = sf->_height;

--- a/engines/ultima/ultima8/gumps/widgets/sliding_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/sliding_widget.cpp
@@ -49,7 +49,7 @@ SlidingWidget::~SlidingWidget() {
 void SlidingWidget::InitGump(Gump *newparent, bool take_focus) {
 	Gump::InitGump(newparent, take_focus);
 
-	ShapeFrame *sf = _shape->getFrame(_frameNum);
+	const ShapeFrame *sf = _shape->getFrame(_frameNum);
 	assert(sf);
 
 	_dims.w = sf->_width;

--- a/engines/ultima/ultima8/world/item_sorter.cpp
+++ b/engines/ultima/ultima8/world/item_sorter.cpp
@@ -656,7 +656,7 @@ void ItemSorter::AddItem(int32 x, int32 y, int32 z, uint32 shapeNum, uint32 fram
 	si->_shape = _shapes->getShape(shapeNum);
 	si->_shapeNum = shapeNum;
 	si->_frame = frame_num;
-	ShapeFrame *_frame = si->_shape->getFrame(si->_frame);
+	const ShapeFrame *_frame = si->_shape->getFrame(si->_frame);
 	if (!_frame) {
 		perr << "Invalid _shape: " << si->_shapeNum << "," << si->_frame
 		     << Std::endl;
@@ -835,7 +835,7 @@ void ItemSorter::AddItem(Item *add) {
 	si->_shape = add->getShapeObject();
 	si->_shapeNum = add->getShape();
 	si->_frame = add->getFrame();
-	ShapeFrame *_frame = si->_shape->getFrame(si->_frame);
+	const ShapeFrame *_frame = si->_shape->getFrame(si->_frame);
 	if (!_frame) {
 		perr << "Invalid _shape: " << si->_shapeNum << "," << si->_frame
 		     << Std::endl;
@@ -1159,7 +1159,7 @@ uint16 ItemSorter::Trace(int32 x, int32 y, HitFace *face, bool item_highlight) {
 				if (x < it->_sx || x >= it->_sx2 || y < it->_sy || y >= it->_sy2) continue;
 
 				// Now check the _frame itself
-				ShapeFrame *_frame = it->_shape->getFrame(it->_frame);
+				const ShapeFrame *_frame = it->_shape->getFrame(it->_frame);
 				assert(_frame); // invalid frames shouldn't have been added to the list
 
 				// Nope, doesn't have a point
@@ -1187,7 +1187,7 @@ uint16 ItemSorter::Trace(int32 x, int32 y, HitFace *face, bool item_highlight) {
 			if (x < it->_sx || x >= it->_sx2 || y < it->_sy || y >= it->_sy2) continue;
 
 			// Now check the _frame itself
-			ShapeFrame *_frame = it->_shape->getFrame(it->_frame);
+			const ShapeFrame *_frame = it->_shape->getFrame(it->_frame);
 			assert(_frame); // invalid frames shouldn't have been added to the list
 
 			// Nope, doesn't have a point


### PR DESCRIPTION
A mostly trivial change to make all the use of `ShapeFrame` pointers const (and also remove the never-used parameter `need_bytes_rle` on `ShapeFrame::getConvertShapeFrame`), so that I can more confidently decompress the frames after loading and avoid separate render paths (as mentioned in #2158).

I think this will conflict with #2158 if one is merged first, I'll rebase if needed.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
