### PR TITLE
COMMON: Standardize conversion between U32String and String

### DIFF
--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -93,7 +93,8 @@ U32String::U32String(const char *beginP, const char *endP) : _size(0), _str(_sto
 }
 
 U32String::U32String(const String &str) : _size(0), _str(_storage) {
-	initWithCStr(str.c_str(), str.size());
+	_storage[0] = 0;
+	*this = U32String(str.decode());
 }
 
 U32String::U32String(const UnicodeBiDiText &txt) : _size(0), _str(_storage) {


### PR DESCRIPTION
Currently the `U32String(const String &str)` constructor converts a string using byte-copy, while the `String(const U32String &str)` constructor converts a string using UTF-8. These are asymmetrical operations, and lead to ~~total protonic reversal~~ corrupt data when converting Unicode back and forth between the two.

As an example, here's what happens if you add Unicode characters to a game description via the GUI:
![GUI bug](https://user-images.githubusercontent.com/603444/92524938-d8e24380-f21a-11ea-8c43-cc22a1ecdeae.png)
This isn't a display bug, the description will keep getting more corrupt as you go in the Edit Game dialog.

While this can be solved via `encode()` and `decode()`, I don't think having error-prone APIs is a good idea, so my proposals are either:
- Default to UTF8 when converting between the two. This guarantees no data loss, is compatible with ASCII strings, and cleans up most uses of `encode()` and `decode()`. The only downside is developers have to be aware this is the default behavior, and to explicitly use `encode()` and `decode()` when they require specific encodings for specific purposes.
- Never convert between the two outside of the explicit `encode()` and `decode()` functions. This makes it explicit to the developers what is happening, at the cost of making the code more verbose. This might also require C++11 literals for Unicode strings.

**Do not merge**. The code is for discussion and not a final solution.