### PR TITLE
Stream warnings

### DIFF
--- a/common/memstream.h
+++ b/common/memstream.h
@@ -33,7 +33,7 @@ namespace Common {
  * Simple memory based 'stream', which implements the ReadStream interface for
  * a plain memory block.
  */
-class MemoryReadStream : public SeekableReadStream {
+class MemoryReadStream : virtual public SeekableReadStream {
 private:
 	const byte * const _ptrOrig;
 	const byte *_ptr;

--- a/common/memstream.h
+++ b/common/memstream.h
@@ -81,7 +81,7 @@ public:
 class MemoryReadStreamEndian : public MemoryReadStream, public SeekableReadStreamEndian {
 public:
 	MemoryReadStreamEndian(const byte *buf, uint32 len, bool bigEndian)
-		: MemoryReadStream(buf, len), SeekableReadStreamEndian(bigEndian), ReadStreamEndian(bigEndian) {}
+		: MemoryReadStream(buf, len), ReadStreamEndian(bigEndian) {}
 
 	int32 pos() const { return MemoryReadStream::pos(); }
 	int32 size() const { return MemoryReadStream::size(); }

--- a/common/stream.h
+++ b/common/stream.h
@@ -711,7 +711,7 @@ public:
  */
 class SeekableReadStreamEndian : virtual public SeekableReadStream, virtual public ReadStreamEndian {
 public:
-	SeekableReadStreamEndian(bool bigEndian) : ReadStreamEndian(bigEndian) {}
+	SeekableReadStreamEndian() {}
 };
 
 

--- a/common/substream.h
+++ b/common/substream.h
@@ -90,7 +90,6 @@ class SeekableSubReadStreamEndian :  virtual public SeekableSubReadStream, virtu
 public:
 	SeekableSubReadStreamEndian(SeekableReadStream *parentStream, uint32 begin, uint32 end, bool bigEndian, DisposeAfterUse::Flag disposeParentStream = DisposeAfterUse::NO)
 		: SeekableSubReadStream(parentStream, begin, end, disposeParentStream),
-		  SeekableReadStreamEndian(bigEndian),
 		  ReadStreamEndian(bigEndian) {
 	}
 

--- a/engines/kyra/resource/resource_intern.h
+++ b/engines/kyra/resource/resource_intern.h
@@ -144,7 +144,7 @@ public:
 
 class EndianAwareStreamWrapper : public Common::SeekableReadStreamEndian {
 public:
-	EndianAwareStreamWrapper(Common::SeekableReadStream *stream, bool bigEndian, bool disposeAfterUse = true) : Common::SeekableReadStreamEndian(bigEndian), Common::ReadStreamEndian(bigEndian), _stream(stream), _dispose(disposeAfterUse) {}
+	EndianAwareStreamWrapper(Common::SeekableReadStream *stream, bool bigEndian, bool disposeAfterUse = true) : Common::ReadStreamEndian(bigEndian), _stream(stream), _dispose(disposeAfterUse) {}
 	~EndianAwareStreamWrapper() override { if (_dispose) delete _stream; }
 
 	// Common::Stream interface


### PR DESCRIPTION
COMMON: fix stream class related warnings

This should take care of the warnings introduced with 1aea38cc.
It is a bit of a delicate matter, since different compilers seem to have slightly different reactions.
I've locally tested MSVC 2019, gcc and clang.

So, let's see what travis says and then we can try the buildbot...