### PR TITLE
SCI: PQ4 - Partial fix for #11660 (keep speech and subtitles setting)

### DIFF
--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -10774,6 +10774,46 @@ static const uint16 pq4CdSpeechAndSubtitlesPatch[] = {
 	PATCH_END
 };
 
+// Applies to: PC CD, Mac CD
+// Responsible methods: signTalker:init, signTalker:dispose,
+//                      computerTalker:init, computerTalker:dispose
+// Fixes bug: #11660
+static const uint16 pq4CdSpeechAndSubtitlesTalkerSignature1[] = {
+	0x89, 0x5a,                     // lsg 5a
+	0x35, 0x02,                     // ldi 02
+	0x12,                           // and
+	SIG_MAGICDWORD,
+	0x31, 0x04,                     // bnt 04
+	0x35, 0x03,                     // ldi 03
+	0xa1, 0x5a,                     // sag 5a
+	SIG_END
+};
+
+static const uint16 pq4CdSpeechAndSubtitlesTalkerPatch1[] = {
+	0x80, PATCH_UINT16(0x005a),     // lag 005a
+	0xa0, PATCH_UINT16(0x00c0),     // sag 00c0 [ save message mode ]
+	0x39, 0x01,                     // pushi 01
+	0x14,                           // or [ enable text ]
+	PATCH_END
+};
+
+static const uint16 pq4CdSpeechAndSubtitlesTalkerSignature2[] = {
+	0x89, 0x5a,                     // lsg 5a
+	0x35, 0x02,                     // ldi 02
+	0x12,                           // and
+	SIG_MAGICDWORD,
+	0x31, 0x04,                     // bnt 04
+	0x35, 0x02,                     // ldi 02
+	0xa1, 0x5a,                     // sag 5a
+	SIG_END
+};
+
+static const uint16 pq4CdSpeechAndSubtitlesTalkerPatch2[] = {
+	0x81, 0xc0,                     // lag c0
+	0x33, 0x05,                     // jmp 05 [ restore message mode ]
+	PATCH_END
+};
+
 // When showing the red shoe to Barbie, after showing the police badge but
 // before exhausting the normal dialogue tree, the game plays the expected
 // dialogue but fails to award points or set an internal flag indicating this
@@ -10915,6 +10955,10 @@ static const uint16 pq4LastActionHeroTimerPatch[] = {
 static const SciScriptPatcherEntry pq4Signatures[] = {
 	{  true,     6, "disable video benchmarking",                      1, sci2BenchmarkSignature,                             sci2BenchmarkPatch },
 	{  true,     9, "add speech+subtitles to in-game UI",              1, pq4CdSpeechAndSubtitlesSignature,                   pq4CdSpeechAndSubtitlesPatch },
+	{  true,    42, "speech+subtitles talker compatibility (1/2)",     1, pq4CdSpeechAndSubtitlesTalkerSignature1,            pq4CdSpeechAndSubtitlesTalkerPatch1 },
+	{  true,    42, "speech+subtitles talker compatibility (2/2)",     1, pq4CdSpeechAndSubtitlesTalkerSignature2,            pq4CdSpeechAndSubtitlesTalkerPatch2 },
+	{  true,    43, "speech+subtitles talker compatibility (1/2)",     1, pq4CdSpeechAndSubtitlesTalkerSignature1,            pq4CdSpeechAndSubtitlesTalkerPatch1 },
+	{  true,    43, "speech+subtitles talker compatibility (2/2)",     1, pq4CdSpeechAndSubtitlesTalkerSignature2,            pq4CdSpeechAndSubtitlesTalkerPatch2 },
 	{  true,   315, "fix missing points showing barbie the red shoe",  1, pq4BittyKittyShowBarieRedShoeSignature,             pq4BittyKittyShowBarbieRedShoePatch },
 	{  true,   390, "change floppy city hall use gun timer",           1, pq4FloppyCityHallDrawGunTimerSignature,             pq4FloppyCityHallDrawGunTimerPatch },
 	{  true,   390, "change floppy city hall say 'drop weapon' timer", 1, pq4FloppyCityHallTellEnemyDropWeaponTimerSignature, pq4FloppyCityHallTellEnemyDropWeaponTimerPatch },

--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -10793,7 +10793,7 @@ static const uint16 pq4CdSpeechAndSubtitlesTalkerPatch1[] = {
 	0x80, PATCH_UINT16(0x005a),     // lag 005a
 	0xa0, PATCH_UINT16(0x00c0),     // sag 00c0 [ save message mode ]
 	0x39, 0x01,                     // pushi 01
-	0x14,                           // or [ enable text ]
+	0x14,                           // or [ enable text ] - always display text, regardless of the mode
 	PATCH_END
 };
 


### PR DESCRIPTION
Issue #11660 is caused by signTalker overriding global90,
which keeps speech and subtitles settings.
That's fixed in this patch.

Similar problem can also be caused by computerTalker.
Waiting to see it happening, before fixing.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
