### PR TITLE
ENGINES: Move all custom engine options dialogs into the engine plugin

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -198,6 +198,13 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 
 	// Create the game's MetaEngine.
 	MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
+	if (err.getCode() == Common::kNoError) {
+		// Set default values for all of the custom engine options
+		// Apparently some engines query them in their constructor, thus we
+		// need to set this up before instance creation.
+		metaEngine.registerDefaultSettings(target);
+	}
+
 	err = metaEngine.createInstance(&system, &engine);
 
 	// Check for errors

--- a/engines/ags/detection.cpp
+++ b/engines/ags/detection.cpp
@@ -30,10 +30,6 @@
 #include "ags/detection.h"
 #include "ags/detection_tables.h"
 
-#include "gui/ThemeEval.h"
-#include "gui/widget.h"
-#include "gui/widgets/popup.h"
-
 namespace AGS3 {
 
 static const char *const HEAD_SIG = "CLIB\x1a";
@@ -63,103 +59,6 @@ static bool isAGSFile(Common::File &f) {
 		return true;
 
 	return false;
-}
-
-class AGSOptionsWidget : public GUI::OptionsContainerWidget {
-public:
-	explicit AGSOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
-
-	// OptionsContainerWidget API
-	void load() override;
-	bool save() override;
-
-private:
-	// OptionsContainerWidget API
-	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
-
-	GUI::PopUpWidget *_langPopUp;
-	Common::StringArray _traFileNames;
-
-	GUI::CheckboxWidget *_forceTextAACheckbox;
-};
-
-AGSOptionsWidget::AGSOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain) :
-	OptionsContainerWidget(boss, name, "AGSGameOptionsDialog", false, domain) {
-
-	// Language
-	GUI::StaticTextWidget *textWidget = new GUI::StaticTextWidget(widgetsBoss(), _dialogLayout + ".translation_desc", _("Game language:"), _("Language to use for multilingual games"));
-	textWidget->setAlign(Graphics::kTextAlignRight);
-
-	_langPopUp = new GUI::PopUpWidget(widgetsBoss(), _dialogLayout + ".translation");
-	_langPopUp->appendEntry(_("<default>"), (uint32) - 1);
-
-	Common::String path = ConfMan.get("path", _domain);
-	Common::FSDirectory dir(path);
-	Common::ArchiveMemberList traFileList;
-	dir.listMatchingMembers(traFileList, "*.tra");
-
-	int i = 0;
-	for (Common::ArchiveMemberList::iterator iter = traFileList.begin(); iter != traFileList.end(); ++iter) {
-		Common::String traFileName = (*iter)->getName();
-		traFileName.erase(traFileName.size() - 4); // remove .tra extension
-		_traFileNames.push_back(traFileName);
-		_langPopUp->appendEntry(traFileName, i++);
-	}
-
-	// Force font antialiasing
-	_forceTextAACheckbox = new GUI::CheckboxWidget(widgetsBoss(), _dialogLayout + ".textAA", _("Force antialiased text"), _("Use antialiasing to draw text even if the game does not ask for it"));
-}
-
-void AGSOptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const {
-	layouts.addDialog(layoutName, overlayedLayout);
-	layouts.addLayout(GUI::ThemeLayout::kLayoutVertical).addPadding(16, 16, 16, 16);
-
-	layouts.addLayout(GUI::ThemeLayout::kLayoutHorizontal).addPadding(0, 0, 0, 0);
-	layouts.addWidget("translation_desc", "OptionsLabel");
-	layouts.addWidget("translation", "PopUp").closeLayout();
-
-	layouts.addWidget("textAA", "Checkbox");
-
-	layouts.closeLayout().closeDialog();
-}
-
-void AGSOptionsWidget::load() {
-	Common::ConfigManager::Domain *gameConfig = ConfMan.getDomain(_domain);
-	if (!gameConfig)
-		return;
-
-	uint32 curLangIndex = (uint32) - 1;
-	Common::String curLang;
-	gameConfig->tryGetVal("translation", curLang);
-	if (!curLang.empty()) {
-		for (uint i = 0; i < _traFileNames.size(); ++i) {
-			if (_traFileNames[i].equalsIgnoreCase(curLang)) {
-				curLangIndex = i;
-				break;
-			}
-		}
-	}
-	_langPopUp->setSelectedTag(curLangIndex);
-
-	Common::String forceTextAA;
-	gameConfig->tryGetVal("force_text_aa", forceTextAA);
-	if (!forceTextAA.empty()) {
-		bool val;
-		if (parseBool(forceTextAA, val))
-			_forceTextAACheckbox->setState(val);
-	}
-}
-
-bool AGSOptionsWidget::save() {
-	uint langIndex = _langPopUp->getSelectedTag();
-	if (langIndex < _traFileNames.size())
-		ConfMan.set("translation", _traFileNames[langIndex], _domain);
-	else
-		ConfMan.removeKey("translation", _domain);
-
-	ConfMan.setBool("force_text_aa", _forceTextAACheckbox->getState(), _domain);
-
-	return true;
 }
 
 } // namespace AGS3
@@ -291,10 +190,6 @@ ADDetectedGame AGSMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 	}
 
 	return ADDetectedGame();
-}
-
-GUI::OptionsContainerWidget *AGSMetaEngineDetection::buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
-	return new AGS3::AGSOptionsWidget(boss, name, target);
 }
 
 REGISTER_PLUGIN_STATIC(AGS_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, AGSMetaEngineDetection);

--- a/engines/ags/detection.h
+++ b/engines/ags/detection.h
@@ -94,8 +94,6 @@ public:
 	bool canPlayUnknownVariants() const override {
 		return true;
 	}
