### PR TITLE
ASYLUM: Add detection entry for German Steam version

### DIFF
--- a/engines/asylum/asylum.cpp
+++ b/engines/asylum/asylum.cpp
@@ -70,11 +70,18 @@ AsylumEngine::AsylumEngine(OSystem *system, const ADGameDescription *gd) : Engin
 	_delayedVideoIndex = -1;
 	_previousScene = NULL;
 
+	// Game data
+	Common::String dataDir("data/");
+	if (checkGameVersion("Steam")) {
+		dataDir += getLanguageCode(getLanguage());
+		dataDir += '/';
+	}
+
 	// Add default search directories
-	const Common::FSNode gameDataDir(ConfMan.get("path"));
-	SearchMan.addSubDirectoryMatching(gameDataDir, "data");
-	SearchMan.addSubDirectoryMatching(gameDataDir, "data/vids");
-	SearchMan.addSubDirectoryMatching(gameDataDir, "data/music");
+	const Common::FSNode gamePath(ConfMan.get("path"));
+	SearchMan.addSubDirectoryMatching(gamePath, dataDir);
+	SearchMan.addSubDirectoryMatching(gamePath, dataDir + "vids");
+	SearchMan.addSubDirectoryMatching(gamePath, dataDir + "music");
 
 	// Initialize random number source
 	_rnd = new Common::RandomSource("asylum");

--- a/engines/asylum/asylum.h
+++ b/engines/asylum/asylum.h
@@ -23,6 +23,7 @@
 #ifndef ASYLUM_ASYLUM_H
 #define ASYLUM_ASYLUM_H
 
+#include "common/language.h"
 #include "common/random.h"
 #include "common/rect.h"
 #include "common/scummsys.h"
@@ -198,6 +199,7 @@ public:
 	void saveLoadWithSerializer(Common::Serializer &s);
 
 	bool checkGameVersion(const char *version) { return !strcmp(_gameDescription->extra, version); }
+	Common::Language getLanguage() { return _gameDescription->language; }
 
 private:
 	const ADGameDescription *_gameDescription;

--- a/engines/asylum/detection.cpp
+++ b/engines/asylum/detection.cpp
@@ -48,7 +48,7 @@ class AsylumMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
 	AsylumMetaEngineDetection() : AdvancedMetaEngineDetection(Asylum::gameDescriptions, sizeof(ADGameDescription), asylumGames) {
 		_md5Bytes = 0;
-		_maxScanDepth = 3;
+		_maxScanDepth = 4;
 		_directoryGlobs = Asylum::directoryGlobs;
 	}
 

--- a/engines/asylum/detection_tables.h
+++ b/engines/asylum/detection_tables.h
@@ -105,6 +105,21 @@ static const ADGameDescription gameDescriptions[] = {
 	},
 	{
 		"asylum",
+		"Steam",
+		{
+			{"SNTRM.DAT", 0, "f427fda37a0e29afd4acf982c4cb9fb0", 8930},
+			{"RES.000",   0, "0578f326b40d22f661ac93cf49dc2c19", 285658},
+			{"SCN.006",   0, "3a5b54da08198012dc0614114782d5fb", 2918330},
+			{"MOV000_2_SMK.ogv", 0, NULL, -1},
+			AD_LISTEND
+		},
+		Common::DE_DEU,
+		Common::kPlatformWindows,
+		ADGF_UNSTABLE | ADGF_DROPPLATFORM,
+		GUIO0()
+	},
+	{
+		"asylum",
 		"French Version",
 		{
 			{"SNTRM.DAT", 0, "e09a12543c6ede1727c8ecffb74e7fd2", 8930},

--- a/engines/asylum/detection_tables.h
+++ b/engines/asylum/detection_tables.h
@@ -29,6 +29,9 @@ namespace Asylum {
 
 static const char *directoryGlobs[] = {
 	"Data",
+	"DE",
+	"EN",
+	"FR",
 	"Vids",
 	0
 };


### PR DESCRIPTION
This patch adds a detection entry for the German Steam version of Sanitarum.

Unfortunately, this version is currently completely broken and crashes with
```File::open: opening 'palette' failed
Assertion failed: _handle, file common/file.cpp, line 142
```
on startup. I'm adding this version basically just for reference at this point. Hopefully, I'll get my hands on a proper German CD release as well.