### PR TITLE
I18N: Fixed typo in wintermute/POTFILES. Updated translations.dat

### DIFF
--- a/engines/wintermute/POTFILES
+++ b/engines/wintermute/POTFILES
@@ -1,3 +1,3 @@
 engines/wintermute/detection.cpp
 engines/wintermute/wintermute.cpp
-keymapper_tables.h
+engines/wintermute/keymapper_tables.h

--- a/po/scummvm.pot
+++ b/po/scummvm.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ScummVM 2.2.0git\n"
 "Report-Msgid-Bugs-To: scummvm-devel@lists.scummvm.org\n"
-"POT-Creation-Date: 2020-05-10 07:57+0200\n"
+"POT-Creation-Date: 2020-06-07 17:06+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -60,9 +60,9 @@ msgstr ""
 #: gui/saveload-dialog.cpp:393 gui/saveload-dialog.cpp:465
 #: gui/saveload-dialog.cpp:767 gui/saveload-dialog.cpp:1162
 #: gui/themebrowser.cpp:55 gui/unknown-game-dialog.cpp:54
-#: engines/engine.cpp:595 backends/dialogs/gtk/gtk-dialogs.cpp:55
+#: engines/engine.cpp:605 backends/dialogs/gtk/gtk-dialogs.cpp:55
 #: backends/events/default/default-events.cpp:176
-#: backends/events/default/default-events.cpp:198
+#: backends/events/default/default-events.cpp:199
 #: backends/platform/wii/options.cpp:48 engines/drascula/saveload.cpp:49
 #: engines/mohawk/myst_stacks/menu.cpp:284
 #: engines/mohawk/myst_stacks/menu.cpp:301
@@ -71,7 +71,8 @@ msgstr ""
 #: engines/mohawk/riven_stacks/aspit.cpp:372
 #: engines/mohawk/riven_stacks/aspit.cpp:456
 #: engines/parallaction/saveload.cpp:271 engines/scumm/dialogs.cpp:187
-#: engines/sword1/control.cpp:889 engines/wintermute/wintermute.cpp:191
+#: engines/sword1/control.cpp:889 engines/wintermute/wintermute.cpp:189
+#: engines/wintermute/wintermute.cpp:202
 msgid "Cancel"
 msgstr ""
 
@@ -124,7 +125,7 @@ msgstr ""
 #: gui/options.cpp:2574 gui/options.cpp:2612
 #: backends/events/symbiansdl/symbiansdl-events.cpp:191
 #: engines/kyra/gui/saveload_eob.cpp:569 engines/kyra/gui/saveload_eob.cpp:602
-#: engines/sci/graphics/controls32.cpp:927
+#: engines/sci/graphics/controls32.cpp:928
 msgid "Yes"
 msgstr ""
 
@@ -134,7 +135,7 @@ msgstr ""
 #: gui/options.cpp:2574 gui/options.cpp:2612
 #: backends/events/symbiansdl/symbiansdl-events.cpp:191
 #: engines/kyra/gui/saveload_eob.cpp:569 engines/kyra/gui/saveload_eob.cpp:602
-#: engines/sci/graphics/controls32.cpp:927
+#: engines/sci/graphics/controls32.cpp:928
 msgid "No"
 msgstr ""
 
@@ -155,7 +156,7 @@ msgstr ""
 #: backends/platform/wii/options.cpp:47 engines/agos/animation.cpp:559
 #: engines/drascula/saveload.cpp:49 engines/groovie/script.cpp:433
 #: engines/parallaction/saveload.cpp:271 engines/sci/engine/kgraphics.cpp:75
-#: engines/sci/graphics/controls32.cpp:924 engines/scumm/dialogs.cpp:189
+#: engines/sci/graphics/controls32.cpp:925 engines/scumm/dialogs.cpp:189
 #: engines/scumm/scumm.cpp:1900 engines/scumm/players/player_v3m.cpp:130
 #: engines/scumm/players/player_v5m.cpp:108 engines/sky/compact.cpp:141
 #: engines/sword1/animation.cpp:532 engines/sword1/animation.cpp:553
@@ -254,7 +255,7 @@ msgid "Engine"
 msgstr ""
 
 #: gui/editgamedialog.cpp:196 gui/options.cpp:1563 gui/options.cpp:1694
-#: backends/graphics/sdl/sdl-graphics.cpp:357
+#: backends/graphics/sdl/sdl-graphics.cpp:365
 msgid "Graphics"
 msgstr ""
 
@@ -566,20 +567,34 @@ msgid "Close"
 msgstr ""
 
 #: gui/gui-manager.cpp:131 backends/platform/symbian/src/SymbianActions.cpp:38
-#: engines/glk/scott/scott.cpp:394
+#: engines/glk/scott/scott.cpp:394 engines/wintermute/keymapper_tables.h:943
+#: engines/wintermute/keymapper_tables.h:1032
+#: engines/wintermute/keymapper_tables.h:1313
+#: engines/wintermute/keymapper_tables.h:1474
 msgid "Up"
 msgstr ""
 
 #: gui/gui-manager.cpp:136 backends/platform/symbian/src/SymbianActions.cpp:39
