### PR TITLE
GUI: Do not show tooltip for hovered widget if there is a focused EditText one

### DIFF
--- a/gui/widget.h
+++ b/gui/widget.h
@@ -153,6 +153,8 @@ public:
 	void lostFocus() { _hasFocus = false; lostFocusWidget(); }
 	virtual bool wantsFocus() { return false; }
 
+	uint32 getType() const { return _type; }
+
 	void setFlags(int flags);
 	void clearFlags(int flags);
 	int getFlags() const		{ return _flags; }


### PR DESCRIPTION
This PR is a more proper fix to the issue that my previous (now closed PR) was addressing: 
(https://github.com/scummvm/scummvm/pull/3055)

Prevents showing a tooltip for the hovered-widget, if an editText field has the current focus, and hence the user will be typing in it. 

This is so that typing text is not interrupted / slowed down by a periodical display of the tooltip for the hovered-widget. This applies whether the mouse cursor is hovering over the same widget that the user is editing or another tooltip-enabled widget (only while an editText widget has the focus). 

The bug was mentioned for the Android port on the forums here:
https://forums.scummvm.org/viewtopic.php?p=95531#p95531
However, it is not Android specific, even though the slowdown is a lot more noticeable on an Android device.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
