### PR TITLE
ICB: Add detection entries for the demo versions

### DIFF
--- a/engines/icb/debug_pc.cpp
+++ b/engines/icb/debug_pc.cpp
@@ -54,8 +54,7 @@ void Fatal_error(const char *format...) {
 	va_list args;
 	va_start(args, format);
 	vsnprintf(buf, 256, const_cast<char *>(format), args);
-	warning("%s", buf);
-	assert(0); // To trap the debugger
+	error("%s", buf);
 }
 void Message_box(const char *, ...) { ; }
 void Zdebug(const char *, ...) { ; }

--- a/engines/icb/detection.cpp
+++ b/engines/icb/detection.cpp
@@ -32,6 +32,7 @@ static const PlainGameDescriptor icbGames[] = {
 static const char *directoryGlobs[] = {
 	"engine",
 	"linc",
+	"demo",
 	0
 };
 
@@ -48,17 +49,29 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NONE)
 	},
 
-/*	{
+	{
 		// In Cold Blood
 		// English Demo
 		"icb",
 		"Demo",
-		AD_ENTRY1s("engine.exe", "0c4a7a5046ec13ccac89ab3f959cc217", 837632),  // TODO: Fill with correct values
-		Common::EN_ANY,
+		AD_ENTRY1s("engine.exe", "94222e343795853b0aa59cb9876415ae", 827392),
+		Common::EN_GRB,
 		Common::kPlatformWindows,
 		ADGF_DEMO,
 		GUIO1(GUIO_NONE)
-	},*/
+	},
+
+	{
+		// In Cold Blood
+		// English Demo
+		"icb",
+		"Demo",
+		AD_ENTRY1s("engine.exe", "d0702069d95423107463001b99a19e73", 939520),
+		Common::EN_USA,
+		Common::kPlatformWindows,
+		ADGF_DEMO,
+		GUIO1(GUIO_NONE)
+	},
 
 	AD_TABLE_END_MARKER
 };

--- a/engines/icb/main_menu_pc.cpp
+++ b/engines/icb/main_menu_pc.cpp
@@ -83,14 +83,16 @@ void InitisliaseScrollingText(const char *textFileName, const char *movieFileNam
 #endif
 
 	// Find movie to play
-	char fullMovieName[128];
+	pxString fullMovieName;
 
 #ifdef PC_DEMO
 	// All in one directory, which is nice
-	sprintf(fullMovieName, "gmovies\\%s.bik", movieFileName);
+	fullMovieName.Format("gmovies\\%s.bik", movieFileName);
+	fullMovieName.ConvertPath();
 #else
 	// All in one directory, which is nice
-	sprintf(fullMovieName, "movies\\%s.bik", movieFileName);
+	fullMovieName.Format("movies\\%s.bik", movieFileName);
+	fullMovieName.ConvertPath();
 #endif
 
 	// Ensure correct CD is in the drive (can't assume this because of movie library)
@@ -132,7 +134,8 @@ void InitisliaseScrollingText(const char *textFileName, const char *movieFileNam
 	if (!checkFileExists(fullMovieName)) { // amode = 0
 		// File is not present in the mission directory so check the global directory
 
-		sprintf(fullMovieName, "gmovies\\%s.bik", movieFileName);
+		fullMovieName.Format("gmovies\\%s.bik", movieFileName);
+		fullMovieName.ConvertPath();
 
 		if (!checkFileExists(fullMovieName))
 			Fatal_error(pxVString("Movie %s.bik does not exist in mission or global movie directory", movieFileName));


### PR DESCRIPTION
As far as I'm aware, there are two different demo versions of In Cold Blood - the one from [here](https://www.scummvm.org/frs/demos/icb/icb-eng-demo.zip), as well as a second one that appears to be larger and mentions Dreamcatcher in the opening title scroll instead of Ubi Soft Entertainment. I'm fairly sure it's the one from [here](https://web.archive.org/web/20020206060605/http://dreamcatchergames.com:80/games/downloads.html), but the Wayback Machine doesn't have it and I couldn't find it anywhere else. If necessary, I can share the copy of the demo I have locally.

This PR also contains a couple of commits that are necessary to get the game to start.
