### PR TITLE
COMMON: Add support for multi-file InstallShield cabinets

### DIFF
--- a/common/installshield_cab.cpp
+++ b/common/installshield_cab.cpp
@@ -123,6 +123,9 @@ bool InstallShieldCabinet::open(const String &baseName) {
 	case 0x0100600c:
 		_version = 6;
 		break;
+	case 0x020004B0: // Found in some Russian variants of Nancy Drew games. Possibly a malformed header
+		_version = 6;
+		break;
 	default:
 		warning("Unsupported CAB version %08x", version);
 		close();

--- a/common/installshield_cab.h
+++ b/common/installshield_cab.h
@@ -42,11 +42,13 @@ class SeekableReadStream;
 
 /**
  * This factory method creates an Archive instance corresponding to the content
- * of the InstallShield compressed stream.
+ * of the single- or multi-file InstallShield cabinet with the given base name
  *
  * May return 0 in case of a failure.
+ * 
+ * @param baseName The base filename, e.g. the "data" in "data1.cab"
  */
-Archive *makeInstallShieldArchive(SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse = DisposeAfterUse::YES);
+Archive *makeInstallShieldArchive(const Common::String &baseName);
 
 /** @} */
 

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -207,10 +207,10 @@ void AGOSEngine::loadArchives() {
 				continue;
 
 			if (!SearchMan.hasArchive(ag->fileName)) {
-				Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember(ag->fileName);
-
-				if (stream)
-					SearchMan.add(ag->fileName, Common::makeInstallShieldArchive(stream, DisposeAfterUse::YES), ag->fileType);
+				// Assumes the cabinet file is named data1.cab
+				Common::Archive *cabinet = Common::makeInstallShieldArchive("data");
+				if (cabinet)
+					SearchMan.add(ag->fileName, cabinet);
 			}
 		}
 	}

--- a/engines/nancy/nancy.cpp
+++ b/engines/nancy/nancy.cpp
@@ -315,13 +315,9 @@ void NancyEngine::bootGameEngine() {
 	ConfMan.registerDefault("second_chance", false);
 
 	// Load archive
-	Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember("data1.cab");
-	if (stream) {
-		Common::Archive *cab = Common::makeInstallShieldArchive(stream);
-
-		if (cab) {
-			SearchMan.add("data1.hdr", cab);
-		}
+	Common::Archive *cabinet = Common::makeInstallShieldArchive("data");
+	if (cabinet) {
+		SearchMan.add("data1.cab", cabinet);
 	}
 
 	_resource = new ResourceManager();

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -120,13 +120,9 @@ Common::ErrorCode TonyEngine::init() {
 		return Common::kUnknownError;
 
 	if (isCompressed()) {
-		Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember("data1.cab");
-		if (!stream)
-			error("Failed to open data1.cab");
-
-		Common::Archive *cabinet = Common::makeInstallShieldArchive(stream);
+		Common::Archive *cabinet = Common::makeInstallShieldArchive("data");
 		if (!cabinet)
-			error("Failed to parse data1.cab");
+			error("Failed to open the InstallShield cabinet");
 
 		SearchMan.add("data1.cab", cabinet);
 	}


### PR DESCRIPTION
This PR adds support for versions 6-13 InstallShield cabinets,
which can be both single- and multi-volume (v5 multi-volume
cabinets are still not supported since I have no test cases). This is
used in some of the Nancy Drew games. The code was written
several years ago by waltervn and clone2727, but never made its
way into the main tree.

This makes some minor changes to the AGOS and Tony engines
which I am unable to test since I don't own any of the games;
I'd appreciate if someone who has The Feeble Files or one of
the Simon the Sorcerer's Puzzle Packs could test the
unextracted versions and see if there are any issues.
