### PR TITLE
GRIM: Fix mapping of joystick action buttons in EMI

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -567,22 +567,22 @@ Common::KeymapArray GrimEngine::initKeymapsEMI(const char *target) {
 	engineKeyMap->addAction(act);
 
 	act = new Action("EXAM", _("Examine/Look"));
-	act->setKeyEvent(KeyState(KEYCODE_s, 'e'));
+	act->setKeyEvent(KeyState(KEYCODE_l, 'e'));
 	act->addDefaultInputMapping("JOY_X");
 	engineKeyMap->addAction(act);
 
 	act = new Action("BUSE", _("Use/Talk"));
-	act->setKeyEvent(KeyState(KEYCODE_w, 'u'));
+	act->setKeyEvent(KeyState(KEYCODE_u, 'u'));
 	act->addDefaultInputMapping("JOY_A");
 	engineKeyMap->addAction(act);
 
 	act = new Action("PICK", _("Pick up/Put away"));
-	act->setKeyEvent(KeyState(KEYCODE_a, 'p'));
+	act->setKeyEvent(KeyState(KEYCODE_KP_PLUS, 'p'));
 	act->addDefaultInputMapping("JOY_B");
 	engineKeyMap->addAction(act);
 
 	act = new Action("INVT", _("Inventory"));
-	act->setKeyEvent(KeyState(KEYCODE_d, 'i'));
+	act->setKeyEvent(KeyState(KEYCODE_INSERT, 'i'));
 	act->addDefaultInputMapping("JOY_Y");
 	engineKeyMap->addAction(act);
 


### PR DESCRIPTION
Joystick buttons are not working in EMI for actions:
It seems that key mapping doesn't map joystick buttons to correct key events.

According to manual: https://mocagh.org/lucasfilm/mi4-manual.pdf

- Examine/Look is E or L
- Use/Talk is U
- Pick up/Put in inventory is P or + (keypad)
- Inventory is I or Insert

With these modifications, the joystick buttons are now working.
Tested on x64 (Ubuntu) and Raspberry 2 and 3 with the French Windows and PS2 versions of the game.