### PR TITLE
AGI: Modify Volume to use ScummVM GUI as maximum range for Script Volume

### DIFF
--- a/engines/agi/agi.cpp
+++ b/engines/agi/agi.cpp
@@ -175,8 +175,7 @@ int AgiEngine::agiInit() {
 	// Reset in-game timer
 	inGameTimerReset();
 
-	// Sync volume settings from ScummVM system settings
-	setVolumeViaSystemSetting();
+	applyVolumeToMixer();
 
 	return ec;
 }
@@ -378,7 +377,7 @@ AgiEngine::AgiEngine(OSystem *syst, const AGIGameDescription *gameDesc) : AgiBas
 	_instructionCounter = 0;
 	resetGetVarSecondsHeuristic();
 
-	_setVolumeBrokenFangame = false; // for further study see AgiEngine::setVolumeViaScripts()
+	_setVolumeBrokenFangame = false; // for further study see AgiEngine::applyVolumeToMixer()
 
 	_playTimeInSecondsAdjust = 0;
 	_lastUsedPlayTimeInCycles = 0;
@@ -530,7 +529,7 @@ Common::Error AgiEngine::go() {
 void AgiEngine::syncSoundSettings() {
 	Engine::syncSoundSettings();
 
-	setVolumeViaSystemSetting();
+	applyVolumeToMixer();
 }
 
 // WORKAROUND:

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -875,8 +875,7 @@ public:
 	void setVar(int16 varNr, byte newValue);
 
 private:
-	void setVolumeViaScripts(byte newVolume);
-	void setVolumeViaSystemSetting();
+	void applyVolumeToMixer();
 
 public:
 	void syncSoundSettings() override;

--- a/engines/agi/saveload.cpp
+++ b/engines/agi/saveload.cpp
@@ -753,8 +753,7 @@ int AgiEngine::loadGame(const Common::String &fileName, bool checkId) {
 	// copy everything over (we should probably only copy over the remaining parts of the screen w/o play screen
 	_gfx->copyDisplayToScreen();
 
-	// Sync volume settings from ScummVM system settings, so that VM volume variable is overwritten
-	setVolumeViaSystemSetting();
+	applyVolumeToMixer();
 
 	return errOK;
 }


### PR DESCRIPTION
This change simplifies the AGI engine volume handling by using the music
and sound fx volumes set in the ScummVM GUI as the maximum levels which
can be set by the scripts. This avoids the complexity of synchronising
changes between these and the scripts (which only had a single 16 step
volume range which is inverted in meaning by quite a large number of
fangames).

This still allows the game scripts to adjust the volumes, but only within
the maximum range set in the Launcher / GMM.

This avoids issues such as https://bugs.scummvm.org/ticket/10732 where
users complained about extremely loud output in some cases.
