### PR TITLE
GUI: Fix display of virtual keyboard for OpenGL/OpenGLES

### DIFF
--- a/backends/vkeybd/virtual-keyboard-gui.cpp
+++ b/backends/vkeybd/virtual-keyboard-gui.cpp
@@ -106,8 +106,17 @@ VirtualKeyboardGUI::~VirtualKeyboardGUI() {
 void VirtualKeyboardGUI::initMode(VirtualKeyboard::Mode *mode) {
 	assert(mode->image);
 
-	_kbdSurface = mode->image;
-	_kbdTransparentColor = mode->transparentColor;
+	Graphics::PixelFormat kbdFormat = mode->image->format;
+	Graphics::PixelFormat overlayFormat = _system->getOverlayFormat();
+	if (kbdFormat.bytesPerPixel == overlayFormat.bytesPerPixel) {
+		_kbdSurface = mode->image;
+		_kbdTransparentColor = mode->transparentColor;
+	} else {
+		_kbdSurface = mode->image->convertTo(overlayFormat);
+		byte a, r, g, b;
+		kbdFormat.colorToARGB(mode->transparentColor, a, r, g, b);
+		_kbdTransparentColor = overlayFormat.ARGBToColor(a, r, g, b);
+	}
 	_kbdBound.setWidth(_kbdSurface->w);
 	_kbdBound.setHeight(_kbdSurface->h);
 


### PR DESCRIPTION
This commit fixes a problem which avoids to display the virtual keyboard on OpenGL/OpenGLES systems, encountered on x64 and Raspberry models.

Indeed, the surface containing the image of the virtual keyboard is loaded at startup.
And later, the `OSystem_SDL::setGraphicsMode` switches to a new graphical manager `OpenGLSdlGraphics3dManager`.

But, in that case, the virtual keyboard has been loaded in 2 bytes-per-pixel format (for initial graphical manager) and overlay is 4bpp (for `OpenGLSdlGraphics3dManager`).
And due to these lines of `blit` method in `virtual-keyboard-gui.cpp`, the keyboard is not displayed:
```
if (surf_dst->format.bytesPerPixel != surf_src->format.bytesPerPixel)
    return;
```

The proper way to solve the problem is perhaps to reload the virtual keyboard surface after the switch of graphical manager.
But I don't know how to do it properly.

So, I propose this workaround which converts the surface to the right format when needed.