### PR TITLE
DIRECTOR: fix the cursor blinking problem in warlock

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -317,8 +317,16 @@ void Channel::setEditable(bool editable) {
 		_sprite->_cast->setEditable(editable);
 
 		if (_widget) {
-			_widget->_editable = editable;
-			g_director->_wm->setActiveWidget(_widget);
+			// since this method may called after the widget is created
+			// so we better also set the attributes which may affected by editable
+			((Graphics::MacText *)_widget)->_focusable = editable;
+			((Graphics::MacText *)_widget)->setEditable(editable);
+			((Graphics::MacText *)_widget)->_selectable = editable;
+			// only when the widget is editable, then we set it to active
+			// otherwise, the active widget may switch very frequently between
+			// editable widgets and non-editable widgets
+			if (editable)
+				g_director->_wm->setActiveWidget(_widget);
 		}
 	}
 }
@@ -375,6 +383,8 @@ void Channel::replaceWidget() {
 		Common::Rect bbox(getBbox());
 		_sprite->_cast->_modified = false;
 
+//		if (_sprite->_cast->_type == kCastText)
+//			debug("%s %d\n", ((TextCastMember *)_sprite->_cast)->_ftext.c_str(), ((TextCastMember *)_sprite->_cast)->_editable);
 		_widget = _sprite->_cast->createWidget(bbox, this);
 		if (_widget) {
 			_widget->_priority = _priority;

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -314,6 +314,8 @@ void Channel::setClean(Sprite *nextSprite, int spriteId, bool partial) {
 
 void Channel::setEditable(bool editable) {
 	if (_sprite->_cast && _sprite->_cast->_type == kCastText) {
+		if (_sprite->_cast->isEditable() == editable)
+			return;
 		_sprite->_cast->setEditable(editable);
 
 		if (_widget) {
@@ -322,11 +324,7 @@ void Channel::setEditable(bool editable) {
 			((Graphics::MacText *)_widget)->_focusable = editable;
 			((Graphics::MacText *)_widget)->setEditable(editable);
 			((Graphics::MacText *)_widget)->_selectable = editable;
-			// only when the widget is editable, then we set it to active
-			// otherwise, the active widget may switch very frequently between
-			// editable widgets and non-editable widgets
-			if (editable)
-				g_director->_wm->setActiveWidget(_widget);
+			g_director->_wm->setActiveWidget(_widget);
 		}
 	}
 }


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
in this movie
./scummvm --start-movie=STAMBUL/FNCOPS warlock
cursor is not visible when it opens the chatbox
the reason is it has a very frequent switch in _wm->_activewidget
for the speed and correctness, i've add the check when we are setting castmember editable
and the problem is solved