### PR TITLE
Fix HiDPI scaling on macOS and iOS

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -101,6 +101,7 @@ public:
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) = 0;
 	virtual int16 getOverlayHeight() const = 0;
 	virtual int16 getOverlayWidth() const = 0;
+	virtual float getHiDPIScreenFactor() const { return 1.0f; }
 
 	virtual bool showMouse(bool visible) = 0;
 	virtual void warpMouse(int x, int y) = 0;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -251,6 +251,12 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	}
 }
 
+float OpenGLSdlGraphicsManager::getHiDPIScreenFactor() const {
+	float scale;
+	getDpiScalingFactor(&scale);
+	return scale;
+}
+
 void OpenGLSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
 	// HACK: This is stupid but the SurfaceSDL backend defaults to 2x. This
 	// assures that the launcher (which requests 320x200) has a reasonable
@@ -288,9 +294,9 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 	// event is processed after recreating the window at the new resolution.
 	int currentWidth, currentHeight;
 	getWindowSizeFromSdl(&currentWidth, &currentHeight);
-	uint scale;
+	float scale;
 	getDpiScalingFactor(&scale);
-	debug(3, "req: %d x %d  cur: %d x %d, scale: %d", width, height, currentWidth, currentHeight, scale);
+	debug(3, "req: %d x %d  cur: %d x %d, scale: %f", width, height, currentWidth, currentHeight, scale);
 
 	handleResize(currentWidth, currentHeight);
 
@@ -299,8 +305,8 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 
 		// FIXME HACK. I don't like this at all, but macOS requires window size in LoDPI
 #ifdef __APPLE__
-		currentWidth /= scale;
-		currentHeight /= scale;
+		currentWidth = (int)(currentWidth / scale);
+		currentHeight = (int)(currentHeight / scale);
 #endif
 		// Reset maximized flag
 		_windowIsMaximized = false;
@@ -643,7 +649,7 @@ bool OpenGLSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 			getWindowSizeFromSdl(&windowWidth, &windowHeight);
 			// FIXME HACK. I don't like this at all, but macOS requires window size in LoDPI
 	#ifdef __APPLE__
-			uint scale;
+			float scale;
 			getDpiScalingFactor(&scale);
 			windowWidth /= scale;
 			windowHeight /= scale;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -250,9 +250,7 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 }
 
 float OpenGLSdlGraphicsManager::getHiDPIScreenFactor() const {
-	float scale;
-	getDpiScalingFactor(&scale);
-	return scale;
+	return getDpiScalingFactor();
 }
 
 void OpenGLSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
@@ -292,8 +290,7 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 	// event is processed after recreating the window at the new resolution.
 	int currentWidth, currentHeight;
 	getWindowSizeFromSdl(&currentWidth, &currentHeight);
-	float scale;
-	getDpiScalingFactor(&scale);
+	float scale = getDpiScalingFactor();
 	debug(3, "req: %d x %d  cur: %d x %d, scale: %f", width, height, currentWidth, currentHeight, scale);
 
 	handleResize(currentWidth, currentHeight);
@@ -647,8 +644,7 @@ bool OpenGLSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 			getWindowSizeFromSdl(&windowWidth, &windowHeight);
 			// FIXME HACK. I don't like this at all, but macOS requires window size in LoDPI
 	#ifdef __APPLE__
-			float scale;
-			getDpiScalingFactor(&scale);
+			float scale = getDpiScalingFactor();
 			windowWidth /= scale;
 			windowHeight /= scale;
 	#endif

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -243,8 +243,6 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 			return _wantsFullScreen;
 		}
 #endif
-	case OSystem::kFeatureHiDPI:
-		return getGraphicsModeScale(0) == 2;
 
 	default:
 		return OpenGLGraphicsManager::getFeatureState(f);

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -42,6 +42,8 @@ public:
 	virtual void initSize(uint w, uint h, const Graphics::PixelFormat *format) override;
 	virtual void updateScreen() override;
 
+	virtual float getHiDPIScreenFactor() const override;
+
 	// EventObserver API
 	virtual bool notifyEvent(const Common::Event &event) override;
 

