### PR TITLE
BUILD: Use git describe --dirty for git 2.x

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -251,10 +251,15 @@ endif
 ifneq ($(shell cd $(srcdir); git rev-parse --verify HEAD 1>/dev/null 2>&1 || echo "error"),error)
 GITROOT := $(srcdir)
 ifeq ($(origin VER_REV), undefined)
+GIT_VER_MAJOR = $(shell git --version | sed 's/^git version //' | cut -d. -f 1)
 # Are there uncommitted changes? (describe --dirty is only available since 1.6.6)
+ifeq ($(GIT_VER_MAJOR),1)
 VER_DIRTY := $(shell cd $(srcdir); git update-index --refresh --unmerged 1>/dev/null 2>&1; git diff-index --quiet HEAD || echo "-dirty")
+else
+GIT_DIRTY_FLAG = --dirty
+endif
 # Get the working copy base revision
-VER_REV := $(shell cd $(srcdir); git describe --long --match desc/\* | cut -d '-' -f 2-)$(VER_DIRTY)
+VER_REV := $(shell cd $(srcdir); git describe $(GIT_DIRTY_FLAG) --long --match desc/\* | cut -d '-' -f 2-)$(VER_DIRTY)
 endif
 else
 GITROOT := git://github.com/scummvm/scummvm.git


### PR DESCRIPTION
It is way faster than git update-index.