### PR TITLE
GUI: Do not show tooltip on hovered focused EditText widget

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -442,14 +442,16 @@ void GuiManager::runLoop() {
 
 		// Handle tooltip for the widget under the mouse cursor
 		uint32 systemMillisNowForTooltipCheck = _system->getMillis(true);
-		bool focusedTextEditWidget = false;
 		if (_lastMousePosition.time + kTooltipDelay < systemMillisNowForTooltipCheck) {
 			Widget *wdg = activeDialog->findWidget(_lastMousePosition.x, _lastMousePosition.y);
 			if (wdg && wdg->hasTooltip() && !(wdg->getFlags() & WIDGET_PRESSED)) {
 				if (wdg->getType() == kEditTextWidget && activeDialog->getFocusWidget() == wdg) {
 					// if the mouse-hovered Edit Text widget also has focus
 					// then don't display a tooltip (so as not to interfere with text typing)
-					focusedTextEditWidget = true;
+					// also force-update the time of last mouse position to the current time,
+					// to avoid the tooltip showing up / blinking as soon as the focus is lost
+					// while the mouse is still hovering over the widget.
+					_lastMousePosition.time = systemMillisNowForTooltipCheck;
 				} else {
 					Tooltip *tooltip = new Tooltip();
 					tooltip->setup(activeDialog, wdg, _lastMousePosition.x, _lastMousePosition.y);
@@ -457,12 +459,6 @@ void GuiManager::runLoop() {
 					delete tooltip;
 				}
 			}
-		}
-		if (focusedTextEditWidget) {
-			// also force-update the time of last mouse position to the current time,
-			// to avoid the tooltip showing up / blinking as soon as the focus is lost
-			// while the mouse is still hovering over the widget.
-			_lastMousePosition.time = systemMillisNowForTooltipCheck;
 		}
 
 		redraw();

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -153,6 +153,8 @@ public:
 	void lostFocus() { _hasFocus = false; lostFocusWidget(); }
 	virtual bool wantsFocus() { return false; }
 
+	uint32 getType() const {return _type;}
+
 	void setFlags(int flags);
 	void clearFlags(int flags);
 	int getFlags() const		{ return _flags; }

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -153,7 +153,7 @@ public:
 	void lostFocus() { _hasFocus = false; lostFocusWidget(); }
 	virtual bool wantsFocus() { return false; }
 
-	uint32 getType() const {return _type;}
+	uint32 getType() const { return _type; }
 
 	void setFlags(int flags);
 	void clearFlags(int flags);


### PR DESCRIPTION
Prevents showing a tooltip for a widget is it is an editable field (editText) and has both mouse hovering above it and the current focus.

This is so that typing text is not interrupted / slowed down by a periodical display of the tooltip, if the mouse is hovering over the same text field that the user is editing.

The bug was mentioned for the Android port on the forums here:
https://forums.scummvm.org/viewtopic.php?p=95531#p95531
However, it is not Android specific, even though the slowdown is a lot more noticeable on an Android device.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
