### PR TITLE
SCUMM: COMI: fix hebrew multiline dialogue

### DIFF
--- a/engines/scumm/smush/smush_font.cpp
+++ b/engines/scumm/smush/smush_font.cpp
@@ -200,9 +200,8 @@ int SmushFont::draw2byte(byte *buffer, int dst_width, int x, int y, int idx) {
 
 void SmushFont::drawSubstring(const char *str, uint numBytesMax, byte *buffer, int dst_width, int x, int y) {
 	if (_vm->_language == Common::HE_ISR) {
-		for (int i = strlen(str); i >= 0 && numBytesMax; i--) {
-			x += drawChar(buffer, dst_width, x, y, str[i]);
-			--numBytesMax;
+		for (int i = numBytesMax; i > 0; i--) {
+			x += drawChar(buffer, dst_width, x, y, str[i - 1]);
 		}
 	} else {
 		for (int i = 0; str[i] != 0 && numBytesMax; ++i) {

--- a/engines/scumm/verbs.cpp
+++ b/engines/scumm/verbs.cpp
@@ -1013,9 +1013,6 @@ void ScummEngine_v7::drawVerb(int verb, int mode) {
 		_charset->setCurID(vs->charset_nr);
 
 		// Compute the text rect
-		if (_language == Common::HE_ISR) {
-			vs->curRect.left = _screenWidth - _charset->getStringWidth(0, buf);
-		}
 		vs->curRect.right = 0;
 		vs->curRect.bottom = 0;
 		const byte *msg2 = msg;
@@ -1046,12 +1043,26 @@ void ScummEngine_v7::drawVerb(int verb, int mode) {
 				}
 				--len;
 			}
+			if (_language == Common::HE_ISR) {
+				vs->curRect.right -= vs->curRect.left;
+				vs->curRect.left = _screenWidth - _charset->getStringWidth(0, tmpBuf);
+				vs->curRect.right += vs->curRect.left;
+			}
 			enqueueText(tmpBuf, vs->curRect.left, vs->curRect.top, color, vs->charset_nr, vs->center);
 			if (len >= 0) {
-				enqueueText(&msg[len + 1], vs->curRect.left, vs->curRect.top + _verbLineSpacing, color, vs->charset_nr, vs->center);
+				int16 leftPos = vs->curRect.left;
+				if (_language == Common::HE_ISR) {
+					leftPos = _screenWidth - _charset->getStringWidth(0, &msg[len + 1]);
+				}
+				enqueueText(&msg[len + 1], leftPos, vs->curRect.top + _verbLineSpacing, color, vs->charset_nr, vs->center);
 				vs->curRect.bottom += _verbLineSpacing;
 			}
 		} else {
+			if (_language == Common::HE_ISR) {
+				vs->curRect.right -= vs->curRect.left;
+				vs->curRect.left = _screenWidth - _charset->getStringWidth(0, buf);
+				vs->curRect.right += vs->curRect.left;
+			}
 			enqueueText(msg, vs->curRect.left, vs->curRect.top, color, vs->charset_nr, vs->center);
 		}
 		_charset->setCurID(oldID);


### PR DESCRIPTION
Fixes bug in dialogue text in COMI hebrew fan translation,
bug was: when the dialogue option should have span on multiple lines, it was instead cropped out of the screen.

this is solved by aligning the text to the right after lines are splitted.

Thanks.