### PR TITLE
COMMON: Introduce BiDi base paragraph directions

### DIFF
--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -132,10 +132,13 @@ String convertBiDiStringByLines(const String &input, const Common::CodePage page
 }
 
 String convertBiDiString(const String &input, const Common::Language lang, BiDiParagraph dir) {
-	if (lang != Common::HE_ISR)		//TODO: modify when we'll support other RTL languages, such as Arabic and Farsi
+	if (lang == Common::HE_ISR) {
+		return Common::convertBiDiString(input, kWindows1255, dir);
+	} else if (lang == Common::FA_IRN) {
+		return Common::convertBiDiString(input, kWindows1256, dir);
+	} else {
 		return input;
-
-	return Common::convertBiDiString(input, kWindows1255, dir);
+	}
 }
 
 String convertBiDiString(const String &input, const Common::CodePage page, BiDiParagraph dir) {

--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -41,12 +41,6 @@ UnicodeBiDiText::UnicodeBiDiText(const Common::U32String &str) :
 	initWithU32String(str);
 }
 
-UnicodeBiDiText::UnicodeBiDiText(const Common::String &str, const Common::CodePage page) :
-	logical(str), _pbase_dir(FRIBIDI_PAR_ON),
-	_log_to_vis_index(NULL), _vis_to_log_index(NULL) {
-	initWithU32String(str.decode(page));
-}
-
 UnicodeBiDiText::UnicodeBiDiText(const Common::String &str, const Common::CodePage page,
 		uint32 *pbase_dir) : logical(str), _log_to_vis_index(NULL), _vis_to_log_index(NULL) {
 	_pbase_dir = *pbase_dir;

--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -26,17 +26,25 @@
 
 #ifdef USE_FRIBIDI
 #include <fribidi/fribidi.h>
-#else
-/* This constant is used below in common code
- * fake it here to lighten code
- */
-#define FRIBIDI_PAR_ON 0
 #endif
 
 namespace Common {
 
-UnicodeBiDiText::UnicodeBiDiText(const Common::U32String &str) :
-	logical(str), _pbase_dir(FRIBIDI_PAR_ON),
+uint32 GetFriBiDiParType(BiDiParagraph dir) {
+#ifdef USE_FRIBIDI
+	if (dir == BIDI_PAR_ON) {
+		return FRIBIDI_PAR_ON;
+	} else if (dir == BIDI_PAR_RTL) {
+		return FRIBIDI_PAR_RTL;
+	} else if (dir == BIDI_PAR_LTR) {
+		return FRIBIDI_PAR_LTR;
+	}
+#endif
+	return 0;
+}
+
+UnicodeBiDiText::UnicodeBiDiText(const Common::U32String &str, BiDiParagraph dir) :
+	logical(str), _pbase_dir(GetFriBiDiParType(dir)),
 	_log_to_vis_index(NULL), _vis_to_log_index(NULL) {
 	initWithU32String(str);
 }
@@ -118,24 +126,24 @@ Common::String bidiByLineHelper(Common::String line, va_list args) {
 	return UnicodeBiDiText(line, page, pbase_dir).visual.encode(page);
 }
 
-String convertBiDiStringByLines(const String &input, const Common::CodePage page) {
-	uint32 pbase_dir = FRIBIDI_PAR_ON;
+String convertBiDiStringByLines(const String &input, const Common::CodePage page, BiDiParagraph dir) {
+	uint32 pbase_dir = GetFriBiDiParType(dir);
 	return input.forEachLine(bidiByLineHelper, page, &pbase_dir);
 }
 
-String convertBiDiString(const String &input, const Common::Language lang) {
+String convertBiDiString(const String &input, const Common::Language lang, BiDiParagraph dir) {
 	if (lang != Common::HE_ISR)		//TODO: modify when we'll support other RTL languages, such as Arabic and Farsi
 		return input;
 
-	return Common::convertBiDiString(input, kWindows1255);
+	return Common::convertBiDiString(input, kWindows1255, dir);
 }
 
-String convertBiDiString(const String &input, const Common::CodePage page) {
-	return convertBiDiU32String(input.decode(page)).visual.encode(page);
+String convertBiDiString(const String &input, const Common::CodePage page, BiDiParagraph dir) {
+	return convertBiDiU32String(input.decode(page), dir).visual.encode(page);
 }
 
-UnicodeBiDiText convertBiDiU32String(const U32String &input) {
-	return UnicodeBiDiText(input);
+UnicodeBiDiText convertBiDiU32String(const U32String &input, BiDiParagraph dir) {
+	return UnicodeBiDiText(input, dir);
 }
 
 } // End of namespace Common

--- a/common/unicode-bidi.h
+++ b/common/unicode-bidi.h
@@ -41,7 +41,6 @@ public:
 	uint32 _pbase_dir;
 
 	UnicodeBiDiText(const Common::U32String &str);
-	UnicodeBiDiText(const Common::String &str, const Common::CodePage page);
 	/* This constructor shouldn't be used outside of unicode-bidi.cpp file */
 	UnicodeBiDiText(const Common::String &str, const Common::CodePage page, uint32 *pbase_dir);
 	~UnicodeBiDiText();

--- a/common/unicode-bidi.h
+++ b/common/unicode-bidi.h
@@ -29,6 +29,15 @@
 
 namespace Common {
 
+/**
+ * List of paragraph directions
+ */
+enum BiDiParagraph {
+	BIDI_PAR_ON = 0,
+	BIDI_PAR_RTL = 1,
+	BIDI_PAR_LTR = 2
+};
+
 class UnicodeBiDiText {
 private:
 	uint32 *_log_to_vis_index; // from fribidi conversion
@@ -40,7 +49,7 @@ public:
 	Common::U32String visual; // from fribidi conversion, ordered visually
 	uint32 _pbase_dir;
 
-	UnicodeBiDiText(const Common::U32String &str);
+	UnicodeBiDiText(const Common::U32String &str, BiDiParagraph dir = BIDI_PAR_ON);
 	/* This constructor shouldn't be used outside of unicode-bidi.cpp file */
 	UnicodeBiDiText(const Common::String &str, const Common::CodePage page, uint32 *pbase_dir);
 	~UnicodeBiDiText();
@@ -56,12 +65,12 @@ public:
 };
 
 /* just call the constructor for convenience */
-UnicodeBiDiText convertBiDiU32String(const U32String &input);
-String convertBiDiString(const String &input, const Common::Language lang);
-String convertBiDiString(const String &input, const Common::CodePage page);
+UnicodeBiDiText convertBiDiU32String(const U32String &input, BiDiParagraph dir = BIDI_PAR_ON);
+String convertBiDiString(const String &input, const Common::Language lang, BiDiParagraph dir = BIDI_PAR_ON);
+String convertBiDiString(const String &input, const Common::CodePage page, BiDiParagraph dir = BIDI_PAR_ON);
 
 // calls convertBiDiString for each line in isolation
-String convertBiDiStringByLines(const String &input, const Common::CodePage page);
+String convertBiDiStringByLines(const String &input, const Common::CodePage page, BiDiParagraph dir = BIDI_PAR_ON);
 
 } // End of namespace Common
 

--- a/engines/wintermute/base/font/base_font_truetype.cpp
+++ b/engines/wintermute/base/font/base_font_truetype.cpp
@@ -277,11 +277,13 @@ BaseSurface *BaseFontTT::renderTextToTexture(const WideString &text, int width, 
 	Common::Array<WideString>::iterator it;
 	int heightOffset = 0;
 	for (it = lines.begin(); it != lines.end(); ++it) {
+		WideString str;
 		if (_gameRef->_textRTL) {
-			_font->drawString(surface, Common::convertBiDiU32String(*it), 0, heightOffset, width, useColor, alignment);
+			str = Common::convertBiDiU32String(*it, Common::BIDI_PAR_RTL);
 		} else {
-			_font->drawString(surface, *it, 0, heightOffset, width, useColor, alignment);
+			str = Common::convertBiDiU32String(*it, Common::BIDI_PAR_LTR);
 		}
+		_font->drawString(surface, str, 0, heightOffset, width, useColor, alignment);
 		heightOffset += (int)_lineHeight;
 	}
 


### PR DESCRIPTION
Some BiDI games require providing exact base paragraph direction for a string.

For example, some Wintermute games are storing BiDi strings as strings that are only displayed correctly with in LTR.
There are 2 possible techniques to fix this - manually adding RTL/LTR Unicode Marks, or using different base paragraph directions.
It seems that current font renderer actually displays "invisible" Unicode Marks, so I selected another way.

This PR adds optional `BiDiParagraph dir = BIDI_PAR_ON` parameter to BiDi constructors and helpers.
Original behavious is provided by default values, desired WME behaviour is provided by other values.

P.S. Results of some experiments with Persian game that is NOT using RTL paragraph direction:
![изображение](https://user-images.githubusercontent.com/5786428/122488237-b40ad000-cfe5-11eb-8e55-3c243865b2e5.png)
