### PR TITLE
BUILD: Disable global-constructors warning for Clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ endif
 
 ifeq "$(HAVE_CLANG)" "1"
 	CXXFLAGS+= -Wno-conversion -Wno-shorten-64-to-32 -Wno-sign-compare -Wno-four-char-constants
+	CXXFLAGS+= -Wno-global-constructors
 	# We use a anonymous nested type declaration in an anonymous union in
 	# common/str.h. This is no standard construct and clang warns about it.
 	# It works for all our target systems though, thus we simply disable that


### PR DESCRIPTION
Most (all?) of the global objects have trivial and independent ctor and
dtor, so this is not a real problem.
