### PR TITLE
CLOUD: Update Dropbox to use refresh_token

### DIFF
--- a/backends/cloud/dropbox/dropboxcreatedirectoryrequest.h
+++ b/backends/cloud/dropbox/dropboxcreatedirectoryrequest.h
@@ -30,8 +30,10 @@
 namespace Cloud {
 namespace Dropbox {
 
+class DropboxStorage;
+
 class DropboxCreateDirectoryRequest: public Networking::Request {
-	Common::String _token;
+	DropboxStorage *_storage;
 	Common::String _path;
 	Storage::BoolCallback _boolCallback;
 	Request *_workingRequest;
@@ -43,7 +45,7 @@ class DropboxCreateDirectoryRequest: public Networking::Request {
 	void errorCallback(Networking::ErrorResponse error);
 	void finishCreation(bool success);
 public:
-	DropboxCreateDirectoryRequest(Common::String token, Common::String path, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
+	DropboxCreateDirectoryRequest(DropboxStorage *storage, Common::String path, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
 	virtual ~DropboxCreateDirectoryRequest();
 
 	virtual void handle();

--- a/backends/cloud/dropbox/dropboxlistdirectoryrequest.h
+++ b/backends/cloud/dropbox/dropboxlistdirectoryrequest.h
@@ -31,12 +31,14 @@
 namespace Cloud {
 namespace Dropbox {
 
+class DropboxStorage;
+
 class DropboxListDirectoryRequest: public Networking::Request {
 	Common::String _requestedPath;
 	bool _requestedRecursive;
 
 	Storage::ListDirectoryCallback _listDirectoryCallback;
-	Common::String _token;
+	DropboxStorage *_storage;
 	Common::Array<StorageFile> _files;
 	Request *_workingRequest;
 	bool _ignoreCallback;
@@ -47,7 +49,7 @@ class DropboxListDirectoryRequest: public Networking::Request {
 	void errorCallback(Networking::ErrorResponse error);
 	void finishListing(Common::Array<StorageFile> &files);
 public:
-	DropboxListDirectoryRequest(Common::String token, Common::String path, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb, bool recursive = false);
+	DropboxListDirectoryRequest(DropboxStorage *storage, Common::String path, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb, bool recursive = false);
 	virtual ~DropboxListDirectoryRequest();
 
 	virtual void handle();

--- a/backends/cloud/dropbox/dropboxstorage.cpp
+++ b/backends/cloud/dropbox/dropboxstorage.cpp
@@ -40,7 +40,8 @@ namespace Dropbox {
 
 #define DROPBOX_API_FILES_DOWNLOAD "https://content.dropboxapi.com/2/files/download"
 
-DropboxStorage::DropboxStorage(Common::String accessToken, bool enabled): BaseStorage(accessToken, "", enabled) {}
+DropboxStorage::DropboxStorage(Common::String accessToken, Common::String refreshToken, bool enabled):
+	BaseStorage(accessToken, refreshToken, enabled) {}
 
 DropboxStorage::DropboxStorage(Common::String code, Networking::ErrorCallback cb): BaseStorage() {
 	getAccessToken(code, cb);
@@ -52,12 +53,13 @@ Common::String DropboxStorage::cloudProvider() { return "dropbox"; }
 
 uint32 DropboxStorage::storageIndex() { return kStorageDropboxId; }
 
-bool DropboxStorage::needsRefreshToken() { return false; }
+bool DropboxStorage::needsRefreshToken() { return true; }
 
-bool DropboxStorage::canReuseRefreshToken() { return false; }
+bool DropboxStorage::canReuseRefreshToken() { return true; }
 
 void DropboxStorage::saveConfig(Common::String keyPrefix) {
 	ConfMan.set(keyPrefix + "access_token", _token, ConfMan.kCloudDomain);
+	ConfMan.set(keyPrefix + "refresh_token", _refreshToken, ConfMan.kCloudDomain);
 	saveIsEnabledFlag(keyPrefix);
 }
 
@@ -66,11 +68,11 @@ Common::String DropboxStorage::name() const {
 }
 
 Networking::Request *DropboxStorage::listDirectory(Common::String path, ListDirectoryCallback outerCallback, Networking::ErrorCallback errorCallback, bool recursive) {
-	return addRequest(new DropboxListDirectoryRequest(_token, path, outerCallback, errorCallback, recursive));
+	return addRequest(new DropboxListDirectoryRequest(this, path, outerCallback, errorCallback, recursive));
 }
 
 Networking::Request *DropboxStorage::upload(Common::String path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) {
-	return addRequest(new DropboxUploadRequest(_token, path, contents, callback, errorCallback));
+	return addRequest(new DropboxUploadRequest(this, path, contents, callback, errorCallback));
 }
 
 Networking::Request *DropboxStorage::streamFileById(Common::String path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) {
@@ -92,13 +94,13 @@ Networking::Request *DropboxStorage::streamFileById(Common::String path, Network
 Networking::Request *DropboxStorage::createDirectory(Common::String path, BoolCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
-	return addRequest(new DropboxCreateDirectoryRequest(_token, path, callback, errorCallback));
+	return addRequest(new DropboxCreateDirectoryRequest(this, path, callback, errorCallback));
 }
 
 Networking::Request *DropboxStorage::info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
-	return addRequest(new DropboxInfoRequest(_token, callback, errorCallback));
+	return addRequest(new DropboxInfoRequest(this, callback, errorCallback));
 }
 
 Common::String DropboxStorage::savesDirectoryPath() { return "/saves/"; }
@@ -109,12 +111,19 @@ DropboxStorage *DropboxStorage::loadFromConfig(Common::String keyPrefix) {
 		return nullptr;
 	}
 
-	Common::String accessToken = ConfMan.get(keyPrefix + "access_token", ConfMan.kCloudDomain);	
-	return new DropboxStorage(accessToken, loadIsEnabledFlag(keyPrefix));
+	if (!ConfMan.hasKey(keyPrefix + "refresh_token", ConfMan.kCloudDomain)) {
+		warning("DropboxStorage: no refresh_token found");
+		return nullptr;
+	}
+
+	Common::String accessToken = ConfMan.get(keyPrefix + "access_token", ConfMan.kCloudDomain);
+	Common::String refreshToken = ConfMan.get(keyPrefix + "refresh_token", ConfMan.kCloudDomain);
+	return new DropboxStorage(accessToken, refreshToken, loadIsEnabledFlag(keyPrefix));
 }
 
 void DropboxStorage::removeFromConfig(Common::String keyPrefix) {
 	ConfMan.removeKey(keyPrefix + "access_token", ConfMan.kCloudDomain);
+	ConfMan.removeKey(keyPrefix + "refresh_token", ConfMan.kCloudDomain);
 	removeIsEnabledFlag(keyPrefix);
 }
 

--- a/backends/cloud/dropbox/dropboxstorage.h
+++ b/backends/cloud/dropbox/dropboxstorage.h
@@ -32,7 +32,7 @@ namespace Dropbox {
 
 class DropboxStorage: public Cloud::BaseStorage {
 	/** This private constructor is called from loadFromConfig(). */
-	DropboxStorage(Common::String token, bool enabled);
+	DropboxStorage(Common::String token, Common::String refreshToken, bool enabled);
 
 protected:
 	/**
@@ -103,6 +103,8 @@ public:
 	 * Remove all DropboxStorage-related data from config.
 	 */
 	static void removeFromConfig(Common::String keyPrefix);
+
+	Common::String accessToken() const { return _token; }
 };
 
 } // End of namespace Dropbox

--- a/backends/cloud/dropbox/dropboxtokenrefresher.cpp
+++ b/backends/cloud/dropbox/dropboxtokenrefresher.cpp
@@ -1,0 +1,125 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
+#include <curl/curl.h>
+#include "backends/cloud/dropbox/dropboxtokenrefresher.h"
+#include "backends/cloud/dropbox/dropboxstorage.h"
+#include "backends/networking/curl/networkreadstream.h"
+#include "common/debug.h"
+#include "common/json.h"
+
+namespace Cloud {
+namespace Dropbox {
+
+DropboxTokenRefresher::DropboxTokenRefresher(DropboxStorage *parent, Networking::JsonCallback callback, Networking::ErrorCallback ecb, const char *url):
+	CurlJsonRequest(callback, ecb, url), _parentStorage(parent) {}
+
+DropboxTokenRefresher::~DropboxTokenRefresher() {}
+
+void DropboxTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
+	if (!response.value) {
+		//failed to refresh token, notify user with NULL in original callback
+		warning("DropboxTokenRefresher: failed to refresh token");
+		finishError(Networking::ErrorResponse(this, false, true, "DropboxTokenRefresher::tokenRefreshed: failed to refresh token", -1));
+		return;
+	}
+
+	//update headers: first change header with token, then pass those to request
+	for (uint32 i = 0; i < _headers.size(); ++i) {
+		if (_headers[i].contains("Authorization")) {
+			_headers[i] = "Authorization: Bearer " + _parentStorage->accessToken();
+		}
+	}
+	setHeaders(_headers);
+
+	//successfully received refreshed token, can restart the original request now
+	retry(0);
+}
+
+void DropboxTokenRefresher::finishJson(Common::JSONValue *json) {
+	if (!json) {
+		//that's probably not an error (200 OK)
+		CurlJsonRequest::finishJson(nullptr);
+		return;
+	}
+
+	if (jsonIsObject(json, "DropboxTokenRefresher")) {
+		Common::JSONObject result = json->asObject();
+
+		if (result.contains("error") || result.contains("error_summary")) {
+			long httpCode = -1;
+			if (_stream) {
+				httpCode = _stream->httpResponseCode();
+				debug(9, "DropboxTokenRefresher: code %ld", httpCode);
+			}
+
+			bool irrecoverable = true;
+			if (jsonContainsString(result, "error_summary", "DropboxTokenRefresher")) {
+				if (result.getVal("error_summary")->asString().contains("expired_access_token")) {
+					irrecoverable = false;
+				}
+			}
+
+			if (irrecoverable) {
+				finishError(Networking::ErrorResponse(this, false, true, json->stringify(true), httpCode));
+				delete json;
+				return;
+			}
+
+			pause();
+			delete json;
+			_parentStorage->refreshAccessToken(new Common::Callback<DropboxTokenRefresher, Storage::BoolResponse>(this, &DropboxTokenRefresher::tokenRefreshed));
+			return;
+		}
+	}
+
+	//notify user of success
+	CurlJsonRequest::finishJson(json);
+}
+
+void DropboxTokenRefresher::finishError(Networking::ErrorResponse error) {
+	if (error.httpResponseCode == 401) {
+		pause();
+		_parentStorage->refreshAccessToken(new Common::Callback<DropboxTokenRefresher, Storage::BoolResponse>(this, &DropboxTokenRefresher::tokenRefreshed));
+		return;
+	}
+
+	Request::finishError(error);
+}
+
+void DropboxTokenRefresher::setHeaders(Common::Array<Common::String> &headers) {
+	_headers = headers;
+	curl_slist_free_all(_headersList);
+	_headersList = 0;
+	for (uint32 i = 0; i < headers.size(); ++i)
+		CurlJsonRequest::addHeader(headers[i]);
+}
+
+void DropboxTokenRefresher::addHeader(Common::String header) {
+	_headers.push_back(header);
+	CurlJsonRequest::addHeader(header);
+}
+
+} // End of namespace Dropbox
+} // End of namespace Cloud

--- a/backends/cloud/dropbox/dropboxtokenrefresher.h
+++ b/backends/cloud/dropbox/dropboxtokenrefresher.h
@@ -20,11 +20,10 @@
  *
  */
 
-#ifndef BACKENDS_CLOUD_DROPBOX_DROPBOXINFOREQUEST_H
-#define BACKENDS_CLOUD_DROPBOX_DROPBOXINFOREQUEST_H
+#ifndef BACKENDS_CLOUD_DROPBOX_DROPBOXTOKENREFRESHER_H
+#define BACKENDS_CLOUD_DROPBOX_DROPBOXTOKENREFRESHER_H
 
 #include "backends/cloud/storage.h"
-#include "backends/networking/curl/request.h"
 #include "backends/networking/curl/curljsonrequest.h"
 
 namespace Cloud {
@@ -32,24 +31,20 @@ namespace Dropbox {
 
 class DropboxStorage;
 
-class DropboxInfoRequest: public Networking::Request {
-	DropboxStorage *_storage;
-	Common::String _uid, _name, _email;
-	Storage::StorageInfoCallback _infoCallback;
-	Request *_workingRequest;
-	bool _ignoreCallback;
+class DropboxTokenRefresher: public Networking::CurlJsonRequest {
+	DropboxStorage *_parentStorage;
+	Common::Array<Common::String> _headers;
 
-	void start();
-	void userResponseCallback(Networking::JsonResponse response);
-	void quotaResponseCallback(Networking::JsonResponse response);
-	void errorCallback(Networking::ErrorResponse error);
-	void finishInfo(StorageInfo info);
+	void tokenRefreshed(Storage::BoolResponse response);
+
+	virtual void finishJson(Common::JSONValue *json);
+	virtual void finishError(Networking::ErrorResponse error);
 public:
-	DropboxInfoRequest(DropboxStorage *storage, Storage::StorageInfoCallback cb, Networking::ErrorCallback ecb);
-	virtual ~DropboxInfoRequest();
+	DropboxTokenRefresher(DropboxStorage *parent, Networking::JsonCallback callback, Networking::ErrorCallback ecb, const char *url);
+	virtual ~DropboxTokenRefresher();
 
-	virtual void handle();
-	virtual void restart();
+	virtual void setHeaders(Common::Array<Common::String> &headers);
+	virtual void addHeader(Common::String header);
 };
 
 } // End of namespace Dropbox

--- a/backends/cloud/dropbox/dropboxuploadrequest.h
+++ b/backends/cloud/dropbox/dropboxuploadrequest.h
@@ -31,8 +31,10 @@
 namespace Cloud {
 namespace Dropbox {
 
+class DropboxStorage;
+
 class DropboxUploadRequest: public Networking::Request {
-	Common::String _token;
+	DropboxStorage *_storage;
 	Common::String _savePath;
 	Common::SeekableReadStream *_contentsStream;
 	Storage::UploadCallback _uploadCallback;
@@ -47,7 +49,7 @@ class DropboxUploadRequest: public Networking::Request {
 	void finishUpload(StorageFile status);
 
 public:
-	DropboxUploadRequest(Common::String token, Common::String path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
+	DropboxUploadRequest(DropboxStorage *storage, Common::String path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
 	virtual ~DropboxUploadRequest();
 
 	virtual void handle();

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -48,6 +48,7 @@ MODULE_OBJS += \
 	cloud/dropbox/dropboxcreatedirectoryrequest.o \
 	cloud/dropbox/dropboxinforequest.o \
 	cloud/dropbox/dropboxlistdirectoryrequest.o \
+	cloud/dropbox/dropboxtokenrefresher.o \
 	cloud/dropbox/dropboxuploadrequest.o \
 	cloud/googledrive/googledrivelistdirectorybyidrequest.o \
 	cloud/googledrive/googledrivestorage.o \

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2672,7 +2672,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 		Common::String url = "https://cloud.scummvm.org/";
 		switch (_selectedStorageIndex) {
 		case Cloud::kStorageDropboxId:
-			url += "dropbox";
+			url += "dropbox?refresh_token=true";
 			break;
 		case Cloud::kStorageOneDriveId:
 			url += "onedrive";


### PR DESCRIPTION
Dropbox [is switching](https://www.dropbox.com/lp/developers/reference/oauth-guide) to short-lived `access_token` OAuth mid 2021. This commit adapts `Cloud::DropboxStorage` to use `refresh_token` similarly to how other Storages do: by introducing a `DropboxTokenRefresher`.

@Mataniko already added a new endpoint on cloud.scummvm.org, which will be used for Dropbox from now on. Older versions of ScummVM, which do not have this change, will still work with "Legacy" endpoint until Dropbox deprecates it.

I've checked all the `Dropbox*Request` classes with Testbed for handling the "expired_access_token" error (handled via the `DropboxTokenRefresher`) and all of them work.