### PR TITLE
SCUMM: Hacks for alternative line-break

### DIFF
--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -421,13 +421,14 @@ int CharsetRenderer::getStringWidth(int arg, const byte *text) {
 
 void CharsetRenderer::addLinebreaks(int a, byte *str, int pos, int maxwidth) {
 	int lastKoreanLineBreak = -1;
-	char tmpStrBuf[512];
 	int origPos = pos;
 	int lastspace = -1;
 	int curw = 1;
 	int chr;
 	int oldID = getCurID();
 	int code = (_vm->_game.heversion >= 80) ? 127 : 64;
+
+	int strLength = _vm->resStrLen(str);
 
 	while ((chr = str[pos++]) != 0) {
 		if (_vm->_game.heversion >= 72) {
@@ -537,8 +538,8 @@ void CharsetRenderer::addLinebreaks(int a, byte *str, int pos, int maxwidth) {
 				lastspace = -1;
 				lastKoreanLineBreak = -1;
 			} else {
-				strcpy(tmpStrBuf, (char*)(str + lastKoreanLineBreak));
-				strcpy((char*)(str + lastKoreanLineBreak + 1), tmpStrBuf);
+				byte* breakPtr = str + lastKoreanLineBreak;
+				memmove(breakPtr + 1, breakPtr, strLength - lastKoreanLineBreak + 1);
 				str[lastKoreanLineBreak] = 0xD;
 				curw = 1;
 				pos = lastKoreanLineBreak + 1;

--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -42,6 +42,12 @@ The advantage will be cleaner coder (easier to debug, in particular), and a
 better separation of the various modules.
 */
 
+bool CharsetRenderer::isScummvmKorTarget() {
+	if (_vm->_language == Common::KO_KOR && (_vm->_game.version < 7 || _vm->_game.id == GID_FT)) {
+		return true;
+	}
+	return false;
+}
 
 void ScummEngine::loadCJKFont() {
 	Common::File fp;
@@ -414,6 +420,9 @@ int CharsetRenderer::getStringWidth(int arg, const byte *text) {
 }
 
 void CharsetRenderer::addLinebreaks(int a, byte *str, int pos, int maxwidth) {
+	int lastKoreanLineBreak = -1;
+	char tmpStrBuf[512];
+	int origPos = pos;
 	int lastspace = -1;
 	int curw = 1;
 	int chr;
@@ -478,6 +487,11 @@ void CharsetRenderer::addLinebreaks(int a, byte *str, int pos, int maxwidth) {
 		if (chr == _vm->_newLineCharacter)
 			lastspace = pos - 1;
 
+		if (_vm->_useCJKMode && isScummvmKorTarget()) {
+			if (_center == false && chr == '(' && pos - 3 >= origPos && checkKSCode(str[pos -3], str[pos -2]))
+				lastKoreanLineBreak = pos - 1;
+		}
+
 		if (_vm->_useCJKMode) {
 			if (_vm->_game.platform == Common::kPlatformFMTowns) {
 				if (checkSJISCode(chr))
@@ -488,6 +502,13 @@ void CharsetRenderer::addLinebreaks(int a, byte *str, int pos, int maxwidth) {
 			} else if (chr & 0x80) {
 				pos++;
 				curw += _vm->_2byteWidth;
+				if (isScummvmKorTarget() && checkKSCode(chr, str[pos])) {
+					if (_center == false
+						&& !(pos - 4 >= origPos && str[pos - 3] == '`' && str[pos - 4] == ' ')	// prevents hanging quotation mark at the end of line
+						&& !(pos - 4 >= origPos && str[pos - 3] == '\'' && str[pos - 4] == ' ')	// prevents hanging single quotation mark at the end of line
+						&& !(pos -3 >= origPos && str[pos -3] == '('))	// prevents hanging parenthesis at the end of line
+						lastKoreanLineBreak = pos - 2;
+				}
 				// Original keeps glyph width and character dimensions separately
 				if (_vm->_language == Common::KO_KOR || _vm->_language == Common::ZH_TWN) {
 					curw++;
@@ -498,13 +519,32 @@ void CharsetRenderer::addLinebreaks(int a, byte *str, int pos, int maxwidth) {
 		} else {
 			curw += getCharWidth(chr);
 		}
-		if (lastspace == -1)
-			continue;
+		if (lastspace == -1) {
+			if (!isScummvmKorTarget() || lastKoreanLineBreak == -1) {
+				continue;
+			}
+		}
 		if (curw > maxwidth) {
-			str[lastspace] = 0xD;
-			curw = 1;
-			pos = lastspace + 1;
-			lastspace = -1;
+			if (!isScummvmKorTarget()) {
+				str[lastspace] = 0xD;
+				curw = 1;
+				pos = lastspace + 1;
+				lastspace = -1;
+			} else if (lastspace >= lastKoreanLineBreak) {
+				str[lastspace] = 0xD;
+				curw = 1;
+				pos = lastspace + 1;
+				lastspace = -1;
+				lastKoreanLineBreak = -1;
+			} else {
+				strcpy(tmpStrBuf, (char*)(str + lastKoreanLineBreak));
+				strcpy((char*)(str + lastKoreanLineBreak + 1), tmpStrBuf);
+				str[lastKoreanLineBreak] = 0xD;
+				curw = 1;
+				pos = lastKoreanLineBreak + 1;
+				lastspace = -1;
+				lastKoreanLineBreak = -1;
+			}
 		}
 	}
 

--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -82,7 +82,8 @@ void ScummEngine::loadCJKFont() {
 		_2byteFontPtr = new byte[_2byteWidth * _2byteHeight * numChar / 8];
 		// set byte 0 to 0xFF (0x00 when loaded) to indicate that the font was not loaded
 		_2byteFontPtr[0] = 0xFF;
-	} else if ((_game.version >= 7 && (_language == Common::KO_KOR || _language == Common::JA_JPN || _language == Common::ZH_TWN)) ||
+	} else if (_language == Common::KO_KOR ||
+			   (_game.version >= 7 && (_language == Common::JA_JPN || _language == Common::ZH_TWN)) ||
 			   (_game.version >= 3 && _language == Common::ZH_CNA)) {
 		int numChar = 0;
 		const char *fontFile = NULL;

--- a/engines/scumm/charset.h
+++ b/engines/scumm/charset.h
@@ -35,6 +35,18 @@ class ScummEngine;
 class NutRenderer;
 struct VirtScreen;
 
+static inline bool checkKSCode(byte hi, byte lo) {
+	//hi : xx
+	//lo : yy
+	if ((0xA1 > lo) || (0xFE < lo)) {
+		return false;
+	}
+	if ((hi >= 0xB0) && (hi <= 0xC8)) {
+		return true;
+	}
+	return false;
+}
+
 static inline bool checkSJISCode(byte c) {
 	if ((c >= 0x80 && c <= 0x9f) || (c >= 0xe0 && c <= 0xfd))
 		return true;
@@ -96,6 +108,8 @@ public:
 	virtual int getCharWidth(uint16 chr) = 0;
 
 	virtual void setColor(byte color) { _color = color; translateColor(); }
+
+	bool isScummvmKorTarget();
 
 	void saveLoadWithSerializer(Common::Serializer &ser);
 };

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -771,7 +771,7 @@ void ScummEngine::CHARSET_1() {
 #endif
 		} else {
 			if (c & 0x80 && _useCJKMode) {
-				if (checkSJISCode(c)) {
+				if (is2ByteCharacter(_language, c)) {
 					byte *buffer = _charsetBuffer + _charsetBufPos;
 					c += *buffer++ * 256; //LE
 					_charsetBufPos = buffer - _charsetBuffer;
@@ -1182,7 +1182,7 @@ void ScummEngine::drawString(int a, const byte *msg) {
 				}
 			}
 			if (c & 0x80 && _useCJKMode) {
-				if (checkSJISCode(c))
+				if (is2ByteCharacter(_language, c))
 					c += buf[i++] * 256;
 			}
 			_charset->printChar(c, true);


### PR DESCRIPTION
This PR is part of scummvm-kor merge project.

This patch introduces alternative line-break style (similar to CSS word-break: break-all), and moves the hanging punctuation mark to the next line for cleaner text display.
This is used in Monkey2 (in the Phatt Island Library.)

![scummvm-monkey2-kr-00009](https://user-images.githubusercontent.com/2627281/98361712-6ac9c980-206f-11eb-86d6-04e2fa66fc8f.png)
