### PR TITLE
Add kFeatureNoQuit in System to remove the Quit buttons from the GUI

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -95,6 +95,10 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 	event = _eventQueue.pop();
 	bool forwardEvent = true;
 
+	// If the backend has the kFeatureNoQuit, replace Quit event with RTL
+	if (event.type == Common::EVENT_QUIT && g_system->hasFeature(OSystem::kFeatureNoQuit))
+		event.type = Common::EVENT_RTL;
+
 	switch (event.type) {
 	case Common::EVENT_KEYDOWN:
 		_modifierState = event.kbd.flags;

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -174,6 +174,7 @@ bool OSystem_iOS7::hasFeature(Feature f) {
 	case kFeatureVirtualKeyboard:
 	case kFeatureClipboardSupport:
 	case kFeatureOpenUrl:
+	case kFeatureNoQuit:
 		return true;
 
 	default:

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -352,22 +352,6 @@ void OSystem_iOS7::addSysArchivesToSearchSet(Common::SearchSet &s, int priority)
 	}
 }
 
-void OSystem_iOS7::logMessage(LogMessageType::Type type, const char *message) {
-	FILE *output = 0;
-
-	if (type == LogMessageType::kInfo || type == LogMessageType::kDebug)
-		output = stdout;
-	else
-		output = stderr;
-
-	if (type == LogMessageType::kError) {
-		_lastErrorMessage = message;
-	}
-
-	fputs(message, output);
-	fflush(output);
-}
-
 bool iOS7_touchpadModeEnabled() {
 	OSystem_iOS7 *sys = (OSystem_iOS7 *) g_system;
 	return sys && sys->touchpadModeEnabled();

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -415,7 +415,4 @@ void iOS7_main(int argc, char **argv) {
 		//*stderr = NULL;
 		fclose(newfp);
 	}
-
-	// prevents hanging on exit
-	exit(0);
 }

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -61,6 +61,24 @@ void OSystem_iOS7::fatalError() {
 	}
 }
 
+void OSystem_iOS7::logMessage(LogMessageType::Type type, const char *message) {
+	FILE *output = 0;
+
+	if (type == LogMessageType::kInfo || type == LogMessageType::kDebug)
+		output = stdout;
+	else
+		output = stderr;
+
+	if (type == LogMessageType::kError) {
+		_lastErrorMessage = message;
+		NSString *messageString = [NSString stringWithUTF8String:message];
+		NSLog(@"%@", messageString);
+	}
+
+	fputs(message, output);
+	fflush(output);
+}
+
 void OSystem_iOS7::engineInit() {
 	EventsBaseBackend::engineInit();
 	// Prevent the device going to sleep during game play (and in particular cut scenes)

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -36,7 +36,7 @@
 
 - (void)alertView:(UIAlertView *)alertView willDismissWithButtonIndex:(NSInteger)buttonIndex {
 	OSystem_iOS7::sharedInstance()->quit();
-	exit(1);
+	abort();
 }
 
 @end

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -36,19 +36,21 @@ static long g_lastTick = 0;
 static int g_frames = 0;
 #endif
 
+void printError(const char *error_message) {
+	NSString *messageString = [NSString stringWithUTF8String:error_message];
+	NSLog(@"%@", messageString);
+	fprintf(stderr, "%s\n", error_message);
+}
+
 #define printOpenGLError() printOglError(__FILE__, __LINE__)
 
-int printOglError(const char *file, int line) {
-	int retCode = 0;
-
-	// returns 1 if an OpenGL error occurred, 0 otherwise.
+void printOglError(const char *file, int line) {
 	GLenum glErr = glGetError();
 	while (glErr != GL_NO_ERROR) {
-		fprintf(stderr, "glError: %u (%s: %d)\n", glErr, file, line);
-		retCode = 1;
+		Common::String error = Common::String::format("glError: %u (%s: %d)", glErr, file, line);
+		printError(error.c_str());
 		glErr = glGetError();
 	}
-	return retCode;
 }
 
 bool iOS7_isBigDevice() {
@@ -118,8 +120,8 @@ uint getSizeNextPOT(uint size) {
 
 	// In case creating the OpenGL ES context failed, we will error out here.
 	if (_context == nil) {
-		fprintf(stderr, "Could not create OpenGL ES context\n");
-		exit(-1);
+		printError("Could not create OpenGL ES context.");
+		abort();
 	}
 
 	if ([EAGLContext setCurrentContext:_context]) {
@@ -255,9 +257,8 @@ uint getSizeNextPOT(uint size) {
 	if (compileSuccess == GL_FALSE) {
 		GLchar messages[256];
 		glGetShaderInfoLog(shaderHandle, sizeof(messages), 0, &messages[0]);
-		NSString *messageString = [NSString stringWithUTF8String:messages];
-		NSLog(@"%@", messageString);
-		exit(1);
+		printError(messages);
+		abort();
 	}
 
 	return shaderHandle;
@@ -303,7 +304,7 @@ uint getSizeNextPOT(uint size) {
 	glGetProgramiv(programHandle, GL_LINK_STATUS, &linkSuccess);
 	if (linkSuccess == GL_FALSE) {
 		printOpenGLError();
-		exit(1);
+		abort();
 	}
 
 	glUseProgram(programHandle);

--- a/common/system.h
+++ b/common/system.h
@@ -418,7 +418,12 @@ public:
 		* Supports for using the native system file browser dialog
 		* through the DialogManager.
 		*/
-		kFeatureSystemBrowserDialog
+		kFeatureSystemBrowserDialog,
+
+		/**
+		* For platforms that should not have a Quit button
+		*/
+		kFeatureNoQuit
 
 	};
 

--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -95,8 +95,8 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 		_rtlButton = new GUI::ButtonWidget(this, "GlobalMenu.RTL", _c("~R~eturn to Launcher", "lowres"), 0, kRTLCmd);
 	_rtlButton->setEnabled(_engine->hasFeature(Engine::kSupportsRTL));
 
-
-	new GUI::ButtonWidget(this, "GlobalMenu.Quit", _("~Q~uit"), 0, kQuitCmd);
+	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
+		new GUI::ButtonWidget(this, "GlobalMenu.Quit", _("~Q~uit"), 0, kQuitCmd);
 
 	_aboutDialog = new GUI::AboutDialog();
 	_loadDialog = new GUI::SaveLoadChooser(_("Load game:"), _("Load"), false);

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -136,8 +136,8 @@ void LauncherDialog::build() {
 	// Show ScummVM version
 	new StaticTextWidget(this, "Launcher.Version", gScummVMFullVersion);
 #endif
-
-	new ButtonWidget(this, "Launcher.QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
+	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
+		new ButtonWidget(this, "Launcher.QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
 	new ButtonWidget(this, "Launcher.AboutButton", _("A~b~out..."), _("About ScummVM"), kAboutCmd);
 	new ButtonWidget(this, "Launcher.OptionsButton", _("~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
 	_startButton =


### PR DESCRIPTION
I am creating this Pull Request mostly for a review on the first commit (commit 27a4ad0) since it touches common code.

The main idea is that for various reasons on some platform we do not want to allow quitting the application programatically, for example through the use of a Quit button. One such platform is iOS. The first commit in this pull request does the following:
- It adds a kFeatureNoQuit in OSystem.
- If this feature is supported by a backend
  - it removes the Quit button from the launcher
  - it removes the Quit button from the GMM
  - it remaps EVENT_QUIT to EVENT_RTL in the event manager.

The rest of the commits are specific to the iOS backend to use this feature and further remove all use of exit() as well as cleanup the error reporting.