### PR TITLE
KYRA: adlib driver fixes

### DIFF
--- a/engines/kyra/sound/drivers/adlib.cpp
+++ b/engines/kyra/sound/drivers/adlib.cpp
@@ -520,6 +520,10 @@ void AdLibDriver::stopAllChannels() {
 			noteOff(chan);
 	}
 	_retrySounds = false;
+
+	_programQueueStart = _programQueueEnd = 0;
+	_programQueue[0] = QueueEntry();
+	_programStartTimeout = 0;
 }
 
 // timer callback

--- a/engines/kyra/sound/drivers/adlib.cpp
+++ b/engines/kyra/sound/drivers/adlib.cpp
@@ -1070,7 +1070,7 @@ void AdLibDriver::noteOn(Channel &channel) {
 	channel.regBx |= 0x20;
 	writeOPL(0xB0 + _curChannel, channel.regBx);
 
-	int8 shift = 9 - channel.unk33;
+	int8 shift = 9 - CLIP<int8>(channel.unk33, 0, 9);
 	uint16 temp = channel.regAx | (channel.regBx << 8);
 	channel.unk37 = ((temp & 0x3FF) >> shift) & 0xFF;
 	channel.unk38 = channel.unk36;

--- a/engines/kyra/sound/drivers/adlib.cpp
+++ b/engines/kyra/sound/drivers/adlib.cpp
@@ -547,11 +547,11 @@ void AdLibDriver::callback() {
 }
 
 void AdLibDriver::setupPrograms() {
-	// If there is no program queued, we skip this.
-	if (_programQueueStart == _programQueueEnd)
-		return;
-
 	uint8 *ptr = _programQueue[_programQueueStart].data;
+
+	// If there is no program queued, we skip this.
+	if (_programQueueStart == _programQueueEnd && !ptr)
+		return;
 
 	// The AdLib driver (in its old versions used for EOB) is not suitable for modern (fast) CPUs.
 	// The stop sound track (track 0 which has a priority of 50) will often still be busy when the

--- a/engines/kyra/sound/drivers/adlib.cpp
+++ b/engines/kyra/sound/drivers/adlib.cpp
@@ -488,10 +488,10 @@ void AdLibDriver::startSound(int track, int volume) {
 	if (!trackData)
 		return;
 
-	// Don't drop tracks in EoB. The queue is always full there if a couple of monsters are around.
-	// If we drop the incoming tracks we get no sound effects, but tons of warnings instead.
-	if (_version >= 3 && _programQueueEnd == _programQueueStart && _programQueue[_programQueueEnd].data != 0) {
-		warning("AdLibDriver: Program queue full, dropping track %d", track);
+	if (_programQueueEnd == _programQueueStart && _programQueue[_programQueueEnd].data != 0) {
+		// Don't warn when dropping tracks in EoB. The queue is always full there if a couple of monsters are around.
+		if (_version >= 3)
+			warning("AdLibDriver: Program queue full, dropping track %d", track);
 		return;
 	}
 

--- a/engines/kyra/sound/drivers/pc_base.h
+++ b/engines/kyra/sound/drivers/pc_base.h
@@ -54,6 +54,10 @@ public:
 
 protected:
 	uint8 *getProgram(int progId) {
+		// Safety check: invalid progId would crash.
+		if (progId < 0 || progId >= _soundDataSize / 2)
+			return nullptr;
+
 		const uint16 offset = READ_LE_UINT16(_soundData + 2 * progId);
 
 		// In case an invalid offset is specified we return nullptr to


### PR DESCRIPTION
I'm fixing some issues with the Westwood ADL driver in AdPlug, which
is based on ScummVM's Kyra AdLib driver. I think these fixes should
go upstream, so I'm submitting them here first.

Most of the work will be about adding safety checks such that even
manipulated sound files can't crash the driver. I'm fixing other issues
along the way when I encounter them, as in the first few commits.
Later, I may also try to name some of the remaining unknowns and
simplify some code.

Don't hesitate to comment if you have suggestions.