### PR TITLE
ULITIMA8: Improve basic avatar keyboard movement.

### DIFF
--- a/engines/ultima/ultima8/meta_engine.cpp
+++ b/engines/ultima/ultima8/meta_engine.cpp
@@ -56,10 +56,10 @@ static const KeybindingRecord KEYS[] = {
 		"GameMapGump::toggleHighlightItems", "TAB", nullptr },
 	{ ACTION_TOGGLE_TOUCHING, "TOUCHING", "Show Touching Items", "GUIApp::toggleShowTouchingItems", nullptr, "h", nullptr },
 	{ ACTION_JUMP, "JUMP", "Jump (fake both-button-click)", "AvatarMoverProcess::setFakeBothButtonClick", nullptr, "SPACE", nullptr },
-	{ ACTION_TURN_LEFT, "TURN_LEFT", "Turn Left", "AvatarMoverProcess::turnLeft", nullptr, "LEFT", nullptr },
-	{ ACTION_TURN_RIGHT, "TURN_RIGHT", "Turn Right", "AvatarMoverProcess::turnRight", nullptr, "RIGHT", nullptr },
-	{ ACTION_MOVE_FORWARD, "MOVE_FORWARD", "Move Forward", "AvatarMoverProcess::moveForward", nullptr, "UP", nullptr },
-	{ ACTION_MOVE_BACK, "MOVE_BACK", "Move Back", "AvatarMoverProcess::moveBack", nullptr, "DOWN", nullptr },
+	{ ACTION_TURN_LEFT, "TURN_LEFT", "Turn Left", "AvatarMoverProcess::startTurnLeft", "AvatarMoverProcess::stopTurnLeft", "LEFT", nullptr },
+	{ ACTION_TURN_RIGHT, "TURN_RIGHT", "Turn Right", "AvatarMoverProcess::startTurnRight", "AvatarMoverProcess::stopTurnRight", "RIGHT", nullptr },
+	{ ACTION_MOVE_FORWARD, "MOVE_FORWARD", "Move Forward", "AvatarMoverProcess::startMoveForward", "AvatarMoverProcess::stopMoveForward", "UP", nullptr },
+	{ ACTION_MOVE_BACK, "MOVE_BACK", "Move Back", "AvatarMoverProcess::startMoveBack", "AvatarMoverProcess::stopMoveBack", "DOWN", nullptr },
 
 	{ ACTION_NONE, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr }
 };

