### PR TITLE
ENGINES: Make AdvancedMetaEngine::toDetectedGame virtual

### DIFF
--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -527,6 +527,19 @@ void ConfigManager::set(const String &key, const String &value) {
 		_appDomain[key] = value;
 }
 
+void ConfigManager::setAndFlush(const String &key, const Common::String &value) {
+	if (value.empty() && !hasKey(key)) {
+		return;
+	}
+
+	if (hasKey(key) && get(key) == value) {
+		return;
+	}
+
+	set(key, value);
+	flushToDisk();
+}
+
 void ConfigManager::set(const String &key, const String &value, const String &domName) {
 	// FIXME: For now we continue to allow empty domName to indicate
 	// "use 'default' domain". This is mainly needed for the SCUMM ConfigDialog

--- a/common/config-manager.h
+++ b/common/config-manager.h
@@ -118,6 +118,12 @@ public:
 	const String &		get(const String &key) const;
 	void				set(const String &key, const String &value);
 
+	/**
+	 * Update a configuration entry for the active domain and flush
+	 * the configuration file to disk if the value changed
+	 */
+	void				setAndFlush(const String &key, const Common::String &value);
+
 #if 1
 	//
 	// Domain specific access methods: Acces *one specific* domain and modify it.

--- a/common/gui_options.cpp
+++ b/common/gui_options.cpp
@@ -128,12 +128,7 @@ const String getGameGUIOptionsDescription(const String &options) {
 
 void updateGameGUIOptions(const String &options, const String &langOption) {
 	const String newOptionString = getGameGUIOptionsDescription(options) + " " + langOption;
-
-	if ((!options.empty() && !ConfMan.hasKey("guioptions")) ||
-	    (ConfMan.hasKey("guioptions") && ConfMan.get("guioptions") != newOptionString)) {
-		ConfMan.set("guioptions", newOptionString);
-		ConfMan.flushToDisk();
-	}
+	ConfMan.setAndFlush("guioptions", newOptionString);
 }
 
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -289,15 +289,11 @@ Common::Error AdvancedMetaEngine::createInstance(OSystem *syst, Engine **engine)
 	if (!agdDesc.desc)
 		return Common::kNoGameDataFoundError;
 
+	DetectedGame gameDescriptor = toDetectedGame(agdDesc);
+
 	// If the GUI options were updated, we catch this here and update them in the users config
 	// file transparently.
-	Common::String lang = getGameGUIOptionsDescriptionLanguage(agdDesc.desc->language);
-	if (agdDesc.desc->flags & ADGF_ADDENGLISH)
-		lang += " " + getGameGUIOptionsDescriptionLanguage(Common::EN_ANY);
-
-	Common::updateGameGUIOptions(agdDesc.desc->guiOptions + _guiOptions, lang);
-
-	DetectedGame gameDescriptor = toDetectedGame(agdDesc);
+	ConfMan.setAndFlush("guioptions", gameDescriptor.getGUIOptions());
 
 	bool showTestingWarning = false;
 

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -317,7 +317,7 @@ protected:
 	bool getFileProperties(const Common::FSNode &parent, const FileMap &allFiles, const ADGameDescription &game, const Common::String fname, FileProperties &fileProps) const;
 
 	/** Convert an AD game description into the shared game description format */
-	DetectedGame toDetectedGame(const ADDetectedGame &adGame) const;
+	virtual DetectedGame toDetectedGame(const ADDetectedGame &adGame) const;
 };
 
 #endif

--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -194,7 +194,7 @@ public:
 		return "Myst and Riven (C) Cyan Worlds\nMohawk OS (C) Ubisoft";
 	}
 
-	DetectedGames detectGames(const Common::FSList &fslist) const override;
+	DetectedGame toDetectedGame(const ADDetectedGame &adGame) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
@@ -208,40 +208,36 @@ public:
 	GUI::OptionsContainerWidget *buildEngineOptionsWidget(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
-DetectedGames MohawkMetaEngine::detectGames(const Common::FSList &fslist) const {
-	DetectedGames detectedGames = AdvancedMetaEngine::detectGames(fslist);
+DetectedGame MohawkMetaEngine::toDetectedGame(const ADDetectedGame &adGame) const {
+	DetectedGame game = AdvancedMetaEngine::toDetectedGame(adGame);
 
 	// The AdvancedDetector model only allows specifying a single supported
 	// game language. The 25th anniversary edition Myst games are multilanguage.
 	// Here we amend the detected games to set the list of supported languages.
-	for (uint i = 0; i < detectedGames.size(); i++) {
-		DetectedGame &game = detectedGames[i];
-
 #ifdef ENABLE_MYST
-		if (game.gameId == "myst"
-		        && Common::checkGameGUIOption(GAMEOPTION_25TH, game.getGUIOptions())
-		        && Common::checkGameGUIOption(GAMEOPTION_ME, game.getGUIOptions())) {
-			const Mohawk::MystLanguage *languages = Mohawk::MohawkEngine_Myst::listLanguages();
-			while (languages->language != Common::UNK_LANG) {
-				game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(languages->language));
-				languages++;
-			}
+	if (game.gameId == "myst"
+			&& Common::checkGameGUIOption(GAMEOPTION_25TH, game.getGUIOptions())
+			&& Common::checkGameGUIOption(GAMEOPTION_ME, game.getGUIOptions())) {
+		const Mohawk::MystLanguage *languages = Mohawk::MohawkEngine_Myst::listLanguages();
+		while (languages->language != Common::UNK_LANG) {
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(languages->language));
+			languages++;
 		}
+	}
 #endif
 
 #ifdef ENABLE_RIVEN
-		if (game.gameId == "riven"
-		        && Common::checkGameGUIOption(GAMEOPTION_25TH, game.getGUIOptions())) {
-			const Mohawk::RivenLanguage *languages = Mohawk::MohawkEngine_Riven::listLanguages();
-			while (languages->language != Common::UNK_LANG) {
-				game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(languages->language));
-				languages++;
-			}
+	if (game.gameId == "riven"
+			&& Common::checkGameGUIOption(GAMEOPTION_25TH, game.getGUIOptions())) {
+		const Mohawk::RivenLanguage *languages = Mohawk::MohawkEngine_Riven::listLanguages();
+		while (languages->language != Common::UNK_LANG) {
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(languages->language));
+			languages++;
 		}
-#endif
 	}
+#endif
 
-	return detectedGames;
+	return game;
 }
 
 bool MohawkMetaEngine::hasFeature(MetaEngineFeature f) const {


### PR DESCRIPTION
This allows subclasses to post-process the games detected by AdvancedMetaEngine before they are added to / updated in the configuration file.

This fixes the issue @antoniou79 noticed where the list of available languages was incorrect in the edit game dialog after starting Myst Masterpiece 25th Anniversary Edition for the first time.