### PR TITLE
GUI: Fix caching of Edit Game dialog layout

### DIFF
--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -954,9 +954,9 @@ void OptionsContainerWidget::reflowLayout() {
 	Widget::reflowLayout();
 
 	if (!_dialogLayout.empty()) {
-		if (!g_gui.xmlEval()->hasDialog(_dialogLayout)) {
-			defineLayout(*g_gui.xmlEval(), _dialogLayout, _name);
-		}
+		// Since different engines have different number of options,
+		// we have to create it every time.
+		defineLayout(*g_gui.xmlEval(), _dialogLayout, _name);
 
 		if (!_scrollContainer) {
 			g_gui.xmlEval()->reflowDialogLayout(_dialogLayout, _firstWidget);


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

Since different engines may have different number of options we have to recreate "Edit Game" dialog layout every time and avoid caching.