### PR TITLE
Partial c++11 support

### DIFF
--- a/common/array.h
+++ b/common/array.h
@@ -28,6 +28,10 @@
 #include "common/textconsole.h" // For error()
 #include "common/memory.h"
 
+#ifdef USE_CXX11
+#include <initializer_list>
+#endif
+
 namespace Common {
 
 /**
@@ -83,6 +87,26 @@ public:
 			uninitialized_copy(array._storage, array._storage + _size, _storage);
 		}
 	}
+
+#ifdef USE_CXX11
+	/**
+	 * Constructs an array as a copy of the given array using the c++11 move semantic.
+	 */
+	Array(Array<T> &&old) : _capacity(old._capacity), _size(old._size), _storage(old._storage) {
+		old._storage = nullptr;
+		old._capacity = 0;
+		old._size = 0;
+	}
+
+	/**
+	 * Constructs an array using list initialization.
+	 */
+	Array(std::initializer_list<T> list) : _size(list.size()) {
+		allocCapacity(list.size());
+		if (_storage)
+			Common::uninitialized_copy(list.begin(), list.end(), _storage);
+	}
+#endif
 
 	/**
 	 * Construct an array by copying data from a regular array.
@@ -209,6 +233,24 @@ public:
 
 		return *this;
 	}
+
+#ifdef USE_CXX11
+	Array &operator=(Array<T> &&old) {
+		if (this == &old)
+			return *this;
+
+		freeStorage(_storage, _size);
+		_capacity = old._capacity;
+		_size = old._size;
+		_storage = old._storage;
+
+		old._storage = nullptr;
+		old._capacity = 0;
+		old._size = 0;
+
+		return *this;
+	}
+#endif
 
 	size_type size() const {
 		return _size;

--- a/common/array.h
+++ b/common/array.h
@@ -29,7 +29,7 @@
 #include "common/memory.h"
 
 #ifdef USE_CXX11
-#include <initializer_list>
+#include "common/initializer_list.h"
 #endif
 
 namespace Common {

--- a/common/initializer_list.h
+++ b/common/initializer_list.h
@@ -1,0 +1,44 @@
+// Some compiler only have partial support for C++11 and we provide replacements for reatures not available.
+#ifdef USE_CXX11
+
+#ifdef NO_CXX11_INITIALIZER_LIST
+namespace std {
+	template<class T> class initializer_list {
+	public:
+		typedef T value_type;
+		typedef const T& reference;
+		typedef const T& const_reference;
+		typedef size_t size_type;
+		typedef const T* iterator;
+		typedef const T* const_iterator;
+
+		constexpr initializer_list() noexcept = default;
+		constexpr size_t size() const noexcept { return m_size; };
+		constexpr const T* begin() const noexcept { return m_begin; };
+		constexpr const T* end() const noexcept { return m_begin + m_size; }
+
+	private:
+		// Note: begin has to be first or the compiler gets very upset
+		const T* m_begin = { nullptr };
+		size_t m_size = { 0 };
+
+		// The compiler is allowed to call this constructor
+		constexpr initializer_list(const T* t, size_t s) noexcept : m_begin(t) , m_size(s) {}
+	};
+
+	template<class T> constexpr const T* begin(initializer_list<T> il) noexcept {
+		return il.begin();
+	}
+
+	template<class T> constexpr const T* end(initializer_list<T> il) noexcept {
+		return il.end();
+	}
+}
+
+#else
+
+#include <initializer_list>
+
+#endif // NO_CXX11_INITIALIZER_LIST
+
+#endif // USE_CXX11

--- a/configure
+++ b/configure
@@ -2299,6 +2299,7 @@ if test "$_use_cxx11" = "yes" ; then
 	append_var CXXFLAGS "-std=c++11"
 fi
 echo $_use_cxx11
+define_in_config_if_yes "$_use_cxx11" 'USE_CXX11'
 
 #
 # Determine extra build flags for debug and/or release builds

--- a/configure
+++ b/configure
@@ -267,6 +267,7 @@ add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
 add_feature lua "lua" "_lua"
 add_feature fribidi "FriBidi" "_fribidi"
+add_feature cxx11 "c++11" "_use_cxx11"
 add_feature test_cxx11 "Test C++11" "_test_cxx11"
 
 # Directories for installing ScummVM.

--- a/configure
+++ b/configure
@@ -2302,6 +2302,30 @@ echo $_use_cxx11
 define_in_config_if_yes "$_use_cxx11" 'USE_CXX11'
 
 #
+# Additional tests for C++11 features that may not be present
+#
+if test "$_use_cxx11" = "yes" ; then
+	# Check if initializer list is available
+	echo_n "Checking if C++11 initializer list is available... "
+	cat > $TMPC << EOF
+#include <initializer_list>
+class FOO {
+public:
+	FOO(std::initializer_list<int> list) : _size(list.size()) {}
+	size_t _size;
+};
+int main(int argc, char *argv[]) { return 0; }
+EOF
+	cc_check
+	if test "$TMPR" -eq 0; then
+		echo yes
+	else
+		echo no
+		define_in_config_if_yes yes 'NO_CXX11_INITIALIZER_LIST'
+	fi
+fi
+
+#
 # Determine extra build flags for debug and/or release builds
 #
 if test "$_debug_build" = auto && test "$_release_build" = yes; then

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1066,6 +1066,7 @@ const Feature s_features[] = {
 	{              "tts",                       "USE_TTS", false, true,  "Text to speech support"},
 	{"builtin-resources",             "BUILTIN_RESOURCES", false, true,  "include resources (e.g. engine data, fonts) into the binary"},
 	{"detection-static", "USE_DETECTION_FEATURES_STATIC",  "", true,  "Static linking of detection objects for engines."}
+	{            "cxx11",                     "USE_CXX11", false, true,  "Compile with c++11 support"}
 };
 
 const Tool s_tools[] = {

--- a/engines/petka/configure.engine
+++ b/engines/petka/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine petka "Red Comrades" no "" "" "highres 16bit freetype2"
+add_engine petka "Red Comrades" no "" "" "highres 16bit freetype2 cxx11"

--- a/test/common/array.h
+++ b/test/common/array.h
@@ -322,6 +322,16 @@ class ArrayTestSuite : public CxxTest::TestSuite
 		Common::Array<Common::NonCopyable> nonCopyable(1);
 	}
 
+	void test_array_constructor_list() {
+#ifdef USE_CXX11
+		Common::Array<int> array = {1, 42, 255};
+		TS_ASSERT_EQUALS(array.size(), 3U);
+		TS_ASSERT_EQUALS(array[0], 1);
+		TS_ASSERT_EQUALS(array[1], 42);
+		TS_ASSERT_EQUALS(array[2], 255);
+#endif
+	}
+
 	void test_array_constructor_count_copy_value() {
 		Common::Array<int> trivial(5, 1);
 		TS_ASSERT_EQUALS(trivial.size(), 5U);


### PR DESCRIPTION
What I am proposing in with this pull request is to:
- Allow any engine to use c++11
- Allow any backend to use c++11
- Restrict c++11 in common code to features that can be disabled

The idea is that I would like to avoid breaking compilation for ports that do not yet support c++11, while allowing more c++11 use in the project.

The way I went about this is:
1. Add a cxx11 feature that can be used as a dependency by engines that use c++11. This will automatically disable those engines when c++11 is not enabled. This is added for the petka engine, and should fix the compilation on buildbot for the canoo, dingux, gp2xwiz, openpandora, and osx_intel builders.
2. Add a USE_CXX11 define when C++11 is enabled. This can be used in common code to add code such as constructors with the move semantics or intializer list. I added those to the Array class as an example.
3. Add check in configure, and replacement in common for `std::initializer_list` when not supported by the standard library (as is the case when compiling for Mac OS X 10.6 on a more recent system (where the compiler supports c++11, but the libstdc++ used when targeting those system does not - Apple switched to libc++ in Mac OS X 10.9, and only that one fully support c++11).

Feedback on both the proposal and the actual commits in this PR are welcome.
Would you for example prefer is we stopped supporting non-c++11 builds and just always enabled c++11 everywhere in the project? And do you see an issue with the commits in this PR?
