### PR TITLE
GUI: Use RGB cursors on supported platforms

### DIFF
--- a/graphics/conversion.cpp
+++ b/graphics/conversion.cpp
@@ -29,6 +29,25 @@ namespace Graphics {
 
 // TODO: YUV to RGB conversion function
 
+// Function to blit a rect
+void copyBlit(byte *dst, const byte *src,
+               const uint dstPitch, const uint srcPitch,
+               const uint w, const uint h,
+               const uint bytesPerPixel) {
+	if (dst == src)
+		return;
+
+	if (dstPitch == srcPitch && ((w * bytesPerPixel) == dstPitch)) {
+		memcpy(dst, src, dstPitch * h);
+	} else {
+		for (uint i = 0; i < h; ++i) {
+			memcpy(dst, src, w * bytesPerPixel);
+			dst += dstPitch;
+			src += srcPitch;
+		}
+	}
+}
+
 namespace {
 
 template<typename SrcColor, typename DstColor, bool backward>
@@ -111,18 +130,7 @@ bool crossBlit(byte *dst, const byte *src,
 
 	// Don't perform unnecessary conversion
 	if (srcFmt == dstFmt) {
-		if (dst != src) {
-			if (dstPitch == srcPitch && ((w * dstFmt.bytesPerPixel) == dstPitch)) {
-				memcpy(dst, src, dstPitch * h);
-			} else {
-				for (uint i = 0; i < h; ++i) {
-					memcpy(dst, src, w * dstFmt.bytesPerPixel);
-					dst += dstPitch;
-					src += srcPitch;
-				}
-			}
-		}
-
+		copyBlit(dst, src, dstPitch, srcPitch, w, h, dstFmt.bytesPerPixel);
 		return true;
 	}
 

--- a/graphics/conversion.h
+++ b/graphics/conversion.h
@@ -46,6 +46,22 @@ inline static void RGB2YUV(byte r, byte g, byte b, byte &y, byte &u, byte &v) {
 // TODO: generic YUV to RGB blit
 
 /**
+ * Blits a rectangle.
+ *
+ * @param dst			the buffer which will recieve the converted graphics data
+ * @param src			the buffer containing the original graphics data
+ * @param dstPitch		width in bytes of one full line of the dest buffer
+ * @param srcPitch		width in bytes of one full line of the source buffer
+ * @param w				the width of the graphics data
+ * @param h				the height of the graphics data
+ * @param bytesPerPixel	the number of bytes per pixel
+ */
+void copyBlit(byte *dst, const byte *src,
+               const uint dstPitch, const uint srcPitch,
+               const uint w, const uint h,
+               const uint bytesPerPixel);
+
+/**
  * Blits a rectangle from one graphical format to another.
  *
  * @param dst		the buffer which will recieve the converted graphics data

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -28,6 +28,7 @@
 #include "common/tokenizer.h"
 #include "common/translation.h"
 
+#include "graphics/conversion.h"
 #include "graphics/cursorman.h"
 #include "graphics/fontman.h"
 #include "graphics/surface.h"
@@ -224,7 +225,11 @@ ThemeEngine::ThemeEngine(Common::String id, GraphicsMode mode) :
 
 	_cursorHotspotX = _cursorHotspotY = 0;
 	_cursorWidth = _cursorHeight = 0;
+#ifndef USE_RGB_COLOR
+	_cursorFormat = Graphics::PixelFormat::createFormatCLUT8();
+	_cursorTransparent = 255;
 	_cursorPalSize = 0;
+#endif
 
 	// We prefer files in archive bundles over the common search paths.
 	_themeFiles.add("default", &SearchMan, 0, false);
@@ -398,8 +403,10 @@ void ThemeEngine::refresh() {
 		_system->showOverlay();
 
 		if (_useCursor) {
+#ifndef USE_RGB_COLOR
 			CursorMan.replaceCursorPalette(_cursorPal, 0, _cursorPalSize);
-			CursorMan.replaceCursor(_cursor, _cursorWidth, _cursorHeight, _cursorHotspotX, _cursorHotspotY, 255, true);
+#endif
+			CursorMan.replaceCursor(_cursor, _cursorWidth, _cursorHeight, _cursorHotspotX, _cursorHotspotY, _cursorTransparent, true, &_cursorFormat);
 		}
 	}
 }
@@ -1481,19 +1488,10 @@ void ThemeEngine::applyScreenShading(ShadingStyle style) {
 }
 
 bool ThemeEngine::createCursor(const Common::String &filename, int hotspotX, int hotspotY) {
-	if (!_system->hasFeature(OSystem::kFeatureCursorPalette))
-		return true;
-
 	// Try to locate the specified file among all loaded bitmaps
 	const Graphics::Surface *cursor = _bitmaps[filename];
 	if (!cursor)
 		return false;
-
-#ifdef USE_RGB_COLOR
-	_cursorFormat.bytesPerPixel = 1;
-	_cursorFormat.rLoss = _cursorFormat.gLoss = _cursorFormat.bLoss = _cursorFormat.aLoss = 8;
-	_cursorFormat.rShift = _cursorFormat.gShift = _cursorFormat.bShift = _cursorFormat.aShift = 0;
-#endif
 
 	// Set up the cursor parameters
 	_cursorHotspotX = hotspotX;
@@ -1501,6 +1499,23 @@ bool ThemeEngine::createCursor(const Common::String &filename, int hotspotX, int
 
 	_cursorWidth = cursor->w;
 	_cursorHeight = cursor->h;
+
+#ifdef USE_RGB_COLOR
+	_cursorFormat = cursor->format;
+	_cursorTransparent = _cursorFormat.RGBToColor(0xFF, 0, 0xFF);
+
+	// Allocate a new buffer for the cursor
+	delete[] _cursor;
+	_cursor = new byte[_cursorWidth * _cursorHeight * _cursorFormat.bytesPerPixel];
+	assert(_cursor);
+	Graphics::copyBlit(_cursor, (const byte *)cursor->getPixels(),
+	                   _cursorWidth * _cursorFormat.bytesPerPixel, cursor->pitch,
+	                   _cursorWidth, _cursorHeight, _cursorFormat.bytesPerPixel);
+
+	_useCursor = true;
+#else
+	if (!_system->hasFeature(OSystem::kFeatureCursorPalette))
+		return true;
 
 	// Allocate a new buffer for the cursor
 	delete[] _cursor;
@@ -1559,6 +1574,7 @@ bool ThemeEngine::createCursor(const Common::String &filename, int hotspotX, int
 
 	_useCursor = true;
 	_cursorPalSize = colorsFound;
+#endif
 
 	return true;
 }
@@ -2008,15 +2024,19 @@ Common::String ThemeEngine::getThemeId(const Common::String &filename) {
 
 void ThemeEngine::showCursor() {
 	if (_useCursor) {
+#ifndef USE_RGB_COLOR
 		CursorMan.pushCursorPalette(_cursorPal, 0, _cursorPalSize);
-		CursorMan.pushCursor(_cursor, _cursorWidth, _cursorHeight, _cursorHotspotX, _cursorHotspotY, 255, true);
+#endif
+		CursorMan.pushCursor(_cursor, _cursorWidth, _cursorHeight, _cursorHotspotX, _cursorHotspotY, _cursorTransparent, true, &_cursorFormat);
 		CursorMan.showMouse(true);
 	}
 }
 
 void ThemeEngine::hideCursor() {
 	if (_useCursor) {
+#ifndef USE_RGB_COLOR
 		CursorMan.popCursorPalette();
+#endif
 		CursorMan.popCursor();
 	}
 }

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -743,9 +743,7 @@ protected:
 	ImagesMap _bitmaps;
 	AImagesMap _abitmaps;
 	Graphics::PixelFormat _overlayFormat;
-#ifdef USE_RGB_COLOR
 	Graphics::PixelFormat _cursorFormat;
-#endif
 
 	/** List of all the dirty screens that must be blitted to the overlay. */
 	Common::List<Common::Rect> _dirtyScreen;
@@ -762,13 +760,16 @@ protected:
 
 	bool _useCursor;
 	int _cursorHotspotX, _cursorHotspotY;
+	uint32 _cursorTransparent;
+	byte *_cursor;
+	uint _cursorWidth, _cursorHeight;
+#ifndef USE_RGB_COLOR
 	enum {
 		MAX_CURS_COLORS = 255
 	};
-	byte *_cursor;
-	uint _cursorWidth, _cursorHeight;
 	byte _cursorPal[3 * MAX_CURS_COLORS];
 	byte _cursorPalSize;
+#endif
 
 	Common::Rect _clip;
 };


### PR DESCRIPTION
From what I understand, all backends with 16-bit colour support should support RGB cursors using the same format as the overlay, meaning that custom cursors in the GUI can be used directly on those platforms without converting them to CLUT8 first. The old code path has been kept for the DS and N64 backends.