### PR TITLE
SDL: Fix HiDPI scaling on Windows (and others?)

### DIFF
--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -269,10 +269,7 @@ float SdlWindow::getDpiScalingFactor() const {
 	getDisplayDpi(&dpi, &defaultDpi);
 	debug(4, "dpi: %g default: %g", dpi, defaultDpi);
 	float ratio = dpi / defaultDpi;
-	if (ratio >= 1.5f)
-		return 2.f;
-	else
-		return 1.f;
+	return ratio;
 }
 
 


### PR DESCRIPTION
Previously SdlWindow::getDpiScalingFactor only returned 100% or 200% scale. This is pretty limiting, as OSes have more fine-grained scales, for example on Windows, the "DPI" (or text scale) is set in increments of 25%: 100% (96dpi), 125% (120dpi), 150%, 175%, etc.

This changes SDL HiDPI to return the exact scaling factor, bringing it line with #3264 for macOS/iOS. I've only tested it on Windows, so I'd appreciate testing on other platforms, and seeing if there's any potential side-effects.