### PR TITLE
COMMON: Fix build when uint32_t and uint32 are not defined the same

### DIFF
--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -85,7 +85,7 @@ void UnicodeBiDiText::initWithU32String(const U32String &input) {
 		_log_to_vis_index = NULL;
 		_vis_to_log_index = NULL;
 	} else {
-		visual = U32String(visual_str, input.size());
+		visual = U32String((uint32 *)visual_str, input.size());
 		delete[] visual_str;
 	}
 #else


### PR DESCRIPTION
FriBidiChar is mapped to uint32_t (from stdint.h) while U32String is
composed of uint32 (from scummsys.h/config.h). On some platforms (like in 3DS) those
two types aren't defined using the same base type (long int vs int) and
compilation errors occur.