### PR TITLE
CINE: OS: Fix MT-32/AdLib SFX & loading savegames

### DIFF
--- a/engines/cine/cine.cpp
+++ b/engines/cine/cine.cpp
@@ -256,15 +256,19 @@ void CineEngine::initialize() {
 	// Used for making sound effects work using Roland MT-32 and AdLib in
 	// Operation Stealth after loading a savegame. The sound effects are loaded
 	// in AUTO00.PRC using a combination of o2_loadAbs and o2_playSample(1, ...)
-	// before checking if _globalVars[255] == 0. In the original game AUTO00.PRC
+	// before o1_freePartRange(0, 200). In the original game AUTO00.PRC
 	// was run when starting or restarting the game and one could not load a savegame
 	// before passing the copy protection. Thus, we try to emulate that behaviour by
 	// running at least part of AUTO00.PRC before loading a savegame.
-	if (getGameType() == Cine::GType_OS && !(getFeatures() & GF_DEMO)) {
+	//
+	// Confirmed that DOS and Atari ST versions do have these commands in their AUTO00.PRC files.
+	// Confirmed that Amiga and demo versions do not have these commands in their AUTO00.PRC files.
+	if (getGameType() == Cine::GType_OS && !(getFeatures() & GF_DEMO) &&
+		(getPlatform() == Common::kPlatformDOS || getPlatform() == Common::kPlatformAtariST)) {
 		loadPrc(BOOT_PRC_NAME);
 		strcpy(currentPrcName, BOOT_PRC_NAME);
 		addScriptToGlobalScripts(BOOT_SCRIPT_INDEX);
-		runOnlyUntilCopyProtectionCheck = true;
+		runOnlyUntilFreePartRangeFirst200 = true;
 		executeGlobalScripts();
 	}
 

--- a/engines/cine/sound.cpp
+++ b/engines/cine/sound.cpp
@@ -751,7 +751,7 @@ void MidiSoundDriverH32::playSample(int mode, int channel, int param3, int param
 		break;
 	case 4: // show text in Roland MT-32 LCD display
 		// Don't display text in Roland MT-32 LCD display when loading a savegame
-		if (!runOnlyUntilCopyProtectionCheck) {
+		if (!runOnlyUntilFreePartRangeFirst200) {
 			selectInstrument5(channel);
 		}
 		break;

--- a/engines/cine/various.cpp
+++ b/engines/cine/various.cpp
@@ -42,7 +42,7 @@ namespace Cine {
 
 int16 disableSystemMenu = 0;
 bool inMenu;
-bool runOnlyUntilCopyProtectionCheck = false;
+bool runOnlyUntilFreePartRangeFirst200 = false;
 
 int16 commandVar3[4];
 int16 commandVar1;

--- a/engines/cine/various.h
+++ b/engines/cine/various.h
@@ -49,7 +49,7 @@ void setTextWindow(uint16 param1, uint16 param2, uint16 param3, uint16 param4);
 
 extern int16 disableSystemMenu;
 extern bool inMenu;
-extern bool runOnlyUntilCopyProtectionCheck;
+extern bool runOnlyUntilFreePartRangeFirst200;
 
 extern CommandeType currentSaveName[kMaxSavegames];
 


### PR DESCRIPTION
In Operation Stealth DOS and Atari ST versions, but not Amiga or
demo versions, sound effects are loaded in AUTO00.PRC using a
combination of o2_loadAbs and o2_playSample(1, ...) before
o1_freePartRange(0, 200). This is a better heuristic for ending the
script at the correct position than checking whether global variable
255 is compared to 0. In the original game AUTO00.PRC was run when
starting or restarting the game and one could not load a savegame
before passing the copy protection. Thus, we try to emulate that
behaviour by running at least part of AUTO00.PRC before loading a
savegame.