### PR TITLE
COMMON: fixed invalid read in zlib read stream

### DIFF
--- a/common/zlib.cpp
+++ b/common/zlib.cpp
@@ -496,7 +496,7 @@ SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped, ui
 	if (toBeWrapped) {
 		if (toBeWrapped->eos() || toBeWrapped->err() || toBeWrapped->size() < 2) {
 			delete toBeWrapped;
-			return NULL;
+			return nullptr;
 		}
 		uint16 header = toBeWrapped->readUint16BE();
 		bool isCompressed = (header == 0x1F8B ||
@@ -508,7 +508,7 @@ SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped, ui
 			return new GZipReadStream(toBeWrapped, knownSize);
 #else
 			delete toBeWrapped;
-			return NULL;
+			return nullptr;
 #endif
 		}
 	}

--- a/common/zlib.cpp
+++ b/common/zlib.cpp
@@ -494,6 +494,10 @@ public:
 
 SeekableReadStream *wrapCompressedReadStream(SeekableReadStream *toBeWrapped, uint32 knownSize) {
 	if (toBeWrapped) {
+		if (toBeWrapped->eos() || toBeWrapped->err() || toBeWrapped->size() < 2) {
+			delete toBeWrapped;
+			return NULL;
+		}
 		uint16 header = toBeWrapped->readUint16BE();
 		bool isCompressed = (header == 0x1F8B ||
 				     ((header & 0x0F00) == 0x0800 &&


### PR DESCRIPTION
```
==1313424== Conditional jump or move depends on uninitialised value(s)
==1313424==    at 0x682225: Common::wrapCompressedReadStream(Common::SeekableReadStream*, unsigned int) (zlib.cpp:498)
==1313424==    by 0x46CDB9: DefaultSaveFileManager::openForLoading(Common::String const&) (default-saves.cpp:134)
==1313424==    by 0x68334D: Common::PlaybackFile::openRead(Common::String const&) (recorderfile.cpp:74)
==1313424==    by 0x444558: GUI::RecorderDialog::updateList() (recorderdialog.cpp:206)
==1313424==    by 0x4446BD: GUI::RecorderDialog::runModal(Common::String&) (recorderdialog.cpp:218)
==1313424==    by 0x3DF0E5: GUI::LauncherDialog::recordGame(int) (launcher.cpp:461)
==1313424==    by 0x3E0397: GUI::LauncherDialog::handleCommand(GUI::CommandSender*, unsigned int, unsigned int) (launcher.cpp:671)
==1313424==    by 0x400BF8: GUI::CommandSender::sendCommand(unsigned int, unsigned int) (object.h:55)
==1313424==    by 0x42DAB8: GUI::DropdownButtonWidget::handleMouseUp(int, int, int, int) (widget.cpp:497)
==1313424==    by 0x3D3A37: GUI::Dialog::handleMouseUp(int, int, int, int) (dialog.cpp:228)
==1313424==    by 0x3DB72C: GUI::GuiManager::processEvent(Common::Event const&, GUI::Dialog*) (gui-manager.cpp:668)
==1313424==    by 0x3DA9EA: GUI::GuiManager::runLoop() (gui-manager.cpp:429)
```

Happens when you start with the event recorder compiled into scummvm and open the dialog to start
a new record.
