### PR TITLE
STARK: Detect TLJ Steam version to fix missing bg resource

### DIFF
--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -80,6 +80,12 @@ struct ADGameFileDescription {
 #define AD_ENTRY2s(f1, x1, s1, f2, x2, s2) {{f1, 0, x1, s1}, {f2, 0, x2, s2}, AD_LISTEND}
 
 /**
+ * A shortcut to produce a list of ADGameFileDescription records with only three
+ * records that contain just a filename with an MD5, plus a file size.
+ */
+#define AD_ENTRY3s(f1, x1, s1, f2, x2, s2, f3, x3, s3) {{f1, 0, x1, s1}, {f2, 0, x2, s2}, {f3, 0, x3, s3}, AD_LISTEND}
+
+/**
  * Flags used in the game description.
  */
 enum ADGameFlags {

--- a/engines/stark/detection.cpp
+++ b/engines/stark/detection.cpp
@@ -24,6 +24,7 @@
 
 #include "common/translation.h"
 
+#include "stark/detection.h"
 #include "stark/debug.h"
 
 namespace Stark {
@@ -44,6 +45,20 @@ static const DebugChannelDef debugFlagList[] = {
 };
 
 static const ADGameDescription gameDescriptions[] = {
+
+	// The Longest Journey
+	// English Steam (game.exe missing valid 147.bmp resource for dialog boxes background)
+	{
+		"tlj", "Steam",
+		AD_ENTRY3s("x.xarc",        "de8327850d7bba90b690b141eaa23f61", 3032,
+				   "chapters.ini",  "5b5a1f1dd2297d9ce0d3d12216d5d2c5", 485,
+				   "game.exe",      "2a68bd64e71635c74a5c6bb172ec1cb1", 95744),
+		Common::EN_ANY,
+		Common::kPlatformWindows,
+		GF_MISSING_EXE_RESOURCES|ADGF_NO_FLAGS,
+		GUIO_NONE
+	},
+
 	// The Longest Journey
 	// English DVD
 	{

--- a/engines/stark/detection.h
+++ b/engines/stark/detection.h
@@ -1,0 +1,34 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef STARK_DETECTION_H
+#define STARK_DETECTION_H
+
+namespace Stark {
+
+enum GameFlags {
+	GF_MISSING_EXE_RESOURCES = 1 << 0
+};
+
+} // End of namespace Stark
+
+#endif // STARK_DETECTION_H

--- a/engines/stark/services/userinterface.cpp
+++ b/engines/stark/services/userinterface.cpp
@@ -60,7 +60,7 @@
 
 namespace Stark {
 
-UserInterface::UserInterface(Gfx::Driver *gfx) :
+UserInterface::UserInterface(StarkEngine *vm, Gfx::Driver *gfx) :
 		_gfx(gfx),
 		_cursor(nullptr),
 		_diaryIndexScreen(nullptr),
@@ -82,6 +82,7 @@ UserInterface::UserInterface(Gfx::Driver *gfx) :
 		_currentScreen(nullptr),
 		_gameWindowThumbnail(nullptr),
 		_modalDialog(nullptr) {
+	_vm = vm;
 }
 
 UserInterface::~UserInterface() {
@@ -114,7 +115,7 @@ void UserInterface::init() {
 	_diaryPagesScreen = new DiaryPagesScreen(_gfx, _cursor);
 	_dialogScreen = new DialogScreen(_gfx, _cursor);
 	_fmvScreen = new FMVScreen(_gfx, _cursor);
-	_modalDialog = new DialogBox(_gfx, _cursor);
+	_modalDialog = new DialogBox(_vm, _gfx, _cursor);
 
 	_prevScreenNameStack.push(Screen::kScreenMainMenu);
 	_currentScreen = _fmvScreen;

--- a/engines/stark/services/userinterface.h
+++ b/engines/stark/services/userinterface.h
@@ -23,6 +23,7 @@
 #ifndef STARK_SERVICES_USER_INTERFACE_H
 #define STARK_SERVICES_USER_INTERFACE_H
 
+#include "engines/stark/stark.h"
 #include "engines/stark/ui/screen.h"
 
 #include "engines/stark/services/gamemessage.h"
@@ -73,7 +74,7 @@ enum {
  */
 class UserInterface {
 public:
-	explicit UserInterface(Gfx::Driver *gfx);
+	explicit UserInterface(StarkEngine *vm, Gfx::Driver *gfx);
 	virtual ~UserInterface();
 
 	void init();
@@ -200,6 +201,7 @@ private:
 
 	void cycleInventory(bool forward);
 
+	StarkEngine *_vm;
 	GameScreen *_gameScreen;
 	FMVScreen *_fmvScreen;
 	DiaryIndexScreen *_diaryIndexScreen;

--- a/engines/stark/stark.cpp
+++ b/engines/stark/stark.cpp
@@ -54,6 +54,7 @@
 #include "common/savefile.h"
 #include "common/system.h"
 #include "common/translation.h"
+#include "engines/advancedDetector.h"
 #include "gui/message.h"
 
 namespace Stark {
@@ -114,7 +115,7 @@ Common::Error StarkEngine::run() {
 	services.dialogPlayer = new DialogPlayer();
 	services.diary = new Diary();
 	services.gameInterface = new GameInterface();
-	services.userInterface = new UserInterface(services.gfx);
+	services.userInterface = new UserInterface(this, services.gfx);
 	services.settings = new Settings(_mixer, _gameDescription);
 	services.gameChapter = new GameChapter();
 	services.gameMessage = new GameMessage();
@@ -522,5 +523,7 @@ void StarkEngine::onScreenChanged() const {
 		StarkUserInterface->onScreenChanged();
 	}
 }
+
+uint32 StarkEngine::getGameFlags() const { return _gameDescription->flags; }
 
 } // End of namespace Stark

--- a/engines/stark/stark.h
+++ b/engines/stark/stark.h
@@ -26,6 +26,7 @@
 #include "engines/engine.h"
 #include "common/events.h"
 #include "common/str-array.h"
+#include "stark/detection.h"
 
 struct ADGameDescription;
 
@@ -69,6 +70,8 @@ public:
 
 	/** Extract the save slot number from the provided save file name */
 	static int getSaveNameSlot(const char *target, const Common::String &saveName);
+
+	uint32 getGameFlags() const;
 
 protected:
 	// Engine APIs

--- a/engines/stark/ui/dialogbox.cpp
+++ b/engines/stark/ui/dialogbox.cpp
@@ -228,8 +228,6 @@ Graphics::Surface *DialogBox::loadBackground() {
 	// GOG version of The Longest Journey is 1.0.0.142 "RC1" (Special Build: "Paper Sun")
 	// Steam's game.exe does not contain a valid resource for the background bitmap id 147
 	// so we skip trying to retrieve it based on build number.
-	// Important Note: For this fix to have any effect the game may have to be re-added to ScummVM 
-	//      so that it can be detected as the Steam version and set the flag.
 	if (_vm->getGameFlags() & GF_MISSING_EXE_RESOURCES) {
 		warning("Steam version does not contain the modal dialog background bitmap in 'game.exe'. Using fallback color for dialog background...");
 		return nullptr;

--- a/engines/stark/ui/dialogbox.cpp
+++ b/engines/stark/ui/dialogbox.cpp
@@ -46,11 +46,11 @@ static const uint buttonHorizontalMargin = 25;
 static const uint buttonVerticalMargin   = 5;
 static const Color textColor = Color(0xFF, 0xFF, 0xFF);
 
-DialogBox::DialogBox(Gfx::Driver *gfx, Cursor *cursor) :
+DialogBox::DialogBox(StarkEngine *vm, Gfx::Driver *gfx, Cursor *cursor) :
 		Window(gfx, cursor),
 		_foregroundTexture(nullptr),
 		_confirmCallback(nullptr) {
-
+	_vm = vm;
 	_surfaceRenderer = gfx->createSurfaceRenderer();
 
 	Graphics::Surface *background = loadBackground();
@@ -228,12 +228,9 @@ Graphics::Surface *DialogBox::loadBackground() {
 	// GOG version of The Longest Journey is 1.0.0.142 "RC1" (Special Build: "Paper Sun")
 	// Steam's game.exe does not contain a valid resource for the background bitmap id 147
 	// so we skip trying to retrieve it based on build number.
-	Common::WinResources::VersionInfo *versionInfo = executable.getVersionResource(1);
-	if (versionInfo
-	    && versionInfo->fileVersion[0] == 1
-	    && versionInfo->fileVersion[1] == 0
-	    && versionInfo->fileVersion[2] == 0
-	    && versionInfo->fileVersion[3] == 161) {
+	// Important Note: For this fix to have any effect the game may have to be re-added to ScummVM 
+	//      so that it can be detected as the Steam version and set the flag.
+	if (_vm->getGameFlags() & GF_MISSING_EXE_RESOURCES) {
 		warning("Steam version does not contain the modal dialog background bitmap in 'game.exe'. Using fallback color for dialog background...");
 		return nullptr;
 	}

--- a/engines/stark/ui/dialogbox.cpp
+++ b/engines/stark/ui/dialogbox.cpp
@@ -227,7 +227,7 @@ Graphics::Surface *DialogBox::loadBackground() {
 	// Steam version of The Longest Journey is 1.0.0.161 "Enno's two-CD Version"
 	// GOG version of The Longest Journey is 1.0.0.142 "RC1" (Special Build: "Paper Sun")
 	// Steam's game.exe does not contain a valid resource for the background bitmap id 147
-	// so we skip trying to retrieve it based on build number.
+	// so we skip trying to retrieve it.
 	if (_vm->getGameFlags() & GF_MISSING_EXE_RESOURCES) {
 		warning("Steam version does not contain the modal dialog background bitmap in 'game.exe'. Using fallback color for dialog background...");
 		return nullptr;

--- a/engines/stark/ui/dialogbox.h
+++ b/engines/stark/ui/dialogbox.h
@@ -23,6 +23,7 @@
 #ifndef STARK_UI_DIALOG_BOX_H
 #define STARK_UI_DIALOG_BOX_H
 
+#include "engines/stark/stark.h"
 #include "engines/stark/ui/window.h"
 
 #include "common/keyboard.h"
@@ -47,7 +48,7 @@ class VisualText;
  */
 class DialogBox : public Window {
 public:
-	DialogBox(Gfx::Driver *gfx, Cursor *cursor);
+	DialogBox(StarkEngine *vm, Gfx::Driver *gfx, Cursor *cursor);
 	~DialogBox() override;
 
 	/** Make the dialog visible with the specified message */
@@ -68,12 +69,14 @@ protected:
 	void onClick(const Common::Point &pos) override;
 
 private:
-	static Graphics::Surface *loadBackground();
+	Graphics::Surface *loadBackground();
 	static void drawBevel(Graphics::Surface *surface, const Common::Rect &rect);
 	static Common::Rect centerRect(const Common::Rect &container, const Common::Rect &size);
 
 	void freeForeground();
 	void recomputeLayout();
+
+	StarkEngine *_vm;
 
 	Gfx::SurfaceRenderer *_surfaceRenderer;
 	Gfx::Texture *_backgroundTexture;


### PR DESCRIPTION
This is an alternative fix for bug https://bugs.scummvm.org/ticket/12762

This fix will set a flag at detection time (when adding the game to ScummVM)
so that the Steam version of The Longest Journey will skip trying to load a background image resource (147.bmp) from the exe file (game.exe), since that specific build is missing this resource and this leads to an assertion fault.

Edit: It wont be necessary to re-add (redetect) the game, if it has already been added before this fix.

The previous fix was this commit and it was based only on version info of the exe file.
That one also works without having to re-add/re-detect the game, but perhaps just checking
version info is not the best approach.
https://github.com/scummvm/scummvm/commit/565a0559ed09660daa83cd529afa4e0efb6949c5


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
