### PR TITLE
GUI: Update "edit game" for new graphics options (please test before merge!)

### DIFF
--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -382,8 +382,13 @@ void EditGameDialog::open() {
 
 	e = ConfMan.hasKey("gfx_mode", _domain) ||
 		ConfMan.hasKey("render_mode", _domain) ||
+		ConfMan.hasKey("stretch_mode", _domain) ||
+		ConfMan.hasKey("aspect_ratio", _domain) ||
 		ConfMan.hasKey("fullscreen", _domain) ||
-		ConfMan.hasKey("aspect_ratio", _domain);
+		ConfMan.hasKey("vsync", _domain) ||
+		ConfMan.hasKey("filtering", _domain) ||
+		ConfMan.hasKey("renderer", _domain) ||
+		ConfMan.hasKey("antialiasing", _domain);
 	_globalGraphicsOverride->setState(e);
 
 	if (g_system->hasFeature(OSystem::kFeatureShader)) {

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -978,7 +978,12 @@ void OptionsDialog::setGraphicSettingsState(bool enabled) {
 	_renderModePopUp->setEnabled(enabled);
 	_stretchPopUpDesc->setEnabled(enabled);
 	_stretchPopUp->setEnabled(enabled);
+	_vsyncCheckbox->setEnabled(enabled);
 	_filteringCheckbox->setEnabled(enabled);
+	_rendererTypePopUpDesc->setEnabled(enabled);
+	_rendererTypePopUp->setEnabled(enabled);
+	_antiAliasPopUpDesc->setEnabled(enabled);
+	_antiAliasPopUp->setEnabled(enabled);
 
 	if (g_system->hasFeature(OSystem::kFeatureFullscreenMode))
 		_fullscreenCheckbox->setEnabled(enabled);


### PR DESCRIPTION
The new graphics settings (I assume they were added in the ResidualVM merge) are always active in "edit game", even if we're not overriding the global settings. This attempts to fix that.

I'm not sure if I got it all right, and the "V-Sync" checkbox is a bit unusual in that this setting is true by default. But it's a start.