### PR TITLE
DIRECTOR: LINGO: Implement moveableSprite of sprite

### DIFF
--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -128,6 +128,7 @@ public:
 	// events.cpp
 	void processEvents();
 	void setDraggedSprite(uint16 id);
+	void releaseDraggedSprite();
 	uint32 getMacTicks();
 	void waitForClick();
 

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -80,6 +80,19 @@ void DirectorEngine::processEvents() {
 			case Common::EVENT_MOUSEMOVE:
 				sc->_lastEventTime = g_director->getMacTicks();
 				sc->_lastRollTime =	 sc->_lastEventTime;
+
+				if (_draggingSprite) {
+					Sprite* draggedSprite = currentFrame->_sprites[_draggingSpriteId];
+					if (draggedSprite->_moveable) {
+						pos = g_system->getEventManager()->getMousePos();
+						Common::Point delta = pos - _draggingSpritePos;
+						draggedSprite->_currentPoint.x += delta.x;
+						draggedSprite->_currentPoint.y += delta.y;
+						_draggingSpritePos = pos;
+					} else {
+						releaseDraggedSprite();
+					}
+				}
 				break;
 
 			case Common::EVENT_LBUTTONDOWN:
@@ -97,9 +110,9 @@ void DirectorEngine::processEvents() {
 				debugC(3, kDebugEvents, "event: Button Down @(%d, %d), sprite id: %d", pos.x, pos.y, spriteId);
 				_lingo->processEvent(kEventMouseDown);
 
-				if (currentFrame->_sprites[spriteId]->_moveable) {
-					warning("Moveable");
-				}
+				if (currentFrame->_sprites[spriteId]->_moveable)
+					g_director->setDraggedSprite(spriteId);
+
 				break;
 
 			case Common::EVENT_LBUTTONUP:
@@ -110,6 +123,7 @@ void DirectorEngine::processEvents() {
 				debugC(3, kDebugEvents, "event: Button Up @(%d, %d), sprite id: %d", pos.x, pos.y, spriteId);
 
 				sc->_mouseIsDown = false;
+				releaseDraggedSprite();
 
 				_lingo->processEvent(kEventMouseUp);
 				sc->_currentMouseDownSpriteId = 0;
@@ -158,8 +172,11 @@ void DirectorEngine::setDraggedSprite(uint16 id) {
 	_draggingSprite = true;
 	_draggingSpriteId = id;
 	_draggingSpritePos = g_system->getEventManager()->getMousePos();
+}
 
-	warning("STUB: DirectorEngine::setDraggedSprite(%d)", id);
+void DirectorEngine::releaseDraggedSprite() {
+	_draggingSprite = false;
+	_draggingSpriteId = 0;
 }
 
 void DirectorEngine::waitForClick() {

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -293,6 +293,8 @@ void Frame::readChannels(Common::ReadStreamEndian *stream) {
 			sprite._startPoint.y = stream->readUint16();
 			sprite._startPoint.x = stream->readUint16();
 
+			sprite._currentPoint = sprite._startPoint;
+
 			sprite._height = stream->readUint16();
 			sprite._width = stream->readUint16();
 
@@ -701,10 +703,10 @@ void Frame::renderShape(Graphics::ManagedSurface &surface, uint16 spriteId) {
 	// for outlined shapes, line thickness of 1 means invisible.
 	lineSize -= 1;
 
-	Common::Rect shapeRect = Common::Rect(sp->_startPoint.x,
-		sp->_startPoint.y,
-		sp->_startPoint.x + sp->_width,
-		sp->_startPoint.y + sp->_height);
+	Common::Rect shapeRect = Common::Rect(sp->_currentPoint.x,
+		sp->_currentPoint.y,
+		sp->_currentPoint.x + sp->_width,
+		sp->_currentPoint.y + sp->_height);
 
 	Graphics::ManagedSurface tmpSurface;
 	tmpSurface.create(shapeRect.width(), shapeRect.height(), Graphics::PixelFormat::createFormatCLUT8());
@@ -794,8 +796,8 @@ void Frame::renderButton(Graphics::ManagedSurface &surface, uint16 spriteId) {
 	uint32 rectLeft = button->_initialRect.left;
 	uint32 rectTop = button->_initialRect.top;
 
-	int x = _sprites[spriteId]->_startPoint.x;
-	int y = _sprites[spriteId]->_startPoint.y;
+	int x = _sprites[spriteId]->_currentPoint.x;
+	int y = _sprites[spriteId]->_currentPoint.y;
 
 	if (_vm->getVersion() > 3) {
 		x += rectLeft;
@@ -857,8 +859,8 @@ void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Commo
 	Score *score = _vm->getCurrentScore();
 	Sprite *sprite = _sprites[spriteId];
 
-	int x = sprite->_startPoint.x; // +rectLeft;
-	int y = sprite->_startPoint.y; // +rectTop;
+	int x = sprite->_currentPoint.x; // +rectLeft;
+	int y = sprite->_currentPoint.y; // +rectTop;
 	int height = textCast->_initialRect.height(); //_sprites[spriteId]->_height;
 	int width;
 
@@ -1048,8 +1050,8 @@ void Frame::renderBitmap(Graphics::ManagedSurface &surface, uint16 spriteId) {
 	int32 rectLeft = bc->_initialRect.left;
 	int32 rectTop = bc->_initialRect.top;
 
-	int x = sprite->_startPoint.x - regX + rectLeft;
-	int y = sprite->_startPoint.y - regY + rectTop;
+	int x = sprite->_currentPoint.x - regX + rectLeft;
+	int y = sprite->_currentPoint.y - regY + rectTop;
 	int height = sprite->_height;
 	int width = _vm->getVersion() > 4 ? bc->_initialRect.width() : sprite->_width;
 	Common::Rect drawRect(x, y, x + width, y + height);

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1445,10 +1445,7 @@ void LB::b_move(int nargs) {
 void LB::b_moveableSprite(int nargs) {
 	Frame *frame = g_director->getCurrentScore()->_frames[g_director->getCurrentScore()->getCurrentFrame()];
 
-	// Will have no effect
 	frame->_sprites[g_lingo->_currentEntityId]->_moveable = true;
-
-	g_director->setDraggedSprite(frame->_sprites[g_lingo->_currentEntityId]->_castId);
 }
 
 void LB::b_pasteClipBoardInto(int nargs) {

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -677,6 +677,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 		break;
 	case kTheMoveableSprite:
 		sprite->_moveable = d.u.i;
+    if (!d.u.i)
+      sprite->_currentPoint = sprite->_startPoint;
 		break;
 	case kTheMovieRate:
 		sprite->_movieRate = d.u.i;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -550,10 +550,10 @@ Datum Lingo::getTheSprite(Datum &id1, int field) {
 		d.u.i = sprite->_thickness & 0x3;
 		break;
 	case kTheLocH:
-		d.u.i = sprite->_startPoint.x;
+		d.u.i = sprite->_currentPoint.x;
 		break;
 	case kTheLocV:
-		d.u.i = sprite->_startPoint.y;
+		d.u.i = sprite->_currentPoint.y;
 		break;
 	case kTheMoveableSprite:
 		d.u.i = sprite->_moveable;
@@ -670,10 +670,10 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 		sprite->_thickness = d.u.i;
 		break;
 	case kTheLocH:
-		sprite->_startPoint.x = d.u.i;
+		sprite->_currentPoint.x = d.u.i;
 		break;
 	case kTheLocV:
-		sprite->_startPoint.y = d.u.i;
+		sprite->_currentPoint.y = d.u.i;
 		break;
 	case kTheMoveableSprite:
 		sprite->_moveable = d.u.i;

--- a/engines/director/sprite.h
+++ b/engines/director/sprite.h
@@ -83,6 +83,7 @@ public:
 
 	byte _thickness;
 	Common::Point _startPoint;
+	Common::Point _currentPoint;
 	uint16 _width;
 	uint16 _height;
 	// TODO: default constraint = 0, if turned on, sprite is constrainted to the bounding rect


### PR DESCRIPTION
This pull request implements the `moveableSprite of sprite`
property. We must thus track sprite positions based upon their 
current point and not just their start point.