### PR TITLE
COMMON: LUA: Fix warnings for header search failure.

### DIFF
--- a/common/lua/lauxlib.h
+++ b/common/lua/lauxlib.h
@@ -12,7 +12,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#include "lua.h"
+#include "common/lua/lua.h"
 
 
 #if defined(LUA_COMPAT_GETN)

--- a/common/lua/lua.h
+++ b/common/lua/lua.h
@@ -15,7 +15,7 @@
 #include <stddef.h>
 
 
-#include "luaconf.h"
+#include "common/lua/luaconf.h"
 
 
 #define LUA_VERSION	"Lua 5.1"

--- a/common/lua/lualib.h
+++ b/common/lua/lualib.h
@@ -8,7 +8,7 @@
 #ifndef lualib_h
 #define lualib_h
 
-#include "lua.h"
+#include "common/lua/lua.h"
 
 
 /* Key to file-handle type */


### PR DESCRIPTION
WARNING: Can't find following headers in User or System Include Paths "luaconf.h" "lua.h" "lua.h"