### PR TITLE
BASE: Fix and enable INITIALIZIER_LIST1 c++11 test

### DIFF
--- a/base/test_new_standards.cpp
+++ b/base/test_new_standards.cpp
@@ -43,15 +43,14 @@
 //
 // We're not testing `nullptr` and `override`, since they're defined in common/c++11-compat.h
 
-// INITIALIZIER_LIST1 test disabled:
-// it fails in my VS 2019 and in GCC 4.8.5 (from 2015)
-// TODO: maybe it's my syntax problem, maybe Common::Array need to be changed to support this syntax?
-#define DONT_TEST_INITIALIZIER_LIST1
-
 #include "common/array.h"
 #include "common/hashmap.h"
 #include "common/hash-str.h"
 #include "common/rect.h"
+
+#ifndef DONT_TEST_INITIALIZIER_LIST1
+#include <initializer_list>
+#endif
 
 #ifndef DONT_TEST_CLASS_ENUM
 // ----------------------------------
@@ -121,6 +120,19 @@ private:
 	Dictionary_11<int> d11;
 #endif
 
+#ifndef DONT_TEST_INITIALIZIER_LIST1
+	// Array with C++11 initialization list
+	template<class T> class ArrayCpp11 : public Common::Array<T> {
+	public:
+		ArrayCpp11(std::initializer_list<T> list) {
+			if (list.size()) {
+				this->allocCapacity(list.size());
+				Common::uninitialized_copy(list.begin(), list.end(), this->_storage);
+			}
+		}
+	};
+#endif
+
 	void test_cpp11() {
 #ifdef DONT_TEST_INITIALIZIER_LIST1
 		// ------------------------
@@ -133,7 +145,7 @@ private:
 		arr.push_back(3);
 #else
 		// C++11
-		Common::Array<int> arr = {1, 2, 3};
+		ArrayCpp11<int> arr = {1, 2, 3};
 #endif
 
 #ifndef DONT_TEST_INITIALIZIER_LIST2

--- a/base/test_new_standards.cpp
+++ b/base/test_new_standards.cpp
@@ -49,7 +49,42 @@
 #include "common/rect.h"
 
 #ifndef DONT_TEST_INITIALIZIER_LIST1
+#ifndef USE_INITIALIZIER_LIST_REPLACEMENT
 #include <initializer_list>
+#else
+namespace std {
+template<class T> class initializer_list {
+public:
+	typedef T value_type;
+	typedef const T& reference;
+	typedef const T& const_reference;
+	typedef size_t size_type;
+	typedef const T* iterator;
+	typedef const T* const_iterator;
+
+	constexpr initializer_list() noexcept = default;
+	constexpr size_t size() const noexcept { return m_size; };
+	constexpr const T* begin() const noexcept { return m_begin; };
+	constexpr const T* end() const noexcept { return m_begin + m_size; }
+
+private:
+	// Note: begin has to be first or the compiler gets very upset
+	const T* m_begin = { nullptr };
+	size_t m_size = { 0 };
+
+	// The compiler is allowed to call this constructor
+	constexpr initializer_list(const T* t, size_t s) noexcept : m_begin(t) , m_size(s) {}
+};
+
+template<class T> constexpr const T* begin(initializer_list<T> il) noexcept {
+	return il.begin();
+}
+
+template<class T> constexpr const T* end(initializer_list<T> il) noexcept {
+	return il.end();
+}
+} // end namespace std
+#endif
 #endif
 
 #ifndef DONT_TEST_CLASS_ENUM

--- a/configure
+++ b/configure
@@ -169,7 +169,7 @@ _iconv=auto
 _tts=auto
 _gtk=auto
 _fribidi=auto
-_test_cpp11=no
+_test_cxx11=no
 # Default option behavior yes/no
 _debug_build=auto
 _release_build=auto
@@ -261,7 +261,7 @@ add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
 add_feature lua "lua" "_lua"
 add_feature fribidi "FriBidi" "_fribidi"
-add_feature test_cpp11 "Test C++11" "_test_cpp11"
+add_feature test_cxx11 "Test C++11" "_test_cxx11"
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,
@@ -1242,8 +1242,8 @@ for ac_option in $@; do
 	--disable-mad)                _mad=no                ;;
 	--enable-fribidi)             _fribidi=yes           ;;
 	--disable-fribidi)            _fribidi=no            ;;
-	--enable-test-cpp11)          _test_cpp11=yes        ;;
-	--disable-test-cpp11)         _test_cpp11=no         ;;
+	--enable-test-c++11)          _test_cxx11=yes        ;;
+	--disable-test-c++11)         _test_cxx11=no         ;;
 	--enable-zlib)                _zlib=yes              ;;
 	--disable-zlib)               _zlib=no               ;;
 	--enable-sparkle)             _sparkle=yes           ;;
@@ -5576,9 +5576,9 @@ echo "$_fribidi"
 #
 # Test C++11 Compatibility
 #
-define_in_config_if_yes "$_test_cpp11" 'ENABLE_TEST_CPP_11'
+define_in_config_if_yes "$_test_cxx11" 'ENABLE_TEST_CPP_11'
 echo_n "Test C++11 compatibility during compilation... "
-echo "$_test_cpp11"
+echo "$_test_cxx11"
 
 # Default to plain text output for pandoc
 if test -z "$_pandocformat" -o "$_pandocformat" = "default"; then


### PR DESCRIPTION
I am creating a pull request for this so that a second pair of eyes can take a look before this is pushed (I am not very confident with my c++11 skills since we are not allowed to use it yet where I work).