-
-	GUI::OptionsContainerWidget *buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
 #endif

--- a/engines/ags/dialogs.cpp
+++ b/engines/ags/dialogs.cpp
@@ -1,0 +1,138 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/config-manager.h"
+#include "common/file.h"
+#include "common/md5.h"
+#include "common/str-array.h"
+#include "common/translation.h"
+#include "common/util.h"
+#include "ags/metaengine.h"
+
+#include "gui/ThemeEval.h"
+#include "gui/widget.h"
+#include "gui/widgets/popup.h"
+
+namespace AGS3 {
+
+class AGSOptionsWidget : public GUI::OptionsContainerWidget {
+public:
+	explicit AGSOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
+
+	// OptionsContainerWidget API
+	void load() override;
+	bool save() override;
+
+private:
+	// OptionsContainerWidget API
+	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
+
+	GUI::PopUpWidget *_langPopUp;
+	Common::StringArray _traFileNames;
+
+	GUI::CheckboxWidget *_forceTextAACheckbox;
+};
+
+AGSOptionsWidget::AGSOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain) :
+	OptionsContainerWidget(boss, name, "AGSGameOptionsDialog", false, domain) {
+
+	// Language
+	GUI::StaticTextWidget *textWidget = new GUI::StaticTextWidget(widgetsBoss(), _dialogLayout + ".translation_desc", _("Game language:"), _("Language to use for multilingual games"));
+	textWidget->setAlign(Graphics::kTextAlignRight);
+
+	_langPopUp = new GUI::PopUpWidget(widgetsBoss(), _dialogLayout + ".translation");
+	_langPopUp->appendEntry(_("<default>"), (uint32) - 1);
+
+	Common::String path = ConfMan.get("path", _domain);
+	Common::FSDirectory dir(path);
+	Common::ArchiveMemberList traFileList;
+	dir.listMatchingMembers(traFileList, "*.tra");
+
+	int i = 0;
+	for (Common::ArchiveMemberList::iterator iter = traFileList.begin(); iter != traFileList.end(); ++iter) {
+		Common::String traFileName = (*iter)->getName();
+		traFileName.erase(traFileName.size() - 4); // remove .tra extension
+		_traFileNames.push_back(traFileName);
+		_langPopUp->appendEntry(traFileName, i++);
+	}
+
+	// Force font antialiasing
+	_forceTextAACheckbox = new GUI::CheckboxWidget(widgetsBoss(), _dialogLayout + ".textAA", _("Force antialiased text"), _("Use antialiasing to draw text even if the game does not ask for it"));
+}
+
+void AGSOptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const {
+	layouts.addDialog(layoutName, overlayedLayout);
+	layouts.addLayout(GUI::ThemeLayout::kLayoutVertical).addPadding(16, 16, 16, 16);
+
+	layouts.addLayout(GUI::ThemeLayout::kLayoutHorizontal).addPadding(0, 0, 0, 0);
+	layouts.addWidget("translation_desc", "OptionsLabel");
+	layouts.addWidget("translation", "PopUp").closeLayout();
+
+	layouts.addWidget("textAA", "Checkbox");
+
+	layouts.closeLayout().closeDialog();
+}
+
+void AGSOptionsWidget::load() {
+	Common::ConfigManager::Domain *gameConfig = ConfMan.getDomain(_domain);
+	if (!gameConfig)
+		return;
+
+	uint32 curLangIndex = (uint32) - 1;
+	Common::String curLang;
+	gameConfig->tryGetVal("translation", curLang);
+	if (!curLang.empty()) {
+		for (uint i = 0; i < _traFileNames.size(); ++i) {
+			if (_traFileNames[i].equalsIgnoreCase(curLang)) {
+				curLangIndex = i;
+				break;
+			}
+		}
+	}
+	_langPopUp->setSelectedTag(curLangIndex);
+
+	Common::String forceTextAA;
+	gameConfig->tryGetVal("force_text_aa", forceTextAA);
+	if (!forceTextAA.empty()) {
+		bool val;
+		if (parseBool(forceTextAA, val))
+			_forceTextAACheckbox->setState(val);
+	}
+}
+
+bool AGSOptionsWidget::save() {
+	uint langIndex = _langPopUp->getSelectedTag();
+	if (langIndex < _traFileNames.size())
+		ConfMan.set("translation", _traFileNames[langIndex], _domain);
+	else
+		ConfMan.removeKey("translation", _domain);
+
+	ConfMan.setBool("force_text_aa", _forceTextAACheckbox->getState(), _domain);
+
+	return true;
+}
+
+} // namespace AGS3
+
+GUI::OptionsContainerWidget *AGSMetaEngine::buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
+	return new AGS3::AGSOptionsWidget(boss, name, target);
+}

--- a/engines/ags/metaengine.h
+++ b/engines/ags/metaengine.h
@@ -54,6 +54,8 @@ public:
 	 */
 	Common::String getSavegameFile(int saveGameIdx, const char *target = nullptr) const override;
 
+	GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
+
 	/**
 	 * Determine whether the engine supports the specified MetaEngine feature.
 	 *

--- a/engines/ags/module.mk
+++ b/engines/ags/module.mk
@@ -2,6 +2,7 @@ MODULE := engines/ags
 
 MODULE_OBJS = \
 	ags.o \
+	dialogs.o \
 	events.o \
 	game_scanner.o \
 	globals.o \

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -193,7 +193,7 @@ public:
 	 *
 	 * @param target  Name of a config manager target.
 	 */
