### PR TITLE
SCUMM: COMI: improve handling of iMUSE markers and triggers

### DIFF
--- a/engines/scumm/imuse_digi/dimuse.cpp
+++ b/engines/scumm/imuse_digi/dimuse.cpp
@@ -414,20 +414,36 @@ void IMuseDigital::switchToNextRegion(Track *track) {
 	ImuseDigiSndMgr::SoundDesc *soundDesc = track->soundDesc;
 	if (_triggerUsed && track->soundDesc->numMarkers) {
 		if (_sound->checkForTriggerByRegionAndMarker(soundDesc, track->curRegion, _triggerParams.marker)) {
-			debug(5, "SwToNeReg(trackId:%d) - trigger %s reached", track->trackId, _triggerParams.marker);
-			debug(5, "SwToNeReg(trackId:%d) - exit current region %d", track->trackId, track->curRegion);
-			debug(5, "SwToNeReg(trackId:%d) - call cloneToFadeOutTrack(delay:%d)", track->trackId, _triggerParams.fadeOutDelay);
-			Track *fadeTrack = cloneToFadeOutTrack(track, _triggerParams.fadeOutDelay);
-			if (fadeTrack) {
-				fadeTrack->dataOffset = _sound->getRegionOffset(fadeTrack->soundDesc, fadeTrack->curRegion);
-				fadeTrack->regionOffset = 0;
-				debug(5, "SwToNeReg(trackId:%d)-sound(%d) select region %d, curHookId: %d", fadeTrack->trackId, fadeTrack->soundId, fadeTrack->curRegion, fadeTrack->curHookId);
-				fadeTrack->curHookId = 0;
+			if (_vm->_game.id != GID_CMI) {
+				debug(5, "SwToNeReg(trackId:%d) - trigger %s reached", track->trackId, _triggerParams.marker);
+				debug(5, "SwToNeReg(trackId:%d) - exit current region %d", track->trackId, track->curRegion);
+				debug(5, "SwToNeReg(trackId:%d) - call cloneToFadeOutTrack(delay:%d)", track->trackId, _triggerParams.fadeOutDelay);
+				Track *fadeTrack = cloneToFadeOutTrack(track, _triggerParams.fadeOutDelay);
+				if (fadeTrack) {
+					fadeTrack->dataOffset = _sound->getRegionOffset(fadeTrack->soundDesc, fadeTrack->curRegion);
+					fadeTrack->regionOffset = 0;
+					debug(5, "SwToNeReg(trackId:%d)-sound(%d) select region %d, curHookId: %d", fadeTrack->trackId, fadeTrack->soundId, fadeTrack->curRegion, fadeTrack->curHookId);
+					fadeTrack->curHookId = 0;
+				}
+				flushTrack(track);
+				startMusic(_triggerParams.filename, _triggerParams.soundId, _triggerParams.hookId, _triggerParams.volume);
+				_triggerUsed = false;
+				return;
+			} else {
+				// Behavior for "_end" (and "exit") marker
+				debug(5, "SwToNeReg(trackId:%d) - trigger %s reached", track->trackId, _triggerParams.marker);
+				debug(5, "SwToNeReg(trackId:%d) - exit current region %d", track->trackId, track->curRegion);
+				debug(5, "SwToNeReg(trackId:%d) - call handleComiFadeOut(delay:%d)", track->trackId, _triggerParams.fadeOutDelay);
+				handleComiFadeOut(track, _triggerParams.fadeOutDelay);
+				track->dataOffset = _sound->getRegionOffset(track->soundDesc, track->curRegion);
+				track->regionOffset = 0;
+				debug(5, "SwToNeReg(trackId:%d)-sound(%d) select region %d, curHookId: %d", track->trackId, track->soundId, track->curRegion, track->curHookId);
+				track->curHookId = 0;
+				if (!scumm_stricmp(_triggerParams.marker, "exit"))
+					startMusic(_triggerParams.filename, _triggerParams.soundId, _triggerParams.hookId, _triggerParams.volume);
+				_triggerUsed = false;
+				return;
 			}
-			flushTrack(track);
-			startMusic(_triggerParams.filename, _triggerParams.soundId, _triggerParams.hookId, _triggerParams.volume);
-			_triggerUsed = false;
-			return;
 		}
 	}
 

--- a/engines/scumm/imuse_digi/dimuse.cpp
+++ b/engines/scumm/imuse_digi/dimuse.cpp
@@ -459,9 +459,16 @@ void IMuseDigital::switchToNextRegion(Track *track) {
 			track->curRegion = region;
 			debug(5, "SwToNeReg(trackId:%d) - sound(%d) jump to region %d, curHookId: %d", track->trackId, track->soundId, track->curRegion, track->curHookId);
 			track->curHookId = 0;
-			
 		} else {
-			debug(5, "SwToNeReg(trackId:%d) - Normal switch region, sound(%d), hookId(%d)", track->trackId, track->soundId, track->curHookId);
+			// Check if the jump led to a  "start" marker; if so, we have to enforce it anyway.
+			// Fixes bug/edge-case #11956;
+			// Go see ImuseDigiSndMgr::getJumpIdByRegionAndHookId(...) for further information.
+			if (_vm->_game.id == GID_CMI && soundDesc->jump[jumpId].dest == soundDesc->marker[2].pos && !scumm_stricmp(soundDesc->marker[2].ptr, "start")) {
+				track->curRegion = region;
+				debug(5, "SwToNeReg(trackId:%d) - Enforced sound(%d) jump to region %d marked with a \"start\" marker, hookId(%d)", track->trackId, track->soundId, track->curRegion, track->curHookId);
+			} else {
+				debug(5, "SwToNeReg(trackId:%d) - Normal switch region, sound(%d), hookId(%d)", track->trackId, track->soundId, track->curHookId);
+			}
 		}
 	} else {
 		debug(5, "SwToNeReg(trackId:%d) - Normal switch region, sound(%d), hookId(%d)", track->trackId, track->soundId, track->curHookId);

--- a/engines/scumm/imuse_digi/dimuse_music.cpp
+++ b/engines/scumm/imuse_digi/dimuse_music.cpp
@@ -322,6 +322,8 @@ void IMuseDigital::playComiMusic(const char *songName, const imuseComiTable *tab
 		return;
 	}
 
+	TriggerParams trigger;
+
 	switch (table->transitionType) {
 	case 0:
 	default:
@@ -330,12 +332,33 @@ void IMuseDigital::playComiMusic(const char *songName, const imuseComiTable *tab
 		setHookIdForMusic(table->hookId);
 		break;
 	case 9:
-		_stopingSequence = 1;
+		// Setup the trigger
+		strcpy(trigger.marker, "_end"); trigger.fadeOutDelay = table->fadeOutDelay;
+		strcpy(trigger.filename, table->filename); trigger.soundId = table->soundId;
+		trigger.hookId = table->hookId; trigger.volume = 127;
+		setTrigger(&trigger);
+
 		setHookIdForMusic(table->hookId);
+		break;
+	case 4:
+		if (table->filename[0] == 0) {
+			fadeOutMusic(60);
+			return;
+		}
+		if (getCurMusicSoundId() == table->soundId)
+			return;
+
+		// Setup the trigger
+		strcpy(trigger.marker, "_end"); trigger.fadeOutDelay = table->fadeOutDelay;
+		strcpy(trigger.filename, table->filename); trigger.soundId = table->soundId;
+		trigger.hookId = table->hookId; trigger.volume = 127;
+		setTrigger(&trigger);
+
+		fadeOutMusic(table->fadeOutDelay);
+		startMusic(table->filename, table->soundId, hookId, 127);
 		break;
 	case 2:
 	case 3:
-	case 4:
 	case 12:
 		if (table->filename[0] == 0) {
 			fadeOutMusic(60);
@@ -352,7 +375,7 @@ void IMuseDigital::playComiMusic(const char *songName, const imuseComiTable *tab
 				(table->attribPos == _comiStateMusicTable[_curMusicState].attribPos)) {
 			fadeOutMusicAndStartNew(table->fadeOutDelay, table->filename, table->soundId);
 		} else if (table->transitionType == 12) {
-			TriggerParams trigger;
+			// Setup the trigger
 			strcpy(trigger.marker, "exit"); trigger.fadeOutDelay = table->fadeOutDelay;
 			strcpy(trigger.filename, table->filename); trigger.soundId = table->soundId;
 			trigger.hookId = table->hookId; trigger.volume = 127;

--- a/engines/scumm/imuse_digi/dimuse_sndmgr.cpp
+++ b/engines/scumm/imuse_digi/dimuse_sndmgr.cpp
@@ -70,7 +70,7 @@ void ImuseDigiSndMgr::countElements(byte *ptr, int &numRegions, int &numJumps, i
 			size = READ_BE_UINT32(ptr); ptr += size + 4;
 			break;
 		case MKTAG('T','E','X','T'):
-			if (!scumm_stricmp((const char *)(ptr + 8), "exit"))
+			if (!scumm_stricmp((const char *)(ptr + 8), "exit") || _vm->_game.id == GID_CMI)
 				numMarkers++;
 			size = READ_BE_UINT32(ptr); ptr += size + 4;
 			break;
@@ -256,7 +256,7 @@ void ImuseDigiSndMgr::prepareSound(byte *ptr, SoundDesc *sound) {
 				sound->channels = READ_BE_UINT32(ptr); ptr += 4;
 				break;
 			case MKTAG('T','E','X','T'):
-				if (!scumm_stricmp((const char *)(ptr + 8), "exit")) {
+				if (!scumm_stricmp((const char *)(ptr + 8), "exit") || _vm->_game.id == GID_CMI) {
 					sound->marker[curIndexMarker].pos = READ_BE_UINT32(ptr + 4);
 					sound->marker[curIndexMarker].length = strlen((const char *)(ptr + 8)) + 1;
 					sound->marker[curIndexMarker].ptr = new char[sound->marker[curIndexMarker].length];
@@ -567,12 +567,26 @@ int ImuseDigiSndMgr::getJumpIdByRegionAndHookId(SoundDesc *soundDesc, int region
 	assert(checkForProperHandle(soundDesc));
 	assert(region >= 0 && region < soundDesc->numRegions);
 	int32 offset = soundDesc->region[region].offset;
+	int jumpIdCandidate = -1;
 	for (int l = 0; l < soundDesc->numJumps; l++) {
 		if (offset == soundDesc->jump[l].offset) {
+			jumpIdCandidate = l;
 			if (soundDesc->jump[l].hookId == hookId)
 				return l;
 		}
 	}
+	// We missed the jump because we didn't have the right hookId...
+	// ...but if that jump led to a region with a "start" marker we have to enforce it anyway!
+	// This fixes edge-cases (like bug #11956) where a different hookId than the one expected prevents us
+	// from playing the music track from the "start" marker, effectively playing also the
+	// silence (or ambient noise) which precedes it.
+	if (_vm->_game.id == GID_CMI)
+		if (jumpIdCandidate != -1) {
+			offset = soundDesc->jump[jumpIdCandidate].dest;
+			// Element 2 in marker[] should always be "start"
+			if (offset == soundDesc->marker[2].pos && !scumm_stricmp(soundDesc->marker[2].ptr, "start"))
+				return jumpIdCandidate;
+		}
 
 	return -1;
 }

--- a/engines/scumm/imuse_digi/dimuse_track.cpp
+++ b/engines/scumm/imuse_digi/dimuse_track.cpp
@@ -171,7 +171,7 @@ void IMuseDigital::startSound(int soundId, const char *soundName, int soundType,
 				track->regionOffset -= track->regionOffset >= (track->feedSize / _callbackFps) ? (track->feedSize / _callbackFps) : 0;
 			}
 		}
-		if (_vm->_game.id == GID_CMI) {
+		if (_vm->_game.id == GID_CMI && (track->volGroupId == IMUSE_VOLGRP_MUSIC)) {
 			// Fade in the new track
 			track->vol = 0;
 			track->volFadeDelay = fadeDelay;
@@ -353,9 +353,9 @@ void IMuseDigital::setTrigger(TriggerParams *trigger) {
 }
 
 Track *IMuseDigital::handleComiFadeOut(Track *track, int fadeDelay) {
-	track->volFadeDelay = fadeDelay;
+	track->volFadeDelay = fadeDelay != 0 ? fadeDelay : 60;
 	track->volFadeDest = 0;
-	track->volFadeStep = (track->volFadeDest - track->vol) * 60 * (1000 / _callbackFps) / (1000 * fadeDelay);
+	track->volFadeStep = (track->volFadeDest - track->vol) * 60 * (1000 / _callbackFps) / (1000 * track->volFadeDelay);
 	track->volFadeUsed = true;
 	track->toBeRemoved = true;
 	return track;
@@ -441,6 +441,7 @@ int IMuseDigital::transformVolumeLinearToEqualPow(int volume, int mode) {
 			break;
 		case 6:  // Half sine curve
 			eqPowValue = (1.0 - cos(mappedValue * M_PI)) / 2.0;
+			break;
 		default: // Fallback to linear
 			eqPowValue = mappedValue;
 			break;


### PR DESCRIPTION
These commits fix the root cause for bug [#11956](https://bugs.scummvm.org/ticket/11956) (even though that song now starts way too early, I need some help on figuring out why that happens, but at least the JUMP behavior is now correct), and implements handling for "_end" triggers found in transitions type 4 and 9.
As a result, this fixes the ending point for a couple of music tracks (seqArriveBarber and seqAttack), which played until the whole audio file had finished, instead of ending on the "_end" marker.