### PR TITLE
AGOS: Fix compatibility with strict-alignment architectures

### DIFF
--- a/engines/agos/string.cpp
+++ b/engines/agos/string.cpp
@@ -332,6 +332,7 @@ void AGOSEngine::loadTextIntoMem(uint16 stringId) {
 
 			_tablesHeapPtr += size;
 			_tablesHeapCurPos += size;
+			alignTableMem();
 
 			if (_tablesHeapCurPos > _tablesHeapSize) {
 				error("loadTextIntoMem: Out of table memory");

--- a/engines/agos/subroutine.cpp
+++ b/engines/agos/subroutine.cpp
@@ -218,9 +218,9 @@ Subroutine *AGOSEngine::getSubroutineByID(uint subroutineId) {
 }
 
 void AGOSEngine::alignTableMem() {
-	if (!IS_ALIGNED(_tablesHeapPtr, 4)) {
-		_tablesHeapPtr += 2;
-		_tablesHeapCurPos += 2;
+	while (!IS_ALIGNED(_tablesHeapPtr, sizeof(byte *))) {
+		_tablesHeapPtr++;
+		_tablesHeapCurPos++;
 	}
 }
 


### PR DESCRIPTION
Proposed fix for a bug I've reported some years ago:
https://bugs.scummvm.org/ticket/6220

SIMON2-FR would crash really early with a SIGBUS on OpenBSD/loongson, which is a mips64el system with strict alignment constraints.

Aligning to `sizeof(byte *)` in alignTableMem(), and calling alignTableMem() in loadTextIntoMem() seems to be enough. It just took me a bit of time to test this :)

(Maybe alignTableMem() could be optimised a bit, but I'm not sure it's worth it.)

Tested with SIMON2-FR and SIMON1-FR on OpenBSD/loongson and on macOS Mojave (x86-64).

I don't really know how to test the "running out of memory" possible case that lordhoto reported above, though. Don't know which platform or use case would be more likely to hit it.