### PR TITLE
GRAPHICS: Improve TTF rendering on transparent surfaces.

### DIFF
--- a/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
@@ -136,6 +136,7 @@ RenderedText *TTFont::renderText(const Std::string &text, unsigned int &remainin
 	uint32 borderColor = PF_RGBA.ARGBToColor(0xFF, 0x00, 0x00, 0x00);
 
 	Graphics::ManagedSurface *texture = new Graphics::ManagedSurface(resultWidth, resultHeight, PF_RGBA);
+	texture->setTransparentColor(0);
 	uint32 *texBuf = (uint32 *)texture->getPixels();
 
 	Std::list<PositionedText>::const_iterator iter;
@@ -154,10 +155,12 @@ RenderedText *TTFont::renderText(const Std::string &text, unsigned int &remainin
 			// When not in antialiased mode, use a paletted surface where '1' is
 			// used for pixels of the text
 			textSurf.create(resultWidth, lineHeight, Graphics::PixelFormat::createFormatCLUT8());
+			textSurf.setTransparentColor(0);
 			_ttfFont->drawString(&textSurf, unicodeText, 0, 0, resultWidth, 1);
 		} else {
 			// Use a high color surface with the specified _color color for text
 			textSurf.create(resultWidth, lineHeight, PF_RGBA);
+			textSurf.setTransparentColor(0);
 			_ttfFont->drawString(&textSurf, unicodeText, 0, 0, resultWidth, _color);
 		};
 

--- a/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
@@ -208,9 +208,10 @@ RenderedText *TTFont::renderText(const Std::string &text, unsigned int &remainin
 							// Blend color with border color
 							PF_RGBA.colorToRGB(borderColor, dR, dG, dB);
 
-							dR = ((255 - sA) * dR + sA * sR) / 255;
-							dG = ((255 - sA) * dG + sA * sG) / 255;
-							dB = ((255 - sA) * dB + sA * sB) / 255;
+							double alpha = (double)sA / 255.0;
+							dR = static_cast<uint8>((sR * alpha) + (dR * (1.0 - alpha)));
+							dG = static_cast<uint8>((sG * alpha) + (dG * (1.0 - alpha)));
+							dB = static_cast<uint8>((sB * alpha) + (dB * (1.0 - alpha)));
 
 							texBuf[ty * resultWidth + tx] = PF_RGBA.RGBToColor(dR, dG, dB);
 							break;
@@ -221,25 +222,8 @@ RenderedText *TTFont::renderText(const Std::string &text, unsigned int &remainin
 								int bx = iter->_dims.left + x + _borderSize + dx;
 								int by = iter->_dims.top + y + _borderSize + dy;
 								if (bx >= 0 && bx < resultWidth && by >= 0 && by < resultHeight) {
-									uint32 dColor = texBuf[by * resultWidth + bx];
-									PF_RGBA.colorToARGB(dColor, sA, dR, dG, dB);
-									switch (sA) {
-									case 0x00:
+									if (texBuf[by * resultWidth + bx] == 0) {
 										texBuf[by * resultWidth + bx] = borderColor;
-										break;
-									case 0xFF:
-										// Color already set 
-										break;
-									default:
-										// Blend source color at dest alpha with border color
-										PF_RGBA.colorToRGB(borderColor, dR, dG, dB);
-
-										dR = ((255 - sA) * dR + sA * sR) / 255;
-										dG = ((255 - sA) * dG + sA * sG) / 255;
-										dB = ((255 - sA) * dB + sA * sB) / 255;
-
-										texBuf[by * resultWidth + bx] = PF_RGBA.RGBToColor(dR, dG, dB);
-										break;
 									}
 								}
 							}


### PR DESCRIPTION
TTF rendering assumed the alpha channel of the surface was completely opaque.
ULTIMA8 TTF rendering attempts to use a transparent surface and became near-illegible for text on scrolls.
