### PR TITLE
ZVISION: Possible fix for music playing over Charon cutscenes in ZGI

### DIFF
--- a/engines/zvision/scripting/actions.cpp
+++ b/engines/zvision/scripting/actions.cpp
@@ -1000,7 +1000,27 @@ bool ActionStreamVideo::execute() {
 		_engine->getRenderManager()->initSubArea(HIRES_WINDOW_WIDTH, HIRES_WINDOW_HEIGHT, workingWindow);
 	}
 
+	// WORKAROUND for what appears to be a script bug. When riding with
+	// Charon in one direction, the game issues a command to kill the
+	// universe_hades_sound_task. When going in the other direction (either
+	// as yourself or as the two-headed beast) it does not. Since the
+	// cutscene plays music, there may be two pieces of music playing
+	// simultaneously during the ride.
+	//
+	// Rather than mucking about with killing and restarting the sound,
+	// simply pause the ScummVM mixer during the ride.
+
+	bool pauseBackgroundMusic = _engine->getGameId() == GID_GRANDINQUISITOR && (_fileName == "hp3ea021.avi" || _fileName == "hp4ea051.avi");
+
+	if (pauseBackgroundMusic) {
+		_engine->_mixer->pauseAll(true);
+	}
+
 	_engine->playVideo(*decoder, destRect, _skippable, sub);
+
+	if (pauseBackgroundMusic) {
+		_engine->_mixer->pauseAll(false);
+	}
 
 	if (switchToHires) {
 		_engine->initScreen();


### PR DESCRIPTION
This was the worst glitch I encountered in my playthroughs while debugging scoring in ZGI, so I figured I should at least make an attempt at fixing it before the next release.

When riding with Charon in one direction, the script stops the background sounds. This is done in hp1f.scr:

```
puzzle:08618 {	# hp1f_pay_charon
    criteria {
        [08616] = 1	# hp1f_charons_hand
        [08622] = 0	# hp1f_charon_state
        [00009] = 87	# Inventory
        [08620] = 1	# hp1f_payed_first_coin
        [08419] = 0	# user_is_charon
    }
    results {
        action:inventory(drop 87)
        action:assign(08616, 0)	# hp1f_charons_hand
        action:assign(08620, 0)	# hp1f_payed_first_coin
        action:kill(05182)	# universe_hades_sound_task
        action:streamvideo(hp2ea021.avi 0 0 640 344 0 1)
        action:assign(19421, 0)	# hp1f_start_bg_music
        action:flush_mouse_events(0)
        action:dissolve()
        action:change_location(h, p, 40, 340)
    }
    flags {
        once_per_inst
    }
}
```

But it's not done when going in the other direction, handled by hp4e.scr, neither when going back as yourself or as the two-headed beast:

```
puzzle:08728 {	# hp4e_boat_ride_back
    criteria {
        [08420] = 1	# user_is_two_headed
        [19242] = 1	# hp4e_two_headed_hotspot
    }
    results {
        action:assign(19242, 0)	# hp4e_two_headed_hotspot
        action:inventory(drop 87)
        action:assign(08731, 0)	# hp4e_paid_one_zorkmid
        action:assign(08729, 0)	# hp4e_charons_hand
        action:stop(08421)	# hp_snavig_timer
        action:assign(08421, 0)	# hp_snavig_timer
        action:assign(08418, 0)	# hp_start_snavig_timer
        action:streamvideo(hp3ea021.avi 0 0 639 343 0 0)
        action:flush_mouse_events(0)
        action:dissolve()
        action:change_location(h, p, 10, 1480)
    }
    flags {
        once_per_inst
    }
}

puzzle:08728 {	# hp4e_boat_ride_back
    criteria {
        [08729] = 1	# hp4e_charons_hand
        [01596] = 1	# user_is_user
        [08730] = 0	# hp_been_thru_gates
        [00009] = 87	# Inventory
        [08731] = 1	# hp4e_paid_one_zorkmid
    }
    results {
        action:assign(08731, 0)	# hp4e_paid_one_zorkmid
        action:assign(08729, 0)	# hp4e_charons_hand
        action:inventory(drop 87)
        action:streamvideo(hp4ea051.avi 0 0 639 343 0 0)
        action:flush_mouse_events(0)
        action:dissolve()
        action:change_location(h, p, 10, 1480)
    }
    flags {
        once_per_inst
    }
}
```

This appears to be an original script bug, because it happens in this video from 2008, which I _think_ predates even the original ZEngine repository: https://www.youtube.com/watch?v=yI8WJOqLkzg&t=435

Rather than mucking about with killing and restarting the sound like the script would do, this pull request simply pauses the mixer while the cutscenes are playing.

I have only tested this with the DVD version of the game.