### PR TITLE
GUI: Refresh stretch mode upon returning to launcher

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -340,6 +340,8 @@ static void setupGraphics(OSystem &system) {
 	system.beginGFXTransaction();
 		// Set the user specified graphics mode (if any).
 		system.setGraphicsMode(ConfMan.get("gfx_mode").c_str());
+		system.setStretchMode(ConfMan.get("stretch_mode").c_str());
+		system.setShader(ConfMan.get("shader").c_str());
 
 		system.initSize(320, 200);
 
@@ -349,10 +351,6 @@ static void setupGraphics(OSystem &system) {
 			system.setFeatureState(OSystem::kFeatureFullscreenMode, ConfMan.getBool("fullscreen"));
 		if (ConfMan.hasKey("filtering"))
 			system.setFeatureState(OSystem::kFeatureFilteringMode, ConfMan.getBool("filtering"));
-		if (ConfMan.hasKey("stretch_mode"))
-			system.setStretchMode(ConfMan.get("stretch_mode").c_str());
-		if (ConfMan.hasKey("shader"))
-			system.setShader(ConfMan.get("shader").c_str());
 	system.endGFXTransaction();
 
 	system.applyBackendSettings();


### PR DESCRIPTION
When the Options...->Misc->"Always return to the launcher on leaving a game" option is checked, the "relaunched" launcher GUI will not launch with correct stretch mode, if "Edit Game...->Graphics->Stretch Mode" was set to <default> from some non-default value. This also results in the game re-launching with the same non-default setting as applied above, as described in Issue #12041.

This requires the same fix as was done in PR #2690, which was to remove the hasKey() constraint, because setStretchMode() and ConfMan.get() methods together were able to set the <default> setting properly in absence of a key.