### PR TITLE
KYRA: Automatically suggest current time when adding a new savegame

### DIFF
--- a/engines/kyra/gui/gui_lol.cpp
+++ b/engines/kyra/gui/gui_lol.cpp
@@ -2673,6 +2673,12 @@ int GUI_LoL::clickedSaveMenu(Button *button) {
 	_saveDescription[0] = 0;
 	if (_saveMenu.item[-s - 2].saveSlot != -3)
 		strcpy(_saveDescription, _saveMenu.item[-s - 2].itemString);
+	else {
+		TimeDate td;
+		g_system->getTimeAndDate(td);
+		Common::String ts = Common::String::format("%d:%d:%d on %d/%d/%d", td.tm_hour, td.tm_min, td.tm_sec, td.tm_mday, td.tm_mon + 1, td.tm_year + 1900);
+		strcpy(_saveDescription, ts.c_str());
+	}
 
 	return 1;
 }


### PR DESCRIPTION
This small quality-of-life change suggests a new savegame name with the current time and date for the Land of Lore games. This allows to play the games with less usage of a keyboard (e.g. only qith mouse or remapping keys to a gamepad).