### PR TITLE
AUDIO: Combine WaveFormat enums under one header

### DIFF
--- a/audio/decoders/asf.cpp
+++ b/audio/decoders/asf.cpp
@@ -382,7 +382,7 @@ ASFStream::Packet *ASFStream::readPacket() {
 
 Codec *ASFStream::createCodec() {
 	switch (_compression) {
-	case kWaveWMAv2:
+	case kWaveFormatWMAv2:
 		return new WMACodec(2, _sampleRate, _channels, _bitRate, _blockAlign, _extraData);
 	default:
 		error("ASFStream::createAudioStream(): Unknown compression 0x%04x", _compression);

--- a/audio/decoders/wave.cpp
+++ b/audio/decoders/wave.cpp
@@ -25,20 +25,13 @@
 #include "common/stream.h"
 
 #include "audio/audiostream.h"
+#include "audio/decoders/wave_types.h"
 #include "audio/decoders/wave.h"
 #include "audio/decoders/adpcm.h"
 #include "audio/decoders/mp3.h"
 #include "audio/decoders/raw.h"
 
 namespace Audio {
-
-// Audio Codecs
-enum {
-	kWaveFormatPCM = 1,
-	kWaveFormatMSADPCM = 2,
-	kWaveFormatMSIMAADPCM = 17,
-	kWaveFormatMP3 = 85
-};
 
 bool loadWAVFromStream(Common::SeekableReadStream &stream, int &size, int &rate, byte &flags, uint16 *wavType, int *blockAlign_) {
 	const int32 initialPos = stream.pos();

--- a/audio/decoders/wave_types.h
+++ b/audio/decoders/wave_types.h
@@ -25,12 +25,16 @@
 
 namespace Audio {
 
+// Audio Codecs
 enum WaveCompressionType {
-	kWavePCM         = 0x0001,
-	kWaveMSADPCM     = 0x0002,
-	kWaveMSIMAADPCM  = 0x0011,
-	kWaveMSIMAADPCM2 = 0x0069,
-	kWaveWMAv2       = 0x0161
+	kWaveFormatNone        = 0x0000,
+	kWaveFormatPCM         = 0x0001,
+	kWaveFormatMSADPCM     = 0x0002,
+	kWaveFormatMSIMAADPCM  = 0x0011,
+	kWaveFormatMP3         = 0x0055,
+	kWaveFormatDK3         = 0x0062, // rogue format number
+	kWaveFormatMSIMAADPCM2 = 0x0069,
+	kWaveFormatWMAv2       = 0x0161
 };
 
 } // End of namespace Audio

--- a/engines/titanic/sound/wave_file.cpp
+++ b/engines/titanic/sound/wave_file.cpp
@@ -22,6 +22,7 @@
 
 #include "audio/decoders/raw.h"
 #include "audio/decoders/wave.h"
+#include "audio/decoders/wave_types.h"
 #include "common/memstream.h"
 #include "titanic/sound/wave_file.h"
 #include "titanic/sound/sound_manager.h"
@@ -176,14 +177,12 @@ Audio::SeekableAudioStream *CWaveFile::createAudioStream() {
 
 
 const int16 *CWaveFile::lock() {
-	enum { kWaveFormatPCM = 1 };
-
 	switch (_loadMode) {
 	case LOADMODE_SCUMMVM:
 		// Sanity checking that only raw 16-bit LE 22Khz waves can be locked
 		assert(_waveData && _rate == AUDIO_SAMPLING_RATE);
 		assert(_flags == (Audio::FLAG_LITTLE_ENDIAN | Audio::FLAG_16BITS));
-		assert(_wavType == kWaveFormatPCM);
+		assert(_wavType == Audio::kWaveFormatPCM);
 
 		// Return a pointer to the data section of the wave file
 		return (const int16 *)(_waveData + _headerSize);

--- a/video/avi_decoder.cpp
+++ b/video/avi_decoder.cpp
@@ -30,6 +30,7 @@
 #include "video/avi_decoder.h"
 
 // Audio Codecs
+#include "audio/decoders/wave_types.h"
 #include "audio/decoders/adpcm.h"
 #include "audio/decoders/mp3.h"
 #include "audio/decoders/raw.h"
@@ -1096,7 +1097,7 @@ void AVIDecoder::AVIAudioTrack::createAudioStream() {
 	_packetStream = 0;
 
 	switch (_wvInfo.tag) {
-	case kWaveFormatPCM: {
+	case Audio::kWaveFormatPCM: {
 		byte flags = 0;
 		if (_audsHeader.sampleSize == 2)
 			flags |= Audio::FLAG_16BITS | Audio::FLAG_LITTLE_ENDIAN;
@@ -1109,23 +1110,23 @@ void AVIDecoder::AVIAudioTrack::createAudioStream() {
 		_packetStream = Audio::makePacketizedRawStream(_wvInfo.samplesPerSec, flags);
 		break;
 	}
-	case kWaveFormatMSADPCM:
+	case Audio::kWaveFormatMSADPCM:
 		_packetStream = Audio::makePacketizedADPCMStream(Audio::kADPCMMS, _wvInfo.samplesPerSec, _wvInfo.channels, _wvInfo.blockAlign);
 		break;
-	case kWaveFormatMSIMAADPCM:
+	case Audio::kWaveFormatMSIMAADPCM:
 		_packetStream = Audio::makePacketizedADPCMStream(Audio::kADPCMMSIma, _wvInfo.samplesPerSec, _wvInfo.channels, _wvInfo.blockAlign);
 		break;
-	case kWaveFormatDK3:
+	case Audio::kWaveFormatDK3:
 		_packetStream = Audio::makePacketizedADPCMStream(Audio::kADPCMDK3, _wvInfo.samplesPerSec, _wvInfo.channels, _wvInfo.blockAlign);
 		break;
-	case kWaveFormatMP3:
+	case Audio::kWaveFormatMP3:
 #ifdef USE_MAD
 		_packetStream = Audio::makePacketizedMP3Stream(_wvInfo.channels, _wvInfo.samplesPerSec);
 #else
 		warning("AVI MP3 stream found, but no libmad support compiled in");
 #endif
 		break;
-	case kWaveFormatNone:
+	case Audio::kWaveFormatNone:
 		break;
 	default:
 		warning("Unsupported AVI audio format %d", _wvInfo.tag);

--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -296,16 +296,6 @@ protected:
 	protected:
 		Audio::AudioStream *getAudioStream() const { return _audioStream; }
 
-		// Audio Codecs
-		enum {
-			kWaveFormatNone = 0,
-			kWaveFormatPCM = 1,
-			kWaveFormatMSADPCM = 2,
-			kWaveFormatMSIMAADPCM = 17,
-			kWaveFormatMP3 = 85,
-			kWaveFormatDK3 = 98		// rogue format number
-		};
-
 		AVIStreamHeader _audsHeader;
 		PCMWaveFormat _wvInfo;
 		Audio::AudioStream *_audioStream;


### PR DESCRIPTION
I noticed the A/V code duplicates the WAV Format Tags multiple times, so I combined all of them into the common `wave_types.h` header, as this should make it easier to add new formats in the future and avoid conflicts.

Dunno if decimal or hexadecimal is better, but since the format specification uses hexadecimal I went with that.