### PR TITLE
WINTERMUTE: Improve keyboard walking for Corrosion

### DIFF
--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -3791,6 +3791,13 @@ bool BaseGame::handleCustomActionStart(BaseGameCustomAction action) {
 	if (BaseEngine::instance().getGameId() == "corrosion") {
 		// Keyboark walking is added, for both original game & Enchanced Edition
 
+		// However, Enchanced Edition contain city map screen, which is
+		// mouse controlled and conflicts with those custom actions
+		const char *m = "items\\street_map\\windows\\street_map_window.script";
+		if (_scEngine->isRunningScript(m)) {
+			return false;
+		}
+
 		Point32 p;
 		switch (action) {
 		case kClickAtCenter:

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -3789,9 +3789,9 @@ bool BaseGame::handleMouseWheel(int32 delta) {
 //////////////////////////////////////////////////////////////////////////
 bool BaseGame::handleCustomActionStart(BaseGameCustomAction action) {
 	if (BaseEngine::instance().getGameId() == "corrosion") {
-		// Keyboark walking is added, for both original game & Enchanced Edition
+		// Keyboard walking is added, for both original game & Enhanced Edition
 
-		// However, Enchanced Edition contain city map screen, which is
+		// However, Enhanced Edition contain city map screen, which is
 		// mouse controlled and conflicts with those custom actions
 		const char *m = "items\\street_map\\windows\\street_map_window.script";
 		if (_scEngine->isRunningScript(m)) {

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -3788,52 +3788,48 @@ bool BaseGame::handleMouseWheel(int32 delta) {
 
 //////////////////////////////////////////////////////////////////////////
 bool BaseGame::handleCustomActionStart(BaseGameCustomAction action) {
-	Point32 p;
+	if (BaseEngine::instance().getGameId() == "corrosion") {
+		// Keyboark walking is added, for both original game & Enchanced Edition
 
-	switch (action) {
-	case kClickAtCenter:
-		p.x = _renderer->getWidth() / 2;
-		p.y = _renderer->getHeight() / 2;
-		break;
-	case kClickAtLeft:
-		p.x = 30;
-		p.y = _renderer->getHeight() / 2;
-		break;
-	case kClickAtRight:
-		p.x = _renderer->getWidth() - 30;
-		p.y = _renderer->getHeight() / 2;
-		break;
-	case kClickAtTop:
-		p.x = _renderer->getWidth() / 2;
-		p.y = 10;
-		break;
-	case kClickAtBottom:
-		p.x = _renderer->getWidth() / 2;
-		p.y = _renderer->getHeight() - 35;
-		break;
-	default:
-		return false;
+		Point32 p;
+		switch (action) {
+		case kClickAtCenter:
+			p.x = _renderer->getWidth() / 2;
+			p.y = _renderer->getHeight() / 2;
+			break;
+		case kClickAtLeft:
+			p.x = 30;
+			p.y = _renderer->getHeight() / 2;
+			break;
+		case kClickAtRight:
+			p.x = _renderer->getWidth() - 30;
+			p.y = _renderer->getHeight() / 2;
+			break;
+		case kClickAtTop:
+			p.x = _renderer->getWidth() / 2;
+			p.y = 10;
+			break;
+		case kClickAtBottom:
+			p.x = _renderer->getWidth() / 2;
+			p.y = _renderer->getHeight();
+			p.y -= ConfMan.get("extra").contains("Enhanced") ? 35 : 90;
+			break;
+		default:
+			return false;
+		}
+
+		BasePlatform::setCursorPos(p.x, p.y);
+		setActiveObject(_gameRef->_renderer->getObjectAt(p.x, p.y)); 
+		onMouseLeftDown();
+		onMouseLeftUp();
+		return true;
 	}
 
-	BasePlatform::setCursorPos(p.x, p.y);
-	setActiveObject(_gameRef->_renderer->getObjectAt(p.x, p.y)); 
-
-	return onMouseLeftDown();
+	return false;
 }
 
 //////////////////////////////////////////////////////////////////////////
 bool BaseGame::handleCustomActionEnd(BaseGameCustomAction action) {
-	switch (action) {
-	case kClickAtCenter:
-	case kClickAtLeft:
-	case kClickAtRight:
-	case kClickAtTop:
-	case kClickAtBottom:
-		return onMouseLeftUp();
-	default:
-		break;
-	}
-
 	return false;
 }
 

--- a/engines/wintermute/base/scriptables/script_engine.cpp
+++ b/engines/wintermute/base/scriptables/script_engine.cpp
@@ -185,6 +185,17 @@ ScScript *ScEngine::runScript(const char *filename, BaseScriptHolder *owner) {
 
 
 //////////////////////////////////////////////////////////////////////////
+bool ScEngine::isRunningScript(const char *filename) {
+	for (uint32 i = 0; i < _scripts.size(); i++) {
+		if (strcmp(_scripts[i]->_filename, filename) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+//////////////////////////////////////////////////////////////////////////
 byte *ScEngine::getCompiledScript(const char *filename, uint32 *outSize, bool ignoreCache) {
 	// is script in cache?
 	if (!ignoreCache) {

--- a/engines/wintermute/base/scriptables/script_engine.h
+++ b/engines/wintermute/base/scriptables/script_engine.h
@@ -86,6 +86,7 @@ public:
 	bool tick();
 	ScValue *_globals;
 	ScScript *runScript(const char *filename, BaseScriptHolder *owner = nullptr);
+	bool isRunningScript(const char *filename);
 	static const bool _compilerAvailable = false;
 
 	ScEngine(BaseGame *inGame);


### PR DESCRIPTION
Previous PR was completed too soon.
1. Added if-statement & comment to state that those custom actions are currently for Corrosion only
2. Fixed kClickAtBottom offset for original game
3. Fixed stuck-at-map buug for Enchanted Edition 