### PR TITLE
MACOS: Changing default macOS savegame location

### DIFF
--- a/backends/saves/posix/posix-saves.cpp
+++ b/backends/saves/posix/posix-saves.cpp
@@ -48,7 +48,7 @@ POSIXSaveFileManager::POSIXSaveFileManager() {
 	const char *home = getenv("HOME");
 	if (home && *home && strlen(home) < MAXPATHLEN) {
 		savePath = home;
-		savePath += "/Documents/ScummVM Savegames";
+		savePath += "/Library/Application Support/ScummVM/Savegames";
 
 		ConfMan.registerDefault("savepath", savePath);
 	}


### PR DESCRIPTION
Addresses [#11427](https://bugs.scummvm.org/ticket/11427) by preventing future installations from accessing Documents (which the user can deny access to), but doesn't warn users if their existing installation still points to this folder and access isn't granted.

My understanding is that existing users will still be pointing to `~/Documents/ScummVM Savegames`, and so ScummVM will prompt them for access to the Documents folder.