### PR TITLE
SDL: Clip the coordinates sent by mouse events

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -192,6 +192,9 @@ bool SdlGraphicsManager::showMouse(bool visible) {
 }
 
 bool SdlGraphicsManager::notifyMousePosition(Common::Point &mouse) {
+	mouse.x = CLIP<int16>(mouse.x, 0, _windowWidth - 1);
+	mouse.y = CLIP<int16>(mouse.y, 0, _windowHeight - 1);
+
 	int showCursor = SDL_DISABLE;
 	bool valid = true;
 	if (_activeArea.drawRect.contains(mouse)) {


### PR DESCRIPTION
When using SDL1, mouse events can range from 0 to `_windowWidth` instead of 0 to `_windowWidth` - 1. This causes mouse input to stop working in full screen on RISC OS when moving the mouse to the lower edge of the screen, as well as causing the mouse to warp back to the centre of the screen when doing so on Windows.