### PR TITLE
CI: Use buildcache also for msbuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,22 @@ jobs:
             configFlags: --enable-faad --enable-mpeg2 --enable-discord --disable-fribidi --disable-opengl
             vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib giflib'
     env:
-      CONFIGURATION: Analysis
+      CONFIGURATION: Release
       PLATFORM: ${{ matrix.platform }}
+      BUILDCACHE_IMPERSONATE: cl.exe
+      BUILDCACHE_MAX_CACHE_SIZE: 2500000000
+      BUILDCACHE_HARD_LINKS: true
+      CLToolExe: buildcache.exe
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - uses: ilammy/setup-nasm@v1
         if: ${{ matrix.useNasm }} == 'true'
+      - name: Build cache
+        uses: mikehardy/buildcache-action@v1.2.2
+        with:
+          install_dir: C:\ProgramData
+          cache_key: ${{ matrix.triplet }}
       - name: Install vcpkg and packages
         uses: lukka/run-vcpkg@v7
         id: runvcpkg
@@ -53,20 +62,20 @@ jobs:
       - name: Build create_project
         run: |
           cd devtools/create_project/cmake
-          cmake .
+          cmake -DCMAKE_CXX_COMPILER_LAUNCHER=buildcache .
           cmake --build . -j 2
           ls
           cd ../../../
       - name: Call create_project
         run: |
-          mkdir build-scummvm
+          New-Item -ItemType Directory -Force -Path C:\build-scummvm
+          New-Item -ItemType Junction -Path build-scummvm -Target C:\build-scummvm
           cd build-scummvm
           ../devtools/create_project/cmake/Debug/create_project.exe .. --msvc --enable-all-engines ${{ matrix.configflags }} --use-canonical-lib-names
           ls
       - name: set SCUMMVM_LIBS env variable
         run: |
-          echo "SCUMMVM_LIBS=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\debug" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Copy-Item "${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\include" -Destination "${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\debug" -Recurse
+          echo "SCUMMVM_LIBS=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Build scummvm
@@ -111,6 +120,7 @@ jobs:
             packagesUrl: https://downloads.scummvm.org/frs/build/scummvm-ios7-libs-v2.zip
     env:
       BUILDCACHE_MAX_CACHE_SIZE: 2000000000
+      BUILDCACHE_HARD_LINKS: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -135,7 +145,8 @@ jobs:
         run: |
           ./devtools/create_project/xcode/build/Release/create_project . --xcode --enable-all-engines ${{ matrix.configflags }}
           ls
-      - uses: mikehardy/buildcache-action@v1
+      - name: Build cache
+        uses: mikehardy/buildcache-action@v1
         with:
           cache_key: ${{ matrix.platform }}
       - name: Build scummvm

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -107,6 +107,7 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 	        << "\t\t<ProjectGuid>{" << uuid << "}</ProjectGuid>\n"
 	        << "\t\t<RootNamespace>" << name << "</RootNamespace>\n"
 	        << "\t\t<Keyword>Win32Proj</Keyword>\n"
+	        << "\t\t<UseMultiToolTask>true</UseMultiToolTask>\n"
 	        << "\t\t<VCTargetsPath Condition=\"'$(VCTargetsPath" << _version << ")' != '' and '$(VSVersion)' == '' and $(VisualStudioVersion) == ''\">$(VCTargetsPath" << _version << ")</VCTargetsPath>\n";
 
 	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
@@ -387,7 +388,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	           << "\t\t\t<CompileAs>Default</CompileAs>\n"
 	           << "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>\n"
 	           << "\t\t\t<ConformanceMode>true</ConformanceMode>\n"
-	           << "\t\t\t<ObjectFileName>$(IntDir)dists\\msvc\\%(RelativeDir)</ObjectFileName>\n"
+	           << "\t\t\t<ObjectFileName>$(IntDir)dists\\msvc\\%(RelativeDir)\\%(Filename).obj</ObjectFileName>\n"
 	           << "\t\t\t<AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>\n"
 	           << "\t\t</ClCompile>\n"
 	           << "\t\t<Link>\n"


### PR DESCRIPTION
* Buildcache doesn't work with PDB, so switch to Release build.
* Object file must be explicit, so adapt create_project. Set UseMultiToolTask to maintain parallel build.