### PR TITLE
SDL: Sync portion code for 2D->3D gfx manager

### DIFF
--- a/backends/graphics3d/sdl/sdl-graphics3d.cpp
+++ b/backends/graphics3d/sdl/sdl-graphics3d.cpp
@@ -105,6 +105,10 @@ bool SdlGraphics3dManager::notifyEvent(const Common::Event &event) {
 	}
 
 	switch ((CustomEventAction) event.customType) {
+	case kActionToggleMouseCapture:
+		getWindow()->toggleMouseGrab();
+		return true;
+
 	case kActionToggleFullscreen:
 		toggleFullScreen();
 		return true;
@@ -139,10 +143,22 @@ Common::Keymap *SdlGraphics3dManager::getKeymap() {
 		keymap->addAction(act);
 	}
 
+	act = new Action("CAPT", _("Toggle mouse capture"));
+	act->addDefaultInputMapping("C+m");
+	act->setCustomBackendActionEvent(kActionToggleMouseCapture);
+	keymap->addAction(act);
+
 	act = new Action("SCRS", _("Save screenshot"));
 	act->addDefaultInputMapping("A+s");
 	act->setCustomBackendActionEvent(kActionSaveScreenshot);
 	keymap->addAction(act);
+
+	if (hasFeature(OSystem::kFeatureAspectRatioCorrection)) {
+		act = new Action("ASPT", _("Toggle aspect ratio correction"));
+		act->addDefaultInputMapping("C+A+a");
+		act->setCustomBackendActionEvent(kActionToggleAspectRatioCorrection);
+		keymap->addAction(act);
+	}
 
 	return keymap;
 }

--- a/backends/graphics3d/sdl/sdl-graphics3d.h
+++ b/backends/graphics3d/sdl/sdl-graphics3d.h
@@ -101,7 +101,7 @@ public:
 	virtual bool notifyMousePosition(Common::Point &mouse);
 
 	virtual bool showMouse(bool visible) override;
-	virtual bool lockMouse(bool lock) override; 
+	virtual bool lockMouse(bool lock) override;
 
 	virtual bool saveScreenshot(const Common::String &filename) const { return false; }
 	void saveScreenshot() override;
@@ -136,7 +136,9 @@ public:
 protected:
 	enum CustomEventAction {
 		kActionToggleFullscreen = 100,
-		kActionSaveScreenshot
+		kActionToggleMouseCapture,
+		kActionSaveScreenshot,
+		kActionToggleAspectRatioCorrection
 	};
 
 protected:


### PR DESCRIPTION
Copy portions of code for SDL 2D GFX manager to 3D. Events related.