### PR TITLE
ULTIMA8: Fix loading of game saves after music process rename.

### DIFF
--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -233,6 +233,8 @@ void Ultima8Engine::startup() {
 		ProcessLoader<CameraProcess>::load);
 	_kernel->addProcessLoader("MusicProcess", // parent class name for save game backwards-compatibility.
 		ProcessLoader<U8MusicProcess>::load);
+	_kernel->addProcessLoader("U8MusicProcess",
+		ProcessLoader<U8MusicProcess>::load);
 	_kernel->addProcessLoader("RemorseMusicProcess",
 		ProcessLoader<RemorseMusicProcess>::load);
 	_kernel->addProcessLoader("AudioProcess",


### PR DESCRIPTION
Both the old class name and the new class name for a process or object must be registered for load compatibility
