### PR TITLE
COMMON: Remove implicit str<->ustr conversions.

### DIFF
--- a/audio/mididrv.cpp
+++ b/audio/mididrv.cpp
@@ -218,7 +218,7 @@ MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 		failedDevStr = selDevStr;
 		Common::U32String warningMsg = Common::U32String::format(
 			_("The selected audio device '%s' was not found (e.g. might be turned off or disconnected)."), failedDevStr.c_str())
-			+ Common::U32String(" ") + _("Attempting to fall back to the next available device...");
+			+ USTR(" ") + _("Attempting to fall back to the next available device...");
 		GUI::MessageDialog dialog(warningMsg);
 		dialog.runModal();
 	}
@@ -232,7 +232,7 @@ MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 			failedDevStr = getDeviceString(hdl, MidiDriver::kDeviceName);
 			Common::U32String warningMsg = Common::U32String::format(
 				_("The selected audio device '%s' cannot be used. See log file for more information."), failedDevStr.c_str())
-				+ Common::U32String(" ") + _("Attempting to fall back to the next available device...");
+				+ USTR(" ") + _("Attempting to fall back to the next available device...");
 			GUI::MessageDialog dialog(warningMsg);
 			dialog.runModal();
 		}
@@ -270,7 +270,7 @@ MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 					if (failedDevStr != devStr) {
 						Common::U32String warningMsg = Common::U32String::format(
 							_("The preferred audio device '%s' was not found (e.g. might be turned off or disconnected)."), devStr.c_str())
-							+ Common::U32String(" ") + _("Attempting to fall back to the next available device...");
+							+ USTR(" ") + _("Attempting to fall back to the next available device...");
 						GUI::MessageDialog dialog(warningMsg);
 						dialog.runModal();
 					}
@@ -287,7 +287,7 @@ MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 						if (failedDevStr != getDeviceString(hdl, MidiDriver::kDeviceName)) {
 							Common::U32String warningMsg = Common::U32String::format(
 								_("The preferred audio device '%s' cannot be used. See log file for more information."), getDeviceString(hdl, MidiDriver::kDeviceName).c_str())
-								+ Common::U32String(" ") + _("Attempting to fall back to the next available device...");
+								+ USTR(" ") + _("Attempting to fall back to the next available device...");
 							GUI::MessageDialog dialog(warningMsg);
 							dialog.runModal();
 						}

