### PR TITLE
COMMON: Fall back to engine icon in taskbar

### DIFF
--- a/common/taskbar.h
+++ b/common/taskbar.h
@@ -167,6 +167,7 @@ protected:
 		Common::String targetIcon = target + extension;
 		Common::String qualifiedIcon = ConfMan.get("engineid") + "-" + ConfMan.get("gameid") + extension;
 		Common::String gameIcon = ConfMan.get("gameid") + extension;
+		Common::String engineIcon = ConfMan.get("engineid") + extension;
 
 #define TRY_ICON_PATH(path) { \
 Common::FSNode node((path)); \
@@ -177,18 +178,22 @@ return (path); \
 			TRY_ICON_PATH(iconsPath + "/" + targetIcon);
 			TRY_ICON_PATH(iconsPath + "/" + qualifiedIcon);
 			TRY_ICON_PATH(iconsPath + "/" + gameIcon);
+			TRY_ICON_PATH(iconsPath + "/" + engineIcon);
 			TRY_ICON_PATH(iconsPath + "/icons/" + targetIcon);
 			TRY_ICON_PATH(iconsPath + "/icons/" + qualifiedIcon);
 			TRY_ICON_PATH(iconsPath + "/icons/" + gameIcon);
+			TRY_ICON_PATH(iconsPath + "/icons/" + engineIcon);
 		}
 
 		if (!extraPath.empty()) {
 			TRY_ICON_PATH(extraPath + "/" + targetIcon);
 			TRY_ICON_PATH(extraPath + "/" + qualifiedIcon);
 			TRY_ICON_PATH(extraPath + "/" + gameIcon);
+			TRY_ICON_PATH(extraPath + "/" + engineIcon);
 			TRY_ICON_PATH(extraPath + "/icons/" + targetIcon);
 			TRY_ICON_PATH(extraPath + "/icons/" + qualifiedIcon);
 			TRY_ICON_PATH(extraPath + "/icons/" + gameIcon);
+			TRY_ICON_PATH(extraPath + "/icons/" + engineIcon);
 		}
 #undef TRY_ICON_PATH
 


### PR DESCRIPTION
When an icon for game ID is not found, use the engine icon instead. This provides a fallback so that every game doesn't need an icon.

When discussing this with @SupSuper, I was hoping that this could be extended to the icons used by Discord RPC. Unfortunately we have no way of knowing which icons are stored as assets on the Discord dev portal, and so couldn't check whether a game ID is present there or not.