### PR TITLE
COMMON: Add String::forEachLine and convertBiDiStringByLines

### DIFF
--- a/common/str.cpp
+++ b/common/str.cpp
@@ -410,6 +410,27 @@ String String::substr(size_t pos, size_t len) const {
 		return String(_str + pos, MIN((size_t)_size - pos, len));
 }
 
+String String::forEachLine(String(*func)(const String, va_list args), ...) const {
+	String result = "";
+	size_t index = findFirstOf('\n', 0);
+	size_t prev_index = 0;
+	va_list args;
+	va_start(args, func);
+	while (index != -1) {
+		String textLine = substr(prev_index, index - prev_index);
+		textLine = (*func)(textLine, args);
+		result = result + textLine + '\n';
+		prev_index = index + 1;
+		index = findFirstOf('\n', index + 1);
+	}
+
+	String textLine = substr(prev_index);
+	textLine = (*func)(textLine, args);
+	result = result + textLine;
+	va_end(args);
+	return result;
+}
+
 #pragma mark -
 
 bool operator==(const char* y, const String &x) {

--- a/common/str.h
+++ b/common/str.h
@@ -242,6 +242,9 @@ public:
 	/** Return a substring of this string */
 	String substr(size_t pos = 0, size_t len = npos) const;
 
+	/** Calls func on each line of the string, and returns a joined string */
+	String forEachLine(String(*func)(const String, va_list args), ...) const;
+
 	/** Python-like method **/
 	U32String decode(CodePage page = kUtf8) const;
 

--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -99,6 +99,15 @@ void UnicodeBiDiText::initWithU32String(const U32String &input) {
 
 }
 
+Common::String bidiByLineHelper(Common::String line, va_list args) {
+	Common::CodePage page = va_arg(args, Common::CodePage);
+	return Common::convertBiDiString(line, page);
+}
+
+String convertBiDiStringByLines(const String &input, const Common::CodePage page) {
+	return input.forEachLine(bidiByLineHelper, page);
+}
+
 String convertBiDiString(const String &input, const Common::Language lang) {
 	if (lang != Common::HE_ISR)		//TODO: modify when we'll support other RTL languages, such as Arabic and Farsi
 		return input;

--- a/common/unicode-bidi.h
+++ b/common/unicode-bidi.h
@@ -34,6 +34,7 @@ private:
 	uint32 *_log_to_vis_index; // from fribidi conversion
 	uint32 *_vis_to_log_index; // from fribidi conversion
 	void initWithU32String(const Common::U32String &str);
+	Common::String bidiByLine(Common::String line, va_list args);
 public:
 	const Common::U32String logical; // original string, ordered logically
 	Common::U32String visual; // from fribidi conversion, ordered visually
@@ -56,6 +57,9 @@ public:
 UnicodeBiDiText convertBiDiU32String(const U32String &input);
 String convertBiDiString(const String &input, const Common::Language lang);
 String convertBiDiString(const String &input, const Common::CodePage page);
+
+// calls convertBiDiString for each line in isolation
+String convertBiDiStringByLines(const String &input, const Common::CodePage page);
 
 } // End of namespace Common
 


### PR DESCRIPTION
`convertBiDiStringByLines` calls the BiDi algo for each line in isolation, and returns a joined result.
That's needed to support BiDi in AGI, and might be needed for other engines in the future.

In order to do that, a new utility function was added:
`String::forEachLine` which gets a function as input, and its arg(s) (if it has any), and calls the function on each line, and returns a new string which is all concatenation of all the lines results (with '\n' added between them).


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
