### PR TITLE
COMMON: Try get functionality for HashMap and ConfMan

### DIFF
--- a/common/config-manager.h
+++ b/common/config-manager.h
@@ -58,37 +58,38 @@ public:
 
 	class Domain {
 	private:
-		StringMap     _entries;
-		StringMap     _keyValueComments;
-		String        _domainComment;
+		StringMap _entries;
+		StringMap _keyValueComments;
+		String _domainComment;
 
 	public:
 		typedef StringMap::const_iterator const_iterator;
 		const_iterator begin() const { return _entries.begin(); }
 		const_iterator end()   const { return _entries.end(); }
 
-		bool           empty() const { return _entries.empty(); }
+		bool empty() const { return _entries.empty(); }
 
-		bool           contains(const String &key) const { return _entries.contains(key); }
+		bool contains(const String &key) const { return _entries.contains(key); }
 
-		String        &operator[](const String &key) { return _entries[key]; }
-		const String  &operator[](const String &key) const { return _entries[key]; }
+		String &operator[](const String &key) { return _entries[key]; }
+		const String &operator[](const String &key) const { return _entries[key]; }
 
-		void           setVal(const String &key, const String &value) { _entries.setVal(key, value); }
+		void setVal(const String &key, const String &value) { _entries.setVal(key, value); }
 
-		String        &getVal(const String &key) { return _entries.getVal(key); }
-		const String  &getVal(const String &key) const { return _entries.getVal(key); }
+		String &getVal(const String &key) { return _entries.getVal(key); }
+		const String &getVal(const String &key) const { return _entries.getVal(key); }
+		bool tryGetVal(const String &key, String &out) const { return _entries.tryGetVal(key, out); }
 
-		void           clear() { _entries.clear(); }
+		void clear() { _entries.clear(); }
 
-		void           erase(const String &key) { _entries.erase(key); }
+		void erase(const String &key) { _entries.erase(key); }
 
-		void           setDomainComment(const String &comment);
-		const String  &getDomainComment() const;
+		void setDomainComment(const String &comment);
+		const String &getDomainComment() const;
 
-		void           setKVComment(const String &key, const String &comment);
-		const String  &getKVComment(const String &key) const;
-		bool           hasKVComment(const String &key) const;
+		void setKVComment(const String &key, const String &comment);
+		const String &getKVComment(const String &key) const;
+		bool hasKVComment(const String &key) const;
 	};
 
 	typedef HashMap<String, Domain, IgnoreCase_Hash, IgnoreCase_EqualTo> DomainMap;
@@ -115,7 +116,7 @@ public:
 	 * @param domName Name of the domain to retrieve.
 	 * @return Pointer to the domain, or 0 if the domain does not exist.
 	 */
-	Domain                  *getDomain(const String &domName);
+	Domain *			getDomain(const String &domName);
 	const Domain            *getDomain(const String &domName) const; /*!< @overload */
 
 
