### PR TITLE
DRAGONS: More visual fixes for big-endian systems

### DIFF
--- a/engines/dragons/font.cpp
+++ b/engines/dragons/font.cpp
@@ -160,7 +160,7 @@ Font *FontManager::loadFont(uint16 index, Common::SeekableReadStream &stream) {
 void updatePalEntry(uint16 *pal, uint16 index, uint16 newValue) {
 	newValue = (uint16)(((uint16)newValue & 0x1f) << 10) | (uint16)(((uint16)newValue & 0x7c00) >> 10) |
 			(newValue & 0x3e0) | (newValue & 0x8000);
-	WRITE_SCREEN(pal + index, newValue);
+	WRITE_LE_INT16(pal + index, newValue);
 }
 
 void FontManager::updatePalette() {

--- a/engines/dragons/screen.cpp
+++ b/engines/dragons/screen.cpp
@@ -162,7 +162,7 @@ void Screen::copyRectToSurface(const void *buffer, int srcPitch, int srcWidth, i
 					dst[j * 2] = src[srcIdx * 2];
 					dst[j * 2 + 1] = src[srcIdx * 2 + 1];
 				} else {
-					WRITE_SCREEN(&dst[j * 2], alphaBlendRGB555(READ_LE_INT16(&src[srcIdx * 2]), READ_LE_INT16(&dst[j * 2]), 128));
+					WRITE_SCREEN(&dst[j * 2], alphaBlendRGB555(READ_SCREEN(&src[srcIdx * 2]), READ_SCREEN(&dst[j * 2]), 128));
 					// semi-transparent pixels.
 				}
 			}
@@ -194,8 +194,8 @@ void Screen::copyRectToSurface8bpp(const void *buffer, const byte* palette, int 
 				} else {
 					// semi-transparent pixels.
 					WRITE_SCREEN(&dst[j * 2], alpha == NORMAL
-						? alphaBlendRGB555(c & 0x7fff, READ_LE_INT16(&dst[j * 2]) & 0x7fff, 128)
-						: alphaBlendAdditiveRGB555(c & 0x7fff, READ_LE_INT16(&dst[j * 2]) & 0x7fff));
+						? alphaBlendRGB555(c & 0x7fff, READ_SCREEN(&dst[j * 2]) & 0x7fff, 128)
+						: alphaBlendAdditiveRGB555(c & 0x7fff, READ_SCREEN(&dst[j * 2]) & 0x7fff));
 				}
 			}
 		}
@@ -249,7 +249,7 @@ void Screen::drawScaledSprite(Graphics::Surface *destSurface, const byte *source
 						// only copy opaque pixels
 						WRITE_SCREEN(wdst, c & ~0x8000);
 					} else {
-						WRITE_SCREEN(wdst, alphaBlendRGB555(c & 0x7fffu, READ_LE_UINT16(wdst) & 0x7fffu, 128));
+						WRITE_SCREEN(wdst, alphaBlendRGB555(c & 0x7fffu, READ_SCREEN(wdst) & 0x7fffu, 128));
 						// semi-transparent pixels.
 					}
 				}
@@ -432,7 +432,7 @@ void Screen::copyRectToSurface8bppWrappedX(const Graphics::Surface &srcSurface, 
 					// only copy opaque pixels
 					WRITE_SCREEN(&dst[j * 2], c & ~0x8000);
 				} else {
-					WRITE_SCREEN(&dst[j * 2], alpha == NORMAL ? alphaBlendRGB555(c, READ_LE_INT16(&dst[j * 2]), 128) : alphaBlendAdditiveRGB555(c, READ_LE_INT16(&dst[j * 2])));
+					WRITE_SCREEN(&dst[j * 2], alpha == NORMAL ? alphaBlendRGB555(c, READ_SCREEN(&dst[j * 2]), 128) : alphaBlendAdditiveRGB555(c, READ_SCREEN(&dst[j * 2])));
 					// semi-transparent pixels.
 				}
 			}

--- a/engines/dragons/screen.h
+++ b/engines/dragons/screen.h
@@ -38,8 +38,10 @@ namespace Dragons {
 
 #ifdef SCUMM_BIG_ENDIAN
 	#define WRITE_SCREEN WRITE_BE_UINT16
+	#define READ_SCREEN READ_BE_INT16
 #else
 	#define WRITE_SCREEN WRITE_LE_UINT16
+	#define READ_SCREEN READ_LE_INT16
 #endif
 
 enum AlphaBlendMode {


### PR DESCRIPTION
This continues the work related to https://bugs.scummvm.org/ticket/11710 and previous PR #2784.

With this, Blazing Dragons visuals on big-endian systems are almost identical to those on little-endian systems. The only remaining visual difference I still see is in the copyright menu, where the left creature has some weird pixels around it (I don't know how to fix that part, but everything else seems to be improved).

(In `font.cpp`, I had to revert the `WRITE_SCREEN` change from my previous PR in order to have proper text rendering.)

Note that `void Screen::drawScaledSprite()` was the only place where an uint16 was used for a read. Changing it to an int16 like the rest doesn't seem to cause a regression.

I haven't tested it back on a little-endian system, yet.