### PR TITLE
SCUMM: FT: update cutscene fix to account for Version B

### DIFF
--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -398,7 +398,8 @@ void ScummEngine_v7::processKeyboard(Common::KeyState lastKeyHit) {
 			// outside the bar is never stopped, so those SFX are unintentionally played throughout the 
 			// rest of the game.
 			// This fix produces the intended behaviour from the original interpreter.
-			if (_game.id == GID_FT && vm.slot[_currentScript].number == 65 && _currentRoom == 6) {
+			if (_game.id == GID_FT && _currentRoom == 6
+				&& (vm.slot[_currentScript].number == 65 || vm.slot[_currentScript].number == 64)) {
 				_skipVideo = false;
 			} else {
 				_skipVideo = true;


### PR DESCRIPTION
Updated the workaround for bug #12022, accounting for the existence of Version B.
Luckily this didn't require comparing md5 values, as it appears there are no edge cases which can take the wrong if-"route" on the non correspondent version.