### PR TITLE
COMMON: removed USE_TTS check from engines

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -52,9 +52,7 @@
 #include "image/bmp.h"
 #endif
 
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 namespace OpenGL {
 
@@ -859,14 +857,12 @@ void OpenGLGraphicsManager::osdMessageUpdateSurface() {
 	_osdMessageAlpha = kOSDMessageInitialAlpha;
 	_osdMessageFadeStartTime = g_system->getMillis() + kOSDMessageFadeOutDelay;
 
-#ifdef USE_TTS
 	if (ConfMan.hasKey("tts_enabled", "scummvm") &&
 			ConfMan.getBool("tts_enabled", "scummvm")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (ttsMan)
 			ttsMan->say(_osdMessageNextData);
 	}
-#endif // USE_TTS
 	// Clear the text update request
 	_osdMessageNextData.clear();
 	_osdMessageChangeRequest = false;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -48,9 +48,7 @@
 #else
 #include "image/bmp.h"
 #endif
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 // SDL surface flags which got removed in SDL2.
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -2220,9 +2218,7 @@ void SurfaceSdlGraphicsManager::drawMouse() {
 void SurfaceSdlGraphicsManager::displayMessageOnOSD(const Common::U32String &msg) {
 	assert(_transactionMode == kTransactionNone);
 	assert(!msg.empty());
-#ifdef USE_TTS
 	Common::U32String textToSay = msg;
-#endif // USE_TTS
 
 	Common::StackLock lock(_graphicsMutex);	// Lock the mutex until this function ends
 
@@ -2298,14 +2294,12 @@ void SurfaceSdlGraphicsManager::displayMessageOnOSD(const Common::U32String &msg
 
 	// Ensure a full redraw takes place next time the screen is updated
 	_forceRedraw = true;
-#ifdef USE_TTS
 	if (ConfMan.hasKey("tts_enabled", "scummvm") &&
 			ConfMan.getBool("tts_enabled", "scummvm")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (ttsMan)
 			ttsMan->say(textToSay);
 	}
-#endif // USE_TTS
 }
 
 SDL_Rect SurfaceSdlGraphicsManager::getOSDMessageRect() const {

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -277,12 +277,10 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 	    && ConfMan.getBool("gui_use_game_language")
 	    && ConfMan.hasKey("language")) {
 		TransMan.setLanguage(ConfMan.get("language"));
-#ifdef USE_TTS
 		Common::TextToSpeechManager *ttsMan;
 		if ((ttsMan = g_system->getTextToSpeechManager()) != nullptr) {
 			ttsMan->setLanguage(ConfMan.get("language"));
 		}
-#endif // USE_TTS
 	}
 #endif // USE_TRANSLATION
 
@@ -322,12 +320,10 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 
 #ifdef USE_TRANSLATION
 	TransMan.setLanguage(previousLanguage);
-#ifdef USE_TTS
-		Common::TextToSpeechManager *ttsMan;
-		if ((ttsMan = g_system->getTextToSpeechManager()) != nullptr) {
-			ttsMan->setLanguage(ConfMan.get("language"));
-		}
-#endif // USE_TTS
+	Common::TextToSpeechManager *ttsMan;
+	if ((ttsMan = g_system->getTextToSpeechManager()) != nullptr) {
+		ttsMan->setLanguage(ConfMan.get("language"));
+	}
 #endif // USE_TRANSLATION
 
 	// Return result (== 0 means no error)
@@ -588,20 +584,15 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 				break;
 			}
 #endif
-#ifdef USE_TTS
 			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 			if (ttsMan != nullptr) {
 				ttsMan->pushState();
 			}
-#endif
 			// Try to run the game
 			Common::Error result = runGame(plugin, enginePlugin, system, specialDebug);
-
-#ifdef USE_TTS
 			if (ttsMan != nullptr) {
 				ttsMan->popState();
 			}
-#endif
 
 #ifdef ENABLE_EVENTRECORDER
 			// Flush Event recorder file. The recorder does not get reinitialized for next game

--- a/common/module.mk
+++ b/common/module.mk
@@ -107,10 +107,8 @@ MODULE_OBJS += \
 	lua/scummvm_file.o
 endif
 
-ifdef USE_TTS
 MODULE_OBJS += \
 	text-to-speech.o
-endif
 
 # Include common rules
 include $(srcdir)/rules.mk

--- a/common/system.cpp
+++ b/common/system.cpp
@@ -50,9 +50,7 @@ OSystem::OSystem() {
 #if defined(USE_UPDATES)
 	_updateManager = nullptr;
 #endif
-#if defined(USE_TTS)
 	_textToSpeechManager = nullptr;
-#endif
 #if defined(USE_SYSDIALOGS)
 	_dialogManager = nullptr;
 #endif
@@ -80,10 +78,8 @@ OSystem::~OSystem() {
 	_updateManager = nullptr;
 #endif
 
-#if defined(USE_TTS)
 	delete _textToSpeechManager;
-	_textToSpeechManager = 0;
-#endif
+	_textToSpeechManager = nullptr;
 
 #if defined(USE_SYSDIALOGS)
 	delete _dialogManager;

--- a/common/system.h
+++ b/common/system.h
@@ -57,9 +57,7 @@ class TaskbarManager;
 #if defined(USE_UPDATES)
 class UpdateManager;
 #endif
-#if defined(USE_TTS)
 class TextToSpeechManager;
-#endif
 #if defined(USE_SYSDIALOGS)
 class DialogManager;
 #endif
@@ -217,14 +215,12 @@ protected:
 	Common::UpdateManager *_updateManager;
 #endif
 
-#if defined(USE_TTS)
 	/**
 	 * No default value is provided for _textToSpeechManager by OSystem.
 	 *
 	 * @note _textToSpeechManager is deleted by the OSystem destructor.
 	 */
 	Common::TextToSpeechManager *_textToSpeechManager;
-#endif
 
 #if defined(USE_SYSDIALOGS)
 	/**
@@ -1556,7 +1552,6 @@ public:
 	}
 #endif
 
-#if defined(USE_TTS)
 	/**
 	 * Return the TextToSpeechManager, used to handle text-to-speech features.
 	 *
@@ -1565,7 +1560,6 @@ public:
 	virtual Common::TextToSpeechManager *getTextToSpeechManager() {
 		return _textToSpeechManager;
 	}
-#endif
 
 #if defined(USE_SYSDIALOGS)
 	/**

--- a/common/text-to-speech.cpp
+++ b/common/text-to-speech.cpp
@@ -23,8 +23,6 @@
 
 #include "common/text-to-speech.h"
 #include "common/system.h"
-#if defined(USE_TTS)
-
 namespace Common {
 
 TTSVoice::TTSVoice()
@@ -159,4 +157,3 @@ void TextToSpeechManager::setLanguage(Common::String language) {
 }
 
 }
-#endif

--- a/common/text-to-speech.h
+++ b/common/text-to-speech.h
@@ -26,8 +26,6 @@
 #include "common/scummsys.h"
 #include "common/str.h"
 
-#if defined(USE_TTS)
-
 #include "common/array.h"
 namespace Common {
 
@@ -349,7 +347,5 @@ protected:
 /** @} */
 
 } // End of namespace Common
-
-#endif	// USE_TTS
 
 #endif // BACKENDS_TEXT_TO_SPEECH_ABSTRACT_H

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -66,9 +66,7 @@
 #include "graphics/pixelformat.h"
 #include "image/bmp.h"
 
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 // FIXME: HACK for error()
 Engine *g_engine = 0;
@@ -600,13 +598,11 @@ void Engine::pauseEngineIntern(bool pause) {
 void Engine::openMainMenuDialog() {
 	if (!_mainMenuDialog)
 		_mainMenuDialog = new MainMenuDialog(this);
-#ifdef USE_TTS
 	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 	if (ttsMan != nullptr) {
 		ttsMan->pushState();
 		g_gui.initTextToSpeech();
 	}
-#endif
 
 	setGameToLoadSlot(-1);
 
@@ -634,10 +630,8 @@ void Engine::openMainMenuDialog() {
 		}
 	}
 
-#ifdef USE_TTS
 	if (ttsMan != nullptr)
 		ttsMan->popState();
-#endif
 
 	g_system->applyBackendSettings();
 	applyGameSettings();

--- a/engines/lure/surface.cpp
+++ b/engines/lure/surface.cpp
@@ -31,10 +31,7 @@
 #include "lure/surface.h"
 #include "common/endian.h"
 #include "common/config-manager.h"
-
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 namespace Lure {
 
@@ -472,21 +469,15 @@ Surface *Surface::newDialog(uint16 width, uint8 numLines, const char **lines, bo
 
 	Surface *s = new Surface(width, size.y);
 	s->createDialog();
-#ifdef USE_TTS
 	Common::String text;
-#endif
 
 	uint16 yP = Surface::textY();
 	for (uint8 ctr = 0; ctr < numLines; ++ctr) {
-#ifdef USE_TTS
 		text += lines[ctr];
-#endif
 		s->writeString(Surface::textX(), yP, lines[ctr], true, color, varLength);
 		yP += squashedLines ? FONT_HEIGHT - 1 : FONT_HEIGHT;
 	}
 
-
-#ifdef USE_TTS
 	if (ConfMan.getBool("tts_narrator")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (ttsMan != nullptr) {
@@ -494,7 +485,6 @@ Surface *Surface::newDialog(uint16 width, uint8 numLines, const char **lines, bo
 			ttsMan->say(text.c_str());
 		}
 	}
-#endif
 
 	return s;
 }

--- a/engines/mads/dialogs.cpp
+++ b/engines/mads/dialogs.cpp
@@ -27,10 +27,7 @@
 #include "mads/msurface.h"
 #include "mads/nebular/dialogs_nebular.h"
 #include "common/config-manager.h"
-
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 namespace MADS {
 
@@ -199,13 +196,11 @@ int TextDialog::estimatePieces(int maxLen) {
 }
 
 TextDialog::~TextDialog() {
-#ifdef USE_TTS
 	if (ConfMan.getBool("tts_narrator")) {
 		Common::TextToSpeechManager* ttsMan = g_system->getTextToSpeechManager();
 		if (ttsMan != nullptr)
 			ttsMan->stop();
 	}
-#endif
 
 	delete _edgeSeries;
 }
@@ -351,9 +346,7 @@ void TextDialog::draw() {
 
 	// Draw the text lines
 	int lineYp = _position.y + 5;
-#ifdef USE_TTS
 	Common::String text;
-#endif
 	for (int lineNum = 0; lineNum <= _numLines; ++lineNum) {
 		if (_lineXp[lineNum] == -1) {
 			// Draw a line across the entire dialog
@@ -377,18 +370,14 @@ void TextDialog::draw() {
 				int lineWidth = _font->getWidth(_lines[lineNum], 1);
 				_vm->_screen->hLine(xp, yp + _font->getHeight(), xp + lineWidth,
 					TEXTDIALOG_BLACK);
-			}
-#ifdef USE_TTS
-			else {
+			} else {
 				text += _lines[lineNum];
 			}
-#endif
 		}
 
 		lineYp += _font->getHeight() + 1;
 	}
 
-#ifdef USE_TTS
 	if (ConfMan.getBool("tts_narrator")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (ttsMan != nullptr) {
@@ -396,7 +385,6 @@ void TextDialog::draw() {
 			ttsMan->say(text.c_str());
 		}
 	}
-#endif
 }
 
 void TextDialog::calculateBounds() {

--- a/engines/mortevielle/dialogs.cpp
+++ b/engines/mortevielle/dialogs.cpp
@@ -422,10 +422,8 @@ void DialogManager::checkForF8(int SpeechNum, bool drawFrame2Fl) {
 			return;
 	} while (_vm->_key != 66); // keycode for F8
 	// just stop the speech when pressing F8
-#ifdef USE_TTS
 	if (_vm->_soundManager->_ttsMan != nullptr)
 		_vm->_soundManager->_ttsMan->stop();
-#endif
 }
 
 /**

--- a/engines/mortevielle/sound.cpp
+++ b/engines/mortevielle/sound.cpp
@@ -33,9 +33,7 @@
 #include "audio/decoders/raw.h"
 #include "common/scummsys.h"
 #include "common/config-manager.h"
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 namespace Mortevielle {
 
@@ -67,7 +65,6 @@ SoundManager::SoundManager(MortevielleEngine *vm, Audio::Mixer *mixer) {
 	_audioStream = nullptr;
 	_ambiantNoiseBuf = nullptr;
 	_noiseBuf = nullptr;
-#ifdef USE_TTS
 	_ttsMan = g_system->getTextToSpeechManager();
 	if (_ttsMan) {
 		_ttsMan->setLanguage(ConfMan.get("language"));
@@ -76,7 +73,6 @@ SoundManager::SoundManager(MortevielleEngine *vm, Audio::Mixer *mixer) {
 		_ttsMan->setPitch(0);
 		_ttsMan->setVolume(100);
 	}
-#endif //USE_TTS
 
 	_soundType = 0;
 	_phonemeNumb = 0;
@@ -207,12 +203,10 @@ void SoundManager::litph(tablint &t, int typ, int tempo) {
 	if (!_buildingSentence) {
 		if (_mixer->isSoundHandleActive(_soundHandle))
 			_mixer->stopHandle(_soundHandle);
-#ifdef USE_TTS
 		if (_ttsMan) {
 			if (_ttsMan->isSpeaking())
 				_ttsMan->stop();
 		}
-#endif // USE_TTS
 		_buildingSentence = true;
 	}
 	int freq = tempo * 252; // 25.2 * 10
@@ -770,7 +764,6 @@ void SoundManager::startSpeech(int rep, int character, int typ) {
 
 	if (typ == 0) {
 		// Speech
-#ifdef USE_TTS
 		const int haut[9] = { 0, 0, 1, -3, 6, -2, 2, 7, -1 };
 		const int voiceIndices[9] = { 0, 1, 2, 3, 0, 4, 5, 1, 6 };
 		if (!_ttsMan)
@@ -806,7 +799,6 @@ void SoundManager::startSpeech(int rep, int character, int typ) {
 
 		_ttsMan->setPitch(pitch);
 		_ttsMan->say(_vm->getString(rep + kDialogStringIndex), Common::kDos850);
-#endif // USE_TTS
 		return;
 	}
 	uint16 savph[501];
@@ -843,15 +835,12 @@ void SoundManager::startSpeech(int rep, int character, int typ) {
 
 void SoundManager::waitSpeech() {
 	if (_soundType == 0) {
-#ifdef USE_TTS
 		if (!_ttsMan)
 			return;
 		while (_ttsMan->isSpeaking() && !_vm->keyPressed() && !_vm->_mouseClick && !_vm->shouldQuit())
 			;
 		// In case the TTS is still speaking, stop it.
 		_ttsMan->stop();
-
-#endif // USE_TTS
 	} else {
 		while (_mixer->isSoundHandleActive(_soundHandle) && !_vm->keyPressed() && !_vm->_mouseClick && !_vm->shouldQuit())
 			;

--- a/engines/mortevielle/sound.h
+++ b/engines/mortevielle/sound.h
@@ -31,9 +31,7 @@
 #include "audio/mixer.h"
 #include "common/mutex.h"
 #include "common/queue.h"
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 namespace Audio {
 class QueuingAudioStream;
@@ -94,9 +92,7 @@ public:
 	~SoundManager();
 
 	Audio::Mixer *_mixer;
-#ifdef USE_TTS
 	Common::TextToSpeechManager *_ttsMan;
-#endif //USE_TTS
 	Audio::SoundHandle _soundHandle;
 	uint16 *_cfiphBuffer;
 

--- a/engines/sherlock/scalpel/scalpel_user_interface.cpp
+++ b/engines/sherlock/scalpel/scalpel_user_interface.cpp
@@ -32,10 +32,7 @@
 #include "sherlock/scalpel/scalpel.h"
 #include "sherlock/sherlock.h"
 #include "common/config-manager.h"
-
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 namespace Sherlock {
 
@@ -2064,7 +2061,6 @@ void ScalpelUserInterface::printObjectDesc(const Common::String &str, bool first
 			SHERLOCK_SCREEN_HEIGHT));
 	}
 
-#ifdef USE_TTS
 	if (ConfMan.getBool("tts_narrator")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (ttsMan != nullptr) {
@@ -2072,7 +2068,6 @@ void ScalpelUserInterface::printObjectDesc(const Common::String &str, bool first
 			ttsMan->say(str.c_str());
 		}
 	}
-#endif
 }
 
 void ScalpelUserInterface::printObjectDesc() {

--- a/engines/sherlock/talk.cpp
+++ b/engines/sherlock/talk.cpp
@@ -34,10 +34,7 @@
 #include "sherlock/tattoo/tattoo_talk.h"
 #include "sherlock/tattoo/tattoo_user_interface.h"
 #include "common/config-manager.h"
-
-#ifdef USE_TTS
 #include "common/text-to-speech.h"
-#endif
 
 namespace Sherlock {
 
@@ -357,7 +354,6 @@ void Talk::talkTo(const Common::String filename) {
 			// Make a copy of the statement (in case the script frees the statement list), and then execute it
 			Statement statement = _statements[select];
 
-#ifdef USE_TTS
 			if (_talkTo == -1 && ConfMan.getBool("tts_narrator")) {
 				Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 				if (ttsMan != nullptr) {
@@ -365,7 +361,6 @@ void Talk::talkTo(const Common::String filename) {
 					ttsMan->say(_statements[select]._reply.c_str());
 				}
 			}
-#endif
 
 			doScript(_statements[select]._reply);
 

--- a/engines/twine/audio/sound.cpp
+++ b/engines/twine/audio/sound.cpp
@@ -118,7 +118,6 @@ bool Sound::playVoxSample(const TextEntry *text) {
 	uint8 *sampPtr = nullptr;
 	int32 sampSize = HQR::getAllocVoxEntry(&sampPtr, _engine->_text->currentVoxBankFile.c_str(), text->index, _engine->_text->voxHiddenIndex);
 	if (sampSize == 0) {
-#ifdef USE_TTS
 		if (ConfMan.hasKey("tts_narrator") && ConfMan.getBool("tts_narrator")) {
 			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 			if (ttsMan != nullptr) {
@@ -128,7 +127,6 @@ bool Sound::playVoxSample(const TextEntry *text) {
 		} else {
 			debug(4, "TTS disabled");
 		}
-#endif
 		warning("Failed to get vox sample for index: %i", text->index);
 		return false;
 	}

--- a/engines/twine/text.cpp
+++ b/engines/twine/text.cpp
@@ -132,12 +132,10 @@ bool Text::playVoxSimple(const TextEntry *text) {
 }
 
 bool Text::stopVox(const TextEntry *text) {
-#ifdef USE_TTS
 	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 	if (ttsMan != nullptr) {
 		ttsMan->stop();
 	}
-#endif
 	if (text == nullptr) {
 		return false;
 	}

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -560,11 +560,9 @@ bool ThemeEngine::addFont(TextData textId, const Common::String &language, const
 				error("Couldn't load font '%s'/'%s'", file.c_str(), scalableFile.c_str());
 #ifdef USE_TRANSLATION
 				TransMan.setLanguage("C");
-#ifdef USE_TTS
 				Common::TextToSpeechManager *ttsMan;
 				if ((ttsMan = g_system->getTextToSpeechManager()) != nullptr)
 					ttsMan->setLanguage("en");
-#endif // USE_TTS
 #endif // USE_TRANSLATION
 
 				// No font, cleanup TextDrawData
@@ -578,11 +576,9 @@ bool ThemeEngine::addFont(TextData textId, const Common::String &language, const
 			// FIXME If we return false anyway why would we attempt the fall-back in the first place?
 #ifdef USE_TRANSLATION
 			TransMan.setLanguage("C");
-#ifdef USE_TTS
-				Common::TextToSpeechManager *ttsMan;
-				if ((ttsMan = g_system->getTextToSpeechManager()) != nullptr)
-					ttsMan->setLanguage("en");
-#endif // USE_TTS
+			Common::TextToSpeechManager *ttsMan;
+			if ((ttsMan = g_system->getTextToSpeechManager()) != nullptr)
+				ttsMan->setLanguage("en");
 #endif // USE_TRANSLATION
 			// Returning true here, would allow falling back to standard fonts for the missing ones,
 			// but that leads to "garbage" glyphs being displayed on screen for non-Latin languages

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -60,7 +60,6 @@ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 	if (g_gui.useRTL())
 		_x = g_system->getOverlayWidth() - _w - _x + g_gui.getOverlayOffset();
 
-#ifdef USE_TTS
 	if (ConfMan.hasKey("tts_enabled", "scummvm") &&
 			ConfMan.getBool("tts_enabled", "scummvm")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
@@ -68,7 +67,6 @@ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 			return;
 		ttsMan->say(widget->getTooltip(), Common::TextToSpeechManager::QUEUE_NO_REPEAT);
 	}
-#endif
 }
 
 void Tooltip::drawDialog(DrawLayer layerToDraw) {

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -83,9 +83,7 @@ GuiManager::GuiManager() : _redrawStatus(kRedrawDisabled), _stateIsSaved(false),
 	setLanguageRTL();
 #endif // USE_TRANSLATION
 
-#ifdef USE_TTS
 	initTextToSpeech();
-#endif // USE_TTS
 
 	ConfMan.registerDefault("gui_theme", "scummremastered");
 	Common::String themefile(ConfMan.get("gui_theme"));
@@ -724,7 +722,6 @@ void GuiManager::setDialogPaddings(int l, int r) {
 	_topDialogRightPadding = r;
 }
 
-#ifdef USE_TTS
 void GuiManager::initTextToSpeech() {
 	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 	if (ttsMan == nullptr)
@@ -749,6 +746,5 @@ void GuiManager::initTextToSpeech() {
 		voice = ttsMan->getDefaultVoice();
 	ttsMan->setVoice(voice);
 }
-#endif
 
 } // End of namespace GUI

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2494,7 +2494,7 @@ void GlobalOptionsDialog::apply() {
 		MessageDialog error(errorMessage);
 		error.runModal();
 	}
-#ifdef USE_TTS
+
 	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 	if (ttsMan) {
 #ifdef USE_TRANSLATION
@@ -2521,7 +2521,6 @@ void GlobalOptionsDialog::apply() {
 			selectedVoice = ttsMan->getDefaultVoice();
 		ttsMan->setVoice(selectedVoice);
 	}
-#endif // USE_TTS
 
 	if (isRebuildNeeded) {
 		g_gui.setLanguageRTL();

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -274,7 +274,6 @@ Common::U32String Widget::cleanupHotkey(const Common::U32String &label) {
 }
 
 void Widget::read(const Common::U32String &str) {
-#ifdef USE_TTS
 	if (ConfMan.hasKey("tts_enabled", "scummvm") &&
 			ConfMan.getBool("tts_enabled", "scummvm")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
@@ -282,7 +281,6 @@ void Widget::read(const Common::U32String &str) {
 			return;
 		ttsMan->say(str);
 	}
-#endif
 }
 
 #pragma mark -

--- a/gui/widgets/popup.cpp
+++ b/gui/widgets/popup.cpp
@@ -200,14 +200,12 @@ void PopUpDialog::handleMouseLeft(int button) {
 }
 
 void PopUpDialog::read(const Common::U32String &str) {
-#ifdef USE_TTS
 	if (ConfMan.hasKey("tts_enabled", "scummvm") &&
 			ConfMan.getBool("tts_enabled", "scummvm")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (ttsMan != nullptr)
 			ttsMan->say(str);
 	}
-#endif
 }
 
 void PopUpDialog::handleKeyDown(Common::KeyState state) {


### PR DESCRIPTION
This removed the need for the engine authors to add scummvm compile time options checks into their engine code. 
There are however still some places where I've left the check in the engine code - this is e.g. for UI options.

OSystem now just returns a `nullptr` if there is no text to speech manager instance (because none is compiled into the binary, or the system doesn't provide support for it). 
