### PR TITLE
BUILD: Support building Android on OSX

### DIFF
--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -1,5 +1,4 @@
 # Android specific build targets
-
 PATH_DIST = $(srcdir)/dists/android
 
 PORT_DISTFILES = $(PATH_DIST)/README.Android
@@ -9,6 +8,7 @@ GRADLE_FILES = $(shell find $(PATH_DIST)/gradle -type f) $(PATH_DIST)/gradlew $(
 PATH_BUILD = ./android_project
 PATH_BUILD_GRADLE = $(PATH_BUILD)/build.gradle
 PATH_BUILD_ASSETS = $(PATH_BUILD)/assets
+PATH_BUILD_LIB = $(PATH_BUILD)/lib/$(ABI)
 PATH_BUILD_LIBSCUMMVM = $(PATH_BUILD)/lib/$(ABI)/libscummvm.so
 
 APK_MAIN = ScummVM-debug.apk
@@ -18,7 +18,7 @@ $(PATH_BUILD):
 	$(MKDIR) $(PATH_BUILD)
 
 $(PATH_BUILD_GRADLE): $(GRADLE_FILES) | $(PATH_BUILD)
-	$(CP) -r $(PATH_DIST)/gradle/ $(PATH_BUILD)
+	$(CP) -r $(PATH_DIST)/gradle/ $(PATH_BUILD)/gradle/
 	$(INSTALL) -c -m 755 $(PATH_DIST)/gradlew $(PATH_BUILD)
 	$(INSTALL) -c -m 644 $(PATH_DIST)/build.gradle $(PATH_BUILD)
 	$(ECHO) "srcdir=$(realpath $(srcdir))" > $(PATH_BUILD)/gradle.properties
@@ -30,7 +30,8 @@ $(PATH_BUILD_ASSETS): $(DIST_FILES_THEMES) $(DIST_FILES_ENGINEDATA) $(DIST_FILES
 	$(INSTALL) -c -m 644 $(DIST_FILES_THEMES) $(DIST_FILES_ENGINEDATA) $(DIST_FILES_NETWORKING) $(DIST_FILES_VKEYBD) $(DIST_FILES_DOCS) $(PORT_DISTFILES) $(PATH_BUILD_ASSETS)/
 
 $(PATH_BUILD_LIBSCUMMVM): libscummvm.so | $(PATH_BUILD)
-	$(INSTALL) -D -c -m 644 libscummvm.so $(PATH_BUILD_LIBSCUMMVM)
+	$(INSTALL) -d  $(PATH_BUILD_LIB)
+	$(INSTALL) -c -m 644 libscummvm.so $(PATH_BUILD_LIBSCUMMVM)
 
 $(APK_MAIN): $(PATH_BUILD_GRADLE) $(PATH_BUILD_ASSETS) $(PATH_BUILD_LIBSCUMMVM) | $(PATH_BUILD)
 	(cd $(PATH_BUILD); ./gradlew assembleDebug)

--- a/configure
+++ b/configure
@@ -1985,8 +1985,29 @@ esac
 
 # Toolchain for Android is in NDK and is using different naming convention
 if test "$_host_os" = android; then
-	# Try to use a known to work (on linux) toolchain
-	_android_toolchain="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64"
+	
+	# Check that we have the correct NDK version
+	echo_n "Checking NDK version... "
+	_ndk_gradle=$(grep "^[[:space:]]*ndkVersion" dists/android/build.gradle | sed 's/[^0-9\.]//g')
+	_ndk_version=$(grep "Pkg.Revision" $ANDROID_NDK_ROOT/source.properties | sed 's/[^0-9\.]//g' | sed 's/.//')
+	if test "$_ndk_version" = "$_ndk_gradle"; then
+		echo "$_ndk_version"
+	else
+		echo "$_ndk_version (Expected $_ndk_gradle)"
+		exit 1
+	fi
+
+	# Try to use a known to work toolchain
+	android_toolchains="windows-x86_64 darwin-x86_64 linux-x86_64"	
+	for toolchain in $android_toolchains; do 
+		_android_toolchain="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$toolchain"
+
+		if test -d "$_android_toolchain"; then
+			break
+		fi
+	done
+
+	# See if an explicit toolchain is used
 	if test -n "$ANDROID_TOOLCHAIN"; then
 		_android_toolchain="$ANDROID_TOOLCHAIN"
 	fi


### PR DESCRIPTION
BUILD: Support building Android on OSX

Updated the build files to enable Android compilation on OSX, and remove the NDK version from the env var.

Can someone on Linux make sure nothing broke there? 