### PR TITLE
CONFIGURE: Also install shaders if gles2 enabled

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -442,7 +442,7 @@ endif
 
 # Shaders
 DIST_FILES_SHADERS=
-ifdef USE_OPENGL_SHADERS
+ifneq ($(USE_OPENGL_SHADERS)$(USE_GLES2),)
 ifdef ENABLE_GRIM
 DIST_FILES_SHADERS+=$(wildcard $(srcdir)/engines/grim/shaders/*)
 endif

--- a/Makefile.common
+++ b/Makefile.common
@@ -440,7 +440,7 @@ ifdef ENABLE_AGI
 DIST_FILES_ENGINEDATA+=$(srcdir)/dists/pred.dic
 endif
 
-# Shaders
+# Shaders: install if USE_OPENGL_SHADERS or USE_GLES2 defined
 DIST_FILES_SHADERS=
 ifneq ($(USE_OPENGL_SHADERS)$(USE_GLES2),)
 ifdef ENABLE_GRIM

--- a/ports.mk
+++ b/ports.mk
@@ -22,7 +22,7 @@ install:
 	$(INSTALL) -c -m 644 "$(srcdir)/dists/scummvm.desktop" "$(DESTDIR)$(datarootdir)/applications/scummvm.desktop"
 	$(INSTALL) -d "$(DESTDIR)$(datarootdir)/metainfo"
 	$(INSTALL) -c -m 644 "$(srcdir)/dists/scummvm.appdata.xml" "$(DESTDIR)$(datarootdir)/metainfo/scummvm.appdata.xml"
-ifdef USE_OPENGL_SHADERS
+ifneq ($(DIST_FILES_SHADERS),)
 	$(INSTALL) -d "$(DESTDIR)$(datadir)/shaders"
 	$(INSTALL) -c -m 644 $(DIST_FILES_SHADERS) "$(DESTDIR)$(datadir)/shaders"
 endif
@@ -48,7 +48,7 @@ install-strip:
 	$(INSTALL) -c -m 644 "$(srcdir)/dists/scummvm.desktop" "$(DESTDIR)$(datarootdir)/applications/scummvm.desktop"
 	$(INSTALL) -d "$(DESTDIR)$(datarootdir)/metainfo"
 	$(INSTALL) -c -m 644 "$(srcdir)/dists/scummvm.appdata.xml" "$(DESTDIR)$(datarootdir)/metainfo/scummvm.appdata.xml"
-ifdef USE_OPENGL_SHADERS
+ifneq ($(DIST_FILES_SHADERS),)
 	$(INSTALL) -d "$(DESTDIR)$(datadir)/shaders"
 	$(INSTALL) -c -m 644 $(DIST_FILES_SHADERS) "$(DESTDIR)$(datadir)/shaders"
 endif
@@ -135,7 +135,7 @@ endif
 ifdef DIST_FILES_VKEYBD
 	cp $(DIST_FILES_VKEYBD) $(bundle_name)/Contents/Resources/
 endif
-ifdef USE_OPENGL_SHADERS
+ifneq ($(DIST_FILES_SHADERS),)
 	mkdir -p $(bundle_name)/Contents/Resources/shaders
 	cp $(DIST_FILES_SHADERS) $(bundle_name)/Contents/Resources/shaders/
 endif
@@ -150,7 +150,7 @@ endif
 	cp $(bundle_name)/Contents/Resources/COPYING.OFL $(bundle_name)/Contents/Resources/COPYING-OFL
 	cp $(bundle_name)/Contents/Resources/COPYING.BSD $(bundle_name)/Contents/Resources/COPYING-BSD
 	chmod 644 $(bundle_name)/Contents/Resources/*
-ifdef USE_OPENGL_SHADERS
+ifneq ($(DIST_FILES_SHADERS),)
 	chmod 755 $(bundle_name)/Contents/Resources/shaders
 endif
 	cp scummvm-static $(bundle_name)/Contents/MacOS/scummvm


### PR DESCRIPTION
Since the commit "CONFIGURE: Do not enable opengl_shaders feature flag for gles2. " (b3ffd89c6824b82b958784305017d5c9e4f207d9), the shaders are no more installed for opengles2 systems.
But they need them as they are used in the code.

I don't know if my way to test "USE_OPENGL_SHADERS or USE_GLES2" in Makefile is the standard of ScummVM but it works.
I'm open to any suggestions ...
