### PR TITLE
ENGINES: Add detection for international releases in many engines

### DIFF
--- a/engines/kyra/detection_tables.h
+++ b/engines/kyra/detection_tables.h
@@ -218,6 +218,32 @@ const KYRAGameDescription adGameDescs[] = {
 		KYRA1_FLOPPY_FLAGS
 	},
 
+	{ // from trembyle
+		{
+			"kyra1",
+			_s("Missing game code"), // Reason for being unsupported
+			AD_ENTRY1("GEMCUT.EMC", "3f319d6908830a46ff42229a39a2c7ec"),
+			Common::ZH_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSUPPORTED,
+			GUIO5(GUIO_NOSPEECH, GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIPCSPK, GUIO_RENDERVGA)
+		},
+		KYRA1_FLOPPY_FLAGS
+	},
+
+	{ // from trembyle
+		{
+			"kyra1",
+			_s("Missing game code"), // Reason for being unsupported
+			AD_ENTRY1("GEMCUT.EMC", "57907d931675dbd16386c1d81d18fee4"),
+			Common::KO_KOR,
+			Common::kPlatformDOS,
+			ADGF_UNSUPPORTED,
+			GUIO5(GUIO_NOSPEECH, GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIPCSPK, GUIO_RENDERVGA)
+		},
+		KYRA1_FLOPPY_FLAGS
+	},
+
 	{
 		{
 			"kyra1",
@@ -542,6 +568,19 @@ const KYRAGameDescription adGameDescs[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
+			GUIO6(GUIO_NOSPEECH, GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_MIDIPCSPK, GUIO_RENDERVGA)
+		},
+		KYRA2_FLOPPY_FLAGS
+	},
+
+	{ // Floppy version extracted
+		{
+			"kyra2",
+			_s("Missing game code"), // Reason for being unsupported
+			AD_ENTRY1("FATE.PAK", "5bfc4dd48778ca1f3a9e001e345a9774"),
+			Common::ZH_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSUPPORTED,
 			GUIO6(GUIO_NOSPEECH, GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_MIDIPCSPK, GUIO_RENDERVGA)
 		},
 		KYRA2_FLOPPY_FLAGS
@@ -1712,6 +1751,20 @@ const KYRAGameDescription adGameDescs[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
+			GUIO7(GUIO_NOSPEECH, GUIO_MIDIADLIB, GUIO_MIDIPCSPK, GUIO_RENDERVGA, GUIO_RENDEREGA, GAMEOPTION_EOB_HPGRAPHS, GAMEOPTION_EOB_MOUSESWAP)
+		},
+		EOB2_FLAGS
+	},
+
+
+	{
+		{
+			"eob2",
+			_s("Missing game code"), // Reason for being unsupported
+			AD_ENTRY1s("LEVEL15.INF", "f972f628d21bae404a7d52bb287c0012", -1),
+			Common::ZH_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSUPPORTED,
 			GUIO7(GUIO_NOSPEECH, GUIO_MIDIADLIB, GUIO_MIDIPCSPK, GUIO_RENDERVGA, GUIO_RENDEREGA, GAMEOPTION_EOB_HPGRAPHS, GAMEOPTION_EOB_MOUSESWAP)
 		},
 		EOB2_FLAGS

--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -143,7 +143,11 @@ static const MadeGameDescription gameDescriptions[] = {
 		{
 			"rtz",
 			"V1.2, 9/29/94, CD",
-			AD_ENTRY1s("rtzcd.red", "946997d8b0aa6cb4e848bad02a1fc3d2", 276584),
+			{
+				{ "rtzcd.red", 0, "946997d8b0aa6cb4e848bad02a1fc3d2", 276584 },
+				{ "rtzcd.prj", 0, "974d74410c3c29d50e857863e8bf40e2", 43016792 },
+				AD_LISTEND
+			},
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
@@ -253,6 +257,29 @@ static const MadeGameDescription gameDescriptions[] = {
 			"V1.2, 3/31/95, CD",
 			AD_ENTRY1s("rtzcd.red", "946997d8b0aa6cb4e848bad02a1fc3d2", 354614),
 			Common::FR_FRA,
+			Common::kPlatformDOS,
+			ADGF_CD,
+			GUIO0()
+		},
+		GID_RTZ,
+		0,
+		GF_CD_COMPRESSED,
+		3,
+	},
+
+	{
+		// Return to Zork - Korean CD version 1.2 9/29/94
+		// Dub only. No text was translated, even in menus, so there are no font issues.
+		// submitted by trembyle
+		{
+			"rtz",
+			"V1.2, 9/29/94, CD",
+			{
+				{ "rtzcd.red", 0, "946997d8b0aa6cb4e848bad02a1fc3d2", 276584 },
+				{ "rtzcd.prj", 0, "3c8644f7ce77b74968637c035c3532d8", 48083511 },
+				AD_LISTEND
+			},
+			Common::KO_KOR,
 			Common::kPlatformDOS,
 			ADGF_CD,
 			GUIO0()

--- a/engines/mohawk/detection_tables.h
+++ b/engines/mohawk/detection_tables.h
@@ -487,7 +487,6 @@ static const MohawkGameDescription gameDescriptions[] = {
 		0,
 	},
 
-
 	// Riven: The Sequel to Myst
 	// Version 1.0J (5CD) - Japanese
 	// From sev
@@ -497,6 +496,24 @@ static const MohawkGameDescription gameDescriptions[] = {
 			"",
 			AD_ENTRY1s("a_Data.MHK", "3a2b4764979dc007a0e6ded64e4b7889", 10014314),
 			Common::JA_JPN,
+			Common::kPlatformWindows,
+			ADGF_DROPPLATFORM,
+			GUI_OPTIONS_RIVEN
+		},
+		GType_RIVEN,
+		0,
+		0,
+	},
+
+	// Riven: The Sequel to Myst
+	// Version 1.0 (5CD) - Brazilian
+	// from trembyle
+	{
+		{
+			"riven",
+			"",
+			AD_ENTRY1s("a_Data.MHK", "49fe3003d6da02b03c5c1f6028a7f719", 9892372),
+			Common::PT_BRA,
 			Common::kPlatformWindows,
 			ADGF_DROPPLATFORM,
 			GUI_OPTIONS_RIVEN

--- a/engines/saga/detection_tables.h
+++ b/engines/saga/detection_tables.h
@@ -929,6 +929,35 @@ static const SAGAGameDescription gameDescriptions[] = {
 		NULL,
 	},
 
+	// I Have No Mouth And I Must Scream - Korean CD version
+	{
+		{
+			"ihnm",
+			_s("Missing game code"), // Reason for being unsupported
+			{
+				{"musicfm.res",	GAME_MUSICFILE_FM,					"0439083e3dfdc51b486071d45872ae52", -1},
+				{"musicgm.res",	GAME_MUSICFILE_GM,					"80f875a1fb384160d1f4b27166eef583", -1},
+				{"scream.res",	GAME_RESOURCEFILE,					"46bbdc65d164ba7e89836a0935eec8e6", 79211140},
+				{"patch.re_",	GAME_PATCHFILE | GAME_RESOURCEFILE,	"58b79e61594779513c7f2d35509fa89e", -1},
+				{"scripts.res",	GAME_SCRIPTFILE,					"be38bbc5a26be809dbf39f13befebd01", -1},
+				{"sfx.res",		GAME_SOUNDFILE,						"1c610d543f32ec8b525e3f652536f269", -1},
+				{"sbh1616.fnt",	0,									"ec047bbe048ed9465def705b5bd74d99", -1},
+				AD_LISTEND
+			},
+			Common::KO_KOR,
+			Common::kPlatformDOS,
+			ADGF_UNSUPPORTED,
+			GUIO1(GUIO_NOASPECT)
+		},
+		GID_IHNM,
+		GF_IHNM_COLOR_FIX,
+		IHNM_DEFAULT_SCENE,
+		&IHNM_Resources,
+		ARRAYSIZE(IHNMCD_GameFonts),
+		IHNMCD_GameFonts,
+		NULL,
+	},
+
 	// I Have No Mouth And I Must Scream - Fr CD version
 	// Censored CD version (without Nimdok)
 	{

--- a/engines/sherlock/detection_tables.h
+++ b/engines/sherlock/detection_tables.h
@@ -281,6 +281,20 @@ static const SherlockGameDescription gameDescriptions[] = {
 		GType_RoseTattoo,
 	},
 
+	{
+		// Case of the Rose Tattoo - Chinese CD
+		{
+			"rosetattoo",
+			"CD",
+			AD_ENTRY1s("talk.lib", "dfd699efdce02a045f46d15da2d44b76", 582381),
+			Common::ZH_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO3(GAMEOPTION_ORIGINAL_SAVES, GAMEOPTION_HELP_STYLE, GAMEOPTION_TRANSPARENT_WINDOWS)
+		},
+		GType_RoseTattoo,
+	},
+
 	{ AD_TABLE_END_MARKER, (GameType)0 }
 };
 

--- a/engines/xeen/detection_tables.h
+++ b/engines/xeen/detection_tables.h
@@ -137,6 +137,21 @@ static const XeenGameDescription gameDescriptions[] = {
 	},
 
 	{
+		// Clouds of Xeen (Chinese)
+		{
+			"cloudsofxeen",
+			nullptr,
+			AD_ENTRY1s("xeen.cc", "1fea0587fe139b13f4effa2b5791bd80", 13859999),
+			Common::ZH_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO2(GAMEOPTION_SHOW_ITEM_COSTS, GAMEOPTION_DURABLE_ARMOR)
+		},
+		GType_Clouds,
+		0
+	},
+
+	{
 		// Darkside of Xeen
 		{
 			"darksideofxeen",
@@ -174,6 +189,21 @@ static const XeenGameDescription gameDescriptions[] = {
 			AD_ENTRY2s("dark.cc",  "84a86bbbc5f2fe96c0b0325485ed8203", 11173657,
 					   "intro.cc", "e47a7ab0223cf32b2d87eed91d024c35", 8899953),
 			Common::DE_DEU,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO2(GAMEOPTION_SHOW_ITEM_COSTS, GAMEOPTION_DURABLE_ARMOR)
+		},
+		GType_DarkSide,
+		0
+	},
+
+	{
+		// Darkside of Xeen (Chinese)
+		{
+			"darksideofxeen",
+			nullptr,
+			AD_ENTRY1s("dark.cc", "4dcbcdb0be885afebc2ab6c9e60c434e", 11137412),
+			Common::ZH_ANY,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE,
 			GUIO2(GAMEOPTION_SHOW_ITEM_COSTS, GAMEOPTION_DURABLE_ARMOR)

--- a/engines/zvision/detection_tables.h
+++ b/engines/zvision/detection_tables.h
@@ -104,7 +104,11 @@ static const ZVisionGameDescription gameDescriptions[] = {
 		{
 			"znemesis",
 			0,
-			AD_ENTRY1s("CSCR.ZFS", "88226e51a205d2e50c67a5237f3bd5f2", 2397741),
+			{
+				{ "CSCR.ZFS", 0, "88226e51a205d2e50c67a5237f3bd5f2", 2397741 },
+				{ "ASCR.ZFS", 0, "9a1e1a48a56cf12a22bad2d2e47f6c92", 917452 },
+				AD_LISTEND
+			},
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -151,6 +155,24 @@ static const ZVisionGameDescription gameDescriptions[] = {
 			AD_ENTRY2s("CSCR.ZFS",		"f04113357b4748c13efcb58b4629887c", 2577873,
 					   "NEMESIS.STR",	"7c568feca8d9f9ae855c47183612c305", 9061),
 			Common::IT_ITA,
+			Common::kPlatformDOS,
+			ADGF_NO_FLAGS,
+			GUIO4(GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_DOUBLE_FPS, GAMEOPTION_ENABLE_VENUS, GAMEOPTION_DISABLE_ANIM_WHILE_TURNING)
+		},
+		GID_NEMESIS
+	},
+
+	{
+		// Zork Nemesis Korean version
+		{
+			"znemesis",
+			0,
+			{
+				{ "CSCR.ZFS", 0, "88226e51a205d2e50c67a5237f3bd5f2", 2397741 },
+				{ "ASCR.ZFS", 0, "127f59f96be3d13eafac665eeede080d", 765413 },
+				AD_LISTEND
+			},
+			Common::KO_KOR,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
 			GUIO4(GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_DOUBLE_FPS, GAMEOPTION_ENABLE_VENUS, GAMEOPTION_DISABLE_ANIM_WHILE_TURNING)


### PR DESCRIPTION
I have several more to add, but I wanted to submit these in case detection code changes and they become obsolete.

Korean Return to Zork is only dubbed. There are no fonts to render, even in the menus. Unlike the Japanese version, this version should work without further changes.

KYRA.DAT still needs to be updated.