### PR TITLE
ZVISION: Fix ZGI scoring

### DIFF
--- a/engines/zvision/scripting/actions.cpp
+++ b/engines/zvision/scripting/actions.cpp
@@ -60,13 +60,15 @@ ResultAction::ResultAction(ZVision *engine, int32 slotKey) :
 ActionAdd::ActionAdd(ZVision *engine, int32 slotKey, const Common::String &line) :
 	ResultAction(engine, slotKey) {
 	_key = 0;
-	_value = 0;
 
-	sscanf(line.c_str(), "%u,%d", &_key, &_value);
+	char buf[64];
+	memset(buf, 0, 64);
+	sscanf(line.c_str(), "%u,%s", &_key, buf);
+	_value = new ValueSlot(_scriptManager, buf);
 }
 
 bool ActionAdd::execute() {
-	_scriptManager->setStateValue(_key, _scriptManager->getStateValue(_key) + _value);
+	_scriptManager->setStateValue(_key, _scriptManager->getStateValue(_key) + _value->getValue());
 	return true;
 }
 

--- a/engines/zvision/scripting/actions.cpp
+++ b/engines/zvision/scripting/actions.cpp
@@ -130,10 +130,9 @@ ActionChangeLocation::ActionChangeLocation(ZVision *engine, int32 slotKey, const
 }
 
 bool ActionChangeLocation::execute() {
-	// We can't directly call ScriptManager::ChangeLocationIntern() because doing so clears all the Puzzles, and thus would corrupt the current puzzle checking
+	// We can't directly call ScriptManager::ChangeLocationReal() because doing so clears all the Puzzles, and thus would corrupt the current puzzle checking
 	_scriptManager->changeLocation(_world, _room, _node, _view, _offset);
-	// Tell the puzzle system to stop checking any more puzzles
-	return false;
+	return true;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/engines/zvision/scripting/actions.h
+++ b/engines/zvision/scripting/actions.h
@@ -63,7 +63,7 @@ public:
 
 private:
 	uint32 _key;
-	int _value;
+	ValueSlot *_value;
 };
 
 class ActionAssign : public ResultAction {

--- a/engines/zvision/scripting/script_manager.h
+++ b/engines/zvision/scripting/script_manager.h
@@ -194,6 +194,7 @@ private:
 
 	Location _currentLocation;
 	Location _nextLocation;
+	int _changeLocationDelayCycles;
 
 	uint32 _currentlyFocusedControl;
 


### PR DESCRIPTION
It was pointed out on the GOG forum that you can't get a perfect score in Zork: Grand Inquisitor. Once case I've found that looks like it should award points, but doesn't, is the Spell Checker (tp4g.scr). It turns out that the script doesn't award the points until after it has changed your location. Example:

```
puzzle:12183 {	# tp4g_gnusto_odibil
    criteria {
        [17225] = 2	# tp4g_deactivate
        [01013] = 4	# person_talking
        [12164] = 1	# tp4g_odibil_in_machine
    }
    results {
        action:assign(17225, 0)	# tp4g_deactivate
        action:cursor(U)
        action:disable_control(12160)	# tp4g_null
        action:assign(12183, 0)	# tp4g_gnusto_odibil
        action:assign(12159, 0)	# tp4g_machine_full
        action:assign(12164, 0)	# tp4g_odibil_in_machine
        action:set_partial_screen(124 77 tp4gv011.tga 0 -1)
        action:universe_music:19549(0 g100h84q.raw 0 91)	# tp4g_pickup_fx
        action:assign(00193, 2)	# SPELL_3_IN_BOOK
        action:assign(03731, 0)	# gjmb_current_page
        action:dissolve()
        action:change_location(g, j, mb, 0)
        action:add(14999, 8)	# user_score
    }
    flags {
        once_per_inst
    }
}
```

ScummVM interprets the location change as a signal that the script has ended, so in the above example action:add(14999,8) is never run. With this change, the script continues until it finishes on its own.

As far as I can see, this is how ScummVM has always done it. I don't think the original Z-Engine project did, though:

https://github.com/Marisa-Chan/Zengine/blob/master/Engine/src/actions.cpp#L117
https://github.com/scummvm/scummvm/commit/327d4a1ccff41af28b010679a29168b7e839de29#diff-e752bac0e583da97f4540bdfb9d0408b

If this was the only such case, I would feel much more comfortable about making this change. As it is, I'm a bit nervous about it. One other positive difference is that with the change, you get to keep the sword after entering the monastery (um1e.scr). Without it, the sword is lost until the end of the game, when you get it back.

These are the scripts I've found in Zork: Grand Inquisitor that do things after a location change:

```
cd7j     action:assign(01721, 1)    # cd7j_screenset_head_up
cd7j     action:assign(01720, 1)    # cd7j_screenset
gjmb     action:delay_render(10)
gjmb     action:delay_render(10)
gjz0     action:delay_render(10)
gjz1     action:delay_render(10)
te1e     action:assign(11104, 1)    # te1e_alright_sport_now_do_the_puzzle
te2e     action:assign(11329, 1)    # te2e_alright_sport_now_do_the_puzzle
te3e     action:assign(11546, 1)    # te3e_alright_sport_now_do_the_puzzle
te5e     action:universe_music:11764(1 g100h84q.raw 0 94)   # te5e_got_kendall
tp4g     action:add(14999, 8)       # user_score
tp4g     action:add(14999, 8)       # user_score
tp4g     action:add(14999, 19)      # user_score
um1e     action:assign(19078, 1)    # um1e_give_sword_back
```

And these are the ones I've found in Zork Nemesis. In some cases, the only line after the location change is a comment:

```
ac4e     #action:cursor(unhide)
ac4g     action:enable_control(6645)  # ac4g-ac4f
ac4g     action:enable_control(6672)  # get-drop stomach jar
ac4h     action:enable_control(6672)  # get-drop stomach jar
ae5w     action:enable_control(5797)  # open drawer W
ae5y     action:enable_control(5811)  # open drawer Y
ag5e     action:flush_mouse_events(0)
al6j     action:disable_control(7462) # turn blood alc back
am1f     action:assign(218, 0)
cc50     action:flush_mouse_events(0)
cc50     action:flush_mouse_events(0)
cc60     action:flush_mouse_events(0)
cc60     action:flush_mouse_events(0)
cc6f     action:stop(8251)
cca0     action:flush_mouse_events(0)
ce6j     action:assign(185, 0)
cl4f     action:crossfade(0 8251 0 30 0 100 1000)
cl4g     action:stop(12426)
cm8g     action:assign(187, 0)
mj4a     action:flush_mouse_events(0)
mj5f     action:flush_mouse_events(0)
mj7g     action:flush_mouse_events(0)
mk1e     action:flush_mouse_events(0)
mp2e     action:flush_mouse_events(0)
mpme     action:flush_mouse_events(0)
tm4a     action:assign(165, 0)
ts2g     action:assign(173, 0)
tt2e     action:assign(163, 0)
tw5e     action:assign(176, 0)
tw5e     action:stop(358)
tz2e     action:assign(179, 0)
tz2e     action:assign(179, 0)
tz2e     action:assign(179, 0)
tz2e     action:assign(179, 0)
tz40     action:assign(177, 0)
vb       action:assign(203, 0)
vk4e     action:disable_control(18390)              # turn locket box handle
vk4l     action:enable_control(18494)               # turn page forward
vm20     action:dissolve
vm30     action:dissolve
vm40     action:dissolve
vm60     action:dissolve
vm70     action:dissolve
vm70     action:dissolve
vm80     action:dissolve
vmmf     #action:cursor(unhide)
vw3k     action:assign(209, 0)
vw4f     #action:cursor(unhide)
```

It is unlikely that I will have the time to thoroughly test the full impact of this change, which is why I'm saying it shouldn't be merged just yet no matter how much sense it makes to me. I've had much less time for ScummVM in the past few years than I used to, and besides I'm just not that fond of Zork Nemesis. The spell checker and sword/rope are the only cases so far where I've been able to verify that the change does make a difference, and in those two cases I think the change is for the better.

Unfortunately none of the Z-Vision maintainers have been active on IRC lately, so I haven't been able to ask them about it.