### PR TITLE
DOCS: Fix misprint for iconspath

### DIFF
--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -244,7 +244,7 @@ There are many recognized configuration keys. In the table below, each key is ei
 		":ref:`herculesfont <herc>`",boolean,false,
 		":ref:`hpbargraphs <hp>`",boolean,true,
 		":ref:`hypercheat <hyper>`",boolean,false,
-		iconpath,string,, "Specifies the path to icons to use as overlay for the ScummVM icon in the Windows taskbar or the macOS Dock when running a game. The icon files should be named after the :ref:`gameid <gameid>`, and be an ICO file on Windows, or a PNG file on macOS."
+		iconspath,string,, "Specifies the path to icons to use as overlay for the ScummVM icon in the Windows taskbar or the macOS Dock when running a game. The icon files should be named after the :ref:`gameid <gameid>`, and be an ICO file on Windows, or a PNG file on macOS."
 		":ref:`improved <improved>`",boolean,true,
 		":ref:`InvObjectsAnimated <objanimated>`",boolean,true,
 		":ref:`joystick_deadzone <deadzone>`",integer, 3


### PR DESCRIPTION
The configuration key "iconpath" is actually "iconspath"

Also, there's more to explain about this feature, but it would probably bloat the details table cell for a minor feature that probably not many people use. 

Anyway, for reference the code seems to accept naming formats of:
 * (gameid).(extension), where gameid is as it appears in scummvm.ini for the game entry
 * (engineid)-(gameid).(extension), where engineid and gameid are as they appear in scummvm.ini for the game entry
 * (gameTarget).(extension), where gameTarget is the "tag" as it appears in scummvm.ini for this game's entry section, which is also what is exposed to the ScummVM launcher GUI as "ID". (Our documentation currently actually points to this one).

If the _iconspath_ is empty or missing, the code will also look for an _extrapath_ --another configuration key, but one which is exposed to the ScummVM launcher GUI, and has a global value and a per-game entry, under Options->Paths (tab)->Extra Path (field) or Edit Game... ->Paths (tab)->Extra Path (field) ).

Finally, within the path specified either in iconspath or the extrapath (if the iconspath is empty/undefined) the icons can either reside directly into that folder path or within a subfolder named "icons".

This is based on the source code in file: common/taskbar.h

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
