### PR TITLE
SDL: Set better default scaler for high-resolution games

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -716,12 +716,20 @@ void SurfaceSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFo
 
 	if ((int)w != _videoMode.screenWidth || (int)h != _videoMode.screenHeight) {
 		const bool useDefault = defaultGraphicsModeConfig();
+		int scaleFactor = ConfMan.getInt("scale_factor");
+		int mode = _videoMode.scalerIndex;
 		if (useDefault && w > 320) {
-			// Only the normal scaler has a 1x mode
-			setScaler(ScalerMan.findScalerPluginIndex("normal"), 1);
-		} else {
-			setScaler(_videoMode.scalerIndex, ConfMan.getInt("scale_factor"));
+			// The default scaler is assumed to be for low
+			// resolution games. For high resolution games, pick
+			// the largest scale factor that gives at most the
+			// same window width.
+			scaleFactor = MAX<uint>(1, (scaleFactor * 320) / w);
+
+			// Only the normal scaler has a 1x mode.
+			if (scaleFactor == 1)
+				mode = ScalerMan.findScalerPluginIndex("normal");
 		}
+		setScaler(mode, scaleFactor);
 	}
 
 	_videoMode.screenWidth = w;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -716,7 +716,7 @@ void SurfaceSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFo
 
 	if ((int)w != _videoMode.screenWidth || (int)h != _videoMode.screenHeight) {
 		const bool useDefault = defaultGraphicsModeConfig();
-		int scaleFactor = ConfMan.getInt("scale_factor");
+		uint scaleFactor = ConfMan.getInt("scale_factor");
 		int mode = _videoMode.scalerIndex;
 		if (useDefault && w > 320) {
 			// The default scaler is assumed to be for low
@@ -725,9 +725,14 @@ void SurfaceSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFo
 			// same window width.
 			scaleFactor = MAX<uint>(1, (scaleFactor * 320) / w);
 
-			// Only the normal scaler has a 1x mode.
-			if (scaleFactor == 1)
+			// Check that the current scaler is available at the
+			// new scale factor. If not, the normal scaler is
+			// assumed to be available at any reasonable factor,
+			// and is - of course -the only one that has a 1x mode.
+			const Common::Array<uint> &factors = _scalerPlugins[mode]->get<ScalerPluginObject>().getFactors();
+			if (Common::find(factors.begin(), factors.end(), scaleFactor) == factors.end()) {
 				mode = ScalerMan.findScalerPluginIndex("normal");
+			}
 		}
 		setScaler(mode, scaleFactor);
 	}


### PR DESCRIPTION
Now that we have higher scale factors than 3, it makes sense to try and figure out a default scaler for high-resolution games that approximate the window size of a low resolution game.

That also means that we are not necessarily restricted to the normal scaler, since AdvMame has both 2x and 4x versions.

Since my own default scaler is Normal 3x, this change won't affect me much personally, though.