### PR TITLE
CREATE-PROJECT: Various portability fixes for Mac OS X Leopard and other older systems

### DIFF
--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -27,6 +27,10 @@
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.
 #endif
 
+#if __cplusplus < 201103L && (!defined(_MSC_VER) || _MSC_VER < 1700)
+#define override           // Compatibility with non-C++11 compilers.
+#endif
+
 #include <list>
 #include <map>
 #include <map>

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -29,7 +29,7 @@
 #ifdef MACOSX
 #include <sstream>
 #include <iomanip>
-#include <CommonCrypto/CommonCrypto.h>
+#include <CommonCrypto/CommonDigest.h>
 #endif
 
 namespace CreateProjectTool {

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -23,6 +23,9 @@
 #include "config.h"
 #include "xcode.h"
 
+#include <limits.h>
+#include <stdlib.h>
+
 #include <fstream>
 #include <algorithm>
 
@@ -938,9 +941,9 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 
 	std::string projectOutputDirectory;
 #ifdef POSIX
-	char *rp = realpath(setup.outputDir.c_str(), NULL);
+	char tmpbuf[PATH_MAX];
+	char *rp = realpath(setup.outputDir.c_str(), tmpbuf);
 	projectOutputDirectory = rp;
-	free(rp);
 #endif
 
 	/****************************************


### PR DESCRIPTION
Here's a set of changes I had to make so that `create_project` could be built on Mac OS X Leopard.

In summary:

* pick the `override` compat macro from `c++11-compat.h` to `msbuild.h`, because this file makes use of the `override` keyword, and older compilers don't have it.
* use `<CommonCrypto/CommonDigest.h>`, not `<CommonCrypto/CommonCrypto.h>` for `CC_MD5()`. This is what the manpage documents, and Leopard will not find it without the proper header.
* use the older POSIX.1-2001 syntax for `realpath()`, not the POSIX.1-2008 one, because it will cause a crash on older systems. Don't `free(rp);` anymore, since we're no longer using the heap for this.

This is maybe useless (although the one for `CommonDigest.h` still looks good to me), or you may want to do this a bit differently, but here's my proposal :)

Tested on Leopard and Mojave.