### PR TITLE
COMMON: Fix compiler warning on MinGW

### DIFF
--- a/common/hashmap.cpp
+++ b/common/hashmap.cpp
@@ -58,11 +58,11 @@ template<> void unknownKeyError(::Common::String key) {
 }
 
 template<> void unknownKeyError(signed char key) {
-	error("Unknown key \"%hhi\"", key);
+	error("Unknown key \"%i\"", key);
 }
 
 template<> void unknownKeyError(unsigned char key) {
-	error("Unknown key \"%hhu\"", key);
+	error("Unknown key \"%u\"", key);
 }
 
 template<> void unknownKeyError(short signed key) {
@@ -89,14 +89,6 @@ void unknownKeyError(signed int key) {
 template<>
 void unknownKeyError(unsigned int key) {
 	error("Unknown key \"%u\"", key);
-}
-
-template<> void unknownKeyError(long long signed key) {
-	error("Unknown key \"%lli\"", key);
-}
-
-template<> void unknownKeyError(long long unsigned key) {
-	error("Unknown key \"%llu\"", key);
 }
 
 template<> void unknownKeyError(void *key) {

--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -330,10 +330,6 @@ void NORETURN_PRE unknownKeyError(signed int key) NORETURN_POST;
 template<>
 void NORETURN_PRE unknownKeyError(unsigned int key) NORETURN_POST;
 template<>
-void NORETURN_PRE unknownKeyError(long long signed key) NORETURN_POST;
-template<>
-void NORETURN_PRE unknownKeyError(long long unsigned key) NORETURN_POST;
-template<>
 void NORETURN_PRE unknownKeyError(void *key) NORETURN_POST;
 template<>
 void NORETURN_PRE unknownKeyError(const char *key) NORETURN_POST;
@@ -733,6 +729,11 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::erase(const Key &key) {
 #undef HASHMAP_DUMMY_NODE
 
 /** @} */
+
+template<class Val, class HashFunc, class EqualFunc>
+class HashMap<signed long long, Val, HashFunc, EqualFunc>;
+template<class Val, class HashFunc, class EqualFunc>
+class HashMap<unsigned long long, Val, HashFunc, EqualFunc>;
 
 } // End of namespace Common
 


### PR DESCRIPTION
Disallow long long HashMap (it is not used anyway), as the lli and llu formats are not supported in MinGW.
