### PR TITLE
MOHAWK: Fix Myst regression (bug #11954)

### DIFF
--- a/engines/mohawk/myst_areas.cpp
+++ b/engines/mohawk/myst_areas.cpp
@@ -192,10 +192,6 @@ MystAreaVideo::MystAreaVideo(MohawkEngine_Myst *vm, ResourceType type, Common::S
 		rlstStream->skip(1);
 	}
 
-	// Trim method does not remove extra trailing nulls
-	while (_videoFile.size() != 0 && _videoFile.lastChar() == 0)
-		_videoFile.deleteLastChar();
-
 	_videoFile = convertMystVideoName(_videoFile);
 	_videoFile = _vm->selectLocalizedMovieFilename(_videoFile);
 

--- a/engines/mohawk/myst_areas.cpp
+++ b/engines/mohawk/myst_areas.cpp
@@ -184,12 +184,13 @@ MystAreaVideo::MystAreaVideo(MohawkEngine_Myst *vm, ResourceType type, Common::S
 		MystAreaAction(vm, type, rlstStream, parent) {
 	char c = 0;
 
-	do {
-		c = rlstStream->readByte();
+	while ((c = rlstStream->readByte()) != 0) {
 		_videoFile += c;
-	} while (c);
+	}
 
-	rlstStream->skip(_videoFile.size() & 1);
+	if ((_videoFile.size() & 1) == 0) {
+		rlstStream->skip(1);
+	}
 
 	// Trim method does not remove extra trailing nulls
 	while (_videoFile.size() != 0 && _videoFile.lastChar() == 0)


### PR DESCRIPTION
This is my attempt at fixing https://bugs.scummvm.org/ticket/11954

Apparently, when reading a movie file name the engine needs to read an even number of bytes (probably to keep the rest of the data aligned), so if the length of the file name is even (not counting the terminating 0) it has to read an extra byte. This was already done, but apparently the String class used to allow you to add terminators to a string, and these were then counted into
the length of it. Not adding the terminator avoids this disambiguity, in case the behavior changes again. (I know it was changed to its current behavior to fix regressions in other engines.)

I've played through the non-Masterpiece version of Myst, getting both the red and blue pages and watching all the bad endings, without any crashes. I figured that this would be the less easily available version even though from what I remember they used to hand it out like candy. (I think my parents got one for free, and since they never played it they had no objections to me taking it.) But there is a limit to how much Myst I can take in one evening, so I would be grateful if someone else would test the Masterpiece version.

I had hoped to be able to find someone familiar with the engine to discuss this change with, but I failed. So if anyone has a better fix, please don't hesitate to chime in.