### PR TITLE
AGS: Pointers should not be casted to long

### DIFF
--- a/engines/ags/engine/ac/string.cpp
+++ b/engines/ags/engine/ac/string.cpp
@@ -300,9 +300,9 @@ size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, i
 int MAXSTRLEN = MAX_MAXSTRLEN;
 void check_strlen(char *ptt) {
 	MAXSTRLEN = MAX_MAXSTRLEN;
-	long charstart = (long)&_GP(game).chars[0];
+	long charstart = (intptr_t)&_GP(game).chars[0];
 	long charend = charstart + sizeof(CharacterInfo) * _GP(game).numcharacters;
-	if (((long)&ptt[0] >= charstart) && ((long)&ptt[0] <= charend))
+	if (((intptr_t)&ptt[0] >= charstart) && ((intptr_t)&ptt[0] <= charend))
 		MAXSTRLEN = 30;
 }
 

--- a/engines/ags/lib/allegro/unicode.cpp
+++ b/engines/ags/lib/allegro/unicode.cpp
@@ -1132,7 +1132,7 @@ int uoffset(const char *s, int index) {
 		}
 	}
 
-	return (long)s - (long)orig;
+	return (intptr_t)s - (intptr_t)orig;
 }
 
 char *ustrlwr(char *s) {
@@ -1209,7 +1209,7 @@ int ustrsizez(const char *s) {
 	do {
 	} while (ugetxc(&s) != 0);
 
-	return (long)s - (long)orig;
+	return (intptr_t)s - (intptr_t)orig;
 }
 
 } // namespace AGS3


### PR DESCRIPTION
New string arithmetic is using pointers diff casted to long...
Trying to avoid C++11 features, the best option is to cast them to intptr_t instead of long