### PR TITLE
DIRECTOR: Fix info entry double frees

### DIFF
--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -158,6 +158,22 @@ struct DirectorPlotData {
 		applyColor = false;
 	}
 
+	DirectorPlotData(const DirectorPlotData &old) : _wm(old._wm), sprite(old.sprite),
+	                                                ink(old.ink), alpha(old.alpha),
+	                                                backColor(old.backColor), foreColor(old.foreColor),
+	                                                srf(old.srf), dst(old.dst),
+	                                                destRect(old.destRect), srcPoint(old.srcPoint),
+	                                                colorWhite(old.colorWhite), colorBlack(old.colorBlack),
+	                                                applyColor(old.applyColor) {
+		if (old.ms) {
+			ms = new MacShape(*old.ms);
+		} else {
+			ms = nullptr;
+		}
+	}
+
+	DirectorPlotData &operator=(const DirectorPlotData &);
+
 	~DirectorPlotData() {
 		delete ms;
 	}

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -60,6 +60,14 @@ struct InfoEntry {
 		data = nullptr;
 	}
 
+	InfoEntry &operator=(const InfoEntry &old) {
+		free(data);
+		len = old.len;
+		data = (byte *)malloc(len);
+		memcpy(data, old.data, len);
+		return *this;
+	}
+
 	Common::String readString(bool pascal = true) {
 		Common::String res;
 

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -49,8 +49,15 @@ struct InfoEntry {
 
 	InfoEntry() { len = 0; data = nullptr; }
 
+	InfoEntry(const InfoEntry &old) {
+		len = old.len;
+		data = (byte *)malloc(len);
+		memcpy(data, old.data, len);
+	}
+
 	~InfoEntry() {
 		free(data);
+		data = nullptr;
 	}
 
 	Common::String readString(bool pascal = true) {


### PR DESCRIPTION
The InfoEntry struct owns a buffer, so the default copy constructor is wrong. This oversight lead to a double free.