### PR TITLE
RFC: SDL: build fix for various non-x86 architectures

### DIFF
--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -111,6 +111,32 @@
 
 #endif // FORBIDDEN_SYMBOL_EXCEPTION_time_h
 
+// Fix compilation on non-x86 architectures
+// It needs various (usually forbidden) symbols from unistd.h
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_unistd_h
+
+	#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_chdir)
+	#undef chdir
+	#define chdir FAKE_chdir
+	#endif
+
+	#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_getcwd)
+	#undef getcwd
+	#define getcwd FAKE_getcwd
+	#endif
+
+	#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_getwd)
+	#undef getwd
+	#define getwd FAKE_getwd
+	#endif
+
+	#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_unlink)
+	#undef unlink
+	#define unlink FAKE_unlink
+	#endif
+
+#endif // FORBIDDEN_SYMBOL_EXCEPTION_unistd_h
+
 // HACK: SDL might include windows.h which defines its own ARRAYSIZE.
 // However, we want to use the version from common/util.h. Thus, we make sure
 // that we actually have this definition after including the SDL headers.
@@ -273,5 +299,30 @@
 	#endif
 
 #endif // FORBIDDEN_SYMBOL_EXCEPTION_time_h
+
+// re-forbid all those unistd.h symbols again (if they were forbidden)
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_unistd_h
+
+	#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_chdir)
+	#undef chdir
+	#define chdir(a) FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+	#endif
+
+	#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_getcwd)
+	#undef getcwd
+	#define getcwd(a,b) FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+	#endif
+
+	#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_getwd)
+	#undef getwd
+	#define getwd(a) FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+	#endif
+
+	#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && !defined(FORBIDDEN_SYMBOL_EXCEPTION_unlink)
+	#undef unlink
+	#define unlink(a) FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+	#endif
+
+#endif // FORBIDDEN_SYMBOL_EXCEPTION_unistd_h
 
 #endif


### PR DESCRIPTION
- add unistd.h to scummsys.h so that it is included before common/forbidden.h
- e.g. on ppc64, armv7, aarch and s390, SDL.h would include indirectly
  unistd.h after common/forbidden.h and so the preprocessor would
  generate broken code even if the symbols are never called by the
  scummvm source code
- according to my understanding how the forbidden.h feature works, any include file which contains some forbidden library function but might be included by depending librarires (in this case SDL) must be included manually before common/forbidden.h 
- the referenced commit fixes the compile issue for all mentioned architectures on Fedora but I'm not 100% sure whether it has negative side-effects to other architectures supported by scummvm

- specific example
  - build for ppc64le
  - https://koji.fedoraproject.org/koji/taskinfo?taskID=70253251 -> build.log:
