### PR TITLE
WINTERMUTE: Disable conflicting keymap in Alpha Polaris

### DIFF
--- a/engines/wintermute/keymapper_tables.h
+++ b/engines/wintermute/keymapper_tables.h
@@ -483,7 +483,7 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 
 		act = new Action("SCRS", _("Save screenshot"));
 		act->setKeyEvent(KeyState(KEYCODE_F5, 0, KBD_CTRL));
-		act->addDefaultInputMapping("C+F5"); // original keyboard
+		// act->addDefaultInputMapping("C+F5"); // original keyboard (disabled due to conflict with GMM)
 		gameKeyMap->addAction(act);
 
 		act = new Action("VOLMAX", _("Volume max"));


### PR DESCRIPTION
Game specific keymaps take priority over the global keymaps, which means that it wasn't possible to open the Global Main Menu with the default mappings.