### PR TITLE
COMPOSER: fix regression macintosh darby & gregory

### DIFF
--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -91,6 +91,11 @@ Common::Error ComposerEngine::run() {
 		}
 	}
 
+	Common::String gameId(getGameId());
+	if (getPlatform() == Common::kPlatformMacintosh && (gameId == "darby" || gameId == "gregory")) {
+		_directoriesToStrip = 0;
+	}
+
 	uint width = 640;
 	if (_bookIni.hasKey("Width", "Common"))
 		width = atoi(getStringFromConfig("Common", "Width").c_str());


### PR DESCRIPTION
Fix regression in macintosh version of "Gregory and the Hot Air Balloon" and "Darby the Dragon" caused by commit #1948
