### PR TITLE
CI: Disable fribidi for all MSVC builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - platform: win32
+            triplet: x86-windows
+            arch: x86
+            vcpkgPackages: 'curl faad2 fluidsynth freetype fribidi libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+            useNasm: 'true'
+          - platform: x64
+            arch: x64
+            triplet: x64-windows
+            vcpkgPackages: 'curl faad2 fluidsynth freetype fribidi libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
           - platform: arm64
             arch: arm64
             triplet: arm64-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,22 @@ jobs:
           - platform: win32
             triplet: x86-windows
             arch: x86
-            vcpkgPackages: 'curl faad2 fluidsynth freetype fribidi libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+            # fribidi is disabled due to timeouts when installing the package
+            configFlags: --enable-faad --enable-mpeg2 --disable-fribidi
+            vcpkgPackages: 'curl faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
             useNasm: 'true'
           - platform: x64
             arch: x64
             triplet: x64-windows
-            vcpkgPackages: 'curl faad2 fluidsynth freetype fribidi libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+            # fribidi is disabled due to timeouts when installing the package
+            configFlags: --enable-faad --enable-mpeg2 --disable-fribidi
+            vcpkgPackages: 'curl faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
           - platform: arm64
             arch: arm64
             triplet: arm64-windows
+            # fribidi is disabled due to https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64
+            # Note that fribidi is also disabled on arm64 in devtools/create_project/msvc.cpp
+            configFlags: --enable-faad --enable-mpeg2 --disable-fribidi
             vcpkgPackages: 'curl faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
     env:
       CONFIGURATION: Release
@@ -52,7 +59,7 @@ jobs:
         run: |
           mkdir build-scummvm
           cd build-scummvm
-          ../devtools/create_project/cmake/Debug/create_project.exe .. --msvc --enable-all-engines --enable-faad --enable-mpeg2 --use-canonical-lib-names
+          ../devtools/create_project/cmake/Debug/create_project.exe .. --msvc --enable-all-engines ${{ matrix.configflags }} --use-canonical-lib-names
           ls
       - name: set SCUMMVM_LIBS env variable
         run: |


### PR DESCRIPTION
This works around the issue of the x86 and x64 builds timing out when installing packages.