### PR TITLE
CLOUD: Fix compiler warnings on linux64

### DIFF
--- a/backends/cloud/cloudmanager.cpp
+++ b/backends/cloud/cloudmanager.cpp
@@ -124,7 +124,7 @@ void CloudManager::save() {
 		Common::String name = getStorageConfigName(i);
 		ConfMan.set(kStoragePrefix + name + "_username", _storages[i].username, ConfMan.kCloudDomain);
 		ConfMan.set(kStoragePrefix + name + "_lastSync", _storages[i].lastSyncDate, ConfMan.kCloudDomain);
-		ConfMan.set(kStoragePrefix + name + "_usedBytes", Common::String::format("%llu", _storages[i].usedBytes), ConfMan.kCloudDomain);
+		ConfMan.set(kStoragePrefix + name + "_usedBytes", Common::String::format("%llu", (unsigned long long)_storages[i].usedBytes), ConfMan.kCloudDomain);
 	}
 
 	ConfMan.set("current_storage", Common::String::format("%u", _currentStorageIndex), ConfMan.kCloudDomain);

--- a/backends/cloud/googledrive/googledrivestorage.cpp
+++ b/backends/cloud/googledrive/googledrivestorage.cpp
@@ -178,7 +178,9 @@ void GoogleDriveStorage::printInfo(StorageInfoResponse response) {
 	debug(9, "\nGoogleDriveStorage: user info:");
 	debug(9, "\tname: %s", response.value.name().c_str());
 	debug(9, "\temail: %s", response.value.email().c_str());
-	debug(9, "\tdisk usage: %llu/%llu", response.value.used(), response.value.available());
+	debug(9, "\tdisk usage: %llu/%llu",
+		  (unsigned long long)response.value.used(),
+		  (unsigned long long)response.value.available());
 }
 
 Networking::Request *GoogleDriveStorage::createDirectoryWithParentId(Common::String parentId, Common::String directoryName, BoolCallback callback, Networking::ErrorCallback errorCallback) {

--- a/backends/cloud/googledrive/googledriveuploadrequest.cpp
+++ b/backends/cloud/googledrive/googledriveuploadrequest.cpp
@@ -199,7 +199,7 @@ void GoogleDriveUploadRequest::uploadNextPart() {
 	uint32 oldPos = _contentsStream->pos();
 	if (oldPos != _serverReceivedBytes) {
 		if (!_contentsStream->seek(_serverReceivedBytes)) {
-			warning("GoogleDriveUploadRequest: cannot upload because stream couldn't seek(%llu)", _serverReceivedBytes);
+			warning("GoogleDriveUploadRequest: cannot upload because stream couldn't seek(%llu)", (unsigned long long)_serverReceivedBytes);
 			finishError(Networking::ErrorResponse(this, false, true, "GoogleDriveUploadRequest::uploadNextPart: seek() didn't work", -1));
 			return;
 		}


### PR DESCRIPTION
`uint64` is unsigned long on linux64 (first match in `configure:find_type_with_size`), so the format should be `lu`, but this is incompatible with Win64, so just cast to make it portable and warning-clean.

Amends commit 1496ad6bb5.
