### PR TITLE
EVENTRECORDER: added new event for OSystem::getTimeAndDate

### DIFF
--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -169,7 +169,7 @@ void OSystem_3DS::delayMillis(uint msecs) {
 	svcSleepThread(msecs * 1000000);
 }
 
-void OSystem_3DS::getTimeAndDate(TimeDate& td) const {
+void OSystem_3DS::getTimeAndDate(TimeDate& td, bool skipRecord) const {
 	time_t curTime = time(0);
 	struct tm t = *localtime(&curTime);
 	td.tm_sec = t.tm_sec;

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -115,7 +115,7 @@ public:
 
 	virtual uint32 getMillis(bool skipRecord = false);
 	virtual void delayMillis(uint msecs);
-	virtual void getTimeAndDate(TimeDate &t) const;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const;
 
 	virtual MutexRef createMutex();
 	virtual void lockMutex(MutexRef mutex);

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -575,7 +575,7 @@ Audio::Mixer *OSystem_Android::getMixer() {
 	return _mixer;
 }
 
-void OSystem_Android::getTimeAndDate(TimeDate &td) const {
+void OSystem_Android::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	struct tm tm;
 	const time_t curTime = time(0);
 

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -135,7 +135,7 @@ public:
 	virtual void setWindowCaption(const Common::U32String &caption) override;
 
 	virtual Audio::Mixer *getMixer() override;
-	virtual void getTimeAndDate(TimeDate &t) const override;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const override;
 	virtual void logMessage(LogMessageType::Type type, const char *message) override;
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0) override;
 	virtual bool openUrl(const Common::String &url) override;

--- a/backends/platform/android3d/android.cpp
+++ b/backends/platform/android3d/android.cpp
@@ -505,7 +505,7 @@ Audio::Mixer *OSystem_Android::getMixer() {
 	return _mixer;
 }
 
-void OSystem_Android::getTimeAndDate(TimeDate &td) const {
+void OSystem_Android::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	struct tm tm;
 	const time_t curTime = time(0);
 

--- a/backends/platform/android3d/android.h
+++ b/backends/platform/android3d/android.h
@@ -179,7 +179,7 @@ public:
 	virtual void showVirtualKeyboard(bool enable);
 
 	virtual Audio::Mixer *getMixer();
-	virtual void getTimeAndDate(TimeDate &t) const;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const;
 	virtual void logMessage(LogMessageType::Type type, const char *message);
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s,
 											int priority = 0);

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -142,7 +142,7 @@ public:
   void delayMillis(uint msecs);
 
   // Get the current time and date. Correspond to time()+localtime().
-  void getTimeAndDate(TimeDate &t) const;
+  void getTimeAndDate(TimeDate &td, bool skipRecord = false) const;
 
   // Get the next event.
   // Returns true if an event was retrieved.

--- a/backends/platform/dc/dcmain.cpp
+++ b/backends/platform/dc/dcmain.cpp
@@ -218,7 +218,7 @@ bool OSystem_Dreamcast::getFeatureState(Feature f)
   }
 }
 
