### PR TITLE
MAKE: allow to override the quite flags without re-executing configure

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -105,18 +105,18 @@ endif
 ifneq ($(findstring $(MAKEFLAGS),s),s)
 ifneq ($(VERBOSE_BUILD),1)
 ifneq ($(VERBOSE_BUILD),yes)
-QUIET_CC      = @echo '   ' C '      ' $@;
-QUIET_CXX     = @echo '   ' C++ '    ' $@;
-QUIET_AS      = @echo '   ' AS '     ' $@;
-QUIET_NASM    = @echo '   ' NASM '   ' $@;
-QUIET_PANDOC  = @echo '   ' PANDOC ' ' $@;
-QUIET_AR      = @echo '   ' AR '     ' $@;
-QUIET_RANLIB  = @echo '   ' RANLIB ' ' $@;
-QUIET_PLUGIN  = @echo '   ' PLUGIN ' ' $@;
-QUIET_LINK    = @echo '   ' LINK '   ' $@;
-QUIET_DWP     = @echo '   ' DWP '    ' $@;
-QUIET_WINDRES = @echo '   ' WINDRES '' $@;
-QUIET         = @
+QUIET_CC      ?= @echo '   ' C '      ' $@;
+QUIET_CXX     ?= @echo '   ' C++ '    ' $@;
+QUIET_AS      ?= @echo '   ' AS '     ' $@;
+QUIET_NASM    ?= @echo '   ' NASM '   ' $@;
+QUIET_PANDOC  ?= @echo '   ' PANDOC ' ' $@;
+QUIET_AR      ?= @echo '   ' AR '     ' $@;
+QUIET_RANLIB  ?= @echo '   ' RANLIB ' ' $@;
+QUIET_PLUGIN  ?= @echo '   ' PLUGIN ' ' $@;
+QUIET_LINK    ?= @echo '   ' LINK '   ' $@;
+QUIET_DWP     ?= @echo '   ' DWP '    ' $@;
+QUIET_WINDRES ?= @echo '   ' WINDRES '' $@;
+QUIET         ?= @
 endif
 endif
 endif


### PR DESCRIPTION
this allows you to activate the flags for a single build without re-building everything
(due to regenerated config.h)