### PR TITLE
GUI: Hide "-unknown" candidates if there are known

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -571,7 +571,10 @@ bool LauncherDialog::doGameDetection(const Common::String &path) {
 		g_system->logMessage(LogMessageType::kInfo, report.encode().c_str());
 	}
 
-	Common::Array<DetectedGame> candidates = detectionResults.listDetectedGames();
+	Common::Array<DetectedGame> candidates = detectionResults.listRecognizedGames();
+	if (candidates.empty()) {
+		candidates = detectionResults.listDetectedGames();
+	}
 
 	int idx;
 	if (candidates.empty()) {


### PR DESCRIPTION
This fixes one of issues mentioned at
https://bugs.scummvm.org/ticket/12377

"Chivalry is Not Dead" contains:
* data.dcp mentioned at Wintermute detection tables
* game.exe unrelated to game.exe files mentioned at AGS detection tables

So, detection result is 100% hit for "chivalry" and possible unknown version hits for a dozen of AGS games.

This PR changes "Add" button behaviour to show list of "xxx-unknown" candidates only if there are no known candidates.
