### PR TITLE
BURIED: Fix missing research points (bug 12881)

### DIFF
--- a/engines/buried/biochip_view.cpp
+++ b/engines/buried/biochip_view.cpp
@@ -746,10 +746,6 @@ void FilesBioChipViewWindow::onLButtonUp(const Common::Point &point, uint flags)
 
 		if (_curPage == 6)
 			((SceneViewWindow *)(_parent->getParent()))->getGlobalFlags().scoreResearchBCJumpsuit = 1;
-		else if (_curPage == 21)
-			((SceneViewWindow *)(_parent->getParent()))->getGlobalFlags().scoreResearchMichelle = 1;
-		else if (_curPage == 31)
-			((SceneViewWindow *)(_parent->getParent()))->getGlobalFlags().scoreResearchMichelleBkg = 1;
 
 		return;
 	}
@@ -764,6 +760,12 @@ void FilesBioChipViewWindow::onLButtonUp(const Common::Point &point, uint flags)
 		if (page.hotspots[i].pageIndex >= 0 && Common::Rect(page.hotspots[i].left, page.hotspots[i].top, page.hotspots[i].right, page.hotspots[i].bottom).contains(point)) {
 			_curPage = page.hotspots[i].pageIndex;
 			invalidateWindow(false);
+
+			if (_curPage == 21)
+				((SceneViewWindow *)(_parent->getParent()))->getGlobalFlags().scoreResearchMichelle = 1;
+			else if (_curPage == 31)
+				((SceneViewWindow *)(_parent->getParent()))->getGlobalFlags().scoreResearchMichelleBkg = 1;
+
 			return;
 		}
 	}

--- a/engines/buried/biochip_view.cpp
+++ b/engines/buried/biochip_view.cpp
@@ -696,8 +696,8 @@ FilesBioChipViewWindow::FilesBioChipViewWindow(BuriedEngine *vm, Window *parent)
 		FilesPage page;
 		page.pageID = fbcStream->readSint16LE();
 		page.returnPageIndex = fbcStream->readSint16LE();
-		page.nextButtonPageIndex = fbcStream->readSint16LE();
 		page.prevButtonPageIndex = fbcStream->readSint16LE();
+		page.nextButtonPageIndex = fbcStream->readSint16LE();
 
 		for (int i = 0; i < 6; i++) {
 			page.hotspots[i].left = fbcStream->readSint16LE();
@@ -731,8 +731,8 @@ void FilesBioChipViewWindow::onLButtonUp(const Common::Point &point, uint flags)
 	const FilesPage &page = _navData[_curPage];
 
 	Common::Rect returnButton(343, 157, 427, 185);
-	Common::Rect next(193, 25, 241, 43);
-	Common::Rect previous(253, 25, 301, 43);
+	Common::Rect previous(193, 25, 241, 43);
+	Common::Rect next(253, 25, 301, 43);
 
 	if (page.returnPageIndex >= 0 && returnButton.contains(point)) {
 		_curPage = page.returnPageIndex;


### PR DESCRIPTION
This should fix the missing research points described in https://bugs.scummvm.org/ticket/12881

Basically, the bug boiled down to the points only being awarded when pressing the "previous" button. And that would never take you to the pages that awarded the points.

Note that since I've never gotten around to playing the game, it's quite difficult for me to tell if I've accidentally mixed up anything. I'd be grateful if someone more familiar with the game could test it.