### PR TITLE
I18N: Always call BiDi algorithm for U32String

### DIFF
--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -412,9 +412,6 @@ bool TranslationManager::checkHeader(File &in) {
 }
 
 U32String TranslationManager::convertBiDiString(const U32String &input) {
-	if (getCurrentLanguage() != "he")		//TODO: modify when we'll support other RTL languages, such as Arabic and Farsi
-		return input;
-
 	return Common::convertBiDiU32String(input).visual;
 }
 

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -411,10 +411,6 @@ bool TranslationManager::checkHeader(File &in) {
 	return true;
 }
 
-U32String TranslationManager::convertBiDiString(const U32String &input) {
-	return Common::convertBiDiU32String(input).visual;
-}
-
 } // End of namespace Common
 
 #endif // USE_TRANSLATION

--- a/common/translation.h
+++ b/common/translation.h
@@ -169,13 +169,6 @@ public:
 	 */
 	String getCurrentLanguage() const;
 
-	/*
-	 * Wrapper for GNU FriBidi implementation of the Unicode Bidirectional Algorithm
-	 * For LTR (Left To Right) languages, returns the original input
-	 * For RTL (Right To Left) languages, returns visual representation of a logical single-line input
-	 */
-	U32String convertBiDiString(const U32String &input);
-
 private:
 	/**
 	 * Tries to find the given language or a derivate of it.

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -27,6 +27,7 @@
 #include "common/unzip.h"
 #include "common/tokenizer.h"
 #include "common/translation.h"
+#include "common/unicode-bidi.h"
 
 #include "graphics/conversion.h"
 #include "graphics/cursorman.h"
@@ -1017,8 +1018,8 @@ void ThemeEngine::drawDDText(TextData type, TextColor color, const Common::Rect 
 		restoreBackground(dirty);
 
 	_vectorRenderer->setFgColor(_textColors[color]->r, _textColors[color]->g, _textColors[color]->b);
-#ifdef USE_TRANSLATION
-	_vectorRenderer->drawString(_texts[type]->_fontPtr, TransMan.convertBiDiString(text), area, alignH, alignV, deltax, ellipsis, dirty);
+#ifdef USE_FRIBIDI
+	_vectorRenderer->drawString(_texts[type]->_fontPtr, Common::convertBiDiU32String(text), area, alignH, alignV, deltax, ellipsis, dirty);
 #else
 	_vectorRenderer->drawString(_texts[type]->_fontPtr, text, area, alignH, alignV, deltax, ellipsis, dirty);
 #endif


### PR DESCRIPTION
U32String can contain characters from all languages, without relation
to the GUI's language. Therefore, we need to always call it.

Use case:
In Hebrew SQ3, when using the game's original save/restore dialogs, it's
possible to give save games Hebrew names.
What happens when we then use ScummVM's load dialog?
- If ScummVM's GUI language is Hebrew, it's calling BiDi algo, and
  the text direction is OK.
- However, if ScummVM's GUI language is English, before this commit it
  didn't call the BiDi algo, and the text was reversed.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
