### PR TITLE
GUI: Small patches.

### DIFF
--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -89,7 +89,11 @@ void UnicodeBiDiText::initWithU32String(const U32String &input) {
 		delete[] visual_str;
 	}
 #else
-	warning("initWithU32String: Fribidi not available, using input string as fallback");
+	static bool fribidiWarning = true;
+	if (fribidiWarning) {
+		warning("initWithU32String: Fribidi not available, will use input strings as fallback.");
+		fribidiWarning = false;
+	}
 	visual = input;
 #endif
 

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -163,8 +163,9 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 	case Common::KEYCODE_DOWN:
 	case Common::KEYCODE_END:
 		// Move caret to end
-		dirty = setCaretPos(_editString.size());
+		setCaretPos(_editString.size());
 		forcecaret = true;
+		dirty = true;
 		break;
 
 	case Common::KEYCODE_LEFT:
@@ -188,8 +189,9 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 	case Common::KEYCODE_UP:
 	case Common::KEYCODE_HOME:
 		// Move caret to start
-		dirty = setCaretPos(0);
+		setCaretPos(0);
 		forcecaret = true;
+		dirty = true;
 		break;
 
 	case Common::KEYCODE_v:


### PR DESCRIPTION
- Fix a small issue of 2 chars being wobbled together if pressing home/end in EditableWidgets.
- Fix warnings being repeatedly printed in the console, when using an RTL language with FriBiDi disabled.