### PR TITLE
SCUMM: COMI: Fix getStringWidth behavior

### DIFF
--- a/engines/scumm/script_v8.cpp
+++ b/engines/scumm/script_v8.cpp
@@ -1337,13 +1337,13 @@ void ScummEngine_v8::o8_getStringWidth() {
 	// Skip to the next instruction
 	_scriptPointer += resStrLen(_scriptPointer) + 1;
 
-	convertMessageToString(msg, transBuf, 256);
+	convertMessageToString(msg, transBuf, 512);
 	msg = transBuf;
 
 	// Temporary set the specified charset id
 	_charset->setCurID(charset);
 	// Determine the strings width
-	width = _charset->getStringWidth(0, msg) - 1;
+	width = _charset->getStringWidth(0, msg);
 	// Revert to old font
 	_charset->setCurID(oldID);
 

--- a/engines/scumm/script_v8.cpp
+++ b/engines/scumm/script_v8.cpp
@@ -1337,13 +1337,13 @@ void ScummEngine_v8::o8_getStringWidth() {
 	// Skip to the next instruction
 	_scriptPointer += resStrLen(_scriptPointer) + 1;
 
-	translateText(msg, transBuf);
+	convertMessageToString(msg, transBuf, 256);
 	msg = transBuf;
 
 	// Temporary set the specified charset id
 	_charset->setCurID(charset);
 	// Determine the strings width
-	width = _charset->getStringWidth(0, msg);
+	width = _charset->getStringWidth(0, msg) - 1;
 	// Revert to old font
 	_charset->setCurID(oldID);
 


### PR DESCRIPTION
While researching for another bug ([the object line being out of place in COMI](https://bugs.scummvm.org/ticket/12796)), I found a bug in how `o8_getStringWidth()` calculates the width for object lines.

Originally, ScummVM calls `translateText()` on the string (say, `/SSBT001/` for objects). This works fine when the input is dialogue string (since it contains not only the `/*/` code, but also the full string. 
And it pretty much falls apart when sending just the  `/*/` code 🤕 This means that if by any chance there's an object line whose width should exceed 640 pixel, the script looking for it will never catch that (e.g.: global script 39).

A call to `convertMessageToString()` is enough to fix that and get the expected width... almost.

For some reason, `getStringWidth()` always, always, always returns the expected width+1 for COMI. Since that code is shared with other games I think adding the `- 1` is enough for sake of accuracy.
