### PR TITLE
GUI: Fix tooltip behavior to be less disruptive

### DIFF
--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -42,6 +42,8 @@ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 
 	_parent = parent;
 
+	setMouseUpdatedOnFocus(false);
+
 	_maxWidth = g_gui.xmlEval()->getVar("Globals.Tooltip.MaxWidth", 100);
 	_xdelta = g_gui.xmlEval()->getVar("Globals.Tooltip.XDelta", 0);
 	_ydelta = g_gui.xmlEval()->getVar("Globals.Tooltip.YDelta", 0);

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -49,6 +49,7 @@ Dialog::Dialog(int x, int y, int w, int h)
 	// started a 640x480 game with a non 1x scaler.
 	g_gui.checkScreenChange();
 
+	_mouseUpdatedOnFocus = true;
 	_result = -1;
 }
 
@@ -66,6 +67,7 @@ Dialog::Dialog(const Common::String &name)
 	// and bug #2903: "SCUMM: F5 crashes game (640x480)"
 	g_gui.checkScreenChange();
 
+	_mouseUpdatedOnFocus = true;
 	_result = -1;
 }
 

--- a/gui/dialog.h
+++ b/gui/dialog.h
@@ -57,6 +57,11 @@ protected:
 	Widget  *_dragWidget;
 	Widget 	*_tickleWidget;
 	bool	_visible;
+	// _mouseUpdatedOnFocus instructs gui-manager whether
+	// its lastMousePosition (time and x,y coordinates)
+	// should be updated, when this Dialog acquires focus.
+	// Default value is true.
+	bool    _mouseUpdatedOnFocus;
 
 	ThemeEngine::DialogBackground _backgroundType;
 
@@ -70,6 +75,8 @@ public:
 	virtual int runModal();
 
 	bool	isVisible() const override	{ return _visible; }
+
+	bool    isMouseUpdatedOnFocus() const { return _mouseUpdatedOnFocus; }
 
 	void	releaseFocus() override;
 	void	setFocusWidget(Widget *widget);
@@ -111,6 +118,7 @@ protected:
 	Widget *findWidget(const char *name);
 	void removeWidget(Widget *widget) override;
 
+	void setMouseUpdatedOnFocus(bool mouseUpdatedOnFocus) { _mouseUpdatedOnFocus = mouseUpdatedOnFocus; }
 	void setDefaultFocusedWidget();
 
 	void setResult(int result) { _result = result; }

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -30,6 +30,7 @@
 #include "common/list.h"
 
 #include "gui/ThemeEngine.h"
+#include "gui/widget.h"
 
 class OSystem;
 
@@ -165,6 +166,13 @@ protected:
 		uint32 time;	// Time
 		int count;	// How often was it already pressed?
 	} _lastClick, _lastMousePosition, _globalMousePosition;
+
+	struct TooltipData {
+		TooltipData() : x(-1), y(-1) { time = 0; wdg = nullptr; }
+		uint32 time; // Time
+		Widget *wdg; // Widget that had its tooltip shown
+		int16 x, y;  // Position of mouse before tooltip was focused
+	} _lastTooltipShown;
 
 	// mouse cursor state
 	int		_cursorAnimateCounter;

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -153,6 +153,8 @@ public:
 	void lostFocus() { _hasFocus = false; lostFocusWidget(); }
 	virtual bool wantsFocus() { return false; }
 
+	uint32 getType() const { return _type; }
+
 	void setFlags(int flags);
 	void clearFlags(int flags);
 	int getFlags() const		{ return _flags; }


### PR DESCRIPTION
This PR is a more proper fix to the issue that my previous (now closed) PRs were addressing:
(https://github.com/scummvm/scummvm/pull/3055, https://github.com/scummvm/scummvm/pull/3057)

The tooltip will show only if mouse cursor was moved but not on a hovered focused editText field

Changes and implications in this commit:
- Fix _lastMousePosition coordinates and time being changed upon giving focus to the tooltip. They now will not (specifically for "focusing" on a Tooltip).
- Check for mouse cursor movement first in the decision for showing the tooltip, then check if sufficient time for mouse resting position has passed (kTooltipDelay).
- Prevent showing a tooltip for a widget if it is an editable field (editText) and has both mouse hovering above it and the current focus. This is so that typing text is not interrupted / slowed down by a periodical display of the tooltip, if the mouse is hovering over the same text field that the user is editing.
- If mouse cursor is moved but lands on the same widget as the one that had its tooltip shown last, then show the tooltip but after a different (larger) delay kTooltipSameWidgetDelay.
- Still shows tooltip for other widgets, including editText ones, if the mouse is hovered over them and they are not the current focused editText widget.

Minor caveats with this PR:
1. Since we now check based on _lastTooltipShown x,y coordinates, then if mouse is moved but cursor lands back at the exact same coordinates, it will not be detected as "movement" as far as the tooltip check is concerned. However, practically this barely has any significance. The user can slightly move the mouse cursor and the tooltip will be displayed.
2. We don't show the tooltip for the *focused* editText. The tooltip can be shown if the cursor is hovering on top of the unfocused editText widget, but not after user clicks on it, setting the focus to it (and presumably starts writing in it) -- not until that widget is unfocused again.

The bug was mentioned for the Android port on the forums here:
https://forums.scummvm.org/viewtopic.php?p=95531#p95531
However, it is not Android specific, even though the slowdown is a lot more noticeable on an Android device.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
