### PR TITLE
BLADERUNNER: fix encodings for save descriptions

### DIFF
--- a/engines/bladerunner/ui/kia_section_load.cpp
+++ b/engines/bladerunner/ui/kia_section_load.cpp
@@ -70,7 +70,7 @@ void KIASectionLoad::open() {
 	if (!_saveList.empty()) {
 		_scrollBox->addLine(_vm->_textOptions->getText(36), -1, 4); // Load game:
 		for (uint i = 0; i < _saveList.size(); ++i) {
-			_scrollBox->addLine(_saveList[i].getDescription(), i, 0);
+			_scrollBox->addLine(_saveList[i].getDescription().encode(Common::kDos850), i, 0);
 		}
 		_scrollBox->addLine("", -1, 4);
 	}

--- a/engines/bladerunner/ui/kia_section_save.cpp
+++ b/engines/bladerunner/ui/kia_section_save.cpp
@@ -112,7 +112,7 @@ void KIASectionSave::open() {
 		}
 
 		for (uint i = 0; i < _saveList.size(); ++i) {
-			_scrollBox->addLine(_saveList[i].getDescription(), i, 0);
+			_scrollBox->addLine(_saveList[i].getDescription().encode(Common::kDos850), i, 0);
 		}
 
 		if (ableToSaveGame) {
@@ -296,7 +296,7 @@ void KIASectionSave::scrollBoxCallback(void *callbackData, void *source, int lin
 		if (self->_selectedLineId == self->_newSaveLineId) {
 			self->_inputBox->setText("");
 		} else {
-			self->_inputBox->setText(self->_saveList[self->_selectedLineId].getDescription());
+			self->_inputBox->setText(self->_saveList[self->_selectedLineId].getDescription().encode(Common::kDos850));
 		}
 
 		self->_vm->_audioPlayer->playAud(self->_vm->_gameInfo->getSfxTrack(kSfxSPNBEEP3), 40, 0, 0, 50, 0);

--- a/engines/bladerunner/ui/kia_section_save.cpp
+++ b/engines/bladerunner/ui/kia_section_save.cpp
@@ -405,7 +405,7 @@ void KIASectionSave::save() {
 	}
 
 	BladeRunner::SaveFileHeader header;
-	header._name = _inputBox->getText();
+	header._name = Common::U32String(_inputBox->getText()).encode(Common::kUtf8);
 	header._playTime = _vm->getTotalPlayTime();
 
 	BladeRunner::SaveFileManager::writeHeader(*saveFile, header);

--- a/engines/bladerunner/ui/ui_input_box.cpp
+++ b/engines/bladerunner/ui/ui_input_box.cpp
@@ -88,6 +88,9 @@ void UIInputBox::hide() {
 }
 
 void UIInputBox::handleKeyDown(const Common::KeyState &kbd) {
+	// The values that the KeyState::ascii field receives from the SDL backend are actually ISO 8859-1 encoded. They need to be
+	// reencoded to DOS so as to match the game font encoding (although we currently use UIInputBox::charIsValid() to block most
+	// extra characters, so it might not make much of a difference).
 	char kc = Common::U32String(Common::String::format("%c", kbd.ascii), Common::kISO8859_1).encode(Common::kDos850).firstChar();
 	if (_isVisible) {
 		if (charIsValid(kc) && _text.size() < _maxLength) {

--- a/engines/bladerunner/ui/ui_input_box.cpp
+++ b/engines/bladerunner/ui/ui_input_box.cpp
@@ -88,9 +88,10 @@ void UIInputBox::hide() {
 }
 
 void UIInputBox::handleKeyDown(const Common::KeyState &kbd) {
+	char kc = Common::U32String(Common::String::format("%c", kbd.ascii), Common::kISO8859_1).encode(Common::kDos850).firstChar();
 	if (_isVisible) {
-		if (charIsValid(kbd) && _text.size() < _maxLength) {
-			_text += kbd.ascii;
+		if (charIsValid(kc) && _text.size() < _maxLength) {
+			_text += kc;
 		} else if (kbd.keycode == Common::KEYCODE_BACKSPACE) {
 			_text.deleteLastChar();
 		} else if (kbd.keycode == Common::KEYCODE_RETURN && !_text.empty()) {
@@ -101,18 +102,18 @@ void UIInputBox::handleKeyDown(const Common::KeyState &kbd) {
 	}
 }
 
-bool UIInputBox::charIsValid(const Common::KeyState &kbd) {
-	return kbd.ascii >= ' '
-		&& kbd.ascii != '<'
-		&& kbd.ascii != '>'
-		&& kbd.ascii != ':'
-		&& kbd.ascii != '"'
-		&& kbd.ascii != '/'
-		&& kbd.ascii != '\\'
-		&& kbd.ascii != '|'
-		&& kbd.ascii != '?'
-		&& kbd.ascii != '*'
-		&& kbd.ascii <= '~';// || kbd.ascii == '¡' || kbd.ascii == 'ß');
+bool UIInputBox::charIsValid(char kc) {
+	return kc >= ' '
+		&& kc != '<'
+		&& kc != '>'
+		&& kc != ':'
+		&& kc != '"'
+		&& kc != '/'
+		&& kc != '\\'
+		&& kc != '|'
+		&& kc != '?'
+		&& kc != '*'
+		&& kc <= '~';// || kc == '¡' || kc == 'ß');
 }
 
 } // End of namespace BladeRunner

--- a/engines/bladerunner/ui/ui_input_box.h
+++ b/engines/bladerunner/ui/ui_input_box.h
@@ -58,7 +58,7 @@ public:
 	void handleKeyDown(const Common::KeyState &kbd) override;
 
 private:
-	bool charIsValid(const Common::KeyState &kbd);
+	bool charIsValid(char kc);
 };
 
 } // End of namespace BladeRunner


### PR DESCRIPTION
If you type save names like e. g. "äöüß" in the GMM this will now show up correctly in the ingame save/load dialogs.

You still cannot type these characters ingame due to the current implementation of UIInputBox::charIsValid(). I don't know the purpose of the function. If I comment out everything and simply return true it works fine (I can enter all these special characters). So it is not a limitation of the font, even though I have the English version. If the only reason for charIsValid() was the wrong encoding it might make sense to limit or even remove it.

