### PR TITLE
SDL: Improve multi-monitor support by replacing display 0 with window display

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -140,10 +140,11 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(SdlEventSource *eventSource, 
 
 	// Retrieve a list of working fullscreen modes
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	const int numModes = SDL_GetNumDisplayModes(0);
+	const int display = _window->getDisplayIndex();
+	const int numModes = SDL_GetNumDisplayModes(display);
 	for (int i = 0; i < numModes; ++i) {
 		SDL_DisplayMode mode;
-		if (SDL_GetDisplayMode(0, i, &mode)) {
+		if (SDL_GetDisplayMode(display, i, &mode)) {
 			continue;
 		}
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -179,17 +179,6 @@ protected:
 		}
 #endif
 	}
-	/**
-	 * Gets the display index that the ScummVM window is on
-	 */
-	void getWindowDisplayIndexFromSdl(int *index) const {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-		assert(_window);
-		*index = SDL_GetWindowDisplayIndex(_window->getSDLWindow());
-#else
-		*index = 0;
-#endif
-	}
 
 	void getDisplayDpiFromSdl(float *dpi, float *defaultDpi) const {
 		const float systemDpi =
@@ -205,10 +194,7 @@ protected:
 
 		if (dpi) {
 #if SDL_VERSION_ATLEAST(2, 0, 4)
-			int displayIndex = 0;
-			getWindowDisplayIndexFromSdl(&displayIndex);
-
-			if (SDL_GetDisplayDPI(displayIndex, NULL, dpi, NULL) != 0) {
+			if (SDL_GetDisplayDPI(_window->getDisplayIndex(), NULL, dpi, NULL) != 0) {
 				*dpi = systemDpi;
 			}
 #else

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -521,18 +521,8 @@ void SurfaceSdlGraphicsManager::detectSupportedFormats() {
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	{
-		SDL_Window *window = _window->getSDLWindow();
-		if (window == nullptr) {
-			error("Could not find ScummVM window for retrieving default display mode");
-		}
-
-		const int displayIndex = SDL_GetWindowDisplayIndex(window);
-		if (displayIndex < 0) {
-			error("Could not find ScummVM window display index");
-		}
-
 		SDL_DisplayMode defaultMode;
-		if (SDL_GetDesktopDisplayMode(displayIndex, &defaultMode) != 0) {
+		if (SDL_GetDesktopDisplayMode(_window->getDisplayIndex(), &defaultMode) != 0) {
 			error("Could not get default system display mode");
 		}
 
@@ -805,7 +795,7 @@ void SurfaceSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFo
 	_transactionDetails.sizeChanged = true;
 }
 
-static void fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &width, int &height) {
+void SurfaceSdlGraphicsManager::fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &width, int &height) const {
 	assert(&width != &height);
 
 	if (desiredAspectRatio.isAuto())
@@ -821,10 +811,11 @@ static void fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &w
 	uint bestMetric = (uint)-1; // Metric is wasted space
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	const int numModes = SDL_GetNumDisplayModes(0);
+	const int display = _window->getDisplayIndex();
+	const int numModes = SDL_GetNumDisplayModes(display);
 	SDL_DisplayMode modeData, *mode = &modeData;
 	for (int i = 0; i < numModes; ++i) {
-		if (SDL_GetDisplayMode(0, i, &modeData)) {
+		if (SDL_GetDisplayMode(display, i, &modeData)) {
 			continue;
 		}
 #else

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -171,6 +171,8 @@ protected:
 
 	virtual void setupHardwareSize();
 
+	void fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &width, int &height) const;
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/* SDL2 features a different API for 2D graphics. We create a wrapper
 	 * around this API to keep the code paths as close as possible. */

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -232,9 +232,8 @@ bool SdlWindow::getSDLWMInformation(SDL_SysWMinfo *info) const {
 
 Common::Rect SdlWindow::getDesktopResolution() {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	int displayIndex = _window ? SDL_GetWindowDisplayIndex(_window) : 0;
 	SDL_DisplayMode displayMode;
-	if (!SDL_GetDesktopDisplayMode(displayIndex, &displayMode)) {
+	if (!SDL_GetDesktopDisplayMode(getDisplayIndex(), &displayMode)) {
 		_desktopRes = Common::Rect(displayMode.w, displayMode.h);
 	}
 #endif
@@ -263,6 +262,16 @@ SDL_Surface *copySDLSurface(SDL_Surface *src) {
 	}
 
 	return res;
+}
+
+int SdlWindow::getDisplayIndex() const {
+	if (_window) {
+		int displayIndex = SDL_GetWindowDisplayIndex(_window);
+		if (displayIndex >= 0)
+			return displayIndex;
+	}
+	// Default to primary display
+	return 0;
 }
 
 bool SdlWindow::createOrUpdateWindow(int width, int height, uint32 flags) {

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -116,6 +116,11 @@ public:
 	SDL_Window *getSDLWindow() const { return _window; }
 
 	/**
+	 * @return The display containing the ScummVM window.
+	 */
+	int getDisplayIndex() const;
+
+	/**
 	 * Creates or updates the SDL window.
 	 *
 	 * @param width   Width of the window.


### PR DESCRIPTION
Currently most SDL2 calls are hardcoded to displayIndex 0 (the primary monitor), so if the ScummVM window is moved to a separate monitor, the results will be incorrect. This attempts to fix this by passing the window display index whenever possible.

This solves the most common bug of resizing / fullscreening on a separate monitor using the wrong resolution, though more work is still necessary to fully support multiple monitors (such as refreshing cached display values when the window is moved).