### PR TITLE
ANDROID: Allow screen rotation

### DIFF
--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -96,13 +96,6 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 	// SurfaceHolder callback
 	final public void surfaceChanged(SurfaceHolder holder, int format,
 										int width, int height) {
-		// the orientation may reset on standby mode and the theme manager
-		// could assert when using a portrait resolution. so lets not do that.
-		if (height > width) {
-			Log.d(LOG_TAG, String.format(Locale.ROOT, "Ignoring surfaceChanged: %dx%d (%d)",
-											width, height, format));
-			return;
-		}
 
 		Log.d(LOG_TAG, String.format(Locale.ROOT, "surfaceChanged: %dx%d (%d)",
 										width, height, format));

--- a/dists/android/AndroidManifest.xml
+++ b/dists/android/AndroidManifest.xml
@@ -15,9 +15,6 @@
 		android:name="android.hardware.wifi"
 		android:required="false" />
 	<uses-feature
-		android:name="android.hardware.screen.landscape"
-		android:required="false" />
-	<uses-feature
 		android:name="android.hardware.touchscreen"
 		android:required="false" />
 	<uses-feature
@@ -42,7 +39,6 @@
 			android:name=".SplashActivity"
 			android:banner="@drawable/leanback_icon"
 			android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
-			android:screenOrientation="landscape"
 			android:theme="@style/SplashTheme"
 			android:windowSoftInputMode="adjustResize">
 			<intent-filter>
@@ -57,7 +53,6 @@
 			android:name=".ScummVMActivity"
 			android:banner="@drawable/leanback_icon"
 			android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
-			android:screenOrientation="landscape"
 			android:theme="@style/AppTheme"
 			android:windowSoftInputMode="adjustResize">
 			<intent-filter>


### PR DESCRIPTION
Screen rotation was previously disabled in commits fba1c6360c0194e5cad6133dc312c1c8ae80ac39 and fb73cef4d9d481f616576a2779b53ea6c8c48b18. Presumably, whatever crash occured with portrait overlays back in 2011 doesn't occur any more, however this would need to be tested on a wider range of devices to be certain.

The GUI is very cramped in portrait mode, however, so maybe it would be best to wait until the `gui-scale` branch is ready before merging this PR.