### PR TITLE
SCUMM: Restore old clock tower behavior to the CD version of MI1

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -619,6 +619,35 @@ void ScummEngine_v5::o5_add() {
 		}
 	}
 
+	// WORKAROUND: The clock tower is controlled by two variables: 163 and
+	// 247 in the floppy VGA version, 164 and 248 in the CD version. I
+	// don't know about the EGA version, but this fix only concerns the
+	// CD version.
+	//
+	// Whenever you enter the room, the first variable is cleared. It is
+	// then set if you examine the clock tower. The second variable
+	// determines which description you see, e.g. "Ten o'clock.", "Hmm.
+	// Still ten o'clock.", etc.
+	//
+	// If the first variable was set, the second is incremented when you
+	// leave the room. That means that every time you examine the clock
+	// tower, you get a new description (there are three of them, with a
+	// random variation on the last one) but only if you've been away from
+	// the room in between.
+	//
+	// But in the CD version, someone has attempted to "fix" this behavior
+	// by always incrementing the second variable when the clock tower is
+	// examined. So you don't have to leave the room in between, and if
+	// you examine the clock tower once and then leave, the second variable
+	// is incremented twice so you'll never see the second description.
+	//
+	// We restore the old behavior by adding 0, not 1, to the second
+	// variable when examining the clock tower.
+
+	if (_game.id == GID_MONKEY && vm.slot[_currentScript].number == 210 && _currentRoom == 35 && _resultVarNumber == 248 && a == 1) {
+		a = 0;
+	}
+
 	setResult(readVar(_resultVarNumber) + a);
 }
 


### PR DESCRIPTION
By popular demand...

It was pointed out that the clock tower in The Secret of Monkey Island behaves slightly differently in the VGA CD version than it did in the VGA floppy (and presumably also EGA floppy, but I don't have that one) version. While I don't think it _completely_ ruins the joke, I agree that the old behavior is preferable.

In the floppy version, if you examine the clock tower you get a new description (there are three possible ones, with a random variation on the last one) when you examine it, but only if you've left the room in between. The reasoning, I guess, is that you've been away for a while and the clock still hasn't changed.

In the CD version, the description changes _immediately_ when you examine the clock tower, with no need to leave in between. Guybrush's remark that it's still/always 10 o'clock makes less sense. And since the description _still_ changes when you leave the room (if you've examined the clock tower) it's very likely that you'll never even see second description.

This pull request works around that by now allowing room-35-210 to increment Var[248]. (I could have patched the script when it's loaded, but since it contains text strings the offset to patch would be different depending on which version of the game you are running.) This way, it even works with the "ultimate talkie" version. Hopefully with the localized versions as well.