--- a/engines/ultima/ultima8/misc/debugger.cpp
+++ b/engines/ultima/ultima8/misc/debugger.cpp
@@ -83,10 +83,14 @@ Debugger::Debugger() : Shared::Debugger() {
 	registerCmd("Ultima8Engine::closeItemGumps", WRAP_METHOD(Debugger, cmdCloseItemGumps));
 
 	registerCmd("AvatarMoverProcess::setFakeBothButtonClick", WRAP_METHOD(Debugger, cmdBothButtonClick));
-	registerCmd("AvatarMoverProcess::turnLeft", WRAP_METHOD(Debugger, cmdTurnLeft));
-	registerCmd("AvatarMoverProcess::turnRight", WRAP_METHOD(Debugger, cmdTurnRight));
-	registerCmd("AvatarMoverProcess::moveForward", WRAP_METHOD(Debugger, cmdMoveForward));
-	registerCmd("AvatarMoverProcess::moveBack", WRAP_METHOD(Debugger, cmdMoveBack));
+	registerCmd("AvatarMoverProcess::startTurnLeft", WRAP_METHOD(Debugger, cmdStartTurnLeft));
+	registerCmd("AvatarMoverProcess::startTurnRight", WRAP_METHOD(Debugger, cmdStartTurnRight));
+	registerCmd("AvatarMoverProcess::startMoveForward", WRAP_METHOD(Debugger, cmdStartMoveForward));
+	registerCmd("AvatarMoverProcess::startMoveBack", WRAP_METHOD(Debugger, cmdStartMoveBack));
+	registerCmd("AvatarMoverProcess::stopTurnLeft", WRAP_METHOD(Debugger, cmdStopTurnLeft));
+	registerCmd("AvatarMoverProcess::stopTurnRight", WRAP_METHOD(Debugger, cmdStopTurnRight));
+	registerCmd("AvatarMoverProcess::stopMoveForward", WRAP_METHOD(Debugger, cmdStopMoveForward));
+	registerCmd("AvatarMoverProcess::stopMoveBack", WRAP_METHOD(Debugger, cmdStopMoveBack));
 
 	registerCmd("AudioProcess::listSFX", WRAP_METHOD(Debugger, cmdListSFX));
 	registerCmd("AudioProcess::playSFX", WRAP_METHOD(Debugger, cmdPlaySFX));
@@ -1111,7 +1115,7 @@ bool Debugger::cmdBothButtonClick(int argc, const char **argv) {
 	return false;
 }
 
-bool Debugger::cmdTurnLeft(int argc, const char **argv) {
+bool Debugger::cmdStartTurnLeft(int argc, const char **argv) {
 	if (Ultima8Engine::get_instance()->isAvatarInStasis()) {
 		debugPrintf("Can't turn left: avatarInStasis\n");
 		return false;
@@ -1119,12 +1123,12 @@ bool Debugger::cmdTurnLeft(int argc, const char **argv) {
 	AvatarMoverProcess *proc = Ultima8Engine::get_instance()->getAvatarMoverProcess();
 
 	if (proc) {
-		proc->tryTurnLeft();
+		proc->tryTurnLeft(true);
 	}
 	return false;
 }
 
-bool Debugger::cmdTurnRight(int argc, const char **argv) {
+bool Debugger::cmdStartTurnRight(int argc, const char **argv) {
 	if (Ultima8Engine::get_instance()->isAvatarInStasis()) {
 		debugPrintf("Can't turn right: avatarInStasis\n");
 		return false;
@@ -1132,12 +1136,12 @@ bool Debugger::cmdTurnRight(int argc, const char **argv) {
 	AvatarMoverProcess *proc = Ultima8Engine::get_instance()->getAvatarMoverProcess();
 
 	if (proc) {
-		proc->tryTurnRight();
+		proc->tryTurnRight(true);
 	}
 	return false;
 }
 
-bool Debugger::cmdMoveForward(int argc, const char **argv) {
+bool Debugger::cmdStartMoveForward(int argc, const char **argv) {
 	if (Ultima8Engine::get_instance()->isAvatarInStasis()) {
 		debugPrintf("Can't move forward: avatarInStasis\n");
 		return false;
@@ -1145,12 +1149,12 @@ bool Debugger::cmdMoveForward(int argc, const char **argv) {
 	AvatarMoverProcess *proc = Ultima8Engine::get_instance()->getAvatarMoverProcess();
 
 	if (proc) {
-		proc->tryMoveForward();
+		proc->tryMoveForward(true);
 	}
 	return false;
 }
 
-bool Debugger::cmdMoveBack(int argc, const char **argv) {
+bool Debugger::cmdStartMoveBack(int argc, const char **argv) {
 	if (Ultima8Engine::get_instance()->isAvatarInStasis()) {
 		debugPrintf("Can't move back: avatarInStasis\n");
 		return false;
@@ -1158,7 +1162,59 @@ bool Debugger::cmdMoveBack(int argc, const char **argv) {
 	AvatarMoverProcess *proc = Ultima8Engine::get_instance()->getAvatarMoverProcess();
 
 	if (proc) {
-		proc->tryMoveBack();
+		proc->tryMoveBack(true);
+	}
+	return false;
+}
+
+bool Debugger::cmdStopTurnLeft(int argc, const char **argv) {
+	if (Ultima8Engine::get_instance()->isAvatarInStasis()) {
+		debugPrintf("Can't turn left: avatarInStasis\n");
+		return false;
+	}
+	AvatarMoverProcess *proc = Ultima8Engine::get_instance()->getAvatarMoverProcess();
+
+	if (proc) {
+		proc->tryTurnLeft(false);
+	}
+	return false;
+}
+
+bool Debugger::cmdStopTurnRight(int argc, const char **argv) {
+	if (Ultima8Engine::get_instance()->isAvatarInStasis()) {
+		debugPrintf("Can't turn right: avatarInStasis\n");
+		return false;
+	}
+	AvatarMoverProcess *proc = Ultima8Engine::get_instance()->getAvatarMoverProcess();
+
+	if (proc) {
+		proc->tryTurnRight(false);
+	}
+	return false;
+}
+
+bool Debugger::cmdStopMoveForward(int argc, const char **argv) {
+	if (Ultima8Engine::get_instance()->isAvatarInStasis()) {
+		debugPrintf("Can't move forward: avatarInStasis\n");
+		return false;
+	}
+	AvatarMoverProcess *proc = Ultima8Engine::get_instance()->getAvatarMoverProcess();
+
+	if (proc) {
+		proc->tryMoveForward(false);
+	}
+	return false;
+}
+
+bool Debugger::cmdStopMoveBack(int argc, const char **argv) {
+	if (Ultima8Engine::get_instance()->isAvatarInStasis()) {
+		debugPrintf("Can't move back: avatarInStasis\n");
+		return false;
+	}
+	AvatarMoverProcess *proc = Ultima8Engine::get_instance()->getAvatarMoverProcess();
+
+	if (proc) {
+		proc->tryMoveBack(false);
 	}
 	return false;
 }

--- a/engines/ultima/ultima8/misc/debugger.h
+++ b/engines/ultima/ultima8/misc/debugger.h
@@ -154,10 +154,14 @@ private:
 
 	// Avatar mover
 	bool cmdBothButtonClick(int argc, const char **argv);
-	bool cmdTurnLeft(int argc, const char **argv);
-	bool cmdTurnRight(int argc, const char **argv);
-	bool cmdMoveForward(int argc, const char **argv);
-	bool cmdMoveBack(int argc, const char **argv);
+	bool cmdStartTurnLeft(int argc, const char **argv);
+	bool cmdStartTurnRight(int argc, const char **argv);
+	bool cmdStartMoveForward(int argc, const char **argv);
+	bool cmdStartMoveBack(int argc, const char **argv);
+	bool cmdStopTurnLeft(int argc, const char **argv);
+	bool cmdStopTurnRight(int argc, const char **argv);
+	bool cmdStopMoveForward(int argc, const char **argv);
+	bool cmdStopMoveBack(int argc, const char **argv);
 
 	// Audio Process
 	bool cmdListSFX(int argc, const char **argv);

--- a/engines/ultima/ultima8/world/actors/avatar_mover_process.h
+++ b/engines/ultima/ultima8/world/actors/avatar_mover_process.h
@@ -53,10 +53,10 @@ public:
 		_fakeBothButtonClick = true;
 	}
 
-	void tryTurnLeft();
-	void tryTurnRight();
-	void tryMoveForward();
-	void tryMoveBack();
+	void tryTurnLeft(bool b);
+	void tryTurnRight(bool b);
+	void tryMoveForward(bool b);
+	void tryMoveBack(bool b);
 
 private:
 	void saveData(Common::WriteStream *ws) override;
@@ -82,8 +82,13 @@ private:
 
 	//! A fake "both button" event has been requested
 	bool _fakeBothButtonClick;
-
+	
 	MButton _mouseButton[2];
+
+	bool _tryTurnLeft;
+	bool _tryTurnRight;
+	bool _tryMoveForward;
+	bool _tryMoveBack;
 };
 
 } // End of namespace Ultima8


### PR DESCRIPTION
ULITIMA8: Improve basic avatar keyboard movement.

This adds continuous movement while the movement keys are depressed. I'm an unsure how Crusader should move, so this was just experimenting until the controls felt good for the Avatar.  I'm thinking a few adjustments might be keyboard jumping being a jump forward instead of towards mouse, and maybe shift modifier to run and control modifier to step.