### PR TITLE
DIRECTOR: LINGO: Fix loadScriptText

### DIFF
--- a/engines/director/lingo/lingo-preprocessor.cpp
+++ b/engines/director/lingo/lingo-preprocessor.cpp
@@ -165,6 +165,7 @@ Common::String Lingo::codePreprocessor(const char *s, ScriptType type, uint16 id
 	const char *lineStart, *prevEnd;
 	int iflevel = 0;
 	int linenumber = 1;
+	bool defFound = false;
 
 	while (*s) {
 		line.clear();
@@ -189,6 +190,19 @@ Common::String Lingo::codePreprocessor(const char *s, ScriptType type, uint16 id
 			res1 = preprocessReturn(res1);
 			res1 = preprocessPlay(res1);
 			res1 = preprocessSound(res1);
+		}
+
+		if (type == kMovieScript && _vm->getVersion() <= 3 && !defFound) {
+			tok = nexttok(line.c_str());
+			if (tok.equals("macro") || tok.equals("factory") || tok.equals("on")) {
+				defFound = true;
+			} else {
+				debugC(2, kDebugLingoParse, "skipping line before first definition");
+				linenumber++;
+				if (*s)	// skip newline symbol
+					s++;
+				continue;
+			}
 		}
 
 		res += res1;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1213,13 +1213,6 @@ void Score::loadScriptText(Common::SeekableSubReadStreamEndian &stream) {
 	if (script.empty() || !script.hasPrefix("--"))
 		return;
 
-	int pos = 2;
-	while (script[pos] == ' ' || script[pos] == '\t')
-		pos++;
-
-	if (script[pos] != '\n')
-		return;
-
 	if (ConfMan.getBool("dump_scripts"))
 		dumpScript(script.c_str(), kMovieScript, _movieScriptCount);
 


### PR DESCRIPTION
This fixes a faulty whitespace check in loadScriptText. Script text only needs to start with "--", no newline necessary, and the faulty check broke Simple Factory, which has a script starting with
```
--  Simple Factory
```
