### PR TITLE
CI: Add GitHub Actions-based CI to excercise vcpkg and MSVC AArch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: win32
+            triplet: x86-windows
+            arch: x86
+            vcpkgPackages: 'curl faad2 fluidsynth freetype fribidi libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+            useNasm: 'true'
+          - platform: x64
+            arch: x64
+            triplet: x64-windows
+            vcpkgPackages: 'curl faad2 fluidsynth freetype fribidi libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+          - platform: arm64
+            arch: arm64
+            triplet: arm64-windows
+            vcpkgPackages: 'curl faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+    env:
+      CONFIGURATION: Release
+      PLATFORM: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: ilammy/setup-nasm@v1
+        if: ${{ matrix.useNasm }} == 'true'
+      - name: Install vcpkg and packages
+        uses: lukka/run-vcpkg@v2
+        id: runvcpkg
+        with:
+          vcpkgGitCommitId: 2f7a104d4d6f1f3790db929f85a4086aa6973d7f
+          vcpkgTriplet: '${{ matrix.triplet }}'
+          vcpkgArguments: '${{ matrix.vcpkgPackages }}'
+      - name: Upload libs
+        uses: actions/upload-artifact@v2
+        with:
+          name: libs-${{ matrix.triplet }}
+          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}
+      - name: Build create_project
+        run: |
+          cd devtools/create_project/cmake
+          cmake .
+          cmake --build . -j 2
+          ls
+          cd ../../../
+      - name: Call create_project
+        run: |
+          mkdir build-scummvm
+          cd build-scummvm
+          ../devtools/create_project/cmake/Debug/create_project.exe .. --msvc --enable-faad --enable-mpeg2 --use-canonical-lib-names
+          ls
+      - name: set SCUMMVM_LIBS env variable
+        run: |
+          echo "::set-env name=SCUMMVM_LIBS::${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}"
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.0
+      - name: Build scummvm
+        run: |
+          cd build-scummvm
+          ls
+          msbuild scummvm.sln /m /p:BuildInParallel=true /p:Configuration=Release /p:Platform=${{ matrix.platform }}
+      - name: Upload scummvm
+        uses: actions/upload-artifact@v2
+        with:
+          name: scummvm-${{ matrix.arch }}
+          path: build-scummvm/Release${{ matrix.arch }}/*.exe
+      - name: Upload scummvm libs
+        uses: actions/upload-artifact@v2
+        with:
+          name: scummvm-${{ matrix.arch }}
+          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\bin\\*.dll
+      - name: Upload scummvm symbols
+        uses: actions/upload-artifact@v2
+        with:
+          name: symbols-${{ matrix.arch }}
+          path: build-scummvm/Release${{ matrix.arch }}/*.pdb
+      - name: Upload scummvm libs symbols
+        uses: actions/upload-artifact@v2
+        with:
+          name: symbols-${{ matrix.arch }}
+          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\bin\\*.pdb


### PR DESCRIPTION
CI integration extracted from https://github.com/scummvm/scummvm/pull/2248 which uses GitHub Actions to provide builds.

Not expected to work until #2248 gets merged, but at the same time #2248 won't get verified with GitHub Actions due to missing workflow definitions in the upstream.

There's caching of vcpkg libraries implemented inside the action, however my tests suggest it works for x86 and arm64 only, with AMD64 job rebuilding them over and over again. I don't know why that is and would rather see the job removed instead of investigating why. The jobs all produce relevant artifacts: libs as produced by vcpkg, scummvm binaries with all used libs, debug symbols.

You can see how it works over at https://github.com/janisozaur/scummvm/actions