### PR TITLE
COMMON: Beginnings of 64-bit filesystem support

### DIFF
--- a/audio/decoders/asf.cpp
+++ b/audio/decoders/asf.cpp
@@ -375,7 +375,7 @@ ASFStream::Packet *ASFStream::readPacket() {
 	_curPacket++;
 
 	if ((uint32)_stream->pos() != packetStartPos + _maxPacketSize)
-		error("ASFStream::readPacket(): Mismatching packet pos: %d (should be %d)", _stream->pos(), _maxPacketSize + packetStartPos);
+		error("ASFStream::readPacket(): Mismatching packet pos: %d (should be %d)", (int)_stream->pos(), _maxPacketSize + packetStartPos);
 
 	return packet;
 }

--- a/backends/fs/n64/romfsstream.h
+++ b/backends/fs/n64/romfsstream.h
@@ -50,9 +50,9 @@ public:
 	virtual uint32 write(const void *dataPtr, uint32 dataSize);
 	virtual bool flush();
 
-	virtual int32 pos() const;
-	virtual int32 size() const;
-	virtual bool seek(int32 offs, int whence = SEEK_SET);
+	virtual int64 pos() const;
+	virtual int64 size() const;
+	virtual bool seek(int64 offs, int whence = SEEK_SET);
 	virtual uint32 read(void *dataPtr, uint32 dataSize);
 };
 

--- a/backends/fs/posix/posix-iostream.cpp
+++ b/backends/fs/posix/posix-iostream.cpp
@@ -106,7 +106,7 @@ PosixIoStream::PosixIoStream(void *handle) :
 #endif // ANDROID_PLAIN_PORT
 }
 
