### PR TITLE
ULTIMA8: Even more custom type checking cleanup 

### DIFF
--- a/engines/ultima/ultima8/audio/audio_process.cpp
+++ b/engines/ultima/ultima8/audio/audio_process.cpp
@@ -41,7 +41,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(AudioProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(AudioProcess)
 
 AudioProcess *AudioProcess::_theAudioProcess = nullptr;
 

--- a/engines/ultima/ultima8/audio/music_flex.cpp
+++ b/engines/ultima/ultima8/audio/music_flex.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MusicFlex, Archive)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MusicFlex)
 
 
 MusicFlex::MusicFlex(Common::SeekableReadStream *rs) : Archive(rs) {

--- a/engines/ultima/ultima8/audio/music_flex.cpp
+++ b/engines/ultima/ultima8/audio/music_flex.cpp
@@ -29,9 +29,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MusicFlex)
-
-
 MusicFlex::MusicFlex(Common::SeekableReadStream *rs) : Archive(rs) {
 	Std::memset(_info, 0, sizeof(SongInfo *) * 128);
 	_songs = new XMidiData *[_count];

--- a/engines/ultima/ultima8/audio/music_flex.h
+++ b/engines/ultima/ultima8/audio/music_flex.h
@@ -32,8 +32,6 @@ namespace Ultima8 {
 
 class MusicFlex : public Archive {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	struct SongInfo {
 		SongInfo();
 		~SongInfo();

--- a/engines/ultima/ultima8/audio/music_process.cpp
+++ b/engines/ultima/ultima8/audio/music_process.cpp
@@ -31,7 +31,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(MusicProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MusicProcess)
 
 MusicProcess *MusicProcess::_theMusicProcess = nullptr;
 

--- a/engines/ultima/ultima8/audio/remorse_music_process.cpp
+++ b/engines/ultima/ultima8/audio/remorse_music_process.cpp
@@ -59,7 +59,7 @@ static const char *TRACK_FILE_NAMES[] = {
 };
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(RemorseMusicProcess, MusicProcess)
+DEFINE_RUNTIME_CLASSTYPE_CODE(RemorseMusicProcess)
 
 RemorseMusicProcess::RemorseMusicProcess() : MusicProcess(), _currentTrack(0), _savedTrack(0), _playingStream(nullptr), _combatMusicActive(false) {
 }

--- a/engines/ultima/ultima8/audio/sound_flex.cpp
+++ b/engines/ultima/ultima8/audio/sound_flex.cpp
@@ -32,9 +32,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(SoundFlex)
-
-
 SoundFlex::SoundFlex(Common::SeekableReadStream *rs) : Archive(rs), _samples(nullptr) {
 	uint32 size;
 	uint8 *buf = getRawObject(0, &size);

--- a/engines/ultima/ultima8/audio/sound_flex.cpp
+++ b/engines/ultima/ultima8/audio/sound_flex.cpp
@@ -32,7 +32,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(SoundFlex, Archive)
+DEFINE_RUNTIME_CLASSTYPE_CODE(SoundFlex)
 
 
 SoundFlex::SoundFlex(Common::SeekableReadStream *rs) : Archive(rs), _samples(nullptr) {

--- a/engines/ultima/ultima8/audio/sound_flex.h
+++ b/engines/ultima/ultima8/audio/sound_flex.h
@@ -42,8 +42,6 @@ public:
 
 class SoundFlex : protected Archive {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	SoundFlex(Common::SeekableReadStream *rs);
 	~SoundFlex() override;
 

--- a/engines/ultima/ultima8/audio/speech_flex.cpp
+++ b/engines/ultima/ultima8/audio/speech_flex.cpp
@@ -29,7 +29,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(SpeechFlex, SoundFlex)
+DEFINE_RUNTIME_CLASSTYPE_CODE(SpeechFlex)
 
 SpeechFlex::SpeechFlex(Common::SeekableReadStream *rs) : SoundFlex(rs) {
 	uint32 size = getRawSize(0);

--- a/engines/ultima/ultima8/audio/speech_flex.cpp
+++ b/engines/ultima/ultima8/audio/speech_flex.cpp
@@ -28,9 +28,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-// p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(SpeechFlex)
-
 SpeechFlex::SpeechFlex(Common::SeekableReadStream *rs) : SoundFlex(rs) {
 	uint32 size = getRawSize(0);
 	const uint8 *buf = getRawObject(0);

--- a/engines/ultima/ultima8/audio/speech_flex.h
+++ b/engines/ultima/ultima8/audio/speech_flex.h
@@ -34,9 +34,6 @@ class SpeechFlex : public SoundFlex {
 	Std::vector<istring> _phrases;
 
 public:
-	// p_dynamic_class stuff
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	SpeechFlex(Common::SeekableReadStream *rs);
 	~SpeechFlex(void) override;
 

--- a/engines/ultima/ultima8/audio/u8_music_process.cpp
+++ b/engines/ultima/ultima8/audio/u8_music_process.cpp
@@ -31,7 +31,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(U8MusicProcess, MusicProcess)
+DEFINE_RUNTIME_CLASSTYPE_CODE(U8MusicProcess)
 
 U8MusicProcess::U8MusicProcess() : _midiPlayer(nullptr), _state(PLAYBACK_NORMAL),
 		_currentTrack(0), _combatMusicActive(false),

--- a/engines/ultima/ultima8/filesys/archive.cpp
+++ b/engines/ultima/ultima8/filesys/archive.cpp
@@ -31,9 +31,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(NamedArchiveFile)
-DEFINE_RUNTIME_CLASSTYPE_CODE(Archive)
-
 Archive::Archive() {
 	_count = 0;
 }

--- a/engines/ultima/ultima8/filesys/archive.cpp
+++ b/engines/ultima/ultima8/filesys/archive.cpp
@@ -31,8 +31,8 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(NamedArchiveFile, ArchiveFile)
-DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(Archive)
+DEFINE_RUNTIME_CLASSTYPE_CODE(NamedArchiveFile)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Archive)
 
 Archive::Archive() {
 	_count = 0;

--- a/engines/ultima/ultima8/filesys/archive.h
+++ b/engines/ultima/ultima8/filesys/archive.h
@@ -34,8 +34,6 @@ class ArchiveFile;
 
 class Archive {
 public:
-	ENABLE_RUNTIME_CLASSTYPE_BASE()
-
 	//! create Archive without any input sources
 	Archive();
 

--- a/engines/ultima/ultima8/filesys/archive_file.cpp
+++ b/engines/ultima/ultima8/filesys/archive_file.cpp
@@ -29,8 +29,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ArchiveFile)
-
 //static
 bool ArchiveFile::extractIndexFromName(const Std::string &name, uint32 &index) {
 	if (name.size() == 0) return false;

--- a/engines/ultima/ultima8/filesys/archive_file.cpp
+++ b/engines/ultima/ultima8/filesys/archive_file.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(ArchiveFile)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ArchiveFile)
 
 //static
 bool ArchiveFile::extractIndexFromName(const Std::string &name, uint32 &index) {

--- a/engines/ultima/ultima8/filesys/archive_file.h
+++ b/engines/ultima/ultima8/filesys/archive_file.h
@@ -31,8 +31,6 @@ namespace Ultima8 {
 
 class ArchiveFile {
 public:
-	ENABLE_RUNTIME_CLASSTYPE_BASE()
-
 	virtual ~ArchiveFile() { }
 
 	//! Check if constructed object is indeed a valid archive

--- a/engines/ultima/ultima8/filesys/flex_file.cpp
+++ b/engines/ultima/ultima8/filesys/flex_file.cpp
@@ -27,10 +27,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(FlexFile)
-
-
-
 FlexFile::FlexFile(Common::SeekableReadStream *rs_) : _rs(rs_), _count(0) {
 	_valid = isFlexFile(_rs);
 

--- a/engines/ultima/ultima8/filesys/flex_file.cpp
+++ b/engines/ultima/ultima8/filesys/flex_file.cpp
@@ -27,7 +27,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(FlexFile, ArchiveFile)
+DEFINE_RUNTIME_CLASSTYPE_CODE(FlexFile)
 
 
 

--- a/engines/ultima/ultima8/filesys/flex_file.h
+++ b/engines/ultima/ultima8/filesys/flex_file.h
@@ -31,8 +31,6 @@ namespace Ultima8 {
 
 class FlexFile : public ArchiveFile {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	//! create FlexFile from datasource; FlexFile takes ownership of ds
 	//! and deletes it when destructed
 	explicit FlexFile(Common::SeekableReadStream *rs);

--- a/engines/ultima/ultima8/filesys/named_archive_file.h
+++ b/engines/ultima/ultima8/filesys/named_archive_file.h
@@ -31,8 +31,6 @@ namespace Ultima8 {
 
 class NamedArchiveFile : public ArchiveFile {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	NamedArchiveFile() : _indexCount(0) { }
 	~NamedArchiveFile() override { }
 

--- a/engines/ultima/ultima8/filesys/raw_archive.cpp
+++ b/engines/ultima/ultima8/filesys/raw_archive.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(RawArchive, Archive)
+DEFINE_RUNTIME_CLASSTYPE_CODE(RawArchive)
 
 RawArchive::~RawArchive() {
 	Archive::uncache();

--- a/engines/ultima/ultima8/filesys/raw_archive.cpp
+++ b/engines/ultima/ultima8/filesys/raw_archive.cpp
@@ -29,8 +29,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(RawArchive)
-
 RawArchive::~RawArchive() {
 	Archive::uncache();
 }

--- a/engines/ultima/ultima8/filesys/raw_archive.h
+++ b/engines/ultima/ultima8/filesys/raw_archive.h
@@ -34,8 +34,6 @@ class IDataSource;
 
 class RawArchive : public Archive {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	RawArchive() : Archive() { }
 	explicit RawArchive(ArchiveFile *af) : Archive(af) { }
 	explicit RawArchive(Common::SeekableReadStream *rs) : Archive(rs) { }

--- a/engines/ultima/ultima8/filesys/u8_save_file.cpp
+++ b/engines/ultima/ultima8/filesys/u8_save_file.cpp
@@ -28,7 +28,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(U8SaveFile, NamedArchiveFile)
+DEFINE_RUNTIME_CLASSTYPE_CODE(U8SaveFile)
 
 
 U8SaveFile::U8SaveFile(Common::SeekableReadStream *rs_) : _rs(rs_), _count(0) {

--- a/engines/ultima/ultima8/filesys/u8_save_file.cpp
+++ b/engines/ultima/ultima8/filesys/u8_save_file.cpp
@@ -28,9 +28,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(U8SaveFile)
-
-
 U8SaveFile::U8SaveFile(Common::SeekableReadStream *rs_) : _rs(rs_), _count(0) {
 	_valid = isU8SaveFile(_rs);
 

--- a/engines/ultima/ultima8/filesys/u8_save_file.h
+++ b/engines/ultima/ultima8/filesys/u8_save_file.h
@@ -32,8 +32,6 @@ namespace Ultima8 {
 
 class U8SaveFile : public NamedArchiveFile {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	//! create U8SaveFile from datasource; U8SaveFile takes ownership of ds
 	//! and deletes it when destructed
 	explicit U8SaveFile(Common::SeekableReadStream *rs);

--- a/engines/ultima/ultima8/games/start_crusader_process.cpp
+++ b/engines/ultima/ultima8/games/start_crusader_process.cpp
@@ -44,7 +44,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(StartCrusaderProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(StartCrusaderProcess)
 
 StartCrusaderProcess::StartCrusaderProcess(int saveSlot) : Process(),
 		_initStage(PlayFirstMovie), _saveSlot(saveSlot), _skipStart(saveSlot >= 0) {

--- a/engines/ultima/ultima8/games/start_u8_process.cpp
+++ b/engines/ultima/ultima8/games/start_u8_process.cpp
@@ -41,7 +41,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(StartU8Process, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(StartU8Process)
 
 StartU8Process::StartU8Process(int saveSlot) : Process(),
 		_init(false), _saveSlot(saveSlot), _skipStart(saveSlot >= 0) {

--- a/engines/ultima/ultima8/graphics/fade_to_modal_process.cpp
+++ b/engines/ultima/ultima8/graphics/fade_to_modal_process.cpp
@@ -31,7 +31,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(FadeToModalProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(FadeToModalProcess)
 
 
 FadeToModalProcess::FadeToModalProcess(ModalGump *modal)

--- a/engines/ultima/ultima8/graphics/fonts/font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font.cpp
@@ -27,7 +27,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(Font)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Font)
 
 Font::Font() : _highRes(false) {
 }

--- a/engines/ultima/ultima8/graphics/fonts/font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font.cpp
@@ -27,8 +27,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(Font)
-
 Font::Font() : _highRes(false) {
 }
 

--- a/engines/ultima/ultima8/graphics/fonts/font.h
+++ b/engines/ultima/ultima8/graphics/fonts/font.h
@@ -44,8 +44,6 @@ public:
 	Font();
 	virtual ~Font();
 
-	ENABLE_RUNTIME_CLASSTYPE_BASE()
-
 	enum TextAlign {
 		TEXT_LEFT,
 		TEXT_CENTER,

--- a/engines/ultima/ultima8/graphics/fonts/font_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font_shape_archive.cpp
@@ -30,8 +30,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(FontShapeArchive)
-
 ShapeFont *FontShapeArchive::getFont(uint32 fontnum) {
 	return dynamic_cast<ShapeFont *>(getShape(fontnum));
 }

--- a/engines/ultima/ultima8/graphics/fonts/font_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font_shape_archive.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(FontShapeArchive, ShapeArchive)
+DEFINE_RUNTIME_CLASSTYPE_CODE(FontShapeArchive)
 
 ShapeFont *FontShapeArchive::getFont(uint32 fontnum) {
 	return dynamic_cast<ShapeFont *>(getShape(fontnum));

--- a/engines/ultima/ultima8/graphics/fonts/font_shape_archive.h
+++ b/engines/ultima/ultima8/graphics/fonts/font_shape_archive.h
@@ -33,8 +33,6 @@ class ShapeFont;
 
 class FontShapeArchive : public ShapeArchive {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	FontShapeArchive(uint16 id_, Palette *pal_ = 0,
 	                 const ConvertShapeFormat *format_ = 0)
 		: ShapeArchive(id_, pal_, format_) { }

--- a/engines/ultima/ultima8/graphics/fonts/jp_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/jp_font.cpp
@@ -31,9 +31,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(JPFont)
-
-
 JPFont::JPFont(ShapeFont *jpfont, unsigned int fontnum_)
 	: _fontNum(fontnum_), _shapeFont(jpfont) {
 	assert(_shapeFont->frameCount() > 256);

--- a/engines/ultima/ultima8/graphics/fonts/jp_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/jp_font.cpp
@@ -31,7 +31,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(JPFont, Font)
+DEFINE_RUNTIME_CLASSTYPE_CODE(JPFont)
 
 
 JPFont::JPFont(ShapeFont *jpfont, unsigned int fontnum_)

--- a/engines/ultima/ultima8/graphics/fonts/jp_font.h
+++ b/engines/ultima/ultima8/graphics/fonts/jp_font.h
@@ -53,7 +53,6 @@ public:
 		TextAlign align = TEXT_LEFT, bool u8specials = false,
 		Std::string::size_type cursor = Std::string::npos) override;
 
-	ENABLE_RUNTIME_CLASSTYPE()
 protected:
 
 	unsigned int _fontNum;

--- a/engines/ultima/ultima8/graphics/fonts/jp_rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/jp_rendered_text.cpp
@@ -31,7 +31,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(JPRenderedText, RenderedText)
+DEFINE_RUNTIME_CLASSTYPE_CODE(JPRenderedText)
 
 
 JPRenderedText::JPRenderedText(Std::list<PositionedText> &lines, int width, int height,

--- a/engines/ultima/ultima8/graphics/fonts/jp_rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/jp_rendered_text.cpp
@@ -31,9 +31,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(JPRenderedText)
-
-
 JPRenderedText::JPRenderedText(Std::list<PositionedText> &lines, int width, int height,
 		int vLead, ShapeFont *font, unsigned int fontNum)
 		: _lines(lines), _font(font), _fontNum(fontNum) {

--- a/engines/ultima/ultima8/graphics/fonts/jp_rendered_text.h
+++ b/engines/ultima/ultima8/graphics/fonts/jp_rendered_text.h
@@ -42,8 +42,6 @@ public:
 	void draw(RenderSurface *surface, int x, int y, bool destmasked = false) override;
 	void drawBlended(RenderSurface *surface, int x, int y, uint32 col, bool destmasked = false) override;
 
-	ENABLE_RUNTIME_CLASSTYPE()
-
 protected:
 	Std::list<PositionedText> _lines;
 	ShapeFont *_font;

--- a/engines/ultima/ultima8/graphics/fonts/rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/rendered_text.cpp
@@ -26,8 +26,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(RenderedText)
-
 RenderedText::RenderedText()
 	: _width(-1), _height(-1), _vLead(0) {
 }

--- a/engines/ultima/ultima8/graphics/fonts/rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/rendered_text.cpp
@@ -26,7 +26,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(RenderedText)
+DEFINE_RUNTIME_CLASSTYPE_CODE(RenderedText)
 
 RenderedText::RenderedText()
 	: _width(-1), _height(-1), _vLead(0) {

--- a/engines/ultima/ultima8/graphics/fonts/rendered_text.h
+++ b/engines/ultima/ultima8/graphics/fonts/rendered_text.h
@@ -57,8 +57,6 @@ public:
 		return _vLead;
 	}
 
-	ENABLE_RUNTIME_CLASSTYPE_BASE()
-
 protected:
 	int _width, _height;
 	int _vLead;

--- a/engines/ultima/ultima8/graphics/fonts/shape_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/shape_font.cpp
@@ -30,9 +30,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeFont)
-
-
 ShapeFont::ShapeFont(const uint8 *data_, uint32 size_,
                      const ConvertShapeFormat *format,
                      const uint16 flexId_, const uint32 shapeNum_)

--- a/engines/ultima/ultima8/graphics/fonts/shape_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/shape_font.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE_MULTI2(ShapeFont, Font, Shape)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeFont)
 
 
 ShapeFont::ShapeFont(const uint8 *data_, uint32 size_,

--- a/engines/ultima/ultima8/graphics/fonts/shape_font.h
+++ b/engines/ultima/ultima8/graphics/fonts/shape_font.h
@@ -70,8 +70,6 @@ public:
 		unsigned int &remaining, int32 width = 0, int32 height = 0,
 		TextAlign align = TEXT_LEFT, bool u8specials = false,
 		Std::string::size_type cursor = Std::string::npos) override;
-
-	ENABLE_RUNTIME_CLASSTYPE()
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.cpp
@@ -29,9 +29,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeRenderedText)
-
-
 ShapeRenderedText::ShapeRenderedText(const Std::list<PositionedText> &lines,
                                      int width, int height, int vLead,
                                      ShapeFont *font)

--- a/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeRenderedText, RenderedText)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeRenderedText)
 
 
 ShapeRenderedText::ShapeRenderedText(const Std::list<PositionedText> &lines,

--- a/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.h
+++ b/engines/ultima/ultima8/graphics/fonts/shape_rendered_text.h
@@ -41,8 +41,6 @@ public:
 	void draw(RenderSurface *surface, int x, int y, bool destmasked = false) override;
 	void drawBlended(RenderSurface *surface, int x, int y, uint32 col, bool destmasked = false) override;
 
-	ENABLE_RUNTIME_CLASSTYPE()
-
 protected:
 	Std::list<PositionedText> _lines;
 	ShapeFont *_font;

--- a/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
@@ -37,7 +37,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(TTFont, Font)
+DEFINE_RUNTIME_CLASSTYPE_CODE(TTFont)
 
 // various unicode characters which look like small black circles
 static const uint16 BULLETS[] = { 0x2022, 0x30FB, 0x25CF, 0 };

--- a/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
@@ -37,8 +37,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(TTFont)
-
 // various unicode characters which look like small black circles
 static const uint16 BULLETS[] = { 0x2022, 0x30FB, 0x25CF, 0 };
 

--- a/engines/ultima/ultima8/graphics/fonts/tt_font.h
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.h
@@ -60,7 +60,6 @@ public:
 		TextAlign align = TEXT_LEFT, bool u8specials = false,
 		Std::string::size_type cursor = Std::string::npos) override;
 
-	ENABLE_RUNTIME_CLASSTYPE()
 protected:
 	Graphics::Font *_ttfFont;
 	uint32 _color;

--- a/engines/ultima/ultima8/graphics/fonts/ttf_rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/ttf_rendered_text.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(TTFRenderedText, RenderedText)
+DEFINE_RUNTIME_CLASSTYPE_CODE(TTFRenderedText)
 
 
 TTFRenderedText::TTFRenderedText(Texture *texture_, int width, int height,

--- a/engines/ultima/ultima8/graphics/fonts/ttf_rendered_text.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/ttf_rendered_text.cpp
@@ -29,9 +29,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(TTFRenderedText)
-
-
 TTFRenderedText::TTFRenderedText(Texture *texture_, int width, int height,
 		int vLead, TTFont *font) : _texture(texture_), _font(font) {
 	_width = width;

--- a/engines/ultima/ultima8/graphics/fonts/ttf_rendered_text.h
+++ b/engines/ultima/ultima8/graphics/fonts/ttf_rendered_text.h
@@ -44,8 +44,6 @@ public:
 	void drawBlended(RenderSurface *surface, int x, int y, uint32 col,
 	                         bool destmasked = false) override;
 
-	ENABLE_RUNTIME_CLASSTYPE()
-
 protected:
 	Texture *_texture;
 	TTFont *_font;

--- a/engines/ultima/ultima8/graphics/gump_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/gump_shape_archive.cpp
@@ -29,8 +29,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(GumpShapeArchive)
-
 GumpShapeArchive::~GumpShapeArchive() {
 	for (unsigned int i = 0; i < _gumpItemArea.size(); ++i)
 		delete _gumpItemArea[i];

--- a/engines/ultima/ultima8/graphics/gump_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/gump_shape_archive.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(GumpShapeArchive, ShapeArchive)
+DEFINE_RUNTIME_CLASSTYPE_CODE(GumpShapeArchive)
 
 GumpShapeArchive::~GumpShapeArchive() {
 	for (unsigned int i = 0; i < _gumpItemArea.size(); ++i)

--- a/engines/ultima/ultima8/graphics/gump_shape_archive.h
+++ b/engines/ultima/ultima8/graphics/gump_shape_archive.h
@@ -33,8 +33,6 @@ struct Rect;
 
 class GumpShapeArchive : public ShapeArchive {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	GumpShapeArchive(uint16 id_, Palette *pal_ = 0,
 	                 const ConvertShapeFormat *format_ = 0)
 		: ShapeArchive(id_, pal_, format_) { }

--- a/engines/ultima/ultima8/graphics/inverter_process.cpp
+++ b/engines/ultima/ultima8/graphics/inverter_process.cpp
@@ -45,7 +45,7 @@ static unsigned int states[] = { 0, 8, 63, 211, 493, 945, 1594, 2459, 3552,
 InverterProcess *InverterProcess::_inverter = nullptr;
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(InverterProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(InverterProcess)
 
 InverterProcess::InverterProcess()
 	: Process(), _targetState(0) {

--- a/engines/ultima/ultima8/graphics/main_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/main_shape_archive.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MainShapeArchive, ShapeArchive)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MainShapeArchive)
 
 
 MainShapeArchive::~MainShapeArchive() {

--- a/engines/ultima/ultima8/graphics/main_shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/main_shape_archive.cpp
@@ -29,9 +29,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MainShapeArchive)
-
-
 MainShapeArchive::~MainShapeArchive() {
 	if (_typeFlags) {
 		delete _typeFlags;

--- a/engines/ultima/ultima8/graphics/main_shape_archive.h
+++ b/engines/ultima/ultima8/graphics/main_shape_archive.h
@@ -37,8 +37,6 @@ struct AnimAction;
 
 class MainShapeArchive : public ShapeArchive {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	MainShapeArchive(uint16 id_, Palette *pal_ = 0,
 	                 const ConvertShapeFormat *format_ = 0)
 		: ShapeArchive(id_, pal_, format_), _typeFlags(0), _animDat(0) { }

--- a/engines/ultima/ultima8/graphics/palette_fader_process.cpp
+++ b/engines/ultima/ultima8/graphics/palette_fader_process.cpp
@@ -31,7 +31,7 @@ namespace Ultima8 {
 PaletteFaderProcess *PaletteFaderProcess::_fader = nullptr;
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(PaletteFaderProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(PaletteFaderProcess)
 
 PaletteFaderProcess::PaletteFaderProcess() : Process(), _priority(0),
 	_counter(0), _maxCounter(0) {

--- a/engines/ultima/ultima8/graphics/shape.cpp
+++ b/engines/ultima/ultima8/graphics/shape.cpp
@@ -35,8 +35,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(Shape)
-
 Shape::Shape(const uint8 *data, uint32 size, const ConvertShapeFormat *format,
              const uint16 id, const uint32 shape)
 		: _flexId(id), _shapeNum(shape), _palette(nullptr) {

--- a/engines/ultima/ultima8/graphics/shape.cpp
+++ b/engines/ultima/ultima8/graphics/shape.cpp
@@ -35,7 +35,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(Shape)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Shape)
 
 Shape::Shape(const uint8 *data, uint32 size, const ConvertShapeFormat *format,
              const uint16 id, const uint32 shape)

--- a/engines/ultima/ultima8/graphics/shape.h
+++ b/engines/ultima/ultima8/graphics/shape.h
@@ -69,8 +69,6 @@ public:
 	static const ConvertShapeFormat *DetectShapeFormat(const uint8 *data, uint32 size);
 	static const ConvertShapeFormat *DetectShapeFormat(IDataSource *ds, uint32 size);
 
-	ENABLE_RUNTIME_CLASSTYPE_BASE()
-
 private:
 	void loadFrames(const uint8 *data, uint32 size, const ConvertShapeFormat *format);
 

--- a/engines/ultima/ultima8/graphics/shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/shape_archive.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeArchive, Archive)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeArchive)
 
 ShapeArchive::~ShapeArchive() {
 	Archive::uncache();

--- a/engines/ultima/ultima8/graphics/shape_archive.cpp
+++ b/engines/ultima/ultima8/graphics/shape_archive.cpp
@@ -30,8 +30,6 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeArchive)
-
 ShapeArchive::~ShapeArchive() {
 	Archive::uncache();
 }

--- a/engines/ultima/ultima8/graphics/shape_archive.h
+++ b/engines/ultima/ultima8/graphics/shape_archive.h
@@ -35,8 +35,6 @@ struct Palette;
 
 class ShapeArchive : public Archive {
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	ShapeArchive(uint16 id, Palette *pal = 0,
 	             const ConvertShapeFormat *format = 0)
 		: Archive(), _id(id), _format(format), _palette(pal) { }

--- a/engines/ultima/ultima8/gumps/ask_gump.cpp
+++ b/engines/ultima/ultima8/gumps/ask_gump.cpp
@@ -31,7 +31,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(AskGump, ItemRelativeGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(AskGump)
 
 AskGump::AskGump() : ItemRelativeGump(), _answers(0) {
 }

--- a/engines/ultima/ultima8/gumps/bark_gump.cpp
+++ b/engines/ultima/ultima8/gumps/bark_gump.cpp
@@ -31,7 +31,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(BarkGump, ItemRelativeGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(BarkGump)
 
 // TODO: Remove all the hacks
 

--- a/engines/ultima/ultima8/gumps/book_gump.cpp
+++ b/engines/ultima/ultima8/gumps/book_gump.cpp
@@ -35,7 +35,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(BookGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(BookGump)
 
 // TODO: Remove all the hacks
 

--- a/engines/ultima/ultima8/gumps/container_gump.cpp
+++ b/engines/ultima/ultima8/gumps/container_gump.cpp
@@ -44,7 +44,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ContainerGump, ItemRelativeGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ContainerGump)
 
 ContainerGump::ContainerGump()
 	: ItemRelativeGump(), _displayDragging(false), _draggingShape(0),

--- a/engines/ultima/ultima8/gumps/credits_gump.cpp
+++ b/engines/ultima/ultima8/gumps/credits_gump.cpp
@@ -35,7 +35,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(CreditsGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CreditsGump)
 
 CreditsGump::CreditsGump()
 	: ModalGump(), _parSkip(0), _timer(0), _title(nullptr),

--- a/engines/ultima/ultima8/gumps/cru_ammo_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_ammo_gump.cpp
@@ -38,7 +38,7 @@ namespace Ultima8 {
 
 static const int AMMO_GUMP_SHAPE = 4;
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(CruAmmoGump, CruStatGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CruAmmoGump)
 
 CruAmmoGump::CruAmmoGump() : CruStatGump(), _ammoShape(nullptr) {
 

--- a/engines/ultima/ultima8/gumps/cru_energy_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_energy_gump.cpp
@@ -38,7 +38,7 @@ namespace Ultima8 {
 
 static const uint32 ENERGY_BAR_COLOR = 0xFF9A0404; // RGB: (0, 48, 113)
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(CruEnergyGump, CruStatGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CruEnergyGump)
 
 CruEnergyGump::CruEnergyGump() : CruStatGump() {
 

--- a/engines/ultima/ultima8/gumps/cru_health_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_health_gump.cpp
@@ -38,7 +38,7 @@ namespace Ultima8 {
 
 static const uint32 HEALTH_BAR_COLOR = 0xFF003071; // RGB = (154, 4, 4)
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(CruHealthGump, CruStatGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CruHealthGump)
 
 CruHealthGump::CruHealthGump() : CruStatGump() {
 

--- a/engines/ultima/ultima8/gumps/cru_inventory_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_inventory_gump.cpp
@@ -38,8 +38,7 @@ namespace Ultima8 {
 
 static const int INVENTORY_GUMP_SHAPE = 3;
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(CruInventoryGump, CruStatGump)
-
+DEFINE_RUNTIME_CLASSTYPE_CODE(CruInventoryGump)
 CruInventoryGump::CruInventoryGump() : CruStatGump(), _inventoryShape(nullptr) {
 
 }

--- a/engines/ultima/ultima8/gumps/cru_stat_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_stat_gump.cpp
@@ -36,7 +36,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(CruStatGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CruStatGump)
 
 CruStatGump::CruStatGump() : Gump() {
 

--- a/engines/ultima/ultima8/gumps/cru_status_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_status_gump.cpp
@@ -39,7 +39,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(CruStatusGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CruStatusGump)
 
 static const int PX_FROM_BOTTOM = 2;	//! gap (y) between bottom of screen and bottom of a single item
 static const int PX_FROM_LEFT = 15;  	//! gap (x) from left of screen to weapon box

--- a/engines/ultima/ultima8/gumps/cru_weapon_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_weapon_gump.cpp
@@ -38,7 +38,7 @@ namespace Ultima8 {
 
 static const int WEAPON_GUMP_SHAPE = 3;
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(CruWeaponGump, CruStatGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CruWeaponGump)
 
 CruWeaponGump::CruWeaponGump() : CruStatGump(), _weaponShape(nullptr) {
 

--- a/engines/ultima/ultima8/gumps/desktop_gump.cpp
+++ b/engines/ultima/ultima8/gumps/desktop_gump.cpp
@@ -61,8 +61,8 @@ void DesktopGump::PaintChildren(RenderSurface *surf, int32 lerp_factor, bool sca
 		if (!g->IsClosing()) {
 			// If background blanking on modal is enabled...
 			// Background is partially transparent
-			if (_fadedModal && g->IsOfType<ModalGump>() &&
-			        !g->IsOfType<TargetGump>() && !g->IsHidden())
+			if (_fadedModal && dynamic_cast<ModalGump *>(g) &&
+			        !dynamic_cast<TargetGump *>(g) && !g->IsHidden())
 				surf->FillBlended(0x7F000000, 0, 0, _dims.w, _dims.h);
 
 			g->Paint(surf, lerp_factor, scaled);

--- a/engines/ultima/ultima8/gumps/desktop_gump.cpp
+++ b/engines/ultima/ultima8/gumps/desktop_gump.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(DesktopGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(DesktopGump)
 
 bool DesktopGump::_fadedModal = true;
 

--- a/engines/ultima/ultima8/gumps/fast_area_vis_gump.cpp
+++ b/engines/ultima/ultima8/gumps/fast_area_vis_gump.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(FastAreaVisGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(FastAreaVisGump)
 
 FastAreaVisGump::FastAreaVisGump(void) : Gump(0, 0, MAP_NUM_CHUNKS + 2, MAP_NUM_CHUNKS + 2, 0, FLAG_DRAGGABLE | FLAG_DONT_SAVE, LAYER_NORMAL) {
 }

--- a/engines/ultima/ultima8/gumps/game_map_gump.cpp
+++ b/engines/ultima/ultima8/gumps/game_map_gump.cpp
@@ -54,7 +54,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(GameMapGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(GameMapGump)
 
 bool GameMapGump::_highlightItems = false;
 

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -533,8 +533,8 @@ bool Gump::GetLocationOfItem(uint16 itemid, int32 &gx, int32 &gy,
 }
 
 // Find a child gump that matches the matching function 
-Gump *Gump::FindGump(const FindPredicate predicate, bool recursive) {
-	if ((this->*predicate)())
+Gump *Gump::FindGump(const FindGumpPredicate predicate, bool recursive) {
+	if (predicate(this))
 		return this;
 
 	// Iterate all children
@@ -548,7 +548,7 @@ Gump *Gump::FindGump(const FindPredicate predicate, bool recursive) {
 		if (g->_flags & FLAG_CLOSING)
 			continue;
 
-		if ((g->*predicate)())
+		if (predicate(g))
 			return g;
 	}
 

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -36,7 +36,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(Gump, Object)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Gump)
 
 Gump::Gump() : Object(), _parent(nullptr), _owner(0),
 	_x(0), _y(0), _flags(0), _layer(0), _index(-1),

--- a/engines/ultima/ultima8/gumps/gump.h
+++ b/engines/ultima/ultima8/gumps/gump.h
@@ -37,6 +37,10 @@ class Shape;
 class Item;
 class GumpNotifyProcess;
 
+class Gump;
+typedef bool (*FindGumpPredicate)(Gump *g);
+template<class T> inline bool IsOfType(Gump *g) { return dynamic_cast<T*>(g) != nullptr; }
+
 //
 // Class Gump
 //
@@ -108,20 +112,18 @@ public:
 	//! \param takefocus If true, set parent's _focusChild to this
 	virtual void                InitGump(Gump *newparent, bool take_focus = true);
 
-	typedef bool (Gump::*FindPredicate)() const;
-
 	//! Find a gump of that matches a predicate function (this or child)
 	//! \param predicate Function to check if a gump is a match
 	//! \param recursive Recursively search through children?
 	//! \return the desired Gump, or NULL if not found
-	virtual Gump               *FindGump(FindPredicate predicate, bool recursive = true);
+	virtual Gump               *FindGump(FindGumpPredicate predicate, bool recursive = true);
 
 	//! Find a gump of the specified type (this or child)
 	//! \param T Type of gump to look for
 	//! \param recursive Recursively search through children?
 	//! \return the desired Gump, or NULL if not found
 	template<class T> Gump     *FindGump(bool recursive = true) {
-		return FindGump(&Gump::IsOfType<T>, recursive);
+		return FindGump(&IsOfType<T>, recursive);
 	}
 
 	//! Find gump (this, child or NULL) at parent coordinates (mx,my)

--- a/engines/ultima/ultima8/gumps/gump_notify_process.cpp
+++ b/engines/ultima/ultima8/gumps/gump_notify_process.cpp
@@ -28,7 +28,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(GumpNotifyProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(GumpNotifyProcess)
 
 GumpNotifyProcess::GumpNotifyProcess()
 	: Process(), _gump(0) {

--- a/engines/ultima/ultima8/gumps/inverter_gump.cpp
+++ b/engines/ultima/ultima8/gumps/inverter_gump.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(InverterGump, DesktopGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(InverterGump)
 
 InverterGump::InverterGump(int32 x, int32 y, int32 width, int32 height)
 	: DesktopGump(x, y, width, height) {

--- a/engines/ultima/ultima8/gumps/item_relative_gump.cpp
+++ b/engines/ultima/ultima8/gumps/item_relative_gump.cpp
@@ -31,7 +31,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ItemRelativeGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ItemRelativeGump)
 
 ItemRelativeGump::ItemRelativeGump() : Gump(), _ix(0), _iy(0) {
 }

--- a/engines/ultima/ultima8/gumps/main_menu_process.cpp
+++ b/engines/ultima/ultima8/gumps/main_menu_process.cpp
@@ -32,7 +32,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(MainMenuProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MainMenuProcess)
 
 MainMenuProcess::MainMenuProcess() : Process() {
 	_init = false;

--- a/engines/ultima/ultima8/gumps/menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/menu_gump.cpp
@@ -50,7 +50,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MenuGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MenuGump)
 
 MenuGump::MenuGump(bool nameEntryMode_)
 	: ModalGump(0, 0, 5, 5, 0, FLAG_DONT_SAVE) {

--- a/engines/ultima/ultima8/gumps/message_box_gump.cpp
+++ b/engines/ultima/ultima8/gumps/message_box_gump.cpp
@@ -43,7 +43,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MessageBoxGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MessageBoxGump)
 
 MessageBoxGump::MessageBoxGump()
 	: ModalGump(), _titleColour(0) {

--- a/engines/ultima/ultima8/gumps/mini_stats_gump.cpp
+++ b/engines/ultima/ultima8/gumps/mini_stats_gump.cpp
@@ -36,7 +36,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MiniStatsGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MiniStatsGump)
 
 static const int gumpshape = 33;
 static const int hpx = 6;

--- a/engines/ultima/ultima8/gumps/minimap_gump.cpp
+++ b/engines/ultima/ultima8/gumps/minimap_gump.cpp
@@ -36,7 +36,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MiniMapGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MiniMapGump)
 
 MiniMapGump::MiniMapGump(int x, int y) :
 	Gump(x, y, MAP_NUM_CHUNKS * 2 + 2, MAP_NUM_CHUNKS * 2 + 2, 0,

--- a/engines/ultima/ultima8/gumps/modal_gump.cpp
+++ b/engines/ultima/ultima8/gumps/modal_gump.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ModalGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ModalGump)
 
 ModalGump::ModalGump() : Gump() {
 

--- a/engines/ultima/ultima8/gumps/movie_gump.cpp
+++ b/engines/ultima/ultima8/gumps/movie_gump.cpp
@@ -37,7 +37,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MovieGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MovieGump)
 
 MovieGump::MovieGump() : ModalGump(), _player(0) {
 

--- a/engines/ultima/ultima8/gumps/paged_gump.cpp
+++ b/engines/ultima/ultima8/gumps/paged_gump.cpp
@@ -32,7 +32,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(PagedGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(PagedGump)
 
 PagedGump::PagedGump(int left, int right, int top, int shape):
 	ModalGump(0, 0, 5, 5), _leftOff(left), _rightOff(right), _topOff(top),

--- a/engines/ultima/ultima8/gumps/paperdoll_gump.cpp
+++ b/engines/ultima/ultima8/gumps/paperdoll_gump.cpp
@@ -41,7 +41,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(PaperdollGump, ContainerGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(PaperdollGump)
 
 
 

--- a/engines/ultima/ultima8/gumps/quit_gump.cpp
+++ b/engines/ultima/ultima8/gumps/quit_gump.cpp
@@ -35,7 +35,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(QuitGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(QuitGump)
 
 static const int u8GumpShape = 17;
 static const int u8AskShapeId = 18;

--- a/engines/ultima/ultima8/gumps/readable_gump.cpp
+++ b/engines/ultima/ultima8/gumps/readable_gump.cpp
@@ -38,7 +38,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ReadableGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ReadableGump)
 
 const int jpsub_font = 6;
 

--- a/engines/ultima/ultima8/gumps/remorse_menu_gump.cpp
+++ b/engines/ultima/ultima8/gumps/remorse_menu_gump.cpp
@@ -49,7 +49,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(RemorseMenuGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(RemorseMenuGump)
 
 RemorseMenuGump::RemorseMenuGump()
 	: ModalGump(0, 0, 640, 480, 0, FLAG_DONT_SAVE) {

--- a/engines/ultima/ultima8/gumps/scaler_gump.cpp
+++ b/engines/ultima/ultima8/gumps/scaler_gump.cpp
@@ -32,7 +32,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ScalerGump, DesktopGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ScalerGump)
 
 ScalerGump::ScalerGump(int32 x, int32 y, int32 width, int32 height) :
 		DesktopGump(x, y, width, height),

--- a/engines/ultima/ultima8/gumps/scroll_gump.cpp
+++ b/engines/ultima/ultima8/gumps/scroll_gump.cpp
@@ -35,7 +35,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ScrollGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ScrollGump)
 
 // TODO: Remove all the hacks
 

--- a/engines/ultima/ultima8/gumps/shape_viewer_gump.cpp
+++ b/engines/ultima/ultima8/gumps/shape_viewer_gump.cpp
@@ -50,7 +50,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeViewerGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ShapeViewerGump)
 
 ShapeViewerGump::ShapeViewerGump()
 	: ModalGump(), _curFlex(0), _flex(nullptr), _curShape(0), _curFrame(0),

--- a/engines/ultima/ultima8/gumps/slider_gump.cpp
+++ b/engines/ultima/ultima8/gumps/slider_gump.cpp
@@ -38,7 +38,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(SliderGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(SliderGump)
 
 SliderGump::SliderGump() : ModalGump(), _renderedText(nullptr), _min(0), _max(0),
 		_delta(0), _value(0), _usecodeNotifyPID(0), _renderedValue(-1) {

--- a/engines/ultima/ultima8/gumps/target_gump.cpp
+++ b/engines/ultima/ultima8/gumps/target_gump.cpp
@@ -31,7 +31,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(TargetGump, ModalGump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(TargetGump)
 
 TargetGump::TargetGump() : ModalGump(), _targetTracing(false) {
 

--- a/engines/ultima/ultima8/gumps/u8_save_gump.cpp
+++ b/engines/ultima/ultima8/gumps/u8_save_gump.cpp
@@ -43,7 +43,7 @@ namespace Ultima8 {
 
 static const int entryfont = 4;
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(U8SaveGump, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(U8SaveGump)
 
 U8SaveGump::U8SaveGump(bool saveMode, int page)
 	: Gump(0, 0, 5, 5), _save(saveMode), _page(page) {

--- a/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
@@ -34,7 +34,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(ButtonWidget, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ButtonWidget)
 
 ButtonWidget::ButtonWidget() : Gump(), _shapeUp(nullptr), _shapeDown(nullptr),
 		_mouseOver(false), _origW(0), _origH(0), _frameNumUp(0),

--- a/engines/ultima/ultima8/gumps/widgets/edit_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/edit_widget.cpp
@@ -34,7 +34,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(EditWidget, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(EditWidget)
 
 EditWidget::EditWidget(int x, int y, Std::string txt, bool gamefont_, int font,
                        int w, int h, unsigned int maxlength_, bool multiline_)

--- a/engines/ultima/ultima8/gumps/widgets/sliding_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/sliding_widget.cpp
@@ -28,7 +28,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(SlidingWidget, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(SlidingWidget)
 
 SlidingWidget::SlidingWidget()
 	: Gump() {

--- a/engines/ultima/ultima8/gumps/widgets/text_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/text_widget.cpp
@@ -193,10 +193,10 @@ void TextWidget::PaintComposited(RenderSurface *surf, int32 lerp_factor, int32 s
 	else
 		_cachedText->drawBlended(surf, x, y, _blendColour, true);
 
-	if (_parent->IsOfType<BarkGump>())
+	if (dynamic_cast<BarkGump *>(_parent))
 		return;
 
-	if (_parent->IsOfType<ButtonWidget>() && _parent->GetParent()->IsOfType<AskGump>())
+	if (dynamic_cast<ButtonWidget *>(_parent) && dynamic_cast<AskGump *>(_parent->GetParent()))
 		return;
 
 	x = _dims.x;

--- a/engines/ultima/ultima8/gumps/widgets/text_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/text_widget.cpp
@@ -34,7 +34,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(TextWidget, Gump)
+DEFINE_RUNTIME_CLASSTYPE_CODE(TextWidget)
 
 TextWidget::TextWidget() : Gump(), _gameFont(false), _fontNum(0), _blendColour(0),
 		_tx(0), _ty(0), _currentStart(0), _currentEnd(0), _targetWidth(0), _targetHeight(0),

--- a/engines/ultima/ultima8/kernel/core_app.cpp
+++ b/engines/ultima/ultima8/kernel/core_app.cpp
@@ -35,9 +35,6 @@ namespace Ultima8 {
 
 using Std::string;
 
-// p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(CoreApp)
-
 CoreApp *CoreApp::_application = nullptr;
 
 CoreApp::CoreApp(const Ultima::UltimaGameDescription *gameDesc)

--- a/engines/ultima/ultima8/kernel/core_app.cpp
+++ b/engines/ultima/ultima8/kernel/core_app.cpp
@@ -36,7 +36,7 @@ namespace Ultima8 {
 using Std::string;
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(CoreApp)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CoreApp)
 
 CoreApp *CoreApp::_application = nullptr;
 

--- a/engines/ultima/ultima8/kernel/core_app.h
+++ b/engines/ultima/ultima8/kernel/core_app.h
@@ -47,7 +47,6 @@ struct GameInfo;
 
 class CoreApp {
 public:
-	ENABLE_RUNTIME_CLASSTYPE_BASE()
 	CoreApp(const Ultima::UltimaGameDescription *gameDesc);
 	virtual ~CoreApp();
 

--- a/engines/ultima/ultima8/kernel/delay_process.cpp
+++ b/engines/ultima/ultima8/kernel/delay_process.cpp
@@ -28,7 +28,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(DelayProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(DelayProcess)
 
 
 

--- a/engines/ultima/ultima8/kernel/object.cpp
+++ b/engines/ultima/ultima8/kernel/object.cpp
@@ -32,7 +32,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(Object)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Object)
 
 Object::~Object() {
 	if (_objId != 0xFFFF)

--- a/engines/ultima/ultima8/kernel/process.cpp
+++ b/engines/ultima/ultima8/kernel/process.cpp
@@ -28,7 +28,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Process)
 
 Process::Process(ObjId it, uint16 ty)
 	: _pid(0xFFFF), _flags(0), _itemNum(it), _type(ty), _result(0) {

--- a/engines/ultima/ultima8/misc/p_dynamic_cast.h
+++ b/engines/ultima/ultima8/misc/p_dynamic_cast.h
@@ -34,10 +34,6 @@ struct RunTimeClassType {
 	}
 };
 
-//
-// Include this in every class. It sets up the class to be able to use
-// p_dynamic_cast. Make sure this is public!
-//
 #define ENABLE_RUNTIME_CLASSTYPE()                                              \
 	static const RunTimeClassType   ClassType;                                  \
 	virtual const RunTimeClassType & GetClassType() const override { return ClassType; }
@@ -46,9 +42,6 @@ struct RunTimeClassType {
 	static const RunTimeClassType   ClassType;                                  \
 	virtual const RunTimeClassType & GetClassType() const { return ClassType; }
 
-//
-// Define this in the source files of child classes, with 1 parent
-//
 #define DEFINE_RUNTIME_CLASSTYPE_CODE(Classname)    \
 	const RunTimeClassType Classname::ClassType = {                     \
 	                                                                    #Classname                                                      \

--- a/engines/ultima/ultima8/misc/p_dynamic_cast.h
+++ b/engines/ultima/ultima8/misc/p_dynamic_cast.h
@@ -40,17 +40,11 @@ struct RunTimeClassType {
 //
 #define ENABLE_RUNTIME_CLASSTYPE()                                              \
 	static const RunTimeClassType   ClassType;                                  \
-	virtual bool IsOfType(const RunTimeClassType & type) const override;        \
-	template<class Type> inline bool IsOfType() const { return IsOfType(Type::ClassType); }   \
 	virtual const RunTimeClassType & GetClassType() const override { return ClassType; }
 
 #define ENABLE_RUNTIME_CLASSTYPE_BASE()                                         \
 	static const RunTimeClassType   ClassType;                                  \
-	virtual bool IsOfType(const RunTimeClassType & type) const;                 \
-	template<class Type> inline bool IsOfType() const { return IsOfType(Type::ClassType); }   \
 	virtual const RunTimeClassType & GetClassType() const { return ClassType; }
-
-
 
 //
 // Define this in the source files of base classes
@@ -58,14 +52,7 @@ struct RunTimeClassType {
 #define DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(Classname)         \
 	const RunTimeClassType Classname::ClassType = {                 \
 	#Classname                                                      \
-    };                                                                  \
-	\
-	bool Classname::IsOfType(const RunTimeClassType &classType) const   \
-	{                                                                   \
-		if (classType == ClassType) return true;                        \
-		return false;                                                   \
-	}
-
+    };
 
 //
 // Define this in the source files of child classes, with 1 parent
@@ -73,13 +60,7 @@ struct RunTimeClassType {
 #define DEFINE_RUNTIME_CLASSTYPE_CODE(Classname,ParentClassname)    \
 	const RunTimeClassType Classname::ClassType = {                     \
 	                                                                    #Classname                                                      \
-	                                              };                                                                  \
-	\
-	bool Classname::IsOfType(const RunTimeClassType & classType) const  \
-	{                                                                   \
-		if (classType == ClassType) return true;                        \
-		return ParentClassname::IsOfType(classType);                    \
-	}
+	                                              };
 
 //
 // Define this in the source files of child classes, with 2 parents
@@ -87,18 +68,7 @@ struct RunTimeClassType {
 #define DEFINE_RUNTIME_CLASSTYPE_CODE_MULTI2(Classname,Parent1,Parent2) \
 	const RunTimeClassType Classname::ClassType = {                         \
 	                                                                        #Classname                                                          \
-	                                              };                                                                      \
-	\
-	bool Classname::IsOfType(const RunTimeClassType &type) const            \
-	{                                                                       \
-		typedef Parent1 P1;                                                 \
-		typedef Parent2 P2;                                                 \
-		if (type == ClassType) return true;                                 \
-		bool ret = P1::IsOfType(type);                                      \
-		if (ret) return true;                                               \
-		return P2::IsOfType(type);                                          \
-	}
-
+	                                              };
 } // End of namespace Ultima8
 } // End of namespace Ultima
 

--- a/engines/ultima/ultima8/misc/p_dynamic_cast.h
+++ b/engines/ultima/ultima8/misc/p_dynamic_cast.h
@@ -47,28 +47,13 @@ struct RunTimeClassType {
 	virtual const RunTimeClassType & GetClassType() const { return ClassType; }
 
 //
-// Define this in the source files of base classes
-//
-#define DEFINE_RUNTIME_CLASSTYPE_CODE_BASE_CLASS(Classname)         \
-	const RunTimeClassType Classname::ClassType = {                 \
-	#Classname                                                      \
-    };
-
-//
 // Define this in the source files of child classes, with 1 parent
 //
-#define DEFINE_RUNTIME_CLASSTYPE_CODE(Classname,ParentClassname)    \
+#define DEFINE_RUNTIME_CLASSTYPE_CODE(Classname)    \
 	const RunTimeClassType Classname::ClassType = {                     \
 	                                                                    #Classname                                                      \
 	                                              };
 
-//
-// Define this in the source files of child classes, with 2 parents
-//
-#define DEFINE_RUNTIME_CLASSTYPE_CODE_MULTI2(Classname,Parent1,Parent2) \
-	const RunTimeClassType Classname::ClassType = {                         \
-	                                                                        #Classname                                                          \
-	                                              };
 } // End of namespace Ultima8
 } // End of namespace Ultima
 

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -130,8 +130,6 @@ struct ProcessLoader {
 	}
 };
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(Ultima8Engine)
-
 Ultima8Engine::Ultima8Engine(OSystem *syst, const Ultima::UltimaGameDescription *gameDesc) :
 		Shared::UltimaEngine(syst, gameDesc), CoreApp(gameDesc), _saveCount(0), _game(nullptr),
 		_kernel(nullptr), _objectManager(nullptr), _mouse(nullptr), _ucMachine(nullptr),

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -130,7 +130,7 @@ struct ProcessLoader {
 	}
 };
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(Ultima8Engine, CoreApp)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Ultima8Engine)
 
 Ultima8Engine::Ultima8Engine(OSystem *syst, const Ultima::UltimaGameDescription *gameDesc) :
 		Shared::UltimaEngine(syst, gameDesc), CoreApp(gameDesc), _saveCount(0), _game(nullptr),

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -947,7 +947,7 @@ bool Ultima8Engine::canSaveGameStateCurrently(bool isAutosave) {
 		// Can't save when a modal gump is open, or avatar in statsis  during cutscenes
 		return false;
 
-	if (_kernel->getRunningProcess() && _kernel->getRunningProcess()->IsOfType<StartU8Process>())
+	if (dynamic_cast<StartU8Process *>(_kernel->getRunningProcess()))
 		// Don't save while starting up.
 		return false;
 
@@ -1381,20 +1381,20 @@ void Ultima8Engine::addGump(Gump *gump) {
 
 	assert(_desktopGump);
 
-	if (gump->IsOfType<ShapeViewerGump>() || gump->IsOfType<MiniMapGump>() ||
-		gump->IsOfType<ScalerGump>() || gump->IsOfType<MessageBoxGump>()// ||
-		//(_ttfOverrides && (gump->IsOfType<BarkGump>() ||
-		//                gump->IsOfType<AskGump>()))
+	if (dynamic_cast<ShapeViewerGump *>(gump) || dynamic_cast<MiniMapGump *>(gump) ||
+		dynamic_cast<ScalerGump *>(gump) || dynamic_cast<MessageBoxGump *>(gump)// ||
+		//(_ttfOverrides && (dynamic_cast<BarkGump *>(gump) ||
+		//                dynamic_cast<AskGump *>(gump)))
 		) {
 		//		pout << "adding to desktopgump: "; gump->dumpInfo();
 		_desktopGump->AddChild(gump);
-	} else if (gump->IsOfType<GameMapGump>()) {
+	} else if (dynamic_cast<GameMapGump *>(gump)) {
 		//		pout << "adding to invertergump: "; gump->dumpInfo();
 		_inverterGump->AddChild(gump);
-	} else if (gump->IsOfType<InverterGump>()) {
+	} else if (dynamic_cast<InverterGump *>(gump)) {
 		//		pout << "adding to _scalerGump: "; gump->dumpInfo();
 		_scalerGump->AddChild(gump);
-	} else if (gump->IsOfType<DesktopGump>()) {
+	} else if (dynamic_cast<DesktopGump *>(gump)) {
 	} else {
 		//		pout << "adding to _scalerGump: "; gump->dumpInfo();
 		_scalerGump->AddChild(gump);

--- a/engines/ultima/ultima8/ultima8.h
+++ b/engines/ultima/ultima8/ultima8.h
@@ -173,8 +173,6 @@ protected:
 public:
 	PointScaler point_scaler;
 public:
-	ENABLE_RUNTIME_CLASSTYPE()
-
 	Ultima8Engine(OSystem *syst, const Ultima::UltimaGameDescription *gameDesc);
 	~Ultima8Engine() override;
 	void GUIError(const Common::String &msg);

--- a/engines/ultima/ultima8/usecode/uc_process.cpp
+++ b/engines/ultima/ultima8/usecode/uc_process.cpp
@@ -30,7 +30,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(UCProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(UCProcess)
 
 UCProcess::UCProcess() : Process(), _classId(0xFFFF), _ip(0xFFFF),
 		_bp(0x0000), _temp32(0) { // !! fixme

--- a/engines/ultima/ultima8/world/actors/actor.cpp
+++ b/engines/ultima/ultima8/world/actors/actor.cpp
@@ -59,7 +59,7 @@ namespace Ultima8 {
 static const unsigned int BACKPACK_SHAPE = 529;
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(Actor, Container)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Actor)
 
 Actor::Actor() : _strength(0), _dexterity(0), _intelligence(0),
 	  _hitPoints(0), _mana(0), _alignment(0), _enemyAlignment(0),

--- a/engines/ultima/ultima8/world/actors/actor_anim_process.cpp
+++ b/engines/ultima/ultima8/world/actors/actor_anim_process.cpp
@@ -57,7 +57,7 @@ static const int watchactor = WATCHACTOR;
 #endif
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(ActorAnimProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ActorAnimProcess)
 
 ActorAnimProcess::ActorAnimProcess() : Process(), _tracker(nullptr),
 	_dir(0), _action(Animation::walk), _steps(0), _firstFrame(true),

--- a/engines/ultima/ultima8/world/actors/actor_bark_notify_process.cpp
+++ b/engines/ultima/ultima8/world/actors/actor_bark_notify_process.cpp
@@ -33,7 +33,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(ActorBarkNotifyProcess, GumpNotifyProcess)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ActorBarkNotifyProcess)
 
 ActorBarkNotifyProcess::ActorBarkNotifyProcess()
 	: GumpNotifyProcess() {

--- a/engines/ultima/ultima8/world/actors/ambush_process.cpp
+++ b/engines/ultima/ultima8/world/actors/ambush_process.cpp
@@ -31,7 +31,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(AmbushProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(AmbushProcess)
 
 AmbushProcess::AmbushProcess() : Process(), _delayCount(0) {
 

--- a/engines/ultima/ultima8/world/actors/avatar_death_process.cpp
+++ b/engines/ultima/ultima8/world/actors/avatar_death_process.cpp
@@ -38,7 +38,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(AvatarDeathProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(AvatarDeathProcess)
 
 AvatarDeathProcess::AvatarDeathProcess() : Process() {
 	_itemNum = 1;

--- a/engines/ultima/ultima8/world/actors/avatar_gravity_process.cpp
+++ b/engines/ultima/ultima8/world/actors/avatar_gravity_process.cpp
@@ -33,7 +33,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(AvatarGravityProcess, GravityProcess)
+DEFINE_RUNTIME_CLASSTYPE_CODE(AvatarGravityProcess)
 
 AvatarGravityProcess::AvatarGravityProcess()
 	: GravityProcess() {

--- a/engines/ultima/ultima8/world/actors/avatar_mover_process.cpp
+++ b/engines/ultima/ultima8/world/actors/avatar_mover_process.cpp
@@ -39,7 +39,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(AvatarMoverProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(AvatarMoverProcess)
 
 AvatarMoverProcess::AvatarMoverProcess() : Process(),
 		_lastFrame(0), _lastAttack(0), _idleTime(0),

--- a/engines/ultima/ultima8/world/actors/clear_feign_death_process.cpp
+++ b/engines/ultima/ultima8/world/actors/clear_feign_death_process.cpp
@@ -31,7 +31,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(ClearFeignDeathProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ClearFeignDeathProcess)
 
 ClearFeignDeathProcess::ClearFeignDeathProcess() : Process() {
 

--- a/engines/ultima/ultima8/world/actors/combat_process.cpp
+++ b/engines/ultima/ultima8/world/actors/combat_process.cpp
@@ -42,7 +42,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(CombatProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CombatProcess)
 
 CombatProcess::CombatProcess() : Process(), _target(0), _fixedTarget(0), _combatMode(CM_WAITING) {
 

--- a/engines/ultima/ultima8/world/actors/grant_peace_process.cpp
+++ b/engines/ultima/ultima8/world/actors/grant_peace_process.cpp
@@ -42,7 +42,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(GrantPeaceProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(GrantPeaceProcess)
 
 GrantPeaceProcess::GrantPeaceProcess() : Process(), _haveTarget(false) {
 }

--- a/engines/ultima/ultima8/world/actors/heal_process.cpp
+++ b/engines/ultima/ultima8/world/actors/heal_process.cpp
@@ -30,7 +30,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(HealProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(HealProcess)
 
 HealProcess::HealProcess() : Process() {
 	_hungerCounter = 0;

--- a/engines/ultima/ultima8/world/actors/loiter_process.cpp
+++ b/engines/ultima/ultima8/world/actors/loiter_process.cpp
@@ -32,7 +32,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(LoiterProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(LoiterProcess)
 
 LoiterProcess::LoiterProcess() : Process(), _count(0) {
 }

--- a/engines/ultima/ultima8/world/actors/main_actor.cpp
+++ b/engines/ultima/ultima8/world/actors/main_actor.cpp
@@ -49,7 +49,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(MainActor, Actor)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MainActor)
 
 MainActor::MainActor() : _justTeleported(false), _accumStr(0), _accumDex(0),
 	_accumInt(0) {

--- a/engines/ultima/ultima8/world/actors/pathfinder_process.cpp
+++ b/engines/ultima/ultima8/world/actors/pathfinder_process.cpp
@@ -34,7 +34,7 @@ static const unsigned int PATH_OK = 1;
 static const unsigned int PATH_FAILED = 0;
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(PathfinderProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(PathfinderProcess)
 
 PathfinderProcess::PathfinderProcess() : Process(),
 		_currentStep(0), _targetItem(0), _hitMode(false),

--- a/engines/ultima/ultima8/world/actors/quick_avatar_mover_process.cpp
+++ b/engines/ultima/ultima8/world/actors/quick_avatar_mover_process.cpp
@@ -35,7 +35,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(QuickAvatarMoverProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(QuickAvatarMoverProcess)
 
 ProcId QuickAvatarMoverProcess::_amp[6] = { 0, 0, 0, 0, 0, 0 };
 bool QuickAvatarMoverProcess::_clipping = false;

--- a/engines/ultima/ultima8/world/actors/resurrection_process.cpp
+++ b/engines/ultima/ultima8/world/actors/resurrection_process.cpp
@@ -29,7 +29,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(ResurrectionProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(ResurrectionProcess)
 
 ResurrectionProcess::ResurrectionProcess() : Process() {
 

--- a/engines/ultima/ultima8/world/actors/scheduler_process.cpp
+++ b/engines/ultima/ultima8/world/actors/scheduler_process.cpp
@@ -31,7 +31,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(SchedulerProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(SchedulerProcess)
 
 SchedulerProcess::SchedulerProcess() : Process() {
 	_lastRun = 0;

--- a/engines/ultima/ultima8/world/actors/targeted_anim_process.cpp
+++ b/engines/ultima/ultima8/world/actors/targeted_anim_process.cpp
@@ -29,7 +29,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(TargetedAnimProcess, ActorAnimProcess)
+DEFINE_RUNTIME_CLASSTYPE_CODE(TargetedAnimProcess)
 
 TargetedAnimProcess::TargetedAnimProcess() : ActorAnimProcess(),
 		_x(0), _y(0), _z(0) {

--- a/engines/ultima/ultima8/world/actors/teleport_to_egg_process.cpp
+++ b/engines/ultima/ultima8/world/actors/teleport_to_egg_process.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(TeleportToEggProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(TeleportToEggProcess)
 
 TeleportToEggProcess::TeleportToEggProcess() : Process(),
 	_mapNum(0), _teleportId(0) {

--- a/engines/ultima/ultima8/world/camera_process.cpp
+++ b/engines/ultima/ultima8/world/camera_process.cpp
@@ -36,7 +36,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(CameraProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CameraProcess)
 
 //
 // Statics

--- a/engines/ultima/ultima8/world/container.cpp
+++ b/engines/ultima/ultima8/world/container.cpp
@@ -38,7 +38,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(Container, Item)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Container)
 
 Container::Container() {
 }

--- a/engines/ultima/ultima8/world/create_item_process.cpp
+++ b/engines/ultima/ultima8/world/create_item_process.cpp
@@ -29,7 +29,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(CreateItemProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(CreateItemProcess)
 
 CreateItemProcess::CreateItemProcess()
 	: Process(), _shape(0), _frame(0), _quality(0), _flags(0),

--- a/engines/ultima/ultima8/world/destroy_item_process.cpp
+++ b/engines/ultima/ultima8/world/destroy_item_process.cpp
@@ -30,7 +30,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(DestroyItemProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(DestroyItemProcess)
 
 DestroyItemProcess::DestroyItemProcess() : Process() {
 

--- a/engines/ultima/ultima8/world/egg.cpp
+++ b/engines/ultima/ultima8/world/egg.cpp
@@ -30,7 +30,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(Egg, Item)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Egg)
 
 Egg::Egg() : _hatched(false) {
 }

--- a/engines/ultima/ultima8/world/egg_hatcher_process.cpp
+++ b/engines/ultima/ultima8/world/egg_hatcher_process.cpp
@@ -31,7 +31,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(EggHatcherProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(EggHatcherProcess)
 
 EggHatcherProcess::EggHatcherProcess() {
 }

--- a/engines/ultima/ultima8/world/fireball_process.cpp
+++ b/engines/ultima/ultima8/world/fireball_process.cpp
@@ -37,7 +37,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(FireballProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(FireballProcess)
 
 FireballProcess::FireballProcess()
 	: Process(), _xSpeed(0), _ySpeed(0), _age(0), _target(0) {

--- a/engines/ultima/ultima8/world/glob_egg.cpp
+++ b/engines/ultima/ultima8/world/glob_egg.cpp
@@ -33,7 +33,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(GlobEgg, Item)
+DEFINE_RUNTIME_CLASSTYPE_CODE(GlobEgg)
 
 GlobEgg::GlobEgg() {
 }

--- a/engines/ultima/ultima8/world/gravity_process.cpp
+++ b/engines/ultima/ultima8/world/gravity_process.cpp
@@ -33,7 +33,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(GravityProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(GravityProcess)
 
 GravityProcess::GravityProcess()
 	: Process(), _xSpeed(0), _ySpeed(0), _zSpeed(0), _gravity(0) {

--- a/engines/ultima/ultima8/world/item.cpp
+++ b/engines/ultima/ultima8/world/item.cpp
@@ -65,7 +65,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(Item, Object)
+DEFINE_RUNTIME_CLASSTYPE_CODE(Item)
 
 Item::Item()
 	: _shape(0), _frame(0), _x(0), _y(0), _z(0),

--- a/engines/ultima/ultima8/world/monster_egg.cpp
+++ b/engines/ultima/ultima8/world/monster_egg.cpp
@@ -35,7 +35,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(MonsterEgg, Item)
+DEFINE_RUNTIME_CLASSTYPE_CODE(MonsterEgg)
 
 MonsterEgg::MonsterEgg() {
 }

--- a/engines/ultima/ultima8/world/split_item_process.cpp
+++ b/engines/ultima/ultima8/world/split_item_process.cpp
@@ -30,7 +30,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_cast stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(SplitItemProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(SplitItemProcess)
 
 SplitItemProcess::SplitItemProcess() : Process(), _target(0) {
 

--- a/engines/ultima/ultima8/world/sprite_process.cpp
+++ b/engines/ultima/ultima8/world/sprite_process.cpp
@@ -32,7 +32,7 @@ namespace Ultima {
 namespace Ultima8 {
 
 // p_dynamic_class stuff
-DEFINE_RUNTIME_CLASSTYPE_CODE(SpriteProcess, Process)
+DEFINE_RUNTIME_CLASSTYPE_CODE(SpriteProcess)
 
 SpriteProcess::SpriteProcess()
 	: Process(), _shape(0), _frame(0), _firstFrame(0), _lastFrame(0),

--- a/engines/ultima/ultima8/world/teleport_egg.cpp
+++ b/engines/ultima/ultima8/world/teleport_egg.cpp
@@ -29,7 +29,7 @@
 namespace Ultima {
 namespace Ultima8 {
 
-DEFINE_RUNTIME_CLASSTYPE_CODE(TeleportEgg, Egg)
+DEFINE_RUNTIME_CLASSTYPE_CODE(TeleportEgg)
 
 TeleportEgg::TeleportEgg() {
 }


### PR DESCRIPTION
Replace remaining uses of IsOfType with dynamic_cast.
Consolide DEFINE_RUNTIME_CLASSTYPE_CODE_* macros. 
Remove RunTimeClassType from classes that no longer need it.

The RunTimeClassType code is down only the classname used for saving and debugger info.