### PR TITLE
BACKENDS: Save files support seeking on all backends

### DIFF
--- a/backends/fs/abstract-fs.h
+++ b/backends/fs/abstract-fs.h
@@ -190,7 +190,7 @@ public:
 	 *
 	 * @return pointer to the stream object, 0 in case of a failure
 	 */
-	virtual Common::WriteStream *createWriteStream() = 0;
+	virtual Common::SeekableWriteStream *createWriteStream() = 0;
 
 	/**
 	* Creates a directory referred by this node.

--- a/backends/fs/amigaos/amigaos-fs.cpp
+++ b/backends/fs/amigaos/amigaos-fs.cpp
@@ -380,7 +380,7 @@ Common::SeekableReadStream *AmigaOSFilesystemNode::createReadStream() {
 }
 
 
-Common::WriteStream *AmigaOSFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *AmigaOSFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/amigaos/amigaos-fs.h
+++ b/backends/fs/amigaos/amigaos-fs.h
@@ -115,7 +115,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream();
 	virtual bool createDirectory();
 };
 

--- a/backends/fs/chroot/chroot-fs.cpp
+++ b/backends/fs/chroot/chroot-fs.cpp
@@ -96,7 +96,7 @@ Common::SeekableReadStream *ChRootFilesystemNode::createReadStream() {
 	return _realNode->createReadStream();
 }
 
-Common::WriteStream *ChRootFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *ChRootFilesystemNode::createWriteStream() {
 	return _realNode->createWriteStream();
 }
 

--- a/backends/fs/chroot/chroot-fs.h
+++ b/backends/fs/chroot/chroot-fs.h
@@ -48,7 +48,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream();
 	virtual bool createDirectory();
 
 private:

--- a/backends/fs/morphos/morphos-fs.cpp
+++ b/backends/fs/morphos/morphos-fs.cpp
@@ -353,7 +353,7 @@ Common::SeekableReadStream *MorphOSFilesystemNode::createReadStream() {
 	return readStream;
 }
 
-Common::WriteStream *MorphOSFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *MorphOSFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/morphos/morphos-fs.h
+++ b/backends/fs/morphos/morphos-fs.h
@@ -116,7 +116,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream();
 	virtual bool createDirectory();
 };
 

--- a/backends/fs/n64/n64-fs.cpp
+++ b/backends/fs/n64/n64-fs.cpp
@@ -156,7 +156,7 @@ Common::SeekableReadStream *N64FilesystemNode::createReadStream() {
 	return RomfsStream::makeFromPath(getPath(), false);
 }
 
-Common::WriteStream *N64FilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *N64FilesystemNode::createWriteStream() {
 	return RomfsStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/n64/n64-fs.h
+++ b/backends/fs/n64/n64-fs.h
@@ -72,7 +72,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream();
 	virtual bool createDirectory();
 };
 

--- a/backends/fs/n64/romfsstream.h
+++ b/backends/fs/n64/romfsstream.h
@@ -28,7 +28,7 @@
 #include "common/stream.h"
 #include "common/str.h"
 
-class RomfsStream : public Common::SeekableReadStream, public Common::WriteStream, public Common::NonCopyable {
+class RomfsStream : public Common::SeekableReadStream, public Common::SeekableWriteStream, public Common::NonCopyable {
 protected:
 	/** File handle to the actual file. */
 	void *_handle;

--- a/backends/fs/posix-drives/posix-drives-fs.cpp
+++ b/backends/fs/posix-drives/posix-drives-fs.cpp
@@ -87,7 +87,7 @@ Common::SeekableReadStream *DrivePOSIXFilesystemNode::createReadStream() {
 	return readStream;
 }
 
