### PR TITLE
AUDIO: Increase number of audio mixer channels to 32

### DIFF
--- a/audio/mixer_intern.h
+++ b/audio/mixer_intern.h
@@ -51,7 +51,7 @@ namespace Audio {
 class MixerImpl : public Mixer {
 private:
 	enum {
-		NUM_CHANNELS = 16
+		NUM_CHANNELS = 32
 	};
 
 	Common::Mutex _mutex;


### PR DESCRIPTION
Purpose of this change is to decrease number of code differences between ResidualVM and ScummVM.

Digital iMuse in Grim engine (GrimE) require more channels in audio mixer available.
