### PR TITLE
SDL: Refactor grabbing and locking the mouse

### DIFF
--- a/backends/graphics/downscalesdl/downscalesdl-graphics.cpp
+++ b/backends/graphics/downscalesdl/downscalesdl-graphics.cpp
@@ -110,7 +110,7 @@ void DownscaleSdlGraphicsManager::initSize(uint w, uint h, const Graphics::Pixel
 	if (w > 320 || h > 240) {
 		setGraphicsMode(GFX_HALF);
 		setGraphicsModeIntern();
-		_window->toggleMouseGrab();
+		_window->grabMouse(!getWindow()->mouseIsGrabbed());
 	}
 
 	_transactionDetails.sizeChanged = true;

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -335,7 +335,7 @@ bool SdlGraphicsManager::notifyEvent(const Common::Event &event) {
 
 	switch ((CustomEventAction) event.customType) {
 	case kActionToggleMouseCapture:
-		getWindow()->toggleMouseGrab();
+		getWindow()->grabMouse(!getWindow()->mouseIsGrabbed());
 		return true;
 
 	case kActionToggleFullscreen:

--- a/backends/graphics3d/sdl/sdl-graphics3d.cpp
+++ b/backends/graphics3d/sdl/sdl-graphics3d.cpp
@@ -106,7 +106,7 @@ bool SdlGraphics3dManager::notifyEvent(const Common::Event &event) {
 
 	switch ((CustomEventAction) event.customType) {
 	case kActionToggleMouseCapture:
-		getWindow()->toggleMouseGrab();
+		getWindow()->grabMouse(!getWindow()->mouseIsGrabbed());
 		return true;
 
 	case kActionToggleFullscreen:

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -46,10 +46,10 @@ public:
 	void setWindowCaption(const Common::String &caption);
 
 	/**
-	 * Toggle mouse grab state. This decides whether the cursor can leave the
-	 * window or not.
+	 * Grab or ungrab the mouse cursor. This decides whether the cursor can leave
+	 * the window or not.
 	 */
-	void toggleMouseGrab();
+	void grabMouse(bool grab);
 
 	/**
 	 * Lock or unlock the mouse cursor within the window.
@@ -92,13 +92,21 @@ public:
 		if (_window) {
 			return SDL_GetWindowGrab(_window) == SDL_TRUE;
 		}
-#endif
+		return false;
+#else
 		return _inputGrabState;
+#endif
+	}
+
+	bool mouseIsLocked() const {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		return SDL_GetRelativeMouseMode() == SDL_TRUE;
+#else
+		return _inputLockState;
+#endif
 	}
 
 private:
-	bool _inputGrabState;
-
 	Common::Rect _desktopRes;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -137,6 +145,8 @@ private:
 	int _lastX, _lastY;
 
 	Common::String _windowCaption;
+#else
+	bool _inputGrabState, _inputLockState;
 #endif
 };
 


### PR DESCRIPTION
Following on from PR #2517, this PR fixes the issues with SDL1 relating to the fact that grabbing and locking the mouse are both done using `SDL_WM_GrabInput`.