### PR TITLE
SDL2: silence 'window magic' assert

### DIFF
--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -186,7 +186,7 @@ void SdlWindow::iconifyWindow() {
 bool SdlWindow::getSDLWMInformation(SDL_SysWMinfo *info) const {
 	SDL_VERSION(&info->version);
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	return SDL_GetWindowWMInfo(_window, info);
+	return _window ? SDL_GetWindowWMInfo(_window, info) : false;
 #else
 	return SDL_GetWMInfo(info);
 #endif


### PR DESCRIPTION
This is a one line fix to silence the weird 'window && window->magic == &this->window_magic' assert that gets triggered at the start of ScummVM with some SDL2 builds (for me it does that with the debug Win64 version from vcpkg).

This shouldn't have any negative impact.  Calling SDL_GetWindowWMInfo() with a nullptr parameter can't really return anything useful. Nonetheless I commit this as a pull request, so that any interested team member can comment on it. 