### PR TITLE
Add Macintosh black-and-white mode for Mac Loom and Indy3

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -168,7 +168,7 @@ static const char HELP_STRING[] =
 	"                           (default: enabled)\n"
 	"  --render-mode=MODE       Enable additional render modes (hercGreen, hercAmber,\n"
 	"                           cga, ega, vga, amiga, fmtowns, pc9821, pc9801, 2gs,\n"
-	"                           atari, macintosh)\n"
+	"                           atari, macintosh, macintoshbw)\n"
 #ifdef ENABLE_EVENTRECORDER
 	"  --record-mode=MODE       Specify record mode for event recorder (record, playback,\n"
 	"                           passthrough [default])\n"

--- a/common/rendermode.cpp
+++ b/common/rendermode.cpp
@@ -44,6 +44,7 @@ const RenderModeDescription g_renderModes[] = {
 	{ "2gs", "Apple IIgs", kRenderApple2GS },
 	{ "atari", "Atari ST", kRenderAtariST },
 	{ "macintosh", "Macintosh", kRenderMacintosh },
+	// I18N: Macintosh black-and-white
 	{ "macintoshbw", _s("Macintosh b/w"), kRenderMacintoshBW },
 	{nullptr, nullptr, kRenderDefault}
 };

--- a/common/rendermode.cpp
+++ b/common/rendermode.cpp
@@ -44,6 +44,7 @@ const RenderModeDescription g_renderModes[] = {
 	{ "2gs", "Apple IIgs", kRenderApple2GS },
 	{ "atari", "Atari ST", kRenderAtariST },
 	{ "macintosh", "Macintosh", kRenderMacintosh },
+	{ "macintoshbw", _s("Macintosh b/w"), kRenderMacintoshBW },
 	{nullptr, nullptr, kRenderDefault}
 };
 

