### PR TITLE
OpenGL: Fix warning for hidden overladed virtual saveScreenshot() function

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -265,31 +265,6 @@ protected:
 	 */
 	bool saveScreenshot(const Common::String &filename) const;
 
-	/**
-	 * @brief Dummy implementation of saveScreenshot() (ie. no file argument) for OpenGLGraphicsManager
-	 *
-	 * Currently we have a backend OpenGLSDLGraphicsManager, which inherits from both
-	 * OpenGLGraphicsManager and SdlGraphicsManager
-	 *
-	 * OpenGLSDLGraphicsManager "implements" saveScreenshot(const Common::String &filename) (can be overridden)
-	 * by calling the saveScreenshot(const Common::String &filename) of OpenGLGraphicsManager
-	 * and saveScreenshot() by calling saveScreenshot() of SdlGraphicsManager
-	 *
-	 * SdlGraphicsManager provides an implementation of saveScreenshot() (which can be overridden)
-	 * but a dummy implementation of saveScreenshot(const Common::String &filename)
-	 *
-	 * OpenGLGraphicsManager provides the implementation of saveScreenshot(const Common::String &filename)
-	 * but needs a (dummy) implementation of saveScreenshot() since OpenGLGraphicsManager inherits from GraphicsManager
-	 * This avoids the noisy warning (when building for OpenGL backend with no SDL support):
-	 * OpenGL::OpenGLGraphicsManager::saveScreenshot
-	 * hides overloaded virtual function
-	 * GraphicsManager::saveScreenshot
-	 *
-	*/
-	// TODO Maybe we should just unify these two method signatures in one
-	//      to avoid this mess
-	void saveScreenshot() override { return; }
-
 private:
 	//
 	// OpenGL utilities

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -265,6 +265,9 @@ protected:
 	 */
 	bool saveScreenshot(const Common::String &filename) const;
 
+	// Do not hide the argument-less saveScreenshot from the base class
+	using WindowedGraphicsManager::saveScreenshot;
+
 private:
 	//
 	// OpenGL utilities

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -362,10 +362,6 @@ bool OpenGLSdlGraphicsManager::saveScreenshot(const Common::String &filename) co
 	return OpenGLGraphicsManager::saveScreenshot(filename);
 }
 
-void OpenGLSdlGraphicsManager::saveScreenshot() {
-	SdlGraphicsManager::saveScreenshot();
-}
-
 bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	// In case we request a fullscreen mode we will use the mode the user
 	// has chosen last time or the biggest mode available.

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -59,7 +59,6 @@ protected:
 	virtual void handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) override;
 
 	virtual bool saveScreenshot(const Common::String &filename) const override;
-	void saveScreenshot() override;
 
 	virtual int getGraphicsModeScale(int mode) const override { return 1; }
 


### PR DESCRIPTION
This reverts commit 0f118d0210d1dc1d4e4174fd72179de82b263ed8.
Instead it attempt to fix the `hiding overloaded virtual function` warning in a cleaner way.