### PR TITLE
RFC: Use custom matcher for games list

### DIFF
--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -124,6 +124,7 @@ Example of a configuration file
     path=C:\amiga_mi2\
     music_driver=windows
 
+.. _configuration_keys:
 
 Configuration keys
 =====================

--- a/doc/docportal/advanced_topics/understand_search_box.rst
+++ b/doc/docportal/advanced_topics/understand_search_box.rst
@@ -1,0 +1,137 @@
+======================================================
+Understanding the search box
+======================================================
+
+This guide expands on the information contained on the :ref:`The search box <search_box>` section of the Launcher interface description.
+
+
+Main functionality
+===========================================
+
+The filter is applied as you type, there is no need to press Enter or click anything to perform the search.
+
+All searchs are case insensitive, there is no way to force the case sensitive search.
+
+To reset the filter and get the full list of games, you could click on a cross icon on the right.
+
+
+Search patterns
+===========================================
+
+Whitespace breaks the search input into separate tokens, search patterns. 
+
+Simple patterns
+___________________________________________
+
+If search pattern does not contain ``:``/``=``/``~`` characters and it does not start with ``!`` character, then it's used for a case insensitive substring search.
+
+For example, if you type ``m`` you would get all the games containing letter 'M' in description.
+
+If you type ``monkey``, you would get games like "The Curse of Monkey Island (Demo/Windows)", "Infinite Monkeys", "Three Monkeys, One Cage", etc.
+
+This is what you need in most simple cases, but is not enough to search for more complex things.
+
+Let's search the configuration key's values
+___________________________________________
+
+Game properties listed at :doc:`configuration_file` can be checked with the filter as well.
+
+Advanced patterns
+*******************************************
+
+There are currently 3 types of patterns, that can be used for accessing configuration file:
+
+.. csv-table::
+  	:header-rows: 1
+	:class: config
+
+		Type,Description,Example,Example result
+		"<key>=<value>", check exact value of ``<key>``, ``gameid=reversion2``, games with exact gameid "reversion2"
+		"<key>:<value>", search substring at ``<key>``, ``description::``, games with ":" substring at description
+		"<key>~<value>", match wildcard against ``<key>``, ``path~D:\\games\\*``, games located at Windows folder D:\\Games\\
+
+Available configuration keys
+*******************************************
+
+.. note::
+
+	The ``\`` character used at Windows paths should be escaped as ``\\`` when using wildcards.
+
+You can use any :ref:`configuration_keys` as a ``<key>`` part of the search pattern.
+
+Here are some more examples:
+
+- ``show_fps=true`` - games with "Show FPS" option set to true
+- ``extra~?*`` - games with non-empty extra part of the description
+- ``guioptions:noLang`` - games without displayed language
+- ``keymap_engine-default_LCLK:MOUSE_RIGHT`` - games with right mouse button remapped to left mouse button
+
+Abbrivating configuration keys
+*******************************************
+
+Some common used configuration keys can be abbrivated, just type any prefix instead of full strings for those 6 keys:
+
+.. csv-table::
+  	:header-rows: 1
+	:class: config
+
+		Full key,Description,Examples
+		``description``, game description as displayed at the game list,"
+
+	- ``d:monkey``
+	- ``desc:monkey``
+	- ``descr:monkey``
+	- ``description:monkey``"
+		``engineid``, internal ID of the game engine,"
+
+	- ``e:ags``
+	- ``engine:monkey``
+	- ``engineed:monkey``"
+		``gameid``, internal ID of the game,"
+
+	- ``g:monkey``
+	- ``game:monkey``
+	- ``gameid:monkey``"
+		``language``, internal ID of the language (usually 2 letter code like "de"/"en"/"fr"/"jp"/etc),"
+
+	- ``l=en``
+	- ``lang=en``
+	- ``language=en``"
+		``path``, Filesystem path for the game,"
+
+	- ``p~D:*``
+	- ``path~D:*``"
+		``path``, Filesystem path for the game,"
+
+	- ``pl~windows``
+	- ``platform~windows``"
+
+.. note::
+
+	The ``platform`` key can't be abbrivated to ``p``, since ``p`` is already used for ``path``.
+
+
+Inverting any search pattern
+___________________________________________
+
+Prefixing search pattern with `!` character inverts the result:
+
+- ``!GOG`` - games that don't contain "GOG" substring in description
+- ``!lang=ru`` - games not in Russian languange
+- ``!p:demo`` - games that don't have "demo" substring in game path
+- ``!engine~sword#`` - games not made with "sword1" and "sword2" engines (but "sword25" is fine)
+
+
+How do the search patterns work together?
+===========================================
+
+If you have provided several search patterns, only games that match all of them are displayed.
+
+The matches are independent and not ordered, which means that when you are looking for ``Monkey Island``, you would get all the games with words "Monkey" and "Island" in description. Note that imaginary titles like "My Island with some Monkeys" would also be displayed.
+
+Here are some more examples of complex requests:
+
+- ``engine=ags path:steamapps !extra:Steam`` - AGS games at your /SteamApps/ folder, but not marked as Steam game at "extra"
+- ``e=wintermute l=`` - Wintermute games with empty "language" property
+- ``pl:dos lang=he desc~a*`` - Hebrew games for DOS with description starting with letter "A"
+

