### PR TITLE
AGS: Fix Android crash to OS on game launch

### DIFF
--- a/engines/ags/shared/util/compress.cpp
+++ b/engines/ags/shared/util/compress.cpp
@@ -177,7 +177,7 @@ int cunpackbitl(uint8 *line, int size, Stream *in) {
 		if (in->HasErrors())
 			break;
 
-		char cx = ix;
+		int8 cx = ix;
 		if (cx == -128)
 			cx = 0;
 
@@ -214,7 +214,7 @@ int cunpackbitl16(uint16 *line, int size, Stream *in) {
 		if (in->HasErrors())
 			break;
 
-		char cx = ix;
+		int8 cx = ix;
 		if (cx == -128)
 			cx = 0;
 
@@ -251,7 +251,7 @@ int cunpackbitl32(uint32 *line, int size, Stream *in) {
 		if (in->HasErrors())
 			break;
 
-		char cx = ix;
+		int8 cx = ix;
 		if (cx == -128)
 			cx = 0;
 


### PR DESCRIPTION
The Android NDK uses unsigned char by default. Fixed the decompression algorithm by replacing them with int8. Also not using the fixed PixelFormat with OpenGL as it is not supported there. These changes allow the Games to run, albeit with messed up colors.