### PR TITLE
KYRA: Fix garbled "New game" line in Russian version

### DIFF
--- a/engines/kyra/gui/gui_v2.cpp
+++ b/engines/kyra/gui/gui_v2.cpp
@@ -470,9 +470,12 @@ void GUI_v2::setupSavegameNames(Menu &menu, int num) {
 			menu.item[0].saveSlot = -2;
 			menu.item[0].enabled = true;
 		} else {
+			int t = menu.item[0].labelId;
+			menu.item[0].labelId = _vm->gameFlags().isTalkie ? 34 : 42;
 			char *dst = getTableString(menu.item[0].itemId);
-			const char *src = getTableString(_vm->gameFlags().isTalkie ? 34 : 42);
+			const char *src = getMenuItemLabel(menu.item[0]);
 			strcpy(dst, src);
+			menu.item[0].labelId = t;
 		}
 	}
 }


### PR DESCRIPTION
In Siberian Gremlin version "Start a new game" uses escape
encoding. So we need to transcode it.

This fix is not ideal but the code is generally dirty wrt to
string usage and its cleaning is a separate story


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
