### PR TITLE
COMMON: Remove resetGraphicsScale from OSystem

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -48,7 +48,6 @@ public:
 	};
 	virtual int getDefaultGraphicsMode() const { return 0; }
 	virtual bool setGraphicsMode(int mode, uint flags = OSystem::kGfxModeNoFlags) { return (mode == 0); }
-	virtual void resetGraphicsScale() {}
 	virtual int getGraphicsMode() const { return 0; }
 	virtual const OSystem::GraphicsMode *getSupportedShaders() const {
 		static const OSystem::GraphicsMode no_shader[2] = {{"NONE", "Normal (no shader)", 0}, {0, 0, 0}};

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -285,10 +285,6 @@ int SurfaceSdlGraphicsManager::getDefaultGraphicsMode() const {
 #endif
 }
 
-void SurfaceSdlGraphicsManager::resetGraphicsScale() {
-	setGraphicsMode(s_gfxModeSwitchTable[_scalerType][0]);
-}
-
 void SurfaceSdlGraphicsManager::beginGFXTransaction() {
 	assert(_transactionMode == kTransactionNone);
 
@@ -811,7 +807,7 @@ void SurfaceSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFo
 	if ((int)w != _videoMode.screenWidth || (int)h != _videoMode.screenHeight) {
 		const bool useDefault = defaultGraphicsModeConfig();
 		if (useDefault && w > 320) {
-			resetGraphicsScale();
+			setGraphicsMode(s_gfxModeSwitchTable[_scalerType][0]);
 		} else {
 			setGraphicsMode(getGraphicsModeIdByName(ConfMan.get("gfx_mode")));
 		}

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -83,7 +83,6 @@ public:
 	virtual int getDefaultGraphicsMode() const override;
 	virtual bool setGraphicsMode(int mode, uint flags = OSystem::kGfxModeNoFlags) override;
 	virtual int getGraphicsMode() const override;
-	virtual void resetGraphicsScale() override;
 #ifdef USE_RGB_COLOR
 	virtual Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override;

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -109,10 +109,6 @@ int ModularGraphicsBackend::getStretchMode() const {
 	return _graphicsManager->getStretchMode();
 }
 
-void ModularGraphicsBackend::resetGraphicsScale() {
-	_graphicsManager->resetGraphicsScale();
-}
-
 #ifdef USE_RGB_COLOR
 
 Graphics::PixelFormat ModularGraphicsBackend::getScreenFormat() const {

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -76,7 +76,6 @@ public:
 	virtual int getDefaultStretchMode() const override final;
 	virtual bool setStretchMode(int mode) override final;
 	virtual int getStretchMode() const override final;
-	virtual void resetGraphicsScale() override final;
 #ifdef USE_RGB_COLOR
 	virtual Graphics::PixelFormat getScreenFormat() const override final;
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override final;

--- a/backends/platform/android3d/graphics.cpp
+++ b/backends/platform/android3d/graphics.cpp
@@ -252,9 +252,6 @@ bool AndroidGraphicsManager::setGraphicsMode(int mode, uint flags) {
 	return true;
 }
 
-void AndroidGraphicsManager::resetGraphicsScale() {
-}
-
 int AndroidGraphicsManager::getGraphicsMode() const {
 	return _graphicsMode;
 }

--- a/backends/platform/android3d/graphics.h
+++ b/backends/platform/android3d/graphics.h
@@ -48,7 +48,6 @@ public:
 	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
 	virtual int getDefaultGraphicsMode() const override;
 	virtual bool setGraphicsMode(int mode, uint flags = OSystem::kGfxModeNoFlags) override;
-	virtual void resetGraphicsScale() override;
 	virtual int getGraphicsMode() const override;
 
 	virtual bool hasFeature(OSystem::Feature f) const override;

--- a/common/system.h
+++ b/common/system.h
@@ -637,13 +637,6 @@ public:
 	 */
 	virtual int getGraphicsMode() const { return 0; }
 
-	/**
-	 * Sets the graphics scale factor to x1. Games with large screen sizes
-	 * reset the scale to x1 so the screen will not be too big when starting
-	 * the game.
-	 */
-	virtual void resetGraphicsScale() {}
-
 #ifdef USE_RGB_COLOR
 	/**
 	 * Determine the pixel format currently in use for screen rendering.


### PR DESCRIPTION
This function used to be called from the Engine class, but was not longer used since commit 432fd52. The single remaining use was an internal use in the SurfaceSdlGraphicsManager, and I kept the behaviour there while removing the function.