### PR TITLE
ULTIMA8: Refactor responsibility of class name save for objects and processes

### DIFF
--- a/engines/ultima/ultima8/audio/audio_process.h
+++ b/engines/ultima/ultima8/audio/audio_process.h
@@ -120,9 +120,9 @@ public:
 	void stopAllExceptSpeech();
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 private:
-	void saveData(Common::WriteStream *ws) override;
 	uint32 _paused;
 
 	//! play the next speech sample for the text in this SampleInfo

--- a/engines/ultima/ultima8/audio/remorse_music_process.h
+++ b/engines/ultima/ultima8/audio/remorse_music_process.h
@@ -40,8 +40,6 @@ class RemorseMusicProcess : public MusicProcess {
 	friend class Debugger;
 
 protected:
-	void saveData(Common::WriteStream *ws) override;
-
 	//! Play a music track
 	//! \param track The track number to play. Pass 0 to stop music
 	void playMusic_internal(int track) override;
@@ -86,6 +84,7 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/audio/u8_music_process.h
+++ b/engines/ultima/ultima8/audio/u8_music_process.h
@@ -60,8 +60,6 @@ public:
 	};
 
 private:
-	void saveData(Common::WriteStream *ws) override;
-
 	//! Play a music track
 	//! \param track The track number to play. Pass 0 to stop music
 	void playMusic_internal(int track) override;
@@ -117,6 +115,7 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/games/start_crusader_process.h
+++ b/engines/ultima/ultima8/games/start_crusader_process.h
@@ -44,7 +44,6 @@ protected:
 	bool _skipStart;
 	int _saveSlot;
 
-	void saveData(Common::WriteStream *ws) override;
 public:
 	StartCrusaderProcess(int saveSlot = -1);
 
@@ -54,6 +53,7 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/games/start_u8_process.h
+++ b/engines/ultima/ultima8/games/start_u8_process.h
@@ -37,7 +37,6 @@ protected:
 	bool _skipStart;
 	int _saveSlot;
 
-	void saveData(Common::WriteStream *ws) override;
 public:
 	StartU8Process(int saveSlot = -1);
 
@@ -47,6 +46,7 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/graphics/inverter_process.h
+++ b/engines/ultima/ultima8/graphics/inverter_process.h
@@ -50,9 +50,9 @@ public:
 	INTRINSIC(I_invertScreen);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	static InverterProcess *_inverter;
 	unsigned int _targetState;
 };

--- a/engines/ultima/ultima8/graphics/palette_fader_process.h
+++ b/engines/ultima/ultima8/graphics/palette_fader_process.h
@@ -58,7 +58,6 @@ public:
 	INTRINSIC(I_lightningBolt);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/ask_gump.h
+++ b/engines/ultima/ultima8/gumps/ask_gump.h
@@ -50,7 +50,6 @@ public:
 	void        ChildNotify(Gump *child, uint32 message) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/bark_gump.h
+++ b/engines/ultima/ultima8/gumps/bark_gump.h
@@ -66,7 +66,6 @@ protected:
 
 public:
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/book_gump.h
+++ b/engines/ultima/ultima8/gumps/book_gump.h
@@ -60,7 +60,6 @@ protected:
 
 public:
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/container_gump.h
+++ b/engines/ultima/ultima8/gumps/container_gump.h
@@ -77,9 +77,9 @@ public:
 	void onMouseDouble(int button, int32 mx, int32 my) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	void GetItemLocation(int32 lerp_factor) override;
 
 	virtual Container *getTargetContainer(Item *item, int mx, int my);

--- a/engines/ultima/ultima8/gumps/cru_ammo_gump.h
+++ b/engines/ultima/ultima8/gumps/cru_ammo_gump.h
@@ -47,7 +47,6 @@ public:
 	void PaintThis(RenderSurface *, int32 lerp_factor, bool scaled) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
 private:

--- a/engines/ultima/ultima8/gumps/cru_energy_gump.h
+++ b/engines/ultima/ultima8/gumps/cru_energy_gump.h
@@ -47,7 +47,6 @@ public:
 	void PaintThis(RenderSurface *, int32 lerp_factor, bool scaled) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/cru_health_gump.h
+++ b/engines/ultima/ultima8/gumps/cru_health_gump.h
@@ -47,7 +47,6 @@ public:
 	void PaintThis(RenderSurface *, int32 lerp_factor, bool scaled) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/cru_inventory_gump.h
+++ b/engines/ultima/ultima8/gumps/cru_inventory_gump.h
@@ -47,7 +47,6 @@ public:
 	void PaintThis(RenderSurface *, int32 lerp_factor, bool scaled) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
 private:

