### PR TITLE
GRIM: use GL_UNSIGNED_SHORT for glDrawElements instead of GL_UNSIGNED…

### DIFF
--- a/engines/grim/emi/modelemi.cpp
+++ b/engines/grim/emi/modelemi.cpp
@@ -36,10 +36,10 @@
 namespace Grim {
 
 struct Vector3int {
-	int _x;
-	int _y;
-	int _z;
-	void setVal(int x, int y, int z) {
+	uint16 _x;
+	uint16 _y;
+	uint16 _z;
+	void setVal(uint16 x, uint16 y, uint16 z) {
 		_x = x; _y = y; _z = z;
 	}
 };
@@ -73,15 +73,14 @@ void EMIMeshFace::loadFace(Common::SeekableReadStream *data) {
 	_indexes = new Vector3int[_faceLength];
 	int j = 0;
 	for (uint32 i = 0; i < _faceLength; i ++) {
-		// FIXME: Are these ever going to be < 0 ?
 		if (g_grim->getGamePlatform() == Common::kPlatformPS2) {
-			x = data->readSint32LE();
-			y = data->readSint32LE();
-			z = data->readSint32LE();
+			x = data->readUint32LE();
+			y = data->readUint32LE();
+			z = data->readUint32LE();
 		} else {
-			x = data->readSint16LE();
-			y = data->readSint16LE();
-			z = data->readSint16LE();
+			x = data->readUint16LE();
+			y = data->readUint16LE();
+			z = data->readUint16LE();
 		}
 		_indexes[j++].setVal(x, y, z);
 	}

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -441,10 +441,10 @@ void GfxOpenGL::getScreenBoundingBox(const EMIModel *model, int *x1, int *y1, in
 	glGetIntegerv(GL_VIEWPORT, viewPort);
 
 	for (uint i = 0; i < model->_numFaces; i++) {
-		int *indices = (int *)model->_faces[i]._indexes;
+		uint16 *indices = (uint16 *)model->_faces[i]._indexes;
 
 		for (uint j = 0; j < model->_faces[i]._faceLength * 3; j++) {
-			int index = indices[j];
+			uint16 index = indices[j];
 			Math::Vector3d obj = model->_drawVertices[index];
 			Math::Vector3d win;
 			Math::gluMathProject<GLdouble, GLint>(obj, modelView, projection, viewPort, win);
@@ -736,7 +736,7 @@ void GfxOpenGL::set3DMode() {
 }
 
 void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face) {
-	int *indices = (int *)face->_indexes;
+	uint16 *indices = (uint16 *)face->_indexes;
 
 	glEnable(GL_DEPTH_TEST);
 	glDisable(GL_ALPHA_TEST);
@@ -755,7 +755,7 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 	}
 	Math::Vector3d noLighting(1.f, 1.f, 1.f);
 	for (uint j = 0; j < face->_faceLength * 3; j++) {
-		int index = indices[j];
+		uint16 index = indices[j];
 
 		if (!_currentShadowArray) {
 			if (face->_hasTexture) {

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -535,10 +535,10 @@ void GfxOpenGLS::getScreenBoundingBox(const EMIModel *model, int *x1, int *y1, i
 	double bottom = -1000;
 
 	for (uint i = 0; i < model->_numFaces; i++) {
-		int *indices = (int *)model->_faces[i]._indexes;
+		uint16 *indices = (uint16 *)model->_faces[i]._indexes;
 
 		for (uint j = 0; j < model->_faces[i]._faceLength * 3; j++) {
-			int index = indices[j];
+			uint16 index = indices[j];
 			const Math::Vector3d &dv = model->_drawVertices[index];
 
 			Math::Vector4d v = Math::Vector4d(dv.x(), dv.y(), dv.z(), 1.0f);
@@ -960,7 +960,7 @@ void GfxOpenGLS::drawEMIModelFace(const EMIModel* model, const EMIMeshFace* face
 
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, face->_indicesEBO);
 
-	glDrawElements(GL_TRIANGLES, 3 * face->_faceLength, GL_UNSIGNED_INT, 0);
+	glDrawElements(GL_TRIANGLES, 3 * face->_faceLength, GL_UNSIGNED_SHORT, 0);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
@@ -2015,7 +2015,7 @@ void GfxOpenGLS::createEMIModel(EMIModel *model) {
 
 	for (uint32 i = 0; i < model->_numFaces; ++i) {
 		EMIMeshFace * face = &model->_faces[i];
-		face->_indicesEBO = OpenGL::ShaderGL::createBuffer(GL_ELEMENT_ARRAY_BUFFER, face->_faceLength * 3 * sizeof(uint32), face->_indexes, GL_STATIC_DRAW);
+		face->_indicesEBO = OpenGL::ShaderGL::createBuffer(GL_ELEMENT_ARRAY_BUFFER, face->_faceLength * 3 * sizeof(uint16), face->_indexes, GL_STATIC_DRAW);
 	}
 
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -329,10 +329,10 @@ void GfxTinyGL::getScreenBoundingBox(const EMIModel *model, int *x1, int *y1, in
 	tglGetIntegerv(TGL_VIEWPORT, viewPort);
 
 	for (uint i = 0; i < model->_numFaces; i++) {
-		int *indices = (int *)model->_faces[i]._indexes;
+		uint16 *indices = (uint16 *)model->_faces[i]._indexes;
 		
 		for (uint j = 0; j < model->_faces[i]._faceLength * 3; j++) {
-			int index = indices[j];
+			uint16 index = indices[j];
 
 			Math::Vector3d obj = model->_drawVertices[index];
 			Math::Vector3d win;
@@ -614,7 +614,7 @@ void GfxTinyGL::getShadowColor(byte *r, byte *g, byte *b) {
 }
 
 void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face) {
-	int *indices = (int *)face->_indexes;
+	uint16 *indices = (uint16 *)face->_indexes;
 
 	tglEnable(TGL_DEPTH_TEST);
 	tglDisable(TGL_ALPHA_TEST);
@@ -633,7 +633,7 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 	}
 	Math::Vector3d noLighting(1.f, 1.f, 1.f);
 	for (uint j = 0; j < face->_faceLength * 3; j++) {
-		int index = indices[j];
+		uint16 index = indices[j];
 
 		if (!_currentShadowArray) {
 			if (face->_hasTexture) {


### PR DESCRIPTION
When running with an OpenGL ES 2 library (not above), glDrawElements(GL_TRIANGLES,3 * face->_faceLength, GL_UNSIGNED_INT, 0) of drawEMIModelFace() (gfx_opengl_shaders.cpp) exits with error code GL_INVALID_ENUM.

Indeed, GLES v2 doesn't support GL_UNSIGNED_INT (only BYTE and SHORT).
See documentation here:  http://docs.gl/es2/glDrawElements

This modification converts GL_UNSIGNED_INT to GL_UNSIGNED_SHORT.
It has been tested and works 
- on different platforms: Raspberry PI 2 and Raspberry PI 3 (both OpenGLES2), Raspberry PI 4 and Odroid XU 4 (OpenGLES3), X86-64 (OpenGLES3, OpenGL without shaders and TinyGL)
- for different games: Grim Fandango (normal and remastered), Escape from Monkey Island (PC and PS2)

The same modification should also be done for Stark engine ... not for Myst3 and Wintermute.

This merge has initially been proposed on ResidualVM project.
See https://github.com/residualvm/residualvm/issues/1519 for the corresponding issue and details.