### PR TITLE
RFC: Address possible fallout from recent String change

### DIFF
--- a/engines/myst3/archive.cpp
+++ b/engines/myst3/archive.cpp
@@ -286,17 +286,14 @@ Common::String ResourceDescription::getTextData(uint index) const {
 	// extract the wanted one
 	cnt = 0;
 	int i = 0;
-	Common::String text;
-	while (cnt <= index && i < 89) {
-		if (cnt == index)
-			text += decrypted[i];
-
+	while (cnt < index) {
 		if (!decrypted[i])
 			cnt++;
 
 		i++;
 	}
 
+	Common::String text((const char *)&decrypted[i]);
 	return text;
 }
 


### PR DESCRIPTION
The String class underwent some rewriting recently. I think it was this: https://github.com/scummvm/scummvm/commit/29cfa7bb0f2c1c76a9ef285b8e5799a7ec91020b

As I understand it, one of the changes was that string comparison now bails out if the two strings have different length. That means that "Hello World" and "Hello World\0" are no longer equal.

This caused regressions in Myst III (the game would complain that it could not find the subtitles font because the string it created for it had an extra terminator), and reportedly also in The Longest Journey though I do not know exactly how. So a change was made to ignore attempts at appending extra terminators to a string. See https://github.com/scummvm/scummvm/commit/54b0b4ac4cd4a42de660ea426edb27840ddfd4f0

This, however, caused a regression in Myst, which was addressed in https://github.com/scummvm/scummvm/pull/2652

The immediate purpose of this pull request is to modify the Myst III engine so that it no longer matters if the String class allows appending terminators or not. Though as I'm pretty unfamiliar with the game so I don't know if it's correct or sufficient. It should not be merged. I'm just making it so that the issue isn't forgotten.