### PR TITLE
CONFIGURE: Do not pass --prefix to sdl2-config

### DIFF
--- a/configure
+++ b/configure
@@ -462,11 +462,6 @@ find_sdlconfig() {
 			if test -f "$path_dir/$sdlconfig" ; then
 				_sdlconfig="$path_dir/$sdlconfig"
 				echo $_sdlconfig
-				# Save the prefix
-				_sdlpath=$path_dir
-				if test `basename $path_dir` = bin || test `basename $path_dir` = sbin ; then
-					_sdlpath=`dirname $path_dir`
-				fi
 				# break at first sdl-config found in path
 				break 2
 			fi
@@ -3740,11 +3735,11 @@ fi
 #
 if test "$_sdl" = auto ; then
 	find_sdlconfig
-	append_var SDL_CFLAGS "`$_sdlconfig --prefix="$_sdlpath" --cflags`"
+	append_var SDL_CFLAGS "`$_sdlconfig --cflags`"
 	if test "$_static_build" = yes ; then
-		append_var SDL_LIBS "`$_sdlconfig --prefix="$_sdlpath" --static-libs`"
+		append_var SDL_LIBS "`$_sdlconfig --static-libs`"
 	else
-		append_var SDL_LIBS "`$_sdlconfig --prefix="$_sdlpath" --libs`"
+		append_var SDL_LIBS "`$_sdlconfig --libs`"
 	fi
 	_sdlversion=`$_sdlconfig --version`
 


### PR DESCRIPTION
sdl2-config should return the correct paths without it. Trying to determine
the path by name lookup is error-prone.

For example, if both the host and a cross-toolchain have sdl2 installed,
the host executable is typically /usr/bin/sdl2-config, and the
cross-toolchain is <triplet>-sdl2-config and
/path/to/toolchain/triplet/bin/sdl2-config.

The toolchain bin path should not be part of PATH, because this can cause
clashes when building for the host (depends on the PATH order, and if the
tool exists on both).

And even if we do add the toolchain bin path, like we currently do at least
on MXE container, if the host path comes before the toolchain then the
<triplet>-sdl2-config will be detected, but this executable *is not* in the
directory that relates to this toolchain, but in the host bin (for example,
/opt/mxe/bin), so we pass the wrong path to --prefix and sdl2 breaks.

This only worked on buildbot because the lookup for mingw was sdl-config
instead of sdl2-config, and sdl-config just doesn't exist on the system.
