### PR TITLE
TITANIC: Fix Clang warning

### DIFF
--- a/engines/titanic/star_control/fmatrix.cpp
+++ b/engines/titanic/star_control/fmatrix.cpp
@@ -51,12 +51,6 @@ FMatrix::FMatrix(const FVector &row1, const FVector &row2, const FVector &row3) 
 	_row3 = row3;
 }
 
-FMatrix::FMatrix(const FMatrix &src) {
-	_row1 = src._row1;
-	_row2 = src._row2;
-	_row3 = src._row3;
-}
-
 void FMatrix::load(SimpleFile *file, int param) {
 	_row1._x = file->readFloat();
 	_row1._y = file->readFloat();

--- a/engines/titanic/star_control/fmatrix.h
+++ b/engines/titanic/star_control/fmatrix.h
@@ -41,7 +41,6 @@ public:
 public:
 	FMatrix();
 	FMatrix(const FVector &, const FVector &, const FVector &);
-	FMatrix(const FMatrix &src);
 
 	/**
 	 * Load the data for the class from file

--- a/engines/titanic/star_control/fpose.cpp
+++ b/engines/titanic/star_control/fpose.cpp
@@ -55,10 +55,6 @@ FPose::FPose(Axis axis, float amount) {
 	setRotationMatrix(axis, amount);
 }
 
-FPose::FPose(const FPose &src) : FMatrix() {
-	copyFrom(src);
-}
-
 FPose::FPose(const FPose &s1, const FPose &s2) {
 	fposeProd(s1, s2, *this);
 }

--- a/engines/titanic/star_control/fpose.h
+++ b/engines/titanic/star_control/fpose.h
@@ -38,7 +38,6 @@ public:
 public:
 	FPose();
 	FPose(Axis axis, float amount);
-	FPose(const FPose &src);
 	FPose(int mode, const FVector &src);
 	/**
 	 * This fpose is the fpose product of s1 (on the left) and s2 (on the right)


### PR DESCRIPTION
```
warning: definition of implicit copy assignment operator for 'X' is deprecated because it has a user-declared copy constructor
```