### PR TITLE
SYMBIAN: Deprecate the actions system

### DIFF
--- a/backends/events/symbiansdl/symbiansdl-events.cpp
+++ b/backends/events/symbiansdl/symbiansdl-events.cpp
@@ -22,7 +22,7 @@
 
 #include "common/scummsys.h"
 
-#ifdef __SYMBIAN32__
+#if defined(__SYMBIAN32__) && defined(GUI_ENABLE_KEYSDIALOG)
 
 #include "backends/events/symbiansdl/symbiansdl-events.h"
 #include "backends/platform/symbian/src/SymbianActions.h"

--- a/backends/events/symbiansdl/symbiansdl-events.h
+++ b/backends/events/symbiansdl/symbiansdl-events.h
@@ -25,6 +25,8 @@
 
 #include "backends/events/sdl/legacy-sdl-events.h"
 
+#ifdef GUI_ENABLE_KEYSDIALOG
+
 #define TOTAL_ZONES 3
 
 /**
@@ -53,5 +55,7 @@ protected:
 
 	virtual bool handleAxisToMouseMotion(int16 xAxis, int16 yAxis);
 };
+
+#endif
 
 #endif

--- a/backends/platform/symbian/src/SymbianActions.cpp
+++ b/backends/platform/symbian/src/SymbianActions.cpp
@@ -22,6 +22,8 @@
 
 #include "backends/platform/symbian/src/SymbianActions.h"
 
+#ifdef GUI_ENABLE_KEYSDIALOG
+
 #include "gui/message.h"
 #include "scumm/scumm.h"
 #include "common/config-manager.h"
@@ -257,3 +259,5 @@ bool SymbianActions::perform(ActionType /*action*/, bool /*pushed*/) {
 }
 
 } // namespace GUI
+
+#endif

--- a/backends/platform/symbian/src/SymbianActions.h
+++ b/backends/platform/symbian/src/SymbianActions.h
@@ -24,6 +24,9 @@
 #define SYMBIANACTIONS_H
 
 #include "common/scummsys.h"
+
+#ifdef GUI_ENABLE_KEYSDIALOG
+
 #include "common/system.h"
 #include "gui/Key.h"
 #include "gui/Actions.h"
@@ -76,5 +79,7 @@ private:
 };
 
 } // namespace GUI
+
+#endif
 
 #endif

--- a/backends/platform/symbian/src/SymbianOS.cpp
+++ b/backends/platform/symbian/src/SymbianOS.cpp
@@ -27,7 +27,6 @@
 #define FORBIDDEN_SYMBOL_EXCEPTION_fopen
 
 #include "backends/platform/symbian/src/SymbianOS.h"
-#include "backends/platform/symbian/src/SymbianActions.h"
 #include "common/config-manager.h"
 #include "common/scummsys.h"
 #include "common/translation.h"
@@ -36,8 +35,12 @@
 
 #include "backends/fs/symbian/symbian-fs-factory.h"
 #include "backends/saves/default/default-saves.h"
-#include "backends/events/symbiansdl/symbiansdl-events.h"
 #include "backends/mixer/symbiansdl/symbiansdl-mixer.h"
+
+#ifdef GUI_ENABLE_KEYSDIALOG
+#include "backends/platform/symbian/src/SymbianActions.h"
+#include "backends/events/symbiansdl/symbiansdl-events.h"
+#endif
 
 #define DEFAULT_CONFIG_FILE "scummvm.ini"
 #define DEFAULT_SAVE_PATH "Savegames"
