### PR TITLE
DONT MERGE - GUI: U32: Transforms from Win32 Ansi encoding to U32 in dialogs

### DIFF
--- a/backends/dialogs/win32/win32-dialogs.cpp
+++ b/backends/dialogs/win32/win32-dialogs.cpp
@@ -190,4 +190,14 @@ Common::DialogManager::DialogResult Win32DialogManager::showFileBrowser(const Co
 	return result;
 }
 
+Common::U32String Win32DialogManager::ansiToU32Str(Common::String s) {
+	wchar_t* str = Win32::ansiToUnicode(s.c_str());
+	return Common::U32String::decodeUTF16Native((uint16 *)str, wcslen(str));;
+}
+
+Common::String Win32DialogManager::u32StrToAnsi(Common::U32String s) {
+	return Win32::unicodeToAnsi((LPWSTR)s.encodeUTF16Native());
+
+}
+
 #endif

--- a/backends/dialogs/win32/win32-dialogs.h
+++ b/backends/dialogs/win32/win32-dialogs.h
@@ -36,6 +36,8 @@ public:
 	Win32DialogManager(SdlWindow_Win32 *window);
 	virtual ~Win32DialogManager();
 	virtual DialogResult showFileBrowser(const Common::U32String &title, Common::FSNode &choice, bool isDirBrowser) override;
+	virtual Common::U32String ansiToU32Str(Common::String s) override;
+	virtual Common::String u32StrToAnsi(Common::U32String s) override;
 
 private:
 	SdlWindow_Win32 *_window;

--- a/common/dialogs.h
+++ b/common/dialogs.h
@@ -69,6 +69,25 @@ public:
 	 */
 	virtual DialogResult showFileBrowser(const Common::U32String &title, FSNode &choice, bool isDirBrowser = false) { return kDialogError; }
 
+	/**
+	 * Transform an Ansi encoded String into a U32String
+	 * If Ansi encoding doesn't apply to OS, returns representation of the original string
+	 *
+	 * @param s		Ansi encoded String
+	 * @return		The U32String result
+	 */
+	virtual Common::U32String ansiToU32Str(Common::String s) { return s; };
+
+	/**
+	 * Transform a U32String into Ansi encoded String
+	 * If Ansi encoding doesn't apply to OS, returns representation of the original string
+	 *
+	 * @param s		U32String
+	 * @return		The String result
+	 */
+	virtual Common::String u32StrToAnsi(Common::U32String s) { return s; };
+
+
 protected:
 	bool _wasFullscreen;
 

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -28,6 +28,7 @@
 #include "common/gui_options.h"
 #include "common/translation.h"
 #include "common/system.h"
+#include "common/dialogs.h"
 
 #include "gui/browser.h"
 #include "gui/gui-manager.h"
@@ -336,7 +337,12 @@ EditGameDialog::EditGameDialog(const String &domain)
 		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _("Game Path:"), Common::U32String(), kCmdGameBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _c("Game Path:", "lowres"), Common::U32String(), kCmdGameBrowser);
-	_gamePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.GamepathText", gamePath);
+
+	Common::DialogManager *dialogManager = g_system->getDialogManager();
+	if (dialogManager)
+		_gamePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.GamepathText", dialogManager->ansiToU32Str(gamePath));
+	else
+		_gamePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.GamepathText", gamePath);
 
 	// GUI:  Button + Label for the additional path
 	if (g_system->getOverlayWidth() > 320)
@@ -483,8 +489,13 @@ void EditGameDialog::apply() {
 		ConfMan.set("language", Common::getLanguageCode(lang), _domain);
 
 	U32String gamePath(_gamePathWidget->getLabel());
-	if (!gamePath.empty())
-		ConfMan.set("path", gamePath, _domain);
+	if (!gamePath.empty()) {
+		Common::DialogManager *dialogManager = g_system->getDialogManager();
+		if (dialogManager)
+			ConfMan.set("path", dialogManager->u32StrToAnsi(gamePath), _domain);
+		else
+			ConfMan.set("path", gamePath, _domain);
+	}
 
 	U32String extraPath(_extraPathWidget->getLabel());
 	if (!extraPath.empty() && (extraPath != _c("None", "path")))


### PR DESCRIPTION
Windows returns paths encoded in local code page. The dialogs use
U32Strings. This commit ensures that the game path is explicitly
transformed to and from U32String when passed to or from the GUI dialog,
otherwise, a wrong implicit conversion is done.

Note:
This PR tries to solve the same problem as PR #2914 , but with (hopefully) simpler approach.
@SupSuper , @sluicebox , as far as I understand, this should be safe for the Win98 build. Please approve my assumption.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
