### PR TITLE
DIRECTOR: LINGO: Remove quirk handling from <> op

### DIFF
--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1063,15 +1063,6 @@ void LC::c_eq() {
 }
 
 Datum LC::neqData(Datum d1, Datum d2) {
-	// Lingo doesn't bother checking list equality if the left is longer
-	if (d1.type == ARRAY && d2.type == ARRAY &&
-			d1.u.farr->size() > d2.u.farr->size()) {
-		return Datum(0);
-	}
-	if (d1.type == PARRAY && d2.type == PARRAY &&
-			d1.u.parr->size() > d2.u.parr->size()) {
-		return Datum(0);
-	}
 	if (d1.type == ARRAY || d2.type == ARRAY ||
 			d1.type == PARRAY || d2.type == PARRAY) {
 		return LC::compareArrays(LC::neqData, d1, d2, false, true);

--- a/engines/director/lingo/tests/lists.lingo
+++ b/engines/director/lingo/tests/lists.lingo
@@ -35,6 +35,9 @@ set res to a = b
 set res to a >= b
 set res to b = a
 set res to b >= a
+set b to [1]
+set res to a = b
+set res to a <> b
 
 set a to [#a:6, #b:3, #c:8, #d:5]
 set res to a = machinery


### PR DESCRIPTION
Upon further testing, this behavior only applies to the = operator.