### PR TITLE
Graphics: Fix compilation warning on AmigaOS4

### DIFF
--- a/graphics/fonts/macfont.cpp
+++ b/graphics/fonts/macfont.cpp
@@ -611,7 +611,11 @@ MacFONTFont *MacFONTFont::scaleFont(const MacFONTFont *src, int newSize, bool bo
 	return new MacFONTFont(data);
 }
 
-#define howmany(x, y)	(((x)+((y)-1))/(y))
+// Fix compilation warning.
+// On AmigaOS4 howmany is already defined in sys/time.h.
+#ifndef __amigaos4__
+	#define howmany(x, y)	(((x)+((y)-1))/(y))
+#endif
 
 static void countupScore(int *dstGray, int x, int y, int bbw, int bbh, float scale) {
 	int newbbw = bbw * scale;


### PR DESCRIPTION
graphics/fonts/macfont.cpp:614: warning: "howmany" redefined
 #define howmany(x, y) (((x)+((y)-1))/(y))
 
In file included from /SDK/newlib/include/sys/time.h:16,
                 from /SDK/newlib/include/sys/resource.h:4,
                 from /SDK/newlib/include/sys/reent.h:19,
                 from /SDK/newlib/include/stdio.h:45,
                 from ./common/scummsys.h:118,
                 from ./common/endian.h:26,
                 from ./common/stream.h:26,
                 from graphics/fonts/macfont.cpp:23:
/SDK/newlib/include/sys/select.h:53: note: this is the location of the previous definition
 #define howmany(x, y) (((x) + ((y) - 1)) / (y))

Feel free to point out errors.