--- a/common/rendermode.h
+++ b/common/rendermode.h
@@ -57,7 +57,8 @@ enum RenderMode {
 	kRenderPC9801 = 9,
 	kRenderApple2GS = 10,
 	kRenderAtariST = 11,
-	kRenderMacintosh = 12
+	kRenderMacintosh = 12,
+	kRenderMacintoshBW = 13
 };
 
 struct RenderModeDescription {

--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -1776,8 +1776,28 @@ void CharsetRendererMac::printChar(int chr, bool ignoreCharsetMask) {
 	_lastTop = _top;
 }
 
+byte CharsetRendererMac::getTextColor() {
+	if (_vm->_renderMode == Common::kRenderMacintoshBW) {
+		if (_color == 0 || _color == 15)
+			return _color;
+		return 15;
+	}
+	return _color;
+}
+
+byte CharsetRendererMac::getTextShadowColor() {
+	if (_vm->_renderMode == Common::kRenderMacintoshBW) {
+		if (getTextColor() == 0)
+			return 15;
+		return 0;
+	}
+	return _shadowColor;
+}
+
 void CharsetRendererMac::printCharInternal(int chr, int color, bool shadow, int x, int y) {
 	if (shadow) {
+		byte shadowColor = getTextShadowColor();
+
 		if (_vm->_game.id == GID_LOOM) {
 			// Shadowing is a bit of guesswork. It doesn't look
 			// like it's using the Mac's built-in form of shadowed
@@ -1790,31 +1810,41 @@ void CharsetRendererMac::printCharInternal(int chr, int color, bool shadow, int 
 			_macFonts[_curId].drawChar(&_vm->_textSurface, chr, x + 3, y + 3, 0);
 
 			if (color != -1) {
-				_macFonts[_curId].drawChar(_vm->_macScreen, chr, x + 2, y, _shadowColor);
-				_macFonts[_curId].drawChar(_vm->_macScreen, chr, x, y + 2, _shadowColor);
-				_macFonts[_curId].drawChar(_vm->_macScreen, chr, x + 3, y + 3, _shadowColor);
+				_macFonts[_curId].drawChar(_vm->_macScreen, chr, x + 2, y, shadowColor);
+				_macFonts[_curId].drawChar(_vm->_macScreen, chr, x, y + 2, shadowColor);
+				_macFonts[_curId].drawChar(_vm->_macScreen, chr, x + 3, y + 3, shadowColor);
 			}
 		} else {
 			// Indy 3 uses simpler shadowing, and doesn't need the
 			// "draw only on text surface" hack.
 
 			_macFonts[_curId].drawChar(&_vm->_textSurface, chr, x + 2, y + 2, 0);
-			_macFonts[_curId].drawChar(_vm->_macScreen, chr, x + 2, y + 2, _shadowColor);
+			_macFonts[_curId].drawChar(_vm->_macScreen, chr, x + 2, y + 2, shadowColor);
 		}			
 	}
 
 	_macFonts[_curId].drawChar(&_vm->_textSurface, chr, x + 1, y + 1, 0);
 
-	if (color != -1)
+	if (color != -1) {
+		if (color != -1) {
+			color = getTextColor();
+		}
+
 		_macFonts[_curId].drawChar(_vm->_macScreen, chr, x + 1, y + 1, color);
+	}
 }
 
 void CharsetRendererMac::printCharToTextBox(int chr, int color, int x, int y) {
-	_macFonts[_curId].drawChar(_vm->_macIndy3TextBox, chr, x + 5, y + 11, _color);
+	if (_vm->_renderMode == Common::kRenderMacintoshBW)
+		color = 15;
+
+	_macFonts[_curId].drawChar(_vm->_macIndy3TextBox, chr, x + 5, y + 11, color);
 }
 
 void CharsetRendererMac::drawChar(int chr, Graphics::Surface &s, int x, int y) {
-	_macFonts[_curId].drawChar(&s, chr, x, y, _color);
+	byte color = getTextColor();
+
+	_macFonts[_curId].drawChar(&s, chr, x, y, color);
 }
 
 void CharsetRendererMac::setColor(byte color) {

--- a/engines/scumm/charset.h
+++ b/engines/scumm/charset.h
@@ -284,6 +284,9 @@ protected:
 	void printCharInternal(int chr, int color, bool shadow, int x, int y);
 	void printCharToTextBox(int chr, int color, int x, int y);
 
+	byte getTextColor();
+	byte getTextShadowColor();
+
 public:
 	CharsetRendererMac(ScummEngine *vm, const Common::String &fontFile);
 

--- a/engines/scumm/charset.h
+++ b/engines/scumm/charset.h
@@ -287,8 +287,11 @@ protected:
 	byte getTextColor();
 	byte getTextShadowColor();
 
+	Graphics::Surface *_glyphSurface;
+
 public:
 	CharsetRendererMac(ScummEngine *vm, const Common::String &fontFile);
+	~CharsetRendererMac() override;
 
 	void setCurID(int32 id) override;
 	int getFontHeight() override;

--- a/engines/scumm/gfx_mac.cpp
+++ b/engines/scumm/gfx_mac.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "common/system.h"
+#include "graphics/macega.h"
 #include "scumm/actor.h"
 #include "scumm/charset.h"
 #include "scumm/usage_bits.h"
@@ -29,6 +30,7 @@
 namespace Scumm {
 
 void ScummEngine::mac_drawStripToScreen(VirtScreen *vs, int top, int x, int y, int width, int height) {
+
 	const byte *pixels = vs->getPixels(x, top);
 	const byte *ts = (byte *)_textSurface.getBasePtr(x * 2, y * 2);
 	byte *mac = (byte *)_macScreen->getBasePtr(x * 2, y * 2);
@@ -37,22 +39,42 @@ void ScummEngine::mac_drawStripToScreen(VirtScreen *vs, int top, int x, int y, i
 	int tsPitch = _textSurface.pitch;
 	int macPitch = _macScreen->pitch;
 
-	for (int h = 0; h < height; h++) {
-		for (int w = 0; w < width; w++) {
-			if (ts[2 * w] == CHARSET_MASK_TRANSPARENCY)
-				mac[2 * w] = pixels[w];
-			if (ts[2 * w + 1] == CHARSET_MASK_TRANSPARENCY)
-				mac[2 * w + 1] = pixels[w];
-			if (ts[2 * w + tsPitch] == CHARSET_MASK_TRANSPARENCY)
-				mac[2 * w + macPitch] = pixels[w];
-			if (ts[2 * w + tsPitch + 1] == CHARSET_MASK_TRANSPARENCY)
-				mac[2 * w + macPitch + 1] = pixels[w];
-		}
+	if (_renderMode == Common::kRenderMacintoshBW) {
+		for (int h = 0; h < height; h++) {
+			for (int w = 0; w < width; w++) {
+				if (ts[2 * w] == CHARSET_MASK_TRANSPARENCY)
+					mac[2 * w] = Graphics::macEGADither[pixels[w]][0];
+				if (ts[2 * w + 1] == CHARSET_MASK_TRANSPARENCY)
+					mac[2 * w + 1] = Graphics::macEGADither[pixels[w]][1];
+				if (ts[2 * w + tsPitch] == CHARSET_MASK_TRANSPARENCY)
+					mac[2 * w + macPitch] = Graphics::macEGADither[pixels[w]][2];
+				if (ts[2 * w + tsPitch + 1] == CHARSET_MASK_TRANSPARENCY)
+					mac[2 * w + macPitch + 1] = Graphics::macEGADither[pixels[w]][3];
+			}
 
-		pixels += pixelsPitch;
-		ts += tsPitch * 2;
-		mac += macPitch * 2;
+			pixels += pixelsPitch;
+			ts += tsPitch * 2;
+			mac += macPitch * 2;
+		}
+	} else {
+		for (int h = 0; h < height; h++) {
+			for (int w = 0; w < width; w++) {
+				if (ts[2 * w] == CHARSET_MASK_TRANSPARENCY)
+					mac[2 * w] = pixels[w];
+				if (ts[2 * w + 1] == CHARSET_MASK_TRANSPARENCY)
+					mac[2 * w + 1] = pixels[w];
+				if (ts[2 * w + tsPitch] == CHARSET_MASK_TRANSPARENCY)
+					mac[2 * w + macPitch] = pixels[w];
+				if (ts[2 * w + tsPitch + 1] == CHARSET_MASK_TRANSPARENCY)
+					mac[2 * w + macPitch + 1] = pixels[w];
+			}
+
+			pixels += pixelsPitch;
+			ts += tsPitch * 2;
+			mac += macPitch * 2;
+		}
 	}
+
 
 	_system->copyRectToScreen(_macScreen->getBasePtr(x * 2, y * 2), _macScreen->pitch, x * 2, y * 2, width * 2, height * 2);
 }

--- a/engines/scumm/gfx_mac.cpp
+++ b/engines/scumm/gfx_mac.cpp
@@ -39,17 +39,30 @@ void ScummEngine::mac_drawStripToScreen(VirtScreen *vs, int top, int x, int y, i
 	int tsPitch = _textSurface.pitch;
 	int macPitch = _macScreen->pitch;
 
+	// In b/w Mac rendering mode, the shadow palette is implemented here,
+	// and not as a palette manipulation. See special cases in o5_roomOps()
+	// and updatePalette().
+	//
+	// This is used at the very least for the lightning flashes at Castle
+	// Brunwald in Indy 3, as well as the scene where the dragon finds
+	// Rusty in Loom.
+	//
+	// Interestingly, the original Mac interpreter does not seem to do
+	// this, and instead just renders the scene as if the palette was
+	// unmodified. At least, that's what Mini vMac did when I tried it.
+
 	if (_renderMode == Common::kRenderMacintoshBW) {
 		for (int h = 0; h < height; h++) {
 			for (int w = 0; w < width; w++) {
+				int color = _shadowPalette[pixels[w]];
 				if (ts[2 * w] == CHARSET_MASK_TRANSPARENCY)
-					mac[2 * w] = Graphics::macEGADither[pixels[w]][0];
+					mac[2 * w] = Graphics::macEGADither[color][0];
 				if (ts[2 * w + 1] == CHARSET_MASK_TRANSPARENCY)
-					mac[2 * w + 1] = Graphics::macEGADither[pixels[w]][1];
+					mac[2 * w + 1] = Graphics::macEGADither[color][1];
 				if (ts[2 * w + tsPitch] == CHARSET_MASK_TRANSPARENCY)
-					mac[2 * w + macPitch] = Graphics::macEGADither[pixels[w]][2];
+					mac[2 * w + macPitch] = Graphics::macEGADither[color][2];
 				if (ts[2 * w + tsPitch + 1] == CHARSET_MASK_TRANSPARENCY)
-					mac[2 * w + macPitch + 1] = Graphics::macEGADither[pixels[w]][3];
+					mac[2 * w + macPitch + 1] = Graphics::macEGADither[color][3];
 			}
 
 			pixels += pixelsPitch;

--- a/engines/scumm/palette.cpp
+++ b/engines/scumm/palette.cpp
@@ -25,6 +25,7 @@
 #include "common/textconsole.h"
 #include "common/util.h"
 
+#include "graphics/macega.h"
 #include "graphics/palette.h"
 
 #include "scumm/resource.h"
@@ -137,20 +138,6 @@ void ScummEngine::resetPalette() {
 		0xFF, 0x99, 0x99, 	0xFF, 0x55, 0xFF, 	0xFF, 0xFF, 0x77, 	0xFF, 0xFF, 0xFF
 	};
 
-	// Theoreticaly, it should be possible to get the palette from the
-	// game's "clut" reosurce. But when I try that, I still get the wrong
-	// colours. This table is based on what Basilisk II draws.
-
-// 6 = brown
-// 11 = bright cyan
-
-	static const byte tableMacPalette[] = {
-		0x00, 0x00, 0x00,	0x00, 0x00, 0xBE,	0x00, 0xBE, 0x00,	0x00, 0xBE, 0xBE,
-		0xBE, 0x00, 0x00,	0xBE, 0x00, 0xBE,	0xBE, 0x75, 0x00,	0xBE, 0xBE, 0xBE,
-		0x75, 0x75, 0x75,	0x75, 0x75, 0xFC,	0x75, 0xFC, 0x75,	0x75, 0xFC, 0xFC,
-		0xFC, 0x75, 0x75,	0xFC, 0x75, 0xFC,	0xFC, 0xFC, 0x75,	0xFC, 0xFC, 0xFC
-	};
-
 	static const byte tableEGAPalette[] = {
 		0x00, 0x00, 0x00, 	0x00, 0x00, 0xAA, 	0x00, 0xAA, 0x00, 	0x00, 0xAA, 0xAA,
 		0xAA, 0x00, 0x00, 	0xAA, 0x00, 0xAA, 	0xAA, 0x55, 0x00, 	0xAA, 0xAA, 0xAA,
@@ -254,7 +241,7 @@ void ScummEngine::resetPalette() {
 			if ((_game.platform == Common::kPlatformAmiga) || (_game.platform == Common::kPlatformAtariST))
 				setPaletteFromTable(tableAmigaPalette, sizeof(tableAmigaPalette) / 3);
 			else if ((_game.id == GID_LOOM || _game.id == GID_INDY3) && _game.platform == Common::kPlatformMacintosh)
-				setPaletteFromTable(tableMacPalette, sizeof(tableMacPalette) / 3);
+				setPaletteFromTable(Graphics::macEGAPalette, sizeof(Graphics::macEGAPalette) / 3);
 			else
 				setPaletteFromTable(tableEGAPalette, sizeof(tableEGAPalette) / 3);
 		}

--- a/engines/scumm/palette.cpp
+++ b/engines/scumm/palette.cpp
@@ -1419,7 +1419,11 @@ void ScummEngine::updatePalette() {
 		for (i = _palDirtyMin; i <= _palDirtyMax; i++) {
 			byte *data;
 
-			if (_game.features & GF_SMALL_HEADER && _game.version > 2)
+			// In b/w Mac rendering mode, the shadow palette is
+			// handled by the renderer itself. See comment in
+			// mac_drawStripToScreen().
+
+			if (_game.features & GF_SMALL_HEADER && _game.version > 2 && _renderMode != Common::kRenderMacintoshBW)
 				data = _currentPalette + _shadowPalette[i] * 3;
 			else
 				data = _currentPalette + i * 3;

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1698,7 +1698,15 @@ void ScummEngine_v5::o5_roomOps() {
 			}
 			assertRange(0, a, 256, "o5_roomOps: 4: room color slot");
 			_shadowPalette[b] = a;
-			setDirtyColors(b, b);
+
+			// In b/w Mac rendering mode, the shadow palette is
+			// handled by the renderer itself. See comment in
+			// mac_drawStripToScreen().
+
+			if (_renderMode == Common::kRenderMacintoshBW) {
+				_fullRedraw = true;
+			} else
+				setDirtyColors(b, b);
 		} else {
 			a = getVarOrDirectWord(PARAM_1);
 			b = getVarOrDirectWord(PARAM_2);

--- a/graphics/macega.h
+++ b/graphics/macega.h
@@ -1,0 +1,81 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef GRAPHICS_MACEGA_H
+#define GRAPHICS_MACEGA_H
+
+namespace Graphics {
+
+// This is the palette that Basilisk II uses by default for 16-color games.
+// It's basically the same as EGA, but a little bit brighter. While it does
+// seem like games can have their own palette (CLUT) resources, at least Loom
+// didn't seem to use it. (I could be wrong about that.)
+
+static const byte macEGAPalette[] = {
+	0x00, 0x00, 0x00,	// Black
+	0x00, 0x00, 0xBE,	// Blue
+	0x00, 0xBE, 0x00,	// Green
+	0x00, 0xBE, 0xBE,	// Cyan
+	0xBE, 0x00, 0x00,	// Red
+	0xBE, 0x00, 0xBE,	// Magenta
+	0xBE, 0x75, 0x00,	// Brown
+	0xBE, 0xBE, 0xBE,	// Light Gray
+	0x75, 0x75, 0x75,	// Dark Gray
+	0x75, 0x75, 0xFC,	// Bright Blue
+	0x75, 0xFC, 0x75,	// Bright Green
+	0x75, 0xFC, 0xFC,	// Bright Cyan
+	0xFC, 0x75, 0x75,	// Bright Red
+	0xFC, 0x75, 0xFC,	// Bright Magenta
+	0xFC, 0xFC, 0x75,	// Bright Yellow
+	0xFC, 0xFC, 0xFC	// White
+};
+
+// Each color has its own 2x2 dithering pattern. This array remaps them to the
+// color indexes for black and white. The order of the pixels is upper left,
+// upper right, lower left, lower right. I don't know if this is the standard
+// method, but it does seem to be what LucasArts used so maybe it's useful for
+// other games as well.
+//
+// One obvious candidate would be the Mac AGI games, though looking at
+// screenshots makes me suspect that they used 3x2 pixels for each color.
+
+const byte macEGADither[16][4] = {
+	{  0,  0,  0,  0 },	// Black
+	{  0,  0,  0, 15 },	// Blue
+	{  0,  0, 15,  0 },	// Green
+	{  0,  0, 15, 15 },	// Cyan
+	{  0, 15,  0,  0 },	// Red
+	{  0, 15,  0, 15 },	// Magenta
+	{  0, 15, 15,  0 },	// Brown
+	{  0, 15, 15, 15 },	// Light Gray
+	{ 15,  0,  0,  0 },	// Dark Gray
+	{ 15,  0,  0, 15 },	// Bright Blue
+	{ 15,  0, 15,  0 },	// Bright Green
+	{ 15,  0, 15, 15 },	// Bright Cyan
+	{ 15, 15,  0,  0 },	// Bright Red
+	{ 15, 15,  0, 15 },	// Bright Magenta
+	{ 15, 15, 15,  0 },	// Bright Yellow
+	{ 15, 15, 15, 15 }	// White
+};
+
+} // end of namespace Graphics
+
+#endif // GRAPHICS_MACEGA_H


### PR DESCRIPTION
This adds a black-and-white mode for Mac Loom and Indy3. This feature was actually requested several years ago [1]. I don't know if that guy is still around, but maybe others want it as well.

Each color is dithered to a 2x2 pattern. I don't know if the actual patterns were some sort of standard, or if LucasArts came up with them themselves. But I believe that the result is pixel-perfect compared to the originals. I have put these, along with the Mac "EGA" palette, in a new header file, graphics/macega.h in case they can be reused elsewhere. When I did it, I was mainly thinking about the Mac AGI games, though looking closer at screenshots I suspect they used 3x2 dither patterns instead. Oh well.

Text is rendered as black or white (I think all of the in-game text is white), except for dark gray which is rendered using a checkerboard pattern. This is used for disabled notes in Loom, and for the replacement verb GUI in Indy3. The Loom notes appear to be pixel perfect, except I still can't figure out exactly if/when/how the notes used shadowed text. Oh well, that'll have to be good enough.

When running in 16 colors, the games use the shadow palette to remap colors. This makes no sense when you only have two colors, so these color changes are handled by the renderer, and any change to the shadow palette triggers a full redraw of the screen. This is used for the lightning flashes around Castle Brunwald in Indy3, and for the scene in Loom where the dragon finds Rusty asleep. (If there are other scenes, I'm not aware of them.)

I have replayed all of Loom, because that's the one where I was the most worried about text color. In Indy3, most text is drawn using a separate functions (for the text boxes) that only knows how to draw white text.

[1] https://forums.scummvm.org/viewtopic.php?f=1&t=12489