### PR TITLE
VOYEUR: Persist data in the config file

### DIFF
--- a/engines/voyeur/data.cpp
+++ b/engines/voyeur/data.cpp
@@ -60,7 +60,6 @@ SVoy::SVoy(VoyeurEngine *vm):_vm(vm) {
 	_playStampMode = 0;
 	_switchBGNum = 0;
 	_transitionId = 0;
-	_victimNumber = 0;
 	_videoEventId = 0;
 	_vocSecondsOffset = 0;
 	_RTANum = 0;
@@ -152,7 +151,7 @@ void SVoy::synchronize(Common::Serializer &s) {
 	s.syncAsSint16LE(_fadingStep1);
 	s.syncAsSint16LE(_fadingStep2);
 	s.syncAsSint16LE(_fadingType);
-	s.syncAsSint16LE(_victimNumber);
+	s.skip(sizeof(int16), 0, 2);
 	s.syncAsSint16LE(_incriminatedVictimNumber);
 	s.syncAsSint16LE(_videoEventId);
 

--- a/engines/voyeur/data.h
+++ b/engines/voyeur/data.h
@@ -137,7 +137,6 @@ public:
 	int _switchBGNum;
 	int _totalPhoneCalls;
 	int _transitionId;
-	int _victimNumber;
 	int _videoEventId;
 	int _vocSecondsOffset;
 	int _RTANum;

--- a/engines/voyeur/files_threads.cpp
+++ b/engines/voyeur/files_threads.cpp
@@ -24,6 +24,7 @@
 #include "voyeur/screen.h"
 #include "voyeur/voyeur.h"
 #include "voyeur/staticres.h"
+#include "common/config-manager.h"
 
 namespace Voyeur {
 
@@ -588,22 +589,21 @@ void ThreadResource::parsePlayCommands() {
 			// Pick the person who is to die, during startup
 			if (_vm->_iForceDeath == -1) {
 				// No specific person has been preset to be killed, so pick one randomly.
-				// The loop below was used because the victim was persisted from the previous
-				// play-through, so it ensured that a different victim is picked.
-				int randomVal;
+				// The loop below ensures that a different victim is picked.
+				int lastVictim = ConfMan.hasKey("lastVictim") ? ConfMan.getInt("lastVictim") : -1;
+				int randomVictim;
 				do {
-					randomVal = _vm->getRandomNumber(3) + 1;
-				} while (randomVal == _vm->_voy->_victimNumber);
+					randomVictim = _vm->getRandomNumber(3) + 1;
+				} while (randomVictim == lastVictim);
 
-				_vm->_voy->_victimNumber = randomVal;
-				_vm->_controlPtr->_state->_victimIndex = randomVal;
+				_vm->_controlPtr->_state->_victimIndex = randomVictim;
 			} else {
-				// Player has seen something that locks in the character to die
-				_vm->_voy->_victimNumber = _vm->_iForceDeath;
+				// Victim selected from command line
 				_vm->_controlPtr->_state->_victimIndex = _vm->_iForceDeath;
 			}
-
-			_vm->saveLastInplay();
+			
+			ConfMan.setInt("lastVictim", _vm->_controlPtr->_state->_victimIndex);
+			ConfMan.flushToDisk();
 			break;
 
 		case 11:

--- a/engines/voyeur/voyeur.cpp
+++ b/engines/voyeur/voyeur.cpp
@@ -250,7 +250,7 @@ bool VoyeurEngine::doLock() {
 	byte *wrongVoc = _filesManager->fload("wrong.voc", &wrongVocSize);
 
 	if (_bVoy->getBoltGroup(0x700)) {
-		Common::String password = "3333";
+		Common::String password = ConfMan.hasKey("lockCode") ? ConfMan.get("lockCode") : "3333";
 
 		_screen->_backgroundPage = _bVoy->getPictureResource(0x700);
 		_screen->_backColors = _bVoy->getCMapResource(0x701);
@@ -361,6 +361,7 @@ bool VoyeurEngine::doLock() {
 				if ((password.empty() && displayString.empty()) || (password != displayString)) {
 					_screen->_vPort->setupViewPort();
 					password = displayString;
+					ConfMan.setAndFlush("lockCode", password);
 					displayString = "";
 					continue;
 				}

--- a/engines/voyeur/voyeur.cpp
+++ b/engines/voyeur/voyeur.cpp
@@ -674,10 +674,6 @@ void VoyeurEngine::doTransitionCard(const Common::String &time, const Common::St
 	flipPageAndWait();
 }
 
-void VoyeurEngine::saveLastInplay() {
-	// No implementation in ScummVM version
-}
-
 void VoyeurEngine::flipPageAndWait() {
 	_screen->_vPort->_flags |= DISPFLAG_8;
 	_screen->flipPage();

--- a/engines/voyeur/voyeur.h
+++ b/engines/voyeur/voyeur.h
@@ -231,10 +231,6 @@ public:
 	 */
 	void playAudio(int audioId);
 
-	/**
-	 * Saves the last time the game was played
-	 */
-	void saveLastInplay();
 	void makeViewFinder();
 	void makeViewFinderP();
 	void initIFace();
@@ -295,7 +291,7 @@ public:
 	void showEndingNews();
 };
 
-#define VOYEUR_SAVEGAME_VERSION 2
+#define VOYEUR_SAVEGAME_VERSION 3
 
 /**
  * Header for Voyeur savegame files


### PR DESCRIPTION
Persist data that the original game kept between games.

Took the time to remove an unneeded duplicate variable. Which was unfortunately in the save file, so the save version had to be bumped.