### PR TITLE
TRAVIS: enable ccache compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ dist: xenial
 script:
   - ccache --show-stats > /tmp/ccache_before
   - export PATH="/usr/local/opt/ccache/libexec:/usr/lib/ccache:$PATH"
+  - export CCACHE_COMPRESS=1
   - ./configure --enable-all-engines --enable-opl2lpt
   - make -j 2
   - make test


### PR DESCRIPTION
Current builds saturate Travis CI caches:

```diff
$ diff -U999 /tmp/ccache_before /tmp/ccache_after || true
--- /tmp/ccache_before	2020-05-08 16:34:12.987955074 +0000
+++ /tmp/ccache_after	2020-05-08 16:45:45.570927610 +0000
@@ -1,13 +1,13 @@
 cache directory                     /home/travis/.ccache
 primary config                      /home/travis/.ccache/ccache.conf
 secondary config      (readonly)    /etc/ccache.conf
 cache hit (direct)                  2816
 cache hit (preprocessed)            1045
-cache miss                       5751026
-called for link                    85473
-called for preprocessing            3832
-compile failed                     11462
-no input file                       2558
-files in cache                     11334
-cache size                         451.9 MB
+cache miss                       5755826
+called for link                    85542
+called for preprocessing            3835
+compile failed                     11471
+no input file                       2559
+files in cache                     11430
+cache size                         458.1 MB
 max cache size                     500.0 MB
```

I doubt it's possible to get more space allocated, though there are no
docs on what exact limits are. I suspect that default explicit setting
matches what's provided. Instead of trying to get more storage,
compress the objects with zlib (default level 6) to try increasing hit
rate.

Testing with compression on/off provides following stats:
```diff
--- compression_off	2020-05-12 21:53:41.597030300 +0200
+++ compression_on	2020-05-12 21:53:52.887293915 +0200
@@ -1,18 +1,18 @@
 cache directory                     /home/janisozaur/.ccache
 primary config                      /home/janisozaur/.ccache/ccache.conf
 secondary config      (readonly)    /etc/ccache.conf
-stats updated                       Tue May 12 20:42:00 2020
-stats zeroed                        Tue May 12 20:29:24 2020
+stats updated                       Tue May 12 20:21:36 2020
+stats zeroed                        Tue May 12 20:09:03 2020
 cache hit (direct)                     0
 cache hit (preprocessed)               0
 cache miss                          3383
 cache hit rate                      0.00 %
 called for link                       41
 called for preprocessing               3
 compile failed                         9
 no input file                          1
 cleanups performed                     0
 files in cache                     13544
-cache size                         377.3 MB
+cache size                         211.9 MB
 max cache size                       5.0 GB
-make -j 4  1997,44s user 332,76s system 336% cpu 11:31,51 total
+make -j 4  2009,84s user 333,39s system 333% cpu 11:41,85 total
```

43% reduction of cached files' size for 10s increase of wall clock compilation time (on my machine). This should hopefully increase the hit rate significantly, which now nearly doesn't exist.

After having merged this, I would suggest clearing the Travis' caches (cf. https://docs.travis-ci.com/user/caching/#clearing-caches) to ensure stale objects don't prevent newer compressed ones from getting in.

Note: this is a re-open of my previous PR which was closed with comment I don't really understand: https://github.com/scummvm/scummvm/pull/2230#issuecomment-627562415