### PR TITLE
CONFIGURE: Do not pass --prefix to sdl2-config

### DIFF
--- a/configure
+++ b/configure
@@ -462,11 +462,6 @@ find_sdlconfig() {
 			if test -f "$path_dir/$sdlconfig" ; then
 				_sdlconfig="$path_dir/$sdlconfig"
 				echo $_sdlconfig
-				# Save the prefix
-				_sdlpath=$path_dir
-				if test `basename $path_dir` = bin || test `basename $path_dir` = sbin ; then
-					_sdlpath=`dirname $path_dir`
-				fi
 				# break at first sdl-config found in path
 				break 2
 			fi
@@ -3414,7 +3409,7 @@ if test -n "$_host"; then
 			_zlib=yes
 			;;
 		*mingw32*)
-			_sdlconfig=$_host-sdl-config
+			_sdlconfig=$_host-sdl2-config
 			_libcurlconfig=$_host-curl-config
 			_pkgconfig=$_host-pkg-config
 			_windres=$_host-windres
@@ -3741,11 +3736,11 @@ fi
 #
 if test "$_sdl" = auto ; then
 	find_sdlconfig
-	append_var SDL_CFLAGS "`$_sdlconfig --prefix="$_sdlpath" --cflags`"
+	append_var SDL_CFLAGS "`$_sdlconfig --cflags`"
 	if test "$_static_build" = yes ; then
-		append_var SDL_LIBS "`$_sdlconfig --prefix="$_sdlpath" --static-libs`"
+		append_var SDL_LIBS "`$_sdlconfig --static-libs`"
 	else
-		append_var SDL_LIBS "`$_sdlconfig --prefix="$_sdlpath" --libs`"
+		append_var SDL_LIBS "`$_sdlconfig --libs`"
 	fi
 	_sdlversion=`$_sdlconfig --version`
 


### PR DESCRIPTION
Reapply a6ded8907570bb4b14101d67f076968f0775f460.

This already works with all the platforms on buildbot. The mingw release
environment had a misconfigured sdl2-config, but this should now be
fixed.
