### PR TITLE
WINTERMUTE: Reset VBO once during init in fixed-function renderer

### DIFF
--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -247,10 +247,6 @@ void BaseRenderOpenGL3D::setWindowed(bool windowed) {
 }
 
 void BaseRenderOpenGL3D::fadeToColor(byte r, byte g, byte b, byte a) {
-#if defined(USE_OPENGL_SHADERS)
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
-
 	setProjection2D();
 
 	const int vertexSize = 16;
@@ -435,6 +431,12 @@ bool BaseRenderOpenGL3D::initRenderer(int width, int height, bool windowed) {
 	_simpleShadow[3].u = 1.0f;
 	_simpleShadow[3].v = 0.0f;
 
+	// The ShaderSurfaceRenderer sets an array buffer which appearently conflicts with us
+	// Reset it!
+#if defined(USE_OPENGL_SHADERS)
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+
 	return true;
 }
 
@@ -616,12 +618,6 @@ bool BaseRenderOpenGL3D::drawSpriteEx(BaseSurfaceOpenGL3D &tex, const Wintermute
                                       float angle, uint32 color, bool alphaDisable, Graphics::TSpriteBlendMode blendMode,
                                       bool mirrorX, bool mirrorY) {
 	// original wme has a batch mode for sprites, we ignore this for the moment
-
-	// The ShaderSurfaceRenderer sets an array buffer which appearently conflicts with us
-	// Reset it!
-#if defined(USE_OPENGL_SHADERS)
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
 
 	if (_forceAlphaColor != 0) {
 		color = _forceAlphaColor;

--- a/engines/wintermute/base/gfx/opengl/meshx_opengl.cpp
+++ b/engines/wintermute/base/gfx/opengl/meshx_opengl.cpp
@@ -58,10 +58,6 @@ bool MeshXOpenGL::render(ModelX *model) {
 		glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, _materials[materialIndex]->_emissive.data);
 		glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, _materials[materialIndex]->_shininess);
 
-#if defined(USE_OPENGL_SHADERS)
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
-#endif // defined(USE_OPENGL_SHADERS)
-
 		if (_materials[materialIndex]->getSurface()) {
 			glEnable(GL_TEXTURE_2D);
 			static_cast<BaseSurfaceOpenGL3D *>(_materials[materialIndex]->getSurface())->setTexture();

--- a/engines/wintermute/base/gfx/opengl/shadow_volume_opengl.cpp
+++ b/engines/wintermute/base/gfx/opengl/shadow_volume_opengl.cpp
@@ -48,9 +48,6 @@ ShadowVolumeOpenGL::~ShadowVolumeOpenGL() {
 //////////////////////////////////////////////////////////////////////////
 bool ShadowVolumeOpenGL::render() {
 	glBindTexture(GL_TEXTURE_2D, 0);
-#if defined(USE_OPENGL_SHADERS)
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
-#endif // defined(USE_OPENGL_SHADERS)
 
 	glEnableClientState(GL_VERTEX_ARRAY);
 	glDisableClientState(GL_COLOR_ARRAY);
@@ -126,9 +123,6 @@ bool ShadowVolumeOpenGL::renderToScene() {
 	_gameRef->_renderer3D->setProjection2D();
 
 	glBindTexture(GL_TEXTURE_2D, 0);
-#if defined(USE_OPENGL_SHADERS)
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
-#endif // defined(USE_OPENGL_SHADERS)
 
 	glEnableClientState(GL_COLOR_ARRAY);
 	glEnableClientState(GL_VERTEX_ARRAY);


### PR DESCRIPTION
The ShaderSurfaceRenderer sets a VBO once without resetting it. This has lead to graphical bugs in the past with the fixed-function renderer (which does not use VBOs), so the current VBO has been reset in several places in the code. Now it is only reset once during renderer initialization, which should suffice.