### PR TITLE
COMMON: Allow ignoring CR line breaks in SeekableReadStream::readLine()

### DIFF
--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -124,7 +124,7 @@ enum {
 	CR = 0x0D
 };
 
-char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
+char *SeekableReadStream::readLine(char *buf, size_t bufSize, bool handleCR) {
 	assert(buf != nullptr && bufSize > 1);
 	char *p = buf;
 	size_t len = 0;
@@ -159,7 +159,7 @@ char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
 		// * DOS and Windows use CRLF line breaks
 		// * Unix and OS X use LF line breaks
 		// * Macintosh before OS X used CR line breaks
-		if (c == CR) {
+		if (c == CR && handleCR) {
 			// Look at the next char -- is it LF? If not, seek back
 			c = readByte();
 
@@ -187,12 +187,12 @@ char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
 	return buf;
 }
 
-String SeekableReadStream::readLine() {
+String SeekableReadStream::readLine(bool handleCR) {
 	// Read a line
 	String line;
 	while (line.lastChar() != '\n') {
 		char buf[256];
-		if (!readLine(buf, 256))
+		if (!readLine(buf, 256, handleCR))
 			break;
 		line += buf;
 	}

--- a/common/stream.h
+++ b/common/stream.h
@@ -629,9 +629,10 @@ public:
 	 *
 	 * @param s	the buffer to store into
 	 * @param bufSize	the size of the buffer
+	 * @param handleCR	if set (default), then CR and CR/LF are handled as well as LF
 	 * @return a pointer to the read string, or NULL if an error occurred
 	 */
-	virtual char *readLine(char *s, size_t bufSize);
+	virtual char *readLine(char *s, size_t bufSize, bool handleCR = true);
 
 
 	/**
@@ -643,8 +644,10 @@ public:
 	 * of the line, *without* the end of a line marker. This method
 	 * does not indicate whether an error occurred. Callers must use
 	 * err() or eos() to determine whether an exception occurred.
+	 *
+	 * @param handleCR	if set (default), then CR and CR/LF are handled as well as LF
 	 */
-	virtual String readLine();
+	virtual String readLine(bool handleCR = true);
 
 	/**
 	 * Print a hexdump of the stream while maintaing position. The number

--- a/devtools/create_titanic/zlib.cpp
+++ b/devtools/create_titanic/zlib.cpp
@@ -49,11 +49,11 @@ namespace Common {
  */
 void debug(int level, const char *s, ...) {}
 
-char *SeekableReadStream::readLine(char *buf, size_t bufSize) {
+char *SeekableReadStream::readLine(char *buf, size_t bufSize, bool handleCR) {
 	return nullptr;
 }
 
-String SeekableReadStream::readLine() {
+String SeekableReadStream::readLine(bool handleCR) {
 	return String();
 }
 


### PR DESCRIPTION
This is needed for [Biik scripts](https://github.com/ccawley2011/scummvm/blob/5bb055994137e7f909b9df06e67fa6c2dc72d6ab/engines/biik/script.cpp#L55), where CR is used for line breaks within formatted text, while LF is used for separating individual script entries. 