### PR TITLE
RFC: SCUMM: Workaround for bug #12734

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -55,6 +55,23 @@ namespace Scumm {
 void ScummEngine::printString(int m, const byte *msg) {
 	switch (m) {
 	case 0:
+		// WORKAROUND bug #12734: The script tries to clear the currently
+		// displayed message after Rapp gives you the map, but that means
+		// you'll never see Guybrush's reaction to finding a map piece.
+		//
+		// It's a bit hard to pin down the exact case, since it happens
+		// at a few different points during the script. We limit it to
+		// when the player has the map piece.
+		//
+		// We have to do it here, because we don't want to delay the
+		// animation of Rapp turning back to Ashes.
+		if (_game.id == GID_MONKEY2 && _roomResource == 19 &&
+			vm.slot[_currentScript].number == 203 &&
+			_actorToPrintStrFor == 255 && strcmp((const char *)msg, " ") == 0 &&
+			getOwner(200) == VAR(VAR_EGO) && VAR(VAR_HAVE_MSG)) {
+			return;
+		}
+
 		actorTalk(msg);
 		break;
 	case 1:


### PR DESCRIPTION
This is my attempt at reinstating a line of text in Monkey Island 2 that is printed, then immediately erased, after Rapp gives you his map piece. The comments in the commit and on bug #12734 should provide the necessary background.

I've given it some testing, but I don't know how much time I will have for ScummVM in the next few weeks. And it's hardly the only way of doing it, so any feedback is appreciated.

My main concern was that I want the animation of Rapp turning back to ash to play without any further delay. Rapp doesn't care what you're talking about. Admittedly, it may make Guybrush seem a bit less caring, too...