### PR TITLE
SDL: Fix crash when switching from OpenGL to another graphics mode

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -795,7 +795,7 @@ void SurfaceSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFo
 			// 0 will currently always be Normal1x scaling
 			setGraphicsMode(0);
 		} else {
-			g_system->setGraphicsMode(ConfMan.get("gfx_mode").c_str());
+			setGraphicsMode(getGraphicsModeIdByName(ConfMan.get("gfx_mode")));
 		}
 	}
 


### PR DESCRIPTION
Tonight I noticed that ScummVM is crashing when switching from the OpenGL graphics mode to any other graphics mode. The crash I get is an assertion:
```
Assertion failed: (_transactionMode == kTransactionActive), function setStretchMode, file backends/graphics/surfacesdl/surfacesdl-graphics.cpp, line 727.
```

And from what I saw in the debugger it seems to be caused by recursive calls to `OSystem_SDL::setGraphicsMode()`.
A bisection indicates that the crash was introduced in commit 12878afc0.
And indeed reverting part of that commit fixes the crash.

I am not sure why that change was made as it seems to be unrelated to the other changes in that commit or indeed to the commit message. But there may have been a good reason to do it, and maybe my proposed change is not good.

