### PR TITLE
PRINCE:  Only the first phrase was displayed when examining an object

### DIFF
--- a/engines/prince/script.cpp
+++ b/engines/prince/script.cpp
@@ -1025,6 +1025,10 @@ void Interpreter::O_GETMOBTEXT() {
 	int32 mob = readScriptFlagValue();
 	debugInterpreter("O_GETMOBTEXT mob %d", mob);
 	_currentString = _vm->_locationNr * 100 + mob + 60001;
+	// Use of memcpy() instead of strncpy() because the examination text can contain
+	// different phrases separated by '\0' characters followed by an ID.
+	// The examination text ends for a mob if the ID is 0xFF.
+	// Strings are properly extracted by the interpreter in that format.
 	memcpy((char *)_stringBuf, _vm->_mobList[mob]._examText.c_str(), 1023);
 	_string = _stringBuf;
 }

--- a/engines/prince/script.cpp
+++ b/engines/prince/script.cpp
@@ -1025,8 +1025,8 @@ void Interpreter::O_GETMOBTEXT() {
 	int32 mob = readScriptFlagValue();
 	debugInterpreter("O_GETMOBTEXT mob %d", mob);
 	_currentString = _vm->_locationNr * 100 + mob + 60001;
-	// Use of memcpy() instead of strncpy() because the examination text can contain
-	// different phrases separated by '\0' characters followed by an ID.
+	// Use memcpy() instead of strncpy() because the examination text can contain
+	// different phrases separated by '\0' characters, followed by an ID.
 	// The examination text ends for a mob if the ID is 0xFF.
 	// Strings are properly extracted by the interpreter in that format.
 	memcpy((char *)_stringBuf, _vm->_mobList[mob]._examText.c_str(), 1023);

--- a/engines/prince/script.cpp
+++ b/engines/prince/script.cpp
@@ -1025,7 +1025,7 @@ void Interpreter::O_GETMOBTEXT() {
 	int32 mob = readScriptFlagValue();
 	debugInterpreter("O_GETMOBTEXT mob %d", mob);
 	_currentString = _vm->_locationNr * 100 + mob + 60001;
-	strncpy((char *)_stringBuf, _vm->_mobList[mob]._examText.c_str(), 1023);
+	memcpy((char *)_stringBuf, _vm->_mobList[mob]._examText.c_str(), 1023);
 	_string = _stringBuf;
 }
 


### PR DESCRIPTION
When examining an object, if the description has multiple phrases, only the first one was displayed on the screen (but speech audio continues).
Thant's because multiple phrases are encoded in the same string using '\0' separator, so strcpy/strncpy should be avoided.
