### PR TITLE
DOXYGEN: Add doxygen groups to header files in the common folder

### DIFF
--- a/common/achievements.h
+++ b/common/achievements.h
@@ -31,6 +31,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_achieve Achievements
+ * @ingroup common
+ *
+ * @brief API related to in-game achievements.
+ *
+ * @{
+ */
+
+/**
  * List of game achievements provider platforms.
  * Possible candidates are XBOX Gamerscore, PSN Trophies, Kongregate Badges, etc...
  */
@@ -96,6 +105,7 @@ private:
 /** Shortcut for accessing the achievements manager. */
 #define AchMan Common::AchievementsManager::instance()
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/algorithm.h
+++ b/common/algorithm.h
@@ -30,6 +30,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_alg Algorithms
+ * @ingroup common
+ *
+ * @brief Templates for algorithms used to manipulate data.
+ *
+ * @{
+ */
+
+/**
  * Copies data from the range [first, last) to [dst, dst + (last - first)).
  * It requires the range [dst, dst + (last - first)) to be valid.
  * It also requires dst not to be in the range [first, last).
@@ -308,5 +317,9 @@ void replace(It begin, It end, const Dat &original, const Dat &replaced) {
     }
 }
 
+/** @} */
+
+
 } // End of namespace Common
+
 #endif

--- a/common/archive.h
+++ b/common/archive.h
@@ -30,6 +30,18 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_arch Archive
+ * @ingroup common
+ *
+ * @brief  The Archive module allows managing the member of arbitrary containers in a uniform
+ * fashion. 
+ * It also supports looking up by names and file names, opening a file, and returning usable input stream.
+ *
+ * @{
+ */
+
+
 class FSNode;
 class SeekableReadStream;
 
@@ -275,6 +287,8 @@ private:
 
 /** Shortcut for accessing the search manager. */
 #define SearchMan		Common::SearchManager::instance()
+
+/** @} */
 
 } // namespace Common
 

--- a/common/array.h
+++ b/common/array.h
@@ -31,6 +31,16 @@
 namespace Common {
 
 /**
+ * @defgroup common_array Arrays
+ * @ingroup common
+ *
+ * @brief  Functions for working on arrays.
+ *
+ * @{
+ */
+
+
+/**
  * This class implements a dynamically sized container, which
  * can be accessed similar to a regular C++ array. Accessing
  * elements is performed in constant time (like with plain arrays).
@@ -455,6 +465,8 @@ private:
 
 	Comparator _comparator;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/bitstream.h
+++ b/common/bitstream.h
@@ -34,6 +34,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_bitstream Bit stream
+ * @ingroup common
+ *
+ * @brief  API for implementing a bit stream.
+ *
+ * @{
+ */
+
+/**
  * A template implementing a bit stream for different data memory layouts.
  *
  * Such a bit stream reads valueBits-wide values from the data stream and
@@ -470,6 +479,7 @@ typedef BitStreamImpl<BitStreamMemoryStream, 32, false, true > BitStreamMemory32
 /** 32-bit big-endian data, LSB to MSB. */
 typedef BitStreamImpl<BitStreamMemoryStream, 32, false, false> BitStreamMemory32BELSB;
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/bufferedstream.h
+++ b/common/bufferedstream.h
@@ -29,6 +29,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_buffstream Buffered stream
+ * @ingroup common
+ *
+ * @brief  API for implementing a buffered stream.
+ *
+ * @{
+ */
+
+/**
  * Take an arbitrary ReadStream and wrap it in a custom stream which
  * transparently provides buffering.
  * Users can specify how big the buffer should be, and whether the wrapped
@@ -60,6 +69,8 @@ SeekableReadStream *wrapBufferedSeekableReadStream(SeekableReadStream *parentStr
  * returned).
  */
 WriteStream *wrapBufferedWriteStream(WriteStream *parentStream, uint32 bufSize);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/callback.h
+++ b/common/callback.h
@@ -26,6 +26,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_callback Callbacks
+ * @ingroup common
+ *
+ * @brief  Callback templates.
+ *
+ * @{
+ */
+
+/**
  * BaseCallback<S> is a simple base class for object-oriented callbacks.
  *
  * Object-oriented callbacks are such callbacks that know exact instance
@@ -132,6 +141,8 @@ public:
 	virtual ~CallbackBridge() {}
 	void operator()(S data) { (_object->*_method)(_outerCallback, data); }
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/config-manager.h
+++ b/common/config-manager.h
@@ -31,6 +31,16 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_config Configuration manager
+ * @ingroup common
+ *
+ * @brief  The (singleton) configuration manager, used to query & set configuration
+ *         values using string keys.
+ *
+ * @{
+ */
+
 class WriteStream;
 class SeekableReadStream;
 
@@ -206,6 +216,8 @@ private:
 
 	String			_filename;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/coroutines.h
+++ b/common/coroutines.h
@@ -31,14 +31,16 @@
 namespace Common {
 
 /**
- * @defgroup Coroutine support for simulating multi-threading.
+ * @defgroup common_coroutine Coroutine support for simulating multi-threading
+ * @ingroup common
  *
- * The following is loosely based on an article by Simon Tatham:
- *   <http://www.chiark.greenend.org.uk/~sgtatham/coroutines.html>.
- * However, many improvements and tweaks have been made, in particular
- * by taking advantage of C++ features not available in C.
+ * @brief  The following implementation is loosely based on an article by Simon Tatham:
+ *         @linkCoroutine.
+ *         However, many improvements and tweaks have been made, in particular
+ *         by taking advantage of C++ features not available in C.
+ *
+ * @{
  */
-//@{
 
 #define CoroScheduler (Common::CoroutineScheduler::instance())
 
@@ -555,7 +557,7 @@ public:
 	void pulseEvent(uint32 pidEvent);
 };
 
-//@}
+/** @} */
 
 } // end of namespace Common
 

--- a/common/cosinetables.h
+++ b/common/cosinetables.h
@@ -25,6 +25,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_cosinetables Cosine tables
+ * @ingroup common
+ *
+ * @brief  Functions for working with cosine tables.
+ *
+ * @{
+ */
+
 class CosineTable {
 public:
 	/**
@@ -68,6 +77,8 @@ private:
 	int _refSize; // _nPoints / 4
 	int _nPoints; // range of operator[]
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/dcl.h
+++ b/common/dcl.h
@@ -21,12 +21,8 @@
  */
 
 /**
- * @file
- * PKWARE DCL ("explode") ("PKWARE data compression library") decompressor used in engines:
- * - agos (exclusively for Simon 2 setup.shr file)
- * - mohawk
- * - neverhood
- * - sci
+ * 
+
  */
 
 #ifndef COMMON_DCL_H
@@ -36,6 +32,21 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_dcl Data compression library
+ * @ingroup common
+ *
+ * @brief  PKWARE data compression library.
+ *
+ * @details PKWARE DCL ("explode") ("PKWARE data compression library") decompressor used in engines:
+ *          - agos (exclusively for Simon 2 setup.shr file)
+ *          - mohawk
+ *          - neverhood
+ *          - sci
+ *
+ * @{
+ */
+ 
 class ReadStream;
 class SeekableReadStream;
 
@@ -56,6 +67,8 @@ SeekableReadStream *decompressDCL(SeekableReadStream *sourceStream, uint32 packe
  * if successful and 0 otherwise. This method is meant for cases, where the unpacked size is not known.
  */
 SeekableReadStream *decompressDCL(SeekableReadStream *sourceStream);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/dct.h
+++ b/common/dct.h
@@ -38,6 +38,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_dct Discrete Cosine Transforms
+ * @ingroup common
+ *
+ * @brief  Discrete Cosine Transforms.
+ *
+ * @{
+ */
+
+/**
  * (Inverse) Discrete Cosine Transforms.
  *
  * Used in engines:
@@ -73,6 +82,8 @@ private:
 	void calcDCTIII(float *data);
 	void calcDSTI  (float *data);
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/debug-channels.h
+++ b/common/debug-channels.h
@@ -34,6 +34,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_debug_channels Debug channels
+ * @ingroup common_debug
+ *
+ * @brief  Functions for managing debug channels.
+ *
+ * @{
+ */
+
 // TODO: Find a better name for this
 class DebugManager : public Singleton<DebugManager> {
 public:
@@ -147,6 +156,8 @@ private:
 
 /** Shortcut for accessing the debug manager. */
 #define DebugMan		Common::DebugManager::instance()
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/debug.h
+++ b/common/debug.h
@@ -38,6 +38,14 @@ inline void debugCN(uint32 debugChannels, const char *s, ...) {}
 
 #else
 
+/**
+ * @defgroup common_debug Debug functions
+ * @ingroup common
+ *
+ * @brief  Debug functions.
+ *
+ * @{
+ */
 
 /**
  * Print a debug message to the text console (stdout).
@@ -143,5 +151,7 @@ extern bool gDebugChannelsOnly;
 enum GlobalDebugLevels {
 	kDebugLevelEventRec = 1 << 30
 };
+
+/** @} */
 
 #endif

--- a/common/dialogs.h
+++ b/common/dialogs.h
@@ -34,6 +34,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_dialogs Dialog Manager
+ * @ingroup common
+ *
+ * @brief  The Dialog Manager allows GUI code to interact with native system dialogs.
+ *
+ * @{
+ */
+
+/**
  * The DialogManager allows GUI code to interact with native system dialogs.
  */
 class DialogManager {
@@ -96,6 +105,8 @@ protected:
 		}
 	}
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/encoding.h
+++ b/common/encoding.h
@@ -31,6 +31,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_encoding Text encoding
+ * @ingroup common
+ *
+ * @brief  Functions for managing text encoding.
+ *
+ * @{
+ */
+
+/**
  * A class, that allows conversion between different text encoding,
  * the encodings available depend on the current backend and if the
  * ScummVM is compiled with or without iconv.
@@ -212,6 +221,8 @@ class Encoding {
 		 */
 		static uint32 *transliterateUTF32(const uint32 *string, size_t length);
 };
+
+/** @} */
 
 }
 

--- a/common/endian.h
+++ b/common/endian.h
@@ -25,10 +25,14 @@
 
 #include "common/scummsys.h"
 
+
 /**
- *  \file endian.h
- *  Endian conversion and byteswap conversion functions or macros
+ * @defgroup common_endian Endian conversions
+ * @ingroup common
  *
+ * @brief  Endian conversion and byteswap conversion functions and macros.
+ *
+ * @details 
  *  SWAP_BYTES_??(a)      - inverse byte order
  *  SWAP_CONSTANT_??(a)   - inverse byte order, implemented as macro.
  *                              Use with compiletime-constants only, the result will be a compiletime-constant aswell.
@@ -42,6 +46,8 @@
  *  CONSTANT_??_??(a)     - convert LE/BE value v to native, implemented as macro.
  *                              Use with compiletime-constants only, the result will be a compiletime-constant aswell.
  *                              Unlike most other functions these can be used for eg. switch-case labels
+ *
+ * @{
  */
 
 // Sanity check
@@ -631,5 +637,7 @@ inline int32 READ_BE_INT32(const void *ptr) {
 inline void WRITE_BE_INT32(void *ptr, int32 value) {
 	WRITE_BE_UINT32(ptr, static_cast<uint32>(value));
 }
+
+/** @} */
 
 #endif

--- a/common/error.h
+++ b/common/error.h
@@ -28,10 +28,13 @@
 namespace Common {
 
 /**
- * This file contains an enum with commonly used error codes.
+ * @defgroup common_error Error codes
+ * @ingroup common
+ *
+ * @brief  Commonly used error codes.
+ *
+ * @{
  */
-
-
 
 /**
  * Error codes which may be reported by plugins under various circumstances.
@@ -102,6 +105,8 @@ public:
 	 */
 	ErrorCode getCode() const { return _code; }
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/events.h
+++ b/common/events.h
@@ -34,14 +34,18 @@
 namespace Common {
 
 /**
- * The types of events backends may generate.
- * @see Event
+ * @defgroup common_events Events
+ * @ingroup common
+ *
+ * @brief  The types of events backends may generate.
  *
  * @todo Merge EVENT_LBUTTONDOWN, EVENT_RBUTTONDOWN and EVENT_WHEELDOWN;
  *       likewise EVENT_LBUTTONUP, EVENT_RBUTTONUP, EVENT_WHEELUP.
  *       To do that, we just have to add a field to the Event which
  *       indicates which button was pressed.
+ * @{
  */
+
 enum EventType {
 	EVENT_INVALID = 0,
 	/** A key was pressed, details in Event::kbd. */
@@ -547,6 +551,8 @@ protected:
  * Does not take ownership of the wrapped EventSource.
  */
 EventSource *makeKeyboardRepeatingEventSource(EventSource *eventSource);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/fft.h
+++ b/common/fft.h
@@ -34,10 +34,19 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_fft Fast Fourier Transform (FFT)
+ * @ingroup common
+ *
+ * @brief  API for the FFT algorithm.
+ *
+ * @{
+ */
+
 class CosineTable;
 
 /**
- * (Inverse) Fast Fourier Transform.
+ * (Inverse) Fast Fourier Transform
  *
  * Used in engines:
  *  - scumm
@@ -79,6 +88,8 @@ private:
 	void fft16(Complex *z);
 	void fft(int n, int logn, Complex *z);
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/file.h
+++ b/common/file.h
@@ -31,6 +31,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_files Files
+ * @ingroup common
+ *
+ * @brief  API for operations on files.
+ *
+ * @{
+ */
+
 class Archive;
 
 /**
@@ -167,6 +176,8 @@ public:
 	virtual bool seek(int32 offset, int whence = SEEK_SET) override;
 	virtual int32 size() const override;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/frac.h
+++ b/common/frac.h
@@ -26,6 +26,15 @@
 #include "common/scummsys.h"
 
 /**
+ * @defgroup common_frac Fixed-point fractions
+ * @ingroup common
+ *
+ * @brief  API for fixed-point fractions.
+ *
+ * @{
+ */
+
+/**
  * The precision of the fractional (fixed point) type we define below.
  * Normally you should never have to modify this value.
  */
@@ -48,5 +57,7 @@ inline double fracToDouble(frac_t value) { return ((double)value) / FRAC_ONE; }
 
 inline frac_t intToFrac(int16 value) { return value * (1 << FRAC_BITS); }
 inline int16 fracToInt(frac_t value) { return value / (1 << FRAC_BITS); }
+
+/** @} */
 
 #endif

--- a/common/fs.h
+++ b/common/fs.h
@@ -34,6 +34,15 @@ class AbstractFSNode;
 
 namespace Common {
 
+/**
+ * @defgroup common_fs File system
+ * @ingroup common
+ *
+ * @brief API for operations on the file system.
+ *
+ * @{
+ */
+
 class FSNode;
 class SeekableReadStream;
 class WriteStream;
@@ -371,6 +380,7 @@ public:
 	virtual SeekableReadStream *createReadStreamForMember(const String &name) const;
 };
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/func.h
+++ b/common/func.h
@@ -28,6 +28,16 @@
 namespace Common {
 
 /**
+ * @defgroup common_func Functions
+ * @ingroup common
+ *
+ * @brief API for managing functions.
+ *
+ * @{
+ */
+
+
+/**
  * Generic unary function.
  */
 template<class Arg, class Result>
@@ -535,6 +545,8 @@ GENERATE_TRIVIAL_HASH_FUNCTOR(unsigned int);
 GENERATE_TRIVIAL_HASH_FUNCTOR(unsigned long);
 
 #undef GENERATE_TRIVIAL_HASH_FUNCTOR
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -95,6 +95,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_gui_options GUI options
+ * @ingroup common
+ *
+ * @brief API for managing the options of the graphical user interface (GUI).
+ *
+ * @{
+ */
+
 class String;
 
 bool checkGameGUIOption(const String &option, const String &str);
@@ -108,6 +117,7 @@ const String getGameGUIOptionsDescription(const String &options);
  */
 void updateGameGUIOptions(const String &options, const String &langOption);
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/hash-ptr.h
+++ b/common/hash-ptr.h
@@ -28,6 +28,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_hashmap_ptr Hash table pointer
+ * @ingroup common_hashmap
+ *
+ * @brief Template for a HashMap pointer.
+ *
+ * @{
+ */
+
+/**
  * Partial specialization of the Hash functor to be able to use pointers as HashMap keys
  */
 template<typename T>
@@ -37,6 +46,8 @@ struct Hash<T *> {
 		return x + (x >> 3);
 	}
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -57,6 +57,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_hashmap Hash table (HashMap)
+ * @ingroup common
+ *
+ * @brief API for operations on a hash table.
+ *
+ * @{
+ */
+
 // The sgi IRIX MIPSpro Compiler has difficulties with nested templates.
 // This and the other __sgi conditionals below work around these problems.
 // The Intel C++ Compiler suffers from the same problems.
@@ -623,6 +632,8 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::erase(const Key &key) {
 }
 
 #undef HASHMAP_DUMMY_NODE
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/huffman.h
+++ b/common/huffman.h
@@ -31,6 +31,18 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_huffmann Huffman bitstream decoding
+ * @ingroup common
+ *
+ * @brief API for operations related to Huffman bitstream decoding.
+ * 
+ * @details Used in engines:
+ *          - scumm
+ *		
+ * @{
+ */
+
 inline uint32 REVERSEBITS(uint32 x) {
 	x = (((x & ~0x55555555) >> 1) | ((x & 0x55555555) << 1));
 	x = (((x & ~0x33333333) >> 2) | ((x & 0x33333333) << 2));
@@ -43,8 +55,6 @@ inline uint32 REVERSEBITS(uint32 x) {
 /**
  * Huffman bitstream decoding
  *
- * Used in engines:
- *  - scumm
  */
 template<class BITSTREAM>
 class Huffman {
@@ -158,6 +168,8 @@ uint32 Huffman<BITSTREAM>::getSymbol(BITSTREAM &bits) const {
 	error("Unknown Huffman code");
 	return 0;
 }
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/iff_container.h
+++ b/common/iff_container.h
@@ -31,6 +31,16 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_iff Interchange File Format (IFF)
+ * @ingroup common
+ *
+ * @brief API for operations on IFF container files.
+ *
+ *		
+ * @{
+ */
+
 typedef uint32 IFF_ID;
 
 #define ID_FORM     MKTAG('F','O','R','M')
@@ -264,6 +274,8 @@ public:
 
 	uint32 read(void *dataPtr, uint32 dataSize);
 };
+
+/** @} */
 
 } // namespace Common
 

--- a/common/ini-file.h
+++ b/common/ini-file.h
@@ -29,6 +29,16 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_ini_file INI files
+ * @ingroup common
+ *
+ * @brief API for operations on INI configuration files.
+ *
+ *		
+ * @{
+ */
+
 class SeekableReadStream;
 class WriteStream;
 
@@ -127,6 +137,8 @@ private:
 	Section *getSection(const String &section);
 	const Section *getSection(const String &section) const;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/installshield_cab.h
+++ b/common/installshield_cab.h
@@ -27,6 +27,16 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_installshield InstallShield
+ * @ingroup common
+ *
+ * @brief API for managing the InstallShield.
+ *
+ *		
+ * @{
+ */
+
 class Archive;
 class SeekableReadStream;
 
@@ -37,6 +47,8 @@ class SeekableReadStream;
  * May return 0 in case of a failure.
  */
 Archive *makeInstallShieldArchive(SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse = DisposeAfterUse::YES);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/keyboard.h
+++ b/common/keyboard.h
@@ -36,6 +36,16 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_keyboard Keyboard
+ * @ingroup common
+ *
+ * @brief API for keyboard operations.
+ *
+ *		
+ * @{
+ */
+
 enum KeyCode {
 	KEYCODE_INVALID     = 0,
 
@@ -355,6 +365,8 @@ struct KeyState {
 		return keycode == x.keycode && hasFlags(x.flags & ~KBD_STICKY);
 	}
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/language.h
+++ b/common/language.h
@@ -27,6 +27,16 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_language Language
+ * @ingroup common
+ *
+ * @brief API for managing game language.
+ *
+ *		
+ * @{
+ */
+
 class String;
 
 /**
@@ -92,6 +102,8 @@ const String getGameGUIOptionsDescriptionLanguage(Common::Language lang);
 
 // TODO: Document this GUIO related function
 bool checkGameGUIOptionLanguage(Common::Language lang, const String &str);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/list.h
+++ b/common/list.h
@@ -28,6 +28,16 @@
 namespace Common {
 
 /**
+ * @defgroup common_list Lists
+ * @ingroup common
+ *
+ * @brief API and templates for managing lists.
+ *
+ *		
+ * @{
+ */
+
+/**
  * Simple double linked list, modeled after the list template of the standard
  * C++ library.
  */
@@ -254,6 +264,8 @@ protected:
 		newNode->_next->_prev = newNode;
 	}
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/localization.h
+++ b/common/localization.h
@@ -29,6 +29,16 @@
 namespace Common {
 
 /**
+ * @defgroup common_localization Localization
+ * @ingroup common
+ *
+ * @brief Functions for managing localized elements of the GUI.
+ *
+ *		
+ * @{
+ */
+
+/**
  * Get localized equivalents for Y/N buttons of the specified language. In
  * case there is no specialized keys for the given language it will fall back
  * to the English keys.
@@ -47,6 +57,8 @@ void getLanguageYesNo(Language id, KeyCode &keyYes, KeyCode &keyNo);
  * @param keyNo Key code for no
  */
 void getLanguageYesNo(KeyCode &keyYes, KeyCode &keyNo);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/lua/double_serialization.h
+++ b/common/lua/double_serialization.h
@@ -25,6 +25,14 @@
 
 #include "common/types.h"
 
+/**
+ * @defgroup lua_ds Double serialization
+ * @ingroup lua
+ *
+ * @brief Functions for encoding and decoding double values.
+ *
+ * @{
+ */
 
 namespace Util {
 
@@ -57,5 +65,7 @@ SerializedDouble encodeDouble(double value);
 double decodeDouble(SerializedDouble value);
 
 } // End of namespace Util
+
+/** @} */
 
 #endif

--- a/common/macresman.h
+++ b/common/macresman.h
@@ -22,12 +22,7 @@
 
 /**
  * @file
- * Macintosh resource fork manager used in engines:
- * - groovie
- * - mohawk
- * - pegasus
- * - sci
- * - scumm
+
  */
 
 #include "common/array.h"
@@ -39,6 +34,21 @@
 #define COMMON_MACRESMAN_H
 
 namespace Common {
+
+/**
+ * @defgroup common_macresman Macintosh resource fork manager
+ * @ingroup common
+ *
+ * @brief API for Macintosh resource fork manager.
+ *
+ * @details Used in engines:
+ *          - groovie
+ *          - mohawk
+ *          - pegasus
+ *          - sci
+ *          - scumm
+ * @{
+ */
 
 typedef Array<uint16> MacResIDArray;
 typedef Array<uint32> MacResTagArray;
@@ -281,6 +291,8 @@ private:
 	ResType *_resTypes;
 	ResPtr  *_resLists;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/md5.h
+++ b/common/md5.h
@@ -27,6 +27,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_md5 MD5 checksum
+ * @ingroup common
+ *
+ * @brief API for computing the MD5 checksum.
+ *
+ * @{
+ */
+
 class ReadStream;
 class String;
 
@@ -53,6 +62,8 @@ bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length = 0);
  * @return the MD5 as a hex string on success, and an empty string if an error occurred
  */
 String computeStreamMD5AsString(ReadStream &stream, uint32 length = 0);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/memory.h
+++ b/common/memory.h
@@ -28,6 +28,14 @@
 namespace Common {
 
 /**
+ * @defgroup common_memory Memory
+ * @ingroup common
+ *
+ * @brief Functions for managing the memory.
+ * @{
+ */
+
+/**
  * Copies data from the range [first, last) to [dst, dst + (last - first)).
  * It requires the range [dst, dst + (last - first)) to be valid and
  * uninitialized.
@@ -60,6 +68,8 @@ void uninitialized_fill_n(Type *dst, size_t n, const Value &x) {
 	while (n--)
 		new ((void *)dst++) Type(x);
 }
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/memorypool.h
+++ b/common/memorypool.h
@@ -30,6 +30,14 @@
 namespace Common {
 
 /**
+ * @defgroup common_memory_pool Memory pool
+ * @ingroup common_memory
+ *
+ * @brief API for managing the memory pool.
+ * @{
+ */
+
+/**
  * This class provides a pool of memory 'chunks' of identical size.
  * The size of a chunk is determined when creating the memory pool.
  *
@@ -140,6 +148,8 @@ public:
 		this->freeChunk(ptr);
 	}
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/memstream.h
+++ b/common/memstream.h
@@ -30,6 +30,14 @@
 namespace Common {
 
 /**
+ * @defgroup common_memory_pool Memory stream
+ * @ingroup common_memory
+ *
+ * @brief API for managing the memory stream.
+ * @{
+ */
+
+/**
  * Simple memory based 'stream', which implements the ReadStream interface for
  * a plain memory block.
  */
@@ -333,6 +341,8 @@ public:
 
 	byte *getData() { return _data; }
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/mutex.h
+++ b/common/mutex.h
@@ -28,6 +28,14 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_mutex Mutex
+ * @ingroup common
+ *
+ * @brief API for managing the mutex.
+ * @{
+ */
+
 class Mutex;
 
 /**
@@ -62,6 +70,7 @@ public:
 	void unlock();
 };
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/noncopyable.h
+++ b/common/noncopyable.h
@@ -26,6 +26,14 @@
 namespace Common {
 
 /**
+ * @defgroup common_noncopy NonCopyable class
+ * @ingroup common
+ *
+ * @brief API for NonCopyable class.
+ * @{
+ */
+
+/**
  * Subclass of NonCopyable can not be copied due to the fact that
  * we made the copy constructor and assigment operator private.
  */
@@ -37,6 +45,8 @@ private:
 	NonCopyable(const NonCopyable&);
 	NonCopyable& operator=(const NonCopyable&);
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/osd_message_queue.h
+++ b/common/osd_message_queue.h
@@ -33,6 +33,14 @@
 namespace Common {
 
 /**
+ * @defgroup common_osd_message_queue OSD message queue
+ * @ingroup common
+ *
+ * @brief API for managing the queue of On Screen Display (OSD) messages.
+ * @{
+ */
+
+/**
  * Queue OSD messages from any thread to be displayed by the graphic thread.
  */
 class OSDMessageQueue : public Singleton<OSDMessageQueue>, public EventSource {
@@ -67,6 +75,8 @@ private:
 	Queue<U32String> _messages;
 	uint32 _lastUpdate;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/platform.h
+++ b/common/platform.h
@@ -27,6 +27,14 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_platform Game platforms
+ * @ingroup common
+ *
+ * @brief API for managing game platforms.
+ * @{
+ */
+
 class String;
 
 /**
@@ -80,6 +88,8 @@ extern Platform parsePlatform(const String &str);
 extern const char *getPlatformCode(Platform id);
 extern const char *getPlatformAbbrev(Platform id);
 extern const char *getPlatformDescription(Platform id);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -30,6 +30,14 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_ptr Pointers
+ * @ingroup common
+ *
+ * @brief API and templates for pointers.
+ * @{
+ */
+
 class SharedPtrDeletionInternal {
 public:
 	virtual ~SharedPtrDeletionInternal() {}
@@ -328,6 +336,8 @@ private:
 	PointerType           _pointer;
 	DisposeAfterUse::Flag _dispose;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/queue.h
+++ b/common/queue.h
@@ -29,6 +29,14 @@
 namespace Common {
 
 /**
+ * @defgroup common_queue Queue
+ * @ingroup common
+ *
+ * @brief API and templates for queues.
+ * @{
+ */
+
+/**
  * Variable size Queue class, implemented using our List class.
  */
 template<class T>
@@ -81,6 +89,8 @@ public:
 private:
 	List<T>	_impl;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/quicktime.h
+++ b/common/quicktime.h
@@ -41,13 +41,18 @@ namespace Common {
 	class MacResManager;
 
 /**
- * Parser for QuickTime/MPEG-4 files.
+ * @defgroup common_quicktime Quicktime file parser
+ * @ingroup common
  *
- * File parser used in engines:
- *  - groovie
- *  - mohawk
- *  - sci
+ * @brief Parser for QuickTime/MPEG-4 files.
+ *
+ * @details File parser used in engines:
+ *          - groovie
+ *          - mohawk
+ *          - sci
+ * @{
  */
+
 class QuickTimeParser {
 public:
 	QuickTimeParser();
@@ -210,6 +215,8 @@ private:
 	int readESDS(Atom atom);
 	int readSMI(Atom atom);
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/random.h
+++ b/common/random.h
@@ -27,6 +27,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_rng RNG
+ * @ingroup common
+ *
+ * @brief Random number generator (RNG) implementation.
+ *
+ * @{
+ */
+
 class String;
 
 /**
@@ -74,6 +83,8 @@ public:
 	 */
 	uint getRandomNumberRng(uint min, uint max);
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/rational.h
+++ b/common/rational.h
@@ -28,6 +28,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_rational Rational class
+ * @ingroup common
+ *
+ * @brief API for rational class.
+ *
+ * @{
+ */
+
 /** A simple rational class that holds fractions. */
 class Rational {
 public:
@@ -107,6 +116,8 @@ bool operator>(int left, const Rational &right);
 bool operator<(int left, const Rational &right);
 bool operator>=(int left, const Rational &right);
 bool operator<=(int left, const Rational &right);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/rdft.h
+++ b/common/rdft.h
@@ -37,9 +37,18 @@
 namespace Common {
 
 /**
- * (Inverse) Real Discrete Fourier Transform.
+ * @defgroup common_rdft RDFT algorithm
+ * @ingroup common
  *
- * Used in audio:
+ * @brief API for the Real Discrete Fourier Transform (RDFT) algorithm.
+ *
+ * @{
+ */
+
+/**
+ * @brief (Inverse) Real Discrete Fourier Transform.
+ *
+ * @details Used in audio:
  *  - QDM2
  *
  * Used in engines:
@@ -106,6 +115,8 @@ private:
 
 	FFT *_fft;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/rect.h
+++ b/common/rect.h
@@ -32,6 +32,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_rect Rectangular zones
+ * @ingroup common
+ *
+ * @brief API for operations on rectangular zones.
+ *
+ * @{
+ */
+
+/**
  * Simple class for handling both 2D position and size.
  */
 struct Point {
@@ -296,6 +305,8 @@ struct Rect {
 		return !rect.isEmpty();
 	}
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/rendermode.h
+++ b/common/rendermode.h
@@ -27,6 +27,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_rendermode Render modes
+ * @ingroup common
+ *
+ * @brief API for render modes.
+ *
+ * @{
+ */
+
 class String;
 
 /**
@@ -70,6 +79,7 @@ extern String renderMode2GUIO(RenderMode id);
 // TODO: Rename the following to something better; also, document it
 extern String allRenderModesGUIOs();
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/safe-bool.h
+++ b/common/safe-bool.h
@@ -40,6 +40,15 @@ namespace Common {
 		};
 	}
 
+    /**
+     * @defgroup common_safe_bool Safe Boolean
+     * @ingroup common
+     *
+     * @brief Template for a SafeBool function.
+     *
+     * @{
+     */
+
 	/**
 	 * Prevents `operator bool` from implicitly converting to other types.
 	 */
@@ -60,6 +69,7 @@ namespace Common {
 			&impl_t::stub : 0;
 		}
 	};
+	/** @} */
 } // End of namespace Common
 
 #endif

--- a/common/savefile.h
+++ b/common/savefile.h
@@ -31,6 +31,14 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_savefile Save files
+ * @ingroup common
+ *
+ * @brief API for managing save files.
+ *
+ * @{
+ */
 
 /**
  * A class which allows game engines to load game state data.
@@ -208,6 +216,8 @@ public:
 	 */
 	virtual void updateSavefilesList(StringArray &lockedFiles) = 0;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/serializer.h
+++ b/common/serializer.h
@@ -28,6 +28,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_serializer Serializer
+ * @ingroup common
+ *
+ * @brief API for serializing data.
+ *
+ * @{
+ */
+
 #define VER(x) Common::Serializer::Version(x)
 
 #define SYNC_AS(SUFFIX,TYPE,SIZE) \
@@ -280,6 +289,7 @@ public:
 	virtual void saveLoadWithSerializer(Serializer &ser) = 0;
 };
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/sinetables.h
+++ b/common/sinetables.h
@@ -25,6 +25,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_sinetables Sine tables
+ * @ingroup common
+ *
+ * @brief API for managing sine tables.
+ *
+ * @{
+ */
+
 class SineTable {
 public:
 	/**
@@ -68,6 +77,8 @@ private:
 	int _refSize; // _nPoints / 4
 	int _nPoints; // range of operator[]
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/singleton.h
+++ b/common/singleton.h
@@ -28,6 +28,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_singleton Singleton
+ * @ingroup common
+ *
+ * @brief API for managing singletons.
+ *
+ * @{
+ */
+
+/**
  * Generic template base class for implementing the singleton design pattern.
  */
 template<class T>
@@ -100,6 +109,8 @@ protected:
  */
 #define DECLARE_SINGLETON(T) \
 	template<> T *Singleton<T>::_singleton = 0
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/stack.h
+++ b/common/stack.h
@@ -29,6 +29,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_stack Stack
+ * @ingroup common
+ *
+ * @brief Fixed-size stack implementation.
+ *
+ * @{
+ */
+
+/**
  * Extremly simple fixed size stack class.
  */
 template<class T, uint MAX_SIZE = 10>
@@ -139,6 +148,8 @@ public:
 		return _stack[i];
 	}
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/str-array.h
+++ b/common/str-array.h
@@ -30,11 +30,21 @@
 namespace Common {
 
 /**
+ * @defgroup common_str_array String array
+ * @ingroup common_str
+ *
+ * @brief String array implementation.
+ *
+ * @{
+ */
+
+/**
  * An array of of strings.
  */
 typedef Array<String>		StringArray;
 typedef Array<U32String>	U32StringArray;
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/str.h
+++ b/common/str.h
@@ -31,6 +31,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_str Strings
+ * @ingroup common
+ *
+ * @brief API for working with strings.
+ *
+ * @{
+ */
+
 class U32String;
 
 /**
@@ -565,6 +574,8 @@ size_t strnlen(const char *src, size_t maxSize);
  * @return The converted string.
  */
 String toPrintable(const String &src, bool keepNewLines = true);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/stream.h
+++ b/common/stream.h
@@ -29,6 +29,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_stream Streams
+ * @ingroup common
+ *
+ * @brief API for managing readable and writable data streams.
+ *
+ * @{
+ */
+
 class ReadStream;
 class SeekableReadStream;
 
@@ -714,6 +723,7 @@ public:
 	SeekableReadStreamEndian(bool bigEndian) : ReadStreamEndian(bigEndian) {}
 };
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/substream.h
+++ b/common/substream.h
@@ -30,6 +30,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_substream Substreams
+ * @ingroup common_stream
+ *
+ * @brief API for managing readable data substreams.
+ *
+ * @{
+ */
+
+/**
  * SubReadStream provides access to a ReadStream restricted to the range
  * [currentPosition, currentPosition+end).
  *
@@ -124,6 +133,7 @@ public:
 	virtual uint32 read(void *dataPtr, uint32 dataSize);
 };
 
+/** @} */
 
 } // End of namespace Common
 

--- a/common/system.h
+++ b/common/system.h
@@ -68,6 +68,15 @@ class Encoding;
 typedef Array<Keymap *> KeymapArray;
 }
 
+/**
+ * @defgroup common_system System
+ * @ingroup common
+ *
+ * @brief Operating system related API.
+ *
+ * @{
+ */
+
 class AudioCDManager;
 class FilesystemFactory;
 class PaletteManager;
@@ -1558,5 +1567,7 @@ protected:
 
 /** The global OSystem instance. Initialized in main(). */
 extern OSystem *g_system;
+
+/** @} */
 
 #endif

--- a/common/taskbar.h
+++ b/common/taskbar.h
@@ -34,6 +34,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_taskbar Taskbar Manager
+ * @ingroup common
+ *
+ * @brief The TaskbarManager module allows for interaction with the ScummVM application icon.
+ *
+ * @{
+ */
+
+/**
  * The TaskbarManager allows interaction with the ScummVM application icon:
  *  - in the taskbar on Windows 7 and later
  *  - in the launcher for Unity
@@ -186,6 +195,8 @@ return (path); \
 		return "";
 	}
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/text-to-speech.h
+++ b/common/text-to-speech.h
@@ -33,6 +33,15 @@ namespace Common {
 
 
 /**
+ * @defgroup common_text_speech Text-to-speech Manager
+ * @ingroup common
+ *
+ * @brief The TTS module allows for speech synthesis.
+ *
+ * @{
+ */
+
+/**
  * Text to speech voice class.
  */
 class TTSVoice {
@@ -340,6 +349,8 @@ protected:
 	void clearState();
 	virtual void updateVoices() {};
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/textconsole.h
+++ b/common/textconsole.h
@@ -28,6 +28,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_text_console Text console
+ * @ingroup common
+ *
+ * @brief Output formatter, typically used for debugging.
+ *
+ * @{
+ */
+
+/**
  * An output formatter takes a source string and 'decorates' it with
  * extra information, storing the result in a destination buffer.
  * A typical use is to (optionally) enhance the output given by
@@ -56,6 +65,8 @@ typedef void (*ErrorHandler)(const char *msg);
  * This can be used to e.g. show a debugger console.
  */
 void setErrorHandler(ErrorHandler handler);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/timer.h
+++ b/common/timer.h
@@ -29,6 +29,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_timer Timer
+ * @ingroup common
+ *
+ * @brief API for managing the timer.
+ *
+ * @{
+ */
+
 class TimerManager : NonCopyable {
 public:
 	typedef void (*TimerProc)(void *refCon);
@@ -56,6 +65,8 @@ public:
 	 */
 	virtual void removeTimerProc(TimerProc proc) = 0;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/tokenizer.h
+++ b/common/tokenizer.h
@@ -30,6 +30,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_tokenizer String tokenizer
+ * @ingroup common
+ *
+ * @brief String tokenizer for creating tokens out of parts of a string.
+ *
+ * @{
+ */
+
+/**
  * A simple non-optimized string tokenizer.
  *
  * Example of use:
@@ -81,6 +90,9 @@ private:
 	U32String::const_iterator            _tokenBegin; ///< Latest found token's begin iterator (Valid after a call to nextToken())
 	U32String::const_iterator            _tokenEnd;   ///< Latest found token's end iterator (Valid after a call to nextToken())
 };
+
+/** @} */
+
 } // End of namespace Common
 
 #endif

--- a/common/translation.h
+++ b/common/translation.h
@@ -34,6 +34,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_translation Message translation manager
+ * @ingroup common
+ *
+ * @brief API related to translation.
+ *
+ * @{
+ */
+
 class File;
 
 enum TranslationIDs {
@@ -216,6 +225,8 @@ private:
 	String _currentCharset;
 	int _currentLang;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/unarj.h
+++ b/common/unarj.h
@@ -33,6 +33,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_unarj ARJ decompressor
+ * @ingroup common
+ *
+ * @brief API related to ARJ archive files.
+ *
+ * @{
+ */
+
 class Archive;
 
 /**
@@ -42,6 +51,8 @@ class Archive;
  * May return 0 in case of a failure.
  */
 Archive *makeArjArchive(const String &name);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/unzip.h
+++ b/common/unzip.h
@@ -27,6 +27,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_unzip ZIP decompressor
+ * @ingroup common
+ *
+ * @brief API related to ZIP archive files.
+ *
+ * @{
+ */
+
 class Archive;
 class FSNode;
 class SeekableReadStream;
@@ -56,6 +65,8 @@ Archive *makeZipArchive(const FSNode &node);
  * May return 0 in case of a failure. In this case stream will still be deleted.
  */
 Archive *makeZipArchive(SeekableReadStream *stream);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/updates.h
+++ b/common/updates.h
@@ -28,6 +28,15 @@
 namespace Common {
 
 /**
+ * @defgroup common_update Update Manager
+ * @ingroup common
+ *
+ * @brief The UpdateManager module allows for automatic update checking.
+ *
+ * @{
+ */
+
+/**
  * The UpdateManager allows configuring of the automatic update checking
  * for systems that support it:
  *  - using Sparkle on Mac OS X
@@ -126,6 +135,8 @@ public:
 	 */
 	static int normalizeInterval(int interval);
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -28,6 +28,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_ustr UTF-32 strings
+ * @ingroup common_str
+ *
+ * @brief API for working with UTF-32 strings.
+ *
+ * @{
+ */
+ 
 class String;
 class UnicodeBiDiText;
 
@@ -280,6 +289,9 @@ private:
 };
 
 U32String operator+(const U32String &x, const U32String &y);
+
+/** @} */
+
 } // End of namespace Common
 
 #endif

--- a/common/util.h
+++ b/common/util.h
@@ -27,6 +27,15 @@
 #include "common/str.h"
 
 /**
+ * @defgroup common_util Util
+ * @ingroup common
+ *
+ * @brief Various utility functions.
+ *
+ * @{
+ */
+
+/**
  * Check whether a given pointer is aligned correctly.
  * Note that 'alignment' must be a power of two!
  */
@@ -105,7 +114,14 @@ template<typename T, size_t N> inline void ARRAYCLEAR(T (&array) [N], const T &v
 #  define SCUMMVM_CURRENT_FUNCTION "<unknown>"
 #endif
 
+/** @} */
+
 namespace Common {
+
+/**
+ * @addtogroup common_util
+ * @{
+ */
 
 /**
  * Print a hexdump of the data passed in. The number of bytes per line is
@@ -251,6 +267,8 @@ bool isGraph(int c);
  * @return			string with a floating point number representing given size
  */
 Common::String getHumanReadableBytes(uint64 bytes, Common::String &unitsOut);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/winexe.h
+++ b/common/winexe.h
@@ -28,6 +28,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_winexe Windows resources
+ * @ingroup common
+ *
+ * @brief API for managing Windows resources.
+ *
+ * @{
+ */
+
 class SeekableReadStream;
 
 /** The default Windows resources. */
@@ -135,6 +144,8 @@ public:
 
 	static VersionHash *parseVersionInfo(SeekableReadStream *stream);
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/winexe_ne.h
+++ b/common/winexe_ne.h
@@ -29,6 +29,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_winexe_ne Windows New Executable resources
+ * @ingroup common_winexe
+ *
+ * @brief API for managing Windows New Executable resources.
+ *
+ * @{
+ */
+
 template<class T> class Array;
 class SeekableReadStream;
 
@@ -89,6 +98,8 @@ private:
 	/** Read a resource string. */
 	static String getResourceString(SeekableReadStream &exe, uint32 offset);
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/winexe_pe.h
+++ b/common/winexe_pe.h
@@ -30,6 +30,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_winexe_ne Windows Portable Executable resources
+ * @ingroup common_winexe
+ *
+ * @brief API for managing Windows Portable Executable resources.
+ *
+ * @{
+ */
+
 template<class T> class Array;
 class SeekableReadStream;
 
@@ -91,6 +100,8 @@ private:
 
 	TypeMap _resources;
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/xmlparser.h
+++ b/common/xmlparser.h
@@ -36,6 +36,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_xmlparser XML parser
+ * @ingroup common
+ *
+ * @brief The XML parser allows for parsing XML-like files.
+ * 
+ * @{
+ */
+
 class SeekableReadStream;
 
 #define MAX_XML_DEPTH 8
@@ -348,6 +357,8 @@ private:
 
 	Stack<ParserNode *> _activeKey; /** Node stack of the parsed keys */
 };
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/zlib.h
+++ b/common/zlib.h
@@ -27,6 +27,15 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_zlib zlib
+ * @ingroup common
+ *
+ * @brief API for zlib operations.
+ * 
+ * @{
+ */
+
 class SeekableReadStream;
 class WriteStream;
 
@@ -144,6 +153,8 @@ SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped, ui
  * returned).
  */
 WriteStream *wrapCompressedWriteStream(WriteStream *toBeWrapped);
+
+/** @} */
 
 } // End of namespace Common
 


### PR DESCRIPTION
All the header files from the ``common`` folder now have doxygen groups added to them. Thanks to that, the usability of API doc is greatly improved and crucial information can be found. Compare:
Old:
![image](https://user-images.githubusercontent.com/29537761/86974023-dcebd980-c175-11ea-85ae-0fc83ed16064.png)
New:
![image](https://user-images.githubusercontent.com/29537761/86975535-d317a580-c178-11ea-9d8a-7d7a8dd903a8.png)
