### PR TITLE
GRAPHICS: Expose ascent value in font class

### DIFF
--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -28,6 +28,10 @@
 
 namespace Graphics {
 
+int Font::getFontAscent() const {
+	return -1;
+}
+
 int Font::getKerningOffset(uint32 left, uint32 right) const {
 	return 0;
 }

--- a/graphics/font.h
+++ b/graphics/font.h
@@ -93,6 +93,14 @@ public:
 	virtual int getFontHeight() const = 0;
 
 	/**
+	 * Return the ascent of the font.
+	 *
+	 * @return Font ascent in pixels. If it is unknown
+	 * a value of -1 is returned.
+	 */
+	virtual int getFontAscent() const;
+
+	/**
 	 * Return the maximum width of the font.
 	 *
 	 * @return Maximum font width in pixels.

--- a/graphics/fonts/bdf.cpp
+++ b/graphics/fonts/bdf.cpp
@@ -58,6 +58,10 @@ int BdfFont::getFontHeight() const {
 	return _data.height;
 }
 
+int BdfFont::getFontAscent() const {
+	return _data.ascent;
+}
+
 int BdfFont::getFontSize() const {
 	return _data.size;
 }

--- a/graphics/fonts/bdf.h
+++ b/graphics/fonts/bdf.h
@@ -64,6 +64,7 @@ public:
 	~BdfFont();
 
 	virtual int getFontHeight() const;
+	virtual int getFontAscent() const;
 	virtual int getMaxCharWidth() const;
 
 	virtual int getCharWidth(uint32 chr) const;

--- a/graphics/fonts/macfont.h
+++ b/graphics/fonts/macfont.h
@@ -150,6 +150,7 @@ public:
 	virtual ~MacFONTFont();
 
 	virtual int getFontHeight() const { return _data._fRectHeight; }
+	virtual int getFontAscent() const { return _data._ascent; }
 	virtual int getMaxCharWidth() const { return _data._maxWidth; }
 	virtual int getCharWidth(uint32 chr) const;
 	virtual void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -149,6 +149,8 @@ public:
 
 	virtual int getFontHeight() const;
 
+	virtual int getFontAscent() const;
+
 	virtual int getMaxCharWidth() const;
 
 	virtual int getCharWidth(uint32 chr) const;
@@ -524,6 +526,10 @@ int TTFFont::computePointSizeFromHeaders(int height) const {
 
 int TTFFont::getFontHeight() const {
 	return _height;
+}
+
+int TTFFont::getFontAscent() const {
+	return _ascent;
 }
 
 int TTFFont::getMaxCharWidth() const {

--- a/graphics/fonts/winfont.cpp
+++ b/graphics/fonts/winfont.cpp
@@ -183,7 +183,7 @@ bool WinFont::loadFromFNT(Common::SeekableReadStream &stream) {
 	/* uint16 points = */ stream.readUint16LE();
 	/* uint16 vertRes = */ stream.readUint16LE();
 	/* uint16 horizRes = */ stream.readUint16LE();
-	/* uint16 ascent = */ stream.readUint16LE();
+	_ascent = stream.readUint16LE();
 	/* uint16 internalLeading = */ stream.readUint16LE();
 	/* uint16 externalLeading = */ stream.readUint16LE();
 	/* byte italic = */ stream.readByte();

--- a/graphics/fonts/winfont.h
+++ b/graphics/fonts/winfont.h
@@ -63,6 +63,7 @@ public:
 
 	// Font API
 	int getFontHeight() const { return _pixHeight; }
+	int getFontAscent() const { return _ascent; }
 	int getMaxCharWidth() const { return _maxWidth; }
 	int getCharWidth(uint32 chr) const;
 	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
@@ -77,6 +78,7 @@ private:
 
 	uint16 _pixHeight;
 	uint16 _maxWidth;
+	uint16 _ascent;
 	byte _firstChar;
 	byte _lastChar;
 	byte _defaultChar;


### PR DESCRIPTION
This pull request adds a `getFontAscent()` function to the `Font` class and implements it various classes that derives from it. I decided to make it optional with a default implementation that returns -1 to avoid having to add it to all the fonts implemented in engines where it is not needed (I saw that at least bladeruner and cryomni3d are implementing other font classes). It is implemented for all the font classes in the Graphics namespace.

This is needed in the AGS engine to properly align vertically the text drawn with TTF fonts.
Since this is a change in common code I am proposing this as a pull request. But I would like to merge this quickly so that I can push the changes in the AGS engine to properly display the text.
