### PR TITLE
CI: Upgrade vcpkg action to v7 and vcpkg to a recent commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
       - uses: ilammy/setup-nasm@v1
         if: ${{ matrix.useNasm }} == 'true'
       - name: Install vcpkg and packages
-        uses: lukka/run-vcpkg@v6
+        uses: lukka/run-vcpkg@v7
         id: runvcpkg
         with:
-          vcpkgGitCommitId: 0bf3923f9fab4001c00f0f429682a0853b5749e0
+          vcpkgGitCommitId: b67fab9861239e33b722b9a44f5c96dec6ca807e
           vcpkgTriplet: '${{ matrix.triplet }}'
           vcpkgArguments: '${{ matrix.vcpkgPackages }}'
 #      - name: Upload libs


### PR DESCRIPTION
Cache is improved, so vcpkg itself is not built every time.

Upgrade of vcpkg itself is required due to
https://github.com/microsoft/vcpkg/issues/18718.
