### PR TITLE
BASE: Avoid calling PluginMan.getEngineFromMetaEngine where possible

### DIFF
--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -269,7 +269,7 @@ void OSystem_iOS7::saveState() {
 		Common::String targetName(ConfMan.getActiveDomainName());
 		int saveSlot = g_engine->getAutosaveSlot();
 		// Make sure we do not overwrite a user save
-		SaveStateDescriptor desc = g_engine->getMetaEngine().querySaveMetaInfos(targetName.c_str(), saveSlot);
+		SaveStateDescriptor desc = g_engine->getMetaEngine()->querySaveMetaInfos(targetName.c_str(), saveSlot);
 		if (desc.getSaveSlot() != -1 && !desc.isAutosave())
 			return;
 

--- a/engines/ags/ags.cpp
+++ b/engines/ags/ags.cpp
@@ -385,7 +385,7 @@ Common::Error AGSEngine::run() {
 }
 
 SaveStateList AGSEngine::listSaves() const {
-	return getMetaEngine().listSaves(_targetName.c_str());
+	return getMetaEngine()->listSaves(_targetName.c_str());
 }
 
 void AGSEngine::setGraphicsMode(size_t w, size_t h) {

--- a/engines/ags/plugins/ags_galaxy_steam/ags_galaxy_steam.cpp
+++ b/engines/ags/plugins/ags_galaxy_steam/ags_galaxy_steam.cpp
@@ -168,8 +168,8 @@ void AGSGalaxy::AGS_EngineStartup(IAGSEngine *engine) {
 	SCRIPT_METHOD_EXT(AGSGalaxy::GetCurrentGameLanguage^0, GetCurrentGameLanguage);
 	SCRIPT_METHOD_EXT(AGSGalaxy::Initialize^2, Initialize);
 
-	const MetaEngine &meta = ::AGS::g_vm->getMetaEngine();
-	Common::AchievementsInfo achievementsInfo = meta.getAchievementsInfo(::AGS::g_vm->getGameId());
+	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
+	Common::AchievementsInfo achievementsInfo = meta->getAchievementsInfo(::AGS::g_vm->getGameId());
 	const Common::String target = achievementsInfo.appId;
 	if (!target.empty()) {
 		AchMan.setActiveDomain(Common::GALAXY_ACHIEVEMENTS, target);
@@ -187,8 +187,8 @@ void AGSGalaxy::IsAchievementAchieved(ScriptMethodParams &params) {
 void AGSGalaxy::SetAchievementAchieved(ScriptMethodParams &params) {
 	PARAMS1(char *, id);
 
-	const MetaEngine &meta = ::AGS::g_vm->getMetaEngine();
-	Common::AchievementsInfo achievementsInfo = meta.getAchievementsInfo(::AGS::g_vm->getGameId());
+	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
+	Common::AchievementsInfo achievementsInfo = meta->getAchievementsInfo(::AGS::g_vm->getGameId());
 
 	Common::String msg = id;
 	for (uint32 i = 0; i < achievementsInfo.descriptions.size(); i++) {
@@ -304,8 +304,8 @@ void AGSSteam::AGS_EngineStartup(IAGSEngine *engine) {
 	SCRIPT_METHOD_EXT(AGSteam::GetCurrentGameLanguage^0, GetCurrentGameLanguage);
 	SCRIPT_METHOD_EXT(AGSteam::FindLeaderboard^1, FindLeaderboard);
 
-	const MetaEngine &meta = ::AGS::g_vm->getMetaEngine();
-	Common::AchievementsInfo achievementsInfo = meta.getAchievementsInfo(::AGS::g_vm->getGameId());
+	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
+	Common::AchievementsInfo achievementsInfo = meta->getAchievementsInfo(::AGS::g_vm->getGameId());
 	const Common::String target = achievementsInfo.appId;
 	if (!target.empty()) {
 		AchMan.setActiveDomain(Common::STEAM_ACHIEVEMENTS, target);
@@ -323,8 +323,8 @@ void AGSSteam::IsAchievementAchieved(ScriptMethodParams &params) {
 void AGSSteam::SetAchievementAchieved(ScriptMethodParams &params) {
 	PARAMS1(char *, id);
 
-	const MetaEngine &meta = ::AGS::g_vm->getMetaEngine();
-	Common::AchievementsInfo achievementsInfo = meta.getAchievementsInfo(::AGS::g_vm->getGameId());
+	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
+	Common::AchievementsInfo achievementsInfo = meta->getAchievementsInfo(::AGS::g_vm->getGameId());
 
 	Common::String msg = id;
 	for (uint32 i = 0; i < achievementsInfo.descriptions.size(); i++) {

--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -325,7 +325,7 @@ Common::Error CineEngine::saveGameState(int slot, const Common::String &desc, bo
 }
 
 Common::String CineEngine::getSaveStateName(int slot) const {
-	return getMetaEngine().getSavegameFile(slot, _targetName.c_str());
+	return getMetaEngine()->getSavegameFile(slot, _targetName.c_str());
 }
 
 bool CineEngine::canLoadGameStateCurrently() {

--- a/engines/cine/saveload.cpp
+++ b/engines/cine/saveload.cpp
@@ -1030,7 +1030,7 @@ void CineEngine::makeSave(const Common::String &saveFileName, uint32 playtime,
 		renderer->popSavedBackBuffer(BEFORE_OPENING_MENU);
 	}
 
-	getMetaEngine().appendExtendedSave(fHandle.get(), playtime, desc, isAutosave);
+	getMetaEngine()->appendExtendedSave(fHandle.get(), playtime, desc, isAutosave);
 
 	renderer->restoreSavedBackBuffer(BEFORE_TAKING_THUMBNAIL);
 

--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -273,7 +273,7 @@ ConfigDialog::ConfigDialog() :
 	assert(g_engine);
 
 	const Common::String &gameDomain = ConfMan.getActiveDomainName();
-	const MetaEngine &metaEngine = g_engine->getMetaEngine();
+	const MetaEngine *metaEngine = g_engine->getMetaEngine();
 
 	// GUI:  Add tab widget
 	GUI::TabWidget *tab = new GUI::TabWidget(this, "GlobalConfig.TabWidget");
@@ -285,7 +285,7 @@ ConfigDialog::ConfigDialog() :
 	int tabId = tab->addTab(_("Game"), "GlobalConfig_Engine");
 
 	if (g_engine->hasFeature(Engine::kSupportsChangingOptionsDuringRuntime)) {
-		_engineOptions = metaEngine.buildEngineOptionsWidgetDynamic(tab, "GlobalConfig_Engine.Container", gameDomain);
+		_engineOptions = metaEngine->buildEngineOptionsWidgetDynamic(tab, "GlobalConfig_Engine.Container", gameDomain);
 	}
 
 	if (_engineOptions) {
@@ -321,7 +321,7 @@ ConfigDialog::ConfigDialog() :
 	// The Keymap tab
 	//
 
-	Common::KeymapArray keymaps = metaEngine.initKeymaps(gameDomain.c_str());
+	Common::KeymapArray keymaps = metaEngine->initKeymaps(gameDomain.c_str());
 	if (!keymaps.empty()) {
 		tab->addTab(_("Keymaps"), "GlobalConfig_KeyMapper");
 		addKeyMapperControls(tab, "GlobalConfig_KeyMapper.", keymaps, gameDomain);
@@ -343,7 +343,7 @@ ConfigDialog::ConfigDialog() :
 	//
 	// The Achievements tab
 	//
-	Common::AchievementsInfo achievementsInfo = metaEngine.getAchievementsInfo(gameDomain);
+	Common::AchievementsInfo achievementsInfo = metaEngine->getAchievementsInfo(gameDomain);
 	if (achievementsInfo.descriptions.size() > 0) {
 		tab->addTab(_("Achievements"), "GlobalConfig_Achievements");
 		addAchievementsControls(tab, "GlobalConfig_Achievements.", achievementsInfo);

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -540,7 +540,7 @@ void Engine::saveAutosaveIfEnabled() {
 
 		if (saveFlag) {
 			// First check for an existing savegame in the slot, and if present, if it's an autosave
-			SaveStateDescriptor desc = getMetaEngine().querySaveMetaInfos(
+			SaveStateDescriptor desc = getMetaEngine()->querySaveMetaInfos(
 				_targetName.c_str(), getAutosaveSlot());
 			saveFlag = desc.getSaveSlot() == -1 || desc.isAutosave();
 		}
@@ -774,7 +774,7 @@ Common::Error Engine::saveGameState(int slot, const Common::String &desc, bool i
 
 	Common::Error result = saveGameStream(saveFile, isAutosave);
 	if (result.getCode() == Common::kNoError) {
-		getMetaEngine().appendExtendedSave(saveFile, getTotalPlayTime() / 1000, desc, isAutosave);
+		getMetaEngine()->appendExtendedSave(saveFile, getTotalPlayTime() / 1000, desc, isAutosave);
 
 		saveFile->finalize();
 	}
@@ -886,16 +886,6 @@ MetaEngineDetection &Engine::getMetaEngineDetection() {
 	const Plugin *plugin = EngineMan.findPlugin(ConfMan.get("engineid"));
 	assert(plugin);
 	return plugin->get<MetaEngineDetection>();
-}
-
-MetaEngine &Engine::getMetaEngine() {
-	const Plugin *metaEnginePlugin = EngineMan.findPlugin(ConfMan.get("engineid"));
-	assert(metaEnginePlugin);
-
-	const Plugin *enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);
-	assert(enginePlugin);
-
-	return enginePlugin->get<MetaEngine>();
 }
 
 PauseToken::PauseToken() : _engine(nullptr) {}

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -175,6 +175,11 @@ protected:
 
 private:
 	/**
+	 * The associated metaengine
+	 */
+	MetaEngine *_metaEngine;
+
+	/**
 	 * The pause level.
 	 *
 	 * 0 means 'running'. A positive value indicates how often the engine
@@ -490,7 +495,12 @@ public:
 	/**
 	 * Return the MetaEngine instance used by this engine.
 	 */
-	static MetaEngine &getMetaEngine();
+	inline MetaEngine *getMetaEngine() const { return _metaEngine; }
+
+	/**
+	 * Set the MetaEngine instance used by this engine.
+	 */
+	inline void setMetaEngine(MetaEngine *metaEngine) { _metaEngine = metaEngine; }
 
 	/**
 	 * Pause the engine.

--- a/engines/hadesch/hadesch.cpp
+++ b/engines/hadesch/hadesch.cpp
@@ -896,7 +896,7 @@ int HadeschEngine::genSubtitleID() {
 
 int HadeschEngine::firstAvailableSlot() {
 	for (unsigned slot = 3; ; slot++) {
-		SaveStateDescriptor desc = getMetaEngine().querySaveMetaInfos(_targetName.c_str(), slot);
+		SaveStateDescriptor desc = getMetaEngine()->querySaveMetaInfos(_targetName.c_str(), slot);
 		if (desc.getSaveSlot() == -1 && !desc.getWriteProtectedFlag())
 			return slot;
 	}
@@ -909,7 +909,7 @@ void HadeschEngine::quit() {
 bool HadeschEngine::hasAnySaves() {
 	Common::SaveFileManager *saveFileMan = getSaveFileManager();
 	Common::StringArray filenames;
-	Common::String pattern(getMetaEngine().getSavegameFilePattern(_targetName.c_str()));
+	Common::String pattern(getMetaEngine()->getSavegameFilePattern(_targetName.c_str()));
 
 	filenames = saveFileMan->listSavefiles(pattern);
 
@@ -919,7 +919,7 @@ bool HadeschEngine::hasAnySaves() {
 Common::Array<HadeschSaveDescriptor> HadeschEngine::getHadeschSavesList() {
 	Common::SaveFileManager *saveFileMan = getSaveFileManager();
 	Common::StringArray filenames;
-	Common::String pattern(getMetaEngine().getSavegameFilePattern(_targetName.c_str()));
+	Common::String pattern(getMetaEngine()->getSavegameFilePattern(_targetName.c_str()));
 
 	filenames = saveFileMan->listSavefiles(pattern);
 
@@ -947,7 +947,7 @@ Common::Array<HadeschSaveDescriptor> HadeschEngine::getHadeschSavesList() {
 }
 
 void HadeschEngine::deleteSave(int slot) {
-	getMetaEngine().removeSaveState(_targetName.c_str(), slot);
+	getMetaEngine()->removeSaveState(_targetName.c_str(), slot);
 }
 
 void EventHandlerWrapper::operator()() const {

--- a/engines/petka/interfaces/save_load.cpp
+++ b/engines/petka/interfaces/save_load.cpp
@@ -72,9 +72,9 @@ void InterfaceSaveLoad::start(int id) {
 
 	Common::ScopedPtr<Graphics::Font> font(Graphics::loadTTFFontFromArchive("FreeSans.ttf", 20));
 
-	MetaEngine &metaEngine = PetkaEngine::getMetaEngine();
+	MetaEngine *metaEngine = g_engine->getMetaEngine();
 	for (int i = 0, j = _page * 6; i < 6; ++i, ++j) {
-		SaveStateDescriptor save = metaEngine.querySaveMetaInfos(g_vm->_desc->gameId, j);
+		SaveStateDescriptor save = metaEngine->querySaveMetaInfos(g_vm->_desc->gameId, j);
 
 		auto surface = save.getThumbnail();
 		if (!surface)

--- a/engines/twine/menu/menuoptions.cpp
+++ b/engines/twine/menu/menuoptions.cpp
@@ -375,7 +375,7 @@ int MenuOptions::chooseSave(int textIdx, bool showEmptySlots) {
 	MenuSettings saveFiles;
 	saveFiles.addButton(TextId::kReturnMenu);
 
-	const int maxButtons = _engine->getMetaEngine().getMaximumSaveSlot() + 1;
+	const int maxButtons = _engine->getMetaEngine()->getMaximumSaveSlot() + 1;
 	for (const SaveStateDescriptor &savegame : savegames) {
 		saveFiles.addButton(savegame.getDescription().encode().c_str(), savegame.getSaveSlot());
 		if (saveFiles.getButtonCount() >= maxButtons) {

--- a/engines/twine/twine.cpp
+++ b/engines/twine/twine.cpp
@@ -324,7 +324,7 @@ bool TwinEEngine::hasFeature(EngineFeature f) const {
 }
 
 SaveStateList TwinEEngine::getSaveSlots() const {
-	return getMetaEngine().listSaves(_targetName.c_str());
+	return getMetaEngine()->listSaves(_targetName.c_str());
 }
 
 void TwinEEngine::wipeSaveSlot(int slot) {
@@ -1150,8 +1150,8 @@ const char *TwinEEngine::getGameId() const {
 }
 
 bool TwinEEngine::unlockAchievement(const Common::String &id) {
-	const MetaEngine &meta = getMetaEngine();
-	const Common::AchievementsInfo &achievementsInfo = meta.getAchievementsInfo(ConfMan.getActiveDomainName());
+	const MetaEngine *meta = getMetaEngine();
+	const Common::AchievementsInfo &achievementsInfo = meta->getAchievementsInfo(ConfMan.getActiveDomainName());
 
 	Common::String msg = id;
 	for (uint32 i = 0; i < achievementsInfo.descriptions.size(); i++) {

--- a/engines/ultima/nuvie/files/nuvie_io_file.cpp
+++ b/engines/ultima/nuvie/files/nuvie_io_file.cpp
@@ -185,7 +185,7 @@ void NuvieIOFileWrite::close() {
 	} else if (_saveFile) {
 		// Writing using savefile interface, so flush out data
 		_saveFile->write(_saveFileData.getData(), _saveFileData.size());
-		g_engine->getMetaEngine().appendExtendedSave(_saveFile, Shared::g_ultima->getTotalPlayTime(), _description, _isAutosave);
+		g_engine->getMetaEngine()->appendExtendedSave(_saveFile, Shared::g_ultima->getTotalPlayTime(), _description, _isAutosave);
 
 		_saveFile->finalize();
 		delete _saveFile;

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -1076,7 +1076,7 @@ bool Ultima8Engine::newGame(int saveSlot) {
 
 	// First validate we still have a save file for the slot
 	if (saveSlot != -1) {
-		SaveStateDescriptor desc = getMetaEngine().querySaveMetaInfos(_targetName.c_str(), saveSlot);
+		SaveStateDescriptor desc = getMetaEngine()->querySaveMetaInfos(_targetName.c_str(), saveSlot);
 		if (desc.getSaveSlot() != saveSlot)
 			saveSlot = -1;
 	}

--- a/engines/wintermute/ext/wme_galaxy.cpp
+++ b/engines/wintermute/ext/wme_galaxy.cpp
@@ -50,9 +50,9 @@ SXWMEGalaxyAPI::SXWMEGalaxyAPI(BaseGame *inGame, ScStack *stack) : BaseScriptabl
 
 //////////////////////////////////////////////////////////////////////////
 void SXWMEGalaxyAPI::init() {
-	const MetaEngine &meta = ((WintermuteEngine *)g_engine)->getMetaEngine();
+	const MetaEngine *meta = g_engine->getMetaEngine();
 	const Common::String target = BaseEngine::instance().getGameTargetName();
-	_achievementsInfo = meta.getAchievementsInfo(target);
+	_achievementsInfo = meta->getAchievementsInfo(target);
 
 	if (!_achievementsInfo.appId.empty()) {
 		AchMan.setActiveDomain(Common::GALAXY_ACHIEVEMENTS, _achievementsInfo.appId);

--- a/engines/wintermute/ext/wme_steam.cpp
+++ b/engines/wintermute/ext/wme_steam.cpp
@@ -50,9 +50,9 @@ SXSteamAPI::SXSteamAPI(BaseGame *inGame, ScStack *stack) : BaseScriptable(inGame
 
 //////////////////////////////////////////////////////////////////////////
 void SXSteamAPI::init() {
-	const MetaEngine &meta = ((WintermuteEngine *)g_engine)->getMetaEngine();
+	const MetaEngine *meta = g_engine->getMetaEngine();
 	const Common::String target = BaseEngine::instance().getGameTargetName();
-	_achievementsInfo = meta.getAchievementsInfo(target);
+	_achievementsInfo = meta->getAchievementsInfo(target);
 
 	if (!_achievementsInfo.appId.empty()) {
 		AchMan.setActiveDomain(Common::STEAM_ACHIEVEMENTS, _achievementsInfo.appId);

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -495,10 +495,11 @@ void LauncherDialog::loadGame(int item) {
 	}
 
 	if (enginePlugin) {
+		assert(enginePlugin->getType() == PLUGIN_TYPE_ENGINE);
 		const MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
 		if (metaEngine.hasFeature(MetaEngine::kSupportsListSaves) &&
 			metaEngine.hasFeature(MetaEngine::kSupportsLoadingDuringStartup)) {
-			int slot = _loadDialog->runModalWithPluginAndTarget(enginePlugin, target);
+			int slot = _loadDialog->runModalWithMetaEngineAndTarget(&metaEngine, target);
 			if (slot >= 0) {
 				ConfMan.setActiveDomain(_domains[item]);
 				ConfMan.setInt("save_slot", slot, Common::ConfigManager::kTransientDomain);

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -103,7 +103,7 @@ void SaveLoadCloudSyncProgressDialog::handleTickle() {
 #endif
 
 #ifndef DISABLE_SAVELOADCHOOSER_GRID
-SaveLoadChooserType getRequestedSaveLoadDialog(const MetaEngine &metaEngine) {
+SaveLoadChooserType getRequestedSaveLoadDialog(const MetaEngine *metaEngine) {
 	const Common::String &userConfig = ConfMan.get("gui_saveload_chooser", Common::ConfigManager::kApplicationDomain);
 
 	// Check (and update if necessary) the theme config here. This catches
@@ -114,8 +114,8 @@ SaveLoadChooserType getRequestedSaveLoadDialog(const MetaEngine &metaEngine) {
 	g_gui.checkScreenChange();
 
 	if (g_gui.getWidth() >= 640 && g_gui.getHeight() >= 400
-		&& metaEngine.hasFeature(MetaEngine::kSavesSupportMetaInfo)
-		&& metaEngine.hasFeature(MetaEngine::kSavesSupportThumbnail)
+		&& metaEngine->hasFeature(MetaEngine::kSavesSupportMetaInfo)
+		&& metaEngine->hasFeature(MetaEngine::kSavesSupportThumbnail)
 		&& userConfig.equalsIgnoreCase("grid")) {
 		// In case we are 640x400 or higher, this dialog is not in save mode,
 		// the user requested the grid dialog and the engines supports it we
@@ -268,7 +268,7 @@ void SaveLoadChooserDialog::handleTickle() {
 void SaveLoadChooserDialog::reflowLayout() {
 #ifndef DISABLE_SAVELOADCHOOSER_GRID
 	const SaveLoadChooserType currentType = getType();
-	const SaveLoadChooserType requestedType = getRequestedSaveLoadDialog(*_metaEngine);
+	const SaveLoadChooserType requestedType = getRequestedSaveLoadDialog(_metaEngine);
 
 	addChooserButtons();
 	if (currentType == kSaveLoadDialogList) {
@@ -1036,7 +1036,7 @@ int SaveLoadChooserGrid::runIntern() {
 	int slot;
 	do {
 		const SaveLoadChooserType currentType = getType();
-		const SaveLoadChooserType requestedType = getRequestedSaveLoadDialog(*_metaEngine);
+		const SaveLoadChooserType requestedType = getRequestedSaveLoadDialog(_metaEngine);
 
 		// Catch resolution changes when the save name dialog was open.
 		if (currentType != requestedType) {

--- a/gui/saveload-dialog.h
+++ b/gui/saveload-dialog.h
@@ -65,7 +65,7 @@ enum SaveLoadChooserType {
 	kSaveLoadDialogGrid = 1
 };
 
-SaveLoadChooserType getRequestedSaveLoadDialog(const MetaEngine &metaEngine);
+SaveLoadChooserType getRequestedSaveLoadDialog(const MetaEngine *metaEngine);
 #endif // !DISABLE_SAVELOADCHOOSER_GRID
 
 class SaveLoadChooserDialog : protected Dialog {

--- a/gui/saveload.h
+++ b/gui/saveload.h
@@ -40,7 +40,7 @@ protected:
 	const U32String _buttonLabel;
 	const bool _saveMode;
 
-	void selectChooser(const MetaEngine &engine);
+	void selectChooser(const MetaEngine *engine);
 public:
 	SaveLoadChooser(const U32String &title, const U32String &buttonLabel, bool saveMode);
 	~SaveLoadChooser();
@@ -52,7 +52,7 @@ public:
 	 * @return The selcted save slot. -1 in case none is selected.
 	 */
 	int runModalWithCurrentTarget();
-	int runModalWithPluginAndTarget(const Plugin *plugin, const String &target);
+	int runModalWithMetaEngineAndTarget(const MetaEngine *engine, const String &target);
 
 	const Common::U32String &getResultString() const;
 


### PR DESCRIPTION
This fixes [Trac #12016](https://bugs.scummvm.org/ticket/12016) by having the engine hold a pointer to the MetaEngine instance, rather than looking it up again when it's needed.