### PR TITLE
AMIGAOS4: Reorder .mk file to fix readme.guide

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -5,21 +5,21 @@ amigaosdist: $(EXECUTABLE) $(PLUGINS)
 	mkdir -p $(AMIGAOSPATH)/extras
 	cp ${srcdir}/dists/amiga/scummvm_drawer.info $(AMIGAOSPATH).info
 	cp ${srcdir}/dists/amiga/scummvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info
-# Copy mandatory installation files.
+ifdef DIST_FILES_DOCS
+	mkdir -p $(AMIGAOSPATH)/doc
+	cp -r $(srcdir)/doc/ $(AMIGAOSPATH)
+	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)/doc/
 # Prepare README.md for AmigaGuide conversion.
 	cat ${srcdir}/README.md | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
 # AmigaOS AREXX has a problem when ${srcdir} is '.'.
 # It will break with a "Program not found" error.
 # Copy the script to cwd and, once it has finished, remove it.
 	cp ${srcdir}/dists/amiga/RM2AG.rexx .
-	rx RM2AG.rexx README.conv $(AMIGAOSPATH)
+	rx RM2AG.rexx README.conv $(AMIGAOSPATH)/doc/
 	rm README.conv
 	rm RM2AG.rexx
-ifdef DIST_FILES_DOCS
-	mkdir -p $(AMIGAOSPATH)/doc
-	cp -r $(srcdir)/doc/ $(AMIGAOSPATH)
-	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)/doc/
 endif
+# Copy mandatory installation files.
 ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) $(AMIGAOSPATH)/extras/
 endif


### PR DESCRIPTION
The created readme.guide file features some in-guide links that point to local files (I.e. AUTHORS), which need to be in the same directory level.
It will otherwise silently fail, when a user clicks on said links.

Due to all documents (except the readme.guide) being installed into the doc/ subdirectory since a few months now, the in-guide links stopped working.
We fix that by restructure the install order to
1) place the .guide creation into the documents loop
2) make sure the /doc subdirectory is available before the guide creation is processed and
3) place the readme.guide into the /doc subdir to secure working in-guide links


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
