### PR TITLE
ULTIMA8: More custom type checking cleanup

### DIFF
--- a/engines/ultima/ultima8/games/start_crusader_process.cpp
+++ b/engines/ultima/ultima8/games/start_crusader_process.cpp
@@ -98,7 +98,7 @@ void StartCrusaderProcess::run() {
 		}
 
 		uint16 objid = uclist.getuint16(0);
-		Egg *egg = p_dynamic_cast<Egg *>(getObject(objid));
+		Egg *egg = dynamic_cast<Egg *>(getObject(objid));
 		int32 ix, iy, iz;
 		egg->getLocation(ix, iy, iz);
 		// Center on egg

--- a/engines/ultima/ultima8/games/start_u8_process.cpp
+++ b/engines/ultima/ultima8/games/start_u8_process.cpp
@@ -78,7 +78,7 @@ void StartU8Process::run() {
 		}
 
 		uint16 objid = uclist.getuint16(0);
-		Egg *egg = p_dynamic_cast<Egg *>(getObject(objid));
+		Egg *egg = dynamic_cast<Egg *>(getObject(objid));
 		int32 ix, iy, iz;
 		egg->getLocation(ix, iy, iz);
 		// Center on egg

--- a/engines/ultima/ultima8/graphics/fonts/font_manager.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font_manager.cpp
@@ -162,7 +162,7 @@ bool FontManager::addTTFOverride(unsigned int fontnum, const Std::string &filena
 
 bool FontManager::addJPOverride(unsigned int fontnum,
                                 unsigned int jpfont, uint32 rgb) {
-	ShapeFont *jf = p_dynamic_cast<ShapeFont *>(GameData::get_instance()->getFonts()->getFont(jpfont));
+	ShapeFont *jf = dynamic_cast<ShapeFont *>(GameData::get_instance()->getFonts()->getFont(jpfont));
 	if (!jf)
 		return false;
 

--- a/engines/ultima/ultima8/graphics/fonts/font_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font_shape_archive.cpp
@@ -33,7 +33,7 @@ namespace Ultima8 {
 DEFINE_RUNTIME_CLASSTYPE_CODE(FontShapeArchive, ShapeArchive)
 
 ShapeFont *FontShapeArchive::getFont(uint32 fontnum) {
-	return p_dynamic_cast<ShapeFont *>(getShape(fontnum));
+	return dynamic_cast<ShapeFont *>(getShape(fontnum));
 }
 
 void FontShapeArchive::cache(uint32 shapenum) {

--- a/engines/ultima/ultima8/gumps/ask_gump.cpp
+++ b/engines/ultima/ultima8/gumps/ask_gump.cpp
@@ -141,7 +141,7 @@ bool AskGump::loadData(Common::ReadStream *rs, uint32 version) {
 		Std::list<Gump *>::iterator it;
 		for (it = _children.begin(); it != _children.end(); ++it) {
 			if ((*it)->GetIndex() != (int)i) continue;
-			child = p_dynamic_cast<ButtonWidget *>(*it);
+			child = dynamic_cast<ButtonWidget *>(*it);
 			if (!child) continue;
 		}
 

--- a/engines/ultima/ultima8/gumps/bark_gump.cpp
+++ b/engines/ultima/ultima8/gumps/bark_gump.cpp
@@ -115,7 +115,7 @@ void BarkGump::InitGump(Gump *newparent, bool take_focus) {
 }
 
 bool BarkGump::NextText() {
-	TextWidget *widget = p_dynamic_cast<TextWidget *>(getGump(_textWidget));
+	TextWidget *widget = dynamic_cast<TextWidget *>(getGump(_textWidget));
 	assert(widget);
 	if (widget->setupNextText()) {
 		// This is just a hack
@@ -209,7 +209,7 @@ bool BarkGump::loadData(Common::ReadStream *rs, uint32 version) {
 		_barked = "";
 	}
 
-	TextWidget *widget = p_dynamic_cast<TextWidget *>(getGump(_textWidget));
+	TextWidget *widget = dynamic_cast<TextWidget *>(getGump(_textWidget));
 	if (!widget)
 		return false;
 

--- a/engines/ultima/ultima8/gumps/book_gump.cpp
+++ b/engines/ultima/ultima8/gumps/book_gump.cpp
@@ -75,8 +75,8 @@ void BookGump::InitGump(Gump *newparent, bool take_focus) {
 }
 
 void BookGump::NextText() {
-	TextWidget *widgetL = p_dynamic_cast<TextWidget *>(getGump(_textWidgetL));
-	TextWidget *widgetR = p_dynamic_cast<TextWidget *>(getGump(_textWidgetR));
+	TextWidget *widgetL = dynamic_cast<TextWidget *>(getGump(_textWidgetL));
+	TextWidget *widgetR = dynamic_cast<TextWidget *>(getGump(_textWidgetR));
 	assert(widgetL);
 	assert(widgetR);
 	if (!widgetR->setupNextText()) {

--- a/engines/ultima/ultima8/gumps/container_gump.cpp
+++ b/engines/ultima/ultima8/gumps/container_gump.cpp
@@ -442,7 +442,7 @@ void ContainerGump::DropItem(Item *item, int mx, int my) {
 	GumpToParent(px, py);
 	// see what the item is being dropped on
 	Item *targetitem = getItem(TraceObjId(px, py));
-	Container *targetcontainer = p_dynamic_cast<Container *>(targetitem);
+	Container *targetcontainer = dynamic_cast<Container *>(targetitem);
 
 
 	if (item->getShapeInfo()->hasQuantity() &&

--- a/engines/ultima/ultima8/gumps/game_map_gump.cpp
+++ b/engines/ultima/ultima8/gumps/game_map_gump.cpp
@@ -345,8 +345,8 @@ void GameMapGump::onMouseClick(int button, int32 mx, int32 my) {
 //			PathfinderProcess* pfp = new PathfinderProcess(devon, objID, false);
 			Kernel::get_instance()->addProcess(pfp);
 #elif 0
-			if (p_dynamic_cast<Actor *>(item)) {
-				p_dynamic_cast<Actor *>(item)->die(0);
+			if (dynamic_cast<Actor *>(item)) {
+				dynamic_cast<Actor *>(item)->die(0);
 			} else {
 				item->destroy();
 			}
@@ -394,7 +394,7 @@ void GameMapGump::onMouseDouble(int button, int32 mx, int32 my) {
 			item->getLocation(xv, yv, zv);
 			item->dumpInfo();
 
-			if (p_dynamic_cast<Actor *>(item) ||
+			if (dynamic_cast<Actor *>(item) ||
 			        avatar->canReach(item, 128)) { // CONSTANT!
 				// call the 'use' event
 				item->use();

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -109,7 +109,7 @@ void Gump::SetNotifyProcess(GumpNotifyProcess *proc) {
 }
 
 GumpNotifyProcess *Gump::GetNotifyProcess() {
-	return p_dynamic_cast<GumpNotifyProcess *>(Kernel::get_instance()->
+	return dynamic_cast<GumpNotifyProcess *>(Kernel::get_instance()->
 	        getProcess(_notifier));
 }
 
@@ -856,7 +856,7 @@ bool Gump::loadData(Common::ReadStream *rs, uint32 version) {
 	uint32 childcount = rs->readUint32LE();
 	for (unsigned int i = 0; i < childcount; ++i) {
 		Object *obj = ObjectManager::get_instance()->loadObject(rs, version);
-		Gump *child = p_dynamic_cast<Gump *>(obj);
+		Gump *child = dynamic_cast<Gump *>(obj);
 		if (!child) return false;
 
 		AddChild(child, false);

--- a/engines/ultima/ultima8/gumps/menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/menu_gump.cpp
@@ -194,9 +194,8 @@ bool MenuGump::OnKeyDown(int key, int mod) {
 }
 
 void MenuGump::ChildNotify(Gump *child, uint32 message) {
-	if (child->IsOfType<EditWidget>() && message == EditWidget::EDIT_ENTER) {
-		EditWidget *editwidget = p_dynamic_cast<EditWidget *>(child);
-		assert(editwidget);
+	EditWidget *editwidget = dynamic_cast<EditWidget *>(child);
+	if (editwidget && message == EditWidget::EDIT_ENTER) {
 		Std::string name = editwidget->getText();
 		if (!name.empty()) {
 			MainActor *av = getMainActor();
@@ -205,7 +204,8 @@ void MenuGump::ChildNotify(Gump *child, uint32 message) {
 		}
 	}
 
-	if (child->IsOfType<ButtonWidget>() && message == ButtonWidget::BUTTON_CLICK) {
+	ButtonWidget *buttonWidget = dynamic_cast<ButtonWidget *>(child);
+	if (buttonWidget && message == ButtonWidget::BUTTON_CLICK) {
 		selectEntry(child->GetIndex());
 	}
 }

--- a/engines/ultima/ultima8/gumps/message_box_gump.cpp
+++ b/engines/ultima/ultima8/gumps/message_box_gump.cpp
@@ -151,7 +151,8 @@ void MessageBoxGump::PaintThis(RenderSurface *surf, int32 lerp_factor, bool /*sc
 }
 
 void MessageBoxGump::ChildNotify(Gump *child, uint32 msg) {
-	if (child->IsOfType<ButtonWidget>() && msg == ButtonWidget::BUTTON_CLICK) {
+	ButtonWidget *buttonWidget = dynamic_cast<ButtonWidget *>(child);
+	if (buttonWidget && msg == ButtonWidget::BUTTON_CLICK) {
 		_processResult = child->GetIndex();
 		Close();
 	}

--- a/engines/ultima/ultima8/gumps/remorse_menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/remorse_menu_gump.cpp
@@ -188,7 +188,8 @@ bool RemorseMenuGump::OnKeyDown(int key, int mod) {
 }
 
 void RemorseMenuGump::ChildNotify(Gump *child, uint32 message) {
-	if (child->IsOfType<ButtonWidget>() && message == ButtonWidget::BUTTON_CLICK) {
+	ButtonWidget *buttonWidget = dynamic_cast<ButtonWidget *>(child);
+	if (buttonWidget && message == ButtonWidget::BUTTON_CLICK) {
 		selectEntry(child->GetIndex());
 	}
 }

--- a/engines/ultima/ultima8/gumps/scroll_gump.cpp
+++ b/engines/ultima/ultima8/gumps/scroll_gump.cpp
@@ -68,7 +68,7 @@ void ScrollGump::InitGump(Gump *newparent, bool take_focus) {
 }
 
 void ScrollGump::NextText() {
-	TextWidget *widget = p_dynamic_cast<TextWidget *>(getGump(_textWidget));
+	TextWidget *widget = dynamic_cast<TextWidget *>(getGump(_textWidget));
 	assert(widget);
 	if (!widget->setupNextText()) {
 		Close();

--- a/engines/ultima/ultima8/gumps/shape_viewer_gump.cpp
+++ b/engines/ultima/ultima8/gumps/shape_viewer_gump.cpp
@@ -156,7 +156,7 @@ void ShapeViewerGump::PaintThis(RenderSurface *surf, int32 lerp_factor, bool /*s
  
 	{
 		// Additional shapeinfo (only in main shapes archive)
-		MainShapeArchive *mainshapes = p_dynamic_cast<MainShapeArchive *>(_flex);
+		MainShapeArchive *mainshapes = dynamic_cast<MainShapeArchive *>(_flex);
 		if (!mainshapes || !shape_) return;
 
 		char buf3[128];

--- a/engines/ultima/ultima8/gumps/slider_gump.cpp
+++ b/engines/ultima/ultima8/gumps/slider_gump.cpp
@@ -183,7 +183,7 @@ void SliderGump::Close(bool no_del) {
 	_processResult = _value;
 
 	if (_usecodeNotifyPID) {
-		UCProcess *ucp = p_dynamic_cast<UCProcess *>(Kernel::get_instance()->getProcess(_usecodeNotifyPID));
+		UCProcess *ucp = dynamic_cast<UCProcess *>(Kernel::get_instance()->getProcess(_usecodeNotifyPID));
 		assert(ucp);
 		ucp->setReturnValue(_value);
 		ucp->wakeUp(_value);

--- a/engines/ultima/ultima8/gumps/u8_save_gump.cpp
+++ b/engines/ultima/ultima8/gumps/u8_save_gump.cpp
@@ -201,7 +201,7 @@ void U8SaveGump::onMouseClick(int button, int32 mx, int32 my) {
 
 	if (_save && !_focusChild && _editWidgets[i]) {
 		_editWidgets[i]->MakeFocus();
-		PagedGump *p = p_dynamic_cast<PagedGump *>(_parent);
+		PagedGump *p = dynamic_cast<PagedGump *>(_parent);
 		if (p) p->enableButtons(false);
 	}
 
@@ -223,12 +223,10 @@ void U8SaveGump::onMouseClick(int button, int32 mx, int32 my) {
 }
 
 void U8SaveGump::ChildNotify(Gump *child, uint32 message) {
-	if (child->IsOfType<EditWidget>() && message == EditWidget::EDIT_ENTER) {
+	EditWidget *widget = dynamic_cast<EditWidget *>(child);
+	if (widget && message == EditWidget::EDIT_ENTER) {
 		// _save
 		assert(_save);
-
-		EditWidget *widget = p_dynamic_cast<EditWidget *>(child);
-		assert(widget);
 
 		Std::string name = widget->getText();
 		if (name.empty()) return;
@@ -239,7 +237,7 @@ void U8SaveGump::ChildNotify(Gump *child, uint32 message) {
 		return;
 	}
 
-	if (child->IsOfType<EditWidget>() && message == EditWidget::EDIT_ESCAPE) {
+	if (widget && message == EditWidget::EDIT_ESCAPE) {
 		// cancel edit
 		assert(_save);
 
@@ -247,11 +245,9 @@ void U8SaveGump::ChildNotify(Gump *child, uint32 message) {
 		if (_focusChild) _focusChild->OnFocus(false);
 		_focusChild = 0;
 
-		PagedGump *p = p_dynamic_cast<PagedGump *>(_parent);
+		PagedGump *p = dynamic_cast<PagedGump *>(_parent);
 		if (p) p->enableButtons(true);
 
-		EditWidget *widget = p_dynamic_cast<EditWidget *>(child);
-		assert(widget);
 		widget->setText(_descriptions[widget->GetIndex() - 1]);
 
 		return;

--- a/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
@@ -87,7 +87,7 @@ void ButtonWidget::InitGump(Gump *newparent, bool take_focus) {
 int ButtonWidget::getVlead() {
 	if (_textWidget != 0) {
 		Gump *widget = getGump(_textWidget);
-		TextWidget *txtWidget = p_dynamic_cast<TextWidget *>(widget);
+		TextWidget *txtWidget = dynamic_cast<TextWidget *>(widget);
 		assert(txtWidget);
 		return txtWidget->getVlead();
 	} else {
@@ -155,7 +155,7 @@ void ButtonWidget::onMouseOver() {
 	if (_mouseOver) {
 		if (_textWidget) {
 			Gump *widget = getGump(_textWidget);
-			TextWidget *txtWidget = p_dynamic_cast<TextWidget *>(widget);
+			TextWidget *txtWidget = dynamic_cast<TextWidget *>(widget);
 			assert(txtWidget);
 			txtWidget->setBlendColour(_mouseOverBlendCol);
 		} else {
@@ -169,7 +169,7 @@ void ButtonWidget::onMouseLeft() {
 	if (_mouseOver) {
 		if (_textWidget) {
 			Gump *widget = getGump(_textWidget);
-			TextWidget *txtWidget = p_dynamic_cast<TextWidget *>(widget);
+			TextWidget *txtWidget = dynamic_cast<TextWidget *>(widget);
 			assert(txtWidget);
 			txtWidget->setBlendColour(0);
 		} else {

--- a/engines/ultima/ultima8/kernel/object_manager.cpp
+++ b/engines/ultima/ultima8/kernel/object_manager.cpp
@@ -100,10 +100,10 @@ void ObjectManager::reset() {
 	for (i = 0; i < _objects.size(); ++i) {
 		if (_objects[i] == 0) continue;
 #if 0
-		Item *item = p_dynamic_cast<Item *>(_objects[i]);
+		Item *item = dynamic_cast<Item *>(_objects[i]);
 		if (item && item->getParent()) continue; // will be deleted by parent
 #endif
-		Gump *gump = p_dynamic_cast<Gump *>(_objects[i]);
+		Gump *gump = dynamic_cast<Gump *>(_objects[i]);
 		if (gump && gump->GetParent()) continue; // will be deleted by parent
 		delete _objects[i];
 	}
@@ -218,9 +218,9 @@ void ObjectManager::save(Common::WriteStream *ws) {
 		if (!object) continue;
 
 		// child items/gumps are saved by their parent.
-		Item *item = p_dynamic_cast<Item *>(object);
+		Item *item = dynamic_cast<Item *>(object);
 		if (item && item->getParent()) continue;
-		Gump *gump = p_dynamic_cast<Gump *>(object);
+		Gump *gump = dynamic_cast<Gump *>(object);
 
 		// don't save Gumps with DONT_SAVE and Gumps with parents, unless
 		// the parent is a core gump
@@ -253,7 +253,7 @@ bool ObjectManager::load(Common::ReadStream *rs, uint32 version) {
 		if (!obj) return false;
 
 		// top level gumps have to be added to the correct core gump
-		Gump *gump = p_dynamic_cast<Gump *>(obj);
+		Gump *gump = dynamic_cast<Gump *>(obj);
 		if (gump) {
 			Ultima8Engine::get_instance()->addGump(gump);
 		}

--- a/engines/ultima/ultima8/misc/debugger.cpp
+++ b/engines/ultima/ultima8/misc/debugger.cpp
@@ -515,7 +515,7 @@ bool Debugger::cmdCheatItems(int argc, const char **argv) {
 	bagitem->setGumpLocation(70, 40);
 
 	bagitem = ItemFactory::createItem(637, 0, 0, 0, 0, 0, 0, true);
-	Container *bag = p_dynamic_cast<Container *>(bagitem);
+	Container *bag = dynamic_cast<Container *>(bagitem);
 
 	Item *reagents = ItemFactory::createItem(395, 0, 50, 0, 0, 0, 0, true);
 	reagents->moveToContainer(bag);
@@ -541,7 +541,7 @@ bool Debugger::cmdCheatItems(int argc, const char **argv) {
 
 	// theurgy foci
 	bagitem = ItemFactory::createItem(637, 0, 0, 0, 0, 0, 0, true);
-	bag = p_dynamic_cast<Container *>(bagitem);
+	bag = dynamic_cast<Container *>(bagitem);
 
 	Item *focus = ItemFactory::createItem(396, 8, 0, 0, 0, 0, 0, true);
 	focus->moveToContainer(bag);

--- a/engines/ultima/ultima8/misc/p_dynamic_cast.h
+++ b/engines/ultima/ultima8/misc/p_dynamic_cast.h
@@ -47,14 +47,12 @@ struct RunTimeClassType {
 #define ENABLE_RUNTIME_CLASSTYPE()                                              \
 	static const RunTimeClassType   ClassType;                                  \
 	virtual bool IsOfType(const RunTimeClassType & type) const override;        \
-	virtual bool IsOfType(const char * type) const override;                    \
 	template<class Type> inline bool IsOfType() const { return IsOfType(Type::ClassType); }   \
 	virtual const RunTimeClassType & GetClassType() const override { return ClassType; }
 
 #define ENABLE_RUNTIME_CLASSTYPE_BASE()                                         \
 	static const RunTimeClassType   ClassType;                                  \
 	virtual bool IsOfType(const RunTimeClassType & type) const;                 \
-	virtual bool IsOfType(const char * type) const;                             \
 	template<class Type> inline bool IsOfType() const { return IsOfType(Type::ClassType); }   \
 	virtual const RunTimeClassType & GetClassType() const { return ClassType; }
 
@@ -72,12 +70,6 @@ struct RunTimeClassType {
 	{                                                                   \
 		if (classType == ClassType) return true;                        \
 		return false;                                                   \
-	}                                                                   \
-	\
-	bool Classname::IsOfType(const char *classType) const               \
-	{                                                                   \
-		if (!Std::strcmp(classType,ClassType._className)) return true;  \
-		return false;                                                   \
 	}
 
 
@@ -93,15 +85,7 @@ struct RunTimeClassType {
 	{                                                                   \
 		if (classType == ClassType) return true;                        \
 		return ParentClassname::IsOfType(classType);                    \
-	}                                                                   \
-	\
-	bool Classname::IsOfType(const char *typeName) const                \
-	{                                                                   \
-		if (!Std::strcmp(typeName,ClassType._className)) return true;   \
-		return ParentClassname::IsOfType(typeName);                     \
 	}
-
-
 
 //
 // Define this in the source files of child classes, with 2 parents
@@ -116,16 +100,6 @@ struct RunTimeClassType {
 		typedef Parent1 P1;                                                 \
 		typedef Parent2 P2;                                                 \
 		if (type == ClassType) return true;                                 \
-		bool ret = P1::IsOfType(type);                                      \
-		if (ret) return true;                                               \
-		return P2::IsOfType(type);                                          \
-	}                                                                       \
-	\
-	bool Classname::IsOfType(const char * type) const                       \
-	{                                                                       \
-		typedef Parent1 P1;                                                 \
-		typedef Parent2 P2;                                                 \
-		if (!Std::strcmp(type,ClassType._className)) return true;           \
 		bool ret = P1::IsOfType(type);                                      \
 		if (ret) return true;                                               \
 		return P2::IsOfType(type);                                          \

--- a/engines/ultima/ultima8/misc/p_dynamic_cast.h
+++ b/engines/ultima/ultima8/misc/p_dynamic_cast.h
@@ -26,12 +26,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-// The Pentagram dynamic cast
-template<class A, class B> inline A p_dynamic_cast(B *object) {
-	if (object && object->IsOfType(static_cast<A>(0)->ClassType)) return static_cast<A>(object);
-	return nullptr;
-}
-
 // This is just a 'type' used to differentiate each class.
 struct RunTimeClassType {
 	const char *_className;

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -792,7 +792,7 @@ void Ultima8Engine::handleEvent(const Common::Event &event) {
 
 	if (!_textModes.empty()) {
 		while (!_textModes.empty()) {
-			gump = p_dynamic_cast<Gump *>(_objectManager->getObject(_textModes.front()));
+			gump = dynamic_cast<Gump *>(_objectManager->getObject(_textModes.front()));
 			if (gump)
 				break;
 
@@ -1369,7 +1369,7 @@ void Ultima8Engine::Error(Std::string message, Std::string title, bool exit_to_m
 }
 
 Gump *Ultima8Engine::getGump(uint16 gumpid) {
-	return p_dynamic_cast<Gump *>(ObjectManager::get_instance()->
+	return dynamic_cast<Gump *>(ObjectManager::get_instance()->
 		getObject(gumpid));
 }
 
@@ -1435,7 +1435,7 @@ bool Ultima8Engine::load(Common::ReadStream *rs, uint32 version) {
 	_timeOffset = absoluteTime - Kernel::get_instance()->getFrameNum();
 
 	uint16 amppid = rs->readUint16LE();
-	_avatarMoverProcess = p_dynamic_cast<AvatarMoverProcess *>(Kernel::get_instance()->getProcess(amppid));
+	_avatarMoverProcess = dynamic_cast<AvatarMoverProcess *>(Kernel::get_instance()->getProcess(amppid));
 
 	int16 matrix[12];
 	for (int i = 0; i < 12; i++)
@@ -1567,7 +1567,7 @@ Gump *Ultima8Engine::getMenuGump() const {
 	if (_textModes.empty())
 		return nullptr;
 
-	return p_dynamic_cast<Gump *>(_objectManager->getObject(_textModes.front()));
+	return dynamic_cast<Gump *>(_objectManager->getObject(_textModes.front()));
 }
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/ultima8.h
+++ b/engines/ultima/ultima8/ultima8.h
@@ -180,7 +180,7 @@ public:
 	void GUIError(const Common::String &msg);
 
 	static Ultima8Engine *get_instance() {
-		return p_dynamic_cast<Ultima8Engine *>(_application);
+		return dynamic_cast<Ultima8Engine *>(_application);
 	}
 
 	void startup();

--- a/engines/ultima/ultima8/usecode/intrinsics.h
+++ b/engines/ultima/ultima8/usecode/intrinsics.h
@@ -73,9 +73,9 @@ typedef uint32(*Intrinsic)(const uint8 *args, unsigned int argsize);
 
 #define ARG_EGG_FROM_PTR(x) ARG_UC_PTR(ucptr_##x); \
 	uint16 id_##x = UCMachine::ptrToObject(ucptr_##x); \
-	Egg* x = p_dynamic_cast<Egg*>(getObject(id_##x));
+	Egg* x = dynamic_cast<Egg*>(getObject(id_##x));
 #define ARG_EGG_FROM_ID(x)    ARG_OBJID(id_##x); \
-	Egg* x = p_dynamic_cast<Egg*>(getObject(id_##x));
+	Egg* x = dynamic_cast<Egg*>(getObject(id_##x));
 
 #define ARG_STRING(x) ARG_UC_PTR(ucptr_##x); \
 	uint16 id_##x = UCMachine::ptrToObject(ucptr_##x); \

--- a/engines/ultima/ultima8/usecode/uc_machine.cpp
+++ b/engines/ultima/ultima8/usecode/uc_machine.cpp
@@ -2178,7 +2178,7 @@ bool UCMachine::assignPointer(uint32 ptr, const uint8 *data, uint32 size) {
 	uint16 offset = static_cast<uint16>(ptr & 0xFFFF);
 
 	if (segment >= SEG_STACK_FIRST && segment <= SEG_STACK_LAST) {
-		UCProcess *proc = p_dynamic_cast<UCProcess *>
+		UCProcess *proc = dynamic_cast<UCProcess *>
 		                  (Kernel::get_instance()->getProcess(segment));
 
 		// reference to the stack of _pid 'segment'
@@ -2215,7 +2215,7 @@ bool UCMachine::dereferencePointer(uint32 ptr, uint8 *data, uint32 size) {
 	uint16 offset = static_cast<uint16>(ptr & 0xFFFF);
 
 	if (segment >= SEG_STACK_FIRST && segment <= SEG_STACK_LAST) {
-		UCProcess *proc = p_dynamic_cast<UCProcess *>
+		UCProcess *proc = dynamic_cast<UCProcess *>
 		                  (Kernel::get_instance()->getProcess(segment));
 
 		// reference to the stack of _pid 'segment'
@@ -2254,7 +2254,7 @@ uint16 UCMachine::ptrToObject(uint32 ptr) {
 	uint16 segment = static_cast<uint16>(ptr >> 16);
 	uint16 offset = static_cast<uint16>(ptr);
 	if (segment >= SEG_STACK_FIRST && segment <= SEG_STACK_LAST) {
-		UCProcess *proc = p_dynamic_cast<UCProcess *>
+		UCProcess *proc = dynamic_cast<UCProcess *>
 		                  (Kernel::get_instance()->getProcess(segment));
 
 		// reference to the stack of _pid 'segment'

--- a/engines/ultima/ultima8/world/actors/actor.cpp
+++ b/engines/ultima/ultima8/world/actors/actor.cpp
@@ -839,7 +839,7 @@ ProcId Actor::killAllButFallAnims(bool death) {
 	ProcessIter iter = Kernel::get_instance()->getProcessBeginIterator();
 	ProcessIter endproc = Kernel::get_instance()->getProcessEndIterator();
 	for (; iter != endproc; ++iter) {
-		ActorAnimProcess *p = p_dynamic_cast<ActorAnimProcess *>(*iter);
+		ActorAnimProcess *p = dynamic_cast<ActorAnimProcess *>(*iter);
 		if (!p) continue;
 		if (p->getItemNum() != _objId) continue;
 		if (p->is_terminated()) continue;
@@ -963,7 +963,7 @@ CombatProcess *Actor::getCombatProcess() {
 	Process *p = Kernel::get_instance()->findProcess(_objId, 0xF2); // CONSTANT!
 	if (!p)
 		return nullptr;
-	CombatProcess *cp = p_dynamic_cast<CombatProcess *>(p);
+	CombatProcess *cp = dynamic_cast<CombatProcess *>(p);
 	assert(cp);
 
 	return cp;

--- a/engines/ultima/ultima8/world/actors/actor_anim_process.cpp
+++ b/engines/ultima/ultima8/world/actors/actor_anim_process.cpp
@@ -490,7 +490,7 @@ void ActorAnimProcess::doHitSpecial(Item *hit) {
 	Actor *a = getActor(_itemNum);
 	assert(a);
 
-	Actor *attacked = p_dynamic_cast<Actor *>(hit);
+	Actor *attacked = dynamic_cast<Actor *>(hit);
 
 	if (_itemNum == 1 && _action == Animation::attack) {
 		// some magic weapons have some special effects

--- a/engines/ultima/ultima8/world/actors/heal_process.cpp
+++ b/engines/ultima/ultima8/world/actors/heal_process.cpp
@@ -100,7 +100,7 @@ uint32 HealProcess::I_feedAvatar(const uint8 *args, unsigned int /*argsize*/) {
 	ARG_UINT16(food);
 
 	Process *p = Kernel::get_instance()->findProcess(0, 0x222); // CONSTANT!
-	HealProcess *hp = p_dynamic_cast<HealProcess *>(p);
+	HealProcess *hp = dynamic_cast<HealProcess *>(p);
 	if (!hp) {
 		perr << "I_feedAvatar: unable to find HealProcess!" << Std::endl;
 		return 0;

--- a/engines/ultima/ultima8/world/actors/main_actor.cpp
+++ b/engines/ultima/ultima8/world/actors/main_actor.cpp
@@ -61,7 +61,7 @@ MainActor::~MainActor() {
 GravityProcess *MainActor::ensureGravityProcess() {
 	AvatarGravityProcess *p;
 	if (_gravityPid) {
-		p = p_dynamic_cast<AvatarGravityProcess *>(
+		p = dynamic_cast<AvatarGravityProcess *>(
 		        Kernel::get_instance()->getProcess(_gravityPid));
 	} else {
 		p = new AvatarGravityProcess(this, 0);
@@ -297,7 +297,7 @@ void MainActor::clearInCombat() {
 ProcId MainActor::die(uint16 damageType) {
 	ProcId animprocid = Actor::die(damageType);
 
-	Ultima8Engine *app = p_dynamic_cast<Ultima8Engine *>(Ultima8Engine::get_instance());
+	Ultima8Engine *app = Ultima8Engine::get_instance();
 	assert(app);
 
 	app->setAvatarInStasis(true);

--- a/engines/ultima/ultima8/world/actors/pathfinder.cpp
+++ b/engines/ultima/ultima8/world/actors/pathfinder.cpp
@@ -163,7 +163,7 @@ void Pathfinder::setTarget(Item *item, bool hit) {
 
 	if (hit) {
 		assert(_start._combat);
-		assert(p_dynamic_cast<Actor *>(_targetItem));
+		assert(dynamic_cast<Actor *>(_targetItem));
 		_hitMode = true;
 	} else {
 		_hitMode = false;
@@ -193,7 +193,7 @@ bool Pathfinder::checkTarget(PathNode *node) const {
 	if (_targetItem) {
 		if (_hitMode) {
 			return node->state.checkHit(_actor,
-			                            p_dynamic_cast<Actor *>(_targetItem));
+			                            dynamic_cast<Actor *>(_targetItem));
 		} else {
 			return node->state.checkItem(_targetItem, 32, 8);
 		}

--- a/engines/ultima/ultima8/world/actors/quick_avatar_mover_process.cpp
+++ b/engines/ultima/ultima8/world/actors/quick_avatar_mover_process.cpp
@@ -140,7 +140,7 @@ void QuickAvatarMoverProcess::terminateMover(int dir) {
 	Kernel *kernel = Kernel::get_instance();
 
 	QuickAvatarMoverProcess *p =
-	    p_dynamic_cast<QuickAvatarMoverProcess *>(kernel->getProcess(_amp[dir]));
+	    dynamic_cast<QuickAvatarMoverProcess *>(kernel->getProcess(_amp[dir]));
 
 	if (p && !p->is_terminated())
 		p->terminate();

--- a/engines/ultima/ultima8/world/container.cpp
+++ b/engines/ultima/ultima8/world/container.cpp
@@ -91,7 +91,7 @@ bool Container::CanAddItem(Item *item, bool checkwghtvol) {
 
 	if (item->getObjId() < 256) return false; // actors don't fit in containers
 
-	Container *c = p_dynamic_cast<Container *>(item);
+	Container *c = dynamic_cast<Container *>(item);
 	if (c) {
 		// To quote Exult: "Watch for snake eating itself."
 		Container *p = this;
@@ -204,7 +204,7 @@ void Container::removeContents() {
 void Container::destroyContents() {
 	while (_contents.begin() != _contents.end()) {
 		Item *item = *(_contents.begin());
-		Container *cont = p_dynamic_cast<Container *>(item);
+		Container *cont = dynamic_cast<Container *>(item);
 		if (cont) cont->destroyContents();
 		item->destroy(true); // we destroy the item immediately
 	}
@@ -216,7 +216,7 @@ void Container::setFlagRecursively(uint32 mask) {
 	Std::list<Item *>::iterator iter;
 	for (iter = _contents.begin(); iter != _contents.end(); ++iter) {
 		(*iter)->setFlag(mask);
-		Container *cont = p_dynamic_cast<Container *>(*iter);
+		Container *cont = dynamic_cast<Container *>(*iter);
 		if (cont) cont->setFlagRecursively(mask);
 	}
 }
@@ -288,7 +288,7 @@ void Container::containerSearch(UCList *itemlist, const uint8 *loopscript,
 
 		if (recurse) {
 			// recurse into child-containers
-			Container *container = p_dynamic_cast<Container *>(*iter);
+			Container *container = dynamic_cast<Container *>(*iter);
 			if (container)
 				container->containerSearch(itemlist, loopscript,
 				                           scriptsize, recurse);
@@ -320,7 +320,7 @@ bool Container::loadData(Common::ReadStream *rs, uint32 version) {
 	// read _contents
 	for (unsigned int i = 0; i < contentcount; ++i) {
 		Object *obj = ObjectManager::get_instance()->loadObject(rs, version);
-		Item *item = p_dynamic_cast<Item *>(obj);
+		Item *item = dynamic_cast<Item *>(obj);
 		if (!item) return false;
 
 		addItem(item);

--- a/engines/ultima/ultima8/world/current_map.cpp
+++ b/engines/ultima/ultima8/world/current_map.cpp
@@ -126,7 +126,7 @@ void CurrentMap::writeback() {
 				}
 
 				// Reset the egg
-				Egg *egg = p_dynamic_cast<Egg *>(item);
+				Egg *egg = dynamic_cast<Egg *>(item);
 				if (egg) {
 					egg->reset();
 				}
@@ -237,9 +237,9 @@ void CurrentMap::addItem(Item *item) {
 	_items[cx][cy].push_front(item);
 	item->setExtFlag(Item::EXT_INCURMAP);
 
-	Egg *egg = p_dynamic_cast<Egg *>(item);
+	Egg *egg = dynamic_cast<Egg *>(item);
 	if (egg) {
-		EggHatcherProcess *ehp = p_dynamic_cast<EggHatcherProcess *>(Kernel::get_instance()->getProcess(_eggHatcher));
+		EggHatcherProcess *ehp = dynamic_cast<EggHatcherProcess *>(Kernel::get_instance()->getProcess(_eggHatcher));
 		assert(ehp);
 		ehp->addEgg(egg);
 	}
@@ -263,9 +263,9 @@ void CurrentMap::addItemToEnd(Item *item) {
 	_items[cx][cy].push_back(item);
 	item->setExtFlag(Item::EXT_INCURMAP);
 
-	Egg *egg = p_dynamic_cast<Egg *>(item);
+	Egg *egg = dynamic_cast<Egg *>(item);
 	if (egg) {
-		EggHatcherProcess *ehp = p_dynamic_cast<EggHatcherProcess *>(Kernel::get_instance()->getProcess(_eggHatcher));
+		EggHatcherProcess *ehp = dynamic_cast<EggHatcherProcess *>(Kernel::get_instance()->getProcess(_eggHatcher));
 		assert(ehp);
 		ehp->addEgg(egg);
 	}
@@ -485,7 +485,7 @@ void CurrentMap::areaSearch(UCList *itemlist, const uint8 *loopscript,
 
 				if (recurse) {
 					// recurse into child-containers
-					const Container *container = p_dynamic_cast<const Container *>(item);
+					const Container *container = dynamic_cast<const Container *>(item);
 					if (container)
 						container->containerSearch(itemlist, loopscript,
 						                           scriptsize, recurse);
@@ -582,7 +582,7 @@ TeleportEgg *CurrentMap::findDestination(uint16 id) {
 			item_list::iterator iter;
 			for (iter = _items[i][j].begin();
 			        iter != _items[i][j].end(); ++iter) {
-				TeleportEgg *egg = p_dynamic_cast<TeleportEgg *>(*iter);
+				TeleportEgg *egg = dynamic_cast<TeleportEgg *>(*iter);
 				if (egg) {
 					if (!egg->isTeleporter() && egg->getTeleportId() == id)
 						return egg;

--- a/engines/ultima/ultima8/world/egg_hatcher_process.cpp
+++ b/engines/ultima/ultima8/world/egg_hatcher_process.cpp
@@ -56,7 +56,7 @@ void EggHatcherProcess::run() {
 
 	for (unsigned int i = 0; i < _eggs.size(); i++) {
 		uint16 eggid = _eggs[i];
-		Egg *egg = p_dynamic_cast<Egg *>(getObject(eggid));
+		Egg *egg = dynamic_cast<Egg *>(getObject(eggid));
 		if (!egg) continue; // egg gone
 
 		int32 x, y, z;
@@ -78,7 +78,7 @@ void EggHatcherProcess::run() {
 		// if the avatar teleports, set the 'justTeleported' flag.
 		// if this is set, don't hatch any teleport _eggs
 		// unset it when you're out of range of any teleport _eggs
-		TeleportEgg *tegg = p_dynamic_cast<TeleportEgg *>(egg);
+		TeleportEgg *tegg = dynamic_cast<TeleportEgg *>(egg);
 
 		if (x1 <= ax && ax - axs < x2 && y1 <= ay && ay - ays < y2 &&
 		        z - 48 < az && az <= z + 48) { // CONSTANTS!

--- a/engines/ultima/ultima8/world/get_object.cpp
+++ b/engines/ultima/ultima8/world/get_object.cpp
@@ -37,23 +37,23 @@ Object *getObject(ObjId id) {
 }
 
 Item *getItem(ObjId id) {
-	return p_dynamic_cast<Item *>(ObjectManager::get_instance()->getObject(id));
+	return dynamic_cast<Item *>(ObjectManager::get_instance()->getObject(id));
 }
 
 Container *getContainer(ObjId id) {
-	return p_dynamic_cast<Container *>(ObjectManager::get_instance()->getObject(id));
+	return dynamic_cast<Container *>(ObjectManager::get_instance()->getObject(id));
 }
 
 Actor *getActor(ObjId id) {
-	return p_dynamic_cast<Actor *>(ObjectManager::get_instance()->getObject(id));
+	return dynamic_cast<Actor *>(ObjectManager::get_instance()->getObject(id));
 }
 
 MainActor *getMainActor() {
-	return p_dynamic_cast<MainActor *>(ObjectManager::get_instance()->getObject(1));
+	return dynamic_cast<MainActor *>(ObjectManager::get_instance()->getObject(1));
 }
 
 Gump *getGump(ObjId id) {
-	return p_dynamic_cast<Gump *>(ObjectManager::get_instance()->getObject(id));
+	return dynamic_cast<Gump *>(ObjectManager::get_instance()->getObject(id));
 }
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/world/gravity_process.cpp
+++ b/engines/ultima/ultima8/world/gravity_process.cpp
@@ -54,7 +54,7 @@ void GravityProcess::init() {
 
 	item->setGravityPID(getPid());
 
-	Actor *actor = p_dynamic_cast<Actor *>(item);
+	Actor *actor = dynamic_cast<Actor *>(item);
 	if (actor) {
 		actor->setFallStart(actor->getZ());
 	}
@@ -81,7 +81,7 @@ void GravityProcess::run() {
 		return;
 	}
 
-	Actor *actor = p_dynamic_cast<Actor *>(item);
+	Actor *actor = dynamic_cast<Actor *>(item);
 	if (actor && actor->getFallStart() < actor->getZ()) {
 		actor->setFallStart(actor->getZ());
 	}
@@ -167,7 +167,7 @@ void GravityProcess::run() {
 		Item *hititem = getItem(hititemid);
 		if (!hititem)
 			return; // shouldn't happen..
-		if (_zSpeed < -2 && !p_dynamic_cast<Actor *>(item)) {
+		if (_zSpeed < -2 && !dynamic_cast<Actor *>(item)) {
 #ifdef BOUNCE_DIAG
 			pout << "item " << _itemNum << " bounce ["
 			     << Kernel::get_instance()->getFrameNum()

--- a/engines/ultima/ultima8/world/item.cpp
+++ b/engines/ultima/ultima8/world/item.cpp
@@ -1149,7 +1149,7 @@ uint32 Item::callUsecodeEvent_guardianBark(int16 unk) {         // event 15
 }
 
 uint32 Item::use() {
-	Actor *actor = p_dynamic_cast<Actor *>(this);
+	Actor *actor = dynamic_cast<Actor *>(this);
 	if (actor) {
 		if (actor->isDead()) {
 			// dead actor, so open/close the dead-body-_gump
@@ -1318,7 +1318,7 @@ void Item::enterFastArea() {
 	// Call usecode
 	if (!(_flags & FLG_FASTAREA)) {
 
-		Actor *actor = p_dynamic_cast<Actor *>(this);
+		Actor *actor = dynamic_cast<Actor *>(this);
 		if (actor && actor->isDead()) {
 			// dead actor, don't call the usecode
 		} else {
@@ -1352,7 +1352,7 @@ void Item::leaveFastArea() {
 	// Kill us if we are fast only, unless we're in a container
 	if ((_flags & FLG_FAST_ONLY) && !getParent()) {
 		// destroy contents if container
-		Container *c = p_dynamic_cast<Container *>(this);
+		Container *c = dynamic_cast<Container *>(this);
 		if (c) c->destroyContents();
 
 		destroy();
@@ -1470,7 +1470,7 @@ int32 Item::ascend(int delta) {
 GravityProcess *Item::ensureGravityProcess() {
 	GravityProcess *p;
 	if (_gravityPid) {
-		p = p_dynamic_cast<GravityProcess *>(
+		p = dynamic_cast<GravityProcess *>(
 		        Kernel::get_instance()->getProcess(_gravityPid));
 	} else {
 		p = new GravityProcess(this, 0);
@@ -1602,7 +1602,7 @@ bool Item::canDrag() {
 	if (si->is_fixed()) return false;
 	if (si->_weight == 0) return false;
 
-	Actor *actor = p_dynamic_cast<Actor *>(this);
+	Actor *actor = dynamic_cast<Actor *>(this);
 	if (actor) {
 		// living actors can't be moved
 		if (!actor->isDead()) return false;
@@ -2742,7 +2742,7 @@ uint32 Item::I_getSliderInput(const uint8 *args, unsigned int /*argsize*/) {
 	ARG_SINT16(maxval);
 	ARG_SINT16(step);
 
-	UCProcess *current = p_dynamic_cast<UCProcess *>(Kernel::get_instance()->getRunningProcess());
+	UCProcess *current = dynamic_cast<UCProcess *>(Kernel::get_instance()->getRunningProcess());
 	assert(current);
 
 //	pout << "SliderGump: min=" << minval << ", max=" << maxval << ", step=" << step << Std::endl;

--- a/engines/ultima/ultima8/world/map.cpp
+++ b/engines/ultima/ultima8/world/map.cpp
@@ -272,7 +272,7 @@ void Map::loadFixedFormatObjects(Std::list<Item *> &itemlist,
 			itemlist.push_back(item);
 		}
 
-		Container *c = p_dynamic_cast<Container *>(item);
+		Container *c = dynamic_cast<Container *>(item);
 		if (c) {
 			// container, so prepare to read contents
 			contdepth++;
@@ -300,7 +300,7 @@ bool Map::load(Common::ReadStream *rs, uint32 version) {
 
 	for (unsigned int i = 0; i < itemcount; ++i) {
 		Object *obj = ObjectManager::get_instance()->loadObject(rs, version);
-		Item *item = p_dynamic_cast<Item *>(obj);
+		Item *item = dynamic_cast<Item *>(obj);
 		if (!item) return false;
 		_dynamicItems.push_back(item);
 	}

--- a/engines/ultima/ultima8/world/monster_egg.cpp
+++ b/engines/ultima/ultima8/world/monster_egg.cpp
@@ -98,7 +98,7 @@ bool MonsterEgg::loadData(Common::ReadStream *rs, uint32 version) {
 
 uint32 MonsterEgg::I_monsterEggHatch(const uint8 *args, unsigned int /*argsize*/) {
 	ARG_ITEM_FROM_PTR(item);
-	MonsterEgg *megg = p_dynamic_cast<MonsterEgg *>(item);
+	MonsterEgg *megg = dynamic_cast<MonsterEgg *>(item);
 	if (!megg) return 0;
 
 	return megg->hatch();
@@ -106,7 +106,7 @@ uint32 MonsterEgg::I_monsterEggHatch(const uint8 *args, unsigned int /*argsize*/
 
 uint32 MonsterEgg::I_getMonId(const uint8 *args, unsigned int /*argsize*/) {
 	ARG_ITEM_FROM_PTR(item);
-	MonsterEgg *megg = p_dynamic_cast<MonsterEgg *>(item);
+	MonsterEgg *megg = dynamic_cast<MonsterEgg *>(item);
 	if (!megg) return 0;
 
 	return megg->getMapNum() >> 3;


### PR DESCRIPTION
Remove unused IsOfType string-based methods and p_dynamic_cast template function.

Remaining IsOfType methods likely can be replaced with dynamic_cast as well
