### PR TITLE
WINTERMUTE: Fix many warnings for header search failure.

### DIFF
--- a/engines/wintermute/debugger/breakpoint.cpp
+++ b/engines/wintermute/debugger/breakpoint.cpp
@@ -22,7 +22,7 @@
 
 #include "breakpoint.h"
 #include "engines/wintermute/base/scriptables/debuggable/debuggable_script.h"
-#include "script_monitor.h"
+#include "engines/wintermute/debugger/script_monitor.h"
 
 namespace Wintermute {
 

--- a/engines/wintermute/debugger/debugger_controller.h
+++ b/engines/wintermute/debugger/debugger_controller.h
@@ -27,9 +27,9 @@
 #include "engines/wintermute/coll_templ.h"
 #include "engines/wintermute/wintermute.h"
 #include "engines/wintermute/debugger/listing_providers/source_listing_provider.h"
-#include "script_monitor.h"
+#include "engines/wintermute/debugger/script_monitor.h"
 #include "error.h"
-#include "listing.h"
+#include "engines/wintermute/debugger/listing.h"
 namespace Wintermute {
 
 class ScScript;

--- a/engines/wintermute/debugger/listing.cpp
+++ b/engines/wintermute/debugger/listing.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "listing.h"
+#include "engines/wintermute/debugger/listing.h"
 #include "common/array.h"
 
 namespace Wintermute {

--- a/engines/wintermute/debugger/listing_provider.h
+++ b/engines/wintermute/debugger/listing_provider.h
@@ -23,7 +23,7 @@
 #ifndef LISTING_PROVIDER_H_
 #define LISTING_PROVIDER_H_
 
-#include "listing.h"
+#include "engines/wintermute/debugger/listing.h"
 #include "engines/wintermute/debugger/error.h"
 
 namespace Wintermute {

--- a/engines/wintermute/debugger/listing_providers/basic_source_listing_provider.cpp
+++ b/engines/wintermute/debugger/listing_providers/basic_source_listing_provider.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "basic_source_listing_provider.h"
+#include "engines/wintermute/debugger/listing_providers/basic_source_listing_provider.h"
 #include "engines/wintermute/base/base_file_manager.h"
 
 namespace Wintermute {

--- a/engines/wintermute/debugger/listing_providers/basic_source_listing_provider.h
+++ b/engines/wintermute/debugger/listing_providers/basic_source_listing_provider.h
@@ -24,7 +24,7 @@
 #define BASIC_SOURCE_LISTING_PROVIDER_H_
 
 #include "engines/wintermute/debugger/listing_provider.h"
-#include "source_listing_provider.h"
+#include "engines/wintermute/debugger/listing_providers/source_listing_provider.h"
 #include "source_listing.h"
 #include "common/fs.h"
 

--- a/engines/wintermute/debugger/listing_providers/cached_source_listing_provider.cpp
+++ b/engines/wintermute/debugger/listing_providers/cached_source_listing_provider.cpp
@@ -20,10 +20,10 @@
  *
  */
 
-#include "cached_source_listing_provider.h"
-#include "basic_source_listing_provider.h"
-#include "blank_listing_provider.h"
-#include "source_listing.h"
+#include "engines/wintermute/debugger/listing_providers/cached_source_listing_provider.h"
+#include "engines/wintermute/debugger/listing_providers/basic_source_listing_provider.h"
+#include "engines/wintermute/debugger/listing_providers/blank_listing_provider.h"
+#include "engines/wintermute/debugger/listing_providers/source_listing.h"
 
 namespace Wintermute {
 

--- a/engines/wintermute/debugger/listing_providers/cached_source_listing_provider.h
+++ b/engines/wintermute/debugger/listing_providers/cached_source_listing_provider.h
@@ -26,7 +26,7 @@
 #include "common/hashmap.h"
 #include "common/hash-str.h"
 #include "engines/wintermute/debugger/error.h"
-#include "source_listing_provider.h"
+#include "engines/wintermute/debugger/listing_providers/source_listing_provider.h"
 
 namespace Wintermute {
 

--- a/engines/wintermute/debugger/script_monitor.cpp
+++ b/engines/wintermute/debugger/script_monitor.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "script_monitor.h"
+#include "engines/wintermute/debugger/script_monitor.h"
 
 namespace Wintermute {
 }

--- a/engines/wintermute/debugger/watch.cpp
+++ b/engines/wintermute/debugger/watch.cpp
@@ -22,7 +22,7 @@
 
 #include "watch.h"
 #include "watch_instance.h"
-#include "script_monitor.h"
+#include "engines/wintermute/debugger/script_monitor.h"
 
 namespace Wintermute {
 


### PR DESCRIPTION
WARNING: Can't find following headers in User or System Include Paths
 "listing.h" "script_monitor.h" "listing.h" etc