### PR TITLE
RFC: Allowing music players to use the Mixer mutex

### DIFF
--- a/audio/mixer.h
+++ b/audio/mixer.h
@@ -23,6 +23,7 @@
 #ifndef AUDIO_MIXER_H
 #define AUDIO_MIXER_H
 
+#include "common/mutex.h"
 #include "common/types.h"
 #include "common/noncopyable.h"
 
@@ -94,6 +95,10 @@ public:
 	 */
 	virtual bool isReady() const = 0;
 
+	/**
+	 * Return the mixer's internal mutex so that audio players can use it.
+	 */
+	virtual Common::Mutex &mutex() = 0;
 
 	/**
 	 * Start playing the given audio stream.

--- a/audio/mixer_intern.h
+++ b/audio/mixer_intern.h
@@ -86,6 +86,8 @@ public:
 
 	virtual bool isReady() const { Common::StackLock lock(_mutex); return _mixerReady; }
 
+	virtual Common::Mutex &mutex() { return _mutex; }
+
 	virtual void playStream(
 		SoundType type,
 		SoundHandle *handle,

--- a/engines/scumm/players/player_ad.cpp
+++ b/engines/scumm/players/player_ad.cpp
@@ -35,8 +35,8 @@ namespace Scumm {
 
 #define AD_CALLBACK_FREQUENCY 472
 
-Player_AD::Player_AD(ScummEngine *scumm)
-	: _vm(scumm) {
+Player_AD::Player_AD(ScummEngine *scumm, Common::Mutex &mutex)
+	: _vm(scumm), _mutex(mutex) {
 	_opl2 = OPL::Config::create();
 	if (!_opl2->init()) {
 		error("Could not initialize OPL2 emulator");

--- a/engines/scumm/players/player_ad.h
+++ b/engines/scumm/players/player_ad.h
@@ -41,7 +41,7 @@ class ScummEngine;
  */
 class Player_AD : public MusicEngine {
 public:
-	Player_AD(ScummEngine *scumm);
+	Player_AD(ScummEngine *scumm, Common::Mutex &mutex);
 	~Player_AD() override;
 
 	// MusicEngine API
@@ -59,7 +59,7 @@ public:
 
 private:
 	ScummEngine *const _vm;
-	Common::Mutex _mutex;
+	Common::Mutex &_mutex;
 
 	void setupVolume();
 	int _musicVolume;

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2095,7 +2095,7 @@ void ScummEngine::setupMusic(int midi, const Common::String &macInstrumentFile) 
 		// EGA/VGA. However, we support multi MIDI for that game and we cannot
 		// support this with the Player_AD code at the moment. The reason here
 		// is that multi MIDI is supported internally by our iMuse output.
-		_musicEngine = new Player_AD(this);
+		_musicEngine = new Player_AD(this, _mixer->mutex());
 #ifdef ENABLE_HE
 	} else if (_game.platform == Common::kPlatformDOS && _sound->_musicType == MDT_ADLIB && _game.heversion >= 60) {
 		_musicEngine = new Player_HE(this);


### PR DESCRIPTION
This experiment was prompted by https://bugs.scummvm.org/ticket/12649 but also https://bugs.scummvm.org/ticket/12617

It seems that it's quite easy to accidentally cause deadlocks in various music players, and one of the causes seem to be that the mixer and music player tend to have one mutex each. So would it be safer if the music player had access to the mixer's mutex? This is a proof-of-concept branch where I've added a mutex() method to the Mixer to get its mutex, and then use that in the Player_AD music player.

Is this a good idea or not? It would - at least in theory - apply to a lot of other music players, of course.