### PR TITLE
AGS: added debug message about unsupported plugin

### DIFF
--- a/engines/ags/plugins/plugin_base.cpp
+++ b/engines/ags/plugins/plugin_base.cpp
@@ -95,6 +95,7 @@ void *pluginOpen(const char *filename) {
 	if (fname.equalsIgnoreCase("AGSWadjetUtil"))
 		return new AGSWadjetUtil::AGSWadjetUtil();
 
+	debug("Plugin '%s' is not yet supported", fname.c_str());
 	return nullptr;
 }
 


### PR DESCRIPTION
Might help in those cases where the assert is triggered, because the plugin is not known.