--- a/backends/graphics/sdl/sdl-graphics-osx.mm
+++ b/backends/graphics/sdl/sdl-graphics-osx.mm
@@ -1,0 +1,45 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+// Disable symbol overrides so that we can use system headers.
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
+#include "SDL_syswm.h"
+#include "backends/graphics/sdl/sdl-graphics.h"
+#include <AppKit/NSWindow.h>
+
+bool SdlGraphicsManager::getMacWindowScaling(float *scale) const {
+#if SDL_VERSION_ATLEAST(2, 0, 0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
+	SDL_SysWMinfo wmInfo;
+	SDL_VERSION(&wmInfo.version); /* initialize info structure with SDL version info */
+	if (!SDL_GetWindowWMInfo(_window->getSDLWindow(), &wmInfo))
+		return false;
+
+	NSWindow *nswindow = wmInfo.info.cocoa.window;
+	if (!nswindow)
+		return false;
+	*scale = [nswindow backingScaleFactor];
+	return true;
+#else
+	return false;
+#endif
+}

--- a/backends/graphics/sdl/sdl-graphics-osx.mm
+++ b/backends/graphics/sdl/sdl-graphics-osx.mm
@@ -27,7 +27,7 @@
 #include "backends/graphics/sdl/sdl-graphics.h"
 #include <AppKit/NSWindow.h>
 