--- a/engines/ultima/ultima8/gumps/cru_stat_gump.h
+++ b/engines/ultima/ultima8/gumps/cru_stat_gump.h
@@ -47,7 +47,6 @@ public:
 	void PaintThis(RenderSurface *, int32 lerp_factor, bool scaled) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/cru_status_gump.h
+++ b/engines/ultima/ultima8/gumps/cru_status_gump.h
@@ -49,7 +49,6 @@ public:
 	void PaintThis(RenderSurface *, int32 lerp_factor, bool scaled) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/cru_weapon_gump.h
+++ b/engines/ultima/ultima8/gumps/cru_weapon_gump.h
@@ -47,7 +47,6 @@ public:
 	void PaintThis(RenderSurface *, int32 lerp_factor, bool scaled) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
 private:

--- a/engines/ultima/ultima8/gumps/desktop_gump.h
+++ b/engines/ultima/ultima8/gumps/desktop_gump.h
@@ -49,6 +49,7 @@ public:
 	void StopDraggingChild(Gump *gump) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 	void RenderSurfaceChanged(RenderSurface *surf);
 
@@ -57,7 +58,6 @@ public:
 	}
 
 protected:
-	void saveData(Common::WriteStream *ws) override;
 	void RenderSurfaceChanged() override;
 };
 

--- a/engines/ultima/ultima8/gumps/game_map_gump.h
+++ b/engines/ultima/ultima8/gumps/game_map_gump.h
@@ -79,6 +79,7 @@ public:
 	void IncSortOrder(int count);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 	static void Set_highlightItems(bool highlight) {
 		_highlightItems = highlight;
@@ -90,8 +91,6 @@ public:
 	void        RenderSurfaceChanged() override;
 
 protected:
-	void saveData(Common::WriteStream *ws) override;
-
 	bool _displayDragging;
 	uint32 _draggingShape;
 	uint32 _draggingFrame;

--- a/engines/ultima/ultima8/gumps/gump.cpp
+++ b/engines/ultima/ultima8/gumps/gump.cpp
@@ -818,7 +818,7 @@ void Gump::saveData(Common::WriteStream *ws) {
 	for (it = _children.begin(); it != _children.end(); ++it) {
 		if (!(*it)->mustSave(false)) continue;
 
-		(*it)->save(ws);
+		ObjectManager::get_instance()->saveObject(ws, *it);
 	}
 }
 

--- a/engines/ultima/ultima8/gumps/gump.h
+++ b/engines/ultima/ultima8/gumps/gump.h
@@ -458,7 +458,6 @@ public:
 	};
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/gump_notify_process.h
+++ b/engines/ultima/ultima8/gumps/gump_notify_process.h
@@ -55,7 +55,6 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/main_menu_process.h
+++ b/engines/ultima/ultima8/gumps/main_menu_process.h
@@ -41,9 +41,9 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	bool _init;
 };
 

--- a/engines/ultima/ultima8/gumps/message_box_gump.h
+++ b/engines/ultima/ultima8/gumps/message_box_gump.h
@@ -53,6 +53,7 @@ public:
 	void Close(bool no_del = false) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 	void PaintThis(RenderSurface *, int32 lerp_factor, bool scaled) override;
 
@@ -68,9 +69,6 @@ public:
 	}
 
 	void ChildNotify(Gump *child, uint32 msg) override;
-
-protected:
-	void saveData(Common::WriteStream *ws) override;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/gumps/mini_stats_gump.h
+++ b/engines/ultima/ultima8/gumps/mini_stats_gump.h
@@ -54,7 +54,6 @@ public:
 	void onMouseDouble(int button, int32 mx, int32 my) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/minimap_gump.h
+++ b/engines/ultima/ultima8/gumps/minimap_gump.h
@@ -52,7 +52,6 @@ public:
 	uint16      TraceObjId(int32 mx, int32 my) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/modal_gump.h
+++ b/engines/ultima/ultima8/gumps/modal_gump.h
@@ -53,7 +53,6 @@ public:
 	Gump *onMouseDown(int button, int32 mx, int32 my) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/movie_gump.h
+++ b/engines/ultima/ultima8/gumps/movie_gump.h
@@ -55,9 +55,9 @@ public:
 	static ProcId U8MovieViewer(Common::SeekableReadStream *rs, bool fade, bool introMusicHack = false);
 
 	bool loadData(Common::ReadStream *rs);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	MoviePlayer *_player;
 };
 