-	virtual void registerDefaultSettings(const Common::String &target) const;
+	void registerDefaultSettings(const Common::String &target) const;
 
 	/**
 	 * Return a GUI widget container for configuring the specified target options.
@@ -209,7 +209,7 @@ public:
 	 * @param name     The name that the returned widget must use.
 	 * @param target   Name of a config manager target.
 	 */
-	virtual GUI::OptionsContainerWidget *buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const;
+	GUI::OptionsContainerWidget *buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const;
 };
 
 /**
@@ -376,6 +376,14 @@ public:
 	 * Return the keymap used by the target.
 	 */
 	virtual Common::Array<Common::Keymap *> initKeymaps(const char *target) const;
+
+	/**
+	 * Register the default values for the settings that the engine uses into the
+	 * configuration manager.
+	 *
+	 * @param target  Name of a config manager target.
+	 */
+	virtual void registerDefaultSettings(const Common::String &target) const {}
 
 	/**
 	 * Return a GUI widget container for configuring the specified target options.

--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -103,8 +103,6 @@ public:
 	}
 
 	DetectedGame toDetectedGame(const ADDetectedGame &adGame, ADDetectedGameExtraInfo *extraInfo) const override;
-
-	void registerDefaultSettings(const Common::String &target) const override;
 };
 
 DetectedGame MohawkMetaEngineDetection::toDetectedGame(const ADDetectedGame &adGame, ADDetectedGameExtraInfo *extraInfo) const {
@@ -133,20 +131,6 @@ DetectedGame MohawkMetaEngineDetection::toDetectedGame(const ADDetectedGame &adG
 	}
 
 	return game;
-}
-
-void MohawkMetaEngineDetection::registerDefaultSettings(const Common::String &target) const {
-	Common::String gameId = ConfMan.get("gameid", target);
-
-	if (gameId == "myst" || gameId == "makingofmyst") {
-		return Mohawk::MohawkMetaEngine_Myst::registerDefaultSettings();
-	}
-
-	if (gameId == "riven") {
-		return Mohawk::MohawkMetaEngine_Riven::registerDefaultSettings();
-	}
-
-	return AdvancedMetaEngineDetection::registerDefaultSettings(target);
 }
 
 REGISTER_PLUGIN_STATIC(MOHAWK_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, MohawkMetaEngineDetection);

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -32,6 +32,8 @@
 #include "mohawk/mohawk.h"
 #include "mohawk/dialogs.h"
 #include "mohawk/livingbooks.h"
+#include "mohawk/riven_metaengine.h"
+#include "mohawk/myst_metaengine.h"
 
 #ifdef ENABLE_CSTIME
 #include "mohawk/cstime.h"
@@ -137,6 +139,8 @@ public:
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
 
+
+	void registerDefaultSettings(const Common::String &target) const override;
 	GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
@@ -301,6 +305,20 @@ Common::Error MohawkMetaEngine::createInstance(OSystem *syst, Engine **engine, c
 	}
 
 	return Common::kNoError;
+}
+
+void MohawkMetaEngine::registerDefaultSettings(const Common::String &target) const {
+	Common::String gameId = ConfMan.get("gameid", target);
+
+	if (gameId == "myst" || gameId == "makingofmyst") {
+		return Mohawk::MohawkMetaEngine_Myst::registerDefaultSettings();
+	}
+
+	if (gameId == "riven") {
+		return Mohawk::MohawkMetaEngine_Riven::registerDefaultSettings();
+	}
+
+	return MetaEngine::registerDefaultSettings(target);
 }
 
 GUI::OptionsContainerWidget *MohawkMetaEngine::buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {

--- a/engines/nancy/detection.cpp
+++ b/engines/nancy/detection.cpp
@@ -246,15 +246,6 @@ public:
 	virtual const DebugChannelDef *getDebugChannels() const override {
 		return debugFlagList;
 	}
-
-	virtual void registerDefaultSettings(const Common::String &target) const override;
 };
-
-void NancyMetaEngineDetection::registerDefaultSettings(const Common::String &target) const {
-	ConfMan.setInt("music_volume", 54 * 255 / 100, target);
-	ConfMan.setInt("speech_volume", 54 * 255 / 100, target);
-	ConfMan.setInt("sfx_volume", 51 * 255 / 100, target);
-	ConfMan.setBool("subtitles", true, target);
-}
 
 REGISTER_PLUGIN_STATIC(NANCY_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, NancyMetaEngineDetection);

--- a/engines/nancy/detection.cpp
+++ b/engines/nancy/detection.cpp
@@ -248,7 +248,6 @@ public:
 	}
 
 	virtual void registerDefaultSettings(const Common::String &target) const override;
-	//virtual GUI::OptionsContainerWidget *buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
 void NancyMetaEngineDetection::registerDefaultSettings(const Common::String &target) const {
@@ -257,11 +256,5 @@ void NancyMetaEngineDetection::registerDefaultSettings(const Common::String &tar
 	ConfMan.setInt("sfx_volume", 51 * 255 / 100, target);
 	ConfMan.setBool("subtitles", true, target);
 }
-
-/*
-GUI::OptionsContainerWidget *NancyMetaEngineDetection::buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
-	return new Nancy::NancyOptionsWidget(boss, name, target);
-}
-*/
 
 REGISTER_PLUGIN_STATIC(NANCY_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, NancyMetaEngineDetection);

--- a/engines/nancy/metaengine.cpp
+++ b/engines/nancy/metaengine.cpp
@@ -39,6 +39,7 @@ public:
 
 	virtual Common::KeymapArray initKeymaps(const char *target) const override;
 
