### PR TITLE
SWORD25: Properly handle colour conversion

### DIFF
--- a/engines/sword25/gfx/animation.cpp
+++ b/engines/sword25/gfx/animation.cpp
@@ -115,7 +115,7 @@ void Animation::initMembers() {
 	_relY = 0;
 	_scaleFactorX = 1.0f;
 	_scaleFactorY = 1.0f;
-	_modulationColor = 0xffffffff;
+	_modulationColor = BS_ARGBMASK;
 	_animationResourcePtr = 0;
 	_animationTemplateHandle = 0;
 	_framesLocked = false;
@@ -424,7 +424,7 @@ void Animation::setAlpha(int alpha) {
 		return;
 	}
 
-	uint newModulationColor = (_modulationColor & 0x00ffffff) | alpha << 24;
+	uint newModulationColor = (_modulationColor & BS_RGBMASK) | alpha << BS_ASHIFT;
 	if (newModulationColor != _modulationColor) {
 		_modulationColor = newModulationColor;
 		forceRefresh();
@@ -439,7 +439,7 @@ void Animation::setModulationColor(uint modulationColor) {
 		return;
 	}
 
-	uint newModulationColor = (modulationColor & 0x00ffffff) | (_modulationColor & 0xff000000);
+	uint newModulationColor = (modulationColor & BS_RGBMASK) | (_modulationColor & BS_AMASK);
 	if (newModulationColor != _modulationColor) {
 		_modulationColor = newModulationColor;
 		forceRefresh();

--- a/engines/sword25/gfx/bitmap.cpp
+++ b/engines/sword25/gfx/bitmap.cpp
@@ -37,7 +37,7 @@ namespace Sword25 {
 
 Bitmap::Bitmap(RenderObjectPtr<RenderObject> parentPtr, TYPES type, uint handle) :
 	RenderObject(parentPtr, type, handle),
-	_modulationColor(0xffffffff),
+	_modulationColor(BS_ARGBMASK),
 	_scaleFactorX(1.0f),
 	_scaleFactorY(1.0f),
 	_flipH(false),
@@ -64,7 +64,7 @@ void Bitmap::setAlpha(int alpha) {
 		return;
 	}
 
-	uint newModulationColor = (_modulationColor & 0x00ffffff) | alpha << 24;
+	uint newModulationColor = (_modulationColor & BS_RGBMASK) | alpha << BS_ASHIFT;
 	if (newModulationColor != _modulationColor) {
 		_modulationColor = newModulationColor;
 		forceRefresh();
@@ -77,7 +77,7 @@ void Bitmap::setModulationColor(uint modulationColor) {
 		return;
 	}
 
-	uint newModulationColor = (modulationColor & 0x00ffffff) | (_modulationColor & 0xff000000);
+	uint newModulationColor = (modulationColor & BS_RGBMASK) | (_modulationColor & BS_AMASK);
 	if (newModulationColor != _modulationColor) {
 		_modulationColor = newModulationColor;
 		forceRefresh();

--- a/engines/sword25/gfx/bitmap.h
+++ b/engines/sword25/gfx/bitmap.h
@@ -33,6 +33,7 @@
 #define SWORD25_BITMAP_H
 
 #include "sword25/kernel/common.h"
+#include "sword25/gfx/graphicengine.h"
 #include "sword25/gfx/renderobject.h"
 
 namespace Sword25 {
@@ -95,7 +96,7 @@ public:
 	    @remark Diese Methode darf nur aufgerufen werden, wenn die Methode IsAlphaAllowed() true zurückgibt.
 	*/
 	int getAlpha() {
-		return _modulationColor >> 24;
+		return _modulationColor >> BS_ASHIFT;
 	}
 
 	/**
@@ -103,7 +104,7 @@ public:
 	    @remark Diese Methode darf nur aufgerufen werden, wenn die Methode IsColorModulationAllowed() true zurückgibt.
 	*/
 	int getModulationColor() {
-		return _modulationColor & 0x00ffffff;
+		return _modulationColor & BS_RGBMASK;
 	}
 
 	/**

--- a/engines/sword25/gfx/graphicengine.cpp
+++ b/engines/sword25/gfx/graphicengine.cpp
@@ -166,14 +166,14 @@ bool GraphicEngine::getVsync() const {
 bool GraphicEngine::fill(const Common::Rect *fillRectPtr, uint color) {
 	Common::Rect rect(_width - 1, _height - 1);
 
-	int ca = (color >> 24) & 0xff;
+	int ca = (color >> BS_ASHIFT) & 0xff;
 
 	if (ca == 0)
 		return true;
 
-	int cr = (color >> 16) & 0xff;
-	int cg = (color >> 8) & 0xff;
-	int cb = (color >> 0) & 0xff;
+	int cr = (color >> BS_RSHIFT) & 0xff;
+	int cg = (color >> BS_GSHIFT) & 0xff;
+	int cb = (color >> BS_BSHIFT) & 0xff;
 
 	if (fillRectPtr) {
 		rect = *fillRectPtr;
@@ -373,10 +373,10 @@ bool GraphicEngine::saveThumbnailScreenshot(const Common::String &filename) {
 
 void GraphicEngine::ARGBColorToLuaColor(lua_State *L, uint color) {
 	lua_Number components[4] = {
-		(lua_Number)((color >> 16) & 0xff), // Red
-		(lua_Number)((color >>  8) & 0xff), // Green
-		(lua_Number)( color        & 0xff), // Blue
-		(lua_Number)( color >> 24),         // Alpha
+		(lua_Number)((color >> BS_RSHIFT) & 0xff), // Red
+		(lua_Number)((color >> BS_GSHIFT) & 0xff), // Green
+		(lua_Number)((color >> BS_BSHIFT) & 0xff), // Blue
+		(lua_Number)( color >> BS_ASHIFT),         // Alpha
 	};
 
 	lua_newtable(L);
@@ -436,7 +436,7 @@ uint GraphicEngine::luaColorToARGBColor(lua_State *L, int stackIndex) {
 	assert(__startStackDepth == lua_gettop(L));
 #endif
 
-	return (alpha << 24) | (red << 16) | (green << 8) | blue;
+	return BS_ARGB(alpha, red, green, blue);
 }
 
 bool GraphicEngine::persist(OutputPersistenceBlock &writer) {

--- a/engines/sword25/gfx/graphicengine.cpp
+++ b/engines/sword25/gfx/graphicengine.cpp
@@ -181,7 +181,7 @@ bool GraphicEngine::fill(const Common::Rect *fillRectPtr, uint color) {
 
 	if (rect.width() > 0 && rect.height() > 0) {
 		if (ca == 0xff) {
-			_backSurface.fillRect(rect, BS_ARGB(cr, cg, cb, ca));
+			_backSurface.fillRect(rect, _backSurface.format.ARGBToColor(ca, cr, cg, cb));
 		} else {
 			byte *outo = (byte *)_backSurface.getBasePtr(rect.left, rect.top);
 			byte *out;

--- a/engines/sword25/gfx/graphicengine.h
+++ b/engines/sword25/gfx/graphicengine.h
@@ -60,10 +60,21 @@ class Panel;
 class Screenshot;
 class RenderObjectManager;
 
-typedef uint BS_COLOR;
+#define BS_ASHIFT 24
+#define BS_RSHIFT 16
+#define BS_GSHIFT 8
+#define BS_BSHIFT 0
 
-#define BS_RGB(R,G,B)       (0xFF000000 | ((R) << 16) | ((G) << 8) | (B))
-#define BS_ARGB(A,R,G,B)    (((A) << 24) | ((R) << 16) | ((G) << 8) | (B))
+#define BS_AMASK 0xFF000000
+#define BS_RMASK 0x00FF0000
+#define BS_GMASK 0x0000FF00
+#define BS_BMASK 0x000000FF
+
+#define BS_RGBMASK (BS_RMASK | BS_GMASK | BS_BMASK)
+#define BS_ARGBMASK (BS_AMASK | BS_RMASK | BS_GMASK | BS_BMASK)
+
+#define BS_RGB(R,G,B)       (BS_AMASK | ((R) << BS_RSHIFT) | ((G) << BS_GSHIFT) | ((B) << BS_BSHIFT))
+#define BS_ARGB(A,R,G,B)    (((A) << BS_ASHIFT) | ((R) << BS_RSHIFT) | ((G) << BS_GSHIFT) | ((B) << BS_BSHIFT))
 
 /**
  * This is the graphics engine. Unlike the original code, this is not

--- a/engines/sword25/gfx/graphicengine.h
+++ b/engines/sword25/gfx/graphicengine.h
@@ -83,31 +83,6 @@ class RenderObjectManager;
  */
 class GraphicEngine : public ResourceService, public Persistable {
 public:
-	// Enums
-	// -----
-
-	// Color formats
-	//
-	/**
-	 * The color format used by the engine
-	 */
-	enum COLOR_FORMATS {
-		/// Undefined/unknown color format
-		CF_UNKNOWN = 0,
-		/**
-		 * 24-bit color format (R8G8B8)
-		 */
-		CF_RGB24,
-		/**
-		 * 32-bit color format (A8R8G8B8) (little endian)
-		*/
-		CF_ARGB32,
-		/**
-		    32-bit color format (A8B8G8R8) (little endian)
-		*/
-		CF_ABGR32
-	};
-
 	// Constructor
 	// -----------
 	GraphicEngine(Kernel *pKernel);
@@ -247,39 +222,6 @@ public:
 	Common::SeekableReadStream *getThumbnail() { return _thumbnail; }
 
 	// Access methods
-
-	/**
-	 * Returns the size of a pixel entry in bytes for a particular color format
-	 * @param ColorFormat   The desired color format. The parameter must be of type COLOR_FORMATS
-	 * @return              Returns the size of a pixel in bytes. If the color format is unknown, -1 is returned.
-	 */
-	static int getPixelSize(GraphicEngine::COLOR_FORMATS colorFormat) {
-		switch (colorFormat) {
-		case GraphicEngine::CF_ARGB32:
-			return 4;
-		default:
-			return -1;
-		}
-	}
-
-	/**
-	 * Calculates the length of an image line in bytes, depending on a given color format.
-	 * @param ColorFormat   The color format
-	 * @param Width         The width of the line in pixels
-	 * @return              Reflects the length of the line in bytes. If the color format is
-	 * unknown, -1 is returned
-	 */
-	static int calcPitch(GraphicEngine::COLOR_FORMATS colorFormat, int width) {
-		switch (colorFormat) {
-		case GraphicEngine::CF_ARGB32:
-			return width * 4;
-
-		default:
-			assert(false);
-		}
-
-		return -1;
-	}
 
 	// Resource-Managing Methods
 	// --------------------------

--- a/engines/sword25/gfx/image/image.h
+++ b/engines/sword25/gfx/image/image.h
@@ -66,11 +66,6 @@ public:
 	*/
 	virtual int getHeight() const = 0;
 
-	/**
-	    @brief Returns the color format of the image
-	*/
-	virtual GraphicEngine::COLOR_FORMATS getColorFormat() const = 0;
-
 	//@}
 
 	//@{

--- a/engines/sword25/gfx/image/renderedimage.cpp
+++ b/engines/sword25/gfx/image/renderedimage.cpp
@@ -227,7 +227,14 @@ uint RenderedImage::getPixel(int x, int y) {
 // -----------------------------------------------------------------------------
 
 bool RenderedImage::blit(int posX, int posY, int flipping, Common::Rect *pPartRect, uint color, int width, int height, RectangleList *updateRects) {
-	_surface.blit(*_backSurface, posX, posY, (((flipping & 1) ? Graphics::FLIP_V : 0) | ((flipping & 2) ? Graphics::FLIP_H : 0)), pPartRect, color, width, height);
+	int newFlipping = (((flipping & 1) ? Graphics::FLIP_V : 0) | ((flipping & 2) ? Graphics::FLIP_H : 0));
+
+	int ca = (color >> BS_ASHIFT) & 0xff;
+	int cr = (color >> BS_RSHIFT) & 0xff;
+	int cg = (color >> BS_GSHIFT) & 0xff;
+	int cb = (color >> BS_BSHIFT) & 0xff;
+
+	_surface.blit(*_backSurface, posX, posY, newFlipping, pPartRect, _surface.format.ARGBToColor(ca, cr, cg, cb), width, height);
 
 	return true;
 }

--- a/engines/sword25/gfx/image/renderedimage.h
+++ b/engines/sword25/gfx/image/renderedimage.h
@@ -69,9 +69,6 @@ public:
 	int getHeight() const override {
 		return _surface.h;
 	}
-	GraphicEngine::COLOR_FORMATS getColorFormat() const override {
-		return GraphicEngine::CF_ARGB32;
-	}
 
 	void copyDirectly(int posX, int posY);
 

--- a/engines/sword25/gfx/image/swimage.cpp
+++ b/engines/sword25/gfx/image/swimage.cpp
@@ -92,7 +92,10 @@ uint SWImage::getPixel(int x, int y) {
 	assert(x >= 0 && x < _image.w);
 	assert(y >= 0 && y < _image.h);
 
-	return *((const uint32 *)_image.getBasePtr(0, 0));
+	byte a, r, g, b;
+	_image.format.colorToARGB(_image.getPixel(0, 0), a, r, g, b);
+
+	return BS_ARGB(a, r, g, b);
 }
 
 } // End of namespace Sword25

--- a/engines/sword25/gfx/image/swimage.h
+++ b/engines/sword25/gfx/image/swimage.h
@@ -50,9 +50,6 @@ public:
 	int getHeight() const override {
 		return _image.h;
 	}
-	GraphicEngine::COLOR_FORMATS getColorFormat() const override {
-		return GraphicEngine::CF_ARGB32;
-	}
 
 	bool blit(int posX = 0, int posY = 0,
 	                  int flipping = Graphics::FLIP_NONE,

--- a/engines/sword25/gfx/image/vectorimage.h
+++ b/engines/sword25/gfx/image/vectorimage.h
@@ -178,9 +178,6 @@ public:
 	int getHeight() const override {
 		return _boundingBox.height();
 	}
-	GraphicEngine::COLOR_FORMATS getColorFormat() const override {
-		return GraphicEngine::CF_ARGB32;
-	}
 	bool fill(const Common::Rect *pFillRect = 0, uint color = BS_RGB(0, 0, 0)) override;
 
 	void render(int width, int height);

--- a/engines/sword25/gfx/image/vectorimagerenderer.cpp
+++ b/engines/sword25/gfx/image/vectorimagerenderer.cpp
@@ -50,7 +50,7 @@ void art_rgb_fill_run1(byte *buf, byte r, byte g, byte b, int n) {
 		memset(buf, g, n + n + n + n);
 	} else {
 		uint32 *alt = (uint32 *)buf;
-		uint32 color = BS_ARGB(r, g, b, 0xff);
+		uint32 color = TS_RGB(r, g, b);
 
 		for (i = 0; i < n; i++)
 			*alt++ = color;

--- a/engines/sword25/gfx/panel.cpp
+++ b/engines/sword25/gfx/panel.cpp
@@ -71,7 +71,7 @@ Panel::~Panel() {
 
 bool Panel::doRender(RectangleList *updateRects) {
 	// Falls der Alphawert 0 ist, ist das Panel komplett durchsichtig und es muss nichts gezeichnet werden.
-	if (_color >> 24 == 0)
+	if (_color >> BS_ASHIFT == 0)
 		return true;
 
 	GraphicEngine *gfxPtr = Kernel::getInstance()->getGfx();

--- a/engines/sword25/gfx/renderobject.h
+++ b/engines/sword25/gfx/renderobject.h
@@ -45,6 +45,7 @@
 #include "sword25/kernel/common.h"
 #include "sword25/kernel/persistable.h"
 #include "common/rect.h"
+#include "sword25/gfx/graphicengine.h"
 #include "sword25/gfx/renderobjectptr.h"
 
 #include "common/list.h"
@@ -132,7 +133,7 @@ public:
 	            Falls ein Fehler aufgetreten ist wird ein ungültiger BS_RenderObjectPtr zurückgegeben.
 	*/
 
-	RenderObjectPtr<Panel> addPanel(int width, int height, uint color = 0xff000000);
+	RenderObjectPtr<Panel> addPanel(int width, int height, uint color = BS_RGB(0, 0, 0));
 	/**
 	    @brief Erzeugt ein Textobjekt als Kinderobjekt des Renderobjektes.
 	    @param Font der Dateiname des zu verwendenen Fonts

--- a/engines/sword25/gfx/staticbitmap.cpp
+++ b/engines/sword25/gfx/staticbitmap.cpp
@@ -124,10 +124,6 @@ uint StaticBitmap::getPixel(int x, int y) const {
 	assert(pResource->getType() == Resource::TYPE_BITMAP);
 	BitmapResource *pBitmapResource = static_cast<BitmapResource *>(pResource);
 	uint result = pBitmapResource->getPixel(x, y);
-	// Convert to LUA-ready format
-	byte a;
-	a = result & 0xff;
-	result = (result >> 8) | (a << 24);
 	pResource->release();
 	return result;
 }

--- a/engines/sword25/gfx/text.cpp
+++ b/engines/sword25/gfx/text.cpp
@@ -46,7 +46,7 @@ const uint32 AUTO_WRAP_THRESHOLD_DEFAULT = 300;
 
 Text::Text(RenderObjectPtr<RenderObject> parentPtr) :
 	RenderObject(parentPtr, RenderObject::TYPE_TEXT),
-	_modulationColor(0xffffffff),
+	_modulationColor(BS_ARGBMASK),
 	_autoWrap(false),
 	_autoWrapThreshold(AUTO_WRAP_THRESHOLD_DEFAULT) {
 
@@ -55,7 +55,7 @@ Text::Text(RenderObjectPtr<RenderObject> parentPtr) :
 Text::Text(InputPersistenceBlock &reader, RenderObjectPtr<RenderObject> parentPtr, uint handle) :
 		RenderObject(parentPtr, TYPE_TEXT, handle),
 		// Temporarily set fields prior to unpersisting actual values
-		_modulationColor(0xffffffff),
+		_modulationColor(BS_ARGBMASK),
 		_autoWrap(false),
 		_autoWrapThreshold(AUTO_WRAP_THRESHOLD_DEFAULT) {
 
@@ -96,7 +96,7 @@ void Text::setText(const Common::String &text) {
 }
 
 void Text::setColor(uint32 modulationColor) {
-	uint32 newModulationColor = (modulationColor & 0x00ffffff) | (_modulationColor & 0xff000000);
+	uint32 newModulationColor = (modulationColor & BS_RGBMASK) | (_modulationColor & BS_AMASK);
 	if (newModulationColor != _modulationColor) {
 		_modulationColor = newModulationColor;
 		forceRefresh();
@@ -105,7 +105,7 @@ void Text::setColor(uint32 modulationColor) {
 
 void Text::setAlpha(int alpha) {
 	assert(alpha >= 0 && alpha < 256);
-	uint32 newModulationColor = (_modulationColor & 0xffffff) | (alpha << 24);
+	uint32 newModulationColor = (_modulationColor & BS_RGBMASK) | (alpha << BS_ASHIFT);
 	if (newModulationColor != _modulationColor) {
 		_modulationColor = newModulationColor;
 		forceRefresh();

--- a/engines/sword25/gfx/text.h
+++ b/engines/sword25/gfx/text.h
@@ -107,7 +107,7 @@ public:
 	    @return Der Alphawert des Textes (0 = keine Deckung, 255 = volle Deckung).
 	*/
 	int getAlpha() const {
-		return _modulationColor >> 24;
+		return _modulationColor >> BS_ASHIFT;
 	}
 
 	/**
@@ -115,7 +115,7 @@ public:
 	    @return Eine 24-Bit RGB Farbe, die die Farbe des Textes angibt.
 	*/
 	int getColor() const {
-		return _modulationColor & 0x00ffffff;
+		return _modulationColor & BS_RGBMASK;
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes a regression from commit 4df3f333990c4cd0f0d1fda9ad1eb03e054fb2e9 which affects text rendering in the main menu, as well as some other places where colour modulation is used.