### PR TITLE
SCUMM: Multi-font for Korean fan translated games

### DIFF
--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -82,7 +82,8 @@ void ScummEngine::loadCJKFont() {
 		_2byteFontPtr = new byte[_2byteWidth * _2byteHeight * numChar / 8];
 		// set byte 0 to 0xFF (0x00 when loaded) to indicate that the font was not loaded
 		_2byteFontPtr[0] = 0xFF;
-	} else if ((_game.version >= 7 && (_language == Common::KO_KOR || _language == Common::JA_JPN || _language == Common::ZH_TWN)) ||
+	} else if (_language == Common::KO_KOR ||
+			   (_game.version >= 7 && (_language == Common::JA_JPN || _language == Common::ZH_TWN)) ||
 			   (_game.version >= 3 && _language == Common::ZH_CNA)) {
 		int numChar = 0;
 		const char *fontFile = NULL;

--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -73,7 +73,7 @@ void ScummEngine::loadCJKFont() {
 			_2byteHeight = 0;
 			for (int i = 0; i < 20; i++) {
 				char fontFile[256];
-				sprintf(fontFile, "korean%02d.fnt", i);
+				snprintf(fontFile, sizeof(fontFile), "korean%02d.fnt", i);
 				_2byteMultiFontPtr[i] = NULL;
 				if (fp.open(fontFile)) {
 					_numLoadedFont++;

--- a/engines/scumm/charset.h
+++ b/engines/scumm/charset.h
@@ -97,6 +97,8 @@ public:
 
 	virtual void setColor(byte color) { _color = color; translateColor(); }
 
+	bool isScummvmKorTarget();
+
 	void saveLoadWithSerializer(Common::Serializer &ser);
 };
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -325,6 +325,8 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 	_costumeRenderer = NULL;
 	_2byteFontPtr = 0;
 	_V1TalkingActor = 0;
+	for (int i = 0; i < 20; i++)
+		_2byteMultiFontPtr[i] = NULL;
 	_NESStartStrip = 0;
 
 	_skipDrawObject = 0;
@@ -614,7 +616,11 @@ ScummEngine::~ScummEngine() {
 
 	delete[] _sortedActors;
 
-	delete[] _2byteFontPtr;
+	if (_2byteFontPtr && !_useMultiFont)
+		delete _2byteFontPtr;
+	for (int i = 0; i < 20; i++)
+		if (_2byteMultiFontPtr[i])
+			delete _2byteMultiFontPtr[i];
 	delete _charset;
 	delete _messageDialog;
 	delete _pauseDialog;

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1137,13 +1137,22 @@ public:
 
 	// Somewhat hackish stuff for 2 byte support (Chinese/Japanese/Korean)
 	bool _useCJKMode;
+	bool _useMultiFont;
+	int _numLoadedFont;
+	int _currentFont;
+	int _2byteShadow;
+
 	int _2byteHeight;
 	int _2byteWidth;
 	byte _newLineCharacter;
 	byte *get2byteCharPtr(int idx);
 
-protected:
+//protected:
 	byte *_2byteFontPtr;
+	byte *_2byteMultiFontPtr[20];
+	int _2byteMultiHeight[20];
+	int _2byteMultiWidth[20];
+	int _2byteMultiShadow[20];
 
 public:
 

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -771,7 +771,7 @@ void ScummEngine::CHARSET_1() {
 #endif
 		} else {
 			if (c & 0x80 && _useCJKMode) {
-				if (checkSJISCode(c)) {
+				if (is2ByteCharacter(_language, c)) {
 					byte *buffer = _charsetBuffer + _charsetBufPos;
 					c += *buffer++ * 256; //LE
 					_charsetBufPos = buffer - _charsetBuffer;
@@ -1182,7 +1182,7 @@ void ScummEngine::drawString(int a, const byte *msg) {
 				}
 			}
 			if (c & 0x80 && _useCJKMode) {
-				if (checkSJISCode(c))
+				if (is2ByteCharacter(_language, c))
 					c += buf[i++] * 256;
 			}
 			_charset->printChar(c, true);


### PR DESCRIPTION
This PR is part of scummvm-kor merge project.

It adds the ability to load and use multiple external Korean fonts to match the original look.

On a separate note, I intend to refactor CJK text rendering to use Graphics::Font*.

Tested with:
- Loom (DOS/CD/Korean patched)
- Monkey Island 2 (DOS/Korean patched)
- Indy 4 (DOS/CD/Korean patched)
- DOTT (DOS/CD/Korean patched)
![scummvm-monkey2-kr-00002](https://user-images.githubusercontent.com/2627281/98331640-54584980-2040-11eb-9c17-e779cc1e0a4a.png)
![scummvm-monkey2-kr-00004](https://user-images.githubusercontent.com/2627281/98331642-55897680-2040-11eb-9fa2-bb65210804ae.png)
