### PR TITLE
NEVERHOOD: Big demo

### DIFF
--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -64,6 +64,11 @@ bool NeverhoodEngine::isDemo() const {
 	return _gameDescription->desc.flags & ADGF_DEMO;
 }
 
+bool NeverhoodEngine::isBigDemo() const {
+	//HACK: this is just a stup to allow testing
+	return true;
+}
+
 bool NeverhoodEngine::applyResourceFixes() const {
 	return getLanguage() == Common::RU_RUS;
 }

--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -34,18 +34,11 @@ namespace Neverhood {
 struct NeverhoodGameDescription {
 	ADGameDescription desc;
 
-	int gameID;
-	int gameType;
 	uint32 features;
-	uint16 version;
 };
 
 const char *NeverhoodEngine::getGameId() const {
 	return _gameDescription->desc.gameId;
-}
-
-uint32 NeverhoodEngine::getFeatures() const {
-	return _gameDescription->features;
 }
 
 Common::Platform NeverhoodEngine::getPlatform() const {
@@ -56,17 +49,12 @@ Common::Language NeverhoodEngine::getLanguage() const {
 	return _gameDescription->desc.language;
 }
 
-uint16 NeverhoodEngine::getVersion() const {
-	return _gameDescription->version;
-}
-
 bool NeverhoodEngine::isDemo() const {
 	return _gameDescription->desc.flags & ADGF_DEMO;
 }
 
 bool NeverhoodEngine::isBigDemo() const {
-	//HACK: this is just a stup to allow testing
-	return true;
+	return _gameDescription->features & GF_BIG_DEMO;
 }
 
 bool NeverhoodEngine::applyResourceFixes() const {
@@ -95,10 +83,7 @@ static const NeverhoodGameDescription gameDescriptions[] = {
 			ADGF_NO_FLAGS,
 			GUIO1(GUIO_NONE)
 		},
-		0,
-		0,
-		0,
-		0,
+		0
 	},
 
 	{
@@ -112,10 +97,7 @@ static const NeverhoodGameDescription gameDescriptions[] = {
 			ADGF_DEMO,
 			GUIO1(GUIO_NONE)
 		},
-		0,
-		0,
-		0,
-		0,
+		GF_BIG_DEMO
 	},
 
     {
@@ -127,11 +109,9 @@ static const NeverhoodGameDescription gameDescriptions[] = {
             Common::EN_ANY,
             Common::kPlatformWindows,
             ADGF_DEMO,
-            GUIO1(GUIO_NONE)},
-        0,
-        0,
-        0,
-        0,
+            GUIO1(GUIO_NONE)
+		},
+        0
     },
 
 	{
@@ -145,10 +125,7 @@ static const NeverhoodGameDescription gameDescriptions[] = {
 			ADGF_DEMO,
 			GUIO1(GUIO_NONE)
 		},
-		0,
-		0,
-		0,
-		0,
+		0
 	},
 
 	{
@@ -162,10 +139,7 @@ static const NeverhoodGameDescription gameDescriptions[] = {
 			ADGF_NO_FLAGS,
 			GUIO1(GUIO_NONE)
 		},
-		0,
-		0,
-		0,
-		0,
+		0
 	},
 
 // FIXME: Disabled for now, as it has broken resources that corrupt the heap
@@ -189,7 +163,7 @@ static const NeverhoodGameDescription gameDescriptions[] = {
 	},
 #endif
 
-	{ AD_TABLE_END_MARKER, 0, 0, 0, 0 }
+	{ AD_TABLE_END_MARKER, 0 }
 };
 
 } // End of namespace Neverhood

