### PR TITLE
RFC: Make FluidSynth logging less noisy by default

### DIFF
--- a/audio/softsynth/fluidsynth.cpp
+++ b/audio/softsynth/fluidsynth.cpp
@@ -55,10 +55,10 @@ static void logHandler(int level, const char *message, void *data) {
 		warning("FluidSynth: %s", message);
 		break;
 	case FLUID_WARN:
-		debug(2, "FluidSynth: %s", message);
+		debug(1, "FluidSynth: %s", message);
 		break;
 	case FLUID_INFO:
-		debug(1, "FluidSynth: %s", message);
+		debug(2, "FluidSynth: %s", message);
 		break;
 	case FLUID_DBG:
 		debug(3, "FluidSynth: %s", message);

--- a/audio/softsynth/fluidsynth.cpp
+++ b/audio/softsynth/fluidsynth.cpp
@@ -46,6 +46,29 @@
 #include "backends/platform/ios7/ios7_common.h"
 #endif
 
+static void logHandler(int level, const char *message, void *data) {
+	switch (level) {
+	case FLUID_PANIC:
+		error("FluidSynth: %s", message);
+		break;
+	case FLUID_ERR:
+		warning("FluidSynth: %s", message);
+		break;
+	case FLUID_WARN:
+		debug(2, "FluidSynth: %s", message);
+		break;
+	case FLUID_INFO:
+		debug(1, "FluidSynth: %s", message);
+		break;
+	case FLUID_DBG:
+		debug(3, "FluidSynth: %s", message);
+		break;
+	default:
+		fluid_default_log_function(level, message, data);
+		break;
+	}
+}
+
 class MidiDriver_FluidSynth : public MidiDriver_Emulated {
 private:
 	MidiChannel_MPU401 _midiChannels[16];
@@ -165,6 +188,12 @@ static long SoundFontMemLoader_tell(void *handle) {
 int MidiDriver_FluidSynth::open() {
 	if (_isOpen)
 		return MERR_ALREADY_OPEN;
+
+	fluid_set_log_function(FLUID_PANIC, logHandler, NULL);
+	fluid_set_log_function(FLUID_ERR, logHandler, NULL);
+	fluid_set_log_function(FLUID_WARN, logHandler, NULL);
+	fluid_set_log_function(FLUID_INFO, logHandler, NULL);
+	fluid_set_log_function(FLUID_DBG, logHandler, NULL);
 
 #if defined(FLUIDSYNTH_VERSION_MAJOR) && FLUIDSYNTH_VERSION_MAJOR > 1
 	// When provided with in-memory SoundFont data, only use the configured


### PR DESCRIPTION
I'm using a SoundFont file called 8MBGMSFX.SF2 that was included with my old SoundBlaster sound card. You'd think that would be as close to an official SoundFont that you can find, and yet I'm still getting a bunch of annoying warnings when the FluidSynth driver is initialized:

```
fluidsynth: warning: Instrument 'Piano 1': Some invalid generators were discarded
fluidsynth: warning: Instrument 'Piano 2': Some invalid generators were discarded
fluidsynth: warning: Instrument 'Piano 3': Some invalid generators were discarded
fluidsynth: warning: Instrument 'Honky-tonk': Some invalid generators were discarded
```

And then when the drive is de-initialized:

```
fluidsynth: warning: No preset found on channel 0 [bank=0 prog=34]
fluidsynth: warning: No preset found on channel 1 [bank=0 prog=73]
fluidsynth: warning: No preset found on channel 2 [bank=0 prog=45]
fluidsynth: warning: No preset found on channel 3 [bank=0 prog=71]
fluidsynth: warning: No preset found on channel 4 [bank=0 prog=65]
fluidsynth: warning: No preset found on channel 5 [bank=0 prog=89]
fluidsynth: warning: No preset found on channel 6 [bank=0 prog=92]
fluidsynth: warning: No preset found on channel 7 [bank=0 prog=86]
fluidsynth: warning: No preset found on channel 8 [bank=0 prog=48]
fluidsynth: warning: No preset found on channel 9 [bank=128 prog=0]
fluidsynth: warning: No preset found on channel 10 [bank=0 prog=16]
fluidsynth: warning: No preset found on channel 11 [bank=0 prog=11]
fluidsynth: warning: No preset found on channel 12 [bank=0 prog=11]
fluidsynth: warning: No preset found on channel 13 [bank=0 prog=57]
fluidsynth: warning: No preset found on channel 14 [bank=0 prog=58]
fluidsynth: warning: No preset found on channel 15 [bank=0 prog=0]
```

This proof-of-concept patch re-routes FluidSynth logging to a custom function, that only prints the messages when running ScummVM in debug mode. The messages are then presented like this:

```
FluidSynth: Instrument 'Piano 1': Some invalid generators were discarded
FluidSynth: Instrument 'Piano 2': Some invalid generators were discarded
FluidSynth: Instrument 'Piano 3': Some invalid generators were discarded
FluidSynth: Instrument 'Honky-tonk': Some invalid generators were discarded
```

Since I've only ever seen warnings, I'm not sure what would cause the other log levels. My mapping to ScummVM debug levels / warnings / errors is therefore a bit arbitrary. But I think it would be a good idea to silence these warnings by default, so I'm submitting this for discussion.