### PR TITLE
TESTBED: Add another PixelFormat test

### DIFF
--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -35,8 +35,6 @@
 #include "graphics/surface.h"
 #include "graphics/VectorRendererSpec.h"
 
-#include "backends/graphics/null/null-graphics.h"
-
 namespace Testbed {
 
 byte GFXTestSuite::_palette[256 * 3] = {0, 0, 0, 255, 255, 255, 255, 255, 255};
@@ -1231,7 +1229,6 @@ TestExitStatus GFXtests::cursorTrails() {
 	return passed;
 }
 
-
 TestExitStatus GFXtests::pixelFormatsSupported() {
 	Testsuite::clearScreen();
 	Common::String info = "Testing pixel formats. Here we iterate over all the supported pixel formats and display some colors using them\n"
@@ -1255,7 +1252,15 @@ TestExitStatus GFXtests::pixelFormatsRequired() {
 		return kTestSkipped;
 	}
 
-	return GFXtests::pixelFormats(NullGraphicsManager().getSupportedFormats());
+	Common::List<Graphics::PixelFormat> list;
+	list.push_back(Graphics::PixelFormat(2, 5, 6, 5, 0, 11,  5,  0,  0)); // BBDoU, Frotz, HDB, Hopkins, Nuvie, Petka, Riven, Sherlock (3DO), Titanic, Tony, Ultima 4, Ultima 8, ZVision
+	list.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16,  8,  0)); // Full Pipe, Gnap (little endian), Griffon, Groovie 2, SCI32 (HQ videos), Sludge, Sword25, Ultima 8, Wintermute
+	list.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8,  0,  8, 16, 24)); // Gnap (big endian)
+	list.push_back(Graphics::PixelFormat(2, 5, 5, 5, 0, 10,  5,  0,  0)); // SCUMM HE99+, Last Express
+	list.push_back(Graphics::PixelFormat(2, 5, 5, 5, 1, 10,  5,  0, 15)); // Dragons
+	// list.push_back(Graphics::PixelFormat::createFormatCLUT8());
+
+	return GFXtests::pixelFormats(list);
 }
 
 TestExitStatus GFXtests::pixelFormats(const Common::List<Graphics::PixelFormat> &pfList) {
@@ -1272,8 +1277,8 @@ TestExitStatus GFXtests::pixelFormats(const Common::List<Graphics::PixelFormat> 
 		if (iter->bytesPerPixel == 1) {
 			// Palettes already tested
 			continue;
-		} else if (iter->bytesPerPixel == 3) {
-			Testsuite::logDetailedPrintf("Can't test pixels with bpp == 3\n");
+		} else if (iter->bytesPerPixel != 2 && iter->bytesPerPixel != 4) {
+			Testsuite::logDetailedPrintf("bytesPerPixel must be 1, 2, or 4\n");
 			continue;
 		}
 

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -35,12 +35,18 @@
 #include "graphics/surface.h"
 #include "graphics/VectorRendererSpec.h"
 
+#include "backends/graphics/null/null-graphics.h"
+
 namespace Testbed {
 
 byte GFXTestSuite::_palette[256 * 3] = {0, 0, 0, 255, 255, 255, 255, 255, 255};
 
 GFXTestSuite::GFXTestSuite() {
 	// Add tests here
+
+	// Pixel Formats
+	addTest("pixelFormatsSupported", &GFXtests::pixelFormatsSupported);
+	addTest("pixelFormatsRequired", &GFXtests::pixelFormatsRequired);
 
 	// Blitting buffer on screen
 	addTest("BlitBitmaps", &GFXtests::copyRectToScreen);
@@ -67,7 +73,6 @@ GFXTestSuite::GFXTestSuite() {
 	// Specific Tests:
 	addTest("PaletteRotation", &GFXtests::paletteRotation);
 	addTest("cursorTrailsInGUI", &GFXtests::cursorTrails);
-	//addTest("Pixel Formats", &GFXtests::pixelFormats);
 }
 
 void GFXTestSuite::prepare() {
@@ -1226,18 +1231,34 @@ TestExitStatus GFXtests::cursorTrails() {
 	return passed;
 }
 
-TestExitStatus GFXtests::pixelFormats() {
+
+TestExitStatus GFXtests::pixelFormatsSupported() {
 	Testsuite::clearScreen();
 	Common::String info = "Testing pixel formats. Here we iterate over all the supported pixel formats and display some colors using them\n"
 		"This may take long, especially if the backend supports many pixel formats";
 
 	if (Testsuite::handleInteractiveInput(info, "OK", "Skip", kOptionRight)) {
-		Testsuite::logPrintf("Info! Skipping test : Pixel Formats\n");
+		Testsuite::logPrintf("Info! Skipping test : Supported Pixel Formats\n");
 		return kTestSkipped;
 	}
 
-	Common::List<Graphics::PixelFormat> pfList = g_system->getSupportedFormats();
+	return GFXtests::pixelFormats(g_system->getSupportedFormats());
+}
 
+TestExitStatus GFXtests::pixelFormatsRequired() {
+	Testsuite::clearScreen();
+	Common::String info = "Testing pixel formats. Here we iterate over some pixel formats directly required by some engines and display some colors using them\n"
+		"This may fail, especially if the backend does not support many pixel formats";
+
+	if (Testsuite::handleInteractiveInput(info, "OK", "Skip", kOptionRight)) {
+		Testsuite::logPrintf("Info! Skipping test : Required Pixel Formats\n");
+		return kTestSkipped;
+	}
+
+	return GFXtests::pixelFormats(NullGraphicsManager().getSupportedFormats());
+}
+
+TestExitStatus GFXtests::pixelFormats(const Common::List<Graphics::PixelFormat> &pfList) {
 	int numFormatsTested = 0;
 	int numPassed = 0;
 	int numFailed = 0;
@@ -1246,11 +1267,13 @@ TestExitStatus GFXtests::pixelFormats() {
 
 	for (Common::List<Graphics::PixelFormat>::const_iterator iter = pfList.begin(); iter != pfList.end(); iter++) {
 		numFormatsTested++;
+
+		Testsuite::logPrintf("Info! Testing Pixel Format: %s, %d of %d\n", iter->toString().c_str(), numFormatsTested, pfList.size());
 		if (iter->bytesPerPixel == 1) {
 			// Palettes already tested
 			continue;
-		} else if (iter->bytesPerPixel > 2) {
-			Testsuite::logDetailedPrintf("Can't test pixels with bpp > 2\n");
+		} else if (iter->bytesPerPixel == 3) {
+			Testsuite::logDetailedPrintf("Can't test pixels with bpp == 3\n");
 			continue;
 		}
 
@@ -1273,7 +1296,7 @@ TestExitStatus GFXtests::pixelFormats() {
 
 		Common::Point pt(0, 170);
 		Common::String msg;
-		msg = Common::String::format("Testing Pixel Formats, %d of %d", numFormatsTested, pfList.size());
+		msg = Common::String::format("Testing Pixel Format %s, %d of %d", iter->toString().c_str(), numFormatsTested, pfList.size());
 		Testsuite::writeOnScreen(msg, pt, true);
 
 		// CopyRectToScreen could have been used, but that may involve writing code which

--- a/engines/testbed/graphics.h
+++ b/engines/testbed/graphics.h
@@ -37,6 +37,7 @@ void initMouseCursor();
 Common::Rect computeSize(const Common::Rect &cursorRect, int scalingFactor, int cursorTargetScale);
 void HSVtoRGB(int &rComp, int &gComp, int &bComp, int hue, int sat, int val);
 Common::Rect drawCursor(bool cursorPaletteDisabled = false, int cursorTargetScale = 1);
+TestExitStatus pixelFormats(const Common::List<Graphics::PixelFormat> &pfList);
 
 // will contain function declarations for GFX tests
 TestExitStatus cursorTrails();
@@ -52,7 +53,8 @@ TestExitStatus shakingEffect();
 TestExitStatus focusRectangle();
 TestExitStatus overlayGraphics();
 TestExitStatus paletteRotation();
-TestExitStatus pixelFormats();
+TestExitStatus pixelFormatsSupported();
+TestExitStatus pixelFormatsRequired();
 // add more here
 
 } // End of namespace GFXtests


### PR DESCRIPTION
I have noticed that Wintermute and FullPipe games are not working on PSP
port (and it looks like they never worked). This was caused by missing
ABGR8888@4 support on the backend, while some engines explicitly
requested this Pixel Format.

I have decided to add a test so that all the backends could be easily
checked for similar issues.

Surprisingly, "backends/graphics/null/null-graphics.h" holds up-to-date,
full and correct list of pixel formats requested by different engines.
There are lots of different Pixel Formats mentioned in different engines
code, but NullGraphicsManager lists all that are explicitly needed for
intGraphics(), not data reading, etc...