@@ -126,16 +127,16 @@ public:
 	 * @{
 	 */
 
-	bool                     hasKey(const String &key) const;
-	const String            &get(const String &key) const;
-	void                     set(const String &key, const String &value);
+	bool				hasKey(const String &key) const;
+	const String &		get(const String &key) const;
+	void				set(const String &key, const String &value);
     /** @} */
-	
+
 	/**
 	 * Update a configuration entry for the active domain and flush
 	 * the configuration file to disk if the value changed.
 	 */
-	void                     setAndFlush(const String &key, const Common::String &value);
+	void				setAndFlush(const String &key, const Common::String &value);
 
 #if 1
     /**
@@ -148,11 +149,11 @@ public:
 	 * @{
 	 */
 
-	bool                     hasKey(const String &key, const String &domName) const;
-	const String            &get(const String &key, const String &domName) const;
-	void                     set(const String &key, const String &value, const String &domName);
+	bool				hasKey(const String &key, const String &domName) const;
+	const String &		get(const String &key, const String &domName) const;
+	void				set(const String &key, const String &value, const String &domName);
 
-	void                     removeKey(const String &key, const String &domName);
+	void				removeKey(const String &key, const String &domName);
 	/** @} */
 #endif
 
@@ -167,10 +168,10 @@ public:
 	void                     setBool(const String &key, bool value, const String &domName = String()); /*!< Set integer value. */
 
 
-	void                     registerDefault(const String &key, const String &value);
-	void                     registerDefault(const String &key, const char *value);
-	void                     registerDefault(const String &key, int value);
-	void                     registerDefault(const String &key, bool value);
+	void				registerDefault(const String &key, const String &value);
+	void				registerDefault(const String &key, const char *value);
+	void				registerDefault(const String &key, int value);
+	void				registerDefault(const String &key, bool value);
 
 	void                     flushToDisk(); /*!< Flush configuration to disk. */
 
@@ -187,43 +188,43 @@ public:
 	void                     removeMiscDomain(const String &domName); /*!< Remove a miscellaneous domain. */
 	void                     renameMiscDomain(const String &oldName, const String &newName); /*!< Rename a miscellaneous domain. */
 
-	bool                     hasGameDomain(const String &domName) const;
-	bool                     hasMiscDomain(const String &domName) const;
+	bool				hasGameDomain(const String &domName) const;
+	bool				hasMiscDomain(const String &domName) const;
 
-	const DomainMap         &getGameDomains() const { return _gameDomains; }
-	DomainMap::iterator      beginGameDomains() { return _gameDomains.begin(); }
-	DomainMap::iterator      endGameDomains() { return _gameDomains.end(); }
+	const DomainMap &	getGameDomains() const { return _gameDomains; }
+	DomainMap::iterator beginGameDomains() { return _gameDomains.begin(); }
+	DomainMap::iterator endGameDomains() { return _gameDomains.end(); }
 
-	static void              defragment(); // move in memory to reduce fragmentation
-	void                     copyFrom(ConfigManager &source);
+	static void			defragment(); // move in memory to reduce fragmentation
+	void 				copyFrom(ConfigManager &source);
 	/** @} */
 private:
 	friend class Singleton<SingletonBaseType>;
 	ConfigManager();
 
-	void                     loadFromStream(SeekableReadStream &stream);
-	void                     addDomain(const String &domainName, const Domain &domain);
-	void                     writeDomain(WriteStream &stream, const String &name, const Domain &domain);
-	void                     renameDomain(const String &oldName, const String &newName, DomainMap &map);
+	void			loadFromStream(SeekableReadStream &stream);
+	void			addDomain(const String &domainName, const Domain &domain);
+	void			writeDomain(WriteStream &stream, const String &name, const Domain &domain);
+	void			renameDomain(const String &oldName, const String &newName, DomainMap &map);
 
-	Domain                  _transientDomain;
-	DomainMap               _gameDomains;
-	DomainMap               _miscDomains; // Any other domains
-	Domain                  _appDomain;
-	Domain                  _defaultsDomain;
+	Domain			_transientDomain;
+	DomainMap		_gameDomains;
+	DomainMap		_miscDomains; // Any other domains
+	Domain			_appDomain;
+	Domain			_defaultsDomain;
 
-	Domain                  _keymapperDomain;
+	Domain			_keymapperDomain;
 
 #ifdef USE_CLOUD
-	Domain                  _cloudDomain;
+	Domain			_cloudDomain;
 #endif
 
-	Array<String>           _domainSaveOrder;
+	Array<String>	_domainSaveOrder;
 
-	String                  _activeDomainName;
-	Domain                 *_activeDomain;
+	String			_activeDomainName;
+	Domain *		_activeDomain;
 
-	String                  _filename;
+	String			_filename;
 };
 
 /** @} */
@@ -231,6 +232,6 @@ private:
 } // End of namespace Common
 
 /** Shortcut for accessing the configuration manager. */
-#define ConfMan                  Common::ConfigManager::instance()
+#define ConfMan		Common::ConfigManager::instance()
 
 #endif

--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -252,6 +252,7 @@ public:
 	Val &getVal(const Key &key);
 	const Val &getVal(const Key &key) const;
 	const Val &getVal(const Key &key, const Val &defaultVal) const;
+	bool tryGetVal(const Key &key, Val &out) const;
 	void setVal(const Key &key, const Val &val);
 
 	void clear(bool shrinkArray = 0);
@@ -590,6 +591,17 @@ const Val &HashMap<Key, Val, HashFunc, EqualFunc>::getVal(const Key &key, const 
 		return _storage[ctr]->_value;
 	else
 		return defaultVal;
+}
+
+template<class Key, class Val, class HashFunc, class EqualFunc>
+bool HashMap<Key, Val, HashFunc, EqualFunc>::tryGetVal(const Key &key, Val &out) const {
+	size_type ctr = lookup(key);
+	if (_storage[ctr] != nullptr) {
+		out = _storage[ctr]->_value;
+		return true;
+	} else {
+		return false;
+	}
 }
 
 template<class Key, class Val, class HashFunc, class EqualFunc>


### PR DESCRIPTION
Makes for simpler/more efficient code when keys are optional.

Saves having to check for the key existing and then fetching the element at that key, which is two searches in the hashmap and two function calls in the code using the map.