### PR TITLE
BUILD: Fix some cross-mingw issues

### DIFF
--- a/backends/platform/sdl/win32/win32.mk
+++ b/backends/platform/sdl/win32/win32.mk
@@ -85,7 +85,11 @@ endif
 endif
 
 win32dist-mingw: win32-data
+ifneq (,$(findstring peldd,$(LDD)))
+	$(LDD) $(WIN32PATH)/$(EXECUTABLE) | xargs -I files cp -vu files $(WIN32PATH)
+else
 	ldd $(WIN32PATH)/$(EXECUTABLE) | grep -i mingw | cut -d">" -f2 | cut -d" " -f2 | sort -u | xargs -I files cp -vu files $(WIN32PATH)
+endif
 
 .PHONY: win32-data win32dist win32dist-mingw
 

--- a/configure
+++ b/configure
@@ -3413,10 +3413,12 @@ if test -n "$_host"; then
 			_zlib=yes
 			;;
 		*mingw32*)
-			_sdlconfig=$_host-sdl-config
+			_sdlconfig=$_host-sdl2-config
+			_libcurlconfig=$_host-curl-config
 			_windres=$_host-windres
 			_ar="$_host-ar cr"
 			_ranlib=$_host-ranlib
+			_strip=$_host-strip
 			;;
 		mips-sgi*)
 			append_var LDFLAGS "-static-libgcc"

--- a/configure
+++ b/configure
@@ -230,6 +230,7 @@ _ar="ar cru"
 _as="as"
 _dwp=dwp
 _windres=windres
+_ldd=ldd
 _stagingpath="staging"
 _amigaospath="install"
 _morphospath="PROGDIR:"
@@ -3419,6 +3420,9 @@ if test -n "$_host"; then
 			_ar="$_host-ar cr"
 			_ranlib=$_host-ranlib
 			_strip=$_host-strip
+			if `which $_host-peldd >/dev/null 2>&1`; then
+				_ldd="$_host-peldd -t --ignore-errors"
+			fi
 			;;
 		mips-sgi*)
 			append_var LDFLAGS "-static-libgcc"
@@ -6163,6 +6167,7 @@ AS := $_as
 ASFLAGS := $ASFLAGS
 DWP := $_dwp
 WINDRES := $_windres
+LDD := $_ldd
 WINDRESFLAGS := $WINDRESFLAGS
 STAGINGPATH=$_stagingpath
 AMIGAOSPATH=$_amigaospath


### PR DESCRIPTION
* Default to `sdl2-config` instead of `sdl-config`
* Use `peldd` when cross-building
* Fix `strip`
* Do not undefine `__STRICT_ANSI__`