### PR TITLE
CREATE_PROJECT: Rely on user-wide vcpkg integration for msvc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,9 @@ jobs:
           cd build-scummvm
           ../devtools/create_project/cmake/Debug/create_project.exe .. --msvc --enable-all-engines ${{ matrix.configflags }} --use-canonical-lib-names
           ls
-      - name: set SCUMMVM_LIBS env variable
+      - name: Install vcpkg integration
         run: |
-          echo "::set-env name=SCUMMVM_LIBS::${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}"
+          ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}/vcpkg integrate install
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.0
       - name: Build scummvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: lukka/run-vcpkg@v2
         id: runvcpkg
         with:
-          vcpkgGitCommitId: 2f7a104d4d6f1f3790db929f85a4086aa6973d7f
+          vcpkgGitCommitId: 0ff75ac80b9a3770afb3d2971c572628d80a631e
           vcpkgTriplet: '${{ matrix.triplet }}'
           vcpkgArguments: '${{ matrix.vcpkgPackages }}'
 #      - name: Upload libs

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -326,7 +326,7 @@ void MSBuildProvider::outputProjectSettings(std::ofstream &project, const std::s
 			// Copy data files to the build folder
 			project << "\t\t<PostBuildEvent>\n"
 			        << "\t\t\t<Message>Copy data files to the build folder</Message>\n"
-			        << "\t\t\t<Command>" << getPostBuildEvent(arch, setup) << "</Command>\n"
+			        << "\t\t\t<Command>" << getPostBuildEvent(setup, isRelease) << "</Command>\n"
 			        << "\t\t</PostBuildEvent>\n";
 		} else if (setup.tests) {
 			project << "\t\t<PreBuildEvent>\n"

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -357,9 +357,6 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	           << "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
 	           << "\t<PropertyGroup>\n"
 	           << "\t\t<_PropertySheetDisplayName>" << setup.projectDescription << "_Global</_PropertySheetDisplayName>\n"
-	           << "\t\t<ExecutablePath>$(" << LIBS_DEFINE << ")\\bin;$(" << LIBS_DEFINE << ")\\bin\\" << getMSVCArchName(arch) << ";$(" << LIBS_DEFINE << ")\\$(Configuration)\\bin;$(ExecutablePath)</ExecutablePath>\n"
-	           << "\t\t<LibraryPath>$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << ";$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << "\\$(Configuration);$(" << LIBS_DEFINE << ")\\lib;$(" << LIBS_DEFINE << ")\\$(Configuration)\\lib;$(LibraryPath)</LibraryPath>\n"
-	           << "\t\t<IncludePath>$(" << LIBS_DEFINE << ")\\include;$(" << LIBS_DEFINE << ")\\include\\" << (setup.useSDL2 ? "SDL2" : "SDL") << ";$(IncludePath)</IncludePath>\n"
 	           << "\t\t<OutDir>$(Configuration)" << getMSVCArchName(arch) << "\\</OutDir>\n"
 	           << "\t\t<IntDir>$(Configuration)" << getMSVCArchName(arch) << "\\$(ProjectName)\\</IntDir>\n"
 	           << "\t</PropertyGroup>\n"
@@ -367,7 +364,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	           << "\t\t<ClCompile>\n"
 	           << "\t\t\t<DisableLanguageExtensions>true</DisableLanguageExtensions>\n"
 	           << "\t\t\t<DisableSpecificWarnings>" << warnings << ";%(DisableSpecificWarnings)</DisableSpecificWarnings>\n"
-	           << "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";" << prefix << "\\engines;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
+	           << "\t\t\t<AdditionalIncludeDirectories>.;" << prefix << ";" << prefix << "\\engines;" << (setup.tests ? prefix + "\\test\\cxxtest;" : "") << "$(VcpkgCurrentInstalledDir)include\\" << (setup.useSDL2 ? "SDL2" : "SDL") << "%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>\n"
 	           << "\t\t\t<PreprocessorDefinitions>" << definesList << "%(PreprocessorDefinitions)</PreprocessorDefinitions>\n"
 	           << "\t\t\t<ExceptionHandling>" << ((setup.devTools || setup.tests) ? "Sync" : "") << "</ExceptionHandling>\n";
 

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -275,7 +275,7 @@ std::string MSVCProvider::getTestPreBuildEvent(const BuildSetup &setup) const {
 	return "&quot;$(SolutionDir)../../test/cxxtest/cxxtestgen.py&quot; --runner=ParenPrinter --no-std --no-eh -o &quot;$(SolutionDir)test_runner.cpp&quot;" + target;
 }
 
-std::string MSVCProvider::getPostBuildEvent(MSVC_Architecture arch, const BuildSetup &setup) const {
+std::string MSVCProvider::getPostBuildEvent(const BuildSetup &setup, bool isRelease) const {
 	std::string cmdLine = "";
 
 	cmdLine = "@echo off\n"
@@ -285,9 +285,10 @@ std::string MSVCProvider::getPostBuildEvent(MSVC_Architecture arch, const BuildS
 
 	cmdLine += (setup.useSDL2) ? "SDL2" : "SDL";
 
-	cmdLine += " &quot;$(VcpkgCurrentInstalledDir)lib/";
-	cmdLine += getMSVCArchName(arch);
-	cmdLine += "/$(Configuration)&quot; ";
+	cmdLine += " &quot;$(VcpkgCurrentInstalledDir)";
+	if (!isRelease)
+		cmdLine += "debug/";
+	cmdLine += "bin/&quot; ";
 
 	// Specify if installer needs to be built or not
 	cmdLine += (setup.createInstaller ? "1" : "0");

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -59,7 +59,7 @@ std::string MSVCProvider::getLibraryFromFeature(const char *feature, const Build
 		{      "sdl2", "SDL2.lib",                  "SDL2d.lib",     "winmm.lib imm32.lib version.lib setupapi.lib",    0 },
 		{      "libz", "zlib.lib",                  "zlibd.lib",     0,                                                 0 },
 		{       "mad", "mad.lib",                   0,               0,                                                 "libmad.lib" },
-		{   "fribidi", "libfribidi.lib",            0,               0,                                                 0 },
+		{   "fribidi", "fribidi.lib",               0,               0,                                                 0 },
 		{       "ogg", "ogg.lib",                   0,               0,                                                 "libogg_static.lib" },
 		{    "vorbis", "vorbis.lib vorbisfile.lib", 0,               0,                                                 "libvorbisfile_static.lib libvorbis_static.lib" },
 		{      "flac", "FLAC.lib",                  0,               0,                                                 "libFLAC_static.lib win_utf8_io_static.lib" },
@@ -285,7 +285,7 @@ std::string MSVCProvider::getPostBuildEvent(MSVC_Architecture arch, const BuildS
 
 	cmdLine += (setup.useSDL2) ? "SDL2" : "SDL";
 
-	cmdLine += " &quot;%" LIBS_DEFINE "%/lib/";
+	cmdLine += " &quot;$(VcpkgCurrentInstalledDir)lib/";
 	cmdLine += getMSVCArchName(arch);
 	cmdLine += "/$(Configuration)&quot; ";
 

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -118,7 +118,7 @@ protected:
 	 *
 	 * @return	The post build event.
 	 */
-	std::string getPostBuildEvent(MSVC_Architecture arch, const BuildSetup &setup) const;
+	std::string getPostBuildEvent(const BuildSetup &setup, bool isRelease) const;
 };
 
 } // namespace CreateProjectTool

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -150,13 +150,13 @@ void VisualStudioProvider::outputConfiguration(const BuildSetup &setup, std::ost
 	        << "\t\t</Configuration>\n";
 }
 
-void VisualStudioProvider::outputBuildEvents(std::ostream &project, const BuildSetup &setup, const MSVC_Architecture arch) {
+void VisualStudioProvider::outputBuildEvents(std::ostream &project, const BuildSetup &setup, bool isRelease) {
 	if (!setup.devTools && !setup.tests && setup.runBuildEvents) {
 		project << "\t\t\t<Tool\tName=\"VCPreBuildEventTool\"\n"
 		        << "\t\t\t\tCommandLine=\"" << getPreBuildEvent() << "\"\n"
 		        << "\t\t\t/>\n"
 		        << "\t\t\t<Tool\tName=\"VCPostBuildEventTool\"\n"
-		        << "\t\t\t\tCommandLine=\"" << getPostBuildEvent(arch, setup) << "\"\n"
+		        << "\t\t\t\tCommandLine=\"" << getPostBuildEvent(setup, isRelease) << "\"\n"
 		        << "\t\t\t/>\n";
 	}
 

--- a/devtools/create_project/visualstudio.h
+++ b/devtools/create_project/visualstudio.h
@@ -52,7 +52,7 @@ protected:
 
 	void outputConfiguration(std::ostream &project, const BuildSetup &setup, bool isRelease, const std::string &config, const MSVC_Architecture arch);
 	void outputConfiguration(const BuildSetup &setup, std::ostream &project, const std::string &toolConfig, const std::string &config, const MSVC_Architecture arch);
-	void outputBuildEvents(std::ostream &project, const BuildSetup &setup, const MSVC_Architecture arch);
+	void outputBuildEvents(std::ostream &project, const BuildSetup &setup, bool isRelease);
 };
 
 } // namespace CreateProjectTool


### PR DESCRIPTION
This change simplifies vcpkg usage, but will also require all msvc
devs to use vcpkg moving forward.

By removing `ExecutablePath`, `LibraryPath` and `IncludePath` we
can rely on user-wide vcpkg integration to set these up correctly.
We can then also use the `VcpkgCurrentInstalledDir` macro to
set up the few custom paths we need like the SDL2 include path.

The consequence of removing those paths is that it's no longer
possible to simply download a prebuilt archive of dependencies
and set the `SCUMMVM_LIBS` environment variable for msvc.

User-wide vcpkg integration can be set up with `vcpkg integrate install`,
but I expect that people familiar with vcpkg will already have that setup.

### Build instructions after this change

1. Clone the vcpkg repository in a place separately from ScummVM if you don't have it yet:

```
https://github.com/microsoft/vcpkg.git
```

2. Open powershell in the vcpkg folder and execute the following commands:

```
./bootstrap-vcpkg.bat
./vcpkg integrate install
```

3. Now install the dependencies for ScummVM by executing the following commands:

```
./vcpkg install --triplet x86-windows curl faad2 fluidsynth freetype fribidi libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib discord-rpc
./vcpkg install --triplet x64-windows curl faad2 fluidsynth freetype fribidi libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib discord-rpc
```

4. Go to the ScummVM folder, compile create_project and run `create_msvc.bat`

5. Open scummvm.sln with your preferred version of Visual Studio and compile the solution.