### PR TITLE
WIN32: Remove F_OK/R_OK/W_OK hack

### DIFF
--- a/backends/fs/windows/windows-fs.cpp
+++ b/backends/fs/windows/windows-fs.cpp
@@ -42,7 +42,7 @@ bool WindowsFilesystemNode::isReadable() const {
 bool WindowsFilesystemNode::isWritable() const {
 	// Check whether the file exists and it can be written.
 	DWORD fileAttribs = GetFileAttributes(charToTchar(_path.c_str()));
-	return (fileAttribs != INVALID_FILE_ATTRIBUTES) & !(fileAttribs & FILE_ATTRIBUTE_READONLY);
+	return ((fileAttribs != INVALID_FILE_ATTRIBUTES) && (!(fileAttribs & FILE_ATTRIBUTE_READONLY)));
 }
 
 void WindowsFilesystemNode::addFile(AbstractFSList &list, ListMode mode, const char *base, bool hidden, WIN32_FIND_DATA* find_data) {


### PR DESCRIPTION
Into `backends/fs/windows/windows-fs.cpp`, the macros `F_OK`/`R_OK`/`W_OK` are not defined by system includes of MSVC, so they have been added manually into the code.
While this solution works, in my opinion it would be much cleaner to use `GetFileAttributes()` for getting this information.
Actually, this is what the `_access()`/`_waccess()` functions do and, afterall, this is a piece of code expected to work on Windows only.
