### PR TITLE
BASE: Purge keyboard events before running Engine

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -296,6 +296,27 @@ void DefaultEventManager::purgeMouseEvents() {
 	_eventQueue = filteredQueue;
 }
 
+void DefaultEventManager::purgeKeyboardEvents() {
+	_dispatcher.dispatch();
+
+	Common::Queue<Common::Event> filteredQueue;
+	while (!_eventQueue.empty()) {
+		Common::Event event = _eventQueue.pop();
+		switch (event.type) {
+		// Update keyboard state even when purging events to avoid desynchronisation with real keyboard state
+		case Common::EVENT_KEYDOWN:
+		case Common::EVENT_KEYUP:
+			_modifierState = event.kbd.flags;
+			break;
+
+		default:
+			filteredQueue.push(event);
+			break;
+		}
+	}
+	_eventQueue = filteredQueue;
+}
+
 Common::Keymap *DefaultEventManager::getGlobalKeymap() {
 	using namespace Common;
 

--- a/backends/events/default/default-events.h
+++ b/backends/events/default/default-events.h
@@ -67,6 +67,7 @@ public:
 	virtual bool pollEvent(Common::Event &event) override;
 	virtual void pushEvent(const Common::Event &event) override;
 	virtual void purgeMouseEvents() override;
+	virtual void purgeKeyboardEvents() override;
 
 	virtual Common::Point getMousePos() const override { return _mousePos; }
 	virtual int getButtonState() const override { return _buttonState; }

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -303,6 +303,10 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 	// Inform backend that the engine is about to be run
 	system.engineInit();
 
+	// Purge queued input events that may remain from the GUI (such as key-up)
+	system.getEventManager()->purgeKeyboardEvents();
+	system.getEventManager()->purgeMouseEvents();
+
 	// Run the engine
 	Common::Error result = engine->run();
 

--- a/common/events.h
+++ b/common/events.h
@@ -489,6 +489,11 @@ public:
 	 */
 	virtual void purgeMouseEvents() = 0;
 
+	/**
+	 * Purge all unprocessed keyboard events already in the event queue.
+	 */
+	virtual void purgeKeyboardEvents() = 0;
+
 	/** Return the current mouse position. */
 	virtual Point getMousePos() const = 0;
 


### PR DESCRIPTION
When pressing Enter to start a game in the GUI, the key-up event remains in the event queue when an engine starts. In the SCI game Phantasmagoria 1, the game scripts for the introduction respond to any input event by skipping the introduction. This means that you only see the introduction by starting the game from the ScummVM GUI with a mouse. The introduction skips if you start the game by pressing Enter.

This PR adds EventManager::purgeKeyboardEvents() and calls it before Engine::run() so that GUI keyboard events no longer leak into engines. There is already a purgeMouseEvents() so I modeled it after that.

Tested on Windows and Mac.