### PR TITLE
CREATE_PROJECT: Update MSVC libraries

### DIFF
--- a/devtools/create_project/config.h
+++ b/devtools/create_project/config.h
@@ -32,7 +32,6 @@
 #define ENABLE_LANGUAGE_EXTENSIONS ""    // Comma separated list of projects that need language extensions
 #define DISABLE_EDIT_AND_CONTINUE "tinsel,tony,scummvm"     // Comma separated list of projects that need Edit&Continue to be disabled for co-routine support (the main project is automatically added)
 
-//#define ADDITIONAL_LIBRARY ""            // Add a single library to the list of externally linked libraries
 #define NEEDS_RTTI 1                     // Enable RTTI globally
 
 #endif // TOOLS_CREATE_PROJECT_CONFIG_H

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -352,7 +352,6 @@ int main(int argc, char *argv[]) {
 
 	// Setup defines and libraries
 	setup.defines = getEngineDefines(setup.engines);
-	setup.libraries = getFeatureLibraries(setup.features);
 
 	// Add features
 	StringList featureDefines = getFeatureDefines(setup.features);
@@ -382,68 +381,25 @@ int main(int argc, char *argv[]) {
 #endif
 	}
 
-	bool updatesEnabled = false, curlEnabled = false, sdlnetEnabled = false, ttsEnabled = false;
 	for (FeatureList::const_iterator i = setup.features.begin(); i != setup.features.end(); ++i) {
 		if (i->enable) {
-			if (!updatesEnabled && !strcmp(i->name, "updates"))
-				updatesEnabled = true;
-			else if (!curlEnabled && !strcmp(i->name, "libcurl"))
-				curlEnabled = true;
-			else if (!sdlnetEnabled && !strcmp(i->name, "sdlnet"))
-				sdlnetEnabled = true;
-			else if (!ttsEnabled && !strcmp(i->name, "tts"))
-				ttsEnabled = true;
+			if (!strcmp(i->name, "updates"))
+				setup.defines.push_back("USE_SPARKLE");
+			else if (backendWin32 && !strcmp(i->name, "libcurl"))
+				setup.defines.push_back("CURL_STATICLIB");
 		}
-	}
-
-	if (updatesEnabled) {
-		setup.defines.push_back("USE_SPARKLE");
-		if (backendWin32)
-			setup.libraries.push_back("winsparkle");
-		else
-			setup.libraries.push_back("sparkle");
-	}
-
-	if (backendWin32) {
-		if (curlEnabled) {
-			setup.defines.push_back("CURL_STATICLIB");
-			setup.libraries.push_back("ws2_32");
-			setup.libraries.push_back("wldap32");
-			setup.libraries.push_back("crypt32");
-			setup.libraries.push_back("normaliz");
-		}
-		if (sdlnetEnabled) {
-			setup.libraries.push_back("iphlpapi");
-		}
-		if (ttsEnabled) {
-			setup.libraries.push_back("sapi");
-		}
-		setup.libraries.push_back("winmm");
 	}
 
 	setup.defines.push_back("SDL_BACKEND");
 	if (!setup.useSDL2) {
 		cout << "\nBuilding against SDL 1.2\n\n";
-		setup.libraries.push_back("sdl");
 	} else {
 		cout << "\nBuilding against SDL 2.0\n\n";
 		// TODO: This also defines USE_SDL2 in the preprocessor, we don't do
 		// this in our configure/make based build system. Adapt create_project
 		// to replicate this behavior.
 		setup.defines.push_back("USE_SDL2");
-		setup.libraries.push_back("sdl2");
 	}
-
-	if (setup.useCanonicalLibNames) {
-		for (StringList::iterator lib = setup.libraries.begin(); lib != setup.libraries.end(); ++lib) {
-			*lib = getCanonicalLibName(*lib);
-		}
-	}
-
-	// Add additional project-specific library
-#ifdef ADDITIONAL_LIBRARY
-	setup.libraries.push_back(ADDITIONAL_LIBRARY);
-#endif
 
 	// List of global warnings and map of project-specific warnings
 	// FIXME: As shown below these two structures have different behavior for
@@ -483,10 +439,6 @@ int main(int argc, char *argv[]) {
 		addGCCWarnings(globalWarnings);
 
 		provider = new CreateProjectTool::CodeBlocksProvider(globalWarnings, projectWarnings);
-
-		// Those libraries are automatically added by MSVC, but we need to add them manually with mingw
-		setup.libraries.push_back("ole32");
-		setup.libraries.push_back("uuid");
 
 		break;
 
@@ -1063,46 +1015,46 @@ TokenList tokenize(const std::string &input, char separator) {
 namespace {
 // clang-format off
 const Feature s_features[] = {
-	// Libraries
-	{      "libz",        "USE_ZLIB", "zlib",             true,  "zlib (compression) support" },
-	{       "mad",         "USE_MAD", "libmad",           true,  "libmad (MP3) support" },
-	{   "fribidi",     "USE_FRIBIDI", "fribidi",          true,  "BiDi support" },
-	{       "ogg",         "USE_OGG", "libogg_static",    true,  "Ogg support" },
-	{    "vorbis",      "USE_VORBIS", "libvorbisfile_static libvorbis_static", true, "Vorbis support" },
-	{    "tremor",      "USE_TREMOR", "libtremor", false, "Tremor support" },
-	{      "flac",        "USE_FLAC", "libFLAC_static win_utf8_io_static",   true, "FLAC support" },
-	{       "png",         "USE_PNG", "libpng16",         true,  "libpng support" },
-	{      "faad",        "USE_FAAD", "libfaad",          false, "AAC support" },
-	{     "mpeg2",       "USE_MPEG2", "libmpeg2",         false, "MPEG-2 support" },
-	{    "theora",   "USE_THEORADEC", "libtheora_static", true, "Theora decoding support" },
-	{  "freetype",   "USE_FREETYPE2", "freetype",         true, "FreeType support" },
-	{      "jpeg",        "USE_JPEG", "jpeg-static",      true, "libjpeg support" },
-	{"fluidsynth",  "USE_FLUIDSYNTH", "libfluidsynth",    true, "FluidSynth support" },
-	{   "libcurl",     "USE_LIBCURL", "libcurl",          true, "libcurl support" },
-	{    "sdlnet",     "USE_SDL_NET", "SDL_net",          true, "SDL_net support" },
+	// Libraries (must be added in generators)
+	{      "libz",        "USE_ZLIB", true, true,  "zlib (compression) support" },
+	{       "mad",         "USE_MAD", true, true,  "libmad (MP3) support" },
+	{   "fribidi",     "USE_FRIBIDI", true, true,  "BiDi support" },
+	{       "ogg",         "USE_OGG", true, true,  "Ogg support" },
+	{    "vorbis",      "USE_VORBIS", true, true,  "Vorbis support" },
+	{    "tremor",      "USE_TREMOR", true, false, "Tremor support" },
+	{      "flac",        "USE_FLAC", true, true,  "FLAC support" },
+	{       "png",         "USE_PNG", true, true,  "libpng support" },
+	{      "faad",        "USE_FAAD", true, false, "AAC support" },
+	{     "mpeg2",       "USE_MPEG2", true, false, "MPEG-2 support" },
+	{    "theora",   "USE_THEORADEC", true, true,  "Theora decoding support" },
+	{  "freetype",   "USE_FREETYPE2", true, true,  "FreeType support" },
+	{      "jpeg",        "USE_JPEG", true, true,  "libjpeg support" },
+	{"fluidsynth",  "USE_FLUIDSYNTH", true, true,  "FluidSynth support" },
+	{   "libcurl",     "USE_LIBCURL", true, true,  "libcurl support" },
+	{    "sdlnet",     "USE_SDL_NET", true, true,  "SDL_net support" },
 
 	// Feature flags
-	{            "bink",                      "USE_BINK",  "", true,  "Bink video support" },
-	{         "scalers",                   "USE_SCALERS",  "", true,  "Scalers" },
-	{       "hqscalers",                "USE_HQ_SCALERS",  "", true,  "HQ scalers" },
-	{           "16bit",                 "USE_RGB_COLOR",  "", true,  "16bit color support" },
-	{         "highres",                   "USE_HIGHRES",  "", true,  "high resolution" },
-	{         "mt32emu",                   "USE_MT32EMU",  "", true,  "integrated MT-32 emulator" },
-	{             "lua",                       "USE_LUA",  "", true,  "lua" },
-	{            "nasm",                      "USE_NASM",  "", true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
-	{          "opengl",                    "USE_OPENGL",  "", true,  "OpenGL support" },
-	{        "opengles",                      "USE_GLES",  "", true,  "forced OpenGL ES mode" },
-	{         "taskbar",                   "USE_TASKBAR",  "", true,  "Taskbar integration support" },
-	{           "cloud",                     "USE_CLOUD",  "", true,  "Cloud integration support" },
-	{     "translation",               "USE_TRANSLATION",  "", true,  "Translation support" },
-	{          "vkeybd",                 "ENABLE_VKEYBD",  "", false, "Virtual keyboard support"},
-	{   "eventrecorder",          "ENABLE_EVENTRECORDER",  "", false, "Event recorder support"},
-	{         "updates",                   "USE_UPDATES",  "", false, "Updates support"},
-	{         "dialogs",                "USE_SYSDIALOGS",  "", true,  "System dialogs support"},
-	{      "langdetect",                "USE_DETECTLANG",  "", true,  "System language detection support" }, // This feature actually depends on "translation", there
-	                                                                                                         // is just no current way of properly detecting this...
-	{    "text-console", "USE_TEXT_CONSOLE_FOR_DEBUGGER",  "", false, "Text console debugger" }, // This feature is always applied in xcode projects
-	{             "tts",                       "USE_TTS",  "", true,  "Text to speech support"}
+	{            "bink",                      "USE_BINK", false, true,  "Bink video support" },
+	{         "scalers",                   "USE_SCALERS", false, true,  "Scalers" },
+	{       "hqscalers",                "USE_HQ_SCALERS", false, true,  "HQ scalers" },
+	{           "16bit",                 "USE_RGB_COLOR", false, true,  "16bit color support" },
+	{         "highres",                   "USE_HIGHRES", false, true,  "high resolution" },
+	{         "mt32emu",                   "USE_MT32EMU", false, true,  "integrated MT-32 emulator" },
+	{             "lua",                       "USE_LUA", false, true,  "lua" },
+	{            "nasm",                      "USE_NASM", false, true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
+	{          "opengl",                    "USE_OPENGL", false, true,  "OpenGL support" },
+	{        "opengles",                      "USE_GLES", false, true,  "forced OpenGL ES mode" },
+	{         "taskbar",                   "USE_TASKBAR", false, true,  "Taskbar integration support" },
+	{           "cloud",                     "USE_CLOUD", false, true,  "Cloud integration support" },
+	{     "translation",               "USE_TRANSLATION", false, true,  "Translation support" },
+	{          "vkeybd",                 "ENABLE_VKEYBD", false, false, "Virtual keyboard support"},
+	{   "eventrecorder",          "ENABLE_EVENTRECORDER", false, false, "Event recorder support"},
+	{         "updates",                   "USE_UPDATES", false, false, "Updates support"},
+	{         "dialogs",                "USE_SYSDIALOGS", false, true,  "System dialogs support"},
+	{      "langdetect",                "USE_DETECTLANG", false, true,  "System language detection support" }, // This feature actually depends on "translation", there
+	                                                                                                           // is just no current way of properly detecting this...
+	{    "text-console", "USE_TEXT_CONSOLE_FOR_DEBUGGER", false, false, "Text console debugger" }, // This feature is always applied in xcode projects
+	{             "tts",                       "USE_TTS", false, true,  "Text to speech support"}
 };
 
 const Tool s_tools[] = {
@@ -1131,21 +1083,6 @@ const MSVCVersion s_msvc[] = {
 	{ 16,    "Visual Studio 2019",    "12.00",    "Version 16",    "16.0",    "v142",    "llvm"        }
 };
 
-const std::pair<std::string, std::string> s_canonical_lib_name_map[] = {
-	std::make_pair("jpeg-static", "jpeg"),
-	std::make_pair("libfaad", "faad"),
-	std::make_pair("libFLAC_static", "FLAC"),
-	std::make_pair("libfluidsynth", "fluidsynth"),
-	std::make_pair("libmad", "mad"),
-	std::make_pair("libmpeg2", "mpeg2"),
-	std::make_pair("libogg_static", "ogg"),
-	std::make_pair("libtheora_static", "theora"),
-	std::make_pair("libvorbis_static", "vorbis"),
-	std::make_pair("libvorbisfile_static", "vorbisfile"),
-	std::make_pair("SDL_net", "SDL2_net"), // Only support SDL2
-	std::make_pair("win_utf8_io_static", "FLAC") // This is some FLAC-specific library not needed with vcpkg, but as there's '.lib' appended to each library, we can't set it to empty, so set it to FLAC again instead
-};
-
 const char *s_msvc_arch_names[] = {"arm64", "x86", "x64"};
 const char *s_msvc_config_names[] = {"arm64", "Win32", "x64"};
 // clang-format on
@@ -1157,17 +1094,6 @@ std::string getMSVCArchName(MSVC_Architecture arch) {
 
 std::string getMSVCConfigName(MSVC_Architecture arch) {
 	return s_msvc_config_names[arch];
-}
-
-std::string getCanonicalLibName(const std::string &lib) {
-	const size_t libCount = sizeof(s_canonical_lib_name_map) / sizeof(s_canonical_lib_name_map[0]);
-
-	for (size_t i = 0; i < libCount; ++i) {
-		if (s_canonical_lib_name_map[i].first == lib) {
-			return s_canonical_lib_name_map[i].second;
-		}
-	}
-	return lib;
 }
 
 FeatureList getAllFeatures() {
@@ -1191,34 +1117,6 @@ StringList getFeatureDefines(const FeatureList &features) {
 	return defines;
 }
 
-StringList getFeatureLibraries(const Feature &feature) {
-	StringList libraries;
-
-	if (feature.enable && feature.libraries && feature.libraries[0]) {
-		StringList fLibraries = tokenize(feature.libraries);
-		libraries.splice(libraries.end(), fLibraries);
-	}
-	// The libraries get sorted as they can get used in algorithms where ordering is a
-	// precondition, e.g. merge()
-	libraries.sort();
-
-	return libraries;
-}
-
-StringList getFeatureLibraries(const FeatureList &features) {
-	StringList libraries;
-
-	for (FeatureList::const_iterator i = features.begin(); i != features.end(); ++i) {
-		StringList fl = getFeatureLibraries(*i);
-		for (StringList::const_iterator flit = fl.begin(); flit != fl.end(); ++flit) {
-			libraries.push_back(*flit);
-		}
-	}
-	libraries.sort();
-
-	return libraries;
-}
-
 bool setFeatureBuildState(const std::string &name, FeatureList &features, bool enable) {
 	FeatureList::iterator i = std::find(features.begin(), features.end(), name);
 	if (i != features.end()) {
@@ -1239,16 +1137,9 @@ bool getFeatureBuildState(const std::string &name, FeatureList &features) {
 }
 
 BuildSetup removeFeatureFromSetup(BuildSetup setup, const std::string &feature) {
-	// TODO: use const_iterator in C++11
+	// TODO: disable feature instead of removing from setup
 	for (FeatureList::iterator i = setup.features.begin(); i != setup.features.end(); ++i) {
 		if (i->enable && feature == i->name) {
-			StringList feature_libs = getFeatureLibraries(*i);
-			for (StringList::iterator lib = feature_libs.begin(); lib != feature_libs.end(); ++lib) {
-				if (setup.useCanonicalLibNames) {
-					*lib = getCanonicalLibName(*lib);
-				}
-				setup.libraries.remove(*lib);
-			}
 			if (i->define && i->define[0]) {
 				setup.defines.remove(i->define);
 			}

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -158,8 +158,7 @@ StringList getEngineDefines(const EngineDescList &engines);
 struct Feature {
 	const char *name;   ///< Name of the feature
 	const char *define; ///< Define of the feature
-
-	const char *libraries; ///< Libraries, which need to be linked, for the feature
+	bool library; ///< Whether this feature needs to be linked to a library
 
 	bool enable; ///< Whether the feature is enabled or not
 
@@ -191,22 +190,6 @@ FeatureList getAllFeatures();
  * @param features List of features for the build (this may contain features, which are *not* enabled!)
  */
 StringList getFeatureDefines(const FeatureList &features);
-
-/**
- * Returns a list of all external library files, according to the
- * feature set passed.
- *
- * @param features List of features for the build (this may contain features, which are *not* enabled!)
- */
-StringList getFeatureLibraries(const FeatureList &features);
-
-/**
- * Returns a list of all external library files, according to the
- * feature passed.
- *
- * @param features Feature for the build (this may contain features, which are *not* enabled!)
- */
-StringList getFeatureLibraries(const Feature &feature);
 
 /**
  * Sets the state of a given feature. This can be used to
@@ -247,7 +230,6 @@ struct BuildSetup {
 	FeatureList features;   ///< Feature list for the build (this may contain features, which are *not* enabled!).
 
 	StringList defines;   ///< List of all defines for the build.
-	StringList libraries; ///< List of all external libraries required for the build.
 	StringList testDirs;  ///< List of all folders containing tests
 
 	bool devTools;             ///< Generate project files for the tools
@@ -334,14 +316,6 @@ const MSVCVersion *getMSVCVersion(int version);
  * @return Version number, or 0 if no installations were found.
  */
 int getInstalledMSVC();
-
-/**
- * Return a "canonical" library name, so it is easier to integrate other providers of dependencies.
- *
- * @param lib The link library as provided by ScummVM libs.
- * @return Canonical link library.
- */
-std::string getCanonicalLibName(const std::string &lib);
 
 /**
  * Removes given feature from setup.

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -303,10 +303,14 @@ void MSBuildProvider::outputProjectSettings(std::ofstream &project, const std::s
 
 	// Link configuration for main project
 	if (name == setup.projectName || setup.devTools || setup.tests) {
-		std::string libraries;
+		std::string libraries = outputLibraryDependencies(setup, isRelease);
 
-		for (StringList::const_iterator i = setup.libraries.begin(); i != setup.libraries.end(); ++i)
-			libraries += *i + ".lib;";
+		// MSBuild uses ; for separators instead of spaces
+		for (std::string::iterator i = libraries.begin(); i != libraries.end(); ++i) {
+			if (*i == ' ') {
+				*i = ';';
+			}
+		}
 
 		project << "\t\t<Link>\n"
 		        << "\t\t\t<OutputFile>$(OutDir)" << ((setup.devTools || setup.tests) ? name : setup.projectName) << ".exe</OutputFile>\n"

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -38,7 +38,21 @@ protected:
 	StringList _disableEditAndContinue;
 
 	std::list<MSVC_Architecture> _archs;
-	std::map<MSVC_Architecture, StringList> _arch_disabled_features;
+	std::map<MSVC_Architecture, StringList> _arch_disabled_features;	
+	
+	/**
+	 * MSVC properties for a library required by a feature
+	*/
+	struct MSVCLibrary {
+		const char *feature; ///< Feature ID.
+		const char *release; ///< Filename of the Release build of the library.
+		const char *debug;   ///< Filename of the Debug build of the library.
+		const char *depends; ///< Win32 libs this library must be linked against.
+		const char *legacy;  ///< Legacy name for old precompiled libraries (deprecated).
+	};
+
+	std::string getLibraryFromFeature(const char *feature, const BuildSetup &setup, bool isRelease) const;
+	std::string outputLibraryDependencies(const BuildSetup &setup, bool isRelease) const;
 
 	void createWorkspace(const BuildSetup &setup);
 

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -79,19 +79,11 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 	std::map<std::string, std::list<std::string> >::iterator warningsIterator = _projectWarnings.find(name);
 
 	if (setup.devTools || setup.tests || name == setup.projectName) {
-		std::string libraries;
-
-		for (StringList::const_iterator i = setup.libraries.begin(); i != setup.libraries.end(); ++i)
-			libraries += ' ' + *i + ".lib";
-
-		// For 'x64' we must disable NASM support. Usually we would need to disable the "nasm" feature for that and
-		// re-create the library list, BUT since NASM doesn't link any additional libraries, we can just use the
-		// libraries list created for IA-32. If that changes in the future, we need to adjust this part!
 		for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
-			outputConfiguration(project, setup, libraries, "Debug", *arch);
-			outputConfiguration(project, setup, libraries, "Analysis", *arch);
-			outputConfiguration(project, setup, libraries, "LLVM", *arch);
-			outputConfiguration(project, setup, libraries, "Release", *arch);
+			outputConfiguration(project, setup, false, "Debug", *arch);
+			outputConfiguration(project, setup, false, "Analysis", *arch);
+			outputConfiguration(project, setup, false, "LLVM", *arch);
+			outputConfiguration(project, setup, true, "Release", *arch);
 		}
 
 	} else {
@@ -140,7 +132,9 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 	        << "</VisualStudioProject>\n";
 }
 
-void VisualStudioProvider::outputConfiguration(std::ostream &project, const BuildSetup &setup, const std::string &libraries, const std::string &config, const MSVC_Architecture arch) {
+void VisualStudioProvider::outputConfiguration(std::ostream &project, const BuildSetup &setup, bool isRelease, const std::string &config, const MSVC_Architecture arch) {
+	std::string libraries = outputLibraryDependencies(setup, isRelease);
+
 	project << "\t\t<Configuration Name=\"" << config << "|" << getMSVCConfigName(arch) << "\" ConfigurationType=\"1\" InheritedPropertySheets=\".\\" << setup.projectDescription << "_" << config << getMSVCArchName(arch) << ".vsprops\">\n"
 	        << "\t\t\t<Tool\tName=\"VCCLCompilerTool\" DisableLanguageExtensions=\"false\" DebugInformationFormat=\"3\" />\n"
 	        << "\t\t\t<Tool\tName=\"VCLinkerTool\" OutputFile=\"$(OutDir)/" << setup.projectName << ".exe\"\n"

--- a/devtools/create_project/visualstudio.h
+++ b/devtools/create_project/visualstudio.h
@@ -50,7 +50,7 @@ protected:
 	const char *getProjectExtension();
 	const char *getPropertiesExtension();
 
-	void outputConfiguration(std::ostream &project, const BuildSetup &setup, const std::string &libraries, const std::string &config, const MSVC_Architecture arch);
+	void outputConfiguration(std::ostream &project, const BuildSetup &setup, bool isRelease, const std::string &config, const MSVC_Architecture arch);
 	void outputConfiguration(const BuildSetup &setup, std::ostream &project, const std::string &toolConfig, const std::string &config, const MSVC_Architecture arch);
 	void outputBuildEvents(std::ostream &project, const BuildSetup &setup, const MSVC_Architecture arch);
 };


### PR DESCRIPTION
One of the biggest challenges of updating the prebuilt MSVC libraries has been the hardcoded libraries in CREATE_PROJECT, as they don't match modern package managers like vcpkg and require manual work. In the process of updating them, I refactored several things:

- MSVC libraries can have different names depending on configuration, so now the `MSVCProvider` has a table of library names for every configuration (Debug/Release/etc) and dependencies. This makes it much easier to maintain, and is similar to the other project providers.
- This removed the need for the BuildSetup `libraries` property, as it was only really used by MSVC. The other providers have their own logic for handling libraries, which makes sense as there is no "global" list of libraries, every platform and tool will have different names and formats. Now each provider is responsible for turning Features into libraries.

So here's what needs testing:
- Make sure I didn't break any of the other project providers and all features still build correctly. 
- For the MSVC users: at long last, [an updated library zip](https://www.dropbox.com/s/erh2i5e0ls1ct59/scummvm_libs_2015.zip?dl=1)! All static, all up-to-date, for all configurations!
To test them just replace your `SCUMMVM_LIBS` folder with the one in my ZIP and enable `--use-canonical-lib-names` in `create_msvc.bat`. If all goes well, these will be the new default.