### PR TITLE
AGI: Apple2GS: Add `Speed` menu and commands

### DIFF
--- a/engines/agi/agi.cpp
+++ b/engines/agi/agi.cpp
@@ -701,4 +701,23 @@ void AgiEngine::artificialDelayTrigger_DrawPicture(int16 newPictureNr) {
 	_artificialDelayCurrentPicture = newPictureNr;
 }
 
+void AgiGame::setAppleIIgsSpeedLevel(int i) {
+	appleIIgsSpeedLevel = i;
+	_vm->setVar(VM_VAR_WINDOW_AUTO_CLOSE_TIMER, 6);
+	switch (i) {
+	case 0:
+		_vm->_text->messageBox("Fastest speed.");
+		break;
+	case 1:
+		_vm->_text->messageBox("Fast speed.");
+		break;
+	case 2:
+		_vm->_text->messageBox("Normal speed.");
+		break;
+	case 3:
+		_vm->_text->messageBox("Slow speed.");
+		break;
+	}
+}
+
 } // End of namespace Agi

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -597,8 +597,8 @@ struct AgiGame {
 
 		automaticRestoreGame = false;
 
-		appleIIgsSpeedControllerSlot = 0xffff;
-		appleIIgsSpeedLevel = 2;  // normal
+		appleIIgsSpeedControllerSlot = 0xffff;	// we didn't add yet speed menu
+		appleIIgsSpeedLevel = 2;  // normal speed
 	}
 };
 

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -500,6 +500,11 @@ struct AgiGame {
 
 	bool automaticRestoreGame;
 
+	uint16 appleIIgsSpeedControllerSlot;
+	int appleIIgsSpeedLevel;
+
+	void setAppleIIgsSpeedLevel(int appleIIgsSpeedLevel);
+
 	AgiGame() {
 		_vm = nullptr;
 
@@ -591,6 +596,9 @@ struct AgiGame {
 		nonBlockingTextCyclesLeft = 0;
 
 		automaticRestoreGame = false;
+
+		appleIIgsSpeedControllerSlot = 0xffff;
+		appleIIgsSpeedLevel = 2;  // normal
 	}
 };
 

--- a/engines/agi/cycle.cpp
+++ b/engines/agi/cycle.cpp
@@ -415,7 +415,7 @@ int AgiEngine::playGame() {
 			if (timeDelayOverwrite >= 0) {
 				if (timeDelayOverwrite != timeDelay) {
 					// delayOverwrite is not the same as the delay taken from the scripts? overwrite it
-					warning("AppleIIgs: time delay overwrite from %d to %d", timeDelay, timeDelayOverwrite);
+					//warning("AppleIIgs: time delay overwrite from %d to %d", timeDelay, timeDelayOverwrite);
 
 					setVar(VM_VAR_TIME_DELAY, timeDelayOverwrite - 1); // adjust for Apple IIgs
 					timeDelay = timeDelayOverwrite;

--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -191,6 +191,16 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 		}
 	},
 
+	{
+		GAMEOPTION_APPLE2GS_ADD_SPEED_MENU,
+		{
+			_s("Add speed menu"),
+			_s("Add game speed menu (similar to PC version)"),
+			"apple2gs_speedmenu",
+			false
+		}
+	},
+
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -27,10 +27,12 @@ namespace Agi {
 #define GAMEOPTION_DISABLE_MOUSE              GUIO_GAMEOPTIONS3
 #define GAMEOPTION_USE_HERCULES_FONT          GUIO_GAMEOPTIONS4
 #define GAMEOPTION_COMMAND_PROMPT_WINDOW      GUIO_GAMEOPTIONS5
-// TODO: properly implement GAMEOPTIONs
+#define GAMEOPTION_APPLE2GS_ADD_SPEED_MENU    GUIO_GAMEOPTIONS6
+	// TODO: properly implement GAMEOPTIONs
 
 #define GAMEOPTIONS_DEFAULT                   GUIO4(GAMEOPTION_ORIGINAL_SAVELOAD,GAMEOPTION_DISABLE_MOUSE,GAMEOPTION_USE_HERCULES_FONT,GAMEOPTION_COMMAND_PROMPT_WINDOW)
 #define GAMEOPTIONS_AMIGA                     GUIO4(GAMEOPTION_ORIGINAL_SAVELOAD,GAMEOPTION_AMIGA_ALTERNATIVE_PALETTE,GAMEOPTION_USE_HERCULES_FONT,GAMEOPTION_COMMAND_PROMPT_WINDOW)
+#define GAMEOPTIONS_APPLE2GS                  GUIO5(GAMEOPTION_ORIGINAL_SAVELOAD,GAMEOPTION_DISABLE_MOUSE,GAMEOPTION_USE_HERCULES_FONT,GAMEOPTION_COMMAND_PROMPT_WINDOW, GAMEOPTION_APPLE2GS_ADD_SPEED_MENU)
 #define GAMEOPTIONS_FANMADE_MOUSE             GUIO3(GAMEOPTION_ORIGINAL_SAVELOAD,GAMEOPTION_USE_HERCULES_FONT,GAMEOPTION_COMMAND_PROMPT_WINDOW)
 
 #define GAME_LVFPN(id,extra,fname,md5,size,lang,ver,features,gid,platform,interp,guioptions) { \
@@ -420,7 +422,7 @@ static const AGIGameDescription gameDescriptions[] = {
 
 	// King's Quest 4 (IIgs) 1.0K 11/22/88 (CE)
 	// Menus not tested
-	GAME3_P("kq4", "1.0K 1988-11-22", "kq4dir", "8536859331159f15012e35dc82cb154e", 0x3086, 0, GID_KQ4, Common::kPlatformApple2GS),
+	GAME3_PO("kq4", "1.0K 1988-11-22", "kq4dir", "8536859331159f15012e35dc82cb154e", 0x3086, 0, GID_KQ4, Common::kPlatformApple2GS, GAMEOPTIONS_APPLE2GS),
 
 	// King's Quest 4 demo (PC) [AGI 3.002.102]
 	// Menus not tested
@@ -523,13 +525,13 @@ static const AGIGameDescription gameDescriptions[] = {
 	GAME_P("pq1", "2.0G 1987-12-03", "805750b66c1c5b88a214e67bfdca17a1", 0x2440, GID_PQ1, Common::kPlatformMacintosh),
 
 	// Police Quest 1 (IIgs) 2.0B-88421
-	GAME_P("pq1", "2.0B 1988-04-21", "e7c175918372336461e3811d594f482f", 0x2917, GID_PQ1, Common::kPlatformApple2GS),
+	GAME_PO("pq1", "2.0B 1988-04-21", "e7c175918372336461e3811d594f482f", 0x2917, GID_PQ1, Common::kPlatformApple2GS, GAMEOPTIONS_APPLE2GS),
 
 	// Police Quest 1 (Amiga) 2.0B 2/22/89  # 2.310
 	GAME3_PSO("pq1", "2.0B 1989-02-22", "dirs", "cfa93e5f2aa7378bddd10ad6746a2ffb", 1613, 0x3149, 0, GID_PQ1, Common::kPlatformAmiga, GAMEOPTIONS_AMIGA),
 
 	// Police Quest 1 (IIgs) 2.0A-88318
-	GAME_P("pq1", "2.0A 1988-03-18", "8994e39d0901de3d07cecfb954075bb5", 0x2917, GID_PQ1, Common::kPlatformApple2GS),
+	GAME_PO("pq1", "2.0A 1988-03-18", "8994e39d0901de3d07cecfb954075bb5", 0x2917, GID_PQ1, Common::kPlatformApple2GS, GAMEOPTIONS_APPLE2GS),
 
 	// Police Quest 1 (PC) 2.0A 10/23/87 [AGI 2.903/2.911]
 	GAME("pq1", "2.0A 1987-10-23", "b9dbb305092851da5e34d6a9f00240b1", 0x2917, GID_PQ1),
@@ -602,7 +604,7 @@ static const AGIGameDescription gameDescriptions[] = {
 	// The SQ2 IIgs AGI definitely has 177 kernel functions, but it seems that Sierra shuffled the last few around / added a few extras at the end.
 	// For KQ3 set.pri.base is called with parameters that seem to be sound resources, which means
 	// set.pri.base was possibly discard.sound. For KQ4 onwards it seems this was cleaned up.
-	GAME_P("sq2", "2.0A 1988-07-25 (CE)", "5dfdac98dd3c01fcfb166529f917e911", 0x2917, GID_SQ2, Common::kPlatformApple2GS),
+	GAME_PO("sq2", "2.0A 1988-07-25 (CE)", "5dfdac98dd3c01fcfb166529f917e911", 0x2917, GID_SQ2, Common::kPlatformApple2GS, GAMEOPTIONS_APPLE2GS),
 
 	{
 		// Space Quest 2 (Amiga) 2.0F

--- a/engines/agi/menu.cpp
+++ b/engines/agi/menu.cpp
@@ -152,6 +152,28 @@ void GfxMenu::submit() {
 	if ((_array.size() == 0) || (_itemArray.size() == 0))
 		return;
 
+	// WORKAROUND: For Apple II gs we add a Speed menu
+	if (_vm->getPlatform() == Common::kPlatformApple2GS) {
+		uint16 maxControllerSlot = 0;
+		for (GuiMenuItemArray::iterator menuIter = _itemArray.begin(); menuIter != _itemArray.end(); ++menuIter)
+			if ((*menuIter)->controllerSlot > maxControllerSlot)
+				maxControllerSlot = (*menuIter)->controllerSlot;
+		for (uint16 curMapping = 0; curMapping < MAX_CONTROLLER_KEYMAPPINGS; curMapping++)
+			if (_vm->_game.controllerKeyMapping[curMapping].controllerSlot > maxControllerSlot)
+				maxControllerSlot = _vm->_game.controllerKeyMapping[curMapping].controllerSlot;
+
+		if (maxControllerSlot >= 0xff - 4)
+			warning("GfxMenu::submit : failed to add 'Speed' menu");
+		else {
+			_vm->_game.appleIIgsSpeedControllerSlot = maxControllerSlot + 1;
+			addMenu("Speed");
+			addMenuItem("Normal", _vm->_game.appleIIgsSpeedControllerSlot + 2);
+			addMenuItem("Slow", _vm->_game.appleIIgsSpeedControllerSlot + 3);
+			addMenuItem("Fast", _vm->_game.appleIIgsSpeedControllerSlot + 1);
+			addMenuItem("Fastest", _vm->_game.appleIIgsSpeedControllerSlot + 0);
+		}
+	}
+
 	_submitted = true;
 
 	// WORKAROUND: For Apple II gs we try to fix the menu text

--- a/engines/agi/menu.cpp
+++ b/engines/agi/menu.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include "common/config-manager.h"
+
 #include "agi/agi.h"
 #include "agi/graphics.h"
 #include "agi/text.h"
@@ -153,7 +155,7 @@ void GfxMenu::submit() {
 		return;
 
 	// WORKAROUND: For Apple II gs we add a Speed menu
-	if (_vm->getPlatform() == Common::kPlatformApple2GS) {
+	if (_vm->getPlatform() == Common::kPlatformApple2GS && ConfMan.getBool("apple2gs_speedmenu")) {
 		uint16 maxControllerSlot = 0;
 		for (GuiMenuItemArray::iterator menuIter = _itemArray.begin(); menuIter != _itemArray.end(); ++menuIter)
 			if ((*menuIter)->controllerSlot > maxControllerSlot)

--- a/engines/agi/words.cpp
+++ b/engines/agi/words.cpp
@@ -320,6 +320,27 @@ void Words::parseUsingDictionary(const char *rawUserInput) {
 	userInputLen = userInput.size();
 	userInputPtr = userInput.c_str();
 
+	// WORKAROUND: For Apple II support speed changes
+	// some of the games hadn't this feature
+	// some (like PQ1) had it, but we override the speed that the game request
+	// with `timeDelayOverwrite`
+	// this mechanism works for all the games, and therefore, doesn't bother to search in the dictionary
+	if (_vm->getPlatform() == Common::kPlatformApple2GS) {
+		if (userInput.equals("fastest")) {
+			_vm->_game.setAppleIIgsSpeedLevel(0);
+			return;
+		} else if (userInput.equals("fast")) {
+			_vm->_game.setAppleIIgsSpeedLevel(1);
+			return;
+		} else if (userInput.equals("normal")) {
+			_vm->_game.setAppleIIgsSpeedLevel(2);
+			return;
+		} else if (userInput.equals("slow")) {
+			_vm->_game.setAppleIIgsSpeedLevel(3);
+			return;
+		}
+	}
+
 	while (userInputPos < userInputLen) {
 		// Skip trailing space
 		if (userInput[userInputPos] == ' ')


### PR DESCRIPTION
Following the suggestion at https://bugs.scummvm.org/ticket/7026, added a `Speed` menu to Apple2GS AGI games.
This menu is configurable, and can be disabled.
The speed can also be changed by text parser commands.
`Normal` speed is as before, with the speed set by the apple2gs workaround mechanism that was added in the past to solve sound issues.
Other speeds are used only if there isn't a specific workaround speed for that room.

Edit
====
It's disabled by default.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
