### PR TITLE
DIRECTOR: implement colorQD builtin

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -272,6 +272,9 @@ static struct BuiltinProto {
 	// XCOD/XFCN (HyperCard), normally exposed
 	{ "GetVolumes", LB::b_getVolumes, 0, 0, true, 400, FBLTIN },
 
+	// Used in "Eastern Mind", normally a TheEntity
+	{ "colorQD", LB::b_colorQD, 0, 0, true, 300, FBLTIN },
+
 	{ 0, 0, 0, 0, false, 0, VOIDSYM }
 };
 
@@ -2542,6 +2545,10 @@ void LB::b_getVolumes(int nargs) {
 	d.u.farr->push_back(Datum("Buried in Time\252 1"));
 
 	g_lingo->push(d);
+}
+
+void LB::b_colorQD(int nargs) {
+	g_lingo->push(Datum(1));
 }
 
 } // End of namespace Director

--- a/engines/director/lingo/lingo-builtins.h
+++ b/engines/director/lingo/lingo-builtins.h
@@ -205,6 +205,9 @@ void b_scummvmassertequal(int nargs);
 // XCOD/XFCN (HyperCard), normally exposed
 void b_getVolumes(int nargs);
 
+// Used in "Eastern Mind", normally a TheEntity
+void b_colorQD(int nargs);
+
 } // End of namespace LB
 
 } // End of namespace Director


### PR DESCRIPTION
Normally, `colorQD` is a `TheEntity`. However, "Eastern Mind: The Lost Souls of Tong-Nou" instead uses it as a builtin with no arguments, both in Mac and Windows versions of the game.

cc @sev-