### PR TITLE
BACKENDS: Support Unicode display names for FSNode

### DIFF
--- a/backends/fs/abstract-fs.h
+++ b/backends/fs/abstract-fs.h
@@ -124,7 +124,7 @@ public:
 	 *
 	 * @note By default, this method returns the value of getName().
 	 */
-	virtual Common::String getDisplayName() const { return getName(); }
+	virtual Common::U32String getDisplayName() const = 0;
 
 	/**
 	 * Returns the last component of the path pointed by this FSNode.

--- a/backends/fs/amigaos/amigaos-fs.h
+++ b/backends/fs/amigaos/amigaos-fs.h
@@ -103,7 +103,7 @@ public:
 	virtual ~AmigaOSFilesystemNode() override;
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override { return _sDisplayName; }
+	virtual Common::U32String getDisplayName() const override { return _sDisplayName; }
 	virtual Common::String getName() const override { return _sDisplayName; }
 	virtual Common::String getPath() const override { return _sPath; }
 	virtual bool isDirectory() const override { return _bIsDirectory; }

--- a/backends/fs/chroot/chroot-fs.cpp
+++ b/backends/fs/chroot/chroot-fs.cpp
@@ -42,12 +42,12 @@ bool ChRootFilesystemNode::exists() const {
 	return _realNode->exists();
 }
 
-Common::String ChRootFilesystemNode::getDisplayName() const {
-	return getName();
+Common::U32String ChRootFilesystemNode::getDisplayName() const {
+	return _realNode->getDisplayName();
 }
 
 Common::String ChRootFilesystemNode::getName() const {
-	return _realNode->AbstractFSNode::getDisplayName();
+	return _realNode->getName();
 }
 
 Common::String ChRootFilesystemNode::getPath() const {

--- a/backends/fs/chroot/chroot-fs.h
+++ b/backends/fs/chroot/chroot-fs.h
@@ -36,7 +36,7 @@ public:
 	virtual ~ChRootFilesystemNode() override;
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override;
+	virtual Common::U32String getDisplayName() const override;
 	virtual Common::String getName() const override;
 	virtual Common::String getPath() const override;
 	virtual bool isDirectory() const override;

--- a/backends/fs/morphos/morphos-fs.h
+++ b/backends/fs/morphos/morphos-fs.h
@@ -103,7 +103,7 @@ public:
 	virtual ~MorphOSFilesystemNode() override;
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override { return _sDisplayName; }
+	virtual Common::U32String getDisplayName() const override { return _sDisplayName; }
 	virtual Common::String getName() const override { return _sDisplayName; }
 	virtual Common::String getPath() const override { return _sPath; }
 	virtual bool isDirectory() const override { return _bIsDirectory; }

--- a/backends/fs/n64/n64-fs.h
+++ b/backends/fs/n64/n64-fs.h
@@ -52,7 +52,7 @@ public:
 	N64FilesystemNode(const Common::String &p, bool verify = true);
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override {
+	virtual Common::U32String getDisplayName() const override {
 		return _displayName;
 	}
 	virtual Common::String getName() const override {

--- a/backends/fs/posix/posix-fs.h
+++ b/backends/fs/posix/posix-fs.h
@@ -55,7 +55,7 @@ public:
 	POSIXFilesystemNode(const Common::String &path);
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override { return _displayName; }
+	virtual Common::U32String getDisplayName() const override { return _displayName; }
 	virtual Common::String getName() const override { return _displayName; }
 	virtual Common::String getPath() const override { return _path; }
 	virtual bool isDirectory() const override { return _isDirectory; }

--- a/backends/fs/psp/psp-fs.h
+++ b/backends/fs/psp/psp-fs.h
@@ -52,7 +52,7 @@ public:
 	PSPFilesystemNode(const Common::String &p, bool verify = true);
 
 	virtual bool exists() const;
-	virtual Common::String getDisplayName() const { return _displayName; }
+	virtual Common::U32String getDisplayName() const { return _displayName; }
 	virtual Common::String getName() const { return _displayName; }
 	virtual Common::String getPath() const { return _path; }
 	virtual bool isDirectory() const { return _isDirectory; }

--- a/backends/fs/riscos/riscos-fs.h
+++ b/backends/fs/riscos/riscos-fs.h
@@ -55,7 +55,7 @@ public:
 	RISCOSFilesystemNode(const Common::String &path);
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override { return _displayName; }
+	virtual Common::U32String getDisplayName() const override { return _displayName; }
 	virtual Common::String getName() const override { return _displayName; }
 	virtual Common::String getPath() const override { return _path; }
 	virtual bool isDirectory() const override { return _isDirectory; }

--- a/backends/fs/symbian/symbian-fs.h
+++ b/backends/fs/symbian/symbian-fs.h
@@ -53,7 +53,7 @@ public:
 	SymbianFilesystemNode(const Common::String &path);
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override { return _displayName; }
+	virtual Common::U32String getDisplayName() const override { return _displayName; }
 	virtual Common::String getName() const override { return _displayName; }
 	virtual Common::String getPath() const override { return _path; }
 	virtual bool isDirectory() const override { return _isDirectory; }

--- a/backends/fs/wii/wii-fs.h
+++ b/backends/fs/wii/wii-fs.h
@@ -56,7 +56,7 @@ public:
 	WiiFilesystemNode(const Common::String &p, const struct stat *st);
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override { return _displayName; }
+	virtual Common::U32String getDisplayName() const override { return _displayName; }
 	virtual Common::String getName() const override { return _displayName; }
 	virtual Common::String getPath() const override { return _path; }
 	virtual bool isDirectory() const override { return _isDirectory; }

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -67,7 +67,7 @@ public:
 	WindowsFilesystemNode(const Common::String &path, const bool currentDir);
 
 	virtual bool exists() const override;
-	virtual Common::String getDisplayName() const override { return _displayName; }
+	virtual Common::U32String getDisplayName() const override { return _displayName; }
 	virtual Common::String getName() const override { return _displayName; }
 	virtual Common::String getPath() const override { return _path; }
 	virtual bool isDirectory() const override { return _isDirectory; }

--- a/backends/networking/sdl_net/handlers/downloadfilehandler.cpp
+++ b/backends/networking/sdl_net/handlers/downloadfilehandler.cpp
@@ -80,7 +80,7 @@ void DownloadFileHandler::handle(Client &client) {
 	GetClientHandler *handler = new GetClientHandler(stream);
 	handler->setResponseCode(200);
 	handler->setHeader("Content-Type", "application/force-download");
-	handler->setHeader("Content-Disposition", "attachment; filename=\"" + node->getDisplayName() + "\"");
+	handler->setHeader("Content-Disposition", "attachment; filename=\"" + node->getName() + "\"");
 	handler->setHeader("Content-Transfer-Encoding", "binary");
 	client.setHandler(handler);
 }

--- a/backends/networking/sdl_net/handlers/filespagehandler.cpp
+++ b/backends/networking/sdl_net/handlers/filespagehandler.cpp
@@ -121,7 +121,7 @@ bool FilesPageHandler::listDirectory(Common::String path, Common::String &conten
 
 	// fill the content
 	for (Common::FSList::iterator i = _nodeContent.begin(); i != _nodeContent.end(); ++i) {
-		Common::String name = i->getDisplayName();
+		Common::String name = i->getName();
 		if (i->isDirectory())
 			name += "/";
 

--- a/backends/networking/sdl_net/handlers/listajaxhandler.cpp
+++ b/backends/networking/sdl_net/handlers/listajaxhandler.cpp
@@ -86,7 +86,7 @@ Common::JSONObject ListAjaxHandler::listDirectory(Common::String path) {
 
 	// fill the content
 	for (Common::FSList::iterator i = _nodeContent.begin(); i != _nodeContent.end(); ++i) {
-		Common::String name = i->getDisplayName();
+		Common::String name = i->getName();
 		if (i->isDirectory()) name += "/";
 
 		Common::String filePath = i->getPath();

--- a/backends/platform/dc/selector.cpp
+++ b/backends/platform/dc/selector.cpp
@@ -157,7 +157,7 @@ static Game the_game;
 
 static bool isIcon(const Common::FSNode &entry)
 {
-	return entry.getDisplayName().hasSuffixIgnoreCase(".ICO");
+	return entry.getName().hasSuffixIgnoreCase(".ICO");
 }
 
 static bool loadIcon(Game &game, Dir *dirs, int num_dirs)
@@ -269,7 +269,7 @@ static int findGames(Game *games, int max, bool use_ini)
 	  files.push_back(*entry);
 	  } else
 	if (isIcon(*entry))
-	  strcpy(dirs[curr_dir-1].deficon, entry->getDisplayName().c_str());
+	  strcpy(dirs[curr_dir-1].deficon, entry->getName().c_str());
 	else if(!use_ini)
 	  files.push_back(*entry);
 	}
@@ -536,7 +536,7 @@ static int findPluginDirs(Game *plugin_dirs, int max, const Common::FSNode &base
 	  if (curr_dir >= max)
 	break;
 	  strncpy(plugin_dirs[curr_dir].dir, (*entry).getPath().c_str(), 256);
-	  strncpy(plugin_dirs[curr_dir].text, (*entry).getDisplayName().c_str(), 256);
+	  strncpy(plugin_dirs[curr_dir].text, (*entry).getName().c_str(), 256);
 	  plugin_dirs[curr_dir].icon.load(NULL, 0, 0);
 	  curr_dir++;
 	}

--- a/common/archive.h
+++ b/common/archive.h
@@ -58,7 +58,7 @@ public:
 	virtual ~ArchiveMember() { }
 	virtual SeekableReadStream *createReadStream() const = 0; /*!< Create a read stream. */
 	virtual String getName() const = 0; /*!< Get the name of the archive member. */
