### PR TITLE
MACGUI: don't activate menu if it is active

### DIFF
--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -261,7 +261,7 @@ MacMenu *MacWindowManager::addMenu() {
 }
 
 void MacWindowManager::activateMenu() {
-	if (!_menu)
+	if (!_menu || _menu->isVisible())
 		return;
 
 	if (_mode & kWMModalMenuMode) {


### PR DESCRIPTION
This pull request fixes activation of menu if it is active.

If menu is activated more than 1 time, it restores screen with menu drawn and moreover leads to error due to assigning to busy PauseToken, which leads to bugs in Pink Panther games .



