### PR TITLE
GRAPHICS: Additional asserts for Surface struct

### DIFF
--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -89,6 +89,7 @@ void Surface::init(uint16 width, uint16 height, uint16 newPitch, void *newPixels
 	pitch = newPitch;
 	pixels = newPixels;
 	format = f;
+	assert(pitch >= w * format.bytesPerPixel);
 }
 
 void Surface::copyFrom(const Surface &surf) {

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -127,6 +127,10 @@ public:
 	 * @return Pointer to the pixel.
 	 */
 	inline const void *getBasePtr(int x, int y) const {
+		assert(x >= 0);
+		assert(x < w);
+		assert(y >= 0);
+		assert(y < h);
 		return (const byte *)(pixels) + y * pitch + x * format.bytesPerPixel;
 	}
 
@@ -139,6 +143,10 @@ public:
 	 * @return Pointer to the pixel.
 	 */
 	inline void *getBasePtr(int x, int y) {
+		assert(x >= 0);
+		assert(x < w);
+		assert(y >= 0);
+		assert(y < h);
 		return static_cast<byte *>(pixels) + y * pitch + x * format.bytesPerPixel;
 	}
 


### PR DESCRIPTION
This aims to disallow reaching beyond the buffer for surfaces.

Suffice to say, but at least `SCUMM` fails this check instantly. This is gonna take a lot of work to cleanup before it can be merged.