### PR TITLE
IMAGE: Use 0-bit alpha for non-transparent PNGs

### DIFF
--- a/image/png.h
+++ b/image/png.h
@@ -67,7 +67,7 @@ public:
 	void setSkipSignature(bool skip) { _skipSignature = skip; }
 	void setKeepTransparencyPaletted(bool keep) { _keepTransparencyPaletted = keep; }
 private:
-	Graphics::PixelFormat getByteOrderRgbaPixelFormat() const;
+	Graphics::PixelFormat getByteOrderRgbaPixelFormat(bool isAlpha) const;
 
 	byte *_palette;
 	uint16 _paletteColorCount;


### PR DESCRIPTION
This PR reverts part of 9f98cddf8dc015e0cdc6b57e303b693bba3cc1fc commit - the byte order part of the commit is kept as is, but I restored the code that checked if alpha-channel is present and providing `isAlpha ? 8 : 0` bits for pixel format.

This fixes the root cause of https://bugs.scummvm.org/ticket/11568 issue, because Wintermute engine decides to use color key for PNG images by checking `getSurface()->format.aBits() == 0`.