+	virtual void registerDefaultSettings(const Common::String &target) const override;
 	virtual GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
@@ -73,6 +74,13 @@ Common::Error NancyMetaEngine::createInstance(OSystem *syst, Engine **engine, co
 }
 
 int NancyMetaEngine::getMaximumSaveSlot() const { return 8; }
+
+void NancyMetaEngine::registerDefaultSettings(const Common::String &target) const {
+	ConfMan.setInt("music_volume", 54 * 255 / 100, target);
+	ConfMan.setInt("speech_volume", 54 * 255 / 100, target);
+	ConfMan.setInt("sfx_volume", 51 * 255 / 100, target);
+	ConfMan.setBool("subtitles", true, target);
+}
 
 GUI::OptionsContainerWidget *NancyMetaEngine::buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
 	return new Nancy::NancyOptionsWidget(boss, name, target);

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -32,6 +32,7 @@
 #include "gui/widgets/popup.h"
 
 #include "sci/detection.h"
+#include "sci/dialogs.h"
 #include "sci/graphics/helpers_detection_enums.h"
 #include "sci/sci.h"
 
@@ -164,215 +165,9 @@ static const PlainGameDescriptor s_sciGameTitles[] = {
 } // End of namespace Sci
 
 #include "sci/detection_tables.h"
