### PR TITLE
Revert "OPENGL: Implement high DPI support on Android (#1895)"

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -922,7 +922,7 @@ void OpenGLGraphicsManager::grabPalette(byte *colors, uint start, uint num) cons
 	memcpy(colors, _gamePalette + start * 3, num * 3);
 }
 
-void OpenGLGraphicsManager::handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) {
+void OpenGLGraphicsManager::handleResizeImpl(const int width, const int height) {
 	// Setup backbuffer size.
 	_backBuffer.setDimensions(width, height);
 
@@ -1025,7 +1025,7 @@ void OpenGLGraphicsManager::notifyContextCreate(const Graphics::PixelFormat &def
 
 	// Refresh the output screen dimensions if some are set up.
 	if (_windowWidth != 0 && _windowHeight != 0) {
-		handleResize(_windowWidth, _windowHeight, _xdpi, _ydpi);
+		handleResize(_windowWidth, _windowHeight);
 	}
 
 	// TODO: Should we try to convert textures into one of those formats if
@@ -1292,16 +1292,6 @@ void OpenGLGraphicsManager::recalculateCursorScaling() {
 
 		_cursorHotspotYScaled = fracToInt(_cursorHotspotYScaled * screenScaleFactorY);
 		_cursorHeightScaled   = fracToInt(_cursorHeightScaled   * screenScaleFactorY);
-	} else {
-		const frac_t screenScaleFactorX = intToFrac(90) / _xdpi;
-		const frac_t screenScaleFactorY = intToFrac(90) / _ydpi;
-
-		// FIXME: Replace this with integer maths
-		_cursorHotspotXScaled /= fracToDouble(screenScaleFactorX);
-		_cursorWidthScaled    /= fracToDouble(screenScaleFactorX);
-
-		_cursorHotspotYScaled /= fracToDouble(screenScaleFactorY);
-		_cursorHeightScaled   /= fracToDouble(screenScaleFactorY);
 	}
 }
 

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -311,7 +311,7 @@ protected:
 
 	virtual bool gameNeedsAspectRatioCorrection() const override;
 	virtual void recalculateDisplayAreas() override;
-	virtual void handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) override;
+	virtual void handleResizeImpl(const int width, const int height) override;
 
 	/**
 	 * The default pixel format of the backend.

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -308,7 +308,7 @@ void OpenGLSdlGraphicsManager::notifyResize(const int w, const int h) {
 	if (width != currentWidth || height != currentHeight)
 		return;
 
-	handleResize(width, height, 90, 90);
+	handleResize(width, height);
 #else
 	if (!_ignoreResizeEvents && _hwScreen && !(_hwScreen->flags & SDL_FULLSCREEN)) {
 		// We save that we handled a resize event here. We need to know this
@@ -360,9 +360,9 @@ void *OpenGLSdlGraphicsManager::getProcAddress(const char *name) const {
 	return SDL_GL_GetProcAddress(name);
 }
 
-void OpenGLSdlGraphicsManager::handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) {
-	OpenGLGraphicsManager::handleResizeImpl(width, height, xdpi, ydpi);
-	SdlGraphicsManager::handleResizeImpl(width, height, xdpi, ydpi);
+void OpenGLSdlGraphicsManager::handleResizeImpl(const int width, const int height) {
+	OpenGLGraphicsManager::handleResizeImpl(width, height);
+	SdlGraphicsManager::handleResizeImpl(width, height);
 }
 
 bool OpenGLSdlGraphicsManager::saveScreenshot(const Common::String &filename) const {
@@ -468,7 +468,7 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	int actualWidth, actualHeight;
 	getWindowSizeFromSdl(&actualWidth, &actualHeight);
 
-	handleResize(actualWidth, actualHeight, 72, 72);
+	handleResize(actualWidth, actualHeight);
 	return true;
 #else
 	// WORKAROUND: Working around infamous SDL bugs when switching
@@ -515,8 +515,7 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 
 	if (_hwScreen) {
 		notifyContextCreate(rgba8888, rgba8888);
-		// TODO: hidpi
-		handleResize(_hwScreen->w, _hwScreen->h, 90, 90);
+		handleResize(_hwScreen->w, _hwScreen->h);
 	}
 
 	// Ignore resize events (from SDL) for a few frames, if this isn't

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -56,7 +56,7 @@ protected:
 
 	virtual void *getProcAddress(const char *name) const override;
 
-	virtual void handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) override;
+	virtual void handleResizeImpl(const int width, const int height) override;
 
 	virtual bool saveScreenshot(const Common::String &filename) const override;
 

--- a/backends/graphics/psp2sdl/psp2sdl-graphics.cpp
+++ b/backends/graphics/psp2sdl/psp2sdl-graphics.cpp
@@ -90,7 +90,7 @@ PSP2SdlGraphicsManager::PSP2SdlGraphicsManager(SdlEventSource *sdlEventSource, S
 	_shaders[0] = NULL;
 
 	/* Vita display size is always 960x544 (that's just the hardware) */
-	handleResize(960, 544, 90, 90);
+	handleResize(960, 544);
 }
 
 PSP2SdlGraphicsManager::~PSP2SdlGraphicsManager() {

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -261,7 +261,7 @@ void SdlGraphicsManager::setSystemMousePosition(const int x, const int y) {
 	}
 }
 
