### PR TITLE
RFC: AUDIO: Add missing (?) mutex locking to MidiDriver_MT32GM::isReady()

### DIFF
--- a/audio/mt32gm.h
+++ b/audio/mt32gm.h
@@ -298,7 +298,10 @@ public:
 	virtual int open(MidiDriver *driver, bool nativeMT32);
 	void close() override;
 	bool isOpen() const override { return _isOpen; }
-	bool isReady() override { return _sysExQueue.empty(); }
+	bool isReady() override {
+		Common::StackLock lock(_sysExQueueMutex);
+		return _sysExQueue.empty();
+	}
 	uint32 property(int prop, uint32 param) override;
 
 	using MidiDriver_BASE::send;


### PR DESCRIPTION
While looking into why Lure of the Temptress takes so long to start with MT-32 audio (turns out that it's because it is setting up a lot of custom sounds?), I noticed what to me looks like a missing mutex lock in MidiDriver_MT32GM::isReady().

Lure of the Temptress calls isRead() to see if the driver has finished processing all the SysEx data. This checks if the queue is empty, but it does so without waiting for the mutex to unlock. Doesn't that mean the queue can be accessed simultaneously from two different threads?

Of course, such problems are notoriously hard to debug. I added some debug() calls, and it _looked_ like it happened a couple of times... assuming I can count on such debug messages to be printed in the correct order.

I tried asking around, but there was no one there who could answer me. So now I'm creating this pull request to see if there's any feedback.
