### PR TITLE
OPENGL: Add support for ARGB8888 pixel format on little endian systems

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -226,6 +226,9 @@ Common::List<Graphics::PixelFormat> OpenGLGraphicsManager::getSupportedFormats()
 #ifdef SCUMM_LITTLE_ENDIAN
 	// RGBA8888
 	formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
+
+	// ARGB8888
+	formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24));
 #else
 	// ABGR8888
 	formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
@@ -1128,6 +1131,10 @@ Surface *OpenGLGraphicsManager::createSurface(const Graphics::PixelFormat &forma
 	} else if (isGLESContext() && format == Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)) { // ABGR8888
 #endif
 		return new TextureRGBA8888Swap();
+#ifdef SCUMM_LITTLE_ENDIAN
+	} else if (isGLESContext() && format == Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24)) { // ARGB8888
+		return new TextureARGB8888();
+#endif
 #endif // !USE_FORCED_GL
 	} else {
 		const bool supported = getGLPixelFormat(format, glIntFormat, glFormat, glType);
@@ -1174,6 +1181,11 @@ bool OpenGLGraphicsManager::getGLPixelFormat(const Graphics::PixelFormat &pixelF
 		glIntFormat = GL_RGBA;
 		glFormat = GL_RGBA;
 		glType = GL_UNSIGNED_INT_8_8_8_8;
+		return true;
+	} else if (pixelFormat == Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24)) { // ARGB8888
+		glIntFormat = GL_RGBA;
+		glFormat = GL_BGRA;
+		glType = GL_UNSIGNED_INT_8_8_8_8_REV;
 		return true;
 #endif
 	} else if (pixelFormat == Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0)) { // RGB555

--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -530,6 +530,46 @@ void TextureRGBA8888Swap::updateGLTexture() {
 	// Do generic handling of updating the texture.
 	Texture::updateGLTexture();
 }
+
+TextureARGB8888::TextureARGB8888()
+    : FakeTexture(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)) // ABGR8888
+{
+}
+
+Graphics::PixelFormat TextureARGB8888::getFormat() const {
+	return Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24); // ARGB8888
+}
+
+void TextureARGB8888::updateGLTexture() {
+	if (!isDirty()) {
+		return;
+	}
+
+	// Convert color space.
+	Graphics::Surface *outSurf = Texture::getSurface();
+
+	const Common::Rect dirtyArea = getDirtyArea();
+
+	uint32 *dst = (uint32 *)outSurf->getBasePtr(dirtyArea.left, dirtyArea.top);
+	const uint dstAdd = outSurf->pitch - 4 * dirtyArea.width();
+
+	const uint32 *src = (const uint32 *)_rgbData.getBasePtr(dirtyArea.left, dirtyArea.top);
+	const uint srcAdd = _rgbData.pitch - 4 * dirtyArea.width();
+
+	for (int height = dirtyArea.height(); height > 0; --height) {
+		for (int width = dirtyArea.width(); width > 0; --width) {
+			const uint32 color = *src++;
+
+			*dst++ = (color & 0xFF00FF00) | ((color >> 16) & 0x000000FF) | ((color << 16) & 0x00FF0000);
+		}
+
+		src = (const uint32 *)((const byte *)src + srcAdd);
+		dst = (uint32 *)((byte *)dst + dstAdd);
+	}
+
+	// Do generic handling of updating the texture.
+	Texture::updateGLTexture();
+}
 #endif // !USE_FORCED_GL
 
 #if !USE_FORCED_GLES

--- a/backends/graphics/opengl/texture.h
+++ b/backends/graphics/opengl/texture.h
@@ -353,6 +353,16 @@ public:
 
 	virtual void updateGLTexture();
 };
+
+class TextureARGB8888 : public FakeTexture {
+public:
+	TextureARGB8888();
+	virtual ~TextureARGB8888() {};
+
+	virtual Graphics::PixelFormat getFormat() const;
+
+	virtual void updateGLTexture();
+};
 #endif // !USE_FORCED_GL
 
 #if !USE_FORCED_GLES


### PR DESCRIPTION
Should also fix display issues for AGS titles on other platforms using mainly OpenGL.