### PR TITLE
SCUMM: Fix findObject(x,y) for DIG and COMI

### DIFF
--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -540,9 +540,15 @@ int ScummEngine::findObject(int x, int y) {
 						return _objs[i].obj_nr;
 				}
 #endif
-				if (_objs[i].x_pos <= x && _objs[i].width + _objs[i].x_pos > x &&
-				    _objs[i].y_pos <= y && _objs[i].height + _objs[i].y_pos > y)
-					return _objs[i].obj_nr;
+				if (_game.id == GID_CMI || _game.id == GID_DIG) {
+					if (_objs[i].x_pos <= x && _objs[i].width + _objs[i].x_pos >= x &&
+						_objs[i].y_pos <= y && _objs[i].height + _objs[i].y_pos >= y)
+						return _objs[i].obj_nr;
+				} else {
+					if (_objs[i].x_pos <= x && _objs[i].width + _objs[i].x_pos > x &&
+						_objs[i].y_pos <= y && _objs[i].height + _objs[i].y_pos > y)
+						return _objs[i].obj_nr;
+				}
 				break;
 			}
 		} while ((_objs[b].state & mask) == a);


### PR DESCRIPTION
Today, while I was testing some sound stuff in COMI, I found out that one of the three destroyable turrets (the farthest one) in the cannon minigame in Part 1 couldn't be destroyed.

...and I took that personally.

Turns out that while Full Throttle (and I believe every previous SCUMM game) indeed did what ScummVM already does when checking for object coordinates, The Dig and COMI use the '>=' operator in place of '>'.

And now, when I try to destroy that turret:

![image](https://user-images.githubusercontent.com/11290886/127902332-17aebf91-ff0d-4286-a125-c10bd6c50b76.png)

Yay!