### PR TITLE
AGS: Remove unused private members and globals

### DIFF
--- a/engines/ags/ags.cpp
+++ b/engines/ags/ags.cpp
@@ -79,7 +79,7 @@ AGSEngine::AGSEngine(OSystem *syst, const AGSGameDescription *gameDesc) : Engine
 	DebugMan.addDebugChannel(kDebugScan, "Scan", "Scan for unrecognised games");
 
 	_events = new EventsManager();
-	_music = new Music(_mixer);
+	_music = new Music();
 	_globals = new ::AGS3::Globals();
 
 	Common::String forceAA;

--- a/engines/ags/music.cpp
+++ b/engines/ags/music.cpp
@@ -29,8 +29,7 @@ namespace AGS {
 
 Music *g_music;
 
-Music::Music(Audio::Mixer *mixer) :
-		Audio::MidiPlayer(), _mixer(mixer) {
+Music::Music() {
 	g_music = this;
 	Audio::MidiPlayer::createDriver();
 

--- a/engines/ags/music.h
+++ b/engines/ags/music.h
@@ -32,14 +32,13 @@ namespace AGS {
 
 class Music : public Audio::MidiPlayer {
 private:
-	Audio::Mixer *_mixer;
 	Audio::SoundHandle _soundHandle;
 	Common::Array<byte> _midiData;
 protected:
 	// Overload Audio::MidiPlayer method
 	void sendToChannel(byte channel, uint32 b) override;
 public:
-	Music(Audio::Mixer *mixer);
+	Music();
 	~Music() override;
 
 	/**

--- a/engines/ags/plugins/ags_flashlight/ags_flashlight.cpp
+++ b/engines/ags/plugins/ags_flashlight/ags_flashlight.cpp
@@ -32,7 +32,6 @@ namespace AGSFlashlight {
 const uint32 Magic = 0xBABE0000;
 const uint32 Version = 2;
 const uint32 SaveMagic = Magic + Version;
-const float PI = 3.14159265f;
 
 int32 AGSFlashlight::AGSFlashlight::screen_width = 320;
 int32 AGSFlashlight::screen_height = 200;

--- a/engines/ags/shared/util/filestream.cpp
+++ b/engines/ags/shared/util/filestream.cpp
@@ -35,7 +35,7 @@ namespace Shared {
 FileStream::FileStream(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode,
 	DataEndianess stream_endianess)
 		: DataStream(stream_endianess), _writeBuffer(DisposeAfterUse::YES),
-		_openMode(open_mode), _workMode(work_mode), _file(nullptr), _outSave(nullptr) {
+		_workMode(work_mode), _file(nullptr), _outSave(nullptr) {
 	Open(file_name, open_mode, work_mode);
 }
 

--- a/engines/ags/shared/util/filestream.h
+++ b/engines/ags/shared/util/filestream.h
@@ -71,7 +71,6 @@ private:
 	void            Open(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode);
 
 	Common::Stream *_file;
-	const FileOpenMode  _openMode;
 	const FileWorkMode  _workMode;
 	Common::MemoryWriteStreamDynamic _writeBuffer;
 	Common::OutSaveFile *_outSave;


### PR DESCRIPTION
Detected by Clang.
