### PR TITLE
MIDI: Fix XMIDI hanging notes

### DIFF
--- a/audio/midiparser_xmidi.cpp
+++ b/audio/midiparser_xmidi.cpp
@@ -120,6 +120,14 @@ void MidiParser_XMIDI::parseNextEvent(EventInfo &info) {
 		info.basic.param1 = *(_position._playPos++);
 		info.basic.param2 = *(_position._playPos++);
 		info.length = readVLQ(_position._playPos);
+		if (info.length == 0) {
+			// Notes with length 0 are played with a very short duration by the AIL driver.
+			// However, the MidiParser will treat notes with length 0 as "active notes"; i.e.
+			// they will only get turned off when a corresponding Note Off event is encountered.
+			// Because XMIDI does not contain Note Off events, this will cause the note to hang.
+			// Set length to 1 to prevent this from happening.
+			info.length = 1;
+		}
 		if (info.basic.param2 == 0) {
 			info.event = info.channel() | 0x80;
 			info.length = 0;


### PR DESCRIPTION
XMIDI uses Note On events with a length which specifies when a corresponding
Note Off event should be generated. Some XMIDI data contains notes with length
0, which are played very briefly by AIL. However, the ScummVM MidiParser will
treat Note On events with length 0 as "active notes", meaning it will wait for
a Note Off event before turning off the note. The Note Off will never come and
the note will hang.

This is particularly noticeable in Ultima 8 (first section of the track that
plays at the beginning of the game, at the shore) and The 7th Guest (the track
that plays while solving the cake puzzle).

I've fixed this by changing the length from 0 to 1. This will cause the notes
to be active for the minimum length.