### PR TITLE
SCUMM: DiMUSE: Implement actual setVolume and setPan constraints

### DIFF
--- a/engines/scumm/imuse_digi/dimuse.cpp
+++ b/engines/scumm/imuse_digi/dimuse.cpp
@@ -445,11 +445,9 @@ void IMuseDigital::callback() {
 						// Just in case the speakingActor is not being set...
 						// This allows for a fallback to pan = 64 (center) and volume = 127 (full)
 						if (track->speakingActor != nullptr) {
-							effVol = track->speakingActor->_talkVolume;
-							// Even though we fixed this in IMuseDigital::setVolume(),
-							// some sounds might be started without even calling that function
-							if (effVol > 127)
-								effVol /= 2;
+							if (track->speakingActor->_talkVolume >= 0 && track->speakingActor->_talkVolume <= 127)
+								effVol = track->speakingActor->_talkVolume;
+
 							effVol = int(round(effVol * 1.04));
 							effPan = (track->speakingActor->_talkPan != 64) ? 2 * track->speakingActor->_talkPan - 127 : 0;
 						}

--- a/engines/scumm/imuse_digi/dimuse_script.cpp
+++ b/engines/scumm/imuse_digi/dimuse_script.cpp
@@ -56,10 +56,12 @@ void IMuseDigital::parseScriptCmds(int cmd, int b, int c, int d, int e, int f, i
 			setPriority(soundId, d);
 			break;
 		case 0x600: // set volume
-			setVolume(soundId, d);
+			if (d >= 0 && d <= 127)
+				setVolume(soundId, d);
 			break;
 		case 0x700: // set pan
-			setPan(soundId, d);
+			if (d >= 0 && d <= 127)
+				setPan(soundId, d);
 			break;
 		default:
 			warning("IMuseDigital::doCommand SetParam DEFAULT command %d", sub_cmd);

--- a/engines/scumm/imuse_digi/dimuse_track.cpp
+++ b/engines/scumm/imuse_digi/dimuse_track.cpp
@@ -178,8 +178,17 @@ int IMuseDigital::startSound(int soundId, const char *soundName, int soundType, 
 			if (_vm->_actorToPrintStrFor != 0xFF && _vm->_actorToPrintStrFor != 0) {
 				Actor *a = _vm->derefActor(_vm->_actorToPrintStrFor, "IMuseDigital::startSound");
 				freq = (freq * a->_talkFrequency) / 256;
-				track->pan = a->_talkPan;
-				track->vol = a->_talkVolume * 1000;
+
+				if (a->_talkPan >= 0 && a->_talkPan <= 127)
+					track->pan = a->_talkPan;
+				else
+					track->pan = 64;
+
+				if (a->_talkVolume >= 0 && a->_talkVolume <= 127)
+					track->vol = a->_talkVolume * 1000;
+				else
+					track->vol = 127 * 1000;
+
 				// Keep track of the current actor in COMI:
 				// This is necessary since pan and volume settings for actors
 				// are often changed AFTER the speech sound is started,
@@ -261,9 +270,6 @@ void IMuseDigital::setVolume(int soundId, int volume) {
 	Common::StackLock lock(_mutex, "IMuseDigital::setVolume()");
 	debug(5, "IMuseDigital::setVolume(%d, %d)", soundId, volume);
 
-	if (_vm->_game.id == GID_CMI && volume > 127)
-		volume = volume / 2;
-
 	for (int l = 0; l < MAX_DIGITAL_TRACKS; l++) {
 		Track *track = _track[l];
 		if (track->used && !track->toBeRemoved && (track->soundId == soundId)) {
@@ -302,15 +308,6 @@ int IMuseDigital::getCurMusicSoundId() {
 void IMuseDigital::setPan(int soundId, int pan) {
 	Common::StackLock lock(_mutex, "IMuseDigital::setPan()");
 	debug(5, "IMuseDigital::setPan(%d, %d)", soundId, pan);
-
-	// Sometimes, COMI scumm scripts try to set pan values in the range 0-255
-	// instead of 0-128. I sincerely have no idea why and what exactly is the
-	// correct way of handling these cases (does it happen on a sound by sound basis?).
-	// Until someone properly reverse engineers the engine, this fix works fine for
-	// those sounds (e.g. the cannon fire SFX in Part 1 minigame, the bell sound
-	// in Plunder Town).
-	if (_vm->_game.id == GID_CMI && pan > 127)
-		pan = pan / 2;
 
 	for (int l = 0; l < MAX_DIGITAL_TRACKS; l++) {
 		Track *track = _track[l];


### PR DESCRIPTION
I hope this is gonna be the last PR for the old Digital iMUSE system, I really want to get the new one done soon.
This commit implements constraints for setPan and setVolume (see [here](https://github.com/AndywinXp/Digital-iMULATOR/blob/57255e3a4637dfbc7cff61e700ef3fa505a4fcbd/iMUSE/tracks.c#L369)). 
The decomp ignores any attempt to set a volume or a pan greater than 127 so we do that. In ScummVM (because of how these parameters are then handled by the Mixer class) we also have to account for negative values which, at least for panning, do appear sometimes.

As a result, all three DiMUSE games behave as they should, and I also managed to delete some nasty COMI hacks :-)