-	virtual String getDisplayName() const { return getName(); } /*!< Get the display name of the archive member. */
+	virtual U32String getDisplayName() const { return getName(); } /*!< Get the display name of the archive member. */
 };
 
 typedef SharedPtr<ArchiveMember> ArchiveMemberPtr; /*!< Shared pointer to an archive member. */

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -54,7 +54,7 @@ bool FSNode::operator<(const FSNode& node) const {
 
 	// If both nodes are of the same type (two files or two dirs),
 	// then sort by name, ignoring case.
-	return getDisplayName().compareToIgnoreCase(node.getDisplayName()) < 0;
+	return getName().compareToIgnoreCase(node.getName()) < 0;
 }
 
 bool FSNode::exists() const {

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -87,7 +87,7 @@ bool FSNode::getChildren(FSList &fslist, ListMode mode, bool hidden) const {
 	return true;
 }
 
-String FSNode::getDisplayName() const {
+U32String FSNode::getDisplayName() const {
 	assert(_realNode);
 	return _realNode->getDisplayName();
 }

--- a/common/fs.h
+++ b/common/fs.h
@@ -29,6 +29,7 @@
 #include "common/hashmap.h"
 #include "common/ptr.h"
 #include "common/str.h"
+#include "common/ustr.h"
 
 class AbstractFSNode;
 
@@ -154,7 +155,7 @@ public:
 	 *
 	 * @return The display name.
 	 */
-	virtual String getDisplayName() const;
+	virtual U32String getDisplayName() const;
 
 	/**
 	 * Return a string representation of the name of the file. This can be

--- a/engines/kyra/resource/resource_intern.cpp
+++ b/engines/kyra/resource/resource_intern.cpp
@@ -318,21 +318,21 @@ Common::Archive *ResLoaderPak::load(Common::ArchiveMemberPtr memberFile, Common:
 	while (!stream.eos()) {
 		// The start offset of a file should never be in the filelist
 		if (startoffset < stream.pos() || startoffset > filesize || startoffset < 0) {
-			warning("PAK file '%s' is corrupted", memberFile->getDisplayName().c_str());
+			warning("PAK file '%s' is corrupted", memberFile->getName().c_str());
 			return 0;
 		}
 
 		file = readString(stream);
 
 		if (stream.eos()) {
-			warning("PAK file '%s' is corrupted", memberFile->getDisplayName().c_str());
+			warning("PAK file '%s' is corrupted", memberFile->getName().c_str());
 			return 0;
 		}
 
 		// Quit now if we encounter an empty string
 		if (file.empty()) {
 			if (firstFile) {
-				warning("PAK file '%s' is corrupted", memberFile->getDisplayName().c_str());
+				warning("PAK file '%s' is corrupted", memberFile->getName().c_str());
 				return 0;
 			} else {
 				break;
@@ -343,7 +343,7 @@ Common::Archive *ResLoaderPak::load(Common::ArchiveMemberPtr memberFile, Common:
 		endoffset = switchEndian ? stream.readUint32BE() : stream.readUint32LE();
 
 		if (endoffset < 0 && stream.pos() != firstOffset) {
-			warning("PAK file '%s' is corrupted", memberFile->getDisplayName().c_str());
+			warning("PAK file '%s' is corrupted", memberFile->getName().c_str());
 			return 0;
 		}
 

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -50,7 +50,7 @@ public:
 		assert(name.hasPrefixIgnoreCase(_innerfolder));
 		return _publicFolder + Common::String(name.c_str() + _innerfolder.size());
 	}
-	Common::String getDisplayName() const override {
+	Common::U32String getDisplayName() const override {
 		return _member->getDisplayName();
 	}
 };

--- a/engines/wintermute/base/base_file_manager.cpp
+++ b/engines/wintermute/base/base_file_manager.cpp
@@ -204,7 +204,7 @@ bool BaseFileManager::registerPackages() {
 	for (Common::FSList::const_iterator it = _packagePaths.begin(); it != _packagePaths.end(); ++it) {
 		debugC(kWintermuteDebugFileAccess, "Should register folder: %s %s", it->getPath().c_str(), it->getName().c_str());
 		if (!it->getChildren(files, Common::FSNode::kListFilesOnly)) {
-			warning("getChildren() failed for path: %s", it->getDisplayName().c_str());
+			warning("getChildren() failed for path: %s", it->getName().c_str());
 		}
 		for (Common::FSList::const_iterator fileIt = files.begin(); fileIt != files.end(); ++fileIt) {
 			// To prevent any case sensitivity issues we make the filename

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -347,7 +347,7 @@ bool ThemeEngine::init() {
 			if (member) {
 				_themeArchive = Common::makeZipArchive(member->createReadStream());
 				if (!_themeArchive) {
-					warning("Failed to open Zip archive '%s'.", member->getDisplayName().c_str());
+					warning("Failed to open Zip archive '%s'.", member->getName().c_str());
 				}
 			} else {
 				_themeArchive = Common::makeZipArchive(node);
@@ -919,13 +919,13 @@ bool ThemeEngine::loadThemeXML(const Common::String &themeId) {
 		assert((*i)->getName().hasSuffix(".stx"));
 
 		if (_parser->loadStream((*i)->createReadStream()) == false) {
-			warning("Failed to load STX file '%s'", (*i)->getDisplayName().c_str());
+			warning("Failed to load STX file '%s'", (*i)->getName().c_str());
 			_parser->close();
 			return false;
 		}
 
 		if (_parser->parse() == false) {
-			warning("Failed to parse STX file '%s'", (*i)->getDisplayName().c_str());
+			warning("Failed to parse STX file '%s'", (*i)->getName().c_str());
 			_parser->close();
 			return false;
 		}
@@ -1913,7 +1913,7 @@ void ThemeEngine::listUsableThemes(Common::Archive &archive, Common::List<ThemeD
 		td.name.clear();
 		if (themeConfigUsable(**i, td.name)) {
 			td.filename = (*i)->getName();
-			td.id = (*i)->getDisplayName();
+			td.id = (*i)->getName();
 
 			// If the name of the node object also contains
 			// the ".zip" suffix, we will strip it.

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -212,9 +212,9 @@ void BrowserDialog::updateListing() {
 	ListWidget::ColorList colors;
 	for (Common::FSList::iterator i = _nodeContent.begin(); i != _nodeContent.end(); ++i) {
 		if (i->isDirectory())
-			list.push_back(i->getDisplayName() + "/");
+			list.push_back(i->getName() + "/");
 		else
-			list.push_back(i->getDisplayName());
+			list.push_back(i->getName());
 
 		if (_isDirBrowser) {
 			if (i->isDirectory())

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -617,7 +617,7 @@ bool Debugger::cmdOpenLog(int argc, const char **argv) {
 #ifndef DISABLE_MD5
 struct ArchiveMemberLess {
 	bool operator()(const Common::ArchiveMemberPtr &x, const Common::ArchiveMemberPtr &y) const {
-		return (*x).getDisplayName().compareToIgnoreCase((*y).getDisplayName()) < 0;
+		return (*x).getName().compareToIgnoreCase((*y).getName()) < 0;
 	}
 };
 
@@ -653,7 +653,7 @@ bool Debugger::cmdMd5(int argc, const char **argv) {
 			for (Common::ArchiveMemberList::iterator iter = list.begin(); iter != list.end(); ++iter) {
 				Common::SeekableReadStream *stream = (*iter)->createReadStream();
 				Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
-				debugPrintf("%s  %s  %d\n", md5.c_str(), (*iter)->getDisplayName().c_str(), (int32)stream->size());
+				debugPrintf("%s  %s  %d\n", md5.c_str(), (*iter)->getName().c_str(), (int32)stream->size());
 				delete stream;
 			}
 		}


### PR DESCRIPTION
Currently FSNode has two identical functions: **getName** and **getDisplayName**. They return the same on every backend AFAICT, but the documentation distinguishes them as:
- **getName**: Return a string representation of the name of the file. This can be used e.g. by detection code that relies on matching he name of a given file. However, it is *not* suitable for use with fopen / File::open, nor should it be archived.
- **getDisplayName**: Return a human-readable string for this node, usable for display (e.g.  in the GUI code). Do *not* rely on it being usable for anything else, like constructing paths.

Now that our GUI is Unicode-aware, I thought it would make more sense for **getDisplayName** to return a U32String, thus separating it from **getName** and allowing backends with unusual filesystem encodings to supply Unicode names for the GUI (or anything else).

Note that this PR is only focused on the API and doesn't change any backend implementations, which would still need to be updated to properly support Unicode (if they don't already use UTF-8).