### PR TITLE
ENGINES: Add new demo detection in many engines

### DIFF
--- a/engines/asylum/detection_tables.h
+++ b/engines/asylum/detection_tables.h
@@ -49,6 +49,17 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO0()
 	},
 	{
+		// Sanitarium - English Alt Demo
+		"asylum",
+		"Demo",
+		AD_ENTRY2s("ASYLUM.DAT", "6a8079e0b49affc99d148624fbb584a1", 326,
+				   "RES.000",    "a527449397576a019cdd4884a96403e2", 9012),
+		Common::EN_ANY,
+		Common::kPlatformWindows,
+		ADGF_DEMO | ADGF_UNSTABLE | ADGF_DROPPLATFORM,
+		GUIO0()
+	},
+	{
 		"asylum",
 		"Unpatched",
 		{

--- a/engines/buried/detection_tables.h
+++ b/engines/buried/detection_tables.h
@@ -351,7 +351,7 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NOLAUNCHLOAD)
 	},
 
-	// English Windows Demo 8BPP
+	// English Windows Demo 8BPP - US Gold (UK)
 	{
 		"buried",
 		"Demo 8BPP",
@@ -362,11 +362,33 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NOLAUNCHLOAD)
 	},
 
-	// English Windows Demo 24BPP
+	// English Windows Demo 24BPP - US Gold (UK)
 	{
 		"buried",
 		"Demo 24BPP",
 		AD_ENTRY1s("BIT2416.EXE", "53c520eb7c977fb1c2bb235e2a517b85", 2816256),
+		Common::EN_ANY,
+		Common::kPlatformWindows,
+		ADGF_DEMO | GF_TRUECOLOR | ADGF_TESTING,
+		GUIO1(GUIO_NOLAUNCHLOAD)
+	},
+
+	// English Windows Demo 8BPP - North America
+	{
+		"buried",
+		"Demo 8BPP",
+		AD_ENTRY1s("BIT816.EXE", "30bbd89d7df8cb319e654a441efce877", 1259072),
+		Common::EN_ANY,
+		Common::kPlatformWindows,
+		ADGF_DEMO | GF_TRUECOLOR | ADGF_TESTING,
+		GUIO1(GUIO_NOLAUNCHLOAD)
+	},
+
+	// English Windows Demo 24BPP - North America
+	{
+		"buried",
+		"Demo 24BPP",
+		AD_ENTRY1s("BIT2416.EXE", "69ba6611561c3eb5f7d8853ef913aa09", 2816256),
 		Common::EN_ANY,
 		Common::kPlatformWindows,
 		ADGF_DEMO | GF_TRUECOLOR | ADGF_TESTING,

--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -66,6 +66,12 @@ static const ADGameDescription gameDescriptions[] = {
 		Common::PL_POL, Common::kPlatformDOS, ADGF_DEMO | ADGF_UNSUPPORTED , GUIO2(GAMEOPTION_COLOR_BLIND_DEFAULT_OFF, GAMEOPTION_TTS)
 	},
 	{
+		"soltys", _s("Missing game code"),
+		AD_ENTRY2s("vol.cat", "ad3c90abf775a45380ce56e4494923fb", 9216,
+				   "vol.dat", "c5d9b15863cab61dc125551576dece04", 1518836),
+		Common::PL_POL, Common::kPlatformDOS, ADGF_DEMO | ADGF_UNSUPPORTED , GUIO2(GAMEOPTION_COLOR_BLIND_DEFAULT_OFF, GAMEOPTION_TTS)
+	},
+	{
 		"soltys", "Freeware v1.0",
 		AD_ENTRY2s("vol.cat", "f1675684c68ab90272f5776f8f2c3974", 50176,
 				   "vol.dat", "4ffeff4abc99ac5999b55ccfc56ab1df", 8430868),

--- a/engines/cge2/detection.cpp
+++ b/engines/cge2/detection.cpp
@@ -69,6 +69,13 @@ static const ADGameDescription gameDescriptions[] = {
 		},
 
 		{
+			"sfinx", "Demo",
+			AD_ENTRY2s("vol.cat", "68271dc56aa37c4e83b792df69625a00", 24576,
+					   "vol.dat", "989c26861bc56fafa3a85784e374ca15", 2710971),
+			Common::PL_POL, Common::kPlatformDOS, ADGF_DEMO, GUIO3(GAMEOPTION_COLOR_BLIND_DEFAULT_OFF, GAMEOPTION_TTS_OBJECTS, GAMEOPTION_TTS_SPEECH)
+		},
+
+		{
 			"sfinx", "Freeware v0.3",
 			AD_ENTRY2s("vol.cat", "f158e469dccbebc5a632eb848df89779", 129024,
 					   "vol.dat", "d40a6b4ae173d6930be54ba56bee15d5", 34183430),

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -98,6 +98,23 @@ static const ChewyGameDescription gameDescriptions[] = {
 		},
 	},
 
+	{
+		// Chewy - ESC von F5 - German demo
+		// Demo version 1.1 (CHEWY.EXE - offset 0x8A520)
+		// From Blue Byte News Version III/97
+		// The source CD-ROM has the Matrix code SONOPRESS T-2037 A
+		// CD-ROM has the label "DEMO"
+		{
+			"chewy",
+			0,
+			AD_ENTRY1s("atds.tap", "c3be5641e90dd01274309b778cf8146d", 230686),
+			Common::DE_DEU,
+			Common::kPlatformDOS,
+			ADGF_DEMO,
+			GUIO1(GUIO_NOMIDI)
+		},
+	},
+
 	{ AD_TABLE_END_MARKER }
 };
 

--- a/engines/cryomni3d/detection_tables.h
+++ b/engines/cryomni3d/detection_tables.h
@@ -535,6 +535,25 @@ static const CryOmni3DGameDescription gameDescriptions[] = {
 		/* GF_VERSAILLES_FONTS_ | */ GF_VERSAILLES_AUDIOPADDING_YES,
 	},
 
+	// Versailles 1685
+	// English DOS Non-interactive Demo (US)
+	{
+		{
+			"versailles",
+			"Demo",
+			{
+				{ "DEMO_US.HNS", 0, "3a65a984353fec354dd26a62ca2cd3fb", 68462303 },
+				{ "PLAYHNS.EXE", 0, "1c992f034f43418a5da2e8ebd0b92620", 472371 }
+			},
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_DEMO | ADGF_UNSUPPORTED,
+			GUI_OPTIONS_VERSAILLES
+		},
+		GType_VERSAILLES,
+		/* GF_VERSAILLES_FONTS_ | */ GF_VERSAILLES_AUDIOPADDING_NO,
+	},
+
 	{ AD_TABLE_END_MARKER, 0, 0 }
 };
 

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -912,10 +912,12 @@ static const PlainGameDescriptor directorGames[] = {
 
 	// Titles containing Director extras
 	{ "amgpremiere",		"The American Girls Premiere" },
+	{ "darylfgates",		"Police Quest Q&A with Daryl F. Gates" },
 	{ "dcanyoncd",			"Dino CD Audio Player" },
 	{ "freeallangels",		"Ash: Free All Angels Video Mixer" },
 	{ "lbfamfun",			"Little Bear Family Fun" },
 	{ "poliq",				"Political IQ Test" },
+	{ "pqmakingof",			"The Making of Police Quest" },
 	{ "scissorsnstones",	"Scissors N Stones On-Line Manual" },
 	{ "solmahjong",			"Solitudes Mahjong Game" },
 	{ "superbowltrivia",	"Super Bowl Trivia Game" },
@@ -1477,6 +1479,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Original filename is キューティ１０デモ
 	MACDEMO1_l("cutie10", "Demo", "Cutie 10 demo", "f5277c53bacd27936158dd3867e587e2", 390315, Common::JA_JPN, 311),
+
+	// From the Police Quest Collection
+	WINGAME1("darylfgates", "", "INTERVEW.EXE", "351c9f2cf2c205eea7a9ce50e73974ee", 1059729, 311),
 
 	MACGAME1("digby", "", "Start Digby's Adventures!", "7f443f2e63fd497a9ad85b10dc880a91", 383758, 313),
 	WINGAME1("digby", "", "DIGBY.EXE", "65d06b5fef155a2473434571aff5bc29", 370972, 310),
@@ -3060,6 +3065,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Plays in English, Simplified Chinese, Tibetan
 	// Alternate titles are 布达拉宫 and ཕོ་བྲང་པོ་ཏ་ལ་
 	WINGAME1("potala", "", "POTALA.EXE", "2d5780d54e3c26281ef4aadef7d004b8", 35710089, 400),
+
+	// From the Police Quest Collection
+	WINGAME1("pqmakingof", "", "MAKING.EXE", "aae6a546b0c6bc51758053d14d9f6db2", 2127119, 400),
 
 	MACGAME1("prangers1", "", "Power Rangers", "13fe5212d9fc599e34b1260dc09970be", 303281, 400),
 	MACGAME1("prangers2", "", "PR Part 2", "0ecc4b4483d638bfb727cc5472b2fde3", 303281, 400),

--- a/engines/dm/detection.cpp
+++ b/engines/dm/detection.cpp
@@ -74,6 +74,18 @@ static const DMADGameDescription gameDescriptions[] = {
 		{ kDMSavePlatformAcceptAny }
 	},
 	{
+		// Added by trembyle
+		{"dm", "Apple IIgs Demo v1.4 English",
+			AD_ENTRY2s("DEMOIIGS.DAT", "6d30bde1f4d7be1cee500e7bb160658b", 190792,
+					   "DEMODUN.DAT",  "9c1b9996aceacb3fffb5bd21ca408fa8", 1487),
+			Common::EN_ANY, Common::kPlatformApple2GS, ADGF_DEMO, GUIO1(GUIO_NOMIDI),
+		},
+		kDMSaveTargetDM21, kDMSaveFormatAmigaPC98FmTowns, kDMSavePlatformAtariSt,
+		{ kDMSaveTargetDM21, kDMSaveTargetEndOfList},
+		{ kDMSaveFormatAmigaPC98FmTowns, kDMSaveFormatEndOfList},
+		{ kDMSavePlatformAcceptAny }
+	},
+	{
 		AD_TABLE_END_MARKER, kDMSaveTargetNone, kDMSaveFormatNone, kDMSavePlatformNone,
 		{kDMSaveTargetNone}, {kDMSaveFormatNone}, {kDMSavePlatformNone}
 	}

--- a/engines/dreamweb/detection_tables.h
+++ b/engines/dreamweb/detection_tables.h
@@ -268,6 +268,59 @@ static const DreamWebGameDescription gameDescriptions[] = {
 		},
 	},
 
