### PR TITLE
BUILD: Add option not to bundle all resources in the executable

### DIFF
--- a/configure
+++ b/configure
@@ -210,6 +210,7 @@ _nasm=auto
 _optimization_level=
 _default_optimization_level=-O2
 _nuked_opl=yes
+_builtin_resources=yes
 # Default commands
 _ranlib=ranlib
 _strip=strip
@@ -1064,6 +1065,8 @@ Optional Features:
                                             gles2 for forcing OpenGL ES 2
                            WARNING: only specify this manually if you know what
                            you are doing!
+  --no-builtin-resources   do not include additional resources (e.g. engine data, fonts)
+                           into the ScummVM binary
 
 Optional Libraries:
   --with-alsa-prefix=DIR   prefix where alsa is installed (optional)
@@ -1483,6 +1486,9 @@ for ac_option in $@; do
 		;;
 	--enable-tsan)
 		_enable_tsan=yes
+		;;
+	--no-builtin-resources)
+		_builtin_resources=no
 		;;
 	--with-sdl-prefix=*)
 		arg=`echo $ac_option | cut -d '=' -f 2`
@@ -5644,6 +5650,11 @@ else
 	echo "$_updates"
 fi
 define_in_config_if_yes $_updates 'USE_UPDATES'
+
+#
+# Check whether to create a build with all resources files linked into the binary
+#
+define_in_config_if_yes "$_builtin_resources" 'BUILTIN_RESOURCES'
 
 #
 # Figure out installation directories

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1036,27 +1036,28 @@ const Feature s_features[] = {
 	{   "discord",     "USE_DISCORD", true, false, "Discord support" },
 
 	// Feature flags
-	{            "bink",                      "USE_BINK", false, true,  "Bink video support" },
-	{         "scalers",                   "USE_SCALERS", false, true,  "Scalers" },
-	{       "hqscalers",                "USE_HQ_SCALERS", false, true,  "HQ scalers" },
-	{           "16bit",                 "USE_RGB_COLOR", false, true,  "16bit color support" },
-	{         "highres",                   "USE_HIGHRES", false, true,  "high resolution" },
-	{         "mt32emu",                   "USE_MT32EMU", false, true,  "integrated MT-32 emulator" },
-	{             "lua",                       "USE_LUA", false, true,  "lua" },
-	{            "nasm",                      "USE_NASM", false, true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
-	{          "opengl",                    "USE_OPENGL", false, true,  "OpenGL support" },
-	{        "opengles",                      "USE_GLES", false, true,  "forced OpenGL ES mode" },
-	{         "taskbar",                   "USE_TASKBAR", false, true,  "Taskbar integration support" },
-	{           "cloud",                     "USE_CLOUD", false, true,  "Cloud integration support" },
-	{     "translation",               "USE_TRANSLATION", false, true,  "Translation support" },
-	{          "vkeybd",                 "ENABLE_VKEYBD", false, false, "Virtual keyboard support"},
-	{   "eventrecorder",          "ENABLE_EVENTRECORDER", false, false, "Event recorder support"},
-	{         "updates",                   "USE_UPDATES", false, false, "Updates support"},
-	{         "dialogs",                "USE_SYSDIALOGS", false, true,  "System dialogs support"},
-	{      "langdetect",                "USE_DETECTLANG", false, true,  "System language detection support" }, // This feature actually depends on "translation", there
+	{             "bink",                      "USE_BINK", false, true,  "Bink video support" },
+	{          "scalers",                   "USE_SCALERS", false, true,  "Scalers" },
+	{        "hqscalers",                "USE_HQ_SCALERS", false, true,  "HQ scalers" },
+	{            "16bit",                 "USE_RGB_COLOR", false, true,  "16bit color support" },
+	{          "highres",                   "USE_HIGHRES", false, true,  "high resolution" },
+	{          "mt32emu",                   "USE_MT32EMU", false, true,  "integrated MT-32 emulator" },
+	{              "lua",                       "USE_LUA", false, true,  "lua" },
+	{             "nasm",                      "USE_NASM", false, true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
+	{           "opengl",                    "USE_OPENGL", false, true,  "OpenGL support" },
+	{         "opengles",                      "USE_GLES", false, true,  "forced OpenGL ES mode" },
+	{          "taskbar",                   "USE_TASKBAR", false, true,  "Taskbar integration support" },
+	{            "cloud",                     "USE_CLOUD", false, true,  "Cloud integration support" },
+	{      "translation",               "USE_TRANSLATION", false, true,  "Translation support" },
+	{           "vkeybd",                 "ENABLE_VKEYBD", false, false, "Virtual keyboard support"},
+	{    "eventrecorder",          "ENABLE_EVENTRECORDER", false, false, "Event recorder support"},
+	{          "updates",                   "USE_UPDATES", false, false, "Updates support"},
+	{          "dialogs",                "USE_SYSDIALOGS", false, true,  "System dialogs support"},
+	{       "langdetect",                "USE_DETECTLANG", false, true,  "System language detection support" }, // This feature actually depends on "translation", there
 	                                                                                                           // is just no current way of properly detecting this...
-	{    "text-console", "USE_TEXT_CONSOLE_FOR_DEBUGGER", false, false, "Text console debugger" }, // This feature is always applied in xcode projects
-	{             "tts",                       "USE_TTS", false, true,  "Text to speech support"}
+	{     "text-console", "USE_TEXT_CONSOLE_FOR_DEBUGGER", false, false, "Text console debugger" }, // This feature is always applied in xcode projects
+	{              "tts",                       "USE_TTS", false, true,  "Text to speech support"},
+	{"builtin-resources",             "BUILTIN_RESOURCES", false, true,  "include resources (e.g. engine data, fonts) into the binary"}
 };
 
 const Tool s_tools[] = {

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -21,6 +21,8 @@ ID_GDF_XML             DATA    "dists/win32/scummvm.gdf.xml"
 scummclassic.zip       FILE    "gui/themes/scummclassic.zip"
 scummmodern.zip        FILE    "gui/themes/scummmodern.zip"
 scummremastered.zip    FILE    "gui/themes/scummremastered.zip"
+
+#ifdef BUILTIN_RESOURCES
 #ifdef USE_TRANSLATION
 translations.dat       FILE    "gui/themes/translations.dat"
 #endif
@@ -94,6 +96,7 @@ xeen.ccs               FILE    "dists/engine-data/xeen.ccs"
 #endif
 #if PLUGIN_ENABLED_STATIC(AGI)
 pred.dic               FILE    "dists/pred.dic"
+#endif
 #endif
 
 VS_VERSION_INFO VERSIONINFO


### PR DESCRIPTION
Currently, the Win32 builds (and possibly other ports as well) bundle all resources (engine-data, fonts, wwwroot...) straight into the main executable. This might have been a good idea back in the days, but now that we easily exceed 20MB for single resource files, this could be pretty limiting in the future.

This patch adds an option to the configure script to create a "slim" build by excluding the resources from being built into the executable. This is currently only used for the Win32 build via scummvm.rc, but it might be helpful for other builds as well.

By default, the resources are built in, so devs have everything in one executable, while the release builds for the end users could be created as what I call slim builds.