### PR TITLE
CINE: Add detection for French patched FW CD (#12490)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@ For a more comprehensive changelog of the latest experimental code, see:
    - Added option to use Text To Speech for Sfinx.
 
  Cine:
+   - Added detection for Future Wars CD version with French translation patch.
    - Added detection for Italian Amiga Operation Stealth.
    - Fixed crash before entering secret base.
    - Fixed space missing in verb line.

--- a/engines/cine/detection_tables.h
+++ b/engines/cine/detection_tables.h
@@ -58,6 +58,23 @@ static const CINEGameDescription gameDescriptions[] = {
 	},
 
 	{
+		// This is the Future Wars CD version
+		// with a French translation patch (#12490).
+		{
+			"fw",
+			"Sony CD version with French translation patch",
+			AD_ENTRY2s("AUTO00.PRC",	"4fe1e7930b38e3c63f0f2474d471bf8f", -1,
+					   "PART01",		"5d1acb97abe9591f9008e00d07add95a", -1),
+			Common::FR_FRA,
+			Common::kPlatformDOS,
+			ADGF_CD,
+			GUIO0()
+		},
+		GType_FW,
+		GF_CD | GF_CRYPTED_BOOT_PRC,
+	},
+
+	{
 		// This is the version included in the UK "Classic Collection"
 		{
 			"fw",


### PR DESCRIPTION
Add detection for Future Wars CD version with French translation patch
applied.

Closes #12490

Please could you also cherry pick this to the 2.3 branch? Thank you very much!

Kari Salminen