### PR TITLE
COMMON: Change PRNG Function to Xorshift

### DIFF
--- a/common/random.cpp
+++ b/common/random.cpp
@@ -73,7 +73,7 @@ int RandomSource::getRandomNumberRngSigned(int min, int max) {
 	return getRandomNumber(max - min) + min;
 }
 		
-private inline void RandomSource::scrambleSeed() {
+inline void RandomSource::scrambleSeed() {
 	//marsaglia's paper says that any of 81 triplets are feasible
 	//(11,21,13) was chosen, with (cba) and (>>,<<,>>)
 	_randSeed ^= _randSeed >> 13;

--- a/common/random.cpp
+++ b/common/random.cpp
@@ -48,7 +48,7 @@ RandomSource::RandomSource(const String &name) {
 }
 
 void RandomSource::setSeed(uint32 seed) {
-	if(seed == 0)
+	if (seed == 0)
 		seed++;
 	_randSeed = seed;
 }

--- a/common/random.cpp
+++ b/common/random.cpp
@@ -52,20 +52,12 @@ void RandomSource::setSeed(uint32 seed) {
 		seed++;
 	_randSeed = seed;
 }
-	
-inline void RandomSource::scrambleSeed() {
-	//marsaglia's paper says that any of 81 triplets are feasible
-	//(11,21,13) was chosen, with (cba) and (>>,<<,>>)
-	_randSeed ^= _randSeed >> 13;
-	_randSeed ^= _randSeed << 21;
-	_randSeed ^= _randSeed >> 11;
-}
 
 uint RandomSource::getRandomNumber(uint max) {
 	scrambleSeed();
 	if (max == UINT_MAX)
 		return _randSeed;
-	return _randSeed % (max + 1);
+	return (_randSeed * 0xDEADBF03) % (max + 1);
 }
 
 uint RandomSource::getRandomBit() {
@@ -79,6 +71,14 @@ uint RandomSource::getRandomNumberRng(uint min, uint max) {
 
 int RandomSource::getRandomNumberRngSigned(int min, int max) {
 	return getRandomNumber(max - min) + min;
+}
+		
+private inline void RandomSource::scrambleSeed() {
+	//marsaglia's paper says that any of 81 triplets are feasible
+	//(11,21,13) was chosen, with (cba) and (>>,<<,>>)
+	_randSeed ^= _randSeed >> 13;
+	_randSeed ^= _randSeed << 21;
+	_randSeed ^= _randSeed >> 11;
 }
 
 } // End of namespace Common

--- a/common/random.cpp
+++ b/common/random.cpp
@@ -56,7 +56,7 @@ void RandomSource::setSeed(uint32 seed) {
 uint RandomSource::getRandomNumber(uint max) {
 	scrambleSeed();
 	if (max == UINT_MAX)
-		return _randSeed;
+		return (_randSeed * 0xDEADBF03);
 	return (_randSeed * 0xDEADBF03) % (max + 1);
 }
 

--- a/common/random.cpp
+++ b/common/random.cpp
@@ -43,13 +43,13 @@ RandomSource::RandomSource(const String &name) {
 	newSeed += time.tm_mday * 86400 + time.tm_mon * 86400 * 31;
 	newSeed += time.tm_year * 86400 * 366;
 	newSeed = newSeed * 1000 + g_system->getMillis();
-	if(newSeed == 0)
-		newSeed++;
 	setSeed(newSeed);
 #endif
 }
 
 void RandomSource::setSeed(uint32 seed) {
+	if(seed == 0)
+		seed++;
 	_randSeed = seed;
 }
 	

--- a/common/random.cpp
+++ b/common/random.cpp
@@ -43,6 +43,8 @@ RandomSource::RandomSource(const String &name) {
 	newSeed += time.tm_mday * 86400 + time.tm_mon * 86400 * 31;
 	newSeed += time.tm_year * 86400 * 366;
 	newSeed = newSeed * 1000 + g_system->getMillis();
+	if(newSeed == 0)
+		newSeed++;
 	setSeed(newSeed);
 #endif
 }
@@ -50,19 +52,24 @@ RandomSource::RandomSource(const String &name) {
 void RandomSource::setSeed(uint32 seed) {
 	_randSeed = seed;
 }
+	
+inline void RandomSource::scrambleSeed() {
+	//marsaglia's paper says that any of 81 triplets are feasible
+	//(11,21,13) was chosen, with (cba) and (>>,<<,>>)
+	_randSeed ^= _randSeed >> 13;
+	_randSeed ^= _randSeed << 21;
+	_randSeed ^= _randSeed >> 11;
+}
 
 uint RandomSource::getRandomNumber(uint max) {
-	_randSeed = 0xDEADBF03 * (_randSeed + 1);
-	_randSeed = (_randSeed >> 13) | (_randSeed << 19);
-
+	scrambleSeed();
 	if (max == UINT_MAX)
 		return _randSeed;
 	return _randSeed % (max + 1);
 }
 
 uint RandomSource::getRandomBit() {
-	_randSeed = 0xDEADBF03 * (_randSeed + 1);
-	_randSeed = (_randSeed >> 13) | (_randSeed << 19);
+	scrambleSeed();
 	return _randSeed & 1;
 }
 

--- a/common/random.h
+++ b/common/random.h
@@ -39,8 +39,8 @@ namespace Common {
 class String;
 
 /**
- * Xorshift PRNG. Replaces the previous PRNG, as
- * the cycles within it were detrimental to gameplay.
+ * Xorshift* random number generator. Although it is definitely not suitable for
+ * cryptographic purposes, it serves our purposes just fine.
  */
 class RandomSource {
 private:
@@ -60,13 +60,6 @@ public:
 	uint32 getSeed() const { /*!< Get a random seed that can be used to initialize the RNG. */
 		return _randSeed;
 	}
-	
-	/**
-	* Scrambles the seed in order to get a new result.
-	* Code is shared between getRandomNumber and getRandomBit,
-	* so it is split off for clarity.
-	*/
-	inline void scrambleSeed();
 
 	/**
 	 * Generate a random unsigned integer in the interval [0, max].
@@ -97,6 +90,13 @@ public:
 	 * @return	a random number in the interval [min, max]
 	 */
 	int getRandomNumberRngSigned(int min, int max);
+	
+	/**
+	* Scrambles the seed in order to get a new result.
+	* Code is shared between getRandomNumber and getRandomBit,
+	* so it is split off for clarity.
+	*/
+	private inline void scrambleSeed();
 };
 
 /** @} */

--- a/common/random.h
+++ b/common/random.h
@@ -96,7 +96,8 @@ public:
 	* Code is shared between getRandomNumber and getRandomBit,
 	* so it is split off for clarity.
 	*/
-	private inline void scrambleSeed();
+private:
+	inline void scrambleSeed();
 };
 
 /** @} */

--- a/common/random.h
+++ b/common/random.h
@@ -39,8 +39,8 @@ namespace Common {
 class String;
 
 /**
- * Simple random number generator. Although it is definitely not suitable for
- * cryptographic purposes, it serves our purposes just fine.
+ * Xorshift PRNG. Replaces the previous PRNG, as
+ * the cycles within it were detrimental to gameplay.
  */
 class RandomSource {
 private:
@@ -60,6 +60,13 @@ public:
 	uint32 getSeed() const { /*!< Get a random seed that can be used to initialize the RNG. */
 		return _randSeed;
 	}
+	
+	/**
+	* Scrambles the seed in order to get a new result.
+	* Code is shared between getRandomNumber and getRandomBit,
+	* so it is split off for clarity.
+	*/
+	inline void scrambleSeed();
 
 	/**
 	 * Generate a random unsigned integer in the interval [0, max].


### PR DESCRIPTION
The old RNG method had non-standard periods, ranging from some seeds looping on themselves (seed = 1184201285) to some seeds having periods as low as 11 or 48, as listed in https://github.com/scummvm/scummvm/pull/3340. This is a problem even for games that run the RNG once a frame, as the possibilities for random events is greatly reduced should the initial seed be in one of these sets of small periods.

Xorshift is a standard, fast, non-cryptographic PRNG with academic backing that has period 2^32-1 (all seeds lead to another seed except 0, which is excluded from the initial seeds).  Many different flavors are possible, as listed in the paper, but the choice implemented in this pull request uses only a single 32-bit integer as a state, like the old PRNG.
