### PR TITLE
COMMON: Fix BASESTRING::contains()

### DIFF
--- a/common/base-str.cpp
+++ b/common/base-str.cpp
@@ -422,6 +422,7 @@ TEMPLATE bool BASESTRING::contains(const BaseString &otherString) const {
 			if (sizeMatch == otherString.size())
 				return true;
 		} else {
+			itr2 -= sizeMatch;
 			sizeMatch = 0;
 			itr = otherString.begin();
 		}

--- a/common/base-str.cpp
+++ b/common/base-str.cpp
@@ -412,19 +412,18 @@ TEMPLATE bool BASESTRING::contains(const BaseString &otherString) const {
 		return false;
 	}
 
-	uint32 sizeMatch = 0;
-	typename BASESTRING::const_iterator itr = otherString.begin();
-
-	for (typename BASESTRING::const_iterator itr2 = begin(); itr != otherString.end() && itr2 != end(); itr2++) {
-		if (*itr == *itr2) {
-			itr++;
-			sizeMatch++;
-			if (sizeMatch == otherString.size())
+	for (const_iterator cur = begin(); cur != end(); ++cur) {
+		uint i = 0;
+		while (true) {
+			if (i == otherString.size()) {
 				return true;
-		} else {
-			itr2 -= sizeMatch;
-			sizeMatch = 0;
-			itr = otherString.begin();
+			}
+
+			if (cur[i] != otherString[i]) {
+				break;
+			}
+
+			++i;
 		}
 	}
 


### PR DESCRIPTION
There is a mistake in current `contains()` implementation - it does not backtrack after partial match, which causing wrong results.
For example, with current implementation word "Russian" contains "ssian", but does not contain "si".

This PR fixes this, however it proposes the simpliest algorithm possible.
Do we need something more clever and efficient here?