### PR TITLE
AGS: recognize alternative name of shell plugin

### DIFF
--- a/engines/ags/plugins/plugin_base.cpp
+++ b/engines/ags/plugins/plugin_base.cpp
@@ -97,7 +97,7 @@ Plugins::PluginBase *pluginOpen(const char *filename) {
 	if (fname.equalsIgnoreCase("AGSPalRender"))
 		return new AGSPalRender::AGSPalRender();
 
-	if (fname.equalsIgnoreCase("ags_shell"))
+	if (fname.equalsIgnoreCase("ags_shell") || fname.equalsIgnoreCase("agsshell"))
 		return new AGSShell::AGSShell();
 
 	if (fname.equalsIgnoreCase("AGSSnowRain") || fname.equalsIgnoreCase("ags_snowrain"))


### PR DESCRIPTION
There is a circulating version of AGS Shell plugin as agsshell.dll
used by some games (Rosewater). Internally it's the same
ags_shell.dll so simply an alias will allow these games to run.
