### PR TITLE
AGI: fixed typo in music volume settings

### DIFF
--- a/engines/agi/global.cpp
+++ b/engines/agi/global.cpp
@@ -154,8 +154,8 @@ void AgiEngine::setVolumeViaSystemSetting() {
 	}
 
 	// Now actually set it
-	_mixer->setVolumeForSoundType(Audio::Mixer::kSFXSoundType, scummVMVolumeMusic);
-	_mixer->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, scummVMVolumeSfx);
+	_mixer->setVolumeForSoundType(Audio::Mixer::kSFXSoundType, scummVMVolumeSfx);
+	_mixer->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, scummVMVolumeMusic);
 
 	// Take lowest volume to the scripts
 	if (scummVMVolumeMusic < scummVMVolumeSfx) {


### PR DESCRIPTION
The typo caused music and sound effects volumes values to be swapped for PCjr (but not to MIDI, because `sound_midi` doesn't call MixerImpl::getVolumeForSoundType)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
