### PR TITLE
BUILD: Add build flags to download the manual from RTD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ lib*.a
 /doc/de/NEUES
 /doc/de/NEUES.html
 /doc/docportal/_build
+/ScummVM Manual*.pdf
 
 /build*
 /staging

--- a/Makefile.common
+++ b/Makefile.common
@@ -116,6 +116,7 @@ QUIET_PLUGIN  = @echo '   ' PLUGIN ' ' $@;
 QUIET_LINK    = @echo '   ' LINK '   ' $@;
 QUIET_DWP     = @echo '   ' DWP '    ' $@;
 QUIET_WINDRES = @echo '   ' WINDRES '' $@;
+QUIET_CURL		= @echo '   ' CURL '   ' $@;
 QUIET         = @
 endif
 endif
@@ -130,8 +131,15 @@ $(EXECUTABLE).dwp: $(EXECUTABLE)
 	$(QUIET_DWP)$(DWP) -e $(EXECUTABLE)
 endif
 
+# Grab the ScummVM Manual from Read the Docs
+manual:
+ifdef USE_CURL
+	$(QUIET_CURL)$(CURL) -s https://docs.scummvm.org/_/downloads/en/$(MANUALVERSION)/pdf/ --output "ScummVM Manual ($(MANUALVERSION)).pdf"
+DIST_FILES_MANUAL := "ScummVM Manual ($(MANUALVERSION)).pdf"
+endif
+
 distclean: clean clean-devtools
-	$(RM) config.h config.mk config.log engines/engines.mk engines/plugins_table.h
+	$(RM) config.h config.mk config.log engines/engines.mk engines/plugins_table.h "ScummVM Manual"*.pdf
 
 clean: clean-toplevel
 clean-toplevel:
@@ -283,6 +291,10 @@ DISTVERSION = git$(VER_REV)
 endif
 else
 DISTVERSION = $(VERSION)
+# Set the manual version to the release tag, unless a manual value was provided
+ifeq ($(MANUALVERSION),latest)
+MANUALVERSION = v$(VERSION)
+endif
 endif
 
 DISTNAME := scummvm-$(DISTVERSION)
@@ -332,6 +344,9 @@ dist-src: \
 DIST_FILES_DOCS:=$(addprefix $(srcdir)/,AUTHORS COPYING COPYING.BSD COPYING.LGPL COPYING.FREEFONT COPYING.OFL COPYING.ISC COPYING.LUA COPYING.MIT COPYING.TINYGL COPYRIGHT NEWS.md README.md CONTRIBUTING.md)
 ifdef USE_PANDOC
 DIST_FILES_DOCS+=README$(PANDOCEXT) NEWS$(PANDOCEXT) CONTRIBUTING$(PANDOCEXT)
+endif
+ifdef DIST_FILES_MANUAL
+DIST_FILES_DOCS+=$(DIST_FILES_MANUAL)
 endif
 
 DIST_FILES_DOCS_languages=cz da de es fr it no-nb se
@@ -469,4 +484,4 @@ DIST_FILES_SHADERS+=$(wildcard $(srcdir)/engines/wintermute/base/gfx/opengl/shad
 endif
 endif
 
-.PHONY: all clean distclean plugins dist-src clean-toplevel
+.PHONY: all clean distclean plugins dist-src clean-toplevel manual

--- a/configure
+++ b/configure
@@ -198,6 +198,7 @@ _no_pragma_pack=no
 _bink=yes
 _cloud=auto
 _pandoc=no
+_curl=yes
 _lld=no
 # Default vkeybd/eventrec options
 _vkeybd=no
@@ -245,10 +246,9 @@ _nasmpath="$PATH"
 NASMFLAGS=""
 NASM=""
 _tainted_build=no
-PANDOC=""
-_pandocpath="$PATH"
 _pandocformat="default"
 _pandocext="default"
+_manualversion="latest"
 # Detection features to be linked into executable or not
 _detection_features_static=yes
 _detection_features_full=yes
@@ -1098,6 +1098,10 @@ Optional Features:
   --no-builtin-resources   do not include additional resources (e.g. engine data, fonts)
                            into the ScummVM binary
 
+Optional Documentation Options:
+  --with-manual-version=VERSION version to use when generating the manuak (optional)
+  --with-pandoc-format=FORMAT   pandoc format to use during the conversion (optional)
+
 Optional Libraries:
   --with-alsa-prefix=DIR   prefix where alsa is installed (optional)
   --disable-alsa           disable ALSA midi sound support [autodetect]
@@ -1176,8 +1180,6 @@ Optional Libraries:
 
   --with-nasm-prefix=DIR   prefix where nasm executable is installed (optional)
   --disable-nasm           disable assembly language optimizations [autodetect]
-
-  --with-pandoc-format=FORMAT   pandoc format to use during the conversion (optional)
 
   --with-readline-prefix=DIR   prefix where readline is installed (optional)
   --disable-readline       disable readline support in text console [autodetect]
@@ -1562,6 +1564,10 @@ for ac_option in $@; do
 		arg=`echo $ac_option | cut -d '=' -f 2`
 		_pandocformat="$arg"
 		_pandoc=yes
+		;;
+	--with-manual-version=*)
+		arg=`echo $ac_option | cut -d '=' -f 2`
+		_manualversion="$arg"
 		;;
 	--with-staticlib-prefix=*)
 		_staticlibpath=`echo $ac_option | cut -d '=' -f 2`
