### PR TITLE
AGS: Add ags_fire and ags_agi plugin stubs (AGS_Fire.dll + ags_agi.dll)

### DIFF
--- a/engines/ags/module.mk
+++ b/engines/ags/module.mk
@@ -287,12 +287,14 @@ MODULE_OBJS = \
 	engine/script/systemimports.o \
 	plugins/agsplugin.o \
 	plugins/plugin_base.o \
+	plugins/ags_agi/ags_agi.o \
 	plugins/ags_blend/ags_blend.o \
 	plugins/ags_controller/ags_controller.o \
 	plugins/ags_creditz/ags_creditz.o \
 	plugins/ags_creditz/ags_creditz1.o \
 	plugins/ags_creditz/ags_creditz2.o \
 	plugins/ags_creditz/drawing.o \
+	plugins/ags_fire/ags_fire.o \
 	plugins/ags_flashlight/ags_flashlight.o \
 	plugins/ags_galaxy_steam/ags_wadjeteye_steam.o \
 	plugins/ags_galaxy_steam/ags_galaxy_steam.o \

--- a/engines/ags/plugins/ags_agi/ags_agi.cpp
+++ b/engines/ags/plugins/ags_agi/ags_agi.cpp
@@ -1,0 +1,78 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "ags/plugins/ags_agi/ags_agi.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSAgi {
+
+int screen_mode = 0;
+
+IAGSEngine *AGSAgi::_engine;
+int AGSAgi::_enabled;
+int AGSAgi::_scaling_mode;
+
+AGSAgi::AGSAgi() : PluginBase() {
+	_engine = nullptr;
+	_enabled = 0;
+	_scaling_mode = 0;
+
+	DLL_METHOD(AGS_GetPluginName);
+	DLL_METHOD(AGS_EngineStartup);
+}
+
+const char *AGSAgi::AGS_GetPluginName() {
+	return "AGS AGI Plugin stub (ags_agi.dll)";
+}
+
+void AGSAgi::AGS_EngineStartup(IAGSEngine *engine) {
+	_engine = engine;
+	_enabled = 0;
+	_scaling_mode = 0;
+
+	SCRIPT_METHOD(SetAGIScalingMode);
+	SCRIPT_METHOD(GetAGIScalingMode);
+	SCRIPT_METHOD(UseAGIScaling);
+}
+
+void AGSAgi::SetAGIScalingMode(ScriptMethodParams &params) {
+	PARAMS1(int, mode);
+	// TODO rest of the code
+
+	_scaling_mode = mode;
+}
+
+void AGSAgi::GetAGIScalingMode(ScriptMethodParams &params) {
+	params._result = _scaling_mode;
+}
+
+void AGSAgi::UseAGIScaling(ScriptMethodParams &params) {
+	PARAMS1(int, active);
+	// TODO rest of the code
+
+	_enabled = active;
+}
+
+} // namespace AGSAgi
+} // namespace Plugins
+} // namespace AGS3

--- a/engines/ags/plugins/ags_agi/ags_agi.h
+++ b/engines/ags/plugins/ags_agi/ags_agi.h
@@ -1,0 +1,55 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef AGS_PLUGINS_AGS_AGI_AGS_AGI_H
+#define AGS_PLUGINS_AGS_AGI_AGS_AGI_H
+
+#include "ags/plugins/plugin_base.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSAgi {
+
+class AGSAgi : public PluginBase {
+private:
+	static IAGSEngine *_engine;
+	static int _enabled;
+	static int _scaling_mode;
+
+private:
+	static const char *AGS_GetPluginName();
+	static void AGS_EngineStartup(IAGSEngine *engine);
+
+private:
+	static void SetAGIScalingMode(ScriptMethodParams &params);
+	static void GetAGIScalingMode(ScriptMethodParams &params);
+	static void UseAGIScaling(ScriptMethodParams &params);
+
+public:
+	AGSAgi();
+};
+
+} // namespace AGSAgi
+} // namespace Plugins
+} // namespace AGS3
+
+#endif

