### PR TITLE
DIRECTOR: Apartment/User Interface fix

### DIFF
--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -706,7 +706,7 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 		// since mactext will add some offsets itself, then we calculate it first, to make sure the result size is the same as bbox
 		// use the initialRect for the dims, (seems like initialRect is same as bbox since we once called setCast)
 		dims = getTextOnlyDimensions(_initialRect);
-		widget = new Graphics::MacText(g_director->getCurrentWindow(), bbox.left, bbox.top, dims.width(), dims.height(), g_director->_wm, _ftext, macFont, getForeColor(), getBackColor(), dims.width(), getAlignment(), 0, _borderSize, _gutterSize, _boxShadow, _textShadow);
+		widget = new Graphics::MacText(g_director->getCurrentWindow(), bbox.left, bbox.top, dims.width(), dims.height(), g_director->_wm, _ftext, macFont, getForeColor(), getBackColor(), dims.width(), getAlignment(), 0, _borderSize, _gutterSize, _boxShadow, _textShadow, Common::kMacCentralEurope);
 		((Graphics::MacText *)widget)->setSelRange(g_director->getCurrentMovie()->_selStart, g_director->getCurrentMovie()->_selEnd);
 		((Graphics::MacText *)widget)->draw();
 		((Graphics::MacText *)widget)->_focusable = _editable;
@@ -724,7 +724,7 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 	case kCastButton:
 		// note that we use _initialRect for the dimensions of the button;
 		// the values provided in the sprite bounding box are ignored
-		widget = new Graphics::MacButton(Graphics::MacButtonType(_buttonType), getAlignment(), g_director->getCurrentWindow(), bbox.left, bbox.top, _initialRect.width(), _initialRect.height(), g_director->_wm, _ftext, macFont, getForeColor(), 0xff);
+		widget = new Graphics::MacButton(Graphics::MacButtonType(_buttonType), getAlignment(), g_director->getCurrentWindow(), bbox.left, bbox.top, _initialRect.width(), _initialRect.height(), g_director->_wm, _ftext, macFont, getForeColor(), 0xff, Common::kMacCentralEurope);
 		widget->_focusable = true;
 
 		((Graphics::MacButton *)widget)->setHilite(_hilite);

