### PR TITLE
SCI: Restart sounds in kDoSoundPlay when already playing

### DIFF
--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -185,7 +185,7 @@ public:
 
 	// sound and midi functions
 	void soundInitSnd(MusicEntry *pSnd);
-	void soundPlay(MusicEntry *pSnd);
+	void soundPlay(MusicEntry *pSnd, bool restoring = false);
 	void soundStop(MusicEntry *pSnd);
 	void soundKill(MusicEntry *pSnd);
 	void soundPause(MusicEntry *pSnd);

--- a/engines/sci/sound/soundcmd.cpp
+++ b/engines/sci/sound/soundcmd.cpp
@@ -238,7 +238,7 @@ void SoundCommandParser::processPlaySound(reg_t obj, bool playBed, bool restorin
 	debugC(kDebugLevelSound, "kDoSound(play): %04x:%04x number %d, loop %d, prio %d, vol %d, bed %d", PRINT_REG(obj),
 			resourceId, musicSlot->loop, musicSlot->priority, musicSlot->volume, playBed ? 1 : 0);
 
-	_music->soundPlay(musicSlot);
+	_music->soundPlay(musicSlot, restoring);
 
 	// Reset any left-over signals
 	musicSlot->signal = 0;


### PR DESCRIPTION
When kDoSoundPlay is called on a sound that's already playing, SSCI would restart that sound, but ScummVM has instead just allowed the existing sound to continue. Not many scripts depend on this but a few do and bugs have built up in the tracker. The codepaths for handling samples vs MIDIs are different but they're in the same function and it causes the same kinds of issues.

Fixed by restarting MIDIs:

- QFG4 doorbell puzzle not playing the same bell multiple times in a row. The script expects to be able to interrupt and restart the bell. https://bugs.scummvm.org/ticket/12105
- KQ6CD wallflower dance lockup when playing the flute while the music is still playing doesn't start the song over. If the song doesn't start over, the signals the script waits on never occur. https://bugs.scummvm.org/ticket/10812

Fixed by restarting samples:

- SQ4CD keypads where pressing keys quickly doesn't play the next tone because the trailing silence from the first one is still playing. There should be a tone for every press as in the original. https://bugs.scummvm.org/ticket/9813

~~These changes will also cause MIDI sounds in saved games to consistently start from the beginning when restored if they were in the Playing status when saved, as that's also what happens in SSCI.~~ (Update: that was wrong, SSCI has a function for fast forwarding on restore, these changes now preserve that behavior.)

The change to the MIDI logic brings it in sync with the logic a few lines earlier for whether or not to send init commands. Looking at the history surrounding these lines and how they evolved over a lot of little changes and fixes, it doesn't look like it was ever the specific intent to not restart a sound that's already playing. Little things just got moved around in isolation.

This should also take care of the remaining issues that PR #2128 addresses.

I want to do more testing on this but thought I'd get it out here in case someone can poke holes in it right away. I'm intimidated by sound stuff but this particular behavior is easy to verify. It's also easy to see what happens to the things that depend on it.

The sample change is simpler than it looks in the github diff, essentially it just removes the "if (!_pMixer->isSoundHandleActive(pSnd->hCurrentAud))" check.