### PR TITLE
Allow engines using the advanced detector to run unknown variants

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -241,8 +241,7 @@ DetectedGames AdvancedMetaEngineDetection::detectGames(const Common::FSList &fsl
 	for (uint i = 0; i < matches.size(); i++) {
 		DetectedGame game = toDetectedGame(matches[i]);
 
-		if (game.hasUnknownFiles) {
-			// Non fallback games with unknown files cannot be added/launched
+		if (game.hasUnknownFiles && !canPlayUnknownVariants()) {
 			game.canBeAdded = false;
 		}
 
@@ -251,7 +250,7 @@ DetectedGames AdvancedMetaEngineDetection::detectGames(const Common::FSList &fsl
 
 	bool foundKnownGames = false;
 	for (uint i = 0; i < detectedGames.size(); i++) {
-		foundKnownGames |= detectedGames[i].canBeAdded;
+		foundKnownGames |= !detectedGames[i].hasUnknownFiles;
 	}
 
 	if (!foundKnownGames) {
@@ -344,7 +343,7 @@ Common::Error AdvancedMetaEngineDetection::createInstance(OSystem *syst, Engine 
 
 	ADDetectedGame agdDesc;
 	for (uint i = 0; i < matches.size(); i++) {
-		if (matches[i].desc->gameId == gameid && !matches[i].hasUnknownFiles) {
+		if (matches[i].desc->gameId == gameid && (!matches[i].hasUnknownFiles || canPlayUnknownVariants())) {
 			agdDesc = matches[i];
 			break;
 		}

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -403,6 +403,12 @@ protected:
 	virtual ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra) const;
 
 	/**
+	 * @return True if variant of a game with unknown files can be played with the engine and false otherwise.
+	 * By default this is false.
+	 */
+	virtual bool canPlayUnknownVariants() const { return false; }
+
+	/**
 	 * Iterate over all @ref ADFileBasedFallback records inside @p fileBasedFallback
 	 * and return the record (or rather, the ADGameDescription
 	 * contained in it) for which all files described by it are present, and

--- a/engines/ags/detection.h
+++ b/engines/ags/detection.h
@@ -72,6 +72,10 @@ public:
 	DetectedGames detectGames(const Common::FSList &fslist) const override;
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist) const override;
+
+	bool canPlayUnknownVariants() const override {
+		return true;
+	}
 	
 	GUI::OptionsContainerWidget *buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };


### PR DESCRIPTION
The advanced detector does not allow adding unknown variants and running them. In the AGS engine however were we have additional checks on the unknown variants to ensure they are AGS games, nothing prevent us in principle to run those games. This pull request allows that.

I am proposing this change as a pull request in case there this change has an impact that I have not foreseen. But since it doesn't change the default behaviour, I think it should be safe.