### PR TITLE
DIRECTOR: Extend --start-movie to start at frame

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -169,7 +169,8 @@ static const char HELP_STRING[] =
 	"  --demo-mode              Start demo mode of Maniac Mansion or The 7th Guest\n"
 #endif
 #if defined(ENABLE_DIRECTOR)
-	"  --start-movie=NAME       Start movie for Director\n"
+	"  --start-movie=NAME@NUM   Start movie at frame for Director\n"
+	"							Either can be specified without the other.\n"
 #endif
 #ifdef ENABLE_SCUMM
 	"  --tempo=NUM              Set music tempo (in percent, 50-200) for SCUMM games\n"

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -59,10 +59,26 @@ Common::Language DirectorEngine::getLanguage() const {
 }
 
 Common::String DirectorEngine::getEXEName() const {
-	if (ConfMan.hasKey("start_movie"))
-		return ConfMan.get("start_movie");
+	StartMovie startMovie = getStartMovie();
+	if (startMovie.startMovie.size() > 0)
+		return startMovie.startMovie;
 
 	return _gameDescription->desc.filesDescriptions[0].fileName;
+}
+
+StartMovie DirectorEngine::getStartMovie() const {
+	StartMovie startMovie;
+	startMovie.startFrame = -1;
+
+	if (ConfMan.hasKey("start_movie")) {
+		Common::String option = ConfMan.get("start_movie");
+		int colonPos = option.findLastOf("@");
+		startMovie.startMovie = option.substr(0, colonPos);
+		Common::String tail = option.substr(colonPos + 1, option.size());
+		if (tail.size() > 0)
+			startMovie.startFrame = atoi(tail.c_str());
+	}
+	return startMovie;
 }
 
 bool DirectorEngine::hasFeature(EngineFeature f) const {

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -96,6 +96,11 @@ struct MovieReference {
 	MovieReference() { frameI = -1; }
 };
 
+struct StartMovie {
+	Common::String startMovie;
+	int16 startFrame;
+};
+
 struct PaletteV4 {
 	int id;
 	byte *palette;
@@ -165,6 +170,7 @@ public:
 	Common::Platform getPlatform() const;
 	Common::Language getLanguage() const;
 	Common::String getEXEName() const;
+	StartMovie getStartMovie() const;
 	DirectorSound *getSoundManager() const { return _soundManager; }
 	Graphics::MacWindowManager *getMacWindowManager() const { return _wm; }
 	Archive *getMainArchive() const;

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -1090,9 +1090,9 @@ void Lingo::runTests() {
 
 	LingoArchive *mainArchive = g_director->getCurrentMovie()->getMainLingoArch();
 
-	// Repurpose commandline option --start-movie to run a specific lingo script.
-	if (ConfMan.hasKey("start_movie")) {
-		fileList.push_back(ConfMan.get("start_movie"));
+	Common::String startMovie = _vm->getStartMovie().startMovie;
+	if (startMovie.size() > 0) {
+		fileList.push_back(startMovie);
 	} else {
 		for (Common::ArchiveMemberList::iterator it = fsList.begin(); it != fsList.end(); ++it)
 			fileList.push_back((*it)->getName());

--- a/engines/director/stage.cpp
+++ b/engines/director/stage.cpp
@@ -54,6 +54,7 @@ Stage::Stage(int id, bool scrollable, bool resizable, bool editable, Graphics::M
 	_newMovieStarted = true;
 
 	_objType = kWindowObj;
+	_startFrame = _vm->getStartMovie().startFrame;
 }
 
 Stage::~Stage() {
@@ -470,6 +471,10 @@ bool Stage::step() {
 				if (!debugChannelSet(-1, kDebugCompileOnly) && goodMovie) {
 					debugC(1, kDebugEvents, "Starting playback of movie '%s'", _currentMovie->getMacName().c_str());
 					_currentMovie->getScore()->startPlay();
+					if (_startFrame != -1) {
+						_currentMovie->getScore()->setCurrentFrame(_startFrame);
+						_startFrame = -1;
+					}
 				} else {
 					return false;
 				}

--- a/engines/director/stage.h
+++ b/engines/director/stage.h
@@ -169,6 +169,7 @@ private:
 	Movie *_currentMovie;
 	Common::String _currentPath;
 	Common::StringArray _movieQueue;
+	int16 _startFrame;
 
 private:
 	int preprocessColor(DirectorPlotData *p, int src);


### PR DESCRIPTION
A frame number can be given to --start-movie and it will start
at that frame.
Examples:
    --start-movie=movie.dir:45  # start movie.dir at frame 45
    --start-movie=:23           # start the default movie frame 23
    --start-movie=movie.dir     # start movie.dir as usual