### PR TITLE
Sci0 sound restart

### DIFF
--- a/engines/sci/engine/savegame.cpp
+++ b/engines/sci/engine/savegame.cpp
@@ -755,6 +755,17 @@ void SoundCommandParser::reconstructPlayList() {
 			processPlaySound(entry->soundObj, entry->playBed, true);
 		}
 	}
+
+	// Emulate the original SCI0 behavior: If no sound with status kSoundPlaying was found we
+	// look for the first sound with status kSoundPaused and start that. It relies on a correctly
+	// sorted playlist, but we have that...
+	if (_soundVersion <= SCI_VERSION_0_LATE && !_music->getFirstSlotWithStatus(kSoundPlaying)) {
+		if (MusicEntry *pSnd = _music->getFirstSlotWithStatus(kSoundPaused)) {
+			writeSelectorValue(_segMan, pSnd->soundObj, SELECTOR(loop), pSnd->loop);
+			writeSelectorValue(_segMan, pSnd->soundObj, SELECTOR(priority), pSnd->priority);
+			processPlaySound(pSnd->soundObj, pSnd->playBed, true);
+		}
+	}
 }
 
 #ifdef ENABLE_SCI32

--- a/engines/sci/sound/midiparser_sci.cpp
+++ b/engines/sci/sound/midiparser_sci.cpp
@@ -840,7 +840,6 @@ bool MidiParser_SCI::processEvent(const EventInfo &info, bool fireEvents) {
 				return true;
 
 			} else {
-				_pSnd->status = kSoundStopped;
 				_pSnd->setSignal(SIGNAL_OFFSET);
 
 				debugC(4, kDebugLevelSound, "signal EOT");

--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -84,8 +84,6 @@ public:
 
 	int time; // "tim"estamp to indicate in which order songs have been added
 
-	bool isQueued; // for SCI0 only!
-
 	uint16 dataInc;
 	uint16 ticker;
 	uint16 signal;
@@ -229,11 +227,13 @@ public:
 	}
 
 	MusicEntry *getSlot(reg_t obj);
-	MusicEntry *getActiveSci0MusicSlot();
+	MusicEntry *getFirstSlotWithStatus(SoundStatus status);
 
 	void pushBackSlot(MusicEntry *slotEntry) {
 		Common::StackLock lock(_mutex);
 		_playList.push_back(slotEntry);
+		if (_soundVersion <= SCI_VERSION_0_LATE) // I limit this to SCI0, since it always inserts the nodes at the correct position, but no idea about >=SCI1
+			sortPlayList();
 	}
 
 	void printPlayList(Console *con);

--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -160,8 +160,21 @@ struct ChannelRemapping {
 	int lowestPrio() const;
 };
 
+struct MidiCommand {
+	enum CmdType {
+		kTypeMidiMessage = 0,
+		kTypeTrackInit
+	};
+	// Keeping this very simple, due to the very limited purpose of it.
+	MidiCommand(CmdType type, uint32 val) : _type(type), _dataPtr(0), _dataVal(val) {}
+	MidiCommand(CmdType type, void *ptr) : _type(type), _dataPtr(ptr), _dataVal(0) {}
+	CmdType _type;
+	void *_dataPtr;
+	uint32 _dataVal;
+};
+
 typedef Common::Array<MusicEntry *> MusicList;
