### PR TITLE
EVENTRECORDER: Fix synchronisation, add 'update' mode

### DIFF
--- a/backends/log/log.cpp
+++ b/backends/log/log.cpp
@@ -94,7 +94,7 @@ void Log::print(const char *message, const bool printTime) {
 void Log::printTimeStamp() {
 	TimeDate date;
 	int curMonth;
-	_system->getTimeAndDate(date);
+	_system->getTimeAndDate(date, true);
 	curMonth = date.tm_mon + 1; // month is base 0, we need base 1 (1 = january and so on)
 
 	_stream->writeString(Common::String::format("[%d-%02d-%02d %02d:%02d:%02d] ",

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -186,6 +186,8 @@ void ModularGraphicsBackend::fillScreen(uint32 col) {
 
 void ModularGraphicsBackend::updateScreen() {
 #ifdef ENABLE_EVENTRECORDER
+	g_system->getMillis();		// force event recorder to update the tick count
+	g_eventRec.processScreenUpdate();
 	g_eventRec.preDrawOverlayGui();
 #endif
 

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -258,6 +258,15 @@ bool ModularGraphicsBackend::lockMouse(bool visible) {
 }
 
 void ModularGraphicsBackend::warpMouse(int x, int y) {
+#ifdef ENABLE_EVENTRECORDER
+	// short circuit for EventRecorder calling warpMouse inside an event poll
+	if ((g_eventRec.getRecordMode() == GUI::EventRecorder::kRecorderPlayback) ||
+		(g_eventRec.getRecordMode() == GUI::EventRecorder::kRecorderUpdate)) {
+		_graphicsManager->warpMouse(x, y);
+		return;
+	}
+#endif
+
 	_eventManager->purgeMouseEvents();
 	_graphicsManager->warpMouse(x, y);
 }

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -171,7 +171,7 @@ static const char HELP_STRING[] =
 	"                           atari, macintosh, macintoshbw)\n"
 #ifdef ENABLE_EVENTRECORDER
 	"  --record-mode=MODE       Specify record mode for event recorder (record, playback,\n"
-	"                           passthrough [default])\n"
+	"                           info, update, passthrough [default])\n"
 	"  --record-file-name=FILE  Specify record file name\n"
 	"  --disable-display        Disable any gfx output. Used for headless events\n"
 	"                           playback by Event Recorder\n"

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -175,6 +175,8 @@ static const char HELP_STRING[] =
 	"  --record-file-name=FILE  Specify record file name\n"
 	"  --disable-display        Disable any gfx output. Used for headless events\n"
 	"                           playback by Event Recorder\n"
+	"  --screenshot-period=NUM  When recording, trigger a screenshot every NUM milliseconds\n"
+	"                           (default: 60000)\n"
 #endif
 	"\n"
 #if defined(ENABLE_SKY) || defined(ENABLE_QUEEN)
@@ -654,6 +656,9 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			END_OPTION
 
 			DO_LONG_OPTION("record-file-name")
+			END_OPTION
+
+			DO_LONG_OPTION_INT("screenshot-period")
 			END_OPTION
 #endif
 

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -600,7 +600,8 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 			Common::String recordFileName = ConfMan.get("record_file_name");
 
 			if (recordMode == "record") {
-				g_eventRec.init(g_eventRec.generateRecordFileName(ConfMan.getActiveDomainName()), GUI::EventRecorder::kRecorderRecord);
+				Common::String targetFileName = ConfMan.hasKey("record_file_name") ? recordFileName : g_eventRec.generateRecordFileName(ConfMan.getActiveDomainName());
+				g_eventRec.init(targetFileName, GUI::EventRecorder::kRecorderRecord);
 			} else if (recordMode == "playback") {
 				g_eventRec.init(recordFileName, GUI::EventRecorder::kRecorderPlayback);
 			} else if ((recordMode == "info") && (!recordFileName.empty())) {

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -602,6 +602,8 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 			if (recordMode == "record") {
 				Common::String targetFileName = ConfMan.hasKey("record_file_name") ? recordFileName : g_eventRec.generateRecordFileName(ConfMan.getActiveDomainName());
 				g_eventRec.init(targetFileName, GUI::EventRecorder::kRecorderRecord);
+			} else if (recordMode == "update") {
+				g_eventRec.init(recordFileName, GUI::EventRecorder::kRecorderUpdate);
 			} else if (recordMode == "playback") {
 				g_eventRec.init(recordFileName, GUI::EventRecorder::kRecorderPlayback);
 			} else if ((recordMode == "info") && (!recordFileName.empty())) {

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -132,7 +132,7 @@ bool PlaybackFile::parseHeader() {
 }
 
 bool PlaybackFile::checkPlaybackFileVersion() {
-	_version = _readStream->readUint32LE();
+	_version = _readStream->readUint32BE();
 	switch (_version) {
 	case 2:
 		break;
@@ -167,8 +167,8 @@ String PlaybackFile::readString(int len) {
 }
 
 bool PlaybackFile::readChunkHeader(PlaybackFile::ChunkHeader &nextChunk) {
-	nextChunk.id = (FileTag)_readStream->readUint32LE();
-	nextChunk.len = _readStream->readUint32LE();
+	nextChunk.id = (FileTag)_readStream->readUint32BE();
+	nextChunk.len = _readStream->readUint32BE();
 	return !_readStream->err() && !_readStream->eos();
 }
 
@@ -286,7 +286,7 @@ void PlaybackFile::readHashMap(ChunkHeader chunk) {
 
 void PlaybackFile::processRndSeedRecord(ChunkHeader chunk) {
 	String randomSourceName = readString(chunk.len - 4);
-	uint32 randomSourceSeed = _readStream->readUint32LE();
+	uint32 randomSourceSeed = _readStream->readUint32BE();
 	_header.randomSourceRecords[randomSourceName] = randomSourceSeed;
 }
 
@@ -381,32 +381,32 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 	event.recordedtype = (RecorderEventType)_tmpPlaybackFile.readByte();
 	switch (event.recordedtype) {
 	case kRecorderEventTypeTimer:
-		event.time = _tmpPlaybackFile.readUint32LE();
+		event.time = _tmpPlaybackFile.readUint32BE();
 		break;
 	case kRecorderEventTypeTimeDate:
-		event.timeDate.tm_sec = _tmpPlaybackFile.readSint32LE();
-		event.timeDate.tm_min = _tmpPlaybackFile.readSint32LE();
-		event.timeDate.tm_hour = _tmpPlaybackFile.readSint32LE();
-		event.timeDate.tm_mday = _tmpPlaybackFile.readSint32LE();
-		event.timeDate.tm_mon = _tmpPlaybackFile.readSint32LE();
-		event.timeDate.tm_year = _tmpPlaybackFile.readSint32LE();
-		event.timeDate.tm_wday = _tmpPlaybackFile.readSint32LE();
+		event.timeDate.tm_sec = _tmpPlaybackFile.readSint32BE();
+		event.timeDate.tm_min = _tmpPlaybackFile.readSint32BE();
+		event.timeDate.tm_hour = _tmpPlaybackFile.readSint32BE();
+		event.timeDate.tm_mday = _tmpPlaybackFile.readSint32BE();
+		event.timeDate.tm_mon = _tmpPlaybackFile.readSint32BE();
+		event.timeDate.tm_year = _tmpPlaybackFile.readSint32BE();
+		event.timeDate.tm_wday = _tmpPlaybackFile.readSint32BE();
 		break;
 	case kRecorderEventTypeScreenUpdate:
-		event.time = _tmpPlaybackFile.readUint32LE();
+		event.time = _tmpPlaybackFile.readUint32BE();
 		break;
 	default:
 		// fallthrough intended
 	case kRecorderEventTypeNormal:
-		event.type = (EventType)_tmpPlaybackFile.readUint32LE();
+		event.type = (EventType)_tmpPlaybackFile.readUint32BE();
 		switch (event.type) {
 		case EVENT_KEYDOWN:
 			event.kbdRepeat = _tmpPlaybackFile.readByte();
 			// fallthrough
 		case EVENT_KEYUP:
-			event.time = _tmpPlaybackFile.readUint32LE();
-			event.kbd.keycode = (KeyCode)_tmpPlaybackFile.readSint32LE();
-			event.kbd.ascii = _tmpPlaybackFile.readUint16LE();
+			event.time = _tmpPlaybackFile.readUint32BE();
+			event.kbd.keycode = (KeyCode)_tmpPlaybackFile.readSint32BE();
+			event.kbd.ascii = _tmpPlaybackFile.readUint16BE();
 			event.kbd.flags = _tmpPlaybackFile.readByte();
 			break;
 		case EVENT_MOUSEMOVE:
@@ -422,27 +422,27 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 		case EVENT_X1BUTTONUP:
 		case EVENT_X2BUTTONDOWN:
 		case EVENT_X2BUTTONUP:
-			event.time = _tmpPlaybackFile.readUint32LE();
-			event.mouse.x = _tmpPlaybackFile.readSint16LE();
-			event.mouse.y = _tmpPlaybackFile.readSint16LE();
+			event.time = _tmpPlaybackFile.readUint32BE();
+			event.mouse.x = _tmpPlaybackFile.readSint16BE();
+			event.mouse.y = _tmpPlaybackFile.readSint16BE();
 			break;
 		case EVENT_CUSTOM_BACKEND_ACTION_START:
 		case EVENT_CUSTOM_BACKEND_ACTION_END:
 		case EVENT_CUSTOM_ENGINE_ACTION_START:
 		case EVENT_CUSTOM_ENGINE_ACTION_END:
-			event.time = _tmpPlaybackFile.readUint32LE();
-			event.customType = _tmpPlaybackFile.readUint32LE();
+			event.time = _tmpPlaybackFile.readUint32BE();
+			event.customType = _tmpPlaybackFile.readUint32BE();
 			break;
 		case EVENT_JOYAXIS_MOTION:
 		case EVENT_JOYBUTTON_UP:
 		case EVENT_JOYBUTTON_DOWN:
-			event.time = _tmpPlaybackFile.readUint32LE();
+			event.time = _tmpPlaybackFile.readUint32BE();
 			event.joystick.axis = _tmpPlaybackFile.readByte();
 			event.joystick.button = _tmpPlaybackFile.readByte();
-			event.joystick.position = _tmpPlaybackFile.readSint16LE();
+			event.joystick.position = _tmpPlaybackFile.readSint16BE();
 			break;
 		default:
-			event.time = _tmpPlaybackFile.readUint32LE();
+			event.time = _tmpPlaybackFile.readUint32BE();
 			break;
 		}
 		break;
@@ -459,8 +459,8 @@ void PlaybackFile::readEventsToBuffer(uint32 size) {
 
 void PlaybackFile::saveScreenShot(Graphics::Surface &screen, byte md5[16]) {
 	dumpRecordsToFile();
-	_writeStream->writeUint32LE(kMD5Tag);
-	_writeStream->writeUint32LE(16);
+	_writeStream->writeUint32BE(kMD5Tag);
+	_writeStream->writeUint32BE(16);
 	_writeStream->write(md5, 16);
 	Graphics::saveThumbnail(*_writeStream, screen);
 }
@@ -473,21 +473,21 @@ void PlaybackFile::dumpRecordsToFile() {
 	if (_recordCount == 0) {
 		return;
 	}
-	_writeStream->writeUint32LE(kEventTag);
-	_writeStream->writeUint32LE(_tmpRecordFile.pos());
+	_writeStream->writeUint32BE(kEventTag);
+	_writeStream->writeUint32BE(_tmpRecordFile.pos());
 	_writeStream->write(_tmpBuffer.data(), _tmpRecordFile.pos());
 	_tmpRecordFile.seek(0);
 	_recordCount = 0;
 }
 
 void PlaybackFile::dumpHeaderToFile() {
-	_writeStream->writeUint32LE(kFormatIdTag);
+	_writeStream->writeUint32BE(kFormatIdTag);
 	// Specify size for first tag as NULL since we cannot calculate
 	// size of the file at time of the header dumping
-	_writeStream->writeUint32LE(0);
-	_writeStream->writeUint32LE(kVersionTag);
-	_writeStream->writeUint32LE(4);
-	_writeStream->writeUint32LE(RECORD_VERSION);
+	_writeStream->writeUint32BE(0);
+	_writeStream->writeUint32BE(kVersionTag);
+	_writeStream->writeUint32BE(4);
+	_writeStream->writeUint32BE(RECORD_VERSION);
 	writeHeaderSection();
 	writeGameHash();
 	writeRandomRecords();
@@ -509,21 +509,21 @@ void PlaybackFile::writeHeaderSection() {
 	if (headerSize == 0) {
 		return;
 	}
-	_writeStream->writeUint32LE(kHeaderSectionTag);
-	_writeStream->writeUint32LE(headerSize);
+	_writeStream->writeUint32BE(kHeaderSectionTag);
+	_writeStream->writeUint32BE(headerSize);
 	if (!_header.author.empty()) {
-		_writeStream->writeUint32LE(kAuthorTag);
-		_writeStream->writeUint32LE(_header.author.size());
+		_writeStream->writeUint32BE(kAuthorTag);
+		_writeStream->writeUint32BE(_header.author.size());
 		_writeStream->writeString(_header.author);
 	}
 	if (!_header.notes.empty()) {
-		_writeStream->writeUint32LE(kCommentsTag);
-		_writeStream->writeUint32LE(_header.notes.size());
+		_writeStream->writeUint32BE(kCommentsTag);
+		_writeStream->writeUint32BE(_header.notes.size());
 		_writeStream->writeString(_header.notes);
 	}
 	if (!_header.name.empty()) {
-		_writeStream->writeUint32LE(kNameTag);
-		_writeStream->writeUint32LE(_header.name.size());
+		_writeStream->writeUint32BE(kNameTag);
+		_writeStream->writeUint32BE(_header.name.size());
 		_writeStream->writeString(_header.name);
 	}
 }
@@ -536,11 +536,11 @@ void PlaybackFile::writeGameHash() {
 	if (_header.hashRecords.size() == 0) {
 		return;
 	}
-	_writeStream->writeUint32LE(kHashSectionTag);
-	_writeStream->writeUint32LE(hashSectionSize);
+	_writeStream->writeUint32BE(kHashSectionTag);
+	_writeStream->writeUint32BE(hashSectionSize);
 	for (StringMap::iterator i = _header.hashRecords.begin(); i != _header.hashRecords.end(); ++i) {
-		_writeStream->writeUint32LE(kHashRecordTag);
-		_writeStream->writeUint32LE(i->_key.size() + i->_value.size());
+		_writeStream->writeUint32BE(kHashRecordTag);
+		_writeStream->writeUint32BE(i->_key.size() + i->_value.size());
 		_writeStream->writeString(i->_key);
 		_writeStream->writeString(i->_value);
 	}
@@ -554,13 +554,13 @@ void PlaybackFile::writeRandomRecords() {
 	if (_header.randomSourceRecords.size() == 0) {
 		return;
 	}
-	_writeStream->writeUint32LE(kRandomSectionTag);
-	_writeStream->writeUint32LE(randomSectionSize);
+	_writeStream->writeUint32BE(kRandomSectionTag);
+	_writeStream->writeUint32BE(randomSectionSize);
 	for (RandomSeedsDictionary::iterator i = _header.randomSourceRecords.begin(); i != _header.randomSourceRecords.end(); ++i) {
-		_writeStream->writeUint32LE(kRandomRecordTag);
-		_writeStream->writeUint32LE(i->_key.size() + 4);
+		_writeStream->writeUint32BE(kRandomRecordTag);
+		_writeStream->writeUint32BE(i->_key.size() + 4);
 		_writeStream->writeString(i->_key);
-		_writeStream->writeUint32LE(i->_value);
+		_writeStream->writeUint32BE(i->_value);
 	}
 }
 
@@ -570,32 +570,32 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 	_tmpRecordFile.writeByte(event.recordedtype);
 	switch (event.recordedtype) {
 	case kRecorderEventTypeTimer:
-		_tmpRecordFile.writeUint32LE(event.time);
+		_tmpRecordFile.writeUint32BE(event.time);
 		break;
 	case kRecorderEventTypeTimeDate:
-		_tmpRecordFile.writeSint32LE(event.timeDate.tm_sec);
-		_tmpRecordFile.writeSint32LE(event.timeDate.tm_min);
-		_tmpRecordFile.writeSint32LE(event.timeDate.tm_hour);
-		_tmpRecordFile.writeSint32LE(event.timeDate.tm_mday);
-		_tmpRecordFile.writeSint32LE(event.timeDate.tm_mon);
-		_tmpRecordFile.writeSint32LE(event.timeDate.tm_year);
-		_tmpRecordFile.writeSint32LE(event.timeDate.tm_wday);
+		_tmpRecordFile.writeSint32BE(event.timeDate.tm_sec);
+		_tmpRecordFile.writeSint32BE(event.timeDate.tm_min);
+		_tmpRecordFile.writeSint32BE(event.timeDate.tm_hour);
+		_tmpRecordFile.writeSint32BE(event.timeDate.tm_mday);
+		_tmpRecordFile.writeSint32BE(event.timeDate.tm_mon);
+		_tmpRecordFile.writeSint32BE(event.timeDate.tm_year);
+		_tmpRecordFile.writeSint32BE(event.timeDate.tm_wday);
 		break;
 	case kRecorderEventTypeScreenUpdate:
-		_tmpRecordFile.writeUint32LE(event.time);
+		_tmpRecordFile.writeUint32BE(event.time);
 		break;
 	default:
 		// fallthrough intended
 	case kRecorderEventTypeNormal:
-		_tmpRecordFile.writeUint32LE((uint32)event.type);
+		_tmpRecordFile.writeUint32BE((uint32)event.type);
 		switch(event.type) {
 		case EVENT_KEYDOWN:
 			_tmpRecordFile.writeByte(event.kbdRepeat);
 			// fallthrough
 		case EVENT_KEYUP:
-			_tmpRecordFile.writeUint32LE(event.time);
-			_tmpRecordFile.writeSint32LE(event.kbd.keycode);
-			_tmpRecordFile.writeUint16LE(event.kbd.ascii);
+			_tmpRecordFile.writeUint32BE(event.time);
+			_tmpRecordFile.writeSint32BE(event.kbd.keycode);
+			_tmpRecordFile.writeUint16BE(event.kbd.ascii);
 			_tmpRecordFile.writeByte(event.kbd.flags);
 			break;
 		case EVENT_MOUSEMOVE:
@@ -611,27 +611,27 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 		case EVENT_X1BUTTONUP:
 		case EVENT_X2BUTTONDOWN:
 		case EVENT_X2BUTTONUP:
-			_tmpRecordFile.writeUint32LE(event.time);
-			_tmpRecordFile.writeSint16LE(event.mouse.x);
-			_tmpRecordFile.writeSint16LE(event.mouse.y);
+			_tmpRecordFile.writeUint32BE(event.time);
+			_tmpRecordFile.writeSint16BE(event.mouse.x);
+			_tmpRecordFile.writeSint16BE(event.mouse.y);
 			break;
 		case EVENT_CUSTOM_BACKEND_ACTION_START:
 		case EVENT_CUSTOM_BACKEND_ACTION_END:
 		case EVENT_CUSTOM_ENGINE_ACTION_START:
 		case EVENT_CUSTOM_ENGINE_ACTION_END:
-			_tmpRecordFile.writeUint32LE(event.time);
-			_tmpRecordFile.writeUint32LE(event.customType);
+			_tmpRecordFile.writeUint32BE(event.time);
+			_tmpRecordFile.writeUint32BE(event.customType);
 			break;
 		case EVENT_JOYAXIS_MOTION:
 		case EVENT_JOYBUTTON_UP:
 		case EVENT_JOYBUTTON_DOWN:
-			_tmpRecordFile.writeUint32LE(event.time);
+			_tmpRecordFile.writeUint32BE(event.time);
 			_tmpRecordFile.writeByte(event.joystick.axis);
 			_tmpRecordFile.writeByte(event.joystick.button);
-			_tmpRecordFile.writeSint16LE(event.joystick.position);
+			_tmpRecordFile.writeSint16BE(event.joystick.position);
 			break;
 		default:
-			_tmpRecordFile.writeUint32LE(event.time);
+			_tmpRecordFile.writeUint32BE(event.time);
 			break;
 		}
 		break;
@@ -644,20 +644,20 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 }
 
 void PlaybackFile::writeGameSettings() {
-	_writeStream->writeUint32LE(kSettingsSectionTag);
+	_writeStream->writeUint32BE(kSettingsSectionTag);
 	uint32 settingsSectionSize = 0;
 	for (StringMap::iterator i = _header.settingsRecords.begin(); i != _header.settingsRecords.end(); ++i) {
 		settingsSectionSize += i->_key.size() + i->_value.size() + 24;
 	}
-	_writeStream->writeUint32LE(settingsSectionSize);
+	_writeStream->writeUint32BE(settingsSectionSize);
 	for (StringMap::iterator i = _header.settingsRecords.begin(); i != _header.settingsRecords.end(); ++i) {
-		_writeStream->writeUint32LE(kSettingsRecordTag);
-		_writeStream->writeUint32LE(i->_key.size() + i->_value.size() + 16);
-		_writeStream->writeUint32LE(kSettingsRecordKeyTag);
-		_writeStream->writeUint32LE(i->_key.size());
+		_writeStream->writeUint32BE(kSettingsRecordTag);
+		_writeStream->writeUint32BE(i->_key.size() + i->_value.size() + 16);
+		_writeStream->writeUint32BE(kSettingsRecordKeyTag);
+		_writeStream->writeUint32BE(i->_key.size());
 		_writeStream->writeString(i->_key);
-		_writeStream->writeUint32LE(kSettingsRecordValueTag);
-		_writeStream->writeUint32LE(i->_value.size());
+		_writeStream->writeUint32BE(kSettingsRecordValueTag);
+		_writeStream->writeUint32BE(i->_value.size());
 		_writeStream->writeString(i->_value);
 	}
 }
@@ -678,14 +678,14 @@ int PlaybackFile::getScreensCount() {
 
 bool PlaybackFile::skipToNextScreenshot() {
 	while (!_readStream->eos() && !_readStream->err()) {
-		FileTag id = (FileTag)_readStream->readUint32LE();
+		FileTag id = (FileTag)_readStream->readUint32BE();
 		if (_readStream->eos() || _readStream->err()) {
 			break;
 		}
 		if (id == kScreenShotTag) {
 			return true;
 		}
-		uint32 size = _readStream->readUint32LE();
+		uint32 size = _readStream->readUint32BE();
 		_readStream->skip(size);
 	}
 	return false;
@@ -743,7 +743,7 @@ void PlaybackFile::updateHeader() {
 
 void PlaybackFile::skipHeader() {
 	while (true) {
-		uint32 id = _readStream->readUint32LE();
+		uint32 id = _readStream->readUint32BE();
 		if (_readStream->eos()) {
 			break;
 		}
@@ -752,7 +752,7 @@ void PlaybackFile::skipHeader() {
 			return;
 		}
 		else {
-			uint32 size = _readStream->readUint32LE();
+			uint32 size = _readStream->readUint32BE();
 			_readStream->skip(size);
 		}
 	}
@@ -775,16 +775,16 @@ void PlaybackFile::writeSaveFilesSection() {
 	if (size == 0) {
 		return;
 	}
-	_writeStream->writeSint32LE(kSaveTag);
-	_writeStream->writeSint32LE(size);
+	_writeStream->writeSint32BE(kSaveTag);
+	_writeStream->writeSint32BE(size);
 	for (HashMap<String, SaveFileBuffer>::iterator  i = _header.saveFiles.begin(); i != _header.saveFiles.end(); ++i) {
-		_writeStream->writeSint32LE(kSaveRecordTag);
-		_writeStream->writeSint32LE(i->_key.size() + i->_value.size + 16);
-		_writeStream->writeSint32LE(kSaveRecordNameTag);
-		_writeStream->writeSint32LE(i->_key.size());
+		_writeStream->writeSint32BE(kSaveRecordTag);
+		_writeStream->writeSint32BE(i->_key.size() + i->_value.size + 16);
+		_writeStream->writeSint32BE(kSaveRecordNameTag);
+		_writeStream->writeSint32BE(i->_key.size());
 		_writeStream->writeString(i->_key);
-		_writeStream->writeSint32LE(kSaveRecordBufferTag);
-		_writeStream->writeSint32LE(i->_value.size);
+		_writeStream->writeSint32BE(kSaveRecordBufferTag);
+		_writeStream->writeSint32BE(i->_value.size);
 		_writeStream->write(i->_value.buffer, i->_value.size);
 	}
 }

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -447,7 +447,8 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 		}
 		break;
 	}
-	debug(3, "read event of type: %i (time: %u, systemmillis: %u)", event.type, event.time, g_system->getMillis(true));
+	debug(3, "read event of recordedtype: %i, type: %i (time: %u, systemmillis: %u)",
+			event.recordedtype, event.type, event.time, g_system->getMillis(true));
 }
 
 void PlaybackFile::readEventsToBuffer(uint32 size) {
@@ -638,7 +639,8 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 	if (_recordCount == kMaxBufferedRecords) {
 		dumpRecordsToFile();
 	}
-	debug(3, "write event of type: %i (time: %u, systemmillis: %u)", event.type, event.time, g_system->getMillis(true));
+	debug(3, "write event of recordedtype: %i, type: %i (time: %u, systemmillis: %u)",
+			event.recordedtype, event.type, event.time, g_system->getMillis(true));
 }
 
 void PlaybackFile::writeGameSettings() {

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -30,7 +30,7 @@
 #include "graphics/surface.h"
 #include "graphics/scaler.h"
 
-#define RECORD_VERSION 2
+#define RECORD_VERSION 1
 
 namespace Common {
 
@@ -47,7 +47,6 @@ PlaybackFile::PlaybackFile()
 	_headerDumped = false;
 	_recordCount = 0;
 	_eventsSize = 0;
-	_trackScreenUpdate = true;
 	_version = RECORD_VERSION;
 	memset(_tmpBuffer.data(), 1, kRecordBuffSize);
 
@@ -134,10 +133,7 @@ bool PlaybackFile::parseHeader() {
 bool PlaybackFile::checkPlaybackFileVersion() {
 	_version = _readStream->readUint32BE();
 	switch (_version) {
-	case 2:
-		break;
 	case 1:
-		_trackScreenUpdate = false;
 		break;
 	default:
 		warning("Unknown playback file version %d. Maximum supported version is %d.", _version, RECORD_VERSION);

--- a/common/recorderfile.h
+++ b/common/recorderfile.h
@@ -159,7 +159,7 @@ public:
 	void updateHeader();
 	void addSaveFile(const String &fileName, InSaveFile *saveStream);
 
-	uint32 getVersion() {return _version;}
+	uint32 getVersion() const {return _version;}
 	bool hasTrackScreenUpdate() {return _trackScreenUpdate;}
 private:
 	Array<byte> _tmpBuffer;

--- a/common/recorderfile.h
+++ b/common/recorderfile.h
@@ -39,7 +39,8 @@ namespace Common {
 enum RecorderEventType {
 	kRecorderEventTypeNormal = 0,
 	kRecorderEventTypeTimer = 1,
-	kRecorderEventTypeTimeDate = 2
+	kRecorderEventTypeTimeDate = 2,
+	kRecorderEventTypeScreenUpdate = 3,
 };
 
 struct RecorderEvent : Event {
@@ -157,6 +158,9 @@ public:
 	PlaybackFileHeader &getHeader() {return _header;}
 	void updateHeader();
 	void addSaveFile(const String &fileName, InSaveFile *saveStream);
+
+	uint32 getVersion() {return _version;}
+	bool hasTrackScreenUpdate() {return _trackScreenUpdate;}
 private:
 	Array<byte> _tmpBuffer;
 	WriteStream *_recordFile;
@@ -172,6 +176,8 @@ private:
 	uint32 _eventsSize;
 	PlaybackFileHeader _header;
 	PlaybackFileState _playbackParseState;
+	bool _trackScreenUpdate;
+	uint32 _version;
 
 	void skipHeader();
 	bool parseHeader();

--- a/common/recorderfile.h
+++ b/common/recorderfile.h
@@ -103,7 +103,7 @@ class PlaybackFile {
 		kHashSectionTag = MKTAG('H','A','S','H'),
 		kRandomSectionTag = MKTAG('R','A','N','D'),
 		kEventTag = MKTAG('E','V','N','T'),
-		kScreenShotTag = MKTAG('B','M','H','T'),
+		kScreenShotTag = MKTAG('T','H','M','B'),
 		kSettingsSectionTag = MKTAG('S','E','T','T'),
 		kAuthorTag = MKTAG('H','A','U','T'),
 		kCommentsTag = MKTAG('H','C','M','T'),

--- a/common/recorderfile.h
+++ b/common/recorderfile.h
@@ -160,7 +160,6 @@ public:
 	void addSaveFile(const String &fileName, InSaveFile *saveStream);
 
 	uint32 getVersion() const {return _version;}
-	bool hasTrackScreenUpdate() {return _trackScreenUpdate;}
 private:
 	Array<byte> _tmpBuffer;
 	WriteStream *_recordFile;
@@ -176,7 +175,6 @@ private:
 	uint32 _eventsSize;
 	PlaybackFileHeader _header;
 	PlaybackFileState _playbackParseState;
-	bool _trackScreenUpdate;
 	uint32 _version;
 
 	void skipHeader();

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -55,6 +55,7 @@
 #include "gui/gui-manager.h"
 #include "gui/debugger.h"
 #include "gui/dialog.h"
+#include "gui/EventRecorder.h"
 #include "gui/message.h"
 #include "gui/saveload.h"
 
@@ -534,6 +535,10 @@ void Engine::warnMissingExtractedCDAudio() {
 }
 
 void Engine::handleAutoSave() {
+#ifdef ENABLE_EVENTRECORDER
+	if (!g_eventRec.processAutosave())
+		return;
+#endif
 	const int diff = _system->getMillis() - _lastAutosaveTime;
 
 	if (_autosaveInterval != 0 && diff > (_autosaveInterval * 1000)) {

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -97,6 +97,7 @@ EventRecorder::EventRecorder() {
 	_lastScreenshotTime = 0;
 	_screenshotPeriod = 0;
 	_playbackFile = nullptr;
+	_recordFile = nullptr;
 }
 
 EventRecorder::~EventRecorder() {
@@ -116,12 +117,18 @@ void EventRecorder::deinit() {
 	_controlPanel->close();
 	delete _controlPanel;
 	debugC(1, kDebugLevelEventRec, "playback:action=stopplayback");
-	Common::EventDispatcher *eventDispater = g_system->getEventManager()->getEventDispatcher();
-	eventDispater->unregisterSource(this);
-	eventDispater->ignoreSources(false);
+	Common::EventDispatcher *eventDispatcher = g_system->getEventManager()->getEventDispatcher();
+	eventDispatcher->unregisterSource(this);
+	eventDispatcher->ignoreSources(false);
 	_recordMode = kPassthrough;
-	_playbackFile->close();
-	delete _playbackFile;
+	if (_playbackFile) {
+		_playbackFile->close();
+		delete _playbackFile;
+	}
+	if (_recordFile) {
+		_recordFile->close();
+		delete _recordFile;
+	}
 	switchMixer();
 	switchTimerManagers();
 	DebugMan.disableDebugChannel("EventRec");
@@ -143,31 +150,41 @@ void EventRecorder::processTimeAndDate(TimeDate &td, bool skipRecord) {
 		return;
 	}
 	Common::RecorderEvent timeDateEvent;
-	switch (_recordMode) {
-	case kRecorderRecord:
+	if (_recordMode == kRecorderRecord) {
 		timeDateEvent.recordedtype = Common::kRecorderEventTypeTimeDate;
 		timeDateEvent.timeDate = td;
 		_lastTimeDate = td;
-		_playbackFile->writeEvent(timeDateEvent);
-		break;
-	case kRecorderPlayback:
+		_recordFile->writeEvent(timeDateEvent);
+	}
+	if ((_recordMode == kRecorderPlayback) || (_recordMode == kRecorderUpdate)) {
 		if (_nextEvent.recordedtype != Common::kRecorderEventTypeTimeDate) {
 			// just re-use any previous date time value
 			td = _lastTimeDate;
+			if (_recordMode == kRecorderUpdate) {
+				// if we make it to here, we're expecting there to be an event in the file
+				// so add one to the updated recording
+				debug(3, "inserting additional timedate event");
+				timeDateEvent.recordedtype = Common::kRecorderEventTypeTimeDate;
+				timeDateEvent.timeDate = td;
+				_recordFile->writeEvent(timeDateEvent);
+			}
 			return;
 		}
 		_lastTimeDate = _nextEvent.timeDate;
 		td = _lastTimeDate;
 		debug(3, "timedate event");
 
+		if (_recordMode == kRecorderUpdate) {
+			// copy the event to the updated recording
+			timeDateEvent.recordedtype = Common::kRecorderEventTypeTimeDate;
+			timeDateEvent.timeDate = td;
+			_recordFile->writeEvent(timeDateEvent);
+		}
+
 		_nextEvent = _playbackFile->getNextEvent();
-		break;
-	case kRecorderPlaybackPause:
-		td = _lastTimeDate;
-		break;
-	default:
-		break;
 	}
+	if (_recordMode == kRecorderPlaybackPause)
+		td = _lastTimeDate;
 }
 
 void EventRecorder::processMillis(uint32 &millis, bool skipRecord) {
@@ -192,6 +209,7 @@ void EventRecorder::processMillis(uint32 &millis, bool skipRecord) {
 		_recordFile->writeEvent(timerEvent);
 		_timerManager->handler();
 		break;
+	case kRecorderUpdate: // fallthrough
 	case kRecorderPlayback:
 		if (_nextEvent.recordedtype != Common::kRecorderEventTypeTimer) {
 			// just re-use any previous millis value
@@ -200,11 +218,25 @@ void EventRecorder::processMillis(uint32 &millis, bool skipRecord) {
 			// is registered and thus dispatched after those EventSource instances, it
 			// might look like it ran out-of-sync.
 			millis = _fakeTimer;
+			if (_recordMode == kRecorderUpdate) {
+				// if we make it to here, we're expecting there to be an event in the file
+				// so add one to the updated recording
+				debug(3, "inserting additional timer event");
+				timerEvent.recordedtype = Common::kRecorderEventTypeTimer;
+				timerEvent.time = _fakeTimer;
+				_recordFile->writeEvent(timerEvent);
+			}
 			return;
 		}
 		_processingMillis = true;
 		_fakeTimer = _nextEvent.time;
 		millis = _fakeTimer;
+		if (_recordMode == kRecorderUpdate) {
+			// copy the event to the updated recording
+			timerEvent.recordedtype = Common::kRecorderEventTypeTimer;
+			timerEvent.time = _fakeTimer;
+			_recordFile->writeEvent(timerEvent);
+		}
 		updateSubsystems();
 		_nextEvent = _playbackFile->getNextEvent();
 		_timerManager->handler();
@@ -242,6 +274,7 @@ void EventRecorder::processScreenUpdate() {
 		takeScreenshot();
 		_timerManager->handler();
 		break;
+	case kRecorderUpdate: // fallthrough
 	case kRecorderPlayback:
 		if (_playbackFile->hasTrackScreenUpdate()) {
 			// if the file has screen update support, but the next event
@@ -261,6 +294,13 @@ void EventRecorder::processScreenUpdate() {
 			_fakeTimer = _nextEvent.time;
 			updateSubsystems();
 			_nextEvent = _playbackFile->getNextEvent();
+			if (_recordMode == kRecorderUpdate) {
+				// write event to the updated file and update screenshot if necessary
+				screenUpdateEvent.recordedtype = Common::kRecorderEventTypeScreenUpdate;
+				screenUpdateEvent.time = _fakeTimer;
+				_recordFile->writeEvent(screenUpdateEvent);
+				takeScreenshot();
+			}
 			_timerManager->handler();
 			_controlPanel->setReplayedTime(_fakeTimer);
 			_processingMillis = false;
@@ -278,7 +318,9 @@ void EventRecorder::checkForKeyCode(const Common::Event &event) {
 }
 
 bool EventRecorder::pollEvent(Common::Event &ev) {
-	if ((_recordMode != kRecorderPlayback) || !_initialized)
+	if (((_recordMode != kRecorderPlayback) &&
+		(_recordMode != kRecorderUpdate)) ||
+		!_initialized)
 		return false;
 
 	if (_nextEvent.recordedtype == Common::kRecorderEventTypeTimer
@@ -317,6 +359,7 @@ void EventRecorder::togglePause() {
 	switch (_recordMode) {
 	case kRecorderPlayback:
 	case kRecorderRecord:
+	case kRecorderUpdate:
 		oldState = _recordMode;
 		_recordMode = kRecorderPlaybackPause;
 		_controlPanel->runModal();
@@ -341,7 +384,7 @@ uint32 EventRecorder::getRandomSeed(const Common::String &name) {
 	}
 	uint32 result = g_system->getMillis();
 	if (_recordMode == kRecorderRecord) {
-		_playbackFile->getHeader().randomSourceRecords[name] = result;
+		_recordFile->getHeader().randomSourceRecords[name] = result;
 	}
 	return result;
 }
@@ -366,7 +409,6 @@ void EventRecorder::init(const Common::String &recordFileName, RecordMode mode) 
 	_fakeMixerManager->suspendAudio();
 	_fakeTimer = 0;
 	_lastMillis = g_system->getMillis();
-	_playbackFile = new Common::PlaybackFile();
 	_lastScreenshotTime = 0;
 	_recordMode = mode;
 	_needcontinueGame = false;
@@ -374,12 +416,12 @@ void EventRecorder::init(const Common::String &recordFileName, RecordMode mode) 
 		DebugMan.enableDebugChannel("EventRec");
 		gDebugLevel = 1;
 	}
-	if (_recordMode == kRecorderPlayback) {
+	if ((_recordMode == kRecorderPlayback) || (_recordMode == kRecorderUpdate)) {
 		debugC(1, kDebugLevelEventRec, "playback:action=\"Load file\" filename=%s", recordFileName.c_str());
-		Common::EventDispatcher *eventDispater = g_system->getEventManager()->getEventDispatcher();
-		eventDispater->clearEvents();
-		eventDispater->ignoreSources(true);
-		eventDispater->registerSource(this, false);
+		Common::EventDispatcher *eventDispatcher = g_system->getEventManager()->getEventDispatcher();
+		eventDispatcher->clearEvents();
+		eventDispatcher->ignoreSources(true);
+		eventDispatcher->registerSource(this, false);
 	}
 	_screenshotPeriod = ConfMan.getInt("screenshot_period");
 	if (_screenshotPeriod == 0) {
@@ -394,11 +436,11 @@ void EventRecorder::init(const Common::String &recordFileName, RecordMode mode) 
 		_controlPanel = new GUI::OnScreenDialog(_recordMode == kRecorderRecord);
 		_controlPanel->reflowLayout();
 	}
-	if (_recordMode == kRecorderPlayback) {
+	if ((_recordMode == kRecorderPlayback) || (_recordMode == kRecorderUpdate)) {
 		applyPlaybackSettings();
 		_nextEvent = _playbackFile->getNextEvent();
 	}
-	if (_recordMode == kRecorderRecord) {
+	if ((_recordMode == kRecorderRecord) || (_recordMode == kRecorderUpdate)) {
 		getConfig();
 	}
 
@@ -419,11 +461,21 @@ bool EventRecorder::openRecordFile(const Common::String &fileName) {
 	bool result;
 	switch (_recordMode) {
 	case kRecorderRecord:
-		return _playbackFile->openWrite(fileName);
+		_recordFile = new Common::PlaybackFile();
+		return _recordFile->openWrite(fileName);
 	case kRecorderPlayback:
 		_recordMode = kPassthrough;
+		_playbackFile = new Common::PlaybackFile();
 		result = _playbackFile->openRead(fileName);
 		_recordMode = kRecorderPlayback;
+		return result;
+	case kRecorderUpdate:
+		_recordMode = kPassthrough;
+		_playbackFile = new Common::PlaybackFile();
+		result = _playbackFile->openRead(fileName);
+		_recordMode = kRecorderUpdate;
+		_recordFile = new Common::PlaybackFile();
+		result &= _recordFile->openWrite(fileName + ".new");
 		return result;
 	default:
 		return false;
@@ -478,19 +530,24 @@ MixerManager *EventRecorder::getMixerManager() {
 
 void EventRecorder::getConfigFromDomain(const Common::ConfigManager::Domain *domain) {
 	for (Common::ConfigManager::Domain::const_iterator entry = domain->begin(); entry!= domain->end(); ++entry) {
-		_playbackFile->getHeader().settingsRecords[entry->_key] = entry->_value;
+		_recordFile->getHeader().settingsRecords[entry->_key] = entry->_value;
 	}
 }
 
 void EventRecorder::getConfig() {
 	getConfigFromDomain(ConfMan.getDomain(ConfMan.kApplicationDomain));
 	getConfigFromDomain(ConfMan.getActiveDomain());
-	_playbackFile->getHeader().settingsRecords["save_slot"] = ConfMan.get("save_slot");
+	_recordFile->getHeader().settingsRecords["save_slot"] = ConfMan.get("save_slot");
 }
 
 
 void EventRecorder::applyPlaybackSettings() {
 	for (Common::StringMap::const_iterator i = _playbackFile->getHeader().settingsRecords.begin(); i != _playbackFile->getHeader().settingsRecords.end(); ++i) {
+		if (_recordMode == kRecorderUpdate) {
+			// copy the header values to the new recording
+			_recordFile->getHeader().settingsRecords[i->_key] = i->_value;
+		}
+
 		Common::String currentValue = ConfMan.get(i->_key);
 		if (currentValue != i->_value) {
 			ConfMan.set(i->_key, i->_value, ConfMan.kTransientDomain);
@@ -549,10 +606,18 @@ bool EventRecorder::notifyEvent(const Common::Event &ev) {
 	evt.mouse.x = evt.mouse.x * (g_system->getOverlayWidth() / g_system->getWidth());
 	evt.mouse.y = evt.mouse.y * (g_system->getOverlayHeight() / g_system->getHeight());
 	switch (_recordMode) {
+	case kRecorderUpdate: // passthrough
 	case kRecorderPlayback:
 		// pass through screen updates to avoid loss of sync!
 		if (evt.type == Common::EVENT_SCREEN_CHANGED)
 			g_gui.processEvent(evt, _controlPanel);
+		if (_recordMode == kRecorderUpdate) {
+			// write a copy of the event to the output buffer
+			Common::RecorderEvent e(ev);
+			e.recordedtype = Common::kRecorderEventTypeNormal;
+			e.time = _fakeTimer;
+			_recordFile->writeEvent(e);
+		}
 		return false;
 	case kRecorderRecord:
 		g_gui.processEvent(evt, _controlPanel);
@@ -562,7 +627,7 @@ bool EventRecorder::notifyEvent(const Common::Event &ev) {
 			Common::RecorderEvent e(ev);
 			e.recordedtype = Common::kRecorderEventTypeNormal;
 			e.time = _fakeTimer;
-			_playbackFile->writeEvent(e);
+			_recordFile->writeEvent(e);
 			return false;
 		}
 	case kRecorderPlaybackPause: {
@@ -586,16 +651,16 @@ bool EventRecorder::notifyEvent(const Common::Event &ev) {
 void EventRecorder::setGameMd5(const ADGameDescription *gameDesc) {
 	for (const ADGameFileDescription *fileDesc = gameDesc->filesDescriptions; fileDesc->fileName; fileDesc++) {
 		if (fileDesc->md5 != nullptr) {
-			_playbackFile->getHeader().hashRecords[fileDesc->fileName] = fileDesc->md5;
+			_recordFile->getHeader().hashRecords[fileDesc->fileName] = fileDesc->md5;
 		}
 	}
 }
 
 void EventRecorder::processGameDescription(const ADGameDescription *desc) {
-	if (_recordMode == kRecorderRecord) {
+	if ((_recordMode == kRecorderRecord) || (_recordMode == kRecorderUpdate)) {
 		setGameMd5(desc);
 	}
-	if ((_recordMode == kRecorderPlayback) && !checkGameHash(desc)) {
+	if (((_recordMode == kRecorderPlayback) || (_recordMode == kRecorderUpdate)) && !checkGameHash(desc)) {
 		deinit();
 		error("playback:action=error reason=\"\"");
 	}
@@ -611,7 +676,7 @@ void EventRecorder::takeScreenshot() {
 		uint8 md5[16];
 		if (grabScreenAndComputeMD5(screen, md5)) {
 			_lastScreenshotTime = _fakeTimer;
-			_playbackFile->saveScreenShot(screen, md5);
+			_recordFile->saveScreenShot(screen, md5);
 			screen.free();
 		}
 	}
@@ -636,7 +701,7 @@ Common::SeekableReadStream *EventRecorder::processSaveStream(const Common::Strin
 	case kRecorderRecord:
 		saveFile = _realSaveManager->openForLoading(fileName);
 		if (saveFile != nullptr) {
-			_playbackFile->addSaveFile(fileName, saveFile);
+			_recordFile->addSaveFile(fileName, saveFile);
 			saveFile->seek(0);
 		}
 		return saveFile;
@@ -681,7 +746,7 @@ void EventRecorder::postDrawOverlayGui() {
 }
 
 Common::StringArray EventRecorder::listSaveFiles(const Common::String &pattern) {
-	if (_recordMode == kRecorderPlayback) {
+	if ((_recordMode == kRecorderPlayback) || (_recordMode == kRecorderUpdate)) {
 		Common::StringArray result;
 		for (Common::HashMap<Common::String, Common::PlaybackFile::SaveFileBuffer>::iterator  i = _playbackFile->getHeader().saveFiles.begin(); i != _playbackFile->getHeader().saveFiles.end(); ++i) {
 			if (i->_key.matchString(pattern, false, "/")) {
@@ -695,7 +760,7 @@ Common::StringArray EventRecorder::listSaveFiles(const Common::String &pattern) 
 }
 
 void EventRecorder::setFileHeader() {
-	if (_recordMode != kRecorderRecord) {
+	if ((_recordMode != kRecorderRecord) && (_recordMode != kRecorderUpdate)) {
 		return;
 	}
 	TimeDate t;
@@ -707,9 +772,9 @@ void EventRecorder::setFileHeader() {
 	if (_name.empty()) {
 		g_eventRec.setName(Common::String::format("%.2d.%.2d.%.4d ", t.tm_mday, t.tm_mon + 1, 1900 + t.tm_year) + desc.description);
 	}
-	_playbackFile->getHeader().author = _author;
-	_playbackFile->getHeader().notes = _desc;
-	_playbackFile->getHeader().name = _name;
+	_recordFile->getHeader().author = _author;
+	_recordFile->getHeader().notes = _desc;
+	_recordFile->getHeader().name = _name;
 }
 
 SDL_Surface *EventRecorder::getSurface(int width, int height) {

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -205,8 +205,6 @@ void EventRecorder::processMillis(uint32 &millis, bool skipRecord) {
 		_processingMillis = true;
 		_fakeTimer = _nextEvent.time;
 		millis = _fakeTimer;
-		debug(3, "millis event: %u", millis);
-
 		updateSubsystems();
 		_nextEvent = _playbackFile->getNextEvent();
 		_timerManager->handler();
@@ -261,7 +259,6 @@ void EventRecorder::processScreenUpdate() {
 			}
 			_processingMillis = true;
 			_fakeTimer = _nextEvent.time;
-			debug(3, "screenUpdate event: %u", _fakeTimer);
 			updateSubsystems();
 			_nextEvent = _playbackFile->getNextEvent();
 			_timerManager->handler();

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -224,6 +224,10 @@ bool EventRecorder::processDelayMillis() {
 	return _fastPlayback;
 }
 
+bool EventRecorder::processAutosave() {
+	return _recordMode == kPassthrough;
+}
+
 void EventRecorder::processScreenUpdate() {
 	if (!_initialized) {
 		return;

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -87,6 +87,7 @@ EventRecorder::EventRecorder() {
 
 	_fakeTimer = 0;
 	_savedState = false;
+	_acquireCount = 0;
 	_needcontinueGame = false;
 	_temporarySlot = 0;
 	_realSaveManager = nullptr;
@@ -552,6 +553,9 @@ bool EventRecorder::notifyEvent(const Common::Event &ev) {
 	evt.mouse.y = evt.mouse.y * (g_system->getOverlayHeight() / g_system->getHeight());
 	switch (_recordMode) {
 	case kRecorderPlayback:
+		// pass through screen updates to avoid loss of sync!
+		if (evt.type == Common::EVENT_SCREEN_CHANGED)
+			g_gui.processEvent(evt, _controlPanel);
 		return false;
 	case kRecorderRecord:
 		g_gui.processEvent(evt, _controlPanel);

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -383,8 +383,8 @@ bool EventRecorder::openRecordFile(const Common::String &fileName) {
 
 bool EventRecorder::checkGameHash(const ADGameDescription *gameDesc) {
 	if (_playbackFile->getHeader().hashRecords.size() == 0) {
-		warning("Engine doesn't contain description table");
-		return false;
+		warning("Engine doesn't contain description table, skipping hash check");
+		return true;
 	}
 	for (const ADGameFileDescription *fileDesc = gameDesc->filesDescriptions; fileDesc->fileName; fileDesc++) {
 		if (fileDesc->md5 == nullptr)

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -74,7 +74,8 @@ public:
 		kPassthrough = 0,		/**< kPassthrough, do nothing */
 		kRecorderRecord = 1,		/**< kRecorderRecord, do the recording */
 		kRecorderPlayback = 2,		/**< kRecorderPlayback, playback existing recording */
-		kRecorderPlaybackPause = 3	/**< kRecordetPlaybackPause, internal state when user pauses the playback */
+		kRecorderPlaybackPause = 3,	/**< kRecorderPlaybackPause, internal state when user pauses the playback */
+		kRecorderUpdate = 4			/**< kRecorderUpdate, playback existing recording and update all hashes */
 	};
 
 	void init(const Common::String &recordFileName, RecordMode mode);
@@ -237,6 +238,7 @@ private:
 	uint32 _lastScreenshotTime;
 	uint32 _screenshotPeriod;
 	Common::PlaybackFile *_playbackFile;
+	Common::PlaybackFile *_recordFile;
 
 	void saveScreenShot();
 	void checkRecordedMD5();

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -83,6 +83,7 @@ public:
 	uint32 getRandomSeed(const Common::String &name);
 	void processTimeAndDate(TimeDate &td, bool skipRecord);
 	void processMillis(uint32 &millis, bool skipRecord);
+	void processScreenUpdate();
 	void processGameDescription(const ADGameDescription *desc);
 	Common::SeekableReadStream *processSaveStream(const Common::String & fileName);
 
@@ -228,6 +229,7 @@ private:
 	void saveScreenShot();
 	void checkRecordedMD5();
 	void deleteTemporarySave();
+	void updateFakeTimer(uint32 millis);
 	volatile RecordMode _recordMode;
 	Common::String _recordFileName;
 	bool _fastPlayback;

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -168,6 +168,10 @@ public:
 			_initialized = _savedState;
 	}
 
+	RecordMode getRecordMode() {
+		return _recordMode;
+	}
+
 	Common::StringArray listSaveFiles(const Common::String &pattern);
 	Common::String generateRecordFileName(const Common::String &target);
 

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -155,6 +155,7 @@ public:
 	bool checkForContinueGame();
 
 	void acquireRecording() {
+		assert(_acquireCount >= 0);
 		if (_acquireCount == 0) {
 			_savedState = _initialized;
 			_initialized = false;
@@ -169,7 +170,7 @@ public:
 			_initialized = _savedState;
 	}
 
-	RecordMode getRecordMode() {
+	RecordMode getRecordMode() const {
 		return _recordMode;
 	}
 

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -85,6 +85,7 @@ public:
 	void processMillis(uint32 &millis, bool skipRecord);
 	void processScreenUpdate();
 	void processGameDescription(const ADGameDescription *desc);
+	bool processAutosave();
 	Common::SeekableReadStream *processSaveStream(const Common::String & fileName);
 
 	/** Hooks for intercepting into GUI processing, so required events could be shoot

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -153,13 +153,19 @@ public:
 	void deleteRecord(const Common::String& fileName);
 	bool checkForContinueGame();
 
-	void suspendRecording() {
-		_savedState = _initialized;
-		_initialized = false;
+	void acquireRecording() {
+		if (_acquireCount == 0) {
+			_savedState = _initialized;
+			_initialized = false;
+		}
+		_acquireCount += 1;
 	}
 
-	void resumeRecording() {
-		_initialized = _savedState;
+	void releaseRecording() {
+		assert(_acquireCount > 0);
+		_acquireCount -= 1;
+		if (_acquireCount == 0)
+			_initialized = _savedState;
 	}
 
 	Common::StringArray listSaveFiles(const Common::String &pattern);
@@ -183,6 +189,7 @@ private:
 	volatile uint32 _fakeTimer;
 	TimeDate _lastTimeDate;
 	bool _savedState;
+	int _acquireCount;
 	bool _needcontinueGame;
 	int _temporarySlot;
 	Common::String _author;

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -368,7 +368,7 @@ void GuiManager::runLoop() {
 
 #ifdef ENABLE_EVENTRECORDER
 	// Suspend recording while GUI is shown
-	g_eventRec.suspendRecording();
+	g_eventRec.acquireRecording();
 #endif
 
 	if (!_stateIsSaved) {
@@ -505,7 +505,7 @@ void GuiManager::runLoop() {
 
 #ifdef ENABLE_EVENTRECORDER
 	// Resume recording once GUI is shown
-	g_eventRec.resumeRecording();
+	g_eventRec.releaseRecording();
 #endif
 }
 
@@ -621,6 +621,13 @@ bool GuiManager::checkScreenChange() {
 }
 
 void GuiManager::screenChange() {
+#ifdef ENABLE_EVENTRECORDER
+	// Suspend recording while GUI is redrawn.
+	// We need this in addition to the lock in runLoop, as EVENT_SCREEN_CHANGED can
+	// be fired by in-game GUI components (such as the event recorder itself)
+	g_eventRec.acquireRecording();
+#endif
+
 	_lastScreenChangeID = _system->getScreenChangeID();
 
 	computeScaleFactor();
@@ -638,6 +645,11 @@ void GuiManager::screenChange() {
 	_redrawStatus = kRedrawFull;
 	redraw();
 	_system->updateScreen();
+
+#ifdef ENABLE_EVENTRECORDER
+	// Resume recording once GUI has redrawn
+	g_eventRec.releaseRecording();
+#endif
 }
 
 void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDialog) {


### PR DESCRIPTION
- Screenshot frequency can now be specified from the command line.
- Screen redraws are now tracked, and all events and screenshots are force-aligned with a screen redraw.
- A few cases of recursion in the event processing stream have been removed.
- Compatibility with the previous version of Event Recorder file format has been dropped, on the advice that no testing efforts use this feature yet.
- A new 'update' mode has been added to the EventRecorder. This new mode is functionally identical to playback mode, however
a new recording file is used to track the actual output of ScummVM. This feature can be used to update a suite of existing recordings after a renderer or a timing change.