### PR TITLE
DIRECTOR: Fix file path loading

### DIFF
--- a/engines/director/util.cpp
+++ b/engines/director/util.cpp
@@ -252,7 +252,7 @@ Common::String pathMakeRelative(Common::String path, bool recursive, bool addext
 
 				Common::String res = pathMakeRelative(newpath, false, false);
 
-				if (!res.equals(newpath))
+				if (f.open(res))
 					return res;
 			}
 		}


### PR DESCRIPTION
Filepaths are converted between mac and windows filepaths. In some cases the filenames were converted correctly, without doing a pass. A filepath conversion would return the same filepath. This wasn't recognized as a conversion that succeeded.

The fix is check if the resulting filename can be opened.