### PR TITLE
DIRECTOR: implement debugflag for screenshotting

### DIFF
--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -61,6 +61,7 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	DebugMan.addDebugChannel(kDebugBytecode, "bytecode", "Execute Lscr bytecode");
 	DebugMan.addDebugChannel(kDebugFewFramesOnly, "fewframesonly", "Only run the first 10 frames");
 	DebugMan.addDebugChannel(kDebugPreprocess, "preprocess", "Lingo preprocessing");
+	DebugMan.addDebugChannel(kDebugScreenshot, "screenshot", "screenshot each frame");
 
 	g_director = this;
 

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -74,7 +74,8 @@ enum {
 	kDebugNoLoop		= 1 << 10,
 	kDebugBytecode		= 1 << 11,
 	kDebugFewFramesOnly	= 1 << 12,
-	kDebugPreprocess	= 1 << 13
+	kDebugPreprocess	= 1 << 13,
+	kDebugScreenshot	= 1 << 14
 };
 
 struct MovieReference {

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -180,6 +180,7 @@ private:
 	void loadFileInfo(Common::SeekableSubReadStreamEndian &stream);
 	void loadFontMap(Common::SeekableSubReadStreamEndian &stream);
 	void dumpScript(const char *script, ScriptType type, uint16 id);
+	void screenShot();
 	Common::String getString(Common::String str);
 	Common::Array<Common::String> loadStrings(Common::SeekableSubReadStreamEndian &stream, uint32 &entryType, bool hasHeader = true);
 


### PR DESCRIPTION
It's now possible to screenshot all played frames by using:
    `--debugflags=screenshot`

Note: it's PNG.