### PR TITLE
GRIM: Fix unknown key error when loading savegame

### DIFF
--- a/engines/grim/pool.h
+++ b/engines/grim/pool.h
@@ -314,9 +314,10 @@ void PoolObject<T>::Pool::restoreObjects(SaveGame *state) {
 	Common::HashMap<int32, T *> tempMap;
 	for (int32 i = 0; i < size; ++i) {
 		int32 id = state->readLESint32();
-		T *t = _map.getVal(id);
-		_map.erase(id);
-		if (!t) {
+		T *t = nullptr;
+		if (_map.tryGetVal(id, t))
+			_map.erase(id);
+		else {
 			t = new T();
 			t->setId(id);
 		}


### PR DESCRIPTION
A user reported a crash with `Unknown key!` error when trying to load a save game in MI4 today on IRC/Discord.
@henke37 suggested that the likely culprit was the code changed in this pull request.

I don't have the game, and the demo doesn't let me save games. So I am unable to test this. This is why I am proposing this as a pull request so that developers who know the engine or can at least test it can validate the change.