### PR TITLE
TESTBED: Fix STATIC_ASSERT expression compilation on gp2x-1

### DIFF
--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -1385,7 +1385,7 @@ void GFXtests::showPixelFormat(const Graphics::PixelFormat &pf, uint aLoss) {
 
 	const uint nTones = nLevels * (nLevels - 1) / 2;
 	const uint paletteSize = nStdColors + nColors * nTones;
-	STATIC_ASSERT(paletteSize < 256, "can't fit the tones in CLUT8");
+	STATIC_ASSERT(paletteSize < 256, cant_fit_all_the_tones_into_CLUT8_palettes);
 
 	uint level[nLevels];
 	for (uint i = 0; i < nLevels - 1; i++) {


### PR DESCRIPTION
It seems that gp2x-1 is the only platform that does not support STATIC_ASSERT(expression, "message").
Changed to STATIC_ASSERT(expression, some_very_long_message_id) to fix the compilation.