-typedef Common::Array<uint32> MidiCommandQueue;
+typedef Common::Array<MidiCommand> MidiCommandQueue;
 
 class SciMusic : public Common::Serializable {
 
@@ -174,6 +187,8 @@ public:
 	void onTimer();
 	void putMidiCommandInQueue(byte status, byte firstOp, byte secondOp);
 	void putMidiCommandInQueue(uint32 midi);
+	void putTrackInitCommandInQueue(MusicEntry *psnd);
+	void removeTrackInitCommandsFromQueue(MusicEntry *psnd);
 private:
 	static void miditimerCallback(void *p);
 	void sendMidiCommandsFromQueue();

--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -287,6 +287,8 @@ private:
 	int8 _channelRemap[16];
 	int8 _globalReverb;
 	bool _needsRemap;
+	int _globalPause;
+	bool _needsResume;
 
 	DeviceChannelUsage _channelMap[16];
 

--- a/engines/sci/sound/soundcmd.cpp
+++ b/engines/sci/sound/soundcmd.cpp
@@ -306,6 +306,9 @@ void SoundCommandParser::processStopSound(reg_t obj, bool sampleFinishedPlaying)
 	musicSlot->dataInc = 0;
 	musicSlot->signal = SIGNAL_OFFSET;
 	_music->soundStop(musicSlot);
+
+	if (_soundVersion <= SCI_VERSION_0_LATE && (musicSlot = _music->getFirstSlotWithStatus(kSoundPlaying)))
+		writeSelectorValue(_segMan, musicSlot->soundObj, SELECTOR(state), kSoundPlaying);
 }
 
 reg_t SoundCommandParser::kDoSoundPause(EngineState *s, int argc, reg_t *argv) {
@@ -318,16 +321,16 @@ reg_t SoundCommandParser::kDoSoundPause(EngineState *s, int argc, reg_t *argv) {
 		// SCI0 games give us 0/1 for either resuming or pausing the current music
 		//  this one doesn't count, so pausing 2 times and resuming once means here that we are supposed to resume
 		uint16 value = argv[0].toUint16();
-		MusicEntry *musicSlot = _music->getActiveSci0MusicSlot();
+		MusicEntry *musicSlot = _music->getFirstSlotWithStatus(kSoundPlaying);
 		switch (value) {
 		case 1:
-			if ((musicSlot) && (musicSlot->status == kSoundPlaying)) {
+			if (musicSlot) {
 				_music->soundPause(musicSlot);
 				writeSelectorValue(_segMan, musicSlot->soundObj, SELECTOR(state), kSoundPaused);
 			}
 			return make_reg(0, 0);
 		case 0:
-			if ((musicSlot) && (musicSlot->status == kSoundPaused)) {
+			if (!musicSlot && (musicSlot = _music->getFirstSlotWithStatus(kSoundPaused))) {
 				_music->soundResume(musicSlot);
 				writeSelectorValue(_segMan, musicSlot->soundObj, SELECTOR(state), kSoundPlaying);
 				return make_reg(0, 1);
@@ -848,33 +851,9 @@ reg_t SoundCommandParser::kDoSoundSuspend(EngineState *s, int argc, reg_t *argv)
 }
 
 void SoundCommandParser::updateSci0Cues() {
-	bool noOnePlaying = true;
-	MusicEntry *pWaitingForPlay = NULL;
-
-	const MusicList::iterator end = _music->getPlayListEnd();
-	for (MusicList::iterator i = _music->getPlayListStart(); i != end; ++i) {
-		// Is the sound stopped, and the sound object updated too? If yes, skip
-		// this sound, as SCI0 only allows one active song.
-		if  ((*i)->isQueued) {
-			if (!pWaitingForPlay || pWaitingForPlay->priority < (*i)->priority)		// fix #9907
-				pWaitingForPlay = (*i);
-			// FIXME(?): In iceman 2 songs are queued when playing the door
-			// sound - if we use the first song for resuming then it's the wrong
-			// one. Both songs have same priority. Maybe the new sound function
-			// in sci0 is somehow responsible.
-			continue;
-		}
-		if ((*i)->signal == 0 && (*i)->status != kSoundPlaying)
-			continue;
-
-		processUpdateCues((*i)->soundObj);
-		noOnePlaying = false;
-	}
-
-	if (noOnePlaying && pWaitingForPlay) {
-		// If there is a queued entry, play it now - check SciMusic::soundPlay()
-		pWaitingForPlay->isQueued = false;
-		_music->soundPlay(pWaitingForPlay);
+	for (MusicList::iterator i = _music->getPlayListStart(); i != _music->getPlayListEnd(); ++i) {
+		if ((*i)->status == kSoundPlaying || (*i)->signal)
+			processUpdateCues((*i)->soundObj);
 	}
 }
 


### PR DESCRIPTION
SCI: SCI0 sound restoring/restarting fixes

The main purpose of this is fixing incorrect sound restore after loading a savegame. Permanently hanging notes could sometimes be experienced when saving while a sound was playing and then reloading that savegame. That bug (and how it could be reproduced in KQIV) was pointed out to me by sluicebox. I just went over disasm (in this case mostly QFG, since I have the best disam there) and tried to match the original behavior a bit better. Commit b449564 is mainly for that. Commit cb50e48 aims at fixing inconsistent thread handling I had introduced with the initTrack method. I don't know whether it actually causes glitches. It was just one of the things I examined during my bug fixing attempts.
Commit 2a8289c fixes ScumVM specific things I had broken in the second commit (e. g. entering the GMM after clicking the SCI menu, which can't happen in the original).

I have done some testing of the bug that was reported to me and of the various situations pointed out by comments in the code (LSL3 start scene, ICEMAN room 14, etc). Sluicebox also has been testing, probably way more than me. So we're now confident that this is good to go...
