### PR TITLE
DIRECTOR: Adds debug option to automate tests.

### DIFF
--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -56,6 +56,7 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	DebugMan.addDebugChannel(kDebugFast, "fast", "Fast (no delay) playback");
 	DebugMan.addDebugChannel(kDebugNoLoop, "noloop", "Do not loop the playback");
 	DebugMan.addDebugChannel(kDebugBytecode, "bytecode", "Execute Lscr bytecode");
+	DebugMan.addDebugChannel(kDebugFewFramesOnly, "fewframesonly", "Only run the first 10 frames");
 
 	g_director = this;
 

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -71,7 +71,8 @@ enum {
 	kDebugSlow				= 1 << 8,
 	kDebugFast				= 1 << 9,
 	kDebugNoLoop			= 1 << 10,
-	kDebugBytecode			= 1 << 11
+	kDebugBytecode			= 1 << 11,
+	kDebugFewFramesOnly		= 1 << 12
 };
 
 struct MovieReference {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -104,6 +104,9 @@ Score::Score(DirectorEngine *vm) {
 	_loadedCast = nullptr;
 
 	_numChannelsDisplayed = 0;
+
+	_framesRan = 0; // used by kDebugFewFramesOnly
+
 }
 
 void Score::setArchive(Archive *archive) {
@@ -1555,6 +1558,11 @@ void Score::startLoop() {
 
 		if (_currentFrame < _frames.size())
 			_vm->processEvents();
+
+		if (debugChannelSet(-1, kDebugFewFramesOnly) && _framesRan > 9) {
+			warning("Score::startLoop(): exiting due to debug few frames only");
+			break;
+		}
 	}
 
 	_lingo->processEvent(kEventStopMovie);
@@ -1672,6 +1680,9 @@ void Score::update() {
 
 	if (debugChannelSet(-1, kDebugFast))
 		_nextFrameTime = g_system->getMillis();
+
+	if (debugChannelSet(-1, kDebugFewFramesOnly))
+		_framesRan++;
 }
 
 Sprite *Score::getSpriteById(uint16 id) {

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -165,6 +165,7 @@ private:
 	uint16 _castArrayStart;
 	uint16 _currentFrame;
 	uint16 _nextFrame;
+	uint16 _framesRan; // used by kDebugFewFramesOnly
 	int _currentLabel;
 	uint32 _flags;
 	uint16 _castArrayEnd;


### PR DESCRIPTION
The debugflag fewframesonly exits the program after running 10 frames.
This is used when running a large amount of Director programs in an
automated fashion. The example script below saves the output for further
inspection.

CAVEAT: A score is ran for 10 frames. The counter is reset if it is
switched before that.

An example script in fishshell:
```
  for movie in (cat list_of_files_to_check.txt)
      ./scummvm --debugflags=runfirstframes -p DIRECTORY/ --start-movie=$movie workshop > output/$movie.txt 2>&1
      if test $status -eq 0
        echo $movie >> output/passed.txt
      else
        echo $movie >> output/failed.txt
      end
    end
```