### PR TITLE
SCUMM: Add Spanish version of the MI1 Lemonhead patch

### DIFF
--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1862,6 +1862,17 @@ bool ScummEngine::tryPatchMI1CannibalScript(byte *buf, int size) {
 		lang[1] = 'T';
 		lang[2] = 'A';
 		break;
+	case Common::ES_ESP:
+		expectedSize = 82829;
+		scriptOffset = 73905;
+		scriptLength = 579;
+		expectedMd5 = "0e282d86f80d4e062a9a145601e6fed3";
+		patchOffset = 161;
+		patchLength = 21;
+		lang[0] = 'E';
+		lang[1] = 'S';
+		lang[2] = 'P';
+		break;
 	default:
 		return false;
 	}

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2880,6 +2880,11 @@ void ScummEngine_v5::printPatchedMI1CannibalString(int textSlot, const byte *ptr
 			"Oooh, che bello.\xFF\x03"
 			"Semplice.  Proprio come uno dei miei.\xFF\x03"
 			"E piccolo.  Come il mio.";
+	} else if (strncmp((const char *)ptr, "/LH.ESP/", 8) == 0) {
+		msg =
+			"Oooh, qu\x82 bonito.\xFF\x03"
+			"Simple.  Como uno de los m\xA1os.\xFF\x03"
+			"Y peque\xA4o, como los m\xA1os.";
 	}
 
 	printString(textSlot, (const byte *)msg);


### PR DESCRIPTION
TEST THIS BEFORE MERGING!!!

This adds the missing Lemonhead lines to the Spanish version of The Secret of Monkey Island.

I don't have this version of the game myself, so the texts are based on a YouTube playthrough and the rest is based on walking timofonic through the steps of locating the script to patch. Unfortunately, at the moment there is no one (including timofonic) who has been able to test it. I'm submitting the pull request so that it won't get lost before the next release, but at the moment it's not ready for merging.

In addition to the script patch, I'm not certain of the character encoding. The current strings look correct if I insert them in the English version, though.
