### PR TITLE
Change the default for useEllipsis to false in Font::drawString

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -849,7 +849,7 @@ void OpenGLGraphicsManager::osdMessageUpdateSurface() {
 	for (uint i = 0; i < osdLines.size(); ++i) {
 		font->drawString(dst, osdLines[i],
 		                 0, i * lineHeight + vOffset + lineSpacing, width,
-		                 white, Graphics::kTextAlignCenter);
+		                 white, Graphics::kTextAlignCenter, 0, true);
 	}
 
 	_osdMessageSurface->updateGLTexture();

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -2217,7 +2217,7 @@ void SurfaceSdlGraphicsManager::displayMessageOnOSD(const Common::U32String &msg
 		font->drawString(&dst, lines[i],
 			0, 0 + i * lineHeight + vOffset + lineSpacing, width,
 			SDL_MapRGB(_osdMessageSurface->format, 255, 255, 255),
-			Graphics::kTextAlignCenter);
+			Graphics::kTextAlignCenter, 0, true);
 	}
 
 	// Finished drawing, so unlock the OSD message surface

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -690,7 +690,7 @@ void OSystem_3DS::displayMessageOnOSD(const Common::U32String &msg) {
 		font->drawString(&_osdMessage, lines[i],
 		                 0, 0 + i * lineHeight + vOffset + lineSpacing, width,
 		                 _pfDefaultTexture.RGBToColor(255, 255, 255),
-		                 Graphics::kTextAlignCenter);
+		                 Graphics::kTextAlignCenter, 0, true);
 	}
 
 	_osdMessageEndTime = getMillis(true) + kOSDMessageDuration;

