### PR TITLE
IMAGE: Move mpeg2dec.h inclusion in CPP file

### DIFF
--- a/image/codecs/mpeg.cpp
+++ b/image/codecs/mpeg.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "common/debug.h"
+#include "common/inttypes.h"
 #include "common/stream.h"
 #include "common/system.h"
 #include "common/textconsole.h"
@@ -28,6 +29,10 @@
 #include "graphics/yuv_to_rgb.h"
 
 #include "image/codecs/mpeg.h"
+
+extern "C" {
+	#include <mpeg2dec/mpeg2.h>
+}
 
 namespace Image {
 

--- a/image/codecs/mpeg.h
+++ b/image/codecs/mpeg.h
@@ -25,13 +25,11 @@
 #ifndef IMAGE_CODECS_MPEG_H
 #define IMAGE_CODECS_MPEG_H
 
-#include "common/inttypes.h"
 #include "image/codecs/codec.h"
 #include "graphics/pixelformat.h"
 
-extern "C" {
-	#include <mpeg2dec/mpeg2.h>
-}
+typedef struct mpeg2dec_s mpeg2dec_t;
+typedef struct mpeg2_info_s mpeg2_info_t;
 
 namespace Common {
 class SeekableReadStream;


### PR DESCRIPTION
This avoids to pollute declarations with inttypes.h and mpeg2dec.h when
including mpeg.h
