### PR TITLE
SCUMM: ZAKFM Add script bug workaround, fixes bug #5624

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -1524,8 +1524,16 @@ void ScummEngine::endCutscene() {
 	vm.cutSceneScript[vm.cutSceneStackPointer] = 0;
 	vm.cutScenePtr[vm.cutSceneStackPointer] = 0;
 
-	if (0 == vm.cutSceneStackPointer)
+	if (0 == vm.cutSceneStackPointer) {
+		// WORKAROUND bug #5624: Due to poor translation of the v2 script to
+		// v5 an if statement jumps in the middle of a cutscene causing a
+		// endCutscene() without a begin cutscene()
+		if (_game.id == GID_ZAK && _game.platform == Common::kPlatformFMTowns &&
+			vm.slot[_currentScript].number == 205 && _currentRoom == 185) {
+			return;
+		}
 		error("Cutscene stack underflow");
+	}
 	vm.cutSceneStackPointer--;
 
 	if (VAR(VAR_CUTSCENE_END_SCRIPT))


### PR DESCRIPTION
Due to poor translation of the v2 script to v5 an if statement jumps in the
middle of a cutscene causing a endCutscene() without a begin cutscene()

Previous "fixes" do improve the code, but do not fix this cutscene issue.

See also

https://bugs.scummvm.org/ticket/3099
https://bugs.scummvm.org/ticket/5624

and commits

1d40f7849965e8b758b88197820daf9c6af4d120
Fixes the mistranslation of getState08(465) into classOfIs(465,[0]) at 001A

0725be325f60fa578b918aaaaef1d5f4008d310a
Fixes several mistranslations of setClass


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
