### PR TITLE
BASE: Convert version strings to const objects. 

### DIFF
--- a/base/version.cpp
+++ b/base/version.cpp
@@ -55,14 +55,14 @@
  * I don't know VC enough to be sure). And of course it must be robust enough
  * to properly work in exports (i.e. release tar balls etc.).
  */
-const char *gScummVMVersion = SCUMMVM_VERSION SCUMMVM_REVISION;
+const char gScummVMVersion[] = SCUMMVM_VERSION SCUMMVM_REVISION;
 #if defined(__amigaos4__) || defined(__MORPHOS__)
 static const char *version_cookie __attribute__((used)) = "$VER: ScummVM " SCUMMVM_VERSION SCUMMVM_REVISION " (" AMIGA_DATE ")";
 #endif
-const char *gScummVMBuildDate = __DATE__ " " __TIME__;
-const char *gScummVMVersionDate = SCUMMVM_VERSION SCUMMVM_REVISION " (" __DATE__ " " __TIME__ ")";
-const char *gScummVMFullVersion = "ScummVM " SCUMMVM_VERSION SCUMMVM_REVISION " (" __DATE__ " " __TIME__ ")";
-const char *gScummVMFeatures = ""
+const char gScummVMBuildDate[] = __DATE__ " " __TIME__;
+const char gScummVMVersionDate[] = SCUMMVM_VERSION SCUMMVM_REVISION " (" __DATE__ " " __TIME__ ")";
+const char gScummVMFullVersion[] = "ScummVM " SCUMMVM_VERSION SCUMMVM_REVISION " (" __DATE__ " " __TIME__ ")";
+const char gScummVMFeatures[] = ""
 #ifdef TAINTED_BUILD
 	// TAINTED means the build contains engines/subengines not enabled by default
 	"TAINTED "

--- a/base/version.h
+++ b/base/version.h
@@ -23,10 +23,10 @@
 #ifndef BASE_VERSION_H
 #define BASE_VERSION_H
 
-extern const char *gScummVMVersion;     // e.g. "0.4.1"
-extern const char *gScummVMBuildDate;   // e.g. "2003-06-24"
-extern const char *gScummVMVersionDate; // e.g. "0.4.1 (2003-06-24)"
-extern const char *gScummVMFullVersion; // e.g. "ScummVM 0.4.1 (2003-06-24)"
-extern const char *gScummVMFeatures;    // e.g. "ALSA MPEG2 zLib"
+extern const char gScummVMVersion[];     // e.g. "0.4.1"
+extern const char gScummVMBuildDate[];   // e.g. "2003-06-24"
+extern const char gScummVMVersionDate[]; // e.g. "0.4.1 (2003-06-24)"
+extern const char gScummVMFullVersion[]; // e.g. "ScummVM 0.4.1 (2003-06-24)"
+extern const char gScummVMFeatures[];    // e.g. "ALSA MPEG2 zLib"
 
 #endif


### PR DESCRIPTION
The following variables:

```
gScummVMVersion
gScummVMBuildDate
gScummVMVersionDate
gScummVMFullVersion
gScummVMFeatures
```

are declared as pointers to strings but there is no need to do so.
They can be simply declared as const strings, since they will be never modified when SCUMMVM runs.