### PR TITLE
AGS: Add AddAchievment method to AGSGalaxySteam

### DIFF
--- a/engines/ags/plugins/ags_galaxy_steam/ags_blackwell_steam.cpp
+++ b/engines/ags/plugins/ags_galaxy_steam/ags_blackwell_steam.cpp
@@ -30,9 +30,13 @@ AGSBlackwellSteam::AGSBlackwellSteam() : AGSSteam() {
 	DLL_METHOD(AGS_EngineStartup);
 }
 
+int AGSBlackwellSteam::AddAchievement(const ScriptMethodParams &params) {
+	return 0;
+}
+
 void AGSBlackwellSteam::AGS_EngineStartup(IAGSEngine *engine) {
 	AGSSteam::AGS_EngineStartup(engine);
-
+	SCRIPT_METHOD_EXT(Steam::AddAchievement^1, AddAchievement);
 	SCRIPT_METHOD_EXT(Steam::IsAchievementAchieved^1, IsAchievementAchieved);
 	SCRIPT_METHOD_EXT(Steam::SetAchievementAchieved^1, SetAchievementAchieved);
 	SCRIPT_METHOD_EXT(Steam::ResetAchievement^1, ResetAchievement);

--- a/engines/ags/plugins/ags_galaxy_steam/ags_blackwell_steam.h
+++ b/engines/ags/plugins/ags_galaxy_steam/ags_blackwell_steam.h
@@ -32,7 +32,8 @@ namespace AGSGalaxySteam {
 class AGSBlackwellSteam : public AGSSteam {
 private:
 	static void AGS_EngineStartup(IAGSEngine *engine);
-
+	static int AddAchievement(const ScriptMethodParams &params);
+    
 public:
 	AGSBlackwellSteam();
 };


### PR DESCRIPTION
AGS:  This pull request adds the AddAchievment method to AGSGalaxySteam to fix a script crash when starting Blackwell Epiphany.