### PR TITLE
SCUMM: Fix wrong rect for verbs on Hebrew

### DIFF
--- a/engines/scumm/script_v8.cpp
+++ b/engines/scumm/script_v8.cpp
@@ -978,7 +978,10 @@ void ScummEngine_v8::o8_verbOps() {
 		break;
 	case 0x9A:		// SO_VERB_AT Set verb (X,Y) placement
 		vs->curRect.top = pop();
-		vs->curRect.left = pop();
+		if (_language == Common::HE_ISR)
+			vs->curRect.right = _screenWidth - 1 - pop();
+		else
+			vs->curRect.left = pop();
 		break;
 	case 0x9B:		// SO_VERB_ON Turn verb on
 		vs->curmode = 1;


### PR DESCRIPTION
The value of left is applied from the script all the time, and was replaced in drawVerb.

The problem with this approach is that redrawVerbs maps the mouse location to verb index **before** calling drawVerb, so the rectangles it compares against are invalid in X-axis (right is always `_screenWidth - 1`, and left is always 5).

This caused several bugs:
* Each verb was clickable all over the screen's width, although it was not highlighted.
* If the mouse was between 2 verbs, long above short, the Y-axis has 6 overlapping pixels (e.g. 1: 330-360, 2: 354-384). Scanning is done bottom-up, so 1 was highlighted, but 2 was selected because of the previous bullet.
* The text on Hebrew was aligned to the right without any padding. Other languages have `left = 5`.

Fixed by setting right instead of left when applying the script, and adjusting left in drawVerb. Other languages are not affected.

Another issue, unrelated to language selection: A verb that was split to 2 lines was clickable all over the screen's width. That's because `curRect.right` was set beyond the `_screenWidth`, and it was not trimmed to the first (longer) line's length. On Hebrew, `curRect.left` became negative. This is also fixed in this commit.