### PR TITLE
MAKEFILE: Add a dependency for rebuilding base/plugins when config is changed

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -147,6 +147,8 @@ endif
 # The build rules for object files.
 #
 
+base/plugins.o: config.mk
+
 ifdef CXX_UPDATE_DEP_FLAG
 
 # Build rule for C++ files. Makes use of CXX_UPDATE_DEP_FLAG for advanced


### PR DESCRIPTION
When adding/removing an engine, config.mk is changed, and this effectively
passes different -DENABLE_* command-line arguments to the compiler.

If base/plugins is not recompiled, the list of active plugins is not updated.

Before b813d1ca0d6f7dbb09deeaebb687d28c2bcf58e9 config.h was created every
time configure was executed, so everything was recompiled anyway. Now we need
to have an explicit dependency.

The only source file that's supposed to be affected is base/plugins, so there
is no reason to rebuild everything. Just add this dependency to update the
plugin list.