-#: engines/glk/scott/scott.cpp:394
+#: engines/glk/scott/scott.cpp:394 engines/wintermute/keymapper_tables.h:949
+#: engines/wintermute/keymapper_tables.h:1039
+#: engines/wintermute/keymapper_tables.h:1319
+#: engines/wintermute/keymapper_tables.h:1480
 msgid "Down"
 msgstr ""
 
 #: gui/gui-manager.cpp:141 backends/platform/symbian/src/SymbianActions.cpp:40
+#: engines/wintermute/keymapper_tables.h:955
+#: engines/wintermute/keymapper_tables.h:1301
+#: engines/wintermute/keymapper_tables.h:1385
+#: engines/wintermute/keymapper_tables.h:1462
 msgid "Left"
 msgstr ""
 
 #: gui/gui-manager.cpp:146 backends/platform/symbian/src/SymbianActions.cpp:41
+#: engines/wintermute/keymapper_tables.h:961
+#: engines/wintermute/keymapper_tables.h:1307
+#: engines/wintermute/keymapper_tables.h:1393
+#: engines/wintermute/keymapper_tables.h:1468
 msgid "Right"
 msgstr ""
 
@@ -712,13 +727,13 @@ msgstr ""
 msgid "Search:"
 msgstr ""
 
-#: gui/launcher.cpp:210 engines/dialogs.cpp:102 engines/engine.cpp:739
+#: gui/launcher.cpp:210 engines/dialogs.cpp:102 engines/engine.cpp:748
 #: engines/pegasus/pegasus.cpp:355 engines/tsage/scenes.cpp:601
 #: engines/wage/saveload.cpp:742
 msgid "Load game:"
 msgstr ""
 
-#: gui/launcher.cpp:210 engines/dialogs.cpp:102 engines/engine.cpp:739
+#: gui/launcher.cpp:210 engines/dialogs.cpp:102 engines/engine.cpp:748
 #: engines/parallaction/saveload.cpp:194 engines/pegasus/pegasus.cpp:355
 #: engines/scumm/dialogs.cpp:185 engines/tsage/scenes.cpp:601
 #: engines/wage/saveload.cpp:742
@@ -933,7 +948,7 @@ msgstr ""
 msgid "Stretch mode:"
 msgstr ""
 
-#: gui/options.cpp:1254 backends/graphics/sdl/sdl-graphics.cpp:348
+#: gui/options.cpp:1254 backends/graphics/sdl/sdl-graphics.cpp:356
 msgid "Fullscreen mode"
 msgstr ""
 
@@ -1810,11 +1825,11 @@ msgstr ""
 msgid "Engine does not support debug level '%s'"
 msgstr ""
 
-#: base/main.cpp:583
+#: base/main.cpp:587
 msgid "Error running game:"
 msgstr ""
 
-#: base/main.cpp:630
+#: base/main.cpp:634
 msgid "Could not find any engine capable of running the selected game"
 msgstr ""
 
@@ -1966,7 +1981,7 @@ msgctxt "lowres"
 msgid "~R~eturn to Launcher"
 msgstr ""
 
-#: engines/dialogs.cpp:103 engines/engine.cpp:764 engines/agi/saveload.cpp:759
+#: engines/dialogs.cpp:103 engines/engine.cpp:777 engines/agi/saveload.cpp:759
 #: engines/avalanche/parser.cpp:1919 engines/cine/various.cpp:348
 #: engines/dm/loadsave.cpp:199 engines/drascula/saveload.cpp:383
 #: engines/dreamweb/saveload.cpp:262 engines/glk/streams.cpp:1424
@@ -1982,7 +1997,7 @@ msgstr ""
 msgid "Save game:"
 msgstr ""
 
-#: engines/dialogs.cpp:103 engines/engine.cpp:764
+#: engines/dialogs.cpp:103 engines/engine.cpp:777
 #: backends/platform/symbian/src/SymbianActions.cpp:44
 #: engines/agi/saveload.cpp:759 engines/avalanche/parser.cpp:1919
 #: engines/cine/various.cpp:348 engines/dm/loadsave.cpp:199
@@ -2083,29 +2098,30 @@ msgstr ""
 msgid "Error occurred making autosave"
 msgstr ""
 
-#: engines/engine.cpp:575
+#: engines/engine.cpp:584
 #, c-format
 msgid ""
 "Failed to load saved game (%s)! Please consult the README for basic "
 "information, and for instructions on how to obtain further assistance."
 msgstr ""
 
-#: engines/engine.cpp:592
+#: engines/engine.cpp:602
 msgid ""
 "WARNING: The game you are about to start is not yet fully supported by "
 "ScummVM. As such, it is likely to be unstable, and any saved game you make "
 "might not work in future versions of ScummVM."
 msgstr ""
 
-#: engines/engine.cpp:595 engines/wintermute/wintermute.cpp:190
+#: engines/engine.cpp:605 engines/wintermute/wintermute.cpp:189
+#: engines/wintermute/wintermute.cpp:201
 msgid "Start anyway"
 msgstr ""
 
-#: engines/engine.cpp:735
+#: engines/engine.cpp:744
 msgid "Loading game is currently unavailable"
 msgstr ""
 
-#: engines/engine.cpp:760
+#: engines/engine.cpp:773
 msgid "Saving game is currently unavailable"
 msgstr ""
 
