### PR TITLE
STARTREK: Additional detection entries

### DIFF
--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -296,6 +296,34 @@ static const StarTrekGameDescription gameDescriptions[] = {
 		GF_CDROM,
 	},
 
+	{ // STJR DOS Floppy edition (ENG) (The White Label - Doubles)
+		{
+			"stjr",
+			"Floppy",
+			AD_ENTRY1s("data.001", "1c8de3c02f69c07c582d59d3c29e4dd9", 2955146),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GType_STJR,
+		0
+	},
+
+	{ // STJR DOS Floppy edition (FRA) (The White Label - Doubles)
+		{
+			"stjr",
+			"Floppy",
+			AD_ENTRY1s("data.001", "1c8de3c02f69c07c582d59d3c29e4dd9", 2966180),
+			Common::FR_FRA,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GType_STJR,
+		0
+	},
+
 	{ AD_TABLE_END_MARKER, 0, 0 }
 };
 

--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -123,6 +123,20 @@ static const StarTrekGameDescription gameDescriptions[] = {
 		0,
 	},
 
+	{ // ST25 DOS floppy edition (EN) #3 (Interplay's 10 Year Anthology: Classic Collection)
+		{
+			"st25",
+			"Floppy",
+			AD_ENTRY1s("data.001", "57040928a0f374281aa86ba4e7db8444", 7222652),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GType_ST25,
+		0,
+	},
+
 	{ // ST25 DOS floppy edition (GER)
 		{
 			"st25",


### PR DESCRIPTION
This adds some detection entries to the Star Trek engine, though I'm not sure whether or not they should be labelled floppy versions or not.

- English Star Trek: 25th Anniversary included on Interplay's 10 Year Anniversary: Classic Collection.
- English Star Trek: Judgment Rites included on The White Label - Doubles
- French Star Trek: Judgment Rites included on The White Label - Doubles

So are they floppy versions? Well, none of them have speech at least.

The White Label CD contains three versions of Judgment Rites: English, German (already detected by ScummVM, albeit as a CD version) and French. Each folder takes up about 44 MB on the CD, for a total of about 133 MB. (The 25th Anniversary CD also has English, German and French versions, but they are all detected by ScummVM. I think the speech is English only.) This may be a bit large for a floppy game? Though if I run the included HD installer, I only get a 27 MB folder on my hard drive since there is a RITES.RNC file (18 MB) that it doesn't copy. Could that be a compressed archive of the other files?

The 10 Year Anthology contains one version of Star Trek: 25th Anniversary. The folder is about 7.2 MB on the CD.

I also have the Macintosh versions on CD, but I may need help if I'm to provide detection entries for those.

The 25th Anniversary CD has a "Voice Data" folder that should be simple enough to copy, but I'm guessing the rest of the files are bundled up in a "Star Trek CD-ROM Installer" thing, so that one probably needs to be run through a Mac emulator.

The Judgment Rites CD has "Movies" and "Speech" folders, with the rest presumably being bundled up into an "Install Star Trek JR" thing. My copy includes a bonus disc with interviews etc. (presumably the same as the bonus disc from the DOS version), but I assume that's outside the scope of this engine.