--- a/engines/ultima/ultima8/gumps/paged_gump.h
+++ b/engines/ultima/ultima8/gumps/paged_gump.h
@@ -57,8 +57,9 @@ public:
 	}
 
 	bool loadData(Common::ReadStream *rs);
-protected:
 	void saveData(Common::WriteStream *ws) override;
+
+protected:
 	int _leftOff, _rightOff, _topOff, _gumpShape;
 	Std::vector<Gump *> _gumps;
 	Gump *_nextButton;

--- a/engines/ultima/ultima8/gumps/paperdoll_gump.h
+++ b/engines/ultima/ultima8/gumps/paperdoll_gump.h
@@ -67,9 +67,9 @@ public:
 	void DropItem(Item *item, int mx, int my) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	//! Paint the stats
 	void PaintStats(RenderSurface *, int32 lerp_factor);
 

--- a/engines/ultima/ultima8/gumps/quit_gump.h
+++ b/engines/ultima/ultima8/gumps/quit_gump.h
@@ -50,8 +50,9 @@ public:
 	static void verifyQuit();
 
 	bool loadData(Common::ReadStream *rs);
-protected:
 	void saveData(Common::WriteStream *ws) override;
+
+protected:
 	ObjId _yesWidget, _noWidget;
 
 	uint32 _gumpShape;	//! shape number for the dialog

--- a/engines/ultima/ultima8/gumps/readable_gump.h
+++ b/engines/ultima/ultima8/gumps/readable_gump.h
@@ -55,7 +55,6 @@ public:
 	INTRINSIC(I_readPlaque);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/scroll_gump.h
+++ b/engines/ultima/ultima8/gumps/scroll_gump.h
@@ -59,7 +59,6 @@ protected:
 
 public:
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/shape_viewer_gump.h
+++ b/engines/ultima/ultima8/gumps/shape_viewer_gump.h
@@ -57,9 +57,9 @@ public:
 	static void U8ShapeViewer();
 
 	bool loadData(Common::ReadStream *rs);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	Std::vector<Std::pair<Std::string, ShapeArchive *> > _flexes;
 	unsigned int _curFlex;
 	ShapeArchive *_flex;

--- a/engines/ultima/ultima8/gumps/slider_gump.h
+++ b/engines/ultima/ultima8/gumps/slider_gump.h
@@ -59,9 +59,9 @@ public:
 	bool OnKeyDown(int key, int mod) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	int16 _min;
 	int16 _max;
 	int16 _delta;

--- a/engines/ultima/ultima8/gumps/target_gump.h
+++ b/engines/ultima/ultima8/gumps/target_gump.h
@@ -50,7 +50,6 @@ public:
 	INTRINSIC(I_target);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
 private:

--- a/engines/ultima/ultima8/gumps/widgets/button_widget.h
+++ b/engines/ultima/ultima8/gumps/widgets/button_widget.h
@@ -79,7 +79,6 @@ protected:
 
 public:
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/widgets/sliding_widget.h
+++ b/engines/ultima/ultima8/gumps/widgets/sliding_widget.h
@@ -41,7 +41,6 @@ public:
 	uint16 TraceObjId(int32 mx, int32 my) override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/gumps/widgets/text_widget.h
+++ b/engines/ultima/ultima8/gumps/widgets/text_widget.h
@@ -100,8 +100,6 @@ protected:
 
 public:
 	bool loadData(Common::ReadStream *rs, uint32 version);
-
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/kernel/delay_process.h
+++ b/engines/ultima/ultima8/kernel/delay_process.h
@@ -43,9 +43,9 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	int _count;
 };
 

