### PR TITLE
Cleanup DebugManager

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -966,7 +966,7 @@ static void printDebugFlags(const DebugChannelDef *debugChannels) {
 /** List debug flags*/
 static void listDebugFlags(const Common::String &engineID) {
 	if (engineID == "global")
-		printDebugFlags(globalDebugChannels);
+		printDebugFlags(gDebugChannels);
 	else {
 		const PluginList &plugins = EngineMan.getPlugins();
 		for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -134,7 +134,6 @@ static const Plugin *detectPlugin() {
 	// Query the plugin for the game descriptor
 	printf("   Looking for a plugin supporting this target... %s\n", plugin->getName());
 	const MetaEngineDetection &metaEngine = plugin->get<MetaEngineDetection>();
-	DebugMan.debugFlagsClear();
 	DebugMan.debugFlagsRegister(metaEngine.getDebugChannels());
 	PlainGameDescriptor game = metaEngine.findGame(gameId.c_str());
 	if (!game.gameId) {
@@ -194,8 +193,6 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 		metaEngineDetection.registerDefaultSettings(target);
 	}
 
-	// clear the flag and add the global ones
-	DebugMan.debugFlagsClear();
 	// before we instantiate the engine, we register debug channels for it
 	DebugMan.debugFlagsRegister(metaEngineDetection.getDebugChannels());
 
@@ -518,8 +515,6 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	system.getAudioCDManager();
 	MusicManager::instance();
 	Common::DebugManager::instance();
-	// set the global debug flags as soon as we instantiate the debug mannager
-	DebugMan.debugFlagsClear();
 
 	// Init the event manager. As the virtual keyboard is loaded here, it must
 	// take place after the backend is initiated and the screen has been setup

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -222,6 +222,7 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 			ConfMan.removeGameDomain(target.c_str());
 		}
 
+		DebugMan.clearAllDebugChannels();
 		return err;
 	}
 
@@ -321,7 +322,6 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 	// Free up memory
 	delete engine;
 
-	// We clear all debug levels again even though the engine should do it
 	DebugMan.clearAllDebugChannels();
 
 	// Reset the file/directory mappings

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -134,7 +134,7 @@ static const Plugin *detectPlugin() {
 	// Query the plugin for the game descriptor
 	printf("   Looking for a plugin supporting this target... %s\n", plugin->getName());
 	const MetaEngineDetection &metaEngine = plugin->get<MetaEngineDetection>();
-	DebugMan.debugFlagsRegister(metaEngine.getDebugChannels());
+	DebugMan.addAllDebugChannels(metaEngine.getDebugChannels());
 	PlainGameDescriptor game = metaEngine.findGame(gameId.c_str());
 	if (!game.gameId) {
 		warning("'%s' is an invalid game ID for the engine '%s'. Use the --list-games option to list supported game IDs", gameId.c_str(), engineId.c_str());
@@ -194,7 +194,7 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 	}
 
 	// before we instantiate the engine, we register debug channels for it
-	DebugMan.debugFlagsRegister(metaEngineDetection.getDebugChannels());
+	DebugMan.addAllDebugChannels(metaEngineDetection.getDebugChannels());
 
 	// Create the game's MetaEngine.
 	MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
@@ -219,7 +219,7 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 			ConfMan.removeGameDomain(target.c_str());
 		}
 
-		DebugMan.clearAllDebugChannels();
+		DebugMan.removeAllDebugChannels();
 		return err;
 	}
 
@@ -319,7 +319,7 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 	// Free up memory
 	delete engine;
 
-	DebugMan.clearAllDebugChannels();
+	DebugMan.removeAllDebugChannels();
 
 	// Reset the file/directory mappings
 	SearchMan.clear();

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -678,7 +678,7 @@ QualifiedGameList EngineManager::findGamesMatching(const Common::String &engineI
 		const Plugin *p = EngineMan.findPlugin(engineId);
 		if (p) {
 			const MetaEngineDetection &engine = p->get<MetaEngineDetection>();
-			DebugMan.debugFlagsRegister(engine.getDebugChannels());
+			DebugMan.addAllDebugChannels(engine.getDebugChannels());
 
 			PlainGameDescriptor pluginResult = engine.findGame(gameId.c_str());
 			if (pluginResult.gameId) {
@@ -708,7 +708,7 @@ QualifiedGameList EngineManager::findGameInLoadedPlugins(const Common::String &g
 
 	for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &engine = (*iter)->get<MetaEngineDetection>();
-		DebugMan.debugFlagsRegister(engine.getDebugChannels());
+		DebugMan.addAllDebugChannels(engine.getDebugChannels());
 		PlainGameDescriptor pluginResult = engine.findGame(gameId.c_str());
 
 		if (pluginResult.gameId) {
@@ -736,7 +736,7 @@ DetectionResults EngineManager::detectGames(const Common::FSList &fslist) const 
 	for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		// set the debug flags
-		DebugMan.debugFlagsRegister(metaEngine.getDebugChannels());
+		DebugMan.addAllDebugChannels(metaEngine.getDebugChannels());
 		DetectedGames engineCandidates = metaEngine.detectGames(fslist);
 
 		for (uint i = 0; i < engineCandidates.size(); i++) {
@@ -867,7 +867,7 @@ QualifiedGameDescriptor EngineManager::findTarget(const Common::String &target, 
 
 	// Make sure it does support the game ID
 	const MetaEngineDetection &engine = foundPlugin->get<MetaEngineDetection>();
-	DebugMan.debugFlagsRegister(engine.getDebugChannels());
+	DebugMan.addAllDebugChannels(engine.getDebugChannels());
 	PlainGameDescriptor desc = engine.findGame(domain->getVal("gameid").c_str());
 	if (!desc.gameId) {
 		return QualifiedGameDescriptor();
@@ -934,7 +934,7 @@ void EngineManager::upgradeTargetForEngineId(const Common::String &target) const
 		// Take the first detection entry
 		const MetaEngineDetection &metaEngine = plugin->get<MetaEngineDetection>();
 		// set debug flags before call detectGames
-		DebugMan.debugFlagsRegister(metaEngine.getDebugChannels());
+		DebugMan.addAllDebugChannels(metaEngine.getDebugChannels());
 		DetectedGames candidates = metaEngine.detectGames(files);
 		if (candidates.empty()) {
 			warning("No games supported by the engine '%s' were found in path '%s' when upgrading target '%s'",

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -678,7 +678,6 @@ QualifiedGameList EngineManager::findGamesMatching(const Common::String &engineI
 		const Plugin *p = EngineMan.findPlugin(engineId);
 		if (p) {
 			const MetaEngineDetection &engine = p->get<MetaEngineDetection>();
-			DebugMan.debugFlagsClear();
 			DebugMan.debugFlagsRegister(engine.getDebugChannels());
 
 			PlainGameDescriptor pluginResult = engine.findGame(gameId.c_str());
@@ -709,7 +708,6 @@ QualifiedGameList EngineManager::findGameInLoadedPlugins(const Common::String &g
 
 	for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &engine = (*iter)->get<MetaEngineDetection>();
-		DebugMan.debugFlagsClear();
 		DebugMan.debugFlagsRegister(engine.getDebugChannels());
 		PlainGameDescriptor pluginResult = engine.findGame(gameId.c_str());
 
@@ -738,7 +736,6 @@ DetectionResults EngineManager::detectGames(const Common::FSList &fslist) const 
 	for (iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		// set the debug flags
-		DebugMan.debugFlagsClear();
 		DebugMan.debugFlagsRegister(metaEngine.getDebugChannels());
 		DetectedGames engineCandidates = metaEngine.detectGames(fslist);
 
@@ -870,7 +867,6 @@ QualifiedGameDescriptor EngineManager::findTarget(const Common::String &target, 
 
 	// Make sure it does support the game ID
 	const MetaEngineDetection &engine = foundPlugin->get<MetaEngineDetection>();
-	DebugMan.debugFlagsClear();
 	DebugMan.debugFlagsRegister(engine.getDebugChannels());
 	PlainGameDescriptor desc = engine.findGame(domain->getVal("gameid").c_str());
 	if (!desc.gameId) {
@@ -938,7 +934,6 @@ void EngineManager::upgradeTargetForEngineId(const Common::String &target) const
 		// Take the first detection entry
 		const MetaEngineDetection &metaEngine = plugin->get<MetaEngineDetection>();
 		// set debug flags before call detectGames
-		DebugMan.debugFlagsClear();
 		DebugMan.debugFlagsRegister(metaEngine.getDebugChannels());
 		DetectedGames candidates = metaEngine.detectGames(files);
 		if (candidates.empty()) {

--- a/common/debug-channels.h
+++ b/common/debug-channels.h
@@ -85,9 +85,15 @@ public:
 	bool addDebugChannel(uint32 channel, const String &name, const String &description);
 
 	/**
-	 * Reset all engine-specific debug channels.
+	 * Add all the debug channels for an engine. This replaces any existing engine
+	 * debug channels and disables all channels.
 	 */
-	void clearAllDebugChannels();
+	void addAllDebugChannels(const DebugChannelDef *channels);
+
+	/**
+	 * Remove all engine debug channels and disable all global debug channels.
+	 */
+	void removeAllDebugChannels();
 
 	/**
 	 * Enable a debug channel.
@@ -124,11 +130,12 @@ public:
 	typedef List<DebugChannel> DebugChannelList;
 
 	/**
-	 * Lists all engine specific debug channels.
+	 * Lists all debug channels. This includes engine and global
+	 * debug channels.
 	 *
-	 * @return returns an array with all debug channels
+	 * @return List of all debug channels sorted by debug level.
 	 */
-	DebugChannelList listDebugChannels();
+	DebugChannelList getDebugChannels();
 
 	/**
 	 * Enable all debug channels.
@@ -145,11 +152,6 @@ public:
 	 */
 	bool isDebugChannelEnabled(uint32 channel, bool enforce = false);
 
-	/**
-	 * register engine specified flags
-	 */
-	void debugFlagsRegister(const DebugChannelDef *channels);
-
 private:
 	typedef HashMap<String, DebugChannel, IgnoreCase_Hash, IgnoreCase_EqualTo> DebugChannelMap;
 
@@ -160,6 +162,9 @@ private:
 
 	DebugManager();
 
+	/**
+	 * Internal method for adding an array of debug channels.
+	 */
 	void addDebugChannels(const DebugChannelDef *channels);
 };
 

--- a/common/debug-channels.h
+++ b/common/debug-channels.h
@@ -145,13 +145,6 @@ public:
 	 */
 	bool isDebugChannelEnabled(uint32 channel, bool enforce = false);
 
-
-	/**
-	 * clear all the engine specified flags
-	 * only left the global debug flags
-	 */
-	void debugFlagsClear();
-
 	/**
 	 * register engine specified flags
 	 */
@@ -164,7 +157,10 @@ private:
 	uint32 _debugChannelsEnabled;
 
 	friend class Singleton<SingletonBaseType>;
-	DebugManager() : _debugChannelsEnabled(0) {}
+
+	DebugManager();
+
+	void addDebugChannels(const DebugChannelDef *channels);
 };
 
 /** Shortcut for accessing the Debug Manager. */

--- a/common/debug-channels.h
+++ b/common/debug-channels.h
@@ -160,11 +160,11 @@ public:
 private:
 	typedef HashMap<String, DebugChannel, IgnoreCase_Hash, IgnoreCase_EqualTo> DebugChannelMap;
 
-	DebugChannelMap gDebugChannels;
-	uint32 gDebugChannelsEnabled;
+	DebugChannelMap _debugChannels;
+	uint32 _debugChannelsEnabled;
 
 	friend class Singleton<SingletonBaseType>;
-	DebugManager() : gDebugChannelsEnabled(0) {}
+	DebugManager() : _debugChannelsEnabled(0) {}
 };
 
 /** Shortcut for accessing the Debug Manager. */

--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -69,7 +69,15 @@ bool DebugManager::addDebugChannel(uint32 channel, const String &name, const Str
 	return true;
 }
 
-void DebugManager::clearAllDebugChannels() {
+void DebugManager::addAllDebugChannels(const DebugChannelDef *channels) {
+	removeAllDebugChannels();
+
+	if (channels) {
+		addDebugChannels(channels);
+	}
+}
+
+void DebugManager::removeAllDebugChannels() {
 	_debugChannelsEnabled = 0;
 	_debugChannels.clear();
 	addDebugChannels(gDebugChannels);
@@ -111,7 +119,7 @@ bool DebugManager::disableDebugChannel(uint32 channel) {
 	return true;
 }
 
-DebugManager::DebugChannelList DebugManager::listDebugChannels() {
+DebugManager::DebugChannelList DebugManager::getDebugChannels() {
 	DebugChannelList tmp;
 	for (DebugChannelMap::iterator i = _debugChannels.begin(); i != _debugChannels.end(); ++i)
 		tmp.push_back(i->_value);
@@ -136,14 +144,6 @@ bool DebugManager::isDebugChannelEnabled(uint32 channel, bool enforce) {
 		return true;
 	else
 		return (_debugChannelsEnabled & channel) != 0;
-}
-
-void DebugManager::debugFlagsRegister(const DebugChannelDef *channels) {
-	clearAllDebugChannels();
-
-	if (channels) {
-		addDebugChannels(channels);
-	}
 }
 
 void DebugManager::addDebugChannels(const DebugChannelDef *channels) {

--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -52,28 +52,28 @@ bool DebugManager::addDebugChannel(uint32 channel, const String &name, const Str
 		return false;
 	}
 
-	if (gDebugChannels.contains(name))
+	if (_debugChannels.contains(name))
 		warning("Duplicate declaration of engine debug channel '%s'", name.c_str());
 
-	for (DebugChannelMap::iterator i = gDebugChannels.begin(); i != gDebugChannels.end(); i++)
+	for (DebugChannelMap::iterator i = _debugChannels.begin(); i != _debugChannels.end(); i++)
 		if (i->_value.channel == channel)
 			error("Duplicate engine debug channel id '%d' for flag '%s'", channel, name.c_str());
 
-	gDebugChannels[name] = DebugChannel(channel, name, description);
+	_debugChannels[name] = DebugChannel(channel, name, description);
 
 	return true;
 }
 
 void DebugManager::clearAllDebugChannels() {
-	gDebugChannelsEnabled = 0;
-	gDebugChannels.clear();
+	_debugChannelsEnabled = 0;
+	_debugChannels.clear();
 }
 
 bool DebugManager::enableDebugChannel(const String &name) {
-	DebugChannelMap::iterator i = gDebugChannels.find(name);
+	DebugChannelMap::iterator i = _debugChannels.find(name);
 
-	if (i != gDebugChannels.end()) {
-		gDebugChannelsEnabled |= i->_value.channel;
+	if (i != _debugChannels.end()) {
+		_debugChannelsEnabled |= i->_value.channel;
 		i->_value.enabled = true;
 
 		return true;
@@ -83,15 +83,15 @@ bool DebugManager::enableDebugChannel(const String &name) {
 }
 
 bool DebugManager::enableDebugChannel(uint32 channel) {
-	gDebugChannelsEnabled |= channel;
+	_debugChannelsEnabled |= channel;
 	return true;
 }
 
 bool DebugManager::disableDebugChannel(const String &name) {
-	DebugChannelMap::iterator i = gDebugChannels.find(name);
+	DebugChannelMap::iterator i = _debugChannels.find(name);
 
-	if (i != gDebugChannels.end()) {
-		gDebugChannelsEnabled &= ~i->_value.channel;
+	if (i != _debugChannels.end()) {
+		_debugChannelsEnabled &= ~i->_value.channel;
 		i->_value.enabled = false;
 
 		return true;
@@ -101,13 +101,13 @@ bool DebugManager::disableDebugChannel(const String &name) {
 }
 
 bool DebugManager::disableDebugChannel(uint32 channel) {
-	gDebugChannelsEnabled &= ~channel;
+	_debugChannelsEnabled &= ~channel;
 	return true;
 }
 
 DebugManager::DebugChannelList DebugManager::listDebugChannels() {
 	DebugChannelList tmp;
-	for (DebugChannelMap::iterator i = gDebugChannels.begin(); i != gDebugChannels.end(); ++i)
+	for (DebugChannelMap::iterator i = _debugChannels.begin(); i != _debugChannels.end(); ++i)
 		tmp.push_back(i->_value);
 	sort(tmp.begin(), tmp.end(), DebugLevelComperator());
 
@@ -115,12 +115,12 @@ DebugManager::DebugChannelList DebugManager::listDebugChannels() {
 }
 
 void DebugManager::enableAllDebugChannels() {
-	for (DebugChannelMap::iterator i = gDebugChannels.begin(); i != gDebugChannels.end(); ++i)
+	for (DebugChannelMap::iterator i = _debugChannels.begin(); i != _debugChannels.end(); ++i)
 		enableDebugChannel(i->_value.name);
 }
 
 void DebugManager::disableAllDebugChannels() {
-	for (DebugChannelMap::iterator i = gDebugChannels.begin(); i != gDebugChannels.end(); ++i)
+	for (DebugChannelMap::iterator i = _debugChannels.begin(); i != _debugChannels.end(); ++i)
 		disableDebugChannel(i->_value.name);
 }
 
@@ -129,7 +129,7 @@ bool DebugManager::isDebugChannelEnabled(uint32 channel, bool enforce) {
 	if (gDebugLevel == 11 && enforce == false)
 		return true;
 	else
-		return (gDebugChannelsEnabled & channel) != 0;
+		return (_debugChannelsEnabled & channel) != 0;
 }
 
 void DebugManager::debugFlagsRegister(const DebugChannelDef *channels) {
@@ -144,7 +144,7 @@ void DebugManager::debugFlagsClear() {
 	// first we clear all the debug channels
 	// then we add the global debug flags
 	clearAllDebugChannels();
-	debugFlagsRegister(globalDebugChannels);
+	debugFlagsRegister(gDebugChannels);
 }
 
 } // End of namespace Common

--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -46,6 +46,11 @@ struct DebugLevelComperator {
 
 } // end of anonymous namespace
 
+DebugManager::DebugManager() :
+	_debugChannelsEnabled(0) {
+	addDebugChannels(gDebugChannels);
+}
+
 bool DebugManager::addDebugChannel(uint32 channel, const String &name, const String &description) {
 	if (name.equalsIgnoreCase("all")) {
 		warning("Debug channel 'all' is reserved for internal use");
@@ -55,7 +60,7 @@ bool DebugManager::addDebugChannel(uint32 channel, const String &name, const Str
 	if (_debugChannels.contains(name))
 		warning("Duplicate declaration of engine debug channel '%s'", name.c_str());
 
-	for (DebugChannelMap::iterator i = _debugChannels.begin(); i != _debugChannels.end(); i++)
+	for (DebugChannelMap::iterator i = _debugChannels.begin(); i != _debugChannels.end(); ++i)
 		if (i->_value.channel == channel)
 			error("Duplicate engine debug channel id '%d' for flag '%s'", channel, name.c_str());
 
@@ -67,6 +72,7 @@ bool DebugManager::addDebugChannel(uint32 channel, const String &name, const Str
 void DebugManager::clearAllDebugChannels() {
 	_debugChannelsEnabled = 0;
 	_debugChannels.clear();
+	addDebugChannels(gDebugChannels);
 }
 
 bool DebugManager::enableDebugChannel(const String &name) {
@@ -133,18 +139,17 @@ bool DebugManager::isDebugChannelEnabled(uint32 channel, bool enforce) {
 }
 
 void DebugManager::debugFlagsRegister(const DebugChannelDef *channels) {
-	if (!channels)
-		return;
-	for (uint i = 0; channels[i].channel != 0; i++) {
-		addDebugChannel(channels[i].channel, channels[i].name, channels[i].description);
+	clearAllDebugChannels();
+
+	if (channels) {
+		addDebugChannels(channels);
 	}
 }
 
-void DebugManager::debugFlagsClear() {
-	// first we clear all the debug channels
-	// then we add the global debug flags
-	clearAllDebugChannels();
-	debugFlagsRegister(gDebugChannels);
+void DebugManager::addDebugChannels(const DebugChannelDef *channels) {
+	for (uint i = 0; channels[i].channel != 0; ++i) {
+		addDebugChannel(channels[i].channel, channels[i].name, channels[i].description);
+	}
 }
 
 } // End of namespace Common

--- a/common/debug.h
+++ b/common/debug.h
@@ -166,7 +166,7 @@ enum GlobalDebugLevels {
 	kDebugLevelEventRec = 1 << 30
 };
 
-static const DebugChannelDef globalDebugChannels[] = {
+static const DebugChannelDef gDebugChannels[] = {
 	{kDebugLevelEventRec, "EventRec", "Event recorder debug level"},
 	{kDebugGlobalDetection, "Detection", "debug messages for advancedDetector"},
 	DEBUG_CHANNEL_END

--- a/engines/asylum/console.cpp
+++ b/engines/asylum/console.cpp
@@ -219,7 +219,6 @@ Console::Console(AsylumEngine *engine) : _vm(engine) {
 }
 
 Console::~Console() {
-	DebugMan.clearAllDebugChannels();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -778,8 +778,6 @@ void BladeRunnerEngine::initChapterAndScene() {
 }
 
 void BladeRunnerEngine::shutdown() {
-	DebugMan.clearAllDebugChannels();
-
 	_mixer->stopAll();
 
 	// BLADE.INI as updated here

--- a/engines/cge/cge.cpp
+++ b/engines/cge/cge.cpp
@@ -164,9 +164,6 @@ void CGEEngine::init() {
 }
 
 void CGEEngine::deinit() {
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
-
 	// Delete engine objects
 	delete _vga;
 	delete _sys;

--- a/engines/cge2/cge2.cpp
+++ b/engines/cge2/cge2.cpp
@@ -142,9 +142,6 @@ void CGE2Engine::init() {
 }
 
 void CGE2Engine::deinit() {
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
-
 	delete _spare;
 	delete _resman;
 	delete _vga;

--- a/engines/cine/cine.cpp
+++ b/engines/cine/cine.cpp
@@ -70,8 +70,6 @@ CineEngine::~CineEngine() {
 	if (getGameType() == Cine::GType_OS) {
 		freeErrmessDat();
 	}
-
-	DebugMan.clearAllDebugChannels();
 }
 
 void CineEngine::syncSoundSettings() {

--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -55,8 +55,6 @@ ComposerEngine::ComposerEngine(OSystem *syst, const ComposerGameDescription *gam
 }
 
 ComposerEngine::~ComposerEngine() {
-	DebugMan.clearAllDebugChannels();
-
 	stopPipes();
 	for (Common::List<OldScript *>::iterator i = _oldScripts.begin(); i != _oldScripts.end(); i++)
 		delete *i;

--- a/engines/cryo/cryo.cpp
+++ b/engines/cryo/cryo.cpp
@@ -54,8 +54,6 @@ CryoEngine::~CryoEngine() {
 	delete _rnd;
 	delete _game;
 	delete _screenView;
-
-	DebugMan.clearAllDebugChannels();
 }
 
 Common::Error CryoEngine::run() {

--- a/engines/cryomni3d/cryomni3d.cpp
+++ b/engines/cryomni3d/cryomni3d.cpp
@@ -55,7 +55,6 @@ CryOmni3DEngine::CryOmni3DEngine(OSystem *syst,
 }
 
 CryOmni3DEngine::~CryOmni3DEngine() {
-	DebugMan.clearAllDebugChannels();
 }
 
 Common::Error CryOmni3DEngine::run() {

--- a/engines/dm/dm.cpp
+++ b/engines/dm/dm.cpp
@@ -204,8 +204,6 @@ DMEngine::~DMEngine() {
 	delete _saveThumbnail;
 
 	delete[] _savedScreenForOpenEntranceDoors;
-	// clear debug channels
-	DebugMan.clearAllDebugChannels();
 }
 
 bool DMEngine::hasFeature(EngineFeature f) const {

--- a/engines/draci/draci.cpp
+++ b/engines/draci/draci.cpp
@@ -391,9 +391,6 @@ DraciEngine::~DraciEngine() {
 	delete _music;
 	delete _soundsArchive;
 	delete _dubbingArchive;
-
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
 }
 
 Common::Error DraciEngine::run() {

--- a/engines/dreamweb/dreamweb.cpp
+++ b/engines/dreamweb/dreamweb.cpp
@@ -266,7 +266,6 @@ DreamWebEngine::DreamWebEngine(OSystem *syst, const DreamWebGameDescription *gam
 }
 
 DreamWebEngine::~DreamWebEngine() {
-	DebugMan.clearAllDebugChannels();
 	delete _sound;
 }
 

--- a/engines/glk/glk.cpp
+++ b/engines/glk/glk.cpp
@@ -69,9 +69,6 @@ GlkEngine::~GlkEngine() {
 	delete _streams;
 	delete _windows;
 	delete _conf;
-
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
 }
 
 void GlkEngine::initialize() {

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -236,7 +236,6 @@ GrimEngine::~GrimEngine() {
 	delete _commentary;
 
 	ConfMan.flushToDisk();
-	DebugMan.clearAllDebugChannels();
 
 	g_grim = nullptr;
 }

--- a/engines/groovie/debug.cpp
+++ b/engines/groovie/debug.cpp
@@ -49,7 +49,6 @@ Debugger::Debugger(GroovieEngine *vm) :
 }
 
 Debugger::~Debugger() {
-	DebugMan.clearAllDebugChannels();
 }
 
 int Debugger::getNumber(const char *arg) {

--- a/engines/hadesch/hadesch.cpp
+++ b/engines/hadesch/hadesch.cpp
@@ -87,7 +87,6 @@ HadeschEngine::HadeschEngine(OSystem *system, const ADGameDescription *desc)
 
 HadeschEngine::~HadeschEngine() {
 	debug("HadeschEngine::dtor");
-	DebugMan.clearAllDebugChannels();
 	for (unsigned i = 0; i < _winCursors.size(); i++) {
 		delete _winCursors[i];
 		_winCursors[i] = nullptr;

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -138,7 +138,6 @@ HugoEngine::~HugoEngine() {
 	delete _file;
 	delete _text;
 
-	DebugMan.clearAllDebugChannels();
 	delete _rnd;
 }
 

--- a/engines/kyra/engine/kyra_lok.cpp
+++ b/engines/kyra/engine/kyra_lok.cpp
@@ -112,8 +112,6 @@ KyraEngine_LoK::~KyraEngine_LoK() {
 		_emc->unload(&_scriptClickData);
 	}
 
-	DebugMan.clearAllDebugChannels();
-
 	delete _screen;
 	delete _sprites;
 	delete _animator;

--- a/engines/lab/lab.cpp
+++ b/engines/lab/lab.cpp
@@ -136,9 +136,6 @@ LabEngine::LabEngine(OSystem *syst, const ADGameDescription *gameDesc)
 }
 
 LabEngine::~LabEngine() {
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
-
 	freeMapData();
 	delete[] _rooms;
 	delete[] _inventory;

--- a/engines/lastexpress/debug.cpp
+++ b/engines/lastexpress/debug.cpp
@@ -94,8 +94,6 @@ Debugger::Debugger(LastExpressEngine *engine) : _engine(engine), _command(NULL),
 }
 
 Debugger::~Debugger() {
-	DebugMan.clearAllDebugChannels();
-
 	SAFE_DELETE(_soundStream);
 	resetCommand();
 

--- a/engines/lilliput/lilliput.cpp
+++ b/engines/lilliput/lilliput.cpp
@@ -257,7 +257,6 @@ LilliputEngine::LilliputEngine(OSystem *syst, const LilliputGameDescription *gd)
 }
 
 LilliputEngine::~LilliputEngine() {
-	DebugMan.clearAllDebugChannels();
 	delete _soundHandler;
 	delete _scriptHandler;
 	delete _rnd;

--- a/engines/lure/lure.cpp
+++ b/engines/lure/lure.cpp
@@ -93,9 +93,6 @@ Common::Error LureEngine::init() {
 }
 
 LureEngine::~LureEngine() {
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
-
 	if (_initialized) {
 		// Delete and deinitialize subsystems
 		Surface::deinitialize();

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -86,8 +86,6 @@ MacVentureEngine::MacVentureEngine(OSystem *syst, const ADGameDescription *gameD
 MacVentureEngine::~MacVentureEngine() {
 	debug("MacVenture::~MacVentureEngine()");
 
-	DebugMan.clearAllDebugChannels();
-
 	if (_rnd)
 		delete _rnd;
 

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -105,8 +105,6 @@ MohawkEngine_Myst::MohawkEngine_Myst(OSystem *syst, const MohawkGameDescription 
 }
 
 MohawkEngine_Myst::~MohawkEngine_Myst() {
-	DebugMan.clearAllDebugChannels();
-
 	delete _gfx;
 	delete _video;
 	delete _sound;

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -112,8 +112,6 @@ MohawkEngine_Riven::~MohawkEngine_Riven() {
 	delete _scriptMan;
 	delete _inventory;
 	delete _rnd;
-
-	DebugMan.clearAllDebugChannels();
 }
 
 Common::Error MohawkEngine_Riven::run() {

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -107,8 +107,6 @@ Myst3Engine::Myst3Engine(OSystem *syst, const Myst3GameDescription *version) :
 }
 
 Myst3Engine::~Myst3Engine() {
-	DebugMan.clearAllDebugChannels();
-
 	closeArchives();
 
 	delete _menu;

--- a/engines/nancy/nancy.cpp
+++ b/engines/nancy/nancy.cpp
@@ -73,7 +73,6 @@ NancyEngine::NancyEngine(OSystem *syst, const NancyGameDescription *gd) : Engine
 
 NancyEngine::~NancyEngine() {
 	clearBootChunks();
-	DebugMan.clearAllDebugChannels();
 	delete _randomSource;
 
 	delete _graphicsManager;

--- a/engines/petka/petka.cpp
+++ b/engines/petka/petka.cpp
@@ -65,7 +65,6 @@ PetkaEngine::PetkaEngine(OSystem *system, const ADGameDescription *desc)
 
 PetkaEngine::~PetkaEngine() {
 	debug("PetkaEngine::dtor");
-	DebugMan.clearAllDebugChannels();
 }
 
 Common::Error PetkaEngine::run() {

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -60,7 +60,6 @@ PinkEngine::~PinkEngine() {
 		delete _cursors[j];
 	}
 	delete _director;
-	DebugMan.clearAllDebugChannels();
 }
 
 Common::Error PinkEngine::init() {

--- a/engines/prince/prince.cpp
+++ b/engines/prince/prince.cpp
@@ -95,8 +95,6 @@ PrinceEngine::PrinceEngine(OSystem *syst, const PrinceGameDescription *gameDesc)
 }
 
 PrinceEngine::~PrinceEngine() {
-	DebugMan.clearAllDebugChannels();
-
 	delete _rnd;
 	delete _cursor1;
 	delete _cursor3;

--- a/engines/private/private.cpp
+++ b/engines/private/private.cpp
@@ -114,9 +114,6 @@ PrivateEngine::~PrivateEngine() {
 
 	delete Gen::g_vm;
 	delete Settings::g_setts;
-
-	// Remove all of our debug levels
-	DebugMan.clearAllDebugChannels();
 }
 
 void PrivateEngine::initializePath(const Common::FSNode &gamePath) {

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -200,9 +200,6 @@ SciEngine::SciEngine(OSystem *syst, const ADGameDescription *desc, SciGameId gam
 }
 
 SciEngine::~SciEngine() {
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
-
 #ifdef ENABLE_SCI32
 	delete _gfxControls32;
 	delete _gfxPaint32;

--- a/engines/scumm/debugger.cpp
+++ b/engines/scumm/debugger.cpp
@@ -507,7 +507,7 @@ bool ScummDebugger::Cmd_Object(int argc, const char **argv) {
 }
 
 bool ScummDebugger::Cmd_Debug(int argc, const char **argv) {
-	const Common::DebugManager::DebugChannelList &lvls = DebugMan.listDebugChannels();
+	const Common::DebugManager::DebugChannelList &lvls = DebugMan.getDebugChannels();
 
 	// No parameters given: Print out a list of all channels and their status
 	if (argc <= 1) {

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -617,8 +617,6 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 
 
 ScummEngine::~ScummEngine() {
-	DebugMan.clearAllDebugChannels();
-
 	delete _musicEngine;
 
 	_mixer->stopAll();

--- a/engines/sludge/sludge.cpp
+++ b/engines/sludge/sludge.cpp
@@ -94,9 +94,6 @@ SludgeEngine::~SludgeEngine() {
 	delete _rnd;
 	_rnd = nullptr;
 
-	// Remove debug levels
-	DebugMan.clearAllDebugChannels();
-
 	// Dispose pixel formats
 	delete _origFormat;
 	_origFormat = nullptr;

--- a/engines/supernova/supernova.cpp
+++ b/engines/supernova/supernova.cpp
@@ -102,8 +102,6 @@ SupernovaEngine::SupernovaEngine(OSystem *syst)
 }
 
 SupernovaEngine::~SupernovaEngine() {
-	DebugMan.clearAllDebugChannels();
-
 	delete _sleepAutoSave;
 	delete _gm;
 	delete _sound;

--- a/engines/sword25/sword25.cpp
+++ b/engines/sword25/sword25.cpp
@@ -69,7 +69,6 @@ Sword25Engine::Sword25Engine(OSystem *syst, const ADGameDescription *gameDesc):
 }
 
 Sword25Engine::~Sword25Engine() {
-	DebugMan.clearAllDebugChannels();
 }
 
 Common::Error Sword25Engine::run() {

--- a/engines/teenagent/teenagent.cpp
+++ b/engines/teenagent/teenagent.cpp
@@ -82,8 +82,6 @@ TeenAgentEngine::~TeenAgentEngine() {
 	res = 0;
 
 	CursorMan.popCursor();
-
-	DebugMan.clearAllDebugChannels();
 }
 
 bool TeenAgentEngine::trySelectedObject() {

--- a/engines/testbed/testbed.cpp
+++ b/engines/testbed/testbed.cpp
@@ -170,8 +170,6 @@ void TestbedEngine::pushTestsuites(Common::Array<Testsuite *> &testsuiteList) {
 
 TestbedEngine::~TestbedEngine() {
 	ConfParams.deleteWriteStream();
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
 
 	for (Common::Array<Testsuite *>::const_iterator i = _testsuiteList.begin(); i != _testsuiteList.end(); ++i) {
 		delete (*i);

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -1359,8 +1359,6 @@ ToonEngine::~ToonEngine() {
 	delete _gameState;
 
 	unloadToonDat();
-
-	DebugMan.clearAllDebugChannels();
 }
 
 void ToonEngine::flushPalette(bool deferFlushToNextRender) {

--- a/engines/touche/touche.cpp
+++ b/engines/touche/touche.cpp
@@ -184,8 +184,6 @@ ToucheEngine::ToucheEngine(OSystem *system, Common::Language language)
 }
 
 ToucheEngine::~ToucheEngine() {
-	DebugMan.clearAllDebugChannels();
-
 	stopMusic();
 	delete _midiPlayer;
 }

--- a/engines/tsage/tsage.cpp
+++ b/engines/tsage/tsage.cpp
@@ -58,8 +58,6 @@ Common::Error TSageEngine::init() {
 }
 
 TSageEngine::~TSageEngine() {
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
 }
 
 bool TSageEngine::hasFeature(EngineFeature f) const {

--- a/engines/wage/wage.cpp
+++ b/engines/wage/wage.cpp
@@ -93,7 +93,6 @@ WageEngine::WageEngine(OSystem *syst, const ADGameDescription *desc) : Engine(sy
 WageEngine::~WageEngine() {
 	debug("WageEngine::~WageEngine()");
 
-	DebugMan.clearAllDebugChannels();
 	delete _world;
 	delete _resManager;
 	delete _gui;

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -81,9 +81,6 @@ WintermuteEngine::~WintermuteEngine() {
 	deinit();
 	delete _game;
 	//_debugger deleted by Engine
-
-	// Remove all of our debug levels here
-	DebugMan.clearAllDebugChannels();
 }
 
 bool WintermuteEngine::hasFeature(EngineFeature f) const {

--- a/engines/zvision/zvision.cpp
+++ b/engines/zvision/zvision.cpp
@@ -128,9 +128,6 @@ ZVision::~ZVision() {
 	delete _midiManager;
 
 	getTimerManager()->removeTimerProc(&fpsTimerCallback);
-
-	// Remove all of our debug levels
-	DebugMan.clearAllDebugChannels();
 }
 
 void ZVision::registerDefaultSettings() {

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -733,7 +733,7 @@ bool Debugger::cmdDebugLevel(int argc, const char **argv) {
 }
 
 bool Debugger::cmdDebugFlagsList(int argc, const char **argv) {
-	const Common::DebugManager::DebugChannelList &debugLevels = DebugMan.listDebugChannels();
+	const Common::DebugManager::DebugChannelList &debugLevels = DebugMan.getDebugChannels();
 
 	debugPrintf("Engine debug levels:\n");
 	debugPrintf("--------------------\n");


### PR DESCRIPTION
I had trouble reading DebugManager to figure out recent regressions so I cleaned it up.

- Renamed methods and members to be consistent and clearer
- Updated doxygen comments to be in sync with method behaviors
- Global debug channels are now automatically added by DebugManager. The code was going to a lot of effort to try to achieve that but still not always succeeding. Now it's explicit and simpler. Callers don't have to always call two methods to add channels.
- Removed unnecessary calls to remove debug channels from Engine destructors. As of PR #3012, Engines are no longer responsible for adding their channels, so this code should have been removed from the destructors. It's redundant; `runGame()` already handles this.
