### PR TITLE
GLK: ZCODE: Fix moving cursor in TextGridWindow

### DIFF
--- a/engines/glk/zcode/windows.cpp
+++ b/engines/glk/zcode/windows.cpp
@@ -228,8 +228,8 @@ void Window::setCursor(const Point &newPos) {
 
 void Window::setCursor() {
 	if (dynamic_cast<TextGridWindow *>(_win)) {
-		g_vm->glk_window_move_cursor(_win, (_properties[X_CURSOR] - 1) / g_vm->h_font_width,
-			(_properties[Y_CURSOR] - 1) / g_vm->h_font_height);
+		g_vm->glk_window_move_cursor(_win, (_properties[X_CURSOR] - 1),
+			(_properties[Y_CURSOR] - 1));
 	}
 }
 


### PR DESCRIPTION
Currently Beyond Zork does not display correctly. It appears that the text is not correctly placed in the Text Grid Window. I don't know if this is the correct change, but just removing the division by the font width and height in `Glk:ZCode::Window::setCursor()` seems to fix the issue. I have not tested with any other games though.

Here are comparaison between current master with and without this change.

Copyright screen without the change:
![image](https://user-images.githubusercontent.com/552105/85964212-ac0ae800-b9b0-11ea-8303-64e04243e05a.png)

And with the change:
![image](https://user-images.githubusercontent.com/552105/85964230-bb8a3100-b9b0-11ea-838a-68dab8cbfd51.png)

Character setup without the change:
![image](https://user-images.githubusercontent.com/552105/85964158-76fe9580-b9b0-11ea-8ab2-dc38f781d2dd.png)

And with the change:
![image](https://user-images.githubusercontent.com/552105/85964191-9d243580-b9b0-11ea-9b08-0cb552cd0685.png)

Hilltop without the change:
![image](https://user-images.githubusercontent.com/552105/85964269-e6748500-b9b0-11ea-8b33-13dadfe0c060.png)

And with the change:
![image](https://user-images.githubusercontent.com/552105/85964281-eeccc000-b9b0-11ea-8a4a-d8202dceecd9.png)