### PR TITLE
GUI: Convert the cursor bitmap to the overlay format

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -1530,16 +1530,16 @@ bool ThemeEngine::createCursor(const Common::String &filename, int hotspotX, int
 	_cursorHeight = cursor->h;
 
 #ifdef USE_RGB_COLOR
-	_cursorFormat = cursor->format;
+	_cursorFormat = _overlayFormat;
 	_cursorTransparent = _cursorFormat.RGBToColor(0xFF, 0, 0xFF);
 
 	// Allocate a new buffer for the cursor
 	delete[] _cursor;
 	_cursor = new byte[_cursorWidth * _cursorHeight * _cursorFormat.bytesPerPixel];
 	assert(_cursor);
-	Graphics::copyBlit(_cursor, (const byte *)cursor->getPixels(),
-	                   _cursorWidth * _cursorFormat.bytesPerPixel, cursor->pitch,
-	                   _cursorWidth, _cursorHeight, _cursorFormat.bytesPerPixel);
+	Graphics::crossBlit(_cursor, (const byte *)cursor->getPixels(),
+	                    _cursorWidth * _cursorFormat.bytesPerPixel, cursor->pitch,
+	                    _cursorWidth, _cursorHeight, _cursorFormat, cursor->format);
 
 	_useCursor = true;
 #else


### PR DESCRIPTION
This fixes a regression from commit 0fc5c4c3916992691b3c8777e8ffaaf45af99ba5, although a better long term solution might be to handle conversion in `Graphics::CursorManager` instead.