### PR TITLE
GUI: Added (partial) BiDi support

### DIFF
--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -36,6 +36,10 @@
 
 #ifdef USE_TRANSLATION
 
+#ifdef USE_FRIBIDI
+#include <fribidi/fribidi.h>
+#endif
+
 namespace Common {
 
 DECLARE_SINGLETON(TranslationManager);
@@ -449,6 +453,68 @@ bool TranslationManager::checkHeader(File &in) {
 
 	return true;
 }
+
+String TranslationManager::convertBiDiString(const String &input) {
+	if (getCurrentLanguage() != "he")		//TODO: modify when we'll support other RTL languages, such as Arabic and Farsi
+		return input;
+
+	if (getCurrentCharset() != "iso-8859-8") {
+		warning("convertBiDiString: Unexpected charset is used with %s language: %s", getCurrentLanguage().c_str(), getCurrentCharset().c_str());
+		return input;
+	};
+
+	return TranslationManager::convertBiDiString(input, HE_ISR);
+}
+
+#ifdef USE_FRIBIDI
+String TranslationManager::convertBiDiString(const String &input, const Common::Language lang) {
+	if (lang != HE_ISR)		//TODO: modify when we'll support other RTL languages, such as Arabic and Farsi
+		return input;
+
+	int buff_length = (input.size() + 2) * 2;		// it's more than enough, but it's better to be on the safe side
+	FriBidiChar *input_unicode = (FriBidiChar *)malloc(buff_length * sizeof(FriBidiChar));
+	FriBidiChar *visual_str = (FriBidiChar *)malloc(buff_length * sizeof(FriBidiChar));
+	char *output = (char *)malloc(buff_length);
+
+	FriBidiCharType pbase_dir = FRIBIDI_TYPE_ON;
+	FriBidiCharSet char_set = FRIBIDI_CHAR_SET_ISO8859_8;
+
+	FriBidiStrIndex length = fribidi_charset_to_unicode(char_set, input.c_str(), input.size(), input_unicode);
+
+	if (!fribidi_log2vis(
+		/* input */
+		input_unicode,
+		length,
+		&pbase_dir,
+		/* output */
+		visual_str,
+		NULL,			// position_L_to_V_list,
+		NULL,			// position_V_to_L_list,
+		NULL			// embedding_level_list
+	)) {
+		warning("convertBiDiString: calling fribidi_log2vis failed");
+		free(input_unicode);
+		free(visual_str);
+		free(output);
+		return input;
+	}
+
+	fribidi_unicode_to_charset(char_set, visual_str, length, output);
+
+	String result = String(output);
+	free(input_unicode);
+	free(visual_str);
+	free(output);
+
+	return result;
+}
+#else
+String TranslationManager::convertBiDiString(const String &input, const Common::Language lang) {
+	return input;
+}
+#endif
+
+
 
 } // End of namespace Common
 

--- a/common/translation.h
+++ b/common/translation.h
@@ -28,6 +28,7 @@
 #include "common/str.h"
 #include "common/singleton.h"
 #include "common/str-array.h"
+#include "common/language.h"
 
 #ifdef USE_TRANSLATION
 
@@ -173,6 +174,14 @@ public:
 	 * Returns currently selected translation language
 	 */
 	String getCurrentLanguage() const;
