### PR TITLE
DEVTOOLS: Add a build script to simplify building with Docker

### DIFF
--- a/devtools/README
+++ b/devtools/README
@@ -149,6 +149,18 @@ dist-scummvm.sh
     account.
 
 
+docker.sh
+---------
+    This shell script is used to simplify building with the Docker images
+    used by the buildbot. It can invoked like this:
+
+      ./devtools/docker.sh toolchain/mxe
+
+    This will fetch the MXE toolchain from the Docker Hub if it hasn't
+    already and launch a shell that can be used to build ScummVM for
+    Windows.
+
+
 dumper_companion.py
 ___________________
     Tool for dumping HFS/HFS+ volumes and game files with non-ASCII

--- a/devtools/docker.sh
+++ b/devtools/docker.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# This shell script is used to simplify building with the Docker images
+# used by the buildbot.
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+_image=
+_update=no
+
+for ac_option in $@; do
+	case "$ac_option" in
+	--update)
+		_update=yes
+		;;
+	--*)
+		echo "Unknown argument '$ac_option'"
+		exit 1
+		;;
+	*)
+		if [ -n "$_image" ]; then
+			echo "A toolchain image has already been specified"
+			exit 1
+		fi
+		_image=$ac_option
+		;;
+	esac;
+done;
+
+if [ -z "$_image" ]; then
+	echo "No toolchain image has been specified"
+	exit 1
+fi
+
+if test "$_update" != yes ; then
+	if ! docker image inspect $_image >/dev/null 2>&1 ; then
+		echo "Image is not available"
+		_update=yes
+	fi
+fi
+
+if test "$_update" = yes ; then
+	docker_url=`echo $_image | sed 's/\([^\/]*\)\/\([^\/]*\)/scummvm\/dockerized-\1:\2/'`
+	(docker pull $docker_url && docker tag $docker_url $_image && docker rmi $docker_url) || exit 1
+fi
+
+docker run -v $DIR:/data/scummvm -w /data/scummvm -it $_image /bin/bash


### PR DESCRIPTION
This handles both fetching images from the Docker Hub and launching a shell with the ScummVM source directory within the image.
