### PR TITLE
SDL: Do not allow toggle fullscreen for backends which can lose openg…

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -94,6 +94,9 @@ bool OpenGLGraphicsManager::hasFeature(OSystem::Feature f) const {
 	case OSystem::kFeatureAspectRatioCorrection:
 	case OSystem::kFeatureCursorPalette:
 	case OSystem::kFeatureFilteringMode:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	case OSystem::kFeatureFullscreenToggleKeepsContext:
+#endif
 	case OSystem::kFeatureStretchMode:
 		return true;
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -205,6 +205,9 @@ bool OpenGLSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 	switch (f) {
 	case OSystem::kFeatureFullscreenMode:
 	case OSystem::kFeatureIconifyWindow:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	case OSystem::kFeatureFullscreenToggleKeepsContext:
+#endif
 		return true;
 
 	default:

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -348,8 +348,10 @@ bool SdlGraphicsManager::notifyEvent(const Common::Event &event) {
 }
 
 void SdlGraphicsManager::toggleFullScreen() {
-	if (!g_system->hasFeature(OSystem::kFeatureFullscreenMode))
+	if (!g_system->hasFeature(OSystem::kFeatureFullscreenMode) ||
+	   (!g_system->hasFeature(OSystem::kFeatureFullscreenToggleKeepsContext) && g_system->hasFeature(OSystem::kFeatureOpenGLForGame))) {
 		return;
+	}
 
 	beginGFXTransaction();
 	setFeatureState(OSystem::kFeatureFullscreenMode, !getFeatureState(OSystem::kFeatureFullscreenMode));

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -222,6 +222,7 @@ bool SurfaceSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 		(f == OSystem::kFeatureAspectRatioCorrection) ||
 		(f == OSystem::kFeatureFilteringMode) ||
 #if SDL_VERSION_ATLEAST(2, 0, 0)
+		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
 		(f == OSystem::kFeatureStretchMode) ||
 #endif
 		(f == OSystem::kFeatureCursorPalette) ||

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -78,7 +78,7 @@ OpenGLSdlGraphics3dManager::~OpenGLSdlGraphics3dManager() {
 bool OpenGLSdlGraphics3dManager::hasFeature(OSystem::Feature f) const {
 	return
 		(f == OSystem::kFeatureFullscreenMode) ||
-		(f == OSystem::kFeatureOpenGL) ||
+		(f == OSystem::kFeatureOpenGLForGame) ||
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
 #endif

--- a/backends/graphics3d/sdl/sdl-graphics3d.cpp
+++ b/backends/graphics3d/sdl/sdl-graphics3d.cpp
@@ -119,8 +119,10 @@ bool SdlGraphics3dManager::notifyEvent(const Common::Event &event) {
 }
 
 void SdlGraphics3dManager::toggleFullScreen() {
-	if (!g_system->hasFeature(OSystem::kFeatureFullscreenMode))
+	if (!g_system->hasFeature(OSystem::kFeatureFullscreenMode) ||
+	   (!g_system->hasFeature(OSystem::kFeatureFullscreenToggleKeepsContext) && g_system->hasFeature(OSystem::kFeatureOpenGLForGame))) {
 		return;
+	}
 
 	setFeatureState(OSystem::kFeatureFullscreenMode, !getFeatureState(OSystem::kFeatureFullscreenMode));
 }

--- a/backends/graphics3d/surfacesdl/surfacesdl-graphics3d.cpp
+++ b/backends/graphics3d/surfacesdl/surfacesdl-graphics3d.cpp
@@ -76,9 +76,7 @@ SurfaceSdlGraphics3dManager::~SurfaceSdlGraphics3dManager() {
 
 bool SurfaceSdlGraphics3dManager::hasFeature(OSystem::Feature f) const {
 	return
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
-#endif
 		(f == OSystem::kFeatureAspectRatioCorrection) ||
 		(f == OSystem::kFeatureFullscreenMode);
 }

--- a/common/system.h
+++ b/common/system.h
@@ -375,9 +375,9 @@ public:
 
 		/**
 		 * This feature flag can be used to check if hardware accelerated
-		 * OpenGl is supported.
+		 * OpenGL is supported and can be used for 3D game rendering.
 		 */
-		kFeatureOpenGL,
+		kFeatureOpenGLForGame,
 
 		/**
 		 * If supported, this feature flag can be used to check if


### PR DESCRIPTION
Do not allow toggle fullscreen if backend can lose OpenGL context which is used for 3d games, but while game running.
SDL1 drop context, but SDL2 does not.
It's also to flag preventing toggle fullscreen from game engine call
