### PR TITLE
TESTBED: Modify Pixel Format tests to display brightness and alpha gradients

### DIFF
--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -1239,7 +1239,8 @@ TestExitStatus GFXtests::pixelFormatsSupported() {
 		return kTestSkipped;
 	}
 
-	return GFXtests::pixelFormats(g_system->getSupportedFormats());
+	Common::List<Graphics::PixelFormat> list = g_system->getSupportedFormats();
+	return GFXtests::pixelFormats(list);
 }
 
 TestExitStatus GFXtests::pixelFormatsRequired() {
@@ -1263,11 +1264,22 @@ TestExitStatus GFXtests::pixelFormatsRequired() {
 	return GFXtests::pixelFormats(list);
 }
 
-TestExitStatus GFXtests::pixelFormats(const Common::List<Graphics::PixelFormat> &pfList) {
+struct PixelFormatComparator {
+	bool operator()(const Graphics::PixelFormat &l, const Graphics::PixelFormat &r) {
+		return l.aLoss != r.aLoss ? l.aLoss < r.aLoss:
+		       l.rLoss != r.rLoss ? l.rLoss < r.rLoss:
+		       l.gLoss != r.gLoss ? l.gLoss < r.gLoss:
+		       l.bLoss != r.bLoss ? l.bLoss < r.bLoss:
+		                            l.toString() < r.toString();
+	}
+};
+
+TestExitStatus GFXtests::pixelFormats(Common::List<Graphics::PixelFormat> &pfList) {
 	int numFormatsTested = 0;
 	int numPassed = 0;
 	int numFailed = 0;
 
+	Common::sort(pfList.begin(), pfList.end(), PixelFormatComparator());
 	Testsuite::logDetailedPrintf("Testing Pixel Formats. Size of list : %d\n", pfList.size());
 
 	for (Common::List<Graphics::PixelFormat>::const_iterator iter = pfList.begin(); iter != pfList.end(); iter++) {

--- a/engines/testbed/graphics.h
+++ b/engines/testbed/graphics.h
@@ -37,7 +37,7 @@ void initMouseCursor();
 Common::Rect computeSize(const Common::Rect &cursorRect, int scalingFactor, int cursorTargetScale);
 void HSVtoRGB(int &rComp, int &gComp, int &bComp, int hue, int sat, int val);
 Common::Rect drawCursor(bool cursorPaletteDisabled = false, int cursorTargetScale = 1);
-TestExitStatus pixelFormats(const Common::List<Graphics::PixelFormat> &pfList);
+TestExitStatus pixelFormats(Common::List<Graphics::PixelFormat> &pfList);
 
 // will contain function declarations for GFX tests
 TestExitStatus cursorTrails();

--- a/engines/testbed/graphics.h
+++ b/engines/testbed/graphics.h
@@ -38,6 +38,7 @@ Common::Rect computeSize(const Common::Rect &cursorRect, int scalingFactor, int 
 void HSVtoRGB(int &rComp, int &gComp, int &bComp, int hue, int sat, int val);
 Common::Rect drawCursor(bool cursorPaletteDisabled = false, int cursorTargetScale = 1);
 TestExitStatus pixelFormats(Common::List<Graphics::PixelFormat> &pfList);
+void showPixelFormat(const Graphics::PixelFormat &pf, uint aLoss);
 
 // will contain function declarations for GFX tests
 TestExitStatus cursorTrails();


### PR DESCRIPTION
There are 2 tests that features Pixel Format testing:
* pixelFormatsSupported - testing formats implemented by backend
* pixelFormatsRequired - testing formats required by engines

Original Pixel Format test was just displaying 6 colored rectangles.
This PR replaces it with displaying gradients of 7 given colors.

For pixel formats with full alpha, both vertical and horizontal gradients are visible.
For pixel formats that ignores alpha, only horizontal gradient is visible.
For pixel formats with 1-bit alpha, the part with alpha < 128 is completely transparent.

Before testing a group of formats, a sample is displayed with CLUT8 pixel format:
![изображение](https://user-images.githubusercontent.com/5786428/118902179-d09be580-b91d-11eb-886b-daf360c9f7b0.png)
![изображение](https://user-images.githubusercontent.com/5786428/118902194-da254d80-b91d-11eb-91f4-ec7d7a694c5b.png)
![изображение](https://user-images.githubusercontent.com/5786428/118902038-7864e380-b91d-11eb-8b9c-ade33678a669.png)
![изображение](https://user-images.githubusercontent.com/5786428/118902054-7ef35b00-b91d-11eb-88d3-19d84a34b5a3.png)
![изображение](https://user-images.githubusercontent.com/5786428/118902073-87e42c80-b91d-11eb-9873-746d67ec7cc7.png)
![изображение](https://user-images.githubusercontent.com/5786428/118902083-8d417700-b91d-11eb-837f-b9c1f408881a.png)
![изображение](https://user-images.githubusercontent.com/5786428/118902087-92062b00-b91d-11eb-9845-95783361723d.png)
![изображение](https://user-images.githubusercontent.com/5786428/118902111-9c282980-b91d-11eb-8fa7-4c0b0f219d42.png)

