### PR TITLE
COMMON: Use const references where possible in punycode

### DIFF
--- a/common/punycode.cpp
+++ b/common/punycode.cpp
@@ -129,7 +129,7 @@ static size_t decode_digit(uint32 v) {
 	return SMAX;
 }
 
-String punycode_encode(U32String src) {
+String punycode_encode(const U32String &src) {
 	size_t srclen = src.size();
 	size_t h = 0, si;
 	String dst = "xn--";
@@ -194,11 +194,11 @@ String punycode_encode(U32String src) {
 	return dst;
 }
 
-bool punycode_hasprefix(const String src) {
+bool punycode_hasprefix(const String &src) {
 	return src.hasPrefix("xn--");
 }
 
-bool punycode_needEncode(const String src) {
+bool punycode_needEncode(const String &src) {
 	for (uint si = 0; si < src.size(); si++) {
 		if (src[si] & 0x80 || src[si] < 0x20 || strchr(SPECIAL_SYMBOLS, src[si])) {
 			return true;
@@ -208,7 +208,7 @@ bool punycode_needEncode(const String src) {
 	return false;
 }
 
-U32String punycode_decode(const String src1) {
+U32String punycode_decode(const String &src1) {
 	if (!src1.hasPrefix("xn--"))
 		return src1;
 
@@ -301,7 +301,7 @@ U32String punycode_decode(const String src1) {
 	return dst;
 }
 
-String punycode_encodefilename(const U32String src) {
+String punycode_encodefilename(const U32String &src) {
 	U32String dst;
 
 	for (uint i = 0; i < src.size(); i++) {
@@ -320,7 +320,7 @@ String punycode_encodefilename(const U32String src) {
 	return punycode_encode(dst);
 }
 
-U32String punycode_decodefilename(const String src1) {
+U32String punycode_decodefilename(const String &src1) {
 	U32String dst;
 	U32String src = punycode_decode(src1);
 

--- a/common/punycode.h
+++ b/common/punycode.h
@@ -52,19 +52,19 @@ namespace Common {
 /**
  * Convert UTF-32 to Punycode. Returns the encoded string.
  */
-String punycode_encode(const U32String src);
+String punycode_encode(const U32String &src);
 
 /**
  * Convert Punycode to UTF-32. Returns the decoded string
  */
-U32String punycode_decode(const String src);
+U32String punycode_decode(const String &src);
 
-String punycode_encodefilename(const U32String src1);
+String punycode_encodefilename(const U32String &src1);
 
 /**
  * Convert Punycode filename to Binary using special 0x81 escape character. Returns the decoded string
  */
-U32String punycode_decodefilename(const String src1);
+U32String punycode_decodefilename(const String &src1);
 
 /**
  * Convert path from Punycode
@@ -76,9 +76,9 @@ Path punycode_decodepath(const Path &src);
  */
 Path punycode_encodepath(const Path &src);
 
-bool punycode_hasprefix(const String src);
+bool punycode_hasprefix(const String &src);
 
-bool punycode_needEncode(const String src);
+bool punycode_needEncode(const String &src);
 
 } // end of namespace Common
 


### PR DESCRIPTION
I saw this in the coverity report (CID 1461548 and 1461550) and it seemed easy enough to fix.
 