### PR TITLE
DEVTOOLS: Unhardcode scummvm-name in create_project for XCode.

### DIFF
--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -745,7 +745,7 @@ void XcodeProvider::setupProject() {
 
 	Object *project = new Object(this, "PBXProject", "PBXProject", "PBXProject", "", "Project object");
 
-	project->addProperty("buildConfigurationList", getHash("XCConfigurationList_scummvm"), "Build configuration list for PBXProject \"" PROJECT_NAME "\"", kSettingsNoValue);
+	project->addProperty("buildConfigurationList", getHash("XCConfigurationList_" PROJECT_NAME), "Build configuration list for PBXProject \"" PROJECT_NAME "\"", kSettingsNoValue);
 	project->addProperty("compatibilityVersion", "Xcode 3.2", "", kSettingsNoValue | kSettingsQuoteVariable);
 	project->addProperty("developmentRegion", "English", "", kSettingsNoValue);
 	project->addProperty("hasScannedForEncodings", "1", "", kSettingsNoValue);


### PR DESCRIPTION
The existing code broke create_project in ResidualVM, as
the loop that creates the actual build configurations
generated the hash from the actual object name, which
for ResidualVM would be XCConfigurationList_residualvm.

The same logic was not applied when generating the reference,
as that would use the hardcoded name XCConfigurationList_scummvm.

This patch makes a minimal fix for that, by using the
PROJECT_NAME define instead of the hardcoded name.