-void OSystem_Dreamcast::getTimeAndDate(TimeDate &td) const {
+void OSystem_Dreamcast::getTimeAndDate(TimeDate &td, bool skipRecord) const {
   time_t curTime;
   time(&curTime);
   struct tm t = *localtime(&curTime);

--- a/backends/platform/ds/osystem_ds.cpp
+++ b/backends/platform/ds/osystem_ds.cpp
@@ -117,7 +117,7 @@ void OSystem_DS::doTimerCallback(int interval) {
 	}
 }
 
-void OSystem_DS::getTimeAndDate(TimeDate &td) const {
+void OSystem_DS::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	time_t curTime = time(0);
 	struct tm t = *localtime(&curTime);
 	td.tm_sec = t.tm_sec;

--- a/backends/platform/ds/osystem_ds.h
+++ b/backends/platform/ds/osystem_ds.h
@@ -125,7 +125,7 @@ public:
 
 	virtual uint32 getMillis(bool skipRecord = false);
 	virtual void delayMillis(uint msecs);
-	virtual void getTimeAndDate(TimeDate &t) const;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const;
 	void doTimerCallback(int interval = 10);
 
 	virtual Common::EventSource *getDefaultEventSource() { return _eventSource; }

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -314,7 +314,7 @@ void OSystem_iOS7::setTimerCallback(TimerProc callback, int interval) {
 void OSystem_iOS7::quit() {
 }
 
-void OSystem_iOS7::getTimeAndDate(TimeDate &td) const {
+void OSystem_iOS7::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	time_t curTime = time(0);
 	struct tm t = *localtime(&curTime);
 	td.tm_sec = t.tm_sec;

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -185,7 +185,7 @@ public:
 	virtual void quit() override;
 
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0) override;
-	virtual void getTimeAndDate(TimeDate &t) const override;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const override;
 
 	virtual Audio::Mixer *getMixer() override;
 

--- a/backends/platform/iphone/osys_main.cpp
+++ b/backends/platform/iphone/osys_main.cpp
@@ -198,7 +198,7 @@ void OSystem_IPHONE::setTimerCallback(TimerProc callback, int interval) {
 void OSystem_IPHONE::quit() {
 }
 
-void OSystem_IPHONE::getTimeAndDate(TimeDate &td) const {
+void OSystem_IPHONE::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	time_t curTime = time(0);
 	struct tm t = *localtime(&curTime);
 	td.tm_sec = t.tm_sec;

--- a/backends/platform/iphone/osys_main.h
+++ b/backends/platform/iphone/osys_main.h
@@ -173,7 +173,7 @@ public:
 	virtual void quit();
 
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0);
-	virtual void getTimeAndDate(TimeDate &t) const;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const;
 
 	virtual Audio::Mixer *getMixer();
 

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -195,7 +195,7 @@ public:
 	virtual void quit();
 
 	virtual Audio::Mixer *getMixer();
-	virtual void getTimeAndDate(TimeDate &t) const;
+	virtual void getTimeAndDate(TimeDate &t, bool skipRecord = false) const;
 	virtual void setTimerCallback(TimerProc callback, int interval);
 	virtual void logMessage(LogMessageType::Type type, const char *message);
 

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -838,7 +838,7 @@ Audio::Mixer *OSystem_N64::getMixer() {
 	return _mixer;
 }
 
-void OSystem_N64::getTimeAndDate(TimeDate &t) const {
+void OSystem_N64::getTimeAndDate(TimeDate &t, bool skipRecord) const {
 	// No RTC inside the N64, read mips timer to simulate
 	// passing of time, not a perfect solution, but can't think
 	// of anything better.

--- a/backends/platform/null/null.cpp
+++ b/backends/platform/null/null.cpp
@@ -87,7 +87,7 @@ public:
 
 	virtual uint32 getMillis(bool skipRecord = false);
 	virtual void delayMillis(uint msecs);
-	virtual void getTimeAndDate(TimeDate &t) const;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const;
 
 	virtual void quit();
 
@@ -208,7 +208,7 @@ void OSystem_NULL::delayMillis(uint msecs) {
 #endif
 }
 
-void OSystem_NULL::getTimeAndDate(TimeDate &td) const {
+void OSystem_NULL::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	time_t curTime = time(0);
 	struct tm t = *localtime(&curTime);
 	td.tm_sec = t.tm_sec;

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -429,7 +429,7 @@ void OSystem_PSP::logMessage(LogMessageType::Type type, const char *message) {
 		PspDebugTrace(false, "%s", message);	// write to file
 }
 
-void OSystem_PSP::getTimeAndDate(TimeDate &td) const {
+void OSystem_PSP::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	time_t curTime = time(0);
 	struct tm t = *localtime(&curTime);
 	td.tm_sec = t.tm_sec;

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -138,7 +138,7 @@ public:
 
 	// Misc
 	FilesystemFactory *getFilesystemFactory() { return &PSPFilesystemFactory::instance(); }
-	void getTimeAndDate(TimeDate &t) const;
+	void getTimeAndDate(TimeDate &td, bool skipRecord = false) const;
 	virtual void engineDone();
 
 	void quit();

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -638,7 +638,7 @@ void OSystem_SDL::delayMillis(uint msecs) {
 		SDL_Delay(msecs);
 }
 
-void OSystem_SDL::getTimeAndDate(TimeDate &td) const {
+void OSystem_SDL::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	time_t curTime = time(0);
 	struct tm t = *localtime(&curTime);
 	td.tm_sec = t.tm_sec;
@@ -648,6 +648,10 @@ void OSystem_SDL::getTimeAndDate(TimeDate &td) const {
 	td.tm_mon = t.tm_mon;
 	td.tm_year = t.tm_year;
 	td.tm_wday = t.tm_wday;
+
+#ifdef ENABLE_EVENTRECORDER
+	g_eventRec.processTimeAndDate(td, skipRecord);
+#endif
 }
 
 MixerManager *OSystem_SDL::getMixerManager() {

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -83,7 +83,7 @@ public:
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0) override;
 	virtual uint32 getMillis(bool skipRecord = false) override;
 	virtual void delayMillis(uint msecs) override;
-	virtual void getTimeAndDate(TimeDate &td) const override;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const override;
 	virtual MixerManager *getMixerManager() override;
 	virtual Common::TimerManager *getTimerManager() override;
 	virtual Common::SaveFileManager *getSavefileManager() override;

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -266,7 +266,7 @@ FilesystemFactory *OSystem_Wii::getFilesystemFactory() {
 	return &WiiFilesystemFactory::instance();
 }
 
-void OSystem_Wii::getTimeAndDate(TimeDate &td) const {
+void OSystem_Wii::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 	time_t curTime = time(0);
 	struct tm t = *localtime(&curTime);
 	td.tm_sec = t.tm_sec;

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -208,7 +208,7 @@ public:
 
 	virtual Audio::Mixer *getMixer() override;
 	virtual FilesystemFactory *getFilesystemFactory() override;
-	virtual void getTimeAndDate(TimeDate &t) const override;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const override;
 
 	virtual void logMessage(LogMessageType::Type type, const char *message) override;
 

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -373,6 +373,15 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 	case kRecorderEventTypeTimer:
 		event.time = _tmpPlaybackFile.readUint32LE();
 		break;
+	case kRecorderEventTypeTimeDate:
+		event.timeDate.tm_sec = _tmpPlaybackFile.readSint32LE();
+		event.timeDate.tm_min = _tmpPlaybackFile.readSint32LE();
+		event.timeDate.tm_hour = _tmpPlaybackFile.readSint32LE();
+		event.timeDate.tm_mday = _tmpPlaybackFile.readSint32LE();
+		event.timeDate.tm_mon = _tmpPlaybackFile.readSint32LE();
+		event.timeDate.tm_year = _tmpPlaybackFile.readSint32LE();
+		event.timeDate.tm_wday = _tmpPlaybackFile.readSint32LE();
+		break;
 	default:
 		// fallthrough intended
 	case kRecorderEventTypeNormal:
@@ -548,6 +557,15 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 	switch (event.recordedtype) {
 	case kRecorderEventTypeTimer:
 		_tmpRecordFile.writeUint32LE(event.time);
+		break;
+	case kRecorderEventTypeTimeDate:
+		_tmpRecordFile.writeSint32LE(event.timeDate.tm_sec);
+		_tmpRecordFile.writeSint32LE(event.timeDate.tm_min);
+		_tmpRecordFile.writeSint32LE(event.timeDate.tm_hour);
+		_tmpRecordFile.writeSint32LE(event.timeDate.tm_mday);
+		_tmpRecordFile.writeSint32LE(event.timeDate.tm_mon);
+		_tmpRecordFile.writeSint32LE(event.timeDate.tm_year);
+		_tmpRecordFile.writeSint32LE(event.timeDate.tm_wday);
 		break;
 	default:
 		// fallthrough intended

--- a/common/recorderfile.h
+++ b/common/recorderfile.h
@@ -38,21 +38,39 @@ namespace Common {
 
 enum RecorderEventType {
 	kRecorderEventTypeNormal = 0,
-	kRecorderEventTypeTimer = 1
+	kRecorderEventTypeTimer = 1,
+	kRecorderEventTypeTimeDate = 2
 };
 
 struct RecorderEvent : Event {
 	RecorderEventType recordedtype;
-	uint32 time;
+	union {
+		uint32 time;
+		TimeDate timeDate;
+	};
 
 	RecorderEvent() {
 		recordedtype = kRecorderEventTypeNormal;
 		time = 0;
+		timeDate.tm_sec = 0;
+		timeDate.tm_min = 0;
+		timeDate.tm_hour = 0;
+		timeDate.tm_mday = 0;
+		timeDate.tm_mon = 0;
+		timeDate.tm_year = 0;
+		timeDate.tm_wday = 0;
 	}
 
 	RecorderEvent(const Event &e) : Event(e) {
 		recordedtype = kRecorderEventTypeNormal;
 		time = 0;
+		timeDate.tm_sec = 0;
+		timeDate.tm_min = 0;
+		timeDate.tm_hour = 0;
+		timeDate.tm_mday = 0;
+		timeDate.tm_mon = 0;
+		timeDate.tm_year = 0;
+		timeDate.tm_wday = 0;
 	}
 };
 

--- a/common/system.h
+++ b/common/system.h
@@ -1368,7 +1368,7 @@ public:
 	 * On many systems, this corresponds to the combination of time()
 	 * and localtime().
 	 */
-	virtual void getTimeAndDate(TimeDate &t) const = 0;
+	virtual void getTimeAndDate(TimeDate &td, bool skipRecord = false) const = 0;
 
 	/**
 	 * Return the timer manager singleton.

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -81,6 +81,7 @@ public:
 	void deinit();
 	bool processDelayMillis();
 	uint32 getRandomSeed(const Common::String &name);
+	void processTimeAndDate(TimeDate &td, bool skipRecord);
 	void processMillis(uint32 &millis, bool skipRecord);
 	void processGameDescription(const ADGameDescription *desc);
 	Common::SeekableReadStream *processSaveStream(const Common::String & fileName);
@@ -178,6 +179,7 @@ private:
 	bool notifyEvent(const Common::Event &event) override;
 	bool _initialized;
 	volatile uint32 _fakeTimer;
+	TimeDate _lastTimeDate;
 	bool _savedState;
 	bool _needcontinueGame;
 	int _temporarySlot;


### PR DESCRIPTION
`OSystem::getTimeAndDate()` is used in e.g. SCI and SCUMM - this wires it up to the event recorder.

Introducing a new event and changed the `getTimeAndDate` method 