### PR TITLE
SCUMM: Add music override for HE games

### DIFF
--- a/engines/scumm/he/sound_he.cpp
+++ b/engines/scumm/he/sound_he.cpp
@@ -807,7 +807,12 @@ void SoundHE::tryLoadSoundOverride(int soundID, Audio::RewindableAudioStream **s
 #endif
 	};
 
-	for (size_t i = 0; i < sizeof(formats) / sizeof(formats[0]); i++) {
+	STATIC_ASSERT(
+	    ARRAYSIZE(formats) == ARRAYSIZE(formatDecoders),
+	    formats_formatDecoders_must_have_same_size
+	);
+
+	for (int i = 0; i < ARRAYSIZE(formats); i++) {
 		debug(5, "tryLoadSoundOverride: %d %s", soundID, formats[i]);
 
 		Common::File soundFileOverride;

--- a/engines/scumm/he/sound_he.cpp
+++ b/engines/scumm/he/sound_he.cpp
@@ -716,6 +716,18 @@ void SoundHE::playHESound(int soundID, int heOffset, int heChannel, int heFlags,
 			_overrideFreq = 0;
 		}
 
+		Common::File musicFileOverride;
+		Common::String mfoBuf(Common::String::format("music%d.wav", soundID));
+
+		if (musicFileOverride.exists(mfoBuf) && musicFileOverride.open(mfoBuf)) {
+			musicFileOverride.seek(0, SEEK_SET);
+			Common::SeekableReadStream *oStr =
+			    musicFileOverride.readStream(musicFileOverride.size());
+			musicFileOverride.close();
+
+			stream = Audio::makeWAVStream(oStr, DisposeAfterUse::YES);
+		}
+
 		_vm->setHETimer(heChannel + 4);
 		_heChannel[heChannel].sound = soundID;
 		_heChannel[heChannel].priority = priority;
@@ -733,7 +745,9 @@ void SoundHE::playHESound(int soundID, int heOffset, int heChannel, int heFlags,
 
 		_mixer->stopHandle(_heSoundChannels[heChannel]);
 
-		stream = Audio::makeRawStream(ptr + heOffset + 8, size, rate, flags, DisposeAfterUse::NO);
+		if (!stream) {
+			stream = Audio::makeRawStream(ptr + heOffset + 8, size, rate, flags, DisposeAfterUse::NO);
+		}
 		_mixer->playStream(type, &_heSoundChannels[heChannel],
 						Audio::makeLoopingAudioStream(stream, (heFlags & 1) ? 0 : 1), soundID);
 	}

--- a/engines/scumm/he/sound_he.h
+++ b/engines/scumm/he/sound_he.h
@@ -25,6 +25,7 @@
 
 #include "common/scummsys.h"
 #include "scumm/sound.h"
+#include "audio/audiostream.h"
 
 namespace Scumm {
 
@@ -85,6 +86,9 @@ public:
 
 protected:
 	void processSoundQueues() override;
+
+private:
+	void tryLoadSoundOverride(int soundID, Audio::RewindableAudioStream **stream);
 };
 
 


### PR DESCRIPTION
This change allows the user to replace the in-game music
with high-quality audio files.

When the game loads a sound ID it will check if the file
`music{SOUND_ID}.wav` exists. If it does the engine will
use this file instead of the original one. If it doesn't the
original sound is used.

Here is an example of the directory structure for
Putt-Putt Saves the Zoo and high-quality soundtrack.
```
puttzoo
|-- PUTTZOO.HE0
|-- PUTTZOO.HE1
|-- PUTTZOO.HE2
|-- PUTTZOO.HE3
|-- PUTTZOO.HE4
|-- PUTTZOO.HE4
|-- music8007.wav
|-- music8008.wav
|-- music8027.wav
|-- music8028.wav
|-- music8029.wav
|-- music8030.wav
|-- music8031.wav
|-- music8032.wav
|-- music8033.wav
|-- music8034.wav
|-- music8035.wav
|-- music8036.wav
|-- music8038.wav
|-- music8052.wav
|-- music8053.wav
|-- music8054.wav
|-- music8092.wav
|-- music8096.wav
|-- music8097.wav
+-- music8098.wav
```
