### PR TITLE
DIRECTOR: allow setting of video casts to castNum

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -291,16 +291,6 @@ void Channel::setClean(Sprite *nextSprite, int spriteId, bool partial) {
 			}
 		}
 
-		// If the previous sprite in this channel was a video, but the new sprite is different,
-		// stop the playback.
-		// TODO: In D4 *any* channels playing the same cast member across a frame change seems
-		// to be enough to keep the same playback going, but the behaviour seems too glitchy
-		// to be reliable? Hopefully nothing relies on this.
-		if (_sprite && _sprite->_cast && _sprite->_cast->_type == kCastDigitalVideo &&
-				_sprite->_castId != nextSprite->_castId) {
-			((DigitalVideoCastMember *)_sprite->_cast)->stopVideo(this);
-		}
-
 		if (_sprite->_puppet || partial) {
 			// Updating scripts, etc. does not require a full re-render
 			_sprite->_scriptId = nextSprite->_scriptId;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1278,6 +1278,20 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 	case kTheCastNum:
 		{
 			int castId = d.asCastId();
+			CastMember *castMember = g_director->getCurrentMovie()->getCastMember(castId);
+
+			if (castMember && castMember->_type == kCastDigitalVideo) {
+				Common::String path = castMember->getCast()->getVideoPath(castId);
+				if (!path.empty()) {
+					((DigitalVideoCastMember *)castMember)->loadVideo(pathMakeRelative(path));
+					((DigitalVideoCastMember *)castMember)->startVideo(channel);
+					// b_updateStage needs to have _videoPlayback set to render video
+					// in the regular case Score::renderSprites sets it.
+					// However Score::renderSprites is not in the current code path.
+					g_director->getCurrentMovie()->_videoPlayback = true;
+				}
+			}
+
 			if (castId != sprite->_castId) {
 				g_director->getCurrentWindow()->addDirtyRect(channel->getBbox());
 				channel->setCast(castId);

--- a/engines/director/window.cpp
+++ b/engines/director/window.cpp
@@ -105,7 +105,7 @@ bool Window::render(bool forceRedraw, Graphics::ManagedSurface *blitTo) {
 		blitTo->clear(_stageColor);
 		markAllDirty();
 	} else {
-		if (_dirtyRects.size() == 0)
+		if (_dirtyRects.size() == 0 && _currentMovie->_videoPlayback == false)
 			return false;
 
 		mergeDirtyRects();


### PR DESCRIPTION
The game Majestic dynamically sets the castNum to video casts and expects them to play directly. Videos were also stopped erroneously. Video stoppage is assumed when movieRate is 0. The comment indicated that it was probably broken for D4.

The corresponding lingo code is: *anim is a cast label*

```
  set the castNum of sprite 48 to cast(anim)
  updateStage()
  set the movieRate of sprite 48 to 1
  repeat while the movieRate of sprite 48
    updateStage()
  end repeat
```