### PR TITLE
ACHIEVEMENTS: Simplify the achievements API 

### DIFF
--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -52,11 +52,11 @@ bool AchievementsManager::setActiveDomain(const AchievementsInfo &info) {
 }
 
 bool AchievementsManager::setActiveDomain(AchievementsPlatform platform, const String &appId) {
-	String prefix = platform == STEAM_ACHIEVEMENTS ? "steam-" + appId :
-					platform == GALAXY_ACHIEVEMENTS ? "galaxy-" + appId :
-					appId;
+	const char* prefix = platform == STEAM_ACHIEVEMENTS ? "steam" :
+					platform == GALAXY_ACHIEVEMENTS ? "galaxy" :
+					"achman";
 
-	String iniFileName = prefix + ".dat";
+	String iniFileName = String::format("%s-%s.dat", prefix, appId.c_str());
 
 	if (_iniFileName == iniFileName) {
 		return true;
@@ -114,7 +114,7 @@ bool AchievementsManager::setAchievement(const String &id, const String &display
 		return true;
 	}
 
-	debug("AchievementsManager::setAchievement('%s'): Achievement unlocked!", id.c_str());
+	debug("AchievementsManager::setAchievement('%s'): %s", id.c_str(), displayedMessage.c_str());
 
 	_iniFile->setKey(id, "achievements", "true");
 	_iniFile->saveToSaveFile(_iniFileName);

--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -46,17 +46,11 @@ bool AchievementsManager::setActiveDomain(const AchievementsInfo &info) {
 		return false;
 	}
 
-	_descriptions = info.descriptions;
-
-	return setActiveDomain(info.platform, info.appId);
-}
-
-bool AchievementsManager::setActiveDomain(AchievementsPlatform platform, const String &appId) {
-	const char* prefix = platform == STEAM_ACHIEVEMENTS ? "steam" :
-					platform == GALAXY_ACHIEVEMENTS ? "galaxy" :
+	const char* prefix = info.platform == STEAM_ACHIEVEMENTS ? "steam" :
+					info.platform == GALAXY_ACHIEVEMENTS ? "galaxy" :
 					"achman";
 
-	String iniFileName = String::format("%s-%s.dat", prefix, appId.c_str());
+	String iniFileName = String::format("%s-%s.dat", prefix, info.appId.c_str());
 
 	if (_iniFileName == iniFileName) {
 		return true;
@@ -70,6 +64,8 @@ bool AchievementsManager::setActiveDomain(AchievementsPlatform platform, const S
 
 	_iniFile = new Common::INIFile();
 	_iniFile->loadFromSaveFile(_iniFileName); // missing file is OK
+
+	_descriptions = info.descriptions;
 
 	return true;
 }
@@ -101,17 +97,6 @@ bool AchievementsManager::setAchievement(const String &id) {
 			displayedMessage = _descriptions[i].title;
 			break;
 		}
-	}
-
-	return setAchievement(id, displayedMessage);
-}
-
-bool AchievementsManager::setAchievement(const String &id, const String &displayedMessage) {
-	if (!isReady()) {
-		return false;
-	}
-	if (isAchieved(id)) {
-		return true;
 	}
 
 	debug("AchievementsManager::setAchievement('%s'): %s", id.c_str(), displayedMessage.c_str());

--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -40,6 +40,17 @@ AchievementsManager::AchievementsManager() {
 AchievementsManager::~AchievementsManager() {
 }
 
+bool AchievementsManager::setActiveDomain(const AchievementsInfo &info) {
+	if (info.appId.empty()) {
+		unsetActiveDomain();
+		return false;
+	}
+
+	_descriptions = info.descriptions;
+
+	return setActiveDomain(info.platform, info.appId);
+}
+
 bool AchievementsManager::setActiveDomain(AchievementsPlatform platform, const String &appId) {
 	String prefix = platform == STEAM_ACHIEVEMENTS ? "steam-" + appId :
 					platform == GALAXY_ACHIEVEMENTS ? "galaxy-" + appId :
@@ -70,9 +81,30 @@ bool AchievementsManager::unsetActiveDomain() {
 	delete _iniFile;
 	_iniFile = nullptr;
 
+	_descriptions.clear();
+
 	return true;
 }
 
+
+bool AchievementsManager::setAchievement(const String &id) {
+	if (!isReady()) {
+		return false;
+	}
+	if (isAchieved(id)) {
+		return true;
+	}
+
+	String displayedMessage = id;
+	for (uint32 i = 0; i < _descriptions.size(); i++) {
+		if (strcmp(_descriptions[i].id, id.c_str()) == 0) {
+			displayedMessage = _descriptions[i].title;
+			break;
+		}
+	}
+
+	return setAchievement(id, displayedMessage);
+}
 
 bool AchievementsManager::setAchievement(const String &id, const String &displayedMessage) {
 	if (!isReady()) {

--- a/common/achievements.h
+++ b/common/achievements.h
@@ -81,12 +81,19 @@ public:
 	~AchievementsManager();
 
 	/**
-	 * Set a platform and application ID as active domain.
+	 * (DEPRECATED) Set a platform and application ID as active domain.
 	 *
 	 * @param[in] platform Achievements platform.
 	 * @param[in] appId	Achievements application ID of the given platform.
 	 */
 	bool setActiveDomain(AchievementsPlatform platform, const String &appId);
+
+	/**
+	 * Set a platform and application ID as active domain, store messages texts.
+	 *
+	 * @param[in] info Achievements platform, application ID and messages information.
+	 */
+	bool setActiveDomain(const AchievementsInfo &info);
 	bool unsetActiveDomain();                            //!< Unset the current active domain.
 	bool isReady() const { return _iniFile != nullptr; } //!< Check whether the domain is ready.
 
@@ -95,12 +102,18 @@ public:
 	 * @{
 	 */
 
-	/** Set an achievement.
+	/** (DEPRECATED) Set an achievement.
 	 *
 	 * @param[in] id			   Internal ID of the achievement.
 	 * @param[in] displayedMessage Message displayed when the achievement is achieved.
 	 */
 	bool setAchievement(const String &id, const String &displayedMessage);
+
+	/** Set an achievement. Message is automatically displayed with text from active domain.
+	 *
+	 * @param[in] id			   Internal ID of the achievement.
+	 */
+	bool setAchievement(const String &id);
 
 	/**
 	 * Set an achievement as achieved.
@@ -167,6 +180,7 @@ public:
 private:
 	INIFile *_iniFile;
 	String _iniFileName;
+	Common::Array<AchievementDescription> _descriptions;
 };
 
 /** Shortcut for accessing the Achievements Manager. */

--- a/common/achievements.h
+++ b/common/achievements.h
@@ -81,14 +81,6 @@ public:
 	~AchievementsManager();
 
 	/**
-	 * (DEPRECATED) Set a platform and application ID as active domain.
-	 *
-	 * @param[in] platform Achievements platform.
-	 * @param[in] appId	Achievements application ID of the given platform.
-	 */
-	bool setActiveDomain(AchievementsPlatform platform, const String &appId);
-
-	/**
 	 * Set a platform and application ID as active domain, store messages texts.
 	 *
 	 * @param[in] info Achievements platform, application ID and messages information.
@@ -101,13 +93,6 @@ public:
 	 * @name Methods for manipulating individual achievements
 	 * @{
 	 */
-
-	/** (DEPRECATED) Set an achievement.
-	 *
-	 * @param[in] id			   Internal ID of the achievement.
-	 * @param[in] displayedMessage Message displayed when the achievement is achieved.
-	 */
-	bool setAchievement(const String &id, const String &displayedMessage);
 
 	/** Set an achievement. Message is automatically displayed with text from active domain.
 	 *

--- a/common/achievements.h
+++ b/common/achievements.h
@@ -116,7 +116,7 @@ public:
 	bool setAchievement(const String &id);
 
 	/**
-	 * Set an achievement as achieved.
+	 * Check if an achievement as achieved.
 	 *
 	 * @param[in] id Internal ID of the achievement.
 	 */

--- a/engines/ags/plugins/ags_galaxy_steam/ags_galaxy_steam.cpp
+++ b/engines/ags/plugins/ags_galaxy_steam/ags_galaxy_steam.cpp
@@ -55,18 +55,25 @@ void AGS2Client::AGS_EngineStartup(IAGSEngine *engine) {
 	SCRIPT_METHOD_EXT(AGS2Client::GetCurrentGameLanguage^0, GetCurrentGameLanguage);
 	SCRIPT_METHOD_EXT(AGS2Client::FindLeaderboard^1, FindLeaderboard);
 	SCRIPT_METHOD_EXT(AGS2Client::Initialize^2, Initialize);
+
+	Common::String gameTarget = ConfMan.getActiveDomainName();
+	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
+	AchMan.setActiveDomain(meta->getAchievementsInfo(gameTarget));
 }
 
 void AGS2Client::IsAchievementAchieved(ScriptMethodParams &params) {
-	params._result = false;
+	PARAMS1(char *, id);
+	params._result = AchMan.isAchieved(id);
 }
 
 void AGS2Client::SetAchievementAchieved(ScriptMethodParams &params) {
-	params._result = false;
+	PARAMS1(char *, id);
+	params._result = AchMan.setAchievement(id);
 }
 
 void AGS2Client::ResetAchievement(ScriptMethodParams &params) {
-	params._result = false;
+	PARAMS1(char *, id);
+	params._result = AchMan.clearAchievement(id);
 }
 
 void AGS2Client::GetIntStat(ScriptMethodParams &params) {
@@ -94,6 +101,8 @@ void AGS2Client::UpdateAverageRateStat(ScriptMethodParams &params) {
 }
 
 void AGS2Client::ResetStatsAndAchievements(ScriptMethodParams &params) {
+	AchMan.resetAllAchievements();
+	AchMan.resetAllStats();
 }
 
 void AGS2Client::get_Initialized(ScriptMethodParams &params) {
@@ -168,108 +177,6 @@ void AGSGalaxy::AGS_EngineStartup(IAGSEngine *engine) {
 	SCRIPT_METHOD_EXT(AGSGalaxy::GetUserName^0, GetUserName);
 	SCRIPT_METHOD_EXT(AGSGalaxy::GetCurrentGameLanguage^0, GetCurrentGameLanguage);
 	SCRIPT_METHOD_EXT(AGSGalaxy::Initialize^2, Initialize);
-
-	Common::String gameTarget = ConfMan.getActiveDomainName();
-	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
-	Common::AchievementsInfo achievementsInfo = meta->getAchievementsInfo(gameTarget);
-	const Common::String target = achievementsInfo.appId;
-	if (!target.empty()) {
-		AchMan.setActiveDomain(Common::GALAXY_ACHIEVEMENTS, target);
-	} else {
-		warning("Unknown game accessing SteamAPI. All achievements will be ignored.");
-		AchMan.unsetActiveDomain();
-	}
-}
-
-void AGSGalaxy::IsAchievementAchieved(ScriptMethodParams &params) {
-	PARAMS1(char *, id);
-	params._result = AchMan.isAchieved(id);
-}
-
-void AGSGalaxy::SetAchievementAchieved(ScriptMethodParams &params) {
-	PARAMS1(char *, id);
-
-	Common::String gameTarget = ConfMan.getActiveDomainName();
-	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
-	Common::AchievementsInfo achievementsInfo = meta->getAchievementsInfo(gameTarget);
-
-	Common::String msg = id;
-	for (uint32 i = 0; i < achievementsInfo.descriptions.size(); i++) {
-		if (strcmp(achievementsInfo.descriptions[i].id, id) == 0) {
-			msg = achievementsInfo.descriptions[i].title;
-		}
-	}
-
-	params._result = AchMan.setAchievement(id, msg);
-}
-
-void AGSGalaxy::ResetAchievement(ScriptMethodParams &params) {
-	PARAMS1(char *, id);
-	params._result = AchMan.clearAchievement(id);
-}
-
-void AGSGalaxy::GetIntStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::GetFloatStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::GetAverageRateStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::SetIntStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::SetFloatStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::UpdateAverageRateStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::ResetStatsAndAchievements(ScriptMethodParams &params) {
-	AchMan.resetAllAchievements();
-	AchMan.resetAllStats();
-}
-
-void AGSGalaxy::get_Initialized(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::get_CurrentLeaderboardName(ScriptMethodParams &params) {
-}
-
-void AGSGalaxy::RequestLeaderboard(ScriptMethodParams &params) {
-}
-
-void AGSGalaxy::UploadScore(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::geti_LeaderboardNames(ScriptMethodParams &params) {
-}
-
-void AGSGalaxy::geti_LeaderboardScores(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::get_LeaderboardCount(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSGalaxy::GetUserName(ScriptMethodParams &params) {
-}
-
-void AGSGalaxy::GetCurrentGameLanguage(ScriptMethodParams &params) {
-}
-
-void AGSGalaxy::Initialize(ScriptMethodParams &params) {
-	params._result = 0;
 }
 
 /*------------------------------------------------------------------*/
@@ -306,108 +213,6 @@ void AGSSteam::AGS_EngineStartup(IAGSEngine *engine) {
 	SCRIPT_METHOD_EXT(AGSteam::GetUserName^0, GetUserName);
 	SCRIPT_METHOD_EXT(AGSteam::GetCurrentGameLanguage^0, GetCurrentGameLanguage);
 	SCRIPT_METHOD_EXT(AGSteam::FindLeaderboard^1, FindLeaderboard);
-
-	Common::String gameTarget = ConfMan.getActiveDomainName();
-	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
-	Common::AchievementsInfo achievementsInfo = meta->getAchievementsInfo(gameTarget);
-	const Common::String target = achievementsInfo.appId;
-	if (!target.empty()) {
-		AchMan.setActiveDomain(Common::STEAM_ACHIEVEMENTS, target);
-	} else {
-		warning("Unknown game accessing SteamAPI. All achievements will be ignored.");
-		AchMan.unsetActiveDomain();
-	}
-}
-
-void AGSSteam::IsAchievementAchieved(ScriptMethodParams &params) {
-	PARAMS1(char *, id);
-	params._result = AchMan.isAchieved(id);
-}
-
-void AGSSteam::SetAchievementAchieved(ScriptMethodParams &params) {
-	PARAMS1(char *, id);
-
-	Common::String gameTarget = ConfMan.getActiveDomainName();
-	const MetaEngine *meta = ::AGS::g_vm->getMetaEngine();
-	Common::AchievementsInfo achievementsInfo = meta->getAchievementsInfo(gameTarget);
-
-	Common::String msg = id;
-	for (uint32 i = 0; i < achievementsInfo.descriptions.size(); i++) {
-		if (strcmp(achievementsInfo.descriptions[i].id, id) == 0) {
-			msg = achievementsInfo.descriptions[i].title;
-		}
-	}
-
-	params._result = AchMan.setAchievement(id, msg);
-}
-
-void AGSSteam::ResetAchievement(ScriptMethodParams &params) {
-	PARAMS1(char *, id);
-	params._result = AchMan.clearAchievement(id);
-}
-
-void AGSSteam::GetIntStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::GetFloatStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::GetAverageRateStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::SetIntStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::SetFloatStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::UpdateAverageRateStat(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::ResetStatsAndAchievements(ScriptMethodParams &params) {
-	AchMan.resetAllAchievements();
-	AchMan.resetAllStats();
-}
-
-void AGSSteam::get_Initialized(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::get_CurrentLeaderboardName(ScriptMethodParams &params) {
-}
-
-void AGSSteam::RequestLeaderboard(ScriptMethodParams &params) {
-}
-
-void AGSSteam::UploadScore(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::geti_LeaderboardNames(ScriptMethodParams &params) {
-}
-
-void AGSSteam::geti_LeaderboardScores(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::get_LeaderboardCount(ScriptMethodParams &params) {
-	params._result = 0;
-}
-
-void AGSSteam::GetUserName(ScriptMethodParams &params) {
-}
-
-void AGSSteam::GetCurrentGameLanguage(ScriptMethodParams &params) {
-}
-
-void AGSSteam::FindLeaderboard(ScriptMethodParams &params) {
-	params._result = 0;
 }
 
 } // namespace AGSGalaxySteam

--- a/engines/ags/plugins/ags_galaxy_steam/ags_galaxy_steam.h
+++ b/engines/ags/plugins/ags_galaxy_steam/ags_galaxy_steam.h
@@ -69,27 +69,6 @@ private:
 	static const char *AGS_GetPluginName();
 	static void AGS_EngineStartup(IAGSEngine *engine);
 
-	static void IsAchievementAchieved(ScriptMethodParams &params);
-	static void SetAchievementAchieved(ScriptMethodParams &params);
-	static void ResetAchievement(ScriptMethodParams &params);
-	static void GetIntStat(ScriptMethodParams &params);
-	static void GetFloatStat(ScriptMethodParams &params);
-	static void GetAverageRateStat(ScriptMethodParams &params);
-	static void SetIntStat(ScriptMethodParams &params);
-	static void SetFloatStat(ScriptMethodParams &params);
-	static void UpdateAverageRateStat(ScriptMethodParams &params);
-	static void ResetStatsAndAchievements(ScriptMethodParams &params);
-	static void get_Initialized(ScriptMethodParams &params);
-	static void get_CurrentLeaderboardName(ScriptMethodParams &params);
-	static void RequestLeaderboard(ScriptMethodParams &params);
-	static void UploadScore(ScriptMethodParams &params);
-	static void geti_LeaderboardNames(ScriptMethodParams &params);
-	static void geti_LeaderboardScores(ScriptMethodParams &params);
-	static void get_LeaderboardCount(ScriptMethodParams &params);
-	static void GetUserName(ScriptMethodParams &params);
-	static void GetCurrentGameLanguage(ScriptMethodParams &params);
-	static void Initialize(ScriptMethodParams &params);
-
 public:
 	AGSGalaxy();
 };
@@ -100,27 +79,6 @@ private:
 
 protected:
 	static void AGS_EngineStartup(IAGSEngine *engine);
-
-	static void IsAchievementAchieved(ScriptMethodParams &params);
-	static void SetAchievementAchieved(ScriptMethodParams &params);
-	static void ResetAchievement(ScriptMethodParams &params);
-	static void GetIntStat(ScriptMethodParams &params);
-	static void GetFloatStat(ScriptMethodParams &params);
-	static void GetAverageRateStat(ScriptMethodParams &params);
-	static void SetIntStat(ScriptMethodParams &params);
-	static void SetFloatStat(ScriptMethodParams &params);
-	static void UpdateAverageRateStat(ScriptMethodParams &params);
-	static void ResetStatsAndAchievements(ScriptMethodParams &params);
-	static void get_Initialized(ScriptMethodParams &params);
-	static void get_CurrentLeaderboardName(ScriptMethodParams &params);
-	static void RequestLeaderboard(ScriptMethodParams &params);
-	static void UploadScore(ScriptMethodParams &params);
-	static void geti_LeaderboardNames(ScriptMethodParams &params);
-	static void geti_LeaderboardScores(ScriptMethodParams &params);
-	static void get_LeaderboardCount(ScriptMethodParams &params);
-	static void GetUserName(ScriptMethodParams &params);
-	static void GetCurrentGameLanguage(ScriptMethodParams &params);
-	static void FindLeaderboard(ScriptMethodParams &params);
 
 public:
 	AGSSteam();

--- a/engines/testbed/achievements.cpp
+++ b/engines/testbed/achievements.cpp
@@ -20,37 +20,29 @@
  *
  */
 
-#include "base/plugins.h"
-
-#include "common/system.h"
-
-#include "engines/advancedDetector.h"
-
 #include "testbed/achievements.h"
 #include "testbed/testbed.h"
+#include "testbed/testsuite.h"
 
-class TestbedMetaEngine : public AdvancedMetaEngine {
-public:
-	const char *getName() const override {
-		return "testbed";
+namespace Testbed {
+
+const Common::AchievementsInfo getAchievementsInfo(const Common::String &target) {
+	Common::AchievementsInfo result;
+	result.platform = Common::UNK_ACHIEVEMENTS;
+	result.appId = "testbed";
+
+	Common::AchievementDescription testSuiteFinalAchievement = {"EVERYTHINGWORKS", true, "Everything works!", "Completed all available testsuites"};
+	result.descriptions.push_back(testSuiteFinalAchievement);
+
+	Common::Array<Testbed::Testsuite *> testsuiteList;
+	Testbed::TestbedEngine::pushTestsuites(testsuiteList);
+	for (Common::Array<Testbed::Testsuite *>::const_iterator i = testsuiteList.begin(); i != testsuiteList.end(); ++i) {
+		Common::AchievementDescription it = {(*i)->getName(), false, (*i)->getDescription(), 0};
+		result.descriptions.push_back(it);
+		delete (*i);
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription * /* desc */) const override {
-		*engine = new Testbed::TestbedEngine(syst);
-		return Common::kNoError;
-	}
+	return result;
+}
 
-	const Common::AchievementsInfo getAchievementsInfo(const Common::String &target) const override {
-		return Testbed::getAchievementsInfo(target);
-	}
-
-	bool hasFeature(MetaEngineFeature f) const override {
-		return false;
-	}
-};
-
-#if PLUGIN_ENABLED_DYNAMIC(TESTBED)
-	REGISTER_PLUGIN_DYNAMIC(TESTBED, PLUGIN_TYPE_ENGINE, TestbedMetaEngine);
-#else
-	REGISTER_PLUGIN_STATIC(TESTBED, PLUGIN_TYPE_ENGINE, TestbedMetaEngine);
-#endif
+} // End of namespace Testbed

--- a/engines/testbed/achievements.h
+++ b/engines/testbed/achievements.h
@@ -20,37 +20,16 @@
  *
  */
 
-#include "base/plugins.h"
+#ifndef TESTBED_ACHIEVEMENTS_H
+#define TESTBED_ACHIEVEMENTS_H
+ 
+#include "common/achievements.h"
 
-#include "common/system.h"
+namespace Testbed {
 
-#include "engines/advancedDetector.h"
+const Common::AchievementsInfo getAchievementsInfo(const Common::String &target);
 
-#include "testbed/achievements.h"
-#include "testbed/testbed.h"
+} // End of namespace Testbed
 
-class TestbedMetaEngine : public AdvancedMetaEngine {
-public:
-	const char *getName() const override {
-		return "testbed";
-	}
+#endif // TESTBED_ACHIEVEMENTS_H 
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription * /* desc */) const override {
-		*engine = new Testbed::TestbedEngine(syst);
-		return Common::kNoError;
-	}
-
-	const Common::AchievementsInfo getAchievementsInfo(const Common::String &target) const override {
-		return Testbed::getAchievementsInfo(target);
-	}
-
-	bool hasFeature(MetaEngineFeature f) const override {
-		return false;
-	}
-};
-
-#if PLUGIN_ENABLED_DYNAMIC(TESTBED)
-	REGISTER_PLUGIN_DYNAMIC(TESTBED, PLUGIN_TYPE_ENGINE, TestbedMetaEngine);
-#else
-	REGISTER_PLUGIN_STATIC(TESTBED, PLUGIN_TYPE_ENGINE, TestbedMetaEngine);
-#endif

--- a/engines/testbed/module.mk
+++ b/engines/testbed/module.mk
@@ -1,6 +1,7 @@
 MODULE := engines/testbed
 
 MODULE_OBJS := \
+	achievements.o \
 	config.o \
 	config-params.o \
 	events.o \

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -32,6 +32,7 @@
 
 #include "engines/util.h"
 
+#include "testbed/achievements.h"
 #include "testbed/events.h"
 #include "testbed/fs.h"
 #include "testbed/graphics.h"
@@ -197,7 +198,7 @@ void TestbedEngine::invokeTestsuites(TestbedConfigManager &cfMan) {
 			(*iter)->execute();
 		}
 		if ((*iter)->getNumTests() == (*iter)->getNumTestsPassed()) {
-			AchMan.setAchievement((*iter)->getName(), (*iter)->getDescription());
+			AchMan.setAchievement((*iter)->getName());
 			checkForAllAchievements();
 		}
 	}
@@ -210,7 +211,7 @@ void TestbedEngine::checkForAllAchievements() {
 			return;
 		}
 	}
-	AchMan.setAchievement("EVERYTHINGWORKS", "Everything works!");
+	AchMan.setAchievement("EVERYTHINGWORKS");
 }
 
 Common::Error TestbedEngine::run() {
@@ -223,7 +224,7 @@ Common::Error TestbedEngine::run() {
 	initGraphics(320, 200);
 
 	// Initialize achievements manager
-	AchMan.setActiveDomain(Common::UNK_ACHIEVEMENTS, "testbed");
+	AchMan.setActiveDomain(getAchievementsInfo(ConfMan.getActiveDomainName()));
 
 	// As of now we are using GUI::MessageDialog for interaction, Test if it works.
 	// interactive mode could also be modified by a config parameter "non-interactive=1"

--- a/engines/twine/twine.cpp
+++ b/engines/twine/twine.cpp
@@ -1148,18 +1148,7 @@ const char *TwinEEngine::getGameId() const {
 }
 
 bool TwinEEngine::unlockAchievement(const Common::String &id) {
-	const MetaEngine *meta = getMetaEngine();
-	const Common::AchievementsInfo &achievementsInfo = meta->getAchievementsInfo(ConfMan.getActiveDomainName());
-
-	Common::String msg = id;
-	for (uint32 i = 0; i < achievementsInfo.descriptions.size(); i++) {
-		if (id == achievementsInfo.descriptions[i].id) {
-			msg = achievementsInfo.descriptions[i].title;
-			break;
-		}
-	}
-
-	return AchMan.setAchievement(id, msg);
+	return AchMan.setAchievement(id);
 }
 
 Common::Rect TwinEEngine::centerOnScreen(int32 w, int32 h) const {

--- a/engines/twine/twine.cpp
+++ b/engines/twine/twine.cpp
@@ -227,6 +227,9 @@ Common::Error TwinEEngine::run() {
 	ConfMan.registerDefault("usehighres", false);
 	ConfMan.registerDefault("wallcollision", false);
 
+	Common::String gameTarget = ConfMan.getActiveDomainName();
+	AchMan.setActiveDomain(getMetaEngine()->getAchievementsInfo(gameTarget));
+
 	syncSoundSettings();
 	int32 w = ORIGINAL_WIDTH;
 	int32 h = ORIGINAL_HEIGHT;

--- a/engines/wintermute/ext/scene_achievements.cpp
+++ b/engines/wintermute/ext/scene_achievements.cpp
@@ -32,18 +32,13 @@
 
 namespace Wintermute {
 
-void SetAchievement(const char *id) {
-	Common::AchievementsInfo info = getAchievementsInfo();
-	AchMan.setActiveDomain(Common::STEAM_ACHIEVEMENTS, info.appId);
-	AchMan.setAchievement(id, getAchievementMessage(info, id));
-}
-
 void SceneAchievements(const char *sceneFilename) {
 	for (const AchievementsList *i = achievementsList; i->gameId; i++) {
 		if (BaseEngine::instance().getGameId() == i->gameId) {
 			for (const Achievement *it = i->mapping; it->sceneFilename; it++) {
 				if (strcmp(sceneFilename, it->sceneFilename) == 0) {
-					SetAchievement(it->id);
+					AchMan.setActiveDomain(getAchievementsInfo());
+					AchMan.setAchievement(it->id);
 					return;
 				}
 			}

--- a/engines/wintermute/ext/wme_galaxy.cpp
+++ b/engines/wintermute/ext/wme_galaxy.cpp
@@ -52,14 +52,7 @@ SXWMEGalaxyAPI::SXWMEGalaxyAPI(BaseGame *inGame, ScStack *stack) : BaseScriptabl
 void SXWMEGalaxyAPI::init() {
 	const MetaEngine *meta = g_engine->getMetaEngine();
 	const Common::String target = BaseEngine::instance().getGameTargetName();
-	_achievementsInfo = meta->getAchievementsInfo(target);
-
-	if (!_achievementsInfo.appId.empty()) {
-		AchMan.setActiveDomain(Common::GALAXY_ACHIEVEMENTS, _achievementsInfo.appId);
-	} else {
-		warning("Unknown game accessing WMEGalaxyAPI. All achievements will be ignored.");
-		AchMan.unsetActiveDomain();
-	}
+	AchMan.setActiveDomain(meta->getAchievementsInfo(target));
 }
 
 
@@ -96,15 +89,7 @@ bool SXWMEGalaxyAPI::scCallMethod(ScScript *script, ScStack *stack, ScStack *thi
 		stack->correctParams(1);
 		const char *id = stack->pop()->getString();
 
-		Common::String msg = id;
-		for (uint32 i = 0; i < _achievementsInfo.descriptions.size(); i++) {
-			if (strcmp(_achievementsInfo.descriptions[i].id, id) == 0) {
-				msg = _achievementsInfo.descriptions[i].title;
-				break;
-			}
-		}
-
-		stack->pushBool(AchMan.setAchievement(id, msg));
+		stack->pushBool(AchMan.setAchievement(id));
 		return STATUS_OK;
 	}
 

--- a/engines/wintermute/ext/wme_galaxy.h
+++ b/engines/wintermute/ext/wme_galaxy.h
@@ -46,8 +46,6 @@ public:
 
 private:
 	void init();
-
-	Common::AchievementsInfo _achievementsInfo;
 };
 
 } // End of namespace Wintermute

--- a/engines/wintermute/ext/wme_steam.cpp
+++ b/engines/wintermute/ext/wme_steam.cpp
@@ -50,17 +50,6 @@ Common::AchievementsInfo getAchievementsInfo() {
 }
 
 //////////////////////////////////////////////////////////////////////////
-Common::String getAchievementMessage(const Common::AchievementsInfo &info, const char *id) {
-	for (uint32 i = 0; i < info.descriptions.size(); i++) {
-		if (strcmp(info.descriptions[i].id, id) == 0) {
-			return info.descriptions[i].title;
-		}
-	}
-	return id;
-}
-
-
-//////////////////////////////////////////////////////////////////////////
 SXSteamAPI::SXSteamAPI(BaseGame *inGame, ScStack *stack) : BaseScriptable(inGame) {
 	stack->correctParams(0);
 	init();
@@ -69,13 +58,7 @@ SXSteamAPI::SXSteamAPI(BaseGame *inGame, ScStack *stack) : BaseScriptable(inGame
 //////////////////////////////////////////////////////////////////////////
 void SXSteamAPI::init() {
 	_achievementsInfo = getAchievementsInfo();
-
-	if (!_achievementsInfo.appId.empty()) {
-		AchMan.setActiveDomain(Common::STEAM_ACHIEVEMENTS, _achievementsInfo.appId);
-	} else {
-		warning("Unknown game accessing SteamAPI. All achievements will be ignored.");
-		AchMan.unsetActiveDomain();
-	}
+	AchMan.setActiveDomain(_achievementsInfo);
 }
 
 
@@ -108,8 +91,7 @@ bool SXSteamAPI::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisSta
 	else if (strcmp(name, "SetAchievement") == 0) {
 		stack->correctParams(1);
 		const char *id = stack->pop()->getString();
-		Common::String msg = getAchievementMessage(_achievementsInfo, id);
-		stack->pushBool(AchMan.setAchievement(id, msg));
+		stack->pushBool(AchMan.setAchievement(id));
 		return STATUS_OK;
 	}
 	//////////////////////////////////////////////////////////////////////////

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -1191,7 +1191,7 @@ void OptionsDialog::addKeyMapperControls(GuiObject *boss, const Common::String &
 
 void OptionsDialog::addAchievementsControls(GuiObject *boss, const Common::String &prefix, const Common::AchievementsInfo &info) {
 	Common::String achDomainId = ConfMan.get("achievements", _domain);
-	AchMan.setActiveDomain(info.platform, info.appId);
+	AchMan.setActiveDomain(info);
 
 	GUI::ScrollContainerWidget *scrollContainer;
 	scrollContainer = new GUI::ScrollContainerWidget(boss, prefix + "Container", "");


### PR DESCRIPTION
I have noticed that `AchMan.setActiveDomain()` and `AchMan.setAchievement()` requires too much code the engines need to write around. 

New API is much simplier - `AchMan.setActiveDomain(<result of MetaEngine's getAchievementsInfo()>)` now additionally stores messages to be displayed on `AchMan.setAchievement(id)` calls instead of old `AchMan.setAchievement(id, message)` call.

Additional things in this review:
* TWINE had no `AchMan.setActiveDomain`, added it to `TwinEEngine::run()`
* moved AGS achievements API calls to the base class AGS2Client

See Commits list for easier reading.