### PR TITLE
SCUMM: Fix X-range of selection for Hebrew on scumm<7

### DIFF
--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -815,7 +815,7 @@ static void syncWithSerializer(Common::Serializer &s, ObjectData &od) {
 }
 
 static void syncWithSerializer(Common::Serializer &s, VerbSlot &vs) {
-	s.syncAsSint16LE(vs.curRect.left, VER(8));
+	s.syncAsSint16LE(vs.origLeft, VER(8));
 	s.syncAsSint16LE(vs.curRect.top, VER(8));
 	s.syncAsSint16LE(vs.curRect.right, VER(8));
 	s.syncAsSint16LE(vs.curRect.bottom, VER(8));
@@ -837,6 +837,8 @@ static void syncWithSerializer(Common::Serializer &s, VerbSlot &vs) {
 	s.syncAsByte(vs.center, VER(8));
 	s.syncAsByte(vs.prep, VER(8));
 	s.syncAsUint16LE(vs.imgindex, VER(8));
+	if (s.isLoading() && s.getVersion() >= 8)
+		vs.curRect.left = vs.origLeft;
 }
 
 static void syncWithSerializer(Common::Serializer &s, ScriptSlot &ss) {

--- a/engines/scumm/script_v2.cpp
+++ b/engines/scumm/script_v2.cpp
@@ -831,7 +831,7 @@ void ScummEngine_v2::o2_verbOps() {
 		vs->imgindex = 0;
 		vs->prep = prep;
 
-		vs->curRect.left = x;
+		vs->curRect.left = vs->origLeft = x;
 		vs->curRect.top = y;
 
 		// FIXME: these keyboard map depends on the language of the game.

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2304,7 +2304,7 @@ void ScummEngine_v5::o5_verbOps() {
 			vs->hicolor = getVarOrDirectByte(PARAM_1);
 			break;
 		case 5:		// SO_VERB_AT
-			vs->curRect.left = getVarOrDirectWord(PARAM_1);
+			vs->curRect.left = vs->origLeft = getVarOrDirectWord(PARAM_1);
 			vs->curRect.top = getVarOrDirectWord(PARAM_2);
 			// Macintosh version of indy3ega used different interface, so adjust values.
 			if ((_game.platform == Common::kPlatformMacintosh) && (_game.id == GID_INDY3)) {

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1946,7 +1946,7 @@ void ScummEngine_v6::o6_verbOps() {
 		break;
 	case 128:		// SO_VERB_AT
 		vs->curRect.top = pop();
-		vs->curRect.left = pop();
+		vs->curRect.left = vs->origLeft = pop();
 		break;
 	case 129:		// SO_VERB_ON
 		vs->curmode = 1;

--- a/engines/scumm/script_v8.cpp
+++ b/engines/scumm/script_v8.cpp
@@ -981,7 +981,7 @@ void ScummEngine_v8::o8_verbOps() {
 		if (_language == Common::HE_ISR)
 			vs->curRect.right = _screenWidth - 1 - pop();
 		else
-			vs->curRect.left = pop();
+			vs->curRect.left = vs->origLeft = pop();
 		break;
 	case 0x9B:		// SO_VERB_ON Turn verb on
 		vs->curmode = 1;

--- a/engines/scumm/verbs.cpp
+++ b/engines/scumm/verbs.cpp
@@ -175,7 +175,7 @@ void ScummEngine_v0::resetVerbs() {
 		vs->center = 0;
 		vs->imgindex = 0;
 		vs->prep = verbPrepIdType(vtable[i - 1].id);
-		vs->curRect.left = vtable[i - 1].x_pos * 8;
+		vs->curRect.left = vs->origLeft = vtable[i - 1].x_pos * 8;
 		vs->curRect.top = vtable[i - 1].y_pos * 8 + virt->topline + 8;
 		loadPtrToResource(rtVerb, i, (const byte*)vtable[i - 1].name);
 	}
@@ -1044,7 +1044,7 @@ void ScummEngine_v7::drawVerb(int verb, int mode) {
 			}
 			int16 leftPos = vs->curRect.left;
 			if (_language == Common::HE_ISR)
-				vs->curRect.left = leftPos = vs->curRect.right - _charset->getStringWidth(0, tmpBuf);
+				vs->curRect.left = vs->origLeft = leftPos = vs->curRect.right - _charset->getStringWidth(0, tmpBuf);
 			else
 				vs->curRect.right = vs->curRect.left + _charset->getStringWidth(0, tmpBuf);
 			enqueueText(tmpBuf, leftPos, vs->curRect.top, color, vs->charset_nr, vs->center);
@@ -1056,7 +1056,7 @@ void ScummEngine_v7::drawVerb(int verb, int mode) {
 			}
 		} else {
 			if (_language == Common::HE_ISR)
-				vs->curRect.left = vs->curRect.right - textWidth;
+				vs->curRect.left = vs->origLeft = vs->curRect.right - textWidth;
 			else
 				vs->curRect.right = vs->curRect.left + textWidth;
 			enqueueText(msg, vs->curRect.left, vs->curRect.top, color, vs->charset_nr, vs->center);
@@ -1084,7 +1084,7 @@ void ScummEngine::drawVerb(int verb, int mode) {
 		restoreVerbBG(verb);
 
 		_string[4].charset = vs->charset_nr;
-		_string[4].xpos = vs->curRect.left;
+		_string[4].xpos = vs->origLeft;
 		_string[4].ypos = vs->curRect.top;
 		_string[4].right = _screenWidth - 1;
 		_string[4].center = vs->center;
@@ -1110,6 +1110,7 @@ void ScummEngine::drawVerb(int verb, int mode) {
 		drawString(4, msg);
 		_charset->_center = tmp;
 
+		vs->curRect.left = _charset->_str.left;
 		vs->curRect.right = _charset->_str.right;
 		vs->curRect.bottom = _charset->_str.bottom;
 		vs->oldRect = _charset->_str;

--- a/engines/scumm/verbs.h
+++ b/engines/scumm/verbs.h
@@ -56,6 +56,7 @@ struct VerbSlot {
 	bool center;
 	uint8 prep;
 	uint16 imgindex;
+	int16 origLeft;
 };
 
 enum VerbsV0 {


### PR DESCRIPTION
`curRect.left` is assigned in the script, and it is not modified. `right` is
assigned with the screen width - original left.

This results in bad highlighting of the verbs all over the line width,
instead of being limited to the actual string.

Due to that, sometimes the selection range of the up/down arrows overlaps
with some of the verbs, and then these verbs cannot be selected.

Solve by storing the original left value, and using it as initial x
position for the string (the actual right-to-left manipulation is done in
`drawString()`), and modify the value of `curRect.left` to match the string
that was actually drawn.

This bug is similar to the one that was fixed in 58e921eb87, but the
solution that was done there for v7 and v8 cannot work here, because the
string logic is much more complicated.
