### PR TITLE
KINGDOM: Fix DS compilation

### DIFF
--- a/engines/kingdom/kingdom.cpp
+++ b/engines/kingdom/kingdom.cpp
@@ -504,7 +504,7 @@ void KingdomGame::playMovie(int movieNum) {
 
 		bool skipMovie = false;
 		while (!decoder->endOfVideo() && !skipMovie && !shouldQuit()) {
-			unsigned int delay = MIN(decoder->getTimeToNextFrame(), 10u);
+			uint delay = MIN<uint>(decoder->getTimeToNextFrame(), 10u);
 			g_system->delayMillis(delay);
 
 			const Graphics::Surface *frame = nullptr;


### PR DESCRIPTION
Without specializing MIN compiler gets confused because the two arguments are of different types: uint32 and uint.
delayMillis is using an uint as argument so fixing the type of delay in the same time.