### PR TITLE
GUI: Fix leak of ManagedSurface in PicButtonWidget

### DIFF
--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -610,7 +610,9 @@ void PicButtonWidget::setGfx(const Graphics::ManagedSurface *gfx, int statenum, 
 }
 
 void PicButtonWidget::setGfx(const Graphics::Surface *gfx, int statenum, bool scale) {
-	setGfx(new Graphics::ManagedSurface(gfx), statenum, scale);
+	const Graphics::ManagedSurface *tmpGfx = new Graphics::ManagedSurface(gfx);
+	setGfx(tmpGfx, statenum, scale);
+	delete tmpGfx;
 }
 
 void PicButtonWidget::setGfxFromTheme(const char *name, int statenum, bool scale) {
@@ -898,7 +900,9 @@ void GraphicsWidget::setGfx(const Graphics::ManagedSurface *gfx, bool scale) {
 }
 
 void GraphicsWidget::setGfx(const Graphics::Surface *gfx, bool scale) {
-	setGfx(new Graphics::ManagedSurface(gfx), scale);
+	const Graphics::ManagedSurface *tmpGfx = new Graphics::ManagedSurface(gfx);
+	setGfx(tmpGfx, scale);
+	delete tmpGfx;
 }
 
 void GraphicsWidget::setGfx(int w, int h, int r, int g, int b) {


### PR DESCRIPTION
- Found leak playing Full Throttle:

```
Direct leak of 3384 byte(s) in 3 object(s) allocated from:
    #0 0x7f21b8b94d30 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xead30)
    #1 0x55cedb20980e in GUI::PicButtonWidget::setGfx(Graphics::Surface const*, int, bool) gui/widget.cpp:613
    #2 0x55cedb0e9241 in GUI::SaveLoadChooserGrid::updateSaves() gui/saveload-dialog.cpp:1110
    #3 0x55cedb0def72 in GUI::SaveLoadChooserGrid::open() gui/saveload-dialog.cpp:913
    #4 0x55cedaf2b498 in GUI::Dialog::runModal() gui/dialog.cpp:74
    #5 0x55cedb0e5856 in GUI::SaveLoadChooserGrid::runIntern() gui/saveload-dialog.cpp:1051
    #6 0x55cedb0aede4 in GUI::SaveLoadChooserDialog::run(Common::String const&, MetaEngine const*) gui/saveload-dialog.cpp:196
    #7 0x55cedb0a495a in GUI::SaveLoadChooser::runModalWithMetaEngineAndTarget(MetaEngine const*, Common::String const&) gui/saveload.cpp:102
    #8 0x55cedb0a3fe2 in GUI::SaveLoadChooser::runModalWithCurrentTarget() gui/saveload.cpp:83
    #9 0x55cedae8803d in MainMenuDialog::load() engines/dialogs.cpp:225
    #10 0x55cedae7fb5e in MainMenuDialog::handleCommand(GUI::CommandSender*, unsigned int, unsigned int) engines/dialogs.cpp:114
    #11 0x55ced832a793 in Scumm::ScummMenuDialog::handleCommand(GUI::CommandSender*, unsigned int, unsigned int) engines/scumm/dialogs.cpp:256
    #12 0x55cedb09c309 in GUI::CommandSender::sendCommand(unsigned int, unsigned int) gui/object.h:55
    #13 0x55cedb1f9d38 in GUI::ButtonWidget::handleMouseUp(int, int, int, int) gui/widget.cpp:377
    #14 0x55cedaf3247d in GUI::Dialog::handleMouseUp(int, int, int, int) gui/dialog.cpp:228
    #15 0x55cedaf5b877 in GUI::GuiManager::processEvent(Common::Event const&, GUI::Dialog*) gui/gui-manager.cpp:668
    #16 0x55cedaf4dbc2 in GUI::GuiManager::runLoop() gui/gui-manager.cpp:429
    #17 0x55cedaf2b596 in GUI::Dialog::runModal() gui/dialog.cpp:77
```

- To reproduce:

Run scummvm compiled with address sanitizer. Press F5 and click "Load". Choose a saved gave. Press F5 and click "Quit".

- Commit details:

Opening the load dialog, to display thumbnails into PicButtonWidget objects,
a call to setGfx creates a temporary ManagedSurface from a Surface but is
not instantiated, so not freed.

Same fix applied in GraphicsWidget which code is the same and reported
as potential memory leak by clang-tidy.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
