### PR TITLE
SCI: add a shortcut alias for the registers debug console command

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -179,6 +179,7 @@ Console::Console(SciEngine *engine) : GUI::Debugger(),
 	// Script
 	registerCmd("addresses",			WRAP_METHOD(Console, cmdAddresses));
 	registerCmd("registers",			WRAP_METHOD(Console, cmdRegisters));
+	registerCmd("reg",					WRAP_METHOD(Console, cmdRegisters));
 	registerCmd("dissect_script",		WRAP_METHOD(Console, cmdDissectScript));
 	registerCmd("backtrace",			WRAP_METHOD(Console, cmdBacktrace));
 	registerCmd("bt",					WRAP_METHOD(Console, cmdBacktrace));	// alias
@@ -405,7 +406,7 @@ bool Console::cmdHelp(int argc, const char **argv) {
 	debugPrintf("\n");
 	debugPrintf("Script:\n");
 	debugPrintf(" addresses - Provides information on how to pass addresses\n");
-	debugPrintf(" registers - Shows the current register values\n");
+	debugPrintf(" registers / reg - Shows the current register values\n");
 	debugPrintf(" dissect_script - Examines a script\n");
 	debugPrintf(" backtrace / bt - Dumps the send/self/super/call/calle/callb stack\n");
 	debugPrintf(" trace / t / s - Executes one operation (no parameters) or several operations (specified as a parameter) \n");


### PR DESCRIPTION
When debugging, I'm constantly inspecting the SCI VM registers and thought this would be a great command to have an alias for.

I am proposing the following alias: `reg` for the command `registers` and also updated the help docs.