### PR TITLE
SCUMM: Add support for basic Korean fan translation

### DIFF
--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -82,7 +82,8 @@ void ScummEngine::loadCJKFont() {
 		_2byteFontPtr = new byte[_2byteWidth * _2byteHeight * numChar / 8];
 		// set byte 0 to 0xFF (0x00 when loaded) to indicate that the font was not loaded
 		_2byteFontPtr[0] = 0xFF;
-	} else if ((_game.version >= 7 && (_language == Common::KO_KOR || _language == Common::JA_JPN || _language == Common::ZH_TWN)) ||
+	} else if (_language == Common::KO_KOR ||
+			   (_game.version >= 7 && (_language == Common::JA_JPN || _language == Common::ZH_TWN)) ||
 			   (_game.version >= 3 && _language == Common::ZH_CNA)) {
 		int numChar = 0;
 		const char *fontFile = NULL;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -771,7 +771,7 @@ void ScummEngine::CHARSET_1() {
 #endif
 		} else {
 			if (c & 0x80 && _useCJKMode) {
-				if (checkSJISCode(c)) {
+				if (is2ByteCharacter(_language, c)) {
 					byte *buffer = _charsetBuffer + _charsetBufPos;
 					c += *buffer++ * 256; //LE
 					_charsetBufPos = buffer - _charsetBuffer;
@@ -1182,7 +1182,7 @@ void ScummEngine::drawString(int a, const byte *msg) {
 				}
 			}
 			if (c & 0x80 && _useCJKMode) {
-				if (checkSJISCode(c))
+				if (is2ByteCharacter(_language, c))
 					c += buf[i++] * 256;
 			}
 			_charset->printChar(c, true);


### PR DESCRIPTION
SCUMM: Add support for basic Korean fan translation

This PR is part of scummvm-kor merge project.

It makes minimal changes enabling Korean fan translation for SCUMM games.
Most of the foundation is already laid, so just removing restriction is enough for basic functions.
However, many games require some more changes to actually "work", so those will come as separate PR.

Tested with:
- Loom (DOS/CD/Korean patched)
- Monkey Island 2 (DOS/Korean patched)
- Monkey Island 2 (FMT/Japanese)
- DOTT (DOS/CD/Korean patched)

![scummvm-loom-vga-kr-00001](https://user-images.githubusercontent.com/2627281/98330775-7b158080-203e-11eb-8b13-5967d9cfcb37.png)