--- a/engines/ags/plugins/ags_fire/ags_fire.cpp
+++ b/engines/ags/plugins/ags_fire/ags_fire.cpp
@@ -1,0 +1,111 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "ags/plugins/ags_fire/ags_fire.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSFire {
+
+IAGSEngine *AGSFire::_engine;
+
+AGSFire::AGSFire() : PluginBase() {
+	_engine = nullptr;
+
+	DLL_METHOD(AGS_GetPluginName);
+	DLL_METHOD(AGS_EngineStartup);
+}
+
+const char *AGSFire::AGS_GetPluginName() {
+	return "Fire Plugin stub (ags_fire.dll)";
+}
+
+void AGSFire::AGS_EngineStartup(IAGSEngine *engine) {
+	_engine = engine;
+
+	SCRIPT_METHOD(FireAddObject);
+	SCRIPT_METHOD(FirePreHeat);
+	SCRIPT_METHOD(FireDisableSeeding);
+	SCRIPT_METHOD(FireEnableSeeding);
+	SCRIPT_METHOD(FireSetStrength);
+	SCRIPT_METHOD(FireRemoveObject);
+	SCRIPT_METHOD(FireUpdate);
+	SCRIPT_METHOD(FireStop);
+}
+
+void AGSFire::FireAddObject(ScriptMethodParams &params) {
+	//PARAMS3(int, object, int, seedSprite, int, paletteSprite)
+	// TODO rest of the code
+
+	params._result = 0;
+}
+
+void AGSFire::FirePreHeat(ScriptMethodParams &params) {
+	//PARAMS1(int, object)
+	// TODO rest of the code
+
+	params._result = 0;
+}
+
+void AGSFire::FireDisableSeeding(ScriptMethodParams &params) {
+	//PARAMS1(int, object)
+	// TODO rest of the code
+
+	params._result = 0;
+}
+
+void AGSFire::FireEnableSeeding(ScriptMethodParams &params) {
+	//PARAMS1(int, object)
+	// TODO rest of the code
+
+	params._result = 0;
+}
+
+void AGSFire::FireSetStrength(ScriptMethodParams &params) {
+	//PARAMS2(int, object, int, strength)
+	// TODO rest of the code
+
+	params._result = 0;
+}
+
+void AGSFire::FireRemoveObject(ScriptMethodParams &params) {
+	//PARAMS1(int, object)
+	// TODO rest of the code
+
+	params._result = 0;
+}
+
+void AGSFire::FireUpdate(ScriptMethodParams &params) {
+	// TODO rest of the owl
+
+	params._result = 0;
+}
+
+void AGSFire::FireStop(ScriptMethodParams &params) {
+	// TODO rest of the owl
+
+	params._result = 0;
+}
+
+} // namespace AGSFire
+} // namespace Plugins
+} // namespace AGS3

--- a/engines/ags/plugins/ags_fire/ags_fire.h
+++ b/engines/ags/plugins/ags_fire/ags_fire.h
@@ -1,0 +1,56 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef AGS_PLUGINS_AGS_FIRE_AGS_FIRE_H
+#define AGS_PLUGINS_AGS_FIRE_AGS_FIRE_H
+
+#include "ags/plugins/plugin_base.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSFire {
+
+class AGSFire : public PluginBase {
+private:
+	static IAGSEngine *_engine;
+	static const char *AGS_GetPluginName();
+	static void AGS_EngineStartup(IAGSEngine *engine);
+
+private:
+	static void FireAddObject(ScriptMethodParams &params);
+	static void FirePreHeat(ScriptMethodParams &params);
+	static void FireDisableSeeding(ScriptMethodParams &params);
+	static void FireEnableSeeding(ScriptMethodParams &params);
+	static void FireSetStrength(ScriptMethodParams &params);
+	static void FireRemoveObject(ScriptMethodParams &params);
+	static void FireUpdate(ScriptMethodParams &params);
+	static void FireStop(ScriptMethodParams &params);
+
+public:
+	AGSFire();
+};
+
+} // namespace AGSFire
+} // namespace Plugins
+} // namespace AGS3
+
+#endif

--- a/engines/ags/plugins/plugin_base.cpp
+++ b/engines/ags/plugins/plugin_base.cpp
@@ -22,10 +22,12 @@
 
 #include "ags/lib/allegro.h"
 #include "ags/plugins/plugin_base.h"
+#include "ags/plugins/ags_agi/ags_agi.h"
 #include "ags/plugins/ags_blend/ags_blend.h"
 #include "ags/plugins/ags_controller/ags_controller.h"
 #include "ags/plugins/ags_creditz/ags_creditz1.h"
 #include "ags/plugins/ags_creditz/ags_creditz2.h"
+#include "ags/plugins/ags_fire/ags_fire.h"
 #include "ags/plugins/ags_flashlight/ags_flashlight.h"
 #include "ags/plugins/ags_galaxy_steam/ags_wadjeteye_steam.h"
 #include "ags/plugins/ags_galaxy_steam/ags_galaxy_steam.h"
@@ -61,6 +63,9 @@ void *pluginOpen(const char *filename) {
 	if (fname.equalsIgnoreCase("ags_tcp_ip"))
 		return new AGSTcpIp::AGSTcpIp();
 
+	if (fname.equalsIgnoreCase("AGS_AGI"))
+		return new AGSAgi::AGSAgi();
+
 	if (fname.equalsIgnoreCase("AGSBlend"))
 		return new AGSBlend::AGSBlend();
 
@@ -72,6 +77,9 @@ void *pluginOpen(const char *filename) {
 
 	if (fname.equalsIgnoreCase("agsCreditz2"))
 		return new AGSCreditz::AGSCreditz2();
+
+	if (fname.equalsIgnoreCase("AGS_Fire"))
+		return new AGSFire::AGSFire();
 
 	if (fname.equalsIgnoreCase("AGSFlashlight"))
 		return new AGSFlashlight::AGSFlashlight();


### PR DESCRIPTION
AGS_Fire: Doesn't do anything, but allows games using plasma fire effects to load
and run.

All methods return 0

A sample game using this plugin is Maniac Mansion Mania 46.

AGS_AGI: Allows games who use AGI lowres effects to load and run.

Games using scaling mode 0 will be squashed on the screen, but others
should be playable without the screen effect.

Sample working games: Gladiator Quest, The Secret of Hutton Grammar School