### PR TITLE
CREATE_PROJECT: Put detection in a separate project

### DIFF
--- a/devtools/create_project/codeblocks.cpp
+++ b/devtools/create_project/codeblocks.cpp
@@ -45,7 +45,7 @@ void CodeBlocksProvider::createWorkspace(const BuildSetup &setup) {
 	writeReferences(setup, workspace);
 
 	// Note we assume that the UUID map only includes UUIDs for enabled engines!
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _allProjUuidMap.begin(); i != _allProjUuidMap.end(); ++i) {
 		if (i->first == setup.projectName)
 			continue;
 
@@ -153,7 +153,7 @@ void CodeBlocksProvider::createProjectFile(const std::string &name, const std::s
 		for (StringList::const_iterator i = libraries.begin(); i != libraries.end(); ++i)
 			project << "\t\t\t\t\t<Add library=\"" << (*i) << "\" />\n";
 
-		for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+		for (UUIDMap::const_iterator i = _allProjUuidMap.begin(); i != _allProjUuidMap.end(); ++i) {
 			if (i->first == setup.projectName)
 				continue;
 
@@ -277,7 +277,7 @@ void CodeBlocksProvider::writeFileListToProject(const FileNode &dir, std::ofstre
 void CodeBlocksProvider::writeReferences(const BuildSetup &setup, std::ofstream &output) {
 	output << "\t\t<Project filename=\"" << setup.projectName << ".cbp\" active=\"1\">\n";
 
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _allProjUuidMap.begin(); i != _allProjUuidMap.end(); ++i) {
 		if (i->first == " << PROJECT_NAME << ")
 			continue;
 

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1512,7 +1512,11 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 	// We also need to add the UUID of the main project file.
 	const std::string svmUUID = _allProjUuidMap[setup.projectName] = createUUID(setup.projectName);
 	// Add the uuid of the detection project
-	const std::string detUUID = _allProjUuidMap["scummvm-detection"] = createUUID("scummvm-detection");
+	const std::string detProject = setup.projectName + "-detection";
+	const std::string detUUID = createUUID(detProject);
+	if (setup.useStaticDetection) {
+		_allProjUuidMap[detProject] = _engineUuidMap[detProject] = detUUID;
+	}
 
 	createWorkspace(setup);
 
@@ -1520,7 +1524,7 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 
 	// Create project files
 	for (UUIDMap::const_iterator i = _engineUuidMap.begin(); i != _engineUuidMap.end(); ++i) {
-		if (i->first == setup.projectName)
+		if (i->first == detProject)
 			continue;
 		// Retain the files between engines if we're creating a single project
 		in.clear();
@@ -1533,7 +1537,7 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 	}
 
 	// Create engine-detection submodules.
-	{
+	if (setup.useStaticDetection) {
 		in.clear();
 		ex.clear();
 		std::vector<std::string> detectionModuleDirs;
@@ -1551,7 +1555,7 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 			createModuleList(str, setup.defines, setup.testDirs, in, ex, true);
 		}
 
-		createProjectFile("Detection", detUUID, setup, setup.srcDir, in, ex);
+		createProjectFile(detProject, detUUID, setup, setup.srcDir, in, ex);
 	}
 
 	if (setup.tests) {

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -482,7 +482,8 @@ protected:
 	StringList &_globalWarnings;                         ///< Global warnings
 	std::map<std::string, StringList> &_projectWarnings; ///< Per-project warnings
 
-	UUIDMap _uuidMap; ///< List of (project name, UUID) pairs
+	UUIDMap _engineUuidMap; ///< List of (project name, UUID) pairs
+	UUIDMap _allProjUuidMap;
 
 	/**
 	 *  Create workspace/solution file

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -255,7 +255,7 @@ void MSBuildProvider::outputFilter(std::ostream &filters, const FileEntries &fil
 void MSBuildProvider::writeReferences(const BuildSetup &setup, std::ofstream &output) {
 	output << "\t<ItemGroup>\n";
 
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _allProjUuidMap.begin(); i != _allProjUuidMap.end(); ++i) {
 		if (i->first == setup.projectName)
 			continue;
 

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -144,8 +144,8 @@ std::string MSVCProvider::outputLibraryDependencies(const BuildSetup &setup, boo
 }
 
 void MSVCProvider::createWorkspace(const BuildSetup &setup) {
-	UUIDMap::const_iterator svmUUID = _uuidMap.find(setup.projectName);
-	if (svmUUID == _uuidMap.end())
+	UUIDMap::const_iterator svmUUID = _allProjUuidMap.find(setup.projectName);
+	if (svmUUID == _allProjUuidMap.end())
 		error("No UUID for \"" + setup.projectName + "\" project created");
 
 	const std::string svmProjectUUID = svmUUID->second;
@@ -174,7 +174,7 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 	}
 
 	// Note we assume that the UUID map only includes UUIDs for enabled engines!
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _allProjUuidMap.begin(); i != _allProjUuidMap.end(); ++i) {
 		if (i->first == setup.projectName)
 			continue;
 
@@ -195,7 +195,7 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 	solution << "\tEndGlobalSection\n"
 	            "\tGlobalSection(ProjectConfigurationPlatforms) = postSolution\n";
 
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _allProjUuidMap.begin(); i != _allProjUuidMap.end(); ++i) {
 		for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 			solution << "\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".ActiveCfg = Debug|" << getMSVCConfigName(*arch) << "\n"
 			         << "\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".Build.0 = Debug|" << getMSVCConfigName(*arch) << "\n"

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -175,7 +175,7 @@ void VisualStudioProvider::outputBuildEvents(std::ostream &project, const BuildS
 void VisualStudioProvider::writeReferences(const BuildSetup &setup, std::ofstream &output) {
 	output << "\tProjectSection(ProjectDependencies) = postProject\n";
 
-	for (UUIDMap::const_iterator i = _uuidMap.begin(); i != _uuidMap.end(); ++i) {
+	for (UUIDMap::const_iterator i = _allProjUuidMap.begin(); i != _allProjUuidMap.end(); ++i) {
 		if (i->first == setup.projectName)
 			continue;
 


### PR DESCRIPTION
Keeps the main project clean and is a prerequisite for building detection as a plugin.