### PR TITLE
DONT MERGE - WIN32: Use Unicode for paths

### DIFF
--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -26,6 +26,7 @@
 #include <windows.h>
 
 #include "backends/fs/abstract-fs.h"
+#include "backends/fs/stdiostream.h"
 
 #include <io.h>
 #include <stdio.h>
@@ -80,6 +81,8 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream() override;
 	virtual Common::WriteStream *createWriteStream() override;
+	//TODO fix StdioStream::makeFromPath, use it instead of this, and remove this
+	StdioStream *makeFromPath(const Common::String &path, bool writeMode);
 	virtual bool createDirectory() override;
 
 private:

--- a/backends/platform/sdl/win32/win32_wrapper.h
+++ b/backends/platform/sdl/win32/win32_wrapper.h
@@ -43,23 +43,23 @@ bool confirmWindowsVersion(int majorVersion, int minorVersion);
  * Used to interact with Win32 Unicode APIs with no ANSI fallback.
  *
  * @param s Source string
- * @param c Code Page, by default is CP_ACP (default Windows ANSI code page)
+ * @param c Code Page, by default is CP_UTF8
  * @return Converted string
  *
  * @note Return value must be freed by the caller.
  */
-wchar_t *ansiToUnicode(const char *s, uint codePage = CP_ACP);
+wchar_t *ansiToUnicode(const char *s, uint codePage = CP_UTF8);
 /**
  * Converts a Windows wide-character string into a C string.
  * Used to interact with Win32 Unicode APIs with no ANSI fallback.
  *
  * @param s Source string
- * @param c Code Page, by default is CP_ACP (default Windows ANSI code page)
+ * @param c Code Page, by default is CP_UTF8
  * @return Converted string
  *
  * @note Return value must be freed by the caller.
  */
-char *unicodeToAnsi(const wchar_t *s, uint codePage = CP_ACP);
+char *unicodeToAnsi(const wchar_t *s, uint codePage = CP_UTF8);
 
 }
 

--- a/backends/plugins/win32/win32-provider.cpp
+++ b/backends/plugins/win32/win32-provider.cpp
@@ -40,7 +40,7 @@ private:
 		return (const TCHAR *)x;
 	#else
 		static TCHAR unicodeString[MAX_PATH];
-		MultiByteToWideChar(CP_ACP, 0, x, strlen(x) + 1, unicodeString, sizeof(unicodeString) / sizeof(TCHAR));
+		MultiByteToWideChar(CP_UTF8, 0, x, strlen(x) + 1, unicodeString, sizeof(unicodeString) / sizeof(TCHAR));
 		return unicodeString;
 	#endif
 	}

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1083,7 +1083,8 @@ const Feature s_features[] = {
 	{              "tts",                       "USE_TTS", false, true,  "Text to speech support"},
 	{"builtin-resources",             "BUILTIN_RESOURCES", false, true,  "include resources (e.g. engine data, fonts) into the binary"},
 	{ "detection-static", "USE_DETECTION_FEATURES_STATIC", false, true,  "Static linking of detection objects for engines."},
-	{            "cxx11",                     "USE_CXX11", false, true,  "Compile with c++11 support"}
+	{            "cxx11",                     "USE_CXX11", false, true,  "Compile with c++11 support"},
+	{    "win32_unicode",              "UNICODE;_UNICODE", false, true,  "Use Win32 API Unicode"}
 };
 
 const Tool s_tools[] = {


### PR DESCRIPTION
Before this commit, Windows returned path names with local computer encoding, and then ScummVM converted them to `U32String`, without knowing what is the proper encoding.

This commit ensures that Windows returns Unicode paths.

When scummvm.ini is opened in GVim, the Hebrew path isn't rendered correctly. However, `:e! ++enc=utf8` makes it show correctly. I'm not certain about this - is it normal? Or should we so something for scummvm.ini so editors will automatically know that it's UTF8? (maybe add a `BOM`? but as far as I know, it's frowned upon in the Linux world)

EDIT
-----
Codacy fails, with:

	backends/fs/windows/windows-fs.cpp

	Does not handle strings that are not \0-terminated; if given one it may perform an over-read (it could cause a crash if unprotected) (CWE-126).
	WideCharToMultiByte(CP_ACP, 0, str, _tcslen(str) + 1, asciiString, sizeof(asciiString), NULL, NULL);

	Does not handle strings that are not \0-terminated; if given one it may perform an over-read (it could cause a crash if unprotected) (CWE-126).
	MultiByteToWideChar(CP_ACP, 0, str, strlen(str) + 1, unicodeString, sizeof(unicodeString) / sizeof(TCHAR));

However, I have only changed the codepage. The rest of these lines is similar to before. Do we want to change something in these lines? Or can we safely ignore these warnings?

(BTW, it's weird that Codacy complains about the **original** lines, before my changes - I have modified `CP_ACP` to `CP_UTF8`)

EDIT2
-----
grepping found that there's another instance of `CP_ACP` usage, at `engines/ags/shared/util/path.cpp`
I assume it should also be changed to `CP_UTF8`. Either as part of this PR, or maybe after its acceptance. However, I'm completely unfamiliar with AGS engine. @PaulGilbert , what do you say?

EDIT3
-----
We should be aware that this PR doesn't provide safe migration for users that already have non ascii characters in their game paths, as they are encoded in the local encoding, which ScummVM isn't aware of. However, this PR still *improves* the situation, because anyway, currently these games simply won't work as ScummVM doesn't understand the old path encoding. So, either with this PR, or without it, we're not backward compatible. This PR at least allows the users to re-add those games.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
