### PR TITLE
Manual manual download

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -132,10 +132,12 @@ $(EXECUTABLE).dwp: $(EXECUTABLE)
 endif
 
 # Grab the ScummVM Manual from Read the Docs
-manual:
 ifdef USE_CURL
-	$(QUIET_CURL)$(CURL) -s https://docs.scummvm.org/_/downloads/en/$(MANUALVERSION)/pdf/ --output "ScummVM Manual ($(MANUALVERSION)).pdf"
-DIST_FILES_MANUAL := "ScummVM Manual ($(MANUALVERSION)).pdf"
+DIST_FILES_MANUAL := ScummVM\ Manual\ $(MANUALVERSION).pdf
+manual:
+	$(QUIET_CURL)$(CURL) -s https://docs.scummvm.org/_/downloads/en/$(MANUALVERSION)/pdf/ --output $(DIST_FILES_MANUAL)
+else
+manual:
 endif
 
 distclean: clean clean-devtools

--- a/Makefile.common
+++ b/Makefile.common
@@ -116,7 +116,7 @@ QUIET_PLUGIN  = @echo '   ' PLUGIN ' ' $@;
 QUIET_LINK    = @echo '   ' LINK '   ' $@;
 QUIET_DWP     = @echo '   ' DWP '    ' $@;
 QUIET_WINDRES = @echo '   ' WINDRES '' $@;
-QUIET_CURL    = @echo '   ' CURL '   ' $@;
+QUIET_CURL		= @echo '   ' CURL '   ' $@;
 QUIET         = @
 endif
 endif
@@ -132,15 +132,10 @@ $(EXECUTABLE).dwp: $(EXECUTABLE)
 endif
 
 # Grab the ScummVM Manual from Read the Docs
+manual:
 ifdef USE_CURL
-DIST_FILES_MANUAL := ScummVM\ Manual\ $(MANUALVERSION).pdf
-manual:
-	$(QUIET_CURL)$(CURL) -s "https://docs.scummvm.org/_/downloads/en/$(MANUALVERSION)/pdf/" --output $(DIST_FILES_MANUAL)
-# If manual doesn't exist yet and ends up in a requisite, download it
-$(DIST_FILES_MANUAL):
-	$(QUIET)$(MAKE) manual
-else
-manual:
+	$(QUIET_CURL)$(CURL) -s https://docs.scummvm.org/_/downloads/en/$(MANUALVERSION)/pdf/ --output "ScummVM Manual ($(MANUALVERSION)).pdf"
+DIST_FILES_MANUAL := "ScummVM Manual ($(MANUALVERSION)).pdf"
 endif
 
 distclean: clean clean-devtools

--- a/Makefile.common
+++ b/Makefile.common
@@ -358,7 +358,9 @@ ifdef USE_PANDOC
 DIST_FILES_DOCS+=README$(PANDOCEXT) NEWS$(PANDOCEXT) CONTRIBUTING$(PANDOCEXT)
 endif
 ifdef DIST_FILES_MANUAL
+ifneq ("$(wildcard $(DIST_FILES_MANUAL))","")
 DIST_FILES_DOCS+=$(DIST_FILES_MANUAL)
+endif
 endif
 
 DIST_FILES_DOCS_languages=cz da de es fr it no-nb se

--- a/backends/platform/androidsdl/androidsdl.mk
+++ b/backends/platform/androidsdl/androidsdl.mk
@@ -1,5 +1,5 @@
 # Special target to create an AndroidSDL snapshot
-androidsdl: $(DIST_FILES_DOCS)
+androidsdl:
 	$(MKDIR) release
 	$(INSTALL) -c -m 644 $(DIST_FILES_THEMES) $(DIST_FILES_NETWORKING) $(DIST_FILES_VKEYBD) $(DIST_FILES_ENGINEDATA) release
 	$(INSTALL) -c -m 644 $(DIST_FILES_DOCS)  release

--- a/backends/platform/dingux/dingux.mk
+++ b/backends/platform/dingux/dingux.mk
@@ -12,7 +12,7 @@ dingux-distclean:
 	rm -rf $(bundle_name)
 	rm $(DINGUX_EXE_STRIPPED)
 
