### PR TITLE
ULTIMA8: Custom type checking cleanup

### DIFF
--- a/engines/ultima/ultima8/gumps/container_gump.cpp
+++ b/engines/ultima/ultima8/gumps/container_gump.cpp
@@ -234,7 +234,7 @@ void ContainerGump::GetItemLocation(int32 lerp_factor) {
 		topitem = p;
 	}
 
-	Gump *gump = GetRootGump()->FindGump(GameMapGump::ClassType);
+	Gump *gump = GetRootGump()->FindGump<GameMapGump>();
 	assert(gump);
 	gump->GetLocationOfItem(topitem->getObjId(), gx, gy, lerp_factor);
 

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -533,8 +533,7 @@ bool Gump::GetLocationOfItem(uint16 itemid, int32 &gx, int32 &gy,
 }
 
 // Find a child gump that matches the matching function 
-Gump *Gump::FindGump(const FindPredicate predicate, bool recursive)
-{
+Gump *Gump::FindGump(const FindPredicate predicate, bool recursive) {
 	if ((this->*predicate)())
 		return this;
 

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -532,13 +532,10 @@ bool Gump::GetLocationOfItem(uint16 itemid, int32 &gx, int32 &gy,
 	return false;
 }
 
-// Find a child gump of the specified type
-Gump *Gump::FindGump(const RunTimeClassType &t, bool recursive,
-                     bool no_inheritance) {
-	// If that is our type, then return us!
-	if (GetClassType() == t)
-		return this;
-	else if (!no_inheritance && IsOfType(t))
+// Find a child gump that matches the matching function 
+Gump *Gump::FindGump(const FindPredicate predicate, bool recursive)
+{
+	if ((this->*predicate)())
 		return this;
 
 	// Iterate all children
@@ -552,9 +549,7 @@ Gump *Gump::FindGump(const RunTimeClassType &t, bool recursive,
 		if (g->_flags & FLAG_CLOSING)
 			continue;
 
-		if (g->GetClassType() == t)
-			return g;
-		else if (!no_inheritance && g->IsOfType(t))
+		if ((g->*predicate)())
 			return g;
 	}
 
@@ -572,7 +567,7 @@ Gump *Gump::FindGump(const RunTimeClassType &t, bool recursive,
 		if (g->_flags & FLAG_CLOSING)
 			continue;
 
-		g = g->FindGump(t, recursive, no_inheritance);
+		g = g->FindGump(predicate, recursive);
 
 		if (g)
 			return g;

--- a/engines/ultima/ultima8/gumps/gump.h
+++ b/engines/ultima/ultima8/gumps/gump.h
@@ -108,23 +108,20 @@ public:
 	//! \param takefocus If true, set parent's _focusChild to this
 	virtual void                InitGump(Gump *newparent, bool take_focus = true);
 
-	//! Find a gump of the specified type (this or child)
-	//! \param t Type of gump to look for
+	typedef bool (Gump::*FindPredicate)() const;
+
+	//! Find a gump of that matches a predicate function (this or child)
+	//! \param predicate Function to check if a gump is a match
 	//! \param recursive Recursively search through children?
-	//! \param no_inheritance Exactly this type, or is a subclass also allowed?
 	//! \return the desired Gump, or NULL if not found
-	virtual Gump               *FindGump(const RunTimeClassType &t,
-	                                     bool recursive = true,
-	                                     bool no_inheritance = false);
+	virtual Gump               *FindGump(FindPredicate predicate, bool recursive = true);
 
 	//! Find a gump of the specified type (this or child)
 	//! \param T Type of gump to look for
 	//! \param recursive Recursively search through children?
-	//! \param no_inheritance Exactly this type, or is a subclass also allowed?
 	//! \return the desired Gump, or NULL if not found
-	template<class T> Gump     *FindGump(bool recursive = true,
-	                                     bool no_inheritance = false) {
-		return FindGump(T::ClassType, recursive, no_inheritance);
+	template<class T> Gump     *FindGump(bool recursive = true) {
+		return FindGump(&Gump::IsOfType<T>, recursive);
 	}
 
 	//! Find gump (this, child or NULL) at parent coordinates (mx,my)

--- a/engines/ultima/ultima8/gumps/item_relative_gump.cpp
+++ b/engines/ultima/ultima8/gumps/item_relative_gump.cpp
@@ -132,7 +132,7 @@ void ItemRelativeGump::GetItemLocation(int32 lerp_factor) {
 	int32 gx, gy;
 
 	if (!gump) {
-		gump = GetRootGump()->FindGump(GameMapGump::ClassType);
+		gump = GetRootGump()->FindGump<GameMapGump>();
 
 		if (!gump) {
 			perr << "ItemRelativeGump::GetItemLocation(): "

--- a/engines/ultima/ultima8/gumps/paperdoll_gump.cpp
+++ b/engines/ultima/ultima8/gumps/paperdoll_gump.cpp
@@ -385,7 +385,7 @@ void PaperdollGump::ChildNotify(Gump *child, uint32 message) {
 	        message == ButtonWidget::BUTTON_CLICK) {
 		// check if there already is an open MiniStatsGump
 		Gump *desktop = Ultima8Engine::get_instance()->getDesktopGump();
-		Gump *statsgump = desktop->FindGump(MiniStatsGump::ClassType);
+		Gump *statsgump = desktop->FindGump<MiniStatsGump>();
 
 		if (!statsgump) {
 			Gump *gump = new MiniStatsGump(0, 0);

--- a/engines/ultima/ultima8/gumps/slider_gump.cpp
+++ b/engines/ultima/ultima8/gumps/slider_gump.cpp
@@ -92,7 +92,7 @@ void SliderGump::setValueFromSlider(int sliderx) {
 }
 
 void SliderGump::setSliderPos() {
-	Gump *slider = Gump::FindGump(SlidingWidget::ClassType);
+	Gump *slider = Gump::FindGump<SlidingWidget>();
 	assert(slider);
 	slider->Move(getSliderPos(), slidery);
 }

--- a/engines/ultima/ultima8/misc/debugger.cpp
+++ b/engines/ultima/ultima8/misc/debugger.cpp
@@ -1447,7 +1447,7 @@ bool Debugger::cmdShowMenu(int argc, const char **argv) {
 bool Debugger::cmdToggleFastArea(int argc, const char **argv) {
 	Ultima8Engine *app = Ultima8Engine::get_instance();
 	Gump *desktop = app->getDesktopGump();
-	Gump *favg = desktop->FindGump(FastAreaVisGump::ClassType);
+	Gump *favg = desktop->FindGump<FastAreaVisGump>();
 
 	if (!favg) {
 		favg = new FastAreaVisGump;
@@ -1502,7 +1502,7 @@ bool Debugger::cmdPlayMusic(int argc, const char **argv) {
 bool Debugger::cmdToggleMinimap(int argc, const char **argv) {
 	Ultima8Engine *app = Ultima8Engine::get_instance();
 	Gump *desktop = app->getDesktopGump();
-	Gump *mmg = desktop->FindGump(MiniMapGump::ClassType);
+	Gump *mmg = desktop->FindGump<MiniMapGump>();
 
 	if (!mmg) {
 		mmg = new MiniMapGump(4, 4);

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -945,7 +945,7 @@ bool Ultima8Engine::canSaveGameStateCurrently(bool isAutosave) {
 		// Can't save when a modal gump is open, or avatar in statsis  during cutscenes
 		return false;
 
-	if (_kernel->getRunningProcess() && _kernel->getRunningProcess()->IsOfType(StartU8Process::ClassType))
+	if (_kernel->getRunningProcess() && _kernel->getRunningProcess()->IsOfType<StartU8Process>())
 		// Don't save while starting up.
 		return false;
 


### PR DESCRIPTION
ULTIMA8: Custom type checking cleanup

Use template methods for type checking instead of referencing static ::ClassType variable directly.
Alter Gump::FindGump to check matches against a function instead of referencing the RunTimeClassType and remove no_inheritence option as it is never used. These changes should help migration from p_dynamic_cast if desired.
