### PR TITLE
CREATE-PROJECT: Set MSVC subsystem

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -2138,3 +2138,16 @@ void error(const std::string &message) {
 	std::cerr << "ERROR: " << message << "!" << std::endl;
 	std::exit(-1);
 }
+
+bool BuildSetup::featureEnabled(std::string feature) const {
+	return getFeature(feature).enable;
+}
+
+Feature BuildSetup::getFeature(std::string feature) const {
+	for (FeatureList::const_iterator itr = features.begin(); itr != features.end(); ++itr) {
+		if (itr->name != feature)
+			continue;
+		return *itr;
+	}
+	error("invalid feature request: " + feature);
+}

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -251,6 +251,9 @@ struct BuildSetup {
 		useCanonicalLibNames = false;
 		useStaticDetection = true;
 	}
+
+	bool featureEnabled(std::string feature) const;
+	Feature getFeature(std::string feature) const;
 };
 
 /**

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -383,8 +383,12 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	           << "\t\t\t<AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>\n"
 	           << "\t\t</ClCompile>\n"
 	           << "\t\t<Link>\n"
-	           << "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n"
-	           << "\t\t\t<SubSystem>Console</SubSystem>\n";
+	           << "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n";
+	if (!setup.featureEnabled("text-console")) {
+		properties << "\t\t\t<SubSystem>Windows</SubSystem>\n";
+	} else {
+		properties << "\t\t\t<SubSystem>Console</SubSystem>\n";
+	}
 
 	if (!setup.devTools && !setup.tests)
 		properties << "\t\t\t<EntryPointSymbol>WinMainCRTStartup</EntryPointSymbol>\n";

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -231,8 +231,12 @@ void VisualStudioProvider::outputGlobalPropFile(const BuildSetup &setup, std::of
 	           << "\t/>\n"
 	           << "\t<Tool\n"
 	           << "\t\tName=\"VCLinkerTool\"\n"
-	           << "\t\tIgnoreDefaultLibraryNames=\"\"\n"
-	           << "\t\tSubSystem=\"1\"\n";
+	           << "\t\tIgnoreDefaultLibraryNames=\"\"\n";
+	if (setup.featureEnabled("text-console")) {
+		properties << "\t\tSubSystem=\"1\"\n";
+	} else {
+		properties << "\t\tSubSystem=\"2\"\n";
+	}
 
 	if (!setup.devTools && !setup.tests)
 		properties << "\t\tEntryPointSymbol=\"WinMainCRTStartup\"\n";


### PR DESCRIPTION
There is no need to show an unusable console window, so only show that if the text console is enabled.