### PR TITLE
ENGINES: Changed AdvancedMetaEngine::createInstance to return a Common::Error

### DIFF
--- a/engines/access/metaengine.cpp
+++ b/engines/access/metaengine.cpp
@@ -76,7 +76,7 @@ public:
 
     bool hasFeature(MetaEngineFeature f) const override;
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -101,21 +101,19 @@ bool Access::AccessEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool AccessMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error AccessMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Access::AccessGameDescription *gd = (const Access::AccessGameDescription *)desc;
-	if (gd) {
-		switch (gd->gameID) {
-		case Access::GType_Amazon:
-			*engine = new Access::Amazon::AmazonEngine(syst, gd);
-			break;
-		case Access::GType_MartianMemorandum:
-			*engine = new Access::Martian::MartianEngine(syst, gd);
-			break;
-		default:
-			error("Unknown game");
-		}
+	switch (gd->gameID) {
+	case Access::GType_Amazon:
+		*engine = new Access::Amazon::AmazonEngine(syst, gd);
+		break;
+	case Access::GType_MartianMemorandum:
+		*engine = new Access::Martian::MartianEngine(syst, gd);
+		break;
+	default:
+		return Common::kUnsupportedGameidError;
 	}
-	return gd != 0;
+	return Common::kNoError;
 }
 
 SaveStateList AccessMetaEngine::listSaves(const char *target) const {

--- a/engines/adl/metaengine.cpp
+++ b/engines/adl/metaengine.cpp
@@ -79,7 +79,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	void removeSaveState(const char *target, int slot) const override;
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 };
 
 bool AdlMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -209,10 +209,7 @@ Engine *HiRes4Engine_create(OSystem *syst, const AdlGameDescription *gd);
 Engine *HiRes5Engine_create(OSystem *syst, const AdlGameDescription *gd);
 Engine *HiRes6Engine_create(OSystem *syst, const AdlGameDescription *gd);
 
-bool AdlMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	if (!gd)
-		return false;
-
+Common::Error AdlMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
 	const AdlGameDescription *adlGd = (const AdlGameDescription *)gd;
 
 	switch (adlGd->gameType) {
@@ -238,10 +235,10 @@ bool AdlMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameD
 		*engine = HiRes6Engine_create(syst, adlGd);
 		break;
 	default:
-		error("Unknown GameType");
+		return Common::kUnsupportedGameidError;
 	}
 
