### PR TITLE
CINE: Fix for bug #10643 to branch-2-2 ("Fix overlay rendering with NULL source mask").

### DIFF
--- a/engines/cine/gfx.cpp
+++ b/engines/cine/gfx.cpp
@@ -653,7 +653,14 @@ void FWRenderer::renderOverlay(const Common::List<overlay>::iterator &it) {
 		sprite = &g_cine->_animDataTable[g_cine->_objectTable[it->objIdx].frame];
 		len = sprite->_realWidth * sprite->_height;
 		mask = new byte[len];
-		memcpy(mask, sprite->mask(), len);
+		if (sprite->mask() != NULL) {
+			memcpy(mask, sprite->mask(), len);
+		} else {
+			// This case happens in French Amiga Future Wars (Bug #10643) when
+			// walking left from the scene with the open manhole cover. This
+			// seems to work fine at least in this case.
+			memset(mask, 0, len);
+		}
 		remaskSprite(mask, it);
 		drawMaskedSprite(g_cine->_objectTable[it->objIdx], mask);
 		delete[] mask;


### PR DESCRIPTION
In French Amiga Future Wars from bug #10643 when walking left from the
scene with the open manhole cover a call to renderOverlay with a
type 0 (color sprite) overlay happens. The source mask for the overlay
is NULL and a memcpy using a NULL pointer as source is initiated.
This results in a memory access violation.

This fixes that memory access violation by simply setting the
destination mask to all zeroes when the source mask is NULL.
Seems to work fine at least in this case.

Fixes bug #10643.