### PR TITLE
Revert "ANDROID: Set minimal SDK to 21+ (Android 5+). The app crashes at launch on Android 4"

### DIFF
--- a/dists/android/build.gradle
+++ b/dists/android/build.gradle
@@ -32,7 +32,7 @@ android {
 
         setProperty("archivesBaseName", "ScummVM")
 
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 29
 
         versionName "2.3.0git"

--- a/dists/android3d/build.gradle
+++ b/dists/android3d/build.gradle
@@ -32,7 +32,7 @@ android {
 
         setProperty("archivesBaseName", "ResidualVM")
 
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 28
 
         versionName "0.4"


### PR DESCRIPTION
My tablet runs Android 4.4, and I haven't encountered major crashes with recent versions of ScummVM. As such, this commit would prevent ScummVM from working on it outright.