+#include "sci/detection_options.h"
 
 namespace Sci {
-
-static const ADExtraGuiOptionsMap optionsList[] = {
-	{
-		GAMEOPTION_EGA_UNDITHER,
-		{
-			_s("Skip EGA dithering pass (full color backgrounds)"),
-			_s("Skip dithering pass in EGA games, graphics are shown with full colors"),
-			"disable_dithering",
-			false
-		}
-	},
-
-	{
-		GAMEOPTION_HIGH_RESOLUTION_GRAPHICS,
-		{
-			_s("Enable high resolution graphics"),
-			_s("Enable high resolution graphics/content"),
-			"enable_high_resolution_graphics",
-			true
-		}
-	},
-
-	{
-		GAMEOPTION_ENABLE_BLACK_LINED_VIDEO,
-		{
-			_s("Enable black-lined video"),
-			_s("Draw black lines over videos to increase their apparent sharpness"),
-			"enable_black_lined_video",
-			false
-		}
-	},
-
-#ifdef USE_RGB_COLOR
-	{
-		GAMEOPTION_HQ_VIDEO,
-		{
-			_s("Use high-quality video scaling"),
-			_s("Use linear interpolation when upscaling videos, where possible"),
-			"enable_hq_video",
-			true
-		}
-	},
-#endif
-
-	{
-		GAMEOPTION_LARRYSCALE,
-		{
-			_s("Use high-quality \"LarryScale\" cel scaling"),
-			_s("Use special cartoon scaler for drawing character sprites"),
-			"enable_larryscale",
-			true
-		}
-	},
-
-	{
-		GAMEOPTION_PREFER_DIGITAL_SFX,
-		{
-			_s("Prefer digital sound effects"),
-			_s("Prefer digital sound effects instead of synthesized ones"),
-			"prefer_digitalsfx",
-			true
-		}
-	},
-
-	{
-		GAMEOPTION_ORIGINAL_SAVELOAD,
-		{
-			_s("Use original save/load screens"),
-			_s("Use the original save/load screens instead of the ScummVM ones"),
-			"originalsaveload",
-			false
-		}
-	},
-	// Jones in the Fast Lane - CD audio tracks or resource.snd
-	{
-		GAMEOPTION_JONES_CDAUDIO,
-		{
-			_s("Use CD audio"),
-			_s("Use CD audio instead of in-game audio, if available"),
-			"use_cdaudio",
-			true
-		}
-	},
-
-	// KQ5 and KQ6 and SQ4 CD Windows - windows cursors
-	{
-		GAMEOPTION_WINDOWS_CURSORS,
-		{
-			_s("Use Windows cursors"),
-			_s("Use the Windows cursors (smaller and monochrome) instead of the DOS ones"),
-			"windows_cursors",
-			false
-		}
-	},
-
-	// SQ4 CD - silver cursors
-	{
-		GAMEOPTION_SQ4_SILVER_CURSORS,
-		{
-			_s("Use silver cursors"),
-			_s("Use the alternate set of silver cursors instead of the normal golden ones"),
-			"silver_cursors",
-			false
-		}
-	},
-
-	// Phantasmagoria 2 - content censoring option
-	{
-		GAMEOPTION_ENABLE_CENSORING,
-		{
-			_s("Enable content censoring"),
-			_s("Enable the game's built-in optional content censoring"),
-			"enable_censoring",
-			false
-		}
-	},
-
-	// KQ7 - Upscale videos to double their size (The in-game "Full screen" video setting)
-	{
-		GAMEOPTION_UPSCALE_VIDEOS,
-		{
-			_s("Upscale videos"),
-			_s("Upscale videos to double their size"),
-			"enable_video_upscale",
-			true
-		}
-	},
-
-	// SCI16 games: use RGB renderer instead of indexed
-	{
-		GAMEOPTION_RGB_RENDERING,
-		{
-			_s("Use RGB rendering"),
-			_s("Use RGB rendering to improve screen transitions"),
-			"rgb_rendering",
-			false
-		}
-	},
-
-	// SCI16 games: use custom per-resource palettes to improve visuals
-	{
-		GAMEOPTION_PALETTE_MODS,
-		{
-			_s("Use per-resource modified palettes"),
-			_s("Use custom per-resource palettes to improve visuals"),
-			"palette_mods",
-			false
-		}
-	},
-
-	// SQ1: Enable graphics that were disabled for legal reasons
-	{
-		GAMEOPTION_SQ1_BEARDED_MUSICIANS,
-		{
-			_s("Enable bearded musicians"),
-			_s("Enable graphics that were disabled for legal reasons"),
-			"enable_bearded_musicians",
-			false
-		}
-	},
-
-	AD_EXTRA_GUI_OPTIONS_TERMINATOR
-};
-
-struct PopUpOptionsItem {
-	const char *label;
-	int configValue;
-};
-
-#define POPUP_OPTIONS_ITEMS_TERMINATOR { nullptr, 0 }
-
-struct PopUpOptionsMap {
-	const char *guioFlag;
-	const char *label;
-	const char *tooltip;
-	const char *configOption;
-	int defaultState;
-	PopUpOptionsItem items[10];
-};
-
-#define POPUP_OPTIONS_TERMINATOR { nullptr, nullptr, nullptr, nullptr, 0, { POPUP_OPTIONS_ITEMS_TERMINATOR } }
-
-static const PopUpOptionsMap popUpOptionsList[] = {
-	{
-		GAMEOPTION_MIDI_MODE,
-		_s("MIDI mode:"),
-		_s("When using external MIDI devices (e.g. through USB-MIDI), select your device here"),
-		"midi_mode",
-		kMidiModeStandard,
-		{
-			{
-				_s("Standard (GM / MT-32)"),
-				kMidiModeStandard
-			},
-			{
-				_s("Roland D-110 / D-10 / D-20"),
-				kMidiModeD110
-			},
-			{
-				_s("Yamaha FB-01"),
-				kMidiModeFB01
-			},
-			POPUP_OPTIONS_ITEMS_TERMINATOR
-		}
-	},
-	POPUP_OPTIONS_TERMINATOR
-};
 
 static const char *directoryGlobs[] = {
 	"avi",
@@ -385,88 +180,6 @@ static const char *directoryGlobs[] = {
 	"patches",
 	0
 };
-
-class OptionsWidget : public GUI::OptionsContainerWidget {
-public:
-	explicit OptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
-
-	// OptionsContainerWidget API
-	void load() override;
-	bool save() override;
-
-private:
-	// OptionsContainerWidget API
-	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
-
-	Common::String _guiOptions;
-	Common::HashMap<Common::String, GUI::CheckboxWidget *> _checkboxes;
-	Common::HashMap<Common::String, GUI::PopUpWidget *> _popUps;
-};
-
-OptionsWidget::OptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain) :
-		OptionsContainerWidget(boss, name, "SciGameOptionsDialog", false, domain) {
-	_guiOptions = ConfMan.get("guioptions", domain);
-
-	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
-		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
-			_checkboxes[entry->option.configOption] = new GUI::CheckboxWidget(widgetsBoss(), _dialogLayout + "." + entry->option.configOption, _(entry->option.label), _(entry->option.tooltip));
-
-	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
-		if (checkGameGUIOption(entry->guioFlag, _guiOptions)) {
-			GUI::StaticTextWidget *textWidget = new GUI::StaticTextWidget(widgetsBoss(), _dialogLayout + "." + entry->configOption + "_desc", _(entry->label), _(entry->tooltip));
-			textWidget->setAlign(Graphics::kTextAlignRight);
-
-			_popUps[entry->configOption] = new GUI::PopUpWidget(widgetsBoss(), _dialogLayout + "." + entry->configOption);
-
-			for (uint i = 0; entry->items[i].label; ++i)
-				_popUps[entry->configOption]->appendEntry(_(entry->items[i].label), entry->items[i].configValue);
-		}
-}
-
-void OptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const {
-	layouts.addDialog(layoutName, overlayedLayout);
-	layouts.addLayout(GUI::ThemeLayout::kLayoutVertical).addPadding(16, 16, 16, 16);
-
-	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
-		layouts.addWidget(entry->option.configOption, "Checkbox");
-
-	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry) {
-		layouts.addLayout(GUI::ThemeLayout::kLayoutHorizontal).addPadding(0, 0, 0, 0);
-		layouts.addWidget(Common::String(entry->configOption) + "_desc", "OptionsLabel");
-		layouts.addWidget(entry->configOption, "PopUp").closeLayout();
-	}
-
-	layouts.closeLayout().closeDialog();
-}
-
-void OptionsWidget::load() {
-	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
-		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
-			_checkboxes[entry->option.configOption]->setState(ConfMan.getBool(entry->option.configOption, _domain));
-
-	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
-		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
-			_popUps[entry->configOption]->setSelectedTag(ConfMan.getInt(entry->configOption, _domain));
-
-	// If the deprecated native_fb01 option is set, use it to set midi_mode
-	if (ConfMan.hasKey("native_fb01", _domain) && ConfMan.getBool("native_fb01", _domain))
-		_popUps["midi_mode"]->setSelectedTag(kMidiModeFB01);
-}
-
-bool OptionsWidget::save() {
-	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
-		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
-			ConfMan.setBool(entry->option.configOption, _checkboxes[entry->option.configOption]->getState(), _domain);
-
-	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
-		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
-			ConfMan.setInt(entry->configOption, _popUps[entry->configOption]->getSelectedTag(), _domain);
-
-	// Remove deprecated option
-	ConfMan.removeKey("native_fb01", _domain);
-
-	return true;
-}
 
 class SciMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
@@ -500,7 +213,6 @@ public:
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra) const override;
 	void registerDefaultSettings(const Common::String &target) const override;
