### PR TITLE
ILLUSIONS: Fix text handling crash on big-endian systems

### DIFF
--- a/engines/illusions/resources/talkresource.cpp
+++ b/engines/illusions/resources/talkresource.cpp
@@ -52,7 +52,7 @@ void TalkEntry::load(byte *dataStart, Common::SeekableReadStream &stream) {
 		_talkId, textOffs, tblOffs, voiceNameOffs);
 
 #if defined(SCUMM_BIG_ENDIAN)
-	for (byte *ptr = (byte *)_text; ptr != _tblPtr; ptr += 2) {
+	for (byte *ptr = (byte *)_text; *ptr != 0; ptr += 2) {
 		WRITE_UINT16(ptr, SWAP_BYTES_16(READ_UINT16(ptr)));
 	}
 #endif


### PR DESCRIPTION
From what I understand, Illusions games use wide strings, and we swap their endianness on big-endian systems. However, some strings would sometimes remain in the wrong endianness, such as the second sentence from the army guy at the start: the `0x0057` character (87d) being misread as `0x5700` (22272), and so `getCharInfo()` wasn't happy with that.

The problem appears to be in the loop doing the uint16 endianness swap:

```
#if defined(SCUMM_BIG_ENDIAN)
	for (byte *ptr = (byte *)_text; ptr != _tblPtr; ptr += 2) {
		WRITE_UINT16(ptr, SWAP_BYTES_16(READ_UINT16(ptr)));
	}
#endif
```

It stops just before `_tblPtr`. But, from what I understand, `_tblPtr` is always going to be way pat all TalkEntry text parts, as hinted by these debug lines:

```
TalkEntry::load() _talkId: 000F00C8; textOffs: 0000065C; tblOffs: 0000285A; voiceNameOffs: 00003C04
TalkEntry::load() _talkId: 000F00C9; textOffs: 000006E8; tblOffs: 00002896; voiceNameOffs: 00003C0C
TalkEntry::load() _talkId: 000F00CA; textOffs: 000007A8; tblOffs: 000028E8; voiceNameOffs: 00003C14
TalkEntry::load() _talkId: 000F00CB; textOffs: 0000080C; tblOffs: 0000290E; voiceNameOffs: 00003C1C
```

... effectively reversing the string multiple times, and at incorrect positions.  Thus, some characters would remain in the incorrect endianness, and the game would crash.

So, I've changed this condition so that the loop stops right before any full-zero uint16 value (since that's also how `TextDrawer::textHasChar` operates). I have no deep understanding of how the engine works, but it seems to fix the problem.

Tested with Duckman on Debian 11 PowerPC, and also tested by raziel on AmigaOS4 (thanks!). (Not tested back on little-endian systems, since the change is in a  `SCUMM_BIG_ENDIAN` ifdef.)

(I also tried doing a PS3 build, but it seems that `scummvm/dockerized-toolchains:ps3` can't produce working binaries at the moment, because I can't even rebuild a working 2.2.0 binary, and the current PS3 snapshots are also KO, while the official 2.2.0 release runs fine).

Should hopefully fix and close Trac tickets [#11528](https://bugs.scummvm.org/ticket/11528) and [#11236]() (and also a PS3 thread on the forum).