### PR TITLE
AUDIO: Use SeekableSubReadStream instead of reallocating streams

### DIFF
--- a/audio/decoders/mac_snd.cpp
+++ b/audio/decoders/mac_snd.cpp
@@ -29,6 +29,7 @@
 
 #include "common/textconsole.h"
 #include "common/stream.h"
+#include "common/substream.h"
 
 #include "audio/decoders/mac_snd.h"
 #include "audio/decoders/raw.h"
@@ -98,15 +99,10 @@ SeekableAudioStream *makeMacSndStream(Common::SeekableReadStream *stream,
 
 	stream->skip(soundDataOffset);
 
-	byte *data = (byte *)malloc(size);
-	assert(data);
-	stream->read(data, size);
-
-	if (disposeAfterUse == DisposeAfterUse::YES)
-		delete stream;
+	Common::SeekableReadStream *dataStream = new Common::SeekableSubReadStream(stream, stream->pos(), stream->pos() + size, disposeAfterUse);
 
 	// Since we allocated our own buffer for the data, we must specify DisposeAfterUse::YES.
-	return makeRawStream(data, size, rate, Audio::FLAG_UNSIGNED);
+	return makeRawStream(dataStream, rate, Audio::FLAG_UNSIGNED);
 }
 
 } // End of namespace Audio

--- a/audio/decoders/quicktime.cpp
+++ b/audio/decoders/quicktime.cpp
@@ -638,11 +638,7 @@ AudioStream *QuickTimeAudioDecoder::AudioSampleDesc::createAudioStream(Common::S
 			flags |= FLAG_STEREO;
 		if (_bitsPerSample == 16)
 			flags |= FLAG_16BITS;
-		uint32 dataSize = stream->size();
-		byte *data = (byte *)malloc(dataSize);
-		stream->read(data, dataSize);
-		delete stream;
-		return makeRawStream(data, dataSize, _sampleRate, flags);
+		return makeRawStream(stream, _sampleRate, flags);
 	} else if (_codecTag == MKTAG('i', 'm', 'a', '4')) {
 		// Riven uses this codec (as do some Myst ME videos)
 		return makeADPCMStream(stream, DisposeAfterUse::YES, stream->size(), kADPCMApple, _sampleRate, _channels, 34);

--- a/engines/cge/sound.cpp
+++ b/engines/cge/sound.cpp
@@ -58,6 +58,7 @@ Sound::~Sound() {
 
 void Sound::close() {
 	_vm->_midiPlayer->killMidi();
+	_vm->_mixer->stopAll();
 }
 
 void Sound::open() {

--- a/engines/cge2/sound.cpp
+++ b/engines/cge2/sound.cpp
@@ -56,6 +56,7 @@ Sound::~Sound() {
 
 void Sound::close() {
 	_vm->_midiPlayer->killMidi();
+	_vm->_mixer->stopAll();
 }
 
 void Sound::open() {


### PR DESCRIPTION
This cleans up audio code that mallocs raw audio data just to discard format headers, instead of just wrapping the stream. This reduces redundant reallocations since a lot of engines/decoders already do this anyways, and makes it easier to add WAV decoders since the extra headers are always discarded now.

One downside of this change is some engines have edge cases freeing sounds that are still being played (eg. closing the game mid-sound), which now crashes. I tried to fix the engines I ran across, but obviously I can't test every engine using raw WAVs, so I'd appreciate extra testing (and engine fixes) for this.