### PR TITLE
GUI: Add delete/backspace support to save/load list

### DIFF
--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -463,7 +463,8 @@ void SaveLoadChooserSimple::handleCommand(CommandSender *sender, uint32 cmd, uin
 		updateSelection(true);
 		break;
 	case kDelCmd:
-		if (selItem >= 0 && _delSupport) {
+	case kListItemRemovalRequestCmd:
+		if (_deleteButton->isEnabled()) {
 			MessageDialog alert(_("Do you really want to delete this saved game?"),
 								_("Delete"), _("Cancel"));
 			if (alert.runModal() == kMessageOK) {

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -633,7 +633,7 @@ void ListWidget::checkBounds() {
 
 void ListWidget::scrollToCurrent() {
 	// Only do something if the current item is not in our view port
-	if (_selectedItem < _currentPos) {
+	if (_selectedItem != -1 && _selectedItem < _currentPos) {
 		// it's above our view
 		_currentPos = _selectedItem;
 	} else if (_selectedItem >= _currentPos + _entriesPerPage ) {


### PR DESCRIPTION
As someone who accumulates a lot of temporary saves, I push the delete key a lot to try and delete them. Now it works!

This revealed that ListWidget::scrollToCurrent() has been doing a less-than comparison that includes the sentinel value -1, causing the list to jump to to the top when there is no currently selected item, such as right after deleting a save and clearing the selection. As that's behavior I fixed in the Delete GUI button in #2628, I added a check so that scrollToCurrent() doesn't scroll when there isn't a current item. This also fixes some existing unusual scroll position resets in the save/load list. I tested the other lists and didn't detect any behavior changes.