### PR TITLE
WINTERMUTE: Implement walking with arrow keys for Corrosion

### DIFF
--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -3792,6 +3792,56 @@ bool BaseGame::handleMouseWheel(int32 delta) {
 	return true;
 }
 
+//////////////////////////////////////////////////////////////////////////
+bool BaseGame::handleCustomActionStart(BaseGameCustomAction action) {
+	Point32 p;
+
+	switch (action) {
+	case kClickAtCenter:
+		p.x = _renderer->getWidth() / 2;
+		p.y = _renderer->getHeight() / 2;
+		break;
+	case kClickAtLeft:
+		p.x = 30;
+		p.y = _renderer->getHeight() / 2;
+		break;
+	case kClickAtRight:
+		p.x = _renderer->getWidth() - 30;
+		p.y = _renderer->getHeight() / 2;
+		break;
+	case kClickAtTop:
+		p.x = _renderer->getWidth() / 2;
+		p.y = 10;
+		break;
+	case kClickAtBottom:
+		p.x = _renderer->getWidth() / 2;
+		p.y = _renderer->getHeight() - 35;
+		break;
+	default:
+		return false;
+	}
+
+	BasePlatform::setCursorPos(p.x, p.y);
+	setActiveObject(_gameRef->_renderer->getObjectAt(p.x, p.y)); 
+
+	return onMouseLeftDown();
+}
+
+//////////////////////////////////////////////////////////////////////////
+bool BaseGame::handleCustomActionEnd(BaseGameCustomAction action) {
+	switch (action) {
+	case kClickAtCenter:
+	case kClickAtLeft:
+	case kClickAtRight:
+	case kClickAtTop:
+	case kClickAtBottom:
+		return onMouseLeftUp();
+	default:
+		break;
+	}
+
+	return false;
+}
 
 //////////////////////////////////////////////////////////////////////////
 bool BaseGame::getVersion(byte *verMajor, byte *verMinor, byte *extMajor, byte *extMinor) const {

--- a/engines/wintermute/base/base_game.h
+++ b/engines/wintermute/base/base_game.h
@@ -30,6 +30,7 @@
 #define WINTERMUTE_BASE_GAME_H
 
 #include "engines/wintermute/base/base_object.h"
+#include "engines/wintermute/base/base_game_custom_actions.h"
 #include "engines/wintermute/base/timer.h"
 #include "engines/wintermute/persistent.h"
 #include "engines/wintermute/coll_templ.h"
@@ -202,6 +203,8 @@ public:
 
 	bool handleKeypress(Common::Event *event, bool printable = false) override;
 	virtual void handleKeyRelease(Common::Event *event);
+	bool handleCustomActionStart(BaseGameCustomAction action);
+	bool handleCustomActionEnd(BaseGameCustomAction action);
 
 	bool unfreeze();
 	bool freeze(bool includingMusic = true);

--- a/engines/wintermute/base/base_game_custom_actions.h
+++ b/engines/wintermute/base/base_game_custom_actions.h
@@ -1,0 +1,44 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+#ifndef WINTERMUTE_BASE_GAME_CUSTOM_ACTION_H
+#define WINTERMUTE_BASE_GAME_CUSTOM_ACTION_H
+
+namespace Wintermute {
+
+enum BaseGameCustomAction {
+	kClickAtCenter = 0,
+	kClickAtLeft = 1,
+	kClickAtRight = 2,
+	kClickAtTop = 3,
+	kClickAtBottom = 4
+};
+
+} // End of namespace Wintermute
+
+#endif

--- a/engines/wintermute/keymapper_tables.h
+++ b/engines/wintermute/keymapper_tables.h
@@ -24,6 +24,8 @@
 #include "backends/keymapper/keymapper.h"
 #include "backends/keymapper/standard-actions.h"
 
+#include "engines/wintermute/base/base_game_custom_actions.h"
+
 #include "common/translation.h"
 
 namespace Wintermute {
@@ -69,7 +71,6 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		gameId == "bickadoodle" ||
 		gameId == "bthreshold" ||
 		gameId == "colorsoncanvas" ||
-		gameId == "corrosion" ||
 		gameId == "deadcity" ||
 		gameId == "darkfallls" ||
 		gameId == "drbohus" ||
@@ -518,6 +519,34 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		act->addDefaultInputMapping("MOUSE_WHEEL_DOWN"); // original mouse
 		act->addDefaultInputMapping("DOWN"); // extra keyboard
 		act->addDefaultInputMapping("JOY_DOWN"); // extra joy
+		gameKeyMap->addAction(act);
+	} else if (gameId == "corrosion") {
+		act = new Action(kStandardActionMoveUp, _("Walk forward"));
+		act->setCustomEngineActionEvent(kClickAtCenter);
+		act->addDefaultInputMapping("UP"); // extra keyboard
+		act->addDefaultInputMapping("KP8"); // extra keyboard
+		act->addDefaultInputMapping("JOY_UP"); // extra joy
+		gameKeyMap->addAction(act);
+
+		act = new Action(kStandardActionMoveDown, _("Walk backward"));
+		act->setCustomEngineActionEvent(kClickAtBottom);
+		act->addDefaultInputMapping("DOWN"); // extra keyboard
+		act->addDefaultInputMapping("KP2"); // extra keyboard
+		act->addDefaultInputMapping("JOY_DOWN"); // extra joy
+		gameKeyMap->addAction(act);
+
+		act = new Action(kStandardActionMoveLeft, _("Turn left"));
+		act->setCustomEngineActionEvent(kClickAtLeft);
+		act->addDefaultInputMapping("LEFT"); // extra keyboard
+		act->addDefaultInputMapping("KP4"); // extra keyboard
+		act->addDefaultInputMapping("JOY_LEFT"); // extra joy
+		gameKeyMap->addAction(act);
+
+		act = new Action(kStandardActionMoveRight, _("Turn right"));
+		act->setCustomEngineActionEvent(kClickAtRight);
+		act->addDefaultInputMapping("RIGHT"); // extra keyboard
+		act->addDefaultInputMapping("KP6"); // extra keyboard
+		act->addDefaultInputMapping("JOY_RIGHT"); // extra joy
 		gameKeyMap->addAction(act);
 	} else if (gameId == "erinmyers") {
 		act = new Action("GUIB", _("Change font size"));

--- a/engines/wintermute/platform_osystem.cpp
+++ b/engines/wintermute/platform_osystem.cpp
@@ -109,6 +109,16 @@ void BasePlatform::handleEvent(Common::Event *event) {
 			_gameRef->handleMouseWheel(event->type == Common::EVENT_WHEELUP ? 1 : -1);
 		}
 		break;
+	case Common::EVENT_CUSTOM_ENGINE_ACTION_START:
+		if (_gameRef) {
+			_gameRef->handleCustomActionStart((BaseGameCustomAction)event->customType);
+		}
+		break;
+	case Common::EVENT_CUSTOM_ENGINE_ACTION_END:
+		if (_gameRef) {
+			_gameRef->handleCustomActionEnd((BaseGameCustomAction)event->customType);
+		}
+		break;
 	case Common::EVENT_SCREEN_CHANGED:
 		if (_gameRef) {
 			_gameRef->_renderer->onWindowChange();


### PR DESCRIPTION
This implements enhancement  #11503 WME: Implement walking with arrow keys for Corrosion: https://bugs.scummvm.org/ticket/11503

 "Corrosion: Cold Winter Waiting" (both original and enchanted edition) requires a lot of walking.

However, this is originally controlled with mouse, by clicking on the edges or the center of the screen, which requires a lot of mouse moving and is not fun.

Mapping some arrow keys to mouse clicks on given regions may be a nice way to improve this game experience.