### PR TITLE
MAKE: added target to build via cmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,3 +133,14 @@ print-version:
 
 print-distversion:
 	@echo $(DISTVERSION)
+
+devtools/create_project/cmake/build/create_project:
+	cmake -Hdevtools/create_project/cmake -Bdevtools/create_project/cmake/build/
+	cmake --build devtools/create_project/cmake/build/
+
+CMakeLists.txt: devtools/create_project/cmake/build/create_project config.mk
+	./devtools/create_project/cmake/build/create_project . --cmake $(SAVED_CONFIGFLAGS)
+
+cmake: CMakeLists.txt
+	cmake -H. -Bbuild
+	cmake --build build


### PR DESCRIPTION
This allows easy `CMakeLists.txt` creation. I would like to check the cmake build against ninja and make as well as the unity build versus the normal build. These targets were produced to ease the build dir creation and compilation. Maybe others find them useful, too.