--- a/doc/docportal/index.rst
+++ b/doc/docportal/index.rst
@@ -51,6 +51,7 @@
       advanced_topics/configuration_file
       advanced_topics/understand_audio
       advanced_topics/understand_graphics
+      advanced_topics/understand_search_box
 
 .. toctree::
       :caption: Help

--- a/doc/docportal/use_scummvm/the_launcher.rst
+++ b/doc/docportal/use_scummvm/the_launcher.rst
@@ -17,13 +17,14 @@ The games list
 
 The pane on the left is the games list, which lists all the games that have been added to ScummVM. The games list usually offers some additional information about each game, such as original platform and language. To highlight any game on the list, type the first letter(s) of its title, or click on it.
 
+.. _search_box:
 
 The search box
 ********************
 
 The search box lets you filter the games list. It is located at the top of the page next to the magnifying glass icon. The filter is applied as you type, and is not case sensitive. To clear the filter, click **X**.
 
-There are many ways to filter games. For example, you can type "Monkey Island" to locate all "Monkey Island" games on the list, or you can type "German" to find German games.
+There are many ways to filter games. For example, you can type "Monkey Island" to locate all "Monkey Island" games on the list, or you can type "lang:de" to find German games. For a comprehensive look at how to use the search box, check out our :doc:`../advanced_topics/understand_search_box` guide.  
 
 The buttons
 ************************

--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -56,6 +56,7 @@ public:
 	void handleKeyUp(Common::KeyState state) override;
 	void handleOtherEvent(const Common::Event &evt) override;
 	bool doGameDetection(const Common::String &path);
