### PR TITLE
SDL: Return unicode keycode for Hebrew input

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -114,7 +114,7 @@ SdlEventSource::~SdlEventSource() {
 int SdlEventSource::mapKey(SDL_Keycode sdlKey, SDL_Keymod mod, Uint16 unicode) {
 	Common::KeyCode key = SDLToOSystemKeycode(sdlKey);
 
-	// Keep unicode in case it's regular ASCII text or in case we didn't get a valid keycode
+	// Keep unicode in case it's regular ASCII text, Hebrew or in case we didn't get a valid keycode
 	//
 	// We need to use unicode in those cases, simply because SDL1.x passes us non-layout-adjusted keycodes.
 	// So unicode is the only way to get layout-adjusted keys.
@@ -136,6 +136,10 @@ int SdlEventSource::mapKey(SDL_Keycode sdlKey, SDL_Keymod mod, Uint16 unicode) {
 				if (unicode > 0x7E)
 					unicode = 0; // do not allow any characters above 0x7E
 			} else {
+				// We allow Hebrew characters
+				if (unicode >= 0x05D0 && unicode <= 0x05EA)
+					return unicode;
+
 				// We must not restrict as much as when Ctrl/Alt-modifiers are active, otherwise
 				// we wouldn't let umlauts through for SDL1. For SDL1 umlauts may set for example KEYCODE_QUOTE, KEYCODE_MINUS, etc.
 				if (unicode > 0xFF)


### PR DESCRIPTION
Before this commit, when typing in Hebrew, SDL reported the equivalent
English keycode. Thus, if user typed Hebrew letter Aleph, it was
reported as ascii of 't' (or 'T', I don't remember...).

It's still impossible to type Hebrew letters in the GUI's input dialogs,
but it's a step forward.

This was supposed to be part of a bigger PR, adding support for Hebrew in SQ3 (SCI0), but I'm waiting with this PR until there will be a decision in PR #2217. However, it's taking time, and I realized it might help @aryanrawlani28 's work on the GUI, and @BLooperZ 's work on other engines, therefore, it's submitted alone.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