-	GUI::OptionsContainerWidget *buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
 void SciMetaEngineDetection::registerDefaultSettings(const Common::String &target) const {
@@ -508,10 +220,6 @@ void SciMetaEngineDetection::registerDefaultSettings(const Common::String &targe
 
 	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
 		ConfMan.registerDefault(entry->configOption, entry->defaultState);
-}
-
-GUI::OptionsContainerWidget *SciMetaEngineDetection::buildEngineOptionsWidgetStatic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
-	return new OptionsWidget(boss, name, target);
 }
 
 ADDetectedGame SciMetaEngineDetection::fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra) const {

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -165,7 +165,6 @@ static const PlainGameDescriptor s_sciGameTitles[] = {
 } // End of namespace Sci
 
 #include "sci/detection_tables.h"
-#include "sci/detection_options.h"
 
 namespace Sci {
 
@@ -183,7 +182,7 @@ static const char *directoryGlobs[] = {
 
 class SciMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	SciMetaEngineDetection() : AdvancedMetaEngineDetection(Sci::SciGameDescriptions, sizeof(ADGameDescription), s_sciGameTitles, optionsList) {
+	SciMetaEngineDetection() : AdvancedMetaEngineDetection(Sci::SciGameDescriptions, sizeof(ADGameDescription), s_sciGameTitles) {
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 		_matchFullPaths = true;
@@ -212,15 +211,7 @@ public:
 	}
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra) const override;
-	void registerDefaultSettings(const Common::String &target) const override;
 };
-
-void SciMetaEngineDetection::registerDefaultSettings(const Common::String &target) const {
-	AdvancedMetaEngineDetection::registerDefaultSettings(target);
-
-	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
-		ConfMan.registerDefault(entry->configOption, entry->defaultState);
-}
 
 ADDetectedGame SciMetaEngineDetection::fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra) const {
 	/**

--- a/engines/sci/detection_options.h
+++ b/engines/sci/detection_options.h
@@ -1,0 +1,219 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef SCI_DETECTION_OPTIONS_H
+#define SCI_DETECTION_OPTIONS_H
+
+namespace Sci {
+
+const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_EGA_UNDITHER,
+		{
+			_s("Skip EGA dithering pass (full color backgrounds)"),
+			_s("Skip dithering pass in EGA games, graphics are shown with full colors"),
+			"disable_dithering",
+			false
+		}
+	},
+
+	{
+		GAMEOPTION_HIGH_RESOLUTION_GRAPHICS,
+		{
+			_s("Enable high resolution graphics"),
+			_s("Enable high resolution graphics/content"),
+			"enable_high_resolution_graphics",
+			true
+		}
+	},
+
+	{
+		GAMEOPTION_ENABLE_BLACK_LINED_VIDEO,
+		{
+			_s("Enable black-lined video"),
+			_s("Draw black lines over videos to increase their apparent sharpness"),
+			"enable_black_lined_video",
+			false
+		}
+	},
+
+#ifdef USE_RGB_COLOR
+	{
+		GAMEOPTION_HQ_VIDEO,
+		{
+			_s("Use high-quality video scaling"),
+			_s("Use linear interpolation when upscaling videos, where possible"),
+			"enable_hq_video",
+			true
+		}
+	},
+#endif
+
+	{
+		GAMEOPTION_LARRYSCALE,
+		{
+			_s("Use high-quality \"LarryScale\" cel scaling"),
+			_s("Use special cartoon scaler for drawing character sprites"),
+			"enable_larryscale",
+			true
+		}
+	},
+
+	{
+		GAMEOPTION_PREFER_DIGITAL_SFX,
+		{
+			_s("Prefer digital sound effects"),
+			_s("Prefer digital sound effects instead of synthesized ones"),
+			"prefer_digitalsfx",
+			true
+		}
+	},
+
+	{
+		GAMEOPTION_ORIGINAL_SAVELOAD,
+		{
+			_s("Use original save/load screens"),
+			_s("Use the original save/load screens instead of the ScummVM ones"),
+			"originalsaveload",
+			false
+		}
+	},
+	// Jones in the Fast Lane - CD audio tracks or resource.snd
+	{
+		GAMEOPTION_JONES_CDAUDIO,
+		{
+			_s("Use CD audio"),
+			_s("Use CD audio instead of in-game audio, if available"),
+			"use_cdaudio",
+			true
+		}
+	},
+
+	// KQ5 and KQ6 and SQ4 CD Windows - windows cursors
+	{
+		GAMEOPTION_WINDOWS_CURSORS,
+		{
+			_s("Use Windows cursors"),
+			_s("Use the Windows cursors (smaller and monochrome) instead of the DOS ones"),
+			"windows_cursors",
+			false
+		}
+	},
+
+	// SQ4 CD - silver cursors
+	{
+		GAMEOPTION_SQ4_SILVER_CURSORS,
+		{
+			_s("Use silver cursors"),
+			_s("Use the alternate set of silver cursors instead of the normal golden ones"),
+			"silver_cursors",
+			false
+		}
+	},
+
+	// Phantasmagoria 2 - content censoring option
+	{
+		GAMEOPTION_ENABLE_CENSORING,
+		{
+			_s("Enable content censoring"),
+			_s("Enable the game's built-in optional content censoring"),
+			"enable_censoring",
+			false
+		}
+	},
+
+	// KQ7 - Upscale videos to double their size (The in-game "Full screen" video setting)
+	{
+		GAMEOPTION_UPSCALE_VIDEOS,
+		{
+			_s("Upscale videos"),
+			_s("Upscale videos to double their size"),
+			"enable_video_upscale",
+			true
+		}
+	},
+
+	// SCI16 games: use RGB renderer instead of indexed
+	{
+		GAMEOPTION_RGB_RENDERING,
+		{
+			_s("Use RGB rendering"),
+			_s("Use RGB rendering to improve screen transitions"),
+			"rgb_rendering",
+			false
+		}
+	},
+
+	// SCI16 games: use custom per-resource palettes to improve visuals
+	{
+		GAMEOPTION_PALETTE_MODS,
+		{
+			_s("Use per-resource modified palettes"),
+			_s("Use custom per-resource palettes to improve visuals"),
+			"palette_mods",
+			false
+		}
+	},
+
+	// SQ1: Enable graphics that were disabled for legal reasons
+	{
+		GAMEOPTION_SQ1_BEARDED_MUSICIANS,
+		{
+			_s("Enable bearded musicians"),
+			_s("Enable graphics that were disabled for legal reasons"),
+			"enable_bearded_musicians",
+			false
+		}
+	},
+
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
+const PopUpOptionsMap popUpOptionsList[] = {
+	{
+		GAMEOPTION_MIDI_MODE,
+		_s("MIDI mode:"),
+		_s("When using external MIDI devices (e.g. through USB-MIDI), select your device here"),
+		"midi_mode",
+		kMidiModeStandard,
+		{
+			{
+				_s("Standard (GM / MT-32)"),
+				kMidiModeStandard
+			},
+			{
+				_s("Roland D-110 / D-10 / D-20"),
+				kMidiModeD110
+			},
+			{
+				_s("Yamaha FB-01"),
+				kMidiModeFB01
+			},
+			POPUP_OPTIONS_ITEMS_TERMINATOR
+		}
+	},
+	POPUP_OPTIONS_TERMINATOR
+};
+
+} // End of namespace Sci
+
+#endif

--- a/engines/sci/dialogs.cpp
+++ b/engines/sci/dialogs.cpp
@@ -31,13 +31,7 @@
 #include "sci/dialogs.h"
 #include "sci/sci.h"
 
-/**
- * When detection is compiled dynamically, options end up in detection plugin and
- * engine cannot link to them so duplicate them in the engine in this case
- */
-#ifndef DETECTION_STATIC
 #include "sci/detection_options.h"
-#endif
 
 namespace Sci {
 

--- a/engines/sci/dialogs.cpp
+++ b/engines/sci/dialogs.cpp
@@ -1,0 +1,109 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "engines/advancedDetector.h"
+#include "base/plugins.h"
+#include "common/file.h"
+#include "common/hashmap.h"
+#include "common/ptr.h"
+#include "common/translation.h"
+
+#include "sci/detection.h"
+#include "sci/dialogs.h"
+#include "sci/sci.h"
+
+/**
+ * When detection is compiled dynamically, options end up in detection plugin and
+ * engine cannot link to them so duplicate them in the engine in this case
+ */
+#ifndef DETECTION_STATIC
+#include "sci/detection_options.h"
+#endif
+
+namespace Sci {
+
+OptionsWidget::OptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain) :
+		OptionsContainerWidget(boss, name, "SciGameOptionsDialog", false, domain) {
+	_guiOptions = ConfMan.get("guioptions", domain);
+
+	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
+		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
+			_checkboxes[entry->option.configOption] = new GUI::CheckboxWidget(widgetsBoss(), _dialogLayout + "." + entry->option.configOption, _(entry->option.label), _(entry->option.tooltip));
+
+	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
+		if (checkGameGUIOption(entry->guioFlag, _guiOptions)) {
+			GUI::StaticTextWidget *textWidget = new GUI::StaticTextWidget(widgetsBoss(), _dialogLayout + "." + entry->configOption + "_desc", _(entry->label), _(entry->tooltip));
+			textWidget->setAlign(Graphics::kTextAlignRight);
+
+			_popUps[entry->configOption] = new GUI::PopUpWidget(widgetsBoss(), _dialogLayout + "." + entry->configOption);
+
+			for (uint i = 0; entry->items[i].label; ++i)
+				_popUps[entry->configOption]->appendEntry(_(entry->items[i].label), entry->items[i].configValue);
+		}
+}
+
+void OptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const {
+	layouts.addDialog(layoutName, overlayedLayout);
+	layouts.addLayout(GUI::ThemeLayout::kLayoutVertical).addPadding(16, 16, 16, 16);
+
+	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
+		layouts.addWidget(entry->option.configOption, "Checkbox");
+
+	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry) {
+		layouts.addLayout(GUI::ThemeLayout::kLayoutHorizontal).addPadding(0, 0, 0, 0);
+		layouts.addWidget(Common::String(entry->configOption) + "_desc", "OptionsLabel");
+		layouts.addWidget(entry->configOption, "PopUp").closeLayout();
+	}
+
+	layouts.closeLayout().closeDialog();
+}
+
+void OptionsWidget::load() {
+	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
+		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
+			_checkboxes[entry->option.configOption]->setState(ConfMan.getBool(entry->option.configOption, _domain));
+
+	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
+		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
+			_popUps[entry->configOption]->setSelectedTag(ConfMan.getInt(entry->configOption, _domain));
+
+	// If the deprecated native_fb01 option is set, use it to set midi_mode
+	if (ConfMan.hasKey("native_fb01", _domain) && ConfMan.getBool("native_fb01", _domain))
+		_popUps["midi_mode"]->setSelectedTag(kMidiModeFB01);
+}
+
+bool OptionsWidget::save() {
+	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
+		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
+			ConfMan.setBool(entry->option.configOption, _checkboxes[entry->option.configOption]->getState(), _domain);
+
+	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
+		if (checkGameGUIOption(entry->guioFlag, _guiOptions))
+			ConfMan.setInt(entry->configOption, _popUps[entry->configOption]->getSelectedTag(), _domain);
+
+	// Remove deprecated option
+	ConfMan.removeKey("native_fb01", _domain);
+
+	return true;
+}
+
+} // End of namespace Sci

--- a/engines/sci/dialogs.h
+++ b/engines/sci/dialogs.h
@@ -1,0 +1,72 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef SCI_DIALOGS_H
+#define SCI_DIALOGS_H
+
+#include "gui/ThemeEval.h"
+#include "gui/widget.h"
+#include "gui/widgets/popup.h"
+
+namespace Sci {
+
+struct PopUpOptionsItem {
+	const char *label;
+	int configValue;
+};
+
+#define POPUP_OPTIONS_ITEMS_TERMINATOR { nullptr, 0 }
+
+struct PopUpOptionsMap {
+	const char *guioFlag;
+	const char *label;
+	const char *tooltip;
+	const char *configOption;
+	int defaultState;
+	PopUpOptionsItem items[10];
+};
+
+#define POPUP_OPTIONS_TERMINATOR { nullptr, nullptr, nullptr, nullptr, 0, { POPUP_OPTIONS_ITEMS_TERMINATOR } }
+
+class OptionsWidget : public GUI::OptionsContainerWidget {
+public:
+	explicit OptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
+
+	// OptionsContainerWidget API
+	void load() override;
+	bool save() override;
+
+private:
+	// OptionsContainerWidget API
+	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
+
+	Common::String _guiOptions;
+	Common::HashMap<Common::String, GUI::CheckboxWidget *> _checkboxes;
+	Common::HashMap<Common::String, GUI::PopUpWidget *> _popUps;
+};
+
+extern const ADExtraGuiOptionsMap optionsList[];
+extern const PopUpOptionsMap popUpOptionsList[];
+
+} // End of namespace Sci
+
+#endif // SCI_DIALOGS_H

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -284,6 +284,7 @@ public:
 	// here fb detection has many engine dependencies.
 	virtual ADDetectedGame fallbackDetectExtern(uint md5Bytes, const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra) const override;
 
+	void registerDefaultSettings(const Common::String &target) const override;
 	GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
@@ -706,6 +707,14 @@ ADDetectedGame SciMetaEngine::fallbackDetectExtern(uint md5Bytes, const FileMap 
 	constructFallbackDetectionEntry(gameId, platform, sciVersion, language, gameViews == kViewEga, isCD, isDemo);
 
 	return ADDetectedGame(&s_fallbackDesc);
+}
+
+void SciMetaEngine::registerDefaultSettings(const Common::String &target) const {
+	for (const ADExtraGuiOptionsMap *entry = optionsList; entry->guioFlag; ++entry)
+		ConfMan.registerDefault(entry->option.configOption, entry->option.defaultState);
+
+	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
+		ConfMan.registerDefault(entry->configOption, entry->defaultState);
 }
 
 GUI::OptionsContainerWidget *SciMetaEngine::buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -32,6 +32,7 @@
 #include "graphics/surface.h"
 
 #include "sci/sci.h"
+#include "sci/dialogs.h"
 #include "sci/engine/kernel.h"
 #include "sci/engine/savegame.h"
 #include "sci/engine/script.h"
@@ -282,6 +283,8 @@ public:
 	// A fallback detection method. This is not ideal as all detection lives in MetaEngine, but
 	// here fb detection has many engine dependencies.
 	virtual ADDetectedGame fallbackDetectExtern(uint md5Bytes, const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra) const override;
+
+	GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 };
 
 Common::Error SciMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
