### PR TITLE
COMMON: Allow use of C++11 final keyword

### DIFF
--- a/common/c++11-compat.h
+++ b/common/c++11-compat.h
@@ -39,12 +39,13 @@
 #endif
 
 //
-// Replacement for the override keyword. This allows compilation of code
-// which uses it, but does not feature any semantic.
+// Replacement for the override & final keywords. This allows compilation of
+// code which uses it, but does not feature any semantic.
 //
-// MSVC 2012 and newer fully support override: http://msdn.microsoft.com/en-us/library/hh567368.aspx
+// MSVC 2012 and newer fully support these: http://msdn.microsoft.com/en-us/library/hh567368.aspx
 #if !defined(_MSC_VER) || _MSC_VER < 1700
 #define override
+#define final
 #endif
 
 #endif

--- a/common/lua/lcode.cpp
+++ b/common/lua/lcode.cpp
@@ -390,7 +390,7 @@ static void exp2reg (FuncState *fs, expdesc *e, int reg) {
   if (e->k == VJMP)
     luaK_concat(fs, &e->t, e->u.s.info);  /* put this jump in `t' list */
   if (hasjumps(e)) {
-    int final;  /* position after whole expression */
+    int final_pos;  /* position after whole expression */
     int p_f = NO_JUMP;  /* position of an eventual LOAD false */
     int p_t = NO_JUMP;  /* position of an eventual LOAD true */
     if (need_value(fs, e->t) || need_value(fs, e->f)) {
@@ -399,9 +399,9 @@ static void exp2reg (FuncState *fs, expdesc *e, int reg) {
       p_t = code_label(fs, reg, 1, 0);
       luaK_patchtohere(fs, fj);
     }
-    final = luaK_getlabel(fs);
-    patchlistaux(fs, e->f, final, reg, p_f);
-    patchlistaux(fs, e->t, final, reg, p_t);
+    final_pos = luaK_getlabel(fs);
+    patchlistaux(fs, e->f, final_pos, reg, p_f);
+    patchlistaux(fs, e->t, final_pos, reg, p_t);
   }
   e->f = e->t = NO_JUMP;
   e->u.s.info = reg;

--- a/engines/draci/walking.cpp
+++ b/engines/draci/walking.cpp
@@ -105,33 +105,33 @@ Common::Point WalkingMap::findNearestWalkable(int startX, int startY) const {
 		while (x <= y) {
 
 			// The place where, eventually, the result coordinates will be stored
-			Common::Point final;
+			Common::Point finalPos;
 
 			// Auxilliary array of multiplicative coefficients for reflecting points.
 			static const int kSigns[] = { 1, -1 };
 
 			// Check all 8 reflections of the basic point.
 			for (uint i = 0; i < 2; ++i) {
-				final.y = startY + y * kSigns[i];
+				finalPos.y = startY + y * kSigns[i];
 
 				for (uint j = 0; j < 2; ++j) {
-					final.x = startX + x * kSigns[j];
+					finalPos.x = startX + x * kSigns[j];
 
 					// If the current point is walkable, return it
-					if (searchRect.contains(final.x, final.y) && isWalkable(final)) {
-						return final;
+					if (searchRect.contains(finalPos.x, finalPos.y) && isWalkable(finalPos)) {
+						return finalPos;
 					}
 				}
 			}
 			for (uint i = 0; i < 2; ++i) {
-				final.y = startY + x * kSigns[i];
+				finalPos.y = startY + x * kSigns[i];
 
 				for (uint j = 0; j < 2; ++j) {
-					final.x = startX + y * kSigns[j];
+					finalPos.x = startX + y * kSigns[j];
 
 					// If the current point is walkable, return it
-					if (searchRect.contains(final.x, final.y) && isWalkable(final)) {
-						return final;
+					if (searchRect.contains(finalPos.x, finalPos.y) && isWalkable(finalPos)) {
+						return finalPos;
 					}
 				}
 			}

--- a/engines/glk/adrift/scparser.cpp
+++ b/engines/glk/adrift/scparser.cpp
@@ -1749,7 +1749,7 @@ sc_char *uip_replace_pronouns(sc_gameref_t game, const sc_char *string) {
 		 */
 		if (prefix && name && extent > 0) {
 			sc_char *position;
-			sc_int prefix_length, name_length, length, final;
+			sc_int prefix_length, name_length, length, final_length;
 
 			/*
 			 * If not yet allocated, allocate a buffer now, and copy the input
@@ -1778,15 +1778,15 @@ sc_char *uip_replace_pronouns(sc_gameref_t game, const sc_char *string) {
 				buffer_allocation += length - extent;
 				buffer = (sc_char *)sc_realloc(buffer, buffer_allocation);
 				current = buffer + offset;
-				final = length;
+				final_length = length;
 			} else
-				final = extent;
+				final_length = extent;
 
 			/* Insert the replacement strings into the buffer. */
 			position = buffer + (current - buffer);
 			memmove(position + length,
 			        position + extent,
-			        buffer_allocation - (current - buffer) - final);
+			        buffer_allocation - (current - buffer) - final_length);
 			memcpy(position, prefix, prefix_length);
 			position[prefix_length] = ' ';
 			memcpy(position + prefix_length + 1, name, name_length);

--- a/engines/glk/adrift/scprintf.cpp
+++ b/engines/glk/adrift/scprintf.cpp
@@ -1345,7 +1345,7 @@ sc_char *pf_filter_input(const sc_char *string, sc_prop_setref_t bundle) {
 		if (index_ < synonym_count && extent > 0) {
 			const sc_char *replacement;
 			sc_char *position;
-			sc_int length, final;
+			sc_int length, final_length;
 
 			/*
 			 * If not yet allocated, allocate a buffer now, and copy the input
@@ -1378,15 +1378,15 @@ sc_char *pf_filter_input(const sc_char *string, sc_prop_setref_t bundle) {
 				buffer_allocation += length - extent;
 				buffer = (sc_char *)sc_realloc(buffer, buffer_allocation);
 				current = buffer + offset;
-				final = length;
+				final_length = length;
 			} else
-				final = extent;
+				final_length = extent;
 
 			/* Insert the replacement string into the buffer. */
 			position = buffer + (current - buffer);
 			memmove(position + length,
 			        position + extent,
-			        buffer_allocation - (current - buffer) - final);
+			        buffer_allocation - (current - buffer) - final_length);
 			memcpy(position, replacement, length);
 
 			/* Adjust current to skip over the replacement. */


### PR DESCRIPTION
The first commit is cherry-picked from the [shivers2 branch](https://github.com/csnover/scummvm/commit/7cf86625f9fbb30562e24b368e580594d1818aed). The remaining commits fix compilation errors caused by the replacement `final` keyword clashing with variable names.