### PR TITLE
COMMON: avoid bad rng seeds

### DIFF
--- a/common/random.cpp
+++ b/common/random.cpp
@@ -26,7 +26,6 @@
 #include "common/system.h"
 #include "gui/EventRecorder.h"
 
-
 namespace Common {
 
 RandomSource::RandomSource(const String &name) {
@@ -43,6 +42,8 @@ RandomSource::RandomSource(const String &name) {
 	newSeed += time.tm_mday * 86400 + time.tm_mon * 86400 * 31;
 	newSeed += time.tm_year * 86400 * 366;
 	newSeed = newSeed * 1000 + g_system->getMillis();
+	// some seeds result in loops
+	newSeed %= 100000000;
 	setSeed(newSeed);
 #endif
 }


### PR DESCRIPTION
RandomSource has some seeds that produce short loops

<details>
<summary>I wrote a test for this</summary>

```

#include <iostream>
#include <thread>
#include <vector>
#include <mutex>

std::mutex mtx;
typedef unsigned int uint32;

uint32 rng(uint32 _randSeed) {
	_randSeed = 0xDEADBF03 * (_randSeed + 1);
	_randSeed = (_randSeed >> 13) | (_randSeed << 19);
	return _randSeed;
}

int test_seed(uint32 orig_seed) {
	uint32 s = orig_seed;
	uint32 prev = s;
	for (int i = 0; i < 50; i++) {
		s = rng(s);
		if (s == orig_seed) return i+1;
		if (s == prev) return i + 1;
		prev = s;
	}
	return -1;
}

void test_seeds(uint32 first, uint32 last) {
	for (uint32 s = first; ; s++) {
		int loops = test_seed(s);
		if (loops != -1) {
			std::lock_guard<std::mutex> lck(mtx);
			std::cout << s << " failed with " << loops << " iterations\n";
		}
		if (s == last) break;
	}
}

void test_rng() {
	std::vector<std::thread> threads;
	uint32 start = 0;
	int num_threads = 12;
	uint32 max = UINT_MAX;
	//uint32 max = 100000000;
	uint32 each = max / num_threads;
	for (int i = 0; i < num_threads-1; i++) {
		threads.push_back(std::thread(test_seeds, start, start +each));
		start += each + 1;
	}
	threads.push_back(std::thread(test_seeds, start, max));

	for (uint32 i = 0; i < threads.size(); i++) {
		threads[i].join();
	}
}

int main()
{
	std::cout << "start!\n\n";
	test_rng();
}

```

</details>

<details>
<summary>which produced this output</summary>

```

1800586416 failed with 48 iterations
1087576404 failed with 48 iterations
3593762925 failed with 11 iterations
730316237 failed with 48 iterations
2527622093 failed with 48 iterations
3969000752 failed with 48 iterations
3997635582 failed with 48 iterations
782266141 failed with 48 iterations
2923531432 failed with 48 iterations
3285614266 failed with 48 iterations
790957358 failed with 48 iterations
2228155406 failed with 11 iterations
2934411674 failed with 48 iterations
3295602753 failed with 48 iterations
3662902891 failed with 11 iterations
450572919 failed with 48 iterations
2598359503 failed with 48 iterations
3675745779 failed with 48 iterations
3314127686 failed with 48 iterations
1183117626 failed with 48 iterations
1184201285 failed with 1 iterations
1532332879 failed with 48 iterations
2985431791 failed with 48 iterations
3728428744 failed with 48 iterations
3732357426 failed with 11 iterations
4103830679 failed with 48 iterations
159978368 failed with 48 iterations
1960730702 failed with 48 iterations
888568342 failed with 48 iterations
535309383 failed with 11 iterations
895276097 failed with 11 iterations
1612982501 failed with 48 iterations
3056724351 failed with 48 iterations
3424350891 failed with 48 iterations
3086530181 failed with 48 iterations
3825293921 failed with 48 iterations
3463439511 failed with 48 iterations
1326826220 failed with 48 iterations
3465351362 failed with 48 iterations
2406416072 failed with 48 iterations
2407747594 failed with 48 iterations
2051590013 failed with 48 iterations
3122928263 failed with 11 iterations
3123690540 failed with 48 iterations
2777780976 failed with 48 iterations
2060636277 failed with 48 iterations
4215288456 failed with 48 iterations
3871845201 failed with 11 iterations
1010819822 failed with 48 iterations
1019732222 failed with 11 iterations
3889985373 failed with 48 iterations
3890987163 failed with 48 iterations
3893166069 failed with 48 iterations
3902497450 failed with 48 iterations
688539017 failed with 48 iterations
1050591644 failed with 48 iterations
1052334923 failed with 48 iterations
1765143913 failed with 48 iterations
1768895800 failed with 11 iterations
2142534809 failed with 11 iterations

```

</details>

We might also want to switch to a more robust rng function. @TehGelly made pull request #3341 which replaces the rng function, we don't need both of these so I'll let you guys pick.