### PR TITLE
Revert "PARALLACTION: Fix buffer overrun"

### DIFF
--- a/engines/parallaction/disk_ns.cpp
+++ b/engines/parallaction/disk_ns.cpp
@@ -590,7 +590,7 @@ private:
 		off_lens = src; src = &src[4];
 		buf = &src[src_len];
 
-		out = dest_end = &dest[dest_len - 1];
+		out = dest_end = &dest[dest_len];
 
 		/* skip the first few bits */
 		PP_READ_BITS(src[src_len + 3], x);


### PR DESCRIPTION
This fixes a crash when starting the Nippon Safes Inc. demo.