### PR TITLE
SCUMM: COMI: Fix bug #12029

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -514,7 +514,7 @@ int Actor::calcMovementFactor(const Common::Point& next) {
 			deltaYFactor = 0;
 		}
 
-		if ((uint)ABS(deltaXFactor) > (_speedx << 16)) {
+		if ((uint)ABS(deltaXFactor >> 16) > _speedx) {
 			deltaXFactor = _speedx << 16;
 			if (diffX < 0)
 				deltaXFactor = -deltaXFactor;


### PR DESCRIPTION
This PR fixes bug [#12029](https://bugs.scummvm.org/ticket/12029). The problem stems from an oversight in `Actor::calcMovementFactor()`:

 `ABS(deltaXFactor) > (_speedx << 16)` is not the same as `ABS(deltaXFactor >> 16) > _speedx`, which is the correct version. This probably went unnoticed because the old calculation pipeline led to slightly wrong (by one or two pixels) values for actor's x and y when walking.

This fix was taken from the disassemblies for COMI, DIG and FT, and it appears to be working fine for old SCUMM versions (I have tried at least MI2 and DOTT).