@@ -2122,6 +2128,26 @@ EOF
 	else
 		eval "$1 $CXXFLAGS $LDFLAGS -o $TMPO$HOSTEXEEXT tmp_cxx_compiler.cpp" 2>> "$TMPLOG" && eval "$TMPO$HOSTEXEEXT 2>> $TMPLOG" && cc_check_clean tmp_cxx_compiler.cpp
 	fi
+}
+
+# Check for an executable in PATH. Takes the name of the EXE and sets
+# two variables with whether the exe exists and the path.
+# For example "test_exe_in_path curl" will set _curlpath and _curl
+test_exe_in_path() {
+	IFS="${IFS= 	}"; ac_save_ifs="$IFS"; IFS=$SEPARATOR
+
+	for path_dir in $PATH; do
+		if test -x "$path_dir/$1$NATIVEEXEEXT" ; then
+			eval "_${1}path"="$path_dir/$1$NATIVEEXEEXT"
+			break
+		fi
+	done
+	IFS="$ac_save_ifs"
+	if ! test "_${1}path" ; then
+		eval "_${1}=no"
+	else
+    eval "_${1}=yes"
+  fi
 }
 
 # Prepare a list of candidates for the C++ compiler
@@ -5679,25 +5705,25 @@ define_in_config_if_yes $_nasm 'USE_NASM'
 if test "$_pandoc" = yes ; then
 	echocheck "pandoc"
 
-	IFS="${IFS= 	}"; ac_save_ifs="$IFS"; IFS=$SEPARATOR
-
-	for path_dir in $_pandocpath; do
-		if test -x "$path_dir/pandoc$NATIVEEXEEXT" ; then
-			PANDOC="$path_dir/pandoc$NATIVEEXEEXT"
-			break
-		fi
-	done
-
-	IFS="$ac_save_ifs"
-
-	if ! test "$PANDOC" ; then
-		_pandoc=no
-	fi
+	test_exe_in_path pandoc
 
 	echo $_pandoc
 fi
 
 define_in_config_if_yes $_pandoc 'USE_PANDOC'
+
+#
+# Check for curl
+#
+if test "$_curl" = yes ; then
+	echocheck "curl"
+
+	test_exe_in_path curl
+
+	echo $_curl
+fi
+
+define_in_config_if_yes $_curl 'USE_CURL'
 
 #
 # Check for FriBidi
@@ -6369,9 +6395,11 @@ EXEPRE := $HOSTEXEPRE
 EXEEXT := $HOSTEXEEXT
 NASM := $NASM
 NASMFLAGS := $NASMFLAGS
-PANDOC := $PANDOC
+PANDOC := $_pandocpath
+CURL := $_curlpath
 PANDOCFORMAT := $_pandocformat
 PANDOCEXT := $_pandocext
+MANUALVERSION := $_manualversion
 ZLIB_LIBS := $ZLIB_LIBS
 ZLIB_CFLAGS := $ZLIB_CFLAGS
 


### PR DESCRIPTION
This PR adds a new build target "manual" that will grab the manual from RTD in PDF format.

By default, we will grab "latest", but if we are tagging for release it will use the semantic version number. (We will need to have the version tagged and a doc version available in RTD for this to work)

Alternatively, a new option was added to configure to allow the user to specify the exact version of the manual they'd want to download.

Not super confident in make, so let me know if you see anything wrong. I'm also not entirely sure where to add rules that will package the manual in the various distribution packaging, so please let me know in the comments.

The current PDF size is around 2.7 MB.