### PR TITLE
CONFIGURE: Allow building with TinyGL disabled

### DIFF
--- a/base/version.cpp
+++ b/base/version.cpp
@@ -173,6 +173,9 @@ const char *gScummVMFeatures = ""
 	"SDL_net "
 #endif
 #endif
+#ifdef USE_TINYGL
+	"TinyGL "
+#endif
 #ifdef USE_OPENGL
 	"OpenGL "
 #ifdef USE_OPENGL_SHADERS

--- a/configure
+++ b/configure
@@ -164,6 +164,7 @@ _opengl_game=auto
 _opengl_game_classic=no
 _opengl_game_shaders=auto
 _opengl_game_es2=no
+_tinygl=yes
 _readline=auto
 _freetype2=auto
 _taskbar=auto
@@ -270,6 +271,7 @@ add_feature mpeg2 "mpeg2" "_mpeg2"
 add_feature opengl_game_shaders "OpenGL with shaders" "_opengl_game_shaders"
 add_feature png "PNG" "_png"
 add_feature theoradec "libtheoradec" "_theoradec"
+add_feature tinygl "TinyGL" "_tinygl"
 add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
 add_feature lua "lua" "_lua"
@@ -1321,6 +1323,8 @@ for ac_option in $@; do
 	--disable-opengl-game)        _opengl_game=no        ;;
 	--disable-opengl-game-shaders) _opengl_game_shaders=no ;;
 	--force-opengl-game-es2)      _opengl_game_es2=yes   ;;
+	--enable-tinygl)              _tinygl=yes            ;;
+	--disable-tinygl)             _tinygl=no             ;;
 	--enable-bink)                _bink=yes              ;;
 	--disable-bink)               _bink=no               ;;
 	--enable-discord)             _discord=yes           ;;
@@ -3396,6 +3400,7 @@ if test -n "$_host"; then
 			_build_scalers=no
 			_mt32emu=no
 			_nuked_opl=no
+			_tinygl=no
 			_bink=no
 			_lua=no
 			_port_mk="backends/platform/ds/ds.mk"
@@ -5861,6 +5866,16 @@ fi
 define_in_config_if_yes $_tts 'USE_TTS'
 
 #
+# Check whether to build with TinyGL support
+#
+echo_n "Building TinyGL support... "
+if test "$_16bit" = "no"; then
+	_tinygl=no
+fi
+define_in_config_if_yes $_tinygl 'USE_TINYGL'
+echo "$_tinygl"
+
+#
 # Check whether to build Bink video support
 #
 echo_n "Building Bink video support... "
@@ -5973,6 +5988,10 @@ fi
 
 if test "$_highres" = yes ; then
 	echo_n ", high resolution"
+fi
+
+if test "$_tinygl" = yes ; then
+	echo_n ", TinyGL"
 fi
 
 if test "$_savegame_timestamp" = yes ; then

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1060,6 +1060,7 @@ const Feature s_features[] = {
 	{          "mt32emu",                   "USE_MT32EMU", false, true,  "integrated MT-32 emulator" },
 	{              "lua",                       "USE_LUA", false, true,  "lua" },
 	{             "nasm",                      "USE_NASM", false, true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
+	{           "tinygl",                    "USE_TINYGL", false, true,  "TinyGL support" },
 	{           "opengl",                    "USE_OPENGL", false, true,  "OpenGL support" },
 	{      "opengl_game",               "USE_OPENGL_GAME", false, true,  "OpenGL support in 3d games" },
 	{   "opengl_shaders",            "USE_OPENGL_SHADERS", false, true,  "OpenGL support (shaders) in 3d games" },

--- a/engines/grim/configure.engine
+++ b/engines/grim/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine grim "Grim" yes "monkey4" "Grim Fandango" "zlib"
+add_engine grim "Grim" yes "monkey4" "Grim Fandango" "tinygl zlib"
 add_engine monkey4 "Escape from Monkey Island" yes "" "" "bink mpeg2"

--- a/engines/icb/configure.engine
+++ b/engines/icb/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine icb "In Cold Blood" no "" "" "zlib"
+add_engine icb "In Cold Blood" no "" "" "tinygl zlib"

--- a/engines/myst3/configure.engine
+++ b/engines/myst3/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine myst3 "Myst 3" yes "" "" "jpeg bink"
+add_engine myst3 "Myst 3" yes "" "" "tinygl jpeg bink"

--- a/graphics/module.mk
+++ b/graphics/module.mk
@@ -51,7 +51,10 @@ MODULE_OBJS := \
 	opengl/surfacerenderer.o \
 	opengl/box_shaders.o \
 	opengl/control_shaders.o \
-	opengl/compat_shaders.o \
+	opengl/compat_shaders.o
+
+ifdef USE_TINYGL
+MODULE_OBJS += \
 	tinygl/api.o \
 	tinygl/arrays.o \
 	tinygl/clear.o \
@@ -73,7 +76,8 @@ MODULE_OBJS := \
 	tinygl/zmath.o \
 	tinygl/ztriangle.o \
 	tinygl/zblit.o \
-	tinygl/zdirtyrect.o \
+	tinygl/zdirtyrect.o
+endif
 
 ifdef USE_SCALERS
 MODULE_OBJS += \

--- a/graphics/renderer.cpp
+++ b/graphics/renderer.cpp
@@ -33,7 +33,9 @@ static const RendererTypeDescription rendererTypes[] = {
 #if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
 	{ "opengl_shaders", _s("OpenGL with shaders"), kRendererTypeOpenGLShaders },
 #endif
+#ifdef USE_TINYGL
 	{ "software", "Software", kRendererTypeTinyGL },
+#endif
 	{ 0, 0, kRendererTypeDefault }
 };
 


### PR DESCRIPTION
Enabling TinyGL increases the size of the main executable considerably, which causes problems for the DS port.