### PR TITLE
DIRECTOR: LINGO: implement scummvmAssert

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -256,6 +256,11 @@ static struct BuiltinProto {
 	{ "lastLineOf",		LB::b_lastlineof,	1, 1, false, 4, FBLTIN },	//			D4 f
 	{ "lastWordOf",		LB::b_lastwordof,	1, 1, false, 4, FBLTIN },	//			D4 f
 
+	//scummVM Asserts: Used for testing scummvm's lingo implementation
+	{ "scummvmAssert",	LB::b_scummvmassert,1, 1, true,  2, FBLTIN },
+	{ "scummvmAssertEqual",	LB::b_scummvmassertequal,2,2,true,2,FBLTIN },
+
+
 	{ 0, 0, 0, 0, false, 0, 0 }
 };
 
@@ -2287,6 +2292,28 @@ void LB::b_lastwordof(int nargs) {
 	warning("STUB: b_lastwordof");
 
 	g_lingo->push(Datum(0));
+}
+
+void LB::b_scummvmassert(int nargs) {
+	Datum d = g_lingo->pop();
+
+	if (d.asInt() != 1) {
+		warning("LB::b_scummvmassert: is false");
+	}
+	assert(d.asInt() == 1);
+	g_lingo->push(d);
+}
+
+void LB::b_scummvmassertequal(int nargs) {
+	Datum d1 = g_lingo->pop();
+	Datum d2 = g_lingo->pop();
+
+	int result = d1.equalTo(d2);
+	if (!result) {
+		warning("LB::b_scummvmassertequals: is false");
+	}
+	assert(result == 1);
+	g_lingo->push(Datum(result));
 }
 
 } // End of namespace Director

--- a/engines/director/lingo/lingo-builtins.h
+++ b/engines/director/lingo/lingo-builtins.h
@@ -202,6 +202,9 @@ namespace LB {
 	void b_lastlineof(int nargs);
 	void b_lastwordof(int nargs);
 
+	void b_scummvmassert(int nargs);
+	void b_scummvmassertequal(int nargs);
+
 } // End of namespace LB
 
 } // End of namespace Director

--- a/engines/director/lingo/tests/strings.lingo
+++ b/engines/director/lingo/tests/strings.lingo
@@ -3,19 +3,24 @@ set z1 = z & " meow"
 set z1 = z1 && "woof"
 put z
 put z1
-put chars("Macromedia", 6, 6)
-put chars("Macromedia", 6, 10)
-put chars("Macromedia", -1, 15)
-if z1 contains "MeÍW" then
-	put "Contains"
-else
-	put "Doesn't contain"
-end if
+set c = chars("Macromedia", 6, 6)
+scummvmAssertEqual(c, "m")
+set c = chars("Macromedia", 6, 10)
+scummvmAssertEqual(c, "media")
+set c = chars("Macromedia", -1, 15)
+scummvmAssertEqual(c, "Macromedia")
+
+set x to z1 contains "bar"
+scummvmAssert(x)
+
+set x to z1 contains "MeÍW"
+scummvmAssert(x)
+
+set x to FALSE
 if "meow" = "MeÍW" then
-	put "Equals"
-else
-	put "Doesn't equal"
+    set x = TRUE
 end if
+scummvmAssert(x)
 
 put "That is the last line of the file." & return & "Click Done to exit." && return && "foo"
 


### PR DESCRIPTION
scummvmAssert is a scummvm specific Lingo function.
Useful for getting feedback on lingo code tests without
having to check if the output is as expected.

Example:

    set x = True
    scummvmAssert(x)    // will pass

    set x = False
    scummvmAssert(x)    // will fail

The core of the implementation is: `assert(d.asInt() == 1)`.
It's defined as a Lingo builtin function for D2.

strings.lingo has been modified to leverage the new scummvmAssert.