### PR TITLE
DIRECTOR: LINGO: Ignore diacritics in = operator

### DIFF
--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -31,6 +31,7 @@
 #include "director/frame.h"
 #include "director/score.h"
 #include "director/sprite.h"
+#include "director/util.h"
 
 namespace Director {
 
@@ -601,7 +602,9 @@ int Datum::compareTo(Datum d) {
 
 int Datum::compareToIgnoreCase(Datum d) {
 	if (type == STRING && d.type == STRING) {
-		return u.s->compareToIgnoreCase(*d.u.s);
+		Common::String *s1 = toLowercaseMac(u.s);
+		Common::String *s2 = toLowercaseMac(d.u.s);
+		return s1->compareTo(*s2);
 	}
 	return compareTo(d);
 }

--- a/engines/director/lingo/tests/strings.lingo
+++ b/engines/director/lingo/tests/strings.lingo
@@ -11,6 +11,11 @@ if z1 contains "MeÍW" then
 else
 	put "Doesn't contain"
 end if
+if "meow" = "MeÍW" then
+	put "Equals"
+else
+	put "Doesn't equal"
+end if
 
 put "That is the last line of the file." & return & "Click Done to exit." && return && "foo"
 


### PR DESCRIPTION
Fixes the comparison of strings with diacritics