### PR TITLE
JANITORIAL: add *.o.tmp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*.swp
 .*.swo
 *.o
+*.o.tmp
 *.dwo
 scummvm.dwp
 lib*.a


### PR DESCRIPTION
Such files are created during compilation, and should not appear in the
output of `git status` nor should `git add` add them.
