### PR TITLE
DEVTOOLS: Fix GCC warnings

### DIFF
--- a/devtools/create_lure/create_lure_dat.cpp
+++ b/devtools/create_lure/create_lure_dat.cpp
@@ -27,6 +27,10 @@
 // Disable symbol overrides so that we can use system headers.
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wnarrowing"
+#endif
+
 // HACK to allow building with the SDL backend on MinGW
 // see bug #3412 "TOOLS: MinGW tools building broken"
 #ifdef main


### PR DESCRIPTION
Appear in travis build.

```
create_lure_dat.cpp:1491:1: error: narrowing conversion of `'\37777777665'` from `char` to `unsigned char` inside { } [-Wnarrowing]
```