### PR TITLE
SYMBIAN: fix conflict declaration for TKey struct between Lua and SDK…

### DIFF
--- a/backends/platform/symbian/src/portdefs.h
+++ b/backends/platform/symbian/src/portdefs.h
@@ -92,7 +92,7 @@ namespace std
 #define USE_RGB_COLOR
 #define USE_TINYGL
 
-#ifndef SYMBIAN_DYMANIC_PLUGIN
+#ifndef SYMBIAN_DYNAMIC_PLUGIN
 #define DETECTION_STATIC
 #endif //DETECTION_STATIC
 


### PR DESCRIPTION
… headers.

Add missed prototypes for math functions.