### PR TITLE
ADL: Add keymapper support

### DIFF
--- a/engines/adl/POTFILES
+++ b/engines/adl/POTFILES
@@ -1,1 +1,2 @@
 engines/adl/detection.cpp
+engines/adl/metaengine.cpp

--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -106,17 +106,15 @@ AdlEngine::AdlEngine(OSystem *syst, const AdlGameDescription *gd) :
 
 bool AdlEngine::pollEvent(Common::Event &event) const {
 	if (g_system->getEventManager()->pollEvent(event)) {
-		if (event.type != Common::EVENT_KEYDOWN)
-			return false;
-
-		if (event.kbd.flags & Common::KBD_CTRL) {
-			if (event.kbd.keycode == Common::KEYCODE_q) {
+		if (event.type == Common::EVENT_CUSTOM_ENGINE_ACTION_START) {
+			if (event.customType == kADLActionQuit) {
 				quitGame();
-				return false;
 			}
+			return false;
 		}
 
-		return true;
+		if (event.type == Common::EVENT_KEYDOWN)
+			return true;
 	}
 
 	return false;

--- a/engines/adl/adl.h
+++ b/engines/adl/adl.h
@@ -68,6 +68,13 @@ enum kDebugChannels {
 	kDebugChannelScript = 1 << 0
 };
 
+enum ADLAction {
+	kADLActionNone,
+	kADLActionQuit,
+
+	kADLActionCount
+};
+
 // Save and restore opcodes
 #define IDO_ACT_SAVE           0x0f
 #define IDO_ACT_LOAD           0x10

--- a/engines/adl/metaengine.cpp
+++ b/engines/adl/metaengine.cpp
@@ -25,9 +25,14 @@
 #include "common/system.h"
 #include "common/savefile.h"
 #include "common/file.h"
+#include "common/translation.h"
 
 #include "graphics/thumbnail.h"
 
+#include "backends/keymapper/action.h"
+#include "backends/keymapper/keymapper.h"
+
+#include "adl/adl.h"
 #include "adl/detection.h"
 #include "adl/disk_image_helpers.h"
 
@@ -80,6 +85,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::KeymapArray initKeymaps(const char *target) const override;
 };
 
 bool AdlMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -239,6 +245,21 @@ Common::Error AdlMetaEngine::createInstance(OSystem *syst, Engine **engine, cons
 	}
 
 	return Common::kNoError;
+}
+
+Common::KeymapArray AdlMetaEngine::initKeymaps(const char *target) const {
+	using namespace Common;
+
+	Keymap *engineKeymap = new Keymap(Keymap::kKeymapTypeGame, "adl", "ADL");
+
+	Action *act;
+
+	act = new Action("QUIT", _("Quit"));
+	act->setCustomEngineActionEvent(kADLActionQuit);
+	act->addDefaultInputMapping("C+q");
+	engineKeymap->addAction(act);
+
+	return Keymap::arrayOf(engineKeymap);
 }
 
 } // End of namespace Adl


### PR DESCRIPTION
The keymap isn't particularly complicated, but having one stops the default game keymap from overriding the global one.