### PR TITLE
DIRECTOR: LINGO: Add FlushXObject

### DIFF
--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -31,6 +31,7 @@
 #include "director/lingo/lingo-the.h"
 #include "director/lingo/lingo-gr.h"
 #include "director/lingo/xlibs/fileio.h"
+#include "director/lingo/xlibs/flushxobj.h"
 
 namespace Director {
 
@@ -96,6 +97,7 @@ static struct XLibProto {
 	int version;
 } xlibs[] = {
 	{ "FileIO",					FileIO::initialize,					kXObj | kFactoryObj,	2 },	// D2
+	{ "FlushXObj",				FlushXObj::initialize,				kXObj,					4 },	// D4
 	{ 0, 0, 0, 0 }
 };
 
@@ -115,7 +117,12 @@ void Lingo::initXLibs() {
 	}
 }
 
-void Lingo::openXLib(const Common::String &name, ObjectType type) {
+void Lingo::openXLib(Common::String name, ObjectType type) {
+	if (_vm->getPlatform() == Common::kPlatformMacintosh) {
+		int pos = name.findLastOf(':');
+		name = name.substr(pos + 1, name.size());
+	}
+
 	if (_xlibInitializers.contains(name)) {
 		Symbol sym = _xlibInitializers[name];
 		(*sym.u.bltin)(type);

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -250,7 +250,7 @@ public:
 	void initBytecode();
 	void initMethods();
 	void initXLibs();
-	void openXLib(const Common::String &name, ObjectType type);
+	void openXLib(Common::String name, ObjectType type);
 
 	void runTests();
 

--- a/engines/director/lingo/tests/flushXObj.lingo
+++ b/engines/director/lingo/tests/flushXObj.lingo
@@ -1,0 +1,8 @@
+openXlib("FlushXObj")
+put FlushXObj
+set flush = FlushXObj(mNew)
+flush(mClearMask)
+flush(mAddToMask, 0, 0)
+flush(mFlush)
+flush(mFlushEvents, 0, 0)
+

--- a/engines/director/lingo/xlibs/flushxobj.cpp
+++ b/engines/director/lingo/xlibs/flushxobj.cpp
@@ -1,0 +1,98 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/* FlushXObj is a Mac only XObject to call the underlying FlushEvents function
+ * from the Macintosh Toolbox. Its purpose is to flush, i.e. remove, events 
+ * that happened while loading code.
+ *
+ * Implemented as a no-op, there's no need to flush events because:
+ * - ScummVM handles them and
+ * - computers were slower and queued events when the program was loading.
+ *
+ * More information about the Toolbox and the flush events can be found here:
+ * https://en.wikipedia.org/wiki/Macintosh_Toolbox
+ * https://developer.apple.com/legacy/library/documentation/mac/pdf/MacintoshToolboxEssentials.pdf
+ * 
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/flushxobj.h"
+
+
+namespace Director {
+
+static const char *xlibName = "FlushXObj";
+
+static MethodProto xlibMethods[] = {
+	{ "new",				FlushXObj::m_new,				 0, 0,	4 },	// D4
+	{ "AddToMask",			FlushXObj::m_addToMask,			 2, 2,	4 },	// D4
+	{ "ClearMask",			FlushXObj::m_clearMask,			 0, 0,	4 },	// D4
+    { "Flush",              FlushXObj::m_flush,              0, 0,  4 },    // D4
+    { "FlushEvents",        FlushXObj::m_flushEvents,        2, 2,  4 },    // D4
+	{ 0, 0, 0, 0, 0 }
+};
+
+void FlushXObj::initialize(int type) {
+    FlushXObject::initMethods(xlibMethods);
+	if (type & kXObj) {
+		if (!g_lingo->_globalvars.contains(xlibName)) {
+			FlushXObject *xobj = new FlushXObject(kXObj);
+			g_lingo->_globalvars[xlibName] = xobj;
+		} else {
+			warning("FlushXObject already initialized");
+		}
+	}
+}
+
+
+FlushXObject::FlushXObject(ObjectType ObjectType) :Object<FlushXObject>("FlushXObj") {
+    _objType = ObjectType;
+}
+
+void FlushXObj::m_new(int nargs) {
+    g_lingo->push(g_lingo->_currentMe);
+}
+
+void FlushXObj::m_clearMask(int nargs) {
+    debug(5, "FlushXobj::m_clearMask: no-op");
+}
+
+void FlushXObj::m_addToMask(int nargs) {
+    g_lingo->pop();
+    g_lingo->pop();
+
+    debug(5, "FlushXobj::m_addToMask: no-op");
+}
+
+void FlushXObj::m_flush(int nargs) {
+    debug(5, "FlushXobj::m_flush: no-op");
+}
+
+void FlushXObj::m_flushEvents(int nargs) {
+    g_lingo->pop();
+    g_lingo->pop();
+    debug(5, "FlushXobj::m_flush: no-op");
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/flushxobj.h
+++ b/engines/director/lingo/xlibs/flushxobj.h
@@ -1,0 +1,45 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XOBJECT_FLUSHXOBJ_H
+#define DIRECTOR_LINGO_XOBJECT_FLUSHXOBJ_H
+
+namespace Director {
+
+class FlushXObject : public Object<FlushXObject> {
+public:
+    FlushXObject(ObjectType objType);
+};
+
+namespace FlushXObj {
+    void initialize(int type);
+
+    void m_new(int nargs);
+    void m_clearMask(int nargs);
+    void m_addToMask(int nargs);
+    void m_flush(int nargs);
+    void m_flushEvents(int nargs);
+} // End of namespace FlushXObj
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -36,7 +36,8 @@ MODULE_OBJS = \
 	lingo/lingo-patcher.o \
 	lingo/lingo-preprocessor.o \
 	lingo/lingo-the.o \
-	lingo/xlibs/fileio.o
+	lingo/xlibs/fileio.o \
+	lingo/xlibs/flushxobj.o
 
 director-grammar:
 	`brew --prefix flex`/bin/flex engines/director/lingo/lingo-lex.l


### PR DESCRIPTION
FlushXObj is a Mac only XObject to call the underlying FlushEvents function
from the Macintosh Toolbox. Its purpose is to flush, i.e. remove, events
that happened while loading code.

Implemented as a no-op, there's no need to flush events because:
 - ScummVM handles them and
 - computers were slower and queued events when the program was loading.

More information about the Toolbox and the flush events can be found here:
 https://en.wikipedia.org/wiki/Macintosh_Toolbox
 https://developer.apple.com/legacy/library/documentation/mac/pdf/MacintoshToolboxEssentials.pdf