### PR TITLE
SDL: Add --logfile command line argument to specify logfile path

### DIFF
--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -150,16 +150,6 @@ void OSystem_SDL::init() {
 	// Disable OS cursor
 	SDL_ShowCursor(SDL_DISABLE);
 
-	if (!_logger)
-		_logger = new Backends::Log::Log(this);
-
-	if (_logger) {
-		Common::WriteStream *logFile = createLogFile();
-		if (logFile)
-			_logger->open(logFile);
-	}
-
-
 	// Creates the early needed managers, if they don't exist yet
 	// (we check for this to allow subclasses to provide their own).
 	if (_mutexManager == 0)
@@ -188,6 +178,15 @@ bool OSystem_SDL::hasFeature(Feature f) {
 void OSystem_SDL::initBackend() {
 	// Check if backend has not been initialized
 	assert(!_inited);
+
+	if (!_logger)
+		_logger = new Backends::Log::Log(this);
+
+	if (_logger) {
+		Common::WriteStream *logFile = createLogFile();
+		if (logFile)
+			_logger->open(logFile);
+	}
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	const char *sdlDriverName = SDL_GetCurrentVideoDriver();
@@ -435,7 +434,11 @@ Common::WriteStream *OSystem_SDL::createLogFile() {
 	// of a failure, we know that no log file is open.
 	_logFilePath.clear();
 
-	Common::String logFile = getDefaultLogFileName();
+	Common::String logFile;
+	if (ConfMan.hasKey("logfile"))
+		logFile = ConfMan.get("logfile");
+	else
+		logFile = getDefaultLogFileName();
 	if (logFile.empty())
 		return nullptr;
 

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -87,6 +87,9 @@ static const char HELP_STRING[] =
 #endif
 	"\n"
 	"  -c, --config=CONFIG      Use alternate configuration file\n"
+#if defined(SDL_BACKEND)
+	"  -l, --logfile=PATH       Use alternate path for log file\n"
+#endif
 	"  -p, --path=PATH          Path to where the game is installed\n"
 	"  -x, --save-slot[=NUM]    Save game slot to load (default: autosave)\n"
 	"  -f, --fullscreen         Force full-screen mode\n"
@@ -543,6 +546,11 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 
 			DO_OPTION('c', "config")
 			END_OPTION
+
+#if defined(SDL_BACKEND)
+			DO_OPTION('l', "logfile")
+			END_OPTION
+#endif
 
 			DO_OPTION_INT('b', "boot-param")
 			END_OPTION


### PR DESCRIPTION
This adds a `-l PATH` or `--logfile=PATH` command line argument to specify a custom log file. Since log files are overwritten with each launch, this could help get a more persistent one when we want to (this remove the need to copy the default one after closing ScummVM, and this also removes the need to know where the default one is ;-) ).

This may also be useful to get a more portable application as mentioned in [bug #11412](https://bugs.scummvm.org/ticket/11412).

This only works with the SDL-based  backends.

Note that for this to work I had to delay a bit the creation of the log file. It is now done in the initBackend() function instead of `OSystem_SDL::init()`. This means for example that using a command line command such as `--detect` no longer overwrites the log file (since ScummVM returns before it is created), and that any logged message during the command line processing phase will only appear in stdout/stderr and will no longer be logged to the log file. In my opinion this is not necessarily a bad thing, but maybe others have a different opinion?