### PR TITLE
MIDI: Fix _gsBank init and bad if statement

### DIFF
--- a/audio/mididrv.cpp
+++ b/audio/mididrv.cpp
@@ -696,8 +696,7 @@ byte MidiDriver::correctInstrumentBank(byte outputChannel, byte patchId) {
 	default:
 		// The other instruments only have a capital tone. Bank selects
 		// 1-63 are corrected to the capital tone.
-		if (_gsBank[outputChannel] >= 0)
-			correctedBank = 0;
+		correctedBank = 0;
 		break;
 	}
 

--- a/audio/mididrv.h
+++ b/audio/mididrv.h
@@ -260,7 +260,9 @@ private:
 
 public:
 	MidiDriver() : _reversePanning(false),
-					_scaleGSPercussionVolumeToMT32(false) { }
+					_scaleGSPercussionVolumeToMT32(false) {
+		memset(_gsBank, 0, sizeof(_gsBank));
+	}
 	virtual ~MidiDriver() { }
 
 	static const byte _mt32ToGm[128];


### PR DESCRIPTION
Fixes a missing variable initialization and unnecessary if statement introduced by 
my latest KYRA changes.