### PR TITLE
DS: Update the MaxMod callback manually

### DIFF
--- a/backends/events/ds/ds-events.cpp
+++ b/backends/events/ds/ds-events.cpp
@@ -26,6 +26,9 @@
 #include "backends/platform/ds/osystem_ds.h"
 
 bool DSEventSource::pollEvent(Common::Event &event) {
+	// Ensure the mixer and timers are updated frequently
+	g_system->delayMillis(0);
+
 	if (_eventQueue.empty()) {
 		if (!_firstPoll) {
 			_firstPoll = true;

--- a/backends/mixer/maxmod/maxmod-mixer.cpp
+++ b/backends/mixer/maxmod/maxmod-mixer.cpp
@@ -70,7 +70,7 @@ void MaxModMixerManager::init() {
 	_stream.callback = on_stream_request;
 	_stream.format = MM_STREAM_16BIT_STEREO;
 	_stream.timer = MM_TIMER2;
-	_stream.manual = 0;
+	_stream.manual = 1;
 
 	mmStreamOpen( &_stream );
 
@@ -89,6 +89,11 @@ int MaxModMixerManager::resumeAudio() {
 	mmStreamOpen( &_stream );
 	_audioSuspended = false;
 	return 0;
+}
+
+void MaxModMixerManager::updateAudio() {
+	if (!_audioSuspended)
+		mmStreamUpdate();
 }
 
 #endif

--- a/backends/mixer/maxmod/maxmod-mixer.h
+++ b/backends/mixer/maxmod/maxmod-mixer.h
@@ -52,6 +52,11 @@ public:
 	 */
 	virtual int resumeAudio();
 
+	/**
+	 * Updates the audio system
+	 */
+	void updateAudio();
+
 protected:
 	mm_stream _stream;
 	int _freq, _bufSize;

--- a/backends/platform/ds/osystem_ds.cpp
+++ b/backends/platform/ds/osystem_ds.cpp
@@ -85,7 +85,7 @@ void OSystem_DS::initBackend() {
 	_timerManager = new DefaultTimerManager();
 	timerStart(0, ClockDivider_1, (u16)TIMER_FREQ(1000), timerTickHandler);
 
-	_mixerManager = new MaxModMixerManager(11025, 4096);
+	_mixerManager = new MaxModMixerManager(11025, 32768);
 	_mixerManager->init();
 
 	BaseBackend::initBackend();
@@ -102,9 +102,11 @@ uint32 OSystem_DS::getMillis(bool skipRecord) {
 void OSystem_DS::delayMillis(uint msecs) {
 	int st = getMillis();
 
-	while (st + msecs >= getMillis());
-
 	doTimerCallback();
+	if (_mixerManager)
+		((MaxModMixerManager *)_mixerManager)->updateAudio();
+
+	while (st + msecs >= getMillis());
 }
 
 void OSystem_DS::doTimerCallback(int interval) {

--- a/engines/bbvs/minigames/bbloogie.cpp
+++ b/engines/bbvs/minigames/bbloogie.cpp
@@ -495,7 +495,7 @@ bool MinigameBbLoogie::updateStatus0(int mouseX, int mouseY, uint mouseButtons) 
 			_playerSounds2 = kBeavisSounds2;
 			_playerSounds2Count = 13;
 			playSound(15);
-			while (isSoundPlaying(15)) { }
+			while (isSoundPlaying(15)) { _vm->_system->delayMillis(10); }
 		} else {
 			// Butt-head
 			_playerKind = 1;
@@ -505,7 +505,7 @@ bool MinigameBbLoogie::updateStatus0(int mouseX, int mouseY, uint mouseButtons) 
 			_playerSounds2 = kButtheadSounds2;
 			_playerSounds2Count = 10;
 			playSound(23);
-			while (isSoundPlaying(23)) { }
+			while (isSoundPlaying(23)) { _vm->_system->delayMillis(10); }
 		}
 		_gameState = _fromMainGame ? kGSMainGame : kGSStandaloneGame;
 		initObjects1();


### PR DESCRIPTION
Running the mixer callback from a timer interrupt is proving to be problematic. This probably isn't the best way to approach this, and introduces stuttering with some games, including FOTAQ and ITE, but it does fix [Trac #12343](https://bugs.scummvm.org/ticket/12343) and [Trac #12344](https://bugs.scummvm.org/ticket/12344).