### PR TITLE
SDL: Cleanup HiDPI macOS hacks

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -290,19 +290,15 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 	// event is processed after recreating the window at the new resolution.
 	int currentWidth, currentHeight;
 	getWindowSizeFromSdl(&currentWidth, &currentHeight);
-	float scale = _window->getDpiScalingFactor();
-	debug(3, "req: %d x %d  cur: %d x %d, scale: %f", width, height, currentWidth, currentHeight, scale);
+	float dpiScale = _window->getSdlDpiScalingFactor();
+	debug(3, "req: %d x %d  cur: %d x %d, scale: %f", width, height, currentWidth, currentHeight, dpiScale);
 
 	handleResize(currentWidth, currentHeight);
 
 	// Remember window size in windowed mode
 	if (!_wantsFullScreen) {
-
-		// FIXME HACK. I don't like this at all, but macOS requires window size in LoDPI
-#ifdef __APPLE__
-		currentWidth = (int)(currentWidth / scale);
-		currentHeight = (int)(currentHeight / scale);
-#endif
+		currentWidth = (int)(currentWidth / dpiScale + 0.5f);
+		currentHeight = (int)(currentHeight / dpiScale + 0.5f);
 
 		// Check if the ScummVM window is maximized and store the current
 		// window dimensions.
@@ -654,12 +650,11 @@ bool OpenGLSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 			// window. Then we apply the direction change.
 			int windowWidth = 0, windowHeight = 0;
 			getWindowSizeFromSdl(&windowWidth, &windowHeight);
-			// FIXME HACK. I don't like this at all, but macOS requires window size in LoDPI
-	#ifdef __APPLE__
-			float scale = _window->getDpiScalingFactor();
-			windowWidth /= scale;
-			windowHeight /= scale;
-	#endif
+
+			float dpiScale = _window->getSdlDpiScalingFactor();
+			windowWidth = (int)(windowWidth / dpiScale + 0.5f);
+			windowHeight = (int)(windowHeight / dpiScale + 0.5f);
+
 			if (direction > 0)
 				_graphicsScale = MAX<int>(windowWidth / _lastRequestedWidth, windowHeight / _lastRequestedHeight);
 			else


### PR DESCRIPTION
This pull request take advantage of the changes I made in feac996b50 cleanup the hacks to handle HiDPI scaling on macOS.

The SDL library handles HiDPI differently depending on the system. On some systems, such as macOS, the drawable area and the SDL window have a different size (the window is on low-dpi size) while on other systems such as Windows they have the same size. Because of that we sometimes need to scale sizes or coordinates between the two, and sometimes we don't.

This was handled in two different ways.
 - In some places we queried the SDL window size and the SDL drawable area to compute the scaling between the two. As far as I know currently the scaling is 1 for all the systems except macOS with Retina screen.
 - In other places we used preprocessor directives to apply a scaling only on macOS.

This commit change the code to handle it consistently everywhere, and also should be more future proof should SDL change the way it handles HiDPI in the future (as we now query the size from SDL itself to find out if the scaling is needed instead of using the `__APPLE__` hack).

I have verified that this still works on macOS, but it might be worth checking that this does not introduce regressions on other systems (I don't think it does as `SdlWindow:: getSdlDpiScalingFactor()` should be 1, but I prefer to be on the safe side by opening a pull request for the change).