### PR TITLE
SCUMM: Fix handling of Ctrl+Key in monkey1 and monkey2

### DIFF
--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -619,6 +619,10 @@ void ScummEngine::processKeyboard(Common::KeyState lastKeyHit) {
 		    lastKeyHit.keycode <= Common::KEYCODE_F9) {
 			_mouseAndKeyboardStat = lastKeyHit.keycode - Common::KEYCODE_F1 + 315;
 
+		} else if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY2) &&
+				   (lastKeyHit.flags & Common::KBD_CTRL) &&
+				   (lastKeyHit.keycode >= Common::KEYCODE_a && lastKeyHit.keycode <= Common::KEYCODE_z)) {
+			_mouseAndKeyboardStat = lastKeyHit.keycode - Common::KEYCODE_a + 1;
 		} else if (_game.id == GID_MONKEY2 && (lastKeyHit.flags & Common::KBD_ALT)) {
 			// Handle KBD_ALT combos in MI2. We know that the result must be 273 for Alt-W
 			// because that's what MI2 looks for in its "instant win" cheat.


### PR DESCRIPTION
There are several Ctrl+Key combinations that are accepted by the engine.
Most famous one is Ctrl+W, which is Instant Win on monkey1 (monkey2 uses
Alt+W, and has a similar hack for passing it correctly).

This used to work with ScummVM 1.9.0/SDL1, but broke with SDL2, and was
later broken further even for SDL1 in f5ed14e93d85.

Fixes #10644.