--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -704,7 +704,7 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 	switch (_type) {
 	case kCastText:
 		// since mactext will add some offsets itself, then we calculate it first, to make sure the result size is the same as bbox
-		// use the initialRect for the dims, (seems like initialRect is same as bbox since we once called setCast)
+		// we are using a very special logic to solve the size for text castmembers now, please refer to sprite.cpp setCast()
 		dims = getTextOnlyDimensions(bbox);
 		widget = new Graphics::MacText(g_director->getCurrentWindow(), bbox.left, bbox.top, dims.width(), dims.height(), g_director->_wm, _ftext, macFont, getForeColor(), getBackColor(), dims.width(), getAlignment(), 0, _borderSize, _gutterSize, _boxShadow, _textShadow, Common::kMacCentralEurope);
 		((Graphics::MacText *)widget)->setSelRange(g_director->getCurrentMovie()->_selStart, g_director->getCurrentMovie()->_selEnd);

--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -728,6 +728,7 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 		widget->_focusable = true;
 
 		((Graphics::MacButton *)widget)->setHilite(_hilite);
+		((Graphics::MacButton *)widget)->setCheckBoxType(g_director->getCurrentMovie()->_checkBoxType);
 		((Graphics::MacButton *)widget)->draw();
 		break;
 

--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -725,9 +725,9 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 		// note that we use _initialRect for the dimensions of the button;
 		// the values provided in the sprite bounding box are ignored
 		widget = new Graphics::MacButton(Graphics::MacButtonType(_buttonType), getAlignment(), g_director->getCurrentWindow(), bbox.left, bbox.top, _initialRect.width(), _initialRect.height(), g_director->_wm, _ftext, macFont, getForeColor(), 0xff);
-		((Graphics::MacButton *)widget)->draw();
 		widget->_focusable = true;
 
+		((Graphics::MacButton *)widget)->setHilite(_hilite);
 		((Graphics::MacButton *)widget)->draw();
 		break;
 

--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -705,7 +705,7 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 	case kCastText:
 		// since mactext will add some offsets itself, then we calculate it first, to make sure the result size is the same as bbox
 		// use the initialRect for the dims, (seems like initialRect is same as bbox since we once called setCast)
-		dims = getTextOnlyDimensions(_initialRect);
+		dims = getTextOnlyDimensions(bbox);
 		widget = new Graphics::MacText(g_director->getCurrentWindow(), bbox.left, bbox.top, dims.width(), dims.height(), g_director->_wm, _ftext, macFont, getForeColor(), getBackColor(), dims.width(), getAlignment(), 0, _borderSize, _gutterSize, _boxShadow, _textShadow, Common::kMacCentralEurope);
 		((Graphics::MacText *)widget)->setSelRange(g_director->getCurrentMovie()->_selStart, g_director->getCurrentMovie()->_selEnd);
 		((Graphics::MacText *)widget)->draw();

--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -541,6 +541,7 @@ TextCastMember::TextCastMember(Cast *cast, uint16 castId, Common::SeekableReadSt
 	_textSlant = 0;
 	_bgpalinfo1 = _bgpalinfo2 = _bgpalinfo3 = 0;
 	_fgpalinfo1 = _fgpalinfo2 = _fgpalinfo3 = 0xff;
+	_widget = nullptr;
 
 	if (version < kFileVer400) {
 		_flags1 = flags1; // region: 0 - auto, 1 - matte, 2 - disabled
@@ -719,6 +720,8 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 			if (activeWidget == nullptr || !activeWidget->isEditable())
 				g_director->_wm->setActiveWidget(widget);
 		}
+		// just a link to the widget which we created. we may use it later
+		_widget = widget;
 		break;
 
 	case kCastButton:
@@ -758,7 +761,15 @@ void TextCastMember::setText(const char *text) {
 	_ptext = text;
 	_ftext = formatting + text;
 
-	_modified = true;
+	// if we have the link to widget, then we modify it directly.
+	// thus we can reach the immediate changing effect
+	if (_widget) {
+		((Graphics::MacText *)_widget)->setText(_ftext);
+		((Graphics::MacText *)_widget)->draw();
+		g_director->getCurrentWindow()->addDirtyRect(_widget->_dims);
+	} else {
+		_modified = true;
+	}
 }
 
 Common::String TextCastMember::getText() {

--- a/engines/director/castmember.h
+++ b/engines/director/castmember.h
@@ -250,7 +250,7 @@ public:
 	Common::String _ftext;
 	Common::String _ptext;
 	void importStxt(const Stxt *stxt);
-	void importRTE(byte* text);
+	void importRTE(byte *text);
 
 	Common::String getText();
 
@@ -259,6 +259,7 @@ private:
 
 	uint32 _bgcolor;
 	uint32 _fgcolor;
+	Graphics::MacWidget *_widget;
 };
 
 class ScriptCastMember : public CastMember {

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -30,6 +30,7 @@
 #include "director/castmember.h"
 
 #include "graphics/macgui/mactext.h"
+#include "graphics/macgui/macbutton.h"
 
 namespace Director {
 
@@ -308,6 +309,7 @@ void Channel::setClean(Sprite *nextSprite, int spriteId, bool partial) {
 	}
 
 	setEditable(_sprite->_editable);
+	updateGlobalAttr();
 
 	_dirty = false;
 }
@@ -315,8 +317,6 @@ void Channel::setClean(Sprite *nextSprite, int spriteId, bool partial) {
 void Channel::setEditable(bool editable) {
 	if (_sprite->_cast && _sprite->_cast->_type == kCastText) {
 		// if the sprite is editable, then we refresh the selEnd and setStart
-		if (editable && _widget)
-			((Graphics::MacText *)_widget)->setSelRange(g_director->getCurrentMovie()->_selStart, g_director->getCurrentMovie()->_selEnd);
 		if (_sprite->_cast->isEditable() == editable)
 			return;
 		_sprite->_cast->setEditable(editable);
@@ -335,6 +335,19 @@ void Channel::setEditable(bool editable) {
 			}
 		}
 	}
+}
+
+// we may optimize this by only update those attributes when we are changing them
+// but not to pass them to widgets everytime
+void Channel::updateGlobalAttr() {
+	if (!_sprite->_cast)
+		return;
+	// update text info, including selEnd and selStart
+	if (_sprite->_cast->_type == kCastText && _sprite->_editable && _widget)
+		((Graphics::MacText *)_widget)->setSelRange(g_director->getCurrentMovie()->_selStart, g_director->getCurrentMovie()->_selEnd);
+	// update button info, including checkBoxType
+	if (_sprite->_cast->_type == kCastButton && _widget)
+		((Graphics::MacButton *)_widget)->setCheckBoxType(g_director->getCurrentMovie()->_checkBoxType);
 }
 
 void Channel::replaceSprite(Sprite *nextSprite) {

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -379,6 +379,8 @@ void Channel::setBbox(int l, int t, int r, int b) {
 	}
 }
 
+// currently, when we are setting hilite, we delete the widget and the re-create it
+// so we may optimize this if this operation takes much time
 void Channel::replaceWidget() {
 	if (_widget) {
 		delete _widget;

--- a/engines/director/channel.h
+++ b/engines/director/channel.h
@@ -65,6 +65,8 @@ public:
 	void replaceWidget();
 	bool updateWidget();
 
+	void updateGlobalAttr();
+
 	void addDelta(Common::Point pos);
 
 public:

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -96,6 +96,8 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	_playbackPaused = false;
 	_skipFrameAdvance = false;
 	_centerStage = true;
+
+	_surface = nullptr;
 }
 
 DirectorEngine::~DirectorEngine() {
@@ -103,6 +105,7 @@ DirectorEngine::~DirectorEngine() {
 	delete _soundManager;
 	delete _lingo;
 	delete _wm;
+	delete _surface;
 
 	for (Common::HashMap<Common::String, Archive *, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo>::iterator it = _openResFiles.begin(); it != _openResFiles.end(); ++it) {
 		delete it->_value;
@@ -161,7 +164,8 @@ Common::Error DirectorEngine::run() {
 	if (!debugChannelSet(-1, kDebugDesktop))
 		_stage->disableBorder();
 
-	_wm->setScreen(1, 1);
+	_surface = new Graphics::ManagedSurface(1, 1);
+	_wm->setScreen(_surface);
 	_wm->addWindowInitialized(_stage);
 	_wm->setActiveWindow(_stage->getId());
 	setPalette(-1);

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -270,6 +270,8 @@ private:
 	Graphics::MacPatterns _director3QuickDrawPatterns;
 
 	Common::HashMap<int, PaletteV4> _loadedPalettes;
+
+	Graphics::ManagedSurface *_surface;
 };
 
 extern DirectorEngine *g_director;

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -148,7 +148,7 @@ bool Movie::processEvent(Common::Event &event) {
 			// D3 doesn't have both mouse up and down.
 			// But we still want to know if the mouse is down for press effects.
 			// Since we don't have mouse up and down before D3, then we use ActiveSprite
-			if (g_director->getVersion() < kFileVer400)
+			if (g_director->getVersion() < 400)
 				spriteId = sc->getActiveSpriteIDFromPos(pos);
 			else
 				spriteId = sc->getMouseSpriteIDFromPos(pos);

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -135,7 +135,11 @@ bool Movie::processEvent(Common::Event &event) {
 
 			// D3 doesn't have both mouse up and down.
 			// But we still want to know if the mouse is down for press effects.
-			spriteId = sc->getMouseSpriteIDFromPos(pos);
+			// Since we don't have mouse up and down before D3, then we use ActiveSprite
+			if (g_director->getVersion() < kFileVer400)
+				spriteId = sc->getActiveSpriteIDFromPos(pos);
+			else
+				spriteId = sc->getMouseSpriteIDFromPos(pos);
 			_currentClickOnSpriteId = sc->getActiveSpriteIDFromPos(pos);
 
 			if (spriteId > 0 && sc->_channels[spriteId]->_sprite->shouldHilite())
@@ -159,7 +163,10 @@ bool Movie::processEvent(Common::Event &event) {
 	case Common::EVENT_LBUTTONUP:
 		pos = _window->getMousePos();
 
-		spriteId = sc->getMouseSpriteIDFromPos(pos);
+		if (g_director->getVersion() < kFileVer400)
+			spriteId = sc->getActiveSpriteIDFromPos(pos);
+		else
+			spriteId = sc->getMouseSpriteIDFromPos(pos);
 		_currentClickOnSpriteId = sc->getActiveSpriteIDFromPos(pos);
 
 		if (spriteId > 0 && sc->_channels[spriteId]->_sprite->shouldHilite())

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1636,19 +1636,52 @@ void LB::b_showLocals(int nargs) {
 void LB::b_constrainH(int nargs) {
 	Datum num = g_lingo->pop();
 	Datum sprite = g_lingo->pop();
+	Score *score = g_director->getCurrentMovie()->getScore();
+	int res = 0;
+	if (score) {
+		Sprite *sp = score->getSpriteById(sprite.asInt());
+		if (sp) {
+			CastMember *cast = sp->_cast;
+			// use startPoint as fallback, if we don't have castmembers
+			if (cast)
+				res = CLIP<int> (num.asInt(), cast->getInitialRect().left, cast->getInitialRect().right);
+			else
+				res = CLIP<int> (num.asInt(), sp->_startPoint.x, sp->_startPoint.x + sp->_width);
+		} else {
+			warning("b_constrainH: cannot find sprite %d", sprite.asInt());
+		}
 
-	warning("STUB: b_constrainH(%d, %d)", sprite.asInt(), num.asInt());
+	} else {
+		warning("b_constrainH: no score");
+	}
 
-	g_lingo->push(Datum(0));
+	g_lingo->push(Datum(res));
 }
 
 void LB::b_constrainV(int nargs) {
 	Datum num = g_lingo->pop();
 	Datum sprite = g_lingo->pop();
 
-	warning("STUB: b_constrainV(%d, %d)", sprite.asInt(), num.asInt());
+	Score *score = g_director->getCurrentMovie()->getScore();
+	int res = 0;
+	if (score) {
+		Sprite *sp = score->getSpriteById(sprite.asInt());
+		if (sp) {
+			CastMember *cast = sp->_cast;
+			// use startPoint as fallback, if we don't have castmembers
+			if (cast)
+				res = CLIP<int> (num.asInt(), cast->getInitialRect().top, cast->getInitialRect().bottom);
+			else
+				res = CLIP<int> (num.asInt(), sp->_startPoint.y, sp->_startPoint.y + sp->_height);
+		} else {
+			warning("b_constrainV cannot find sprite %d", sprite.asInt());
+		}
 
-	g_lingo->push(Datum(0));
+	} else {
+		warning("b_constrainV: no score");
+	}
+
+	g_lingo->push(Datum(res));
 }
 
 void LB::b_copyToClipBoard(int nargs) {

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1639,18 +1639,12 @@ void LB::b_constrainH(int nargs) {
 	Score *score = g_director->getCurrentMovie()->getScore();
 	int res = 0;
 	if (score) {
-		Sprite *sp = score->getSpriteById(sprite.asInt());
-		if (sp) {
-			CastMember *cast = sp->_cast;
-			// use startPoint as fallback, if we don't have castmembers
-			if (cast)
-				res = CLIP<int> (num.asInt(), cast->getInitialRect().left, cast->getInitialRect().right);
-			else
-				res = CLIP<int> (num.asInt(), sp->_startPoint.x, sp->_startPoint.x + sp->_width);
+		Channel *ch = score->getChannelById(sprite.asInt());
+		if (ch) {
+			res = CLIP<int> (num.asInt(), ch->getBbox().left, ch->getBbox().right);
 		} else {
-			warning("b_constrainH: cannot find sprite %d", sprite.asInt());
+			warning("b_constrainH: cannot find channel %d", sprite.asInt());
 		}
-
 	} else {
 		warning("b_constrainH: no score");
 	}
@@ -1665,18 +1659,12 @@ void LB::b_constrainV(int nargs) {
 	Score *score = g_director->getCurrentMovie()->getScore();
 	int res = 0;
 	if (score) {
-		Sprite *sp = score->getSpriteById(sprite.asInt());
-		if (sp) {
-			CastMember *cast = sp->_cast;
-			// use startPoint as fallback, if we don't have castmembers
-			if (cast)
-				res = CLIP<int> (num.asInt(), cast->getInitialRect().top, cast->getInitialRect().bottom);
-			else
-				res = CLIP<int> (num.asInt(), sp->_startPoint.y, sp->_startPoint.y + sp->_height);
+		Channel *ch = score->getChannelById(sprite.asInt());
+		if (ch) {
+			res = CLIP<int> (num.asInt(), ch->getBbox().top, ch->getBbox().bottom);
 		} else {
-			warning("b_constrainV cannot find sprite %d", sprite.asInt());
+			warning("b_constrainH: cannot find channel %d", sprite.asInt());
 		}
-
 	} else {
 		warning("b_constrainV: no score");
 	}

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1526,6 +1526,14 @@ void LC::call(const Common::String &name, int nargs, bool allowRetVal) {
 		}
 	}
 
+	// use lingo-the as fallback
+	if (funcSym.type == VOIDSYM && g_lingo->_theEntities.contains(name)) {
+		Datum id;
+		Datum res = g_lingo->getTheEntity(g_lingo->_theEntities[name]->entity, id, kTheNOField);
+		g_lingo->push(res);
+		return;
+	}
+
 	call(funcSym, nargs, allowRetVal);
 }
 

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1526,8 +1526,8 @@ void LC::call(const Common::String &name, int nargs, bool allowRetVal) {
 		}
 	}
 
-	// use lingo-the as fallback
-	if (funcSym.type == VOIDSYM && g_lingo->_theEntities.contains(name)) {
+	// use lingo-the as fallback. we can only use functions as fallback, not properties
+	if (funcSym.type == VOIDSYM && g_lingo->_theEntities.contains(name) && g_lingo->_theEntities[name]->isFunction) {
 		Datum id;
 		Datum res = g_lingo->getTheEntity(g_lingo->_theEntities[name]->entity, id, kTheNOField);
 		g_lingo->push(res);

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -899,6 +899,7 @@ bool TextCastMember::setField(int field, const Datum &d) {
 		// TODO: Understand how texts can be selected programmatically as well.
 		if (_type == kCastButton) {
 			_hilite = (bool)d.asInt();
+			_modified = true;
 			return true;
 		}
 		break;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -389,7 +389,8 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		getTheEntitySTUB(kTheCheckBoxAccess);
 		break;
 	case kTheCheckBoxType:
-		getTheEntitySTUB(kTheCheckBoxType);
+		d.type = INT;
+		d.u.i = g_director->getCurrentMovie()->_checkBoxType;
 		break;
 	case kTheClickLoc:
 		d.u.farr = new DatumArray;
@@ -885,7 +886,7 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 		setTheEntitySTUB(kTheCheckBoxAccess);
 		break;
 	case kTheCheckBoxType:
-		setTheEntitySTUB(kTheCheckBoxType);
+		g_director->getCurrentMovie()->_checkBoxType = d.asInt();
 		break;
 	case kTheColorDepth:
 		_vm->_colorDepth = d.asInt();

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -43,118 +43,118 @@ namespace Director {
 class Sprite;
 
 TheEntity entities[] = {
-	{ kTheActorList,		"actorList",		false, 400 },	//			D4 property
-	{ kTheBeepOn,			"beepOn",			false, 200 },	// D2 p
-	{ kTheButtonStyle,		"buttonStyle",		false, 200 },	// D2 p
-	{ kTheCast,				"cast",				true,  200 },	// D2
-	{ kTheCastMembers,		"castmembers",		false, 300 },	//		 D3
-	{ kTheCenterStage,		"centerStage",		false, 200 },	// D2 p
-	{ kTheCheckBoxAccess,	"checkBoxAccess",	false, 200 },	// D2 p
-	{ kTheCheckBoxType,		"checkBoxType",		false, 200 },	// D2 p
-	{ kTheClickLoc,			"clickLoc",			false, 400 },	// 			D4 function
-	{ kTheClickOn,			"clickOn",			false, 200 },	// D2 f
-	{ kTheColorDepth,		"colorDepth",		false, 200 },	// D2 p
-	{ kTheColorQD,			"colorQD",			false, 200 },	// D2 f
-	{ kTheCommandDown,		"commandDown",		false, 200 },	// D2 f
-	{ kTheControlDown,		"controlDown",		false, 200 },	// D2 f
-	{ kTheDate,				"date",				false, 300 },	//		D3 f
-	{ kTheDoubleClick,		"doubleClick",		false, 200 },	// D2 f
-	{ kTheExitLock,			"exitLock",			false, 200 },	// D2 p
-	{ kTheField,			"field",			true,  300 },	//		D3
-	{ kTheFixStageSize,		"fixStageSize",		false, 200 },	// D2 p
-	{ kTheFloatPrecision,	"floatPrecision",	false, 300 },	//		D3 p
-	{ kTheFrame,			"frame",			false, 200 },	// D2 f
-	{ kTheFrameLabel,		"frameLabel",		false, 400 },	//			D4 p
-	{ kTheFrameScript,		"frameScript",		false, 400 },	//			D4 p
-	{ kTheFramePalette,		"framePalette",		false, 400 },	//			D4 p
-	{ kTheFrameTempo,		"frameTempo",		false, 400 },	//			D4 f
-	{ kTheFreeBlock,		"freeBlock",		false, 200 },	// D2 f
-	{ kTheFreeBytes,		"freeBytes",		false, 200 },	// D2 f
-	{ kTheFullColorPermit,	"fullColorPermit",	false, 200 },	// D2 p
-	{ kTheImageDirect,		"imageDirect",		false, 200 },	// D2 p
-	{ kTheItemDelimiter,	"itemDelimiter",	false, 400 },	//			D4 p
-	{ kTheKey,				"key",				false, 200 },	// D2 f
-	{ kTheKeyCode,			"keyCode",			false, 200 },	// D2 f
-	{ kTheKeyDownScript,	"keyDownScript",	false, 200 },	// D2 p
-	{ kTheKeyUpScript,		"keyUpScript",		false, 400 },	//			D4 p
-	{ kTheLabelList,		"labelList",		false, 300 },	//		D3 f
-	{ kTheLastClick,		"lastClick",		false, 200 },	// D2 f
-	{ kTheLastEvent,		"lastEvent",		false, 200 },	// D2 f
-	{ kTheLastFrame,		"lastFrame",		false, 400 },	//			D4 p
-	{ kTheLastKey,			"lastKey",			false, 200 },	// D2 f
-	{ kTheLastRoll,			"lastRoll",			false, 200 },	// D2 f
-	{ kTheMachineType,		"machineType",		false, 200 },	// D2 f
-	{ kTheMaxInteger,		"maxInteger",		false, 300 },	//		D3.1 f
-	{ kTheMemorySize,		"memorySize",		false, 200 },	// D2 f
-	{ kTheMenu,				"menu",				true,  300 },	//		D3 p
-	{ kTheMenuItem,			"menuitem",			true,  300 },	//		D3 p
-	{ kTheMenuItems,		"menuitems",		false, 300 },	//		D3 f
-	{ kTheMouseCast,		"mouseCast",		false, 300 },	//		D3 f
-	{ kTheMouseChar,		"mouseChar",		false, 300 },	//		D3 f
-	{ kTheMouseDown,		"mouseDown",		false, 200 },	// D2 f
-	{ kTheMouseDownScript,  "mouseDownScript",	false, 200 },	// D2 p
-	{ kTheMouseH,			"mouseH",			false, 200 },	// D2 f
-	{ kTheMouseItem,		"mouseItem",		false, 300 },	//		D3 f
-	{ kTheMouseLine,		"mouseLine",		false, 300 },	//		D3 f
-	{ kTheMouseUp,			"mouseUp",			false, 200 },	// D2 f
-	{ kTheMouseUpScript,  	"mouseUpScript",	false, 200 },	// D2 p
-	{ kTheMouseV,			"mouseV",			false, 200 },	// D2 f
-	{ kTheMouseWord,		"mouseWord",		false, 300 },	//		D3 f
-	{ kTheMovie,			"movie",			false, 200 },	// D2 f
-	{ kTheMovieFileFreeSize,"movieFileFreeSize",false, 400 },	//			D4 f
-	{ kTheMovieFileSize,	"movieFileSize",	false, 400 },	//			D4 f
-	{ kTheMovieName,		"movieName",		false, 400 },	//			D4 f
-	{ kTheMoviePath,		"moviePath",		false, 400 },	//			D4 f
-	{ kTheMultiSound,		"multiSound",		false, 300 },	//		D3.1 f
-	{ kTheOptionDown,		"optionDown",		false, 200 },	// D2 f
-	{ kTheParamCount,		"paramCount",		false, 400 },	//			D4 f
-	{ kThePathName,			"pathName",			false, 200 },	// D2 f
-	{ kThePauseState,		"pauseState",		false, 200 },	// D2 f
-	{ kThePerFrameHook,		"perFrameHook",		false, 200 },	// D2 p
-	{ kThePreloadEventAbort,"preloadEventAbort",false, 400 },	//			D4 p
-	{ kThePreLoadRAM,		"preLoadRAM",		false, 400 },	//			D4 p
-	{ kThePi,				"pi",				false, 400 },	//			D4 f
-	{ kTheQuickTimePresent,	"quickTimePresent",	false, 300 },	//		D3.1 f
-	{ kTheRandomSeed,		"randomSeed",		false, 400 },	//			D4 p
-	{ kTheResult,			"result",			false, 200 },	// D2 f
-	{ kTheRightMouseDown,	"rightMouseDown",	false, 500 },	//					D5 f
-	{ kTheRightMouseUp,		"rightMouseUp",		false, 500 },	//					D5 f
-	{ kTheRomanLingo,		"romanLingo",		false, 300 },	//		D3.1 p
-	{ kTheScummvmVersion,	"scummvmVersion",	false, 200 }, // 					ScummVM only
-	{ kTheSearchCurrentFolder,"searchCurrentFolder",false,400 },//			D4 f
-	{ kTheSearchPath,		"searchPath",		false, 400 },	//			D4 f
-	{ kTheSelection,		"selection",		false, 200 },	// D2 f
-	{ kTheSelEnd,			"selEnd",			false, 200 },	// D2 p
-	{ kTheSelStart,			"selStart",			false, 200 },	// D2 p
-	{ kTheShiftDown,		"shiftDown",		false, 200 },	// D2 f
-	{ kTheSoundEnabled,		"soundEnabled",		false, 200 },	// D2 p
-	{ kTheSoundEntity,		"sound",			true,  300 },	// 		D3 p
-	{ kTheSoundLevel,		"soundLevel",		false, 200 },	// D2 p
-	{ kTheSprite,			"sprite",			true,  200 },	// 			D4 p
-	{ kTheStage,			"stage",			false, 400 },	//			D4 p
-	{ kTheStageBottom,		"stageBottom",		false, 200 },	// D2 f
-	{ kTheStageColor,		"stageColor",		false, 300 },	//		D3 p
-	{ kTheStageLeft,		"stageLeft",		false, 200 },	// D2 f
-	{ kTheStageRight,		"stageRight",		false, 200 },	// D2 f
-	{ kTheStageTop,			"stageTop",			false, 200 },	// D2 f
-	{ kTheStillDown,		"stillDown",		false, 200 },	// D2 f
-	{ kTheSwitchColorDepth,	"switchColorDepth",	false, 200 },	// D2 p
-	{ kTheTicks,			"ticks",			false, 200 },	// D2 f
-	{ kTheTime,				"time",				false, 300 },	// 		D3 f
-	{ kTheTimeoutKeyDown,	"timeoutKeyDown",	false, 200 },	// D2 p
-	{ kTheTimeoutLapsed,	"timeoutLapsed",	false, 200 },	// D2 p
-	{ kTheTimeoutLength,	"timeoutLength",	false, 200 },	// D2 p
-	{ kTheTimeoutMouse,		"timeoutMouse",		false, 200 },	// D2 p
-	{ kTheTimeoutPlay,		"timeoutPlay",		false, 200 },	// D2 p
-	{ kTheTimeoutScript,	"timeoutScript",	false, 200 },	// D2 p
-	{ kTheTimer,			"timer",			false, 200 },	// D2 p
-	{ kTheTrace,			"trace",			false, 400 },	//			D4 p
-	{ kTheTraceLoad,		"traceLoad",		false, 400 },	//			D4 p
-	{ kTheTraceLogFile,		"traceLogFile",		false, 400 },	//			D4 p
-	{ kTheUpdateMovieEnabled,"updateMovieEnabled",false,400 },//			D4 p
-	{ kTheWindow,			"window",			true,  400 },	//			D4
-	{ kTheWindowList,		"windowList",		false, 400 },	//			D4 p
-	{ kTheNOEntity, NULL, false, 0 }
+	{ kTheActorList,		"actorList",		false, 400, false },	//			D4 property
+	{ kTheBeepOn,			"beepOn",			false, 200, false },	// D2 p
+	{ kTheButtonStyle,		"buttonStyle",		false, 200, false },	// D2 p
+	{ kTheCast,				"cast",				true,  200, false },	// D2
+	{ kTheCastMembers,		"castmembers",		false, 300, false },	//		 D3
+	{ kTheCenterStage,		"centerStage",		false, 200, false },	// D2 p
+	{ kTheCheckBoxAccess,	"checkBoxAccess",	false, 200, false },	// D2 p
+	{ kTheCheckBoxType,		"checkBoxType",		false, 200, false },	// D2 p
+	{ kTheClickLoc,			"clickLoc",			false, 400, true },	// 			D4 function
+	{ kTheClickOn,			"clickOn",			false, 200, true },	// D2 f
+	{ kTheColorDepth,		"colorDepth",		false, 200, false },	// D2 p
+	{ kTheColorQD,			"colorQD",			false, 200, true },	// D2 f
+	{ kTheCommandDown,		"commandDown",		false, 200, true },	// D2 f
+	{ kTheControlDown,		"controlDown",		false, 200, true },	// D2 f
+	{ kTheDate,				"date",				false, 300, true },	//		D3 f
+	{ kTheDoubleClick,		"doubleClick",		false, 200, true },	// D2 f
+	{ kTheExitLock,			"exitLock",			false, 200, false },	// D2 p
+	{ kTheField,			"field",			true,  300, false },	//		D3
+	{ kTheFixStageSize,		"fixStageSize",		false, 200, false },	// D2 p
+	{ kTheFloatPrecision,	"floatPrecision",	false, 300, false },	//		D3 p
+	{ kTheFrame,			"frame",			false, 200, true },	// D2 f
+	{ kTheFrameLabel,		"frameLabel",		false, 400, false },	//			D4 p
+	{ kTheFrameScript,		"frameScript",		false, 400, false },	//			D4 p
+	{ kTheFramePalette,		"framePalette",		false, 400, false },	//			D4 p
+	{ kTheFrameTempo,		"frameTempo",		false, 400, true },	//			D4 f
+	{ kTheFreeBlock,		"freeBlock",		false, 200, true },	// D2 f
+	{ kTheFreeBytes,		"freeBytes",		false, 200, true },	// D2 f
+	{ kTheFullColorPermit,	"fullColorPermit",	false, 200, false },	// D2 p
+	{ kTheImageDirect,		"imageDirect",		false, 200, false },	// D2 p
+	{ kTheItemDelimiter,	"itemDelimiter",	false, 400, false },	//			D4 p
+	{ kTheKey,				"key",				false, 200, true },	// D2 f
+	{ kTheKeyCode,			"keyCode",			false, 200, true },	// D2 f
+	{ kTheKeyDownScript,	"keyDownScript",	false, 200, false },	// D2 p
+	{ kTheKeyUpScript,		"keyUpScript",		false, 400, false },	//			D4 p
+	{ kTheLabelList,		"labelList",		false, 300, true },	//		D3 f
+	{ kTheLastClick,		"lastClick",		false, 200, true },	// D2 f
+	{ kTheLastEvent,		"lastEvent",		false, 200, true },	// D2 f
+	{ kTheLastFrame,		"lastFrame",		false, 400, false },	//			D4 p
+	{ kTheLastKey,			"lastKey",			false, 200, true },	// D2 f
+	{ kTheLastRoll,			"lastRoll",			false, 200, true },	// D2 f
+	{ kTheMachineType,		"machineType",		false, 200, true },	// D2 f
+	{ kTheMaxInteger,		"maxInteger",		false, 300, true },	//		D3.1 f
+	{ kTheMemorySize,		"memorySize",		false, 200, true },	// D2 f
+	{ kTheMenu,				"menu",				true,  300, false },	//		D3 p
+	{ kTheMenuItem,			"menuitem",			true,  300, false },	//		D3 p
+	{ kTheMenuItems,		"menuitems",		false, 300, true },	//		D3 f
+	{ kTheMouseCast,		"mouseCast",		false, 300, true },	//		D3 f
+	{ kTheMouseChar,		"mouseChar",		false, 300, true },	//		D3 f
+	{ kTheMouseDown,		"mouseDown",		false, 200, true },	// D2 f
+	{ kTheMouseDownScript,  "mouseDownScript",	false, 200, false },	// D2 p
+	{ kTheMouseH,			"mouseH",			false, 200, true },	// D2 f
+	{ kTheMouseItem,		"mouseItem",		false, 300, true },	//		D3 f
+	{ kTheMouseLine,		"mouseLine",		false, 300, true },	//		D3 f
+	{ kTheMouseUp,			"mouseUp",			false, 200, true },	// D2 f
+	{ kTheMouseUpScript,  	"mouseUpScript",	false, 200, false },	// D2 p
+	{ kTheMouseV,			"mouseV",			false, 200, true },	// D2 f
+	{ kTheMouseWord,		"mouseWord",		false, 300, true },	//		D3 f
+	{ kTheMovie,			"movie",			false, 200, true },	// D2 f
+	{ kTheMovieFileFreeSize,"movieFileFreeSize",false, 400, true },	//			D4 f
+	{ kTheMovieFileSize,	"movieFileSize",	false, 400, true },	//			D4 f
+	{ kTheMovieName,		"movieName",		false, 400, true },	//			D4 f
+	{ kTheMoviePath,		"moviePath",		false, 400, true },	//			D4 f
+	{ kTheMultiSound,		"multiSound",		false, 300, true },	//		D3.1 f
+	{ kTheOptionDown,		"optionDown",		false, 200, true },	// D2 f
+	{ kTheParamCount,		"paramCount",		false, 400, true },	//			D4 f
+	{ kThePathName,			"pathName",			false, 200, true },	// D2 f
+	{ kThePauseState,		"pauseState",		false, 200, true },	// D2 f
+	{ kThePerFrameHook,		"perFrameHook",		false, 200, false },	// D2 p
+	{ kThePreloadEventAbort,"preloadEventAbort",false, 400, false },	//			D4 p
+	{ kThePreLoadRAM,		"preLoadRAM",		false, 400, false },	//			D4 p
+	{ kThePi,				"pi",				false, 400, true },	//			D4 f
+	{ kTheQuickTimePresent,	"quickTimePresent",	false, 300, true },	//		D3.1 f
+	{ kTheRandomSeed,		"randomSeed",		false, 400, false },	//			D4 p
+	{ kTheResult,			"result",			false, 200, true },	// D2 f
+	{ kTheRightMouseDown,	"rightMouseDown",	false, 500, true },	//					D5 f
+	{ kTheRightMouseUp,		"rightMouseUp",		false, 500, true },	//					D5 f
+	{ kTheRomanLingo,		"romanLingo",		false, 300, false },	//		D3.1 p
+	{ kTheScummvmVersion,	"scummvmVersion",	false, 200, true }, // 					ScummVM only
+	{ kTheSearchCurrentFolder,"searchCurrentFolder",false,400, true },//			D4 f
+	{ kTheSearchPath,		"searchPath",		false, 400, true },	//			D4 f
+	{ kTheSelection,		"selection",		false, 200, true },	// D2 f
+	{ kTheSelEnd,			"selEnd",			false, 200, false },	// D2 p
+	{ kTheSelStart,			"selStart",			false, 200, false },	// D2 p
+	{ kTheShiftDown,		"shiftDown",		false, 200, true },	// D2 f
+	{ kTheSoundEnabled,		"soundEnabled",		false, 200, false },	// D2 p
+	{ kTheSoundEntity,		"sound",			true,  300, false },	// 		D3 p
+	{ kTheSoundLevel,		"soundLevel",		false, 200, false },	// D2 p
+	{ kTheSprite,			"sprite",			true,  200, false },	// 			D4 p
+	{ kTheStage,			"stage",			false, 400, false },	//			D4 p
+	{ kTheStageBottom,		"stageBottom",		false, 200, true },	// D2 f
+	{ kTheStageColor,		"stageColor",		false, 300, false },	//		D3 p
+	{ kTheStageLeft,		"stageLeft",		false, 200, true },	// D2 f
+	{ kTheStageRight,		"stageRight",		false, 200, true },	// D2 f
+	{ kTheStageTop,			"stageTop",			false, 200, true },	// D2 f
+	{ kTheStillDown,		"stillDown",		false, 200, true },	// D2 f
+	{ kTheSwitchColorDepth,	"switchColorDepth",	false, 200, false },	// D2 p
+	{ kTheTicks,			"ticks",			false, 200, true },	// D2 f
+	{ kTheTime,				"time",				false, 300, true },	// 		D3 f
+	{ kTheTimeoutKeyDown,	"timeoutKeyDown",	false, 200, false },	// D2 p
+	{ kTheTimeoutLapsed,	"timeoutLapsed",	false, 200, false },	// D2 p
+	{ kTheTimeoutLength,	"timeoutLength",	false, 200, false },	// D2 p
+	{ kTheTimeoutMouse,		"timeoutMouse",		false, 200, false },	// D2 p
+	{ kTheTimeoutPlay,		"timeoutPlay",		false, 200, false },	// D2 p
+	{ kTheTimeoutScript,	"timeoutScript",	false, 200, false },	// D2 p
+	{ kTheTimer,			"timer",			false, 200, false },	// D2 p
+	{ kTheTrace,			"trace",			false, 400, false },	//			D4 p
+	{ kTheTraceLoad,		"traceLoad",		false, 400, false },	//			D4 p
+	{ kTheTraceLogFile,		"traceLogFile",		false, 400, false },	//			D4 p
+	{ kTheUpdateMovieEnabled,"updateMovieEnabled",false,400, false },//			D4 p
+	{ kTheWindow,			"window",			true,  400, false },	//			D4
+	{ kTheWindowList,		"windowList",		false, 400, false },	//			D4 p
+	{ kTheNOEntity, NULL, false, 0, false }
 };
 
 TheEntityField fields[] = {

--- a/engines/director/lingo/lingo-the.h
+++ b/engines/director/lingo/lingo-the.h
@@ -238,6 +238,7 @@ struct TheEntity {
 	const char *name;
 	bool hasId;
 	int version;
+	bool isFunction;
 };
 
 struct TheEntityField {

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -62,6 +62,8 @@ Movie::Movie(Window *window) {
 	_keyFlags = 0;
 
 	_currentDraggedChannel = nullptr;
+	_currentHiliteChannelId = 0;
+	_currentHandlingChannelId = 0;
 
 	_allowOutdatedLingo = false;
 

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -139,7 +139,7 @@ bool Movie::loadArchive() {
 		uint16 windowWidth = debugChannelSet(-1, kDebugDesktop) ? 1024 : _movieRect.width();
 		uint16 windowHeight = debugChannelSet(-1, kDebugDesktop) ? 768 : _movieRect.height();
 		if (_vm->_wm->_screenDims.width() != windowWidth || _vm->_wm->_screenDims.height() != windowHeight) {
-			_vm->_wm->_screenDims = Common::Rect(windowWidth, windowHeight);
+			_vm->_wm->resizeScreen(windowWidth, windowHeight);
 			recenter = true;
 
 			initGraphics(windowWidth, windowHeight, &_vm->_pixelformat);

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -73,6 +73,8 @@ Movie::Movie(Window *window) {
 
 	_selEnd = -1;
 	_selStart = -1;
+
+	_checkBoxType = 0;
 }
 
 Movie::~Movie() {

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -172,6 +172,8 @@ public:
 	int _selStart;
 	int _selEnd;
 
+	int _checkBoxType;
+
 private:
 	Window *_window;
 	DirectorEngine *_vm;

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -189,6 +189,8 @@ private:
 	Common::String _script;
 	Common::String _directory;
 
+	uint16 _currentHiliteChannelId;
+	uint16 _currentHandlingChannelId;
 	Channel *_currentDraggedChannel;
 	Common::Point _draggingSpritePos;
 };

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -529,9 +529,11 @@ void Score::renderCursor(Common::Point pos) {
 	if (_channels.empty())
 		return;
 
-	for (int i = _channels.size() - 1; i >=0; i--)
-		if (_channels[i]->isMouseIn(pos) && !_channels[i]->_cursor.isEmpty())
+	for (int i = _channels.size() - 1; i >= 0; i--)
+		if (_channels[i]->isMouseIn(pos) && !_channels[i]->_cursor.isEmpty()) {
 			spriteId = i;
+			break;
+		}
 
 	if (_channels[spriteId]->_cursor.isEmpty()) {
 		if (_currentCursor) {

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -129,6 +129,9 @@ bool Sprite::shouldHilite() {
 		return true;
 
 	if (_cast) {
+		// we have our own check for button, thus we don't need it here
+		if (_cast->_type == kCastButton)
+			return false;
 		CastMemberInfo *castInfo = _cast->getInfo();
 		if (castInfo)
 			return castInfo->autoHilite;

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -135,6 +135,9 @@ bool Sprite::shouldHilite() {
 		CastMemberInfo *castInfo = _cast->getInfo();
 		if (castInfo)
 			return castInfo->autoHilite;
+		else if (_cast->_type == kCastBitmap && _ink == kInkTypeMatte)
+			return true;
+		// fallback check for the irregular button in apartment
 	}
 
 	return false;

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -125,7 +125,7 @@ bool Sprite::shouldHilite() {
 	if (_moveable)
 		return false;
 
-	if (g_director->getVersion() < 400 && _ink == kInkTypeMatte)
+	if (_ink == kInkTypeMatte)
 		return true;
 
 	if (_cast) {
@@ -135,9 +135,6 @@ bool Sprite::shouldHilite() {
 		CastMemberInfo *castInfo = _cast->getInfo();
 		if (castInfo)
 			return castInfo->autoHilite;
-		else if (_cast->_type == kCastBitmap && _ink == kInkTypeMatte)
-			return true;
-		// fallback check for the irregular button in apartment
 	}
 
 	return false;

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -200,8 +200,19 @@ void Sprite::setCast(uint16 castId) {
 		// them properly.
 		if (_cast->_type != kCastShape) {
 			Common::Rect dims = _cast->getInitialRect();
-			_width = dims.width();
-			_height = dims.height();
+			//for the text cast members, we use the max number of size of the first sprite we saw and the initialRect, and we reset that cast too
+			// quite strange logic, but it's useful for now, but still we need to figure out the correct solution
+			if (_cast->_type == kCastButton || _cast->_type == kCastText) {
+				if (_cast->_boundingRect.isEmpty()) {
+					_cast->_boundingRect = Common::Rect(MAX<int>(_width, dims.width()), MAX<int>(_height, dims.height()));
+					_cast->_initialRect = _cast->_boundingRect;
+				}
+				_width = _cast->_initialRect.width();
+				_height = _cast->_initialRect.height();
+			} else {
+				_width = dims.width();
+				_height = dims.height();
+			}
 		}
 	} else {
 		warning("Sprite::setCast(): CastMember id %d(%s) has null member", castId, numToCastNum(castId));

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -125,7 +125,7 @@ bool Sprite::shouldHilite() {
 	if (_moveable)
 		return false;
 
-	if (_ink == kInkTypeMatte)
+	if (g_director->getVersion() < 400 && _ink == kInkTypeMatte)
 		return true;
 
 	if (_cast) {
@@ -204,6 +204,7 @@ void Sprite::setCast(uint16 castId) {
 			// quite strange logic, but it's useful for now, but still we need to figure out the correct solution
 			if (_cast->_type == kCastButton || _cast->_type == kCastText) {
 				if (_cast->_boundingRect.isEmpty()) {
+					warning("Sprite::setCast(): trying to modify initialRect of cast with the first sprite size");
 					_cast->_boundingRect = Common::Rect(MAX<int>(_width, dims.width()), MAX<int>(_height, dims.height()));
 					_cast->_initialRect = _cast->_boundingRect;
 				}

--- a/engines/director/window.cpp
+++ b/engines/director/window.cpp
@@ -256,7 +256,7 @@ void Window::inkBlitSurface(DirectorPlotData *pd, Common::Rect &srcRect, const G
 			const byte *msk = mask ? (const byte *)mask->getBasePtr(pd->srcPoint.x, pd->srcPoint.y) : nullptr;
 
 			for (int j = 0; j < pd->destRect.width(); j++, pd->srcPoint.x++) {
-				if (!mask || (msk && (pd->ink == kInkTypeMask ? *msk++ : !(*msk++)))) {
+				if (!mask || (msk && !(*msk++))) {
 					(g_director->getInkDrawPixel())(pd->destRect.left + j, pd->destRect.top + i,
 											preprocessColor(pd, *((byte *)pd->srf->getBasePtr(pd->srcPoint.x, pd->srcPoint.y))), pd);
 				}
@@ -266,7 +266,7 @@ void Window::inkBlitSurface(DirectorPlotData *pd, Common::Rect &srcRect, const G
 			const uint32 *msk = mask ? (const uint32 *)mask->getBasePtr(pd->srcPoint.x, pd->srcPoint.y) : nullptr;
 
 			for (int j = 0; j < pd->destRect.width(); j++, pd->srcPoint.x++) {
-				if (!mask || (msk && (pd->ink == kInkTypeMask ? *msk++ : !(*msk++)))) {
+				if (!mask || (msk && !(*msk++))) {
 					(g_director->getInkDrawPixel())(pd->destRect.left + j, pd->destRect.top + i,
 											preprocessColor(pd, *((int *)pd->srf->getBasePtr(pd->srcPoint.x, pd->srcPoint.y))), pd);
 				}
@@ -294,7 +294,7 @@ void Window::inkBlitStretchSurface(DirectorPlotData *pd, Common::Rect &srcRect, 
 			const byte *msk = mask ? (const byte *)mask->getBasePtr(pd->srcPoint.x, pd->srcPoint.y) : nullptr;
 
 			for (int xCtr = 0, scaleXCtr = 0; xCtr < pd->destRect.width(); xCtr++, scaleXCtr += scaleX, pd->srcPoint.x++) {
-				if (!mask || (msk && (pd->ink == kInkTypeMask ? *msk++ : !(*msk++)))) {
+				if (!mask || !(*msk++)) {
 				(g_director->getInkDrawPixel())(pd->destRect.left + xCtr, pd->destRect.top + i,
 										preprocessColor(pd, *((byte *)pd->srf->getBasePtr(scaleXCtr / SCALE_THRESHOLD, scaleYCtr / SCALE_THRESHOLD))), pd);
 				}
@@ -304,7 +304,7 @@ void Window::inkBlitStretchSurface(DirectorPlotData *pd, Common::Rect &srcRect, 
 			const uint32 *msk = mask ? (const uint32 *)mask->getBasePtr(pd->srcPoint.x, pd->srcPoint.y) : nullptr;
 
 			for (int xCtr = 0, scaleXCtr = 0; xCtr < pd->destRect.width(); xCtr++, scaleXCtr += scaleX, pd->srcPoint.x++) {
-				if (!mask || (msk && (pd->ink == kInkTypeMask ? *msk++ : !(*msk++)))) {
+				if (!mask || !(*msk++)) {
 				(g_director->getInkDrawPixel())(pd->destRect.left + xCtr, pd->destRect.top + i,
 										preprocessColor(pd, *((int *)pd->srf->getBasePtr(scaleXCtr / SCALE_THRESHOLD, scaleYCtr / SCALE_THRESHOLD))), pd);
 				}
@@ -320,7 +320,7 @@ int Window::preprocessColor(DirectorPlotData *p, uint32 src) {
 	if (p->sprite == kTextSprite) {
 		switch(p->ink) {
 		case kInkTypeMask:
-			src = (src == p->backColor ? 0xff : p->foreColor);
+			src = (src == p->backColor ? p->foreColor : 0xff);
 			break;
 		case kInkTypeReverse:
 			src = (src == p->foreColor ? 0 : p->colorWhite);

--- a/graphics/macgui/macbutton.cpp
+++ b/graphics/macgui/macbutton.cpp
@@ -39,6 +39,7 @@ MacButton::MacButton(MacButtonType buttonType, TextAlign textAlignment, MacWidge
 	_buttonType = buttonType;
 	_invertOuter = false;
 	_invertInner = false;
+	_checkBoxType = 0;
 
 	switch (buttonType) {
 	case kCheckBox:
@@ -91,14 +92,34 @@ void MacButton::invertOuter() {
 	}
 }
 
+void MacButton::setCheckBoxType(int type) {
+	if (_checkBoxType == type)
+		return;
+	_checkBoxType = type;
+	_contentIsDirty = true;
+}
+
 void MacButton::invertInner() {
 	Common::Rect r(_dims.width() - 1, _dims.height() - 1);
+	Common::Rect c;
 
 	switch (_buttonType) {
 	case kCheckBox:
-		Graphics::drawLine(r.left + 1, r.top + 3, r.left + 9, r.top + 11, 0, _wm->getDrawPixel(), &_pd);
-		Graphics::drawLine(r.left + 1, r.top + 11, r.left + 9, r.top + 3, 0, _wm->getDrawPixel(), &_pd);
-		(_wm->getDrawInvertPixel())(5, 7, 0, &_pd);
+		switch(_checkBoxType) {
+		case kNormal:
+			Graphics::drawLine(r.left + 1, r.top + 3, r.left + 9, r.top + 11, 0, _wm->getDrawPixel(), &_pd);
+			Graphics::drawLine(r.left + 1, r.top + 11, r.left + 9, r.top + 3, 0, _wm->getDrawPixel(), &_pd);
+			(_wm->getDrawInvertPixel())(5, 7, 0, &_pd);
+			break;
+		case kInsetBlack:
+			c = Common::Rect(r.left + 2, r.top + 4, r.left + 2 + 6, r.top + 4 + 6);
+			Graphics::drawFilledRect(c, 0, _wm->getDrawPixel(), &_pd);
+			break;
+		case kFilledBlack:
+			c = Common::Rect(r.left + 1, r.top + 3, r.left + 1 + 8, r.top + 3 + 8);
+			Graphics::drawFilledRect(c, 0, _wm->getDrawPixel(), &_pd);
+			break;
+		}
 		break;
 	case kRound:
 		break;

--- a/graphics/macgui/macbutton.cpp
+++ b/graphics/macgui/macbutton.cpp
@@ -62,6 +62,35 @@ MacButton::MacButton(MacButtonType buttonType, TextAlign textAlignment, MacWidge
 	_composeSurface->clear(_bgcolor);
 }
 
+MacButton::MacButton(MacButtonType buttonType, TextAlign textAlignment, MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *macFont, int fgcolor, int bgcolor, Common::CodePage encodeType) :
+	MacText(parent, x, y, w, h, wm, s, macFont, fgcolor, bgcolor, w, textAlignment, 0, 0, 0, 0, 0, encodeType), _pd(Graphics::MacPlotData(_composeSurface, nullptr, &_wm->getPatterns(), 1, 0, 0, 1, 0, true)) {
+
+	_buttonType = buttonType;
+	_invertOuter = false;
+	_invertInner = false;
+	_checkBoxType = 0;
+
+	switch (buttonType) {
+	case kCheckBox:
+		_alignOffset.x += 16;
+		_dims.right += 16;
+		break;
+	case kRound:
+		_alignOffset.x += 2;
+		_alignOffset.y += 2;
+		_dims.right += 2;
+		_dims.bottom += 4;
+		break;
+	case kRadio:
+		_alignOffset.x += 16;
+		_dims.right += 16;
+		break;
+	}
+
+	_composeSurface->create(_dims.width(), _dims.height(), _wm->_pixelformat);
+	_composeSurface->clear(_bgcolor);
+}
+
 void MacButton::setActive(bool active) {
 	if (active == _active)
 		return;

--- a/graphics/macgui/macbutton.cpp
+++ b/graphics/macgui/macbutton.cpp
@@ -107,6 +107,13 @@ void MacButton::invertInner() {
 	}
 }
 
+void MacButton::setHilite(bool hilite) {
+	if (hilite == _invertInner)
+		return;
+	_invertInner = hilite;
+	_contentIsDirty = true;
+}
+
 bool MacButton::draw(bool forceRedraw) {
 	if (!_contentIsDirty && !forceRedraw)
 		return false;

--- a/graphics/macgui/macbutton.cpp
+++ b/graphics/macgui/macbutton.cpp
@@ -130,23 +130,23 @@ void MacButton::setCheckBoxType(int type) {
 
 void MacButton::invertInner() {
 	Common::Rect r(_dims.width() - 1, _dims.height() - 1);
-	Common::Rect c;
+	Common::Rect checkbox;
 
 	switch (_buttonType) {
 	case kCheckBox:
-		switch(_checkBoxType) {
-		case kNormal:
+		switch (_checkBoxType) {
+		case kCBNormal:
 			Graphics::drawLine(r.left + 1, r.top + 3, r.left + 9, r.top + 11, 0, _wm->getDrawPixel(), &_pd);
 			Graphics::drawLine(r.left + 1, r.top + 11, r.left + 9, r.top + 3, 0, _wm->getDrawPixel(), &_pd);
 			(_wm->getDrawInvertPixel())(5, 7, 0, &_pd);
 			break;
-		case kInsetBlack:
-			c = Common::Rect(r.left + 2, r.top + 4, r.left + 2 + 6, r.top + 4 + 6);
-			Graphics::drawFilledRect(c, 0, _wm->getDrawPixel(), &_pd);
+		case kCBInsetBlack:
+			checkbox = Common::Rect(r.left + 2, r.top + 4, r.left + 2 + 6, r.top + 4 + 6);
+			Graphics::drawFilledRect(checkbox, 0, _wm->getDrawPixel(), &_pd);
 			break;
-		case kFilledBlack:
-			c = Common::Rect(r.left + 1, r.top + 3, r.left + 1 + 8, r.top + 3 + 8);
-			Graphics::drawFilledRect(c, 0, _wm->getDrawPixel(), &_pd);
+		case kCBFilledBlack:
+			checkbox = Common::Rect(r.left + 1, r.top + 3, r.left + 1 + 8, r.top + 3 + 8);
+			Graphics::drawFilledRect(checkbox, 0, _wm->getDrawPixel(), &_pd);
 			break;
 		}
 		break;

--- a/graphics/macgui/macbutton.cpp
+++ b/graphics/macgui/macbutton.cpp
@@ -37,7 +37,6 @@ MacButton::MacButton(MacButtonType buttonType, TextAlign textAlignment, MacWidge
 	MacText(parent, x, y, w, h, wm, s, macFont, fgcolor, bgcolor, w, textAlignment), _pd(Graphics::MacPlotData(_composeSurface, nullptr, &_wm->getPatterns(), 1, 0, 0, 1, 0, true)) {
 
 	_buttonType = buttonType;
-	_invertOuter = false;
 	_invertInner = false;
 	_checkBoxType = 0;
 
@@ -66,7 +65,6 @@ MacButton::MacButton(MacButtonType buttonType, TextAlign textAlignment, MacWidge
 	MacText(parent, x, y, w, h, wm, s, macFont, fgcolor, bgcolor, w, textAlignment, 0, 0, 0, 0, 0, encodeType), _pd(Graphics::MacPlotData(_composeSurface, nullptr, &_wm->getPatterns(), 1, 0, 0, 1, 0, true)) {
 
 	_buttonType = buttonType;
-	_invertOuter = false;
 	_invertInner = false;
 	_checkBoxType = 0;
 
@@ -96,10 +94,8 @@ void MacButton::setActive(bool active) {
 		return;
 
 	MacWidget::setActive(active);
-	if (_composeSurface) {
-		_invertOuter = !_invertOuter;
+	if (_composeSurface)
 		_contentIsDirty = true;
-	}
 }
 
 // whether to use getDrawPixel or getDrawInvertPixel to draw invert pixel, maybe depends on the pattle we are using
@@ -188,7 +184,7 @@ bool MacButton::draw(bool forceRedraw) {
 		break;
 	}
 
-	if (_invertOuter)
+	if (_active)
 		invertOuter();
 	if (_invertInner)
 		invertInner();

--- a/graphics/macgui/macbutton.cpp
+++ b/graphics/macgui/macbutton.cpp
@@ -72,20 +72,21 @@ void MacButton::setActive(bool active) {
 	}
 }
 
+// whether to use getDrawPixel or getDrawInvertPixel to draw invert pixel, maybe depends on the pattle we are using
 void MacButton::invertOuter() {
 	Common::Rect r(_dims.width() - 1, _dims.height() - 1);
 
 	switch (_buttonType) {
 	case kCheckBox: {
 		Common::Rect c = Common::Rect(r.left + 1, r.top + 3, r.left + 9, r.top + 11);
-		Graphics::drawRect(c, 0, _wm->getDrawInvertPixel(), &_pd);
+		Graphics::drawRect(c, 0, _wm->getDrawPixel(), &_pd);
 	}
 		break;
 	case kRound:
-		Graphics::drawRoundRect(r, 4, 0, true, _wm->getDrawInvertPixel(), &_pd);
+		Graphics::drawRoundRect(r, 4, 0, true, _wm->getDrawPixel(), &_pd);
 		break;
 	case kRadio:
-		Graphics::drawEllipse(r.left + 1, r.top + 3, r.left + 10, r.top + 12, 0, false, _wm->getDrawInvertPixel(), &_pd);
+		Graphics::drawEllipse(r.left + 1, r.top + 3, r.left + 10, r.top + 12, 0, false, _wm->getDrawPixel(), &_pd);
 		break;
 	}
 }
@@ -95,14 +96,14 @@ void MacButton::invertInner() {
 
 	switch (_buttonType) {
 	case kCheckBox:
-		Graphics::drawLine(r.left + 1, r.top + 3, r.left + 9, r.top + 11, 0, _wm->getDrawInvertPixel(), &_pd);
-		Graphics::drawLine(r.left + 1, r.top + 11, r.left + 9, r.top + 3, 0, _wm->getDrawInvertPixel(), &_pd);
+		Graphics::drawLine(r.left + 1, r.top + 3, r.left + 9, r.top + 11, 0, _wm->getDrawPixel(), &_pd);
+		Graphics::drawLine(r.left + 1, r.top + 11, r.left + 9, r.top + 3, 0, _wm->getDrawPixel(), &_pd);
 		(_wm->getDrawInvertPixel())(5, 7, 0, &_pd);
 		break;
 	case kRound:
 		break;
 	case kRadio:
-		Graphics::drawEllipse(r.left + 3, r.top + 5, r.left + 8, r.top + 10, 0, true, _wm->getDrawInvertPixel(), &_pd);
+		Graphics::drawEllipse(r.left + 3, r.top + 5, r.left + 8, r.top + 10, 0, true, _wm->getDrawPixel(), &_pd);
 		break;
 	}
 }
@@ -130,7 +131,7 @@ bool MacButton::draw(bool forceRedraw) {
 		break;
 	}
 	case kRound:
-		Graphics::drawRoundRect(r, 4, 0, _active, _wm->getDrawPixel(), &pd);
+		Graphics::drawRoundRect(r, 4, 0, false, _wm->getDrawPixel(), &pd);
 		break;
 	case kRadio:
 		Graphics::drawEllipse(r.left, r.top + 2, r.left + 11, r.top + 13, 0, false, _wm->getDrawPixel(), &pd);

--- a/graphics/macgui/macbutton.h
+++ b/graphics/macgui/macbutton.h
@@ -40,9 +40,9 @@ enum MacButtonType {
 
 // those name comes from Apartment
 enum CheckBoxType {
-	kNormal,
-	kInsetBlack,
-	kFilledBlack
+	kCBNormal,
+	kCBInsetBlack,
+	kCBFilledBlack
 };
 
 class MacButton : public MacText {

--- a/graphics/macgui/macbutton.h
+++ b/graphics/macgui/macbutton.h
@@ -38,6 +38,13 @@ enum MacButtonType {
 	kRadio
 };
 
+// those name comes from Apartment
+enum CheckBoxType {
+	kNormal,
+	kInsetBlack,
+	kFilledBlack
+};
+
 class MacButton : public MacText {
 public:
 	MacButton(MacButtonType buttonType, TextAlign textAlignment, MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *macFont, int fgcolor, int bgcolor);
@@ -48,6 +55,7 @@ public:
 	void invertInner();
 
 	void setHilite(bool hilite);
+	void setCheckBoxType(int type);
 
 	virtual bool draw(ManagedSurface *g, bool forceRedraw = false) override;
 	virtual bool draw(bool forceRedraw = false) override;
@@ -59,6 +67,7 @@ private:
 	MacPlotData _pd;
 	bool _invertInner;
 	bool _invertOuter;
+	int _checkBoxType;
 };
 
 } // End of namespace Graphics

--- a/graphics/macgui/macbutton.h
+++ b/graphics/macgui/macbutton.h
@@ -48,6 +48,7 @@ enum CheckBoxType {
 class MacButton : public MacText {
 public:
 	MacButton(MacButtonType buttonType, TextAlign textAlignment, MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *macFont, int fgcolor, int bgcolor);
+	MacButton(MacButtonType buttonType, TextAlign textAlignment, MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *macFont, int fgcolor, int bgcolor, Common::CodePage encodeType = Common::kMacCentralEurope);
 
 	virtual void setActive(bool active) override;
 

--- a/graphics/macgui/macbutton.h
+++ b/graphics/macgui/macbutton.h
@@ -67,7 +67,6 @@ private:
 	MacButtonType _buttonType;
 	MacPlotData _pd;
 	bool _invertInner;
-	bool _invertOuter;
 	int _checkBoxType;
 };
 

--- a/graphics/macgui/macbutton.h
+++ b/graphics/macgui/macbutton.h
@@ -46,6 +46,9 @@ public:
 
 	void invertOuter();
 	void invertInner();
+
+	void setHilite(bool hilite);
+
 	virtual bool draw(ManagedSurface *g, bool forceRedraw = false) override;
 	virtual bool draw(bool forceRedraw = false) override;
 	virtual bool processEvent(Common::Event &event) override;

--- a/graphics/macgui/macbutton.h
+++ b/graphics/macgui/macbutton.h
@@ -54,6 +54,8 @@ public:
 private:
 	MacButtonType _buttonType;
 	MacPlotData _pd;
+	bool _invertInner;
+	bool _invertOuter;
 };
 
 } // End of namespace Graphics

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -378,21 +378,21 @@ int MacFontManager::parseFontSlant(Common::String slant) {
 int MacFontManager::parseSlantFromName(const Common::String &name) {
 	int slantVal = 0;
 
-	if (strstr(name.c_str(), "Bold"))
+	if (name.contains(" Bold"))
 		slantVal |= kMacFontBold;
-	if (strstr(name.c_str(), "Italic"))
+	if (name.contains(" Italic"))
 		slantVal |= kMacFontItalic;
-	if (strstr(name.c_str(), "Regular"))
+	if (name.contains(" Regular"))
 		slantVal |= kMacFontRegular;
-	if (strstr(name.c_str(), "Underline"))
+	if (name.contains(" Underline"))
 		slantVal |= kMacFontUnderline;
-	if (strstr(name.c_str(), "Shadow"))
+	if (name.contains(" Shadow"))
 		slantVal |= kMacFontShadow;
-	if (strstr(name.c_str(), "Outline"))
+	if (name.contains(" Outline"))
 		slantVal |= kMacFontOutline;
-	if (strstr(name.c_str(), "Condense"))
+	if (name.contains(" Condense"))
 		slantVal |= kMacFontCondense;
-	if (strstr(name.c_str(), "Extend"))
+	if (name.contains(" Extend"))
 		slantVal |= kMacFontExtend;
 
 	return slantVal;

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -375,6 +375,29 @@ int MacFontManager::parseFontSlant(Common::String slant) {
 	return slantVal;
 }
 
+int MacFontManager::parseSlantFromName(const Common::String &name) {
+	int slantVal = 0;
+
+	if (strstr(name.c_str(), "Bold"))
+		slantVal |= kMacFontBold;
+	if (strstr(name.c_str(), "Italic"))
+		slantVal |= kMacFontItalic;
+	if (strstr(name.c_str(), "Regular"))
+		slantVal |= kMacFontRegular;
+	if (strstr(name.c_str(), "Underline"))
+		slantVal |= kMacFontUnderline;
+	if (strstr(name.c_str(), "Shadow"))
+		slantVal |= kMacFontShadow;
+	if (strstr(name.c_str(), "Outline"))
+		slantVal |= kMacFontOutline;
+	if (strstr(name.c_str(), "Condense"))
+		slantVal |= kMacFontCondense;
+	if (strstr(name.c_str(), "Extend"))
+		slantVal |= kMacFontExtend;
+
+	return slantVal;
+}
+
 void MacFontManager::registerFontMapping(uint16 id, Common::String name) {
 	_extraFontNames[id] = name;
 	_extraFontIds[name] = id;
@@ -400,6 +423,9 @@ const Common::String MacFontManager::getFontName(int id, int size, int slant, bo
 	if (_extraFontNames.contains(id)) {
 		n = cleanFontName(_extraFontNames[id]);
 		extraSlant = parseFontSlant(_extraFontNames[id]);
+		// let's try parse slant from name
+		if (!extraSlant)
+			extraSlant = parseSlantFromName(_extraFontNames[id]);
 	} else if (id < ARRAYSIZE(fontNames)) {
 		if (fontNames[id])
 			n = fontNames[id];

--- a/graphics/macgui/macfontmanager.h
+++ b/graphics/macgui/macfontmanager.h
@@ -139,6 +139,7 @@ public:
 	void clearFontMapping();
 
 	void forceBuiltinFonts() { _builtInFonts = true; }
+	int parseSlantFromName(const Common::String &name);
 
 private:
 	void loadFontsBDF();

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -94,7 +94,7 @@ uint MacTextLine::getChunkNum(int *col) {
 }
 
 
-MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow, Common::CodePage encodeType, bool plainByteMode) :
+MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow) :
 	MacWidget(parent, x, y, w + 2, h, wm, true, border, gutter, boxShadow),
 	_macFont(macFont), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
@@ -106,8 +106,8 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 	_bgcolor = bgcolor;
 	_textShadow = textShadow;
 	_macFontMode = true;
-	_encodeType = encodeType;
-	_plainByteMode = plainByteMode;
+	_encodeType = Common::kUtf8;
+	_plainByteMode = false;
 
 	if (macFont) {
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
@@ -119,7 +119,7 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 	init();
 }
 
-MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow, Common::CodePage encodeType, bool plainByteMode) :
+MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow, Common::CodePage encodeType) :
 	MacWidget(parent, x, y, w + 2, h, wm, true, border, gutter, boxShadow),
 	_macFont(macFont), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
@@ -131,7 +131,7 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 	_textShadow = textShadow;
 	_macFontMode = true;
 	_encodeType = encodeType;
-	_plainByteMode = plainByteMode;
+	_plainByteMode = true;
 
 	if (macFont) {
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
@@ -144,7 +144,7 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 }
 
 // NOTE: This constructor and the one afterward are for MacText engines that don't use widgets. This is the classic was MacText was constructed.
-MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, Common::CodePage encodeType, bool plainByteMode) :
+MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear) :
 	MacWidget(nullptr, 0, 0, 0, 0, wm, false, 0, 0, 0),
 	_macFont(macFont), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
@@ -155,8 +155,8 @@ MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont
 	_bgcolor = bgcolor;
 	_textShadow = 0;
 	_macFontMode = true;
-	_encodeType = encodeType;
-	_plainByteMode = plainByteMode;
+	_encodeType = Common::kUtf8;
+	_plainByteMode = false;
 
 	if (macFont) {
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
@@ -168,7 +168,7 @@ MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont
 	init();
 }
 
-MacText::MacText(const Common::String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, Common::CodePage encodeType, bool plainByteMode) :
+MacText::MacText(const Common::String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, Common::CodePage encodeType) :
 	MacWidget(nullptr, 0, 0, 0, 0, wm, false, 0, 0, 0),
 	_macFont(macFont), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
@@ -180,7 +180,7 @@ MacText::MacText(const Common::String &s, MacWindowManager *wm, const MacFont *m
 	_textShadow = 0;
 	_macFontMode = true;
 	_encodeType = encodeType;
-	_plainByteMode = plainByteMode;
+	_plainByteMode = true;
 
 	if (macFont) {
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
@@ -193,7 +193,7 @@ MacText::MacText(const Common::String &s, MacWindowManager *wm, const MacFont *m
 }
 
 // Working with plain Font
-MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, Common::CodePage encodeType, bool plainByteMode) :
+MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear) :
 	MacWidget(nullptr, 0, 0, 0, 0, wm, false, 0, 0, 0),
 	_macFont(nullptr), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
@@ -204,8 +204,8 @@ MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const Font *f
 	_bgcolor = bgcolor;
 	_textShadow = 0;
 	_macFontMode = false;
-	_encodeType = encodeType;
-	_plainByteMode = plainByteMode;
+	_encodeType = Common::kUtf8;
+	_plainByteMode = false;
 
 	if (font) {
 		_defaultFormatting = MacFontRun(_wm, font, 0, font->getFontHeight(), 0, 0, 0);
@@ -277,6 +277,13 @@ MacText::~MacText() {
 	delete _surface;
 	delete _cursorSurface;
 	delete _cursorSurface2;
+}
+
+int MacText::getStringWidth(const Font *font, const Common::U32String &str) {
+	if (_plainByteMode)
+		return font->getStringWidth(Common::convertFromU32String(str, _encodeType));
+	else
+		return font->getStringWidth(str);
 }
 
 void MacText::setMaxWidth(int maxWidth) {
@@ -528,7 +535,7 @@ void MacText::splitString(const Common::U32String &str, int curLine) {
 				continue;
 			}
 			// calc word_width, the trick we define here is we don`t count the space
-			int word_width = current_format.getFont()->getStringWidth(tmp);
+			int word_width = getStringWidth(current_format.getFont(), tmp);
 			// add all spaces left
 			while (*s == ' ') {
 				tmp += *s;
@@ -547,7 +554,7 @@ void MacText::splitString(const Common::U32String &str, int curLine) {
 			}
 
 			for (int i = 1; i < (int)word.size(); i++) {
-				word_width += word[i].getFont()->getStringWidth(word[i].text);
+				word_width += getStringWidth(word[i].getFont(), word[i].text);
 				D(9, "** word \"%s\" textslant [%d]", Common::toPrintable(word[i].text.encode()).c_str(), word[i].textSlant);
 			}
 
@@ -586,7 +593,14 @@ void MacText::splitString(const Common::U32String &str, int curLine) {
 							}
 							break;
 						}
-						int char_width = word[i].getFont()->getCharWidth(c);
+
+						// here, if we are in the plainByteMode, then we need to get the original text width, because current font may not resolve that u32string
+						int char_width = 0;
+						if (_plainByteMode) {
+							char_width = word[i].getFont()->getCharWidth(Common::convertFromU32String(Common::U32String(it, 1), _encodeType)[0]);
+						} else {
+							char_width = word[i].getFont()->getCharWidth(c);
+						}
 						if (char_width + tmp_width + cur_width > _maxWidth) {
 							++curLine;
 							_textLines.insert_at(curLine, MacTextLine());
@@ -764,14 +778,14 @@ int MacText::getLineWidth(int line, bool enforce, int col) {
 			} else {
 				Common::U32String tmp = _textLines[line].chunks[i].text.substr(0, col);
 
-				width += _textLines[line].chunks[i].getFont()->getStringWidth(tmp);
+				width += getStringWidth(_textLines[line].chunks[i].getFont(), tmp);
 
 				return width;
 			}
 		}
 
 		if (!_textLines[line].chunks[i].text.empty()) {
-			width += _textLines[line].chunks[i].getFont()->getStringWidth(_textLines[line].chunks[i].text);
+			width += getStringWidth(_textLines[line].chunks[i].getFont(), _textLines[line].chunks[i].text);
 			charwidth += _textLines[line].chunks[i].text.size();
 			hastext = true;
 		}
@@ -991,7 +1005,7 @@ void MacText::appendText_(const Common::U32String &strWithFont, uint oldLen) {
 }
 
 void MacText::appendText(const Common::String &str, int fontId, int fontSize, int fontSlant, bool skipAdd) {
-	appendText(Common::U32String(str), fontId, fontSize, fontSlant, skipAdd);
+	appendText(Common::U32String(str, _encodeType), fontId, fontSize, fontSlant, skipAdd);
 }
 
 void MacText::appendTextDefault(const Common::U32String &str, bool skipAdd) {
@@ -1318,12 +1332,12 @@ void MacText::setSelection(int pos, bool start) {
 			if (pos < getLineCharWidth(row)) {
 				for (uint i = 0; i < _textLines[row].chunks.size(); i++) {
 					if ((uint)pos < _textLines[row].chunks[i].text.size()) {
-						colX += _textLines[row].chunks[i].getFont()->getStringWidth(_textLines[row].chunks[i].text.substr(0, pos));
+						colX += getStringWidth(_textLines[row].chunks[i].getFont(), _textLines[row].chunks[i].text.substr(0, pos));
 						col += pos;
 						pos = 0;
 						break;
 					} else {
-						colX += _textLines[row].chunks[i].getFont()->getStringWidth(Common::U32String(_textLines[row].chunks[i].text));
+						colX += getStringWidth(_textLines[row].chunks[i].getFont(), _textLines[row].chunks[i].text);
 						pos -= _textLines[row].chunks[i].text.size();
 						col += _textLines[row].chunks[i].text.size();
 					}
@@ -1691,7 +1705,7 @@ void MacText::getRowCol(int x, int y, int *sx, int *sy, int *row, int *col) {
 		pwidth = width;
 		pmcol = mcol;
 		if (!_textLines[nrow].chunks[chunk].text.empty()) {
-			width += _textLines[nrow].chunks[chunk].getFont()->getStringWidth(_textLines[nrow].chunks[chunk].text);
+			width += getStringWidth(_textLines[nrow].chunks[chunk].getFont(), _textLines[nrow].chunks[chunk].text);
 			mcol += _textLines[nrow].chunks[chunk].text.size();
 		}
 
@@ -1708,7 +1722,7 @@ void MacText::getRowCol(int x, int y, int *sx, int *sy, int *row, int *col) {
 	nsx = pwidth;
 
 	for (int i = str.size(); i >= 0; i--) {
-		int strw = _textLines[nrow].chunks[chunk].getFont()->getStringWidth(str);
+		int strw = getStringWidth(_textLines[nrow].chunks[chunk].getFont(), str);
 		if (strw + pwidth + alignOffset <= x) {
 			ncol = pmcol + i;
 			nsx = strw + pwidth;
@@ -1892,14 +1906,14 @@ void MacText::insertChar(byte c, int *row, int *col) {
 	int pos = *col;
 	uint ch = line->getChunkNum(&pos);
 
-	Common::U32String newchunk(line->chunks[ch].text);
+	Common::U32String newchunk(line->chunks[ch].text, _encodeType);
 
 	if (pos >= (int)newchunk.size())
 		newchunk += c;
 	else
 		newchunk.insertChar(c, pos);
-	int chunkw = line->chunks[ch].getFont()->getStringWidth(newchunk);
-	int oldw = line->chunks[ch].getFont()->getStringWidth(line->chunks[ch].text);
+	int chunkw = getStringWidth(line->chunks[ch].getFont(), newchunk);
+	int oldw = getStringWidth(line->chunks[ch].getFont(), line->chunks[ch].text);
 
 	line->chunks[ch].text = newchunk;
 	line->width = -1;	// Force recalc

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -711,10 +711,10 @@ void MacText::render(int from, int to) {
 		else if (_textAlignment == kTextAlignCenter)
 			xOffset = (_textMaxWidth / 2) - (getLineWidth(i) / 2);
 
-		int maxHeightForRow = 0;
+		int maxAscentForRow = 0;
 		for (uint j = 0; j < _textLines[i].chunks.size(); j++) {
-			if (_textLines[i].chunks[j].font->getFontHeight() > maxHeightForRow)
-				maxHeightForRow = _textLines[i].chunks[j].font->getFontHeight();
+			if (_textLines[i].chunks[j].font->getFontAscent() > maxAscentForRow)
+				maxAscentForRow = _textLines[i].chunks[j].font->getFontAscent();
 		}
 
 		// TODO: _textMaxWidth, when -1, was not rendering ANY text.
@@ -729,9 +729,8 @@ void MacText::render(int from, int to) {
 
 			//TODO: There might be a vertical alignment setting somewhere for differing font sizes in a single row?
 			int yOffset = 0;
-			if (_textLines[i].chunks[j].font->getFontHeight() < maxHeightForRow) {
-				//TODO: determine where the magic value 2 comes from
-				yOffset = maxHeightForRow - _textLines[i].chunks[j].font->getFontHeight() - 2;
+			if (_textLines[i].chunks[j].font->getFontAscent() < maxAscentForRow) {
+				yOffset = maxAscentForRow -_textLines[i].chunks[j].font->getFontAscent();
 			}
 
 			if (_plainByteMode) {

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -1887,8 +1887,36 @@ void MacText::insertTextFromClipboard() {
 	_cursorCol = ppos;
 	recalcDims();
 	updateCursorPos();
-	render();
 	_fullRefresh = true;
+	render();
+}
+
+void MacText::setText(const Common::U32String &str) {
+	_str = str;
+	_textLines.clear();
+	splitString(_str);
+
+	_cursorRow = _cursorCol = 0;
+	recalcDims();
+	updateCursorPos();
+	_fullRefresh = true;
+	render();
+
+	_contentIsDirty = true;
+}
+
+void MacText::setText(const Common::String &str) {
+	_str = Common::U32String(str, _encodeType);
+	_textLines.clear();
+	splitString(_str);
+
+	_cursorRow = _cursorCol = 0;
+	recalcDims();
+	updateCursorPos();
+	_fullRefresh = true;
+	render();
+
+	_contentIsDirty = true;
 }
 
 //////////////////

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -94,7 +94,7 @@ uint MacTextLine::getChunkNum(int *col) {
 }
 
 
-MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow) :
+MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow, Common::CodePage encodeType, bool plainByteMode) :
 	MacWidget(parent, x, y, w + 2, h, wm, true, border, gutter, boxShadow),
 	_macFont(macFont), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
@@ -106,6 +106,8 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 	_bgcolor = bgcolor;
 	_textShadow = textShadow;
 	_macFontMode = true;
+	_encodeType = encodeType;
+	_plainByteMode = plainByteMode;
 
 	if (macFont) {
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
@@ -117,17 +119,19 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 	init();
 }
 
-MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow) :
+MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 border, uint16 gutter, uint16 boxShadow, uint16 textShadow, Common::CodePage encodeType, bool plainByteMode) :
 	MacWidget(parent, x, y, w + 2, h, wm, true, border, gutter, boxShadow),
 	_macFont(macFont), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
-	_str = Common::U32String(s);
+	_str = Common::U32String(s, encodeType);
 
 	_wm = wm;
 	_fgcolor = fgcolor;
 	_bgcolor = bgcolor;
 	_textShadow = textShadow;
 	_macFontMode = true;
+	_encodeType = encodeType;
+	_plainByteMode = plainByteMode;
 
 	if (macFont) {
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
@@ -140,7 +144,7 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 }
 
 // NOTE: This constructor and the one afterward are for MacText engines that don't use widgets. This is the classic was MacText was constructed.
-MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear) :
+MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, Common::CodePage encodeType, bool plainByteMode) :
 	MacWidget(nullptr, 0, 0, 0, 0, wm, false, 0, 0, 0),
 	_macFont(macFont), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
@@ -151,6 +155,8 @@ MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont
 	_bgcolor = bgcolor;
 	_textShadow = 0;
 	_macFontMode = true;
+	_encodeType = encodeType;
+	_plainByteMode = plainByteMode;
 
 	if (macFont) {
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
@@ -162,17 +168,19 @@ MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont
 	init();
 }
 
-MacText::MacText(const Common::String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear) :
+MacText::MacText(const Common::String &s, MacWindowManager *wm, const MacFont *macFont, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, Common::CodePage encodeType, bool plainByteMode) :
 	MacWidget(nullptr, 0, 0, 0, 0, wm, false, 0, 0, 0),
 	_macFont(macFont), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
-	_str = Common::U32String(s);
+	_str = Common::U32String(s, encodeType);
 
 	_wm = wm;
 	_fgcolor = fgcolor;
 	_bgcolor = bgcolor;
 	_textShadow = 0;
 	_macFontMode = true;
+	_encodeType = encodeType;
+	_plainByteMode = plainByteMode;
 
 	if (macFont) {
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
@@ -185,7 +193,7 @@ MacText::MacText(const Common::String &s, MacWindowManager *wm, const MacFont *m
 }
 
 // Working with plain Font
-MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear) :
+MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, Common::CodePage encodeType, bool plainByteMode) :
 	MacWidget(nullptr, 0, 0, 0, 0, wm, false, 0, 0, 0),
 	_macFont(nullptr), _maxWidth(maxWidth), _textAlignment(textAlignment), _interLinear(interlinear) {
 
@@ -196,6 +204,8 @@ MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const Font *f
 	_bgcolor = bgcolor;
 	_textShadow = 0;
 	_macFontMode = false;
+	_encodeType = encodeType;
+	_plainByteMode = plainByteMode;
 
 	if (font) {
 		_defaultFormatting = MacFontRun(_wm, font, 0, font->getFontHeight(), 0, 0, 0);
@@ -710,8 +720,14 @@ void MacText::render(int from, int to) {
 				yOffset = maxHeightForRow - _textLines[i].chunks[j].font->getFontHeight() - 2;
 			}
 
-			_textLines[i].chunks[j].getFont()->drawString(_surface, convertBiDiU32String(_textLines[i].chunks[j].text), xOffset, _textLines[i].y + yOffset, w, _textLines[i].chunks[j].fgcolor);
-			xOffset += _textLines[i].chunks[j].getFont()->getStringWidth(_textLines[i].chunks[j].text);
+			if (_plainByteMode) {
+				Common::String str = Common::convertFromU32String(_textLines[i].chunks[j].text, _encodeType);
+				_textLines[i].chunks[j].getFont()->drawString(_surface, str, xOffset, _textLines[i].y + yOffset, w, _textLines[i].chunks[j].fgcolor);
+				xOffset += _textLines[i].chunks[j].getFont()->getStringWidth(str);
+			} else {
+				_textLines[i].chunks[j].getFont()->drawString(_surface, convertBiDiU32String(_textLines[i].chunks[j].text), xOffset, _textLines[i].y + yOffset, w, _textLines[i].chunks[j].fgcolor);
+				xOffset += _textLines[i].chunks[j].getFont()->getStringWidth(_textLines[i].chunks[j].text);
+			}
 		}
 	}
 

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -279,6 +279,8 @@ MacText::~MacText() {
 	delete _cursorSurface2;
 }
 
+// we are doing this because we may need to dealing with the plain byte. See ctor of mactext which contains String str instead of U32String str
+// thus, if we are passing the str, meaning we are using plainByteMode. And when we calculating the string width. we need to convert it to it's orignal state first;
 int MacText::getStringWidth(const Font *font, const Common::U32String &str) {
 	if (_plainByteMode)
 		return font->getStringWidth(Common::convertFromU32String(str, _encodeType));

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -665,14 +665,14 @@ void MacText::reallocSurface() {
 	//int requiredH = (_text.size() + (_text.size() * 10 + 9) / 10) * lineH
 
 	if (!_surface) {
-		_surface = new ManagedSurface(_textMaxWidth, _textMaxHeight, _wm->_pixelformat);
+		_surface = new ManagedSurface(_maxWidth, _textMaxHeight, _wm->_pixelformat);
 
 		return;
 	}
 
 	if (_surface->w < _textMaxWidth || _surface->h < _textMaxHeight) {
 		// realloc surface and copy old content
-		ManagedSurface *n = new ManagedSurface(_textMaxWidth, _textMaxHeight, _wm->_pixelformat);
+		ManagedSurface *n = new ManagedSurface(_maxWidth, _textMaxHeight, _wm->_pixelformat);
 		n->clear(_bgcolor);
 		n->blitFrom(*_surface, Common::Point(0, 0));
 
@@ -707,9 +707,9 @@ void MacText::render(int from, int to) {
 	for (int i = from; i <= to; i++) {
 		int xOffset = 0;
 		if (_textAlignment == kTextAlignRight)
-			xOffset = _textMaxWidth - getLineWidth(i);
+			xOffset = _maxWidth - getLineWidth(i);
 		else if (_textAlignment == kTextAlignCenter)
-			xOffset = (_textMaxWidth / 2) - (getLineWidth(i) / 2);
+			xOffset = (_maxWidth / 2) - (getLineWidth(i) / 2);
 
 		int maxAscentForRow = 0;
 		for (uint j = 0; j < _textLines[i].chunks.size(); j++) {
@@ -884,7 +884,7 @@ void MacText::setAlignOffset(TextAlign align) {
 }
 
 Common::Point MacText::calculateOffset() {
-	return Common::Point(_alignOffset.x + _border + _gutter + 2, _alignOffset.y + _border + _gutter/2);
+	return Common::Point(_border + _gutter + 2, _border + _gutter / 2);
 }
 
 void MacText::setActive(bool active) {
@@ -1224,9 +1224,9 @@ void MacText::drawSelection(int xoff, int yoff) {
 		// deal with the first line, which is not a complete line
 		if (numLines) {
 			if (_textAlignment == kTextAlignRight)
-				alignOffset = _textMaxWidth - getLineWidth(start_row);
+				alignOffset = _maxWidth - getLineWidth(start_row);
 			else if (_textAlignment == kTextAlignCenter)
-				alignOffset = (_textMaxWidth / 2) - (getLineWidth(start_row) / 2);
+				alignOffset = (_maxWidth / 2) - (getLineWidth(start_row) / 2);
 
 			if (swaped && start_row == s.startRow && s.startCol != 0) {
 				x1 = MIN<int>(x1 + xoff + alignOffset, getDimensions().width() - 1);
@@ -1246,9 +1246,9 @@ void MacText::drawSelection(int xoff, int yoff) {
 			x2 = getDimensions().width() - 1;
 
 			if (_textAlignment == kTextAlignRight)
-				alignOffset = _textMaxWidth - getLineWidth(row);
+				alignOffset = _maxWidth - getLineWidth(row);
 			else if (_textAlignment == kTextAlignCenter)
-				alignOffset = (_textMaxWidth / 2) - (getLineWidth(row) / 2);
+				alignOffset = (_maxWidth / 2) - (getLineWidth(row) / 2);
 
 			numLines = getLineHeight(row);
 			if (y + _scrollPos == s.startY && s.startX > 0)
@@ -1693,9 +1693,9 @@ void MacText::getRowCol(int x, int y, int *sx, int *sy, int *row, int *col) {
 
 	int alignOffset = 0;
 	if (_textAlignment == kTextAlignRight)
-		alignOffset = _textMaxWidth - getLineWidth(nrow);
+		alignOffset = _maxWidth - getLineWidth(nrow);
 	else if (_textAlignment == kTextAlignCenter)
-		alignOffset = (_textMaxWidth / 2) - (getLineWidth(nrow) / 2);
+		alignOffset = (_maxWidth / 2) - (getLineWidth(nrow) / 2);
 
 	int width = 0, pwidth = 0;
 	int mcol = 0, pmcol = 0;
@@ -2168,9 +2168,9 @@ void MacText::updateCursorPos() {
 
 		int alignOffset = 0;
 		if (_textAlignment == kTextAlignRight)
-			alignOffset = _textMaxWidth - getLineWidth(_cursorRow);
+			alignOffset = _maxWidth - getLineWidth(_cursorRow);
 		else if (_textAlignment == kTextAlignCenter)
-			alignOffset = (_textMaxWidth / 2) - (getLineWidth(_cursorRow) / 2);
+			alignOffset = (_maxWidth / 2) - (getLineWidth(_cursorRow) / 2);
 
 		_cursorY = _textLines[_cursorRow].y - _scrollPos;
 		_cursorX = getLineWidth(_cursorRow, false, _cursorCol) + alignOffset;

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -145,14 +145,14 @@ struct SelectedText {
 
 class MacText : public MacWidget {
 public:
-	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
-	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
+	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0);
+	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0, Common::CodePage encodeType = Common::kUtf8);
 	// 0 pixels between the lines by default
 
-	MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
-	MacText(const Common::String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
+	MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0);
+	MacText(const Common::String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kUtf8);
 
-	MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
+	MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0);
 
 	virtual ~MacText();
 
@@ -192,6 +192,8 @@ private:
 	void appendText_(const Common::U32String &strWithFont, uint oldLen);
 	void deletePreviousCharInternal(int *row, int *col);
 	void insertTextFromClipboard();
+	// getStringWidth for mactext version, because we may have the plain bytes mode
+	int getStringWidth(const Font * font, const Common::U32String &str);
 
 public:
 	void appendTextDefault(const Common::U32String &str, bool skipAdd = false);

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -146,11 +146,11 @@ struct SelectedText {
 class MacText : public MacWidget {
 public:
 	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0);
-	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0, Common::CodePage encodeType = Common::kUtf8);
+	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0, Common::CodePage encodeType = Common::kMacCentralEurope);
 	// 0 pixels between the lines by default
 
 	MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0);
-	MacText(const Common::String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kUtf8);
+	MacText(const Common::String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kMacCentralEurope);
 
 	MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0);
 

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -207,6 +207,9 @@ public:
 	int getLineHeight(int line);
 	int getTextMaxWidth() { return _textMaxWidth; }
 
+	void setText(const Common::U32String &str);
+	void setText(const Common::String &str);
+
 	void deleteSelection();
 	void deletePreviousChar(int *row, int *col);
 	void addNewLine(int *row, int *col);

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -145,14 +145,14 @@ struct SelectedText {
 
 class MacText : public MacWidget {
 public:
-	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0);
-	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0);
+	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::U32String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
+	MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, const Common::String &s, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment = kTextAlignLeft, int interlinear = 0, uint16 border = 0, uint16 gutter = 0, uint16 boxShadow = 0, uint16 textShadow = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
 	// 0 pixels between the lines by default
 
-	MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0);
-	MacText(const Common::String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0);
+	MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
+	MacText(const Common::String &s, MacWindowManager *wm, const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
 
-	MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0);
+	MacText(const Common::U32String &s, MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, int interlinear = 0, Common::CodePage encodeType = Common::kUtf8, bool plainByteMode = false);
 
 	virtual ~MacText();
 
@@ -307,6 +307,10 @@ protected:
 	MacFontRun _currentFormatting;
 
 	bool _macFontMode;
+
+	bool _plainByteMode;
+
+	Common::CodePage _encodeType;
 
 private:
 	ManagedSurface *_cursorSurface;

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -397,12 +397,13 @@ void MacWindowManager::disableScreenCopy() {
 		_screenCopyPauseToken = nullptr;
 	}
 
-	if (_screen)
-		*_screen = *_screenCopy; // restore screen
-
 	// add a check, we may not get the _screenCopy because we may not activate the menu
 	if (!_screenCopy)
 		return;
+
+	if (_screen)
+		*_screen = *_screenCopy; // restore screen
+
 	g_system->copyRectToScreen(_screenCopy->getBasePtr(0, 0), _screenCopy->pitch, 0, 0, _screenCopy->w, _screenCopy->h);
 }
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -1120,6 +1120,8 @@ void MacWindowManager::popCursor() {
 	} else {
 		CursorMan.popCursor();
 		CursorMan.popCursorPalette();
+		// since we may only have one cursor available when we using macCursor, so we restore the cursorType when we pop the cursor
+		_cursorType = kMacCursorArrow;
 	}
 }
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -188,6 +188,7 @@ MacWindowManager::MacWindowManager(uint32 mode, MacPatterns *patterns) {
 	_colorGreen2 = kColorGreen2;
 
 	_fullRefresh = true;
+	_inEditableArea = false;
 
 	if (mode & kWMMode32bpp)
 		_pixelformat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
@@ -839,11 +840,16 @@ bool MacWindowManager::processEvent(Common::Event &event) {
 				 _activeWidget->getDimensions().contains(event.mouse.x, event.mouse.y))) {
 			if (_cursorType != kMacCursorBeam) {
 				_tempType = _cursorType;
+				_inEditableArea = true;
 				replaceCursor(kMacCursorBeam);
 			}
 		} else {
-			if (_cursorType == kMacCursorBeam)
+			// here, we use _inEditableArea is distinguish whether the current Beam cursor is set by director or ourself
+			// if we are not in the editable area but we are drawing the Beam cursor, then the cursor is set by director, thus we don't replace it
+			if (_cursorType == kMacCursorBeam && _inEditableArea) {
 				replaceCursor(_tempType, _cursor);
+				_inEditableArea = false;
+			}
 		}
 	}
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -267,11 +267,10 @@ void MacWindowManager::setScreen(int w, int h) {
 }
 
 void MacWindowManager::resizeScreen(int w, int h) {
+	if (!_screen)
+		error("Trying to creating surface on non-existing screen");
 	_screenDims = Common::Rect(w, h);
-	if (_screen)
-		_screen->free();
-	else
-		_screen = new ManagedSurface();
+	_screen->free();
 	_screen->create(w, h, _pixelformat);
 }
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -266,6 +266,15 @@ void MacWindowManager::setScreen(int w, int h) {
 	drawDesktop();
 }
 
+void MacWindowManager::resizeScreen(int w, int h) {
+	_screenDims = Common::Rect(w, h);
+	if (_screen)
+		_screen->free();
+	else
+		_screen = new ManagedSurface();
+	_screen->create(w, h, _pixelformat);
+}
+
 void MacWindowManager::setMode(uint32 mode) {
 	_mode = mode;
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -269,7 +269,7 @@ void MacWindowManager::setScreen(int w, int h) {
 
 void MacWindowManager::resizeScreen(int w, int h) {
 	if (!_screen)
-		error("Trying to creating surface on non-existing screen");
+		error("MacWindowManager::resizeScreen(): Trying to creating surface on non-existing screen");
 	_screenDims = Common::Rect(w, h);
 	_screen->free();
 	_screen->create(w, h, _pixelformat);

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -392,6 +392,9 @@ void MacWindowManager::disableScreenCopy() {
 	if (_screen)
 		*_screen = *_screenCopy; // restore screen
 
+	// add a check, we may not get the _screenCopy because we may not activate the menu
+	if (!_screenCopy)
+		return;
 	g_system->copyRectToScreen(_screenCopy->getBasePtr(0, 0), _screenCopy->pitch, 0, 0, _screenCopy->w, _screenCopy->h);
 }
 

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -372,6 +372,8 @@ private:
 
 	bool _fullRefresh;
 
+	bool _inEditableArea;
+
 	MacPatterns _patterns;
 	byte *_palette;
 	uint _paletteSize;

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -172,6 +172,7 @@ public:
 	MacWindow *addWindow(bool scrollable, bool resizable, bool editable);
 	MacTextWindow *addTextWindow(const MacFont *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, MacMenu *menu, bool cursorHandler = true);
 	MacTextWindow *addTextWindow(const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, MacMenu *menu, bool cursorHandler = true);
+	void resizeScreen(int w, int h);
 
 	/**
 	 * Adds a window that has already been initialized to the registry.


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
---> add checkBoxType for macbutton, implement the checkBoxType for lingo.
fix hilite state for button castmember.
modify event handling to make director behave more like the original one.
drawing on _screen of wm instead of drawing directly on screen. 
fix zoombox of apartment
since the Beam Cursor for macgui will get conflict when we set the cursor type explictly, i added a check for whether the cursor type is modified manually.
and the cursor type is not managed well when we are pop the cursor. fortunately, we will only use one level for macgui, so we always get the default one (kMacCursorArrow) when we are popping up the cursor. Thus, i restore the cursor type whenever we pop the cursor. And this will fix Apartment/User Interface/cursor. 
add plainBytesMode for mactext to deal with the plainBytes
use kMacCentralEurope to encode our text in director
