### PR TITLE
SCI: Hebrew in parentheses isn't stage direction

### DIFF
--- a/engines/sci/engine/message.cpp
+++ b/engines/sci/engine/message.cpp
@@ -444,6 +444,10 @@ bool MessageState::stringStage(Common::String &outstr, const Common::String &inS
 		// SCI32 seems to support having digits in stage directions
 		if (((inStr[i] >= 'a') && (inStr[i] <= 'z')) || ((inStr[i] >= '0') && (inStr[i] <= '9') && (getSciVersion() < SCI_VERSION_2)))
 			return false;
+
+		// If it contains Hebrew letters, it's not a stage direction
+		if (g_sci->getLanguage() == Common::HE_ISR && (byte)inStr[i] >= 128 && (byte)inStr[i] <= 255)
+			return false;
 	}
 
 	// We ran into the end of the string without finding a closing bracket


### PR DESCRIPTION
Before this PR, Hebrew text in parentheses was treated as stage direction (because it doesn't contain English lower case letters, and usually doesn't contain digits), and wasn't printed.

This PR makes Hebrew letters behave similar to English lower case letters - if they exist - print the message.
(There is no point in translating the stage direction to Hebrew, if ever there will be a Hebrew dubbing project, the actors will use the English directions...)

This PR is coordinated with the group that translated previous Sierra titles to Hebrew (Torin, GK2, SQ3), and working now on QFG1VGA - that's were we understood that problem. In previous titles, the text in parentheses wasn't translated at all, thus, this fix won't make any unwanted text to start appearing. 

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
