### PR TITLE
SDL: Add new pixel perfect stretch mode

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -241,6 +241,7 @@ namespace {
 const OSystem::GraphicsMode glStretchModes[] = {
 	{"center", _s("Center"), STRETCH_CENTER},
 	{"pixel-perfect", _s("Pixel-perfect scaling"), STRETCH_INTEGRAL},
+	{"even-pixels", _s("Even pixels scaling"), STRETCH_INTEGRAL_AR},
 	{"fit", _s("Fit to window"), STRETCH_FIT},
 	{"stretch", _s("Stretch to window"), STRETCH_STRETCH},
 	{"fit_force_aspect", _s("Fit to window (4:3)"), STRETCH_FIT_FORCE_ASPECT},

--- a/doc/docportal/advanced_topics/understand_graphics.rst
+++ b/doc/docportal/advanced_topics/understand_graphics.rst
@@ -142,6 +142,10 @@ There are five stretch modes:
 
     - For example, a game with an original resolution of 320x200 with aspect ratio correction applied (320x240) and a 3x graphics mode, will be stretched to a multiple of 900x720 pixels: 1800x1440, 2700x2160 and so on.
 
+- Even pixels scaling: scales the image to the highest multiple of the original game width and height. Any empty space is filled with black bars. When aspect ratio is enabled, it may be different from pixel-perfect as it will use a height that is a multiple of the original game height at the cost of not respecting exactly the aspect ratio. This ensure we get even pixels. This stretch mode is only available in OpenGL graphics mode.
+
+    - For example, with a screen resolution of 1920x1080, a game with an original resolution of 320x200 with aspect ratio correction applied (320x240) will be stretched to 1280x1000 (original width of 320 x 4 and original height of 200 x 5) which is a ratio of 320x250 and not 320x240. For comparison the pixel-perfect mode would stretch to 1280x960 (320x240 scaled by a factor 4, which means a scaling of x4.8 on the original height that would introduce some artifacts).
+
 - Fit to window: fits the image to the window, but maintains the aspect ratio and does not stretch it to fill the window.
 - Stretch: stretches the image to fill the window
 - Fit to window (4:3): fits the image to the window, at a forced 4:3 aspect ratio.


### PR DESCRIPTION
The commit in this pull request add a new pixel perfect mode. This mode ensure that an integral scaling from the original game resolution is used both for the width and for the height, thus providing homogeneous pixels. Compared to the old pixel perfect stretch mode it thus differs in the way it handles the aspect ratio correction as it may stretch or squeeze the vertical direction to snap it to a multiple of the original game height. When aspect ratio correction is off, the two modes should behave in exactly the same way.

For example with DOTT, which has an original resolution of 320x200, when I use aspect ratio correction and fullscreen on my laptop (with a screen resolution of 2880x1800) I get:
 - Old Pixel Perfect: Stretch (320, 200) -> (2240, 1680) with scaling x7 and x8.4
 - New Pixel Perfect: Stretch (320, 200) -> (2240, 1600) with scaling x7 and x8

So the new mode provides a compromise between the aspect ratio correction and getting perfect pixels.

I am creating this as a draft pull request as I have two questions:
 1. Should it replace the old pixel perfect stretch mode or do we want both? I would tend to keep both as some players may want a perfect aspect ratio and others perfect pixels.
 2. If we want both, how should they be named? For now I have used a temporary name that is not meant to be the final name. Maybe use `Pixel-perfect scaling` for the new one and renamed the old one to `Almost pixel-perfect scaling`? (I am joking here, but I am really struggling to find descriptive names for both).


See https://forums.scummvm.org/viewtopic.php?f=2&t=16297 for background on why I am proposing this change.

Also the documentation will need to be updated, but I am waiting on suggestions and opinions on the two questions above before finalising the change and updating the documentation.
