### PR TITLE
DIRECTOR: LINGO: Add scripts to the correct cast

### DIFF
--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -71,6 +71,7 @@ public:
 	void setCastMemberModified(int castId);
 	CastMember *getCastMember(int castId);
 	CastMember *getCastMemberByName(const Common::String &name);
+	CastMember *getCastMemberByScriptId(int scriptId);
 	CastMemberInfo *getCastMemberInfo(int castId);
 	const Stxt *getStxt(int castId);
 
@@ -106,6 +107,7 @@ private:
 
 	Common::HashMap<uint16, CastMemberInfo *> _castsInfo;
 	Common::HashMap<Common::String, int, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _castsNames;
+	Common::HashMap<uint16, int> _castsScriptIds;
 };
 
 } // End of namespace Director

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -898,7 +898,10 @@ ScriptContext *Lingo::compileLingoV4(Common::SeekableSubReadStreamEndian &stream
 	for (uint32 i = 0; i < 0x4; i++) {
 		stream.readByte();
 	}
-	uint16 castId = stream.readUint16();
+	/* uint16 castId = */ stream.readUint16();
+	// The script is coupled with to a Cast via the script ID.
+	// This castId isn't always correct.
+
 	int16 factoryNameId = stream.readSint16();
 
 	// offset 50 - contents map
@@ -928,15 +931,18 @@ ScriptContext *Lingo::compileLingoV4(Common::SeekableSubReadStreamEndian &stream
 	// initialise the script
 	ScriptType scriptType = kCastScript;
 	Common::String castName;
-	CastMember *member = g_director->getCurrentMovie()->getCastMember(castId);
+	CastMember *member = g_director->getCurrentMovie()->getCastMemberByScriptId(lctxIndex + 1);
+	uint16 castId;
 	if (member) {
 		if (member->_type == kCastLingoScript)
 			scriptType = ((ScriptCastMember *)member)->_scriptType;
 
+		castId = member->getID();
 		CastMemberInfo *info = g_director->getCurrentMovie()->getCastMemberInfo(castId);
 		if (info)
 			castName = info->name;
 	} else {
+		castId = -1;
 		warning("Script %d has invalid cast member %d", lctxIndex, castId);
 	}
 

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -1154,7 +1154,7 @@ ScriptContext *Lingo::compileLingoV4(Common::SeekableSubReadStreamEndian &stream
 	bool skipdump = false;
 
 	if (ConfMan.getBool("dump_scripts")) {
-		Common::String buf = dumpScriptName(archName.c_str(), scriptType, lctxIndex, "lscr");
+		Common::String buf = dumpScriptName(archName.c_str(), scriptType, castId, "lscr");
 
 		if (!out.open(buf, true)) {
 			warning("Lingo::addCodeV4(): Can not open dump file %s", buf.c_str());

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -288,6 +288,14 @@ CastMember *Movie::getCastMemberByName(const Common::String &name) {
 	return result;
 }
 
+CastMember *Movie::getCastMemberByScriptId(int scriptId) {
+	CastMember *result = _cast->getCastMemberByScriptId(scriptId);
+	if (result == nullptr && _sharedCast) {
+		result = _sharedCast->getCastMemberByScriptId(scriptId);
+	}
+	return result;
+}
+
 CastMemberInfo *Movie::getCastMemberInfo(int castId) {
 	CastMemberInfo *result = _cast->getCastMemberInfo(castId);
 	if (result == nullptr && _sharedCast) {

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -104,6 +104,7 @@ public:
 
 	CastMember *getCastMember(int castId);
 	CastMember *getCastMemberByName(const Common::String &name);
+	CastMember *getCastMemberByScriptId(int scriptId);
 	CastMemberInfo *getCastMemberInfo(int castId);
 	const Stxt *getStxt(int castId);
 


### PR DESCRIPTION
Repair the castIds of script when the scripts are loaded.
The castIds that are defined in the scripts can be wrong.
A better way to link scripts with casts is via the scriptId.

To achieve this casts need to be fetched by their scriptId.
This commit implements the necessary getCastMemberByScript functions
to enable fetching a cast by it's scriptId.