### PR TITLE
SDL: Prefer OpenGL over Metal rendering on macOS

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -2635,6 +2635,14 @@ SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, 
 		return nullptr;
 	}
 
+#if defined(MACOSX) && SDL_VERSION_ATLEAST(2, 0, 10)
+	// WORKAROUND: Bug #11430: "macOS: blurry content on Retina displays"
+	// Since SDL 2.0.10, Metal takes priority over OpenGL rendering on macOS,
+	// but this causes blurriness issues on Retina displays. Just switch
+	// back to OpenGL for now.
+	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+#endif
+
 	_renderer = SDL_CreateRenderer(_window->getSDLWindow(), -1, 0);
 	if (!_renderer) {
 		deinitializeRenderer();


### PR DESCRIPTION
SDL 2.0.10 and above favors Metal over OpenGL rendering on macOS, but
this currently causes blurriness issues on Retina displays.

Going back to OpenGL rendering works around this bug for now.

Users can override this with the SDL_RENDER_DRIVER environment variable.

c59bf95ba85b25b1 and 70f79d3df8b4a9d4 are still a requirement to
work around this bug, too.

Bug #11430.

(This should probably backported to any 2.2.1 release)