@@ -2151,40 +2167,40 @@ msgstr ""
 msgid "OPL3LPT"
 msgstr ""
 
-#: audio/mididrv.cpp:233
+#: audio/mididrv.cpp:252
 #, c-format
 msgid ""
 "The selected audio device '%s' was not found (e.g. might be turned off or "
 "disconnected)."
 msgstr ""
 
-#: audio/mididrv.cpp:233 audio/mididrv.cpp:245 audio/mididrv.cpp:281
-#: audio/mididrv.cpp:296
+#: audio/mididrv.cpp:252 audio/mididrv.cpp:264 audio/mididrv.cpp:300
+#: audio/mididrv.cpp:315
 msgid "Attempting to fall back to the next available device..."
 msgstr ""
 
-#: audio/mididrv.cpp:245
+#: audio/mididrv.cpp:264
 #, c-format
 msgid ""
 "The selected audio device '%s' cannot be used. See log file for more "
 "information."
 msgstr ""
 
-#: audio/mididrv.cpp:281
+#: audio/mididrv.cpp:300
 #, c-format
 msgid ""
 "The preferred audio device '%s' was not found (e.g. might be turned off or "
 "disconnected)."
 msgstr ""
 
-#: audio/mididrv.cpp:296
+#: audio/mididrv.cpp:315
 #, c-format
 msgid ""
 "The preferred audio device '%s' cannot be used. See log file for more "
 "information."
 msgstr ""
 
-#: audio/mididrv.cpp:448
+#: audio/mididrv.cpp:635
 msgid "Starting MIDI dump"
 msgstr ""
 
@@ -2269,11 +2285,11 @@ msgstr ""
 msgid "Launcher"
 msgstr ""
 
-#: backends/events/default/default-events.cpp:198
+#: backends/events/default/default-events.cpp:199
 msgid "Do you really want to quit?"
 msgstr ""
 
-#: backends/events/default/default-events.cpp:198
+#: backends/events/default/default-events.cpp:199
 #: backends/events/default/default-events.cpp:315
 #: backends/platform/symbian/src/SymbianActions.cpp:52
 #: engines/mohawk/myst_stacks/menu.cpp:318
@@ -2411,33 +2427,33 @@ msgstr ""
 msgid "Fit to window (4:3)"
 msgstr ""
 
-#: backends/graphics/openglsdl/openglsdl-graphics.cpp:600
+#: backends/graphics/openglsdl/openglsdl-graphics.cpp:586
 #, c-format
 msgid "Resolution: %dx%d"
 msgstr ""
 
-#: backends/graphics/openglsdl/openglsdl-graphics.cpp:623
-#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2556
+#: backends/graphics/openglsdl/openglsdl-graphics.cpp:609
+#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2540
 msgid "Enabled aspect ratio correction"
 msgstr ""
 
-#: backends/graphics/openglsdl/openglsdl-graphics.cpp:625
-#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2562
+#: backends/graphics/openglsdl/openglsdl-graphics.cpp:611
+#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2546
 msgid "Disabled aspect ratio correction"
 msgstr ""
 
-#: backends/graphics/openglsdl/openglsdl-graphics.cpp:646
-#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2579
+#: backends/graphics/openglsdl/openglsdl-graphics.cpp:632
+#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2563
 msgid "Filtering enabled"
 msgstr ""
 
-#: backends/graphics/openglsdl/openglsdl-graphics.cpp:648
-#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2581
+#: backends/graphics/openglsdl/openglsdl-graphics.cpp:634
+#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2565
 msgid "Filtering disabled"
 msgstr ""
 
-#: backends/graphics/openglsdl/openglsdl-graphics.cpp:677
-#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2609
+#: backends/graphics/openglsdl/openglsdl-graphics.cpp:663
+#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2593
 msgid "Stretch mode"
 msgstr ""
 
@@ -2450,75 +2466,84 @@ msgctxt "lowres"
 msgid "Normal (no scaling)"
 msgstr ""
 
-#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2522
+#: backends/graphics/surfacesdl/surfacesdl-graphics.cpp:2506
 msgid "Active graphics filter:"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:350
+#: backends/graphics/sdl/sdl-graphics.cpp:358
 msgid "Windowed mode"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:361 engines/scumm/help.cpp:87
+#: backends/graphics/sdl/sdl-graphics.cpp:369 engines/scumm/help.cpp:87
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:368 engines/scumm/help.cpp:100
+#: backends/graphics/sdl/sdl-graphics.cpp:376 engines/scumm/help.cpp:100
+#: engines/wintermute/keymapper_tables.h:642
 msgid "Toggle mouse capture"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:373
+#: backends/graphics/sdl/sdl-graphics.cpp:381
+#: engines/wintermute/keymapper_tables.h:417
+#: engines/wintermute/keymapper_tables.h:779
+#: engines/wintermute/keymapper_tables.h:993
+#: engines/wintermute/keymapper_tables.h:1061
+#: engines/wintermute/keymapper_tables.h:1153
+#: engines/wintermute/keymapper_tables.h:1241
+#: engines/wintermute/keymapper_tables.h:1258
+#: engines/wintermute/keymapper_tables.h:1289
 msgid "Save screenshot"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:379
