### PR TITLE
BACKENDS: Use Common::U32String for OSystem::setWindowCaption

### DIFF
--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -581,9 +581,7 @@ void OSystem_Android::quit() {
 	pthread_join(_timer_thread, 0);
 }
 
-void OSystem_Android::setWindowCaption(const char *caption) {
-	ENTER("%s", caption);
-
+void OSystem_Android::setWindowCaption(const Common::U32String &caption) {
 	JNI::setWindowCaption(caption);
 }
 

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -124,7 +124,7 @@ public:
 
 	virtual void quit() override;
 
-	virtual void setWindowCaption(const char *caption) override;
+	virtual void setWindowCaption(const Common::U32String &caption) override;
 
 	virtual Audio::Mixer *getMixer() override;
 	virtual void getTimeAndDate(TimeDate &t) const override;

--- a/backends/platform/android/jni-android.cpp
+++ b/backends/platform/android/jni-android.cpp
@@ -340,9 +340,9 @@ bool JNI::isConnectionLimited() {
 	return limited;
 }
 
-void JNI::setWindowCaption(const Common::String &caption) {
+void JNI::setWindowCaption(const Common::U32String &caption) {
 	JNIEnv *env = JNI::getEnv();
-	jstring java_caption = convertToJString(env, caption.decode(Common::kISO8859_1));
+	jstring java_caption = convertToJString(env, caption);
 
 	env->CallVoidMethod(_jobj, _MID_setWindowCaption, java_caption);
 

--- a/backends/platform/android/jni-android.h
+++ b/backends/platform/android/jni-android.h
@@ -58,7 +58,7 @@ public:
 
 	static void setReadyForEvents(bool ready);
 
-	static void setWindowCaption(const Common::String &caption);
+	static void setWindowCaption(const Common::U32String &caption);
 	static void getDPI(float *values);
 	static void displayMessageOnOSD(const Common::U32String &msg);
 	static bool openUrl(const Common::String &url);

--- a/backends/platform/android3d/android.cpp
+++ b/backends/platform/android3d/android.cpp
@@ -490,9 +490,7 @@ void OSystem_Android::quit() {
 	dynamic_cast<AndroidGraphicsManager *>(_graphicsManager)->deinitSurface();
 }
 
-void OSystem_Android::setWindowCaption(const char *caption) {
-	ENTER("%s", caption);
-
+void OSystem_Android::setWindowCaption(const Common::U32String &caption) {
 	JNI::setWindowCaption(caption);
 }
 

--- a/backends/platform/android3d/android.h
+++ b/backends/platform/android3d/android.h
@@ -175,7 +175,7 @@ public:
 
 	virtual void quit();
 
-	virtual void setWindowCaption(const char *caption);
+	virtual void setWindowCaption(const Common::U32String &caption);
 	virtual void showVirtualKeyboard(bool enable);
 
 	virtual Audio::Mixer *getMixer();

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -170,7 +170,7 @@ public:
 
   // Set a window caption or any other comparable status display to the
   // given value.
-  void setWindowCaption(const char *caption);
+  void setWindowCaption(const Common::U32String &caption);
 
   // Modulatized backend
   Audio::Mixer *getMixer() { return _mixer; }

--- a/backends/platform/dc/dcmain.cpp
+++ b/backends/platform/dc/dcmain.cpp
@@ -37,7 +37,7 @@
 
 
 Icon icon;
-const char *gGameName;
+const char gGameName[32];
 
 
 OSystem_Dreamcast::OSystem_Dreamcast()
@@ -143,9 +143,9 @@ bool DCCDManager::isPlaying() const {
 	return getCdState() == 3;
 }
 
-void OSystem_Dreamcast::setWindowCaption(const char *caption)
+void OSystem_Dreamcast::setWindowCaption(const Common::U32String &caption)
 {
-  gGameName = caption;
+  Common::strlcpy(gGameName, cap.encode(Common::kISO8859_1).c_str(), 32);
 }
 
 void OSystem_Dreamcast::quit() {

--- a/backends/platform/dc/vmsave.cpp
+++ b/backends/platform/dc/vmsave.cpp
@@ -340,7 +340,7 @@ public:
 
 void OutVMSave::finalize()
 {
-  extern const char *gGameName;
+  extern const char gGameName[32];
   extern Icon icon;
 
   if (committed >= _pos)

--- a/backends/platform/maemo/maemo.cpp
+++ b/backends/platform/maemo/maemo.cpp
@@ -99,21 +99,8 @@ void OSystem_SDL_Maemo::setXWindowName(const char *caption) {
 	}
 }
 
-void OSystem_SDL_Maemo::setWindowCaption(const char *caption) {
-	Common::String cap;
-	byte c;
-
-	// The string caption is supposed to be in LATIN-1 encoding.
-	// SDL expects UTF-8. So we perform the conversion here.
-	while ((c = *(const byte *)caption++)) {
-		if (c < 0x80)
-			cap += c;
-		else {
-			cap += 0xC0 | (c >> 6);
-			cap += 0x80 | (c & 0x3F);
-		}
-	}
-
+void OSystem_SDL_Maemo::setWindowCaption(const Common::U32String &caption) {
+	Common::String cap = caption.encode();
 	_window->setWindowCaption(cap);
 
 	Common::String cap2("ScummVM - "); // 2 lines in OS2008 task switcher, set first line

--- a/backends/platform/maemo/maemo.h
+++ b/backends/platform/maemo/maemo.h
@@ -40,7 +40,7 @@ public:
 	virtual void initBackend() override;
 	virtual void quit() override;
 	virtual void fatalError() override;
-	virtual void setWindowCaption(const char *caption) override;
+	virtual void setWindowCaption(const Common::U32String &caption) override;
 	virtual Common::HardwareInputSet *getHardwareInputSet() override;
 	virtual Common::KeymapArray getGlobalKeymaps() override;
 	virtual Common::KeymapperDefaultBindings *getKeymapperDefaultBindings() override;

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -470,21 +470,8 @@ void OSystem_SDL::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) 
 
 }
 
-void OSystem_SDL::setWindowCaption(const char *caption) {
-	Common::String cap;
-	byte c;
-
-	// The string caption is supposed to be in LATIN-1 encoding.
-	// SDL expects UTF-8. So we perform the conversion here.
-	while ((c = *(const byte *)caption++)) {
-		if (c < 0x80)
-			cap += c;
-		else {
-			cap += 0xC0 | (c >> 6);
-			cap += 0x80 | (c & 0x3F);
-		}
-	}
-
+void OSystem_SDL::setWindowCaption(const Common::U32String &caption) {
+	Common::String cap = caption.encode();
 	_window->setWindowCaption(cap);
 }
 

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -78,7 +78,7 @@ public:
 	virtual bool setTextInClipboard(const Common::U32String &text) override;
 #endif
 
-	virtual void setWindowCaption(const char *caption) override;
+	virtual void setWindowCaption(const Common::U32String &caption) override;
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0) override;
 	virtual uint32 getMillis(bool skipRecord = false) override;
 	virtual void delayMillis(uint msecs) override;

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -257,10 +257,6 @@ void OSystem_Wii::deleteMutex(MutexRef mutex) {
 	free(mutex);
 }
 
-void OSystem_Wii::setWindowCaption(const char *caption) {
-	printf("window caption: %s\n", caption);
-}
-
 Audio::Mixer *OSystem_Wii::getMixer() {
 	assert(_mixer);
 	return _mixer;

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -206,8 +206,6 @@ public:
 
 	virtual void quit() override;
 
-	virtual void setWindowCaption(const char *caption) override;
-
 	virtual Audio::Mixer *getMixer() override;
 	virtual FilesystemFactory *getFilesystemFactory() override;
 	virtual void getTimeAndDate(TimeDate &t) const override;

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -237,7 +237,7 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 	if (caption.empty())
 		caption = target;
 	if (!caption.empty())	{
-		system.setWindowCaption(caption.c_str());
+		system.setWindowCaption(caption.decode());
 	}
 
 	//
@@ -360,7 +360,7 @@ static void setupGraphics(OSystem &system) {
 	GUI::GuiManager::instance();
 
 	// Set initial window caption
-	system.setWindowCaption(gScummVMFullVersion);
+	system.setWindowCaption(Common::U32String(gScummVMFullVersion));
 
 	// Clear the main screen
 	system.fillScreen(0);

--- a/common/system.h
+++ b/common/system.h
@@ -1467,13 +1467,9 @@ public:
 	 * Set a window caption or any other comparable status display to the
 	 * given value.
 	 *
-	 * The caption must be a pure ISO LATIN 1 string. Passing a string
-	 * with a different encoding may lead to unexpected behavior,
-	 * even crashes.
-	 *
-	 * @param caption The window caption to use, as an ISO LATIN 1 string.
+	 * @param caption The window caption to use.
 	 */
-	virtual void setWindowCaption(const char *caption) {}
+	virtual void setWindowCaption(const Common::U32String &caption) {}
 
 	/**
 	 * Display a message in an 'on-screen display'.

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -417,7 +417,7 @@ void GUIErrorMessage(const Common::String &msg, const char *url) {
 }
 
 void GUIErrorMessage(const Common::U32String &msg, const char *url) {
-	g_system->setWindowCaption("Error");
+	g_system->setWindowCaption(_("Error"));
 	g_system->beginGFXTransaction();
 		initCommonGFX();
 		g_system->initSize(320, 200);

--- a/engines/icb/surface_manager.cpp
+++ b/engines/icb/surface_manager.cpp
@@ -192,7 +192,7 @@ unsigned int _surface_manager::Init_direct_draw() {
 	// Debug info
 	Zdebug("*SURFACE_MANAGER* Initalizing the SDL video interface");
 
-	g_system->setWindowCaption("In Cold Blood (C)2000 Revolution Software Ltd");
+	g_system->setWindowCaption(Common::U32String("In Cold Blood (C)2000 Revolution Software Ltd"));
 	initGraphics(640, 480, nullptr);
 
 	_zb = new TinyGL::FrameBuffer(640, 480, g_system->getScreenFormat()); // TODO: delete

--- a/engines/scumm/he/script_v100he.cpp
+++ b/engines/scumm/he/script_v100he.cpp
@@ -1721,18 +1721,12 @@ void ScummEngine_v100he::o100_setSystemMessage() {
 	switch (subOp) {
 	case 80: // Set Window Caption
 		// TODO: The 'name' string can contain non-ASCII data. This can lead to
-		// problems, because (a) the encoding used for "name" is not clear,
-		// (b) OSystem::setWindowCaption only supports ASCII. As a result, odd
-		// behavior can occur, from strange wrong titles, up to crashes (happens
-		// under Mac OS X).
+		// problems, because the encoding used for "name" is not clear,
 		//
 		// Possible fixes/workarounds:
 		// - Simply stop using this. It's a rather unimportant "feature" anyway.
-		// - Try to translate the text to ASCII.
-		// - Refine OSystem to accept window captions that are non-ASCII, e.g.
-		//   by enhancing all backends to deal with UTF-8 data. Of course, then
-		//   one still would have to convert 'name' to the correct encoding.
-		//_system->setWindowCaption((const char *)name);
+		// - Try to translate the text to UTF-32.
+		//_system->setWindowCaption(Common::U32String((const char *)name));
 		break;
 	case 131: // Set Version
 		debug(1,"o100_setSystemMessage: (%d) %s", subOp, name);

--- a/engines/scumm/he/script_v70he.cpp
+++ b/engines/scumm/he/script_v70he.cpp
@@ -490,18 +490,12 @@ void ScummEngine_v70he::o70_setSystemMessage() {
 		break;
 	case 243: // Set Window Caption
 		// TODO: The 'name' string can contain non-ASCII data. This can lead to
-		// problems, because (a) the encoding used for "name" is not clear,
-		// (b) OSystem::setWindowCaption only supports ASCII. As a result, odd
-		// behavior can occur, from strange wrong titles, up to crashes (happens
-		// under Mac OS X).
+		// problems, because the encoding used for "name" is not clear.
 		//
 		// Possible fixes/workarounds:
 		// - Simply stop using this. It's a rather unimportant "feature" anyway.
-		// - Try to translate the text to ASCII.
-		// - Refine OSystem to accept window captions that are non-ASCII, e.g.
-		//   by enhancing all backends to deal with UTF-8 data. Of course, then
-		//   one still would have to convert 'name' to the correct encoding.
-		//_system->setWindowCaption((const char *)name);
+		// - Try to translate the text to UTF-32.
+		//_system->setWindowCaption(Common::U32String((const char *)name));
 		break;
 	default:
 		error("o70_setSystemMessage: default case %d", subOp);

--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -1993,18 +1993,12 @@ void ScummEngine_v72he::o72_setSystemMessage() {
 		break;
 	case 243: // Set Window Caption
 		// TODO: The 'name' string can contain non-ASCII data. This can lead to
-		// problems, because (a) the encoding used for "name" is not clear,
-		// (b) OSystem::setWindowCaption only supports ASCII. As a result, odd
-		// behavior can occur, from strange wrong titles, up to crashes (happens
-		// under Mac OS X).
+		// problems, because the encoding used for "name" is not clear.
 		//
 		// Possible fixes/workarounds:
 		// - Simply stop using this. It's a rather unimportant "feature" anyway.
-		// - Try to translate the text to ASCII.
-		// - Refine OSystem to accept window captions that are non-ASCII, e.g.
-		//   by enhancing all backends to deal with UTF-8 data. Of course, then
-		//   one still would have to convert 'name' to the correct encoding.
-		//_system->setWindowCaption((const char *)name);
+		// - Try to translate the text to UTF-32.
+		//_system->setWindowCaption(Common::U32String((const char *)name));
 		break;
 	default:
 		error("o72_setSystemMessage: default case %d", subOp);

--- a/engines/sword2/maketext.cpp
+++ b/engines/sword2/maketext.cpp
@@ -674,7 +674,7 @@ void Sword2Engine::initializeFontResourceFlags() {
 	else
 		textLine = (char *)fetchTextLine(textFile, 54) + 2;
 
-	_system->setWindowCaption(textLine);
+	_system->setWindowCaption(Common::U32String(textLine));
 	_resman->closeResource(TEXT_RES);
 }
 


### PR DESCRIPTION
This is in draft mode until PR #2586 is merged.