### PR TITLE
NULL: Allow using Ctrl+C to open the debugger

### DIFF
--- a/configure
+++ b/configure
@@ -3715,6 +3715,7 @@ case $_backend in
 		;;
 	null)
 		append_var DEFINES "-DUSE_NULL_DRIVER"
+		_text_console=yes
 		;;
 	openpandora)
 		append_var DEFINES "-DOPENPANDORA"


### PR DESCRIPTION
This allows the debugger to be activated when using the null backend. This is done using a signal handler. In addition, the text console is now enabled by default when using the null backend, since the regular console obviously won't work without proper graphics or input support.