### PR TITLE
CINE: Fixes for #11687, #11708, #11723 and #12812

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,7 @@ For a more comprehensive changelog of the latest experimental code, see:
 
  Cine:
    - Added detection for Italian Amiga Operation Stealth.
+   - Fixed crash before entering secret base.
    - Fixed space missing in verb line.
    - Fixed vertically overflowing message boxes.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,9 @@ For a more comprehensive changelog of the latest experimental code, see:
  CGE2:
    - Added option to use Text To Speech for Sfinx.
 
+ Cine:
+   - Fixed vertically overflowing message boxes.
+
  Dreamweb:
    - Rendering fixes for Russian fan translation.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,7 @@ For a more comprehensive changelog of the latest experimental code, see:
 
  Cine:
    - Added detection for Italian Amiga Operation Stealth.
+   - Fixed space missing in verb line.
    - Fixed vertically overflowing message boxes.
 
  Dreamweb:

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@ For a more comprehensive changelog of the latest experimental code, see:
    - Added option to use Text To Speech for Sfinx.
 
  Cine:
+   - Added detection for Italian Amiga Operation Stealth.
    - Fixed vertically overflowing message boxes.
 
  Dreamweb:

--- a/engines/cine/detection_tables.h
+++ b/engines/cine/detection_tables.h
@@ -407,6 +407,20 @@ static const CINEGameDescription gameDescriptions[] = {
 		0,
 	},
 
+	{ // Submitted by Nyarlathotep7777 in #12812 (Italian Amiga version)
+		{
+			"os",
+			"",
+			AD_ENTRY1s("procs1", "d7458be2b14d77410e6330148ca6c371", 61682),
+			Common::IT_ITA,
+			Common::kPlatformAmiga,
+			ADGF_NO_FLAGS,
+			GUIO0()
+		},
+		GType_OS,
+		0,
+	},
+
 	{
 		{
 			"os",

--- a/engines/cine/gfx.h
+++ b/engines/cine/gfx.h
@@ -154,13 +154,13 @@ protected:
 	void drawMaskedSprite(const ObjectStruct &obj, const byte *mask);
 	virtual void drawSprite(const ObjectStruct &obj);
 
-	void drawMessage(const char *str, int x, int y, int width, int color);
+	int drawMessage(const char *str, int x, int y, int width, int color, bool draw = true);
 	void drawPlainBox(int x, int y, int width, int height, byte color);
 	byte transparentDialogBoxStartColor();
 	void drawTransparentBox(int x, int y, int width, int height);
 	void drawBorder(int x, int y, int width, int height, byte color);
 	void drawDoubleBorder(int x, int y, int width, int height, byte color);
-	virtual int drawChar(char character, int x, int y);
+	virtual int drawChar(char character, int x, int y, bool draw = true);
 	virtual int undrawChar(char character, int x, int y);
 	void drawLine(int x, int y, int width, int height, byte color);
 	void remaskSprite(byte *mask, Common::List<overlay>::iterator it);
@@ -260,7 +260,7 @@ protected:
 	const Cine::Palette& getFadeInSourcePalette() override;
 	void drawSprite(const ObjectStruct &obj) override;
 	void drawSprite(overlay *overlayPtr, const byte *spritePtr, int16 width, int16 height, byte *page, int16 x, int16 y, byte transparentColor, byte bpp);
-	int drawChar(char character, int x, int y) override;
+	int drawChar(char character, int x, int y, bool draw = true) override;
 	void drawBackground() override;
 	void renderOverlay(const Common::List<overlay>::iterator &it) override;
 

--- a/engines/cine/part.cpp
+++ b/engines/cine/part.cpp
@@ -197,7 +197,8 @@ void CineEngine::readVolCnf() {
 int16 findFileInBundle(const char *fileName) {
 	// HACK: Fix underwater background palette by reading it from correct file
 	if (hacksEnabled && g_cine->getGameType() == Cine::GType_OS &&
-		scumm_stricmp(currentPrcName, "SOUSMAR2.PRC") == 0) {
+		scumm_stricmp(currentPrcName, "SOUSMAR2.PRC") == 0 &&
+		g_cine->_volumeEntriesMap.contains(fileName)) {
 		Common::Array<VolumeResource> volRes = g_cine->_volumeEntriesMap.find(fileName)->_value;
 		if (volRes.size() == 2 && scumm_stricmp(volRes[0].name, "rsc12") == 0 &&
 			scumm_stricmp(volRes[1].name, "rsc08") == 0 &&

--- a/engines/cine/various.cpp
+++ b/engines/cine/various.cpp
@@ -1074,6 +1074,7 @@ void playerCommandMouseLeft(uint16 &mouseButton, uint16 &mouseX, uint16 &mouseY)
 			g_cine->_commandBuffer = "";
 		} else if (g_cine->getGameType() == Cine::GType_OS) {
 			isDrawCommandEnabled = 1;
+			g_cine->_commandBuffer += " ";
 			g_cine->_commandBuffer += commandPrepositionTable[playerCommand];
 		}
 


### PR DESCRIPTION
  Hello!
Here are fixes for the following bugs/feature requests:
 - #11687 ("CINE: OS: Space missing in verb line")
 - #11708 ("CINE: OS (Atari ST/German) - Dialogue window overflow")
 - #11723 ("CINE: OS: Crash in Secret Base")
 - #12812 ("CINE: Unknown game variant for Operation Stealth, Amiga OCS Italian.")

Please could you cherry pick these to the 2.3.0 branch also? Thank you very much!

Kari Salminen