### PR TITLE
PINK: Warn when the timestamps mismatch

### DIFF
--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -94,8 +94,16 @@ Common::Error PinkEngine::init() {
 		orbName = "HPP.ORB";
 	}
 
-	if (!_orb.open(orbName) || (_bro && !_bro->open(broName) && _orb.getTimestamp() == _bro->getTimestamp()))
+	if (!_orb.open(orbName))
 		return Common::kNoGameDataFoundError;
+	if (_bro) {
+		if (!_bro->open(broName))
+			return Common::kNoGameDataFoundError;
+		if (_orb.getTimestamp() != _bro->getTimestamp()) {
+			warning("ORB and BRO timestamp mismatch. %lx != %lx", _orb.getTimestamp(), _bro->getTimestamp());
+			return Common::kNoGameDataFoundError;
+		}
+	}
 
 	if (!loadCursors())
 		return Common::kNoGameDataFoundError;


### PR DESCRIPTION
Write to the log when the timestamps are mismatched so that the issue has a chance of being spotted.