### PR TITLE
COMMON: Add conversion operator from UnicodeBiDiText to U32String

### DIFF
--- a/common/unicode-bidi.h
+++ b/common/unicode-bidi.h
@@ -42,6 +42,11 @@ public:
 	UnicodeBiDiText(const Common::String &str, const Common::CodePage page);
 	~UnicodeBiDiText();
 
+	/**
+	 * Implicit conversion to U32String to get the visual representation.
+	 */
+	operator const U32String &() const { return visual; }
+
 	uint32 getVisualPosition(uint32 logicalPos) const;
 	uint32 getLogicalPosition(uint32 visualPos) const;
 	uint32 size() const { return logical.size(); }

--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -24,7 +24,6 @@
 #include "common/str.h"
 #include "common/memorypool.h"
 #include "common/util.h"
-#include "unicode-bidi.h"
 
 namespace Common {
 
@@ -48,10 +47,6 @@ U32String::U32String(const char *beginP, const char *endP) : BaseString<u32char_
 
 U32String::U32String(const String &str) : BaseString<u32char_type_t>() {
 	initWithCStr(str.c_str(), str.size());
-}
-
-U32String::U32String(const UnicodeBiDiText &txt) : BaseString<u32char_type_t>() {
-	initWithValueTypeStr(txt.visual.c_str(), txt.visual.size());
 }
 
 U32String::~U32String() {

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -39,7 +39,6 @@ namespace Common {
  */
  
 class String;
-class UnicodeBiDiText;
 
 /**
  * Very simple string class for UTF-32 strings in ScummVM. The main intention
@@ -83,9 +82,6 @@ public:
 
 	/** Construct a copy of the given string. */
 	U32String(const U32String &str) : BaseString<u32char_type_t>(str) {}
-
-	/** Construct a copy of the given unicode BiDi converted string. */
-	U32String(const UnicodeBiDiText &txt);
 
 	/** Construct a new string from the given NULL-terminated C string. */
 	explicit U32String(const char *str);


### PR DESCRIPTION
Replace the `U32String` constructor that takes a `UnicodeBiDiText` by an implicit conversion operator in `UnicodeBiDiText`. This serves the same purpose of allowing to use a `UnicodeBiDiText` in places where a `U32String` is expected (such as in [ThemeEngine::drawDDText()](https://github.com/scummvm/scummvm/blob/606eeae46f9742e4947d5bea5e198ba3f822a1fe/gui/ThemeEngine.cpp#L1022) , but avoids making a copy (although we can still make a copy using the `U32String` copy constructor if that is what we want to do).

I am suggesting this change in a pull request in case C++ experts want to have a look and comment before this is merged, as I may have missed something.