### PR TITLE
SCUMM: COMI: fix missing soundKludge call

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -736,6 +736,25 @@ void ScummEngine_v6::o6_startScript() {
 	script = pop();
 	flags = pop();
 
+	// WORKAROUND for a bug also present in the original EXE: After greasing (or oiling?)
+	// the cannonballs in the Plunder Town Theater, during the juggling show, the game
+	// cuts from room 18 (backstage) to room 19 (stage).
+	//
+	// Usually, when loading a room script 29 handles the change of background music, 
+	// based on which room we've just loaded.
+	// Unfortunately, during this particular cutscene, script 29 is not executing,
+	// therefore the music is unchanged from room 18 to 19 (the muffled backstage 
+	// version is played), and is not coherent with the drums fill played afterwards 
+	// (sequence 2225), which is unmuffled.
+	//
+	// This fix checks for this situation happening (and only this one), and makes a call
+	// to a soundKludge operation like script 29 would have done.
+	if (_game.id == GID_CMI && _currentRoom == 19 &&
+		vm.slot[_currentScript].number == 168 && script == 118) {
+		int list[16] = { 4096, 1278, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+		_sound->soundKludge(list, 2);
+	}
+
 	// WORKAROUND bug #556558: At Dino Bungee National Memorial, the buttons for
 	// the Wally and Rex dinosaurs will always restart their speech, instead of
 	// stopping and starting their speech. This was a script bug in the original


### PR DESCRIPTION
This PR patches a script bug (or oversight?) which was of course also present in the original EXE: 
after greasing the cannonballs in the Plunder Town Theater, during the juggling show, the game cuts from room 18 (backstage) to room 19 (stage).

Usually, when loading a room, script 29 is in charge of switching the background music, based on which room we've just loaded.
Unfortunately, during this cutscene, script 29 is not executing, therefore the music is unchanged from room 18 to 19.
This creates a coherency issue between the current music (state 1277, which is a muffled version of the juggling theme, used in the backstage) and the drums fill played afterwards (sequence 2225, which is a continuation of the unmuffled juggling theme played on the stage).

This fix checks for this exact situation happening, and makes a call to the appropriate soundKludge operation, like script 29 would have done.