### PR TITLE
BACKENDS: SDL: Fix memory leak in supported graphics modes

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -300,27 +300,8 @@ static void initGraphicsModes() {
 	s_supportedGraphicsModes->push_back(gm);
 }
 
-const OSystem::GraphicsMode *SurfaceSdlGraphicsManager::supportedGraphicsModes() const {
-	if (!s_supportedGraphicsModes)
-		initGraphicsModes();
-
-	int size = s_supportedGraphicsModes->size();
-	OSystem::GraphicsMode *modes = new OSystem::GraphicsMode[size];
-	memcpy(modes, &(*s_supportedGraphicsModes)[0], size * sizeof(OSystem::GraphicsMode));
-
-	// Do deep copy. Each can be freed independently of the other.
-	OSystem::GraphicsMode *gm = modes;
-	while (gm->name) {
-		gm->name = scumm_strdup(gm->name);
-		gm->description = scumm_strdup(gm->description);
-		++gm;
-	}
-
-	return modes;
-}
-
 const OSystem::GraphicsMode *SurfaceSdlGraphicsManager::getSupportedGraphicsModes() const {
-	return supportedGraphicsModes();
+	return s_supportedGraphicsModes->begin();
 }
 
 int SurfaceSdlGraphicsManager::getDefaultGraphicsMode() const {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -65,7 +65,6 @@ public:
 	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 	virtual bool getFeatureState(OSystem::Feature f) const override;
 
-	const OSystem::GraphicsMode *supportedGraphicsModes() const;
 	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
 	virtual int getDefaultGraphicsMode() const override;
 	virtual bool setGraphicsMode(int mode, uint flags = OSystem::kGfxModeNoFlags) override;

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -139,7 +139,7 @@ protected:
 #endif
 
 	/**
-	 * Initialze the SDL library.
+	 * Initialize the SDL library.
 	 */
 	virtual void initSDL();
 
@@ -163,9 +163,14 @@ protected:
 	int _defaultGLMode;
 
 	/**
-	 * Creates the merged graphics modes list
+	 * Create the merged graphics modes list.
 	 */
 	void setupGraphicsModes();
+
+	/**
+	 * Clear the merged graphics modes list.
+	 */
+	void clearGraphicsModes();
 
 	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
 	virtual int getDefaultGraphicsMode() const override;


### PR DESCRIPTION
I found leaks running scummvm built with address sanitizer.
They are easy to reproduce: just starts scummvm and exit when
the launcher appears.

```
Direct leak of 432 byte(s) in 1 object(s) allocated from:
    #0 0x7f08a98daef0 in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xeaef0)
    #1 0x55b41cbb76eb in SurfaceSdlGraphicsManager::supportedGraphicsModes() const backends/graphics/surfacesdl/surfacesdl-graphics.cpp:310
    #2 0x55b41cbb7b6d in SurfaceSdlGraphicsManager::getSupportedGraphicsModes() const backends/graphics/surfacesdl/surfacesdl-graphics.cpp:325
    #3 0x55b41a8e2886 in OSystem_SDL::setupGraphicsModes() backends/platform/sdl/sdl.cpp:904
    #4 0x55b41a8e867b in OSystem_SDL::initBackend() backends/platform/sdl/sdl.cpp:290
    #5 0x55b41a8f1ea5 in OSystem_POSIX::initBackend() backends/platform/sdl/posix/posix.cpp:93
    #6 0x55b41a909900 in scummvm_main base/main.cpp:475
    #7 0x55b41a8f1844 in main backends/platform/sdl/posix/posix-main.cpp:45
    #8 0x7f08a6c5109a in __libc_start_main ../csu/libc-start.c:308

Indirect leak of 142 byte(s) in 17 object(s) allocated from:
    #0 0x7f08a98d9330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x55b41e42590c in scumm_strdup(char const*) common/str.cpp:889
    #2 0x55b41cbb78a4 in SurfaceSdlGraphicsManager::supportedGraphicsModes() const backends/graphics/surfacesdl/surfacesdl-graphics.cpp:317
    #3 0x55b41cbb7b6d in SurfaceSdlGraphicsManager::getSupportedGraphicsModes() const backends/graphics/surfacesdl/surfacesdl-graphics.cpp:325
    #4 0x55b41a8e2886 in OSystem_SDL::setupGraphicsModes() backends/platform/sdl/sdl.cpp:904
    #5 0x55b41a8e867b in OSystem_SDL::initBackend() backends/platform/sdl/sdl.cpp:290
    #6 0x55b41a8f1ea5 in OSystem_POSIX::initBackend() backends/platform/sdl/posix/posix.cpp:93
    #7 0x55b41a909900 in scummvm_main base/main.cpp:475
    #8 0x55b41a8f1844 in main backends/platform/sdl/posix/posix-main.cpp:45
    #9 0x7f08a6c5109a in __libc_start_main ../csu/libc-start.c:308

Indirect leak of 142 byte(s) in 17 object(s) allocated from:
    #0 0x7f08a98d9330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x55b41e42590c in scumm_strdup(char const*) common/str.cpp:889
    #2 0x55b41cbb7828 in SurfaceSdlGraphicsManager::supportedGraphicsModes() const backends/graphics/surfacesdl/surfacesdl-graphics.cpp:316
    #3 0x55b41cbb7b6d in SurfaceSdlGraphicsManager::getSupportedGraphicsModes() const backends/graphics/surfacesdl/surfacesdl-graphics.cpp:325
    #4 0x55b41a8e2886 in OSystem_SDL::setupGraphicsModes() backends/platform/sdl/sdl.cpp:904
    #5 0x55b41a8e867b in OSystem_SDL::initBackend() backends/platform/sdl/sdl.cpp:290
    #6 0x55b41a8f1ea5 in OSystem_POSIX::initBackend() backends/platform/sdl/posix/posix.cpp:93
    #7 0x55b41a909900 in scummvm_main base/main.cpp:475
    #8 0x55b41a8f1844 in main backends/platform/sdl/posix/posix-main.cpp:45
    #9 0x7f08a6c5109a in __libc_start_main ../csu/libc-start.c:308
```

Changes description:

Supported graphics modes are grouped in an merged array in which
the first part contains modes from the non-OpenGL SDL manager,
obtained by a copy dynamically allocated.

When the array was rebuilt or aimed to be destroyed, it was only
cleared (removing elements) but not freeing duplicated fields
name and description.

An additional leak came from the temporary array (srcModes)
not freed.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
