### PR TITLE
ENGINES: Make creation of savegame thumbnails an overrideable method

### DIFF
--- a/engines/cine/saveload.cpp
+++ b/engines/cine/saveload.cpp
@@ -1030,7 +1030,7 @@ void CineEngine::makeSave(const Common::String &saveFileName, uint32 playtime,
 		renderer->popSavedBackBuffer(BEFORE_OPENING_MENU);
 	}
 
-	MetaEngine::appendExtendedSave(fHandle.get(), playtime, desc, isAutosave);
+	getMetaEngine().appendExtendedSave(fHandle.get(), playtime, desc, isAutosave);
 
 	renderer->restoreSavedBackBuffer(BEFORE_TAKING_THUMBNAIL);
 

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -774,7 +774,7 @@ Common::Error Engine::saveGameState(int slot, const Common::String &desc, bool i
 
 	Common::Error result = saveGameStream(saveFile, isAutosave);
 	if (result.getCode() == Common::kNoError) {
-		MetaEngine::appendExtendedSave(saveFile, getTotalPlayTime() / 1000, desc, isAutosave);
+		getMetaEngine().appendExtendedSave(saveFile, getTotalPlayTime() / 1000, desc, isAutosave);
 
 		saveFile->finalize();
 	}

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -165,21 +165,19 @@ void MetaEngine::appendExtendedSave(Common::OutSaveFile *saveFile, uint32 playti
 	saveFile->writeString(desc);
 	saveFile->writeByte(isAutosave);
 
-	saveScreenThumbnail(saveFile);
+	// Write out the thumbnail
+	Graphics::Surface thumb;
+	getSavegameThumbnail(thumb);
+	Graphics::saveThumbnail(*saveFile, thumb);
+	thumb.free();
 
 	saveFile->writeUint32LE(headerPos);	// Store where the header starts
 
 	saveFile->finalize();
 }
 
-void MetaEngine::saveScreenThumbnail(Common::OutSaveFile *saveFile) {
-	// Create a thumbnail surface from the screen
-	Graphics::Surface thumb;
+void MetaEngine::getSavegameThumbnail(Graphics::Surface &thumb) {
 	::createThumbnailFromScreen(&thumb);
-
-	// Write out the thumbnail
-	Graphics::saveThumbnail(*saveFile, thumb);
-	thumb.free();
 }
 
 void MetaEngine::parseSavegameHeader(ExtendedSavegameHeader *header, SaveStateDescriptor *desc) {

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -202,11 +202,13 @@ public:
  * the engine, while a MetaEngine will always build into the executable to be able to detect code.
  */
 class MetaEngine : public PluginObject {
-private:
+protected:
 	/**
-	 * Convert the current screen contents to a thumbnail and save it.
+	 * Convert the current screen contents to a thumbnail. Can be overriden by individual
+	 * engine meta engines to provide their own thumb, such as hiding any on-screen save
+	 * dialog so that it won't appear in the thumbnail.
 	 */
-	static void saveScreenThumbnail(Common::OutSaveFile *saveFile);
+	virtual void getSavegameThumbnail(Graphics::Surface &thumb);
 public:
 	virtual ~MetaEngine() {}
 
@@ -490,7 +492,8 @@ public:
 	/**
 	 * Write the extended savegame header to the given savegame file.
 	 */
-	static void appendExtendedSave(Common::OutSaveFile *saveFile, uint32 playtime, Common::String desc, bool isAutosave);
+	void appendExtendedSave(Common::OutSaveFile *saveFile, uint32 playtime, Common::String desc, bool isAutosave);
+
 	/**
 	 * Parse the extended savegame header to retrieve the SaveStateDescriptor information.
 	 */

--- a/engines/ultima/nuvie/files/nuvie_io_file.cpp
+++ b/engines/ultima/nuvie/files/nuvie_io_file.cpp
@@ -185,7 +185,7 @@ void NuvieIOFileWrite::close() {
 	} else if (_saveFile) {
 		// Writing using savefile interface, so flush out data
 		_saveFile->write(_saveFileData.getData(), _saveFileData.size());
-		MetaEngine::appendExtendedSave(_saveFile, Shared::g_ultima->getTotalPlayTime(), _description, _isAutosave);
+		g_engine->getMetaEngine().appendExtendedSave(_saveFile, Shared::g_ultima->getTotalPlayTime(), _description, _isAutosave);
 
 		_saveFile->finalize();
 		delete _saveFile;


### PR DESCRIPTION
I think this is a straightforward minor change, but since it touches the engine base, I thought I'd do a pull request for a quick review.

This change changes the methods for appending the new style extra savegame info to instance methods, and the method that generates the thumbnail a virtual method. This will allow engines to override the method in their own meta engine subclass, and do things like create a thumbnail without any on-screen dialogs showing.
