### PR TITLE
AUDIO: Fix compiler warning

### DIFF
--- a/audio/soundfont/vgmcoll.cpp
+++ b/audio/soundfont/vgmcoll.cpp
@@ -185,7 +185,7 @@ SynthFile *VGMColl::CreateSynthFile(VGMInstrSet *theInstrSet) {
 				newRgn->SetWaveLinkInfo(0, 0, 1, (uint32) realSampNum);
 
 				if (realSampNum >= finalSamps.size()) {
-					debug("Sample %u does not exist", unsigned(realSampNum));
+					debug("Sample %u does not exist", (uint32) realSampNum);
 					realSampNum = finalSamps.size() - 1;
 				}
 

--- a/audio/soundfont/vgmcoll.cpp
+++ b/audio/soundfont/vgmcoll.cpp
@@ -185,7 +185,7 @@ SynthFile *VGMColl::CreateSynthFile(VGMInstrSet *theInstrSet) {
 				newRgn->SetWaveLinkInfo(0, 0, 1, (uint32) realSampNum);
 
 				if (realSampNum >= finalSamps.size()) {
-					debug("Sample %lu does not exist", realSampNum);
+					debug("Sample %u does not exist", unsigned(realSampNum));
 					realSampNum = finalSamps.size() - 1;
 				}
 


### PR DESCRIPTION
size_t and long are not the same on Win64.