-int32 PosixIoStream::size() const {
+int64 PosixIoStream::size() const {
 	int fd = fileno((FILE *)_handle);
 	if (fd == -1) {
 		return StdioStream::size();

--- a/backends/fs/posix/posix-iostream.h
+++ b/backends/fs/posix/posix-iostream.h
@@ -42,7 +42,7 @@ public:
 	~PosixIoStream();
 #endif
 
-	int32 size() const override;
+	int64 size() const override;
 };
 
 #endif

--- a/backends/fs/psp/psp-stream.h
+++ b/backends/fs/psp/psp-stream.h
@@ -78,9 +78,9 @@ public:
 	virtual uint32 write(const void *dataPtr, uint32 dataSize);
 	virtual bool flush();
 
-	virtual int32 pos() const;
-	virtual int32 size() const;
-	virtual bool seek(int32 offs, int whence = SEEK_SET);
+	virtual int64 pos() const;
+	virtual int64 size() const;
+	virtual bool seek(int64 offs, int whence = SEEK_SET);
 	virtual uint32 read(void *dataPtr, uint32 dataSize);
 
 	// for suspending

--- a/backends/fs/stdiostream.cpp
+++ b/backends/fs/stdiostream.cpp
@@ -54,21 +54,36 @@ bool StdioStream::eos() const {
 	return feof((FILE *)_handle) != 0;
 }
 
-int32 StdioStream::pos() const {
+int64 StdioStream::pos() const {
+#if defined(WIN32)
+	return _ftelli64((FILE *)_handle);
+#else
 	return ftell((FILE *)_handle);
+#endif
 }
 
-int32 StdioStream::size() const {
-	int32 oldPos = ftell((FILE *)_handle);
+int64 StdioStream::size() const {
+#if defined(WIN32)
+	int64 oldPos = _ftelli64((FILE *)_handle);
+	_fseeki64((FILE *)_handle, 0, SEEK_END);
+	int64 length = _ftelli64((FILE *)_handle);
+	_fseeki64((FILE *)_handle, oldPos, SEEK_SET);
+#else
+	int64 oldPos = ftell((FILE *)_handle);
 	fseek((FILE *)_handle, 0, SEEK_END);
-	int32 length = ftell((FILE *)_handle);
+	int64 length = ftell((FILE *)_handle);
 	fseek((FILE *)_handle, oldPos, SEEK_SET);
+#endif
 
 	return length;
 }
 
-bool StdioStream::seek(int32 offs, int whence) {
+bool StdioStream::seek(int64 offs, int whence) {
+#if defined(WIN32)
+	return _fseeki64((FILE *)_handle, offs, whence) == 0;
+#else
 	return fseek((FILE *)_handle, offs, whence) == 0;
+#endif
 }
 
 uint32 StdioStream::read(void *ptr, uint32 len) {

--- a/backends/fs/stdiostream.cpp
+++ b/backends/fs/stdiostream.cpp
@@ -55,7 +55,7 @@ bool StdioStream::eos() const {
 }
 
 int64 StdioStream::pos() const {
-#if defined(WIN32)
+#if defined(_MSC_VER)
 	return _ftelli64((FILE *)_handle);
 #else
 	return ftell((FILE *)_handle);
@@ -63,7 +63,7 @@ int64 StdioStream::pos() const {
 }
 
 int64 StdioStream::size() const {
-#if defined(WIN32)
+#if defined(_MSC_VER)
 	int64 oldPos = _ftelli64((FILE *)_handle);
 	_fseeki64((FILE *)_handle, 0, SEEK_END);
 	int64 length = _ftelli64((FILE *)_handle);
@@ -79,7 +79,7 @@ int64 StdioStream::size() const {
 }
 
 bool StdioStream::seek(int64 offs, int whence) {
-#if defined(WIN32)
+#if defined(_MSC_VER)
 	return _fseeki64((FILE *)_handle, offs, whence) == 0;
 #else
 	return fseek((FILE *)_handle, offs, whence) == 0;

--- a/backends/fs/stdiostream.cpp
+++ b/backends/fs/stdiostream.cpp
@@ -55,19 +55,26 @@ bool StdioStream::eos() const {
 }
 
 int64 StdioStream::pos() const {
-#if defined(_MSC_VER)
+#if defined(WIN32)
 	return _ftelli64((FILE *)_handle);
+#elif defined(__linux__) || defined(__APPLE__)
+	return ftello((FILE *)_handle);
 #else
 	return ftell((FILE *)_handle);
 #endif
 }
 
 int64 StdioStream::size() const {
-#if defined(_MSC_VER)
+#if defined(WIN32)
 	int64 oldPos = _ftelli64((FILE *)_handle);
 	_fseeki64((FILE *)_handle, 0, SEEK_END);
 	int64 length = _ftelli64((FILE *)_handle);
 	_fseeki64((FILE *)_handle, oldPos, SEEK_SET);
+#elif defined(__linux__) || defined(__APPLE__)
+	int64 oldPos = ftello((FILE *)_handle);
+	fseeko((FILE *)_handle, 0, SEEK_END);
+	int64 length = ftello((FILE *)_handle);
+	fseeko((FILE *)_handle, oldPos, SEEK_SET);
 #else
 	int64 oldPos = ftell((FILE *)_handle);
 	fseek((FILE *)_handle, 0, SEEK_END);
@@ -79,8 +86,10 @@ int64 StdioStream::size() const {
 }
 
 bool StdioStream::seek(int64 offs, int whence) {
-#if defined(_MSC_VER)
+#if defined(WIN32)
 	return _fseeki64((FILE *)_handle, offs, whence) == 0;
+#elif defined(__linux__) || defined(__APPLE__)
+	return fseeko((FILE *)_handle, offs, whence) == 0;
 #else
 	return fseek((FILE *)_handle, offs, whence) == 0;
 #endif

--- a/backends/fs/stdiostream.h
+++ b/backends/fs/stdiostream.h
@@ -50,9 +50,9 @@ public:
 	uint32 write(const void *dataPtr, uint32 dataSize) override;
 	bool flush() override;
 
-	int32 pos() const override;
-	int32 size() const override;
-	bool seek(int32 offs, int whence = SEEK_SET) override;
+	int64 pos() const override;
+	int64 size() const override;
+	bool seek(int64 offs, int whence = SEEK_SET) override;
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 
 	/**

--- a/backends/fs/symbian/symbianstream.h
+++ b/backends/fs/symbian/symbianstream.h
@@ -50,9 +50,9 @@ public:
 	virtual uint32 write(const void *dataPtr, uint32 dataSize);
 	virtual bool flush();
 
-	virtual int32 pos() const;
-	virtual int32 size() const;
-	bool seek(int32 offs, int whence = SEEK_SET);
+	virtual int64 pos() const;
+	virtual int64 size() const;
+	bool seek(int64 offs, int whence = SEEK_SET);
 	uint32 read(void *dataPtr, uint32 dataSize);
 };
 

--- a/backends/platform/android/asset-archive.cpp
+++ b/backends/platform/android/asset-archive.cpp
@@ -49,11 +49,11 @@ public:
 
 	virtual uint32 read(void *dataPtr, uint32 dataSize);
 
-	virtual int32 pos() const { return _pos; }
+	virtual int64 pos() const { return _pos; }
 
-	virtual int32 size() const { return _len; }
+	virtual int64 size() const { return _len; }
 
-	virtual bool seek(int32 offset, int whence = SEEK_SET);
+	virtual bool seek(int64 offset, int whence = SEEK_SET);
 
 private:
 	void close();

--- a/backends/platform/dc/vmsave.cpp
+++ b/backends/platform/dc/vmsave.cpp
@@ -245,7 +245,7 @@ private:
 
   uint32 read(void *buf, uint32 cnt) override;
   bool skip(uint32 offset) override;
-  bool seek(int32 offs, int whence) override;
+  bool seek(int64 offs, int whence) override;
 
 public:
   InVMSave()
@@ -259,8 +259,8 @@ public:
 
   bool eos() const override { return _eos; }
   void clearErr() override { _eos = false; }
-  int32 pos() const override { return _pos; }
-  int32 size() const override { return _size; }
+  int64 pos() const override { return _pos; }
+  int64 size() const override { return _size; }
 
   bool readSaveGame(const char *filename)
   { return ::readSaveGame(buffer, _size, filename); }
@@ -275,7 +275,7 @@ private:
 
 public:
   uint32 write(const void *buf, uint32 cnt);
-  virtual int32 pos() const { return _pos; }
+  virtual int64 pos() const { return _pos; }
 
   OutVMSave(const char *_filename)
 	: _pos(0), committed(-1), iofailed(false)

--- a/backends/platform/n64/framfs_save_manager.h
+++ b/backends/platform/n64/framfs_save_manager.h
@@ -36,7 +36,7 @@ private:
 
 	uint32 read(void *buf, uint32 cnt) override;
 	bool skip(uint32 offset) override;
-	bool seek(int32 offs, int whence) override;
+	bool seek(int64 offs, int whence) override;
 
 public:
 	InFRAMSave() : fd(NULL) { }
@@ -52,10 +52,10 @@ public:
 	void clearErr() override {
 		framfs_clearerr(fd);
 	}
-	int32 pos() const override {
+	int64 pos() const override {
 		return framfs_tell(fd);
 	}
-	int32 size() const override {
+	int64 size() const override {
 		return fd->size;
 	}
 
@@ -71,7 +71,7 @@ private:
 
 public:
 	uint32 write(const void *buf, uint32 cnt);
-	virtual int32 pos() const {
+	virtual int64 pos() const {
 		return framfs_tell(fd);
 	}
 

--- a/backends/platform/n64/pakfs_save_manager.h
+++ b/backends/platform/n64/pakfs_save_manager.h
@@ -36,7 +36,7 @@ private:
 
 	uint32 read(void *buf, uint32 cnt) override;
 	bool skip(uint32 offset) override;
-	bool seek(int32 offs, int whence) override;
+	bool seek(int64 offs, int whence) override;
 
 public:
 	InPAKSave() : fd(NULL) { }
@@ -52,10 +52,10 @@ public:
 	void clearErr() override {
 		pakfs_clearerr(fd);
 	}
-	int32 pos() const override {
+	int64 pos() const override {
 		return pakfs_tell(fd);
 	}
-	int32 size() const override {
+	int64 size() const override {
 		return fd->size;
 	}
 
@@ -72,7 +72,7 @@ private:
 public:
 	uint32 write(const void *buf, uint32 cnt);
 
-	virtual int32 pos() const {
+	virtual int64 pos() const {
 		return pakfs_tell(fd);
 	}
 

--- a/backends/saves/savefile.cpp
+++ b/backends/saves/savefile.cpp
@@ -52,7 +52,7 @@ uint32 OutSaveFile::write(const void *dataPtr, uint32 dataSize) {
 	return _wrapped->write(dataPtr, dataSize);
 }
 
-int32 OutSaveFile::pos() const {
+int64 OutSaveFile::pos() const {
 	return _wrapped->pos();
 }
 

--- a/common/bitstream.h
+++ b/common/bitstream.h
@@ -265,12 +265,12 @@ public:
 	}
 
 	/** Return the stream position in bits. */
-	uint32 pos() const {
+	uint64 pos() const {
 		return _pos;
 	}
 
 	/** Return the stream size in bits. */
-	uint32 size() const {
+	uint64 size() const {
 		return _size;
 	}
 
@@ -325,11 +325,11 @@ public:
 		return false;
 	}
 
-	int32 pos() const {
+	int64 pos() const {
 		return _pos;
 	}
 
-	int32 size() const {
+	int64 size() const {
 		return _size;
 	}
 

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -123,17 +123,17 @@ bool File::eos() const {
 	return _handle->eos();
 }
 
-int32 File::pos() const {
+int64 File::pos() const {
 	assert(_handle);
 	return _handle->pos();
 }
 
-int32 File::size() const {
+int64 File::size() const {
 	assert(_handle);
 	return _handle->size();
 }
 
-bool File::seek(int32 offs, int whence) {
+bool File::seek(int64 offs, int whence) {
 	assert(_handle);
 	return _handle->seek(offs, whence);
 }
@@ -221,14 +221,14 @@ bool DumpFile::flush() {
 	return _handle->flush();
 }
 
-int32 DumpFile::pos() const { return _handle->pos(); }
+int64 DumpFile::pos() const { return _handle->pos(); }
 
-bool DumpFile::seek(int32 offset, int whence) {
+bool DumpFile::seek(int64 offset, int whence) {
 	SeekableWriteStream *ws = dynamic_cast<SeekableWriteStream *>(_handle);
 	return ws ? ws->seek(offset, whence) : false;
 }
 
-int32 DumpFile::size() const {
+int64 DumpFile::size() const {
 	SeekableWriteStream *ws = dynamic_cast<SeekableWriteStream *>(_handle);
 	return ws ? ws->size() : -1;
 }

--- a/common/file.h
+++ b/common/file.h
@@ -130,9 +130,9 @@ public:
 	void clearErr() override;	/*!< Implement abstract Stream method. */
 	bool eos() const override;	/*!< Implement abstract SeekableReadStream method. */
 
-	int32 pos() const override;	 /*!< Implement abstract SeekableReadStream method. */
-	int32 size() const override; /*!< Implement abstract SeekableReadStream method. */
-	bool seek(int32 offs, int whence = SEEK_SET) override;	/*!< Implement abstract SeekableReadStream method. */
+	int64 pos() const override;	 /*!< Implement abstract SeekableReadStream method. */
+	int64 size() const override; /*!< Implement abstract SeekableReadStream method. */
+	bool seek(int64 offs, int whence = SEEK_SET) override;	/*!< Implement abstract SeekableReadStream method. */
 	uint32 read(void *dataPtr, uint32 dataSize) override;	/*!< Implement abstract SeekableReadStream method. */
 };
 
@@ -171,10 +171,10 @@ public:
 
 	virtual bool flush() override;
 
-	virtual int32 pos() const override;
+	virtual int64 pos() const override;
 
-	virtual bool seek(int32 offset, int whence = SEEK_SET) override;
-	virtual int32 size() const override;
+	virtual bool seek(int64 offset, int whence = SEEK_SET) override;
+	virtual int64 size() const override;
 };
 
 /** @} */

--- a/common/memstream.h
+++ b/common/memstream.h
@@ -75,10 +75,10 @@ public:
 	bool eos() const { return _eos; }
 	void clearErr() { _eos = false; }
 
-	int32 pos() const { return _pos; }
-	int32 size() const { return _size; }
+	int64 pos() const { return _pos; }
+	int64 size() const { return _size; }
 
-	bool seek(int32 offs, int whence = SEEK_SET);
+	bool seek(int64 offs, int whence = SEEK_SET);
 };
 
 
@@ -91,10 +91,10 @@ public:
 	MemoryReadStreamEndian(const byte *buf, uint32 len, bool bigEndian, DisposeAfterUse::Flag disposeMemory = DisposeAfterUse::NO)
 		: MemoryReadStream(buf, len, disposeMemory), SeekableReadStreamEndian(bigEndian), ReadStreamEndian(bigEndian) {}
 
-	int32 pos() const override { return MemoryReadStream::pos(); }
-	int32 size() const override { return MemoryReadStream::size(); }
+	int64 pos() const override { return MemoryReadStream::pos(); }
+	int64 size() const override { return MemoryReadStream::size(); }
 
-	bool seek(int32 offs, int whence = SEEK_SET) override { return MemoryReadStream::seek(offs, whence); }
+	bool seek(int64 offs, int whence = SEEK_SET) override { return MemoryReadStream::seek(offs, whence); }
 
 	bool skip(uint32 offset) override { return MemoryReadStream::seek(offset, SEEK_CUR); }
 };
@@ -126,13 +126,13 @@ public:
 		return dataSize;
 	}
 
-	virtual int32 pos() const override { return _pos; }
-	virtual int32 size() const override { return _bufSize; }
+	virtual int64 pos() const override { return _pos; }
+	virtual int64 size() const override { return _bufSize; }
 
 	virtual bool err() const override { return _err; }
 	virtual void clearErr() override { _err = false; }
 
-	virtual bool seek(int32 offset, int whence = SEEK_SET) override { return false; }
+	virtual bool seek(int64 offset, int whence = SEEK_SET) override { return false; }
 };
 
 /**
@@ -144,7 +144,7 @@ private:
 public:
 	SeekableMemoryWriteStream(byte *buf, uint32 len) : MemoryWriteStream(buf, len), _ptrOrig(buf) {}
 
-	virtual bool seek(int32 offset, int whence = SEEK_SET) override {
+	virtual bool seek(int64 offset, int whence = SEEK_SET) override {
 		switch (whence) {
 		case SEEK_END:
 			// SEEK_END works just like SEEK_SET, only 'reversed',
@@ -222,12 +222,12 @@ public:
 		return dataSize;
 	}
 
-	virtual int32 pos() const override { return _pos; }
-	virtual int32 size() const override { return _size; }
+	virtual int64 pos() const override { return _pos; }
+	virtual int64 size() const override { return _size; }
 
 	byte *getData() { return _data; }
 
-	virtual bool seek(int32 offs, int whence = SEEK_SET) override {
+	virtual bool seek(int64 offs, int whence = SEEK_SET) override {
 		// Pre-Condition
 		assert(_pos <= _size);
 		switch (whence) {
@@ -333,9 +333,9 @@ public:
 		return dataSize;
 	}
 
-	virtual int32 pos() const override { return _pos - _length; }
-	virtual int32 size() const override { return _size; }
-	virtual bool seek(int32, int) override { return false; }
+	virtual int64 pos() const override { return _pos - _length; }
+	virtual int64 size() const override { return _size; }
+	virtual bool seek(int64, int) override { return false; }
 	virtual bool eos() const override { return _eos; }
 	virtual void clearErr() override { _eos = false; }
 
@@ -378,8 +378,8 @@ public:
 		return dataSize;
 	}
 
-	int32 pos() const override { return _pos; }
-	int32 size() const override { return _bufSize; }
+	int64 pos() const override { return _pos; }
+	int64 size() const override { return _bufSize; }
 
 	bool eos() const override { return _eos; }
 
@@ -412,7 +412,7 @@ public:
 		return dataSize;
 	}
 
-	bool seek(int32 offset, int whence = SEEK_SET) override {
+	bool seek(int64 offset, int whence = SEEK_SET) override {
 		switch (whence) {
 		case SEEK_END:
 			// SEEK_END works just like SEEK_SET, only 'reversed',

--- a/common/savefile.h
+++ b/common/savefile.h
@@ -106,7 +106,7 @@ public:
 	*
 	* @return The current position indicator, or -1 if an error occurred.
 	 */
-	virtual int32 pos() const;
+	virtual int64 pos() const;
 };
 
 /**

--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -108,7 +108,7 @@ uint32 MemoryReadStream::read(void *dataPtr, uint32 dataSize) {
 	return dataSize;
 }
 
-bool MemoryReadStream::seek(int32 offs, int whence) {
+bool MemoryReadStream::seek(int64 offs, int whence) {
 	// Pre-Condition
 	assert(_pos <= _size);
 	switch (whence) {
@@ -245,7 +245,7 @@ SeekableSubReadStream::SeekableSubReadStream(SeekableReadStream *parentStream, u
 	_eos = false;
 }
 
-bool SeekableSubReadStream::seek(int32 offset, int whence) {
+bool SeekableSubReadStream::seek(int64 offset, int whence) {
 	assert(_pos >= _begin);
 	assert(_pos <= _end);
 
@@ -416,10 +416,10 @@ protected:
 public:
 	BufferedSeekableReadStream(SeekableReadStream *parentStream, uint32 bufSize, DisposeAfterUse::Flag disposeParentStream = DisposeAfterUse::NO);
 
-	virtual int32 pos() const { return _parentStream->pos() - (_bufSize - _pos); }
-	virtual int32 size() const { return _parentStream->size(); }
+	virtual int64 pos() const { return _parentStream->pos() - (_bufSize - _pos); }
+	virtual int64 size() const { return _parentStream->size(); }
 
-	virtual bool seek(int32 offset, int whence = SEEK_SET);
+	virtual bool seek(int64 offset, int whence = SEEK_SET);
 };
 
 BufferedSeekableReadStream::BufferedSeekableReadStream(SeekableReadStream *parentStream, uint32 bufSize, DisposeAfterUse::Flag disposeParentStream)
@@ -427,7 +427,7 @@ BufferedSeekableReadStream::BufferedSeekableReadStream(SeekableReadStream *paren
 	_parentStream(parentStream) {
 }
 
-bool BufferedSeekableReadStream::seek(int32 offset, int whence) {
+bool BufferedSeekableReadStream::seek(int64 offset, int whence) {
 	// If it is a "local" seek, we may get away with "seeking" around
 	// in the buffer only.
 	_eos = false; // seeking always cancels EOS
@@ -551,7 +551,7 @@ public:
 
 	virtual bool flush() { return flushBuffer(); }
 
-	virtual int32 pos() const { return _pos; }
+	virtual int64 pos() const { return _pos; }
 
 };
 

--- a/common/stream.h
+++ b/common/stream.h
@@ -123,7 +123,7 @@ public:
 	*
 	* @return The current position indicator, or -1 if an error occurred.
 	 */
-	virtual int32 pos() const = 0;
+	virtual int64 pos() const = 0;
 
 	/**
 	 * @name Functions for writing data
@@ -320,7 +320,7 @@ public:
 	 *
 	 * @return True on success, false in case of a failure.
 	 */
-	virtual bool seek(int32 offset, int whence = SEEK_SET) = 0;
+	virtual bool seek(int64 offset, int whence = SEEK_SET) = 0;
 
 	/**
 	 * Obtain the current size of the stream, measured in bytes.
@@ -329,7 +329,7 @@ public:
 	 *
 	 * @return The size of the stream, or -1 if an error occurred.
 	 */
-	virtual int32 size() const = 0;
+	virtual int64 size() const = 0;
 };
 
 /**
@@ -670,7 +670,7 @@ public:
 	 *
 	 * @return The current position indicator, or -1 if an error occurred.
 	 */
-	virtual int32 pos() const = 0;
+	virtual int64 pos() const = 0;
 
 	/**
 	 * Obtain the total size of the stream, measured in bytes.
@@ -678,7 +678,7 @@ public:
 	 *
 	 * @return The size of the stream, or -1 if an error occurred.
 	 */
-	virtual int32 size() const = 0;
+	virtual int64 size() const = 0;
 
 	/**
 	 * Set the stream position indicator for the stream.
@@ -697,7 +697,7 @@ public:
 	 *
 	 * @return True on success, false in case of a failure.
 	 */
-	virtual bool seek(int32 offset, int whence = SEEK_SET) = 0;
+	virtual bool seek(int64 offset, int whence = SEEK_SET) = 0;
 
 	/**
 	 * Skip the given number of bytes in the stream.

--- a/common/substream.h
+++ b/common/substream.h
@@ -82,10 +82,10 @@ protected:
 public:
 	SeekableSubReadStream(SeekableReadStream *parentStream, uint32 begin, uint32 end, DisposeAfterUse::Flag disposeParentStream = DisposeAfterUse::NO);
 
-	virtual int32 pos() const { return _pos - _begin; }
-	virtual int32 size() const { return _end - _begin; }
+	virtual int64 pos() const { return _pos - _begin; }
+	virtual int64 size() const { return _end - _begin; }
 
-	virtual bool seek(int32 offset, int whence = SEEK_SET);
+	virtual bool seek(int64 offset, int whence = SEEK_SET);
 };
 
 /**
@@ -103,10 +103,10 @@ public:
 		  ReadStreamEndian(bigEndian) {
 	}
 
-	virtual int32 pos() const override { return SeekableSubReadStream::pos(); }
-	virtual int32 size() const override { return SeekableSubReadStream::size(); }
+	virtual int64 pos() const override { return SeekableSubReadStream::pos(); }
+	virtual int64 size() const override { return SeekableSubReadStream::size(); }
 
-	virtual bool seek(int32 offset, int whence = SEEK_SET) override { return SeekableSubReadStream::seek(offset, whence); }
+	virtual bool seek(int64 offset, int whence = SEEK_SET) override { return SeekableSubReadStream::seek(offset, whence); }
 	void hexdump(int len, int bytesPerLine = 16, int startOffset = 0) { SeekableSubReadStream::hexdump(len, bytesPerLine, startOffset); }
 	bool skip(uint32 offset) override { return SeekableSubReadStream::seek(offset, SEEK_CUR); }
 };

--- a/common/zlib.cpp
+++ b/common/zlib.cpp
@@ -316,13 +316,13 @@ public:
 	bool eos() const {
 		return _eos;
 	}
-	int32 pos() const {
+	int64 pos() const {
 		return _pos;
 	}
-	int32 size() const {
+	int64 size() const {
 		return _origSize;
 	}
-	bool seek(int32 offset, int whence = SEEK_SET) {
+	bool seek(int64 offset, int whence = SEEK_SET) {
 		int32 newPos = 0;
 		switch (whence) {
 		default:
@@ -372,7 +372,7 @@ public:
 		// bytes, so this should be fine.
 		byte tmpBuf[1024];
 		while (!err() && offset > 0) {
-			offset -= read(tmpBuf, MIN((int32)sizeof(tmpBuf), offset));
+			offset -= read(tmpBuf, MIN((int64)sizeof(tmpBuf), offset));
 		}
 
 		_eos = false;
@@ -487,7 +487,7 @@ public:
 		return dataSize - _stream.avail_in;
 	}
 
-	virtual int32 pos() const { return _pos; }
+	virtual int64 pos() const { return _pos; }
 };
 
 #endif	// USE_ZLIB

--- a/devtools/create_titanic/zlib.cpp
+++ b/devtools/create_titanic/zlib.cpp
@@ -251,13 +251,13 @@ public:
 	bool eos() const {
 		return _eos;
 	}
-	int32 pos() const {
+	int64 pos() const {
 		return _pos;
 	}
-	int32 size() const {
+	int64 size() const {
 		return _origSize;
 	}
-	bool seek(int32 offset, int whence = SEEK_SET) {
+	bool seek(int64 offset, int whence = SEEK_SET) {
 		int32 newPos = 0;
 		switch (whence) {
 		default:
@@ -422,7 +422,7 @@ public:
 		return dataSize - _stream.avail_in;
 	}
 
-	virtual int32 pos() const { return _pos; }
+	virtual int64 pos() const { return _pos; }
 };
 
 #endif	// USE_ZLIB

--- a/engines/adl/disk.cpp
+++ b/engines/adl/disk.cpp
@@ -307,7 +307,7 @@ static void printGoodSectors(Common::Array<bool> &goodSectors, uint sectorsPerTr
 
 static Common::SeekableReadStream *readImage_NIB(Common::File &f, bool dos33, uint tracks = 35) {
 	if (f.size() != 35 * kNibTrackLen) {
-		warning("NIB: image '%s' has invalid size of %d bytes", f.getName(), f.size());
+		warning("NIB: image '%s' has invalid size of %d bytes", f.getName(), (int)f.size());
 		return nullptr;
 	}
 
@@ -543,7 +543,7 @@ bool DiskImage::open(const Common::String &filename) {
 		return false;
 
 	if (_stream->size() != expectedSize)
-		error("Unrecognized disk image '%s' of size %d bytes (expected %d bytes)", filename.c_str(), _stream->size(), expectedSize);
+		error("Unrecognized disk image '%s' of size %d bytes (expected %d bytes)", filename.c_str(), (int)_stream->size(), expectedSize);
 
 	return true;
 }

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -517,7 +517,7 @@ bool AdvancedMetaEngineDetection::getFileProperties(const FileMap &allFiles, con
 		return false;
 
 	fileProps.md5 = Common::computeStreamMD5AsString(testFile, _md5Bytes);
-	fileProps.size = (int32)testFile.size();
+	fileProps.size = testFile.size();
 	MD5Man.setMD5(hashname, fileProps.md5);
 	MD5Man.setSize(hashname, fileProps.size);
 
@@ -551,7 +551,7 @@ bool AdvancedMetaEngine::getFilePropertiesExtern(uint md5Bytes, const FileMap &a
 	if (!testFile.open(allFiles[fname]))
 		return false;
 
-	fileProps.size = (int32)testFile.size();
+	fileProps.size = testFile.size();
 	fileProps.md5 = Common::computeStreamMD5AsString(testFile, md5Bytes);
 	return true;
 }

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -52,7 +52,7 @@ struct ADGameFileDescription {
 	const char *fileName; ///< Name of the described file.
 	uint16 fileType;      ///< Optional. Not used during detection, only by engines.
 	const char *md5;      ///< MD5 of (the beginning of) the described file. Optional. Set to NULL to ignore.
-	int32 fileSize;       ///< Size of the described file. Set to -1 to ignore.
+	int64 fileSize;       ///< Size of the described file. Set to -1 to ignore.
 };
 
 /**
@@ -522,11 +522,11 @@ public:
 		return md5HashMap.getVal(fname);
 	}
 
-	void setSize(Common::String fname, int32 size) {
+	void setSize(Common::String fname, int64 size) {
 		sizeHashMap.setVal(fname, size);
 	}
 
-	int32 getSize(Common::String fname) {
+	int64 getSize(Common::String fname) {
 		return sizeHashMap.getVal(fname);
 	}
 
@@ -547,7 +547,7 @@ private:
 	friend class Common::Singleton<MD5CacheManager>;
 
 	typedef Common::HashMap<Common::String, Common::String, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> FileHashMap;
-	typedef Common::HashMap<Common::String, int32, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> SizeHashMap;
+	typedef Common::HashMap<Common::String, int64, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> SizeHashMap;
 	FileHashMap md5HashMap;
 	SizeHashMap sizeHashMap;
 };

--- a/engines/agi/sound_2gs.cpp
+++ b/engines/agi/sound_2gs.cpp
@@ -750,7 +750,7 @@ bool SoundGen2GS::loadInstrumentHeaders(Common::String &exePath, const IIgsExeIn
 	file.open(exePath);
 	if (file.size() != (int32)exeInfo.exeSize) {
 		debugC(3, kDebugLevelSound, "Apple IIGS executable (%s) has wrong size (Is %d, should be %d)",
-		       exePath.c_str(), file.size(), exeInfo.exeSize);
+		       exePath.c_str(), (int)file.size(), exeInfo.exeSize);
 	}
 
 	// Read the whole executable file into memory

--- a/engines/ags/ags.cpp
+++ b/engines/ags/ags.cpp
@@ -85,7 +85,7 @@ AGSEngine::AGSEngine(OSystem *syst, const AGSGameDescription *gameDesc) : Engine
 }
 
 AGSEngine::~AGSEngine() {
-	if (_G(proper_exit) == 0) {
+	if (_globals && _G(proper_exit) == 0) {
 		_G(platform)->DisplayAlert("Error: the program has exited without requesting it.\n"
 		                           "Program pointer: %+03d  (write this number down), ACI version %s\n"
 		                           "If you see a list of numbers above, please write them down and contact\n"
@@ -122,6 +122,15 @@ Common::Error AGSEngine::run() {
 
 	if (isUnsupportedPre25()) {
 		GUIError("The selected game is a completed unsupported pre-2.5 version");
+		return Common::kNoError;
+	}
+
+	if (is64BitGame()) {
+		// If the game file was opened and the engine started, but the
+		// size is -1, then it must be a game like Strangeland where
+		// the data file is > 2Gb
+		GUIError("The selected game has a data file greater than 2Gb, " \
+			"which isn't supported by your version of ScummVM yet");
 		return Common::kNoError;
 	}
 
@@ -222,6 +231,12 @@ void AGSEngine::setGraphicsMode(size_t w, size_t h, int colorDepth) {
 bool AGSEngine::isUnsupportedPre25() const {
 	return _gameDescription->desc.extra &&
 		!strcmp(_gameDescription->desc.extra, "Pre 2.5");
+}
+
+bool AGSEngine::is64BitGame() const {
+	Common::File f;
+	return f.open(_gameDescription->desc.filesDescriptions[0].fileName)
+		&& f.size() == -1;
 }
 
 bool AGSEngine::canLoadGameStateCurrently() {

--- a/engines/ags/ags.h
+++ b/engines/ags/ags.h
@@ -138,6 +138,11 @@ public:
 	 */
 	bool isUnsupportedPre25() const;
 
+	/*
+	 * Returns true if the game has data files greater than 2Gb
+	 */
+	bool is64BitGame() const;
+
 	/**
 	 * Indicate whether a game state can be loaded.
 	 */

--- a/engines/ags/detection_tables.h
+++ b/engines/ags/detection_tables.h
@@ -1824,19 +1824,17 @@ const AGSGameDescription GAME_DESCRIPTIONS[] = {
 	PRE_25_ENTRY("whokilledkennyrogers", "mags.exe", "ed778afb4f46c3f2a70d330532a83a2f", 1240103),
 	PRE_25_ENTRY("winfry", "fry.exe", "73f87b30f84e9c34ab09ec8dd7ae109d", 4164041),
 
+	// Post 2.5 games that aren't currently supported
 	// uses unsupported agslua plugin
 	UNSUPPORTED_GAME_ENTRY("allthewaydown", "deepuns3.exe", "6c0b5468657c22d62201e3769cd8d2b3", 29830067),
 	// MMM13 crashes during the intro with an error
 	// Error: unexpected data size for WRITELIT op: 8
 	GAME_ENTRY("mmm13", "traum.exe", "3b7cceb3e4bdb031dc5d8f290936e94b", 6703140),
-	// Strangeland isn't yet supported becuase the executable is >2Gb.
-	UNSUPPORTED_GAME_ENTRY("strangeland", "Strangeland.exe", "c5978d50a9b7ee1c8a50a731847d8504", -1),
 	// Commercial game that likely uses custom extensions. Not only does it seem
 	// to use AGSController plugin built-in, even when I hooked up AGSController for
 	// the stand-alone AGS 3.5 interpreter, it hangs just like in ScummVM
 	UNSUPPORTED_GAME_ENTRY("untilihaveyou", "until i have you.exe", "cda1d7e36993dd55ba5513c1c43e5b2b", 1089857773), // Steam
 	UNSUPPORTED_GAME_ENTRY("untilihaveyou", "until i have you.exe", "cda1d7e36993dd55ba5513c1c43e5b2b", 1072879555),
-	// Post 2.5 games that aren't currently supported
 	// 2.55 game, but uses a plugin agsflashlight. Also, even with AGS interpreter
 	// hacked to specify plugin, errors on loading room107 saying that
 	// "room animations are no longer supported"
@@ -3399,6 +3397,7 @@ const AGSGameDescription GAME_DESCRIPTIONS[] = {
 	GAME_ENTRY("stickmeni", "stick.exe", "f3a13b2d6c2e0fe04c6f466062920e23", 2399329),
 	GAME_ENTRY("stickythestickfigurepart1thecrimsonhouse", "Crimson House Files.exe", "3b095a7872e04769d04ab45e9c1b66eb", 3610653),
 	GAME_ENTRY("stranded", "Stranded.exe", "18b284c22010850f79bc5c20054a70c4", 39791629),
+	GAME_ENTRY("strangeland", "Strangeland.exe", "c5978d50a9b7ee1c8a50a731847d8504", 3186614879),
 	GAME_ENTRY("stranger", "Stranger.exe", "0500aacb6c176d47ac0f8158f055db83", 5854099),
 	GAME_ENTRY("strangerinstickworld", "game1.exe", "a524cbb1c51589903c4043b98917f1d9", 42525810),
 	GAME_ENTRY("strangerthings", "StrangerThings.exe", "cc19db728abbcf657db6b76afb0e92d1", 43636017),

--- a/engines/ags/detection_tables.h
+++ b/engines/ags/detection_tables.h
@@ -3398,6 +3398,7 @@ const AGSGameDescription GAME_DESCRIPTIONS[] = {
 	GAME_ENTRY("stickythestickfigurepart1thecrimsonhouse", "Crimson House Files.exe", "3b095a7872e04769d04ab45e9c1b66eb", 3610653),
 	GAME_ENTRY("stranded", "Stranded.exe", "18b284c22010850f79bc5c20054a70c4", 39791629),
 	GAME_ENTRY("strangeland", "Strangeland.exe", "c5978d50a9b7ee1c8a50a731847d8504", 3186614879),
+	GAME_ENTRY("strangeland", "Strangeland.exe", "c5978d50a9b7ee1c8a50a731847d8504", -1), // for 32-bit limited filesystems
 	GAME_ENTRY("stranger", "Stranger.exe", "0500aacb6c176d47ac0f8158f055db83", 5854099),
 	GAME_ENTRY("strangerinstickworld", "game1.exe", "a524cbb1c51589903c4043b98917f1d9", 42525810),
 	GAME_ENTRY("strangerthings", "StrangerThings.exe", "cc19db728abbcf657db6b76afb0e92d1", 43636017),

--- a/engines/ags/engine/main/engine.cpp
+++ b/engines/ags/engine/main/engine.cpp
@@ -1105,6 +1105,8 @@ static void engine_print_info(const std::set<String> &keys, ConfigTree *user_cfg
 // is mixed with game-related data adjustments. Divide it in parts, move game
 // data init into either InitGameState() or other game method as appropriate.
 int initialize_engine(const ConfigTree &startup_opts) {
+	_G(proper_exit) = false;
+
 	if (_G(engine_pre_init_callback)) {
 		_G(engine_pre_init_callback)();
 	}

--- a/engines/ags/globals.h
+++ b/engines/ags/globals.h
@@ -742,7 +742,7 @@ public:
 	int _new_room_pos = 0;
 	int _new_room_x = SCR_NO_VALUE, _new_room_y = SCR_NO_VALUE;
 	int _new_room_loop = SCR_NO_VALUE;
-	bool _proper_exit = false;
+	bool _proper_exit = true;
 	int _our_eip = 0;
 
 	int _oldmouse = 0;

--- a/engines/ags/shared/util/stream.h
+++ b/engines/ags/shared/util/stream.h
@@ -114,15 +114,15 @@ public:
 		return _stream->Read(dataPtr, dataSize);
 	}
 
-	int32 pos() const override {
+	int64 pos() const override {
 		return _stream->GetPosition();
 	}
 
-	int32 size() const override {
+	int64 size() const override {
 		return _stream->GetLength();
 	}
 
-	bool seek(int32 offset, int whence = SEEK_SET) override {
+	bool seek(int64 offset, int whence = SEEK_SET) override {
 		StreamSeek origin = kSeekBegin;
 		if (whence == SEEK_CUR)
 			origin = kSeekCurrent;

--- a/engines/bladerunner/audio_speech.cpp
+++ b/engines/bladerunner/audio_speech.cpp
@@ -83,7 +83,7 @@ bool AudioSpeech::playSpeech(const Common::String &name, int pan) {
 	}
 
 	if (r->size() > kBufferSize) {
-		warning("AudioSpeech::playSpeech: AUD larger than buffer size (%d > %d)", r->size(), kBufferSize);
+		warning("AudioSpeech::playSpeech: AUD larger than buffer size (%d > %d)", (int)r->size(), kBufferSize);
 		return false;
 	}
 

--- a/engines/bladerunner/savefile.h
+++ b/engines/bladerunner/savefile.h
@@ -95,7 +95,7 @@ public:
 
 	uint32 write(const void *dataPtr, uint32 dataSize) override { return _s.write(dataPtr, dataSize); }
 	bool flush() override { return _s.flush(); }
-	int32 pos() const override { return _s.pos(); }
+	int64 pos() const override { return _s.pos(); }
 
 	void debug(char *p);
 
@@ -120,9 +120,9 @@ public:
 
 	bool eos() const override { return _s.eos(); }
 	uint32 read(void *dataPtr, uint32 dataSize) override { return _s.read(dataPtr, dataSize); }
-	int32 pos() const override { return _s.pos(); }
-	int32 size() const override { return _s.size(); }
-	bool seek(int32 offset, int whence = SEEK_SET) override { return _s.seek(offset, whence); }
+	int64 pos() const override { return _s.pos(); }
+	int64 size() const override { return _s.size(); }
+	bool seek(int64 offset, int whence = SEEK_SET) override { return _s.seek(offset, whence); }
 
 	int32 readInt();
 	float readFloat();

--- a/engines/cine/texte.cpp
+++ b/engines/cine/texte.cpp
@@ -61,7 +61,7 @@ void loadTextData(const char *filename) {
 	static const uint bytesPerRow = FONT_WIDTH / 2;    // The input font data is 4-bit so it takes only half the space
 
 	if (headerSize + fontDataSize != (uint)fileHandle.size()) {
-		warning("loadTextData: file '%s' (entrySize = %d, entryCount = %d) is of incorrect size %d", filename, entrySize, entryCount, fileHandle.size());
+		warning("loadTextData: file '%s' (entrySize = %d, entryCount = %d) is of incorrect size %d", filename, entrySize, entryCount, (int)fileHandle.size());
 	}
 
 	Common::Array<byte> source;

--- a/engines/composer/graphics.cpp
+++ b/engines/composer/graphics.cpp
@@ -576,7 +576,7 @@ void ComposerEngine::loadCTBL(uint16 id, uint fadePercent) {
 	debug(1, "CTBL: %d entries", numEntries);
 
 	if ((numEntries > 256) || (stream->size() < 2 + (numEntries * 3)))
-		error("CTBL %d was invalid (%d entries, size %d)", id, numEntries, stream->size());
+		error("CTBL %d was invalid (%d entries, size %d)", id, numEntries, (int)stream->size());
 
 	byte buffer[256 * 3];
 	stream->read(buffer, numEntries * 3);
@@ -680,7 +680,7 @@ void ComposerEngine::decompressBitmap(uint16 type, Common::SeekableReadStream *s
 	case kBitmapUncompressed:
 		if (stream->size() - (uint)stream->pos() != size)
 			error("kBitmapUncompressed stream had %d bytes left, supposed to be %d",
-				stream->size() - (uint)stream->pos(), size);
+				(int)(stream->size() - stream->pos()), size);
 		if (size != outSize)
 			error("kBitmapUncompressed size %d doesn't match required size %d",
 				size, outSize);

--- a/engines/composer/scripting.cpp
+++ b/engines/composer/scripting.cpp
@@ -109,7 +109,7 @@ void ComposerEngine::runEvent(uint16 id, int16 param1, int16 param2, int16 param
 
 	Common::SeekableReadStream *stream = getResource(ID_EVNT, id);
 	if (stream->size() != 2)
-		error("bad EVNT size %d", stream->size());
+		error("bad EVNT size %d", (int)stream->size());
 	uint16 scriptId = stream->readUint16LE();
 	delete stream;
 
@@ -178,10 +178,10 @@ void ComposerEngine::runScript(uint16 id) {
 
 	Common::SeekableReadStream *stream = getResource(ID_SCRP, id);
 	if (stream->size() < 2)
-		error("SCRP was too small (%d)", stream->size());
+		error("SCRP was too small (%d)", (int)stream->size());
 	uint16 size = stream->readUint16LE();
-	if (stream->size() < 2 + 2*size)
-		error("SCRP was too small (%d, but claimed %d entries)", stream->size(), size);
+	if ((int)stream->size() < 2 + 2*size)
+		error("SCRP was too small (%d, but claimed %d entries)", (int)stream->size(), size);
 	uint16 *script = new uint16[size];
 	for (uint i = 0; i < size; i++)
 		script[i] = stream->readUint16LE();

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -548,12 +548,12 @@ void Cast::loadCastChildren() {
 
 		switch (tag) {
 		case MKTAG('D', 'I', 'B', ' '):
-			debugC(2, kDebugLoading, "****** Loading 'DIB ' id: %d (%d), %d bytes", imgId, realId, pic->size());
+			debugC(2, kDebugLoading, "****** Loading 'DIB ' id: %d (%d), %d bytes", imgId, realId, (int)pic->size());
 			img = new DIBDecoder();
 			break;
 
 		case MKTAG('B', 'I', 'T', 'D'):
-			debugC(2, kDebugLoading, "****** Loading 'BITD' id: %d (%d), %d bytes", imgId, realId, pic->size());
+			debugC(2, kDebugLoading, "****** Loading 'BITD' id: %d (%d), %d bytes", imgId, realId, (int)pic->size());
 
 			if (w > 0 && h > 0) {
 				if (_version < kFileVer600) {
@@ -682,7 +682,7 @@ PaletteV4 Cast::loadPalette(Common::SeekableReadStreamEndian &stream) {
 	uint16 index = (steps * 3) - 1;
 	byte *_palette = new byte[index + 1];
 
-	debugC(3, kDebugLoading, "Cast::loadPalette(): %d steps, %d bytes", steps, stream.size());
+	debugC(3, kDebugLoading, "Cast::loadPalette(): %d steps, %d bytes", steps, (int)stream.size());
 
 	if (steps > 256) {
 		warning("Cast::loadPalette(): steps > 256: %d", steps);

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -314,7 +314,7 @@ bool SNDDecoder::processBufferCommand(Common::SeekableReadStreamEndian &stream) 
 	/*uint16 unk1 =*/stream.readUint16();
 	int32 offset = stream.readUint32();
 	if (offset != stream.pos()) {
-		warning("SNDDecoder: Bad sound header offset. Expected: %d, read: %d", stream.pos(), offset);
+		warning("SNDDecoder: Bad sound header offset. Expected: %d, read: %d", (int)stream.pos(), offset);
 		return false;
 	}
 	/*uint32 dataPtr =*/stream.readUint32();

--- a/engines/draci/script.cpp
+++ b/engines/draci/script.cpp
@@ -1139,7 +1139,7 @@ void Script::run(const GPL2Program &program, uint16 offset) {
 		if (_jump != 0) {
 			debugC(3, kDraciBytecodeDebugLevel,
 				"Jumping from offset %d to %d (%d bytes)",
-				reader.pos(), reader.pos() + _jump, _jump);
+				(int)reader.pos(), (int)reader.pos() + _jump, _jump);
 			reader.seek(_jump, SEEK_CUR);
 		}
 

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -222,7 +222,7 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 	report += Common::U32String("\n\n");
 
 	for (FilePropertiesMap::const_iterator file = matchedFiles.begin(); file != matchedFiles.end(); ++file)
-		report += Common::String::format("  {\"%s\", 0, \"%s\", %d},\n", file->_key.c_str(), file->_value.md5.c_str(), file->_value.size);
+		report += Common::String::format("  {\"%s\", 0, \"%s\", %lld},\n", file->_key.c_str(), file->_value.md5.c_str(), (long long)file->_value.size);
 
 	report += Common::U32String("\n");
 

--- a/engines/game.h
+++ b/engines/game.h
@@ -104,7 +104,7 @@ enum GameSupportLevel {
  * files while detecting a game.
  */
 struct FileProperties {
-	int32 size;
+	int64 size;
 	Common::String md5;
 
 	FileProperties() : size(-1) {}

--- a/engines/glk/comprehend/file_buf.cpp
+++ b/engines/glk/comprehend/file_buf.cpp
@@ -55,7 +55,7 @@ void FileBuffer::close() {
 	_pos = 0;
 }
 
-bool FileBuffer::seek(int32 offset, int whence) {
+bool FileBuffer::seek(int64 offset, int whence) {
 	switch (whence) {
 	case SEEK_SET:
 		_pos = offset;

--- a/engines/glk/comprehend/file_buf.h
+++ b/engines/glk/comprehend/file_buf.h
@@ -43,13 +43,13 @@ public:
 	static bool exists(const Common::String &filename);
 	void close();
 
-	int32 pos() const override {
+	int64 pos() const override {
 		return _pos;
 	}
-	int32 size() const override {
+	int64 size() const override {
 		return _data.size();
 	}
-	bool seek(int32 offset, int whence = SEEK_SET) override;
+	bool seek(int64 offset, int whence = SEEK_SET) override;
 
 	bool eos() const override {
 		return _pos >= (int)_data.size();

--- a/engines/glk/comprehend/game_data.cpp
+++ b/engines/glk/comprehend/game_data.cpp
@@ -216,7 +216,7 @@ void GameData::parse_function(FileBuffer *fb, Function *func) {
 
 	p = (const uint8 *)memchr(fb->dataPtr(), 0x00, fb->size() - fb->pos());
 	if (!p)
-		error("bad function @ %.4x", fb->pos());
+		error("bad function @ %.4x", (int)fb->pos());
 
 	for (;;) {
 		Instruction instruction;

--- a/engines/glk/comprehend/pics.cpp
+++ b/engines/glk/comprehend/pics.cpp
@@ -149,7 +149,7 @@ bool Pics::ImageFile::doImageOp(Pics::ImageContext *ctx) const {
 	uint16 a, b;
 
 	opcode = ctx->_file.readByte();
-	debugCN(kDebugGraphics, "  %.4x [%.2x]: ", ctx->_file.pos() - 1, opcode);
+	debugCN(kDebugGraphics, "  %.4x [%.2x]: ", (int)ctx->_file.pos() - 1, opcode);
 
 	byte param = opcode & 0xf;
 	opcode >>= 4;

--- a/engines/glk/quest/geas_util.h
+++ b/engines/glk/quest/geas_util.h
@@ -83,7 +83,7 @@ public:
 private:
 	class Nullstreambuf : public Common::WriteStream {
 		uint32 write(const void *dataPtr, uint32 dataSize) override { return dataSize; }
-		int32 pos() const override { return 0; }
+		int64 pos() const override { return 0; }
 	};
 
 //	Common::WriteStream *logfilestr_;

--- a/engines/glk/quest/streams.h
+++ b/engines/glk/quest/streams.h
@@ -36,7 +36,7 @@ namespace Quest {
 class ConsoleStream : public Common::WriteStream {
 public:
 	uint32 write(const void *dataPtr, uint32 dataSize) override;
-	int32 pos() const override { return 0; }
+	int64 pos() const override { return 0; }
 };
 
 class ostringstream : public Common::MemoryWriteStreamDynamic {

--- a/engines/gob/demos/scnplayer.cpp
+++ b/engines/gob/demos/scnplayer.cpp
@@ -91,7 +91,7 @@ bool SCNPlayer::readLabels(Common::SeekableReadStream &scn, LabelMap &labels) {
 		if (lineStartsWith(line, "LABEL ")) {
 			// Label => Add to the hashmap
 			labels.setVal(line.c_str() + 6, scn.pos());
-			debugC(2, kDebugDemo, "Found label \"%s\" (%d)", line.c_str() + 6, scn.pos());
+			debugC(2, kDebugDemo, "Found label \"%s\" (%d)", line.c_str() + 6, (int)scn.pos());
 		}
 	}
 

--- a/engines/gob/inter_playtoons.cpp
+++ b/engines/gob/inter_playtoons.cpp
@@ -289,7 +289,7 @@ void Inter_Playtoons::oPlaytoons_readData(OpFuncParams &params) {
 	_vm->_draw->animateCursor(4);
 	if (offset > stream->size()) {
 		warning("oPlaytoons_readData: File \"%s\", Offset (%d) > file size (%d)",
-				file.c_str(), offset, stream->size());
+				file.c_str(), offset, (int)stream->size());
 		delete stream;
 		return;
 	}

--- a/engines/gob/save/saveconverter.cpp
+++ b/engines/gob/save/saveconverter.cpp
@@ -332,21 +332,21 @@ uint32 SaveConverter::read(void *dataPtr, uint32 dataSize) {
 	return _stream->read(dataPtr, dataSize);
 }
 
-int32 SaveConverter::pos() const {
+int64 SaveConverter::pos() const {
 	if (!_data || !_stream)
 		return -1;
 
 	return _stream->pos();
 }
 
-int32 SaveConverter::size() const {
+int64 SaveConverter::size() const {
 	if (!_data || !_stream)
 		return -1;
 
 	return _stream->size();
 }
 
-bool SaveConverter::seek(int32 offset, int whence) {
+bool SaveConverter::seek(int64 offset, int whence) {
 	if (!_data || !_stream)
 		return false;
 

--- a/engines/gob/save/saveconverter.h
+++ b/engines/gob/save/saveconverter.h
@@ -64,9 +64,9 @@ public:
 	bool eos() const override;
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 	// SeekableReadStream
-	int32 pos() const override;
-	int32 size() const override;
-	bool seek(int32 offset, int whence = SEEK_SET) override;
+	int64 pos() const override;
+	int64 size() const override;
+	bool seek(int64 offset, int whence = SEEK_SET) override;
 
 protected:
 	GobEngine *_vm;

--- a/engines/gob/sound/adlplayer.cpp
+++ b/engines/gob/sound/adlplayer.cpp
@@ -184,7 +184,7 @@ bool ADLPlayer::load(Common::SeekableReadStream &adl) {
 bool ADLPlayer::readHeader(Common::SeekableReadStream &adl, int &timbreCount) {
 	// Sanity check
 	if (adl.size() < 60) {
-		warning("ADLPlayer::readHeader(): File too small (%d)", adl.size());
+		warning("ADLPlayer::readHeader(): File too small (%d)", (int)adl.size());
 		return false;
 	}
 

--- a/engines/gob/sound/musplayer.cpp
+++ b/engines/gob/sound/musplayer.cpp
@@ -220,7 +220,7 @@ bool MUSPlayer::readString(Common::SeekableReadStream &stream, Common::String &s
 bool MUSPlayer::readSNDHeader(Common::SeekableReadStream &snd, int &timbreCount, int &timbrePos) {
 	// Sanity check
 	if (snd.size() <= 6) {
-		warning("MUSPlayer::readSNDHeader(): File too small (%d)", snd.size());
+		warning("MUSPlayer::readSNDHeader(): File too small (%d)", (int)snd.size());
 		return false;
 	}
 

--- a/engines/grim/patchr.cpp
+++ b/engines/grim/patchr.cpp
@@ -43,9 +43,9 @@ public:
 	virtual uint32 read(void *dataPtr, uint32 dataSize) override;
 
 	// Common::SeekableReadStream implementation
-	virtual int32 pos() const override;
-	virtual int32 size() const override;
-	virtual bool seek(int32 offset, int whence = SEEK_SET) override;
+	virtual int64 pos() const override;
+	virtual int64 size() const override;
+	virtual bool seek(int64 offset, int whence = SEEK_SET) override;
 
 private:
 	// Consts
@@ -286,15 +286,15 @@ bool PatchedFile::eos() const {
 		return false;
 }
 
-int32 PatchedFile::pos() const {
+int64 PatchedFile::pos() const {
 	return _pos;
 }
 
-int32 PatchedFile::size() const {
+int64 PatchedFile::size() const {
 	return _newSize;
 }
 
-bool PatchedFile::seek(int32 offset, int whence) {
+bool PatchedFile::seek(int64 offset, int whence) {
 	int32 totJump, relOffset;
 	uint32 skipDiff, skipExtra, skipSize;
 	relOffset = 0;

--- a/engines/grim/update/packfile.cpp
+++ b/engines/grim/update/packfile.cpp
@@ -119,15 +119,15 @@ bool PackFile::eos() const {
 	return _orgStream->eos();
 }
 
-int32 PackFile::pos() const {
+int64 PackFile::pos() const {
 	return _orgStream->pos() - _offset;
 }
 
-int32 PackFile::size() const {
+int64 PackFile::size() const {
 	return _size;
 }
 
-bool PackFile::seek(int32 offset, int whence) {
+bool PackFile::seek(int64 offset, int whence) {
 	if (_codeTable && whence == SEEK_SET)
 		offset += _offset;
 	return _orgStream->seek(offset, whence);

--- a/engines/grim/update/packfile.h
+++ b/engines/grim/update/packfile.h
@@ -38,9 +38,9 @@ public:
 	void clearErr();
 	uint32 read(void *dataPtr, uint32 dataSize);
 	bool eos() const;
-	int32 pos() const;
-	int32 size() const;
-	bool seek(int32 offset, int whence = SEEK_SET);
+	int64 pos() const;
+	int64 size() const;
+	bool seek(int64 offset, int whence = SEEK_SET);
 
 private:
 	Common::SeekableReadStream *_orgStream;

--- a/engines/groovie/font.cpp
+++ b/engines/groovie/font.cpp
@@ -75,7 +75,7 @@ bool T7GFont::load(Common::SeekableReadStream &stream) {
 			uint16 offset = glyphOffsets[i];
 			delete[] glyphOffsets;
 			error("Groovie::T7GFont: Glyph %d starts at %d but the current "
-				"offset is %d", i, offset, stream.pos());
+				"offset is %d", i, offset, (int)stream.pos());
 			return false;
 		}
 

--- a/engines/groovie/roq.cpp
+++ b/engines/groovie/roq.cpp
@@ -268,7 +268,7 @@ bool ROQPlayer::processBlock() {
 	}
 
 	if (endpos != _file->pos())
-		warning("Groovie::ROQ: BLOCK %04x Should have ended at %d, and has ended at %d", blockHeader.type, endpos, _file->pos());
+		warning("Groovie::ROQ: BLOCK %04x Should have ended at %d, and has ended at %d", blockHeader.type, endpos, (int)_file->pos());
 
 	// End the frame when the graphics have been modified or when there's an error
 	return endframe || !ok;

--- a/engines/hdb/saveload.cpp
+++ b/engines/hdb/saveload.cpp
@@ -131,41 +131,41 @@ Common::Error HDBGame::loadGameState(int slot) {
 }
 
 void HDBGame::saveGame(Common::OutSaveFile *out) {
-	debug(1, "HDBGame::saveGame: start at %u", out->pos());
+	debug(1, "HDBGame::saveGame: start at %u", (uint32)out->pos());
 
 	// Save Map Name and Time
 	out->writeUint32LE(_saveHeader.seconds);
 	out->write(_inMapName, 32);
 
-	debug(1, "HDBGame::saveGame: map at %u", out->pos());
+	debug(1, "HDBGame::saveGame: map at %u", (uint32)out->pos());
 	// Save Map Object Data
 	_map->save(out);
 
 	// Save Window Object Data
-	debug(1, "HDBGame::saveGame: window at %u", out->pos());
+	debug(1, "HDBGame::saveGame: window at %u", (uint32)out->pos());
 	_window->save(out);
 
 	// Save Gfx Object Data
-	debug(1, "HDBGame::saveGame: gfx at %u", out->pos());
+	debug(1, "HDBGame::saveGame: gfx at %u", (uint32)out->pos());
 	_gfx->save(out);
 
 	// Save Sound Object Data
-	debug(1, "HDBGame::saveGame: sound at %u", out->pos());
+	debug(1, "HDBGame::saveGame: sound at %u", (uint32)out->pos());
 	_sound->save(out);
 
 	// Save Game Object Data
-	debug(1, "HDBGame::saveGame: game object at %u", out->pos());
+	debug(1, "HDBGame::saveGame: game object at %u", (uint32)out->pos());
 	save(out);
 
 	// Save AI Object Data
-	debug(1, "HDBGame::saveGame: ai at %u", out->pos());
+	debug(1, "HDBGame::saveGame: ai at %u", (uint32)out->pos());
 	_ai->save(out);
 
-	debug(1, "HDBGame::saveGame: end at %u", out->pos());
+	debug(1, "HDBGame::saveGame: end at %u", (uint32)out->pos());
 }
 
 void HDBGame::loadGame(Common::InSaveFile *in) {
-	debug(1, "HDBGame::loadGame: start at %u", in->pos());
+	debug(1, "HDBGame::loadGame: start at %u", (uint32)in->pos());
 
 	// Load Map Name and Time
 	_timeSeconds = in->readUint32LE();
@@ -177,30 +177,30 @@ void HDBGame::loadGame(Common::InSaveFile *in) {
 	Common::strlcpy(_saveHeader.mapName, _inMapName, sizeof(_saveHeader.mapName));
 
 	// Load Map Object Data
-	debug(1, "HDBGame::loadGame: map at %u", in->pos());
+	debug(1, "HDBGame::loadGame: map at %u", (uint32)in->pos());
 	_map->loadSaveFile(in);
 
 	// Load Window Object Data
-	debug(1, "HDBGame::loadGame: window at %u", in->pos());
+	debug(1, "HDBGame::loadGame: window at %u", (uint32)in->pos());
 	_window->loadSaveFile(in);
 
 	// Load Gfx Object Data
-	debug(1, "HDBGame::loadGame: gfx at %u", in->pos());
+	debug(1, "HDBGame::loadGame: gfx at %u", (uint32)in->pos());
 	_gfx->loadSaveFile(in);
 
 	// Load Sound Object Data
-	debug(1, "HDBGame::loadGame: sound at %u", in->pos());
+	debug(1, "HDBGame::loadGame: sound at %u", (uint32)in->pos());
 	_sound->loadSaveFile(in);
 
 	// Load Game Object Data
-	debug(1, "HDBGame::loadGame: game object at %u", in->pos());
+	debug(1, "HDBGame::loadGame: game object at %u", (uint32)in->pos());
 	loadSaveFile(in);
 
 	// Load AI Object Data
-	debug(1, "HDBGame::loadGame: ai at %u", in->pos());
+	debug(1, "HDBGame::loadGame: ai at %u", (uint32)in->pos());
 	_ai->loadSaveFile(in);
 
-	debug(1, "HDBGame::loadGame: end at %u", in->pos());
+	debug(1, "HDBGame::loadGame: end at %u", (uint32)in->pos());
 
 	_gfx->turnOffFade();
 }

--- a/engines/kyra/graphics/screen.cpp
+++ b/engines/kyra/graphics/screen.cpp
@@ -3336,7 +3336,7 @@ bool Screen::loadPalette(const char *filename, Palette &pal) {
 			numCols = stream->size() / Palette::kVGABytesPerColor;
 			pal.loadVGAPalette(*stream, 0, MIN(maxCols, numCols));
 		} else {
-			error("Screen::loadPalette(): Failed to load file '%s' with invalid size %d in HiColor mode", filename, stream->size());
+			error("Screen::loadPalette(): Failed to load file '%s' with invalid size %d in HiColor mode", filename, (int)stream->size());
 		}
 	}
 

--- a/engines/kyra/resource/resource_intern.h
+++ b/engines/kyra/resource/resource_intern.h
@@ -155,9 +155,9 @@ public:
 	uint32 read(void *dataPtr, uint32 dataSize) override { return _stream->read(dataPtr, dataSize); }
 
 	// Common::SeekableReadStream interface
-	int32 pos() const override { return _stream->pos(); }
-	int32 size() const override { return _stream->size(); }
-	bool seek(int32 offset, int whence = SEEK_SET) override { return _stream->seek(offset, whence); }
+	int64 pos() const override { return _stream->pos(); }
+	int64 size() const override { return _stream->size(); }
+	bool seek(int64 offset, int whence = SEEK_SET) override { return _stream->seek(offset, whence); }
 
 private:
 	Common::SeekableReadStream *_stream;

--- a/engines/lastexpress/debug.cpp
+++ b/engines/lastexpress/debug.cpp
@@ -290,7 +290,7 @@ bool Debugger::cmdDumpFiles(int argc, const char **) {
 			return true; \
 		} \
 		Common::String md5str = Common::computeStreamMD5AsString(*stream); \
-		debugC(1, kLastExpressDebugResource, "%s, %d, %s", (*it)->getName().c_str(), stream->size(), md5str.c_str()); \
+		debugC(1, kLastExpressDebugResource, "%s, %d, %s", (*it)->getName().c_str(), (int)stream->size(), md5str.c_str()); \
 		delete stream; \
 	} \
 }

--- a/engines/lastexpress/game/savegame.cpp
+++ b/engines/lastexpress/game/savegame.cpp
@@ -439,7 +439,7 @@ uint32 SaveLoad::init(GameId id, bool resetHeaders) {
 void SaveLoad::loadStream(GameId id) {
 	Common::InSaveFile *save = openForLoading(id);
 	if (save->size() < 32)
-		error("[SaveLoad::loadStream] Savegame seems to be corrupted (not enough data: %i bytes)", save->size());
+		error("[SaveLoad::loadStream] Savegame seems to be corrupted (not enough data: %i bytes)", (int)save->size());
 
 	if (!_savegame)
 		error("[SaveLoad::loadStream] Savegame stream is invalid");
@@ -629,7 +629,7 @@ bool SaveLoad::loadMainHeader(Common::InSaveFile *stream, SavegameMainHeader *he
 
 	// Check there is enough data (32 bytes)
 	if (stream->size() < 32) {
-		debugC(2, kLastExpressDebugSavegame, "Savegame seems to be corrupted (not enough data: %i bytes)", stream->size());
+		debugC(2, kLastExpressDebugSavegame, "Savegame seems to be corrupted (not enough data: %i bytes)", (int)stream->size());
 		return false;
 	}
 

--- a/engines/lastexpress/game/savegame.h
+++ b/engines/lastexpress/game/savegame.h
@@ -105,9 +105,9 @@ public:
 		memset(_buffer, 0, 256);
 	}
 
-	int32 pos() const override { return MemoryWriteStreamDynamic::pos(); }
-	int32 size() const override { return MemoryWriteStreamDynamic::size(); }
-	bool seek(int32 offset, int whence = SEEK_SET) override { return MemoryWriteStreamDynamic::seek(offset, whence); }
+	int64 pos() const override { return MemoryWriteStreamDynamic::pos(); }
+	int64 size() const override { return MemoryWriteStreamDynamic::size(); }
+	bool seek(int64 offset, int whence = SEEK_SET) override { return MemoryWriteStreamDynamic::seek(offset, whence); }
 	bool eos() const override { return _eos; }
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 	uint32 write(const void *dataPtr, uint32 dataSize) override;

--- a/engines/made/database.cpp
+++ b/engines/made/database.cpp
@@ -681,7 +681,7 @@ bool GameDatabaseV3::getSavegameDescription(const char *filename, Common::String
 	}
 
 	if (size != in->size() - 64) {
-		warning("Unexpected save game size. Expected %d, size is %d (file size - 64)", size, in->size() - 64);
+		warning("Unexpected save game size. Expected %d, size is %d (file size - 64)", size, (int)in->size() - 64);
 		delete in;
 		return false;
 	}

--- a/engines/made/pmvplayer.cpp
+++ b/engines/made/pmvplayer.cpp
@@ -238,7 +238,7 @@ void PmvPlayer::readChunk(uint32 &chunkType, uint32 &chunkSize) {
 	chunkSize = _fd->readUint32LE();
 
 	debug(2, "ofs = %08X; chunkType = %c%c%c%c; chunkSize = %d\n",
-		_fd->pos(),
+		(int)_fd->pos(),
 		(chunkType >> 24) & 0xFF, (chunkType >> 16) & 0xFF, (chunkType >> 8) & 0xFF, chunkType & 0xFF,
 		chunkSize);
 

--- a/engines/made/resource.cpp
+++ b/engines/made/resource.cpp
@@ -162,7 +162,7 @@ void PictureResource::loadChunked(byte *source, int size) {
 			_picturePalette = new byte[_paletteColorCount * 3];
 			sourceS->read(_picturePalette, _paletteColorCount * 3);
 		} else {
-			error("PictureResource::loadChunked() Invalid chunk %08X at %08X", chunkType, sourceS->pos());
+			error("PictureResource::loadChunked() Invalid chunk %08X at %08X", chunkType, (int)sourceS->pos());
 		}
 
 	}

--- a/engines/mohawk/bitmap.cpp
+++ b/engines/mohawk/bitmap.cpp
@@ -704,7 +704,7 @@ MohawkSurface *LivingBooksBitmap_v1::decodeImageLB(Common::SeekableReadStreamEnd
 		uint16 lengthBits = endianStream->readUint16();
 
 		if (compressedSize != (uint32)endianStream->size() - 24)
-			error("More bytes (%d) remaining in stream than header says there should be (%d)", endianStream->size() - 24, compressedSize);
+			error("More bytes (%d) remaining in stream than header says there should be (%d)", (int)endianStream->size() - 24, compressedSize);
 
 		// These two errors are really just sanity checks and should never go off
 		if (posBits != POS_BITS)

--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -1749,7 +1749,7 @@ LBAnimation::LBAnimation(MohawkEngine_LivingBooks *vm, LBAnimationItem *parent, 
 	debug(5, "ANI SPRResourceId: %d, offset %d", sprResourceId, sprResourceOffset);
 
 	if (aniStream->pos() != aniStream->size())
-		error("Still %d bytes at the end of anim stream", aniStream->size() - aniStream->pos());
+		error("Still %d bytes at the end of anim stream", (int)(aniStream->size() - aniStream->pos()));
 
 	delete aniStream;
 
@@ -1788,7 +1788,7 @@ LBAnimation::LBAnimation(MohawkEngine_LivingBooks *vm, LBAnimationItem *parent, 
 		error("Ignoring %d back nodes", numBackNodes);
 
 	if (sprStream->pos() != sprStream->size())
-		error("Still %d bytes at the end of sprite stream", sprStream->size() - sprStream->pos());
+		error("Still %d bytes at the end of sprite stream", (int)(sprStream->size() - sprStream->pos()));
 
 	delete sprStream;
 
@@ -1819,7 +1819,7 @@ void LBAnimation::loadShape(uint16 resourceId) {
 
 	if (_vm->isPreMohawk()) {
 		if (shapeStream->size() < 6)
-			error("V1 SHP Record size too short (%d)", shapeStream->size());
+			error("V1 SHP Record size too short (%d)", (int)shapeStream->size());
 
 		uint16 u0 = shapeStream->readUint16();
 		if (u0 != 3)
@@ -1833,7 +1833,7 @@ void LBAnimation::loadShape(uint16 resourceId) {
 		debug(8, "V1 SHP: idCount: %d", idCount);
 
 		if (shapeStream->size() != (idCount * 2) + 6)
-			error("V1 SHP Record size mismatch (%d)", shapeStream->size());
+			error("V1 SHP Record size mismatch (%d)", (int)shapeStream->size());
 
 		for (uint16 i = 0; i < idCount; i++) {
 			_shapeResources.push_back(shapeStream->readUint16());
@@ -1844,7 +1844,7 @@ void LBAnimation::loadShape(uint16 resourceId) {
 		debug(8, "SHP: idCount: %d", idCount);
 
 		if (shapeStream->size() != (idCount * 6) + 2)
-			error("SHP Record size mismatch (%d)", shapeStream->size());
+			error("SHP Record size mismatch (%d)", (int)shapeStream->size());
 
 		for (uint16 i = 0; i < idCount; i++) {
 			_shapeResources.push_back(shapeStream->readUint16());
@@ -2083,7 +2083,7 @@ void LBItem::readFrom(Common::SeekableSubReadStreamEndian *stream) {
 
 	int endPos = stream->pos() + size;
 	if (endPos > stream->size())
-		error("Item is larger (should end at %d) than stream (size %d)", endPos, stream->size());
+		error("Item is larger (should end at %d) than stream (size %d)", endPos, (int)stream->size());
 
 	while (true) {
 		if (stream->pos() == endPos)
@@ -2105,7 +2105,7 @@ void LBItem::readFrom(Common::SeekableSubReadStreamEndian *stream) {
 				(int)stream->pos() - (int)(oldPos + 4 + (uint)dataSize), dataType, dataSize);
 
 		if (stream->pos() > endPos)
-			error("Read off the end (at %d) of data (ends at %d)", stream->pos(), endPos);
+			error("Read off the end (at %d) of data (ends at %d)", (int)stream->pos(), endPos);
 
 		assert(!stream->eos());
 	}

--- a/engines/mohawk/livingbooks_code.cpp
+++ b/engines/mohawk/livingbooks_code.cpp
@@ -185,7 +185,7 @@ LBCode::LBCode(MohawkEngine_LivingBooks *vm, uint16 baseId) : _vm(vm) {
 
 	uint32 totalSize = bcodStream->readUint32();
 	if (totalSize != (uint32)bcodStream->size())
-		error("BCOD had size %d, but claimed to be of size %d", bcodStream->size(), totalSize);
+		error("BCOD had size %d, but claimed to be of size %d", (int)bcodStream->size(), totalSize);
 	_size = bcodStream->readUint32();
 	if (_size + 8 > totalSize)
 		error("BCOD code was of size %d, beyond size %d", _size, totalSize);

--- a/engines/myst3/effects.cpp
+++ b/engines/myst3/effects.cpp
@@ -665,7 +665,7 @@ bool ShieldEffect::loadPattern() {
 
 	Common::SeekableReadStream *stream = desc.getData();
 	if (stream->size() != 4096) {
-		error("Incorrect shield effect support file size %d", stream->size());
+		error("Incorrect shield effect support file size %d", (int)stream->size());
 	}
 
 	stream->read(_pattern, 4096);

--- a/engines/ngi/gameloader.cpp
+++ b/engines/ngi/gameloader.cpp
@@ -622,7 +622,7 @@ bool Sc2::load(MfcArchive &file) {
 	}
 
 	if (file.size() - file.pos() > 0)
-		error("Sc2::load(): (%d bytes left)", file.size() - file.pos());
+		error("Sc2::load(): (%d bytes left)", (int)(file.size() - file.pos()));
 
 	return true;
 }

--- a/engines/ngi/scene.cpp
+++ b/engines/ngi/scene.cpp
@@ -237,7 +237,7 @@ bool Scene::load(MfcArchive &file) {
 	initStaticANIObjects();
 
 	if (file.size() - file.pos() > 0)
-		error("Scene::load  (%d bytes left)", file.size() - file.pos());
+		error("Scene::load  (%d bytes left)", (int)(file.size() - file.pos()));
 
 	return true;
 }

--- a/engines/ngi/stateloader.cpp
+++ b/engines/ngi/stateloader.cpp
@@ -55,7 +55,7 @@ bool GameLoader::readSavegame(const char *fname) {
 	header.encSize = saveFile->readUint32LE();
 
 	debugC(3, kDebugLoading, "version: %d magic: %s updateCounter: %d unkField: %d encSize: %d, pos: %d",
-			header.version, header.magic, header.updateCounter, header.unkField, header.encSize, saveFile->pos());
+			header.version, header.magic, header.updateCounter, header.unkField, header.encSize, (int)saveFile->pos());
 
 	if (header.version != 48)
 		return false;

--- a/engines/ngi/statesaver.cpp
+++ b/engines/ngi/statesaver.cpp
@@ -122,7 +122,7 @@ bool GameLoader::writeSavegame(Scene *sc, const char *fname, const Common::Strin
 	saveFile->writeUint32LE(header.encSize);
 
 	debugC(3, kDebugLoading, "version: %d magic: %s updateCounter: %d unkField: %d encSize: %d, pos: %d",
-			header.version, header.magic, header.updateCounter, header.unkField, header.encSize, saveFile->pos());
+			header.version, header.magic, header.updateCounter, header.unkField, header.encSize, (int)saveFile->pos());
 
 	saveFile->write(stream.getData(), stream.size());
 

--- a/engines/ngi/utils.cpp
+++ b/engines/ngi/utils.cpp
@@ -364,7 +364,7 @@ CObject *MfcArchive::parseClass(bool *isCopyReturned) {
 
 	uint obTag = readUint16LE();
 
-	debugC(7, kDebugLoading, "parseClass::obTag = %d (%04x)  at 0x%08x", obTag, obTag, pos() - 2);
+	debugC(7, kDebugLoading, "parseClass::obTag = %d (%04x)  at 0x%08x", obTag, obTag, (int)pos() - 2);
 
 	if (obTag == 0x0000) {
 		return NULL;
@@ -394,7 +394,7 @@ CObject *MfcArchive::parseClass(bool *isCopyReturned) {
 		*isCopyReturned = false;
 	} else if ((obTag & 0x8000) == 0) {
 		if (_objectMap.size() < obTag) {
-			error("Object index too big: %d  at 0x%08x", obTag, pos() - 2);
+			error("Object index too big: %d  at 0x%08x", obTag, (int)pos() - 2);
 		}
 		debugC(7, kDebugLoading, "parseClass::obTag <%s>", lookupObjectId(_objectIdMap[obTag]));
 
@@ -406,7 +406,7 @@ CObject *MfcArchive::parseClass(bool *isCopyReturned) {
 		obTag &= ~0x8000;
 
 		if (_objectMap.size() < obTag) {
-			error("Object index too big: %d  at 0x%08x", obTag, pos() - 2);
+			error("Object index too big: %d  at 0x%08x", obTag, (int)pos() - 2);
 		}
 
 		debugC(7, kDebugLoading, "parseClass::obTag <%s>", lookupObjectId(_objectIdMap[obTag]));

--- a/engines/ngi/utils.h
+++ b/engines/ngi/utils.h
@@ -78,9 +78,9 @@ public:
 
 	bool eos() const override { return _stream->eos(); }
 	uint32 read(void *dataPtr, uint32 dataSize) override { return _stream->read(dataPtr, dataSize); }
-	int32 pos() const override { return _stream ? _stream->pos() : _wstream->pos(); }
-	int32 size() const override { return _stream->size(); }
-	bool seek(int32 offset, int whence = SEEK_SET) override { return _stream->seek(offset, whence); }
+	int64 pos() const override { return _stream ? _stream->pos() : _wstream->pos(); }
+	int64 size() const override { return _stream->size(); }
+	bool seek(int64 offset, int whence = SEEK_SET) override { return _stream->seek(offset, whence); }
 
 	uint32 write(const void *dataPtr, uint32 dataSize) override { return _wstream->write(dataPtr, dataSize); }
 

--- a/engines/parallaction/disk_ns.cpp
+++ b/engines/parallaction/disk_ns.cpp
@@ -688,11 +688,11 @@ public:
 		if (_dispose) delete _stream;
 	}
 
-	int32 size() const override {
+	int64 size() const override {
 		return _stream->size();
 	}
 
-	int32 pos() const override {
+	int64 pos() const override {
 		return _stream->pos();
 	}
 
@@ -700,7 +700,7 @@ public:
 		return _stream->eos();
 	}
 
-	bool seek(int32 offs, int whence = SEEK_SET) override {
+	bool seek(int64 offs, int whence = SEEK_SET) override {
 		return _stream->seek(offs, whence);
 	}
 

--- a/engines/prince/resource.cpp
+++ b/engines/prince/resource.cpp
@@ -52,7 +52,7 @@ Common::SeekableReadStream *Resource::getDecompressedStream(Common::SeekableRead
 		dec.decompress(buffer + 18, decompData, decompLen);
 		free(buffer);
 
-		debug(8, "Resource::getDecompressedStream: decompressed %d to %d bytes", stream->size(), decompLen);
+		debug(8, "Resource::getDecompressedStream: decompressed %d to %d bytes", (int)stream->size(), decompLen);
 
 		return new Common::MemoryReadStream(decompData, decompLen, DisposeAfterUse::YES);
 	} else {

--- a/engines/sci/engine/file.h
+++ b/engines/sci/engine/file.h
@@ -128,10 +128,10 @@ public:
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 
 	bool eos() const override { return _eos; }
-	int32 pos() const override { return _pos; }
-	int32 size() const override { return _size; }
+	int64 pos() const override { return _pos; }
+	int64 size() const override { return _size; }
 	void clearErr() override { _eos = false; Common::MemoryWriteStreamDynamic::clearErr(); }
-	bool seek(int32 offs, int whence = SEEK_SET) override { return Common::MemoryWriteStreamDynamic::seek(offs, whence); }
+	bool seek(int64 offs, int whence = SEEK_SET) override { return Common::MemoryWriteStreamDynamic::seek(offs, whence); }
 
 protected:
 	bool _eos;

--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -930,7 +930,7 @@ bool MidiPlayer_Midi::readD110DrvData() {
 	}
 
 	if (f.size() != 3500)
-		error("Unknown '%s' size (%d)", fileName, f.size());
+		error("Unknown '%s' size (%d)", fileName, (int)f.size());
 
 	f.seek(42);
 

--- a/engines/scumm/file.cpp
+++ b/engines/scumm/file.cpp
@@ -121,15 +121,15 @@ bool ScummFile::eos() const {
 	return _subFileLen ? _myEos : File::eos();
 }
 
-int32 ScummFile::pos() const {
+int64 ScummFile::pos() const {
 	return File::pos() - _subFileStart;
 }
 
-int32 ScummFile::size() const {
+int64 ScummFile::size() const {
 	return _subFileLen ? _subFileLen : File::size();
 }
 
-bool ScummFile::seek(int32 offs, int whence) {
+bool ScummFile::seek(int64 offs, int whence) {
 	if (_subFileLen) {
 		// Constrain the seek to the subfile
 		switch (whence) {

--- a/engines/scumm/file.h
+++ b/engines/scumm/file.h
@@ -41,9 +41,9 @@ public:
 	bool open(const Common::String &filename) override = 0;
 	virtual bool openSubFile(const Common::String &filename) = 0;
 
-	int32 pos() const override = 0;
-	int32 size() const override = 0;
-	bool seek(int32 offs, int whence = SEEK_SET) override = 0;
+	int64 pos() const override = 0;
+	int64 size() const override = 0;
+	bool seek(int64 offs, int whence = SEEK_SET) override = 0;
 
 // Unused
 #if 0
@@ -70,9 +70,9 @@ public:
 	void clearErr() override { _myEos = false; BaseScummFile::clearErr(); }
 
 	bool eos() const override;
-	int32 pos() const override;
-	int32 size() const override;
-	bool seek(int32 offs, int whence = SEEK_SET) override;
+	int64 pos() const override;
+	int64 size() const override;
+	bool seek(int64 offs, int whence = SEEK_SET) override;
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 };
 
@@ -114,9 +114,9 @@ public:
 
 	void close() override;
 	bool eos() const override { return _stream->eos(); }
-	int32 pos() const override { return _stream->pos(); }
-	int32 size() const override { return _stream->size(); }
-	bool seek(int32 offs, int whence = SEEK_SET) override { return _stream->seek(offs, whence); }
+	int64 pos() const override { return _stream->pos(); }
+	int64 size() const override { return _stream->size(); }
+	bool seek(int64 offs, int whence = SEEK_SET) override { return _stream->seek(offs, whence); }
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 };
 

--- a/engines/scumm/file_nes.cpp
+++ b/engines/scumm/file_nes.cpp
@@ -986,7 +986,7 @@ uint16 ScummNESFile::extractResource(Common::WriteStream *output, const Resource
 		}
 
 		if (File::pos() - res->offset != res->length)
-			error("extract_resource - length mismatch while extracting graphics resource (was %04X, should be %04X)", File::pos() - res->offset, res->length);
+			error("extract_resource - length mismatch while extracting graphics resource (was %04X, should be %04X)", (int32)File::pos() - res->offset, res->length);
 
 		break;
 
@@ -1049,7 +1049,7 @@ uint16 ScummNESFile::extractResource(Common::WriteStream *output, const Resource
 			error("extract_resource - unknown sound type %d/%d detected",val,cnt);
 
 		if (File::pos() - res->offset != res->length)
-			error("extract_resource - length mismatch while extracting sound resource (was %04X, should be %04X)", File::pos() - res->offset, res->length);
+			error("extract_resource - length mismatch while extracting sound resource (was %04X, should be %04X)", (int32)File::pos() - res->offset, res->length);
 
 		break;
 

--- a/engines/scumm/file_nes.h
+++ b/engines/scumm/file_nes.h
@@ -84,9 +84,9 @@ public:
 
 	void close() override;
 	bool eos() const override { return _stream->eos(); }
-	int32 pos() const override { return _stream->pos(); }
-	int32 size() const override { return _stream->size(); }
-	bool seek(int32 offs, int whence = SEEK_SET) override { return _stream->seek(offs, whence); }
+	int64 pos() const override { return _stream->pos(); }
+	int64 size() const override { return _stream->size(); }
+	bool seek(int64 offs, int whence = SEEK_SET) override { return _stream->seek(offs, whence); }
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 };
 

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -1296,7 +1296,7 @@ int ScummEngine::readSoundResource(ResId idx) {
 		Common::File dmuFile;
 		char buffer[128];
 		debugC(DEBUG_SOUND, "Found base tag FMUS in sound %d, size %d", idx, total_size);
-		debugC(DEBUG_SOUND, "It was at position %d", _fileHandle->pos());
+		debugC(DEBUG_SOUND, "It was at position %d", (int)_fileHandle->pos());
 
 		_fileHandle->seek(4, SEEK_CUR);
 		// HSHD size

--- a/engines/sherlock/objects.cpp
+++ b/engines/sherlock/objects.cpp
@@ -1121,7 +1121,7 @@ void Object::load3DO(Common::SeekableReadStream &s) {
 	_goto.y = _goto.y * FIXED_INT_MULTIPLIER / 100;
 
 	// Offset 42
-	warning("pos %d", s.pos());
+	warning("pos %d", (int)s.pos());
 
 	// Unverified
 	_lookFlag = s.readSint16BE();

--- a/engines/sky/compact.cpp
+++ b/engines/sky/compact.cpp
@@ -141,7 +141,7 @@ SkyCompact::SkyCompact() {
 	if (SKY_CPT_SIZE != _cptFile->size()) {
 		GUI::MessageDialog dialog(_("The \"sky.cpt\" engine data file has an incorrect size."), _("OK"));
 		dialog.runModal();
-		error("Incorrect sky.cpt size (%d, expected: %d)", _cptFile->size(), SKY_CPT_SIZE);
+		error("Incorrect sky.cpt size (%d, expected: %d)", (int)_cptFile->size(), SKY_CPT_SIZE);
 	}
 
 	// set the necessary data structs up...

--- a/engines/sludge/imgloader.cpp
+++ b/engines/sludge/imgloader.cpp
@@ -33,7 +33,7 @@
 namespace Sludge {
 
 bool ImgLoader::loadImage(int num, const char *fname, Common::SeekableReadStream *stream, Graphics::Surface *dest, int reserve) {
-	debugC(3, kSludgeDebugGraphics, "Loading image at position: %i", stream->pos());
+	debugC(3, kSludgeDebugGraphics, "Loading image at position: %d", (int)stream->pos());
 
 	bool dumpPng = false;
 

--- a/engines/sword2/music.cpp
+++ b/engines/sword2/music.cpp
@@ -225,7 +225,7 @@ void CLUInputStream::refill() {
 
 	_file->seek(_file_pos, SEEK_SET);
 
-	uint len_left = _file->read(in, MIN((uint32)BUFFER_SIZE, _end_pos - _file->pos()));
+	uint len_left = _file->read(in, MIN((uint32)BUFFER_SIZE, _end_pos - (uint32)_file->pos()));
 
 	_file_pos = _file->pos();
 

--- a/engines/teenagent/font.cpp
+++ b/engines/teenagent/font.cpp
@@ -51,7 +51,7 @@ void Font::load(const Pack &pack, int id, byte height, byte widthPack) {
 
 	_data = new byte[s->size()];
 	s->read(_data, s->size());
-	debugC(0, kDebugFont, "font size: %d", s->size());
+	debugC(0, kDebugFont, "font size: %d", (int)s->size());
 
 	_height = height;
 	_widthPack = widthPack;

--- a/engines/tinsel/drives.cpp
+++ b/engines/tinsel/drives.cpp
@@ -200,17 +200,17 @@ void TinselFile::close() {
 	_stream = nullptr;
 }
 
-int32 TinselFile::pos() const {
+int64 TinselFile::pos() const {
 	assert(_stream);
 	return _stream->pos();
 }
 
-int32 TinselFile::size() const {
+int64 TinselFile::size() const {
 	assert(_stream);
 	return _stream->size();
 }
 
-bool TinselFile::seek(int32 offset, int whence) {
+bool TinselFile::seek(int64 offset, int whence) {
 	assert(_stream);
 	return _stream->seek(offset, whence);
 }

--- a/engines/tinsel/drives.h
+++ b/engines/tinsel/drives.h
@@ -74,9 +74,9 @@ public:
 	bool eos() const override;
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 
-	int32 pos() const override;
-	int32 size() const override;
-	bool seek(int32 offset, int whence = SEEK_SET) override;
+	int64 pos() const override;
+	int64 size() const override;
+	bool seek(int64 offset, int whence = SEEK_SET) override;
 };
 
 

--- a/engines/tinsel/sound.cpp
+++ b/engines/tinsel/sound.cpp
@@ -301,7 +301,7 @@ bool SoundManager::playSample(int id, int sub, bool bLooped, int x, int y, int p
 	}
 
 	debugC(DEBUG_DETAILED, kTinselDebugSound, "Playing sound %d.%d, %d bytes at %d (pan %d)", id, sub, sampleLen,
-			_sampleStream.pos(), getPan(x));
+			(int)_sampleStream.pos(), getPan(x));
 
 	// allocate a buffer
 	byte *sampleBuf = (byte *) malloc(sampleLen);

--- a/engines/titanic/support/avi_surface.h
+++ b/engines/titanic/support/avi_surface.h
@@ -56,9 +56,9 @@ public:
 
 	uint32 read(void *dataPtr, uint32 dataSize) override;
 	bool eos() const override { return _innerStream->eos(); }
-	int32 pos() const override { return _innerStream->pos(); }
-	int32 size() const override { return _innerStream->size(); }
-	bool seek(int32 offset, int whence = SEEK_SET) override {
+	int64 pos() const override { return _innerStream->pos(); }
+	int64 size() const override { return _innerStream->size(); }
+	bool seek(int64 offset, int whence = SEEK_SET) override {
 		return _innerStream->seek(offset, whence);
 	}
 	bool skip(uint32 offset) override {

--- a/engines/toltecs/movie.cpp
+++ b/engines/toltecs/movie.cpp
@@ -179,7 +179,7 @@ void MoviePlayer::playMovie(uint resIndex) {
 			_vm->_screen->finishTalkTextItems();
 			break;
 		default:
-			error("MoviePlayer::playMovie(%04X) Unknown chunk type %d at %08X", resIndex, chunkType, _vm->_arc->pos() - 5 - chunkSize);
+			error("MoviePlayer::playMovie(%04X) Unknown chunk type %d at %08X", resIndex, chunkType, (int)_vm->_arc->pos() - 5 - chunkSize);
 		}
 
 		if (!handleInput())

--- a/engines/twine/resources/lzss.cpp
+++ b/engines/twine/resources/lzss.cpp
@@ -100,7 +100,7 @@ uint32 LzssReadStream::read(void *buf, uint32 dataSize) {
 	return dataSize;
 }
 
-bool LzssReadStream::seek(int32 offset, int whence) {
+bool LzssReadStream::seek(int64 offset, int whence) {
 	if (whence == SEEK_SET) {
 		_pos = offset;
 	} else if (whence == SEEK_CUR) {

--- a/engines/twine/resources/lzss.h
+++ b/engines/twine/resources/lzss.h
@@ -42,9 +42,9 @@ public:
 
 	void clearErr() override { _err = false; }
 	bool err() const override { return _err; }
-	int32 pos() const override { return _pos; }
-	int32 size() const override { return _size; }
-	bool seek(int32 offset, int whence = SEEK_SET) override;
+	int64 pos() const override { return _pos; }
+	int64 size() const override { return _size; }
+	bool seek(int64 offset, int whence = SEEK_SET) override;
 
 	bool eos() const override;
 	uint32 read(void *buf, uint32 size) override;

--- a/engines/twine/script/script_life_v1.cpp
+++ b/engines/twine/script/script_life_v1.cpp
@@ -1876,7 +1876,7 @@ void ScriptLife::processLifeScript(int32 actorIdx) {
 		if (scriptOpcode < ARRAYSIZE(function_map)) {
 			end = function_map[scriptOpcode].function(_engine, ctx);
 		} else {
-			error("Actor %d with wrong offset/opcode - Offset: %d (opcode: %i)", actorIdx, ctx.stream.pos() - 1, scriptOpcode);
+			error("Actor %d with wrong offset/opcode - Offset: %d (opcode: %i)", actorIdx, (int)ctx.stream.pos() - 1, scriptOpcode);
 		}
 
 		if (end < 0) {

--- a/engines/twine/script/script_move_v1.cpp
+++ b/engines/twine/script/script_move_v1.cpp
@@ -723,7 +723,7 @@ void ScriptMove::processMoveScript(int32 actorIdx) {
 		if (scriptOpcode < ARRAYSIZE(function_map)) {
 			end = function_map[scriptOpcode].function(_engine, ctx);
 		} else {
-			error("Actor %d with wrong offset/opcode - Offset: %d (opcode: %u)", actorIdx, ctx.stream.pos() - 1, scriptOpcode);
+			error("Actor %d with wrong offset/opcode - Offset: %d (opcode: %u)", actorIdx, (int)ctx.stream.pos() - 1, scriptOpcode);
 		}
 
 		if (end < 0) {

--- a/engines/ultima/ultima8/graphics/raw_shape_frame.cpp
+++ b/engines/ultima/ultima8/graphics/raw_shape_frame.cpp
@@ -127,7 +127,7 @@ void RawShapeFrame::loadGenericFormat(const uint8 *data, uint32 size, const Conv
 		} else {
 			if (ds.size() - ds.pos() < (int32)format->_bytes_line_offset) {
 				warning("going off end of %d buffer at %d reading %d",
-						ds.size(), ds.pos(), format->_bytes_line_offset);
+						(int)ds.size(), (int)ds.pos(), format->_bytes_line_offset);
 			}
 			_line_offsets[i] = readX(ds, format->_bytes_line_offset) - ((_height - i) * format->_bytes_line_offset);
 		}

--- a/engines/ultima/ultima8/misc/debugger.h
+++ b/engines/ultima/ultima8/misc/debugger.h
@@ -41,7 +41,7 @@ public:
 	ConsoleStream() : Common::WriteStream(), _precision(dec) {
 	}
 
-	int32 pos() const override {
+	int64 pos() const override {
 		return 0;
 	}
 

--- a/engines/wage/script.cpp
+++ b/engines/wage/script.cpp
@@ -216,7 +216,7 @@ bool Script::execute(World *world, int loopCount, Common::String *inputText, Des
 			processIf();
 			break;
 		case 0x87: // EXIT
-			debug(6, "exit at offset %d", _data->pos() - 1);
+			debug(6, "exit at offset %d", (int)_data->pos() - 1);
 
 			return true;
 		case 0x89: // MOVE
@@ -267,7 +267,7 @@ bool Script::execute(World *world, int loopCount, Common::String *inputText, Des
 		case 0x88: // END
 			break;
 		default:
-			debug(0, "Unknown opcode: %d", _data->pos());
+			debug(0, "Unknown opcode: %d", (int)_data->pos());
 		}
 	}
 
@@ -335,7 +335,7 @@ bool Script::execute(World *world, int loopCount, Common::String *inputText, Des
 Script::Operand *Script::readOperand() {
 	byte operandType = _data->readByte();
 
-	debug(7, "%x: readOperand: 0x%x", _data->pos(), operandType);
+	debug(7, "%x: readOperand: 0x%x", (int)_data->pos(), operandType);
 
 	Context *cont = &_world->_player->_context;
 	switch (operandType) {
@@ -418,7 +418,7 @@ Script::Operand *Script::readOperand() {
 			_data->seek(-1, SEEK_CUR);
 			return readStringOperand();
 		} else {
-			debug("Dunno what %x is (index=%d)!\n", operandType, _data->pos()-1);
+			debug("Dunno what %x is (index=%d)!\n", operandType, (int)_data->pos() - 1);
 		}
 		return NULL;
 	}
@@ -486,7 +486,7 @@ void Script::assign(byte operandType, int uservar, uint16 value) {
 		cont->_statVariables[PHYS_SPE_CUR] = value;
 		break;
 	default:
-		debug("No idea what I'm supposed to assign! (%x at %d)!\n", operandType, _data->pos()-1);
+		debug("No idea what I'm supposed to assign! (%x at %d)!\n", operandType, (int)_data->pos() - 1);
 	}
 }
 
@@ -1207,7 +1207,7 @@ void Script::convertToText() {
 
 		if (c < 0x80) {
 			if (c < 0x20) {
-				warning("convertToText: Unknown code 0x%02x at %d", c, _data->pos());
+				warning("convertToText: Unknown code 0x%02x at %d", c, (int)_data->pos());
 				c = ' ';
 			}
 
@@ -1216,7 +1216,7 @@ void Script::convertToText() {
 				c = _data->readByte();
 
 				if (c < 0x20) {
-					warning("convertToText: Unknown code 0x%02x at %d", c, _data->pos());
+					warning("convertToText: Unknown code 0x%02x at %d", c, (int)_data->pos());
 					c = ' ';
 				}
 			} while (c < 0x80);

--- a/engines/wintermute/base/base_file_manager.cpp
+++ b/engines/wintermute/base/base_file_manager.cpp
@@ -105,7 +105,7 @@ byte *BaseFileManager::readWholeFile(const Common::String &filename, uint32 *siz
 
 	buffer = new byte[file->size() + 1];
 	if (buffer == nullptr) {
-		debugC(kWintermuteDebugFileAccess | kWintermuteDebugLog, "Error allocating buffer for file '%s' (%d bytes)", filename.c_str(), file->size() + 1);
+		debugC(kWintermuteDebugFileAccess | kWintermuteDebugLog, "Error allocating buffer for file '%s' (%d bytes)", filename.c_str(), (int)file->size() + 1);
 		closeFile(file);
 		return nullptr;
 	}

--- a/engines/xeen/files.cpp
+++ b/engines/xeen/files.cpp
@@ -638,7 +638,7 @@ uint32 OutFile::write(const void *dataPtr, uint32 dataSize) {
 	return _backingStream.write(dataPtr, dataSize);
 }
 
-int32 OutFile::pos() const {
+int64 OutFile::pos() const {
 	return _backingStream.pos();
 }
 

--- a/engines/xeen/files.h
+++ b/engines/xeen/files.h
@@ -222,7 +222,7 @@ public:
 	}
 	bool flush() override { return _parentStream->flush(); }
 	void finalize() override {}
-	int32 pos() const override { return _parentStream->pos() - _begin; }
+	int64 pos() const override { return _parentStream->pos() - _begin; }
 };
 
 class StringArray : public Common::StringArray {
@@ -392,7 +392,7 @@ public:
 	/**
 	 * Returns the current position
 	 */
-	int32 pos() const override;
+	int64 pos() const override;
 };
 
 } // End of namespace Xeen

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -653,7 +653,7 @@ bool Debugger::cmdMd5(int argc, const char **argv) {
 			for (Common::ArchiveMemberList::iterator iter = list.begin(); iter != list.end(); ++iter) {
 				Common::SeekableReadStream *stream = (*iter)->createReadStream();
 				Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
-				debugPrintf("%s  %s  %d\n", md5.c_str(), (*iter)->getDisplayName().c_str(), stream->size());
+				debugPrintf("%s  %s  %d\n", md5.c_str(), (*iter)->getDisplayName().c_str(), (int32)stream->size());
 				delete stream;
 			}
 		}
@@ -703,7 +703,7 @@ bool Debugger::cmdMd5Mac(int argc, const char **argv) {
 				if (macResMan.hasDataFork()) {
 					Common::SeekableReadStream *stream = macResMan.getDataFork();
 					Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
-					debugPrintf("%s  %s (data)  %d\n", md5.c_str(), macResMan.getBaseFileName().c_str(), stream->size());
+					debugPrintf("%s  %s (data)  %d\n", md5.c_str(), macResMan.getBaseFileName().c_str(), (int32)stream->size());
 				}
 			}
 			macResMan.close();

--- a/image/codecs/cdtoons.cpp
+++ b/image/codecs/cdtoons.cpp
@@ -74,7 +74,7 @@ Graphics::Surface *CDToonsDecoder::decodeFrame(Common::SeekableReadStream &strea
 	byte u6 = stream.readByte();
 	byte backgroundColor = stream.readByte();
 	debugN(5, "CDToons frame %d, size %d, unknown %04x (at 0), blocks valid until %d, unknown 6 is %02x, bkg color is %02x\n",
-		frameId, stream.size(), u0, blocksValidUntil, u6, backgroundColor);
+		frameId, (int)stream.size(), u0, blocksValidUntil, u6, backgroundColor);
 
 	Common::Rect clipRect = readRect(stream);
 	debugN(9, "CDToons clipRect: (%d, %d) to (%d, %d)\n",
@@ -125,10 +125,10 @@ Graphics::Surface *CDToonsDecoder::decodeFrame(Common::SeekableReadStream &strea
 
 	if (stream.pos() > blockOffset)
 		error("CDToons header ended at 0x%08x, but blocks should have started at 0x%08x",
-			stream.pos(), blockOffset);
+			(int)stream.pos(), blockOffset);
 
 	if (stream.pos() != blockOffset)
-		error("CDToons had %d unknown bytes after header", blockOffset - stream.pos());
+		error("CDToons had %d unknown bytes after header", blockOffset - (int)stream.pos());
 
 	for (uint i = 0; i < blockCount; i++) {
 		uint16 blockId = stream.readUint16BE();
@@ -278,9 +278,9 @@ Graphics::Surface *CDToonsDecoder::decodeFrame(Common::SeekableReadStream &strea
 
 		if (stream.pos() > nextPos)
 			error("CDToons ran off the end of a block while reading it (at %d, next block at %d)",
-				stream.pos(), nextPos);
+				(int)stream.pos(), nextPos);
 		if (stream.pos() != nextPos) {
-			warning("CDToons had %d unknown bytes after block", nextPos - stream.pos());
+			warning("CDToons had %d unknown bytes after block", nextPos - (int32)stream.pos());
 			stream.seek(nextPos);
 		}
 

--- a/image/codecs/msvideo1.cpp
+++ b/image/codecs/msvideo1.cpp
@@ -30,7 +30,7 @@ namespace Image {
 
 #define CHECK_STREAM_PTR(n) \
   if ((stream.pos() + n) > stream.size() ) { \
-	warning ("MS Video-1: Stream out of bounds (%d >= %d) d%d", stream.pos() + n, stream.size(), n); \
+	warning ("MS Video-1: Stream out of bounds (%d >= %d) d%d", (int)stream.pos() + n, (int)stream.size(), n); \
 	return; \
   }
 

--- a/image/codecs/qtrle.cpp
+++ b/image/codecs/qtrle.cpp
@@ -63,7 +63,7 @@ QTRLEDecoder::~QTRLEDecoder() {
 #define CHECK_STREAM_PTR(n) \
 	do { \
 		if ((stream.pos() + n) > stream.size()) { \
-			warning("QTRLE Problem: stream out of bounds (%d > %d)", stream.pos() + n, stream.size()); \
+			warning("QTRLE Problem: stream out of bounds (%d > %d)", (int)stream.pos() + n, (int)stream.size()); \
 			return; \
 		} \
 	} while (0)

--- a/image/codecs/smc.cpp
+++ b/image/codecs/smc.cpp
@@ -79,7 +79,7 @@ const Graphics::Surface *SMCDecoder::decodeFrame(Common::SeekableReadStream &str
 
 	int32 chunkSize = stream.readUint32BE() & 0x00FFFFFF;
 	if (chunkSize != stream.size())
-		warning("MOV chunk size != SMC chunk size (%d != %d); ignoring SMC chunk size", chunkSize, stream.size());
+		warning("MOV chunk size != SMC chunk size (%d != %d); ignoring SMC chunk size", chunkSize, (int)stream.size());
 
 	int32 totalBlocks = ((_surface->w + 3) / 4) * ((_surface->h + 3) / 4);
 
@@ -91,7 +91,7 @@ const Graphics::Surface *SMCDecoder::decodeFrame(Common::SeekableReadStream &str
 
 		// make sure stream ptr hasn't gone out of bounds
 		if (stream.pos() > stream.size()) {
-			warning("SMC decoder just went out of bounds (stream ptr = %d, chunk size = %d)", stream.pos(), stream.size());
+			warning("SMC decoder just went out of bounds (stream ptr = %d, chunk size = %d)", (int)stream.pos(), (int)stream.size());
 			return _surface;
 		}
 


### PR DESCRIPTION
This one has been pending for supporting the AGS game Strangeland, which has a 3Gb executable. It required pushing up the data types of the Stream class's seek, size, and pos methods to 64-bits offsets/sizes. This is necessary, for example, for allowing seek to still specify negative offsets for moving backwards with SEEK_CUR, yet allow for seeking to offsets greater than the 2Gb mark.

At the moment, I've only put in a special _MSC_VER check in the StdIOStream class for Visual Studio to use it's 64-bit versions of fseek/ftell.. I'm uncertain whether gcc for Windows, as well as the other backends, will need changes, or their versions will handle the int64 offsets transparently. I'll need assistance from the various port maintainers to review their backends accordingly.

For AGS at least, I've also added some code in the startup so that if the size() method returns -1 for the file, it will give an error message saying that the particular platform doesn't support the game due to it's size, rather than threw an arbitrary wobbly at some point during game loading/startup. Also, additionally, Strangeland does require some plugin work, so even with this change it won't start up yet, but I'll wait until this pull request is accepted into master before I start doing further work on it.
