### PR TITLE
ENGINES: Use ScummVM's 2D API for blitting the TinyGL framebuffer

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -191,6 +191,10 @@ bool SdlGraphicsManager::showMouse(bool visible) {
 	return WindowedGraphicsManager::showMouse(visible);
 }
 
+bool SdlGraphicsManager::lockMouse(bool lock) {
+	return _window->lockMouse(lock);
+}
+
 bool SdlGraphicsManager::notifyMousePosition(Common::Point &mouse) {
 	mouse.x = CLIP<int16>(mouse.x, 0, _windowWidth - 1);
 	mouse.y = CLIP<int16>(mouse.y, 0, _windowHeight - 1);

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -95,6 +95,7 @@ public:
 	virtual bool notifyMousePosition(Common::Point &mouse);
 
 	virtual bool showMouse(bool visible) override;
+	virtual bool lockMouse(bool lock) override;
 
 	virtual bool saveScreenshot(const Common::String &filename) const { return false; }
 	void saveScreenshot() override;

--- a/backends/graphics3d/sdl/sdl-graphics3d.cpp
+++ b/backends/graphics3d/sdl/sdl-graphics3d.cpp
@@ -190,20 +190,8 @@ bool SdlGraphics3dManager::showMouse(bool visible) {
 }
 
 bool SdlGraphics3dManager::lockMouse(bool lock) {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	if (lock)
-		SDL_SetRelativeMouseMode(SDL_TRUE);
-	else
-		SDL_SetRelativeMouseMode(SDL_FALSE);
-#else
-	if (lock)
-		SDL_WM_GrabInput(SDL_GRAB_ON);
-	else
-		SDL_WM_GrabInput(SDL_GRAB_OFF);
-#endif
-	return true;
+	return _window->lockMouse(lock);
 }
-
 
 bool SdlGraphics3dManager::notifyMousePosition(Common::Point &mouse) {
 	transformMouseCoordinates(mouse);

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -162,6 +162,21 @@ void SdlWindow::toggleMouseGrab() {
 #endif
 }
 
+bool SdlWindow::lockMouse(bool lock) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (lock)
+		SDL_SetRelativeMouseMode(SDL_TRUE);
+	else
+		SDL_SetRelativeMouseMode(SDL_FALSE);
+#else
+	if (lock)
+		SDL_WM_GrabInput(SDL_GRAB_ON);
+	else
+		SDL_WM_GrabInput(SDL_GRAB_OFF);
+#endif
+	return true;
+}
+
 bool SdlWindow::hasMouseFocus() const {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_window) {

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -52,6 +52,11 @@ public:
 	void toggleMouseGrab();
 
 	/**
+	 * Lock or unlock the mouse cursor within the window.
+	 */
+	bool lockMouse(bool lock);
+
+	/**
 	 * Check whether the application has mouse focus.
 	 */
 	bool hasMouseFocus() const;

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -78,8 +78,6 @@ GfxTinyGL::~GfxTinyGL() {
 }
 
 void GfxTinyGL::setupScreen(int screenW, int screenH, bool fullscreen) {
-	Graphics::PixelBuffer buf = g_system->getScreenPixelBuffer();
-
 	_screenWidth = screenW;
 	_screenHeight = screenH;
 	_scaleW = _screenWidth / (float)_gameWidth;
@@ -87,9 +85,9 @@ void GfxTinyGL::setupScreen(int screenW, int screenH, bool fullscreen) {
 
 	g_system->showMouse(!fullscreen);
 
-	_pixelFormat = buf.getFormat();
+	_pixelFormat = g_system->getScreenFormat();
 	debug("INFO: TinyGL front buffer pixel format: %s", _pixelFormat.toString().c_str());
-	_zb = new TinyGL::FrameBuffer(screenW, screenH, buf);
+	_zb = new TinyGL::FrameBuffer(screenW, screenH, _pixelFormat);
 	TinyGL::glInit(_zb, 256);
 	tglEnableDirtyRects(ConfMan.getBool("dirtyrects"));
 
@@ -176,6 +174,8 @@ void GfxTinyGL::clearDepthBuffer() {
 
 void GfxTinyGL::flipBuffer() {
 	TinyGL::tglPresentBuffer();
+	g_system->copyRectToScreen(_zb->getPixelBuffer(), _zb->linesize,
+	                           0, 0, _zb->xsize, _zb->ysize);
 	g_system->updateScreen();
 }
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -269,7 +269,11 @@ GfxBase *GrimEngine::createRenderer(int screenW, int screenH, bool fullscreen) {
 	Graphics::RendererType matchingRendererType = Graphics::getBestMatchingAvailableRendererType(desiredRendererType);
 
 	_softRenderer = matchingRendererType == Graphics::kRendererTypeTinyGL;
-	initGraphics3d(screenW, screenH, fullscreen, !_softRenderer);
+	if (!_softRenderer) {
+		initGraphics3d(screenW, screenH, fullscreen, true);
+	} else {
+		initGraphics(screenW, screenH, nullptr);
+	}
 
 #if defined(USE_OPENGL_GAME)
 	// Check the OpenGL context actually supports shaders

--- a/engines/icb/surface_manager.cpp
+++ b/engines/icb/surface_manager.cpp
@@ -193,10 +193,9 @@ unsigned int _surface_manager::Init_direct_draw() {
 	Zdebug("*SURFACE_MANAGER* Initalizing the SDL video interface");
 
 	g_system->setWindowCaption("In Cold Blood (C)2000 Revolution Software Ltd");
-	initGraphics3d(640, 480, ConfMan.getBool("fullscreen"), false);
+	initGraphics(640, 480, nullptr);
 
-	Graphics::PixelBuffer pixBuff = g_system->getScreenPixelBuffer();
-	_zb = new TinyGL::FrameBuffer(640, 480, pixBuff); // TODO: delete
+	_zb = new TinyGL::FrameBuffer(640, 480, g_system->getScreenFormat()); // TODO: delete
 	TinyGL::glInit(_zb, 256);
 
 	sdl_screen = new Graphics::Surface();
@@ -413,6 +412,8 @@ void _surface_manager::Flip() {
 	Graphics::tglUploadBlitImage(blitImage, *sdl_screen, 0, false);
 	Graphics::tglBlitFast(blitImage, 0, 0);
 	TinyGL::tglPresentBuffer();
+	g_system->copyRectToScreen(_zb->getPixelBuffer(), _zb->linesize,
+	                           0, 0, _zb->xsize, _zb->ysize);
 	g_system->updateScreen();
 	Graphics::tglDeleteBlitImage(blitImage);
 #endif

--- a/engines/myst3/gfx.cpp
+++ b/engines/myst3/gfx.cpp
@@ -204,7 +204,11 @@ Renderer *createRenderer(OSystem *system) {
 		width = Renderer::kOriginalWidth;
 	}
 
-	initGraphics3d(width, height, fullscreen, isAccelerated);
+	if (isAccelerated) {
+		initGraphics3d(width, height, fullscreen, true);
+	} else {
+		initGraphics(width, height, nullptr);
+	}
 
 #if defined(USE_OPENGL_GAME)
 	// Check the OpenGL context actually supports shaders

--- a/engines/myst3/gfx_tinygl.cpp
+++ b/engines/myst3/gfx_tinygl.cpp
@@ -63,8 +63,7 @@ void TinyGLRenderer::init() {
 
 	computeScreenViewport();
 
-	Graphics::PixelBuffer screenBuffer = _system->getScreenPixelBuffer();
-	_fb = new TinyGL::FrameBuffer(kOriginalWidth, kOriginalHeight, screenBuffer);
+	_fb = new TinyGL::FrameBuffer(kOriginalWidth, kOriginalHeight, g_system->getScreenFormat());
 	TinyGL::glInit(_fb, 512);
 	tglEnableDirtyRects(ConfMan.getBool("dirtyrects"));
 
@@ -291,6 +290,8 @@ Graphics::Surface *TinyGLRenderer::getScreenshot() {
 
 void TinyGLRenderer::flipBuffer() {
 	TinyGL::tglPresentBuffer();
+	g_system->copyRectToScreen(_fb->getPixelBuffer(), _fb->linesize,
+	                           0, 0, _fb->xsize, _fb->ysize);
 }
 
 } // End of namespace Myst3


### PR DESCRIPTION
This is a continuation of residualvm/residualvm#1712. Compared to that PR, this PR now adapts the Myst3 and ICB engines as well.