@@ -99,11 +102,14 @@ void OSystem_SDL_Symbian::initBackend() {
 	ConfMan.setBool("fullscreen", true);
 	ConfMan.flushToDisk();
 
+#ifdef GUI_ENABLE_KEYSDIALOG
 	GUI::Actions::init();
 
 	// Creates the backend managers
 	if (_eventSource == 0)
 		_eventSource = new SymbianSdlEventSource();
+#endif
+
 	if (_mixerManager == 0) {
 		_mixerManager = new SymbianSdlMixerManager();
 
@@ -114,11 +120,13 @@ void OSystem_SDL_Symbian::initBackend() {
 	// Call parent implementation of this method
 	OSystem_SDL::initBackend();
 
+#ifdef GUI_ENABLE_KEYSDIALOG
 	// Initialize global key mapping for Smartphones
 	GUI::Actions* actions = GUI::Actions::Instance();
 
 	actions->initInstanceMain(this);
 	actions->loadMapping();
+#endif
 }
 
 void OSystem_SDL_Symbian::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
@@ -135,6 +143,7 @@ void OSystem_SDL_Symbian::quitWithErrorMsg(const char * /*aMsg*/) {
 		g_system->quit();
 }
 
+#ifdef GUI_ENABLE_KEYSDIALOG
 void OSystem_SDL_Symbian::quit() {
 	delete GUI_Actions::Instance();
 
@@ -158,6 +167,7 @@ void OSystem_SDL_Symbian::checkMappings() {
 
 	GUI::Actions::Instance()->initInstanceGame();
 }
+#endif
 
 Common::String OSystem_SDL_Symbian::getDefaultConfigFileName() {
 	char configFile[MAXPATHLEN];
@@ -167,7 +177,11 @@ Common::String OSystem_SDL_Symbian::getDefaultConfigFileName() {
 }
 
 bool OSystem_SDL_Symbian::hasFeature(Feature f) {
-	if (f == kFeatureJoystickDeadzone || f == kFeatureFullscreenMode)
+#ifdef GUI_ENABLE_KEYSDIALOG
+	if (f == kFeatureJoystickDeadzone)
+		return false;
+#endif
+	if (f == kFeatureFullscreenMode)
 		return false;
 
 	return OSystem_SDL::hasFeature(f);

--- a/backends/platform/symbian/src/SymbianOS.h
+++ b/backends/platform/symbian/src/SymbianOS.h
@@ -34,9 +34,11 @@ public:
 	// Override from OSystem_SDL
 	virtual void init();
 	virtual void initBackend();
+#ifdef GUI_ENABLE_KEYSDIALOG
 	virtual void quit();
 	virtual void engineInit();
 	virtual void engineDone();
+#endif
 	virtual Common::String getDefaultConfigFileName();
 	virtual bool hasFeature(Feature f);
 
@@ -50,10 +52,12 @@ public:
 	void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0);
 
 protected:
+#ifdef GUI_ENABLE_KEYSDIALOG
 	/**
 	 * Used to intialized special game mappings
 	 */
 	void checkMappings();
+#endif
 
 	RFs* _RFs;
 };

--- a/backends/platform/symbian/src/portdefs.h
+++ b/backends/platform/symbian/src/portdefs.h
@@ -84,6 +84,7 @@ namespace std
 #undef remove
 #endif
 
+// TODO: Replace this with the keymapper
 #define GUI_ENABLE_KEYSDIALOG
 
 #define DISABLE_COMMAND_LINE

--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -239,9 +239,11 @@ void MainMenuDialog::load() {
 		close();
 }
 
+#ifdef GUI_ENABLE_KEYSDIALOG
 enum {
 	kKeysCmd = 'KEYS'
 };
+#endif
 
 namespace GUI {
 
@@ -378,24 +380,23 @@ void ConfigDialog::apply() {
 	OptionsDialog::apply();
 }
 
+#ifdef GUI_ENABLE_KEYSDIALOG
 void ConfigDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) {
 	switch (cmd) {
 	case kKeysCmd:
-
-#ifdef GUI_ENABLE_KEYSDIALOG
-	//
-	// Create the sub dialog(s)
-	//
-	_keysDialog = new GUI::KeysDialog();
-	_keysDialog->runModal();
-	delete _keysDialog;
-	_keysDialog = NULL;
-#endif
+		//
+		// Create the sub dialog(s)
+		//
+		_keysDialog = new GUI::KeysDialog();
+		_keysDialog->runModal();
+		delete _keysDialog;
+		_keysDialog = NULL;
 		break;
 	default:
 		GUI::OptionsDialog::handleCommand (sender, cmd, data);
 	}
 }
+#endif
 
 ExtraGuiOptionsWidget::ExtraGuiOptionsWidget(GuiObject *containerBoss, const Common::String &name, const Common::String &domain, const ExtraGuiOptions &options) :
 		OptionsContainerWidget(containerBoss, name, dialogLayout(domain), false, domain),

--- a/engines/dialogs.h
+++ b/engines/dialogs.h
@@ -85,8 +85,6 @@ public:
 	ConfigDialog();
 	~ConfigDialog() override;
 
-	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
-
 	// OptionsDialog API
 	void build() override;
 	void apply() override;
@@ -95,6 +93,10 @@ private:
 	OptionsContainerWidget *_engineOptions;
 
 #ifdef GUI_ENABLE_KEYSDIALOG
+public:
+	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
+
+private:
 	Dialog *_keysDialog;
 #endif
 };

--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -48,10 +48,6 @@
 #include "scumm/help.h"
 #endif
 
-#ifdef GUI_ENABLE_KEYSDIALOG
-#include "gui/KeysDialog.h"
-#endif
-
 using Graphics::kTextAlignCenter;
 using Graphics::kTextAlignLeft;
 using GUI::WIDGET_ENABLED;

--- a/gui/Actions.cpp
+++ b/gui/Actions.cpp
@@ -21,12 +21,17 @@
  */
 
 #include "gui/Actions.h"
+
+#ifdef GUI_ENABLE_KEYSDIALOG
+
 #include "gui/message.h"
 #include "common/config-manager.h"
 
 #ifdef __SYMBIAN32__
 	#include "backends/platform/symbian/src/SymbianActions.h"
 #endif
+
+#warning The actions system is deprecated. Please use the keymapper instead.
 
 namespace GUI {
 
@@ -150,3 +155,5 @@ Actions *Actions::_instance = NULL;
 
 
 } // namespace GUI
+
+#endif

--- a/gui/Actions.h
+++ b/gui/Actions.h
@@ -24,6 +24,9 @@
 #define GUI_ACTIONS_H
 
 #include "common/scummsys.h"
+
+#ifdef GUI_ENABLE_KEYSDIALOG
+
 #include "common/system.h"
 #include "gui/Key.h"
 
@@ -82,4 +85,7 @@ protected:
 
 } // namespace GUI
 typedef GUI::Actions GUI_Actions;
+
+#endif
+
 #endif

--- a/gui/Key.cpp
+++ b/gui/Key.cpp
@@ -22,6 +22,10 @@
 
 #include "gui/Key.h"
 
+#ifdef GUI_ENABLE_KEYSDIALOG
+
+#warning The actions system is deprecated. Please use the keymapper instead.
+
 namespace GUI {
 
 Key::Key() :
@@ -65,3 +69,5 @@ int Key::flags() {
 }
 
 } // namespace GUI
+
+#endif

--- a/gui/Key.h
+++ b/gui/Key.h
@@ -24,6 +24,9 @@
 #define GUI_KEY_H
 
 #include "common/scummsys.h"
+
+#ifdef GUI_ENABLE_KEYSDIALOG
+
 #include "common/system.h"
 
 namespace GUI {
@@ -54,5 +57,7 @@ private:
 };
 
 } // namespace GUI
