### PR TITLE
IMAGE: Improve BMP support

### DIFF
--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -78,8 +78,8 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	}
 
 	uint32 infoSize = stream.readUint32LE();
-	if (infoSize != 40 && infoSize != 108) {
-		warning("Only Windows v3 & v4 bitmaps are supported");
+	if (infoSize != 40 && infoSize != 52 && infoSize != 56 && infoSize != 108 && infoSize != 124) {
+		warning("Only Windows v1-v5 bitmaps are supported, unknown header: %d", infoSize);
 		return false;
 	}
 
@@ -108,6 +108,8 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	/* uint32 pixelsPerMeterY = */ stream.readUint32LE();
 	_paletteColorCount = stream.readUint32LE();
 	/* uint32 colorsImportant = */ stream.readUint32LE();
+
+	stream.seek(infoSize - 40, SEEK_CUR);
 
 	if (bitsPerPixel == 4 || bitsPerPixel == 8) {
 		if (_paletteColorCount == 0)

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -97,7 +97,7 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	/* uint16 planes = */ stream.readUint16LE();
 	uint16 bitsPerPixel = stream.readUint16LE();
 
-	if (bitsPerPixel != 8 && bitsPerPixel != 24 && bitsPerPixel != 32) {
+	if (bitsPerPixel != 4 && bitsPerPixel != 8 && bitsPerPixel != 24 && bitsPerPixel != 32) {
 		warning("%dbpp bitmaps not supported", bitsPerPixel);
 		return false;
 	}
@@ -109,9 +109,9 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	_paletteColorCount = stream.readUint32LE();
 	/* uint32 colorsImportant = */ stream.readUint32LE();
 
-	if (bitsPerPixel == 8) {
+	if (bitsPerPixel == 4 || bitsPerPixel == 8) {
 		if (_paletteColorCount == 0)
-			_paletteColorCount = 256;
+			_paletteColorCount = bitsPerPixel == 8 ? 256 : 16;
 
 		// Read the palette
 		_palette = new byte[_paletteColorCount * 3];

--- a/image/codecs/bmp_raw.cpp
+++ b/image/codecs/bmp_raw.cpp
@@ -46,6 +46,9 @@ const Graphics::Surface *BitmapRawDecoder::decodeFrame(Common::SeekableReadStrea
 	if (_bitsPerPixel == 1) {
 		srcPitch = (_width + 7) / 8;
 		extraDataLength = (srcPitch % 2) ? 2 - (srcPitch % 2) : 0;
+	} else if (_bitsPerPixel == 4) {
+		srcPitch = (_width + 1) / 2;
+		extraDataLength = (srcPitch % 4) ? 4 - (srcPitch % 4) : 0;
 	}
 
 	if (_bitsPerPixel == 1) {

--- a/image/codecs/bmp_raw.h
+++ b/image/codecs/bmp_raw.h
@@ -34,7 +34,7 @@ namespace Image {
  */
 class BitmapRawDecoder : public Codec {
 public:
-	BitmapRawDecoder(int width, int height, int bitsPerPixel);
+	BitmapRawDecoder(int width, int height, int bitsPerPixel, bool ignoreAlpha);
 	~BitmapRawDecoder();
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream);
@@ -44,6 +44,7 @@ private:
 	Graphics::Surface _surface;
 	int _width, _height;
 	int _bitsPerPixel;
+	bool _ignoreAlpha;
 };
 
 } // End of namespace Image

--- a/image/codecs/codec.cpp
+++ b/image/codecs/codec.cpp
@@ -207,11 +207,14 @@ Codec *createBitmapCodec(uint32 tag, uint32 streamTag, int width, int height, in
 
 	switch (tag) {
 	case SWAP_CONSTANT_32(0):
-		return new BitmapRawDecoder(width, height, bitsPerPixel);
+		return new BitmapRawDecoder(width, height, bitsPerPixel, true);
 	case SWAP_CONSTANT_32(1):
 		return new MSRLEDecoder(width, height, bitsPerPixel);
 	case SWAP_CONSTANT_32(2):
 		return new MSRLE4Decoder(width, height, bitsPerPixel);
+	case SWAP_CONSTANT_32(3):
+		// Used with v4-v5 BMP headers to produce transparent BMPs
+		return new BitmapRawDecoder(width, height, bitsPerPixel, false);
 	case MKTAG('C','R','A','M'):
 	case MKTAG('m','s','v','c'):
 	case MKTAG('W','H','A','M'):
@@ -278,7 +281,7 @@ Codec *createQuickTimeCodec(uint32 tag, int width, int height, int bitsPerPixel)
 		return new CDToonsDecoder(width, height);
 	case MKTAG('r','a','w',' '):
 		// Used my L-Zone-mac (Director game)
-		return new BitmapRawDecoder(width, height, bitsPerPixel);
+		return new BitmapRawDecoder(width, height, bitsPerPixel, true);
 	default:
 		warning("Unsupported QuickTime codec \'%s\'", tag2str(tag));
 	}


### PR DESCRIPTION
1. Allow various DIB headers (Windows v1-v5), see https://en.wikipedia.org/wiki/BMP_file_format#DIB_header_(bitmap_information_header) and fix loading palette for formats with extended DIB header
2. Allow 4bpp BMP images and fix pitch calculation for 4bpp
3. Extend raw decoder to support BMPs with alpha channel and use it for BMP compression method = 3