### PR TITLE
GLK: Fix Clang warning

### DIFF
--- a/engines/glk/tads/tads2/debug.cpp
+++ b/engines/glk/tads/tads2/debug.cpp
@@ -224,7 +224,7 @@ static void dbgpbval(dbgcxdef *ctx, dattyp typ, const uchar *val,
         while (len)
         {
             dbgpbval(ctx, (dattyp)*p, (const uchar *)(p + 1), dispfn, dispctx);
-            lstadv((uchar **)&p, &len);
+            lstadv((uchar **)const_cast<char **>(&p), &len);
             if (len) (*dispfn)(dispctx, " ", 1);
         }
         (*dispfn)(dispctx, "]", 1);


### PR DESCRIPTION
```
../scummvm/engines/glk/tads/tads2/debug.cpp:227:30: warning: cast from 'const char *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
            lstadv((uchar **)&p, &len);
                             ^
```

Notice that lstadv doesn't modify the pointer contents, only the pointer itself,
so it really should have been const uchar ** in the first place, but changing that
requires too many changes in calling functions, so I took the easy path.
