### PR TITLE
SCUMM: Some graphics rendering cleanup

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -2210,11 +2210,10 @@ void ScummEngine_v90he::processActors() {
 // Used in Scumm v8, to allow the verb coin to be drawn over the inventory
 // chest. I'm assuming that draw order won't matter here.
 int ScummEngine::processUpperActors() {
-	int i;
 	_upperActorQueuePos = 0;
 
 	_processing_upper_actors = true;
-	for (i = 1; i < _numActors; i++) {
+	for (int i = 1; i < _numActors; i++) {
 		if (_actors[i]->isInCurrentRoom() && _actors[i]->_costume && _actors[i]->_layer < 0) {
 			_actors[i]->drawActorCostume(false, &_virtscr[kVerbVirtScreen]);
 			_actors[i]->animateCostume();
@@ -2228,8 +2227,7 @@ int ScummEngine::processUpperActors() {
 void ScummEngine::removeUpperActors() {
 	int i;
 
-	for (i = 0; i < _upperActorQueuePos; i++) {
-		//restoreBackground(_blastTextQueue[i].rect);
+	for (int i = 0; i < _upperActorQueuePos; i++) {
 		_virtscr[kVerbVirtScreen].fillRect(_upperActorQueue[i], CHARSET_MASK_TRANSPARENCY);
 		markRectAsDirty(kMainVirtScreen, _upperActorQueue[i]);
 	}

--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -220,7 +220,7 @@ public:
 	void faceToObject(int obj);
 	void turnToDirection(int newdir);
 	virtual void walkActor();
-	void drawActorCostume(bool hitTestMode = false);
+	void drawActorCostume(bool hitTestMode = false, VirtScreen *vs = NULL);
 	virtual void prepareDrawActorCostume(BaseCostumeRenderer *bcr);
 	virtual void animateCostume();
 	virtual void setActorCostume(int c);

--- a/engines/scumm/akos.cpp
+++ b/engines/scumm/akos.cpp
@@ -930,8 +930,13 @@ byte AkosRenderer::codec1(int xmoveCur, int ymoveCur) {
 	if (_actorHitMode) {
 		if (_actorHitX < rect.left || _actorHitX >= rect.right || _actorHitY < rect.top || _actorHitY >= rect.bottom)
 			return 0;
-	} else
+	} else {
 		markRectAsDirty(rect);
+		if (_vm->_processing_upper_actors) {
+			_vm->_upperActorQueue[_vm->_upperActorQueuePos] = rect;
+			_vm->_upperActorQueuePos++;
+		}
+	}
 
 	if (rect.top >= v1.boundsRect.bottom || rect.bottom <= v1.boundsRect.top)
 		return 0;

--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -601,7 +601,7 @@ void CharsetRendererPCE::setColor(byte color) {
 }
 #endif
 
-void CharsetRendererV3::printChar(int chr, bool ignoreCharsetMask) {
+void CharsetRendererV3::printChar(int chr, bool ignoreCharsetMask, VirtScreen *_vs) {
 	// WORKAROUND for bug #1509509: Indy3 Mac does not show black
 	// characters (such as in the grail diary) if ignoreCharsetMask
 	// is true. See also patch #1851568.
@@ -719,7 +719,7 @@ void CharsetRenderer::saveLoadWithSerializer(Common::Serializer &ser) {
 	}
 }
 
-void CharsetRendererClassic::printChar(int chr, bool ignoreCharsetMask) {
+void CharsetRendererClassic::printChar(int chr, bool ignoreCharsetMask, VirtScreen *vs_) {
 	VirtScreen *vs;
 	bool is2byte = (chr >= 256 && _vm->_useCJKMode);
 
@@ -770,9 +770,15 @@ void CharsetRendererClassic::printChar(int chr, bool ignoreCharsetMask) {
 	if (_top < _str.top)
 		_str.top = _top;
 
+	if (vs_)
+		vs = vs_;
+
 	int drawTop = _top - vs->topline;
 
-	_vm->markRectAsDirty(vs->number, _left, _left + _width, drawTop, drawTop + _height);
+	if (_vm->_game.version >= 7)
+		_vm->markRectAsDirty(kMainVirtScreen, _left, _left + _width, drawTop, drawTop + _height);
+	else
+		_vm->markRectAsDirty(vs->number, _left, _left + _width, drawTop, drawTop + _height);
 
 	// This check for kPlatformFMTowns and kMainVirtScreen is at least required for the chat with
 	// the navigator's head in front of the ghost ship in Monkey Island 1
@@ -1251,7 +1257,7 @@ int CharsetRendererNut::getFontHeight() {
 	return _current->getCharHeight('|');
 }
 
-void CharsetRendererNut::printChar(int chr, bool ignoreCharsetMask) {
+void CharsetRendererNut::printChar(int chr, bool ignoreCharsetMask, VirtScreen *vs_) {
 	Common::Rect shadow;
 
 	assert(_current);
@@ -1287,7 +1293,7 @@ void CharsetRendererNut::printChar(int chr, bool ignoreCharsetMask) {
 
 	int drawTop = _top;
 	if (ignoreCharsetMask) {
-		VirtScreen *vs = &_vm->_virtscr[kMainVirtScreen];
+		VirtScreen *vs = (vs_) ? vs_ : &_vm->_virtscr[kMainVirtScreen];
 		s = *vs;
 		s.setPixels(vs->getPixels(0, 0));
 	} else {
@@ -1318,7 +1324,7 @@ void CharsetRendererNut::printChar(int chr, bool ignoreCharsetMask) {
 }
 #endif
 
-void CharsetRendererNES::printChar(int chr, bool ignoreCharsetMask) {
+void CharsetRendererNES::printChar(int chr, bool ignoreCharsetMask, VirtScreen *_vs) {
 	int width, height, origWidth, origHeight;
 	VirtScreen *vs;
 	byte *charPtr;

--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -818,7 +818,7 @@ void CharsetRendererClassic::printCharIntern(bool is2byte, const byte *charPtr, 
 		if (ignoreCharsetMask || !vs->hasTwoBuffers) {
 			dstPtr = vs->getPixels(0, 0);
 		} else {
-			dstPtr = (byte *)_vm->_textSurface.getPixels();
+			dstPtr = (byte *)_vm->_textSurface.getBasePtr(0, 0);
 		}
 
 		if (_blitAlso && vs->hasTwoBuffers) {

--- a/engines/scumm/charset.h
+++ b/engines/scumm/charset.h
@@ -129,7 +129,7 @@ public:
 class CharsetRendererClassic : public CharsetRendererPC {
 protected:
 	virtual void drawBitsN(const Graphics::Surface &s, byte *dst, const byte *src, byte bpp, int drawTop, int width, int height);
-	void printCharIntern(bool is2byte, const byte *charPtr, int origWidth, int origHeight, int width, int height, VirtScreen *vs, bool ignoreCharsetMask);
+	bool printCharIntern(bool is2byte, const byte *charPtr, int origWidth, int origHeight, int width, int height, VirtScreen *vs, bool ignoreCharsetMask);
 	virtual bool prepareDraw(uint16 chr);
 
 	int _width, _height, _origWidth, _origHeight;

--- a/engines/scumm/charset.h
+++ b/engines/scumm/charset.h
@@ -72,7 +72,7 @@ public:
 	CharsetRenderer(ScummEngine *vm);
 	virtual ~CharsetRenderer();
 
-	virtual void printChar(int chr, bool ignoreCharsetMask) = 0;
+	virtual void printChar(int chr, bool ignoreCharsetMask, VirtScreen *vs_ = NULL) = 0;
 	virtual void drawChar(int chr, Graphics::Surface &s, int x, int y) {}
 
 	int getStringWidth(int a, const byte *str);
@@ -142,7 +142,7 @@ protected:
 public:
 	CharsetRendererClassic(ScummEngine *vm) : CharsetRendererPC(vm) {}
 
-	void printChar(int chr, bool ignoreCharsetMask) override;
+	void printChar(int chr, bool ignoreCharsetMask, VirtScreen *_vs = NULL) override;
 	void drawChar(int chr, Graphics::Surface &s, int x, int y) override;
 
 	int getCharWidth(uint16 chr) override;
@@ -179,7 +179,7 @@ public:
 	CharsetRendererNES(ScummEngine *vm) : CharsetRendererCommon(vm) {}
 
 	void setCurID(int32 id) override {}
-	void printChar(int chr, bool ignoreCharsetMask) override;
+	void printChar(int chr, bool ignoreCharsetMask, VirtScreen *_vs = NULL) override;
 	void drawChar(int chr, Graphics::Surface &s, int x, int y) override;
 
 	int getFontHeight() override { return 8; }
@@ -197,7 +197,7 @@ protected:
 public:
 	CharsetRendererV3(ScummEngine *vm) : CharsetRendererPC(vm) {}
 
-	void printChar(int chr, bool ignoreCharsetMask) override;
+	void printChar(int chr, bool ignoreCharsetMask, VirtScreen *_vs = NULL) override;
 	void drawChar(int chr, Graphics::Surface &s, int x, int y) override;
 	void setCurID(int32 id) override;
 	void setColor(byte color) override;
@@ -262,7 +262,7 @@ public:
 	CharsetRendererNut(ScummEngine *vm);
 	~CharsetRendererNut() override;
 
-	void printChar(int chr, bool ignoreCharsetMask) override;
+	void printChar(int chr, bool ignoreCharsetMask, VirtScreen *vs_ = NULL) override;
 
 	void setCurID(int32 id) override;
 

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -344,11 +344,14 @@ void ScummEngine::initScreens(int b, int h) {
 		// Use the mostly unused Unk virtual screen for blast objects for V6+.
 		initVirtScreen(kUnkVirtScreen, adj, _screenWidth, _screenHeight, false, false); // Use for blast objects
 		_virtscr[kUnkVirtScreen].fillRect(clear_rect, CHARSET_MASK_TRANSPARENCY);
-
-		if (_game.version >= 7) {
+		if (_game.version == 6) {
+			// Initialize these like the previous version screens for DoTT.
+			initVirtScreen(kTextVirtScreen, adj, _screenWidth, b, false, false);
+			initVirtScreen(kVerbVirtScreen, h + adj, _screenWidth, _screenHeight - h - adj, false, false);
+		}
+		else if (_game.version >= 7) {
 			// V7+ games only used the main virtual screen, so let's repurpose these
 			// three "unused" screens as blast text and verb coin layers.
-			
 			initVirtScreen(kTextVirtScreen, adj, _screenWidth, _screenHeight, false, false);
 			initVirtScreen(kVerbVirtScreen, adj, _screenWidth, _screenHeight, false, false);
 			_virtscr[kTextVirtScreen].fillRect(clear_rect, CHARSET_MASK_TRANSPARENCY);
@@ -450,6 +453,8 @@ void ScummEngine::initVirtScreen(VirtScreenNumber slot, int top, int width, int 
 			vs->backBuf = (byte *)malloc(size);
 		else
 			vs->backBuf = NULL;
+
+		vs->byte_size = size;
 	}
 
 	if (_game.platform == Common::kPlatformNES)

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -622,7 +622,7 @@ void ScummEngine::drawStripToScreen(VirtScreen *vs, int x, int width, int top, i
 	// Some paranoia checks
 	assert(top >= 0 && bottom <= vs->h);
 	assert(x >= 0 && width <= vs->pitch);
-	assert(_textSurface.getPixels());
+	assert(_textSurface.getBasePtr(0, 0));
 
 	// Perform some clipping
 	if (width > vs->w - x)
@@ -1115,7 +1115,7 @@ void ScummEngine::clearTextSurface() {
 		_townsScreen->fillLayerRect(1, 0, 0, _textSurface.w, _textSurface.h, 0);
 #endif
 
-	fill((byte *)_textSurface.getPixels(),  _textSurface.pitch,
+	fill((byte *)_textSurface.getBasePtr(0, 0),  _textSurface.pitch,
 #ifndef DISABLE_TOWNS_DUAL_LAYER_MODE
 		_game.platform == Common::kPlatformFMTowns ? 0 :
 #endif

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -348,8 +348,7 @@ void ScummEngine::initScreens(int b, int h) {
 			// Initialize these like the previous version screens for DoTT.
 			initVirtScreen(kTextVirtScreen, adj, _screenWidth, b, false, false);
 			initVirtScreen(kVerbVirtScreen, h + adj, _screenWidth, _screenHeight - h - adj, false, false);
-		}
-		else if (_game.version >= 7) {
+		} else if (_game.version >= 7) {
 			// V7+ games only used the main virtual screen, so let's repurpose these
 			// three "unused" screens as blast text and verb coin layers.
 			initVirtScreen(kTextVirtScreen, adj, _screenWidth, _screenHeight, false, false);
@@ -357,8 +356,7 @@ void ScummEngine::initScreens(int b, int h) {
 			_virtscr[kTextVirtScreen].fillRect(clear_rect, CHARSET_MASK_TRANSPARENCY);
 			_virtscr[kVerbVirtScreen].fillRect(clear_rect, CHARSET_MASK_TRANSPARENCY);
 		}
-	}
-	else {
+	} else {
 		if (!_virtscr[kUnkVirtScreen].getBasePtr(0,0)) {
 			// Since the size of screen 3 is fixed, there is no need to reallocate
 			// it if its size changed.
@@ -440,7 +438,7 @@ void ScummEngine::initVirtScreen(VirtScreenNumber slot, int top, int width, int 
 
 	// No need to reallocate the memory if the allocated screen is the same
 	// size in bytes as before.
-	if (size != vs->byte_size) {
+	if (size != vs->bufferSize) {
 		if (vs->getBasePtr(0,0))
 			free(vs->getBasePtr(0,0));
 		byte *ptr = (byte *)malloc(size);
@@ -454,7 +452,7 @@ void ScummEngine::initVirtScreen(VirtScreenNumber slot, int top, int width, int 
 		else
 			vs->backBuf = NULL;
 
-		vs->byte_size = size;
+		vs->bufferSize = size;
 	}
 
 	if (_game.platform == Common::kPlatformNES)
@@ -583,8 +581,7 @@ void ScummEngine_v6::drawDirtyScreenParts() {
 		_layers[0] = (!_blastObjectQueuePos) ? NULL : &_virtscr[kUnkVirtScreen];
 		_layers[1] = NULL;
 		_layers[3] = (!_blastTextQueuePos) ? NULL : &_virtscr[kTextVirtScreen];
-	}
-	else {
+	} else {
 		updateDirtyScreen(kVerbVirtScreen);
 		updateDirtyScreen(kTextVirtScreen);
 	}
@@ -1174,7 +1171,6 @@ void ScummEngine::restoreCharsetBg() {
 		_charset->_left = -1;
 
 		int i;
-		int w = 8;
 		int start = 0;
 
 		// Clear out any dirty rects that have been marked on the text surface.
@@ -1183,6 +1179,7 @@ void ScummEngine::restoreCharsetBg() {
 			return;
 
 		for (i = 0; i < _gdi->_numStrips; i++) {
+			static int w = 8;
 			if (vs->bdirty[i]) {
 				const int top = vs->tdirty[i];
 				const int bottom = vs->bdirty[i];
@@ -1192,7 +1189,6 @@ void ScummEngine::restoreCharsetBg() {
 					w += 8;
 					continue;
 				}
-				debug(9, "Restore charset BG rect: %d,%d-%d,%d", start * 8, top, (start * 8) + w, bottom);
 				Common::Rect r(start * 8, top, (start * 8) + w, bottom);
 				vs->fillRect(r, CHARSET_MASK_TRANSPARENCY);
 				markRectAsDirty(kMainVirtScreen, r, USAGE_BIT_RESTORED);

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -722,9 +722,11 @@ void ScummEngine::drawStripToScreen(VirtScreen *vs, int x, int width, int top, i
 		blit(dst, width * bpp, srcPtr, vs->pitch, width, height, bpp);
 	
 #endif
-		if (_game.heversion == 0) { // If 16-bit color HE game using old charset, draw nothing.
-		masked_blit(dst, width * bpp, textPtr, vs->pitch, width, height, bpp,
-			(bpp == 4) ? CHARSET_MASK_TRANSPARENCY_32 : CHARSET_MASK_TRANSPARENCY, _16BitPalette);
+		// 16-bit color HE games and the NES version of Maniac Mansion do not
+		// use the text surface.
+		if (_game.heversion == 0 && _game.platform != Common::kPlatformNES) {
+			masked_blit(dst, width * bpp, textPtr, vs->pitch, width, height, bpp,
+				(bpp == 4) ? CHARSET_MASK_TRANSPARENCY_32 : CHARSET_MASK_TRANSPARENCY, _16BitPalette);
 		}
 
 		src = _compositeBuf;
@@ -1199,9 +1201,16 @@ void ScummEngine::restoreCharsetBg() {
 			start = i + 1;
 		}
 
-		if (_game.platform == Common::kPlatformNES) {
+		if (_game.version <= 3) {
+			vs = &_virtscr[kTextVirtScreen];
 			byte *screenBuf = vs->getPixels(0, 0);
-			memset(screenBuf, 0x1d, vs->h * vs->pitch);
+			
+			if (_game.platform == Common::kPlatformNES)
+				memset(screenBuf, 0x1d, vs->h * vs->pitch);
+			else
+				memset(screenBuf, 0x00, vs->h * vs->pitch);
+
+			markRectAsDirty(kTextVirtScreen, Common::Rect(0, 0, vs->w, vs->h), USAGE_BIT_RESTORED);
 		}
 
 		if (vs->hasTwoBuffers) {

--- a/engines/scumm/gfx.h
+++ b/engines/scumm/gfx.h
@@ -69,10 +69,11 @@ struct CameraData {
 
 /** Virtual screen identifiers */
 enum VirtScreenNumber {
-	kMainVirtScreen = 0,	// The 'stage'
-	kTextVirtScreen = 1,	// In V0-V3 games: the area where text is printed
-	kVerbVirtScreen = 2,	// The verb area
-	kUnkVirtScreen = 3		// ?? Not sure what this one is good for...
+	kMainVirtScreen,	// The 'stage'
+	kTextVirtScreen,	// In V0-V3 games: the area where text is printed
+	kVerbVirtScreen,	// The verb area
+	kUnkVirtScreen,		// ?? Not sure what this one is good for...
+	kNumVirtScreens
 };
 
 /**
@@ -155,6 +156,12 @@ struct VirtScreen : Graphics::Surface {
 	 * the screen.
 	 */
 	uint16 bdirty[80 + 1];
+
+	/**
+	 * The size of the allocated memory area in bytes.
+	 * Mostly useful to avoid unnecessary re-allocations of the buffer.
+	 */
+	int byte_size;
 
 	/**
 	 * Convenience method to set the whole tdirty and bdirty arrays to one

--- a/engines/scumm/gfx.h
+++ b/engines/scumm/gfx.h
@@ -69,12 +69,12 @@ struct CameraData {
 
 /** Virtual screen identifiers */
 enum VirtScreenNumber {
-	kMainVirtScreen,	// The 'stage'
-	kTextVirtScreen,	// In V0-V3 games: the area where text is printed
-	kVerbVirtScreen,	// The verb area
-	kUnkVirtScreen,		// ?? Not sure what this one is good for...
-	kNumVirtScreens,
-	kTextSurface		// The text surface exists outside the main virtscreen index
+	kMainVirtScreen = 0,	// The 'stage'
+	kTextVirtScreen = 1,	// In V0-V3 games: the area where text is printed
+	kVerbVirtScreen = 2,	// The verb area
+	kUnkVirtScreen  = 3,	// ?? Not sure what this one is good for...
+	kNumVirtScreens = 4,
+	kTextSurface    = 5		// The text surface exists outside the main virtscreen index
 };
 
 /**
@@ -162,7 +162,7 @@ struct VirtScreen : Graphics::Surface {
 	 * The size of the allocated memory area in bytes.
 	 * Mostly useful to avoid unnecessary re-allocations of the buffer.
 	 */
-	int byte_size;
+	int bufferSize;
 
 	/**
 	 * Convenience method to set the whole tdirty and bdirty arrays to one

--- a/engines/scumm/gfx.h
+++ b/engines/scumm/gfx.h
@@ -73,7 +73,8 @@ enum VirtScreenNumber {
 	kTextVirtScreen,	// In V0-V3 games: the area where text is printed
 	kVerbVirtScreen,	// The verb area
 	kUnkVirtScreen,		// ?? Not sure what this one is good for...
-	kNumVirtScreens
+	kNumVirtScreens,
+	kTextSurface		// The text surface exists outside the main virtscreen index
 };
 
 /**

--- a/engines/scumm/gfx_towns.cpp
+++ b/engines/scumm/gfx_towns.cpp
@@ -35,7 +35,7 @@ void ScummEngine::towns_drawStripToScreen(VirtScreen *vs, int dstX, int dstY, in
 	if (width <= 0 || height <= 0)
 		return;
 
-	assert(_textSurface.getPixels());
+	assert(_textSurface.getBasePtr(0, 0));
 
 	int m = _textSurfaceMultiplier;
 

--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -1697,23 +1697,23 @@ void ScummEngine_v6::enqueueObject(int objectNumber, int objectX, int objectY, i
 	eo->mode = mode;
 }
 
-void ScummEngine_v6::drawBlastObjects() {
+void ScummEngine_v6::drawBlastObjects(VirtScreen *vs) {
 	BlastObject *eo;
 	int i;
 
 	eo = _blastObjectQueue;
 	for (i = 0; i < _blastObjectQueuePos; i++, eo++) {
-		drawBlastObject(eo);
+		drawBlastObject(eo, vs);
 	}
 }
 
-void ScummEngine_v6::drawBlastObject(BlastObject *eo) {
+void ScummEngine_v6::drawBlastObject(BlastObject *eo, VirtScreen *vs_) {
 	VirtScreen *vs;
 	const byte *bomp, *ptr;
 	int objnum;
 	BompDrawData bdd;
 
-	vs = &_virtscr[kMainVirtScreen];
+	vs = (vs_) ? vs_ : &_virtscr[kUnkVirtScreen];
 
 	assertRange(30, eo->number, _numGlobalObjects - 1, "blast object");
 
@@ -1776,16 +1776,20 @@ void ScummEngine_v6::drawBlastObject(BlastObject *eo) {
 
 	drawBomp(bdd);
 
-	markRectAsDirty(vs->number, bdd.x, bdd.x + bdd.srcwidth, bdd.y, bdd.y + bdd.srcheight);
+	markRectAsDirty(kMainVirtScreen, bdd.x, bdd.x + bdd.srcwidth, bdd.y, bdd.y + bdd.srcheight);
 }
 
-void ScummEngine_v6::removeBlastObjects() {
+void ScummEngine_v6::removeBlastObjects(VirtScreen *vs_) {
 	BlastObject *eo;
 	int i;
 
+	VirtScreen *vs = (vs_) ? vs_ : &_virtscr[kUnkVirtScreen];
+
 	eo = _blastObjectQueue;
 	for (i = 0; i < _blastObjectQueuePos; i++, eo++) {
-		removeBlastObject(eo);
+		//removeBlastObject(eo);
+		vs->fillRect(_blastObjectQueue[i].rect, CHARSET_MASK_TRANSPARENCY);
+		markRectAsDirty(kMainVirtScreen, _blastObjectQueue[i].rect);
 	}
 	_blastObjectQueuePos = 0;
 }

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1428,6 +1428,7 @@ void ScummEngine::setupScumm() {
 	}
 
 	int maxHeapThreshold = -1;
+	int minHeapThreshold = 400000;
 
 	if (_game.features & GF_16BIT_COLOR) {
 		// 16bit color games require double the memory, due to increased resource sizes.
@@ -1436,11 +1437,23 @@ void ScummEngine::setupScumm() {
 		// Since the new costumes are very big, we increase the heap limit, to avoid having
 		// to constantly reload stuff from the data files.
 		maxHeapThreshold = 6 * 1024 * 1024;
+		if (_game.id == GID_CMI) {
+			// A minimum heap threshold of 400000 causes COMI to very often swap out and
+			// reload resources when something in the current room is animating, can be
+			// observed for instance when Wally cries in the very first scene.
+			// The game is also very often over the max heap threshold due to loaded
+			// resources that can't be easily discarded. This will obviously not work very
+			// well on a host with less than 6MB of RAM, but it would've broken on there
+			// regardless since resource usage is very often above 6MB even with resources
+			// being discarded too often.
+			maxHeapThreshold = 12 * 1024 * 1024;
+			minHeapThreshold = 6 * 1024 * 1024;
+		}
 	} else {
 		maxHeapThreshold = 550000;
 	}
 
-	_res->setHeapThreshold(400000, maxHeapThreshold);
+	_res->setHeapThreshold(minHeapThreshold, maxHeapThreshold);
 
 	free(_compositeBuf);
 	_compositeBuf = (byte *)malloc(_screenWidth * _textSurfaceMultiplier * _screenHeight * _textSurfaceMultiplier * _outputPixelFormat.bytesPerPixel);

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -651,6 +651,15 @@ ScummEngine::~ScummEngine() {
 
 	free(_16BitPalette);
 
+	for (int i = 0; i < kNumVirtScreens; i++) {
+		if (_virtscr[i].getBasePtr(0,0)) {
+			free(_virtscr[i].getBasePtr(0,0));
+			_virtscr[i].setPixels((void *)0);
+		}
+		if (_virtscr[i].backBuf)
+			free(_virtscr[i].backBuf);
+	}
+
 #ifndef DISABLE_TOWNS_DUAL_LAYER_MODE
 	delete _townsScreen;
 #ifdef USE_RGB_COLOR

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1369,7 +1369,9 @@ void ScummEngine::setupScumm() {
 	setupCharsetRenderer();
 
 	// Create and clear the text surface
+	memset((void *)&_textSurface, 0x00, sizeof(VirtScreen));
 	_textSurface.create(_screenWidth * _textSurfaceMultiplier, _screenHeight * _textSurfaceMultiplier, Graphics::PixelFormat::createFormatCLUT8());
+	_textSurface.number = kTextSurface;
 	clearTextSurface();
 
 	// Create the costume renderer

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -785,6 +785,11 @@ int ScummEngine_v0::DelayCalculateDelta() {
 
 ScummEngine_v6::ScummEngine_v6(OSystem *syst, const DetectorResult &dr)
 	: ScummEngine(syst, dr) {
+	
+	for (int i = 0; i < kNumVirtScreens; i++) {
+		_layers[i] = NULL;
+	}
+
 	_blastObjectQueuePos = 0;
 	memset(_blastObjectQueue, 0, sizeof(_blastObjectQueue));
 	_blastTextQueuePos = 0;
@@ -1785,6 +1790,9 @@ void ScummEngine_v4::resetScumm() {
 
 void ScummEngine_v6::resetScumm() {
 	ScummEngine::resetScumm();
+	for (int i = 0; i < kNumVirtScreens; i++) {
+		_layers[i] = NULL;
+	}
 	setDefaultCursor();
 }
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -286,6 +286,7 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 	_hePalettes = NULL;
 	_hePaletteSlot = 0;
 	_16BitPalette = NULL;
+	_compositeBuf = NULL;
 #ifndef DISABLE_TOWNS_DUAL_LAYER_MODE
 	_townsScreen = 0;
 #ifdef USE_RGB_COLOR
@@ -574,12 +575,6 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 		sizeMult = 2;
 #endif
 #endif
-
-	// Allocate gfx compositing buffer (not needed for V7/V8 games).
-	if (_game.version < 7)
-		_compositeBuf = (byte *)malloc(_screenWidth * _screenHeight * sizeMult);
-	else
-		_compositeBuf = 0;
 
 	_herculesBuf = 0;
 	if (_renderMode == Common::kRenderHercA || _renderMode == Common::kRenderHercG) {
@@ -1455,8 +1450,12 @@ void ScummEngine::setupScumm() {
 
 	_res->setHeapThreshold(minHeapThreshold, maxHeapThreshold);
 
-	free(_compositeBuf);
-	_compositeBuf = (byte *)malloc(_screenWidth * _textSurfaceMultiplier * _screenHeight * _textSurfaceMultiplier * _outputPixelFormat.bytesPerPixel);
+	if (_compositeBuf)
+		free(_compositeBuf);
+	if (_game.version < 7)
+		_compositeBuf = (byte *)malloc(_screenWidth * _textSurfaceMultiplier * _screenHeight * _textSurfaceMultiplier * _outputPixelFormat.bytesPerPixel);
+	else
+		_compositeBuf = (byte *)malloc((_screenWidth * 2) * _textSurfaceMultiplier * (_screenHeight * 2) * _textSurfaceMultiplier * _outputPixelFormat.bytesPerPixel);
 }
 
 #ifdef ENABLE_SCUMM_7_8

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -903,7 +903,8 @@ protected:
 	void resetV1ActorTalkColor();
 	void resetActorBgs();
 	virtual void processActors();
-	void processUpperActors();
+	int processUpperActors();
+	void removeUpperActors();
 	virtual int getActorFromPos(int x, int y);
 
 public:
@@ -916,6 +917,10 @@ public:
 	int16 _talkDelay;
 	int _NES_lastTalkingActor;
 	int _NES_talkColor;
+
+	int _upperActorQueuePos;
+	Common::Rect _upperActorQueue[10];
+	bool _processing_upper_actors;
 
 	virtual void actorTalk(const byte *msg);
 	void stopTalk();
@@ -1049,7 +1054,7 @@ protected:
 
 	virtual void drawDirtyScreenParts();
 	void updateDirtyScreen(VirtScreenNumber slot);
-	void drawStripToScreen(VirtScreen *vs, int x, int w, int t, int b);
+	virtual void drawStripToScreen(VirtScreen *vs, int x, int w, int t, int b);
 	void ditherCGA(byte *dst, int dstPitch, int x, int y, int width, int height) const;
 
 public:
@@ -1187,8 +1192,9 @@ public:
 
 	/**
 	 * All text is normally rendered into this overlay surface. Then later
-	 * drawStripToScreen() composits it over the game graphics.
+	 * drawStripToScreen() composites it over the game graphics.
 	 */
+	VirtScreen _textSurface;
 	int _textSurfaceMultiplier;
 
 protected:

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -931,7 +931,7 @@ protected:
 public:
 	int _roomHeight, _roomWidth;
 	int _screenHeight, _screenWidth;
-	VirtScreen _virtscr[4];		// Virtual screen areas
+	VirtScreen _virtscr[kNumVirtScreens];		// Virtual screen areas
 	CameraData camera;			// 'Camera' - viewport
 
 	int _screenStartStrip, _screenEndStrip;
@@ -1189,7 +1189,6 @@ public:
 	 * All text is normally rendered into this overlay surface. Then later
 	 * drawStripToScreen() composits it over the game graphics.
 	 */
-	Graphics::Surface _textSurface;
 	int _textSurfaceMultiplier;
 
 protected:

--- a/engines/scumm/scumm_v6.h
+++ b/engines/scumm/scumm_v6.h
@@ -114,6 +114,7 @@ protected:
 
 	void palManipulateInit(int resID, int start, int end, int time) override;
 	void drawDirtyScreenParts() override;
+	void drawStripToScreen(VirtScreen *vs, int x, int width, int top, int bottom) override;
 
 	int getStackList(int *args, uint maxnum);
 	int popRoomAndObj(int *room);
@@ -144,9 +145,9 @@ protected:
 
 	void enqueueObject(int objectNumber, int objectX, int objectY, int objectWidth,
 	                   int objectHeight, int scaleX, int scaleY, int image, int mode);
-	void drawBlastObjects();
-	void drawBlastObject(BlastObject *eo);
-	void removeBlastObjects();
+	void drawBlastObjects(VirtScreen *vs = NULL);
+	void drawBlastObject(BlastObject *eo, VirtScreen *vs_ = NULL);
+	void removeBlastObjects(VirtScreen *vs_ = NULL);
 	void removeBlastObject(BlastObject *eo);
 
 	void clearDrawQueues() override;

--- a/engines/scumm/scumm_v6.h
+++ b/engines/scumm/scumm_v6.h
@@ -92,6 +92,8 @@ protected:
 	bool _forcedWaitForMessage;
 	bool _skipVideo;
 
+	VirtScreen *_layers[kNumVirtScreens];
+
 public:
 	ScummEngine_v6(OSystem *syst, const DetectorResult &dr);
 

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -199,7 +199,7 @@ void ScummEngine_v6::drawBlastTexts() {
 							c += *buf++ * 256;
 						}
 					}
-					_charset->printChar(c, true);
+					_charset->printChar(c, true, &_virtscr[kTextVirtScreen]);
 				}
 			} while (c && c != '\n');
 
@@ -214,7 +214,9 @@ void ScummEngine_v6::removeBlastTexts() {
 	int i;
 
 	for (i = 0; i < _blastTextQueuePos; i++) {
-		restoreBackground(_blastTextQueue[i].rect);
+		//restoreBackground(_blastTextQueue[i].rect);
+		_virtscr[kTextVirtScreen].fillRect(_blastTextQueue[i].rect, CHARSET_MASK_TRANSPARENCY);
+		markRectAsDirty(kMainVirtScreen, _blastTextQueue[i].rect);
 	}
 	_blastTextQueuePos = 0;
 }


### PR DESCRIPTION
While working on the AmigaOS 3 port of ScummVM, I ran into issues
with a lot of spread out code and looparounds, making it difficult to
add any optimizations that would allow the m68k processors in these
machines to run things better, so I wanted to clean up at least a bit
of the main graphics rendering loop.

There are still quite a few different memcpy/rendering loops in the
other files (charset, actor, etc.), but I will continue to look at
these as I make progress with getting the AmigaOS 3 port back
in better shape.

This lowers CPU load in games that do a lot of blast object/text
rendering, such as Curse of Monkey Island (naturally) and the
V6/V7 games by avoiding data copying in favor of just erasing dirty
rects from layers directly. The simple two layer rendering for
games like INDY4 may be a tiny bit slower than before, but not to
any noticeable extent even on an m68k processor.

NOTE:
I have not tested all SCUMM/HE games with these changes, but I did
test most of the ones I own to a reasonable extent to make sure that
everything seemed to be working correctly compared to before these
changes were made.)