### PR TITLE
BUILD: Add a target to download manual when not present

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -116,7 +116,7 @@ QUIET_PLUGIN  = @echo '   ' PLUGIN ' ' $@;
 QUIET_LINK    = @echo '   ' LINK '   ' $@;
 QUIET_DWP     = @echo '   ' DWP '    ' $@;
 QUIET_WINDRES = @echo '   ' WINDRES '' $@;
-QUIET_CURL		= @echo '   ' CURL '   ' $@;
+QUIET_CURL    = @echo '   ' CURL '   ' $@;
 QUIET         = @
 endif
 endif
@@ -132,10 +132,15 @@ $(EXECUTABLE).dwp: $(EXECUTABLE)
 endif
 
 # Grab the ScummVM Manual from Read the Docs
-manual:
 ifdef USE_CURL
-	$(QUIET_CURL)$(CURL) -s https://docs.scummvm.org/_/downloads/en/$(MANUALVERSION)/pdf/ --output "ScummVM Manual ($(MANUALVERSION)).pdf"
-DIST_FILES_MANUAL := "ScummVM Manual ($(MANUALVERSION)).pdf"
+DIST_FILES_MANUAL := ScummVM\ Manual\ $(MANUALVERSION).pdf
+manual:
+	$(QUIET_CURL)$(CURL) -s "https://docs.scummvm.org/_/downloads/en/$(MANUALVERSION)/pdf/" --output $(DIST_FILES_MANUAL)
+# If manual doesn't exist yet and ends up in a requisite, download it
+$(DIST_FILES_MANUAL):
+	$(QUIET)$(MAKE) manual
+else
+manual:
 endif
 
 distclean: clean clean-devtools

--- a/backends/platform/androidsdl/androidsdl.mk
+++ b/backends/platform/androidsdl/androidsdl.mk
@@ -1,5 +1,5 @@
 # Special target to create an AndroidSDL snapshot
-androidsdl:
+androidsdl: $(DIST_FILES_DOCS)
 	$(MKDIR) release
 	$(INSTALL) -c -m 644 $(DIST_FILES_THEMES) $(DIST_FILES_NETWORKING) $(DIST_FILES_VKEYBD) $(DIST_FILES_ENGINEDATA) release
 	$(INSTALL) -c -m 644 $(DIST_FILES_DOCS)  release

--- a/backends/platform/dingux/dingux.mk
+++ b/backends/platform/dingux/dingux.mk
@@ -12,7 +12,7 @@ dingux-distclean:
 	rm -rf $(bundle_name)
 	rm $(DINGUX_EXE_STRIPPED)
 
-dingux-dist: all
+dingux-dist: all $(DIST_FILES_DOCS)
 	$(MKDIR) $(bundle_name)
 	$(MKDIR) $(bundle_name)/saves
 	$(STRIP) $(EXECUTABLE) -o $(bundle_name)/scummvm.elf
@@ -37,7 +37,7 @@ endif
 	$(CP) $(srcdir)/backends/platform/dingux/scummvm.png $(bundle_name)/
 
 # Special target for generationg GCW-Zero OPK bundle
-$(gcw0_bundle): all
+$(gcw0_bundle): all $(DIST_FILES_DOCS)
 	$(MKDIR) $(gcw0_bundle)
 	$(CP) $(DIST_FILES_DOCS) $(gcw0_bundle)/
 	$(MKDIR) $(gcw0_bundle)/themes

--- a/backends/platform/gph/caanoo-bundle.mk
+++ b/backends/platform/gph/caanoo-bundle.mk
@@ -5,7 +5,7 @@ bundle_name = release/scummvm-caanoo
 f=$(shell which $(STRIP))
 libloc = $(shell dirname $(f))
 
-caanoo-bundle: $(EXECUTABLE)
+caanoo-bundle: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/saves"
@@ -43,7 +43,7 @@ endif
 	tar -C $(bundle_name) -cvjf $(bundle_name).tar.bz2 .
 	rm -R ./$(bundle_name)
 
-caanoo-bundle-debug: $(EXECUTABLE)
+caanoo-bundle-debug: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/saves"

--- a/backends/platform/gph/gp2x-bundle.mk
+++ b/backends/platform/gph/gp2x-bundle.mk
@@ -4,7 +4,7 @@ bundle_name = release/scummvm-gp2x
 f=$(shell which $(STRIP))
 libloc = $(shell dirname $(f))
 
-gp2x-bundle: $(EXECUTABLE)
+gp2x-bundle: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/saves"
 	$(MKDIR) "$(bundle_name)/engine-data"
@@ -42,7 +42,7 @@ endif
 	tar -C $(bundle_name) -cvjf $(bundle_name).tar.bz2 .
 	rm -R ./$(bundle_name)
 
