### PR TITLE
GRAPHICS: Fix GL crash on AmigaOS4 (at least)

### DIFF
--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -174,7 +174,7 @@ void OpenGLSdlGraphics3dManager::setupScreen() {
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	bool needsWindowReset = false;
-	if (_window->getSDLWindow()) {
+	if (_window->getSDLWindow() && _glContext) {
 		// The anti-aliasing setting cannot be changed without recreating the window.
 		// So check if the window needs to be recreated.
 


### PR DESCRIPTION
It looks like OpenGL calls are executed without context.

Just before the crash:
[OS4_GL_MakeCurrent] Called window=0x00000000 context=0x00000000
[OS4_GL_DeleteContext] Called with context=0x6319D300
[OS4_GL_DeleteContext] Found MiniGL context, clearing window binding
[OS4_GL_GetProcAddress] Called for 'glGetString'
[OS4_GL_GetProcAddress] Called for 'glGetIntegerv'

So, the context was deleted right before the crash happened on glGetInteger.
I think the issue might be in ScummVM, because SDL_GL_GetAttribute is supposed to get information about "the current context" ( https://wiki.libsdl.org/SDL_GL_GetAttribute ), which doesn't exist (== nullptr) here:
https://github.com/scummvm/scummvm/blob/master/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp#L182

Please be aware that i´m not sure if this is the correct solution (especially because it addresses all platforms), it at least fixes all the crashes i get in numerous 3D games for me (Grim, EMI, Myst3, WME etc.)

Please advise, thank you