### PR TITLE
GLK: ADRIFT - Fix #11569 by extending game entry

### DIFF
--- a/engines/glk/adrift/detection_tables.h
+++ b/engines/glk/adrift/detection_tables.h
@@ -277,8 +277,8 @@ const PlainGameDescriptor ADRIFT5_GAME_LIST[] = {
 	{ "mystman", "Mystman" },
 	{ "starshipquest", "Starship Quest" },
 	{ "sixsilverbullets", "Six Silver Bullets" },
-	{ "tcom", "TCOM" },
-	{ "tcom2", "TCOM2" },
+	{ "tcom1", "The Cave of Morpheus 1" },
+	{ "tcom2", "The Cave of Morpheus 2" },
 	{ "thetest", "The Test" },
 	{ "tingalan", "Tingalan" },
 	// ADRIFT One-Hour Game Competition 1


### PR DESCRIPTION
"tcom" is "The Cave of Morpheus"
(i *think* it consists of part 1 and 2 but i can´t be sure, since this is an unsupported v5 game)
According to the information given in this results list from if-archive.org, it matches:
https://www.ifarchive.org/if-archive/games/competition2001/results.txt
See entry 33, second line (It´s the only game that matches the short name)

In addition this also fixes bug #11569
(https://bugs.scummvm.org/ticket/11569)
It´s because of a second entry with the same short name of "tcom" living in GLK/GLULXE ("The Colour of Magic")
They clash and break the "Add game" option on my platform.
See here for the entry in GLULXE:
​https://github.com/scummvm/scummvm/blob/master/engines/glk/glulxe/detection_tables.h#L206