### PR TITLE
VIDEO: Added getter for getFrameRate() for BINK and SMK video streams.

### DIFF
--- a/video/bink_decoder.cpp
+++ b/video/bink_decoder.cpp
@@ -332,6 +332,11 @@ BinkDecoder::BinkVideoTrack::~BinkVideoTrack() {
 	_surface.free();
 }
 
+Common::Rational BinkDecoder::getFrameRate() {
+	BinkVideoTrack *videoTrack = (BinkVideoTrack *)getTrack(0);
+
+	return videoTrack->getFrameRate();
+}
 void BinkDecoder::BinkVideoTrack::decodePacket(VideoFrame &frame) {
 	assert(frame.bits);
 

--- a/video/bink_decoder.h
+++ b/video/bink_decoder.h
@@ -73,6 +73,8 @@ public:
 	bool loadStream(Common::SeekableReadStream *stream);
 	void close();
 
+	Common::Rational getFrameRate();
+
 protected:
 	void readNextPacket();
 	bool supportsAudioTrackSwitching() const { return true; }
@@ -155,7 +157,6 @@ private:
 		/** Decode a video packet. */
 		void decodePacket(VideoFrame &frame);
 
-	protected:
 		Common::Rational getFrameRate() const { return _frameRate; }
 
 	private:

--- a/video/smk_decoder.cpp
+++ b/video/smk_decoder.cpp
@@ -872,4 +872,10 @@ SmackerDecoder::SmackerVideoTrack *SmackerDecoder::createVideoTrack(uint32 width
 	return new SmackerVideoTrack(width, height, frameCount, frameRate, flags, signature);
 }
 
+Common::Rational SmackerDecoder::getFrameRate() const {
+	const SmackerVideoTrack *videoTrack = (const SmackerVideoTrack *)getTrack(0);
+
+	return videoTrack->getFrameRate();
+}
+
 } // End of namespace Video

--- a/video/smk_decoder.h
+++ b/video/smk_decoder.h
@@ -67,6 +67,8 @@ public:
 
 	bool rewind();
 
+	Common::Rational getFrameRate() const;
+
 protected:
 	void readNextPacket();
 	bool supportsAudioTrackSwitching() const { return true; }
@@ -96,9 +98,9 @@ protected:
 		void decodeFrame(Common::BitStreamMemory8LSB &bs);
 		void unpackPalette(Common::SeekableReadStream *stream);
 
-	protected:
 		Common::Rational getFrameRate() const { return _frameRate; }
 
+	protected:
 		Graphics::Surface *_surface;
 
 	private:


### PR DESCRIPTION
Purpose of this change is to decrease number of code differences between ResidualVM and ScummVM.

Added public method, getter for SMK and BINK video frame rate.
It's used for override frame rate by video player in The Longest Journey engine.