### PR TITLE
MOHAWK: Fix game "Just Grandma and Me" german and french version crash

### DIFF
--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -298,6 +298,7 @@ void MohawkEngine_LivingBooks::pauseEngineIntern(bool pause) {
 }
 
 void MohawkEngine_LivingBooks::loadBookInfo(const Common::String &filename) {
+	_bookInfoFile.allowNonEnglishCharacters();
 	if (!_bookInfoFile.loadFromFile(filename))
 		error("Could not open %s as a config file", filename.c_str());
 


### PR DESCRIPTION
The german and french version of "Just Grandma and Me" (Mohawk engine) have the special characters "ç" and "ö" in their config files. This causes ScummVM to crash when trying to start the game in german or french. Allowing non english chars in config files for Living Books games fixes this issue.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
