### PR TITLE
COMMON: Added PS2 and XBOX platform definitions.

### DIFF
--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -51,6 +51,8 @@ const PlatformDescription g_platforms[] = {
 	{ "segacd", "segacd", "sega", "SegaCD", kPlatformSegaCD },
 	{ "windows", "win", "win", "Windows", kPlatformWindows },
 	{ "playstation", "psx", "psx", "Sony PlayStation", kPlatformPSX },
+	{ "playstation2", "ps2", "ps2", "Sony PlayStation 2", kPlatformPS2 },
+	{ "xbox", "xbox", "xbox", "Microsoft Xbox", kPlatformXbox },
 	{ "cdi", "cdi", "cdi", "Philips CD-i", kPlatformCDi },
 	{ "ios", "ios", "ios", "Apple iOS", kPlatformIOS },
 	{ "os2", "os2", "os2", "OS/2", kPlatformOS2 },

--- a/common/platform.h
+++ b/common/platform.h
@@ -56,6 +56,8 @@ enum Platform {
 	kPlatformPC98,
 	kPlatformWii,
 	kPlatformPSX,
+	kPlatformPS2,
+	kPlatformXbox,
 	kPlatformCDi,
 	kPlatformIOS,
 	kPlatformOS2,


### PR DESCRIPTION
Purpose of this change is to decrease number of code differences between ResidualVM and ScummVM.

There are PS2 and XBOX game versions of Myst III: Exile.
Change add them to platform definitions which are used by code game detection in Myst engine.
