### PR TITLE
DEVTOOLS: COMPANION: Fix masking lower bits of flag

### DIFF
--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -130,7 +130,7 @@ def decode_macjapanese(text: ByteString) -> str:
 
 def file_to_macbin(f: machfs.File, name: ByteString) -> bytes:
     oldFlags = f.flags >> 8
-    newFlags = f.flags & 8
+    newFlags = f.flags & 15
     macbin = pack(
         ">xB63s4s4sBxHHHBxIIIIHB14xIHBB",
         len(name),

--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -130,7 +130,7 @@ def decode_macjapanese(text: ByteString) -> str:
 
 def file_to_macbin(f: machfs.File, name: ByteString) -> bytes:
     oldFlags = f.flags >> 8
-    newFlags = f.flags & 15
+    newFlags = f.flags & 0xFF
     macbin = pack(
         ">xB63s4s4sBxHHHBxIIIIHB14xIHBB",
         len(name),


### PR DESCRIPTION
Properly gets the "new" Finder flags from the flags property, covers the flags introduced in Finder 5.4.