### PR TITLE
Add support for MSVC AArch64 and vcpkg

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,4 +19,5 @@
     SpacesInAngles: false,
     SpacesInParentheses: false,
     SpacesInSquareBrackets: false,
+    Standard: c++03,
 }

--- a/audio/decoders/flac.cpp
+++ b/audio/decoders/flac.cpp
@@ -355,8 +355,7 @@ int FLACStream::readBuffer(int16 *buffer, const int numSamples) {
 		break;
 	default:
 		decoderOk = false;
-		warning("FLACStream: An error occurred while decoding. DecoderState is: %s",
-			FLAC__StreamDecoderStateString[getStreamDecoderState()]);
+		warning("FLACStream: An error occurred while decoding. DecoderState is: %d", getStreamDecoderState());
 	}
 
 	// Compute how many samples we actually produced
@@ -668,8 +667,7 @@ inline void FLACStream::callbackMetadata(const ::FLAC__StreamMetadata *metadata)
 }
 inline void FLACStream::callbackError(::FLAC__StreamDecoderErrorStatus status) {
 	// some of these are non-critical-Errors
-	debug(1, "FLACStream: An error occurred while decoding. DecoderState is: %s",
-			FLAC__StreamDecoderErrorStatusString[status]);
+	debug(1, "FLACStream: An error occurred while decoding. DecoderStateError is: %d", status);
 }
 
 /* Static Callback Wrappers */

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -457,7 +457,8 @@
 		  defined(_M_X64) || \
 		  defined(__ppc64__) || \
 		  defined(__powerpc64__) || \
-		  defined(__LP64__)
+		  defined(__LP64__) || \
+		  defined(_M_ARM64)
 
 typedef uint64 uintptr;
 

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1201,8 +1201,12 @@ StringList getFeatureLibraries(const FeatureList &features) {
 	StringList libraries;
 
 	for (FeatureList::const_iterator i = features.begin(); i != features.end(); ++i) {
-		libraries.merge(getFeatureLibraries(*i));
+		StringList fl = getFeatureLibraries(*i);
+		for (StringList::const_iterator flit = fl.begin(); flit != fl.end(); ++flit) {
+			libraries.push_back(*flit);
+		}
 	}
+	libraries.sort();
 
 	return libraries;
 }
