### PR TITLE
AGS: Fix text rendering onto surfaces with a transparent pixel color

### DIFF
--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -94,8 +94,8 @@ int getStringWidthImpl(const Font &font, const StringType &str) {
 	return space;
 }
 
-template<class StringType>
-void drawStringImpl(const Font &font, Surface *dst, const StringType &str, int x, int y, int w, uint32 color, TextAlign align, int deltax) {
+template<class SurfaceType, class StringType>
+void drawStringImpl(const Font &font, SurfaceType *dst, const StringType &str, int x, int y, int w, uint32 color, TextAlign align, int deltax) {
 	// The logic in getBoundingImpl is the same as we use here. In case we
 	// ever change something here we will need to change it there too.
 	assert(dst != 0);
@@ -443,7 +443,7 @@ int Font::getStringWidth(const Common::U32String &str) const {
 }
 
 void Font::drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const {
-	drawChar(&dst->_innerSurface, chr, x, y, color);
+	drawChar(dst->surfacePtr(), chr, x, y, color);
 
 	Common::Rect charBox = getBoundingBox(chr);
 	charBox.translate(x, y);
@@ -461,14 +461,18 @@ void Font::drawString(Surface *dst, const Common::U32String &str, int x, int y, 
 }
 
 void Font::drawString(ManagedSurface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis) const {
-	drawString(&dst->_innerSurface, str, x, y, w, color, align, deltax, useEllipsis);
+	Common::String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
+	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax);
+
 	if (w != 0) {
 		dst->addDirtyRect(getBoundingBox(str, x, y, w, align, deltax, useEllipsis));
 	}
 }
 
 void Font::drawString(ManagedSurface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis) const {
-	drawString(&dst->_innerSurface, str, x, y, w, color, align, deltax, useEllipsis);
+	Common::U32String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
+	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax);
+
 	if (w != 0) {
 		dst->addDirtyRect(getBoundingBox(str, x, y, w, align, useEllipsis));
 	}

--- a/graphics/font.h
+++ b/graphics/font.h
@@ -180,8 +180,9 @@ public:
 	 * @param color The color of the character.
 	 */
 	virtual void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const = 0;
+	virtual void drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const;
+
 	/** @overload */
-	void drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const;
 
 	/**
 	 * Draw the given @p str string to the given @p dst surface.
@@ -238,7 +239,6 @@ public:
 	int wordWrapText(const Common::String &str, int maxWidth, Common::Array<Common::String> &lines, int initWidth = 0, uint32 mode = kWordWrapOnExplicitNewLines) const;
 	/** @overload */
 	int wordWrapText(const Common::U32String &str, int maxWidth, Common::Array<Common::U32String> &lines, int initWidth = 0, uint32 mode = kWordWrapOnExplicitNewLines) const;
-
 };
 /** @} */
 } // End of namespace Graphics

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -39,15 +39,11 @@ namespace Graphics {
  * @{
  */
 
-class Font;
-
 /**
  * A derived graphics surface, which supports automatically managing the allocated
  * surface data block and introduces several new blitting methods.
  */
 class ManagedSurface {
-	/** See @ref Font. */
-	friend class Font;
 private:
 	/**
 	 * The Graphics::Surface that the managed surface encapsulates.
@@ -85,12 +81,6 @@ private:
 	uint32 _palette[256];
 	bool _paletteSet;
 protected:
-	/**
-	 * Base method that descendant classes can override for recording the affected
-	 * dirty areas of the surface.
-	 */
-	virtual void addDirtyRect(const Common::Rect &r);
-
 	/**
 	 * Inner method for blitting.
 	 */
@@ -156,14 +146,16 @@ public:
 	 * directly to it, since it would bypass dirty rect handling.
 	 */
 	operator const Surface &() const { return _innerSurface; }
+
 	/**
-	 * Automatically convert to a Graphics::Surface by
-	 * simply returning the inner surface.
+	 * Return the underyling Graphics::Surface
 	 *
-	 * This must be const, because changes are not supposed to be done
-	 * directly to it, since it would bypass dirty rect handling.
+	 * If a caller uses the non-const surfacePtr version and changes
+	 * the surface, they'll be responsible for calling addDirtyRect
+	 * for any affected area
 	 */
 	const Surface &rawSurface() const { return _innerSurface; }
+	Surface *surfacePtr() { return &_innerSurface; }
 
 	/**
 	 * Reassign one managed surface to another one.
@@ -250,6 +242,12 @@ public:
 	 * Clear any pending dirty rectangles that have been generated for the surface.
 	 */
 	virtual void clearDirtyRects() {}
+
+	/**
+	 * Base method that descendant classes can override for recording the affected
+	 * dirty areas of the surface.
+	 */
+	virtual void addDirtyRect(const Common::Rect &r);
 
 	/**
 	 * When the managed surface is a subsection of a parent surface, return the

--- a/graphics/screen.h
+++ b/graphics/screen.h
@@ -64,12 +64,6 @@ protected:
 	 * Returns the union of two dirty area rectangles
 	 */
 	bool unionRectangle(Common::Rect &destRect, const Common::Rect &src1, const Common::Rect &src2);
-
-	/**
-	 * Adds a rectangle to the list of modified areas of the screen during the
-	 * current frame
-	 */
-	virtual void addDirtyRect(const Common::Rect &r);
 public:
 	Screen();
 	Screen(int width, int height);
@@ -90,6 +84,12 @@ public:
 	 * Clear the current dirty rects list
 	 */
 	virtual void clearDirtyRects() { _dirtyRects.clear(); }
+
+	/**
+	 * Adds a rectangle to the list of modified areas of the screen during the
+	 * current frame
+	 */
+	virtual void addDirtyRect(const Common::Rect &r);
 
 	/**
 	 * Updates the screen by copying any affected areas to the system


### PR DESCRIPTION
This pull request resolves the outstanding problem with rendering TTF text onto surfaces in the AGS engine.. the problem being that with the surfaces having a designated transparent color, partially transparent pixels in the TTF glyphs were doing an alpha blend of the font color with the pink color AGS uses for transparency. Since this affects the core font code, I figure to make it a pull request for review first.

This change introduces a new virtual method on Graphics::Font called "setTransparentColor", and then overrides that in TTFFont.  In the TTFFont glyph drawing code, if it's drawing a partially transparent pixel and detects the transparent color, it forces it to be transparent so it won't be blended.