### PR TITLE
GRAPHICS: Support having transparent ManagedSurface

### DIFF
--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -92,12 +92,6 @@ protected:
 	virtual void addDirtyRect(const Common::Rect &r);
 
 	/**
-	 * Adds a full solid alpha to the passed color for surfaces that have
-	 * an alpha channel
-	 */
-	uint32 addAlphaToColor(uint32 color);
-
-	/**
 	 * Inner method for blitting.
 	 */
 	void blitFromInner(const Surface &src, const Common::Rect &srcRect,
@@ -513,7 +507,7 @@ public:
 	 * Draw a line.
 	 */
 	void drawLine(int x0, int y0, int x1, int y1, uint32 color) {
-		_innerSurface.drawLine(x0, y0, x1, y1, addAlphaToColor(color));
+		_innerSurface.drawLine(x0, y0, x1, y1, color);
 		addDirtyRect(Common::Rect(MIN(x0, x1), MIN(y0, y1), MAX(x0, x1), MAX(y0, y1)));
 	}
 
@@ -521,7 +515,7 @@ public:
 	 * Draw a thick line.
 	 */
 	void drawThickLine(int x0, int y0, int x1, int y1, int penX, int penY, uint32 color) {
-		_innerSurface.drawThickLine(x0, y0, x1, y1, penX, penY, addAlphaToColor(color));
+		_innerSurface.drawThickLine(x0, y0, x1, y1, penX, penY, color);
 		addDirtyRect(Common::Rect(MIN(x0, x1 + penX), MIN(y0, y1 + penY), MAX(x0, x1 + penX), MAX(y0, y1 + penY)));
 	}
 
@@ -529,7 +523,7 @@ public:
 	 * Draw a horizontal line.
 	 */
 	void hLine(int x, int y, int x2, uint32 color) {
-		_innerSurface.hLine(x, y, x2, addAlphaToColor(color));
+		_innerSurface.hLine(x, y, x2, color);
 		addDirtyRect(Common::Rect(x, y, x2 + 1, y + 1));
 	}
 
@@ -537,7 +531,7 @@ public:
 	 * Draw a vertical line.
 	 */
 	void vLine(int x, int y, int y2, uint32 color) {
-		_innerSurface.vLine(x, y, y2, addAlphaToColor(color));
+		_innerSurface.vLine(x, y, y2, color);
 		addDirtyRect(Common::Rect(x, y, x + 1, y2 + 1));
 	}
 
@@ -545,7 +539,7 @@ public:
 	 * Fill a rect with a given color.
 	 */
 	void fillRect(Common::Rect r, uint32 color) {
-		_innerSurface.fillRect(r, addAlphaToColor(color));
+		_innerSurface.fillRect(r, color);
 		addDirtyRect(r);
 	}
 
@@ -553,7 +547,7 @@ public:
 	 * Draw a frame around a specified rect.
 	 */
 	void frameRect(const Common::Rect &r, uint32 color) {
-		_innerSurface.frameRect(r, addAlphaToColor(color));
+		_innerSurface.frameRect(r, color);
 		addDirtyRect(r);
 	}
 


### PR DESCRIPTION
A change made yesterday forces `ManagedSurface` to be fully opaque. This may be an issue for some engines.
This commit revert this and also adds proper handling of the surface alpha when blitting pixels.