### PR TITLE
AMIGAOS/MORPHOS: Avoid copying the entire doc directory when packaging

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -13,8 +13,9 @@ amigaosdist: $(EXECUTABLE) $(PLUGINS)
 	cp ${srcdir}/dists/amigaos/scummvm_drawer.info $(patsubst %/,%,$(AMIGAOSPATH)).info
 	cp ${srcdir}/dists/amigaos/scummvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info
 ifdef DIST_FILES_DOCS
-	cp -r ${srcdir}/doc/ $(AMIGAOSPATH)
+	makedir all $(AMIGAOSPATH)/doc
 	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)/doc
+	$(foreach lang, $(DIST_FILES_DOCS_languages), makedir all $(AMIGAOSPATH)/doc/$(lang); cp $(DIST_FILES_DOCS_$(lang)) $(AMIGAOSPATH)/doc/$(lang);)
 	# README.md must be in the current working directory
 	# when building out of tree.
 	cp ${srcdir}/README.md README.tmp

--- a/backends/platform/sdl/morphos/morphos.mk
+++ b/backends/platform/sdl/morphos/morphos.mk
@@ -5,8 +5,8 @@ morphosdist: $(EXECUTABLE) $(PLUGINS)
 	cp ${srcdir}/dists/amiga/scummvm.info $(MORPHOSPATH)/$(EXECUTABLE).info
 ifdef DIST_FILES_DOCS
 	mkdir -p $(MORPHOSPATH)/doc
-	cp -r $(srcdir)/doc/ $(MORPHOSPATH)
 	cp $(DIST_FILES_DOCS) $(MORPHOSPATH)doc/
+	$(foreach lang, $(DIST_FILES_DOCS_languages), makedir all $(AMIGAOSPATH)/doc/$(lang); cp $(DIST_FILES_DOCS_$(lang)) $(AMIGAOSPATH)/doc/$(lang);)
 endif
 ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) $(MORPHOSPATH)extras/


### PR DESCRIPTION
This prevents the doxygen and docportal sources from being included in packages.