### PR TITLE
DIRECTOR: LINGO: Implement last* functions

### DIFF
--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -126,7 +126,7 @@ public:
 	// events.cpp
 	void processEvents();
 	void setDraggedSprite(uint16 id);
-  uint32 getMacTicks();
+	uint32 getMacTicks();
 	void waitForClick();
 
 public:

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -126,6 +126,7 @@ public:
 	// events.cpp
 	void processEvents();
 	void setDraggedSprite(uint16 id);
+  uint32 getMacTicks();
 	void waitForClick();
 
 public:

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -50,6 +50,8 @@ bool processQuitEvent(bool click) {
 	return false;
 }
 
+uint32 DirectorEngine::getMacTicks() { return g_system->getMillis() * 60 / 1000.; }
+
 void DirectorEngine::processEvents() {
 	Common::Event event;
 

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -129,6 +129,7 @@ void DirectorEngine::processEvents() {
 					debugC(1, kDebugEvents, "processEvents(): keycode: %d", _keyCode);
 				}
 
+        sc->_lastKeyTime = g_director->getMacTicks();
 				_lingo->processEvent(kEventKeyDown);
 				break;
 

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -77,10 +77,10 @@ void DirectorEngine::processEvents() {
 				sc->_stopPlay = true;
 				break;
 
-      case Common::EVENT_MOUSEMOVE:
-        sc->_lastEventTime = g_director->getMacTicks();
-        sc->_lastRollTime =  sc->_lastEventTime;
-        break;
+			case Common::EVENT_MOUSEMOVE:
+				sc->_lastEventTime = g_director->getMacTicks();
+				sc->_lastRollTime =	 sc->_lastEventTime;
+				break;
 
 			case Common::EVENT_LBUTTONDOWN:
 				pos = g_system->getEventManager()->getMousePos();
@@ -91,8 +91,8 @@ void DirectorEngine::processEvents() {
 				sc->_currentMouseDownSpriteId = spriteId;
 
 				sc->_mouseIsDown = true;
-        sc->_lastEventTime = g_director->getMacTicks();
-        sc->_lastClickTime = sc->_lastEventTime;
+				sc->_lastEventTime = g_director->getMacTicks();
+				sc->_lastClickTime = sc->_lastEventTime;
 
 				debugC(3, kDebugEvents, "event: Button Down @(%d, %d), sprite id: %d", pos.x, pos.y, spriteId);
 				_lingo->processEvent(kEventMouseDown);
@@ -136,8 +136,8 @@ void DirectorEngine::processEvents() {
 					debugC(1, kDebugEvents, "processEvents(): keycode: %d", _keyCode);
 				}
 
-        sc->_lastEventTime = g_director->getMacTicks();
-        sc->_lastKeyTime = sc->_lastEventTime;
+				sc->_lastEventTime = g_director->getMacTicks();
+				sc->_lastKeyTime = sc->_lastEventTime;
 				_lingo->processEvent(kEventKeyDown);
 				break;
 

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -79,6 +79,7 @@ void DirectorEngine::processEvents() {
 
       case Common::EVENT_MOUSEMOVE:
         sc->_lastEventTime = g_director->getMacTicks();
+        sc->_lastRollTime =  sc->_lastEventTime;
         break;
 
 			case Common::EVENT_LBUTTONDOWN:

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -77,6 +77,10 @@ void DirectorEngine::processEvents() {
 				sc->_stopPlay = true;
 				break;
 
+      case Common::EVENT_MOUSEMOVE:
+        sc->_lastEventTime = g_director->getMacTicks();
+        break;
+
 			case Common::EVENT_LBUTTONDOWN:
 				pos = g_system->getEventManager()->getMousePos();
 
@@ -86,7 +90,8 @@ void DirectorEngine::processEvents() {
 				sc->_currentMouseDownSpriteId = spriteId;
 
 				sc->_mouseIsDown = true;
-        sc->_lastClickTime = g_director->getMacTicks();
+        sc->_lastEventTime = g_director->getMacTicks();
+        sc->_lastClickTime = sc->_lastEventTime;
 
 				debugC(3, kDebugEvents, "event: Button Down @(%d, %d), sprite id: %d", pos.x, pos.y, spriteId);
 				_lingo->processEvent(kEventMouseDown);
@@ -130,7 +135,8 @@ void DirectorEngine::processEvents() {
 					debugC(1, kDebugEvents, "processEvents(): keycode: %d", _keyCode);
 				}
 
-        sc->_lastKeyTime = g_director->getMacTicks();
+        sc->_lastEventTime = g_director->getMacTicks();
+        sc->_lastKeyTime = sc->_lastEventTime;
 				_lingo->processEvent(kEventKeyDown);
 				break;
 

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -86,6 +86,7 @@ void DirectorEngine::processEvents() {
 				sc->_currentMouseDownSpriteId = spriteId;
 
 				sc->_mouseIsDown = true;
+        sc->_lastClickTime = g_director->getMacTicks();
 
 				debugC(3, kDebugEvents, "event: Button Down @(%d, %d), sprite id: %d", pos.x, pos.y, spriteId);
 				_lingo->processEvent(kEventMouseDown);

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -430,6 +430,10 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
     d.type = INT;
     d.u.i = _vm->getCurrentScore()->_frames.size() - 1;
 		break;
+  case kTheLastClick:
+    d.type = INT;
+    d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastClickTime;
+    break;
   case kTheLastKey:
     d.type = INT;
     d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastKeyTime;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -425,7 +425,11 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 	case kTheStillDown:
 		d.type = INT;
 		d.u.i = _vm->getCurrentScore()->_mouseIsDown;
-		break;
+    break;
+  case kTheLastFrame:
+    d.type = INT;
+    d.u.i = _vm->getCurrentScore()->_frames.size() - 1;
+    break;
 	default:
 		warning("Lingo::getTheEntity(): Unprocessed getting field \"%s\" of entity %s", field2str(field), entity2str(entity));
 		d.type = VOID;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -442,6 +442,10 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
     d.type = INT;
     d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastKeyTime;
     break;
+  case kTheLastRoll:
+    d.type = INT;
+    d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastRollTime;
+    break;
 	default:
 		warning("Lingo::getTheEntity(): Unprocessed getting field \"%s\" of entity %s", field2str(field), entity2str(entity));
 		d.type = VOID;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -429,6 +429,10 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
   case kTheLastFrame:
     d.type = INT;
     d.u.i = _vm->getCurrentScore()->_frames.size() - 1;
+		break;
+  case kTheLastKey:
+    d.type = INT;
+    d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastKeyTime;
     break;
 	default:
 		warning("Lingo::getTheEntity(): Unprocessed getting field \"%s\" of entity %s", field2str(field), entity2str(entity));

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -430,6 +430,10 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
     d.type = INT;
     d.u.i = _vm->getCurrentScore()->_frames.size() - 1;
 		break;
+  case kTheLastEvent:
+    d.type = INT;
+    d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastEventTime;
+    break;
   case kTheLastClick:
     d.type = INT;
     d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastClickTime;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -426,26 +426,26 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d.type = INT;
 		d.u.i = _vm->getCurrentScore()->_mouseIsDown;
     break;
-  case kTheLastFrame:
-    d.type = INT;
-    d.u.i = _vm->getCurrentScore()->_frames.size() - 1;
+	case kTheLastFrame:
+		d.type = INT;
+		d.u.i = _vm->getCurrentScore()->_frames.size() - 1;
 		break;
-  case kTheLastEvent:
-    d.type = INT;
-    d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastEventTime;
-    break;
-  case kTheLastClick:
-    d.type = INT;
-    d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastClickTime;
-    break;
-  case kTheLastKey:
-    d.type = INT;
-    d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastKeyTime;
-    break;
-  case kTheLastRoll:
-    d.type = INT;
-    d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastRollTime;
-    break;
+	case kTheLastEvent:
+		d.type = INT;
+		d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastEventTime;
+		break;
+	case kTheLastClick:
+		d.type = INT;
+		d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastClickTime;
+		break;
+	case kTheLastKey:
+		d.type = INT;
+		d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastKeyTime;
+		break;
+	case kTheLastRoll:
+		d.type = INT;
+		d.u.i = _vm->getMacTicks() - _vm->getCurrentScore()->_lastRollTime;
+		break;
 	default:
 		warning("Lingo::getTheEntity(): Unprocessed getting field \"%s\" of entity %s", field2str(field), entity2str(entity));
 		d.type = VOID;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -77,6 +77,7 @@ Score::Score(DirectorEngine *vm) {
 	_currentMouseDownSpriteId = 0;
 	_mouseIsDown = false;
   _lastKeyTime = _vm->getMacTicks();
+  _lastClickTime = _vm->getMacTicks();
 
 	// FIXME: TODO: Check whether the original truely does it
 	if (_vm->getVersion() <= 3) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -76,10 +76,10 @@ Score::Score(DirectorEngine *vm) {
 	_soundManager = _vm->getSoundManager();
 	_currentMouseDownSpriteId = 0;
 	_mouseIsDown = false;
-  _lastEventTime = _vm->getMacTicks();
-  _lastKeyTime = _lastEventTime;
-  _lastClickTime = _lastEventTime;
-  _lastRollTime = _lastEventTime;
+	_lastEventTime = _vm->getMacTicks();
+	_lastKeyTime = _lastEventTime;
+	_lastClickTime = _lastEventTime;
+	_lastRollTime = _lastEventTime;
 
 	// FIXME: TODO: Check whether the original truely does it
 	if (_vm->getVersion() <= 3) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -79,6 +79,7 @@ Score::Score(DirectorEngine *vm) {
   _lastEventTime = _vm->getMacTicks();
   _lastKeyTime = _lastEventTime;
   _lastClickTime = _lastEventTime;
+  _lastRollTime = _lastEventTime;
 
 	// FIXME: TODO: Check whether the original truely does it
 	if (_vm->getVersion() <= 3) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -76,6 +76,7 @@ Score::Score(DirectorEngine *vm) {
 	_soundManager = _vm->getSoundManager();
 	_currentMouseDownSpriteId = 0;
 	_mouseIsDown = false;
+  _lastKeyTime = _vm->getMacTicks();
 
 	// FIXME: TODO: Check whether the original truely does it
 	if (_vm->getVersion() <= 3) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -76,8 +76,9 @@ Score::Score(DirectorEngine *vm) {
 	_soundManager = _vm->getSoundManager();
 	_currentMouseDownSpriteId = 0;
 	_mouseIsDown = false;
-  _lastKeyTime = _vm->getMacTicks();
-  _lastClickTime = _vm->getMacTicks();
+  _lastEventTime = _vm->getMacTicks();
+  _lastKeyTime = _lastEventTime;
+  _lastClickTime = _lastEventTime;
 
 	// FIXME: TODO: Check whether the original truely does it
 	if (_vm->getVersion() <= 3) {

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -141,6 +141,7 @@ public:
 	Common::Rect _movieRect;
 	uint16 _currentMouseDownSpriteId;
 	bool _mouseIsDown;
+  uint32 _lastEventTime;
   uint32 _lastClickTime;
   uint32 _lastKeyTime;
 

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -141,6 +141,7 @@ public:
 	Common::Rect _movieRect;
 	uint16 _currentMouseDownSpriteId;
 	bool _mouseIsDown;
+  uint32 _lastKeyTime;
 
 	bool _stopPlay;
 	uint32 _nextFrameTime;

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -141,6 +141,7 @@ public:
 	Common::Rect _movieRect;
 	uint16 _currentMouseDownSpriteId;
 	bool _mouseIsDown;
+  uint32 _lastClickTime;
   uint32 _lastKeyTime;
 
 	bool _stopPlay;

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -142,6 +142,7 @@ public:
 	uint16 _currentMouseDownSpriteId;
 	bool _mouseIsDown;
   uint32 _lastEventTime;
+  uint32 _lastRollTime;
   uint32 _lastClickTime;
   uint32 _lastKeyTime;
 

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -141,10 +141,10 @@ public:
 	Common::Rect _movieRect;
 	uint16 _currentMouseDownSpriteId;
 	bool _mouseIsDown;
-  uint32 _lastEventTime;
-  uint32 _lastRollTime;
-  uint32 _lastClickTime;
-  uint32 _lastKeyTime;
+	uint32 _lastEventTime;
+	uint32 _lastRollTime;
+	uint32 _lastClickTime;
+	uint32 _lastKeyTime;
 
 	bool _stopPlay;
 	uint32 _nextFrameTime;


### PR DESCRIPTION
This pull request implements tick-based timekeeping, and uses 
it to implement time-dependent `last`* Lingo functions 
(lastKey, lastClick, lastEvent, lastRoll). lastFrame is also implemented.

The respective movies from the Lingo Workshop dictionary now run properly.

The Lingo function `last` is a bit different and is not implemented in this PR.