### PR TITLE
PARALLACTION: implement GIVE command for BRA 

### DIFF
--- a/engines/parallaction/exec_br.cpp
+++ b/engines/parallaction/exec_br.cpp
@@ -299,16 +299,14 @@ DECLARE_COMMAND_OPCODE(swap) {
 
 
 DECLARE_COMMAND_OPCODE(give) {
-	warning("Parallaction_br::cmdOp_give not yet implemented");
+	int item = ctxt._cmd->_object;
+	Inventory *targetInventory = _vm->findInventory(ctxt._cmd->_characterName.c_str());
 
-	/* NOTE: the following code is disabled until I deal with _inventory and
-	 * _charInventories not being public
-	 */
-/*  int item = ctxt._cmd->_object;
-	int recipient = ctxt._cmd->_characterId;
-	_vm->_charInventories[recipient]->addItem(item);
+	if (targetInventory) {
+		targetInventory->addItem(item);
+	}
+
 	_vm->_inventory->removeItem(item);
-*/
 }
 
 

--- a/engines/parallaction/objects.cpp
+++ b/engines/parallaction/objects.cpp
@@ -42,7 +42,6 @@ Command::Command() {
 	_zeta0 = 0;
 	_zeta1 = 0;
 	_zeta2 = 0;
-	_characterId = 0;
 	_musicCommand = 0;
 	_musicParm = 0;
 }

--- a/engines/parallaction/objects.h
+++ b/engines/parallaction/objects.h
@@ -130,7 +130,7 @@ struct Command {
 	int				_zeta0;
 	int				_zeta1;
 	int				_zeta2;
-	int				_characterId;
+	Common::String	_characterName;
 	Common::String	_string2;
 	int				_musicCommand;
 	int				_musicParm;

--- a/engines/parallaction/parser_br.cpp
+++ b/engines/parallaction/parser_br.cpp
@@ -657,13 +657,13 @@ DECLARE_COMMAND_PARSER(give)  {
 	ctxt.nextToken++;
 
 	if (!scumm_stricmp("dino", _tokens[2])) {
-		ctxt.cmd->_characterId = 1;
+		ctxt.cmd->_characterName = "dino";
 	} else
 	if (!scumm_stricmp("doug", _tokens[2])) {
-		ctxt.cmd->_characterId = 2;
+		ctxt.cmd->_characterName = "doug";
 	} else
 	if (!scumm_stricmp("donna", _tokens[2])) {
-		ctxt.cmd->_characterId = 3;
+		ctxt.cmd->_characterName = "donna";
 	} else
 		error("unknown recipient '%s' in give command", _tokens[2]);
 

--- a/engines/parallaction/parser_br.cpp
+++ b/engines/parallaction/parser_br.cpp
@@ -653,7 +653,7 @@ DECLARE_COMMAND_PARSER(give)  {
 
 	createCommand(_parser->_lookup);
 
-	ctxt.cmd->_object = 4 + atoi(_tokens[1]);
+	ctxt.cmd->_object = 4 + _vm->_objectsNames->lookup(_tokens[1]);
 	ctxt.nextToken++;
 
 	if (!scumm_stricmp("dino", _tokens[2])) {


### PR DESCRIPTION
This PR implements the whole GIVE command, which is used to transfer inventory items among the 3 BRA playable characters.

I haven't verified it in practice, but this change should make PART 3 completable.