### PR TITLE
TSAGE: Include and handle Ringworld Spanish messages

### DIFF
--- a/engines/tsage/blue_force/blueforce_dialogs.cpp
+++ b/engines/tsage/blue_force/blueforce_dialogs.cpp
@@ -467,7 +467,7 @@ void OptionsDialog::show() {
 		// Quit game
 		int rc;
 		if (g_vm->getLanguage() == Common::ES_ESP) {
-			rc = MessageDialog::show(ESP_QUIT_CONFIRM_MSG, ESP_CANCEL_BTN_STRING, ESP_QUIT_BTN_STRING);
+			rc = MessageDialog::show(ESP_BF_QUIT_CONFIRM_MSG, ESP_CANCEL_BTN_STRING, ESP_BF_QUIT_BTN_STRING);
 		} else {
 			rc = MessageDialog::show(QUIT_CONFIRM_MSG, CANCEL_BTN_STRING, QUIT_BTN_STRING);
 		}
@@ -485,11 +485,11 @@ OptionsDialog::OptionsDialog() {
 	if (g_vm->getLanguage() == Common::ES_ESP) {
 		_gfxMessage.set(ESP_OPTIONS_MSG, 140, ALIGN_LEFT);
 		_btnRestore.setText(ESP_RESTORE_BTN_STRING);
-		_btnSave.setText(ESP_SAVE_BTN_STRING);
-		_btnRestart.setText(ESP_RESTART_BTN_STRING);
-		_btnQuit.setText(ESP_QUIT_BTN_STRING);
+		_btnSave.setText(ESP_BF_SAVE_BTN_STRING);
+		_btnRestart.setText(ESP_BF_RESTART_BTN_STRING);
+		_btnQuit.setText(ESP_BF_QUIT_BTN_STRING);
 		_btnSound.setText(ESP_SOUND_BTN_STRING);
-		_btnResume.setText(ESP_RESUME_BTN_STRING);
+		_btnResume.setText(ESP_BF_RESUME_BTN_STRING);
 	} else {
 		_gfxMessage.set(OPTIONS_MSG, 140, ALIGN_LEFT);
 		_btnRestore.setText(RESTORE_BTN_STRING);

--- a/engines/tsage/blue_force/blueforce_logic.cpp
+++ b/engines/tsage/blue_force/blueforce_logic.cpp
@@ -330,7 +330,7 @@ void BlueForceGame::processEvent(Event &event) {
 			// F10 - Pause
 			GfxDialog::setPalette();
 			if (g_vm->getLanguage() == Common::ES_ESP) {
-				MessageDialog::show(ESP_GAME_PAUSED_MSG, ESP_OK_BTN_STRING);
+				MessageDialog::show(ESP_BF_GAME_PAUSED_MSG, ESP_OK_BTN_STRING);
 			} else {
 				MessageDialog::show(GAME_PAUSED_MSG, OK_BTN_STRING);
 			}

--- a/engines/tsage/ringworld/ringworld_dialogs.cpp
+++ b/engines/tsage/ringworld/ringworld_dialogs.cpp
@@ -224,7 +224,13 @@ void OptionsDialog::show() {
 
 	if (btn == &dlg->_btnQuit) {
 		// Quit game
-		if (MessageDialog::show(QUIT_CONFIRM_MSG, CANCEL_BTN_STRING, QUIT_BTN_STRING) == 1) {
+		int rc;
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			rc = MessageDialog::show(ESP_RW_QUIT_CONFIRM_1_MSG, ESP_CANCEL_BTN_STRING, ESP_RW_QUIT_BTN_STRING);
+		} else {
+			rc = MessageDialog::show(QUIT_CONFIRM_MSG, CANCEL_BTN_STRING, QUIT_BTN_STRING);
+		}
+		if (rc == 1) {
 			g_vm->quitGame();
 		}
 	} else if (btn == &dlg->_btnRestart) {
@@ -247,13 +253,23 @@ void OptionsDialog::show() {
 
 OptionsDialog::OptionsDialog() {
 	// Set the element text
-	_gfxMessage.set(OPTIONS_MSG, 140, ALIGN_LEFT);
-	_btnRestore.setText(RESTORE_BTN_STRING);
-	_btnSave.setText(SAVE_BTN_STRING);
-	_btnRestart.setText(RESTART_BTN_STRING);
-	_btnQuit.setText(QUIT_BTN_STRING);
-	_btnSound.setText(SOUND_BTN_STRING);
-	_btnResume.setText(RESUME_BTN_STRING);
+	if (g_vm->getLanguage() == Common::ES_ESP) {
+		_gfxMessage.set(ESP_OPTIONS_MSG, 140, ALIGN_LEFT);
+		_btnRestore.setText(ESP_RESTORE_BTN_STRING);
+		_btnSave.setText(ESP_RW_SAVE_BTN_STRING);
+		_btnRestart.setText(ESP_RW_RESTART_BTN_1_STRING);
+		_btnQuit.setText(ESP_RW_QUIT_BTN_STRING);
+		_btnSound.setText(ESP_SOUND_BTN_STRING);
+		_btnResume.setText(ESP_RW_RESUME_BTN_STRING);
+	} else {
+		_gfxMessage.set(OPTIONS_MSG, 140, ALIGN_LEFT);
+		_btnRestore.setText(RESTORE_BTN_STRING);
+		_btnSave.setText(SAVE_BTN_STRING);
+		_btnRestart.setText(RESTART_BTN_STRING);
+		_btnQuit.setText(QUIT_BTN_STRING);
+		_btnSound.setText(SOUND_BTN_STRING);
+		_btnResume.setText(RESUME_BTN_STRING);
+	}
 
 	// Set position of the elements
 	_gfxMessage._bounds.moveTo(0, 1);
@@ -303,7 +319,11 @@ void InventoryDialog::show() {
 	}
 
 	if (itemCount == 0) {
-		MessageDialog::show(INV_EMPTY_MSG, OK_BTN_STRING);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			MessageDialog::show(ESP_INV_EMPTY_MSG, ESP_OK_BTN_STRING);
+		} else {
+			MessageDialog::show(INV_EMPTY_MSG, OK_BTN_STRING);
+		}
 		return;
 	}
 
@@ -363,9 +383,14 @@ InventoryDialog::InventoryDialog() {
 
 	// Set up the buttons
 	pt.y += imgHeight + 2;
-	_btnOk.setText(OK_BTN_STRING);
+	if (g_vm->getLanguage() == Common::ES_ESP) {
+		_btnOk.setText(ESP_OK_BTN_STRING);
+		_btnLook.setText(ESP_LOOK_BTN_STRING);
+	} else {
+		_btnOk.setText(OK_BTN_STRING);
+		_btnLook.setText(LOOK_BTN_STRING);
+	}
 	_btnOk._bounds.moveTo((imgWidth + 2) * cellsSize - _btnOk._bounds.width(), pt.y);
-	_btnLook.setText(LOOK_BTN_STRING);
 	_btnLook._bounds.moveTo(_btnOk._bounds.left - _btnLook._bounds.width() - 2, _btnOk._bounds.top);
 	addElements(&_btnLook, &_btnOk, NULL);
 
@@ -423,14 +448,26 @@ void InventoryDialog::execute() {
 			break;
 		} else if (hiliteObj == &_btnLook) {
 			// Look button clicked
-			if (_btnLook._message == LOOK_BTN_STRING) {
-				_btnLook._message = PICK_BTN_STRING;
-				lookFlag = 1;
-				g_globals->_events.setCursor(CURSOR_LOOK);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				if (_btnLook._message == ESP_LOOK_BTN_STRING) {
+					_btnLook._message = ESP_PICK_BTN_STRING;
+					lookFlag = 1;
+					g_globals->_events.setCursor(CURSOR_LOOK);
+				} else {
+					_btnLook._message = ESP_LOOK_BTN_STRING;
+					lookFlag = 0;
+					g_globals->_events.setCursor(CURSOR_WALK);
+				}
 			} else {
-				_btnLook._message = LOOK_BTN_STRING;
-				lookFlag = 0;
-				g_globals->_events.setCursor(CURSOR_WALK);
+				if (_btnLook._message == LOOK_BTN_STRING) {
+					_btnLook._message = PICK_BTN_STRING;
+					lookFlag = 1;
+					g_globals->_events.setCursor(CURSOR_LOOK);
+				} else {
+					_btnLook._message = LOOK_BTN_STRING;
+					lookFlag = 0;
+					g_globals->_events.setCursor(CURSOR_WALK);
+				}
 			}
 
 			hiliteObj->draw();

--- a/engines/tsage/ringworld/ringworld_logic.cpp
+++ b/engines/tsage/ringworld/ringworld_logic.cpp
@@ -351,39 +351,40 @@ void SceneArea::synchronize(Serializer &s) {
 /*--------------------------------------------------------------------------*/
 
 RingworldInvObjectList::RingworldInvObjectList() :
-		_stunner(2280, 1, 2, OBJECT_STUNNER, "This is your stunner."),
-		_scanner(1, 1, 3, OBJECT_SCANNER, "A combination scanner comm unit."),
-		_stasisBox(5200, 1, 4, OBJECT_STASIS_BOX, "A stasis box."),
-		_infoDisk(40, 1, 1, OBJECT_INFODISK, "The infodisk you took from the assassin."),
-		_stasisNegator(0, 2, 2, OBJECT_STASIS_NEGATOR, "The stasis field negator."),
-		_keyDevice(4250, 1, 6, OBJECT_KEY_DEVICE, "A magnetic key device."),
-		_medkit(2280, 1, 7, OBJECT_MEDKIT,  "Your medkit."),
-		_ladder(4100, 1, 8, OBJECT_LADDER, "The chief's ladder."),
-		_rope(4150, 1, 9, OBJECT_ROPE, "The chief's rope."),
-		_key(7700, 1, 11, OBJECT_KEY, "A key."),
-		_translator(7700, 1, 13, OBJECT_TRANSLATOR,  "The dolphin translator box."),
-		_ale(2150, 1, 10, OBJECT_ALE, "A bottle of ale."),
-		_paper(7700, 1, 12, OBJECT_PAPER, "A slip of paper with the numbers 2,4, and 3 written on it."),
-		_waldos(0, 1, 14, OBJECT_WALDOS, "A pair of waldos from the ruined probe."),
-		_stasisBox2(8100, 1, 4, OBJECT_STASIS_BOX2, "A stasis box."),
-		_ring(8100, 2, 5, OBJECT_RING, "This is a signet ring sent to you by Louis Wu."),
-		_cloak(9850, 2, 6, OBJECT_CLOAK, "A fine silk cloak."),
-		_tunic(9450, 2, 7, OBJECT_TUNIC, "The patriarch's soiled tunic."),
-		_candle(9500, 2, 8, OBJECT_CANDLE, "A tallow candle."),
-		_straw(9400, 2, 9, OBJECT_STRAW, "Clean, dry straw."),
-		_scimitar(9850, 1, 18, OBJECT_SCIMITAR, "A scimitar from the Patriarch's closet."),
-		_sword(9850, 1, 17, OBJECT_SWORD, "A short sword from the Patriarch's closet."),
-		_helmet(9500, 2, 4, OBJECT_HELMET, "Some type of helmet."),
-		_items(4300, 2, 10, OBJECT_ITEMS, "Two interesting items from the Tnuctipun vessel."),
-		_concentrator(4300, 2, 11, OBJECT_CONCENTRATOR, "The Tnuctipun anti-matter concentrator contained in a stasis field."),
-		_nullifier(5200, 2, 12, OBJECT_NULLIFIER, "A purported neural wave nullifier."),
-		_peg(4045, 2, 16, OBJECT_PEG, "A peg with a symbol."),
-		_vial(5100, 2, 17, OBJECT_VIAL, "A vial of the bat creatures anti-pheromone drug."),
-		_jacket(9850, 3, 1, OBJECT_JACKET, "A natty padded jacket."),
-		_tunic2(9850, 3, 2, OBJECT_TUNIC2, "A very hairy tunic."),
-		_bone(5300, 3, 5, OBJECT_BONE, "A very sharp bone."),
-		_jar(7700, 3, 4, OBJECT_JAR, "An jar filled with a green substance."),
-		_emptyJar(7700, 3, 3, OBJECT_EMPTY_JAR, "An empty jar.") {
+		_ESP(g_vm->getLanguage() == Common::ES_ESP),
+		_stunner(2280, 1, 2, OBJECT_STUNNER, _ESP ? "Tu paralizador." : "This is your stunner."),
+		_scanner(1, 1, 3, OBJECT_SCANNER, _ESP ? "Una unidad combinada de esc\240ner y comunicaciones." : "A combination scanner comm unit."),
+		_stasisBox(5200, 1, 4, OBJECT_STASIS_BOX, _ESP ? "Una caja est\240sica." : "A stasis box."),
+		_infoDisk(40, 1, 1, OBJECT_INFODISK, _ESP ? "El infodisk que le cogiste al asesino." : "The infodisk you took from the assassin."),
+		_stasisNegator(0, 2, 2, OBJECT_STASIS_NEGATOR, _ESP ? "El negador de campos est\240sicos." : "The stasis field negator."),
+		_keyDevice(4250, 1, 6, OBJECT_KEY_DEVICE, _ESP ? "Una llave magn\202tica." : "A magnetic key device."),
+		_medkit(2280, 1, 7, OBJECT_MEDKIT, _ESP ? "Tu botiqu\241n." : "Your medkit."),
+		_ladder(4100, 1, 8, OBJECT_LADDER, _ESP ? "La escalera del jefe." : "The chief's ladder."),
+		_rope(4150, 1, 9, OBJECT_ROPE, _ESP ? "La cuerda del jefe." : "The chief's rope."),
+		_key(7700, 1, 11, OBJECT_KEY, _ESP ? "Una llave." : "A key."),
+		_translator(7700, 1, 13, OBJECT_TRANSLATOR,  _ESP ? "La caja traductora delfiniana." : "The dolphin translator box."),
+		_ale(2150, 1, 10, OBJECT_ALE, _ESP ? "Una botella de cerveza." : "A bottle of ale."),
+		_paper(7700, 1, 12, OBJECT_PAPER, _ESP ? "Un trozo de papel con los n\243meros 2,4, y 3 escritos en \202l." : "A slip of paper with the numbers 2,4, and 3 written on it."),
+		_waldos(0, 1, 14, OBJECT_WALDOS, _ESP ? "Un par de brazos de la sonda averiada." : "A pair of waldos from the ruined probe."),
+		_stasisBox2(8100, 1, 4, OBJECT_STASIS_BOX2, _ESP ? "Una caja est\240sica." : "A stasis box."),
+		_ring(8100, 2, 5, OBJECT_RING, _ESP ? "El anillo que te envi\242 Louis Wu." : "This is a signet ring sent to you by Louis Wu."),
+		_cloak(9850, 2, 6, OBJECT_CLOAK, _ESP ? "Una t\243nica de seda fina." : "A fine silk cloak."),
+		_tunic(9450, 2, 7, OBJECT_TUNIC, _ESP ? "La t\243nica manchada del patriarca." : "The patriarch's soiled tunic."),
+		_candle(9500, 2, 8, OBJECT_CANDLE, _ESP ? "Una vela de sebo." : "A tallow candle."),
+		_straw(9400, 2, 9, OBJECT_STRAW, _ESP ? "Paja limpia y seca." : "Clean, dry straw."),
+		_scimitar(9850, 1, 18, OBJECT_SCIMITAR, _ESP ? "La cimitarra del armario del Patriarca." : "A scimitar from the Patriarch's closet."),
+		_sword(9850, 1, 17, OBJECT_SWORD, _ESP ? "La espada corta del armario del Patriarca." : "A short sword from the Patriarch's closet."),
+		_helmet(9500, 2, 4, OBJECT_HELMET, _ESP ? "Un extra\244o yelmo." : "Some type of helmet."),
+		_items(4300, 2, 10, OBJECT_ITEMS, _ESP ? "Dos interesantes objetos de la nave Tnuctipun." : "Two interesting items from the Tnuctipun vessel."),
+		_concentrator(4300, 2, 11, OBJECT_CONCENTRATOR, _ESP ? "El concentrador antimateria Tnuctipun contenido en un campo est\240sico." : "The Tnuctipun anti-matter concentrator contained in a stasis field."),
+		_nullifier(5200, 2, 12, OBJECT_NULLIFIER, _ESP ? "Un anulador de ondas neuronales." : "A purported neural wave nullifier."),
+		_peg(4045, 2, 16, OBJECT_PEG, _ESP ? "Una clavija con un s\241mbolo." : "A peg with a symbol."),
+		_vial(5100, 2, 17, OBJECT_VIAL, _ESP ? "Un frasco con la droga antiferomonas de los murci\202lagos." : "A vial of the bat creatures anti-pheromone drug."),
+		_jacket(9850, 3, 1, OBJECT_JACKET, _ESP ? "Una elegante chaqueta." : "A natty padded jacket."),
+		_tunic2(9850, 3, 2, OBJECT_TUNIC2, _ESP ? "Una t\243nica muy ligera." : "A very hairy tunic."),
+		_bone(5300, 3, 5, OBJECT_BONE, _ESP ? "Un hueso muy afilado." : "A very sharp bone."),
+		_jar(7700, 3, 4, OBJECT_JAR, _ESP ? "Un frasco lleno de una sustancia verde." : "An jar filled with a green substance."),
+		_emptyJar(7700, 3, 3, OBJECT_EMPTY_JAR, _ESP ? "Un frasco vac\241o." : "An empty jar.") {
 
 	// Add the items to the list
 	_itemList.push_back(&_stunner);
@@ -520,7 +521,13 @@ void RingworldGame::endGame(int resNum, int lineNum) {
 
 	if (!savesExist) {
 		// No savegames exist, so prompt the user to restart or quit
-		if (MessageDialog::show(msg, QUIT_BTN_STRING, RESTART_BTN_STRING) == 0)
+		int rc;
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			rc = MessageDialog::show(msg, ESP_RW_QUIT_BTN_STRING, ESP_RW_RESTART_BTN_2_STRING);
+		} else {
+			rc = MessageDialog::show(msg, QUIT_BTN_STRING, RESTART_BTN_STRING);
+		}
+		if (rc == 0)
 			g_vm->quitGame();
 		else
 			restart();
@@ -530,12 +537,20 @@ void RingworldGame::endGame(int resNum, int lineNum) {
 		do {
 			if (g_vm->shouldQuit()) {
 				breakFlag = true;
-			} else if (MessageDialog::show(msg, RESTART_BTN_STRING, RESTORE_BTN_STRING) == 0) {
-				restart();
-				breakFlag = true;
 			} else {
-				handleSaveLoad(false, g_globals->_sceneHandler->_loadGameSlot, g_globals->_sceneHandler->_saveName);
-				breakFlag = g_globals->_sceneHandler->_loadGameSlot >= 0;
+				int rc;
+				if (g_vm->getLanguage() == Common::ES_ESP) {
+					rc = MessageDialog::show(msg, ESP_RW_RESTART_BTN_2_STRING, ESP_RESTORE_BTN_STRING);
+				} else {
+					rc = MessageDialog::show(msg, RESTART_BTN_STRING, RESTORE_BTN_STRING);
+				}
+				if (rc== 0) {
+					restart();
+					breakFlag = true;
+				} else {
+					handleSaveLoad(false, g_globals->_sceneHandler->_loadGameSlot, g_globals->_sceneHandler->_saveName);
+					breakFlag = g_globals->_sceneHandler->_loadGameSlot >= 0;
+				}
 			}
 		} while (!breakFlag);
 	}
@@ -548,7 +563,11 @@ void RingworldGame::processEvent(Event &event) {
 		switch (event.kbd.keycode) {
 		case Common::KEYCODE_F1:
 			// F1 - Help
-			MessageDialog::show(HELP_MSG, OK_BTN_STRING);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				MessageDialog::show(ESP_HELP_MSG, ESP_OK_BTN_STRING);
+			} else {
+				MessageDialog::show(HELP_MSG, OK_BTN_STRING);
+			}
 			break;
 
 		case Common::KEYCODE_F2:
@@ -577,7 +596,11 @@ void RingworldGame::processEvent(Event &event) {
 		case Common::KEYCODE_F10:
 			// F10 - Pause
 			GfxDialog::setPalette();
-			MessageDialog::show(GAME_PAUSED_MSG, OK_BTN_STRING);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				MessageDialog::show(ESP_RW_GAME_PAUSED_MSG, ESP_OK_BTN_2_STRING);
+			} else {
+				MessageDialog::show(GAME_PAUSED_MSG, OK_BTN_STRING);
+			}
 			g_globals->_events.setCursorFromFlag();
 			break;
 

--- a/engines/tsage/ringworld/ringworld_logic.h
+++ b/engines/tsage/ringworld/ringworld_logic.h
@@ -104,6 +104,8 @@ public:
 /*--------------------------------------------------------------------------*/
 
 class RingworldInvObjectList : public InvObjectList {
+private:
+	bool _ESP;
 public:
 	InvObject _stunner;
 	InvObject _scanner;

--- a/engines/tsage/ringworld/ringworld_scenes1.cpp
+++ b/engines/tsage/ringworld/ringworld_scenes1.cpp
@@ -2478,7 +2478,11 @@ void Scene60::signal() {
 			g_globals->_player._uiEnabled = true;
 			g_globals->_events.setCursor(CURSOR_USE);
 
-			_gfxButton.setText(EXIT_MSG);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				_gfxButton.setText(ESP_EXIT_MSG);
+			} else {
+				_gfxButton.setText(EXIT_MSG);
+			}
 			_gfxButton._bounds.center(160, 193);
 			_gfxButton.draw();
 			_gfxButton._bounds.expandPanes();
@@ -2911,10 +2915,18 @@ void Scene6100::Action1::signal() {
 
 	switch (_actionIndex++) {
 	case 0:
-		scene->showMessage(SCENE6100_CAREFUL, 13, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_CAREFUL, 13, this);
+		} else {
+			scene->showMessage(SCENE6100_CAREFUL, 13, this);
+		}
 		break;
 	case 1:
-		scene->showMessage(SCENE6100_TOUGHER, 35, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_TOUGHER, 35, this);
+		} else {
+			scene->showMessage(SCENE6100_TOUGHER, 35, this);
+		}
 		break;
 	case 2:
 		scene->showMessage(NULL, 0, NULL);
@@ -2930,10 +2942,18 @@ void Scene6100::Action2::signal() {
 
 	switch (_actionIndex++) {
 	case 0:
-		scene->showMessage(SCENE6100_ONE_MORE_HIT, 13, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_ONE_MORE_HIT, 13, this);
+		} else {
+			scene->showMessage(SCENE6100_ONE_MORE_HIT, 13, this);
+		}
 		break;
 	case 1:
-		scene->showMessage(SCENE6100_DOING_BEST, 35, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_DOING_BEST, 35, this);
+		} else {
+			scene->showMessage(SCENE6100_DOING_BEST, 35, this);
+		}
 		break;
 	case 2:
 		scene->showMessage(NULL, 0, NULL);
@@ -2970,7 +2990,11 @@ void Scene6100::Action3::signal() {
 		scene->_stripManager.start(8120, this);
 		break;
 	case 2:
-		scene->showMessage(SCENE6100_REPAIR, 7, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_REPAIR, 7, this);
+		} else {
+			scene->showMessage(SCENE6100_REPAIR, 7, this);
+		}
 		break;
 	case 3:
 		scene->showMessage(NULL, 0, NULL);
@@ -2993,10 +3017,18 @@ void Scene6100::Action4::signal() {
 
 	switch (_actionIndex++) {
 	case 0:
-		scene->showMessage(SCENE6100_ROCKY_AREA, 13, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_ROCKY_AREA, 13, this);
+		} else {
+			scene->showMessage(SCENE6100_ROCKY_AREA, 13, this);
+		}
 		break;
 	case 1:
-		scene->showMessage(SCENE6100_REPLY, 35, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_REPLY, 35, this);
+		} else {
+			scene->showMessage(SCENE6100_REPLY, 35, this);
+		}
 		break;
 	case 2:
 		scene->showMessage(NULL, 0, NULL);
@@ -3123,7 +3155,11 @@ void Scene6100::GetBoxAction::signal() {
 		break;
 	}
 	case 1: {
-		scene->showMessage(SCENE6100_TAKE_CONTROLS, 35, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_TAKE_CONTROLS, 35, this);
+		} else {
+			scene->showMessage(SCENE6100_TAKE_CONTROLS, 35, this);
+		}
 		g_globals->_scenePalette.clearListeners();
 
 		Common::Point pt(scene->_rocks._position.x, scene->_rocks._position.y - 10);
@@ -3133,13 +3169,25 @@ void Scene6100::GetBoxAction::signal() {
 	}
 	case 2:
 		scene->_probe._percent = 4;
-		scene->showMessage(SCENE6100_SURPRISE, 13, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_SURPRISE, 13, this);
+		} else {
+			scene->showMessage(SCENE6100_SURPRISE, 13, this);
+		}
 		break;
 	case 3:
-		scene->showMessage(SCENE6100_SWEAT, 35, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_SWEAT, 35, this);
+		} else {
+			scene->showMessage(SCENE6100_SWEAT, 35, this);
+		}
 		break;
 	case 4:
-		scene->showMessage(SCENE6100_VERY_WELL, 13, this);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			scene->showMessage(ESP_SCENE6100_VERY_WELL, 13, this);
+		} else {
+			scene->showMessage(SCENE6100_VERY_WELL, 13, this);
+		}
 		break;
 	case 5:
 		scene->showMessage(NULL, 0, NULL);

--- a/engines/tsage/ringworld/ringworld_scenes10.cpp
+++ b/engines/tsage/ringworld/ringworld_scenes10.cpp
@@ -1243,7 +1243,11 @@ void Scene9700::signal() {
 		// fall through
 	case 9701:
 	case 9702:
-		_gfxButton1.setText(EXIT_MSG);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			_gfxButton1.setText(ESP_EXIT_MSG);
+		} else {
+			_gfxButton1.setText(EXIT_MSG);
+		}
 		_gfxButton1._bounds.center(50, 190);
 		_gfxButton1.draw();
 		_gfxButton1._bounds.expandPanes();

--- a/engines/tsage/ringworld/ringworld_scenes2.cpp
+++ b/engines/tsage/ringworld/ringworld_scenes2.cpp
@@ -128,7 +128,13 @@ void Scene1000::Action3::signal() {
 			// Prompt user for whether to start play or watch introduction
 			g_globals->_player.enableControl();
 
-			if (MessageDialog::show2(WATCH_INTRO_MSG, START_PLAY_BTN_STRING, INTRODUCTION_BTN_STRING) == 0) {
+			int rc;
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				rc = MessageDialog::show2(ESP_WATCH_INTRO_MSG, ESP_START_PLAY_BTN_STRING, ESP_INTRODUCTION_BTN_STRING);
+			} else {
+				rc = MessageDialog::show2(WATCH_INTRO_MSG, START_PLAY_BTN_STRING, INTRODUCTION_BTN_STRING);
+			}
+			if (rc == 0) {
 				_actionIndex = 20;
 				g_globals->_soundHandler.fadeOut(this);
 			} else {

--- a/engines/tsage/ringworld/ringworld_scenes5.cpp
+++ b/engines/tsage/ringworld/ringworld_scenes5.cpp
@@ -1674,7 +1674,11 @@ void Scene4025::remove() {
 void Scene4025::signal() {
 	if (_sceneMode != 4027) {
 		if (_sceneMode != 4028) {
-			_gfxButton.setText(EXIT_MSG);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				_gfxButton.setText(ESP_EXIT_MSG);
+			} else {
+				_gfxButton.setText(EXIT_MSG);
+			}
 			_gfxButton._bounds.center(144, 107);
 			_gfxButton.draw();
 			_gfxButton._bounds.expandPanes();
@@ -4292,7 +4296,11 @@ void Scene4300::signal() {
 		_hotspot14.setStrip(7);
 		_hotspot14.setPosition(Common::Point(60, 199));
 
-		_gfxButton.setText(EXIT_MSG);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			_gfxButton.setText(ESP_EXIT_MSG);
+		} else {
+			_gfxButton.setText(EXIT_MSG);
+		}
 		_gfxButton._bounds.center(60, 193);
 		_gfxButton.draw();
 		_gfxButton._bounds.expandPanes();

--- a/engines/tsage/ringworld/ringworld_scenes8.cpp
+++ b/engines/tsage/ringworld/ringworld_scenes8.cpp
@@ -2138,7 +2138,11 @@ void Scene7700::Object8::doAction(int action) {
 			scene->_object14.fixPriority(250);
 			scene->_object14.setPosition(Common::Point(139, 151));
 
-			scene->_gfxButton.setText(EXIT_MSG);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				scene->_gfxButton.setText(ESP_EXIT_MSG);
+			} else {
+				scene->_gfxButton.setText(EXIT_MSG);
+			}
 			scene->_gfxButton._bounds.center(140, 189);
 			scene->_gfxButton.draw();
 
@@ -2151,7 +2155,11 @@ void Scene7700::Object8::doAction(int action) {
 			scene->_object15.setPosition(Common::Point(140, 165));
 			scene->_object15.fixPriority(200);
 
-			scene->_gfxButton.setText(EXIT_MSG);
+			if (g_vm->getLanguage() == Common::ES_ESP) {
+				scene->_gfxButton.setText(ESP_EXIT_MSG);
+			} else {
+				scene->_gfxButton.setText(EXIT_MSG);
+			}
 			scene->_gfxButton._bounds.center(140, 186);
 			scene->_gfxButton.draw();
 			scene->_gfxButton._bounds.expandPanes();

--- a/engines/tsage/scenes.cpp
+++ b/engines/tsage/scenes.cpp
@@ -568,7 +568,12 @@ void Scene::setZoomPercents(int yStart, int minPercent, int yEnd, int maxPercent
 void Game::restartGame() {
 	int rc;
 	if (g_vm->getLanguage() == Common::ES_ESP) {
-		rc = MessageDialog::show(ESP_RESTART_MSG, ESP_CANCEL_BTN_STRING, ESP_RESTART_BTN_STRING);
+		if (g_vm->getGameID() == GType_Ringworld) {
+			rc = MessageDialog::show(ESP_RW_RESTART_MSG, ESP_CANCEL_BTN_STRING, ESP_RW_RESTART_BTN_2_STRING);
+		}
+		else {
+			rc = MessageDialog::show(ESP_BF_RESTART_MSG, ESP_CANCEL_BTN_STRING, ESP_BF_RESTART_BTN_STRING);
+		}
 	} else {
 		rc = MessageDialog::show(RESTART_MSG, CANCEL_BTN_STRING, RESTART_BTN_STRING);
 	}
@@ -578,7 +583,11 @@ void Game::restartGame() {
 
 void Game::saveGame() {
 	if (!g_vm->canSaveGameStateCurrently())
-		MessageDialog::show(SAVING_NOT_ALLOWED_MSG, OK_BTN_STRING);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			MessageDialog::show(ESP_SAVING_NOT_ALLOWED_MSG, ESP_OK_BTN_STRING);
+		} else {
+			MessageDialog::show(SAVING_NOT_ALLOWED_MSG, OK_BTN_STRING);
+		}
 	else {
 		// Show the save dialog
 		handleSaveLoad(true, g_globals->_sceneHandler->_saveGameSlot, g_globals->_sceneHandler->_saveName);
@@ -587,7 +596,11 @@ void Game::saveGame() {
 
 void Game::restoreGame() {
 	if (!g_vm->canLoadGameStateCurrently())
-		MessageDialog::show(RESTORING_NOT_ALLOWED_MSG, OK_BTN_STRING);
+		if (g_vm->getLanguage() == Common::ES_ESP) {
+			MessageDialog::show(ESP_RESTORING_NOT_ALLOWED_MSG, ESP_OK_BTN_STRING);
+		} else {
+			MessageDialog::show(RESTORING_NOT_ALLOWED_MSG, OK_BTN_STRING);
+		}
 	else {
 		// Show the load dialog
 		handleSaveLoad(false, g_globals->_sceneHandler->_loadGameSlot, g_globals->_sceneHandler->_saveName);
@@ -597,7 +610,12 @@ void Game::restoreGame() {
 void Game::quitGame() {
 	int rc;
 	if (g_vm->getLanguage() == Common::ES_ESP) {
-		rc = MessageDialog::show(ESP_QUIT_CONFIRM_MSG, ESP_CANCEL_BTN_STRING, ESP_QUIT_BTN_STRING);
+		if (g_vm->getGameID() == GType_Ringworld) {
+			rc = MessageDialog::show(ESP_RW_QUIT_CONFIRM_2_MSG, ESP_CANCEL_BTN_STRING, ESP_RW_QUIT_BTN_STRING);
+		}
+		else {
+			rc = MessageDialog::show(ESP_BF_QUIT_CONFIRM_MSG, ESP_CANCEL_BTN_STRING, ESP_BF_QUIT_BTN_STRING);
+		}
 	} else {
 		rc = MessageDialog::show(QUIT_CONFIRM_MSG, CANCEL_BTN_STRING, QUIT_BTN_STRING);
 	}

--- a/engines/tsage/staticres.cpp
+++ b/engines/tsage/staticres.cpp
@@ -94,19 +94,34 @@ char const *const ESP_USE_SCENE_HOTSPOT = "Con eso no conseguir\240s nada.";
 char const *const ESP_TALK_SCENE_HOTSPOT = "Yak, yak.";
 char const *const ESP_SPECIAL_SCENE_HOTSPOT = "Es una forma original de usar eso.";
 char const *const ESP_DEFAULT_SCENE_HOTSPOT = "No ves nada especial.";
-char const *const ESP_SAVE_ERROR_MSG = "El juego no ha podido ser archivado. Por favor, no intente recuperar este juego!";
+char const *const ESP_SAVE_ERROR_MSG = "Error salvando el juego. \255Por favor, no intentes recuperarlo!";
+char const *const ESP_SAVING_NOT_ALLOWED_MSG = "No es posible salvar en este momento.";
+char const *const ESP_RESTORING_NOT_ALLOWED_MSG = "No es posible recuperar una partida en este momento.";
+char const *const ESP_INV_EMPTY_MSG = "No llevas nada contigo.";
 
-char const *const ESP_QUIT_CONFIRM_MSG = "Quieres dejar de jugar?";
-char const *const ESP_RESTART_MSG = "Deseas volver a comenzar el juego?";
-char const *const ESP_GAME_PAUSED_MSG = "Juego en pausa.";
+char const *const ESP_RW_QUIT_CONFIRM_1_MSG = "\250Quieres abandonar el juego?";
+char const *const ESP_RW_QUIT_CONFIRM_2_MSG = "\250Quieres abandonar esta partida?";
+char const *const ESP_BF_QUIT_CONFIRM_MSG = "\250Quieres dejar de jugar?";
+char const *const ESP_RW_RESTART_MSG = "   \250Quieres empezar de nuevo?    ";
+char const *const ESP_BF_RESTART_MSG = "\250Quieres volver a comenzar el juego?";
+char const *const ESP_RW_GAME_PAUSED_MSG = "Juego pausado";
+char const *const ESP_BF_GAME_PAUSED_MSG = "Juego en pausa.";
 char const *const ESP_OK_BTN_STRING = " Ok ";
+char const *const ESP_OK_BTN_2_STRING = " Continuar ";
 char const *const ESP_CANCEL_BTN_STRING = "Cancelar";
-char const *const ESP_QUIT_BTN_STRING = " Salir ";
-char const *const ESP_RESTART_BTN_STRING = "Reiniciar";
-char const *const ESP_SAVE_BTN_STRING = "Guardar";
+char const *const ESP_RW_QUIT_BTN_STRING = " Abandonar ";
+char const *const ESP_BF_QUIT_BTN_STRING = " Salir ";
+char const *const ESP_RW_RESTART_BTN_1_STRING = "Empezar \rde nuevo";
+char const *const ESP_RW_RESTART_BTN_2_STRING = "Empezar de nuevo";
+char const *const ESP_BF_RESTART_BTN_STRING = "Volver a empezar";
+char const *const ESP_RW_SAVE_BTN_STRING = "Salvar";
+char const *const ESP_BF_SAVE_BTN_STRING = "Guardar";
 char const *const ESP_RESTORE_BTN_STRING = "Recuperar";
 char const *const ESP_SOUND_BTN_STRING = "Sonido";
-char const *const ESP_RESUME_BTN_STRING = " Seguir \rjugando";
+char const *const ESP_RW_RESUME_BTN_STRING = " Continuar \rjuego";
+char const *const ESP_BF_RESUME_BTN_STRING = " Seguir \rjugando";
+char const *const ESP_LOOK_BTN_STRING = "Mirar";
+char const *const ESP_PICK_BTN_STRING = "Escoger";
 
 namespace Ringworld {
 
@@ -141,6 +156,36 @@ char const *const DEMO_EXIT_MSG = "Press ENTER to resume the Ringworld\x14 demo.
 char const *const EXIT_BTN_STRING = "Exit";
 char const *const DEMO_BTN_STRING = "Demo";
 char const *const DEMO_RESUME_BTN_STRING = "Resume";
+
+// Spanish version
+// Dialog resources
+char const *const ESP_HELP_MSG = "Mundo Anillo\x14\rLa Venganza del Patriarca\rVersi\242n ScummVM\r\r\
+\x01 Teclas de aceso r\240pido...\rF2 - Opciones de Sonido\rF3 - Abandonar\r\
+F4 - Empezar de nuevo\rF5 - Salvar\rF7 - Recuperar\rF10 - Pausa";
+char const *const ESP_WATCH_INTRO_MSG = "        \250Quieres ver la introducci\242n?         ";
+char const *const ESP_START_PLAY_BTN_STRING = " Comenzar el Juego ";
+char const *const ESP_INTRODUCTION_BTN_STRING = "Introducci\242n";
+char const *const ESP_OPTIONS_MSG = "\x01Opciones...";
+
+// Scene specific resources
+char const *const ESP_EXIT_MSG = "   SALIR   ";
+char const *const ESP_SCENE6100_CAREFUL = "\255Cuidado! La sonda no puede manipular mucho de eso.";
+char const *const ESP_SCENE6100_TOUGHER = "\255Hey! Esto es m\240s duro de lo que parece!";
+char const *const ESP_SCENE6100_ONE_MORE_HIT = "Deber\241as tener m\240s cuidado. Un impacto m\240s como \
+ese y la sonda podr\241a ser destruida";
+char const *const ESP_SCENE6100_DOING_BEST = "Lo hago lo mejor que puedo. \255Espero que se mantenga de \
+una pieza!";
+char const *const ESP_SCENE6100_REPAIR = "\r\rQuinn y Seeker reparan la sonda....";
+char const *const ESP_SCENE6100_ROCKY_AREA = "La zona rocosa deber\241a estar justo en frente de t\241. \
+\250La ves?";
+char const *const ESP_SCENE6100_REPLY = "S\241. Ahora a ver si soy capaz de esquivar esos rayos de luz \
+solar.";
+char const *const ESP_SCENE6100_TAKE_CONTROLS = "Toma t\243 los controles Seeker. Me sudan las manos.";
+char const *const ESP_SCENE6100_SURPRISE = "Me sorprendes Quinn. Pens\202 que aguantar\241as m\240s";
+char const *const ESP_SCENE6100_SWEAT = "Los humanos sudan, los Kzinti mueven convulsivamente su cola. \
+\250D\242nde est\240 la diferencia?";
+char const *const ESP_SCENE6100_VERY_WELL = "Muy bien. Recoger\202 la caja est\240sica y traer\202 la \
+sonda. Espera en la bodega de carga.";
 
 } // End of namespace Ringworld
 
@@ -200,10 +245,10 @@ char const *const THE_NEXT_DAY = "The Next Day";
 
 // Spanish version
 // Dialog resources
-char const *const ESP_HELP_MSG = "Blue Force\x14\rScummVM Version\r\r\
+char const *const ESP_HELP_MSG = "Blue Force\x14\rVersi\242n ScummVM\r\r\
 Funciones del Teclado...\rF2 - Sonido\rF3 - Salir del Juego\r\
 F4 - Recomenzar\rF5 - Guardar\rF7 - Recuperar\rF10 - Pausa";
-char const *const ESP_WATCH_INTRO_MSG = "Quieres ver la introducci\242n?";
+char const *const ESP_WATCH_INTRO_MSG = "\250Quieres ver la introducci\242n?";
 char const *const ESP_START_PLAY_BTN_STRING = " Jugar ";
 char const *const ESP_INTRODUCTION_BTN_STRING = " Ver ";
 char const *const ESP_OPTIONS_MSG = "Opciones...";

--- a/engines/tsage/staticres.h
+++ b/engines/tsage/staticres.h
@@ -63,19 +63,34 @@ extern char const *const ESP_TALK_SCENE_HOTSPOT;
 extern char const *const ESP_SPECIAL_SCENE_HOTSPOT;
 extern char const *const ESP_DEFAULT_SCENE_HOTSPOT;
 extern char const *const ESP_SAVE_ERROR_MSG;
+extern char const *const ESP_SAVING_NOT_ALLOWED_MSG;
+extern char const *const ESP_RESTORING_NOT_ALLOWED_MSG;
+extern char const *const ESP_INV_EMPTY_MSG;
 
 // Dialogs
-extern char const *const ESP_QUIT_CONFIRM_MSG;
-extern char const *const ESP_RESTART_MSG;
-extern char const *const ESP_GAME_PAUSED_MSG;
+extern char const *const ESP_RW_QUIT_CONFIRM_1_MSG;
+extern char const *const ESP_RW_QUIT_CONFIRM_2_MSG;
+extern char const *const ESP_BF_QUIT_CONFIRM_MSG;
+extern char const *const ESP_RW_RESTART_MSG;
+extern char const *const ESP_BF_RESTART_MSG;
+extern char const *const ESP_RW_GAME_PAUSED_MSG;
+extern char const *const ESP_BF_GAME_PAUSED_MSG;
 extern char const *const ESP_OK_BTN_STRING;
+extern char const *const ESP_OK_BTN_2_STRING;
 extern char const *const ESP_CANCEL_BTN_STRING;
-extern char const *const ESP_QUIT_BTN_STRING;
-extern char const *const ESP_RESTART_BTN_STRING;
-extern char const *const ESP_SAVE_BTN_STRING;
+extern char const *const ESP_RW_QUIT_BTN_STRING;
+extern char const *const ESP_BF_QUIT_BTN_STRING;
+extern char const *const ESP_RW_RESTART_BTN_1_STRING;
+extern char const *const ESP_RW_RESTART_BTN_2_STRING;
+extern char const *const ESP_BF_RESTART_BTN_STRING;
+extern char const *const ESP_RW_SAVE_BTN_STRING;
+extern char const *const ESP_BF_SAVE_BTN_STRING;
 extern char const *const ESP_RESTORE_BTN_STRING;
 extern char const *const ESP_SOUND_BTN_STRING;
-extern char const *const ESP_RESUME_BTN_STRING;
+extern char const *const ESP_RW_RESUME_BTN_STRING;
+extern char const *const ESP_BF_RESUME_BTN_STRING;
+extern char const *const ESP_LOOK_BTN_STRING;
+extern char const *const ESP_PICK_BTN_STRING;
 
 namespace Ringworld {
 
@@ -109,6 +124,28 @@ extern char const *const DEMO_EXIT_MSG;
 extern char const *const EXIT_BTN_STRING;
 extern char const *const DEMO_BTN_STRING;
 extern char const *const DEMO_RESUME_BTN_STRING;
+
+// Spanish version
+// Dialog resources
+extern char const *const ESP_HELP_MSG;
+extern char const *const ESP_WATCH_INTRO_MSG;
+extern char const *const ESP_START_PLAY_BTN_STRING;
+extern char const *const ESP_INTRODUCTION_BTN_STRING;
+extern char const *const ESP_OPTIONS_MSG;
+
+// Scene specific resources
+extern char const *const ESP_EXIT_MSG;
+extern char const *const ESP_SCENE6100_CAREFUL;
+extern char const *const ESP_SCENE6100_TOUGHER;
+extern char const *const ESP_SCENE6100_ONE_MORE_HIT;
+extern char const *const ESP_SCENE6100_DOING_BEST;
+extern char const *const ESP_SCENE6100_REPAIR;
+extern char const *const ESP_SCENE6100_ROCKY_AREA;
+extern char const *const ESP_SCENE6100_REPLY;
+extern char const *const ESP_SCENE6100_TAKE_CONTROLS;
+extern char const *const ESP_SCENE6100_SURPRISE;
+extern char const *const ESP_SCENE6100_SWEAT;
+extern char const *const ESP_SCENE6100_VERY_WELL;
 
 } // End of namespace Ringworld
 


### PR DESCRIPTION
Text was extracted from the Spanish RING.EXE using a hex editor.
These include the options menu, dialogs, and inventory items.

Now the game plays fully in Spanish, like the original version.

Note that some menu options were originally translated in different
ways for Ringworld and Blue Force (e.g. Save -> Salvar/Guardar).


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
