### PR TITLE
ENGINES: Change mac resource fork file detection to use the file cache

### DIFF
--- a/common/macresman.h
+++ b/common/macresman.h
@@ -68,14 +68,14 @@ public:
 	bool open(const String &fileName);
 
 	/**
-	 * Open a Mac data/resource fork pair.
+	 * Open a Mac data/resource fork pair from within the given archive.
 	 *
 	 * @param path The path that holds the forks
 	 * @param fileName The base file name of the file
 	 * @note This will check for the raw resource fork, MacBinary, and AppleDouble formats.
 	 * @return True on success
 	 */
-	bool open(const FSNode &path, const String &fileName);
+	bool open(const String &fileName, Archive &archive);
 
 	/**
 	 * See if a Mac data/resource fork pair exists.

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -35,6 +35,45 @@
 #include "engines/advancedDetector.h"
 #include "engines/obsolete.h"
 
+/**
+ * Adapter to be able to use Common::Archive based code from the AD.
+ */
+class FileMapArchive : public Common::Archive {
+public:
+	FileMapArchive(const AdvancedMetaEngine::FileMap &fileMap) : _fileMap(fileMap) {}
+
+	bool hasFile(const Common::String &name) const override {
+		return _fileMap.contains(name);
+	}
+
+	int listMembers(Common::ArchiveMemberList &list) const override {
+		int files = 0;
+		for (AdvancedMetaEngine::FileMap::const_iterator it = _fileMap.begin(); it != _fileMap.end(); ++it) {
+			list.push_back(Common::ArchiveMemberPtr(new Common::FSNode(it->_value)));
+			++files;
+		}
+
+		return files;
+	}
+
+	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override {
+		AdvancedMetaEngine::FileMap::const_iterator it = _fileMap.find(name);
+		if (it == _fileMap.end()) {
+			return Common::ArchiveMemberPtr();
+		}
+
+		return Common::ArchiveMemberPtr(new Common::FSNode(it->_value));
+	}
+
+	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override {
+		Common::FSNode fsNode = _fileMap[name];
+		return fsNode.createReadStream();
+	}
+
+private:
+	const AdvancedMetaEngine::FileMap &_fileMap;
+};
+
 static Common::String sanitizeName(const char *name) {
 	Common::String res;
 
@@ -355,14 +394,16 @@ void AdvancedMetaEngine::composeFileHashMap(FileMap &allFiles, const Common::FSL
 	}
 }
 
