### PR TITLE
CONFIGURE: Partially revert recent mingw change

### DIFF
--- a/configure
+++ b/configure
@@ -3414,7 +3414,7 @@ if test -n "$_host"; then
 			_zlib=yes
 			;;
 		*mingw32*)
-			_sdlconfig=$_host-sdl2-config
+			_sdlconfig=$_host-sdl-config
 			_libcurlconfig=$_host-curl-config
 			_pkgconfig=$_host-pkg-config
 			_windres=$_host-windres


### PR DESCRIPTION
See the commit message of a6ded8907570bb4b14101d67f076968f0775f460 for the
gory details. Until we come up with a proper fix, revert that part to make
it compile again.
