### PR TITLE
COMMON: Use assert for CLIP() if bounds are not properly ordered

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -49,7 +49,18 @@ template<typename T> inline T ABS(T x)		{ return (x >= 0) ? x : -x; }
 template<typename T> inline T MIN(T a, T b)	{ return (a < b) ? a : b; }
 template<typename T> inline T MAX(T a, T b)	{ return (a > b) ? a : b; }
 template<typename T> inline T CLIP(T v, T amin, T amax)
-		{ if (amin > amax) {T tmp = amin; amin = amax; amax = tmp;} if (v < amin) return amin; else if (v > amax) return amax; else return v; }
+	{
+#if !defined(RELEASE_BUILD)
+		// debug builds use this assert to pinpoint
+		// any problematic cases, where amin and amax
+		// are incorrectly ordered
+		// and thus CLIP() would return an invalid result
+		assert(amin <= amax);
+#endif
+		if (v < amin) return amin;
+		else if (v > amax) return amax;
+		return v;
+	}
 
 /**
  * Template method which swaps the values of its two parameters.

--- a/common/util.h
+++ b/common/util.h
@@ -49,7 +49,7 @@ template<typename T> inline T ABS(T x)		{ return (x >= 0) ? x : -x; }
 template<typename T> inline T MIN(T a, T b)	{ return (a < b) ? a : b; }
 template<typename T> inline T MAX(T a, T b)	{ return (a > b) ? a : b; }
 template<typename T> inline T CLIP(T v, T amin, T amax)
-		{ if (v < amin) return amin; else if (v > amax) return amax; else return v; }
+		{ if (amin > amax) {T tmp = amin; amin = amax; amax = tmp;} if (v < amin) return amin; else if (v > amax) return amax; else return v; }
 
 /**
  * Template method which swaps the values of its two parameters.


### PR DESCRIPTION
If the boundary arguments of CLIP function are not ordered as expected (the first should the min of the two), then the function may return an invalid result. This is more likely to happen if the boundary arguments are variables rather than literals. 