--- a/engines/ultima/ultima8/kernel/kernel.cpp
+++ b/engines/ultima/ultima8/kernel/kernel.cpp
@@ -327,6 +327,14 @@ void Kernel::save(Common::WriteStream *ws) {
 		const char *cname = (*it)->GetClassType()._className; // virtual
 		uint16 clen = strlen(cname);
 
+		Std::map<Common::String, ProcessLoadFunc>::iterator iter;
+		iter = _processLoaders.find(cname);
+
+		if (iter == _processLoaders.end()) {
+			perr << "Process class cannot save without registered loader: " << cname << Std::endl;
+			continue;
+		}
+
 		ws->writeUint16LE(clen);
 		ws->write(cname, clen);
 		(*it)->saveData(ws);

--- a/engines/ultima/ultima8/kernel/kernel.cpp
+++ b/engines/ultima/ultima8/kernel/kernel.cpp
@@ -324,7 +324,12 @@ void Kernel::save(Common::WriteStream *ws) {
 	_pIDs->save(ws);
 	ws->writeUint32LE(_processes.size());
 	for (ProcessIterator it = _processes.begin(); it != _processes.end(); ++it) {
-		(*it)->save(ws);
+		const char *cname = (*it)->GetClassType()._className; // virtual
+		uint16 clen = strlen(cname);
+
+		ws->writeUint16LE(clen);
+		ws->write(cname, clen);
+		(*it)->saveData(ws);
 	}
 }
 

--- a/engines/ultima/ultima8/kernel/kernel.cpp
+++ b/engines/ultima/ultima8/kernel/kernel.cpp
@@ -324,14 +324,13 @@ void Kernel::save(Common::WriteStream *ws) {
 	_pIDs->save(ws);
 	ws->writeUint32LE(_processes.size());
 	for (ProcessIterator it = _processes.begin(); it != _processes.end(); ++it) {
-		Std::string classname = (*it)->GetClassType()._className; // virtual
+		const Std::string & classname = (*it)->GetClassType()._className; // virtual
 
 		Std::map<Common::String, ProcessLoadFunc>::iterator iter;
 		iter = _processLoaders.find(classname);
 
 		if (iter == _processLoaders.end()) {
-			perr << "Process class cannot save without registered loader: " << classname << Std::endl;
-			continue;
+			error("Process class cannot save without registered loader: %s", classname.c_str());
 		}
 
 		ws->writeUint16LE(classname.size());

--- a/engines/ultima/ultima8/kernel/kernel.cpp
+++ b/engines/ultima/ultima8/kernel/kernel.cpp
@@ -324,19 +324,18 @@ void Kernel::save(Common::WriteStream *ws) {
 	_pIDs->save(ws);
 	ws->writeUint32LE(_processes.size());
 	for (ProcessIterator it = _processes.begin(); it != _processes.end(); ++it) {
-		const char *cname = (*it)->GetClassType()._className; // virtual
-		uint16 clen = strlen(cname);
+		Std::string classname = (*it)->GetClassType()._className; // virtual
 
 		Std::map<Common::String, ProcessLoadFunc>::iterator iter;
-		iter = _processLoaders.find(cname);
+		iter = _processLoaders.find(classname);
 
 		if (iter == _processLoaders.end()) {
-			perr << "Process class cannot save without registered loader: " << cname << Std::endl;
+			perr << "Process class cannot save without registered loader: " << classname << Std::endl;
 			continue;
 		}
 
-		ws->writeUint16LE(clen);
-		ws->write(cname, clen);
+		ws->writeUint16LE(classname.size());
+		ws->write(classname.c_str(), classname.size());
 		(*it)->saveData(ws);
 	}
 }

--- a/engines/ultima/ultima8/kernel/object.cpp
+++ b/engines/ultima/ultima8/kernel/object.cpp
@@ -65,20 +65,6 @@ ProcId Object::callUsecode(uint16 classid, uint16 offset,
 	return Kernel::get_instance()->addProcess(p);
 }
 
-
-void Object::save(Common::WriteStream *ws) {
-	writeObjectHeader(ws);
-	saveData(ws); // virtual
-}
-
-void Object::writeObjectHeader(Common::WriteStream *ws) const {
-	const char *cname = GetClassType()._className; // note: virtual
-	uint16 clen = strlen(cname);
-
-	ws->writeUint16LE(clen);
-	ws->write(cname, clen);
-}
-
 void Object::saveData(Common::WriteStream *ws) {
 	// note: Object is unversioned. If we ever want to version it,
 	// increase the global savegame version

--- a/engines/ultima/ultima8/kernel/object.h
+++ b/engines/ultima/ultima8/kernel/object.h
@@ -54,9 +54,6 @@ public:
 	//! dump some info about this object to pout
 	virtual void dumpInfo() const;
 
-	//! save this object
-	void save(Common::WriteStream *ws);
-
 	//! Spawn a usecode function on this object
 	//! \param classid The usecode class to run
 	//! \param offset The offset in that class to run
@@ -68,14 +65,9 @@ public:
 	                   const uint8 *args = 0, int argsize = 0);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-
-protected:
-	//! write the Object savegame header (mainly consisting of the classname)
-	void writeObjectHeader(Common::WriteStream *ws) const;
-
-	//! save the actual Object data
 	virtual void saveData(Common::WriteStream *ws);
 
+protected:
 	ObjId _objId;
 };
 

--- a/engines/ultima/ultima8/kernel/object_manager.cpp
+++ b/engines/ultima/ultima8/kernel/object_manager.cpp
@@ -292,6 +292,13 @@ void ObjectManager::saveObject(Common::WriteStream *ws, Object *obj) const {
 	const char *cname = obj->GetClassType()._className; // note: virtual
 	uint16 clen = strlen(cname);
 
+	Std::map<Common::String, ObjectLoadFunc>::iterator iter;
+	iter = _objectLoaders.find(cname);
+	if (iter == _objectLoaders.end()) {
+		perr << "Object class cannot save without registered loader: " << cname << Std::endl;
+		return;
+	}
+
 	ws->writeUint16LE(clen);
 	ws->write(cname, clen);
 	obj->saveData(ws);

--- a/engines/ultima/ultima8/kernel/object_manager.cpp
+++ b/engines/ultima/ultima8/kernel/object_manager.cpp
@@ -227,7 +227,7 @@ void ObjectManager::save(Common::WriteStream *ws) {
 		// FIXME: This leaks _objIDs. See comment in ObjectManager::load().
 		if (gump && !gump->mustSave(true)) continue;
 
-		object->save(ws);
+		saveObject(ws, object);
 	}
  
 	ws->writeUint16LE(0);
@@ -286,6 +286,15 @@ bool ObjectManager::load(Common::ReadStream *rs, uint32 version) {
 	pout << "Reclaimed " << count << " _objIDs on load." << Std::endl;
 
 	return true;
+}
+
+void ObjectManager::saveObject(Common::WriteStream *ws, Object *obj) const {
+	const char *cname = obj->GetClassType()._className; // note: virtual
+	uint16 clen = strlen(cname);
+
+	ws->writeUint16LE(clen);
+	ws->write(cname, clen);
+	obj->saveData(ws);
 }
 
 Object *ObjectManager::loadObject(Common::ReadStream *rs, uint32 version) {

--- a/engines/ultima/ultima8/kernel/object_manager.cpp
+++ b/engines/ultima/ultima8/kernel/object_manager.cpp
@@ -289,18 +289,17 @@ bool ObjectManager::load(Common::ReadStream *rs, uint32 version) {
 }
 
 void ObjectManager::saveObject(Common::WriteStream *ws, Object *obj) const {
-	const char *cname = obj->GetClassType()._className; // note: virtual
-	uint16 clen = strlen(cname);
+	Std::string classname = obj->GetClassType()._className; // note: virtual
 
 	Std::map<Common::String, ObjectLoadFunc>::iterator iter;
-	iter = _objectLoaders.find(cname);
+	iter = _objectLoaders.find(classname);
 	if (iter == _objectLoaders.end()) {
-		perr << "Object class cannot save without registered loader: " << cname << Std::endl;
+		perr << "Object class cannot save without registered loader: " << classname << Std::endl;
 		return;
 	}
 
-	ws->writeUint16LE(clen);
-	ws->write(cname, clen);
+	ws->writeUint16LE(classname.size());
+	ws->write(classname.c_str(), classname.size());
 	obj->saveData(ws);
 }
 

--- a/engines/ultima/ultima8/kernel/object_manager.cpp
+++ b/engines/ultima/ultima8/kernel/object_manager.cpp
@@ -289,13 +289,12 @@ bool ObjectManager::load(Common::ReadStream *rs, uint32 version) {
 }
 
 void ObjectManager::saveObject(Common::WriteStream *ws, Object *obj) const {
-	Std::string classname = obj->GetClassType()._className; // note: virtual
+	const Std::string & classname = obj->GetClassType()._className; // note: virtual
 
 	Std::map<Common::String, ObjectLoadFunc>::iterator iter;
 	iter = _objectLoaders.find(classname);
 	if (iter == _objectLoaders.end()) {
-		perr << "Object class cannot save without registered loader: " << classname << Std::endl;
-		return;
+		error("Object class cannot save without registered loader: %s", classname.c_str());
 	}
 
 	ws->writeUint16LE(classname.size());

--- a/engines/ultima/ultima8/kernel/object_manager.h
+++ b/engines/ultima/ultima8/kernel/object_manager.h
@@ -65,6 +65,7 @@ public:
 	void save(Common::WriteStream *ws);
 	bool load(Common::ReadStream *rs, uint32 version);
 
+	void saveObject(Common::WriteStream *ws, Object *obj) const;
 	Object *loadObject(Common::ReadStream *rs, uint32 version);
 
 	Std::vector<Object *> _objects;

--- a/engines/ultima/ultima8/kernel/process.cpp
+++ b/engines/ultima/ultima8/kernel/process.cpp
@@ -117,19 +117,6 @@ void Process::dumpInfo() const {
 	g_debugger->debugPrintf("%s\n", info.c_str());
 }
 
-void Process::save(Common::WriteStream *ws) {
-	writeProcessHeader(ws);
-	saveData(ws); // virtual
-}
-
-void Process::writeProcessHeader(Common::WriteStream *ws) {
-	const char *cname = GetClassType()._className; // virtual
-	uint16 clen = strlen(cname);
-
-	ws->writeUint16LE(clen);
-	ws->write(cname, clen);
-}
-
 void Process::saveData(Common::WriteStream *ws) {
 	ws->writeUint16LE(_pid);
 	ws->writeUint32LE(_flags);

--- a/engines/ultima/ultima8/kernel/process.h
+++ b/engines/ultima/ultima8/kernel/process.h
@@ -109,18 +109,13 @@ public:
 	//! dump some info about this process to pout
 	virtual void dumpInfo() const;
 
-	//! save this process
-	void save(Common::WriteStream *ods);
-
 	//! load Process data
 	bool loadData(Common::ReadStream *rs, uint32 version);
 
-protected:
-	//! save the Process data
+	//! save Process data
 	virtual void saveData(Common::WriteStream *ws);
 
-	void writeProcessHeader(Common::WriteStream *ods);
-
+protected:
 	//! process id
 	ProcId _pid;
 

--- a/engines/ultima/ultima8/usecode/uc_process.h
+++ b/engines/ultima/ultima8/usecode/uc_process.h
@@ -58,9 +58,9 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	void load(uint16 classid_, uint16 offset_, uint32 this_ptr = 0,
 	          int thissize = 0, const uint8 *args = 0, int argsize = 0);
 	void call(uint16 classid_, uint16 offset_);

--- a/engines/ultima/ultima8/world/actors/actor.h
+++ b/engines/ultima/ultima8/world/actors/actor.h
@@ -217,8 +217,8 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
-	// p_dynamic_cast stuff
 	ENABLE_RUNTIME_CLASSTYPE()
 
 	INTRINSIC(I_isNPC);
@@ -292,8 +292,6 @@ public:
 	};
 
 protected:
-	void saveData(Common::WriteStream *ws) override;
-
 	int16 _strength;
 	int16 _dexterity;
 	int16 _intelligence;

--- a/engines/ultima/ultima8/world/actors/actor_anim_process.h
+++ b/engines/ultima/ultima8/world/actors/actor_anim_process.h
@@ -57,9 +57,9 @@ public:
 	}
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	virtual bool init();
 
 	//! perform special action for an animation

--- a/engines/ultima/ultima8/world/actors/actor_bark_notify_process.h
+++ b/engines/ultima/ultima8/world/actors/actor_bark_notify_process.h
@@ -39,7 +39,6 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/world/actors/ambush_process.h
+++ b/engines/ultima/ultima8/world/actors/ambush_process.h
@@ -41,9 +41,9 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	uint32 _delayCount;
 };
 

--- a/engines/ultima/ultima8/world/actors/avatar_death_process.h
+++ b/engines/ultima/ultima8/world/actors/avatar_death_process.h
@@ -40,7 +40,6 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/world/actors/avatar_gravity_process.h
+++ b/engines/ultima/ultima8/world/actors/avatar_gravity_process.h
@@ -41,7 +41,6 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/world/actors/avatar_mover_process.h
+++ b/engines/ultima/ultima8/world/actors/avatar_mover_process.h
@@ -48,6 +48,7 @@ public:
 	}
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 	void setFakeBothButtonClick() {
 		_fakeBothButtonClick = true;
@@ -59,8 +60,6 @@ public:
 	void tryMoveBack(bool b);
 
 private:
-	void saveData(Common::WriteStream *ws) override;
-
 	void handleHangingMode();
 	void handleCombatMode();
 	void handleNormalMode();

--- a/engines/ultima/ultima8/world/actors/clear_feign_death_process.h
+++ b/engines/ultima/ultima8/world/actors/clear_feign_death_process.h
@@ -41,7 +41,6 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/world/actors/combat_process.h
+++ b/engines/ultima/ultima8/world/actors/combat_process.h
@@ -49,9 +49,9 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	bool isValidTarget(Actor *target_);
 	bool isEnemy(Actor *target_);
 	bool inAttackRange();

--- a/engines/ultima/ultima8/world/actors/grant_peace_process.h
+++ b/engines/ultima/ultima8/world/actors/grant_peace_process.h
@@ -44,9 +44,9 @@ public:
 	INTRINSIC(I_castGrantPeace);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	bool _haveTarget;
 };
 

--- a/engines/ultima/ultima8/world/actors/heal_process.h
+++ b/engines/ultima/ultima8/world/actors/heal_process.h
@@ -41,9 +41,9 @@ public:
 	INTRINSIC(I_feedAvatar);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	void feedAvatar(uint16 food);
 
 	uint16 _healCounter;

--- a/engines/ultima/ultima8/world/actors/loiter_process.h
+++ b/engines/ultima/ultima8/world/actors/loiter_process.h
@@ -41,9 +41,9 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	int32 _count;
 };
 

--- a/engines/ultima/ultima8/world/actors/main_actor.h
+++ b/engines/ultima/ultima8/world/actors/main_actor.h
@@ -91,8 +91,8 @@ public:
 	}
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
-	// p_dynamic_cast stuff
 	ENABLE_RUNTIME_CLASSTYPE()
 
 	INTRINSIC(I_teleportToEgg);
