### PR TITLE
DIRECTOR: LINGO: Implement list math

### DIFF
--- a/engines/director/lingo/lingo-code.h
+++ b/engines/director/lingo/lingo-code.h
@@ -29,11 +29,18 @@ namespace LC {
 	void c_xpop();
 	void c_printtop();
 
+	Datum mapBinaryOp(Datum (*func)(Datum, Datum), Datum d1, Datum d2);
+	Datum addData(Datum d1, Datum d2);
 	void c_add();
+	Datum subData(Datum d1, Datum d2);
 	void c_sub();
+	Datum mulData(Datum d1, Datum d2);
 	void c_mul();
+	Datum divData(Datum d1, Datum d2);
 	void c_div();
+	Datum modData(Datum d1, Datum d2);
 	void c_mod();
+	Datum negateData(Datum d1);
 	void c_negate();
 
 	void c_and();

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -518,7 +518,8 @@ Common::String *Datum::toString() {
 		for (uint i = 0; i < u.farr->size(); i++) {
 			if (i > 0)
 				*s += ", ";
-			*s += *u.farr->operator[](i).toString();
+			Datum d = u.farr->operator[](i);
+			*s += *d.toString();
 		}
 
 		*s += "]";

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -316,34 +316,22 @@ int Lingo::alignTypes(Datum &d1, Datum &d2) {
 
 	if (d1.type == STRING) {
 		char *endPtr = 0;
-		int i = strtol(d1.u.s->c_str(), &endPtr, 10);
+		double d = strtod(d1.u.s->c_str(), &endPtr);
 		if (*endPtr == 0) {
-			d1.type = INT;
-			d1.u.i = i;
+			d1.type = FLOAT;
+			d1.u.f = d;
 		} else {
-			double d = strtod(d1.u.s->c_str(), &endPtr);
-			if (*endPtr == 0) {
-				d1.type = FLOAT;
-				d1.u.f = d;
-			} else {
-				warning("Unable to parse '%s' as a number", d1.u.s->c_str());
-			}
+			warning("Unable to parse '%s' as a number", d1.u.s->c_str());
 		}
 	}
 	if (d2.type == STRING) {
 		char *endPtr = 0;
-		int i = strtol(d2.u.s->c_str(), &endPtr, 10);
+		double d = strtod(d2.u.s->c_str(), &endPtr);
 		if (*endPtr == 0) {
-			d2.type = INT;
-			d2.u.i = i;
+			d2.type = FLOAT;
+			d2.u.f = d;
 		} else {
-			double d = strtod(d2.u.s->c_str(), &endPtr);
-			if (*endPtr == 0) {
-				d2.type = FLOAT;
-				d2.u.f = d;
-			} else {
-				warning("Unable to parse '%s' as a number", d2.u.s->c_str());
-			}
+			warning("Unable to parse '%s' as a number", d2.u.s->c_str());
 		}
 	}
 

--- a/engines/director/lingo/tests/lists.lingo
+++ b/engines/director/lingo/tests/lists.lingo
@@ -8,3 +8,19 @@ set a to [1, 2, 3]
 put a
 
 set gList = [point(70, 190), point(217, 66), point(364, 185)]
+
+set b to [4, 5, 6, 7]
+set res to a + b
+set res to a - b
+set res to a * b
+set res to b / a
+set res to b mod a
+set res to -a
+
+set floats to [4.0, 5.0, 6.0, 7.0]
+set strings to ["4", "5", "6", "7"]
+
+set res to a + floats
+set res to a + strings
+set res to a + 1
+set res to 1 + b


### PR DESCRIPTION
This implements Lingo list math. e.g.
```
set a to [1, 2, 3]
set b to [4, 5, 6, 7]
set floats to [4.0, 5.0, 6.0, 7.0]
set strings to ["4", "5", "6", "7"]

put a + b
-- [5, 7, 9]
put a + floats
-- [5.0, 7.0, 9.0]
put a + strings
-- [5.0, 7.0, 9.0]
put a + 1
-- [2, 3, 4]
```

This also fixes a bug in Datum::toString() which caused arrays' contents to be overwritten with strings. Since Datum::toString() is called frequently, this prevented list math from working properly.