### PR TITLE
SCI: Hebrew - fix save games encoding

### DIFF
--- a/engines/sci/engine/file.cpp
+++ b/engines/sci/engine/file.cpp
@@ -23,6 +23,7 @@
 #include "common/savefile.h"
 #include "common/stream.h"
 #include "common/memstream.h"
+#include "common/unicode-bidi.h"
 
 #include "sci/sci.h"
 #include "sci/engine/file.h"
@@ -333,9 +334,15 @@ bool fillSavegameDesc(const Common::String &filename, SavegameDesc &desc) {
 	if (meta.name.lastChar() == '\n')
 		meta.name.deleteLastChar();
 
+	Common::String nameString = meta.name;
+	if (g_sci->getLanguage() == Common::HE_ISR) {
+		Common::U32String nameU32String = meta.name.decode(Common::kUtf8);
+		nameString = nameU32String.encode(Common::kWindows1255);
+	}
+	
 	// At least Phant2 requires use of strncpy, since it creates save game
 	// names of exactly kMaxSaveNameLength
-	strncpy(desc.name, meta.name.c_str(), kMaxSaveNameLength);
+	strncpy(desc.name, nameString.c_str(), kMaxSaveNameLength);
 
 	return true;
 }

--- a/engines/sci/engine/kfile.cpp
+++ b/engines/sci/engine/kfile.cpp
@@ -30,6 +30,7 @@
 #include "common/system.h"
 #include "common/translation.h"
 #include "common/memstream.h"
+#include "common/str-enc.h"
 
 #include "gui/saveload.h"
 
@@ -1087,6 +1088,11 @@ reg_t kSaveGame(EngineState *s, int argc, reg_t *argv) {
 		if (argv[2].isNull())
 			error("kSaveGame: called with description being NULL");
 		game_description = s->_segMan->getString(argv[2]);
+		if (g_sci->getLanguage() == Common::HE_ISR) {
+			Common::U32String u32string = game_description.decode(Common::kWindows1255);
+			game_description = u32string.encode(Common::kUtf8);
+		};
+
 
 		debug(3, "kSaveGame(%s,%d,%s,%s)", game_id.c_str(), virtualId, game_description.c_str(), version.c_str());
 


### PR DESCRIPTION
Make sure that Hebrew save games are using UTF8 (otherwise, when saving
in Hebrew it works well from original Sierra save/restore dialogs, but
when loading from ScummVM's dialog, it looks garbled)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
