### PR TITLE
DIRECTOR: LINGO: Fix script text loading

### DIFF
--- a/engines/director/lingo/lingo-preprocessor.cpp
+++ b/engines/director/lingo/lingo-preprocessor.cpp
@@ -165,6 +165,7 @@ Common::String Lingo::codePreprocessor(const char *s, ScriptType type, uint16 id
 	const char *lineStart, *prevEnd;
 	int iflevel = 0;
 	int linenumber = 1;
+	bool defFound = false;
 
 	while (*s) {
 		line.clear();
@@ -179,6 +180,19 @@ Common::String Lingo::codePreprocessor(const char *s, ScriptType type, uint16 id
 				linenumber++;
 		}
 		debugC(2, kDebugLingoParse, "line: %d                         '%s'", iflevel, line.c_str());
+
+		if (type == kMovieScript && _vm->getVersion() <= 3 && !defFound) {
+			tok = nexttok(line.c_str());
+			if (tok.equals("macro") || tok.equals("factory") || tok.equals("on")) {
+				defFound = true;
+			} else {
+				debugC(2, kDebugLingoParse, "skipping line before first definition");
+				linenumber++;
+				if (*s)	// copy newline symbol
+					res += *s++;
+				continue;
+			}
+		}
 
 		res1 = patchLingoCode(res1, type, id, linenumber);
 

--- a/engines/director/score-loading.cpp
+++ b/engines/director/score-loading.cpp
@@ -1073,16 +1073,9 @@ void Score::loadScriptText(Common::SeekableSubReadStreamEndian &stream) {
 		script += ch;
 	}
 
-	// Check if the script has macro. They must start with a comment.
+	// Check if this is a script. It must start with a comment.
 	// See D2 Interactivity Manual pp.46-47 (Ch.2.11. Using a macro)
 	if (script.empty() || !script.hasPrefix("--"))
-		return;
-
-	int pos = 2;
-	while (script[pos] == ' ' || script[pos] == '\t')
-		pos++;
-
-	if (script[pos] != '\n')
 		return;
 
 	if (ConfMan.getBool("dump_scripts"))


### PR DESCRIPTION
This is a new version of #2305, which removes a faulty whitespace check in loadScriptText and skips garbage in script text.