### PR TITLE
WINTERMUTE: Add save thumbnails to Corrosion

### DIFF
--- a/engines/wintermute/ad/ad_game.cpp
+++ b/engines/wintermute/ad/ad_game.cpp
@@ -415,6 +415,17 @@ bool AdGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, 
 		stack->correctParams(1);
 		ScValue *val = stack->pop();
 		AdObject *obj = (AdObject *)val->getNative();
+
+		// HACK: We take corrosion screenshot before entering main menu
+		// Unused screenshots must be deleted, after main menu is closed
+		if (obj && BaseEngine::instance().getGameId() == "corrosion") {
+			const char *mm = "interface\\system\\mainmenu.window";
+			const char *fn = obj->getFilename();
+			if (fn && strcmp(fn, mm) == 0) {
+				deleteSaveThumbnail();
+			}
+		}
+
 		removeObject(obj);
 		if (val->getType() == VAL_VARIABLE_REF) {
 			val->setNULL();

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -1624,6 +1624,13 @@ bool BaseGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 		byte blue = stack->pop()->getInt(0);
 		byte alpha = stack->pop()->getInt(0xFF);
 
+		// HACK: Corrosion fades screen to black while opening main menu
+		// Thus, we get black screenshots when saving game from in-game menus
+		// Let's take & keep screenshot before entering main menu
+		if (duration == 750 && BaseEngine::instance().getGameId() == "corrosion") {
+			storeSaveThumbnail();
+		}
+
 		bool system = (strcmp(name, "SystemFadeOut") == 0 || strcmp(name, "SystemFadeOutAsync") == 0);
 
 		_fader->fadeOut(BYTETORGBA(red, green, blue, alpha), duration, system);

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -1931,16 +1931,7 @@ bool BaseGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "StoreSaveThumbnail") == 0) {
 		stack->correctParams(0);
-		delete _cachedThumbnail;
-		_cachedThumbnail = new SaveThumbHelper(this);
-		if (DID_FAIL(_cachedThumbnail->storeThumbnail())) {
-			delete _cachedThumbnail;
-			_cachedThumbnail = nullptr;
-			stack->pushBool(false);
-		} else {
-			stack->pushBool(true);
-		}
-
+		stack->pushBool(storeSaveThumbnail());
 		return STATUS_OK;
 	}
 
@@ -1949,10 +1940,8 @@ bool BaseGame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack
 	//////////////////////////////////////////////////////////////////////////
 	else if (strcmp(name, "DeleteSaveThumbnail") == 0) {
 		stack->correctParams(0);
-		delete _cachedThumbnail;
-		_cachedThumbnail = nullptr;
+		deleteSaveThumbnail();
 		stack->pushNULL();
-
 		return STATUS_OK;
 	}
 
@@ -4078,6 +4067,23 @@ bool BaseGame::drawCursor(BaseSprite *cursor) {
 		_lastCursor = cursor;
 	}
 	return cursor->draw(_mousePos.x, _mousePos.y);
+}
+
+//////////////////////////////////////////////////////////////////////////
+bool BaseGame::storeSaveThumbnail() {
+	delete _cachedThumbnail;
+	_cachedThumbnail = new SaveThumbHelper(this);
+	if (DID_FAIL(_cachedThumbnail->storeThumbnail())) {
+		deleteSaveThumbnail();
+		return false;
+	}
+	return true;
+}
+
+//////////////////////////////////////////////////////////////////////////
+void BaseGame::deleteSaveThumbnail() {
+	delete _cachedThumbnail;
+	_cachedThumbnail = nullptr;
 }
 
 

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -246,8 +246,6 @@ BaseGame::~BaseGame() {
 
 	cleanup();
 
-	delete _cachedThumbnail;
-
 	delete _mathClass;
 	delete _directoryClass;
 
@@ -263,8 +261,6 @@ BaseGame::~BaseGame() {
 	delete _renderer;
 	delete _musicSystem;
 	delete _settings;
-
-	_cachedThumbnail = nullptr;
 
 	_mathClass = nullptr;
 	_directoryClass = nullptr;
@@ -295,6 +291,8 @@ BaseGame::~BaseGame() {
 bool BaseGame::cleanup() {
 	delete _loadingIcon;
 	_loadingIcon = nullptr;
+
+	deleteSaveThumbnail();
 
 	_engineLogCallback = nullptr;
 	_engineLogCallbackData = nullptr;

--- a/engines/wintermute/base/base_game.h
+++ b/engines/wintermute/base/base_game.h
@@ -259,6 +259,8 @@ public:
 	bool setActiveObject(BaseObject *Obj);
 	BaseSprite *_lastCursor;
 	bool drawCursor(BaseSprite *Cursor);
+	bool storeSaveThumbnail();
+	void deleteSaveThumbnail();
 
 	SaveThumbHelper *_cachedThumbnail;
 	void addMem(int32 bytes);


### PR DESCRIPTION
This implements enhancement #11032 WME: Add save thumbnails to Corrosion: https://bugs.scummvm.org/ticket/11032

1. Move some code to separate methods to make it accessible from other code points.
2. Clean cached thumbnail on game load (I believe it's original WME engine bug that this thumbnail may be not cleared after game load)
3. Save thumbnail to cache on Game.FadeOut(750) for Corrosion
4. Delete thumbnail on Game.UnloadObject(<interface\\system\\mainmenu.window>) for Corrosion

This has some unsupported scenarios like "opening the save menu, then opening ScummVM menu, save in second one, save in first one", but works in all normal use-cases.