### PR TITLE
BACKENDS: Replace use of Graphics::ColorMasks

### DIFF
--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -22,7 +22,6 @@
 
 #include "backends/base-backend.h"
 #include <graphics/surface.h>
-#include <graphics/colormasks.h>
 #include <graphics/palette.h>
 #include <ronin/soundcommon.h>
 #include "backends/timer/default/default-timer.h"
@@ -160,7 +159,7 @@ public:
   void clearOverlay();
   void grabOverlay(void *buf, int pitch);
   void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
-  virtual Graphics::PixelFormat getOverlayFormat() const { return Graphics::createPixelFormat<4444>(); }
+  virtual Graphics::PixelFormat getOverlayFormat() const { return Graphics::PixelFormat(2, 4, 4, 4, 4, 8, 4, 0, 12); }
 
   // Mutex handling
   MutexRef createMutex();

--- a/backends/platform/ds/arm9/source/osystem_ds.h
+++ b/backends/platform/ds/arm9/source/osystem_ds.h
@@ -35,7 +35,6 @@
 #include "backends/saves/default/default-saves.h"
 #include "audio/mixer_intern.h"
 #include "graphics/surface.h"
-#include "graphics/colormasks.h"
 #include "graphics/palette.h"
 
 class OSystem_DS : public EventsBaseBackend, public PaletteManager {
@@ -108,7 +107,7 @@ public:
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
 	virtual int16 getOverlayHeight();
 	virtual int16 getOverlayWidth();
-	virtual Graphics::PixelFormat getOverlayFormat() const { return Graphics::createPixelFormat<1555>(); }
+	virtual Graphics::PixelFormat getOverlayFormat() const { return Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15); }
 
 	virtual bool showMouse(bool visible);
 

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -31,7 +31,6 @@
 #include "base/main.h"
 
 #include "graphics/surface.h"
-#include "graphics/colormasks.h"
 #include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 
@@ -174,7 +173,7 @@ public:
 	virtual int16 getOverlayHeight();
 	virtual int16 getOverlayWidth();
 	virtual Graphics::PixelFormat getOverlayFormat() const {
-		return Graphics::createPixelFormat<555>();
+		return Graphics::PixelFormat(2, 5, 5, 5, 0, 11, 6, 1, 0);
 	}
 
 	virtual bool showMouse(bool visible);

--- a/backends/platform/ps2/Gs2dScreen.cpp
+++ b/backends/platform/ps2/Gs2dScreen.cpp
@@ -34,7 +34,6 @@
 #include "DmaPipe.h"
 #include "GsDefs.h"
 #include "graphics/surface.h"
-#include "graphics/colormasks.h"
 #include "backends/platform/ps2/ps2debug.h"
 
 extern void *_gp;
