### PR TITLE
BASE: Fix crash when building with uncached plugins and static detection

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -344,12 +344,14 @@ void PluginManagerUncached::init() {
 
 	unloadPluginsExcept(PLUGIN_TYPE_ENGINE, NULL, false); // empty the engine plugins
 
+#ifndef DETECTION_STATIC
 	Common::String detectPluginName = "detection";
 #ifdef PLUGIN_SUFFIX
 	detectPluginName += PLUGIN_SUFFIX;
 #endif
 
 	bool foundDetectPlugin = false;
+#endif
 
 	for (ProviderList::iterator pp = _providers.begin();
 	                            pp != _providers.end();
@@ -361,6 +363,7 @@ void PluginManagerUncached::init() {
 			// file plugins. Currently this is the case. If it changes, we
 			// should find a fast way of detecting whether a plugin is a
 			// music or an engine plugin.
+#ifndef DETECTION_STATIC
 			if (!foundDetectPlugin && (*pp)->isFilePluginProvider()) {
 				Common::String pName = (*p)->getFileName();
 				if (pName.hasSuffix(detectPluginName)) {
@@ -370,6 +373,7 @@ void PluginManagerUncached::init() {
 					continue;
 				}
 			}
+#endif
 
 			if ((*pp)->isFilePluginProvider()) {
 				_allEnginePlugins.push_back(*p);
@@ -443,6 +447,7 @@ void PluginManagerUncached::updateConfigWithFileName(const Common::String &engin
 	}
 }
 
+#ifndef DETECTION_STATIC
 void PluginManagerUncached::loadDetectionPlugin() {
 	bool linkMetaEngines = false;
 
@@ -484,6 +489,7 @@ void PluginManagerUncached::unloadDetectionPlugin() {
 		debug(9, "Detection plugin is already unloaded.");
 	}
 }
+#endif
 
 void PluginManagerUncached::loadFirstPlugin() {
 	unloadPluginsExcept(PLUGIN_TYPE_ENGINE, NULL, false);

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -372,7 +372,7 @@ protected:
 
 	bool _isDetectionLoaded;
 
-	PluginManagerUncached() : _isDetectionLoaded(false) {}
+	PluginManagerUncached() : _isDetectionLoaded(false), _detectionPlugin(nullptr) {}
 	bool loadPluginByFileName(const Common::String &filename);
 
 public:
@@ -381,8 +381,10 @@ public:
 	virtual bool loadNextPlugin() override;
 	virtual bool loadPluginFromEngineId(const Common::String &engineId) override;
 	virtual void updateConfigWithFileName(const Common::String &engineId) override;
+#ifndef DETECTION_STATIC
 	virtual void loadDetectionPlugin() override;
 	virtual void unloadDetectionPlugin() override;
+#endif
 
 	virtual void loadAllPlugins() override {} 	// we don't allow these
 	virtual void loadAllPluginsOfType(PluginType type) override {}


### PR DESCRIPTION
This should fix [Trac #12094](https://bugs.scummvm.org/ticket/12094).