### PR TITLE
ENGINES: Ensure there is no recursive call to auto-save

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -537,6 +537,11 @@ void Engine::handleAutoSave() {
 }
 
 void Engine::saveAutosaveIfEnabled() {
+	// Reset the last autosave time first.
+	// Doing it here rather than after saving the game prevents recursive calls if saving the game
+	// causes the engine to poll events (as is the case with the AGS engine for example).
+	_lastAutosaveTime = _system->getMillis();
+
 	if (_autosaveInterval != 0) {
 		bool saveFlag = canSaveAutosaveCurrently();
 
@@ -556,13 +561,9 @@ void Engine::saveAutosaveIfEnabled() {
 		if (!saveFlag) {
 			// Set the next autosave interval to be in 5 minutes, rather than whatever
 			// full autosave interval the user has selected
-			_lastAutosaveTime = _system->getMillis() + (5 * 60 * 1000) - _autosaveInterval;
-			return;
+			_lastAutosaveTime += (5 * 60 * 1000) - _autosaveInterval;
 		}
 	}
-
-	// Reset the last autosave time
-	_lastAutosaveTime = _system->getMillis();
 }
 
 void Engine::errorString(const char *buf1, char *buf2, int size) {


### PR DESCRIPTION
When autosave triggers in the AGS engine, it causes an infinite recursive loop because the AGS engine polls events when saving games. Here is a portion of the call stack (I don't think you need the remaining 1705 lines ;-) ):
```
frame #1706: AGS3::update_polled_stuff_if_runtime() at game_run.cpp:989:19
frame #1707: AGS3::save_game(slotn=0, descript="Autosave") at game.cpp:924:2
frame #1708: AGS::AGSEngine::saveGameState(slot=0, desc, isAutosave=true) at ags.cpp:233:8
frame #1709: Engine::saveAutosaveIfEnabled() at engine.cpp:550:19
frame #1710: Engine::handleAutoSave() at engine.cpp:535:3
frame #1711: DefaultEventManager::pollEvent(event) at default-events.cpp:89:13
frame #1712: AGS::EventsManager::pollEvents() at events.cpp:45:38
frame #1713: AGS3::update_polled_stuff_if_runtime() at game_run.cpp:989:19
frame #1714: AGS3::save_game(slotn=0, descript="Autosave") at game.cpp:924:2
frame #1715: AGS::AGSEngine::saveGameState(slot=0, desc, isAutosave=true) at ags.cpp:233:8
frame #1716: Engine::saveAutosaveIfEnabled() at engine.cpp:550:19
frame #1717: Engine::handleAutoSave() at engine.cpp:535:3
frame #1718: DefaultEventManager::pollEvent(event) at default-events.cpp:89:13
frame #1719: AGS::EventsManager::pollEvents() at events.cpp:45:38
frame #1720: AGS3::sys_evt_process_pending() at sys_events.cpp:288:19
frame #1721: AGS3::UpdateGameOnce(checkControls=true, extraBitmap, extraX=0, extraY=0) at game_run.cpp:705:2
```

I could check for the recursive call in `AGSEngine::saveGameState` or `AGS3::save_game`, but it seems to me it might be better to do it at the base Engine level, which is what I am proposing in this pull request.

In this change I am assuming that the time it takes to create the savegame is negligible compared to the autosave interval, so updating the timer before doing the save should have little effect other than preventing the recursive call.