### PR TITLE
ULTIMA: Fix Clang warnings

### DIFF
--- a/engines/ultima/shared/core/str.h
+++ b/engines/ultima/shared/core/str.h
@@ -45,6 +45,7 @@ public:
 	String(const String &str) : Common::String(str) {}
 	String(const Common::String &str) : Common::String(str) {}
 	explicit String(char c) : Common::String(c) {}
+	String& operator=(const String &str) { this->Common::String::operator=(str); return *this; }
 
 	/**
 	 * Returns the index of a given character, or -1 if not present

--- a/engines/ultima/shared/gfx/sprites.cpp
+++ b/engines/ultima/shared/gfx/sprites.cpp
@@ -52,6 +52,12 @@ Sprite::Sprite(const byte *src, uint bpp, uint16 w, uint16 h) {
 	}
 }
 
+Sprite &Sprite::operator=(const Sprite &src) {
+	_surface.copyFrom(src._surface);
+	_transSurface.copyFrom(src._transSurface);
+	return *this;
+}
+
 void Sprite::draw(Graphics::ManagedSurface &dest, const Common::Point &pt) {
 	// Get area to be drawn on
 	Graphics::Surface s = dest.getSubArea(Common::Rect(pt.x, pt.y, pt.x + _surface.w, pt.y + _surface.h));

--- a/engines/ultima/shared/gfx/sprites.h
+++ b/engines/ultima/shared/gfx/sprites.h
@@ -56,6 +56,11 @@ public:
 	Sprite(const byte *src, uint bpp, uint16 w = 16, uint16 h = 16);
 
 	/**
+	 * Copy assignment operator
+	 */
+	Sprite &operator=(const Sprite &src);
+
+	/**
 	 * Draw a tile onto a passed surface
 	 */
 	void draw(Graphics::ManagedSurface &dest, const Common::Point &pt);

--- a/engines/ultima/ultima4/map/map_tile.h
+++ b/engines/ultima/ultima4/map/map_tile.h
@@ -38,8 +38,6 @@ public:
 	}
 	MapTile(const TileId &i, byte f = 0) : _id(i), _frame(f), _freezeAnimation(false) {
 	}
-	MapTile(const MapTile &t) : _id(t._id), _frame(t._frame), _freezeAnimation(t._freezeAnimation) {
-	}
 
 	TileId getId() const {
 		return _id;


### PR DESCRIPTION
```
warning: definition of implicit copy assignment operator for 'X' is deprecated because it has a user-declared copy constructor
```