### PR TITLE
SDL: Move getDisplayDpiFromSdl and getDpiScalingFactor into the SdlWindow class

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -250,7 +250,7 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 }
 
 float OpenGLSdlGraphicsManager::getHiDPIScreenFactor() const {
-	return getDpiScalingFactor();
+	return _window->getDpiScalingFactor();
 }
 
 void OpenGLSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
@@ -290,7 +290,7 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 	// event is processed after recreating the window at the new resolution.
 	int currentWidth, currentHeight;
 	getWindowSizeFromSdl(&currentWidth, &currentHeight);
-	float scale = getDpiScalingFactor();
+	float scale = _window->getDpiScalingFactor();
 	debug(3, "req: %d x %d  cur: %d x %d, scale: %f", width, height, currentWidth, currentHeight, scale);
 
 	handleResize(currentWidth, currentHeight);
@@ -644,7 +644,7 @@ bool OpenGLSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 			getWindowSizeFromSdl(&windowWidth, &windowHeight);
 			// FIXME HACK. I don't like this at all, but macOS requires window size in LoDPI
 	#ifdef __APPLE__
-			float scale = getDpiScalingFactor();
+			float scale = _window->getDpiScalingFactor();
 			windowWidth /= scale;
 			windowHeight /= scale;
 	#endif

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -180,51 +180,6 @@ protected:
 #endif
 	}
 
-	void getDisplayDpiFromSdl(float *dpi, float *defaultDpi) const {
-		const float systemDpi =
-#ifdef __APPLE__
-		72.0f;
-#elif defined(_WIN32)
-		96.0f;
-#else
-		90.0f; // ScummVM default
-#endif
-		if (defaultDpi)
-			*defaultDpi = systemDpi;
-
-		if (dpi) {
-#if SDL_VERSION_ATLEAST(2, 0, 4)
-			if (SDL_GetDisplayDPI(_window->getDisplayIndex(), NULL, dpi, NULL) != 0) {
-				*dpi = systemDpi;
-			}
-#else
-			*dpi = systemDpi;
-#endif
-		}
-	}
-
-	/**
-	 * Returns the scaling mode based on the display DPI
-	 */
-	float getDpiScalingFactor() const {
-#ifdef MACOSX
-		float scale;
-		if (getMacWindowScaling(scale)) {
-			debug(4, "NSWindow HiDPI scaling: %f", scale);
-			return scale;
-		}
-#endif
-
-		float dpi, defaultDpi;
-		getDisplayDpiFromSdl(&dpi, &defaultDpi);
-		debug(4, "dpi: %g default: %g", dpi, defaultDpi);
-		float ratio = dpi / defaultDpi;
-		if (ratio >= 1.5f)
-			return 2.f;
-		else
-			return 1.f;
-	}
-
 	virtual void setSystemMousePosition(const int x, const int y) override;
 
 	virtual void handleResizeImpl(const int width, const int height) override;
@@ -251,10 +206,6 @@ protected:
 
 private:
 	void toggleFullScreen();
-
-#ifdef MACOSX
-	bool getMacWindowScaling(float &) const;
-#endif
 };
 
 #endif

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -149,11 +149,6 @@ MODULE_OBJS += \
 	plugins/sdl/sdl-provider.o \
 	timer/sdl/sdl-timer.o
 
-ifdef MACOSX
-MODULE_OBJS += \
-	graphics/sdl/sdl-graphics-osx.o
-endif
-
 # SDL 2 removed audio CD support
 ifndef USE_SDL2
 MODULE_OBJS += \

--- a/backends/platform/sdl/macosx/macosx-window.h
+++ b/backends/platform/sdl/macosx/macosx-window.h
@@ -1,0 +1,39 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKENDS_PLATFORM_SDL_MACOSX_MACOSX_WINDOW_H
+#define BACKENDS_PLATFORM_SDL_MACOSX_MACOSX_WINDOW_H
+
+#ifdef MACOSX
+
+#include "backends/platform/sdl/sdl-window.h"
+
+class SdlWindow_MacOSX final : public SdlWindow {
+public:
+	// Use an iconless window on OS X, as we use a nicer external icon there.
+	virtual void setupIcon() override {}
+	virtual float getDpiScalingFactor() const override;
+};
+
+#endif
+
+#endif

