### PR TITLE
DETECTION: Fix MD5 cache when starting engine

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -335,6 +335,9 @@ Common::Error AdvancedMetaEngineDetection::createInstance(OSystem *syst, Engine 
 	FileMap allFiles;
 	composeFileHashMap(allFiles, files, (_maxScanDepth == 0 ? 1 : _maxScanDepth));
 
+	// Clear md5 cache before each detection starts, just in case.
+	MD5Man.clear();
+
 	// Run the detector on this
 	ADDetectedGames matches = detectGame(files.begin()->getParent(), allFiles, language, platform, extra);
 


### PR DESCRIPTION
This fixes a bug with PR #2997 
Currently the MD5 cache is cleared when adding new games. However, starting games uses detection as well. So starting different games with same-name files will result in a "data not found" error, as the cache won't update.

This makes sure to clear the cache before starting new games. @a-yyg mentioned in the PR clearing the cache in detectFiles was a bad idea, so I put it here instead. Feedback welcome.