### PR TITLE
SDL: Fix trying to set unsupported pixel format when changing  gfx mode

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -77,7 +77,15 @@ SdlGraphicsManager::State SdlGraphicsManager::getState() const {
 bool SdlGraphicsManager::setState(const State &state) {
 	beginGFXTransaction();
 #ifdef USE_RGB_COLOR
-		initSize(state.screenWidth, state.screenHeight, &state.pixelFormat);
+		// When switching between the SDL and OpenGL graphics manager, the list
+		// of supported format changes. This means that the pixel format in the
+		// state may not be supported. In that case use the preferred supported
+		// pixel format instead.
+		Graphics::PixelFormat format = state.pixelFormat;
+		Common::List<Graphics::PixelFormat> supportedFormats = getSupportedFormats();
+		if (Common::find(supportedFormats.begin(), supportedFormats.end(), format) == supportedFormats.end())
+			format = supportedFormats.front();
+		initSize(state.screenWidth, state.screenHeight, &format);
 #else
 		initSize(state.screenWidth, state.screenHeight, nullptr);
 #endif


### PR DESCRIPTION
When switching between the SDL and OpenGL graphics managers, trying to restore the state could fail as the two managers do not have the same list of supported formats, so we may not be able to transfer the pixel format from one to the other. This then resulted in an assert.

This fixes [bug #12079](https://bugs.scummvm.org/ticket/12079).

I am not sure the way I fixed it is the best way to do it. So I am opening that pull request for review before merging.