@@ -107,8 +107,6 @@ public:
 
 
 protected:
-	void saveData(Common::WriteStream *ws) override;
-
 	void useInventoryItem(uint32 shapenum);
 
 	bool _justTeleported;

--- a/engines/ultima/ultima8/world/actors/pathfinder_process.h
+++ b/engines/ultima/ultima8/world/actors/pathfinder_process.h
@@ -48,9 +48,9 @@ public:
 //	virtual void terminate();
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	int32 _targetX, _targetY, _targetZ;
 	ObjId _targetItem;
 	bool _hitMode;

--- a/engines/ultima/ultima8/world/actors/quick_avatar_mover_process.h
+++ b/engines/ultima/ultima8/world/actors/quick_avatar_mover_process.h
@@ -58,9 +58,9 @@ public:
 	static void startMover(int x, int y, int z, int _dir);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	int _dx, _dy, _dz, _dir;
 	static ProcId _amp[6];
 	static bool _clipping;

--- a/engines/ultima/ultima8/world/actors/resurrection_process.h
+++ b/engines/ultima/ultima8/world/actors/resurrection_process.h
@@ -41,7 +41,6 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/world/actors/scheduler_process.h
+++ b/engines/ultima/ultima8/world/actors/scheduler_process.h
@@ -39,9 +39,9 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	uint32 _lastRun;
 	uint16 _nextActor;
 };

