### PR TITLE
GRIM: Add Monkey4 Steam/GOG version detection

### DIFF
--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -461,6 +461,71 @@ static const GrimGameDescription gameDescriptions[] = {
 		GType_MONKEY4
 	},
 	{
+		// Escape from Monkey Island English Steam/GOG
+		{
+			"monkey4",
+			"",
+			AD_ENTRY1s("artAll.m4b", "8c7db9dab564854f2c4bab0571104780", 18515664),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUI_OPTIONS_GRIME
+		},
+		GType_MONKEY4
+	},
+	{
+		// Escape from Monkey Island German Steam/GOG
+		{
+			"monkey4",
+			"",
+			AD_ENTRY1s("artAll.m4b", "7c1da307c5c3eb1ba65b7c1a2e6b5bce", 18512568),
+			Common::DE_DEU,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUI_OPTIONS_GRIME
+		},
+		GType_MONKEY4
+	},
+	{
+		// Escape from Monkey Island French Steam/GOG
+		{
+			"monkey4",
+			"",
+			AD_ENTRY1s("artAll.m4b", "e0fbba846efca842553bb1a726a25dcf", 18514420),
+			Common::FR_FRA,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUI_OPTIONS_GRIME
+		},
+		GType_MONKEY4
+	},
+	{
+		// Escape from Monkey Island Italian Steam/GOG
+		{
+			"monkey4",
+			"",
+			AD_ENTRY1s("artAll.m4b", "b9838ab13a672a42b1fbc8893b94ca26", 18513451),
+			Common::IT_ITA,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUI_OPTIONS_GRIME
+		},
+		GType_MONKEY4
+	},
+	{
+		// Escape from Monkey Island Spanish Steam/GOG
+		{
+			"monkey4",
+			"",
+			AD_ENTRY1s("artAll.m4b", "f2ec4854639cd25792dd3e88fb08a1e6", 18514404),
+			Common::ES_ESP,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUI_OPTIONS_GRIME
+		},
+		GType_MONKEY4
+	},
+	{
 		// Escape from Monkey Island German (Mac)
 		{
 			"monkey4",


### PR DESCRIPTION
Hi

This PR makes it so the Steam and GOG versions of Escape from Monkey Island can be added and played.

The actual commit is simple enough, but there are a few points to note:

The files used for the Steam and GOG versions are mostly the same as for the CD versions, but of course there is no duplicate data situation. In particular there is only one `FullMonkeyMap.imt`, but as far as I can tell this works fine.

When trying to launch the game, the resources check will complain that `monkey4-patch.m4b`is missing. This is because the file is called `patch.m4b`. Simply renaming it fixes this.
Now, it's not ideal that one has to rename `patch.m4b`. But to be completely honest, I don't understand the codebase well enough to know whether there is a good solution for this, and if there is, how/where to implement it. I hope somebody more knowledgeable can help out here :)

I tested this rudimentarily by playing the game a bit.

Even if the PR doesn't make it, I hope it helps in supporting the Steam/GOG versions, because those are currently by far the easiest to get in a convenient and legal manner.