### PR TITLE
SCUMM: COMI: Disable saving/loading during SMUSH videos

### DIFF
--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -96,9 +96,8 @@ bool ScummEngine::canLoadGameStateCurrently() {
 	// the main menu) via its scripts, thus we need to make an
 	// exception here. This the same forced overwriting of the
 	// script decisions as in ScummEngine::processKeyboard.
-	// Also, disable saving/loading when a SAN video is playing.
 	if (_game.id == GID_CMI)
-		return !((ScummEngine_v7 *)this)->isSmushActive();
+		return true;
 
 	return (VAR_MAINMENU_KEY == 0xFF || VAR(VAR_MAINMENU_KEY) != 0);
 }
@@ -131,7 +130,7 @@ bool ScummEngine::canSaveGameStateCurrently() {
 	// the main menu) via its scripts, thus we need to make an
 	// exception here. This the same forced overwriting of the
 	// script decisions as in ScummEngine::processKeyboard.
-	// Also, disable saving/loading when a SAN video is playing.
+	// Also, disable saving when a SAN video is playing.
 	if (_game.id == GID_CMI)
 		return !((ScummEngine_v7 *)this)->isSmushActive();
 

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -96,8 +96,9 @@ bool ScummEngine::canLoadGameStateCurrently() {
 	// the main menu) via its scripts, thus we need to make an
 	// exception here. This the same forced overwriting of the
 	// script decisions as in ScummEngine::processKeyboard.
+	// Also, disable saving/loading when a SAN video is playing.
 	if (_game.id == GID_CMI)
-		return true;
+		return !((ScummEngine_v7 *)this)->isSmushActive();
 
 	return (VAR_MAINMENU_KEY == 0xFF || VAR(VAR_MAINMENU_KEY) != 0);
 }
@@ -130,8 +131,9 @@ bool ScummEngine::canSaveGameStateCurrently() {
 	// the main menu) via its scripts, thus we need to make an
 	// exception here. This the same forced overwriting of the
 	// script decisions as in ScummEngine::processKeyboard.
+	// Also, disable saving/loading when a SAN video is playing.
 	if (_game.id == GID_CMI)
-		return true;
+		return !((ScummEngine_v7 *)this)->isSmushActive();
 
 	// SCUMM v4+ doesn't allow saving in room 0 or if
 	// VAR(VAR_MAINMENU_KEY) to set to zero.


### PR DESCRIPTION
This commit prevents an edge case in COMI, in which SMUSH videos were terminated in case of an event of autosaving.
Also, saving and loading was disabled in the original exe, so I guess we're not losing much here...