### PR TITLE
SCUMM: Indy4 - Put coat/window in office, fixes bug #12420

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1386,7 +1386,7 @@ void ScummEngine_v5::o5_loadRoom() {
 	// WORKAROUND bug #12420 (also occurs in original) Broken window and coat missing
 	// This happens when you skip the cutscenes in the beginning, in particular
 	// the one where Indy enters the office for the first time. If object 23 (National
-	// Archeology) is in possession of Indy (owner == 1) then it's safe the force the
+	// Archeology) is in possession of Indy (owner == 1) then it's safe to force the
 	// coat (object 24) and broken window (object 25) into the room.
 	if (_game.id == GID_INDY4 && room == 1 && _objectOwnerTable[23] == 1) {
 		putState(24, 1);

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1383,6 +1383,16 @@ void ScummEngine_v5::o5_loadRoom() {
 
 	room = getVarOrDirectByte(PARAM_1);
 
+	// WORKAROUND bug #12420 (also occurs in original) Broken window and coat missing
+	// This happens when you skip the cutscenes in the beginning, in particular
+	// the one where Indy enters the office for the first time. If object 23 (National
+	// Archeology) is in possession of Indy (owner == 1) then it's safe the force the
+	// coat (object 24) and broken window (object 25) into the room.
+	if (_game.id == GID_INDY4 && room == 1 && _objectOwnerTable[23] == 1) {
+		putState(24, 1);
+		putState(25, 1);
+	}
+
 	// For small header games, we only call startScene if the room
 	// actually changed. This avoid unwanted (wrong) fades in Zak256
 	// and others. OTOH, it seems to cause a problem in newer games.


### PR DESCRIPTION
WORKAROUND bug #12420 (also occurs in original) Broken window and coat missing

This happens when you skip the cutscenes in the beginning, in particular
the one where Indy enters the office for the first time. If object 23 (National
Archeology) is in possession of Indy (owner == 1) then it's safe the force the
coat (object 24) and broken window (object 25) into the room to compensate for
the skipped code.