### PR TITLE
SCI: Allow channel 9 on all matching audio drivers

### DIFF
--- a/engines/sci/resource_audio.cpp
+++ b/engines/sci/resource_audio.cpp
@@ -968,7 +968,7 @@ int SoundResource::getChannelFilterMask(int hardwareMask, bool wantsRhythm) {
 			break;
 		case 9:
 			// Play rhythm channel when requested
-			play = wantsRhythm;
+			play = wantsRhythm || (flags & hardwareMask);
 			break;
 		default:
 			// Otherwise check for flag


### PR DESCRIPTION
ScummVM doesn't play several Adlib sounds in The Colonel's Bequest when using the Adlib driver: https://bugs.scummvm.org/ticket/10734 

The current logic in SoundResource::getChannelFilterMask() is intended to always play channel 9 if a driver has a rhythm channel, even if the driver's play-flag isn't set in the sound resource. The way it's written though, it also bans channel 9 from ever playing if a driver doesn't have rhythm channel, such as Adlib, which is incorrect.

This PR adds the normal play-flag check to channel 9 when the driver doesn't have a rhythm channel. (This switch hasn't been touched in 10 years!)

For example, here are the channels in sound 48, when knocking on the door in room 14:
channel: 01 voices: 00 flags: 30
channel: 09 voices: 82 flags: 0F [ Adlib flag 04 ]

Other sounds in the same situation:
Turning the crank in room 52
Turning the valve in room 65
Prying open a crypt vault in room 57
Skull falling out of a crypt vault in room 57

ADL.DRV does not filter out channel 9, which I've confirmed in all the other SCI0 Late ADL.DRVs I have.