### PR TITLE
DRAGONS: Incomplete attempt at improving big-endian compatibility

### DIFF
--- a/engines/dragons/bag.cpp
+++ b/engines/dragons/bag.cpp
@@ -71,7 +71,7 @@ void Bag::load(BigfileArchive *bigFileArchive) {
 		} else {
 			//c = (uint16)(((uint)c & 0x1f) << 10) | (uint16)(((uint)c & 0x7c00) >> 10) | c & 0x3e0;
 		}
-		WRITE_LE_UINT16(&pal[i * 2], c);
+		WRITE_SCREEN(&pal[i * 2], c);
 	}
 
 	stream.seek(0x308);

--- a/engines/dragons/font.cpp
+++ b/engines/dragons/font.cpp
@@ -160,7 +160,7 @@ Font *FontManager::loadFont(uint16 index, Common::SeekableReadStream &stream) {
 void updatePalEntry(uint16 *pal, uint16 index, uint16 newValue) {
 	newValue = (uint16)(((uint16)newValue & 0x1f) << 10) | (uint16)(((uint16)newValue & 0x7c00) >> 10) |
 			(newValue & 0x3e0) | (newValue & 0x8000);
-	WRITE_LE_INT16(pal + index, newValue);
+	WRITE_SCREEN(pal + index, newValue);
 }
 
 void FontManager::updatePalette() {

--- a/engines/dragons/screen.cpp
+++ b/engines/dragons/screen.cpp
@@ -162,7 +162,7 @@ void Screen::copyRectToSurface(const void *buffer, int srcPitch, int srcWidth, i
 					dst[j * 2] = src[srcIdx * 2];
 					dst[j * 2 + 1] = src[srcIdx * 2 + 1];
 				} else {
-					WRITE_LE_UINT16(&dst[j * 2], alphaBlendRGB555(READ_LE_INT16(&src[srcIdx * 2]), READ_LE_INT16(&dst[j * 2]), 128));
+					WRITE_SCREEN(&dst[j * 2], alphaBlendRGB555(READ_LE_INT16(&src[srcIdx * 2]), READ_LE_INT16(&dst[j * 2]), 128));
 					// semi-transparent pixels.
 				}
 			}
@@ -190,10 +190,10 @@ void Screen::copyRectToSurface8bpp(const void *buffer, const byte* palette, int 
 			if (c != 0) {
 				if (!(c & 0x8000) || alpha == NONE) {
 					// only copy opaque pixels
-					WRITE_LE_UINT16(&dst[j * 2], c & ~0x8000);
+					WRITE_SCREEN(&dst[j * 2], c & ~0x8000);
 				} else {
 					// semi-transparent pixels.
-					WRITE_LE_UINT16(&dst[j * 2], alpha == NORMAL
+					WRITE_SCREEN(&dst[j * 2], alpha == NORMAL
 						? alphaBlendRGB555(c & 0x7fff, READ_LE_INT16(&dst[j * 2]) & 0x7fff, 128)
 						: alphaBlendAdditiveRGB555(c & 0x7fff, READ_LE_INT16(&dst[j * 2]) & 0x7fff));
 				}
@@ -247,9 +247,9 @@ void Screen::drawScaledSprite(Graphics::Surface *destSurface, const byte *source
 				if (c != 0) {
 					if (!(c & 0x8000u) || alpha == NONE) {
 						// only copy opaque pixels
-						WRITE_LE_UINT16(wdst, c & ~0x8000);
+						WRITE_SCREEN(wdst, c & ~0x8000);
 					} else {
-						WRITE_LE_UINT16(wdst, alphaBlendRGB555(c & 0x7fffu, READ_LE_UINT16(wdst) & 0x7fffu, 128));
+						WRITE_SCREEN(wdst, alphaBlendRGB555(c & 0x7fffu, READ_LE_UINT16(wdst) & 0x7fffu, 128));
 						// semi-transparent pixels.
 					}
 				}
@@ -357,7 +357,7 @@ void Screen::loadPalette(uint16 paletteNum, const byte *palette) {
 		uint16 c = READ_LE_INT16(&_palettes[paletteNum][i * 2]);
 		if ((c & ~0x8000) == 0) {
 			if (!isTransPalette) {
-				WRITE_LE_UINT16(&_palettes[paletteNum][i * 2], 0x8000);
+				WRITE_SCREEN(&_palettes[paletteNum][i * 2], 0x8000);
 			}
 		} else {
 			//TODO is this needed? see load_palette_into_frame_buffer()
@@ -365,13 +365,13 @@ void Screen::loadPalette(uint16 paletteNum, const byte *palette) {
 //					(c & 0x3e0) | (c & 0x8000);
 		}
 	}
-	WRITE_LE_UINT16(&_palettes[paletteNum][0], 0);
+	WRITE_SCREEN(&_palettes[paletteNum][0], 0);
 }
 
 void Screen::setPaletteRecord(uint16 paletteNum, uint16 offset, uint16 newValue) {
 	assert(paletteNum < DRAGONS_NUM_PALETTES);
 	assert(offset < 256);
-	WRITE_LE_UINT16(&_palettes[paletteNum][offset * 2], newValue);
+	WRITE_SCREEN(&_palettes[paletteNum][offset * 2], newValue);
 }
 
 byte *Screen::getPalette(uint16 paletteNum) {
@@ -408,7 +408,7 @@ void Screen::copyRectToSurface8bppWrappedY(const Graphics::Surface &srcSurface, 
 		for (int j = 0; j < DRAGONS_SCREEN_WIDTH; j++) {
 			uint16 c = READ_LE_UINT16(&palette[src[j] * 2]);
 			if (c != 0) {
-					WRITE_LE_UINT16(&dst[j * 2], c & ~0x8000);
+				WRITE_SCREEN(&dst[j * 2], c & ~0x8000);
 			}
 		}
 		dst += _backSurface->pitch;
@@ -430,9 +430,9 @@ void Screen::copyRectToSurface8bppWrappedX(const Graphics::Surface &srcSurface, 
 			if (c != 0) {
 				if (!(c & 0x8000) || alpha == NONE) {
 					// only copy opaque pixels
-					WRITE_LE_UINT16(&dst[j * 2], c & ~0x8000);
+					WRITE_SCREEN(&dst[j * 2], c & ~0x8000);
 				} else {
-					WRITE_LE_UINT16(&dst[j * 2], alpha == NORMAL ? alphaBlendRGB555(c, READ_LE_INT16(&dst[j * 2]), 128) : alphaBlendAdditiveRGB555(c, READ_LE_INT16(&dst[j * 2])));
+					WRITE_SCREEN(&dst[j * 2], alpha == NORMAL ? alphaBlendRGB555(c, READ_LE_INT16(&dst[j * 2]), 128) : alphaBlendAdditiveRGB555(c, READ_LE_INT16(&dst[j * 2])));
 					// semi-transparent pixels.
 				}
 			}

--- a/engines/dragons/screen.h
+++ b/engines/dragons/screen.h
@@ -24,6 +24,7 @@
 
 #include "graphics/surface.h"
 #include "graphics/pixelformat.h"
+#include "common/scummsys.h"
 #include "common/rect.h"
 
 namespace Dragons {
@@ -34,6 +35,12 @@ namespace Dragons {
 #define DRAGONS_SCREEN_HEIGHT 200
 
 #define DRAGONS_NUM_FLAT_QUADS 0xf
+
+#ifdef SCUMM_BIG_ENDIAN
+	#define WRITE_SCREEN WRITE_BE_UINT16
+#else
+	#define WRITE_SCREEN WRITE_LE_UINT16
+#endif
 
 enum AlphaBlendMode {
 	NONE,


### PR DESCRIPTION
Hi,

This is related to https://bugs.scummvm.org/ticket/11710.

DRAGONS has some important rendering issues with big-endian systems. I have a PowerBook G4 running Debian unstable on ppc32 (big-endian), so I tried having a look at this. (I'm doing my tests with `Blazing Dragons (Sony Playstation/French)`, for reference.)

This first commit is incomplete, and has been mostly done through naive trial-and-error, so see this more as an attempt at showing where the problem lies. Feel free to improve on it or to rewrite it completely in a better way :)

It seems that, in this engine, screen content must be written in native endianness here, not in little-endian. So, I've just introduced a naive `WRITE_SCREEN` macro that choses `WRITE_LE_UINT16` or `WRITE_BE_UINT16`, depending on your platform. Probably not the best way to handle this, but once again, let's suggest something and improve it.

The first commit I'm including in this PR appears to fix most scenes, cutscenes, and the bag.

Shadows, menus, and text are still wrong (I think I'm just missing something for the menus, and for the fonts/shadows it looks like some possible alpha blending problem). Audio hasn't been tested yet (Fluidsynth gives me some really strange initialisation errors, but it's maybe a problem with Debian unstable -- I'll look at this a bit later).

By the way, I also see these `(char)` casts in this engine:

```
sound.cpp:      second = (char)iVar3 + (char)(iVar3 / 10) * 6;
sound.cpp:      sector = (char)iVar2 + (char)(iVar2 / 10) * 6;
sound.cpp:      minute = (char)iVar1 + (char)(iVar1 / 10) * 6;
talk.cpp:                               talkDialogEntry->yPosMaybe = talkDialogEntry->yPosMaybe + (char)sVar2;
```

on PowerPC, `char` is unsigned by default, and I'm not sure the `char` here are used in a "pure character" way? Otherwise, we might want to use `signed char`, `int8` or `uint8` instead. But I don't really understand this part yet.

We can arrange for some more tests through Discord or whatever, if you like.