### PR TITLE
EVENTS: Fix mouse position outside active area

### DIFF
--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -180,9 +180,9 @@ bool SdlEventSource::processMouseEvent(Common::Event &event, int x, int y, int r
 
 	if (_graphicsManager) {
 		if (dynamic_cast<SdlGraphics3dManager *>(_graphicsManager)) {
-			dynamic_cast<SdlGraphics3dManager *>(_graphicsManager)->notifyMousePosition(event.mouse);
+			return dynamic_cast<SdlGraphics3dManager *>(_graphicsManager)->notifyMousePosition(event.mouse);
 		} else if (dynamic_cast<SdlGraphicsManager *>(_graphicsManager)) {
-			dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->notifyMousePosition(event.mouse);
+			return dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->notifyMousePosition(event.mouse);
 		}
 	}
 


### PR DESCRIPTION
The ResidualVM merge 35b9cccbde37d20fdbc10254d4ab8cc260551e84 introduced a regression: the return value from SdlGraphicsManager::notifyMousePosition() became ignored, causing SdlEventSource::processMouseEvent() to always return true even when the mouse is outside of the active area. This appears to be unintentional and wasn't a problem for ResidualVM code because SdlGraphics3dManager::notifyMousePosition() always returns true.

This bug causes invalid mouse positions to be exposed to game engines through DefaultEventManager::getMousePos(). Instead of clipping coordinates to the active area, real window coordinates are exposed. For example, if the window is sized so that there's 100 pixels above the active area, then mousing above the top edge sets the y coordinate 100 instead of 0, causing the cursor to jump or do odd things depending on the game.

Confirmed that SCI games and Blade Runner are affected and fixed as they use DefaultEventManager::getMousePos().