### PR TITLE
Ports: Pause token mk2

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -160,11 +160,10 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 		if (_vk->isDisplaying()) {
 			_vk->close(true);
 		} else {
+			PauseToken pt;
 			if (g_engine)
-				g_engine->pauseEngine(true);
+				pt = g_engine->pauseEngine();
 			_vk->show();
-			if (g_engine)
-				g_engine->pauseEngine(false);
 			forwardEvent = false;
 		}
 		break;

--- a/backends/events/ps3sdl/ps3sdl-events.cpp
+++ b/backends/events/ps3sdl/ps3sdl-events.cpp
@@ -37,9 +37,10 @@
  */
 void PS3SdlEventSource::preprocessEvents(SDL_Event *event) {
 	if (event->type == SDL_APP_DIDENTERBACKGROUND) {
+		PauseToken pt;
 		// XMB opened
 		if (g_engine)
-			g_engine->pauseEngine(true);
+			pt = g_engine->pauseEngine();
 
 		for (;;) {
 			if (!SDL_PollEvent(event)) {
@@ -56,8 +57,6 @@ void PS3SdlEventSource::preprocessEvents(SDL_Event *event) {
 				return;
 			if (event->type == SDL_APP_DIDENTERFOREGROUND) {
 				// XMB closed
-				if (g_engine)
-					g_engine->pauseEngine(false);
 				return;
 			}
 		}

--- a/backends/platform/3ds/osystem-events.cpp
+++ b/backends/platform/3ds/osystem-events.cpp
@@ -208,7 +208,7 @@ static void aptHookFunc(APT_HookType hookType, void *param) {
 		case APTHOOK_ONSUSPEND:
 		case APTHOOK_ONSLEEP:
 			if (g_engine) {
-				g_engine->pauseEngine(true);
+				osys->_sleepPauseToken = g_engine->pauseEngine();
 			}
 			osys->sleeping = true;
 			if (R_SUCCEEDED(gspLcdInit())) {
@@ -219,7 +219,7 @@ static void aptHookFunc(APT_HookType hookType, void *param) {
 		case APTHOOK_ONRESTORE:
 		case APTHOOK_ONWAKEUP:
 			if (g_engine) {
-				g_engine->pauseEngine(false);
+				osys->_sleepPauseToken.clear();
 			}
 			osys->sleeping = false;
 			loadConfig();

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -282,6 +282,9 @@ private:
 	u16 _magX, _magY;
 	u16 _magWidth, _magHeight;
 	u16 _magCenterX, _magCenterY;
+
+	// Pause
+	PauseToken _sleepPauseToken;
 };
 
 } // namespace _3DS

--- a/backends/platform/android/jni-android.cpp
+++ b/backends/platform/android/jni-android.cpp
@@ -689,7 +689,10 @@ void JNI::setPause(JNIEnv *env, jobject self, jboolean value) {
 	if (g_engine) {
 		LOGD("pauseEngine: %d", value);
 
-		g_engine->pauseEngine(value);
+		if (value)
+			_pauseToken = g_engine->pauseEngine(value);
+		else
+			_pauseToken.clear();
 
 		/*if (value &&
 				g_engine->hasFeature(Engine::kSupportsSavingDuringRuntime) &&

--- a/backends/platform/android/jni-android.h
+++ b/backends/platform/android/jni-android.h
@@ -139,6 +139,8 @@ private:
 	static void setPause(JNIEnv *env, jobject self, jboolean value);
 
 	static jstring getCurrentCharset(JNIEnv *env, jobject self);
+
+	static PauseToken _pauseToken;
 };
 
 inline bool JNI::haveSurface() {

--- a/backends/platform/psp/image_viewer.cpp
+++ b/backends/platform/psp/image_viewer.cpp
@@ -136,7 +136,7 @@ void ImageViewer::setVisible(bool visible) {
 
 	// from here on, we're making the loader visible
 	if (visible && g_engine) {	// we can only run the image viewer when there's an engine
-		g_engine->pauseEngine(true);
+		_pauseToken = g_engine->pauseEngine();
 
 		load(_imageNum ? _imageNum : 1); 	// load the 1st image or the current
 	}
@@ -157,7 +157,7 @@ void ImageViewer::setVisible(bool visible) {
 		setViewerButtons(false);
 
 		if (g_engine && g_engine->isPaused())
-			g_engine->pauseEngine(false);
+			_pauseToken.clear();
 	}
 	setDirty();
 }

--- a/backends/platform/psp/image_viewer.h
+++ b/backends/platform/psp/image_viewer.h
@@ -54,6 +54,7 @@ private:
 	float _visibleHeight, _visibleWidth;
 	float _centerX, _centerY;
 	Event _movement;
+	PauseToken _pauseToken;
 
 	InputHandler *_inputHandler;
 	DisplayManager *_displayManager;

--- a/backends/platform/psp/powerman.cpp
+++ b/backends/platform/psp/powerman.cpp
@@ -121,12 +121,12 @@ void PowerManager::pollPauseEngine() {
 		if (g_engine) { // Check to see if we have an engine
 			if (pause && _pauseClientState == UNPAUSED) {
 				_pauseClientState = PAUSING;		// Tell PM we're in the middle of pausing
-				g_engine->pauseEngine(true);
 				PSP_DEBUG_PRINT_FUNC("Pausing engine\n");
+				_pauseToken = g_engine->pauseEngine();
 				_pauseClientState = PAUSED;			// Tell PM we're done pausing
 			} else if (!pause && _pauseClientState == PAUSED) {
-				g_engine->pauseEngine(false);
 				PSP_DEBUG_PRINT_FUNC("Unpausing for resume\n");
+				_pauseToken.clear();
 				_pauseClientState = UNPAUSED;		// Tell PM we're unpaused
 			}
 		}

--- a/backends/platform/psp/powerman.h
+++ b/backends/platform/psp/powerman.h
@@ -80,6 +80,7 @@ private:
 	volatile bool _pauseFlag;						// For pausing, which is before suspending
 	volatile bool _pauseFlagOld;					// Save the last state of the flag while polling
 	volatile PauseState _pauseClientState;			// Pause state of the target
+	PauseToken _pauseToken;
 
 	volatile bool _suspendFlag;						// protected variable
 	PspMutex _flagMutex;							// mutex to access access flag


### PR DESCRIPTION
Fix some missed uses of `Engine::pauseEngine` from #2147.