### PR TITLE
AMIGAOS: Add native system dialogs support through ASL

### DIFF
--- a/backends/dialogs/amigaos/amigaos-dialogs.cpp
+++ b/backends/dialogs/amigaos/amigaos-dialogs.cpp
@@ -1,0 +1,136 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
+#define FORBIDDEN_SYMBOL_EXCEPTION_strdup
+#define FORBIDDEN_SYMBOL_EXCEPTION_time_h
+#define FORBIDDEN_SYMBOL_EXCEPTION_unistd_h
+
+#include "common/scummsys.h"
+
+#if defined(__amigaos4__) && defined(USE_SYSDIALOGS)
+
+#include "backends/dialogs/amigaos/amigaos-dialogs.h"
+
+#include "common/config-manager.h"
+#include "common/encoding.h"
+
+#include <proto/asl.h>
+#include <proto/codesets.h>
+#include <proto/dos.h>
+#include <proto/exec.h>
+
+#include <cstdlib>
+#include <cstring>
+
+struct CodesetsIFace *ICodesets = nullptr;
+struct Library *CodesetsBase = nullptr;
+
+char *AmigaOSDialogManager::utf8ToLocal(const char *in) {
+
+	if (!in) {
+		return strdup("");
+	}
+
+	CodesetsBase = IExec->OpenLibrary("codesets.library", 6);
+
+	if (CodesetsBase) {
+
+		ICodesets = (CodesetsIFace *)IExec->GetInterface(CodesetsBase, "main", 1L, nullptr);
+
+		struct codeset *dstmib = ICodesets->CodesetsFind("UTF-8", CSA_FallbackToDefault, FALSE, TAG_DONE);
+		struct codeset *srcmib = ICodesets->CodesetsFind("ISO-8859-1", CSA_FallbackToDefault, FALSE, TAG_DONE);
+
+		if (dstmib != nullptr) {
+			ULONG dstlen = 0;
+			STRPTR dst_str = ICodesets->CodesetsConvertStr(CSA_SourceCodeset, srcmib, CSA_DestCodeset, dstmib, CSA_Source, in, CSA_DestLenPtr, &dstlen, TAG_DONE);
+			if (dst_str!= nullptr) {
+				char *out = (char *)malloc(dstlen + 1);
+				if (out) {
+					strcpy(out, dst_str);
+					CodesetsBase = nullptr;
+					ICodesets->CodesetsFreeA(dst_str, nullptr);
+					ICodesets = nullptr;
+					IExec->CloseLibrary(CodesetsBase);
+					IExec->DropInterface((struct Interface *)ICodesets);
+					return out;
+				}
+				free(out);	
+			}
+		}
+	}
+	return strdup(in);
+}
+
+struct AslIFace *IAsl;
+struct Library *AslBase;
+
+Common::DialogManager::DialogResult AmigaOSDialogManager::showFileBrowser(const Common::U32String &title, Common::FSNode &choice, bool isDirBrowser) {
+
+	char pathBuffer[MAXPATHLEN];
+
+	Common::String utf8Title = title.encode();	
+
+	DialogResult result = kDialogCancel;
+
+	AslBase = IExec->OpenLibrary(AslName, 50);
+	if (AslBase) {
+
+		IAsl = (struct AslIFace*)IExec->GetInterface(AslBase, "main", 1, nullptr);
+
+		struct FileRequester *fr = nullptr;
+
+		if (ConfMan.hasKey("browser_lastpath")) {
+			strncpy(pathBuffer, ConfMan.get("browser_lastpath").c_str(), sizeof(pathBuffer)-1);
+		}
+
+		fr = (struct FileRequester *)IAsl->AllocAslRequestTags(ASL_FileRequest, TAG_DONE);
+
+		if (!fr)
+			return result;
+
+		char *newTitle = utf8ToLocal(utf8Title.c_str());
+
+		if (IAsl->AslRequestTags(fr, ASLFR_TitleText, newTitle, ASLFR_RejectIcons, TRUE, ASLFR_InitialDrawer, pathBuffer, (isDirBrowser ? TRUE : FALSE), TAG_DONE)) {
+
+			if (strlen(fr->fr_Drawer) < sizeof(pathBuffer)) {
+				strncpy(pathBuffer, fr->fr_Drawer, sizeof(pathBuffer));
+				if (!isDirBrowser) {
+					IDOS->AddPart(pathBuffer, fr->fr_File, sizeof(pathBuffer));
+				}
+				choice = Common::FSNode(pathBuffer);
+				ConfMan.set("browser_lastpath", pathBuffer);
+				result = kDialogOk;
+			}
+			free(newTitle);
+			IAsl->FreeAslRequest((APTR)fr);
+		}
+		AslBase = nullptr;
+		IAsl = nullptr;
+		IExec->CloseLibrary(AslBase); 
+		IExec->DropInterface((struct Interface*)IAsl);
+	}
+
+	return result;
+}
+
+#endif

