### PR TITLE
DETECTOR: Modify getFileProperties to cache md5 results

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -32,6 +32,8 @@
 
 #include "base/detection/detection.h"
 
+#include "engines/advancedDetector.h"
+
 // Plugin versioning
 
 int pluginTypeVersions[PLUGIN_TYPE_MAX] = {
@@ -705,6 +707,9 @@ DetectionResults EngineManager::detectGames(const Common::FSList &fslist) const 
 	// MetaEngines are always loaded into memory, so, get them and
 	// run detection for all of them.
 	plugins = getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
+
+	// Clear md5 cache before each detection starts, just in case.
+	MD5Man.clear();
 
 	// Iterate over all known games and for each check if it might be
 	// the game in the presented directory.

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -462,13 +462,7 @@ bool AdvancedMetaEngineDetection::getFileProperties(const FileMap &allFiles, con
 	if (!allFiles.contains(fname))
 		return false;
 
-	fileProps.md5.clear();
-
-	const char *numbers = "0123456789";
-	Common::String hashname = allFiles[fname].getPath() + ":";
-	for (uint n = _md5Bytes; n > 0; n/=10) {
-		hashname += numbers[n % 10];
-	}
+	Common::String hashname = Common::String::format("%s:%d", allFiles[fname].getPath().c_str(), _md5Bytes);
 
 	if (MD5Man.contains(hashname)) {
 		fileProps.md5 = MD5Man.getMD5(hashname);

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -500,5 +500,51 @@ public:
 	 */
 	bool getFilePropertiesExtern(uint md5Bytes, const FileMap &allFiles, const ADGameDescription &game, const Common::String fname, FileProperties &fileProps) const;
 };
+
+/**
+ * Singleton Cache Storage for Computed MD5s
+ */
+class MD5CacheManager : public Common::Singleton<MD5CacheManager> {
+public:
+	void setMD5(Common::String fname, Common::String md5) {
+		md5HashMap.setVal(fname, md5);
+	}
+
+	Common::String getMD5(Common::String fname) {
+		return md5HashMap.getVal(fname);
+	}
+
+	void setSize(Common::String fname, int32 size) {
+		sizeHashMap.setVal(fname, size);
+	}
+
+	int32 getSize(Common::String fname) {
+		return sizeHashMap.getVal(fname);
+	}
+
+	bool contains(Common::String fname) {
+		return (md5HashMap.contains(fname) && sizeHashMap.contains(fname));
+	}
+
+	MD5CacheManager() {
+		clear();
+	}
+
+	void clear() {
+		md5HashMap.clear(true);
+		sizeHashMap.clear(true);
+	}
+
+private:
+	friend class Common::Singleton<MD5CacheManager>;
+
+	typedef Common::HashMap<Common::String, Common::String, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> FileHashMap;
+	typedef Common::HashMap<Common::String, int32, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> SizeHashMap;
+	FileHashMap md5HashMap;
+	SizeHashMap sizeHashMap;
+};
+
+/** Convenience shortcut for accessing the MD5CacheManager. */
+#define MD5Man MD5CacheManager::instance()
 /** @} */
 #endif

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -567,51 +567,5 @@ private:
 
 /** Convenience shortcut for accessing the engine manager. */
 #define EngineMan EngineManager::instance()
-
-/**
- * Singleton Cache Storage for Computed MD5s
- */
-class MD5CacheManager : public Common::Singleton<MD5CacheManager> {
-public:
-	void setMD5(Common::String fname, Common::String md5) {
-		md5HashMap.setVal(fname, md5);
-	}
-
-	Common::String getMD5(Common::String fname) {
-		return md5HashMap.getVal(fname);
-	}
-
-	void setSize(Common::String fname, int32 size) {
-		sizeHashMap.setVal(fname, size);
-	}
-
-	int32 getSize(Common::String fname) {
-		return sizeHashMap.getVal(fname);
-	}
-
-	bool contains(Common::String fname) {
-		return (md5HashMap.contains(fname) && sizeHashMap.contains(fname));
-	}
-
-	MD5CacheManager() {
-		clear();
-	}
-
-	void clear() {
-		md5HashMap.clear(true);
-		sizeHashMap.clear(true);
-	}
-
-private:
-	friend class Common::Singleton<MD5CacheManager>;
-
-	typedef Common::HashMap<Common::String, Common::String, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> FileHashMap;
-	typedef Common::HashMap<Common::String, int32, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> SizeHashMap;
-	FileHashMap md5HashMap;
-	SizeHashMap sizeHashMap;
-};
-
-/** Convenience shortcut for accessing the MD5CacheManager. */
-#define MD5Man MD5CacheManager::instance()
 /** @} */
 #endif

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -567,5 +567,51 @@ private:
 
 /** Convenience shortcut for accessing the engine manager. */
 #define EngineMan EngineManager::instance()
+
+/**
+ * Singleton Cache Storage for Computed MD5s
+ */
+class MD5CacheManager : public Common::Singleton<MD5CacheManager> {
+public:
+	void setMD5(Common::String fname, Common::String md5) {
+		md5HashMap.setVal(fname, md5);
+	}
+
+	Common::String getMD5(Common::String fname) {
+		return md5HashMap.getVal(fname);
+	}
+
+	void setSize(Common::String fname, int32 size) {
+		sizeHashMap.setVal(fname, size);
+	}
+
+	int32 getSize(Common::String fname) {
+		return sizeHashMap.getVal(fname);
+	}
+
+	bool contains(Common::String fname) {
+		return (md5HashMap.contains(fname) && sizeHashMap.contains(fname));
+	}
+
+	MD5CacheManager() {
+		clear();
+	}
+
+	void clear() {
+		md5HashMap.clear(true);
+		sizeHashMap.clear(true);
+	}
+
+private:
+	friend class Common::Singleton<MD5CacheManager>;
+
+	typedef Common::HashMap<Common::String, Common::String, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> FileHashMap;
+	typedef Common::HashMap<Common::String, int32, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> SizeHashMap;
+	FileHashMap md5HashMap;
+	SizeHashMap sizeHashMap;
+};
+
+/** Convenience shortcut for accessing the MD5CacheManager. */
+#define MD5Man MD5CacheManager::instance()
 /** @} */
 #endif

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -51,6 +51,7 @@
 #include "gui/widgets/tab.h"
 #include "gui/widgets/popup.h"
 #include "gui/ThemeEval.h"
+#include "engines/advancedDetector.h"
 
 #include "graphics/cursorman.h"
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -393,6 +393,7 @@ void LauncherDialog::massAddGame() {
 	MessageDialog alert(_("Do you really want to run the mass game detector? "
 						  "This could potentially add a huge number of games."), _("Yes"), _("No"));
 	if (alert.runModal() == GUI::kMessageOK && _browser->runModal() > 0) {
+		MD5Man.clear();
 		MassAddDialog massAddDlg(_browser->getResult());
 
 		massAddDlg.runModal();


### PR DESCRIPTION
Define a Singleton that stores the md5 and size of files, used during mass add.
This skips the double computing of md5s during a single mass add, with the cache being cleared in subsequent mass adds.