### PR TITLE
CINE: OS: Fix Amiga music and sample playing.

### DIFF
--- a/audio/mods/paula.cpp
+++ b/audio/mods/paula.cpp
@@ -40,8 +40,8 @@
 
 namespace Audio {
 
-Paula::Paula(bool stereo, int rate, uint interruptFreq, FilterMode filterMode) :
-		_stereo(stereo), _rate(rate), _periodScale((double)kPalPaulaClock / rate), _intFreq(interruptFreq) {
+Paula::Paula(bool stereo, int rate, uint interruptFreq, FilterMode filterMode, int periodScaleDivisor) :
+		_stereo(stereo), _rate(rate), _periodScale((double)kPalPaulaClock / (rate * periodScaleDivisor)), _intFreq(interruptFreq) {
 
 	_filterState.mode      = filterMode;
 	_filterState.ledFilter = false;

--- a/audio/mods/paula.h
+++ b/audio/mods/paula.h
@@ -69,9 +69,10 @@ public:
 	};
 
 	Paula(bool stereo = false, int rate = 44100, uint interruptFreq = 0,
-	      FilterMode filterMode = kFilterModeA1200);
+	      FilterMode filterMode = Paula::defaultFilterMode(), int periodScaleDivisor = 1);
 	~Paula();
 
+	static FilterMode defaultFilterMode() { return kFilterModeA1200; }
 	bool playing() const { return _playing; }
 	void setTimerBaseValue( uint32 ticksPerSecond ) { _timerBase = ticksPerSecond; }
 	uint32 getTimerBaseValue() { return _timerBase; }

--- a/audio/mods/soundfx.cpp
+++ b/audio/mods/soundfx.cpp
@@ -47,7 +47,7 @@ public:
 		NUM_INSTRUMENTS = 15
 	};
 
-	SoundFx(int rate, bool stereo);
+	SoundFx(int rate, bool stereo, int periodScaleDivisor = 1);
 	virtual ~SoundFx();
 
 	bool load(Common::SeekableReadStream *data, LoadSoundFxInstrumentCallback loadCb);
@@ -75,8 +75,8 @@ protected:
 	uint16 _effects[NUM_CHANNELS];
 };
 
