### PR TITLE
MOHAWK: MYST: Add simulation for CD-ROM loading times

### DIFF
--- a/engines/mohawk/dialogs.cpp
+++ b/engines/mohawk/dialogs.cpp
@@ -100,6 +100,7 @@ MystOptionsWidget::MystOptionsWidget(GuiObject *boss, const Common::String &name
 		_transitionsCheckbox(nullptr),
 		_mystFlyByCheckbox(nullptr),
 		_spaceshipFuzzyLogicCheckbox(nullptr),
+		_addCdromDelayCheckbox(nullptr),
 		_languagePopUp(nullptr),
 		_dropPageButton(nullptr),
 		_showMapButton(nullptr),
@@ -133,6 +134,8 @@ MystOptionsWidget::MystOptionsWidget(GuiObject *boss, const Common::String &name
 		 */
 		_spaceshipFuzzyLogicCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MystGameOptionsDialog.FuzzyMode", _("~F~uzzy Logic in SpaceShip Active"));
 	}
+
+	_addCdromDelayCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MystGameOptionsDialog.CdromDelay", _("Simulate loading times of old CD drives"));
 
 	if (isInGame()) {
 		MohawkEngine_Myst *vm = static_cast<MohawkEngine_Myst *>(g_engine);
@@ -177,6 +180,7 @@ void MystOptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common::Stri
 	                .addWidget("Transistions", "Checkbox")
 	                .addWidget("PlayMystFlyBy", "Checkbox")
 	                .addWidget("FuzzyMode", "Checkbox")
+					.addWidget("CdromDelay", "Checkbox")
 	                .addLayout(GUI::ThemeLayout::kLayoutHorizontal)
 	                    .addPadding(0, 0, 0, 0)
 	                    .addWidget("LanguageDesc", "OptionsLabel")
@@ -211,6 +215,10 @@ void MystOptionsWidget::load() {
 
 	if (_spaceshipFuzzyLogicCheckbox) {
 		_spaceshipFuzzyLogicCheckbox->setState(ConfMan.getBool("fuzzy_logic", _domain));
+	}
+
+	if (_addCdromDelayCheckbox) {
+		_addCdromDelayCheckbox->setState(ConfMan.getBool("cdromdelay", _domain));
 	}
 
 	if (_languagePopUp) {
@@ -251,6 +259,10 @@ bool MystOptionsWidget::save() {
 
 	if (_spaceshipFuzzyLogicCheckbox) {
 		ConfMan.setBool("fuzzy_logic", _spaceshipFuzzyLogicCheckbox->getState(), _domain);
+	}
+
+	if (_addCdromDelayCheckbox) {
+		ConfMan.setBool("cdromdelay", _addCdromDelayCheckbox->getState(), _domain);
 	}
 
 	if (_languagePopUp) {

--- a/engines/mohawk/dialogs.h
+++ b/engines/mohawk/dialogs.h
@@ -101,6 +101,7 @@ private:
 	GUI::CheckboxWidget *_transitionsCheckbox;
 	GUI::CheckboxWidget *_mystFlyByCheckbox;
 	GUI::CheckboxWidget *_spaceshipFuzzyLogicCheckbox;
+	GUI::CheckboxWidget *_addCdromDelayCheckbox;
 
 	GUI::PopUpWidget *_languagePopUp;
 

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -933,12 +933,12 @@ void MohawkEngine_Myst::changeToStack(MystStack stackId, uint16 card, uint16 lin
 
 	// Add artificial CD-ROM delay
 	if (addCdRomDelay == true) {
-		if (_stack->getStackId() != kIntroStack || _stack->getStackId() != kMenuStack) {
+		if (_stack->getStackId() != kIntroStack && _stack->getStackId() != kMenuStack) {
 			// Pretty arbitrary delays to mimic a period correct 4x drive
 			// TODO: Since the disc layout of the original CD-ROMs is known,
 			//       it should be possible to adapt the delay depending on the
 			//       target stack in order to replicate the original loading times.
-			g_system->delayMillis(_rnd->getRandomNumberRng(200,500));
+			g_system->delayMillis(_rnd->getRandomNumberRng(1000,1200));
 		}
 	}
 
@@ -974,8 +974,11 @@ void MohawkEngine_Myst::changeToCard(uint16 card, TransitionType transition) {
 			// The original engine disables the mouse cursor when loading new cards.
 			_cursor->hideCursor();
 			_system->updateScreen();
-			// Pretty arbitrary delays to mimic a period correct 4x drive
-			g_system->delayMillis(_rnd->getRandomNumberRng(175,225));
+
+			// Pretty arbitrary delays to mimic a period correct 2x-4x drive
+			// Note: This is not only based on seeking times (only 80-120ms depending
+			//       on the source), but also accounts for loading the next chunk of data.
+			g_system->delayMillis(_rnd->getRandomNumberRng(350,400));
 			_cursor->showCursor();
 		}
 	}

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -917,6 +917,17 @@ void MohawkEngine_Myst::changeToStack(MystStack stackId, uint16 card, uint16 lin
 	_cache.clear();
 	_gfx->clearCache();
 
+	// Add artificial CD-ROM delay
+	if (ConfMan.getBool("cdromdelay")) {
+		if (_stack->getStackId() != kIntroStack || _stack->getStackId() != kMenuStack) {
+			// Pretty arbitrary delays to mimic a period correct 4x drive
+			// TODO: Since the disc layout of the original CD-ROMs is known,
+			//       it should be possible to adapt the delay depending on the
+			//       target stack in order to replicate the original loading times.
+			g_system->delayMillis(_rnd->getRandomNumberRng(500,750));
+		}
+	}
+
 	changeToCard(card, kTransitionCopy);
 
 	if (linkDstSound)
@@ -940,6 +951,19 @@ void MohawkEngine_Myst::changeToCard(uint16 card, TransitionType transition) {
 
 	if (_card) {
 		_card->leave();
+	}
+
+	// Add artificial CD-ROM delay
+	if (ConfMan.getBool("cdromdelay")) {
+		if (_stack->getStackId() != kIntroStack && _stack->getStackId() != kMenuStack) {
+
+			// The original engine disables the mouse cursor when loading new cards.
+			_cursor->hideCursor();
+			_system->updateScreen();
+			// Pretty arbitrary delays to mimic a period correct 4x drive
+			g_system->delayMillis(_rnd->getRandomNumberRng(175,225));
+			_cursor->showCursor();
+		}
 	}
 
 	_card = MystCardPtr(new MystCard(this, card));

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -102,6 +102,13 @@ MohawkEngine_Myst::MohawkEngine_Myst(OSystem *syst, const MohawkGameDescription 
 	// and to support the drop page and other actions in the options dialog.
 	assert(!_mainMenuDialog);
 	_mainMenuDialog = new MystMenuDialog(this);
+
+	// Enable CD-ROM delay simulation if necessary
+	if (ConfMan.getBool("cdromdelay")) {
+		addCdRomDelay = true;
+	} else {
+		addCdRomDelay = false;
+	}
 }
 
 MohawkEngine_Myst::~MohawkEngine_Myst() {
@@ -533,6 +540,13 @@ void MohawkEngine_Myst::applyGameSettings() {
 		_gfx->loadMenuFont();
 		changeToStack(_stack->getStackId(), _card->getId(), 0, 0);
 	}
+
+	// Toggle CD-ROM simulation if necessary
+	if (ConfMan.getBool("cdromdelay")) {
+		addCdRomDelay = true;
+	} else {
+		addCdRomDelay = false;
+	}
 }
 
 Common::KeymapArray MohawkEngine_Myst::initKeymaps(const char *target) {
@@ -918,7 +932,7 @@ void MohawkEngine_Myst::changeToStack(MystStack stackId, uint16 card, uint16 lin
 	_gfx->clearCache();
 
 	// Add artificial CD-ROM delay
-	if (ConfMan.getBool("cdromdelay")) {
+	if (addCdRomDelay == true) {
 		if (_stack->getStackId() != kIntroStack || _stack->getStackId() != kMenuStack) {
 			// Pretty arbitrary delays to mimic a period correct 4x drive
 			// TODO: Since the disc layout of the original CD-ROMs is known,
@@ -954,7 +968,7 @@ void MohawkEngine_Myst::changeToCard(uint16 card, TransitionType transition) {
 	}
 
 	// Add artificial CD-ROM delay
-	if (ConfMan.getBool("cdromdelay")) {
+	if (addCdRomDelay == true) {
 		if (_stack->getStackId() != kIntroStack && _stack->getStackId() != kMenuStack) {
 
 			// The original engine disables the mouse cursor when loading new cards.

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -970,7 +970,6 @@ void MohawkEngine_Myst::changeToCard(uint16 card, TransitionType transition) {
 	// Add artificial CD-ROM delay
 	if (addCdRomDelay == true) {
 		if (_stack->getStackId() != kIntroStack && _stack->getStackId() != kMenuStack) {
-
 			// The original engine disables the mouse cursor when loading new cards.
 			_cursor->hideCursor();
 			_system->updateScreen();
@@ -978,7 +977,7 @@ void MohawkEngine_Myst::changeToCard(uint16 card, TransitionType transition) {
 			// Pretty arbitrary delays to mimic a period correct 2x-4x drive
 			// Note: This is not only based on seeking times (only 80-120ms depending
 			//       on the source), but also accounts for loading the next chunk of data.
-			g_system->delayMillis(_rnd->getRandomNumberRng(350,400));
+			g_system->delayMillis(_rnd->getRandomNumberRng(300,400));
 			_cursor->showCursor();
 		}
 	}

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -938,7 +938,7 @@ void MohawkEngine_Myst::changeToStack(MystStack stackId, uint16 card, uint16 lin
 			// TODO: Since the disc layout of the original CD-ROMs is known,
 			//       it should be possible to adapt the delay depending on the
 			//       target stack in order to replicate the original loading times.
-			g_system->delayMillis(_rnd->getRandomNumberRng(1000,1200));
+			g_system->delayMillis(_rnd->getRandomNumberRng(1000, 1200));
 		}
 	}
 
@@ -977,7 +977,7 @@ void MohawkEngine_Myst::changeToCard(uint16 card, TransitionType transition) {
 			// Pretty arbitrary delays to mimic a period correct 2x-4x drive
 			// Note: This is not only based on seeking times (only 80-120ms depending
 			//       on the source), but also accounts for loading the next chunk of data.
-			g_system->delayMillis(_rnd->getRandomNumberRng(300,400));
+			g_system->delayMillis(_rnd->getRandomNumberRng(300, 400));
 			_cursor->showCursor();
 		}
 	}

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -104,11 +104,7 @@ MohawkEngine_Myst::MohawkEngine_Myst(OSystem *syst, const MohawkGameDescription 
 	_mainMenuDialog = new MystMenuDialog(this);
 
 	// Enable CD-ROM delay simulation if necessary
-	if (ConfMan.getBool("cdromdelay")) {
-		addCdRomDelay = true;
-	} else {
-		addCdRomDelay = false;
-	}
+	addCdRomDelay = ConfMan.getBool("cdromdelay");
 }
 
 MohawkEngine_Myst::~MohawkEngine_Myst() {
@@ -542,11 +538,7 @@ void MohawkEngine_Myst::applyGameSettings() {
 	}
 
 	// Toggle CD-ROM simulation if necessary
-	if (ConfMan.getBool("cdromdelay")) {
-		addCdRomDelay = true;
-	} else {
-		addCdRomDelay = false;
-	}
+	addCdRomDelay = ConfMan.getBool("cdromdelay");
 }
 
 Common::KeymapArray MohawkEngine_Myst::initKeymaps(const char *target) {
@@ -932,7 +924,7 @@ void MohawkEngine_Myst::changeToStack(MystStack stackId, uint16 card, uint16 lin
 	_gfx->clearCache();
 
 	// Add artificial CD-ROM delay
-	if (addCdRomDelay == true) {
+	if (addCdRomDelay) {
 		if (_stack->getStackId() != kIntroStack && _stack->getStackId() != kMenuStack) {
 			// Pretty arbitrary delays to mimic a period correct 4x drive
 			// TODO: Since the disc layout of the original CD-ROMs is known,
@@ -968,7 +960,7 @@ void MohawkEngine_Myst::changeToCard(uint16 card, TransitionType transition) {
 	}
 
 	// Add artificial CD-ROM delay
-	if (addCdRomDelay == true) {
+	if (addCdRomDelay) {
 		if (_stack->getStackId() != kIntroStack && _stack->getStackId() != kMenuStack) {
 			// The original engine disables the mouse cursor when loading new cards.
 			_cursor->hideCursor();

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -924,7 +924,7 @@ void MohawkEngine_Myst::changeToStack(MystStack stackId, uint16 card, uint16 lin
 			// TODO: Since the disc layout of the original CD-ROMs is known,
 			//       it should be possible to adapt the delay depending on the
 			//       target stack in order to replicate the original loading times.
-			g_system->delayMillis(_rnd->getRandomNumberRng(500,750));
+			g_system->delayMillis(_rnd->getRandomNumberRng(200,500));
 		}
 	}
 

--- a/engines/mohawk/myst.h
+++ b/engines/mohawk/myst.h
@@ -147,6 +147,9 @@ public:
 	uint16 getMainCursor() { return _mainCursor; }
 	void refreshCursor();
 	bool wait(uint32 duration, bool skippable = false);
+	bool addCdRomDelay;
+	uint minCdRomDelay;
+	uint maxCdRomDelay;
 
 	/** Update the game state according to events and update the screen */
 	void doFrame();

--- a/engines/mohawk/myst.h
+++ b/engines/mohawk/myst.h
@@ -148,8 +148,6 @@ public:
 	void refreshCursor();
 	bool wait(uint32 duration, bool skippable = false);
 	bool addCdRomDelay;
-	uint minCdRomDelay;
-	uint maxCdRomDelay;
 
 	/** Update the game state according to events and update the screen */
 	void doFrame();

--- a/engines/mohawk/myst_metaengine.cpp
+++ b/engines/mohawk/myst_metaengine.cpp
@@ -27,6 +27,7 @@ void Mohawk::MohawkMetaEngine_Myst::registerDefaultSettings() {
 	ConfMan.registerDefault("zip_mode", false);
 	ConfMan.registerDefault("transition_mode", false);
 	ConfMan.registerDefault("fuzzy_logic", false);
+	ConfMan.registerDefault("cdromdelay", false);
 }
 
 const Mohawk::MystLanguage *Mohawk::MohawkMetaEngine_Myst::listLanguages() {


### PR DESCRIPTION
This patch adds support for artificial delays during scene transitions in order to mimic the behavior of CD-ROM drives.

Usually, games supported by ScummVM are limiting their speed by themselves, e.g. through actor movement. This is not the case for the Myst series where the only transitions are the different scenes/cards. Even though the game itself is pretty slow-paced, the current implementation allows to 'rush' through it since you'll notice basically no loading times at all.

While faster loading speeds are in general a good idea, this is not the case for Myst (at least in my opinion). When this game was first released in 1993, CD-ROM drivers were slow - like double-speed slow. This means not only access times of 80 to 200ms (depending on which source you trust), but also a blazing transfer speed of 300KB/s at ideal conditions.

By adding a new game option to enable additional delays during scene transition, I try to mimic the loading speeds of the old CD drives. The way I obtained the values is by no means _really_ scientific. I played through the game on my trusty Windows 9x computer with the CD-ROM drive throttled to 4x speed. Unfortunately, I can't go lower with the drives I have, and the only drive that's theoretically capable of going 2x is currently broken.

By default, this option is disabled and only activated upon request. I think the same concept could be applied to Riven as well, even though Riven didn't fully ran from CD but rather allowed a full installation on the hard drive.