### PR TITLE
GUI: Fix RTL layout in engines with custom options widget

### DIFF
--- a/engines/mohawk/dialogs.cpp
+++ b/engines/mohawk/dialogs.cpp
@@ -95,7 +95,7 @@ enum {
 #ifdef ENABLE_MYST
 
 MystOptionsWidget::MystOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain) :
-		OptionsContainerWidget(boss, name, "MystOptionsDialog", false, domain),
+		OptionsContainerWidget(boss, name, "MystGameOptionsDialog", false, domain),
 		_zipModeCheckbox(nullptr),
 		_transitionsCheckbox(nullptr),
 		_mystFlyByCheckbox(nullptr),
@@ -109,13 +109,13 @@ MystOptionsWidget::MystOptionsWidget(GuiObject *boss, const Common::String &name
 
 	if (!isDemo) {
 		// I18N: Option for fast scene switching
-		_zipModeCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MystOptionsDialog.ZipMode", _("~Z~ip Mode Activated"));
+		_zipModeCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MystGameOptionsDialog.ZipMode", _("~Z~ip Mode Activated"));
 	}
 
-	_transitionsCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MystOptionsDialog.Transistions", _("~T~ransitions Enabled"));
+	_transitionsCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MystGameOptionsDialog.Transistions", _("~T~ransitions Enabled"));
 
 	if (isME) {
-		_mystFlyByCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MystOptionsDialog.PlayMystFlyBy", _("Play the Myst fly by movie"),
+		_mystFlyByCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MystGameOptionsDialog.PlayMystFlyBy", _("Play the Myst fly by movie"),
 		                                             _("The Myst fly by movie was not played by the original engine."));
 	}
 
@@ -124,23 +124,23 @@ MystOptionsWidget::MystOptionsWidget(GuiObject *boss, const Common::String &name
 		assert(vm);
 
 		// I18N: Drop book page
-		_dropPageButton = new GUI::ButtonWidget(widgetsBoss(), "MystOptionsDialog.DropPage", _("~D~rop Page"), Common::U32String(), kDropCmd);
+		_dropPageButton = new GUI::ButtonWidget(widgetsBoss(), "MystGameOptionsDialog.DropPage", _("~D~rop Page"), Common::U32String(), kDropCmd);
 
 		// Myst ME only has maps
 		if (vm->isGameVariant(GF_ME)) {
-			_showMapButton = new GUI::ButtonWidget(widgetsBoss(), "MystOptionsDialog.ShowMap", _("Show ~M~ap"), Common::U32String(), kMapCmd);
+			_showMapButton = new GUI::ButtonWidget(widgetsBoss(), "MystGameOptionsDialog.ShowMap", _("Show ~M~ap"), Common::U32String(), kMapCmd);
 		}
 
 		// Myst demo only has a menu
 		if (vm->isGameVariant(GF_DEMO)) {
-			_returnToMenuButton = new GUI::ButtonWidget(widgetsBoss(), "MystOptionsDialog.MainMenu", _("Main Men~u~"), Common::U32String(), kMenuCmd);
+			_returnToMenuButton = new GUI::ButtonWidget(widgetsBoss(), "MystGameOptionsDialog.MainMenu", _("Main Men~u~"), Common::U32String(), kMenuCmd);
 		}
 
 		if (vm->isGameVariant(GF_25TH)) {
-			GUI::StaticTextWidget *languageCaption = new GUI::StaticTextWidget(widgetsBoss(), "MystOptionsDialog.LanguageDesc", _("Language:"));
+			GUI::StaticTextWidget *languageCaption = new GUI::StaticTextWidget(widgetsBoss(), "MystGameOptionsDialog.LanguageDesc", _("Language:"));
 			languageCaption->setAlign(Graphics::kTextAlignRight);
 
-			_languagePopUp = new GUI::PopUpWidget(widgetsBoss(), "MystOptionsDialog.Language");
+			_languagePopUp = new GUI::PopUpWidget(widgetsBoss(), "MystGameOptionsDialog.Language");
 
 			const MystLanguage *languages = MohawkMetaEngine_Myst::listLanguages();
 			while (languages->language != Common::UNK_LANG) {

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -362,7 +362,7 @@ private:
 };
 
 OptionsWidget::OptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain) :
-		OptionsContainerWidget(boss, name, "SciOptionsDialog", false, domain) {
+		OptionsContainerWidget(boss, name, "SciGameOptionsDialog", false, domain) {
 	_guiOptions = ConfMan.get("guioptions", domain);
 
 	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)

--- a/gui/ThemeEval.h
+++ b/gui/ThemeEval.h
@@ -76,7 +76,7 @@ public:
 
 	ThemeEval &addDialog(const Common::String &name, const Common::String &overlays, int16 maxWidth = -1, int16 maxHeight = -1, int inset = 0);
 	ThemeEval &addLayout(ThemeLayout::LayoutType type, int spacing = -1, ThemeLayout::ItemAlign itemAlign = ThemeLayout::kItemAlignStart);
-	ThemeEval &addWidget(const Common::String &name, const Common::String &type, int w = -1, int h = -1, Graphics::TextAlign align = Graphics::kTextAlignStart, bool useRTL = false);
+	ThemeEval &addWidget(const Common::String &name, const Common::String &type, int w = -1, int h = -1, Graphics::TextAlign align = Graphics::kTextAlignStart, bool useRTL = true);
 	ThemeEval &addImportedLayout(const Common::String &name);
 	ThemeEval &addSpace(int size = -1);
 


### PR DESCRIPTION
This addresses bug [GUI: I18N - RTL: "Edit game" dialog looks distorted for SCI games](https://bugs.scummvm.org/ticket/12028#no1).

![Fixed version](https://user-images.githubusercontent.com/603444/103394606-755d8800-4b21-11eb-8b59-04a0f7458c03.png)

The issue affects all engines with a custom options widget, as currently the RTL layout doesn't apply to widgets created via code. I made the following changes:

- Set `useRTL` to `true` in the `addWidget()` calls.

Should this be the default instead? There's no other uses of `addWidget()`.

- Renamed the dialogs to `"GameOptions"` so the RTL rule would apply correctly: https://github.com/scummvm/scummvm/blob/master/gui/widget.cpp#L119

Should this be a Widget property instead? Relying on a magic name isn't obvious.