### PR TITLE
NEWS: Mention macOS improvements and big-endian fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -190,6 +190,14 @@ For a more comprehensive changelog of the latest experimental code, see:
    - Add native system file browser feature.
    - Re-activate nuked OPL Adlib driver.
 
+ Big-endian ports:
+   - Fixed crashes or rendering issues with the Blazing Dragons, Duckman and
+     Full Pipe games.
+
+ macOS port:
+   - Add support for Dark Mode.
+   - Provide new binaries for Apple Silicon (M1) systems.
+
  MorphOS port:
    - Added native system file browser feature.
    - Added Cloud feature.


### PR DESCRIPTION
Here's some stuff I had in mind for the next release.

For Apple M1, I'm inferring that the download page for 2.3.0 will provide an M1 build which is going to be close to what's currently available in the buildbot, but that's just a guess.