### PR TITLE
WINTERMUTE: Add move keymaps and improve keyboard movement

### DIFF
--- a/engines/wintermute/ad/ad_game.cpp
+++ b/engines/wintermute/ad/ad_game.cpp
@@ -61,6 +61,7 @@
 #include "engines/wintermute/video/video_player.h"
 #include "engines/wintermute/video/video_theora_player.h"
 #include "engines/wintermute/platform_osystem.h"
+#include "common/config-manager.h"
 #include "common/str.h"
 
 namespace Wintermute {
@@ -1529,6 +1530,75 @@ bool AdGame::scheduleChangeScene(const char *filename, bool fadeIn) {
 
 		return STATUS_OK;
 	}
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+bool AdGame::handleCustomActionStart(BaseGameCustomAction action) {
+	bool isCorrosion = BaseEngine::instance().getGameId() == "corrosion";
+	
+	if (isCorrosion) {
+		// Corrosion Enhanced Edition contain city map screen, which is
+		// mouse controlled and conflicts with those custom actions
+		const char *m = "items\\street_map\\windows\\street_map_window.script";
+		if (_scEngine->isRunningScript(m)) {
+			return false;
+		}
+	}
+
+	int xLeft   = 30;
+	int xCenter = _renderer->getWidth() / 2;
+	int xRight  = _renderer->getWidth() - 30;
+
+	int yTop    = 35;
+	int yCenter = _renderer->getHeight() / 2;
+	int yBottom = _renderer->getHeight() - 35;
+	if (isCorrosion && !(ConfMan.get("extra").contains("Enhanced"))) {
+		// original version of Corrosion has a toolbar under the game screen
+		yBottom -= 60;
+	}
+
+	BaseArray<AdObject *> objects;
+
+	Point32 p;
+	int distance = xCenter * xCenter + yCenter * yCenter;
+
+	switch (action) {
+	case kClickAtCenter:
+		p.x = xCenter;
+		p.y = yCenter;
+		break;
+	case kClickAtLeft:
+		p.x = xLeft;
+		p.y = yCenter;
+		break;
+	case kClickAtRight:
+		p.x = xRight;
+		p.y = yCenter;
+		break;
+	case kClickAtTop:
+		p.x = xCenter;
+		p.y = yTop;
+		break;
+	case kClickAtBottom:
+		p.x = xCenter;
+		p.y = yBottom;
+		break;
+	default:
+		return false;
+	}
+
+	BasePlatform::setCursorPos(p.x, p.y);
+	setActiveObject(_gameRef->_renderer->getObjectAt(p.x, p.y)); 
+	onMouseLeftDown();
+	onMouseLeftUp();
+	return true;
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+bool AdGame::handleCustomActionEnd(BaseGameCustomAction action) {
+	return false;
 }
 
 

--- a/engines/wintermute/ad/ad_game.h
+++ b/engines/wintermute/ad/ad_game.h
@@ -52,6 +52,9 @@ public:
 	bool onMouseRightDown() override;
 	bool onMouseRightUp() override;
 
+	bool handleCustomActionStart(BaseGameCustomAction action) override;
+	bool handleCustomActionEnd(BaseGameCustomAction action) override;
+
 	bool displayDebugInfo() override;
 
 	bool addSpeechDir(const char *dir);

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -3788,50 +3788,6 @@ bool BaseGame::handleMouseWheel(int32 delta) {
 
 //////////////////////////////////////////////////////////////////////////
 bool BaseGame::handleCustomActionStart(BaseGameCustomAction action) {
-	if (BaseEngine::instance().getGameId() == "corrosion") {
-		// Keyboard walking is added, for both original game & Enhanced Edition
-
-		// However, Enhanced Edition contain city map screen, which is
-		// mouse controlled and conflicts with those custom actions
-		const char *m = "items\\street_map\\windows\\street_map_window.script";
-		if (_scEngine->isRunningScript(m)) {
-			return false;
-		}
-
-		Point32 p;
-		switch (action) {
-		case kClickAtCenter:
-			p.x = _renderer->getWidth() / 2;
-			p.y = _renderer->getHeight() / 2;
-			break;
-		case kClickAtLeft:
-			p.x = 30;
-			p.y = _renderer->getHeight() / 2;
-			break;
-		case kClickAtRight:
-			p.x = _renderer->getWidth() - 30;
-			p.y = _renderer->getHeight() / 2;
-			break;
-		case kClickAtTop:
-			p.x = _renderer->getWidth() / 2;
-			p.y = 10;
-			break;
-		case kClickAtBottom:
-			p.x = _renderer->getWidth() / 2;
-			p.y = _renderer->getHeight();
-			p.y -= ConfMan.get("extra").contains("Enhanced") ? 35 : 90;
-			break;
-		default:
-			return false;
-		}
-
-		BasePlatform::setCursorPos(p.x, p.y);
-		setActiveObject(_gameRef->_renderer->getObjectAt(p.x, p.y)); 
-		onMouseLeftDown();
-		onMouseLeftUp();
-		return true;
-	}
-
 	return false;
 }
 

--- a/engines/wintermute/base/base_game.h
+++ b/engines/wintermute/base/base_game.h
@@ -203,8 +203,8 @@ public:
 
 	bool handleKeypress(Common::Event *event, bool printable = false) override;
 	virtual void handleKeyRelease(Common::Event *event);
-	bool handleCustomActionStart(BaseGameCustomAction action);
-	bool handleCustomActionEnd(BaseGameCustomAction action);
+	virtual bool handleCustomActionStart(BaseGameCustomAction action);
+	virtual bool handleCustomActionEnd(BaseGameCustomAction action);
 
 	bool unfreeze();
 	bool freeze(bool includingMusic = true);

--- a/engines/wintermute/base/base_game_custom_actions.h
+++ b/engines/wintermute/base/base_game_custom_actions.h
@@ -36,7 +36,8 @@ enum BaseGameCustomAction {
 	kClickAtLeft = 1,
 	kClickAtRight = 2,
 	kClickAtTop = 3,
-	kClickAtBottom = 4
+	kClickAtBottom = 4,
+	kClickAtEntityNearestToCenter = 5
 };
 
 } // End of namespace Wintermute

--- a/engines/wintermute/keymapper_tables.h
+++ b/engines/wintermute/keymapper_tables.h
@@ -72,7 +72,11 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		gameId == "agustin" ||
 		gameId == "bickadoodle" ||
 		gameId == "bthreshold" ||
+		gameId == "carolreed6" ||
+		gameId == "carolreed7" ||
+		gameId == "carolreed8" ||
 		gameId == "colorsoncanvas" ||
+		gameId == "corrosion" ||
 		gameId == "deadcity" ||
 		gameId == "darkfallls" ||
 		gameId == "drbohus" ||
@@ -86,6 +90,7 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		gameId == "hamlet" ||
 		gameId == "hor" ||
 		gameId == "juliauntold" ||
+		gameId == "lifein3minutes" ||
 		gameId == "lonelyrobot" ||
 		gameId == "machumayu" ||
 		gameId == "mirage" ||
@@ -213,6 +218,10 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		act->addDefaultInputMapping("JOY_Y"); // extra joy
 		gameKeyMap->addAction(act);
 	} else if (gameId == "drdoylemotch" ||
+		gameId == "carolreed9" ||
+		gameId == "carolreed10" ||
+		gameId == "carolreed11" ||
+		gameId == "carolreed12" ||
 		gameId == "kulivocko" ||
 		gameId == "rebeccacarlson1"
 	) {
@@ -517,6 +526,13 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		act->addDefaultInputMapping("MOUSE_WHEEL_DOWN"); // original mouse
 		act->addDefaultInputMapping("PAGEDOWN"); // extra keyboard
 		//TODO: extra joy control, e.g. "JOY_R+JOY_DOWN"
+		gameKeyMap->addAction(act);
+	} else if (gameId == "carolreed5") {
+		act = new Action("HINT", _("Show hints"));
+		act->setKeyEvent(KeyState(KEYCODE_TAB, ASCII_TAB));
+		act->addDefaultInputMapping("TAB"); // original keyboard
+		act->addDefaultInputMapping("MOUSE_MIDDLE"); // extra mouse
+		act->addDefaultInputMapping("JOY_Y"); // extra joy
 		gameKeyMap->addAction(act);
 	} else if (gameId == "erinmyers") {
 		act = new Action("GUIB", _("Change font size"));

--- a/engines/wintermute/keymapper_tables.h
+++ b/engines/wintermute/keymapper_tables.h
@@ -508,15 +508,15 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		act = new Action("VOLMAX", _("Volume max"));
 		act->setMouseWheelUpEvent();
 		act->addDefaultInputMapping("MOUSE_WHEEL_UP"); // original mouse
-		act->addDefaultInputMapping("UP"); // extra keyboard
-		act->addDefaultInputMapping("JOY_UP"); // extra joy
+		act->addDefaultInputMapping("PAGEUP"); // extra keyboard
+		//TODO: extra joy control, e.g. "JOY_R+JOY_UP"
 		gameKeyMap->addAction(act);
 
 		act = new Action("VOLOFF", _("Volume off"));
 		act->setMouseWheelDownEvent();
 		act->addDefaultInputMapping("MOUSE_WHEEL_DOWN"); // original mouse
-		act->addDefaultInputMapping("DOWN"); // extra keyboard
-		act->addDefaultInputMapping("JOY_DOWN"); // extra joy
+		act->addDefaultInputMapping("PAGEDOWN"); // extra keyboard
+		//TODO: extra joy control, e.g. "JOY_R+JOY_DOWN"
 		gameKeyMap->addAction(act);
 	} else if (gameId == "erinmyers") {
 		act = new Action("GUIB", _("Change font size"));

--- a/engines/wintermute/keymapper_tables.h
+++ b/engines/wintermute/keymapper_tables.h
@@ -35,6 +35,8 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 	using namespace Common;
 
 	Keymap *engineKeyMap = new Keymap(Keymap::kKeymapTypeGame, "wintermute", "Wintermute engine");
+	Keymap *gameKeyMap = new Keymap(Keymap::kKeymapTypeGame, gameId, gameDescr);
+	Keymap *extraKeyMap = new Keymap(Keymap::kKeymapTypeGame, "extras", "ScummVM extra actions");
 
 	Action *act;
 
@@ -102,12 +104,8 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		gameId == "tradestory" ||
 		gameId == "wmedemo"
 	) {
-		return Keymap::arrayOf(engineKeyMap);
-	}
-
-	Keymap *gameKeyMap = new Keymap(Keymap::kKeymapTypeGame, gameId, gameDescr);
-
-	if (gameId == "dfafadventure" ||
+		/* no game-specific keymap */
+	} else if (gameId == "dfafadventure" ||
 		gameId == "dreamcat" ||
 		gameId == "openquest"
 	) {
@@ -519,34 +517,6 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		act->addDefaultInputMapping("MOUSE_WHEEL_DOWN"); // original mouse
 		act->addDefaultInputMapping("DOWN"); // extra keyboard
 		act->addDefaultInputMapping("JOY_DOWN"); // extra joy
-		gameKeyMap->addAction(act);
-	} else if (gameId == "corrosion") {
-		act = new Action(kStandardActionMoveUp, _("Walk forward"));
-		act->setCustomEngineActionEvent(kClickAtCenter);
-		act->addDefaultInputMapping("UP"); // extra keyboard
-		act->addDefaultInputMapping("KP8"); // extra keyboard
-		act->addDefaultInputMapping("JOY_UP"); // extra joy
-		gameKeyMap->addAction(act);
-
-		act = new Action(kStandardActionMoveDown, _("Walk backward"));
-		act->setCustomEngineActionEvent(kClickAtBottom);
-		act->addDefaultInputMapping("DOWN"); // extra keyboard
-		act->addDefaultInputMapping("KP2"); // extra keyboard
-		act->addDefaultInputMapping("JOY_DOWN"); // extra joy
-		gameKeyMap->addAction(act);
-
-		act = new Action(kStandardActionMoveLeft, _("Turn left"));
-		act->setCustomEngineActionEvent(kClickAtLeft);
-		act->addDefaultInputMapping("LEFT"); // extra keyboard
-		act->addDefaultInputMapping("KP4"); // extra keyboard
-		act->addDefaultInputMapping("JOY_LEFT"); // extra joy
-		gameKeyMap->addAction(act);
-
-		act = new Action(kStandardActionMoveRight, _("Turn right"));
-		act->setCustomEngineActionEvent(kClickAtRight);
-		act->addDefaultInputMapping("RIGHT"); // extra keyboard
-		act->addDefaultInputMapping("KP6"); // extra keyboard
-		act->addDefaultInputMapping("JOY_RIGHT"); // extra joy
 		gameKeyMap->addAction(act);
 	} else if (gameId == "erinmyers") {
 		act = new Action("GUIB", _("Change font size"));
@@ -1542,8 +1512,39 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		act->addDefaultInputMapping("TAB"); // original keyboard
 		gameKeyMap->addAction(act);
 	}
-
 	result.push_back(gameKeyMap);
+
+	if (gameId == "corrosion") {
+		act = new Action(kStandardActionMoveUp, _("Walk forward"));
+		act->setCustomEngineActionEvent(kClickAtCenter);
+		act->addDefaultInputMapping("UP"); // extra keyboard
+		act->addDefaultInputMapping("KP5"); // extra keyboard
+		act->addDefaultInputMapping("JOY_UP"); // extra joy
+		extraKeyMap->addAction(act);
+	
+		act = new Action(kStandardActionMoveDown, _("Walk backward"));
+		act->setCustomEngineActionEvent(kClickAtBottom);
+		act->addDefaultInputMapping("DOWN"); // extra keyboard
+		act->addDefaultInputMapping("KP2"); // extra keyboard
+		act->addDefaultInputMapping("JOY_DOWN"); // extra joy
+		extraKeyMap->addAction(act);
+	
+		act = new Action(kStandardActionMoveLeft, _("Turn left"));
+		act->setCustomEngineActionEvent(kClickAtLeft);
+		act->addDefaultInputMapping("LEFT"); // extra keyboard
+		act->addDefaultInputMapping("KP4"); // extra keyboard
+		act->addDefaultInputMapping("JOY_LEFT"); // extra joy
+		extraKeyMap->addAction(act);
+
+		act = new Action(kStandardActionMoveRight, _("Turn right"));
+		act->setCustomEngineActionEvent(kClickAtRight);
+		act->addDefaultInputMapping("RIGHT"); // extra keyboard
+		act->addDefaultInputMapping("KP6"); // extra keyboard
+		act->addDefaultInputMapping("JOY_RIGHT"); // extra joy
+		extraKeyMap->addAction(act);
+	}
+	result.push_back(extraKeyMap);
+	
 	return result;
 
 }

