### PR TITLE
GRAPHICS: 32-bit surfaces, points, and rects

### DIFF
--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -176,8 +176,8 @@ Surface::Surface()
 
 void Surface::copyRectToTexture(uint x, uint y, uint w, uint h, const void *srcPtr, uint srcPitch) {
 	Graphics::Surface *dstSurf = getSurface();
-	assert(x + w <= dstSurf->w);
-	assert(y + h <= dstSurf->h);
+	assert(x + w <= (uint)dstSurf->w);
+	assert(y + h <= (uint)dstSurf->h);
 
 	// *sigh* Common::Rect::extend behaves unexpected whenever one of the two
 	// parameters is an empty rect. Thus, we check whether the current dirty
@@ -194,7 +194,7 @@ void Surface::copyRectToTexture(uint x, uint y, uint w, uint h, const void *srcP
 	const uint pitch = dstSurf->pitch;
 	const uint bytesPerPixel = dstSurf->format.bytesPerPixel;
 
-	if (srcPitch == pitch && x == 0 && w == dstSurf->w) {
+	if (srcPitch == pitch && x == 0 && w == (uint)dstSurf->w) {
 		memcpy(dst, src, h * pitch);
 	} else {
 		while (h-- > 0) {
@@ -257,7 +257,7 @@ void Texture::allocate(uint width, uint height) {
 
 	// In case the needed texture dimension changed we will reinitialize the
 	// texture data buffer.
-	if (_glTexture.getWidth() != _textureData.w || _glTexture.getHeight() != _textureData.h) {
+	if (_glTexture.getWidth() != (uint)_textureData.w || _glTexture.getHeight() != (uint)_textureData.h) {
 		// Create a buffer for the texture data.
 		_textureData.create(_glTexture.getWidth(), _glTexture.getHeight(), _format);
 	}
@@ -330,7 +330,7 @@ void TextureCLUT8::allocate(uint width, uint height) {
 
 	// We only need to reinitialize our CLUT8 surface when the output size
 	// changed.
-	if (width == _clut8Data.w && height == _clut8Data.h) {
+	if (width == (uint)_clut8Data.w && height == (uint)_clut8Data.h) {
 		return;
 	}
 
@@ -443,7 +443,7 @@ void FakeTexture::allocate(uint width, uint height) {
 
 	// We only need to reinitialize our surface when the output size
 	// changed.
-	if (width == _rgbData.w && height == _rgbData.h) {
+	if (width == (uint)_rgbData.w && height == (uint)_rgbData.h) {
 		return;
 	}
 
@@ -604,7 +604,7 @@ void TextureCLUT8GPU::allocate(uint width, uint height) {
 
 	// In case the needed texture dimension changed we will reinitialize the
 	// texture data buffer.
-	if (_clut8Texture.getWidth() != _clut8Data.w || _clut8Texture.getHeight() != _clut8Data.h) {
+	if ((int)_clut8Texture.getWidth() != _clut8Data.w || (int)_clut8Texture.getHeight() != _clut8Data.h) {
 		// Create a buffer for the texture data.
 		_clut8Data.create(_clut8Texture.getWidth(), _clut8Texture.getHeight(), Graphics::PixelFormat::createFormatCLUT8());
 	}

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -2281,7 +2281,7 @@ void SurfaceSdlGraphicsManager::displayActivityIconOnOSD(const Graphics::Surface
 
 		byte *dst = (byte *) _osdIconSurface->pixels;
 		const byte *src = (const byte *) icon->getPixels();
-		for (uint y = 0; y < icon->h; y++) {
+		for (int y = 0; y < icon->h; y++) {
 			memcpy(dst, src, icon->w * iconFormat.bytesPerPixel);
 			src += icon->pitch;
 			dst += _osdIconSurface->pitch;

--- a/common/rect.h
+++ b/common/rect.h
@@ -44,15 +44,15 @@ namespace Common {
  * Simple class for handling both 2D position and size.
  */
 struct Point {
-	int16 x;	/*!< The horizontal position of the point. */
-	int16 y;	/*!< The vertical position of the point. */
+	int32 x;	/*!< The horizontal position of the point. */
+	int32 y;	/*!< The vertical position of the point. */
 
 	Point() : x(0), y(0) {}
 
 	/**
 	 * Create a point with position defined by @p x1 and @p y1.
 	 */
-	Point(int16 x1, int16 y1) : x(x1), y(y1) {}
+	Point(int32 x1, int32 y1) : x(x1), y(y1) {}
 	/**
 	 * Determine whether the position of two points is the same.
 	 */
@@ -143,21 +143,21 @@ static inline Point operator*(double multiplier, const Point &p) { return Point(
  * When writing code using our Rect class, always keep this principle in mind!
 */
 struct Rect {
-	int16 top, left;		/*!< The point at the top left of the rectangle (part of the Rect). */
-	int16 bottom, right;	/*!< The point at the bottom right of the rectangle (not part of the Rect). */
+	int32 top, left;		/*!< The point at the top left of the rectangle (part of the Rect). */
+	int32 bottom, right;	/*!< The point at the bottom right of the rectangle (not part of the Rect). */
 
 	Rect() : top(0), left(0), bottom(0), right(0) {}
 	/**
 	 * Create a rectangle with the top-left corner at position (0, 0) and the given width @p w and height @p h.
 	 */
-	Rect(int16 w, int16 h) : top(0), left(0), bottom(h), right(w) {}
+	Rect(int32 w, int32 h) : top(0), left(0), bottom(h), right(w) {}
 	/**
 	 * Create a rectangle with the top-left corner at the given position (x1, y1)
 	 * and the bottom-right corner at the position (x2, y2).
 	 *
 	 * The @p x2 value must be greater or equal @p x1 and @p y2 must be greater or equal @p y1.
 	 */
-	Rect(int16 x1, int16 y1, int16 x2, int16 y2) : top(y1), left(x1), bottom(y2), right(x2) {
+	Rect(int32 x1, int32 y1, int32 x2, int32 y2) : top(y1), left(x1), bottom(y2), right(x2) {
 		assert(isValidRect());
 	}
 	/**
@@ -173,14 +173,14 @@ struct Rect {
 	 */
 	bool operator!=(const Rect &rhs) const { return !equals(rhs); }
 
-	int16 width() const { return right - left; }  /*!< Return the width of a rectangle. */
-	int16 height() const { return bottom - top; } /*!< Return the height of a rectangle. */
+	int32 width() const { return right - left; }  /*!< Return the width of a rectangle. */
+	int32 height() const { return bottom - top; } /*!< Return the height of a rectangle. */
 
-	void setWidth(int16 aWidth) {   /*!< Set the width to @p aWidth value. */
+	void setWidth(int32 aWidth) {   /*!< Set the width to @p aWidth value. */
 		right = left + aWidth;
 	}
 
-	void setHeight(int16 aHeight) { /*!< Set the height to @p aHeight value. */
+	void setHeight(int32 aHeight) { /*!< Set the height to @p aHeight value. */
 		bottom = top + aHeight;
 	}
 
@@ -192,7 +192,7 @@ struct Rect {
 	 *
 	 * @return True if the given position is inside this rectangle, false otherwise.
 	 */
-	bool contains(int16 x, int16 y) const {
+	bool contains(int32 x, int32 y) const {
 		return (left <= x) && (x < right) && (top <= y) && (y < bottom);
 	}
 
@@ -272,7 +272,7 @@ struct Rect {
 	 *
 	 * @param offset The size to grow by.
 	 */
-	void grow(int16 offset) {
+	void grow(int32 offset) {
 		top -= offset;
 		left -= offset;
 		bottom += offset;
@@ -302,7 +302,7 @@ struct Rect {
    	/**
 	 * Reduce the dimensions of this rectangle by setting max width and max heigth.
 	 */
-	void clip(int16 maxw, int16 maxh) {
+	void clip(int32 maxw, int32 maxh) {
 		clip(Rect(0, 0, maxw, maxh));
 	}
 
@@ -326,7 +326,7 @@ struct Rect {
 	/**
 	 * Move this rectangle to the position defined by @p x, @p y.
 	 */
-	void moveTo(int16 x, int16 y) {
+	void moveTo(int32 x, int32 y) {
 		bottom += y - top;
 		right += x - left;
 		top = y;
@@ -336,7 +336,7 @@ struct Rect {
 	/**
 	 * Move the rectangle by the given delta x and y values.
 	 */
-	void translate(int16 dx, int16 dy) {
+	void translate(int32 dx, int32 dy) {
 		left += dx; right += dx;
 		top += dy; bottom += dy;
 	}
@@ -359,7 +359,7 @@ struct Rect {
 	 * Create a rectangle around the given center.
 	 * @note The center point is rounded up and left when given an odd width and height.
 	 */
-	static Rect center(int16 cx, int16 cy, int16 w, int16 h) {
+	static Rect center(int32 cx, int32 cy, int32 w, int32 h) {
 		int x = cx - w / 2, y = cy - h / 2;
 		return Rect(x, y, x + w, y + h);
 	}

--- a/engines/access/bubble_box.cpp
+++ b/engines/access/bubble_box.cpp
@@ -67,7 +67,7 @@ void BubbleBox::clearBubbles() {
 		_vm->_screen->_screenYOff = 0;
 		Common::Rect r = _bubbles[i];
 		r.left -= 2;
-		r.right = MIN(r.right, (int16)_vm->_screen->w);
+		r.right = MIN(r.right, (int32)_vm->_screen->w);
 
 		_vm->_screen->copyBlock(&_vm->_buffer1, r);
 	}

--- a/engines/ags/lib/allegro/surface.cpp
+++ b/engines/ags/lib/allegro/surface.cpp
@@ -34,7 +34,7 @@ BITMAP::BITMAP(Graphics::ManagedSurface *owner) : _owner(owner),
 	w(owner->w), h(owner->h), pitch(owner->pitch), format(owner->format),
 	clip(true), ct(0), cl(0), cr(owner->w), cb(owner->h) {
 	line.resize(h);
-	for (uint y = 0; y < h; ++y)
+	for (int y = 0; y < h; ++y)
 		line[y] = (byte *)_owner->getBasePtr(0, y);
 }
 

--- a/engines/ags/lib/allegro/surface.h
+++ b/engines/ags/lib/allegro/surface.h
@@ -33,7 +33,7 @@ class BITMAP {
 private:
 	Graphics::ManagedSurface *_owner;
 	public:
-	uint16 &w, &h, &pitch;
+	int32 &w, &h, &pitch;
 	Graphics::PixelFormat &format;
 	bool clip;
 	int ct, cb, cl, cr;

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -1026,8 +1026,8 @@ bool BladeRunnerEngine::loadSplash() {
 
 Common::Point BladeRunnerEngine::getMousePos() const {
 	Common::Point p = _eventMan->getMousePos();
-	p.x = CLIP(p.x, int16(0), int16(639));
-	p.y = CLIP(p.y, int16(0), int16(479));
+	p.x = CLIP(p.x, int32(0), int32(639));
+	p.y = CLIP(p.y, int32(0), int32(479));
 	return p;
 }
 

--- a/engines/bladerunner/ui/esper.cpp
+++ b/engines/bladerunner/ui/esper.cpp
@@ -957,10 +957,10 @@ void ESPER::drawPhotoWithGrid(Graphics::Surface &surface) {
 }
 
 void ESPER::drawSelection(Graphics::Surface &surface, bool crosshair, int style) {
-	int left   = CLIP(_selection.left,   _screen.left, (int16)(_screen.right  - 1));
-	int top    = CLIP(_selection.top,    _screen.top,  (int16)(_screen.bottom - 1));
-	int right  = CLIP(_selection.right,  _screen.left, (int16)(_screen.right  - 1));
-	int bottom = CLIP(_selection.bottom, _screen.top,  (int16)(_screen.bottom - 1));
+	int left   = CLIP(_selection.left,   _screen.left, (int32)(_screen.right  - 1));
+	int top    = CLIP(_selection.top,    _screen.top,  (int32)(_screen.bottom - 1));
+	int right  = CLIP(_selection.right,  _screen.left, (int32)(_screen.right  - 1));
+	int bottom = CLIP(_selection.bottom, _screen.top,  (int32)(_screen.bottom - 1));
 
 	int color = surface.format.RGBToColor(0, 144, 0);
 	if (style) {

--- a/engines/cruise/cruise_main.cpp
+++ b/engines/cruise/cruise_main.cpp
@@ -1389,8 +1389,8 @@ bool checkInput(int16 *buttonPtr) {
 extern bool manageEvents();
 
 int CruiseEngine::processInput() {
-	int16 mouseX = 0;
-	int16 mouseY = 0;
+	int32 mouseX = 0;
+	int32 mouseY = 0;
 	int16 button = 0;
 
 	/*if (inputSub1keyboad())
@@ -1746,7 +1746,7 @@ bool manageEvents() {
 	return false;
 }
 
-void getMouseStatus(int16 *pMouseVar, int16 *pMouseX, int16 *pMouseButton, int16 *pMouseY) {
+void getMouseStatus(int16 *pMouseVar, int32 *pMouseX, int16 *pMouseButton, int32 *pMouseY) {
 	*pMouseX = currentMouseX;
 	*pMouseY = currentMouseY;
 	*pMouseButton = currentMouseButton;
@@ -1757,7 +1757,7 @@ void CruiseEngine::mainLoop() {
 	//int32 t_start,t_left;
 	//uint32 t_end;
 	//int32 q=0;                     /* Dummy */
-	int16 mouseX, mouseY;
+	int32 mouseX, mouseY;
 	int16 mouseButton;
 
 	int enableUser = 0;

--- a/engines/cruise/cruise_main.h
+++ b/engines/cruise/cruise_main.h
@@ -101,7 +101,7 @@ void getFileExtention(const char *name, char *buffer);
 void *allocAndZero(int size);
 void freeStuff2();
 void mainLoop();
-void getMouseStatus(int16 *pMouseVar, int16 *pMouseX, int16 *pMouseButton, int16 *pMouseY);
+void getMouseStatus(int16 *pMouseVar, int32 *pMouseX, int16 *pMouseButton, int32 *pMouseY);
 bool testMask(int x, int y, unsigned char* pData, int stride);
 menuElementSubStruct *getSelectedEntryInMenu(menuStruct *pMenu);
 void closeAllMenu();

--- a/engines/cruise/function.cpp
+++ b/engines/cruise/function.cpp
@@ -164,8 +164,8 @@ int16 Op_Narrator() {
 
 int16 Op_GetMouseX() {
 	int16 dummy;
-	int16 mouseX;
-	int16 mouseY;
+	int32 mouseX;
+	int32 mouseY;
 	int16 mouseButton;
 
 	getMouseStatus(&dummy, &mouseX, &mouseButton, &mouseY);
@@ -175,8 +175,8 @@ int16 Op_GetMouseX() {
 
 int16 Op_GetMouseY() {
 	int16 dummy;
-	int16 mouseX;
-	int16 mouseY;
+	int32 mouseX;
+	int32 mouseY;
 	int16 mouseButton;
 
 	getMouseStatus(&dummy, &mouseX, &mouseButton, &mouseY);
@@ -705,8 +705,8 @@ int16 Op_FadeIn() {
 
 int16 Op_GetMouseButton() {
 	int16 dummy;
-	int16 mouseX;
-	int16 mouseY;
+	int32 mouseX;
+	int32 mouseY;
 	int16 mouseButton;
 
 	getMouseStatus(&dummy, &mouseX, &mouseButton, &mouseY);

--- a/engines/cruise/gfxModule.cpp
+++ b/engines/cruise/gfxModule.cpp
@@ -230,8 +230,8 @@ void gfxModuleData_flipScreen() {
 }
 
 void gfxModuleData_addDirtyRect(const Common::Rect &r) {
-	_vm->_dirtyRects.push_back(Common::Rect(	MAX(r.left, (int16)0), MAX(r.top, (int16)0),
-		MIN(r.right, (int16)320), MIN(r.bottom, (int16)200)));
+	_vm->_dirtyRects.push_back(Common::Rect(	MAX(r.left, (int32)0), MAX(r.top, (int32)0),
+		MIN(r.right, (int32)320), MIN(r.bottom, (int32)200)));
 }
 
 /**

--- a/engines/cruise/mainDraw.cpp
+++ b/engines/cruise/mainDraw.cpp
@@ -1561,8 +1561,8 @@ void mainDraw(bool waitFl) {
 			return;
 		}
 	} else if ((linkedRelation) && (linkedMsgList)) {
-		int16 mouseX;
-		int16 mouseY;
+		int32 mouseX;
+		int32 mouseY;
 		int16 button;
 		getMouseStatus(&main10, &mouseX, &button, &mouseY);
 

--- a/engines/cruise/menu.cpp
+++ b/engines/cruise/menu.cpp
@@ -152,8 +152,8 @@ void updateMenuMouse(int mouseX, int mouseY, menuStruct *pMenu) {
 bool manageEvents();
 
 int processMenu(menuStruct *pMenu) {
-	int16 mouseX;
-	int16 mouseY;
+	int32 mouseX;
+	int32 mouseY;
 	int16 mouseButton;
 	int di;
 	int si;

--- a/engines/cryomni3d/versailles/engine.cpp
+++ b/engines/cryomni3d/versailles/engine.cpp
@@ -541,8 +541,8 @@ void CryOmni3DEngine_Versailles::makeTranslucent(Graphics::Surface &dst,
 
 	const byte *srcP = (const byte *) src.getPixels();
 	byte *dstP = (byte *) dst.getPixels();
-	for (uint y = 0; y < dst.h; y++) {
-		for (uint x = 0; x < dst.w; x++) {
+	for (int y = 0; y < dst.h; y++) {
+		for (int x = 0; x < dst.w; x++) {
 			dstP[x] = _transparentPaletteMap[srcP[x]];
 		}
 		dstP += dst.pitch;

--- a/engines/director/images.cpp
+++ b/engines/director/images.cpp
@@ -226,7 +226,7 @@ bool BITDDecoder::loadStream(Common::SeekableReadStream &stream) {
 	}
 
 	int offset = 0;
-	if (_surface->w < (pixels.size() / _surface->h))
+	if (_surface->w < (int)(pixels.size() / _surface->h))
 		offset = (pixels.size() / _surface->h) - _surface->w;
 
 	uint32 color;

--- a/engines/glk/debugger.cpp
+++ b/engines/glk/debugger.cpp
@@ -118,11 +118,11 @@ void Debugger::saveRawPicture(const RawDecoder &rd, Common::WriteStream &ws) {
 	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
 	Graphics::ManagedSurface destSurface(surface->w, surface->h, format);
 
-	for (uint y = 0; y < surface->h; ++y) {
+	for (int y = 0; y < surface->h; ++y) {
 		const byte *srcP = (const byte *)surface->getBasePtr(0, y);
 		uint32 *destP = (uint32 *)destSurface.getBasePtr(0, y);
 
-		for (uint x = 0; x < surface->w; ++x, ++srcP, ++destP) {
+		for (int x = 0; x < surface->w; ++x, ++srcP, ++destP) {
 			if ((int)*srcP == transColor || (int)*srcP < palStart) {
 				*destP = format.ARGBToColor(0, 0, 0, 0);
 			} else {

--- a/engines/glk/glk_api.cpp
+++ b/engines/glk/glk_api.cpp
@@ -922,7 +922,7 @@ bool GlkAPI::glk_image_draw_scaled(winid_t win, const Graphics::Surface &image, 
 	if (!win) {
 		warning("image_draw_scaled: invalid ref");
 	} else if (g_conf->_graphics) {
-		if (image.w == width && image.h == height) {
+		if (image.w == (int32)width && image.h == (int32)height) {
 			return glk_image_draw(win, image, transColor, xp, yp);
 
 		} else {

--- a/engines/glk/picture.cpp
+++ b/engines/glk/picture.cpp
@@ -217,7 +217,7 @@ Picture *Pictures::load(const Common::String &name) {
 Picture *Pictures::scale(Picture *src, size_t sx, size_t sy) {
 	// Check for the presence of an already scaled version of that size
 	Picture *dst = retrieve(src->_name, true);
-	if (dst && dst->w == sx && dst->h == sy)
+	if (dst && (size_t)dst->w == sx && (size_t)dst->h == sy)
 		return dst;
 
 	// Create a new picture of the destination size and rescale the source picture

--- a/engines/glk/selection.cpp
+++ b/engines/glk/selection.cpp
@@ -147,8 +147,8 @@ void Selection::startSelection(const Point &pos) {
 		return;
 	}
 
-	tx = MIN(pos.x, (int16)_hor);
-	ty = MIN(pos.y, (int16)_ver);
+	tx = MIN(pos.x, (int32)_hor);
+	ty = MIN(pos.y, (int32)_ver);
 
 	_select.left = _select.right = _last.x = tx;
 	_select.top = _select.bottom = _last.y = ty;
@@ -167,8 +167,8 @@ void Selection::moveSelection(const Point &pos) {
 		return;
 	}
 
-	tx = MIN(pos.x, (int16)_hor);
-	ty = MIN(pos.y, (int16)_ver);
+	tx = MIN(pos.x, (int32)_hor);
+	ty = MIN(pos.y, (int32)_ver);
 
 	_select.right = _last.x = tx;
 	_select.bottom = _last.y = ty;

--- a/engines/glk/window_text_grid.h
+++ b/engines/glk/window_text_grid.h
@@ -101,8 +101,8 @@ public:
 	 */
 	void setSize(const Point &newSize) override {
 		Window::setSize(newSize);
-		_curX = CLIP((int16)_curX, _bbox.left, _bbox.right);
-		_curY = CLIP((int16)_curY, _bbox.top, _bbox.bottom);
+		_curX = CLIP((int32)_curX, _bbox.left, _bbox.right);
+		_curY = CLIP((int32)_curY, _bbox.top, _bbox.bottom);
 	}
 
 	/**
@@ -110,8 +110,8 @@ public:
 	 */
 	void setPosition(const Point &newPos) override {
 		_bbox.moveTo(newPos);
-		_curX = CLIP((int16)_curX, _bbox.left, _bbox.right);
-		_curY = CLIP((int16)_curY, _bbox.top, _bbox.bottom);
+		_curX = CLIP((int32)_curX, _bbox.left, _bbox.right);
+		_curY = CLIP((int32)_curY, _bbox.top, _bbox.bottom);
 	}
 
 	/**

--- a/engines/hopkins/graphics.cpp
+++ b/engines/hopkins/graphics.cpp
@@ -1227,10 +1227,10 @@ void GraphicsManager::displayDebugRect(Graphics::Surface *surface, const Common:
 
 	// Move for scrolling offset and adjust to crop on-screen
 	r.translate(-_scrollPosX, 0);
-	r.left = MAX(r.left, (int16)0);
-	r.top = MAX(r.top, (int16)0);
-	r.right = MIN(r.right, (int16)SCREEN_WIDTH);
-	r.bottom = MIN(r.bottom, (int16)SCREEN_HEIGHT);
+	r.left = MAX(r.left, (int32)0);
+	r.top = MAX(r.top, (int32)0);
+	r.right = MIN(r.right, (int32)SCREEN_WIDTH);
+	r.bottom = MIN(r.bottom, (int32)SCREEN_HEIGHT);
 
 	// If there's an on-screen portion, display it
 	if (r.isValidRect())

--- a/engines/icb/movie_pc.cpp
+++ b/engines/icb/movie_pc.cpp
@@ -178,7 +178,7 @@ uint32 MovieManager::drawFrame(uint32 surface_id) {
 	}
 
 	// For access to buffer
-	uint16 pitch;
+	int pitch;
 	uint8 *surface_address;
 
 	// Lock the surface

--- a/engines/icb/options_manager_pc.cpp
+++ b/engines/icb/options_manager_pc.cpp
@@ -6174,7 +6174,7 @@ void OptionsManager::DrawSlideShow() {
 
 		// Lock the buffers now so bink has somewhere ot put it's data
 		uint8 *surface = (uint8 *)surface_manager->Lock_surface(m_mySlotSurface1ID);
-		uint16 pitch = surface_manager->Get_pitch(m_mySlotSurface1ID);
+		int pitch = surface_manager->Get_pitch(m_mySlotSurface1ID);
 		uint32 height = surface_manager->Get_height(m_mySlotSurface1ID);
 
 		// Screen coordinates

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -1241,8 +1241,8 @@ void menuCommandsCallback(int action, Common::String &text, void *data) {
 
 void Gui::invertWindowColors(WindowReference winID) {
 	Graphics::ManagedSurface *srf = findWindow(winID)->getWindowSurface();
-	for (uint y = 0; y < srf->h; y++) {
-		for (uint x = 0; x < srf->w; x++) {
+	for (int y = 0; y < srf->h; y++) {
+		for (int x = 0; x < srf->w; x++) {
 			byte p = *(byte *)srf->getBasePtr(x, y);
 			*(byte *)srf->getBasePtr(x, y) =
 				(p == kColorWhite) ? kColorBlack : kColorGray80;

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -738,8 +738,8 @@ void Gui::drawDraggedObject() {
 		ImageAsset *asset = _assets[_draggedObj.id];
 
 		// In case of overflow from the right/top
-		uint w = asset->getWidth() + MIN((int16)0, _draggedObj.pos.x);
-		uint h = asset->getHeight() + MIN((int16)0, _draggedObj.pos.y);
+		uint w = asset->getWidth() + MIN((int32)0, _draggedObj.pos.x);
+		uint h = asset->getHeight() + MIN((int32)0, _draggedObj.pos.y);
 
 		// In case of overflow from the bottom/left
 		if (_draggedObj.pos.x > 0 && _draggedObj.pos.x + w > kScreenWidth) {
@@ -766,7 +766,7 @@ void Gui::drawDraggedObject() {
 				target.x + _draggedSurface.w,
 				target.y + _draggedSurface.h),
 			Common::Point(0, 0));
-		asset->blitInto(&_draggedSurface, MIN((int16)0, _draggedObj.pos.x), MIN((int16)0, _draggedObj.pos.y), kBlitBIC);
+		asset->blitInto(&_draggedSurface, MIN((int32)0, _draggedObj.pos.x), MIN((int32)0, _draggedObj.pos.y), kBlitBIC);
 
 		g_system->copyRectToScreen(
 			_draggedSurface.getBasePtr(0, 0),

--- a/engines/macventure/image.cpp
+++ b/engines/macventure/image.cpp
@@ -458,10 +458,10 @@ void ImageAsset::blitDirect(Graphics::ManagedSurface *target, int ox, int oy, co
 	uint sx, sy, w, h;
 	calculateSectionToDraw(target, ox, oy, bitWidth, bitHeight, sx, sy, w, h);
 
-	for (uint y = 0; y < h; y++) {
+	for (int y = 0; y < h; y++) {
 		uint bmpofs = (y + sy) * rowBytes;
 		byte pix = 0;
-		for (uint x = 0; x < w; x++) {
+		for (int x = 0; x < w; x++) {
 			assert(ox + x <= target->w);
 			assert(oy + y <= target->h);
 			pix = data[bmpofs + ((x + sx) >> 3)] & (1 << (7 - ((x + sx) & 7)));
@@ -479,8 +479,8 @@ void ImageAsset::blitBIC(Graphics::ManagedSurface *target, int ox, int oy, const
 		uint bmpofs = (y + sy) * rowBytes;
 		byte pix = 0;
 		for (uint x = 0; x < w; x++) {
-			assert(ox + x <= target->w);
-			assert(oy + y <= target->h);
+			assert(ox + x <= (uint)target->w);
+			assert(oy + y <= (uint)target->h);
 			pix = data[bmpofs + ((x + sx) >> 3)] & (1 << (7 - ((x + sx) & 7)));
 			if (pix) {
 				*((byte *)target->getBasePtr(ox + x, oy + y)) = kColorWhite;
@@ -497,8 +497,8 @@ void ImageAsset::blitOR(Graphics::ManagedSurface *target, int ox, int oy, const 
 		uint bmpofs = (y + sy) * rowBytes;
 		byte pix = 0;
 		for (uint x = 0; x < w; x++) {
-			assert(ox + x <= target->w);
-			assert(oy + y <= target->h);
+			assert(ox + x <= (uint)target->w);
+			assert(oy + y <= (uint)target->h);
 			pix = data[bmpofs + ((x + sx) >> 3)] & (1 << (7 - ((x + sx) & 7)));
 			if (pix) {
 				*((byte *)target->getBasePtr(ox + x, oy + y)) = kColorBlack;
@@ -517,8 +517,8 @@ void ImageAsset::blitXOR(Graphics::ManagedSurface *target, int ox, int oy, const
 		for (uint x = 0; x < w; x++) {
 			pix = data[bmpofs + ((x + sx) >> 3)] & (1 << (7 - ((x + sx) & 7)));
 			if (pix) { // We need to xor
-				assert(ox + x <= target->w);
-				assert(oy + y <= target->h);
+				assert(ox + x <= (uint)target->w);
+				assert(oy + y <= (uint)target->h);
 				byte p = *((byte *)target->getBasePtr(ox + x, oy + y));
 				*((byte *)target->getBasePtr(ox + x, oy + y)) =
 					(p == kColorWhite) ? kColorBlack : kColorWhite;
@@ -532,12 +532,12 @@ void ImageAsset::calculateSectionToDraw(Graphics::ManagedSurface *target, int &o
 	calculateSectionInDirection(target->w, bitWidth, ox, sx, w);
 	calculateSectionInDirection(target->h, bitHeight, oy, sy, h);
 
-	assert(w <= target->w);
+	assert((int)w <= target->w);
 	assert((int)w >= 0);
-	assert(w <= bitWidth);
-	assert(h <= target->h);
+	assert((int)w <= bitWidth);
+	assert((int)h <= target->h);
 	assert((int)h >= 0);
-	assert(h <= bitHeight);
+	assert((int)h <= bitHeight);
 }
 
 void ImageAsset::calculateSectionInDirection(uint targetWhole, uint originWhole, int &originPosition, uint &startPosition, uint &blittedWhole) {

--- a/engines/mads/camera.cpp
+++ b/engines/mads/camera.cpp
@@ -83,7 +83,7 @@ void Camera::camPanTo(int target) {
 	}
 }
 
-bool Camera::camPan(int16 *picture_view, int16 *player_loc, int display_size, int picture_size) {
+bool Camera::camPan(int32 *picture_view, int32 *player_loc, int display_size, int picture_size) {
 	bool panningFl = false;
 	if (_panAllowedFl) {
 		Scene &scene = _vm->_game->_scene;

--- a/engines/mads/camera.h
+++ b/engines/mads/camera.h
@@ -53,7 +53,7 @@ public:
 	Camera(MADSEngine *vm);
 
 	void camPanTo(int target);
-	bool camPan(int16 *picture_view, int16 *player_loc, int display_size, int picture_size);
+	bool camPan(int32 *picture_view, int32 *player_loc, int display_size, int picture_size);
 	void setDefaultPanX();
 	void setDefaultPanY();
 };

--- a/engines/mads/player.cpp
+++ b/engines/mads/player.cpp
@@ -342,7 +342,7 @@ void Player::update() {
 			scene._spriteSlots[slotIndex]._flags = IMG_ERASE;
 
 		int newDepth = 1;
-		int yp = MIN(_playerPos.y, (int16)(MADS_SCENE_HEIGHT - 1));
+		int yp = MIN(_playerPos.y, (int32)(MADS_SCENE_HEIGHT - 1));
 
 		for (int idx = 1; idx < DEPTH_BANDS_SIZE; ++idx) {
 			if (scene._sceneInfo->_depthList[newDepth] >= yp)

--- a/engines/mads/screen.cpp
+++ b/engines/mads/screen.cpp
@@ -682,7 +682,7 @@ void Screen::panTransition(MSurface &newScreen, byte *palData, int entrySide,
 //	uint32 baseTicks, currentTicks;
 	byte paletteMap[256];
 
-	size.x = MIN(newScreen.w, (uint16)MADS_SCREEN_WIDTH);
+	size.x = MIN(newScreen.w, MADS_SCREEN_WIDTH);
 	size.y = newScreen.h;
 	if (newScreen.h >= MADS_SCREEN_HEIGHT)
 		size.y = MADS_SCENE_HEIGHT;

--- a/engines/mohawk/bitmap.cpp
+++ b/engines/mohawk/bitmap.cpp
@@ -818,8 +818,8 @@ void DOSBitmap::expandMonochromePlane(Graphics::Surface *surface, Common::Seekab
 
 	// Expand the 8 pixels in a byte into a full byte per pixel
 
-	for (uint32 i = 0; i < surface->h; i++) {
-		for (uint x = 0; x < surface->w;) {
+	for (int32 i = 0; i < surface->h; i++) {
+		for (int x = 0; x < surface->w;) {
 			byte temp = rawStream->readByte();
 
 			for (int j = 7; j >= 0 && x < surface->w; j--) {
@@ -845,7 +845,7 @@ void DOSBitmap::expandEGAPlanes(Graphics::Surface *surface, Common::SeekableRead
 
 	byte *dst = (byte *)surface->getPixels();
 
-	for (uint32 i = 0; i < surface->h; i++) {
+	for (int32 i = 0; i < surface->h; i++) {
 		uint x = 0;
 
 		for (int32 j = 0; j < surface->w / 4; j++) {

--- a/engines/mohawk/livingbooks_code.cpp
+++ b/engines/mohawk/livingbooks_code.cpp
@@ -139,7 +139,7 @@ Common::Point LBValue::toPoint() const {
 	case kLBValueString:
 		{
 		Common::Point ret;
-		sscanf(string.c_str(), "%hd , %hd", &ret.x, &ret.y);
+		sscanf(string.c_str(), "%d , %d", &ret.x, &ret.y);
 		return ret;
 		}
 	case kLBValueInteger:
@@ -158,7 +158,7 @@ Common::Rect LBValue::toRect() const {
 	case kLBValueString:
 		{
 		Common::Rect ret;
-		sscanf(string.c_str(), "%hd , %hd , %hd , %hd", &ret.left, &ret.top, &ret.right, &ret.bottom);
+		sscanf(string.c_str(), "%d , %d , %d , %d", &ret.left, &ret.top, &ret.right, &ret.bottom);
 		return ret;
 		}
 	case kLBValueInteger:

--- a/engines/mohawk/riven_graphics.cpp
+++ b/engines/mohawk/riven_graphics.cpp
@@ -281,11 +281,11 @@ public:
 			Graphics::Surface *screen = _system->lockScreen();
 
 			uint alpha = elapsed * 255 / _duration;
-			for (uint y = 0; y < _mainScreen->h; y++) {
+			for (int y = 0; y < _mainScreen->h; y++) {
 				uint16 *src1 = (uint16 *) _mainScreen->getBasePtr(0, y);
 				uint16 *src2 = (uint16 *) _effectScreen->getBasePtr(0, y);
 				uint16 *dst = (uint16 *) screen->getBasePtr(0, y);
-				for (uint x = 0; x < _mainScreen->w; x++) {
+				for (int x = 0; x < _mainScreen->w; x++) {
 					uint8 r1, g1, b1, r2, g2, b2;
 					_mainScreen->format.colorToRGB(*src1++, r1, g1, b1);
 					_effectScreen->format.colorToRGB(*src2++, r2, g2, b2);
@@ -715,7 +715,7 @@ void RivenGraphics::updateCredits() {
 			Graphics::Surface *frame = findImage(_creditsImage)->getSurface();
 			memcpy(_mainScreen->getBasePtr(124, _mainScreen->h - 1), frame->getBasePtr(0, _creditsPos), frame->pitch);
 			_creditsPos++;
-			if (_creditsPos == _mainScreen->h) {
+			if (_creditsPos == (uint)_mainScreen->h) {
 				_creditsImage++;
 				_creditsPos = 0;
 			}

--- a/engines/myst3/cursor.cpp
+++ b/engines/myst3/cursor.cpp
@@ -98,9 +98,9 @@ void Cursor::loadAvailableCursors() {
 		delete bmpStream;
 
 		// Apply the colorkey for transparency
-		for (uint y = 0; y < surfaceRGBA->h; y++) {
+		for (int y = 0; y < surfaceRGBA->h; y++) {
 			byte *pixels = (byte *)(surfaceRGBA->getBasePtr(0, y));
-			for (uint x = 0; x < surfaceRGBA->w; x++) {
+			for (int x = 0; x < surfaceRGBA->w; x++) {
 				byte *r = pixels + 0;
 				byte *g = pixels + 1;
 				byte *b = pixels + 2;

--- a/engines/myst3/effects.cpp
+++ b/engines/myst3/effects.cpp
@@ -281,7 +281,7 @@ void WaterEffect::apply(Graphics::Surface *src, Graphics::Surface *dst, Graphics
 	uint32 *dstPtr = (uint32 *)dst->getPixels();
 	byte *maskPtr = (byte *)mask->getPixels();
 
-	for (uint y = 0; y < dst->h; y++) {
+	for (int y = 0; y < dst->h; y++) {
 		if (!bottomFace) {
 			uint32 strength = (320 * (9 - y / 64)) / waterEffectAttenuation;
 			if (strength > 4)
@@ -289,7 +289,7 @@ void WaterEffect::apply(Graphics::Surface *src, Graphics::Surface *dst, Graphics
 			hDisplacement = _horizontalDisplacements[strength];
 		}
 
-		for (uint x = 0; x < dst->w; x++) {
+		for (int x = 0; x < dst->w; x++) {
 			int8 maskValue = *maskPtr;
 
 			if (maskValue != 0) {
@@ -395,8 +395,8 @@ void LavaEffect::applyForFace(uint face, Graphics::Surface *src, Graphics::Surfa
 	uint32 *dstPtr = (uint32 *)dst->getPixels();
 	byte *maskPtr = (byte *)mask->surface->getPixels();
 
-	for (uint y = 0; y < dst->h; y++) {
-		for (uint x = 0; x < dst->w; x++) {
+	for (int y = 0; y < dst->h; y++) {
+		for (int x = 0; x < dst->w; x++) {
 			uint8 maskValue = *maskPtr;
 
 			if (maskValue != 0) {
@@ -524,8 +524,8 @@ void MagnetEffect::apply(Graphics::Surface *src, Graphics::Surface *dst, Graphic
 	uint32 *dstPtr = (uint32 *)dst->getPixels();
 	byte *maskPtr = (byte *)mask->getPixels();
 
-	for (uint y = 0; y < dst->h; y++) {
-		for (uint x = 0; x < dst->w; x++) {
+	for (int y = 0; y < dst->h; y++) {
+		for (int x = 0; x < dst->w; x++) {
 			uint8 maskValue = *maskPtr;
 
 			if (maskValue != 0) {
@@ -778,8 +778,8 @@ void ShieldEffect::applyForFace(uint face, Graphics::Surface *src, Graphics::Sur
 	uint32 *dstPtr = (uint32 *)dst->getPixels();
 	byte *maskPtr = (byte *)mask->surface->getPixels();
 
-	for (uint y = 0; y < dst->h; y++) {
-		for (uint x = 0; x < dst->w; x++) {
+	for (int y = 0; y < dst->h; y++) {
+		for (int x = 0; x < dst->w; x++) {
 			uint8 maskValue = *maskPtr;
 
 			if (maskValue != 0) {

--- a/engines/myst3/menu.cpp
+++ b/engines/myst3/menu.cpp
@@ -429,8 +429,8 @@ Graphics::Surface *Menu::createThumbnail(Graphics::Surface *big) {
 	Graphics::Surface frameSurface = big->getSubArea(frame);
 
 	uint32 *dst = (uint32 *)small->getPixels();
-	for (uint i = 0; i < small->h; i++) {
-		for (uint j = 0; j < small->w; j++) {
+	for (int i = 0; i < small->h; i++) {
+		for (int j = 0; j < small->w; j++) {
 			uint32 srcX = frameSurface.w * j / small->w;
 			uint32 srcY = frameSurface.h * i / small->h;
 			uint32 *src = (uint32 *)frameSurface.getBasePtr(srcX, srcY);

--- a/engines/myst3/movie.cpp
+++ b/engines/myst3/movie.cpp
@@ -509,9 +509,9 @@ void ProjectorMovie::update() {
 	float delta = zoom / 10.0 / _frame->w;
 
 	// For each pixel in the target image
-	for (uint i = 0; i < _frame->h; i++) {
+	for (int i = 0; i < _frame->h; i++) {
 		byte *dst = (byte *)_frame->getBasePtr(0, i);
-		for (uint j = 0; j < _frame->w; j++) {
+		for (int j = 0; j < _frame->w; j++) {
 			uint8 depth;
 			uint16 r = 0, g = 0, b = 0;
 			uint32 srcX = (uint32)(backgroundX + j * delta);

--- a/engines/myst3/node.cpp
+++ b/engines/myst3/node.cpp
@@ -422,7 +422,7 @@ Common::Rect SpotItemFace::getFaceRect() const {
 }
 
 void SpotItemFace::draw() {
-	for (uint i = 0; i < _bitmap->h; i++) {
+	for (int i = 0; i < _bitmap->h; i++) {
 		memcpy(_face->_bitmap->getBasePtr(_posX, _posY + i),
 				_bitmap->getBasePtr(0, i),
 				_bitmap->w * 4);
@@ -433,7 +433,7 @@ void SpotItemFace::draw() {
 }
 
 void SpotItemFace::undraw() {
-	for (uint i = 0; i < _notDrawnBitmap->h; i++) {
+	for (int i = 0; i < _notDrawnBitmap->h; i++) {
 		memcpy(_face->_bitmap->getBasePtr(_posX, _posY + i),
 				_notDrawnBitmap->getBasePtr(0, i),
 				_notDrawnBitmap->w * 4);

--- a/engines/myst3/puzzles.cpp
+++ b/engines/myst3/puzzles.cpp
@@ -1151,7 +1151,7 @@ void Puzzles::journalSaavedro(int16 move) {
 			Graphics::Surface *leftBitmap = new Graphics::Surface();
 			leftBitmap->create(bitmap->w / 2, bitmap->h, Texture::getRGBAPixelFormat());
 
-			for (uint i = 0; i < bitmap->h; i++) {
+			for (int i = 0; i < bitmap->h; i++) {
 				memcpy(leftBitmap->getBasePtr(0, i),
 						bitmap->getBasePtr(0, i),
 						leftBitmap->w * 4);

--- a/engines/myst3/state.cpp
+++ b/engines/myst3/state.cpp
@@ -517,8 +517,8 @@ Graphics::Surface *GameState::resizeThumbnail(Graphics::Surface *big, uint width
 	small->create(width, height, big->format);
 
 	uint32 *dst = (uint32 *)small->getPixels();
-	for (uint i = 0; i < small->h; i++) {
-		for (uint j = 0; j < small->w; j++) {
+	for (int i = 0; i < small->h; i++) {
+		for (int j = 0; j < small->w; j++) {
 			uint32 srcX = big->w * j / small->w;
 			uint32 srcY = big->h * i / small->h;
 			uint32 *src = (uint32 *)big->getBasePtr(srcX, srcY);

--- a/engines/nancy/graphics.cpp
+++ b/engines/nancy/graphics.cpp
@@ -163,13 +163,13 @@ void GraphicsManager::copyToManaged(const Graphics::Surface &src, Graphics::Mana
 		return;
 	}
 
-	for (uint y = 0; y < src.h; ++y) {
+	for (int y = 0; y < src.h; ++y) {
 		if (!doubleSize) {
 			// Copy single line bottom to top
 			memcpy(dst.getBasePtr(0, y), src.getBasePtr(0, src.h - y - 1), src.w * src.format.bytesPerPixel);
 		} else {
 			// Make four copies of each source pixel
-			for (uint x = 0; x < src.w; ++x) {
+			for (int x = 0; x < src.w; ++x) {
 				switch (src.format.bytesPerPixel) {
 				case 1: {
 					const byte *srcP = (const byte *)src.getBasePtr(x, y);

--- a/engines/nancy/ui/viewport.cpp
+++ b/engines/nancy/ui/viewport.cpp
@@ -257,7 +257,7 @@ void Viewport::setPreviousFrame() {
 }
 
 void Viewport::setVerticalScroll(uint scroll) {
-	assert(scroll + _drawSurface.h <= _fullFrame.h);
+	assert(scroll + (int)_drawSurface.h <= _fullFrame.h);
 
 	Common::Rect sourceBounds = _screenPosition;
 	sourceBounds.moveTo(0, scroll);

--- a/engines/pegasus/transition.cpp
+++ b/engines/pegasus/transition.cpp
@@ -74,8 +74,8 @@ void ScreenFader::setFaderValue(const int32 value) {
 			// linear fade instead, which looks fairly well, IMO.
 			Graphics::Surface *screen = g_system->lockScreen();
 
-			for (uint y = 0; y < _screen.h; y++) {
-				for (uint x = 0; x < _screen.w; x++) {
+			for (int y = 0; y < _screen.h; y++) {
+				for (int x = 0; x < _screen.w; x++) {
 					if (_screen.format.bytesPerPixel == 2)
 						WRITE_UINT16(screen->getBasePtr(x, y), fadePixel(READ_UINT16(_screen.getBasePtr(x, y)), value));
 					else

--- a/engines/pegasus/types.h
+++ b/engines/pegasus/types.h
@@ -46,7 +46,7 @@ typedef uint32 NotificationFlags;
 
 // Mac types.
 typedef int16 ResIDType;
-typedef int16 CoordType;
+typedef int32 CoordType;
 
 enum SlideDirection {
 	kSlideLeftMask = 1,

--- a/engines/prince/cursor.cpp
+++ b/engines/prince/cursor.cpp
@@ -80,8 +80,8 @@ void PrinceEngine::changeCursor(uint16 curId) {
 	case 3:
 		curSurface = _cursor3->getSurface();
 		Common::Point mousePos = _system->getEventManager()->getMousePos();
-		mousePos.x = CLIP(mousePos.x, (int16) 315, (int16) 639);
-		mousePos.y = CLIP(mousePos.y, (int16) 0, (int16) 170);
+		mousePos.x = CLIP(mousePos.x, (int32) 315, (int32) 639);
+		mousePos.y = CLIP(mousePos.y, (int32) 0, (int32) 170);
 		_system->warpMouse(mousePos.x, mousePos.y);
 		break;
 	}

--- a/engines/prince/graphics.cpp
+++ b/engines/prince/graphics.cpp
@@ -83,7 +83,7 @@ void GraphicsMan::draw(Graphics::Surface *screen, const Graphics::Surface *s) {
 	uint16 w = MIN(screen->w, s->w);
 	const byte *src = (const byte *)s->getBasePtr(0, 0);
 	byte *dst = (byte *)screen->getBasePtr(0, 0);
-	for (uint y = 0; y < s->h; y++) {
+	for (int y = 0; y < s->h; y++) {
 		if (y < screen->h) {
 			memcpy(dst, src, w);
 		}

--- a/engines/prince/prince.cpp
+++ b/engines/prince/prince.cpp
@@ -1016,9 +1016,9 @@ void PrinceEngine::mouseWeirdo() {
 		default:
 			break;
 		}
-		mousePos.x = CLIP(mousePos.x, (int16) 315, (int16) 639);
+		mousePos.x = CLIP(mousePos.x, (int32) 315, (int32) 639);
 		_flags->setFlagValue(Flags::MXFLAG, mousePos.x);
-		mousePos.y = CLIP(mousePos.y, (int16) 0, (int16) 170);
+		mousePos.y = CLIP(mousePos.y, (int32) 0, (int32) 170);
 		_flags->setFlagValue(Flags::MYFLAG, mousePos.y);
 		_system->warpMouse(mousePos.x, mousePos.y);
 	}

--- a/engines/saga/actor.h
+++ b/engines/saga/actor.h
@@ -180,8 +180,8 @@ enum DragonMoveTypes {
 
 struct PathDirectionData {
 	int8 direction;
-	int16 x;
-	int16 y;
+	int32 x;
+	int32 y;
 };
 
 struct ActorFrameRange {

--- a/engines/sci/engine/kevent.cpp
+++ b/engines/sci/engine/kevent.cpp
@@ -323,8 +323,8 @@ reg_t kGlobalToLocal(EngineState *s, int argc, reg_t *argv) {
 	SegManager *segMan = s->_segMan;
 
 	if (obj.getSegment()) {
-		int16 x = readSelectorValue(segMan, obj, SELECTOR(x));
-		int16 y = readSelectorValue(segMan, obj, SELECTOR(y));
+		int32 x = readSelectorValue(segMan, obj, SELECTOR(x));
+		int32 y = readSelectorValue(segMan, obj, SELECTOR(y));
 
 		g_sci->_gfxCoordAdjuster->kernelGlobalToLocal(x, y);
 
@@ -341,8 +341,8 @@ reg_t kLocalToGlobal(EngineState *s, int argc, reg_t *argv) {
 	SegManager *segMan = s->_segMan;
 
 	if (obj.getSegment()) {
-		int16 x = readSelectorValue(segMan, obj, SELECTOR(x));
-		int16 y = readSelectorValue(segMan, obj, SELECTOR(y));
+		int32 x = readSelectorValue(segMan, obj, SELECTOR(x));
+		int32 y = readSelectorValue(segMan, obj, SELECTOR(y));
 
 		g_sci->_gfxCoordAdjuster->kernelLocalToGlobal(x, y);
 

--- a/engines/sci/graphics/coordadjuster.cpp
+++ b/engines/sci/graphics/coordadjuster.cpp
@@ -39,13 +39,13 @@ GfxCoordAdjuster16::GfxCoordAdjuster16(GfxPorts *ports)
 GfxCoordAdjuster16::~GfxCoordAdjuster16() {
 }
 
-void GfxCoordAdjuster16::kernelGlobalToLocal(int16 &x, int16 &y, reg_t planeObject) {
+void GfxCoordAdjuster16::kernelGlobalToLocal(int32 &x, int32 &y, reg_t planeObject) {
 	Port *curPort = _ports->getPort();
 	x -= curPort->left;
 	y -= curPort->top;
 }
 
-void GfxCoordAdjuster16::kernelLocalToGlobal(int16 &x, int16 &y, reg_t planeObject) {
+void GfxCoordAdjuster16::kernelLocalToGlobal(int32 &x, int32 &y, reg_t planeObject) {
 	Port *curPort = _ports->getPort();
 	x += curPort->left;
 	y += curPort->top;

--- a/engines/sci/graphics/coordadjuster.h
+++ b/engines/sci/graphics/coordadjuster.h
@@ -40,8 +40,8 @@ public:
 	GfxCoordAdjuster16(GfxPorts *ports);
 	~GfxCoordAdjuster16();
 
-	void kernelGlobalToLocal(int16 &x, int16 &y, reg_t planeObject = NULL_REG);
-	void kernelLocalToGlobal(int16 &x, int16 &y, reg_t planeObject = NULL_REG);
+	void kernelGlobalToLocal(int32 &x, int32 &y, reg_t planeObject = NULL_REG);
+	void kernelLocalToGlobal(int32 &x, int32 &y, reg_t planeObject = NULL_REG);
 
 	Common::Rect onControl(Common::Rect rect);
 	void setCursorPos(Common::Point &pos);

--- a/engines/sci/graphics/menu.cpp
+++ b/engines/sci/graphics/menu.cpp
@@ -363,8 +363,8 @@ void GfxMenu::drawBar() {
 	listIterator = _list.begin();
 	while (listIterator != listEnd) {
 		listEntry = *listIterator;
-		int16 textWidth;
-		int16 textHeight;
+		int32 textWidth;
+		int32 textHeight;
 		if (g_sci->isLanguageRTL()) {
 			_text16->StringWidth(listEntry->textSplit.c_str(), _text16->GetFontId(), textWidth, textHeight);
 			_ports->_curPort->curLeft -= textWidth;
@@ -383,7 +383,7 @@ void GfxMenu::calculateMenuWidth() {
 	GuiMenuList::iterator menuIterator;
 	GuiMenuList::iterator menuEnd = _list.end();
 	GuiMenuEntry *menuEntry;
-	int16 dummyHeight;
+	int32 dummyHeight;
 
 	menuIterator = _list.begin();
 	while (menuIterator != menuEnd) {
@@ -400,7 +400,7 @@ void GfxMenu::calculateMenuAndItemWidth() {
 	GuiMenuItemList::iterator itemIterator;
 	GuiMenuItemList::iterator itemEnd = _itemList.end();
 	GuiMenuItemEntry *itemEntry;
-	int16 dummyHeight;
+	int32 dummyHeight;
 
 	calculateMenuWidth();
 
@@ -1024,8 +1024,8 @@ void GfxMenu::kernelDrawStatus(const char *text, int16 colorPen, int16 colorBack
 	if (!g_sci->isLanguageRTL()) {
 		_ports->moveTo(0, 1);
 	} else {
-		int16 textWidth;
-		int16 textHeight;
+		int32 textWidth;
+		int32 textHeight;
 		_text16->StringWidth(text, _text16->GetFontId(), textWidth, textHeight);
 		_ports->moveTo(_screen->getWidth() - textWidth, 1);
 	}

--- a/engines/sci/graphics/menu.h
+++ b/engines/sci/graphics/menu.h
@@ -43,7 +43,7 @@ struct GuiMenuEntry {
 	uint16 id;
 	Common::String text;
 	Common::String textSplit;
-	int16 textWidth;
+	int32 textWidth;
 
 	GuiMenuEntry(uint16 curId)
 	 : id(curId), textWidth(0) { }
@@ -62,9 +62,9 @@ struct GuiMenuItemEntry {
 	Common::String text;
 	Common::String textSplit;
 	reg_t textVmPtr;
-	int16 textWidth;
+	int32 textWidth;
 	Common::String textRightAligned;
-	int16 textRightAlignedWidth;
+	int32 textRightAlignedWidth;
 
 	GuiMenuItemEntry(uint16 curMenuId, uint16 curId)
 	 : menuId(curMenuId), id(curId),

--- a/engines/sci/graphics/picture.cpp
+++ b/engines/sci/graphics/picture.cpp
@@ -82,9 +82,9 @@ void GfxPicture::draw(bool mirroredFlag, bool addToFlag, int16 EGApaletteNo) {
 }
 
 void GfxPicture::reset() {
-	int16 startY = _ports->getPort()->top;
-	int16 startX = 0;
-	int16 x, y;
+	int32 startY = _ports->getPort()->top;
+	int32 startX = 0;
+	int32 x, y;
 	_screen->vectorAdjustCoordinate(&startX, &startY);
 	for (y = startY; y < _screen->getHeight(); y++) {
 		for (x = startX; x < _screen->getWidth(); x++) {
@@ -868,11 +868,11 @@ void GfxPicture::vectorFloodFill(int16 x, int16 y, byte color, byte priority, by
 	}
 
 	// hard borders for filling
-	int16 borderLeft = curPort->rect.left + curPort->left;
-	int16 borderTop = curPort->rect.top + curPort->top;
-	int16 borderRight = curPort->rect.right + curPort->left - 1;
-	int16 borderBottom = curPort->rect.bottom + curPort->top - 1;
-	int16 curToLeft, curToRight, a_set, b_set;
+	int32 borderLeft = curPort->rect.left + curPort->left;
+	int32 borderTop = curPort->rect.top + curPort->top;
+	int32 borderRight = curPort->rect.right + curPort->left - 1;
+	int32 borderBottom = curPort->rect.bottom + curPort->top - 1;
+	int32 curToLeft, curToRight, a_set, b_set;
 
 	// Translate coordinates, if required (needed for Macintosh 480x300)
 	_screen->vectorAdjustCoordinate(&borderLeft, &borderTop);

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -980,12 +980,12 @@ struct UpScaledAdjust {
 	int denominator;
 };
 
-void GfxScreen::adjustToUpscaledCoordinates(int16 &y, int16 &x) {
+void GfxScreen::adjustToUpscaledCoordinates(int32 &y, int32 &x) {
 	x = _upscaledWidthMapping[x];
 	y = _upscaledHeightMapping[y];
 }
 
-void GfxScreen::adjustBackUpscaledCoordinates(int16 &y, int16 &x) {
+void GfxScreen::adjustBackUpscaledCoordinates(int32 &y, int32 &x) {
 	switch (_upscaledHires) {
 	case GFX_SCREEN_UPSCALED_480x300:
 		x = (x * 4) / 6;

--- a/engines/sci/graphics/screen.h
+++ b/engines/sci/graphics/screen.h
@@ -128,8 +128,8 @@ public:
 
 	void scale2x(const SciSpan<const byte> &src, SciSpan<byte> &dst, int16 srcWidth, int16 srcHeight, byte bytesPerPixel = 1);
 
-	void adjustToUpscaledCoordinates(int16 &y, int16 &x);
-	void adjustBackUpscaledCoordinates(int16 &y, int16 &x);
+	void adjustToUpscaledCoordinates(int32 &y, int32 &x);
+	void adjustBackUpscaledCoordinates(int32 &y, int32 &x);
 
 	void dither(bool addToFlag);
 
@@ -459,7 +459,7 @@ public:
 		return vectorGetPixel(_controlScreen, x, y);
 	}
 
-	void vectorAdjustCoordinate(int16 *x, int16 *y) {
+	void vectorAdjustCoordinate(int32 *x, int32 *y) {
 		switch (_upscaledHires) {
 		case GFX_SCREEN_UPSCALED_480x300:
 			*x = (*x * 3) / 2;

--- a/engines/sci/graphics/text16.cpp
+++ b/engines/sci/graphics/text16.cpp
@@ -367,7 +367,7 @@ int16 GfxText16::GetLongest(const char *&textPtr, int16 maxWidth, GuiResourceId 
 	return resultCharCount;
 }
 
-void GfxText16::Width(const char *text, int16 from, int16 len, GuiResourceId orgFontId, int16 &textWidth, int16 &textHeight, bool restoreFont) {
+void GfxText16::Width(const char *text, int16 from, int16 len, GuiResourceId orgFontId, int32 &textWidth, int32 &textHeight, bool restoreFont) {
 	uint16 curChar;
 	GuiResourceId previousFontId = GetFontId();
 	int16 previousPenColor = _ports->_curPort->penClr;
@@ -412,7 +412,7 @@ void GfxText16::Width(const char *text, int16 from, int16 len, GuiResourceId org
 	return;
 }
 
-void GfxText16::StringWidth(const Common::String &str, GuiResourceId orgFontId, int16 &textWidth, int16 &textHeight) {
+void GfxText16::StringWidth(const Common::String &str, GuiResourceId orgFontId, int32 &textWidth, int32 &textHeight) {
 	Width(str.c_str(), 0, str.size(), orgFontId, textWidth, textHeight, true);
 }
 
@@ -423,12 +423,12 @@ void GfxText16::DrawString(const Common::String &str, GuiResourceId orgFontId, i
 	Draw(str.c_str(), 0, str.size(), orgFontId, orgPenColor);
 }
 
-int16 GfxText16::Size(Common::Rect &rect, const char *text, uint16 languageSplitter, GuiResourceId fontId, int16 maxWidth) {
+int16 GfxText16::Size(Common::Rect &rect, const char *text, uint16 languageSplitter, GuiResourceId fontId, int32 maxWidth) {
 	GuiResourceId previousFontId = GetFontId();
 	int16 previousPenColor = _ports->_curPort->penClr;
 	int16 charCount;
-	int16 maxTextWidth = 0, textWidth;
-	int16 totalHeight = 0, textHeight;
+	int32 maxTextWidth = 0, textWidth;
+	int32 totalHeight = 0, textHeight;
 
 	if (fontId != -1)
 		SetFont(fontId);
@@ -538,7 +538,7 @@ void GfxText16::Show(const char *text, int16 from, int16 len, GuiResourceId orgF
 
 // Draws a text in rect.
 void GfxText16::Box(const char *text, uint16 languageSplitter, bool show, const Common::Rect &rect, TextAlignment alignment, GuiResourceId fontId) {
-	int16 textWidth, maxTextWidth, textHeight, charCount;
+	int32 textWidth, maxTextWidth, textHeight, charCount;
 	int16 offset = 0;
 	int16 hline = 0;
 	GuiResourceId previousFontId = GetFontId();

--- a/engines/sci/graphics/text16.h
+++ b/engines/sci/graphics/text16.h
@@ -52,11 +52,11 @@ public:
 	void ClearChar(int16 chr);
 
 	int16 GetLongest(const char *&text, int16 maxWidth, GuiResourceId orgFontId);
-	void Width(const char *text, int16 from, int16 len, GuiResourceId orgFontId, int16 &textWidth, int16 &textHeight, bool restoreFont);
-	void StringWidth(const Common::String &str, GuiResourceId orgFontId, int16 &textWidth, int16 &textHeight);
+	void Width(const char *text, int16 from, int16 len, GuiResourceId orgFontId, int32 &textWidth, int32 &textHeight, bool restoreFont);
+	void StringWidth(const Common::String &str, GuiResourceId orgFontId, int32 &textWidth, int32 &textHeight);
 	void ShowString(const Common::String &str, GuiResourceId orgFontId, int16 orgPenColor);
 	void DrawString(const Common::String &str, GuiResourceId orgFontId, int16 orgPenColor);
-	int16 Size(Common::Rect &rect, const char *text, uint16 textLanguage, GuiResourceId fontId, int16 maxWidth);
+	int16 Size(Common::Rect &rect, const char *text, uint16 textLanguage, GuiResourceId fontId, int32 maxWidth);
 	void Draw(const char *text, int16 from, int16 len, GuiResourceId orgFontId, int16 orgPenColor);
 	void Show(const char *text, int16 from, int16 len, GuiResourceId orgFontId, int16 orgPenColor);
 	void Box(const char *text, uint16 languageSplitter, bool show, const Common::Rect &rect, TextAlignment alignment, GuiResourceId fontId);

--- a/engines/sci/graphics/transitions.cpp
+++ b/engines/sci/graphics/transitions.cpp
@@ -462,7 +462,7 @@ void GfxTransitions::straight(int16 number, bool blackoutFlag) {
 	}
 }
 
-void GfxTransitions::scrollCopyOldToScreen(Common::Rect screenRect, int16 x, int16 y) {
+void GfxTransitions::scrollCopyOldToScreen(Common::Rect screenRect, int32 x, int32 y) {
 	if (_screen->getUpscaledHires()) {
 		_screen->adjustToUpscaledCoordinates(screenRect.top, screenRect.left);
 		_screen->adjustToUpscaledCoordinates(screenRect.bottom, screenRect.right);

--- a/engines/sci/graphics/transitions.h
+++ b/engines/sci/graphics/transitions.h
@@ -80,7 +80,7 @@ private:
 	void pixelation(bool blackoutFlag);
 	void blocks(bool blackoutFlag);
 	void straight(int16 number, bool blackoutFlag);
-	void scrollCopyOldToScreen(Common::Rect screenRect, int16 x, int16 y);
+	void scrollCopyOldToScreen(Common::Rect screenRect, int32 x, int32 y);
 	void scroll(int16 number);
 	void verticalRollFromCenter(bool blackoutFlag);
 	void verticalRollToCenter(bool blackoutFlag);

--- a/engines/sci/graphics/view.cpp
+++ b/engines/sci/graphics/view.cpp
@@ -805,8 +805,8 @@ void GfxView::draw(const Common::Rect &rect, const Common::Rect &clipRect, const
 	const Palette *palette = _embeddedPal ? &_viewPalette : &_palette->_sysPalette;
 	const CelInfo *celInfo = getCelInfo(loopNo, celNo);
 	const SciSpan<const byte> &bitmap = getBitmap(loopNo, celNo);
-	const int16 celHeight = celInfo->height;
-	const int16 celWidth = celInfo->width;
+	const int32 celHeight = celInfo->height;
+	const int32 celWidth = celInfo->width;
 	const byte clearKey = celInfo->clearKey;
 	const byte drawMask = priority > 15 ? GFX_SCREEN_MASK_VISUAL : GFX_SCREEN_MASK_VISUAL|GFX_SCREEN_MASK_PRIORITY;
 
@@ -814,8 +814,8 @@ void GfxView::draw(const Common::Rect &rect, const Common::Rect &clipRect, const
 		// Merge view palette in...
 		_palette->set(&_viewPalette, false);
 
-	const int16 width = MIN(clipRect.width(), celWidth);
-	const int16 height = MIN(clipRect.height(), celHeight);
+	const int32 width = MIN(clipRect.width(), celWidth);
+	const int32 height = MIN(clipRect.height(), celHeight);
 
 	if (!width || !height) {
 		return;
@@ -886,11 +886,11 @@ void GfxView::drawScaled(const Common::Rect &rect, const Common::Rect &clipRect,
 	createScalingTable(scalingX, celWidth, _screen->getWidth(), scaleX);
 	createScalingTable(scalingY, celHeight, _screen->getHeight(), scaleY);
 
-	int16 scaledWidth = MIN(clipRect.width(), (int16)scalingX.size());
-	int16 scaledHeight = MIN(clipRect.height(), (int16)scalingY.size());
+	int32 scaledWidth = MIN(clipRect.width(), (int32)scalingX.size());
+	int32 scaledHeight = MIN(clipRect.height(), (int32)scalingY.size());
 
-	const int16 offsetY = clipRect.top - rect.top;
-	const int16 offsetX = clipRect.left - rect.left;
+	const int32 offsetY = clipRect.top - rect.top;
+	const int32 offsetX = clipRect.left - rect.left;
 
 	const byte *bitmapData = bitmap.getUnsafeDataAt(0, celWidth * celHeight);
 	for (int y = 0; y < scaledHeight; y++) {
@@ -930,11 +930,11 @@ void GfxView::createScalingTable(Common::Array<uint16> &table, int16 celSize, ui
 	}
 }
 
-void GfxView::adjustToUpscaledCoordinates(int16 &y, int16 &x) {
+void GfxView::adjustToUpscaledCoordinates(int32 &y, int32 &x) {
 	_screen->adjustToUpscaledCoordinates(y, x);
 }
 
-void GfxView::adjustBackUpscaledCoordinates(int16 &y, int16 &x) {
+void GfxView::adjustBackUpscaledCoordinates(int32 &y, int32 &x) {
 	_screen->adjustBackUpscaledCoordinates(y, x);
 }
 

--- a/engines/sci/graphics/view.h
+++ b/engines/sci/graphics/view.h
@@ -78,8 +78,8 @@ public:
 
 	bool isScaleable();
 
-	void adjustToUpscaledCoordinates(int16 &y, int16 &x);
-	void adjustBackUpscaledCoordinates(int16 &y, int16 &x);
+	void adjustToUpscaledCoordinates(int32 &y, int32 &x);
+	void adjustBackUpscaledCoordinates(int32 &y, int32 &x);
 
 private:
 	void initData(GuiResourceId resourceId);

--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -1785,7 +1785,7 @@ AdjustBoxResult Actor_v2::adjustXYToBeInBox(const int dstX, const int dstY) {
 AdjustBoxResult Actor::adjustXYToBeInBox(int dstX, int dstY) {
 	const uint thresholdTable[] = { 30, 80, 0 };
 	AdjustBoxResult abr;
-	int16 tmpX, tmpY;
+	int32 tmpX, tmpY;
 	int tmpDist, bestDist, threshold, numBoxes;
 	byte flags, bestBox;
 	int box;

--- a/engines/scumm/boxes.cpp
+++ b/engines/scumm/boxes.cpp
@@ -643,7 +643,7 @@ BoxCoords ScummEngine::getBoxCoordinates(int boxnum) {
 	return *box;
 }
 
-int getClosestPtOnBox(const BoxCoords &box, int x, int y, int16& outX, int16& outY) {
+int getClosestPtOnBox(const BoxCoords &box, int x, int y, int32 &outX, int32 &outY) {
 	const Common::Point p(x, y);
 	Common::Point tmp;
 	uint dist;

--- a/engines/scumm/boxes.h
+++ b/engines/scumm/boxes.h
@@ -49,7 +49,7 @@ struct BoxCoords {			/* Box coordinates */
 	Common::Point lr;
 };
 
-int getClosestPtOnBox(const BoxCoords &box, int x, int y, int16& outX, int16& outY);
+int getClosestPtOnBox(const BoxCoords &box, int x, int y, int32 & outX, int32 & outY);
 
 } // End of namespace Scumm
 

--- a/engines/scumm/he/wiz_he.cpp
+++ b/engines/scumm/he/wiz_he.cpp
@@ -2091,7 +2091,7 @@ void Wiz::drawWizPolygonImage(uint8 *dst, const uint8 *src, const uint8 *mask, i
 	bbox[3].x = 0;
 	bbox[3].y = wizH - 1;
 
-	int16 xmin_p, xmax_p, ymin_p, ymax_p;
+	int32 xmin_p, xmax_p, ymin_p, ymax_p;
 	xmin_p = ymin_p = (int16)0x7FFF;
 	xmax_p = ymax_p = (int16)0x8000;
 
@@ -2102,7 +2102,7 @@ void Wiz::drawWizPolygonImage(uint8 *dst, const uint8 *src, const uint8 *mask, i
 		ymax_p = MAX(wp[i].y, ymax_p);
 	}
 
-	int16 xmin_b, xmax_b, ymin_b, ymax_b;
+	int32 xmin_b, xmax_b, ymin_b, ymax_b;
 	xmin_b = ymin_b = (int16)0x7FFF;
 	xmax_b = ymax_b = (int16)0x8000;
 

--- a/engines/scumm/verbs.h
+++ b/engines/scumm/verbs.h
@@ -56,7 +56,7 @@ struct VerbSlot {
 	bool center;
 	uint8 prep;
 	uint16 imgindex;
-	int16 origLeft;
+	int32 origLeft;
 };
 
 enum VerbsV0 {

--- a/engines/sherlock/events.cpp
+++ b/engines/sherlock/events.cpp
@@ -154,7 +154,7 @@ void Events::setCursor(CursorId cursorId, const Common::Point &cursorPos, const 
 	s.SHblitFrom(surface, Common::Point(drawPos.x, drawPos.y));
 
 	// Draw the cursor image
-	drawPos = Common::Point(MAX(cursorPt.x, (int16)0), MAX(cursorPt.y, (int16)0));
+	drawPos = Common::Point(MAX(cursorPt.x, (int32)0), MAX(cursorPt.y, (int32)0));
 	s.SHtransBlitFrom(cursorImg, Common::Point(drawPos.x, drawPos.y));
 
 	// Set up hotspot position for cursor, adjusting for cursor image's position within the surface

--- a/engines/sherlock/fonts.cpp
+++ b/engines/sherlock/fonts.cpp
@@ -131,8 +131,8 @@ void Fonts::setFont(int fontNum) {
 	// Iterate through the frames to find the widest and tallest font characters
 	_fontHeight = _widestChar = 0;
 	for (uint idx = 0; idx < MIN<uint>(_charCount, 128 - 32); ++idx) {
-		_fontHeight = MAX((uint16)_fontHeight, (*_font)[idx]._frame.h);
-		_widestChar = MAX((uint16)_widestChar, (*_font)[idx]._frame.w);
+		_fontHeight = MAX(_fontHeight, (*_font)[idx]._frame.h);
+		_widestChar = MAX(_widestChar, (*_font)[idx]._frame.w);
 	}
 
 	// Initialize the Y offset table for the extended character set

--- a/engines/sherlock/screen.cpp
+++ b/engines/sherlock/screen.cpp
@@ -204,8 +204,8 @@ void Screen::slamRect(const Common::Rect &r) {
 	}
 }
 
-void Screen::flushImage(ImageFrame *frame, const Common::Point &pt, int16 *xp, int16 *yp,
-		int16 *width_, int16 *height_) {
+void Screen::flushImage(ImageFrame *frame, const Common::Point &pt, int32 *xp, int32 *yp,
+		int32 *width_, int32 *height_) {
 	Common::Point imgPos = pt + frame->_offset;
 	Common::Rect newBounds(imgPos.x, imgPos.y, imgPos.x + frame->_frame.w, imgPos.y + frame->_frame.h);
 	Common::Rect oldBounds(*xp, *yp, *xp + *width_, *yp + *height_);
@@ -232,8 +232,8 @@ void Screen::flushImage(ImageFrame *frame, const Common::Point &pt, int16 *xp, i
 	*height_ = newBounds.height();
 }
 
-void Screen::flushScaleImage(ImageFrame *frame, const Common::Point &pt, int16 *xp, int16 *yp,
-		int16 *width_, int16 *height_, int scaleVal) {
+void Screen::flushScaleImage(ImageFrame *frame, const Common::Point &pt, int32 *xp, int32 *yp,
+		int32 *width_, int32 *height_, int scaleVal) {
 	Common::Point imgPos(pt.x + frame->sDrawXOffset(scaleVal), pt.y + frame->sDrawYOffset(scaleVal));
 	Common::Rect newBounds(imgPos.x, imgPos.y, imgPos.x + frame->sDrawXSize(scaleVal),
 		imgPos.y + frame->sDrawYSize(scaleVal));

--- a/engines/sherlock/screen.h
+++ b/engines/sherlock/screen.h
@@ -132,15 +132,15 @@ public:
 	 * Copy an image from the back buffer to the screen, taking care of both the
 	 * new area covered by the shape as well as the old area, which must be restored
 	 */
-	void flushImage(ImageFrame *frame, const Common::Point &pt, int16 *xp, int16 *yp,
-		int16 *width, int16 *height);
+	void flushImage(ImageFrame *frame, const Common::Point &pt, int32 *xp, int32 *yp,
+		int32 *width, int32 *height);
 
 	/**
 	 * Similar to flushImage, this method takes in an extra parameter for the scale proporation,
 	 * which affects the calculated bounds accordingly
 	 */
-	void flushScaleImage(ImageFrame *frame, const Common::Point &pt, int16 *xp, int16 *yp,
-		int16 *width, int16 *height, int scaleVal);
+	void flushScaleImage(ImageFrame *frame, const Common::Point &pt, int32 *xp, int32 *yp,
+		int32 *width, int32 *height, int scaleVal);
 
 	/**
 	 * Variation of flushImage/flushScaleImage that takes in and updates a rect

--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -76,7 +76,7 @@ bool GraphicsManager::loadParallax(uint16 v, uint16 fracX, uint16 fracY) {
 	// 65535 is the value of AUTOFIT constant in Sludge
 	if (fracX == 65535) {
 		nP->wrapS = false;
-		if (nP->surface.w < _winWidth) {
+		if (nP->surface.w < (int32)_winWidth) {
 			fatal("For AUTOFIT parallax backgrounds, the image must be at least as wide as the game window/screen.");
 			return false;
 		}
@@ -86,7 +86,7 @@ bool GraphicsManager::loadParallax(uint16 v, uint16 fracX, uint16 fracY) {
 
 	if (fracY == 65535) {
 		nP->wrapT = false;
-		if (nP->surface.h < _winHeight) {
+		if (nP->surface.h < (int32)_winHeight) {
 			fatal("For AUTOFIT parallax backgrounds, the image must be at least as tall as the game window/screen.");
 			return false;
 		}
@@ -357,7 +357,7 @@ bool GraphicsManager::loadLightMap(int v) {
 	if (!ImgLoader::loadImage(v, "lightmap", g_sludge->_resMan->getData(), &tmp))
 		return false;
 
-	if (tmp.w != _sceneWidth || tmp.h != _sceneHeight) {
+	if ((uint)tmp.w != _sceneWidth || (uint)tmp.h != _sceneHeight) {
 		if (_lightMapMode == LIGHTMAPMODE_HOTSPOT) {
 			return fatal("Light map width and height don't match scene width and height. That is required for lightmaps in HOTSPOT mode.");
 		} else if (_lightMapMode == LIGHTMAPMODE_PIXEL) {

--- a/engines/stark/services/userinterface.cpp
+++ b/engines/stark/services/userinterface.cpp
@@ -360,8 +360,8 @@ void UserInterface::saveGameScreenThumbnail() {
 	_gameWindowThumbnail->create(kThumbnailWidth, kThumbnailHeight, big->format);
 
 	uint32 *dst = (uint32 *)_gameWindowThumbnail->getPixels();
-	for (uint i = 0; i < _gameWindowThumbnail->h; i++) {
-		for (uint j = 0; j < _gameWindowThumbnail->w; j++) {
+	for (int i = 0; i < _gameWindowThumbnail->h; i++) {
+		for (int j = 0; j < _gameWindowThumbnail->w; j++) {
 			uint32 srcX = big->w * j / _gameWindowThumbnail->w;
 			uint32 srcY = big->h * i / _gameWindowThumbnail->h;
 			uint32 *src = (uint32 *)big->getBasePtr(srcX, srcY);

--- a/engines/stark/visual/explodingimage.cpp
+++ b/engines/stark/visual/explodingimage.cpp
@@ -74,8 +74,8 @@ void VisualExplodingImage::initFromSurface(const Graphics::Surface *surface, uin
 	explosionAmplitude.y *= _surface->h / (float)originalHeight;
 
 	uint index = 0;
-	for (uint y = 0; y < _surface->h; y++) {
-		for (uint x = 0; x < _surface->w; x++, index++) {
+	for (int y = 0; y < _surface->h; y++) {
+		for (int x = 0; x < _surface->w; x++, index++) {
 			_units[index].setPosition(x, y);
 			_units[index].setExplosionSettings(explosionCenter, explosionAmplitude, _surface->w / (float)originalWidth);
 			_units[index].setColor(*static_cast<uint32 *>(_surface->getBasePtr(x, y)), _surface->format);

--- a/engines/stark/visual/image.cpp
+++ b/engines/stark/visual/image.cpp
@@ -107,11 +107,11 @@ Graphics::Surface *VisualImageXMG::multiplyColorWithAlpha(const Graphics::Surfac
 	Graphics::Surface *dest = new Graphics::Surface();
 	dest->create(source->w, source->h, Gfx::Driver::getRGBAPixelFormat());
 
-	for (uint y = 0; y < source->h; y++) {
+	for (int y = 0; y < source->h; y++) {
 		const uint8 *src = (const uint8 *) source->getBasePtr(0, y);
 		uint8 *dst = (uint8 *) dest->getBasePtr(0, y);
 
-		for (uint x = 0; x < source->w; x++) {
+		for (int x = 0; x < source->w; x++) {
 			uint8 a, r, g, b;
 			r = *src++;
 			g = *src++;

--- a/engines/stark/visual/text.cpp
+++ b/engines/stark/visual/text.cpp
@@ -155,11 +155,11 @@ static float linearToSrgb(float x) {
 static void multiplyColorWithAlpha(Graphics::Surface *source) {
 	assert(source->format == Gfx::Driver::getRGBAPixelFormat());
 
-	for (uint y = 0; y < source->h; y++) {
+	for (int y = 0; y < source->h; y++) {
 		const uint8 *src = (const uint8 *) source->getBasePtr(0, y);
 		uint8 *dst = (uint8 *) source->getBasePtr(0, y);
 
-		for (uint x = 0; x < source->w; x++) {
+		for (int x = 0; x < source->w; x++) {
 			uint8 a, r, g, b;
 			r = *src++;
 			g = *src++;
@@ -206,11 +206,11 @@ static void blendWithColor(Graphics::Surface *source, const Color &color) {
 	float sGL = srgbToLinear(color.g / 255.f);
 	float sBL = srgbToLinear(color.b / 255.f);
 
-	for (uint y = 0; y < source->h; y++) {
+	for (int y = 0; y < source->h; y++) {
 		const uint8 *src = (const uint8 *) source->getBasePtr(0, y);
 		uint8 *dst = (uint8 *) source->getBasePtr(0, y);
 
-		for (uint x = 0; x < source->w; x++) {
+		for (int x = 0; x < source->w; x++) {
 			uint8 a, r, g, b;
 			r = *src++;
 			g = *src++;

--- a/engines/sword25/gfx/screenshot.cpp
+++ b/engines/sword25/gfx/screenshot.cpp
@@ -48,8 +48,8 @@ bool Screenshot::saveToFile(Graphics::Surface *data, Common::WriteStream *stream
 	stream->writeUint16LE(data->h);
 	stream->writeByte(THUMBNAIL_VERSION);
 
-	for (uint y = 0; y < data->h; y++) {
-		for (uint x = 0; x < data->w; x++) {
+	for (int y = 0; y < data->h; y++) {
+		for (int x = 0; x < data->w; x++) {
 			// This is only called by createThumbnail below, which
 			// provides a fake 'surface' with LE data in it.
 			byte a, r, g, b;
@@ -106,7 +106,7 @@ Common::SeekableReadStream *Screenshot::createThumbnail(Graphics::Surface *data)
 
 		// Move to next block
 		++x;
-		if (x == thumbnail.w) {
+		if (x == (uint)thumbnail.w) {
 			x = 0;
 			++y;
 		}

--- a/engines/titanic/support/avi_surface.cpp
+++ b/engines/titanic/support/avi_surface.cpp
@@ -328,11 +328,11 @@ void AVISurface::copyMovieFrame(const Graphics::Surface &src, Graphics::ManagedS
 		assert(src.format.bytesPerPixel == 4 && dest.format.bytesPerPixel == 2);
 		uint16 transPixel = _videoSurface->getTransparencyColor();
 
-		for (uint y = 0; y < MIN(src.h, dest.h); ++y) {
+		for (int y = 0; y < MIN(src.h, dest.h); ++y) {
 			const uint32 *pSrc = (const uint32 *)src.getBasePtr(0, y);
 			uint16 *pDest = (uint16 *)dest.getBasePtr(0, y);
 
-			for (uint x = 0; x < MIN(src.w, dest.w); ++x, ++pSrc, ++pDest) {
+			for (int x = 0; x < MIN(src.w, dest.w); ++x, ++pSrc, ++pDest) {
 				src.format.colorToARGB(*pSrc, a, r, g, b);
 				assert(a == 0 || a == 0xff);
 

--- a/engines/touche/saveload.cpp
+++ b/engines/touche/saveload.cpp
@@ -46,7 +46,15 @@ static void saveOrLoad(Common::WriteStream &stream, int16 &i) {
 	stream.writeSint16LE(i);
 }
 
+static void saveOrLoad(Common::WriteStream &stream, int32 &i) {
+	stream.writeSint16LE(i);
+}
+
 static void saveOrLoad(Common::ReadStream &stream, int16 &i) {
+	i = stream.readSint16LE();
+}
+
+static void saveOrLoad(Common::ReadStream &stream, int32 &i) {
 	i = stream.readSint16LE();
 }
 

--- a/engines/tsage/blue_force/blueforce_dialogs.cpp
+++ b/engines/tsage/blue_force/blueforce_dialogs.cpp
@@ -511,7 +511,7 @@ OptionsDialog::OptionsDialog() {
 
 	// Set all the buttons to the widest button
 	GfxButton *btnList[6] = {&_btnRestore, &_btnSave, &_btnRestart, &_btnQuit, &_btnSound, &_btnResume};
-	int16 btnWidth = 0;
+	int32 btnWidth = 0;
 	for (int idx = 0; idx < 6; ++idx)
 		btnWidth = MAX(btnWidth, btnList[idx]->_bounds.width());
 	for (int idx = 0; idx < 6; ++idx)

--- a/engines/tsage/core.cpp
+++ b/engines/tsage/core.cpp
@@ -2841,7 +2841,7 @@ GfxSurface SceneObject::getFrame() {
 void SceneObject::reposition() {
 	if (g_vm->getGameID() == GType_Ringworld2) {
 		if (!(_flags & OBJFLAG_ZOOMED)) {
-			setZoom(g_globals->_sceneManager._scene->_zoomPercents[MIN(_position.y, (int16)255)]);
+			setZoom(g_globals->_sceneManager._scene->_zoomPercents[MIN(_position.y, (int32)255)]);
 		}
 	}
 

--- a/engines/tsage/graphics.cpp
+++ b/engines/tsage/graphics.cpp
@@ -250,7 +250,7 @@ GfxSurface::~GfxSurface() {
 	assert(disposeAfterUse() == DisposeAfterUse::NO);
 }
 
-void GfxSurface::create(uint16 width, uint16 height) {
+void GfxSurface::create(int32 width, int32 height) {
 	free();
 
 	_rawSurface.create(width, height);

--- a/engines/tsage/graphics.h
+++ b/engines/tsage/graphics.h
@@ -103,7 +103,7 @@ public:
 	Graphics::ManagedSurface &lockSurface();
 	void unlockSurface();
 	void synchronize(Serializer &s);
-	void create(uint16 width, uint16 height) override;
+	void create(int32 width, int32 height) override;
 	void setBounds(const Rect &bounds);
 	const Rect &getBounds() const { return _bounds; }
 

--- a/engines/tsage/ringworld/ringworld_dialogs.cpp
+++ b/engines/tsage/ringworld/ringworld_dialogs.cpp
@@ -282,7 +282,7 @@ OptionsDialog::OptionsDialog() {
 
 	// Set all the buttons to the widest button
 	GfxButton *btnList[6] = {&_btnRestore, &_btnSave, &_btnRestart, &_btnQuit, &_btnSound, &_btnResume};
-	int16 btnWidth = 0;
+	int32 btnWidth = 0;
 	for (int idx = 0; idx < 6; ++idx)
 		btnWidth = MAX(btnWidth, btnList[idx]->_bounds.width());
 	for (int idx = 0; idx < 6; ++idx)

--- a/engines/ultima/shared/core/map.cpp
+++ b/engines/ultima/shared/core/map.cpp
@@ -144,8 +144,8 @@ void Map::MapBase::shiftViewport(const Point &delta) {
 	topLeft += delta;
 
 	// Shift the viewport, but constraining the map to fill up the screen
-	topLeft.x = CLIP(topLeft.x, (int16)0, (int16)(width() - _viewportPos._size.x));
-	topLeft.y = CLIP(topLeft.y, (int16)0, (int16)(height() - _viewportPos._size.y));
+	topLeft.x = CLIP(topLeft.x, (int32)0, (int32)(width() - _viewportPos._size.x));
+	topLeft.y = CLIP(topLeft.y, (int32)0, (int32)(height() - _viewportPos._size.y));
 }
 
 void Map::MapBase::addWidget(MapWidget *widget) {

--- a/engines/ultima/shared/maps/map_base.cpp
+++ b/engines/ultima/shared/maps/map_base.cpp
@@ -156,8 +156,8 @@ void MapBase::shiftViewport(const Point &delta) {
 	topLeft += delta;
 
 	// Shift the viewport, but constraining the map to fill up the screen
-	topLeft.x = CLIP(topLeft.x, (int16)0, (int16)(width() - _viewportPos._size.x));
-	topLeft.y = CLIP(topLeft.y, (int16)0, (int16)(height() - _viewportPos._size.y));
+	topLeft.x = CLIP(topLeft.x, (int32)0, (int32)(width() - _viewportPos._size.x));
+	topLeft.y = CLIP(topLeft.y, (int32)0, (int32)(height() - _viewportPos._size.y));
 }
 
 void MapBase::addWidget(MapWidget *widget) {

--- a/engines/ultima/ultima4/gfx/image.cpp
+++ b/engines/ultima/ultima4/gfx/image.cpp
@@ -284,15 +284,15 @@ void Image::performTransparencyHack(uint colorValue, uint numFrames,
 									uint currentFrameIndex, uint haloWidth,
 									uint haloOpacityIncrementByPixelDistance) {
 	Common::List<Std::pair<uint, uint> > opaqueXYs;
-	uint x, y;
+	int x, y;
 	byte t_r, t_g, t_b;
 
 	_surface->format.colorToRGB(colorValue, t_r, t_g, t_b);
 
 	uint frameHeight = _surface->h / numFrames;
 	//Min'd so that they never go out of range (>=h)
-	uint top = MIN(_surface->h, (uint16)(currentFrameIndex * frameHeight));
-	uint bottom = MIN(_surface->h, (uint16)(top + frameHeight));
+	int top = MIN(_surface->h, (int32)(currentFrameIndex * frameHeight));
+	int bottom = MIN(_surface->h, (int32)(top + frameHeight));
 
 	for (y = top; y < bottom; y++) {
 
@@ -317,11 +317,11 @@ void Image::performTransparencyHack(uint colorValue, uint numFrames,
 		ox = xy->first;
 		oy = xy->second;
 		int span = int(haloWidth);
-		uint x_start = MAX(0, ox - span);
-		uint x_finish = MIN(int(_surface->w), ox + span + 1);
+		int x_start = MAX(0, ox - span);
+		int x_finish = MIN(int(_surface->w), ox + span + 1);
 		for (x = x_start; x < x_finish; ++x) {
-			uint y_start = MAX(int(top), oy - span);
-			uint y_finish = MIN(int(bottom), oy + span + 1);
+			int y_start = MAX(int(top), oy - span);
+			int y_finish = MIN(int(bottom), oy + span + 1);
 			for (y = y_start; y < y_finish; ++y) {
 
 				int divisor = 1 + span * 2 - abs(int(ox - x)) - abs(int(oy - y));
@@ -477,8 +477,8 @@ void Image::dump() {
 
 void Image::drawHighlighted() {
 	RGBA c;
-	for (unsigned i = 0; i < _surface->h; i++) {
-		for (unsigned j = 0; j < _surface->w; j++) {
+	for (int i = 0; i < _surface->h; i++) {
+		for (int j = 0; j < _surface->w; j++) {
 			getPixel(j, i, c.r, c.g, c.b, c.a);
 			putPixel(j, i, 0xff - c.r, 0xff - c.g, 0xff - c.b, c.a);
 		}

--- a/engines/wage/design.cpp
+++ b/engines/wage/design.cpp
@@ -195,7 +195,7 @@ bool Design::isPointOpaque(int x, int y) {
 	return pixel != kColorGreen;
 }
 
-void Design::adjustBounds(int16 x, int16 y) {
+void Design::adjustBounds(int32 x, int32 y) {
 	_bounds->right  = MAX(x, _bounds->right);
 	_bounds->bottom = MAX(y, _bounds->bottom);
 }

--- a/engines/wage/design.h
+++ b/engines/wage/design.h
@@ -83,7 +83,7 @@ public:
 	static void drawVLine(Graphics::ManagedSurface *surface, int x, int y1, int y2, int thickness, int color, Graphics::MacPatterns &patterns, byte fillType);
 
 	bool isBoundsCalculation() { return _boundsCalculationMode; }
-	void adjustBounds(int16 x, int16 y);
+	void adjustBounds(int32 x, int32 y);
 
 private:
 	byte *_data;

--- a/engines/xeen/sprites.cpp
+++ b/engines/xeen/sprites.cpp
@@ -370,7 +370,7 @@ void SpriteDrawer::draw(XSurface &dest, uint16 offset, const Common::Point &pt,
 				(flags & SPRFLAG_SCENE_CLIPPED) ? SCENE_CLIP_LEFT : clipRect.left, destPos.y);
 			_destRight = (byte *)dest.getBasePtr(
 				(flags & SPRFLAG_SCENE_CLIPPED) ? SCENE_CLIP_RIGHT : clipRect.right, destPos.y);
-			int16 xp = destPos.x;
+			int32 xp = destPos.x;
 			lineP = &tempLine[SCREEN_WIDTH];
 
 			for (int xCtr = 0; xCtr < width; ++xCtr, ++lineP) {

--- a/engines/zvision/graphics/render_manager.cpp
+++ b/engines/zvision/graphics/render_manager.cpp
@@ -245,7 +245,7 @@ void RenderManager::readImageToSurface(const Common::String &fileName, Graphics:
 
 	// If the destination internal buffer is the same size as what we're copying into it,
 	// there is no need to free() and re-create
-	if (imageWidth != destination.w || imageHeight != destination.h) {
+	if ((int)imageWidth != destination.w || (int)imageHeight != destination.h) {
 		destination.create(imageWidth, imageHeight, _engine->_resourcePixelFormat);
 	}
 
@@ -345,10 +345,10 @@ Graphics::Surface *RenderManager::tranposeSurface(const Graphics::Surface *surfa
 	const uint16 *source = (const uint16 *)surface->getPixels();
 	uint16 *dest = (uint16 *)tranposedSurface->getPixels();
 
-	for (uint32 y = 0; y < tranposedSurface->h; ++y) {
+	for (int32 y = 0; y < tranposedSurface->h; ++y) {
 		uint32 columnIndex = y * tranposedSurface->w;
 
-		for (uint32 x = 0; x < tranposedSurface->w; ++x) {
+		for (int32 x = 0; x < tranposedSurface->w; ++x) {
 			dest[columnIndex + x] = source[x * surface->w + y];
 		}
 	}

--- a/engines/zvision/scripting/effects/animation_effect.cpp
+++ b/engines/zvision/scripting/effects/animation_effect.cpp
@@ -153,9 +153,9 @@ bool AnimationEffect::process(uint32 deltaTimeInMillis) {
 				// aa10 in Nemesis (Juperon, outside the asylum). We do allow scaling up only
 				// when a simple 2x filter is requested (e.g. the alchemists and cup sequence
 				// in Nemesis)
-				if (frame->w > dstw || frame->h > dsth || (frame->w == dstw / 2 && frame->h == dsth / 2)) {
+				if (frame->w > (int)dstw || frame->h > (int)dsth || (frame->w == (int)dstw / 2 && frame->h == (int)dsth / 2)) {
 					if (nod->_scaled)
-						if (nod->_scaled->w != dstw || nod->_scaled->h != dsth) {
+						if (nod->_scaled->w != (int)dstw || nod->_scaled->h != (int)dsth) {
 							nod->_scaled->free();
 							delete nod->_scaled;
 							nod->_scaled = NULL;

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1135,8 +1135,8 @@ bool MacMenu::mouseClick(int x, int y) {
 			if (_wm->_mode & kWMModalMenuMode) {
 				int x1 = _menustack.back()->bbox.left;
 				int y1 = _menustack.back()->bbox.top;
-				uint w = _menustack.back()->bbox.width() + 2;
-				uint h = _menustack.back()->bbox.height() + 2;
+				int w = _menustack.back()->bbox.width() + 2;
+				int h = _menustack.back()->bbox.height() + 2;
 
 				if (x1 + w > _wm->_screenCopy->w)
 					w = _wm->_screenCopy->w - 1 - x1;

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -656,8 +656,8 @@ void MacWindowManager::loadDesktop() {
 
 void MacWindowManager::drawDesktop() {
 	if (_desktopBmp) {
-		for (uint i = 0; i < _desktop->w; ++i) {
-			for (uint j = 0; j < _desktop->h; ++j) {
+		for (int i = 0; i < _desktop->w; ++i) {
+			for (int j = 0; j < _desktop->h; ++j) {
 				uint32 color = *(uint32 *)_desktopBmp->getBasePtr(i % _desktopBmp->w, j % _desktopBmp->h);
 				if (_pixelformat.bytesPerPixel == 1) {
 					byte r, g, b;

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -765,7 +765,7 @@ void MacWindowManager::draw() {
 				}
 
 				adjustDimensions(clip, innerDims, adjWidth, adjHeight);
-				g_system->copyRectToScreen(w->getWindowSurface()->getBasePtr(MAX(clip.left - innerDims.left, 0), MAX(clip.top - innerDims.top, 0)), w->getWindowSurface()->pitch,MAX(innerDims.left, (int16)0), MAX(innerDims.top, (int16)0), adjWidth, adjHeight);
+				g_system->copyRectToScreen(w->getWindowSurface()->getBasePtr(MAX(clip.left - innerDims.left, 0), MAX(clip.top - innerDims.top, 0)), w->getWindowSurface()->pitch,MAX(innerDims.left, (int32)0), MAX(innerDims.top, (int32)0), adjWidth, adjHeight);
 
 				dirtyRects.push_back(clip);
 			}

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -144,11 +144,11 @@ void ManagedSurface::setPixels(void *newPixels) {
 	_innerSurface.setPixels(newPixels);
 }
 
-void ManagedSurface::create(uint16 width, uint16 height) {
+void ManagedSurface::create(int32 width, int32 height) {
 	create(width, height, PixelFormat::createFormatCLUT8());
 }
 
-void ManagedSurface::create(uint16 width, uint16 height, const PixelFormat &pixelFormat) {
+void ManagedSurface::create(int32 width, int32 height, const PixelFormat &pixelFormat) {
 	free();
 	_innerSurface.create(width, height, pixelFormat);
 

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -99,9 +99,9 @@ public:
 	 */
 	bool clip(Common::Rect &srcBounds, Common::Rect &destBounds);
 public:
-	uint16 &w;           /*!< Width of the surface rectangle. */
-	uint16 &h;           /*!< Height of the surface rectangle. */
-	uint16 &pitch;       /*!< Pitch of the surface rectangle. See @ref Surface::pitch. */
+	int32 &w;           /*!< Width of the surface rectangle. */
+	int32 &h;           /*!< Height of the surface rectangle. */
+	int32 &pitch;       /*!< Pitch of the surface rectangle. See @ref Surface::pitch. */
 	PixelFormat &format; /*!< Pixel format of the surface. See @ref PixelFormat. */
 public:
 	/**
@@ -249,12 +249,12 @@ public:
 	/**
 	 * Allocate memory for the pixel data of the surface.
 	 */
-	virtual void create(uint16 width, uint16 height);
+	virtual void create(int32 width, int32 height);
 
 	/**
 	 * Allocate memory for the pixel data of the surface.
 	 */
-	virtual void create(uint16 width, uint16 height, const PixelFormat &pixelFormat);
+	virtual void create(int32 width, int32 height, const PixelFormat &pixelFormat);
 
 	/**
 	 * Set up the surface as a subsection of another passed parent surface.

--- a/graphics/nine_patch.cpp
+++ b/graphics/nine_patch.cpp
@@ -290,8 +290,8 @@ void NinePatchBitmap::blit(Graphics::Surface &target, int dx, int dy, int dw, in
 		_cached_colors.clear();
 
 		if (palette) {
-			for (uint i = 0; i < srf->w; ++i) {
-				for (uint j = 0; j < srf->h; ++j) {
+			for (int i = 0; i < srf->w; ++i) {
+				for (int j = 0; j < srf->h; ++j) {
 					uint32 color = *(uint32*)srf->getBasePtr(i, j);
 					if (color != transColor) {
 						*((byte *)target.getBasePtr(i, j)) = closestGrayscale(color, palette, numColors);
@@ -299,8 +299,8 @@ void NinePatchBitmap::blit(Graphics::Surface &target, int dx, int dy, int dw, in
 				}
 			}
 		} else {
-			for (uint i = 0; i < srf->w; ++i) {
-				for (uint j = 0; j < srf->h; ++j) {
+			for (int i = 0; i < srf->w; ++i) {
+				for (int j = 0; j < srf->h; ++j) {
 					uint32 color = *(uint32*)srf->getBasePtr(i, j);
 					byte a, r, g, b;
 					_bmp->format.colorToARGB(color, a, r, g, b);

--- a/graphics/scaler/thumbnail_intern.cpp
+++ b/graphics/scaler/thumbnail_intern.cpp
@@ -187,8 +187,8 @@ static bool grabScreen565(Graphics::Surface *surf) {
 		g_system->getPaletteManager()->grabPalette(palette, 0, 256);
 	}
 
-	for (uint y = 0; y < screen->h; ++y) {
-		for (uint x = 0; x < screen->w; ++x) {
+	for (int y = 0; y < screen->h; ++y) {
+		for (int x = 0; x < screen->w; ++x) {
 			byte r = 0, g = 0, b = 0;
 
 			if (screenFormat.bytesPerPixel == 1) {
@@ -246,8 +246,8 @@ bool createThumbnail(Graphics::Surface *surf, const uint8 *pixels, int w, int h,
 	Graphics::Surface screen;
 	screen.create(w, h, Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0));
 
-	for (uint y = 0; y < screen.h; ++y) {
-		for (uint x = 0; x < screen.w; ++x) {
+	for (int y = 0; y < screen.h; ++y) {
+		for (int x = 0; x < screen.w; ++x) {
 			byte r, g, b;
 			r = palette[pixels[y * w + x] * 3];
 			g = palette[pixels[y * w + x] * 3 + 1];
@@ -274,8 +274,8 @@ bool createScreenShot(Graphics::Surface &surf) {
 			return false;
 		}
 		surf.create(screen->w, screen->h, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-		for (uint y = 0; y < screen->h; ++y) {
-			for (uint x = 0; x < screen->w; ++x) {
+		for (int y = 0; y < screen->h; ++y) {
+			for (int x = 0; x < screen->w; ++x) {
 				byte r = 0, g = 0, b = 0, a = 0;
 				uint32 col = READ_UINT32(screen->getBasePtr(x, y));
 				screenFormat.colorToARGB(col, a, r, g, b);

--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -63,8 +63,9 @@ void Surface::drawThickLine(int x0, int y0, int x1, int y1, int penX, int penY, 
 		error("Surface::drawThickLine: bytesPerPixel must be 1, 2, or 4");
 }
 
-void Surface::create(uint16 width, uint16 height, const PixelFormat &f) {
+void Surface::create(int32 width, int32 height, const PixelFormat &f) {
 	free();
+	assert(width >= 0 && height >= 0);
 
 	w = width;
 	h = height;
@@ -84,7 +85,8 @@ void Surface::free() {
 	format = PixelFormat();
 }
 
-void Surface::init(uint16 width, uint16 height, uint16 newPitch, void *newPixels, const PixelFormat &f) {
+void Surface::init(int32 width, int32 height, int32 newPitch, void *newPixels, const PixelFormat &f) {
+	assert(width >= 0 && height >= 0);
 	w = width;
 	h = height;
 	pitch = newPitch;
@@ -369,7 +371,7 @@ void Surface::flipVertical(const Common::Rect &r) {
 	delete[] temp;
 }
 
-Graphics::Surface *Surface::scale(uint16 newWidth, uint16 newHeight, bool filtering) const {
+Graphics::Surface *Surface::scale(uint32 newWidth, uint32 newHeight, bool filtering) const {
 
 	Graphics::Surface *target = new Graphics::Surface();
 

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -55,19 +55,19 @@ struct Surface {
 	/**
 	 * Width of the surface.
 	 */
-	uint16 w;
+	int32 w;
 
 	/**
 	 * Height of the surface.
 	 */
-	uint16 h;
+	int32 h;
 
 	/**
 	 * Number of bytes in a pixel line.
 	 *
 	 * @note This might not equal w * bytesPerPixel.
 	 */
-	uint16 pitch;
+	int32 pitch;
 
 protected:
 	/**
@@ -151,7 +151,7 @@ public:
 		if (format.bytesPerPixel == 1)
 			return *((const uint8 *)getBasePtr(x, y));
 		else if (format.bytesPerPixel == 2)
-			return *((const uint16 *)getBasePtr(x, y));
+			return *((const uint32 *)getBasePtr(x, y));
 		else if (format.bytesPerPixel == 3)
 			return READ_UINT24(getBasePtr(x, y));
 		else if (format.bytesPerPixel == 4)
@@ -172,7 +172,7 @@ public:
 		if (format.bytesPerPixel == 1)
 			*((uint8 *)getBasePtr(x, y)) = pixel;
 		else if (format.bytesPerPixel == 2)
-			*((uint16 *)getBasePtr(x, y)) = pixel;
+			*((uint32 *)getBasePtr(x, y)) = pixel;
 		else if (format.bytesPerPixel == 3)
 			WRITE_UINT24(getBasePtr(x, y), pixel);
 		else if (format.bytesPerPixel == 4)
@@ -188,7 +188,7 @@ public:
 	 * @param height  Height of the surface object.
 	 * @param format  The pixel format to be used by the surface.
 	 */
-	void create(uint16 width, uint16 height, const PixelFormat &format);
+	void create(int32 width, int32 height, const PixelFormat &format);
 
 	/**
 	 * Release the memory used by the pixel memory of this surface.
@@ -212,7 +212,7 @@ public:
 	 * @param pixels  Pixel data.
 	 * @param format  Pixel format of the pixel data.
 	 */
-	void init(uint16 width, uint16 height, uint16 pitch, void *pixels, const PixelFormat &format);
+	void init(int32 width, int32 height, int32 pitch, void *pixels, const PixelFormat &format);
 
 	/**
 	 * Copy the data from another surface.
@@ -402,7 +402,7 @@ public:
 	 * @param newHeight  The resulting height.
 	 * @param filtering  Whether or not to use bilinear filtering.
 	 */
-	Graphics::Surface *scale(uint16 newWidth, uint16 newHeight, bool filtering = false) const;
+	Graphics::Surface *scale(uint32 newWidth, uint32 newHeight, bool filtering = false) const;
 
 	/**
 	 * @brief Rotoscale function; this returns a transformed version of this surface after rotation and

--- a/graphics/thumbnail.cpp
+++ b/graphics/thumbnail.cpp
@@ -183,14 +183,14 @@ bool loadThumbnail(Common::SeekableReadStream &in, Graphics::Surface *&thumbnail
 		switch (header.format.bytesPerPixel) {
 		case 2: {
 			uint16 *pixels = (uint16 *)thumbnail->getBasePtr(0, y);
-			for (uint x = 0; x < thumbnail->w; ++x) {
+			for (int x = 0; x < thumbnail->w; ++x) {
 				*pixels++ = in.readUint16BE();
 			}
 			} break;
 
 		case 4: {
 			uint32 *pixels = (uint32 *)thumbnail->getBasePtr(0, y);
-			for (uint x = 0; x < thumbnail->w; ++x) {
+			for (int x = 0; x < thumbnail->w; ++x) {
 				*pixels++ = in.readUint32BE();
 			}
 			} break;
@@ -247,18 +247,18 @@ bool saveThumbnail(Common::WriteStream &out, const Graphics::Surface &thumb) {
 	out.writeByte(thumb.format.aShift);
 
 	// Serialize the pixel data
-	for (uint y = 0; y < thumb.h; ++y) {
+	for (int y = 0; y < thumb.h; ++y) {
 		switch (thumb.format.bytesPerPixel) {
 		case 2: {
 			const uint16 *pixels = (const uint16 *)thumb.getBasePtr(0, y);
-			for (uint x = 0; x < thumb.w; ++x) {
+			for (int x = 0; x < thumb.w; ++x) {
 				out.writeUint16BE(*pixels++);
 			}
 			} break;
 
 		case 4: {
 			const uint32 *pixels = (const uint32 *)thumb.getBasePtr(0, y);
-			for (uint x = 0; x < thumb.w; ++x) {
+			for (int x = 0; x < thumb.w; ++x) {
 				out.writeUint32BE(*pixels++);
 			}
 			} break;

--- a/graphics/transparent_surface.cpp
+++ b/graphics/transparent_surface.cpp
@@ -739,7 +739,7 @@ void TransparentSurface::setAlphaMode(AlphaType mode) {
 	_alphaMode = mode;
 }
 
-TransparentSurface *TransparentSurface::scale(uint16 newWidth, uint16 newHeight, bool filtering) const {
+TransparentSurface *TransparentSurface::scale(int32 newWidth, int32 newHeight, bool filtering) const {
 
 	TransparentSurface *target = new TransparentSurface();
 

--- a/graphics/transparent_surface.h
+++ b/graphics/transparent_surface.h
@@ -144,7 +144,7 @@ struct TransparentSurface : public Graphics::Surface {
 	 * @param filtering Whether or not to use bilinear filtering.
 	 * @see TransformStruct
 	 */
-	TransparentSurface *scale(uint16 newWidth, uint16 newHeight, bool filtering = false) const;
+	TransparentSurface *scale(int32 newWidth, int32 newHeight, bool filtering = false) const;
 
 	/**
 	 * @brief Rotoscale function; this returns a transformed version of this surface after rotation and

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -1163,7 +1163,7 @@ void ThemeEngine::drawSlider(const Common::Rect &r, int width, WidgetStateInfo s
 		dd = kDDSliderDisabled;
 
 	Common::Rect r2 = r;
-	r2.setWidth(MIN((int16)width, r.width()));
+	r2.setWidth(MIN((int32)width, r.width()));
 	//	r2.top++; r2.bottom--; r2.left++; r2.right--;
 
 	if (rtl) {

--- a/image/codecs/cdtoons.cpp
+++ b/image/codecs/cdtoons.cpp
@@ -334,9 +334,9 @@ void CDToonsDecoder::renderBlock(byte *data, uint dataSize, int destX, int destY
 	debugN(9, "CDToons renderBlock at (%d, %d), width %d, height %d\n",
 		destX, destY, width, height);
 
-	if (destX + width > _surface->w)
+	if (destX + width > (uint)_surface->w)
 		width = _surface->w - destX;
-	if (destY + height > _surface->h)
+	if (destY + height > (uint)_surface->h)
 		height = _surface->h - destY;
 
 	uint skip = 0;

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -298,7 +298,7 @@ bool JPEGDecoder::loadStream(Common::SeekableReadStream &stream) {
 
 	// Allocate buffer for one scanline
 	JDIMENSION pitch = cinfo.output_width * _surface.format.bytesPerPixel;
-	assert(_surface.pitch >= pitch);
+	assert(_surface.pitch >= (int)pitch);
 	JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE, pitch, 1);
 
 	// Go through the image data scanline by scanline

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -352,7 +352,7 @@ bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const by
 
 	Common::Array<const uint8 *> rows;
 	rows.reserve(surface->h);
-	for (uint y = 0; y < surface->h; ++y) {
+	for (int y = 0; y < surface->h; ++y) {
 		rows.push_back((const uint8 *)surface->getBasePtr(0, y));
 	}
 


### PR DESCRIPTION
The genesis of this pull request was a need for one AGS game, Guard Duty, to create a 100,000 x 15 surface, which exceeds the maximum size of both the Surface class as well as the Rect and Point classes. To fix this, I've increased the dimensions of the Point, Rect, Surface, ManagedSurface, and TransparentSurface to 32-bits. This fixes the problem for AGS.

As far as I'm aware, there should be no issues for other engines, since all usage of 16-bit fields will work equally well for 32-bit fields.  Finally, one thing I'll mention is that although the original surface w, h, and pitch were uint16, but I've changed them to be int32 rather than uint32. In most cases when surface w & h are referred to, we're using int fields anyway, such as checking x < 0 || x >= surface->w. So with the expanded field size, it makes things more convenient to have them signed.
