### PR TITLE
GUI: Retain scroll position when deleting a save

### DIFF
--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -467,7 +467,9 @@ void SaveLoadChooserSimple::handleCommand(CommandSender *sender, uint32 cmd, uin
 				_metaEngine->removeSaveState(_target.c_str(), _saveList[selItem].getSaveSlot());
 
 				setResult(-1);
-				_list->setSelected(-1);
+				int scrollPos = _list->getCurrentScrollPos();
+				_list->setSelected(-1); // resets scroll pos
+				_list->scrollTo(scrollPos);
 
 				updateSaveList();
 				updateSelection(true);


### PR DESCRIPTION
Currently, deleting a save game resets the scroll position, scrolling the list to the very top. This isn't noticeable if there's not many saves, but once there's a lot it's a pain to delete save 72, get kicked back to the beginning, and then try to find where you were again. This happens to me frequently. It doesn't look like the current behavior is intentional and I think it's reasonable to expect the list to be stable when deleting.