### PR TITLE
TINSEL: Add a missing case to switch statement

### DIFF
--- a/engines/tinsel/bmv.cpp
+++ b/engines/tinsel/bmv.cpp
@@ -339,6 +339,8 @@ void BMVPlayer::t3DoOperation(BMV_OP op, uint32 len, const byte **src, byte **ds
 			}
 			break;
 		}
+		case BMV_OP_COUNT:
+			break;
 	}
 }
 


### PR DESCRIPTION
It's not really needed, only to satisfy the compilers.
