### PR TITLE
COMMON: Use appropriate equals() in BaseString

### DIFF
--- a/common/base-str.cpp
+++ b/common/base-str.cpp
@@ -316,7 +316,7 @@ TEMPLATE bool BASESTRING::operator==(const BaseString &x) const {
 }
 
 TEMPLATE bool BASESTRING::operator==(const value_type *x) const {
-	return equals(BaseString(x));
+	return equals(x);
 }
 
 TEMPLATE bool BASESTRING::operator!=(const BaseString &x) const {
@@ -324,7 +324,7 @@ TEMPLATE bool BASESTRING::operator!=(const BaseString &x) const {
 }
 
 TEMPLATE bool BASESTRING::operator!=(const value_type *x) const {
-	return !equals(BaseString(x));
+	return !equals(x);
 }
 
 TEMPLATE int BASESTRING::compareTo(const BaseString &x) const {


### PR DESCRIPTION
Remove a useless creation of a BaseString object with a C string in
comparison operators of this class, because there is a function equals()
that accepts a C string in parameter. So this was not necessary but
moreover the created BaseString object was never freed.
