### PR TITLE
GRIM: fix localization of dialogue transcript

### DIFF
--- a/engines/grim/lua_v1_text.cpp
+++ b/engines/grim/lua_v1_text.cpp
@@ -257,7 +257,7 @@ void Lua_V1::LocalizeString() {
 		// If the string that we're passed isn't localized yet then
 		// construct the localized string, otherwise spit back what
 		// we've been given
-		if (str[0] == '/' && str[strlen(str) - 1] == '/') {
+		if (str[0] == '/') {
 			Common::String msg = parseMsgText(str, msgId);
 			sprintf(buf, "/%s/%s", msgId, msg.c_str());
 			str = buf;


### PR DESCRIPTION
Fixes bug where cutscenes lines were always written to dialogue transcript in english regardless of game language
as described in https://bugs.scummvm.org/ticket/11878

The change removes the second condition of checking the string to localize ends with `/`
sayLine do receive string formatted as `/{msgId}/`
but in cutscene they received as `/{msgId}/{original}`

as `parseMsgText` / `localize` only care about the first part `/{msgId}/` (rest is ignored)
it seems to work on both cases