--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -97,11 +97,11 @@ static const NeverhoodGameDescription gameDescriptions[] = {
 	},
 
 	{
-		// Neverhood English demo version
+		// Neverhood English big demo version
 		{
 			"neverhood",
-			"Demo",
-			AD_ENTRY1s("nevdemo.blb", "05b735cfb1086892bec79b54dca5545b", 22564568),
+			"Big Demo",
+            AD_ENTRY1s("nevdemo.blb", "e637221d296f9a25ff22eaed96b07519", 117274189),
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_DEMO,
@@ -112,6 +112,22 @@ static const NeverhoodGameDescription gameDescriptions[] = {
 		0,
 		0,
 	},
+
+    {
+        // Neverhood English demo version
+        {
+            "neverhood",
+            "Demo",
+            AD_ENTRY1s("nevdemo.blb", "05b735cfb1086892bec79b54dca5545b", 22564568),
+            Common::EN_ANY,
+            Common::kPlatformWindows,
+            ADGF_DEMO,
+            GUIO1(GUIO_NONE)},
+        0,
+        0,
+        0,
+        0,
+    },
 
 	{
 		// Neverhood earlier English demo version

--- a/engines/neverhood/gamemodule.cpp
+++ b/engines/neverhood/gamemodule.cpp
@@ -715,7 +715,9 @@ void GameModule::updateModule() {
 			createModule(2600, 1);
 			break;
 		case 2600:
-			if (_moduleResult == 1)
+			if (_vm->isDemo())
+				createModule(9999, -1);
+			else if (_moduleResult == 1)
 				createModule(2500, 0);
 			else
 				createModule(1200, 1);

--- a/engines/neverhood/gamemodule.cpp
+++ b/engines/neverhood/gamemodule.cpp
@@ -715,7 +715,7 @@ void GameModule::updateModule() {
 			createModule(2600, 1);
 			break;
 		case 2600:
-			if (_vm->isDemo())
+			if (_vm->isDemo() && !_vm->isBigDemo())
 				createModule(9999, -1);
 			else if (_moduleResult == 1)
 				createModule(2500, 0);

--- a/engines/neverhood/modules/module1000.cpp
+++ b/engines/neverhood/modules/module1000.cpp
@@ -96,7 +96,7 @@ void Module1000::updateScene() {
 			if (_moduleResult == 1)
 				leaveModule(0);
 			else if (_moduleResult == 2) {
-				if (_vm->isDemo())
+				if (_vm->isDemo() && !_vm->isBigDemo())
 					// Demo version returns to the same scene
 					createScene(1, 2);
 				else

--- a/engines/neverhood/modules/module2300.cpp
+++ b/engines/neverhood/modules/module2300.cpp
@@ -127,7 +127,7 @@ void Module2300::updateScene() {
 		case 1:
 			if (_moduleResult == 1)
 				createScene(0, 0);
-			else if (_vm->isDemo())
+			else if (_vm->isDemo() && !(_vm->isBigDemo() && _moduleResult == 4))
 				createScene(9999, 0);
 			else if (_moduleResult == 2)
 				createScene(2, 1);

--- a/engines/neverhood/neverhood.cpp
+++ b/engines/neverhood/neverhood.cpp
@@ -111,7 +111,7 @@ Common::Error NeverhoodEngine::run() {
 	_updateSound = true;
 	_enableMusic = !_mixer->isSoundTypeMuted(Audio::Mixer::kMusicSoundType);
 
-	if (isDemo()) {
+	if (isDemo() && !isBigDemo()) {
 		// Adjust this navigation list for the demo version
 		NavigationList *navigationList = _staticData->getNavigationList(0x004B67E8);
 		(*navigationList)[0].middleSmackerFileHash = 0;

--- a/engines/neverhood/neverhood.h
+++ b/engines/neverhood/neverhood.h
@@ -75,6 +75,7 @@ public:
 	Common::Language getLanguage() const;
 	bool hasFeature(EngineFeature f) const override;
 	bool isDemo() const;
+	bool isBigDemo() const;
 	bool applyResourceFixes() const;
 	Common::String getTargetName() { return _targetName; };
 

--- a/engines/neverhood/neverhood.h
+++ b/engines/neverhood/neverhood.h
@@ -38,6 +38,7 @@
 namespace Neverhood {
 
 enum NeverhoodGameFeatures {
+	GF_BIG_DEMO = (1 << 0)
 };
 
 struct NeverhoodGameDescription;
@@ -69,8 +70,6 @@ public:
 	// Detection related functions
 	const NeverhoodGameDescription *_gameDescription;
 	const char *getGameId() const;
-	uint32 getFeatures() const;
-	uint16 getVersion() const;
 	Common::Platform getPlatform() const;
 	Common::Language getLanguage() const;
 	bool hasFeature(EngineFeature f) const override;


### PR DESCRIPTION
This adds support for a new demo version of the game.

In addition to the detection entry, it fixes the game logic to allow for fully accessing the demo.