### PR TITLE
WINTERMUTE: Opengl es 2 conformance

### DIFF
--- a/engines/wintermute/base/gfx/base_renderer3d.h
+++ b/engines/wintermute/base/gfx/base_renderer3d.h
@@ -85,7 +85,6 @@ public:
 	void initLoop() override;
 
 	virtual bool setProjection2D() = 0;
-	virtual void resetModelViewTransform() = 0;
 	virtual void setWorldTransform(const Math::Matrix4 &transform) = 0;
 
 	void project(const Math::Matrix4 &worldMatrix, const Math::Vector3d &point, int32 &x, int32 &y);

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -638,11 +638,8 @@ bool BaseRenderOpenGL3D::drawSpriteEx(BaseSurfaceOpenGL3D &tex, const Wintermute
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-	// might as well provide getters for those
-	GLint texWidth;
-	GLint texHeight;
-	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &texWidth);
-	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &texHeight);
+	int texWidth = tex.getGLTextureWidth();
+	int texHeight = tex.getGLTextureHeight();
 
 	float texLeft = (float)rect.left / (float)texWidth;
 	float texTop = (float)rect.top / (float)texHeight;

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -365,11 +365,6 @@ bool BaseRenderOpenGL3D::setProjection2D() {
 	return true;
 }
 
-void BaseRenderOpenGL3D::resetModelViewTransform() {
-	glMatrixMode(GL_MODELVIEW);
-	glLoadIdentity();
-}
-
 void BaseRenderOpenGL3D::setWorldTransform(const Math::Matrix4 &transform) {
 	Math::Matrix4 tmp = transform;
 	tmp.transpose();
@@ -742,7 +737,8 @@ bool BaseRenderOpenGL3D::drawSpriteEx(BaseSurfaceOpenGL3D &tex, const Wintermute
 
 void BaseRenderOpenGL3D::renderSceneGeometry(const BaseArray<AdWalkplane *> &planes, const BaseArray<AdBlock *> &blocks,
                                              const BaseArray<AdGeneric *> &generics, const BaseArray<Light3D *> &lights, Camera3D *camera) {
-	_gameRef->_renderer3D->resetModelViewTransform();
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
 	_gameRef->_renderer3D->setup3D(camera, true);
 
 	glDisable(GL_LIGHTING);
@@ -808,7 +804,8 @@ void BaseRenderOpenGL3D::renderSceneGeometry(const BaseArray<AdWalkplane *> &pla
 }
 
 void BaseRenderOpenGL3D::renderShadowGeometry(const BaseArray<AdWalkplane *> &planes, const BaseArray<AdBlock *> &blocks, const BaseArray<AdGeneric *> &generics, Camera3D *camera) {
-	resetModelViewTransform();
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
 	setup3D(camera, true);
 
 	// disable color write

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.h
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.h
@@ -91,7 +91,6 @@ public:
 
 	bool setProjection() override;
 	bool setProjection2D() override;
-	void resetModelViewTransform() override;
 	void setWorldTransform(const Math::Matrix4 &transform) override;
 
 	bool windowedBlt() override;

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -558,11 +558,8 @@ bool BaseRenderOpenGL3DShader::drawSpriteEx(BaseSurfaceOpenGL3D &tex, const Wint
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-	// might as well provide getters for those
-	int texWidth;
-	int texHeight;
-	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &texWidth);
-	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &texHeight);
+	int texWidth = tex.getGLTextureWidth();
+	int texHeight = tex.getGLTextureHeight();
 
 	float texLeft = (float)rect.left / (float)texWidth;
 	float texTop = (float)rect.top / (float)texHeight;

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -308,11 +308,6 @@ bool BaseRenderOpenGL3DShader::setProjection2D() {
 	return true;
 }
 
-void BaseRenderOpenGL3DShader::resetModelViewTransform() {
-	glMatrixMode(GL_MODELVIEW);
-	glLoadIdentity();
-}
-
 void BaseRenderOpenGL3DShader::setWorldTransform(const Math::Matrix4 &transform) {
 	Math::Matrix4 tmp = transform;
 	tmp.transpose();
@@ -648,7 +643,6 @@ void BaseRenderOpenGL3DShader::renderSceneGeometry(const BaseArray<AdWalkplane *
 }
 
 void BaseRenderOpenGL3DShader::renderShadowGeometry(const BaseArray<AdWalkplane *> &planes, const BaseArray<AdBlock *> &blocks, const BaseArray<AdGeneric *> &generics, Camera3D *camera) {
-	resetModelViewTransform();
 	setup3D(camera, true);
 
 	// disable color write

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h
@@ -76,7 +76,6 @@ public:
 
 	bool setProjection() override;
 	bool setProjection2D() override;
-	void resetModelViewTransform() override;
 	void setWorldTransform(const Math::Matrix4 &transform) override;
 
 	bool windowedBlt() override;

--- a/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h
+++ b/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h
@@ -66,6 +66,14 @@ public:
 		return _tex;
 	}
 
+	uint getGLTextureWidth() const {
+		return _texWidth;
+	}
+
+	uint getGLTextureHeight() const {
+		return _texHeight;
+	}
+
 private:
 	GLuint _tex;
 	BaseRenderer3D *_renderer;

--- a/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h
+++ b/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h
@@ -69,7 +69,7 @@ public:
 private:
 	GLuint _tex;
 	BaseRenderer3D *_renderer;
-	uint8 *_imageData;
+	Graphics::Surface *_imageData;
 	uint _texWidth;
 	uint _texHeight;
 };

--- a/engines/wintermute/base/gfx/opengl/shadow_volume_opengl_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/shadow_volume_opengl_shader.cpp
@@ -107,8 +107,6 @@ bool ShadowVolumeOpenGLShader::renderToStencilBuffer() {
 	// renderstate is really not needed.
 	glStencilFunc(GL_ALWAYS, 0x1, 0xFFFFFFFF);
 
-	glShadeModel(GL_FLAT);
-
 	// Make sure that no pixels get drawn to the frame buffer
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_ZERO, GL_ONE);
@@ -128,7 +126,6 @@ bool ShadowVolumeOpenGLShader::renderToStencilBuffer() {
 
 	// Restore render states
 	glFrontFace(GL_CCW);
-	glShadeModel(GL_SMOOTH);
 	glDepthMask(GL_TRUE);
 	glDisable(GL_STENCIL_TEST);
 	glDisable(GL_BLEND);


### PR DESCRIPTION
This should remove all non-conforming OpenGL calls from the shader renderer.
