### PR TITLE
TWINE: Add detection for UK version of Little Big Adventure

### DIFF
--- a/engines/twine/detection.cpp
+++ b/engines/twine/detection.cpp
@@ -59,6 +59,15 @@ static const ADGameDescription twineGameDescriptions[] = {
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NONE)
 	},
+	{
+		"twine",
+		"",
+		AD_ENTRY1s("text.hqr", "31d880f658cc6cc6d6cf70df732aec4f", 248829),
+		Common::EN_GRB,
+		Common::kPlatformDOS,
+		ADGF_UNSTABLE,
+		GUIO1(GUIO_NONE)
+	},
 	AD_TABLE_END_MARKER
 };
 

--- a/engines/twine/twine.cpp
+++ b/engines/twine/twine.cpp
@@ -68,6 +68,11 @@ namespace TwinE {
 
 TwinEEngine::TwinEEngine(OSystem *system, Common::Language language, uint32 flags)
     : Engine(system), _gameLang(language), _gameFlags(flags), _rnd("twine") {
+	// Add default file directories
+	const Common::FSNode gameDataDir(ConfMan.get("path"));
+	SearchMan.addSubDirectoryMatching(gameDataDir, "fla");
+	SearchMan.addSubDirectoryMatching(gameDataDir, "vox");
+
 	setDebugger(new GUI::Debugger());
 	_actor = new Actor(this);
 	_animations = new Animations(this);


### PR DESCRIPTION
This adds detection for the UK release of Little Big Adventure. This is what my CD looks like:

https://www.mobygames.com/game/dos/relentless-twinsens-adventure/cover-art/gameCoverId,198155/

And this is what the box looks like:

https://www.mobygames.com/game/dos/relentless-twinsens-adventure/cover-art/gameCoverId,198153/

It may be misleading to call it an "UK release", because the "vox" directory (which I added to the search manager, even though I'm not sure if it's used) contains files prefixed "en_", "de_" and "fr_". But the CD says "Made in the U.K.", and the manual - which I **clearly** need to read, because right now I'm just hitting buttons blindly - is in English, so... But feel free to edit the description in any way.

The "fla" directory is probably animated cutscenes, or something like that? I definitely had to add that to the search manager.

Anyway, the game starts and runs for a bit. So that's promising.