### PR TITLE
KYRA/MIDI: Fix minor MT-32/GM issues

### DIFF
--- a/audio/mididrv.h
+++ b/audio/mididrv.h
@@ -125,7 +125,7 @@ public:
 	void send(int8 source, byte status, byte firstOp, byte secondOp);
 
 	/**
-	 * Transmit a sysEx to the midi device.
+	 * Transmit a SysEx to the MIDI device.
 	 *
 	 * The given msg MUST NOT contain the usual SysEx frame, i.e.
 	 * do NOT include the leading 0xF0 and the trailing 0xF7.
@@ -135,6 +135,20 @@ public:
 	 * undefined behavior (most likely, a crash).
 	 */
 	virtual void sysEx(const byte *msg, uint16 length) { }
+
+	/**
+	 * Transmit a SysEx to the MIDI device and return the necessary
+	 * delay until the next SysEx event in milliseconds.
+	 *
+	 * This can be used to implement an alternate delay method than the
+	 * OSystem::delayMillis function used by most sysEx implementations.
+	 * Note that not every driver needs a delay, or supports this method.
+	 * In this case, 0 is returned and the driver itself will do a delay 
+	 * if necessary.
+	 *
+	 * For information on the SysEx data requirements, see the sysEx method.
+	 */
+	virtual uint16 sysExNoDelay(const byte *msg, uint16 length) { sysEx(msg, length); return 0; }
 
 	// TODO: Document this.
 	virtual void metaEvent(byte type, byte *data, uint16 length) { }

--- a/audio/mididrv.h
+++ b/audio/mididrv.h
@@ -247,6 +247,8 @@ protected:
 	bool _reversePanning;
 	// True if GS percussion channel volume should be scaled to match MT-32 volume.
 	bool _scaleGSPercussionVolumeToMT32;
+	// The currently selected GS instrument bank / variation for each channel.
+	byte _gsBank[16];
 
 private:
 	// If detectDevice() detects MT32 and we have a preferred MT32 device
@@ -361,6 +363,18 @@ public:
 
 	// Does this driver accept soundFont data?
 	virtual bool acceptsSoundFontData() { return false; }
