### PR TITLE
ENGINES: Move all implementations of getExtraGuiOptions into the detection plugin

### DIFF
--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -372,15 +372,6 @@ GUI::OptionsContainerWidget *MetaEngineDetection::buildEngineOptionsWidgetStatic
 	return new GUI::ExtraGuiOptionsWidget(boss, name, target, engineOptions);
 }
 
-GUI::OptionsContainerWidget *MetaEngine::buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
-	const ExtraGuiOptions engineOptions = getExtraGuiOptions(target);
-	if (engineOptions.empty()) {
-		return nullptr;
-	}
-
-	return new GUI::ExtraGuiOptionsWidget(boss, name, target, engineOptions);
-}
-
 void MetaEngine::removeSaveState(const char *target, int slot) const {
 	if (!hasFeature(kSavesUseExtendedFormat))
 		return;

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -369,29 +369,20 @@ public:
 	virtual Common::Array<Common::Keymap *> initKeymaps(const char *target) const;
 
 	/**
-	 * Return the extra GUI options used by the target.
-	 */
-	virtual const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const {
-		return ExtraGuiOptions();
-	}
-
-	/**
 	 * Return a GUI widget container for configuring the specified target options.
 	 *
-	 * Engines can build custom option dialogs from here, but by default a simple widget
-	 * allowing to configure the extra GUI options is used.
+	 * Engines can build custom option dialogs from here.
 	 *
-	 * The engine that builds the Engines tab in the Edit Game dialog uses a MetaEngineDetection.
-	 * The engine that specifies a custom dialog when a game is running uses a MetaEngine.
-	 *
-	 * Engines are not supposed to have an Engine tab in the Edit Game dialog
-	 * can return nullptr.
+	 * Engines that don't have an Engine tab in the Edit Game dialog, or that use
+	 * ExtraGuiOptions in MetaEngineDetection can return nullptr.
 	 *
 	 * @param boss    The widget or dialog that the returned widget is a child of.
 	 * @param name    The name that the returned widget must use.
 	 * @param target  Name of a config manager target.
 	 */
-	virtual GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const;
+	virtual GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
+		return nullptr;
+	}
 
 	/**
 	 * MetaEngine feature flags.

--- a/engines/twine/detection.cpp
+++ b/engines/twine/detection.cpp
@@ -534,6 +534,100 @@ static const ADGameDescription twineGameDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
+static const ExtraGuiOption OptWallCollision = {
+	_s("Enable wall collisions"),
+	_s("Enable the original wall collision damage"),
+	"wallcollision",
+	false
+};
+
+static const ExtraGuiOption OptCrossFade = {
+	_s("Enable cross fade"),
+	_s("Enable cross fading of images and scenes"),
+	"crossfade",
+	false
+};
+
+// this only changes the menu and doesn't change the autosave behaviour - as scummvm is handling this now
+static const ExtraGuiOption OptDisableSaveMenu = {
+	_s("Disable save menu"),
+	_s("The original only had autosaves. This allows you to save whenever you want."),
+	"useautosaving",
+	false
+};
+
+static const ExtraGuiOption OptDebug = {
+	_s("Enable debug mode"),
+	_s("Enable the debug mode"),
+	"debug",
+	false
+};
+
+static const ExtraGuiOption OptUseCD = {
+	_s("Enable audio CD"),
+	_s("Enable the original audio cd track"),
+	"usecd",
+	false
+};
+
+static const ExtraGuiOption OptSound = {
+	_s("Enable sound"),
+	_s("Enable the sound for the game"),
+	"sound",
+	true
+};
+
+static const ExtraGuiOption OptVoices = {
+	_s("Enable voices"),
+	_s("Enable the voices for the game"),
+	"voice",
+	true
+};
+
+static const ExtraGuiOption OptText = {
+	_s("Enable text"),
+	_s("Enable the text for the game"),
+	"displaytext",
+	true
+};
+
+static const ExtraGuiOption OptMovies = {
+	_s("Enable movies"),
+	_s("Enable the cutscenes for the game"),
+	"movie",
+	true
+};
+
+static const ExtraGuiOption OptMouse = {
+	_s("Enable mouse"),
+	_s("Enable the mouse for the UI"),
+	"mouse",
+	true
+};
+
+static const ExtraGuiOption OptUSAVersion = {
+	_s("Use the USA version"),
+	_s("Enable the USA specific version flags"),
+	"version",
+	false
+};
+
+static const ExtraGuiOption OptHighRes = {
+	_s("Enable high resolution"),
+	_s("Enable a higher resolution for the game"),
+	"usehighres",
+	false
+};
+
+#ifdef USE_TTS
+static const ExtraGuiOption OptTextToSpeech = {
+	_s("TTS Narrator"),
+	_s("Use TTS to read the descriptions (if TTS is available)"),
+	"tts_narrator",
+	false
+};
+#endif
+
 class TwinEMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
 	TwinEMetaEngineDetection() : AdvancedMetaEngineDetection(twineGameDescriptions, sizeof(ADGameDescription), twineGames) {
@@ -550,6 +644,29 @@ public:
 	const char *getOriginalCopyright() const override {
 		return "Little Big Adventure (C) Adeline Software International";
 	}
+
+	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
+
+const ExtraGuiOptions TwinEMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
+	ExtraGuiOptions options;
+	options.push_back(OptWallCollision);
+	options.push_back(OptCrossFade);
+	options.push_back(OptDisableSaveMenu);
+	options.push_back(OptMouse);
+	options.push_back(OptHighRes);
+	options.push_back(OptSound);
+	options.push_back(OptUseCD);
+	// TODO: only 7 are shown right onw - see GUI::ExtraGuiOptionsWidget
+	options.push_back(OptMovies);
+	options.push_back(OptUSAVersion);
+	options.push_back(OptVoices);
+	options.push_back(OptText);
+	options.push_back(OptDebug);
+#ifdef USE_TTS
+	options.push_back(OptTextToSpeech);
+#endif
+	return options;
+}
 
 REGISTER_PLUGIN_STATIC(TWINE_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, TwinEMetaEngineDetection);

--- a/engines/twine/metaengine.cpp
+++ b/engines/twine/metaengine.cpp
@@ -60,129 +60,12 @@ public:
 
 	Common::Array<Common::Keymap *> initKeymaps(const char *target) const override;
 
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
-
 	const Common::AchievementDescriptionList* getAchievementDescriptionList() const override {
 		return TwinE::achievementDescriptionList;
 	}
 
 	void getSavegameThumbnail(Graphics::Surface &thumb) override;
 };
-
-static const ExtraGuiOption OptWallCollision = {
-	_s("Enable wall collisions"),
-	_s("Enable the original wall collision damage"),
-	"wallcollision",
-	false
-};
-
-static const ExtraGuiOption OptCrossFade = {
-	_s("Enable cross fade"),
-	_s("Enable cross fading of images and scenes"),
-	"crossfade",
-	false
-};
-
-// this only changes the menu and doesn't change the autosave behaviour - as scummvm is handling this now
-static const ExtraGuiOption OptDisableSaveMenu = {
-	_s("Disable save menu"),
-	_s("The original only had autosaves. This allows you to save whenever you want."),
-	"useautosaving",
-	false
-};
-
-static const ExtraGuiOption OptDebug = {
-	_s("Enable debug mode"),
-	_s("Enable the debug mode"),
-	"debug",
-	false
-};
-
-static const ExtraGuiOption OptUseCD = {
-	_s("Enable audio CD"),
-	_s("Enable the original audio cd track"),
-	"usecd",
-	false
-};
-
-static const ExtraGuiOption OptSound = {
-	_s("Enable sound"),
-	_s("Enable the sound for the game"),
-	"sound",
-	true
-};
-
-static const ExtraGuiOption OptVoices = {
-	_s("Enable voices"),
-	_s("Enable the voices for the game"),
-	"voice",
-	true
-};
-
-static const ExtraGuiOption OptText = {
-	_s("Enable text"),
-	_s("Enable the text for the game"),
-	"displaytext",
-	true
-};
-
-static const ExtraGuiOption OptMovies = {
-	_s("Enable movies"),
-	_s("Enable the cutscenes for the game"),
-	"movie",
-	true
-};
-
-static const ExtraGuiOption OptMouse = {
-	_s("Enable mouse"),
-	_s("Enable the mouse for the UI"),
-	"mouse",
-	true
-};
-
-static const ExtraGuiOption OptUSAVersion = {
-	_s("Use the USA version"),
-	_s("Enable the USA specific version flags"),
-	"version",
-	false
-};
-
-static const ExtraGuiOption OptHighRes = {
-	_s("Enable high resolution"),
-	_s("Enable a higher resolution for the game"),
-	"usehighres",
-	false
-};
-
-#ifdef USE_TTS
-static const ExtraGuiOption OptTextToSpeech = {
-	_s("TTS Narrator"),
-	_s("Use TTS to read the descriptions (if TTS is available)"),
-	"tts_narrator",
-	false
-};
-#endif
-
-const ExtraGuiOptions TwinEMetaEngine::getExtraGuiOptions(const Common::String &target) const {
-	ExtraGuiOptions options;
-	options.push_back(OptWallCollision);
-	options.push_back(OptCrossFade);
-	options.push_back(OptDisableSaveMenu);
-	options.push_back(OptMouse);
-	options.push_back(OptHighRes);
-	options.push_back(OptSound);
-	options.push_back(OptUseCD);
-	// TODO: only 7 are shown right onw - see GUI::ExtraGuiOptionsWidget
-	options.push_back(OptMovies);
-	options.push_back(OptUSAVersion);
-	options.push_back(OptVoices);
-	options.push_back(OptText);
-	options.push_back(OptDebug);
-#ifdef USE_TTS
-	options.push_back(OptTextToSpeech);
-#endif
-	return options;
-}
 
 void TwinEMetaEngine::getSavegameThumbnail(Graphics::Surface &thumb) {
 	thumb.copyFrom(((TwinEEngine*)g_engine)->_workVideoBuffer);

--- a/engines/ultima/detection.cpp
+++ b/engines/ultima/detection.cpp
@@ -22,6 +22,7 @@
 
 #include "base/plugins.h"
 
+#include "common/config-manager.h"
 #include "common/translation.h"
 
 #include "ultima/detection.h"
@@ -61,6 +62,79 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
+static const ExtraGuiOption COMMON_OPTIONS[] = {
+	{
+		_s("Enable frame skipping"),
+		_s("Allow the game to skip animation frames when running too slow."),
+		"frameSkip",
+		false
+	},
+	{
+		_s("Enable frame limiting"),
+		_s("Limits the speed of the game to prevent running too fast."),
+		"frameLimit",
+		true
+	},
+	{
+		_s("Enable cheats"),
+		_s("Allow cheats by commands and a menu when player is clicked."),
+		"cheat",
+		false
+	},
+	{
+		_s("Enable high resolution"),
+		_s("Enable a higher resolution for the game"),
+		"usehighres",
+		false
+	},
+	{ nullptr, nullptr, nullptr, false }
+};
+
+static const ExtraGuiOption U8_OPTIONS[] = {
+	{
+		_s("Play foot step sounds"),
+		_s("Plays sound when the player moves."),
+		"footsteps",
+		true
+	},
+	{
+		_s("Enable jump to mouse position"),
+		_s("Jumping while not moving targets the mouse cursor rather than direction only."),
+		"targetedjump",
+		true
+	},
+	{
+		_s("Use original save/load screens"),
+		_s("Use the original save/load screens instead of the ScummVM ones"),
+		"originalsaveload",
+		false
+	},
+	{
+		_s("Enable font replacement"),
+		_s("Replaces game fonts with rendered fonts"),
+		"font_override",
+		false
+	},
+	{
+		_s("Enable font anti-aliasing"),
+		_s("When font anti-aliasing is enabled, the text is smoother."),
+		"font_antialiasing",
+		false
+	},
+	{ nullptr, nullptr, nullptr, false }
+};
+
+static const ExtraGuiOption CRUSADER_OPTIONS[] = {
+	{
+		// I18N: Silencer is the player-character in Crusader games, known as the Avatar in Ultima series.
+		_s("Camera moves with Silencer"),
+		_s("Camera tracks the player movement rather than snapping to defined positions."),
+		"camera_on_player",
+		true
+	},
+	{ nullptr, nullptr, nullptr, false }
+};
+
 } // End of namespace Ultima
 
 UltimaMetaEngineDetection::UltimaMetaEngineDetection() : AdvancedMetaEngineDetection(Ultima::GAME_DESCRIPTIONS,
@@ -68,6 +142,41 @@ UltimaMetaEngineDetection::UltimaMetaEngineDetection() : AdvancedMetaEngineDetec
 	static const char *const DIRECTORY_GLOBS[2] = { "usecode", 0 };
 	_maxScanDepth = 2;
 	_directoryGlobs = DIRECTORY_GLOBS;
+}
+
+Common::String UltimaMetaEngineDetection::getGameId(const Common::String& target) {
+	// Store a copy of the active domain
+	Common::String currDomain = ConfMan.getActiveDomainName();
+
+	// Switch to the given target domain and get it's game Id
+	ConfMan.setActiveDomain(target);
+	Common::String gameId = ConfMan.get("gameid");
+
+	// Switch back to the original domain and return the game Id
+	ConfMan.setActiveDomain(currDomain);
+	return gameId;
+}
+
+const ExtraGuiOptions UltimaMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
+	// TODO: Use ADExtraGuiOptionsMap for all games
+	const Common::String gameId = getGameId(target);
+	if (gameId == "ultima8" || gameId == "remorse" || gameId == "regret") {
+		ExtraGuiOptions options;
+
+		for (const ExtraGuiOption *o = Ultima::COMMON_OPTIONS; o->configOption; ++o) {
+			options.push_back(*o);
+		}
+
+		// Game specific options
+		const ExtraGuiOption *game_options = (target.equals("ultima8") ? Ultima::U8_OPTIONS : Ultima::CRUSADER_OPTIONS);
+		for (const ExtraGuiOption *o = game_options; o->configOption; ++o) {
+			options.push_back(*o);
+		}
+
+		return options;
+	}
+
+	return MetaEngineDetection::getExtraGuiOptions(gameId);
 }
 
 REGISTER_PLUGIN_STATIC(ULTIMA_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, UltimaMetaEngineDetection);

--- a/engines/ultima/detection.h
+++ b/engines/ultima/detection.h
@@ -87,6 +87,11 @@ public:
 	const char *getOriginalCopyright() const override {
 		return "Ultima Games (C) 1980-1995 Origin Systems Inc.";
 	}
+
+	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
+
+private:
+	static Common::String getGameId(const Common::String& target);
 };
 
 #endif

--- a/engines/ultima/metaengine.cpp
+++ b/engines/ultima/metaengine.cpp
@@ -94,16 +94,6 @@ Common::KeymapArray UltimaMetaEngine::initKeymaps(const char *target) const {
 	return Common::KeymapArray();
 }
 
-const ExtraGuiOptions UltimaMetaEngine::getExtraGuiOptions(const Common::String& target) const
-{
-	const Common::String gameId = getGameId(target);
-	if (gameId == "ultima8" || gameId == "remorse" || gameId == "regret")
-		return Ultima::Ultima8::MetaEngine::getExtraGuiOptions(gameId);
-
-	ExtraGuiOptions options;
-	return options;
-}
-
 Common::String UltimaMetaEngine::getGameId(const Common::String& target) {
 	// Store a copy of the active domain
 	Common::String currDomain = ConfMan.getActiveDomainName();

--- a/engines/ultima/metaengine.h
+++ b/engines/ultima/metaengine.h
@@ -49,11 +49,6 @@ public:
 	 * Initialize keymaps
 	 */
 	Common::KeymapArray initKeymaps(const char *target) const override;
