### PR TITLE
SCUMM: FT: Fix softlock on negative walk destination

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -604,13 +604,13 @@ int Actor::actorWalkStep() {
 			_walkdata.yfrac -= _v3stepThreshold;
 		}
 	} else {
-		tmpX = (_pos.x * (1 << 16)) + _walkdata.xfrac + (_walkdata.deltaXFactor / 256) * _scalex;
+		tmpX = (_pos.x << 16) + _walkdata.xfrac + (_walkdata.deltaXFactor >> 8) * _scalex;
 		_walkdata.xfrac = (uint16)tmpX;
-		_pos.x = (tmpX / (1 << 16));
+		_pos.x = (tmpX >> 16);
 
-		tmpY = (_pos.y * (1 << 16)) + _walkdata.yfrac + (_walkdata.deltaYFactor / 256) * _scaley;
+		tmpY = (_pos.y << 16) + _walkdata.yfrac + (_walkdata.deltaYFactor >> 8) * _scaley;
 		_walkdata.yfrac = (uint16)tmpY;
-		_pos.y = (tmpY / (1 << 16));
+		_pos.y = (tmpY >> 16);
 	}
 
 	if (ABS(_pos.x - _walkdata.cur.x) > distX) {


### PR DESCRIPTION
This commit fixes bug [#12030](https://bugs.scummvm.org/ticket/12030), but to do so it reverts commit [SCUMM: Fix UB shifting negative integers in Actor](https://github.com/scummvm/scummvm/commit/57084b4a1b23e131be7497c4c97c75db060210c9).

I tried comparing the calculations of these two versions of the code and they do indeed give different results when being fed negative values, and while I don't know if that's intentional or not, with my commit I'm restoring the behavior which matches the disassembly, just in case.