### PR TITLE
TESTBED: Bugfix & Achievements

### DIFF
--- a/dists/engine-data/testbed-audiocd-files/TEST3/FILE.txt
+++ b/dists/engine-data/testbed-audiocd-files/TEST3/FILE.txt
@@ -1,0 +1,1 @@
+It works!

--- a/dists/engine-data/testbed-audiocd-files/Test2/File.txt
+++ b/dists/engine-data/testbed-audiocd-files/Test2/File.txt
@@ -1,0 +1,1 @@
+It works!

--- a/dists/engine-data/testbed-audiocd-files/tEST4/fILe.txt
+++ b/dists/engine-data/testbed-audiocd-files/tEST4/fILe.txt
@@ -1,0 +1,1 @@
+It works!

--- a/dists/engine-data/testbed-audiocd-files/test1/file.txt
+++ b/dists/engine-data/testbed-audiocd-files/test1/file.txt
@@ -1,0 +1,1 @@
+It works!

--- a/dists/engine-data/testbed-audiocd-files/test5/file
+++ b/dists/engine-data/testbed-audiocd-files/test5/file
@@ -1,0 +1,1 @@
+It works!

--- a/engines/testbed/config-params.cpp
+++ b/engines/testbed/config-params.cpp
@@ -69,6 +69,7 @@ bool ConfigParams::isRerunRequired() {
 void ConfigParams::deleteWriteStream() {
 	if (_ws) {
 		delete _ws;
+		_ws = 0;
 	}
 }
 

--- a/engines/testbed/detection.cpp
+++ b/engines/testbed/detection.cpp
@@ -26,6 +26,7 @@
 #include "base/plugins.h"
 
 #include "testbed/testbed.h"
+#include "testbed/testsuite.h"
 
 static const PlainGameDescriptor testbed_setting[] = {
 	{ "testbed", "Testbed: The Backend Testing Framework" },
@@ -69,6 +70,24 @@ public:
 		return true;
 	}
 
+	const Common::AchievementsInfo getAchievementsInfo(const Common::String &target) const override {
+		Common::AchievementsInfo result;
+		result.platform = Common::UNK_ACHIEVEMENTS;
+		result.appId = "testbed";
+		Common::AchievementDescription final = {"EVERYTHINGWORKS", true, "Everything works!", "Completed all available testsuites"};
+		result.descriptions.push_back(final);
+
+		Common::Array<Testbed::Testsuite *> testsuiteList;
+		Testbed::TestbedEngine::pushTestsuites(testsuiteList);
+		for (Common::Array<Testbed::Testsuite *>::const_iterator i = testsuiteList.begin(); i != testsuiteList.end(); ++i) {
+			Common::AchievementDescription it = {(*i)->getName(), false, (*i)->getDescription(), 0};
+			result.descriptions.push_back(it);
+			delete (*i);
+		}
+
+		return result;
+	}
+	
 	bool hasFeature(MetaEngineFeature f) const override {
 		return false;
 	}

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -40,15 +40,6 @@ namespace Testbed {
 byte GFXTestSuite::_palette[256 * 3] = {0, 0, 0, 255, 255, 255, 255, 255, 255};
 
 GFXTestSuite::GFXTestSuite() {
-	// Initialize color palettes
-	// The fourth field is for alpha channel which is unused
-	// Assuming 8bpp as of now
-	g_system->getPaletteManager()->setPalette(_palette, 0, 3);
-
-	// Init Mouse Palette (White-black-yellow)
-	GFXtests::initMousePalette();
-	GFXtests::initMouseCursor();
-
 	// Add tests here
 
 	// Blitting buffer on screen
@@ -77,6 +68,17 @@ GFXTestSuite::GFXTestSuite() {
 	addTest("PaletteRotation", &GFXtests::paletteRotation);
 	addTest("cursorTrailsInGUI", &GFXtests::cursorTrails);
 	//addTest("Pixel Formats", &GFXtests::pixelFormats);
+}
+
+void GFXTestSuite::prepare() {
+	// Initialize color palettes
+	// The fourth field is for alpha channel which is unused
+	// Assuming 8bpp as of now
+	g_system->getPaletteManager()->setPalette(_palette, 0, 3);
+
+	// Init Mouse Palette (White-black-yellow)
+	GFXtests::initMousePalette();
+	GFXtests::initMouseCursor();
 }
 
 void GFXTestSuite::setCustomColor(uint r, uint g, uint b) {

--- a/engines/testbed/graphics.h
+++ b/engines/testbed/graphics.h
@@ -75,6 +75,7 @@ public:
 	const char *getDescription() const override {
 		return "Graphics Subsystem";
 	}
+	void prepare() override;
 	static void setCustomColor(uint r, uint g, uint b);
 
 private:

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include "common/achievements.h"
 #include "common/debug-channels.h"
 #include "common/scummsys.h"
 #include "common/archive.h"
@@ -196,12 +197,29 @@ void TestbedEngine::invokeTestsuites(TestbedConfigManager &cfMan) {
 			Testsuite::updateStats("Testsuite", (*iter)->getName(), count++, numSuitesEnabled, pt);
 			(*iter)->execute();
 		}
+		if ((*iter)->getNumTests() == (*iter)->getNumTestsPassed()) {
+			AchMan.setAchievement((*iter)->getName(), (*iter)->getDescription());
+			checkForAllAchievements();
+		}
 	}
+}
+
+void TestbedEngine::checkForAllAchievements() {
+	Common::Array<Testsuite *>::const_iterator iter;
+	for (iter = _testsuiteList.begin(); iter != _testsuiteList.end(); iter++) {
+		if (!AchMan.isAchieved((*iter)->getName())) {
+			return;
+		}
+	}
+	AchMan.setAchievement("EVERYTHINGWORKS", "Everything works!");
 }
 
 Common::Error TestbedEngine::run() {
 	// Initialize graphics using following:
 	initGraphics(320, 200);
+
+	// Initialize achievements manager
+	AchMan.setActiveDomain(Common::UNK_ACHIEVEMENTS, "testbed");
 
 	// As of now we are using GUI::MessageDialog for interaction, Test if it works.
 	// interactive mode could also be modified by a config parameter "non-interactive=1"

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -122,46 +122,50 @@ TestbedEngine::TestbedEngine(OSystem *syst)
 	DebugMan.addDebugChannel(kTestbedEngineDebug, "Debug", "Engine-specific debug statements");
 	DebugMan.enableDebugChannel("LOG");
 
+	pushTestsuites(_testsuiteList);
+}
+
+void TestbedEngine::pushTestsuites(Common::Array<Testsuite *> &testsuiteList) {
 	// Initialize testsuites here
 	Testsuite *ts;
 	// GFX
 	ts = new GFXTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 	// FS
 	ts = new FSTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 	// Savegames
 	ts = new SaveGameTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 	// Misc.
 	ts = new MiscTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 	// Events
 	ts = new EventTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 	// Sound
 	ts = new SoundSubsystemTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 	// Midi
 	ts = new MidiTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 #ifdef USE_TTS
 	 // TextToSpeech
 	 ts = new SpeechTestSuite();
-	 _testsuiteList.push_back(ts);
+	 testsuiteList.push_back(ts);
 #endif
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)
 	// Cloud
 	ts = new CloudTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 #endif
 #ifdef USE_SDL_NET
 	// Webserver
 	ts = new WebserverTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 #endif
 	ts = new EncodingTestSuite();
-	_testsuiteList.push_back(ts);
+	testsuiteList.push_back(ts);
 }
 
 TestbedEngine::~TestbedEngine() {

--- a/engines/testbed/testbed.h
+++ b/engines/testbed/testbed.h
@@ -60,6 +60,7 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 
 private:
+	void checkForAllAchievements();
 	Common::Array<Testsuite *> _testsuiteList;
 };
 

--- a/engines/testbed/testbed.h
+++ b/engines/testbed/testbed.h
@@ -50,6 +50,11 @@ public:
 	/**
 	 * Invokes configured testsuites.
 	 */
+	static void pushTestsuites(Common::Array<Testsuite *> &testsuiteList);
+
+	/**
+	 * Invokes configured testsuites.
+	 */
 	void invokeTestsuites(TestbedConfigManager &cfMan);
 
 	bool hasFeature(EngineFeature f) const override;

--- a/engines/testbed/testsuite.cpp
+++ b/engines/testbed/testsuite.cpp
@@ -287,6 +287,8 @@ void Testsuite::execute() {
 	if (!numEnabledTests)
 		return;
 
+	prepare();
+
 	for (Common::Array<Test *>::iterator i = _testsToExecute.begin(); i != _testsToExecute.end(); ++i) {
 		if (!(*i)->enabled) {
 			logPrintf("Info! Skipping Test: %s, Skipped by configuration.\n", ((*i)->featureName).c_str());

--- a/engines/testbed/testsuite.h
+++ b/engines/testbed/testsuite.h
@@ -135,6 +135,11 @@ public:
 	void addTest(const Common::String &name, InvokingFunction f, bool isInteractive = true);
 
 	/**
+	 * Testsuite state preparation code, like tweaking mouse cursors should go there
+	 */
+	virtual void prepare() {}
+
+	/**
 	 * The driver function for the testsuite
 	 * All code should go in here.
 	 */


### PR DESCRIPTION
1. Minor refactoring to have a single function to create testsuites list both at TestbedEngine() constructor and metaengine's getAchievementsInfo() method. Some code was moved away from GFXTestSuite() constructor to avoid running it inside getAchievementsInfo() from main menu.

2. Fixed a bug that chashed TestBed after Return-To-Launcher

3. Give achievement for each testsuite and a secret achievement for completing them all.

4. Added some files required for FS testsuite to pass (test1/file.txt, etc)
