### PR TITLE
TRAVIS: enable ccache compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ dist: xenial
 script:
   - ccache --show-stats > /tmp/ccache_before
   - export PATH="/usr/local/opt/ccache/libexec:/usr/lib/ccache:$PATH"
+  - export CCACHE_COMPRESS=1
   - ./configure --enable-all-engines --enable-opl2lpt
   - make -j 2
   - make test


### PR DESCRIPTION
Current builds saturate Travis CI caches:

```
$ diff -U999 /tmp/ccache_before /tmp/ccache_after || true
--- /tmp/ccache_before	2019-11-19 21:45:52.491212479 +0000
+++ /tmp/ccache_after	2019-11-19 21:58:32.335898083 +0000
@@ -1,10 +1,13 @@
 cache directory                     /home/travis/.ccache
 primary config                      /home/travis/.ccache/ccache.conf
 secondary config      (readonly)    /etc/ccache.conf
 cache hit (direct)                     0
 cache hit (preprocessed)               0
-cache miss                             0
-no input file                          1
-files in cache                         0
-cache size                           0.0 kB
+cache miss                          4156
+called for link                       66
+called for preprocessing               3
+compile failed                         9
+no input file                          2
+files in cache                     10568
+cache size                         434.1 MB
 max cache size                     500.0 MB
```

I doubt it's possible to get more space allocated, though there are no
docs on what exact limits are. I suspect that default explicit setting
matches what's provided. Instead of trying to get more storage,
compress the objects with zlib (default level 6) to try increasing hit
rate.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
