### PR TITLE
SCUMM: Add italian translation for MI1 Cannibal script patch

### DIFF
--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1841,6 +1841,17 @@ bool ScummEngine::tryPatchMI1CannibalScript(byte *buf, int size) {
 		lang[1] = 'N';
 		lang[2] = 'G';
 		break;
+	case Common::IT_ITA:
+		expectedSize = 83211;
+		scriptOffset = 73998;
+		scriptLength = 602;
+		expectedMd5 = "39eb6116d67f2318f31d6fa98df2e931";
+		patchOffset = 161;
+		patchLength = 20;
+		lang[0] = 'I';
+		lang[1] = 'T';
+		lang[2] = 'A';
+		break;
 	default:
 		return false;
 	}

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2875,6 +2875,11 @@ void ScummEngine_v5::printPatchedMI1CannibalString(int textSlot, const byte *ptr
 "Oooh, that's nice.\xFF\x03"
 "Simple.  Just like one of mine.\xFF\x03"
 "And little.  Like mine.";
+	} else if (strncmp((const char *)ptr, "/LH.ITA/", 8) == 0) {
+		msg =
+"Oooh, che bello.\xFF\x03"
+"Semplice.  Proprio come uno dei miei.\xFF\x03"
+"E piccolo.  Come il mio.";
 	}
 
 	printString(textSlot, (const byte *)msg);

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2872,14 +2872,14 @@ void ScummEngine_v5::printPatchedMI1CannibalString(int textSlot, const byte *ptr
 
 	if (strncmp((const char *)ptr, "/LH.ENG/", 8) == 0) {
 		msg =
-"Oooh, that's nice.\xFF\x03"
-"Simple.  Just like one of mine.\xFF\x03"
-"And little.  Like mine.";
+			"Oooh, that's nice.\xFF\x03"
+			"Simple.  Just like one of mine.\xFF\x03"
+			"And little.  Like mine.";
 	} else if (strncmp((const char *)ptr, "/LH.ITA/", 8) == 0) {
 		msg =
-"Oooh, che bello.\xFF\x03"
-"Semplice.  Proprio come uno dei miei.\xFF\x03"
-"E piccolo.  Come il mio.";
+			"Oooh, che bello.\xFF\x03"
+			"Semplice.  Proprio come uno dei miei.\xFF\x03"
+			"E piccolo.  Come il mio.";
 	}
 
 	printString(textSlot, (const byte *)msg);


### PR DESCRIPTION
This commit adds the italian translation for the patch implemented by @eriktorbjorn for the CD version of MI1.