### PR TITLE
BUILD: Fix parallel "clean all" builds

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -133,7 +133,8 @@ endif
 distclean: clean clean-devtools
 	$(RM) config.h config.mk config.log engines/engines.mk engines/plugins_table.h
 
-clean:
+clean: clean-toplevel
+clean-toplevel:
 	$(RM_REC) $(DEPDIRS)
 	$(RM) $(OBJS) $(DETECT_OBJS) $(EXECUTABLE)
 ifdef SPLIT_DWARF
@@ -460,4 +461,4 @@ DIST_FILES_SHADERS+=$(wildcard $(srcdir)/engines/wintermute/base/gfx/opengl/shad
 endif
 endif
 
-.PHONY: all clean distclean plugins dist-src
+.PHONY: all clean distclean plugins dist-src clean-toplevel


### PR DESCRIPTION
I'm trying to have successful builds with the "make -j 6 clean all" command and before this change, the failure rate was 100%.

This change fixes the problem that the clean target was run partially at the start of the build and the rest just before the linking of the final executable, which was the reason of the 100% failure rate. The change prevents the redefinition of the "clean" target by hooking on the existing one instead.

Unfortunately, it's not good enough to entirely fix the problem, the failure rate is now about 50%. While the "clean" target runs entirely at the start, it seems that "all" can still start before "clean" is fully completed. I attempted to serialize the "clean" and "all" targets using the ".ORDER" directive and also order only prerequisites with no success.

I'm looking for help to resolve this part.