### PR TITLE
Add missing Monkey1 FM-Towns Lemonhead lines

### DIFF
--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1849,6 +1849,9 @@ bool ScummEngine::tryPatchMI1CannibalScript(byte *buf, int size) {
 		if (_game.platform == Common::kPlatformMacintosh) {
 			expectedSize -= 4;
 			scriptOffset -= 4;
+		} else if (_game.platform == Common::kPlatformFMTowns) {
+			expectedSize = 82817;
+			scriptOffset = 73794;
 		}
 		break;
 	case Common::DE_DEU:


### PR DESCRIPTION
This adds the missing Lemonhead lines to English FM-Towns version of Monkey Island as well using @eriktorbjorn's resource patch for this. Playtested it.