--- a/engines/ultima/ultima8/world/actors/targeted_anim_process.h
+++ b/engines/ultima/ultima8/world/actors/targeted_anim_process.h
@@ -41,9 +41,9 @@ public:
 	ENABLE_RUNTIME_CLASSTYPE()
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	bool init() override;
 
 	int32 _x, _y, _z;

--- a/engines/ultima/ultima8/world/actors/teleport_to_egg_process.h
+++ b/engines/ultima/ultima8/world/actors/teleport_to_egg_process.h
@@ -41,9 +41,9 @@ public:
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
 
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	int _mapNum;
 	int _teleportId;
 };

--- a/engines/ultima/ultima8/world/camera_process.h
+++ b/engines/ultima/ultima8/world/camera_process.h
@@ -84,9 +84,9 @@ public:
 	void terminate() override;   // Terminate NOW!
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-private:
 	void saveData(Common::WriteStream *ws) override;
 
+private:
 	int32 _sx, _sy, _sz;
 	int32 _ex, _ey, _ez;
 	int32 _time;

--- a/engines/ultima/ultima8/world/container.cpp
+++ b/engines/ultima/ultima8/world/container.cpp
@@ -308,7 +308,7 @@ void Container::saveData(Common::WriteStream *ws) {
 	ws->writeUint32LE(static_cast<uint32>(_contents.size()));
 	Std::list<Item *>::iterator iter;
 	for (iter = _contents.begin(); iter != _contents.end(); ++iter) {
-		(*iter)->save(ws);
+		ObjectManager::get_instance()->saveObject(ws, *iter);
 	}
 }
 

