### PR TITLE
SDL: Move detection of the desktop resolution into the SdlWindow class

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -32,7 +32,7 @@
 #include "common/translation.h"
 #endif
 
-OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(uint desktopWidth, uint desktopHeight, SdlEventSource *eventSource, SdlWindow *window)
+OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(SdlEventSource *eventSource, SdlWindow *window)
     : SdlGraphicsManager(eventSource, window), _lastRequestedHeight(0),
 #if SDL_VERSION_ATLEAST(2, 0, 0)
       _glContext(),
@@ -175,10 +175,12 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(uint desktopWidth, uint deskt
 		}
 	}
 
+	Common::Rect desktopRes = _window->getDesktopResolution();
+
 	// In case SDL is fine with every mode we will force the desktop mode.
 	// TODO? We could also try to add some default resolutions here.
-	if (_fullscreenVideoModes.empty() && desktopWidth && desktopHeight) {
-		_fullscreenVideoModes.push_back(VideoMode(desktopWidth, desktopHeight));
+	if (_fullscreenVideoModes.empty() && !desktopRes.isEmpty()) {
+		_fullscreenVideoModes.push_back(VideoMode(desktopRes.width(), desktopRes.height()));
 	}
 
 	// Get information about display sizes from the previous runs.
@@ -187,8 +189,8 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(uint desktopWidth, uint deskt
 		_desiredFullscreenHeight = ConfMan.getInt("last_fullscreen_mode_height", Common::ConfigManager::kApplicationDomain);
 	} else {
 		// Use the desktop resolutions when no previous default has been setup.
-		_desiredFullscreenWidth  = desktopWidth;
-		_desiredFullscreenHeight = desktopHeight;
+		_desiredFullscreenWidth  = desktopRes.width();
+		_desiredFullscreenHeight = desktopRes.height();
 	}
 }
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -32,7 +32,7 @@
 
 class OpenGLSdlGraphicsManager : public OpenGL::OpenGLGraphicsManager, public SdlGraphicsManager {
 public:
-	OpenGLSdlGraphicsManager(uint desktopWidth, uint desktopHeight, SdlEventSource *eventSource, SdlWindow *window);
+	OpenGLSdlGraphicsManager(SdlEventSource *eventSource, SdlWindow *window);
 	virtual ~OpenGLSdlGraphicsManager();
 
 	// GraphicsManager API

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -38,6 +38,15 @@ SdlWindow::SdlWindow()
 	_lastFlags(0), _lastX(SDL_WINDOWPOS_UNDEFINED), _lastY(SDL_WINDOWPOS_UNDEFINED)
 #endif
 	{
+
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+	// Query the desktop resolution. We simply hope nothing tried to change
+	// the resolution so far.
+	const SDL_VideoInfo *videoInfo = SDL_GetVideoInfo();
+	if (videoInfo && videoInfo->current_w > 0 && videoInfo->current_h > 0) {
+		_desktopRes = Common::Rect(videoInfo->current_w, videoInfo->current_h);
+	}
+#endif
 }
 
 SdlWindow::~SdlWindow() {
@@ -191,6 +200,19 @@ bool SdlWindow::getSDLWMInformation(SDL_SysWMinfo *info) const {
 	return SDL_GetWMInfo(info);
 #endif
 }
+
+Common::Rect SdlWindow::getDesktopResolution() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	int displayIndex = _window ? SDL_GetWindowDisplayIndex(_window) : 0;
+	SDL_DisplayMode displayMode;
+	if (!SDL_GetDesktopDisplayMode(displayIndex, &displayMode)) {
+		_desktopRes = Common::Rect(displayMode.w, displayMode.h);
+	}
+#endif
+
+	return _desktopRes;
+}
+
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 SDL_Surface *copySDLSurface(SDL_Surface *src) {

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -25,6 +25,7 @@
 
 #include "backends/platform/sdl/sdl-sys.h"
 
+#include "common/rect.h"
 #include "common/str.h"
 
 class SdlWindow {
@@ -76,6 +77,11 @@ public:
 	 */
 	bool getSDLWMInformation(SDL_SysWMinfo *info) const;
 
+	/*
+	 * Retrieve the current desktop resolution.
+	 */
+	Common::Rect getDesktopResolution();
+
 	bool mouseIsGrabbed() const {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		if (_window) {
@@ -87,6 +93,8 @@ public:
 
 private:
 	bool _inputGrabState;
+
+	Common::Rect _desktopRes;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 public:

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -69,8 +69,6 @@
 OSystem_SDL::OSystem_SDL()
 	:
 #ifdef USE_OPENGL
-	_desktopWidth(0),
-	_desktopHeight(0),
 	_graphicsModes(),
 	_graphicsMode(0),
 	_firstGLMode(0),
@@ -214,25 +212,6 @@ void OSystem_SDL::initBackend() {
 		_eventManager = new DefaultEventManager(_eventSourceWrapper ? _eventSourceWrapper : _eventSource);
 	}
 
-
-#ifdef USE_OPENGL
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	SDL_DisplayMode displayMode;
-	if (!SDL_GetDesktopDisplayMode(0, &displayMode)) {
-		_desktopWidth  = displayMode.w;
-		_desktopHeight = displayMode.h;
-	}
-#else
-	// Query the desktop resolution. We simply hope nothing tried to change
-	// the resolution so far.
-	const SDL_VideoInfo *videoInfo = SDL_GetVideoInfo();
-	if (videoInfo && videoInfo->current_w > 0 && videoInfo->current_h > 0) {
-		_desktopWidth  = videoInfo->current_w;
-		_desktopHeight = videoInfo->current_h;
-	}
-#endif
-#endif
-
 	if (_graphicsManager == 0) {
 #ifdef USE_OPENGL
 		// Setup a list with both SDL and OpenGL graphics modes. We only do
@@ -248,7 +227,7 @@ void OSystem_SDL::initBackend() {
 			Common::String gfxMode(ConfMan.get("gfx_mode"));
 			for (uint i = _firstGLMode; i < _graphicsModeIds.size(); ++i) {
 				if (!scumm_stricmp(_graphicsModes[i].name, gfxMode.c_str())) {
-					_graphicsManager = new OpenGLSdlGraphicsManager(_desktopWidth, _desktopHeight, _eventSource, _window);
+					_graphicsManager = new OpenGLSdlGraphicsManager(_eventSource, _window);
 					_graphicsMode = i;
 					break;
 				}
@@ -655,7 +634,7 @@ bool OSystem_SDL::setGraphicsMode(int mode) {
 		debug(1, "switching to OpenGL graphics");
 		sdlGraphicsManager->deactivateManager();
 		delete _graphicsManager;
-		_graphicsManager = sdlGraphicsManager = new OpenGLSdlGraphicsManager(_desktopWidth, _desktopHeight, _eventSource, _window);
+		_graphicsManager = sdlGraphicsManager = new OpenGLSdlGraphicsManager(_eventSource, _window);
 
 		switchedManager = true;
 	}
@@ -719,7 +698,7 @@ void OSystem_SDL::setupGraphicsModes() {
 	assert(_defaultSDLMode != -1);
 
 	_firstGLMode = _graphicsModes.size();
-	manager = new OpenGLSdlGraphicsManager(_desktopWidth, _desktopHeight, _eventSource, _window);
+	manager = new OpenGLSdlGraphicsManager(_eventSource, _window);
 	srcMode = manager->getSupportedGraphicsModes();
 	defaultMode = manager->getDefaultGraphicsMode();
 	while (srcMode->name) {

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -142,8 +142,6 @@ protected:
 	Backends::Log::Log *_logger;
 
 #ifdef USE_OPENGL
-	int _desktopWidth, _desktopHeight;
-
 	typedef Common::Array<GraphicsMode> GraphicsModeArray;
 	GraphicsModeArray _graphicsModes;
 	Common::Array<int> _graphicsModeIds;


### PR DESCRIPTION
This PR unifies the code for detecting the desktop resolution across both ScummVM and ResidualVM, which previously handled it slightly differently. It's also needed by residualvm/residualvm#1624.