### PR TITLE
CONFIGURE: Undefine __STRICT_ANSI__ for newlib based platforms

### DIFF
--- a/configure
+++ b/configure
@@ -1786,6 +1786,8 @@ switch)
 	datarootdir='${prefix}/data'
 	datadir='${datarootdir}'
 	docdir='${prefix}/doc'
+	# Switch SDK has C++11 constructs so we must enable it
+	_use_cxx11=yes
 	;;
 tizen)
  	_host_os=tizen
@@ -2251,16 +2253,17 @@ if test "$have_gcc" = yes ; then
 	if test "$_cxx_major" -ge "3" ; then
 		# Try to use ANSI mode when C++11 is disabled.
 		if test "$_use_cxx11" = "no" ; then
-			case $_host_os in
-			# newlib-based system include files suppress non-C89 function
-			# declarations under __STRICT_ANSI__
-			3ds | amigaos* | android | androidsdl | dreamcast | ds | gamecube | mingw* | mint* | n64 | psp | ps2 | ps3 | psp2 | switch | tizen | wii )
-				;;
-			*)
-				append_var CXXFLAGS "-ansi"
-				;;
-			esac
+			append_var CXXFLAGS "-ansi"
 		fi
+		case $_host_os in
+		# newlib-based system include files suppress non-C89 function
+		# declarations under __STRICT_ANSI__, undefine it
+		3ds | amigaos* | android | androidsdl | dreamcast | ds | gamecube | mingw* | mint* | n64 | psp | ps2 | ps3 | psp2 | switch | tizen | wii )
+			append_var CXXFLAGS "-U__STRICT_ANSI__"
+			;;
+		*)
+			;;
+		esac
 		append_var CXXFLAGS "-W -Wno-unused-parameter"
 		add_line_to_config_mk 'HAVE_GCC3 = 1'
 		add_line_to_config_mk 'CXX_UPDATE_DEP_FLAG = -MMD -MF "$(*D)/$(DEPDIR)/$(*F).d" -MQ "$@" -MP'


### PR DESCRIPTION
This allows backends to use non-ANSI functions.
As it was the main reason to not set -ansi on these platforms, add it
back to ensure strict adherence to C++ standard.

This commit makes compilation work when using --enable-c++11 on tested platforms.
Adding -ansi is where the risk is and we could add -U__STRICT_ANSI__ only when enabling C++11 on newlib platforms.
Though, I think using -ansi everywhere would be nice to have.

:warning: This commit has only be tested on some platforms impacted by this change and some are still missing.
Most tests have been done using [dockerized-bb](https://github.com/lephilousophe/dockerized-bb).
- [x] 3ds
- [x] amigaos (thanks to @raziel-)
- [x] android
- [ ] androidsdl (though I don't expect any error on it)
- [x] dreamcast (thanks to @zeldin)
- [x] ds
- [x] gamecube
- [x] mingw64
- [ ] mint
- [ ] n64
- [ ] ps2
- [x] ps3
- [x] psp
- [x] psp2
- [x] switch
- [ ] tizen
- [x] wii

For DS, PR #2294 is needed to compile without C++11 mode.

@sev- I don't really know how to ask to porters to test this change, hence I request your review :)