### PR TITLE
COMMON: Don't use unavailable macros in unicode-bidi.h

### DIFF
--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -26,6 +26,11 @@
 
 #ifdef USE_FRIBIDI
 #include <fribidi/fribidi.h>
+#else
+/* This constant is used below in common code
+ * fake it here to lighten code
+ */
+#define FRIBIDI_PAR_ON 0
 #endif
 
 namespace Common {
@@ -107,13 +112,15 @@ void UnicodeBiDiText::initWithU32String(const U32String &input) {
 }
 
 Common::String bidiByLineHelper(Common::String line, va_list args) {
-	Common::CodePage page = va_arg(args, Common::CodePage);
+	/* Common::CodePage is int
+	 * GCC warns that using Common::CodePage in va_arg would abort program */
+	Common::CodePage page = (Common::CodePage) va_arg(args, int);
 	uint32 *pbase_dir = va_arg(args, uint32*);
 	return UnicodeBiDiText(line, page, pbase_dir).visual.encode(page);
 }
 
 String convertBiDiStringByLines(const String &input, const Common::CodePage page) {
-	uint32 pbase_dir = SCUMMVM_FRIBIDI_PAR_ON;
+	uint32 pbase_dir = FRIBIDI_PAR_ON;
 	return input.forEachLine(bidiByLineHelper, page, &pbase_dir);
 }
 

--- a/common/unicode-bidi.h
+++ b/common/unicode-bidi.h
@@ -27,21 +27,6 @@
 #include "common/ustr.h"
 #include "common/language.h"
 
-
-// SCUMMVM_FRIBIDI_PAR_ON: automatically check the text's direction
-// SCUMMVM_FRIBIDI_PAR_LTR, SCUMMVM_FRIBIDI_PAR_RTL: enforce LTR or RTL direction
-// if not USE_FRIBIDI, these defines values don't matter
-#ifdef USE_FRIBIDI
-#define SCUMMVM_FRIBIDI_PAR_ON			FRIBIDI_PAR_ON
-#define SCUMMVM_FRIBIDI_PAR_LTR			FRIBIDI_PAR_LTR
-#define SCUMMVM_FRIBIDI_PAR_RTL			FRIBIDI_PAR_RTL
-#else
-#define SCUMMVM_FRIBIDI_PAR_ON			0
-#define SCUMMVM_FRIBIDI_PAR_LTR			0
-#define SCUMMVM_FRIBIDI_PAR_RTL			0
-#endif
-
-
 namespace Common {
 
 class UnicodeBiDiText {
@@ -57,6 +42,7 @@ public:
 
 	UnicodeBiDiText(const Common::U32String &str);
 	UnicodeBiDiText(const Common::String &str, const Common::CodePage page);
+	/* This constructor shouldn't be used outside of unicode-bidi.cpp file */
 	UnicodeBiDiText(const Common::String &str, const Common::CodePage page, uint32 *pbase_dir);
 	~UnicodeBiDiText();
 


### PR DESCRIPTION
Yet another stab at the FriBidiParType bug.

I use long unsigned int as it's the type used by the original enum defined in Fribidi (use of L suffixed integer literals).
According to https://en.cppreference.com/w/cpp/language/types, using uint32 could fail on some platforms where long unsigned int is 64 bits (LP64).

In addition, don't define constants in unicode-bidi.h as they are not available without Fribidi include.
This would fail if someone would want to use these constants.
As a consequence, the constructor with pbase should not be used outside of unicode-bidi.