--- a/backends/platform/sdl/macosx/macosx-window.mm
+++ b/backends/platform/sdl/macosx/macosx-window.mm
@@ -23,23 +23,18 @@
 // Disable symbol overrides so that we can use system headers.
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
-#include "SDL_syswm.h"
-#include "backends/graphics/sdl/sdl-graphics.h"
+#include "backends/platform/sdl/macosx/macosx-window.h"
 #include <AppKit/NSWindow.h>
 
-bool SdlGraphicsManager::getMacWindowScaling(float &scale) const {
+float SdlWindow_MacOSX::getDpiScalingFactor() const {
 #if SDL_VERSION_ATLEAST(2, 0, 0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
 	SDL_SysWMinfo wmInfo;
-	SDL_VERSION(&wmInfo.version); /* initialize info structure with SDL version info */
-	if (!SDL_GetWindowWMInfo(_window->getSDLWindow(), &wmInfo))
-		return false;
-
-	NSWindow *nswindow = wmInfo.info.cocoa.window;
-	if (!nswindow)
-		return false;
-	scale = [nswindow backingScaleFactor];
-	return true;
-#else
-	return false;
+	if (getSDLWMInformation(&wmInfo)) {
+		NSWindow *nswindow = wmInfo.info.cocoa.window;
+		if (nswindow)
+			return [nswindow backingScaleFactor];
+	}
 #endif
+
+	return SdlWindow::getDpiScalingFactor();
 }

--- a/backends/platform/sdl/macosx/macosx.cpp
+++ b/backends/platform/sdl/macosx/macosx.cpp
@@ -30,6 +30,7 @@
 #include "backends/audiocd/macosx/macosx-audiocd.h"
 #include "backends/platform/sdl/macosx/appmenu_osx.h"
 #include "backends/platform/sdl/macosx/macosx.h"
+#include "backends/platform/sdl/macosx/macosx-window.h"
 #include "backends/updates/macosx/macosx-updates.h"
 #include "backends/taskbar/macosx/macosx-taskbar.h"
 #include "backends/text-to-speech/macosx/macosx-text-to-speech.h"
@@ -62,9 +63,8 @@ OSystem_MacOSX::~OSystem_MacOSX() {
 }
 
 void OSystem_MacOSX::init() {
-	// Use an iconless window on OS X, as we use a nicer external icon there.
 	initSDL();
-	_window = new SdlIconlessWindow();
+	_window = new SdlWindow_MacOSX();
 
 #if defined(USE_TASKBAR)
 	// Initialize taskbar manager

--- a/backends/platform/sdl/module.mk
+++ b/backends/platform/sdl/module.mk
@@ -14,6 +14,7 @@ ifdef MACOSX
 MODULE_OBJS += \
 	macosx/macosx-main.o \
 	macosx/macosx.o \
+	macosx/macosx-window.o \
 	macosx/macosx_wrapper.o \
 	macosx/appmenu_osx.o
 endif

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -241,6 +241,40 @@ Common::Rect SdlWindow::getDesktopResolution() {
 	return _desktopRes;
 }
 
+void SdlWindow::getDisplayDpi(float *dpi, float *defaultDpi) const {
+	const float systemDpi =
+#ifdef __APPLE__
+	72.0f;
+#elif defined(_WIN32)
+	96.0f;
+#else
+	90.0f; // ScummVM default
+#endif
+	if (defaultDpi)
+		*defaultDpi = systemDpi;
+
+	if (dpi) {
+#if SDL_VERSION_ATLEAST(2, 0, 4)
+		if (SDL_GetDisplayDPI(getDisplayIndex(), NULL, dpi, NULL) != 0) {
+			*dpi = systemDpi;
+		}
+#else
+		*dpi = systemDpi;
+#endif
+	}
+}
+
+float SdlWindow::getDpiScalingFactor() const {
+	float dpi, defaultDpi;
+	getDisplayDpi(&dpi, &defaultDpi);
+	debug(4, "dpi: %g default: %g", dpi, defaultDpi);
+	float ratio = dpi / defaultDpi;
+	if (ratio >= 1.5f)
+		return 2.f;
+	else
+		return 1.f;
+}
+
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 SDL_Surface *copySDLSurface(SDL_Surface *src) {

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -87,6 +87,13 @@ public:
 	 */
 	Common::Rect getDesktopResolution();
 
+	void getDisplayDpi(float *dpi, float *defaultDpi) const;
+
+	/**
+	 * Returns the scaling mode based on the display DPI
+	 */
+	virtual float getDpiScalingFactor() const;
+
 	bool mouseIsGrabbed() const {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		if (_window) {


### PR DESCRIPTION
This should make it simpler to provide custom implementations by overriding the `SdlWindow` class.