### PR TITLE
GUI: added `warningGuiAndConsole`

### DIFF
--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -107,11 +107,13 @@ void TranslationManager::setLanguage(const String &lang) {
 	}
 }
 
-const char *TranslationManager::getTranslation(const char *message) const {
+const char *TranslationManager::getTranslation(const char *message) {
 	return getTranslation(message, nullptr);
 }
 
-const char *TranslationManager::getTranslation(const char *message, const char *context) const {
+const char *TranslationManager::getTranslation(const char *message, const char *context) {
+	_lastOrigMessage = message;
+
 	// If no language is set or message is empty, return msgid as is
 	if (_currentTranslationMessages.empty() || *message == '\0')
 		return message;
@@ -175,11 +177,17 @@ String TranslationManager::getCurrentLanguage() const {
 	return _langs[_currentLang];
 }
 
-String TranslationManager::getTranslation(const String &message) const {
+String TranslationManager::_lastOrigMessage = "";
+
+String TranslationManager::getLastOrigMessage() {
+	return _lastOrigMessage;
+}
+
+String TranslationManager::getTranslation(const String &message) {
 	return getTranslation(message.c_str());
 }
 
-String TranslationManager::getTranslation(const String &message, const String &context) const {
+String TranslationManager::getTranslation(const String &message, const String &context) {
 	return getTranslation(message.c_str(), context.c_str());
 }
 

--- a/common/translation.h
+++ b/common/translation.h
@@ -111,25 +111,14 @@ public:
 	 * message. In case the message isn't found in the translation catalog,
 	 * it returns the original untranslated message.
 	 */
-	const char *getTranslation(const char *message) const;
+	const char *getTranslation(const char *message);
 
 	/**
 	 * Returns the translation into the current language of the parameter
 	 * message. In case the message isn't found in the translation catalog,
 	 * it returns the original untranslated message.
 	 */
-	String getTranslation(const String &message) const;
-
-	/**
-	 * Returns the translation into the current language of the parameter
-	 * message. In case the message isn't found in the translation catalog,
-	 * it returns the original untranslated message.
-	 *
-	 * If a translation is found for the given context it will return that
-	 * translation, otherwise it will look for a translation for the same
-	 * massage without a context or with a different context.
-	 */
-	const char *getTranslation(const char *message, const char *context) const;
+	String getTranslation(const String &message);
 
 	/**
 	 * Returns the translation into the current language of the parameter
@@ -140,7 +129,18 @@ public:
 	 * translation, otherwise it will look for a translation for the same
 	 * massage without a context or with a different context.
 	 */
-	String getTranslation(const String &message, const String &context) const;
+	const char *getTranslation(const char *message, const char *context);
+
+	/**
+	 * Returns the translation into the current language of the parameter
+	 * message. In case the message isn't found in the translation catalog,
+	 * it returns the original untranslated message.
+	 *
+	 * If a translation is found for the given context it will return that
+	 * translation, otherwise it will look for a translation for the same
+	 * massage without a context or with a different context.
+	 */
+	String getTranslation(const String &message, const String &context);
 
 	/**
 	 * Returns a list of supported languages.
@@ -173,6 +173,11 @@ public:
 	 * Returns currently selected translation language
 	 */
 	String getCurrentLanguage() const;
+
+	/**
+	 * Returns the last message that was translated - in its original, untranslated, form
+	 */
+	static String getLastOrigMessage();
 
 private:
 	/**
@@ -225,6 +230,8 @@ private:
 
 	uint32 _charmapStart;
 	uint32 *_charmap;
+
+	static String _lastOrigMessage;
 };
 
 } // End of namespace Common

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -30,7 +30,6 @@
 #include "common/textconsole.h"
 #include "common/translation.h"
 #include "gui/EventRecorder.h"
-#include "gui/gui-manager.h"
 #include "gui/message.h"
 #include "engines/advancedDetector.h"
 #include "engines/obsolete.h"
@@ -134,11 +133,7 @@ bool cleanupPirated(ADDetectedGames &matched) {
 
 		// We ruled out all variants and now have nothing
 		if (matched.empty()) {
-			warning("Illegitimate game copy detected. We provide no support in such cases");
-			if (GUI::GuiManager::hasInstance()) {
-				GUI::MessageDialog dialog(_("Illegitimate game copy detected. We provide no support in such cases"));
-				dialog.runModal();
-			};
+			GUI::warningGuiAndConsole(_("Illegitimate game copy detected. We provide no support in such cases"));
 			return true;
 		}
 	}

--- a/engines/sci/engine/kfile.cpp
+++ b/engines/sci/engine/kfile.cpp
@@ -32,6 +32,7 @@
 #include "common/memstream.h"
 
 #include "gui/saveload.h"
+#include "gui/message.h"
 
 #include "sci/sci.h"
 #include "sci/engine/file.h"
@@ -401,7 +402,7 @@ reg_t kFileIOOpen(EngineState *s, int argc, reg_t *argv) {
 			const int skip = name.firstChar() < '0' || name.firstChar() > '9';
 
 			if (sscanf(name.c_str() + skip, "%i.DTA", &saveNo) != 1) {
-				warning("Could not parse game filename %s", name.c_str());
+				GUI::warningGuiAndConsole(_("Could not parse game filename %s"), name.c_str());
 			}
 
 			saveNo += kSaveIdShift;
@@ -1159,17 +1160,17 @@ reg_t kSaveGame(EngineState *s, int argc, reg_t *argv) {
 
 	out = saveFileMan->openForSaving(filename);
 	if (!out) {
-		warning("Error opening savegame \"%s\" for writing", filename.c_str());
+		GUI::warningGuiAndConsole(_("Error opening savegame \"%s\" for writing"), filename.c_str());
 	} else {
 		if (!gamestate_save(s, out, game_description, version)) {
-			warning("Saving the game failed");
+			GUI::warningGuiAndConsole(_("Saving the game failed"));
 		} else {
 			s->r_acc = TRUE_REG; // save successful
 		}
 
 		out->finalize();
 		if (out->err()) {
-			warning("Writing the savegame failed");
+			GUI::warningGuiAndConsole(_("Writing the savegame failed"));
 			s->r_acc = NULL_REG; // write failure
 		}
 		delete out;
@@ -1399,12 +1400,12 @@ reg_t kSaveGame32(EngineState *s, int argc, reg_t *argv) {
 	Common::OutSaveFile *saveStream = saveFileMan->openForSaving(filename);
 
 	if (saveStream == nullptr) {
-		warning("Error opening savegame \"%s\" for writing", filename.c_str());
+		GUI::warningGuiAndConsole(_("Error opening savegame \"%s\" for writing"), filename.c_str());
 		return NULL_REG;
 	}
 
 	if (!gamestate_save(s, saveStream, saveDescription, gameVersion)) {
-		warning("Saving the game failed");
+		GUI::warningGuiAndConsole(_("Saving the game failed"));
 		saveStream->finalize();
 		delete saveStream;
 		return NULL_REG;
@@ -1412,7 +1413,7 @@ reg_t kSaveGame32(EngineState *s, int argc, reg_t *argv) {
 
 	saveStream->finalize();
 	if (saveStream->err()) {
-		warning("Writing the savegame failed");
+		GUI::warningGuiAndConsole(_("Writing the savegame failed"));
 		delete saveStream;
 		return NULL_REG;
 	}
@@ -1455,7 +1456,7 @@ reg_t kRestoreGame32(EngineState *s, int argc, reg_t *argv) {
 	Common::SeekableReadStream *saveStream = saveFileMan->openForLoading(filename);
 
 	if (saveStream == nullptr) {
-		warning("Savegame #%d not found", saveNo);
+		GUI::warningGuiAndConsole(_("Savegame #%d not found"), saveNo);
 		return NULL_REG;
 	}
 
@@ -1487,17 +1488,17 @@ reg_t kCheckSaveGame32(EngineState *s, int argc, reg_t *argv) {
 	}
 
 	if (save.version < MINIMUM_SCI32_SAVEGAME_VERSION) {
-		warning("Save version %d is below minimum SCI32 savegame version %d", save.version, MINIMUM_SCI32_SAVEGAME_VERSION);
+		GUI::warningGuiAndConsole(_("Save version %d is below minimum SCI32 savegame version %d"), save.version, MINIMUM_SCI32_SAVEGAME_VERSION);
 		return NULL_REG;
 	}
 
 	if (save.version > CURRENT_SAVEGAME_VERSION) {
-		warning("Save version %d is above maximum SCI32 savegame version %d", save.version, CURRENT_SAVEGAME_VERSION);
+		GUI::warningGuiAndConsole(_("Save version %d is above maximum SCI32 savegame version %d"), save.version, CURRENT_SAVEGAME_VERSION);
 		return NULL_REG;
 	}
 
 	if (save.gameVersion != gameVersion) {
-		warning("Save game was created for game version %s, but the current game version is %s", save.gameVersion.c_str(), gameVersion.c_str());
+		GUI::warningGuiAndConsole(_("Save game was created for game version %s, but the current game version is %s"), save.gameVersion.c_str(), gameVersion.c_str());
 		return NULL_REG;
 	}
 
@@ -1506,12 +1507,12 @@ reg_t kCheckSaveGame32(EngineState *s, int argc, reg_t *argv) {
 		assert(script0);
 
 		if (save.script0Size != script0->size()) {
-			warning("Save game was created for a game with a script 0 size of %u, but the current game script 0 size is %u", save.script0Size, script0->size());
+			GUI::warningGuiAndConsole(_("Save game was created for a game with a script 0 size of %u, but the current game script 0 size is %u"), save.script0Size, script0->size());
 			return NULL_REG;
 		}
 
 		if (save.gameObjectOffset != g_sci->getGameObject().getOffset()) {
-			warning("Save game was created for a game with the main game object at offset %u, but the current main game object offset is %u", save.gameObjectOffset, g_sci->getGameObject().getOffset());
+			GUI::warningGuiAndConsole(_("Save game was created for a game with the main game object at offset %u, but the current main game object offset is %u"), save.gameObjectOffset, g_sci->getGameObject().getOffset());
 			return NULL_REG;
 		}
 	}

--- a/gui/message.cpp
+++ b/gui/message.cpp
@@ -22,6 +22,7 @@
 
 #include "common/str.h"
 #include "common/system.h"
+#include "common/translation.h"
 #include "gui/message.h"
 #include "gui/gui-manager.h"
 #include "gui/ThemeEval.h"
@@ -119,6 +120,25 @@ void TimedMessageDialog::handleTickle() {
 	MessageDialog::handleTickle();
 	if (g_system->getMillis() > _timer)
 		close();
+}
+
+void warningGuiAndConsole(const char *s, ...) {
+	Common::String output;
+	va_list va;
+
+	va_start(va, s);
+	output = Common::String::vformat(Common::TranslationManager::getLastOrigMessage().c_str(), va);
+	va_end(va);
+
+	warning(output.c_str());
+
+	if (GuiManager::hasInstance()) {
+		va_start(va, s);
+		output = Common::String::vformat(s, va);
+		va_end(va);
+		MessageDialog dialog(output, "OK");
+		dialog.runModal();
+	};
 }
 
 } // End of namespace GUI

--- a/gui/message.h
+++ b/gui/message.h
@@ -59,6 +59,8 @@ protected:
 	uint32 _timer;
 };
 
+void warningGuiAndConsole(const char *s, ...);
+
 } // End of namespace GUI
 
 #endif


### PR DESCRIPTION
Add `warningGuiAndConsole` function to send warnings with
regular `warning` and to GUI - if available.

Used for example in SCI failures to save/load games, which used only
console `warning`s - and it's not clear enough to users.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
