### PR TITLE
AUDIO: SOUNDFONT: Fix warnings for header search failure.

### DIFF
--- a/audio/soundfont/sf2file.cpp
+++ b/audio/soundfont/sf2file.cpp
@@ -27,8 +27,8 @@
 
 #include "common/scummsys.h"
 #include "common/str.h"
-#include "sf2file.h"
-#include "synthfile.h"
+#include "audio/soundfont/sf2file.h"
+#include "audio/soundfont/synthfile.h"
 
 using namespace std;
 

--- a/audio/soundfont/vgminstrset.h
+++ b/audio/soundfont/vgminstrset.h
@@ -30,8 +30,8 @@
 #include "common/scummsys.h"
 #include "common/str.h"
 #include "common/array.h"
-#include "vgmitem.h"
-#include "sf2file.h"
+#include "audio/soundfont/vgmitem.h"
+#include "audio/soundfont/sf2file.h"
 
 class VGMSampColl;
 class VGMInstr;

--- a/audio/soundfont/vgmitem.cpp
+++ b/audio/soundfont/vgmitem.cpp
@@ -25,9 +25,9 @@
  * refer to the included VGMTrans_LICENSE.txt file
  */
 
-#include "common.h"
-#include "vgmitem.h"
-#include "vgminstrset.h"
+#include "audio/soundfont/common.h"
+#include "audio/soundfont/vgmitem.h"
+#include "audio/soundfont/vgminstrset.h"
 
 using namespace std;
 

--- a/audio/soundfont/vgmsamp.h
+++ b/audio/soundfont/vgmsamp.h
@@ -27,10 +27,10 @@
 #ifndef AUDIO_SOUNDFONT_VGMSAMP_H
 #define AUDIO_SOUNDFONT_VGMSAMP_H
 
-#include "common.h"
+#include "audio/soundfont/common.h"
 #include "common/scummsys.h"
 #include "common/str.h"
-#include "vgmitem.h"
+#include "audio/soundfont/vgmitem.h"
 
 class VGMSampColl;
 class VGMInstrSet;


### PR DESCRIPTION
WARNING: Can't find following headers in User or System Include Paths "vgmitem.h" "sf2file.h" "common.h" "vgmitem.h" "common.h"