+#: backends/graphics/sdl/sdl-graphics.cpp:387
 msgid "Toggle aspect ratio correction"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:386
+#: backends/graphics/sdl/sdl-graphics.cpp:394
 msgid "Toggle linear filtered scaling"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:393
+#: backends/graphics/sdl/sdl-graphics.cpp:401
 msgid "Cycle through stretch modes"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:399
+#: backends/graphics/sdl/sdl-graphics.cpp:407
 msgid "Increase the scale factor"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:405
+#: backends/graphics/sdl/sdl-graphics.cpp:413
 msgid "Decrease the scale factor"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:417
+#: backends/graphics/sdl/sdl-graphics.cpp:425
 msgid "Switch to nearest neighbour scaling"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:418
+#: backends/graphics/sdl/sdl-graphics.cpp:426
 msgid "Switch to AdvMame 2x/3x scaling"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:420
+#: backends/graphics/sdl/sdl-graphics.cpp:428
 msgid "Switch to HQ 2x/3x scaling"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:422
+#: backends/graphics/sdl/sdl-graphics.cpp:430
 msgid "Switch to 2xSai scaling"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:423
+#: backends/graphics/sdl/sdl-graphics.cpp:431
 msgid "Switch to Super2xSai scaling"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:424
+#: backends/graphics/sdl/sdl-graphics.cpp:432
 msgid "Switch to SuperEagle scaling"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:425
+#: backends/graphics/sdl/sdl-graphics.cpp:433
 msgid "Switch to TV 2x scaling"
 msgstr ""
 
-#: backends/graphics/sdl/sdl-graphics.cpp:426
+#: backends/graphics/sdl/sdl-graphics.cpp:434
 msgid "Switch to DotMatrix scaling"
 msgstr ""
 
@@ -3095,16 +3120,20 @@ msgstr ""
 #: backends/platform/maemo/maemo.cpp:174
 #: backends/platform/symbian/src/SymbianActions.cpp:42
 #: backends/platform/tizen/form.cpp:274
+#: engines/wintermute/keymapper_tables.h:39
 msgid "Left Click"
 msgstr ""
 
 #: backends/platform/maemo/maemo.cpp:178
+#: engines/wintermute/keymapper_tables.h:237
+#: engines/wintermute/keymapper_tables.h:1486
 msgid "Middle Click"
 msgstr ""
 
 #: backends/platform/maemo/maemo.cpp:182
 #: backends/platform/symbian/src/SymbianActions.cpp:43
 #: backends/platform/tizen/form.cpp:266
+#: engines/wintermute/keymapper_tables.h:45
 msgid "Right Click"
 msgstr ""
 
@@ -3210,6 +3239,11 @@ msgstr ""
 
 #: backends/platform/symbian/src/SymbianActions.cpp:45
 #: engines/mohawk/myst.cpp:579 engines/mohawk/riven.cpp:848
+#: engines/wintermute/keymapper_tables.h:210
+#: engines/wintermute/keymapper_tables.h:929
+#: engines/wintermute/keymapper_tables.h:1115
+#: engines/wintermute/keymapper_tables.h:1228
+#: engines/wintermute/keymapper_tables.h:1430
 msgid "Skip"
 msgstr ""
 
@@ -3231,7 +3265,7 @@ msgstr ""
 
 #: backends/platform/symbian/src/SymbianActions.cpp:50
 #: engines/mohawk/myst.cpp:608 engines/mohawk/riven.cpp:877
-#: engines/sky/detection.cpp:253
+#: engines/sky/detection.cpp:253 engines/wintermute/keymapper_tables.h:1122
 msgid "Pause"
 msgstr ""
 
@@ -3599,29 +3633,29 @@ msgstr ""
 msgid "Cutscene file '%s' not found!"
 msgstr ""
 
-#: engines/bladerunner/bladerunner.cpp:356
+#: engines/bladerunner/bladerunner.cpp:358
 msgid "Failed to initialize resources"
 msgstr ""
 
-#: engines/bladerunner/bladerunner.cpp:1028
+#: engines/bladerunner/bladerunner.cpp:1049
 msgid "A required game resource was not found"
 msgstr ""
 
-#: engines/bladerunner/bladerunner.cpp:2188
+#: engines/bladerunner/bladerunner.cpp:2221
 msgid ""
 "WARNING: This game was saved in Restored Cut Content mode, but you are "
 "playing in Original Content mode. The mode will be adjusted to Restored Cut "
 "Content for this session until you completely Quit the game."
 msgstr ""
 
-#: engines/bladerunner/bladerunner.cpp:2190
+#: engines/bladerunner/bladerunner.cpp:2223
 msgid ""
 "WARNING: This game was saved in Original Content mode, but you are playing "
 "in Restored Cut Content mode. The mode will be adjusted to Original Content "
 "mode for this session until you completely Quit the game."
 msgstr ""
 
-#: engines/bladerunner/bladerunner.cpp:2192
+#: engines/bladerunner/bladerunner.cpp:2225
 msgid "Continue"
 msgstr ""
 
@@ -3671,6 +3705,16 @@ msgid ""
 "clicking the mouse"
 msgstr ""
 
