### PR TITLE
COMMON: Use __gnu_printf__ instead of __printf__ for gcc on MinGW

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -339,7 +339,11 @@
 //
 #ifndef GCC_PRINTF
 	#if defined(__GNUC__) || defined(__INTEL_COMPILER)
-		#define GCC_PRINTF(x,y) __attribute__((__format__(__printf__, x, y)))
+		#if __USE_MINGW_ANSI_STDIO && !defined(__clang__)
+			#define GCC_PRINTF(x,y) __attribute__((__format__(__gnu_printf__, x, y)))
+		#else
+			#define GCC_PRINTF(x,y) __attribute__((__format__(__printf__, x, y)))
+		#endif
 	#else
 		#define GCC_PRINTF(x,y)
 	#endif


### PR DESCRIPTION
With `__printf__`, MinGW prefers the portable old ms-style printf, and
warns if formats like `%lld` and `%hhd` are used.

In practice, if __USE_MINGW_ANSI_STDIO is not defined, it defaults to 1
on C++11, and these formats are supported. Using `__gnu_printf__`
suppresses bad format warnings.
