### PR TITLE
GUI: Allow text selection

### DIFF
--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -56,6 +56,14 @@ protected:
 
 	int			_editScrollOffset;
 
+	U32String	_highlightString;
+	bool		_highlightVisible;
+	int			_highlightPos;
+	int			_highlightSize;
+	int			_highlightCharacterCount;
+	int			_visiblestr;
+
+	Graphics::TextAlign _highlightalign;
 	Graphics::TextAlign _align;
 	Graphics::TextAlign _drawAlign;
 
@@ -71,14 +79,14 @@ public:
 	void init();
 
 	virtual void setEditString(const U32String &str);
-	virtual const U32String &getEditString() const		{ return _editString; }
+	virtual const U32String &getEditString() const		{ return (_highlightVisible)?_highlightString:_editString; }
 
 	void handleTickle() override;
 	bool handleKeyDown(Common::KeyState state) override;
 	void reflowLayout() override;
 
 	bool setCaretPos(int newPos);
-
+	void initHighlight();
 protected:
 	virtual void startEditMode() = 0;
 	virtual void endEditMode() = 0;
@@ -90,6 +98,7 @@ protected:
 	 */
 	virtual Common::Rect getEditRect() const = 0;
 	virtual int getCaretOffset() const;
+	virtual int getHighlightOffset() const;
 	void drawCaret(bool erase);
 	bool adjustOffset();
 	void makeCaretVisible();

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -72,6 +72,10 @@ void EditTextWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 	if (_caretVisible)
 		drawCaret(true);
 
+	// Remove highlight
+	if (_highlightVisible)
+		initHighlight();
+
 	if (g_gui.useRTL()) {
 		x = _w - x;
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
This PR adds the enhancement requested at
https://bugs.scummvm.org/ticket/6948

The key combination Shift+Left Arrow will highlight and select text towards left of the caret.

Two methods have been added:
- initHighlight() - resets highlight.
- getHighlightOffset() - used for scrolling text animation as text is selected.

Files changed:
- editable.h: declared variables and methods.
- edittext.cpp: Code segment that prevents highlight from being drawn on any position where mouse is clicked.
- editable.cpp:
  - Select and highlight text towards left.
  - Copy selected text using Ctrl-C.
  - Remove selected characters on Backspace/Delete key.
  - Replace selected text with a character.
  - Disable and re-initialize highlight on press of Left Arrow/Right Arrow/Home/End keys