### PR TITLE
CONFIGURE: Enable building with Windows text console output

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -71,7 +71,7 @@ static const char HELP_STRING[] =
 	"  -z, --list-games         Display list of supported games and exit\n"
 	"  --list-all-games         Display list of all detected games and exit\n"
 	"  -t, --list-targets       Display list of configured targets and exit\n"
-	"  --list-engines           Display list of suppported engines and exit\n"
+	"  --list-engines           Display list of supported engines and exit\n"
 	"  --list-all-engines       Display list of all detection engines and exit\n"
 	"  --list-debugflags=engine Display list of engine specified debugflags\n"
 	"                           if engine=global or engine is not specified, then it will list global debugflags\n"

--- a/configure
+++ b/configure
@@ -221,6 +221,7 @@ _optimization_level=
 _default_optimization_level=-O2
 _nuked_opl=yes
 _builtin_resources=yes
+_windows_console=yes
 _windows_unicode=no
 # Default commands
 _ranlib=ranlib
@@ -907,6 +908,8 @@ Optional Features:
                            you are doing!
   --no-builtin-resources   do not include additional resources (e.g. engine data, fonts)
                            into the ScummVM binary
+  --enable-windows-console  show console output on Windows (default)
+  --disable-windows-console do not show console output on Windows
   --enable-windows-unicode  use Windows Unicode APIs
   --disable-windows-unicode use Windows ANSI APIs (default)
 
@@ -1378,6 +1381,12 @@ for ac_option in $@; do
 		;;
 	--no-builtin-resources)
 		_builtin_resources=no
+		;;
+	--enable-windows-console)
+		_windows_console=yes
+		;;
+	--disable-windows-console)
+		_windows_console=no
 		;;
 	--enable-windows-unicode)
 		_windows_unicode=yes
@@ -5960,6 +5969,21 @@ fi
 
 if test "$_text_console" = yes ; then
 	echo_n ", text console"
+	if test "$_windows_console" = no ; then
+		case "$_host_os" in
+			mingw*)
+				_windows_console=yes
+				;;
+		esac
+	fi
+fi
+
+if test "$_windows_console" = yes ; then
+	case "$_host_os" in
+		mingw*)
+			echo_n ", Windows console"
+			;;
+	esac
 fi
 
 if test "$_vkeybd" = yes ; then
@@ -6036,6 +6060,11 @@ case $_host_os in
 	mingw*)
 		if test "$_windows_unicode" = yes; then
 			append_var DEFINES "-DUNICODE -D_UNICODE"
+		fi
+		# SDL2 sets -mwindows flag by default in sdl2.pc
+		# We need to directly replace this in the SDL pkg-config
+		if test "$_windows_console" = yes; then
+			LIBS=`echo $LIBS | sed -e 's/-mconsole//g' -e 's/-mwindows//g'`
 		fi
 		;;
 	riscos)


### PR DESCRIPTION
Previously available on the wiki as a patch file for developers to apply to their configure script, this PR moves the option to a flag. The default behavior is for NO console output because users prefer that (for some weird reason).

`--enable-windows-console` and `--disable-windows-console` are the new flags. I'm open to suggestions if someone has a better name or description.

I noticed this when PR #3003 moved things around in `configure`, which caused the patch to stop working. If this PR is merged, I'll remove the patch from the wiki and suggest that devs use this flag instead.

I've tested this only on mingw-w32 with the console enabled, the console disabled by the new flag, and the console disabled as the default option.