### PR TITLE
DIRECTOR: speed up transitions for debugFast

### DIFF
--- a/engines/director/transitions.cpp
+++ b/engines/director/transitions.cpp
@@ -1052,6 +1052,11 @@ void Window::initTransParams(TransParams &t, Common::Rect &clipRect) {
 		h = (h + 1) >> 1;
 	}
 
+	// If we requested fast transitions, speed everything up
+	// Ensure the chunksize isn't larger than the amount of pixels.
+	if (debugChannelSet(-1, kDebugFast))
+		t.chunkSize = MIN(m, (int) t.chunkSize*16);
+
 	switch (transProps[t.type].dir) {
 	case kTransDirHorizontal:
 		t.steps = w / t.chunkSize;


### PR DESCRIPTION
The number of steps a transition has is calculated based on the
chunksize. A larger chunksize means quicker execution with a downside
of not having pixel perfect frames.

This is only enabled when the debugflag is used.