### PR TITLE
BACKENDS: Drop getScreenPixelBuffer() as no longer needed.

### DIFF
--- a/backends/base-backend.cpp
+++ b/backends/base-backend.cpp
@@ -51,11 +51,6 @@ void BaseBackend::initBackend() {
 	OSystem::initBackend();
 }
 
-Graphics::PixelBuffer BaseBackend::getScreenPixelBuffer() {
-	warning("BaseBackend::getScreenPixelBuffer(): not implemented");
-	return Graphics::PixelBuffer();
-}
-
 void BaseBackend::fillScreen(uint32 col) {
 	Graphics::Surface *screen = lockScreen();
 	if (screen)

--- a/backends/base-backend.h
+++ b/backends/base-backend.h
@@ -34,7 +34,6 @@ class BaseBackend : public OSystem {
 public:
 	virtual void initBackend() override;
 
-	virtual Graphics::PixelBuffer getScreenPixelBuffer() override;
 	virtual void displayMessageOnOSD(const Common::U32String &msg) override;
 	virtual void displayActivityIconOnOSD(const Graphics::Surface *icon) override {}
 	virtual void fillScreen(uint32 col) override;

--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -112,7 +112,6 @@ public:
 	//virtual void setPalette(const byte *colors, uint start, uint num) = 0;
 	//virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
 
-	virtual Graphics::PixelBuffer getScreenPixelBuffer() { return Graphics::PixelBuffer(); }
 	virtual void saveScreenshot() {}
 	virtual bool lockMouse(bool lock) { return false; }
 };

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -352,10 +352,6 @@ void OpenGLSdlGraphics3dManager::notifyResize(const int width, const int height)
 #endif
 }
 
-Graphics::PixelBuffer OpenGLSdlGraphics3dManager::getScreenPixelBuffer() {
-	error("Direct screen buffer access is not allowed when using OpenGL");
-}
-
 void OpenGLSdlGraphics3dManager::initializeOpenGLContext() const {
 	OpenGL::ContextOGLType type;
 

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -76,7 +76,6 @@ public:
 #endif
 	virtual int getScreenChangeID() const override { return _screenChangeCount; }
 	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format) override;
-	virtual Graphics::PixelBuffer getScreenPixelBuffer() override;
 	virtual int16 getHeight() const override;
 	virtual int16 getWidth() const override;
 

--- a/backends/graphics3d/surfacesdl/surfacesdl-graphics3d.cpp
+++ b/backends/graphics3d/surfacesdl/surfacesdl-graphics3d.cpp
@@ -232,10 +232,6 @@ void SurfaceSdlGraphics3dManager::createOrUpdateScreen() {
 	_screenChangeCount++;
 }
 
-Graphics::PixelBuffer SurfaceSdlGraphics3dManager::getScreenPixelBuffer() {
-	return Graphics::PixelBuffer(_screenFormat, (byte *)_subScreen->pixels);
-}
-
 void SurfaceSdlGraphics3dManager::drawOverlay() {
 	if (!_overlayscreen)
 		return;

--- a/backends/graphics3d/surfacesdl/surfacesdl-graphics3d.h
+++ b/backends/graphics3d/surfacesdl/surfacesdl-graphics3d.h
@@ -54,7 +54,6 @@ public:
 #endif
 	virtual int getScreenChangeID() const override { return _screenChangeCount; }
 	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format) override;
-	virtual Graphics::PixelBuffer getScreenPixelBuffer() override;
 	virtual int16 getHeight() const override;
 	virtual int16 getWidth() const override;
 

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -125,11 +125,7 @@ Common::List<Graphics::PixelFormat> ModularGraphicsBackend::getSupportedFormats(
 
 #endif
 
-Graphics::PixelBuffer ModularGraphicsBackend::getScreenPixelBuffer() {
-	return _graphicsManager->getScreenPixelBuffer();
-}
-
-void ModularGraphicsBackend::initSize(uint w, uint h, const Graphics::PixelFormat *format ) {
+void ModularGraphicsBackend::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
 	_graphicsManager->initSize(w, h, format);
 }
 

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -82,7 +82,6 @@ public:
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override final;
 #endif
 	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) override final;
-	virtual Graphics::PixelBuffer getScreenPixelBuffer() override;
 	virtual void initSizeHint(const Graphics::ModeList &modes) override final;
 	virtual int getScreenChangeID() const override final;
 

--- a/backends/platform/android3d/graphics.cpp
+++ b/backends/platform/android3d/graphics.cpp
@@ -689,10 +689,6 @@ void AndroidGraphicsManager::setupScreen(uint screenW, uint screenH, bool fullsc
 	}
 }
 
-Graphics::PixelBuffer AndroidGraphicsManager::getScreenPixelBuffer() {
-	return _game_pbuf;
-}
-
 void AndroidGraphicsManager::clipMouse(Common::Point &p) const {
 	const GLESBaseTexture *tex = getActiveTexture();
 

--- a/backends/platform/android3d/graphics.h
+++ b/backends/platform/android3d/graphics.h
@@ -95,7 +95,6 @@ public:
 	void setupScreen(uint screenW, uint screenH, bool fullscreen, bool accel3d);
 
 	void setupScreen(uint screenW, uint screenH, bool fullscreen, bool accel3d, bool isGame);
-	virtual Graphics::PixelBuffer getScreenPixelBuffer() override;
 	void updateScreenRect();
 	const GLESBaseTexture *getActiveTexture() const;
 	void clipMouse(Common::Point &p) const;

--- a/common/system.h
+++ b/common/system.h
@@ -903,13 +903,6 @@ public:
 	virtual TransactionError endGFXTransaction() { return kTransactionSuccess; }
 
 	/**
-	 * Return a Graphics::PixelBuffer representing the framebuffer.
-	 * The caller can then perform arbitrary graphics transformations
-	 * on the framebuffer (blitting, scrolling, etc.).
-	 */
-	virtual Graphics::PixelBuffer getScreenPixelBuffer() = 0;
-
-	/**
 	 * Returns the currently set virtual screen height.
 	 * @see initSize
 	 * @return the currently set virtual screen height


### PR DESCRIPTION
The getScreenPixelBuffer() system call is no longer needed.