--- a/engines/ultima/ultima8/world/container.h
+++ b/engines/ultima/ultima8/world/container.h
@@ -109,14 +109,12 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 	INTRINSIC(I_removeContents);
 	INTRINSIC(I_destroyContents);
 
 protected:
-	//! save Container data
-	void saveData(Common::WriteStream *ws) override;
-
 	Std::list<Item *> _contents;
 };
 

--- a/engines/ultima/ultima8/world/create_item_process.h
+++ b/engines/ultima/ultima8/world/create_item_process.h
@@ -43,9 +43,9 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	uint32 _shape;
 	uint32 _frame;
 	uint16 _quality;

--- a/engines/ultima/ultima8/world/destroy_item_process.h
+++ b/engines/ultima/ultima8/world/destroy_item_process.h
@@ -45,7 +45,6 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/world/egg.h
+++ b/engines/ultima/ultima8/world/egg.h
@@ -66,6 +66,7 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 	INTRINSIC(I_getEggXRange);
 	INTRINSIC(I_getEggYRange);
@@ -75,8 +76,6 @@ public:
 	INTRINSIC(I_setEggId);
 
 protected:
-	void saveData(Common::WriteStream *ws) override;
-
 	bool _hatched;
 };
 

--- a/engines/ultima/ultima8/world/egg_hatcher_process.h
+++ b/engines/ultima/ultima8/world/egg_hatcher_process.h
@@ -45,9 +45,9 @@ public:
 	void addEgg(uint16 egg);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-private:
 	void saveData(Common::WriteStream *ws) override;
 
