### PR TITLE
SYMBIAN: Fix compiler error.

### DIFF
--- a/backends/events/symbiansdl/symbiansdl-events.cpp
+++ b/backends/events/symbiansdl/symbiansdl-events.cpp
@@ -140,7 +140,7 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 						_km.y = _mouseYZone[_currentZone] * MULTIPLIER;
 
 						if (_graphicsManager) {
-							_graphicsManager->getWindow()->warpMouseInWindow(event.mouse.x, event.mouse.y);
+							dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->getWindow()->warpMouseInWindow(event.mouse.x, event.mouse.y);
 						}
 				}
 


### PR DESCRIPTION
Multiple inheritance not allowed at Symbian but it works for 2.2.0 release. It's good to get rid of such thing.