--- a/backends/vkeybd/virtual-keyboard-gui.cpp
+++ b/backends/vkeybd/virtual-keyboard-gui.cpp
@@ -441,7 +441,7 @@ void VirtualKeyboardGUI::updateDisplay() {
 
 	// draw to display surface
 	_dispSurface.fillRect(Rect(_dispSurface.w, _dispSurface.h), _dispBackColor);
-	_dispFont->drawString(&_dispSurface, dispText, 0, 0, _dispSurface.w, _dispForeColor);
+	_dispFont->drawString(&_dispSurface, dispText, 0, 0, _dispSurface.w, _dispForeColor, Graphics::kTextAlignLeft, 0, true);
 
 	String beforeCaret(wholeText.c_str() + _dispI, wholeText.c_str() + cursorPos);
 	_caretX = _dispFont->getStringWidth(beforeCaret);

--- a/graphics/font.h
+++ b/graphics/font.h
@@ -206,13 +206,13 @@ public:
 	 * @param useEllipsis  Use ellipsis if needed to fit the string in the area.
 	 *
 	 */
-	void drawString(Surface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = true) const;
+	void drawString(Surface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false) const;
 	/** @overload */
-	void drawString(Surface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = true) const;
+	void drawString(Surface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false) const;
 	/** @overload */
-	void drawString(ManagedSurface *dst, const Common::String &str, int x, int _y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = true) const;
+	void drawString(ManagedSurface *dst, const Common::String &str, int x, int _y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false) const;
 	/** @overload */
-	void drawString(ManagedSurface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = true) const;
+	void drawString(ManagedSurface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false) const;
 
 	/**
 	 * Compute and return the width of the string @p str when rendered using this font.

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1037,12 +1037,12 @@ bool MacMenu::draw(ManagedSurface *g, bool forceRedraw) {
 			int accOff = _align == kTextAlignRight ? it->bbox.width() - _font->getStringWidth(it->unicodeText) : 0;
 			Common::UnicodeBiDiText utxt(it->unicodeText);
 
-			_font->drawString(&_screen, utxt.visual, x, y, it->bbox.width(), color, _align);
+			_font->drawString(&_screen, utxt.visual, x, y, it->bbox.width(), color, _align, 0, true);
 			underlineAccelerator(&_screen, _font, utxt, x + accOff, y, it->shortcutPos, color);
 		} else {
 			const Font *font = getMenuFont(it->style);
 
-			font->drawString(&_screen, it->text, x, y, it->bbox.width(), color);
+			font->drawString(&_screen, it->text, x, y, it->bbox.width(), color, Graphics::kTextAlignLeft, 0, true);
 		}
 	}
 
@@ -1121,12 +1121,12 @@ void MacMenu::renderSubmenu(MacMenuSubMenu *menu, bool recursive) {
 
 			if (menu->items[i]->unicode) {
 				Common::UnicodeBiDiText utxt(unicodeText);
-				_font->drawString(s, utxt.visual, tx, ty, r->width(), color, _align);
+				_font->drawString(s, utxt.visual, tx, ty, r->width(), color, _align, 0, true);
 				underlineAccelerator(s, _font, utxt, tx + accOff, ty, shortcutPos, color);
 			} else {
 				const Font *font = getMenuFont(menu->items[i]->style);
 
-				font->drawString(s, text, tx, ty, r->width(), color);
+				font->drawString(s, text, tx, ty, r->width(), color, Graphics::kTextAlignLeft, 0, true);
 			}
 
 			if (menu->items[i]->checked) {

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -914,10 +914,10 @@ void MacText::render(int from, int to, int shadow) {
 
 			if (_textLines[i].chunks[j].plainByteMode()) {
 				Common::String str = _textLines[i].chunks[j].getEncodedText();
-				_textLines[i].chunks[j].getFont()->drawString(surface, str, xOffset, _textLines[i].y + yOffset, w, shadow ? _wm->_colorBlack : _textLines[i].chunks[j].fgcolor);
+				_textLines[i].chunks[j].getFont()->drawString(surface, str, xOffset, _textLines[i].y + yOffset, w, shadow ? _wm->_colorBlack : _textLines[i].chunks[j].fgcolor, Graphics::kTextAlignLeft, 0, true);
 				xOffset += _textLines[i].chunks[j].getFont()->getStringWidth(str);
 			} else {
-				_textLines[i].chunks[j].getFont()->drawString(surface, convertBiDiU32String(_textLines[i].chunks[j].text), xOffset, _textLines[i].y + yOffset, w, shadow ? _wm->_colorBlack : _textLines[i].chunks[j].fgcolor);
+				_textLines[i].chunks[j].getFont()->drawString(surface, convertBiDiU32String(_textLines[i].chunks[j].text), xOffset, _textLines[i].y + yOffset, w, shadow ? _wm->_colorBlack : _textLines[i].chunks[j].fgcolor, Graphics::kTextAlignLeft, 0, true);
 				xOffset += _textLines[i].chunks[j].getFont()->getStringWidth(_textLines[i].chunks[j].text);
 			}
 		}


### PR DESCRIPTION
This change was made for a couple of reasons:
 - The default is now consistent with the one in Font::getBoundingBox
 - Engines are unlikely to want ellipsis

I checked the current use of `Font::drawString`:
 - The GUI always specify if it wants ellipses or not. So changing the default does not impact this code.
 - The OSD and virtual keyboard used the default and I changed the code to continue using ellipsis if needed.
 - The MacGUI code (`MacMenu` and `MacText`) used the default and  I changed the code to continue using ellipsis if needed (except for the `MacMenu` accelerator string). I am not familiar with this code, and not sure if it should use ellipsis or not. So I would be happy to change it if you think I got it wrong.
 - The engines always (or almost always - I did not check all the usage) use the default. But I assumed no engines wants ellipsis, so did not change any of the calls there.

This pull request fixes for example the menu in Myst ME:
 
Current master:
![image](https://user-images.githubusercontent.com/552105/127748623-6faced4e-4d21-4a2a-9338-03e07e03001c.png)

With this pull request:
![image](https://user-images.githubusercontent.com/552105/127748627-7a5b781e-3057-42e4-a59e-0823da37606f.png)