+
+	/*
+	 * Wrapper for GNU FriBidi implementation of the Unicode Bidirectional Algorithm
+	 * For LTR (Left To Right) languages, returns the original input
+	 * For RTL (Right To Left) languages, returns visual representation of a logical single-line input
+	 */
+	String convertBiDiString(const String &input);
+	String convertBiDiString(const String &input, const Common::Language lang);
 
 private:
 	/**

--- a/configure
+++ b/configure
@@ -168,6 +168,7 @@ _dialogs=auto
 _iconv=auto
 _tts=auto
 _gtk=auto
+_fribidi=auto
 # Default option behavior yes/no
 _debug_build=auto
 _release_build=auto
@@ -258,6 +259,7 @@ add_feature theoradec "libtheoradec" "_theoradec"
 add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
 add_feature lua "lua" "_lua"
+add_feature fribidi "FriBidi" "_fribidi"
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,
@@ -1076,6 +1078,9 @@ Optional Libraries:
   --with-mad-prefix=DIR    prefix where libmad is installed (optional)
   --disable-mad            disable libmad (MP3) support [autodetect]
 
+  --with-fribidi-prefix=DIR    prefix where libfribidi is installed
+  --disable-fribidi            disable libfribidi support [autodetect]
+
   --with-flac-prefix=DIR   prefix where libFLAC is installed (optional)
   --disable-flac           disable FLAC support [autodetect]
 
@@ -1233,6 +1238,8 @@ for ac_option in $@; do
 	--disable-flac)               _flac=no               ;;
 	--enable-mad)                 _mad=yes               ;;
 	--disable-mad)                _mad=no                ;;
+	--enable-fribidi)             _fribidi=yes           ;;
+	--disable-fribidi)            _fribidi=no            ;;
 	--enable-zlib)                _zlib=yes              ;;
 	--disable-zlib)               _zlib=no               ;;
 	--enable-sparkle)             _sparkle=yes           ;;
@@ -1354,6 +1361,11 @@ for ac_option in $@; do
 		arg=`echo $ac_option | cut -d '=' -f 2`
 		MAD_CFLAGS="-I$arg/include"
 		MAD_LIBS="-L$arg/lib"
+		;;
+	--with-fribidi-prefix=*)
+		arg=`echo $ac_option | cut -d '=' -f 2`
+		FRIBIDI_CFLAGS="-I$arg/include"
+		FRIBIDI_LIBS="-L$arg/lib"
 		;;
 	--with-jpeg-prefix=*)
 		arg=`echo $ac_option | cut -d '=' -f 2`
@@ -5495,6 +5507,26 @@ if test "$_pandoc" = yes ; then
 fi
 
 define_in_config_if_yes $_pandoc 'USE_PANDOC'
+
+#
+# Check for FriBidi
+#
+echocheck "FriBidi"
+if test "$_fribidi" = auto ; then
+	_fribidi=no
+	cat > $TMPC << EOF
+#include <fribidi/fribidi.h>
+int main(void) { return 0; }
+EOF
+	cc_check $FRIBIDI_CFLAGS $FRIBIDI_LIBS -lfribidi && _fribidi=yes
+fi
+if test "$_fribidi" = yes ; then
+	append_var LIBS "$FRIBIDI_LIBS -lfribidi"
+	append_var INCLUDES "$FRIBIDI_CFLAGS"
+fi
+define_in_config_if_yes "$_fribidi" 'USE_FRIBIDI'
+echo "$_fribidi"
+
 
 # Default to plain text output for pandoc
 if test -z "$_pandocformat" -o "$_pandocformat" = "default"; then

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -919,7 +919,11 @@ void ThemeEngine::drawDDText(TextData type, TextColor color, const Common::Rect 
 		restoreBackground(dirty);
 
 	_vectorRenderer->setFgColor(_textColors[color]->r, _textColors[color]->g, _textColors[color]->b);
+#ifdef USE_TRANSLATION
+	_vectorRenderer->drawString(_texts[type]->_fontPtr, TransMan.convertBiDiString(text), area, alignH, alignV, deltax, ellipsis, dirty);
+#else
 	_vectorRenderer->drawString(_texts[type]->_fontPtr, text, area, alignH, alignV, deltax, ellipsis, dirty);
+#endif
 
 	addDirtyRect(dirty);
 }

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,6 +39,7 @@ parts:
       - libfreetype6-dev
       - zlib1g-dev
       - libunity-dev
+      - libfribidi-dev
     stage-packages:
       - libicu55
       - libasound2

--- a/snapcraft.yaml.in
+++ b/snapcraft.yaml.in
@@ -39,6 +39,7 @@ parts:
       - libfreetype6-dev
       - zlib1g-dev
       - libunity-dev
+      - libfribidi-dev
     stage-packages:
       - libicu55
       - libasound2


### PR DESCRIPTION
Added GNU FriBidi, thus allowing Hebrew (or other future RTL languages)
to be displayed correctly.
It's been implemented for all ScummVM GUI (as far as I have noticed),
and can be further used by the engines as needed.

This work is only partial, because for complete BiDi support we'll need
to mirror the widgets, and support input text areas (which currently
don't even support Hebrew text input at all).

Some changes are required in order to to use this:
- Visual Studio:
  -- add FriBidi lib from https://github.com/ShiftMediaProject/fribidi
     (and place the files in the other libs location)
  -- add fribidi.dll to the current directory
  -- add fribidi.lib to VS library list
     (in GUI it's: Project -> scummvm Properties -> Linker ->
                   input -> Additional Dependencies)
  -- Add USE_FRIBIDI define
         either to:
             dists/msvc/ScummVM_Global.props   <PreprocessorDefinitions>
         or in GUI:
             Project -> scummvm Properties ->
             C/C++ -> Preprocessor -> Preprocessor Definitions
- GCC:
  -- install FriBidi
     e.g.,
        Ubuntu: `apt-get install libfribidi-dev`
        CentOS: `yum install fribidi-devel`
  -- rerun `configure`

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
