### PR TITLE
CONFIGURE: Add -fno-operator-names for clang/gcc

### DIFF
--- a/configure
+++ b/configure
@@ -2275,6 +2275,7 @@ if test "$have_gcc" = yes ; then
 	else
 		append_var CXXFLAGS "-Wconversion"
 	fi;
+	append_var CXXFLAGS "-fno-operator-names"
 elif test "$have_icc" = yes ; then
 	add_line_to_config_mk 'CXX_UPDATE_DEP_FLAG = -MMD -MF "$(*D)/$(DEPDIR)/$(*F).d" -MQ "$@" -MP'
 fi;

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -161,7 +161,7 @@ int WintermuteEngine::init() {
 	}
 
 	// check dependencies for games with high resolution assets
-	#if not defined(USE_PNG) || not defined(USE_JPEG) || not defined(USE_VORBIS)
+	#if !defined(USE_PNG) || !defined(USE_JPEG) || !defined(USE_VORBIS)
 		if (!(instance.getFlags() & GF_LOWSPEC_ASSETS)) {
 			GUI::MessageDialog dialog(_("This game requires PNG, JPEG and Vorbis support."));
 			dialog.runModal();
@@ -172,7 +172,7 @@ int WintermuteEngine::init() {
 	#endif
 
 	// check dependencies for games with FoxTail subengine
-	#if not defined(ENABLE_FOXTAIL)
+	#if !defined(ENABLE_FOXTAIL)
 		if (BaseEngine::isFoxTailCheck(instance.getTargetExecutable())) {
 			GUI::MessageDialog dialog(_("This game requires the FoxTail subengine, which is not compiled in."));
 			dialog.runModal();
@@ -183,7 +183,7 @@ int WintermuteEngine::init() {
 	#endif
 
 	// check dependencies for games with HeroCraft subengine
-	#if not defined(ENABLE_HEROCRAFT)
+	#if !defined(ENABLE_HEROCRAFT)
 		if (instance.getTargetExecutable() == WME_HEROCRAFT) {
 			GUI::MessageDialog dialog(_("This game requires the HeroCraft subengine, which is not compiled in."));
 			dialog.runModal();


### PR DESCRIPTION
The use of operator names works fine on gcc and clang, but breaks MSVC.  Make
them error on gcc/clang too.

According to this random link, gcc and clang have supported this flag for a
really long time, so it shouldn't need an extra compile check:
https://phabricator.kde.org/D3850

Since I've never changed the `configure` file before I wanted to get more eyes on this change, so doing as a PR.

Background: My last PR (#2214) contained an `and`, which worked on all the buildbots, but broke when someone tried to compile with MSVC.  This should avoid similar breakage in the future.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
