### PR TITLE
WIN32: Use UTF8 instead of local codepage

### DIFF
--- a/backends/dialogs/win32/win32-dialogs.cpp
+++ b/backends/dialogs/win32/win32-dialogs.cpp
@@ -92,7 +92,7 @@ HRESULT getShellPath(IShellItem *item, Common::String &path) {
 	LPWSTR name = NULL;
 	HRESULT hr = item->GetDisplayName(SIGDN_FILESYSPATH, &name);
 	if (SUCCEEDED(hr)) {
-		char *str = Win32::unicodeToAnsi(name);
+		char *str = Win32::winUnicodeToAscii(name);
 		path = Common::String(str);
 		CoTaskMemFree(name);
 		free(str);
@@ -140,7 +140,7 @@ Common::DialogManager::DialogResult Win32DialogManager::showFileBrowser(const Co
 
 		LPWSTR str;
 		if (ConfMan.hasKey("browser_lastpath")) {
-			str = Win32::ansiToUnicode(ConfMan.get("browser_lastpath").c_str());
+			str = Win32::asciiToWinUnicode(ConfMan.get("browser_lastpath").c_str());
 			IShellItem *item = NULL;
 			hr = winCreateItemFromParsingName(str, NULL, IID_IShellItem, reinterpret_cast<void **> (&(item)));
 			if (SUCCEEDED(hr)) {

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -26,6 +26,7 @@
 #include <windows.h>
 
 #include "backends/fs/abstract-fs.h"
+#include "backends/fs/stdiostream.h"
 
 #include <io.h>
 #include <stdio.h>
@@ -80,6 +81,8 @@ public:
 
 	virtual Common::SeekableReadStream *createReadStream() override;
 	virtual Common::WriteStream *createWriteStream() override;
+	//TODO fix StdioStream::makeFromPath, use it instead of this, and remove this
+	StdioStream *makeFromPath(const Common::String &path, bool writeMode);
 	virtual bool createDirectory() override;
 
 private:
@@ -93,23 +96,7 @@ private:
 	 * @param hidden       true if hidden files should be added, false otherwise
 	 * @param find_data    Describes a file that the FindFirstFile, FindFirstFileEx, or FindNextFile functions find.
 	 */
-	static void addFile(AbstractFSList &list, ListMode mode, const char *base, bool hidden, WIN32_FIND_DATA* find_data);
-
-	/**
-	 * Converts a Unicode string to Ascii format.
-	 *
-	 * @param str Common::String to convert from Unicode to Ascii.
-	 * @return str in Ascii format.
-	 */
-	static char *toAscii(TCHAR *str);
-
-	/**
-	 * Converts an Ascii string to Unicode format.
-	 *
-	 * @param str Common::String to convert from Ascii to Unicode.
-	 * @return str in Unicode format.
-	 */
-	static const TCHAR* toUnicode(const char *str);
+	static void addFile(AbstractFSList &list, ListMode mode, const char *base, bool hidden, LPWIN32_FIND_DATAW find_data);
 
 	/**
 	 * Tests and sets the _isValid and _isDirectory flags, using the GetFileAttributes() function.

--- a/backends/platform/sdl/win32/win32_wrapper.cpp
+++ b/backends/platform/sdl/win32/win32_wrapper.cpp
@@ -31,6 +31,7 @@
 #include "common/scummsys.h"
 #include "backends/platform/sdl/win32/win32_wrapper.h"
 
+
 // VerSetConditionMask, VerifyVersionInfo and SHGetFolderPath didn't appear until Windows 2000,
 // so we need to check for them at runtime
 ULONGLONG VerSetConditionMaskFunc(ULONGLONG dwlConditionMask, DWORD dwTypeMask, BYTE dwConditionMask) {
@@ -80,7 +81,7 @@ bool confirmWindowsVersion(int majorVersion, int minorVersion) {
 	return VerifyVersionInfoFunc(&versionInfo, VER_MAJORVERSION | VER_MINORVERSION, conditionMask);
 }
 
-wchar_t *ansiToUnicode(const char *s, uint codePage) {
+wchar_t *asciiToWinUnicode(const char *s, uint codePage) {
 	DWORD size = MultiByteToWideChar(codePage, 0, s, -1, NULL, 0);
 
 	if (size > 0) {
@@ -92,7 +93,7 @@ wchar_t *ansiToUnicode(const char *s, uint codePage) {
 	return NULL;
 }
 
-char *unicodeToAnsi(const wchar_t *s, uint codePage) {
+char *winUnicodeToAscii(const wchar_t *s, uint codePage) {
 	DWORD size = WideCharToMultiByte(codePage, 0, s, -1, NULL, 0, 0, 0);
 
 	if (size > 0) {

--- a/backends/platform/sdl/win32/win32_wrapper.h
+++ b/backends/platform/sdl/win32/win32_wrapper.h
@@ -43,23 +43,23 @@ bool confirmWindowsVersion(int majorVersion, int minorVersion);
  * Used to interact with Win32 Unicode APIs with no ANSI fallback.
  *
  * @param s Source string
- * @param c Code Page, by default is CP_ACP (default Windows ANSI code page)
+ * @param c Code Page, by default is CP_UTF8
  * @return Converted string
  *
  * @note Return value must be freed by the caller.
  */
-wchar_t *ansiToUnicode(const char *s, uint codePage = CP_ACP);
+wchar_t *asciiToWinUnicode(const char *s, uint codePage = CP_UTF8);
 /**
  * Converts a Windows wide-character string into a C string.
  * Used to interact with Win32 Unicode APIs with no ANSI fallback.
  *
  * @param s Source string
- * @param c Code Page, by default is CP_ACP (default Windows ANSI code page)
+ * @param c Code Page, by default is CP_UTF8
  * @return Converted string
  *
  * @note Return value must be freed by the caller.
  */
-char *unicodeToAnsi(const wchar_t *s, uint codePage = CP_ACP);
+char *winUnicodeToAscii(const wchar_t *s, uint codePage = CP_UTF8);
 
 }
 

--- a/backends/plugins/win32/win32-provider.cpp
+++ b/backends/plugins/win32/win32-provider.cpp
@@ -40,7 +40,7 @@ private:
 		return (const TCHAR *)x;
 	#else
 		static TCHAR unicodeString[MAX_PATH];
-		MultiByteToWideChar(CP_ACP, 0, x, strlen(x) + 1, unicodeString, sizeof(unicodeString) / sizeof(TCHAR));
+		MultiByteToWideChar(CP_UTF8, 0, x, strlen(x) + 1, unicodeString, sizeof(unicodeString) / sizeof(TCHAR));
 		return unicodeString;
 	#endif
 	}

--- a/backends/taskbar/win32/win32-taskbar.cpp
+++ b/backends/taskbar/win32/win32-taskbar.cpp
@@ -129,7 +129,7 @@ void Win32TaskbarManager::setOverlayIcon(const Common::String &name, const Commo
 	}
 
 	// Sets the overlay icon
-	LPWSTR desc = Win32::ansiToUnicode(description.c_str());
+	LPWSTR desc = Win32::asciiToWinUnicode(description.c_str());
 	_taskbar->SetOverlayIcon(_window->getHwnd(), pIcon, desc);
 
 	DestroyIcon(pIcon);
@@ -263,7 +263,7 @@ void Win32TaskbarManager::setCount(int count) {
 	}
 
 	// Sets the overlay icon
-	LPWSTR desc = Win32::ansiToUnicode(Common::String::format("Found games: %d", count).c_str());
+	LPWSTR desc = Win32::asciiToWinUnicode(Common::String::format("Found games: %d", count).c_str());
 	_taskbar->SetOverlayIcon(_window->getHwnd(), _icon, desc);
 	free(desc);
 }
@@ -284,8 +284,8 @@ void Win32TaskbarManager::addRecent(const Common::String &name, const Common::St
 	// Create a shell link.
 	if (SUCCEEDED(CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC, IID_IShellLinkW, reinterpret_cast<void **> (&link)))) {
 		// Convert game name and description to Unicode.
-		LPWSTR game = Win32::ansiToUnicode(name.c_str());
-		LPWSTR desc = Win32::ansiToUnicode(description.c_str());
+		LPWSTR game = Win32::asciiToWinUnicode(name.c_str());
+		LPWSTR desc = Win32::asciiToWinUnicode(description.c_str());
 
 		// Set link properties.
 		link->SetPath(path);
@@ -295,7 +295,7 @@ void Win32TaskbarManager::addRecent(const Common::String &name, const Common::St
 		if (iconPath.empty()) {
 			link->SetIconLocation(path, 0); // No game-specific icon available
 		} else {
-			LPWSTR icon = Win32::ansiToUnicode(iconPath.c_str());
+			LPWSTR icon = Win32::asciiToWinUnicode(iconPath.c_str());
 
 			link->SetIconLocation(icon, 0);
 

--- a/engines/ags/shared/util/path.cpp
+++ b/engines/ags/shared/util/path.cpp
@@ -216,7 +216,7 @@ String WidePathNameToAnsi(LPCWSTR pathw) {
 	LPCWSTR arg_path = pathw;
 	if (GetShortPathNameW(arg_path, short_path, MAX_PATH) == 0)
 		return "";
-	WideCharToMultiByte(CP_ACP, 0, short_path, -1, ascii_buffer, MAX_PATH, NULL, NULL);
+	WideCharToMultiByte(CP_UTF8, 0, short_path, -1, ascii_buffer, MAX_PATH, NULL, NULL);
 	return ascii_buffer;
 }
 #endif


### PR DESCRIPTION
Third attempt to solve the same problem as https://github.com/scummvm/scummvm/pull/2914 and https://github.com/scummvm/scummvm/pull/2928

This one is quite similar to https://github.com/scummvm/scummvm/pull/2914 , but without using `define UNICODE`.

@sluicebox , at #2914  you've mentioned problems with Win98. Do you think this PR is also problematic with Win98? What's the exact problem? Doesn't Win98 support wide chars? But we already have such usage in our codebase, at backends\platform\sdl\win32\win32_wrapper.cpp - so, is it OK? Or maybe that file isn't used at Win98?

EDIT
-----
I've described the problem, and my analysis, at https://bugs.scummvm.org/ticket/12409

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
