### PR TITLE
BACKENDS: Harden grabOverlay in all platforms

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -641,14 +641,13 @@ void OpenGLGraphicsManager::clearOverlay() {
 void OpenGLGraphicsManager::grabOverlay(Graphics::Surface &surface) const {
 	const Graphics::Surface *overlayData = _overlay->getSurface();
 
+	assert(surface.w >= overlayData->w);
+	assert(surface.h >= overlayData->h);
+	assert(surface.format.bytesPerPixel == overlayData->format.bytesPerPixel);
+
 	const byte *src = (const byte *)overlayData->getPixels();
 	byte *dst = (byte *)surface.getPixels();
-
-	for (uint h = overlayData->h; h > 0; --h) {
-		memcpy(dst, src, overlayData->w * overlayData->format.bytesPerPixel);
-		dst += surface.pitch;
-		src += overlayData->pitch;
-	}
+	Graphics::copyBlit(dst, src, surface.pitch, overlayData->pitch, overlayData->w, overlayData->h, overlayData->format.bytesPerPixel);
 }
 
 namespace {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1700,11 +1700,14 @@ void SurfaceSdlGraphicsManager::grabOverlay(Graphics::Surface &surface) const {
 	if (SDL_LockSurface(_overlayscreen) == -1)
 		error("SDL_LockSurface failed: %s", SDL_GetError());
 
+	assert(surface.w >= _videoMode.overlayWidth);
+	assert(surface.h >= _videoMode.overlayHeight);
+	assert(surface.format.bytesPerPixel == 2);
+
 	byte *src = (byte *)_overlayscreen->pixels;
 	byte *dst = (byte *)surface.getPixels();
-	int h = MIN<int>(surface.h, _videoMode.overlayHeight);
-	int w = MIN<int>(surface.w, _videoMode.overlayWidth);
-	crossBlit(dst, src, surface.pitch, _overlayscreen->pitch, w, h, surface.format, _overlayFormat);
+	Graphics::copyBlit(dst, src, surface.pitch, _overlayscreen->pitch,
+		_videoMode.overlayWidth, _videoMode.overlayHeight, 2);
 
 	SDL_UnlockSurface(_overlayscreen);
 }

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -30,6 +30,7 @@
 #include "common/config-manager.h"
 #include "common/file.h"
 #include "engines/engine.h"
+#include "graphics/conversion.h"
 #include "graphics/pixelbuffer.h"
 #include "graphics/opengl/context.h"
 #include "graphics/opengl/framebuffer.h"
@@ -646,14 +647,13 @@ void OpenGLSdlGraphics3dManager::clearOverlay() {
 void OpenGLSdlGraphics3dManager::grabOverlay(Graphics::Surface &surface) const {
 	const Graphics::Surface *overlayData = _overlayScreen->getBackingSurface();
 
+	assert(surface.w >= overlayData->w);
+	assert(surface.h >= overlayData->h);
+	assert(surface.format.bytesPerPixel == overlayData->format.bytesPerPixel);
+
 	const byte *src = (const byte *)overlayData->getPixels();
 	byte *dst = (byte *)surface.getPixels();
-
-	for (uint h = overlayData->h; h > 0; --h) {
-		memcpy(dst, src, overlayData->w * overlayData->format.bytesPerPixel);
-		dst += surface.pitch;
-		src += overlayData->pitch;
-	}
+	Graphics::copyBlit(dst, src, surface.pitch, overlayData->pitch, overlayData->w, overlayData->h, overlayData->format.bytesPerPixel);
 }
 
 void OpenGLSdlGraphics3dManager::closeOverlay() {

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -26,6 +26,7 @@
 #include "backends/platform/3ds/options-dialog.h"
 #include "backends/platform/3ds/config.h"
 #include "common/rect.h"
+#include "graphics/conversion.h"
 #include "graphics/fontman.h"
 #include "gui/gui-manager.h"
 
@@ -627,12 +628,14 @@ void OSystem_3DS::clearOverlay() {
 }
 
 void OSystem_3DS::grabOverlay(Graphics::Surface &surface) {
-	byte *dst = (byte *)surface.getPixels();
+	assert(surface.w >= getOverlayWidth());
+	assert(surface.h >= getOverlayHeight());
+	assert(surface.format.bytesPerPixel == _overlay.format.bytesPerPixel);
 
-	for (int y = 0; y < getOverlayHeight(); ++y) {
-		memcpy(dst, _overlay.getBasePtr(0, y), getOverlayWidth() * _overlay.format.bytesPerPixel);
-		dst += surface.pitch;
-	}
+	byte *src = (byte *)_overlay.getPixels();
+	byte *dst = (byte *)surface.getPixels();
+	Graphics::copyBlit(dst, src, surface.pitch, _overlay.pitch,
+		getOverlayWidth(), getOverlayHeight(), _overlay.format.bytesPerPixel);
 }
 
 void OSystem_3DS::copyRectToOverlay(const void *buf, int pitch, int x,

--- a/backends/platform/android3d/graphics.cpp
+++ b/backends/platform/android3d/graphics.cpp
@@ -340,17 +340,15 @@ void AndroidGraphicsManager::grabOverlay(Graphics::Surface &surface) const {
 	GLTHREADCHECK;
 
 	const Graphics::Surface *overlaySurface = _overlay_texture->surface_const();
+
+	assert(surface.w >= overlaySurface->w);
+	assert(surface.h >= overlaySurface->h);
+	assert(surface.format.bytesPerPixel == sizeof(uint16));
 	assert(overlaySurface->format.bytesPerPixel == sizeof(uint16));
 
-	byte *dst = (byte *)surface.getPixels();
 	const byte *src = (const byte *)overlaySurface->getPixels();
-	uint h = overlaySurface->h;
-
-	do {
-		memcpy(dst, src, overlaySurface->w * overlaySurface->format.bytesPerPixel);
-		src += overlaySurface->pitch;
-		dst += surface.pitch;
-	} while (--h);
+	byte *dst = (byte *)surface.getPixels();
+	Graphics::copyBlit(dst, src, surface.pitch, overlaySurface->pitch, w, h, sizeof(uint16));
 }
 
 void AndroidGraphicsManager::copyRectToOverlay(const void *buf, int pitch,

--- a/backends/platform/dc/display.cpp
+++ b/backends/platform/dc/display.cpp
@@ -23,6 +23,7 @@
 #define RONIN_TIMER_ACCESS
 
 #include "common/scummsys.h"
+#include "graphics/conversion.h"
 #include "graphics/surface.h"
 #include "dc.h"
 
@@ -657,14 +658,14 @@ void OSystem_Dreamcast::clearOverlay()
 
 void OSystem_Dreamcast::grabOverlay(Graphics::Surface &surface)
 {
-  int h = OVL_H;
-  unsigned short *src = overlay;
-  unsigned char *dst = (unsigned char *)surface.getPixels();
-  do {
-	memcpy(dst, src, OVL_W*sizeof(int16));
-	src += OVL_W;
-	dst += surface.pitch;
-  } while (--h);
+  assert(surface.w >= OVL_W);
+  assert(surface.h >= OVL_H);
+  assert(surface.format.bytesPerPixel == sizeof(unsigned short));
+
+  byte *src = (byte *)overlay;
+  byte *dst = (byte *)surface.getPixels();
+  Graphics::copyBlit(dst, src, surface.pitch, OVL_W * sizeof(unsigned short),
+	OVL_W, OVL_H, sizeof(unsigned short));
 }
 
 void OSystem_Dreamcast::copyRectToOverlay(const void *buf, int pitch,

--- a/backends/platform/ds/ds-graphics.cpp
+++ b/backends/platform/ds/ds-graphics.cpp
@@ -411,6 +411,9 @@ void OSystem_DS::clearOverlay() {
 }
 
 void OSystem_DS::grabOverlay(Graphics::Surface &surface) {
+	assert(surface.w >= _overlay.w);
+	assert(surface.h >= _overlay.h);
+	assert(surface.format.bytesPerPixel == _overlay.format.bytesPerPixel);
 	_overlay.grab((byte *)surface.getPixels(), surface.pitch);
 }
 

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -382,15 +382,14 @@ void OSystem_iOS7::clearOverlay() {
 
 void OSystem_iOS7::grabOverlay(Graphics::Surface &surface) {
 	//printf("grabOverlay()\n");
-	int h = _videoContext->overlayHeight;
+	assert(surface.w >= _videoContext->overlayWidth);
+	assert(surface.h >= _videoContext->overlayHeight);
+	assert(surface.format.bytesPerPixel == sizeof(uint16));
 
-	byte *dst = (byte *)surface.getPixels();
 	const byte *src = (const byte *)_videoContext->overlayTexture.getPixels();
-	do {
-		memcpy(dst, src, _videoContext->overlayWidth * sizeof(uint16));
-		src += _videoContext->overlayTexture.pitch;
-		dst += surface.pitch;
-	} while (--h);
+	byte *dst = (byte *)surface.getPixels();
+	Graphics::copyBlit(dst, src, surface.pitch,  _videoContext->overlayTexture.pitch,
+		_videoContext->overlayWidth, _videoContext->overlayHeight, sizeof(uint16));
 }
 
 void OSystem_iOS7::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {

--- a/backends/platform/iphone/osys_video.mm
+++ b/backends/platform/iphone/osys_video.mm
@@ -306,15 +306,14 @@ void OSystem_IPHONE::clearOverlay() {
 
 void OSystem_IPHONE::grabOverlay(Graphics::Surface &surface) {
 	//printf("grabOverlay()\n");
-	int h = _videoContext->overlayHeight;
+	assert(surface.w >= _videoContext->overlayWidth);
+	assert(surface.h >= _videoContext->overlayHeight);
+	assert(surface.format.bytesPerPixel == sizeof(uint16));
 
-	byte *dst = (byte *)surface.getPixels();
 	const byte *src = (const byte *)_videoContext->overlayTexture.getPixels();
-	do {
-		memcpy(dst, src, _videoContext->overlayWidth * sizeof(uint16));
-		src += _videoContext->overlayTexture.pitch;
-		dst += surface.pitch;
-	} while (--h);
+	byte *dst = (byte *)surface.getPixels();
+	Graphics::copyBlit(dst, src, surface.pitch,  _videoContext->overlayTexture.pitch,
+		_videoContext->overlayWidth, _videoContext->overlayHeight, sizeof(uint16));
 }
 
 void OSystem_IPHONE::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -32,6 +32,7 @@
 #include "backends/fs/n64/n64-fs-factory.h"
 #include "backends/saves/default/default-saves.h"
 #include "backends/timer/default/default-timer.h"
+#include "graphics/conversion.h"
 
 typedef unsigned long long uint64;
 
@@ -666,15 +667,14 @@ void OSystem_N64::clearOverlay() {
 }
 
 void OSystem_N64::grabOverlay(Graphics::Surface &surface) {
-	int h = _overlayHeight;
-	uint16 *src = _overlayBuffer;
-	byte *dst = (byte *)surface.getPixels();
+	assert(surface.w >= _overlayWidth);
+	assert(surface.h >= _overlayHeight);
+	assert(surface.format.bytesPerPixel == sizeof(uint16));
 
-	do {
-		memcpy(dst, src, _overlayWidth * sizeof(uint16));
-		src += _overlayWidth;
-		dst += surface.pitch;
-	} while (--h);
+	byte *src = (byte *)_overlayBuffer;
+	byte *dst = (byte *)surface.getPixels();
+	Graphics::copyBlit(dst, src, surface.pitch, _overlayWidth * sizeof(uint16),
+		_overlayWidth, _overlayHeight, sizeof(uint16));
 }
 
 void OSystem_N64::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -260,6 +260,9 @@ void OSystem_PSP::clearOverlay() {
 
 void OSystem_PSP::grabOverlay(Graphics::Surface &surface) {
 	DEBUG_ENTER_FUNC();
+	assert(surface.w >= _overlay.getWidth());
+	assert(surface.h >= _overlay.getHeight());
+	assert(surface.format.bytesPerPixel == 2);
 	_overlay.copyToArray(surface.getPixels(), surface.pitch);
 }
 

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -577,15 +577,14 @@ void OSystem_Wii::clearOverlay() {
 }
 
 void OSystem_Wii::grabOverlay(Graphics::Surface &surface) {
-	int h = _overlayHeight;
-	uint16 *src = _overlayPixels;
-	byte *dst = (byte *)surface.getPixels();
+	assert(surface.w >= _overlayWidth);
+	assert(surface.h >= _overlayHeight);
+	assert(surface.format.bytesPerPixel == sizeof(uint16));
 
-	do {
-		memcpy(dst, src, _overlayWidth * sizeof(uint16));
-		src += _overlayWidth;
-		dst += surface.pitch;
-	} while (--h);
+	byte *src = (byte *)_overlayPixels;
+	byte *dst = (byte *)surface.getPixels();
+	Graphics::copyBlit(dst, src, surface.pitch, _overlayWidth * sizeof(uint16),
+		_overlayWidth, _overlayHeight, sizeof(uint16));
 }
 
 void OSystem_Wii::copyRectToOverlay(const void *buf, int pitch, int x,

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -606,6 +606,7 @@ void EventRecorder::preDrawOverlayGui() {
 		RecordMode oldMode = _recordMode;
 		_recordMode = kPassthrough;
 		g_system->showOverlay();
+		g_gui.checkScreenChange();
 		g_gui.theme()->clearAll();
 		g_gui.theme()->drawToBackbuffer();
 		_controlPanel->drawDialog(kDrawLayerBackground);


### PR DESCRIPTION
Use specific copy code where applicable and replace duplicated code by
calls to copyBlit which optimizes blitting

This is a follow-up of 5af11925809267eee1abd5ddf251530f6f5f5572 and 5c8bd3b687ac166ada7d26362aa16523c002d6a6.

crossBlit can't be use on all platforms (PSP and DS especially). Instead of encouraging to pass whatever surface format we want, expect the format to be the one given by `getOverlayFormat`.
Instead of cropping image to surface size and hiding bugs, just make sure we will never overflow allocated memory.
Bug if any must be fixed at the correct place.

This way, all platforms are safe and rendering looks as expected.