### PR TITLE
BUILD: Add NDEBUG define for release builds

### DIFF
--- a/common/textconsole.h
+++ b/common/textconsole.h
@@ -77,5 +77,16 @@ void warning(const char *s, ...) GCC_PRINTF(1, 2);
 
 #endif
 
+/**
+ * Test the given expression and call error() with the file, line, and expression
+ * if it is false.
+ *
+ * Unlike assert(), scumm_assert() is not disabled when NDEBUG is defined. Also
+ * the message is visible to the user (or at least logged) on all platforms.
+ */
+#define scumm_assert(expr) \
+	if (expr) {} \
+	else \
+		error("Assertion \"%s\" failed: file \"%s\", line %d", #expr, __FILE__, __LINE__)
 
 #endif

--- a/configure
+++ b/configure
@@ -2296,6 +2296,9 @@ echo $_use_cxx11
 #
 # Determine extra build flags for debug and/or release builds
 #
+if test "$_debug_build" = auto && test "$_release_build" = yes; then
+	_debug_build=no
+fi
 if test "$_debug_build" != no; then
 	# debug mode not explicitly disabled -> compile with debug information
 	echo_n "Checking best debug mode... "

--- a/configure
+++ b/configure
@@ -2329,6 +2329,7 @@ if test "$_release_build" = yes; then
 	# Add a define, which indicates we are doing
 	# an build for a release version.
 	append_var DEFINES "-DRELEASE_BUILD"
+	append_var DEFINES "-DNDEBUG"
 fi
 
 # By default, we add -pedantic to the CXXFLAGS to catch some potentially

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -272,7 +272,7 @@ void VisualStudioProvider::createBuildProp(const BuildSetup &setup, bool isRelea
 	if (isRelease) {
 		properties << "\t\tEnableIntrinsicFunctions=\"true\"\n"
 		           << "\t\tWholeProgramOptimization=\"true\"\n"
-		           << "\t\tPreprocessorDefinitions=\"WIN32;RELEASE_BUILD\"\n"
+		           << "\t\tPreprocessorDefinitions=\"WIN32;RELEASE_BUILD;NDEBUG\"\n"
 		           << "\t\tStringPooling=\"true\"\n"
 		           << "\t\tBufferSecurityCheck=\"false\"\n"
 		           << "\t\tDebugInformationFormat=\"0\"\n"

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -985,6 +985,7 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	REMOVE_SETTING(scummvm_Release, "GCC_PREPROCESSOR_DEFINITIONS");
 	ValueList scummvm_Release_defines(scummvm_defines);
 	ADD_DEFINE(scummvm_Release_defines, "RELEASE_BUILD");
+	ADD_DEFINE(scummvm_Release_defines, "NDEBUG");
 	ADD_SETTING_LIST(scummvm_Release, "GCC_PREPROCESSOR_DEFINITIONS", scummvm_Release_defines, kSettingsNoQuote | kSettingsAsList, 5);
 
 	scummvm_Release_Object->addProperty("name", "Release", "", kSettingsNoValue);


### PR DESCRIPTION
Currently we do not define `NDEBUG` in our release builds. However this define is checked in a few places (`common/hashmap.h`, `audio/mods/maxtrax.cpp`, and `engines/sci/graphics/celobj32.cpp`). This define also affects the behaviour of `assert()`, which we use in many more places.

It seems to me that we likely want to define `NDEBUG` in our release builds, but I am creating a pull request for this in case I overlooked something and there is a good reason for not defining it.

Edit: I added another commit to disable debug builds by default when doing a release build. On Discord several porter mentioned using both `--enable-release` and `--disable-debug` for their release build, and it seems to me that disabling debug symbols should be the default when we use `--enable-release`.

This also raise the question: should `NDEBUG` be defined when `_release_build` =  `yes` or when `_debug_build` = `no`? In other word, if we use `configure --enable-release --enable-debug`, do we want `NDEBUG` to be defined or not?