### PR TITLE
EVENTRECORDER: fixes for keymapper custom engine events

### DIFF
--- a/backends/cloud/cloudicon.cpp
+++ b/backends/cloud/cloudicon.cpp
@@ -75,12 +75,12 @@ CloudIcon::Type CloudIcon::getShownType() const {
 }
 
 bool CloudIcon::needsUpdate() const {
-	uint32 delaySinceLastUpdate = g_system->getMillis() - _lastUpdateTime;
+	uint32 delaySinceLastUpdate = g_system->getMillis(true) - _lastUpdateTime;
 	return delaySinceLastUpdate >= UPDATE_DELAY_MIN_MILLIS;
 }
 
 void CloudIcon::update() {
-	uint32 currentTime = g_system->getMillis();
+	uint32 currentTime = g_system->getMillis(true);
 	uint32 delaySinceLastUpdate = currentTime - _lastUpdateTime;
 	_lastUpdateTime = currentTime;
 

--- a/backends/keymapper/keymapper.cpp
+++ b/backends/keymapper/keymapper.cpp
@@ -427,7 +427,7 @@ bool DelayedEventSource::pollEvent(Event &event) {
 		return false;
 	}
 
-	uint32 now = g_system->getMillis();
+	uint32 now = g_system->getMillis(true);
 
 	if (now >= _delayedEffectiveTime) {
 		event = _delayedEvents.pop().event;

--- a/common/events.cpp
+++ b/common/events.cpp
@@ -71,6 +71,8 @@ void EventDispatcher::dispatch() {
 	dispatchPoll();
 
 	for (List<SourceEntry>::iterator i = _sources.begin(); i != _sources.end(); ++i) {
+		if (i->ignore)
+			continue;
 		while (i->source->pollEvent(event)) {
 			// We only try to process the events via the setup event mapper, when
 			// we have a setup mapper and when the event source allows mapping.
@@ -102,6 +104,8 @@ void EventDispatcher::clearEvents() {
 	Event event;
 
 	for (List<SourceEntry>::iterator i = _sources.begin(); i != _sources.end(); ++i) {
+		if (i->ignore)
+			continue;
 		while (i->source->pollEvent(event)) {}
 	}
 }
@@ -117,6 +121,7 @@ void EventDispatcher::registerSource(EventSource *source, bool autoFree) {
 
 	newEntry.source = source;
 	newEntry.autoFree = autoFree;
+	newEntry.ignore = false;
 
 	_sources.push_back(newEntry);
 }
@@ -130,6 +135,12 @@ void EventDispatcher::unregisterSource(EventSource *source) {
 			_sources.erase(i);
 			return;
 		}
+	}
+}
+
+void EventDispatcher::ignoreSources(bool ignore) {
+	for (List<SourceEntry>::iterator i = _sources.begin(); i != _sources.end(); ++i) {
+		i->ignore = ignore;
 	}
 }
 

--- a/common/events.h
+++ b/common/events.h
@@ -403,6 +403,12 @@ public:
 	void unregisterSource(EventSource *source);
 
 	/**
+	 * Ignore some event sources and don't poll them. This is useful for e.g. the EventRecorder
+	 * where you don't want the other EventSource instances to interfer with the serialized events.
+	 */
+	void ignoreSources(bool ignore);
+
+	/**
 	 * Register a new EventObserver with the Dispatcher.
 	 *
 	 * @param listenPolls If set, then all pollEvent() calls are passed to the observer.
@@ -421,6 +427,7 @@ private:
 
 	struct Entry {
 		bool autoFree;
+		bool ignore;
 	};
 
 	struct SourceEntry : public Entry {

--- a/common/osd_message_queue.cpp
+++ b/common/osd_message_queue.cpp
@@ -47,7 +47,7 @@ void OSDMessageQueue::addMessage(const Common::U32String &msg) {
 bool OSDMessageQueue::pollEvent(Common::Event &event) {
 	_mutex.lock();
 	if (!_messages.empty()) {
-		uint t = g_system->getMillis();
+		uint t = g_system->getMillis(true);
 		if (t - _lastUpdate >= kMinimumDelay) {
 			_lastUpdate = t;
 			Common::U32String msg = _messages.pop();

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -319,9 +319,19 @@ bool PlaybackFile::readSaveRecord() {
 	return true;
 }
 
-
+bool PlaybackFile::hasNextEvent() const {
+	if (_readStream->err()) {
+		return false;
+	}
+	return !_readStream->eos();
+}
 
 RecorderEvent PlaybackFile::getNextEvent() {
+	if (!hasNextEvent()) {
+		debug(3, "end of recorder file reached.");
+		g_system->quit();
+	}
+
 	assert(_mode == kRead);
 	if (isEventsBufferEmpty()) {
 		PlaybackFile::ChunkHeader header;

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -370,6 +370,8 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 		event.type = (EventType)_tmpPlaybackFile.readUint32LE();
 		switch (event.type) {
 		case EVENT_KEYDOWN:
+			event.kbdRepeat = _tmpPlaybackFile.readByte();
+			// fallthrough
 		case EVENT_KEYUP:
 			event.time = _tmpPlaybackFile.readUint32LE();
 			event.kbd.keycode = (KeyCode)_tmpPlaybackFile.readSint32LE();
@@ -392,6 +394,21 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 			event.time = _tmpPlaybackFile.readUint32LE();
 			event.mouse.x = _tmpPlaybackFile.readSint16LE();
 			event.mouse.y = _tmpPlaybackFile.readSint16LE();
+			break;
+		case EVENT_CUSTOM_BACKEND_ACTION_START:
+		case EVENT_CUSTOM_BACKEND_ACTION_END:
+		case EVENT_CUSTOM_ENGINE_ACTION_START:
+		case EVENT_CUSTOM_ENGINE_ACTION_END:
+			event.time = _tmpPlaybackFile.readUint32LE();
+			event.customType = _tmpPlaybackFile.readUint32LE();
+			break;
+		case EVENT_JOYAXIS_MOTION:
+		case EVENT_JOYBUTTON_UP:
+		case EVENT_JOYBUTTON_DOWN:
+			event.time = _tmpPlaybackFile.readUint32LE();
+			event.joystick.axis = _tmpPlaybackFile.readByte();
+			event.joystick.button = _tmpPlaybackFile.readByte();
+			event.joystick.position = _tmpPlaybackFile.readSint16LE();
 			break;
 		default:
 			event.time = _tmpPlaybackFile.readUint32LE();
@@ -529,6 +546,8 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 		_tmpRecordFile.writeUint32LE((uint32)event.type);
 		switch(event.type) {
 		case EVENT_KEYDOWN:
+			_tmpRecordFile.writeByte(event.kbdRepeat);
+			// fallthrough
 		case EVENT_KEYUP:
 			_tmpRecordFile.writeUint32LE(event.time);
 			_tmpRecordFile.writeSint32LE(event.kbd.keycode);
@@ -551,6 +570,21 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 			_tmpRecordFile.writeUint32LE(event.time);
 			_tmpRecordFile.writeSint16LE(event.mouse.x);
 			_tmpRecordFile.writeSint16LE(event.mouse.y);
+			break;
+		case EVENT_CUSTOM_BACKEND_ACTION_START:
+		case EVENT_CUSTOM_BACKEND_ACTION_END:
+		case EVENT_CUSTOM_ENGINE_ACTION_START:
+		case EVENT_CUSTOM_ENGINE_ACTION_END:
+			_tmpRecordFile.writeUint32LE(event.time);
+			_tmpRecordFile.writeUint32LE(event.customType);
+			break;
+		case EVENT_JOYAXIS_MOTION:
+		case EVENT_JOYBUTTON_UP:
+		case EVENT_JOYBUTTON_DOWN:
+			_tmpRecordFile.writeUint32LE(event.time);
+			_tmpRecordFile.writeByte(event.joystick.axis);
+			_tmpRecordFile.writeByte(event.joystick.button);
+			_tmpRecordFile.writeSint16LE(event.joystick.position);
 			break;
 		default:
 			_tmpRecordFile.writeUint32LE(event.time);

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -415,7 +415,7 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 		}
 		break;
 	}
-	event.kbdRepeat = true;
+	debug(3, "read event of type: %i (time: %u, systemmillis: %u)", event.type, event.time, g_system->getMillis(true));
 }
 
 void PlaybackFile::readEventsToBuffer(uint32 size) {
@@ -594,6 +594,7 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 	if (_recordCount == kMaxBufferedRecords) {
 		dumpRecordsToFile();
 	}
+	debug(3, "write event of type: %i (time: %u, systemmillis: %u)", event.type, event.time, g_system->getMillis(true));
 }
 
 void PlaybackFile::writeGameSettings() {

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -112,7 +112,6 @@ void PlaybackFile::close() {
 }
 
 bool PlaybackFile::parseHeader() {
-	PlaybackFileHeader result;
 	ChunkHeader nextChunk;
 	_playbackParseState = kFileStateCheckFormat;
 	if (!readChunkHeader(nextChunk)) {

--- a/common/recorderfile.h
+++ b/common/recorderfile.h
@@ -127,6 +127,7 @@ public:
 	bool openRead(const String &fileName);
 	void close();
 
+	bool hasNextEvent() const;
 	RecorderEvent getNextEvent();
 	void writeEvent(const RecorderEvent &event);
 

--- a/engines/twine/input.cpp
+++ b/engines/twine/input.cpp
@@ -138,10 +138,12 @@ void Input::processCustomEngineEventStart(const Common::Event &event) {
 	} else {
 		actionStates[event.customType] = 1 + event.kbdRepeat;
 	}
+	debug(3, "twine custom event type start: %i", event.customType);
 }
 
 void Input::processCustomEngineEventEnd(const Common::Event &event) {
 	actionStates[event.customType] = 0;
+	debug(3, "twine custom event type end: %i", event.customType);
 }
 
 void Input::readKeys() {

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -107,7 +107,9 @@ void EventRecorder::deinit() {
 	_controlPanel->close();
 	delete _controlPanel;
 	debugC(1, kDebugLevelEventRec, "playback:action=stopplayback");
-	g_system->getEventManager()->getEventDispatcher()->unregisterSource(this);
+	Common::EventDispatcher *eventDispater = g_system->getEventManager()->getEventDispatcher();
+	eventDispater->unregisterSource(this);
+	eventDispater->ignoreSources(false);
 	_recordMode = kPassthrough;
 	_playbackFile->close();
 	delete _playbackFile;
@@ -271,8 +273,11 @@ void EventRecorder::init(const Common::String &recordFileName, RecordMode mode) 
 	}
 	if (_recordMode == kRecorderPlayback) {
 		debugC(1, kDebugLevelEventRec, "playback:action=\"Load file\" filename=%s", recordFileName.c_str());
+		Common::EventDispatcher *eventDispater = g_system->getEventManager()->getEventDispatcher();
+		eventDispater->clearEvents();
+		eventDispater->ignoreSources(true);
+		eventDispater->registerSource(this, false);
 	}
-	g_system->getEventManager()->getEventDispatcher()->registerSource(this, false);
 	_screenshotPeriod = ConfMan.getInt("screenshot_period");
 	if (_screenshotPeriod == 0) {
 		_screenshotPeriod = kDefaultScreenshotPeriod;
@@ -304,9 +309,8 @@ void EventRecorder::init(const Common::String &recordFileName, RecordMode mode) 
 /**
  * Opens or creates file depend of recording mode.
  *
- *@param id of recording or playing back game
- *@return true in case of success, false in case of error
- *
+ * @param id of recording or playing back game
+ * @return true in case of success, false in case of error
  */
 bool EventRecorder::openRecordFile(const Common::String &fileName) {
 	bool result;

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -454,9 +454,6 @@ bool EventRecorder::notifyEvent(const Common::Event &ev) {
 	evt.mouse.y = evt.mouse.y * (g_system->getOverlayHeight() / g_system->getHeight());
 	switch (_recordMode) {
 	case kRecorderPlayback:
-		if (!ev.kbdRepeat) {
-			return true;
-		}
 		return false;
 	case kRecorderRecord:
 		g_gui.processEvent(evt, _controlPanel);

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -230,6 +230,7 @@ private:
 	Common::String _recordFileName;
 	bool _fastPlayback;
 	bool _needRedraw;
+	bool _processingMillis;
 };
 
 } // End of namespace GUI


### PR DESCRIPTION
The record file format is changed. But the version wasn't bumped because the old state wasn't working anyway.

This added the custom engine events from the key mapper to the serialization of the event recorder. 

With this change I can record a play in twine.

During a playback there is currently no interaction possible as all event sources except the recorder are disabled. I don't consider this a problem atm - as I see the main benefit on running the recorded plays on the buildbot - but if someone needs to have this back, I would consider doing this in a future PR.

# Follow up tasks:

* create recording for game demos
* integrate into buildbot


https://www.youtube.com/watch?v=SOD97joxFds