+	// English floppy demo
+	{
+		{
+			"dreamweb",
+			"Demo",
+			{
+				{"dreamweb.r57", 0, "dba78ab266054ad98151db0a9aa845f6", 102904},
+				{"dreamweb.r59", 0, "b1635ce312c7273b343eb0c2946361af", 199262},
+				{"dreamweb.exe", 0, "2362f28683ffe4ae4986c21226e132c9", 63656},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_DEMO,
+			GUIO2(GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_BRIGHTPALETTE)
+		},
+	},
+
+	// English CD demo
+	{
+		{
+			"dreamweb",
+			"CD Demo",
+			{
+				{"dreamweb.r60", 0, "45fb1438d165da9f098852cc8e14ad92", 108933},
+				{"dreamweb.r22", 0, "35537525b55837b91b56f2468500ea43", 190222},
+				{"dreamweb.exe", 0, "34218e66ffd0e0d65d71282e57ac4fcc", 64445},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_CD|ADGF_DEMO,
+			GUIO2(GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_BRIGHTPALETTE)
+		},
+	},
+
+	// English Amiga demo
+	{
+		{
+			"dreamweb",
+			"Demo",
+			{
+				{"dreamweb.r57", 0, "f52b88b8417c7bddc8c63b684c6ad1dd", 117720},
+				{"dreamweb.r59", 0, "996dfe6d963c27a302952c77a297b0fa", 223764},
+				{"dreamweb",	 0,	"093103deb9712340ee34c4bed94aab12", 51496},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformAmiga,
+			ADGF_DEMO,
+			GUIO2(GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_BRIGHTPALETTE)
+		},
+	},
 
 	{ AD_TABLE_END_MARKER }
 };

--- a/engines/gob/detection/detection.h
+++ b/engines/gob/detection/detection.h
@@ -54,7 +54,8 @@ enum GameType {
 	kGameTypeLittleRed,
 	kGameTypeOnceUponATime, // Need more inspection to see if Baba Yaga or Abracadabra
 	kGameTypeAJWorld,
-	kGameTypeCrousti
+	kGameTypeCrousti,
+	kGameTypeDynastyWood
 };
 
 enum Features {

--- a/engines/gob/detection/tables.h
+++ b/engines/gob/detection/tables.h
@@ -50,6 +50,7 @@ static const PlainGameDescriptor gobGames[] = {
 	{"inca2", "Inca II: Wiracocha"},
 	{"woodruff", "The Bizarre Adventures of Woodruff and the Schnibble"},
 	{"dynasty", "The Last Dynasty"},
+	{"dynastywood", "Woodruff and The Last Dynasty"},
 	{"urban", "Urban Runner"},
 	{"playtoons1", "Playtoons 1 - Uncle Archibald"},
 	{"playtoons2", "Playtoons 2 - The Case of the Counterfeit Collaborator"},

--- a/engines/gob/detection/tables_dynasty.h
+++ b/engines/gob/detection/tables_dynasty.h
@@ -142,5 +142,36 @@
 	kFeatures640x480,
 	"lda1.stk", 0, 0
 },
+{
+	{
+		"dynasty",
+		"Demo",
+		AD_ENTRY2s("demo.scn",	"a0d801c43a560b7471114744858b129c", 89,
+				   "demo5.vmd", "2abb7b6a26406c984f389f0b24b5e28e", 13290970),
+		EN_ANY,
+		kPlatformDOS,
+		ADGF_DEMO,
+		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
+	},
+	kGameTypeDynasty,
+	kFeatures640x480 | kFeaturesSCNDemo,
+	"demo.scn", 0, 1
+},
+// Combined demo for Woodruff and The Last Dynasty
+{
+	{
+		"dynastywood",
+		"Non-Interactive Demos",
+		AD_ENTRY2s("demo.scn",		"040a00b7276aa86fe7a51f5f362f63c7", 124,
+				   "demo5.vmd",		"2abb7b6a26406c984f389f0b24b5e28e", 13290970),
+		EN_ANY,
+		kPlatformDOS,
+		ADGF_DEMO,
+		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)	
+	},
+	kGameTypeDynastyWood,
+	kFeatures640x480 | kFeaturesSCNDemo,
+	"demo.scn", 0, 1
+},
 
 #endif // GOB_DETECTION_TABLES_DYNASTY_H

--- a/engines/gob/detection/tables_gob3.h
+++ b/engines/gob/detection/tables_gob3.h
@@ -508,7 +508,7 @@
 	{
 		"gob3",
 		"Non-interactive Demo",
-		AD_ENTRY1("intro.stk", "b9b898fccebe02b69c086052d5024a55"),
+		AD_ENTRY1s("intro.stk", "b9b898fccebe02b69c086052d5024a55", 600143),
 		UNK_LANG,
 		kPlatformDOS,
 		ADGF_DEMO,
@@ -522,7 +522,7 @@
 	{
 		"gob3",
 		"Interactive Demo",
-		AD_ENTRY1("intro.stk", "7aebd94e49c2c5c518c9e7b74f25de9d"),
+		AD_ENTRY1s("intro.stk", "7aebd94e49c2c5c518c9e7b74f25de9d", 270737),
 		FR_FRA,
 		kPlatformDOS,
 		ADGF_DEMO,
@@ -536,7 +536,7 @@
 	{
 		"gob3",
 		"Interactive Demo 2",
-		AD_ENTRY1("intro.stk", "e5dcbc9f6658ebb1e8fe26bc4da0806d"),
+		AD_ENTRY1s("intro.stk", "e5dcbc9f6658ebb1e8fe26bc4da0806d", 590631),
 		FR_FRA,
 		kPlatformDOS,
 		ADGF_DEMO,

--- a/engines/gob/detection/tables_inca2.h
+++ b/engines/gob/detection/tables_inca2.h
@@ -252,7 +252,7 @@
 		},
 		EN_ANY,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeInca2,

--- a/engines/gob/detection/tables_lit.h
+++ b/engines/gob/detection/tables_lit.h
@@ -441,7 +441,7 @@
 	{
 		"lit",
 		"Non-interactive Demo",
-		AD_ENTRY1("demo.stk", "2eba8abd9e3878c57307576012dd2fec"),
+		AD_ENTRY1s("demo.stk", "2eba8abd9e3878c57307576012dd2fec", 3031494),
 		UNK_LANG,
 		kPlatformDOS,
 		ADGF_DEMO,

--- a/engines/gob/detection/tables_ween.h
+++ b/engines/gob/detection/tables_ween.h
@@ -268,7 +268,7 @@
 	{
 		"ween",
 		"Demo",
-		AD_ENTRY1("intro.stk", "15fb91a1b9b09684b28ac75edf66e504"),
+		AD_ENTRY1s("intro.stk", "15fb91a1b9b09684b28ac75edf66e504", 2340230),
 		EN_USA,
 		kPlatformDOS,
 		ADGF_DEMO,
@@ -297,6 +297,20 @@
 		"ween",
 		"Demo",
 		AD_ENTRY1("intro.stk", "aca10b973c03ba8b8b2804f4e7029ece"),
+		EN_GRB,
+		kPlatformDOS,
+		ADGF_DEMO,
+		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
+	},
+	kGameTypeWeen,
+	kFeaturesAdLib,
+	0, 0, 0
+},
+{
+	{
+		"ween",
+		"v1.2 Demo",
+		AD_ENTRY1s("intro.stk", "dcff8f3a7dd1f4c33fd94aa7659b7578", 2425477),
 		EN_GRB,
 		kPlatformDOS,
 		ADGF_DEMO,

--- a/engines/gob/detection/tables_woodruff.h
+++ b/engines/gob/detection/tables_woodruff.h
@@ -374,7 +374,7 @@
 				   "wooddem3.vmd",	"a1700596172c2d4e264760030c3a3d47", 8994250),
 		EN_ANY,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
 	kGameTypeWoodruff,

--- a/engines/gob/gob.cpp
+++ b/engines/gob/gob.cpp
@@ -584,6 +584,18 @@ Common::Error GobEngine::initGameParts() {
 		_saveLoad = new SaveLoad(this);
 		break;
 
+	case kGameTypeDynastyWood:
+		_init     = new Init_v3(this);
+		_video    = new Video_v2(this);
+		_inter    = new Inter_v5(this);
+		_mult     = new Mult_v2(this);
+		_draw     = new Draw_v2(this);
+		_map      = new Map_v2(this);
+		_goblin   = new Goblin_v4(this);
+		_scenery  = new Scenery_v2(this);
+		_saveLoad = new SaveLoad(this);
+		break;
+
 	case kGameTypeUrban:
 		_init     = new Init_v6(this);
 		_video    = new Video_v6(this);

--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -540,12 +540,26 @@ static const GrimGameDescription gameDescriptions[] = {
 		GType_MONKEY4
 	},
 	{
-		// Escape from Monkey Island demo (English)
+		// Escape from Monkey Island CD demo (English)
 		{
 			"monkey4",
-			"Demo",
+			"CD Demo",
 			AD_ENTRY2s("magdemo.lab",	"9e7eaa1b9317ff47d5deeda0b2c42ce3", 19826116,
-					   "i9n.lab",		 "274f8579b01e0872fe6f1ba267266149", 26951),
+					   "monkey4.exe",	"119ee6b9380cc0e373287fabb25e0578", 884736),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_DEMO | ADGF_UNSTABLE,
+			GUI_OPTIONS_GRIME
+		},
+		GType_MONKEY4
+	},
+	{
+		// Escape from Monkey Island web demo (English)
+		{
+			"monkey4",
+			"Web Demo",
+			AD_ENTRY2s("magdemo.lab",	"9e7eaa1b9317ff47d5deeda0b2c42ce3", 19826116,
+					   "i9n.lab",		"274f8579b01e0872fe6f1ba267266149", 26951),
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_DEMO | ADGF_UNSTABLE,

--- a/engines/grim/md5check.cpp
+++ b/engines/grim/md5check.cpp
@@ -355,7 +355,7 @@ const char *emiPS2_voiceMon[] = {
 	"b4a938b9c116e9370e992c8edfb00c35", // english
 };
 
-// EMI demo
+// EMI demo (CD demo does not include i9n.lab)
 
 const char *emid_i9n[] = {
 	"d913504ec3a2fe52ee02a20a154a2b17", // english patched
@@ -454,7 +454,6 @@ void MD5Check::init() {
 		}
 	} else {
 		if (g_grim->getGameFlags() & ADGF_DEMO) {
-			MD5SUM("i9n.lab", emid_i9n)
 			MD5SUM("lip.lab", emid_lip)
 			MD5SUM("MagDemo.lab", emid_MagDemo)
 			MD5SUM("tile.lab", emid_tile)

--- a/engines/grim/resource.cpp
+++ b/engines/grim/resource.cpp
@@ -160,7 +160,6 @@ ResourceLoader::ResourceLoader() {
 		SearchMan.listMatchingMembers(files, emi_patches_filename);
 
 		if (g_grim->getGameFlags() & ADGF_DEMO) {
-			SearchMan.listMatchingMembers(files, "i9n.lab");
 			SearchMan.listMatchingMembers(files, "lip.lab");
 			SearchMan.listMatchingMembers(files, "MagDemo.lab");
 			SearchMan.listMatchingMembers(files, "tile.lab");

--- a/engines/groovie/detection.cpp
+++ b/engines/groovie/detection.cpp
@@ -108,6 +108,17 @@ static const GroovieGameDescription gameDescriptions[] = {
 		kGroovieT7G
 	},
 
+	// "Guest" early DOS demo
+	{
+		{
+			"t7g", "The early \"Guest\" demo is not supported",
+			AD_ENTRY1s("playtlc.exe", "9cff0e9649ddf49e9fe5168730aa7201", 254768),
+			Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO | ADGF_UNSUPPORTED,
+			GUIO3(GUIO_NOMIDI, GUIO_NOASPECT, GAMEOPTION_T7G_FAST_MOVIE_SPEED)
+		},
+		kGroovieT7G
+	},
+
 	// The 11th Hour DOS/Windows English (Available on Steam)
 	{
 		{

--- a/engines/hopkins/detection_tables.h
+++ b/engines/hopkins/detection_tables.h
@@ -30,7 +30,7 @@ static const HopkinsGameDescription gameDescriptions[] = {
 		// Hopkins FBI Linux Demo UK 1.00 and 1.02
 		{
 			"hopkins",
-			"Linux Demo",
+			"Demo",
 			AD_ENTRY1s("RES_VAN.RES", "29414c05be8f9fe794c61572a65def12", 16060544),
 			Common::EN_ANY,
 			Common::kPlatformLinux,
@@ -154,7 +154,7 @@ static const HopkinsGameDescription gameDescriptions[] = {
 		// CHECKME: No voice! a second file is required though... Also, it has multi-language support
 		{
 			"hopkins",
-			"Win95 Demo",
+			"Demo",
 			AD_ENTRY1s("Hopkins.exe", "0c9ebfe371f4dcf84a49f333f04839a0", 376897),
 			Common::EN_ANY,
 			Common::kPlatformWindows,
@@ -166,7 +166,7 @@ static const HopkinsGameDescription gameDescriptions[] = {
 		// Hopkins FBI Win95 Polish Demo, provided by Strangerke
 		{
 			"hopkins",
-			"Win95 Demo",
+			"Demo",
 			AD_ENTRY1s("RES_VAN.RES", "8262cfba261c200af4451902689dffe0", 12233202),
 			Common::PL_POL,
 			Common::kPlatformWindows,

--- a/engines/kyra/detection_tables.h
+++ b/engines/kyra/detection_tables.h
@@ -83,6 +83,7 @@ namespace {
 static const char msg_missingLangResources[]			= _s("Missing language specific game code and/or resources.");
 static const char msg_fanTrans_missingLangResources[]	= _s("Missing language specific game code and/or resources for this fan translation.");
 static const char msg_fanTrans_unsupportiveTranslator[]	= _s("The fan translator does not wish his translation to be incorporated into ScummVM.");
+static const char msg_nonEngineDemo[]					= _s("Demo plays simple animations without using Westwood's Engine.");
 
 const KYRAGameDescription adGameDescs[] = {
 	/* disable these targets until they get supported
@@ -1881,7 +1882,7 @@ const KYRAGameDescription adGameDescs[] = {
 					   "L01.PAK",		"759a0ac26808d77ea968bd392355ba1d", -1),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
-			ADGF_DROPLANGUAGE | ADGF_CD,
+			ADGF_DROPLANGUAGE | ADGF_CD | ADGF_DEMO,
 			GUIO8(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_MIDIPCSPK, GUIO_RENDERVGA, GAMEOPTION_LOL_SCROLLING, GAMEOPTION_LOL_CURSORS, GAMEOPTION_LOL_SAVENAMES)
 		},
 		LOL_CD_DEMO_FLAGS
@@ -1895,7 +1896,7 @@ const KYRAGameDescription adGameDescs[] = {
 					   "L01.PAK",		"759a0ac26808d77ea968bd392355ba1d", -1),
 			Common::FR_FRA,
 			Common::kPlatformDOS,
-			ADGF_DROPLANGUAGE | ADGF_CD,
+			ADGF_DROPLANGUAGE | ADGF_CD | ADGF_DEMO,
 			GUIO8(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_MIDIPCSPK, GUIO_RENDERVGA, GAMEOPTION_LOL_SCROLLING, GAMEOPTION_LOL_CURSORS, GAMEOPTION_LOL_SAVENAMES)
 		},
 		LOL_CD_DEMO_FLAGS
@@ -1909,7 +1910,7 @@ const KYRAGameDescription adGameDescs[] = {
 					   "L01.PAK",		"759a0ac26808d77ea968bd392355ba1d", -1),
 			Common::DE_DEU,
 			Common::kPlatformDOS,
-			ADGF_DROPLANGUAGE | ADGF_CD,
+			ADGF_DROPLANGUAGE | ADGF_CD | ADGF_DEMO,
 			GUIO8(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_MIDIPCSPK, GUIO_RENDERVGA, GAMEOPTION_LOL_SCROLLING, GAMEOPTION_LOL_CURSORS, GAMEOPTION_LOL_SAVENAMES)
 		},
 		LOL_CD_DEMO_FLAGS
@@ -2073,6 +2074,18 @@ const KYRAGameDescription adGameDescs[] = {
 		EOB2_FLAGS
 	},
 
+	{ // Autodesk (Flic) demo
+		{
+			"eob2",
+			msg_nonEngineDemo, // Reason for being unsupported
+			AD_ENTRY1s("DARKMOON", "46b94e1308764864746db07df64ddcc0", -1),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_DEMO | ADGF_UNSUPPORTED,
+			0
+		},
+		EOB2_FLAGS
+	},
 
 	{
 		{

--- a/engines/lilliput/detection.cpp
+++ b/engines/lilliput/detection.cpp
@@ -99,6 +99,19 @@ static const LilliputGameDescription gameDescriptions[] = {
 		},
 		kGameTypeRobin
 	},
+	// Rome Demo
+	{
+		{
+			"rome", "Demo",
+			AD_ENTRY2s("rules.prg",	 "bdf4173fe294cae627903d9731549cac", 746,
+					   "isomap.dta", "48eaaa382c4cb7a5c200ffc48c9bab1c", 16384),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE | ADGF_DEMO,
+			GUIO0()
+		},
+		kGameTypeRome
+	},
 	{AD_TABLE_END_MARKER, kGameTypeNone}
 };
 

--- a/engines/macventure/detection.cpp
+++ b/engines/macventure/detection.cpp
@@ -30,11 +30,13 @@ namespace MacVenture {
 #define ADGF_DEFAULT (ADGF_DROPLANGUAGE|ADGF_DROPPLATFORM|ADGF_MACRESFORK|ADGF_UNSTABLE)
 
 #define BASEGAME(n, v, f, md5, s) {n, v, AD_ENTRY1s(f, md5, s), Common::EN_ANY, Common::kPlatformMacintosh, ADGF_DEFAULT, GUIO1(GUIO_NOMIDI)}
+#define BASEDEMO(n, v, f, md5, s) {n, v, AD_ENTRY1s(f, md5, s), Common::EN_ANY, Common::kPlatformMacintosh, ADGF_DEFAULT|ADGF_DEMO, GUIO1(GUIO_NOMIDI)}
 
 static const ADGameDescription gameDescriptions[] = {
 	BASEGAME("shadowgate", "Zojoi Rerelease", "Shadowgate.bin", "ebbfbcbf93938bd2900cb0c0213b19ad", 68974), // Zojoi Rerelease
 	BASEGAME("deja_vu", "Zojoi Rerelease", "Deja Vu.bin", "5e9f5a8e3c8eb29ed02b34ae5937354f", 69034), // Zojoi Rerelease
 	BASEGAME("deja_vu2", "Zojoi Rerelease", "Lost in Las Vegas.bin", "8f8e1d8d41f577ee0fbc03847969af0d", 66520), // Zojoi Rerelease
+	BASEDEMO("uninvited", "Demo", "Uninvited Demo", "e53adca77d773dca926f61faac68df86", 53375),
 	AD_TABLE_END_MARKER
 };
 
@@ -55,6 +57,7 @@ static const PlainGameDescriptor macventureGames[] = {
 	{ "shadowgate", "Shadowgate" },
 	{ "deja_vu", "Deja Vu"},
 	{ "deja_vu2", "Deja Vu II"},
+	{ "uninvited", "Uninvited."},
 	{ 0, 0 }
 };
 

--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -29,6 +29,7 @@
 namespace Made {
 
 static const MadeGameDescription gameDescriptions[] = {
+
 	{
 		// NOTE: Return to Zork entries with *.dat are used to detect the game via rtzcd.dat,
 		// which is packed inside rtzcd.red. Entries with *.red refer to the packed file
@@ -325,20 +326,56 @@ static const MadeGameDescription gameDescriptions[] = {
 	},
 
 	{
-		// Return to Zork - Demo from Zork Anthology CD
-		// Bugreport #11202
+		// Return to Zork - Standalone CD Demo v1.1
 		{
 			"rtz",
-			"Demo",
-			AD_ENTRY1s("rtzcd.red", "946997d8b0aa6cb4e848bad02a1fc3d2", 130683),
+			"V1.1, 12/6/93, Demo CD",
+			AD_ENTRY1s("rtzcd.red", "827cfb323eae37b385985a2359fae3e9", 133784),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
-			ADGF_DEMO,
+			ADGF_DEMO | ADGF_CD,
 			GUIO0()
 		},
 		GID_RTZ,
 		0,
-		GF_DEMO,
+		GF_CD_COMPRESSED,
+		3,
+	},
+
+	{
+		// Return to Zork - Demo from Zork Anthology CD
+		// Bugreport #11202
+		{
+			"rtz",
+			"V1.2, 9/8/94, Demo CD",
+			AD_ENTRY1s("rtzcd.red", "946997d8b0aa6cb4e848bad02a1fc3d2", 130683),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_DEMO | ADGF_CD,
+			GUIO0()
+		},
+		GID_RTZ,
+		0,
+		GF_CD_COMPRESSED,
+		3,
+	},
+
+	{
+		// Return to Zork - Mac Demo from Zork Anthology CD
+		// Same disc as DOS version (on ISO-9660)
+		// The only resource fork is in the executable
+		{
+			"rtz",
+			"V1.2, 5/4/94, Demo CD",
+			AD_ENTRY1s("Return To Zork", "0c1377afd4b6fc4ee900e1882ac13895", 1714320),
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_DEMO | ADGF_CD | ADGF_MACRESFORK,
+			GUIO0()
+		},
+		GID_RTZ,
+		0,
+		GF_CD_COMPRESSED,
 		3,
 	},
 

--- a/engines/mads/detection_tables.h
+++ b/engines/mads/detection_tables.h
@@ -75,6 +75,21 @@ static const MADSGameDescription gameDescriptions[] = {
 		0
 	},
 
+	{
+		// Rex Nebular and the Cosmic Gender Bender DOS English Demo
+		{
+			"nebular",
+			"Demo",
+			AD_ENTRY1s("section1.hag", "ead7ea63459173c32569feecac608c4f", 192065),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_DEMO,
+			GUIO5(GUIO_NOSPEECH, GAMEOPTION_EASY_MOUSE, GAMEOPTION_ANIMATED_INVENTORY, GAMEOPTION_ANIMATED_INTERFACE, GAMEOPTION_NAUGHTY_MODE)
+		},
+		GType_RexNebular,
+		0
+	},
+
 #ifdef ENABLE_MADSV2
 
 	{
@@ -86,6 +101,21 @@ static const MADSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE,
+			GUIO1(GAMEOPTION_EASY_MOUSE)
+		},
+		GType_Phantom,
+		0
+	},
+
+	{
+		// Return of the Phantom DOS English Demo
+		{
+			"phantom",
+			"Demo",
+			AD_ENTRY1s("section1.hag", "ad738c8edb139790ebaf78f8ceceb182", 123627),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE | ADGF_DEMO,
 			GUIO1(GAMEOPTION_EASY_MOUSE)
 		},
 		GType_Phantom,

--- a/engines/mohawk/detection_tables.h
+++ b/engines/mohawk/detection_tables.h
@@ -88,6 +88,24 @@ static const MohawkGameDescription gameDescriptions[] = {
 	},
 
 	// Myst Demo
+	// English Windows 3.11, v1.0
+	// From PC Format (UK) July, 1994
+	{
+		{
+			"myst",
+			"Demo",
+			AD_ENTRY1("DEMO.DAT", "8ff8ae264f759ea4a79cc915757f17c4"),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_DEMO | ADGF_NO_FLAGS,
+			GUI_OPTIONS_MYST_DEMO
+		},
+		GType_MYST,
+		GF_DEMO,
+		0,
+	},
+
+	// Myst Demo
 	// English Windows 3.11
 	// From CD-ROM Today July, 1994
 	{

--- a/engines/mutationofjb/detection.cpp
+++ b/engines/mutationofjb/detection.cpp
@@ -71,6 +71,24 @@ static const ADGameDescription mutationofjbDescriptions[] = {
 		ADGF_CD,
 		GUIO1(GUIO_NOMIDI)
 	},
+	{	// Demo from Riki Multimedia Magazine (Slovakia) #23 - Nov 1996
+		"mutationofjb",
+		"Demo",
+		{
+			{"jbdemo.exe", 0, "97943a569bacc4131447577436389276", 121696},
+			{"strt.dat", 0, nullptr, -1},
+			{"startupb.dat", 0, nullptr, -1},
+			{"global.atn", 0, nullptr, -1},
+			{"piggy.apk", 0, nullptr, -1},
+			{"font1.aft", 0, nullptr, -1},
+			{"sysfnt.aft", 0, nullptr, -1},
+			{nullptr, 0, nullptr, 0}
+		},
+		Common::SK_SVK,
+		Common::kPlatformDOS,
+		ADGF_DEMO,
+		GUIO1(GUIO_NOMIDI)
+	},
 	AD_TABLE_END_MARKER
 };
 

--- a/engines/myst3/detection.cpp
+++ b/engines/myst3/detection.cpp
@@ -179,6 +179,20 @@ static const Myst3GameDescription gameDescriptions[] = {
 		0
 	},
 
+	{
+		// Myst 3 PS2 Preview Build 6/02
+		{
+			"myst3",
+			_s("PS2 version is not yet supported"),
+			AD_ENTRY1s("RSRC.m3r", "1850580ada496acdc06b41f1d82b4ede", 331930989),
+			Common::UNK_LANG,
+			Common::kPlatformPS2,
+			ADGF_UNSUPPORTED,
+			GUIO_NONE
+		},
+		0
+	},
+
 	{ AD_TABLE_END_MARKER, 0 }
 };
 

--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -81,6 +81,17 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NONE)
 	},
 
+	// Neverhood lite English demo version
+	{
+		"neverhood",
+		"Demo",
+		AD_ENTRY1s("nevdemo.blb", "816741610771f6434a673b6821e88899", 11986100),
+		Common::EN_ANY,
+		Common::kPlatformWindows,
+		ADGF_DEMO | ADGF_DROPPLATFORM,
+		GUIO1(GUIO_NONE)
+	},
+
 	// Neverhood Russian version. Dyadyushka Risech
 	{
 		"neverhood",

--- a/engines/ngi/detection.cpp
+++ b/engines/ngi/detection.cpp
@@ -54,7 +54,7 @@ namespace NGI {
 
 static const NGIGameDescription gameDescriptions[] = {
 
-	// Full Pipe Russian version
+	// Magic Dream Russian version
 	{
 		{
 			"mdream",
@@ -142,7 +142,7 @@ static const NGIGameDescription gameDescriptions[] = {
 	{
 		{
 			"fullpipe",
-			0,
+			"Demo",
 			AD_ENTRY1s("4620.sc2", "a0c71b47fc35a5e163fcd8d0972639bb", 70),
 			Common::RU_RUS,
 			Common::kPlatformWindows,
@@ -152,11 +152,26 @@ static const NGIGameDescription gameDescriptions[] = {
 		GID_FULLPIPE
 	},
 
+	// Full Pipe Russian 1997 Demo version
+	// Contains General MIDI file
+	{
+		{
+			"fullpipe",
+			"Demo",
+			AD_ENTRY1s("0001.nl", "c19d5281671c8fe2584bd02209bc4a10", 8998307),
+			Common::RU_RUS,
+			Common::kPlatformWindows,
+			ADGF_DROPPLATFORM | ADGF_DEMO,
+			0
+		},
+		GID_FULLPIPE
+	},
+
 	// Full Pipe German Demo version
 	{
 		{
 			"fullpipe",
-			0,
+			"Demo",
 			AD_ENTRY1s("4620.sc2", "e5e98df537e56b39c33ae1d5c90976fe", 510),
 			Common::DE_DEU,
 			Common::kPlatformWindows,

--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -84,6 +84,25 @@ static const PegasusGameDescription gameDescriptions[] = {
 		},
 	},
 
+	// The Next Generation Disc #31 - July 1997
+	// Mac Addict #12 - August 1997
+	// Publisher is Bandai Digital Entertainment Corporation
+	// File modified date is Mar 29 1997 (v1.0)
+	{
+		{
+			"pegasus",
+			"v1.0 Demo",
+			AD_ENTRY1s("JMP PP Resources", "d13a602d2498010d720a6534f097f88b", 365585),
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_MACRESFORK | ADGF_DEMO,
+			GUIO2(GUIO_NOLAUNCHLOAD, GUIO_NOMIDI)
+		},
+	},
+
+	// Official distribution from Presto website
+	// http://thejourneymanproject.com/presto/journeymanprime/demos.html
+	// File modified date is date is Dec 15 2011
 	{
 		{
 			"pegasus",

--- a/engines/private/detection.cpp
+++ b/engines/private/detection.cpp
@@ -50,7 +50,7 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NOMIDI)
 	},
 	{
-		"private-eye", // Demo from the US release
+		"private-eye", // Demo from the US release v1.0.0.23
 		"Demo",
 		AD_ENTRY2s("pvteye.z", "af383c813157810e89d8d6d595895ff7", 263893,
 		   "bklynlgo.bmp", "1dfb703349a46f8ec183de107992b7f5", 33118),
@@ -80,19 +80,9 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NOMIDI)
 	},
 	{
-		"private-eye", // Demo from PCGamer Disc 2.6 JULY 1996
+		"private-eye", // Demo from PCGamer Disc 2.6 JULY 1996 v1.0.0.12
 		"Demo",
 		AD_ENTRY2s("pvteye.z", "8ef908e212bb9c1e10f5e3c81f56682c", 263893,
-		   "bklynlgo.bmp", "1dfb703349a46f8ec183de107992b7f5", 33118),
-		Common::EN_USA,
-		Common::kPlatformWindows,
-		ADGF_TESTING | ADGF_DEMO,
-		GUIO1(GUIO_NOMIDI)
-	},
-	{
-		"private-eye", // Another demo
-		"Demo",
-		AD_ENTRY2s("pvteye.z", "af383c813157810e89d8d6d595895ff7", 271214,
 		   "bklynlgo.bmp", "1dfb703349a46f8ec183de107992b7f5", 33118),
 		Common::EN_USA,
 		Common::kPlatformWindows,

--- a/engines/saga/detection_tables.h
+++ b/engines/saga/detection_tables.h
@@ -341,6 +341,33 @@ static const SAGAGameDescription gameDescriptions[] = {
 		NULL,
 	},
 
+	// Inherit the earth - MAC CD First edition
+	{
+		{
+			"ite",
+			"CD",
+			{
+				{"ite resources.bin",	GAME_RESOURCEFILE | GAME_MACBINARY,	"473768a17d843de5126d608b26ed7250", -1},
+				{"ite scripts.bin",		GAME_SCRIPTFILE | GAME_MACBINARY,	"294cad2d7bb6cd7dd602c9a5867873d7", -1},
+				{"ite sounds.bin",		GAME_SOUNDFILE | GAME_MACBINARY,	"178fa322aeb8eb51bba821eb128e037b", -1},
+				{"ite music.bin",		GAME_MUSICFILE_GM | GAME_MACBINARY,	"023fddf96a39edeaed647f16947de9c1", -1},
+				//{"ite voices.bin",		GAME_VOICEFILE | GAME_MACBINARY,	"dba92ae7d57e942250fe135609708369", -1},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_CD,
+			GUIO0()
+		},
+		GID_ITE,
+		GF_8BIT_UNSIGNED_PCM,
+		ITE_DEFAULT_SCENE,
+		&ITE_Resources,
+		ARRAYSIZE(ITEWINDEMO_GameFonts),
+		ITEWINDEMO_GameFonts,
+		NULL,
+	},
+
 	// Inherit the earth - MAC CD Wyrmkeep version
 	{
 		{
@@ -462,6 +489,7 @@ static const SAGAGameDescription gameDescriptions[] = {
 				// TODO: add size for ite.rsc
 				{"ite.rsc",						GAME_RESOURCEFILE,					"a6433e34b97b15e64fe8214651012db9", -1},
 				{"scripts.rsc",					GAME_SCRIPTFILE,					"a891405405edefc69c9d6c420c868b84", -1},
+				{"voices.rsc",					GAME_VOICEFILE,						"41bb6b95d792dde5196bdb78740895a6", -1},
 				AD_LISTEND
 			},
 			Common::IT_ITA,
@@ -614,7 +642,7 @@ static const SAGAGameDescription gameDescriptions[] = {
 			},
 			Common::EN_ANY,
 			Common::kPlatformWindows,
-			ADGF_CD | ADGF_UNSUPPORTED,
+			ADGF_CD | ADGF_DEMO | ADGF_UNSUPPORTED,
 			GUIO0()
 		},
 		GID_ITE,
@@ -624,6 +652,58 @@ static const SAGAGameDescription gameDescriptions[] = {
 		ARRAYSIZE(ITE_GameFonts),
 		ITE_GameFonts,
 		NULL,
+	},
+
+	// Inherit the earth - macOS Trial
+	// Linux trial version uses same resources a Wyrmkeep Multi-OS
+	{
+		{
+			"ite",
+			// I18N: Inherit the Earth had a "trial" version which is a full game with a simple check
+			_s("macOS Trial version is not supported"),
+			{
+				{"ite_i.rsc",		GAME_RESOURCEFILE,	"a6433e34b97b15e64fe8214651012db9", 8927169},
+				{"scripts_i.rsc",	GAME_SCRIPTFILE,	"bbf929f1e6d6f2af30c41d078798f5c1", 335927},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_CD | ADGF_DEMO | ADGF_UNSUPPORTED,
+			GUIO0()
+		},
+		GID_ITE,
+		0,
+		ITE_DEFAULT_SCENE,
+		&ITE_Resources,
+		ARRAYSIZE(ITE_GameFonts),
+		ITE_GameFonts,
+		NULL,
+	},
+
+	// Inherit the earth - Pocket PC Trial
+	{
+		{
+			"ite",
+			// I18N: Inherit the Earth had a "trial" version which is a full game with a simple check
+			_s("Pocket PC Trial version is not supported"),
+			{
+				{"ite.rsc",			GAME_RESOURCEFILE,	"a6433e34b97b15e64fe8214651012db9", 8927169},
+				{"scripts.rsc",		GAME_SCRIPTFILE,	"a891405405edefc69c9d6c420c868b84", 335927},
+				{"voicesv.rsc",		GAME_VOICEFILE,		"7e751eaab3b3127cec5a360e94cafd8b", 43744418},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformPocketPC,
+			ADGF_DEMO | ADGF_UNSUPPORTED,
+			GUIO0()
+		},
+		GID_ITE,
+		0,
+		ITE_DEFAULT_SCENE,
+		&ITE_Resources,
+		ARRAYSIZE(ITE_GameFonts),
+		ITE_GameFonts,
+		ITEPatch_Files,
 	},
 
 	// Inherit the Earth - Japanese PC-98 CD version

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -2496,6 +2496,150 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		AD_LISTEND},
 		Common::ES_ESP, Common::kPlatformDOS, ADGF_CD, GUIO_STD16_SPEECH	},
 
+#define GUIO_LIGHTHOUSE_DEMO GUIO6(GUIO_NOSPEECH, \
+								   GUIO_NOMUSIC, \
+								   GUIO_NOASPECT, \
+								   GUIO_NOMIDI, \
+								   GUIO_NOLAUNCHLOAD, \
+								   GAMEOPTION_HQ_VIDEO)
+#define GUIO_LIGHTHOUSE      GUIO8(GUIO_NOASPECT, \
+								   GUIO_NOMIDI, \
+								   GUIO_NOSUBTITLES, \
+								   GUIO_LINKMUSICTOSFX, \
+								   GUIO_LINKSPEECHTOSFX, \
+								   GAMEOPTION_ENABLE_BLACK_LINED_VIDEO, \
+								   GAMEOPTION_ORIGINAL_SAVELOAD, \
+								   GAMEOPTION_HQ_VIDEO)
+#define GUIO_LIGHTHOUSE_MAC  GUIO7(GUIO_NOASPECT, \
+								   GUIO_NOMIDI, \
+								   GUIO_NOSUBTITLES, \
+								   GUIO_LINKMUSICTOSFX, \
+								   GUIO_LINKSPEECHTOSFX, \
+								   GAMEOPTION_ENABLE_BLACK_LINED_VIDEO, \
+								   GAMEOPTION_HQ_VIDEO)
+
+	// Lighthouse - English Windows Demo (from jvprat)
+	// Executable scanning reports "2.100.002", VERSION file reports "1.00", plays 2.VMD
+	{"lighthouse", "Non-interactive Demo", {
+		{"resource.map", 0, "543124606352bfa5e07696ddf2a669be", 64},
+		{"resource.000", 0, "5d7714416b612463d750fb9c5690c859", 28952},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_LIGHTHOUSE_DEMO },
+
+	// Lighthouse - English Windows Demo (from trembyle)
+	// Found on CD-Action (Poland) #8a - Jan 1997
+	// Executable scanning reports "2.100.002", VERSION file reports "1.00", plays 3.VMD
+	{"lighthouse", "Non-interactive Demo", {
+		{"resource.map", 0, "999c2db3ca39c83c18ba6f16095b4c64", 64},
+		{"resource.000", 0, "bed2bafe872ffa1e7bfe6d706fac1c81", 28951},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_LIGHTHOUSE_DEMO },
+
+	// Lighthouse - English Windows Demo
+	// Executable scanning reports "3.000.000", VERSION file reports "1.00"
+	{"lighthouse", "Demo", {
+		{"resmap.000", 0, "3bdee7a16926975a4729f75cf6b80a92", 1525},
+		{"ressci.000", 0, "3c585827fa4a82f4c04a56a0bc52ccee", 11494351},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_LIGHTHOUSE_DEMO },
+
+	// Lighthouse - English Windows Glider Demo
+	// Executable scanning reports "3.000.000"
+	{"lighthouse", "Glider Demo", {
+		{"resmap.000", 0, "fca5bec5f778fc3f86d3176dc4ae6e54", 346},
+		{"ressci.000", 0, "896e81b6d70940c3b0696ef51cee51bc", 3300500},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_LIGHTHOUSE_DEMO },
+
+	// Lighthouse - English DOS (from jvprat)
+	// Executable scanning reports "3.000.000", VERSION file reports "1.1"
+	{"lighthouse", "", {
+		{"resmap.001", 0, "47abc502c0b541b582db28f38dbc6a56", 7801},
+		{"ressci.001", 0, "14e922c47b92156377cb49e241691792", 99591924},
+		{"resmap.002", 0, "c68db5333f152fea6ca2dfc75cad8b34", 7573},
+		{"ressci.002", 0, "175468431a979b9f317c294ce3bc1430", 94628315},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
+
+	// Lighthouse - Japanese DOS (from m_kiewitz)
+	// Executable scanning reports "3.000.000", VERSION file reports "1.0C"
+	{"lighthouse", "", {
+		{"resmap.001", 0, "18e0ac1597fe1cf6dc663118fe983e3b", 7885},
+		{"ressci.001", 0, "14e922c47b92156377cb49e241691792", 99573473},
+		{"resmap.002", 0, "723fc742c623d8933e5753a264324cb0", 7657},
+		{"ressci.002", 0, "175468431a979b9f317c294ce3bc1430", 94627469},
+		AD_LISTEND},
+		Common::JA_JPN, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
+
+	// Lighthouse - Spanish DOS (from jvprat)
+	// Executable scanning reports "3.000.000", VERSION file reports "1.1"
+	{"lighthouse", "", {
+		{"resmap.001", 0, "c5d49b2a8a4eafc92fd041a3a0f2da68", 7846},
+		{"ressci.001", 0, "18553177dbf83fb2cb6c8edcbb174183", 99543093},
+		{"resmap.002", 0, "e7dc85884a2417e2eff9de0c63dd65fa", 7630},
+		{"ressci.002", 0, "3c8d627c555b0e3e4f1d9955bc0f0df4", 94631127},
+		AD_LISTEND},
+		Common::ES_ESP, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
+
+	// Lighthouse - French DOS (from bgK)
+	// Executable scanning reports "3.000.000", VERSION file reports "1.1"
+	{"lighthouse", "", {
+		{"resmap.001", 0, "911c9cc5f49d4a96ff836154d3a86a8f", 7876},
+		{"ressci.001", 0, "dbb615146ec943e4ff7764a485c90511", 122516760},
+		{"resmap.002", 0, "703e7ab04bd358e76bc098995d71f36a", 7642},
+		{"ressci.002", 0, "6635764dc258b2041ca9a387e5aaab25", 115212682},
+		AD_LISTEND},
+		Common::FR_FRA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
+
+	// Lighthouse - German DOS (from bug #10359)
+	{"lighthouse", "", {
+		{"resmap.001", 0, "d2dc13bb936d6528a19feac92fc7df1c", 7852},
+		{"ressci.001", 0, "dbb615146ec943e4ff7764a485c90511", 122330257},
+		{"resmap.002", 0, "8fdb8544d801057d3123539d8e6d039a", 7618},
+		{"ressci.002", 0, "6635764dc258b2041ca9a387e5aaab25", 115026179},
+		AD_LISTEND},
+		Common::DE_DEU, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
+
+	// Lighthouse - French DOS
+	// VERSION file reports "1.0c"
+	{"lighthouse", "", {
+		{"resmap.001", 0, "7f768cb4ee53026ea8fc662e44e7c0de", 7870},
+		{"ressci.001", 0, "dbb615146ec943e4ff7764a485c90511", 122184234},
+		{"resmap.002", 0, "3fa427abab4c1d7bbea3033c064fc182", 7636},
+		{"ressci.002", 0, "6635764dc258b2041ca9a387e5aaab25", 114880156},
+		AD_LISTEND},
+		Common::FR_FRA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
+
+	// Lighthouse - Italian DOS
+	// VERSION file reports "1.0"
+	{"lighthouse", "", {
+		{"resmap.001", 0, "4e07734dcfdb593f755a05dc43ca4532", 7846},
+		{"ressci.001", 0, "dbb615146ec943e4ff7764a485c90511", 121894854},
+		{"resmap.002", 0, "012a93dc0612f62142afabb673b157aa", 7612},
+		{"ressci.002", 0, "6635764dc258b2041ca9a387e5aaab25", 114590776},
+		AD_LISTEND},
+		Common::IT_ITA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
+
+	// Lighthouse - English Macintosh CD
+	// NOTE: This only contains disc 1 files
+	{ "lighthouse", "", {
+		 {"Data1", 0, "9fd95df4288bcc5f07b114bbeabaa89a", 7498955},
+		 {"Data2", 0, "97a5c80a12eee099349748a72b9f561a", 11278999},
+		 {"Data3", 0, "51085a80ec0f448938d279dc3464e1b1", 8295799},
+		 {"Data4", 0, "8c01d5243c62868207c144125de46c5a", 9132628},
+		 {"Data5", 0, "6830ea75c4459533ba6c11a09a886a8a", 9096667},
+		 {"Data6", 0, "b7b207a5d9faa1192aa566d484ffdde6", 9294588},
+		 {"Data7", 0, "87156321c318e6b61c84d7600f5cd28a", 1690205},
+		 {"Data8", 0, "c486982e4169eb42096029ee1635b2ae", 7515248},
+		 {"Data9", 0, "e5f5ad0cab47eb4b2240e3843ed5fe3c", 9833960},
+		 {"Data10", 0, "9fd95df4288bcc5f07b114bbeabaa89a", 5298538},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK | ADGF_UNSTABLE, GUIO_LIGHTHOUSE_MAC },
+
+#undef GUIO_LIGHTHOUSE_DEMO
+#undef GUIO_LIGHTHOUSE
+#undef GUIO_LIGHTHOUSE_MAC
+
 	// Larry 1 EGA Remake - English DOS (from spookypeanut)
 	// SCI interpreter version 0.000.510 (or 0.000.577?)
 	{"lsl1sci", "SCI/EGA", {
@@ -3299,141 +3443,6 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 #undef GUIO_LSL7_DEMO
 #undef GUIO_LSL7
 
-#define GUIO_LIGHTHOUSE_DEMO GUIO6(GUIO_NOSPEECH, \
-								   GUIO_NOMUSIC, \
-								   GUIO_NOASPECT, \
-								   GUIO_NOMIDI, \
-								   GUIO_NOLAUNCHLOAD, \
-								   GAMEOPTION_HQ_VIDEO)
-#define GUIO_LIGHTHOUSE      GUIO8(GUIO_NOASPECT, \
-								   GUIO_NOMIDI, \
-								   GUIO_NOSUBTITLES, \
-								   GUIO_LINKMUSICTOSFX, \
-								   GUIO_LINKSPEECHTOSFX, \
-								   GAMEOPTION_ENABLE_BLACK_LINED_VIDEO, \
-								   GAMEOPTION_ORIGINAL_SAVELOAD, \
-								   GAMEOPTION_HQ_VIDEO)
-#define GUIO_LIGHTHOUSE_MAC  GUIO7(GUIO_NOASPECT, \
-								   GUIO_NOMIDI, \
-								   GUIO_NOSUBTITLES, \
-								   GUIO_LINKMUSICTOSFX, \
-								   GUIO_LINKSPEECHTOSFX, \
-								   GAMEOPTION_ENABLE_BLACK_LINED_VIDEO, \
-								   GAMEOPTION_HQ_VIDEO)
-
-	// Lighthouse - English Windows Demo (from jvprat)
-	// Executable scanning reports "2.100.002", VERSION file reports "1.00"
-	{"lighthouse", "Non-interactive Demo", {
-		{"resource.map", 0, "543124606352bfa5e07696ddf2a669be", 64},
-		{"resource.000", 0, "5d7714416b612463d750fb9c5690c859", 28952},
-		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_LIGHTHOUSE_DEMO },
-
-	// Lighthouse - English Windows Demo
-	// Executable scanning reports "3.000.000", VERSION file reports "1.00"
-	{"lighthouse", "Demo", {
-		{"resmap.000", 0, "3bdee7a16926975a4729f75cf6b80a92", 1525},
-		{"ressci.000", 0, "3c585827fa4a82f4c04a56a0bc52ccee", 11494351},
-		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_LIGHTHOUSE_DEMO },
-
-	// Lighthouse - English Windows Glider Demo
-	// Executable scanning reports "3.000.000"
-	{"lighthouse", "Glider Demo", {
-		{"resmap.000", 0, "fca5bec5f778fc3f86d3176dc4ae6e54", 346},
-		{"ressci.000", 0, "896e81b6d70940c3b0696ef51cee51bc", 3300500},
-		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_LIGHTHOUSE_DEMO },
-
-	// Lighthouse - English DOS (from jvprat)
-	// Executable scanning reports "3.000.000", VERSION file reports "1.1"
-	{"lighthouse", "", {
-		{"resmap.001", 0, "47abc502c0b541b582db28f38dbc6a56", 7801},
-		{"ressci.001", 0, "14e922c47b92156377cb49e241691792", 99591924},
-		{"resmap.002", 0, "c68db5333f152fea6ca2dfc75cad8b34", 7573},
-		{"ressci.002", 0, "175468431a979b9f317c294ce3bc1430", 94628315},
-		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
-
-	// Lighthouse - Japanese DOS (from m_kiewitz)
-	// Executable scanning reports "3.000.000", VERSION file reports "1.0C"
-	{"lighthouse", "", {
-		{"resmap.001", 0, "18e0ac1597fe1cf6dc663118fe983e3b", 7885},
-		{"ressci.001", 0, "14e922c47b92156377cb49e241691792", 99573473},
-		{"resmap.002", 0, "723fc742c623d8933e5753a264324cb0", 7657},
-		{"ressci.002", 0, "175468431a979b9f317c294ce3bc1430", 94627469},
-		AD_LISTEND},
-		Common::JA_JPN, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
-
-	// Lighthouse - Spanish DOS (from jvprat)
-	// Executable scanning reports "3.000.000", VERSION file reports "1.1"
-	{"lighthouse", "", {
-		{"resmap.001", 0, "c5d49b2a8a4eafc92fd041a3a0f2da68", 7846},
-		{"ressci.001", 0, "18553177dbf83fb2cb6c8edcbb174183", 99543093},
-		{"resmap.002", 0, "e7dc85884a2417e2eff9de0c63dd65fa", 7630},
-		{"ressci.002", 0, "3c8d627c555b0e3e4f1d9955bc0f0df4", 94631127},
-		AD_LISTEND},
-		Common::ES_ESP, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
-
-	// Lighthouse - French DOS (from bgK)
-	// Executable scanning reports "3.000.000", VERSION file reports "1.1"
-	{"lighthouse", "", {
-		{"resmap.001", 0, "911c9cc5f49d4a96ff836154d3a86a8f", 7876},
-		{"ressci.001", 0, "dbb615146ec943e4ff7764a485c90511", 122516760},
-		{"resmap.002", 0, "703e7ab04bd358e76bc098995d71f36a", 7642},
-		{"ressci.002", 0, "6635764dc258b2041ca9a387e5aaab25", 115212682},
-		AD_LISTEND},
-		Common::FR_FRA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
-
-	// Lighthouse - German DOS (from bug #10359)
-	{"lighthouse", "", {
-		{"resmap.001", 0, "d2dc13bb936d6528a19feac92fc7df1c", 7852},
-		{"ressci.001", 0, "dbb615146ec943e4ff7764a485c90511", 122330257},
-		{"resmap.002", 0, "8fdb8544d801057d3123539d8e6d039a", 7618},
-		{"ressci.002", 0, "6635764dc258b2041ca9a387e5aaab25", 115026179},
-		AD_LISTEND},
-		Common::DE_DEU, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
-
-	// Lighthouse - French DOS
-	// VERSION file reports "1.0c"
-	{"lighthouse", "", {
-		{"resmap.001", 0, "7f768cb4ee53026ea8fc662e44e7c0de", 7870},
-		{"ressci.001", 0, "dbb615146ec943e4ff7764a485c90511", 122184234},
-		{"resmap.002", 0, "3fa427abab4c1d7bbea3033c064fc182", 7636},
-		{"ressci.002", 0, "6635764dc258b2041ca9a387e5aaab25", 114880156},
-		AD_LISTEND},
-		Common::FR_FRA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
-
-	// Lighthouse - Italian DOS
-	// VERSION file reports "1.0"
-	{"lighthouse", "", {
-		{"resmap.001", 0, "4e07734dcfdb593f755a05dc43ca4532", 7846},
-		{"ressci.001", 0, "dbb615146ec943e4ff7764a485c90511", 121894854},
-		{"resmap.002", 0, "012a93dc0612f62142afabb673b157aa", 7612},
-		{"ressci.002", 0, "6635764dc258b2041ca9a387e5aaab25", 114590776},
-		AD_LISTEND},
-		Common::IT_ITA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_LIGHTHOUSE },
-
-	// Lighthouse - English Macintosh CD
-	// NOTE: This only contains disc 1 files
-	{ "lighthouse", "", {
-		 {"Data1", 0, "9fd95df4288bcc5f07b114bbeabaa89a", 7498955},
-		 {"Data2", 0, "97a5c80a12eee099349748a72b9f561a", 11278999},
-		 {"Data3", 0, "51085a80ec0f448938d279dc3464e1b1", 8295799},
-		 {"Data4", 0, "8c01d5243c62868207c144125de46c5a", 9132628},
-		 {"Data5", 0, "6830ea75c4459533ba6c11a09a886a8a", 9096667},
-		 {"Data6", 0, "b7b207a5d9faa1192aa566d484ffdde6", 9294588},
-		 {"Data7", 0, "87156321c318e6b61c84d7600f5cd28a", 1690205},
-		 {"Data8", 0, "c486982e4169eb42096029ee1635b2ae", 7515248},
-		 {"Data9", 0, "e5f5ad0cab47eb4b2240e3843ed5fe3c", 9833960},
-		 {"Data10", 0, "9fd95df4288bcc5f07b114bbeabaa89a", 5298538},
-		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK | ADGF_UNSTABLE, GUIO_LIGHTHOUSE_MAC },
-
-#undef GUIO_LIGHTHOUSE_DEMO
-#undef GUIO_LIGHTHOUSE
-#undef GUIO_LIGHTHOUSE_MAC
-
 	// Mixed-Up Fairy Tales v1.000 - English DOS Non-Interactive Demo
 	{"fairytales", "Demo", {
 		{"resource.map", 0, "c2cf672c3f4251e7472d4542af3bf764", 933},
@@ -3722,8 +3731,16 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		AD_LISTEND},
 		Common::IT_ITA, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_PHANTASMAGORIA },
 
+	// Phantasmagoria - English DOS Demo (from trembyle)
+	// Executable scanning reports "2.100.002", VERSION file reports "1.000.000"
+	{"phantasmagoria", "Demo", {
+		{"resmap.001", 0, "43c395f312a190e67b90b2c1e93a79e2", 11518},
+		{"ressci.001", 0, "3aae6559aa1df273bc542d5ac6330d75", 65844612},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_PHANTASMAGORIA_DEMO },
+
 	// Phantasmagoria - English DOS Demo
-	// Executable scanning reports "2.100.002"
+	// Executable scanning reports "2.100.002", VERSION file reports "1.100.000"
 	{"phantasmagoria", "Demo", {
 		{"resmap.001", 0, "416138651ea828219ca454cae18341a3", 11518},
 		{"ressci.001", 0, "3aae6559aa1df273bc542d5ac6330d75", 65844612},
@@ -4864,6 +4881,14 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		AD_LISTEND},
 		Common::EN_ANY, Common::kPlatformWindows, ADGF_DEMO | ADGF_DROPPLATFORM, GUIO_SHIVERS },
 
+	// Shivers - English Windows CD Demo (from Metro Games Sierra CD Sampler)
+	// Executable scanning reports "2.100.002"
+	{"shivers", "CD Demo", {
+		{"resmap.000", 0, "0b0e89db3ca62e537922d2f38cce78c7", 30907},
+		{"ressci.000", 0, "4606f32e83c301a4e90ca5e5d2d85a70", 78611217},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformWindows, ADGF_DEMO | ADGF_DROPPLATFORM, GUIO_SHIVERS },
+
 	// Shivers - English Macintosh CD
 	{"shivers", "", {
 		{"Data1", 0, "7154f2fc5466f0cd6923deb1a6f6729a", 4635483},
@@ -5612,21 +5637,30 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		AD_LISTEND},
 		Common::DE_DEU, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_SQ6 },
 
-	// Space Quest 6 - English DOS/Win3.11 Interactive Demo (from FRG)
-	// SCI interpreter version 2.100.002 (just a guess)
+	// Space Quest 6 - English Win3.11 Demo (from Sneak Peeks 2)
+	// Executable scanning reports "2.100.002", VERSION file reports "1.000.000"
+	{"sq6", "Demo", {
+		{"resource.map", 0, "5cf3f0db76080a4ac327190bd027e355", 2164},
+		{"resource.000", 0, "ab12724e078dea34b624e0d2a38dcd7c", 2159708},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformWindows, ADGF_DEMO, GUIO_SQ6_DEMO },
+
+	// Space Quest 6 - English Win3.1 Demo (from trembyle)
+	// Found on Interactive Entertainment Episode 10 - Feb 1995
+	// Executable scanning reports "2.100.002"
+	{"sq6", "Demo", {
+		{"resource.map", 0, "fe5759d4d87785210806431338815f76", 1852},
+		{"resource.000", 0, "a199ee68c0a1d1ea878137084e76301d", 8200543},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformWindows, ADGF_DEMO, GUIO_SQ6_DEMO },
+
+	// Space Quest 6 - English DOS/Win3.11 Interactive Demo (from FRG, from Phantasmagoria US)
+	// SCI interpreter version 2.100.002
 	{"sq6", "Demo", {
 		{"resource.map", 0, "368f07b07433db3f819fa3fa0e5efee5", 2572},
 		{"resource.000", 0, "ab12724e078dea34b624e0d2a38dcd7c", 2272050},
 		AD_LISTEND},
 		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_SQ6_DEMO },
-
-	// Space Quest 6 - English Win3.11 Demo (from Sneak Peeks 2 CD)
-	// Executable scanning reports "2.100.002", VERSION file reports "1.000.000"
-	{"sq6", "", {
-		{"resource.map", 0, "5cf3f0db76080a4ac327190bd027e355", 2164},
-		{"resource.000", 0, "ab12724e078dea34b624e0d2a38dcd7c", 2159708},
-		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformWindows, ADGF_DEMO, GUIO_SQ6_DEMO },
 
 	// Space Quest 6 - English Macintosh CD
 	// VERSION file reports "1.000"

--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -189,6 +189,20 @@ static const StarTrekGameDescription gameDescriptions[] = {
 		GF_DEMO,
 	},
 
+	{ // ST25 MAC demo (EN)
+		{
+			"st25",
+			"Demo",
+			AD_ENTRY1("Star Trek Data", "871fa51c7680c0a43df9622128f1569f"),
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_MACRESFORK | ADGF_DEMO | ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GType_ST25,
+		GF_DEMO,
+	},
+
 	// These are commented until future notice because I don't have complete information
 	// on them (the file size for data.000 / data.001). Will be relying on people to
 	// report the missing data.
@@ -257,20 +271,6 @@ static const StarTrekGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO0()
-		},
-		GType_ST25,
-		GF_DEMO,
-	},
-
-	{ // ST25 MAC demo ? (EN)
-		{
-			"st25",
-			"Demo",
-			AD_ENTRY1("Star Trek Data", "88f88b81d389a3217fc7efd6ee631c42"),
-			Common::EN_ANY,
-			Common::kPlatformMacintosh,
-			ADGF_MACRESFORK | ADGF_DEMO | ADGF_UNSTABLE,
 			GUIO0()
 		},
 		GType_ST25,


### PR DESCRIPTION
I'm going through the engines to find demos that are in detection tables but missing from the site. In the process I keep finding brand new demos. As I find them, I'm uploading to them to scummvm. @sev- will move them to frs so that they can go on the site.

Moving alphabetically through the engines, I'm now finished with GOB. I would expect to find more by the time I get to ZVISION. Since the individual engine developers likely want to weigh in on changes, it can't hurt to get an early start on reviewing them.

Some options:
1. Shelve this for now until I have all the changes for one big PR
2. Review changes to individual engines as I add them, but don't merge until all are ready
3. Split this PR (or merge what's here), and I'll submit new ones as I have changes

## Notes on individual engines
### **ASYLUM**
Nothing really to report on this one. Asylum is being actively developed. Maybe @alxpnv will get a chance to look into support at some point.
### **BURIED**
It's only a regional variant of other known demos. Should run fine.
### **CGE**
The Sołtys and Sfinx demos both start and can probably be supported.
### **CHEWY**
We didn't have any demos for this before. This one manages to load the opening screen then crashes within two seconds.
### **OMNI3D**
Uses the same engine but has only one data file, which the engine isn't looking for. Does not start.
### **DM**
Found an Apple IIgs demo. That platform isn't currently supported by the engine, so this won't really help unless development picks up again.
### **DREAMWEB**
The two DOS demos have resource files in the same format, but the files are named differently. I'm hopeful that these can be supported. And I found an Amiga demo that's not going to be supported unless someone new looks at the engine.
### **GOB**
A new Ween demo variant and a new non-interactive Last Dynasty demo work fine right now.

I also found a _combined_ demo for Dynasty/Woodruff. It really just plays the VMDs for the two games in sequence. Just like indyloom, indyzak, zakloom, I guess we could give this a new game ID. It seems to work, although the Woodruff portion may have some issues. I gave the new game the same engine parameters as used for Dynasty, but Woodruff's are slightly different.
### **GRIME**
Found an official Monkey4 CD demo. Someone just uploaded it to IA. This one does not include `i9n.lab`, which had been used for detection. I changed the file for this and disabled the check for it at first runtime. I hope that's ok. It seems to run as well as the other demos.
### **GROOVIE**
Six new demos are added to detection. Since there is some new development activity in this engine, hopefully this will give some nice new Groovie v2 examples, plus the one potential Groovie v0 demo.
### **HYPNO**
Just a note about this - I know it's not an engine that's merged yet - but I did work with @neuromancer to find three new Wetlands demos in addition to the one that he's already working to support. We have detection for these now for whenever or if ever the engine is merged to master.
### **KYRA**
There is a non-interactive EOB2 "demo" that simply plays through some FLICs and static GIFs using Autodesk Animator player. I left a message telling users that it is unsupported. If someone really wanted to, it would not be difficult to add support for this.
### **LILLIPUT**
There is a Rome demo. There is a game ID for this one in the detection table, although there are no detection entries for the game itself. I added the demo anyway just so we have it.
### **LURE**
The only demo that I can find is from the cover disk of ST Action (UK) Issue 50. The Atari ST platform is not supported at the moment. If someday it was supported, this disk has some copy protection that I haven't figured out. Either the images will need to be accessed directly, or we'll need to find a way to extract the files.

https://archive.org/details/ST_Action_UK_Magazine_Coverdisk_Disk_Image
### **MACVENTURE**
Added an Uninvited demo. All of the MacVenture games are now in the detection table. This appears to be MacVenture v2 based on the FourCC creator code `MCV2`.

I also have a demo for the Windows port of Shadowgate. Are ports being considered for inclusion once the original MacVenture games are running?
### **MADE**
The [user reported](https://bugs.scummvm.org/ticket/11202) demo from Zork Anthology CD also contains a Mac version. There's also a new standalone CD demo. I'm fairly certain that there was a Japanese CD demo as well. I've been looking for that a long time and haven't found it yet.
### **MADS**
In this case, there were Rex and Phantom demos on the site but they were not in the detection tables. I wasn't able to test adding a directory with the Phantom demo because I can't get MADSv2 to compile. This was split into a subengine earlier this year. Since it's in master, shouldn't it at least compile without error?
### **MOHAWK**
I'm slightly shocked that after all these years another Myst demo has been found. This one includes The Making of Myst (see screenshot). Unfortunately the movie is not playing for me. Hopefully it's an easy fix.
### **MUTATIONOFJB**
Floppy demo from Riki Magazine does not start as it's looking for some engine files that aren't used in the demo. I'm not sure how much effort it would take to get these running.
### **SPRINT**
Not really a demo (and it can't be distributed) but we can sneak in detection for a Myst3 prototype DVD for the Playstation2. As with the full versions, this is marked as not yet supported.
### **NEVERHOOD**
Lite demo is found here:
https://archive.org/details/Neverhood
### **NGI**
This early demo is from 1997, a full 6 years before the game released in Russia. Some work may be needed to get it running. For one thing, it appears to use general MIDI.
### **PEGASUS**
Demos were found in Mac Addict and the Next Generation Disc. At the time, the game was to be published by Bandai and the demo retains some of their branding on the splash screen and in the credits. The `VERS` resource in the executable says this is `DEMO-1.0`.
### **PRIVATE**
Already discussed this with @neuromancer. There is version info in the extended file attributes. We can use this to differentiate the demos while still noting where they were originally distributed.
### **SAGA**
The Pocket PC trial version is interesting to me. It uses TiMidity with a directory of standard MIDI files and a directory of patch files (in a different format than the Mac instrument patches). The wayback machine is missing the package unfortunately, but originally it was here: [http://www.wyrmkeep.com/ite/mobile.html](https://web.archive.org/web/20080207033701/http://www.wyrmkeep.com/ite/mobile.html)

As mentioned in comments in the detection tables, the trial versions contain the full game, along with a simple check for the registration code. Understandably, we cannot support a method to bypass legally purchasing the game. What I don't understand is why this check can't simply be reimplemented in ScummVM.
### **STARTREK**
It's a Mac demo, and that platform isn't supported yet. Maybe @bluegr would want to look at it once the DOS version is ready to go.

---
More to come ...