### PR TITLE
ACHIEVEMENTS: Fix compilation when translations are disabled

### DIFF
--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -85,10 +85,12 @@ bool AchievementsManager::setActiveDomain(const AchievementsInfo &info) {
 
 
 String AchievementsManager::getCurrentLang() const {
+#ifdef USE_TRANSLATION
 	String uiLang = TransMan.getCurrentLanguage().c_str();
 	if (_achievements.contains(uiLang)) {
 		return uiLang;
 	}
+#endif
 
 	return "en";
 }


### PR DESCRIPTION
`common/achievements.cpp` would fail to compile without this, in a `--disable-translation` build.