### PR TITLE
GIU: Fix warnings for header search failure.

### DIFF
--- a/gui/widgets/scrollcontainer.h
+++ b/gui/widgets/scrollcontainer.h
@@ -25,7 +25,7 @@
 
 #include "gui/widget.h"
 #include "common/str.h"
-#include "scrollbar.h"
+#include "gui/widgets/scrollbar.h"
 
 namespace GUI {
 


### PR DESCRIPTION
WARNING: Can't find following headers in User or System Include Paths "scrollbar.h"