### PR TITLE
COMMON: Fix inclusion cstddef.

### DIFF
--- a/common/ptr.h
+++ b/common/ptr.h
@@ -27,10 +27,6 @@
 #include "common/noncopyable.h"
 #include "common/safe-bool.h"
 #include "common/types.h"
-#ifdef USE_CXX11
-/* For nullptr_t */
-#include <cstddef>
-#endif
 
 namespace Common {
 

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -486,6 +486,8 @@ typedef uint32 uintptr;
 namespace std {
 	typedef decltype(nullptr) nullptr_t;
 }
+#else
+#include <cstddef>
 #endif
 
 #include "common/forbidden.h"


### PR DESCRIPTION
That file included for nullptr_t use. If header not aviable that break build. I think it good use cstddef here.