### PR TITLE
SCUMM: Add missing MI1 Lemonhead lines

### DIFF
--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1882,7 +1882,7 @@ bool ScummEngine::tryPatchMI1CannibalScript(byte *buf, int size) {
 		// Pad the rest of the replaced script part with spaces before
 		// terminating the string. Finally, add WaitForMessage().
 
-		memset(scriptPtr + patchOffset+ sizeof(patchData), 32, patchLength - sizeof(patchData) - 3);
+		memset(scriptPtr + patchOffset + sizeof(patchData), 32, patchLength - sizeof(patchData) - 3);
 		scriptPtr[patchOffset + patchLength - 3] = 0;
 		scriptPtr[patchOffset + patchLength - 2] = 0xAE;
 		scriptPtr[patchOffset + patchLength - 1] = 0x02;

--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1827,7 +1827,7 @@ bool ScummEngine::tryPatchMI1CannibalScript(byte *buf, int size) {
 	Common::String expectedMd5;
 	int patchOffset = -1;
 	int patchLength = -1;
-	char lang[4];
+	byte lang[3];
 
 	switch (_language) {
 	case Common::EN_ANY:
@@ -1837,7 +1837,9 @@ bool ScummEngine::tryPatchMI1CannibalScript(byte *buf, int size) {
 		expectedMd5 = "98b1126a836ef5bfefff10b605b20555";
 		patchOffset = 167;
 		patchLength = 22;
-		strcpy(lang, "ENG");
+		lang[0] = 'E';
+		lang[1] = 'N';
+		lang[2] = 'G';
 		break;
 	default:
 		return false;
@@ -1877,7 +1879,7 @@ bool ScummEngine::tryPatchMI1CannibalScript(byte *buf, int size) {
 		// language.
 
 		memcpy(scriptPtr + patchOffset, patchData, sizeof(patchData));
-		memcpy(scriptPtr + patchOffset + 7, lang, 3);
+		memcpy(scriptPtr + patchOffset + 7, lang, sizeof(lang));
 
 		// Pad the rest of the replaced script part with spaces before
 		// terminating the string. Finally, add WaitForMessage().

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2815,21 +2815,12 @@ void ScummEngine_v5::decodeParseString() {
 void ScummEngine_v5::printPatchedMI1CannibalString(int textSlot, const byte *ptr) {
 	const char *msg = (const char *)ptr;
 
-#define MSG_WAIT "\xFF\x03"
-
-	if (strncmp((const char *)ptr, "/LMH.001/", 9) == 0) {
+	if (strncmp((const char *)ptr, "/LH.1/", 6) == 0) {
 		msg =
-"Oooh, that's nice." MSG_WAIT
-"Simple.  Just like one of mine." MSG_WAIT
+"Oooh, that's nice.\xFF\x03"
+"Simple.  Just like one of mine.\xFF\x03"
 "And little.  Like mine.";
-	} else if (strncmp((const char *)ptr, "/LMH.002/", 9) == 0) {
-		msg =
-"And it says, `Made by Lemonhead`^" MSG_WAIT
-"^just like one of mine!" MSG_WAIT
-"We should take this to the Great Monkey.";
 	}
-
-#undef MSG_WAIT
 
 	printString(textSlot, (const byte *)msg);
 }

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2815,7 +2815,7 @@ void ScummEngine_v5::decodeParseString() {
 void ScummEngine_v5::printPatchedMI1CannibalString(int textSlot, const byte *ptr) {
 	const char *msg = (const char *)ptr;
 
-	if (strncmp((const char *)ptr, "/LH.1/", 6) == 0) {
+	if (strncmp((const char *)ptr, "/LH.ENG/", 8) == 0) {
 		msg =
 "Oooh, that's nice.\xFF\x03"
 "Simple.  Just like one of mine.\xFF\x03"

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2777,6 +2777,8 @@ void ScummEngine_v5::decodeParseString() {
 					strcpy(tmpBuf + diff, "5000");
 					strcpy(tmpBuf + diff + 4, tmp + sizeof("NCREDIT-NOTE-AMOUNT") - 1);
 					printString(textSlot, (byte *)tmpBuf);
+				} if (_game.id == GID_MONKEY && _roomResource == 25 && vm.slot[_currentScript].number == 205) {
+					printPatchedMI1CannibalString(textSlot, _scriptPointer);
 				} else {
 					printString(textSlot, _scriptPointer);
 				}
@@ -2808,6 +2810,28 @@ void ScummEngine_v5::decodeParseString() {
 	}
 
 	_string[textSlot].saveDefault();
+}
+
+void ScummEngine_v5::printPatchedMI1CannibalString(int textSlot, const byte *ptr) {
+	const char *msg = (const char *)ptr;
+
+#define MSG_WAIT "\xFF\x03"
+
+	if (strncmp((const char *)ptr, "/LMH.001/", 9) == 0) {
+		msg =
+"Oooh, that's nice." MSG_WAIT
+"Simple.  Just like one of mine." MSG_WAIT
+"And little.  Like mine.";
+	} else if (strncmp((const char *)ptr, "/LMH.002/", 9) == 0) {
+		msg =
+"And it says, `Made by Lemonhead`^" MSG_WAIT
+"^just like one of mine!" MSG_WAIT
+"We should take this to the Great Monkey.";
+	}
+
+#undef MSG_WAIT
+
+	printString(textSlot, (const byte *)msg);
 }
 
 } // End of namespace Scumm

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -701,6 +701,8 @@ public:
 	void applyWorkaroundIfNeeded(ResType type, int idx);
 	bool verifyMI2MacBootScript();
 	bool verifyMI2MacBootScript(byte *buf, int size);
+	bool tryPatchMI1CannibalScript(byte *buf, int size);
+
 	int getResourceDataSize(const byte *ptr) const;
 	void dumpResource(const char *tag, int index, const byte *ptr, int length = -1);
 

--- a/engines/scumm/scumm_v5.h
+++ b/engines/scumm/scumm_v5.h
@@ -65,6 +65,7 @@ protected:
 	void setupScummVars() override;
 	void resetScummVars() override;
 	virtual void decodeParseString();
+	void printPatchedMI1CannibalString(int textSlot, const byte *ptr);
 
 	void saveLoadWithSerializer(Common::Serializer &s) override;
 


### PR DESCRIPTION
Apparently some lines for Lemonhead went missing when The Secret From Monkey Island was updated for the CD version. It looks like a mistake, since one of the message that's still there isn't even displayed long enough to see. This pull request re-inserts the missing lines for the English CD version. Apparently localized versions are affected too, but I don't have them so all I can do is trying to make it as easy as possible to extend the workaround for them as well.

The "Ultimate Talkie" also has the bug. This pull request does nothing to fix that. I don't even know if the missing lines were recorded.

Unfortunately, my only savegame is based on boot params, not playing. (I did replay the game recently, but that was on a tablet and frog knows where those savefiles were hidden!)

[monkey1.s22.gz](https://github.com/scummvm/scummvm/files/6930299/monkey1.s22.gz)

