### PR TITLE
SCUMM: Fix calculation of arrow position on Hebrew

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1123,7 +1123,7 @@ void ScummEngine::drawString(int a, const byte *msg) {
 				if (_charset->_center) {
 					_charset->_left = _charset->_startLeft - _charset->getStringWidth(a, buf + i);
 				} else if (_game.version >= 4 && _game.version < 7 && _game.heversion == 0 && _language == Common::HE_ISR) {
-					_charset->_left = _screenWidth - _charset->_startLeft - _charset->getStringWidth(a, buf);
+					_charset->_left = _screenWidth - _charset->_startLeft - _charset->getStringWidth(a, buf + i);
 				} else {
 					_charset->_left = _charset->_startLeft;
 				}


### PR DESCRIPTION
The text buffer starts on the i offset. This was overlooked in the original patch.

This amends commit 89c5cd5e5d81d780c74bf5da01ac6fb227e0695c.