+	Common::String getGameConfig(int item, Common::String key);
 protected:
 	EditTextWidget  *_searchWidget;
 	ListWidget		*_list;

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -33,6 +33,10 @@
 
 namespace GUI {
 
+bool ListWidgetDefaultMatcher(void *, int, const Common::U32String &item, Common::U32String token) {
+	return item.contains(token);
+}
+
 ListWidget::ListWidget(Dialog *boss, const String &name, const U32String &tooltip, uint32 cmd)
 	: EditableWidget(boss, name, tooltip), _cmd(cmd) {
 
@@ -61,6 +65,9 @@ ListWidget::ListWidget(Dialog *boss, const String &name, const U32String &toolti
 	_quickSelect = true;
 	_editColor = ThemeEngine::kFontColorNormal;
 	_dictionarySelect = false;
+
+	_filterMatcher = ListWidgetDefaultMatcher;
+	_filterMatcherArg = nullptr;
 
 	_lastRead = -1;
 
@@ -97,6 +104,9 @@ ListWidget::ListWidget(Dialog *boss, int x, int y, int w, int h, const U32String
 	_quickSelect = true;
 	_editColor = ThemeEngine::kFontColorNormal;
 	_dictionarySelect = false;
+
+	_filterMatcher = ListWidgetDefaultMatcher;
+	_filterMatcherArg = nullptr;
 
 	_lastRead = -1;
 
@@ -748,8 +758,7 @@ void ListWidget::setFilter(const U32String &filter, bool redraw) {
 		_list = _dataList;
 		_listIndex.clear();
 	} else {
-		// Restrict the list to everything which contains all words in _filter
-		// as substrings, ignoring case.
+		// Restrict the list to everything which matches all tokens in _filter, ignoring case.
 
 		Common::U32StringTokenizer tok(_filter);
 		U32String tmp;
@@ -764,7 +773,7 @@ void ListWidget::setFilter(const U32String &filter, bool redraw) {
 			bool matches = true;
 			tok.reset();
 			while (!tok.empty()) {
-				if (!tmp.contains(tok.nextToken())) {
+				if (!_filterMatcher(_filterMatcherArg, n, tmp, tok.nextToken())) {
 					matches = false;
 					break;
 				}

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -56,6 +56,8 @@ public:
 	typedef Common::Array<Common::U32String> U32StringArray;
 
 	typedef Common::Array<ThemeEngine::FontColor> ColorList;
+	
+	typedef bool (*FilterMatcher)(void *arg, int idx, const Common::U32String &item, Common::U32String token);
 protected:
 	U32StringArray	_list;
 	U32StringArray		_dataList;
@@ -91,6 +93,9 @@ protected:
 
 	int				_lastRead;
 
+	FilterMatcher	_filterMatcher;
+	void			*_filterMatcherArg;
+
 public:
 	ListWidget(Dialog *boss, const String &name, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	ListWidget(Dialog *boss, int x, int y, int w, int h, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
@@ -123,6 +128,7 @@ public:
 	bool isEditable() const						{ return _editable; }
 	void setEditable(bool editable)				{ _editable = editable; }
 	void setEditColor(ThemeEngine::FontColor color) { _editColor = color; }
+	void setFilterMatcher(FilterMatcher matcher, void *arg) { _filterMatcher = matcher; _filterMatcherArg = arg; }
 
 	// Made startEditMode/endEditMode for SaveLoadChooser
 	void startEditMode() override;


### PR DESCRIPTION
This PR extends filter of games list to use some simple google-like syntax.

Filter is split into tokens, each token are checked separately, if any token does not match a game, it's filtered out.

Oldfashioned requests are still supported with tokens without ":", "=", "~":
* `Hamlet Hungarian` - games that have "Hamlet" and "Hungarian" substrings in description

Three kinds of property checkers added:
* "=" is used to check exact value of something, e.g. `gameid=reversion2` - games with exact gameid match
* ":" is used to search substring at something, e.g. `description::` - games with ":" substring at description
* "~" is used to match wildcard against something, e.g. `path:D:\\games\\*` - games at Windows folder D:\Games\

6 properties can be abbrivated:
* For "description" you can use "d", "de", ... "description"
* For "engineid" you can use "e", "en", ... "engineid"
* For "gameid" you can use "g", "ga", ... "gameid"
* For "language" you can use "l", "la", ... "language"
* For "path" you can use "p", "pa", "pat", "path"
* For "platform" you can use "pl", ... "platform"

Any other property can be checked as well:
* `guioptions:noLang` - games with "noLang" option at "guioptions" property of ConfMan
* `extra~?*` - games with non-empty "extra" property of ConfMan

"!" inverts token result:
* `!GOG` - games that don't contain "GOG" substring in description
* `!lang=ru` - games not in Russian languange
* `!p:demo` - games that don't have "demo" substring in game path
* `!engine~sword#` - games not made with sword1 and sword2 engines

Let's try it alltogether:
* `engine=ags path:steamapps !extra:Steam` - AGS games at /SteamApps/ folder not marked as Steam game at "extra"
* `e=wintermute l=` - Wintermute games with empty "language" property
* `pl:dos lang=he desc~a*` - Hebrew games for DOS with description starting with letter "A"

Current grammar is something like this;
```
FILTER = TOKEN [ WHITESPACE TOKEN ]*
TOKEN = "!"* ( SUBSTRING | GAMEPROPERTY )
GAMEPROPERTY = PROPERTY ( ":" | "=" | "~" ) FILTER
SUBSTRING = string of characters without ":", "=", "~", does not starts with "!"
PROPERTY = string of characters without ":", "=", "~", does not starts with "!"
FILTER = string of any characters
```

Obligatory screenshot:
![изображение](https://user-images.githubusercontent.com/5786428/122655262-c4dc5280-d159-11eb-81d9-eb1c597260a1.png)
