### PR TITLE
Use native language names

### DIFF
--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -42,7 +42,7 @@ namespace Common {
 DECLARE_SINGLETON(TranslationManager);
 
 bool operator<(const TLanguage &l, const TLanguage &r) {
-	return strcmp(l.name, r.name) < 0;
+	return l.name < r.name;
 }
 
 TranslationManager::TranslationManager() : _currentLang(-1) {
@@ -188,7 +188,7 @@ const TLangArray TranslationManager::getSupportedLanguageNames() const {
 	TLangArray languages;
 
 	for (unsigned int i = 0; i < _langNames.size(); i++) {
-		TLanguage lng(_langNames[i].c_str(), i + 1);
+		TLanguage lng(_langNames[i], i + 1);
 		languages.push_back(lng);
 	}
 
@@ -306,7 +306,7 @@ void TranslationManager::loadTranslationsInfoDat() {
 		_langs[i] = String(buf, len - 1);
 		len = in.readUint16BE();
 		in.read(buf, len);
-		_langNames[i] = String(buf, len - 1);
+		_langNames[i] = String(buf, len - 1).decode();
 	}
 
 	// Read messages

--- a/common/translation.h
+++ b/common/translation.h
@@ -42,11 +42,11 @@ enum TranslationIDs {
 };
 
 struct TLanguage {
-	const char *name;
+	U32String name;
 	int id;
 
-	TLanguage() : name(nullptr), id(0) {}
-	TLanguage(const char *n, int i) : name(n), id(i) {}
+	TLanguage() : id(0) {}
+	TLanguage(const U32String &n, int i) : name(n), id(i) {}
 };
 
 bool operator<(const TLanguage &l, const TLanguage &r);
@@ -209,7 +209,7 @@ private:
 	bool checkHeader(File &in);
 
 	StringArray _langs;
-	StringArray _langNames;
+	U32StringArray _langNames;
 
 	StringArray _messageIds;
 	Array<PoMessageEntry> _currentTranslationMessages;

--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -196,6 +196,34 @@ bool U32String::operator!=(const char *x) const {
 	return !equals(x);
 }
 
+bool U32String::operator<(const String &x) const {
+	for (int i = 0 ; i < _size && i < x.size() ; ++i) {
+		if (_str[i] < x[i])
+			return true;
+		else if (_str[i] > x[i])
+			return false;
+	}
+	return (_size < x.size());
+}
+
+bool U32String::operator<=(const String &x) const {
+	return !operator>(x);
+}
+
+bool U32String::operator>(const String &x) const {
+	for (int i = 0 ; i < _size && i < x.size() ; ++i) {
+		if (_str[i] > x[i])
+			return true;
+		else if (_str[i] < x[i])
+			return false;
+	}
+	return (_size > x.size());
+}
+
+bool U32String::operator>=(const String &x) const {
+	return !operator<(x);
+}
+
 bool U32String::equals(const U32String &x) const {
 	if (this == &x || _str == x._str) {
 		return true;

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -136,6 +136,11 @@ public:
 	bool operator!=(const value_type *x) const;
 	bool operator!=(const char *x) const;
 
+	bool operator<(const String &x) const;
+	bool operator<=(const String &x) const;
+	bool operator>(const String &x) const;
+	bool operator>=(const String &x) const;
+
 	/**
 	 * Compares whether two U32String are the same based on memory comparison.
 	 * This does *not* do comparison based on canonical equivalence.

--- a/po/be_BY.po
+++ b/po/be_BY.po
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Belarusian\n"
+"X-Language-name: Беларуская\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/ca_ES.po
+++ b/po/ca_ES.po
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Catalan\n"
+"X-Language-name: Català\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/cs_CZ.po
+++ b/po/cs_CZ.po
@@ -20,7 +20,7 @@ msgstr ""
 "X-Generator: Weblate 4.0.4\n"
 "X-Poedit-SourceCharset: iso-8859-2\n"
 "X-Poedit-Basepath: ..\n"
-"X-Language-name: Cesky\n"
+"X-Language-name: Český\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Greek\n"
+"X-Language-name: Ελληνικά\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Espanol\n"
+"X-Language-name: Español\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Francais\n"
+"X-Language-name: Français\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && "
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Hebrew\n"
+"X-Language-name: תירבע\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0.4\n"
 "X-Poedit-SourceCharset: iso-8859-1\n"
-"X-Language-name: Norsk (bokmaal)\n"
+"X-Language-name: Norsk (bokmål)\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-Language: Portuguese\n"
 "X-Poedit-Country: BRAZIL\n"
 "X-Poedit-SourceCharset: iso-8859-1\n"
-"X-Language-name: Portugues (Brasil)\n"
+"X-Language-name: Português (Brasil)\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Portugues (Portugal)\n"
+"X-Language-name: Português (Portugal)\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
 "4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Russian\n"
+"X-Language-name: Русский\n"
 
 #: gui/about.cpp:102
 #, c-format

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
 "4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0.4\n"
-"X-Language-name: Ukrainian\n"
+"X-Language-name: Українська\n"
 
 #: gui/about.cpp:102
 #, c-format


### PR DESCRIPTION
Now that the GUI uses UTF-32, we no longer need to restrict language names to ASCII characters. This means we can use accentuated characters and non-latin alphabets.

This pull request proposes to do that.
Possible issues:
- I pulled the language names from the wikipedia language selection menu. Hopefully this is correct, but it would be good to check.
- I only implemented a basic sorting of `U32String` based on the character values. This is not ideal, so if somebody wants to implement proper unicode string sorting, that would be welcome. But I considered that it was overkill just for a language selection menu. I only considered doing the sorting based on the language code, but this is not ideal either (for example we end up having Suomi between Euskara and Français).

![image](https://user-images.githubusercontent.com/552105/91669575-c4f95c00-eb0d-11ea-8cce-9624704781a8.png)