### PR TITLE
ANDROID: Add support for additional mouse buttons

### DIFF
--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -475,6 +475,60 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 
 		return;
 
+	case JE_MMB_DOWN:
+		e.type = Common::EVENT_MBUTTONDOWN;
+		e.mouse.x = arg1;
+		e.mouse.y = arg2;
+
+		pushEvent(e);
+
+		return;
+
+	case JE_MMB_UP:
+		e.type = Common::EVENT_MBUTTONUP;
+		e.mouse.x = arg1;
+		e.mouse.y = arg2;
+
+		pushEvent(e);
+
+		return;
+
+	case JE_BMB_DOWN:
+		e.type = Common::EVENT_X1BUTTONDOWN;
+		e.mouse.x = arg1;
+		e.mouse.y = arg2;
+
+		pushEvent(e);
+
+		return;
+
+	case JE_BMB_UP:
+		e.type = Common::EVENT_X1BUTTONUP;
+		e.mouse.x = arg1;
+		e.mouse.y = arg2;
+
+		pushEvent(e);
+
+		return;
+
+	case JE_FMB_DOWN:
+		e.type = Common::EVENT_X2BUTTONDOWN;
+		e.mouse.x = arg1;
+		e.mouse.y = arg2;
+
+		pushEvent(e);
+
+		return;
+
+	case JE_FMB_UP:
+		e.type = Common::EVENT_X2BUTTONUP;
+		e.mouse.x = arg1;
+		e.mouse.y = arg2;
+
+		pushEvent(e);
+
+		return;
+
 	case JE_GAMEPAD:
 		switch (arg1) {
 		case JACTION_DOWN:
@@ -547,18 +601,6 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 
 		return;
 
-	case JE_MMB_DOWN:
-		e.type = Common::EVENT_MAINMENU;
-
-		pushEvent(e);
-
-		return;
-
-	case JE_MMB_UP:
-		// No action
-
-		return;
-
 	case JE_QUIT:
 		e.type = Common::EVENT_QUIT;
 
@@ -617,17 +659,9 @@ bool OSystem_Android::pollEvent(Common::Event &event) {
 
 	unlockMutex(_event_queue_lock);
 
-	switch (event.type) {
-	case Common::EVENT_MOUSEMOVE:
-	case Common::EVENT_LBUTTONDOWN:
-	case Common::EVENT_LBUTTONUP:
-	case Common::EVENT_RBUTTONDOWN:
-	case Common::EVENT_RBUTTONUP:
+	if (Common::isMouseEvent(event)) {
 		if (_graphicsManager)
 			return dynamic_cast<AndroidGraphicsManager *>(_graphicsManager)->notifyMousePosition(event.mouse);
-		break;
-	default:
-		break;
 	}
 
 	return true;

--- a/backends/platform/android/events.h
+++ b/backends/platform/android/events.h
@@ -50,6 +50,10 @@ enum {
 	JE_JOYSTICK = 15,
 	JE_MMB_DOWN = 16,
 	JE_MMB_UP = 17,
+	JE_BMB_DOWN = 18,
+	JE_BMB_UP = 19,
+	JE_FMB_DOWN = 20,
+	JE_FMB_UP = 21,
 	JE_QUIT = 0x1000
 };
 

--- a/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
+++ b/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
@@ -15,6 +15,10 @@ public class MouseHelper {
 	private boolean _rmbPressed;
 	private boolean _lmbPressed;
 	private boolean _mmbPressed;
+	private boolean _bmbPressed;
+	private boolean _fmbPressed;
+	private boolean _srmbPressed;
+	private boolean _smmbPressed;
 
 	/**
 	 * Class initialization fails when this throws an exception.
@@ -77,6 +81,25 @@ public class MouseHelper {
 		       ((sources & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD);
 	}
 
+	private boolean handleButton(MotionEvent e, boolean mbPressed, int mask, int downEvent, int upEvent) {
+		boolean mbDown = (e.getButtonState() & mask) == mask;
+		if (mbDown) {
+			if (!mbPressed) {
+				// left mouse button was pressed just now
+				_scummvm.pushEvent(downEvent, (int)e.getX(), (int)e.getY(), e.getButtonState(), 0, 0, 0);
+			}
+
+			return true;
+		} else {
+			if (mbPressed) {
+				// left mouse button was released just now
+				_scummvm.pushEvent(upEvent, (int)e.getX(), (int)e.getY(), e.getButtonState(), 0, 0, 0);
+			}
+
+			return false;
+		}
+	}
+
 	public boolean onMouseEvent(MotionEvent e, boolean hover) {
 		_scummvm.pushEvent(ScummVMEvents.JE_MOUSE_MOVE, (int)e.getX(), (int)e.getY(), 0, 0, 0, 0);
 
@@ -105,39 +128,12 @@ public class MouseHelper {
 			_lmbPressed = false;
 		}
 
-		boolean rmbDown = (buttonState & MotionEvent.BUTTON_SECONDARY) == MotionEvent.BUTTON_SECONDARY;
-		if (rmbDown) {
-			if (!_rmbPressed) {
-				// right mouse button was pressed just now
-				_scummvm.pushEvent(ScummVMEvents.JE_RMB_DOWN, (int)e.getX(), (int)e.getY(), e.getButtonState(), 0, 0, 0);
-			}
-
-			_rmbPressed = true;
-		} else {
-			if (_rmbPressed) {
-				// right mouse button was released just now
-				_scummvm.pushEvent(ScummVMEvents.JE_RMB_UP, (int)e.getX(), (int)e.getY(), e.getButtonState(), 0, 0, 0);
-			}
-
-			_rmbPressed = false;
-		}
-
-		boolean mmbDown = (buttonState & MotionEvent.BUTTON_TERTIARY) == MotionEvent.BUTTON_TERTIARY;
-		if (mmbDown) {
-			if (!_mmbPressed) {
-				// middle mouse button was pressed just now
-				_scummvm.pushEvent(ScummVMEvents.JE_MMB_DOWN, (int)e.getX(), (int)e.getY(), e.getButtonState(), 0, 0, 0);
-			}
-
-			_mmbPressed = true;
-		} else {
-			if (_mmbPressed) {
-				// middle mouse button was released just now
-				_scummvm.pushEvent(ScummVMEvents.JE_MMB_UP, (int)e.getX(), (int)e.getY(), e.getButtonState(), 0, 0, 0);
-			}
-
-			_mmbPressed = false;
-		}
+		_rmbPressed = handleButton(e, _rmbPressed, MotionEvent.BUTTON_SECONDARY, ScummVMEvents.JE_RMB_DOWN, ScummVMEvents.JE_RMB_UP);
+		_mmbPressed = handleButton(e, _mmbPressed, MotionEvent.BUTTON_TERTIARY, ScummVMEvents.JE_MMB_DOWN, ScummVMEvents.JE_MMB_UP);
+		_bmbPressed = handleButton(e, _bmbPressed, MotionEvent.BUTTON_BACK, ScummVMEvents.JE_BMB_DOWN, ScummVMEvents.JE_BMB_UP);
+		_fmbPressed = handleButton(e, _fmbPressed, MotionEvent.BUTTON_FORWARD, ScummVMEvents.JE_FMB_DOWN, ScummVMEvents.JE_FMB_UP);
+		_srmbPressed = handleButton(e, _srmbPressed, MotionEvent.BUTTON_STYLUS_PRIMARY, ScummVMEvents.JE_RMB_DOWN, ScummVMEvents.JE_RMB_UP);
+		_smmbPressed = handleButton(e, _smmbPressed, MotionEvent.BUTTON_STYLUS_SECONDARY, ScummVMEvents.JE_MMB_DOWN, ScummVMEvents.JE_MMB_UP);
 
 		return true;
 	}

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMEvents.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMEvents.java
@@ -36,6 +36,10 @@ public class ScummVMEvents implements
 	public static final int JE_JOYSTICK = 15;
 	public static final int JE_MMB_DOWN = 16;
 	public static final int JE_MMB_UP = 17;
+	public static final int JE_BMB_DOWN = 18;
+	public static final int JE_BMB_UP = 19;
+	public static final int JE_FMB_DOWN = 20;
+	public static final int JE_FMB_UP = 21;
 	public static final int JE_QUIT = 0x1000;
 
 	final protected Context _context;


### PR DESCRIPTION
With this PR, the Android backend now sends events for the middle, forward and back mouse buttons, as well as the primary and secondary stylus buttons. Unfortunately, on my device at least, Android maps the middle mouse button to opening the home menu, and I can't find any obvious way of working around it. I also wasn't able to test the stylus changes.

This should fix [Trac 11352](https://bugs.scummvm.org/ticket/11352).