### PR TITLE
SCUMM: FT: fix bug #12022

### DIFF
--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -391,7 +391,18 @@ void ScummEngine_v7::processKeyboard(Common::KeyState lastKeyHit) {
 				_insane->escapeKeyHandler();
 			else
 				_smushVideoShouldFinish = true;
-			_skipVideo = true;
+
+			// WORKAROUND bug #12022: For some reason, skipping the cutscene in which Ben fires up
+			// his bike (after retrieving the keys from the bartender), will outright skip the first
+			// bike fight sequence. Because of this, the script which handles playing ambient and wind SFX
+			// outside the bar is never stopped, so those SFX are unintentionally played throughout the 
+			// rest of the game.
+			// This fix produces the intended behaviour from the original interpreter.
+			if (_game.id == GID_FT && vm.slot[_currentScript].number == 65 && _currentRoom == 6) {
+				_skipVideo = false;
+			} else {
+				_skipVideo = true;
+			}
 		} else {
 			abortCutscene();
 		}


### PR DESCRIPTION
This PR fixes bug [#12022](https://bugs.scummvm.org/ticket/12022) by bypassing the _skipVideo flag only for that certain room and script, preventing unintended side effects for the remainder of the game.