### PR TITLE
VIDEO: Added support for PS2 audio codec in MPEG stream

### DIFF
--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -180,6 +180,36 @@ private:
 	};
 #endif
 
+	class PS2AudioTrack : public AudioTrack, public MPEGStream {
+	public:
+		PS2AudioTrack(Common::SeekableReadStream *firstPacket, Audio::Mixer::SoundType soundType);
+		~PS2AudioTrack();
+
+		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts);
+		StreamType getStreamType() const { return kStreamTypeAudio; }
+
+	protected:
+		Audio::AudioStream *getAudioStream() const;
+
+	private:
+		Audio::PacketizedAudioStream *_audStream;
+
+		enum {
+			PS2_PCM = 0x01,
+			PS2_ADPCM = 0x10
+		};
+
+		uint32 _channels;
+		uint32 _soundType;
+		uint32 _interleave;
+		bool _isFirstPacket;
+
+		byte *_blockBuffer;
+		uint32 _blockPos, _blockUsed;
+
+		uint32 calculateSampleCount(uint32 packetSize) const;
+	};
+
 	// The different types of private streams we can detect at the moment
 	enum PrivateStreamType {
 		kPrivateStreamUnknown,


### PR DESCRIPTION
Purpose of this change is to decrease number of code differences between ResidualVM and ScummVM.

This change introduce support PS2 audio codec in MPEG stream.
It's used by Grim engine for "Escape from Monkey Island" in video player.
