### PR TITLE
SCI: Hebrew - add prefix rules

### DIFF
--- a/engines/sci/parser/vocabulary.h
+++ b/engines/sci/parser/vocabulary.h
@@ -221,6 +221,7 @@ public:
 
 	/**
 	 * Helper function for lookupWordPrefix, checking specific prefix for match
+	 * Intended for nouns and prepositions, and the prefix has meaning as another word
 	 * @param parent_retval     lookupWordPrefix's parent's function list of matches
 	 * @param retval            lookupWordPrefix's list of matches
 	 * @param word              pointer to the word to look up
@@ -229,8 +230,19 @@ public:
 	 * @param meaning           the meaning of that prefix
 	 * @return true on prefix match, false on prefix not matching
 	 */
-	bool lookupSpecificPrefix(ResultWordListList &parent_retval, ResultWordList &retval, const char *word, int word_len, unsigned char prefix, const char *meaning);
+	bool lookupSpecificPrefixWithMeaning(ResultWordListList &parent_retval, ResultWordList &retval, const char *word, int word_len, unsigned char prefix, const char *meaning);
 
+	/**
+	 * Helper function for lookupWordPrefix, checking specific prefix for match
+	 * Intended for verbs, and the prefix doesn't have any meaning
+	 * @param parent_retval     lookupWordPrefix's parent's function list of matches
+	 * @param retval            lookupWordPrefix's list of matches
+	 * @param word              pointer to the word to look up
+	 * @param word_len          length of the word to look up
+	 * @param prefix            the prefix to look for in the word
+	 * @return true on prefix match, false on prefix not matching
+	 */
+	bool lookupVerbPrefix(ResultWordListList &parent_retval, ResultWordList &retval, Common::String word, int word_len, Common::String prefix);
 
 	/**
 	 * Tokenizes a string and compiles it into word_ts.
@@ -346,11 +358,6 @@ private:
 	 * @return true on success, false on failure
 	 */
 	bool loadSuffixes();
-
-	/**
-	 * Appends required suffixes for specific languages
-	 */
-	void appendSuffixes();
 
 	/**
 	 * Frees all suffixes in the given list.


### PR DESCRIPTION
Added verb prefix rules required for SQ3 Hebrew translation.
Removed the suffix rules, since they are now added with a vocab.901 file


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
