### PR TITLE
GUI: Fix crash in launcher dialog when search filter no longer matches anything

### DIFF
--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -123,7 +123,7 @@ void ListWidget::setSelected(int item) {
 	// HACK/FIXME: If our _listIndex has a non zero size,
 	// we will need to look up, whether the user selected
 	// item is present in that list
-	if (_listIndex.size()) {
+	if (!_filter.empty()) {
 		int filteredItem = -1;
 
 		for (uint i = 0; i < _listIndex.size(); ++i) {


### PR DESCRIPTION
Lately I've been modifying the descriptions of the games I've added to ScummVM to give each engine and/or company its own unique prefix, e.g. "[LucasArts] Loom (Floppy)".

Today I decided to change "[Comprehend]" to "[Polarware]" so I entered "Comprehend" in the search box and started editing. For each edit, the game would - of course - be removed from the filtered list. When I got to the last one, and the filtered list became empty, ScummVM crashed with the following assertion:

```
scummvm: gui/widgets/list.cpp:139: void GUI::ListWidget::setSelected(int): Assertion `item >= -1 && item < (int)_list.size()' failed.
Aborted
```

I _think_ the problem is that setSelected() uses _listIndex.size() to determine if the list is filtered. That works as long as there is something in the _listIndex: It translates the original index to the filtered one, and if it can't find anything it's translated to -1. But when the _listIndex is empty, that translation is bypassed.

I've changed it to see if _filter is empty instead, since that should hold true whether or not the filter actually matches anything. Does that seem sensible? Are there other cases where a similar fix should be applied?