-
-	/**
-	* Return the extra GUI options used by the target.
-	*/
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
 
 #endif

--- a/engines/ultima/ultima8/meta_engine.cpp
+++ b/engines/ultima/ultima8/meta_engine.cpp
@@ -124,79 +124,6 @@ static const KeybindingRecord DEBUG_KEYS[] = {
 };
 #endif
 
-static const ExtraGuiOption COMMON_OPTIONS[] = {
-	{
-		_s("Enable frame skipping"),
-		_s("Allow the game to skip animation frames when running too slow."),
-		"frameSkip",
-		false
-	},
-	{
-		_s("Enable frame limiting"),
-		_s("Limits the speed of the game to prevent running too fast."),
-		"frameLimit",
-		true
-	},
-	{
-		_s("Enable cheats"),
-		_s("Allow cheats by commands and a menu when player is clicked."),
-		"cheat",
-		false
-	},
-	{
-		_s("Enable high resolution"),
-		_s("Enable a higher resolution for the game"),
-		"usehighres",
-		false
-	},
-	{ nullptr, nullptr, nullptr, false }
-};
-
-static const ExtraGuiOption U8_OPTIONS[] = {
-	{
-		_s("Play foot step sounds"),
-		_s("Plays sound when the player moves."),
-		"footsteps",
-		true
-	},
-	{
-		_s("Enable jump to mouse position"),
-		_s("Jumping while not moving targets the mouse cursor rather than direction only."),
-		"targetedjump",
-		true
-	},
-	{
-		_s("Use original save/load screens"),
-		_s("Use the original save/load screens instead of the ScummVM ones"),
-		"originalsaveload",
-		false
-	},
-	{
-		_s("Enable font replacement"),
-		_s("Replaces game fonts with rendered fonts"),
-		"font_override",
-		false
-	},
-	{
-		_s("Enable font anti-aliasing"),
-		_s("When font anti-aliasing is enabled, the text is smoother."),
-		"font_antialiasing",
-		false
-	},
-	{ nullptr, nullptr, nullptr, false }
-};
-
-static const ExtraGuiOption CRUSADER_OPTIONS[] = {
-	{
-		// I18N: Silencer is the player-character in Crusader games, known as the Avatar in Ultima series.
-		_s("Camera moves with Silencer"),
-		_s("Camera tracks the player movement rather than snapping to defined positions."),
-		"camera_on_player",
-		true
-	},
-	{ nullptr, nullptr, nullptr, false }
-};
-
 Common::KeymapArray MetaEngine::initKeymaps(const Common::String &gameId, bool isMenuActive) {
 	Common::KeymapArray keymapArray;
 
@@ -282,22 +209,6 @@ Common::KeymapArray MetaEngine::initKeymaps(const Common::String &gameId, bool i
 #endif
 
 	return keymapArray;
-}
-
-const ExtraGuiOptions MetaEngine::getExtraGuiOptions(const Common::String& target) {
-	ExtraGuiOptions options;
-
-	for (const ExtraGuiOption *o = COMMON_OPTIONS; o->configOption; ++o) {
-		options.push_back(*o);
-	}
-
-	// Game specific options
-	const ExtraGuiOption *game_options = (target.equals("ultima8") ? U8_OPTIONS : CRUSADER_OPTIONS);
-	for (const ExtraGuiOption *o = game_options; o->configOption; ++o) {
-		options.push_back(*o);
-	}
-
-	return options;
 }
 
 void MetaEngine::setTextInputActive(bool isActive) {

--- a/engines/ultima/ultima8/meta_engine.h
+++ b/engines/ultima/ultima8/meta_engine.h
@@ -68,11 +68,6 @@ public:
 	static Common::KeymapArray initKeymaps(const Common::String &gameId, bool isMenuActive = false);
 
 	/**
-	* Return the extra GUI options used by the target.
-	*/
-	static const ExtraGuiOptions getExtraGuiOptions(const Common::String& target);
-
-	/**
 	 * Execute an engine keymap press action
 	 */
 	static void pressAction(KeybindingAction keyAction);


### PR DESCRIPTION
This is more consistent with the other engines, and allows simplifying the `MetaEngine` interface slightly.

Only the twine changes have been tested. Both engines would potentially benefit from using `ADExtraGuiOptionsMap`, but I've left that for another PR.