### PR TITLE
AMIGAOS: Remove dependency on the codesets library

### DIFF
--- a/backends/dialogs/amigaos/amigaos-dialogs.h
+++ b/backends/dialogs/amigaos/amigaos-dialogs.h
@@ -31,9 +31,6 @@
 class AmigaOSDialogManager : public Common::DialogManager {
 public:
 	virtual DialogResult showFileBrowser(const Common::U32String &title, Common::FSNode &choice, bool isDirBrowser);
-
-private:
-	char *utf8ToLocal(const char *in);
 };
 
 #endif


### PR DESCRIPTION
The codesets library is provided separately from the main SDK, and it's only used for converting from UTF-8 to ISO 8859-1, which can be done using ScummVM's builtin encoding code.

This has not been tested.