### PR TITLE
BASE: WIN32: Exclude scummvm's base directory from plugin path

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -159,7 +159,9 @@ PluginList FilePluginProvider::getPlugins() {
 	Common::FSList pluginDirs;
 
 	// Add the default directories
+	#ifndef WIN32
 	pluginDirs.push_back(Common::FSNode("."));
+	#endif
 	pluginDirs.push_back(Common::FSNode("plugins"));
 
 	// Add the provider's custom directories


### PR DESCRIPTION
Currently, the plugin architecture searches for plugins in ScummVM's
base directory and in the plugins directory itself.

However, for Win32, we need to bundle several DLL files in order to
make ScummVM run at all. Currently, this leads to several warning
messages since ScummVM tries to load those DLLs as plugins.

This patch excludes the ScummVM base directory when running on Win32 and
only accepts plugins from the plugins directory.
