### PR TITLE
BACKENDS: OPENGLSDL: Remember maximized window state, fix off-screen positioning of window

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -550,7 +550,9 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 
 	// WORKAROUND: Prevent (nearly) offscreen positioning of the ScummVM window by forcefully
 	// trigger a re-positioning event to center the window.
-	SDL_SetWindowPosition(_window->getSDLWindow(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+	if (!_wantsFullScreen && !(SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED)) {
+		SDL_SetWindowPosition(_window->getSDLWindow(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+	}
 	return true;
 #else
 	// WORKAROUND: Working around infamous SDL bugs when switching

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -548,11 +548,13 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 
 	handleResize(actualWidth, actualHeight);
 
+#ifdef WIN32
 	// WORKAROUND: Prevent (nearly) offscreen positioning of the ScummVM window by forcefully
 	// trigger a re-positioning event to center the window.
 	if (!_wantsFullScreen && !(SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED)) {
 		SDL_SetWindowPosition(_window->getSDLWindow(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}
+#endif
 	return true;
 #else
 	// WORKAROUND: Working around infamous SDL bugs when switching

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -547,6 +547,10 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	getWindowSizeFromSdl(&actualWidth, &actualHeight);
 
 	handleResize(actualWidth, actualHeight);
+
+	// WORKAROUND: Prevent (nearly) offscreen positioning of the ScummVM window by forcefully
+	// trigger a re-positioning event to center the window.
+	SDL_SetWindowPosition(_window->getSDLWindow(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	return true;
 #else
 	// WORKAROUND: Working around infamous SDL bugs when switching

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -309,9 +309,11 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 		if (SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) {
 			ConfMan.setInt("window_maximized_width", currentWidth, Common::ConfigManager::kApplicationDomain);
 			ConfMan.setInt("window_maximized_height", currentHeight, Common::ConfigManager::kApplicationDomain);
+			ConfMan.setBool("window_maximized", true, Common::ConfigManager::kApplicationDomain);
 		} else {
 			ConfMan.setInt("last_window_width", currentWidth, Common::ConfigManager::kApplicationDomain);
 			ConfMan.setInt("last_window_height", currentHeight, Common::ConfigManager::kApplicationDomain);
+			ConfMan.setBool("window_maximized", false, Common::ConfigManager::kApplicationDomain);
 		}
 		ConfMan.flushToDisk();
 	}
@@ -515,6 +517,10 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 		height = _desiredFullscreenHeight;
 
 		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+	}
+
+	if (ConfMan.getBool("window_maximized", Common::ConfigManager::kApplicationDomain)) {
+		flags |= SDL_WINDOW_MAXIMIZED;
 	}
 
 	// Request a OpenGL (ES) context we can use.

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -354,13 +354,13 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_Window *window = _window->getSDLWindow();
 	bool _isMaximized = window ? (SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED) : false;
-	if (_isMaximized && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
+	if (_isMaximized && !_wantsFullScreen && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
 		// Set the window size to the values stored when the window was maximized
 		// for the last time.
 		requestedWidth  = ConfMan.getInt("window_maximized_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
 
-	} else if (!_isMaximized && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
+	} else if (!_isMaximized && _wantsFullScreen && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
 		// Load previously stored window dimensions.
 		requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);
@@ -519,7 +519,7 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
 
-	if (ConfMan.getBool("window_maximized", Common::ConfigManager::kApplicationDomain)) {
+	if (!_wantsFullScreen && ConfMan.getBool("window_maximized", Common::ConfigManager::kApplicationDomain)) {
 		flags |= SDL_WINDOW_MAXIMIZED;
 	}
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -552,7 +552,16 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	// WORKAROUND: Prevent (nearly) offscreen positioning of the ScummVM window by forcefully
 	// trigger a re-positioning event to center the window.
 	if (!_wantsFullScreen && !(SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED)) {
-		SDL_SetWindowPosition(_window->getSDLWindow(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+
+		// Read the current window position
+		int _xWindowPos;
+		SDL_GetWindowPosition(_window->getSDLWindow(), &_xWindowPos, NULL);
+
+		// Relocate the window to the center of the screen in case we try to draw
+		// outside the window area. In this case, _xWindowPos always returns 0.
+		if (_xWindowPos == 0) {
+			SDL_SetWindowPosition(_window->getSDLWindow(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+		}
 	}
 #endif
 	return true;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -360,7 +360,7 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 		requestedWidth  = ConfMan.getInt("window_maximized_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
 
-	} else if (!_isMaximized && _wantsFullScreen && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
+	} else if (!_isMaximized && !_wantsFullScreen && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
 		// Load previously stored window dimensions.
 		requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
 		requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);


### PR DESCRIPTION
_Disclaimer: Not sure if this change is allowed right now or if it's affected by the current freeze. Would be nice to get it into the next release though._

Last time, I didn't know about the various SDL window flags, but this is my next try. This patch makes ScummVM remember if we left off with a maximized window and restores it properly.