### PR TITLE
GRIM: Fix alloc-dealloc mismatch in grim engine

### DIFF
--- a/engines/grim/textsplit.cpp
+++ b/engines/grim/textsplit.cpp
@@ -235,8 +235,8 @@ static void parse(const char *line, const char *fmt, int field_count, va_list va
 				break;
 		}
 	}
-	delete[] str;
-	delete[] format;
+	free(str);
+	free(format);
 
 	if (count < field_count) {
 		error("Expected line of format '%s', got '%s'", fmt, line);


### PR DESCRIPTION
A previous fix in ResidualVM changed 2 calls to free() into delete
operators because scumm_strdup() was using the new operator.
Later scumm_strdup() switched to malloc() to be aligned with strdup()
function. So move back to free().
