### PR TITLE
BACKENDS: OPENGLSDL: Fix logic errors in window size management

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -348,6 +348,7 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	// Fetch current desktop resolution and determining max. width and height
 	Common::Rect desktopRes = _window->getDesktopResolution();
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	if ((SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
 		// Set the window size to the values stored when the window was maximized
 		// for the last time.
@@ -374,6 +375,18 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		ConfMan.setInt("last_window_height", requestedHeight, Common::ConfigManager::kApplicationDomain);
 		ConfMan.flushToDisk();
 	}
+
+#else
+		// Set the basic window size based on the desktop resolution
+		// since we cannot reliably determine the current window state
+		// on SDL1.
+		requestedWidth  = desktopRes.width()  * 0.3f;
+		requestedHeight = desktopRes.height() * 0.4f;
+
+		// Apply scaler
+		requestedWidth  *= _graphicsScale;
+		requestedHeight *= _graphicsScale;
+#endif
 
 	// Determine current aspect ratio
 	uint maxAllowedWidth   = desktopRes.width();

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -302,17 +302,13 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 		currentWidth /= scale;
 		currentHeight /= scale;
 #endif
-		// Reset maximized flag
-		_windowIsMaximized = false;
 
 		// Check if the ScummVM window is maximized and store the current
 		// window dimensions.
-		if ((SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) == 128) {
-			_windowIsMaximized = true;
+		if (SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) {
 			ConfMan.setInt("window_maximized_width", currentWidth, Common::ConfigManager::kApplicationDomain);
 			ConfMan.setInt("window_maximized_height", currentHeight, Common::ConfigManager::kApplicationDomain);
 		} else {
-			_windowIsMaximized = false;
 			ConfMan.setInt("last_window_width", currentWidth, Common::ConfigManager::kApplicationDomain);
 			ConfMan.setInt("last_window_height", currentHeight, Common::ConfigManager::kApplicationDomain);
 		}
@@ -352,13 +348,13 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	// Fetch current desktop resolution and determining max. width and height
 	Common::Rect desktopRes = _window->getDesktopResolution();
 
-	if (_windowIsMaximized == true) {
+	if ((SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
 		// Set the window size to the values stored when the window was maximized
-		// for the last time. We also need to reset any scaling here.
+		// for the last time.
 		requestedWidth  = ConfMan.getInt("window_maximized_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
 
-	} else if (ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
+	} else if (!(SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
 		// Restore previously stored window dimensions.
 		requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -348,6 +348,9 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	// Fetch current desktop resolution and determining max. width and height
 	Common::Rect desktopRes = _window->getDesktopResolution();
 
+	// Determine current desktop aspect ratio
+	float ratio = (float)desktopRes.width() / (float)desktopRes.height();
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	bool _isMaximized = (SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED);
 	if (_isMaximized && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
@@ -364,8 +367,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	} else {
 		// Set the basic window size based on the desktop resolution
 		// since we have no values stored, e.g. on first launch.
-		requestedWidth  = desktopRes.width()  * (1.0f / 4.0f) * 1.2f;
-		requestedHeight = desktopRes.height() * (1.0f / 3.0f) * 1.2f;
+		requestedWidth  = desktopRes.width()  * (1.0f / 3.0f) * 1.5f / ratio;
+		requestedHeight = desktopRes.height() * (1.0f / 4.0f) * 1.5f;
 
 		// Apply scaler
 		requestedWidth  *= _graphicsScale;
@@ -381,18 +384,17 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		// Set the basic window size based on the desktop resolution
 		// since we cannot reliably determine the current window state
 		// on SDL1.
-		requestedWidth  = desktopRes.width()  * (1.0f / 4.0f) * 1.2f;
-		requestedHeight = desktopRes.height() * (1.0f / 3.0f) * 1.2f;
+		requestedWidth  = desktopRes.width()  * (1.0f / 3.0f) * 1.5f / ratio;
+		requestedHeight = desktopRes.height() * (1.0f / 4.0f) * 1.5f;
 
 		// Apply scaler
 		requestedWidth  *= _graphicsScale;
 		requestedHeight *= _graphicsScale;
 #endif
 
-	// Determine current aspect ratio
+	// Set allowed dimensions
 	uint maxAllowedWidth   = desktopRes.width();
 	uint maxAllowedHeight  = desktopRes.height();
-	float ratio = (float)requestedWidth / (float)requestedHeight;
 
 	// Check if we request a larger window than physically possible,
 	// e.g. by starting with additional launcher parameters forcing

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -360,7 +360,7 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
 
 	} else if (!_isMaximized && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
-		// Restore previously stored window dimensions.
+		// Load previously stored window dimensions.
 		requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);
 
@@ -384,6 +384,14 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		requestedHeight = MIN<uint>(requestedWidth * 3 / 4, desktopRes.height());
 
 #endif
+
+	// In case we detected an increase in the requested window dimensions (e.g. when launching
+	// a game in 800x600 while having a smaller screen size stored in the configuration file),
+	// we override the window dimensions with the "real" request.
+	if ((requestedWidth < _lastRequestedWidth || requestedHeight < _lastRequestedHeight) && ConfMan.getActiveDomain()) {
+		requestedWidth  = _lastRequestedWidth  * _graphicsScale;
+		requestedHeight = _lastRequestedHeight * _graphicsScale;
+	}
 
 	// Set allowed dimensions
 	uint maxAllowedWidth   = desktopRes.width();

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -383,9 +383,6 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		requestedWidth  = MAX<uint>(desktopRes.width() / 2, MIN<uint>(640, desktopRes.width()));
 		requestedHeight = MIN<uint>(requestedWidth * 3 / 4, desktopRes.height());
 
-		// Apply scaler
-		requestedWidth  *= _graphicsScale;
-		requestedHeight *= _graphicsScale;
 #endif
 
 	// Set allowed dimensions

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -367,12 +367,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	} else {
 		// Set the basic window size based on the desktop resolution
 		// since we have no values stored, e.g. on first launch.
-		requestedWidth  = desktopRes.width()  * (1.0f / 3.0f) * 1.5f / ratio;
-		requestedHeight = desktopRes.height() * (1.0f / 4.0f) * 1.5f;
-
-		// Apply scaler
-		requestedWidth  *= _graphicsScale;
-		requestedHeight *= _graphicsScale;
+		requestedWidth  = MAX<uint>(desktopRes.width() / 2, MIN<uint>(640, desktopRes.width()));
+		requestedHeight = MIN<uint>(requestedWidth * 3 / 4, desktopRes.height());
 
 		// Save current window dimensions
 		ConfMan.setInt("last_window_width", requestedWidth, Common::ConfigManager::kApplicationDomain);
@@ -384,8 +380,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		// Set the basic window size based on the desktop resolution
 		// since we cannot reliably determine the current window state
 		// on SDL1.
-		requestedWidth  = desktopRes.width()  * (1.0f / 3.0f) * 1.5f / ratio;
-		requestedHeight = desktopRes.height() * (1.0f / 4.0f) * 1.5f;
+		requestedWidth  = MAX<uint>(desktopRes.width() / 2, MIN<uint>(640, desktopRes.width()));
+		requestedHeight = MIN<uint>(requestedWidth * 3 / 4, desktopRes.height());
 
 		// Apply scaler
 		requestedWidth  *= _graphicsScale;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -350,13 +350,13 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	bool _isMaximized = (SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED);
-	if ((_isMaximized) && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
+	if (_isMaximized && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
 		// Set the window size to the values stored when the window was maximized
 		// for the last time.
 		requestedWidth  = ConfMan.getInt("window_maximized_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
 
-	} else if (!(_isMaximized) && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
+	} else if (!_isMaximized && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
 		// Restore previously stored window dimensions.
 		requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);
@@ -364,8 +364,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	} else {
 		// Set the basic window size based on the desktop resolution
 		// since we have no values stored, e.g. on first launch.
-		requestedWidth  = desktopRes.width()  * ((float)1 / (float)4) * 1.2f;
-		requestedHeight = desktopRes.height() * ((float)1 / (float)3) * 1.2f;
+		requestedWidth  = desktopRes.width()  * (1.0f / 4.0f) * 1.2f;
+		requestedHeight = desktopRes.height() * (1.0f / 3.0f) * 1.2f;
 
 		// Apply scaler
 		requestedWidth  *= _graphicsScale;
@@ -381,8 +381,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		// Set the basic window size based on the desktop resolution
 		// since we cannot reliably determine the current window state
 		// on SDL1.
-		requestedWidth  = desktopRes.width()  * ((float)1 / (float)4) * 1.2f;
-		requestedHeight = desktopRes.height() * ((float)1 / (float)3) * 1.2f;
+		requestedWidth  = desktopRes.width()  * (1.0f / 4.0f) * 1.2f;
+		requestedHeight = desktopRes.height() * (1.0f / 3.0f) * 1.2f;
 
 		// Apply scaler
 		requestedWidth  *= _graphicsScale;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -386,8 +386,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 #endif
 
 	// Set allowed dimensions
-	uint maxAllowedWidth   = desktopRes.width();
-	uint maxAllowedHeight  = desktopRes.height();
+	uint maxAllowedWidth   = desktopRes.width()  * 0.9f;
+	uint maxAllowedHeight  = desktopRes.height() * 0.9f;
 
 	// Check if we request a larger window than physically possible,
 	// e.g. by starting with additional launcher parameters forcing

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -363,8 +363,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	} else {
 		// Set the basic window size based on the desktop resolution
 		// since we have no values stored, e.g. on first launch.
-		requestedWidth  = desktopRes.width()  * 0.3f;
-		requestedHeight = desktopRes.height() * 0.4f;
+		requestedWidth  = desktopRes.width()  * ((float)1 / (float)4) * 1.2f;
+		requestedHeight = desktopRes.height() * ((float)1 / (float)3) * 1.2f;
 
 		// Apply scaler
 		requestedWidth  *= _graphicsScale;
@@ -380,8 +380,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		// Set the basic window size based on the desktop resolution
 		// since we cannot reliably determine the current window state
 		// on SDL1.
-		requestedWidth  = desktopRes.width()  * 0.3f;
-		requestedHeight = desktopRes.height() * 0.4f;
+		requestedWidth  = desktopRes.width()  * ((float)1 / (float)4) * 1.2f;
+		requestedHeight = desktopRes.height() * ((float)1 / (float)3) * 1.2f;
 
 		// Apply scaler
 		requestedWidth  *= _graphicsScale;
@@ -391,7 +391,7 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	// Determine current aspect ratio
 	uint maxAllowedWidth   = desktopRes.width();
 	uint maxAllowedHeight  = desktopRes.height();
-	float ratio = (float)requestedWidth / requestedHeight;
+	float ratio = (float)requestedWidth / (float)requestedHeight;
 
 	// Check if we request a larger window than physically possible,
 	// e.g. by starting with additional launcher parameters forcing

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -367,8 +367,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	} else {
 		// Set the basic window size based on the desktop resolution
 		// since we have no values stored, e.g. on first launch.
-		requestedWidth  = MAX<uint>(desktopRes.width() / 2, MIN<uint>(640, desktopRes.width()));
-		requestedHeight = MIN<uint>(requestedWidth * 3 / 4, desktopRes.height());
+		requestedWidth  = MAX<uint>(desktopRes.width() / 2, 640);
+		requestedHeight = requestedWidth * 3 / 4;
 
 		// Save current window dimensions
 		ConfMan.setInt("last_window_width", requestedWidth, Common::ConfigManager::kApplicationDomain);
@@ -380,8 +380,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		// Set the basic window size based on the desktop resolution
 		// since we cannot reliably determine the current window state
 		// on SDL1.
-		requestedWidth  = MAX<uint>(desktopRes.width() / 2, MIN<uint>(640, desktopRes.width()));
-		requestedHeight = MIN<uint>(requestedWidth * 3 / 4, desktopRes.height());
+		requestedWidth  = MAX<uint>(desktopRes.width() / 2, 640);
+		requestedHeight = requestedWidth * 3 / 4;
 
 #endif
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -348,9 +348,6 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	// Fetch current desktop resolution and determining max. width and height
 	Common::Rect desktopRes = _window->getDesktopResolution();
 
-	// Determine current desktop aspect ratio
-	float ratio = (float)desktopRes.width() / (float)desktopRes.height();
-
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	bool _isMaximized = (SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED);
 	if (_isMaximized && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
@@ -396,6 +393,7 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	// Set allowed dimensions
 	uint maxAllowedWidth   = desktopRes.width();
 	uint maxAllowedHeight  = desktopRes.height();
+	float ratio = (float)requestedWidth / (float)requestedHeight;
 
 	// Check if we request a larger window than physically possible,
 	// e.g. by starting with additional launcher parameters forcing

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -385,9 +385,9 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 
 #endif
 
-	// In case we detected an increase in the requested window dimensions (e.g. when launching
+	// In order to prevent any unnecessary downscaling (e.g. when launching
 	// a game in 800x600 while having a smaller screen size stored in the configuration file),
-	// we override the window dimensions with the "real" request.
+	// we override the window dimensions with the "real" resolution request made by the engine.
 	if ((requestedWidth < _lastRequestedWidth || requestedHeight < _lastRequestedHeight) && ConfMan.getActiveDomain()) {
 		requestedWidth  = _lastRequestedWidth  * _graphicsScale;
 		requestedHeight = _lastRequestedHeight * _graphicsScale;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -386,8 +386,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 #endif
 
 	// Set allowed dimensions
-	uint maxAllowedWidth   = desktopRes.width()  * 0.9f;
-	uint maxAllowedHeight  = desktopRes.height() * 0.9f;
+	uint maxAllowedWidth   = desktopRes.width();
+	uint maxAllowedHeight  = desktopRes.height();
 
 	// Check if we request a larger window than physically possible,
 	// e.g. by starting with additional launcher parameters forcing

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -349,13 +349,14 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	Common::Rect desktopRes = _window->getDesktopResolution();
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	if ((SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
+	bool _isMaximized = (SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED);
+	if ((_isMaximized) && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
 		// Set the window size to the values stored when the window was maximized
 		// for the last time.
 		requestedWidth  = ConfMan.getInt("window_maximized_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
 
-	} else if (!(SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
+	} else if (!(_isMaximized) && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
 		// Restore previously stored window dimensions.
 		requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -388,7 +388,7 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	// In order to prevent any unnecessary downscaling (e.g. when launching
 	// a game in 800x600 while having a smaller screen size stored in the configuration file),
 	// we override the window dimensions with the "real" resolution request made by the engine.
-	if ((requestedWidth < _lastRequestedWidth || requestedHeight < _lastRequestedHeight) && ConfMan.getActiveDomain()) {
+	if ((requestedWidth < _lastRequestedWidth  * _graphicsScale || requestedHeight < _lastRequestedHeight * _graphicsScale) && ConfMan.getActiveDomain()) {
 		requestedWidth  = _lastRequestedWidth  * _graphicsScale;
 		requestedHeight = _lastRequestedHeight * _graphicsScale;
 	}

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -91,7 +91,6 @@ private:
 	bool _gotResize;
 
 	bool _wantsFullScreen;
-	bool _windowIsMaximized;
 	uint _ignoreResizeEvents;
 
 	struct VideoMode {


### PR DESCRIPTION
The current implementation of of checking if we have a maximized window was pretty unreliable. This lead to the ScummVM window randomly being started up with the dimensions of the maximized window, effectively rendering the image too large.

The main issue was that `_windowIsMaximized` was never properly set _unless_ a previous resizing event occured. This is fixed by getting rid of this helper variable and instead querying the return values of `SDL_WINDOW_MAXIMIZED` at runtime.

I wasn't able to reproduce any issues with this, but since we are pretty close to branching off for the next release, I'm submitting this as PR.