### PR TITLE
GROOVIE: The 7th Guest MIDI fixes

### DIFF
--- a/engines/groovie/groovie.h
+++ b/engines/groovie/groovie.h
@@ -111,6 +111,7 @@ protected:
 
 public:
 	void waitForInput();
+	bool isWaitingForInput() { return _waitingForInput; }
 
 	Graphics::PixelFormat _pixelFormat;
 	bool _spookyMode;

--- a/engines/groovie/music.cpp
+++ b/engines/groovie/music.cpp
@@ -236,6 +236,10 @@ void MusicPlayer::onTimer(void *refCon) {
 		music->applyFading();
 	}
 
+	// If the game is accepting user input, start the background music if necessary
+	if (music->_vm->isWaitingForInput())
+		music->startBackground();
+
 	// Handle internal timed events
 	music->onTimerInternal();
 }

--- a/engines/groovie/music.cpp
+++ b/engines/groovie/music.cpp
@@ -58,6 +58,7 @@ void MusicPlayer::playSong(uint32 fileref) {
 	// Set the volumes
 	_fadingEndVolume = 100;
 	_gameVolume = 100;
+	updateVolume();
 
 	// Play the referenced file once
 	play(fileref, false);
@@ -203,7 +204,15 @@ void MusicPlayer::applyFading() {
 		// If we were fading to 0, stop the playback and restore the volume
 		if (_fadingEndVolume == 0) {
 			debugC(1, kDebugMIDI, "Groovie::Music: Faded to zero: end of song. _fadingEndVolume set to 100");
-			unload();
+			// WORKAROUND The original interpreter would keep playing a track
+			// at volume 0 after it has faded out. When a new track was
+			// started, it would restore the volume first and a short part of
+			// the old track would be heard before the new track would start.
+			// To prevent this, playback is actually stopped after fading out,
+			// but _isPlaying remains true. This keeps the original
+			// interpreter behavior of not starting the background music, but 
+			// it prevents the issue when starting playback of a new track.
+			unload(false);
 		}
 	}
 
@@ -226,11 +235,12 @@ void MusicPlayer::onTimer(void *refCon) {
 	music->onTimerInternal();
 }
 
-void MusicPlayer::unload() {
+void MusicPlayer::unload(bool updateState) {
 	debugC(1, kDebugMIDI, "Groovie::Music: Stopping the playback");
 
-	// Set the new state
-	_isPlaying = false;
+	if (updateState)
+		// Set the new state
+		_isPlaying = false;
 }
 
 void MusicPlayer::playCreditsIOS() {
@@ -357,8 +367,8 @@ void MusicPlayerMidi::updateVolume() {
 	}
 }
 
-void MusicPlayerMidi::unload() {
-	MusicPlayer::unload();
+void MusicPlayerMidi::unload(bool updateState) {
+	MusicPlayer::unload(updateState);
 
 	// Unload the parser data
 	if (_midiParser)
@@ -503,8 +513,8 @@ bool MusicPlayerXMI::load(uint32 fileref, bool loop) {
 	return loadParser(file, loop);
 }
 
-void MusicPlayerXMI::unload() {
-	MusicPlayerMidi::unload();
+void MusicPlayerXMI::unload(bool updateState) {
+	MusicPlayerMidi::unload(updateState);
 	if (_milesMidiDriver) {
 		_milesMidiDriver->deinitSource(0);
 	}
@@ -659,8 +669,8 @@ void MusicPlayerIOS::updateVolume() {
 	_vm->_system->getMixer()->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, _userVolume * _gameVolume / 100);
 }
 
-void MusicPlayerIOS::unload() {
-	MusicPlayer::unload();
+void MusicPlayerIOS::unload(bool updateState) {
+	MusicPlayer::unload(updateState);
 
 	_vm->_system->getMixer()->stopHandle(_handle);
 }

--- a/engines/groovie/music.cpp
+++ b/engines/groovie/music.cpp
@@ -185,6 +185,11 @@ bool MusicPlayer::play(uint32 fileref, bool loop) {
 	return load(fileref, loop);
 }
 
+void MusicPlayer::stop() {
+	_backgroundFileRef = 0;
+	unload();
+}
+
 void MusicPlayer::applyFading() {
 	debugC(6, kDebugMIDI, "Groovie::Music: applyFading() _fadingStartTime = %d, _fadingDuration = %d, _fadingStartVolume = %d, _fadingEndVolume = %d", _fadingStartTime, _fadingDuration, _fadingStartVolume, _fadingEndVolume);
 	Common::StackLock lock(_mutex);

--- a/engines/groovie/music.h
+++ b/engines/groovie/music.h
@@ -41,6 +41,9 @@ public:
 	virtual ~MusicPlayer();
 
 	void playSong(uint32 fileref);
+	// Stops all music playback. Clears the current
+	// background song.
+	void stop();
 	void setBackgroundSong(uint32 fileref);
 	void playCD(uint8 track);
 	void startBackground();

--- a/engines/groovie/music.h
+++ b/engines/groovie/music.h
@@ -102,7 +102,7 @@ protected:
 	// These are specific for each type of music
 	virtual void updateVolume() = 0;
 	virtual bool load(uint32 fileref, bool loop) = 0;
-	virtual void unload();
+	virtual void unload(bool updateState = true);
 };
 
 class MusicPlayerMidi : public MusicPlayer, public MidiDriver_BASE {
@@ -130,7 +130,7 @@ protected:
 
 	void onTimerInternal() override;
 	void updateVolume() override;
-	void unload() override;
+	void unload(bool updateState = true) override;
 	void endTrack();
 
 	bool loadParser(Common::SeekableReadStream *stream, bool loop);
@@ -153,7 +153,7 @@ public:
 protected:
 	void updateVolume() override;
 	bool load(uint32 fileref, bool loop) override;
-	void unload() override;
+	void unload(bool updateState = true) override;
 
 private:
 	// Output music type
@@ -189,7 +189,7 @@ public:
 protected:
 	void updateVolume() override;
 	bool load(uint32 fileref, bool loop) override;
-	void unload() override;
+	void unload(bool updateState = true) override;
 
 private:
 	Audio::SoundHandle _handle;

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -445,6 +445,8 @@ bool Script::hotspot(Common::Rect rect, uint16 address, uint8 cursor) {
 }
 
 void Script::loadgame(uint slot) {
+	_vm->_musicPlayer->stop();
+
 	Common::InSaveFile *file = SaveLoad::openForLoading(ConfMan.getActiveDomainName(), slot);
 
 	// Loading the variables. It is endian safe because they're byte variables

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -768,8 +768,6 @@ void Script::o_inputloopstart() {	//0x0B
 	// Save the current pressed character for the whole loop
 	_kbdChar = _eventKbdChar;
 	_eventKbdChar = 0;
-
-	_vm->_musicPlayer->startBackground();
 }
 
 void Script::o_keyboardaction() {


### PR DESCRIPTION
This PR contains fixes for 3 small MIDI issues in The 7th Guest:

- Music fade-outs would sometimes cause the background music to start playing 
while there would be no music in the original interpreter, and it would not 
always restore volume when playing a new track, causing it to play at volume 0.
- Loading a savegame would start or continue playing background music for a few 
seconds before the music for the loaded room would start playing.
- Checking if the game should start background music would only happen if the 
game was receiving input.