### PR TITLE
GUI: Fix shading being applied more than once

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -287,7 +287,7 @@ void GuiManager::redraw() {
 	// Tanoku: Do not apply shading more than once when opening many dialogs
 	// on top of each other. Screen ends up being too dark and it's a
 	// performance hog.
-	if (_redrawStatus == kRedrawOpenDialog && _dialogStack.size() > 3)
+	if (_redrawStatus == kRedrawOpenDialog && _dialogStack.size() > 2)
 		shading = ThemeEngine::kShadingNone;
 
 	switch (_redrawStatus) {


### PR DESCRIPTION
Fixes nested GUI dialogs causing background shading to be applied multiple times. This is a regression that occurred between release 1.8.0 and 1.9.0.  The GUI code tries to prevent this by testing the dialog stack count, so presumably the structure changed but this wasn't updated.

To reproduce and see another unintended effect:

1. Click Options (applies shading)
2. Go to MIDI tab
3. Click FluidSynth Settings (bug: applies more shading)
4. Go to the Chorus tab (extra shading goes away on redraw)