### PR TITLE
GRAPHICS: Fix warnings for header search failure.

### DIFF
--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -457,7 +457,7 @@ void glClose();
 // glopXXX functions
 
 #define ADD_OP(a,b,c) void glop ## a (GLContext *, GLParam *);
-#include "opinfo.h"
+#include "graphics/tinygl/opinfo.h"
 
 // this clip epsilon is needed to avoid some rounding errors after
 // several clipping stages


### PR DESCRIPTION
WARNING: Can't find following headers in User or System Include Paths "opinfo.h"