### PR TITLE
SCI: MIDI - don't send "controller 75" to physical device

### DIFF
--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -308,6 +308,7 @@ void MidiPlayer_Midi::noteOn(int channel, int note, int velocity) {
 
 void MidiPlayer_Midi::controlChange(int channel, int control, int value) {
 	assert(channel <= 15);
+	bool standard_midi_controller = true;
 
 	switch (control) {
 	case 0x07:
@@ -340,6 +341,8 @@ void MidiPlayer_Midi::controlChange(int channel, int control, int value) {
 		_channels[channel].hold = value;
 		break;
 	case 0x4b:	// voice mapping
+		// this is an internal Sierra command, and shouldn't be sent to the real MIDI driver - fixing #11409
+		standard_midi_controller = false;
 		break;
 	case 0x4e:	// velocity
 		break;
@@ -349,7 +352,8 @@ void MidiPlayer_Midi::controlChange(int channel, int control, int value) {
 		break;
 	}
 
-	_driver->send(0xb0 | channel, control, value);
+	if (standard_midi_controller)
+		_driver->send(0xb0 | channel, control, value);
 }
 
 void MidiPlayer_Midi::setPatch(int channel, int patch) {


### PR DESCRIPTION
Sierra used MIDI controller 75 for internal purposes, and it shouldn't
be issued to the real MIDI device.
This fixes issue #11409


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
