### PR TITLE
BACKENDS: Add OSystem::messageBox() and use it for error handling

### DIFF
--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -608,6 +608,26 @@ bool OSystem_SDL::setTextInClipboard(const Common::U32String &text) {
 	Common::String utf8Text = text.encode();
 	return SDL_SetClipboardText(utf8Text.c_str()) == 0;
 }
+
+void OSystem_SDL::messageBox(LogMessageType::Type type, const char *message) {
+	Uint32 flags = 0;
+
+	switch (type) {
+	case LogMessageType::kError:
+		flags = SDL_MESSAGEBOX_ERROR;
+		break;
+	case LogMessageType::kWarning:
+		flags = SDL_MESSAGEBOX_WARNING;
+		break;
+	case LogMessageType::kInfo:
+	case LogMessageType::kDebug:
+	default:
+		flags = SDL_MESSAGEBOX_INFORMATION;
+		break;
+	}
+
+	SDL_ShowSimpleMessageBox(flags, "ScummVM", message, _window ? _window->getSDLWindow() : nullptr);
+}
 #endif
 
 #if SDL_VERSION_ATLEAST(2, 0, 14)

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -73,6 +73,8 @@ public:
 	virtual bool hasTextInClipboard() override;
 	virtual Common::U32String getTextFromClipboard() override;
 	virtual bool setTextInClipboard(const Common::U32String &text) override;
+
+	virtual void messageBox(LogMessageType::Type type, const char *message) override;
 #endif
 
 #if SDL_VERSION_ATLEAST(2, 0, 14)

--- a/common/system.h
+++ b/common/system.h
@@ -1725,6 +1725,14 @@ public:
 	virtual void logMessage(LogMessageType::Type type, const char *message) = 0;
 
 	/**
+	 * Display a dialog box containing the given message.
+	 *
+	 * @param type    Type of the message.
+	 * @param message The message itself.
+	 */
+	virtual void messageBox(LogMessageType::Type type, const char *message) {}
+
+	/**
 	 * Open the log file in a way that allows the user to review it,
 	 * and possibly email it (or parts of it) to the ScummVM team,
 	 * for example as part of a bug report.

--- a/common/textconsole.cpp
+++ b/common/textconsole.cpp
@@ -96,8 +96,12 @@ void NORETURN_PRE error(const char *s, ...) {
 	// any OSystem yet.
 
 	// If there is an error handler, invoke it now
+	bool handled = false;
 	if (Common::s_errorHandler)
-		(*Common::s_errorHandler)(buf_output);
+		handled = (*Common::s_errorHandler)(buf_output);
+
+	if (!handled && g_system)
+		g_system->messageBox(LogMessageType::kError, buf_output);
 
 	if (g_system)
 		g_system->fatalError();

--- a/common/textconsole.h
+++ b/common/textconsole.h
@@ -58,7 +58,7 @@ void setErrorOutputFormatter(OutputFormatter f);
  * A typical example would be a function that shows a debug
  * console and displays the given message in it.
  */
-typedef void (*ErrorHandler)(const char *msg);
+typedef bool (*ErrorHandler)(const char *msg);
 
 /**
  * Set a callback that is invoked by error() after the error

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -120,7 +120,7 @@ Archive *DirectorEngine::getMainArchive() const { return _currentWindow->getMain
 Movie *DirectorEngine::getCurrentMovie() const { return _currentWindow->getCurrentMovie(); }
 Common::String DirectorEngine::getCurrentPath() const { return _currentWindow->getCurrentPath(); }
 
-static void buildbotErrorHandler(const char *msg) { }
+static bool buildbotErrorHandler(const char *msg) { return true; }
 
 void DirectorEngine::setCurrentMovie(Movie *movie) {
 	_currentWindow = movie->getWindow();

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -79,7 +79,9 @@ static void defaultOutputFormatter(char *dst, const char *src, size_t dstSize) {
 	}
 }
 
-static void defaultErrorHandler(const char *msg) {
+static bool defaultErrorHandler(const char *msg) {
+	bool handled = false;
+
 	// Unless this error -originated- within the debugger itself, we
 	// now invoke the debugger, if available / supported.
 	if (g_engine) {
@@ -92,6 +94,7 @@ static void defaultErrorHandler(const char *msg) {
 		if (debugger && !debugger->isActive()) {
 			debugger->attach(msg);
 			debugger->onFrame();
+			handled = true;
 		}
 
 
@@ -100,6 +103,8 @@ static void defaultErrorHandler(const char *msg) {
 #endif
 
 	}
+
+	return handled;
 }
 
 // Chained games manager


### PR DESCRIPTION
Previously, if an error occurred that couldn't be handled by the debugger, it would only be reported to stdout/stderr. This would result in ScummVM exiting without warning on platforms where the console isn't visible when such an error occurs. This PR adds a message box function to `OSystem` and uses it as a fallback when the currently registered error handler fails.