### PR TITLE
PINK: Remove direct use of OSystem cursor functions

### DIFF
--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -269,11 +269,8 @@ bool PinkEngine::loadCursors() {
 }
 
 void PinkEngine::setCursor(uint cursorIndex) {
-	Graphics::Cursor *cursor = _cursors[cursorIndex]->cursors[0].cursor;
-	_system->setCursorPalette(cursor->getPalette(), cursor->getPaletteStartIndex(), cursor->getPaletteCount());
-	_system->setMouseCursor(cursor->getSurface(), cursor->getWidth(), cursor->getHeight(),
-							cursor->getHotspotX(), cursor->getHotspotY(), cursor->getKeyColor());
-	_system->showMouse(true);
+	CursorMan.replaceCursor(_cursors[cursorIndex]->cursors[0].cursor);
+	CursorMan.showMouse(true);
 }
 
 bool PinkEngine::canLoadGameStateCurrently() {


### PR DESCRIPTION
As mentioned [here](https://github.com/scummvm/scummvm/blob/3c03b4bfc2d31744b43b318ab78623a78d5a2129/common/system.h#L1053), engines should use `CursorMan` instead of calling the `OSystem` cursor functions directly. As such, this PR modifies the Pink engine to reflect that.