### PR TITLE
SCUMM: Implement language bundle for Korean fan translation

### DIFF
--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1116,8 +1116,7 @@ void ScummEngine::loadPtrToResource(ResType type, ResId idx, const byte *source)
 
 	// Translate resource text
 	byte translateBuffer[512];
-	if (isScummvmKorTarget())
-	{
+	if (isScummvmKorTarget()) {
 		if (!source) {
 			refreshScriptPointer();
 			source = _scriptPointer;

--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1103,11 +1103,30 @@ void ScummEngine::loadPtrToResource(ResType type, ResId idx, const byte *source)
 	byte *alloced;
 	int len;
 
+	bool sourceWasNull = !source;
+	int originalLen;
+
 	_res->nukeResource(type, idx);
 
 	len = resStrLen(source) + 1;
 	if (len <= 0)
 		return;
+
+	originalLen = len;
+
+	// Translate resource text
+	byte translateBuffer[512];
+	if (isScummvmKorTarget())
+	{
+		if (!source) {
+			refreshScriptPointer();
+			source = _scriptPointer;
+		}
+		translateText(source, translateBuffer);
+
+		source = translateBuffer;
+		len = resStrLen(source) + 1;
+	}
 
 	alloced = _res->createResource(type, idx, len);
 
@@ -1115,8 +1134,12 @@ void ScummEngine::loadPtrToResource(ResType type, ResId idx, const byte *source)
 		// Need to refresh the script pointer, since createResource may
 		// have caused the script resource to expire.
 		refreshScriptPointer();
-		memcpy(alloced, _scriptPointer, len);
-		_scriptPointer += len;
+		memcpy(alloced, _scriptPointer, originalLen);
+		_scriptPointer += originalLen;
+	} else if (sourceWasNull) {
+		refreshScriptPointer();
+		memcpy(alloced, source, len);
+		_scriptPointer += originalLen;
 	} else {
 		memcpy(alloced, source, len);
 	}

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -325,9 +325,9 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 	_costumeRenderer = NULL;
 	_existLanguageFile = false;
 	_languageBuffer = 0;
-	_translatedLines = 0;
 	_numTranslatedLines = 0;
-	_lastUsedTranslatedLine = 0;
+	_translatedLines = 0;
+	_languageLineIndex = 0;
 	_2byteFontPtr = 0;
 	_krStrPost = 0;
 	_V1TalkingActor = 0;
@@ -624,10 +624,10 @@ ScummEngine::~ScummEngine() {
 
 	delete[] _languageBuffer;
 	delete[] _translatedLines;
+	delete[] _languageLineIndex;
 
-	delete[] _2byteFontPtr;
 	if (_2byteFontPtr && !_useMultiFont)
-		delete _2byteFontPtr;
+		delete[] _2byteFontPtr;
 	for (int i = 0; i < 20; i++)
 		if (_2byteMultiFontPtr[i])
 			delete _2byteMultiFontPtr[i];

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -325,9 +325,9 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 	_costumeRenderer = NULL;
 	_existLanguageFile = false;
 	_languageBuffer = 0;
-	_translationEntries = 0;
-	_numTranslationEntry = 0;
-	_lastUsedTranslationEntry = 0;
+	_translatedLines = 0;
+	_numTranslatedLines = 0;
+	_lastUsedTranslatedLine = 0;
 	_2byteFontPtr = 0;
 	_krStrPost = 0;
 	_V1TalkingActor = 0;
@@ -623,7 +623,7 @@ ScummEngine::~ScummEngine() {
 	delete[] _sortedActors;
 
 	delete[] _languageBuffer;
-	delete[] _translationEntries;
+	delete[] _translatedLines;
 
 	delete[] _2byteFontPtr;
 	if (_2byteFontPtr && !_useMultiFont)

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -323,6 +323,11 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 	_msgCount = 0;
 	_costumeLoader = NULL;
 	_costumeRenderer = NULL;
+	_existLanguageFile = false;
+	_languageBuffer = 0;
+	_translationEntries = 0;
+	_numTranslationEntry = 0;
+	_lastUsedTranslationEntry = 0;
 	_2byteFontPtr = 0;
 	_krStrPost = 0;
 	_V1TalkingActor = 0;
@@ -617,6 +622,10 @@ ScummEngine::~ScummEngine() {
 
 	delete[] _sortedActors;
 
+	delete[] _languageBuffer;
+	delete[] _translationEntries;
+
+	delete[] _2byteFontPtr;
 	if (_2byteFontPtr && !_useMultiFont)
 		delete _2byteFontPtr;
 	for (int i = 0; i < 20; i++)

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1160,9 +1160,8 @@ public:
 
 private:
 	struct TranslatedLine {
-		uint16 key;
-		uint32 originalOffset;
-		uint32 translatedOffset;
+		uint32 originalTextOffset;
+		uint32 translatedTextOffset;
 	};
 
 	struct TranslationRange {
@@ -1173,12 +1172,18 @@ private:
 		TranslationRange() : left(0), right(0) {}
 	};
 
+	struct TranslationRoom {
+		Common::HashMap<uint32, TranslationRange> scriptRanges;
+	};
+
 	bool _existLanguageFile;
 	byte *_languageBuffer;
-	TranslatedLine *_translatedLines;
-	Common::HashMap<uint16, TranslationRange> _languageIndex;
 	int _numTranslatedLines;
-	int _lastUsedTranslatedLine;
+	TranslatedLine *_translatedLines;
+	uint16 *_languageLineIndex;
+	Common::HashMap<byte, TranslationRoom> _roomIndex;
+
+	const byte *searchTranslatedLine(const byte *text, const TranslationRange &range);
 
 public:
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1159,27 +1159,26 @@ public:
 	int _2byteMultiShadow[20];
 
 private:
-	bool _existLanguageFile;
-	byte *_languageBuffer;
-
-	struct TranslationEntry {
+	struct TranslatedLine {
 		uint16 key;
 		uint32 originalOffset;
 		uint32 translatedOffset;
 	};
 
-	struct Range {
+	struct TranslationRange {
 		uint32 left;
 		uint32 right;
 
-		Range(uint32 left_, uint32 right_) : left(left_), right(right_) {}
-		Range() : left(0), right(0) {}
+		TranslationRange(uint32 left_, uint32 right_) : left(left_), right(right_) {}
+		TranslationRange() : left(0), right(0) {}
 	};
 
-	TranslationEntry *_translationEntries;
-	Common::HashMap<uint16, Range> _languageIndex;
-	int _numTranslationEntry;
-	int _lastUsedTranslationEntry;
+	bool _existLanguageFile;
+	byte *_languageBuffer;
+	TranslatedLine *_translatedLines;
+	Common::HashMap<uint16, TranslationRange> _languageIndex;
+	int _numTranslatedLines;
+	int _lastUsedTranslatedLine;
 
 public:
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1183,7 +1183,7 @@ private:
 	uint16 *_languageLineIndex;
 	Common::HashMap<byte, TranslationRoom> _roomIndex;
 
-	const byte *searchTranslatedLine(const byte *text, const TranslationRange &range);
+	const byte *searchTranslatedLine(const byte *text, const TranslationRange &range, bool useIndex);
 
 public:
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -356,7 +356,7 @@ protected:
 	void setupCharsetRenderer();
 	void setupCostumeRenderer();
 
-	virtual void loadLanguageBundle() {}
+	virtual void loadLanguageBundle();
 	void loadCJKFont();
 	void loadKorFont();
 	void setupMusic(int midi);
@@ -1157,6 +1157,29 @@ public:
 	int _2byteMultiHeight[20];
 	int _2byteMultiWidth[20];
 	int _2byteMultiShadow[20];
+
+private:
+	bool _existLanguageFile;
+	byte *_languageBuffer;
+
+	struct TranslationEntry {
+		uint16 key;
+		uint32 originalOffset;
+		uint32 translatedOffset;
+	};
+
+	struct Range {
+		uint32 left;
+		uint32 right;
+
+		Range(uint32 left_, uint32 right_) : left(left_), right(right_) {}
+		Range() : left(0), right(0) {}
+	};
+
+	TranslationEntry *_translationEntries;
+	Common::HashMap<uint16, Range> _languageIndex;
+	int _numTranslationEntry;
+	int _lastUsedTranslationEntry;
 
 public:
 

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1911,7 +1911,7 @@ void ScummEngine::loadLanguageBundle() {
 	}
 
 	ScummFile file;
-	openFile(file, "language.bnd");
+	openFile(file, "korean.trs");
 
 	if (!file.isOpen()) {
 		_existLanguageFile = false;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1946,7 +1946,9 @@ void ScummEngine::loadLanguageBundle() {
 
 	// sanity check
 	for (int i = 0; i < _numTranslatedLines; i++) {
-		assert(_languageLineIndex[i] != 0xffff);
+		if (_languageLineIndex[i] == 0xffff) {
+			error("Invalid language bundle file");
+		}
 	}
 
 	// Room
@@ -2038,6 +2040,8 @@ void ScummEngine::translateText(const byte *text, byte *trans_buff) {
 			// used in drawVerb(), etc
 			debug(7, "translateText: Room=%d, CurrentScript == 0xff", _currentRoom);
 		} else {
+			// Use series of heuristics to preserve "the context of the conversation",
+			// since one English text can be translated differently depending on the context.
 			ScriptSlot *slot = &vm.slot[_currentScript];
 			debug(7, "translateText: Room=%d, Script=%d, WIO=%d", _currentRoom, slot->number, slot->where);
 
@@ -2046,13 +2050,10 @@ void ScummEngine::translateText(const byte *text, byte *trans_buff) {
 				roomKey = _currentRoom;
 			}
 
-			uint32 scriptKey = (uint32)slot->where << 16 | slot->number;
+			uint32 scriptKey = slot->where << 16 | slot->number;
 			if (slot->where == WIO_ROOM) {
-				scriptKey = (uint32)slot->where << 16;
+				scriptKey = slot->where << 16;
 			}
-
-			// The purpose of the heuristics is to preserve context.
-			// The same English text can be translated differently depending on the context.
 
 			// First search by _currentRoom and _currentScript
 			Common::HashMap<byte, TranslationRoom>::const_iterator iterator = _roomIndex.find(roomKey);

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1991,25 +1991,6 @@ void ScummEngine::loadLanguageBundle() {
 	debug(2, "loadLanguageBundle: Loaded %d entries", _numTranslatedLines);
 }
 
-// strcmp equivalent for Scumm string
-static int compareResString(const byte* a, int aLen, const byte* b, int bLen) {
-	byte c1;
-	byte c2;
-
-	int i = 0;
-	do {
-		c1 = a[i];
-		c2 = b[i];
-
-		if (i >= aLen - 1 || i >= bLen - 1)
-			return c1 - c2;
-
-		i++;
-	} while (c1 == c2);
-
-	return c1 - c2;
-}
-
 const byte *ScummEngine::searchTranslatedLine(const byte *text, const TranslationRange &range, bool useIndex) {
 	int textLen = resStrLen(text);
 
@@ -2025,7 +2006,7 @@ const byte *ScummEngine::searchTranslatedLine(const byte *text, const Translatio
 		int idx = useIndex ? _languageLineIndex[mid] : mid;
 		const byte *originalText = &_languageBuffer[_translatedLines[idx].originalTextOffset];
 		int originalLen = resStrLen(originalText);
-		int compare = compareResString(text, textLen + 1, originalText, originalLen + 1);
+		int compare = memcmp(text, originalText, MIN(textLen + 1, originalLen + 1));
 		if (compare == 0) {
 			debug(8, "searchTranslatedLine: Found in %d iteration", dbgIterationCount);
 			const byte *translatedText = &_languageBuffer[_translatedLines[idx].translatedTextOffset];

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1620,6 +1620,11 @@ static int indexCompare(const void *p1, const void *p2) {
 
 // Create an index of the language file.
 void ScummEngine_v7::loadLanguageBundle() {
+	if (isScummvmKorTarget()) {
+		// HACK to support language bundle for FT
+		ScummEngine::loadLanguageBundle();
+		return;
+	}
 	ScummFile file;
 	int32 size;
 
@@ -1796,6 +1801,11 @@ void ScummEngine_v7::playSpeech(const byte *ptr) {
 }
 
 void ScummEngine_v7::translateText(const byte *text, byte *trans_buff) {
+	if (isScummvmKorTarget()) {
+		// HACK to support language bundle for FT
+		ScummEngine::translateText(text, trans_buff);
+		return;
+	}
 	LangIndexNode target;
 	LangIndexNode *found = NULL;
 	int i;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1927,7 +1927,7 @@ void ScummEngine::loadLanguageBundle() {
 		return;
 	}
 
-	_numTranslatedLines = file.readUint32LE();
+	_numTranslatedLines = file.readUint16LE();
 	_translatedLines = new TranslatedLine[_numTranslatedLines];
 	_languageLineIndex = new uint16[_numTranslatedLines];
 

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1621,7 +1621,7 @@ static int indexCompare(const void *p1, const void *p2) {
 // Create an index of the language file.
 void ScummEngine_v7::loadLanguageBundle() {
 	if (isScummvmKorTarget()) {
-		// HACK to support language bundle for FT
+		// Support language bundle for FT
 		ScummEngine::loadLanguageBundle();
 		return;
 	}
@@ -1802,7 +1802,7 @@ void ScummEngine_v7::playSpeech(const byte *ptr) {
 
 void ScummEngine_v7::translateText(const byte *text, byte *trans_buff) {
 	if (isScummvmKorTarget()) {
-		// HACK to support language bundle for FT
+		// Support language bundle for FT
 		ScummEngine::translateText(text, trans_buff);
 		return;
 	}


### PR DESCRIPTION
This adds support for language bundle to the SCUMM v1~v7 games.
It enables fan translation without the need for patching game resource.
While it's kind of similar to the DIG/COMI language bundle, the file format and the logic is different.

Tested with:
- Maniac Mansion (V1 DOS)
- Indy 3, 4 (Steam)
- Loom (EGA)
- Day of the Tentacle (CD)
- Sam & Max (CD)
- Full Throttle