### PR TITLE
SCUMM: Fix autosave

### DIFF
--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2315,14 +2315,6 @@ void ScummEngine::scummLoop(int delta) {
 		}
 	}
 
-	// Trigger autosave if necessary.
-	if (!_saveLoadFlag && shouldPerformAutoSave(_lastSaveTime) && canSaveGameStateCurrently()) {
-		_saveLoadSlot = 0;
-		_saveLoadDescription = Common::String::format("Autosave %d", _saveLoadSlot);
-		_saveLoadFlag = 1;
-		_saveTemporaryState = false;
-	}
-
 	if (VAR_GAME_LOADED != 0xFF)
 		VAR(VAR_GAME_LOADED) = 0;
 load_game:

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -340,10 +340,6 @@ public:
 	bool canLoadGameStateCurrently() override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently() override;
-	bool canSaveAutosaveCurrently() override {
-		// Keep base engine autosave code disabled in favour of engine's autosave code
-		return false;
-	}
 
 	void pauseEngineIntern(bool pause) override;
 


### PR DESCRIPTION
Autosave was centralized in 30d34fa63d1f5ccf37dfd9c80b0009c4115e78f2, but
SCUMM engine was left behind.

Bugreport #12026
