### PR TITLE
AMIGAOS: Platform updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,10 @@ For a more comprehensive changelog of the latest experimental code, see:
    - Fixed occasional border corruption during fights.
    - Improvements to cutscenes to better match the original games.
 
+ AmigaOS port:
+   - Add native system file browser feature
+   - Re-activate nuked OPL Adlib driver
+
  MorphOS port:
    - Add native system file browser feature
    - Add Cloud feature

--- a/backends/platform/sdl/amigaos/amigaos-main.cpp
+++ b/backends/platform/sdl/amigaos/amigaos-main.cpp
@@ -31,38 +31,34 @@
 
 int main(int argc, char *argv[]) {
 
-	// The following will gather ScummVM's system application name
-	// and add the binary path to a variable in AmigaOS ENV(ARC) system.
-	// It will be added to AppPaths, so ScummVM becomes AmiUpdate aware.
+	// Update support (AmiUpdate):
+	// This will save ScummVM's system application name and add it's binary
+	// path to a variable in the platforms native ENV(ARC) system.
 	const char *const appname = "ScummVM";
 
 	BPTR lock;
-	APTR oldwin;
+	APTR reqwin;
 
-	// Obtain a lock to the home directory.
+	// Obtain a lock to it's home directory.
 	if ((lock = IDOS->GetProgramDir())) {
 		TEXT progpath[2048];
 		TEXT apppath[1024] = "AppPaths";
 
-		if (IDOS->DevNameFromLock(lock,
-			progpath,
-			sizeof(progpath),
-			DN_FULLPATH)) {
+		if (IDOS->DevNameFromLock(lock,	progpath, sizeof(progpath),	DN_FULLPATH)) {
+			// Stop any "Please insert volume ..." type system requester.
+			reqwin = IDOS->SetProcWindow((APTR)-1);
 
-			// Stop any "Insert volume..." type requesters.
-			oldwin = IDOS->SetProcWindow((APTR)-1);
+			// Set the AppPaths variable to the path the binary was run from.
+			IDOS->AddPart(apppath, appname, 1024);
+			IDOS->SetVar(apppath, progpath, -1, GVF_GLOBAL_ONLY|GVF_SAVE_VAR );
 
-			// Finally, set the variable to the path the executable was run from.
-			IDOS->AddPart( apppath, appname, 1024);
-			IDOS->SetVar( apppath, progpath, -1, GVF_GLOBAL_ONLY|GVF_SAVE_VAR );
-
-			// Turn system requesters back on.
-			IDOS->SetProcWindow( oldwin );
+			// Turn system requester back on.
+			IDOS->SetProcWindow(reqwin);
 		}
 	}
 
-	// Set up a stack cookie to avoid crashes from a stack set too low.
-	static const char *stack_cookie __attribute__((used)) = "$STACK: 2048000";
+	// Set a stack cookie to avoid crashes from a too low stack.
+	static const char *stack_cookie __attribute__((used)) = "$STACK: 20971520";
 
 	// Create our OSystem instance.
 	g_system = new OSystem_AmigaOS();

--- a/backends/platform/sdl/amigaos/amigaos-main.cpp
+++ b/backends/platform/sdl/amigaos/amigaos-main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
 
 			// Set the AppPaths variable to the path the binary was run from.
 			IDOS->AddPart(apppath, appname, 1024);
-			IDOS->SetVar(apppath, progpath, -1, GVF_GLOBAL_ONLY|GVF_SAVE_VAR );
+			IDOS->SetVar(apppath, progpath, -1, GVF_GLOBAL_ONLY|GVF_SAVE_VAR);
 
 			// Turn system requester back on.
 			IDOS->SetProcWindow(reqwin);
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	// Set a stack cookie to avoid crashes from a too low stack.
-	static const char *stack_cookie __attribute__((used)) = "$STACK: 20971520";
+	static const char *stack_cookie __attribute__((used)) = "$STACK: 2048000";
 
 	// Create our OSystem instance.
 	g_system = new OSystem_AmigaOS();

--- a/configure
+++ b/configure
@@ -2702,19 +2702,27 @@ case $_host_os in
 		append_var LIBS "-lcitro3d"
 		;;
 	amigaos*)
+		# On building dynamic, everything (possible) should be built as plugin.
+		if test "$_dynamic_modules" = yes ; then
+			_detection_features_static=no
+			_plugins_default=dynamic
+		fi
+		# We have to use 'long' for our 4 byte typedef, because AmigaOS
+		# already typedefs (u)int32 as (unsigned) long  and consequently we'd
+		# get a compiler error otherwise.
+		type_4_byte='long'
+		# Supress format warnings as the long 4 byte causes noisy warnings.
+		append_var CXXFLAGS "-Wno-format"
+		# Enable optimizations for non-debug builds
 		if test "$_debug_build" = no; then
 			_optimization_level=-O2
 		fi
 		append_var LDFLAGS "-Wl,--export-dynamic"
 		append_var LDFLAGS "-L/sdk/local/newlib/lib"
-		# We have to use 'long' for our 4 byte typedef because AmigaOS already typedefs (u)int32
-		# as (unsigned) long, and consequently we'd get a compiler error otherwise.
-		type_4_byte='long'
-		# Supress format warnings as the long 4 byte causes noisy warnings.
-		append_var CXXFLAGS "-Wno-format"
 		add_line_to_config_mk 'AMIGAOS = 1'
 		_port_mk="backends/platform/sdl/amigaos/amigaos.mk"
-		_nuked_opl=no
+		# Leave out resources by default, save binary size.
+		_builtin_resources=no
 		;;
 	android)
 		case $_host in


### PR DESCRIPTION
- Readability
- Changed and added comments
- Changed one variable name for comprehensibility
- Added no builtin resources as default to save as much binary size as possible
- Tried to apply to the coding standards (and probably failed miserably)
- Re-activate the formerly locked-out nuked OPL Adlib driver
- Reflect changes in NEWS.md