### PR TITLE
MOHAWK: Fix Clang warning

### DIFF
--- a/engines/mohawk/livingbooks_code.cpp
+++ b/engines/mohawk/livingbooks_code.cpp
@@ -30,6 +30,42 @@
 
 namespace Mohawk {
 
+LBValue &LBValue::operator=(const LBValue &other)
+{
+	if (type != other.type) {
+		switch (type) {
+		case kLBValueString:
+			string.clear();
+			break;
+		case kLBValueInteger:
+			integer = 0;
+			break;
+		case kLBValueReal:
+			real = 0.0;
+			break;
+		case kLBValuePoint:
+			point = Common::Point();
+			break;
+		case kLBValueRect:
+			rect = Common::Rect();
+			break;
+		case kLBValueItemPtr:
+			item = nullptr;
+			break;
+		case kLBValueLBX:
+			lbx.reset();
+			break;
+		case kLBValueList:
+			list.reset();
+			break;
+		default:
+			break;
+		}
+	}
+	copy(other);
+	return *this;
+}
+
 bool LBValue::operator==(const LBValue &x) const {
 	if (type != x.type) {
 		if (isNumeric() && x.isNumeric())

--- a/engines/mohawk/livingbooks_code.h
+++ b/engines/mohawk/livingbooks_code.h
@@ -80,6 +80,10 @@ struct LBValue {
 		list = l;
 	}
 	LBValue(const LBValue &val) {
+		copy(val);
+	}
+
+	void copy(const LBValue &val) {
 		type = val.type;
 		switch (type) {
 		case kLBValueString:
@@ -110,6 +114,8 @@ struct LBValue {
 			break;
 		}
 	}
+
+	LBValue &operator=(const LBValue &other);
 
 	LBValueType type;
 	Common::String string;


### PR DESCRIPTION
```
warning: definition of implicit copy assignment operator for 'LBValue' is deprecated because it has a user-declared copy constructor
```