### PR TITLE
(Do not merge yet) KEYMAPPER: Fix virtual mouse bound in small rectangle in VKBD

### DIFF
--- a/backends/keymapper/virtual-mouse.cpp
+++ b/backends/keymapper/virtual-mouse.cpp
@@ -65,7 +65,7 @@ bool VirtualMouse::pollEvent(Event &event) {
 
 	// Adjust the speed of the cursor according to the virtual screen resolution
 	Common::Rect screenSize;
-	if (g_gui.isActive()) {
+	if (g_system->isOverlayVisible()) {
 		screenSize = Common::Rect(g_system->getOverlayWidth(), g_system->getOverlayHeight());
 	} else {
 		screenSize = Common::Rect(g_system->getWidth(), g_system->getHeight());


### PR DESCRIPTION
Without this PR, the virtual mouse, controlled via game controller analog stick, is stuck in a 320x200 top left rectangle when VKBD is displayed with graphics mode 2x in low res games like Dreamweb in-game. Note gfx mode 2x or higher has long been the default on almost all platforms that have at least 640x400 capability.

This bug is a consequence of g_gui.isActive() returning false when vkbd is being displayed (why is this?!?!). Due to this, the game resolution is used erroneously instead of the overlay resolution for clipping the virtual mouse.

This should be included for 2.2.0 Switch and Vita releases, otherwise VKBD is unusable in 320x200 games in docked Switch modes and VitaTV modes due to not being able to move the mouse pointer over the whole keyboard.