```
[...]
mkdir -p backends/platform/sdl/posix/.deps
g++ -MMD -MF "backends/platform/sdl/posix/.deps/posix-main.d" -MQ "backends/platform/sdl/posix/posix-main.o" -MP -Wall -O2  -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -mcpu=power8 -mtune=power8 -fasynchronous-unwind-tables -fstack-clash-protection  -W -Wno-unused-parameter -Wno-empty-body -fno-operator-names -std=c++11 -g -fvar-tracking-assignments -pedantic -Wno-long-long  -O2 -Wuninitialized -fPIC  -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-4 -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/libxml2 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/gio-unix-2.0 -I/usr/include/cloudproviders -I/usr/include/atk-1.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/usr/include/at-spi-2.0 -pthread  -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-4 -pthread  -Wno-long-long -Wno-multichar -Wno-unknown-pragmas -Wno-reorder -Wpointer-arith -Wcast-qual -Wshadow -Wnon-virtual-dtor -Wwrite-strings -fno-exceptions -fcheck-new -DHAVE_CONFIG_H -DRELEASE_BUILD -DPPC_TARGET -DSDL_BACKEND -DPOSIX -DHAS_POSIX_SPAWN -DDATA_PATH=\"/usr/share/scummvm\" -DPLUGIN_DIRECTORY=\"/usr/lib64/scummvm\" -DENABLE_SCUMM=DYNAMIC_PLUGIN -DENABLE_SCUMM_7_8 -DENABLE_HE -DENABLE_ACCESS=DYNAMIC_PLUGIN -DENABLE_ADL=DYNAMIC_PLUGIN -DENABLE_AGI=DYNAMIC_PLUGIN -DENABLE_AGOS=DYNAMIC_PLUGIN -DENABLE_AGOS2 -DENABLE_AVALANCHE=DYNAMIC_PLUGIN -DENABLE_BBVS=DYNAMIC_PLUGIN -DENABLE_BLADERUNNER=DYNAMIC_PLUGIN -DENABLE_CGE=DYNAMIC_PLUGIN -DENABLE_CGE2=DYNAMIC_PLUGIN -DENABLE_CHEWY=DYNAMIC_PLUGIN -DENABLE_CINE=DYNAMIC_PLUGIN -DENABLE_COMPOSER=DYNAMIC_PLUGIN -DENABLE_CRUISE=DYNAMIC_PLUGIN -DENABLE_CRYO=DYNAMIC_PLUGIN -DENABLE_CRYOMNI3D=DYNAMIC_PLUGIN -DENABLE_VERSAILLES -DENABLE_DIRECTOR=DYNAMIC_PLUGIN -DENABLE_DM=DYNAMIC_PLUGIN -DENABLE_DRACI=DYNAMIC_PLUGIN -DENABLE_DRAGONS=DYNAMIC_PLUGIN -DENABLE_DRASCULA=DYNAMIC_PLUGIN -DENABLE_DREAMWEB=DYNAMIC_PLUGIN -DENABLE_FULLPIPE=DYNAMIC_PLUGIN -DENABLE_GLK=DYNAMIC_PLUGIN -DENABLE_GNAP=DYNAMIC_PLUGIN -DENABLE_GOB=DYNAMIC_PLUGIN -DENABLE_GRIFFON=DYNAMIC_PLUGIN -DENABLE_GROOVIE=DYNAMIC_PLUGIN -DENABLE_GROOVIE2 -DENABLE_HDB=DYNAMIC_PLUGIN -DENABLE_HOPKINS=DYNAMIC_PLUGIN -DENABLE_HUGO=DYNAMIC_PLUGIN -DENABLE_ILLUSIONS=DYNAMIC_PLUGIN -DENABLE_KINGDOM=DYNAMIC_PLUGIN -DENABLE_KYRA=DYNAMIC_PLUGIN -DENABLE_LOL -DENABLE_EOB -DENABLE_LAB=DYNAMIC_PLUGIN -DENABLE_LASTEXPRESS=DYNAMIC_PLUGIN -DENABLE_LILLIPUT=DYNAMIC_PLUGIN -DENABLE_LURE=DYNAMIC_PLUGIN -DENABLE_MACVENTURE=DYNAMIC_PLUGIN -DENABLE_MADE=DYNAMIC_PLUGIN -DENABLE_MADS=DYNAMIC_PLUGIN -DENABLE_MOHAWK=DYNAMIC_PLUGIN -DENABLE_CSTIME -DENABLE_MYST -DENABLE_MYSTME -DENABLE_RIVEN -DENABLE_MORTEVIELLE=DYNAMIC_PLUGIN -DENABLE_MUTATIONOFJB=DYNAMIC_PLUGIN -DENABLE_NEVERHOOD=DYNAMIC_PLUGIN -DENABLE_PARALLACTION=DYNAMIC_PLUGIN -DENABLE_PEGASUS=DYNAMIC_PLUGIN -DENABLE_PETKA=DYNAMIC_PLUGIN -DENABLE_PINK=DYNAMIC_PLUGIN -DENABLE_PLUMBERS=DYNAMIC_PLUGIN -DENABLE_PRINCE=DYNAMIC_PLUGIN -DENABLE_QUEEN=DYNAMIC_PLUGIN -DENABLE_SAGA=DYNAMIC_PLUGIN -DENABLE_IHNM -DENABLE_SAGA2 -DENABLE_SCI=DYNAMIC_PLUGIN -DENABLE_SCI32 -DENABLE_SHERLOCK=DYNAMIC_PLUGIN -DENABLE_SKY=DYNAMIC_PLUGIN -DENABLE_SLUDGE=DYNAMIC_PLUGIN -DENABLE_STARTREK=DYNAMIC_PLUGIN -DENABLE_SUPERNOVA=DYNAMIC_PLUGIN -DENABLE_SWORD1=DYNAMIC_PLUGIN -DENABLE_SWORD2=DYNAMIC_PLUGIN -DENABLE_SWORD25=DYNAMIC_PLUGIN -DENABLE_TEENAGENT=DYNAMIC_PLUGIN -DENABLE_TESTBED=DYNAMIC_PLUGIN -DENABLE_TINSEL=DYNAMIC_PLUGIN -DENABLE_TITANIC=DYNAMIC_PLUGIN -DENABLE_TOLTECS=DYNAMIC_PLUGIN -DENABLE_TONY=DYNAMIC_PLUGIN -DENABLE_TOON=DYNAMIC_PLUGIN -DENABLE_TOUCHE=DYNAMIC_PLUGIN -DENABLE_TSAGE=DYNAMIC_PLUGIN -DENABLE_TUCKER=DYNAMIC_PLUGIN -DENABLE_ULTIMA=DYNAMIC_PLUGIN -DENABLE_VOYEUR=DYNAMIC_PLUGIN -DENABLE_WAGE=DYNAMIC_PLUGIN -DENABLE_WINTERMUTE=DYNAMIC_PLUGIN -DENABLE_FOXTAIL -DENABLE_HEROCRAFT -DENABLE_XEEN=DYNAMIC_PLUGIN -DENABLE_ZVISION=DYNAMIC_PLUGIN -I. -I. -I./engines -I/usr/include/SDL2 -D_REENTRANT       -I/usr/include/libpng16         -I/usr/include/fribidi  -c backends/platform/sdl/posix/posix-main.cpp -o backends/platform/sdl/posix/posix-main.o
In file included from ./common/scummsys.h:467,
                 from backends/platform/sdl/posix/posix-main.cpp:23:
./common/forbidden.h:57:92: error: expected initializer before 'SYMBOL'
   57 | #define FORBIDDEN_SYMBOL_REPLACEMENT    FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
      |                                                                                            ^~~~~~
./common/forbidden.h:57:92: error: expected initializer before 'SYMBOL'
   57 | #define FORBIDDEN_SYMBOL_REPLACEMENT    FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
      |                                                                                            ^~~~~~
./common/forbidden.h:57:92: error: expected initializer before 'SYMBOL'
   57 | #define FORBIDDEN_SYMBOL_REPLACEMENT    FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
      |                                                                                            ^~~~~~
./common/forbidden.h:57:92: error: expected initializer before 'SYMBOL'
   57 | #define FORBIDDEN_SYMBOL_REPLACEMENT    FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
      |                                                                                            ^~~~~~
In file included from /usr/include/features.h:488,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:27,
                 from ./common/scummsys.h:118,
                 from backends/platform/sdl/posix/posix-main.cpp:23:
./common/forbidden.h:57:92: error: expected initializer before 'SYMBOL'
   57 | #define FORBIDDEN_SYMBOL_REPLACEMENT    FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
      |                                                                                            ^~~~~~
./common/forbidden.h:57:92: error: expected initializer before 'SYMBOL'
   57 | #define FORBIDDEN_SYMBOL_REPLACEMENT    FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
      |                                                                                            ^~~~~~
make: *** [Makefile.common:122: backends/platform/sdl/posix/posix-main.o] Error 1
[...]
```
   - 