### PR TITLE
SCUMM: Restore missing cigar smoke to captain Smirk's close-up

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -444,7 +444,25 @@ void ScummEngine_v5::o5_actorOps() {
 			getVarOrDirectByte(PARAM_1);
 			break;
 		case 1:			// SO_COSTUME
-			a->setActorCostume(getVarOrDirectByte(PARAM_1));
+			i = getVarOrDirectByte(PARAM_1);
+
+			// WORKAROUND: In the VGA floppy version of the Monkey
+			// Island 1, there are two different costumes for the
+			// captain Smirk close-up: 0 for when the game is run
+			// from floppies, and 76 for when the game is run from
+			// hard disk, I believe.
+			//
+			// Costume 0 doesn't have any cigar smoke, perhaps to
+			// cut down on disk access.
+			//
+			// But in the VGA CD version, only costume 0 is used
+			// and the close-up is missing the cigar smoke.
+
+			if (_game.id == GID_MONKEY && _currentRoom == 76 && act == 12 && i == 0) {
+				i = 76;
+			}
+
+			a->setActorCostume(i);
 			break;
 		case 2:			// SO_STEP_DIST
 			i = getVarOrDirectByte(PARAM_1);
@@ -1452,12 +1470,32 @@ void ScummEngine_v5::o5_pseudoRoom() {
 }
 
 void ScummEngine_v5::o5_putActor() {
-	int x, y;
-	Actor *a;
+	int act, x, y;
 
-	a = derefActor(getVarOrDirectByte(PARAM_1), "o5_putActor");
+	act = getVarOrDirectByte(PARAM_1);
 	x = getVarOrDirectWord(PARAM_2);
 	y = getVarOrDirectWord(PARAM_3);
+
+	// WORKAROUND: When enabling the cigar smoke in the captain Smirk
+	// close-up, it turns out that the coordinates were changed in the CD
+	// version's script for no apparent reason. (Were they taken from the
+	// EGA version?)
+	//
+	// The coordinates below are taken from the VGA floppy version. The
+	// "Ultimate Talkie" version also corrects the positions, but uses
+	// other coordinates. The difference is never more than a single pixel,
+	// so there's not much reason to correct those.
+
+	if (_game.id == GID_MONKEY && _currentRoom == 76 && act == 12) {
+		if (x == 176 && y == 80) {
+			x = 174;
+			y = 86;
+		} else if (x == 176 && y == 78) {
+			x = 172;
+		}
+	}
+
+	Actor *a = derefActor(act, "o5_putActor");
 	a->putActor(x, y);
 }
 


### PR DESCRIPTION
In the EGA and VGA floppy versions, the close-up of captain Smirk has animated cigar smoke. This is missing from the VGA CD version. This pull request fixes that. (Note that it's already fixed in the "Ultimate Talkie" version, but my fix should not interfere with that.)

The animated smoke is set up by the entry script for room 76. In the VGA floppy version (I don't have the EGA one) it looks like this:

```
[001A] (A8) if (VAR_FIXEDDISK) {
[001F] (13)   ActorOps(12,[Costume(76)]);
[0024] (18) } else {
[0027] (13)   ActorOps(12,[Costume(0)]);
[002C] (**) }
[002C] (13) ActorOps(12,[Init(),Palette(2,3),Palette(9,3),Palette(3,7)]);
[0039] (5D) setClass(12,[150,148]);
[0043] (11) animateCostume(12,250);
[0046] (2D) putActorInRoom(12,76);
[0049] (01) putActor(12,172,78);
[004F] (11) animateCostume(12,6);
```

I think this means that when playing the game from floppy, you get costume 0 which doesn't have any animation for the smoke. Perhaps to cut down on disc accesses? In the CD version, it looks like this:

```
[0000] (13) ActorOps(12,[Costume(0)]);
[0005] (13) ActorOps(12,[Init(),Palette(2,3),Palette(9,3),Palette(3,7),IgnoreBoxes(),NeverZClip()]);
[0014] (11) animateCostume(12,250);
[0017] (2D) putActorInRoom(12,76);
[001A] (01) putActor(12,172,78);
[0020] (11) animateCostume(12,6);
```

So it _always_ gets the non-animated costume. Oops. Furthermore, the position of the smoke has been changed for the worse in a few spots. I've adjusted them to match the floppy version. This is handled by script 57. The whole scene can be tested with boot param 888.

The "Ultimate Talkie" version also corrects the position of the smoke, but uses slightly different positions than the floppy version. The difference is never more than a single pixel, so I see no reason to change that here.

The two versions use different colors for the smoke. I see no reason to change that, since both look fine to me. This is what the floppy version looks like:

![scummvm-monkeyvga-00000](https://user-images.githubusercontent.com/601765/127746483-fa360c24-8f64-483b-81bc-c57f0a3fed78.png)

And this is what the CD version looks like, with this pull request:

![scummvm-monkey1-00000](https://user-images.githubusercontent.com/601765/127746482-16d308a1-54ed-4786-b021-7cdd665e07c1.png)
