### PR TITLE
[RFC] Prefer in-memory SoundFont data over global setting in FluidSynth driver

### DIFF
--- a/audio/softsynth/fluidsynth.cpp
+++ b/audio/softsynth/fluidsynth.cpp
@@ -167,7 +167,9 @@ int MidiDriver_FluidSynth::open() {
 		return MERR_ALREADY_OPEN;
 
 #if defined(FLUIDSYNTH_VERSION_MAJOR) && FLUIDSYNTH_VERSION_MAJOR > 1
-	bool isUsingInMemorySoundFontData = _engineSoundFontData && !ConfMan.hasKey("soundfont");
+	// When provided with in-memory SoundFont data, only use the configured
+	// SoundFont instead if it's explicitly configured on the current game.
+	bool isUsingInMemorySoundFontData = _engineSoundFontData && !ConfMan.getActiveDomain()->contains("soundfont");
 #else
 	bool isUsingInMemorySoundFontData = false;
 #endif
@@ -241,7 +243,7 @@ int MidiDriver_FluidSynth::open() {
 
 	fluid_synth_set_interp_method(_synth, -1, interpMethod);
 
-	const char *soundfont = ConfMan.hasKey("soundfont") ?
+	const char *soundfont = !isUsingInMemorySoundFontData ?
 			ConfMan.get("soundfont").c_str() : Common::String::format("&%p", (void *)_engineSoundFontData).c_str();
 
 #if defined(FLUIDSYNTH_VERSION_MAJOR) && FLUIDSYNTH_VERSION_MAJOR > 1


### PR DESCRIPTION
Blazing Dragons provides a custom SoundFont to the FluidSynth driver. Unfortunately, I can't find any sensible way to use that because my global SoundFont setting takes precedence over the in-memory data. Even overriding the MIDI settings for Blazing Dragons and leaving the SoundFont setting blank did not help.

What I've tried to do here is to soften the check so that FluidSynth will prefer in-memory data unless a SoundFont has been explicitly configured for the current game.

Does this seem like a sensible solution? If so, should it also go into the 2.2 branch?