### PR TITLE
SCI: adlib - unmap channels on `voiceOff`

### DIFF
--- a/engines/sci/sound/drivers/adlib.cpp
+++ b/engines/sci/sound/drivers/adlib.cpp
@@ -697,6 +697,8 @@ void MidiDriver_AdLib::voiceOff(int voice) {
 	_voices[voice].isSustained = false;
 	setNote(voice, _voices[voice].note, 0);
 	_voices[voice].note = -1;
+	_voices[voice].channel = -1;
+	_voices[voice].mappedChannel = -1;
 	_voices[voice].age = 0;
 	queueMoveToBack(voice);
 	--_channels[channel].voices;


### PR DESCRIPTION
Bug #11476 has two issues. This solves the adlib issue described there.

Adding debugging prints, before the fix:

	initTrack, resetting mappedChannels
	assignVoices: channel: 2, voices: 1
	   assignVoices: _voices[0].mappedChannel = 2
	assignVoices: channel: 3, voices: 7
	   assignVoices: _voices[1].mappedChannel = 3
	   assignVoices: _voices[2].mappedChannel = 3
	   assignVoices: _voices[3].mappedChannel = 3
	   assignVoices: _voices[4].mappedChannel = 3
	   assignVoices: _voices[5].mappedChannel = 3
	   assignVoices: _voices[6].mappedChannel = 3
	   assignVoices: _voices[7].mappedChannel = 3
	ADLIB: assigning 6 additional voices to channel 1
	assignVoices: channel: 1, voices: 6
	   assignVoices: _voices[8].mappedChannel = 1
	   
	  
We see that it failed to allocate 6 additional voices to channel 1,
and allocated only 1 (creating unpleasant effect, instead of chord),
because the previous channel 3 had still the voices mapped to it,
even though it already finished, and called `voiceOff`


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
