### PR TITLE
GUI: If GraphicsWidget is hidden do not proceed with setGfx()

### DIFF
--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -630,7 +630,7 @@ void PicButtonWidget::setGfx(int w, int h, int r, int g, int b, int statenum) {
 	_gfx[statenum].free();
 
 	if (!isVisible() || !_boss->isVisible())
-	return;
+		return;
 
 	if (w == -1)
 		w = _w;
@@ -919,7 +919,7 @@ void GraphicsWidget::setGfx(int w, int h, int r, int g, int b) {
 	_gfx.free();
 
 	if (!isVisible() || !_boss->isVisible())
-	return;
+		return;
 
 	if (w == -1)
 		w = _w;

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -880,6 +880,9 @@ void GraphicsWidget::setGfx(const Graphics::ManagedSurface *gfx, bool scale) {
 		return;
 	}
 
+	if (!isVisible())
+		return;
+
 	float sf = g_gui.getScaleFactor();
 	if (scale && sf != 1.0) {
 		_w = gfx->w * sf;

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -598,6 +598,9 @@ void PicButtonWidget::setGfx(const Graphics::ManagedSurface *gfx, int statenum, 
 		return;
 	}
 
+	if (!isVisible() || !_boss->isVisible())
+		return;
+
 	float sf = g_gui.getScaleFactor();
 	if (scale && sf != 1.0) {
 		Graphics::Surface *tmp2 = gfx->rawSurface().scale(gfx->w * sf, gfx->h * sf, false);
@@ -624,6 +627,11 @@ void PicButtonWidget::setGfxFromTheme(const char *name, int statenum, bool scale
 }
 
 void PicButtonWidget::setGfx(int w, int h, int r, int g, int b, int statenum) {
+	_gfx[statenum].free();
+
+	if (!isVisible() || !_boss->isVisible())
+	return;
+
 	if (w == -1)
 		w = _w;
 	if (h == -1)
@@ -631,7 +639,6 @@ void PicButtonWidget::setGfx(int w, int h, int r, int g, int b, int statenum) {
 
 	const Graphics::PixelFormat &requiredFormat = g_gui.theme()->getPixelFormat();
 
-	_gfx[statenum].free();
 	_gfx[statenum].create(w, h, requiredFormat);
 	_gfx[statenum].fillRect(Common::Rect(0, 0, w, h), _gfx[statenum].format.RGBToColor(r, g, b));
 }
@@ -880,7 +887,7 @@ void GraphicsWidget::setGfx(const Graphics::ManagedSurface *gfx, bool scale) {
 		return;
 	}
 
-	if (!isVisible())
+	if (!isVisible() || !_boss->isVisible())
 		return;
 
 	float sf = g_gui.getScaleFactor();
@@ -909,6 +916,11 @@ void GraphicsWidget::setGfx(const Graphics::Surface *gfx, bool scale) {
 }
 
 void GraphicsWidget::setGfx(int w, int h, int r, int g, int b) {
+	_gfx.free();
+
+	if (!isVisible() || !_boss->isVisible())
+	return;
+
 	if (w == -1)
 		w = _w;
 	if (h == -1)
@@ -916,7 +928,6 @@ void GraphicsWidget::setGfx(int w, int h, int r, int g, int b) {
 
 	const Graphics::PixelFormat &requiredFormat = g_gui.theme()->getPixelFormat();
 
-	_gfx.free();
 	_gfx.create(w, h, requiredFormat);
 	_gfx.fillRect(Common::Rect(0, 0, w, h), _gfx.format.RGBToColor(r, g, b));
 }


### PR DESCRIPTION
Removes interfering invisible thumbnail with list item selection in saveload-dialog (OpenGL, large scale)

This issue is more apparent at least on the Android port, which uses OpenGL rendering and may default to large scale mode. It is not Android specific, though. It can be observed on the Windows builds too.

In large scale mode, ScummVM's Load/Save dialogue screen displays only a list of the saved game entries. No thumbnail is shown when selecting an entry -- the space at the right for thumbnail, playtime and save datetime is removed/hidden. However, in that Large scale mode, before this fix, when selecting an item entry from the list, the SaveLoadChooserSimple::updateSelection() method would be called, and eventually _gfxWidget->setGfx(thumb, true), which essentially would create a region overlayed on top of part of the list (aligned top left) for the (invisible) thumbnail. This new region would then "block" the list from receiving mouse down events when clicking on that part of the list, since the dialogue would detect the _gfxWidget instead and send the "mouse down" to that. The result would be clicks and double clicks not being registered for the list. 

Here's a recent forum post that reports the same issue -- for libretro core build, but essentially it is the same bug and the user provides a video showcasing the issue. 
https://forums.scummvm.org/viewtopic.php?f=2&t=16310

I'm issuing this as a PR because I'm unsure if this fix is ok, since it affects all GraphicsWidget objects, not just the one for thumbnail in saveload-dialog. **Edit**: I've also added the same check in other setGfx() methods in widget.cpp that seemed to be relevant / prone to similar issues with rogue invisible widgets being overlayed over other widgets and "stealing" clicks.

Note, that an alternative fix, which also works, would be to only modify gui/saveload-dialog.cpp and method SaveLoadChooserSimple::updateSelection(), to check for _gfxWidget isVisible status before calling: _gfxWidget->setGfx(thumb, true);

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
