### PR TITLE
BACKENDS: Add support for OpenGL 1.1 contexts

### DIFF
--- a/backends/graphics/opengl/opengl-defs.h
+++ b/backends/graphics/opengl/opengl-defs.h
@@ -224,6 +224,7 @@ typedef GLhandleARB GLshader;
 #define GL_TEXTURE_WRAP_T                 0x2803
 
 /* TextureWrapMode */
+#define GL_CLAMP                          0x2900
 #define GL_REPEAT                         0x2901
 #define GL_CLAMP_TO_EDGE                  0x812F
 

--- a/backends/graphics/opengl/opengl-sys.h
+++ b/backends/graphics/opengl/opengl-sys.h
@@ -103,6 +103,14 @@ struct Context {
 	 */
 	void reset();
 
+	/** Helper function for checking the GL version supported by the context. */
+	inline bool isGLVersionOrHigher(int major, int minor) {
+		return ((majorVersion > major) || ((majorVersion == major) && (minorVersion >= minor)));
+	}
+
+	/** The GL version supported by the context. */
+	int majorVersion, minorVersion;
+
 	/** The maximum texture size supported by the context. */
 	GLint maxTextureSize;
 
@@ -117,6 +125,12 @@ struct Context {
 
 	/** Whether FBO support is available or not. */
 	bool framebufferObjectSupported;
+
+	/** Whether packed pixels support is available or not. */
+	bool packedPixelsSupported;
+
+	/** Whether texture coordinate edge clamping is available or not. */
+	bool textureEdgeClampSupported;
 
 #define GL_FUNC_DEF(ret, name, param) ret (GL_CALL_CONV *name)param
 #include "backends/graphics/opengl/opengl-func.h"

--- a/backends/graphics/opengl/texture.h
+++ b/backends/graphics/opengl/texture.h
@@ -318,28 +318,28 @@ private:
 	byte *_palette;
 };
 
-#if !USE_FORCED_GL
 class FakeTexture : public Texture {
 public:
-	FakeTexture(GLenum glIntFormat, GLenum glFormat, GLenum glType, const Graphics::PixelFormat &format);
+	FakeTexture(GLenum glIntFormat, GLenum glFormat, GLenum glType, const Graphics::PixelFormat &format, const Graphics::PixelFormat &fakeFormat);
 	virtual ~FakeTexture();
 
 	virtual void allocate(uint width, uint height);
 
-	virtual Graphics::PixelFormat getFormat() const = 0;
+	virtual Graphics::PixelFormat getFormat() const { return _fakeFormat; }
 
 	virtual Graphics::Surface *getSurface() { return &_rgbData; }
 	virtual const Graphics::Surface *getSurface() const { return &_rgbData; }
+
+	virtual void updateGLTexture();
 protected:
 	Graphics::Surface _rgbData;
+	Graphics::PixelFormat _fakeFormat;
 };
 
 class TextureRGB555 : public FakeTexture {
 public:
 	TextureRGB555();
 	virtual ~TextureRGB555() {};
-
-	virtual Graphics::PixelFormat getFormat() const;
 
 	virtual void updateGLTexture();
 };
@@ -349,11 +349,8 @@ public:
 	TextureRGBA8888Swap();
 	virtual ~TextureRGBA8888Swap() {};
 
-	virtual Graphics::PixelFormat getFormat() const;
-
 	virtual void updateGLTexture();
 };
-#endif // !USE_FORCED_GL
 
 #if !USE_FORCED_GLES
 class TextureTarget;


### PR DESCRIPTION
As part of this PR, `FakeTexture` has been extended to handle converting from any pixel format, not just RGB555 and RGBA8888, which is potentially useful for OpenGL ES as well. None of the 3D games were adapted to support this. Testing was done on Windows 98 SE with the built-in GDI Generic renderer.