### PR TITLE
DIRECTOR: LINGO: Implement kTheImmediate

### DIFF
--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -640,6 +640,9 @@ Datum Lingo::getTheSprite(Datum &id1, int field) {
 	case kTheHeight:
 		d.u.i = sprite->_height;
 		break;
+	case kTheImmediate:
+		d.u.i = sprite->_immediate;
+		break;
 	case kTheInk:
 		d.u.i = sprite->_ink;
 		break;
@@ -751,6 +754,9 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 		break;
 	case kTheHeight:
 		sprite->_height = d.asInt();
+		break;
+	case kTheImmediate:
+		sprite->_immediate = d.asInt();
 		break;
 	case kTheInk:
 		sprite->_ink = static_cast<InkType>(d.asInt());

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -52,6 +52,7 @@ Sprite::Sprite() {
 	_moveable = false;
 	_editable = false;
 	_puppet = false;
+	_immediate = false;
 	_backColor = 255;
 	_foreColor = 0;
 

--- a/engines/director/sprite.h
+++ b/engines/director/sprite.h
@@ -100,6 +100,7 @@ public:
 	bool _moveable;
 	bool _editable;
 	bool _puppet;
+	bool _immediate;
 	byte _backColor;
 	byte _foreColor;
 


### PR DESCRIPTION
This implements the sprite property `immediate`, which causes sprite scripts to run on mouseDown instead of mouseUp.