### PR TITLE
ULTIMA8: Fix compiler warnings

### DIFF
--- a/engines/ultima/ultima8/filesys/idata_source.h
+++ b/engines/ultima/ultima8/filesys/idata_source.h
@@ -95,8 +95,8 @@ public:
 		return _in->read(b, len);
 	}
 
-	bool seek(int32 pos, int whence = SEEK_SET) override {
-		return _in->seek(pos, whence);
+	bool seek(int32 position, int whence = SEEK_SET) override {
+		return _in->seek(position, whence);
 	}
 
 	int32 size() const override {

--- a/engines/ultima/ultima8/filesys/idata_source.h
+++ b/engines/ultima/ultima8/filesys/idata_source.h
@@ -162,12 +162,12 @@ public:
 		return count;
 	}
 
-	bool seek(int32 pos, int whence = SEEK_SET) override {
+	bool seek(int32 position, int whence = SEEK_SET) override {
 		assert(whence == SEEK_SET || whence == SEEK_CUR);
 		if (whence == SEEK_CUR) {
-			_bufPtr += pos;
+			_bufPtr += position;
 		} else if (whence == SEEK_SET) {
-			_bufPtr = _buf + pos;
+			_bufPtr = _buf + position;
 		}
 		return true;
 	}

--- a/engines/ultima/ultima8/filesys/odata_source.h
+++ b/engines/ultima/ultima8/filesys/odata_source.h
@@ -120,10 +120,10 @@ public:
 		return len;
 	};
 
-	bool seek(int32 pos, int whence = SEEK_SET) override {
+	bool seek(int32 position, int whence = SEEK_SET) override {
 		assert(whence == SEEK_SET);
 		// No seeking past the end of the buffer
-		if (pos <= static_cast<int32>(_size)) _loc = pos;
+		if (position <= static_cast<int32>(_size)) _loc = position;
 		else _loc = _size;
 
 		_bufPtr = const_cast<unsigned char *>(_buf) + _loc;

--- a/engines/ultima/ultima8/filesys/odata_source.h
+++ b/engines/ultima/ultima8/filesys/odata_source.h
@@ -79,7 +79,7 @@ protected:
 		// Reallocate the buffer
 		if (_loc > _allocated) {
 			// The old pointer position
-			uint32 pos = static_cast<uint32>(_bufPtr - _buf);
+			uint32 position = static_cast<uint32>(_bufPtr - _buf);
 
 			// The new buffer and size (2 times what is needed)
 			_allocated = _loc * 2;
@@ -89,7 +89,7 @@ protected:
 			delete [] _buf;
 
 			_buf = new_buf;
-			_bufPtr = _buf + pos;
+			_bufPtr = _buf + position;
 		}
 
 		// Update size

--- a/engines/ultima/ultima8/filesys/odata_source.h
+++ b/engines/ultima/ultima8/filesys/odata_source.h
@@ -130,15 +130,15 @@ public:
 		return true;
 	};
 
-	void skip(int32 pos) override {
+	void skip(int32 position) override {
 		// No seeking past the end
-		if (pos >= 0) {
-			_loc += pos;
+		if (position >= 0) {
+			_loc += position;
 			if (_loc > _size) _loc = _size;
 		}
 		// No seeking past the start
 		else {
-			uint32 invpos = -pos;
+			uint32 invpos = -position;
 			if (invpos > _loc) invpos = _loc;
 			_loc -= invpos;
 		}


### PR DESCRIPTION
These commits fix compiler warnings that come from headers.
They are all about shadowing a member variable.
Since these headers are included in many other files, the warnings are reduced by about 600 lines.