### PR TITLE
3DS: Rename the _3DS namespace

### DIFF
--- a/backends/platform/3ds/config.cpp
+++ b/backends/platform/3ds/config.cpp
@@ -27,7 +27,7 @@
 #include "backends/platform/3ds/options-dialog.h"
 #include "common/config-manager.h"
 
-namespace _3DS {
+namespace N3DS {
 
 Config config;
 static Common::String prefix = "3ds_";
@@ -86,4 +86,4 @@ void saveConfig() {
 	ConfMan.flushToDisk();
 }
 
-} // namespace _3DS
+} // namespace N3DS

--- a/backends/platform/3ds/config.h
+++ b/backends/platform/3ds/config.h
@@ -25,7 +25,7 @@
 
 #include "common/str.h"
 
-namespace _3DS {
+namespace N3DS {
 
 struct Config {
 	bool showCursor;
@@ -39,6 +39,6 @@ extern Config config;
 void loadConfig();
 void saveConfig();
 
-} // namespace _3DS
+} // namespace N3DS
 
 #endif // CONFIG_3DS_H

--- a/backends/platform/3ds/main.cpp
+++ b/backends/platform/3ds/main.cpp
@@ -38,7 +38,7 @@ struct CommandLine {
 };
 
 static void mainThreadFunc(void *threadParams) {
-	g_system = new _3DS::OSystem_3DS();
+	g_system = new N3DS::OSystem_3DS();
 	assert(g_system);
 
 #ifdef DYNAMIC_MODULES

--- a/backends/platform/3ds/options-dialog.cpp
+++ b/backends/platform/3ds/options-dialog.cpp
@@ -34,7 +34,7 @@
 #include "common/translation.h"
 #include "common/ustr.h"
 
-namespace _3DS {
+namespace N3DS {
 
 bool optionMenuOpened = false;
 
@@ -107,4 +107,4 @@ void OptionsDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32
 	}
 }
 
-} // namespace _3DS
+} // namespace N3DS

--- a/backends/platform/3ds/options-dialog.h
+++ b/backends/platform/3ds/options-dialog.h
@@ -32,7 +32,7 @@
 #include "gui/widgets/tab.h"
 #include "scumm/dialogs.h"
 
-namespace _3DS {
+namespace N3DS {
 
 enum {
 	kSave = 0x10000000,
@@ -71,6 +71,6 @@ protected:
 	GUI::RadiobuttonWidget *_screenBothRadioWidget;
 };
 
-} // namespace _3DS
+} // namespace N3DS
 
 #endif // OPTIONS_DIALOG_3DS_H

--- a/backends/platform/3ds/osystem-audio.cpp
+++ b/backends/platform/3ds/osystem-audio.cpp
@@ -23,7 +23,7 @@
 #include "backends/platform/3ds/osystem.h"
 #include "audio/mixer.h"
 
-namespace _3DS {
+namespace N3DS {
 
 static bool hasAudio = false;
 
@@ -105,4 +105,4 @@ Audio::Mixer *OSystem_3DS::getMixer() {
 	return _mixer;
 }
 
-} // namespace _3DS
+} // namespace N3DS

--- a/backends/platform/3ds/osystem-events.cpp
+++ b/backends/platform/3ds/osystem-events.cpp
@@ -37,7 +37,7 @@
 #include "engines/engine.h"
 #include "gui/gui-manager.h"
 
-namespace _3DS {
+namespace N3DS {
 
 static Common::Mutex *eventMutex;
 static InputMode inputMode = MODE_DRAG;
@@ -482,4 +482,4 @@ void OSystem_3DS::runOptionsDialog() {
 	optionsDialogRunning = false;
 }
 
-} // namespace _3DS
+} // namespace N3DS

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -41,7 +41,7 @@
          GX_TRANSFER_OUT_FORMAT(fmt) | GX_TRANSFER_SCALING(GX_TRANSFER_SCALE_NO))
 #define DEFAULT_MODE _modeRGBA8
 
-namespace _3DS {
+namespace N3DS {
 /* Group the various enums, values, etc. needed for
  * each graphics mode into instaces of GfxMode3DS */
 static const GfxMode3DS _modeRGBA8 = { Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0),
@@ -835,4 +835,4 @@ void OSystem_3DS::flushCursor() {
 	}
 }
 
-} // namespace _3DS
+} // namespace N3DS

--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -41,7 +41,7 @@
 #include <unistd.h>
 #include <time.h>
 
-namespace _3DS {
+namespace N3DS {
 
 OSystem_3DS::OSystem_3DS():
 	_focusDirty(true),
@@ -224,4 +224,4 @@ void OSystem_3DS::logMessage(LogMessageType::Type type, const char *message) {
 	printf("%s", message);
 }
 
-} // namespace _3DS
+} // namespace N3DS

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -39,7 +39,7 @@
 
 #define TICKS_PER_MSEC 268123
 
-namespace _3DS {
+namespace N3DS {
 
 enum MagnifyMode {
 	MODE_MAGON,
@@ -292,6 +292,6 @@ public:
 	PauseToken _sleepPauseToken;
 };
 
-} // namespace _3DS
+} // namespace N3DS
 
 #endif

--- a/backends/platform/3ds/sprite.cpp
+++ b/backends/platform/3ds/sprite.cpp
@@ -25,7 +25,7 @@
 #include "common/algorithm.h"
 #include "common/util.h"
 
-namespace _3DS {
+namespace N3DS {
 
 Sprite::Sprite()
 	: textureTransferFlags(0)
@@ -153,4 +153,4 @@ void Sprite::setFilteringMode(bool enableLinearFiltering) {
 	C3D_TexSetFilter(&texture, filteringMode, filteringMode);
 }
 
-} // namespace _3DS
+} // namespace N3DS

--- a/backends/platform/3ds/sprite.h
+++ b/backends/platform/3ds/sprite.h
@@ -29,7 +29,7 @@
 #include <3ds.h>
 #include <citro3d.h>
 
-namespace _3DS {
+namespace N3DS {
 
 typedef struct {
 	float position[3];
@@ -79,6 +79,6 @@ private:
 	float scaleY;
 };
 
-} // namespace _3DS
+} // namespace N3DS
 
 #endif


### PR DESCRIPTION
This fixes a clash with a define from the devkitPro build scripts.