### PR TITLE
TESTS: Fix GCC warnings

### DIFF
--- a/test/cxxtest/cxxtest/ValueTraits.h
+++ b/test/cxxtest/cxxtest/ValueTraits.h
@@ -20,6 +20,15 @@
 
 namespace CxxTest
 {
+    /// remove_const
+    template<typename T>
+    struct remove_const
+    { typedef T type; };
+
+    template<typename T>
+    struct remove_const<T const>
+    { typedef T type; };
+
     //
     // This is how we use the value traits
     //
@@ -100,7 +109,7 @@ namespace CxxTest
     { \
         ValueTraits< CXXTEST_OLD_CLASS > _old; \
     public: \
-        ValueTraits( CXXTEST_NEW_CLASS n ) : _old( (CXXTEST_OLD_CLASS)n ) {} \
+        ValueTraits( CXXTEST_NEW_CLASS n ) : _old( static_cast<remove_const<CXXTEST_OLD_CLASS>::type>(n) ) {} \
         const char *asString( void ) const { return _old.asString(); } \
     }
 


### PR DESCRIPTION
```
../scummvm/test/cxxtest/cxxtest/ValueTraits.h:120:52: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
  120 |         ValueTraits( CXXTEST_NEW_CLASS n ) : _old( (CXXTEST_OLD_CLASS)n ) {} \
      |                                                    ^~~~~~~~~~~~~~~~~~~~
```
