### PR TITLE
GUI: Sort games list ignoring articles

### DIFF
--- a/common/str.cpp
+++ b/common/str.cpp
@@ -1299,6 +1299,8 @@ const char *scumm_skipArticle(const char *s1) {
 		o1 = 4;
 	else if (!scumm_strnicmp(s1, "a ", 2))
 		o1 = 2;
+	else if (!scumm_strnicmp(s1, "an ", 3))
+		o1 = 3;
 
 	return &s1[o1];
 }

--- a/common/str.cpp
+++ b/common/str.cpp
@@ -895,6 +895,15 @@ int String::compareToIgnoreCase(const char *x) const {
 	return scumm_stricmp(c_str(), x);
 }
 
+int String::compareDictionary(const String &x) const {
+	return compareDictionary(x.c_str());
+}
+
+int String::compareDictionary(const char *x) const {
+	assert(x != nullptr);
+	return scumm_compareDictionary(c_str(), x);
+}
+
 #pragma mark -
 
 String operator+(const String &x, const String &y) {
@@ -1282,6 +1291,20 @@ int scumm_strnicmp(const char *s1, const char *s2, uint n) {
 		l2 = tolower(l2);
 	} while (l1 == l2 && l1 != 0);
 	return l1 - l2;
+}
+
+const char *scumm_skipArticle(const char *s1) {
+	int o1 = 0;
+	if (!scumm_strnicmp(s1, "the ", 4))
+		o1 = 4;
+	else if (!scumm_strnicmp(s1, "a ", 2))
+		o1 = 2;
+
+	return &s1[o1];
+}
+
+int scumm_compareDictionary(const char *s1, const char *s2) {
+	return scumm_stricmp(scumm_skipArticle(s1), scumm_skipArticle(s2));
 }
 
 //  Portable implementation of strdup.

--- a/common/str.h
+++ b/common/str.h
@@ -156,6 +156,8 @@ public:
 	bool equalsIgnoreCase(const char *x) const;
 	int compareTo(const char *x) const;             // strcmp clone
 	int compareToIgnoreCase(const char *x) const;   // stricmp clone
+	int compareDictionary(const String &x) const;
+	int compareDictionary(const char *x) const;
 
 	bool hasSuffix(const String &x) const;
 	bool hasSuffix(const char *x) const;
@@ -340,7 +342,7 @@ public:
 	size_t findLastOf(const String &chars, size_t pos = npos) const {
 		return findLastOf(chars.c_str(), pos);
 	}
- 
+
 	/** Find first character in the string that's not the specified character */
 	size_t findFirstNotOf(char c, size_t pos = 0) const;
 
@@ -562,5 +564,8 @@ String toPrintable(const String &src, bool keepNewLines = true);
 extern int scumm_stricmp(const char *s1, const char *s2);
 extern int scumm_strnicmp(const char *s1, const char *s2, uint n);
 extern char *scumm_strdup(const char *in);
+
+extern int scumm_compareDictionary(const char *s1, const char *s2);
+extern const char *scumm_skipArticle(const char *s1);
 
 #endif

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -190,6 +190,7 @@ void LauncherDialog::build() {
 	// Add list with game titles
 	_list = new ListWidget(this, "Launcher.GameList", nullptr, kListSearchCmd);
 	_list->setEditable(false);
+	_list->enableDictionarySelect(true);
 	_list->setNumberingMode(kListNumberingOff);
 
 	// Populate the list
@@ -292,7 +293,7 @@ void LauncherDialog::updateListing() {
 			// Insert the game into the launcher list
 			int pos = 0, size = l.size();
 
-			while (pos < size && (scumm_stricmp(description.c_str(), l[pos].c_str()) > 0))
+			while (pos < size && (scumm_compareDictionary(description.c_str(), l[pos].c_str()) > 0))
 				pos++;
 
 			color = ThemeEngine::kFontColorNormal;

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -59,6 +59,7 @@ ListWidget::ListWidget(Dialog *boss, const String &name, const char *tooltip, ui
 
 	_quickSelect = true;
 	_editColor = ThemeEngine::kFontColorNormal;
+	_dictionarySelect = false;
 
 	_lastRead = -1;
 }
@@ -89,6 +90,7 @@ ListWidget::ListWidget(Dialog *boss, int x, int y, int w, int h, const char *too
 
 	_quickSelect = true;
 	_editColor = ThemeEngine::kFontColorNormal;
+	_dictionarySelect = false;
 
 	_lastRead = -1;
 }
@@ -296,8 +298,12 @@ int ListWidget::findItem(int x, int y) const {
 		return -1;
 }
 
-static int matchingCharsIgnoringCase(const char *x, const char *y, bool &stop) {
+static int matchingCharsIgnoringCase(const char *x, const char *y, bool &stop, bool dictionary) {
 	int match = 0;
+	if (dictionary) {
+		x = scumm_skipArticle(x);
+		y = scumm_skipArticle(y);
+	}
 	while (*x && *y && tolower(*x) == tolower(*y)) {
 		++x;
 		++y;
@@ -333,7 +339,7 @@ bool ListWidget::handleKeyDown(Common::KeyState state) {
 			int bestMatch = 0;
 			bool stop;
 			for (StringArray::const_iterator i = _list.begin(); i != _list.end(); ++i) {
-				const int match = matchingCharsIgnoringCase(i->c_str(), _quickSelectStr.c_str(), stop);
+				const int match = matchingCharsIgnoringCase(i->c_str(), _quickSelectStr.c_str(), stop, _dictionarySelect);
 				if (match > bestMatch || stop) {
 					_selectedItem = newSelectedItem;
 					bestMatch = match;

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -79,6 +79,7 @@ protected:
 
 	String			_filter;
 	bool			_quickSelect;
+	bool			_dictionarySelect;
 
 	uint32			_cmd;
 
@@ -112,6 +113,8 @@ public:
 
 	void enableQuickSelect(bool enable) 		{ _quickSelect = enable; }
 	String getQuickSelectString() const 		{ return _quickSelectStr; }
+
+	void enableDictionarySelect(bool enable)	{ _dictionarySelect = enable; }
 
 	bool isEditable() const						{ return _editable; }
 	void setEditable(bool editable)				{ _editable = editable; }


### PR DESCRIPTION
This PR introduces dictionary sort to the list of games.

Thus, 'The Dig' is inserted between 'Deja Vu' and 'Discworld'.

Quick search by typing also works properly.
