### PR TITLE
ACHIEVEMENTS: Improve GOG achivements support

### DIFF
--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -46,11 +46,11 @@ bool AchievementsManager::setActiveDomain(const AchievementsInfo &info) {
 		return false;
 	}
 
-	const char* prefix = info.platform == STEAM_ACHIEVEMENTS ? "steam" :
+	const char* platform = info.platform == STEAM_ACHIEVEMENTS ? "steam" :
 					info.platform == GALAXY_ACHIEVEMENTS ? "galaxy" :
 					"achman";
 
-	String iniFileName = String::format("%s-%s.dat", prefix, info.appId.c_str());
+	String iniFileName = String::format("%s-%s.dat", platform, info.appId.c_str());
 
 	if (_iniFileName == iniFileName) {
 		return true;
@@ -66,6 +66,9 @@ bool AchievementsManager::setActiveDomain(const AchievementsInfo &info) {
 	_iniFile->loadFromSaveFile(_iniFileName); // missing file is OK
 
 	_descriptions = info.descriptions;
+
+	setSpecialString("platform", platform);
+	setSpecialString("gameId", info.appId);
 
 	return true;
 }
@@ -217,6 +220,17 @@ int AchievementsManager::getStatInt(String const &id) {
 	String tmp;
 	_iniFile->getKey(id, "statistics", tmp);
 	return (int)atol(tmp.c_str());
+}
+
+
+bool AchievementsManager::setSpecialString(String const &id, String const &value) {
+	if (!isReady()) {
+		return false;
+	}
+
+	_iniFile->setKey(id, "special", value);
+	_iniFile->saveToSaveFile(_iniFileName);
+	return 0;
 }
 
 

--- a/common/achievements.h
+++ b/common/achievements.h
@@ -179,6 +179,22 @@ public:
 
 	/** @} */
 
+	/**
+	 * @name Methods for storing platform-specific data
+	 * @{
+	 */
+
+	/**
+	 * Store provided key and value pair in additional section.
+	 * May be useful for posting achievements to original platform.
+	 *
+	 * @param[in] id	Internal ID of the achievement.
+	 * @param[in] value Value to which the statistic is set.
+	 */
+	bool setSpecialString(const String &id, const String &value);
+
+	/** @} */
+
 private:
 	float getStatFloatEx(const String &id, const String &section);
 	bool setStatFloatEx(const String &id, float value, const String &section);

--- a/engines/ags/achievements_tables.h
+++ b/engines/ags/achievements_tables.h
@@ -41,7 +41,7 @@ static const AchievementDescriptionList achievementDescriptionList[] = {
 	{
 		"detectivegallo",
 		Common::GALAXY_ACHIEVEMENTS,
-		"50086217303942317",
+		"1745746005",
 		{
 			ACHIEVEMENT_SIMPLE_ENTRY("Achiev_01", "Vigilante", "That taxi driver picked up his last fare\xe2\x80\xa6"),
 			ACHIEVEMENT_SIMPLE_ENTRY("Achiev_02", "Alcoholic", "Cocktails go to my head."),
@@ -75,7 +75,7 @@ static const AchievementDescriptionList achievementDescriptionList[] = {
 	{
 		"guardduty",
 		Common::GALAXY_ACHIEVEMENTS,
-		"53208190275284474",
+		"1455980545",
 		{
 			ACHIEVEMENT_SIMPLE_ENTRY("ACH_KICKED_OUT", "Airborne", "Get kicked out of the Castle"),
 			ACHIEVEMENT_SIMPLE_ENTRY("ACH_FROG_KISS", "Pucker Up", "Girtrude finds a new friend"),
@@ -104,7 +104,7 @@ static const AchievementDescriptionList achievementDescriptionList[] = {
 	{
 		"kathyrain",
 		Common::GALAXY_ACHIEVEMENTS,
-		"49013395759351343",
+		"1460710709",
 		{
 			ACHIEVEMENT_SIMPLE_ENTRY("FinishDayOne", "Get on the Katmobile", "Finished day one"),
 			ACHIEVEMENT_SIMPLE_ENTRY("FinishDayTwo", "Wow, they're hypnotic...", "Finished day two"),
@@ -133,7 +133,7 @@ static const AchievementDescriptionList achievementDescriptionList[] = {
 	{
 		"mage",
 		Common::GALAXY_ACHIEVEMENTS,
-		"51907450760339722",
+		"1469845437",
 		{
 			ACHIEVEMENT_SIMPLE_ENTRY("DABBLING", "Dabbling", "Earn your first spells from the Sphere of Knowledge."),
 			ACHIEVEMENT_SIMPLE_ENTRY("BACK_OFF_BACKERS", "Back Off Backers", "Beat both Mage sparring partners."),
@@ -186,7 +186,7 @@ static const AchievementDescriptionList achievementDescriptionList[] = {
 	{
 		"oott",
 		Common::GALAXY_ACHIEVEMENTS,
-		"48480489121931650",
+		"1444830704",
 		{
 			ACHIEVEMENT_SIMPLE_ENTRY("tkc_TwoGirls", "He is Gnomor'", "The girls, Snow and Red, tried to save the gnome but alas, they failed."),
 			ACHIEVEMENT_SIMPLE_ENTRY("tkc_HighPriest", "High Priest", "The high priest hightailed it out of the Faerie Realm."),
@@ -208,7 +208,7 @@ static const AchievementDescriptionList achievementDescriptionList[] = {
 	{
 		"whispersofamachine",
 		Common::GALAXY_ACHIEVEMENTS,
-		"51996409849683928",
+		"1845001352",
 		{
 			ACHIEVEMENT_SIMPLE_ENTRY("CaseClosed", "Case Closed", "Finished the game"),
 			ACHIEVEMENT_SIMPLE_ENTRY("PathOfTyr", "Path of Tyr", "Finished the game assertively"),

--- a/engines/ags/plugins/ags_galaxy_steam/ags_galaxy_steam.cpp
+++ b/engines/ags/plugins/ags_galaxy_steam/ags_galaxy_steam.cpp
@@ -146,6 +146,9 @@ void AGS2Client::FindLeaderboard(ScriptMethodParams &params) {
 }
 
 void AGS2Client::Initialize(ScriptMethodParams &params) {
+	PARAMS2(char *, clientId, char *, clientSecret);
+	AchMan.setSpecialString("clientId", clientId);
+	AchMan.setSpecialString("clientSecret", clientSecret);
 	params._result = 0;
 }
 

--- a/engines/wintermute/achievements_tables.h
+++ b/engines/wintermute/achievements_tables.h
@@ -38,7 +38,7 @@ static const AchievementDescriptionList achievementDescriptionList[] = {
 	{
 		"juliastars",
 		Common::GALAXY_ACHIEVEMENTS,
-		"48891696681534931",
+		"1457085654",
 		{
 			ACHIEVEMENT_SIMPLE_ENTRY("ACHI_LAND", "Good morning Xenophon!", "You've managed to land on a planet."),
 			ACHIEVEMENT_SIMPLE_ENTRY("ACHI_MIND", "Observant player", "You've obtained your first Mind'o'Matic."),

--- a/engines/wintermute/ext/wme_galaxy.cpp
+++ b/engines/wintermute/ext/wme_galaxy.cpp
@@ -77,7 +77,9 @@ bool SXWMEGalaxyAPI::scCallMethod(ScScript *script, ScStack *stack, ScStack *thi
 		stack->correctParams(2);
 		const char *clientId = stack->pop()->getString();
 		const char *clientSecret = stack->pop()->getString();
-		_gameRef->LOG(0, "InitGalaxy(%s, %s)", clientId, clientSecret);
+
+		AchMan.setSpecialString("clientId", clientId);
+		AchMan.setSpecialString("clientSecret", clientSecret);
 
 		stack->pushNULL();
 		return STATUS_OK;


### PR DESCRIPTION
This PR introduces a new "[special]" section at achievements ini-files.
For Steam it's quite useless, containing the same information as the file name - `platform=steam"` and `gameid=<gameid>`.
For GOG it additionally stores clientId and clientSecret provided as a required parameters to various Galaxy plugins like AGSGalaxy & SXWMEGalaxyAPI.
Those are NOT player's personal data and are not even unique for each played - clientId and clientSecret are actually always the same for each gameid and can be looked up at gogdb.com. However, I'd prefer to keep it inside achievements file just in case.

Also switching appId for GOG games from clientId to gameId which is shorter and usable by user in links like https://www.gog.com/u/[username]/game/1469845437.