### PR TITLE
CINE: FW: Fix Roland MT-32 sample playing.

### DIFF
--- a/engines/cine/sound.cpp
+++ b/engines/cine/sound.cpp
@@ -768,7 +768,7 @@ void MidiSoundDriverH32::playSample(const byte *data, int size, int channel, int
 	if (data[0] < 0x80) {
 		selectInstrument(channel, data[0] / 0x40, data[0] % 0x40, volume);
 	} else {
-		writeInstrument(channel * 512 + 0x80000, data + 1, size - 1);
+		writeInstrument(channel * 512 + 0x80000, data + 1, 256);
 		selectInstrument(channel, 2, channel, volume);
 	}
 


### PR DESCRIPTION
Fix bug #11547 ("CINE: FW: Game crashes during intro with MT-32 music").
Future Wars PC disassembly passes 256 to writeInstrument and
writeInstrument overwrites it with value 246 here. So the value
becomes 246 in the end.