+#: engines/dragons/dragons.cpp:1759
+#, c-format
+msgid ""
+"Error: The file '%s' hasn't been extracted properly.\n"
+"Please refer to the wiki page\n"
+"https://wiki.scummvm.org/index.php?title=HOWTO-PlayStation_Videos for "
+"details on how to properly extract the DTSPEECH.XA and *.STR files from your "
+"game disc."
+msgstr ""
+
 #: engines/drascula/saveload.cpp:47
 msgid ""
 "ScummVM found that you have old saved games for Drascula that should be "
@@ -3694,7 +3738,7 @@ msgstr ""
 msgid "[ press any key to exit ]"
 msgstr ""
 
-#: engines/glk/quetzal.cpp:146 engines/glk/quetzal.cpp:155
+#: engines/glk/quetzal.cpp:148 engines/glk/quetzal.cpp:157
 msgid "Untitled Savegame"
 msgstr ""
 
@@ -4075,13 +4119,13 @@ msgstr ""
 
 #: engines/kyra/engine/eobcommon.cpp:348 engines/kyra/engine/lol.cpp:468
 #: engines/ultima/ultima4/meta_engine.cpp:232
-#: engines/ultima/ultima8/meta_engine.cpp:101
+#: engines/ultima/ultima8/meta_engine.cpp:111
 msgid "Interact via Left Click"
 msgstr ""
 
 #: engines/kyra/engine/eobcommon.cpp:354 engines/kyra/engine/lol.cpp:474
 #: engines/ultima/ultima4/meta_engine.cpp:238
-#: engines/ultima/ultima8/meta_engine.cpp:107
+#: engines/ultima/ultima8/meta_engine.cpp:117
 msgid "Interact via Right Click"
 msgstr ""
 
@@ -4102,12 +4146,12 @@ msgid "Move Right"
 msgstr ""
 
 #: engines/kyra/engine/eobcommon.cpp:384 engines/kyra/engine/lol.cpp:522
-#: engines/pegasus/pegasus.cpp:2501
+#: engines/pegasus/pegasus.cpp:2497
 msgid "Turn Left"
 msgstr ""
 
 #: engines/kyra/engine/eobcommon.cpp:390 engines/kyra/engine/lol.cpp:528
-#: engines/pegasus/pegasus.cpp:2508
+#: engines/pegasus/pegasus.cpp:2504
 msgid "Turn Right"
 msgstr ""
 
@@ -4357,7 +4401,8 @@ msgstr ""
 msgid "Drop page"
 msgstr ""
 
-#: engines/mohawk/myst.cpp:619
+#: engines/mohawk/myst.cpp:619 engines/wintermute/keymapper_tables.h:1185
+#: engines/wintermute/keymapper_tables.h:1234
 msgid "Show map"
 msgstr ""
 
@@ -4370,6 +4415,7 @@ msgstr ""
 
 #: engines/mohawk/myst_stacks/menu.cpp:284
 #: engines/mohawk/riven_stacks/aspit.cpp:350
+#: engines/wintermute/keymapper_tables.h:607
 msgid "Load game"
 msgstr ""
 
@@ -4427,11 +4473,15 @@ msgstr ""
 msgid "Move backwards"
 msgstr ""
 
-#: engines/mohawk/riven.cpp:902
+#: engines/mohawk/riven.cpp:902 engines/wintermute/keymapper_tables.h:152
+#: engines/wintermute/keymapper_tables.h:459
+#: engines/wintermute/keymapper_tables.h:1442
 msgid "Turn left"
 msgstr ""
 
-#: engines/mohawk/riven.cpp:908
+#: engines/mohawk/riven.cpp:908 engines/wintermute/keymapper_tables.h:158
+#: engines/wintermute/keymapper_tables.h:464
+#: engines/wintermute/keymapper_tables.h:1448
 msgid "Turn right"
 msgstr ""
 
@@ -4527,47 +4577,55 @@ msgstr ""
 msgid "Invalid file name for saving"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2487
+#: engines/pegasus/pegasus.cpp:2483
 msgid "Up/Zoom In/Move Forward/Open Doors"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2494
+#: engines/pegasus/pegasus.cpp:2490
 msgid "Down/Zoom Out"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2515
+#: engines/pegasus/pegasus.cpp:2511
 msgid "Action/Select"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2535
+#: engines/pegasus/pegasus.cpp:2531
 msgid "Display/Hide Inventory Tray"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2542
+#: engines/pegasus/pegasus.cpp:2538
 msgid "Display/Hide Biochip Tray"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2550
+#: engines/pegasus/pegasus.cpp:2546
 msgid "Toggle Center Data Display"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2557
+#: engines/pegasus/pegasus.cpp:2553
 msgid "Display/Hide Info Screen"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2564
+#: engines/pegasus/pegasus.cpp:2560
 msgid "Display/Hide Pause Menu"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2575
+#: engines/pegasus/pegasus.cpp:2571 engines/wintermute/keymapper_tables.h:264
+#: engines/wintermute/keymapper_tables.h:368
+#: engines/wintermute/keymapper_tables.h:496
+#: engines/wintermute/keymapper_tables.h:529
+#: engines/wintermute/keymapper_tables.h:667
+#: engines/wintermute/keymapper_tables.h:875
+#: engines/wintermute/keymapper_tables.h:922
+#: engines/wintermute/keymapper_tables.h:1283
+#: engines/wintermute/keymapper_tables.h:1337
 msgid "???"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2581