-gp2x-bundle-debug: $(EXECUTABLE)
+gp2x-bundle-debug: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/saves"
 	$(MKDIR) "$(bundle_name)/engine-data"

--- a/backends/platform/gph/gp2xwiz-bundle.mk
+++ b/backends/platform/gph/gp2xwiz-bundle.mk
@@ -4,7 +4,7 @@ bundle_name = release/scummvm-gp2xwiz
 f=$(shell which $(STRIP))
 libloc = $(shell dirname $(f))
 
-gp2xwiz-bundle: $(EXECUTABLE)
+gp2xwiz-bundle: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/saves"
@@ -45,7 +45,7 @@ endif
 	tar -C $(bundle_name) -cvjf $(bundle_name).tar.bz2 .
 	rm -R ./$(bundle_name)
 
-gp2xwiz-bundle-debug: $(EXECUTABLE)
+gp2xwiz-bundle-debug: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/saves"

--- a/backends/platform/n64/n64.mk
+++ b/backends/platform/n64/n64.mk
@@ -12,7 +12,7 @@ n64-distclean:
 	rm -rf $(bundle_name)
 	rm $(N64_EXE_STRIPPED)
 
-n64-dist: all
+n64-dist: all $(DIST_FILES_DOCS)
 	$(MKDIR) $(bundle_name)
 	$(MKDIR) $(bundle_name)/romfs
 ifdef DIST_FILES_ENGINEDATA

--- a/backends/platform/openpandora/op-bundle.mk
+++ b/backends/platform/openpandora/op-bundle.mk
@@ -5,7 +5,7 @@ bundle_name = release/scummvm-op
 f=$(shell which $(STRIP))
 libloc = $(shell dirname $(f))
 
-op-bundle: $(EXECUTABLE)
+op-bundle: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/bin"
@@ -49,7 +49,7 @@ endif
 	tar -C $(bundle_name) -cvjf $(bundle_name).tar.bz2 .
 	rm -R ./$(bundle_name)
 
-op-pnd: $(EXECUTABLE)
+op-pnd: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/bin"

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -8,7 +8,7 @@
 # missing theme files and a missing valid translation.dat.
 # Switching to AmigaOS' own "makedir" until there is a fix or other solution.
 #
-amigaosdist: $(EXECUTABLE) $(PLUGINS)
+amigaosdist: $(EXECUTABLE) $(PLUGINS) $(DIST_FILES_DOCS)
 	makedir all $(AMIGAOSPATH)
 	cp ${srcdir}/dists/amigaos/scummvm_drawer.info $(patsubst %/,%,$(AMIGAOSPATH)).info
 	cp ${srcdir}/dists/amigaos/scummvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info

--- a/backends/platform/sdl/morphos/morphos.mk
+++ b/backends/platform/sdl/morphos/morphos.mk
@@ -1,6 +1,6 @@
 # Special target to create an MorphOS snapshot installation.
 # AmigaOS shell doesn't like indented comments.
-morphosdist: $(EXECUTABLE) $(PLUGINS)
+morphosdist: $(EXECUTABLE) $(PLUGINS) $(DIST_FILES_DOCS)
 	mkdir -p $(MORPHOSPATH)extras
 	cp ${srcdir}/dists/amiga/scummvm.info $(MORPHOSPATH)/$(EXECUTABLE).info
 ifdef DIST_FILES_DOCS

--- a/backends/platform/sdl/ps3/ps3.mk
+++ b/backends/platform/sdl/ps3/ps3.mk
@@ -1,4 +1,4 @@
-ps3pkg: $(EXECUTABLE)
+ps3pkg: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	$(STRIP) $(EXECUTABLE)
 	sprxlinker $(EXECUTABLE)
 	mkdir -p ps3pkg/USRDIR/data/

--- a/backends/platform/sdl/psp2/psp2.mk
+++ b/backends/platform/sdl/psp2/psp2.mk
@@ -3,7 +3,7 @@ PSP2_EXE_STRIPPED := scummvm_stripped$(EXEEXT)
 $(PSP2_EXE_STRIPPED): $(EXECUTABLE)
 	$(STRIP) --strip-debug $< -o $@
 
-psp2vpk: $(PSP2_EXE_STRIPPED)
+psp2vpk: $(PSP2_EXE_STRIPPED) $(DIST_FILES_DOCS)
 	rm -rf psp2pkg
 	rm -f $(EXECUTABLE).vpk
 	mkdir -p psp2pkg/sce_sys/livearea/contents

--- a/backends/platform/sdl/riscos/riscos.mk
+++ b/backends/platform/sdl/riscos/riscos.mk
@@ -7,7 +7,7 @@ endif
 APP_NAME=!ScummVM
 
 # Special target to create an RISC OS snapshot installation
