### PR TITLE
GRAPHICS: Problem with virtual mouse position in an overlay when full…

### DIFF
--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -672,7 +672,7 @@ int16 OpenGLSdlGraphics3dManager::getOverlayWidth() const {
 }
 
 void OpenGLSdlGraphics3dManager::warpMouse(int x, int y) {
-	if (_frameBuffer) {
+	if (!_overlayVisible && _frameBuffer) {
 		// Scale from game coordinates to screen coordinates
 		x = (x * _gameRect.getWidth() * _overlayScreen->getWidth()) / _frameBuffer->getWidth();
 		y = (y * _gameRect.getHeight() * _overlayScreen->getHeight()) / _frameBuffer->getHeight();


### PR DESCRIPTION
There is a problem with the virtual mouse position when game is in an overlay (menu, warning message) in fullscreen mode (for OPENGL, OPENGLES):
The cursor moves far too fast and stays stuck at the bottom-right corner.

It is due to the fact that coordinates are converted as it was still in game.
So a test "!overlayVisible" must be added, as it is done in the reverse method (transformMouseCoordinates).