### PR TITLE
WIP: SCUMM: Fix selection x-range of verbs on Hebrew

### DIFF
--- a/engines/scumm/script_v8.cpp
+++ b/engines/scumm/script_v8.cpp
@@ -978,10 +978,7 @@ void ScummEngine_v8::o8_verbOps() {
 		break;
 	case 0x9A:		// SO_VERB_AT Set verb (X,Y) placement
 		vs->curRect.top = pop();
-		if (_language == Common::HE_ISR)
-			vs->curRect.right = _screenWidth - 1 - pop();
-		else
-			vs->curRect.left = pop();
+		vs->curRect.left = pop();
 		break;
 	case 0x9B:		// SO_VERB_ON Turn verb on
 		vs->curmode = 1;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1071,6 +1071,7 @@ void ScummEngine::drawString(int a, const byte *msg) {
 			*space = '\0';
 	}
 
+	bool isRTL = false;
 	if (_charset->_center) {
 		_charset->_left -= _charset->getStringWidth(a, buf) / 2;
 	} else if (_game.version >= 4 && _game.version < 7 && _game.heversion == 0 && _game.id != GID_SAMNMAX && _language == Common::HE_ISR) {
@@ -1078,6 +1079,7 @@ void ScummEngine::drawString(int a, const byte *msg) {
 		if (_game.id != GID_INDY4 || buf[0] == 127) {
 			if (_game.id == GID_INDY4)
 				buf[0] = 32;
+			isRTL = true;
 			_charset->_left = _screenWidth - _charset->_startLeft - _charset->getStringWidth(a, buf);
 		}
 	}
@@ -1181,6 +1183,8 @@ void ScummEngine::drawString(int a, const byte *msg) {
 		_string[a]._default.xpos = _string[a].xpos;
 		_string[a]._default.ypos = _string[a].ypos;
 	}
+	if (isRTL)
+		_charset->_str.right = _screenWidth - 1 - _charset->_str.left;
 }
 
 int ScummEngine::convertMessageToString(const byte *msg, byte *dst, int dstSize) {


### PR DESCRIPTION
TODO:
* Artifacts on centered text after it should be erased.
* Short verbs on COMI are split to 2 lines, and the next verb overwrites it.
* It possibly breaks other things I haven't noticed yet.
