### PR TITLE
GLK: Fix warnings for TRUE/FALSE redefinition on Symbian build.

### DIFF
--- a/engines/glk/level9/level9_main.h
+++ b/engines/glk/level9/level9_main.h
@@ -36,6 +36,14 @@ typedef uint16 L9UINT16;
 typedef uint32 L9UINT32;
 typedef bool L9BOOL;
 
+#if defined(FALSE)
+#undef FALSE
+#endif
+
+#if defined(TRUE)
+#undef TRUE
+#endif
+
 #define FALSE false
 #define TRUE true
 

--- a/engines/glk/tads/tads2/lib.h
+++ b/engines/glk/tads/tads2/lib.h
@@ -62,6 +62,14 @@ typedef int            eword;
 #define CLRSTRUCT(x) memset(&(x), 0, (size_t)sizeof(x))
 #define CPSTRUCT(dst,src) memcpy(&(dst), &(src), (size_t)sizeof(dst))
 
+#if defined(TRUE)
+#undef TRUE
+#endif
+
+#if defined(FALSE)
+#undef FALSE
+#endif
+
 /* TRUE and FALSE */
 #define TRUE true
 #define FALSE false


### PR DESCRIPTION
Solve bug #12740.