### PR TITLE
AGI: Fix bug #11209 (wrong `horizon` value saved)

### DIFF
--- a/engines/agi/saveload.cpp
+++ b/engines/agi/saveload.cpp
@@ -147,7 +147,7 @@ int AgiEngine::saveGame(const Common::String &fileName, const Common::String &de
 	for (i = 0; i < MAX_VARS; i++)
 		out->writeByte(_game.vars[i]);
 
-	out->writeSint16BE((int8)_game.horizon);
+	out->writeSint16BE((int16)_game.horizon);
 	out->writeSint16BE((int16)_text->statusRow_Get());
 	out->writeSint16BE((int16)_text->promptRow_Get());
 	out->writeSint16BE((int16)_text->getWindowRowMin());


### PR DESCRIPTION
`_game.horizon` is defined as uint16, but was casted to uint8 before saving
thus, caused problems for values bigger than 128 - they were interpreted
as negative values


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
