### PR TITLE
SCUMM: Add workaround for Pete Wheeler softlock

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1409,7 +1409,25 @@ void ScummEngine_v6::o6_getActorAnimCounter() {
 void ScummEngine_v6::o6_getAnimateVariable() {
 	int var = pop();
 	Actor *a = derefActor(pop(), "o6_getAnimateVariable");
-	push(a->getAnimVar(var));
+
+	// WORKAROUND: In Backyard Baseball 2001 and 2003,
+	// bunting a foul ball as Pete Wheeler may softlock the game
+	// with an animation loop if the ball goes way into
+	// the left or right field line.
+	//
+	// This is a script bug because Pete's actor variable never
+	// sets to 1 in this condition and script room-4-2105
+	// (or room-3-2105 in 2003) will always break.
+	// We fix that by forcing Pete to play the return animation
+	// regardless if the ball's foul or not.
+	if ((_game.id == GID_BASEBALL2001 || _game.id == GID_BASEBALL2003) && \
+	 		_currentRoom == ((_game.id == GID_BASEBALL2001) ? 4 : 3) && \
+			vm.slot[_currentScript].number == 2105 && \
+			a->_costume == ((_game.id == GID_BASEBALL2001) ? 107 : 99) && \
+			readVar(0x8000 + 5) != 0)
+		push(1);
+	else
+		push(a->getAnimVar(var));
 }
 
 void ScummEngine_v6::o6_isActorInBox() {


### PR DESCRIPTION
There's this rare script bug in Backyard Baseball 2001 and 2003 where bunting a foul ball as Pete Wheeler may softlock the game if the ball goes far left or right field.  This is because the actor animation variable never sets to 1 under this condition due the game thinks he has hit a good ball while in reality he didn't.  You can see a couple instances of this occurring [here in Baseball 2003](https://www.reddit.com/r/BackyardBaseball/comments/m8xkrs/when_its_stuck_on_this/), and [here in Baseball 2001](https://clips.twitch.tv/HonorableCarefulGoatSeemsGood-hVQ4yDighlEYHqYS).  Unsure if this is a ScummVM specific issue somewhere or not, but I've heard from some people this has occurred in the original engine as well.  The original Backyard Baseball 1997 release does not seem to have this bug in my testing.

This workaround basically sets Pete Wheeler back to his "batting stance" regardless he has hit a good ball or not.  To make testing easier, I've attached a ZIP archive containing the save games for Backyard Baseball 2001 and Backyard Baseball 2003 (must be loaded through the debugger) which takes to the point where the bug occurs.

[pete-bug.zip](https://github.com/LittleToonCat/scummvm/files/6282717/pete-bug.zip)