### PR TITLE
AUDIO: Add ability for engine to supply its own soundfont data.

### DIFF
--- a/audio/mididrv.cpp
+++ b/audio/mididrv.cpp
@@ -173,6 +173,9 @@ Common::String MidiDriver::getDeviceString(DeviceHandle handle, DeviceStringType
 MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 	// Query the selected music device (defaults to MT_AUTO device).
 	Common::String selDevStr = ConfMan.hasKey("music_driver") ? ConfMan.get("music_driver") : Common::String("auto");
+	if ((flags & MDT_PREFER_FLUID) && selDevStr == "auto") {
+		selDevStr = "fluidsynth";
+	}
 	DeviceHandle hdl = getDeviceHandle(selDevStr.empty() ? Common::String("auto") : selDevStr);
 	DeviceHandle reslt = 0;
 

--- a/audio/mididrv.h
+++ b/audio/mididrv.h
@@ -25,6 +25,7 @@
 
 #include "common/scummsys.h"
 #include "common/str.h"
+#include "common/stream.h"
 #include "common/timer.h"
 #include "common/array.h"
 
@@ -79,7 +80,8 @@ enum MidiDriverFlags {
 	MDT_PC98        = 1 << 8,		// FM-TOWNS: Maps to MT_PC98
 	MDT_MIDI        = 1 << 9,		// Real MIDI
 	MDT_PREFER_MT32 = 1 << 10,		// MT-32 output is preferred
-	MDT_PREFER_GM   = 1 << 11		// GM output is preferred
+	MDT_PREFER_GM   = 1 << 11,		// GM output is preferred
+	MDT_PREFER_FLUID= 1 << 12		// FluidSynth driver is preferred
 };
 
 /**
@@ -339,6 +341,12 @@ public:
 	// Channel allocation functions
 	virtual MidiChannel *allocateChannel() = 0;
 	virtual MidiChannel *getPercussionChannel() = 0;
+
+	// Allow an engine to supply its own soundFont data. This stream will be destroyed after use.
+	virtual void setEngineSoundFont(Common::SeekableReadStream *soundFontData) { }
+
+	// Does this driver accept soundFont data?
+	virtual bool acceptsSoundFontData() { return false; }
 };
 
 class MidiChannel {


### PR DESCRIPTION
* Add ability for engine to supply its own soundfont data.
* Add MDT_PREFER_FLUID to allow engines to indicate they prefer the fluidsynth driver.

The fluidsynth driver will only be given preference if the midi driver is set to auto.

This PR allows engines to specify their own soundFont data. This will be used by Blazing Dragons and Tinsel to support PSX SEQ midi music.

I will work on a midiPlayer to extracts the soundFont data in another PR.

I added the following new virtual methods to the midi driver class.
```
// Allow an engine to supply its own soundFont data. This stream will be destroyed after use.
virtual void setEngineSoundFont(Common::SeekableReadStream *soundFontData) { }

// Does this driver accept soundFont data?
virtual bool acceptsSoundFontData() { return false; }
```

FluidSynth has a weird way of accepting in memory soundfont data. I followed the example given here. http://www.fluidsynth.org/api/fluidsynth_sfload_mem_8c-example.html