### PR TITLE
SYMBIAN: Add a dependency static library

### DIFF
--- a/backends/platform/symbian/S60v3/build_app_config.mmh
+++ b/backends/platform/symbian/S60v3/build_app_config.mmh
@@ -55,6 +55,7 @@ STATICLIBRARY	libtremor.lib
 STATICLIBRARY	zlib.lib
 STATICLIBRARY	esdl.lib
 STATICLIBRARY	openlibm.lib
+STATICLIBRARY	libc_missed.lib
 
 // *** SOURCE files
 


### PR DESCRIPTION
Add a dependency static library with libc functions missing in Symbian.