+
+#endif
 
 #endif

--- a/gui/KeysDialog.cpp
+++ b/gui/KeysDialog.cpp
@@ -21,6 +21,11 @@
  */
 
 #include "gui/KeysDialog.h"
+
+#ifdef GUI_ENABLE_KEYSDIALOG
+
+#warning The actions system is deprecated. Please use the keymapper instead.
+
 #include "gui/Actions.h"
 #include "common/translation.h"
 #include <SDL_keyboard.h>
@@ -146,3 +151,5 @@ void KeysDialog::handleKeyUp(Common::KeyState state) {
 }
 
 } // namespace GUI
+
+#endif

--- a/gui/KeysDialog.h
+++ b/gui/KeysDialog.h
@@ -23,6 +23,10 @@
 #ifndef KEYSDIALOG_H
 #define KEYSDIALOG_H
 
+#include "common/scummsys.h"
+
+#ifdef GUI_ENABLE_KEYSDIALOG
+
 #include "gui/gui-manager.h"
 #include "gui/dialog.h"
 #include "gui/widgets/list.h"
@@ -48,5 +52,7 @@ protected:
 };
 
 } // namespace GUI
+
+#endif
 
 #endif


### PR DESCRIPTION
The Actions system is only used by the Symbian port, and it’s main purpose is something that can be accomplished in a much simpler way using the keymapper. This PR moves as much code from the actions system as possible behind the GUI_ENABLE_KEYSDIALOG, and adds compiler warnings if the code is used on any new platforms. It should be possible to move the Symbian port over to the keymapper (with some minor limitations) by simply undefining GUI_ENABLE_KEYSDIALOG, but I have no way of testing this.

Requesting a review from @fedor4ever as the most recent Symbian porter.