### PR TITLE
GRAPHICS: Fix leak in ManagedSurface, not forcing _disposeAfterUse to NO

### DIFF
--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -101,8 +101,8 @@ ManagedSurface::ManagedSurface(const Surface *surf) :
 		return;
 	}
 
-	copyFrom(*surf);
 	_disposeAfterUse = DisposeAfterUse::NO;
+	copyFrom(*surf);
 }
 
 ManagedSurface::~ManagedSurface() {

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -136,7 +136,7 @@ public:
 	/**
 	 * Create a managed surface from plain Surface.
 	 *
-	 * If disiposeAgter use flag is set (default), the surface will reuse all structures
+	 * If disposeAfterUse flag is set (default), the surface will reuse all structures
 	 * from the surface and destroy it, otherwise it will make a copy.
 	 */
 	ManagedSurface(Surface *surf, DisposeAfterUse::Flag disposeAfterUse = DisposeAfterUse::YES);
@@ -161,7 +161,7 @@ public:
 	operator const Surface &() const { return _innerSurface; }
 
 	/**
-	 * Return the underyling Graphics::Surface
+	 * Return the underlying Graphics::Surface
 	 *
 	 * If a caller uses the non-const surfacePtr version and changes
 	 * the surface, they'll be responsible for calling addDirtyRect
@@ -610,7 +610,7 @@ public:
 	 * @param dstFormat  The desired format.
 	 * @param palette    The palette (in RGB888), if the source format has a bpp of 1.
 	 */
-	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette = 0) {
+	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette = nullptr) {
 		_innerSurface.convertToInPlace(dstFormat, palette);
 	}
 


### PR DESCRIPTION
With the commit just merged about leak from PicButtonWidget, the ManagedSurface object is freed but not its pixel buffer because _disposeAfterUse was overwritten with value NO after the allocation with copyFrom().

That causes this indirect leak of thumbnail buffers (160x100x2 bytes):

```
Indirect leak of 96000 byte(s) in 3 object(s) allocated from:
    #0 0x7f21b8b93518 in calloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9518)
    #1 0x55cedbde0908 in Graphics::Surface::create(unsigned short, unsigned short, Graphics::PixelFormat const&) graphics/surface.cpp:75
    #2 0x55cedbde14dc in Graphics::Surface::copyFrom(Graphics::Surface const&) graphics/surface.cpp:96
    #3 0x55cedbd82895 in Graphics::ManagedSurface::copyFrom(Graphics::Surface const&) graphics/managed_surface.cpp:218
    #4 0x55cedbd7b331 in Graphics::ManagedSurface::ManagedSurface(Graphics::Surface const*) graphics/managed_surface.cpp:105
    #5 0x55cedb209847 in GUI::PicButtonWidget::setGfx(Graphics::Surface const*, int, bool) gui/widget.cpp:613
    #6 0x55cedb0e9241 in GUI::SaveLoadChooserGrid::updateSaves() gui/saveload-dialog.cpp:1110
    #7 0x55cedb0def72 in GUI::SaveLoadChooserGrid::open() gui/saveload-dialog.cpp:913
    #8 0x55cedaf2b498 in GUI::Dialog::runModal() gui/dialog.cpp:74
```

In the case of the ManagedSurface constructor from a Surface object,
_disposeAfterUse is not initialized. But more, copyFrom() sets
_disposeAfterUse to YES after allocation of buffer. And then,
after the call to copyFrom, _disposeAfterUse was set to NO, what
made the pixels buffer not freed.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