--- a/backends/dialogs/amigaos/amigaos-dialogs.h
+++ b/backends/dialogs/amigaos/amigaos-dialogs.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKEND_AMIGAOS_DIALOGS_H
+#define BACKEND_AMIGAOS_DIALOGS_H
+
+#if defined(__amigaos4__) && defined(USE_SYSDIALOGS) 
+
+#include "common/dialogs.h"
+#include "common/fs.h"
+
+class AmigaOSDialogManager : public Common::DialogManager {
+public:
+	virtual DialogResult showFileBrowser(const Common::U32String &title, Common::FSNode &choice, bool isDirBrowser);
+
+private:
+	char *utf8ToLocal(const char *in);
+};
+
+#endif
+
+#endif // BACKEND_AMIGAOS_DIALOGS_H

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -241,6 +241,7 @@ endif
 
 ifdef AMIGAOS
 MODULE_OBJS += \
+	dialogs/amigaos/amigaos-dialogs.o \
 	fs/amigaos4/amigaos4-fs.o \
 	fs/amigaos4/amigaos4-fs-factory.o \
 	midi/camd.o

--- a/backends/platform/sdl/amigaos/amigaos.cpp
+++ b/backends/platform/sdl/amigaos/amigaos.cpp
@@ -26,6 +26,7 @@
 
 #include "backends/platform/sdl/amigaos/amigaos.h"
 #include "backends/fs/amigaos4/amigaos4-fs-factory.h"
+#include "backends/dialogs/amigaos/amigaos-dialogs.h"
 
 void OSystem_AmigaOS::init() {
 	// Initialze File System Factory
@@ -33,6 +34,18 @@ void OSystem_AmigaOS::init() {
 
 	// Invoke parent implementation of this method
 	OSystem_SDL::init();
+
+#if defined(USE_SYSDIALOGS)
+	_dialogManager = new AmigaOSDialogManager();
+#endif
 }
 
+bool OSystem_AmigaOS::hasFeature(Feature f) {
+#if defined(USE_SYSDIALOGS)
+	if (f == kFeatureSystemBrowserDialog)
+		return true;
+#endif
+
+	return OSystem_SDL::hasFeature(f);
+}
 #endif

--- a/configure
+++ b/configure
@@ -5747,8 +5747,12 @@ if test "$_dialogs" = "no"; then
 	echo "no"
 else
 	case $_host_os in
-	morphos*)
-		echo "morphos"
+	amigaos*)
+		echo "amigaos (asl)"
+		_dialogs=yes
+		;;
+	darwin*)
+		echo "osx"
 		_dialogs=yes
 		;;
 	mingw*)
@@ -5756,8 +5760,8 @@ else
 		echo "win32"
 		_dialogs=yes
 		;;
-	darwin*)
-		echo "osx"
+	morphos*)
+		echo "morphos"
 		_dialogs=yes
 		;;
 	*)


### PR DESCRIPTION
This adds a native file browser (ASL) to the AmigaOS port.

utf8 is handled just like MorphOS does it

Thanks a lot Capehill and jabirulo
![Workbench Screen_025](https://user-images.githubusercontent.com/799923/99968208-26da0280-2d99-11eb-9d3c-96cbb570cd7a.png)
