### PR TITLE
JANITORIAL: Fix compiler warning

### DIFF
--- a/engines/ultima/shared/conf/conf_serializer.h
+++ b/engines/ultima/shared/conf/conf_serializer.h
@@ -38,7 +38,7 @@ public:
 	/**
 	 * Constructor
 	 */
-	ConfSerializer(bool isSaving) : _isSaving(isSaving) {}
+	ConfSerializer(bool saving) : _isSaving(saving) {}
 
 	/**
 	 * Destructor


### PR DESCRIPTION
The following change fixes compiler warning about shadowing a variable, because a method with same name exists.

Since the header is included elsewhere, this removes over 580 lines of compiler errors.