### PR TITLE
PARALLACTION: make IFCHAR command skip other characters' commands

### DIFF
--- a/engines/parallaction/parser_br.cpp
+++ b/engines/parallaction/parser_br.cpp
@@ -502,8 +502,9 @@ DECLARE_LOCATION_PARSER(zeta)  {
 DECLARE_COMMAND_PARSER(ifchar)  {
 	debugC(7, kDebugParser, "COMMAND_PARSER(ifchar) ");
 
-	if (scumm_stricmp(_vm->_char.getName(), _tokens[1]))
+	if (scumm_stricmp(_vm->_char.getName(), _tokens[1])) {
 		_script->skip("endif");
+	}
 }
 
 

--- a/engines/parallaction/parser_br.cpp
+++ b/engines/parallaction/parser_br.cpp
@@ -502,7 +502,7 @@ DECLARE_LOCATION_PARSER(zeta)  {
 DECLARE_COMMAND_PARSER(ifchar)  {
 	debugC(7, kDebugParser, "COMMAND_PARSER(ifchar) ");
 
-	if (!scumm_stricmp(_vm->_char.getName(), _tokens[1]))
+	if (scumm_stricmp(_vm->_char.getName(), _tokens[1]))
 		_script->skip("endif");
 }
 


### PR DESCRIPTION
The command version of IFCHAR was skipping the commands for the current character, instead of those for the other characters. After this change it behaves like the location version of IFCHAR.

The IFCHAR command appears for the first time in BRA part 3.