### PR TITLE
SCUMM: Digital iMUSE: fix FT crash and music breaking bug

### DIFF
--- a/engines/scumm/imuse_digi/dimuse.cpp
+++ b/engines/scumm/imuse_digi/dimuse.cpp
@@ -589,22 +589,25 @@ void IMuseDigital::switchToNextRegion(Track *track) {
 	}
 
 	int jumpId = _sound->getJumpIdByRegionAndHookId(soundDesc, track->curRegion, track->curHookId);
-	if ((_vm->_game.id != GID_CMI && jumpId != -1) || (_vm->_game.id == GID_CMI && jumpId != -1 && !track->alreadyCrossfading)) {
+	if ((_vm->_game.id != GID_CMI && jumpId != -1) || (_vm->_game.id == GID_CMI && jumpId != -1 && !track->toBeRemoved && !track->alreadyCrossfading)) {
 		int region = _sound->getRegionIdByJumpId(soundDesc, jumpId);
 		assert(region != -1);
 		int sampleHookId = _sound->getJumpHookId(soundDesc, jumpId);
 		assert(sampleHookId != -1);
 
-		bool isJumpToStart = (soundDesc->jump[jumpId].dest == soundDesc->marker[2].pos && !scumm_stricmp(soundDesc->marker[2].ptr, "start"));
+		bool isJumpToStart = false;
 		bool isJumpToLoop = false;
-		if (!isJumpToStart) {
-			for (int m = 0; m < soundDesc->numMarkers; m++) {
-				if (soundDesc->jump[jumpId].dest == soundDesc->marker[m].pos) {
-					Common::String markerDesc = soundDesc->marker[m].ptr;
-					if (markerDesc.contains("loop")) {
-						isJumpToLoop = true;
+		if (_vm->_game.id == GID_CMI) {
+			isJumpToStart = (soundDesc->jump[jumpId].dest == soundDesc->marker[2].pos && !scumm_stricmp(soundDesc->marker[2].ptr, "start"));
+			if (!isJumpToStart) {
+				for (int m = 0; m < soundDesc->numMarkers; m++) {
+					if (soundDesc->jump[jumpId].dest == soundDesc->marker[m].pos) {
+						Common::String markerDesc = soundDesc->marker[m].ptr;
+						if (markerDesc.contains("loop")) {
+							isJumpToLoop = true;
+						}
+						break;
 					}
-					break;
 				}
 			}
 		}

--- a/engines/scumm/imuse_digi/dimuse_script.cpp
+++ b/engines/scumm/imuse_digi/dimuse_script.cpp
@@ -165,6 +165,9 @@ void IMuseDigital::flushTrack(Track *track) {
 	if (!_mixer->isSoundHandleActive(track->mixChanHandle)) {
 		track->reset();
 	}
+
+	if (_vm->_game.id == GID_CMI && track->trackId < MAX_DIGITAL_TRACKS)
+		_scheduledCrossfades[track->trackId].scheduled = false;
 }
 
 void IMuseDigital::flushTracks() {
@@ -174,6 +177,8 @@ void IMuseDigital::flushTracks() {
 		Track *track = _track[l];
 		if (track->used && track->toBeRemoved && !_mixer->isSoundHandleActive(track->mixChanHandle)) {
 			debug(5, "flushTracks() - trackId:%d, soundId:%d", track->trackId, track->soundId);
+			if (_vm->_game.id == GID_CMI && l < MAX_DIGITAL_TRACKS)
+				_scheduledCrossfades[track->trackId].scheduled = false;
 			track->reset();
 		}
 	}


### PR DESCRIPTION
This is an urgent fix which is contained in PR [#2701](https://github.com/scummvm/scummvm/pull/2701). Since that PR is quite big and it's taking some time to be approved, and since people are rightfully telling me that FT is currently broken in the current dev build, I'm sending these _urgent_ fixes as a separate PR.

_Please_ merge this as soon as you can, since this fixes Full Throttle crashing and another bug in COMI which allowed zero volume (toBeRemoved) tracks to be able to make JUMPs and loops before being flushed.