### PR TITLE
ULTIMA: Use correct enum for button constants

### DIFF
--- a/engines/ultima/nuvie/core/nuvie_defs.h
+++ b/engines/ultima/nuvie/core/nuvie_defs.h
@@ -33,10 +33,10 @@ typedef int8 sint8;
 typedef int16 sint16;
 typedef int32 sint32;
 
-#define USE_BUTTON Shared::MK_LBUTTON
-#define WALK_BUTTON Shared::MK_RBUTTON
-#define ACTION_BUTTON Shared::MK_RBUTTON
-#define DRAG_BUTTON Shared::MK_LBUTTON
+#define USE_BUTTON Shared::BUTTON_LEFT
+#define WALK_BUTTON Shared::BUTTON_RIGHT
+#define ACTION_BUTTON Shared::BUTTON_RIGHT
+#define DRAG_BUTTON Shared::BUTTON_LEFT
 
 typedef uint8 nuvie_game_t; // Game type (1=u6,2=md,4=se)
 


### PR DESCRIPTION
All the comparisons are done against Shared::MouseButton. Using values
from SpecialButtons makes no sense.