-Common::WriteStream *DrivePOSIXFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *DrivePOSIXFilesystemNode::createWriteStream() {
 	PosixIoStream *writeStream = PosixIoStream::makeFromPath(getPath(), true);
 
 	configureStream(writeStream);

--- a/backends/fs/posix-drives/posix-drives-fs.h
+++ b/backends/fs/posix-drives/posix-drives-fs.h
@@ -62,7 +62,7 @@ public:
 
 	// AbstractFSNode API
 	Common::SeekableReadStream *createReadStream() override;
-	Common::WriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream() override;
 	AbstractFSNode *getChild(const Common::String &n) const override;
 	bool getChildren(AbstractFSList &list, ListMode mode, bool hidden) const override;
 	AbstractFSNode *getParent() const override;

--- a/backends/fs/posix/posix-fs.cpp
+++ b/backends/fs/posix/posix-fs.cpp
@@ -297,7 +297,7 @@ Common::SeekableReadStream *POSIXFilesystemNode::createReadStream() {
 	return PosixIoStream::makeFromPath(getPath(), false);
 }
 
-Common::WriteStream *POSIXFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *POSIXFilesystemNode::createWriteStream() {
 	return PosixIoStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/posix/posix-fs.h
+++ b/backends/fs/posix/posix-fs.h
@@ -67,7 +67,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream();
 	virtual bool createDirectory();
 
 protected:

--- a/backends/fs/psp/psp-fs.cpp
+++ b/backends/fs/psp/psp-fs.cpp
@@ -231,10 +231,10 @@ Common::SeekableReadStream *PSPFilesystemNode::createReadStream() {
 	return Common::wrapBufferedSeekableReadStream(stream, READ_BUFFER_SIZE, DisposeAfterUse::YES);
 }
 
-Common::WriteStream *PSPFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *PSPFilesystemNode::createWriteStream() {
 	const uint32 WRITE_BUFFER_SIZE = 1024;
 
-	Common::WriteStream *stream = PspIoStream::makeFromPath(getPath(), true);
+	Common::SeekableWriteStream *stream = PspIoStream::makeFromPath(getPath(), true);
 
 	return Common::wrapBufferedWriteStream(stream, WRITE_BUFFER_SIZE);
 }

--- a/backends/fs/psp/psp-fs.h
+++ b/backends/fs/psp/psp-fs.h
@@ -64,7 +64,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream();
 	virtual bool createDirectory();
 };
 

--- a/backends/fs/psp/psp-stream.h
+++ b/backends/fs/psp/psp-stream.h
@@ -33,7 +33,7 @@
 /**
  *  Class to handle special suspend/resume needs of PSP IO Streams
  */
-class PspIoStream : public Common::SeekableReadStream, public Common::WriteStream, public Common::NonCopyable, public Suspendable {
+class PspIoStream : public Common::SeekableReadStream, public Common::SeekableWriteStream, public Common::NonCopyable, public Suspendable {
 protected:
 	SceUID _handle;		// file handle
 	Common::String _path;

--- a/backends/fs/riscos/riscos-fs.cpp
+++ b/backends/fs/riscos/riscos-fs.cpp
@@ -210,7 +210,7 @@ Common::SeekableReadStream *RISCOSFilesystemNode::createReadStream() {
 	return StdioStream::makeFromPath(getPath(), false);
 }
 
-Common::WriteStream *RISCOSFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *RISCOSFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/riscos/riscos-fs.h
+++ b/backends/fs/riscos/riscos-fs.h
@@ -67,7 +67,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream();
 	virtual bool createDirectory();
 private:
 	/**

--- a/backends/fs/symbian/symbian-fs.cpp
+++ b/backends/fs/symbian/symbian-fs.cpp
@@ -228,7 +228,7 @@ Common::SeekableReadStream *SymbianFilesystemNode::createReadStream() {
 	return SymbianStdioStream::makeFromPath(getPath(), false);
 }
 
-Common::WriteStream *SymbianFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *SymbianFilesystemNode::createWriteStream() {
 	return SymbianStdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/symbian/symbian-fs.h
+++ b/backends/fs/symbian/symbian-fs.h
@@ -65,7 +65,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream();
 	virtual bool createDirectory();
 };
 

--- a/backends/fs/symbian/symbianstream.h
+++ b/backends/fs/symbian/symbianstream.h
@@ -28,7 +28,7 @@
 #include "common/stream.h"
 #include "common/str.h"
 
-class SymbianStdioStream : public Common::SeekableReadStream, public Common::WriteStream, public Common::NonCopyable {
+class SymbianStdioStream : public Common::SeekableReadStream, public Common::SeekableWriteStream, public Common::NonCopyable {
 protected:
 	/** File handle to the actual file. */
 	void *_handle;

--- a/backends/fs/wii/wii-fs.cpp
+++ b/backends/fs/wii/wii-fs.cpp
@@ -209,7 +209,7 @@ Common::SeekableReadStream *WiiFilesystemNode::createReadStream() {
 	return readStream;
 }
 
-Common::WriteStream *WiiFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *WiiFilesystemNode::createWriteStream() {
 	StdioStream *writeStream = StdioStream::makeFromPath(getPath(), true);
 
 	// disable newlib's buffering, the device libraries handle caching

--- a/backends/fs/wii/wii-fs.h
+++ b/backends/fs/wii/wii-fs.h
@@ -68,7 +68,7 @@ public:
 	virtual AbstractFSNode *getParent() const override;
 
 	virtual Common::SeekableReadStream *createReadStream() override;
-	virtual Common::WriteStream *createWriteStream() override;
+	virtual Common::SeekableWriteStream *createWriteStream() override;
 	virtual bool createDirectory() override;
 };
 

--- a/backends/fs/windows/windows-fs.cpp
+++ b/backends/fs/windows/windows-fs.cpp
@@ -234,7 +234,7 @@ Common::SeekableReadStream *WindowsFilesystemNode::createReadStream() {
 	return StdioStream::makeFromPath(getPath(), false);
 }
 
-Common::WriteStream *WindowsFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *WindowsFilesystemNode::createWriteStream() {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -79,7 +79,7 @@ public:
 	virtual AbstractFSNode *getParent() const override;
 
 	virtual Common::SeekableReadStream *createReadStream() override;
-	virtual Common::WriteStream *createWriteStream() override;
+	virtual Common::SeekableWriteStream *createWriteStream() override;
 	virtual bool createDirectory() override;
 
 private:

--- a/backends/platform/dc/dc-fs.cpp
+++ b/backends/platform/dc/dc-fs.cpp
@@ -56,7 +56,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::WriteStream *createWriteStream() { return 0; }
+	virtual Common::SeekableWriteStream *createWriteStream() { return 0; }
 	virtual bool createDirectory() { return false; }
 
 	static AbstractFSNode *makeFileNodePath(const Common::String &path);

--- a/backends/saves/default/default-saves.cpp
+++ b/backends/saves/default/default-saves.cpp
@@ -168,7 +168,7 @@ Common::OutSaveFile *DefaultSaveFileManager::openForSaving(const Common::String 
 	}
 
 	// Open the file for saving.
-	Common::WriteStream *const sf = fileNode.createWriteStream();
+	Common::SeekableWriteStream *const sf = fileNode.createWriteStream();
 	if (!sf)
 		return nullptr;
 	Common::OutSaveFile *const result = new Common::OutSaveFile(compress ? Common::wrapCompressedWriteStream(sf) : sf);

--- a/backends/saves/savefile.cpp
+++ b/backends/saves/savefile.cpp
@@ -56,6 +56,30 @@ int64 OutSaveFile::pos() const {
 	return _wrapped->pos();
 }
 
+bool OutSaveFile::seek(int64 offset, int whence) {
+	Common::SeekableWriteStream *sws =
+		dynamic_cast<Common::SeekableWriteStream *>(_wrapped);
+
+	if (sws) {
+		return sws->seek(offset, whence);
+	} else {
+		warning("Seeking isn't supported for compressed save files");
+		return false;
+	}
+}
+
+int64 OutSaveFile::size() const {
+	Common::SeekableWriteStream *sws =
+		dynamic_cast<Common::SeekableWriteStream *>(_wrapped);
+
+	if (sws) {
+		return sws->size();
+	} else {
+		warning("Size isn't supported for compressed save files");
+		return -1;
+	}
+}
+
 bool SaveFileManager::copySavefile(const String &oldFilename, const String &newFilename, bool compress) {
 	InSaveFile *inFile = 0;
 	OutSaveFile *outFile = 0;

--- a/common/bufferedstream.h
+++ b/common/bufferedstream.h
@@ -80,6 +80,7 @@ SeekableReadStream *wrapBufferedSeekableReadStream(SeekableReadStream *parentStr
  * @param bufSize             Size of the buffer.
  */
 
+SeekableWriteStream *wrapBufferedWriteStream(SeekableWriteStream *parentStream, uint32 bufSize);
 WriteStream *wrapBufferedWriteStream(WriteStream *parentStream, uint32 bufSize);
 
 /** @} */

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -142,7 +142,7 @@ SeekableReadStream *FSNode::createReadStream() const {
 	return _realNode->createReadStream();
 }
 
-WriteStream *FSNode::createWriteStream() const {
+SeekableWriteStream *FSNode::createWriteStream() const {
 	if (_realNode == nullptr)
 		return nullptr;
 

--- a/common/fs.h
+++ b/common/fs.h
@@ -46,6 +46,7 @@ namespace Common {
 class FSNode;
 class SeekableReadStream;
 class WriteStream;
+class SeekableWriteStream;
 
 /**
  * List of multiple file system nodes. For example, the contents of a given directory.
@@ -238,7 +239,7 @@ public:
 	 *
 	 * @return Pointer to the stream object, 0 in case of a failure.
 	 */
-	WriteStream *createWriteStream() const;
+	SeekableWriteStream *createWriteStream() const;
 
 	/**
 	 * Create a directory referred by this node. This assumes that this

--- a/common/savefile.h
+++ b/common/savefile.h
@@ -52,7 +52,7 @@ typedef SeekableReadStream InSaveFile;
  * That typically means "save games", but also includes things like the
  * IQ points in Indy3.
  */
-class OutSaveFile: public WriteStream {
+class OutSaveFile: public SeekableWriteStream {
 protected:
 	WriteStream *_wrapped; /*!< @todo Doc required. */
 
@@ -107,6 +107,18 @@ public:
 	* @return The current position indicator, or -1 if an error occurred.
 	 */
 	virtual int64 pos() const;
+
+	/**
+	 * Seeks to a new position within the file.
+	 * This is only supported when creating uncompressed save files.
+	 */
+	bool seek(int64 offset, int whence) override;
+
+	/**
+	 * Returns the size of the save file
+	 * This is only supported when creating uncompressed save files.
+	 */
+	int64 size() const override;
 };
 
 /**

--- a/engines/ags/shared/util/file_stream.h
+++ b/engines/ags/shared/util/file_stream.h
@@ -23,7 +23,6 @@
 #ifndef AGS_SHARED_UTIL_FILE_STREAM_H
 #define AGS_SHARED_UTIL_FILE_STREAM_H
 
-#include "common/memstream.h"
 #include "common/savefile.h"
 #include "common/stream.h"
 #include "ags/shared/util/data_stream.h"
@@ -71,8 +70,6 @@ private:
 
 	Common::Stream *_file;
 	const FileWorkMode  _workMode;
-	Common::MemoryWriteStreamDynamic _writeBuffer;
-	Common::OutSaveFile *_outSave;
 };
 
 } // namespace Shared


### PR DESCRIPTION
This is a cleaner implementation of my prior pull request for AGS Strangeland that should implement save file seeking across all the backends. Given that we've already integrated in a change to the stream class for 64-bit file support, I think it's the most opportune time to make this change as well. AGS isn't the first engine that's needed to do seeking within the save files being written out, and it's previously required hacky workarounds, like writing data to a MemoryWriteStreamDynamic first and then dumping out to the save files. Now, that will no longer be required.

The pull request is two main parts:
1) Enhancing the file system node createWriteStream() to return a SeekableWriteStream. Most of the backends instantiate a write stream directly using StdIOStream or a class that derives from it, so they didn't require much changes. As for the few remaining ones, the most common was to use a BufferedFileStream wrapper. So I enhanced the class to support SeekableWriteStream as well.
2) OutSaveFile is enhanced to derive from SeekableWriteStream as well. OutSaveFile still takes in a plain WriteStream, because the GZip compressed write stream doesn't support seeking. As with the prior PR, OutSaveFile's seek and size methods try casting the wrapped stream to a SeekableWriteStream, and only pass on the method call if that's successfully.

Finally, the AGS commit is also present to clean up the FileStream class, since the save file can be directly written to.