### PR TITLE
SCI: kDoAudio stops samples played with kDoSound

### DIFF
--- a/engines/sci/engine/ksound.cpp
+++ b/engines/sci/engine/ksound.cpp
@@ -178,6 +178,9 @@ reg_t kDoAudio(EngineState *s, int argc, reg_t *argv) {
 		uint32 number;
 
 		g_sci->_audio->stopAudio();
+		// In SSCI, kDoAudio handles all samples, even if started by kDoSound.
+		// We manage samples started by kDoSound in SoundCommandParser. 
+		g_sci->_soundCmd->stopAllSamples();
 
 		if (argc == 2) {
 			module = 65535;
@@ -204,6 +207,9 @@ reg_t kDoAudio(EngineState *s, int argc, reg_t *argv) {
 	case kSciAudioStop:
 		debugC(kDebugLevelSound, "kDoAudio: stop");
 		g_sci->_audio->stopAudio();
+		// In SSCI, kDoAudio handles all samples, even if started by kDoSound.
+		// We manage samples started by kDoSound in SoundCommandParser. 
+		g_sci->_soundCmd->stopAllSamples();
 		break;
 	case kSciAudioPause:
 		debugC(kDebugLevelSound, "kDoAudio: pause");

--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -264,6 +264,15 @@ void SciMusic::stopAll() {
 	}
 }
 
+void SciMusic::stopAllSamples() {
+	const MusicList::iterator end = _playList.end();
+	for (MusicList::iterator i = _playList.begin(); i != end; ++i) {
+		if ((*i)->isSample) {
+			soundStop(*i);
+		}
+	}
+}
+
 void SciMusic::soundSetSoundOn(bool soundOnFlag) {
 	Common::StackLock lock(_mutex);
 

--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -182,6 +182,7 @@ public:
 	void clearPlayList();
 	void pauseAll(bool pause);
 	void stopAll();
+	void stopAllSamples();
 
 	// sound and midi functions
 	void soundInitSnd(MusicEntry *pSnd);

--- a/engines/sci/sound/soundcmd.cpp
+++ b/engines/sci/sound/soundcmd.cpp
@@ -888,6 +888,10 @@ void SoundCommandParser::stopAllSounds() {
 	_music->stopAll();
 }
 
+void SoundCommandParser::stopAllSamples() {
+	_music->stopAllSamples();
+}
+
 void SoundCommandParser::startNewSound(int number) {
 	// NB: This is only used by the debugging console.
 

--- a/engines/sci/sound/soundcmd.h
+++ b/engines/sci/sound/soundcmd.h
@@ -63,6 +63,7 @@ public:
 	// Debug console functions
 	void startNewSound(int number);
 	void stopAllSounds();
+	void stopAllSamples();
 	void printPlayList(Console *con);
 	void printSongInfo(reg_t obj, Console *con);
 


### PR DESCRIPTION
This fixes subtle sound bugs in SCI16 games with speech. The SQ4CD introduction has at least two:

- When the alien dissolves in a puddle of vomit, the sound keeps playing during the narration in the next room
- When the Vohaul hologram appears, the static sound effect keeps playing when he talks

In both of these cases, the digital sample should have stopped as soon as speech started.

In SSCI, digital samples are handled by kDoAudio. If a digital sample is played with kDoSound then SSCI just calls kDoAudio and it still does the work. When kDoAudio plays, it first stops any samples that it already played.

In ScummVM, all sounds played with kDoSound are handled separately from kDoAudio, even if they're samples, so an extra step is needed for our kDoAudio to stop all samples as SSCI does.

[ Ignore the name of my branch; I wasn't paying attention ]