### PR TITLE
Petka: Fix copy and paste errors in comments

### DIFF
--- a/engines/petka/file_mgr.cpp
+++ b/engines/petka/file_mgr.cpp
@@ -115,4 +115,4 @@ Common::SeekableReadStream *FileMgr::getFileStream(const Common::String &name) {
 	return nullptr;
 }
 
-} // End of namespace Pink
+} // End of namespace Petka

--- a/engines/petka/sound.h
+++ b/engines/petka/sound.h
@@ -70,6 +70,6 @@ private:
 	SoundsMap _sounds;
 };
 
-} // End of namespace Pink
+} // End of namespace Petka
 
 #endif


### PR DESCRIPTION
As fun the `pink` games are, this isn't that engine.