### PR TITLE
COMMON: Specialize unknownKeyError for more types

### DIFF
--- a/common/hashmap.cpp
+++ b/common/hashmap.cpp
@@ -81,6 +81,16 @@ template<> void unknownKeyError(long unsigned key) {
 	error("Unknown key \"%lu\"", key);
 }
 
+template<>
+void unknownKeyError(signed int key) {
+	error("Unknown key \"%i\"", key);
+}
+
+template<>
+void unknownKeyError(unsigned int key) {
+	error("Unknown key \"%u\"", key);
+}
+
 template<> void unknownKeyError(long long signed key) {
 	error("Unknown key \"%lli\"", key);
 }

--- a/common/hashmap.cpp
+++ b/common/hashmap.cpp
@@ -93,6 +93,10 @@ template<> void unknownKeyError(void *key) {
 	error("Unknown key \"%p\"", key);
 }
 
+template<> void unknownKeyError(const char *key) {
+	error("Unknown key \"%s\"", key);
+}
+
 #ifdef DEBUG_HASH_COLLISIONS
 static double
 	g_collisions = 0,

--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -326,6 +326,10 @@ void NORETURN_PRE unknownKeyError(long signed key) NORETURN_POST;
 template<>
 void NORETURN_PRE unknownKeyError(long unsigned key) NORETURN_POST;
 template<>
+void NORETURN_PRE unknownKeyError(signed int key) NORETURN_POST;
+template<>
+void NORETURN_PRE unknownKeyError(unsigned int key) NORETURN_POST;
+template<>
 void NORETURN_PRE unknownKeyError(long long signed key) NORETURN_POST;
 template<>
 void NORETURN_PRE unknownKeyError(long long unsigned key) NORETURN_POST;

--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -331,6 +331,8 @@ template<>
 void NORETURN_PRE unknownKeyError(long long unsigned key) NORETURN_POST;
 template<>
 void NORETURN_PRE unknownKeyError(void *key) NORETURN_POST;
+template<>
+void NORETURN_PRE unknownKeyError(const char *key) NORETURN_POST;
 
 //-------------------------------------------------------
 // HashMap functions


### PR DESCRIPTION
Gives better error messages if someone is using `const char*` as the hashmap Key.
