### PR TITLE
CINE: Fix disabled action menu and autosave thumbnail.

### DIFF
--- a/engines/cine/cine.cpp
+++ b/engines/cine/cine.cpp
@@ -235,6 +235,12 @@ void CineEngine::initialize() {
 		// A proper fix here would be to save this variable in FW's saves.
 		// Since it seems these are unversioned so far, there would be need
 		// to properly add versioning to them first.
+		//
+		// Adding versioning to FW saves didn't solve this problem. Setting
+		// disableSystemMenu according to the saved value still caused the
+		// action menu (EXAMINE, TAKE, INVENTORY, ...) sometimes to be
+		// disabled when it wasn't supposed to be disabled when
+		// loading from the launcher or command line.
 		disableSystemMenu = 0;
 	}
 

--- a/engines/cine/saveload.cpp
+++ b/engines/cine/saveload.cpp
@@ -1026,7 +1026,7 @@ void CineEngine::makeSave(const Common::String &saveFileName, uint32 playtime,
 	}
 
 	renderer->saveBackBuffer(BEFORE_TAKING_THUMBNAIL);
-	if (renderer->hasSavedBackBuffer(BEFORE_OPENING_MENU)) {
+	if (!isAutosave && renderer->hasSavedBackBuffer(BEFORE_OPENING_MENU)) {
 		renderer->popSavedBackBuffer(BEFORE_OPENING_MENU);
 	}
 

--- a/engines/cine/saveload.cpp
+++ b/engines/cine/saveload.cpp
@@ -783,7 +783,13 @@ bool CineEngine::loadPlainSaveFW(Common::SeekableReadStream &in, CineSaveGameFor
 	loadOverlayList(in);
 	loadBgIncrustFromSave(in);
 
-	disableSystemMenu = ((version >= 4) ? in.readUint16BE() : 0);
+	if (version >= 4) {
+		// Skip the saved value of disableSystemMenu because using its value
+		// sometimes disabled the action menu (i.e. EXAMINE, TAKE, INVENTORY, ...)
+		// when it wasn't supposed to be disabled when loading from the launcher
+		// or command line.
+		in.readUint16BE();
+	}
 
 	if (strlen(currentMsgName)) {
 		loadMsg(currentMsgName);


### PR DESCRIPTION
This pull request has two bugfixes:

#1:
Future Wars PC disassembly does not save disableSysteMenu variable.
After adding versioning to Future Wars saves this value was also
saved and loaded but using it on load seems to have caused the
action menu (EXAMINE, TAKE, INVENTORY, ...) to be disabled sometimes
when it is not supposed to be disabled. Thus, now skipping the loading
of disableSystemMenu variable for versioned Future Wars saves.

#2:
Using the current screen contents for autosaves now.
For non-autosaves the screen contents before opening
the system menu are used.