### PR TITLE
MSVC: Add compiler printf validation

### DIFF
--- a/backends/midi/timidity.cpp
+++ b/backends/midi/timidity.cpp
@@ -95,7 +95,7 @@ private:
 	int connect_to_server(const char* hostname, const char* tcp_port);
 
 	/* send command to the server; printf-like; returns reply string */
-	char *timidity_ctl_command(const char *fmt, ...) GCC_PRINTF(2, 3);
+	char *timidity_ctl_command(MSVC_PRINTF const char *fmt, ...) GCC_PRINTF(2, 3);
 
 	/* timidity data socket-related stuff */
 	void timidity_meta_seq(int p1, int p2, int p3);

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -208,7 +208,7 @@ static const char HELP_STRING[] =
 
 static const char *s_appName = "scummvm";
 
-static void NORETURN_PRE usage(const char *s, ...) GCC_PRINTF(1, 2) NORETURN_POST;
+static void NORETURN_PRE usage(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2) NORETURN_POST;
 
 static void usage(const char *s, ...) {
 	char buf[STRINGBUFLEN];

--- a/common/debug.h
+++ b/common/debug.h
@@ -52,7 +52,7 @@ inline void debugCN(uint32 debugChannels, const char *s, ...) {}
  * Print a debug message to the text console (stdout).
  * Automatically appends a newline.
  */
-void debug(const char *s, ...) GCC_PRINTF(1, 2);
+void debug(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -60,13 +60,13 @@ void debug(const char *s, ...) GCC_PRINTF(1, 2);
  * As a rule of thumb, the more important the message, the lower the level.
  * Automatically appends a newline.
  */
-void debug(int level, const char *s, ...) GCC_PRINTF(2, 3);
+void debug(int level, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
 
 /**
  * Print a debug message to the text console (stdout).
  * Does not append a newline.
  */
-void debugN(const char *s, ...) GCC_PRINTF(1, 2);
+void debugN(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -74,7 +74,7 @@ void debugN(const char *s, ...) GCC_PRINTF(1, 2);
  * As a rule of thumb, the more important the message, the lower the level.
  * Does not append a newline.
  */
-void debugN(int level, const char *s, ...) GCC_PRINTF(2, 3);
+void debugN(int level, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -88,7 +88,7 @@ void debugN(int level, const char *s, ...) GCC_PRINTF(2, 3);
  * @param debugChannels Bitfield of channels to check against.
  * @param s             Message to print.
  */
-void debugC(int level, uint32 debugChannels, const char *s, ...) GCC_PRINTF(3, 4);
+void debugC(int level, uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(3, 4);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -103,7 +103,7 @@ void debugC(int level, uint32 debugChannels, const char *s, ...) GCC_PRINTF(3, 4
  * @param s             Message to print.
  *
  */
-void debugCN(int level, uint32 debugChannels, const char *s, ...) GCC_PRINTF(3, 4);
+void debugCN(int level, uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(3, 4);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -114,7 +114,7 @@ void debugCN(int level, uint32 debugChannels, const char *s, ...) GCC_PRINTF(3, 
  * @param debugChannels Bitfield of channels to check against.
  * @param s             Message to print.
  */
-void debugC(uint32 debugChannels, const char *s, ...) GCC_PRINTF(2, 3);
+void debugC(uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -125,7 +125,7 @@ void debugC(uint32 debugChannels, const char *s, ...) GCC_PRINTF(2, 3);
  * @param debugChannels Bitfield of channels to check against.
  * @param s             Message to print.
  */
-void debugCN(uint32 debugChannels, const char *s, ...) GCC_PRINTF(2, 3);
+void debugCN(uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
 
 #endif
 

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -349,6 +349,14 @@
 	#endif
 #endif
 
+#ifndef MSVC_PRINTF
+	#if _MSC_VER > 1400
+		#define MSVC_PRINTF _Printf_format_string_
+	#else
+		#define MSVC_PRINTF
+	#endif
+#endif
+
 #ifndef PACKED_STRUCT
 	#if defined(__GNUC__) || defined(__INTEL_COMPILER)
 		#define PACKED_STRUCT __attribute__((__packed__))

--- a/common/str.h
+++ b/common/str.h
@@ -185,7 +185,7 @@ public:
 	 * except that it stores the result in (variably sized) String
 	 * instead of a fixed size buffer.
 	 */
-	static String format(const char *fmt, ...) GCC_PRINTF(1, 2);
+	static String format(MSVC_PRINTF const char *fmt, ...) GCC_PRINTF(1, 2);
 
 	/**
 	 * Print formatted data into a String object. Similar to vsprintf,

--- a/common/textconsole.h
+++ b/common/textconsole.h
@@ -81,11 +81,11 @@ void setErrorHandler(ErrorHandler handler);
 /**
  * Print an error message to the text console and then terminate the process.
  */
-void NORETURN_PRE error(const char *s, ...) GCC_PRINTF(1, 2) NORETURN_POST;
+void NORETURN_PRE error(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2) NORETURN_POST;
 
 #ifdef DISABLE_TEXT_CONSOLE
 
-inline void warning(const char *s, ...) {}
+inline void warning(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2) {}
 
 #else
 
@@ -95,7 +95,7 @@ inline void warning(const char *s, ...) {}
  * Automatically prepends the text "WARNING: " and appends
  * an exclamation mark and a newline.
  */
-void warning(const char *s, ...) GCC_PRINTF(1, 2);
+void warning(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2);
 
 #endif
 /** @} */


### PR DESCRIPTION
Currently ScummVM uses the GCC_PRINTF annotation to validate strings in printf-like functions. This doesn't work for MSVC which has a different annotation for this, so I added it, and corrected some incorrect usages.

Sadly MSVC requires annotating the parameter, not the function, so I couldn't combine both macros into one.