+#: engines/pegasus/pegasus.cpp:2577
 msgid "Save Game"
 msgstr ""
 
-#: engines/pegasus/pegasus.cpp:2587
+#: engines/pegasus/pegasus.cpp:2583
 msgid "Load Game"
 msgstr ""
 
@@ -4679,7 +4737,7 @@ msgstr ""
 msgid "Upscale videos to double their size"
 msgstr ""
 
-#: engines/sci/detection.cpp:856 engines/sci/engine/kfile.cpp:484
+#: engines/sci/detection.cpp:857 engines/sci/engine/kfile.cpp:484
 msgid "(Autosave)"
 msgstr ""
 
@@ -4761,7 +4819,7 @@ msgid ""
 "GK2Subtitles.zip\n"
 msgstr ""
 
-#: engines/sci/sci.cpp:879
+#: engines/sci/sci.cpp:883
 msgid ""
 "Characters saved inside ScummVM are shown automatically. Character files "
 "saved in the original interpreter need to be put inside ScummVM's saved "
@@ -4792,7 +4850,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: engines/scumm/detection.cpp:1140
+#: engines/scumm/detection.cpp:1139
 msgid ""
 "Your game version appears to be unknown. If this is *NOT* a fan-modified\n"
 "version (in particular, not a fan-made translation), please, report the\n"
@@ -4801,26 +4859,26 @@ msgid ""
 "to add and its version, language, etc.:\n"
 msgstr ""
 
-#: engines/scumm/detection.cpp:1158
+#: engines/scumm/detection.cpp:1157
 msgid ""
 "The Lite version of Putt-Putt Saves the Zoo iOS is not supported to avoid "
 "piracy.\n"
 "The full version is available for purchase from the iTunes Store."
 msgstr ""
 
-#: engines/scumm/detection.cpp:1369
+#: engines/scumm/detection.cpp:1368
 msgid "Show Object Line"
 msgstr ""
 
-#: engines/scumm/detection.cpp:1370
+#: engines/scumm/detection.cpp:1369
 msgid "Show the names of objects at the bottom of the screen"
 msgstr ""
 
-#: engines/scumm/detection.cpp:1376
+#: engines/scumm/detection.cpp:1375
 msgid "Use NES Classic Palette"
 msgstr ""
 
-#: engines/scumm/detection.cpp:1377
+#: engines/scumm/detection.cpp:1376
 msgid "Use a more neutral color palette that closely emulates the NES Classic"
 msgstr ""
 
@@ -4960,7 +5018,7 @@ msgstr ""
 msgid "Skip cutscene"
 msgstr ""
 
-#: engines/scumm/help.cpp:79
+#: engines/scumm/help.cpp:79 engines/wintermute/keymapper_tables.h:1456
 msgid "Space"
 msgstr ""
 
@@ -5006,7 +5064,7 @@ msgstr ""
 msgid "Simulate left mouse button"
 msgstr ""
 
-#: engines/scumm/help.cpp:91
+#: engines/scumm/help.cpp:91 engines/wintermute/keymapper_tables.h:1511
 msgid "Tab"
 msgstr ""
 
@@ -5108,6 +5166,7 @@ msgstr ""
 #: engines/scumm/help.cpp:171 engines/scumm/help.cpp:199
 #: engines/scumm/help.cpp:214 engines/scumm/help.cpp:225
 #: engines/scumm/help.cpp:251 engines/sky/detection.cpp:222
+#: engines/wintermute/keymapper_tables.h:131
 msgid "Use"
 msgstr ""
 
@@ -5136,7 +5195,7 @@ msgstr ""
 
 #: engines/scumm/help.cpp:144 engines/scumm/help.cpp:169
 #: engines/scumm/help.cpp:196 engines/scumm/help.cpp:211
-#: engines/scumm/help.cpp:228
+#: engines/scumm/help.cpp:228 engines/wintermute/keymapper_tables.h:125
 msgid "Pick up"
 msgstr ""
 
@@ -5222,7 +5281,7 @@ msgid "pull (Yank)"
 msgstr ""
 
 #: engines/scumm/help.cpp:197 engines/scumm/help.cpp:213
-#: engines/scumm/help.cpp:249
+#: engines/scumm/help.cpp:249 engines/wintermute/keymapper_tables.h:119
 msgid "Talk to"
 msgstr ""
 
@@ -5582,7 +5641,7 @@ msgstr ""
 msgid "Walk / Look / Talk"
 msgstr ""
 
-#: engines/sky/detection.cpp:228
+#: engines/sky/detection.cpp:228 engines/wintermute/keymapper_tables.h:51
 msgid "Confirm"
 msgstr ""
 
@@ -5757,27 +5816,27 @@ msgstr ""
 msgid "Transfer Character"
 msgstr ""
 
-#: engines/ultima/ultima8/meta_engine.cpp:96
+#: engines/ultima/ultima8/meta_engine.cpp:106
 msgid "Ultima VIII"
 msgstr ""
 
