### PR TITLE
ZVISION: Fix warnings for header search failure.

### DIFF
--- a/engines/zvision/graphics/render_manager.h
+++ b/engines/zvision/graphics/render_manager.h
@@ -31,7 +31,7 @@
 
 #include "graphics/surface.h"
 
-#include "graphics_effect.h"
+#include "zvision/graphics/graphics_effect.h"
 
 class OSystem;
 


### PR DESCRIPTION
WARNING: Can't find following headers in User or System Include Paths "graphics_effect.h"