### PR TITLE
GUI: Fix #11767 - STARK: The Longest Journey - random text replaced with ...

### DIFF
--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -52,8 +52,7 @@ Common::Rect getBoundingBoxImpl(const Font &font, const StringType &str, int x, 
 		x = x + w - width;
 	x += deltax;
 
-	bool first = true;
-	Common::Rect bbox;
+	Common::Rect bbox(x, y, x + width, y);
 
 	typename StringType::unsigned_type last = 0;
 	for (typename StringType::const_iterator i = str.begin(), end = str.end(); i != end; ++i) {
@@ -66,12 +65,7 @@ Common::Rect getBoundingBoxImpl(const Font &font, const StringType &str, int x, 
 			break;
 		if (x + charBox.right >= leftX) {
 			charBox.translate(x, y);
-			if (first) {
-				bbox = charBox;
-				first = false;
-			} else {
-				bbox.extend(charBox);
-			}
+			bbox.extend(charBox);
 		}
 
 		x += font.getCharWidth(cur);


### PR DESCRIPTION
This is an attempt to fix ellipsifying of text in STARK by changing width and bounding box calculation discrepancy in recently introduced `handleEllipsis()` and `getBoundingBoxImpl()`.

I haven't dug too deep so this probably makes no sense. Only tested in STARK so far.