### PR TITLE
AGS: Savegames for Strangeland

### DIFF
--- a/backends/saves/default/default-saves.cpp
+++ b/backends/saves/default/default-saves.cpp
@@ -171,7 +171,8 @@ Common::OutSaveFile *DefaultSaveFileManager::openForSaving(const Common::String 
 	Common::WriteStream *const sf = fileNode.createWriteStream();
 	if (!sf)
 		return nullptr;
-	Common::OutSaveFile *const result = new Common::OutSaveFile(compress ? Common::wrapCompressedWriteStream(sf) : sf);
+	Common::WriteStream *const stream = compress ? Common::wrapCompressedWriteStream(sf) : sf;
+	Common::OutSaveFile *const result = new Common::OutSaveFile(stream, stream != sf);
 
 	// Add file to cache now that it exists.
 	_saveFileCache[filename] = Common::FSNode(fileNode.getPath());

--- a/backends/saves/savefile.cpp
+++ b/backends/saves/savefile.cpp
@@ -83,9 +83,9 @@ int64 OutSaveFile::size() const {
 
 void OutSaveFile::unsupportedMethodWarning(const Common::String &methodName) const {
 	if (_isCompressed)
-		warning("%s method is unsupported for compressed save files", methodName.c_str());
+		warning("OutSaveFile::%s function is unsupported for compressed save files", methodName.c_str());
 	else
-		warning("%s method is unsupported for this particular backend", methodName.c_str());
+		warning("OutSaveFile::%s function is unsupported for this particular backend", methodName.c_str());
 }
 
 bool SaveFileManager::copySavefile(const String &oldFilename, const String &newFilename, bool compress) {

--- a/common/savefile.h
+++ b/common/savefile.h
@@ -52,12 +52,23 @@ typedef SeekableReadStream InSaveFile;
  * That typically means "save games", but also includes things like the
  * IQ points in Indy3.
  */
-class OutSaveFile: public WriteStream {
+class OutSaveFile: public SeekableWriteStream {
+	/**
+	 * Used to print a warning if an unsupported SeekableWriteStream
+	 * method is called
+	 */
+	void unsupportedMethodWarning(const Common::String &methodName) const;
+
 protected:
 	WriteStream *_wrapped; /*!< @todo Doc required. */
+	bool _isCompressed;
 
 public:
-	OutSaveFile(WriteStream *w); /*!< Create an OutSaveFile that uses the given WriteStream to write the data. */
+	/**
+	 * Create an OutSaveFile that uses the given WriteStream
+	 * to write the data.
+	 */
+	OutSaveFile(WriteStream *w, bool isCompressed);
 	virtual ~OutSaveFile();
 
 	/**
@@ -107,6 +118,28 @@ public:
 	* @return The current position indicator, or -1 if an error occurred.
 	 */
 	virtual int64 pos() const;
+
+	/**
+	 * Relocate the position in the file
+	 * This is only relevant when creating save files not using compression.
+	 * Also, not all backends support seeking the OutSaveFile yet.
+	 * A good way to check is to try checking the size immediately
+	 * after creating, and only rely on the seek method if size
+	 * returns 0
+	 * @return True if the seeking was able to be done
+	 */
+	virtual bool seek(int64 offset, int whence = SEEK_SET);
+
+	/**
+	 * Obtain the current size of the stream, measured in bytes.
+	 * This is only relevant when creating save files not using compression.
+	 *
+	 * If this value is unknown or cannot be computed, -1 is returned.
+	 *
+	 * @return The size of the stream, or -1 if an error occurred,
+	 * such as if the backend doesn't support seeking and size.
+	 */
+	virtual int64 size() const;
 };
 
 /**

--- a/engines/ags/shared/util/file_stream.h
+++ b/engines/ags/shared/util/file_stream.h
@@ -69,11 +69,11 @@ public:
 private:
 	void Open(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode);
 
-	Common::Stream *_file;
+	Common::Stream *_file = nullptr;
 	const FileOpenMode  _openMode;
 	const FileWorkMode  _workMode;
 	Common::MemoryWriteStreamDynamic _writeBuffer;
-	Common::OutSaveFile *_outSave;
+	Common::OutSaveFile *_outSave = nullptr;
 };
 
 } // namespace Shared


### PR DESCRIPTION
As I mentioned on Discord, the commercial AGS game Strangeland uses 300Mb+ save files. Currently, savegames are written to an intermediate memory buffer to allow for seeking to be done backwards to fill out chunk lengths and the offset of the screenshot, and not all backends support seekable write streams yet. But for Strangeland, it needs to be able to write directly to the disk, since for Visual Studio at least, the memory allocator throws a wobbly once I try to allocate more than 150Mb of memory at once.

This pull request has two commits. The first is changing OutSaveFile to derive from SeekableWriteStream rather than just WriteStream. This introduces two methods: seek and pos. In case a given backend doesn't support it, it keeps the internal _wrapped as a WriteStream, and does a dynamic cast to SeekableWriteStream in the seek and pos methods. This allows it to gracefully fail when the wrapped stream doesn't support the methods.

The second commit builds on this with some changes to the AGS FileStream class. In it, when the save file is opened, it tries to do a size() call on it. If the save file's underlying stream doesn't support seeking, size() will return -1, allowing the save code to fall back on using a memory buffer.. with an explicit error if the game being run is Strangeland.
