### PR TITLE
WINTERMUTE: Sync render creation code with other engines

### DIFF
--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -504,8 +504,9 @@ bool BaseGame::initialize2() { // we know whether we are going to be accelerated
 #ifdef ENABLE_WME3D
 	Common::String rendererConfig = ConfMan.get("renderer");
 	Graphics::RendererType desiredRendererType = Graphics::parseRendererTypeCode(rendererConfig);
+	Graphics::RendererType matchingRendererType = Graphics::getBestMatchingAvailableRendererType(desiredRendererType);
 
-	if (!_playing3DGame && desiredRendererType == Graphics::kRendererTypeTinyGL) {
+	if (!_playing3DGame && (desiredRendererType == Graphics::kRendererTypeTinyGL || desiredRendererType == Graphics::kRendererTypeDefault)) {
 		_renderer = makeOSystemRenderer(this);
 		if (_renderer == nullptr) {
 			return STATUS_FAILED;
@@ -520,22 +521,27 @@ bool BaseGame::initialize2() { // we know whether we are going to be accelerated
 
 #if defined(USE_OPENGL_GAME)
 	// Check the OpenGL context actually supports shaders
-	if (backendCapableOpenGL && desiredRendererType == Graphics::kRendererTypeOpenGLShaders && !OpenGLContext.shadersSupported) {
-		desiredRendererType = Graphics::kRendererTypeOpenGL;
+	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGLShaders && !OpenGLContext.shadersSupported) {
+		matchingRendererType = Graphics::kRendererTypeOpenGL;
 	}
 #endif
 
+	if (matchingRendererType != desiredRendererType && desiredRendererType != Graphics::kRendererTypeDefault) {
+		// Display a warning if unable to use the desired renderer
+		warning("Unable to create a '%s' renderer", rendererConfig.c_str());
+	}
+
 #if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
-	if (backendCapableOpenGL && desiredRendererType == Graphics::kRendererTypeOpenGLShaders) {
+	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGLShaders) {
 		_renderer3D = makeOpenGL3DShaderRenderer(this);
 	}
 #endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
 #if defined(USE_OPENGL_GAME)
-	if (backendCapableOpenGL && desiredRendererType == Graphics::kRendererTypeOpenGL) {
+	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGL) {
 		_renderer3D = makeOpenGL3DRenderer(this);
 	}
 #endif // defined(USE_OPENGL)
-	if (_playing3DGame && desiredRendererType == Graphics::kRendererTypeTinyGL) {
+	if (_playing3DGame && matchingRendererType == Graphics::kRendererTypeTinyGL) {
 		_renderer3D = nullptr;// TODO: makeTinyGL3DRenderer(this);
 		error("3D software renderered is not supported yet");
 	}


### PR DESCRIPTION
Fixes part of https://bugs.scummvm.org/ticket/12377 issue.

BaseGame::initialize2() is synced with similar functions from #2973 