### PR TITLE
ULTIMA4: Enable keymapper actions to optionally trigger on kbd repeats

### DIFF
--- a/backends/keymapper/action.h
+++ b/backends/keymapper/action.h
@@ -115,6 +115,14 @@ public:
 	}
 
 	/**
+	 * Allows an action bound to a keyboard event to be repeatedly
+	 * triggered by key repeats
+	 */
+	void allowKbdReapets() {
+		event.kbdRepeat = true;
+	}
+
+	/**
 	 * Add a default input mapping for the action
 	 *
 	 * Unknown hardware inputs will be silently ignored.

--- a/backends/keymapper/keymapper.cpp
+++ b/backends/keymapper/keymapper.cpp
@@ -186,10 +186,10 @@ List<Event> Keymapper::mapEvent(const Event &ev) {
 		}
 	}
 
-	// Ignore keyboard repeat events. Repeat event are meant for text input,
-	// the keymapper / keymaps are supposed to be disabled during text input.
-	// TODO: Add a way to keep repeat events if needed.
-	if (!mappedEvents.empty() && ev.type == EVENT_KEYDOWN && ev.kbdRepeat) {
+	// Ignore keyboard repeat events unless the action explicitly allows it.
+	// This is a convenience to prevent actions getting triggered multiple times
+	if (!mappedEvents.empty() && ev.type == EVENT_KEYDOWN && ev.kbdRepeat
+			&& !mappedEvents.front().kbdRepeat) {
 		return List<Event>();
 	}
 

--- a/engines/ultima/ultima4/meta_engine.cpp
+++ b/engines/ultima/ultima4/meta_engine.cpp
@@ -155,6 +155,11 @@ Common::KeymapArray MetaEngine::initKeymaps() {
 			act->addDefaultInputMapping(r->_key);
 			if (r->_joy)
 				act->addDefaultInputMapping(r->_joy);
+			if (r->_action == KEYBIND_UP || r->_action == KEYBIND_DOWN ||
+					r->_action == KEYBIND_LEFT || r->_action == KEYBIND_RIGHT)
+				// Allow movement actions to be triggered on keyboard repeats
+				act->allowKbdReapets();
+
 			keyMap->addAction(act);
 		}
 	}


### PR DESCRIPTION
This is a minor change to the keymapper to optionally allow actions to specify that they can be triggered by keyboard repeats, to allow the arrow keys in Ultima IV to repeatedly trigger movement whilst they're held down. Unless the method is called by engines for any actions when they set up their keymapper, the existing behaviour still happens, and keyboard reports won't trigger actions. Since it touches the core keymapper, I thought I'd get opinion on it from anyone familiar with the keymapper rather than simply committing it in master.
