### PR TITLE
ULTIMA4: Change damage to match DOS version

### DIFF
--- a/engines/ultima/ultima4/game/creature.cpp
+++ b/engines/ultima/ultima4/game/creature.cpp
@@ -253,7 +253,7 @@ int  Creature::getDamage() const {
 	int damage, val, x;
 	val = _baseHp;
 	x = xu4_random(val >> 2);
-	damage = (x >> 4) + ((x >> 2) & 0xfc);
+	damage = (x >> 4) * 10;
 	damage += x % 10;
 	return damage;
 }


### PR DESCRIPTION
Through an interesting series of events I noticed that the xu4 damage was different from the DOS version of the game.
Disassembled DOS version: https://github.com/ergonomy-joe/u4-decompiled/blob/master/SRC/U4_AI.C#L127

Note: D_23D2[C_7C25((unsigned char)Fighters._tile[bp04])] is equivalent to creature.basehp

If I'm doing the math right then they are equal when the monster base health is below 64. But above that they diverge with xu4 creatures doing significantly less damage.

(It is possible that the xu4 version is getting the damage calculation from a different port of the game. I haven't been able to check that.)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