@@ -668,7 +667,6 @@ void Gs2dScreen::hideOverlay(void) {
 
 Graphics::PixelFormat Gs2dScreen::getOverlayFormat(void) {
 	return _overlayFormat;
-	// return Graphics::createPixelFormat<1555>();
 }
 
 int16 Gs2dScreen::getOverlayWidth(void) {

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -25,7 +25,6 @@
 
 #include "common/scummsys.h"
 #include "graphics/surface.h"
-#include "graphics/colormasks.h"
 #include "graphics/palette.h"
 #include "audio/mixer_intern.h"
 #include "backends/base-backend.h"
@@ -110,7 +109,7 @@ public:
 	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
 	int16 getOverlayHeight();
 	int16 getOverlayWidth();
-	Graphics::PixelFormat getOverlayFormat() const { return Graphics::createPixelFormat<4444>(); }
+	Graphics::PixelFormat getOverlayFormat() const { return Graphics::PixelFormat(2, 4, 4, 4, 4, 0, 4, 8, 12); }
 
 	// Mouse related
 	bool showMouse(bool visible);

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -67,9 +67,9 @@ OSystem_Wii::OSystem_Wii() :
 	_configGraphicsMode(0),
 	_actualGraphicsMode(0),
 	_bilinearFilter(false),
-#ifdef USE_RGB_COLOR
 	_pfRGB565(Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0)),
 	_pfRGB3444(Graphics::PixelFormat(2, 4, 4, 4, 3, 8, 4, 0, 12)),
+#ifdef USE_RGB_COLOR
 	_pfGame(Graphics::PixelFormat::createFormatCLUT8()),
 	_pfGameTexture(Graphics::PixelFormat::createFormatCLUT8()),
 	_pfCursor(Graphics::PixelFormat::createFormatCLUT8()),

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -84,9 +84,9 @@ private:
 	s32 _configGraphicsMode;
 	s32 _actualGraphicsMode;
 	bool _bilinearFilter;
-#ifdef USE_RGB_COLOR
 	const Graphics::PixelFormat _pfRGB565;
 	const Graphics::PixelFormat _pfRGB3444;
+#ifdef USE_RGB_COLOR
 	Graphics::PixelFormat _pfGame;
 	Graphics::PixelFormat _pfGameTexture;
 	Graphics::PixelFormat _pfCursor;

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -28,7 +28,6 @@
 #include <gxflux/gfx_con.h>
 
 #include "common/config-manager.h"
-#include "graphics/colormasks.h"
 #include "graphics/conversion.h"
 #include "backends/fs/wii/wii-fs-factory.h"
 
@@ -332,7 +331,7 @@ void OSystem_Wii::setPalette(const byte *colors, uint start, uint num) {
 	u16 *d = _texGame.palette;
 
 	for (uint i = 0; i < num; ++i, s +=3)
-		d[start + i] = Graphics::RGBToColor<Graphics::ColorMasks<565> >(s[0], s[1], s[2]);
+		d[start + i] = _pfRGB565.RGBToColor(s[0], s[1], s[2]);
 
 	gfx_tex_flush_palette(&_texGame);
 
@@ -340,7 +339,7 @@ void OSystem_Wii::setPalette(const byte *colors, uint start, uint num) {
 	d = _cursorPalette;
 
 	for (uint i = 0; i < num; ++i, s += 3) {
-		d[start + i] = Graphics::ARGBToColor<Graphics::ColorMasks<3444> >(0xff, s[0], s[1], s[2]);
+		d[start + i] = _pfRGB3444.ARGBToColor(0xff, s[0], s[1], s[2]);
 	}
 
 	if (_cursorPaletteDisabled) {
@@ -363,7 +362,7 @@ void OSystem_Wii::grabPalette(byte *colors, uint start, uint num) const {
 
 	u8 r, g, b;
 	for (uint i = 0; i < num; ++i, d += 3) {
-		Graphics::colorToRGB<Graphics::ColorMasks<565> >(s[start + i], r, g, b);
+		_pfRGB565.colorToRGB(s[start + i], r, g, b);
 		d[0] = r;
 		d[1] = g;
 		d[2] = b;
@@ -392,7 +391,7 @@ void OSystem_Wii::setCursorPalette(const byte *colors, uint start, uint num) {
 	u16 *d = _texMouse.palette;
 
 	for (uint i = 0; i < num; ++i, s += 3)
-		d[start + i] = Graphics::ARGBToColor<Graphics::ColorMasks<3444> >(0xff, s[0], s[1], s[2]);
+		d[start + i] = _pfRGB3444.ARGBToColor(0xff, s[0], s[1], s[2]);
 
 	_cursorPaletteDirty = true;
 }
@@ -631,7 +630,7 @@ int16 OSystem_Wii::getOverlayHeight() {
 }
 
 Graphics::PixelFormat OSystem_Wii::getOverlayFormat() const {
-	return Graphics::createPixelFormat<3444>();
+	return _pfRGB3444;
 }
 
 bool OSystem_Wii::showMouse(bool visible) {

--- a/graphics/colormasks.h
+++ b/graphics/colormasks.h
@@ -116,18 +116,10 @@ struct ColorMasks<555> {
 		kGreenBits  = 5,
 		kBlueBits   = 5,
 
-#ifdef __N64__
-		/* Nintendo 64 uses a BGR555 color format for 16bit display */
-		kAlphaShift = 0,
-		kRedShift   = kBlueBits+kGreenBits+1,
-		kGreenShift = kBlueBits + 1,
-		kBlueShift  = 1,
-#else   /* RGB555 */
 		kAlphaShift = 0,
 		kRedShift   = kGreenBits+kBlueBits,
 		kGreenShift = kBlueBits,
 		kBlueShift  = 0,
-#endif
 
 		kAlphaMask = ((1 << kAlphaBits) - 1) << kAlphaShift,
 		kRedMask   = ((1 << kRedBits) - 1) << kRedShift,
@@ -206,17 +198,10 @@ struct ColorMasks<4444> {
 		kGreenBits  = 4,
 		kBlueBits   = 4,
 
-#ifdef __PSP__	//PSP uses ABGR
-		kAlphaShift = kRedBits+kGreenBits+kBlueBits,
-		kRedShift   = 0,
-		kGreenShift = kRedBits,
-		kBlueShift  = kRedBits+kGreenBits,
-#else		//ARGB
 		kAlphaShift = kRedBits+kGreenBits+kBlueBits,
 		kRedShift   = kGreenBits+kBlueBits,
 		kGreenShift = kBlueBits,
 		kBlueShift  = 0,
-#endif
 
 		kAlphaMask = ((1 << kAlphaBits) - 1) << kAlphaShift,
 		kRedMask   = ((1 << kRedBits) - 1) << kRedShift,

--- a/graphics/colormasks.h
+++ b/graphics/colormasks.h
@@ -302,35 +302,6 @@ struct ColorMasks<8888> {
 	typedef uint32 PixelType;
 };
 
-#ifdef __WII__
-/* Gamecube/Wii specific ColorMask ARGB3444 */
-template<>
-struct ColorMasks<3444> {
-	enum {
-		kBytesPerPixel = 2,
-
-		kAlphaBits  = 3,
-		kRedBits    = 4,
-		kGreenBits  = 4,
-		kBlueBits   = 4,
-
-		kBlueShift  = 0,
-		kGreenShift = kBlueBits,
-		kRedShift   = kGreenBits+kBlueBits,
-		kAlphaShift = kGreenBits+kBlueBits+kRedBits,
-
-		kAlphaMask = ((1 << kAlphaBits) - 1) << kAlphaShift,
-		kRedMask   = ((1 << kRedBits) - 1) << kRedShift,
-		kGreenMask = ((1 << kGreenBits) - 1) << kGreenShift,
-		kBlueMask  = ((1 << kBlueBits) - 1) << kBlueShift,
-
-		kRedBlueMask = kRedMask | kBlueMask
-	};
-
-	typedef uint16 PixelType;
-};
-#endif
-
 template<class T>
 uint32 RGBToColor(uint8 r, uint8 g, uint8 b) {
 	return T::kAlphaMask |


### PR DESCRIPTION
A number of backends use `Graphics::createPixelFormat<>()`, to specify the pixel format used by the overlay, however the GUI was rewritten to use `Graphics::PixelFormat` instead of `Graphics::ColorMasks` in commit a3516483587b736922901ae74305dcf6f043987c. Replacing this means that some of the platform-specific `ifdef`s in `graphics/colormasks.h` can be removed.

In addition, I also removed the additional use of `Graphics::ColorMasks` in the Wii backend, which means that the Wii-specific ARGB3444 ColorMask can also be removed. It's only used in `setPalette`, `grabPalette` and `setCursorPalette`, so the performance impact should be minimal.

The Dreamcast and N64 changes have not been tested. I also didn't touch the iPhone and iOS 7 backends.