+private:
 	Std::vector<uint16> _eggs;
 };
 

--- a/engines/ultima/ultima8/world/fireball_process.h
+++ b/engines/ultima/ultima8/world/fireball_process.h
@@ -46,9 +46,9 @@ public:
 	INTRINSIC(I_TonysBalls);
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	void explode();
 
 	int _xSpeed, _ySpeed;

--- a/engines/ultima/ultima8/world/glob_egg.h
+++ b/engines/ultima/ultima8/world/glob_egg.h
@@ -43,7 +43,6 @@ public:
 	void enterFastArea() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/world/gravity_process.h
+++ b/engines/ultima/ultima8/world/gravity_process.h
@@ -50,9 +50,9 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	void fallStopped();
 
 	int _gravity;

--- a/engines/ultima/ultima8/world/item.h
+++ b/engines/ultima/ultima8/world/item.h
@@ -448,6 +448,7 @@ public:
 	void dumpInfo() const override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 	// Intrinsics
 	INTRINSIC(I_touch);
@@ -565,9 +566,6 @@ protected:
 
 	ObjId _gump;             // Item's gump
 	ProcId _gravityPid;      // Item's GravityTracker (or 0)
-
-	//! save the actual Item data
-	void saveData(Common::WriteStream *ws) override;
 
 private:
 

--- a/engines/ultima/ultima8/world/map.cpp
+++ b/engines/ultima/ultima8/world/map.cpp
@@ -290,7 +290,7 @@ void Map::save(Common::WriteStream *ws) {
 
 	Std::list<Item *>::iterator iter;
 	for (iter = _dynamicItems.begin(); iter != _dynamicItems.end(); ++iter) {
-		(*iter)->save(ws);
+		ObjectManager::get_instance()->saveObject(ws, *iter);
 	}
 }
 

--- a/engines/ultima/ultima8/world/monster_egg.h
+++ b/engines/ultima/ultima8/world/monster_egg.h
@@ -50,12 +50,10 @@ public:
 	uint16 hatch();
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
+	void saveData(Common::WriteStream *ws) override;
 
 	INTRINSIC(I_monsterEggHatch);
 	INTRINSIC(I_getMonId);
-
-protected:
-	void saveData(Common::WriteStream *ws) override;
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/world/split_item_process.h
+++ b/engines/ultima/ultima8/world/split_item_process.h
@@ -41,9 +41,9 @@ public:
 	void run() override;
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+protected:
 	ObjId _target;
 };
 

--- a/engines/ultima/ultima8/world/sprite_process.h
+++ b/engines/ultima/ultima8/world/sprite_process.h
@@ -74,7 +74,6 @@ protected:
 
 public:
 	bool loadData(Common::ReadStream *rs, uint32 version);
-protected:
 	void saveData(Common::WriteStream *ws) override;
 };
 

--- a/engines/ultima/ultima8/world/teleport_egg.h
+++ b/engines/ultima/ultima8/world/teleport_egg.h
@@ -44,11 +44,9 @@ public:
 	}
 
 	bool loadData(Common::ReadStream *rs, uint32 version);
-
-	uint16 hatch() override;
-protected:
 	void saveData(Common::WriteStream *ws) override;
 
+	uint16 hatch() override;
 };
 
 } // End of namespace Ultima8


### PR DESCRIPTION
ULTIMA8: Refactor responsibility of class name save for objects and processes

Objects and processes were responsible for saving the name that identifies them but cannot be responsible for the load of that class name as it is used to determine what object to construct. The better choice is to force the kernel and object manager to be responsible for both saving and loading of these class type headers.

Ideally, this will lead into a future change were the registration of the class for loading would also be used for registering known types for saving and possibly eliminate errors that occur when renaming or adding a class.