@@ -1227,7 +1231,8 @@ bool getFeatureBuildState(const std::string &name, FeatureList &features) {
 }
 
 BuildSetup removeFeatureFromSetup(BuildSetup setup, const std::string &feature) {
-	for (FeatureList::const_iterator i = setup.features.begin(); i != setup.features.end(); ++i) {
+	// TODO: use const_iterator in C++11
+	for (FeatureList::iterator i = setup.features.begin(); i != setup.features.end(); ++i) {
 		if (i->enable && feature == i->name) {
 			StringList feature_libs = getFeatureLibraries(*i);
 			for (StringList::iterator lib = feature_libs.begin(); lib != feature_libs.end(); ++lib) {

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1195,6 +1195,9 @@ StringList getFeatureLibraries(const Feature &feature) {
 		StringList fLibraries = tokenize(feature.libraries);
 		libraries.splice(libraries.end(), fLibraries);
 	}
+	// The libraries get sorted as they can get used in algorithms where ordering is a
+	// precondition, e.g. merge()
+	libraries.sort();
 
 	return libraries;
 }

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -283,6 +283,8 @@ int main(int argc, char *argv[]) {
 			setup.tests = true;
 		} else if (!std::strcmp(argv[i], "--sdl1")) {
 			setup.useSDL2 = false;
+		} else if (!std::strcmp(argv[i], "--use-canonical-lib-names")) {
+			setup.useCanonicalLibNames = true;
 		} else {
 			std::cerr << "ERROR: Unknown parameter \"" << argv[i] << "\"\n";
 			return -1;
@@ -429,6 +431,12 @@ int main(int argc, char *argv[]) {
 		// to replicate this behavior.
 		setup.defines.push_back("USE_SDL2");
 		setup.libraries.push_back("sdl2");
+	}
+
+	if (setup.useCanonicalLibNames) {
+		for (auto& lib : setup.libraries) {
+			lib = getCanonicalLibName(lib);
+		}
 	}
 
 	// Add additional project-specific library
@@ -704,49 +712,52 @@ void displayHelp(const char *exe) {
 	        " Additionally there are the following switches for changing various settings:\n"
 	        "\n"
 	        "Project specific settings:\n"
-	        " --cmake                  build CMake project files\n"
-	        " --codeblocks             build Code::Blocks project files\n"
-	        " --msvc                   build Visual Studio project files\n"
-	        " --xcode                  build XCode project files\n"
-	        " --file-prefix prefix     allow overwriting of relative file prefix in the\n"
-	        "                          MSVC project files. By default the prefix is the\n"
-	        "                          \"path\\to\\source\" argument\n"
-	        " --output-dir path        overwrite path, where the project files are placed\n"
-	        "                          By default this is \".\", i.e. the current working\n"
-	        "                          directory\n"
+	        " --cmake                    build CMake project files\n"
+	        " --codeblocks               build Code::Blocks project files\n"
+	        " --msvc                     build Visual Studio project files\n"
+	        " --xcode                    build XCode project files\n"
+	        " --file-prefix prefix       allow overwriting of relative file prefix in the\n"
+	        "                            MSVC project files. By default the prefix is the\n"
+	        "                            \"path\\to\\source\" argument\n"
+	        " --output-dir path          overwrite path, where the project files are placed\n"
+	        "                            By default this is \".\", i.e. the current working\n"
+	        "                            directory\n"
 	        "\n"
 	        "MSVC specific settings:\n"
-	        " --msvc-version version   set the targeted MSVC version. Possible values:\n";
+	        " --msvc-version version     set the targeted MSVC version. Possible values:\n";
 
 	const MSVCList msvc = getAllMSVCVersions();
 	for (MSVCList::const_iterator i = msvc.begin(); i != msvc.end(); ++i)
 		cout << "                           " << i->version << " stands for \"" << i->name << "\"\n";
 
-	cout << "                           If no version is set, the latest installed version is used\n"
-	        " --build-events           Run custom build events as part of the build\n"
-	        "                          (default: false)\n"
-	        " --installer              Create installer after the build (implies --build-events)\n"
-	        "                          (default: false)\n"
-	        " --tools                  Create project files for the devtools\n"
-	        "                          (ignores --build-events and --installer, as well as engine settings)\n"
-	        "                          (default: false)\n"
-	        " --tests                  Create project files for the tests\n"
-	        "                          (ignores --build-events and --installer, as well as engine settings)\n"
-	        "                          (default: false)\n"
+	cout << "                            If no version is set, the latest installed version is used\n"
+	        " --build-events             Run custom build events as part of the build\n"
+	        "                            (default: false)\n"
+	        " --installer                Create installer after the build (implies --build-events)\n"
+	        "                            (default: false)\n"
+	        " --tools                    Create project files for the devtools\n"
+	        "                            (ignores --build-events and --installer, as well as engine settings)\n"
+	        "                            (default: false)\n"
+	        " --tests                    Create project files for the tests\n"
+	        "                            (ignores --build-events and --installer, as well as engine settings)\n"
+	        "                            (default: false)\n"
+            " --use-canonical-lib-names  Use canonical library names for linking. This makes it easy to use\n"
+            "                            e.g. vcpkg-provided libraries\n"
+	        "                            (default: false)\n"
 	        "\n"
 	        "Engines settings:\n"
-	        " --list-engines           list all available engines and their default state\n"
-	        " --enable-engine=<name>   enable building of the engine with the name \"name\"\n"
-	        " --disable-engine=<name>  disable building of the engine with the name \"name\"\n"
-	        " --enable-all-engines     enable building of all engines\n"
-	        " --disable-all-engines    disable building of all engines\n"
+	        " --list-engines             list all available engines and their default state\n"
+	        " --enable-engine=<name>     enable building of the engine with the name \"name\"\n"
+	        " --disable-engine=<name>    disable building of the engine with the name \"name\"\n"
+	        " --enable-all-engines       enable building of all engines\n"
+	        " --disable-all-engines      disable building of all engines\n"
 	        "\n"
 	        "Optional features settings:\n"
-	        " --enable-<name>          enable inclusion of the feature \"name\"\n"
-	        " --disable-<name>         disable inclusion of the feature \"name\"\n"
+	        " --enable-<name>            enable inclusion of the feature \"name\"\n"
+	        " --disable-<name>           disable inclusion of the feature \"name\"\n"
 	        "\n"
 	        "SDL settings:\n"
-	        " --sdl1                   link to SDL 1.2, instead of SDL 2.0\n"
+	        " --sdl1                     link to SDL 1.2, instead of SDL 2.0\n"
 	        "\n"
 	        " There are the following features available:\n"
 	        "\n";
@@ -1111,7 +1122,30 @@ const MSVCVersion s_msvc[] = {
 	{ 15,    "Visual Studio 2017",    "12.00",            "15",    "15.0",    "v141",    "llvm"        },
 	{ 16,    "Visual Studio 2019",    "12.00",    "Version 16",    "16.0",    "v142",    "llvm"        }
 };
+
+const std::map<std::string, std::string> s_canonical_lib_name_map = {
+	{ "jpeg-static", "jpeg" },
+	{ "libfaad", "faad" },
+	{ "libFLAC_static", "FLAC" },
+	{ "libfluidsynth", "fluidsynth" },
+	{ "libmad", "mad" },
+	{ "libmpeg2", "mpeg2" },
+	{ "libogg_static", "ogg" },
+	{ "libtheora_static", "theora" },
+	{ "libvorbis_static", "vorbis" },
+	{ "libvorbisfile_static", "vorbisfile" },
+	{ "SDL_net", "SDL2_net" }, // Only support SDL2
+	{ "win_utf8_io_static", "FLAC" }, // This is some FLAC-specific library not needed with vcpkg, but as there's '.lib' appended to each library, we can't set it to empty, so set it to FLAC again instead
+};
 } // End of anonymous namespace
+
+std::string getCanonicalLibName(std::string lib) {
+	auto it = s_canonical_lib_name_map.find(lib);
+	if (it != s_canonical_lib_name_map.end()) {
+		return it->second;
+	}
+	return lib;
+}
 
 FeatureList getAllFeatures() {
 	const size_t featureCount = sizeof(s_features) / sizeof(s_features[0]);

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <iterator>
+#include <utility>
 
 #include <cstring>
 #include <cstdlib>
@@ -1123,46 +1124,40 @@ const MSVCVersion s_msvc[] = {
 	{ 16,    "Visual Studio 2019",    "12.00",    "Version 16",    "16.0",    "v142",    "llvm"        }
 };
 
-const std::map<std::string, std::string> s_canonical_lib_name_map = {
-	{ "jpeg-static", "jpeg" },
-	{ "libfaad", "faad" },
-	{ "libFLAC_static", "FLAC" },
-	{ "libfluidsynth", "fluidsynth" },
-	{ "libmad", "mad" },
-	{ "libmpeg2", "mpeg2" },
-	{ "libogg_static", "ogg" },
-	{ "libtheora_static", "theora" },
-	{ "libvorbis_static", "vorbis" },
-	{ "libvorbisfile_static", "vorbisfile" },
-	{ "SDL_net", "SDL2_net" }, // Only support SDL2
-	{ "win_utf8_io_static", "FLAC" }, // This is some FLAC-specific library not needed with vcpkg, but as there's '.lib' appended to each library, we can't set it to empty, so set it to FLAC again instead
+const std::pair<std::string, std::string> s_canonical_lib_name_map[] = {
+	std::make_pair("jpeg-static", "jpeg"),
+	std::make_pair("libfaad", "faad"),
+	std::make_pair("libFLAC_static", "FLAC"),
+	std::make_pair("libfluidsynth", "fluidsynth"),
+	std::make_pair("libmad", "mad"),
+	std::make_pair("libmpeg2", "mpeg2"),
+	std::make_pair("libogg_static", "ogg"),
+	std::make_pair("libtheora_static", "theora"),
+	std::make_pair("libvorbis_static", "vorbis"),
+	std::make_pair("libvorbisfile_static", "vorbisfile"),
+	std::make_pair("SDL_net", "SDL2_net"), // Only support SDL2
+	std::make_pair("win_utf8_io_static", "FLAC") // This is some FLAC-specific library not needed with vcpkg, but as there's '.lib' appended to each library, we can't set it to empty, so set it to FLAC again instead
 };
 
-const std::map<MSVC_Architecture, std::string> s_msvc_arch_names = {
-	{ MSVC_Architecture::ARCH_ARM64, "arm64" },
-	{   MSVC_Architecture::ARCH_X86,   "x86" },
-	{ MSVC_Architecture::ARCH_AMD64,   "x64" },
-};
-
-const std::map<MSVC_Architecture, std::string> s_msvc_config_names = {
-	{ MSVC_Architecture::ARCH_ARM64, "arm64" },
-	{   MSVC_Architecture::ARCH_X86, "Win32" },
-	{ MSVC_Architecture::ARCH_AMD64,   "x64" },
-};
+const char *s_msvc_arch_names[] = {"arm64", "x86", "x64"};
+const char *s_msvc_config_names[] = {"arm64", "Win32", "x64"};
 } // End of anonymous namespace
 
 std::string getMSVCArchName(MSVC_Architecture arch) {
-	return s_msvc_arch_names.at(arch);
+	return s_msvc_arch_names[arch];
 }
 
 std::string getMSVCConfigName(MSVC_Architecture arch) {
-	return s_msvc_config_names.at(arch);
+	return s_msvc_config_names[arch];
 }
 
-std::string getCanonicalLibName(std::string lib) {
-	std::map<std::string, std::string>::const_iterator it = s_canonical_lib_name_map.find(lib);
-	if (it != s_canonical_lib_name_map.cend()) {
-		return it->second;
+std::string getCanonicalLibName(const std::string &lib) {
+	const size_t libCount = sizeof(s_canonical_lib_name_map) / sizeof(s_canonical_lib_name_map[0]);
+
+	for (size_t i = 0; i < libCount; ++i) {
+		if (s_canonical_lib_name_map[i].first == lib) {
+			return s_canonical_lib_name_map[i].second;
+		}
 	}
 	return lib;
 }

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -434,8 +434,8 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (setup.useCanonicalLibNames) {
-		for (auto& lib : setup.libraries) {
-			lib = getCanonicalLibName(lib);
+		for (StringList::iterator lib = setup.libraries.begin(); lib != setup.libraries.end(); ++lib) {
+			*lib = getCanonicalLibName(*lib);
 		}
 	}
 
@@ -741,8 +741,8 @@ void displayHelp(const char *exe) {
 	        " --tests                    Create project files for the tests\n"
 	        "                            (ignores --build-events and --installer, as well as engine settings)\n"
 	        "                            (default: false)\n"
-            " --use-canonical-lib-names  Use canonical library names for linking. This makes it easy to use\n"
-            "                            e.g. vcpkg-provided libraries\n"
+	        " --use-canonical-lib-names  Use canonical library names for linking. This makes it easy to use\n"
+	        "                            e.g. vcpkg-provided libraries\n"
 	        "                            (default: false)\n"
 	        "\n"
 	        "Engines settings:\n"
@@ -1160,8 +1160,8 @@ std::string getMSVCConfigName(MSVC_Architecture arch) {
 }
 
 std::string getCanonicalLibName(std::string lib) {
-	auto it = s_canonical_lib_name_map.find(lib);
-	if (it != s_canonical_lib_name_map.end()) {
+	std::map<std::string, std::string>::const_iterator it = s_canonical_lib_name_map.find(lib);
+	if (it != s_canonical_lib_name_map.cend()) {
 		return it->second;
 	}
 	return lib;
@@ -1234,12 +1234,12 @@ bool getFeatureBuildState(const std::string &name, FeatureList &features) {
 BuildSetup removeFeatureFromSetup(BuildSetup setup, const std::string &feature) {
 	for (FeatureList::const_iterator i = setup.features.begin(); i != setup.features.end(); ++i) {
 		if (i->enable && feature == i->name) {
-			StringList fribidi_libs = getFeatureLibraries(*i);
-			for (auto& lib : fribidi_libs) {
+			StringList feature_libs = getFeatureLibraries(*i);
+			for (StringList::iterator lib = feature_libs.begin(); lib != feature_libs.end(); ++lib) {
 				if (setup.useCanonicalLibNames) {
-					lib = getCanonicalLibName(lib);
+					*lib = getCanonicalLibName(*lib);
 				}
-				setup.libraries.remove(lib);
+				setup.libraries.remove(*lib);
 			}
 			if (i->define && i->define[0]) {
 				setup.defines.remove(i->define);

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1137,7 +1137,27 @@ const std::map<std::string, std::string> s_canonical_lib_name_map = {
 	{ "SDL_net", "SDL2_net" }, // Only support SDL2
 	{ "win_utf8_io_static", "FLAC" }, // This is some FLAC-specific library not needed with vcpkg, but as there's '.lib' appended to each library, we can't set it to empty, so set it to FLAC again instead
 };
+
+const std::map<MSVC_Architecture, std::string> s_msvc_arch_names = {
+	{ MSVC_Architecture::ARCH_ARM64, "arm64" },
+	{   MSVC_Architecture::ARCH_X86,   "x86" },
+	{ MSVC_Architecture::ARCH_AMD64,   "x64" },
+};
+
+const std::map<MSVC_Architecture, std::string> s_msvc_config_names = {
+	{ MSVC_Architecture::ARCH_ARM64, "arm64" },
+	{   MSVC_Architecture::ARCH_X86, "Win32" },
+	{ MSVC_Architecture::ARCH_AMD64,   "x64" },
+};
 } // End of anonymous namespace
+
+std::string getMSVCArchName(MSVC_Architecture arch) {
+	return s_msvc_arch_names.at(arch);
+}
+
+std::string getMSVCConfigName(MSVC_Architecture arch) {
+	return s_msvc_config_names.at(arch);
+}
 
 std::string getCanonicalLibName(std::string lib) {
 	auto it = s_canonical_lib_name_map.find(lib);

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -28,27 +28,27 @@
 #undef main
 #endif // main
 
-#include "config.h"
 #include "create_project.h"
+#include "config.h"
 
 #include "cmake.h"
 #include "codeblocks.h"
+#include "msbuild.h"
 #include "msvc.h"
 #include "visualstudio.h"
-#include "msbuild.h"
 #include "xcode.h"
 
+#include <algorithm>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <sstream>
 #include <stack>
-#include <algorithm>
-#include <iomanip>
-#include <iterator>
 #include <utility>
 
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 
 #if (defined(_WIN32) || defined(WIN32)) && !defined(__GNUC__)
@@ -58,11 +58,11 @@
 #if (defined(_WIN32) || defined(WIN32))
 #include <windows.h>
 #else
+#include <dirent.h>
+#include <errno.h>
 #include <sstream>
 #include <sys/param.h>
 #include <sys/stat.h>
-#include <dirent.h>
-#include <errno.h>
 #endif
 
 namespace {
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
 	setup.features = getAllFeatures();
 
 	ProjectType projectType = kProjectNone;
-	const MSVCVersion* msvc = NULL;
+	const MSVCVersion *msvc = NULL;
 	int msvcVersion = 0;
 
 	// Parse command line arguments
@@ -142,7 +142,7 @@ int main(int argc, char *argv[]) {
 	for (int i = 2; i < argc; ++i) {
 		if (!std::strcmp(argv[i], "--list-engines")) {
 			cout << " The following enables are available in the " PROJECT_DESCRIPTION " source distribution\n"
-			        " located at \"" << srcDir << "\":\n";
+			     << " located at \"" << srcDir << "\":\n";
 
 			cout << "   state  |       name      |     description\n\n";
 			cout.setf(std::ios_base::left, std::ios_base::adjustfield);
@@ -276,7 +276,7 @@ int main(int argc, char *argv[]) {
 		} else if (!std::strcmp(argv[i], "--build-events")) {
 			setup.runBuildEvents = true;
 		} else if (!std::strcmp(argv[i], "--installer")) {
-			setup.runBuildEvents  = true;
+			setup.runBuildEvents = true;
 			setup.createInstaller = true;
 		} else if (!std::strcmp(argv[i], "--tools")) {
 			setup.devTools = true;
@@ -484,7 +484,6 @@ int main(int argc, char *argv[]) {
 
 		provider = new CreateProjectTool::CodeBlocksProvider(globalWarnings, projectWarnings);
 
-
 		// Those libraries are automatically added by MSVC, but we need to add them manually with mingw
 		setup.libraries.push_back("ole32");
 		setup.libraries.push_back("uuid");
@@ -674,11 +673,11 @@ int main(int argc, char *argv[]) {
 	}
 
 	// Setup project name and description
-	setup.projectName        = PROJECT_NAME;
+	setup.projectName = PROJECT_NAME;
 	setup.projectDescription = PROJECT_DESCRIPTION;
 
 	if (setup.devTools) {
-		setup.projectName        += "-tools";
+		setup.projectName += "-tools";
 		setup.projectDescription += "Tools";
 	}
 
@@ -964,9 +963,12 @@ bool parseEngine(const std::string &line, EngineDesc &engine) {
 		return false;
 	++token;
 
-	engine.name = *token; ++token;
-	engine.desc = *token; ++token;
-	engine.enable = (*token == "yes"); ++token;
+	engine.name = *token;
+	++token;
+	engine.desc = *token;
+	++token;
+	engine.enable = (*token == "yes");
+	++token;
 	if (token != tokens.end()) {
 		engine.subEngines = tokenize(*token);
 		++token;
@@ -1055,6 +1057,7 @@ TokenList tokenize(const std::string &input, char separator) {
 }
 
 namespace {
+// clang-format off
 const Feature s_features[] = {
 	// Libraries
 	{      "libz",        "USE_ZLIB", "zlib",             true,  "zlib (compression) support" },
@@ -1141,6 +1144,7 @@ const std::pair<std::string, std::string> s_canonical_lib_name_map[] = {
 
 const char *s_msvc_arch_names[] = {"arm64", "x86", "x64"};
 const char *s_msvc_config_names[] = {"arm64", "Win32", "x64"};
+// clang-format on
 } // End of anonymous namespace
 
 std::string getMSVCArchName(MSVC_Architecture arch) {
@@ -1345,7 +1349,8 @@ void splitFilename(const std::string &fileName, std::string &name, std::string &
 
 std::string basename(const std::string &fileName) {
 	const std::string::size_type slash = fileName.find_last_of('/');
-	if (slash == std::string::npos) return fileName;
+	if (slash == std::string::npos)
+		return fileName;
 	return fileName.substr(slash + 1);
 }
 
@@ -1505,7 +1510,6 @@ void createDirectory(const std::string &dir) {
 		}
 	}
 #endif
-
 }
 
 /**
@@ -1570,7 +1574,7 @@ FileNode *scanFiles(const std::string &dir, const StringList &includeList, const
 // Project Provider methods
 //////////////////////////////////////////////////////////////////////////
 ProjectProvider::ProjectProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version)
-	: _version(version), _globalWarnings(global_warnings), _projectWarnings(project_warnings) {
+    : _version(version), _globalWarnings(global_warnings), _projectWarnings(project_warnings) {
 }
 
 void ProjectProvider::createProject(BuildSetup &setup) {
@@ -1596,7 +1600,8 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 		if (i->first == setup.projectName)
 			continue;
 		// Retain the files between engines if we're creating a single project
-		in.clear(); ex.clear();
+		in.clear();
+		ex.clear();
 
 		const std::string moduleDir = setup.srcDir + targetFolder + i->first;
 
@@ -1606,7 +1611,8 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 
 	if (setup.tests) {
 		// Create the main project file.
-		in.clear(); ex.clear();
+		in.clear();
+		ex.clear();
 		createModuleList(setup.srcDir + "/backends", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/backends/platform/sdl", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/base", setup.defines, setup.testDirs, in, ex);
@@ -1620,7 +1626,8 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 		createProjectFile(setup.projectName, svmUUID, setup, setup.srcDir, in, ex);
 	} else if (!setup.devTools) {
 		// Last but not least create the main project file.
-		in.clear(); ex.clear();
+		in.clear();
+		ex.clear();
 		// File list for the Project file
 		createModuleList(setup.srcDir + "/backends", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/backends/platform/sdl", setup.defines, setup.testDirs, in, ex);
@@ -1713,8 +1720,10 @@ std::string ProjectProvider::createUUID() const {
 	for (int i = 0; i < kUUIDLen; ++i)
 		uuid[i] = (unsigned char)((std::rand() / (double)(RAND_MAX)) * 0xFF);
 
-	uuid[8] &= 0xBF; uuid[8] |= 0x80;
-	uuid[6] &= 0x4F; uuid[6] |= 0x40;
+	uuid[8] &= 0xBF;
+	uuid[8] |= 0x80;
+	uuid[6] &= 0x4F;
+	uuid[6] |= 0x40;
 
 	return UUIDToString(uuid);
 #endif
@@ -1726,7 +1735,7 @@ std::string ProjectProvider::createUUID(const std::string &name) const {
 	if (!CryptAcquireContext(&hProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
 		error("CryptAcquireContext failed");
 	}
-	
+
 	// Use MD5 hashing algorithm
 	HCRYPTHASH hHash = NULL;
 	if (!CryptCreateHash(hProv, CALG_MD5, 0, 0, &hHash)) {
@@ -1736,7 +1745,7 @@ std::string ProjectProvider::createUUID(const std::string &name) const {
 
 	// Hash unique ScummVM namespace {5f5b43e8-35ff-4f1e-ad7e-a2a87e9b5254}
 	const BYTE uuidNs[kUUIDLen] =
-		{ 0x5f, 0x5b, 0x43, 0xe8, 0x35, 0xff, 0x4f, 0x1e, 0xad, 0x7e, 0xa2, 0xa8, 0x7e, 0x9b, 0x52, 0x54 };
+	    {0x5f, 0x5b, 0x43, 0xe8, 0x35, 0xff, 0x4f, 0x1e, 0xad, 0x7e, 0xa2, 0xa8, 0x7e, 0x9b, 0x52, 0x54};
 	if (!CryptHashData(hHash, uuidNs, kUUIDLen, 0)) {
 		CryptDestroyHash(hHash);
 		CryptReleaseContext(hProv, 0);
@@ -1760,8 +1769,10 @@ std::string ProjectProvider::createUUID(const std::string &name) const {
 	}
 
 	// Add version and variant
-	uuid[6] &= 0x0F; uuid[6] |= 0x30;
-	uuid[8] &= 0x3F; uuid[8] |= 0x80;
+	uuid[6] &= 0x0F;
+	uuid[6] |= 0x30;
+	uuid[8] &= 0x3F;
+	uuid[8] |= 0x80;
 
 	CryptDestroyHash(hHash);
 	CryptReleaseContext(hProv, 0);
@@ -1812,7 +1823,8 @@ void ProjectProvider::addFilesToProject(const std::string &dir, std::ofstream &p
 			continue;
 
 		// Search for duplicates
-		StringList::const_iterator j = i; ++j;
+		StringList::const_iterator j = i;
+		++j;
 		for (; j != includeList.end(); ++j) {
 			std::string candidateFileName = getLastPathComponent(*j);
 			std::transform(candidateFileName.begin(), candidateFileName.end(), candidateFileName.begin(), tolower);
@@ -2083,7 +2095,7 @@ void ProjectProvider::createEnginePluginsTable(const BuildSetup &setup) {
 		                   << "#endif\n";
 	}
 }
-} // End of anonymous namespace
+} // namespace CreateProjectTool
 
 void error(const std::string &message) {
 	std::cerr << "ERROR: " << message << "!" << std::endl;

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -304,7 +304,7 @@ struct MSVCVersion {
 };
 typedef std::list<MSVCVersion> MSVCList;
 
-enum class MSVC_Architecture {
+enum MSVC_Architecture {
 	ARCH_ARM64,
 	ARCH_X86,
 	ARCH_AMD64
@@ -341,7 +341,7 @@ int getInstalledMSVC();
  * @param lib The link library as provided by ScummVM libs.
  * @return Canonical link library.
  */
-std::string getCanonicalLibName(std::string lib);
+std::string getCanonicalLibName(const std::string &lib);
 
 /**
  * Removes given feature from setup.

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -206,7 +206,7 @@ StringList getFeatureLibraries(const FeatureList &features);
  *
  * @param features Feature for the build (this may contain features, which are *not* enabled!)
  */
-StringList getFeatureLibraries(const Feature& feature);
+StringList getFeatureLibraries(const Feature &feature);
 
 /**
  * Sets the state of a given feature. This can be used to

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -242,18 +242,20 @@ struct BuildSetup {
 	StringList libraries; ///< List of all external libraries required for the build.
 	StringList testDirs;  ///< List of all folders containing tests
 
-	bool devTools;         ///< Generate project files for the tools
-	bool tests;            ///< Generate project files for the tests
-	bool runBuildEvents;   ///< Run build events as part of the build (generate revision number and copy engine/theme data & needed files to the build folder
-	bool createInstaller;  ///< Create installer after the build
-	bool useSDL2;          ///< Whether to use SDL2 or not.
+	bool devTools;             ///< Generate project files for the tools
+	bool tests;                ///< Generate project files for the tests
+	bool runBuildEvents;       ///< Run build events as part of the build (generate revision number and copy engine/theme data & needed files to the build folder
+	bool createInstaller;      ///< Create installer after the build
+	bool useSDL2;              ///< Whether to use SDL2 or not.
+	bool useCanonicalLibNames; ///< Whether to use canonical libraries names or default ones
 
 	BuildSetup() {
-		devTools        = false;
-		tests           = false;
-		runBuildEvents  = false;
-		createInstaller = false;
-		useSDL2         = true;
+		devTools             = false;
+		tests                = false;
+		runBuildEvents       = false;
+		createInstaller      = false;
+		useSDL2              = true;
+		useCanonicalLibNames = false;
 	}
 };
 
@@ -315,6 +317,14 @@ const MSVCVersion *getMSVCVersion(int version);
  * @return Version number, or 0 if no installations were found.
  */
 int getInstalledMSVC();
+
+/**
+ * Return a "canonical" library name, so it is easier to integrate other providers of dependencies.
+ *
+ * @param lib The link library as provided by ScummVM libs.
+ * @return Canonical link library.
+ */
+std::string getCanonicalLibName(std::string lib);
 
 namespace CreateProjectTool {
 

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -201,6 +201,14 @@ StringList getFeatureDefines(const FeatureList &features);
 StringList getFeatureLibraries(const FeatureList &features);
 
 /**
+ * Returns a list of all external library files, according to the
+ * feature passed.
+ *
+ * @param features Feature for the build (this may contain features, which are *not* enabled!)
+ */
+StringList getFeatureLibraries(const Feature& feature);
+
+/**
  * Sets the state of a given feature. This can be used to
  * either include or exclude an feature.
  *
@@ -325,6 +333,15 @@ int getInstalledMSVC();
  * @return Canonical link library.
  */
 std::string getCanonicalLibName(std::string lib);
+
+/**
+ * Removes given feature from setup.
+ *
+ * @param setup The setup to be processed.
+ * @param feature The feature to be removed
+ * @return A copy of setup less feature.
+ */
+BuildSetup removeFeatureFromSetup(BuildSetup setup, const std::string &feature);
 
 namespace CreateProjectTool {
 

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -304,6 +304,15 @@ struct MSVCVersion {
 };
 typedef std::list<MSVCVersion> MSVCList;
 
+enum class MSVC_Architecture {
+	ARCH_ARM64,
+	ARCH_X86,
+	ARCH_AMD64
+};
+
+std::string getMSVCArchName(MSVC_Architecture arch);
+std::string getMSVCConfigName(MSVC_Architecture arch);
+
 /**
  * Creates a list of all supported versions of Visual Studio.
  *

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -23,12 +23,12 @@
 #ifndef TOOLS_CREATE_PROJECT_H
 #define TOOLS_CREATE_PROJECT_H
 
-#ifndef __has_feature       // Optional of course.
-#define __has_feature(x) 0  // Compatibility with non-clang compilers.
+#ifndef __has_feature      // Optional of course.
+#define __has_feature(x) 0 // Compatibility with non-clang compilers.
 #endif
 
-#include <map>
 #include <list>
+#include <map>
 #include <string>
 
 #include <cassert>
@@ -156,12 +156,12 @@ StringList getEngineDefines(const EngineDescList &engines);
  * used to build ScummVM.
  */
 struct Feature {
-	const char *name;        ///< Name of the feature
-	const char *define;      ///< Define of the feature
+	const char *name;   ///< Name of the feature
+	const char *define; ///< Define of the feature
 
-	const char *libraries;   ///< Libraries, which need to be linked, for the feature
+	const char *libraries; ///< Libraries, which need to be linked, for the feature
 
-	bool enable;             ///< Whether the feature is enabled or not
+	bool enable; ///< Whether the feature is enabled or not
 
 	const char *description; ///< Human readable description of the feature
 
@@ -172,8 +172,8 @@ struct Feature {
 typedef std::list<Feature> FeatureList;
 
 struct Tool {
-	const char *name;        ///< Name of the tools
-	bool enable;             ///< Whether the tools is enabled or not
+	const char *name; ///< Name of the tools
+	bool enable;      ///< Whether the tools is enabled or not
 };
 typedef std::list<Tool> ToolList;
 
@@ -236,8 +236,8 @@ bool getFeatureBuildState(const std::string &name, FeatureList &features);
  * It also contains the path to the project source root.
  */
 struct BuildSetup {
-	std::string projectName;         ///< Project name
-	std::string projectDescription;  ///< Project description
+	std::string projectName;        ///< Project name
+	std::string projectDescription; ///< Project description
 
 	std::string srcDir;     ///< Path to the sources.
 	std::string filePrefix; ///< Prefix for the relative path arguments in the project files.
@@ -258,11 +258,11 @@ struct BuildSetup {
 	bool useCanonicalLibNames; ///< Whether to use canonical libraries names or default ones
 
 	BuildSetup() {
-		devTools             = false;
-		tests                = false;
-		runBuildEvents       = false;
-		createInstaller      = false;
-		useSDL2              = true;
+		devTools = false;
+		tests = false;
+		runBuildEvents = false;
+		createInstaller = false;
+		useSDL2 = true;
 		useCanonicalLibNames = false;
 	}
 };
@@ -273,17 +273,17 @@ struct BuildSetup {
  * @param message The error message to print to stderr.
  */
 #if defined(__GNUC__)
-	#define NORETURN_POST __attribute__((__noreturn__))
+#define NORETURN_POST __attribute__((__noreturn__))
 #elif defined(_MSC_VER)
-	#define NORETURN_PRE __declspec(noreturn)
+#define NORETURN_PRE __declspec(noreturn)
 #endif
 
 #ifndef NORETURN_PRE
-#define	NORETURN_PRE
+#define NORETURN_PRE
 #endif
 
 #ifndef NORETURN_POST
-#define	NORETURN_POST
+#define NORETURN_POST
 #endif
 void NORETURN_PRE error(const std::string &message) NORETURN_POST;
 
@@ -500,11 +500,11 @@ public:
 	static std::string getLastPathComponent(const std::string &path);
 
 protected:
-	const int _version;                                      ///< Target project version
-	StringList &_globalWarnings;                             ///< Global warnings
-	std::map<std::string, StringList> &_projectWarnings;     ///< Per-project warnings
+	const int _version;                                  ///< Target project version
+	StringList &_globalWarnings;                         ///< Global warnings
+	std::map<std::string, StringList> &_projectWarnings; ///< Per-project warnings
 
-	UUIDMap _uuidMap;                                        ///< List of (project name, UUID) pairs
+	UUIDMap _uuidMap; ///< List of (project name, UUID) pairs
 
 	/**
 	 *  Create workspace/solution file
@@ -626,7 +626,6 @@ protected:
 	std::string createUUID(const std::string &name) const;
 
 private:
-
 	/**
 	 * Returns the string representation of an existing UUID.
 	 *
@@ -644,6 +643,6 @@ private:
 	void createEnginePluginsTable(const BuildSetup &setup);
 };
 
-} // End of CreateProjectTool namespace
+} // namespace CreateProjectTool
 
 #endif // TOOLS_CREATE_PROJECT_H

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -25,7 +25,6 @@
 
 #include <fstream>
 #include <algorithm>
-#include <array>
 
 namespace CreateProjectTool {
 
@@ -81,7 +80,10 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 	           "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
 	           "\t<ItemGroup Label=\"ProjectConfigurations\">\n";
 
-	std::array<MSVC_Architecture, 3> archs{ MSVC_Architecture::ARCH_X86, MSVC_Architecture::ARCH_AMD64, MSVC_Architecture::ARCH_ARM64 };
+	std::list<MSVC_Architecture> archs;
+	archs.push_back(MSVC_Architecture::ARCH_X86);
+	archs.push_back(MSVC_Architecture::ARCH_AMD64);
+	archs.push_back(MSVC_Architecture::ARCH_ARM64);
 
 	for (const auto& arch : archs) {
 		// NOTE: different order

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -77,8 +77,10 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
                                         const StringList &includeList, const StringList &excludeList) {
 	const std::string projectFile = setup.outputDir + '/' + name + getProjectExtension();
 	std::ofstream project(projectFile.c_str());
-	if (!project)
+	if (!project || !project.is_open()) {
 		error("Could not open \"" + projectFile + "\" for writing");
+		return;
+	}
 
 	project << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 	           "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
@@ -207,8 +209,10 @@ void MSBuildProvider::createFiltersFile(const BuildSetup &setup, const std::stri
 
 	const std::string filtersFile = setup.outputDir + '/' + name + getProjectExtension() + ".filters";
 	std::ofstream filters(filtersFile.c_str());
-	if (!filters)
+	if (!filters || !filters.is_open()) {
 		error("Could not open \"" + filtersFile + "\" for writing");
+		return;
+	}
 
 	filters << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 	           "<Project ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n";
@@ -398,8 +402,10 @@ void MSBuildProvider::createBuildProp(const BuildSetup &setup, bool isRelease, M
 	const std::string outputBitness = (arch == ARCH_X86 ? "32" : "64");
 
 	std::ofstream properties((setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCArchName(arch) + getPropertiesExtension()).c_str());
-	if (!properties)
+	if (!properties || !properties.is_open()) {
 		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCArchName(arch) + getPropertiesExtension() + "\" for writing");
+		return;
+	}
 
 	properties << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 	              "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -35,7 +35,6 @@ namespace CreateProjectTool {
 MSBuildProvider::MSBuildProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion& msvc)
 	: MSVCProvider(global_warnings, project_warnings, version, msvc) {
 
-	// NOTE: different order
 	_archs.push_back(ARCH_X86);
 	_archs.push_back(ARCH_AMD64);
 	_archs.push_back(ARCH_ARM64);
@@ -85,23 +84,23 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 	           "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
 	           "\t<ItemGroup Label=\"ProjectConfigurations\">\n";
 
-	for (std::list<MSVC_Architecture>::const_iterator i = _archs.begin(); i != _archs.end(); ++i) {
-		outputConfiguration(project, "Debug", getMSVCConfigName(*i));
-		outputConfiguration(project, "Analysis", getMSVCConfigName(*i));
-		outputConfiguration(project, "LLVM", getMSVCConfigName(*i));
-		outputConfiguration(project, "Release", getMSVCConfigName(*i));
+	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
+		outputConfiguration(project, "Debug", getMSVCConfigName(*arch));
+		outputConfiguration(project, "Analysis", getMSVCConfigName(*arch));
+		outputConfiguration(project, "LLVM", getMSVCConfigName(*arch));
+		outputConfiguration(project, "Release", getMSVCConfigName(*arch));
 	}
 	project << "\t</ItemGroup>\n";
 
 	// Project name & Guid
 	project << "\t<PropertyGroup Label=\"Globals\">\n"
-		"\t\t<ProjectGuid>{" << uuid << "}</ProjectGuid>\n"
-		"\t\t<RootNamespace>" << name << "</RootNamespace>\n"
-		"\t\t<Keyword>Win32Proj</Keyword>\n"
-		"\t\t<VCTargetsPath Condition=\"'$(VCTargetsPath" << _version << ")' != '' and '$(VSVersion)' == '' and $(VisualStudioVersion) == ''\">$(VCTargetsPath" << _version << ")</VCTargetsPath>\n";
+			   "\t\t<ProjectGuid>{" << uuid << "}</ProjectGuid>\n"
+			   "\t\t<RootNamespace>" << name << "</RootNamespace>\n"
+			   "\t\t<Keyword>Win32Proj</Keyword>\n"
+			   "\t\t<VCTargetsPath Condition=\"'$(VCTargetsPath" << _version << ")' != '' and '$(VSVersion)' == '' and $(VisualStudioVersion) == ''\">$(VCTargetsPath" << _version << ")</VCTargetsPath>\n";
 
-	for (std::list<MSVC_Architecture>::const_iterator i = _archs.begin(); i != _archs.end(); ++i) {
-		project << "\t\t<VcpkgTriplet Condition=\"'$(Platform)' == '" << getMSVCConfigName(*i) << "'\">" << getMSVCArchName(*i) << "-windows</VcpkgTriplet>";
+	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
+		project << "\t\t<VcpkgTriplet Condition=\"'$(Platform)' == '" << getMSVCConfigName(*arch) << "'\">" << getMSVCArchName(*arch) << "-windows</VcpkgTriplet>";
 	}
 
 	project << "\t</PropertyGroup>\n";
@@ -109,39 +108,39 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 	// Shared configuration
 	project << "\t<Import Project=\"$(VCTargetsPath)\\Microsoft.Cpp.Default.props\" />\n";
 
-	for (std::list<MSVC_Architecture>::const_iterator i = _archs.begin(); i != _archs.end(); ++i) {
-		outputConfigurationType(setup, project, name, "Release|" + getMSVCConfigName(*i), _msvcVersion.toolsetMSVC);
-		outputConfigurationType(setup, project, name, "Analysis" + getMSVCConfigName(*i), _msvcVersion.toolsetMSVC);
-		outputConfigurationType(setup, project, name, "LLVM|" + getMSVCConfigName(*i), _msvcVersion.toolsetLLVM);
-		outputConfigurationType(setup, project, name, "Debug|" + getMSVCConfigName(*i), _msvcVersion.toolsetMSVC);
+	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
+		outputConfigurationType(setup, project, name, "Release|" + getMSVCConfigName(*arch), _msvcVersion.toolsetMSVC);
+		outputConfigurationType(setup, project, name, "Analysis" + getMSVCConfigName(*arch), _msvcVersion.toolsetMSVC);
+		outputConfigurationType(setup, project, name, "LLVM|" + getMSVCConfigName(*arch), _msvcVersion.toolsetLLVM);
+		outputConfigurationType(setup, project, name, "Debug|" + getMSVCConfigName(*arch), _msvcVersion.toolsetMSVC);
 	}
 
 	project << "\t<Import Project=\"$(VCTargetsPath)\\Microsoft.Cpp.props\" />\n"
 	           "\t<ImportGroup Label=\"ExtensionSettings\">\n"
 	           "\t</ImportGroup>\n";
 
-	for (std::list<MSVC_Architecture>::const_iterator i = _archs.begin(); i != _archs.end(); ++i) {
-		outputProperties(project, "Release|" + getMSVCConfigName(*i), setup.projectDescription + "_Release" + getMSVCArchName(*i) + ".props");
-		outputProperties(project, "Analysis|" + getMSVCConfigName(*i), setup.projectDescription + "_Analysis" + getMSVCArchName(*i) + ".props");
-		outputProperties(project, "LLVM|" + getMSVCConfigName(*i), setup.projectDescription + "_LLVM" + getMSVCArchName(*i) + ".props");
-		outputProperties(project, "Debug|" + getMSVCConfigName(*i), setup.projectDescription + "_Debug" + getMSVCArchName(*i) + ".props");
+	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
+		outputProperties(project, "Release|" + getMSVCConfigName(*arch), setup.projectDescription + "_Release" + getMSVCArchName(*arch) + ".props");
+		outputProperties(project, "Analysis|" + getMSVCConfigName(*arch), setup.projectDescription + "_Analysis" + getMSVCArchName(*arch) + ".props");
+		outputProperties(project, "LLVM|" + getMSVCConfigName(*arch), setup.projectDescription + "_LLVM" + getMSVCArchName(*arch) + ".props");
+		outputProperties(project, "Debug|" + getMSVCConfigName(*arch), setup.projectDescription + "_Debug" + getMSVCArchName(*arch) + ".props");
 	}
 
 	project << "\t<PropertyGroup Label=\"UserMacros\" />\n";
 
 	// Project-specific settings (analysis uses debug properties)
-	for (std::list<MSVC_Architecture>::const_iterator i = _archs.begin(); i != _archs.end(); ++i) {
+	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 		BuildSetup archsetup = setup;
-		std::map<MSVC_Architecture, StringList>::const_iterator disabled_features_it = _arch_disabled_features.find(*i);
+		std::map<MSVC_Architecture, StringList>::const_iterator disabled_features_it = _arch_disabled_features.find(*arch);
 		if (disabled_features_it != _arch_disabled_features.end()) {
 			for (StringList::const_iterator j = disabled_features_it->second.begin(); j != disabled_features_it->second.end(); ++j) {
 				archsetup = removeFeatureFromSetup(archsetup, *j);
 			}
 		}
-		outputProjectSettings(project, name, archsetup, false, *i, "Debug");
-		outputProjectSettings(project, name, archsetup, false, *i, "Analysis");
-		outputProjectSettings(project, name, archsetup, false, *i, "LLVM");
-		outputProjectSettings(project, name, archsetup, true, *i, "Release");
+		outputProjectSettings(project, name, archsetup, false, *arch, "Debug");
+		outputProjectSettings(project, name, archsetup, false, *arch, "Analysis");
+		outputProjectSettings(project, name, archsetup, false, *arch, "LLVM");
+		outputProjectSettings(project, name, archsetup, true, *arch, "Release");
 	}
 
 	// Files

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -102,7 +102,7 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 			   "\t\t<VCTargetsPath Condition=\"'$(VCTargetsPath" << _version << ")' != '' and '$(VSVersion)' == '' and $(VisualStudioVersion) == ''\">$(VCTargetsPath" << _version << ")</VCTargetsPath>\n";
 
 	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
-		project << "\t\t<VcpkgTriplet Condition=\"'$(Platform)' == '" << getMSVCConfigName(*arch) << "'\">" << getMSVCArchName(*arch) << "-windows</VcpkgTriplet>";
+		project << "\t\t<VcpkgTriplet Condition=\"'$(Platform)' == '" << getMSVCConfigName(*arch) << "'\">" << getMSVCArchName(*arch) << "-windows</VcpkgTriplet>\n";
 	}
 
 	project << "\t</PropertyGroup>\n";
@@ -399,8 +399,6 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 }
 
 void MSBuildProvider::createBuildProp(const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration) {
-	const std::string outputBitness = (arch == ARCH_X86 ? "32" : "64");
-
 	std::ofstream properties((setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCArchName(arch) + getPropertiesExtension()).c_str());
 	if (!properties || !properties.is_open()) {
 		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCArchName(arch) + getPropertiesExtension() + "\" for writing");
@@ -455,6 +453,7 @@ void MSBuildProvider::createBuildProp(const BuildSetup &setup, bool isRelease, M
 
 		if (configuration == "LLVM") {
 			// FIXME The LLVM cl wrapper does not seem to work properly with the $(TargetDir) path so we hard-code the build folder until the issue is resolved
+			const std::string outputBitness = (arch == ARCH_X86 ? "32" : "64");
 			properties << "\t\t\t<AdditionalIncludeDirectories>" << configuration << outputBitness <<";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
 		                  "\t\t\t<AdditionalOptions>-Wno-microsoft -Wno-long-long -Wno-multichar -Wno-unknown-pragmas -Wno-reorder -Wpointer-arith -Wcast-qual -Wshadow -Wnon-virtual-dtor -Wwrite-strings -Wno-conversion -Wno-shorten-64-to-32 -Wno-sign-compare -Wno-four-char-constants -Wno-nested-anon-types -Qunused-arguments %(AdditionalOptions)</AdditionalOptions>\n";
 		}

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -20,11 +20,11 @@
  *
  */
 
-#include "config.h"
 #include "msbuild.h"
+#include "config.h"
 
-#include <fstream>
 #include <algorithm>
+#include <fstream>
 
 namespace CreateProjectTool {
 
@@ -32,8 +32,8 @@ namespace CreateProjectTool {
 // MSBuild Provider (Visual Studio 2010 and later)
 //////////////////////////////////////////////////////////////////////////
 
-MSBuildProvider::MSBuildProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion& msvc)
-	: MSVCProvider(global_warnings, project_warnings, version, msvc) {
+MSBuildProvider::MSBuildProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion &msvc)
+    : MSVCProvider(global_warnings, project_warnings, version, msvc) {
 
 	_archs.push_back(ARCH_X86);
 	_archs.push_back(ARCH_AMD64);
@@ -52,23 +52,23 @@ namespace {
 
 inline void outputConfiguration(std::ostream &project, const std::string &config, const std::string &platform) {
 	project << "\t\t<ProjectConfiguration Include=\"" << config << "|" << platform << "\">\n"
-	           "\t\t\t<Configuration>" << config << "</Configuration>\n"
-	           "\t\t\t<Platform>" << platform << "</Platform>\n"
-	           "\t\t</ProjectConfiguration>\n";
+	        << "\t\t\t<Configuration>" << config << "</Configuration>\n"
+	        << "\t\t\t<Platform>" << platform << "</Platform>\n"
+	        << "\t\t</ProjectConfiguration>\n";
 }
 
 inline void outputConfigurationType(const BuildSetup &setup, std::ostream &project, const std::string &name, const std::string &config, const std::string &toolset) {
 	project << "\t<PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='" << config << "'\" Label=\"Configuration\">\n"
-	           "\t\t<ConfigurationType>" << ((name == setup.projectName || setup.devTools || setup.tests) ? "Application" : "StaticLibrary") << "</ConfigurationType>\n"
-	           "\t\t<PlatformToolset>" << toolset << "</PlatformToolset>\n"
-	           "\t</PropertyGroup>\n";
+	        << "\t\t<ConfigurationType>" << ((name == setup.projectName || setup.devTools || setup.tests) ? "Application" : "StaticLibrary") << "</ConfigurationType>\n"
+	        << "\t\t<PlatformToolset>" << toolset << "</PlatformToolset>\n"
+	        << "\t</PropertyGroup>\n";
 }
 
 inline void outputProperties(std::ostream &project, const std::string &config, const std::string &properties) {
 	project << "\t<ImportGroup Condition=\"'$(Configuration)|$(Platform)'=='" << config << "'\" Label=\"PropertySheets\">\n"
-	           "\t\t<Import Project=\"$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props\" Condition=\"exists('$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props')\" Label=\"LocalAppDataPlatform\" />\n"
-	           "\t\t<Import Project=\"" << properties << "\" />\n"
-	           "\t</ImportGroup>\n";
+	        << "\t\t<Import Project=\"$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props\" Condition=\"exists('$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props')\" Label=\"LocalAppDataPlatform\" />\n"
+	        << "\t\t<Import Project=\"" << properties << "\" />\n"
+	        << "\t</ImportGroup>\n";
 }
 
 } // End of anonymous namespace
@@ -83,8 +83,8 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 	}
 
 	project << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-	           "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
-	           "\t<ItemGroup Label=\"ProjectConfigurations\">\n";
+	        << "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
+	        << "\t<ItemGroup Label=\"ProjectConfigurations\">\n";
 
 	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 		outputConfiguration(project, "Debug", getMSVCConfigName(*arch));
@@ -96,10 +96,10 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 
 	// Project name & Guid
 	project << "\t<PropertyGroup Label=\"Globals\">\n"
-			   "\t\t<ProjectGuid>{" << uuid << "}</ProjectGuid>\n"
-			   "\t\t<RootNamespace>" << name << "</RootNamespace>\n"
-			   "\t\t<Keyword>Win32Proj</Keyword>\n"
-			   "\t\t<VCTargetsPath Condition=\"'$(VCTargetsPath" << _version << ")' != '' and '$(VSVersion)' == '' and $(VisualStudioVersion) == ''\">$(VCTargetsPath" << _version << ")</VCTargetsPath>\n";
+	        << "\t\t<ProjectGuid>{" << uuid << "}</ProjectGuid>\n"
+	        << "\t\t<RootNamespace>" << name << "</RootNamespace>\n"
+	        << "\t\t<Keyword>Win32Proj</Keyword>\n"
+	        << "\t\t<VCTargetsPath Condition=\"'$(VCTargetsPath" << _version << ")' != '' and '$(VSVersion)' == '' and $(VisualStudioVersion) == ''\">$(VCTargetsPath" << _version << ")</VCTargetsPath>\n";
 
 	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 		project << "\t\t<VcpkgTriplet Condition=\"'$(Platform)' == '" << getMSVCConfigName(*arch) << "'\">" << getMSVCArchName(*arch) << "-windows</VcpkgTriplet>\n";
@@ -118,8 +118,8 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 	}
 
 	project << "\t<Import Project=\"$(VCTargetsPath)\\Microsoft.Cpp.props\" />\n"
-	           "\t<ImportGroup Label=\"ExtensionSettings\">\n"
-	           "\t</ImportGroup>\n";
+	        << "\t<ImportGroup Label=\"ExtensionSettings\">\n"
+	        << "\t</ImportGroup>\n";
 
 	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 		outputProperties(project, "Release|" + getMSVCConfigName(*arch), setup.projectDescription + "_Release" + getMSVCArchName(*arch) + ".props");
@@ -215,14 +215,14 @@ void MSBuildProvider::createFiltersFile(const BuildSetup &setup, const std::stri
 	}
 
 	filters << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-	           "<Project ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n";
+	        << "<Project ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n";
 
 	// Output the list of filters
 	filters << "\t<ItemGroup>\n";
 	for (std::list<std::string>::iterator filter = _filters.begin(); filter != _filters.end(); ++filter) {
 		filters << "\t\t<Filter Include=\"" << *filter << "\">\n"
-		           "\t\t\t<UniqueIdentifier>" << createUUID() << "</UniqueIdentifier>\n"
-		           "\t\t</Filter>\n";
+		        << "\t\t\t<UniqueIdentifier>" << createUUID() << "</UniqueIdentifier>\n"
+		        << "\t\t</Filter>\n";
 	}
 	filters << "\t</ItemGroup>\n";
 
@@ -242,8 +242,8 @@ void MSBuildProvider::outputFilter(std::ostream &filters, const FileEntries &fil
 		for (FileEntries::const_iterator entry = files.begin(), end = files.end(); entry != end; ++entry) {
 			if ((*entry).filter != "") {
 				filters << "\t\t<" << action << " Include=\"" << (*entry).path << "\">\n"
-				           "\t\t\t<Filter>" << (*entry).filter << "</Filter>\n"
-				           "\t\t</" << action << ">\n";
+				        << "\t\t\t<Filter>" << (*entry).filter << "</Filter>\n"
+				        << "\t\t</" << action << ">\n";
 			} else {
 				filters << "\t\t<" << action << " Include=\"" << (*entry).path << "\" />\n";
 			}
@@ -260,8 +260,8 @@ void MSBuildProvider::writeReferences(const BuildSetup &setup, std::ofstream &ou
 			continue;
 
 		output << "\t<ProjectReference Include=\"" << i->first << ".vcxproj\">\n"
-		          "\t\t<Project>{" << i->second << "}</Project>\n"
-		          "\t</ProjectReference>\n";
+		       << "\t\t<Project>{" << i->second << "}</Project>\n"
+		       << "\t</ProjectReference>\n";
 	}
 
 	output << "\t</ItemGroup>\n";
@@ -280,10 +280,10 @@ void MSBuildProvider::outputProjectSettings(std::ofstream &project, const std::s
 	std::string warnings = "";
 	if (warningsIterator != _projectWarnings.end())
 		for (StringList::const_iterator i = warningsIterator->second.begin(); i != warningsIterator->second.end(); ++i)
-			warnings +=  *i + ';';
+			warnings += *i + ';';
 
 	project << "\t<ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='" << configuration << "|" << getMSVCConfigName(arch) << "'\">\n"
-	           "\t\t<ClCompile>\n";
+	        << "\t\t<ClCompile>\n";
 
 	// Language Extensions
 	if (setup.devTools || setup.tests || name == setup.projectName || enableLanguageExtensions) {
@@ -309,26 +309,26 @@ void MSBuildProvider::outputProjectSettings(std::ofstream &project, const std::s
 			libraries += *i + ".lib;";
 
 		project << "\t\t<Link>\n"
-		           "\t\t\t<OutputFile>$(OutDir)" << ((setup.devTools || setup.tests) ? name : setup.projectName) << ".exe</OutputFile>\n"
-		           "\t\t\t<AdditionalDependencies>" << libraries << "%(AdditionalDependencies)</AdditionalDependencies>\n"
-		           "\t\t</Link>\n";
+		        << "\t\t\t<OutputFile>$(OutDir)" << ((setup.devTools || setup.tests) ? name : setup.projectName) << ".exe</OutputFile>\n"
+		        << "\t\t\t<AdditionalDependencies>" << libraries << "%(AdditionalDependencies)</AdditionalDependencies>\n"
+		        << "\t\t</Link>\n";
 
 		if (!setup.devTools && !setup.tests && setup.runBuildEvents) {
 			project << "\t\t<PreBuildEvent>\n"
-			           "\t\t\t<Message>Generate revision</Message>\n"
-			           "\t\t\t<Command>" << getPreBuildEvent() << "</Command>\n"
-			           "\t\t</PreBuildEvent>\n";
+			        << "\t\t\t<Message>Generate revision</Message>\n"
+			        << "\t\t\t<Command>" << getPreBuildEvent() << "</Command>\n"
+			        << "\t\t</PreBuildEvent>\n";
 
 			// Copy data files to the build folder
 			project << "\t\t<PostBuildEvent>\n"
-					   "\t\t\t<Message>Copy data files to the build folder</Message>\n"
-					   "\t\t\t<Command>" << getPostBuildEvent(arch, setup) << "</Command>\n"
-					   "\t\t</PostBuildEvent>\n";
+			        << "\t\t\t<Message>Copy data files to the build folder</Message>\n"
+			        << "\t\t\t<Command>" << getPostBuildEvent(arch, setup) << "</Command>\n"
+			        << "\t\t</PostBuildEvent>\n";
 		} else if (setup.tests) {
 			project << "\t\t<PreBuildEvent>\n"
-			           "\t\t\t<Message>Generate runner.cpp</Message>\n"
-			           "\t\t\t<Command>" << getTestPreBuildEvent(setup) << "</Command>\n"
-			           "\t\t</PreBuildEvent>\n";
+			        << "\t\t\t<Message>Generate runner.cpp</Message>\n"
+			        << "\t\t\t<Command>" << getTestPreBuildEvent(setup) << "</Command>\n"
+			        << "\t\t</PreBuildEvent>\n";
 		}
 	}
 
@@ -339,7 +339,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 
 	std::string warnings;
 	for (StringList::const_iterator i = _globalWarnings.begin(); i != _globalWarnings.end(); ++i)
-		warnings +=  *i + ';';
+		warnings += *i + ';';
 
 	std::string definesList;
 	for (StringList::const_iterator i = defines.begin(); i != defines.end(); ++i)
@@ -350,22 +350,22 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 		definesList += REVISION_DEFINE ";";
 
 	properties << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-	              "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
-	              "\t<PropertyGroup>\n"
-	              "\t\t<_PropertySheetDisplayName>" << setup.projectDescription << "_Global</_PropertySheetDisplayName>\n"
-	              "\t\t<ExecutablePath>$(" << LIBS_DEFINE << ")\\bin;$(" << LIBS_DEFINE << ")\\bin\\" << getMSVCArchName(arch) << ";$(" << LIBS_DEFINE << ")\\$(Configuration)\\bin;$(ExecutablePath)</ExecutablePath>\n"
-	              "\t\t<LibraryPath>$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << ";$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << "\\$(Configuration);$(" << LIBS_DEFINE << ")\\lib;$(" << LIBS_DEFINE << ")\\$(Configuration)\\lib;$(LibraryPath)</LibraryPath>\n"
-	              "\t\t<IncludePath>$(" << LIBS_DEFINE << ")\\include;$(" << LIBS_DEFINE << ")\\include\\" << (setup.useSDL2 ? "SDL2" : "SDL") << ";$(IncludePath)</IncludePath>\n"
-	              "\t\t<OutDir>$(Configuration)" << getMSVCArchName(arch) << "\\</OutDir>\n"
-	              "\t\t<IntDir>$(Configuration)" << getMSVCArchName(arch) << "\\$(ProjectName)\\</IntDir>\n"
-	              "\t</PropertyGroup>\n"
-	              "\t<ItemDefinitionGroup>\n"
-	              "\t\t<ClCompile>\n"
-	              "\t\t\t<DisableLanguageExtensions>true</DisableLanguageExtensions>\n"
-	              "\t\t\t<DisableSpecificWarnings>" << warnings << ";%(DisableSpecificWarnings)</DisableSpecificWarnings>\n"
-	              "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";" << prefix << "\\engines;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
-	              "\t\t\t<PreprocessorDefinitions>" << definesList << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
-	              "\t\t\t<ExceptionHandling>" << ((setup.devTools || setup.tests) ? "Sync" : "") << "</ExceptionHandling>\n";
+	           << "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
+	           << "\t<PropertyGroup>\n"
+	           << "\t\t<_PropertySheetDisplayName>" << setup.projectDescription << "_Global</_PropertySheetDisplayName>\n"
+	           << "\t\t<ExecutablePath>$(" << LIBS_DEFINE << ")\\bin;$(" << LIBS_DEFINE << ")\\bin\\" << getMSVCArchName(arch) << ";$(" << LIBS_DEFINE << ")\\$(Configuration)\\bin;$(ExecutablePath)</ExecutablePath>\n"
+	           << "\t\t<LibraryPath>$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << ";$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << "\\$(Configuration);$(" << LIBS_DEFINE << ")\\lib;$(" << LIBS_DEFINE << ")\\$(Configuration)\\lib;$(LibraryPath)</LibraryPath>\n"
+	           << "\t\t<IncludePath>$(" << LIBS_DEFINE << ")\\include;$(" << LIBS_DEFINE << ")\\include\\" << (setup.useSDL2 ? "SDL2" : "SDL") << ";$(IncludePath)</IncludePath>\n"
+	           << "\t\t<OutDir>$(Configuration)" << getMSVCArchName(arch) << "\\</OutDir>\n"
+	           << "\t\t<IntDir>$(Configuration)" << getMSVCArchName(arch) << "\\$(ProjectName)\\</IntDir>\n"
+	           << "\t</PropertyGroup>\n"
+	           << "\t<ItemDefinitionGroup>\n"
+	           << "\t\t<ClCompile>\n"
+	           << "\t\t\t<DisableLanguageExtensions>true</DisableLanguageExtensions>\n"
+	           << "\t\t\t<DisableSpecificWarnings>" << warnings << ";%(DisableSpecificWarnings)</DisableSpecificWarnings>\n"
+	           << "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";" << prefix << "\\engines;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
+	           << "\t\t\t<PreprocessorDefinitions>" << definesList << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
+	           << "\t\t\t<ExceptionHandling>" << ((setup.devTools || setup.tests) ? "Sync" : "") << "</ExceptionHandling>\n";
 
 #if NEEDS_RTTI
 	properties << "\t\t\t<RuntimeTypeInfo>true</RuntimeTypeInfo>\n";
@@ -374,26 +374,26 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 #endif
 
 	properties << "\t\t\t<WarningLevel>Level4</WarningLevel>\n"
-	              "\t\t\t<TreatWarningAsError>false</TreatWarningAsError>\n"
-	              "\t\t\t<CompileAs>Default</CompileAs>\n"
-	              "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>\n"
-	              "\t\t\t<ConformanceMode>true</ConformanceMode>\n"
-	              "\t\t\t<AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>\n"
-	              "\t\t</ClCompile>\n"
-	              "\t\t<Link>\n"
-	              "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n"
-	              "\t\t\t<SubSystem>Console</SubSystem>\n";
+	           << "\t\t\t<TreatWarningAsError>false</TreatWarningAsError>\n"
+	           << "\t\t\t<CompileAs>Default</CompileAs>\n"
+	           << "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>\n"
+	           << "\t\t\t<ConformanceMode>true</ConformanceMode>\n"
+	           << "\t\t\t<AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>\n"
+	           << "\t\t</ClCompile>\n"
+	           << "\t\t<Link>\n"
+	           << "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n"
+	           << "\t\t\t<SubSystem>Console</SubSystem>\n";
 
 	if (!setup.devTools && !setup.tests)
 		properties << "\t\t\t<EntryPointSymbol>WinMainCRTStartup</EntryPointSymbol>\n";
 
 	properties << "\t\t</Link>\n"
-	              "\t\t<ResourceCompile>\n"
-	              "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
-	              "\t\t\t<PreprocessorDefinitions>" << definesList << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
-	              "\t\t</ResourceCompile>\n"
-	              "\t</ItemDefinitionGroup>\n"
-	              "</Project>\n";
+	           << "\t\t<ResourceCompile>\n"
+	           << "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
+	           << "\t\t\t<PreprocessorDefinitions>" << definesList << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
+	           << "\t\t</ResourceCompile>\n"
+	           << "\t</ItemDefinitionGroup>\n"
+	           << "</Project>\n";
 
 	properties.flush();
 }
@@ -406,44 +406,44 @@ void MSBuildProvider::createBuildProp(const BuildSetup &setup, bool isRelease, M
 	}
 
 	properties << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-	              "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
-	              "\t<ImportGroup Label=\"PropertySheets\">\n"
-	              "\t\t<Import Project=\"" << setup.projectDescription << "_Global" << getMSVCArchName(arch) << ".props\" />\n"
-	              "\t</ImportGroup>\n"
-	              "\t<PropertyGroup>\n"
-	              "\t\t<_PropertySheetDisplayName>" << setup.projectDescription << "_" << configuration << getMSVCArchName(arch) << "</_PropertySheetDisplayName>\n"
-	              "\t\t<LinkIncremental>" << (isRelease ? "false" : "true") << "</LinkIncremental>\n"
-	              "\t\t<GenerateManifest>false</GenerateManifest>\n"
-	              "\t</PropertyGroup>\n"
-	              "\t<ItemDefinitionGroup>\n"
-	              "\t\t<ClCompile>\n";
+	           << "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
+	           << "\t<ImportGroup Label=\"PropertySheets\">\n"
+	           << "\t\t<Import Project=\"" << setup.projectDescription << "_Global" << getMSVCArchName(arch) << ".props\" />\n"
+	           << "\t</ImportGroup>\n"
+	           << "\t<PropertyGroup>\n"
+	           << "\t\t<_PropertySheetDisplayName>" << setup.projectDescription << "_" << configuration << getMSVCArchName(arch) << "</_PropertySheetDisplayName>\n"
+	           << "\t\t<LinkIncremental>" << (isRelease ? "false" : "true") << "</LinkIncremental>\n"
+	           << "\t\t<GenerateManifest>false</GenerateManifest>\n"
+	           << "\t</PropertyGroup>\n"
+	           << "\t<ItemDefinitionGroup>\n"
+	           << "\t\t<ClCompile>\n";
 
 	if (isRelease) {
 		properties << "\t\t\t<IntrinsicFunctions>true</IntrinsicFunctions>\n"
-		              "\t\t\t<WholeProgramOptimization>true</WholeProgramOptimization>\n"
-		              "\t\t\t<PreprocessorDefinitions>WIN32;RELEASE_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
-		              "\t\t\t<StringPooling>true</StringPooling>\n"
-		              "\t\t\t<BufferSecurityCheck>false</BufferSecurityCheck>\n"
-		              "\t\t\t<DebugInformationFormat></DebugInformationFormat>\n"
-		              "\t\t\t<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>\n"
-		              "\t\t\t<EnablePREfast>" << (configuration == "Analysis" ? "true" : "false") << "</EnablePREfast>\n"
-		              "\t\t</ClCompile>\n"
-		              "\t\t<Lib>\n"
-		              "\t\t\t<LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>\n"
-		              "\t\t</Lib>\n"
-		              "\t\t<Link>\n"
-		              "\t\t\t<LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>\n"
-		              "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n"
-		              "\t\t\t<SetChecksum>true</SetChecksum>\n";
+		           << "\t\t\t<WholeProgramOptimization>true</WholeProgramOptimization>\n"
+		           << "\t\t\t<PreprocessorDefinitions>WIN32;RELEASE_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
+		           << "\t\t\t<StringPooling>true</StringPooling>\n"
+		           << "\t\t\t<BufferSecurityCheck>false</BufferSecurityCheck>\n"
+		           << "\t\t\t<DebugInformationFormat></DebugInformationFormat>\n"
+		           << "\t\t\t<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>\n"
+		           << "\t\t\t<EnablePREfast>" << (configuration == "Analysis" ? "true" : "false") << "</EnablePREfast>\n"
+		           << "\t\t</ClCompile>\n"
+		           << "\t\t<Lib>\n"
+		           << "\t\t\t<LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>\n"
+		           << "\t\t</Lib>\n"
+		           << "\t\t<Link>\n"
+		           << "\t\t\t<LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>\n"
+		           << "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n"
+		           << "\t\t\t<SetChecksum>true</SetChecksum>\n";
 	} else {
 		properties << "\t\t\t<Optimization>Disabled</Optimization>\n"
-		              "\t\t\t<PreprocessorDefinitions>WIN32;" << (configuration == "LLVM" ? "_CRT_SECURE_NO_WARNINGS;" : "") << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
-		              "\t\t\t<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>\n"
-		              "\t\t\t<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>\n"
-		              "\t\t\t<FunctionLevelLinking>true</FunctionLevelLinking>\n"
-		              "\t\t\t<TreatWarningAsError>false</TreatWarningAsError>\n";
+		           << "\t\t\t<PreprocessorDefinitions>WIN32;" << (configuration == "LLVM" ? "_CRT_SECURE_NO_WARNINGS;" : "") << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
+		           << "\t\t\t<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>\n"
+		           << "\t\t\t<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>\n"
+		           << "\t\t\t<FunctionLevelLinking>true</FunctionLevelLinking>\n"
+		           << "\t\t\t<TreatWarningAsError>false</TreatWarningAsError>\n";
 		if (_version >= 14) {
-			// Since MSVC 2015 Edit and Continue is supported for x86 and x86-64, but not for ARM.
+			// Since<<SVC 2015 Edit and Continue is supported for x86 and x86-64, but not for ARM.
 			properties << "\t\t\t<DebugInformationFormat>" << (arch != ARCH_ARM64 ? "EditAndContinue" : "ProgramDatabase") << "</DebugInformationFormat>\n";
 		} else {
 			// Older MSVC versions did not support Edit and Continue for x64, thus we do not use it.
@@ -454,19 +454,19 @@ void MSBuildProvider::createBuildProp(const BuildSetup &setup, bool isRelease, M
 		if (configuration == "LLVM") {
 			// FIXME The LLVM cl wrapper does not seem to work properly with the $(TargetDir) path so we hard-code the build folder until the issue is resolved
 			const std::string outputBitness = (arch == ARCH_X86 ? "32" : "64");
-			properties << "\t\t\t<AdditionalIncludeDirectories>" << configuration << outputBitness <<";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
-		                  "\t\t\t<AdditionalOptions>-Wno-microsoft -Wno-long-long -Wno-multichar -Wno-unknown-pragmas -Wno-reorder -Wpointer-arith -Wcast-qual -Wshadow -Wnon-virtual-dtor -Wwrite-strings -Wno-conversion -Wno-shorten-64-to-32 -Wno-sign-compare -Wno-four-char-constants -Wno-nested-anon-types -Qunused-arguments %(AdditionalOptions)</AdditionalOptions>\n";
+			properties << "\t\t\t<AdditionalIncludeDirectories>" << configuration << outputBitness << ";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
+			           << "\t\t\t<AdditionalOptions>-Wno-microsoft -Wno-long-long -Wno-multichar -Wno-unknown-pragmas -Wno-reorder -Wpointer-arith -Wcast-qual -Wshadow -Wnon-virtual-dtor -Wwrite-strings -Wno-conversion -Wno-shorten-64-to-32 -Wno-sign-compare -Wno-four-char-constants -Wno-nested-anon-types -Qunused-arguments %(AdditionalOptions)</AdditionalOptions>\n";
 		}
 
 		properties << "\t\t</ClCompile>\n"
-		              "\t\t<Link>\n"
-		              "\t\t\t<GenerateDebugInformation>true</GenerateDebugInformation>\n"
-		              "\t\t\t<ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>\n";
+		           << "\t\t<Link>\n"
+		           << "\t\t\t<GenerateDebugInformation>true</GenerateDebugInformation>\n"
+		           << "\t\t\t<ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>\n";
 	}
 
 	properties << "\t\t</Link>\n"
-	              "\t</ItemDefinitionGroup>\n"
-	              "</Project>\n";
+	           << "\t</ItemDefinitionGroup>\n"
+	           << "</Project>\n";
 
 	properties.flush();
 	properties.close();
@@ -474,7 +474,7 @@ void MSBuildProvider::createBuildProp(const BuildSetup &setup, bool isRelease, M
 
 bool hasEnding(std::string const &fullString, std::string const &ending) {
 	if (fullString.length() > ending.length()) {
-		return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+		return (0 == fullString.compare(fullString.length() - ending.length(), ending.length(), ending));
 	} else {
 		return false;
 	}
@@ -484,7 +484,7 @@ namespace {
 
 inline void outputNasmCommand(std::ostream &projectFile, const std::string &config, const std::string &prefix) {
 	projectFile << "\t\t\t<Command Condition=\"'$(Configuration)|$(Platform)'=='" << config << "|Win32'\">nasm.exe -f win32 -g -o \"$(IntDir)" << prefix << "%(Filename).obj\" \"%(FullPath)\"</Command>\n"
-	               "\t\t\t<Outputs Condition=\"'$(Configuration)|$(Platform)'=='" << config << "|Win32'\">$(IntDir)" << prefix << "%(Filename).obj;%(Outputs)</Outputs>\n";
+	            << "\t\t\t<Outputs Condition=\"'$(Configuration)|$(Platform)'=='" << config << "|Win32'\">$(IntDir)" << prefix << "%(Filename).obj;%(Outputs)</Outputs>\n";
 }
 
 } // End of anonymous namespace
@@ -502,7 +502,7 @@ void MSBuildProvider::writeFileListToProject(const FileNode &dir, std::ofstream 
 	// Compute the list of files
 	_filters.push_back(""); // init filters
 	computeFileList(dir, duplicate, objPrefix, filePrefix);
-	_filters.pop_back();    // remove last empty filter
+	_filters.pop_back(); // remove last empty filter
 
 	// Output compile files
 	if (!_compileFiles.empty()) {
@@ -515,7 +515,7 @@ void MSBuildProvider::writeFileListToProject(const FileNode &dir, std::ofstream 
 			// Deal with duplicated file names
 			if (isDuplicate) {
 				projectFile << "\t\t<ClCompile Include=\"" << (*entry).path << "\">\n"
-							   "\t\t\t<ObjectFileName>$(IntDir)" << (*entry).prefix << "%(Filename).obj</ObjectFileName>\n";
+				            << "\t\t\t<ObjectFileName>$(IntDir)" << (*entry).prefix << "%(Filename).obj</ObjectFileName>\n";
 
 				projectFile << "\t\t</ClCompile>\n";
 			} else {
@@ -538,7 +538,7 @@ void MSBuildProvider::writeFileListToProject(const FileNode &dir, std::ofstream 
 			const bool isDuplicate = (std::find(duplicate.begin(), duplicate.end(), (*entry).name + ".o") != duplicate.end());
 
 			projectFile << "\t\t<CustomBuild Include=\"" << (*entry).path << "\">\n"
-			               "\t\t\t<FileType>Document</FileType>\n";
+			            << "\t\t\t<FileType>Document</FileType>\n";
 
 			outputNasmCommand(projectFile, "Debug", (isDuplicate ? (*entry).prefix : ""));
 			outputNasmCommand(projectFile, "Analysis", (isDuplicate ? (*entry).prefix : ""));
@@ -599,4 +599,4 @@ void MSBuildProvider::computeFileList(const FileNode &dir, const StringList &dup
 	}
 }
 
-} // End of CreateProjectTool namespace
+} // namespace CreateProjectTool

--- a/devtools/create_project/msbuild.h
+++ b/devtools/create_project/msbuild.h
@@ -56,8 +56,8 @@ private:
 		std::string filter;
 		std::string prefix;
 
-		bool operator<(const FileEntry& rhs) const {
-			return path.compare(rhs.path) == -1;   // Not exactly right for alphabetical order, but good enough
+		bool operator<(const FileEntry &rhs) const {
+			return path.compare(rhs.path) == -1; // Not exactly right for alphabetical order, but good enough
 		}
 	};
 	typedef std::list<FileEntry> FileEntries;
@@ -76,6 +76,6 @@ private:
 	void outputFiles(std::ostream &projectFile, const FileEntries &files, const std::string &action);
 };
 
-} // End of CreateProjectTool namespace
+} // namespace CreateProjectTool
 
 #endif // TOOLS_CREATE_PROJECT_MSBUILD_H

--- a/devtools/create_project/msbuild.h
+++ b/devtools/create_project/msbuild.h
@@ -35,16 +35,16 @@ protected:
 	void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
 	                       const StringList &includeList, const StringList &excludeList);
 
-	void outputProjectSettings(std::ofstream &project, const std::string &name, const BuildSetup &setup, bool isRelease, bool isWin32, std::string configuration);
+	void outputProjectSettings(std::ofstream &project, const std::string &name, const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration);
 
 	void writeFileListToProject(const FileNode &dir, std::ofstream &projectFile, const int indentation,
 	                            const StringList &duplicate, const std::string &objPrefix, const std::string &filePrefix);
 
 	void writeReferences(const BuildSetup &setup, std::ofstream &output);
 
-	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, int bits, const StringList &defines, const std::string &prefix, bool runBuildEvents);
+	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix, bool runBuildEvents) override;
 
-	void createBuildProp(const BuildSetup &setup, bool isRelease, bool isWin32, std::string configuration);
+	void createBuildProp(const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration) override;
 
 	const char *getProjectExtension();
 	const char *getPropertiesExtension();

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -176,10 +176,10 @@ void MSVCProvider::createGlobalProp(const BuildSetup &setup) {
 		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(MSVC_Architecture::ARCH_AMD64) + getPropertiesExtension() + "\" for writing");
 
 	BuildSetup amd64setup = setup;
-	auto amd64_disabled_features_it = s_arch_disabled_features.find(MSVC_Architecture::ARCH_AMD64);
+	std::map<MSVC_Architecture, StringList>::const_iterator amd64_disabled_features_it = s_arch_disabled_features.find(MSVC_Architecture::ARCH_AMD64);
 	if (amd64_disabled_features_it != s_arch_disabled_features.end()) {
-		for (auto feature : amd64_disabled_features_it->second) {
-			amd64setup = removeFeatureFromSetup(amd64setup, feature);
+		for (StringList::const_iterator feature = amd64_disabled_features_it->second.begin(); feature != amd64_disabled_features_it->second.end(); ++feature) {
+			amd64setup = removeFeatureFromSetup(amd64setup, *feature);
 		}
 	}
 
@@ -191,10 +191,10 @@ void MSVCProvider::createGlobalProp(const BuildSetup &setup) {
 		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(MSVC_Architecture::ARCH_ARM64) + getPropertiesExtension() + "\" for writing");
 
 	BuildSetup arm64setup = setup;
-	auto arm64_disabled_features_it = s_arch_disabled_features.find(MSVC_Architecture::ARCH_ARM64);
+	std::map<MSVC_Architecture, StringList>::const_iterator arm64_disabled_features_it = s_arch_disabled_features.find(MSVC_Architecture::ARCH_ARM64);
 	if (arm64_disabled_features_it != s_arch_disabled_features.end()) {
-		for (auto feature : arm64_disabled_features_it->second) {
-			arm64setup = removeFeatureFromSetup(arm64setup, feature);
+		for (StringList::const_iterator feature = arm64_disabled_features_it->second.begin(); feature != arm64_disabled_features_it->second.end(); ++feature) {
+			arm64setup = removeFeatureFromSetup(arm64setup, *feature);
 		}
 	}
 	outputGlobalPropFile(arm64setup, properties, MSVC_Architecture::ARCH_ARM64, arm64setup.defines, convertPathToWin(setup.filePrefix), setup.runBuildEvents);

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -58,8 +58,10 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 	std::string solutionUUID = createUUID(setup.projectName + ".sln");
 
 	std::ofstream solution((setup.outputDir + '/' + setup.projectName + ".sln").c_str());
-	if (!solution)
+	if (!solution || !solution.is_open()) {
 		error("Could not open \"" + setup.outputDir + '/' + setup.projectName + ".sln\" for writing");
+		return;
+	}
 
 	solution << "Microsoft Visual Studio Solution File, Format Version " << _msvcVersion.solutionFormat << "\n";
 	solution << "# Visual Studio " << _msvcVersion.solutionVersion << "\n";

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -40,11 +40,18 @@ MSVCProvider::MSVCProvider(StringList &global_warnings, std::map<std::string, St
 	_disableEditAndContinue   = tokenize(DISABLE_EDIT_AND_CONTINUE, ',');
 
 	// NASM not supported for Windows on AMD64 target
-	_arch_disabled_features[ARCH_AMD64] = {"nasm"};
+	StringList amd64_disabled_features;
+	amd64_disabled_features.push_back("nasm");
+	_arch_disabled_features[ARCH_AMD64] = amd64_disabled_features;
 	// NASM not supported for WoA target
 	// No OpenGL, OpenGL ES on Windows on ARM
 	// https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64
-	_arch_disabled_features[ARCH_ARM64] = {"nasm", "opengl", "opengles", "fribidi"};
+	StringList arm64_disabled_features;
+	arm64_disabled_features.push_back("nasm");
+	arm64_disabled_features.push_back("opengl");
+	arm64_disabled_features.push_back("opengles");
+	arm64_disabled_features.push_back("fribidi");
+	_arch_disabled_features[ARCH_ARM64] = arm64_disabled_features;
 }
 
 void MSVCProvider::createWorkspace(const BuildSetup &setup) {

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -85,47 +85,29 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 	}
 
 	solution << "Global\n"
-	            "\tGlobalSection(SolutionConfigurationPlatforms) = preSolution\n"
-	            "\t\tDebug|Win32 = Debug|Win32\n"
-	            "\t\tAnalysis|Win32 = Analysis|Win32\n"
-	            "\t\tLLVM|Win32 = LLVM|Win32\n"
-	            "\t\tRelease|Win32 = Release|Win32\n"
-	            "\t\tDebug|x64 = Debug|x64\n"
-	            "\t\tAnalysis|x64 = Analysis|x64\n"
-	            "\t\tLLVM|x64 = LLVM|x64\n"
-	            "\t\tRelease|x64 = Release|x64\n"
-	            "\t\tDebug|arm64 = Debug|arm64\n"
-	            "\t\tAnalysis|arm64 = Analysis|arm64\n"
-	            "\t\tLLVM|arm64 = LLVM|arm64\n"
-	            "\t\tRelease|arm64 = Release|arm64\n"
-	            "\tEndGlobalSection\n"
+	            "\tGlobalSection(SolutionConfigurationPlatforms) = preSolution\n";
+
+	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
+		solution << "\t\tDebug|" << getMSVCConfigName(*arch) << " = Debug|" << getMSVCConfigName(*arch) << "\n"
+					"\t\tAnalysis|" << getMSVCConfigName(*arch) << " = Analysis|" << getMSVCConfigName(*arch) << "\n"
+					"\t\tLLVM|" << getMSVCConfigName(*arch) << " = LLVM|" << getMSVCConfigName(*arch) << "\n"
+					"\t\tRelease|" << getMSVCConfigName(*arch) << " = Release|" << getMSVCConfigName(*arch) << "\n";
+	}
+
+	solution << "\tEndGlobalSection\n"
 	            "\tGlobalSection(ProjectConfigurationPlatforms) = postSolution\n";
 
 	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
-		solution << "\t\t{" << i->second << "}.Debug|Win32.ActiveCfg = Debug|Win32\n"
-		            "\t\t{" << i->second << "}.Debug|Win32.Build.0 = Debug|Win32\n"
-		            "\t\t{" << i->second << "}.Analysis|Win32.ActiveCfg = Analysis|Win32\n"
-		            "\t\t{" << i->second << "}.Analysis|Win32.Build.0 = Analysis|Win32\n"
-		            "\t\t{" << i->second << "}.LLVM|Win32.ActiveCfg = LLVM|Win32\n"
-		            "\t\t{" << i->second << "}.LLVM|Win32.Build.0 = LLVM|Win32\n"
-		            "\t\t{" << i->second << "}.Release|Win32.ActiveCfg = Release|Win32\n"
-		            "\t\t{" << i->second << "}.Release|Win32.Build.0 = Release|Win32\n"
-		            "\t\t{" << i->second << "}.Debug|x64.ActiveCfg = Debug|x64\n"
-		            "\t\t{" << i->second << "}.Debug|x64.Build.0 = Debug|x64\n"
-		            "\t\t{" << i->second << "}.Analysis|x64.ActiveCfg = Analysis|x64\n"
-		            "\t\t{" << i->second << "}.Analysis|x64.Build.0 = Analysis|x64\n"
-		            "\t\t{" << i->second << "}.LLVM|x64.ActiveCfg = LLVM|x64\n"
-		            "\t\t{" << i->second << "}.LLVM|x64.Build.0 = LLVM|x64\n"
-		            "\t\t{" << i->second << "}.Release|x64.ActiveCfg = Release|x64\n"
-		            "\t\t{" << i->second << "}.Release|x64.Build.0 = Release|x64\n"
-		            "\t\t{" << i->second << "}.Debug|arm64.ActiveCfg = Debug|arm64\n"
-		            "\t\t{" << i->second << "}.Debug|arm64.Build.0 = Debug|arm64\n"
-		            "\t\t{" << i->second << "}.Analysis|arm64.ActiveCfg = Analysis|arm64\n"
-		            "\t\t{" << i->second << "}.Analysis|arm64.Build.0 = Analysis|arm64\n"
-		            "\t\t{" << i->second << "}.LLVM|arm64.ActiveCfg = LLVM|arm64\n"
-		            "\t\t{" << i->second << "}.LLVM|arm64.Build.0 = LLVM|arm64\n"
-		            "\t\t{" << i->second << "}.Release|arm64.ActiveCfg = Release|arm64\n"
-		            "\t\t{" << i->second << "}.Release|arm64.Build.0 = Release|arm64\n";
+		for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
+			solution << "\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".ActiveCfg = Debug|" << getMSVCConfigName(*arch) << "\n"
+						"\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".Build.0 = Debug|" << getMSVCConfigName(*arch) << "\n"
+						"\t\t{" << i->second << "}.Analysis|" << getMSVCConfigName(*arch) << ".ActiveCfg = Analysis|" << getMSVCConfigName(*arch) << "\n"
+						"\t\t{" << i->second << "}.Analysis|" << getMSVCConfigName(*arch) << ".Build.0 = Analysis|" << getMSVCConfigName(*arch) << "\n"
+						"\t\t{" << i->second << "}.LLVM|" << getMSVCConfigName(*arch) << ".ActiveCfg = LLVM|" << getMSVCConfigName(*arch) << "\n"
+						"\t\t{" << i->second << "}.LLVM|" << getMSVCConfigName(*arch) << ".Build.0 = LLVM|" << getMSVCConfigName(*arch) << "\n"
+						"\t\t{" << i->second << "}.Release|" << getMSVCConfigName(*arch) << ".ActiveCfg = Release|" << getMSVCConfigName(*arch) << "\n"
+						"\t\t{" << i->second << "}.Release|" << getMSVCConfigName(*arch) << ".Build.0 = Release|" << getMSVCConfigName(*arch) << "\n";
+		}
 	}
 
 	solution << "\tEndGlobalSection\n"
@@ -141,18 +123,12 @@ void MSVCProvider::createOtherBuildFiles(const BuildSetup &setup) {
 
 	// Create the configuration property files (for Debug and Release with 32 and 64bits versions)
 	// Note: we use the debug properties for the analysis configuration
-	createBuildProp(setup, true, ARCH_AMD64, "Release");
-	createBuildProp(setup, true, ARCH_X86, "Release");
-	createBuildProp(setup, true, ARCH_ARM64, "Release");
-	createBuildProp(setup, false, ARCH_AMD64, "Debug");
-	createBuildProp(setup, false, ARCH_X86, "Debug");
-	createBuildProp(setup, false, ARCH_ARM64, "Debug");
-	createBuildProp(setup, false, ARCH_AMD64, "Analysis");
-	createBuildProp(setup, false, ARCH_X86, "Analysis");
-	createBuildProp(setup, false, ARCH_ARM64, "Analysis");
-	createBuildProp(setup, false, ARCH_AMD64, "LLVM");
-	createBuildProp(setup, false, ARCH_X86, "LLVM");
-	createBuildProp(setup, false, ARCH_ARM64, "LLVM");
+	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
+		createBuildProp(setup, true, *arch, "Release");
+		createBuildProp(setup, false, *arch, "Debug");
+		createBuildProp(setup, false, *arch, "Analysis");
+		createBuildProp(setup, false, *arch, "LLVM");
+	}
 }
 
 void MSVCProvider::addResourceFiles(const BuildSetup &setup, StringList &includeList, StringList &excludeList) {
@@ -161,41 +137,22 @@ void MSVCProvider::addResourceFiles(const BuildSetup &setup, StringList &include
 }
 
 void MSVCProvider::createGlobalProp(const BuildSetup &setup) {
-	std::ofstream properties((setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(ARCH_X86) + getPropertiesExtension()).c_str());
-	if (!properties)
-		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(ARCH_X86) + getPropertiesExtension() + "\" for writing");
+	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
+		std::ofstream properties((setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(*arch) + getPropertiesExtension()).c_str());
+		if (!properties)
+			error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(*arch) + getPropertiesExtension() + "\" for writing");
 
-	outputGlobalPropFile(setup, properties, ARCH_X86, setup.defines, convertPathToWin(setup.filePrefix), setup.runBuildEvents);
-	properties.close();
-
-	properties.open((setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(ARCH_AMD64) + getPropertiesExtension()).c_str());
-	if (!properties)
-		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(ARCH_AMD64) + getPropertiesExtension() + "\" for writing");
-
-	BuildSetup amd64setup = setup;
-	std::map<MSVC_Architecture, StringList>::const_iterator amd64_disabled_features_it = _arch_disabled_features.find(ARCH_AMD64);
-	if (amd64_disabled_features_it != _arch_disabled_features.end()) {
-		for (StringList::const_iterator feature = amd64_disabled_features_it->second.begin(); feature != amd64_disabled_features_it->second.end(); ++feature) {
-			amd64setup = removeFeatureFromSetup(amd64setup, *feature);
+		BuildSetup archSetup = setup;
+		std::map<MSVC_Architecture, StringList>::const_iterator arch_disabled_features_it = _arch_disabled_features.find(*arch);
+		if (arch_disabled_features_it != _arch_disabled_features.end()) {
+			for (StringList::const_iterator feature = arch_disabled_features_it->second.begin(); feature != arch_disabled_features_it->second.end(); ++feature) {
+				archSetup = removeFeatureFromSetup(archSetup, *feature);
+			}
 		}
+
+		outputGlobalPropFile(archSetup, properties, *arch, archSetup.defines, convertPathToWin(archSetup.filePrefix), archSetup.runBuildEvents);
+		properties.close();
 	}
-
-	outputGlobalPropFile(amd64setup, properties, ARCH_AMD64, amd64setup.defines, convertPathToWin(amd64setup.filePrefix), amd64setup.runBuildEvents);
-	properties.close();
-
-	properties.open((setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(ARCH_ARM64) + getPropertiesExtension()).c_str());
-	if (!properties)
-		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_Global" + getMSVCArchName(ARCH_ARM64) + getPropertiesExtension() + "\" for writing");
-
-	BuildSetup arm64setup = setup;
-	std::map<MSVC_Architecture, StringList>::const_iterator arm64_disabled_features_it = _arch_disabled_features.find(ARCH_ARM64);
-	if (arm64_disabled_features_it != _arch_disabled_features.end()) {
-		for (StringList::const_iterator feature = arm64_disabled_features_it->second.begin(); feature != arm64_disabled_features_it->second.end(); ++feature) {
-			arm64setup = removeFeatureFromSetup(arm64setup, *feature);
-		}
-	}
-	outputGlobalPropFile(arm64setup, properties, ARCH_ARM64, arm64setup.defines, convertPathToWin(setup.filePrefix), setup.runBuildEvents);
-	properties.close();
 }
 
 std::string MSVCProvider::getPreBuildEvent() const {

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -20,13 +20,12 @@
  *
  */
 
-#include "config.h"
 #include "msvc.h"
+#include "config.h"
 
-#include <fstream>
 #include <algorithm>
 #include <cstring>
-
+#include <fstream>
 
 namespace CreateProjectTool {
 
@@ -34,10 +33,10 @@ namespace CreateProjectTool {
 // MSVC Provider (Base class)
 //////////////////////////////////////////////////////////////////////////
 MSVCProvider::MSVCProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion &msvc)
-	: ProjectProvider(global_warnings, project_warnings, version), _msvcVersion(msvc) {
+    : ProjectProvider(global_warnings, project_warnings, version), _msvcVersion(msvc) {
 
 	_enableLanguageExtensions = tokenize(ENABLE_LANGUAGE_EXTENSIONS, ',');
-	_disableEditAndContinue   = tokenize(DISABLE_EDIT_AND_CONTINUE, ',');
+	_disableEditAndContinue = tokenize(DISABLE_EDIT_AND_CONTINUE, ',');
 
 	// NASM not supported for Windows on AMD64 target
 	StringList amd64_disabled_features;
@@ -98,9 +97,9 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 
 	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 		solution << "\t\tDebug|" << getMSVCConfigName(*arch) << " = Debug|" << getMSVCConfigName(*arch) << "\n"
-					"\t\tAnalysis|" << getMSVCConfigName(*arch) << " = Analysis|" << getMSVCConfigName(*arch) << "\n"
-					"\t\tLLVM|" << getMSVCConfigName(*arch) << " = LLVM|" << getMSVCConfigName(*arch) << "\n"
-					"\t\tRelease|" << getMSVCConfigName(*arch) << " = Release|" << getMSVCConfigName(*arch) << "\n";
+		         << "\t\tAnalysis|" << getMSVCConfigName(*arch) << " = Analysis|" << getMSVCConfigName(*arch) << "\n"
+		         << "\t\tLLVM|" << getMSVCConfigName(*arch) << " = LLVM|" << getMSVCConfigName(*arch) << "\n"
+		         << "\t\tRelease|" << getMSVCConfigName(*arch) << " = Release|" << getMSVCConfigName(*arch) << "\n";
 	}
 
 	solution << "\tEndGlobalSection\n"
@@ -109,21 +108,21 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
 		for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 			solution << "\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".ActiveCfg = Debug|" << getMSVCConfigName(*arch) << "\n"
-						"\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".Build.0 = Debug|" << getMSVCConfigName(*arch) << "\n"
-						"\t\t{" << i->second << "}.Analysis|" << getMSVCConfigName(*arch) << ".ActiveCfg = Analysis|" << getMSVCConfigName(*arch) << "\n"
-						"\t\t{" << i->second << "}.Analysis|" << getMSVCConfigName(*arch) << ".Build.0 = Analysis|" << getMSVCConfigName(*arch) << "\n"
-						"\t\t{" << i->second << "}.LLVM|" << getMSVCConfigName(*arch) << ".ActiveCfg = LLVM|" << getMSVCConfigName(*arch) << "\n"
-						"\t\t{" << i->second << "}.LLVM|" << getMSVCConfigName(*arch) << ".Build.0 = LLVM|" << getMSVCConfigName(*arch) << "\n"
-						"\t\t{" << i->second << "}.Release|" << getMSVCConfigName(*arch) << ".ActiveCfg = Release|" << getMSVCConfigName(*arch) << "\n"
-						"\t\t{" << i->second << "}.Release|" << getMSVCConfigName(*arch) << ".Build.0 = Release|" << getMSVCConfigName(*arch) << "\n";
+			         << "\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".Build.0 = Debug|" << getMSVCConfigName(*arch) << "\n"
+			         << "\t\t{" << i->second << "}.Analysis|" << getMSVCConfigName(*arch) << ".ActiveCfg = Analysis|" << getMSVCConfigName(*arch) << "\n"
+			         << "\t\t{" << i->second << "}.Analysis|" << getMSVCConfigName(*arch) << ".Build.0 = Analysis|" << getMSVCConfigName(*arch) << "\n"
+			         << "\t\t{" << i->second << "}.LLVM|" << getMSVCConfigName(*arch) << ".ActiveCfg = LLVM|" << getMSVCConfigName(*arch) << "\n"
+			         << "\t\t{" << i->second << "}.LLVM|" << getMSVCConfigName(*arch) << ".Build.0 = LLVM|" << getMSVCConfigName(*arch) << "\n"
+			         << "\t\t{" << i->second << "}.Release|" << getMSVCConfigName(*arch) << ".ActiveCfg = Release|" << getMSVCConfigName(*arch) << "\n"
+			         << "\t\t{" << i->second << "}.Release|" << getMSVCConfigName(*arch) << ".Build.0 = Release|" << getMSVCConfigName(*arch) << "\n";
 		}
 	}
 
 	solution << "\tEndGlobalSection\n"
-	            "\tGlobalSection(SolutionProperties) = preSolution\n"
-	            "\t\tHideSolutionNode = FALSE\n"
-	            "\tEndGlobalSection\n"
-	            "EndGlobal\n";
+	         << "\tGlobalSection(SolutionProperties) = preSolution\n"
+	         << "\t\tHideSolutionNode = FALSE\n"
+	         << "\tEndGlobalSection\n"
+	         << "EndGlobal\n";
 }
 
 void MSVCProvider::createOtherBuildFiles(const BuildSetup &setup) {
@@ -209,4 +208,4 @@ std::string MSVCProvider::getPostBuildEvent(MSVC_Architecture arch, const BuildS
 	return cmdLine;
 }
 
-} // End of CreateProjectTool namespace
+} // namespace CreateProjectTool

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -25,8 +25,6 @@
 
 #include "create_project.h"
 
-extern std::map<MSVC_Architecture, StringList> s_arch_disabled_features;
-
 namespace CreateProjectTool {
 
 class MSVCProvider : public ProjectProvider {
@@ -38,6 +36,9 @@ protected:
 
 	StringList _enableLanguageExtensions;
 	StringList _disableEditAndContinue;
+
+	std::list<MSVC_Architecture> _archs;
+	std::map<MSVC_Architecture, StringList> _arch_disabled_features;
 
 	void createWorkspace(const BuildSetup &setup);
 

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -25,6 +25,8 @@
 
 #include "create_project.h"
 
+extern std::map<MSVC_Architecture, StringList> s_arch_disabled_features;
+
 namespace CreateProjectTool {
 
 class MSVCProvider : public ProjectProvider {
@@ -64,17 +66,17 @@ protected:
 	 * @param prefix File prefix, used to add additional include paths.
 	 * @param runBuildEvents true if generating a revision number, false otherwise
 	 */
-	virtual void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, int bits, const StringList &defines, const std::string &prefix, bool runBuildEvents) = 0;
+	virtual void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix, bool runBuildEvents) = 0;
 
 	/**
 	 * Generates the project properties for debug and release settings.
 	 *
 	 * @param setup Description of the desired build setup.
 	 * @param isRelease       Type of property file
-	 * @param isWin32         Bitness of property file
+	 * @param arch            Target architecture
 	 * @param configuration   Name of property file
 	 */
-	virtual void createBuildProp(const BuildSetup &setup, bool isRelease, bool isWin32, std::string configuration) = 0;
+	virtual void createBuildProp(const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration) = 0;
 
 	/**
 	 * Get the file extension for property files
@@ -96,12 +98,12 @@ protected:
 	/**
 	 * Get the command line for copying data files to the build directory.
 	 *
-	 * @param	isWin32	Bitness of property file.
+	 * @param	arch	Target architecture
 	 * @param	setup	Description of the desired build setup.
 	 *
 	 * @return	The post build event.
 	 */
-	std::string getPostBuildEvent(bool isWin32, const BuildSetup &setup) const;
+	std::string getPostBuildEvent(MSVC_Architecture arch, const BuildSetup &setup) const;
 };
 
 } // End of CreateProjectTool namespace

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -107,6 +107,6 @@ protected:
 	std::string getPostBuildEvent(MSVC_Architecture arch, const BuildSetup &setup) const;
 };
 
-} // End of CreateProjectTool namespace
+} // namespace CreateProjectTool
 
 #endif // TOOLS_CREATE_PROJECT_MSVC_H

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -79,19 +79,19 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 			libraries += ' ' + *i + ".lib";
 
 		// Win32
-		outputConfiguration(project, setup, libraries, "Debug", MSVC_Architecture::ARCH_X86);
-		outputConfiguration(project, setup, libraries, "Analysis", MSVC_Architecture::ARCH_X86);
-		outputConfiguration(project, setup, libraries, "LLVM", MSVC_Architecture::ARCH_X86);
-		outputConfiguration(project, setup, libraries, "Release", MSVC_Architecture::ARCH_X86);
+		outputConfiguration(project, setup, libraries, "Debug", ARCH_X86);
+		outputConfiguration(project, setup, libraries, "Analysis", ARCH_X86);
+		outputConfiguration(project, setup, libraries, "LLVM", ARCH_X86);
+		outputConfiguration(project, setup, libraries, "Release", ARCH_X86);
 
 		// x64
 		// For 'x64' we must disable NASM support. Usually we would need to disable the "nasm" feature for that and
 		// re-create the library list, BUT since NASM doesn't link any additional libraries, we can just use the
 		// libraries list created for IA-32. If that changes in the future, we need to adjust this part!
-		outputConfiguration(project, setup, libraries, "Debug", MSVC_Architecture::ARCH_AMD64);
-		outputConfiguration(project, setup, libraries, "Analysis", MSVC_Architecture::ARCH_AMD64);
-		outputConfiguration(project, setup, libraries, "LLVM", MSVC_Architecture::ARCH_AMD64); // NOTE: it was win32-x64 here
-		outputConfiguration(project, setup, libraries, "Release", MSVC_Architecture::ARCH_AMD64);
+		outputConfiguration(project, setup, libraries, "Debug", ARCH_AMD64);
+		outputConfiguration(project, setup, libraries, "Analysis", ARCH_AMD64);
+		outputConfiguration(project, setup, libraries, "LLVM", ARCH_AMD64); // NOTE: it was win32-x64 here
+		outputConfiguration(project, setup, libraries, "Release", ARCH_AMD64);
 
 	} else {
 		bool enableLanguageExtensions = find(_enableLanguageExtensions.begin(), _enableLanguageExtensions.end(), name) != _enableLanguageExtensions.end();
@@ -299,7 +299,7 @@ void VisualStudioProvider::createBuildProp(const BuildSetup &setup, bool isRelea
 		              "\t\tRuntimeLibrary=\"1\"\n"
 		              "\t\tEnableFunctionLevelLinking=\"true\"\n"
 		              "\t\tWarnAsError=\"false\"\n"
-		              "\t\tDebugInformationFormat=\"" << (arch == MSVC_Architecture::ARCH_X86 ? "3" : "4") << "\"\n" // For x64 format "4" (Edit and continue) is not supported, thus we default to "3"
+		              "\t\tDebugInformationFormat=\"" << (arch == ARCH_X86 ? "3" : "4") << "\"\n" // For x64 format "4" (Edit and continue) is not supported, thus we default to "3"
 		              "\t\tAdditionalOption=\"" << (configuration == "Analysis" ? "/analyze" : "") << "\"\n"
 		              "\t/>\n"
 		              "\t<Tool\n"

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -51,8 +51,10 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
                                              const StringList &includeList, const StringList &excludeList) {
 	const std::string projectFile = setup.outputDir + '/' + name + getProjectExtension();
 	std::ofstream project(projectFile.c_str());
-	if (!project)
+	if (!project || !project.is_open()) {
 		error("Could not open \"" + projectFile + "\" for writing");
+		return;
+	}
 
 	project << "<?xml version=\"1.0\" encoding=\"windows-1252\"?>\n"
 	           "<VisualStudioProject\n"
@@ -259,8 +261,10 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 void VisualStudioProvider::createBuildProp(const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration) {
 
 	std::ofstream properties((setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCConfigName(arch) + getPropertiesExtension()).c_str());
-	if (!properties)
+	if (!properties || !properties.is_open()) {
 		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCConfigName(arch) + getPropertiesExtension() + "\" for writing");
+		return;
+	}
 
 	properties << "<?xml version=\"1.0\" encoding=\"Windows-1252\"?>\n"
 	              "<VisualStudioPropertySheet\n"

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -20,11 +20,11 @@
  *
  */
 
-#include "config.h"
 #include "visualstudio.h"
+#include "config.h"
 
-#include <fstream>
 #include <algorithm>
+#include <fstream>
 
 namespace CreateProjectTool {
 
@@ -32,8 +32,8 @@ namespace CreateProjectTool {
 // Visual Studio Provider (Visual Studio 2008)
 //////////////////////////////////////////////////////////////////////////
 
-VisualStudioProvider::VisualStudioProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion& msvc)
-	: MSVCProvider(global_warnings, project_warnings, version, msvc) {
+VisualStudioProvider::VisualStudioProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion &msvc)
+    : MSVCProvider(global_warnings, project_warnings, version, msvc) {
 
 	_archs.push_back(ARCH_X86);
 	_archs.push_back(ARCH_AMD64);
@@ -57,13 +57,13 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 	}
 
 	project << "<?xml version=\"1.0\" encoding=\"windows-1252\"?>\n"
-	           "<VisualStudioProject\n"
-	           "\tProjectType=\"Visual C++\"\n"
-	           "\tVersion=\"" << _version << ".00\"\n"
-	           "\tName=\"" << name << "\"\n"
-	           "\tProjectGUID=\"{" << uuid << "}\"\n"
-	           "\tRootNamespace=\"" << name << "\"\n"
-	           "\tKeyword=\"Win32Proj\"\n";
+	        << "<VisualStudioProject\n"
+	        << "\tProjectType=\"Visual C++\"\n"
+	        << "\tVersion=\"" << _version << ".00\"\n"
+	        << "\tName=\"" << name << "\"\n"
+	        << "\tProjectGUID=\"{" << uuid << "}\"\n"
+	        << "\tRootNamespace=\"" << name << "\"\n"
+	        << "\tKeyword=\"Win32Proj\"\n";
 
 	project << "\tTargetFrameworkVersion=\"131072\"\n";
 
@@ -73,10 +73,10 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 		project << "\t\t<Platform Name=\"" << getMSVCConfigName(*arch) << "\" />\n";
 	}
 	project << "\t</Platforms>\n"
-	           "\t<Configurations>\n";
+	        << "\t<Configurations>\n";
 
 	// Check for project-specific warnings:
-	std::map< std::string, std::list<std::string> >::iterator warningsIterator = _projectWarnings.find(name);
+	std::map<std::string, std::list<std::string> >::iterator warningsIterator = _projectWarnings.find(name);
 
 	if (setup.devTools || setup.tests || name == setup.projectName) {
 		std::string libraries;
@@ -101,11 +101,11 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 		std::string warnings = "";
 		if (warningsIterator != _projectWarnings.end())
 			for (StringList::const_iterator i = warningsIterator->second.begin(); i != warningsIterator->second.end(); ++i)
-				warnings +=  *i + ';';
+				warnings += *i + ';';
 
 		std::string toolConfig;
-		toolConfig  = (!warnings.empty() ? "DisableSpecificWarnings=\"" + warnings + "\"" : "");
-		toolConfig += (disableEditAndContinue   ? "DebugInformationFormat=\"3\" " : "");
+		toolConfig = (!warnings.empty() ? "DisableSpecificWarnings=\"" + warnings + "\"" : "");
+		toolConfig += (disableEditAndContinue ? "DebugInformationFormat=\"3\" " : "");
 		toolConfig += (enableLanguageExtensions ? "DisableLanguageExtensions=\"false\" " : "");
 
 		for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
@@ -117,7 +117,7 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 	}
 
 	project << "\t</Configurations>\n"
-	           "\t<Files>\n";
+	        << "\t<Files>\n";
 
 	std::string modulePath;
 	if (!moduleDir.compare(0, setup.srcDir.size(), setup.srcDir)) {
@@ -137,44 +137,44 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 	}
 
 	project << "\t</Files>\n"
-	           "</VisualStudioProject>\n";
+	        << "</VisualStudioProject>\n";
 }
 
 void VisualStudioProvider::outputConfiguration(std::ostream &project, const BuildSetup &setup, const std::string &libraries, const std::string &config, const MSVC_Architecture arch) {
 	project << "\t\t<Configuration Name=\"" << config << "|" << getMSVCConfigName(arch) << "\" ConfigurationType=\"1\" InheritedPropertySheets=\".\\" << setup.projectDescription << "_" << config << getMSVCArchName(arch) << ".vsprops\">\n"
-	           "\t\t\t<Tool\tName=\"VCCLCompilerTool\" DisableLanguageExtensions=\"false\" DebugInformationFormat=\"3\" />\n"
-	           "\t\t\t<Tool\tName=\"VCLinkerTool\" OutputFile=\"$(OutDir)/" << setup.projectName << ".exe\"\n"
-	           "\t\t\t\tAdditionalDependencies=\"" << libraries << "\"\n"
-	           "\t\t\t/>\n";
+	        << "\t\t\t<Tool\tName=\"VCCLCompilerTool\" DisableLanguageExtensions=\"false\" DebugInformationFormat=\"3\" />\n"
+	        << "\t\t\t<Tool\tName=\"VCLinkerTool\" OutputFile=\"$(OutDir)/" << setup.projectName << ".exe\"\n"
+	        << "\t\t\t\tAdditionalDependencies=\"" << libraries << "\"\n"
+	        << "\t\t\t/>\n";
 	outputBuildEvents(project, setup, arch);
 	project << "\t\t</Configuration>\n";
 }
 
 void VisualStudioProvider::outputConfiguration(const BuildSetup &setup, std::ostream &project, const std::string &toolConfig, const std::string &config, const MSVC_Architecture arch) {
 	project << "\t\t<Configuration Name=\"" << config << "|" << getMSVCConfigName(arch) << "\" ConfigurationType=\"4\" InheritedPropertySheets=\".\\" << setup.projectDescription << "_" << config << getMSVCArchName(arch) << ".vsprops\">\n"
-	           "\t\t\t<Tool Name=\"VCCLCompilerTool\" "<< toolConfig << "/>\n"
-	           "\t\t</Configuration>\n";
+	        << "\t\t\t<Tool Name=\"VCCLCompilerTool\" " << toolConfig << "/>\n"
+	        << "\t\t</Configuration>\n";
 }
 
 void VisualStudioProvider::outputBuildEvents(std::ostream &project, const BuildSetup &setup, const MSVC_Architecture arch) {
 	if (!setup.devTools && !setup.tests && setup.runBuildEvents) {
 		project << "\t\t\t<Tool\tName=\"VCPreBuildEventTool\"\n"
-		           "\t\t\t\tCommandLine=\"" << getPreBuildEvent() << "\"\n"
-		           "\t\t\t/>\n"
-		           "\t\t\t<Tool\tName=\"VCPostBuildEventTool\"\n"
-		           "\t\t\t\tCommandLine=\"" << getPostBuildEvent(arch, setup) << "\"\n"
-		           "\t\t\t/>\n";
+		        << "\t\t\t\tCommandLine=\"" << getPreBuildEvent() << "\"\n"
+		        << "\t\t\t/>\n"
+		        << "\t\t\t<Tool\tName=\"VCPostBuildEventTool\"\n"
+		        << "\t\t\t\tCommandLine=\"" << getPostBuildEvent(arch, setup) << "\"\n"
+		        << "\t\t\t/>\n";
 	}
 
 	// Generate runner file before build for tests
 	if (setup.tests) {
 		project << "\t\t\t<Tool\tName=\"VCPreBuildEventTool\"\n"
-			"\t\t\t\tCommandLine=\"" << getTestPreBuildEvent(setup) << "\"\n"
-			"\t\t\t/>\n";
+		        << "\t\t\t\tCommandLine=\"" << getTestPreBuildEvent(setup) << "\"\n"
+		        << "\t\t\t/>\n";
 
 		project << "\t\t\t<Tool\tName=\"VCPostBuildEventTool\"\n"
-			"\t\t\t\tCommandLine=\"$(TargetPath)\" IgnoreExitCode=\"true\"\n"
-			"\t\t\t/>\n";
+		        << "\t\t\t\tCommandLine=\"$(TargetPath)\" IgnoreExitCode=\"true\"\n"
+		        << "\t\t\t/>\n";
 	}
 }
 
@@ -194,7 +194,7 @@ void VisualStudioProvider::writeReferences(const BuildSetup &setup, std::ofstrea
 void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix, bool runBuildEvents) {
 	std::string warnings;
 	for (StringList::const_iterator i = _globalWarnings.begin(); i != _globalWarnings.end(); ++i)
-		warnings +=  *i + ';';
+		warnings += *i + ';';
 
 	std::string definesList;
 	for (StringList::const_iterator i = defines.begin(); i != defines.end(); ++i) {
@@ -208,20 +208,20 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 		definesList += REVISION_DEFINE ";";
 
 	properties << "<?xml version=\"1.0\" encoding=\"Windows-1252\"?>\n"
-	              "<VisualStudioPropertySheet\n"
-	              "\tProjectType=\"Visual C++\"\n"
-	              "\tVersion=\"8.00\"\n"
-	              "\tName=\"" << setup.projectDescription << "_Global\"\n"
-	              "\tOutputDirectory=\"$(ConfigurationName)" << getMSVCArchName(arch) << "\"\n"
-	              "\tIntermediateDirectory=\"$(ConfigurationName)" << getMSVCArchName(arch) << "/$(ProjectName)\"\n"
-	              "\t>\n"
-	              "\t<Tool\n"
-	              "\t\tName=\"VCCLCompilerTool\"\n"
-	              "\t\tDisableLanguageExtensions=\"" << (setup.devTools ? "false" : "true") << "\"\n"
-	              "\t\tDisableSpecificWarnings=\"" << warnings << "\"\n"
-	              "\t\tAdditionalIncludeDirectories=\".\\;" << prefix << ";" << prefix << "\\engines;$(" << LIBS_DEFINE << ")\\include;$(" << LIBS_DEFINE << ")\\include\\SDL;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "\"\n"
-	              "\t\tPreprocessorDefinitions=\"" << definesList << "\"\n"
-	              "\t\tExceptionHandling=\"" << ((setup.devTools || setup.tests || _version == 14) ? "1" : "0") << "\"\n";
+	           << "<VisualStudioPropertySheet\n"
+	           << "\tProjectType=\"Visual C++\"\n"
+	           << "\tVersion=\"8.00\"\n"
+	           << "\tName=\"" << setup.projectDescription << "_Global\"\n"
+	           << "\tOutputDirectory=\"$(ConfigurationName)" << getMSVCArchName(arch) << "\"\n"
+	           << "\tIntermediateDirectory=\"$(ConfigurationName)" << getMSVCArchName(arch) << "/$(ProjectName)\"\n"
+	           << "\t>\n"
+	           << "\t<Tool\n"
+	           << "\t\tName=\"VCCLCompilerTool\"\n"
+	           << "\t\tDisableLanguageExtensions=\"" << (setup.devTools ? "false" : "true") << "\"\n"
+	           << "\t\tDisableSpecificWarnings=\"" << warnings << "\"\n"
+	           << "\t\tAdditionalIncludeDirectories=\".\\;" << prefix << ";" << prefix << "\\engines;$(" << LIBS_DEFINE << ")\\include;$(" << LIBS_DEFINE << ")\\include\\SDL;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "\"\n"
+	           << "\t\tPreprocessorDefinitions=\"" << definesList << "\"\n"
+	           << "\t\tExceptionHandling=\"" << ((setup.devTools || setup.tests || _version == 14) ? "1" : "0") << "\"\n";
 
 #if NEEDS_RTTI
 	properties << "\t\tRuntimeTypeInfo=\"true\"\n";
@@ -230,29 +230,29 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 #endif
 
 	properties << "\t\tWarningLevel=\"4\"\n"
-	              "\t\tWarnAsError=\"false\"\n"
-	              "\t\tCompileAs=\"0\"\n"
-	              "\t\t/>\n"
-	              "\t<Tool\n"
-	              "\t\tName=\"VCLibrarianTool\"\n"
-	              "\t\tIgnoreDefaultLibraryNames=\"\"\n"
-	              "\t/>\n"
-	              "\t<Tool\n"
-	              "\t\tName=\"VCLinkerTool\"\n"
-	              "\t\tIgnoreDefaultLibraryNames=\"\"\n"
-	              "\t\tSubSystem=\"1\"\n";
+	           << "\t\tWarnAsError=\"false\"\n"
+	           << "\t\tCompileAs=\"0\"\n"
+	           << "\t\t/>\n"
+	           << "\t<Tool\n"
+	           << "\t\tName=\"VCLibrarianTool\"\n"
+	           << "\t\tIgnoreDefaultLibraryNames=\"\"\n"
+	           << "\t/>\n"
+	           << "\t<Tool\n"
+	           << "\t\tName=\"VCLinkerTool\"\n"
+	           << "\t\tIgnoreDefaultLibraryNames=\"\"\n"
+	           << "\t\tSubSystem=\"1\"\n";
 
 	if (!setup.devTools && !setup.tests)
 		properties << "\t\tEntryPointSymbol=\"WinMainCRTStartup\"\n";
 
 	properties << "\t\tAdditionalLibraryDirectories=\"$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << "\"\n"
-	              "\t/>\n"
-	              "\t<Tool\n"
-	              "\t\tName=\"VCResourceCompilerTool\"\n"
-	              "\t\tAdditionalIncludeDirectories=\".\\;" << prefix << "\"\n"
-	              "\t\tPreprocessorDefinitions=\"" << definesList << "\"\n"
-	              "\t/>\n"
-	              "</VisualStudioPropertySheet>\n";
+	           << "\t/>\n"
+	           << "\t<Tool\n"
+	           << "\t\tName=\"VCResourceCompilerTool\"\n"
+	           << "\t\tAdditionalIncludeDirectories=\".\\;" << prefix << "\"\n"
+	           << "\t\tPreprocessorDefinitions=\"" << definesList << "\"\n"
+	           << "\t/>\n"
+	           << "</VisualStudioPropertySheet>\n";
 
 	properties.flush();
 }
@@ -266,52 +266,52 @@ void VisualStudioProvider::createBuildProp(const BuildSetup &setup, bool isRelea
 	}
 
 	properties << "<?xml version=\"1.0\" encoding=\"Windows-1252\"?>\n"
-	              "<VisualStudioPropertySheet\n"
-	              "\tProjectType=\"Visual C++\"\n"
-	              "\tVersion=\"8.00\"\n"
-	              "\tName=\"" << setup.projectDescription << "_" << configuration << getMSVCArchName(arch) << "\"\n"
-	              "\tInheritedPropertySheets=\".\\" << setup.projectDescription << "_Global" << getMSVCArchName(arch) << ".vsprops\"\n"
-	              "\t>\n"
-	              "\t<Tool\n"
-	              "\t\tName=\"VCCLCompilerTool\"\n";
+	           << "<VisualStudioPropertySheet\n"
+	           << "\tProjectType=\"Visual C++\"\n"
+	           << "\tVersion=\"8.00\"\n"
+	           << "\tName=\"" << setup.projectDescription << "_" << configuration << getMSVCArchName(arch) << "\"\n"
+	           << "\tInheritedPropertySheets=\".\\" << setup.projectDescription << "_Global" << getMSVCArchName(arch) << ".vsprops\"\n"
+	           << "\t>\n"
+	           << "\t<Tool\n"
+	           << "\t\tName=\"VCCLCompilerTool\"\n";
 
 	if (isRelease) {
 		properties << "\t\tEnableIntrinsicFunctions=\"true\"\n"
-		              "\t\tWholeProgramOptimization=\"true\"\n"
-		              "\t\tPreprocessorDefinitions=\"WIN32;RELEASE_BUILD\"\n"
-		              "\t\tStringPooling=\"true\"\n"
-		              "\t\tBufferSecurityCheck=\"false\"\n"
-		              "\t\tDebugInformationFormat=\"0\"\n"
-		              "\t\tRuntimeLibrary=\"0\"\n"
-		              "\t\tAdditionalOption=\"" << (configuration == "Analysis" ? "/analyze" : "") << "\"\n"
-		              "\t/>\n"
-		              "\t<Tool\n"
-		              "\t\tName=\"VCLinkerTool\"\n"
-		              "\t\tLinkIncremental=\"1\"\n"
-		              "\t\tGenerateManifest=\"false\"\n"
-		              "\t\tIgnoreDefaultLibraryNames=\"\"\n"
-		              "\t\tSetChecksum=\"true\"\n";
+		           << "\t\tWholeProgramOptimization=\"true\"\n"
+		           << "\t\tPreprocessorDefinitions=\"WIN32;RELEASE_BUILD\"\n"
+		           << "\t\tStringPooling=\"true\"\n"
+		           << "\t\tBufferSecurityCheck=\"false\"\n"
+		           << "\t\tDebugInformationFormat=\"0\"\n"
+		           << "\t\tRuntimeLibrary=\"0\"\n"
+		           << "\t\tAdditionalOption=\"" << (configuration == "Analysis" ? "/analyze" : "") << "\"\n"
+		           << "\t/>\n"
+		           << "\t<Tool\n"
+		           << "\t\tName=\"VCLinkerTool\"\n"
+		           << "\t\tLinkIncremental=\"1\"\n"
+		           << "\t\tGenerateManifest=\"false\"\n"
+		           << "\t\tIgnoreDefaultLibraryNames=\"\"\n"
+		           << "\t\tSetChecksum=\"true\"\n";
 	} else {
 		properties << "\t\tOptimization=\"0\"\n"
-		              "\t\tPreprocessorDefinitions=\"WIN32\"\n"
-		              "\t\tMinimalRebuild=\"true\"\n"
-		              "\t\tBasicRuntimeChecks=\"3\"\n"
-		              "\t\tRuntimeLibrary=\"1\"\n"
-		              "\t\tEnableFunctionLevelLinking=\"true\"\n"
-		              "\t\tWarnAsError=\"false\"\n"
-		              "\t\tDebugInformationFormat=\"" << (arch == ARCH_X86 ? "3" : "4") << "\"\n" // For x64 format "4" (Edit and continue) is not supported, thus we default to "3"
-		              "\t\tAdditionalOption=\"" << (configuration == "Analysis" ? "/analyze" : "") << "\"\n"
-		              "\t/>\n"
-		              "\t<Tool\n"
-		              "\t\tName=\"VCLinkerTool\"\n"
-		              "\t\tLinkIncremental=\"2\"\n"
-		              "\t\tGenerateManifest=\"false\"\n"
-		              "\t\tGenerateDebugInformation=\"true\"\n"
-		              "\t\tIgnoreDefaultLibraryNames=\"libcmt.lib\"\n";
+		           << "\t\tPreprocessorDefinitions=\"WIN32\"\n"
+		           << "\t\tMinimalRebuild=\"true\"\n"
+		           << "\t\tBasicRuntimeChecks=\"3\"\n"
+		           << "\t\tRuntimeLibrary=\"1\"\n"
+		           << "\t\tEnableFunctionLevelLinking=\"true\"\n"
+		           << "\t\tWarnAsError=\"false\"\n"
+		           << "\t\tDebugInformationFormat=\"" << (arch == ARCH_X86 ? "3" : "4") << "\"\n" // For x64 format "4" (Edit and continue) is not supported, thus we default to "3"
+		           << "\t\tAdditionalOption=\"" << (configuration == "Analysis" ? "/analyze" : "") << "\"\n"
+		           << "\t/>\n"
+		           << "\t<Tool\n"
+		           << "\t\tName=\"VCLinkerTool\"\n"
+		           << "\t\tLinkIncremental=\"2\"\n"
+		           << "\t\tGenerateManifest=\"false\"\n"
+		           << "\t\tGenerateDebugInformation=\"true\"\n"
+		           << "\t\tIgnoreDefaultLibraryNames=\"libcmt.lib\"\n";
 	}
 
 	properties << "\t/>\n"
-	              "</VisualStudioPropertySheet>\n";
+	           << "</VisualStudioPropertySheet>\n";
 
 	properties.flush();
 	properties.close();
@@ -370,7 +370,7 @@ void VisualStudioProvider::writeFileListToProject(const FileNode &dir, std::ofst
 }
 
 void VisualStudioProvider::writeFileToProject(std::ofstream &projectFile, const std::string &filePath, MSVC_Architecture arch,
-											  const std::string &indentString, const std::string &toolLine) {
+                                              const std::string &indentString, const std::string &toolLine) {
 	projectFile << indentString << "<File RelativePath=\"" << filePath << "\">\n"
 	            << indentString << "\t<FileConfiguration Name=\"Debug|" << getMSVCConfigName(arch) << "\">\n"
 	            << toolLine
@@ -387,4 +387,4 @@ void VisualStudioProvider::writeFileToProject(std::ofstream &projectFile, const 
 	            << indentString << "</File>\n";
 }
 
-} // End of CreateProjectTool namespace
+} // namespace CreateProjectTool

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -109,11 +109,10 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 		toolConfig += (enableLanguageExtensions ? "DisableLanguageExtensions=\"false\" " : "");
 
 		for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
-			const std::string outputBitness = (*arch == ARCH_X86 ? "" : "64");
-			outputConfiguration(setup, project, toolConfig, "Debug", getMSVCConfigName(*arch), outputBitness);
-			outputConfiguration(setup, project, toolConfig, "Analysis", getMSVCConfigName(*arch), outputBitness);
-			outputConfiguration(setup, project, toolConfig, "LLVM", getMSVCConfigName(*arch), outputBitness);
-			outputConfiguration(setup, project, toolConfig, "Release", getMSVCConfigName(*arch), outputBitness);
+			outputConfiguration(setup, project, toolConfig, "Debug", *arch);
+			outputConfiguration(setup, project, toolConfig, "Analysis", *arch);
+			outputConfiguration(setup, project, toolConfig, "LLVM", *arch);
+			outputConfiguration(setup, project, toolConfig, "Release", *arch);
 		}
 	}
 
@@ -151,8 +150,8 @@ void VisualStudioProvider::outputConfiguration(std::ostream &project, const Buil
 	project << "\t\t</Configuration>\n";
 }
 
-void VisualStudioProvider::outputConfiguration(const BuildSetup &setup, std::ostream &project, const std::string &toolConfig, const std::string &config, const std::string &platform, const std::string &props) {
-	project << "\t\t<Configuration Name=\"" << config << "|" << platform << "\" ConfigurationType=\"4\" InheritedPropertySheets=\".\\" << setup.projectDescription << "_" << config << props << ".vsprops\">\n"
+void VisualStudioProvider::outputConfiguration(const BuildSetup &setup, std::ostream &project, const std::string &toolConfig, const std::string &config, const MSVC_Architecture arch) {
+	project << "\t\t<Configuration Name=\"" << config << "|" << getMSVCConfigName(arch) << "\" ConfigurationType=\"4\" InheritedPropertySheets=\".\\" << setup.projectDescription << "_" << config << getMSVCArchName(arch) << ".vsprops\">\n"
 	           "\t\t\t<Tool Name=\"VCCLCompilerTool\" "<< toolConfig << "/>\n"
 	           "\t\t</Configuration>\n";
 }
@@ -260,9 +259,9 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 
 void VisualStudioProvider::createBuildProp(const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration) {
 
-	std::ofstream properties((setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCConfigName(arch) + getPropertiesExtension()).c_str());
+	std::ofstream properties((setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCArchName(arch) + getPropertiesExtension()).c_str());
 	if (!properties || !properties.is_open()) {
-		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCConfigName(arch) + getPropertiesExtension() + "\" for writing");
+		error("Could not open \"" + setup.outputDir + '/' + setup.projectDescription + "_" + configuration + getMSVCArchName(arch) + getPropertiesExtension() + "\" for writing");
 		return;
 	}
 
@@ -270,8 +269,8 @@ void VisualStudioProvider::createBuildProp(const BuildSetup &setup, bool isRelea
 	              "<VisualStudioPropertySheet\n"
 	              "\tProjectType=\"Visual C++\"\n"
 	              "\tVersion=\"8.00\"\n"
-	              "\tName=\"" << setup.projectDescription << "_" << configuration << getMSVCConfigName(arch) << "\"\n"
-	              "\tInheritedPropertySheets=\".\\" << setup.projectDescription << "_Global" << getMSVCConfigName(arch) << ".vsprops\"\n"
+	              "\tName=\"" << setup.projectDescription << "_" << configuration << getMSVCArchName(arch) << "\"\n"
+	              "\tInheritedPropertySheets=\".\\" << setup.projectDescription << "_Global" << getMSVCArchName(arch) << ".vsprops\"\n"
 	              "\t>\n"
 	              "\t<Tool\n"
 	              "\t\tName=\"VCCLCompilerTool\"\n";

--- a/devtools/create_project/visualstudio.h
+++ b/devtools/create_project/visualstudio.h
@@ -40,16 +40,16 @@ protected:
 
 	void writeReferences(const BuildSetup &setup, std::ofstream &output);
 
-	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, int bits, const StringList &defines, const std::string &prefix, bool runBuildEvents);
+	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix, bool runBuildEvents);
 
-	void createBuildProp(const BuildSetup &setup, bool isRelease, bool isWin32, std::string configuration);
+	void createBuildProp(const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration);
 
 	const char *getProjectExtension();
 	const char *getPropertiesExtension();
 
-	void outputConfiguration(std::ostream &project, const BuildSetup &setup, const std::string &libraries, const std::string &config, const std::string &platform, const std::string &props, const bool isWin32);
+	void outputConfiguration(std::ostream &project, const BuildSetup &setup, const std::string &libraries, const std::string &config, const MSVC_Architecture arch);
 	void outputConfiguration(const BuildSetup &setup, std::ostream &project, const std::string &toolConfig, const std::string &config, const std::string &platform, const std::string &props);
-	void outputBuildEvents(std::ostream &project, const BuildSetup &setup, const bool isWin32);
+	void outputBuildEvents(std::ostream &project, const BuildSetup &setup, const MSVC_Architecture arch);
 };
 
 } // End of CreateProjectTool namespace

--- a/devtools/create_project/visualstudio.h
+++ b/devtools/create_project/visualstudio.h
@@ -38,6 +38,9 @@ protected:
 	void writeFileListToProject(const FileNode &dir, std::ofstream &projectFile, const int indentation,
 	                            const StringList &duplicate, const std::string &objPrefix, const std::string &filePrefix);
 
+	void writeFileToProject(std::ofstream &projectFile, const std::string &filePath, MSVC_Architecture arch,
+							const std::string &indentString, const std::string &toolLine);
+
 	void writeReferences(const BuildSetup &setup, std::ofstream &output);
 
 	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix, bool runBuildEvents);

--- a/devtools/create_project/visualstudio.h
+++ b/devtools/create_project/visualstudio.h
@@ -51,7 +51,7 @@ protected:
 	const char *getPropertiesExtension();
 
 	void outputConfiguration(std::ostream &project, const BuildSetup &setup, const std::string &libraries, const std::string &config, const MSVC_Architecture arch);
-	void outputConfiguration(const BuildSetup &setup, std::ostream &project, const std::string &toolConfig, const std::string &config, const std::string &platform, const std::string &props);
+	void outputConfiguration(const BuildSetup &setup, std::ostream &project, const std::string &toolConfig, const std::string &config, const MSVC_Architecture arch);
 	void outputBuildEvents(std::ostream &project, const BuildSetup &setup, const MSVC_Architecture arch);
 };
 

--- a/devtools/create_project/visualstudio.h
+++ b/devtools/create_project/visualstudio.h
@@ -29,7 +29,7 @@ namespace CreateProjectTool {
 
 class VisualStudioProvider : public MSVCProvider {
 public:
-	VisualStudioProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion& msvc);
+	VisualStudioProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion &msvc);
 
 protected:
 	void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
@@ -39,7 +39,7 @@ protected:
 	                            const StringList &duplicate, const std::string &objPrefix, const std::string &filePrefix);
 
 	void writeFileToProject(std::ofstream &projectFile, const std::string &filePath, MSVC_Architecture arch,
-							const std::string &indentString, const std::string &toolLine);
+	                        const std::string &indentString, const std::string &toolLine);
 
 	void writeReferences(const BuildSetup &setup, std::ofstream &output);
 
@@ -55,6 +55,6 @@ protected:
 	void outputBuildEvents(std::ostream &project, const BuildSetup &setup, const MSVC_Architecture arch);
 };
 
-} // End of CreateProjectTool namespace
+} // namespace CreateProjectTool
 
 #endif // TOOLS_CREATE_PROJECT_VISUALSTUDIO_H


### PR DESCRIPTION
[vcpkg](https://github.com/microsoft/vcpkg) is a C++ Library Manager, primarily for Windows. It's fairly popular as Windows is missing a proper package manager built into the system. Vcpkg also provides support for targetting different architectures supported by MSVC: x86, AMD64, arm64.

Last year I built ScummVM for Windows on Arm as a one-off binary and created relevant ports in vcpkg upstream. The last has finally landed and I want to contribute a more sustainable way of producing vcpkg-based ScummVM builds and extend support for MSVC arm64.

My initial plan was to use cmake, the cross-platform meta build system, but ScummVM seems to take the cross-platform out of it, so instead I restorted to using the msbuild-based system.

I tried keeping with the code style, but given how many contradicting formatters are provided, I used none.

I tried keeping current libraries working without any changes, but haven't tested that. I had to add a new option to `create_project`: `--use-canonical-lib-names` to map the libraries' names from how they're called in `SCUMMVM_LIBS` to how they are usually called when built with respective build systems. The bulk of work to support vcpkg went into extending the expected paths for includes and libraries.

As a non-Windows user I may have mislabelled something or violated some convention, but the builds were tested and all work.

One issue I encountered was I couldn't get the symbols for `FLAC__StreamDecoderStateString` and `FLAC__StreamDecoderErrorStatusString` to link properly, so I removed them in hope this is a rarely reported issue and the error code will suffice.

The builds are by default using dynamic linking, unlike the binaries usually produced by the project, that's primarily to accommodate one of the libs' (I think it was freetype, but I'm not sure) dependency on glib, which needs to be compiled to a dynamic library and it should be relatively easy to change it to static linkage, if said library was to be dropped from build. I don't know about mix-n-match situation, but as this is not intended to replace the current builds, I don't consider this a problem.

~~On top of it all sits a commit a bit out of scope for this PR, enabling GitHub Actions-based CI exercising the vcpkg-provided libs. There's caching of vcpkg libraries implemented inside the action, however my tests suggest it works for x86 and arm64 only, with AMD64 job rebuilding them over and over again. I don't know why that is and would rather see the job removed instead of investigating why. The jobs all produce relevant artifacts: libs as produced by vcpkg, scummvm binaries with all used libs, debug symbols.~~

CI stuff moved out to https://github.com/scummvm/scummvm/pull/2369

Finally, a screenshot:

![teenagent](https://user-images.githubusercontent.com/550290/81870472-3076e800-9576-11ea-991a-2c92972d0251.PNG)
