### PR TITLE
GUI: Fix keymap of virtual keyboard if no GUI opened before

### DIFF
--- a/backends/vkeybd/virtual-keyboard.cpp
+++ b/backends/vkeybd/virtual-keyboard.cpp
@@ -24,6 +24,7 @@
 
 #ifdef ENABLE_VKEYBD
 
+#include "gui/gui-manager.h"
 #include "backends/vkeybd/virtual-keyboard.h"
 
 #include "backends/keymapper/keymapper.h"
@@ -223,6 +224,21 @@ void VirtualKeyboard::handleMouseUp(int16 x, int16 y) {
 	_kbdGUI->endDrag();
 }
 
+// If no GUI opened before the virtual keyboard, kKeymapTypeGui is not yet initialized
+// Check and do it if needed
+void VirtualKeyboard::initKeymap() {
+        using namespace Common;
+
+        Keymapper *mapper = _system->getEventManager()->getKeymapper();
+
+        // Do not try to recreate same keymap over again
+        if (mapper->getKeymap(kGuiKeymapName) != 0)
+                return;
+
+        Keymap *guiMap = g_gui.getKeymap();
+        mapper->addGlobalKeymap(guiMap);
+}
+
 void VirtualKeyboard::show() {
 	if (!_loaded) {
 		debug(1, "VirtualKeyboard::show() - Virtual keyboard not loaded");
@@ -234,6 +250,7 @@ void VirtualKeyboard::show() {
 	switchMode(_initialMode);
 
 	{
+		initKeymap();
 		KeymapTypeEnabler guiKeymap(_system->getEventManager()->getKeymapper(), Keymap::kKeymapTypeGui);
 		_kbdGUI->run();
 	}

--- a/backends/vkeybd/virtual-keyboard.h
+++ b/backends/vkeybd/virtual-keyboard.h
@@ -242,6 +242,7 @@ protected:
 	bool checkModeResolutions();
 	void switchMode(Mode *newMode);
 	void switchMode(const String &newMode);
+	void initKeymap();
 	void handleMouseDown(int16 x, int16 y);
 	void handleMouseUp(int16 x, int16 y);
 	String findArea(int16 x, int16 y);


### PR DESCRIPTION
When starting a game from the command line (without using the menu) and opening the virtual keyboard, the keymap `kKeymapTypeGui` is not defined and it is not possible to click on virtual keyboard with a joystick/controller.

So, this patch initializes the `kKeymapTypeGui` keymap if it was not already done before (using the standard GuiManager mapping).

Perhaps, there are other solutions to solve this issue: For instance, make `GuiManager::initKeymap()` public and directly call it.
I'm open to any suggestion.