### PR TITLE
STARTREK: Fix compilation for all platforms

### DIFF
--- a/engines/startrek/action.h
+++ b/engines/startrek/action.h
@@ -56,7 +56,7 @@ enum ActionTypes {
 };
 
 struct Action {
-	signed char type;
+	int8 type;
 	byte b1;
 	byte b2;
 	byte b3;

--- a/engines/startrek/awaymission.cpp
+++ b/engines/startrek/awaymission.cpp
@@ -535,7 +535,7 @@ void StarTrekEngine::addAction(const Action &action) {
 	_actionQueue.push(action);
 }
 
-void StarTrekEngine::addAction(char type, byte b1, byte b2, byte b3) {
+void StarTrekEngine::addAction(int8 type, byte b1, byte b2, byte b3) {
 	const Action a = {type, b1, b2, b3};
 	addAction(a);
 }

--- a/engines/startrek/awaymission.h
+++ b/engines/startrek/awaymission.h
@@ -41,7 +41,7 @@ struct AwayMission {
 	byte disableInput; // 0x1d
 
 	bool redshirtDead; // 0x1e
-	char activeAction; // 0x1f
+	int8 activeAction; // 0x1f
 	byte activeObject;  // 0x20; The item that is going to be used on something
 	byte passiveObject; // 0x21; The item that the active item is used on (or the item looked at, etc).
 

--- a/engines/startrek/room.cpp
+++ b/engines/startrek/room.cpp
@@ -319,7 +319,7 @@ bool Room::actionHasCode(const Action &action) {
 	return false;
 }
 
-bool Room::actionHasCode(char type, byte b1, byte b2, byte b3) {
+bool Room::actionHasCode(int8 type, byte b1, byte b2, byte b3) {
 	const Action a = {type, b1, b2, b3};
 	return actionHasCode(a);
 }
@@ -339,7 +339,7 @@ bool Room::handleAction(const Action &action) {
 	return false;
 }
 
-bool Room::handleAction(char type, byte b1, byte b2, byte b3) {
+bool Room::handleAction(int8 type, byte b1, byte b2, byte b3) {
 	const Action a = {type, b1, b2, b3};
 	return handleAction(a);
 }
@@ -360,7 +360,7 @@ bool Room::handleActionWithBitmask(const Action &action) {
 	return false;
 }
 
-bool Room::handleActionWithBitmask(char type, byte b1, byte b2, byte b3) {
+bool Room::handleActionWithBitmask(int8 type, byte b1, byte b2, byte b3) {
 	Action a = {type, b1, b2, b3};
 	return handleActionWithBitmask(a);
 }

--- a/engines/startrek/room.h
+++ b/engines/startrek/room.h
@@ -102,19 +102,19 @@ public:
 	 * Check if a particular action is defined for this room.
 	 */
 	bool actionHasCode(const Action &action);
-	bool actionHasCode(char type, byte b1, byte b2, byte b3);
+	bool actionHasCode(int8 type, byte b1, byte b2, byte b3);
 
 	/**
 	 * Execute a particular action for this room, if defined.
 	 */
 	bool handleAction(const Action &action);
-	bool handleAction(char type, byte b1, byte b2, byte b3);
+	bool handleAction(int8 type, byte b1, byte b2, byte b3);
 
 	/**
 	 * Same as above, but if any byte in the action is -1 (0xff), it matches any value.
 	 */
 	bool handleActionWithBitmask(const Action &action);
-	bool handleActionWithBitmask(char type, byte b1, byte b2, byte b3);
+	bool handleActionWithBitmask(int8 type, byte b1, byte b2, byte b3);
 
 	uint16 getFirstHotspot() {
 		return readRdfWord(0x12);

--- a/engines/startrek/startrek.h
+++ b/engines/startrek/startrek.h
@@ -312,7 +312,7 @@ public:
 	int loadActorAnimWithRoomScaling(int actorIndex, const Common::String &animName, int16 x, int16 y);
 	Fixed8 getActorScaleAtPosition(int16 y);
 	void addAction(const Action &action);
-	void addAction(char type, byte b1, byte b2, byte b3);
+	void addAction(int8 type, byte b1, byte b2, byte b3);
 	void handleAwayMissionAction();
 
 	void checkTouchedLoadingZone(int16 x, int16 y);


### PR DESCRIPTION
Use an int8 everywhere for the Action type

This completes PR #2692 and take @sev- suggestion into account.