+
+protected:
+	/**
+	 * Checks if the currently selected GS bank / instrument variation
+	 * on the specified channel is valid for the specified patch.
+	 * If this is not the case, the correct bank will be returned which
+	 * can be set by sending a bank select message. If no correction is
+	 * needed, 0xFF will be returned.
+	 * This emulates the fallback functionality of the Roland SC-55 v1.2x,
+	 * on which some games rely to correct wrong bank selects.
+	 */
+	byte correctInstrumentBank(byte outputChannel, byte patchId);
 };
 
 class MidiChannel {

--- a/audio/midiparser.h
+++ b/audio/midiparser.h
@@ -276,6 +276,7 @@ protected:
 	uint32 _ppqn;           ///< Pulses Per Quarter Note. (We refer to "pulses" as "ticks".)
 	uint32 _tempo;          ///< Microseconds per quarter note.
 	uint32 _psecPerTick;  ///< Microseconds per tick (_tempo / _ppqn).
+	uint32 _sysExDelay;     ///< Number of microseconds until the next SysEx event can be sent.
 	bool   _autoLoop;       ///< For lightweight clients that don't provide their own flow control.
 	bool   _smartJump;      ///< Support smart expiration of hanging notes when jumping
 	bool   _centerPitchWheelOnUnload;  ///< Center the pitch wheels when unloading a song

--- a/audio/midiparser.h
+++ b/audio/midiparser.h
@@ -294,6 +294,7 @@ protected:
 	bool   _abortParse;    ///< If a jump or other operation interrupts parsing, flag to abort.
 	bool   _jumpingToTick; ///< True if currently inside jumpToTick
 	bool   _doParse;       ///< True if the parser should be parsing; false if it should be active
+	bool   _pause;		   ///< True if the parser has paused parsing
 
 protected:
 	static uint32 readVLQ(byte * &data);
@@ -420,6 +421,24 @@ public:
 	 * Stops playback. This resets the current playback position.
 	 */
 	void stopPlaying();
+	/**
+	 * Pauses playback and stops all active notes. Use resumePlaying to
+	 * continue playback at the current track position; startPlaying will
+	 * do nothing if the parser is paused.
+	 * stopPlaying, unloadMusic, loadMusic and setTrack will unpause the
+	 * parser. jumpToTick and jumpToIndex do nothing while the parser is
+	 * paused.
+	 * If the parser is not playing or already paused, this function does
+	 * nothing. Note that isPlaying will continue to return true while
+	 * playback is paused.
+	 * Not every parser implementation might support pausing properly.
+	 */
+	void pausePlaying();
+	/**
+	 * Resumes playback at the current track position.
+	 * If the parser is not paused, this function does nothing.
+	 */
+	void resumePlaying();
 
 	bool setTrack(int track);
 	bool jumpToTick(uint32 tick, bool fireEvents = false, bool stopNotes = true, bool dontSendNoteOn = false);

--- a/audio/midiparser_xmidi.cpp
+++ b/audio/midiparser_xmidi.cpp
@@ -140,7 +140,7 @@ bool MidiParser_XMIDI::hasJumpIndex(uint8 index) {
 }
 
 bool MidiParser_XMIDI::jumpToIndex(uint8 index, bool stopNotes) {
-	if (_activeTrack >= _numTracks)
+	if (_activeTrack >= _numTracks || _pause)
 		return false;
 
 	if (index >= MAXIMUM_TRACK_BRANCHES || _trackBranches[_activeTrack][index] == 0) {

--- a/audio/miles.h
+++ b/audio/miles.h
@@ -125,6 +125,7 @@ public:
 	void send(uint32 b) override;
 	void send(int8 source, uint32 b) override;
 	void sysEx(const byte *msg, uint16 length) override;
+	uint16 sysExNoDelay(const byte *msg, uint16 length) override;
 	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
 
 	/**

--- a/audio/miles.h
+++ b/audio/miles.h
@@ -39,6 +39,8 @@ namespace Audio {
 #define MILES_CONTROLLER_PROTECT_TIMBRE 113
 #define MILES_CONTROLLER_LOCK_CHANNEL 110
 #define MILES_CONTROLLER_PROTECT_CHANNEL 111
+#define MILES_CONTROLLER_BANK_SELECT_MSB 0
+#define MILES_CONTROLLER_BANK_SELECT_LSB 32
 #define MILES_CONTROLLER_MODULATION 1
 #define MILES_CONTROLLER_VOLUME 7
 #define MILES_CONTROLLER_EXPRESSION 11
@@ -327,7 +329,7 @@ private:
 	 * @param controlData The new program value will be set on this MidiChannelControlData
 	 * @param sendMessage True if the message should be sent out to the device
 	 */
-	void programChange(byte outputChannel, byte patchId, MidiChannelControlData &controlData, bool sendMessage);
+	void programChange(byte outputChannel, byte patchId, uint8 source, MidiChannelControlData &controlData, bool sendMessage);
 
 	void stopNotesOnChannel(uint8 outputChannelNumber);
 

--- a/audio/miles_midi.cpp
+++ b/audio/miles_midi.cpp
@@ -75,6 +75,7 @@ MidiDriver_Miles_Midi::MidiDriver_Miles_Midi(MusicType midiType, MilesMT32Instru
 		break;
 	}
 
+	memset(_gsBank, 0, sizeof(_gsBank));
 	memset(_patchesBank, 0, sizeof(_patchesBank));
 
 	_instrumentTablePtr = instrumentTablePtr;
@@ -383,7 +384,7 @@ void MidiDriver_Miles_Midi::send(int8 source, uint32 b) {
 		controlChange(outputChannel, op1, op2, source, controlData, sendMessage);
 		break;
 	case 0xc0: // Program Change
-		programChange(outputChannel, op1, controlData, sendMessage);
+		programChange(outputChannel, op1, source, controlData, sendMessage);
 		break;
 	case 0xf0: // SysEx
 		warning("MILES-MIDI: SysEx: %x", b);
@@ -469,7 +470,10 @@ void MidiDriver_Miles_Midi::controlChange(byte outputChannel, byte controllerNum
 	}
 
 	// XMIDI MT-32 SysEx controllers
-	if (_nativeMT32 && (controllerNumber >= MILES_CONTROLLER_SYSEX_RANGE_BEGIN) && (controllerNumber <= MILES_CONTROLLER_SYSEX_RANGE_END)) {
+	if (_midiType == MT_MT32 && (controllerNumber >= MILES_CONTROLLER_SYSEX_RANGE_BEGIN) && (controllerNumber <= MILES_CONTROLLER_SYSEX_RANGE_END)) {
+		if (!_nativeMT32)
+			return;
+
 		// send SysEx
 		byte sysExQueueNr = 0;
 
@@ -540,6 +544,10 @@ void MidiDriver_Miles_Midi::controlChange(byte outputChannel, byte controllerNum
 
 	// Standard MIDI controllers
 	switch (controllerNumber) {
+	case MILES_CONTROLLER_BANK_SELECT_MSB:
+		// Keep track of the current bank for each channel
+		_gsBank[outputChannel] = controllerValue;
+		break;
 	case MILES_CONTROLLER_MODULATION:
 		controlData.modulation = controllerValue;
 		break;
@@ -722,7 +730,7 @@ void MidiDriver_Miles_Midi::unlockChannel(uint8 outputChannel) {
 	if (channel.currentData.currentPatchBank != channel.unlockData.currentPatchBank)
 		controlChange(outputChannel, MILES_CONTROLLER_SELECT_PATCH_BANK, channel.unlockData.currentPatchBank, channel.currentData.source, channel.currentData, true);
 	if (channel.unlockData.program != 0xFF && (channel.currentData.program != channel.unlockData.program || channel.currentData.currentPatchBank != channel.unlockData.currentPatchBank))
-		programChange(outputChannel, channel.unlockData.program, channel.currentData, true);
+		programChange(outputChannel, channel.unlockData.program, channel.currentData.source, channel.currentData, true);
 	if (channel.currentData.pitchWheel != channel.unlockData.pitchWheel)
 		send(channel.currentData.source, 0xE0 | outputChannel, channel.unlockData.pitchWheel & 0x7F, (channel.unlockData.pitchWheel >> 7) & 0x7F);
 }
@@ -752,7 +760,7 @@ void MidiDriver_Miles_Midi::allNotesOff() {
 	}
 }
 
-void MidiDriver_Miles_Midi::programChange(byte outputChannel, byte patchId, MidiChannelControlData &controlData, bool sendMessage) {
+void MidiDriver_Miles_Midi::programChange(byte outputChannel, byte patchId, uint8 source, MidiChannelControlData &controlData, bool sendMessage) {
 	// remember patch id for the current MIDI-channel
 	controlData.program = patchId;
 
@@ -794,8 +802,15 @@ void MidiDriver_Miles_Midi::programChange(byte outputChannel, byte patchId, Midi
 		if (outputChannel == MILES_RHYTHM_CHANNEL) {
 			// Correct possible wrong GS drumkit number
 			patchId = _gsDrumkitFallbackMap[patchId];
-		}
-		else if (_nativeMT32) {
+		} else if (!_nativeMT32) {
+			// Correct possible wrong bank / instrument variation
+			byte correctedBank = correctInstrumentBank(outputChannel, patchId);
+			if (correctedBank != 0xFF) {
+				// Send out a bank select for the corrected bank number
+				controlChange(outputChannel, MILES_CONTROLLER_BANK_SELECT_MSB, correctedBank, source, controlData, sendMessage);
+				controlChange(outputChannel, MILES_CONTROLLER_BANK_SELECT_LSB, 0, source, controlData, sendMessage);
+			}
+		} else {
 			// GM on an MT-32: map the patch to the MT-32 equivalent
 			patchId = _gmToMt32[patchId];
 		}

--- a/audio/miles_midi.cpp
+++ b/audio/miles_midi.cpp
@@ -208,21 +208,28 @@ void MidiDriver_Miles_Midi::initMidiDevice() {
 }
 
 void MidiDriver_Miles_Midi::sysEx(const byte *msg, uint16 length) {
+	uint16 delay = sysExNoDelay(msg, length);
+
+	if (delay > 0)
+		g_system->delayMillis(delay);
+}
+
+uint16 MidiDriver_Miles_Midi::sysExNoDelay(const byte *msg, uint16 length) {
 	if (!_nativeMT32 && length >= 3 && msg[0] == 0x41 && msg[2] == 0x16)
 		// MT-32 SysExes have no effect on GM devices.
-		return;
+		return 0;
 
 	// Send SysEx
 	_driver->sysEx(msg, length);
 
 	// Wait the time it takes to send the SysEx data
-	uint32 delay = (length + 2) * 1000 / 3125;
+	uint16 delay = (length + 2) * 1000 / 3125;
 
 	// Plus an additional delay for the MT-32 rev00
 	if (_nativeMT32)
 		delay += 40;
 
-	g_system->delayMillis(delay);
+	return delay;
 }
 
 void MidiDriver_Miles_Midi::MT32SysEx(const uint32 targetAddress, const byte *dataPtr) {

--- a/engines/kyra/sound/sound_pc_midi.cpp
+++ b/engines/kyra/sound/sound_pc_midi.cpp
@@ -121,9 +121,10 @@ bool SoundMidiPC::init() {
 
 	_output->setTimerCallback(this, SoundMidiPC::onTimer);
 
+	// Load MT-32 and GM initialization files
+	const char* midiFile = 0;
+	const char* pakFile = 0;
 	if (_nativeMT32 && _type == kMidiMT32) {
-		const char *midiFile = 0;
-		const char *pakFile = 0;
 		if (_vm->game() == GI_KYRA1) {
 			midiFile = "INTRO";
 		} else if (_vm->game() == GI_KYRA2) {
@@ -133,7 +134,7 @@ bool SoundMidiPC::init() {
 			midiFile = "LOREINTR";
 
 			if (_vm->gameFlags().isDemo) {
-				if (_vm->gameFlags().useAltShapeHeader) {
+				if (_vm->resource()->exists("INTROVOC.PAK")) {
 					// Intro demo
 					pakFile = "INTROVOC.PAK";
 				} else {
@@ -148,26 +149,35 @@ bool SoundMidiPC::init() {
 					pakFile = "INTROVOC.PAK";
 			}
 		}
-
-		if (!midiFile)
-			return true;
-
-		if (pakFile)
-			_vm->resource()->loadPakFile(pakFile);
-
-		loadSoundFile(midiFile);
-		playTrack(0);
-
-		Common::Event event;
-		while (isPlaying() && !_vm->shouldQuit()) {
-			_vm->_system->updateScreen();
-			_vm->_eventMan->pollEvent(event);
-			_vm->_system->delayMillis(10);
+	} else if (_type == kMidiGM && _vm->game() == GI_LOL) {
+		if (_vm->gameFlags().isDemo && _vm->resource()->exists("INTROVOC.PAK")) {
+			// Intro demo
+			midiFile = "LOREINTR";
+			pakFile = "INTROVOC.PAK";
+		} else {
+			midiFile = "LOLSYSEX";
+			pakFile = "GENERAL.PAK";
 		}
-
-		if (pakFile)
-			_vm->resource()->unloadPakFile(pakFile);
 	}
+
+	if (!midiFile)
+		return true;
+
+	if (pakFile)
+		_vm->resource()->loadPakFile(pakFile);
+
+	loadSoundFile(midiFile);
+	playTrack(0);
+
+	Common::Event event;
+	while (isPlaying() && !_vm->shouldQuit()) {
+		_vm->_system->updateScreen();
+		_vm->_eventMan->pollEvent(event);
+		_vm->_system->delayMillis(10);
+	}
+
+	if (pakFile)
+		_vm->resource()->unloadPakFile(pakFile);
 
 	return true;
 }

--- a/engines/kyra/sound/sound_pc_midi.cpp
+++ b/engines/kyra/sound/sound_pc_midi.cpp
@@ -352,15 +352,15 @@ void SoundMidiPC::pause(bool paused) {
 	Common::StackLock lock(_mutex);
 
 	if (paused) {
-		_music->setMidiDriver(0);
+		_music->pausePlaying();
 		for (int i = 0; i < 3; i++)
-			_sfx[i]->setMidiDriver(0);
+			_sfx[i]->pausePlaying();
 		if (_output)
 			_output->allNotesOff();
 	} else {
-		_music->setMidiDriver(_output);
+		_music->resumePlaying();
 		for (int i = 0; i < 3; ++i)
-			_sfx[i]->setMidiDriver(_output);
+			_sfx[i]->resumePlaying();
 		// Possible TODO (IMHO unnecessary): restore notes and/or update _fadeStartTime
 	}
 }

--- a/engines/kyra/sound/sound_pc_midi.cpp
+++ b/engines/kyra/sound/sound_pc_midi.cpp
@@ -43,10 +43,12 @@ SoundMidiPC::SoundMidiPC(KyraEngine_v1 *vm, Audio::Mixer *mixer, MidiDriver *dri
 	_music = MidiParser::createParser_XMIDI(MidiParser::defaultXMidiCallback, NULL, NULL, NULL, 0);
 	assert(_music);
 	_music->property(MidiParser::mpDisableAllNotesOffMidiEvents, true);
+	_music->property(MidiParser::mpDisableAutoStartPlayback, true);
 	for (int i = 0; i < 3; ++i) {
 		_sfx[i] = MidiParser::createParser_XMIDI(MidiParser::defaultXMidiCallback, NULL, NULL, NULL, i + 1);
 		assert(_sfx[i]);
 		_sfx[i]->property(MidiParser::mpDisableAllNotesOffMidiEvents, true);
+		_sfx[i]->property(MidiParser::mpDisableAutoStartPlayback, true);
 	}
 
 	_musicVolume = _sfxVolume = 0;
@@ -248,14 +250,12 @@ void SoundMidiPC::loadSoundFile(Common::String file) {
 	_mFileName = file;
 
 	_music->loadMusic(_musicFile, fileSize);
-	_music->stopPlaying();
 
 	// Since KYRA1 uses the same file for SFX and Music
 	// we setup sfx to play from music file as well
 	if (_vm->game() == GI_KYRA1) {
 		for (int i = 0; i < 3; ++i) {
 			_sfx[i]->loadMusic(_musicFile, fileSize);
-			_sfx[i]->stopPlaying();
 		}
 	}
 }
@@ -304,6 +304,7 @@ void SoundMidiPC::playTrack(uint8 track) {
 	_output->setSourceVolume(0, _musicVolume);
 
 	_music->setTrack(track);
+	_music->startPlaying();
 }
 
 void SoundMidiPC::haltTrack() {
@@ -327,6 +328,7 @@ void SoundMidiPC::playSoundEffect(uint8 track, uint8) {
 	for (int i = 0; i < 3; ++i) {
 		if (!_sfx[i]->isPlaying()) {
 			_sfx[i]->setTrack(track);
+			_sfx[i]->startPlaying();
 			return;
 		}
 	}

--- a/engines/kyra/sound/sound_pc_midi.cpp
+++ b/engines/kyra/sound/sound_pc_midi.cpp
@@ -301,8 +301,8 @@ void SoundMidiPC::playTrack(uint8 track) {
 	
 	_output->setSourceVolume(0, _musicVolume);
 
-	_music->setTrack(track);
-	_music->startPlaying();
+	if (_music->setTrack(track))
+		_music->startPlaying();
 }
 
 void SoundMidiPC::haltTrack() {
@@ -325,8 +325,8 @@ void SoundMidiPC::playSoundEffect(uint8 track, uint8) {
 	Common::StackLock lock(_mutex);
 	for (int i = 0; i < 3; ++i) {
 		if (!_sfx[i]->isPlaying()) {
-			_sfx[i]->setTrack(track);
-			_sfx[i]->startPlaying();
+			if (_sfx[i]->setTrack(track))
+				_sfx[i]->startPlaying();
 			return;
 		}
 	}


### PR DESCRIPTION
This PR fixes a few minor issues with MIDI playback in KYRA engine games:

- SysExes embedded in MIDI files would cause an OSystem:delayMillis call, which 
would affect the timing of the MIDI parser and cause MIDI events to "pile up" 
and be executed in a shorter timespan than intended. I've changed this so the 
MIDI parser will pause playback for the necessary time between SysExes, which 
avoids this problem. This restores a sound effect after the MT-32 
initialization of Legend of Kyrandia.
- I've added the instrument fallback feature of the Roland SC-55 that corrects 
invalid bank selects. Lands of Lore depends on this in some cases, f.e. the 
sound effect of the ring in the introduction.
- Lands of Lore GM initialization was not done. These SysExes only affect the 
display of the Roland SC-55 and are not important, but it is a quite unique 
and fun feature.
- The KYRA engine games use MIDI files with multiple tracks in them. Because 
the MIDI parser would automatically start playback of the first track after 
loading the MIDI data, the engine would load the data, stop playback, then set 
the correct track and start playback. I've now made use of a recently added 
feature of the parser to disable the start of playback after loading the data, 
so that stopping playback first is no longer necessary.
- I've changed the way All Notes Off events are used by the engine. In some 
places these were sent on all channels after stopping playback of the music, 
but this risks cutting off notes of MIDI sound effects playing at the same 
time. I've added them when quitting the game.
- I've added pausing and resuming to the MIDI parser, so that the engine no 
longer needs to remove and re-add the driver to the parser when pausing the 
MIDI playback.