### PR TITLE
CI: Switch Windows build to Debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             configFlags: --enable-faad --enable-mpeg2 --enable-discord --disable-fribidi --disable-opengl
             vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib giflib'
     env:
-      CONFIGURATION: Analysis
+      CONFIGURATION: Debug
       PLATFORM: ${{ matrix.platform }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Analysis is 4.5x slower, and most users don't even look at the warnings.