-	return true;
+	return Common::kNoError;
 }
 
 } // End of namespace Adl

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -399,12 +399,10 @@ Common::Error AdvancedMetaEngineDetection::createInstance(OSystem *syst, Engine 
 
 	if (plugin) {
 		// Call child class's createInstanceMethod.
-		if (plugin->get<AdvancedMetaEngine>().createInstance(syst, engine, agdDesc.desc)) {
-			return Common::Error(Common::kNoError);
-		}
+		return plugin->get<AdvancedMetaEngine>().createInstance(syst, engine, agdDesc.desc);
 	}
 
-	return Common::Error(Common::kNoGameDataFoundError);
+	return Common::Error(Common::kEnginePluginNotFound);
 }
 
 void AdvancedMetaEngineDetection::composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::String &parentName) const {

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -448,7 +448,7 @@ public:
 	 * A createInstance implementation for subclasses. To be called after the base
 	 * createInstance function above is called.
 	 */
-	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const = 0;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const = 0;
 
 	/**
 	 * Return the name of the engine plugin based on the engineID.

--- a/engines/agi/metaengine.cpp
+++ b/engines/agi/metaengine.cpp
@@ -112,7 +112,7 @@ public:
 		return "agi";
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -134,9 +134,8 @@ bool AgiMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSimpleSavesNames);
 }
 
-bool AgiMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error AgiMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Agi::AGIGameDescription *gd = (const Agi::AGIGameDescription *)desc;
-	bool res = true;
 
 	switch (gd->gameType) {
 	case Agi::GType_PreAGI:
@@ -151,9 +150,7 @@ bool AgiMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameD
 			*engine = new Agi::WinnieEngine(syst, gd);
 			break;
 		default:
-			res = false;
-			error("PreAGI engine: unknown gameID");
-			break;
+			return Common::kUnsupportedGameidError;
 		}
 		break;
 	case Agi::GType_V1:
@@ -162,11 +159,10 @@ bool AgiMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameD
 		*engine = new Agi::AgiEngine(syst, gd);
 		break;
 	default:
-		res = false;
-		error("AGI engine: unknown gameType");
+		return Common::kUnsupportedGameidError;
 	}
 
-	return res;
+	return Common::kNoError;
 }
 
 SaveStateList AgiMetaEngine::listSaves(const char *target) const {

--- a/engines/agos/POTFILES
+++ b/engines/agos/POTFILES
@@ -1,3 +1,4 @@
 engines/agos/saveload.cpp
 engines/agos/animation.cpp
+engines/agos/metaengine.cpp
 engines/agos/midi.cpp

--- a/engines/agos/detection.cpp
+++ b/engines/agos/detection.cpp
@@ -46,13 +46,11 @@ static const PlainGameDescriptor agosGames[] = {
 	{"waxworks", "Waxworks"},
 	{"simon1", "Simon the Sorcerer 1"},
 	{"simon2", "Simon the Sorcerer 2"},
-#ifdef ENABLE_AGOS2
 	{"feeble", "The Feeble Files"},
 	{"dimp", "Demon in my Pocket"},
 	{"jumble", "Jumble"},
 	{"puzzle", "NoPatience"},
 	{"swampy", "Swampy Adventures"},
-#endif
 	{0, 0}
 };
 

--- a/engines/agos/detection_tables.h
+++ b/engines/agos/detection_tables.h
@@ -2551,7 +2551,6 @@ static const AGOSGameDescription gameDescriptions[] = {
 		GF_TALKIE | GF_WAVSFX
 	},
 
-#ifdef ENABLE_AGOS2
 	// The Feeble Files - English DOS Demo
 	{
 		{
@@ -3194,7 +3193,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 		GID_SWAMPY,
 		GF_OLD_BUNDLE | GF_TALKIE
 	},
-#endif
+
 	{ AD_TABLE_END_MARKER, 0, 0, 0 }
 };
 

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -45,7 +45,7 @@ public:
 		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
 		return AdvancedMetaEngine::createInstance(syst, engine);
 	}
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -62,9 +62,8 @@ bool AGOS::AGOSEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-bool AgosMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error AgosMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const AGOS::AGOSGameDescription *gd = (const AGOS::AGOSGameDescription *)desc;
-	bool res = true;
 
 	switch (gd->gameType) {
 	case AGOS::GType_PN:
@@ -100,11 +99,10 @@ bool AgosMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGame
 		break;
 #endif
 	default:
-		res = false;
-		error("AGOS engine: unknown gameType");
+		return Common::kUnsupportedGameidError;
 	}
 
-	return res;
+	return Common::kNoError;
 }
 
 SaveStateList AgosMetaEngine::listSaves(const char *target) const {

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -24,6 +24,7 @@
 #include "common/savefile.h"
 #include "common/system.h"
 #include "common/installshield_cab.h"
+#include "common/translation.h"
 
 #include "engines/advancedDetector.h"
 #include "engines/obsolete.h"
@@ -97,6 +98,10 @@ Common::Error AgosMetaEngine::createInstance(OSystem *syst, Engine **engine, con
 		else
 			*engine = new AGOS::AGOSEngine_PuzzlePack(syst, gd);
 		break;
+#else
+	case AGOS::GType_FF:
+	case AGOS::GType_PP:
+		return Common::Error(Common::kUnsupportedGameidError, _s("AGOS 2 support is not compiled in"));
 #endif
 	default:
 		return Common::kUnsupportedGameidError;

--- a/engines/avalanche/metaengine.cpp
+++ b/engines/avalanche/metaengine.cpp
@@ -60,7 +60,7 @@ public:
 		return "avalanche";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override { return 99; }
@@ -69,10 +69,9 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
-bool AvalancheMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	if (gd)
-		*engine = new AvalancheEngine(syst, (const AvalancheGameDescription *)gd);
-	return gd != 0;
+Common::Error AvalancheMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
+	*engine = new AvalancheEngine(syst, (const AvalancheGameDescription *)gd);
+	return Common::kNoError;
 }
 
 bool AvalancheMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/bbvs/metaengine.cpp
+++ b/engines/bbvs/metaengine.cpp
@@ -44,7 +44,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -121,11 +121,9 @@ SaveStateDescriptor BbvsMetaEngine::querySaveMetaInfos(const char *target, int s
 	return SaveStateDescriptor();
 }
 
-bool BbvsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Bbvs::BbvsEngine(syst, desc);
-	}
-	return desc != 0;
+Common::Error BbvsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Bbvs::BbvsEngine(syst, desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(BBVS)

--- a/engines/bladerunner/metaengine.cpp
+++ b/engines/bladerunner/metaengine.cpp
@@ -35,7 +35,7 @@ class BladeRunnerMetaEngine : public AdvancedMetaEngine {
 public:
     const char *getName() const override;
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	SaveStateList listSaves(const char *target) const override;
@@ -48,10 +48,9 @@ const char *BladeRunnerMetaEngine::getName() const {
 	return "bladerunner";
 }
 
-bool BladeRunnerMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error BladeRunnerMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	*engine = new BladeRunner::BladeRunnerEngine(syst, desc);
-
-	return true;
+	return Common::kNoError;
 }
 
 bool BladeRunnerMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/cge/metaengine.cpp
+++ b/engines/cge/metaengine.cpp
@@ -39,7 +39,7 @@ public:
 
     bool hasFeature(MetaEngineFeature f) const override;
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -153,11 +153,9 @@ SaveStateDescriptor CGEMetaEngine::querySaveMetaInfos(const char *target, int sl
 	return SaveStateDescriptor();
 }
 
-bool CGEMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new CGE::CGEEngine(syst, desc);
-	}
-	return desc != 0;
+Common::Error CGEMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new CGE::CGEEngine(syst, desc);
+	return Common::kNoError;
 }
 
 } // End of namespace CGE

--- a/engines/cge2/metaengine.cpp
+++ b/engines/cge2/metaengine.cpp
@@ -39,7 +39,7 @@ public:
 		return "cge2";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -47,11 +47,9 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 };
 
-bool CGE2MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc)
-		*engine = new CGE2::CGE2Engine(syst, desc);
-
-	return desc != 0;
+Common::Error CGE2MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new CGE2::CGE2Engine(syst, desc);
+	return Common::kNoError;
 }
 
 bool CGE2MetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/chewy/metaengine.cpp
+++ b/engines/chewy/metaengine.cpp
@@ -48,7 +48,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -74,12 +74,9 @@ bool Chewy::ChewyEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool ChewyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Chewy::ChewyGameDescription *gd = (const Chewy::ChewyGameDescription *)desc;
-	if (gd) {
-		*engine = new Chewy::ChewyEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error ChewyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Chewy::ChewyEngine(syst, (const Chewy::ChewyGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList ChewyMetaEngine::listSaves(const char *target) const {

--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -54,10 +54,7 @@ public:
 		return "cine";
 	}
 
-    Common::Error createInstance(OSystem *syst, Engine **engine) const override {
-		return AdvancedMetaEngine::createInstance(syst, engine);
-	}
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -86,12 +83,9 @@ bool Cine::CineEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool CineMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Cine::CINEGameDescription *gd = (const Cine::CINEGameDescription *)desc;
-	if (gd) {
-		*engine = new Cine::CineEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error CineMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Cine::CineEngine(syst, (const Cine::CINEGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList CineMetaEngine::listSaves(const char *target) const {

--- a/engines/composer/metaengine.cpp
+++ b/engines/composer/metaengine.cpp
@@ -71,19 +71,16 @@ public:
 		return "composer";
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char* target) const override;
 };
 
-bool ComposerMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Composer::ComposerGameDescription *gd = (const Composer::ComposerGameDescription *)desc;
-	if (gd) {
-		*engine = new Composer::ComposerEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error ComposerMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Composer::ComposerEngine(syst, (const Composer::ComposerGameDescription *)desc);
+	return Common::kNoError;
 }
 
 bool ComposerMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/cruise/metaengine.cpp
+++ b/engines/cruise/metaengine.cpp
@@ -56,7 +56,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool CruiseMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -123,12 +123,9 @@ SaveStateDescriptor CruiseMetaEngine::querySaveMetaInfos(const char *target, int
 	return SaveStateDescriptor();
 }
 
-bool CruiseMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Cruise::CRUISEGameDescription *gd = (const Cruise::CRUISEGameDescription *)desc;
-	if (gd) {
-		*engine = new Cruise::CruiseEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error CruiseMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Cruise::CruiseEngine(syst, (const Cruise::CRUISEGameDescription *)desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(CRUISE)

--- a/engines/cryo/metaengine.cpp
+++ b/engines/cryo/metaengine.cpp
@@ -42,18 +42,16 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool CryoMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return false;
 }
 
-bool CryoMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Cryo::CryoEngine(syst, desc);
-	}
-	return desc != 0;
+Common::Error CryoMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Cryo::CryoEngine(syst, desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(CRYO)

--- a/engines/cryomni3d/POTFILES
+++ b/engines/cryomni3d/POTFILES
@@ -1,0 +1,1 @@
+engines/cryomni3d/metaengine.cpp

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -74,7 +74,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 999; }
@@ -129,26 +129,21 @@ void CryOmni3DMetaEngine::removeSaveState(const char *target, int slot) const {
 	g_system->getSavefileManager()->removeSavefile(filename);
 }
 
-bool CryOmni3DMetaEngine::createInstance(OSystem *syst, Engine **engine,
+Common::Error CryOmni3DMetaEngine::createInstance(OSystem *syst, Engine **engine,
 		const ADGameDescription *desc) const {
 	const CryOmni3DGameDescription *gd = (const CryOmni3DGameDescription *)desc;
 
-	if (gd) {
-		switch (gd->gameType) {
-		case GType_VERSAILLES:
+	switch (gd->gameType) {
+	case GType_VERSAILLES:
 #ifdef ENABLE_VERSAILLES
-			*engine = new Versailles::CryOmni3DEngine_Versailles(syst, gd);
-			break;
+		*engine = new Versailles::CryOmni3DEngine_Versailles(syst, gd);
+		return Common::kNoError;
 #else
-			warning("Versailles support not compiled in");
-			return false;
+		return Common::Error(Common::kUnsupportedGameidError, _s("Versailles 1685 support is not compiled in"));
 #endif
-		default:
-			error("Unknown Cryo Omni3D Engine");
-		}
+	default:
+		return Common::kUnsupportedGameidError;
 	}
-
-	return (gd != 0);
 }
 
 } // End of namespace CryOmni3D

--- a/engines/director/metaengine.cpp
+++ b/engines/director/metaengine.cpp
@@ -92,16 +92,12 @@ public:
 		return "director";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
-bool DirectorMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Director::DirectorGameDescription *gd = (const Director::DirectorGameDescription *)desc;
-
-	if (gd)
-		*engine = new Director::DirectorEngine(syst, gd);
-
-	return (gd != 0);
+Common::Error DirectorMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Director::DirectorEngine(syst, (const Director::DirectorGameDescription *)desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(DIRECTOR)

--- a/engines/dm/metaengine.cpp
+++ b/engines/dm/metaengine.cpp
@@ -42,10 +42,9 @@ public:
 		return "dm";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc)
-			*engine = new DM::DMEngine(syst, (const DMADGameDescription*)desc);
-		return desc != nullptr;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		*engine = new DM::DMEngine(syst, (const DMADGameDescription*)desc);
+		return Common::kNoError;
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override {

--- a/engines/draci/metaengine.cpp
+++ b/engines/draci/metaengine.cpp
@@ -39,7 +39,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool DraciMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -120,11 +120,9 @@ SaveStateDescriptor DraciMetaEngine::querySaveMetaInfos(const char *target, int 
 	return SaveStateDescriptor();
 }
 
-bool DraciMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Draci::DraciEngine(syst, desc);
-	}
-	return desc != 0;
+Common::Error DraciMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Draci::DraciEngine(syst, desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(DRACI)

--- a/engines/dragons/metaengine.cpp
+++ b/engines/dragons/metaengine.cpp
@@ -38,7 +38,7 @@ public:
 	}
 
 	virtual bool hasFeature(MetaEngineFeature f) const override;
-	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	virtual int getMaximumSaveSlot() const override;
 	virtual SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
@@ -113,23 +113,21 @@ SaveStateDescriptor DragonsMetaEngine::querySaveMetaInfos(const char *target, in
 	return SaveStateDescriptor();
 }
 
-bool DragonsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error DragonsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Dragons::DragonsGameDescription *gd = (const Dragons::DragonsGameDescription *)desc;
-	if (gd) {
-		switch (gd->gameId) {
-		case Dragons::kGameIdDragons:
-			*engine = new Dragons::DragonsEngine(syst, desc);
-			break;
-		case Dragons::kGameIdDragonsBadExtraction:
-			GUIErrorMessageWithURL(_("Error: It appears that the game data files were extracted incorrectly.\n\nYou should only extract STR and XA files using the special method. The rest should be copied normally from your game CD.\n\n See https://wiki.scummvm.org/index.php?title=Datafiles#Blazing_Dragons"),
-								   "https://wiki.scummvm.org/index.php?title=Datafiles#Blazing_Dragons");
-			break;
-		default:
-			error("Unknown game id");
-			break;
-		}
+
+	switch (gd->gameId) {
+	case Dragons::kGameIdDragons:
+		*engine = new Dragons::DragonsEngine(syst, desc);
+		break;
+	case Dragons::kGameIdDragonsBadExtraction:
+		GUIErrorMessageWithURL(_("Error: It appears that the game data files were extracted incorrectly.\n\nYou should only extract STR and XA files using the special method. The rest should be copied normally from your game CD.\n\n See https://wiki.scummvm.org/index.php?title=Datafiles#Blazing_Dragons"),
+		                       "https://wiki.scummvm.org/index.php?title=Datafiles#Blazing_Dragons");
+		break;
+	default:
+		return Common::kUnsupportedGameidError;
 	}
-	return desc != 0;
+	return Common::kNoError;
 }
 
 Common::KeymapArray DragonsMetaEngine::initKeymaps(const char *target) const {

--- a/engines/drascula/metaengine.cpp
+++ b/engines/drascula/metaengine.cpp
@@ -64,7 +64,7 @@ public:
 		return "drascula";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
     SaveStateList listSaves(const char *target) const override;
@@ -157,12 +157,9 @@ void DrasculaMetaEngine::removeSaveState(const char *target, int slot) const {
 	g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
-bool DrasculaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Drascula::DrasculaGameDescription *gd = (const Drascula::DrasculaGameDescription *)desc;
-	if (gd) {
-		*engine = new Drascula::DrasculaEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error DrasculaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Drascula::DrasculaEngine(syst, (const Drascula::DrasculaGameDescription *)desc);
+	return Common::kNoError;
 }
 
 } // End of namespace Drascula

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -35,7 +35,7 @@ public:
 		return "dreamweb";
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
@@ -71,12 +71,9 @@ bool DreamWeb::DreamWebEngine::hasFeature(EngineFeature f) const {
 	}
 }
 
-bool DreamWebMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const DreamWeb::DreamWebGameDescription *gd = (const DreamWeb::DreamWebGameDescription *)desc;
-	if (gd) {
-		*engine = new DreamWeb::DreamWebEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error DreamWebMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new DreamWeb::DreamWebEngine(syst, (const DreamWeb::DreamWebGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList DreamWebMetaEngine::listSaves(const char *target) const {

--- a/engines/gnap/metaengine.cpp
+++ b/engines/gnap/metaengine.cpp
@@ -36,7 +36,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -144,11 +144,9 @@ SaveStateDescriptor GnapMetaEngine::querySaveMetaInfos(const char *target, int s
 	return SaveStateDescriptor();
 }
 
-bool GnapMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Gnap::GnapEngine(syst, desc);
-	}
-	return desc != 0;
+Common::Error GnapMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Gnap::GnapEngine(syst, desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(GNAP)

--- a/engines/gob/metaengine.cpp
+++ b/engines/gob/metaengine.cpp
@@ -35,8 +35,7 @@ public:
 
     bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool GobMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -48,17 +47,11 @@ bool Gob::GobEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-Common::Error GobMetaEngine::createInstance(OSystem *syst, Engine **engine) const {
-	return AdvancedMetaEngine::createInstance(syst, engine);
-}
-
-bool GobMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error GobMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Gob::GOBGameDescription *gd = (const Gob::GOBGameDescription *)desc;
-	if (gd) {
-		*engine = new Gob::GobEngine(syst);
-		((Gob::GobEngine *)*engine)->initGame(gd);
-	}
-	return gd != 0;
+	*engine = new Gob::GobEngine(syst);
+	((Gob::GobEngine *)*engine)->initGame(gd);
+	return Common::kNoError;
 }
 
 

--- a/engines/griffon/metaengine.cpp
+++ b/engines/griffon/metaengine.cpp
@@ -41,7 +41,7 @@ public:
 		return ConfMan.getInt("autosave_period") ? 4 : 3;
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	virtual int getAutosaveSlot() const override {
 		return 4;
@@ -69,11 +69,9 @@ bool Griffon::GriffonEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool GriffonMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc)
-		*engine = new Griffon::GriffonEngine(syst);
-
-	return desc != nullptr;
+Common::Error GriffonMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Griffon::GriffonEngine(syst);
+	return Common::kNoError;
 }
 
 Common::KeymapArray GriffonMetaEngine::initKeymaps(const char *target) const {

--- a/engines/grim/POTFILES
+++ b/engines/grim/POTFILES
@@ -2,5 +2,6 @@ engines/grim/detection.cpp
 engines/grim/grim.cpp
 engines/grim/md5check.cpp
 engines/grim/md5checkdialog.cpp
+engines/grim/metaengine.cpp
 engines/grim/resource.cpp
 engines/grim/emi/sound/emisound.cpp

--- a/engines/grim/metaengine.cpp
+++ b/engines/grim/metaengine.cpp
@@ -27,6 +27,7 @@
 
 #include "common/system.h"
 #include "common/savefile.h"
+#include "common/translation.h"
 #include "common/config-manager.h"
 
 namespace Grim {
@@ -42,7 +43,7 @@ public:
 		return AdvancedMetaEngine::createInstance(syst, engine);
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
@@ -52,22 +53,20 @@ public:
 
 };
 
-bool GrimMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error GrimMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const GrimGameDescription *gd = (const GrimGameDescription *)desc;
 
-	if (gd) {
-		if (gd->gameType == GType_MONKEY4) {
+	if (gd->gameType == GType_MONKEY4) {
 #ifdef ENABLE_MONKEY4
-			*engine = new EMIEngine(syst, gd->desc.flags, gd->gameType, gd->desc.platform, gd->desc.language);
+		*engine = new EMIEngine(syst, gd->desc.flags, gd->gameType, gd->desc.platform, gd->desc.language);
 #else
-			return false;
+		return Common::Error(Common::kUnsupportedGameidError, _s("Escape from Monkey Island support is not compiled in"));
 #endif
-		} else {
-			*engine = new GrimEngine(syst, gd->desc.flags, gd->gameType, gd->desc.platform, gd->desc.language);
-		}
+	} else {
+		*engine = new GrimEngine(syst, gd->desc.flags, gd->gameType, gd->desc.platform, gd->desc.language);
 	}
 
-	return gd != nullptr;
+	return Common::kNoError;
 }
 
 bool GrimMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/groovie/metaengine.cpp
+++ b/engines/groovie/metaengine.cpp
@@ -37,7 +37,7 @@ public:
 		return "groovie";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	SaveStateList listSaves(const char *target) const override;
@@ -46,18 +46,14 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
-bool GroovieMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	if (gd) {
+Common::Error GroovieMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
 #ifndef ENABLE_GROOVIE2
-		if (((const GroovieGameDescription *)gd)->version == kGroovieV2) {
-			Engine::errorUnsupportedGame(_("GroovieV2 support is not compiled in"));
-			return false;
-		}
+	if (((const GroovieGameDescription *)gd)->version == kGroovieV2)
+		return Common::Error(Common::kUnsupportedGameidError, _s("GroovieV2 support is not compiled in"));
 #endif
 
-		*engine = new GroovieEngine(syst, (const GroovieGameDescription *)gd);
-	}
-	return gd != 0;
+	*engine = new GroovieEngine(syst, (const GroovieGameDescription *)gd);
+	return Common::kNoError;
 }
 
 bool GroovieMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/hadesch/metaengine.cpp
+++ b/engines/hadesch/metaengine.cpp
@@ -41,11 +41,9 @@ public:
 			(f == kSavesUseExtendedFormat);
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc)
-			*engine = new Hadesch::HadeschEngine(syst, desc);
-		
-		return desc != 0;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		*engine = new Hadesch::HadeschEngine(syst, desc);
+		return Common::kNoError;
 	}
 
 	const char *getName() const override {

--- a/engines/hdb/metaengine.cpp
+++ b/engines/hdb/metaengine.cpp
@@ -76,7 +76,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool HDBMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -260,12 +260,9 @@ Common::KeymapArray HDBMetaEngine::initKeymaps(const char *target) const {
 	return Keymap::arrayOf(engineKeyMap);
 }
 
-bool HDBMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new HDB::HDBGame(syst, desc);
-	}
-
-	return desc != nullptr;
+Common::Error HDBMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new HDB::HDBGame(syst, desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(HDB)

--- a/engines/hopkins/metaengine.cpp
+++ b/engines/hopkins/metaengine.cpp
@@ -65,7 +65,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -90,12 +90,9 @@ bool Hopkins::HopkinsEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool HopkinsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Hopkins::HopkinsGameDescription *gd = (const Hopkins::HopkinsGameDescription *)desc;
-	if (gd) {
-		*engine = new Hopkins::HopkinsEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error HopkinsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Hopkins::HopkinsEngine(syst, (const Hopkins::HopkinsGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList HopkinsMetaEngine::listSaves(const char *target) const {

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -46,7 +46,7 @@ public:
 		return "hugo";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override;
@@ -56,12 +56,10 @@ public:
 
 };
 
-bool HugoMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	if (gd) {
-		*engine = new HugoEngine(syst, (const HugoGameDescription *)gd);
-		((HugoEngine *)*engine)->initGame((const HugoGameDescription *)gd);
-	}
-	return gd != 0;
+Common::Error HugoMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
+	*engine = new HugoEngine(syst, (const HugoGameDescription *)gd);
+	((HugoEngine *)*engine)->initGame((const HugoGameDescription *)gd);
+	return Common::kNoError;
 }
 
 bool HugoMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/icb/metaengine.cpp
+++ b/engines/icb/metaengine.cpp
@@ -34,14 +34,12 @@ public:
 	}
 	virtual bool hasFeature(MetaEngineFeature f) const override { return false; }
 
-	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
-bool IcbMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc)
-		*engine = new IcbEngine(syst, desc);
-
-	return desc != nullptr;
+Common::Error IcbMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new IcbEngine(syst, desc);
+	return Common::kNoError;
 }
 
 } // End of namespace ICB

--- a/engines/illusions/metaengine.cpp
+++ b/engines/illusions/metaengine.cpp
@@ -52,7 +52,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -127,22 +127,19 @@ SaveStateDescriptor IllusionsMetaEngine::querySaveMetaInfos(const char *target, 
 	return SaveStateDescriptor();
 }
 
-bool IllusionsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error IllusionsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Illusions::IllusionsGameDescription *gd = (const Illusions::IllusionsGameDescription *)desc;
-	if (gd) {
-		switch (gd->gameId) {
-		case Illusions::kGameIdBBDOU:
-			*engine = new Illusions::IllusionsEngine_BBDOU(syst, gd);
-			break;
-		case Illusions::kGameIdDuckman:
-			*engine = new Illusions::IllusionsEngine_Duckman(syst, gd);
-			break;
-		default:
-			error("Unknown game id");
-			break;
-		}
+	switch (gd->gameId) {
+	case Illusions::kGameIdBBDOU:
+		*engine = new Illusions::IllusionsEngine_BBDOU(syst, gd);
+		break;
+	case Illusions::kGameIdDuckman:
+		*engine = new Illusions::IllusionsEngine_Duckman(syst, gd);
+		break;
+	default:
+		return Common::kUnsupportedGameidError;
 	}
-	return desc != 0;
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(ILLUSIONS)

--- a/engines/kingdom/metaengine.cpp
+++ b/engines/kingdom/metaengine.cpp
@@ -45,7 +45,7 @@ public:
 	}
 
 	virtual bool hasFeature(MetaEngineFeature f) const override;
-	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	virtual int getMaximumSaveSlot() const override;
 	virtual SaveStateList listSaves(const char *target) const override;
@@ -63,11 +63,9 @@ bool KingdomMetaEngine::hasFeature(MetaEngineFeature f) const {
 	    (f == kSavesSupportCreationDate);
 }
 
-bool KingdomMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc)
-		*engine = new Kingdom::KingdomGame(syst, desc);
-
-	return desc != nullptr;
+Common::Error KingdomMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Kingdom::KingdomGame(syst, desc);
+	return Common::kNoError;
 }
 
 int KingdomMetaEngine::getMaximumSaveSlot() const {

--- a/engines/lab/metaengine.cpp
+++ b/engines/lab/metaengine.cpp
@@ -49,10 +49,9 @@ public:
 		return "lab";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		// Instantiate Engine even if the game data is not found.
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
 		*engine = new Lab::LabEngine(syst, desc);
-		return true;
+		return Common::kNoError;
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;

--- a/engines/lastexpress/metaengine.cpp
+++ b/engines/lastexpress/metaengine.cpp
@@ -32,14 +32,12 @@ public:
 	}
 
 protected:
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 };
 
-bool LastExpressMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	if (gd) {
-		*engine = new LastExpressEngine(syst, (const ADGameDescription *)gd);
-	}
-	return gd != 0;
+Common::Error LastExpressMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
+	*engine = new LastExpressEngine(syst, (const ADGameDescription *)gd);
+	return Common::kNoError;
 }
 
 bool LastExpressEngine::isDemo() const {

--- a/engines/lilliput/metaengine.cpp
+++ b/engines/lilliput/metaengine.cpp
@@ -50,7 +50,7 @@ public:
 		return "lilliput";
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override;
@@ -59,12 +59,10 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 };
 
-bool LilliputMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	if (gd) {
-		*engine = new LilliputEngine(syst, (const LilliputGameDescription *)gd);
-		((LilliputEngine *)*engine)->initGame((const LilliputGameDescription *)gd);
-	}
-	return gd != 0;
+Common::Error LilliputMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
+	*engine = new LilliputEngine(syst, (const LilliputGameDescription *)gd);
+	((LilliputEngine *)*engine)->initGame((const LilliputGameDescription *)gd);
+	return Common::kNoError;
 }
 
 bool LilliputMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/lure/metaengine.cpp
+++ b/engines/lure/metaengine.cpp
@@ -57,7 +57,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -78,12 +78,9 @@ bool Lure::LureEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool LureMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Lure::LureGameDescription *gd = (const Lure::LureGameDescription *)desc;
-	if (gd) {
-		*engine = new Lure::LureEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error LureMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Lure::LureEngine(syst, (const Lure::LureGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList LureMetaEngine::listSaves(const char *target) const {

--- a/engines/macventure/metaengine.cpp
+++ b/engines/macventure/metaengine.cpp
@@ -47,7 +47,7 @@ public:
 	}
 
 protected:
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -113,11 +113,9 @@ SaveStateList MacVentureMetaEngine::listSaves(const char *target) const {
 
 int MacVentureMetaEngine::getMaximumSaveSlot() const { return 999; }
 
-bool MacVentureMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *game) const {
-	if (game) {
-		*engine = new MacVenture::MacVentureEngine(syst, game);
-	}
-	return game != 0;
+Common::Error MacVentureMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *game) const {
+	*engine = new MacVenture::MacVentureEngine(syst, game);
+	return Common::kNoError;
 }
 
 void MacVentureMetaEngine::removeSaveState(const char *target, int slot) const {

--- a/engines/made/metaengine.cpp
+++ b/engines/made/metaengine.cpp
@@ -52,7 +52,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool MadeMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -65,12 +65,9 @@ bool Made::MadeEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-bool MadeMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Made::MadeGameDescription *gd = (const Made::MadeGameDescription *)desc;
-	if (gd) {
-		*engine = new Made::MadeEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error MadeMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Made::MadeEngine(syst, (const Made::MadeGameDescription *)desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(MADE)

--- a/engines/mads/metaengine.cpp
+++ b/engines/mads/metaengine.cpp
@@ -69,7 +69,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -94,12 +94,9 @@ bool MADS::MADSEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool MADSMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const MADS::MADSGameDescription *gd = (const MADS::MADSGameDescription *)desc;
-	if (gd) {
-		*engine = new MADS::MADSEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error MADSMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new MADS::MADSEngine(syst, (const MADS::MADSGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList MADSMetaEngine::listSaves(const char *target) const {

--- a/engines/mohawk/POTFILES
+++ b/engines/mohawk/POTFILES
@@ -1,5 +1,6 @@
 engines/mohawk/detection.cpp
 engines/mohawk/dialogs.cpp
+engines/mohawk/metaengine.cpp
 engines/mohawk/mohawk.cpp
 engines/mohawk/metaengine.cpp
 engines/mohawk/myst.cpp

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -127,7 +127,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateList listSavesForPrefix(const char *prefix, const char *extension) const;
@@ -259,55 +259,48 @@ Common::KeymapArray MohawkMetaEngine::initKeymaps(const char *target) const {
 	return AdvancedMetaEngine::initKeymaps(target);
 }
 
-bool MohawkMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error MohawkMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Mohawk::MohawkGameDescription *gd = (const Mohawk::MohawkGameDescription *)desc;
 
-	if (gd) {
-		switch (gd->gameType) {
-		case Mohawk::GType_MYST:
-		case Mohawk::GType_MAKINGOF:
+	switch (gd->gameType) {
+	case Mohawk::GType_MYST:
+	case Mohawk::GType_MAKINGOF:
 #ifdef ENABLE_MYST
 #ifndef ENABLE_MYSTME
-			if (gd->features & Mohawk::GF_ME) {
-				Engine::errorUnsupportedGame(_("Myst ME support not compiled in"));
-				return false;
-			}
+		if (gd->features & Mohawk::GF_ME)
+			return Common::Error(Common::kUnsupportedGameidError, _s("Myst ME support not compiled in"));
 #endif
-			*engine = new Mohawk::MohawkEngine_Myst(syst, gd);
-			break;
+		*engine = new Mohawk::MohawkEngine_Myst(syst, gd);
+		break;
 #else
-			Engine::errorUnsupportedGame(_("Myst support not compiled in"));
-			return false;
+		return Common::Error(Common::kUnsupportedGameidError, _s("Myst support not compiled in"));
 #endif
-		case Mohawk::GType_RIVEN:
+	case Mohawk::GType_RIVEN:
 #ifdef ENABLE_RIVEN
-			*engine = new Mohawk::MohawkEngine_Riven(syst, gd);
-			break;
+		*engine = new Mohawk::MohawkEngine_Riven(syst, gd);
+		break;
 #else
-			Engine::errorUnsupportedGame(_("Riven support not compiled in"));
-			return false;
+		return Common::Error(Common::kUnsupportedGameidError, _s("Riven support not compiled in"));
 #endif
-		case Mohawk::GType_LIVINGBOOKSV1:
-		case Mohawk::GType_LIVINGBOOKSV2:
-		case Mohawk::GType_LIVINGBOOKSV3:
-		case Mohawk::GType_LIVINGBOOKSV4:
-		case Mohawk::GType_LIVINGBOOKSV5:
-			*engine = new Mohawk::MohawkEngine_LivingBooks(syst, gd);
-			break;
-		case Mohawk::GType_CSTIME:
+	case Mohawk::GType_LIVINGBOOKSV1:
+	case Mohawk::GType_LIVINGBOOKSV2:
+	case Mohawk::GType_LIVINGBOOKSV3:
+	case Mohawk::GType_LIVINGBOOKSV4:
+	case Mohawk::GType_LIVINGBOOKSV5:
+		*engine = new Mohawk::MohawkEngine_LivingBooks(syst, gd);
+		break;
+	case Mohawk::GType_CSTIME:
 #ifdef ENABLE_CSTIME
-			*engine = new Mohawk::MohawkEngine_CSTime(syst, gd);
-			break;
+		*engine = new Mohawk::MohawkEngine_CSTime(syst, gd);
+		break;
 #else
-			Engine::errorUnsupportedGame(_("CSTime support not compiled in"));
-			return false;
+		return Common::Error(Common::kUnsupportedGameidError, _s("CSTime support not compiled in"));
 #endif
-		default:
-			error("Unknown Mohawk Engine");
-		}
+	default:
+		return Common::kUnsupportedGameidError;
 	}
 
-	return (gd != nullptr);
+	return Common::kNoError;
 }
 
 GUI::OptionsContainerWidget *MohawkMetaEngine::buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {

--- a/engines/mortevielle/metaengine.cpp
+++ b/engines/mortevielle/metaengine.cpp
@@ -45,7 +45,7 @@ public:
 		return "mortevielle";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override;
@@ -53,11 +53,9 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
-bool MortevielleMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Mortevielle::MortevielleEngine(syst, (const Mortevielle::MortevielleGameDescription *)desc);
-	}
-	return desc != 0;
+Common::Error MortevielleMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Mortevielle::MortevielleEngine(syst, (const Mortevielle::MortevielleGameDescription *)desc);
+	return Common::kNoError;
 }
 
 bool MortevielleMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/mutationofjb/metaengine.cpp
+++ b/engines/mutationofjb/metaengine.cpp
@@ -35,11 +35,9 @@ public:
 		return "mutationofjb";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc) {
-			*engine = new MutationOfJB::MutationOfJBEngine(syst, desc);
-		}
-		return desc != nullptr;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		*engine = new MutationOfJB::MutationOfJBEngine(syst, desc);
+		return Common::kNoError;
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override {

--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -131,15 +131,12 @@ public:
 		return 999;
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
-bool Myst3MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Myst3GameDescription *gd = (const Myst3GameDescription *)desc;
-	if (gd) {
-		*engine = new Myst3Engine(syst, gd);
-	}
-	return gd != 0;
+Common::Error Myst3MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Myst3Engine(syst, (const Myst3GameDescription *)desc);
+	return Common::kNoError;
 }
 
 Common::Platform Myst3Engine::getPlatform() const {

--- a/engines/neverhood/metaengine.cpp
+++ b/engines/neverhood/metaengine.cpp
@@ -63,7 +63,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -90,11 +90,9 @@ bool Neverhood::NeverhoodEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool NeverhoodMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Neverhood::NeverhoodEngine(syst, desc);
-	}
-	return desc != 0;
+Common::Error NeverhoodMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Neverhood::NeverhoodEngine(syst, desc);
+	return Common::kNoError;
 }
 
 SaveStateList NeverhoodMetaEngine::listSaves(const char *target) const {

--- a/engines/ngi/metaengine.cpp
+++ b/engines/ngi/metaengine.cpp
@@ -68,7 +68,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool NGIMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -154,13 +154,9 @@ SaveStateDescriptor NGIMetaEngine::querySaveMetaInfos(const char *target, int sl
 	return SaveStateDescriptor();
 }
 
-bool NGIMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const NGI::NGIGameDescription *gd = (const NGI::NGIGameDescription *)desc;
-
-	if (gd) {
-		*engine = new NGI::NGIEngine(syst, gd);
-	}
-	return desc != 0;
+Common::Error NGIMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new NGI::NGIEngine(syst, (const NGI::NGIGameDescription *)desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(NGI)

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -46,7 +46,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -64,9 +64,8 @@ bool Parallaction::Parallaction::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-bool ParallactionMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error ParallactionMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Parallaction::PARALLACTIONGameDescription *gd = (const Parallaction::PARALLACTIONGameDescription *)desc;
-	bool res = true;
 
 	switch (gd->gameType) {
 	case Parallaction::GType_Nippon:
@@ -76,11 +75,10 @@ bool ParallactionMetaEngine::createInstance(OSystem *syst, Engine **engine, cons
 		*engine = new Parallaction::Parallaction_br(syst, gd);
 		break;
 	default:
-		res = false;
-		error("Parallaction engine: unknown gameType");
+		return Common::kUnsupportedGameidError;
 	}
 
-	return res;
+	return Common::kNoError;
 }
 
 SaveStateList ParallactionMetaEngine::listSaves(const char *target) const {

--- a/engines/pegasus/metaengine.cpp
+++ b/engines/pegasus/metaengine.cpp
@@ -68,7 +68,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 999; }
@@ -112,13 +112,9 @@ Common::KeymapArray PegasusMetaEngine::initKeymaps(const char *target) const {
 	return Pegasus::PegasusEngine::initKeymaps();
 }
 
-bool PegasusMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Pegasus::PegasusGameDescription *gd = (const Pegasus::PegasusGameDescription *)desc;
-
-	if (gd)
-		*engine = new Pegasus::PegasusEngine(syst, gd);
-
-	return (gd != 0);
+Common::Error PegasusMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Pegasus::PegasusEngine(syst, (const Pegasus::PegasusGameDescription *)desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(PEGASUS)

--- a/engines/petka/metaengine.cpp
+++ b/engines/petka/metaengine.cpp
@@ -38,7 +38,7 @@ public:
 	virtual SaveStateList listSaves(const char *target) const override;
 	virtual void removeSaveState(const char *target, int slot) const override;
 	virtual SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool PetkaMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -96,11 +96,9 @@ SaveStateDescriptor PetkaMetaEngine::querySaveMetaInfos(const char *target, int 
 	return SaveStateDescriptor();
 }
 
-bool PetkaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc)
-		*engine = new Petka::PetkaEngine(syst, desc);
-
-	return desc != 0;
+Common::Error PetkaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Petka::PetkaEngine(syst, desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(PETKA)

--- a/engines/pink/metaengine.cpp
+++ b/engines/pink/metaengine.cpp
@@ -47,7 +47,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 
 bool PinkMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -105,11 +105,9 @@ SaveStateDescriptor PinkMetaEngine::querySaveMetaInfos(const char *target, int s
 	return SaveStateDescriptor();
 }
 
-bool PinkMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc)
-		*engine = new Pink::PinkEngine(syst, desc);
-
-	return desc != 0;
+Common::Error PinkMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Pink::PinkEngine(syst, desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(PINK)

--- a/engines/plumbers/metaengine.cpp
+++ b/engines/plumbers/metaengine.cpp
@@ -36,15 +36,13 @@ class PlumbersMetaEngine : public AdvancedMetaEngine {
 		return "plumbers";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 };
 
-bool PlumbersMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc)
-		*engine = new Plumbers::PlumbersGame(syst, desc);
-
-	return desc != nullptr;
+Common::Error PlumbersMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Plumbers::PlumbersGame(syst, desc);
+	return Common::kNoError;
 }
 
 bool PlumbersMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/prince/metaengine.cpp
+++ b/engines/prince/metaengine.cpp
@@ -50,7 +50,7 @@ public:
 		return "prince";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override { return 99; }
@@ -159,13 +159,9 @@ void PrinceMetaEngine::removeSaveState(const char *target, int slot) const {
 	g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
-bool PrinceMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	using namespace Prince;
-	const PrinceGameDescription *gd = (const PrinceGameDescription *)desc;
-	if (gd) {
-		*engine = new PrinceEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error PrinceMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Prince::PrinceEngine(syst, (const Prince::PrinceGameDescription *)desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(PRINCE)

--- a/engines/queen/metaengine.cpp
+++ b/engines/queen/metaengine.cpp
@@ -36,7 +36,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 99; }
 	void removeSaveState(const char *target, int slot) const override;
@@ -86,13 +86,9 @@ void QueenMetaEngine::removeSaveState(const char *target, int slot) const {
 	g_system->getSavefileManager()->removeSavefile(filename);
 }
 
-bool QueenMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Queen::QueenGameDescription *gd = (const Queen::QueenGameDescription *)desc;
-
-	if (gd)
-		*engine = new Queen::QueenEngine(syst); //FIXME , gd);
-
-	return (gd != 0);
+Common::Error QueenMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Queen::QueenEngine(syst); //FIXME , (const Queen::QueenGameDescription *)desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(QUEEN)

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -78,10 +78,7 @@ public:
 
     bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine) const override {
-		return AdvancedMetaEngine::createInstance(syst, engine);
-	}
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -108,31 +105,27 @@ bool Saga::SagaEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool SagaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error SagaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Saga::SAGAGameDescription *gd = (const Saga::SAGAGameDescription *)desc;
 
 	switch (gd->gameId) {
 	case Saga::GID_IHNM:
 #ifndef ENABLE_IHNM
-		Engine::errorUnsupportedGame(_("I Have No Mouth support not compiled in"));
-		return false;
+		return Common::Error(Common::kUnsupportedGameidError, _s("I Have No Mouth support not compiled in"));
 #endif
 		break;
 	case Saga::GID_DINO:
 	case Saga::GID_FTA2:
 #ifndef ENABLE_SAGA2
-		Engine::errorUnsupportedGame(_("SAGA2 support not compiled in"));
-		return false;
+		return Common::Error(Common::kUnsupportedGameidError, _s("SAGA2 support not compiled in"));
 #endif
 		break;
 	default:
 		break;
 	}
 
-	if (gd) {
-		*engine = new Saga::SagaEngine(syst, gd);
-	}
-	return gd != 0;
+	*engine = new Saga::SagaEngine(syst, gd);
+	return Common::kNoError;
 }
 
 SaveStateList SagaMetaEngine::listSaves(const char *target) const {

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -303,7 +303,7 @@ public:
 		return "sci";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	SaveStateList listSaves(const char *target) const override;
@@ -316,7 +316,7 @@ public:
 	virtual ADDetectedGame fallbackDetectExtern(uint md5Bytes, const FileMap &allFiles, const Common::FSList &fslist) const override;
 };
 
-bool SciMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error SciMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const GameIdStrToEnum *g = s_gameIdStrToEnum;
 	for (; g->gameidStr; ++g) {
 		if (0 == strcmp(desc->gameId, g->gameidStr)) {
@@ -328,11 +328,11 @@ bool SciMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameD
 #endif
 
 			*engine = new SciEngine(syst, desc, g->gameidEnum);
-			return true;
+			return Common::kNoError;
 		}
 	}
 
-	return false;
+	return Common::kUnsupportedGameidError;
 }
 
 bool SciMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/sherlock/metaengine.cpp
+++ b/engines/sherlock/metaengine.cpp
@@ -56,7 +56,7 @@ public:
     /**
 	 * Creates an instance of the game engine
 	 */
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	/**
 	 * Returns a list of features the game's MetaEngine support
@@ -84,22 +84,19 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
-bool SherlockMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error SherlockMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Sherlock::SherlockGameDescription *gd = (const Sherlock::SherlockGameDescription *)desc;
-	if (gd) {
-		switch (gd->gameID) {
-		case Sherlock::GType_SerratedScalpel:
-			*engine = new Sherlock::Scalpel::ScalpelEngine(syst, gd);
-			break;
-		case Sherlock::GType_RoseTattoo:
-			*engine = new Sherlock::Tattoo::TattooEngine(syst, gd);
-			break;
-		default:
-			error("Unknown game");
-			break;
-		}
+	switch (gd->gameID) {
+	case Sherlock::GType_SerratedScalpel:
+		*engine = new Sherlock::Scalpel::ScalpelEngine(syst, gd);
+		break;
+	case Sherlock::GType_RoseTattoo:
+		*engine = new Sherlock::Tattoo::TattooEngine(syst, gd);
+		break;
+	default:
+		return Common::kUnsupportedGameidError;
 	}
-	return gd != 0;
+	return Common::kNoError;
 }
 
 bool SherlockMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/sludge/metaengine.cpp
+++ b/engines/sludge/metaengine.cpp
@@ -46,12 +46,9 @@ public:
 		return "sludge";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		const Sludge::SludgeGameDescription *gd = (const Sludge::SludgeGameDescription *)desc;
-			if (gd) {
-				*engine = new Sludge::SludgeEngine(syst, gd);
-			}
-			return gd != 0;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		*engine = new Sludge::SludgeEngine(syst, (const Sludge::SludgeGameDescription *)desc);
+		return Common::kNoError;
 	}
 };
 

--- a/engines/stark/metaengine.cpp
+++ b/engines/stark/metaengine.cpp
@@ -114,11 +114,9 @@ public:
 		g_system->getSavefileManager()->removeSavefile(filename);
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc)
-			*engine = new StarkEngine(syst, desc);
-
-		return desc != nullptr;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		*engine = new StarkEngine(syst, desc);
+		return Common::kNoError;
 	}    
 };
 

--- a/engines/startrek/metaengine.cpp
+++ b/engines/startrek/metaengine.cpp
@@ -61,7 +61,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -81,12 +81,9 @@ bool StarTrekMetaEngine::hasFeature(MetaEngineFeature f) const {
 	    (f == kSimpleSavesNames);
 }
 
-bool StarTrekMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const StarTrek::StarTrekGameDescription *gd = (const StarTrek::StarTrekGameDescription *)desc;
-
-	*engine = new StarTrek::StarTrekEngine(syst, gd);
-
-	return (gd != 0);
+Common::Error StarTrekMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new StarTrek::StarTrekEngine(syst, (const StarTrek::StarTrekGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList StarTrekMetaEngine::listSaves(const char *target) const {

--- a/engines/supernova/metaengine.cpp
+++ b/engines/supernova/metaengine.cpp
@@ -37,7 +37,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	void removeSaveState(const char *target, int slot) const override;
@@ -62,12 +62,9 @@ bool SupernovaMetaEngine::hasFeature(MetaEngineFeature f) const {
 	}
 }
 
-bool SupernovaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Supernova::SupernovaEngine(syst);
-	}
-
-	return desc != nullptr;
+Common::Error SupernovaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Supernova::SupernovaEngine(syst);
+	return Common::kNoError;
 }
 
 SaveStateList SupernovaMetaEngine::listSaves(const char *target) const {

--- a/engines/sword25/metaengine.cpp
+++ b/engines/sword25/metaengine.cpp
@@ -37,18 +37,16 @@ public:
 		return "sword25";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
     int getMaximumSaveSlot() const override { return Sword25::PersistenceService::getSlotCount(); }
 	SaveStateList listSaves(const char *target) const override;
 };
 
-bool Sword25MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Sword25::Sword25Engine(syst, desc);
-	}
-	return desc != 0;
+Common::Error Sword25MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Sword25::Sword25Engine(syst, desc);
+	return Common::kNoError;
 }
 
 bool Sword25MetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -54,11 +54,9 @@ public:
 		}
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc) {
-			*engine = new TeenAgent::TeenAgentEngine(syst, desc);
-		}
-		return desc != 0;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		*engine = new TeenAgent::TeenAgentEngine(syst, desc);
+		return Common::kNoError;
 	}
 
 	static Common::String generateGameStateFileName(const char *target, int slot) {

--- a/engines/testbed/metaengine.cpp
+++ b/engines/testbed/metaengine.cpp
@@ -35,10 +35,9 @@ public:
 		return "testbed";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription * /* desc */) const override {
-		// Instantiate Engine even if the game data is not found.
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription * /* desc */) const override {
 		*engine = new Testbed::TestbedEngine(syst);
-		return true;
+		return Common::kNoError;
 	}
 
 	const Common::AchievementsInfo getAchievementsInfo(const Common::String &target) const override {

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -69,7 +69,7 @@ public:
 		return "tinsel";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
     bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -169,12 +169,9 @@ SaveStateList TinselMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-bool TinselMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Tinsel::TinselGameDescription *gd = (const Tinsel::TinselGameDescription *)desc;
-	if (gd) {
-		*engine = new Tinsel::TinselEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error TinselMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Tinsel::TinselEngine(syst, (const Tinsel::TinselGameDescription *)desc);
+	return Common::kNoError;
 }
 
 int TinselMetaEngine::getMaximumSaveSlot() const { return 99; }

--- a/engines/titanic/metaengine.cpp
+++ b/engines/titanic/metaengine.cpp
@@ -52,7 +52,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -79,11 +79,9 @@ bool Titanic::TitanicEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool TitanicMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Titanic::TitanicGameDescription *gd = (const Titanic::TitanicGameDescription *)desc;
-	*engine = new Titanic::TitanicEngine(syst, gd);
-
-	return gd != 0;
+Common::Error TitanicMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Titanic::TitanicEngine(syst, (const Titanic::TitanicGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList TitanicMetaEngine::listSaves(const char *target) const {

--- a/engines/toltecs/metaengine.cpp
+++ b/engines/toltecs/metaengine.cpp
@@ -50,7 +50,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
     SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -77,12 +77,9 @@ bool Toltecs::ToltecsEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool ToltecsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Toltecs::ToltecsGameDescription *gd = (const Toltecs::ToltecsGameDescription *)desc;
-	if (gd) {
-		*engine = new Toltecs::ToltecsEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error ToltecsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Toltecs::ToltecsEngine(syst, (const Toltecs::ToltecsGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList ToltecsMetaEngine::listSaves(const char *target) const {

--- a/engines/tony/metaengine.cpp
+++ b/engines/tony/metaengine.cpp
@@ -58,7 +58,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -82,12 +82,9 @@ bool Tony::TonyEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool TonyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Tony::TonyGameDescription *gd = (const Tony::TonyGameDescription *)desc;
-	if (gd) {
-		*engine = new Tony::TonyEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error TonyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Tony::TonyEngine(syst, (const Tony::TonyGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList TonyMetaEngine::listSaves(const char *target) const {

--- a/engines/toon/metaengine.cpp
+++ b/engines/toon/metaengine.cpp
@@ -35,7 +35,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -157,11 +157,9 @@ SaveStateDescriptor ToonMetaEngine::querySaveMetaInfos(const char *target, int s
 	return SaveStateDescriptor();
 }
 
-bool ToonMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Toon::ToonEngine(syst, desc);
-	}
-	return desc != 0;
+Common::Error ToonMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Toon::ToonEngine(syst, desc);
+	return Common::kNoError;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(TOON)

--- a/engines/touche/metaengine.cpp
+++ b/engines/touche/metaengine.cpp
@@ -36,7 +36,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
@@ -57,11 +57,9 @@ bool Touche::ToucheEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSubtitleOptions);
 }
 
-bool ToucheMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Touche::ToucheEngine(syst, desc->language);
-	}
-	return desc != 0;
+Common::Error ToucheMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Touche::ToucheEngine(syst, desc->language);
+	return Common::kNoError;
 }
 
 SaveStateList ToucheMetaEngine::listSaves(const char *target) const {

--- a/engines/tsage/metaengine.cpp
+++ b/engines/tsage/metaengine.cpp
@@ -77,11 +77,9 @@ public:
 		}
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc) {
-			*engine = new TsAGE::TSageEngine(syst, (const TsAGE::tSageGameDescription *)desc);
-		}
-		return desc != 0;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		*engine = new TsAGE::TSageEngine(syst, (const TsAGE::tSageGameDescription *)desc);
+		return Common::kNoError;
 	}
 
 	static Common::String generateGameStateFileName(const char *target, int slot) {

--- a/engines/tucker/metaengine.cpp
+++ b/engines/tucker/metaengine.cpp
@@ -50,11 +50,9 @@ public:
 		}
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc) {
-			*engine = new Tucker::TuckerEngine(syst, desc->language, desc->flags);
-		}
-		return desc != nullptr;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		*engine = new Tucker::TuckerEngine(syst, desc->language, desc->flags);
+		return Common::kNoError;
 	}
 
     SaveStateList listSaves(const char *target) const override {

--- a/engines/twine/metaengine.cpp
+++ b/engines/twine/metaengine.cpp
@@ -45,18 +45,16 @@ public:
 		return 6;
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc) {
-			TwineGameType gameType = TwineGameType::GType_LBA;
-			const Common::String gameId = desc->gameId;
-			if (gameId == "lba") {
-				gameType = TwineGameType::GType_LBA;
-			} else if (gameId == "lba2") {
-				gameType = TwineGameType::GType_LBA2;
-			}
-			*engine = new TwinE::TwinEEngine(syst, desc->language, desc->flags, gameType);
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		TwineGameType gameType = TwineGameType::GType_LBA;
+		const Common::String gameId = desc->gameId;
+		if (gameId == "lba") {
+			gameType = TwineGameType::GType_LBA;
+		} else if (gameId == "lba2") {
+			gameType = TwineGameType::GType_LBA2;
 		}
-		return desc != nullptr;
+		*engine = new TwinE::TwinEEngine(syst, desc->language, desc->flags, gameType);
+		return Common::kNoError;
 	}
 
 	Common::Array<Common::Keymap *> initKeymaps(const char *target) const override;

--- a/engines/ultima/metaengine.cpp
+++ b/engines/ultima/metaengine.cpp
@@ -41,34 +41,32 @@ const char *UltimaMetaEngine::getName() const {
 	return "ultima";
 }
 
-bool UltimaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error UltimaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Ultima::UltimaGameDescription *gd = (const Ultima::UltimaGameDescription *)desc;
-	if (gd) {
-		switch (gd->gameId) {
+	switch (gd->gameId) {
 #ifndef RELEASE_BUILD
-		case Ultima::GAME_ULTIMA1:
-			*engine = new Ultima::Shared::UltimaEarlyEngine(syst, gd);
-			break;
+	case Ultima::GAME_ULTIMA1:
+		*engine = new Ultima::Shared::UltimaEarlyEngine(syst, gd);
+		break;
 #endif
-		case Ultima::GAME_ULTIMA4:
-			*engine = new Ultima::Ultima4::Ultima4Engine(syst, gd);
-			break;
-		case Ultima::GAME_ULTIMA6:
-		case Ultima::GAME_MARTIAN_DREAMS:
-		case Ultima::GAME_SAVAGE_EMPIRE:
-			*engine = new Ultima::Nuvie::NuvieEngine(syst, gd);
-			break;
-		case Ultima::GAME_ULTIMA8:
-		case Ultima::GAME_CRUSADER_REG:
-		case Ultima::GAME_CRUSADER_REM:
-			*engine = new Ultima::Ultima8::Ultima8Engine(syst, gd);
-			break;
+	case Ultima::GAME_ULTIMA4:
+		*engine = new Ultima::Ultima4::Ultima4Engine(syst, gd);
+		break;
+	case Ultima::GAME_ULTIMA6:
+	case Ultima::GAME_MARTIAN_DREAMS:
+	case Ultima::GAME_SAVAGE_EMPIRE:
+		*engine = new Ultima::Nuvie::NuvieEngine(syst, gd);
+		break;
+	case Ultima::GAME_ULTIMA8:
+	case Ultima::GAME_CRUSADER_REG:
+	case Ultima::GAME_CRUSADER_REM:
+		*engine = new Ultima::Ultima8::Ultima8Engine(syst, gd);
+		break;
 
-		default:
-			error("Unsupported ultima engine game specified");
-		}
+	default:
+		return Common::kUnsupportedGameidError;
 	}
-	return gd != 0;
+	return Common::kNoError;
 }
 
 int UltimaMetaEngine::getMaximumSaveSlot() const {

--- a/engines/ultima/metaengine.h
+++ b/engines/ultima/metaengine.h
@@ -37,7 +37,7 @@ private:
 public:
 	const char *getName() const override;
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	int getMaximumSaveSlot() const override;
 
 	/**

--- a/engines/voyeur/metaengine.cpp
+++ b/engines/voyeur/metaengine.cpp
@@ -60,7 +60,7 @@ public:
 	}
 
     bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
@@ -84,12 +84,9 @@ bool Voyeur::VoyeurEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool VoyeurMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Voyeur::VoyeurGameDescription *gd = (const Voyeur::VoyeurGameDescription *)desc;
-	if (gd) {
-		*engine = new Voyeur::VoyeurEngine(syst, gd);
-	}
-	return gd != 0;
+Common::Error VoyeurMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Voyeur::VoyeurEngine(syst, (const Voyeur::VoyeurGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList VoyeurMetaEngine::listSaves(const char *target) const {

--- a/engines/wage/metaengine.cpp
+++ b/engines/wage/metaengine.cpp
@@ -43,7 +43,7 @@ public:
 		return "wage";
 	}
 
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -66,11 +66,9 @@ bool Wage::WageEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool WageMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc) {
-		*engine = new Wage::WageEngine(syst, desc);
-	}
-	return desc != 0;
+Common::Error WageMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Wage::WageEngine(syst, desc);
+	return Common::kNoError;
 }
 
 SaveStateList WageMetaEngine::listSaves(const char *target) const {

--- a/engines/wintermute/metaengine.cpp
+++ b/engines/wintermute/metaengine.cpp
@@ -57,34 +57,29 @@ public:
 		return "wintermute";
 	}
 
-    bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		assert(syst);
-		assert(engine);
+    Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
 		const WMEGameDescription *gd = (const WMEGameDescription *)desc;
 
 #ifndef ENABLE_FOXTAIL
 		if (gd->targetExecutable >= FOXTAIL_OLDEST_VERSION && gd->targetExecutable <= FOXTAIL_LATEST_VERSION) {
-			Engine::errorUnsupportedGame(_("FoxTail support is not compiled in"));
-			return false;
+			return Common::Error(Common::kUnsupportedGameidError, _s("FoxTail support is not compiled in"));
 		}
 #endif
 
 #ifndef ENABLE_HEROCRAFT
 		if (gd->targetExecutable == WME_HEROCRAFT) {
-			Engine::errorUnsupportedGame(_("Hero Craft support is not compiled in"));
-			return false;
+			return Common::Error(Common::kUnsupportedGameidError, _s("Hero Craft support is not compiled in"));
 		}
 #endif
 
 #ifndef ENABLE_WME3D
 		if (gd->adDesc.flags & GF_3D) {
-			Engine::errorUnsupportedGame(_("Wintermute3D support is not compiled in"));
-			return false;
+			return Common::Error(Common::kUnsupportedGameidError, _s("Wintermute3D support is not compiled in"));
 		}
 #endif
 
 		*engine = new Wintermute::WintermuteEngine(syst, gd);
-		return true;
+		return Common::kNoError;
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override {

--- a/engines/xeen/metaengine.cpp
+++ b/engines/xeen/metaengine.cpp
@@ -75,7 +75,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
@@ -101,7 +101,7 @@ bool Xeen::XeenEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool XeenMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error XeenMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
 	const Xeen::XeenGameDescription *gd = (const Xeen::XeenGameDescription *)desc;
 
 	switch (gd->gameID) {
@@ -114,10 +114,10 @@ bool XeenMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGame
 		*engine = new Xeen::SwordsOfXeen::SwordsOfXeenEngine(syst, gd);
 		break;
 	default:
-		error("Invalid game");
+		return Common::kUnsupportedGameidError;
 	}
 
-	return true;
+	return Common::kNoError;
 }
 
 SaveStateList XeenMetaEngine::listSaves(const char *target) const {

--- a/engines/zvision/metaengine.cpp
+++ b/engines/zvision/metaengine.cpp
@@ -59,7 +59,7 @@ public:
 
     bool hasFeature(MetaEngineFeature f) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -232,12 +232,9 @@ Common::KeymapArray ZVisionMetaEngine::initKeymaps(const char *target) const {
 	return keymaps;
 }
 
-bool ZVisionMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const ZVision::ZVisionGameDescription *gd = (const ZVision::ZVisionGameDescription *)desc;
-	if (gd) {
-		*engine = new ZVision::ZVision(syst, gd);
-	}
-	return gd != 0;
+Common::Error ZVisionMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new ZVision::ZVision(syst, (const ZVision::ZVisionGameDescription *)desc);
+	return Common::kNoError;
 }
 
 SaveStateList ZVisionMetaEngine::listSaves(const char *target) const {


### PR DESCRIPTION
This allows for improved error reporting in cases where, for example, a particular sub-engine is disabled.