### PR TITLE
WIN32: Enable building with UNICODE

### DIFF
--- a/backends/fs/stdiostream.cpp
+++ b/backends/fs/stdiostream.cpp
@@ -27,6 +27,13 @@
 
 #include "backends/fs/stdiostream.h"
 
+// for Windows unicode fopen(): _wfopen()
+#if defined(WIN32) && defined(UNICODE)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include "backends/platform/sdl/win32/win32_wrapper.h"
+#endif
+
 StdioStream::StdioStream(void *handle) : _handle(handle) {
 	assert(handle);
 }
@@ -85,7 +92,13 @@ bool StdioStream::flush() {
 }
 
 StdioStream *StdioStream::makeFromPath(const Common::String &path, bool writeMode) {
+#if defined(WIN32) && defined(UNICODE)
+	wchar_t *wPath = Win32::stringToTchar(path);
+	FILE *handle = _wfopen(wPath, writeMode ? L"wb" : L"rb");
+	free(wPath);
+#else
 	FILE *handle = fopen(path.c_str(), writeMode ? "wb" : "rb");
+#endif
 
 	if (handle)
 		return new StdioStream(handle);

--- a/backends/fs/windows/windows-fs.cpp
+++ b/backends/fs/windows/windows-fs.cpp
@@ -44,40 +44,40 @@
 #endif
 
 bool WindowsFilesystemNode::exists() const {
-	return _access(_path.c_str(), F_OK) == 0;
+	return _taccess(charToTchar(_path.c_str()), F_OK) == 0;
 }
 
 bool WindowsFilesystemNode::isReadable() const {
-	return _access(_path.c_str(), R_OK) == 0;
+	return _taccess(charToTchar(_path.c_str()), R_OK) == 0;
 }
 
 bool WindowsFilesystemNode::isWritable() const {
-	return _access(_path.c_str(), W_OK) == 0;
+	return _taccess(charToTchar(_path.c_str()), W_OK) == 0;
 }
 
 void WindowsFilesystemNode::addFile(AbstractFSList &list, ListMode mode, const char *base, bool hidden, WIN32_FIND_DATA* find_data) {
-	WindowsFilesystemNode entry;
-	char *asciiName = toAscii(find_data->cFileName);
-	bool isDirectory;
-
 	// Skip local directory (.) and parent (..)
-	if (!strcmp(asciiName, ".") || !strcmp(asciiName, ".."))
+	if (!_tcscmp(find_data->cFileName, TEXT(".")) ||
+		!_tcscmp(find_data->cFileName, TEXT("..")))
 		return;
 
 	// Skip hidden files if asked
 	if ((find_data->dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) && !hidden)
 		return;
 
-	isDirectory = (find_data->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ? true : false);
+	bool isDirectory = ((find_data->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? true : false);
 
 	if ((!isDirectory && mode == Common::FSNode::kListDirectoriesOnly) ||
 		(isDirectory && mode == Common::FSNode::kListFilesOnly))
 		return;
 
+	const char *fileName = tcharToChar(find_data->cFileName);
+
+	WindowsFilesystemNode entry;
 	entry._isDirectory = isDirectory;
-	entry._displayName = asciiName;
+	entry._displayName = fileName;
 	entry._path = base;
-	entry._path += asciiName;
+	entry._path += fileName;
 	if (entry._isDirectory)
 		entry._path += "\\";
 	entry._isValid = true;
@@ -86,23 +86,23 @@ void WindowsFilesystemNode::addFile(AbstractFSList &list, ListMode mode, const c
 	list.push_back(new WindowsFilesystemNode(entry));
 }
 
-char* WindowsFilesystemNode::toAscii(TCHAR *str) {
+const char* WindowsFilesystemNode::tcharToChar(const TCHAR *str) {
 #ifndef UNICODE
-	return (char *)str;
+	return str;
 #else
-	static char asciiString[MAX_PATH];
-	WideCharToMultiByte(CP_ACP, 0, str, _tcslen(str) + 1, asciiString, sizeof(asciiString), NULL, NULL);
-	return asciiString;
+	static char multiByteString[MAX_PATH];
+	WideCharToMultiByte(CP_UTF8, 0, str, _tcslen(str) + 1, multiByteString, MAX_PATH, NULL, NULL);
+	return multiByteString;
 #endif
 }
 
-const TCHAR* WindowsFilesystemNode::toUnicode(const char *str) {
+const TCHAR* WindowsFilesystemNode::charToTchar(const char *str) {
 #ifndef UNICODE
-	return (const TCHAR *)str;
+	return str;
 #else
-	static TCHAR unicodeString[MAX_PATH];
-	MultiByteToWideChar(CP_ACP, 0, str, strlen(str) + 1, unicodeString, sizeof(unicodeString) / sizeof(TCHAR));
-	return unicodeString;
+	static wchar_t wideCharString[MAX_PATH];
+	MultiByteToWideChar(CP_UTF8, 0, str, strlen(str) + 1, wideCharString, MAX_PATH);
+	return wideCharString;
 #endif
 }
 
@@ -116,9 +116,9 @@ WindowsFilesystemNode::WindowsFilesystemNode() {
 
 WindowsFilesystemNode::WindowsFilesystemNode(const Common::String &p, const bool currentDir) {
 	if (currentDir) {
-		char path[MAX_PATH];
+		TCHAR path[MAX_PATH];
 		GetCurrentDirectory(MAX_PATH, path);
-		_path = path;
+		_path = tcharToChar(path);
 	} else {
 		assert(p.size() > 0);
 		_path = p;
@@ -133,7 +133,7 @@ WindowsFilesystemNode::WindowsFilesystemNode(const Common::String &p, const bool
 
 void WindowsFilesystemNode::setFlags() {
 	// Check whether it is a directory, and whether the file actually exists
-	DWORD fileAttribs = GetFileAttributes(toUnicode(_path.c_str()));
+	DWORD fileAttribs = GetFileAttributes(charToTchar(_path.c_str()));
 
 	if (fileAttribs == INVALID_FILE_ATTRIBUTES) {
 		_isDirectory = false;
@@ -175,13 +175,13 @@ bool WindowsFilesystemNode::getChildren(AbstractFSList &myList, ListMode mode, b
 				WindowsFilesystemNode entry;
 				char drive_name[2];
 
-				drive_name[0] = toAscii(current_drive)[0];
+				drive_name[0] = tcharToChar(current_drive)[0];
 				drive_name[1] = '\0';
 				entry._displayName = drive_name;
 				entry._isDirectory = true;
 				entry._isValid = true;
 				entry._isPseudoRoot = false;
-				entry._path = toAscii(current_drive);
+				entry._path = tcharToChar(current_drive);
 				myList.push_back(new WindowsFilesystemNode(entry));
 		}
 	} else {
@@ -192,7 +192,7 @@ bool WindowsFilesystemNode::getChildren(AbstractFSList &myList, ListMode mode, b
 
 		sprintf(searchPath, "%s*", _path.c_str());
 
-		handle = FindFirstFile(toUnicode(searchPath), &desc);
+		handle = FindFirstFile(charToTchar(searchPath), &desc);
 
 		if (handle == INVALID_HANDLE_VALUE)
 			return false;
@@ -239,7 +239,7 @@ Common::WriteStream *WindowsFilesystemNode::createWriteStream() {
 }
 
 bool WindowsFilesystemNode::createDirectory() {
-	if (CreateDirectory(toUnicode(_path.c_str()), NULL) != 0)
+	if (CreateDirectory(charToTchar(_path.c_str()), NULL) != 0)
 		setFlags();
 
 	return _isValid && _isDirectory;

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -96,20 +96,26 @@ private:
 	static void addFile(AbstractFSList &list, ListMode mode, const char *base, bool hidden, WIN32_FIND_DATA* find_data);
 
 	/**
-	 * Converts a Unicode string to Ascii format.
+	 * Converts a string of TCHARs returned from a Windows API function to
+	 * a character string. If UNICODE is defined then the incoming string
+	 * is wide characters and is converted to UTF8, otherwise the incoming
+	 * string is returned with no conversion.
 	 *
-	 * @param str Common::String to convert from Unicode to Ascii.
-	 * @return str in Ascii format.
+	 * @param str String to convert if UNICODE is defined
+	 * @return str in UTF8 format if UNICODE is defined, otherwise just str
 	 */
-	static char *toAscii(TCHAR *str);
+	static const char *tcharToChar(const TCHAR *str);
 
 	/**
-	 * Converts an Ascii string to Unicode format.
+	 * Converts a character string to a string of TCHARs for passing
+	 * to a Windows API function. If UNICODE is defined then the incoming
+	 * string is converted from UTF8 to wide characters, otherwise the incoming
+	 * string is returned with no conversion.
 	 *
-	 * @param str Common::String to convert from Ascii to Unicode.
-	 * @return str in Unicode format.
+	 * @param str String to convert if UNICODE is defined
+	 * @return str in wide character format if UNICODE is defined, otherwise just str
 	 */
-	static const TCHAR* toUnicode(const char *str);
+	static const TCHAR* charToTchar(const char *str);
 
 	/**
 	 * Tests and sets the _isValid and _isDirectory flags, using the GetFileAttributes() function.

--- a/backends/midi/windows.cpp
+++ b/backends/midi/windows.cpp
@@ -32,6 +32,7 @@
 
 #include "audio/musicplugin.h"
 #include "audio/mpu401.h"
+#include "backends/platform/sdl/win32/win32_wrapper.h"
 #include "common/config-manager.h"
 #include "common/translation.h"
 #include "common/textconsole.h"
@@ -151,10 +152,11 @@ void MidiDriver_WIN::sysEx(const byte *msg, uint16 length) {
 }
 
 void MidiDriver_WIN::check_error(MMRESULT result) {
-	char buf[200];
+	TCHAR buf[MAXERRORLENGTH];
 	if (result != MMSYSERR_NOERROR) {
-		midiOutGetErrorText(result, buf, 200);
-		warning("MM System Error '%s'", buf);
+		midiOutGetErrorText(result, buf, MAXERRORLENGTH);
+		Common::String errorMessage = Win32::tcharToString(buf);
+		warning("MM System Error '%s'", errorMessage.c_str());
 	}
 }
 
@@ -184,7 +186,8 @@ MusicDevices WindowsMusicPlugin::getDevices() const {
 	for (int i = 0; i < numDevs; i++) {
 		if (midiOutGetDevCaps(i, &tmp, sizeof(MIDIOUTCAPS)) != MMSYSERR_NOERROR)
 			break;
-		deviceNames.push_back(tmp.szPname);
+		Common::String deviceName = Win32::tcharToString(tmp.szPname);
+		deviceNames.push_back(deviceName);
 	}
 
 	// Limit us to the number of actually retrieved devices.

--- a/backends/platform/sdl/win32/win32-main.cpp
+++ b/backends/platform/sdl/win32/win32-main.cpp
@@ -35,6 +35,7 @@
 #include <windows.h>
 
 #include "backends/platform/sdl/win32/win32.h"
+#include "backends/platform/sdl/win32/win32_wrapper.h"
 #include "backends/plugins/sdl/sdl-provider.h"
 #include "base/main.h"
 
@@ -56,6 +57,10 @@ int __stdcall WinMain(HINSTANCE /*hInst*/, HINSTANCE /*hPrevInst*/,  LPSTR /*lpC
 }
 
 int main(int argc, char *argv[]) {
+#ifdef UNICODE
+	argv = Win32::getArgvUtf8(&argc);
+#endif
+
 	// Create our OSystem instance
 	g_system = new OSystem_Win32();
 	assert(g_system);
@@ -72,6 +77,10 @@ int main(int argc, char *argv[]) {
 
 	// Free OSystem
 	g_system->destroy();
+
+#ifdef UNICODE
+	Win32::freeArgvUtf8(argc, argv);
+#endif
 
 	return res;
 }

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -340,7 +340,8 @@ BOOL CALLBACK EnumResNameProc(HMODULE hModule, LPCTSTR lpszType, LPTSTR lpszName
 		return TRUE;
 
 	Win32ResourceArchive *arch = (Win32ResourceArchive *)lParam;
-	arch->_files.push_back(lpszName);
+	Common::String filename = Win32::tcharToString(lpszName);
+	arch->_files.push_back(filename);
 	return TRUE;
 }
 
@@ -371,7 +372,9 @@ const Common::ArchiveMemberPtr Win32ResourceArchive::getMember(const Common::Str
 }
 
 Common::SeekableReadStream *Win32ResourceArchive::createReadStreamForMember(const Common::String &name) const {
-	HRSRC resource = FindResource(NULL, name.c_str(), MAKEINTRESOURCE(256));
+	TCHAR *tName = Win32::stringToTchar(name);
+	HRSRC resource = FindResource(NULL, tName, MAKEINTRESOURCE(256));
+	free(tName);
 
 	if (resource == NULL)
 		return 0;

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -232,7 +232,7 @@ Common::String OSystem_Win32::getScreenshotsPath() {
 	}
 
 	// Use the My Pictures folder.
-	char picturesPath[MAXPATHLEN];
+	char picturesPath[MAX_PATH];
 
 	if (SHGetFolderPathFunc(NULL, CSIDL_MYPICTURES, NULL, SHGFP_TYPE_CURRENT, picturesPath) != S_OK) {
 		warning("Unable to access My Pictures directory");
@@ -252,7 +252,7 @@ Common::String OSystem_Win32::getScreenshotsPath() {
 }
 
 Common::String OSystem_Win32::getDefaultConfigFileName() {
-	char configFile[MAXPATHLEN];
+	char configFile[MAX_PATH];
 
 	// Use the Application Data directory of the user profile.
 	if (SHGetFolderPathFunc(NULL, CSIDL_APPDATA, NULL, SHGFP_TYPE_CURRENT, configFile) == S_OK) {
@@ -267,9 +267,9 @@ Common::String OSystem_Win32::getDefaultConfigFileName() {
 		FILE *tmp = NULL;
 		if ((tmp = fopen(configFile, "r")) == NULL) {
 			// Check windows directory
-			char oldConfigFile[MAXPATHLEN];
-			uint ret = GetWindowsDirectory(oldConfigFile, MAXPATHLEN);
-			if (ret == 0 || ret > MAXPATHLEN)
+			char oldConfigFile[MAX_PATH];
+			uint ret = GetWindowsDirectory(oldConfigFile, MAX_PATH);
+			if (ret == 0 || ret > MAX_PATH)
 				error("Cannot retrieve the path of the Windows directory");
 
 			strcat(oldConfigFile, "\\" DEFAULT_CONFIG_FILE);
@@ -284,8 +284,8 @@ Common::String OSystem_Win32::getDefaultConfigFileName() {
 	} else {
 		warning("Unable to access application data directory");
 		// Check windows directory
-		uint ret = GetWindowsDirectory(configFile, MAXPATHLEN);
-		if (ret == 0 || ret > MAXPATHLEN)
+		uint ret = GetWindowsDirectory(configFile, MAX_PATH);
+		if (ret == 0 || ret > MAX_PATH)
 			error("Cannot retrieve the path of the Windows directory");
 
 		strcat(configFile, "\\" DEFAULT_CONFIG_FILE);
@@ -295,7 +295,7 @@ Common::String OSystem_Win32::getDefaultConfigFileName() {
 }
 
 Common::String OSystem_Win32::getDefaultLogFileName() {
-	char logFile[MAXPATHLEN];
+	char logFile[MAX_PATH];
 
 	// Use the Application Data directory of the user profile.
 	if (SHGetFolderPathFunc(NULL, CSIDL_APPDATA, NULL, SHGFP_TYPE_CURRENT, logFile) != S_OK) {

--- a/backends/platform/sdl/win32/win32_wrapper.cpp
+++ b/backends/platform/sdl/win32/win32_wrapper.cpp
@@ -86,6 +86,13 @@ bool confirmWindowsVersion(int majorVersion, int minorVersion) {
 	return VerifyVersionInfoFunc(&versionInfo, VER_MAJORVERSION | VER_MINORVERSION, conditionMask);
 }
 
+bool isDriveCD(char driveLetter) {
+	TCHAR drivePath[] = TEXT("x:\\");
+	drivePath[0] = (TCHAR)driveLetter;
+
+	return (GetDriveType(drivePath) == DRIVE_CDROM);
+}
+
 wchar_t *ansiToUnicode(const char *s) {
 #ifndef UNICODE
 	uint codePage = CP_ACP;

--- a/backends/platform/sdl/win32/win32_wrapper.cpp
+++ b/backends/platform/sdl/win32/win32_wrapper.cpp
@@ -22,6 +22,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <shellapi.h> // for CommandLineToArgvW()
 #if defined(__GNUC__) && defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
  // required for SHGetSpecialFolderPath in shlobj.h
 #define _WIN32_IE 0x400
@@ -147,5 +148,29 @@ Common::String tcharToString(const TCHAR *t) {
 	return s;
 #endif
 }
+
+#ifdef UNICODE
+char **getArgvUtf8(int *argc) {
+	// get command line arguments in wide-character
+	LPWSTR *wargv = CommandLineToArgvW(GetCommandLineW(), argc);
+
+	// convert each argument to utf8
+	char **argv = (char **)malloc((*argc + 1) * sizeof(char *));
+	for (int i = 0; i < *argc; ++i) {
+		argv[i] = Win32::unicodeToAnsi(wargv[i]);
+	}
+	argv[*argc] = NULL; // null terminated array
+
+	LocalFree(wargv);
+	return argv;
+}
+
+void freeArgvUtf8(int argc, char **argv) {
+	for (int i = 0; i < argc; ++i) {
+		free(argv[i]);
+	}
+	free(argv);
+}
+#endif
 
 }

--- a/backends/platform/sdl/win32/win32_wrapper.h
+++ b/backends/platform/sdl/win32/win32_wrapper.h
@@ -39,6 +39,14 @@ namespace Win32 {
  * @param minorVersion The minor version number (0.x)
  */
 bool confirmWindowsVersion(int majorVersion, int minorVersion);
+
+/**
+ * Returns true if the drive letter is a CDROM
+ *
+ * @param driveLetter The drive letter to test
+ */
+bool isDriveCD(char driveLetter);
+
 /**
  * Converts a C string into a Windows wide-character string.
  * Used to interact with Win32 Unicode APIs with no ANSI fallback.

--- a/backends/platform/sdl/win32/win32_wrapper.h
+++ b/backends/platform/sdl/win32/win32_wrapper.h
@@ -95,6 +95,26 @@ TCHAR *stringToTchar(const Common::String& s);
  */
 Common::String tcharToString(const TCHAR *s);
 
+#ifdef UNICODE
+/**
+ * Returns command line arguments in argc / argv format in UTF8.
+ *
+ * @param argc argument count
+ * @return argument array
+ *
+ * @note Return value must be freed by the caller with freeArgvUtf8()
+ */
+char **getArgvUtf8(int *argc);
+
+/**
+ * Frees an argument array created by getArgvUtf8()
+ *
+ * @param argc argument count in argv
+ * @param argv argument array created by getArgvUtf8()
+ */
+void freeArgvUtf8(int argc, char **argv);
+#endif
+
 }
 
 #endif

--- a/backends/platform/sdl/win32/win32_wrapper.h
+++ b/backends/platform/sdl/win32/win32_wrapper.h
@@ -24,8 +24,9 @@
 #define PLATFORM_SDL_WIN32_WRAPPER_H
 
 #include "common/scummsys.h"
+#include "common/str.h"
 
-HRESULT SHGetFolderPathFunc(HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, LPSTR pszPath);
+HRESULT SHGetFolderPathFunc(HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, LPTSTR pszPath);
 
 // Helper functions
 namespace Win32 {
@@ -41,25 +42,50 @@ bool confirmWindowsVersion(int majorVersion, int minorVersion);
 /**
  * Converts a C string into a Windows wide-character string.
  * Used to interact with Win32 Unicode APIs with no ANSI fallback.
+ * If UNICODE is defined then the conversion will use code page CP_UTF8,
+ * otherwise CP_ACP will be used.
  *
  * @param s Source string
- * @param c Code Page, by default is CP_ACP (default Windows ANSI code page)
  * @return Converted string
  *
  * @note Return value must be freed by the caller.
  */
-wchar_t *ansiToUnicode(const char *s, uint codePage = CP_ACP);
+wchar_t *ansiToUnicode(const char *s);
 /**
  * Converts a Windows wide-character string into a C string.
  * Used to interact with Win32 Unicode APIs with no ANSI fallback.
+ * If UNICODE is defined then the conversion will use code page CP_UTF8,
+ * otherwise CP_ACP will be used.
  *
  * @param s Source string
- * @param c Code Page, by default is CP_ACP (default Windows ANSI code page)
  * @return Converted string
  *
  * @note Return value must be freed by the caller.
  */
-char *unicodeToAnsi(const wchar_t *s, uint codePage = CP_ACP);
+char *unicodeToAnsi(const wchar_t *s);
+
+/**
+ * Converts a Common::String to a TCHAR array for the purpose of passing to
+ * a Windows API or CRT call. If UNICODE is defined then the string will be
+ * converted from UTF8 to to wide characters, otherwise the character array
+ * will be copied with no conversion.
+ *
+ * @param s Source string
+ * @return Converted string
+ *
+ * @note Return value must be freed by the caller.
+ */
+TCHAR *stringToTchar(const Common::String& s);
+
+/**
+ * Converts a TCHAR array returned from a Windows API or CRT call to a Common::String.
+ * If UNICODE is defined then the wide character array will be converted to UTF8,
+ * otherwise the char array will be copied with no conversion.
+ *
+ * @param s Source string
+ * @return Converted string
+ */
+Common::String tcharToString(const TCHAR *s);
 
 }
 

--- a/backends/plugins/win32/win32-provider.cpp
+++ b/backends/plugins/win32/win32-provider.cpp
@@ -24,6 +24,7 @@
 
 #if defined(DYNAMIC_MODULES) && defined(_WIN32)
 
+#include "backends/platform/sdl/win32/win32_wrapper.h"
 #include "backends/plugins/win32/win32-provider.h"
 #include "backends/plugins/dynamic-plugin.h"
 #include "common/debug.h"
@@ -34,23 +35,11 @@
 
 
 class Win32Plugin final : public DynamicPlugin {
-private:
-	static const TCHAR* toUnicode(const char *x) {
-	#ifndef UNICODE
-		return (const TCHAR *)x;
-	#else
-		static TCHAR unicodeString[MAX_PATH];
-		MultiByteToWideChar(CP_ACP, 0, x, strlen(x) + 1, unicodeString, sizeof(unicodeString) / sizeof(TCHAR));
-		return unicodeString;
-	#endif
-	}
-
-
 protected:
 	void *_dlHandle;
 
 	virtual VoidFunc findSymbol(const char *symbol) override {
-		FARPROC func = GetProcAddress((HMODULE)_dlHandle, toUnicode(symbol));
+		FARPROC func = GetProcAddress((HMODULE)_dlHandle, symbol);
 		if (!func)
 			debug("Failed loading symbol '%s' from plugin '%s'", symbol, _filename.c_str());
 
@@ -63,7 +52,9 @@ public:
 
 	virtual bool loadPlugin() override {
 		assert(!_dlHandle);
-		_dlHandle = LoadLibrary(toUnicode(_filename.c_str()));
+		TCHAR *tFilename = Win32::stringToTchar(_filename);
+		_dlHandle = LoadLibrary(tFilename);
+		free(tFilename);
 
 		if (!_dlHandle) {
 			debug("Failed loading plugin '%s' (error code %d)", _filename.c_str(), (int32) GetLastError());

--- a/backends/saves/windows/windows-saves.cpp
+++ b/backends/saves/windows/windows-saves.cpp
@@ -36,7 +36,7 @@
 #include "backends/platform/sdl/win32/win32_wrapper.h"
 
 WindowsSaveFileManager::WindowsSaveFileManager() {
-	char defaultSavepath[MAXPATHLEN];
+	char defaultSavepath[MAX_PATH];
 
 
 	// Use the Application Data directory of the user profile.

--- a/backends/saves/windows/windows-saves.cpp
+++ b/backends/saves/windows/windows-saves.cpp
@@ -24,6 +24,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <tchar.h>
 #if defined(__GNUC__) && defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
  // required for SHGFP_TYPE_CURRENT in shlobj.h
 #define _WIN32_IE 0x500
@@ -36,24 +37,23 @@
 #include "backends/platform/sdl/win32/win32_wrapper.h"
 
 WindowsSaveFileManager::WindowsSaveFileManager() {
-	char defaultSavepath[MAX_PATH];
-
+	TCHAR defaultSavepath[MAX_PATH];
 
 	// Use the Application Data directory of the user profile.
 	if (SHGetFolderPathFunc(NULL, CSIDL_APPDATA, NULL, SHGFP_TYPE_CURRENT, defaultSavepath) == S_OK) {
-		strcat(defaultSavepath, "\\ScummVM");
+		_tcscat(defaultSavepath, TEXT("\\ScummVM"));
 		if (!CreateDirectory(defaultSavepath, NULL)) {
 			if (GetLastError() != ERROR_ALREADY_EXISTS)
 				error("Cannot create ScummVM application data folder");
 		}
 
-		strcat(defaultSavepath, "\\Saved games");
+		_tcscat(defaultSavepath, TEXT("\\Saved games"));
 		if (!CreateDirectory(defaultSavepath, NULL)) {
 			if (GetLastError() != ERROR_ALREADY_EXISTS)
 				error("Cannot create ScummVM Saved games folder");
 		}
 
-		ConfMan.registerDefault("savepath", defaultSavepath);
+		ConfMan.registerDefault("savepath", Win32::tcharToString(defaultSavepath));
 	} else {
 		warning("Unable to access application data directory");
 	}

--- a/backends/taskbar/win32/win32-taskbar.cpp
+++ b/backends/taskbar/win32/win32-taskbar.cpp
@@ -58,6 +58,7 @@
 #endif
 
 #include <shlobj.h>
+#include <tchar.h>
 
 #include "common/scummsys.h"
 
@@ -118,11 +119,13 @@ void Win32TaskbarManager::setOverlayIcon(const Common::String &name, const Commo
 	}
 
 	// Compute full icon path
-	Common::String path = getIconPath(name, ".ico");
-	if (path.empty())
+	Common::String iconPath = getIconPath(name, ".ico");
+	if (iconPath.empty())
 		return;
 
-	HICON pIcon = (HICON)::LoadImage(NULL, path.c_str(), IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
+	TCHAR *tIconPath = Win32::stringToTchar(iconPath);
+	HICON pIcon = (HICON)::LoadImage(NULL, tIconPath, IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
+	free(tIconPath);
 	if (!pIcon) {
 		warning("[Win32TaskbarManager::setOverlayIcon] Cannot load icon!");
 		return;
@@ -216,7 +219,7 @@ void Win32TaskbarManager::setCount(int count) {
 		lFont.lfHeight = 10;
 		lFont.lfWeight = FW_BOLD;
 		lFont.lfItalic = 1;
-		strcpy(lFont.lfFaceName, "Arial");
+		_tcscpy(lFont.lfFaceName, TEXT("Arial"));
 
 		HFONT hFont = CreateFontIndirect(&lFont);
 		SelectObject(hMemDC, hFont);
@@ -225,7 +228,9 @@ void Win32TaskbarManager::setCount(int count) {
 		SetRect(&rect, 4, 4, 12, 12);
 		SetTextColor(hMemDC, RGB(48, 48, 48));
 		SetBkMode(hMemDC, TRANSPARENT);
-		DrawText(hMemDC, countString.c_str(), -1, &rect, DT_NOCLIP|DT_CENTER);
+		TCHAR *tCountString = Win32::stringToTchar(countString);
+		DrawText(hMemDC, tCountString, -1, &rect, DT_NOCLIP|DT_CENTER);
+		free(tCountString);
 
 		// Set the text alpha to fully opaque (we consider the data inside the text rect)
 		DWORD *lpdwPixel = (DWORD *)lpBits;

--- a/backends/text-to-speech/windows/windows-text-to-speech.cpp
+++ b/backends/text-to-speech/windows/windows-text-to-speech.cpp
@@ -416,10 +416,10 @@ void WindowsTextToSpeechManager::createVoice(void *cpVoiceToken) {
 }
 
 Common::String WindowsTextToSpeechManager::lcidToLocale(LCID locale) {
-	int nchars = GetLocaleInfoA(locale, LOCALE_SISO639LANGNAME, NULL, 0);
-	char *languageCode = new char[nchars];
-	GetLocaleInfoA(locale, LOCALE_SISO639LANGNAME, languageCode, nchars);
-	Common::String result = languageCode;
+	int nchars = GetLocaleInfo(locale, LOCALE_SISO639LANGNAME, NULL, 0);
+	TCHAR *languageCode = new TCHAR[nchars];
+	GetLocaleInfo(locale, LOCALE_SISO639LANGNAME, languageCode, nchars);
+	Common::String result = Win32::tcharToString(languageCode);
 	delete[] languageCode;
 	return result;
 }

--- a/configure
+++ b/configure
@@ -221,6 +221,7 @@ _optimization_level=
 _default_optimization_level=-O2
 _nuked_opl=yes
 _builtin_resources=yes
+_windows_unicode=no
 # Default commands
 _ranlib=ranlib
 _strip=strip
@@ -906,6 +907,8 @@ Optional Features:
                            you are doing!
   --no-builtin-resources   do not include additional resources (e.g. engine data, fonts)
                            into the ScummVM binary
+  --enable-windows-unicode  use Windows Unicode APIs
+  --disable-windows-unicode use Windows ANSI APIs (default)
 
 Optional Libraries:
   --with-alsa-prefix=DIR   prefix where alsa is installed (optional)
@@ -1375,6 +1378,12 @@ for ac_option in $@; do
 		;;
 	--no-builtin-resources)
 		_builtin_resources=no
+		;;
+	--enable-windows-unicode)
+		_windows_unicode=yes
+		;;
+	--disable-windows-unicode)
+		_windows_unicode=no
 		;;
 	--with-sdl-prefix=*)
 		arg=`echo $ac_option | cut -d '=' -f 2`
@@ -6022,6 +6031,11 @@ case $_host_os in
 			append_var LDFLAGS "-Wl,--no-gc-sections"
 			# TODO automate this required 2 step linking phase
 			# append_var LDFLAGS "-Wl,--retain-symbols-file,ds.syms"
+		fi
+		;;
+	mingw*)
+		if test "$_windows_unicode" = yes; then
+			append_var DEFINES "-DUNICODE -D_UNICODE"
 		fi
 		;;
 	riscos)

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -289,6 +289,10 @@ int main(int argc, char *argv[]) {
 			setup.useSDL2 = false;
 		} else if (!std::strcmp(argv[i], "--use-canonical-lib-names")) {
 			setup.useCanonicalLibNames = true;
+		} else if (!std::strcmp(argv[i], "--use-windows-unicode")) {
+			setup.useWindowsUnicode = true;
+		} else if (!std::strcmp(argv[i], "--use-windows-ansi")) {
+			setup.useWindowsUnicode = false;
 		} else {
 			std::cerr << "ERROR: Unknown parameter \"" << argv[i] << "\"\n";
 			return -1;
@@ -724,6 +728,10 @@ void displayHelp(const char *exe) {
 	        " --use-canonical-lib-names  Use canonical library names for linking. This makes it easy to use\n"
 	        "                            e.g. vcpkg-provided libraries\n"
 	        "                            (default: false)\n"
+	        " --use-windows-unicode      Use Windows Unicode APIs\n"
+	        "                            (default: false)\n"
+	        " --use-windows-ansi         Use Windows ANSI APIs\n"
+	        "                            (default: true)\n"
 	        "\n"
 	        "Engines settings:\n"
 	        " --list-engines             list all available engines and their default state\n"

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -245,6 +245,7 @@ struct BuildSetup {
 	bool useSDL2;              ///< Whether to use SDL2 or not.
 	bool useCanonicalLibNames; ///< Whether to use canonical libraries names or default ones
 	bool useStaticDetection;   ///< Whether to link detection features inside the executable or not.
+	bool useWindowsUnicode;    ///< Whether to use Windows Unicode APIs or ANSI APIs.
 
 	BuildSetup() {
 		devTools = false;
@@ -254,6 +255,7 @@ struct BuildSetup {
 		useSDL2 = true;
 		useCanonicalLibNames = false;
 		useStaticDetection = true;
+		useWindowsUnicode = false;
 	}
 
 	bool featureEnabled(std::string feature) const;

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -65,6 +65,7 @@ inline void outputConfigurationType(const BuildSetup &setup, std::ostream &proje
 		project << "\t\t<ConfigurationType>StaticLibrary</ConfigurationType>\n";
 	}
 	project << "\t\t<PlatformToolset>" << (config == "LLVM" ? msvc.toolsetLLVM : msvc.toolsetMSVC ) << "</PlatformToolset>\n";
+	project << "\t\t<CharacterSet>" << (setup.useWindowsUnicode ? "Unicode" : "NotSet") << "</CharacterSet>\n";
 	if (msvc.version >= 16 && config == "Analysis") {
 		project << "\t\t<EnableASAN>true</EnableASAN>\n";
 	}	

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -480,19 +480,19 @@ void Engine::checkCD() {
 
 	// If we can find a compressed audio track, then it should be ok even
 	// if it's running from CD.
-	char buffer[MAXPATHLEN];
+	char buffer[MAX_PATH];
 	int i;
 
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 
 	if (gameDataDir.getPath().empty()) {
 		// That's it! I give up!
-		if (getcwd(buffer, MAXPATHLEN) == NULL)
+		if (getcwd(buffer, MAX_PATH) == NULL)
 			return;
 	} else
 		Common::strlcpy(buffer, gameDataDir.getPath().c_str(), sizeof(buffer));
 
-	for (i = 0; i < MAXPATHLEN - 1; i++) {
+	for (i = 0; i < MAX_PATH - 1; i++) {
 		if (buffer[i] == '\\')
 			break;
 	}

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -20,12 +20,10 @@
  *
  */
 
-#define FORBIDDEN_SYMBOL_EXCEPTION_getcwd
-
 #if defined(WIN32) && !defined(__SYMBIAN32__)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <direct.h>
+#include "backends/platform/sdl/win32/win32_wrapper.h"
 #endif
 
 #include "engines/engine.h"
@@ -480,26 +478,21 @@ void Engine::checkCD() {
 
 	// If we can find a compressed audio track, then it should be ok even
 	// if it's running from CD.
-	char buffer[MAX_PATH];
-	int i;
-
+	char driveLetter;
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
-
-	if (gameDataDir.getPath().empty()) {
+	if (!gameDataDir.getPath().empty()) {
+		driveLetter = gameDataDir.getPath()[0];
+	} else {
 		// That's it! I give up!
-		if (getcwd(buffer, MAX_PATH) == NULL)
+		Common::FSNode currentDir(".");
+		if (!currentDir.getPath().empty()) {
+			driveLetter = currentDir.getPath()[0];
+		} else {
 			return;
-	} else
-		Common::strlcpy(buffer, gameDataDir.getPath().c_str(), sizeof(buffer));
-
-	for (i = 0; i < MAX_PATH - 1; i++) {
-		if (buffer[i] == '\\')
-			break;
+		}
 	}
 
-	buffer[i + 1] = 0;
-
-	if (GetDriveType(buffer) == DRIVE_CDROM) {
+	if (Win32::isDriveCD(driveLetter)) {
 		GUI::MessageDialog dialog(
 			_("You appear to be playing this game directly\n"
 			"from the CD. This is known to cause problems,\n"


### PR DESCRIPTION
This PR adds the ability to configure Windows builds with UNICODE (and _UNICODE) defined. It keeps existing behavior when they are not defined. It does not change default configurations. The idea is that this is safe to merge, `--enable-windows-unicode` can be tested for a while, and then eventually become the default.

Windows builds currently can't handle paths with most unicode characters because we always use the Windows ANSI API. On NT-based Windowses, that means strings are converted to and from the native wide-character API using CP_ACP. This works on some characters but it's a lossy conversion that depends on machine settings. A path that gets returned by Windows might not work when ScummVM passes it back to open a file or list a directory. Games can't be loaded if a path contains these characters and user profile paths break if the username contains one of these. Most long-lived Windows codebases have faced these problems. The way out is to use the native wide-character API by defining UNICODE and do conversions to and from the application with UTF8.

Our current Windows code is a bit incoherent when it comes to UNICODE. There are #if(n)def UNICODE sections that imply some kind of support... except that there really isn't, and the code in these sections wouldn't have compiled if there was. The rest of the code is inconsistent and doesn't build when UNICODE is defined, which isn't surprising since it's never been used.

This PR sorts all that out. We can now build with UNICODE so we can see what it fixes and what still needs work. If all goes well we can eventually enable it by default and then all paths will work. Disabling UNICODE retains the existing behavior and DLL imports, preserving Win9x support. So far it's working well for me. I can browse to paths I couldn't before in the ScummVM UI, and I can add and run games from paths I couldn't before. Unicode paths can now be safely passed in command line arguments. All paths I've tested have persisted correctly in scummvm.ini and displayed properly in the UI.

The strategy:
* Fix all build errors when UNICODE is defined.
* Keep the exact same behavior as now when UNICODE isn't defined.
* Use wide-char APIs with UTF8 conversions when UNICODE is defined.

To enable, pass  `--enable-windows-unicode` to `configure` or `--use-windows-unicode` to `create_project`. `--disable-windows-unicode` / `--use-windows-ansi` can be used should this become a default.

Tested:
* Building with a very old mingw with unicode enabled and disabled
* Building with a very new mingw-w64 with unicode enabled and disabled
* Building with vs2015/vs2019 with unicode enabled and disabled

Scummvm.ini files exist in the wild with path strings created by CP_ACP conversion, so that may need some compatibility handling. If there's anything to be done there, I think it will be easier to figure out and test after this is merged.

https://bugs.scummvm.org/ticket/12409 is an example of one of the many symptoms of CP_ACP.