### PR TITLE
KEYMAPPER: executeAction - keep original ascii value

### DIFF
--- a/backends/keymapper/keymapper.cpp
+++ b/backends/keymapper/keymapper.cpp
@@ -275,6 +275,7 @@ Keymapper::IncomingEventType Keymapper::convertToIncomingEventType(const Event &
 
 Event Keymapper::executeAction(const Action *action, const Event &incomingEvent) {
 	Event outgoingEvent = Event(action->event);
+	outgoingEvent.kbd.ascii = incomingEvent.kbd.ascii;
 
 	IncomingEventType incomingType = convertToIncomingEventType(incomingEvent);
 


### PR DESCRIPTION
If user presses SHIFT+. , it was interpreted as a dot.
That's because there is a `kKeymapMatchPartial` with
"Skip line" action, which caused execution of `executeAction`.
And `executeActio`n replaced the original `incomingEvent`
with `action`, thus 'forgetting' the original ascii code.

The problem was seen (and fixed) on PQ1 (AGI) and SQ3 (SCI).

**NOTE**
I'm not certain that it's a good fix, as I don't fully understand `executeAction`, and all the implications of my change. It's only a single line change, but please review it carefully...


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
