### PR TITLE
GOB: Avoid an off by one

### DIFF
--- a/engines/gob/videoplayer.cpp
+++ b/engines/gob/videoplayer.cpp
@@ -918,7 +918,7 @@ void VideoPlayer::copyPalette(const Video &video, int16 palStart, int16 palEnd) 
 	palStart =  palStart      * 3;
 	palEnd   = (palEnd   + 1) * 3;
 
-	for (int i = palStart; i <= palEnd; i++)
+	for (int i = palStart; i < palEnd; i++)
 		((char *)(_vm->_global->_pPaletteDesc->vgaPal))[i] = video.decoder->getPalette()[i] >> 2;
 }
 


### PR DESCRIPTION
Lost in Time (English floppy version but CD version might be affected as well) garbles colours during some clips playback otherwise.

The easiest way to reproduce is in manor section of the game: when it starts, just click the horse at the gate or any object in the tractor. A video will play that will also garble one colour in the picture to red (the same happens in other parts of manor section when small clips play). 

I believe it's caused by an off-by-one error in palette copy (e.g. for PORTAL04.IMD colours 16-127 are copied).

This patch seems to fix it.
