### PR TITLE
MAKEFILE: Fix build without implicit rules

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -153,64 +153,64 @@ ifdef CXX_UPDATE_DEP_FLAG
 # dependency tracking.
 %.o: %.c
 	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
-	$(QUIET_CC)$(CC) $(CXX_UPDATE_DEP_FLAG) $(CFLAGS) $(CPPFLAGS) -c $(<) -o $*.o
+	$(QUIET_CC)$(CC) $(CXX_UPDATE_DEP_FLAG) $(CFLAGS) $(CPPFLAGS) -c $(<) -o $@
 %.o: %.cpp
 	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
-	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CXXFLAGS) $(CPPFLAGS) -c $(<) -o $*.o
+	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CXXFLAGS) $(CPPFLAGS) -c $(<) -o $@
 
 
 # Build rules for Objective-C and Objective-C++ files. Strictly speaking, this is for OS X only.
 %.o: %.mm
 	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
-	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CXXFLAGS) $(CPPFLAGS) -c $(<) -o $*.o
+	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CXXFLAGS) $(CPPFLAGS) -c $(<) -o $@
 
 %.o: %.m
 	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
-	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CPPFLAGS) $(OBJCFLAGS) -c $(<) -o $*.o
+	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CPPFLAGS) $(OBJCFLAGS) -c $(<) -o $@
 
 # Build rule for assembler files with preprocessing
 %.o: %.S
 	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
-	$(QUIET_AS)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(ASFLAGS) -c $(<) -o $*.o
+	$(QUIET_AS)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(ASFLAGS) -c $(<) -o $@
 
 base/version.o: base/version.cpp
 	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
-	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CXXFLAGS) $(VERFLAGS) $(CPPFLAGS) -c $(<) -o $*.o
+	$(QUIET_CXX)$(CXX) $(CXX_UPDATE_DEP_FLAG) $(CXXFLAGS) $(VERFLAGS) $(CPPFLAGS) -c $(<) -o $@
 
 else
 
 # Dumb compile rule, for C++ compilers that don't allow dependency tracking or
 # where it is broken (such as GCC 2.95).
-.cpp.o:
+%.o: %.cpp
 	$(QUIET)$(MKDIR) $(*D)
-	$(QUIET_CXX)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(<) -o $*.o
+	$(QUIET_CXX)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(<) -o $@
 
 # Build rule for assembler files with preprocessing
 %.o: %.S
 	$(QUIET)$(MKDIR) $(*D)
-	$(QUIET_AS)$(CXX) $(ASFLAGS) -c $(<) -o $*.o
+	$(QUIET_AS)$(CXX) $(ASFLAGS) -c $(<) -o $@
 
 base/version.o: base/version.cpp
 	$(QUIET)$(MKDIR) $(*D)
-	$(QUIET_CXX)$(CXX) $(CXXFLAGS) $(VERFLAGS) $(CPPFLAGS) -c $(<) -o $*.o
+	$(QUIET_CXX)$(CXX) $(CXXFLAGS) $(VERFLAGS) $(CPPFLAGS) -c $(<) -o $@
 endif
 
 # Build rule for assembler files
 %.o: %.s
 	$(QUIET)$(MKDIR) $(*D)
-	$(QUIET_AS)$(AS) $(ASFLAGS) $(<) -o $*.o
+	$(QUIET_AS)$(AS) $(ASFLAGS) $(<) -o $@
 
 # Build rule for Windows resource files
 # TODO: Support dependency tracking
 %.o: %.rc
 	$(QUIET)$(MKDIR) $(*D)
-	$(QUIET_WINDRES)$(WINDRES) $(WINDRESFLAGS) $(CPPFLAGS) $(<) -o $*.o
+	$(QUIET_WINDRES)$(WINDRES) $(WINDRESFLAGS) $(CPPFLAGS) $(<) -o $@
 
 ifdef USE_NASM
 # Build rule for NASM assembler files
 %.o: %.asm
 	$(QUIET)$(MKDIR) $(*D)
-	$(QUIET_NASM)$(NASM) $(NASMFLAGS) -o $*.o $(<)
+	$(QUIET_NASM)$(NASM) $(NASMFLAGS) -o $@ $(<)
 endif
 
 # Include the dependency tracking files.


### PR DESCRIPTION
Running `make -r` used `.o` (with no base name) for the compilation output of `base/version.o`.