### PR TITLE
SCUMM: MI1: Use correct colors for Smirk's cigar smoke in CD version

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -504,6 +504,22 @@ void ScummEngine_v5::o5_actorOps() {
 			i = getVarOrDirectByte(PARAM_1);
 			j = getVarOrDirectByte(PARAM_2);
 			assertRange(0, i, 31, "o5_actorOps: palette slot");
+
+			// WORKAROUND: The smoke animation is the same as
+			// what's used for the voodoo lady's cauldron. But
+			// for some reason, the colors changed between the
+			// VGA floppy and CD versions. So when it tries to
+			// remap the colors, it uses the wrong indexes. The
+			// CD animation uses colors 1-3, where the floppy
+			// version uses 2, 3, and 9.
+
+			if (_game.id == GID_MONKEY && _currentRoom == 76) {
+				if (i == 3)
+					i = 1;
+				else if (i == 9)
+					i = 3;
+			}
+
 			a->setPalette(i, j);
 			break;
 		case 12:		// SO_TALK_COLOR
@@ -1751,6 +1767,16 @@ void ScummEngine_v5::o5_roomOps() {
 			c = getVarOrDirectWord(PARAM_3);
 			_opcode = fetchScriptByte();
 			d = getVarOrDirectByte(PARAM_1);
+
+			// WORKAROUND: The CD version of Monkey Island 1 will
+			// set a couple of default colors, presumably for the
+			// GUI to use. But in the close-up of captain Smirk,
+			// we want the original color 3 for the cigar smoke. It
+			// should be ok since there is no GUI in this scene.
+
+			if (_game.id == GID_MONKEY && _currentRoom == 76 && d == 3)
+				break;
+
 			setPalColor(d, a, b, c);	/* index, r, g, b */
 		}
 		break;


### PR DESCRIPTION
This pull request is a continuation of https://github.com/scummvm/scummvm/pull/3211 and is an attempt at getting the same colors for the cigar smoke in the CD version as in the floppy version.

My reasoning here is that while we probably can't do anything about the colors in the other cases where this animation is used, and the special edition made the new colors canonical anyway, the cigar smoke has never before been seen in the CD version. Therefore, the floppy version is the canonical version in this particular case.

The CD version without this pull request:

![cd-before](https://user-images.githubusercontent.com/601765/128782209-574b34a0-52cc-499d-9181-ef30a2057f1d.png)

The CD version with this pull request:

![cd-after](https://user-images.githubusercontent.com/601765/128782208-b7fd1016-e268-4190-ab00-04b31898c34a.png)

The floppy version:

![floppy](https://user-images.githubusercontent.com/601765/128782210-342e0e49-e66f-43fa-9eb1-1fcd8c43d910.png)
