### PR TITLE
IPHONE: Fix building with recent cross-compiled SDK

### DIFF
--- a/configure
+++ b/configure
@@ -3909,14 +3909,18 @@ EOF
 	if test "$_sdlnet" = yes ; then
 		set_var SDL_NET_LIBS   "$SDL2_NET_LIBS"
 		set_var SDL_NET_CFLAGS "$SDL2_NET_CFLAGS"
+		add_line_to_config_mk "SDL_NET_MAJOR = 2"
 	else
 		cat > $TMPC << EOF
 #include "SDL_net.h"
 int main(int argc, char *argv[]) { SDLNet_Init(); return 0; }
 EOF
 		cc_check $SDL1_NET_LIBS $LIBS $INCLUDES $SDL1_NET_CFLAGS && _sdlnet=yes
-		set_var SDL_NET_LIBS   "$SDL1_NET_LIBS"
-		set_var SDL_NET_CFLAGS "$SDL1_NET_CFLAGS"
+		if test "$_sdlnet" = yes ; then
+			set_var SDL_NET_LIBS   "$SDL1_NET_LIBS"
+			set_var SDL_NET_CFLAGS "$SDL1_NET_CFLAGS"
+			add_line_to_config_mk "SDL_NET_MAJOR = 1"
+		fi
 	fi
 
 	if test "$_sdlnet" = yes ; then
@@ -3924,6 +3928,7 @@ EOF
 		prepend_var LIBS "$SDL_NET_LIBS"
 		append_var INCLUDES "$SDL_NET_CFLAGS"
 	fi
+	define_in_config_if_no "$_sdl" 'WITHOUT_SDL'
 	define_in_config_if_yes "$_sdlnet" 'USE_SDL_NET'
 	echo "$_sdlnet"
 fi

--- a/configure
+++ b/configure
@@ -3482,7 +3482,7 @@ if test -n "$_host"; then
 			_timidity=no
 			;;
 		ios7)
-			append_var DEFINES "-DIPHONE"
+			append_var DEFINES "-DIPHONE -DIPHONE_IOS7 -DIPHONE_SANDBOXED"
 			_backend="ios7"
 			_seq_midi=no
 			_timidity=no

--- a/ports.mk
+++ b/ports.mk
@@ -350,7 +350,7 @@ endif # WITHOUT_SDL
 endif # USE_SDL_NET
 
 ifdef USE_LIBCURL
-OSX_STATIC_LIBS += -lcurl
+OSX_STATIC_LIBS += -lcurl -framework Security
 endif
 
 ifdef USE_FREETYPE2

--- a/ports.mk
+++ b/ports.mk
@@ -322,22 +322,32 @@ endif
 	cp $(srcdir)/dists/ios7/Images.xcassets/LaunchImage.launchimage/ScummVM-splash-2208x1242.png $(bundle_name)/LaunchImage-800-Landscape-736h@3x.png
 	cp $(srcdir)/dists/ios7/Images.xcassets/LaunchImage.launchimage/ScummVM-splash-750x1334.png $(bundle_name)/LaunchImage-800-667h@2x.png
 
-# Location of static libs for the iPhone
-ifneq ($(BACKEND), iphone)
-ifneq ($(BACKEND), ios7)
-# Static libaries, used for the scummvm-static and iphone targets
-OSX_STATIC_LIBS := `$(SDLCONFIG) --prefix=$(STATICLIBPATH) --static-libs`
+# Special SDL_Net library without SDL (iPhone)
 ifdef USE_SDL_NET
+ifdef WITHOUT_SDL
+
+ifeq ($(SDL_NET_MAJOR),1)
+OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libSDL_net.a
+else
+ifeq ($(SDL_NET_MAJOR),2)
+OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libSDL2_net.a
+endif
+endif
+
+else # WITHOUT_SDL
+
+# Static libaries, used for the scummvm-static target
+OSX_STATIC_LIBS := `$(SDLCONFIG) --prefix=$(STATICLIBPATH) --static-libs`
 ifdef USE_SDL2
 OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libSDL2_net.a
 else
 OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libSDL_net.a
 endif
-endif
 # With sdl2-config we don't always get the OpenGL framework
 OSX_STATIC_LIBS += -framework OpenGL
-endif
-endif
+
+endif # WITHOUT_SDL
+endif # USE_SDL_NET
 
 ifdef USE_LIBCURL
 OSX_STATIC_LIBS += -lcurl


### PR DESCRIPTION
This PR contains several little fixes to the Makefile based build system which are needed for my iPhone toolchain.
- defines are updated to match what's done in create_project for Xcode in ios7 platform
- When configure script don't find SDL but SDL_Net (when it is patched to not depend on SDL), don't try to link with SDL.
- Link against Security framework when linking with curl statically, in the case curl uses DarwinSSL.

These changes shouldn't affect existing buildbot toolchain except maybe the first one.