-riscosdist: all
+riscosdist: all $(DIST_FILES_DOCS)
 	mkdir -p $(APP_NAME)
 	elf2aif $(EXECUTABLE) $(APP_NAME)/scummvm,ff8
 	cp ${srcdir}/dists/riscos/!Boot,feb $(APP_NAME)/!Boot,feb

--- a/backends/platform/sdl/switch/switch.mk
+++ b/backends/platform/sdl/switch/switch.mk
@@ -1,4 +1,4 @@
-scummvm.nro: $(EXECUTABLE)
+scummvm.nro: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	mkdir -p ./switch_release/scummvm/data
 	mkdir -p ./switch_release/scummvm/doc
 	nacptool --create "ScummVM" "Cpasjuste" "$(VERSION)" ./switch_release/scummvm.nacp

--- a/backends/platform/wii/wii.mk
+++ b/backends/platform/wii/wii.mk
@@ -23,7 +23,7 @@ wiidebug:
 	$(DEVKITPPC)/bin/powerpc-eabi-gdb -n $(EXECUTABLE) -x $(srcdir)/backends/platform/wii/gdb.txt
 
 # target to create a Wii snapshot
-wiidist: all
+wiidist: all $(DIST_FILES_DOCS)
 	$(MKDIR) wiidist/scummvm
 ifeq ($(GAMECUBE),1)
 	$(DEVKITPPC)/bin/elf2dol $(EXECUTABLE) wiidist/scummvm/scummvm.dol

--- a/ports.mk
+++ b/ports.mk
@@ -5,7 +5,7 @@
 #
 # POSIX specific
 #
-install-data:
+install-data: $(DIST_FILES_DOCS)
 	$(INSTALL) -d "$(DESTDIR)$(mandir)/man6/"
 	$(INSTALL) -c -m 644 "$(srcdir)/dists/scummvm.6" "$(DESTDIR)$(mandir)/man6/scummvm.6"
 	$(INSTALL) -d "$(DESTDIR)$(datarootdir)/pixmaps/"
@@ -56,7 +56,7 @@ endif
 
 # Special generic target for simple archive distribution
 
-dist-generic: $(EXECUTABLE)
+dist-generic: $(EXECUTABLE) $(DIST_FILES_DOCS)
 	mkdir -p ./dist-generic/scummvm/data
 	mkdir -p ./dist-generic/scummvm/doc
 	cp $(EXECUTABLE) ./dist-generic/scummvm
@@ -114,7 +114,7 @@ endif
 
 bundle_name = ScummVM.app
 
-bundle-pack:
+bundle-pack: $(DIST_FILES_DOCS)
 	mkdir -p $(bundle_name)/Contents/MacOS
 	mkdir -p $(bundle_name)/Contents/Resources
 	echo "APPL????" > $(bundle_name)/Contents/PkgInfo
@@ -174,7 +174,7 @@ else
 bundle: scummvm-static bundle-pack
 endif
 
-iphonebundle: iphone
+iphonebundle: iphone $(DIST_FILES_DOCS)
 	mkdir -p $(bundle_name)
 	cp $(srcdir)/dists/iphone/Info.plist $(bundle_name)/
 	sed -i'' -e 's/$$(PRODUCT_BUNDLE_IDENTIFIER)/org.scummvm.scummvm/' $(bundle_name)/Info.plist
@@ -198,7 +198,7 @@ endif
 	cp $(srcdir)/dists/iphone/Default.png $(bundle_name)/
 	codesign -s - --deep --force $(bundle_name)
 
-ios7bundle: iphone
+ios7bundle: iphone $(DIST_FILES_DOCS)
 	mkdir -p $(bundle_name)
 	awk 'BEGIN {s=0}\
 		/<key>CFBundleIcons<\/key>/ {\
@@ -481,7 +481,7 @@ iphone: $(DETECT_OBJS) $(OBJS)
 
 # Special target to create a snapshot disk image for Mac OS X
 # TODO: Replace AUTHORS by Credits.rtf
-osxsnap: bundle
+osxsnap: bundle $(DIST_FILES_DOCS)
 	mkdir ScummVM-snapshot
 	cp $(DIST_FILES_DOCS) ./ScummVM-snapshot/
 	mv ./ScummVM-snapshot/COPYING ./ScummVM-snapshot/License\ \(GPL\)


### PR DESCRIPTION
Don't use special characters in file name as make and shell don't have
same rules.

When we use parentheses, shell expects them to be escaped (or quoted) while make doesn't want to hear about quotes nor escaping (it doesn't see file).
Spaces are not ideal too but they can be handled as we don't do heavy processing with the variables.

Then, add the $(DIST_FILES_DOCS) as a prerequisite to all targets using it. This will download the manual when it's not present and curl is available.