### PR TITLE
BACKENDS: SDL: Fix stack buffer overflow on empty supported formats list

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -85,8 +85,10 @@ bool SdlGraphicsManager::setState(const State &state) {
 		// pixel format instead.
 		Graphics::PixelFormat format = state.pixelFormat;
 		Common::List<Graphics::PixelFormat> supportedFormats = getSupportedFormats();
-		if (Common::find(supportedFormats.begin(), supportedFormats.end(), format) == supportedFormats.end())
-			format = supportedFormats.front();
+		if (!supportedFormats.empty()) {
+			if (Common::find(supportedFormats.begin(), supportedFormats.end(), format) == supportedFormats.end())
+				format = supportedFormats.front();
+		}
 		initSize(state.screenWidth, state.screenHeight, &format);
 #else
 		initSize(state.screenWidth, state.screenHeight, nullptr);


### PR DESCRIPTION
Still running scummvm compiled with address sanitizer (by default here), running the GRIM engine (GRIM or EMI games) with the default 3D renderer (OpenGL), there is a stack buffer overflow when starting the game:

```
==24643==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffff182b530 at pc 0x55bdad2014b9 bp 0x7ffff182b350 sp 0x7ffff182b348
READ of size 9 at 0x7ffff182b530 thread T0
    #0 0x55bdad2014b8 in SdlGraphicsManager::setState(SdlGraphicsManager::State const&) backends/graphics/sdl/sdl-graphics.cpp:89
    #1 0x55bdac938bf3 in OSystem_SDL::setGraphicsMode(int, unsigned int) backends/platform/sdl/sdl.cpp:825
    #2 0x55bdacf2ae1d in initGraphics3d(int, int) engines/engine.cpp:398
    #3 0x55bdacd1cbc3 in Grim::GrimEngine::createRenderer(int, int) engines/grim/grim.cpp:273
    #4 0x55bdacd43617 in Grim::GrimEngine::run() engines/grim/grim.cpp:389
    #5 0x55bdac94e61c in runGame base/main.cpp:300
    #6 0x55bdac94e61c in scummvm_main base/main.cpp:592
    #7 0x55bdac94221e in main backends/platform/sdl/posix/posix-main.cpp:45
    #8 0x7f12f940509a in __libc_start_main ../csu/libc-start.c:308
    #9 0x55bdac898369 in _start (/home/mathias/Sources/SCUMMVM/scummvm-mpa-clang/scummvm+0x59e369)

Address 0x7ffff182b530 is located in stack of thread T0 at offset 432 in frame
    #0 0x55bdad200bb7 in SdlGraphicsManager::setState(SdlGraphicsManager::State const&) backends/graphics/sdl/sdl-graphics.cpp:79

  This frame has 7 object(s):
    [32, 40) '<unknown>'
    [96, 104) '<unknown>'
    [160, 168) '<unknown>'
    [224, 232) '<unknown>'
    [288, 296) '<unknown>'
    [352, 361) 'format'
    [416, 432) 'supportedFormats' <== Memory access at offset 432 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow backends/graphics/sdl/sdl-graphics.cpp:89 in SdlGraphicsManager::setState(SdlGraphicsManager::State const&)
```

    With GRIM engine and OpenGL renderer, the called getSupportedFormats() is
    from openglsdl-graphics3d.h, that returns an empty list. So, data field
    is read from the front node, that has no real value, what cause an access
    beyond the stack frame.

I just added a check to ignore and keep the default format if the list is empty.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
