### PR TITLE
TSAGE: Support Blue Force Spanish

### DIFF
--- a/engines/tsage/blue_force/blueforce_dialogs.cpp
+++ b/engines/tsage/blue_force/blueforce_dialogs.cpp
@@ -465,7 +465,13 @@ void OptionsDialog::show() {
 		g_globals->_game->restartGame();
 	} else if (btnIndex == 3) {
 		// Quit game
-		if (MessageDialog::show(QUIT_CONFIRM_MSG, CANCEL_BTN_STRING, QUIT_BTN_STRING) == 1) {
+		int rc;
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			rc = MessageDialog::show(ESP_QUIT_CONFIRM_MSG, ESP_CANCEL_BTN_STRING, ESP_QUIT_BTN_STRING);
+		} else {
+			rc = MessageDialog::show(QUIT_CONFIRM_MSG, CANCEL_BTN_STRING, QUIT_BTN_STRING);
+		}
+		if(rc == 1) {
 			g_vm->quitGame();
 		}
 	} else if (btnIndex == 4) {
@@ -476,13 +482,23 @@ void OptionsDialog::show() {
 
 OptionsDialog::OptionsDialog() {
 	// Set the element text
-	_gfxMessage.set(OPTIONS_MSG, 140, ALIGN_LEFT);
-	_btnRestore.setText(RESTORE_BTN_STRING);
-	_btnSave.setText(SAVE_BTN_STRING);
-	_btnRestart.setText(RESTART_BTN_STRING);
-	_btnQuit.setText(QUIT_BTN_STRING);
-	_btnSound.setText(SOUND_BTN_STRING);
-	_btnResume.setText(RESUME_BTN_STRING);
+	if (g_vm->getLanguage() == Common::ES_ESP) {
+		_gfxMessage.set(ESP_OPTIONS_MSG, 140, ALIGN_LEFT);
+		_btnRestore.setText(ESP_RESTORE_BTN_STRING);
+		_btnSave.setText(ESP_SAVE_BTN_STRING);
+		_btnRestart.setText(ESP_RESTART_BTN_STRING);
+		_btnQuit.setText(ESP_QUIT_BTN_STRING);
+		_btnSound.setText(ESP_SOUND_BTN_STRING);
+		_btnResume.setText(ESP_RESUME_BTN_STRING);
+	} else {
+		_gfxMessage.set(OPTIONS_MSG, 140, ALIGN_LEFT);
+		_btnRestore.setText(RESTORE_BTN_STRING);
+		_btnSave.setText(SAVE_BTN_STRING);
+		_btnRestart.setText(RESTART_BTN_STRING);
+		_btnQuit.setText(QUIT_BTN_STRING);
+		_btnSound.setText(SOUND_BTN_STRING);
+		_btnResume.setText(RESUME_BTN_STRING);
+	}
 
 	// Set position of the elements
 	_gfxMessage._bounds.moveTo(0, 1);

--- a/engines/tsage/blue_force/blueforce_logic.cpp
+++ b/engines/tsage/blue_force/blueforce_logic.cpp
@@ -296,7 +296,11 @@ void BlueForceGame::processEvent(Event &event) {
 		switch (event.kbd.keycode) {
 		case Common::KEYCODE_F1:
 			// F1 - Help
-			MessageDialog::show(HELP_MSG, OK_BTN_STRING);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				MessageDialog::show(ESP_HELP_MSG, ESP_OK_BTN_STRING);
+			} else {
+				MessageDialog::show(HELP_MSG, OK_BTN_STRING);
+			}
 			break;
 
 		case Common::KEYCODE_F2:
@@ -325,7 +329,11 @@ void BlueForceGame::processEvent(Event &event) {
 		case Common::KEYCODE_F10:
 			// F10 - Pause
 			GfxDialog::setPalette();
-			MessageDialog::show(GAME_PAUSED_MSG, OK_BTN_STRING);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				MessageDialog::show(ESP_GAME_PAUSED_MSG, ESP_OK_BTN_STRING);
+			} else {
+				MessageDialog::show(GAME_PAUSED_MSG, OK_BTN_STRING);
+			}
 			g_globals->_events.setCursorFromFlag();
 			break;
 
@@ -968,7 +976,13 @@ void SceneHandlerExt::process(Event &event) {
 		BF_GLOBALS._player.enableControl();
 		BF_GLOBALS._events.setCursor(CURSOR_WALK);
 
-		if (MessageDialog::show2(WATCH_INTRO_MSG, START_PLAY_BTN_STRING, INTRODUCTION_BTN_STRING) == 0) {
+		int rc;
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			rc = MessageDialog::show2(ESP_WATCH_INTRO_MSG, ESP_START_PLAY_BTN_STRING, ESP_INTRODUCTION_BTN_STRING);
+		} else {
+			rc = MessageDialog::show2(WATCH_INTRO_MSG, START_PLAY_BTN_STRING, INTRODUCTION_BTN_STRING);
+		}
+		if (rc == 0) {
 			// Start the game
 			BF_GLOBALS._dayNumber = 1;
 			BF_GLOBALS._sceneManager.changeScene(190);

--- a/engines/tsage/blue_force/blueforce_scenes0.cpp
+++ b/engines/tsage/blue_force/blueforce_scenes0.cpp
@@ -364,13 +364,21 @@ void Scene50::postInit(SceneObjectList *OwnerList) {
 	_text.fixPriority(256);
 
 	// Set all the hotspots
-	_location3.set(Rect(10, 92, 24, 105), 180, GRANDMA_FRANNIE, 4);
+	if (g_vm->getLanguage() == Common::ES_ESP) {
+		_location3.set(Rect(10, 92, 24, 105), 180, ESP_GRANDMA_FRANNIE, 4);
+		_location1.set(Rect(573, 103, 604, 130), 190, ESP_POLICE_DEPARTMENT, 1);
+		_location4.set(Rect(313, 21, 325, 33), 114, ESP_TONYS_BAR, 8);
+		_location8.set(Rect(69, 79, 82, 88), 580, ESP_CHILD_PROTECTIVE_SERVICES, 256);
+		_location5.set(Rect(383, 57, 402, 70), 380, ESP_CITY_HALL_JAIL, 32);
+	} else {
+		_location3.set(Rect(10, 92, 24, 105), 180, GRANDMA_FRANNIE, 4);
+		_location1.set(Rect(573, 103, 604, 130), 190, POLICE_DEPARTMENT, 1);
+		_location4.set(Rect(313, 21, 325, 33), 114, TONYS_BAR, 8);
+		_location8.set(Rect(69, 79, 82, 88), 580, CHILD_PROTECTIVE_SERVICES, 256);
+		_location5.set(Rect(383, 57, 402, 70), 380, CITY_HALL_JAIL, 32);
+	}
 	_location2.set(Rect(443, 149, 508, 178), 330, MARINA, 2);
-	_location1.set(Rect(573, 103, 604, 130), 190, POLICE_DEPARTMENT, 1);
-	_location4.set(Rect(313, 21, 325, 33), 114, TONYS_BAR, 8);
-	_location8.set(Rect(69, 79, 82, 88), 580, CHILD_PROTECTIVE_SERVICES, 256);
 	_location6.set(Rect(242, 131, 264, 144), 440, ALLEY_CAT, 64);
-	_location5.set(Rect(383, 57, 402, 70), 380, CITY_HALL_JAIL, 32);
 	_location7.set(Rect(128, 32, 143, 42), 800, JAMISON_RYAN, 128);
 	_location9.set(Rect(349, 125, 359, 132),
 		(BF_GLOBALS._bookmark == bInspectionDone) || (BF_GLOBALS._bookmark == bCalledToDrunkStop) ? 551 : 550,

--- a/engines/tsage/blue_force/blueforce_scenes1.cpp
+++ b/engines/tsage/blue_force/blueforce_scenes1.cpp
@@ -63,7 +63,11 @@ void Scene100::Action1::signal() {
 			setTextStrings(msg1, msg2, this);
 			--_actionIndex;
 		} else {
-			setTextStrings(BF_NAME, BF_ALL_RIGHTS_RESERVED, this);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				setTextStrings(BF_NAME, ESP_BF_ALL_RIGHTS_RESERVED, this);
+			} else {
+				setTextStrings(BF_NAME, BF_ALL_RIGHTS_RESERVED, this);
+			}
 
 			Common::Point pt(_sceneText1._position.x, 80);
 			NpcMover *mover = new NpcMover();
@@ -145,7 +149,13 @@ void Scene100::Action2::signal() {
 			g_globals->_player.enableControl();
 			g_globals->_events.setCursor(CURSOR_WALK);
 
-			if (MessageDialog::show2(WATCH_INTRO_MSG, START_PLAY_BTN_STRING, INTRODUCTION_BTN_STRING) == 0) {
+			int rc;
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				rc = MessageDialog::show2(ESP_WATCH_INTRO_MSG, ESP_START_PLAY_BTN_STRING, ESP_INTRODUCTION_BTN_STRING);
+			} else {
+				rc = MessageDialog::show2(WATCH_INTRO_MSG, START_PLAY_BTN_STRING, INTRODUCTION_BTN_STRING);
+			}
+			if (rc == 0) {
 				// Signal to start the game
 				scene->_index = 190;
 				remove();
@@ -233,7 +243,11 @@ void Scene109::Action1::signal() {
 		setDelay(10);
 		break;
 	case 2:
-		scene->_text.setup(BF_19840515, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->_text.setup(ESP_BF_19840515, this);
+		} else {
+			scene->_text.setup(BF_19840515, this);
+		}
 		break;
 	case 3:
 		scene->loadScene(115);
@@ -2253,7 +2267,11 @@ void Scene140::Action1::signal() {
 	case 1:
 		BF_GLOBALS._scenePalette.loadPalette(2);
 		BF_GLOBALS._scenePalette.refresh();
-		scene->_text.setup(BF_19840518, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->_text.setup(ESP_BF_19840518, this);
+		} else {
+			scene->_text.setup(BF_19840518, this);
+		}
 		break;
 	case 2:
 		scene->_object1.show();
@@ -2615,7 +2633,11 @@ void Scene160::Action2::signal() {
 		break;
 	case 22:
 		scene->_sceneBounds.set(0, 0, 320, 200);
-		scene->_text.setup(BF_11_YEARS, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->_text.setup(ESP_BF_11_YEARS, this);
+		} else {
+			scene->_text.setup(BF_11_YEARS, this);
+		}
 		break;
 	case 23:
 		BF_GLOBALS._scenePalette.loadPalette(2);
@@ -2659,7 +2681,11 @@ void Scene160::Action3::signal() {
 
 	switch (_actionIndex++) {
 	case 0:
-		scene->_text.setup(BF_3_DAYS, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->_text.setup(ESP_BF_3_DAYS, this);
+		} else {
+			scene->_text.setup(BF_3_DAYS, this);
+		}
 		break;
 	case 1: {
 		Common::Point destPos(720, 100);
@@ -2784,7 +2810,11 @@ void Scene180::postInit(SceneObjectList *OwnerList) {
 	setZoomPercents(121, 60, 125, 70);
 
 	if ((BF_GLOBALS._bookmark == bLyleStoppedBy) && (BF_GLOBALS._dayNumber == 1)) {
-		_sceneMessage.setup(THE_NEXT_DAY);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			_sceneMessage.setup(ESP_THE_NEXT_DAY);
+		} else {
+			_sceneMessage.setup(THE_NEXT_DAY);
+		}
 		_sceneMode = 6;
 		setAction(&_sceneMessage, this);
 		BF_GLOBALS._driveFromScene = 4;
@@ -2792,7 +2822,11 @@ void Scene180::postInit(SceneObjectList *OwnerList) {
 		BF_GLOBALS._mapLocationId = 4;
 	} else if (((BF_GLOBALS._bookmark == bDroppedOffLyle) && (BF_GLOBALS._dayNumber == 3)) ||
 			((BF_GLOBALS._bookmark == bDoneAtLyles) && (BF_GLOBALS._dayNumber == 4))) {
-		_sceneMessage.setup(THE_NEXT_DAY);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			_sceneMessage.setup(ESP_THE_NEXT_DAY);
+		} else {
+			_sceneMessage.setup(THE_NEXT_DAY);
+		}
 		_sceneMode = 6;
 		setAction(&_sceneMessage, this);
 	} else if (BF_GLOBALS._dayNumber == 0) {

--- a/engines/tsage/core.cpp
+++ b/engines/tsage/core.cpp
@@ -1604,22 +1604,42 @@ void SceneItem::doAction(int action) {
 	} else {
 		const char *msg = NULL;
 
-		switch ((int)action) {
-		case CURSOR_LOOK:
-			msg = LOOK_SCENE_HOTSPOT;
-			break;
-		case CURSOR_USE:
-			msg = USE_SCENE_HOTSPOT;
-			break;
-		case CURSOR_TALK:
-			msg = TALK_SCENE_HOTSPOT;
-			break;
-		case 0x1000:
-			msg = SPECIAL_SCENE_HOTSPOT;
-			break;
-		default:
-			msg = DEFAULT_SCENE_HOTSPOT;
-			break;
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			switch ((int)action) {
+			case CURSOR_LOOK:
+				msg = ESP_LOOK_SCENE_HOTSPOT;
+				break;
+			case CURSOR_USE:
+				msg = ESP_USE_SCENE_HOTSPOT;
+				break;
+			case CURSOR_TALK:
+				msg = ESP_TALK_SCENE_HOTSPOT;
+				break;
+			case 0x1000:
+				msg = ESP_SPECIAL_SCENE_HOTSPOT;
+				break;
+			default:
+				msg = ESP_DEFAULT_SCENE_HOTSPOT;
+				break;
+			}
+		} else {
+			switch ((int)action) {
+			case CURSOR_LOOK:
+				msg = LOOK_SCENE_HOTSPOT;
+				break;
+			case CURSOR_USE:
+				msg = USE_SCENE_HOTSPOT;
+				break;
+			case CURSOR_TALK:
+				msg = TALK_SCENE_HOTSPOT;
+				break;
+			case 0x1000:
+				msg = SPECIAL_SCENE_HOTSPOT;
+				break;
+			default:
+				msg = DEFAULT_SCENE_HOTSPOT;
+				break;
+			}
 		}
 
 		GUIErrorMessage(msg);
@@ -1924,19 +1944,31 @@ void SceneHotspot::doAction(int action) {
 	switch ((int)action) {
 	case CURSOR_LOOK:
 		if (g_vm->getGameID() == GType_BlueForce)
-			SceneItem::display(LOOK_SCENE_HOTSPOT);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				SceneItem::display(ESP_LOOK_SCENE_HOTSPOT);
+			} else {
+				SceneItem::display(LOOK_SCENE_HOTSPOT);
+			}
 		else
 			display(1, 0, SET_Y, 20, SET_WIDTH, 200, SET_EXT_BGCOLOR, 7, LIST_END);
 		break;
 	case CURSOR_USE:
 		if (g_vm->getGameID() == GType_BlueForce)
-			SceneItem::display(USE_SCENE_HOTSPOT);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				SceneItem::display(ESP_USE_SCENE_HOTSPOT);
+			} else {
+				SceneItem::display(USE_SCENE_HOTSPOT);
+			}
 		else
 			display(1, 5, SET_Y, 20, SET_WIDTH, 200, SET_EXT_BGCOLOR, 7, LIST_END);
 		break;
 	case CURSOR_TALK:
 		if (g_vm->getGameID() == GType_BlueForce)
-			SceneItem::display(TALK_SCENE_HOTSPOT);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				SceneItem::display(ESP_TALK_SCENE_HOTSPOT);
+			} else {
+				SceneItem::display(TALK_SCENE_HOTSPOT);
+			}
 		else
 			display(1, 15, SET_Y, 20, SET_WIDTH, 200, SET_EXT_BGCOLOR, 7, LIST_END);
 		break;
@@ -1944,7 +1976,11 @@ void SceneHotspot::doAction(int action) {
 		break;
 	default:
 		if (g_vm->getGameID() == GType_BlueForce)
-			SceneItem::display(DEFAULT_SCENE_HOTSPOT);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				SceneItem::display(ESP_DEFAULT_SCENE_HOTSPOT);
+			} else {
+				SceneItem::display(DEFAULT_SCENE_HOTSPOT);
+			}
 		else
 			display(2, action, SET_Y, 20, SET_WIDTH, 200, SET_EXT_BGCOLOR, 7, LIST_END);
 		break;
@@ -4477,8 +4513,13 @@ void SceneHandler::dispatch() {
 		Common::Error err = g_saver->save(saveSlot, _saveName);
 		// FIXME: Make use of the description string in err to enhance
 		// the error reported to the user.
-		if (err.getCode() != Common::kNoError)
-			GUIErrorMessage(SAVE_ERROR_MSG);
+		if (err.getCode() != Common::kNoError) {
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				GUIErrorMessage(ESP_SAVE_ERROR_MSG);
+			} else {
+				GUIErrorMessage(SAVE_ERROR_MSG);
+			}
+		}
 	}
 	if (_loadGameSlot != -1) {
 		int priorSceneBeforeLoad = GLOBALS._sceneManager._previousScene;

--- a/engines/tsage/detection_tables.h
+++ b/engines/tsage/detection_tables.h
@@ -142,20 +142,19 @@ static const tSageGameDescription gameDescriptions[] = {
 		GF_CD | GF_ALT_REGIONS
 	},
 
-	// Blue Force Spanish doesn't yet work
-	// Blue Force Spanish CD
+	// Blue Force Spanish Floppy and CD use the same files
 	{
 		{
 			"blueforce",
-			_s("Spanish CD version is not yet supported"),
+			"",
 			AD_ENTRY1s("blue.rlb", "5b2b35c51b62e82d82b0791540bfae2d", 10082565),
 			Common::ES_ESP,
 			Common::kPlatformDOS,
-			ADGF_CD | ADGF_UNSUPPORTED,
+			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSPEECH, GUIO_NOSFX)
 		},
 		GType_BlueForce,
-		GF_CD | GF_ALT_REGIONS
+		GF_FLOPPY | GF_ALT_REGIONS
 	},
 
 	// Return to Ringworld

--- a/engines/tsage/metaengine.cpp
+++ b/engines/tsage/metaengine.cpp
@@ -45,6 +45,10 @@ uint32 TSageEngine::getFeatures() const {
 	return _gameDescription->features;
 }
 
+Common::Language TSageEngine::getLanguage() const {
+	return _gameDescription->desc.language;
+}
+
 Common::String TSageEngine::getPrimaryFilename() const {
 	return Common::String(_gameDescription->desc.filesDescriptions[0].fileName);
 }

--- a/engines/tsage/scenes.cpp
+++ b/engines/tsage/scenes.cpp
@@ -566,7 +566,13 @@ void Scene::setZoomPercents(int yStart, int minPercent, int yEnd, int maxPercent
 /*--------------------------------------------------------------------------*/
 
 void Game::restartGame() {
-	if (MessageDialog::show(RESTART_MSG, CANCEL_BTN_STRING, RESTART_BTN_STRING) == 1)
+	int rc;
+	if (g_vm->getLanguage() == Common::ES_ESP) {
+		rc = MessageDialog::show(ESP_RESTART_MSG, ESP_CANCEL_BTN_STRING, ESP_RESTART_BTN_STRING);
+	} else {
+		rc = MessageDialog::show(RESTART_MSG, CANCEL_BTN_STRING, RESTART_BTN_STRING);
+	}
+	if (rc == 1)
 		g_globals->_game->restart();
 }
 
@@ -589,7 +595,13 @@ void Game::restoreGame() {
 }
 
 void Game::quitGame() {
-	if (MessageDialog::show(QUIT_CONFIRM_MSG, CANCEL_BTN_STRING, QUIT_BTN_STRING) == 1)
+	int rc;
+	if (g_vm->getLanguage() == Common::ES_ESP) {
+		rc = MessageDialog::show(ESP_QUIT_CONFIRM_MSG, ESP_CANCEL_BTN_STRING, ESP_QUIT_BTN_STRING);
+	} else {
+		rc = MessageDialog::show(QUIT_CONFIRM_MSG, CANCEL_BTN_STRING, QUIT_BTN_STRING);
+	}
+	if (rc == 1)
 		g_vm->quitGame();
 }
 

--- a/engines/tsage/staticres.cpp
+++ b/engines/tsage/staticres.cpp
@@ -88,6 +88,25 @@ char const *const RESUME_BTN_STRING = " Resume \rplay";
 char const *const LOOK_BTN_STRING = "Look";
 char const *const PICK_BTN_STRING = "Pick";
 
+// Spanish version
+char const *const ESP_LOOK_SCENE_HOTSPOT = "No ves nada especial.";
+char const *const ESP_USE_SCENE_HOTSPOT = "Con eso no conseguir\240s nada.";
+char const *const ESP_TALK_SCENE_HOTSPOT = "Yak, yak.";
+char const *const ESP_SPECIAL_SCENE_HOTSPOT = "Es una forma original de usar eso.";
+char const *const ESP_DEFAULT_SCENE_HOTSPOT = "No ves nada especial.";
+char const *const ESP_SAVE_ERROR_MSG = "El juego no ha podido ser archivado. Por favor, no intente recuperar este juego!";
+
+char const *const ESP_QUIT_CONFIRM_MSG = "Quieres dejar de jugar?";
+char const *const ESP_RESTART_MSG = "Deseas volver a comenzar el juego?";
+char const *const ESP_GAME_PAUSED_MSG = "Juego en pausa.";
+char const *const ESP_OK_BTN_STRING = " Ok ";
+char const *const ESP_CANCEL_BTN_STRING = "Cancelar";
+char const *const ESP_QUIT_BTN_STRING = " Salir ";
+char const *const ESP_RESTART_BTN_STRING = "Reiniciar";
+char const *const ESP_SAVE_BTN_STRING = "Guardar";
+char const *const ESP_RESTORE_BTN_STRING = "Recuperar";
+char const *const ESP_SOUND_BTN_STRING = "Sonido";
+char const *const ESP_RESUME_BTN_STRING = " Seguir \rjugando";
 
 namespace Ringworld {
 
@@ -178,6 +197,34 @@ char const *const SCENE570_WACKYDATA = "WACKYDATA";
 
 // Scene 180 messages
 char const *const THE_NEXT_DAY = "The Next Day";
+
+// Spanish version
+// Dialog resources
+char const *const ESP_HELP_MSG = "Blue Force\x14\rScummVM Version\r\r\
+Funciones del Teclado...\rF2 - Sonido\rF3 - Salir del Juego\r\
+F4 - Recomenzar\rF5 - Guardar\rF7 - Recuperar\rF10 - Pausa";
+char const *const ESP_WATCH_INTRO_MSG = "Quieres ver la introducci\242n?";
+char const *const ESP_START_PLAY_BTN_STRING = " Jugar ";
+char const *const ESP_INTRODUCTION_BTN_STRING = " Ver ";
+char const *const ESP_OPTIONS_MSG = "Opciones...";
+
+// Blue Force general messages
+char const *const ESP_BF_ALL_RIGHTS_RESERVED = "Todos los derechos reservados";
+char const *const ESP_BF_19840518 = "18 de Mayo de 1984";
+char const *const ESP_BF_19840515 = "15 de Mayo de 1984";
+char const *const ESP_BF_3_DAYS = "Tres d\241as despu\202s";
+char const *const ESP_BF_11_YEARS = "Once a\244os despu\202s.";
+
+// Scene 50 hotspots
+char const *const ESP_GRANDMA_FRANNIE = "La abuela Frannie";
+char const *const ESP_POLICE_DEPARTMENT = "Departamento de Polic\241a";
+char const *const ESP_TONYS_BAR = "El Bar de Tony";
+char const *const ESP_CHILD_PROTECTIVE_SERVICES = "Servicio de Protecci\242n de Menores";
+char const *const ESP_CITY_HALL_JAIL = "Ayuntamiento & C\240rcel";
+
+// Scene 180 messages
+char const *const ESP_THE_NEXT_DAY = "Al d\241a siguiente";
+
 
 } // End of namespace BlueForce
 

--- a/engines/tsage/staticres.h
+++ b/engines/tsage/staticres.h
@@ -56,6 +56,27 @@ extern char const *const LOOK_BTN_STRING;
 extern char const *const PICK_BTN_STRING;
 extern char const *const INV_EMPTY_MSG;
 
+// Spanish version
+extern char const *const ESP_LOOK_SCENE_HOTSPOT;
+extern char const *const ESP_USE_SCENE_HOTSPOT;
+extern char const *const ESP_TALK_SCENE_HOTSPOT;
+extern char const *const ESP_SPECIAL_SCENE_HOTSPOT;
+extern char const *const ESP_DEFAULT_SCENE_HOTSPOT;
+extern char const *const ESP_SAVE_ERROR_MSG;
+
+// Dialogs
+extern char const *const ESP_QUIT_CONFIRM_MSG;
+extern char const *const ESP_RESTART_MSG;
+extern char const *const ESP_GAME_PAUSED_MSG;
+extern char const *const ESP_OK_BTN_STRING;
+extern char const *const ESP_CANCEL_BTN_STRING;
+extern char const *const ESP_QUIT_BTN_STRING;
+extern char const *const ESP_RESTART_BTN_STRING;
+extern char const *const ESP_SAVE_BTN_STRING;
+extern char const *const ESP_RESTORE_BTN_STRING;
+extern char const *const ESP_SOUND_BTN_STRING;
+extern char const *const ESP_RESUME_BTN_STRING;
+
 namespace Ringworld {
 
 // Dialog resources
@@ -141,6 +162,31 @@ extern char const *const RADIO_BTN_LIST[8];
 
 // Scene 180 message
 extern char const *const THE_NEXT_DAY;
+
+// Spanish version
+// Dialog resources
+extern char const *const ESP_HELP_MSG;
+extern char const *const ESP_WATCH_INTRO_MSG;
+extern char const *const ESP_START_PLAY_BTN_STRING;
+extern char const *const ESP_INTRODUCTION_BTN_STRING;
+extern char const *const ESP_OPTIONS_MSG;
+
+// Blue Force messages
+extern char const *const ESP_BF_ALL_RIGHTS_RESERVED;
+extern char const *const ESP_BF_19840518;
+extern char const *const ESP_BF_19840515;
+extern char const *const ESP_BF_3_DAYS;
+extern char const *const ESP_BF_11_YEARS;
+
+// Scene 50 tooltips
+extern char const *const ESP_GRANDMA_FRANNIE;
+extern char const *const ESP_POLICE_DEPARTMENT;
+extern char const *const ESP_TONYS_BAR;
+extern char const *const ESP_CHILD_PROTECTIVE_SERVICES;
+extern char const *const ESP_CITY_HALL_JAIL;
+
+// Scene 180 message
+extern char const *const ESP_THE_NEXT_DAY;
 
 } // End of namespace BlueForce
 

--- a/engines/tsage/tsage.h
+++ b/engines/tsage/tsage.h
@@ -57,6 +57,7 @@ public:
 	const char *getGameId() const;
 	uint32 getGameID() const;
 	uint32 getFeatures() const;
+	Common::Language getLanguage() const;
 	Common::String getPrimaryFilename() const;
 
 	virtual Common::Error init();


### PR DESCRIPTION
This change has two parts

- make the ScummVM TSAGE engine not crash with the Spanish version of Blue Force.
- translate all remaining bits (taken from Spanish BLUE.EXE).

More info provided in the individual commits.