-dingux-dist: all $(DIST_FILES_DOCS)
+dingux-dist: all
 	$(MKDIR) $(bundle_name)
 	$(MKDIR) $(bundle_name)/saves
 	$(STRIP) $(EXECUTABLE) -o $(bundle_name)/scummvm.elf
@@ -37,7 +37,7 @@ endif
 	$(CP) $(srcdir)/backends/platform/dingux/scummvm.png $(bundle_name)/
 
 # Special target for generationg GCW-Zero OPK bundle
-$(gcw0_bundle): all $(DIST_FILES_DOCS)
+$(gcw0_bundle): all
 	$(MKDIR) $(gcw0_bundle)
 	$(CP) $(DIST_FILES_DOCS) $(gcw0_bundle)/
 	$(MKDIR) $(gcw0_bundle)/themes

--- a/backends/platform/gph/caanoo-bundle.mk
+++ b/backends/platform/gph/caanoo-bundle.mk
@@ -5,7 +5,7 @@ bundle_name = release/scummvm-caanoo
 f=$(shell which $(STRIP))
 libloc = $(shell dirname $(f))
 
-caanoo-bundle: $(EXECUTABLE) $(DIST_FILES_DOCS)
+caanoo-bundle: $(EXECUTABLE)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/saves"
@@ -43,7 +43,7 @@ endif
 	tar -C $(bundle_name) -cvjf $(bundle_name).tar.bz2 .
 	rm -R ./$(bundle_name)
 
-caanoo-bundle-debug: $(EXECUTABLE) $(DIST_FILES_DOCS)
+caanoo-bundle-debug: $(EXECUTABLE)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/saves"

--- a/backends/platform/gph/gp2x-bundle.mk
+++ b/backends/platform/gph/gp2x-bundle.mk
@@ -4,7 +4,7 @@ bundle_name = release/scummvm-gp2x
 f=$(shell which $(STRIP))
 libloc = $(shell dirname $(f))
 
-gp2x-bundle: $(EXECUTABLE) $(DIST_FILES_DOCS)
+gp2x-bundle: $(EXECUTABLE)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/saves"
 	$(MKDIR) "$(bundle_name)/engine-data"
@@ -42,7 +42,7 @@ endif
 	tar -C $(bundle_name) -cvjf $(bundle_name).tar.bz2 .
 	rm -R ./$(bundle_name)
 
-gp2x-bundle-debug: $(EXECUTABLE) $(DIST_FILES_DOCS)
+gp2x-bundle-debug: $(EXECUTABLE)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/saves"
 	$(MKDIR) "$(bundle_name)/engine-data"

--- a/backends/platform/gph/gp2xwiz-bundle.mk
+++ b/backends/platform/gph/gp2xwiz-bundle.mk
@@ -4,7 +4,7 @@ bundle_name = release/scummvm-gp2xwiz
 f=$(shell which $(STRIP))
 libloc = $(shell dirname $(f))
 
-gp2xwiz-bundle: $(EXECUTABLE) $(DIST_FILES_DOCS)
+gp2xwiz-bundle: $(EXECUTABLE)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/saves"
@@ -45,7 +45,7 @@ endif
 	tar -C $(bundle_name) -cvjf $(bundle_name).tar.bz2 .
 	rm -R ./$(bundle_name)
 
-gp2xwiz-bundle-debug: $(EXECUTABLE) $(DIST_FILES_DOCS)
+gp2xwiz-bundle-debug: $(EXECUTABLE)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/saves"

--- a/backends/platform/n64/n64.mk
+++ b/backends/platform/n64/n64.mk
@@ -12,7 +12,7 @@ n64-distclean:
 	rm -rf $(bundle_name)
 	rm $(N64_EXE_STRIPPED)
 
-n64-dist: all $(DIST_FILES_DOCS)
+n64-dist: all
 	$(MKDIR) $(bundle_name)
 	$(MKDIR) $(bundle_name)/romfs
 ifdef DIST_FILES_ENGINEDATA

--- a/backends/platform/openpandora/op-bundle.mk
+++ b/backends/platform/openpandora/op-bundle.mk
@@ -5,7 +5,7 @@ bundle_name = release/scummvm-op
 f=$(shell which $(STRIP))
 libloc = $(shell dirname $(f))
 
