### PR TITLE
CONFIGURE: Allow building without detection code for disabled engines

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -62,12 +62,14 @@ KYRARPG_COMMON_OBJ_ORIG := $(KYRARPG_COMMON_OBJ)
 # Skip rules for these files, by resetting the LOAD_RULES_MK
 LOAD_RULES_MK :=
 
+ifdef DETECTION_FULL
 # Reset detection objects, which uptill now are filled with only
 # enabled engines.
 DETECT_OBJS :=
 
 # Include all engine's module files, which populate DETECT_OBJS
 -include $(srcdir)/engines/*/module.mk
+endif
 
 # Reset stuff
 MODULES := $(MODULES_ORIG)

--- a/configure
+++ b/configure
@@ -248,6 +248,7 @@ _pandocformat="default"
 _pandocext="default"
 # Detection features to be linked into executable or not
 _detection_features_static=yes
+_detection_features_full=yes
 # The following variables are automatically detected, and should not
 # be modified otherwise. Consider them read-only.
 _posix=no
@@ -1241,6 +1242,8 @@ for ac_option in $@; do
 	--enable-static)              _static_build=yes      ;;
 	--enable-detection-static)    _detection_features_static=yes;;
 	--enable-detection-dynamic)   _detection_features_static=no;;
+	--enable-detection-full)      _detection_features_full=yes;;
+	--disable-detection-full)     _detection_features_full=no;;
 	--disable-16bit)              _16bit=no              ;;
 	--enable-highres)             _highres=yes           ;;
 	--disable-highres)            _highres=no            ;;
@@ -3107,6 +3110,7 @@ EOF
 		append_var DEFINES "-DDISABLE_SID"
 		append_var DEFINES "-DREDUCE_MEMORY_USAGE"
 		add_line_to_config_mk 'N64 = 1'
+		_detection_features_full=no
 		_nuked_opl=no
 		;;
 	ps3)
@@ -4276,6 +4280,13 @@ fi
 define_in_config_if_yes "$_detection_features_static" "DETECTION_STATIC"
 echo_n "Checking if detection features building statically... "
 echo "$_detection_features_static"
+
+#
+# Set up a define for detection to be used as static or not
+#
+define_in_config_if_yes "$_detection_features_full" "DETECTION_FULL"
+echo_n "Checking if building detection features for all engines... "
+echo "$_detection_features_full"
 
 #
 # Check whether integrated MT-32 emulator support is requested
@@ -6373,7 +6384,9 @@ for engine in $_sorted_engines; do
 		j=`echo $engine | tr '[:lower:]' '[:upper:]'`
 		detectEngine="${j}${detectId}"
 		cat >> engines/detection_table.h << EOF
+#if defined(ENABLE_$j) || defined(DETECTION_FULL)
 LINK_PLUGIN($detectEngine)
+#endif
 EOF
 	fi
 done


### PR DESCRIPTION
This provides a fairly significant reduction in code size at the cost of not being able to detect games from disabled engines. This should hopefully fix the N64 port, which is currently failing on the buildbot due to the .rodata section overflowing, and is likely to be useful on other platforms with very limited amounts of RAM.