--- a/audio/softsynth/fluidsynth.cpp
+++ b/audio/softsynth/fluidsynth.cpp
@@ -276,7 +276,7 @@ int MidiDriver_FluidSynth::open() {
 #endif
 
 	if (_soundFont == -1) {
-		GUI::MessageDialog dialog(_("FluidSynth: Failed loading custom SoundFont '%s'. Music is off."), soundfont);
+		GUI::MessageDialog dialog(_("FluidSynth: Failed loading custom SoundFont '%s'. Music is off."), Common::U32String(soundfont, Common::kLatin1));
 		dialog.runModal();
 		return MERR_DEVICE_NOT_AVAILABLE;
 	}

--- a/audio/softsynth/mt32.cpp
+++ b/audio/softsynth/mt32.cpp
@@ -67,17 +67,17 @@ public:
 
 	// Callbacks for reporting various errors and information
 	void onErrorControlROM() {
-		GUI::MessageDialog dialog("MT32Emu: Init Error - Missing or invalid Control ROM image", "OK");
+		GUI::MessageDialog dialog(USTR("MT32Emu: Init Error - Missing or invalid Control ROM image"), USTR("OK"));
 		dialog.runModal();
 		error("MT32emu: Init Error - Missing or invalid Control ROM image");
 	}
 	void onErrorPCMROM() {
-		GUI::MessageDialog dialog("MT32Emu: Init Error - Missing PCM ROM image", "OK");
+		GUI::MessageDialog dialog(USTR("MT32Emu: Init Error - Missing PCM ROM image"), USTR("OK"));
 		dialog.runModal();
 		error("MT32emu: Init Error - Missing PCM ROM image");
 	}
 	void showLCDMessage(const char *message) {
-		Common::OSDMessageQueue::instance().addMessage(Common::U32String(message));
+		Common::OSDMessageQueue::instance().addMessage(Common::U32String(message, Common::kLatin1));
 	}
 
 	// Unused callbacks

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -38,7 +38,7 @@
 #define GAMECONTROLLERDB_FILE "gamecontrollerdb.txt"
 
 static uint32 convUTF8ToUTF32(const char *src) {
-	Common::U32String u32(src);
+	Common::U32String u32(src, Common::kUtf8);
 	return u32[0];
 }
 

--- a/backends/keymapper/keymap.cpp
+++ b/backends/keymapper/keymap.cpp
@@ -47,7 +47,7 @@ Keymap::Keymap(KeymapType type, const String &id, const U32String &description) 
 Keymap::Keymap(KeymapType type, const String &id, const String &description) :
 		_type(type),
 		_id(id),
-		_description(U32String(description)),
+		_description(description.decode(Common::kLatin1)),
 		_enabled(true),
 		_configDomain(nullptr),
 		_hardwareInputSet(nullptr),

--- a/backends/keymapper/remap-widget.cpp
+++ b/backends/keymapper/remap-widget.cpp
@@ -224,8 +224,8 @@ void RemapWidget::startRemapping(uint actionIndex) {
 	_remapTimeout = g_system->getMillis() + remapTimeoutDelay;
 	_remapInputWatcher->startWatching();
 
-	_actions[actionIndex].keyButton->setLabel("...");
-	_actions[actionIndex].keyButton->setTooltip("");
+	_actions[actionIndex].keyButton->setLabel(USTR("..."));
+	_actions[actionIndex].keyButton->setTooltip(USTR(""));
 	_actions[actionIndex].keyButton->markAsDirty();
 
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
@@ -296,7 +296,7 @@ void RemapWidget::refreshKeymap() {
 		U32String keysLabel;
 		for (uint j = 0; j < mappedInputs.size(); j++) {
 			if (!keysLabel.empty()) {
-				keysLabel += Common::U32String(", ");
+				keysLabel += USTR(", ");
 			}
 
 			keysLabel += mappedInputs[j].description;
@@ -306,8 +306,8 @@ void RemapWidget::refreshKeymap() {
 			row.keyButton->setLabel(keysLabel);
 			row.keyButton->setTooltip(keysLabel);
 		} else {
-			row.keyButton->setLabel("-");
-			row.keyButton->setTooltip("");
+			row.keyButton->setLabel(USTR("-"));
+			row.keyButton->setTooltip(USTR(""));
 		}
 
 		KeymapTitleRow &keymapTitle = _keymapSeparators[row.keymap];

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -600,8 +600,7 @@ Common::U32String OSystem_SDL::getTextFromClipboard() {
 
 	char *text = SDL_GetClipboardText();
 
-	Common::String utf8Text(text);
-	Common::U32String strText = utf8Text.decode();
+	Common::U32String strText(text, Common::kUtf8);
 	SDL_free(text);
 
 	return strText;

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -210,7 +210,7 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 		// display an error dialog, so we don't have to do this here.
 		warning("%s failed to instantiate engine: %s (target '%s', path '%s')",
 			plugin->getName(),
-			err.getDesc().encode(Common::kUtf8).c_str(),
+			err.getDesc().c_str(),
 			target.c_str(),
 			dir.getPath().c_str()
 			);
@@ -463,7 +463,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	// TODO: deal with settings that require plugins to be loaded
 	if (Base::processSettings(command, settings, res)) {
 		if (res.getCode() != Common::kNoError)
-			warning("%s", res.getDesc().encode(Common::kUtf8).c_str());
+			warning("%s", res.getDesc().c_str());
 		return res.getCode();
 	}
 

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -210,7 +210,7 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 		// display an error dialog, so we don't have to do this here.
 		warning("%s failed to instantiate engine: %s (target '%s', path '%s')",
 			plugin->getName(),
-			err.getDesc().c_str(),
+			err.getDesc().encode(Common::kUtf8).c_str(),
 			target.c_str(),
 			dir.getPath().c_str()
 			);
@@ -237,7 +237,7 @@ static Common::Error runGame(const Plugin *plugin, OSystem &system, const Common
 	if (caption.empty())
 		caption = target;
 	if (!caption.empty())	{
-		system.setWindowCaption(caption.decode());
+		system.setWindowCaption(caption.decode(Common::kUtf8));
 	}
 
 	//
@@ -364,7 +364,7 @@ static void setupGraphics(OSystem &system) {
 	GUI::GuiManager::instance();
 
 	// Set initial window caption
-	system.setWindowCaption(Common::U32String(gScummVMFullVersion));
+	system.setWindowCaption(Common::U32String(gScummVMFullVersion, Common::kUtf8));
 
 	// Clear the main screen
 	system.fillScreen(0);
@@ -463,7 +463,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	// TODO: deal with settings that require plugins to be loaded
 	if (Base::processSettings(command, settings, res)) {
 		if (res.getCode() != Common::kNoError)
-			warning("%s", res.getDesc().c_str());
+			warning("%s", res.getDesc().encode(Common::kUtf8).c_str());
 		return res.getCode();
 	}
 

--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -89,9 +89,10 @@ bool AchievementsManager::setAchievement(const String &id, const String &display
 
 	if (!displayedMessage.empty() && g_system) {
 		U32String msg;
-		msg = Common::U32String::format("%S\n%S",
-			_("Achievement unlocked!").c_str(),
-			Common::U32String(displayedMessage).c_str()
+		msg = Common::U32String::format(
+		    "%S\n%S",
+		    _("Achievement unlocked!").c_str(),
+		    displayedMessage.decode(Common::kLatin1).c_str()
 		);
 		g_system->displayMessageOnOSD(msg);
 	}

--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -74,7 +74,7 @@ bool AchievementsManager::unsetActiveDomain() {
 }
 
 
-bool AchievementsManager::setAchievement(const String &id, const String &displayedMessage) {
+bool AchievementsManager::setAchievement(const String &id, const U32String &displayedMessage) {
 	if (!isReady()) {
 		return false;
 	}
@@ -92,7 +92,7 @@ bool AchievementsManager::setAchievement(const String &id, const String &display
 		msg = Common::U32String::format(
 		    "%S\n%S",
 		    _("Achievement unlocked!").c_str(),
-		    displayedMessage.decode(Common::kLatin1).c_str()
+		    displayedMessage.c_str()
 		);
 		g_system->displayMessageOnOSD(msg);
 	}

--- a/common/achievements.h
+++ b/common/achievements.h
@@ -104,7 +104,7 @@ public:
      * @param[in] displayedMessage Message displayed when the achievement is achieved.
      */
 
-	bool setAchievement(const String &id, const String &displayedMessage);
+	bool setAchievement(const String &id, const U32String &displayedMessage);
 	
     /**
      * Set an achievement as achieved.

--- a/common/error.cpp
+++ b/common/error.cpp
@@ -79,11 +79,15 @@ static String errorToString(ErrorCode errorCode) {
 }
 
 Error::Error(ErrorCode code)
-	: _code(code), _desc(errorToString(code)) {
+	: _code(code), _desc(_(errorToString(code))) {
 }
 
 Error::Error(ErrorCode code, const String &desc)
-	: _code(code), _desc(errorToString(code) + " (" + desc + ")") {
+	: _code(code), _desc(_(errorToString(code)) + USTR(" (") + desc.decode(Common::kLatin1) + USTR(")")) {
+}
+
+Error::Error(ErrorCode code, const U32String &desc)
+	: _code(code), _desc(_(errorToString(code)) + USTR(" (") + desc + USTR(")")) {
 }
 
 

--- a/common/error.cpp
+++ b/common/error.cpp
@@ -79,15 +79,11 @@ static String errorToString(ErrorCode errorCode) {
 }
 
 Error::Error(ErrorCode code)
-	: _code(code), _desc(_(errorToString(code))) {
+	: _code(code), _desc(errorToString(code)) {
 }
 
 Error::Error(ErrorCode code, const String &desc)
-	: _code(code), _desc(_(errorToString(code)) + USTR(" (") + desc.decode(Common::kLatin1) + USTR(")")) {
-}
-
-Error::Error(ErrorCode code, const U32String &desc)
-	: _code(code), _desc(_(errorToString(code)) + USTR(" (") + desc + USTR(")")) {
+	: _code(code), _desc(errorToString(code) + " (" + desc + ")") {
 }
 
 

--- a/common/error.h
+++ b/common/error.h
@@ -85,7 +85,7 @@ enum ErrorCode {
 class Error {
 protected:
 	ErrorCode _code; /*!< Error code. */
-	U32String _desc;    /*!< Error description. */
+	String _desc;    /*!< Error description. */
 public:
 	/**
 	 * Construct a new Error with the specified error code and the default
@@ -96,21 +96,14 @@ public:
 	/**
 	 * Construct a new Error with the specified error code and an augmented
 	 * error message. Specifically, the provided extra text is suitably
-	 * appended to the default message, used for English messages.
+	 * appended to the default message.
 	 */
 	Error(ErrorCode code, const String &extra);
 
 	/**
-	 * Construct a new Error with the specified error code and an augmented
-	 * error message. Specifically, the provided extra text is suitably
-	 * appended to the default message, used for localized messages.
-	 */
-	Error(ErrorCode code, const U32String &extra);
-
-	/**
 	 * Get the description of this error.
 	 */
-	const U32String &getDesc() const { return _desc; }
+	const String &getDesc() const { return _desc; }
 
 	/**
 	 * Get the error code of this error.

--- a/common/error.h
+++ b/common/error.h
@@ -85,7 +85,7 @@ enum ErrorCode {
 class Error {
 protected:
 	ErrorCode _code; /*!< Error code. */
-	String _desc;    /*!< Error description. */
+	U32String _desc;    /*!< Error description. */
 public:
 	/**
 	 * Construct a new Error with the specified error code and the default
@@ -96,14 +96,21 @@ public:
 	/**
 	 * Construct a new Error with the specified error code and an augmented
 	 * error message. Specifically, the provided extra text is suitably
-	 * appended to the default message.
+	 * appended to the default message, used for English messages.
 	 */
 	Error(ErrorCode code, const String &extra);
 
 	/**
+	 * Construct a new Error with the specified error code and an augmented
+	 * error message. Specifically, the provided extra text is suitably
+	 * appended to the default message, used for localized messages.
+	 */
+	Error(ErrorCode code, const U32String &extra);
+
+	/**
 	 * Get the description of this error.
 	 */
-	const String &getDesc() const { return _desc; }
+	const U32String &getDesc() const { return _desc; }
 
 	/**
 	 * Get the error code of this error.

--- a/common/str-enc.cpp
+++ b/common/str-enc.cpp
@@ -833,6 +833,14 @@ void String::encodeOneByte(const U32String &src, CodePage page, bool translitera
 	}
 }
 
+void String::encodeLegacy(const U32String &src) {
+	ensureCapacity(src.size(), false);
+
+	for (uint i = 0; i < src.size(); ++i) {
+		operator+=((char)src[i]);
+	}
+}
+
 void String::encodeInternal(const U32String &src, CodePage page) {
 	switch(page) {
 	case kUtf8:
@@ -913,6 +921,12 @@ String U32String::encode(CodePage page) const {
 
 	String string;
 	string.encodeInternal(*this, page);
+	return string;
+}
+
+String U32String::legacyEncode() const {
+	String string;
+	string.encodeLegacy(*this);
 	return string;
 }
 

--- a/common/str.h
+++ b/common/str.h
@@ -85,7 +85,7 @@ public:
 	explicit String(char c);
 
 	/** Construct a new string from the given u32 string. */
-	String(const U32String &str, CodePage page = kUtf8);
+	String(const U32String &str, CodePage page);
 
 	String &operator=(const char *str);
 	String &operator=(const String &str);
@@ -243,7 +243,7 @@ public:
 	String substr(size_t pos = 0, size_t len = npos) const;
 
 	/** Python-like method **/
-	U32String decode(CodePage page = kUtf8) const;
+	U32String decode(CodePage page) const;
 
 protected:
 	void encodeUTF8(const U32String &src);
@@ -251,6 +251,7 @@ protected:
     	void encodeWindows949(const U32String &src);
 	void encodeWindows950(const U32String &src, bool translit = true);
 	void encodeOneByte(const U32String &src, CodePage page, bool translit = true);
+    	void encodeLegacy(const U32String &src);
 	void encodeInternal(const U32String &src, CodePage page);
 	void translitChar(U32String::value_type point);
 

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -115,7 +115,7 @@ U32String TranslationManager::getTranslation(const char *message) const {
 U32String TranslationManager::getTranslation(const char *message, const char *context) const {
 	// If no language is set or message is empty, return msgid as is
 	if (_currentTranslationMessages.empty() || *message == '\0')
-		return U32String(message);
+		return U32String(message, Common::kLatin1);
 
 	// Binary-search for the msgid
 	int leftIndex = 0;
@@ -161,7 +161,7 @@ U32String TranslationManager::getTranslation(const char *message, const char *co
 			leftIndex = midIndex + 1;
 	}
 
-	return U32String(message);
+	return U32String(message, Common::kLatin1);
 }
 
 String TranslationManager::getCurrentCharset() const {
@@ -306,7 +306,7 @@ void TranslationManager::loadTranslationsInfoDat() {
 		_langs[i] = String(buf, len - 1);
 		len = in.readUint16BE();
 		in.read(buf, len);
-		_langNames[i] = String(buf, len - 1).decode();
+		_langNames[i] = String(buf, len - 1).decode(Common::kUtf8);
 	}
 
 	// Read messages
@@ -378,7 +378,7 @@ void TranslationManager::loadLanguageDat(int index) {
 			msg += String(buf, len > 256 ? 256 : len - 1);
 			len -= 256;
 		}
-		_currentTranslationMessages[i].msgstr = msg.decode();
+		_currentTranslationMessages[i].msgstr = msg.decode(Common::kUtf8);
 		len = in.readUint16BE();
 		if (len > 0) {
 			in.read(buf, len);

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -115,7 +115,7 @@ U32String TranslationManager::getTranslation(const char *message) const {
 U32String TranslationManager::getTranslation(const char *message, const char *context) const {
 	// If no language is set or message is empty, return msgid as is
 	if (_currentTranslationMessages.empty() || *message == '\0')
-		return U32String(message, Common::kLatin1);
+		return U32String(message, Common::kUtf8);
 
 	// Binary-search for the msgid
 	int leftIndex = 0;
@@ -161,7 +161,7 @@ U32String TranslationManager::getTranslation(const char *message, const char *co
 			leftIndex = midIndex + 1;
 	}
 
-	return U32String(message, Common::kLatin1);
+	return U32String(message, Common::kUtf8);
 }
 
 String TranslationManager::getCurrentCharset() const {

--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -34,7 +34,7 @@ UnicodeBiDiText::UnicodeBiDiText(const Common::U32String &str) : logical(str), _
 	initWithU32String(str);
 }
 
-UnicodeBiDiText::UnicodeBiDiText(const Common::String &str, const Common::CodePage page) : logical(str), _log_to_vis_index(NULL), _vis_to_log_index(NULL) {
+UnicodeBiDiText::UnicodeBiDiText(const Common::String &str, const Common::CodePage page) : logical(str.decode(page)), _log_to_vis_index(NULL), _vis_to_log_index(NULL) {
 	initWithU32String(str.decode(page));
 }
 

--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -54,20 +54,8 @@ U32String &U32String::operator=(const U32String &str) {
 	return *this;
 }
 
-U32String &U32String::operator=(const String &str) {
-	clear();
-	decodeInternal(str.c_str(), str.size(), Common::kUtf8);
-	return *this;
-}
-
 U32String &U32String::operator=(const value_type *str) {
 	return U32String::operator=(U32String(str));
-}
-
-U32String &U32String::operator=(const char *str) {
-	clear();
-	decodeInternal(str, strlen(str), Common::kUtf8);
-	return *this;
 }
 
 U32String &U32String::operator+=(const U32String &str) {
@@ -153,7 +141,7 @@ U32String U32String::format(U32String fmt, ...) {
 U32String U32String::format(const char *fmt, ...) {
 	U32String output;
 
-	Common::U32String fmtU32(fmt);
+	Common::U32String fmtU32(fmt, Common::kUtf8);
 	va_list va;
 	va_start(va, fmt);
 	U32String::vformat(fmtU32.c_str(), fmtU32.c_str() + fmtU32.size(),
@@ -193,7 +181,7 @@ int U32String::vformat(const value_type *fmt, const value_type *fmtEnd, U32Strin
 			case 's':
 				string_temp = va_arg(args, char *);
 				tempPos = output.size();
-				output.insertString(string_temp, pos);
+				output.insertString(string_temp, pos, Common::kUtf8);
 				len = output.size() - tempPos;
 				length += len;
 				pos += len - 1;
@@ -206,7 +194,7 @@ int U32String::vformat(const value_type *fmt, const value_type *fmtEnd, U32Strin
 				len = strlen(buffer);
 				length += len;
 
-				output.insertString(buffer, pos);
+				output.insertString(buffer, pos, Common::kUtf8);
 				pos += len - 1;
 				break;
 			case 'u':
@@ -215,7 +203,7 @@ int U32String::vformat(const value_type *fmt, const value_type *fmtEnd, U32Strin
 				len = strlen(buffer);
 				length += len;
 
-				output.insertString(buffer, pos);
+				output.insertString(buffer, pos, Common::kUtf8);
 				pos += len - 1;
 				break;
 			case 'c':
@@ -224,6 +212,10 @@ int U32String::vformat(const value_type *fmt, const value_type *fmtEnd, U32Strin
 				output.insertChar(int_temp, pos);
 				++length;
 				break;
+			case '%':
+				output.insertChar('%', pos);
+				++length;
+				break;				
 			default:
 				warning("Unexpected formatting type for U32String::Format.");
 				break;

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -194,6 +194,7 @@ private:
 	friend class String;
 };
 
+/** Declare a unicode string. Should be limited to ASCII subset */
 #ifdef USE_CXX11
 #define USTR(x) Common::U32String(U ## x)
 #else

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -84,28 +84,22 @@ public:
 	U32String(const U32String &str) : BaseString<u32char_type_t>(str) {}
 
 	/** Construct a new string from the given null-terminated C string that uses the given @p page encoding. */
-	explicit U32String(const char *str, CodePage page = kUtf8);
+	explicit U32String(const char *str, CodePage page);
 
 	/** Construct a new string containing exactly @p len characters read from address @p str. */
-	U32String(const char *str, uint32 len, CodePage page = kUtf8);
+	U32String(const char *str, uint32 len, CodePage page);
 
 	/** Construct a new string containing the characters between @p beginP (including) and @p endP (excluding). */
-	U32String(const char *beginP, const char *endP, CodePage page = kUtf8);
+	U32String(const char *beginP, const char *endP, CodePage page);
 
 	/** Construct a copy of the given string. */
-	U32String(const String &str, CodePage page = kUtf8);
+	U32String(const String &str, CodePage page);
 
 	/** Assign a given string to this string. */
 	U32String &operator=(const U32String &str);
 
 	/** @overload */
-	U32String &operator=(const String &str);
-
-	/** @overload */
 	U32String &operator=(const value_type *str);
-
-	/** @overload */
-	U32String &operator=(const char *str);
 
 	/** Append the given string to this string. */
 	U32String &operator+=(const U32String &str);
@@ -131,6 +125,12 @@ public:
 	/** Convert the string to the given @p page encoding and return the result as a new String. */
 	String encode(CodePage page = kUtf8) const;
 
+	/** Convert to String while dropping high bits. Shouldn't be used for new code, only for migration.
+	    As this is not a meaningful operation most likely every single call to it is either a bug
+	    that was never noticed or should be replaced with encode to latin1 or ascii
+	 */
+	String legacyEncode() const;
+
 	/**
 	 * Print formatted data into a U32String object.
 	 *
@@ -155,8 +155,8 @@ public:
 	static char* itoa(int num, char* str, int base);
 
 	using BaseString<value_type>::insertString;
-	void insertString(const char *s, uint32 p, CodePage page = kUtf8);   /*!< Insert string @p s into this string at position @p p. */
-	void insertString(const String &s, uint32 p, CodePage page = kUtf8); /*!< @overload */
+	void insertString(const char *s, uint32 p, CodePage page);   /*!< Insert string @p s into this string at position @p p. */
+	void insertString(const String &s, uint32 p, CodePage page); /*!< @overload */
 
 	/** Return a substring of this string */
 	U32String substr(size_t pos = 0, size_t len = npos) const;
@@ -193,6 +193,13 @@ private:
 		
 	friend class String;
 };
+
+#ifdef USE_CXX11
+#define USTR(x) Common::U32String(U ## x)
+#else
+#define USTR(x) Common::U32String(x, Common::kUtf8)
+#endif
+    
 
 /** Concatenate strings @p x and @p y. */
 U32String operator+(const U32String &x, const U32String &y);

--- a/common/winexe.cpp
+++ b/common/winexe.cpp
@@ -227,8 +227,8 @@ WinResources::VersionHash *WinResources::parseVersionInfo(SeekableReadStream *re
 				uint16 prodD = res->readUint16LE();
 				uint16 prodC = res->readUint16LE();
 
-				versionMap->setVal("File:", Common::String::format("%d.%d.%d.%d", fileA, fileB, fileC, fileD));
-				versionMap->setVal("Prod:", Common::String::format("%d.%d.%d.%d", prodA, prodB, prodC, prodD));
+				versionMap->setVal("File:", Common::U32String::format("%d.%d.%d.%d", fileA, fileB, fileC, fileD));
+				versionMap->setVal("Prod:", Common::U32String::format("%d.%d.%d.%d", prodA, prodB, prodC, prodD));
 
 				while (res->pos() != pos2 && !res->eos())
 					res->readByte();

--- a/engines/access/metaengine.cpp
+++ b/engines/access/metaengine.cpp
@@ -135,7 +135,7 @@ SaveStateList AccessMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Access::AccessEngine::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 
 				delete in;
 			}
@@ -170,7 +170,7 @@ SaveStateDescriptor AccessMetaEngine::querySaveMetaInfos(const char *target, int
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/adl/metaengine.cpp
+++ b/engines/adl/metaengine.cpp
@@ -125,7 +125,7 @@ SaveStateDescriptor AdlMetaEngine::querySaveMetaInfos(const char *target, int sl
 		return SaveStateDescriptor();
 	}
 
-	SaveStateDescriptor sd(slot, name);
+	SaveStateDescriptor sd(slot, Common::U32String(name, Common::kLatin1));
 
 	int year = inFile->readUint16BE();
 	int month = inFile->readByte();
@@ -187,7 +187,7 @@ SaveStateList AdlMetaEngine::listSaves(const char *target) const {
 		delete inFile;
 
 		int slotNum = atoi(fileName.c_str() + fileName.size() - 2);
-		SaveStateDescriptor sd(slotNum, name);
+		SaveStateDescriptor sd(slotNum, Common::U32String(name, Common::kLatin1));
 		saveList.push_back(sd);
 	}
 

--- a/engines/agi/metaengine.cpp
+++ b/engines/agi/metaengine.cpp
@@ -205,7 +205,7 @@ SaveStateList AgiMetaEngine::listSaves(const char *target) const {
 
 				delete in;
 
-				saveList.push_back(SaveStateDescriptor(slotNr, description));
+				saveList.push_back(SaveStateDescriptor(slotNr, Common::U32String(description, Common::kLatin1)));
 			}
 		}
 	}
@@ -248,11 +248,11 @@ SaveStateDescriptor AgiMetaEngine::querySaveMetaInfos(const char *target, int sl
 			// broken description, ignore it
 			delete in;
 
-			SaveStateDescriptor descriptor(slotNr, "[broken saved game]");
+			SaveStateDescriptor descriptor(slotNr, USTR("[broken saved game]"));
 			return descriptor;
 		}
 
-		SaveStateDescriptor descriptor(slotNr, description);
+		SaveStateDescriptor descriptor(slotNr, Common::U32String(description, Common::kLatin1));
 
 		// Do not allow save slot 0 (used for auto-saving) to be deleted or
 		// overwritten.

--- a/engines/agi/saveload.cpp
+++ b/engines/agi/saveload.cpp
@@ -759,15 +759,15 @@ int AgiEngine::scummVMSaveLoadDialog(bool isSave) {
 		dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 
 		slot = dialog->runModalWithCurrentTarget();
-		desc = dialog->getResultString();
+		desc = dialog->getResultString().legacyEncode();
 
 		if (desc.empty()) {
 			// create our own description for the saved game, the user didnt enter it
-			desc = dialog->createDefaultSaveDescription(slot);
+			desc = dialog->createDefaultSaveDescription(slot).legacyEncode();
 		}
 
 		if (desc.size() > 28)
-			desc = Common::String(desc.c_str(), 28);
+			desc = desc.substr(0, 28);
 	} else {
 		dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
 		slot = dialog->runModalWithCurrentTarget();

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -128,7 +128,7 @@ SaveStateList AgosMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				saveDesc = file->c_str();
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveDesc, Common::kLatin1)));
 				delete in;
 			}
 		}

--- a/engines/agos/string.cpp
+++ b/engines/agos/string.cpp
@@ -712,7 +712,7 @@ void AGOSEngine_PuzzlePack::printInfoText(const char *itemText) {
 	}
 
 	if (itemName != NULL) {
-		Common::String buf = Common::String::format("%s\n%s", itemName, itemText);
+		Common::U32String buf = Common::U32String::format("%s\n%s", itemName, itemText);
 		GUI::TimedMessageDialog dialog(buf, 1500);
 		dialog.runModal();
 	}

--- a/engines/avalanche/metaengine.cpp
+++ b/engines/avalanche/metaengine.cpp
@@ -126,7 +126,7 @@ SaveStateList AvalancheMetaEngine::listSaves(const char *target) const {
 				file->read(name, nameSize);
 				name[nameSize] = 0;
 
-				saveList.push_back(SaveStateDescriptor(slotNum, name));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(name, Common::kLatin1)));
 				delete[] name;
 				delete file;
 			}
@@ -172,7 +172,7 @@ SaveStateDescriptor AvalancheMetaEngine::querySaveMetaInfos(const char *target, 
 			description += actChar;
 		}
 
-		SaveStateDescriptor desc(slot, description);
+		SaveStateDescriptor desc(slot, description.decode(Common::kLatin1));
 
 		Graphics::Surface *thumbnail;
 		if (!Graphics::loadThumbnail(*f, thumbnail)) {

--- a/engines/avalanche/parser.cpp
+++ b/engines/avalanche/parser.cpp
@@ -1918,7 +1918,7 @@ void Parser::doThat() {
 	case kVerbCodeSave: {
 		GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 		int16 savegameId = dialog->runModalWithCurrentTarget();
-		Common::String savegameDescription = dialog->getResultString();
+		Common::String savegameDescription = dialog->getResultString().legacyEncode();
 		delete dialog;
 
 		if (savegameId < 0)

--- a/engines/bbvs/metaengine.cpp
+++ b/engines/bbvs/metaengine.cpp
@@ -87,7 +87,7 @@ SaveStateList BbvsMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Bbvs::BbvsEngine::readSaveHeader(in, header) == Bbvs::BbvsEngine::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.description, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -107,7 +107,7 @@ SaveStateDescriptor BbvsMetaEngine::querySaveMetaInfos(const char *target, int s
 		error = Bbvs::BbvsEngine::readSaveHeader(in, header, false);
 		delete in;
 		if (error == Bbvs::BbvsEngine::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(slot, Common::U32String(header.description, Common::kLatin1));
 			// Slot 0 is used for the "Continue" save
 			desc.setDeletableFlag(slot != 0);
 			desc.setWriteProtectedFlag(slot == 0);

--- a/engines/bbvs/minigames/bbairguitar.cpp
+++ b/engines/bbvs/minigames/bbairguitar.cpp
@@ -1243,9 +1243,9 @@ bool MinigameBbAirGuitar::querySaveModifiedDialog() {
 		Original ok button caption: "Yeah, heh, heh, save it!"
 		Original discard button caption: "Who cares?  It sucked!"
 	*/
-	GUI::MessageDialog query("Hey Beavis - you didn't save that last Jam!",
-		"Save it!",
-		"It sucked!");
+	GUI::MessageDialog query(USTR("Hey Beavis - you didn't save that last Jam!"),
+				 USTR("Save it!"),
+				 USTR("It sucked!"));
 	return query.runModal() == GUI::kMessageOK;
 }
 
@@ -1271,7 +1271,7 @@ bool MinigameBbAirGuitar::loadTracks() {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::InSaveFile *stream = saveFileMan->openForLoading(filename);
 	if (!loadFromStream(stream)) {
-		Common::String msg = Common::String::format("%s is not a valid Air Guitar file", filename.c_str());
+		Common::U32String msg = Common::U32String::format("%s is not a valid Air Guitar file", filename.c_str());
 		GUI::MessageDialog dialog(msg);
 		dialog.runModal();
 	}

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -360,7 +360,7 @@ Common::Error BladeRunnerEngine::run() {
 
 	if (!startup(hasSavegames)) {
 		// shutting down
-		return Common::Error(Common::kUnknownError, _("Failed to initialize resources"));
+		return Common::Error(Common::kUnknownError, _s("Failed to initialize resources"));
 	}
 
 	// improvement: Use a do-while() loop to handle the normal end-game state
@@ -1064,8 +1064,8 @@ void BladeRunnerEngine::gameTick() {
 
 	if (!_kia->isOpen() && !_sceneScript->isInsideScript() && !_aiScripts->isInsideScript()) {
 		if (!_settings->openNewScene()) {
-			Common::Error runtimeError = Common::Error(Common::kUnknownError, _("A required game resource was not found"));
-			GUI::MessageDialog dialog(runtimeError.getDesc());
+			Common::Error runtimeError = Common::Error(Common::kUnknownError, _s("A required game resource was not found"));
+			GUI::MessageDialog dialog(_(runtimeError.getDesc()));
 			dialog.runModal();
 			return;
 		}

--- a/engines/bladerunner/savefile.cpp
+++ b/engines/bladerunner/savefile.cpp
@@ -50,7 +50,7 @@ SaveStateList SaveFileManager::list(const Common::String &target) {
 		readHeader(*saveFile, header);
 
 		int slotNum = atoi(fileName->c_str() + fileName->size() - 3);
-		saveList.push_back(SaveStateDescriptor(slotNum, header._name));
+		saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header._name, Common::kLatin1)));
 
 		delete saveFile;
 	}
@@ -75,7 +75,7 @@ SaveStateDescriptor SaveFileManager::queryMetaInfos(const Common::String &target
 	}
 	delete saveFile;
 
-	SaveStateDescriptor desc(slot, header._name);
+	SaveStateDescriptor desc(slot, Common::U32String(header._name, Common::kLatin1));
 	desc.setThumbnail(header._thumbnail);
 	desc.setSaveDate(header._year, header._month, header._day);
 	desc.setSaveTime(header._hour, header._minute);

--- a/engines/bladerunner/subtitles.cpp
+++ b/engines/bladerunner/subtitles.cpp
@@ -242,7 +242,7 @@ void Subtitles::loadInGameSubsText(int actorId, int speech_id)  {
 
 	// Search in the first TextResource of the _vqaSubsTextResourceEntries table, which is the TextResource for in-game dialogue (i.e. not VQA dialogue)
 	const char *text = _vqaSubsTextResourceEntries[0]->getText((uint32)id);
-	_currentText = _useUTF8 ? Common::convertUtf8ToUtf32(text) : Common::U32String(text);
+	_currentText = Common::U32String(text, _useUTF8 ? Common::kUtf8 : Common::kLatin1);
 }
 
 /**
@@ -262,7 +262,7 @@ void Subtitles::loadOuttakeSubsText(const Common::String &outtakesName, int fram
 	// Search in the requested TextResource at the fileIdx index of the _vqaSubsTextResourceEntries table for a quote that corresponds to the specified video frame
 	// debug("Number of resource quotes to search: %d, requested frame: %u", _vqaSubsTextResourceEntries[fileIdx]->getCount(), (uint32)frame );
 	const char *text = _vqaSubsTextResourceEntries[fileIdx]->getOuttakeTextByFrame((uint32)frame);
-	_currentText = _useUTF8 ? Common::convertUtf8ToUtf32(text) : Common::U32String(text);
+	_currentText = Common::U32String(text, _useUTF8 ? Common::kUtf8 : Common::kLatin1);
 }
 
 /**
@@ -270,7 +270,7 @@ void Subtitles::loadOuttakeSubsText(const Common::String &outtakesName, int fram
  * Used for debug purposes mainly.
  */
 void Subtitles::setGameSubsText(Common::String dbgQuote, bool forceShowWhenNoSpeech) {
-	_currentText = _useUTF8 ? Common::convertUtf8ToUtf32(dbgQuote) : Common::U32String(dbgQuote);
+	_currentText = dbgQuote.decode(_useUTF8 ? Common::kUtf8 : Common::kLatin1);
 	_forceShowWhenNoSpeech = forceShowWhenNoSpeech; // overrides not showing subtitles when no one is speaking
 }
 

--- a/engines/bladerunner/ui/kia_section_load.cpp
+++ b/engines/bladerunner/ui/kia_section_load.cpp
@@ -70,7 +70,7 @@ void KIASectionLoad::open() {
 	if (!_saveList.empty()) {
 		_scrollBox->addLine(_vm->_textOptions->getText(36), -1, 4); // Load game:
 		for (uint i = 0; i < _saveList.size(); ++i) {
-			_scrollBox->addLine(_saveList[i].getDescription(), i, 0);
+			_scrollBox->addLine(_saveList[i].getDescription().legacyEncode(), i, 0);
 		}
 		_scrollBox->addLine("", -1, 4);
 	}

--- a/engines/bladerunner/ui/kia_section_save.cpp
+++ b/engines/bladerunner/ui/kia_section_save.cpp
@@ -112,7 +112,7 @@ void KIASectionSave::open() {
 		}
 
 		for (uint i = 0; i < _saveList.size(); ++i) {
-			_scrollBox->addLine(_saveList[i].getDescription(), i, 0);
+			_scrollBox->addLine(_saveList[i].getDescription().legacyEncode(), i, 0);
 		}
 
 		if (ableToSaveGame) {
@@ -122,7 +122,7 @@ void KIASectionSave::open() {
 		} else {
 			// Overwrite first save
 			_selectedLineId = 0;
-			_inputBox->setText(_saveList[_selectedLineId].getDescription());
+			_inputBox->setText(_saveList[_selectedLineId].getDescription().legacyEncode());
 		}
 
 		_scrollBox->setFlags(_selectedLineId, 8);
@@ -162,7 +162,7 @@ void KIASectionSave::draw(Graphics::Surface &surface) {
 	} else if (_state == kStateOverwrite) {
 		surface.fillRect(Common::Rect(155, 230, 462, 239), surface.format.RGBToColor(80, 56, 32));
 
-		const Common::String &saveName = _saveList[_selectedLineId].getDescription();
+		const Common::U32String &saveName = _saveList[_selectedLineId].getDescription();
 		int saveNameWidth = _vm->_mainFont->getStringWidth(saveName);
 		_vm->_mainFont->drawString(&surface, saveName, 308 - saveNameWidth / 2, 230, surface.w, surface.format.RGBToColor(232, 208, 136));
 
@@ -172,7 +172,7 @@ void KIASectionSave::draw(Graphics::Surface &surface) {
 	} else if (_state == kStateDelete) {
 		surface.fillRect(Common::Rect(155, 230, 462, 239), surface.format.RGBToColor(80, 56, 32));
 
-		const Common::String &saveName = _saveList[_selectedLineId].getDescription();
+		const Common::U32String &saveName = _saveList[_selectedLineId].getDescription();
 		int saveNameWidth = _vm->_mainFont->getStringWidth(saveName); // Delete this game?
 		_vm->_mainFont->drawString(&surface, saveName, 308 - saveNameWidth / 2, 230, surface.w, surface.format.RGBToColor(232, 208, 136));
 
@@ -296,7 +296,7 @@ void KIASectionSave::scrollBoxCallback(void *callbackData, void *source, int lin
 		if (self->_selectedLineId == self->_newSaveLineId) {
 			self->_inputBox->setText("");
 		} else {
-			self->_inputBox->setText(self->_saveList[self->_selectedLineId].getDescription());
+			self->_inputBox->setText(self->_saveList[self->_selectedLineId].getDescription().legacyEncode());
 		}
 
 		self->_vm->_audioPlayer->playAud(self->_vm->_gameInfo->getSfxTrack(kSfxSPNBEEP3), 40, 0, 0, 50, 0);

--- a/engines/cge/cge.cpp
+++ b/engines/cge/cge.cpp
@@ -225,7 +225,8 @@ Common::Error CGEEngine::run() {
 
 	// If game is finished, display ending message
 	if (_flag[3]) {
-		Common::String msg = Common::String(_text->getText(kSayTheEnd));
+		Common::U32String msg(
+		    _text->getText(kSayTheEnd), Common::kLatin1);
 		if (!msg.empty()) {
 			g_system->delayMillis(10);
 			GUI::MessageDialog dialog(msg);

--- a/engines/cge/metaengine.cpp
+++ b/engines/cge/metaengine.cpp
@@ -94,11 +94,11 @@ SaveStateList CGEMetaEngine::listSaves(const char *target) const {
 				if (!strncmp(buffer, CGE::savegameStr, kSavegameStrSize + 1)) {
 					// Valid savegame
 					if (CGE::CGEEngine::readSavegameHeader(file, header)) {
-						saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+						saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.saveName, Common::kLatin1)));
 					}
 				} else {
 					// Must be an original format savegame
-					saveList.push_back(SaveStateDescriptor(slotNum, "Unknown"));
+					saveList.push_back(SaveStateDescriptor(slotNum, USTR("Unknown")));
 				}
 
 				delete file;
@@ -128,11 +128,11 @@ SaveStateDescriptor CGEMetaEngine::querySaveMetaInfos(const char *target, int sl
 
 		if (!hasHeader) {
 			// Original savegame perhaps?
-			SaveStateDescriptor desc(slot, "Unknown");
+			SaveStateDescriptor desc(slot, USTR("Unknown"));
 			return desc;
 		} else {
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(slot, Common::U32String(header.saveName, Common::kLatin1));
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveYear, header.saveMonth, header.saveDay);
 			desc.setSaveTime(header.saveHour, header.saveMinutes);

--- a/engines/cge2/metaengine.cpp
+++ b/engines/cge2/metaengine.cpp
@@ -94,11 +94,11 @@ SaveStateList CGE2MetaEngine::listSaves(const char *target) const {
 				if (!strncmp(buffer, kSavegameStr, kSavegameStrSize + 1)) {
 					// Valid savegame
 					if (CGE2::CGE2Engine::readSavegameHeader(file, header)) {
-						saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+						saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.saveName, Common::kLatin1)));
 					}
 				} else {
 					// Must be an original format savegame
-					saveList.push_back(SaveStateDescriptor(slotNum, "Unknown"));
+					saveList.push_back(SaveStateDescriptor(slotNum, USTR("Unknown")));
 				}
 
 				delete file;
@@ -128,11 +128,11 @@ SaveStateDescriptor CGE2MetaEngine::querySaveMetaInfos(const char *target, int s
 
 		if (!hasHeader) {
 			// Original savegame perhaps?
-			SaveStateDescriptor desc(slot, "Unknown");
+			SaveStateDescriptor desc(slot, USTR("Unknown"));
 			return desc;
 		} else {
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(slot, Common::U32String(header.saveName, Common::kLatin1));
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveYear, header.saveMonth, header.saveDay);
 			desc.setSaveTime(header.saveHour, header.saveMinutes);

--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -127,7 +127,7 @@ SaveStateList CineMetaEngine::listSaves(const char *target) const {
 				strncpy(saveDesc, saveNames[slotNum], SAVEGAME_NAME_LEN);
 				saveDesc[sizeof(CommandeType) - 1] = 0;
 
-				SaveStateDescriptor saveStateDesc(slotNum, saveDesc);
+				SaveStateDescriptor saveStateDesc(slotNum, Common::U32String(saveDesc, Common::kLatin1));
 				saveStateDesc.setAutosave(slotNum == getAutosaveSlot());
 				saveStateDesc.setWriteProtectedFlag(saveStateDesc.isAutosave());
 
@@ -205,7 +205,7 @@ SaveStateDescriptor CineMetaEngine::querySaveMetaInfos(const char *target, int s
 			}
 
 			saveNames[slot][SAVEGAME_NAME_LEN - 1] = 0;
-			Common::String saveNameStr((const char *)saveNames[slot]);
+			Common::U32String saveNameStr((const char *)saveNames[slot], Common::kUtf8);
 			desc.setDescription(saveNameStr);
 		}
 

--- a/engines/cine/various.cpp
+++ b/engines/cine/various.cpp
@@ -343,7 +343,7 @@ void CineEngine::resetEngine() {
 
 int CineEngine::scummVMSaveLoadDialog(bool isSave) {
 	GUI::SaveLoadChooser *dialog;
-	Common::String desc;
+	Common::U32String desc;
 	int slot;
 
 	if (isSave) {
@@ -378,12 +378,12 @@ int CineEngine::scummVMSaveLoadDialog(bool isSave) {
 			return false;
 		}
 
-		Common::strlcpy(currentSaveName[slot], desc.c_str(), sizeof(CommandeType));
+		Common::strlcpy(currentSaveName[slot], desc.legacyEncode().c_str(), sizeof(CommandeType));
 
 		fHandle->write(currentSaveName, sizeof(currentSaveName));
 		delete fHandle;
 
-		makeSave(saveFileName, getTotalPlayTime() / 1000, desc, false);
+		makeSave(saveFileName, getTotalPlayTime() / 1000, desc.legacyEncode(), false);
 
 		return true;
 	} else {

--- a/engines/composer/metaengine.cpp
+++ b/engines/composer/metaengine.cpp
@@ -116,7 +116,7 @@ SaveStateList ComposerMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				saveDesc = getSaveName(in);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc.decode(Common::kLatin1)));
 				delete in;
 			}
 		}

--- a/engines/cruise/metaengine.cpp
+++ b/engines/cruise/metaengine.cpp
@@ -85,7 +85,7 @@ SaveStateList CruiseMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				Cruise::CruiseSavegameHeader header;
 				if (Cruise::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.saveName, Common::kLatin1)));
 				delete in;
 			}
 		}
@@ -114,7 +114,7 @@ SaveStateDescriptor CruiseMetaEngine::querySaveMetaInfos(const char *target, int
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header.saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header.saveName, Common::kLatin1));
 		desc.setThumbnail(header.thumbnail);
 
 		return desc;

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -113,7 +113,7 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveMan->openForLoading(*file);
 			if (in) {
 				if (in->read(saveName, kSaveDescriptionLen) == kSaveDescriptionLen) {
-					saveList.push_back(SaveStateDescriptor(slotNum - 1, saveName));
+					saveList.push_back(SaveStateDescriptor(slotNum - 1, Common::U32String(saveName, Common::kLatin1)));
 				}
 				delete in;
 			}

--- a/engines/cryomni3d/versailles/data.cpp
+++ b/engines/cryomni3d/versailles/data.cpp
@@ -106,8 +106,8 @@ void CryOmni3DEngine_Versailles::loadStaticData() {
 		_bombAlphabet = data->readString16().decode(Common::kWindows932);
 		_bombPassword = data->readString16().decode(Common::kWindows932);
 	} else {
-		_bombAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ '";
-		_bombPassword = data->readString16();
+		_bombAlphabet = USTR("ABCDEFGHIJKLMNOPQRSTUVWXYZ '");
+		_bombPassword = data->readString16().decode(Common::kLatin1);
 	}
 
 	// messages, paintings titles

--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -59,15 +59,15 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 		_logo->useThemeTransparency(true);
 		_logo->setGfx(g_gui.theme()->getImageSurface(GUI::ThemeEngine::kImageLogoSmall));
 	} else {
-		GUI::StaticTextWidget *title = new GUI::StaticTextWidget(this, "GlobalMenu.Title", Common::U32String("ScummVM"));
+		GUI::StaticTextWidget *title = new GUI::StaticTextWidget(this, "GlobalMenu.Title", USTR("ScummVM"));
 		title->setAlign(Graphics::kTextAlignCenter);
 	}
 #else
-	GUI::StaticTextWidget *title = new GUI::StaticTextWidget(this, "GlobalMenu.Title", Common::U32String("ScummVM"));
+	GUI::StaticTextWidget *title = new GUI::StaticTextWidget(this, "GlobalMenu.Title", USTR("ScummVM"));
 	title->setAlign(Graphics::kTextAlignCenter);
 #endif
 
-	GUI::StaticTextWidget *version = new GUI::StaticTextWidget(this, "GlobalMenu.Version", Common::U32String(gScummVMVersionDate));
+	GUI::StaticTextWidget *version = new GUI::StaticTextWidget(this, "GlobalMenu.Version", Common::U32String(gScummVMVersionDate, Common::kLatin1));
 	version->setAlign(Graphics::kTextAlignCenter);
 
 	new GUI::ButtonWidget(this, "GlobalMenu.Resume", _("~R~esume"), Common::U32String(), kPlayCmd, 'P');
@@ -186,7 +186,7 @@ void MainMenuDialog::reflowLayout() {
 	} else {
 		GUI::StaticTextWidget *title = (GUI::StaticTextWidget *)findWidget("GlobalMenu.Title");
 		if (!title) {
-			title = new GUI::StaticTextWidget(this, "GlobalMenu.Title", Common::U32String("ScummVM"));
+			title = new GUI::StaticTextWidget(this, "GlobalMenu.Title", USTR("ScummVM"));
 			title->setAlign(Graphics::kTextAlignCenter);
 		}
 
@@ -206,13 +206,13 @@ void MainMenuDialog::save() {
 	int slot = _saveDialog->runModalWithCurrentTarget();
 
 	if (slot >= 0) {
-		Common::String result(_saveDialog->getResultString());
+		Common::U32String result(_saveDialog->getResultString());
 		if (result.empty()) {
 			// If the user was lazy and entered no save name, come up with a default name.
 			result = _saveDialog->createDefaultSaveDescription(slot);
 		}
 
-		Common::Error status = _engine->saveGameState(slot, result);
+		Common::Error status = _engine->saveGameState(slot, result.legacyEncode());
 		if (status.getCode() != Common::kNoError) {
 			Common::U32String failMessage = Common::U32String::format(_("Failed to save game (%s)! "
 				  "Please consult the README for basic information, and for "

--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -667,7 +667,7 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 	case kCastButton:
 		// note that we use _initialRect for the dimensions of the button;
 		// the values provided in the sprite bounding box are ignored
-		widget = new Graphics::MacButton(Graphics::MacButtonType(_buttonType), getAlignment(), g_director->getCurrentWindow(), bbox.left, bbox.top, _initialRect.width(), _initialRect.height(), g_director->_wm, _ftext, macFont, getForeColor(), 0xff);
+		widget = new Graphics::MacButton(Graphics::MacButtonType(_buttonType), getAlignment(), g_director->getCurrentWindow(), bbox.left, bbox.top, _initialRect.width(), _initialRect.height(), g_director->_wm, _ftext.decode(Common::kLatin1), macFont, getForeColor(), 0xff);
 		((Graphics::MacButton *)widget)->draw();
 		widget->_focusable = true;
 

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1496,7 +1496,7 @@ void LB::b_alert(int nargs) {
 	warning("b_alert(%s)", alert.c_str());
 
 	if (!debugChannelSet(-1, kDebugFewFramesOnly)) {
-		GUI::MessageDialog dialog(alert.c_str(), "OK");
+		GUI::MessageDialog dialog(alert.decode(Common::kLatin1), USTR("OK"));
 		dialog.runModal();
 	}
 }

--- a/engines/dm/dm.h
+++ b/engines/dm/dm.h
@@ -164,7 +164,7 @@ private:
 	void initConstants();
 	Common::String getSavefileName(uint16 slot);
 	void writeSaveGameHeader(Common::OutSaveFile *out, const Common::String &saveName);
-	bool writeCompleteSaveFile(int16 slot, Common::String &desc, int16 saveAndPlayChoice);
+	bool writeCompleteSaveFile(int16 slot, const Common::String &desc, int16 saveAndPlayChoice);
 	void drawEntrance(); // @ F0439_STARTEND_DrawEntrance
 	void fuseSequenceUpdate(); // @ F0445_STARTEND_FuseSequenceUpdate
 	void processEntrance(); // @ F0441_STARTEND_ProcessEntrance

--- a/engines/dm/loadsave.cpp
+++ b/engines/dm/loadsave.cpp
@@ -198,9 +198,9 @@ void DMEngine::saveGame() {
 	if (saveAndPlayChoice == kSaveAndQuit || saveAndPlayChoice == kSaveAndPlay) {
 		GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 		int16 saveSlot = dialog->runModalWithCurrentTarget();
-		Common::String saveDescription = dialog->getResultString();
+		Common::U32String saveDescription = dialog->getResultString();
 		if (saveDescription.empty())
-			saveDescription = "Nice save ^^";
+			saveDescription = USTR("Nice save ^^");
 		delete dialog;
 
 		if (saveSlot >= 0) {
@@ -223,7 +223,7 @@ void DMEngine::saveGame() {
 				_championMan->_champions[_championMan->_leaderIndex]._load -= champHandObjWeight;
 			}
 
-			if (!writeCompleteSaveFile(saveSlot, saveDescription, saveAndPlayChoice)) {
+			if (!writeCompleteSaveFile(saveSlot, saveDescription.legacyEncode(), saveAndPlayChoice)) {
 				_dialog->dialogDraw(nullptr, "Unable to open file for saving", "OK", nullptr, nullptr, nullptr, false, false, false);
 				_dialog->getChoice(1, kDMDialogCommandSetViewport, 0, kDMDialogChoiceNone);
 			}
@@ -282,7 +282,7 @@ void DMEngine::writeSaveGameHeader(Common::OutSaveFile *out, const Common::Strin
 	out->writeUint32BE(playTime);
 }
 
-bool DMEngine::writeCompleteSaveFile(int16 saveSlot, Common::String& saveDescription, int16 saveAndPlayChoice) {
+bool DMEngine::writeCompleteSaveFile(int16 saveSlot, const Common::String& saveDescription, int16 saveAndPlayChoice) {
 	Common::String savefileName = getSavefileName(saveSlot);
 	Common::SaveFileManager *saveFileManager = _system->getSavefileManager();
 	Common::OutSaveFile *file = saveFileManager->openForSaving(savefileName);
@@ -419,7 +419,7 @@ WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeade
 	char ch;
 	while ((ch = (char)in->readByte()) != '\0')
 		saveName += ch;
-	header->_descr.setDescription(saveName);
+	header->_descr.setDescription(saveName.decode(Common::kUtf8));
 
 	// Get the thumbnail
 	Graphics::Surface *thumbnail;

--- a/engines/draci/metaengine.cpp
+++ b/engines/draci/metaengine.cpp
@@ -70,7 +70,7 @@ SaveStateList DraciMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				Draci::DraciSavegameHeader header;
 				if (Draci::readSavegameHeader(in, header)) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.saveName, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -100,7 +100,7 @@ SaveStateDescriptor DraciMetaEngine::querySaveMetaInfos(const char *target, int 
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header.saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header.saveName, Common::kLatin1));
 		desc.setThumbnail(header.thumbnail);
 
 		int day = (header.date >> 24) & 0xFF;

--- a/engines/dragons/metaengine.cpp
+++ b/engines/dragons/metaengine.cpp
@@ -80,7 +80,7 @@ SaveStateList DragonsMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Dragons::DragonsEngine::readSaveHeader(in, header) == Dragons::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.description, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -99,7 +99,7 @@ SaveStateDescriptor DragonsMetaEngine::querySaveMetaInfos(const char *target, in
 		error = Dragons::DragonsEngine::readSaveHeader(in, header, false);
 		delete in;
 		if (error == Dragons::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(slot, Common::U32String(header.description, Common::kLatin1));
 			// Slot 0 is used for the "Continue" save
 			desc.setDeletableFlag(slot != 0);
 			desc.setWriteProtectedFlag(slot == 0);

--- a/engines/drascula/saveload.cpp
+++ b/engines/drascula/saveload.cpp
@@ -105,7 +105,7 @@ SaveStateDescriptor loadMetaData(Common::ReadStream *s, int slot, bool setPlayTi
 	uint32 sig = s->readUint32BE();
 	byte version = s->readByte();
 
-	SaveStateDescriptor desc(-1, "");	// init to an invalid save slot
+	SaveStateDescriptor desc(-1, USTR(""));	// init to an invalid save slot
 
 	if (sig != MAGIC_HEADER || version > SAVEGAME_VERSION)
 		return desc;
@@ -117,7 +117,7 @@ SaveStateDescriptor loadMetaData(Common::ReadStream *s, int slot, bool setPlayTi
 	byte size = s->readByte();
 	for (int i = 0; i < size; ++i)
 		name += s->readByte();
-	desc.setDescription(name);
+	desc.setDescription(name.decode(Common::kUtf8));
 
 	uint32 saveDate = s->readUint32LE();
 	int day = (saveDate >> 24) & 0xFF;
@@ -219,7 +219,7 @@ void DrasculaEngine::loadSaveNames() {
 		saveFileName = Common::String::format("%s.%03d", _targetName.c_str(), n + 1);
 		if ((in = _saveFileMan->openForLoading(saveFileName))) {
 			SaveStateDescriptor desc = loadMetaData(in, n + 1, false);
-			_saveNames[n] = desc.getDescription();
+			_saveNames[n] = desc.getDescription().legacyEncode();
 			delete in;
 		}
 	}
@@ -383,15 +383,15 @@ bool DrasculaEngine::scummVMSaveLoadDialog(bool isSave) {
 		dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 
 		slot = dialog->runModalWithCurrentTarget();
-		desc = dialog->getResultString();
+		desc = dialog->getResultString().legacyEncode();
 
 		if (desc.empty()) {
 			// create our own description for the saved game, the user didnt enter it
-			desc = dialog->createDefaultSaveDescription(slot);
+			desc = dialog->createDefaultSaveDescription(slot).legacyEncode();
 		}
 
 		if (desc.size() > 28)
-			desc = Common::String(desc.c_str(), 28);
+			desc = desc.substr(0, 28);
 	} else {
 		dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
 		slot = dialog->runModalWithCurrentTarget();

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -92,7 +92,7 @@ SaveStateList DreamWebMetaEngine::listSaves(const char *target) const {
 		delete stream;
 
 		int slotNum = atoi(file.c_str() + file.size() - 2);
-		SaveStateDescriptor sd(slotNum, name);
+		SaveStateDescriptor sd(slotNum, Common::U32String(name, Common::kLatin1));
 		saveList.push_back(sd);
 	}
 
@@ -123,7 +123,7 @@ SaveStateDescriptor DreamWebMetaEngine::querySaveMetaInfos(const char *target, i
 		for (i = 0; i < descSize; i++)
 			saveName += (char)in->readByte();
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(saveName, Common::kLatin1));
 
 		// Check if there is a ScummVM data block
 		if (header.len(6) == SCUMMVM_BLOCK_MAGIC_SIZE) {

--- a/engines/dreamweb/saveload.cpp
+++ b/engines/dreamweb/saveload.cpp
@@ -261,10 +261,11 @@ void DreamWebEngine::saveGame() {
 
 		GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 		int savegameId = dialog->runModalWithCurrentTarget();
-		Common::String game_description = dialog->getResultString();
-		if (game_description.empty())
-			game_description = "Untitled";
+		Common::U32String game_description32 = dialog->getResultString();
+		if (game_description32.empty())
+			game_description32 = USTR("Untitled");
 		delete dialog;
+		Common::String game_description = game_description32.legacyEncode();
 
 		if (savegameId < 0) {
 			_getBack = 0;
@@ -728,7 +729,7 @@ uint DreamWebEngine::scanForNames() {
 		delete stream;
 
 		int slotNum = atoi(file.c_str() + file.size() - 2);
-		SaveStateDescriptor sd(slotNum, name);
+		SaveStateDescriptor sd(slotNum, Common::U32String(name, Common::kLatin1));
 		saveList.push_back(sd);
 		if (slotNum < 21)
 			Common::strlcpy(&_saveNames[17 * slotNum + 1], name, 16);	// the first character is unused

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -408,14 +408,6 @@ void GUIErrorMessageWithURL(const Common::U32String &msg, const char *url) {
 	GUIErrorMessage(msg, url);
 }
 
-void GUIErrorMessageWithURL(const Common::String &msg, const char *url) {
-	GUIErrorMessage(Common::U32String(msg), url);
-}
-
-void GUIErrorMessage(const Common::String &msg, const char *url) {
-	GUIErrorMessage(Common::U32String(msg), url);
-}
-
 void GUIErrorMessage(const Common::U32String &msg, const char *url) {
 	g_system->setWindowCaption(_("Error"));
 	g_system->beginGFXTransaction();
@@ -442,11 +434,11 @@ void GUIErrorMessageFormat(const char *fmt, ...) {
 	msg = Common::String::vformat(fmt, va);
 	va_end(va);
 
-	GUIErrorMessage(msg);
+	GUIErrorMessage(Common::U32String(msg, Common::kLatin1));
 }
 
 void GUIErrorMessageFormat(Common::U32String fmt, ...) {
-	Common::U32String msg("");
+	Common::U32String msg = USTR("");
 
 	va_list va;
 	va_start(va, fmt);
@@ -656,9 +648,9 @@ bool Engine::warnUserAboutUnsupportedGame() {
 }
 
 void Engine::errorUnsupportedGame(Common::String extraMsg) {
-	Common::String message = extraMsg.empty() ? _("This game is not supported.") : _("This game is not supported for the following reason:\n\n");
+	Common::U32String message = extraMsg.empty() ? _("This game is not supported.") : _("This game is not supported for the following reason:\n\n");
 	message += _(extraMsg);
-	message += "\n\n";
+	message += USTR("\n\n");
 	GUI::MessageDialog(message).runModal();
 }
 
@@ -835,7 +827,7 @@ bool Engine::saveGameDialog() {
 		slotNum = dialog->runModalWithCurrentTarget();
 	}
 
-	Common::String desc = dialog->getResultString();
+	Common::U32String desc = dialog->getResultString();
 	if (desc.empty())
 		desc = dialog->createDefaultSaveDescription(slotNum);
 
@@ -844,7 +836,7 @@ bool Engine::saveGameDialog() {
 	if (slotNum < 0)
 		return false;
 
-	Common::Error saveError = saveGameState(slotNum, desc);
+	Common::Error saveError = saveGameState(slotNum, desc.legacyEncode());
 	if (saveError.getCode() != Common::kNoError) {
 		GUI::MessageDialog errorDialog(saveError.getDesc());
 		errorDialog.runModal();

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -806,7 +806,7 @@ bool Engine::loadGameDialog() {
 
 	Common::Error loadError = loadGameState(slotNum);
 	if (loadError.getCode() != Common::kNoError) {
-		GUI::MessageDialog errorDialog(loadError.getDesc());
+		GUI::MessageDialog errorDialog(_(loadError.getDesc()));
 		errorDialog.runModal();
 		return false;
 	}
@@ -838,7 +838,7 @@ bool Engine::saveGameDialog() {
 
 	Common::Error saveError = saveGameState(slotNum, desc.legacyEncode());
 	if (saveError.getCode() != Common::kNoError) {
-		GUI::MessageDialog errorDialog(saveError.getDesc());
+		GUI::MessageDialog errorDialog(_(saveError.getDesc()));
 		errorDialog.runModal();
 		return false;
 	}

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -67,15 +67,7 @@ void GUIErrorMessage(const Common::U32String &msg, const char *url = nullptr);
 /**
  * Initialize graphics and show an error message.
  */
-void GUIErrorMessage(const Common::String &msg, const char *url = nullptr);
-/**
- * Initialize graphics and show an error message.
- */
 void GUIErrorMessageWithURL(const Common::U32String &msg, const char *url);
-/**
- * Initialize graphics and show an error message.
- */
-void GUIErrorMessageWithURL(const Common::String &msg, const char *url);
 /**
  * Initialize graphics and show an error message.
  */

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -175,11 +175,11 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 	const char *reportEngineHeader = _s("Matched game IDs for the %s engine:");
 
 	Common::U32String report = Common::U32String::format(
-			translate ? _(reportStart) : Common::U32String(reportStart),
+			translate ? _(reportStart) : Common::U32String(reportStart, Common::kLatin1),
 			fullPath ? detectedGames[0].path.c_str() : detectedGames[0].shortPath.c_str(),
 			"https://bugs.scummvm.org/"
 	);
-	report += Common::U32String("\n");
+	report += USTR("\n");
 
 	FilePropertiesMap matchedFiles;
 
@@ -193,21 +193,21 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 			currentEngineId = game.engineId;
 
 			// If the engine is not the same as for the previous entry, print an engine line header
-			report += Common::U32String("\n");
+			report += USTR("\n");
 			report += Common::U32String::format(
-					translate ? _(reportEngineHeader) : Common::U32String(reportEngineHeader),
+				translate ? _(reportEngineHeader) : Common::U32String(reportEngineHeader, Common::kLatin1),
 					game.engineId.c_str()
 			);
-			report += Common::U32String(" ");
+			report += USTR(" ");
 
 		} else {
-			report += Common::U32String(", ");
+			report += USTR(", ");
 		}
 
 		// Add the gameId to the list of matched games for the engine
 		// TODO: Use the gameId here instead of the preferred target.
 		// This is currently impossible due to the AD singleId feature losing the information.
-		report += game.preferredTarget;
+		report += game.preferredTarget.decode(Common::kLatin1);
 
 		// Consolidate matched files across all engines and detection entries
 		for (FilePropertiesMap::const_iterator it = game.matchedFiles.begin(); it != game.matchedFiles.end(); it++) {
@@ -219,12 +219,12 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 		report.wordWrap(wordwrapAt);
 	}
 
-	report += Common::U32String("\n\n");
+	report += USTR("\n\n");
 
 	for (FilePropertiesMap::const_iterator file = matchedFiles.begin(); file != matchedFiles.end(); ++file)
-		report += Common::String::format("  {\"%s\", 0, \"%s\", %d},\n", file->_key.c_str(), file->_value.md5.c_str(), file->_value.size);
+		report += Common::U32String::format("  {\"%s\", 0, \"%s\", %d},\n", file->_key.c_str(), file->_value.md5.c_str(), file->_value.size);
 
-	report += Common::U32String("\n");
+	report += USTR("\n");
 
 	return report;
 }

--- a/engines/glk/alan2/alan2.cpp
+++ b/engines/glk/alan2/alan2.cpp
@@ -85,7 +85,7 @@ bool Alan2::initialize() {
 	// Open up the text file
 	txtfil = new Common::File();
 	if (!txtfil->open(Common::String::format("%s.dat", _advName.c_str()))) {
-		GUIErrorMessage("Could not open adventure text data file");
+		GUIErrorMessage(USTR("Could not open adventure text data file"));
 		delete txtfil;
 		return false;
 	}

--- a/engines/glk/alan3/alan3.cpp
+++ b/engines/glk/alan3/alan3.cpp
@@ -94,7 +94,7 @@ bool Alan3::initialize() {
 	// In Alan 3, the text data comes from the adventure file itself
 	Common::File *txt = new Common::File();
 	if (!txt->open(getFilename())) {
-	    GUIErrorMessage("Could not open adventure file for text data");
+	    GUIErrorMessage(USTR("Could not open adventure file for text data"));
 	    delete txt;
 	    return false;
 	}

--- a/engines/glk/comprehend/game.cpp
+++ b/engines/glk/comprehend/game.cpp
@@ -316,7 +316,7 @@ void ComprehendGame::game_save() {
 		return;
 	}
 
-	g_comprehend->saveGameState(c - '0', _("Savegame"));
+	g_comprehend->saveGameState(c - '0', _("Savegame").encode(Common::kUtf8));
 }
 
 void ComprehendGame::game_restore() {

--- a/engines/glk/hugo/herun.cpp
+++ b/engines/glk/hugo/herun.cpp
@@ -184,7 +184,7 @@ Start:
 	// Handle any savegame selected directly from the ScummVM launcher
 	if (_savegameSlot != -1) {
 		if (loadGameState(_savegameSlot).getCode() != Common::kNoError) {
-			GUIErrorMessage("Loading failed");
+			GUIErrorMessage(USTR("Loading failed"));
 			_savegameSlot = -1;
 		}
 	}

--- a/engines/glk/metaengine.cpp
+++ b/engines/glk/metaengine.cpp
@@ -249,7 +249,7 @@ SaveStateList GlkMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				Common::String saveName;
 				if (Glk::QuetzalReader::getSavegameDescription(in, saveName))
-					saveList.push_back(SaveStateDescriptor(slot, saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(saveName, Common::kLatin1)));
 
 				delete in;
 			}

--- a/engines/glk/quetzal.cpp
+++ b/engines/glk/quetzal.cpp
@@ -145,7 +145,7 @@ bool QuetzalReader::getSavegameDescription(Common::SeekableReadStream *rs, Commo
 		}
 	}
 
-	saveName = _("Untitled Savegame");
+	saveName = _("Untitled Savegame").encode(Common::kUtf8);
 	return true;
 }
 
@@ -159,7 +159,7 @@ bool QuetzalReader::getSavegameMetaInfo(Common::SeekableReadStream *rs, SaveStat
 	for (Iterator it = r.begin(); it != r.end(); ++it) {
 		if ((*it)._id == ID_ANNO) {
 			Common::SeekableReadStream *s = it.getStream();
-			ssd.setDescription(readString(s));
+			ssd.setDescription(readString(s).decode(Common::kUtf8));
 			delete s;
 
 		} else if ((*it)._id == ID_SCVM) {

--- a/engines/glk/scott/scott.cpp
+++ b/engines/glk/scott/scott.cpp
@@ -400,7 +400,7 @@ void Scott::output(const Common::String &a) {
 
 void Scott::output(const Common::U32String &a) {
 	if (_saveSlot == -1)
-		display(_bottomWindow, Common::U32String("%S"), a.c_str());
+		display(_bottomWindow, USTR("%S"), a.c_str());
 }
 
 void Scott::outputNumber(int a) {
@@ -447,7 +447,7 @@ void Scott::look(void) {
 				f = 1;
 			else
 				display(_topWindow, ", ");
-			display(_topWindow, Common::U32String("%S"), _(ExitNames[ct]).c_str());
+			display(_topWindow, USTR("%S"), _(ExitNames[ct]).c_str());
 		}
 		ct++;
 	}

--- a/engines/glk/streams.cpp
+++ b/engines/glk/streams.cpp
@@ -1434,8 +1434,8 @@ frefid_t Streams::createByPrompt(uint usage, FileMode fmode, uint rock) {
 
 			int slot = dialog->runModalWithCurrentTarget();
 			if (slot >= 0) {
-				Common::String desc = dialog->getResultString();
-				return createRef(slot, desc, usage, rock);
+				Common::U32String desc = dialog->getResultString();
+				return createRef(slot, desc.encode(Common::kUtf8), usage, rock);
 			}
 		} else if (fmode == filemode_Read) {
 			// Load a savegame slot

--- a/engines/glk/zcode/processor_text.cpp
+++ b/engines/glk/zcode/processor_text.cpp
@@ -569,14 +569,14 @@ void Processor::handleAbbreviations() {
 	Common::U32String word(_decoded, _decoded + wordSize);
 
 	// Check for standard abbreviations
-	if (word == "g")
-		word = "again";
-	else if (word == "o")
-		word = "oops";
-	else if (word == "x")
-		word = "examine";
-	else if (word == "z")
-		word = "wait";
+	if (word == USTR("g"))
+		word = USTR("again");
+	else if (word == USTR("o"))
+		word = USTR("oops");
+	else if (word == USTR("x"))
+		word = USTR("examine");
+	else if (word == USTR("z"))
+		word = USTR("wait");
 	else
 		return;
 

--- a/engines/gnap/menu.cpp
+++ b/engines/gnap/menu.cpp
@@ -465,7 +465,7 @@ void GnapEngine::updateMenuStatusMainMenu() {
 		if (_sceneClickedHotspot == 1) {
 			GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 			int16 savegameId = dialog->runModalWithCurrentTarget();
-			Common::String savegameDescription = dialog->getResultString();
+			Common::String savegameDescription = dialog->getResultString().legacyEncode();
 			delete dialog;
 
 			if (savegameId != -1) {

--- a/engines/gnap/metaengine.cpp
+++ b/engines/gnap/metaengine.cpp
@@ -88,7 +88,7 @@ SaveStateList GnapMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Gnap::GnapEngine::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 				delete in;
 			}
 		}
@@ -117,7 +117,7 @@ SaveStateDescriptor GnapMetaEngine::querySaveMetaInfos(const char *target, int s
 		while ((ch = (char)file->readByte()) != '\0')
 			saveName += ch;
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(saveName, Common::kLatin1));
 
 		if (version != 1) {
 			Graphics::Surface *thumbnail;

--- a/engines/gob/gob.cpp
+++ b/engines/gob/gob.cpp
@@ -81,14 +81,14 @@ public:
 	void handleKeyDown(Common::KeyState state) override;
 
 private:
-	Common::String _message;
+	Common::U32String _message;
 	GUI::StaticTextWidget *_text;
 };
 
 PauseDialog::PauseDialog() : GUI::Dialog(0, 0, 0, 0) {
 	_backgroundType = GUI::ThemeEngine::kDialogBackgroundSpecial;
 
-	_message = "Game paused. Press Ctrl+p again to continue.";
+	_message = USTR("Game paused. Press Ctrl+p again to continue.");
 	_text = new GUI::StaticTextWidget(this, 4, 0, 10, 10,
 			_message, Graphics::kTextAlignCenter);
 }

--- a/engines/grim/inputdialog.cpp
+++ b/engines/grim/inputdialog.cpp
@@ -45,9 +45,9 @@ InputDialog::InputDialog(const Common::String &message, const Common::String &st
 	// down the string into lines, and taking the maximum of their widths.
 	// Using this, and accounting for the space the button(s) need, we can set
 	// the real size of the dialog
-	Common::Array<Common::String> lines;
+	Common::Array<Common::U32String> lines;
 	int lineCount;
-	int maxlineWidth = g_gui.getFont().wordWrapText(message, screenW - 2 * 20, lines);
+	int maxlineWidth = g_gui.getFont().wordWrapText(message.decode(Common::kLatin1), screenW - 2 * 20, lines);
 
 	// Calculate the desired dialog size (maxing out at 300*180 for now)
 	_w = MAX(maxlineWidth, (2 * buttonWidth) + 10) + 20;
@@ -76,16 +76,16 @@ InputDialog::InputDialog(const Common::String &message, const Common::String &st
 	}
 	height += 10;
 	if (_hasTextField) {
-		m_text = new GUI::EditTextWidget(this, 10, height, _w - 20, kLineHeight, Common::U32String(string), Common::U32String("input"));
+		m_text = new GUI::EditTextWidget(this, 10, height, _w - 20, kLineHeight, Common::U32String(string, Common::kLatin1), USTR("input"));
 		height += kLineHeight + 10;
 	}
 
-	new GUI::ButtonWidget(this, 10, height, buttonWidth, buttonHeight, Common::U32String("Ok"), Common::U32String(), GUI::kOKCmd, Common::ASCII_RETURN); // Confirm dialog
-	new GUI::ButtonWidget(this, _w - buttonWidth - 10, height, buttonWidth, buttonHeight, Common::U32String("Cancel"), Common::U32String(), GUI::kCloseCmd, Common::ASCII_ESCAPE);   // Cancel dialog
+	new GUI::ButtonWidget(this, 10, height, buttonWidth, buttonHeight, USTR("Ok"), Common::U32String(), GUI::kOKCmd, Common::ASCII_RETURN); // Confirm dialog
+	new GUI::ButtonWidget(this, _w - buttonWidth - 10, height, buttonWidth, buttonHeight, USTR("Cancel"), Common::U32String(), GUI::kCloseCmd, Common::ASCII_ESCAPE);   // Cancel dialog
 }
 
 Common::String InputDialog::getString() {
-	return m_text->getEditString();
+	return m_text->getEditString().legacyEncode();
 }
 
 void InputDialog::handleKeyDown(Common::KeyState state) {

--- a/engines/grim/metaengine.cpp
+++ b/engines/grim/metaengine.cpp
@@ -121,7 +121,7 @@ SaveStateList GrimMetaEngine::listSaves(const char *target) const {
 				strSize = savedState->readLESint32();
 				savedState->read(str, strSize);
 				savedState->endSection();
-				saveList.push_back(SaveStateDescriptor(slotNum, str));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(str, Common::kLatin1)));
 			}
 			delete savedState;
 		}

--- a/engines/groovie/saveload.cpp
+++ b/engines/groovie/saveload.cpp
@@ -142,7 +142,7 @@ Common::InSaveFile *SaveLoad::openForLoading(const Common::String &target, int s
 				description += c;
 			}
 		}
-		descriptor->setDescription(description);
+		descriptor->setDescription(description.decode(Common::kUtf8));
 	}
 
 	// Return a substream, skipping the metadata

--- a/engines/groovie/saveload.cpp
+++ b/engines/groovie/saveload.cpp
@@ -142,7 +142,7 @@ Common::InSaveFile *SaveLoad::openForLoading(const Common::String &target, int s
 				description += c;
 			}
 		}
-		descriptor->setDescription(description.decode(Common::kUtf8));
+		descriptor->setDescription(description.decode(Common::kLatin1));
 	}
 
 	// Return a substream, skipping the metadata

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -502,7 +502,7 @@ void Script::savegame(uint slot) {
 			save[i] = newchar;
 		}
 	}
-	_saveNames[slot] = save;
+	_saveNames[slot] = Common::U32String(save, Common::kLatin1);
 }
 
 void Script::printString(Graphics::Surface *surface, const char *str) {
@@ -1453,7 +1453,7 @@ void Script::o_hotspot_slot() {
 		// Clear the top bar
 		gamescreen->fillRect(topbar, 0);
 
-		printString(gamescreen, _saveNames[slot].c_str());
+		printString(gamescreen, _saveNames[slot].legacyEncode().c_str());
 
 		_vm->_system->unlockScreen();
 
@@ -1482,7 +1482,7 @@ void Script::o_checkvalidsaves() {
 	// Reset the array of valid saves and the savegame names cache
 	for (int i = 0; i < MAX_SAVES; i++) {
 		setVariable(i, 0);
-		_saveNames[i] = "E M P T Y";
+		_saveNames[i] = USTR("E M P T Y");
 	}
 
 	// Get the list of savefiles

--- a/engines/groovie/script.h
+++ b/engines/groovie/script.h
@@ -79,7 +79,7 @@ private:
 	Common::String _savedScriptFile;
 
 	// Save names
-	Common::String _saveNames[MAX_SAVES];
+	Common::U32String _saveNames[MAX_SAVES];
 
 	// Code
 	byte *_code;

--- a/engines/hadesch/hadesch.cpp
+++ b/engines/hadesch/hadesch.cpp
@@ -34,6 +34,7 @@
 #include "common/util.h"
 #include "common/zlib.h"
 #include "common/config-manager.h"
+#include "common/translation.h"
 
 #include "engines/advancedDetector.h"
 #include "engines/util.h"
@@ -694,11 +695,11 @@ Common::Error HadeschEngine::loadGameStream(Common::SeekableReadStream *stream) 
 Common::Error HadeschEngine::saveGameStream(Common::WriteStream *stream, bool isAutosave) {
 	Common::Serializer s(nullptr, stream);
 	if (isAutosave)
-		_persistent._slotDescription = "Autosave";
+		_persistent._slotDescription = _("Autosave");
 	if(_persistent._currentRoomId == 0)
 		return Common::kUnknownError;
 	bool res = _persistent.syncGameStream(s);
-	_persistent._slotDescription = "";
+	_persistent._slotDescription = USTR("");
 	return res ? Common::kNoError
 		: Common::kUnknownError;
 }

--- a/engines/hadesch/persistent.cpp
+++ b/engines/hadesch/persistent.cpp
@@ -167,9 +167,9 @@ HadeschSaveDescriptor::HadeschSaveDescriptor(Common::Serializer &s, int slot) {
 	if (s.getVersion() < 2) {
 		Common::String str;
 		s.syncString(str);
-		_heroName = str;
+		_heroName = str.decode(Common::kUtf8);
 		s.syncString(str);
-		_slotName = str;
+		_slotName = str.decode(Common::kUtf8);
 	} else {
 		s.syncString32(_heroName);
 		s.syncString32(_slotName);
@@ -187,9 +187,9 @@ bool Persistent::syncGameStream(Common::Serializer &s) {
 	if (s.getVersion() < 2) {
 		Common::String str;
 		s.syncString(str);
-		_heroName = str;
+		_heroName = str.decode(Common::kUtf8);
 		s.syncString(str);
-		_slotDescription = str;
+		_slotDescription = str.decode(Common::kUtf8);
 	} else {
 		s.syncString32(_heroName);
 		s.syncString32(_slotDescription);

--- a/engines/hadesch/rooms/options.cpp
+++ b/engines/hadesch/rooms/options.cpp
@@ -422,12 +422,12 @@ private:
 			saveDescs[persistent->_currentRoomId],
 			heroNameUTF8.c_str());
 		// UTF-8
-		Common::String desc = _typedSlotName.empty() ? descPos
-		    : _typedSlotName + " (" + descPos + ")";
+		Common::String desc = (_typedSlotName.empty() ? descPos
+				       : _typedSlotName.encode(Common::kUtf8)) + " (" + descPos + ")";
 
 		persistent->_slotDescription = _typedSlotName;
 		Common::Error res = g_vm->saveGameState(slot, desc);
-		debug("%d, %s->[%d, %s]", slot, desc.c_str(), res.getCode(), res.getDesc().c_str());
+		debug("%d, %s->[%d, %s]", slot, desc.c_str(), res.getCode(), res.getDesc().encode(Common::kUtf8).c_str());
 		_savesLoaded = false; // Invalidate cache
 		switch (_saveVariant) {
 		case kSaveFromMainMenu:
@@ -517,7 +517,7 @@ private:
 		for (int i = 0; i < 6 && _showPos + i < (int) _userNames.size(); i++) {
 			Common::U32String name = _userNames[_showPos + i];
 			if (name == "")
-				name = "No name";
+				name = USTR("No name");
 			room->renderString("largeascii", name,
 					   Common::Point(150, 134 + 36 * i), 4000, 0,
 					   Common::String::format("username%d", i));
@@ -625,7 +625,7 @@ private:
 		_selectedSave = -1;
 		_showPos = 0;
 
-		_typedSlotName = "";
+		_typedSlotName = USTR("");
 
 		room->selectFrame("saveas", kTitleZ, 0);
 		room->selectFrame(LayerId("thumbnails", 0, "save"), 5000,

--- a/engines/hadesch/rooms/options.cpp
+++ b/engines/hadesch/rooms/options.cpp
@@ -427,7 +427,7 @@ private:
 
 		persistent->_slotDescription = _typedSlotName;
 		Common::Error res = g_vm->saveGameState(slot, desc);
-		debug("%d, %s->[%d, %s]", slot, desc.c_str(), res.getCode(), res.getDesc().encode(Common::kUtf8).c_str());
+		debug("%d, %s->[%d, %s]", slot, desc.c_str(), res.getCode(), res.getDesc().c_str());
 		_savesLoaded = false; // Invalidate cache
 		switch (_saveVariant) {
 		case kSaveFromMainMenu:

--- a/engines/hdb/metaengine.cpp
+++ b/engines/hdb/metaengine.cpp
@@ -136,9 +136,9 @@ SaveStateList HDBMetaEngine::listSaves(const char *target) const {
 				desc.setPlayTime(timeSeconds * 1000);
 
 				if (slotNum < 8)
-					desc.setDescription(Common::String::format("Auto: %s", mapName));
+					desc.setDescription(Common::U32String::format("Auto: %s", mapName));
 				else
-					desc.setDescription(mapName);
+					desc.setDescription(Common::U32String(mapName, Common::kUtf8));
 
 				saveList.push_back(desc);
 			}
@@ -168,7 +168,7 @@ SaveStateDescriptor HDBMetaEngine::querySaveMetaInfos(const char *target, int sl
 
 		desc.setSaveSlot(slot);
 		desc.setPlayTime(timeSeconds * 1000);
-		desc.setDescription(mapName);
+		desc.setDescription(Common::U32String(mapName, Common::kLatin1));
 
 		return desc;
 	}

--- a/engines/hopkins/metaengine.cpp
+++ b/engines/hopkins/metaengine.cpp
@@ -115,7 +115,7 @@ SaveStateList HopkinsMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Hopkins::SaveLoadManager::readSavegameHeader(in, header)) {
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 				}
 
 				delete in;
@@ -151,7 +151,7 @@ SaveStateDescriptor HopkinsMetaEngine::querySaveMetaInfos(const char *target, in
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/hugo/dialogs.cpp
+++ b/engines/hugo/dialogs.cpp
@@ -56,15 +56,15 @@ void TopMenu::init() {
 	int x = kMenuX;
 	int y = kMenuY;
 
-	_whatButton    =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("What is it?"),              kCmdWhat);
-	_musicButton   =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("Music"),                    kCmdMusic);
-	_soundFXButton =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("Sound FX"),                 kCmdSoundFX);
-	_saveButton    =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("Save game"),                kCmdSave);
-	_loadButton    =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("Load game"),                kCmdLoad);
-	_recallButton  =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("Recall last command"),      kCmdRecall);
-	_turboButton   =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("Turbo"),                    kCmdTurbo);
-	_lookButton    =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("Description of the scene"), kCmdLook);
-	_inventButton  =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	Common::U32String("Inventory"),                kCmdInvent);
+	_whatButton    =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("What is it?"),              kCmdWhat);
+	_musicButton   =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("Music"),                    kCmdMusic);
+	_soundFXButton =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("Sound FX"),                 kCmdSoundFX);
+	_saveButton    =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("Save game"),                kCmdSave);
+	_loadButton    =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("Load game"),                kCmdLoad);
+	_recallButton  =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("Recall last command"),      kCmdRecall);
+	_turboButton   =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("Turbo"),                    kCmdTurbo);
+	_lookButton    =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("Description of the scene"), kCmdLook);
+	_inventButton  =  new GUI::PicButtonWidget(this, x, y, kButtonWidth, kButtonHeight,	USTR("Inventory"),                kCmdInvent);
 }
 
 void TopMenu::reflowLayout() {
@@ -249,9 +249,9 @@ EntryDialog::EntryDialog(const Common::String &title, const Common::String &butt
 	// down the string into lines, and taking the maximum of their widths.
 	// Using this, and accounting for the space the button(s) need, we can set
 	// the real size of the dialog
-	Common::Array<Common::String> lines;
+	Common::Array<Common::U32String> lines;
 	int lineCount, buttonPos;
-	int maxlineWidth = g_gui.getFont().wordWrapText(title, screenW - 2 * 30, lines);
+	int maxlineWidth = g_gui.getFont().wordWrapText(title.decode(Common::kLatin1), screenW - 2 * 30, lines);
 
 	// Calculate the desired dialog size (maxing out at 300*180 for now)
 	_w = MAX(maxlineWidth, buttonWidth) + 20;
@@ -277,13 +277,13 @@ EntryDialog::EntryDialog(const Common::String &title, const Common::String &butt
 	}
 
 	_text = new GUI::EditTextWidget(this, 10, 10 + lineCount * (kLineHeight + 1), _w - 20, kLineHeight, Common::U32String(), Common::U32String(), 0, kCmdFinishEdit);
-	_text->setEditString(defaultValue);
+	_text->setEditString(defaultValue.decode(Common::kLatin1));
 
 	_h += kLineHeight + 5;
 
 	buttonPos = (_w - buttonWidth) / 2;
 
-	new GUI::ButtonWidget(this, buttonPos, _h - buttonHeight - 8, buttonWidth, buttonHeight, buttonLabel, Common::U32String(), kCmdButton, Common::ASCII_RETURN);	// Confirm dialog
+	new GUI::ButtonWidget(this, buttonPos, _h - buttonHeight - 8, buttonWidth, buttonHeight, buttonLabel.decode(Common::kLatin1), Common::U32String(), kCmdButton, Common::ASCII_RETURN);	// Confirm dialog
 
 }
 

--- a/engines/hugo/file.cpp
+++ b/engines/hugo/file.cpp
@@ -297,7 +297,7 @@ bool FileManager::saveGame(const int16 slot, const Common::String &descrip) {
 	if (slot == -1) {
 		GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 		savegameId = dialog->runModalWithCurrentTarget();
-		savegameDescription = dialog->getResultString();
+		savegameDescription = dialog->getResultString().encode(Common::kUtf8);
 		delete dialog;
 	} else {
 		savegameId = slot;

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -111,7 +111,7 @@ SaveStateList HugoMetaEngine::listSaves(const char *target) const {
 				file->read(name, nameSize);
 				name[nameSize] = 0;
 
-				saveList.push_back(SaveStateDescriptor(slotNum, name));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(name, Common::kLatin1)));
 				delete file;
 			}
 		}
@@ -140,7 +140,7 @@ SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int s
 		file->read(saveName, saveNameLength);
 		saveName[saveNameLength] = 0;
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(saveName, Common::kLatin1));
 
 		Graphics::Surface *thumbnail;
 		if (!Graphics::loadThumbnail(*file, thumbnail)) {

--- a/engines/hugo/util.cpp
+++ b/engines/hugo/util.cpp
@@ -87,7 +87,7 @@ void reverseByte(byte *data) {
 }
 
 void notifyBox(const Common::String &msg) {
-	notifyBox(Common::U32String(msg));
+	notifyBox(msg.decode(Common::kLatin1));
 }
 
 void notifyBox(const Common::U32String &msg) {
@@ -106,18 +106,18 @@ Common::String promptBox(const Common::String &msg) {
 
 	dialog.runModal();
 
-	return dialog.getEditString();
+	return dialog.getEditString().legacyEncode();
 }
 
 bool yesNoBox(const Common::String &msg) {
-	return yesNoBox(Common::U32String(msg));
+    return yesNoBox(msg.decode(Common::kLatin1));
 }
 
 bool yesNoBox(const Common::U32String &msg) {
 	if (msg.empty())
 		return 0;
 
-	GUI::MessageDialog dialog(msg, Common::U32String("YES"), Common::U32String("NO"));
+	GUI::MessageDialog dialog(msg, USTR("YES"), USTR("NO"));
 	return (dialog.runModal() == GUI::kMessageOK);
 }
 

--- a/engines/icb/surface_manager.cpp
+++ b/engines/icb/surface_manager.cpp
@@ -192,7 +192,7 @@ unsigned int _surface_manager::Init_direct_draw() {
 	// Debug info
 	Zdebug("*SURFACE_MANAGER* Initalizing the SDL video interface");
 
-	g_system->setWindowCaption(Common::U32String("In Cold Blood (C)2000 Revolution Software Ltd"));
+	g_system->setWindowCaption(USTR("In Cold Blood (C)2000 Revolution Software Ltd"));
 	initGraphics(640, 480, nullptr);
 
 	_zb = new TinyGL::FrameBuffer(640, 480, g_system->getScreenFormat()); // TODO: delete

--- a/engines/illusions/menusystem.cpp
+++ b/engines/illusions/menusystem.cpp
@@ -697,7 +697,7 @@ MenuActionSaveGame::MenuActionSaveGame(BaseMenuSystem *menuSystem, uint choiceIn
 
 void MenuActionSaveGame::execute() {
 	GUI::SaveLoadChooser *dialog;
-	Common::String desc;
+	Common::U32String desc;
 	int slot;
 
 	dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
@@ -708,7 +708,7 @@ void MenuActionSaveGame::execute() {
 
 	if (slot >= 0) {
 		_menuSystem->setSavegameSlotNum(slot);
-		_menuSystem->setSavegameDescription(desc);
+		_menuSystem->setSavegameDescription(desc.encode(Common::kUtf8));
 		_menuSystem->selectMenuChoiceIndex(_choiceIndex);
 	}
 }

--- a/engines/illusions/metaengine.cpp
+++ b/engines/illusions/metaengine.cpp
@@ -94,7 +94,7 @@ SaveStateList IllusionsMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Illusions::IllusionsEngine::readSaveHeader(in, header) == Illusions::IllusionsEngine::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.description, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -113,7 +113,7 @@ SaveStateDescriptor IllusionsMetaEngine::querySaveMetaInfos(const char *target, 
 		error = Illusions::IllusionsEngine::readSaveHeader(in, header, false);
 		delete in;
 		if (error == Illusions::IllusionsEngine::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(slot, Common::U32String(header.description, Common::kLatin1));
 			// Slot 0 is used for the "Continue" save
 			desc.setDeletableFlag(slot != 0);
 			desc.setWriteProtectedFlag(slot == 0);

--- a/engines/kingdom/kingdom.cpp
+++ b/engines/kingdom/kingdom.cpp
@@ -738,11 +738,11 @@ Common::String KingdomGame::getSavegameFilename(int slot) {
 void KingdomGame::saveGame() {
 	GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 	int16 savegameId = dialog->runModalWithCurrentTarget();
-	Common::String savegameDescription = dialog->getResultString();
+	Common::U32String savegameDescription = dialog->getResultString();
 	delete dialog;
 	if (savegameId < 0)
 		return; // dialog aborted
-	saveGameState(savegameId, savegameDescription);
+	saveGameState(savegameId, savegameDescription.encode(Common::kUtf8));
 }
 
 void KingdomGame::restoreGame() {

--- a/engines/kingdom/metaengine.cpp
+++ b/engines/kingdom/metaengine.cpp
@@ -92,7 +92,7 @@ SaveStateList KingdomMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Kingdom::KingdomGame::readSavegameHeader(in, header)) {
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 
 					header._thumbnail->free();
 					delete header._thumbnail;
@@ -123,7 +123,7 @@ SaveStateDescriptor KingdomMetaEngine::querySaveMetaInfos(const char *target, in
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/kyra/gui/saveload.cpp
+++ b/engines/kyra/gui/saveload.cpp
@@ -263,7 +263,7 @@ void KyraEngine_v1::loadGameStateCheck(int slot) {
 		errorMessage += filename;
 		errorMessage += "'";
 
-		GUIErrorMessage(errorMessage);
+		GUIErrorMessage(errorMessage.decode(Common::kLatin1));
 		error("%s", errorMessage.c_str());
 	}
 }

--- a/engines/kyra/metaengine.cpp
+++ b/engines/kyra/metaengine.cpp
@@ -162,7 +162,7 @@ SaveStateList KyraMetaEngine::listSaves(const char *target) const {
 					if (slotNum == 0 && header.gameID == Kyra::GI_KYRA3)
 						header.description = "New Game";
 
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.description, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -202,7 +202,7 @@ SaveStateDescriptor KyraMetaEngine::querySaveMetaInfos(const char *target, int s
 		delete in;
 
 		if (error == Kyra::KyraEngine_v1::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(slot, Common::U32String(header.description, Common::kLatin1));
 
 			// Slot 0 is used for the 'restart game' save in all three Kyrandia games, thus
 			// we prevent it from being deleted.
@@ -218,7 +218,7 @@ SaveStateDescriptor KyraMetaEngine::querySaveMetaInfos(const char *target, int s
 		}
 	}
 
-	SaveStateDescriptor desc(slot, Common::String());
+	SaveStateDescriptor desc(slot, Common::U32String());
 
 	// We don't allow quick saves (slot 990 till 998) to be overwritten.
 	// The same goes for the 'Autosave', which is slot 999. Slot 0 will also

--- a/engines/kyra/resource/staticres.cpp
+++ b/engines/kyra/resource/staticres.cpp
@@ -163,7 +163,7 @@ bool StaticResource::loadStaticResourceFile() {
 
 	if (!foundWorkingKyraDat) {
 		Common::String errorMessage = "You're missing the '" + StaticResource::staticDataFilename() + "' engine data file or it got corrupted.";
-		GUIErrorMessage(errorMessage);
+		GUIErrorMessage(errorMessage.decode(Common::kLatin1));
 		error("%s", errorMessage.c_str());
 	}
 

--- a/engines/lab/savegame.cpp
+++ b/engines/lab/savegame.cpp
@@ -95,7 +95,7 @@ WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeade
 	char ch;
 	while ((ch = (char)in->readByte()) != '\0')
 		saveName += ch;
-	header._descr.setDescription(saveName);
+	header._descr.setDescription(saveName.decode(Common::kUtf8));
 
 	// Get the thumbnail
 	Graphics::Surface *thumbnail = nullptr;
@@ -243,14 +243,14 @@ bool LabEngine::saveRestoreGame() {
 		GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 		int slot = dialog->runModalWithCurrentTarget();
 		if (slot >= 0) {
-			Common::String desc = dialog->getResultString();
+			Common::U32String desc = dialog->getResultString();
 
 			if (desc.empty()) {
 				// create our own description for the saved game, the user didn't enter it
 				desc = dialog->createDefaultSaveDescription(slot);
 			}
 
-			isOK = saveGame(slot, desc);
+			isOK = saveGame(slot, desc.encode(Common::kUtf8));
 		}
 		delete dialog;
 	} else {

--- a/engines/lilliput/metaengine.cpp
+++ b/engines/lilliput/metaengine.cpp
@@ -117,7 +117,7 @@ SaveStateList LilliputMetaEngine::listSaves(const char *target) const {
 				file->read(name, nameSize);
 				name[nameSize] = 0;
 
-				saveList.push_back(SaveStateDescriptor(slotNum, name));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(name, Common::kLatin1)));
 				delete file;
 			}
 		}
@@ -147,7 +147,7 @@ SaveStateDescriptor LilliputMetaEngine::querySaveMetaInfos(const char *target, i
 			saveName += curChr;
 		}
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(saveName, Common::kLatin1));
 
 		Graphics::Surface *thumbnail;
 		if (!Graphics::loadThumbnail(*file, thumbnail)) {

--- a/engines/lure/metaengine.cpp
+++ b/engines/lure/metaengine.cpp
@@ -100,7 +100,7 @@ SaveStateList LureMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				saveDesc = Lure::getSaveName(in);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveDesc, Common::kLatin1)));
 				delete in;
 			}
 		}

--- a/engines/macventure/metaengine.cpp
+++ b/engines/macventure/metaengine.cpp
@@ -143,7 +143,7 @@ SaveStateDescriptor MacVentureMetaEngine::querySaveMetaInfos(const char *target,
 		delete in;
 		return desc;
 	}
-	return SaveStateDescriptor(-1, "");
+	return SaveStateDescriptor(-1, USTR(""));
 }
 
 } // End of namespace MacVenture

--- a/engines/macventure/saveload.cpp
+++ b/engines/macventure/saveload.cpp
@@ -52,7 +52,7 @@ SaveStateDescriptor loadMetaData(Common::SeekableReadStream *s, int slot, bool s
 	uint32 sig = s->readUint32BE();
 	byte version = s->readByte();
 
-	SaveStateDescriptor desc(-1, "");	// init to an invalid save slot
+	SaveStateDescriptor desc(-1, USTR(""));	// init to an invalid save slot
 
 	if (sig != MACVENTURE_SAVE_HEADER || version > MACVENTURE_SAVE_VERSION)
 		return desc;
@@ -77,7 +77,7 @@ SaveStateDescriptor loadMetaData(Common::SeekableReadStream *s, int slot, bool s
 	for (uint32 i = 0; i < descSize; ++i) {
 		name += s->readByte();
 	}
-	desc.setDescription(name);
+	desc.setDescription(name.decode(Common::kUtf8));
 
 	// Load date
 	uint32 saveDate = s->readUint32LE();
@@ -168,7 +168,7 @@ Common::Error MacVentureEngine::saveGameState(int slot, const Common::String &de
 bool MacVentureEngine::scummVMSaveLoadDialog(bool isSave) {
 	if (!isSave) {
 		// do loading
-		GUI::SaveLoadChooser dialog = GUI::SaveLoadChooser(Common::String("Load game:"), Common::String("Load"), false);
+		GUI::SaveLoadChooser dialog = GUI::SaveLoadChooser(USTR("Load game:"), USTR("Load"), false);
 		int slot = dialog.runModalWithCurrentTarget();
 
 		if (slot < 0)
@@ -178,9 +178,9 @@ bool MacVentureEngine::scummVMSaveLoadDialog(bool isSave) {
 	}
 
 	// do saving
-	GUI::SaveLoadChooser dialog = GUI::SaveLoadChooser(Common::String("Save game:"), Common::String("Save"), true);
+	GUI::SaveLoadChooser dialog = GUI::SaveLoadChooser(USTR("Save game:"), USTR("Save"), true);
 	int slot = dialog.runModalWithCurrentTarget();
-	Common::String desc = dialog.getResultString();
+	Common::U32String desc = dialog.getResultString();
 
 	if (desc.empty()) {
 		// create our own description for the saved game, the user didnt enter it
@@ -194,7 +194,7 @@ bool MacVentureEngine::scummVMSaveLoadDialog(bool isSave) {
 	if (slot < 0)
 		return true;
 
-	return saveGameState(slot, desc).getCode() == Common::kNoError;
+	return saveGameState(slot, desc.encode(Common::kUtf8)).getCode() == Common::kNoError;
 }
 
 bool MacVentureEngine::canLoadGameStateCurrently() {

--- a/engines/mads/metaengine.cpp
+++ b/engines/mads/metaengine.cpp
@@ -118,7 +118,7 @@ SaveStateList MADSMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (MADS::Game::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 				delete in;
 			}
 		}
@@ -151,7 +151,7 @@ SaveStateDescriptor MADSMetaEngine::querySaveMetaInfos(const char *target, int s
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/mads/nebular/dialogs_nebular.cpp
+++ b/engines/mads/nebular/dialogs_nebular.cpp
@@ -351,7 +351,7 @@ void DialogsNebular::showScummVMSaveDialog() {
 
 	int slot = dialog->runModalWithCurrentTarget();
 	if (slot >= 0) {
-		Common::String desc = dialog->getResultString();
+		Common::U32String desc = dialog->getResultString();
 
 		if (desc.empty()) {
 			// create our own description for the saved game, the user didn't enter it
@@ -363,7 +363,7 @@ void DialogsNebular::showScummVMSaveDialog() {
 		scene._userInterface.noInventoryAnim();
 		game._scene.drawElements(kTransitionFadeIn, false);
 
-		game.saveGame(slot, desc);
+		game.saveGame(slot, desc.encode(Common::kUtf8));
 	}
 
 	// Flag for scene loading that we're returning from a dialog

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -192,7 +192,7 @@ void MetaEngine::parseSavegameHeader(ExtendedSavegameHeader *header, SaveStateDe
 	desc->setSaveTime(hour, minutes);
 	desc->setPlayTime(header->playtime * 1000);
 
-	desc->setDescription(header->description);
+	desc->setDescription(header->description.decode(Common::kUtf8));
 }
 
 void MetaEngine::fillDummyHeader(ExtendedSavegameHeader *header) {

--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -3920,7 +3920,7 @@ bool LBMiniGameItem::togglePlaying(bool playing, bool restart) {
 	else
 		error("Unknown minigame '%s'", _desc.c_str());
 
-	GUI::MessageDialog dialog(Common::String::format("The '%s' minigame is not supported yet.", _desc.c_str()));
+	GUI::MessageDialog dialog(Common::U32String::format("The '%s' minigame is not supported yet.", _desc.c_str()));
 	dialog.runModal();
 
 	// Go back to the menu if requested, otherwise go to the requested page

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -167,7 +167,7 @@ SaveStateList MohawkMetaEngine::listSavesForPrefix(const char *prefix, const cha
 
 		int slotNum = atoi(slot);
 
-		saveList.push_back(SaveStateDescriptor(slotNum, ""));
+		saveList.push_back(SaveStateDescriptor(slotNum, USTR("")));
 	}
 
 	Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
@@ -187,7 +187,7 @@ SaveStateList MohawkMetaEngine::listSaves(const char *target) const {
 		for (SaveStateList::iterator save = saveList.begin(); save != saveList.end(); ++save) {
 			// Read the description from the save
 			int slot = save->getSaveSlot();
-			Common::String description = Mohawk::MystGameState::querySaveDescription(slot);
+			Common::U32String description = Mohawk::MystGameState::querySaveDescription(slot).decode(Common::kUtf8);
 			save->setDescription(description);
 		}
 	}
@@ -199,7 +199,7 @@ SaveStateList MohawkMetaEngine::listSaves(const char *target) const {
 		for (SaveStateList::iterator save = saveList.begin(); save != saveList.end(); ++save) {
 			// Read the description from the save
 			int slot = save->getSaveSlot();
-			Common::String description = Mohawk::RivenSaveLoad::querySaveDescription(slot);
+			Common::U32String description = Mohawk::RivenSaveLoad::querySaveDescription(slot).decode(Common::kUtf8);
 			save->setDescription(description);
 		}
 	}

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -300,7 +300,7 @@ SaveStateDescriptor MystGameState::querySaveMetaInfos(int slot) {
 	}
 
 	// Set the save description
-	desc.setDescription(metadata.saveDescription);
+	desc.setDescription(metadata.saveDescription.decode(Common::kUtf8));
 	desc.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
 	desc.setSaveTime(metadata.saveHour, metadata.saveMinute);
 	desc.setPlayTime(metadata.totalPlayTime);

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -504,7 +504,7 @@ bool MohawkEngine_Riven::checkDatafiles() {
 	}
 
 	const char *msg = _s("You are missing the following required Riven data files:\n");
-	Common::U32String message = _(msg) + Common::U32String(missingFiles);
+	Common::U32String message = _(msg) + missingFiles.decode(Common::kUtf8);
 
 	warning("%s%s", msg, missingFiles.c_str());
 	GUIErrorMessage(message);

--- a/engines/mohawk/riven_saveload.cpp
+++ b/engines/mohawk/riven_saveload.cpp
@@ -136,7 +136,7 @@ SaveStateDescriptor RivenSaveLoad::querySaveMetaInfos(const int slot) {
 	}
 
 	descriptor.setSaveSlot(slot);
-	descriptor.setDescription(metadata.saveDescription);
+	descriptor.setDescription(metadata.saveDescription.decode(Common::kUtf8));
 	descriptor.setPlayTime(metadata.totalPlayTime);
 	descriptor.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
 	descriptor.setSaveTime(metadata.saveHour, metadata.saveMinute);

--- a/engines/mortevielle/saveload.cpp
+++ b/engines/mortevielle/saveload.cpp
@@ -274,7 +274,7 @@ SaveStateList SavegameManager::listSaves(const Common::String &target) {
 
 			if (validFlag)
 				// Got a valid savegame
-				saveList.push_back(SaveStateDescriptor(slotNumber, saveDescription));
+				saveList.push_back(SaveStateDescriptor(slotNumber, Common::U32String(saveDescription, Common::kLatin1)));
 
 			delete in;
 		}
@@ -303,7 +303,7 @@ SaveStateDescriptor SavegameManager::querySaveMetaInfos(const Common::String &fi
 			// Original savegame perhaps?
 			delete f;
 
-			SaveStateDescriptor desc(slot, Common::String::format("Savegame - %03d", slot));
+			SaveStateDescriptor desc(slot, Common::String::format("Savegame - %03d", slot).decode(Common::kLatin1));
 			desc.setDeletableFlag(slot != 0);
 			desc.setWriteProtectedFlag(slot == 0);
 			return desc;
@@ -317,7 +317,7 @@ SaveStateDescriptor SavegameManager::querySaveMetaInfos(const Common::String &fi
 			delete f;
 
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(slot, Common::U32String(header.saveName, Common::kLatin1));
 			desc.setDeletableFlag(true);
 			desc.setWriteProtectedFlag(false);
 			desc.setThumbnail(header.thumbnail);

--- a/engines/mutationofjb/metaengine.cpp
+++ b/engines/mutationofjb/metaengine.cpp
@@ -72,7 +72,7 @@ public:
 
 				MutationOfJB::SaveHeader saveHdr;
 				if (saveHdr.sync(sz)) {
-					saveList.push_back(SaveStateDescriptor(slotNo, saveHdr._description));
+					saveList.push_back(SaveStateDescriptor(slotNo, Common::U32String(saveHdr._description, Common::kLatin1)));
 				}
 			}
 		}

--- a/engines/myst3/menu.cpp
+++ b/engines/myst3/menu.cpp
@@ -31,6 +31,7 @@
 #include "engines/myst3/state.h"
 
 #include "common/events.h"
+#include "common/translation.h"
 
 #include "graphics/colormasks.h"
 
@@ -588,7 +589,7 @@ void PagingMenu::loadMenuLoad() {
 
 	Common::Error loadError = _vm->loadGameState(_saveLoadFiles[index], kTransitionFade);
 	if (loadError.getCode() != Common::kNoError) {
-		GUI::MessageDialog dialog(loadError.getDesc());
+		GUI::MessageDialog dialog(_(loadError.getDesc()));
 		dialog.runModal();
 	}
 }
@@ -648,7 +649,7 @@ void PagingMenu::saveMenuSave() {
 
 	Common::Error saveError = _vm->saveGameState(_saveName, _saveThumbnail.get(), false);
 	if (saveError.getCode() != Common::kNoError) {
-		GUI::MessageDialog dialog(saveError.getDesc());
+		GUI::MessageDialog dialog(_(saveError.getDesc()));
 		dialog.runModal();
 	}
 
@@ -971,7 +972,7 @@ void AlbumMenu::loadMenuLoad() {
 
 	Common::Error loadError = _vm->loadGameState(saveFiles[selectedSave], kTransitionFade);
 	if (loadError.getCode() != Common::kNoError) {
-		GUI::MessageDialog dialog(loadError.getDesc());
+		GUI::MessageDialog dialog(_(loadError.getDesc()));
 		dialog.runModal();
 	}
 }
@@ -1000,7 +1001,7 @@ void AlbumMenu::saveMenuSave() {
 
 	Common::Error saveError = _vm->saveGameState(saveName, _saveThumbnail.get(), false);
 	if (saveError.getCode() != Common::kNoError) {
-		GUI::MessageDialog dialog(saveError.getDesc());
+		GUI::MessageDialog dialog(_(saveError.getDesc()));
 		dialog.runModal();
 	}
 

--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -56,7 +56,7 @@ public:
 
 		SaveStateList saveList;
 		for (uint32 i = 0; i < filenames.size(); i++)
-			saveList.push_back(SaveStateDescriptor(i, filenames[i]));
+			saveList.push_back(SaveStateDescriptor(i, filenames[i].decode(Common::kLatin1)));
 
 		return saveList;
 	}
@@ -83,7 +83,7 @@ public:
 		}
 
 		// Open save
-		Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(saveInfos.getDescription());
+		Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(saveInfos.getDescription().encode(Common::kUtf8));
 		if (!saveFile) {
 			warning("Unable to open file %s for reading, slot %d", saveInfos.getDescription().encode().c_str(), slot);
 			return SaveStateDescriptor();
@@ -110,7 +110,7 @@ public:
 		}
 
 		if (data.saveDescription != "") {
-			saveInfos.setDescription(data.saveDescription);
+			saveInfos.setDescription(data.saveDescription.decode(Common::kUtf8));
 		}
 
 		if (s.getVersion() >= 150) {
@@ -124,7 +124,7 @@ public:
 
 	void removeSaveState(const char *target, int slot) const override {
 		SaveStateDescriptor saveInfos = getSaveDescription(target, slot);
-		g_system->getSavefileManager()->removeSavefile(saveInfos.getDescription());
+		g_system->getSavefileManager()->removeSavefile(saveInfos.getDescription().encode(Common::kUtf8));
 	}
 
 	int getMaximumSaveSlot() const override {

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1572,7 +1572,7 @@ Common::Error Myst3Engine::saveGameState(int slot, const Common::String &desc, b
 	assert(!desc.empty());
 
 	if (!isValidSaveFileName(desc)) {
-		return Common::Error(Common::kCreatingFileFailed, _("Invalid file name for saving"));
+		return Common::Error(Common::kCreatingFileFailed, _s("Invalid file name for saving"));
 	}
 
 	// Try to use an already generated thumbnail

--- a/engines/neverhood/menumodule.cpp
+++ b/engines/neverhood/menumodule.cpp
@@ -883,7 +883,7 @@ void SavegameListBox::pageDown() {
 
 int GameStateMenu::scummVMSaveLoadDialog(bool isSave, Common::String &saveDesc) {
 	GUI::SaveLoadChooser *dialog;
-	Common::String desc;
+	Common::U32String desc;
 	int slot;
 
 	if (isSave) {
@@ -896,9 +896,9 @@ int GameStateMenu::scummVMSaveLoadDialog(bool isSave, Common::String &saveDesc) 
 			desc = dialog->createDefaultSaveDescription(slot);
 
 		if (desc.size() > 29)
-			desc = Common::String(desc.c_str(), 29);
+			desc = desc.substr(0, 29);
 
-		saveDesc = desc;
+		saveDesc = desc.encode(Common::kUtf8);
 	} else {
 		dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
 		slot = dialog->runModalWithCurrentTarget();

--- a/engines/neverhood/metaengine.cpp
+++ b/engines/neverhood/metaengine.cpp
@@ -112,7 +112,7 @@ SaveStateList NeverhoodMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Neverhood::NeverhoodEngine::readSaveHeader(in, header) == Neverhood::NeverhoodEngine::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.description, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -146,7 +146,7 @@ SaveStateDescriptor NeverhoodMetaEngine::querySaveMetaInfos(const char *target, 
 		delete in;
 
 		if (error == Neverhood::NeverhoodEngine::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(slot, Common::U32String(header.description, Common::kLatin1));
 
 			desc.setDeletableFlag(false);
 			desc.setWriteProtectedFlag(false);

--- a/engines/ngi/modal.cpp
+++ b/engines/ngi/modal.cpp
@@ -2153,7 +2153,7 @@ bool ModalSaveGame::getFileInfo(int slot, FileInfo *fileinfo) {
 		return false;
 
 	// Create the return descriptor
-	SaveStateDescriptor desc(slot, header.saveName);
+	SaveStateDescriptor desc(slot, Common::U32String(header.saveName, Common::kLatin1));
 	char res[17];
 
 	NGI::parseSavegameHeader(header, desc);

--- a/engines/ngi/stateloader.cpp
+++ b/engines/ngi/stateloader.cpp
@@ -182,7 +182,7 @@ void parseSavegameHeader(NGI::FullpipeSavegameHeader &header, SaveStateDescripto
 	desc.setSaveTime(hour, minutes);
 	desc.setPlayTime(header.playtime * 1000);
 
-	desc.setDescription(header.description);
+	desc.setDescription(header.description.decode(Common::kUtf8));
 }
 
 void fillDummyHeader(NGI::FullpipeSavegameHeader &header) {

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -96,7 +96,7 @@ SaveStateList ParallactionMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				Common::String saveDesc = in->readLine();
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveDesc, Common::kLatin1)));
 				delete in;
 			}
 		}

--- a/engines/parallaction/saveload.cpp
+++ b/engines/parallaction/saveload.cpp
@@ -183,7 +183,7 @@ int SaveLoad::selectSaveFile(Common::String &selectedName, bool saveMode, const 
 
 	int idx = slc.runModalWithCurrentTarget();
 	if (idx >= 0) {
-		selectedName = slc.getResultString();
+		selectedName = slc.getResultString().legacyEncode();
 	}
 
 	return idx;

--- a/engines/pegasus/metaengine.cpp
+++ b/engines/pegasus/metaengine.cpp
@@ -96,7 +96,7 @@ SaveStateList PegasusMetaEngine::listSaves(const char *target) const {
 		for (int j = 0; j < 4; j++)
 			desc.deleteLastChar();
 
-		saveList.push_back(SaveStateDescriptor(i, desc));
+		saveList.push_back(SaveStateDescriptor(i, Common::U32String(desc, Common::kLatin1)));
 	}
 
 	return saveList;

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -698,7 +698,7 @@ static bool isValidSaveFileName(const Common::String &desc) {
 
 Common::Error PegasusEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	if (!isValidSaveFileName(desc))
-		return Common::Error(Common::kCreatingFileFailed, _("Invalid file name for saving"));
+		return Common::Error(Common::kCreatingFileFailed, _s("Invalid file name for saving"));
 
 	Common::String output = Common::String::format("pegasus-%s.sav", desc.c_str());
 	Common::OutSaveFile *saveFile = _saveFileMan->openForSaving(output, false);

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -151,7 +151,7 @@ Common::Error PegasusEngine::run() {
 		message += "Be sure to rename \"Opening/Closing\" to \"Opening_Closing\".";
 #endif
 
-		GUIErrorMessage(message);
+		GUIErrorMessage(message.decode(Common::kLatin1));
 		warning("%s", message.c_str());
 		return Common::kNoGameDataFoundError;
 	}
@@ -376,7 +376,7 @@ Common::Error PegasusEngine::showSaveDialog() {
 	int slot = slc.runModalWithCurrentTarget();
 
 	if (slot >= 0)
-		return saveGameState(slot, slc.getResultString());
+		return saveGameState(slot, slc.getResultString().encode(Common::kUtf8));
 
 	return Common::kUserCanceled;
 }

--- a/engines/petka/saveload.cpp
+++ b/engines/petka/saveload.cpp
@@ -133,7 +133,7 @@ bool readSaveHeader(Common::InSaveFile &in, SaveStateDescriptor &desc, bool skip
 	desc.setSaveDate(year, month, day);
 	desc.setSaveTime(hour, minutes);
 	desc.setPlayTime(playTime * 1000);
-	desc.setDescription(description);
+	desc.setDescription(description.decode(Common::kUtf8));
 	desc.setThumbnail(thumbnail);
 
 	return true;

--- a/engines/pink/objects/actions/action_text.cpp
+++ b/engines/pink/objects/actions/action_text.cpp
@@ -85,13 +85,15 @@ void ActionText::start() {
 	stream->read(str, stream->size());
 	delete stream;
 
+	Common::CodePage codePage;
+
 	switch(_actor->getPage()->getGame()->getLanguage()) {
 	case Common::RU_RUS:
-		_text = Common::String(str).decode(Common::kWindows1251);
+		codePage = Common::kWindows1251;
 		break;
 
 	case Common::HE_ISR:
-		_text = Common::String(str).decode(Common::kWindows1255);
+		codePage = Common::kWindows1255;
 		if (!_centered) {
 			align = Graphics::kTextAlignRight;
 		}
@@ -99,9 +101,11 @@ void ActionText::start() {
 
 	case Common::EN_ANY:
 	default:
-		_text = Common::String(str);
+		codePage = Common::kLatin1;
 		break;
 	}
+
+	_text = Common::U32String(str, codePage);
 
 	delete[] str;
 

--- a/engines/pink/saveload.cpp
+++ b/engines/pink/saveload.cpp
@@ -109,7 +109,7 @@ WARN_UNUSED_RESULT bool readSaveHeader(Common::InSaveFile &in, SaveStateDescript
 	desc.setSaveDate(year, month, day);
 	desc.setSaveTime(hour, minutes);
 	desc.setPlayTime(playTime * 1000);
-	desc.setDescription(description);
+	desc.setDescription(description.decode(Common::kUtf8));
 	desc.setThumbnail(thumbnail);
 
 	return true;

--- a/engines/prince/metaengine.cpp
+++ b/engines/prince/metaengine.cpp
@@ -104,11 +104,11 @@ SaveStateList PrinceMetaEngine::listSaves(const char *target) const {
 				if (!strncmp(buffer, kSavegameStr, kSavegameStrSize + 1)) {
 					// Valid savegame
 					if (Prince::PrinceEngine::readSavegameHeader(file, header)) {
-						saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+						saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.saveName, Common::kLatin1)));
 					}
 				} else {
 					// Must be an original format savegame
-					saveList.push_back(SaveStateDescriptor(slotNum, "Unknown"));
+					saveList.push_back(SaveStateDescriptor(slotNum, USTR("Unknown")));
 				}
 
 				delete file;
@@ -137,11 +137,11 @@ SaveStateDescriptor PrinceMetaEngine::querySaveMetaInfos(const char *target, int
 
 		if (!hasHeader) {
 			// Original savegame perhaps?
-			SaveStateDescriptor desc(slot, "Unknown");
+			SaveStateDescriptor desc(slot, USTR("Unknown"));
 			return desc;
 		} else {
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(slot, Common::U32String(header.saveName, Common::kLatin1));
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveYear, header.saveMonth, header.saveDay);
 			desc.setSaveTime(header.saveHour, header.saveMinutes);

--- a/engines/prince/saveload.cpp
+++ b/engines/prince/saveload.cpp
@@ -48,7 +48,7 @@ class Interpreter;
 
 bool PrinceEngine::scummVMSaveLoadDialog(bool isSave) {
 	GUI::SaveLoadChooser *dialog;
-	Common::String desc;
+	Common::U32String desc;
 	int slot;
 
 	if (isSave) {
@@ -71,7 +71,7 @@ bool PrinceEngine::scummVMSaveLoadDialog(bool isSave) {
 		return false;
 
 	if (isSave) {
-		return saveGameState(slot, desc).getCode() == Common::kNoError;
+		return saveGameState(slot, desc.legacyEncode()).getCode() == Common::kNoError;
 	} else {
 		return loadGameState(slot).getCode() == Common::kNoError;
 	}

--- a/engines/queen/metaengine.cpp
+++ b/engines/queen/metaengine.cpp
@@ -69,7 +69,7 @@ SaveStateList QueenMetaEngine::listSaves(const char *target) const {
 				for (int i = 0; i < 4; i++)
 					in->readUint32BE();
 				in->read(saveDesc, 32);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveDesc, Common::kLatin1)));
 				delete in;
 			}
 		}

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -149,7 +149,7 @@ SaveStateList SagaMetaEngine::listSaves(const char *target) const {
 				for (int i = 0; i < 3; i++)
 					in->readUint32BE();
 				in->read(saveDesc, SAVE_TITLE_SIZE);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveDesc, Common::kLatin1)));
 				delete in;
 			}
 		}
@@ -183,7 +183,7 @@ SaveStateDescriptor SagaMetaEngine::querySaveMetaInfos(const char *target, int s
 		char name[SAVE_TITLE_SIZE];
 		in->read(name, sizeof(name));
 
-		SaveStateDescriptor desc(slot, name);
+		SaveStateDescriptor desc(slot, Common::U32String(name, Common::kLatin1));
 
 		// Some older saves were not written in an endian safe fashion.
 		// We try to detect this here by checking for extremely high version values.

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -38,12 +38,6 @@ SaveStateDescriptor::SaveStateDescriptor(int s, const Common::U32String &d)
 	_thumbnail(), _saveType(kSaveTypeUndetermined) {
 }
 
-SaveStateDescriptor::SaveStateDescriptor(int s, const Common::String &d)
-	: _slot(s), _description(Common::U32String(d)), _isDeletable(true), _isWriteProtected(false),
-	_isLocked(false), _saveDate(), _saveTime(), _playTime(), _playTimeMSecs(0),
-	_thumbnail(), _saveType(kSaveTypeUndetermined) {
-}
-
 void SaveStateDescriptor::setThumbnail(Graphics::Surface *t) {
 	if (_thumbnail.get() == t)
 		return;

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -62,7 +62,6 @@ private:
 public:
 	SaveStateDescriptor();
 	SaveStateDescriptor(int s, const Common::U32String &d);
-	SaveStateDescriptor(int s, const Common::String &d);
 
 	/**
 	 * @param slot The saveslot id, as it would be passed to the "-x" command line switch.
@@ -77,7 +76,6 @@ public:
 	/**
 	 * @param desc A human readable description of the save state.
 	 */
-	void setDescription(const Common::String &desc) { _description = desc.decode(); }
 	void setDescription(const Common::U32String &desc) { _description = desc; }
 
 	/**

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -367,11 +367,11 @@ OptionsWidget::OptionsWidget(GuiObject *boss, const Common::String &name, const 
 
 	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
 		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
-			_checkboxes[entry->option.configOption] = new GUI::CheckboxWidget(widgetsBoss(), _dialogLayout + "." + entry->option.configOption, Common::U32String(entry->option.label), Common::U32String(entry->option.tooltip));
+			_checkboxes[entry->option.configOption] = new GUI::CheckboxWidget(widgetsBoss(), _dialogLayout + "." + entry->option.configOption, Common::U32String(entry->option.label, Common::kLatin1), Common::U32String(entry->option.tooltip, Common::kLatin1));
 
 	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
 		if (checkGameGUIOption(entry->guioFlag, _guiOptions)) {
-			GUI::StaticTextWidget *textWidget = new GUI::StaticTextWidget(widgetsBoss(), _dialogLayout + "." + entry->configOption + "_desc", Common::U32String(entry->label), Common::U32String(entry->tooltip));
+			GUI::StaticTextWidget *textWidget = new GUI::StaticTextWidget(widgetsBoss(), _dialogLayout + "." + entry->configOption + "_desc", Common::U32String(entry->label, Common::kLatin1), Common::U32String(entry->tooltip, Common::kLatin1));
 			textWidget->setAlign(Graphics::kTextAlignRight);
 
 			_popUps[entry->configOption] = new GUI::PopUpWidget(widgetsBoss(), _dialogLayout + "." + entry->configOption);

--- a/engines/sci/engine/guest_additions.cpp
+++ b/engines/sci/engine/guest_additions.cpp
@@ -705,9 +705,9 @@ int GuestAdditions::runSaveRestore(const bool isSave, Common::String &outDescrip
 		GUI::SaveLoadChooser dialog(title, action, isSave);
 		saveId = dialog.runModalWithCurrentTarget();
 		if (saveId != -1) {
-			outDescription = dialog.getResultString();
+			outDescription = dialog.getResultString().legacyEncode();
 			if (outDescription.empty()) {
-				outDescription = dialog.createDefaultSaveDescription(saveId - 1);
+				outDescription = dialog.createDefaultSaveDescription(saveId - 1).legacyEncode();
 			}
 		}
 	}

--- a/engines/sci/engine/kfile.cpp
+++ b/engines/sci/engine/kfile.cpp
@@ -482,7 +482,7 @@ reg_t kFileIOOpen(EngineState *s, int argc, reg_t *argv) {
 				if (out) {
 					Common::String saveName;
 					if (saveNo == kAutoSaveId) {
-						saveName = _("(Autosave)");
+						saveName = _("(Autosave)").legacyEncode();
 					} else {
 						saveName = getRamaSaveName(s, saveNo - kSaveIdShift);
 					}
@@ -1074,10 +1074,10 @@ reg_t kSaveGame(EngineState *s, int argc, reg_t *argv) {
 		g_sci->_soundCmd->pauseAll(true); // pause music
 		GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 		savegameId = dialog->runModalWithCurrentTarget();
-		game_description = dialog->getResultString();
+		game_description = dialog->getResultString().legacyEncode();
 		if (game_description.empty()) {
 			// create our own description for the saved game, the user didn't enter it
-			game_description = dialog->createDefaultSaveDescription(savegameId);
+			game_description = dialog->createDefaultSaveDescription(savegameId).legacyEncode();
 		}
 		delete dialog;
 		g_sci->_soundCmd->pauseAll(false); // unpause music (we can't have it paused during save)

--- a/engines/sci/engine/kmisc.cpp
+++ b/engines/sci/engine/kmisc.cpp
@@ -898,7 +898,7 @@ reg_t kWinDLL(EngineState *s, int argc, reg_t *argv) {
 reg_t kKawaHacks(EngineState *s, int argc, reg_t *argv) {
 	switch (argv[0].toUint16()) {
 	case 0: { // DoAlert
-		showScummVMDialog(s->_segMan->getString(argv[1]));
+		showScummVMDialog(s->_segMan->getString(argv[1]).decode(Common::kLatin1));
 		return NULL_REG;
 	}
 	case 1: { // ZaWarudo

--- a/engines/sci/graphics/controls32.cpp
+++ b/engines/sci/graphics/controls32.cpp
@@ -922,10 +922,10 @@ reg_t GfxControls32::kernelMessageBox(const Common::String &message, const Commo
 
 	switch (style & 0xF) {
 	case kMessageBoxOK:
-		result = showMessageBox(message, _("OK"), Common::U32String(), 1, 1);
+		result = showMessageBox(message.decode(Common::kLatin1), _("OK"), Common::U32String(), 1, 1);
 	break;
 	case kMessageBoxYesNo:
-		result = showMessageBox(message, _("Yes"), _("No"), 6, 7);
+		result = showMessageBox(message.decode(Common::kLatin1), _("Yes"), _("No"), 6, 7);
 	break;
 	default:
 		error("Unsupported MessageBox style 0x%x", style & 0xF);

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -383,7 +383,7 @@ SaveStateList SciMetaEngine::listSaves(const char *target) const {
 					delete in;
 					continue;
 				}
-				SaveStateDescriptor descriptor(slotNr, meta.name);
+				SaveStateDescriptor descriptor(slotNr, Common::U32String(meta.name, Common::kLatin1));
 
 				if (slotNr == 0) {
 					// ScummVM auto-save slot
@@ -413,7 +413,7 @@ SaveStateList SciMetaEngine::listSaves(const char *target) const {
 SaveStateDescriptor SciMetaEngine::querySaveMetaInfos(const char *target, int slotNr) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slotNr);
 	Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(fileName);
-	SaveStateDescriptor descriptor(slotNr, "");
+	SaveStateDescriptor descriptor(slotNr, USTR(""));
 
 	if (slotNr == 0) {
 		// ScummVM auto-save slot
@@ -431,18 +431,18 @@ SaveStateDescriptor SciMetaEngine::querySaveMetaInfos(const char *target, int sl
 			// invalid
 			delete in;
 
-			descriptor.setDescription("*Invalid*");
+			descriptor.setDescription(USTR("*Invalid*"));
 			return descriptor;
 		}
 
-		descriptor.setDescription(meta.name);
+		descriptor.setDescription(meta.name.decode(Common::kLatin1));
 
 		Graphics::Surface *thumbnail;
 		if (!Graphics::loadThumbnail(*in, thumbnail)) {
 			// invalid
 			delete in;
 
-			descriptor.setDescription("*Invalid*");
+			descriptor.setDescription(USTR("*Invalid*"));
 			return descriptor;
 		}
 		descriptor.setThumbnail(thumbnail);

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -519,21 +519,21 @@ void SciEngine::suggestDownloadGK2SubTitlesPatch() {
 		downloadMessage = _("(or click 'Download patch' button. But note - it only downloads, you will have to continue from there)\n");
 	}
 	else {
-		altButton = "";
-		downloadMessage = "";
+		altButton = USTR("");
+		downloadMessage = USTR("");
 	}
 
 	int result = showScummVMDialog(_("GK2 has a fan made subtitles, available thanks to the good persons at SierraHelp.\n\n"
-		"Installation:\n"
-		"- download http://www.sierrahelp.com/Files/Patches/GabrielKnight/GK2Subtitles.zip\n" +
-		downloadMessage +
-		"- extract zip file\n"
-		"- no need to run the .exe file\n"
-		"- extract the .exe file with a file archiver, like 7-zip\n"
-		"- create a PATCHES subdirectory inside your GK2 directory\n"
-		"- copy the content of GK2Subtitles\\SUBPATCH to the PATCHES subdirectory\n"
-		"- replace files with similar names\n"
-		"- restart the game\n"), altButton, false);
+					 "Installation:\n"
+					 "- download http://www.sierrahelp.com/Files/Patches/GabrielKnight/GK2Subtitles.zip\n") +
+				       downloadMessage +
+				       _("- extract zip file\n"
+					 "- no need to run the .exe file\n"
+					 "- extract the .exe file with a file archiver, like 7-zip\n"
+					 "- create a PATCHES subdirectory inside your GK2 directory\n"
+					 "- copy the content of GK2Subtitles\\SUBPATCH to the PATCHES subdirectory\n"
+					 "- replace files with similar names\n"
+					 "- restart the game\n"), altButton, false);
 	if (!result) {
 		char url[] = "http://www.sierrahelp.com/Files/Patches/GabrielKnight/GK2Subtitles.zip";
 		g_system->openUrl(url);

--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -160,7 +160,7 @@ void SciMusic::init() {
 				Common::U32String message = _(
 					"The selected audio driver requires the following file(s):\n\n"
 				);
-				message += Common::U32String(missingFiles);
+				message += Common::U32String(missingFiles, Common::kUtf8);
 				message += _("\n\n"
 					"Some audio drivers (at least for some games) were made\n"
 					"available by Sierra as aftermarket patches and thus might not\n"

--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -431,7 +431,7 @@ const Common::U32String InfoDialog::queryResString(int stringno) {
 	const byte *result;
 
 	if (stringno == 0)
-		return String();
+		return Common::U32String();
 
 	if (_vm->_game.heversion >= 80)
 		return _(string_map_table_v6[stringno - 1].string);
@@ -635,7 +635,7 @@ void SubtitleSettingsDialog::cycleValue() {
 }
 
 Indy3IQPointsDialog::Indy3IQPointsDialog(ScummEngine *scumm, char* text)
-	: InfoDialog(scumm, Common::U32String(text)) {
+	: InfoDialog(scumm, Common::U32String(text, Common::kLatin1)) {
 }
 
 void Indy3IQPointsDialog::handleKeyDown(Common::KeyState state) {
@@ -646,7 +646,7 @@ void Indy3IQPointsDialog::handleKeyDown(Common::KeyState state) {
 }
 
 DebugInputDialog::DebugInputDialog(ScummEngine *scumm, char* text)
-	: InfoDialog(scumm, U32String(text)) {
+	: InfoDialog(scumm, U32String(text, Common::kLatin1)) {
 	mainText = text;
 	done = 0;
 }
@@ -655,7 +655,7 @@ void DebugInputDialog::handleKeyDown(Common::KeyState state) {
 	if (state.keycode == Common::KEYCODE_BACKSPACE && buffer.size() > 0) {
 		buffer.deleteLastChar();
 		Common::String total = mainText + ' ' + buffer;
-		setInfoText(total);
+		setInfoText(total.decode(Common::kLatin1));
 		g_gui.scheduleTopDialogRedraw();
 		reflowLayout();
 	} else if (state.keycode == Common::KEYCODE_RETURN) {
@@ -667,7 +667,7 @@ void DebugInputDialog::handleKeyDown(Common::KeyState state) {
 		Common::String total = mainText + ' ' + buffer;
 		g_gui.scheduleTopDialogRedraw();
 		reflowLayout();
-		setInfoText(total);
+		setInfoText(total.decode(Common::kLatin1));
 	}
 }
 

--- a/engines/scumm/he/moonbase/net_main.cpp
+++ b/engines/scumm/he/moonbase/net_main.cpp
@@ -61,12 +61,12 @@ int Net::hostGame(char *sessionName, char *userName) {
 		if (addUser(userName, userName)) {
 			return 1;
 		} else {
-			_vm->displayMessage(0, "Error Adding User \"%s\" to Session \"%s\"", userName, sessionName);
+			_vm->displayMessage(Common::U32String(), Common::U32String::format("Error Adding User \"%s\" to Session \"%s\"", userName, sessionName));
 			endSession();
 			closeProvider();
 		}
 	} else {
-		_vm->displayMessage(0, "Error creating session \"%s\"", userName );
+		_vm->displayMessage(Common::U32String(), Common::U32String::format("Error creating session \"%s\"", userName) );
 
 		closeProvider();
 	}

--- a/engines/scumm/help.cpp
+++ b/engines/scumm/help.cpp
@@ -60,8 +60,8 @@ int ScummHelp::numPages(byte gameId) {
 }
 
 #define ADD_BIND(k,d) do { key[i] = k; dsc[i] = d; i++; } while (0)
-#define ADD_TEXT(d) ADD_BIND("",d)
-#define ADD_LINE ADD_BIND("","")
+#define ADD_TEXT(d) ADD_BIND(USTR(""),d)
+#define ADD_LINE ADD_BIND(USTR(""),USTR(""))
 
 void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platform,
 				int page, U32String &title, U32String *&key, U32String *&dsc) {
@@ -71,35 +71,35 @@ void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platfo
 	switch (page) {
 	case 1:
 		title = _("Common keyboard commands:");
-		ADD_BIND("F5", _("Save / Load dialog"));
+		ADD_BIND(USTR("F5"), _("Save / Load dialog"));
 		if (version >= 5)
-			ADD_BIND(".", _("Skip line of text"));
+			ADD_BIND(USTR("."), _("Skip line of text"));
 		ADD_BIND(_("Esc"), _("Skip cutscene"));
 		ADD_BIND(_("Space"), _("Pause game"));
-		ADD_BIND(_("Ctrl") + U32String(" 0-9"), _("Load saved game 1-10"));
-		ADD_BIND(_("Alt") + U32String(" 0-9"), _("Save game 1-10"));
+		ADD_BIND(_("Ctrl") + USTR(" 0-9"), _("Load saved game 1-10"));
+		ADD_BIND(_("Alt") + USTR(" 0-9"), _("Save game 1-10"));
 #ifdef MACOSX
-		ADD_BIND("Cmd q", _("Quit"));
+		ADD_BIND(USTR("Cmd q"), _("Quit"));
 #else
-		ADD_BIND(_("Alt") + U32String(" x, ") + _("Ctrl") + U32String(" z"), _("Quit"));
+		ADD_BIND(_("Alt") + USTR(" x, ") + _("Ctrl") + USTR(" z"), _("Quit"));
 #endif
-		ADD_BIND(_("Alt") + U32String(" ") + _("Enter"), _("Toggle fullscreen"));
-		ADD_BIND("[, ]", _("Music volume up / down"));
-		ADD_BIND("-, +", _("Text speed slower / faster"));
+		ADD_BIND(_("Alt") + USTR(" ") + _("Enter"), _("Toggle fullscreen"));
+		ADD_BIND(USTR("[, ]"), _("Music volume up / down"));
+		ADD_BIND(USTR("-, +"), _("Text speed slower / faster"));
 		ADD_BIND(_("Enter"), _("Simulate left mouse button"));
 		ADD_BIND(_("Tab"), _("Simulate right mouse button"));
 		break;
 	case 2:
 		title = _("Special keyboard commands:");
-		ADD_BIND("~, #", _("Show / Hide console"));
-		ADD_BIND(_("Ctrl") + U32String(" d"), _("Start the debugger"));
-		ADD_BIND(_("Ctrl") + U32String(" s"), _("Show memory consumption"));
-		ADD_BIND(_("Ctrl") + U32String(" f"), _("Run in fast mode (*)"));
-		ADD_BIND(_("Ctrl") + U32String(" g"), _("Run in really fast mode (*)"));
-		ADD_BIND(_("Ctrl") + U32String(" m"), _("Toggle mouse capture"));
-		ADD_BIND(_("Ctrl") + U32String(" ") + _("Alt") + U32String(" 1-8"), _("Switch between graphics filters"));
-		ADD_BIND(_("Ctrl") + U32String(" ") + _("Alt") + U32String(" +, -"), _("Increase / Decrease scale factor"));
-		ADD_BIND(_("Ctrl") + U32String(" ") + _("Alt") + U32String(" a"), _("Toggle aspect-ratio correction"));
+		ADD_BIND(USTR("~, #"), _("Show / Hide console"));
+		ADD_BIND(_("Ctrl") + USTR(" d"), _("Start the debugger"));
+		ADD_BIND(_("Ctrl") + USTR(" s"), _("Show memory consumption"));
+		ADD_BIND(_("Ctrl") + USTR(" f"), _("Run in fast mode (*)"));
+		ADD_BIND(_("Ctrl") + USTR(" g"), _("Run in really fast mode (*)"));
+		ADD_BIND(_("Ctrl") + USTR(" m"), _("Toggle mouse capture"));
+		ADD_BIND(_("Ctrl") + USTR(" ") + _("Alt") + USTR(" 1-8"), _("Switch between graphics filters"));
+		ADD_BIND(_("Ctrl") + USTR(" ") + _("Alt") + USTR(" +, -"), _("Increase / Decrease scale factor"));
+		ADD_BIND(_("Ctrl") + USTR(" ") + _("Alt") + USTR(" a"), _("Toggle aspect-ratio correction"));
 		ADD_LINE;
 		ADD_LINE;
 		// FIXME: This should use word-wrapping, and should not assume
@@ -118,136 +118,136 @@ void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platfo
 		case GID_ZAK:
 		case GID_MANIAC:
 			if (platform == Common::kPlatformNES) {
-				ADD_BIND("q", _("Push"));
-				ADD_BIND("a", _("Pull"));
-				ADD_BIND("z", _("Give"));
-				ADD_BIND("w", _("Open"));
-				ADD_BIND("s", _("Close"));
-				ADD_BIND("x", _("Go to"));
-				ADD_BIND("e", _("Get"));
-				ADD_BIND("d", _("Use"));
-				ADD_BIND("c", _("Read"));
-				ADD_BIND("r", _("New kid"));
-				ADD_BIND("f", _("Turn on"));
-				ADD_BIND("v", _("Turn off"));
+				ADD_BIND(USTR("q"), _("Push"));
+				ADD_BIND(USTR("a"), _("Pull"));
+				ADD_BIND(USTR("z"), _("Give"));
+				ADD_BIND(USTR("w"), _("Open"));
+				ADD_BIND(USTR("s"), _("Close"));
+				ADD_BIND(USTR("x"), _("Go to"));
+				ADD_BIND(USTR("e"), _("Get"));
+				ADD_BIND(USTR("d"), _("Use"));
+				ADD_BIND(USTR("c"), _("Read"));
+				ADD_BIND(USTR("r"), _("New kid"));
+				ADD_BIND(USTR("f"), _("Turn on"));
+				ADD_BIND(USTR("v"), _("Turn off"));
 				break;
 			}
 
-			ADD_BIND("q", _("Push"));
-			ADD_BIND("a", _("Pull"));
-			ADD_BIND("z", _("Give"));
-			ADD_BIND("w", _("Open"));
-			ADD_BIND("s", _("Close"));
-			ADD_BIND("x", _("Read"));
-			ADD_BIND("e", _("Walk to"));
-			ADD_BIND("d", _("Pick up"));
-			ADD_BIND("c", _("What is"));
+			ADD_BIND(USTR("q"), _("Push"));
+			ADD_BIND(USTR("a"), _("Pull"));
+			ADD_BIND(USTR("z"), _("Give"));
+			ADD_BIND(USTR("w"), _("Open"));
+			ADD_BIND(USTR("s"), _("Close"));
+			ADD_BIND(USTR("x"), _("Read"));
+			ADD_BIND(USTR("e"), _("Walk to"));
+			ADD_BIND(USTR("d"), _("Pick up"));
+			ADD_BIND(USTR("c"), _("What is"));
 			if (gameId == GID_MANIAC) {
-				ADD_BIND("r", _("Unlock"));
-				ADD_BIND("f", _("New kid"));
+				ADD_BIND(USTR("r"), _("Unlock"));
+				ADD_BIND(USTR("f"), _("New kid"));
 			} else {
-				ADD_BIND("r", _("Put on"));
-				ADD_BIND("f", _("Take off"));
+				ADD_BIND(USTR("r"), _("Put on"));
+				ADD_BIND(USTR("f"), _("Take off"));
 			}
-			ADD_BIND("v", _("Use"));
-			ADD_BIND("t", _("Turn on"));
-			ADD_BIND("g", _("Turn off"));
+			ADD_BIND(USTR("v"), _("Use"));
+			ADD_BIND(USTR("t"), _("Turn on"));
+			ADD_BIND(USTR("g"), _("Turn off"));
 			if (gameId == GID_MANIAC)
-				ADD_BIND("b", _("Fix"));
+				ADD_BIND(USTR("b"), _("Fix"));
 			else
-				ADD_BIND("b", _("Switch"));
+				ADD_BIND(USTR("b"), _("Switch"));
 			break;
 		case GID_INDY3:
-			ADD_BIND("q", _("Push"));
-			ADD_BIND("a", _("Pull"));
-			ADD_BIND("z", _("Give"));
-			ADD_BIND("w", _("Open"));
-			ADD_BIND("s", _("Close"));
-			ADD_BIND("x", _("Look"));
-			ADD_BIND("e", _("Walk to"));
-			ADD_BIND("d", _("Pick up"));
-			ADD_BIND("c", _("What is"));
-			ADD_BIND("r", _("Use"));
-			ADD_BIND("f", _("Turn on"));
-			ADD_BIND("v", _("Turn off"));
-			ADD_BIND("t", _("Talk"));
-			ADD_BIND("g", _("Travel"));
-			ADD_BIND("b", _("To Henry / To Indy"));
+			ADD_BIND(USTR("q"), _("Push"));
+			ADD_BIND(USTR("a"), _("Pull"));
+			ADD_BIND(USTR("z"), _("Give"));
+			ADD_BIND(USTR("w"), _("Open"));
+			ADD_BIND(USTR("s"), _("Close"));
+			ADD_BIND(USTR("x"), _("Look"));
+			ADD_BIND(USTR("e"), _("Walk to"));
+			ADD_BIND(USTR("d"), _("Pick up"));
+			ADD_BIND(USTR("c"), _("What is"));
+			ADD_BIND(USTR("r"), _("Use"));
+			ADD_BIND(USTR("f"), _("Turn on"));
+			ADD_BIND(USTR("v"), _("Turn off"));
+			ADD_BIND(USTR("t"), _("Talk"));
+			ADD_BIND(USTR("g"), _("Travel"));
+			ADD_BIND(USTR("b"), _("To Henry / To Indy"));
 			break;
 		case GID_LOOM:
 			// I18N: These are different musical notes
-			ADD_BIND("q, c", _("play C minor on distaff"));
-			ADD_BIND("w, d", _("play D on distaff"));
-			ADD_BIND("e, e", _("play E on distaff"));
-			ADD_BIND("r, f", _("play F on distaff"));
-			ADD_BIND("t, g", _("play G on distaff"));
-			ADD_BIND("y, a", _("play A on distaff"));
-			ADD_BIND("u, b", _("play B on distaff"));
-			ADD_BIND("i, C", _("play C major on distaff"));
+			ADD_BIND(USTR("q, c"), _("play C minor on distaff"));
+			ADD_BIND(USTR("w, d"), _("play D on distaff"));
+			ADD_BIND(USTR("e, e"), _("play E on distaff"));
+			ADD_BIND(USTR("r, f"), _("play F on distaff"));
+			ADD_BIND(USTR("t, g"), _("play G on distaff"));
+			ADD_BIND(USTR("y, a"), _("play A on distaff"));
+			ADD_BIND(USTR("u, b"), _("play B on distaff"));
+			ADD_BIND(USTR("i, C"), _("play C major on distaff"));
 			break;
 		case GID_MONKEY_EGA:
 		case GID_MONKEY_VGA:
-			ADD_BIND("o", _("Open"));
-			ADD_BIND("c", _("Close"));
-			ADD_BIND("s", _("puSh"));
-			ADD_BIND("y", _("pull (Yank)"));
-			ADD_BIND("w", _("Walk to"));
-			ADD_BIND("p", _("Pick up"));
-			ADD_BIND("t", _("Talk to"));
-			ADD_BIND("g", _("Give"));
-			ADD_BIND("u", _("Use"));
-			ADD_BIND("l", _("Look at"));
-			ADD_BIND("n", _("turn oN"));
-			ADD_BIND("f", _("turn oFf"));
+			ADD_BIND(USTR("o"), _("Open"));
+			ADD_BIND(USTR("c"), _("Close"));
+			ADD_BIND(USTR("s"), _("puSh"));
+			ADD_BIND(USTR("y"), _("pull (Yank)"));
+			ADD_BIND(USTR("w"), _("Walk to"));
+			ADD_BIND(USTR("p"), _("Pick up"));
+			ADD_BIND(USTR("t"), _("Talk to"));
+			ADD_BIND(USTR("g"), _("Give"));
+			ADD_BIND(USTR("u"), _("Use"));
+			ADD_BIND(USTR("l"), _("Look at"));
+			ADD_BIND(USTR("n"), _("turn oN"));
+			ADD_BIND(USTR("f"), _("turn oFf"));
 			break;
 		case GID_MONKEY:
 		case GID_MONKEY2:
 		case GID_INDY4:
 		case GID_TENTACLE:
-			ADD_BIND("g", _("Give"));
-			ADD_BIND("o", _("Open"));
-			ADD_BIND("c", _("Close"));
-			ADD_BIND("p", _("Pick up"));
-			ADD_BIND("l", _("Look at"));
-			ADD_BIND("t", _("Talk to"));
-			ADD_BIND("u", _("Use"));
-			ADD_BIND("s", _("puSh"));
-			ADD_BIND("y", _("pull (Yank)"));
+			ADD_BIND(USTR("g"), _("Give"));
+			ADD_BIND(USTR("o"), _("Open"));
+			ADD_BIND(USTR("c"), _("Close"));
+			ADD_BIND(USTR("p"), _("Pick up"));
+			ADD_BIND(USTR("l"), _("Look at"));
+			ADD_BIND(USTR("t"), _("Talk to"));
+			ADD_BIND(USTR("u"), _("Use"));
+			ADD_BIND(USTR("s"), _("puSh"));
+			ADD_BIND(USTR("y"), _("pull (Yank)"));
 			if (platform == Common::kPlatformSegaCD) {
 				ADD_BIND(_("KeyUp"), _("Highlight prev dialogue"));
 				ADD_BIND(_("KeyDown"), _("Highlight next dialogue"));
 			}
 			break;
 		case GID_SAMNMAX:
-			ADD_BIND("w", _("Walk"));
-			ADD_BIND("t", _("Talk"));
-			ADD_BIND("u", _("Use"));
-			ADD_BIND("i", _("Inventory"));
-			ADD_BIND("o", _("Object"));
-			ADD_BIND("p", _("Pick up"));
-			ADD_BIND("l", _("Look"));
-			ADD_BIND("b", _("Black and White / Color"));
+			ADD_BIND(USTR("w"), _("Walk"));
+			ADD_BIND(USTR("t"), _("Talk"));
+			ADD_BIND(USTR("u"), _("Use"));
+			ADD_BIND(USTR("i"), _("Inventory"));
+			ADD_BIND(USTR("o"), _("Object"));
+			ADD_BIND(USTR("p"), _("Pick up"));
+			ADD_BIND(USTR("l"), _("Look"));
+			ADD_BIND(USTR("b"), _("Black and White / Color"));
 			break;
 		case GID_FT:
-			ADD_BIND("e", _("Eyes"));
-			ADD_BIND("t", _("Tongue"));
-			ADD_BIND("i", _("Inventory"));
-			ADD_BIND("p", _("Punch"));
-			ADD_BIND("k", _("Kick"));
+			ADD_BIND(USTR("e"), _("Eyes"));
+			ADD_BIND(USTR("t"), _("Tongue"));
+			ADD_BIND(USTR("i"), _("Inventory"));
+			ADD_BIND(USTR("p"), _("Punch"));
+			ADD_BIND(USTR("k"), _("Kick"));
 			break;
 		case GID_DIG:
-			ADD_BIND("e", _("Examine"));
-			ADD_BIND("t", _("Regular cursor"));
-			ADD_BIND("i", _("Inventory"));
+			ADD_BIND(USTR("e"), _("Examine"));
+			ADD_BIND(USTR("t"), _("Regular cursor"));
+			ADD_BIND(USTR("i"), _("Inventory"));
 			// I18N: Comm is a communication device
-			ADD_BIND("c", _("Comm"));
+			ADD_BIND(USTR("c"), _("Comm"));
 			break;
 		case GID_CMI:
-			ADD_BIND("F1", _("Save / Load / Options"));
-			ADD_BIND("e", _("Examine"));
-			ADD_BIND("t", _("Talk to"));
-			ADD_BIND("i", _("Inventory"));
-			ADD_BIND("u", _("Use"));
+			ADD_BIND(USTR("F1"), _("Save / Load / Options"));
+			ADD_BIND(USTR("e"), _("Examine"));
+			ADD_BIND(USTR("t"), _("Talk to"));
+			ADD_BIND(USTR("i"), _("Inventory"));
+			ADD_BIND(USTR("u"), _("Use"));
 			break;
 		default:
 			break;
@@ -257,41 +257,41 @@ void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platfo
 		title = _("Other game controls:");
 		if (version <= 2) {
 			ADD_TEXT(_("Inventory:"));
-			ADD_BIND("u", _("Scroll list up"));
-			ADD_BIND("j", _("Scroll list down"));
-			ADD_BIND("i", _("Upper left item"));
-			ADD_BIND("k", _("Lower left item"));
-			ADD_BIND("o", _("Upper right item"));
-			ADD_BIND("l", _("Lower right item"));
+			ADD_BIND(USTR("u"), _("Scroll list up"));
+			ADD_BIND(USTR("j"), _("Scroll list down"));
+			ADD_BIND(USTR("i"), _("Upper left item"));
+			ADD_BIND(USTR("k"), _("Lower left item"));
+			ADD_BIND(USTR("o"), _("Upper right item"));
+			ADD_BIND(USTR("l"), _("Lower right item"));
 			ADD_LINE;
 		} else if (gameId == GID_INDY3 || gameId == GID_ZAK) {
 			// Indy3, or FM-TOWNS Zak
 			ADD_TEXT(_("Inventory:"));
-			ADD_BIND("y", _("Upper left item"));
-			ADD_BIND("h", _("Middle left item"));
-			ADD_BIND("n", _("Lower left item"));
-			ADD_BIND("u", _("Upper right item"));
-			ADD_BIND("j", _("Middle right item"));
-			ADD_BIND("m", _("Lower right item"));
-			ADD_BIND("o", _("Scroll list up"));
-			ADD_BIND("l", _("Scroll list down"));
+			ADD_BIND(USTR("y"), _("Upper left item"));
+			ADD_BIND(USTR("h"), _("Middle left item"));
+			ADD_BIND(USTR("n"), _("Lower left item"));
+			ADD_BIND(USTR("u"), _("Upper right item"));
+			ADD_BIND(USTR("j"), _("Middle right item"));
+			ADD_BIND(USTR("m"), _("Lower right item"));
+			ADD_BIND(USTR("o"), _("Scroll list up"));
+			ADD_BIND(USTR("l"), _("Scroll list down"));
 			ADD_LINE;
 		}
 		if (gameId == GID_MANIAC) {
 			ADD_TEXT(_("Switching characters:"));
-			ADD_BIND("F1", "Dave");
-			ADD_BIND("F2", _("Second kid"));
-			ADD_BIND("F3", _("Third kid"));
+			ADD_BIND(USTR("F1"), USTR("Dave"));
+			ADD_BIND(USTR("F2"), _("Second kid"));
+			ADD_BIND(USTR("F3"), _("Third kid"));
 		} else if (gameId == GID_ZAK) {
 			ADD_TEXT(_("Switching characters:"));
-			ADD_BIND("F1", "Zak");
-			ADD_BIND("F2", "Annie");
-			ADD_BIND("F3", "Melissa");
-			ADD_BIND("F4", "Leslie");
+			ADD_BIND(USTR("F1"), USTR("Zak"));
+			ADD_BIND(USTR("F2"), USTR("Annie"));
+			ADD_BIND(USTR("F3"), USTR("Melissa"));
+			ADD_BIND(USTR("F4"), USTR("Leslie"));
 		}
 		if (gameId == GID_INDY4) {
-			ADD_BIND("i", _("Toggle Inventory/IQ Points display"));
-			ADD_BIND("f", _("Toggle Keyboard/Mouse Fighting (*)"));
+			ADD_BIND(USTR("i"), _("Toggle Inventory/IQ Points display"));
+			ADD_BIND(USTR("f"), _("Toggle Keyboard/Mouse Fighting (*)"));
 			ADD_LINE;
 			ADD_TEXT(_("* Keyboard Fighting is always on,"));
 			ADD_TEXT(_("  so despite the in-game message this"));
@@ -303,17 +303,17 @@ void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platfo
 		case GID_INDY3:
 		case GID_INDY4:
 			title = _("Fighting controls (numpad):");
-			ADD_BIND("7", _("Step back"));
-			ADD_BIND("4", _("Step back"));
-			ADD_BIND("1", _("Step back"));
-			ADD_BIND("8", _("Block high"));
-			ADD_BIND("5", _("Block middle"));
-			ADD_BIND("2", _("Block low"));
-			ADD_BIND("9", _("Punch high"));
-			ADD_BIND("6", _("Punch middle"));
-			ADD_BIND("3", _("Punch low"));
+			ADD_BIND(USTR("7"), _("Step back"));
+			ADD_BIND(USTR("4"), _("Step back"));
+			ADD_BIND(USTR("1"), _("Step back"));
+			ADD_BIND(USTR("8"), _("Block high"));
+			ADD_BIND(USTR("5"), _("Block middle"));
+			ADD_BIND(USTR("2"), _("Block low"));
+			ADD_BIND(USTR("9"), _("Punch high"));
+			ADD_BIND(USTR("6"), _("Punch middle"));
+			ADD_BIND(USTR("3"), _("Punch low"));
 			if (gameId == GID_INDY4) {
-				ADD_BIND("0", _("Sucker punch"));
+				ADD_BIND(USTR("0"), _("Sucker punch"));
 			}
 			ADD_LINE;
 			ADD_TEXT(_("These are for Indy on left."));
@@ -329,15 +329,15 @@ void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platfo
 		switch (gameId) {
 		case GID_INDY3:
 			title = _("Biplane controls (numpad):");
-			ADD_BIND("7", _("Fly to upper left"));
-			ADD_BIND("4", _("Fly to left"));
-			ADD_BIND("1", _("Fly to lower left"));
-			ADD_BIND("8", _("Fly upwards"));
-			ADD_BIND("5", _("Fly straight"));
-			ADD_BIND("2", _("Fly down"));
-			ADD_BIND("9", _("Fly to upper right"));
-			ADD_BIND("6", _("Fly to right"));
-			ADD_BIND("3", _("Fly to lower right"));
+			ADD_BIND(USTR("7"), _("Fly to upper left"));
+			ADD_BIND(USTR("4"), _("Fly to left"));
+			ADD_BIND(USTR("1"), _("Fly to lower left"));
+			ADD_BIND(USTR("8"), _("Fly upwards"));
+			ADD_BIND(USTR("5"), _("Fly straight"));
+			ADD_BIND(USTR("2"), _("Fly down"));
+			ADD_BIND(USTR("9"), _("Fly to upper right"));
+			ADD_BIND(USTR("6"), _("Fly to right"));
+			ADD_BIND(USTR("3"), _("Fly to lower right"));
 			break;
 		default:
 			break;

--- a/engines/scumm/imuse/drivers/amiga.cpp
+++ b/engines/scumm/imuse/drivers/amiga.cpp
@@ -654,7 +654,7 @@ int IMuseDriver_Amiga::open() {
 		Common::U32String message = _("This AMIGA version is missing (at least) the following file(s):\n\n");
 		for (int i = 0; i < 11; ++i) {
 			if (_missingFiles & (1 << i))
-				message += Common::String::format("AMIGA%d.IMS\n", i + 1);
+				message += Common::U32String::format("AMIGA%d.IMS\n", i + 1);
 		}
 		message += _("\nPlease copy these file(s) into the game data directory.\n\n");
 		::GUI::displayErrorDialog(message);

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -476,7 +476,7 @@ SaveStateList ScummMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				Scumm::getSavegameName(in, saveDesc, 0);	// FIXME: heversion?!?
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc.decode(Common::kLatin1)));
 				delete in;
 			}
 		}
@@ -504,7 +504,7 @@ SaveStateDescriptor ScummMetaEngine::querySaveMetaInfos(const char *target, int 
 		return SaveStateDescriptor();
 	}
 
-	SaveStateDescriptor desc(slot, saveDesc);
+	SaveStateDescriptor desc(slot, saveDesc.decode(Common::kLatin1));
 
 	// Do not allow save slot 0 (used for auto-saving) to be deleted or
 	// overwritten.

--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -211,8 +211,6 @@ bool ScummEngine::openResourceFile(const Common::String &filename, byte encByte)
 }
 
 void ScummEngine::askForDisk(const char *filename, int disknum) {
-	char buf[128];
-
 	if (_game.version == 8) {
 #ifdef ENABLE_SCUMM_7_8
 		char result;
@@ -220,19 +218,18 @@ void ScummEngine::askForDisk(const char *filename, int disknum) {
 		_imuseDigital->stopAllSounds();
 
 #ifdef MACOSX
-		sprintf(buf, "Cannot find file: '%s'\nPlease insert disc %d.\nPress OK to retry, Quit to exit", filename, disknum);
+		Common::U32String buf = Common::U32String::format("Cannot find file: '%s'\nPlease insert disc %d.\nPress OK to retry, Quit to exit", filename, disknum);
 #else
-		sprintf(buf, "Cannot find file: '%s'\nInsert disc %d into drive %s\nPress OK to retry, Quit to exit", filename, disknum, ConfMan.get("path").c_str());
+		Common::U32String buf = Common::U32String::format("Cannot find file: '%s'\nInsert disc %d into drive %s\nPress OK to retry, Quit to exit", filename, disknum, ConfMan.get("path").c_str());
 #endif
 
-		result = displayMessage("Quit", "%s", buf);
+		result = displayMessage(USTR("Quit"), buf);
 		if (!result) {
 			error("Cannot find file: '%s'", filename);
 		}
 #endif
 	} else {
-		sprintf(buf, "Cannot find file: '%s'", filename);
-		InfoDialog dialog(this, Common::U32String(buf));
+		InfoDialog dialog(this, Common::U32String::format("Cannot find file: '%s'", filename));
 		runDialog(dialog);
 		error("Cannot find file: '%s'", filename);
 	}
@@ -288,7 +285,7 @@ void ScummEngine::readIndexFile() {
 	}
 
 	if (checkTryMedia(_fileHandle)) {
-		displayMessage(NULL, "You're trying to run game encrypted by ActiveMark. This is not supported.");
+		displayMessage(Common::U32String(), USTR("You're trying to run game encrypted by ActiveMark. This is not supported."));
 		quitGame();
 
 		return;

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2872,15 +2872,8 @@ void ScummEngine::confirmRestartDialog() {
 	}
 }
 
-char ScummEngine::displayMessage(const char *altButton, const char *message, ...) {
-	char buf[STRINGBUFLEN];
-	va_list va;
-
-	va_start(va, message);
-	vsnprintf(buf, STRINGBUFLEN, message, va);
-	va_end(va);
-
-	GUI::MessageDialog dialog(buf, "OK", altButton);
+char ScummEngine::displayMessage(const Common::U32String &altButton, const Common::U32String &message) {
+	GUI::MessageDialog dialog(message, USTR("OK"), altButton);
 	return runDialog(dialog);
 }
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -409,7 +409,7 @@ protected:
 	void versionDialog();
 
 public:
-	char displayMessage(const char *altButton, const char *message, ...) GCC_PRINTF(3, 4);
+	char displayMessage(const Common::U32String &altButton, const Common::U32String &message);
 
 protected:
 	byte _fastMode;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -118,7 +118,7 @@ void ScummEngine::showMessageDialog(const byte *msg) {
 	if (_string[3].color == 0)
 		_string[3].color = 4;
 
-	InfoDialog dialog(this, Common::U32String((char *)buf));
+	InfoDialog dialog(this, Common::U32String((char *)buf, Common::kLatin1));
 	VAR(VAR_KEYPRESS) = runDialog(dialog);
 }
 

--- a/engines/sherlock/metaengine.cpp
+++ b/engines/sherlock/metaengine.cpp
@@ -148,7 +148,7 @@ SaveStateDescriptor SherlockMetaEngine::querySaveMetaInfos(const char *target, i
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/sherlock/saveload.cpp
+++ b/engines/sherlock/saveload.cpp
@@ -69,7 +69,7 @@ void SaveManager::createSavegameList() {
 	for (uint idx = 0; idx < saveList.size(); ++idx) {
 		int slot = saveList[idx].getSaveSlot();
 		if (slot >= 0 && slot < MAX_SAVEGAME_SLOTS)
-			_savegames[slot] = saveList[idx].getDescription();
+			_savegames[slot] = saveList[idx].getDescription().legacyEncode();
 	}
 
 	// Ensure the names will fit on the screen
@@ -104,7 +104,7 @@ SaveStateList SaveManager::getSavegameList(const Common::String &target) {
 
 			if (in) {
 				if (readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 
 				delete in;
 			}

--- a/engines/sherlock/scalpel/scalpel.cpp
+++ b/engines/sherlock/scalpel/scalpel.cpp
@@ -1251,9 +1251,9 @@ void ScalpelEngine::showScummVMSaveDialog() {
 
 	int slot = dialog->runModalWithCurrentTarget();
 	if (slot >= 0) {
-		Common::String desc = dialog->getResultString();
+		Common::U32String desc = dialog->getResultString();
 
-		saveGameState(slot, desc);
+		saveGameState(slot, desc.legacyEncode());
 	}
 
 	delete dialog;

--- a/engines/sherlock/tattoo/widget_files.cpp
+++ b/engines/sherlock/tattoo/widget_files.cpp
@@ -76,14 +76,14 @@ void WidgetFiles::showScummVMSaveDialog() {
 
 	int slot = dialog->runModalWithCurrentTarget();
 	if (slot >= 0) {
-		Common::String desc = dialog->getResultString();
+		Common::U32String desc = dialog->getResultString();
 
 		if (desc.empty()) {
 			// create our own description for the saved game, the user didn't enter it
 			desc = dialog->createDefaultSaveDescription(slot);
 		}
 
-		_vm->saveGameState(slot, desc);
+		_vm->saveGameState(slot, desc.legacyEncode());
 	}
 
 	close();

--- a/engines/sky/control.cpp
+++ b/engines/sky/control.cpp
@@ -1129,7 +1129,8 @@ int Control::displayMessage(const char *altButton, const char *message, ...) {
 	vsnprintf(buf, STRINGBUFLEN, message, va);
 	va_end(va);
 
-	GUI::MessageDialog dialog(buf, "OK", altButton);
+	GUI::MessageDialog dialog(Common::U32String(buf, Common::kLatin1),
+				  USTR("OK"), Common::U32String(altButton, Common::kLatin1));
 	int result = dialog.runModal();
 	_skyMouse->spriteMouse(MOUSE_NORMAL, 0, 0);
 	return result;

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -173,7 +173,7 @@ SaveStateList SkyMetaEngine::listSaves(const char *target) const {
 		Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 		if (in) {
 			saveList.push_back(SaveStateDescriptor(slotNum,
-				(slotNum == 0) ? _("Autosave") : Common::U32String(savenames[slotNum - 1])));
+							       (slotNum == 0) ? _("Autosave") : Common::U32String(savenames[slotNum - 1], Common::kLatin1)));
 			delete in;
 		}
 	}

--- a/engines/stark/metaengine.cpp
+++ b/engines/stark/metaengine.cpp
@@ -66,7 +66,7 @@ public:
 				description = stream.readString();
 			}
 
-			saveList.push_back(SaveStateDescriptor(slot, description));
+			saveList.push_back(SaveStateDescriptor(slot, Common::U32String(description, Common::kLatin1)));
 		}
 
 		Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
@@ -90,7 +90,7 @@ public:
 			return descriptor;
 		}
 
-		descriptor.setDescription(metadata.description);
+		descriptor.setDescription(metadata.description.decode(Common::kUtf8));
 
 		if (metadata.version >= 9) {
 			Graphics::Surface *thumb = metadata.readGameScreenThumbnail(save);

--- a/engines/stark/stark.cpp
+++ b/engines/stark/stark.cpp
@@ -326,7 +326,7 @@ void StarkEngine::checkRecommendedDatafiles() {
 	}
 
 	if (missingFiles) {
-		warning("%s", message.c_str());
+		warning("%s", message.encode(Common::kUtf8).c_str());
 
 		GUI::MessageDialog dialog(message);
 		dialog.runModal();

--- a/engines/stark/stark.cpp
+++ b/engines/stark/stark.cpp
@@ -288,7 +288,7 @@ void StarkEngine::checkRecommendedDatafiles() {
 		return;
 	}
 
-	Common::String message = _("You are missing recommended data files:");
+	Common::U32String message = _("You are missing recommended data files:");
 
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 	Common::FSNode fontsDir = gameDataDir.getChild("fonts");
@@ -301,26 +301,26 @@ void StarkEngine::checkRecommendedDatafiles() {
 
 	bool missingFiles = false;
 	if (!fontsDir.isDirectory()) {
-		message += "\n\n";
+		message += USTR("\n\n");
 		message += _("The 'fonts' folder is required to experience the text style as it was designed. "
 				"The Steam release is known to be missing it. You can get the fonts from the demo version of the game.");
 		missingFiles = true;
 	}
 
 	if (!SearchMan.hasFile("gui.ini")) {
-		message += "\n\n";
+		message += USTR("\n\n");
 		message += _("'gui.ini' is recommended to get proper font settings for the game localization.");
 		missingFiles = true;
 	}
 
 	if (!SearchMan.hasFile("language.ini")) {
-		message += "\n\n";
+		message += USTR("\n\n");
 		message += _("'language.ini' is recommended to get localized confirmation dialogs.");
 		missingFiles = true;
 	}
 
 	if (!SearchMan.hasFile("game.exe") && !SearchMan.hasFile("game.dll")) {
-		message += "\n\n";
+		message += USTR("\n\n");
 		message += _("'game.exe' is recommended to get styled confirmation dialogs.");
 		missingFiles = true;
 	}

--- a/engines/stark/ui/menu/saveloadmenu.cpp
+++ b/engines/stark/ui/menu/saveloadmenu.cpp
@@ -41,6 +41,7 @@
 
 #include "common/config-manager.h"
 #include "common/savefile.h"
+#include "common/translation.h"
 
 #include "gui/message.h"
 
@@ -147,7 +148,7 @@ void SaveLoadMenuScreen::backHandler() {
 
 void SaveLoadMenuScreen::checkError(Common::Error error) {
 	if (error.getCode() != Common::kNoError) {
-		GUI::MessageDialog dialog(error.getDesc());
+		GUI::MessageDialog dialog(_(error.getDesc()));
 		dialog.runModal();
 	}
 }

--- a/engines/startrek/metaengine.cpp
+++ b/engines/startrek/metaengine.cpp
@@ -118,7 +118,7 @@ SaveStateList StarTrekMetaEngine::listSaves(const char *target) const {
 					strcpy(meta.description, "[broken saved game]");
 				}
 
-				saveList.push_back(SaveStateDescriptor(slotNr, meta.description));
+				saveList.push_back(SaveStateDescriptor(slotNr, Common::U32String(meta.description, Common::kLatin1)));
 			}
 		}
 	}
@@ -157,11 +157,11 @@ SaveStateDescriptor StarTrekMetaEngine::querySaveMetaInfos(const char *target, i
 		}
 		if (descriptionPos >= sizeof(meta.description)) {
 			// broken meta.description, ignore it
-			SaveStateDescriptor descriptor(slotNr, "[broken saved game]");
+			SaveStateDescriptor descriptor(slotNr, USTR("[broken saved game]"));
 			return descriptor;
 		}
 
-		SaveStateDescriptor descriptor(slotNr, meta.description);
+		SaveStateDescriptor descriptor(slotNr, Common::U32String(meta.description, Common::kLatin1));
 
 		// Do not allow save slot 0 (used for auto-saving) to be deleted or
 		// overwritten.

--- a/engines/startrek/saveload.cpp
+++ b/engines/startrek/saveload.cpp
@@ -43,11 +43,11 @@ bool StarTrekEngine::showSaveMenu() {
 	dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 
 	slot = dialog->runModalWithCurrentTarget();
-	desc = dialog->getResultString();
+	desc = dialog->getResultString().legacyEncode();
 
 	if (desc.empty()) {
 		// create our own description for the saved game, the user didnt enter it
-		desc = dialog->createDefaultSaveDescription(slot);
+		desc = dialog->createDefaultSaveDescription(slot).legacyEncode();
 	}
 
 	if (desc.size() > 28)

--- a/engines/supernova/metaengine.cpp
+++ b/engines/supernova/metaengine.cpp
@@ -92,7 +92,7 @@ SaveStateList SupernovaMetaEngine::listSaves(const char *target) const {
 						int saveFileDescSize = savefile->readSint16LE();
 						char* saveFileDesc = new char[saveFileDescSize];
 						savefile->read(saveFileDesc, saveFileDescSize);
-						saveFileList.push_back(SaveStateDescriptor(saveSlot, saveFileDesc));
+						saveFileList.push_back(SaveStateDescriptor(saveSlot, Common::U32String(saveFileDesc, Common::kLatin1)));
 						delete [] saveFileDesc;
 					}
 				}
@@ -138,7 +138,7 @@ SaveStateDescriptor SupernovaMetaEngine::querySaveMetaInfos(const char *target, 
 		int descriptionSize = savefile->readSint16LE();
 		char* description = new char[descriptionSize];
 		savefile->read(description, descriptionSize);
-		SaveStateDescriptor desc(slot, description);
+		SaveStateDescriptor desc(slot, Common::U32String(description, Common::kLatin1));
 		delete [] description;
 
 		uint32 saveDate = savefile->readUint32LE();

--- a/engines/sword1/control.cpp
+++ b/engines/sword1/control.cpp
@@ -865,7 +865,7 @@ int Control::displayMessage(const char *altButton, const char *message, ...) {
 	vsnprintf(buf, STRINGBUFLEN, message, va);
 	va_end(va);
 
-	GUI::MessageDialog dialog(buf, "OK", altButton);
+	GUI::MessageDialog dialog(Common::U32String(buf, Common::kLatin1), USTR("OK"), Common::U32String(altButton, Common::kLatin1));
 	int result = dialog.runModal();
 	_mouse->setPointer(MSE_POINTER, 0);
 	return result;

--- a/engines/sword1/metaengine.cpp
+++ b/engines/sword1/metaengine.cpp
@@ -88,7 +88,7 @@ SaveStateList SwordMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				in->readUint32LE(); // header
 				in->read(saveName, 40);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveName));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveName, Common::kLatin1)));
 				delete in;
 			}
 		}
@@ -118,7 +118,7 @@ SaveStateDescriptor SwordMetaEngine::querySaveMetaInfos(const char *target, int 
 		in->read(name, sizeof(name));
 		in->read(&versionSave, 1);      // version
 
-		SaveStateDescriptor desc(slot, name);
+		SaveStateDescriptor desc(slot, Common::U32String(name, Common::kLatin1));
 
 		if (versionSave < 2) // These older version of the savegames used a flag to signal presence of thumbnail
 			in->skip(1);

--- a/engines/sword1/resman.cpp
+++ b/engines/sword1/resman.cpp
@@ -36,7 +36,7 @@ void guiFatalError(char *msg) {
 	// TODO: We really need to setup a special palette for cases when
 	// the engine is erroring before setting one... otherwise invisible cursor :)
 
-	GUI::MessageDialog dialog(msg);
+	GUI::MessageDialog dialog(Common::U32String(msg, Common::kLatin1));
 	dialog.runModal();
 	error("%s", msg);
 }

--- a/engines/sword1/sword1.cpp
+++ b/engines/sword1/sword1.cpp
@@ -432,7 +432,7 @@ void SwordEngine::showFileErrorMsg(uint8 type, bool *fileExists) {
 				}
 		}
 	}
-	GUI::MessageDialog dialog(msg);
+	GUI::MessageDialog dialog(Common::U32String(msg, Common::kLatin1));
 	dialog.runModal();
 	if (type == TYPE_IMMED) // we can't start without this file, so error() out.
 		error("%s", msg);

--- a/engines/sword2/maketext.cpp
+++ b/engines/sword2/maketext.cpp
@@ -674,7 +674,7 @@ void Sword2Engine::initializeFontResourceFlags() {
 	else
 		textLine = (char *)fetchTextLine(textFile, 54) + 2;
 
-	_system->setWindowCaption(Common::U32String(textLine));
+	_system->setWindowCaption(Common::U32String(textLine, Common::kLatin1));
 	_resman->closeResource(TEXT_RES);
 }
 

--- a/engines/sword2/metaengine.cpp
+++ b/engines/sword2/metaengine.cpp
@@ -86,7 +86,7 @@ SaveStateList Sword2MetaEngine::listSaves(const char *target) const {
 			if (in) {
 				in->readUint32LE();
 				in->read(saveDesc, SAVE_DESCRIPTION_LEN);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveDesc, Common::kLatin1)));
 				delete in;
 			}
 		}

--- a/engines/sword2/protocol.cpp
+++ b/engines/sword2/protocol.cpp
@@ -305,7 +305,7 @@ byte *Sword2Engine::fetchPsxBackground(uint32 location) {
 	byte *buffer;
 
 	if (!file.open("screens.clu")) {
-		GUIErrorMessage("Broken Sword II: Cannot open screens.clu");
+		GUIErrorMessage(USTR("Broken Sword II: Cannot open screens.clu"));
 		return NULL;
 	}
 
@@ -373,7 +373,7 @@ byte *Sword2Engine::fetchPsxParallax(uint32 location, uint8 level) {
 		return NULL;
 
 	if (!file.open("screens.clu")) {
-		GUIErrorMessage("Broken Sword II: Cannot open screens.clu");
+		GUIErrorMessage(USTR("Broken Sword II: Cannot open screens.clu"));
 		return NULL;
 	}
 

--- a/engines/sword2/resman.cpp
+++ b/engines/sword2/resman.cpp
@@ -104,7 +104,7 @@ bool ResourceManager::init() {
 	Common::File file;
 
 	if (!file.open("resource.inf")) {
-		GUIErrorMessage("Broken Sword II: Cannot open resource.inf");
+		GUIErrorMessage(USTR("Broken Sword II: Cannot open resource.inf"));
 		return false;
 	}
 
@@ -125,7 +125,7 @@ bool ResourceManager::init() {
 		_resFiles[_totalClusters].numEntries = -1;
 		_resFiles[_totalClusters].entryTab = NULL;
 		if (++_totalClusters >= MAX_res_files) {
-			GUIErrorMessage("Broken Sword II: Too many entries in resource.inf");
+			GUIErrorMessage(USTR("Broken Sword II: Too many entries in resource.inf"));
 			return false;
 		}
 	}
@@ -134,7 +134,7 @@ bool ResourceManager::init() {
 
 	// Now load in the binary id to res conversion table
 	if (!file.open("resource.tab")) {
-		GUIErrorMessage("Broken Sword II: Cannot open resource.tab");
+		GUIErrorMessage(USTR("Broken Sword II: Cannot open resource.tab"));
 		return false;
 	}
 
@@ -151,7 +151,7 @@ bool ResourceManager::init() {
 
 	if (file.eos() || file.err()) {
 		file.close();
-		GUIErrorMessage("Broken Sword II: Cannot read resource.tab");
+		GUIErrorMessage(USTR("Broken Sword II: Cannot read resource.tab"));
 		return false;
 	}
 
@@ -161,7 +161,7 @@ bool ResourceManager::init() {
 	// version, which has all files on one disc.
 
 	if (!file.open("cd.inf") && !Sword2Engine::isPsx()) {
-		GUIErrorMessage("Broken Sword II: Cannot open cd.inf");
+		GUIErrorMessage(USTR("Broken Sword II: Cannot open cd.inf"));
 		return false;
 	}
 
@@ -179,7 +179,7 @@ bool ResourceManager::init() {
 			if (file.eos() || file.err()) {
 				delete[] cdInf;
 				file.close();
-				GUIErrorMessage("Broken Sword II: Cannot read cd.inf");
+				GUIErrorMessage(USTR("Broken Sword II: Cannot read cd.inf"));
 				return false;
 			}
 
@@ -207,7 +207,7 @@ bool ResourceManager::init() {
 		// the resource manager will print a fatal error.
 
 		if (cdInf[i].cd == 0 && !Common::File::exists((char *)cdInf[i].clusterName)) {
-			GUIErrorMessage("Broken Sword II: Cannot find " + Common::String((char *)cdInf[i].clusterName));
+			GUIErrorMessage(USTR("Broken Sword II: Cannot find ") + Common::U32String((char *)cdInf[i].clusterName, Common::kLatin1));
 			delete[] cdInf;
 			return false;
 		}
@@ -227,7 +227,7 @@ bool ResourceManager::init() {
 
 			if (j == _totalClusters) {
 				delete[] cdInf;
-				GUIErrorMessage(Common::String(_resFiles[i].fileName) + " is not in cd.inf");
+				GUIErrorMessage(Common::U32String(_resFiles[i].fileName, Common::kLatin1) + USTR(" is not in cd.inf"));
 				return false;
 			}
 

--- a/engines/sword25/metaengine.cpp
+++ b/engines/sword25/metaengine.cpp
@@ -67,7 +67,7 @@ SaveStateList Sword25MetaEngine::listSaves(const char *target) const {
 	for (uint i = 0; i < ps.getSlotCount(); ++i) {
 		if (ps.isSlotOccupied(i)) {
 			Common::String desc = ps.getSavegameDescription(i);
-			saveList.push_back(SaveStateDescriptor(i, desc));
+			saveList.push_back(SaveStateDescriptor(i, Common::U32String(desc, Common::kLatin1)));
 		}
 	}
 

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -81,7 +81,7 @@ public:
 				in->seek(0);
 				in->read(buf, 24);
 				buf[24] = 0;
-				saveList.push_back(SaveStateDescriptor(slot, buf));
+				saveList.push_back(SaveStateDescriptor(slot, Common::U32String(buf, Common::kLatin1)));
 			}
 		}
 		// Sort saves based on slot number.
@@ -113,9 +113,9 @@ public:
 
 		in->seek(TeenAgent::saveStateSize);
 		if (!Graphics::checkThumbnailHeader(*in))
-			return SaveStateDescriptor(slot, desc);
+			return SaveStateDescriptor(slot, Common::U32String(desc, Common::kLatin1));
 
-		SaveStateDescriptor ssd(slot, desc);
+		SaveStateDescriptor ssd(slot, Common::U32String(desc, Common::kLatin1));
 
 		//checking for the thumbnail
 		Graphics::Surface *thumbnail;

--- a/engines/testbed/config.cpp
+++ b/engines/testbed/config.cpp
@@ -34,8 +34,8 @@ TestbedOptionsDialog::TestbedOptionsDialog(Common::Array<Testsuite *> &tsList, T
 		GUI::Dialog("TestbedOptions"),
 		_testbedConfMan(tsConfMan) {
 
-	new GUI::StaticTextWidget(this, "TestbedOptions.Headline", Common::U32String("Select Testsuites to Execute"));
-	new GUI::StaticTextWidget(this, "TestbedOptions.Info", Common::U32String("Use Doubleclick to select/deselect"));
+	new GUI::StaticTextWidget(this, "TestbedOptions.Headline", USTR("Select Testsuites to Execute"));
+	new GUI::StaticTextWidget(this, "TestbedOptions.Info", USTR("Use Doubleclick to select/deselect"));
 
 	// Construct a String Array
 	Common::Array<Testsuite *>::const_iterator iter;
@@ -46,11 +46,11 @@ TestbedOptionsDialog::TestbedOptionsDialog(Common::Array<Testsuite *> &tsList, T
 		_testSuiteArray.push_back(*iter);
 		description = (*iter)->getDescription();
 		if ((*iter)->isEnabled()) {
-			_testSuiteDescArray.push_back(description + "(selected)");
+			_testSuiteDescArray.push_back((description + "(selected)").decode(Common::kLatin1));
 			selected++;
 			_colors.push_back(GUI::ThemeEngine::kFontColorNormal);
 		} else {
-			_testSuiteDescArray.push_back(description);
+			_testSuiteDescArray.push_back(description.decode(Common::kLatin1));
 			_colors.push_back(GUI::ThemeEngine::kFontColorAlternate);
 		}
 	}
@@ -63,12 +63,12 @@ TestbedOptionsDialog::TestbedOptionsDialog(Common::Array<Testsuite *> &tsList, T
 	_testListDisplay->setEditable(false);
 
 	if (selected > (tsList.size() - selected)) {
-		_selectButton = new GUI::ButtonWidget(this, "TestbedOptions.SelectAll", Common::U32String("Deselect All"), Common::U32String(), kTestbedDeselectAll, 0);
+		_selectButton = new GUI::ButtonWidget(this, "TestbedOptions.SelectAll", USTR("Deselect All"), Common::U32String(), kTestbedDeselectAll, 0);
 	} else {
-		_selectButton = new GUI::ButtonWidget(this, "TestbedOptions.SelectAll", Common::U32String("Select All"), Common::U32String(), kTestbedSelectAll, 0);
+		_selectButton = new GUI::ButtonWidget(this, "TestbedOptions.SelectAll", USTR("Select All"), Common::U32String(), kTestbedSelectAll, 0);
 	}
-	new GUI::ButtonWidget(this, "TestbedOptions.RunTests", Common::U32String("Run tests"), Common::U32String(), GUI::kCloseCmd);
-	new GUI::ButtonWidget(this, "TestbedOptions.Quit", Common::U32String("Exit Testbed"), Common::U32String(), kTestbedQuitCmd);
+	new GUI::ButtonWidget(this, "TestbedOptions.RunTests", USTR("Run tests"), Common::U32String(), GUI::kCloseCmd);
+	new GUI::ButtonWidget(this, "TestbedOptions.Quit", USTR("Exit Testbed"), Common::U32String(), kTestbedQuitCmd);
 }
 
 TestbedOptionsDialog::~TestbedOptionsDialog() {}
@@ -102,7 +102,7 @@ void TestbedOptionsDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd,
 		break;
 
 	case kTestbedDeselectAll:
-		_selectButton->setLabel("Select All");
+		_selectButton->setLabel(USTR("Select All"));
 		_selectButton->setCmd(kTestbedSelectAll);
 		for (uint i = 0; i < _testSuiteArray.size(); i++) {
 			_testListDisplay->markAsDeselected(i);
@@ -114,7 +114,7 @@ void TestbedOptionsDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd,
 		break;
 
 	case kTestbedSelectAll:
-		_selectButton->setLabel("Deselect All");
+		_selectButton->setLabel(USTR("Deselect All"));
 		_selectButton->setCmd(kTestbedDeselectAll);
 		for (uint i = 0; i < _testSuiteArray.size(); i++) {
 			_testListDisplay->markAsSelected(i);
@@ -143,7 +143,7 @@ void TestbedInteractionDialog::addText(uint w, uint h, const Common::String text
 		xOffset = _xOffset;
 	}
 	_yOffset += yPadding;
-	new GUI::StaticTextWidget(this, xOffset, _yOffset, w, h, text, textAlign);
+	new GUI::StaticTextWidget(this, xOffset, _yOffset, w, h, text.decode(Common::kLatin1), textAlign);
 	_yOffset += h;
 }
 
@@ -152,7 +152,7 @@ void TestbedInteractionDialog::addButton(uint w, uint h, const Common::String na
 		xOffset = _xOffset;
 	}
 	_yOffset += yPadding;
-	_buttonArray.push_back(new GUI::ButtonWidget(this, xOffset, _yOffset, w, h, name, Common::U32String(), cmd));
+	_buttonArray.push_back(new GUI::ButtonWidget(this, xOffset, _yOffset, w, h, name.decode(Common::kLatin1), Common::U32String(), cmd));
 	_yOffset += h;
 }
 
@@ -166,7 +166,7 @@ void TestbedInteractionDialog::addList(uint x, uint y, uint w, uint h, const Com
 }
 
 void TestbedInteractionDialog::addButtonXY(uint x, uint /* y */, uint w, uint h, const Common::String name, uint32 cmd) {
-	_buttonArray.push_back(new GUI::ButtonWidget(this, x, _yOffset, w, h, name, Common::U32String(), cmd));
+	_buttonArray.push_back(new GUI::ButtonWidget(this, x, _yOffset, w, h, name.decode(Common::kLatin1), Common::U32String(), cmd));
 }
 
 void TestbedInteractionDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) {

--- a/engines/testbed/config.h
+++ b/engines/testbed/config.h
@@ -73,7 +73,7 @@ public:
 
 	void markAsSelected(int i) {
 		if (!_list[i].encode().contains("selected")) {
-			_list[i] += Common::U32String(" (selected)");
+			_list[i] += USTR(" (selected)");
 		}
 		_listColors[i] = GUI::ThemeEngine::kFontColorNormal;
 		draw();
@@ -81,7 +81,7 @@ public:
 
 	void markAsDeselected(int i) {
 		if (_list[i].encode().contains("selected")) {
-			_list[i] = _testSuiteArray[i]->getDescription();
+			_list[i] = Common::U32String(_testSuiteArray[i]->getDescription(), Common::kLatin1);
 		}
 		_listColors[i] = GUI::ThemeEngine::kFontColorAlternate;
 		draw();

--- a/engines/testbed/sound.cpp
+++ b/engines/testbed/sound.cpp
@@ -76,32 +76,32 @@ void SoundSubsystemDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd,
 
 	switch (cmd) {
 		case kPlayChannel1:
-			_buttonArray[0]->setLabel("Pause Channel #1");
+			_buttonArray[0]->setLabel(USTR("Pause Channel #1"));
 			_buttonArray[0]->setCmd(kPauseChannel1);
 			_mixer->pauseHandle(_h1, false);
 			break;
 		case kPlayChannel2:
-			_buttonArray[1]->setLabel("Pause Channel #2");
+			_buttonArray[1]->setLabel(USTR("Pause Channel #2"));
 			_buttonArray[1]->setCmd(kPauseChannel2);
 			_mixer->pauseHandle(_h2, false);
 			break;
 		case kPlayChannel3:
-			_buttonArray[2]->setLabel("Pause Channel #3");
+			_buttonArray[2]->setLabel(USTR("Pause Channel #3"));
 			_buttonArray[2]->setCmd(kPauseChannel3);
 			_mixer->pauseHandle(_h3, false);
 			break;
 		case kPauseChannel1:
-			_buttonArray[0]->setLabel("Play Channel #1");
+			_buttonArray[0]->setLabel(USTR("Play Channel #1"));
 			_buttonArray[0]->setCmd(kPlayChannel1);
 			_mixer->pauseHandle(_h1, true);
 			break;
 		case kPauseChannel2:
-			_buttonArray[1]->setLabel("Play Channel #2");
+			_buttonArray[1]->setLabel(USTR("Play Channel #2"));
 			_buttonArray[1]->setCmd(kPlayChannel2);
 			_mixer->pauseHandle(_h2, true);
 			break;
 		case kPauseChannel3:
-			_buttonArray[2]->setLabel("Play Channel #3");
+			_buttonArray[2]->setLabel(USTR("Play Channel #3"));
 			_buttonArray[2]->setCmd(kPlayChannel3);
 			_mixer->pauseHandle(_h3, true);
 			break;

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -62,12 +62,12 @@ void TestbedExitDialog::init() {
 	GUI::ListWidget::ColorList colors;
 
 	for (Common::Array<Testsuite *>::const_iterator i = _testsuiteList.begin(); i != _testsuiteList.end(); ++i) {
-		strArray.push_back(Common::String::format("%s :", (*i)->getDescription()));
+		strArray.push_back(Common::U32String::format("%s :", (*i)->getDescription()));
 		colors.push_back(GUI::ThemeEngine::kFontColorNormal);
 		if ((*i)->isEnabled()) {
-			strArray.push_back(Common::String::format("Passed: %d  Failed: %d Skipped: %d", (*i)->getNumTestsPassed(), (*i)->getNumTestsFailed(), (*i)->getNumTestsSkipped()));
+			strArray.push_back(Common::U32String::format("Passed: %d  Failed: %d Skipped: %d", (*i)->getNumTestsPassed(), (*i)->getNumTestsFailed(), (*i)->getNumTestsSkipped()));
 		} else {
-			strArray.push_back(Common::U32String("Skipped"));
+			strArray.push_back(USTR("Skipped"));
 		}
 		colors.push_back(GUI::ThemeEngine::kFontColorAlternate);
 	}

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -199,7 +199,7 @@ void TestbedEngine::invokeTestsuites(TestbedConfigManager &cfMan) {
 			(*iter)->execute();
 		}
 		if ((*iter)->getNumTests() == (*iter)->getNumTestsPassed()) {
-			AchMan.setAchievement((*iter)->getName(), (*iter)->getDescription());
+			AchMan.setAchievement((*iter)->getName(), Common::U32String((*iter)->getDescription(), Common::kLatin1));
 			checkForAllAchievements();
 		}
 	}
@@ -212,7 +212,7 @@ void TestbedEngine::checkForAllAchievements() {
 			return;
 		}
 	}
-	AchMan.setAchievement("EVERYTHINGWORKS", "Everything works!");
+	AchMan.setAchievement("EVERYTHINGWORKS", USTR("Everything works!"));
 }
 
 Common::Error TestbedEngine::run() {

--- a/engines/testbed/testsuite.cpp
+++ b/engines/testbed/testsuite.cpp
@@ -111,12 +111,13 @@ void Testsuite::genReport() const {
 }
 
 bool Testsuite::handleInteractiveInput(const Common::String &textToDisplay, const char *opt1, const char *opt2, OptionSelected result) {
-	GUI::MessageDialog prompt(textToDisplay.c_str(), opt1, opt2);
+	GUI::MessageDialog prompt(textToDisplay.decode(Common::kLatin1), Common::U32String(opt1, Common::kLatin1),
+				  Common::U32String(opt2, Common::kLatin1));
 	return prompt.runModal() == result ? true : false;
 }
 
 void Testsuite::displayMessage(const Common::String &textToDisplay, const char *defaultButton) {
-	GUI::MessageDialog prompt(textToDisplay.c_str(), defaultButton);
+	GUI::MessageDialog prompt(textToDisplay.decode(Common::kLatin1), Common::U32String(defaultButton, Common::kLatin1));
 	prompt.runModal();
 }
 

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -112,7 +112,7 @@ SaveStateDescriptor TinselMetaEngine::querySaveMetaInfos(const char *target, int
 	file->read(saveDesc, sizeof(saveDesc));
 
 	saveDesc[SG_DESC_LEN - 1] = 0;
-	SaveStateDescriptor desc(slot, saveDesc);
+	SaveStateDescriptor desc(slot, Common::U32String(saveDesc, Common::kLatin1));
 
 	int8 tm_year = file->readUint16LE();
 	int8 tm_mon = file->readSByte();
@@ -159,7 +159,7 @@ SaveStateList TinselMetaEngine::listSaves(const char *target) const {
 
 			saveDesc[SG_DESC_LEN - 1] = 0;
 
-			saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+			saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveDesc, Common::kLatin1)));
 			delete in;
 		}
 	}

--- a/engines/tinsel/sound.cpp
+++ b/engines/tinsel/sound.cpp
@@ -485,7 +485,7 @@ void SoundManager::setSFXVolumes(uint8 volume) {
 void SoundManager::showSoundError(const char *errorMsg, const char *soundFile) {
 	Common::String msg;
 	msg = Common::String::format(errorMsg, soundFile);
-	GUI::MessageDialog dialog(msg.c_str(), "OK");
+	GUI::MessageDialog dialog(msg.decode(Common::kLatin1), USTR("OK"));
 	dialog.runModal();
 
 	error("%s", msg.c_str());

--- a/engines/tinsel/strres.cpp
+++ b/engines/tinsel/strres.cpp
@@ -105,7 +105,7 @@ void ChangeLanguage(LANGUAGE newLang) {
 		if ((newLang == TXT_ENGLISH) || !f.open(_vm->getTextFile(TXT_ENGLISH))) {
 			char buf[50];
 			sprintf(buf, CANNOT_FIND_FILE, _vm->getTextFile(newLang));
-			GUI::MessageDialog dialog(buf, "OK");
+			GUI::MessageDialog dialog(Common::U32String(buf, Common::kLatin1), USTR("OK"));
 			dialog.runModal();
 
 			error(CANNOT_FIND_FILE, _vm->getTextFile(newLang));

--- a/engines/titanic/core/project_item.cpp
+++ b/engines/titanic/core/project_item.cpp
@@ -486,7 +486,7 @@ SaveStateList CProjectItem::getSavegameList(const Common::String &target) {
 				SimpleFile f;
 				f.open(in);
 				if (readSavegameHeader(&f, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 
 				delete in;
 			}

--- a/engines/titanic/metaengine.cpp
+++ b/engines/titanic/metaengine.cpp
@@ -106,7 +106,7 @@ SaveStateList TitanicMetaEngine::listSaves(const char *target) const {
 				cf.open(in);
 
 				if (Titanic::CProjectItem::readSavegameHeader(&cf, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 
 				cf.close();
 			}
@@ -144,7 +144,7 @@ SaveStateDescriptor TitanicMetaEngine::querySaveMetaInfos(const char *target, in
 		file.close();
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 
 		if (header._version) {
 			desc.setThumbnail(header._thumbnail);

--- a/engines/titanic/support/files_manager.cpp
+++ b/engines/titanic/support/files_manager.cpp
@@ -39,19 +39,19 @@ CFilesManager::~CFilesManager() {
 
 bool CFilesManager::loadResourceIndex() {
 	if (!_datFile.open("titanic.dat")) {
-		GUIErrorMessage("Could not find titanic.dat data file");
+		GUIErrorMessage(USTR("Could not find titanic.dat data file"));
 		return false;
 	}
 
 	uint headerId = _datFile.readUint32BE();
 	_version = _datFile.readUint16LE();
 	if (headerId != MKTAG('S', 'V', 'T', 'N')) {
-		GUIErrorMessage("titanic.dat has invalid contents");
+		GUIErrorMessage(USTR("titanic.dat has invalid contents"));
 		return false;
 	}
 
 	if (_version != 5) {
-		GUIErrorMessage("titanic.dat is out of date");
+		GUIErrorMessage(USTR("titanic.dat is out of date"));
 		return false;
 	}
 

--- a/engines/toltecs/menu.cpp
+++ b/engines/toltecs/menu.cpp
@@ -291,10 +291,10 @@ void MenuSystem::initMenu(MenuID menuID) {
 		} else {
 			GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 			int slot = dialog->runModalWithCurrentTarget();
-			Common::String desc = dialog->getResultString();
+			Common::String desc = dialog->getResultString().legacyEncode();
 			if (desc.empty()) {
 				// Create our own description for the saved game, the user didn't enter one
-				desc = dialog->createDefaultSaveDescription(slot);
+				desc = dialog->createDefaultSaveDescription(slot).legacyEncode();
 			}
 
 			if (slot >= 0)

--- a/engines/toltecs/metaengine.cpp
+++ b/engines/toltecs/metaengine.cpp
@@ -100,7 +100,7 @@ SaveStateList ToltecsMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Toltecs::ToltecsEngine::readSaveHeader(in, header) == Toltecs::ToltecsEngine::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.description, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -152,7 +152,7 @@ SaveStateDescriptor ToltecsMetaEngine::querySaveMetaInfos(const char *target, in
 		delete in;
 
 		if (error == Toltecs::ToltecsEngine::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(slot, Common::U32String(header.description, Common::kLatin1));
 
 			desc.setThumbnail(header.thumbnail);
 

--- a/engines/tony/metaengine.cpp
+++ b/engines/tony/metaengine.cpp
@@ -107,7 +107,7 @@ SaveStateList TonyMetaEngine::listSaves(const char *target) const {
 
 			if (Tony::RMOptionScreen::loadThumbnailFromSaveState(slotNum, thumbnailData, saveName, difficulty)) {
 				// Add the save name to the savegame list
-				saveList.push_back(SaveStateDescriptor(slotNum, saveName));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveName, Common::kLatin1)));
 			}
 		}
 	}
@@ -141,7 +141,7 @@ SaveStateDescriptor TonyMetaEngine::querySaveMetaInfos(const char *target, int s
 			pixels[i] = READ_LE_UINT16(pixels + i);
 #endif
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(slot, saveName.decode(Common::kLatin1));
 		desc.setDeletableFlag(true);
 		desc.setWriteProtectedFlag(false);
 		desc.setThumbnail(to);

--- a/engines/toon/metaengine.cpp
+++ b/engines/toon/metaengine.cpp
@@ -94,7 +94,7 @@ SaveStateList ToonMetaEngine::listSaves(const char *target) const {
 				file->read(name, nameSize);
 				name[nameSize] = 0;
 
-				saveList.push_back(SaveStateDescriptor(slotNum, name));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(name, Common::kLatin1)));
 				delete file;
 			}
 		}
@@ -122,7 +122,7 @@ SaveStateDescriptor ToonMetaEngine::querySaveMetaInfos(const char *target, int s
 		file->read(saveName, saveNameLength);
 		saveName[saveNameLength] = 0;
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(saveName, Common::kLatin1));
 
 		Graphics::Surface *thumbnail = nullptr;
 		if (!Graphics::loadThumbnail(*file, thumbnail, false)) {

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -3361,7 +3361,7 @@ bool ToonEngine::saveGame(int32 slot, const Common::String &saveGameDesc) {
 	if (slot == -1) {
 		GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 		savegameId = dialog->runModalWithCurrentTarget();
-		savegameDescription = dialog->getResultString();
+		savegameDescription = dialog->getResultString().legacyEncode();
 		delete dialog;
 	} else {
 		savegameId = slot;

--- a/engines/touche/metaengine.cpp
+++ b/engines/touche/metaengine.cpp
@@ -82,7 +82,7 @@ SaveStateList ToucheMetaEngine::listSaves(const char *target) const {
 				char description[64];
 				Touche::readGameStateDescription(in, description, sizeof(description) - 1);
 				if (description[0]) {
-					saveList.push_back(SaveStateDescriptor(slot, description));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(description, Common::kLatin1)));
 				}
 				delete in;
 			}

--- a/engines/tsage/core.cpp
+++ b/engines/tsage/core.cpp
@@ -1622,7 +1622,7 @@ void SceneItem::doAction(int action) {
 			break;
 		}
 
-		GUIErrorMessage(msg);
+		GUIErrorMessage(Common::U32String(msg, Common::kLatin1));
 	}
 }
 
@@ -4436,7 +4436,7 @@ void SceneHandler::dispatch() {
 		// FIXME: Make use of the description string in err to enhance
 		// the error reported to the user.
 		if (err.getCode() != Common::kNoError)
-			GUIErrorMessage(SAVE_ERROR_MSG);
+			GUIErrorMessage(Common::U32String(SAVE_ERROR_MSG, Common::kLatin1));
 	}
 	if (_loadGameSlot != -1) {
 		int priorSceneBeforeLoad = GLOBALS._sceneManager._previousScene;

--- a/engines/tsage/metaengine.cpp
+++ b/engines/tsage/metaengine.cpp
@@ -103,7 +103,7 @@ public:
 
 				if (in) {
 					if (TsAGE::Saver::readSavegameHeader(in, header)) {
-						saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+						saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 					}
 
 					delete in;
@@ -139,7 +139,7 @@ public:
 			delete f;
 
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header._saveName);
+			SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 			desc.setThumbnail(header._thumbnail);
 			desc.setSaveDate(header._saveYear, header._saveMonth, header._saveDay);
 			desc.setSaveTime(header._saveHour, header._saveMinutes);

--- a/engines/tsage/scenes.cpp
+++ b/engines/tsage/scenes.cpp
@@ -601,7 +601,7 @@ void Game::handleSaveLoad(bool saveFlag, int &saveSlot, Common::String &saveName
 		dialog = new GUI::SaveLoadChooser(_("Load game:"), _("Load"), saveFlag);
 
 	saveSlot = dialog->runModalWithCurrentTarget();
-	saveName = dialog->getResultString();
+	saveName = dialog->getResultString().legacyEncode();
 
 	delete dialog;
 }

--- a/engines/tucker/metaengine.cpp
+++ b/engines/tucker/metaengine.cpp
@@ -68,7 +68,7 @@ public:
 				Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(*file);
 				if (in) {
 					if (Tucker::TuckerEngine::readSavegameHeader(in, header) == Tucker::TuckerEngine::kSavegameNoError) {
-						saveList.push_back(SaveStateDescriptor(slot, header.description));
+						saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header.description, Common::kLatin1)));
 					}
 
 					delete in;
@@ -109,7 +109,7 @@ public:
 			return SaveStateDescriptor();
 		}
 
-		SaveStateDescriptor desc(slot, header.description);
+		SaveStateDescriptor desc(slot, Common::U32String(header.description, Common::kLatin1));
 
 		if (slot == Tucker::kAutoSaveSlot) {
 			bool autosaveAllowed = Tucker::TuckerEngine::isAutosaveAllowed(target);

--- a/engines/ultima/nuvie/save/save_game.cpp
+++ b/engines/ultima/nuvie/save/save_game.cpp
@@ -216,7 +216,7 @@ bool SaveGame::transfer_character() {
 	Common::FSNode folder = dialog.getResult();
 
 	// TODO: Load in character data from given folder and start new game
-	g_engine->GUIError(Common::String::format("Load party file from folder - %s", folder.getPath().c_str()));
+	g_engine->GUIError(Common::U32String::format("Load party file from folder - %s", folder.getPath().c_str()));
 
 	return false;
 }

--- a/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
@@ -84,7 +84,7 @@ int TTFont::getBaselineSkip() {
 template<class T>
 static Common::U32String toUnicode(const Std::string &text, uint16 bullet) {
 	Std::string::size_type len = T::length(text);
-	Common::U32String result = Common::U32String(text.c_str(), len);
+	Common::U32String result = Common::U32String(text.c_str(), len, Common::kLatin1);
 
 	for (uint idx = 0; idx < result.size(); ++idx) {
 		if (result[idx] == '@')

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -846,7 +846,7 @@ void Ultima8Engine::handleEvent(const Common::Event &event) {
 					if (!g_system->hasTextInClipboard())
 						return;
 
-					Common::String text = g_system->getTextFromClipboard();
+					Common::String text = g_system->getTextFromClipboard().legacyEncode();
 
 					// Only read the first line of text
 					while (!text.empty() && text.firstChar() >= ' ')

--- a/engines/voyeur/metaengine.cpp
+++ b/engines/voyeur/metaengine.cpp
@@ -109,7 +109,7 @@ SaveStateList VoyeurMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (header.read(in)) {
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -140,7 +140,7 @@ SaveStateDescriptor VoyeurMetaEngine::querySaveMetaInfos(const char *target, int
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._saveYear, header._saveMonth, header._saveDay);
 		desc.setSaveTime(header._saveHour, header._saveMinutes);

--- a/engines/wage/gui.cpp
+++ b/engines/wage/gui.cpp
@@ -353,7 +353,8 @@ const Graphics::Font *Gui::getConsoleFont() {
 }
 
 void Gui::appendText(const char *s) {
-	_consoleWindow->appendText(s, getConsoleMacFont());
+	_consoleWindow->appendText(Common::U32String(s, Common::kLatin1),
+				   getConsoleMacFont());
 }
 
 void Gui::clearOutput() {
@@ -361,7 +362,7 @@ void Gui::clearOutput() {
 }
 
 void Gui::actionCopy() {
-	g_system->setTextInClipboard(Common::convertUtf32ToUtf8(_consoleWindow->getSelection()));
+	g_system->setTextInClipboard(_consoleWindow->getSelection());
 
 	_menu->enableCommand(kMenuEdit, kMenuActionPaste, true);
 }
@@ -378,7 +379,7 @@ void Gui::actionPaste() {
 
 void Gui::actionUndo() {
 	_consoleWindow->clearInput();
-	_consoleWindow->appendInput(_undobuffer);
+	_consoleWindow->appendInput(_undobuffer.decode(Common::kLatin1));
 
 	_menu->enableCommand(kMenuEdit, kMenuActionUndo, false);
 }

--- a/engines/wage/metaengine.cpp
+++ b/engines/wage/metaengine.cpp
@@ -101,7 +101,7 @@ SaveStateList WageMetaEngine::listSaves(const char *target) const {
 						in->read(saveDesc, 127);
 					}
 				}
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(saveDesc, Common::kLatin1)));
 				delete in;
 			}
 		}

--- a/engines/wage/saveload.cpp
+++ b/engines/wage/saveload.cpp
@@ -751,15 +751,15 @@ bool WageEngine::scummVMSaveLoadDialog(bool isSave) {
 	// do saving
 	GUI::SaveLoadChooser dialog = GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 	int slot = dialog.runModalWithCurrentTarget();
-	Common::String desc = dialog.getResultString();
+	Common::String desc = dialog.getResultString().legacyEncode();
 
 	if (desc.empty()) {
 		// create our own description for the saved game, the user didnt enter it
-		desc = dialog.createDefaultSaveDescription(slot);
+		desc = dialog.createDefaultSaveDescription(slot).legacyEncode();
 	}
 
 	if (desc.size() > 28)
-		desc = Common::String(desc.c_str(), 28);
+	    desc = desc.substr(0, 28);
 
 	if (slot < 0)
 		return true;

--- a/engines/wintermute/base/base_persistence_manager.cpp
+++ b/engines/wintermute/base/base_persistence_manager.cpp
@@ -159,7 +159,7 @@ void BasePersistenceManager::getSaveStateDesc(int slot, SaveStateDescriptor &des
 		return;
 	}
 	desc.setSaveSlot(slot);
-	desc.setDescription(_savedDescription);
+	desc.setDescription(Common::U32String(_savedDescription, Common::kUtf8));
 	desc.setDeletableFlag(true);
 	desc.setWriteProtectedFlag(false);
 

--- a/engines/wintermute/ext/wme_galaxy.cpp
+++ b/engines/wintermute/ext/wme_galaxy.cpp
@@ -103,7 +103,7 @@ bool SXWMEGalaxyAPI::scCallMethod(ScScript *script, ScStack *stack, ScStack *thi
 			}
 		}
 
-		stack->pushBool(AchMan.setAchievement(id, msg));
+		stack->pushBool(AchMan.setAchievement(id, msg.decode(Common::kLatin1)));
 		return STATUS_OK;
 	}
 

--- a/engines/wintermute/ext/wme_steam.cpp
+++ b/engines/wintermute/ext/wme_steam.cpp
@@ -100,7 +100,7 @@ bool SXSteamAPI::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisSta
 			}
 		}
 
-		stack->pushBool(AchMan.setAchievement(id, msg));
+		stack->pushBool(AchMan.setAchievement(id, msg.decode(Common::kLatin1)));
 		return STATUS_OK;
 	}
 	//////////////////////////////////////////////////////////////////////////

--- a/engines/wintermute/metaengine.cpp
+++ b/engines/wintermute/metaengine.cpp
@@ -126,7 +126,7 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {
 		Wintermute::BasePersistenceManager pm(target, true);
 		SaveStateDescriptor retVal;
-		retVal.setDescription("Invalid savegame");
+		retVal.setDescription(USTR("Invalid savegame"));
 		pm.getSaveStateDesc(slot, retVal);
 		return retVal;
 	}

--- a/engines/xeen/files.cpp
+++ b/engines/xeen/files.cpp
@@ -255,14 +255,14 @@ bool FileManager::setup() {
 	// Ensure the custom CC archive is present
 	File f;
 	if (!f.exists("xeen.ccs")) {
-		GUIErrorMessage("Could not find xeen.ccs data file");
+		GUIErrorMessage(USTR("Could not find xeen.ccs data file"));
 		return false;
 	}
 
 	// Verify the version of the CC is correct
 	CCArchive *dataCc = new CCArchive("xeen.ccs", "data", true);
 	if (!f.open("VERSION", *dataCc) || f.readUint32LE() != 4) {
-		GUIErrorMessage("xeen.ccs is out of date");
+		GUIErrorMessage(USTR("xeen.ccs is out of date"));
 		return false;
 	}
 	SearchMan.add("data", dataCc);

--- a/engines/xeen/metaengine.cpp
+++ b/engines/xeen/metaengine.cpp
@@ -139,7 +139,7 @@ SaveStateList XeenMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Xeen::SavesManager::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(slot, Common::U32String(header._saveName, Common::kLatin1)));
 
 				delete in;
 			}
@@ -173,7 +173,7 @@ SaveStateDescriptor XeenMetaEngine::querySaveMetaInfos(const char *target, int s
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(slot, Common::U32String(header._saveName, Common::kLatin1));
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/xeen/saves.cpp
+++ b/engines/xeen/saves.cpp
@@ -276,7 +276,7 @@ bool SavesManager::saveGame() {
 	} else {
 		GUI::SaveLoadChooser *dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 		int slotNum = dialog->runModalWithCurrentTarget();
-		Common::String saveName = dialog->getResultString();
+		Common::String saveName = dialog->getResultString().legacyEncode();
 		delete dialog;
 
 		if (slotNum != -1)
@@ -287,7 +287,7 @@ bool SavesManager::saveGame() {
 }
 
 void SavesManager::doAutosave() {
-	if (saveGameState(kAutoSaveSlot, _("Autosave")).getCode() != Common::kNoError)
+	if (saveGameState(kAutoSaveSlot, _("Autosave").legacyEncode()).getCode() != Common::kNoError)
 		g_vm->GUIError(_("Failed to autosave"));
 }
 

--- a/engines/zvision/file/save_manager.cpp
+++ b/engines/zvision/file/save_manager.cpp
@@ -49,15 +49,15 @@ bool SaveManager::scummVMSaveLoadDialog(bool isSave) {
 		dialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 
 		slot = dialog->runModalWithCurrentTarget();
-		desc = dialog->getResultString();
+		desc = dialog->getResultString().legacyEncode();
 
 		if (desc.empty()) {
 			// create our own description for the saved game, the user didnt enter it
-			desc = dialog->createDefaultSaveDescription(slot);
+			desc = dialog->createDefaultSaveDescription(slot).legacyEncode();
 		}
 
 		if (desc.size() > 28)
-			desc = Common::String(desc.c_str(), 28);
+		    desc = desc.substr(0, 28);
 	} else {
 		dialog = new GUI::SaveLoadChooser(_("Restore game:"), _("Restore"), false);
 		slot = dialog->runModalWithCurrentTarget();

--- a/engines/zvision/metaengine.cpp
+++ b/engines/zvision/metaengine.cpp
@@ -258,7 +258,7 @@ SaveStateList ZVisionMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (zvisionSaveMan->readSaveGameHeader(in, header)) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+					saveList.push_back(SaveStateDescriptor(slotNum, Common::U32String(header.saveName, Common::kLatin1)));
 				}
 				delete in;
 			}
@@ -295,7 +295,7 @@ SaveStateDescriptor ZVisionMetaEngine::querySaveMetaInfos(const char *target, in
 		delete in;
 
 		if (successfulRead) {
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(slot, Common::U32String(header.saveName, Common::kLatin1));
 
 			// Do not allow save slot 0 (used for auto-saving) to be deleted or
 			// overwritten.

--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -335,7 +335,8 @@ StringType handleEllipsis(const Font &font, const StringType &input, int w) {
 
 	if (width > w) {
 		StringType str;
-		StringType ellipsis("...");
+		typename StringType::value_type vt[] = { '.', '.', '.', '\0' };
+		StringType ellipsis(vt);
 
 		// String is too wide. So we shorten it "intelligently" by
 		// replacing parts of the string by an ellipsis. There are

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -360,7 +360,7 @@ int MacMenu::addMenuItem(MacMenuSubMenu *submenu, const Common::String &text, in
 int MacMenu::addMenuItem(MacMenuSubMenu *submenu, const Common::U32String &text, int action, int style, char shortcut, bool enabled) {
 	_dimensionsDirty = true;
 
-	Common::U32String amp("&");
+	Common::U32String amp(USTR("&"));
 	Common::U32String res;
 	int shortcutPos = -1;
 
@@ -596,7 +596,7 @@ void MacMenu::processSubmenuTabs(MacMenuSubMenu *submenu) {
 	int maxWidth = 0;
 	bool haveTabs = false;
 
-	Common::U32String tabSymbol("\t");
+	Common::U32String tabSymbol(USTR("\t"));
 
 	// First, we replace \t with two spaces, and thus, obtain
 	// the widest string
@@ -623,7 +623,7 @@ void MacMenu::processSubmenuTabs(MacMenuSubMenu *submenu) {
 			Common::U32String end = item->unicodeText.substr(pos + 1);
 
 			res = start;
-			res += Common::U32String("  ");
+			res += USTR("  ");
 			res += end;
 		}
 
@@ -651,7 +651,7 @@ void MacMenu::processSubmenuTabs(MacMenuSubMenu *submenu) {
 		Common::U32String start = item->unicodeText.substr(0, pos);
 		Common::U32String end = item->unicodeText.substr(pos + 1);
 		Common::U32String res;
-		Common::U32String spaces(" ");
+		Common::U32String spaces(USTR(" "));
 		int width;
 
 		do {
@@ -693,7 +693,7 @@ int MacMenu::calcSubMenuWidth(MacMenuSubMenu *submenu) {
 			Common::U32String text(item->unicodeText);
 
 			if (item->submenu != nullptr) // If we're drawing triangle
-				text += Common::U32String("  ");
+				text += USTR("  ");
 
 			int width = _font->getStringWidth(text);
 			if (width > maxWidth) {

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -126,7 +126,7 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow) :
 	MacWidget(parent, x, y, w + 2, h, wm, true, border, gutter, boxShadow) {
 
-	_str = Common::U32String(s);
+	_str = s.decode(Common::kLatin1);
 	_fullRefresh = true;
 
 	_wm = wm;
@@ -184,7 +184,7 @@ MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont
 MacText::MacText(const Common::String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear) :
 	MacWidget(nullptr, 0, 0, 0, 0, wm, false, 0, 0, 0) {
 
-	_str = Common::U32String(s);
+	_str = s.decode(Common::kLatin1);
 	_fullRefresh = true;
 
 	_wm = wm;
@@ -774,7 +774,7 @@ void MacText::appendText(const Common::U32String &str, int fontId, int fontSize,
 	_currentFormatting = fontRun;
 
 	if (!skipAdd) {
-		_str += fontRun.toString();
+		_str += fontRun.toString().decode(Common::kLatin1);
 		_str += str;
 	}
 
@@ -795,17 +795,13 @@ void MacText::appendText(const Common::U32String &str, int fontId, int fontSize,
 	}
 }
 
-void MacText::appendText(const Common::String &str, int fontId, int fontSize, int fontSlant, bool skipAdd) {
-	appendText(Common::U32String(str), fontId, fontSize, fontSlant, skipAdd);
-}
-
 void MacText::appendTextDefault(const Common::U32String &str, bool skipAdd) {
 	uint oldLen = _textLines.size();
 
 	_currentFormatting = _defaultFormatting;
 
 	if (!skipAdd) {
-		_str += _defaultFormatting.toString();
+		_str += _defaultFormatting.toString().decode(Common::kLatin1);
 		_str += str;
 	}
 
@@ -813,10 +809,6 @@ void MacText::appendTextDefault(const Common::U32String &str, bool skipAdd) {
 	recalcDims();
 
 	render(oldLen - 1, _textLines.size());
-}
-
-void MacText::appendTextDefault(const Common::String &str, bool skipAdd) {
-	appendTextDefault(Common::U32String(str), skipAdd);
 }
 
 void MacText::clearText() {
@@ -1401,7 +1393,7 @@ void MacText::getRowCol(int x, int y, int *sx, int *sy, int *row, int *col) {
 // This happens when a long paragraph is split into several lines
 #define ADDFORMATTING() \
 	if (formatted) { \
-		formatting = _textLines[i].chunks[chunk].toString(); \
+		formatting = _textLines[i].chunks[chunk].toString().decode(Common::kLatin1); \
 		if (formatting != prevformatting) { \
 			res += formatting; \
 			prevformatting = formatting; \
@@ -1513,7 +1505,8 @@ Common::U32String MacText::getTextChunk(int startRow, int startCol, int endRow, 
 // Text editing
 void MacText::insertChar(byte c, int *row, int *col) {
 	if (_textLines.empty()) {
-		appendTextDefault(Common::String(c));
+		Common::U32String::value_type vt[2] = { c, 0 };
+		appendTextDefault(Common::U32String(vt));
 		(*col)++;
 
 		return;
@@ -1593,7 +1586,7 @@ void MacText::deletePreviousChar(int *row, int *col) {
 
 void MacText::addNewLine(int *row, int *col) {
 	if (_textLines.empty()) {
-		appendTextDefault(Common::String("\n"));
+		appendTextDefault(USTR("\n"));
 		(*row)++;
 
 		return;

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -173,7 +173,6 @@ public:
 	void appendText(const Common::U32String &str, int fontId = kMacFontChicago, int fontSize = 12, int fontSlant = kMacFontRegular, bool skipAdd = false);
 	void appendText(const Common::String &str, int fontId = kMacFontChicago, int fontSize = 12, int fontSlant = kMacFontRegular, bool skipAdd = false);
 	void appendTextDefault(const Common::U32String &str, bool skipAdd = false);
-	void appendTextDefault(const Common::String &str, bool skipAdd = false);
 	void clearText();
 	void removeLastLine();
 	int getLineCount() { return _textLines.size(); }

--- a/graphics/macgui/mactextwindow.cpp
+++ b/graphics/macgui/mactextwindow.cpp
@@ -102,10 +102,6 @@ void MacTextWindow::appendText(const Common::U32String &str, const MacFont *macF
 	}
 }
 
-void MacTextWindow::appendText(const Common::String &str, const MacFont *macFont, bool skipAdd) {
-	appendText(Common::U32String(str), macFont, skipAdd);
-}
-
 void MacTextWindow::clearText() {
 	_mactext->clearText();
 
@@ -466,7 +462,7 @@ void MacTextWindow::undrawInput() {
 		_mactext->removeLastLine();
 
 	if (_inputTextHeight)
-		appendText("\n", _font, true);
+		appendText(USTR("\n"), _font, true);
 
 	_inputTextHeight = 0;
 }
@@ -501,10 +497,6 @@ void MacTextWindow::appendInput(const Common::U32String &str) {
 	_inputText += str;
 
 	drawInput();
-}
-
-void MacTextWindow::appendInput(const Common::String &str) {
-	appendInput(Common::U32String(str));
 }
 
 //////////////////

--- a/graphics/macgui/mactextwindow.h
+++ b/graphics/macgui/mactextwindow.h
@@ -45,7 +45,6 @@ public:
 	const MacFont *getTextWindowFont();
 
 	void appendText(const Common::U32String &str, const MacFont *macFont, bool skipAdd = false);
-	void appendText(const Common::String &str, const MacFont *macFont, bool skipAdd = false);
 	void clearText();
 
 	void setEditable(bool editable) { _editable = editable; }
@@ -56,7 +55,6 @@ public:
 	const Common::U32String &getInput() { return _inputText; }
 	void clearInput();
 	void appendInput(const Common::U32String &str);
-	void appendInput(const Common::String &str);
 
 	Common::U32String getSelection(bool formatted = false, bool newlines = true);
 	void clearSelection();

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -97,24 +97,24 @@ AboutDialog::AboutDialog()
 
 	Common::String version("C0""ScummVM ");
 	version += gScummVMVersion;
-	_lines.push_back(version);
+	_lines.push_back(version.decode(Common::kLatin1));
 
 	Common::U32String date = Common::U32String::format(_("(built on %s)"), gScummVMBuildDate);
-	_lines.push_back(U32String("C2") + date);
+	_lines.push_back(USTR("C2") + date);
 
 	for (i = 0; i < ARRAYSIZE(copyright_text); i++)
-		addLine(U32String(copyright_text[i]));
+		addLine(U32String(copyright_text[i], Common::kLatin1));
 
-	Common::U32String features("C1");
+	Common::U32String features = USTR("C1");
 	features += _("Features compiled in:");
 	addLine(features);
 	Common::String featureList("C0");
 	featureList += gScummVMFeatures;
-	addLine(featureList);
+	addLine(featureList.decode(Common::kLatin1));
 
 	_lines.push_back(U32String());
 
-	Common::U32String engines("C1");
+	Common::U32String engines = USTR("C1");
 	engines += _("Available engines:");
 	addLine(engines);
 
@@ -124,22 +124,22 @@ AboutDialog::AboutDialog()
 		Common::String str;
 		str = "C0";
 		str += (*iter)->getName();
-		addLine(str);
+		addLine(str.decode(Common::kLatin1));
 
 		str = "C2";
 		str += (*iter)->get<MetaEngineDetection>().getOriginalCopyright();
-		addLine(str);
+		addLine(str.decode(Common::kLatin1));
 
 		//addLine("");
 	}
 
 	for (i = 0; i < ARRAYSIZE(gpl_text); i++)
-		addLine(U32String(gpl_text[i]));
+		addLine(U32String(gpl_text[i], Common::kLatin1));
 
 	_lines.push_back(U32String());
 
 	for (i = 0; i < ARRAYSIZE(credits); i++)
-		addLine(U32String(credits[i]));
+	    addLine(U32String(credits[i], Common::kLatin1));
 }
 
 void AboutDialog::addLine(const U32String &str) {
@@ -312,7 +312,7 @@ void AboutDialog::reflowLayout() {
 	int maxW = _w - 2*_xOff;
 	_w = 0;
 	for (i = 0; i < ARRAYSIZE(credits); i++) {
-		int tmp = g_gui.getStringWidth(credits[i]) + 5;
+		int tmp = g_gui.getStringWidth(U32String(credits[i], Common::kLatin1)) + 5;
 		if (_w < tmp && tmp <= maxW) {
 			_w = tmp;
 		}

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -186,7 +186,7 @@ void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 
 void BrowserDialog::updateListing() {
 	// Update the path display
-	_currentPath->setEditString(_node.getPath());
+	_currentPath->setEditString(_node.getPath().decode(Common::kLatin1));
 
 	// We memorize the last visited path.
 	// Don't memorize a path that is not a directory
@@ -205,9 +205,9 @@ void BrowserDialog::updateListing() {
 	ListWidget::ColorList colors;
 	for (Common::FSList::iterator i = _nodeContent.begin(); i != _nodeContent.end(); ++i) {
 		if (i->isDirectory())
-			list.push_back(i->getDisplayName() + "/");
+			list.push_back(i->getDisplayName().decode(Common::kLatin1) + USTR("/"));
 		else
-			list.push_back(i->getDisplayName());
+			list.push_back(i->getDisplayName().decode(Common::kLatin1));
 
 		if (_isDirBrowser) {
 			if (i->isDirectory())

--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -538,7 +538,7 @@ void ConsoleDialog::specialKeys(Common::KeyCode keycode) {
 		{
 			Common::String userInput = getUserInput();
 			if (!userInput.empty())
-				g_system->setTextInClipboard(userInput);
+				g_system->setTextInClipboard(userInput.decode(Common::kLatin1));
 		}
 		break;
 	default:

--- a/gui/downloaddialog.cpp
+++ b/gui/downloaddialog.cpp
@@ -57,7 +57,7 @@ DownloadDialog::DownloadDialog(uint32 storageId, LauncherDialog *launcher) :
 	_progressBar->setMaxValue(100);
 	_progressBar->setValue(progress);
 	_progressBar->setEnabled(false);
-	_percentLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.PercentText", Common::String::format("%u %%", progress));
+	_percentLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.PercentText", Common::U32String::format("%u %%", progress));
 	_downloadSizeLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.DownloadSize", Common::U32String());
 	_downloadSpeedLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.DownloadSpeed", Common::U32String());
 	if (g_system->getOverlayWidth() > 320)
@@ -224,10 +224,10 @@ Common::U32String DownloadDialog::getSpeedLabelText() {
 
 void DownloadDialog::refreshWidgets() {
 	_localDirectory = CloudMan.getDownloadLocalDirectory();
-	_remoteDirectoryLabel->setLabel(_("From: ") + Common::U32String(CloudMan.getDownloadRemoteDirectory()));
-	_localDirectoryLabel->setLabel(_("To: ") + Common::U32String(_localDirectory));
+	_remoteDirectoryLabel->setLabel(_("From: ") + CloudMan.getDownloadRemoteDirectory().decode(Common::kLatin1));
+	_localDirectoryLabel->setLabel(_("To: ") + _localDirectory.decode(Common::kLatin1));
 	uint32 progress = (uint32)(100 * CloudMan.getDownloadingProgress());
-	_percentLabel->setLabel(Common::String::format("%u %%", progress));
+	_percentLabel->setLabel(Common::U32String::format("%u %%", progress));
 	_downloadSizeLabel->setLabel(getSizeLabelText());
 	_downloadSpeedLabel->setLabel(getSpeedLabelText());
 	_progressBar->setValue(progress);

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -145,14 +145,14 @@ EditGameDialog::EditGameDialog(const String &domain)
 		new StaticTextWidget(tab, "GameOptions_Game.Id", _("ID:"), _("Short game identifier used for referring to saved games and running the game from the command line"));
 	else
 		new StaticTextWidget(tab, "GameOptions_Game.Id", _c("ID:", "lowres"), _("Short game identifier used for referring to saved games and running the game from the command line"));
-	_domainWidget = new DomainEditTextWidget(tab, "GameOptions_Game.Domain", _domain, _("Short game identifier used for referring to saved games and running the game from the command line"));
+	_domainWidget = new DomainEditTextWidget(tab, "GameOptions_Game.Domain", _domain.decode(Common::kLatin1), _("Short game identifier used for referring to saved games and running the game from the command line"));
 
 	// GUI:  Label & edit widget for the description
 	if (g_system->getOverlayWidth() > 320)
 		new StaticTextWidget(tab, "GameOptions_Game.Name", _("Name:"), _("Full title of the game"));
 	else
 		new StaticTextWidget(tab, "GameOptions_Game.Name", _c("Name:", "lowres"), _("Full title of the game"));
-	_descriptionWidget = new EditTextWidget(tab, "GameOptions_Game.Desc", description, _("Full title of the game"));
+	_descriptionWidget = new EditTextWidget(tab, "GameOptions_Game.Desc", description.decode(Common::kLatin1), _("Full title of the game"));
 
 	// Language popup
 	_langPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.LangPopupDesc", _("Language:"), _("Language of the game. This will not turn your Spanish game version into English"));
@@ -330,14 +330,14 @@ EditGameDialog::EditGameDialog(const String &domain)
 		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _("Game Path:"), Common::U32String(), kCmdGameBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _c("Game Path:", "lowres"), Common::U32String(), kCmdGameBrowser);
-	_gamePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.GamepathText", gamePath);
+	_gamePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.GamepathText", gamePath.decode(Common::kLatin1));
 
 	// GUI:  Button + Label for the additional path
 	if (g_system->getOverlayWidth() > 320)
 		new ButtonWidget(tab, "GameOptions_Paths.Extrapath", _("Extra Path:"), _("Specifies path to additional data used by the game"), kCmdExtraBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Extrapath", _c("Extra Path:", "lowres"), _("Specifies path to additional data used by the game"), kCmdExtraBrowser);
-	_extraPathWidget = new StaticTextWidget(tab, "GameOptions_Paths.ExtrapathText", extraPath, _("Specifies path to additional data used by the game"));
+	_extraPathWidget = new StaticTextWidget(tab, "GameOptions_Paths.ExtrapathText", extraPath.decode(Common::kLatin1), _("Specifies path to additional data used by the game"));
 
 	_extraPathClearButton = addClearButton(tab, "GameOptions_Paths.ExtraPathClearButton", kCmdExtraPathClear);
 
@@ -346,7 +346,7 @@ EditGameDialog::EditGameDialog(const String &domain)
 		new ButtonWidget(tab, "GameOptions_Paths.Savepath", _("Save Path:"), _("Specifies where your saved games are put"), kCmdSaveBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Savepath", _c("Save Path:", "lowres"), _("Specifies where your saved games are put"), kCmdSaveBrowser);
-	_savePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.SavepathText", savePath, _("Specifies where your saved games are put"));
+	_savePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.SavepathText", savePath.decode(Common::kLatin1), _("Specifies where your saved games are put"));
 
 	_savePathClearButton = addClearButton(tab, "GameOptions_Paths.SavePathClearButton", kCmdSavePathClear);
 
@@ -463,7 +463,7 @@ void EditGameDialog::open() {
 }
 
 void EditGameDialog::apply() {
-	ConfMan.set("description", _descriptionWidget->getEditString(), _domain);
+	ConfMan.set("description", _descriptionWidget->getEditString().legacyEncode(), _domain);
 
 	Common::Language lang = (Common::Language)_langPopUp->getSelectedTag();
 	if (lang < 0)
@@ -473,17 +473,17 @@ void EditGameDialog::apply() {
 
 	U32String gamePath(_gamePathWidget->getLabel());
 	if (!gamePath.empty())
-		ConfMan.set("path", gamePath, _domain);
+		ConfMan.set("path", gamePath.legacyEncode(), _domain);
 
 	U32String extraPath(_extraPathWidget->getLabel());
 	if (!extraPath.empty() && (extraPath != _c("None", "path")))
-		ConfMan.set("extrapath", extraPath, _domain);
+		ConfMan.set("extrapath", extraPath.legacyEncode(), _domain);
 	else
 		ConfMan.removeKey("extrapath", _domain);
 
 	U32String savePath(_savePathWidget->getLabel());
 	if (!savePath.empty() && (savePath != _("Default")))
-		ConfMan.set("savepath", savePath, _domain);
+		ConfMan.set("savepath", savePath.legacyEncode(), _domain);
 	else
 		ConfMan.removeKey("savepath", _domain);
 
@@ -536,7 +536,7 @@ void EditGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 		if (browser.runModal() > 0) {
 			// User made this choice...
 			Common::FSNode file(browser.getResult());
-			_soundFont->setLabel(file.getPath());
+			_soundFont->setLabel(file.getPath().decode(Common::kLatin1));
 
 			if (!file.getPath().empty() && (file.getPath() != Common::convertFromU32String(_c("None", "path"))))
 				_soundFontClearButton->setEnabled(true);
@@ -560,7 +560,7 @@ void EditGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 			// done with optional specific gameid to pluginmgr detectgames?
 			// FSList files = dir.listDir(FSNode::kListFilesOnly);
 
-			_gamePathWidget->setLabel(dir.getPath());
+			_gamePathWidget->setLabel(dir.getPath().decode(Common::kLatin1));
 			g_gui.scheduleTopDialogRedraw();
 		}
 		g_gui.scheduleTopDialogRedraw();
@@ -574,7 +574,7 @@ void EditGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 		if (browser.runModal() > 0) {
 			// User made his choice...
 			Common::FSNode dir(browser.getResult());
-			_extraPathWidget->setLabel(dir.getPath());
+			_extraPathWidget->setLabel(dir.getPath().decode(Common::kLatin1));
 			g_gui.scheduleTopDialogRedraw();
 		}
 		g_gui.scheduleTopDialogRedraw();
@@ -587,7 +587,7 @@ void EditGameDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 		if (browser.runModal() > 0) {
 			// User made his choice...
 			Common::FSNode dir(browser.getResult());
-			_savePathWidget->setLabel(dir.getPath());
+			_savePathWidget->setLabel(dir.getPath().decode(Common::kLatin1));
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)
 			MessageDialog warningMessage(_("Saved games sync feature doesn't work with non-default directories. If you want your saved games to sync, use default directory."));
 			warningMessage.runModal();

--- a/gui/error.cpp
+++ b/gui/error.cpp
@@ -36,7 +36,7 @@ void displayErrorDialog(const Common::U32String &text) {
 void displayErrorDialog(const Common::Error &error, const Common::U32String &extraText) {
 	Common::U32String errorText(extraText);
 	errorText += USTR(" ");
-	errorText += error.getDesc();
+	errorText += _(error.getDesc());
 	GUI::MessageDialog alert(errorText);
 	alert.runModal();
 }

--- a/gui/error.cpp
+++ b/gui/error.cpp
@@ -35,8 +35,8 @@ void displayErrorDialog(const Common::U32String &text) {
 
 void displayErrorDialog(const Common::Error &error, const Common::U32String &extraText) {
 	Common::U32String errorText(extraText);
-	errorText += Common::U32String(" ");
-	errorText += _(error.getDesc());
+	errorText += USTR(" ");
+	errorText += error.getDesc();
 	GUI::MessageDialog alert(errorText);
 	alert.runModal();
 }

--- a/gui/filebrowser-dialog.cpp
+++ b/gui/filebrowser-dialog.cpp
@@ -107,12 +107,12 @@ void FileBrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 
 }
 
 void FileBrowserDialog::normalieFileName() {
-	Common::String filename = Common::convertFromU32String(_fileName->getEditString());
+	Common::String filename = _fileName->getEditString().encode(Common::kUtf8);
 
 	if (filename.matchString(_fileMask, true))
 		return;
 
-	_fileName->setEditString(filename + "." + _fileExt);
+	_fileName->setEditString((filename + "." + _fileExt).decode(Common::kUtf8));
 }
 
 
@@ -148,7 +148,7 @@ void FileBrowserDialog::updateListing() {
 	Common::sort(filenames.begin(), filenames.end());
 
 	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {
-		list.push_back(Common::U32String(*file));
+		list.push_back(Common::U32String(*file, Common::kLatin1));
 	}
 
 	_fileList->setList(list);

--- a/gui/fluidsynth-dialog.cpp
+++ b/gui/fluidsynth-dialog.cpp
@@ -75,28 +75,28 @@ FluidSynthSettingsDialog::FluidSynthSettingsDialog()
 	// 0.00 - 1.20, Default: 0.20
 	_reverbRoomSizeSlider->setMinValue(0);
 	_reverbRoomSizeSlider->setMaxValue(120);
-	_reverbRoomSizeLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.RoomSizeLabel", Common::U32String("20"));
+	_reverbRoomSizeLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.RoomSizeLabel", USTR("20"));
 
 	_reverbDampingDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.DampingText", _("Damp:"));
 	_reverbDampingSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Reverb.DampingSlider", Common::U32String(), kReverbDampingChangedCmd);
 	// 0.00 - 1.00, Default: 0.00
 	_reverbDampingSlider->setMinValue(0);
 	_reverbDampingSlider->setMaxValue(100);
-	_reverbDampingLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.DampingLabel", Common::U32String("0"));
+	_reverbDampingLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.DampingLabel", USTR("0"));
 
 	_reverbWidthDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.WidthText", _("Width:"));
 	_reverbWidthSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Reverb.WidthSlider", Common::U32String(), kReverbWidthChangedCmd);
 	// 0 - 100, Default: 1
 	_reverbWidthSlider->setMinValue(0);
 	_reverbWidthSlider->setMaxValue(100);
-	_reverbWidthLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.WidthLabel", Common::U32String("1"));
+	_reverbWidthLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.WidthLabel", USTR("1"));
 
 	_reverbLevelDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.LevelText", _("Level:"));
 	_reverbLevelSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Reverb.LevelSlider", Common::U32String(), kReverbLevelChangedCmd);
 	// 0.00 - 1.00, Default: 0.90
 	_reverbLevelSlider->setMinValue(0);
 	_reverbLevelSlider->setMaxValue(100);
-	_reverbLevelLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.LevelLabel", Common::U32String("90"));
+	_reverbLevelLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Reverb.LevelLabel", USTR("90"));
 
 	_tabWidget->addTab(_("Chorus"), "FluidSynthSettings_Chorus");
 
@@ -107,28 +107,28 @@ FluidSynthSettingsDialog::FluidSynthSettingsDialog()
 	// 0-99, Default: 3
 	_chorusVoiceCountSlider->setMinValue(0);
 	_chorusVoiceCountSlider->setMaxValue(99);
-	_chorusVoiceCountLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.VoiceCountLabel", Common::U32String("3"));
+	_chorusVoiceCountLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.VoiceCountLabel", USTR("3"));
 
 	_chorusLevelDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.LevelText", _("Level:"));
 	_chorusLevelSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Chorus.LevelSlider", Common::U32String(), kChorusLevelChangedCmd);
 	// 0.00 - 1.00, Default: 1.00
 	_chorusLevelSlider->setMinValue(0);
 	_chorusLevelSlider->setMaxValue(100);
-	_chorusLevelLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.LevelLabel", Common::U32String("100"));
+	_chorusLevelLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.LevelLabel", USTR("100"));
 
 	_chorusSpeedDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.SpeedText", _("Speed:"));
 	_chorusSpeedSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Chorus.SpeedSlider", Common::U32String(), kChorusSpeedChangedCmd);
 	// 0.30 - 5.00, Default: 0.30
 	_chorusSpeedSlider->setMinValue(30);
 	_chorusSpeedSlider->setMaxValue(500);
-	_chorusSpeedLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.SpeedLabel", Common::U32String("30"));
+	_chorusSpeedLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.SpeedLabel", USTR("30"));
 
 	_chorusDepthDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.DepthText", _("Depth:"));
 	_chorusDepthSlider = new SliderWidget(_tabWidget, "FluidSynthSettings_Chorus.DepthSlider", Common::U32String(), kChorusDepthChangedCmd);
 	// 0.00 - 21.00, Default: 8.00
 	_chorusDepthSlider->setMinValue(0);
 	_chorusDepthSlider->setMaxValue(210);
-	_chorusDepthLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.DepthLabel", Common::U32String("80"));
+	_chorusDepthLabel = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.DepthLabel", USTR("80"));
 
 	_chorusWaveFormTypePopUpDesc = new StaticTextWidget(_tabWidget, "FluidSynthSettings_Chorus.WaveFormTypeText", _("Type:"));
 	_chorusWaveFormTypePopUp = new PopUpWidget(_tabWidget, "FluidSynthSettings_Chorus.WaveFormType");
@@ -180,38 +180,38 @@ void FluidSynthSettingsDialog::handleCommand(CommandSender *sender, uint32 cmd, 
 		setChorusSettingsState(data);
 		break;
 	case kChorusVoiceCountChangedCmd:
-		_chorusVoiceCountLabel->setLabel(Common::String::format("%d", _chorusVoiceCountSlider->getValue()));
+		_chorusVoiceCountLabel->setLabel(Common::U32String::format("%d", _chorusVoiceCountSlider->getValue()));
 		_chorusVoiceCountLabel->markAsDirty();
 		break;
 	case kChorusLevelChangedCmd:
-		_chorusLevelLabel->setLabel(Common::String::format("%d", _chorusLevelSlider->getValue()));
+		_chorusLevelLabel->setLabel(Common::U32String::format("%d", _chorusLevelSlider->getValue()));
 		_chorusLevelLabel->markAsDirty();
 		break;
 	case kChorusSpeedChangedCmd:
-		_chorusSpeedLabel->setLabel(Common::String::format("%d", _chorusSpeedSlider->getValue()));
+		_chorusSpeedLabel->setLabel(Common::U32String::format("%d", _chorusSpeedSlider->getValue()));
 		_chorusSpeedLabel->markAsDirty();
 		break;
 	case kChorusDepthChangedCmd:
-		_chorusDepthLabel->setLabel(Common::String::format("%d", _chorusDepthSlider->getValue()));
+		_chorusDepthLabel->setLabel(Common::U32String::format("%d", _chorusDepthSlider->getValue()));
 		_chorusDepthLabel->markAsDirty();
 		break;
 	case kActivateReverbCmd:
 		setReverbSettingsState(data);
 		break;
 	case kReverbRoomSizeChangedCmd:
-		_reverbRoomSizeLabel->setLabel(Common::String::format("%d", _reverbRoomSizeSlider->getValue()));
+		_reverbRoomSizeLabel->setLabel(Common::U32String::format("%d", _reverbRoomSizeSlider->getValue()));
 		_reverbRoomSizeLabel->markAsDirty();
 		break;
 	case kReverbDampingChangedCmd:
-		_reverbDampingLabel->setLabel(Common::String::format("%d", _reverbDampingSlider->getValue()));
+		_reverbDampingLabel->setLabel(Common::U32String::format("%d", _reverbDampingSlider->getValue()));
 		_reverbDampingLabel->markAsDirty();
 		break;
 	case kReverbWidthChangedCmd:
-		_reverbWidthLabel->setLabel(Common::String::format("%d", _reverbWidthSlider->getValue()));
+		_reverbWidthLabel->setLabel(Common::U32String::format("%d", _reverbWidthSlider->getValue()));
 		_reverbWidthLabel->markAsDirty();
 		break;
 	case kReverbLevelChangedCmd:
-		_reverbLevelLabel->setLabel(Common::String::format("%d", _reverbLevelSlider->getValue()));
+		_reverbLevelLabel->setLabel(Common::U32String::format("%d", _reverbLevelSlider->getValue()));
 		_reverbLevelLabel->markAsDirty();
 		break;
 	case kResetSettingsCmd: {
@@ -267,13 +267,13 @@ void FluidSynthSettingsDialog::setReverbSettingsState(bool enabled) {
 
 void FluidSynthSettingsDialog::readSettings() {
 	_chorusVoiceCountSlider->setValue(ConfMan.getInt("fluidsynth_chorus_nr", _domain));
-	_chorusVoiceCountLabel->setLabel(Common::String::format("%d", _chorusVoiceCountSlider->getValue()));
+	_chorusVoiceCountLabel->setLabel(Common::U32String::format("%d", _chorusVoiceCountSlider->getValue()));
 	_chorusLevelSlider->setValue(ConfMan.getInt("fluidsynth_chorus_level", _domain));
-	_chorusLevelLabel->setLabel(Common::String::format("%d", _chorusLevelSlider->getValue()));
+	_chorusLevelLabel->setLabel(Common::U32String::format("%d", _chorusLevelSlider->getValue()));
 	_chorusSpeedSlider->setValue(ConfMan.getInt("fluidsynth_chorus_speed", _domain));
-	_chorusSpeedLabel->setLabel(Common::String::format("%d", _chorusSpeedSlider->getValue()));
+	_chorusSpeedLabel->setLabel(Common::U32String::format("%d", _chorusSpeedSlider->getValue()));
 	_chorusDepthSlider->setValue(ConfMan.getInt("fluidsynth_chorus_depth", _domain));
-	_chorusDepthLabel->setLabel(Common::String::format("%d", _chorusDepthSlider->getValue()));
+	_chorusDepthLabel->setLabel(Common::U32String::format("%d", _chorusDepthSlider->getValue()));
 
 	Common::String waveForm = ConfMan.get("fluidsynth_chorus_waveform", _domain);
 	if (waveForm == "sine") {
@@ -283,13 +283,13 @@ void FluidSynthSettingsDialog::readSettings() {
 	}
 
 	_reverbRoomSizeSlider->setValue(ConfMan.getInt("fluidsynth_reverb_roomsize", _domain));
-	_reverbRoomSizeLabel->setLabel(Common::String::format("%d", _reverbRoomSizeSlider->getValue()));
+	_reverbRoomSizeLabel->setLabel(Common::U32String::format("%d", _reverbRoomSizeSlider->getValue()));
 	_reverbDampingSlider->setValue(ConfMan.getInt("fluidsynth_reverb_damping", _domain));
-	_reverbDampingLabel->setLabel(Common::String::format("%d", _reverbDampingSlider->getValue()));
+	_reverbDampingLabel->setLabel(Common::U32String::format("%d", _reverbDampingSlider->getValue()));
 	_reverbWidthSlider->setValue(ConfMan.getInt("fluidsynth_reverb_width", _domain));
-	_reverbWidthLabel->setLabel(Common::String::format("%d", _reverbWidthSlider->getValue()));
+	_reverbWidthLabel->setLabel(Common::U32String::format("%d", _reverbWidthSlider->getValue()));
 	_reverbLevelSlider->setValue(ConfMan.getInt("fluidsynth_reverb_level", _domain));
-	_reverbLevelLabel->setLabel(Common::String::format("%d", _reverbLevelSlider->getValue()));
+	_reverbLevelLabel->setLabel(Common::U32String::format("%d", _reverbLevelSlider->getValue()));
 
 	Common::String interpolation = ConfMan.get("fluidsynth_misc_interpolation", _domain);
 	if (interpolation == "none") {

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -102,7 +102,7 @@ public:
 
 	const Graphics::Font &getFont(ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return *(_theme->getFont(style)); }
 	int getFontHeight(ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getFontHeight(style); }
-	int getStringWidth(const Common::String &str, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getStringWidth(str, style); }
+	int getStringWidth(const Common::String &str, Common::CodePage encoding, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getStringWidth(Common::U32String(str, encoding), style); }
 	int getStringWidth(const Common::U32String &str, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getStringWidth(str, style); }
 	int getCharWidth(byte c, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getCharWidth(c, style); }
 	int getKerningOffset(byte left, byte right, ThemeEngine::FontStyle font = ThemeEngine::kFontStyleBold) const { return _theme->getKerningOffset(left, right, font); }

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -129,9 +129,9 @@ void LauncherDialog::build() {
 		_logo->useThemeTransparency(true);
 		_logo->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageLogo));
 
-		new StaticTextWidget(this, "Launcher.Version", Common::U32String(gScummVMVersionDate));
+		new StaticTextWidget(this, "Launcher.Version", Common::U32String(gScummVMVersionDate, Common::kLatin1));
 	} else
-		new StaticTextWidget(this, "Launcher.Version", Common::U32String(gScummVMFullVersion));
+		new StaticTextWidget(this, "Launcher.Version", Common::U32String(gScummVMFullVersion, Common::kLatin1));
 #else
 	// Show ScummVM version
 	new StaticTextWidget(this, "Launcher.Version", Common::U32String(gScummVMFullVersion));
@@ -184,7 +184,7 @@ void LauncherDialog::build() {
 #endif
 		_searchDesc = new StaticTextWidget(this, "Launcher.SearchDesc", _("Search:"));
 
-	_searchWidget = new EditTextWidget(this, "Launcher.Search", _search, Common::U32String(), kSearchCmd);
+	_searchWidget = new EditTextWidget(this, "Launcher.Search", _search.decode(Common::kLatin1), Common::U32String(), kSearchCmd);
 	_searchClearButton = addClearButton(this, "Launcher.SearchClearButton", kSearchClearCmd);
 
 	// Add list with game titles
@@ -331,7 +331,7 @@ void LauncherDialog::updateListing() {
 			}
 		}
 
-		l.push_back(iter->description);
+		l.push_back(iter->description.decode(Common::kLatin1));
 		colors.push_back(color);
 		_domains.push_back(iter->key);
 	}
@@ -594,10 +594,10 @@ bool LauncherDialog::doGameDetection(const Common::String &path) {
 		// Display the candidates to the user and let her/him pick one
 		U32StringArray list;
 		for (idx = 0; idx < (int)candidates.size(); idx++) {
-			Common::U32String description = candidates[idx].description;
+			Common::U32String description = candidates[idx].description.decode(Common::kLatin1);
 
 			if (candidates[idx].hasUnknownFiles) {
-				description += Common::U32String(" - ");
+				description += USTR(" - ");
 				description += _("Unknown variant");
 			}
 
@@ -748,7 +748,7 @@ void LauncherDialog::reflowLayout() {
 		StaticTextWidget *ver = (StaticTextWidget *)findWidget("Launcher.Version");
 		if (ver) {
 			ver->setAlign(g_gui.xmlEval()->getWidgetTextHAlign("Launcher.Version"));
-			ver->setLabel(Common::U32String(gScummVMVersionDate));
+			ver->setLabel(Common::U32String(gScummVMVersionDate, Common::kLatin1));
 		}
 
 		if (!_logo)
@@ -759,7 +759,7 @@ void LauncherDialog::reflowLayout() {
 		StaticTextWidget *ver = (StaticTextWidget *)findWidget("Launcher.Version");
 		if (ver) {
 			ver->setAlign(g_gui.xmlEval()->getWidgetTextHAlign("Launcher.Version"));
-			ver->setLabel(Common::U32String(gScummVMFullVersion));
+			ver->setLabel(Common::U32String(gScummVMFullVersion, Common::kLatin1));
 		}
 
 		if (_logo) {

--- a/gui/message.cpp
+++ b/gui/message.cpp
@@ -107,12 +107,6 @@ MessageDialog::MessageDialog(const Common::U32String &message, const Common::U32
 	init(message, defaultButton, altButton, alignment, url);
 }
 
-MessageDialog::MessageDialog(const Common::String &message, const Common::String &defaultButton, const Common::String &altButton, Graphics::TextAlign alignment, const char *url)
-	: Dialog(30, 20, 260, 124) {
-
-	init(Common::U32String(message), Common::U32String(defaultButton), Common::U32String(altButton), alignment, url);
-}
-
 void MessageDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	// FIXME: It's a really bad thing that we use two arbitrary constants
 	if (cmd == kOkCmd) {
@@ -146,10 +140,6 @@ void TimedMessageDialog::handleTickle() {
 
 MessageDialogWithURL::MessageDialogWithURL(const Common::U32String &message, const char *url, const Common::U32String &defaultButton, Graphics::TextAlign alignment)
 	: MessageDialog(message, defaultButton, _("Open URL"), alignment, url) {
-}
-
-MessageDialogWithURL::MessageDialogWithURL(const Common::String &message, const char *url, const char *defaultButton, Graphics::TextAlign alignment)
-		: MessageDialog(Common::U32String(message), Common::U32String(defaultButton), _("Open URL"), alignment, url) {
 }
 
 

--- a/gui/message.h
+++ b/gui/message.h
@@ -41,8 +41,7 @@ enum {
  */
 class MessageDialog : public Dialog {
 public:
-	MessageDialog(const Common::U32String &message, const Common::U32String &defaultButton = Common::U32String("OK"), const Common::U32String &altButton = Common::U32String(), Graphics::TextAlign alignment = Graphics::kTextAlignCenter, const char *url = nullptr);
-	MessageDialog(const Common::String &message, const Common::String &defaultButton = "OK", const Common::String &altButton = "", Graphics::TextAlign alignment = Graphics::kTextAlignCenter, const char *url = nullptr);
+	MessageDialog(const Common::U32String &message, const Common::U32String &defaultButton = USTR("OK"), const Common::U32String &altButton = Common::U32String(), Graphics::TextAlign alignment = Graphics::kTextAlignCenter, const char *url = nullptr);
 
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 private:
@@ -68,8 +67,7 @@ protected:
  */
 class MessageDialogWithURL : public MessageDialog {
 public:
-	MessageDialogWithURL(const Common::U32String &message, const char *url, const Common::U32String &defaultButton = Common::U32String("OK"), Graphics::TextAlign alignment = Graphics::kTextAlignCenter);
-	MessageDialogWithURL(const Common::String &message, const char *url, const char *defaultButton = "OK", Graphics::TextAlign alignment = Graphics::kTextAlignCenter);
+	MessageDialogWithURL(const Common::U32String &message, const char *url, const Common::U32String &defaultButton = USTR("OK"), Graphics::TextAlign alignment = Graphics::kTextAlignCenter);
 };
 
 

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -420,13 +420,13 @@ void OptionsDialog::build() {
 			_soundFont->setLabel(_c("None", "soundfont"));
 			_soundFontClearButton->setEnabled(false);
 		} else {
-			_soundFont->setLabel(soundFont);
+			_soundFont->setLabel(soundFont.decode(Common::kLatin1));
 			_soundFontClearButton->setEnabled(true);
 		}
 
 		// MIDI gain setting
 		_midiGainSlider->setValue(ConfMan.getInt("midi_gain", _domain));
-		_midiGainLabel->setLabel(Common::String::format("%.2f", (double)_midiGainSlider->getValue() / 100.0));
+		_midiGainLabel->setLabel(Common::String::format("%.2f", (double)_midiGainSlider->getValue() / 100.0).decode(Common::kLatin1));
 	}
 
 	// MT-32 options
@@ -667,7 +667,7 @@ void OptionsDialog::apply() {
 					}
 					gm++;
 				}
-				message += Common::U32String("\n");
+				message += USTR("\n");
 				message += _("the video mode could not be changed");
 			}
 
@@ -680,25 +680,25 @@ void OptionsDialog::apply() {
 					}
 					sm++;
 				}
-				message += Common::U32String("\n");
+				message += USTR("\n");
 				message += _("the stretch mode could not be changed");
 			}
 
 			if (gfxError & OSystem::kTransactionAspectRatioFailed) {
 				ConfMan.setBool("aspect_ratio", g_system->getFeatureState(OSystem::kFeatureAspectRatioCorrection), _domain);
-				message += Common::U32String("\n");
+				message += USTR("\n");
 				message += _("the aspect ratio setting could not be changed");
 			}
 
 			if (gfxError & OSystem::kTransactionFullscreenFailed) {
 				ConfMan.setBool("fullscreen", g_system->getFeatureState(OSystem::kFeatureFullscreenMode), _domain);
-				message += Common::U32String("\n");
+				message += USTR("\n");
 				message += _("the fullscreen setting could not be changed");
 			}
 
 			if (gfxError & OSystem::kTransactionFilteringFailed) {
 				ConfMan.setBool("filtering", g_system->getFeatureState(OSystem::kFeatureFilteringMode), _domain);
-				message += Common::U32String("\n");
+				message += USTR("\n");
 				message += _("the filtering setting could not be changed");
 			}
 
@@ -872,7 +872,7 @@ void OptionsDialog::close() {
 void OptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	switch (cmd) {
 	case kMidiGainChanged:
-		_midiGainLabel->setLabel(Common::String::format("%.2f", (double)_midiGainSlider->getValue() / 100.0));
+		_midiGainLabel->setLabel(Common::String::format("%.2f", (double)_midiGainSlider->getValue() / 100.0).decode(Common::kLatin1));
 		_midiGainLabel->markAsDirty();
 		break;
 	case kMusicVolumeChanged: {
@@ -1142,7 +1142,7 @@ void OptionsDialog::addControlControls(GuiObject *boss, const Common::String &pr
 		else
 			_kbdMouseSpeedDesc = new StaticTextWidget(boss, prefix + "grKbdMouseSpeedDesc", _c("Pointer Speed:", "lowres"), _("Speed for keyboard/joystick mouse pointer control"));
 		_kbdMouseSpeedSlider = new SliderWidget(boss, prefix + "grKbdMouseSpeedSlider", _("Speed for keyboard/joystick mouse pointer control"), kKbdMouseSpeedChanged);
-		_kbdMouseSpeedLabel = new StaticTextWidget(boss, prefix + "grKbdMouseSpeedLabel", Common::U32String("  "));
+		_kbdMouseSpeedLabel = new StaticTextWidget(boss, prefix + "grKbdMouseSpeedLabel", USTR("  "));
 		_kbdMouseSpeedSlider->setMinValue(0);
 		_kbdMouseSpeedSlider->setMaxValue(7);
 		_kbdMouseSpeedLabel->setFlags(WIDGET_CLEARBG);
@@ -1155,7 +1155,7 @@ void OptionsDialog::addControlControls(GuiObject *boss, const Common::String &pr
 		else
 			_joystickDeadzoneDesc = new StaticTextWidget(boss, prefix + "grJoystickDeadzoneDesc", _c("Joy Deadzone:", "lowres"), _("Analog joystick Deadzone"));
 		_joystickDeadzoneSlider = new SliderWidget(boss, prefix + "grJoystickDeadzoneSlider", _("Analog joystick Deadzone"), kJoystickDeadzoneChanged);
-		_joystickDeadzoneLabel = new StaticTextWidget(boss, prefix + "grJoystickDeadzoneLabel", Common::U32String("  "));
+		_joystickDeadzoneLabel = new StaticTextWidget(boss, prefix + "grJoystickDeadzoneLabel", USTR("  "));
 		_joystickDeadzoneSlider->setMinValue(1);
 		_joystickDeadzoneSlider->setMaxValue(10);
 		_joystickDeadzoneLabel->setFlags(WIDGET_CLEARBG);
@@ -1212,13 +1212,13 @@ void OptionsDialog::addAchievementsControls(GuiObject *boss, const Common::Strin
 			}
 
 			CheckboxWidget *checkBox;
-			checkBox = new CheckboxWidget(scrollContainer, lineHeight, yPos, width, yStep, Common::U32String(info.descriptions[idx].title));
+			checkBox = new CheckboxWidget(scrollContainer, lineHeight, yPos, width, yStep, Common::U32String(info.descriptions[idx].title, Common::kLatin1));
 			checkBox->setEnabled(false);
 			checkBox->setState(isAchieved);
 			yPos += yStep;
 
-	        if (info.descriptions[idx].comment && strlen(info.descriptions[idx].comment) > 0) {
-				new StaticTextWidget(scrollContainer, lineHeight + descrDelta, yPos, width - descrDelta, yStep, Common::U32String(info.descriptions[idx].comment), Graphics::kTextAlignStart, Common::U32String(), ThemeEngine::kFontStyleNormal);
+			if (info.descriptions[idx].comment && strlen(info.descriptions[idx].comment) > 0) {
+				new StaticTextWidget(scrollContainer, lineHeight + descrDelta, yPos, width - descrDelta, yStep, Common::U32String(info.descriptions[idx].comment, Common::kLatin1), Graphics::kTextAlignStart, Common::U32String(), ThemeEngine::kFontStyleNormal);
 				yPos += yStep;
 			}
 
@@ -1444,7 +1444,7 @@ void OptionsDialog::addMIDIControls(GuiObject *boss, const Common::String &prefi
 	_midiGainSlider = new SliderWidget(boss, prefix + "mcMidiGainSlider", Common::U32String(), kMidiGainChanged);
 	_midiGainSlider->setMinValue(0);
 	_midiGainSlider->setMaxValue(1000);
-	_midiGainLabel = new StaticTextWidget(boss, prefix + "mcMidiGainLabel", Common::U32String("1.00"));
+	_midiGainLabel = new StaticTextWidget(boss, prefix + "mcMidiGainLabel", USTR("1.00"));
 
 	_enableMIDISettings = true;
 }
@@ -1519,7 +1519,7 @@ void OptionsDialog::addSubtitleControls(GuiObject *boss, const Common::String &p
 
 	// Subtitle speed
 	_subSpeedSlider = new SliderWidget(boss, prefix + "subSubtitleSpeedSlider", Common::U32String(), kSubtitleSpeedChanged);
-	_subSpeedLabel = new StaticTextWidget(boss, prefix + "subSubtitleSpeedLabel", Common::U32String("100%"));
+	_subSpeedLabel = new StaticTextWidget(boss, prefix + "subSubtitleSpeedLabel", USTR("100%"));
 	_subSpeedSlider->setMinValue(0); _subSpeedSlider->setMaxValue(maxSliderVal);
 	_subSpeedLabel->setFlags(WIDGET_CLEARBG);
 
@@ -1534,7 +1534,7 @@ void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &pre
 	else
 		_musicVolumeDesc = new StaticTextWidget(boss, prefix + "vcMusicText", _c("Music volume:", "lowres"));
 	_musicVolumeSlider = new SliderWidget(boss, prefix + "vcMusicSlider", Common::U32String(), kMusicVolumeChanged);
-	_musicVolumeLabel = new StaticTextWidget(boss, prefix + "vcMusicLabel", Common::U32String("100%"));
+	_musicVolumeLabel = new StaticTextWidget(boss, prefix + "vcMusicLabel", USTR("100%"));
 	_musicVolumeSlider->setMinValue(0);
 	_musicVolumeSlider->setMaxValue(Audio::Mixer::kMaxMixerVolume);
 	_musicVolumeLabel->setFlags(WIDGET_CLEARBG);
@@ -1546,7 +1546,7 @@ void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &pre
 	else
 		_sfxVolumeDesc = new StaticTextWidget(boss, prefix + "vcSfxText", _c("SFX volume:", "lowres"), _("Special sound effects volume"));
 	_sfxVolumeSlider = new SliderWidget(boss, prefix + "vcSfxSlider", _("Special sound effects volume"), kSfxVolumeChanged);
-	_sfxVolumeLabel = new StaticTextWidget(boss, prefix + "vcSfxLabel", Common::U32String("100%"));
+	_sfxVolumeLabel = new StaticTextWidget(boss, prefix + "vcSfxLabel", USTR("100%"));
 	_sfxVolumeSlider->setMinValue(0);
 	_sfxVolumeSlider->setMaxValue(Audio::Mixer::kMaxMixerVolume);
 	_sfxVolumeLabel->setFlags(WIDGET_CLEARBG);
@@ -1556,7 +1556,7 @@ void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &pre
 	else
 		_speechVolumeDesc = new StaticTextWidget(boss, prefix + "vcSpeechText" , _c("Speech volume:", "lowres"));
 	_speechVolumeSlider = new SliderWidget(boss, prefix + "vcSpeechSlider", Common::U32String(), kSpeechVolumeChanged);
-	_speechVolumeLabel = new StaticTextWidget(boss, prefix + "vcSpeechLabel", Common::U32String("100%"));
+	_speechVolumeLabel = new StaticTextWidget(boss, prefix + "vcSpeechLabel", USTR("100%"));
 	_speechVolumeSlider->setMinValue(0);
 	_speechVolumeSlider->setMaxValue(Audio::Mixer::kMaxMixerVolume);
 	_speechVolumeLabel->setFlags(WIDGET_CLEARBG);
@@ -1957,19 +1957,19 @@ void GlobalOptionsDialog::build() {
 	if (savePath.empty() || !ConfMan.hasKey("savepath", _domain)) {
 		_savePath->setLabel(_("Default"));
 	} else {
-		_savePath->setLabel(savePath);
+		_savePath->setLabel(savePath.decode(Common::kLatin1));
 	}
 
 	if (themePath.empty() || !ConfMan.hasKey("themepath", _domain)) {
 		_themePath->setLabel(_c("None", "path"));
 	} else {
-		_themePath->setLabel(themePath);
+		_themePath->setLabel(themePath.decode(Common::kLatin1));
 	}
 
 	if (extraPath.empty() || !ConfMan.hasKey("extrapath", _domain)) {
 		_extraPath->setLabel(_c("None", "path"));
 	} else {
-		_extraPath->setLabel(extraPath);
+		_extraPath->setLabel(extraPath.decode(Common::kLatin1));
 	}
 
 #ifdef DYNAMIC_MODULES
@@ -2001,7 +2001,7 @@ void GlobalOptionsDialog::build() {
 	if (rootPath.empty() || !ConfMan.hasKey("rootpath", "cloud")) {
 		_rootPath->setLabel(_c("None", "path"));
 	} else {
-		_rootPath->setLabel(rootPath);
+		_rootPath->setLabel(rootPath.decode(Common::kLatin1));
 	}
 #endif
 #endif
@@ -2039,7 +2039,7 @@ void GlobalOptionsDialog::addPathsControls(GuiObject *boss, const Common::String
 		new ButtonWidget(boss, prefix + "SaveButton", _("Save Path:"), _("Specifies where your saved games are put"), kChooseSaveDirCmd);
 	else
 		new ButtonWidget(boss, prefix + "SaveButton", _c("Save Path:", "lowres"), _("Specifies where your saved games are put"), kChooseSaveDirCmd);
-	_savePath = new StaticTextWidget(boss, prefix + "SavePath", Common::U32String("/foo/bar"), _("Specifies where your saved games are put"));
+	_savePath = new StaticTextWidget(boss, prefix + "SavePath", USTR("/foo/bar"), _("Specifies where your saved games are put"));
 
 	_savePathClearButton = addClearButton(boss, prefix + "SavePathClearButton", kSavePathClearCmd);
 
@@ -2073,7 +2073,7 @@ void GlobalOptionsDialog::addPathsControls(GuiObject *boss, const Common::String
 
 void GlobalOptionsDialog::addMiscControls(GuiObject *boss, const Common::String &prefix, bool lowres) {
 	new ButtonWidget(boss, prefix + "ThemeButton", _("Theme:"), Common::U32String(), kChooseThemeCmd);
-	_curTheme = new StaticTextWidget(boss, prefix + "CurTheme", g_gui.theme()->getThemeName());
+	_curTheme = new StaticTextWidget(boss, prefix + "CurTheme", g_gui.theme()->getThemeName().decode(Common::kLatin1));
 
 
 	_rendererPopUpDesc = new StaticTextWidget(boss, prefix + "RendererPopupDesc", _("GUI renderer:"));
@@ -2203,7 +2203,7 @@ void GlobalOptionsDialog::addCloudControls(GuiObject *boss, const Common::String
 	_storageUsername = new StaticTextWidget(boss, prefix + "StorageUsernameLabel", _("<none>"), Common::U32String(), ThemeEngine::kFontStyleNormal);
 
 	_storageUsedSpaceDesc = new StaticTextWidget(boss, prefix + "StorageUsedSpaceDesc", _("Used space:"), _("Space used by ScummVM's saved games on this storage"));
-	_storageUsedSpace = new StaticTextWidget(boss, prefix + "StorageUsedSpaceLabel", Common::U32String("0 bytes"), Common::U32String(), ThemeEngine::kFontStyleNormal);
+	_storageUsedSpace = new StaticTextWidget(boss, prefix + "StorageUsedSpaceLabel", USTR("0 bytes"), Common::U32String(), ThemeEngine::kFontStyleNormal);
 
 	_storageLastSyncDesc = new StaticTextWidget(boss, prefix + "StorageLastSyncDesc", _("Last sync:"), _("When was the last time saved games were synced with this storage"));
 	_storageLastSync = new StaticTextWidget(boss, prefix + "StorageLastSyncLabel", _("<never>"), Common::U32String(), ThemeEngine::kFontStyleNormal);
@@ -2230,7 +2230,7 @@ void GlobalOptionsDialog::addCloudControls(GuiObject *boss, const Common::String
 	else
 		_storageWizardNotConnectedHint = new StaticTextWidget(boss, prefix + "StorageWizardNotConnectedHint", _("This storage is not connected yet! To connect,"));
 	_storageWizardOpenLinkHint = new StaticTextWidget(boss, prefix + "StorageWizardOpenLinkHint", _("1. Open this link:"));
-	_storageWizardLink = new ButtonWidget(boss, prefix + "StorageWizardLink", Common::U32String("https://cloud.scummvm.org/"), _("Open URL"), kOpenUrlStorageCmd);
+	_storageWizardLink = new ButtonWidget(boss, prefix + "StorageWizardLink", USTR("https://cloud.scummvm.org/"), _("Open URL"), kOpenUrlStorageCmd);
 	if (lowres)
 		_storageWizardCodeHint = new StaticTextWidget(boss, prefix + "StorageWizardCodeHint", _c("2. Get the code and enter it here:", "lowres"));
 	else
@@ -2238,7 +2238,7 @@ void GlobalOptionsDialog::addCloudControls(GuiObject *boss, const Common::String
 	_storageWizardCodeBox = new EditTextWidget(boss, prefix + "StorageWizardCodeBox", Common::U32String(), Common::U32String(), 0, 0, ThemeEngine::kFontStyleConsole);
 	_storageWizardPasteButton = new ButtonWidget(boss, prefix + "StorageWizardPasteButton", _("Paste"), _("Paste code from clipboard"), kPasteCodeStorageCmd);
 	_storageWizardConnectButton = new ButtonWidget(boss, prefix + "StorageWizardConnectButton", _("3. Connect"), _("Connect your cloud storage account"), kConnectStorageCmd);
-	_storageWizardConnectionStatusHint = new StaticTextWidget(boss, prefix + "StorageWizardConnectionStatusHint", Common::U32String("..."));
+	_storageWizardConnectionStatusHint = new StaticTextWidget(boss, prefix + "StorageWizardConnectionStatusHint", USTR("..."));
 
 	setupCloudTab();
 }
@@ -2254,13 +2254,13 @@ void GlobalOptionsDialog::addNetworkControls(GuiObject *boss, const Common::Stri
 		_rootPathButton = new ButtonWidget(boss, prefix + "RootPathButton", _c("/root/ Path:", "lowres"), _("Select which directory will be shown as /root/ in the Files Manager"), kChooseRootDirCmd);
 	else
 		_rootPathButton = new ButtonWidget(boss, prefix + "RootPathButton", _("/root/ Path:"), _("Select which directory will be shown as /root/ in the Files Manager"), kChooseRootDirCmd);
-	_rootPath = new StaticTextWidget(boss, prefix + "RootPath", Common::U32String("/foo/bar"), _("Select which directory will be shown as /root/ in the Files Manager"));
+	_rootPath = new StaticTextWidget(boss, prefix + "RootPath", USTR("/foo/bar"), _("Select which directory will be shown as /root/ in the Files Manager"));
 	_rootPathClearButton = addClearButton(boss, prefix + "RootPathClearButton", kRootPathClearCmd);
 
 	uint32 port = Networking::LocalWebserver::getPort();
 
 	_serverPortDesc = new StaticTextWidget(boss, prefix + "ServerPortDesc", _("Server's port:"), _("Port for server to use"));
-	_serverPort = new EditTextWidget(boss, prefix + "ServerPortEditText", Common::String::format("%u", port), Common::U32String());
+	_serverPort = new EditTextWidget(boss, prefix + "ServerPortEditText", Common::U32String::format("%u", port), Common::U32String());
 	_serverPortClearButton = addClearButton(boss, prefix + "ServerPortClearButton", kServerPortClearCmd);
 
 	if (lowres) {
@@ -2370,7 +2370,7 @@ void GlobalOptionsDialog::apply() {
 			bool anotherStorageIsWorking = CloudMan.isWorking();
 			Common::U32String message = _("Failed to change cloud storage!");
 			if (anotherStorageIsWorking) {
-				message += Common::U32String("\n");
+				message += USTR("\n");
 				message += _("Another cloud storage is already active.");
 			}
 			MessageDialog dialog(message);
@@ -2440,7 +2440,7 @@ void GlobalOptionsDialog::apply() {
 	if (!g_gui.loadNewTheme(_newTheme, gfxMode, true)) {
 		Common::U32String errorMessage;
 
-		_curTheme->setLabel(oldThemeName);
+		_curTheme->setLabel(oldThemeName.decode(Common::kLatin1));
 		_newTheme = oldThemeId;
 		ConfMan.set("gui_theme", _newTheme);
 		gfxMode = GUI::ThemeEngine::findMode(oldGfxConfig);
@@ -2523,7 +2523,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 			// User made his choice...
 			Common::FSNode dir(browser.getResult());
 			if (dir.isWritable()) {
-				_savePath->setLabel(dir.getPath());
+				_savePath->setLabel(dir.getPath().decode(Common::kLatin1));
 			} else {
 				MessageDialog error(_("The chosen directory cannot be written to. Please select another one."));
 				error.runModal();
@@ -2538,7 +2538,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 		if (browser.runModal() > 0) {
 			// User made his choice...
 			Common::FSNode dir(browser.getResult());
-			_themePath->setLabel(dir.getPath());
+			_themePath->setLabel(dir.getPath().decode(Common::kLatin1));
 			g_gui.scheduleTopDialogRedraw();
 		}
 		break;
@@ -2548,7 +2548,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 		if (browser.runModal() > 0) {
 			// User made his choice...
 			Common::FSNode dir(browser.getResult());
-			_extraPath->setLabel(dir.getPath());
+			_extraPath->setLabel(dir.getPath().decode(Common::kLatin1));
 			g_gui.scheduleTopDialogRedraw();
 		}
 		break;
@@ -2575,7 +2575,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 			Common::String path = dir.getPath();
 			if (path.empty())
 				path = "/"; // absolute root
-			_rootPath->setLabel(path);
+			_rootPath->setLabel(path.decode(Common::kLatin1));
 			g_gui.scheduleTopDialogRedraw();
 		}
 		break;
@@ -2608,9 +2608,9 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 		if (browser.runModal() > 0) {
 			// User made his choice...
 			Common::FSNode file(browser.getResult());
-			_soundFont->setLabel(file.getPath());
+			_soundFont->setLabel(file.getPath().decode(Common::kLatin1));
 
-			if (!file.getPath().empty() && (file.getPath().decode() != _c("None", "path")))
+			if (!file.getPath().empty() && (file.getPath().decode(Common::kUtf8) != _c("None", "path")))
 				_soundFontClearButton->setEnabled(true);
 			else
 				_soundFontClearButton->setEnabled(false);
@@ -2625,7 +2625,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 		if (browser.runModal() > 0) {
 			// User made his choice...
 			_newTheme = browser.getSelected();
-			_curTheme->setLabel(browser.getSelectedName());
+			_curTheme->setLabel(browser.getSelectedName().decode(Common::kLatin1));
 		}
 		break;
 	}
@@ -2793,7 +2793,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 	}
 	case kServerPortClearCmd: {
 		if (_serverPort) {
-			_serverPort->setEditString(Common::String::format("%u", Networking::LocalWebserver::DEFAULT_SERVER_PORT));
+			_serverPort->setEditString(Common::U32String::format("%u", Networking::LocalWebserver::DEFAULT_SERVER_PORT));
 		}
 		g_gui.scheduleTopDialogRedraw();
 		break;
@@ -2921,7 +2921,7 @@ void GlobalOptionsDialog::setupCloudTab() {
 
 	if (_storageUsernameDesc) _storageUsernameDesc->setVisible(shownConnectedInfo);
 	if (_storageUsername) {
-		_storageUsername->setLabel(username);
+		_storageUsername->setLabel(username.decode(Common::kLatin1));
 		_storageUsername->setVisible(shownConnectedInfo);
 	}
 	if (_storageUsedSpaceDesc) _storageUsedSpaceDesc->setVisible(shownConnectedInfo);
@@ -2938,7 +2938,7 @@ void GlobalOptionsDialog::setupCloudTab() {
 	}
 	if (_storageLastSyncDesc) _storageLastSyncDesc->setVisible(shownConnectedInfo);
 	if (_storageLastSync) {
-		Common::U32String sync = CloudMan.getStorageLastSync(_selectedStorageIndex);
+		Common::U32String sync = CloudMan.getStorageLastSync(_selectedStorageIndex).decode(Common::kLatin1);
 		if (sync == "") {
 			if (_selectedStorageIndex == CloudMan.getStorageIndex() && CloudMan.isSyncing())
 				sync = _("<right now>");
@@ -3056,7 +3056,7 @@ void GlobalOptionsDialog::reflowNetworkTabLayout() {
 	if (_serverInfoLabel) {
 		_serverInfoLabel->setVisible(true);
 		if (serverIsRunning)
-			_serverInfoLabel->setLabel(LocalServer.getAddress());
+			_serverInfoLabel->setLabel(LocalServer.getAddress().decode(Common::kLatin1));
 		else
 			_serverInfoLabel->setLabel(_("Not running"));
 	}
@@ -3100,7 +3100,7 @@ void GlobalOptionsDialog::reflowNetworkTabLayout() {
 
 #ifdef USE_LIBCURL
 void GlobalOptionsDialog::storageConnectionCallback(Networking::ErrorResponse response) {
-	Common::U32String message("...");
+	Common::U32String message = USTR("...");
 	if (!response.failed && !response.interrupted) {
 		// success
 		g_system->displayMessageOnOSD(_("Storage connected."));

--- a/gui/predictivedialog.cpp
+++ b/gui/predictivedialog.cpp
@@ -68,7 +68,7 @@ enum {
 };
 
 PredictiveDialog::PredictiveDialog() : Dialog("Predictive") {
-	new StaticTextWidget(this, "Predictive.Headline", Common::U32String("Enter Text"));
+	new StaticTextWidget(this, "Predictive.Headline", USTR("Enter Text"));
 
 	_button[kCancelAct] =  new ButtonWidget(this, "Predictive.Cancel",  _("Cancel")   , Common::U32String(), kCancelCmd);
 	_button[kOkAct] =      new ButtonWidget(this, "Predictive.OK",      _("Ok")       , Common::U32String(), kOkCmd);
@@ -79,27 +79,27 @@ PredictiveDialog::PredictiveDialog() : Dialog("Predictive") {
 			The rest, like okButton, cancel, etc are all flipped.
 		*/
 
-		_button[kButton3Act] = new ButtonWidget(this, "Predictive.Button1", Common::U32String("3  def"      ), Common::U32String(), kBut3Cmd);
-		_button[kButton2Act] = new ButtonWidget(this, "Predictive.Button2", Common::U32String("2  abc"      ), Common::U32String(), kBut2Cmd);
-		_button[kButton1Act] = new ButtonWidget(this, "Predictive.Button3", Common::U32String("1  `-.&"     ), Common::U32String(), kBut1Cmd);
-		_button[kButton6Act] = new ButtonWidget(this, "Predictive.Button4", Common::U32String("6  mno"      ), Common::U32String(), kBut6Cmd);
-		_button[kButton5Act] = new ButtonWidget(this, "Predictive.Button5", Common::U32String("5  jkl"      ), Common::U32String(), kBut5Cmd);
-		_button[kButton4Act] = new ButtonWidget(this, "Predictive.Button6", Common::U32String("4  ghi"      ), Common::U32String(), kBut4Cmd);
-		_button[kButton9Act] = new ButtonWidget(this, "Predictive.Button7", Common::U32String("9  wxyz"     ), Common::U32String(), kBut9Cmd);
-		_button[kButton8Act] = new ButtonWidget(this, "Predictive.Button8", Common::U32String("8  tuv"      ), Common::U32String(), kBut8Cmd);
-		_button[kButton7Act] = new ButtonWidget(this, "Predictive.Button9", Common::U32String("7  pqrs"     ), Common::U32String(), kBut7Cmd);
-		_button[kButton0Act] = new ButtonWidget(this, "Predictive.Button0", Common::U32String("0"           ), Common::U32String(), kBut0Cmd);
+		_button[kButton3Act] = new ButtonWidget(this, "Predictive.Button1", USTR("3  def"      ), Common::U32String(), kBut3Cmd);
+		_button[kButton2Act] = new ButtonWidget(this, "Predictive.Button2", USTR("2  abc"      ), Common::U32String(), kBut2Cmd);
+		_button[kButton1Act] = new ButtonWidget(this, "Predictive.Button3", USTR("1  `-.&"     ), Common::U32String(), kBut1Cmd);
+		_button[kButton6Act] = new ButtonWidget(this, "Predictive.Button4", USTR("6  mno"      ), Common::U32String(), kBut6Cmd);
+		_button[kButton5Act] = new ButtonWidget(this, "Predictive.Button5", USTR("5  jkl"      ), Common::U32String(), kBut5Cmd);
+		_button[kButton4Act] = new ButtonWidget(this, "Predictive.Button6", USTR("4  ghi"      ), Common::U32String(), kBut4Cmd);
+		_button[kButton9Act] = new ButtonWidget(this, "Predictive.Button7", USTR("9  wxyz"     ), Common::U32String(), kBut9Cmd);
+		_button[kButton8Act] = new ButtonWidget(this, "Predictive.Button8", USTR("8  tuv"      ), Common::U32String(), kBut8Cmd);
+		_button[kButton7Act] = new ButtonWidget(this, "Predictive.Button9", USTR("7  pqrs"     ), Common::U32String(), kBut7Cmd);
+		_button[kButton0Act] = new ButtonWidget(this, "Predictive.Button0", USTR("0"           ), Common::U32String(), kBut0Cmd);
 	} else {
-		_button[kButton1Act] = new ButtonWidget(this, "Predictive.Button1", Common::U32String("1  `-.&"     ), Common::U32String(), kBut1Cmd);
-		_button[kButton2Act] = new ButtonWidget(this, "Predictive.Button2", Common::U32String("2  abc"      ), Common::U32String(), kBut2Cmd);
-		_button[kButton3Act] = new ButtonWidget(this, "Predictive.Button3", Common::U32String("3  def"      ), Common::U32String(), kBut3Cmd);
-		_button[kButton4Act] = new ButtonWidget(this, "Predictive.Button4", Common::U32String("4  ghi"      ), Common::U32String(), kBut4Cmd);
-		_button[kButton5Act] = new ButtonWidget(this, "Predictive.Button5", Common::U32String("5  jkl"      ), Common::U32String(), kBut5Cmd);
-		_button[kButton6Act] = new ButtonWidget(this, "Predictive.Button6", Common::U32String("6  mno"      ), Common::U32String(), kBut6Cmd);
-		_button[kButton7Act] = new ButtonWidget(this, "Predictive.Button7", Common::U32String("7  pqrs"     ), Common::U32String(), kBut7Cmd);
-		_button[kButton8Act] = new ButtonWidget(this, "Predictive.Button8", Common::U32String("8  tuv"      ), Common::U32String(), kBut8Cmd);
-		_button[kButton9Act] = new ButtonWidget(this, "Predictive.Button9", Common::U32String("9  wxyz"     ), Common::U32String(), kBut9Cmd);
-		_button[kButton0Act] = new ButtonWidget(this, "Predictive.Button0", Common::U32String("0"           ), Common::U32String(), kBut0Cmd);
+		_button[kButton1Act] = new ButtonWidget(this, "Predictive.Button1", USTR("1  `-.&"     ), Common::U32String(), kBut1Cmd);
+		_button[kButton2Act] = new ButtonWidget(this, "Predictive.Button2", USTR("2  abc"      ), Common::U32String(), kBut2Cmd);
+		_button[kButton3Act] = new ButtonWidget(this, "Predictive.Button3", USTR("3  def"      ), Common::U32String(), kBut3Cmd);
+		_button[kButton4Act] = new ButtonWidget(this, "Predictive.Button4", USTR("4  ghi"      ), Common::U32String(), kBut4Cmd);
+		_button[kButton5Act] = new ButtonWidget(this, "Predictive.Button5", USTR("5  jkl"      ), Common::U32String(), kBut5Cmd);
+		_button[kButton6Act] = new ButtonWidget(this, "Predictive.Button6", USTR("6  mno"      ), Common::U32String(), kBut6Cmd);
+		_button[kButton7Act] = new ButtonWidget(this, "Predictive.Button7", USTR("7  pqrs"     ), Common::U32String(), kBut7Cmd);
+		_button[kButton8Act] = new ButtonWidget(this, "Predictive.Button8", USTR("8  tuv"      ), Common::U32String(), kBut8Cmd);
+		_button[kButton9Act] = new ButtonWidget(this, "Predictive.Button9", USTR("9  wxyz"     ), Common::U32String(), kBut9Cmd);
+		_button[kButton0Act] = new ButtonWidget(this, "Predictive.Button0", USTR("0"           ), Common::U32String(), kBut0Cmd);
 	}
 
 	// I18N: You must leave "#" as is, only word 'next' is translatable
@@ -117,7 +117,7 @@ PredictiveDialog::PredictiveDialog() : Dialog("Predictive") {
 		_button[kDelAct] = new ButtonWidget(this, "Predictive.Delete" , _("<") , Common::U32String(), kDelCmd);
 	// I18N: Pre means 'Predictive', leave '*' as is
 	_button[kModeAct] = new ButtonWidget(this, "Predictive.Pre", _("*  Pre"), Common::U32String(), kModeCmd);
-	_editText = new EditTextWidget(this, "Predictive.Word", _search, Common::U32String(), 0, 0);
+	_editText = new EditTextWidget(this, "Predictive.Word", _search.decode(Common::kLatin1), Common::U32String(), 0, 0);
 
 	_userDictHasChanged = false;
 

--- a/gui/remotebrowser.cpp
+++ b/gui/remotebrowser.cpp
@@ -47,7 +47,7 @@ RemoteBrowserDialog::RemoteBrowserDialog(const Common::U32String &title):
 	_backgroundType = GUI::ThemeEngine::kDialogBackgroundPlain;
 
 	new StaticTextWidget(this, "Browser.Headline", title);
-	_currentPath = new StaticTextWidget(this, "Browser.Path", Common::U32String("DUMMY"));
+	_currentPath = new StaticTextWidget(this, "Browser.Path", USTR("DUMMY"));
 
 	_fileList = new ListWidget(this, "Browser.List");
 	_fileList->setNumberingMode(kListNumberingOff);
@@ -140,7 +140,7 @@ void RemoteBrowserDialog::updateListing() {
 		path = "/"; //root
 	if (_navigationLocked)
 		path = "Loading... " + path;
-	_currentPath->setLabel(path);
+	_currentPath->setLabel(path.decode(Common::kLatin1));
 
 	if (!_navigationLocked) {
 		// Populate the ListWidget
@@ -148,10 +148,10 @@ void RemoteBrowserDialog::updateListing() {
 		ListWidget::ColorList colors;
 		for (Common::Array<Cloud::StorageFile>::iterator i = _nodeContent.begin(); i != _nodeContent.end(); ++i) {
 			if (i->isDirectory()) {
-				list.push_back(i->name() + "/");
+				list.push_back(i->name().decode(Common::kLatin1) + USTR("/"));
 				colors.push_back(ThemeEngine::kFontColorNormal);
 			} else {
-				list.push_back(i->name());
+				list.push_back(i->name().decode(Common::kLatin1));
 				colors.push_back(ThemeEngine::kFontColorAlternate);
 			}
 		}

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -56,7 +56,7 @@ SaveLoadCloudSyncProgressDialog::SaveLoadCloudSyncProgressDialog(bool canRunInBa
 	_progressBar->setMaxValue(100);
 	_progressBar->setValue(progress);
 	_progressBar->setEnabled(false);
-	_percentLabel = new StaticTextWidget(this, "SaveLoadCloudSyncProgress.PercentText", Common::String::format("%u %%", progress));
+	_percentLabel = new StaticTextWidget(this, "SaveLoadCloudSyncProgress.PercentText", Common::U32String::format("%u %%", progress));
 	new ButtonWidget(this, "SaveLoadCloudSyncProgress.Cancel", _("Cancel"), Common::U32String(), kCancelSyncCmd, Common::ASCII_ESCAPE);	// Cancel dialog
 	ButtonWidget *backgroundButton = new ButtonWidget(this, "SaveLoadCloudSyncProgress.Background", _("Run in background"), Common::U32String(), kBackgroundSyncCmd, Common::ASCII_RETURN);	// Confirm dialog
 	backgroundButton->setEnabled(canRunInBackground);
@@ -70,7 +70,7 @@ SaveLoadCloudSyncProgressDialog::~SaveLoadCloudSyncProgressDialog() {
 void SaveLoadCloudSyncProgressDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	switch(cmd) {
 	case kSavesSyncProgressCmd:
-		_percentLabel->setLabel(Common::String::format("%u%%", data));
+		_percentLabel->setLabel(Common::U32String::format("%u%%", data));
 		_progressBar->setValue(data);
 		_progressBar->markAsDirty();
 		break;
@@ -318,7 +318,7 @@ void SaveLoadChooserDialog::listSaves() {
 				slotNum = slotNum * 10 + (c - '0');
 			}
 
-			SaveStateDescriptor slot(slotNum, files[i]);
+			SaveStateDescriptor slot(slotNum, files[i].decode(Common::kLatin1));
 			slot.setLocked(true);
 			_saveList.push_back(slot);
 		}
@@ -340,8 +340,8 @@ void SaveLoadChooserDialog::addChooserButtons() {
 		delete _gridButton;
 	}
 
-	_listButton = createSwitchButton("SaveLoadChooser.ListSwitch", Common::U32String("L"), _("List view"), ThemeEngine::kImageList, kListSwitchCmd);
-	_gridButton = createSwitchButton("SaveLoadChooser.GridSwitch", Common::U32String("G"), _("Grid view"), ThemeEngine::kImageGrid, kGridSwitchCmd);
+	_listButton = createSwitchButton("SaveLoadChooser.ListSwitch", USTR("L"), _("List view"), ThemeEngine::kImageList, kListSwitchCmd);
+	_gridButton = createSwitchButton("SaveLoadChooser.GridSwitch", USTR("G"), _("Grid view"), ThemeEngine::kImageGrid, kGridSwitchCmd);
 	if (!_metaInfoSupport || !_thumbnailSupport || !(g_gui.getWidth() >= 640 && g_gui.getHeight() >= 400)) {
 		_gridButton->setEnabled(false);
 		_listButton->setEnabled(false);
@@ -591,17 +591,17 @@ void SaveLoadChooserSimple::updateSelection(bool redraw) {
 		}
 
 		if (_saveDateSupport) {
-			const Common::U32String &saveDate = desc.getSaveDate();
+			const Common::U32String &saveDate = desc.getSaveDate().decode(Common::kLatin1);
 			if (!saveDate.empty())
 				_date->setLabel(_("Date: ") + saveDate);
 
-			const Common::U32String &saveTime = desc.getSaveTime();
+			const Common::U32String &saveTime = desc.getSaveTime().decode(Common::kLatin1);
 			if (!saveTime.empty())
 				_time->setLabel(_("Time: ") + saveTime);
 		}
 
 		if (_playTimeSupport) {
-			const Common::U32String &playTime = desc.getPlayTime();
+			const Common::U32String &playTime = desc.getPlayTime().decode(Common::kLatin1);
 			if (!playTime.empty())
 				_playtime->setLabel(_("Playtime: ") + playTime);
 		}
@@ -685,7 +685,7 @@ void SaveLoadChooserSimple::updateSaveList() {
 		saveSlot = x->getSaveSlot();
 		if (curSlot < saveSlot) {
 			while (curSlot < saveSlot) {
-				SaveStateDescriptor dummySave(curSlot, "");
+				SaveStateDescriptor dummySave(curSlot, USTR(""));
 				_saveList.insert_at(curSlot, dummySave);
 				saveNames.push_back(dummySave.getDescription());
 				colors.push_back(ThemeEngine::kFontColorNormal);
@@ -726,10 +726,10 @@ void SaveLoadChooserSimple::updateSaveList() {
 	}
 #endif
 
-	Common::String emptyDesc;
+	Common::U32String emptyDesc;
 	for (int i = curSlot; i <= maximumSaveSlots; i++) {
 		saveNames.push_back(emptyDesc);
-		SaveStateDescriptor dummySave(i, "");
+		SaveStateDescriptor dummySave(i, USTR(""));
 		_saveList.push_back(dummySave);
 		colors.push_back(ThemeEngine::kFontColorNormal);
 	}
@@ -999,7 +999,7 @@ void SaveLoadChooserGrid::reflowLayout() {
 			PicButtonWidget *button = new PicButtonWidget(container, dstX, dstY, buttonWidth, buttonHeight, Common::U32String(), buttonCmd);
 			dstY += buttonHeight;
 
-			StaticTextWidget *description = new StaticTextWidget(container, dstX, dstY, buttonWidth, kLineHeight, Common::String(), Graphics::kTextAlignStart);
+			StaticTextWidget *description = new StaticTextWidget(container, dstX, dstY, buttonWidth, kLineHeight, Common::U32String(), Graphics::kTextAlignStart);
 
 			_buttons.push_back(SlotButton(container, button, description));
 		}
@@ -1104,29 +1104,29 @@ void SaveLoadChooserGrid::updateSaves() {
 		} else {
 			curButton.button->setGfx(kThumbnailWidth, kThumbnailHeight2, 0, 0, 0);
 		}
-		curButton.description->setLabel(Common::U32String(Common::String::format("%d. ", saveSlot)) + desc.getDescription());
+		curButton.description->setLabel(Common::U32String::format("%d. ", saveSlot) + desc.getDescription());
 
 		Common::U32String tooltip(_("Name: "));
 		tooltip += desc.getDescription();
 
 		if (_saveDateSupport) {
-			const Common::U32String &saveDate = desc.getSaveDate();
+			const Common::U32String &saveDate = desc.getSaveDate().decode(Common::kLatin1);
 			if (!saveDate.empty()) {
-				tooltip += Common::U32String("\n");
+				tooltip += USTR("\n");
 				tooltip +=  _("Date: ") + saveDate;
 			}
 
-			const Common::U32String &saveTime = desc.getSaveTime();
+			const Common::U32String &saveTime = desc.getSaveTime().decode(Common::kLatin1);
 			if (!saveTime.empty()) {
-				tooltip += Common::U32String("\n");
+				tooltip += USTR("\n");
 				tooltip += _("Time: ") + saveTime;
 			}
 		}
 
 		if (_playTimeSupport) {
-			const Common::U32String &playTime = desc.getPlayTime();
+			const Common::U32String &playTime = desc.getPlayTime().decode(Common::kLatin1);
 			if (!playTime.empty()) {
-				tooltip += Common::U32String("\n");
+				tooltip += USTR("\n");
 				tooltip += _("Playtime: ") + playTime;
 			}
 		}
@@ -1145,7 +1145,7 @@ void SaveLoadChooserGrid::updateSaves() {
 	}
 
 	const uint numPages = (_entriesPerPage != 0 && !_saveList.empty()) ? ((_saveList.size() + _entriesPerPage - 1) / _entriesPerPage) : 1;
-	_pageDisplay->setLabel(Common::String::format("%u/%u", _curPage + 1, numPages));
+	_pageDisplay->setLabel(Common::U32String::format("%u/%u", _curPage + 1, numPages));
 
 	if (_curPage > 0)
 		_prevButton->setEnabled(true);
@@ -1160,7 +1160,7 @@ void SaveLoadChooserGrid::updateSaves() {
 
 SavenameDialog::SavenameDialog()
 	: Dialog("SavenameDialog") {
-	_title = new StaticTextWidget(this, "SavenameDialog.DescriptionText", Common::String());
+	_title = new StaticTextWidget(this, "SavenameDialog.DescriptionText", Common::U32String());
 
 	new ButtonWidget(this, "SavenameDialog.Cancel", _("Cancel"), Common::U32String(), kCloseCmd);
 	new ButtonWidget(this, "SavenameDialog.Ok", _("OK"), Common::U32String(), kOKCmd);

--- a/gui/saveload.cpp
+++ b/gui/saveload.cpp
@@ -63,15 +63,15 @@ void SaveLoadChooser::selectChooser(const MetaEngine &engine) {
 #endif // !DISABLE_SAVELOADCHOOSER_GRID
 }
 
-Common::String SaveLoadChooser::createDefaultSaveDescription(const int slot) const {
+Common::U32String SaveLoadChooser::createDefaultSaveDescription(const int slot) const {
 #if defined(USE_SAVEGAME_TIMESTAMP)
 	TimeDate curTime;
 	g_system->getTimeAndDate(curTime);
 	curTime.tm_year += 1900; // fixup year
 	curTime.tm_mon++; // fixup month
-	return Common::String::format("%04d-%02d-%02d / %02d:%02d:%02d", curTime.tm_year, curTime.tm_mon, curTime.tm_mday, curTime.tm_hour, curTime.tm_min, curTime.tm_sec);
+	return Common::U32String::format("%04d-%02d-%02d / %02d:%02d:%02d", curTime.tm_year, curTime.tm_mon, curTime.tm_mday, curTime.tm_hour, curTime.tm_min, curTime.tm_sec);
 #else
-	return Common::String::format("Save %d", slot + 1);
+	return Common::U32String::format("Save %d", slot + 1);
 #endif
 }
 

--- a/gui/saveload.h
+++ b/gui/saveload.h
@@ -69,7 +69,7 @@ public:
 	 * @param slot The slot number (must be >= 0).
 	 * @return The slot description.
 	 */
-	Common::String createDefaultSaveDescription(const int slot) const;
+	Common::U32String createDefaultSaveDescription(const int slot) const;
 };
 
 } // End of namespace GUI

--- a/gui/themebrowser.cpp
+++ b/gui/themebrowser.cpp
@@ -104,7 +104,7 @@ void ThemeBrowser::updateListing() {
 
 	ListWidget::U32StringArray list;
 	for (ThemeDescList::const_iterator i = _themes.begin(); i != _themes.end(); ++i, ++index) {
-		list.push_back(i->name);
+		list.push_back(i->name.decode(Common::kLatin1));
 
 		if (i->id == currentThemeId)
 			currentThemeIndex = index;

--- a/gui/unknown-game-dialog.cpp
+++ b/gui/unknown-game-dialog.cpp
@@ -97,12 +97,12 @@ void UnknownGameDialog::rebuild() {
 
 	// Check if we have clipboard functionality and expand the reportTranslated message if needed...
 	if (g_system->hasFeature(OSystem::kFeatureClipboardSupport)) {
-		reportTranslated += Common::U32String("\n");
+		reportTranslated += USTR("\n");
 		reportTranslated += _("Use the button below to copy the required game information into your clipboard.");
 	}
 	// Check if we have support for opening URLs and expand the reportTranslated message if needed...
 	if (g_system->hasFeature(OSystem::kFeatureOpenUrl)) {
-		reportTranslated += Common::U32String("\n");
+		reportTranslated += USTR("\n");
 		reportTranslated += _("You can also directly report your game to the Bug Tracker.");
 	}
 
@@ -133,7 +133,7 @@ Common::String UnknownGameDialog::encodeUrlString(const Common::String &string) 
 }
 
 Common::String UnknownGameDialog::generateBugtrackerURL() {
-	Common::String report = generateUnknownGameReport(_detectedGame, false, false);
+	Common::String report = generateUnknownGameReport(_detectedGame, false, false).legacyEncode();
 	report = encodeUrlString(report);
 
 	Common::String engineId = encodeUrlString(_detectedGame.engineId);

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -268,7 +268,7 @@ uint8 Widget::parseHotkey(const Common::U32String &label) {
 }
 
 Common::U32String Widget::cleanupHotkey(const Common::U32String &label) {
-	Common::U32String res("");
+	Common::U32String res;
 
 	for (Common::U32String::const_iterator itr = label.begin(); itr != label.end(); itr++) {
 		if (*itr != '~') {
@@ -312,7 +312,7 @@ StaticTextWidget::StaticTextWidget(GuiObject *boss, const Common::String &name, 
 }
 
 void StaticTextWidget::setValue(int value) {
-	_label = Common::String::format("%d", value);
+	_label = Common::U32String::format("%d", value);
 }
 
 void StaticTextWidget::setLabel(const Common::U32String &label) {
@@ -400,10 +400,6 @@ void ButtonWidget::setLabel(const Common::U32String &label) {
 	StaticTextWidget::setLabel(cleanupHotkey(label));
 }
 
-void ButtonWidget::setLabel(const Common::String &label) {
-	ButtonWidget::setLabel(Common::U32String(label));
-}
-
 ButtonWidget *addClearButton(GuiObject *boss, const Common::String &name, uint32 cmd, int x, int y, int w, int h) {
 	ButtonWidget *button;
 
@@ -418,9 +414,9 @@ ButtonWidget *addClearButton(GuiObject *boss, const Common::String &name, uint32
 	} else
 #endif
 		if (!name.empty())
-			button = new ButtonWidget(boss, name, Common::U32String("C"), _("Clear value"), cmd);
+			button = new ButtonWidget(boss, name, USTR("C"), _("Clear value"), cmd);
 		else
-			button = new ButtonWidget(boss, x, y, w, h, Common::U32String("C"), _("Clear value"), cmd);
+			button = new ButtonWidget(boss, x, y, w, h, USTR("C"), _("Clear value"), cmd);
 
 	return button;
 }

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -172,7 +172,6 @@ public:
 	bool hasTooltip() const { return !_tooltip.empty(); }
 	const Common::U32String &getTooltip() const { return _tooltip; }
 	void setTooltip(const Common::U32String &tooltip) { _tooltip = tooltip; }
-	void setTooltip(const Common::String &tooltip) { _tooltip = Common::U32String(tooltip); }
 
 	virtual bool containsWidget(Widget *) const { return false; }
 
@@ -233,7 +232,6 @@ public:
 	uint32 getCmd() const				{ return _cmd; }
 
 	void setLabel(const Common::U32String &label);
-	void setLabel(const Common::String &label);
 
 	void handleMouseUp(int x, int y, int button, int clickCount) override;
 	void handleMouseDown(int x, int y, int button, int clickCount) override;

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -340,7 +340,7 @@ void EditableWidget::drawCaret(bool erase) {
 		// possible glitches due to different methods used.
 		width = MIN(editRect.width() - caretOffset, width);
 		if (width > 0) {
-			g_gui.theme()->drawText(Common::Rect(x, y, x + width, y + editRect.height()), character,
+			g_gui.theme()->drawText(Common::Rect(x, y, x + width, y + editRect.height()), character.decode(Common::kLatin1),
 			                        _state, _drawAlign, _inversion, 0, false, _font,
 			                        ThemeEngine::kFontColorNormal, true, _textDrawableArea);
 		}

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -204,8 +204,8 @@ void ListWidget::append(const String &s, ThemeEngine::FontColor color) {
 		_listColors.push_back(color);
 	}
 
-	_dataList.push_back(s);
-	_list.push_back(s);
+	_dataList.push_back(s.decode(Common::kLatin1));
+	_list.push_back(s.decode(Common::kLatin1));
 
 	setFilter(_filter, false);
 
@@ -556,7 +556,7 @@ void ListWidget::drawWidget() {
 
 		// If in numbering mode & not in RTL based GUI, we first print a number prefix
 		if (_numberingMode != kListNumberingOff && g_gui.useRTL() == false) {
-			buffer = Common::String::format("%2d. ", (pos + _numberingMode));
+			buffer = Common::String::format("%2d. ", (pos + _numberingMode)).decode(Common::kLatin1);
 			g_gui.theme()->drawText(Common::Rect(_x + _hlLeftPadding, y, _x + r.left + _leftPadding, y + fontHeight - 2),
 									buffer, _state, _drawAlign, inverted, _leftPadding, true);
 			pad = 0;
@@ -595,7 +595,7 @@ void ListWidget::drawWidget() {
 
 		// If in numbering mode & using RTL layout in GUI, we print a number suffix after drawing the text
 		if (_numberingMode != kListNumberingOff && g_gui.useRTL()) {
-			buffer = Common::String::format(" .%2d", (pos + _numberingMode));
+			buffer = Common::String::format(" .%2d", (pos + _numberingMode)).decode(Common::kLatin1);
 
 			Common::Rect r2 = r1;
 
@@ -617,7 +617,7 @@ Common::Rect ListWidget::getEditRect() const {
 	if (_numberingMode != kListNumberingOff) {
 		// FIXME: Assumes that all digits have the same width.
 		Common::String temp = Common::String::format("%2d. ", (_list.size() - 1 + _numberingMode));
-		r.left += g_gui.getStringWidth(temp) + _leftPadding;
+		r.left += g_gui.getStringWidth(temp.decode(Common::kLatin1)) + _leftPadding;
 	}
 
 	return r;

--- a/gui/widgets/popup.cpp
+++ b/gui/widgets/popup.cpp
@@ -504,7 +504,7 @@ void PopUpWidget::appendEntry(const U32String &entry, uint32 tag) {
 }
 
 void PopUpWidget::appendEntry(const String &entry, uint32 tag) {
-	appendEntry(U32String(entry), tag);
+	appendEntry(U32String(entry, Common::kLatin1), tag);
 }
 
 void PopUpWidget::clearEntries() {

--- a/gui/widgets/tab.cpp
+++ b/gui/widgets/tab.cpp
@@ -73,8 +73,8 @@ void TabWidget::init() {
 	String leftArrow = g_gui.useRTL() ? ">" : "<";
 	String rightArrow = g_gui.useRTL() ? "<" : ">";
 
-	_navLeft = new ButtonWidget(this, x, y, _butW, _butH, Common::U32String(leftArrow), Common::U32String(), kCmdLeft);
-	_navRight = new ButtonWidget(this, x + _butW + 2, y, _butW, _butH, Common::U32String(rightArrow), Common::U32String(), kCmdRight);
+	_navLeft = new ButtonWidget(this, x, y, _butW, _butH, Common::U32String(leftArrow, Common::kLatin1), Common::U32String(), kCmdLeft);
+	_navRight = new ButtonWidget(this, x + _butW + 2, y, _butW, _butH, Common::U32String(rightArrow, Common::kLatin1), Common::U32String(), kCmdRight);
 
 	_navLeft->setEnabled(false);
 	_navRight->setEnabled(true);

--- a/test/common/str.h
+++ b/test/common/str.h
@@ -601,7 +601,7 @@ class StringTestSuite : public CxxTest::TestSuite
 	}
 
 	void test_ustr_comparison() {
-		Common::U32String a("abc"), b("abd");
+		Common::U32String a(USTR("abc")), b(USTR("abd"));
 
 		TS_ASSERT_EQUALS(a, a);
 		TS_ASSERT_EQUALS(b, b);


### PR DESCRIPTION
Implicit conversion is suboptimal as it masks problems. This patch
uncovers many problems with handling of hcaracters outside of Latin1.

Old behaviour in 2.2.0 was as following:

str->ustr is converted as normal Latin-1 decode.
ustr->str is done by dropping high bits. It's not a meaningful operation so
encapsulate it in a new function legacyEncode in order to remove it later.

Some of the areas where more unicode is neeeded:
* Filenames. Especially on windows.
* Save descriptions
* Config values


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
