### PR TITLE
SCUMM: Fix verb selection on overlapping verbs

### DIFF
--- a/engines/scumm/verbs.cpp
+++ b/engines/scumm/verbs.cpp
@@ -952,11 +952,8 @@ int ScummEngine::findVerbAtPos(int x, int y) const {
 	if (!_numVerbs)
 		return 0;
 
-	VerbSlot *vs;
-	int i = _numVerbs - 1;
-
-	vs = &_verbs[i];
-	do {
+	for (int i = 1; i < _numVerbs; ++i) {
+		VerbSlot *vs = &_verbs[i];
 		if (vs->curmode != 1 || !vs->verbid || vs->saveid || y < vs->curRect.top || y >= vs->curRect.bottom)
 			continue;
 		if (vs->center) {
@@ -968,7 +965,7 @@ int ScummEngine::findVerbAtPos(int x, int y) const {
 		}
 
 		return i;
-	} while (--vs, --i);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
On COMI, verbs can vertically overlap. For example, verb 1 is 330-360
and verb 2 is 354-384.

Highlighting is done by the first match, but clicking chooses the last
one, as it is scanned backwards.

So if the mouse is in range 354-360, the highlighted text is not picked.