### PR TITLE
ACCESS: Support Amazon Spanish in access.dat R/W

### DIFF
--- a/devtools/create_access/create_access_dat.cpp
+++ b/devtools/create_access/create_access_dat.cpp
@@ -231,7 +231,7 @@ bool processExecutable(int exeIdx, const char *name) {
 	const char *const *itemNames;
 	const int *comboTable;
 	byte gameId = 0, discType = 0, demoType = 0;
-	byte language = Common::EN_ANY;
+	byte language = 5; //old Common::EN_ANY;
 
 	// Open up the file for access
 	File exeFile;
@@ -258,6 +258,28 @@ bool processExecutable(int exeIdx, const char *name) {
 		roomsStart = dataSegmentOffset + 0x35a8;
 		roomsEnd = dataSegmentOffset + 0x4234;
 		travelPosOffset = dataSegmentOffset + 0x5ff7;
+		numRooms = 64;
+		roomDescs = &Amazon::ROOM_DESCR[0];
+		deathScreens = Amazon::DEATH_SCREENS_ENG;
+		deathText = &Amazon::DEATH_TEXT_ENG[0];
+		numDeaths = sizeof(Amazon::DEATH_SCREENS_ENG);
+		numItems = 85;
+		itemNames = &Amazon::INVENTORY_NAMES_ENG[0];
+		comboTable = &Amazon::COMBO_TABLE[0][0];
+		break;
+
+	case 12012:
+		// Amazon Spanish floppy
+		language = 23; //old Common::ES_ESP;
+		gameId = 1;
+		dataSegmentOffset = 0xC8C0;
+		filenamesOffset = dataSegmentOffset + 0x3628 + 0x128;
+		numFilenames = 100;
+		charsStart = dataSegmentOffset + 0x4234 + 0x128;
+		charsEnd = dataSegmentOffset + 0x49c6 + 0x128;
+		roomsStart = dataSegmentOffset + 0x35a8 + 0x128;
+		roomsEnd = dataSegmentOffset + 0x4234 + 0x128;
+		travelPosOffset = dataSegmentOffset + 0x5ff7 + 0x128 + 0x2b;
 		numRooms = 64;
 		roomDescs = &Amazon::ROOM_DESCR[0];
 		deathScreens = Amazon::DEATH_SCREENS_ENG;

--- a/engines/access/resources.cpp
+++ b/engines/access/resources.cpp
@@ -79,6 +79,9 @@ bool Resources::load(Common::U32String &errorMessage) {
 		case 5:
 			_datIndex[idx]._language = Common::EN_ANY;
 			break;
+		case 23:
+			_datIndex[idx]._language = Common::ES_ESP;
+			break;
 		default:
 			error("Unknown language");
 			break;


### PR DESCRIPTION
I assume we want to use stable language codes in access/resources.cpp
even if language.h keeps changing, so I've used language code "23" for
ES_ESP since this was the enum value in language.h the last time
access.dat was generated.

Note: we still need access.dat to be regenerated for the game to work,
but create_access should now be able to extract the needed info
from the Spanish version of AMAZON.EXE and the game should run fine
afterwards.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
