### PR TITLE
CONFIGURE: Improve readline detection

### DIFF
--- a/configure
+++ b/configure
@@ -5037,6 +5037,7 @@ if test "$_text_console" = yes ; then
 #include <readline/history.h>
 
 int main(void) {
+	rl_hook_func_t f; // not present in apple's libedit
 	char *x = readline("");
 }
 EOF

--- a/configure
+++ b/configure
@@ -5055,9 +5055,6 @@ else
 fi
 
 if test "$_readline" = yes ; then
-	append_var LIBS "$READLINE_LIBS $_READLINE_LIBS"
-	append_var INCLUDES "$READLINE_CFLAGS"
-
 	#
 	# Check the type of rl_completion_entry_function.
 	# It can be int(*)(const char *, int) or char *(*)(const char *, int).
@@ -5074,9 +5071,15 @@ int main(void) {
 	rl_completion_entry_function = &readline_completionFunction;
 }
 EOF
-	cc_check -c && add_line_to_config_h '#define USE_READLINE_INT_COMPLETION'
+	cc_check $READLINE_CFLAGS $READLINE_LIBS $_READLINE_LIBS -c && add_line_to_config_h '#define USE_READLINE_INT_COMPLETION'
 
 fi
+
+if test "$_readline" = yes ; then
+	append_var LIBS "$READLINE_LIBS $_READLINE_LIBS"
+	append_var INCLUDES "$READLINE_CFLAGS"
+fi
+
 define_in_config_h_if_yes "$_readline" 'USE_READLINE'
 
 define_in_config_h_if_yes "$_text_console" 'USE_TEXT_CONSOLE_FOR_DEBUGGER'


### PR DESCRIPTION
I was trying to get `--enable-text-console` working on mac and ran into some issues:

1. configure detected apple's libedit as readline, even though doing that produces a broken build.
2. Passing `--with-readline-prefix=/opt/homebrew/Cellar/readline/8.1` caused configure to correctly detect the presence of readline, but then incorrectly detect the readline function signature, which also produced a broken build. The readline tests are run with different include orders and the second one used Apple's libedit even though the previous test had just correctly found and used readline with the prefix I specified.

Now configure's detection test includes a reference to `rl_hook_func_t` which gui/debugger.cpp depends on so that it fails early instead of producing a broken build.

The function signature test now uses the same parameters / include-order as the detection test so that the results are consistent and `--with-readline-prefix` is respected.

I can now `--enable-text-console --with-readline-prefix=/opt/homebrew/Cellar/readline/8.1` on a mac M1 and it works great.