### PR TITLE
MACOSX: simplify Retina blurriness workarounds and restore Dark Mode

### DIFF
--- a/configure
+++ b/configure
@@ -2902,9 +2902,6 @@ case $_host_os in
 			fi
 		fi
 
-		# Building with SDK 10.14+ causes blurry display on Retina screens.
-		# A workaround is to set the LC_VERSION_MIN_MACOSX load command's sdk value
-		# to n/a (i.e. 0.0). See bug #11430 for details.
 		echocheck "macOS deployment target"
 		cat > $TMPC << EOF
 #include "AvailabilityMacros.h"
@@ -2938,23 +2935,6 @@ EOF
 			fi
 		fi
 		echo $_macos_min_version_dot
-
-		# Building with SDK 10.14+ causes blurry display on Retina screens.
-		# A workaround is to set the LC_VERSION_MIN_MACOSX load command's sdk value
-		# to n/a (i.e. 0.0). See bug #11430 for details.
-		# We do it in any case when the linker supports the -platform_version flag,
-		# even when using an older SDK.
-		echo_n "Checking if linker supports -platform_version... "
-		_macos_has_ld_platform_version=no
-		cat > $TMPC << EOF
-int main(int argc, char *argv[]) { return 0; }
-EOF
-		_macos_ldflags_platform_version="-Xlinker -platform_version -Xlinker macos -Xlinker $_macos_min_version_dot -Xlinker 0.0.0"
-		cc_check $_macos_ldflags_platform_version && _macos_has_ld_platform_version=yes
-		echo $_macos_has_ld_platform_version
-		if test "$_macos_has_ld_platform_version" = yes ; then
-			append_var LDFLAGS "$_macos_ldflags_platform_version"
-		fi
 
 		# Version-specific quirks
 		if test -n "$_macos_min_version" ; then

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -30,11 +30,6 @@
 #include <sstream>
 #include <iomanip>
 #include <CommonCrypto/CommonCrypto.h>
-
-// If we want to unset the sdk version in the executable to work around bug #11430
-// (blury display on retina screens when building with SDK 10.14+).
-// This workaround only works with Xcode 11+.
-//#define MACOSX_NO_SDKVERSION
 #endif
 
 namespace CreateProjectTool {
@@ -1162,19 +1157,6 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	ADD_SETTING_LIST(scummvmOSX_Debug, "LIBRARY_SEARCH_PATHS", scummvmOSX_LibPaths, kSettingsNoQuote | kSettingsAsList, 5);
 	ADD_SETTING_QUOTE(scummvmOSX_Debug, "OTHER_CFLAGS", "");
 	ADD_SETTING(scummvmOSX_Debug, "PRODUCT_NAME", PROJECT_NAME);
-	ValueList scummvmOSX_LinkerFlags;
-#ifdef MACOSX_NO_SDKVERSION
-	scummvmOSX_LinkerFlags.push_back("-Xlinker");
-	scummvmOSX_LinkerFlags.push_back("-platform_version");
-	scummvmOSX_LinkerFlags.push_back("-Xlinker");
-	scummvmOSX_LinkerFlags.push_back("macos");
-	scummvmOSX_LinkerFlags.push_back("-Xlinker");
-	// Since the option can only be used with Xcode 11, assume the min version targetted is 10.14
-	scummvmOSX_LinkerFlags.push_back("10.14");
-	scummvmOSX_LinkerFlags.push_back("-Xlinker");
-	scummvmOSX_LinkerFlags.push_back("0.0.0");
-	ADD_SETTING_LIST(scummvmOSX_Debug, "OTHER_LDFLAGS", scummvmOSX_LinkerFlags, kSettingsAsList, 5);
-#endif
 
 	scummvmOSX_Debug_Object->addProperty("name", "Debug", "", kSettingsNoValue);
 	scummvmOSX_Debug_Object->_properties["buildSettings"] = scummvmOSX_Debug;
@@ -1189,9 +1171,6 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	ADD_SETTING(scummvmOSX_Release, "WRAPPER_EXTENSION", "app");
 	REMOVE_SETTING(scummvmOSX_Release, "DEBUG_INFORMATION_FORMAT");
 	ADD_SETTING_QUOTE(scummvmOSX_Release, "DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym");
-#ifdef MACOSX_NO_SDKVERSION
-	ADD_SETTING_LIST(scummvmOSX_Release, "OTHER_LDFLAGS", scummvmOSX_LinkerFlags, kSettingsAsList, 5);
-#endif
 
 	scummvmOSX_Release_Object->addProperty("name", "Release", "", kSettingsNoValue);
 	scummvmOSX_Release_Object->_properties["buildSettings"] = scummvmOSX_Release;

--- a/dists/macosx/Info.plist
+++ b/dists/macosx/Info.plist
@@ -72,6 +72,8 @@
 	<string>faYfM+DGPgJCrRzpxSHoFD0rzHa6ZnnEXuzz2E7ZRUk=</string>
 	<key>NSDockTilePlugIn</key>
 	<string>scummvm.docktileplugin</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<false/>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>ScummVM saves and loads savegames in the Documents folder by default.</string>
 	<key>SUPublicDSAKeyFile</key>

--- a/dists/macosx/Info.plist.in
+++ b/dists/macosx/Info.plist.in
@@ -72,6 +72,8 @@
 	<string>faYfM+DGPgJCrRzpxSHoFD0rzHa6ZnnEXuzz2E7ZRUk=</string>
 	<key>NSDockTilePlugIn</key>
 	<string>scummvm.docktileplugin</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<false/>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>ScummVM saves and loads savegames in the Documents folder by default.</string>
 	<key>SUPublicDSAKeyFile</key>


### PR DESCRIPTION
This is related to bugs #11430 and #11305.

It appears that commit a1d930209a6452649ab704dbbcf2084c9177936e is actually enough to avoid blurriness display issues on Retina screens (i.e. favour OpenGL rendering over Metal rendering inside SDL2, because of interaction problems between macOS on Retina screens and SDL2).

Previous attempts at working around this included disabling Dark Mode (c59bf95ba85b25b134110eb0ff9c3d0e17750630) and passing a particular "invalid" argument to the `-platform_version` linker flag (70f79d3df8b4a9d4c6d1b69838ff5a722c51b61e), but it appears that `SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl")` is sufficient to avoid this bug (until a future version of SDL2 possibly fixes this for good and makes any workaround unnecessary).

(Note when manually testing changes to `Info.plist`: temporary rename your `.app` before launching it again, otherwise macOS may cache some previous values ― that's probably why I thought the other commits were still necessary when submitting my `SDL_HINT_RENDER_DRIVER` PR.)

This works for me with a local Xcode 12.2 build on macOS 11.1, with a quick test of the old builtin theme, which isn't blurry. (I can also test this on my other Retina machine with Mojave if you like, but only in a few weeks.) However, I use newer SDKs than what's used for official builds, so maybe the best way to validate this PR would be to provide an official test build containing it?

And if this PR is accepted, a backport to the `2.2` branch might be wanted.