### PR TITLE
MUTATIONOFJB: Fix warnings for header search failure.

### DIFF
--- a/engines/mutationofjb/tasks/taskmanager.h
+++ b/engines/mutationofjb/tasks/taskmanager.h
@@ -24,12 +24,11 @@
 #define MUTATIONOFJB_TASKMANAGER_H
 
 #include "common/array.h"
-#include "task.h"
+#include "mutationofjb/tasks/task.h"
 
 namespace MutationOfJB {
 
 class Game;
-class Task;
 
 /**
  * Handles task management.


### PR DESCRIPTION
WARNING: Can't find following headers in User or System Include Paths "task.h"