### PR TITLE
DIRECTOR: return early where textCast is null

### DIFF
--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -857,6 +857,11 @@ void Frame::renderButton(Graphics::ManagedSurface &surface, uint16 spriteId) {
 
 void Frame::renderText(Graphics::ManagedSurface &surface, uint16 spriteId, Common::Rect *textRect) {
 	TextCast *textCast = (TextCast*)_sprites[spriteId]->_cast;
+	if (textCast == nullptr){
+		warning("Frame::renderText(): TextCast: %d is a nullptr", spriteId);
+		return;
+	}
+
 	Score *score = _vm->getCurrentScore();
 	Sprite *sprite = _sprites[spriteId];
 


### PR DESCRIPTION
Fixes a segfault for the rectangle not being valid and
resolves multiple test crashes in the buildbot.