### PR TITLE
AMIGAOS: Fix automatic (dynamic) building process

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -10,13 +10,12 @@ ifdef DIST_FILES_DOCS
 	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)/doc/
 	# Prepare README.md for AmigaGuide conversion.
 	cat ${srcdir}/README.md | sed -f ${srcdir}/dists/amigaos/convertRM.sed > README.conv
-	# AmigaOS AREXX has a problem when ${srcdir} is '.'.
-	# It will break with a "Program not found" error.
-	# Copy the script to cwd and, once it has finished, remove it.
+	# AmigaOS AREXX will break with a "Program not found" error, if srcdir is
+	# '.'. Copy the script to cwd instead.
 	cp ${srcdir}/dists/amigaos/RM2AG.rexx .
 	rx RM2AG.rexx README.conv $(AMIGAOSPATH)/doc/
-	rm README.conv
-	rm RM2AG.rexx
+	rm -f README.conv
+	rm -f RM2AG.rexx
 endif
 	# Copy mandatory installation files.
 ifdef DIST_FILES_ENGINEDATA
@@ -36,12 +35,15 @@ endif
 ifdef DYNAMIC_MODULES
 	mkdir -p $(AMIGAOSPATH)/plugins
 	$(foreach plugin, $(PLUGINS), $(STRIP) $(plugin) -o $(AMIGAOSPATH)/$(plugin);)
-	# Extract and install compiled-in shared libraries.
-	# Not every AmigaOS installation, especially vanilla ones,
-	# come with every mandatory shared library.
+	# Shared objects on AmigaOS change. To avoid conflicts with old or
+	# outdated .so's, always remove and install them completely.
+	rm -rf $(AMIGAOSPATH)/sobjs
 	mkdir -p $(AMIGAOSPATH)/sobjs
+	# Extract and install compiled-in shared libraries.
+	# Not every AmigaOS installation, especially vanilla ones, have
+	# every mandatory shared library installed in the correct place.
 	cp ${srcdir}/dists/amigaos/Ext_Inst_so.rexx .
 	rx Ext_Inst_so.rexx $(EXECUTABLE) $(AMIGAOSPATH)
-	rm Ext_Inst_so.rexx
+	rm -f Ext_Inst_so.rexx
 endif
 	$(STRIP) $(EXECUTABLE) -o $(AMIGAOSPATH)/$(EXECUTABLE)

--- a/dists/amigaos/Ext_Inst_so.rexx
+++ b/dists/amigaos/Ext_Inst_so.rexx
@@ -1,5 +1,5 @@
 /*
-$VER: Ext_Inst_so.rexx 0.4 (23.10.2019) Extract and install compiled-in shared libraries from a given ELF binary.
+$VER: Ext_Inst_so.rexx 0.5 (05.12.2020) Extract and install compiled-in shared libraries from a given ELF binary.
 */
 
 PARSE ARG executable install_path
@@ -14,10 +14,10 @@ IF ~ARG() THEN DO
 END
 
 /*
-If the given filename/path has spaces in it, AmigaDOS/CLI
-will add extra quotation marks to secure a sane working path.
-Get rid of them to make AREXX find the file and remove leading
-and trailing spaces.
+If the given filename/path has spaces in it, AmigaDOS/CLI will add extra
+quotation marks to secure a sane working path.
+Get rid of them to make AREXX find the file and remove leading and trailing
+spaces.
 */
 IF ~EXISTS(executable) THEN DO
 	SAY executable' not available!'
@@ -43,9 +43,14 @@ ELSE DO
 END
 
 /*
+Save used gcc version. Needed later to install libgcc.so.
+*/
+ADDRESS COMMAND 'gcc -dumpversion >so_dump'
+
+/*
 Create shared objects dump.
 */
-ADDRESS COMMAND 'readelf -d 'executable' >so_dump'
+ADDRESS COMMAND 'readelf -d 'executable' >>so_dump'
 
 /*
 Error check, if I/O went wrong.
@@ -56,8 +61,13 @@ IF ~OPEN(SO_read,'so_dump','R') THEN DO
 END
 
 /*
-We know that the dumped shared library entries always start
-at line 4. Skip unneeded lines to speed up processing.
+Get used gcc version.
+*/
+gcc_version=READLN(SO_read)
+
+/*
+We know that the dumped shared library entries always start at line 4 (line 5
+now with the added gcc version). Skip unneeded lines to speed up processing.
 */
 working_line=CALL READLN(SO_read)
 working_line=CALL READLN(SO_read)
@@ -74,20 +84,21 @@ DO WHILE i>0
 		*/
 		lib.so=SUBSTR(working_line,59,LASTPOS(']', working_line)-59)
 		/*
-		Check whether the installed shared libraries are placed in the SDK
-		(most of them) or AmigaOS SOBJS: drawer (few of them) and copy them accordingly.
+		- Find and install the mandatory shared libraries from their varying
+		  home directories.
+		- libgcc.so is deeply hidden inside the gcc install directory tree
+		  by default. Since people can use different gcc versions we have
+		  determine which to use the correct path.
 		*/
 		IF EXISTS('SDK:local/newlib/lib/'lib.so) THEN
 			ADDRESS COMMAND 'copy clone SDK:local/newlib/lib/'lib.so install_path'/sobjs/'
-		ELSE
+		ELSE DO
 			IF EXISTS('SDK:gcc/lib/'lib.so) THEN
-				ADDRESS COMMAND 'copy clone SYS:SOBJS/'lib.so install_path'/sobjs/'
+				ADDRESS COMMAND 'copy clone SDK:gcc/lib/'lib.so install_path'/sobjs/'
 			ELSE DO
-				/*
-				If a shared library is not found, abort.
-				*/
-				SAY lib.so' not found! Aborting!'
-				EXIT
+				IF EXISTS('SDK:gcc/lib/gcc/ppc-amigaos/'gcc_version'/'lib.so) THEN
+					ADDRESS COMMAND 'copy clone SDK:gcc/lib/gcc/ppc-amigaos/'gcc_version'/'lib.so install_path'/sobjs/'
+			END
 		END
 	END
 	ELSE

--- a/dists/amigaos/Ext_Inst_so.rexx
+++ b/dists/amigaos/Ext_Inst_so.rexx
@@ -98,6 +98,13 @@ DO WHILE i>0
 			ELSE DO
 				IF EXISTS('SDK:gcc/lib/gcc/ppc-amigaos/'gcc_version'/'lib.so) THEN
 					ADDRESS COMMAND 'copy clone SDK:gcc/lib/gcc/ppc-amigaos/'gcc_version'/'lib.so install_path'/sobjs/'
+				ELSE DO
+					/*
+					If a shared library is not found, abort.
+					*/
+					SAY lib.so' not found! Aborting!'
+					EXIT
+				END
 			END
 		END
 	END


### PR DESCRIPTION
amigaos.mk
- Add force to rm
- Always remove shared objects before installing, otherwise outdated ones will bitrot

Ext_Inst_so.rexx:
- Add used gcc version check to be able to install libgcc.so from it's default install directory
- Fixed a wrong *copy from* directory
- *Never* use anything installed in system's SOBJS: (since users can install stuff there from all over the place)