### PR TITLE
PARALLACTION: implement SWAP command for BRA

### DIFF
--- a/engines/parallaction/callables_ns.cpp
+++ b/engines/parallaction/callables_ns.cpp
@@ -377,7 +377,7 @@ void Parallaction_ns::_c_finito(void *parm) {
 
 	_saveLoad->setPartComplete(_char.getBaseName());
 
-	cleanInventory();
+	cleanInventory(true);
 	cleanupGame();
 
 	_gfx->setPalette(_gfx->_palette);

--- a/engines/parallaction/exec_br.cpp
+++ b/engines/parallaction/exec_br.cpp
@@ -272,7 +272,29 @@ DECLARE_COMMAND_OPCODE(scroll) {
 
 
 DECLARE_COMMAND_OPCODE(swap) {
-	warning("Parallaction_br::cmdOp_swap not yet implemented");
+	warning("Parallaction_br::cmdOp_swap does not handle a follower yet");
+
+	/*
+		TODO:
+		- fixup follower
+		- change mouse pointer
+	*/
+
+	const char *newCharacterName = ctxt._cmd->_string.c_str();
+	AnimationPtr newCharacterAnimation = _vm->_location.findAnimation(newCharacterName);
+	AnimationPtr oldCharaterAnimation = _vm->_char._ani;
+
+	strlcpy(oldCharaterAnimation->_name, _vm->_char.getName(), ZONENAME_LENGTH);
+	_vm->_char.setName(newCharacterName);
+
+	_vm->_char._ani = newCharacterAnimation;
+	_vm->_char._talk = _vm->_disk->loadTalk(newCharacterName);
+	strlcpy(_vm->_char._ani->_name, "yourself", ZONENAME_LENGTH);
+
+	_vm->linkUnlinkedZoneAnimations();
+
+	_vm->_inventory = _vm->findInventory(newCharacterName);
+	_vm->_inventoryRenderer->setInventory(_vm->_inventory);
 }
 
 

--- a/engines/parallaction/inventory.cpp
+++ b/engines/parallaction/inventory.cpp
@@ -358,11 +358,8 @@ void Parallaction_ns::initInventory() {
 }
 
 void Parallaction_br::initInventory() {
-	_inventory = new Inventory(_invProps_BR._maxItems, _verbs_BR);
-	assert(_inventory);
 	_inventoryRenderer = new InventoryRenderer(this, &_invProps_BR);
 	assert(_inventoryRenderer);
-	_inventoryRenderer->setInventory(_inventory);
 
 	_dinoInventory = new Inventory(_invProps_BR._maxItems, _verbs_BR);
 	_donnaInventory = new Inventory(_invProps_BR._maxItems, _verbs_BR);
@@ -378,7 +375,6 @@ void Parallaction_ns::destroyInventory() {
 
 void Parallaction_br::destroyInventory() {
 	delete _inventoryRenderer;
-	delete _inventory;
 	_inventory = 0;
 	_inventoryRenderer = 0;
 

--- a/engines/parallaction/inventory.cpp
+++ b/engines/parallaction/inventory.cpp
@@ -134,8 +134,18 @@ void Parallaction::closeInventory() {
 	_inventoryRenderer->hideInventory();
 }
 
-
-
+Inventory *Parallaction_br::findInventory(const char *name) {
+	if (!scumm_stricmp(name, "dino")) {
+		return _dinoInventory;
+	}
+	if (!scumm_stricmp(name, "donna")) {
+		return _donnaInventory;
+	}
+	if (!scumm_stricmp(name, "doug")) {
+		return _dougInventory;
+	}
+	return 0;
+}
 
 InventoryRenderer::InventoryRenderer(Parallaction *vm, InventoryProperties *props) : _vm(vm), _props(props) {
 	_surf.create(_props->_width, _props->_height, Graphics::PixelFormat::createFormatCLUT8());

--- a/engines/parallaction/inventory.cpp
+++ b/engines/parallaction/inventory.cpp
@@ -122,8 +122,14 @@ int16 Parallaction::getInventoryItemIndex(int16 pos) {
 	return _inventory->getItemName(pos);
 }
 
-void Parallaction::cleanInventory(bool keepVerbs) {
+void Parallaction_ns::cleanInventory(bool keepVerbs) {
 	_inventory->clear(keepVerbs);
+}
+
+void Parallaction_br::cleanInventory(bool keepVerbs) {
+	_dinoInventory->clear(keepVerbs);
+	_donnaInventory->clear(keepVerbs);
+	_dougInventory->clear(keepVerbs);
 }
 
 void Parallaction::openInventory() {

--- a/engines/parallaction/inventory.cpp
+++ b/engines/parallaction/inventory.cpp
@@ -137,12 +137,16 @@ void Parallaction::closeInventory() {
 
 
 
-InventoryRenderer::InventoryRenderer(Parallaction *vm, InventoryProperties *props, Inventory *inv) : _vm(vm), _props(props), _inv(inv) {
+InventoryRenderer::InventoryRenderer(Parallaction *vm, InventoryProperties *props) : _vm(vm), _props(props) {
 	_surf.create(_props->_width, _props->_height, Graphics::PixelFormat::createFormatCLUT8());
 }
 
 InventoryRenderer::~InventoryRenderer() {
 	_surf.free();
+}
+
+void InventoryRenderer::setInventory(Inventory *inventory) {
+	_inv = inventory;
 }
 
 void InventoryRenderer::showInventory() {
@@ -338,15 +342,17 @@ const InventoryItem* Inventory::getItem(ItemPosition pos) const {
 void Parallaction_ns::initInventory() {
 	_inventory = new Inventory(_invProps_NS._maxItems, _verbs_NS);
 	assert(_inventory);
-	_inventoryRenderer = new InventoryRenderer(this, &_invProps_NS, _inventory);
+	_inventoryRenderer = new InventoryRenderer(this, &_invProps_NS);
 	assert(_inventoryRenderer);
+	_inventoryRenderer->setInventory(_inventory);
 }
 
 void Parallaction_br::initInventory() {
 	_inventory = new Inventory(_invProps_BR._maxItems, _verbs_BR);
 	assert(_inventory);
-	_inventoryRenderer = new InventoryRenderer(this, &_invProps_BR, _inventory);
+	_inventoryRenderer = new InventoryRenderer(this, &_invProps_BR);
 	assert(_inventoryRenderer);
+	_inventoryRenderer->setInventory(_inventory);
 
 	_charInventories[0] = new Inventory(_invProps_BR._maxItems, _verbs_BR);
 	_charInventories[1] = new Inventory(_invProps_BR._maxItems, _verbs_BR);

--- a/engines/parallaction/inventory.cpp
+++ b/engines/parallaction/inventory.cpp
@@ -354,9 +354,9 @@ void Parallaction_br::initInventory() {
 	assert(_inventoryRenderer);
 	_inventoryRenderer->setInventory(_inventory);
 
-	_charInventories[0] = new Inventory(_invProps_BR._maxItems, _verbs_BR);
-	_charInventories[1] = new Inventory(_invProps_BR._maxItems, _verbs_BR);
-	_charInventories[2] = new Inventory(_invProps_BR._maxItems, _verbs_BR);
+	_dinoInventory = new Inventory(_invProps_BR._maxItems, _verbs_BR);
+	_donnaInventory = new Inventory(_invProps_BR._maxItems, _verbs_BR);
+	_dougInventory = new Inventory(_invProps_BR._maxItems, _verbs_BR);
 }
 
 void Parallaction_ns::destroyInventory() {
@@ -372,12 +372,12 @@ void Parallaction_br::destroyInventory() {
 	_inventory = 0;
 	_inventoryRenderer = 0;
 
-	delete _charInventories[0];
-	delete _charInventories[1];
-	delete _charInventories[2];
-	_charInventories[0] = 0;
-	_charInventories[1] = 0;
-	_charInventories[2] = 0;
+	delete _dinoInventory;
+	delete _donnaInventory;
+	delete _dougInventory;
+	_dinoInventory = 0;
+	_donnaInventory = 0;
+	_dougInventory = 0;
 }
 
 

--- a/engines/parallaction/inventory.h
+++ b/engines/parallaction/inventory.h
@@ -98,8 +98,10 @@ protected:
 	void refresh();
 
 public:
-	InventoryRenderer(Parallaction *vm, InventoryProperties *props, Inventory *inv);
+	InventoryRenderer(Parallaction *vm, InventoryProperties *props);
 	virtual ~InventoryRenderer();
+
+	void setInventory(Inventory *inventory);
 
 	void showInventory();
 	void hideInventory();

--- a/engines/parallaction/parallaction.h
+++ b/engines/parallaction/parallaction.h
@@ -547,7 +547,9 @@ private:
 	LocationParser_br		*_locationParser;
 	ProgramParser_br		*_programParser;
 	SoundMan_br				*_soundManI;
-	Inventory				*_charInventories[3];	// all the inventories
+	Inventory				*_dinoInventory;
+	Inventory				*_donnaInventory;
+	Inventory				*_dougInventory;
 
 	int32		_counters[32];
 	Table		*_countersNames;

--- a/engines/parallaction/parallaction.h
+++ b/engines/parallaction/parallaction.h
@@ -558,6 +558,7 @@ private:
 	void	initResources();
 	void	initInventory();
 	void	destroyInventory();
+	Inventory *findInventory(const char *name);
 	void	setupBalloonManager();
 	void	initFonts();
 	void	freeFonts();

--- a/engines/parallaction/parallaction.h
+++ b/engines/parallaction/parallaction.h
@@ -511,6 +511,8 @@ public:
 	void setupSubtitles(const char *s, const char *s2, int y);
 	void clearSubtitles();
 
+	Inventory *findInventory(const char *name);
+
 	void testCounterCondition(const Common::String &name, int op, int value);
 	void restoreOrSaveZoneFlags(ZonePtr z, bool restore);
 
@@ -541,7 +543,6 @@ public:
 	ZonePtr		_activeZone2;
 	uint32		_zoneFlags[NUM_LOCATIONS][NUM_ZONES];
 
-
 private:
 	LocationParser_br		*_locationParser;
 	ProgramParser_br		*_programParser;
@@ -557,7 +558,7 @@ private:
 	void	initResources();
 	void	initInventory();
 	void	destroyInventory();
-	Inventory *findInventory(const char *name);
+
 	void	cleanInventory(bool keepVerbs);
 	void	setupBalloonManager();
 	void	initFonts();

--- a/engines/parallaction/parallaction.h
+++ b/engines/parallaction/parallaction.h
@@ -512,6 +512,7 @@ public:
 	void clearSubtitles();
 
 	Inventory *findInventory(const char *name);
+	void linkUnlinkedZoneAnimations();
 
 	void testCounterCondition(const Common::String &name, int op, int value);
 	void restoreOrSaveZoneFlags(ZonePtr z, bool restore);

--- a/engines/parallaction/parallaction.h
+++ b/engines/parallaction/parallaction.h
@@ -358,7 +358,6 @@ public:
 	bool		isItemInInventory(int32 v);
 	const		InventoryItem* getInventoryItem(int16 pos);
 	int16		getInventoryItemIndex(int16 pos);
-	void		cleanInventory(bool keepVerbs = true);
 	void		openInventory();
 	void		closeInventory();
 
@@ -403,7 +402,7 @@ public:
 	void scheduleWalk(int16 x, int16 y, bool fromUser) override;
 	DialogueManager *createDialogueManager(ZonePtr z) override;
 	bool processGameEvent(int event) override;
-
+	void cleanInventory(bool keepVerbs);
 	void	changeBackground(const char *background, const char *mask = 0, const char *path = 0);
 
 private:
@@ -559,6 +558,7 @@ private:
 	void	initInventory();
 	void	destroyInventory();
 	Inventory *findInventory(const char *name);
+	void	cleanInventory(bool keepVerbs);
 	void	setupBalloonManager();
 	void	initFonts();
 	void	freeFonts();

--- a/engines/parallaction/parallaction_br.cpp
+++ b/engines/parallaction/parallaction_br.cpp
@@ -456,7 +456,14 @@ void Parallaction_br::loadProgram(AnimationPtr a, const char *filename) {
 	return;
 }
 
-
+void Parallaction_br::linkUnlinkedZoneAnimations() {
+	ZoneList::iterator zit = _location._zones.begin();
+	for ( ; zit != _location._zones.end(); ++zit) {
+		if ((*zit)->_flags & kFlagsActive) {
+			(*zit)->_linkedAnim = _location.findAnimation((*zit)->_linkedName.c_str());
+		}
+	}
+}
 
 void Parallaction_br::changeCharacter(const char *name) {
 

--- a/engines/parallaction/parallaction_br.cpp
+++ b/engines/parallaction/parallaction_br.cpp
@@ -471,10 +471,8 @@ void Parallaction_br::changeCharacter(const char *name) {
 		_char._ani->gfxobj = _gfx->loadCharacterAnim(name);
 		_char._talk = _disk->loadTalk(name);
 
-		/* TODO: adjust inventories as following
-		 * 1) if not on game load, then copy _inventory to the right slot of _charInventories
-		 * 2) copy the new inventory from the right slot of _charInventories
-		 */
+		_inventory = findInventory(name);
+		_inventoryRenderer->setInventory(_inventory);
 	}
 
 	_char._ani->_flags |= kFlagsActive;

--- a/engines/parallaction/parallaction_br.cpp
+++ b/engines/parallaction/parallaction_br.cpp
@@ -51,9 +51,6 @@ Parallaction_br::Parallaction_br(OSystem* syst, const PARALLACTIONGameDescriptio
 	_subtitleY = 0;
 	_subtitle[0] = 0;
 	_subtitle[1] = 0;
-	_charInventories[0] = 0;
-	_charInventories[1] = 0;
-	_charInventories[2] = 0;
 	_countersNames = 0;
 	_callables = 0;
 	_walker = 0;


### PR DESCRIPTION
The SWAP command switches control from the playing character to another one onscreen (the 'current' character becomes an NPC).

Limitations:
- the mouse cursor is not switched, as the engine has no such capability yet
- the playing character's follower is not switched, as I'd need to reach a place where the feature is used first