-#: engines/ultima/ultima8/meta_engine.cpp:126
+#: engines/ultima/ultima8/meta_engine.cpp:137
 msgid "Ultima VIII Cheats"
 msgstr ""
 
-#: engines/ultima/ultima8/meta_engine.cpp:140
+#: engines/ultima/ultima8/meta_engine.cpp:152
 msgid "Ultima VIII Debug"
 msgstr ""
 
-#: engines/ultima/ultima8/gumps/u8_save_gump.cpp:304
+#: engines/ultima/ultima8/gumps/u8_save_gump.cpp:299
 msgid "[corrupt]"
 msgstr ""
 
-#: engines/ultima/ultima8/gumps/u8_save_gump.cpp:307
+#: engines/ultima/ultima8/gumps/u8_save_gump.cpp:302
 msgid "[outdated]"
 msgstr ""
 
-#: engines/ultima/ultima8/gumps/u8_save_gump.cpp:310
+#: engines/ultima/ultima8/gumps/u8_save_gump.cpp:305
 msgid "[too modern]"
 msgstr ""
 
@@ -5809,9 +5868,476 @@ msgstr ""
 msgid "This game requires the HeroCraft subengine, which is not compiled in."
 msgstr ""
 
-#: engines/wintermute/wintermute.cpp:189
+#: engines/wintermute/wintermute.cpp:188
+msgid ""
+"This game requires 3D capabilities that are out ScummVM scope. As such, it "
+"is likely to be unplayable totally or partially."
+msgstr ""
+
+#: engines/wintermute/wintermute.cpp:200
 msgid ""
 "This game requires 3D characters support, which is out of ScummVM's scope."
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:57
+msgid "Escape"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:113
+msgid "Look At"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:140
+#: engines/wintermute/keymapper_tables.h:449
+#: engines/wintermute/keymapper_tables.h:1436
+msgid "Walk forward"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:146
+#: engines/wintermute/keymapper_tables.h:454
+msgid "Walk backward"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:164
+#: engines/wintermute/keymapper_tables.h:407
+#: engines/wintermute/keymapper_tables.h:1251
+msgid "Show scene geometry"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:173
+#: engines/wintermute/keymapper_tables.h:189
+#: engines/wintermute/keymapper_tables.h:588
+#: engines/wintermute/keymapper_tables.h:784
+#: engines/wintermute/keymapper_tables.h:912
+msgid "Previous page"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:180
+#: engines/wintermute/keymapper_tables.h:197
+#: engines/wintermute/keymapper_tables.h:595
+#: engines/wintermute/keymapper_tables.h:791
+#: engines/wintermute/keymapper_tables.h:917
+msgid "Next page"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:220
+#: engines/wintermute/keymapper_tables.h:243
+#: engines/wintermute/keymapper_tables.h:270
+#: engines/wintermute/keymapper_tables.h:374
+#: engines/wintermute/keymapper_tables.h:502
+#: engines/wintermute/keymapper_tables.h:540
+#: engines/wintermute/keymapper_tables.h:567
+#: engines/wintermute/keymapper_tables.h:726
+#: engines/wintermute/keymapper_tables.h:972
+#: engines/wintermute/keymapper_tables.h:998
+#: engines/wintermute/keymapper_tables.h:1054
+#: engines/wintermute/keymapper_tables.h:1080
+#: engines/wintermute/keymapper_tables.h:1172
+#: engines/wintermute/keymapper_tables.h:1221
+#: engines/wintermute/keymapper_tables.h:1423
+msgid "Show hints"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:230
+#: engines/wintermute/keymapper_tables.h:381
+#: engines/wintermute/keymapper_tables.h:546
+#: engines/wintermute/keymapper_tables.h:1025
+#: engines/wintermute/keymapper_tables.h:1179
+#: engines/wintermute/keymapper_tables.h:1191
+#: engines/wintermute/keymapper_tables.h:1200
+#: engines/wintermute/keymapper_tables.h:1343
+msgid "Show inventory"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:250
+#: engines/wintermute/keymapper_tables.h:277
+#: engines/wintermute/keymapper_tables.h:1325
+msgid "GUI variant A"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:257
+#: engines/wintermute/keymapper_tables.h:284
+#: engines/wintermute/keymapper_tables.h:1331
+msgid "GUI variant B"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:291
+#: engines/wintermute/keymapper_tables.h:798
+msgid "Phone cancel button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:296
+#: engines/wintermute/keymapper_tables.h:803
+msgid "Phone up button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:302
+#: engines/wintermute/keymapper_tables.h:809
+msgid "Phone down button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:308
+#: engines/wintermute/keymapper_tables.h:815
+msgid "Phone 0 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:313
+#: engines/wintermute/keymapper_tables.h:820
+msgid "Phone 1 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:318
+#: engines/wintermute/keymapper_tables.h:825
+msgid "Phone 2 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:323
+#: engines/wintermute/keymapper_tables.h:830
+msgid "Phone 3 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:328
+#: engines/wintermute/keymapper_tables.h:835
+msgid "Phone 4 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:333
+#: engines/wintermute/keymapper_tables.h:840
+msgid "Phone 5 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:338
+#: engines/wintermute/keymapper_tables.h:845
+msgid "Phone 6 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:343
+#: engines/wintermute/keymapper_tables.h:850
+msgid "Phone 7 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:348
+#: engines/wintermute/keymapper_tables.h:855
+msgid "Phone 8 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:353
+#: engines/wintermute/keymapper_tables.h:860
+msgid "Phone 9 button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:358
+#: engines/wintermute/keymapper_tables.h:865
+msgid "Phone * button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:363
+#: engines/wintermute/keymapper_tables.h:870
+msgid "Phone # button"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:387
+#: engines/wintermute/keymapper_tables.h:1005
+msgid "Show help"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:393
+#: engines/wintermute/keymapper_tables.h:553
+#: engines/wintermute/keymapper_tables.h:574
+#: engines/wintermute/keymapper_tables.h:979
+#: engines/wintermute/keymapper_tables.h:1011
+#: engines/wintermute/keymapper_tables.h:1066
+#: engines/wintermute/keymapper_tables.h:1087
+#: engines/wintermute/keymapper_tables.h:1207
+#: engines/wintermute/keymapper_tables.h:1362
+#: engines/wintermute/keymapper_tables.h:1491
+msgid "Scroll up"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:400
+#: engines/wintermute/keymapper_tables.h:560
+#: engines/wintermute/keymapper_tables.h:581
+#: engines/wintermute/keymapper_tables.h:986
+#: engines/wintermute/keymapper_tables.h:1018
+#: engines/wintermute/keymapper_tables.h:1073
+#: engines/wintermute/keymapper_tables.h:1094
+#: engines/wintermute/keymapper_tables.h:1214
+#: engines/wintermute/keymapper_tables.h:1369
+#: engines/wintermute/keymapper_tables.h:1496
+msgid "Scroll down"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:412
+msgid "Change shadow type"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:422
+#: engines/wintermute/keymapper_tables.h:509
+msgid "Volume max"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:427
+msgid "Show debug parser"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:434
+#: engines/wintermute/keymapper_tables.h:535
+#: engines/wintermute/keymapper_tables.h:1273
+msgid "Debug print"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:439
+#: engines/wintermute/keymapper_tables.h:1246
+msgid "Exit"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:444
+msgid "Light helper window"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:469
+msgid "Run forward"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:474
+msgid "Run backward"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:479
+msgid "Turn left fast"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:484
+msgid "Turn right fast"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:489
+msgid "Show blueprint"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:516
+msgid "Volume off"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:523
+msgid "Change font size"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:602
+msgid "Save game"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:612
+msgid "Quick save"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:617
+msgid "Walking speed: Low"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:622
+msgid "Walking speed: Medium"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:627
+msgid "Walking speed: High"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:632
+msgid "Quick load"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:637
+#: engines/wintermute/keymapper_tables.h:967
+#: engines/wintermute/keymapper_tables.h:1268
+msgid "Cancel waiting"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:647
+msgid "First page"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:652
+msgid "Last page"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:659
+msgid "Walking speed: Ultra Super Mega Fast"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:675
+msgid "Show game credits"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:680
+msgid "Play selected music record"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:685
+msgid "Select next music record"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:690
+msgid "Play note 1: A"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:695
+msgid "Play note 2: F#"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:700
+msgid "Play note 3: D#"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:705
+msgid "Play note 4: C#"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:710
+msgid "Play note 5: E"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:715
+msgid "Play note 6: G#"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:720
+msgid "Play note 7: B"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:733
+msgid "Ability: Telekinesis"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:738
+msgid "Ability: Push"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:743
+msgid "Ability: Lightning"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:748
+msgid "Ability: Light"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:753
+msgid "Ability: Wind"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:758
+msgid "Ability: Sound"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:763
+msgid "Ability: Esence"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:768
+msgid "Ability: Exorcist"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:773
+msgid "Skip minigame"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:881
+msgid "Show hints / Dance move"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:888
+msgid "Dance move up"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:894
+msgid "Dance move down"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:900
+msgid "Dance move left"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:906
+msgid "Dance move right"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:936
+msgid "Cancel input"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1046
+msgid "Shift"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1101
+#: engines/wintermute/keymapper_tables.h:1409
+msgid "Next action"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1109
+#: engines/wintermute/keymapper_tables.h:1417
+msgid "Previous action"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1128
+#: engines/wintermute/keymapper_tables.h:1263
+msgid "Settings"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1133
+msgid "Dialogue answer 1"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1138
+msgid "Dialogue answer 2"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1143
+msgid "Dialogue answer 3"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1148
+msgid "Dialogue answer 4"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1158
+msgid "Spin slower"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1165
+msgid "Spin faster"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1278
+msgid "Bezier window"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1294
+msgid "Droid action"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1350
+msgid "Show journal"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1356
+msgid "Music menu"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1376
+msgid "Rotate"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1401
+msgid "Drop"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1501
+msgid "F1"
+msgstr ""
+
+#: engines/wintermute/keymapper_tables.h:1506
+msgid "Key i"
 msgstr ""
 
 #: engines/xeen/detection.cpp:96


### PR DESCRIPTION
Fixed typo in Wintermute POTFILE. It was missing the folders. The file also needed a carriage return at the end.

I haven't updated the translations.dat before so I've make a PR just to check I'm following the right process.

