### PR TITLE
BACKENDS: Add a function to return if the overlay is visible

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -91,6 +91,7 @@ public:
 
 	virtual void showOverlay() = 0;
 	virtual void hideOverlay() = 0;
+	virtual bool isOverlayVisible() const = 0;
 	virtual Graphics::PixelFormat getOverlayFormat() const = 0;
 	virtual void clearOverlay() = 0;
 	virtual void grabOverlay(void *buf, int pitch) const = 0;

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -72,8 +72,9 @@ public:
 	void setFocusRectangle(const Common::Rect& rect) override {}
 	void clearFocusRectangle() override {}
 
-	void showOverlay() override {}
-	void hideOverlay() override {}
+	void showOverlay() override { _overlayVisible = true; }
+	void hideOverlay() override { _overlayVisible = false; }
+	bool isOverlayVisible() const override { return _overlayVisible; }
 	Graphics::PixelFormat getOverlayFormat() const override { return Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0); }
 	void clearOverlay() override {}
 	void grabOverlay(void *buf, int pitch) const override {}
@@ -89,6 +90,7 @@ public:
 private:
 	uint _width, _height;
 	Graphics::PixelFormat _format;
+	bool _overlayVisible;
 };
 
 #endif

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -77,6 +77,8 @@ public:
 		_forceRedraw = true;
 	}
 
+	virtual bool isOverlayVisible() const override { return _overlayVisible; }
+
 	virtual void setShakePos(int shakeXOffset, int shakeYOffset) override {
 		if (_gameScreenShakeXOffset != shakeXOffset || _gameScreenShakeYOffset != shakeYOffset) {
 			_gameScreenShakeXOffset = shakeXOffset;

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -202,6 +202,10 @@ void ModularGraphicsBackend::hideOverlay() {
 	_graphicsManager->hideOverlay();
 }
 
+bool ModularGraphicsBackend::isOverlayVisible() const {
+	return _graphicsManager->isOverlayVisible();
+}
+
 Graphics::PixelFormat ModularGraphicsBackend::getOverlayFormat() const {
 	return _graphicsManager->getOverlayFormat();
 }

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -102,6 +102,7 @@ public:
 
 	virtual void showOverlay() override final;
 	virtual void hideOverlay() override final;
+	virtual bool isOverlayVisible() const override final;
 	virtual Graphics::PixelFormat getOverlayFormat() const override final;
 	virtual void clearOverlay() override final;
 	virtual void grabOverlay(void *buf, int pitch) override final;

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -159,6 +159,7 @@ public:
 	void clearFocusRectangle();
 	void showOverlay();
 	void hideOverlay();
+	bool isOverlayVisible() const { return _overlayVisible; }
 	Graphics::PixelFormat getOverlayFormat() const;
 	void clearOverlay();
 	void grabOverlay(void *buf, int pitch);

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -154,6 +154,7 @@ public:
   // Overlay
   int16 getOverlayHeight();
   int16 getOverlayWidth();
+  bool isOverlayVisible() const { return _overlay_visible; }
   void showOverlay();
   void hideOverlay();
   void clearOverlay();

--- a/backends/platform/ds/arm9/source/osystem_ds.cpp
+++ b/backends/platform/ds/arm9/source/osystem_ds.cpp
@@ -486,6 +486,10 @@ void OSystem_DS::hideOverlay() {
 	DS::displayMode8Bit();
 }
 
+bool OSystem_DS::isOverlayVisible() const {
+	return !DS::getIsDisplayMode8Bit();
+}
+
 void OSystem_DS::clearOverlay() {
 	memset((u16 *) DS::get16BitBackBuffer(), 0, 512 * 256 * 2);
 //	consolePrintf("clearovl\n");

--- a/backends/platform/ds/arm9/source/osystem_ds.h
+++ b/backends/platform/ds/arm9/source/osystem_ds.h
@@ -102,6 +102,7 @@ public:
 
 	virtual void showOverlay();
 	virtual void hideOverlay();
+	virtual bool isOverlayVisible() const;
 	virtual void clearOverlay();
 	virtual void grabOverlay(void *buf, int pitch);
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -166,6 +166,7 @@ public:
 
 	virtual void showOverlay();
 	virtual void hideOverlay();
+	virtual bool isOverlayVisible() const { return _videoContext->overlayVisible; }
 	virtual void clearOverlay();
 	virtual void grabOverlay(void *buf, int pitch);
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);

--- a/backends/platform/iphone/osys_main.h
+++ b/backends/platform/iphone/osys_main.h
@@ -154,6 +154,7 @@ public:
 
 	virtual void showOverlay();
 	virtual void hideOverlay();
+	virtual bool isOverlayVisible() const { return _videoContext->overlayVisible; }
 	virtual void clearOverlay();
 	virtual void grabOverlay(void *buf, int pitch);
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -167,6 +167,7 @@ public:
 
 	virtual void showOverlay();
 	virtual void hideOverlay();
+	virtual bool isOverlayVisible() const { return _overlayVisible; }
 	virtual void clearOverlay();
 	virtual void grabOverlay(void *buf, int pitch);
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -246,6 +246,11 @@ void OSystem_PSP::hideOverlay() {
 	_cursor.useGlobalScaler(true);	// mouse needs to be scaled with screen
 }
 
+bool OSystem_PSP::isOverlayVisible() const {
+	DEBUG_ENTER_FUNC();
+	return _overlay.isVisible();
+}
+
 void OSystem_PSP::clearOverlay() {
 	DEBUG_ENTER_FUNC();
 	_displayManager.waitUntilRenderFinished();

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -104,6 +104,7 @@ public:
 	// Overlay related
 	void showOverlay();
 	void hideOverlay();
+	bool isOverlayVisible() const;
 	void clearOverlay();
 	void grabOverlay(void *buf, int pitch);
 	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -176,6 +176,7 @@ public:
 
 	virtual void showOverlay();
 	virtual void hideOverlay();
+	virtual bool isOverlayVisible() const { return _overlayVisible; }
 	virtual void clearOverlay();
 	virtual void grabOverlay(void *buf, int pitch);
 	virtual void copyRectToOverlay(const void *buf, int pitch,

--- a/common/system.h
+++ b/common/system.h
@@ -999,6 +999,9 @@ public:
 	/** Deactivate the overlay mode. */
 	virtual void hideOverlay() = 0;
 
+	/** Returns true if the overlay mode is activated, false otherwise. */
+	virtual bool isOverlayVisible() const = 0;
+
 	/**
 	 * Returns the pixel format description of the overlay.
 	 * @see Graphics::PixelFormat


### PR DESCRIPTION
Only the SDL and OpenGL graphics managers have been tested so far.