### PR TITLE
WINTERMUTE: Fix double-notifications for 3D games

### DIFF
--- a/engines/wintermute/base/base_engine.h
+++ b/engines/wintermute/base/base_engine.h
@@ -174,6 +174,7 @@ public:
 	bool isFoxTail(WMETargetExecutable v1=FOXTAIL_OLDEST_VERSION, WMETargetExecutable v2=FOXTAIL_LATEST_VERSION) const {
 		return isFoxTailCheck(_targetExecutable, v1, v2);
 	}
+	void addFlags(uint32 flags) { _flags |= flags; }
 };
 
 } // End of namespace Wintermute


### PR DESCRIPTION
Let's merge recently added "flags & GF_3D" check and existing 3D characters lookup heuristic check into a single notification warning.

It's useful to have both:
* for known games, GF_3D flag is set manually for 2.5D games
* for unknown games, 3D-characters lookup is made