### PR TITLE
CREATE_PROJECT: Use relative paths for static libraries for Xcode

### DIFF
--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -408,7 +408,7 @@ void XcodeProvider::setupCopyFilesBuildPhase() {
 #define DEF_LOCALLIB_STATIC_PATH(path,lib,absolute) properties[lib".a"] = FileProperty("archive.ar", lib ".a", path, (absolute ? "\"<absolute>\"" : "\"<group>\"")); \
 	ADD_SETTING_ORDER_NOVALUE(children, getHash(lib".a"), lib".a", fwOrder++);
 
-#define DEF_LOCALLIB_STATIC(lib) DEF_LOCALLIB_STATIC_PATH("/usr/local/lib/" lib ".a", lib, true)
+#define DEF_LOCALLIB_STATIC(lib) DEF_LOCALLIB_STATIC_PATH(lib ".a", lib, false)
 
 
 /**


### PR DESCRIPTION
With the project including both iOS and macOS targets, using an absolute path ensures it is incorrect for at least one of those. Since it was using /usr/local/lib/ all the paths had to be changed in Xcode to build the iOS target.

Also as the paths where we expect the libraries to be (/usr/local/lib on macOS and lib under the build directory for iOS) are added to the search path in the Xcode project, we do not actually need to use absolute path). Also this make it easier to use a different path for libraries (e.g. if using MacPort or brew) as we only need to change the search path setting in the Xcode project and not the path for each library).

This was tested on two different machines, one with Xcode 9.2 and one with Xcode 11.4, and on both I was able to build for both iOS and macOS without any change to the generated Xcode project.

However as I am not familiar with create_project, and don't usually use it to build for macOS, I would appreciate somebody to review this. Was there any reason to use absolute paths? Is there something I am overlooking?