### PR TITLE
COMMON: Create Path type

### DIFF
--- a/backends/platform/android/asset-archive.cpp
+++ b/backends/platform/android/asset-archive.cpp
@@ -163,11 +163,10 @@ const Common::ArchiveMemberPtr AndroidAssetArchive::getMember(const Common::Path
 }
 
 Common::SeekableReadStream *AndroidAssetArchive::createReadStreamForMember(const Common::Path &path) const {
-	Common::String name = path.toString();
-	if (!hasFile(name)) {
+	if (!hasFile(path)) {
 		return nullptr;
 	}
-	return new AssetInputStream(_am, name);
+	return new AssetInputStream(_am, path.toString());
 }
 
 #endif

--- a/backends/platform/android/asset-archive.cpp
+++ b/backends/platform/android/asset-archive.cpp
@@ -115,7 +115,8 @@ AndroidAssetArchive::AndroidAssetArchive(jobject am) : _hasCached(false) {
 AndroidAssetArchive::~AndroidAssetArchive() {
 }
 
-bool AndroidAssetArchive::hasFile(const Common::String &name) const {
+bool AndroidAssetArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	AAsset *asset = AAssetManager_open(_am, name.c_str(), AASSET_MODE_RANDOM);
 	bool exists = false;
 	if (asset != NULL) {
@@ -156,15 +157,17 @@ int AndroidAssetArchive::listMembers(Common::ArchiveMemberList &member_list) con
 	return count;
 }
 
-const Common::ArchiveMemberPtr AndroidAssetArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr AndroidAssetArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *AndroidAssetArchive::createReadStreamForMember(const Common::String &path) const {
-	if (!hasFile(path)) {
+Common::SeekableReadStream *AndroidAssetArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
+	if (!hasFile(name)) {
 		return nullptr;
 	}
-	return new AssetInputStream(_am, path);
+	return new AssetInputStream(_am, name);
 }
 
 #endif

--- a/backends/platform/android/asset-archive.h
+++ b/backends/platform/android/asset-archive.h
@@ -39,10 +39,10 @@ public:
 	AndroidAssetArchive(jobject am);
 	virtual ~AndroidAssetArchive();
 
-	virtual bool hasFile(const Common::String &name) const override;
+	virtual bool hasFile(const Common::Path &path) const override;
 	virtual int listMembers(Common::ArchiveMemberList &list) const override;
-	virtual const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	virtual Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	virtual const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	virtual Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	AAssetManager *_am;

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -370,12 +370,12 @@ int Win32ResourceArchive::listMembers(Common::ArchiveMemberList &list) const {
 
 const Common::ArchiveMemberPtr Win32ResourceArchive::getMember(const Common::Path &path) const {
 	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name.toString(), this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
 Common::SeekableReadStream *Win32ResourceArchive::createReadStreamForMember(const Common::Path &path) const {
 	Common::String name = path.toString();
-	TCHAR *tName = Win32::stringToTchar(name.toString());
+	TCHAR *tName = Win32::stringToTchar(name);
 	HRSRC resource = FindResource(NULL, tName, MAKEINTRESOURCE(256));
 	free(tName);
 

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -325,10 +325,10 @@ class Win32ResourceArchive final : public Common::Archive {
 public:
 	Win32ResourceArchive();
 
-	virtual bool hasFile(const Common::String &name) const override;
+	virtual bool hasFile(const Common::Path &path) const override;
 	virtual int listMembers(Common::ArchiveMemberList &list) const override;
-	virtual const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	virtual Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	virtual const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	virtual Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 private:
 	typedef Common::List<Common::String> FilenameList;
 
@@ -349,7 +349,8 @@ Win32ResourceArchive::Win32ResourceArchive() {
 	EnumResourceNames(NULL, MAKEINTRESOURCE(256), &EnumResNameProc, (LONG_PTR)this);
 }
 
-bool Win32ResourceArchive::hasFile(const Common::String &name) const {
+bool Win32ResourceArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (FilenameList::const_iterator i = _files.begin(); i != _files.end(); ++i) {
 		if (i->equalsIgnoreCase(name))
 			return true;
@@ -367,12 +368,14 @@ int Win32ResourceArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return count;
 }
 
-const Common::ArchiveMemberPtr Win32ResourceArchive::getMember(const Common::String &name) const {
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+const Common::ArchiveMemberPtr Win32ResourceArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name.toString(), this));
 }
 
-Common::SeekableReadStream *Win32ResourceArchive::createReadStreamForMember(const Common::String &name) const {
-	TCHAR *tName = Win32::stringToTchar(name);
+Common::SeekableReadStream *Win32ResourceArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
+	TCHAR *tName = Win32::stringToTchar(name.toString());
 	HRSRC resource = FindResource(NULL, tName, MAKEINTRESOURCE(256));
 	free(tName);
 

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -205,13 +205,13 @@ void SearchSet::setPriority(const String &name, int priority) {
 	insert(node);
 }
 
-bool SearchSet::hasFile(const String &name) const {
-	if (name.empty())
+bool SearchSet::hasFile(const Path &path) const {
+	if (path.empty())
 		return false;
 
 	ArchiveNodeList::const_iterator it = _list.begin();
 	for (; it != _list.end(); ++it) {
-		if (it->_arc->hasFile(name))
+		if (it->_arc->hasFile(path))
 			return true;
 	}
 
@@ -238,26 +238,26 @@ int SearchSet::listMembers(ArchiveMemberList &list) const {
 	return matches;
 }
 
-const ArchiveMemberPtr SearchSet::getMember(const String &name) const {
-	if (name.empty())
+const ArchiveMemberPtr SearchSet::getMember(const Path &path) const {
+	if (path.empty())
 		return ArchiveMemberPtr();
 
 	ArchiveNodeList::const_iterator it = _list.begin();
 	for (; it != _list.end(); ++it) {
-		if (it->_arc->hasFile(name))
-			return it->_arc->getMember(name);
+		if (it->_arc->hasFile(path))
+			return it->_arc->getMember(path);
 	}
 
 	return ArchiveMemberPtr();
 }
 
-SeekableReadStream *SearchSet::createReadStreamForMember(const String &name) const {
-	if (name.empty())
+SeekableReadStream *SearchSet::createReadStreamForMember(const Path &path) const {
+	if (path.empty())
 		return nullptr;
 
 	ArchiveNodeList::const_iterator it = _list.begin();
 	for (; it != _list.end(); ++it) {
-		SeekableReadStream *stream = it->_arc->createReadStreamForMember(name);
+		SeekableReadStream *stream = it->_arc->createReadStreamForMember(path);
 		if (stream)
 			return stream;
 	}

--- a/common/archive.h
+++ b/common/archive.h
@@ -25,6 +25,7 @@
 
 #include "common/str.h"
 #include "common/list.h"
+#include "common/path.h"
 #include "common/ptr.h"
 #include "common/singleton.h"
 
@@ -107,7 +108,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	virtual bool hasFile(const String &name) const = 0;
+	virtual bool hasFile(const Path &path) const = 0;
 
 	/**
 	 * Add all members of the Archive matching the specified pattern to the list.
@@ -128,7 +129,7 @@ public:
 	/**
 	 * Return an ArchiveMember representation of the given file.
 	 */
-	virtual const ArchiveMemberPtr getMember(const String &name) const = 0;
+	virtual const ArchiveMemberPtr getMember(const Path &path) const = 0;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
@@ -136,7 +137,7 @@ public:
 	 *
 	 * @return The newly created input stream.
 	 */
-	virtual SeekableReadStream *createReadStreamForMember(const String &name) const = 0;
+	virtual SeekableReadStream *createReadStreamForMember(const Path &path) const = 0;
 };
 
 
@@ -251,17 +252,17 @@ public:
 	 */
 	void setPriority(const String& name, int priority);
 
-	virtual bool hasFile(const String &name) const;
+	virtual bool hasFile(const Path &path) const;
 	virtual int listMatchingMembers(ArchiveMemberList &list, const String &pattern) const;
 	virtual int listMembers(ArchiveMemberList &list) const;
 
-	virtual const ArchiveMemberPtr getMember(const String &name) const;
+	virtual const ArchiveMemberPtr getMember(const Path &path) const;
 
 	/**
 	 * Implement createReadStreamForMember from the Archive base class. The current policy is
 	 * opening the first file encountered that matches the name.
 	 */
-	virtual SeekableReadStream *createReadStreamForMember(const String &name) const;
+	virtual SeekableReadStream *createReadStreamForMember(const Path &path) const;
 
 	/**
 	 * Ignore clashes when adding directories. For more details, see the corresponding parameter

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -38,25 +38,25 @@ File::~File() {
 	close();
 }
 
-bool File::open(const String &filename) {
+bool File::open(const Path &filename) {
 	return open(filename, SearchMan);
 }
 
-bool File::open(const String &filename, Archive &archive) {
+bool File::open(const Path &filename, Archive &archive) {
 	assert(!filename.empty());
 	assert(!_handle);
 
 	SeekableReadStream *stream = nullptr;
 
 	if ((stream = archive.createReadStreamForMember(filename))) {
-		debug(8, "Opening hashed: %s", filename.c_str());
+		debug(8, "Opening hashed: %s", filename.toString().c_str());
 	} else if ((stream = archive.createReadStreamForMember(filename + "."))) {
 		// WORKAROUND: Bug #2548: "SIMON1: Game Detection fails"
 		// sometimes instead of "GAMEPC" we get "GAMEPC." (note trailing dot)
-		debug(8, "Opening hashed: %s.", filename.c_str());
+		debug(8, "Opening hashed: %s.", filename.toString().c_str());
 	}
 
-	return open(stream, filename);
+	return open(stream, filename.toString());
 }
 
 bool File::open(const FSNode &node) {
@@ -87,7 +87,7 @@ bool File::open(SeekableReadStream *stream, const String &name) {
 }
 
 
-bool File::exists(const String &filename) {
+bool File::exists(const Path &filename) {
 	if (SearchMan.hasFile(filename)) {
 		return true;
 	} else if (SearchMan.hasFile(filename + ".")) {

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -50,7 +50,7 @@ bool File::open(const Path &filename, Archive &archive) {
 
 	if ((stream = archive.createReadStreamForMember(filename))) {
 		debug(8, "Opening hashed: %s", filename.toString().c_str());
-	} else if ((stream = archive.createReadStreamForMember(filename + "."))) {
+	} else if ((stream = archive.createReadStreamForMember(filename.append(".")))) {
 		// WORKAROUND: Bug #2548: "SIMON1: Game Detection fails"
 		// sometimes instead of "GAMEPC" we get "GAMEPC." (note trailing dot)
 		debug(8, "Opening hashed: %s.", filename.toString().c_str());
@@ -90,7 +90,7 @@ bool File::open(SeekableReadStream *stream, const String &name) {
 bool File::exists(const Path &filename) {
 	if (SearchMan.hasFile(filename)) {
 		return true;
-	} else if (SearchMan.hasFile(filename + ".")) {
+	} else if (SearchMan.hasFile(filename.append("."))) {
 		// WORKAROUND: Bug #2548: "SIMON1: Game Detection fails"
 		// sometimes instead of "GAMEPC" we get "GAMEPC." (note trailing dot)
 		return true;

--- a/common/file.h
+++ b/common/file.h
@@ -64,7 +64,7 @@ public:
 	 * @param	filename	The file to check for.
 	 * @return	True if the file exists, false otherwise.
 	 */
-	static bool exists(const String &filename);
+	static bool exists(const Path &filename);
 
 	/**
 	 * Try to open the file with the given file name, by searching SearchMan.
@@ -73,7 +73,7 @@ public:
 	 * @param	filename	Name of the file to open.
 	 * @return	True if the file was opened successfully, false otherwise.
 	 */
-	virtual bool open(const String &filename);
+	virtual bool open(const Path &filename);
 
 	/**
 	 * Try to open the file with the given file name from within the given archive.
@@ -83,7 +83,7 @@ public:
 	 * @param	archive		Archive in which to search for the file.
 	 * @return	True if the file was opened successfully, false otherwise.
 	 */
-	virtual bool open(const String &filename, Archive &archive);
+	virtual bool open(const Path &filename, Archive &archive);
 
 	/**
 	 * Try to open the file corresponding to the given node. Will check whether the

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -39,12 +39,11 @@ FSNode::FSNode(const Path &p) {
 	assert(g_system);
 	FilesystemFactory *factory = g_system->getFilesystemFactory();
 	AbstractFSNode *tmp = nullptr;
-	String s = p.toString();
 
-	if (s.empty() || s == ".")
+	if (p.empty() || p == Path("."))
 		tmp = factory->makeCurrentDirectoryFileNode();
 	else
-		tmp = factory->makeFileNodePath(s);
+		tmp = factory->makeFileNodePath(p.toString());
 	_realNode = SharedPtr<AbstractFSNode>(tmp);
 }
 

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -240,10 +240,10 @@ const ArchiveMemberPtr FSDirectory::getMember(const Path &path) const {
 	FSNode *node = lookupCache(_fileCache, name);
 
 	if (!node || !node->exists()) {
-		warning("FSDirectory::getMember: '%s' does not exist", name.c_str());
+		warning("FSDirectory::getMember: '%s' does not exist", Common::toPrintable(name).c_str());
 		return ArchiveMemberPtr();
 	} else if (node->isDirectory()) {
-		warning("FSDirectory::getMember: '%s' is a directory", name.c_str());
+		warning("FSDirectory::getMember: '%s' is a directory", Common::toPrintable(name).c_str());
 		return ArchiveMemberPtr();
 	}
 
@@ -260,7 +260,7 @@ SeekableReadStream *FSDirectory::createReadStreamForMember(const Path &path) con
 		return nullptr;
 	SeekableReadStream *stream = node->createReadStream();
 	if (!stream)
-		warning("FSDirectory::createReadStreamForMember: Can't create stream for file '%s'", name.c_str());
+		warning("FSDirectory::createReadStreamForMember: Can't create stream for file '%s'", Common::toPrintable(name).c_str());
 
 	return stream;
 }
@@ -303,12 +303,12 @@ void FSDirectory::cacheDirectoryRecursive(FSNode node, int depth, const Path& pr
 				// Always warn in this case as it's when there are 2 directories at the same place with different case
 				// That means a problem in user installation as lookups are always done case insensitive
 				warning("FSDirectory::cacheDirectory: name clash when building cache, ignoring sub-directory '%s'",
-				        name.c_str());
+				        Common::toPrintable(name).c_str());
 			} else {
 				if (_subDirCache.contains(lowercaseName)) {
 					if (!_ignoreClashes) {
 						warning("FSDirectory::cacheDirectory: name clash when building subDirCache with subdirectory '%s'",
-						        name.c_str());
+						        Common::toPrintable(name).c_str());
 					}
 				}
 				cacheDirectoryRecursive(*it, depth - 1, _flat ? prefix : lowercaseName + DIR_SEPARATOR);
@@ -318,7 +318,7 @@ void FSDirectory::cacheDirectoryRecursive(FSNode node, int depth, const Path& pr
 			if (_fileCache.contains(lowercaseName)) {
 				if (!_ignoreClashes) {
 					warning("FSDirectory::cacheDirectory: name clash when building cache, ignoring file '%s'",
-					        name.c_str());
+					        Common::toPrintable(name).c_str());
 				}
 			} else {
 				_fileCache[lowercaseName] = *it;

--- a/common/fs.h
+++ b/common/fs.h
@@ -102,7 +102,7 @@ public:
 	 * operating system does not support the concept), some other directory is
 	 * used (usually the root directory).
 	 */
-	explicit FSNode(const String &path);
+	explicit FSNode(const Path &path);
 
 	virtual ~FSNode() {}
 
@@ -313,7 +313,7 @@ class FSDirectory : public Archive {
 	FSNode *lookupCache(NodeCache &cache, const String &name) const;
 
 	// cache management
-	void cacheDirectoryRecursive(FSNode node, int depth, const String& prefix) const;
+	void cacheDirectoryRecursive(FSNode node, int depth, const Path& prefix) const;
 
 	// fill cache if not already cached
 	void ensureCached() const;
@@ -324,7 +324,7 @@ public:
 	 * unbound FSDirectory if name is not found in the file system or if the node is not a
 	 * valid directory.
 	 */
-	FSDirectory(const String &name, int depth = 1, bool flat = false,
+	FSDirectory(const Path &name, int depth = 1, bool flat = false,
 	            bool ignoreClashes = false, bool includeDirectories = false);
 	/**
 	 * @overload
@@ -336,12 +336,12 @@ public:
 	 * Create a FSDirectory representing a tree with the specified depth. The parameter
 	 * prefix is prepended to the keys in the cache. See @ref FSDirectory.
 	 */
-	FSDirectory(const String &prefix, const String &name, int depth = 1,
+	FSDirectory(const Path &prefix, const Path &name, int depth = 1,
 	            bool flat = false, bool ignoreClashes = false, bool includeDirectories = false);
 	/**
 	 * @overload
 	 */
-	FSDirectory(const String &prefix, const FSNode &node, int depth = 1,
+	FSDirectory(const Path &prefix, const FSNode &node, int depth = 1,
 	            bool flat = false, bool ignoreClashes = false, bool includeDirectories = false);
 
 	virtual ~FSDirectory();
@@ -355,21 +355,21 @@ public:
 	 * Create a new FSDirectory pointing to a subdirectory of the instance.
 	 * @return A new FSDirectory instance.
 	 */
-	FSDirectory *getSubDirectory(const String &name, int depth = 1, bool flat = false,
+	FSDirectory *getSubDirectory(const Path &name, int depth = 1, bool flat = false,
 	                             bool ignoreClashes = false);
 	/**
 	 * Create a new FSDirectory pointing to a subdirectory of the instance. See FSDirectory
 	 * for an explanation of the prefix parameter.
 	 * @return A new FSDirectory instance.
 	 */
-	FSDirectory *getSubDirectory(const String &prefix, const String &name, int depth = 1,
+	FSDirectory *getSubDirectory(const Path &prefix, const Path &name, int depth = 1,
 	                             bool flat = false, bool ignoreClashes = false);
 
 	/**
 	 * Check for the existence of a file in the cache. A full match of relative path and file name
 	 * is needed for success.
 	 */
-	virtual bool hasFile(const String &name) const;
+	virtual bool hasFile(const Path &path) const;
 
 	/**
 	 * Return a list of matching file names. Pattern can use GLOB wildcards.
@@ -385,13 +385,13 @@ public:
 	 * Get an ArchiveMember representation of the specified file. A full match of relative
 	 * path and file name is needed for success.
 	 */
-	virtual const ArchiveMemberPtr getMember(const String &name) const;
+	virtual const ArchiveMemberPtr getMember(const Path &path) const;
 
 	/**
 	 * Open the specified file. A full match of relative path and file name is needed
 	 * for success.
 	 */
-	virtual SeekableReadStream *createReadStreamForMember(const String &name) const;
+	virtual SeekableReadStream *createReadStreamForMember(const Path &path) const;
 };
 
 /** @} */

--- a/common/installshield_cab.cpp
+++ b/common/installshield_cab.cpp
@@ -64,10 +64,10 @@ public:
 	void close();
 
 	// Archive API implementation
-	virtual bool hasFile(const String &name) const;
+	virtual bool hasFile(const Path &path) const;
 	virtual int listMembers(ArchiveMemberList &list) const;
-	virtual const ArchiveMemberPtr getMember(const String &name) const;
-	virtual SeekableReadStream *createReadStreamForMember(const String &name) const;
+	virtual const ArchiveMemberPtr getMember(const Path &path) const;
+	virtual SeekableReadStream *createReadStreamForMember(const Path &path) const;
 
 private:
 	struct FileEntry {
@@ -217,7 +217,8 @@ void InstallShieldCabinet::close() {
 	_version = 0;
 }
 
-bool InstallShieldCabinet::hasFile(const String &name) const {
+bool InstallShieldCabinet::hasFile(const Path &path) const {
+	String name = path.toString();
 	return _map.contains(name);
 }
 
@@ -228,11 +229,13 @@ int InstallShieldCabinet::listMembers(ArchiveMemberList &list) const {
 	return _map.size();
 }
 
-const ArchiveMemberPtr InstallShieldCabinet::getMember(const String &name) const {
+const ArchiveMemberPtr InstallShieldCabinet::getMember(const Path &path) const {
+	String name = path.toString();
 	return ArchiveMemberPtr(new GenericArchiveMember(name, this));
 }
 
-SeekableReadStream *InstallShieldCabinet::createReadStreamForMember(const String &name) const {
+SeekableReadStream *InstallShieldCabinet::createReadStreamForMember(const Path &path) const {
+	String name = path.toString();
 	if (!_map.contains(name))
 		return nullptr;
 

--- a/common/installshieldv3_archive.cpp
+++ b/common/installshieldv3_archive.cpp
@@ -107,7 +107,8 @@ void InstallShieldV3::close() {
 	_map.clear();
 }
 
-bool InstallShieldV3::hasFile(const Common::String &name) const {
+bool InstallShieldV3::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return _map.contains(name);
 }
 
@@ -118,11 +119,13 @@ int InstallShieldV3::listMembers(Common::ArchiveMemberList &list) const {
 	return _map.size();
 }
 
-const Common::ArchiveMemberPtr InstallShieldV3::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr InstallShieldV3::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *InstallShieldV3::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *InstallShieldV3::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_stream || !_map.contains(name))
 		return nullptr;
 

--- a/common/installshieldv3_archive.h
+++ b/common/installshieldv3_archive.h
@@ -43,10 +43,10 @@ public:
 	bool isOpen() const { return _stream != nullptr; }
 
 	// Common::Archive API implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	struct FileEntry {

--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -140,7 +140,7 @@ bool MacResManager::open(const Path &fileName, Archive &archive) {
 #endif
 
 	// Prefer standalone files first, starting with raw forks
-	SeekableReadStream *stream = archive.createReadStreamForMember(fileName + ".rsrc");
+	SeekableReadStream *stream = archive.createReadStreamForMember(fileName.append(".rsrc"));
 	if (stream && loadFromRawFork(*stream)) {
 		_baseFileName = fileName;
 		return true;
@@ -156,7 +156,7 @@ bool MacResManager::open(const Path &fileName, Archive &archive) {
 	delete stream;
 
 	// Check .bin for MacBinary next
-	stream = archive.createReadStreamForMember(fileName + ".bin");
+	stream = archive.createReadStreamForMember(fileName.append(".bin"));
 	if (stream && loadFromMacBinary(*stream)) {
 		_baseFileName = fileName;
 		return true;
@@ -191,12 +191,12 @@ bool MacResManager::exists(const Path &fileName) {
 		return true;
 
 	// Try the .rsrc extension
-	if (File::exists(fileName + ".rsrc"))
+	if (File::exists(fileName.append(".rsrc")))
 		return true;
 
 	// Check if we have a MacBinary file
 	File tempFile;
-	if (tempFile.open(fileName + ".bin") && isMacBinary(tempFile))
+	if (tempFile.open(fileName.append(".bin")) && isMacBinary(tempFile))
 		return true;
 
 	// Check if we have an AppleDouble file

--- a/common/macresman.h
+++ b/common/macresman.h
@@ -75,7 +75,7 @@ public:
 	 * @note This will check for the raw resource fork, MacBinary, and AppleDouble formats.
 	 * @return True on success
 	 */
-	bool open(const String &fileName);
+	bool open(const Path &fileName);
 
 	/**
 	 * Open a Mac data/resource fork pair from within the given archive.
@@ -85,14 +85,14 @@ public:
 	 * @note This will check for the raw resource fork, MacBinary, and AppleDouble formats.
 	 * @return True on success
 	 */
-	bool open(const String &fileName, Archive &archive);
+	bool open(const Path &fileName, Archive &archive);
 
 	/**
 	 * See if a Mac data/resource fork pair exists.
 	 * @param fileName The base file name of the file
 	 * @return True if either a data fork or resource fork with this name exists
 	 */
-	static bool exists(const String &fileName);
+	static bool exists(const Path &fileName);
 
 	/**
 	 * List all filenames matching pattern for opening with open().
@@ -178,9 +178,9 @@ public:
 	 * Get the base file name of the data/resource fork pair
 	 * @return The base file name of the data/resource fork pair
 	 */
-	String getBaseFileName() const { return _baseFileName; }
+	Path getBaseFileName() const { return _baseFileName; }
 
-	void setBaseFileName(Common::String str) { _baseFileName = str; }
+	void setBaseFileName(Common::Path str) { _baseFileName = str; }
 
 	/**
 	 * Return list of resource IDs with specified type ID
@@ -222,15 +222,15 @@ public:
 
 private:
 	SeekableReadStream *_stream;
-	String _baseFileName;
+	Path _baseFileName;
 
 	bool load(SeekableReadStream &stream);
 
 	bool loadFromRawFork(SeekableReadStream &stream);
 	bool loadFromAppleDouble(SeekableReadStream &stream);
 
-	static String constructAppleDoubleName(String name);
-	static String disassembleAppleDoubleName(String name, bool *isAppleDouble);
+	static Path constructAppleDoubleName(Path name);
+	static Path disassembleAppleDoubleName(Path name, bool *isAppleDouble);
 
 	/**
 	 * Do a sanity check whether the given stream is a raw resource fork.

--- a/common/module.mk
+++ b/common/module.mk
@@ -27,6 +27,7 @@ MODULE_OBJS := \
 	mdct.o \
 	mutex.o \
 	osd_message_queue.o \
+	path.o \
 	platform.o \
 	punycode.o \
 	quicktime.o \

--- a/common/path.cpp
+++ b/common/path.cpp
@@ -1,0 +1,141 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/path.h"
+
+namespace Common {
+
+Path::Path(const Path &path) {
+	_str = path.rawString();
+}
+
+Path::Path(const char *str, char separator) {
+	setString(str, separator);
+}
+
+Path::Path(const String &str, char separator) {
+	setString(str.c_str(), separator);
+}
+
+Path::Path(char c, char separator) {
+	const char str[] = { c, '\0' };
+	setString(str, separator);
+}
+
+void Path::setString(const char *str, char separator) {
+	for (; *str; str++) {
+		if (*str == separator)
+			_str += DIR_SEPARATOR;
+		else
+			_str += *str;
+	}
+}
+
+String Path::toString(char separator) const {
+	String res;
+	for (const char *ptr = _str.c_str(); *ptr; ptr++) {
+		if (*ptr == DIR_SEPARATOR)
+			res += separator;
+		else
+			res += *ptr;
+	}
+	return res;
+}
+
+bool Path::operator==(const Path &x) const {
+	return _str == x.rawString();
+}
+
+bool Path::operator!=(const Path &x) const {
+	return _str != x.rawString();
+}
+
+bool Path::empty() const {
+	return _str.empty();
+}
+
+Path &Path::operator=(const Path &path) {
+	_str = path.rawString();
+	return *this;
+}
+
+Path &Path::operator=(const char *str) {
+	setString(str);
+	return *this;
+}
+
+Path &Path::operator=(const String &str) {
+	setString(str.c_str());
+	return *this;
+}
+
+Path &Path::operator=(char c) {
+	const char str[] = { c, '\0' };
+	setString(str);
+	return *this;
+}
+
+Path &Path::operator+=(const Path &path) {
+	_str += path.rawString();
+	return *this;
+}
+
+Path &Path::operator+=(const char *str) {
+	_str += Path(str).rawString();
+	return *this;
+}
+
+Path &Path::operator+=(const String &str) {
+	_str += Path(str).rawString();
+	return *this;
+}
+
+Path &Path::operator+=(char c) {
+	_str += Path(c).rawString();
+	return *this;
+}
+
+Path operator+(const Path &x, const Path &y) {
+	Path temp(x);
+	temp += y;
+	return temp;
+}
+
+Path operator+(const Path &x, const String &y) {
+	Path temp(x);
+	temp += y;
+	return temp;
+}
+
+Path operator+(const Path &x, const char *y) {
+	Path temp(x);
+	temp += y;
+	return temp;
+}
+
+Path operator+(const Path &x, char y) {
+	Path temp(x);
+	temp += y;
+	return temp;
+}
+
+} // End of namespace Common

--- a/common/path.cpp
+++ b/common/path.cpp
@@ -29,25 +29,11 @@ Path::Path(const Path &path) {
 }
 
 Path::Path(const char *str, char separator) {
-	setString(str, separator);
+	set(str, separator);
 }
 
 Path::Path(const String &str, char separator) {
-	setString(str.c_str(), separator);
-}
-
-Path::Path(char c, char separator) {
-	const char str[] = { c, '\0' };
-	setString(str, separator);
-}
-
-void Path::setString(const char *str, char separator) {
-	for (; *str; str++) {
-		if (*str == separator)
-			_str += DIR_SEPARATOR;
-		else
-			_str += *str;
-	}
+	set(str.c_str(), separator);
 }
 
 String Path::toString(char separator) const {
@@ -79,62 +65,97 @@ Path &Path::operator=(const Path &path) {
 }
 
 Path &Path::operator=(const char *str) {
-	setString(str);
+	set(str);
 	return *this;
 }
 
 Path &Path::operator=(const String &str) {
-	setString(str.c_str());
+	set(str.c_str());
 	return *this;
 }
 
-Path &Path::operator=(char c) {
-	const char str[] = { c, '\0' };
-	setString(str);
+void Path::set(const char *str, char separator) {
+	_str.clear();
+	appendInPlace(str, separator);
+}
+
+Path &Path::appendInPlace(const Path &x) {
+	_str += x.rawString();
 	return *this;
 }
 
-Path &Path::operator+=(const Path &path) {
-	_str += path.rawString();
+Path &Path::appendInPlace(const String &str, char separator) {
+	appendInPlace(str.c_str(), separator);
 	return *this;
 }
 
-Path &Path::operator+=(const char *str) {
-	_str += Path(str).rawString();
+Path &Path::appendInPlace(const char *str, char separator) {
+	for (; *str; str++) {
+		if (*str == separator)
+			_str += DIR_SEPARATOR;
+		else
+			_str += *str;
+	}
 	return *this;
 }
 
-Path &Path::operator+=(const String &str) {
-	_str += Path(str).rawString();
-	return *this;
-}
-
-Path &Path::operator+=(char c) {
-	_str += Path(c).rawString();
-	return *this;
-}
-
-Path operator+(const Path &x, const Path &y) {
-	Path temp(x);
-	temp += y;
+Path Path::append(const Path &x) const {
+	Path temp(*this);
+	temp.appendInPlace(x);
 	return temp;
 }
 
-Path operator+(const Path &x, const String &y) {
-	Path temp(x);
-	temp += y;
+Path Path::append(const String &str, char separator) const {
+	return append(str.c_str(), separator);
+}
+
+Path Path::append(const char *str, char separator) const {
+	Path temp(*this);
+	temp.appendInPlace(str, separator);
 	return temp;
 }
 
-Path operator+(const Path &x, const char *y) {
-	Path temp(x);
-	temp += y;
+Path &Path::joinInPlace(const Path &x) {
+	if (x.empty())
+		return *this;
+
+	if (!_str.empty() && _str.lastChar() != DIR_SEPARATOR && x.rawString().firstChar() != DIR_SEPARATOR)
+		_str += DIR_SEPARATOR;
+
+	_str += x.rawString();
+
+	return *this;
+}
+
+Path &Path::joinInPlace(const String &str, char separator) {
+	return joinInPlace(str.c_str(), separator);
+}
+
+Path &Path::joinInPlace(const char *str, char separator) {
+	if (*str == '\0')
+		return *this;
+
+	if (!_str.empty() && _str.lastChar() != DIR_SEPARATOR && *str != separator)
+		_str += DIR_SEPARATOR;
+
+	appendInPlace(str, separator);
+
+	return *this;
+}
+
+Path Path::join(const Path &x) const {
+	Path temp(*this);
+	temp.joinInPlace(x);
 	return temp;
 }
 
-Path operator+(const Path &x, char y) {
-	Path temp(x);
-	temp += y;
+Path Path::join(const String &str, char separator) const {
+	return join(str.c_str(), separator);
+}
+
+Path Path::join(const char *str, char separator) const {
+	Path temp(*this);
+	temp.joinInPlace(str, DIR_SEPARATOR);
 	return temp;
 }
 

--- a/common/path.h
+++ b/common/path.h
@@ -28,45 +28,130 @@
 
 namespace Common {
 
+/**
+ * @defgroup common_path Path
+ * @ingroup common
+ *
+ * @brief API for working with paths.
+ *
+ * @{
+ */
+
 const char DIR_SEPARATOR = '\x1f'; // unit separator
 
+/**
+ * Simple path class. Allows simple conversion to/from path strings with
+ * arbitrary directory separators, providing a common representation.
+ * 
+ * Internally, this is just a simple wrapper around a String, using
+ * '\x1f' (unit separator) as a directory separator. As this is not
+ * a printable character, it should not appear in file names, unlike
+ * '/', '\', or ':', which are allowed on certain platforms.
+ */
 class Path {
 private:
 	String _str;
 
 public:
+	/** Construct a new empty path. */
 	Path() {}
+
+	/** Construct a copy of the given path. */
 	Path(const Path &path);
+
+	/**
+	 * Construct a new path from the given NULL-terminated C string.
+	 * 
+	 * @param str       A NULL-terminated C string representing a path,
+	 *                  e.g. "foo/bar/baz"
+	 * @param separator The directory separator used in the path string.
+	 *                  Defaults to '/'.
+	 */
 	Path(const char *str, char separator = '/');
+
+	/**
+	 * Construct a new path from the given String.
+	 * 
+	 * @param str       A String representing a path, e.g. "foo/bar/baz"
+	 * @param separator The directory separator used in the path string.
+	 *                  Defaults to '/'.
+	 */
 	Path(const String &str, char separator = '/');
+
+	/** Construct a path consisting of the given character. */
 	Path(char c, char separator = '/');
 
 private:
 	void setString(const char *str, char separator = '/');
 
 public:
+	/**
+	 * Returns the unmodified, internal representation of the path,
+	 * using '\x1f' as a directory separator.
+	 */
 	const String &rawString() const { return _str; }
+
+	/**
+	 * Converts a path to a string using the given directory separator.
+	 * 
+	 * @param separator The character used to separate directory names.
+	 *                  Defaults to '/'.
+	 */
 	String toString(char separator = '/') const;
 
+	/** Check whether this path is identical to path @p x. */
 	bool operator==(const Path &x) const;
+
+	/** Check whether this path is different than path @p x. */
 	bool operator!=(const Path &x) const;
 
+	/** Return if this path is empty */
 	bool empty() const;
 
+	/** Assign a given path to this path. */
 	Path &operator=(const Path &str);
+
+	/** @overload */
 	Path &operator=(const char *str);
+
+	/** @overload */
 	Path &operator=(const String &str);
+
+	/** @overload */
 	Path &operator=(char c);
+
+	/**
+	 * Append the given path to this path. Does not automatically
+	 * add a directory separator.
+	 */
 	Path &operator+=(const Path &str);
+
+	/** @overload */
 	Path &operator+=(const char *str);
+
+	/** @overload */
 	Path &operator+=(const String &str);
+
+	/** @overload */
 	Path &operator+=(char c);
 };
 
+/**
+ * Concatenate paths @p x and @p y. Does not automatically
+ * add a directory separator between them.
+ */
 Path operator+(const Path &x, const Path &y);
+
+/** @overload */
 Path operator+(const Path &x, const String &y);
+
+/** @overload */
 Path operator+(const Path &x, const char *y);
+
+/** @overload */
 Path operator+(const Path &x, char y);
+
+/** @} */
 
 } // End of namespace Common
 

--- a/common/path.h
+++ b/common/path.h
@@ -78,13 +78,6 @@ public:
 	 */
 	Path(const String &str, char separator = '/');
 
-	/** Construct a path consisting of the given character. */
-	Path(char c, char separator = '/');
-
-private:
-	void setString(const char *str, char separator = '/');
-
-public:
 	/**
 	 * Returns the unmodified, internal representation of the path,
 	 * using '\x1f' as a directory separator.
@@ -117,39 +110,57 @@ public:
 	/** @overload */
 	Path &operator=(const String &str);
 
-	/** @overload */
-	Path &operator=(char c);
+	void set(const char *str, char separator = '/');
 
 	/**
-	 * Append the given path to this path. Does not automatically
-	 * add a directory separator.
+	 * Appends the given path to this path (in-place).
+	 * Does not automatically add a directory separator.
 	 */
-	Path &operator+=(const Path &str);
+	Path &appendInPlace(const Path &x);
 
 	/** @overload */
-	Path &operator+=(const char *str);
+	Path &appendInPlace(const String &str, char separator = '/');
 
 	/** @overload */
-	Path &operator+=(const String &str);
+	Path &appendInPlace(const char *str, char separator = '/');
+
+	/**
+	 * Returns this path with the given path appended (out-of-place).
+	 * Does not automatically add a directory separator.
+	 */
+	Path append(const Path &x) const;
 
 	/** @overload */
-	Path &operator+=(char c);
+	Path append(const String &str, char separator = '/') const;
+
+	/** @overload */
+	Path append(const char *str, char separator = '/') const;
+
+
+	/**
+	 * Joins the given path to this path (in-place).
+	 * Automatically adds a directory separator.
+	 */
+	Path &joinInPlace(const Path &x);
+
+	/** @overload */
+	Path &joinInPlace(const String &str, char separator = '/');
+
+	/** @overload */
+	Path &joinInPlace(const char *str, char separator = '/');
+
+	/**
+	 * Returns this path joined with the given path (out-of-place).
+	 * Automatically adds a directory separator.
+	 */
+	Path join(const Path &x) const;
+
+	/** @overload */
+	Path join(const String &str, char separator = '/') const;
+
+	/** @overload */
+	Path join(const char *str, char separator = '/') const;
 };
-
-/**
- * Concatenate paths @p x and @p y. Does not automatically
- * add a directory separator between them.
- */
-Path operator+(const Path &x, const Path &y);
-
-/** @overload */
-Path operator+(const Path &x, const String &y);
-
-/** @overload */
-Path operator+(const Path &x, const char *y);
-
-/** @overload */
-Path operator+(const Path &x, char y);
 
 /** @} */
 

--- a/common/path.h
+++ b/common/path.h
@@ -1,0 +1,73 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef COMMON_PATH_H
+#define COMMON_PATH_H
+
+#include "common/scummsys.h"
+#include "common/str.h"
+
+namespace Common {
+
+const char DIR_SEPARATOR = '\x1f'; // unit separator
+
+class Path {
+private:
+	String _str;
+
+public:
+	Path() {}
+	Path(const Path &path);
+	Path(const char *str, char separator = '/');
+	Path(const String &str, char separator = '/');
+	Path(char c, char separator = '/');
+
+private:
+	void setString(const char *str, char separator = '/');
+
+public:
+	const String &rawString() const { return _str; }
+	String toString(char separator = '/') const;
+
+	bool operator==(const Path &x) const;
+	bool operator!=(const Path &x) const;
+
+	bool empty() const;
+
+	Path &operator=(const Path &str);
+	Path &operator=(const char *str);
+	Path &operator=(const String &str);
+	Path &operator=(char c);
+	Path &operator+=(const Path &str);
+	Path &operator+=(const char *str);
+	Path &operator+=(const String &str);
+	Path &operator+=(char c);
+};
+
+Path operator+(const Path &x, const Path &y);
+Path operator+(const Path &x, const String &y);
+Path operator+(const Path &x, const char *y);
+Path operator+(const Path &x, char y);
+
+} // End of namespace Common
+
+#endif

--- a/common/punycode.cpp
+++ b/common/punycode.cpp
@@ -352,17 +352,17 @@ String punycode_decodefilename(const String src1) {
 	return dst;
 }
 
-String punycode_decodepath(const String src) {
-	StringTokenizer tok(src, "/");
+Path punycode_decodepath(const Path &src) {
+	StringTokenizer tok(src.rawString(), Common::String(DIR_SEPARATOR));
 	String res;
 
 	while (!tok.empty()) {
 		res += punycode_decodefilename(tok.nextToken());
 		if (!tok.empty())
-			res += '/';
+			res += DIR_SEPARATOR;
 	}
 
-	return res;
+	return Path(res, DIR_SEPARATOR);
 }
 
 } // end of namespace Common

--- a/common/punycode.h
+++ b/common/punycode.h
@@ -72,6 +72,11 @@ String punycode_decodefilename(const String src1);
  */
 Path punycode_decodepath(const Path &src);
 
+/**
+ * Convert path to Punycode with '/' as separators
+ */
+Path punycode_encodepath(const Path &src);
+
 bool punycode_hasprefix(const String src);
 
 bool punycode_needEncode(const String src);

--- a/common/punycode.h
+++ b/common/punycode.h
@@ -44,6 +44,7 @@
 #ifndef COMMON_PUNYCODE_H
 #define COMMON_PUNYCODE_H
 
+#include "common/path.h"
 #include "common/str.h"
 
 namespace Common {
@@ -69,7 +70,7 @@ String punycode_decodefilename(const String src1);
 /**
  * Convert path with '/' as separators from Punycode
  */
-String punycode_decodepath(const String src);
+Path punycode_decodepath(const Path &src);
 
 bool punycode_hasprefix(const String src);
 

--- a/common/quicktime.cpp
+++ b/common/quicktime.cpp
@@ -59,7 +59,7 @@ QuickTimeParser::~QuickTimeParser() {
 	delete _resFork;
 }
 
-bool QuickTimeParser::parseFile(const String &filename) {
+bool QuickTimeParser::parseFile(const Path &filename) {
 	if (!_resFork->open(filename) || !_resFork->hasDataFork())
 		return false;
 

--- a/common/quicktime.h
+++ b/common/quicktime.h
@@ -33,6 +33,7 @@
 
 #include "common/array.h"
 #include "common/scummsys.h"
+#include "common/path.h"
 #include "common/stream.h"
 #include "common/rational.h"
 #include "common/types.h"
@@ -62,7 +63,7 @@ public:
 	 * Load a QuickTime file
 	 * @param filename	the filename to load
 	 */
-	bool parseFile(const String &filename);
+	bool parseFile(const Path &filename);
 
 	/**
 	 * Load a QuickTime file from a SeekableReadStream

--- a/common/stuffit.cpp
+++ b/common/stuffit.cpp
@@ -47,10 +47,10 @@ public:
 	bool isOpen() const { return _stream != 0; }
 
 	// Common::Archive API implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	struct FileEntry {
@@ -199,7 +199,8 @@ void StuffItArchive::close() {
 	_map.clear();
 }
 
-bool StuffItArchive::hasFile(const Common::String &name) const {
+bool StuffItArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return _map.contains(name);
 }
 
@@ -210,11 +211,13 @@ int StuffItArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return _map.size();
 }
 
-const Common::ArchiveMemberPtr StuffItArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr StuffItArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *StuffItArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *StuffItArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_stream || !_map.contains(name))
 		return nullptr;
 

--- a/common/unarj.cpp
+++ b/common/unarj.cpp
@@ -702,10 +702,10 @@ public:
 	virtual ~ArjArchive();
 
 	// Archive implementation
-	virtual bool hasFile(const String &name) const;
+	virtual bool hasFile(const Path &path) const;
 	virtual int listMembers(ArchiveMemberList &list) const;
-	virtual const ArchiveMemberPtr getMember(const String &name) const;
-	virtual SeekableReadStream *createReadStreamForMember(const String &name) const;
+	virtual const ArchiveMemberPtr getMember(const Path &path) const;
+	virtual SeekableReadStream *createReadStreamForMember(const Path &path) const;
 };
 
 ArjArchive::ArjArchive(const String &filename) : _arjFilename(filename) {
@@ -746,7 +746,8 @@ ArjArchive::~ArjArchive() {
 	}
 }
 
-bool ArjArchive::hasFile(const String &name) const {
+bool ArjArchive::hasFile(const Path &path) const {
+	String name = path.toString();
 	return _headers.contains(name);
 }
 
@@ -762,14 +763,16 @@ int ArjArchive::listMembers(ArchiveMemberList &list) const {
 	return matches;
 }
 
-const ArchiveMemberPtr ArjArchive::getMember(const String &name) const {
+const ArchiveMemberPtr ArjArchive::getMember(const Path &path) const {
+	String name = path.toString();
 	if (!hasFile(name))
 		return ArchiveMemberPtr();
 
 	return ArchiveMemberPtr(new GenericArchiveMember(name, this));
 }
 
-SeekableReadStream *ArjArchive::createReadStreamForMember(const String &name) const {
+SeekableReadStream *ArjArchive::createReadStreamForMember(const Path &path) const {
+	String name = path.toString();
 	if (!_headers.contains(name)) {
 		return nullptr;
 	}

--- a/common/unzip.cpp
+++ b/common/unzip.cpp
@@ -1429,10 +1429,10 @@ public:
 
 	~ZipArchive();
 
-	virtual bool hasFile(const String &name) const;
+	virtual bool hasFile(const Path &path) const;
 	virtual int listMembers(ArchiveMemberList &list) const;
-	virtual const ArchiveMemberPtr getMember(const String &name) const;
-	virtual SeekableReadStream *createReadStreamForMember(const String &name) const;
+	virtual const ArchiveMemberPtr getMember(const Path &path) const;
+	virtual SeekableReadStream *createReadStreamForMember(const Path &path) const;
 };
 
 /*
@@ -1461,7 +1461,8 @@ ZipArchive::~ZipArchive() {
 	unzClose(_zipFile);
 }
 
-bool ZipArchive::hasFile(const String &name) const {
+bool ZipArchive::hasFile(const Path &path) const {
+	String name = path.toString();
 	return (unzLocateFile(_zipFile, name.c_str(), 2) == UNZ_OK);
 }
 
@@ -1478,14 +1479,16 @@ int ZipArchive::listMembers(ArchiveMemberList &list) const {
 	return members;
 }
 
-const ArchiveMemberPtr ZipArchive::getMember(const String &name) const {
+const ArchiveMemberPtr ZipArchive::getMember(const Path &path) const {
+	String name = path.toString();
 	if (!hasFile(name))
 		return ArchiveMemberPtr();
 
 	return ArchiveMemberPtr(new GenericArchiveMember(name, this));
 }
 
-SeekableReadStream *ZipArchive::createReadStreamForMember(const String &name) const {
+SeekableReadStream *ZipArchive::createReadStreamForMember(const Path &path) const {
+	String name = path.toString();
 	if (unzLocateFile(_zipFile, name.c_str(), 2) != UNZ_OK)
 		return nullptr;
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -43,7 +43,8 @@ class FileMapArchive : public Common::Archive {
 public:
 	FileMapArchive(const AdvancedMetaEngineDetection::FileMap &fileMap) : _fileMap(fileMap) {}
 
-	bool hasFile(const Common::String &name) const override {
+	bool hasFile(const Common::Path &path) const override {
+		Common::String name = path.toString();
 		return _fileMap.contains(name);
 	}
 
@@ -57,7 +58,8 @@ public:
 		return files;
 	}
 
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override {
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override {
+		Common::String name = path.toString();
 		AdvancedMetaEngineDetection::FileMap::const_iterator it = _fileMap.find(name);
 		if (it == _fileMap.end()) {
 			return Common::ArchiveMemberPtr();
@@ -66,7 +68,8 @@ public:
 		return Common::ArchiveMemberPtr(new Common::FSNode(it->_value));
 	}
 
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override {
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override {
+		Common::String name = path.toString();
 		Common::FSNode fsNode = _fileMap.getValOrDefault(name);
 		return fsNode.createReadStream();
 	}

--- a/engines/ags/engine/ac/listbox.cpp
+++ b/engines/ags/engine/ac/listbox.cpp
@@ -82,7 +82,7 @@ void FillDirList(std::set<String> &files, const String &path) {
 		return;
 	}
 
-	Common::FSDirectory dir(dirName);
+	Common::FSDirectory dir(dirName.GetCStr());
 	Common::ArchiveMemberList fileList;
 	dir.listMatchingMembers(fileList, filePattern);
 	for (Common::ArchiveMemberList::iterator iter = fileList.begin(); iter != fileList.end(); ++iter) {

--- a/engines/ags/shared/util/directory.cpp
+++ b/engines/ags/shared/util/directory.cpp
@@ -92,7 +92,7 @@ String GetCurrentDirectory() {
 }
 
 static bool GetFilesImpl(const String &dir_path, std::vector<String> &files, bool isDirectories) {
-	Common::FSNode fsNode(dir_path);
+	Common::FSNode fsNode(dir_path.GetCStr());
 	Common::FSList fsList;
 
 	fsNode.getChildren(fsList,
@@ -120,7 +120,7 @@ FindFile::~FindFile() {
 
 FindFile FindFile::Open(const String &path, const String &wildcard, bool do_file, bool do_dir) {
 	FindFile ff;
-	ff._folder = Common::FSNode(path);
+	ff._folder = Common::FSNode(path.GetCStr());
 
 	Common::FSNode::ListMode mode = Common::FSNode::kListAll;
 	if (do_file && !do_dir)

--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -230,7 +230,7 @@ bool MacArchive::openFile(const Common::String &fileName) {
 		return false;
 	}
 
-	_pathName = _resFork->getBaseFileName();
+	_pathName = _resFork->getBaseFileName().toString();
 	if (_pathName.hasSuffix(".bin")) {
 		for (int i = 0; i < 4; i++)
 			_pathName.deleteLastChar();

--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -500,7 +500,7 @@ bool RIFXArchive::openStream(Common::SeekableReadStream *stream, uint32 startOff
 		Common::DumpFile out;
 
 		char buf[256];
-		sprintf(buf, "./dumps/%s-%08x", g_director->getEXEName().c_str(), startOffset);
+		sprintf(buf, "./dumps/%s-%08x", encodePathForDump(g_director->getEXEName()).c_str(), startOffset);
 
 		if (out.open(buf, true)) {
 			out.write(dumpData, sz);
@@ -559,7 +559,7 @@ bool RIFXArchive::openStream(Common::SeekableReadStream *stream, uint32 startOff
 			else
 				prepend = "stream";
 
-			Common::String filename = Common::String::format("./dumps/%s-%s-%d", prepend.c_str(), tag2str(_resources[i]->tag), _resources[i]->index);
+			Common::String filename = Common::String::format("./dumps/%s-%s-%d", encodePathForDump(prepend).c_str(), tag2str(_resources[i]->tag), _resources[i]->index);
 			resStream->read(data, len);
 
 			if (!out.open(filename, true)) {
@@ -716,7 +716,7 @@ bool RIFXArchive::readAfterburnerMap(Common::SeekableReadStreamEndian &stream, u
 		Common::DumpFile out;
 
 		char buf[256];
-		sprintf(buf, "./dumps/%s-%s", g_director->getEXEName().c_str(), "ABMP");
+		sprintf(buf, "./dumps/%s-%s", encodePathForDump(g_director->getEXEName()).c_str(), "ABMP");
 
 		if (out.open(buf, true)) {
 			byte *data = (byte *)malloc(abmpStream->size());

--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -49,7 +49,7 @@ Common::String Archive::getFileName() const { return Director::getFileName(_path
 bool Archive::openFile(const Common::String &fileName) {
 	Common::File *file = new Common::File();
 
-	if (!file->open(fileName)) {
+	if (!file->open(Common::Path(fileName, g_director->_dirSeparator))) {
 		warning("Archive::openFile(): Error opening file %s", fileName.c_str());
 		delete file;
 		return false;
@@ -225,12 +225,12 @@ bool MacArchive::openFile(const Common::String &fileName) {
 
 	Common::String fName = fileName;
 
-	if (!_resFork->open(fName) || !_resFork->hasResFork()) {
+	if (!_resFork->open(Common::Path(fName, g_director->_dirSeparator)) || !_resFork->hasResFork()) {
 		close();
 		return false;
 	}
 
-	_pathName = _resFork->getBaseFileName().toString();
+	_pathName = _resFork->getBaseFileName().toString(g_director->_dirSeparator);
 	if (_pathName.hasSuffix(".bin")) {
 		for (int i = 0; i < 4; i++)
 			_pathName.deleteLastChar();

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -678,7 +678,7 @@ Common::String Cast::getVideoPath(int castId) {
 		Common::String filename = _castsInfo[castId]->fileName;
 		Common::String directory = _castsInfo[castId]->directory;
 
-		res = directory + "\\" + filename;
+		res = directory + g_director->_dirSeparator + filename;
 	} else {
 		warning("STUB: Cast::getVideoPath(%d): unsupported non-zero MooV block", castId);
 	}

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -1088,7 +1088,7 @@ void Cast::loadScriptText(Common::SeekableReadStreamEndian &stream, uint16 id) {
 
 void Cast::dumpScript(const char *script, ScriptType type, uint16 id) {
 	Common::DumpFile out;
-	Common::String buf = dumpScriptName(_macName.c_str(), type, id, "txt");
+	Common::String buf = dumpScriptName(encodePathForDump(_macName).c_str(), type, id, "txt");
 
 	if (!out.open(buf, true)) {
 		warning("Cast::dumpScript(): Can not open dump file %s", buf.c_str());

--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -358,7 +358,7 @@ bool DigitalVideoCastMember::loadVideo(Common::String path) {
 	_video = new Video::QuickTimeDecoder();
 
 	debugC(2, kDebugLoading | kDebugImages, "Loading video %s", path.c_str());
-	bool result = _video->loadFile(path);
+	bool result = _video->loadFile(Common::Path(path, g_director->_dirSeparator));
 
 	if (result && g_director->_pixelformat.bytesPerPixel == 1) {
 		// Director supports playing back RGB and paletted video in 256 colour mode.

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -58,6 +58,8 @@ DirectorEngine *g_director;
 DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc) {
 	g_director = this;
 
+	_dirSeparator = ':';
+
 	parseOptions();
 
 	// Setup mixer
@@ -102,7 +104,6 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	_playbackPaused = false;
 	_skipFrameAdvance = false;
 	_centerStage = true;
-	_dirSeparator = ':';
 
 	_surface = nullptr;
 }

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -102,6 +102,7 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	_playbackPaused = false;
 	_skipFrameAdvance = false;
 	_centerStage = true;
+	_dirSeparator = ':';
 
 	_surface = nullptr;
 }
@@ -272,7 +273,7 @@ void DirectorEngine::parseOptions() {
 			}
 
 			if (Common::punycode_hasprefix(_options.startMovie.startMovie))
-				_options.startMovie.startMovie = Common::punycode_decodepath(_options.startMovie.startMovie).toString();
+				_options.startMovie.startMovie = Common::punycode_decodepath(_options.startMovie.startMovie).toString(_dirSeparator);
 
 			debug(2, "parseOptions(): Movie is: %s, frame is: %d", _options.startMovie.startMovie.c_str(), _options.startMovie.startFrame);
 		} else if (key == "startup") {

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -272,8 +272,7 @@ void DirectorEngine::parseOptions() {
 					_options.startMovie.startFrame = atoi(tail.c_str());
 			}
 
-			if (Common::punycode_hasprefix(_options.startMovie.startMovie))
-				_options.startMovie.startMovie = Common::punycode_decodepath(_options.startMovie.startMovie).toString(_dirSeparator);
+			_options.startMovie.startMovie = Common::punycode_decodepath(_options.startMovie.startMovie).toString(_dirSeparator);
 
 			debug(2, "parseOptions(): Movie is: %s, frame is: %d", _options.startMovie.startMovie.c_str(), _options.startMovie.startFrame);
 		} else if (key == "startup") {

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -272,7 +272,7 @@ void DirectorEngine::parseOptions() {
 			}
 
 			if (Common::punycode_hasprefix(_options.startMovie.startMovie))
-				_options.startMovie.startMovie = Common::punycode_decodepath(_options.startMovie.startMovie);
+				_options.startMovie.startMovie = Common::punycode_decodepath(_options.startMovie.startMovie).toString();
 
 			debug(2, "parseOptions(): Movie is: %s, frame is: %d", _options.startMovie.startMovie.c_str(), _options.startMovie.startFrame);
 		} else if (key == "startup") {

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -255,6 +255,7 @@ public:
 	bool _playbackPaused;
 	bool _skipFrameAdvance;
 	bool _centerStage;
+	char _dirSeparator;
 
 	Common::HashMap<Common::String, Archive *, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _openResFiles;
 

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -1177,7 +1177,7 @@ ScriptContext *LingoCompiler::compileLingoV4(Common::SeekableReadStreamEndian &s
 	bool skipdump = false;
 
 	if (ConfMan.getBool("dump_scripts")) {
-		Common::String buf = dumpScriptName(archName.c_str(), scriptType, castId, "lscr");
+		Common::String buf = dumpScriptName(encodePathForDump(archName).c_str(), scriptType, castId, "lscr");
 
 		if (!out.open(buf, true)) {
 			warning("Lingo::addCodeV4(): Can not open dump file %s", buf.c_str());

--- a/engines/director/lingo/lingo-funcs.cpp
+++ b/engines/director/lingo/lingo-funcs.cpp
@@ -296,7 +296,7 @@ void Lingo::func_play(Datum &frame, Datum &movie) {
 	}
 
 	if (movie.type != VOID) {
-		ref.movie = unixToMacPath(_vm->getCurrentMovie()->_movieArchive->getPathName());
+		ref.movie = _vm->getCurrentMovie()->_movieArchive->getPathName();
 	}
 	ref.frameI = _vm->getCurrentMovie()->getScore()->getCurrentFrame();
 

--- a/engines/director/lingo/lingo-patcher.cpp
+++ b/engines/director/lingo/lingo-patcher.cpp
@@ -43,108 +43,108 @@ struct ScriptPatch {
 	const char *replace;
 } const scriptPatches[] = {
 	// Garbage at end of script
-	{"warlock", nullptr, kPlatformMacintosh, "WARLOCKSHIP/UpForeECall", kScoreScript, 12, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "WARLOCKSHIP:UpForeECall", kScoreScript, 12, 0,
 			2, "SS Warlock:DATA:WARLOCKSHIP:Up.GCGunner", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "WARLOCKSHIP/UpForeECall", kScoreScript, 12, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "WARLOCKSHIP:UpForeECall", kScoreScript, 12, 0,
 			3, "Channels 17 to 18", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "WARLOCKSHIP/UpForeECall", kScoreScript, 12, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "WARLOCKSHIP:UpForeECall", kScoreScript, 12, 0,
 			4, "Frames 150 to 160", ""},
 
 	// Garbage at end of script
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/HE.Aft", kScoreScript, 8, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:HE.Aft", kScoreScript, 8, 0,
 			2, "SS Warlock:DATA:WARLOCKSHIP:HangStairsFore", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/HE.Aft", kScoreScript, 8, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:HE.Aft", kScoreScript, 8, 0,
 			3, "Channels 4 to 5", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/HE.Aft", kScoreScript, 8, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:HE.Aft", kScoreScript, 8, 0,
 			4, "Frames 20 to 20", ""},
 
 	// Garbage at end of script
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/ENG/D10", kScoreScript, 8, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:ENG:D10", kScoreScript, 8, 0,
 			2, "SS Warlock:ENG.Fold:C9", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/ENG/D10", kScoreScript, 8, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:ENG:D10", kScoreScript, 8, 0,
 			3, "Channels 19 to 20", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/ENG/D10", kScoreScript, 8, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:ENG:D10", kScoreScript, 8, 0,
 			4, "Frames 165 to 180", ""},
 
 	// Garbage at end of script
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/Up.c2", kScoreScript, 10, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:Up.c2", kScoreScript, 10, 0,
 			2, "Frames 150 to 160", ""},
 
 	// Garbage at end of script
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/Up.ForeECall", kScoreScript, 12, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:Up.ForeECall", kScoreScript, 12, 0,
 			2, "SS Warlock:DATA:WARLOCKSHIP:Up.GCGunner", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/Up.ForeECall", kScoreScript, 12, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:Up.ForeECall", kScoreScript, 12, 0,
 			3, "Channels 17 to 18", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/Up.ForeECall", kScoreScript, 12, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:Up.ForeECall", kScoreScript, 12, 0,
 			4, "Frames 150 to 160", ""},
 
 	// Garbage at end of script
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/Up.B2", kScoreScript, 9, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:Up.B2", kScoreScript, 9, 0,
 			2, "SS Warlock:DATA:WARLOCKSHIP:Up.GCGunner", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/Up.B2", kScoreScript, 9, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:Up.B2", kScoreScript, 9, 0,
 			3, "Channels 17 to 18", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/Up.B2", kScoreScript, 9, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:Up.B2", kScoreScript, 9, 0,
 			4, "Frames 150 to 160", ""},
 
 	// Garbage at end of script
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/BELSHAZZAR/STELLA/ORIGIN", kScoreScript, 12, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:BELSHAZZAR:STELLA:ORIGIN", kScoreScript, 12, 0,
 			2, "Frames 1 to 1", ""},
 
 	// Garbage at end of script
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/HangHallAft", kScoreScript, 7, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:HangHallAft", kScoreScript, 7, 0,
 			2, "SS Warlock:DATA:WARLOCKSHIP:HangStairsFore", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/HangHallAft", kScoreScript, 7, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:HangHallAft", kScoreScript, 7, 0,
 			3, "Channels 4 to 5", ""},
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/WARLOCKSHIP/HangHallAft", kScoreScript, 7, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:WARLOCKSHIP:HangHallAft", kScoreScript, 7, 0,
 			4, "Frames 20 to 20", ""},
 
 	// Stray 'then' (obvious copy/paste error)
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/K/KT/OutMarauderKT", kMovieScript, 14, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:K:KT:OutMarauderKT", kMovieScript, 14, 0,
 			23, "set Spacesuit = 0 then", "set Spacesuit = 0"},
 
 	// Missing '&'
-	{"warlock", nullptr, kPlatformMacintosh, "DATA/NAV/Shared Cast", kMovieScript, 510, 0,
+	{"warlock", nullptr, kPlatformMacintosh, "DATA:NAV:Shared Cast", kMovieScript, 510, 0,
 			19, "alert \"Failed Save.\" & return & \"Error message number: \" string ( filer )",
 				"alert \"Failed Save.\" & return & \"Error message number: \" & string ( filer )"},
 
 	// Garbage at end of script
-	{"warlock", "", kPlatformWindows, "WRLCKSHP/UpForeECall", kScoreScript, 12, 0,
+	{"warlock", "", kPlatformWindows, "WRLCKSHP:UpForeECall", kScoreScript, 12, 0,
 			2, "SS Warlock:DATA:WARLOCKSHIP:Up.GCGunner", ""},
-	{"warlock", "", kPlatformWindows, "WRLCKSHP/UpForeECall", kScoreScript, 12, 0,
+	{"warlock", "", kPlatformWindows, "WRLCKSHP:UpForeECall", kScoreScript, 12, 0,
 			3, "Channels 17 to 18", ""},
-	{"warlock", "", kPlatformWindows, "WRLCKSHP/UpForeECall", kScoreScript, 12, 0,
+	{"warlock", "", kPlatformWindows, "WRLCKSHP:UpForeECall", kScoreScript, 12, 0,
 			4, "Frames 150 to 160", ""},
 
 	// Missing '&'
-	{"warlock", nullptr, kPlatformUnknown, "NAV/Shared Cast", kMovieScript, 510, 0,
+	{"warlock", nullptr, kPlatformUnknown, "NAV:Shared Cast", kMovieScript, 510, 0,
 			23, "alert \"Failed Save.\" & return & \"Error message number: \" string ( filer )",
 				"alert \"Failed Save.\" & return & \"Error message number: \" & string ( filer )"},
 
 
 	// Patching dead loop which was fixed in v2
-	{"lzone", "", kPlatformMacintosh, "DATA/R-A/Ami-00", kScoreScript, 3, 0,
+	{"lzone", "", kPlatformMacintosh, "DATA:R-A:Ami-00", kScoreScript, 3, 0,
 			2, "continue", "go \"OUT\""},
 
 	// Garbage at end of statements
-	{"lzone", "", kPlatformMacintosh, "DATA/R-E/ZD2-LAS", kScoreScript, 7, 0,
+	{"lzone", "", kPlatformMacintosh, "DATA:R-E:ZD2-LAS", kScoreScript, 7, 0,
 			4, "go to the frame 0", "go to the frame"},
-	{"lzone", "", kPlatformMacintosh, "DATA/R-E/zd1-con1", kScoreScript, 27, 0,
+	{"lzone", "", kPlatformMacintosh, "DATA:R-E:zd1-con1", kScoreScript, 27, 0,
 			1, "go to the frame 0", "go to the frame"},
-	{"lzone", "", kPlatformMacintosh, "DATA/R-E/zd1-con1", kScoreScript, 30, 0,
+	{"lzone", "", kPlatformMacintosh, "DATA:R-E:zd1-con1", kScoreScript, 30, 0,
 			4, "go the frame 0", "go to the frame"},
-	{"lzone", "", kPlatformMacintosh, "DATA/R-G/st-c", kScoreScript, 14, 0,
+	{"lzone", "", kPlatformMacintosh, "DATA:R-G:st-c", kScoreScript, 14, 0,
 			1, "go to the frame 0", "go to the frame"},
-	{"lzone", "", kPlatformMacintosh, "DATA/R-G/st-d.mo", kScoreScript, 4, 0,
+	{"lzone", "", kPlatformMacintosh, "DATA:R-G:st-d.mo", kScoreScript, 4, 0,
 			1, "go to the frame 0", "go to the frame"},
-	{"lzone", "", kPlatformMacintosh, "DATA/R-F/ARCH-U.D-1", kScoreScript, 8, 0,
+	{"lzone", "", kPlatformMacintosh, "DATA:R-F:ARCH-U.D-1", kScoreScript, 8, 0,
 			1, "GO \"SPACE\" OF MOVIE \"L-ZONE:DATA:R-G:ST-A2\",\"242,197\"",
 			   "GO \"SPACE\" OF MOVIE \"L-ZONE:DATA:R-G:ST-A2\""},
 
-	{"lingoexpo", "", kPlatformMacintosh, "Lingo Expo/Navigator", kMovieScript, 9, 0,
+	{"lingoexpo", "", kPlatformMacintosh, "Lingo Expo:Navigator", kMovieScript, 9, 0,
 			97, "  append(codeExampleList,\"6,301,302,303,304,305,306\")  - KIOSK SCRIPTS",
 				"  append(codeExampleList,\"6,301,302,303,304,305,306\")"},
 
-	{"jman", "", kPlatformWindows, "mmm/Mars Space Game 05", kMovieScript, 10, 0,
+	{"jman", "", kPlatformWindows, "mmm:Mars Space Game 05", kMovieScript, 10, 0,
 			68, "set DamageParameter = (gProcessorSpeed/2) + 7)", "set DamageParameter = (gProcessorSpeed/2) + 7"},
 
 	{nullptr, nullptr, kPlatformUnknown, nullptr, kNoneScript, 0, 0, 0, nullptr, nullptr}

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -691,7 +691,7 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 	case kTheMoviePath:
 	case kThePathName:
 		d.type = STRING;
-		d.u.s = new Common::String(unixToMacPath(_vm->getCurrentPath()));
+		d.u.s = new Common::String(_vm->getCurrentPath());
 		break;
 	case kTheMultiSound:
 		// We always support multiple sound channels!

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -282,7 +282,7 @@ void Window::loadEXEv3(Common::SeekableReadStream *stream) {
 			byte *buf = (byte *)malloc(mmmSize);
 			stream->read(buf, mmmSize);
 			stream->seek(riffOffset);
-			Common::String fname = Common::String::format("./dumps/%s", mmmFileName.c_str());
+			Common::String fname = Common::String::format("./dumps/%s", encodePathForDump(mmmFileName).c_str());
 
 
 			if (!out.open(fname.c_str(), true)) {

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -206,7 +206,7 @@ void Window::loadEXE(const Common::String movie) {
 		warning("No LINGO.INI");
 	}
 
-	Common::SeekableReadStream *exeStream = SearchMan.createReadStreamForMember(movie);
+	Common::SeekableReadStream *exeStream = SearchMan.createReadStreamForMember(Common::Path(movie, g_director->_dirSeparator));
 	if (!exeStream)
 		error("Failed to open EXE '%s'", g_director->getEXEName().c_str());
 
@@ -382,7 +382,7 @@ void Window::loadMac(const Common::String movie) {
 		// The RIFX is located in the data fork of the executable
 		_macBinary = new Common::MacResManager();
 
-		if (!_macBinary->open(movie) || !_macBinary->hasDataFork())
+		if (!_macBinary->open(Common::Path(movie, g_director->_dirSeparator)) || !_macBinary->hasDataFork())
 			error("Failed to open Mac binary '%s'", movie.c_str());
 
 		Common::SeekableReadStream *dataFork = _macBinary->getDataFork();

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -622,7 +622,7 @@ void Score::screenShot() {
 	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 0, 8, 16, 24);
 	Graphics::Surface *newSurface = rawSurface.convertTo(requiredFormat_4byte, _vm->getPalette());
 	Common::String currentPath = _vm->getCurrentPath().c_str();
-	Common::replace(currentPath, "/", "-"); // exclude '/' from screenshot filename prefix
+	Common::replace(currentPath, Common::String(g_director->_dirSeparator), "-"); // exclude dir separator from screenshot filename prefix
 	Common::String prefix = Common::String::format("%s%s", currentPath.c_str(), _movie->getMacName().c_str());
 	Common::String filename = dumpScriptName(prefix.c_str(), kMovieScript, _framesRan, "png");
 

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -709,7 +709,7 @@ Audio::AudioStream *AudioFileDecoder::getAudioStream(bool looping, DisposeAfterU
 		return nullptr;
 
 	Common::File *file = new Common::File();
-	if (!file->open(_path)) {
+	if (!file->open(Common::Path(_path, g_director->_dirSeparator))) {
 		warning("Failed to open %s", _path.c_str());
 		return nullptr;
 	}

--- a/engines/director/util.cpp
+++ b/engines/director/util.cpp
@@ -23,6 +23,7 @@
 #include "common/file.h"
 #include "common/keyboard.h"
 #include "common/memstream.h"
+#include "common/punycode.h"
 #include "common/tokenizer.h"
 #include "common/zlib.h"
 
@@ -809,6 +810,10 @@ int compareStrings(const Common::String &s1, const Common::String &s2) {
 		p2++;
 	}
 	return c1 - c2;
+}
+
+Common::String encodePathForDump(const Common::String &path) {
+	return punycode_encodepath(Common::Path(path, g_director->_dirSeparator)).toString();
 }
 
 } // End of namespace Director

--- a/engines/director/util.h
+++ b/engines/director/util.h
@@ -91,6 +91,8 @@ int charToNum(Common::u32char_type_t ch);
 Common::u32char_type_t numToChar(int num);
 int compareStrings(const Common::String &s1, const Common::String &s2);
 
+Common::String encodePathForDump(const Common::String &path);
+
 } // End of namespace Director
 
 #endif

--- a/engines/director/window.cpp
+++ b/engines/director/window.cpp
@@ -413,20 +413,20 @@ bool Window::setNextMovie(Common::String &movieFilenameRaw) {
 			if (*p >= 0x20 && *p <= 0x7f)
 				cleanedFilename += (char) *p;
 
-		if (resMan.open(movieFilename)) {
+		if (resMan.open(Common::Path(movieFilename, _vm->_dirSeparator))) {
 			fileExists = true;
 			cleanedFilename = movieFilename;
-		} else if (!movieFilename.equals(cleanedFilename) && resMan.open(cleanedFilename)) {
+		} else if (!movieFilename.equals(cleanedFilename) && resMan.open(Common::Path(cleanedFilename, _vm->_dirSeparator))) {
 			fileExists = true;
 		}
 	} else {
 		Common::File file;
 		cleanedFilename = movieFilename + ".MMM";
 
-		if (file.open(movieFilename)) {
+		if (file.open(Common::Path(movieFilename, _vm->_dirSeparator))) {
 			fileExists = true;
 			cleanedFilename = movieFilename;
-		} else if (!movieFilename.equals(cleanedFilename) && file.open(cleanedFilename)) {
+		} else if (!movieFilename.equals(cleanedFilename) && file.open(Common::Path(cleanedFilename, _vm->_dirSeparator))) {
 			fileExists = true;
 		}
 	}
@@ -483,7 +483,7 @@ bool Window::step() {
 		delete _currentMovie;
 		_currentMovie = nullptr;
 
-		Archive *mov = openMainArchive(_currentPath + Common::lastPathComponent(_nextMovie.movie, '/'));
+		Archive *mov = openMainArchive(_currentPath + Common::lastPathComponent(_nextMovie.movie, g_director->_dirSeparator));
 
 		if (!mov) {
 			warning("nextMovie: No movie is loaded");
@@ -589,7 +589,7 @@ Common::String Window::getSharedCastPath() {
 
 	for (uint i = 0; i < namesToTry.size(); i++) {
 		Common::File f;
-		if (f.open(_currentPath + namesToTry[i])) {
+		if (f.open(Common::Path(_currentPath + namesToTry[i], _vm->_dirSeparator))) {
 			f.close();
 			return _currentPath + namesToTry[i];
 		}

--- a/engines/glk/blorb.cpp
+++ b/engines/glk/blorb.cpp
@@ -39,7 +39,8 @@ Blorb::Blorb(const Common::FSNode &fileNode, InterpreterType interpType) :
 		error("Could not parse blorb file");
 }
 
-bool Blorb::hasFile(const Common::String &name) const {
+bool Blorb::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (uint idx = 0; idx < _chunks.size(); ++idx) {
 		if (_chunks[idx]._filename.equalsIgnoreCase(name))
 			return true;
@@ -56,14 +57,16 @@ int Blorb::listMembers(Common::ArchiveMemberList &list) const {
 	return (int)_chunks.size();
 }
 
-const Common::ArchiveMemberPtr Blorb::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr Blorb::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *Blorb::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *Blorb::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (uint idx = 0; idx < _chunks.size(); ++idx) {
 		const ChunkEntry &ce = _chunks[idx];
 

--- a/engines/glk/blorb.h
+++ b/engines/glk/blorb.h
@@ -112,7 +112,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -125,14 +125,14 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
 	 * archive. If no member with this name exists, 0 is returned.
 	 * @return the newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 	/**
 	 * Read the RIdx section from the stream.

--- a/engines/glk/comprehend/pics.cpp
+++ b/engines/glk/comprehend/pics.cpp
@@ -360,7 +360,8 @@ int Pics::getPictureNumber(const Common::String &filename) const {
 	return atoi(num.c_str());
 }
 
-bool Pics::hasFile(const Common::String &name) const {
+bool Pics::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	int num = getPictureNumber(name);
 	if (num == -1)
 		return false;
@@ -379,14 +380,16 @@ int Pics::listMembers(Common::ArchiveMemberList &list) const {
 	return list.size();
 }
 
-const Common::ArchiveMemberPtr Pics::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr Pics::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *Pics::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *Pics::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	// Get the picture number
 	int num = getPictureNumber(name);
 	if (num == -1 || !hasFile(name))

--- a/engines/glk/comprehend/pics.h
+++ b/engines/glk/comprehend/pics.h
@@ -122,7 +122,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -135,14 +135,14 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
 	 * archive. If no member with this name exists, 0 is returned.
 	 * @return the newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 };
 
 } // namespace Comprehend

--- a/engines/glk/hugo/resource_archive.cpp
+++ b/engines/glk/hugo/resource_archive.cpp
@@ -48,7 +48,8 @@ bool ResourceArchive::splitName(const Common::String &name,
 }
 
 
-bool ResourceArchive::hasFile(const Common::String &name) const {
+bool ResourceArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	Common::String filename, resName;
 
 	if (!splitName(name, filename, resName))
@@ -59,14 +60,16 @@ bool ResourceArchive::hasFile(const Common::String &name) const {
 	return resLength != 0;
 }
 
-const Common::ArchiveMemberPtr ResourceArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr ResourceArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *ResourceArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *ResourceArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	Common::String filename, resName;
 
 	// Split up the file and resource entry; return if it's not one

--- a/engines/glk/hugo/resource_archive.h
+++ b/engines/glk/hugo/resource_archive.h
@@ -47,7 +47,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -62,14 +62,14 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
 	 * archive. If no member with this name exists, 0 is returned.
 	 * @return the newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 };
 
 } // End of namespace Hugo

--- a/engines/glk/zcode/pics.cpp
+++ b/engines/glk/zcode/pics.cpp
@@ -113,7 +113,8 @@ bool Pics::exists() {
 	return Common::File::exists(getFilename());
 }
 
-bool Pics::hasFile(const Common::String &name) const {
+bool Pics::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (uint idx = 0; idx < _index.size(); ++idx) {
 		if (_index[idx]._filename.equalsIgnoreCase(name))
 			return true;
@@ -130,14 +131,16 @@ int Pics::listMembers(Common::ArchiveMemberList &list) const {
 	return (int)_index.size();
 }
 
-const Common::ArchiveMemberPtr Pics::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr Pics::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *Pics::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *Pics::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	PictureDecoder decoder;
 
 	for (uint idx = 0; idx < _index.size(); ++idx) {

--- a/engines/glk/zcode/pics.h
+++ b/engines/glk/zcode/pics.h
@@ -108,7 +108,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -121,14 +121,14 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
 	 * archive. If no member with this name exists, 0 is returned.
 	 * @return the newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 };
 
 } // End of namespace ZCode

--- a/engines/glk/zcode/sound_folder.cpp
+++ b/engines/glk/zcode/sound_folder.cpp
@@ -48,7 +48,8 @@ SoundSubfolder::SoundSubfolder(const Common::FSNode &folder) : _folder(folder) {
 	}
 }
 
-bool SoundSubfolder::hasFile(const Common::String &name) const {
+bool SoundSubfolder::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return _filenames.contains(name);
 }
 
@@ -62,14 +63,16 @@ int SoundSubfolder::listMembers(Common::ArchiveMemberList &list) const {
 	return total;
 }
 
-const Common::ArchiveMemberPtr SoundSubfolder::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr SoundSubfolder::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *SoundSubfolder::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *SoundSubfolder::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	Common::File *f = new Common::File();
 	if (_filenames.contains(name) && f->open(_folder.getChild(_filenames[name])))
 		return f;
@@ -112,7 +115,8 @@ SoundZip::~SoundZip() {
 	delete _zip;
 }
 
-bool SoundZip::hasFile(const Common::String &name) const {
+bool SoundZip::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return _filenames.contains(name);
 }
 
@@ -127,7 +131,8 @@ int SoundZip::listMembers(Common::ArchiveMemberList &list) const {
 	return total;
 }
 
-const Common::ArchiveMemberPtr SoundZip::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr SoundZip::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
@@ -135,7 +140,8 @@ const Common::ArchiveMemberPtr SoundZip::getMember(const Common::String &name) c
 
 }
 
-Common::SeekableReadStream *SoundZip::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *SoundZip::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_filenames.contains(name))
 		return nullptr;
 

--- a/engines/glk/zcode/sound_folder.h
+++ b/engines/glk/zcode/sound_folder.h
@@ -56,7 +56,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -69,14 +69,14 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
 	 * archive. If no member with this name exists, 0 is returned.
 	 * @return the newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 };
 
 /**
@@ -109,7 +109,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -122,14 +122,14 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
 	 * archive. If no member with this name exists, 0 is returned.
 	 * @return the newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 };
 
 } // End of namespace ZCode

--- a/engines/grim/lab.cpp
+++ b/engines/grim/lab.cpp
@@ -146,8 +146,8 @@ void Lab::parseMonkey4FileTable(Common::File *file) {
 	delete[] stringTable;
 }
 
-bool Lab::hasFile(const Common::String &filename) const {
-	Common::String fname(filename);
+bool Lab::hasFile(const Common::Path &filename) const {
+	Common::String fname(filename.toString());
 	fname.toLowercase();
 	return _entries.contains(fname);
 }
@@ -163,7 +163,8 @@ int Lab::listMembers(Common::ArchiveMemberList &list) const {
 	return count;
 }
 
-const Common::ArchiveMemberPtr Lab::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr Lab::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
@@ -172,7 +173,8 @@ const Common::ArchiveMemberPtr Lab::getMember(const Common::String &name) const 
 	return _entries[fname];
 }
 
-Common::SeekableReadStream *Lab::createReadStreamForMember(const Common::String &filename) const {
+Common::SeekableReadStream *Lab::createReadStreamForMember(const Common::Path &path) const {
+	Common::String filename = path.toString();
 	if (!hasFile(filename))
 		return nullptr;
 

--- a/engines/grim/lab.h
+++ b/engines/grim/lab.h
@@ -50,10 +50,10 @@ public:
 	Lab();
 	virtual ~Lab();
 	// Common::Archive implementation
-	virtual bool hasFile(const Common::String &name) const override;
+	virtual bool hasFile(const Common::Path &path) const override;
 	virtual int listMembers(Common::ArchiveMemberList &list) const override;
-	virtual const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	virtual Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	virtual const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	virtual Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	void parseGrimFileTable(Common::File *_f);

--- a/engines/grim/update/lang_filter.cpp
+++ b/engines/grim/update/lang_filter.cpp
@@ -66,7 +66,8 @@ LangFilter::~LangFilter() {
 	delete _arc;
 }
 
-bool LangFilter::hasFile(const Common::String &name) const {
+bool LangFilter::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_arc)
 		return false;
 
@@ -109,11 +110,13 @@ int LangFilter::listMembers(Common::ArchiveMemberList &list) const {
 	return num;
 }
 
-const Common::ArchiveMemberPtr LangFilter::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr LangFilter::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *LangFilter::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *LangFilter::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_arc)
 		return nullptr;
 

--- a/engines/grim/update/lang_filter.h
+++ b/engines/grim/update/lang_filter.h
@@ -34,10 +34,10 @@ public:
 	~LangFilter();
 
 	// Common::Archive API implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 private:
 	Common::Archive *_arc;
 

--- a/engines/grim/update/mscab.cpp
+++ b/engines/grim/update/mscab.cpp
@@ -146,7 +146,8 @@ Common::String MsCabinet::readString(Common::ReadStream *stream) {
 	return ret;
 }
 
-bool MsCabinet::hasFile(const Common::String &name) const {
+bool MsCabinet::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return _fileMap.contains(name);
 }
 
@@ -157,11 +158,13 @@ int MsCabinet::listMembers(Common::ArchiveMemberList &list) const {
 	return _fileMap.size();
 }
 
-const Common::ArchiveMemberPtr MsCabinet::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr MsCabinet::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *MsCabinet::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *MsCabinet::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	byte *fileBuf;
 
 	if (!hasFile(name))

--- a/engines/grim/update/mscab.h
+++ b/engines/grim/update/mscab.h
@@ -38,10 +38,10 @@ public:
 	~MsCabinet();
 
 	// Common::Archive API implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	Common::SeekableReadStream *_data;

--- a/engines/kyra/resource/resource_intern.cpp
+++ b/engines/kyra/resource/resource_intern.cpp
@@ -37,7 +37,8 @@ PlainArchive::PlainArchive(Common::ArchiveMemberPtr file)
 	: _file(file), _files() {
 }
 
-bool PlainArchive::hasFile(const Common::String &name) const {
+bool PlainArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return (_files.find(name) != _files.end());
 }
 
@@ -52,14 +53,16 @@ int PlainArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return count;
 }
 
-const Common::ArchiveMemberPtr PlainArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr PlainArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *PlainArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *PlainArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	FileMap::const_iterator fDesc = _files.find(name);
 	if (fDesc == _files.end())
 		return 0;
@@ -92,7 +95,8 @@ TlkArchive::~TlkArchive() {
 	delete[] _fileEntries;
 }
 
-bool TlkArchive::hasFile(const Common::String &name) const {
+bool TlkArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return (findFile(name) != 0);
 }
 
@@ -107,14 +111,16 @@ int TlkArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return count;
 }
 
-const Common::ArchiveMemberPtr TlkArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr TlkArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *TlkArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *TlkArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	const uint32 *fileDesc = findFile(name);
 	if (!fileDesc)
 		return 0;
@@ -186,7 +192,8 @@ CachedArchive::~CachedArchive() {
 	_files.clear();
 }
 
-bool CachedArchive::hasFile(const Common::String &name) const {
+bool CachedArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return (_files.find(name) != _files.end());
 }
 
@@ -201,14 +208,16 @@ int CachedArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return count;
 }
 
-const Common::ArchiveMemberPtr CachedArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr CachedArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *CachedArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *CachedArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	FileMap::const_iterator fDesc = _files.find(name);
 	if (fDesc == _files.end())
 		return 0;

--- a/engines/kyra/resource/resource_intern.h
+++ b/engines/kyra/resource/resource_intern.h
@@ -50,10 +50,10 @@ public:
 	Entry getFileEntry(const Common::String &name) const;
 
 	// Common::Archive API implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 private:
 	typedef Common::HashMap<Common::String, Entry, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> FileMap;
 
@@ -66,10 +66,10 @@ public:
 	TlkArchive(Common::ArchiveMemberPtr file, uint16 entryCount, const uint32 *fileEntries);
 	~TlkArchive() override;
 
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 private:
 	Common::ArchiveMemberPtr _file;
 
@@ -93,10 +93,10 @@ public:
 	CachedArchive(const FileInputList &files);
 	~CachedArchive() override;
 
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 private:
 	struct Entry {
 		byte *data;

--- a/engines/lastexpress/data/archive.cpp
+++ b/engines/lastexpress/data/archive.cpp
@@ -74,7 +74,8 @@ HPFArchive::HPFArchive(const Common::String &path) {
 	delete archive;
 }
 
-bool HPFArchive::hasFile(const Common::String &name) const {
+bool HPFArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return (_files.find(name) != _files.end());
 }
 
@@ -89,14 +90,16 @@ int HPFArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return numMembers;
 }
 
-const Common::ArchiveMemberPtr HPFArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr HPFArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *HPFArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *HPFArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	FileMap::const_iterator fDesc = _files.find(name);
 	if (fDesc == _files.end())
 		return NULL;

--- a/engines/lastexpress/data/archive.h
+++ b/engines/lastexpress/data/archive.h
@@ -46,10 +46,10 @@ class HPFArchive : public Common::Archive {
 public:
 	HPFArchive(const Common::String &path);
 
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 	int count() { return _files.size(); }
 

--- a/engines/lastexpress/resource.cpp
+++ b/engines/lastexpress/resource.cpp
@@ -144,7 +144,8 @@ Common::SeekableReadStream *ResourceManager::getFileStream(const Common::String 
 //////////////////////////////////////////////////////////////////////////
 // Archive functions
 //////////////////////////////////////////////////////////////////////////
-bool ResourceManager::hasFile(const Common::String &name) const {
+bool ResourceManager::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (Common::Array<HPFArchive *>::const_iterator it = _archives.begin(); it != _archives.end(); ++it) {
 		if ((*it)->hasFile(name))
 			return true;
@@ -167,14 +168,16 @@ int ResourceManager::listMembers(Common::ArchiveMemberList &list) const {
 	return count;
 }
 
-const Common::ArchiveMemberPtr ResourceManager::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr ResourceManager::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *ResourceManager::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *ResourceManager::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (Common::Array<HPFArchive *>::const_iterator it = _archives.begin(); it != _archives.end(); ++it) {
 
 		Common::SeekableReadStream *stream = (*it)->createReadStreamForMember(name);

--- a/engines/lastexpress/resource.h
+++ b/engines/lastexpress/resource.h
@@ -45,10 +45,10 @@ public:
 	Common::SeekableReadStream *getFileStream(const Common::String &name) const;
 
 	// Archive functions
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 	// Resource loading
 	Background *loadBackground(const Common::String &name) const;

--- a/engines/mads/resources.cpp
+++ b/engines/mads/resources.cpp
@@ -83,10 +83,10 @@ public:
 	~HagArchive() override;
 
 	// Archive implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 };
 
 const char *const MADSCONCAT_STRING = "MADSCONCAT";
@@ -99,7 +99,8 @@ HagArchive::~HagArchive() {
 }
 
 // Archive implementation
-bool HagArchive::hasFile(const Common::String &name) const {
+bool HagArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	HagIndex hagIndex;
 	HagEntry hagEntry;
 	return getHeaderEntry(name, hagIndex, hagEntry);
@@ -122,14 +123,16 @@ int HagArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return members;
 }
 
-const Common::ArchiveMemberPtr HagArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr HagArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *HagArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *HagArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	HagIndex hagIndex;
 	HagEntry hagEntry;
 

--- a/engines/mohawk/installer_archive.cpp
+++ b/engines/mohawk/installer_archive.cpp
@@ -107,7 +107,8 @@ void InstallerArchive::close() {
 	_map.clear();
 }
 
-bool InstallerArchive::hasFile(const Common::String &name) const {
+bool InstallerArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return _map.contains(name);
 }
 
@@ -118,11 +119,13 @@ int InstallerArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return _map.size();
 }
 
-const Common::ArchiveMemberPtr InstallerArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr InstallerArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *InstallerArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *InstallerArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_stream || !_map.contains(name))
 		return nullptr;
 

--- a/engines/mohawk/installer_archive.h
+++ b/engines/mohawk/installer_archive.h
@@ -43,10 +43,10 @@ public:
 	bool isOpen() const { return _stream != nullptr; }
 
 	// Common::Archive API implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	struct FileEntry {

--- a/engines/ngi/ngiarchive.cpp
+++ b/engines/ngi/ngiarchive.cpp
@@ -100,7 +100,8 @@ NGIArchive::~NGIArchive() {
 	g_nmi->_currArchive = nullptr;
 }
 
-bool NGIArchive::hasFile(const Common::String &name) const {
+bool NGIArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return _headers.contains(name);
 }
 
@@ -116,14 +117,16 @@ int NGIArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return matches;
 }
 
-const Common::ArchiveMemberPtr NGIArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr NGIArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *NGIArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *NGIArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_headers.contains(name)) {
 		return 0;
 	}

--- a/engines/ngi/ngiarchive.h
+++ b/engines/ngi/ngiarchive.h
@@ -51,10 +51,10 @@ public:
 	~NGIArchive() override;
 
 	// Archive implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 };
 
 /**

--- a/engines/parallaction/disk_ns.cpp
+++ b/engines/parallaction/disk_ns.cpp
@@ -74,10 +74,10 @@ public:
 	NSArchive(Common::SeekableReadStream *stream, Common::Platform platform, uint32 features);
 	~NSArchive() override;
 
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
-	bool hasFile(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 };
 
 
@@ -123,7 +123,8 @@ uint32 NSArchive::lookup(const char *name) const {
 	return i;
 }
 
-Common::SeekableReadStream *NSArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *NSArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	debugC(3, kDebugDisk, "NSArchive::createReadStreamForMember(%s)", name.c_str());
 
 	if (name.empty())
@@ -139,7 +140,8 @@ Common::SeekableReadStream *NSArchive::createReadStreamForMember(const Common::S
 	return new Common::SeekableSubReadStream(_stream, offset, endOffset, DisposeAfterUse::NO);
 }
 
-bool NSArchive::hasFile(const Common::String &name) const {
+bool NSArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (name.empty())
 		return false;
 	return lookup(name.c_str()) != _numFiles;
@@ -152,7 +154,8 @@ int NSArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return _numFiles;
 }
 
-const Common::ArchiveMemberPtr NSArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr NSArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	uint32 index = lookup(name.c_str());
 
 	const char *item = 0;

--- a/engines/pegasus/surface.cpp
+++ b/engines/pegasus/surface.cpp
@@ -92,10 +92,10 @@ void Surface::getImageFromPICTFile(const Common::String &fileName) {
 void Surface::getImageFromPICTResource(Common::MacResManager *resFork, uint16 id) {
 	Common::SeekableReadStream *res = resFork->getResource(MKTAG('P', 'I', 'C', 'T'), id);
 	if (!res)
-		error("Could not open PICT resource %d from '%s'", id, resFork->getBaseFileName().c_str());
+		error("Could not open PICT resource %d from '%s'", id, resFork->getBaseFileName().toString().c_str());
 
 	if (!getImageFromPICTStream(res))
-		error("Failed to load PICT resource %d from '%s'", id, resFork->getBaseFileName().c_str());
+		error("Failed to load PICT resource %d from '%s'", id, resFork->getBaseFileName().toString().c_str());
 
 	delete res;
 }

--- a/engines/pink/file.cpp
+++ b/engines/pink/file.cpp
@@ -50,7 +50,7 @@ OrbFile::~OrbFile() {
 	delete[] _table;
 }
 
-bool OrbFile::open(const Common::String &name) {
+bool OrbFile::open(const Common::Path &name) {
 	if (!File::open(name) || readUint32BE() != MKTAG('O', 'R', 'B', '\0'))
 		return false;
 
@@ -122,7 +122,7 @@ void OrbFile::seekToObject(const char *name) {
 	seek(desc->objectsOffset);
 }
 
-bool BroFile::open(const Common::String &name) {
+bool BroFile::open(const Common::Path &name) {
 	if (!File::open(name) || readUint32BE() != MKTAG('B', 'R', 'O', '\0'))
 		return false;
 

--- a/engines/pink/file.h
+++ b/engines/pink/file.h
@@ -53,7 +53,7 @@ class OrbFile : public Common::File {
 public:
 	OrbFile();
 	~OrbFile() override;
-	bool open(const Common::String &name) override;
+	bool open(const Common::Path &name) override;
 
 public:
 	void loadGame(PinkEngine *game);
@@ -77,7 +77,7 @@ private:
 class BroFile : public Common::File {
 public:
 	BroFile() : _timestamp(0) {}
-	bool open(const Common::String &name) override;
+	bool open(const Common::Path &name) override;
 	uint32 getTimestamp() { return _timestamp; }
 
 private:

--- a/engines/prince/archive.cpp
+++ b/engines/prince/archive.cpp
@@ -130,7 +130,8 @@ void PtcArchive::close() {
 	_items.clear();
 }
 
-bool PtcArchive::hasFile(const Common::String &name) const {
+bool PtcArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	// TODO: check if path matching should be added
 	return _items.contains(name);
 }
@@ -146,14 +147,16 @@ int PtcArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return matches;
 }
 
-const Common::ArchiveMemberPtr PtcArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr PtcArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_items.contains(name)) {
 		Common::ArchiveMemberPtr();
 	}
 	return Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *PtcArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *PtcArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_items.contains(name)) {
 		return 0;
 	}

--- a/engines/prince/archive.h
+++ b/engines/prince/archive.h
@@ -40,10 +40,10 @@ public:
 	bool isOpen() const { return _stream != 0; }
 
 	// Common::Archive API implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	struct FileEntry {

--- a/engines/scumm/file.cpp
+++ b/engines/scumm/file.cpp
@@ -50,7 +50,7 @@ void ScummFile::resetSubfile() {
 	seek(0, SEEK_SET);
 }
 
-bool ScummFile::open(const Common::String &filename) {
+bool ScummFile::open(const Common::Path &filename) {
 	if (File::open(filename)) {
 		resetSubfile();
 		return true;
@@ -187,8 +187,8 @@ uint32 ScummFile::read(void *dataPtr, uint32 dataSize) {
 #pragma mark --- ScummSteamFile ---
 #pragma mark -
 
-bool ScummSteamFile::open(const Common::String &filename) {
-	if (filename.equalsIgnoreCase(_indexFile.indexFileName)) {
+bool ScummSteamFile::open(const Common::Path &filename) {
+	if (filename.toString().equalsIgnoreCase(_indexFile.indexFileName)) {
 		return openWithSubRange(_indexFile.executableName, _indexFile.start, _indexFile.len);
 	} else {
 		// Regular non-bundled file
@@ -323,7 +323,7 @@ bool ScummDiskImage::openDisk(char num) {
 	return true;
 }
 
-bool ScummDiskImage::open(const Common::String &filename) {
+bool ScummDiskImage::open(const Common::Path &filename) {
 	uint16 signature;
 
 	// check signature

--- a/engines/scumm/file.h
+++ b/engines/scumm/file.h
@@ -38,7 +38,7 @@ public:
 	BaseScummFile() : _encbyte(0) {}
 	void setEnc(byte value) { _encbyte = value; }
 
-	bool open(const Common::String &filename) override = 0;
+	bool open(const Common::Path &filename) override = 0;
 	virtual bool openSubFile(const Common::String &filename) = 0;
 
 	int64 pos() const override = 0;
@@ -64,7 +64,7 @@ protected:
 public:
 	ScummFile();
 
-	bool open(const Common::String &filename) override;
+	bool open(const Common::Path &filename) override;
 	bool openSubFile(const Common::String &filename) override;
 
 	void clearErr() override { _myEos = false; BaseScummFile::clearErr(); }
@@ -109,7 +109,7 @@ private:
 public:
 	ScummDiskImage(const char *disk1, const char *disk2, GameSettings game);
 
-	bool open(const Common::String &filename) override;
+	bool open(const Common::Path &filename) override;
 	bool openSubFile(const Common::String &filename) override;
 
 	void close() override;
@@ -138,7 +138,7 @@ private:
 public:
 	ScummSteamFile(const SteamIndexFile &indexFile) : ScummFile(), _indexFile(indexFile) {}
 
-	bool open(const Common::String &filename) override;
+	bool open(const Common::Path &filename) override;
 };
 
 } // End of namespace Scumm

--- a/engines/scumm/file_nes.cpp
+++ b/engines/scumm/file_nes.cpp
@@ -1361,7 +1361,7 @@ bool ScummNESFile::generateIndex() {
 	return true;
 }
 
-bool ScummNESFile::open(const Common::String &filename) {
+bool ScummNESFile::open(const Common::Path &filename) {
 
 	if (_ROMset == kROMsetNum) {
 		Common::String md5str;

--- a/engines/scumm/file_nes.h
+++ b/engines/scumm/file_nes.h
@@ -79,7 +79,7 @@ private:
 public:
 	ScummNESFile();
 
-	bool open(const Common::String &filename) override;
+	bool open(const Common::Path &filename) override;
 	bool openSubFile(const Common::String &filename) override;
 
 	void close() override;

--- a/engines/stark/formats/xarc.cpp
+++ b/engines/stark/formats/xarc.cpp
@@ -134,7 +134,8 @@ Common::String XARCArchive::getFilename() const {
 	return _filename;
 }
 
-bool XARCArchive::hasFile(const Common::String &name) const {
+bool XARCArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (Common::ArchiveMemberList::const_iterator it = _members.begin(); it != _members.end(); ++it) {
 		if ((*it)->getName() == name) {
 			// Found it
@@ -170,7 +171,8 @@ int XARCArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return files;
 }
 
-const Common::ArchiveMemberPtr XARCArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr XARCArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (Common::ArchiveMemberList::const_iterator it = _members.begin(); it != _members.end(); ++it) {
 		if ((*it)->getName() == name) {
 			// Found it
@@ -182,7 +184,8 @@ const Common::ArchiveMemberPtr XARCArchive::getMember(const Common::String &name
 	return Common::ArchiveMemberPtr();
 }
 
-Common::SeekableReadStream *XARCArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *XARCArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (Common::ArchiveMemberList::const_iterator it = _members.begin(); it != _members.end(); ++it) {
 		if ((*it)->getName() == name) {
 			// Found it

--- a/engines/stark/formats/xarc.h
+++ b/engines/stark/formats/xarc.h
@@ -37,11 +37,11 @@ public:
 	Common::String getFilename() const;
 
 	// Archive API
-	bool hasFile(const Common::String &name) const;
+	bool hasFile(const Common::Path &path) const;
 	int listMatchingMembers(Common::ArchiveMemberList &list, const Common::String &pattern) const;
 	int listMembers(Common::ArchiveMemberList &list) const;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const;
 
 	Common::SeekableReadStream *createReadStreamForMember(const XARCMember *member) const;
 

--- a/engines/titanic/support/simple_file.cpp
+++ b/engines/titanic/support/simple_file.cpp
@@ -36,9 +36,9 @@ CString readStringFromStream(Common::SeekableReadStream *s) {
 
 /*------------------------------------------------------------------------*/
 
-bool File::open(const Common::String &filename) {
+bool File::open(const Common::Path &filename) {
 	if (!Common::File::open(filename))
-		error("Could not open file - %s", filename.c_str());
+		error("Could not open file - %s", filename.toString().c_str());
 	return true;
 }
 

--- a/engines/titanic/support/simple_file.h
+++ b/engines/titanic/support/simple_file.h
@@ -41,7 +41,7 @@ class DecompressorData;
  */
 class File : public Common::File {
 public:
-	bool open(const Common::String &filename) override;
+	bool open(const Common::Path &filename) override;
 };
 
 /**

--- a/engines/trecision/fastfile.cpp
+++ b/engines/trecision/fastfile.cpp
@@ -74,7 +74,8 @@ void FastFile::close() {
 	_fileEntries.clear();
 }
 
-bool FastFile::hasFile(const Common::String &name) const {
+bool FastFile::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	const FileEntry *entry = getEntry(name);
 	return entry != nullptr;
 }
@@ -87,11 +88,13 @@ int FastFile::listMembers(Common::ArchiveMemberList &list) const {
 	return list.size();
 }
 
-const Common::ArchiveMemberPtr FastFile::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr FastFile::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *FastFile::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *FastFile::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_stream)
 		return nullptr;
 

--- a/engines/trecision/fastfile.h
+++ b/engines/trecision/fastfile.h
@@ -47,10 +47,10 @@ public:
 	Common::SeekableReadStream *createReadStreamForCompressedMember(const Common::String &name);
 
 	// Common::Archive API implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	Common::SeekableReadStreamEndian *_stream;

--- a/engines/ultima/shared/core/file.cpp
+++ b/engines/ultima/shared/core/file.cpp
@@ -28,6 +28,7 @@ namespace Ultima {
 namespace Shared {
 
 #define ERROR error("Could not open file - %s", name.c_str())
+#define PATH_ERROR error("Could not open file - %s", name.toString().c_str())
 
 File::File(const Common::String &name) : Common::File(), _filesize(-1) {
 	close();
@@ -36,19 +37,19 @@ File::File(const Common::String &name) : Common::File(), _filesize(-1) {
 		ERROR;
 }
 
-bool File::open(const Common::String &name) {
+bool File::open(const Common::Path &name) {
 	close();
 
 	if (!Common::File::open(name))
-		ERROR;
+		PATH_ERROR;
 	return true;
 }
 
-bool File::open(const Common::String &name, Common::Archive &archive) {
+bool File::open(const Common::Path &name, Common::Archive &archive) {
 	close();
 
 	if (!Common::File::open(name, archive))
-		ERROR;
+		PATH_ERROR;
 	return true;
 }
 

--- a/engines/ultima/shared/core/file.h
+++ b/engines/ultima/shared/core/file.h
@@ -43,14 +43,14 @@ public:
 	 * Open the file with the given filename, by searching SearchMan.
 	 * @param	name	the name of the file to open
 	 */
-	bool open(const Common::String &name) override;
+	bool open(const Common::Path &name) override;
 
 	/**
 	 * Open the file with the given filename from within the given archive.
 	 * @param	name	the name of the file to open
 	 * @param	archive		the archive in which to search for the file
 	 */
-	bool open(const Common::String &name, Common::Archive &archive) override;
+	bool open(const Common::Path &name, Common::Archive &archive) override;
 
 	/**
 	 * Open the file corresponding to the give node.

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -116,7 +116,8 @@ bool UltimaDataArchive::load(const Common::String &subfolder,
 
 /*-------------------------------------------------------------------*/
 
-bool UltimaDataArchive::hasFile(const Common::String &name) const {
+bool UltimaDataArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!name.hasPrefixIgnoreCase(_publicFolder))
 		return false;
 
@@ -159,14 +160,16 @@ int UltimaDataArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return result;
 }
 
-const Common::ArchiveMemberPtr UltimaDataArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr UltimaDataArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *UltimaDataArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *UltimaDataArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (hasFile(name)) {
 		Common::String filename = innerToPublic(name);
 		return _zip->createReadStreamForMember(filename);
@@ -179,14 +182,16 @@ Common::SeekableReadStream *UltimaDataArchive::createReadStreamForMember(const C
 
 #ifndef RELEASE_BUILD
 
-const Common::ArchiveMemberPtr UltimaDataArchiveProxy::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr UltimaDataArchiveProxy::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *UltimaDataArchiveProxy::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *UltimaDataArchiveProxy::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (hasFile(name))
 		return getNode(name).createReadStream();
 

--- a/engines/ultima/shared/engine/data_archive.h
+++ b/engines/ultima/shared/engine/data_archive.h
@@ -72,7 +72,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive matching the specified pattern to list.
@@ -94,7 +94,7 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name)
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path)
 		const override;
 
 	/**
@@ -103,7 +103,7 @@ public:
 	 * @return the newly created input stream
 	 */
 	Common::SeekableReadStream *createReadStreamForMember(
-		const Common::String &name) const override;
+		const Common::Path &path) const override;
 };
 
 #ifndef RELEASE_BUILD
@@ -136,7 +136,8 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override {
+	bool hasFile(const Common::Path &path) const override {
+		Common::String name = path.toString();
 		return name.hasPrefixIgnoreCase(_publicFolder) && getNode(name).exists();
 	}
 
@@ -164,7 +165,7 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name)
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path)
 		const override;
 
 	/**
@@ -173,7 +174,7 @@ public:
 	 * @return the newly created input stream
 	 */
 	Common::SeekableReadStream *createReadStreamForMember(
-		const Common::String &name) const override;
+		const Common::Path &path) const override;
 };
 
 #endif

--- a/engines/ultima/shared/engine/resources.cpp
+++ b/engines/ultima/shared/engine/resources.cpp
@@ -55,7 +55,8 @@ void Resources::addResource(const Common::String &name, const byte *data, size_t
 	Common::copy(data, data + size, &lr._data[0]);
 }
 
-bool Resources::hasFile(const Common::String &name) const {
+bool Resources::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (uint idx = 0; idx < _localResources.size(); ++idx)
 		if (!_localResources[idx]._name.compareToIgnoreCase(name))
 			return true;
@@ -71,14 +72,16 @@ int Resources::listMembers(Common::ArchiveMemberList &list) const {
 	return _localResources.size();
 }
 
-const Common::ArchiveMemberPtr Resources::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr Resources::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *Resources::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *Resources::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	for (uint idx = 0; idx < _localResources.size(); ++idx) {
 		const LocalResource &lr = _localResources[idx];
 		if (!lr._name.compareToIgnoreCase(name))

--- a/engines/ultima/shared/engine/resources.h
+++ b/engines/ultima/shared/engine/resources.h
@@ -168,7 +168,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const  override;
+	bool hasFile(const Common::Path &path) const  override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -181,14 +181,14 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const  override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const  override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
 	 * archive. If no member with this name exists, 0 is returned.
 	 * @return the newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const  override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const  override;
 };
 
 } // End of namespace Shared

--- a/engines/wage/world.cpp
+++ b/engines/wage/world.cpp
@@ -140,7 +140,7 @@ bool World::loadWorld(Common::MacResManager *resMan) {
 	if ((resArray = resMan->getResIDArray(MKTAG('V','E','R','S'))).size() == 0)
 		return false;
 
-	_name = resMan->getBaseFileName();
+	_name = resMan->getBaseFileName().toString();
 
 	if (resArray.size() > 1)
 		warning("Too many VERS resources");
@@ -160,7 +160,7 @@ bool World::loadWorld(Common::MacResManager *resMan) {
 		res->skip(3);
 		_aboutMessage = res->readPascalString();
 
-		if (!scumm_stricmp(resMan->getBaseFileName().c_str(), "Scepters"))
+		if (!scumm_stricmp(resMan->getBaseFileName().toString().c_str(), "Scepters"))
 			res->skip(1); // ????
 
 		_soundLibrary1 = res->readPascalString();

--- a/engines/wintermute/base/file/base_package.cpp
+++ b/engines/wintermute/base/file/base_package.cpp
@@ -247,7 +247,8 @@ PackageSet::~PackageSet() {
 	_packages.clear();
 }
 
-bool PackageSet::hasFile(const Common::String &name) const {
+bool PackageSet::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	Common::String upcName = name;
 	upcName.toUppercase();
 	Common::HashMap<Common::String, Common::ArchiveMemberPtr>::const_iterator it;
@@ -267,7 +268,8 @@ int PackageSet::listMembers(Common::ArchiveMemberList &list) const {
 	return count;
 }
 
-const Common::ArchiveMemberPtr PackageSet::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr PackageSet::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	Common::String upcName = name;
 	upcName.toUppercase();
 	Common::HashMap<Common::String, Common::ArchiveMemberPtr>::const_iterator it;
@@ -275,7 +277,8 @@ const Common::ArchiveMemberPtr PackageSet::getMember(const Common::String &name)
 	return Common::ArchiveMemberPtr(it->_value);
 }
 
-Common::SeekableReadStream *PackageSet::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *PackageSet::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	Common::String upcName = name;
 	upcName.toUppercase();
 	Common::HashMap<Common::String, Common::ArchiveMemberPtr>::const_iterator it;

--- a/engines/wintermute/base/file/base_package.h
+++ b/engines/wintermute/base/file/base_package.h
@@ -55,7 +55,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -68,14 +68,14 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
 	 * archive. If no member with this name exists, 0 is returned.
 	 * @return the newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 	int getPriority() const { return _priority; }
 	uint32 getVersion() const { return _version; }

--- a/engines/xeen/files.cpp
+++ b/engines/xeen/files.cpp
@@ -324,21 +324,21 @@ File::File(const Common::String &filename, int ccMode) {
 	File::open(filename, ccMode);
 }
 
-bool File::open(const Common::String &filename) {
+bool File::open(const Common::Path &filename) {
 	if (!_currentSave || !Common::File::open(filename, *_currentSave)) {
 		if (!Common::File::open(filename, *_currentArchive)) {
 			// Could not find in current archive, so try intro.cc or in folder
 			if (!Common::File::open(filename))
-				error("Could not open file - %s", filename.c_str());
+				error("Could not open file - %s", filename.toString().c_str());
 		}
 	}
 
 	return true;
 }
 
-bool File::open(const Common::String &filename, Common::Archive &archive) {
+bool File::open(const Common::Path &filename, Common::Archive &archive) {
 	if (!Common::File::open(filename, archive))
-		error("Could not open file - %s", filename.c_str());
+		error("Could not open file - %s", filename.toString().c_str());
 	return true;
 }
 

--- a/engines/xeen/files.cpp
+++ b/engines/xeen/files.cpp
@@ -121,7 +121,8 @@ void BaseCCArchive::saveIndex(Common::WriteStream &stream) {
 	delete[] rawIndex;
 }
 
-bool BaseCCArchive::hasFile(const Common::String &name) const {
+bool BaseCCArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	CCEntry ccEntry;
 	return getHeaderEntry(name, ccEntry);
 }
@@ -143,7 +144,8 @@ bool BaseCCArchive::getHeaderEntry(uint16 id, CCEntry &ccEntry) const {
 	return false;
 }
 
-const Common::ArchiveMemberPtr BaseCCArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr BaseCCArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
@@ -193,7 +195,8 @@ bool CCArchive::getHeaderEntry(const Common::String &resourceName, CCEntry &ccEn
 	return BaseCCArchive::getHeaderEntry(resName, ccEntry);
 }
 
-Common::SeekableReadStream *CCArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *CCArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	CCEntry ccEntry;
 
 	if (getHeaderEntry(name, ccEntry)) {
@@ -465,7 +468,8 @@ SaveArchive::~SaveArchive() {
 	delete[] _data;
 }
 
-Common::SeekableReadStream *SaveArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *SaveArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 
 	// If the given resource has already been perviously "written" to the
 	// save manager, then return that new resource

--- a/engines/xeen/files.h
+++ b/engines/xeen/files.h
@@ -144,12 +144,12 @@ public:
 	/**
 	 * Opens the given file, throwing an error if it can't be opened
 	 */
-	bool open(const Common::String &filename) override;
+	bool open(const Common::Path &filename) override;
 
 	/**
 	 * Opens the given file, throwing an error if it can't be opened
 	 */
-	bool open(const Common::String &filename, Common::Archive &archive) override;
+	bool open(const Common::Path &filename, Common::Archive &archive) override;
 
 	/**
 	 * Opens the given file, throwing an error if it can't be opened

--- a/engines/xeen/files.h
+++ b/engines/xeen/files.h
@@ -295,9 +295,9 @@ public:
 	BaseCCArchive() {}
 
 	// Archive implementation
-	bool hasFile(const Common::String &name) const override;
+	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList &list) const override;
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 };
 
 /**
@@ -316,7 +316,7 @@ public:
 	~CCArchive() override;
 
 	// Archive implementation
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 };
 
 class SaveArchive : public BaseCCArchive {
@@ -338,7 +338,7 @@ public:
 	/**
 	 * Archive implementation
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 	/**
 	 * Archive implementation

--- a/engines/zvision/file/zfs_archive.cpp
+++ b/engines/zvision/file/zfs_archive.cpp
@@ -104,7 +104,8 @@ Common::String ZfsArchive::readEntryName(Common::SeekableReadStream *stream) con
 	return Common::String(buffer);
 }
 
-bool ZfsArchive::hasFile(const Common::String &name) const {
+bool ZfsArchive::hasFile(const Common::Path &path) const {
+	Common::String name = path.toString();
 	return _entryHeaders.contains(name);
 }
 
@@ -119,14 +120,16 @@ int ZfsArchive::listMembers(Common::ArchiveMemberList &list) const {
 	return matches;
 }
 
-const Common::ArchiveMemberPtr ZfsArchive::getMember(const Common::String &name) const {
+const Common::ArchiveMemberPtr ZfsArchive::getMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_entryHeaders.contains(name))
 		return Common::ArchiveMemberPtr();
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
 }
 
-Common::SeekableReadStream *ZfsArchive::createReadStreamForMember(const Common::String &name) const {
+Common::SeekableReadStream *ZfsArchive::createReadStreamForMember(const Common::Path &path) const {
+	Common::String name = path.toString();
 	if (!_entryHeaders.contains(name)) {
 		return 0;
 	}

--- a/engines/zvision/file/zfs_archive.h
+++ b/engines/zvision/file/zfs_archive.h
@@ -65,7 +65,7 @@ public:
 	 * Patterns are not allowed, as this is meant to be a quick File::exists()
 	 * replacement.
 	 */
-	bool hasFile(const Common::String &fileName) const override;
+	bool hasFile(const Common::Path &path) const override;
 
 	/**
 	 * Add all members of the Archive to list.
@@ -78,7 +78,7 @@ public:
 	/**
 	 * Returns a ArchiveMember representation of the given file.
 	 */
-	const Common::ArchiveMemberPtr getMember(const Common::String &name) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 
 	/**
 	 * Create a stream bound to a member with the specified name in the
@@ -86,7 +86,7 @@ public:
 	 *
 	 * @return    The newly created input stream
 	 */
-	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
 
 private:
 	const Common::String _fileName;

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -693,17 +693,17 @@ bool Debugger::cmdMd5Mac(int argc, const char **argv) {
 			debugPrintf("Resource file '%s' not found\n", filename.c_str());
 		} else {
 			if (!macResMan.hasResFork() && !macResMan.hasDataFork()) {
-				debugPrintf("'%s' has neither data not resource fork\n", macResMan.getBaseFileName().c_str());
+				debugPrintf("'%s' has neither data not resource fork\n", macResMan.getBaseFileName().toString().c_str());
 			} else {
 				// The resource fork is probably the most relevant one.
 				if (macResMan.hasResFork()) {
 					Common::String md5 = macResMan.computeResForkMD5AsString(length);
-					debugPrintf("%s  %s (resource)  %d\n", md5.c_str(), macResMan.getBaseFileName().c_str(), macResMan.getResForkDataSize());
+					debugPrintf("%s  %s (resource)  %d\n", md5.c_str(), macResMan.getBaseFileName().toString().c_str(), macResMan.getResForkDataSize());
 				}
 				if (macResMan.hasDataFork()) {
 					Common::SeekableReadStream *stream = macResMan.getDataFork();
 					Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
-					debugPrintf("%s  %s (data)  %d\n", md5.c_str(), macResMan.getBaseFileName().c_str(), (int32)stream->size());
+					debugPrintf("%s  %s (data)  %d\n", md5.c_str(), macResMan.getBaseFileName().toString().c_str(), (int32)stream->size());
 				}
 			}
 			macResMan.close();

--- a/video/qt_decoder.cpp
+++ b/video/qt_decoder.cpp
@@ -57,7 +57,7 @@ QuickTimeDecoder::~QuickTimeDecoder() {
 	close();
 }
 
-bool QuickTimeDecoder::loadFile(const Common::String &filename) {
+bool QuickTimeDecoder::loadFile(const Common::Path &filename) {
 	if (!Common::QuickTimeParser::parseFile(filename))
 		return false;
 

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -63,7 +63,7 @@ public:
 	QuickTimeDecoder();
 	virtual ~QuickTimeDecoder();
 
-	bool loadFile(const Common::String &filename);
+	bool loadFile(const Common::Path &filename);
 	bool loadStream(Common::SeekableReadStream *stream);
 	void close();
 	uint16 getWidth() const { return _width; }

--- a/video/video_decoder.cpp
+++ b/video/video_decoder.cpp
@@ -82,7 +82,7 @@ void VideoDecoder::close() {
 	_canSetDither = true;
 }
 
-bool VideoDecoder::loadFile(const Common::String &filename) {
+bool VideoDecoder::loadFile(const Common::Path &filename) {
 	Common::File *file = new Common::File();
 
 	if (!file->open(filename)) {

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -26,6 +26,7 @@
 #include "audio/mixer.h"
 #include "audio/timestamp.h"	// TODO: Move this to common/ ?
 #include "common/array.h"
+#include "common/path.h"
 #include "common/rational.h"
 #include "common/str.h"
 #include "graphics/pixelformat.h"
@@ -66,7 +67,7 @@ public:
 	 * @param filename	the filename to load
 	 * @return whether loading the file succeeded
 	 */
-	virtual bool loadFile(const Common::String &filename);
+	virtual bool loadFile(const Common::Path &filename);
 
 	/**
 	 * Load a video from a generic read stream. The ownership of the


### PR DESCRIPTION
This introduces `Common::Path`, a type which is used to pass paths to file-related common functions. Previously, these functions took a string as an argument, using '/' as a directory separator. This was a problem for the Director engine, which has several titles with '/' in file names. Path solves this by allowing path strings with arbitrary directory separators to be converted to/from a safer, common form.

For example, a Path can be created with `Common::Path("dir:subdir:file", ':')` where ':' is the directory separator. A Path can be converted back to a string with `path.toString(':')`. If no directory separator is specified, it defaults to '/', allowing existing code to work with almost no modification.

Internally, Path is just a simple wrapper around a string, and it uses '\x1f' (unit separator) to separate path components. As this is a control character, I don't anticipate that it will appear in file names. However, if needed, Path could easily be changed to use a different separator character or to store path components in an array.