### PR TITLE
COMMON: Change JSON integer storage to int32

### DIFF
--- a/backends/cloud/dropbox/dropboxuploadrequest.cpp
+++ b/backends/cloud/dropbox/dropboxuploadrequest.cpp
@@ -91,7 +91,7 @@ void DropboxUploadRequest::uploadNextPart() {
 			url += "finish";
 			Common::JSONObject jsonCursor, jsonCommit;
 			jsonCursor.setVal("session_id", new Common::JSONValue(_sessionId));
-			jsonCursor.setVal("offset", new Common::JSONValue((long long int)_contentsStream->pos()));
+			jsonCursor.setVal("offset", new Common::JSONValue(_contentsStream->pos()));
 			jsonCommit.setVal("path", new Common::JSONValue(_savePath));
 			jsonCommit.setVal("mode", new Common::JSONValue("overwrite"));
 			jsonCommit.setVal("autorename", new Common::JSONValue(false));
@@ -102,7 +102,7 @@ void DropboxUploadRequest::uploadNextPart() {
 			url += "append_v2";
 			Common::JSONObject jsonCursor;
 			jsonCursor.setVal("session_id", new Common::JSONValue(_sessionId));
-			jsonCursor.setVal("offset", new Common::JSONValue((long long int)_contentsStream->pos()));
+			jsonCursor.setVal("offset", new Common::JSONValue(_contentsStream->pos()));
 			jsonRequestParameters.setVal("cursor", new Common::JSONValue(jsonCursor));
 			jsonRequestParameters.setVal("close", new Common::JSONValue(false));
 		}

--- a/common/json.cpp
+++ b/common/json.cpp
@@ -358,7 +358,7 @@ JSONValue *JSONValue::parse(const char **data) {
 		bool neg = **data == '-';
 		if (neg) (*data)++;
 
-		long long int integer = 0;
+		int integer = 0;
 		double number = 0.0;
 		bool onlyInteger = true;
 
@@ -626,7 +626,7 @@ JSONValue::JSONValue(double numberValue) {
 *
 * @param int numberValue The number to use as the value
 */
-JSONValue::JSONValue(long long int numberValue) {
+JSONValue::JSONValue(int32 numberValue) {
 	_type = JSONType_IntegerNumber;
 	_integerValue = numberValue;
 }
@@ -854,7 +854,7 @@ double JSONValue::asNumber() const {
 *
 * @return int Returns the number value
 */
-long long int JSONValue::asIntegerNumber() const {
+int32 JSONValue::asIntegerNumber() const {
 	return _integerValue;
 }
 
@@ -1047,7 +1047,7 @@ String JSONValue::stringifyImpl(size_t const indentDepth) const {
 	}
 
 	case JSONType_IntegerNumber: {
-		ret_string = String::format("%lld", _integerValue);
+		ret_string = String::format("%d", _integerValue);
 		break;
 	}
 

--- a/common/json.h
+++ b/common/json.h
@@ -90,13 +90,17 @@ enum JSONType { JSONType_Null, JSONType_String, JSONType_Bool, JSONType_Number, 
 class JSONValue {
 	friend class JSON;
 
+private:
+	// Not implemented, and should not be used.
+	JSONValue(long long int numberValue);
+
 public:
 	JSONValue(/*NULL*/);
 	JSONValue(const char *charValue);
 	JSONValue(const String &stringValue);
 	JSONValue(bool boolValue);
 	JSONValue(double numberValue);
-	JSONValue(long long int numberValue);
+	JSONValue(int32 numberValue);
 	JSONValue(const JSONArray &arrayValue);
 	JSONValue(const JSONObject &objectValue);
 	JSONValue(const JSONValue &source);
@@ -113,7 +117,7 @@ public:
 	const String &asString() const;
 	bool asBool() const;
 	double asNumber() const;
-	long long int asIntegerNumber() const;
+	int32 asIntegerNumber() const;
 	const JSONArray &asArray() const;
 	const JSONObject &asObject() const;
 
@@ -140,7 +144,7 @@ private:
 	union {
 		bool _boolValue;
 		double _numberValue;
-		long long int _integerValue;
+		int32 _integerValue;
 		String *_stringValue;
 		JSONArray *_arrayValue;
 		JSONObject *_objectValue;


### PR DESCRIPTION
Almost the last piece of `%lld`.

Fixes GCC warnings on MinGW-64.
