### PR TITLE
JANITORIAL: Remove extraneous period from math/matrix.h

### DIFF
--- a/math/matrix.h
+++ b/math/matrix.h
@@ -29,7 +29,7 @@
 #include "common/streamdebug.h"
 
 /**
- * \namespace Math.
+ * \namespace Math
  * This namespace contains some useful classes dealing with math and geometry.
  *
  * The most important classes are Matrix and its base classes.


### PR DESCRIPTION
When the ```math``` folder is added to ```doc/doxygen/scummvm.doxyfile``` as an input directory, the period would cause the doxygen build to fail.