### PR TITLE
SCI32: Add GK1 Italian translation patch detection

### DIFF
--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -816,6 +816,14 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		AD_LISTEND},
 		Common::FR_FRA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_GK1_FLOPPY },
 
+	// Gabriel Knight - Italian DOS Floppy (translation patch by Enrico Rolfi)
+	// SCI interpreter version 2.000.000
+	{"gk1", "", {
+		{"alt.map", 0, "ecf55868f9327f2abaf237710a657db7", 1557},
+		{"resource.alt", 0, "b2198dc83b1d030b332e78380e2ad00c", 3058970},
+		AD_LISTEND},
+		Common::IT_ITA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_GK1_FLOPPY },
+
 	// Gabriel Knight - English DOS CD (from jvprat)
 	// Executable scanning reports "2.000.000", VERSION file reports "01.100.000"
 	{"gk1", "CD", {


### PR DESCRIPTION
This patch can be found here, on the left side:
https://gkpatches.vogons.org/

It can technically be applied to any English DOS/Windows Floppy or CD release, and so I'm not sure how we want to handle the version checks. I've confirmed that this correctly detects and runs the game against the floppy that I patched.

If anyone has contact info for Enrico Rolfi, I'd be happy to send him a note.