-op-bundle: $(EXECUTABLE) $(DIST_FILES_DOCS)
+op-bundle: $(EXECUTABLE)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/bin"
@@ -49,7 +49,7 @@ endif
 	tar -C $(bundle_name) -cvjf $(bundle_name).tar.bz2 .
 	rm -R ./$(bundle_name)
 
-op-pnd: $(EXECUTABLE) $(DIST_FILES_DOCS)
+op-pnd: $(EXECUTABLE)
 	$(MKDIR) "$(bundle_name)"
 	$(MKDIR) "$(bundle_name)/scummvm"
 	$(MKDIR) "$(bundle_name)/scummvm/bin"

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -8,7 +8,7 @@
 # missing theme files and a missing valid translation.dat.
 # Switching to AmigaOS' own "makedir" until there is a fix or other solution.
 #
-amigaosdist: $(EXECUTABLE) $(PLUGINS) $(DIST_FILES_DOCS)
+amigaosdist: $(EXECUTABLE) $(PLUGINS)
 	makedir all $(AMIGAOSPATH)
 	cp ${srcdir}/dists/amigaos/scummvm_drawer.info $(patsubst %/,%,$(AMIGAOSPATH)).info
 	cp ${srcdir}/dists/amigaos/scummvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info

--- a/backends/platform/sdl/morphos/morphos.mk
+++ b/backends/platform/sdl/morphos/morphos.mk
@@ -1,6 +1,6 @@
 # Special target to create an MorphOS snapshot installation.
 # AmigaOS shell doesn't like indented comments.
-morphosdist: $(EXECUTABLE) $(PLUGINS) $(DIST_FILES_DOCS)
+morphosdist: $(EXECUTABLE) $(PLUGINS)
 	mkdir -p $(MORPHOSPATH)extras
 	cp ${srcdir}/dists/amiga/scummvm.info $(MORPHOSPATH)/$(EXECUTABLE).info
 ifdef DIST_FILES_DOCS

--- a/backends/platform/sdl/ps3/ps3.mk
+++ b/backends/platform/sdl/ps3/ps3.mk
@@ -1,4 +1,4 @@
-ps3pkg: $(EXECUTABLE) $(DIST_FILES_DOCS)
+ps3pkg: $(EXECUTABLE)
 	$(STRIP) $(EXECUTABLE)
 	sprxlinker $(EXECUTABLE)
 	mkdir -p ps3pkg/USRDIR/data/

--- a/backends/platform/sdl/psp2/psp2.mk
+++ b/backends/platform/sdl/psp2/psp2.mk
@@ -3,7 +3,7 @@ PSP2_EXE_STRIPPED := scummvm_stripped$(EXEEXT)
 $(PSP2_EXE_STRIPPED): $(EXECUTABLE)
 	$(STRIP) --strip-debug $< -o $@
 
-psp2vpk: $(PSP2_EXE_STRIPPED) $(DIST_FILES_DOCS)
+psp2vpk: $(PSP2_EXE_STRIPPED)
 	rm -rf psp2pkg
 	rm -f $(EXECUTABLE).vpk
 	mkdir -p psp2pkg/sce_sys/livearea/contents

--- a/backends/platform/sdl/riscos/riscos.mk
+++ b/backends/platform/sdl/riscos/riscos.mk
@@ -7,7 +7,7 @@ endif
 APP_NAME=!ScummVM
 
 # Special target to create an RISC OS snapshot installation
-riscosdist: all $(DIST_FILES_DOCS)
+riscosdist: all
 	mkdir -p $(APP_NAME)
 	elf2aif $(EXECUTABLE) $(APP_NAME)/scummvm,ff8
 	cp ${srcdir}/dists/riscos/!Boot,feb $(APP_NAME)/!Boot,feb

--- a/backends/platform/sdl/switch/switch.mk
+++ b/backends/platform/sdl/switch/switch.mk
@@ -1,4 +1,4 @@
-scummvm.nro: $(EXECUTABLE) $(DIST_FILES_DOCS)
+scummvm.nro: $(EXECUTABLE)
 	mkdir -p ./switch_release/scummvm/data
 	mkdir -p ./switch_release/scummvm/doc
 	nacptool --create "ScummVM" "Cpasjuste" "$(VERSION)" ./switch_release/scummvm.nacp

