### PR TITLE
COMMON: Change TransMan builtin language to "en" instead of "C"

### DIFF
--- a/backends/platform/ios7/ios7_osys_misc.mm
+++ b/backends/platform/ios7/ios7_osys_misc.mm
@@ -39,10 +39,14 @@ static inline void execute_on_main_thread_async(void (^block)(void)) {
 }
 
 Common::String OSystem_iOS7::getSystemLanguage() const {
-	NSString *locale = [[NSLocale currentLocale] localeIdentifier];
-	if (locale == nil)
+	NSString *language = [[NSLocale preferredLanguages] firstObject];
+	if (language == nil)
 		return Common::String();
-	return Common::String([locale cStringUsingEncoding:NSISOLatin1StringEncoding]);
+	Common::String lang([language cStringUsingEncoding:NSISOLatin1StringEncoding]);
+	// Depending on the iOS version this may use an underscore (e.g. en_US) or a
+	// dash (en-US). Make sure we always return one with an underscore.
+	Common::replace(lang, "-", "_");
+	return lang;
 }
 
 bool OSystem_iOS7::hasTextInClipboard() {

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -565,16 +565,17 @@ Common::String OSystem_SDL::getSystemLanguage() const {
 	// Detect the language from the locale
 	if (locale.empty()) {
 		return BaseBackend::getSystemLanguage();
+	} else if (locale == "C" || locale == "POSIX") {
+		return "en_US";
 	} else {
 		int length = 0;
 
-		// Strip out additional information, like
-		// ".UTF-8" or the like. We do this, since
-		// our translation languages are usually
-		// specified without any charset information.
+		// Assume the locale is in the form language[_territory[.codeset]][@modifier].
+		// On macOS the format is different (it looks like C/UTF-8/C/C/C/C), but we
+		// have a different implementation of getSystemLanguage for macOS anyway, so
+		// we don't have to handle it here.
+		// Strip out additional information, like ".UTF-8" or the like.
 		for (int size = locale.size(); length < size; ++length) {
-			// TODO: Check whether "@" should really be checked
-			// here.
 			if (locale[length] == '.' || locale[length] == ' ' || locale[length] == '@')
 				break;
 		}

--- a/common/system.h
+++ b/common/system.h
@@ -1799,16 +1799,17 @@ public:
 	virtual bool openUrl(const Common::String &url) {return false; }
 
 	/**
-	 * Return the locale of the system.
+	 * Return the language of the system.
 	 *
-	 * This returns the currently set locale of the system on which
+	 * This returns the currently set language of the system on which
 	 * ScummVM is run.
 	 *
-	 * The format of the locale is language_country. These should match
-	 * the POSIX locale values.
+	 * The format is an ISO 639 language code, optionally followed by an ISO 3166-1 country code
+	 * in the form language_country.
 	 *
 	 * For information about POSIX locales, see the following link:
-	 * https://en.wikipedia.org/wiki/Locale_(computer_software)#POSIX_platforms
+	 * https://en.wikipedia.org/wiki/ISO_639
+	 * https://en.wikipedia.org/wiki/ISO_3166-1
 	 *
 	 * The default implementation returns "en_US".
 	 *

--- a/common/text-to-speech.cpp
+++ b/common/text-to-speech.cpp
@@ -144,8 +144,6 @@ Array<int> TextToSpeechManager::getVoiceIndicesByGender(TTSVoice::Gender gender)
 }
 
 void TextToSpeechManager::setLanguage(Common::String language) {
-	if (language == "C")
-		language = "en";
 	// The speech manager uses the ISO 639-1 for language codes (2 letter code)
 	// if we get a longer language string, just take the first 2 letters from that
 	// if it won't be a valid language code, the Manager just won't find any voice

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -172,7 +172,7 @@ String TranslationManager::getCurrentCharset() const {
 
 String TranslationManager::getCurrentLanguage() const {
 	if (_currentLang == -1)
-		return "C";
+		return "en";
 	return _langs[_currentLang];
 }
 
@@ -211,7 +211,7 @@ String TranslationManager::getLangById(int id) const {
 	case kTranslationAutodetectId:
 		return "";
 	case kTranslationBuiltinId:
-		return "C";
+		return "en";
 	default:
 		if (id >= 0 && id - 1 < (int)_langs.size())
 			return _langs[id - 1];

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -527,7 +527,7 @@ bool ThemeEngine::addFont(TextData textId, const Common::String &language, const
 #ifdef USE_TRANSLATION
 		Common::String cl = TransMan.getCurrentLanguage();
 #else
-		Common::String cl("C");
+		Common::String cl("en");
 #endif
 		if (!cl.matchString(language, true))
 			return true;	// Skip
@@ -562,7 +562,7 @@ bool ThemeEngine::addFont(TextData textId, const Common::String &language, const
 			if (!_texts[textId]->_fontPtr) {
 				error("Couldn't load font '%s'/'%s'", file.c_str(), scalableFile.c_str());
 #ifdef USE_TRANSLATION
-				TransMan.setLanguage("C");
+				TransMan.setLanguage("en");
 				Common::TextToSpeechManager *ttsMan;
 				if ((ttsMan = g_system->getTextToSpeechManager()) != nullptr)
 					ttsMan->setLanguage("en");
@@ -578,7 +578,7 @@ bool ThemeEngine::addFont(TextData textId, const Common::String &language, const
 			// However, still returns false here, probably to avoid ugly / garbage glyphs side-effects
 			// FIXME If we return false anyway why would we attempt the fall-back in the first place?
 #ifdef USE_TRANSLATION
-			TransMan.setLanguage("C");
+			TransMan.setLanguage("en");
 			Common::TextToSpeechManager *ttsMan;
 			if ((ttsMan = g_system->getTextToSpeechManager()) != nullptr)
 				ttsMan->setLanguage("en");

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -754,8 +754,6 @@ void GuiManager::initTextToSpeech() {
 		return;
 #ifdef USE_TRANSLATION
 	Common::String currentLanguage = TransMan.getCurrentLanguage();
-	if (currentLanguage == "C")
-		currentLanguage = "en";
 	ttsMan->setLanguage(currentLanguage);
 #endif
 	int volume = (ConfMan.getInt("speech_volume", "scummvm") * 100) / 256;

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2637,11 +2637,7 @@ void GlobalOptionsDialog::apply() {
 	if (ttsMan) {
 #ifdef USE_TRANSLATION
 		if (newLang != oldLang) {
-			if (newLang == "C")
-				ttsMan->setLanguage("en");
-			else {
-				ttsMan->setLanguage(newLang);
-			}
+			ttsMan->setLanguage(newLang);
 			_ttsVoiceSelectionPopUp->setSelected(0);
 		}
 #else


### PR DESCRIPTION
The change in this pull request change `Common::TranslationManager` so that `getCurrentLanguage` and `getLangById` both return "en" instead of "C" for the built-in language.

This seems more logical to me and allows to simplify some code (which is also included in this pull request).
Advantages of this change include:
 - Better readability

For example
```c++
#ifdef USE_TRANSLATION
	Common::String cl = TransMan.getCurrentLanguage();
#else
	Common::String cl("en");
#endif
```
makes more sense than
```c++
#ifdef USE_TRANSLATION
	Common::String cl = TransMan.getCurrentLanguage();
#else
	Common::String cl("C");
#endif
```

 - No need for special cases

We can remove the following in various places
```c++
	if (currentLanguage == "C")
		currentLanguage = "en";
```

 - More language id in themes:

If we ever want to use a custom font for English in a theme, it makes more sense to write
```
<language id = 'en'  scalable_file = 'foo.ttf'/>
```
than
```
<language id = 'C'  scalable_file = 'foo.ttf'/>
```

If we want to provide an English translation that differs from the hardcoded strings in the source code, I would expect it to be something like "en_GB" or "en_ZA" for example. So that would still be possible with this change.

Also current config files are still correctly loaded as `TransMan.parseLanguage("C")` still returns `kTranslationBuiltinId` (as it does for any unrecognised language, such as "en").