### PR TITLE
COMMON: Fix warnings on mingw build

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -108,7 +108,7 @@
 		#define NOWH
 		#define NOSOUND
 		#define NODRAWTEXT
-		#define NOMINMAX
+		#define NOMINMAX 1
 
 	#endif
 


### PR DESCRIPTION
bits/os_defines.h has #define NOMINMAX 1, which conflicts with the
non-value #define NOMINXMAX in scummsys.h.

```
In file included from ../scummvm/common/lua/lua.h:12,
                 from ../scummvm/common/lua/ltable.cpp:27:
../scummvm/common/scummsys.h:111: warning: "NOMINMAX" redefined
  111 |   #define NOMINMAX
      |
In file included from C:/msys64/mingw64/include/c++/10.2.0/x86_64-w64-
mingw32/bits/c++config.h:518,
                 from C:/msys64/mingw64/include/c++/10.2.0/cmath:41,
                 from C:/msys64/mingw64/include/c++/10.2.0/math.h:36,
                 from ../scummvm/common/lua/ltable.cpp:21:
C:/msys64/mingw64/include/c++/10.2.0/x86_64-w64-mingw32/bits/
os_defines.h:45: note: this is the location of the previous definition
   45 | #define NOMINMAX 1
      |
```

Amends commit 88f685217b1c8e7ab2c7a588677ad4744480b4a3.