-bool SdlGraphicsManager::getMacWindowScaling(float *scale) const {
+bool SdlGraphicsManager::getMacWindowScaling(float &scale) const {
 #if SDL_VERSION_ATLEAST(2, 0, 0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
 	SDL_SysWMinfo wmInfo;
 	SDL_VERSION(&wmInfo.version); /* initialize info structure with SDL version info */
@@ -37,7 +37,7 @@ bool SdlGraphicsManager::getMacWindowScaling(float *scale) const {
 	NSWindow *nswindow = wmInfo.info.cocoa.window;
 	if (!nswindow)
 		return false;
-	*scale = [nswindow backingScaleFactor];
+	scale = [nswindow backingScaleFactor];
 	return true;
 #else
 	return false;

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -228,9 +228,9 @@ bool SdlGraphicsManager::notifyMousePosition(Common::Point &mouse) {
 
 	int showCursor = SDL_DISABLE;
 	// DPI aware scaling to mouse position
-	uint scale = getFeatureState(BaseBackend::kFeatureHiDPI) ? 2 : 1;
-	mouse.x *= scale;
-	mouse.y *= scale;
+	float scale = getHiDPIScreenFactor();
+	mouse.x = (int)(mouse.x * scale + 0.5f);
+	mouse.y = (int)(mouse.y * scale + 0.5f);
 	bool valid = true;
 	if (_activeArea.drawRect.contains(mouse)) {
 		_cursorLastInActiveArea = true;

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -206,16 +206,16 @@ protected:
 	/**
 	 * Returns the scaling mode based on the display DPI
 	 */
-	void getDpiScalingFactor(uint *scale) const {
+	void getDpiScalingFactor(float *scale) const {
 		float dpi, defaultDpi, ratio;
 
 		getDisplayDpiFromSdl(&dpi, &defaultDpi);
 		debug(4, "dpi: %g default: %g", dpi, defaultDpi);
 		ratio = dpi / defaultDpi;
 		if (ratio >= 1.5f) {
-			*scale = 2;
+			*scale = 2.f;
 		} else {
-			*scale = 1;
+			*scale = 1.f;
 		}
 	}
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -206,24 +206,23 @@ protected:
 	/**
 	 * Returns the scaling mode based on the display DPI
 	 */
-	void getDpiScalingFactor(float *scale) const {
+	float getDpiScalingFactor() const {
 #ifdef MACOSX
+		float scale;
 		if (getMacWindowScaling(scale)) {
-			debug(4, "NSWindow HiDPI scaling: %f", *scale);
-			return;
+			debug(4, "NSWindow HiDPI scaling: %f", scale);
+			return scale;
 		}
 #endif
 
-		float dpi, defaultDpi, ratio;
-
+		float dpi, defaultDpi;
 		getDisplayDpiFromSdl(&dpi, &defaultDpi);
 		debug(4, "dpi: %g default: %g", dpi, defaultDpi);
-		ratio = dpi / defaultDpi;
-		if (ratio >= 1.5f) {
-			*scale = 2.f;
-		} else {
-			*scale = 1.f;
-		}
+		float ratio = dpi / defaultDpi;
+		if (ratio >= 1.5f)
+			return 2.f;
+		else
+			return 1.f;
 	}
 
 	virtual void setSystemMousePosition(const int x, const int y) override;
@@ -254,7 +253,7 @@ private:
 	void toggleFullScreen();
 
 #ifdef MACOSX
-	bool getMacWindowScaling(float *) const;
+	bool getMacWindowScaling(float &) const;
 #endif
 };
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -207,6 +207,13 @@ protected:
 	 * Returns the scaling mode based on the display DPI
 	 */
 	void getDpiScalingFactor(float *scale) const {
+#ifdef MACOSX
+		if (getMacWindowScaling(scale)) {
+			debug(4, "NSWindow HiDPI scaling: %f", *scale);
+			return;
+		}
+#endif
+
 		float dpi, defaultDpi, ratio;
 
 		getDisplayDpiFromSdl(&dpi, &defaultDpi);
@@ -245,6 +252,10 @@ protected:
 
 private:
 	void toggleFullScreen();
+
+#ifdef MACOSX
+	bool getMacWindowScaling(float *) const;
+#endif
 };
 
 #endif

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -243,6 +243,10 @@ int16 ModularGraphicsBackend::getOverlayWidth() {
 	return _graphicsManager->getOverlayWidth();
 }
 
+float ModularGraphicsBackend::getHiDPIScreenFactor() const {
+	return _graphicsManager->getHiDPIScreenFactor();
+}
+
 bool ModularGraphicsBackend::showMouse(bool visible) {
 	return _graphicsManager->showMouse(visible);
 }

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -114,6 +114,8 @@ public:
 	virtual int16 getOverlayHeight() override final;
 	virtual int16 getOverlayWidth() override final;
 
+	virtual float getHiDPIScreenFactor() const override final;
+
 	virtual bool showMouse(bool visible) override final;
 	virtual void warpMouse(int x, int y) override final;
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override final;

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -149,6 +149,11 @@ MODULE_OBJS += \
 	plugins/sdl/sdl-provider.o \
 	timer/sdl/sdl-timer.o
 
+ifdef MACOSX
+MODULE_OBJS += \
+	graphics/sdl/sdl-graphics-osx.o
+endif
+
 # SDL 2 removed audio CD support
 ifndef USE_SDL2
 MODULE_OBJS += \

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -452,8 +452,7 @@ bool OSystem_Android::hasFeature(Feature f) {
 		return false;
 	if (f == kFeatureVirtualKeyboard ||
 			f == kFeatureOpenUrl ||
-			f == kFeatureClipboardSupport ||
-	                f == OSystem::kFeatureHiDPI) {
+			f == kFeatureClipboardSupport) {
 		return true;
 	}
 	return ModularGraphicsBackend::hasFeature(f);

--- a/backends/platform/android/graphics.cpp
+++ b/backends/platform/android/graphics.cpp
@@ -101,6 +101,17 @@ void AndroidGraphicsManager::displayMessageOnOSD(const Common::U32String &msg) {
 	JNI::displayMessageOnOSD(msg);
 }
 
+float AndroidGraphicsManager::getHiDPIScreenFactor() const {
+	// TODO: Use JNI to get DisplayMetrics.density, which according to the documentation
+	// seems to be what we want.
+	// "On a medium-density screen, DisplayMetrics.density equals 1.0; on a high-density
+	//  screen it equals 1.5; on an extra-high-density screen, it equals 2.0; and on a
+	//  low-density screen, it equals 0.75. This figure is the factor by which you should
+	//  multiply the dp units in order to get the actual pixel count for the current screen."
+
+	return 2.f;
+}
+
 bool AndroidGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format) {
 	ENTER("%d, %d, %s", requestedWidth, requestedHeight, format.toString().c_str());
 

--- a/backends/platform/android/graphics.h
+++ b/backends/platform/android/graphics.h
@@ -41,6 +41,8 @@ public:
 	bool notifyMousePosition(Common::Point &mouse);
 	Common::Point getMousePosition() { return Common::Point(_cursorX, _cursorY); }
 
+	virtual float getHiDPIScreenFactor() const override;
+
 protected:
 	virtual void setSystemMousePosition(const int x, const int y) override {}
 

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -199,8 +199,6 @@ bool OSystem_iOS7::getFeatureState(Feature f) {
 		return _videoContext->asprectRatioCorrection;
 	case kFeatureVirtualKeyboard:
 		return isKeyboardShown();
-	case kFeatureHiDPI:
-		return true;
 
 	default:
 		return false;

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -146,6 +146,9 @@ public:
 #endif
 
 	virtual PaletteManager *getPaletteManager() override { return this; }
+
+	virtual float getHiDPIScreenFactor() const override;
+
 protected:
 	// PaletteManager API
 	virtual void setPalette(const byte *colors, uint start, uint num) override;

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -119,6 +119,10 @@ static inline void execute_on_main_thread(void (^block)(void)) {
 	}
 }
 
+float OSystem_iOS7::getHiDPIScreenFactor() const {
+	return [UIScreen mainScreen].scale;
+}
+
 void OSystem_iOS7::initSize(uint width, uint height, const Graphics::PixelFormat *format) {
 	//printf("initSize(%u, %u, %p)\n", width, height, (const void *)format);
 

--- a/common/system.h
+++ b/common/system.h
@@ -1053,6 +1053,12 @@ public:
 	virtual PaletteManager *getPaletteManager() = 0;
 
 	/**
+	 * Return the scale factor for HiDPI screens.
+	 * Returns 1 for non-HiDPI screens, or if HiDPI display is not supported by the backend.
+	 */
+	virtual float getHiDPIScreenFactor() const { return 1.0f; }
+
+	/**
 	 * Blit a bitmap to the virtual screen.
 	 *
 	 * The real screen will not immediately be updated to reflect the changes.

--- a/common/system.h
+++ b/common/system.h
@@ -363,11 +363,6 @@ public:
 		kFeatureFilteringMode,
 
 		/**
-		 * Indicates that GUI runs in HiDPI mode
-		 */
-		kFeatureHiDPI,
-
-		/**
 		 * Indicate if stretch modes are supported by the backend.
 		 */
 		kFeatureStretchMode,

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -109,33 +109,12 @@ GuiManager::~GuiManager() {
 void GuiManager::computeScaleFactor() {
 	uint16 w = g_system->getOverlayWidth();
 	uint16 h = g_system->getOverlayHeight();
-	float scale = g_system->getHiDPIScreenFactor();
 
-	_baseHeight = 0;	// Clean up from previous iteration
+	_scaleFactor = g_system->getHiDPIScreenFactor();
+	if (ConfMan.hasKey("gui_scale"))
+		_scaleFactor *= ConfMan.getInt("gui_scale") / 100.f;
 
-	if (ConfMan.hasKey("gui_base")) {
-		_baseHeight = ConfMan.getInt("gui_base");
-
-		if (h < _baseHeight)
-			_baseHeight = 0; // Switch to auto for lower resolutions
-	}
-
-	if (_baseHeight == 0) {	// auto
-		if (h < 240 * scale) {	// 320 x 200
-			_baseHeight = MIN<int16>(200, h);
-		} else if (h < 400 * scale) {	// 320 x 240
-			_baseHeight = 240;
-		} else if (h < 480 * scale) {	// 640 x 400
-			_baseHeight = 400;
-		} else if (h < 720 * scale) {	// 640 x 480
-			_baseHeight = 480;
-		} else {				// 960 x 720
-			_baseHeight = 720;
-		}
-	}
-
-	_scaleFactor = (float)h / (float)_baseHeight;
-
+	_baseHeight = (int16)((float)h / _scaleFactor);
 	_baseWidth = (int16)((float)w / _scaleFactor);
 
 	if (_theme)

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -109,7 +109,7 @@ GuiManager::~GuiManager() {
 void GuiManager::computeScaleFactor() {
 	uint16 w = g_system->getOverlayWidth();
 	uint16 h = g_system->getOverlayHeight();
-	uint scale = g_system->getFeatureState(OSystem::kFeatureHiDPI) ? 2 : 1;
+	float scale = g_system->getHiDPIScreenFactor();
 
 	_baseHeight = 0;	// Clean up from previous iteration
 

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -134,8 +134,8 @@ static const char *savePeriodLabels[] = { _s("Never"), _s("Every 5 mins"), _s("E
 static const int savePeriodValues[] = { 0, 5 * 60, 10 * 60, 15 * 60, 30 * 60, -1 };
 
 static const char *guiBaseLabels[] = {
-	// I18N: Automatic GUI scaling
-	_s("Auto"),
+	// I18N: Very large GUI scale
+	_s("Very large"),
 	// I18N: Large GUI scale
 	_s("Large"),
 	// I18N: Medium GUI scale
@@ -144,7 +144,7 @@ static const char *guiBaseLabels[] = {
 	_s("Small"),
 	nullptr
 };
-static const int guiBaseValues[] = { 0, 240, 480, 720, -1 };
+static const int guiBaseValues[] = { 150, 125, 100, 75, -1 };
 
 // The keyboard mouse speed values range from 0 to 7 and correspond to speeds shown in the label
 // "10" (value 3) is the default speed corresponding to the speed before introduction of this control
@@ -2134,8 +2134,8 @@ void GlobalOptionsDialog::build() {
 #endif
 
 	// Misc Tab
-	_guiBasePopUp->setSelected(1);
-	int value = ConfMan.getInt("gui_base");
+	_guiBasePopUp->setSelected(2);
+	int value = ConfMan.getInt("gui_scale");
 	for (int i = 0; guiBaseLabels[i]; i++) {
 		if (value == guiBaseValues[i])
 			_guiBasePopUp->setSelected(i);
@@ -2517,9 +2517,9 @@ void GlobalOptionsDialog::apply() {
 #endif // USE_SDL_NET
 #endif // USE_CLOUD
 
-	int oldGuiBase = ConfMan.getInt("gui_base");
-	ConfMan.setInt("gui_base", _guiBasePopUp->getSelectedTag(), _domain);
-	if (oldGuiBase != (int)_guiBasePopUp->getSelectedTag())
+	int oldGuiScale = ConfMan.getInt("gui_scale");
+	ConfMan.setInt("gui_scale", _guiBasePopUp->getSelectedTag(), _domain);
+	if (oldGuiScale != (int)_guiBasePopUp->getSelectedTag())
 		g_gui.computeScaleFactor();
 
 	ConfMan.setInt("autosave_period", _autosavePeriodPopUp->getSelectedTag(), _domain);


### PR DESCRIPTION
The main purpose of this pull request is to fix issues with the HiDPI handling on macOS and iOS.

On macOS the main issue is that on some non-retina screens, the code in master currently think that the screen is a HiDPI screen with a scale of 2. This results in various issues, such as:
 - the GUI appearing by default in lowres layout despite the window being big enough for the normal layout
 - the window get smaller and smaller each time we close and restart ScummVM (https://bugs.scummvm.org/ticket/12590)

On iOS the issue is the other way around. The code in master currently assume the HiDPI scaling is 2. But on some iOS device it can be 3, and that causes the GUI to be too small by default (and it makes it difficult to go into the option to change the GUI scale).

Both are fixed by adding a new `float getHiDPIScreenFactor()` to `OSystem` and implementing it on both iOS and macOS using the system API. On other SDL backends the implementation is the same as in master (looks at the dpi and returns 1 or 2).

I also added an implementation in the Android backend, and it currently always return 2. This should preserver the current behaviour from master, but I suspect the scaling should actually depend on the device (as on iOS). A developer familiar with that backend should take a look to implement it properly. According to https://developer.android.com/training/multiscreen/screendensities, it seems that DisplayMetrics.density might gives us what we want:
> On a medium-density screen, DisplayMetrics.density equals 1.0; on a high-density screen it equals 1.5; on an extra-high-density screen, it equals 2.0; and on a low-density screen, it equals 0.75. This figure is the factor by which you should multiply the dp units in order to get the actual pixel count for the current screen.

I tested this on macOS on both a retina laptop and a non-retina one, and both are now working properly. In particular I confirmed that this fixes [bug #12590](https://bugs.scummvm.org/ticket/12590).

I have not yet tested on iOS, but since we have limited time before the next release I decided to open this pull request as soon as possible so that others can have a look and test it while I confirm that the behaviour on iOS is also fixed.

Finally I have added one last commit that is not required but in my opinion improves the behaviour of the GUI scale option. Instead of indicating a base resolution, it indicates a scaling. This scaling is multiplied with the HiDPI scaling, and is 100% by default. This change means that when resizing the window it now preserves the text size instead of making it bigger or smaller. This might also work better on some devices with unusual sizes since it no longer relies on a small set of hardcoded base resolutions.