### PR TITLE
TINSEL: Fix Clang warning

### DIFF
--- a/engines/tinsel/tinlib.cpp
+++ b/engines/tinsel/tinlib.cpp
@@ -1551,6 +1551,8 @@ static void Play(CORO_PARAM, SCNHANDLE hFilm, int x, int y, int compit, int acto
  * Play a film
  */
 static void Play(CORO_PARAM, SCNHANDLE hFilm, int x, int y, int compit, int myEscape, bool bTop, TINSEL_EVENT event, HPOLYGON hPoly, int taggedActor) {
+	OBJECT** playfield = nullptr;
+
 	CORO_BEGIN_CONTEXT;
 	CORO_END_CONTEXT(_ctx);
 
@@ -1589,10 +1591,8 @@ static void Play(CORO_PARAM, SCNHANDLE hFilm, int x, int y, int compit, int myEs
 		_vm->_actor->SetActorTalkFilm(actor, hFilm);
 	}
 
-	OBJECT** playfield;
 	bool bComplete;
 
-	playfield = nullptr;
 	bComplete = compit;
 
 	if (TinselV3) {


### PR DESCRIPTION
```
../scummvm/engines/tinsel/tinlib.cpp:1610:3: warning: variable 'playfield' is used uninitialized whenever switch case is taken [-Wsometimes-uninitialized]
                CORO_INVOKE_ARGS(PlayFilmc, (CORO_SUBCTX, hFilm, x, y, 0, false, false, myEscape != 0, myEscape, bTop, playfield));
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../scummvm\common/coroutines.h:226:17: note: expanded from macro 'CORO_INVOKE_ARGS'
                        return; case __LINE__:; \
                                     ^~~~~~~~
<scratch space>:143:1: note: expanded from here
1610
^~~~
../scummvm/engines/tinsel/tinlib.cpp:1610:106: note: uninitialized use occurs here
                CORO_INVOKE_ARGS(PlayFilmc, (CORO_SUBCTX, hFilm, x, y, 0, false, false, myEscape != 0, myEscape, bTop, playfield));
                                                                                                                       ^~~~~~~~~
../scummvm\common/coroutines.h:222:12: note: expanded from macro 'CORO_INVOKE_ARGS'
                        subCoro ARGS; \
                                ^~~~
../scummvm/engines/tinsel/tinlib.cpp:1592:20: note: initialize the variable 'playfield' to silence this warning
        OBJECT** playfield;
                          ^
                           = nullptr
```