### PR TITLE
CINE: OS: Fallback to default error messages

### DIFF
--- a/engines/cine/texte.cpp
+++ b/engines/cine/texte.cpp
@@ -186,6 +186,78 @@ void initLanguage(Common::Language lang) {
 		"A wall of silence ..."
 	};
 
+	/**
+	 * British English error messages for Operation Stealth.
+	 */
+	static const char *const failureMessages_OS_EN[] = {
+		// EXAMINE
+		"You haven't noticed anything special.",
+		"Nothing interesting.",
+		"Nothing to say about it.",
+		"You find nothing.",
+		// TAKE
+		"Let's forget about it.",
+		"I could if I wanted, but I don't.",
+		"There are so many things to take and you want this one!",
+		"No need.",
+		// INVENTORY
+		"",
+		"",
+		"",
+		"",
+		// USE
+		"That won't do anything.",
+		"Nothing's happening.",
+		"If you have anything else like this, go ahead and finish it.",
+		"It's like you did nothing.",
+		// OPERATE
+		"You do it, nothing happens.",
+		"Why don't you try it and we won't talk about it anymore.",
+		"Nothing's happening.",
+		"No result.",
+		// SPEAK
+		"You speak with him. No answer.",
+		"More action and less talk.",
+		"My name is GLAMES... JOHN GLAMES.",
+		"A wall of silence..."
+	};
+
+	/**
+	 * American English error messages for Operation Stealth.
+	 */
+	static const char *const failureMessages_OS_US[] = {
+		// EXAMINE
+		"You haven't noticed anything special.",
+		"Nothing interesting.",
+		"Nothing to say about it.",
+		"You find nothing.",
+		// TAKE
+		"Let's forget about it.",
+		"I could if I wanted, but I don't.",
+		"There are so many things to take and you want this one!",
+		"No need.",
+		// INVENTORY
+		"",
+		"",
+		"",
+		"",
+		// USE
+		"That won't do anything.",
+		"Nothing's happening.",
+		"If you have anything else like this, go ahead and finish it.",
+		"It's like you did nothing.",
+		// OPERATE
+		"You do it, nothing happens.",
+		"Absolutely not! It would be a waste of my valuable time.",
+		"Nothing's happening.",
+		"No result.",
+		// SPEAK
+		"You speak with him. No answer.",
+		"More action and less talk.",
+		"My name is BOND... JAMES BOND.   ",
+		"A wall of silence..."
+	};
+
 	static const CommandeType defaultActionCommand_EN[] = {
 		"EXAMINE",
 		"TAKE",
@@ -260,6 +332,42 @@ void initLanguage(Common::Language lang) {
 		"Vous lui parlez . Sans r\x82ponse.",
 		"Plus d'actes et moins de Paroles !",
 		"Je serais bien surpris si vous obteniez une r\x82ponse.",
+		"Un mur de silence ..."
+	};
+
+	/**
+	 * French error messages for Operation Stealth.
+	 */
+	static const char *const failureMessages_OS_FR[] = {
+		// EXAMINER
+		"Vous ne remarquez rien de sp\x82""cial.",
+		"Rien d'int\x82ressant.",
+		"Peu de choses \x85 dire l\x85-dessus.",
+		"Vous ne trouvez rien.",
+		// PRENDRE
+		"N'en parlons plus...",
+		"Je pourrais si je le voulais! MAIS JE NE VEUX PAS!",
+		"Il y a des tas de choses \x85 prendre et vous voulez celle l\x85!",
+		"C'est inutile!",
+		// INVENTAIRE
+		"",
+		"",
+		"",
+		"",
+		// UTILISER
+		"C'est absolument sans effet.",
+		"Il ne se passe rien.",
+		"Si vous en avez d'autres comme \x87""a, allez-y qu'on en finisse.",
+		"C'est comme si vous n'aviez rien fait!",
+		// ACTIONNER
+		"OK! vous l'actionnez. Il ne se passe rien.",
+		"Supposons que vous essayiez et n'en parlons plus.",
+		"Rien n'y fait.",
+		"Aucun r\x82sultat.",
+		// PARLER
+		"Vous lui parlez . Pas de r\x82ponse.",
+		"Plus d'actes et moins de Paroles !",
+		"Mon nom est GLAMES... JOHN GLAMES.",
 		"Un mur de silence ..."
 	};
 
@@ -417,6 +525,42 @@ void initLanguage(Common::Language lang) {
 		"Eine Wand des Schweigens..."
 	};
 
+	/**
+	 * German error messages for Operation Stealth.
+	 */
+	static const char *const failureMessages_OS_DE[] = {
+		// EXAMINE
+		"Ich sehe nichts Besonderes",
+		"Es gibt hier nichts Interessantes",
+		"Das ist nicht besonders interessant",
+		"Sie werden nichts finden",
+		// TAKE
+		"Ich Kann das nicht nehmen",
+		"Das finde ich schwierig",
+		"Ich wei\x9e nicht, was ich nehmen soll",
+		"Ich kann Ihnen nicht folgen",
+		// INVENTORY
+		"Das bringt nichts",
+		"Sie haben wirklich was Besseres zu tun",
+		"Los, wir sollten keine Zeit verschwenden",
+		"Das scheint mir eine gute Idee zu sein",
+		// USE
+		"Ich wei\x9e nicht, warum ich das tun soll",
+		"Es hat so oder so nichts begracht",
+		"Davon haben wir nichts",
+		"Versuchen Sie, etwas anderes zu finden",
+		// OPERATE
+		"Es geht nicht",
+		"Nichts passiert",
+		"Nichts passiert",
+		"Sie haben wirklich was Besseres zu tun",
+		// SPEAK
+		"Sie sprechen mit ihm. Keine Antwort",
+		"Nicht reden, sondern handeln!",
+		"Wenn Sie eine Antwork bek\x84men, w\x81rde es mich sehr wundern",
+		"Eine Wand des Schweigens..."
+	};
+
 	static const CommandeType defaultActionCommand_DE[] = {
 		"Pr\x81""fe", // FIXME? The third letter should be Latin Small Letter U with diaeresis
 		"Nimm",
@@ -540,7 +684,11 @@ void initLanguage(Common::Language lang) {
 
 	switch (lang) {
 	case Common::FR_FRA:
-		setFailureMessages(failureMessages_FR, false);
+		if (g_cine->getGameType() == Cine::GType_OS) {
+			setFailureMessages(failureMessages_OS_FR, false);
+		} else {
+			setFailureMessages(failureMessages_FR, false);
+		}
 		defaultActionCommand = defaultActionCommand_FR;
 		systemMenu = systemMenu_FR;
 		confirmMenu = confirmMenu_FR;
@@ -560,7 +708,11 @@ void initLanguage(Common::Language lang) {
 		break;
 
 	case Common::DE_DEU:
-		setFailureMessages(failureMessages_DE, false);
+		if (g_cine->getGameType() == Cine::GType_OS) {
+			setFailureMessages(failureMessages_OS_DE, false);
+		} else {
+			setFailureMessages(failureMessages_DE, false);
+		}
 		defaultActionCommand = defaultActionCommand_DE;
 		systemMenu = systemMenu_DE;
 		confirmMenu = confirmMenu_DE;
@@ -580,7 +732,15 @@ void initLanguage(Common::Language lang) {
 		break;
 
 	default:
-		setFailureMessages(failureMessages_EN, false);
+		if (g_cine->getGameType() == Cine::GType_OS) {
+			if (lang == Common::EN_USA) {
+				setFailureMessages(failureMessages_OS_US, false);
+			} else {
+				setFailureMessages(failureMessages_OS_EN, false);
+			}
+		} else {
+			setFailureMessages(failureMessages_EN, false);
+		}
 		defaultActionCommand = defaultActionCommand_EN;
 		systemMenu = systemMenu_EN;
 		confirmMenu = confirmMenu_EN;
@@ -619,7 +779,7 @@ void loadErrmessDat(const char *fname) {
 
 		in.close();
 	} else {
-		error("Cannot open file %s for reading", fname);
+		warning("Cannot read error messages from '%s'. Using default values. Error messages may be incorrect!", fname);
 	}
 }
 


### PR DESCRIPTION
If the error messages can not be found (They are in the file
ERRMESS.DAT in Operation Stealth) then use the default values.

There are now the following default error messages included in ScummVM
for Operation Stealth:
 - American English (Protagonist is James Bond)
 - British English (Protagonist is John Glames)
 - French
 - German

For the Italian and Spanish releases of Operation Stealth the error
messages from Future Wars are used as fallback. This is incorrect
but better than nothing.

This makes the error message handling more lenient than before so that
not having an ERRMESS.DAT does not block the starting of the game
anymore.

Fixes bug #11649.