### PR TITLE
SDL: Ensure that SDL is initialized before creating the window object

### DIFF
--- a/backends/platform/maemo/maemo.cpp
+++ b/backends/platform/maemo/maemo.cpp
@@ -52,6 +52,7 @@ void OSystem_SDL_Maemo::init() {
 	// Use an iconless window for Maemo
 	// also N900 is hit by SDL_WM_SetIcon bug (window cannot receive input)
 	// http://bugzilla.libsdl.org/show_bug.cgi?id=586
+	initSDL();
 	_window = new SdlIconlessWindow();
 
 	OSystem_POSIX::init();

--- a/backends/platform/sdl/macosx/macosx.cpp
+++ b/backends/platform/sdl/macosx/macosx.cpp
@@ -51,6 +51,7 @@ OSystem_MacOSX::~OSystem_MacOSX() {
 
 void OSystem_MacOSX::init() {
 	// Use an iconless window on OS X, as we use a nicer external icon there.
+	initSDL();
 	_window = new SdlIconlessWindow();
 
 #if defined(USE_TASKBAR)

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -66,6 +66,7 @@ void OSystem_Win32::init() {
 	_fsFactory = new WindowsFilesystemFactory();
 
 	// Create Win32 specific window
+	initSDL();
 	_window = new SdlWindow_Win32();
 
 #if defined(USE_TASKBAR)

--- a/backends/platform/symbian/src/SymbianOS.cpp
+++ b/backends/platform/symbian/src/SymbianOS.cpp
@@ -66,6 +66,7 @@ OSystem_SDL_Symbian::OSystem_SDL_Symbian()
 void OSystem_SDL_Symbian::init() {
 	_RFs = &CEikonEnv::Static()->FsSession();
 	// Use iconless window: it uses the EScummVM.aif file for the icon.
+	initSDL();
 	_window = new SdlIconlessWindow();
 	_fsFactory = new SymbianFilesystemFactory();
 	OSystem_SDL::init();


### PR DESCRIPTION
This is needed with SDL1 so that `SDL_GetVideoInfo` works properly.