### PR TITLE
DC: Fix broken physical audio CD playback

### DIFF
--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -60,13 +60,14 @@ class DCCDManager : public DefaultAudioCDManager {
 public:
 	// Poll cdrom status
 	// Returns true if cd audio is playing
-	bool isPlaying() const;
+	bool isPlaying() const override;
 
 	// Play cdrom audio track
-	bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false);
+	bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false,
+		Audio::Mixer::SoundType soundType) override;
 
 	// Stop cdrom audio track
-	void stop();
+	void stop() override;
 };
 
 class OSystem_Dreamcast : private DCHardware, public EventsBaseBackend, public PaletteManager, public FilesystemFactory

--- a/backends/platform/dc/dcmain.cpp
+++ b/backends/platform/dc/dcmain.cpp
@@ -90,8 +90,11 @@ static bool find_track(int track, int &first_sec, int &last_sec)
   return false;
 }
 
-bool DCCDManager::play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate) {
-	DefaultAudioCDManager::play(track, numLoops, startFrame, duration, onlyEmulate);
+bool DCCDManager::play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate,
+		Audio::Mixer::SoundType soundType) {
+	// Prefer emulation
+	if (DefaultAudioCDManager::play(track, numLoops, startFrame, duration, onlyEmulate, soundType))
+		return true;
 
 	// If we're playing now return here
 	if (isPlaying()) {


### PR DESCRIPTION
Commit f5238c6 added the `soundType` argument to the `play()` function, which resulted in `DCCDManager` having a different signature for `play()` compared to the base class. A similar fix was made for Linux, Mac OS X and SDL 1.2 in commit de886a8.

As an aside, it might be a good idea to move `DCCDManager` into `backends/audiocd` alongside the Audio CD managers for other platforms, to reduce the possibility of issues like this happening in the future.

This has not been tested.