### PR TITLE
SCUMM: fix bug 4591 Zak keeps walk animation without moving

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -2507,6 +2507,7 @@ void Actor::animateActor(int anim) {
 		break;
 	case 4:				// turn to new direction
 		turnToDirection(dir);
+		startAnimActor(_standFrame);
 		break;
 	case 64:
 		if (_vm->_game.version == 0) {


### PR DESCRIPTION
This fixes a bug described here: https://bugs.scummvm.org/ticket/4594

It seems that if the script tells the player actor to turn towards
something while the player actor is walking, the walk animation is not
stopped.

The fix is to play the standing animation after turning
direction.

The bug is easy to reproduce following the steps in the bug report, and is also reproducible in the PC version (Zak McKracken and the Alien Mindbenders (V2/DOS/English)). I played through a good deal of scripted events in Zak and could see no adverse behaviour. To be on the safe side, we could put a guard around the code change so it's only executed if the game is Zak.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements. 

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
