### PR TITLE
NUVIE: Fix compiler warnings

### DIFF
--- a/engines/ultima/nuvie/core/converse.h
+++ b/engines/ultima/nuvie/core/converse.h
@@ -239,8 +239,8 @@ public:
 	converse_value read(uint32 advance = 1);
 	converse_value read2();
 	converse_value read4();
-	converse_value peek(uint32 skip = 0) {
-		return ((converse_value) * (buf_pt + skip));
+	converse_value peek(uint32 displacement = 0) {
+		return ((converse_value) * (buf_pt + displacement));
 	}
 
 	/* Writing */

--- a/engines/ultima/nuvie/core/timed_event.h
+++ b/engines/ultima/nuvie/core/timed_event.h
@@ -122,9 +122,9 @@ public:
 class TimedMessage : public TimedEvent {
 	Std::string msg;
 public:
-	TimedMessage(uint32 reltime, const char *m, bool repeat = false)
+	TimedMessage(uint32 reltime, const char *m, bool repeating = false)
 		: TimedEvent(reltime), msg(m) {
-		repeat_count = repeat ? -1 : 0;
+		repeat_count = repeating ? -1 : 0;
 	}
 	void timed(uint32 evtime) override {
 		DEBUG(0, LEVEL_NOTIFICATION, "Activate! evtime=%d msg=\"%s\"\n", evtime, msg.c_str());


### PR DESCRIPTION
These commits remove compiler warnings about variable shadowing that come from headers.
As the headers are included in many other files, the warnings are reduced by about 200 lines.