### PR TITLE
SCUMM: SMUSH: always enable line wrap on hebrew fan translation

### DIFF
--- a/engines/scumm/insane/insane.cpp
+++ b/engines/scumm/insane/insane.cpp
@@ -1302,7 +1302,7 @@ void Insane::smlayer_showStatusMsg(int32 arg_0, byte *renderBitmap, int32 codecp
 	// bit 2 - word wrap               0x04
 	// bit 3 - switchable              0x08
 	// bit 4 - fill background         0x10
-	if (flags & 4) {
+	if ((flags & 4) || _vm->_language == Common::HE_ISR) {
 		Common::Rect clipRect(0, 0, _player->_width, _player->_height);
 		sf->drawStringWrap(str, renderBitmap, clipRect, pos_x, pos_y, flags & 1);
 	} else {

--- a/engines/scumm/smush/smush_player.cpp
+++ b/engines/scumm/smush/smush_player.cpp
@@ -641,7 +641,7 @@ void SmushPlayer::handleTextResource(uint32 subType, int32 subSize, Common::Seek
 	// bit 7 - skip ^ codes (COMI)     0x80        (should be irrelevant for Smush, we strip these commands anyway)
 	// bit 8 - no vertical fix (COMI)  0x100       (COMI handles this in the printing method, but I haven't seen a case where it is used)
 
-	if (flags & 4) {
+	if ((flags & 4) || _vm->_language == Common::HE_ISR) {
 		// COMI has to do it all a bit different, of course. SCUMM7 games immediately render the text from here and actually use the clipping data
 		// provided by the text resource. COMI does not render directly, but enqueues a blast string (which is then drawn through the usual main
 		// loop routines). During that process the rect data will get dumped and replaced with the following default values. It's hard to tell


### PR DESCRIPTION
In Hebrew there are no distinction between capital/small letters,
which results in wider text that although originally was able to fit in screen width, usually go beyond the width of the screen in translation.
This may be the easier way to solve this and it doesn't seem to have negative side effect. 
(the other way is to change the text flag in all animation files)

Thanks
