### PR TITLE
BURIED: Clear the live text window when moving, as advertised (bug 12887)

### DIFF
--- a/engines/buried/scene_view.cpp
+++ b/engines/buried/scene_view.cpp
@@ -554,13 +554,13 @@ bool SceneViewWindow::moveToDestination(const DestinationScene &destinationData)
 			newSceneStaticData.location.environment != oldLocation.environment ||
 			newSceneStaticData.location.node != oldLocation.node) {
 		((GameUIWindow *)_parent)->_bioChipRightWindow->disableEvidenceCapture();
-		((GameUIWindow *)_parent)->_navArrowWindow->enableWindow(false);
+		((GameUIWindow *)_parent)->_liveTextWindow->updateLiveText();
 	}
 
 	// Disable the arrow window
 	((GameUIWindow *)_parent)->_navArrowWindow->enableWindow(false);
 
-	// Get thr esults from the pre-exit room function
+	// Get the results from the pre-exit room function
 	int retVal = _currentScene->preExitRoom(this, destinationData.destinationScene);
 
 	// If we died, return here


### PR DESCRIPTION
The comment says it will clear the live text window, but instead disabled the navigation arrows (I think), which it then does again right aftewards. A cut and paste error, perhaps? Anyway, I hope this produces the correct behavior as described in https://bugs.scummvm.org/ticket/12887

I also noticed that there are a number of updateLiveText("") calls (to clear the text), even though an empty string is the default value for it. But I didn't bother cleaning that up.
