### PR TITLE
BACKENDS: fixed EventRecorder crashes and event polling issues

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -93,7 +93,7 @@ public:
 	virtual bool isOverlayVisible() const = 0;
 	virtual Graphics::PixelFormat getOverlayFormat() const = 0;
 	virtual void clearOverlay() = 0;
-	virtual void grabOverlay(void *buf, int pitch) const = 0;
+	virtual void grabOverlay(Graphics::Surface &surface) const = 0;
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) = 0;
 	virtual int16 getOverlayHeight() const = 0;
 	virtual int16 getOverlayWidth() const = 0;

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -77,7 +77,7 @@ public:
 	bool isOverlayVisible() const override { return _overlayVisible; }
 	Graphics::PixelFormat getOverlayFormat() const override { return Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0); }
 	void clearOverlay() override {}
-	void grabOverlay(void *buf, int pitch) const override {}
+	void grabOverlay(Graphics::Surface &surface) const override {}
 	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override {}
 	int16 getOverlayHeight() const override { return _height; }
 	int16 getOverlayWidth() const override { return _width; }

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -638,15 +638,15 @@ void OpenGLGraphicsManager::clearOverlay() {
 	_overlay->fill(0);
 }
 
-void OpenGLGraphicsManager::grabOverlay(void *buf, int pitch) const {
+void OpenGLGraphicsManager::grabOverlay(Graphics::Surface &surface) const {
 	const Graphics::Surface *overlayData = _overlay->getSurface();
 
 	const byte *src = (const byte *)overlayData->getPixels();
-	byte *dst = (byte *)buf;
+	byte *dst = (byte *)surface.getPixels();
 
 	for (uint h = overlayData->h; h > 0; --h) {
 		memcpy(dst, src, overlayData->w * overlayData->format.bytesPerPixel);
-		dst += pitch;
+		dst += surface.pitch;
 		src += overlayData->pitch;
 	}
 }

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -107,7 +107,7 @@ public:
 
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
 	virtual void clearOverlay() override;
-	virtual void grabOverlay(void *buf, int pitch) const override;
+	virtual void grabOverlay(Graphics::Surface &surface) const override;
 
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) override;
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) override;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1737,7 +1737,7 @@ void SurfaceSdlGraphicsManager::clearOverlay() {
 	_forceRedraw = true;
 }
 
