### PR TITLE
WINTERMUTE: Init screenmode once

### DIFF
--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -34,6 +34,7 @@
 #include "engines/wintermute/math/math_util.h"
 #include "engines/wintermute/base/base_game.h"
 #include "engines/wintermute/base/base_sprite.h"
+#include "engines/util.h"
 #include "common/system.h"
 #include "common/queue.h"
 #include "common/config-manager.h"
@@ -123,11 +124,9 @@ bool BaseRenderOSystem::initRenderer(int width, int height, bool windowed) {
 	_windowed = !ConfMan.getBool("fullscreen");
 
 	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	g_system->beginGFXTransaction();
-		g_system->initSize(_width, _height, &format);
-	OSystem::TransactionError gfxError = g_system->endGFXTransaction();
+	initGraphics(_width, _height, &format);
 
-	if (gfxError != OSystem::kTransactionSuccess) {
+	if (g_system->getScreenFormat() != format) {
 		warning("Couldn't setup GFX-backend for %dx%dx%d", _width, _height, format.bytesPerPixel * 8);
 		return STATUS_FAILED;
 	}

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -31,7 +31,6 @@
 #include "common/tokenizer.h"
 #include "common/translation.h"
 
-#include "engines/util.h"
 #include "engines/wintermute/ad/ad_game.h"
 #include "engines/wintermute/wintermute.h"
 #include "engines/wintermute/debugger.h"
@@ -102,21 +101,6 @@ bool WintermuteEngine::hasFeature(EngineFeature f) const {
 }
 
 Common::Error WintermuteEngine::run() {
-	// Initialize graphics using following:
-	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	if (_gameDescription->adDesc.flags & GF_LOWSPEC_ASSETS) {
-		initGraphics(320, 240, &format);
-#ifdef ENABLE_FOXTAIL
-	} else if (BaseEngine::isFoxTailCheck(_gameDescription->targetExecutable)) {
-		initGraphics(640, 360, &format);
-#endif
-	} else {
-		initGraphics(800, 600, &format);
-	}
-	if (g_system->getScreenFormat() != format) {
-		return Common::kUnsupportedColorMode;
-	}
-
 	// Create debugger console. It requires GFX to be initialized
 	_dbgController = new DebuggerController(this);
 	_debugger = new Console(this);
@@ -195,7 +179,7 @@ int WintermuteEngine::init() {
 	#ifndef ENABLE_WME3D
 	// check if game require 3D capabilities
 	if (instance.getFlags() & GF_3D) {
-		GUI::MessageDialog dialog(_("This game requires 3D capabilities that are out ScummVM scope. As such, it"
+		GUI::MessageDialog dialog(_("This game requires 3D capabilities, which is not compiled in. As such, it"
 			" is likely to be unplayable totally or partially."), _("Start anyway"), _("Cancel"));
 		if (dialog.runModal() != GUI::kMessageOK) {
 			delete _game;


### PR DESCRIPTION
I have noticed, that for 2D games graphics initialization was done twice - at WintermuteEngine::run() and BaseRenderOSystem::initRenderer(int width, int height, bool windowed).

The first call looks unnecessary, let's remove it.
Probably, this would fix https://bugs.scummvm.org/ticket/11160, since second call seems to be ineffective when this first one is called with different screen dimentions.