### PR TITLE
STARK: Play sound when hovering active cursor

### DIFF
--- a/engines/stark/services/staticprovider.h
+++ b/engines/stark/services/staticprovider.h
@@ -76,6 +76,8 @@ public:
 	};
 
 	enum UISound {
+		kActionMouthHover = 0,
+		kActionHover = 1,
 		kInventoryNewItem = 2
 	};
 

--- a/engines/stark/ui/cursor.cpp
+++ b/engines/stark/ui/cursor.cpp
@@ -31,6 +31,7 @@
 #include "engines/stark/services/staticprovider.h"
 
 #include "engines/stark/resources/item.h"
+#include "engines/stark/resources/sound.h"
 
 #include "engines/stark/visual/image.h"
 #include "engines/stark/visual/text.h"
@@ -44,11 +45,12 @@ Cursor::Cursor(Gfx::Driver *gfx) :
 		_cursorImage(nullptr),
 		_mouseText(nullptr),
 		_currentCursorType(kImage),
-		_fading(false),
+		_itemActive(false),
 		_fadeLevelIncreasing(true),
 		_fadeLevel(0),
 		_hintDisplayDelay(150) {
 	setCursorType(kDefault);
+	_actionHoverSound = StarkStaticProvider->getUISound(StaticProvider::kActionHover);
 }
 
 Cursor::~Cursor() {
@@ -74,8 +76,16 @@ void Cursor::setMousePosition(const Common::Point &pos) {
 	_hintDisplayDelay = 150;
 }
 
-void Cursor::setFading(bool fading) {
-	_fading = fading;
+void Cursor::setItemActive(bool itemActive) {
+	if (_itemActive == itemActive) {
+		return;
+	}
+	if (itemActive) {
+		_actionHoverSound->play();
+	} else {
+		_actionHoverSound->stop();
+	}
+	_itemActive = itemActive;
 }
 
 void Cursor::onScreenChanged() {
@@ -85,7 +95,7 @@ void Cursor::onScreenChanged() {
 }
 
 void Cursor::updateFadeLevel() {
-	if (_fading) {
+	if (_itemActive) {
 		if (_fadeLevelIncreasing) {
 			_fadeLevel += 0.001f * StarkGlobal->getMillisecondsPerGameloop();
 		} else {

--- a/engines/stark/ui/cursor.h
+++ b/engines/stark/ui/cursor.h
@@ -35,6 +35,10 @@ namespace Gfx {
 class Driver;
 }
 
+namespace Resources {
+class Sound;
+}
+
 /**
  * Manager for the current game Cursor
  */
@@ -49,8 +53,8 @@ public:
 	/** Update the mouse position */
 	void setMousePosition(const Common::Point &pos);
 
-	/** Make cycle the cursor's brightness */
-	void setFading(bool fading);
+	/** Make cycle the cursor's brightness and play sound */
+	void setItemActive(bool fading);
 
 	/** Update when the screen resolution has changed */
 	void onScreenChanged();
@@ -87,7 +91,9 @@ private:
 	VisualText *_mouseText;
 	CursorType _currentCursorType;
 
-	bool _fading;
+	Resources::Sound *_actionHoverSound;
+
+	bool _itemActive;
 	float _fadeLevel;
 	bool _fadeLevelIncreasing;
 	static const float _fadeValueMax;

--- a/engines/stark/ui/world/actionmenu.h
+++ b/engines/stark/ui/world/actionmenu.h
@@ -35,6 +35,7 @@ class GameWindow;
 
 namespace Resources {
 class ItemVisual;
+class Sound;
 }
 
 class ActionMenu : public Window {
@@ -60,11 +61,13 @@ protected:
 private:
 	void clearActions();
 	void enableAction(uint32 action);
+	void updateActionSound();
 
 	enum ActionMenuType {
-		kActionHand  = 0,
-		kActionEye   = 1,
-		kActionMouth = 2
+		kActionNone  = -1,
+		kActionHand  =  0,
+		kActionEye   =  1,
+		kActionMouth =  2
 	};
 
 	struct ActionButton {
@@ -85,6 +88,11 @@ private:
 	InventoryWindow *_inventory;
 
 	int32 _autoCloseTimeRemaining;
+
+	int32 _activeMenuType;
+
+	Resources::Sound *_actionMouthHoverSound;
+	Resources::Sound *_actionHoverSound;
 };
 
 } // End of namespace Stark

--- a/engines/stark/ui/world/gamewindow.cpp
+++ b/engines/stark/ui/world/gamewindow.cpp
@@ -117,7 +117,6 @@ void GameWindow::onRender() {
 
 void GameWindow::onMouseMove(const Common::Point &pos) {
 	_renderEntries = StarkGlobal->getCurrent()->getLocation()->listRenderEntries();
-	_cursor->setFading(false);
 
 	if (!StarkUserInterface->isInteractive()) {
 		_objectUnderCursor = nullptr;
@@ -129,13 +128,14 @@ void GameWindow::onMouseMove(const Common::Point &pos) {
 	int16 selectedInventoryItem = _inventory->getSelectedInventoryItem();
 	int16 singlePossibleAction = -1;
 	bool defaultAction = false;
+	bool itemActive = false;
 
 	checkObjectAtPos(pos, selectedInventoryItem, singlePossibleAction, defaultAction);
 
 	if (selectedInventoryItem != -1 && !defaultAction) {
 		VisualImageXMG *cursorImage = StarkGameInterface->getCursorImage(selectedInventoryItem);
 		_cursor->setCursorImage(cursorImage);
-		_cursor->setFading(singlePossibleAction == selectedInventoryItem);
+		itemActive = singlePossibleAction == selectedInventoryItem;
 	} else if (_objectUnderCursor) {
 		switch (singlePossibleAction) {
 			case -1:
@@ -159,6 +159,7 @@ void GameWindow::onMouseMove(const Common::Point &pos) {
 		// Not an object
 		_cursor->setCursorType(Cursor::kDefault);
 	}
+	_cursor->setItemActive(itemActive);
 
 	Common::String mouseHint;
 	if (_objectUnderCursor) {

--- a/engines/stark/ui/world/inventorywindow.cpp
+++ b/engines/stark/ui/world/inventorywindow.cpp
@@ -196,15 +196,15 @@ void InventoryWindow::onMouseMove(const Common::Point &pos) {
 		} else if ((canScrollDown() && _scrollDownArrowRect.contains(pos))
 		           || (canScrollUp() && _scrollUpArrowRect.contains(pos))) {
 			_cursor->setCursorType(Cursor::kActive);
-			_cursor->setFading(false);
+			_cursor->setItemActive(false);
 		} else {
 			_cursor->setCursorType(Cursor::kDefault);
 		}
-		_cursor->setFading(false);
+		_cursor->setItemActive(false);
 	} else {
 		VisualImageXMG *cursorImage = StarkGameInterface->getCursorImage(_selectedInventoryItem);
 		_cursor->setCursorImage(cursorImage);
-		_cursor->setFading(hoveredItemAction == _selectedInventoryItem);
+		_cursor->setItemActive(hoveredItemAction == _selectedInventoryItem);
 	}
 
 	if (hoveredItem) {


### PR DESCRIPTION
* Play sound when hovering over action menu items. Fixes https://bugs.scummvm.org/ticket/11875
* Play sound when hovering useable items. Fixes https://bugs.scummvm.org/ticket/11874
* Rename `_fading` cursor property to `_itemActive` to reflect that this property now controls more than just fading.