### PR TITLE
BACKENDS: Fix incorrect cursor scaling on high-DPI Windows

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -289,10 +289,10 @@ void OpenGLSdlGraphicsManager::updateScreen() {
 void OpenGLSdlGraphicsManager::notifyVideoExpose() {
 }
 
-void OpenGLSdlGraphicsManager::notifyResize(const int w, const int h) {
+void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	// We sometime get outdated resize events from SDL2. So check that the size we get
-	// is the actual current window size. If not ignore the resize.
+	// We sometime get inaccurate resize events from SDL2. So use the real drawable size
+	// we get from SDL2 and ignore the event data.
 	// The issue for example occurs when switching from fullscreen to windowed mode or
 	// when switching between different fullscreen resolutions because SDL_DestroyWindow
 	// for a fullscreen window that doesn't have the SDL_WINDOW_FULLSCREEN_DESKTOP flag
@@ -302,20 +302,16 @@ void OpenGLSdlGraphicsManager::notifyResize(const int w, const int h) {
 	getWindowSizeFromSdl(&currentWidth, &currentHeight);
 	uint scale;
 	getDpiScalingFactor(&scale);
-	int width = w * scale;
-	int height = h * scale;
 	debug(3, "req: %d x %d  cur: %d x %d, scale: %d", width, height, currentWidth, currentHeight, scale);
-	if (width != currentWidth || height != currentHeight)
-		return;
 
-	handleResize(width, height);
+	handleResize(currentWidth, currentHeight);
 #else
 	if (!_ignoreResizeEvents && _hwScreen && !(_hwScreen->flags & SDL_FULLSCREEN)) {
 		// We save that we handled a resize event here. We need to know this
 		// so we do not overwrite the users requested window size whenever we
 		// switch aspect ratio or similar.
 		_gotResize = true;
-		if (!setupMode(w, h)) {
+		if (!setupMode(width, height)) {
 			warning("OpenGLSdlGraphicsManager::notifyResize: Resize failed ('%s')", SDL_GetError());
 			g_system->quit();
 		}

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -61,9 +61,16 @@ protected:
 	virtual bool saveScreenshot(const Common::String &filename) const override;
 
 	virtual int getGraphicsModeScale(int mode) const override {
-		uint scale;
-		getDpiScalingFactor(&scale);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		int windowWidth, windowHeight;
+		SDL_GetWindowSize(_window->getSDLWindow(), &windowWidth, &windowHeight);
+		int realWidth, realHeight;
+		SDL_GL_GetDrawableSize(_window->getSDLWindow(), &realWidth, &realHeight);
+		int scale = realWidth / windowWidth;
 		return scale;
+#else
+		return 1;
+#endif
 	}
 
 private:

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -164,7 +164,6 @@ protected:
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		assert(_window);
 		SDL_GL_GetDrawableSize(_window->getSDLWindow(), width, height);
-		// SDL_GetWindowSize(_window->getSDLWindow(), width, height);
 #else
 		assert(_hwScreen);
 


### PR DESCRIPTION
This tries to correct handling coordinates from mouse events and window events on high-DPI systems:
- on some platforms (eg. Windows), mouse and window events need to be unscaled 
- on some platforms (eg. OSX), mouse and window events need to be scaled by the DPI

We try to determine this by comparing the WindowSize and DrawableSize and scaling appropriately.

Only tested on Windows, appreciate testing and feedback from other systems.