### PR TITLE
ULTIMA8: Font override option 

### DIFF
--- a/engines/ultima/detection.cpp
+++ b/engines/ultima/detection.cpp
@@ -22,7 +22,10 @@
 
 #include "base/plugins.h"
 
+#include "common/translation.h"
+
 #include "ultima/detection.h"
+#include "ultima/detection_tables.h"
 
 namespace Ultima {
 
@@ -45,12 +48,21 @@ static const PlainGameDescriptor ULTIMA_GAMES[] = {
 	{ 0, 0 }
 };
 
+static const ADExtraGuiOptionsMap optionsList[] = {
+    GAMEOPTION_OVERRIDE_FONTS,
+	{
+        _s("Enable font replacement"),
+        _s("Replaces game fonts with rendered fonts"),
+        "overridefonts",
+        false
+	},
+    AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
 } // End of namespace Ultima
 
-#include "ultima/detection_tables.h"
-
 UltimaMetaEngineDetection::UltimaMetaEngineDetection() : AdvancedMetaEngineDetection(Ultima::GAME_DESCRIPTIONS,
-	        sizeof(Ultima::UltimaGameDescription), Ultima::ULTIMA_GAMES) {
+	        sizeof(Ultima::UltimaGameDescription), Ultima::ULTIMA_GAMES, Ultima::optionsList) {
 	static const char *const DIRECTORY_GLOBS[2] = { "usecode", 0 };
 	_maxScanDepth = 2;
 	_directoryGlobs = DIRECTORY_GLOBS;

--- a/engines/ultima/detection_tables.h
+++ b/engines/ultima/detection_tables.h
@@ -22,6 +22,8 @@
 
 namespace Ultima {
 
+#define GAMEOPTION_OVERRIDE_FONTS GUIO_GAMEOPTIONS1
+
 static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 #ifndef RELEASE_BUILD
 	{
@@ -248,7 +250,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOMIDI)
+			GUIO2(GUIO_NOMIDI, GAMEOPTION_OVERRIDE_FONTS)
 		},
 		GAME_ULTIMA8,
 		0
@@ -263,7 +265,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOMIDI)
+			GUIO2(GUIO_NOMIDI, GAMEOPTION_OVERRIDE_FONTS)
 		},
 		GAME_ULTIMA8,
 		0
@@ -278,7 +280,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOMIDI)
+			GUIO2(GUIO_NOMIDI, GAMEOPTION_OVERRIDE_FONTS)
 		},
 		GAME_ULTIMA8,
 		0
@@ -292,7 +294,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOMIDI)
+			GUIO2(GUIO_NOMIDI, GAMEOPTION_OVERRIDE_FONTS)
 		},
 		GAME_ULTIMA8,
 		0
@@ -306,7 +308,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOMIDI)
+			GUIO2(GUIO_NOMIDI, GAMEOPTION_OVERRIDE_FONTS)
 		},
 		GAME_ULTIMA8,
 		0
@@ -321,7 +323,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOMIDI)
+			GUIO2(GUIO_NOMIDI, GAMEOPTION_OVERRIDE_FONTS)
 		},
 		GAME_ULTIMA8,
 		0
@@ -335,7 +337,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOMIDI)
+			GUIO2(GUIO_NOMIDI, GAMEOPTION_OVERRIDE_FONTS)
 		},
 		GAME_ULTIMA8,
 		0
@@ -349,7 +351,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 			Common::JA_JPN,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOMIDI)
+			GUIO2(GUIO_NOMIDI, GAMEOPTION_OVERRIDE_FONTS)
 		},
 		GAME_ULTIMA8,
 		0

--- a/engines/ultima/ultima8/games/game_data.cpp
+++ b/engines/ultima/ultima8/games/game_data.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include "common/config-manager.h"
+
 #include "ultima/ultima8/misc/pent_include.h"
 #include "ultima/ultima8/misc/util.h"
 #include "ultima/ultima8/games/game_data.h"
@@ -373,7 +375,6 @@ void GameData::setupFontOverrides() {
 }
 
 void GameData::setupJPOverrides() {
-	SettingManager *settingman = SettingManager::get_instance();
 	ConfigFileManager *config = ConfigFileManager::get_instance();
 	FontManager *fontmanager = FontManager::get_instance();
 	KeyMap jpkeyvals;
@@ -400,22 +401,19 @@ void GameData::setupJPOverrides() {
 		}
 	}
 
-	bool ttfoverrides = false;
-	settingman->get("ttf", ttfoverrides);
-	if (ttfoverrides)
+	bool overridefonts = ConfMan.getBool("overridefonts");
+	if (overridefonts)
 		setupTTFOverrides("language/fontoverride", true);
 }
 
 void GameData::setupTTFOverrides(const char *configkey, bool SJIS) {
 	ConfigFileManager *config = ConfigFileManager::get_instance();
-	SettingManager *settingman = SettingManager::get_instance();
 	FontManager *fontmanager = FontManager::get_instance();
 	KeyMap ttfkeyvals;
 	KeyMap::const_iterator iter;
 
-	bool ttfoverrides = false;
-	settingman->get("ttf", ttfoverrides);
-	if (!ttfoverrides) return;
+	bool overridefonts = ConfMan.getBool("overridefonts");
+	if (!overridefonts) return;
 
 	ttfkeyvals = config->listKeyValues(configkey);
 	for (iter = ttfkeyvals.begin(); iter != ttfkeyvals.end(); ++iter) {

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -329,8 +329,8 @@ bool Ultima8Engine::startupGame() {
 
 	_game = Game::createGame(getGameInfo());
 
-	_settingMan->setDefault("ttf", false);
-	_settingMan->get("ttf", _ttfOverrides);
+	ConfMan.registerDefault("overridefonts", false);
+	_ttfOverrides = ConfMan.getBool("overridefonts");
 
 	_settingMan->setDefault("frameSkip", false);
 	_settingMan->get("frameSkip", _frameSkip);


### PR DESCRIPTION
ULTIMA8: Add engine option for replacing the game font with ttf rendering

This option was previously controlled by pentagram.ini "ttf" setting.
I'd prefer a review as this is the first option added for this engine.