--- a/engines/wintermute/keymapper_tables.h
+++ b/engines/wintermute/keymapper_tables.h
@@ -1530,7 +1530,19 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 	}
 	result.push_back(gameKeyMap);
 
-	if (gameId == "corrosion") {
+
+	if (gameId == "carolreed4" ||
+		gameId == "carolreed5" ||
+		gameId == "carolreed6" ||
+		gameId == "carolreed7" ||
+		gameId == "carolreed8" ||
+		gameId == "carolreed9" ||
+		gameId == "carolreed10" ||
+		gameId == "carolreed11" ||
+		gameId == "carolreed12" ||
+		gameId == "corrosion" ||
+		gameId == "rebeccacarlson1"
+	) {
 		act = new Action(kStandardActionMoveUp, _("Walk forward"));
 		act->setCustomEngineActionEvent(kClickAtEntityNearestToCenter);
 		act->addDefaultInputMapping("UP"); // extra keyboard

--- a/engines/wintermute/keymapper_tables.h
+++ b/engines/wintermute/keymapper_tables.h
@@ -1516,7 +1516,7 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 
 	if (gameId == "corrosion") {
 		act = new Action(kStandardActionMoveUp, _("Walk forward"));
-		act->setCustomEngineActionEvent(kClickAtCenter);
+		act->setCustomEngineActionEvent(kClickAtEntityNearestToCenter);
 		act->addDefaultInputMapping("UP"); // extra keyboard
 		act->addDefaultInputMapping("KP5"); // extra keyboard
 		act->addDefaultInputMapping("JOY_UP"); // extra joy


### PR DESCRIPTION
1. Added keymaps for Carol Reed 5-12 and Life in 3 minutes
2. Keyboard movement added to 10 more 1st person WME2D games!
3. Keyboard movement now use "smart" forward key, which clicks on object closest to screen center (useful for opening doors, picking the only one object on the screen, etc)
4. Carol Reed 4 keymap is tweaked to avoid using up/down keys and joy controls.
