### PR TITLE
MACOSX: Remove NSRequiresAquaSystemAppearance from Info.plist

### DIFF
--- a/dists/macosx/Info.plist
+++ b/dists/macosx/Info.plist
@@ -72,8 +72,6 @@
 	<string>faYfM+DGPgJCrRzpxSHoFD0rzHa6ZnnEXuzz2E7ZRUk=</string>
 	<key>NSDockTilePlugIn</key>
 	<string>scummvm.docktileplugin</string>
-	<key>NSRequiresAquaSystemAppearance</key>
-	<false/>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>ScummVM saves and loads savegames in the Documents folder by default.</string>
 	<key>SUPublicDSAKeyFile</key>

--- a/dists/macosx/Info.plist.in
+++ b/dists/macosx/Info.plist.in
@@ -72,8 +72,6 @@
 	<string>faYfM+DGPgJCrRzpxSHoFD0rzHa6ZnnEXuzz2E7ZRUk=</string>
 	<key>NSDockTilePlugIn</key>
 	<string>scummvm.docktileplugin</string>
-	<key>NSRequiresAquaSystemAppearance</key>
-	<false/>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>ScummVM saves and loads savegames in the Documents folder by default.</string>
 	<key>SUPublicDSAKeyFile</key>


### PR DESCRIPTION
Bug #11430.

Enabling Dark Mode compatibility on macOS, either by using `NSRequiresAquaSystemAppearance` on older SDKs, or by building with 10.14+ SDKs, makes the display blurry on Retina screens on Mojave (and probably Catalina).

This happens in OpenGL or SDL2 mode, filtered or not, with any rendering mode, etc.

This is possibly a macOS bug in OpenGL:

  https://bugzilla.libsdl.org/show_bug.cgi?id=5087
  https://communities.vmware.com/thread/618831
  https://code.videolan.org/videolan/VLCKit/issues/82#note_30971
  https://openradar.appspot.com/45895864 

This has been reported to Apple, but I don't think it's going to be fixed soon. SDL2 developers are hesitant about adding even more NSOpenGLView workarounds.

The only workaround that looks OK today is:

* to continue building official ScumMVM on older macOS releases (possibly any pre-10.14 SDK)
* and to stop providing any `NSRequiresAquaSystemAppearance` content in Info.plist.

So, revert commit 485e8bee17230ed8e17a27eaf148a3330f305a6f for now.

Missing Dark mode for now is probably less important that having incorrect output. It looks like VLC still doesn't enable Dark mode for the same reason.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
