### PR TITLE
SCUMM: Add German MI1 Lemonhead lines

### DIFF
--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1851,6 +1851,17 @@ bool ScummEngine::tryPatchMI1CannibalScript(byte *buf, int size) {
 			scriptOffset -= 4;
 		}
 		break;
+	case Common::DE_DEU:
+		expectedSize = 83554;
+		scriptOffset = 74198;
+		scriptLength = 632;
+		expectedMd5 = "27d6d8eab4e0f66792e10769090ae047";
+		patchOffset = 170;
+		patchLength = 23;
+		lang[0] = 'D';
+		lang[1] = 'E';
+		lang[2] = 'U';
+		break;
 	case Common::IT_ITA:
 		expectedSize = 83211;
 		scriptOffset = 73998;

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2875,6 +2875,11 @@ void ScummEngine_v5::printPatchedMI1CannibalString(int textSlot, const byte *ptr
 			"Oooh, that's nice.\xFF\x03"
 			"Simple.  Just like one of mine.\xFF\x03"
 			"And little.  Like mine.";
+	} else if (strncmp((const char *)ptr, "/LH.DEU/", 8) == 0) {
+		msg =
+			"Oooh, das ist nett.\xFF\x03"
+			"Einfach.  Wie eines von meinen.\xFF\x03"
+			"Und klein.  Wie meine.";
 	} else if (strncmp((const char *)ptr, "/LH.ITA/", 8) == 0) {
 		msg =
 			"Oooh, che bello.\xFF\x03"


### PR DESCRIPTION
This commit adds a patch that will readd the missing Lemonhead lines for the German CD version of Monkey Island