--- a/backends/platform/wii/wii.mk
+++ b/backends/platform/wii/wii.mk
@@ -23,7 +23,7 @@ wiidebug:
 	$(DEVKITPPC)/bin/powerpc-eabi-gdb -n $(EXECUTABLE) -x $(srcdir)/backends/platform/wii/gdb.txt
 
 # target to create a Wii snapshot
-wiidist: all $(DIST_FILES_DOCS)
+wiidist: all
 	$(MKDIR) wiidist/scummvm
 ifeq ($(GAMECUBE),1)
 	$(DEVKITPPC)/bin/elf2dol $(EXECUTABLE) wiidist/scummvm/scummvm.dol

--- a/ports.mk
+++ b/ports.mk
@@ -5,7 +5,7 @@
 #
 # POSIX specific
 #
-install-data: $(DIST_FILES_DOCS)
+install-data:
 	$(INSTALL) -d "$(DESTDIR)$(mandir)/man6/"
 	$(INSTALL) -c -m 644 "$(srcdir)/dists/scummvm.6" "$(DESTDIR)$(mandir)/man6/scummvm.6"
 	$(INSTALL) -d "$(DESTDIR)$(datarootdir)/pixmaps/"
@@ -56,7 +56,7 @@ endif
 
 # Special generic target for simple archive distribution
 
-dist-generic: $(EXECUTABLE) $(DIST_FILES_DOCS)
+dist-generic: $(EXECUTABLE)
 	mkdir -p ./dist-generic/scummvm/data
 	mkdir -p ./dist-generic/scummvm/doc
 	cp $(EXECUTABLE) ./dist-generic/scummvm
@@ -114,7 +114,7 @@ endif
 
 bundle_name = ScummVM.app
 
-bundle-pack: $(DIST_FILES_DOCS)
+bundle-pack:
 	mkdir -p $(bundle_name)/Contents/MacOS
 	mkdir -p $(bundle_name)/Contents/Resources
 	echo "APPL????" > $(bundle_name)/Contents/PkgInfo
@@ -174,7 +174,7 @@ else
 bundle: scummvm-static bundle-pack
 endif
 
-iphonebundle: iphone $(DIST_FILES_DOCS)
+iphonebundle: iphone
 	mkdir -p $(bundle_name)
 	cp $(srcdir)/dists/iphone/Info.plist $(bundle_name)/
 	sed -i'' -e 's/$$(PRODUCT_BUNDLE_IDENTIFIER)/org.scummvm.scummvm/' $(bundle_name)/Info.plist
@@ -198,7 +198,7 @@ endif
 	cp $(srcdir)/dists/iphone/Default.png $(bundle_name)/
 	codesign -s - --deep --force $(bundle_name)
 
-ios7bundle: iphone $(DIST_FILES_DOCS)
+ios7bundle: iphone
 	mkdir -p $(bundle_name)
 	awk 'BEGIN {s=0}\
 		/<key>CFBundleIcons<\/key>/ {\
@@ -481,7 +481,7 @@ iphone: $(DETECT_OBJS) $(OBJS)
 
 # Special target to create a snapshot disk image for Mac OS X
 # TODO: Replace AUTHORS by Credits.rtf
-osxsnap: bundle $(DIST_FILES_DOCS)
+osxsnap: bundle
 	mkdir ScummVM-snapshot
 	cp $(DIST_FILES_DOCS) ./ScummVM-snapshot/
 	mv ./ScummVM-snapshot/COPYING ./ScummVM-snapshot/License\ \(GPL\)


### PR DESCRIPTION
Fixes trying to copy the user manual pdf file when it is not present.
This does so by checking if the file is present before adding it to `DIST_FILES_DOCS`.

This is an alternative to pull request #3317 that instead automatically downloads the manual if not present (or at least try to do so). Since that pull request had already been merged, this pull request includes reverting the commits it contained.

I am not sure which approach is best, which is why I am proposing this as a pull request. With the changes here, if we want to bundle the user manual, we need to run manually `make manual` first. But in the case of a release, the file could be included in the release tarball.

One issue with the automatic download is that it requires an internet access. Without one trying to do `make bundle` or `make install` will fail.