### PR TITLE
WIN32: Support using additional OneCore voices for text to speech

### DIFF
--- a/backends/text-to-speech/windows/windows-text-to-speech.cpp
+++ b/backends/text-to-speech/windows/windows-text-to-speech.cpp
@@ -462,7 +462,11 @@ void WindowsTextToSpeechManager::updateVoices() {
 	ISpObjectTokenCategory *cpCategory;
 	HRESULT hr = CoCreateInstance(CLSID_SpObjectTokenCategory, NULL, CLSCTX_ALL, IID_ISpObjectTokenCategory, (void**)&cpCategory);
 	if (SUCCEEDED(hr)) {
-		hr = cpCategory->SetId(SPCAT_VOICES, FALSE);
+		hr = cpCategory->SetId(L"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices", FALSE);
+		if (!SUCCEEDED(hr)) {
+			hr = cpCategory->SetId(SPCAT_VOICES, FALSE);
+		}
+
 		if (SUCCEEDED(hr)) {
 			hr = cpCategory->EnumTokens(NULL, NULL, &cpEnum);
 		}


### PR DESCRIPTION
A number of additional voices on Windows 10 are listed as OneCore voices, and are intended to be used via the Universal Windows Platform APIs, however it is possible to use them via SAPI using the hack provided in this PR. Tested on both Windows 10 and Windows XP.

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1544143