### PR TITLE
AUDIO OPL2/3 EMULATION: Fix DOS_BOX OPL3 mode runnin as OPL2

### DIFF
--- a/audio/softsynth/opl/dosbox.cpp
+++ b/audio/softsynth/opl/dosbox.cpp
@@ -324,7 +324,7 @@ void OPL::dualWrite(uint8 index, uint8 reg, uint8 val) {
 void OPL::generateSamples(int16 *buffer, int length) {
 	// For stereo OPL cards, we divide the sample count by 2,
 	// to match stereo AudioStream behavior.
-	if (_type != Config::kOpl2)
+	if (_type != Config::kOpl2 && _emulator->opl3Active)
 		length >>= 1;
 
 	const uint bufferLength = 512;


### PR DESCRIPTION
AUDIO OPL2/3 EMULATION: Fix DOS_BOX OPL3 mode runnin as OPL2

If running an OPL2 track on a DOS_BOX OPL3 emulation,
The buffer will be divided by 2 like if it is stereo,
but it will generate a mono audio stream, as opl3Active
flag is disabled, so it will act as an OPL2.
The error results in wrong sound produced.
This fix the issue when OPL3 is used as OPL2 and therefore
as a mono audio source.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
