### PR TITLE
CINE: Add _animDataTable bounds checkings.

### DIFF
--- a/engines/cine/anim.cpp
+++ b/engines/cine/anim.cpp
@@ -436,8 +436,7 @@ void freeAnimDataRange(byte startIdx, byte numIdx) {
 		if (startIdx + numIdx > g_cine->_animDataTable.size()) {
 			numIdx = (byte)(g_cine->_animDataTable.size() - startIdx);
 		}
-		assert(startIdx < g_cine->_animDataTable.size() ||
-			(g_cine->_animDataTable.empty() && numIdx == 0));
+		assert(startIdx < g_cine->_animDataTable.size());
 		assert(startIdx + numIdx <= g_cine->_animDataTable.size());
 	}
 		


### PR DESCRIPTION
Hopefully a fix for Coverity check CID 1430586
("Untrusted value as argument").