### PR TITLE
GLK: Fix typo in ADRIFT game title

### DIFF
--- a/engines/glk/adrift/detection_tables.h
+++ b/engines/glk/adrift/detection_tables.h
@@ -43,7 +43,7 @@ const PlainGameDescriptor ADRIFT_GAME_LIST[] = {
 	{ "caveofwonders", "Cave of Wondors" },
 	{ "circusmenagerie", "Menagerie!" },
 	{ "cityInfear", "City In Fear" },
-	{ "coloromcadrift", "Color of Milk COffee" },
+	{ "coloromcadrift", "Color of Milk Coffee" },
 	{ "compendiumendgame", "The Woodfish Compendium: The Game to End All Games" },
 	{ "compendiumforum", "The Woodfish Compendium: Forum" },
 	{ "compendiumforum2", "The Woodfish Compendium: Forum2" },

--- a/engines/glk/adrift/detection_tables.h
+++ b/engines/glk/adrift/detection_tables.h
@@ -39,7 +39,7 @@ const PlainGameDescriptor ADRIFT_GAME_LIST[] = {
 	{ "bariscebik", "Bariscebik" },
 	{ "barneysproblem", "Barney's Problem" },
 	{ "beanstalk", "Beanstalk the and Jack" },
-	{ "beerisntenough", "WHen Beer Isn't Enough" },
+	{ "beerisntenough", "When Beer Isn't Enough" },
 	{ "caveofwonders", "Cave of Wondors" },
 	{ "circusmenagerie", "Menagerie!" },
 	{ "cityInfear", "City In Fear" },


### PR DESCRIPTION
Fix typo in game title