### PR TITLE
SCUMM: Fixed regression caused by Pete Workaround

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1424,6 +1424,9 @@ void ScummEngine_v6::o6_getAnimateVariable() {
 	 		_currentRoom == ((_game.id == GID_BASEBALL2001) ? 4 : 3) && \
 			vm.slot[_currentScript].number == 2105 && \
 			a->_costume == ((_game.id == GID_BASEBALL2001) ? 107 : 99) && \
+			// Room variable 5 to ensure this workaround executes only once at
+			// the beginning of the script and room variable 22 to check if we
+			// are bunting.
 			readVar(0x8000 + 5) != 0 && readVar(0x8000 + 22) == 4)
 		push(1);
 	else

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1424,7 +1424,7 @@ void ScummEngine_v6::o6_getAnimateVariable() {
 	 		_currentRoom == ((_game.id == GID_BASEBALL2001) ? 4 : 3) && \
 			vm.slot[_currentScript].number == 2105 && \
 			a->_costume == ((_game.id == GID_BASEBALL2001) ? 107 : 99) && \
-			readVar(0x8000 + 5) != 0)
+			readVar(0x8000 + 5) != 0 && readVar(0x8000 + 22) == 4)
 		push(1);
 	else
 		push(a->getAnimVar(var));


### PR DESCRIPTION
The original commit containing the Pete Wheeler workaround for the Baseball games (#2933) has caused a regression where batting with any other bat as Pete Wheeler would slow down his swinging animation after hitting the ball.  Whoops, This fixes the regression by adding another check to determine whether he is bunting or not.  So sorry about that.