### PR TITLE
MIDI/ULTIMA8: Add XMIDI sequence branch indexes

### DIFF
--- a/audio/midiparser.cpp
+++ b/audio/midiparser.cpp
@@ -43,7 +43,7 @@ _smartJump(false),
 _centerPitchWheelOnUnload(false),
 _sendSustainOffOnNotesOff(false),
 _disableAllNotesOffMidiEvents(false),
-_doNotAutoStartPlayback(false),
+_disableAutoStartPlayback(false),
 _numTracks(0),
 _activeTrack(255),
 _abortParse(false),
@@ -74,8 +74,8 @@ void MidiParser::property(int prop, int value) {
 	case mpDisableAllNotesOffMidiEvents:
 		_disableAllNotesOffMidiEvents = (value != 0);
 		break;
-	case mpDoNotAutoStartPlayback:
-		_doNotAutoStartPlayback = (value != 0);
+	case mpDisableAutoStartPlayback:
+		_disableAutoStartPlayback = (value != 0);
 		break;
 	default:
 		break;
@@ -353,7 +353,7 @@ bool MidiParser::setTrack(int track) {
 
 	resetTracking();
 	memset(_activeNotes, 0, sizeof(_activeNotes));
-	if (_doNotAutoStartPlayback)
+	if (_disableAutoStartPlayback)
 		_doParse = false;
 	_activeTrack = track;
 	_position._playPos = _tracks[track];

--- a/audio/midiparser.h
+++ b/audio/midiparser.h
@@ -281,7 +281,7 @@ protected:
 	bool   _centerPitchWheelOnUnload;  ///< Center the pitch wheels when unloading a song
 	bool   _sendSustainOffOnNotesOff;   ///< Send a sustain off on a notes off event, stopping hanging notes
 	bool   _disableAllNotesOffMidiEvents;   ///< Don't send All Notes Off MIDI messages
-	bool   _doNotAutoStartPlayback;  ///< Do not automatically start playback after parsing MIDI data or setting the track
+	bool   _disableAutoStartPlayback;  ///< Do not automatically start playback after parsing MIDI data or setting the track
 	byte  *_tracks[MAXIMUM_TRACKS];    ///< Multi-track MIDI formats are supported, up to 120 tracks.
 	byte   _numTracks;     ///< Count of total tracks for multi-track MIDI formats. 1 for single-track formats.
 	byte   _activeTrack;   ///< Keeps track of the currently active track, in multi-track formats.
@@ -388,7 +388,7 @@ public:
 		  * or setting the track. Use startPlaying to start playback.
 		  * Note that not every parser implementation might support this.
 		  */
-		  mpDoNotAutoStartPlayback = 7
+		  mpDisableAutoStartPlayback = 7
 	};
 
 public:

--- a/audio/midiparser.h
+++ b/audio/midiparser.h
@@ -264,6 +264,8 @@ struct NoteTimer {
  */
 class MidiParser {
 protected:
+	static const uint8 MAXIMUM_TRACKS = 120;
+
 	uint16    _activeNotes[128];   ///< Each uint16 is a bit mask for channels that have that note on.
 	NoteTimer _hangingNotes[32];   ///< Maintains expiration info for up to 32 notes.
 	                                ///< Used for "Smart Jump" and MIDI formats that do not include explicit Note Off events.
@@ -280,7 +282,7 @@ protected:
 	bool   _sendSustainOffOnNotesOff;   ///< Send a sustain off on a notes off event, stopping hanging notes
 	bool   _disableAllNotesOffMidiEvents;   ///< Don't send All Notes Off MIDI messages
 	bool   _doNotAutoStartPlayback;  ///< Do not automatically start playback after parsing MIDI data or setting the track
-	byte  *_tracks[120];    ///< Multi-track MIDI formats are supported, up to 120 tracks.
+	byte  *_tracks[MAXIMUM_TRACKS];    ///< Multi-track MIDI formats are supported, up to 120 tracks.
 	byte   _numTracks;     ///< Count of total tracks for multi-track MIDI formats. 1 for single-track formats.
 	byte   _activeTrack;   ///< Keeps track of the currently active track, in multi-track formats.
 

--- a/audio/midiparser_xmidi.cpp
+++ b/audio/midiparser_xmidi.cpp
@@ -55,7 +55,7 @@ protected:
 	 * The sequence branches defined for each track. These point to
 	 * positions in the MIDI data.
 	 */
-	byte *_trackBranches[ARRAYSIZE(_tracks)][MAXIMUM_TRACK_BRANCHES];
+	byte *_trackBranches[MAXIMUM_TRACKS][MAXIMUM_TRACK_BRANCHES];
 
 	XMidiCallbackProc _callbackProc;
 	void *_callbackData;

--- a/audio/midiparser_xmidi.cpp
+++ b/audio/midiparser_xmidi.cpp
@@ -33,6 +33,8 @@
  */
 class MidiParser_XMIDI : public MidiParser {
 protected:
+	static const uint8 MAXIMUM_TRACK_BRANCHES = 128;
+
 	struct Loop {
 		byte *pos;
 		byte repeat;
@@ -49,6 +51,11 @@ protected:
 	 * of MIDI messages and multiple source functionality is disabled.
 	 */
 	int8 _source;
+	/**
+	 * The sequence branches defined for each track. These point to
+	 * positions in the MIDI data.
+	 */
+	byte *_trackBranches[ARRAYSIZE(_tracks)][MAXIMUM_TRACK_BRANCHES];
 
 	XMidiCallbackProc _callbackProc;
 	void *_callbackData;
@@ -71,6 +78,14 @@ protected:
 
 protected:
 	uint32 readVLQ2(byte * &data);
+	/**
+	 * Platform independent LE uint32 read-and-advance.
+	 * This helper function reads Little Endian 32-bit numbers
+	 * from a memory pointer, at the same time advancing
+	 * the pointer.
+	 */
+	uint32 read4low(byte *&data);
+
 	void parseNextEvent(EventInfo &info);
 
 	virtual void resetTracking() {
@@ -91,14 +106,16 @@ public:
 			_activeTrackTimbreList(NULL),
 			_activeTrackTimbreListSize(0) {
 		memset(_loop, 0, sizeof(_loop));
+		memset(_trackBranches, 0, sizeof(_trackBranches));
 		memset(_tracksTimbreList, 0, sizeof(_tracksTimbreList));
 		memset(_tracksTimbreListSize, 0, sizeof(_tracksTimbreListSize));
 	}
 	~MidiParser_XMIDI() { }
 
 	bool loadMusic(byte *data, uint32 size);
+	bool hasJumpIndex(uint8 index) override;
+	bool jumpToIndex(uint8 index, bool stopNotes) override;
 };
-
 
 // This is a special XMIDI variable length quantity
 uint32 MidiParser_XMIDI::readVLQ2(byte * &pos) {
@@ -107,6 +124,49 @@ uint32 MidiParser_XMIDI::readVLQ2(byte * &pos) {
 		value += *pos++;
 	}
 	return value;
+}
+
+uint32 MidiParser_XMIDI::read4low(byte *&data) {
+	uint32 val = READ_LE_UINT32(data);
+	data += 4;
+	return val;
+}
+
+bool MidiParser_XMIDI::hasJumpIndex(uint8 index) {
+	if (_activeTrack < 0 || _activeTrack >= _numTracks)
+		return false;
+
+	return index < MAXIMUM_TRACK_BRANCHES && _trackBranches[_activeTrack][index] != 0;
+}
+
+bool MidiParser_XMIDI::jumpToIndex(uint8 index, bool stopNotes) {
+	if (_activeTrack < 0 || _activeTrack >= _numTracks)
+		return false;
+
+	if (index >= MAXIMUM_TRACK_BRANCHES || _trackBranches[_activeTrack][index] == 0) {
+		warning("MidiParser-XMIDI: jumpToIndex called with invalid sequence branch index %x", index);
+		return false;
+	}
+
+	// Prevent concurrent execution of multiple jumps
+	assert(!_jumpingToTick);
+	_jumpingToTick = true;
+
+	if (stopNotes) {
+		if (!_smartJump || !_position._playPos) {
+			allNotesOff();
+		} else {
+			hangAllActiveNotes();
+		}
+	}
+
+	resetTracking();
+	_position._playPos = _trackBranches[_activeTrack][index];
+	parseNextEvent(_nextEvent);
+
+	_jumpingToTick = false;
+
+	return true;
 }
 
 void MidiParser_XMIDI::parseNextEvent(EventInfo &info) {
@@ -184,6 +244,12 @@ void MidiParser_XMIDI::parseNextEvent(EventInfo &info) {
 				_callbackProc(info.basic.param2, _callbackData);
 			break;
 
+		case 0x78:	// XMIDI_CONTROLLER_SEQ_BRANCH_INDEX
+			// This controller marks a branch point. It is converted
+			// to an entry in the RBRN header by the XMIDI conversion
+			// tool. For playback it is unnecessary.
+			break;
+
 		case 0x6e:	// XMIDI_CONTROLLER_CHAN_LOCK
 		case 0x6f:	// XMIDI_CONTROLLER_CHAN_LOCK_PROT
 		case 0x70:	// XMIDI_CONTROLLER_VOICE_PROT
@@ -194,9 +260,8 @@ void MidiParser_XMIDI::parseNextEvent(EventInfo &info) {
 
 		case 0x73:	// XMIDI_CONTROLLER_IND_CTRL_PREFIX
 		case 0x76:	// XMIDI_CONTROLLER_CLEAR_BB_COUNT
-		case 0x78:	// XMIDI_CONTROLLER_SEQ_BRANCH_INDEX
 		default:
-			if (info.basic.param1 >= 0x73 && info.basic.param1 <= 0x78) {
+			if (info.basic.param1 >= 0x73 && info.basic.param1 <= 0x76) {
 				warning("Unsupported XMIDI controller %d (0x%2x)",
 					info.basic.param1, info.basic.param1);
 			}
@@ -363,6 +428,8 @@ bool MidiParser_XMIDI::loadMusic(byte *data, uint32 size) {
 		}
 
 		int tracksRead = 0;
+		uint32 branchOffsets[128];
+		memset(branchOffsets, 0, sizeof(branchOffsets));
 		while (tracksRead < _numTracks) {
 			if (!memcmp(pos, "FORM", 4)) {
 				// Skip this plus the 4 bytes after it.
@@ -388,13 +455,40 @@ bool MidiParser_XMIDI::loadMusic(byte *data, uint32 size) {
 				pos += 4;
 				len = read4high(pos);
 				pos += (len + 1) & ~1;
+				// Calculate branch index positions using the track position we just found
+				for (int j = 0; j < MAXIMUM_TRACK_BRANCHES; ++j) {
+					if (branchOffsets[j] != 0) {
+						byte *branchPos = _tracks[tracksRead] + branchOffsets[j];
+						if (branchPos >= pos) {
+							warning("Invalid sequence branch position (after track end)");
+							branchPos = _tracks[tracksRead];
+						}
+						_trackBranches[tracksRead][j] = branchPos;
+					}
+				}
+				// Clear the branch offsets for the next track
+				memset(branchOffsets, 0, sizeof(branchOffsets));
 				++tracksRead;
 			} else if (!memcmp(pos, "RBRN", 4)) {
-				// optional branch point offsets. Ignored
+				// optional branch point offsets
 				pos += 4;
 				len = read4high(pos);
-				pos += (len + 1) & ~1;
-
+				uint16 numBranches = (len - 2) / 6;
+				uint16 numBranches2 = read2low(pos);
+				if (numBranches != numBranches2) {
+					warning("Number of sequence branch definitions %d does not match RBRN block length %d", numBranches2, len);
+					numBranches = 0;
+				}
+				for (int j = 0; j < numBranches; ++j) {
+					uint16 index = read2low(pos);
+					if (index >= MAXIMUM_TRACK_BRANCHES) {
+						warning("Invalid sequence branch index value %x", index);
+						pos += 4;
+						continue;
+					}
+					// This is the offset from the start of the track
+					branchOffsets[index] = read4low(pos);
+				}
 			} else {
 				warning("Hit invalid block '%c%c%c%c' while scanning for track locations", pos[0], pos[1], pos[2], pos[3]);
 				return false;

--- a/engines/ultima/ultima8/audio/midi_player.cpp
+++ b/engines/ultima/ultima8/audio/midi_player.cpp
@@ -76,7 +76,7 @@ void MidiPlayer::load(byte *data, size_t size, int seqNo, bool speedHack) {
 			_parser->setTempo(_driver->getBaseTempo() * 2);
 		_parser->property(MidiParser::mpCenterPitchWheelOnUnload, 1);
 		_parser->property(MidiParser::mpSendSustainOffOnNotesOff, 1);
-		_parser->property(MidiParser::mpDoNotAutoStartPlayback, 1);
+		_parser->property(MidiParser::mpDisableAutoStartPlayback, 1);
 
 		int volume = g_engine->_mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType);
 		setVolume(volume);

--- a/engines/ultima/ultima8/audio/midi_player.h
+++ b/engines/ultima/ultima8/audio/midi_player.h
@@ -35,14 +35,27 @@ public:
 	~MidiPlayer() override;
 
 	/**
-	 * Play the specified music
+	 * Load the specified music data
 	 */
-	void play(byte *data, size_t size, int seqNo, int trackNo, bool speedHack);
+	void load(byte *data, size_t size, int seqNo, bool speedHack);
+
+	/**
+	 * Play the specified music track, starting at the
+	 * specified branch. Use branchNo -1 to start from the
+	 * beginning.
+	 */
+	void play(int trackNo, int branchNo);
 
 	/**
 	 * Sets whether the music should loop
 	 */
 	void setLooping(bool loop);
+
+	/**
+	 * Returns true if the current music track has a branch
+	 * defined for the specified index.
+	 */
+	bool hasBranchIndex(uint8 index);
 
 	bool isFMSynth() const {
 		return _isFMSynth;

--- a/engines/ultima/ultima8/audio/u8_music_process.cpp
+++ b/engines/ultima/ultima8/audio/u8_music_process.cpp
@@ -225,9 +225,15 @@ void U8MusicProcess::run() {
 				bool repeat = (_trackState._queued == 0);
 				_midiPlayer->load(xmidi->_data, xmidi->_size, 0, false);
 				_midiPlayer->setLooping(repeat);
-				if (_songBranches[_trackState._wanted] >= 0 && !_midiPlayer->hasBranchIndex(_songBranches[_trackState._wanted]))
-					// Current branch is past the end of the list of branches. Reset to 0.
-					_songBranches[_trackState._wanted] = 0;
+				if (_songBranches[_trackState._wanted] >= 0 && !_midiPlayer->hasBranchIndex(_songBranches[_trackState._wanted])) {
+					if (_songBranches[_trackState._wanted] == 0) {
+						// This track does not have any branches.
+						_songBranches[_trackState._wanted] = -1;
+					} else {
+						// Current branch is past the end of the list of branches. Reset to 0.
+						_songBranches[_trackState._wanted] = 0;
+					}
+				}
 				_midiPlayer->play(0, _songBranches[_trackState._wanted]);
 			}
 

--- a/engines/ultima/ultima8/audio/u8_music_process.h
+++ b/engines/ultima/ultima8/audio/u8_music_process.h
@@ -66,6 +66,7 @@ private:
 
 	MidiPlayer *_midiPlayer;
 	PlaybackStates _state;
+	//! The branch (starting point) to use for each music track
 	int _songBranches[128];
 
 	int _currentTrack;      //! Currently playing track (don't save)


### PR DESCRIPTION
This adds support for the "sequence branch index" feature of the XMIDI format. 
These "branches" (positions in the MIDI bytestream) are defined in the track 
header. I've added two generic functions to the MidiParser interface to set the 
current parsing position to one of these positions, or to check for the 
existence of a position with a certain number.

Additionally, I've added an option to the MIDI parser to prevent the parser 
from starting playback immediately after parsing, so that a starting position 
(or a track) can be selected first.

Ultima 8 uses sequence branches to mark different playback starting points in 
the music files. I've added support for starting playback at these points.