### PR TITLE
TINSEL: numPolygons fixes for big-endian systems

### DIFF
--- a/engines/tinsel/tinsel.cpp
+++ b/engines/tinsel/tinsel.cpp
@@ -763,8 +763,7 @@ GameChunk createGameChunkV2() {
 	chunk.numObjects = (cptr != NULL) ? READ_32(cptr) : 0;
 
 	cptr = FindChunk(MASTER_SCNHANDLE, CHUNK_TOTAL_POLY);
-	if (cptr != NULL)
-		chunk.numPolygons = READ_32(cptr);
+	chunk.numPolygons = (cptr != NULL) ? READ_32(cptr) : 0;
 
 	if (TinselV2) {
 		cptr = FindChunk(MASTER_SCNHANDLE, CHUNK_NUM_PROCESSES);
@@ -815,7 +814,7 @@ void LoadBasicChunks() {
 
 	_vm->_dialogs->RegisterIcons(cptr, game.numObjects);
 
-	// Max polygons are 0 in DW1 Mac (both in the demo and the full version)
+	// Max polygons are 0 in the original DW1 V0 demo and in DW1 Mac (both in the demo and the full version)
 	if (game.numPolygons != 0)
 		MaxPolygons(game.numPolygons);
 

--- a/engines/tinsel/tinsel.cpp
+++ b/engines/tinsel/tinsel.cpp
@@ -764,7 +764,7 @@ GameChunk createGameChunkV2() {
 
 	cptr = FindChunk(MASTER_SCNHANDLE, CHUNK_TOTAL_POLY);
 	if (cptr != NULL)
-		chunk.numPolygons = *cptr;
+		chunk.numPolygons = READ_32(cptr);
 
 	if (TinselV2) {
 		cptr = FindChunk(MASTER_SCNHANDLE, CHUNK_NUM_PROCESSES);


### PR DESCRIPTION
When testing the original V0 Floppy Demo of Disworld (`dw-dos-floppy-demo-en.zip`) on a big-endian PowerPC machine, the game would immediately trigger `assert(numPolys <= MAX_POLY)` in `MaxPolygons()`.

It appears that numPolygons was left uninitialized, and so it was set to a big value which would trigger this assertion.

Looking at the changes done in commit 24b77f1, I think the original intent was to use the `(cptr != NULL) ? READ_32(cptr) : 0` idiom, like the rest around it.

Tested with the various available Discworld1 demos on a big-endian system.