### PR TITLE
Add engine option widget for language selection

### DIFF
--- a/engines/ags/detection.cpp
+++ b/engines/ags/detection.cpp
@@ -24,8 +24,14 @@
 #include "common/config-manager.h"
 #include "common/file.h"
 #include "common/md5.h"
+#include "common/str-array.h"
+#include "common/translation.h"
 #include "ags/detection.h"
 #include "ags/detection_tables.h"
+
+#include "gui/ThemeEval.h"
+#include "gui/widget.h"
+#include "gui/widgets/popup.h"
 
 namespace AGS3 {
 
@@ -56,6 +62,85 @@ static bool isAGSFile(Common::File &f) {
 		return true;
 
 	return false;
+}
+
+class AGSOptionsWidget : public GUI::OptionsContainerWidget {
+public:
+	explicit AGSOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
+
+	// OptionsContainerWidget API
+	void load() override;
+	bool save() override;
+
+private:
+	// OptionsContainerWidget API
+	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
+
+	GUI::PopUpWidget *_langPopUp;
+	Common::StringArray _traFileNames;
+};
+
+AGSOptionsWidget::AGSOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain) :
+		OptionsContainerWidget(boss, name, "AGSGameOptionsDialog", false, domain) {
+			
+	GUI::StaticTextWidget *textWidget = new GUI::StaticTextWidget(widgetsBoss(), _dialogLayout + ".translation_desc", _("Game language:"), _("Language to use for multilingual games"));
+	textWidget->setAlign(Graphics::kTextAlignRight);
+			
+	_langPopUp = new GUI::PopUpWidget(widgetsBoss(), _dialogLayout + ".translation");
+	_langPopUp->appendEntry(_("<default>"), (uint32)-1);
+
+	Common::String path = ConfMan.get("path", _domain);
+	Common::FSDirectory dir(path);
+	Common::ArchiveMemberList traFileList;
+	dir.listMatchingMembers(traFileList, "*.tra");
+
+	int i = 0;
+	for (Common::ArchiveMemberList::iterator iter = traFileList.begin(); iter != traFileList.end(); ++iter) {
+		Common::String traFileName = (*iter)->getName();
+		traFileName.erase(traFileName.size() - 4); // remove .tra extension
+		_traFileNames.push_back(traFileName);
+		_langPopUp->appendEntry(traFileName, i++);
+	}
+}
+
+void AGSOptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const {
+	layouts.addDialog(layoutName, overlayedLayout);
+	layouts.addLayout(GUI::ThemeLayout::kLayoutVertical).addPadding(16, 16, 16, 16);
+
+	layouts.addLayout(GUI::ThemeLayout::kLayoutHorizontal).addPadding(0, 0, 0, 0);
+	layouts.addWidget("translation_desc", "OptionsLabel");
+	layouts.addWidget("translation", "PopUp").closeLayout();
+
+	layouts.closeLayout().closeDialog();
+}
+
+void AGSOptionsWidget::load() {
+	Common::ConfigManager::Domain *gameConfig = ConfMan.getDomain(_domain);
+	if (!gameConfig)
+		return;
+
+	uint32 curLangIndex = (uint32)-1;
+	Common::String curLang;
+	gameConfig->tryGetVal("translation", curLang);
+	if (!curLang.empty()) {
+		for (uint i = 0; i < _traFileNames.size(); ++i) {
+			if (_traFileNames[i].equalsIgnoreCase(curLang)) {
+				curLangIndex = i;
+				break;
+			}
+		}
+	}
+	_langPopUp->setSelectedTag(curLangIndex);
+}
+
+bool AGSOptionsWidget::save() {
+	uint langIndex = _langPopUp->getSelectedTag();
+	if (langIndex < _traFileNames.size())
+		ConfMan.set("translation", _traFileNames[langIndex], _domain);
+	else
+		ConfMan.removeKey("translation", _domain);
+
+	return true;
 }
 
 } // namespace AGS3
@@ -131,6 +216,10 @@ ADDetectedGame AGSMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 	}
 
 	return ADDetectedGame();
+}
+
+GUI::OptionsContainerWidget *AGSMetaEngineDetection::buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
+	return new AGS3::AGSOptionsWidget(boss, name, target);
 }
 
 REGISTER_PLUGIN_STATIC(AGS_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, AGSMetaEngineDetection);

--- a/engines/ags/detection.h
+++ b/engines/ags/detection.h
@@ -69,6 +69,8 @@ public:
 	}
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const override;
+	
+	GUI::OptionsContainerWidget *buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
 #endif

--- a/engines/ags/engine/platform/windows/setup/winsetup.cpp
+++ b/engines/ags/engine/platform/windows/setup/winsetup.cpp
@@ -181,7 +181,11 @@ void WinConfig::Load(const ConfigTree &cfg) {
 		MouseSpeed = 1.f;
 
 	SpriteCacheSize = INIreadint(cfg, "misc", "cachemax", SpriteCacheSize);
-	Language = INIreadstring(cfg, "language", "translation", Language);
+	
+	if (ConfMan.getActiveDomain()->tryGetVal("translation", translation) && !translation.empty())
+		Language = translation;
+	else
+		Language = INIreadstring(cfg, "language", "translation", Language);
 	DefaultLanguageName = INIreadstring(cfg, "language", "default_translation_name", DefaultLanguageName);
 
 	Title = INIreadstring(cfg, "misc", "titletext", Title);
@@ -211,6 +215,14 @@ void WinConfig::Save(ConfigTree &cfg) {
 
 	INIwriteint(cfg, "misc", "cachemax", SpriteCacheSize);
 	INIwritestring(cfg, "language", "translation", Language);
+
+	if (Language.empty()) {
+		if (ConfMan.getActiveDomain()->contains("translation"))
+			ConfMan.getActiveDomain()->erase("translation");
+	} else
+		ConfMan.getActiveDomain()->setVal("translation", Language);
+	
+	ConfMan.flushToDisk();
 }
 
 


### PR DESCRIPTION
AGS games can have multiple languages by providing additional translations as .tra files. The language selection is done by setting the config "translation" key to the tra file name. This means that we cannot easily use the standard ScummVM language selection for this purpose as the tra file name may not map to language names easily.

Also the advanced detector does not allow specifying multiple languages for a game, and adding separate detections for all the languages by using the tra files for the detection would be cumbersome.

Instead this pull request  does something similar to the original games by detecting at runtime the available .tra files, but replaces the original setup utility by a game option widget.

![image](https://user-images.githubusercontent.com/552105/107886914-9c69f080-6efa-11eb-8bc1-66caf13e80b2.png)

It's not ideal that we have an ineffective Language selector in the Game tab, and another one in the Engine tab. Maybe to avoid confusion we could add a GUIO_NOLANGUAGE  option that would hide the Language selector in the Game tab for the games that define it.