### PR TITLE
GRAPHICS: Fix no shader error on Raspberry PI

### DIFF
--- a/graphics/opengl/shader.cpp
+++ b/graphics/opengl/shader.cpp
@@ -136,6 +136,14 @@ ShaderGL::ShaderGL(const Common::String &name, GLuint vertexShader, GLuint fragm
 	}
 	glLinkProgram(shaderProgram);
 
+	GLint status;
+	glGetProgramiv(shaderProgram, GL_LINK_STATUS, &status);
+	if (status != GL_TRUE) {
+		char buffer[512];
+		glGetProgramInfoLog(shaderProgram, 512, NULL, buffer);
+		error("Could not link shader %s: %s", name.c_str(), buffer);
+	}
+
 	glDetachShader(shaderProgram, vertexShader);
 	glDetachShader(shaderProgram, fragmentShader);
 


### PR DESCRIPTION
On Raspberry PI, an error in OpenGLES shaders is not reported during the compilation step but during the link step.
See https://www.raspberrypi.org/forums/viewtopic.php?t=26205 for more information (last post).

This commit simply adds reporting of errors which occurred during the link step.
