### PR TITLE
COMMON: Fix divide by zero in getRandomNumber()

### DIFF
--- a/common/random.cpp
+++ b/common/random.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include <climits>
+
 #include "common/random.h"
 #include "common/system.h"
 #include "gui/EventRecorder.h"
@@ -46,6 +48,9 @@ void RandomSource::setSeed(uint32 seed) {
 uint RandomSource::getRandomNumber(uint max) {
 	_randSeed = 0xDEADBF03 * (_randSeed + 1);
 	_randSeed = (_randSeed >> 13) | (_randSeed << 19);
+
+	if (max == UINT_MAX)
+		return _randSeed;
 	return _randSeed % (max + 1);
 }
 


### PR DESCRIPTION
Calling RandomSource::getRandomNumber() results in divide by zero
exception when called with max = 4294967295 as max + 1 overflows to zero
and the subsequent modulus operation causes the exception.

Certain game saves in Bladerunner trigger this.