-SoundFx::SoundFx(int rate, bool stereo)
-	: Paula(stereo, rate) {
+SoundFx::SoundFx(int rate, bool stereo, int periodScaleDivisor)
+	: Paula(stereo, rate, 0, Paula::defaultFilterMode(), periodScaleDivisor) {
 	setTimerBaseValue(kPalCiaClock);
 	_ticks = 0;
 	_delay = 0;
@@ -264,8 +264,8 @@ void SoundFx::interrupt() {
 	handleTick();
 }
 
-AudioStream *makeSoundFxStream(Common::SeekableReadStream *data, LoadSoundFxInstrumentCallback loadCb, int rate, bool stereo) {
-	SoundFx *stream = new SoundFx(rate, stereo);
+AudioStream *makeSoundFxStream(Common::SeekableReadStream *data, LoadSoundFxInstrumentCallback loadCb, int rate, bool stereo, int periodScaleDivisor) {
+	SoundFx *stream = new SoundFx(rate, stereo, periodScaleDivisor);
 	if (stream->load(data, loadCb)) {
 		stream->play();
 		return stream;

--- a/audio/mods/soundfx.cpp
+++ b/audio/mods/soundfx.cpp
@@ -148,7 +148,7 @@ bool SoundFx::load(Common::SeekableReadStream *data, LoadSoundFxInstrumentCallba
 			}
 		} else {
 			if (ins->name[0]) {
-				ins->name[8] = '\0';
+				ins->name[22] = '\0';
 				ins->data = (int8 *)(*loadCb)(ins->name, 0);
 				if (!ins->data) {
 					return false;

--- a/audio/mods/soundfx.h
+++ b/audio/mods/soundfx.h
@@ -45,7 +45,7 @@ typedef byte *(*LoadSoundFxInstrumentCallback)(const char *name, uint32 *size);
  * stream object is kept). If loadCb is non 0, then instruments are loaded using
  * it, buffers returned are free'd at the end of playback.
  */
-AudioStream *makeSoundFxStream(Common::SeekableReadStream *data, LoadSoundFxInstrumentCallback loadCb, int rate = 44100, bool stereo = true);
+AudioStream *makeSoundFxStream(Common::SeekableReadStream *data, LoadSoundFxInstrumentCallback loadCb, int rate = 44100, bool stereo = true, int periodScaleDivisor = 1);
 
 } // End of namespace Audio
 

--- a/engines/cine/anim.cpp
+++ b/engines/cine/anim.cpp
@@ -899,7 +899,7 @@ int loadResource(const char *resourceName, int16 idx, int16 frameIndex) {
 	} else if (strstr(resourceName, ".ADL")) {
 		result = loadSpl(resourceName, idx);
 	} else if (strstr(resourceName, ".AMI")) {
-		result = loadAni(resourceName, idx, frameIndex);
+		result = loadSpl(resourceName, idx);
 	} else if (strstr(resourceName, "ECHEC")) { // Echec (French) means failure
 		g_cine->quitGame();
 	} else {

--- a/engines/cine/sound.cpp
+++ b/engines/cine/sound.cpp
@@ -1443,10 +1443,14 @@ void PaulaSound::playSound(int mode, int channel, int param3, int param4, int pa
 void PaulaSound::playSound(int channel, int frequency, const uint8 *data, int size, int volumeStep, int stepCount, int volume, int repeat) {
 	debugC(5, kCineDebugSound, "PaulaSound::playSound() channel %d size %d", channel, size);
 	Common::StackLock lock(_sfxMutex);
-	assert(frequency > 0);
+
+	if (channel < 0 || channel >= NUM_CHANNELS) {
+		warning("PaulaSound::playSound: Channel number out of range (%d)", channel);
+		return;
+	}
 
 	stopSound(channel);
-	if (size > 0) {
+	if (frequency > 0 && size > 0) {
 		byte *sound = (byte *)malloc(size);
 		if (sound) {
 			// Create the audio stream
@@ -1454,6 +1458,10 @@ void PaulaSound::playSound(int channel, int frequency, const uint8 *data, int si
 
 			// Clear the first and last 16 bits like in the original.
 			sound[0] = sound[1] = sound[size - 2] = sound[size - 1] = 0;
+
+			if (g_cine->getGameType() == Cine::GType_OS) {
+				frequency = ((frequency * 2) / 20) + 50;
+			}
 
 			Audio::SeekableAudioStream *stream = Audio::makeRawStream(sound, size, PAULA_FREQ / frequency, 0);
 

--- a/engines/cine/sound.cpp
+++ b/engines/cine/sound.cpp
@@ -1402,7 +1402,10 @@ void PaulaSound::loadMusic(const char *name) {
 		byte *buf = readBundleSoundFile(name, &size);
 		if (buf) {
 			Common::MemoryReadStream s(buf, size);
-			_moduleStream = Audio::makeSoundFxStream(&s, readBundleSoundFile, _mixer->getOutputRate());
+			// Operation Stealth for Amiga has to have its music frequency halved
+			// or otherwise the music sounds too high pitched.
+			const int periodScaleDivisor = 2;
+			_moduleStream = Audio::makeSoundFxStream(&s, readBundleSoundFile, _mixer->getOutputRate(), true, periodScaleDivisor);
 			free(buf);
 		}
 	}


### PR DESCRIPTION
  Hi!
Here are fixes for Amiga music and sample playing in Operation Stealth.
This also slightly touches some common audio source code (See commits
0a4ebbf and 1f28961) but they were done in order to fix playing music
correctly in Amiga versions of Operation Stealth.

Please could you also cherry-pick these to the branch-2-2 branch?
Thank you!

Kari Salminen