-void SurfaceSdlGraphicsManager::grabOverlay(void *buf, int pitch) const {
+void SurfaceSdlGraphicsManager::grabOverlay(Graphics::Surface &surface) const {
 	assert(_transactionMode == kTransactionNone);
 
 	if (_overlayscreen == NULL)
@@ -1747,12 +1747,13 @@ void SurfaceSdlGraphicsManager::grabOverlay(void *buf, int pitch) const {
 		error("SDL_LockSurface failed: %s", SDL_GetError());
 
 	byte *src = (byte *)_overlayscreen->pixels;
-	byte *dst = (byte *)buf;
-	int h = _videoMode.overlayHeight;
+	byte *dst = (byte *)surface.getPixels();
+	int h = MIN<int>(surface.h, _videoMode.overlayHeight);
+	int pitch = MIN<int>(surface.w, _videoMode.overlayWidth * 2);
 	do {
-		memcpy(dst, src, _videoMode.overlayWidth * 2);
+		memcpy(dst, src, pitch);
 		src += _overlayscreen->pitch;
-		dst += pitch;
+		dst += surface.pitch;
 	} while (--h);
 
 	SDL_UnlockSurface(_overlayscreen);

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -110,7 +110,7 @@ public:
 
 	virtual Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
 	virtual void clearOverlay() override;
-	virtual void grabOverlay(void *buf, int pitch) const override;
+	virtual void grabOverlay(Graphics::Surface &surface) const override;
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
 	virtual int16 getOverlayHeight() const override { return _videoMode.overlayHeight; }
 	virtual int16 getOverlayWidth() const override { return _videoMode.overlayWidth; }

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -643,15 +643,15 @@ void OpenGLSdlGraphics3dManager::clearOverlay() {
 	_overlayScreen->fill(0);
 }
 
-void OpenGLSdlGraphics3dManager::grabOverlay(void *buf, int pitch) const {
+void OpenGLSdlGraphics3dManager::grabOverlay(Graphics::Surface &surface) const {
 	const Graphics::Surface *overlayData = _overlayScreen->getBackingSurface();
 
 	const byte *src = (const byte *)overlayData->getPixels();
-	byte *dst = (byte *)buf;
+	byte *dst = (byte *)surface.getPixels();
 
 	for (uint h = overlayData->h; h > 0; --h) {
 		memcpy(dst, src, overlayData->w * overlayData->format.bytesPerPixel);
-		dst += pitch;
+		dst += surface.pitch;
 		src += overlayData->pitch;
 	}
 }

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -90,7 +90,7 @@ public:
 	virtual void hideOverlay() override;
 	virtual Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
 	virtual void clearOverlay() override;
-	virtual void grabOverlay(void *buf, int pitch) const override;
+	virtual void grabOverlay(Graphics::Surface &surface) const override;
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
 	int16 getOverlayWidth() const override;
 	int16 getOverlayHeight() const override;

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -211,8 +211,8 @@ void ModularGraphicsBackend::clearOverlay() {
 	_graphicsManager->clearOverlay();
 }
 
-void ModularGraphicsBackend::grabOverlay(void *buf, int pitch) {
-	_graphicsManager->grabOverlay(buf, pitch);
+void ModularGraphicsBackend::grabOverlay(Graphics::Surface &surface) {
+	_graphicsManager->grabOverlay(surface);
 }
 
 void ModularGraphicsBackend::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -104,7 +104,7 @@ public:
 	virtual bool isOverlayVisible() const override final;
 	virtual Graphics::PixelFormat getOverlayFormat() const override final;
 	virtual void clearOverlay() override final;
-	virtual void grabOverlay(void *buf, int pitch) override final;
+	virtual void grabOverlay(Graphics::Surface &surface) override final;
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override final;
 	virtual int16 getOverlayHeight() override final;
 	virtual int16 getOverlayWidth() override final;

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -626,12 +626,12 @@ void OSystem_3DS::clearOverlay() {
 	_overlay.clear();
 }
 
-void OSystem_3DS::grabOverlay(void *buf, int pitch) {
-	byte *dst = (byte *)buf;
+void OSystem_3DS::grabOverlay(Graphics::Surface &surface) {
+	byte *dst = (byte *)surface.getPixels();
 
 	for (int y = 0; y < getOverlayHeight(); ++y) {
 		memcpy(dst, _overlay.getBasePtr(0, y), getOverlayWidth() * _overlay.format.bytesPerPixel);
-		dst += pitch;
+		dst += surface.pitch;
 	}
 }
 

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -162,7 +162,7 @@ public:
 	bool isOverlayVisible() const { return _overlayVisible; }
 	Graphics::PixelFormat getOverlayFormat() const;
 	void clearOverlay();
-	void grabOverlay(void *buf, int pitch);
+	void grabOverlay(Graphics::Surface &surface);
 	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w,
 	                       int h);
 	virtual int16 getOverlayHeight();

--- a/backends/platform/android3d/graphics.cpp
+++ b/backends/platform/android3d/graphics.cpp
@@ -334,22 +334,22 @@ void AndroidGraphicsManager::clearOverlay() {
 	_overlay_texture->fillBuffer(0);
 }
 
-void AndroidGraphicsManager::grabOverlay(void *buf, int pitch) const {
+void AndroidGraphicsManager::grabOverlay(Graphics::Surface &surface) const {
 	ENTER("%p, %d", buf, pitch);
 
 	GLTHREADCHECK;
 
-	const Graphics::Surface *surface = _overlay_texture->surface_const();
-	assert(surface->format.bytesPerPixel == sizeof(uint16));
+	const Graphics::Surface *overlaySurface = _overlay_texture->surface_const();
+	assert(overlaySurface->format.bytesPerPixel == sizeof(uint16));
 
-	byte *dst = (byte *)buf;
-	const byte *src = (const byte *)surface->getPixels();
-	uint h = surface->h;
+	byte *dst = (byte *)surface.getPixels();
+	const byte *src = (const byte *)overlaySurface->getPixels();
+	uint h = overlaySurface->h;
 
 	do {
-		memcpy(dst, src, surface->w * surface->format.bytesPerPixel);
-		src += surface->pitch;
-		dst += pitch;
+		memcpy(dst, src, overlaySurface->w * overlaySurface->format.bytesPerPixel);
+		src += overlaySurface->pitch;
+		dst += surface.pitch;
 	} while (--h);
 }
 

--- a/backends/platform/android3d/graphics.h
+++ b/backends/platform/android3d/graphics.h
@@ -57,7 +57,7 @@ public:
 	virtual void showOverlay() override;
 	virtual void hideOverlay() override;
 	virtual void clearOverlay() override;
-	virtual void grabOverlay(void *buf, int pitch) const override;
+	virtual void grabOverlay(Graphics::Surface &surface) const override;
 	virtual void copyRectToOverlay(const void *buf, int pitch,
 									int x, int y, int w, int h) override;
 	virtual int16 getOverlayHeight() const override;

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -158,7 +158,7 @@ public:
   void showOverlay();
   void hideOverlay();
   void clearOverlay();
-  void grabOverlay(void *buf, int pitch);
+  void grabOverlay(Graphics::Surface &surface);
   void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
   virtual Graphics::PixelFormat getOverlayFormat() const { return Graphics::PixelFormat(2, 4, 4, 4, 4, 8, 4, 0, 12); }
 

--- a/backends/platform/dc/display.cpp
+++ b/backends/platform/dc/display.cpp
@@ -655,15 +655,15 @@ void OSystem_Dreamcast::clearOverlay()
   _overlay_dirty = true;
 }
 
-void OSystem_Dreamcast::grabOverlay(void *buf, int pitch)
+void OSystem_Dreamcast::grabOverlay(Graphics::Surface &surface)
 {
   int h = OVL_H;
   unsigned short *src = overlay;
-  unsigned char *dst = (unsigned char *)buf;
+  unsigned char *dst = (unsigned char *)surface.getPixels();
   do {
 	memcpy(dst, src, OVL_W*sizeof(int16));
 	src += OVL_W;
-	dst += pitch;
+	dst += surface.pitch;
   } while (--h);
 }
 

--- a/backends/platform/ds/ds-graphics.cpp
+++ b/backends/platform/ds/ds-graphics.cpp
@@ -410,8 +410,8 @@ void OSystem_DS::clearOverlay() {
 	_overlay.clear();
 }
 
-void OSystem_DS::grabOverlay(void *buf, int pitch) {
-	_overlay.grab((byte *)buf, pitch);
+void OSystem_DS::grabOverlay(Graphics::Surface &surface) {
+	_overlay.grab((byte *)surface.getPixels(), surface.pitch);
 }
 
 void OSystem_DS::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {

--- a/backends/platform/ds/osystem_ds.h
+++ b/backends/platform/ds/osystem_ds.h
@@ -109,7 +109,7 @@ public:
 	virtual void hideOverlay();
 	virtual bool isOverlayVisible() const;
 	virtual void clearOverlay();
-	virtual void grabOverlay(void *buf, int pitch);
+	virtual void grabOverlay(Graphics::Surface &surface);
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
 	virtual int16 getOverlayHeight();
 	virtual int16 getOverlayWidth();

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -163,7 +163,7 @@ public:
 	virtual void hideOverlay() override;
 	virtual bool isOverlayVisible() const override { return _videoContext->overlayVisible; }
 	virtual void clearOverlay() override;
-	virtual void grabOverlay(void *buf, int pitch) override;
+	virtual void grabOverlay(Graphics::Surface &surface) override;
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
 	virtual int16 getOverlayHeight() override;
 	virtual int16 getOverlayWidth() override;

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -380,16 +380,16 @@ void OSystem_iOS7::clearOverlay() {
 	dirtyFullOverlayScreen();
 }
 
-void OSystem_iOS7::grabOverlay(void *buf, int pitch) {
+void OSystem_iOS7::grabOverlay(Graphics::Surface &surface) {
 	//printf("grabOverlay()\n");
 	int h = _videoContext->overlayHeight;
 
-	byte *dst = (byte *)buf;
+	byte *dst = (byte *)surface.getPixels();
 	const byte *src = (const byte *)_videoContext->overlayTexture.getPixels();
 	do {
 		memcpy(dst, src, _videoContext->overlayWidth * sizeof(uint16));
 		src += _videoContext->overlayTexture.pitch;
-		dst += pitch;
+		dst += surface.pitch;
 	} while (--h);
 }
 

--- a/backends/platform/iphone/osys_main.h
+++ b/backends/platform/iphone/osys_main.h
@@ -151,7 +151,7 @@ public:
 	virtual void hideOverlay();
 	virtual bool isOverlayVisible() const { return _videoContext->overlayVisible; }
 	virtual void clearOverlay();
-	virtual void grabOverlay(void *buf, int pitch);
+	virtual void grabOverlay(Graphics::Surface &surface);
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
 	virtual int16 getOverlayHeight();
 	virtual int16 getOverlayWidth();

--- a/backends/platform/iphone/osys_video.mm
+++ b/backends/platform/iphone/osys_video.mm
@@ -304,16 +304,16 @@ void OSystem_IPHONE::clearOverlay() {
 	dirtyFullOverlayScreen();
 }
 
-void OSystem_IPHONE::grabOverlay(void *buf, int pitch) {
+void OSystem_IPHONE::grabOverlay(Graphics::Surface &surface) {
 	//printf("grabOverlay()\n");
 	int h = _videoContext->overlayHeight;
 
-	byte *dst = (byte *)buf;
+	byte *dst = (byte *)surface.getPixels();
 	const byte *src = (const byte *)_videoContext->overlayTexture.getPixels();
 	do {
 		memcpy(dst, src, _videoContext->overlayWidth * sizeof(uint16));
 		src += _videoContext->overlayTexture.pitch;
-		dst += pitch;
+		dst += surface.pitch;
 	} while (--h);
 }
 

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -169,7 +169,7 @@ public:
 	virtual void hideOverlay();
 	virtual bool isOverlayVisible() const { return _overlayVisible; }
 	virtual void clearOverlay();
-	virtual void grabOverlay(void *buf, int pitch);
+	virtual void grabOverlay(Graphics::Surface &surface);
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
 	virtual int16 getOverlayHeight();
 	virtual int16 getOverlayWidth();

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -665,15 +665,15 @@ void OSystem_N64::clearOverlay() {
 	_dirtyOffscreen = true;
 }
 
-void OSystem_N64::grabOverlay(void *buf, int pitch) {
+void OSystem_N64::grabOverlay(Graphics::Surface &surface) {
 	int h = _overlayHeight;
 	uint16 *src = _overlayBuffer;
-	byte *dst = (byte *)buf;
+	byte *dst = (byte *)surface.getPixels();
 
 	do {
 		memcpy(dst, src, _overlayWidth * sizeof(uint16));
 		src += _overlayWidth;
-		dst += pitch;
+		dst += surface.pitch;
 	} while (--h);
 }
 

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -258,9 +258,9 @@ void OSystem_PSP::clearOverlay() {
 	_overlay.clearBuffer();
 }
 
-void OSystem_PSP::grabOverlay(void *buf, int pitch) {
+void OSystem_PSP::grabOverlay(Graphics::Surface &surface) {
 	DEBUG_ENTER_FUNC();
-	_overlay.copyToArray(buf, pitch);
+	_overlay.copyToArray(surface.getPixels(), surface.pitch);
 }
 
 void OSystem_PSP::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -106,7 +106,7 @@ public:
 	void hideOverlay();
 	bool isOverlayVisible() const;
 	void clearOverlay();
-	void grabOverlay(void *buf, int pitch);
+	void grabOverlay(Graphics::Surface &surface);
 	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
 	int16 getOverlayHeight();
 	int16 getOverlayWidth();

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -178,7 +178,7 @@ public:
 	virtual void hideOverlay() override;
 	virtual bool isOverlayVisible() const override { return _overlayVisible; }
 	virtual void clearOverlay() override;
-	virtual void grabOverlay(void *buf, int pitch) override;
+	virtual void grabOverlay(Graphics::Surface &surface) override;
 	virtual void copyRectToOverlay(const void *buf, int pitch,
 									int x, int y, int w, int h) override;
 	virtual int16 getOverlayWidth() override;

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -576,15 +576,15 @@ void OSystem_Wii::clearOverlay() {
 	_overlayDirty = true;
 }
 
-void OSystem_Wii::grabOverlay(void *buf, int pitch) {
+void OSystem_Wii::grabOverlay(Graphics::Surface &surface) {
 	int h = _overlayHeight;
 	uint16 *src = _overlayPixels;
-	byte *dst = (byte *)buf;
+	byte *dst = (byte *)surface.getPixels();
 
 	do {
 		memcpy(dst, src, _overlayWidth * sizeof(uint16));
 		src += _overlayWidth;
-		dst += pitch;
+		dst += surface.pitch;
 	} while (--h);
 }
 

--- a/backends/vkeybd/virtual-keyboard-gui.cpp
+++ b/backends/vkeybd/virtual-keyboard-gui.cpp
@@ -178,7 +178,7 @@ void VirtualKeyboardGUI::run() {
 		_system->clearOverlay();
 	}
 	_overlayBackup.create(_screenW, _screenH, _system->getOverlayFormat());
-	_system->grabOverlay(_overlayBackup.getPixels(), _overlayBackup.pitch);
+	_system->grabOverlay(_overlayBackup);
 
 	setupCursor();
 
@@ -279,7 +279,7 @@ void VirtualKeyboardGUI::screenChanged() {
 		_screenH = newScreenH;
 
 		_overlayBackup.create(_screenW, _screenH, _system->getOverlayFormat());
-		_system->grabOverlay(_overlayBackup.getPixels(), _overlayBackup.pitch);
+		_system->grabOverlay(_overlayBackup);
 
 		if (!_kbd->checkModeResolutions()) {
 			_displaying = false;

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -594,18 +594,16 @@ int PlaybackFile::getScreensCount() {
 }
 
 bool PlaybackFile::skipToNextScreenshot() {
-	while (true) {
+	while (!_readStream->eos() && !_readStream->err()) {
 		FileTag id = (FileTag)_readStream->readUint32LE();
-		if (_readStream->eos()) {
+		if (_readStream->eos() || _readStream->err()) {
 			break;
 		}
 		if (id == kScreenShotTag) {
 			return true;
 		}
-		else {
-			uint32 size = _readStream->readUint32LE();
-			_readStream->skip(size);
-		}
+		uint32 size = _readStream->readUint32LE();
+		_readStream->skip(size);
 	}
 	return false;
 }

--- a/common/system.h
+++ b/common/system.h
@@ -1175,7 +1175,7 @@ public:
 	 *
 	 * This is only used to implement fake alpha blending.
 	 */
-	virtual void grabOverlay(void *buf, int pitch) = 0;
+	virtual void grabOverlay(Graphics::Surface &surface) = 0;
 
 	/**
 	 * Blit a graphics buffer to the overlay.

--- a/graphics/conversion.cpp
+++ b/graphics/conversion.cpp
@@ -445,14 +445,14 @@ void scaleBlitBilinearLogic(byte *dst, const byte *src,
 	}
 }
 
-template <typename Size, bool filtering, bool flipx, bool flipy> // TODO: See mirroring comment in RenderTicket ctor
+template<typename Size, bool filtering, bool flipx, bool flipy> // TODO: See mirroring comment in RenderTicket ctor
 void rotoscaleBlitLogic(byte *dst, const byte *src,
-                       const uint dstPitch, const uint srcPitch,
-                       const uint dstW, const uint dstH,
-                       const uint srcW, const uint srcH,
-                       const Graphics::PixelFormat &fmt,
-                       const TransformStruct &transform,
-                       const Common::Point &newHotspot) {
+						const uint dstPitch, const uint srcPitch,
+						const uint dstW, const uint dstH,
+						const uint srcW, const uint srcH,
+						const Graphics::PixelFormat &fmt,
+						const TransformStruct &transform,
+						const Common::Point &newHotspot) {
 
 	assert(transform._angle != kDefaultAngle); // This would not be ideal; rotoscale() should never be called in conditional branches where angle = 0 anyway.
 
@@ -607,12 +607,12 @@ bool scaleBlitBilinear(byte *dst, const byte *src,
 }
 
 bool rotoscaleBlit(byte *dst, const byte *src,
-                   const uint dstPitch, const uint srcPitch,
-                   const uint dstW, const uint dstH,
-                   const uint srcW, const uint srcH,
-                   const Graphics::PixelFormat &fmt,
-                   const TransformStruct &transform,
-                   const Common::Point &newHotspot) {
+				   const uint dstPitch, const uint srcPitch,
+				   const uint dstW, const uint dstH,
+				   const uint srcW, const uint srcH,
+				   const Graphics::PixelFormat &fmt,
+				   const TransformStruct &transform,
+				   const Common::Point &newHotspot) {
 	if (fmt.bytesPerPixel == 4) {
 		rotoscaleBlitLogic<uint32, false, false, false>(dst, src, dstPitch, srcPitch, dstW, dstH, srcW, srcH, fmt, transform, newHotspot);
 	} else if (fmt.bytesPerPixel == 2) {
@@ -627,12 +627,12 @@ bool rotoscaleBlit(byte *dst, const byte *src,
 }
 
 bool rotoscaleBlitBilinear(byte *dst, const byte *src,
-                           const uint dstPitch, const uint srcPitch,
-                           const uint dstW, const uint dstH,
-                           const uint srcW, const uint srcH,
-                           const Graphics::PixelFormat &fmt,
-                           const TransformStruct &transform,
-                           const Common::Point &newHotspot) {
+						   const uint dstPitch, const uint srcPitch,
+						   const uint dstW, const uint dstH,
+						   const uint srcW, const uint srcH,
+						   const Graphics::PixelFormat &fmt,
+						   const TransformStruct &transform,
+						   const Common::Point &newHotspot) {
 	if (fmt.bytesPerPixel == 4) {
 		rotoscaleBlitLogic<uint32, true, false, false>(dst, src, dstPitch, srcPitch, dstW, dstH, srcW, srcH, fmt, transform, newHotspot);
 	} else if (fmt.bytesPerPixel == 2) {

--- a/graphics/conversion.h
+++ b/graphics/conversion.h
@@ -131,20 +131,20 @@ bool scaleBlitBilinear(byte *dst, const byte *src,
 					   const Graphics::PixelFormat &fmt);
 
 bool rotoscaleBlit(byte *dst, const byte *src,
-                   const uint dstPitch, const uint srcPitch,
-                   const uint dstW, const uint dstH,
-                   const uint srcW, const uint srcH,
-                   const Graphics::PixelFormat &fmt,
-                   const TransformStruct &transform,
-                   const Common::Point &newHotspot);
+				   const uint dstPitch, const uint srcPitch,
+				   const uint dstW, const uint dstH,
+				   const uint srcW, const uint srcH,
+				   const Graphics::PixelFormat &fmt,
+				   const TransformStruct &transform,
+				   const Common::Point &newHotspot);
 
 bool rotoscaleBlitBilinear(byte *dst, const byte *src,
-                           const uint dstPitch, const uint srcPitch,
-                           const uint dstW, const uint dstH,
-                           const uint srcW, const uint srcH,
-                           const Graphics::PixelFormat &fmt,
-                           const TransformStruct &transform,
-                           const Common::Point &newHotspot);
+						   const uint dstPitch, const uint srcPitch,
+						   const uint dstW, const uint dstH,
+						   const uint srcW, const uint srcH,
+						   const Graphics::PixelFormat &fmt,
+						   const TransformStruct &transform,
+						   const Common::Point &newHotspot);
 /** @} */
 } // End of namespace Graphics
 

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -244,7 +244,7 @@ uint32 EventRecorder::getRandomSeed(const Common::String &name) {
 }
 
 Common::String EventRecorder::generateRecordFileName(const Common::String &target) {
-	Common::String pattern(target+".r??");
+	Common::String pattern(target + ".r??");
 	Common::StringArray files = g_system->getSavefileManager()->listSavefiles(pattern);
 	for (int i = 0; i < kMaxRecordsNames; ++i) {
 		Common::String recordName = Common::String::format("%s.r%02d", target.c_str(), i);

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -537,7 +537,6 @@ Common::SeekableReadStream *EventRecorder::processSaveStream(const Common::Strin
 		return saveFile;
 	default:
 		return nullptr;
-		break;
 	}
 }
 

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -373,7 +373,7 @@ bool ThemeEngine::init() {
 void ThemeEngine::clearAll() {
 	if (_initOk) {
 		_system->clearOverlay();
-		_system->grabOverlay(_backBuffer.getPixels(), _backBuffer.pitch);
+		_system->grabOverlay(*_backBuffer.surfacePtr());
 	}
 }
 


### PR DESCRIPTION
Fixed segfault in `EventRecorder` with buffer out of bounds writes
    
```
    ==3124361== Invalid write of size 8
    ==3124361==    at 0x483F803: memmove (vg_replace_strmem.c:1270)
    ==3124361==    by 0x4DBF61: SurfaceSdlGraphicsManager::grabOverlay(void*, int) const (surfacesdl-graphics.cpp:1753)
    ==3124361==    by 0x482051: ModularGraphicsBackend::grabOverlay(void*, int) (modular-backend.cpp:215)
    ==3124361==    by 0x434EE1: GUI::ThemeEngine::clearAll() (ThemeEngine.cpp:376)
    ==3124361==    by 0x40128E: GUI::EventRecorder::preDrawOverlayGui() (EventRecorder.cpp:558)
    ==3124361==    by 0x481DB2: ModularGraphicsBackend::updateScreen() (modular-backend.cpp:173)
    ==3124361==    by 0x559967: Graphics::Screen::updateScreen() (screen.cpp:62)
    ==3124361==    by 0x55991C: Graphics::Screen::update() (screen.cpp:56)
    ==3124361==    by 0x38AFC7: TwinE::TwineScreen::update() (twine.cpp:126)
    ==3124361==    by 0x3B8759: TwinE::Screens::adjustPalette(unsigned char, unsigned char, unsigned char, unsigned int const*, int) (screens.cpp:150)
    ==3124361==    by 0x3B8A89: TwinE::Screens::fadeToPal(unsigned int const*) (screens.cpp:207)
    ==3124361==    by 0x3B8403: TwinE::Screens::loadImage(int, int, bool) (screens.cpp:80)
    ==3124361==  Address 0x31453050 is 16 bytes after a block of size 512,000 alloc'd
    ==3124361==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
    ==3124361==    by 0x55B38C: Graphics::Surface::create(unsigned short, unsigned short, Graphics::PixelFormat const&) (surface.cpp:75)
    ==3124361==    by 0x551111: Graphics::ManagedSurface::create(unsigned short, unsigned short, Graphics::PixelFormat const&) (managed_surface.cpp:153)
    ==3124361==    by 0x4352D5: GUI::ThemeEngine::setGraphicsMode(GUI::ThemeEngine::GraphicsMode) (ThemeEngine.cpp:453)
    ==3124361==    by 0x434A52: GUI::ThemeEngine::init() (ThemeEngine.cpp:324)
    ==3124361==    by 0x43501B: GUI::ThemeEngine::refresh() (ThemeEngine.cpp:394)
    ==3124361==    by 0x405780: GUI::GuiManager::screenChange() (gui-manager.cpp:603)
    ==3124361==    by 0x405C6B: GUI::GuiManager::processEvent(Common::Event const&, GUI::Dialog*) (gui-manager.cpp:677)
    ==3124361==    by 0x404EBA: GUI::GuiManager::runLoop() (gui-manager.cpp:429)
    ==3124361==    by 0x3FD847: GUI::Dialog::runModal() (dialog.cpp:77)
    ==3124361==    by 0x36D747: launcherDialog() (main.cpp:106)
    ==3124361==    by 0x36FF92: scummvm_main (main.cpp:552)
```
    
It looks like the `_videoMode.overlayHeight` in `SurfaceSdlGraphicsManager::grabOverlay` and `ThemeEngine::_backBuffer::h` are somehow out of sync after starting the game in a different resolution as the gui was started with. So the `overlayHeight` is updated - but the `backbuffer` (Surface) is not resized.
    
This is with event recorder being active - right after starting the game and switching the resolution.
