### PR TITLE
SCUMM: COMI: Fix #4635/#10473 and #4391 (iMUSE Digital)

### DIFF
--- a/engines/scumm/imuse_digi/dimuse.cpp
+++ b/engines/scumm/imuse_digi/dimuse.cpp
@@ -218,32 +218,67 @@ void IMuseDigital::callback() {
 				return;
 
 			if (track->volFadeUsed) {
-				if (track->vol == track->volFadeDest) // Sanity check
-					track->volFadeUsed = false;
+				if (_vm->_game.id == GID_CMI) {
+					if (track->vol == track->volFadeDest) // Sanity check
+						track->volFadeUsed = false;
 
-				if (track->volFadeStep < 0) { // Fade out
-					if (track->vol > track->volFadeDest) {
-						track->vol += track->volFadeStep;
-						if (track->vol <= track->volFadeDest) {
-							track->vol = track->volFadeDest;
-							track->volFadeUsed = false;
-						}
-						if (track->vol == 0) {
-							// Fade out complete -> remove this track
-							flushTrack(track);
-							continue;
+					if (track->volFadeStep < 0) { // Fade out
+						if (track->vol > track->volFadeDest) {
+							int tempVolume = transformVolumeEqualPowToLinear(track->vol, 1); // Equal power to linear...
+							tempVolume += track->volFadeStep; // Remove step...
+							track->vol = transformVolumeLinearToEqualPow(tempVolume, 1); // Linear to equal power...
+
+							if (track->vol <= track->volFadeDest) {
+								track->vol = track->volFadeDest;
+								track->volFadeUsed = false;
+								flushTrack(track);
+								continue;
+							}
+							if (track->vol == 0) {
+								// Fade out complete -> remove this track
+								flushTrack(track);
+								continue;
+							}
 						}
 					}
-				} else if (track->volFadeStep > 0) { // Fade in
-					if (track->vol < track->volFadeDest) {
-						track->vol += track->volFadeStep;
-						if (track->vol >= track->volFadeDest) {
-							track->vol = track->volFadeDest;
-							track->volFadeUsed = false;
+					else if (track->volFadeStep > 0) { // Fade in
+						if (track->vol < track->volFadeDest) {
+							int tempVolume = transformVolumeEqualPowToLinear(track->vol, 1); // Equal power to linear...
+							tempVolume += track->volFadeStep; // Add step...
+							track->vol = transformVolumeLinearToEqualPow(tempVolume, 1); // Linear to equal power...
+							if (track->vol >= track->volFadeDest) {
+								track->vol = track->volFadeDest;
+								track->volFadeUsed = false;
+							}
 						}
 					}
 				}
- 				debug(5, "Fade: sound(%d), Vol(%d)", track->soundId, track->vol / 1000);
+				else {
+					if (track->volFadeStep < 0) {
+						if (track->vol > track->volFadeDest) {
+							track->vol += track->volFadeStep; 
+							if (track->vol < track->volFadeDest) {
+								track->vol = track->volFadeDest;
+								track->volFadeUsed = false;
+							}
+							if (track->vol == 0) {
+								// Fade out complete -> remove this track
+								flushTrack(track);
+								continue;
+							}
+						}
+					}
+					else if (track->volFadeStep > 0) {
+						if (track->vol < track->volFadeDest) {
+							track->vol += track->volFadeStep;
+							if (track->vol > track->volFadeDest) {
+								track->vol = track->volFadeDest;
+								track->volFadeUsed = false;
+							}
+						}
+					}
+				}
+ 				debug(5, "Fade: sound(%d), Vol(%d) in track(%d)", track->soundId, track->vol / 1000, track->trackId);
 			}
 
 			if (!track->souStreamUsed) {
@@ -410,35 +445,30 @@ void IMuseDigital::switchToNextRegion(Track *track) {
 			int fadeDelay = (60 * _sound->getJumpFade(soundDesc, jumpId)) / 1000;
 			debug(5, "SwToNeReg(trackId:%d) - sound(%d) match hookId", track->trackId, track->soundId);
 			if (fadeDelay) {
-				debug(5, "SwToNeReg(trackId:%d) - call cloneToFadeOutTrack(delay:%d)", track->trackId, fadeDelay);
-				Track *fadeTrack = cloneToFadeOutTrack(track, fadeDelay);
-				if (fadeTrack) {
-					fadeTrack->dataOffset = _sound->getRegionOffset(fadeTrack->soundDesc, fadeTrack->curRegion);
-					fadeTrack->regionOffset = 0;
-					debug(5, "SwToNeReg(trackId:%d) - sound(%d) faded track, select region %d, curHookId: %d", fadeTrack->trackId, fadeTrack->soundId, fadeTrack->curRegion, fadeTrack->curHookId);
-					fadeTrack->curHookId = 0;
-
-					// Fade in the next region if the fade out track from
-					// the previous region has been allocated
-					track->volFadeDest = 127 * 1000;
-					track->vol = 25000; // Empirical value which works well for now, accounting for the fade track apparent desync
-					track->volFadeDelay = fadeDelay;
-					track->volFadeStep = (track->volFadeDest - track->vol) * 60 * (1000 / _callbackFps) / (1000 * fadeDelay);
-					track->volFadeUsed = true;
-				}
-
-				
+				// COMI specific: jump to new region without true crossfades; this is not true to the original interpreter,
+				// but crossfading between regions in the correct way requires an implementation which is more complex.
+				// Leaving as is, for now.
+				if (_vm->_game.id != GID_CMI) {
+					debug(5, "SwToNeReg(trackId:%d) - call cloneToFadeOutTrack(delay:%d)", track->trackId, fadeDelay);
+					Track *fadeTrack = cloneToFadeOutTrack(track, fadeDelay);
+					if (fadeTrack) {
+						fadeTrack->dataOffset = _sound->getRegionOffset(fadeTrack->soundDesc, fadeTrack->curRegion);
+						fadeTrack->regionOffset = 0;
+						debug(5, "SwToNeReg(trackId:%d) - sound(%d) faded track, select region %d, curHookId: %d", fadeTrack->trackId, fadeTrack->soundId, fadeTrack->curRegion, fadeTrack->curHookId);
+						fadeTrack->curHookId = 0;
+					}
+				}	
 			}
 			track->curRegion = region;
 			debug(5, "SwToNeReg(trackId:%d) - sound(%d) jump to region %d, curHookId: %d", track->trackId, track->soundId, track->curRegion, track->curHookId);
 			track->curHookId = 0;
+			
 		} else {
 			debug(5, "SwToNeReg(trackId:%d) - Normal switch region, sound(%d), hookId(%d)", track->trackId, track->soundId, track->curHookId);
 		}
 	} else {
 		debug(5, "SwToNeReg(trackId:%d) - Normal switch region, sound(%d), hookId(%d)", track->trackId, track->soundId, track->curHookId);
 	}
-
 	debug(5, "SwToNeReg(trackId:%d) - sound(%d), select region %d", track->trackId, track->soundId, track->curRegion);
 	track->dataOffset = _sound->getRegionOffset(soundDesc, track->curRegion);
 	track->regionOffset = 0;

--- a/engines/scumm/imuse_digi/dimuse.cpp
+++ b/engines/scumm/imuse_digi/dimuse.cpp
@@ -240,8 +240,7 @@ void IMuseDigital::callback() {
 								continue;
 							}
 						}
-					}
-					else if (track->volFadeStep > 0) { // Fade in
+					} else if (track->volFadeStep > 0) { // Fade in
 						if (track->vol < track->volFadeDest) {
 							int tempVolume = transformVolumeEqualPowToLinear(track->vol, 1); // Equal power to linear...
 							tempVolume += track->volFadeStep; // Add step...
@@ -252,8 +251,7 @@ void IMuseDigital::callback() {
 							}
 						}
 					}
-				}
-				else {
+				} else {
 					if (track->volFadeStep < 0) {
 						if (track->vol > track->volFadeDest) {
 							track->vol += track->volFadeStep; 
@@ -267,8 +265,7 @@ void IMuseDigital::callback() {
 								continue;
 							}
 						}
-					}
-					else if (track->volFadeStep > 0) {
+					} else if (track->volFadeStep > 0) {
 						if (track->vol < track->volFadeDest) {
 							track->vol += track->volFadeStep;
 							if (track->vol > track->volFadeDest) {

--- a/engines/scumm/imuse_digi/dimuse.cpp
+++ b/engines/scumm/imuse_digi/dimuse.cpp
@@ -414,7 +414,6 @@ void IMuseDigital::switchToNextRegion(Track *track) {
 				Track *fadeTrack = cloneToFadeOutTrack(track, fadeDelay);
 				if (fadeTrack) {
 					fadeTrack->dataOffset = _sound->getRegionOffset(fadeTrack->soundDesc, fadeTrack->curRegion);
-					fadeTrack->vol = 0;
 					fadeTrack->regionOffset = 0;
 					debug(5, "SwToNeReg(trackId:%d) - sound(%d) faded track, select region %d, curHookId: %d", fadeTrack->trackId, fadeTrack->soundId, fadeTrack->curRegion, fadeTrack->curHookId);
 					fadeTrack->curHookId = 0;

--- a/engines/scumm/imuse_digi/dimuse.h
+++ b/engines/scumm/imuse_digi/dimuse.h
@@ -105,7 +105,10 @@ private:
 	void setTrigger(TriggerParams *trigger);
 	void setHookIdForMusic(int hookId);
 	Track *cloneToFadeOutTrack(Track *track, int fadeDelay);
-
+	Track *handleComiFadeOut(Track *track, int fadeDelay);
+	int transformVolumeLinearToEqualPow(int volume, int mode);
+	int transformVolumeEqualPowToLinear(int volume, int mode);
+	
 	void setFtMusicState(int stateId);
 	void setFtMusicSequence(int seqId);
 	void setFtMusicCuePoint(int cueId);

--- a/engines/scumm/imuse_digi/dimuse_music.cpp
+++ b/engines/scumm/imuse_digi/dimuse_music.cpp
@@ -321,8 +321,6 @@ void IMuseDigital::playComiMusic(const char *songName, const imuseComiTable *tab
 		}
 		if (getCurMusicSoundId() == table->soundId)
 			return;
-		if (table->transitionType == 4)
-			_stopingSequence = 1;
 		if (table->transitionType == 2) {
 			fadeOutMusic(table->fadeOutDelay);
 			startMusic(table->filename, table->soundId, table->hookId, 127);

--- a/engines/scumm/imuse_digi/dimuse_script.cpp
+++ b/engines/scumm/imuse_digi/dimuse_script.cpp
@@ -166,7 +166,7 @@ void IMuseDigital::flushTrack(Track *track) {
 	if (track->souStreamUsed) {
 		_mixer->stopHandle(track->mixChanHandle);
 	} else if (track->stream) {
-		debug(5, "flushTrack() - soundId:%d", track->soundId);
+		debug(5, "flushTrack(trackId: %d) - soundId:%d", track->trackId, track->soundId);
 		// Finalize the appendable stream, then remove our reference to it.
 		// Note that there might still be some data left in the buffers of the
 		// appendable stream. We play it nice and wait till all of it
@@ -190,7 +190,7 @@ void IMuseDigital::flushTracks() {
 	for (int l = 0; l < MAX_DIGITAL_TRACKS + MAX_DIGITAL_FADETRACKS; l++) {
 		Track *track = _track[l];
 		if (track->used && track->toBeRemoved && !_mixer->isSoundHandleActive(track->mixChanHandle)) {
-			debug(5, "flushTracks() - soundId:%d", track->soundId);
+			debug(5, "flushTracks() - trackId:%d, soundId:%d", track->trackId, track->soundId);
 			track->reset();
 		}
 	}

--- a/engines/scumm/imuse_digi/dimuse_track.cpp
+++ b/engines/scumm/imuse_digi/dimuse_track.cpp
@@ -321,7 +321,6 @@ void IMuseDigital::fadeOutMusic(int fadeDelay) {
 			debug(5, "IMuseDigital::fadeOutMusic(fade:%d, sound:%d)", fadeDelay, track->soundId);
 			if (_vm->_game.id == GID_CMI) {
 				handleComiFadeOut(track, fadeDelay);
-				
 			}
 			else {
 				cloneToFadeOutTrack(track, fadeDelay);
@@ -419,7 +418,7 @@ int IMuseDigital::transformVolumeLinearToEqualPow(int volume, int mode) {
 	int result = volume;
 	if (!(volume < 0 || volume > 127000)) {
 		// Change range of values from 0-127*1000 to 0.0-1.0
-		double mappedValue = (((volume - 0)*(1.0 - 0.0)) / (127000 - 0)) + 0;
+		double mappedValue = (((volume - 0) * (1.0 - 0.0)) / (127000 - 0)) + 0;
 		double eqPowValue;
 
 		switch (mode)
@@ -431,16 +430,16 @@ int IMuseDigital::transformVolumeLinearToEqualPow(int volume, int mode) {
 			eqPowValue = sin(mappedValue * M_PI / 2.0);
 			break;
 		case 2:  // Parabola
-			eqPowValue = (1 - (1 - mappedValue)*(1 - mappedValue));
+			eqPowValue = (1 - (1 - mappedValue) * (1 - mappedValue));
 			break;
 		case 3:  // Logarithmic 1
-			eqPowValue = 1 + 0.2*log10(mappedValue);
+			eqPowValue = 1 + 0.2 * log10(mappedValue);
 			break;
 		case 4:  // Logarithmic 2
-			eqPowValue = 1 + 0.5*log10(mappedValue);
+			eqPowValue = 1 + 0.5 * log10(mappedValue);
 			break;
 		case 5:  // Logarithmic 3
-			eqPowValue = 1 + 0.7*log10(mappedValue);
+			eqPowValue = 1 + 0.7 * log10(mappedValue);
 			break;
 		case 6:  // Half sine curve
 			eqPowValue = (1.0 - cos(mappedValue * M_PI)) / 2.0;
@@ -450,7 +449,7 @@ int IMuseDigital::transformVolumeLinearToEqualPow(int volume, int mode) {
 		}
 
 		// Change range again, this time round the result
-		result = (((eqPowValue - 0.0)*(127000 - 0)) / (1.0 - 0.0)) + 0.0;
+		result = (((eqPowValue - 0.0) * (127000 - 0)) / (1.0 - 0.0)) + 0.0;
 		result = (int)round(result);
 	}
 
@@ -464,7 +463,7 @@ int IMuseDigital::transformVolumeEqualPowToLinear(int volume, int mode) {
 	int result = volume;
 	if (!(volume < 0 || volume > 127000)) {
 		// Change range of values from 0-127*1000 to 0.0-1.0
-		double mappedValue = (((volume - 0)*(1.0 - 0.0)) / (127000 - 0)) + 0;
+		double mappedValue = (((volume - 0) * (1.0 - 0.0)) / (127000 - 0)) + 0;
 		double linearValue;
 
 		switch (mode)
@@ -479,13 +478,13 @@ int IMuseDigital::transformVolumeEqualPowToLinear(int volume, int mode) {
 			linearValue = 1 - sqrt(1 - mappedValue);
 			break;
 		case 3:  // Logarithmic 1
-			linearValue = 0.00001*pow(M_E, 11.5129*mappedValue);
+			linearValue = 0.00001 * pow(M_E, 11.5129 * mappedValue);
 			break;
 		case 4:  // Logarithmic 2
-			linearValue = 0.01*pow(M_E, 4.60517*mappedValue);
+			linearValue = 0.01 * pow(M_E, 4.60517 * mappedValue);
 			break;
 		case 5:  // Logarithmic 3
-			linearValue = 0.0372759*pow(M_E, 3.28941*mappedValue);
+			linearValue = 0.0372759 * pow(M_E, 3.28941 * mappedValue);
 			break;
 		case 6:  // Half sine curve
 			linearValue = (2 * asin(sqrt(mappedValue))) / M_PI; // Ricontrolla
@@ -496,7 +495,7 @@ int IMuseDigital::transformVolumeEqualPowToLinear(int volume, int mode) {
 		}
 
 		// Change range again, this time round the result
-		result = (((linearValue - 0.0)*(127000 - 0)) / (1.0 - 0.0)) + 0.0;
+		result = (((linearValue - 0.0) * (127000 - 0)) / (1.0 - 0.0)) + 0.0;
 		result = (int)round(result);
 	}
 

--- a/engines/scumm/imuse_digi/dimuse_track.cpp
+++ b/engines/scumm/imuse_digi/dimuse_track.cpp
@@ -158,17 +158,25 @@ void IMuseDigital::startSound(int soundId, const char *soundName, int soundType,
 		} else
 			error("IMuseDigital::startSound(): Can't handle %d bit samples", bits);
 
+		int fadeDelay = 30; // Default fade value if not found anywhere else
+
 		if (otherTrack && otherTrack->used && !otherTrack->toBeRemoved) {
-			track->vol = 0;
 			track->curRegion = otherTrack->curRegion;
 			track->dataOffset = otherTrack->dataOffset;
 			track->regionOffset = otherTrack->regionOffset;
 			track->dataMod12Bit = otherTrack->dataMod12Bit;
 
+			if (_vm->_game.id == GID_CMI) {
+				fadeDelay = otherTrack->volFadeDelay != 0 ? otherTrack->volFadeDelay : fadeDelay;
+				track->regionOffset -= track->regionOffset >= (track->feedSize / _callbackFps) ? (track->feedSize / _callbackFps) : 0;
+			}
+		}
+		if (_vm->_game.id == GID_CMI) {
 			// Fade in the new track
-			track->volFadeDelay = otherTrack->volFadeDelay != 0 ? otherTrack->volFadeDelay : 60;
-			track->volFadeDest = volume*1000;
-			track->volFadeStep = (track->volFadeDest - track->vol) * 60 * (1000 / _callbackFps) / (1000 * otherTrack->volFadeDelay);
+			track->vol = 0;
+			track->volFadeDelay = fadeDelay;
+			track->volFadeDest = volume * 1000;
+			track->volFadeStep = (track->volFadeDest - track->vol) * 60 * (1000 / _callbackFps) / (1000 * fadeDelay);
 			track->volFadeUsed = true;
 		}
 
@@ -286,10 +294,18 @@ void IMuseDigital::fadeOutMusicAndStartNew(int fadeDelay, const char *filename, 
 		Track *track = _track[l];
 		if (track->used && !track->toBeRemoved && (track->volGroupId == IMUSE_VOLGRP_MUSIC)) {
 			debug(5, "IMuseDigital::fadeOutMusicAndStartNew(sound:%d) - starting", soundId);
-			track->volFadeDelay = fadeDelay;
-			startMusicWithOtherPos(filename, soundId, 0, 127, track);
-			cloneToFadeOutTrack(track, fadeDelay);
-			flushTrack(track);
+
+			// Store the fadeDelay in the track: startMusicWithOtherPos will use it to 
+			// fade in the new track; this will match fade in and fade out speeds.
+			if (_vm->_game.id == GID_CMI) {
+				track->volFadeDelay = fadeDelay;
+				startMusicWithOtherPos(filename, soundId, 0, 127, track);
+				handleComiFadeOut(track, fadeDelay);
+			} else {
+				startMusicWithOtherPos(filename, soundId, 0, 127, track);
+				cloneToFadeOutTrack(track, fadeDelay);
+				flushTrack(track);
+			}
 			break;
 		}
 	}
@@ -303,8 +319,14 @@ void IMuseDigital::fadeOutMusic(int fadeDelay) {
 		Track *track = _track[l];
 		if (track->used && !track->toBeRemoved && (track->volGroupId == IMUSE_VOLGRP_MUSIC)) {
 			debug(5, "IMuseDigital::fadeOutMusic(fade:%d, sound:%d)", fadeDelay, track->soundId);
-			cloneToFadeOutTrack(track, fadeDelay);
-			flushTrack(track);
+			if (_vm->_game.id == GID_CMI) {
+				handleComiFadeOut(track, fadeDelay);
+				
+			}
+			else {
+				cloneToFadeOutTrack(track, fadeDelay);
+				flushTrack(track);
+			}
 			break;
 		}
 	}
@@ -332,6 +354,16 @@ void IMuseDigital::setTrigger(TriggerParams *trigger) {
 	_triggerUsed = true;
 }
 
+Track *IMuseDigital::handleComiFadeOut(Track *track, int fadeDelay) {
+	track->volFadeDelay = fadeDelay;
+	track->volFadeDest = 0;
+	track->volFadeStep = (track->volFadeDest - track->vol) * 60 * (1000 / _callbackFps) / (1000 * fadeDelay);
+	track->volFadeUsed = true;
+	track->toBeRemoved = true;
+	return track;
+}
+
+
 Track *IMuseDigital::cloneToFadeOutTrack(Track *track, int fadeDelay) {
 	assert(track);
 	Track *fadeTrack;
@@ -345,7 +377,6 @@ Track *IMuseDigital::cloneToFadeOutTrack(Track *track, int fadeDelay) {
 
 	assert(track->trackId < MAX_DIGITAL_TRACKS);
 	fadeTrack = _track[track->trackId + MAX_DIGITAL_TRACKS];
-
 	if (fadeTrack->used) {
 		debug(5, "cloneToFadeOutTrack: No free fade track, force flush fade soundId:%d", fadeTrack->soundId);
 		flushTrack(fadeTrack);
@@ -364,7 +395,7 @@ Track *IMuseDigital::cloneToFadeOutTrack(Track *track, int fadeDelay) {
 		// so gave up
 		error("Game not supported while playing on 2 different CDs");
 	}
-	track->soundDesc = soundDesc;
+	fadeTrack->soundDesc = soundDesc;
 
 	// Set the volume fading parameters to indicate a fade out
 	fadeTrack->volFadeDelay = fadeDelay;
@@ -376,10 +407,100 @@ Track *IMuseDigital::cloneToFadeOutTrack(Track *track, int fadeDelay) {
 	fadeTrack->stream = Audio::makeQueuingAudioStream(_sound->getFreq(fadeTrack->soundDesc), track->mixerFlags & kFlagStereo);
 	_mixer->playStream(track->getType(), &fadeTrack->mixChanHandle, fadeTrack->stream, -1, fadeTrack->getVol(), fadeTrack->getPan());
 	fadeTrack->used = true;
-
 	debug(5, "cloneToFadeOutTrack() - end of func, soundId %d, fade soundId %d", track->soundId, fadeTrack->soundId);
 
 	return fadeTrack;
+}
+
+int IMuseDigital::transformVolumeLinearToEqualPow(int volume, int mode) {
+	if (volume == 0 || volume == 127000)
+		return volume;
+
+	int result = volume;
+	if (!(volume < 0 || volume > 127000)) {
+		// Change range of values from 0-127*1000 to 0.0-1.0
+		double mappedValue = (((volume - 0)*(1.0 - 0.0)) / (127000 - 0)) + 0;
+		double eqPowValue;
+
+		switch (mode)
+		{
+		case 0:  // Sqrt curve
+			eqPowValue = sqrt(mappedValue);
+			break;
+		case 1:  // Quarter sine curve
+			eqPowValue = sin(mappedValue * M_PI / 2.0);
+			break;
+		case 2:  // Parabola
+			eqPowValue = (1 - (1 - mappedValue)*(1 - mappedValue));
+			break;
+		case 3:  // Logarithmic 1
+			eqPowValue = 1 + 0.2*log10(mappedValue);
+			break;
+		case 4:  // Logarithmic 2
+			eqPowValue = 1 + 0.5*log10(mappedValue);
+			break;
+		case 5:  // Logarithmic 3
+			eqPowValue = 1 + 0.7*log10(mappedValue);
+			break;
+		case 6:  // Half sine curve
+			eqPowValue = (1.0 - cos(mappedValue * M_PI)) / 2.0;
+		default: // Fallback to linear
+			eqPowValue = mappedValue;
+			break;
+		}
+
+		// Change range again, this time round the result
+		result = (((eqPowValue - 0.0)*(127000 - 0)) / (1.0 - 0.0)) + 0.0;
+		result = (int)round(result);
+	}
+
+	return result;
+}
+
+int IMuseDigital::transformVolumeEqualPowToLinear(int volume, int mode) {
+	if (volume == 0 || volume == 127000)
+		return volume;
+
+	int result = volume;
+	if (!(volume < 0 || volume > 127000)) {
+		// Change range of values from 0-127*1000 to 0.0-1.0
+		double mappedValue = (((volume - 0)*(1.0 - 0.0)) / (127000 - 0)) + 0;
+		double linearValue;
+
+		switch (mode)
+		{
+		case 0:  // Sqrt curve
+			linearValue = mappedValue * mappedValue;
+			break;
+		case 1:  // Quarter sine curve
+			linearValue = 0.63662 * asin(mappedValue);
+			break;
+		case 2:  // Parabola
+			linearValue = 1 - sqrt(1 - mappedValue);
+			break;
+		case 3:  // Logarithmic 1
+			linearValue = 0.00001*pow(M_E, 11.5129*mappedValue);
+			break;
+		case 4:  // Logarithmic 2
+			linearValue = 0.01*pow(M_E, 4.60517*mappedValue);
+			break;
+		case 5:  // Logarithmic 3
+			linearValue = 0.0372759*pow(M_E, 3.28941*mappedValue);
+			break;
+		case 6:  // Half sine curve
+			linearValue = (2 * asin(sqrt(mappedValue))) / M_PI; // Ricontrolla
+			break;
+		default: // Fallback to linear
+			linearValue = mappedValue;
+			break;
+		}
+
+		// Change range again, this time round the result
+		result = (((linearValue - 0.0)*(127000 - 0)) / (1.0 - 0.0)) + 0.0;
+		result = (int)round(result);
+	}
+
+	return result;
 }
 
 } // End of namespace Scumm

--- a/engines/scumm/imuse_digi/dimuse_track.cpp
+++ b/engines/scumm/imuse_digi/dimuse_track.cpp
@@ -394,7 +394,7 @@ Track *IMuseDigital::cloneToFadeOutTrack(Track *track, int fadeDelay) {
 		// so gave up
 		error("Game not supported while playing on 2 different CDs");
 	}
-	fadeTrack->soundDesc = soundDesc;
+	track->soundDesc = soundDesc;
 
 	// Set the volume fading parameters to indicate a fade out
 	fadeTrack->volFadeDelay = fadeDelay;

--- a/engines/scumm/imuse_digi/dimuse_track.cpp
+++ b/engines/scumm/imuse_digi/dimuse_track.cpp
@@ -321,8 +321,7 @@ void IMuseDigital::fadeOutMusic(int fadeDelay) {
 			debug(5, "IMuseDigital::fadeOutMusic(fade:%d, sound:%d)", fadeDelay, track->soundId);
 			if (_vm->_game.id == GID_CMI) {
 				handleComiFadeOut(track, fadeDelay);
-			}
-			else {
+			} else {
 				cloneToFadeOutTrack(track, fadeDelay);
 				flushTrack(track);
 			}
@@ -421,8 +420,7 @@ int IMuseDigital::transformVolumeLinearToEqualPow(int volume, int mode) {
 		double mappedValue = (((volume - 0) * (1.0 - 0.0)) / (127000 - 0)) + 0;
 		double eqPowValue;
 
-		switch (mode)
-		{
+		switch (mode) {
 		case 0:  // Sqrt curve
 			eqPowValue = sqrt(mappedValue);
 			break;
@@ -466,8 +464,7 @@ int IMuseDigital::transformVolumeEqualPowToLinear(int volume, int mode) {
 		double mappedValue = (((volume - 0) * (1.0 - 0.0)) / (127000 - 0)) + 0;
 		double linearValue;
 
-		switch (mode)
-		{
+		switch (mode) {
 		case 0:  // Sqrt curve
 			linearValue = mappedValue * mappedValue;
 			break;


### PR DESCRIPTION
`SCUMM: COMI: Fix iMUSE Digital #4635/#10473 bugs`

This commit fixes the early stopping of ArriveBarber sequence, during the first arrival in Barbery Coast.
If this particular cutscene is skipped while this sequence is playing (e.g.: via ESCAPE key), the sequence is faded out
and the main Barbery Coast theme is played, as per correct behavior.
That's also the only COMI sequence using a transitionType with value 4, so the fix should not be able to break anything else, and in fact I haven't been able to break anything during my test run.

`SCUMM: COMI: Fix #4391 iMUSE Digital fades`

This commit implements fade-ins during song transitions (e.g. statePreVooOut --> statePreVooIn --> statePreVooLady) and also between regions of the same song (e.g. any JUMP instruction used for looping songs).

This results in a linear cross-fade. This is not ideal since the correct thing would be to implement a logarithmic crossfade (or "audio taper"), but for now this will do without changing too much of the current codebase. I'm still going to investigate the possibility of implementing this in a correct way.

I know, _I know_ the implementation looks terrible, a "real" fix would supposedly use fade tracks also for fade-ins, and require some kind of cloneToFadeInTrack(track, fadeDelay) to be used together with cloneToFadeOutTrack.

I didn't do this for two reasons:
- I think this would create some desync problems between fade tracks and proper tracks (for the life of me I just can't get fade out tracks to **always** be in perfect sync with the "parent" track).
- I would have to delaying putting the new song in the parent track until the correspondent fade in has occurred, and I don't know how to do it.

Having said that, this fix unfortunately does not account for the _**sync issue between fade-out and parent track**_, but it already sounds much better than the current implementation (even in the 30% of times in which the fade-outs happen not to be in sync). And besides, these bugs have remained unfixed for more than 10 years, so at this point I doubt anyone else has a plan to have a proper attempt at this anytime soon.
	
There might be another solution, for sure, but it's currently beyond my knowledge, I'm sorry 😢 

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
