### PR TITLE
DRAGONS: Implementing midi music player

### DIFF
--- a/engines/dragons/dragons.cpp
+++ b/engines/dragons/dragons.cpp
@@ -654,7 +654,9 @@ void DragonsEngine::updateHandler() {
 
 	// 0x8001b200
 	if (isFlagSet(ENGINE_FLAG_8000) && !_sound->isSpeechPlaying()) {
+		//dialog finished playing.
 		clearFlags(ENGINE_FLAG_8000);
+		_sound->resumeMusic();
 	}
 
 	//TODO logic here

--- a/engines/dragons/midimusicplayer.cpp
+++ b/engines/dragons/midimusicplayer.cpp
@@ -1,0 +1,132 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "common/stream.h"
+#include "audio/midiparser.h"
+#include "midimusicplayer.h"
+
+
+namespace Dragons {
+
+MidiMusicPlayer::MidiMusicPlayer(VabSound *musicVab): _musicVab(musicVab) {
+	_midiData = nullptr;
+	_midiDataSize = 0;
+	MidiPlayer::createDriver();
+
+	int ret = _driver->open();
+	if (ret == 0) {
+		if (_nativeMT32)
+			_driver->sendMT32Reset();
+		else
+			_driver->sendGMReset();
+
+		_driver->setTimerCallback(this, &timerCallback);
+	}
+}
+
+MidiMusicPlayer::~MidiMusicPlayer() {
+	if (isPlaying()) {
+		stop();
+	}
+}
+
+void MidiMusicPlayer::playSong(Common::SeekableReadStream *seqData) {
+	Common::StackLock lock(_mutex);
+
+	if (isPlaying()) {
+		stop();
+	}
+
+	if (seqData->readUint32LE() != MKTAG('S', 'E', 'Q', 'p'))
+		error("Failed to find SEQp tag");
+
+	// Make sure we don't have a SEP file (with multiple SEQ's inside)
+	if (seqData->readUint32BE() != 1)
+		error("Can only play SEQ files, not SEP");
+
+	uint16 ppqn = seqData->readUint16BE();
+	uint32 tempo = seqData->readUint16BE() << 8;
+	tempo |= seqData->readByte();
+	/* uint16 beat = */ seqData->readUint16BE();
+
+	// SEQ is directly based on SMF and we'll use that to our advantage here
+	// and convert to SMF and then use the SMF MidiParser.
+
+	// Calculate the SMF size we'll need
+	uint32 dataSize = seqData->size() - 15;
+	uint32 actualSize = dataSize + 7 + 22;
+
+	// Resize the buffer if necessary
+	byte *midiData = resizeMidiBuffer(actualSize);
+
+	// Now construct the header
+	WRITE_BE_UINT32(midiData, MKTAG('M', 'T', 'h', 'd'));
+	WRITE_BE_UINT32(midiData + 4, 6); // header size
+	WRITE_BE_UINT16(midiData + 8, 0); // type 0
+	WRITE_BE_UINT16(midiData + 10, 1); // one track
+	WRITE_BE_UINT16(midiData + 12, ppqn);
+	WRITE_BE_UINT32(midiData + 14, MKTAG('M', 'T', 'r', 'k'));
+	WRITE_BE_UINT32(midiData + 18, dataSize + 7); // SEQ data size + tempo change event size
+
+	// Add in a fake tempo change event
+	WRITE_BE_UINT32(midiData + 22, 0x00FF5103); // no delta, meta event, tempo change, param size = 3
+	WRITE_BE_UINT16(midiData + 26, tempo >> 8);
+	midiData[28] = tempo & 0xFF;
+
+	// Now copy in the rest of the events
+	seqData->read(midiData + 29, dataSize);
+
+	MidiParser *parser = MidiParser::createParser_SMF();
+	if (parser->loadMusic(midiData, actualSize)) {
+		parser->setTrack(0);
+		parser->setMidiDriver(this);
+		parser->setTimerRate(getBaseTempo());
+		parser->property(MidiParser::mpCenterPitchWheelOnUnload, 1);
+		parser->property(MidiParser::mpSendSustainOffOnNotesOff, 1);
+
+		_parser = parser;
+
+		_isLooping = true;
+		_isPlaying = true;
+	} else {
+		delete parser;
+	}
+}
+
+byte *MidiMusicPlayer::resizeMidiBuffer(uint32 desiredSize) {
+	if (_midiData == nullptr) {
+		_midiData = (byte *)malloc(desiredSize);
+		_midiDataSize = desiredSize;
+	} else {
+		if (desiredSize > _midiDataSize) {
+			_midiData = (byte *)realloc(_midiData, desiredSize);
+			_midiDataSize = desiredSize;
+		}
+	}
+	return _midiData;
+}
+
+void MidiMusicPlayer::setVolume(int volume) {
+//	_vm->_mixer->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, volume); TODO do we need this?
+	MidiPlayer::setVolume(volume);
+}
+
+} // End of namespace Dragons

--- a/engines/dragons/midimusicplayer.cpp
+++ b/engines/dragons/midimusicplayer.cpp
@@ -26,9 +26,8 @@
 
 namespace Dragons {
 
-MidiMusicPlayer::MidiMusicPlayer(VabSound *musicVab): _musicVab(musicVab) {
+MidiMusicPlayer::MidiMusicPlayer(VabSound *musicVab): _musicVab(musicVab), _midiDataSize(0) {
 	_midiData = nullptr;
-	_midiDataSize = 0;
 	MidiPlayer::createDriver();
 
 	int ret = _driver->open();

--- a/engines/dragons/midimusicplayer.h
+++ b/engines/dragons/midimusicplayer.h
@@ -1,0 +1,51 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef DRAGONS_MIDIMUSICPLAYER_H
+#define DRAGONS_MIDIMUSICPLAYER_H
+
+#include "audio/midiplayer.h"
+#include "vabsound.h"
+
+namespace Dragons {
+
+class MidiMusicPlayer : public Audio::MidiPlayer {
+private:
+	VabSound *_musicVab;
+	uint32 _midiDataSize;
+public:
+	MidiMusicPlayer(VabSound *musicVab);
+	~MidiMusicPlayer();
+
+	void setVolume(int volume) override;
+
+	void playSong(Common::SeekableReadStream *seqData);
+
+	// The original sets the "sequence timing" to 109 Hz, whatever that
+	// means. The default is 120.
+	uint32 getBaseTempo()	{ return _driver ? (109 * _driver->getBaseTempo()) / 120 : 0; }
+private:
+	byte *resizeMidiBuffer(uint32 desiredSize);
+};
+
+} // End of namespace Dragons
+
+#endif //DRAGONS_MIDIMUSICPLAYER_H

--- a/engines/dragons/minigame2.cpp
+++ b/engines/dragons/minigame2.cpp
@@ -693,7 +693,7 @@ void Minigame2::run(int16 param_1, uint16 param_2, int16 param_3) {
 
 	_vm->fadeToBlack();
 	_vm->_fontManager->clearText();
-	_vm->_sound->PauseCDMusic();
+	_vm->_sound->resumeMusic();
 //	DisableVSyncEvent();
 	_vm->_dragonINIResource->getRecord(0)->x = 0x91;
 	_vm->_dragonINIResource->getRecord(0)->y = 0x9b;

--- a/engines/dragons/minigame3.cpp
+++ b/engines/dragons/minigame3.cpp
@@ -731,7 +731,7 @@ void Minigame3::run() {
 		_vm->_dragonINIResource->getRecord(0x178)->objectState2 = 0;
 	}
 	_vm->waitForFrames(0x3c * 2);
-	_vm->_sound->PauseCDMusic();
+	_vm->_sound->resumeMusic();
 	_vm->fadeToBlack();
 //	fun_80017f28_noop();
 //	DAT_80093234 = DAT_80093234 + 1;

--- a/engines/dragons/module.mk
+++ b/engines/dragons/module.mk
@@ -19,6 +19,7 @@ MODULE_OBJS := \
 	dragons.o \
 	font.o \
 	inventory.o \
+	midimusicplayer.o \
 	minigame1.o \
 	minigame2.o \
 	minigame3.o \

--- a/engines/dragons/scriptopcodes.cpp
+++ b/engines/dragons/scriptopcodes.cpp
@@ -477,10 +477,10 @@ void ScriptOpcodes::opActorLoadSequence(ScriptOpCall &scriptOpCall) {
 }
 
 void ScriptOpcodes::opPlayMusic(ScriptOpCall &scriptOpCall) {
-	//byte *code = scriptOpCall._code;
-	scriptOpCall._code += 4;
+	ARG_SKIP(2);
+	ARG_INT16(songNumber);
 	if (scriptOpCall._field8 == 0) {
-		//TODO play music here.
+		_vm->_sound->playMusic(songNumber);
 	}
 }
 
@@ -534,7 +534,7 @@ void ScriptOpcodes::opPreLoadSceneData(ScriptOpCall &scriptOpCall) {
 	ARG_INT16(field0);
 	ARG_INT16(sceneId);
 
-	_vm->_sound->PauseCDMusic();
+	_vm->_sound->resumeMusic();
 	_vm->_isLoadingDialogAudio = true;
 
 	if (sceneId >= 2) {
@@ -547,7 +547,7 @@ void ScriptOpcodes::opPauseCurrentSpeechAndFetchNextDialog(ScriptOpCall &scriptO
 	ARG_UINT32(textIndex);
 
 	if (scriptOpCall._field8 == 0) {
-		_vm->_sound->PauseCDMusic();
+		_vm->_sound->resumeMusic();
 		//The original starts seeking the CD-ROM here for the `textIndex` dialog but we don't need to do that.
 	}
 }
@@ -907,7 +907,7 @@ void ScriptOpcodes::opLoadScene(ScriptOpCall &scriptOpCall) {
 
 	_vm->fadeToBlack();
 	_vm->clearSceneUpdateFunction();
-	_vm->_sound->PauseCDMusic();
+	_vm->_sound->resumeMusic();
 
 	if (newSceneID != 0) {
 		_vm->_scene->_mapTransitionEffectSceneID = _vm->_scene->getSceneId();

--- a/engines/dragons/sound.h
+++ b/engines/dragons/sound.h
@@ -25,6 +25,7 @@
 #include "common/scummsys.h"
 #include "audio/mixer.h"
 #include "audio/audiostream.h"
+#include "midimusicplayer.h"
 
 
 namespace Dragons {
@@ -54,9 +55,10 @@ public:
 	void loadMsf(uint32 sceneId);
 	void playOrStopSound(uint16 soundId);
 
+	void playMusic(int16 song);
 	void playSpeech(uint32 textIndex);
 	bool isSpeechPlaying();
-	void PauseCDMusic();
+	void resumeMusic();
 
 public:
 	uint16 _dat_8006bb60_sound_related;
@@ -74,15 +76,19 @@ private:
 	uint8 _soundArr[0x780];
 
 	VabSound* _vabMusx;
+	VabSound* _vabMsf;
 	VabSound* _vabGlob;
 
 	Audio::SoundHandle _speechHandle;
+	MidiMusicPlayer *_midiPlayer;
+
 	Voice _voice[NUM_VOICES];
+	int16 _currentSong;
 
 private:
 	void SomeInitSound_FUN_8003f64c();
 
-	void loadMusAndGlob();
+	void initVabData();
 
 	void playSound(uint16 soundId, uint16 i);
 

--- a/engines/dragons/specialopcodes.cpp
+++ b/engines/dragons/specialopcodes.cpp
@@ -330,7 +330,7 @@ void SpecialOpcodes::spcLadyOfTheLakeCapturedSceneLogic() {
 
 void SpecialOpcodes::spcStopLadyOfTheLakeCapturedSceneLogic() {
 	_vm->clearSceneUpdateFunction();
-	_vm->_sound->PauseCDMusic();
+	_vm->_sound->resumeMusic();
 	if ((_dat_80083148 != 0) || (_uint16_t_80083154 != 0)) {
 		//TODO FUN_8001ac5c((uint)_dat_80083148, (uint)DAT_80083150, (uint)_uint16_t_80083154, (uint)DAT_80083158);
 	}

--- a/engines/dragons/talk.cpp
+++ b/engines/dragons/talk.cpp
@@ -427,7 +427,7 @@ uint8 Talk::conversation_related_maybe(uint16 *dialogText, uint16 x, uint16 y, u
 	}
 	if (param_5 != 0) {
 		if (_vm->isFlagSet(ENGINE_FLAG_8000)) {
-			_vm->_sound->PauseCDMusic();
+			_vm->_sound->resumeMusic();
 		}
 		if (isFlag8Set) {
 			_vm->setFlags(ENGINE_FLAG_8);


### PR DESCRIPTION
I'm starting to implement music for Blazing Dragons. It uses PS1 SEQ files for music. These files are almost identical to standard SMF MIDI but use specific sound bank for instruments.

I've copied the method that is used by the tinsel engine to support SEQ files.

I was thinking that we could load the sound bank samples automatically in the engine and convert them into the soundfont format to be used by midi drivers that support loading samples.

I haven't implemented the soundfont loading bit yet. It would probably require changes to base audio classes.

What does everyone think?

This PR implements the midi player. I've tested it with a manually converted VAB to SF2 file and it sounds good to my ears.

I could also apply this technique to the tinsel engine to add proper sound samples there too.
