### PR TITLE
CREATE_PROJECT: Fix enabling fluidlite

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -411,6 +411,8 @@ int main(int argc, char *argv[]) {
 				setup.defines.push_back("USE_SPARKLE");
 			else if (backendWin32 && !strcmp(i->name, "libcurl"))
 				setup.defines.push_back("CURL_STATICLIB");
+			else if (!strcmp(i->name, "fluidlite"))
+				setup.defines.push_back("USE_FLUIDSYNTH");
 		}
 	}
 

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -459,14 +459,13 @@ void XcodeProvider::setupFrameworksBuildPhase(const BuildSetup &setup) {
 	if (CONTAINS_DEFINE(setup.defines, "USE_FLAC")) {
 		DEF_LOCALLIB_STATIC("libFLAC");
 	}
-	if (CONTAINS_DEFINE(setup.defines, "USE_FLUIDSYNTH")) {
+	if (CONTAINS_DEFINE(setup.defines, "USE_FLUIDLITE")) {
+		DEF_LOCALLIB_STATIC("libfluidlite");
+	} else if (CONTAINS_DEFINE(setup.defines, "USE_FLUIDSYNTH")) {
 		DEF_LOCALLIB_STATIC("libfluidsynth");
 		DEF_LOCALLIB_STATIC("libffi");
 		DEF_LOCALLIB_STATIC("libglib-2.0");
 		DEF_SYSTBD("libffi");
-	}
-	if (CONTAINS_DEFINE(setup.defines, "USE_FLUIDLITE")) {
-		DEF_LOCALLIB_STATIC("libfluidlite");
 	}
 	if (CONTAINS_DEFINE(setup.defines, "USE_FREETYPE2")) {
 		DEF_LOCALLIB_STATIC("libfreetype");
@@ -601,7 +600,8 @@ void XcodeProvider::setupFrameworksBuildPhase(const BuildSetup &setup) {
 	if (CONTAINS_DEFINE(setup.defines, "USE_FRIBIDI")) {
 		frameworks_iOS.push_back("libfribidi.a");
 	}
-	if (CONTAINS_DEFINE(setup.defines, "USE_FLUIDSYNTH")) {
+	if (CONTAINS_DEFINE(setup.defines, "USE_FLUIDSYNTH") &&
+		!CONTAINS_DEFINE(setup.defines, "USE_FLUIDLITE")) {
 		frameworks_iOS.push_back("libfluidsynth.a");
 		frameworks_iOS.push_back("libglib-2.0.a");
 		frameworks_iOS.push_back("libffi.a");
@@ -667,7 +667,8 @@ void XcodeProvider::setupFrameworksBuildPhase(const BuildSetup &setup) {
 	if (CONTAINS_DEFINE(setup.defines, "USE_FLAC")) {
 		frameworks_osx.push_back("libFLAC.a");
 	}
-	if (CONTAINS_DEFINE(setup.defines, "USE_FLUIDSYNTH")) {
+	if (CONTAINS_DEFINE(setup.defines, "USE_FLUIDSYNTH") &&
+		!CONTAINS_DEFINE(setup.defines, "USE_FLUIDLITE")) {
 		frameworks_osx.push_back("libfluidsynth.a");
 		frameworks_osx.push_back("libglib-2.0.a");
 		frameworks_osx.push_back("libffi.tbd");


### PR DESCRIPTION
`--enable-fluidlite` doesn't work because create_project doesn't define USE_FLUIDSYNTH when fluidlite is enabled. USE_FLUIDLITE requires USE_FLUIDSYNTH to be defined. The two libraries are mutually exclusive but not the definitions. 

See: https://github.com/scummvm/scummvm/blob/fcf56cae45244e0d53f5870437439f4fdf6d22be/audio/softsynth/fluidsynth.cpp#L27


And: https://github.com/scummvm/scummvm/blob/fcf56cae45244e0d53f5870437439f4fdf6d22be/configure#L5013