### PR TITLE
COMMON: Add Sega Megadrive/Genesis platform

### DIFF
--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -56,6 +56,7 @@ const PlatformDescription g_platforms[] = {
 	{ "os2", "os2", "os2", "OS/2", kPlatformOS2 },
 	{ "beos", "beos", "beos", "BeOS", kPlatformBeOS },
 	{ "ppc", "ppc", "ppc", "PocketPC", kPlatformPocketPC },
+	{ "megadrive", "genesis", "md", "Mega Drive/Genesis", kPlatformMegaDrive },
 
 	{ nullptr, nullptr, nullptr, "Default", kPlatformUnknown }
 };

--- a/common/platform.h
+++ b/common/platform.h
@@ -61,6 +61,7 @@ enum Platform {
 	kPlatformOS2,
 	kPlatformBeOS,
 	kPlatformPocketPC,
+	kPlatformMegaDrive,
 
 	kPlatformUnknown = -1
 };


### PR DESCRIPTION
This PR adds the Sega Mega Drive/Genesis as a platform.

I'm working on support for Scooby Doo Mystery on the Genesis.