-void SdlGraphicsManager::handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) {
+void SdlGraphicsManager::handleResizeImpl(const int width, const int height) {
 	_forceRedraw = true;
 }
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -231,7 +231,7 @@ protected:
 
 	virtual void setSystemMousePosition(const int x, const int y) override;
 
-	virtual void handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) override;
+	virtual void handleResizeImpl(const int width, const int height) override;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 public:

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -958,7 +958,7 @@ bool SurfaceSdlGraphicsManager::loadGFXMode() {
 	}
 
 #if !SDL_VERSION_ATLEAST(2, 0, 0)
-	handleResize(_videoMode.hardwareWidth, _videoMode.hardwareHeight, 90, 90);
+	handleResize(_videoMode.hardwareWidth, _videoMode.hardwareHeight);
 #endif
 
 	//
@@ -2423,8 +2423,8 @@ void SurfaceSdlGraphicsManager::drawOSD() {
 
 #endif
 
-void SurfaceSdlGraphicsManager::handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) {
-	SdlGraphicsManager::handleResizeImpl(width, height, xdpi, ydpi);
+void SurfaceSdlGraphicsManager::handleResizeImpl(const int width, const int height) {
+	SdlGraphicsManager::handleResizeImpl(width, height);
 	recalculateDisplayAreas();
 }
 
@@ -2594,7 +2594,7 @@ void SurfaceSdlGraphicsManager::notifyVideoExpose() {
 
 void SurfaceSdlGraphicsManager::notifyResize(const int width, const int height) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	handleResize(width, height, _xdpi, _ydpi);
+	handleResize(width, height);
 #endif
 }
 
@@ -2649,9 +2649,8 @@ SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, 
 		return nullptr;
 	}
 
-	// TODO: Implement high DPI support
 	getWindowSizeFromSdl(&_windowWidth, &_windowHeight);
-	handleResize(_windowWidth, _windowHeight, 90, 90);
+	handleResize(_windowWidth, _windowHeight);
 
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, _videoMode.filtering ? "linear" : "nearest");
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -165,7 +165,7 @@ protected:
 		return _videoMode.scaleFactor;
 	}
 
-	virtual void handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) override;
+	virtual void handleResizeImpl(const int width, const int height) override;
 
 	virtual int getGraphicsModeScale(int mode) const override;
 

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -50,8 +50,6 @@ public:
 		_cursorVisible(false),
 		_cursorX(0),
 		_cursorY(0),
-		_xdpi(90),
-		_ydpi(90),
 		_cursorNeedsRedraw(false),
 		_cursorLastInActiveArea(true) {}
 
@@ -102,7 +100,7 @@ protected:
 	 * Backend-specific implementation for updating internal surfaces that need
 	 * to reflect the new window size.
 	 */
-	virtual void handleResizeImpl(const int width, const int height, const int xdpi, const int ydpi) = 0;
+	virtual void handleResizeImpl(const int width, const int height) = 0;
 
 	/**
 	 * Converts the given point from the active virtual screen's coordinate
@@ -181,12 +179,10 @@ protected:
 	 * @param width The new width of the window, excluding window decoration.
 	 * @param height The new height of the window, excluding window decoration.
 	 */
-	void handleResize(const int width, const int height, const int xdpi, const int ydpi) {
+	void handleResize(const int width, const int height) {
 		_windowWidth = width;
 		_windowHeight = height;
-		_xdpi = xdpi;
-		_ydpi = ydpi;
-		handleResizeImpl(width, height, xdpi, ydpi);
+		handleResizeImpl(width, height);
 	}
 
 	/**
@@ -285,11 +281,6 @@ protected:
 	 * The height of the window, excluding window decoration.
 	 */
 	int _windowHeight;
-
-	/**
-	 * The DPI of the window.
-	 */
-	int _xdpi, _ydpi;
 
 	/**
 	 * Whether the overlay (i.e. launcher, including the out-of-game launcher)

--- a/backends/platform/android/graphics.cpp
+++ b/backends/platform/android/graphics.cpp
@@ -72,9 +72,7 @@ void AndroidGraphicsManager::initSurface() {
 	// mode we setup.
 	notifyContextCreate(Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0), Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0));
 
-	float dpi[2];
-	JNI::getDPI(dpi);
-	handleResize(JNI::egl_surface_width, JNI::egl_surface_height, dpi[0], dpi[1]);
+	handleResize(JNI::egl_surface_width, JNI::egl_surface_height);
 }
 
 void AndroidGraphicsManager::deinitSurface() {


### PR DESCRIPTION
The old code from PR #1895 isn't needed any more, and removing it should simplify the code and resolves some issues with scaling the cursor.