### PR TITLE
TINSEL: Add detection for Discworld 1 PSX Ger/Jap PSX versions

### DIFF
--- a/engines/tinsel/detection_tables.h
+++ b/engines/tinsel/detection_tables.h
@@ -420,11 +420,27 @@ static const TinselGameDescription gameDescriptions[] = {
 		TINSEL_V1,
 	},
 
+	{	// Discworld PSX German CD
+		{
+			"dw",
+			"CD",
+			AD_ENTRY1s("dw.scn", "0b34bb57cd3961e4528e4bce48cc0ab9", 339764),
+			Common::DE_DEU,
+			Common::kPlatformPSX,
+			ADGF_CD,
+			GUIO0()
+		},
+		GID_DW1,
+		0,
+		GF_SCNFILES | GF_ENHANCED_AUDIO_SUPPORT,
+		TINSEL_V1,
+	},
+
 	{	// Discworld PSX CD Japanese
 		{
 			"dw",
 			"CD",
-			AD_ENTRY1s("dw.scn", "3cbe25971651631fdc33fece642c9c78", 328048),
+			AD_ENTRY1s("dw.scn", "bd2e47010565998641ec45a9c9285be0", 328048),
 			Common::JA_JPN,
 			Common::kPlatformPSX,
 			ADGF_CD | ADGF_UNSTABLE,

--- a/engines/tinsel/tinsel.cpp
+++ b/engines/tinsel/tinsel.cpp
@@ -1355,8 +1355,7 @@ const char *TinselEngine::getSampleIndex(LANGUAGE lang) {
 
 	} else {
 		cd = 0;
-		TinselFile f;
-		if (!f.open(_sampleFiles[lang][cd]))
+		if (!Common::File::exists(_sampleFiles[lang][cd]))
 			lang = TXT_ENGLISH; // fallback to ENGLISH.IDX/.SMP if <LANG>.IDX is not found
 	}
 
@@ -1377,8 +1376,7 @@ const char *TinselEngine::getSampleFile(LANGUAGE lang) {
 
 	} else {
 		cd = 0;
-		TinselFile f;
-		if (!f.open(_sampleFiles[lang][cd]))
+		if (!Common::File::exists(_sampleFiles[lang][cd]))
 			lang = TXT_ENGLISH; // fallback to ENGLISH.IDX/.SMP if <LANG>.IDX is not found
 	}
 

--- a/engines/tinsel/tinsel.cpp
+++ b/engines/tinsel/tinsel.cpp
@@ -1355,8 +1355,9 @@ const char *TinselEngine::getSampleIndex(LANGUAGE lang) {
 
 	} else {
 		cd = 0;
-		if (lang != TXT_JAPANESE)
-			lang = TXT_ENGLISH;
+		TinselFile f;
+		if (!f.open(_sampleFiles[lang][cd]))
+			lang = TXT_ENGLISH; // fallback to ENGLISH.IDX/.SMP if <LANG>.IDX is not found
 	}
 
 	return _sampleIndices[lang][cd];
@@ -1376,8 +1377,9 @@ const char *TinselEngine::getSampleFile(LANGUAGE lang) {
 
 	} else {
 		cd = 0;
-		if (lang != TXT_JAPANESE)
-			lang = TXT_ENGLISH;
+		TinselFile f;
+		if (!f.open(_sampleFiles[lang][cd]))
+			lang = TXT_ENGLISH; // fallback to ENGLISH.IDX/.SMP if <LANG>.IDX is not found
 	}
 
 	return _sampleFiles[lang][cd];


### PR DESCRIPTION
Follow up on: https://bugs.scummvm.org/ticket/11368

Adds detection for German Playstation version.
Also corrects detection of Japanese Playstation version.

getSampleIndex and getSampleFile in tinsel.cpp now fallback to ENGLISH files if they fail to find (e.g.) GERMAN.IDX.

This was an easy way to add support for the PSX German CD, without breaking the German DOS CD, Japanese PSX CD etc.

The German PSX version should be as compatible as the English PSX version.

The Japanese PSX version subtitles are not supported, and cause ScummVM to crash when you first try to hover over an object. However, you can view the intro cutscene, and hear the audio.

__
_Edit: I only marked as draft as this is my first submission, the code should be ready as is._