@@ -703,6 +706,10 @@ ADDetectedGame SciMetaEngine::fallbackDetectExtern(uint md5Bytes, const FileMap 
 	constructFallbackDetectionEntry(gameId, platform, sciVersion, language, gameViews == kViewEga, isCD, isDemo);
 
 	return ADDetectedGame(&s_fallbackDesc);
+}
+
+GUI::OptionsContainerWidget *SciMetaEngine::buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
+	return new OptionsWidget(boss, name, target);
 }
 
 } // End of namespace Sci

--- a/engines/sci/module.mk
+++ b/engines/sci/module.mk
@@ -2,6 +2,7 @@ MODULE := engines/sci
 
 MODULE_OBJS := \
 	console.o \
+	dialogs.o \
 	event.o \
 	metaengine.o \
 	sci.o \

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -192,8 +192,10 @@ EditGameDialog::EditGameDialog(const String &domain)
 
 		const MetaEngineDetection &metaEngineDetection = metaEnginePlugin->get<MetaEngineDetection>();
 		metaEngineDetection.registerDefaultSettings(_domain);
-		if (enginePlugin)
+		if (enginePlugin) {
+			enginePlugin->get<MetaEngine>().registerDefaultSettings(_domain);
 			_engineOptions = enginePlugin->get<MetaEngine>().buildEngineOptionsWidgetDynamic(tab, "GameOptions_Engine.Container", _domain);
+		}
 		if (!_engineOptions)
 			_engineOptions = metaEngineDetection.buildEngineOptionsWidgetStatic(tab, "GameOptions_Engine.Container", _domain);
 


### PR DESCRIPTION
This should slightly reduce the size of the detection plugin, and serves as a step towards fixing [Trac #12345](https://bugs.scummvm.org/ticket/12345).