### PR TITLE
fix rng seeding

### DIFF
--- a/common/random.cpp
+++ b/common/random.cpp
@@ -37,7 +37,13 @@ RandomSource::RandomSource(const String &name) {
 #ifdef ENABLE_EVENTRECORDER
 	setSeed(g_eventRec.getRandomSeed(name));
 #else
-	setSeed(g_system->getMillis());
+	TimeDate time;
+	g_system->getTimeAndDate(time);
+	uint32 newSeed = time.tm_sec + time.tm_min * 60 + time.tm_hour * 3600;
+	newSeed += time.tm_mday * 86400 + time.tm_mon * 86400 * 31;
+	newSeed += time.tm_year * 86400 * 366;
+	newSeed = newSeed * 1000 + g_system->getMillis();
+	setSeed(newSeed);
 #endif
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
Common::RandomSource fix rng seeding

Rng seeding on Windows had a small range of possible values, because it was set in the constructor based on milliseconds since process start. This was greatly reducing the number of possible seeds. @TehGelly noticed this issue and pointed out that the only seeds he ever gets when playing Shivers are between about 900 to 1050.

```
uint32 OSystem_NULL::getMillis(bool skipRecord) {
#ifdef POSIX
	timeval curTime;

	gettimeofday(&curTime, 0);

	return (uint32)(((curTime.tv_sec - _startTime.tv_sec) * 1000) +
			((curTime.tv_usec - _startTime.tv_usec) / 1000));
#elif defined(WIN32)
	return GetTickCount() - _startTime;
#else
	return 0;
#endif
}
```