-bool AdvancedMetaEngine::getFileProperties(const Common::FSNode &parent, const FileMap &allFiles, const ADGameDescription &game, const Common::String fname, FileProperties &fileProps) const {
+bool AdvancedMetaEngine::getFileProperties(const FileMap &allFiles, const ADGameDescription &game, const Common::String fname, FileProperties &fileProps) const {
 	// FIXME/TODO: We don't handle the case that a file is listed as a regular
 	// file and as one with resource fork.
 
 	if (game.flags & ADGF_MACRESFORK) {
+		FileMapArchive fileMapArchive(allFiles);
+
 		Common::MacResManager macResMan;
 
-		if (!macResMan.open(parent, fname))
+		if (!macResMan.open(fname, fileMapArchive))
 			return false;
 
 		fileProps.md5 = macResMan.computeResForkMD5AsString(_md5Bytes);
@@ -407,7 +448,7 @@ ADDetectedGames AdvancedMetaEngine::detectGame(const Common::FSNode &parent, con
 				continue;
 
 			FileProperties tmp;
-			if (getFileProperties(parent, allFiles, *g, fname, tmp)) {
+			if (getFileProperties(allFiles, *g, fname, tmp)) {
 				debug(3, "> '%s': '%s'", fname.c_str(), tmp.md5.c_str());
 			}
 
@@ -510,7 +551,7 @@ ADDetectedGames AdvancedMetaEngine::detectGame(const Common::FSNode &parent, con
 	return matched;
 }
 
-ADDetectedGame AdvancedMetaEngine::detectGameFilebased(const FileMap &allFiles, const Common::FSList &fslist, const ADFileBasedFallback *fileBasedFallback) const {
+ADDetectedGame AdvancedMetaEngine::detectGameFilebased(const FileMap &allFiles, const ADFileBasedFallback *fileBasedFallback) const {
 	const ADFileBasedFallback *ptr;
 	const char* const* filenames;
 
@@ -546,7 +587,7 @@ ADDetectedGame AdvancedMetaEngine::detectGameFilebased(const FileMap &allFiles, 
 				for (filenames = ptr->filenames; *filenames; ++filenames) {
 					FileProperties tmp;
 
-					if (getFileProperties(fslist.begin()->getParent(), allFiles, *agdesc, *filenames, tmp))
+					if (getFileProperties(allFiles, *agdesc, *filenames, tmp))
 						game.matchedFiles[*filenames] = tmp;
 				}
 

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -305,7 +305,7 @@ protected:
 	 * @param fileBasedFallback	a list of ADFileBasedFallback records, zero-terminated
 	 * @param filesProps	if not 0, return a map of properties for all detected files here
 	 */
-	ADDetectedGame detectGameFilebased(const FileMap &allFiles, const Common::FSList &fslist, const ADFileBasedFallback *fileBasedFallback) const;
+	ADDetectedGame detectGameFilebased(const FileMap &allFiles, const ADFileBasedFallback *fileBasedFallback) const;
 
 	/**
 	 * Compose a hashmap of all files in fslist.
@@ -314,10 +314,12 @@ protected:
 	void composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::String &parentName = Common::String()) const;
 
 	/** Get the properties (size and MD5) of this file. */
-	bool getFileProperties(const Common::FSNode &parent, const FileMap &allFiles, const ADGameDescription &game, const Common::String fname, FileProperties &fileProps) const;
+	bool getFileProperties(const FileMap &allFiles, const ADGameDescription &game, const Common::String fname, FileProperties &fileProps) const;
 
 	/** Convert an AD game description into the shared game description format */
 	virtual DetectedGame toDetectedGame(const ADDetectedGame &adGame) const;
+
+	friend class FileMapArchive; // for FileMap
 };
 
 #endif

--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -164,7 +164,7 @@ static const ADFileBasedFallback fileBasedFallback[] = {
 };
 
 ADDetectedGame CGEMetaEngine::fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const {
-	ADDetectedGame game = detectGameFilebased(allFiles, fslist, CGE::fileBasedFallback);
+	ADDetectedGame game = detectGameFilebased(allFiles, CGE::fileBasedFallback);
 
 	if (!game.desc)
 		return ADDetectedGame();

--- a/engines/cge2/detection.cpp
+++ b/engines/cge2/detection.cpp
@@ -162,7 +162,7 @@ static const ADFileBasedFallback fileBasedFallback[] = {
 // This fallback detection looks identical to the one used for CGE. In fact, the difference resides
 // in the ResourceManager which handles a different archive format. The rest of the detection is identical.
 ADDetectedGame CGE2MetaEngine::fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const {
-	ADDetectedGame game = detectGameFilebased(allFiles, fslist, CGE2::fileBasedFallback);
+	ADDetectedGame game = detectGameFilebased(allFiles, CGE2::fileBasedFallback);
 
 	if (!game.desc)
 		return ADDetectedGame();

--- a/engines/cryomni3d/detection.cpp
+++ b/engines/cryomni3d/detection.cpp
@@ -91,7 +91,7 @@ public:
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles,
 								  const Common::FSList &fslist) const override {
-		return detectGameFilebased(allFiles, fslist, fileBased);
+		return detectGameFilebased(allFiles, fileBased);
 	}
 
 	const char *getEngineId() const override {

--- a/engines/gob/detection/detection.cpp
+++ b/engines/gob/detection/detection.cpp
@@ -60,7 +60,7 @@ GobMetaEngine::GobMetaEngine() :
 }
 
 ADDetectedGame GobMetaEngine::fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const {
-	ADDetectedGame detectedGame = detectGameFilebased(allFiles, fslist, Gob::fileBased);
+	ADDetectedGame detectedGame = detectGameFilebased(allFiles, Gob::fileBased);
 	if (!detectedGame.desc) {
 		return ADDetectedGame();
 	}

--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -179,7 +179,7 @@ public:
 	}
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const override {
-		return detectGameFilebased(allFiles, fslist, Mohawk::fileBased);
+		return detectGameFilebased(allFiles, Mohawk::fileBased);
 	}
 
 	const char *getEngineId() const override {

--- a/engines/sludge/detection.cpp
+++ b/engines/sludge/detection.cpp
@@ -159,7 +159,7 @@ ADDetectedGame SludgeMetaEngine::fallbackDetect(const FileMap &allFiles, const C
 		game.desc = &s_fallbackDesc.desc;
 
 		FileProperties tmp;
-		if (getFileProperties(file->getParent(), allFiles, s_fallbackDesc.desc, fileName, tmp)) {
+		if (getFileProperties(allFiles, s_fallbackDesc.desc, fileName, tmp)) {
 			game.hasUnknownFiles = true;
 			game.matchedFiles[fileName] = tmp;
 		}

--- a/engines/toon/detection.cpp
+++ b/engines/toon/detection.cpp
@@ -142,7 +142,7 @@ public:
 	}
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const override {
-		return detectGameFilebased(allFiles, fslist, Toon::fileBasedFallback);
+		return detectGameFilebased(allFiles, Toon::fileBasedFallback);
 	}
 
 	const char *getEngineId() const override {

--- a/engines/touche/detection.cpp
+++ b/engines/touche/detection.cpp
@@ -133,7 +133,7 @@ public:
 	}
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const override {
-		return detectGameFilebased(allFiles, fslist, Touche::fileBasedFallback);
+		return detectGameFilebased(allFiles, Touche::fileBasedFallback);
 	}
 
 	const char *getEngineId() const override {

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -148,7 +148,7 @@ public:
 			if (!file->getName().hasSuffixIgnoreCase(".dcp")) continue;
 
 			FileProperties tmp;
-			if (getFileProperties(file->getParent(), allFiles, s_fallbackDesc, file->getName(), tmp)) {
+			if (getFileProperties(allFiles, s_fallbackDesc, file->getName(), tmp)) {
 				game.hasUnknownFiles = true;
 				game.matchedFiles[file->getName()] = tmp;
 			}


### PR DESCRIPTION
Common::MacResMan is now able to open files from a specified
Common::Archive. This is a bit hacky as dynamic_cast is used to break
the Archive encapsulation to retreive the underlying FSNode. It should
however be more correct than the previous code that assumed files were
at the root of the currently running game's path.

AdvancedDetector constructs a Common::Archive from its FileMap based
filesystem cache and uses it to detect the mac resource fork files
instead of repeatedly querying the filesystem for file presence.

This cuts the time it takes to run the detection code with all the
engines enabled as dynamic plugins on the 3DS to 30 s from 280 s.

This seems to work properly as I've been able to play Pegasus Prime
on Linux and to detect the Director version of The Journeyman Project
on macOS. However I'd be glad if someone familiar could check it.
