### PR TITLE
WINTERMUTE: Theora and BaseFileManager::hasFile residualvm fixes

### DIFF
--- a/engines/wintermute/base/base_file_manager.cpp
+++ b/engines/wintermute/base/base_file_manager.cpp
@@ -34,6 +34,7 @@
 #include "engines/wintermute/base/file/base_package.h"
 #include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/wintermute.h"
+#include "common/algorithm.h"
 #include "common/debug.h"
 #include "common/str.h"
 #include "common/tokenizer.h"
@@ -372,6 +373,10 @@ uint32 BaseFileManager::getPackageVersion(const Common::String &filename) {
 
 //////////////////////////////////////////////////////////////////////////
 bool BaseFileManager::hasFile(const Common::String &filename) {
+	Common::String backwardSlashesPath = filename;
+	// correct slashes
+	Common::replace(backwardSlashesPath.begin(), backwardSlashesPath.end(), '/', '\\');
+
 	if (scumm_strnicmp(filename.c_str(), "savegame:", 9) == 0) {
 		BasePersistenceManager pm(BaseEngine::instance().getGameTargetName());
 		if (filename.size() <= 9) {
@@ -386,7 +391,7 @@ bool BaseFileManager::hasFile(const Common::String &filename) {
 	if (diskFileExists(filename)) {
 		return true;
 	}
-	if (_packages.hasFile(filename)) {
+	if (_packages.hasFile(backwardSlashesPath)) {
 		return true;    // We don't bother checking if the file can actually be opened, something bigger is wrong if that is the case.
 	}
 	if (!_detectionMode && _resources->hasFile(filename)) {

--- a/engines/wintermute/video/video_theora_player.cpp
+++ b/engines/wintermute/video/video_theora_player.cpp
@@ -30,7 +30,7 @@
 #include "engines/wintermute/video/video_theora_player.h"
 #include "engines/wintermute/base/base_game.h"
 #include "engines/wintermute/base/base_file_manager.h"
-#include "engines/wintermute/base/gfx/osystem/base_surface_osystem.h"
+#include "engines/wintermute/base/gfx/base_surface.h"
 #include "engines/wintermute/base/gfx/base_image.h"
 #include "engines/wintermute/base/gfx/base_renderer.h"
 #include "engines/wintermute/base/sound/base_sound_manager.h"
@@ -143,7 +143,7 @@ bool VideoTheoraPlayer::initialize(const Common::String &filename, const Common:
 
 	// Additional setup.
 	_surface.create(_theoraDecoder->getWidth(), _theoraDecoder->getHeight(), _theoraDecoder->getPixelFormat());
-	_texture = new BaseSurfaceOSystem(_gameRef);
+	_texture = _gameRef->_renderer->createSurface();
 	_texture->create(_theoraDecoder->getWidth(), _theoraDecoder->getHeight());
 	_state = THEORA_STATE_PLAYING;
 	_playZoom = 100;


### PR DESCRIPTION
Some things that popped up during implementing the WIntermute 3D port in ResidualVM.

The theora video player should use the appropriate factory method to create a surface instead of constructing it directly.

The file manager changes forward to backward slashes when opening files from a dcp package. However, when it's only looking for a file, slashes are not flipped, which is inconsistent and causes bugs in Alpha Polaris.