### PR TITLE
BASE: Move CoreMIDI to end of list to speed up finding the right device

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -116,7 +116,6 @@ public:
 		#endif
 		#if defined(MACOSX)
 		LINK_PLUGIN(COREAUDIO)
-		LINK_PLUGIN(COREMIDI)
 		#endif
 		#ifdef USE_FLUIDSYNTH
 		LINK_PLUGIN(FLUIDSYNTH)
@@ -140,6 +139,11 @@ public:
 		LINK_PLUGIN(PC98)
 		#if defined(USE_TIMIDITY)
 		LINK_PLUGIN(TIMIDITY)
+		#endif
+		#if defined(MACOSX)
+		// Keep this at the end of the list - it takes a long time to enumerate
+		// and is only for hardware midi devices
+		LINK_PLUGIN(COREMIDI)
 		#endif
 
 		return pl;


### PR DESCRIPTION
Doing this as a pull request as I wanted to get a sanity check on it as an idea.

CoreMIDI provides hardware midi device support.

On my MacBook, the first call to MIDIGetNumberOfDestinations() takes around 2
seconds.  Using one of the midi devices lower on the plugin list (mt32,
fluidsynth, etc) takes 2 extra seconds on every game start as
MidiDriver::getDeviceHandle() enumerates all the plugins to find the right one, 
and hits CoreMIDI first.

This change simply moves CoreMIDI to the bottom of the list.  It will still
take 2 extra seconds when opening the options box, but that's a rare operation
relative to starting games.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
