### PR TITLE
VIDEO: add support for BLACK chunk in FLIC decoder

### DIFF
--- a/video/flic_decoder.cpp
+++ b/video/flic_decoder.cpp
@@ -158,6 +158,7 @@ Graphics::PixelFormat FlicDecoder::FlicVideoTrack::getPixelFormat() const {
 
 #define FLI_SETPAL            4
 #define FLI_SS2               7
+#define FLI_BLACK             13
 #define FLI_BRUN              15
 #define FLI_COPY              16
 #define PSTAMP                18
@@ -233,6 +234,11 @@ void FlicDecoder::FlicVideoTrack::handleFrame() {
 			break;
 		case FLI_SS2:
 			decodeDeltaFLC(data);
+			break;
+		case FLI_BLACK:
+			_surface->fillRect(Common::Rect(0, 0, getWidth(), getHeight()), 0);
+			_dirtyRects.clear();
+			_dirtyRects.push_back(Common::Rect(0, 0, getWidth(), getHeight()));
 			break;
 		case FLI_BRUN:
 			decodeByteRun(data);


### PR DESCRIPTION
This pull request adds support for BLACK chunk in FLIC decoder.

[> All pixels in the frame have colour 0. This chunk has no data following the chunk header.](https://www.compuphase.com/flic.htm#BLACK)

Red comrades flics use this chunk.