### PR TITLE
AGS: Change a few char variables to int8

### DIFF
--- a/engines/ags/engine/ac/character_extras.h
+++ b/engines/ags/engine/ac/character_extras.h
@@ -52,8 +52,8 @@ struct CharacterExtras {
 	short tint_b;
 	short tint_level;
 	short tint_light;
-	char  process_idle_this_time;
-	char  slow_move_counter;
+	int8  process_idle_this_time;
+	int8  slow_move_counter;
 	short animwait;
 
 	void ReadFromFile(Shared::Stream *in);

--- a/engines/ags/engine/ac/dialog.cpp
+++ b/engines/ags/engine/ac/dialog.cpp
@@ -309,7 +309,7 @@ int run_dialog_script(DialogTopic *dtpp, int dialogID, int offse, int optionInde
 }
 
 int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, int numdisp, int mouseison, int areawid,
-                         int bullet_wid, int usingfont, DialogTopic *dtop, char *disporder, short *dispyp,
+                         int bullet_wid, int usingfont, DialogTopic *dtop, int8 *disporder, short *dispyp,
                          int linespacing, int utextcol, int padding) {
 	int ww;
 
@@ -412,7 +412,7 @@ struct DialogOptions {
 	GUITextBox *parserInput;
 	DialogTopic *dtop;
 
-	char disporder[MAXTOPICOPTIONS];
+	int8 disporder[MAXTOPICOPTIONS];
 	short dispyp[MAXTOPICOPTIONS];
 
 	int numdisp;

--- a/engines/ags/engine/ac/game_state.h
+++ b/engines/ags/engine/ac/game_state.h
@@ -158,7 +158,7 @@ struct GameState {
 	int   bg_frame = 0, bg_anim_delay = 0;  // for animating backgrounds
 	int   music_vol_was = 0;  // before the volume drop
 	short wait_counter = 0;
-	char  wait_skipped_by = 0; // tells how last blocking wait was skipped [not serialized]
+	int8  wait_skipped_by = 0; // tells how last blocking wait was skipped [not serialized]
 	int   wait_skipped_by_data = 0; // extended data telling how last blocking wait was skipped [not serialized]
 	short mboundx1 = 0, mboundx2 = 0, mboundy1 = 0, mboundy2 = 0;
 	int   fade_effect = 0;
@@ -175,7 +175,7 @@ struct GameState {
 	int32_t   script_timers[MAX_TIMERS];
 	int   sound_volume = 0, speech_volume = 0;
 	int   normal_font = 0, speech_font = 0;
-	char  key_skip_wait = 0;
+	int8  key_skip_wait = 0;
 	int   swap_portrait_lastchar = 0;
 	int   swap_portrait_lastlastchar = 0;
 	int   separate_music_lib = 0;

--- a/engines/ags/engine/ac/global_api.cpp
+++ b/engines/ags/engine/ac/global_api.cpp
@@ -374,7 +374,7 @@ RuntimeScriptValue Sc_FileReadInt(const RuntimeScriptValue *params, int32_t para
 	API_SCALL_INT_PINT(FileReadInt);
 }
 
-// char (int handle)
+// int8 (int handle)
 RuntimeScriptValue Sc_FileReadRawChar(const RuntimeScriptValue *params, int32_t param_count) {
 	API_SCALL_INT_PINT(FileReadRawChar);
 }

--- a/engines/ags/engine/ac/global_file.cpp
+++ b/engines/ags/engine/ac/global_file.cpp
@@ -167,7 +167,7 @@ int FileReadInt(int32_t handle) {
 	return in->ReadInt32();
 }
 
-char FileReadRawChar(int32_t handle) {
+int8 FileReadRawChar(int32_t handle) {
 	Stream *in = get_valid_file_stream_from_handle(handle, "FileReadRawChar");
 	if (in->EOS())
 		return -1;

--- a/engines/ags/engine/ac/global_file.h
+++ b/engines/ags/engine/ac/global_file.h
@@ -46,7 +46,7 @@ int   FileIsEOF(int32_t handle);
 int   FileIsError(int32_t handle);
 void  FileWriteInt(int32_t handle, int into);
 int   FileReadInt(int32_t handle);
-char  FileReadRawChar(int32_t handle);
+int8  FileReadRawChar(int32_t handle);
 int   FileReadRawInt(int32_t handle);
 void  FileWriteRawChar(int32_t handle, int chartoWrite);
 

--- a/engines/ags/engine/ac/move_list.h
+++ b/engines/ags/engine/ac/move_list.h
@@ -46,8 +46,8 @@ struct MoveList {
 	int   fromx, fromy;
 	int   onstage, onpart;
 	int   lastx, lasty;
-	char  doneflag;
-	char  direct;  // MoveCharDirect was used or not
+	int8  doneflag;
+	int8  direct;  // MoveCharDirect was used or not
 
 	void ReadFromFile_Legacy(Shared::Stream *in);
 	AGS::Engine::HSaveError ReadFromFile(Shared::Stream *in, int32_t cmp_ver);

--- a/engines/ags/engine/ac/parser.cpp
+++ b/engines/ags/engine/ac/parser.cpp
@@ -148,7 +148,7 @@ int FindMatchingMultiWordWord(char *thisword, const char **text) {
 int parse_sentence(const char *src_text, int *numwords, short *wordarray, short *compareto, int comparetonum) {
 	char thisword[150] = "\0";
 	int  i = 0, comparing = 0;
-	char in_optional = 0, do_word_now = 0;
+	int8 in_optional = 0, do_word_now = 0;
 	int  optional_start = 0;
 
 	numwords[0] = 0;

--- a/engines/ags/engine/ac/room_object.h
+++ b/engines/ags/engine/ac/room_object.h
@@ -57,10 +57,10 @@ struct RoomObject {
 	short baseline;       // <=0 to use Y co-ordinate; >0 for specific baseline
 	uint16_t view, loop, frame; // only used to track animation - 'num' holds the current sprite
 	short wait, moving;
-	char  cycling;        // is it currently animating?
-	char  overall_speed;
-	char  on;
-	char  flags;
+	int8  cycling;        // is it currently animating?
+	int8  overall_speed;
+	int8  on;
+	int8  flags;
 	short blocking_width, blocking_height;
 
 	RoomObject();

--- a/engines/ags/engine/ac/room_status.h
+++ b/engines/ags/engine/ac/room_status.h
@@ -63,8 +63,8 @@ struct RoomStatus {
 	EventBlock objcond[MAX_ROOM_OBJECTS];
 	EventBlock misccond;
 #endif
-	char  hotspot_enabled[MAX_ROOM_HOTSPOTS];
-	char  region_enabled[MAX_ROOM_REGIONS];
+	int8  hotspot_enabled[MAX_ROOM_HOTSPOTS];
+	int8  region_enabled[MAX_ROOM_REGIONS];
 	short walkbehind_base[MAX_WALK_BEHINDS];
 	int32_t interactionVariableValues[MAX_GLOBAL_VARIABLES];
 

--- a/engines/ags/engine/gui/new_control.h
+++ b/engines/ags/engine/gui/new_control.h
@@ -31,8 +31,8 @@ using namespace AGS; // FIXME later
 
 struct NewControl {
 	int x, y, wid, hit, state, typeandflags, wlevel;
-	char visible, enabled;        // not implemented
-	char needredraw;
+	int8 visible, enabled;        // not implemented
+	int8 needredraw;
 	virtual void draw(Shared::Bitmap *ds) = 0;
 	virtual int pressedon(int mousex, int mousey) = 0;
 	virtual int processmessage(int, int, NumberPtr) = 0;

--- a/engines/ags/engine/main/game_run.cpp
+++ b/engines/ags/engine/main/game_run.cpp
@@ -945,7 +945,7 @@ static void GameLoopUntilEvent(int untilwhat, const void *daaa) {
 	_G(user_disabled_for) = cached_user_disabled_for;
 }
 
-void GameLoopUntilValueIsZero(const char *value) {
+void GameLoopUntilValueIsZero(const int8 *value) {
 	GameLoopUntilEvent(UNTIL_CHARIS0, value);
 }
 

--- a/engines/ags/engine/main/game_run.h
+++ b/engines/ags/engine/main/game_run.h
@@ -33,7 +33,7 @@ class IDriverDependantBitmap;
 using namespace AGS::Engine; // FIXME later
 
 // Loops game frames until certain event takes place (for blocking actions)
-void GameLoopUntilValueIsZero(const char *value);
+void GameLoopUntilValueIsZero(const int8 *value);
 void GameLoopUntilValueIsZero(const short *value);
 void GameLoopUntilValueIsZero(const int *value);
 void GameLoopUntilValueIsZeroOrLess(const short *move);

--- a/engines/ags/engine/script/executing_script.h
+++ b/engines/ags/engine/script/executing_script.h
@@ -68,7 +68,7 @@ struct ExecutingScript {
 	int  numPostScriptActions;
 	QueuedScript ScFnQueue[MAX_QUEUED_SCRIPTS];
 	int  numanother;
-	char forked;
+	int8 forked;
 
 	int queue_action(PostScriptAction act, int data, const char *aname);
 	void run_another(const char *namm, ScriptInstType scinst, size_t param_count, const RuntimeScriptValue &p1, const RuntimeScriptValue &p2);

--- a/engines/ags/globals.h
+++ b/engines/ags/globals.h
@@ -1106,21 +1106,21 @@ public:
 	 * @{
 	 */
 
-	char _currentcursor = 0;
+	int8 _currentcursor = 0;
 	// virtual mouse cursor coordinates
 	int _mousex = 0, _mousey = 0, _numcurso = -1, _hotx = 0, _hoty = 0;
 	// real mouse coordinates and bounds
 	int _real_mouse_x = 0, _real_mouse_y = 0;
 	int _boundx1 = 0, _boundx2 = 99999, _boundy1 = 0, _boundy2 = 99999;
 	int _disable_mgetgraphpos = 0;
-	char _ignore_bounds = 0;
+	int8 _ignore_bounds = 0;
 	AGS::Shared::Bitmap *_mousecurs[MAXCURSORS];
 
 	ScriptMouse *_scmouse;
 	int _cur_mode = 0, _cur_cursor = 0;
 	int _mouse_frame = 0, _mouse_delay = 0;
 	int _lastmx = -1, _lastmy = -1;
-	char _alpha_blend_cursor = 0;
+	int8 _alpha_blend_cursor = 0;
 	AGS::Shared::Bitmap *_dotted_mouse_cursor = nullptr;
 	AGS::Engine::IDriverDependantBitmap *_mouseCursor = nullptr;
 	AGS::Shared::Bitmap *_blank_mouse_cursor = nullptr;
@@ -1359,7 +1359,7 @@ public:
 
 	char *_walkBehindExists = nullptr;  // whether a WB area is in this column
 	int *_walkBehindStartY = nullptr, *_walkBehindEndY = nullptr;
-	char _noWalkBehindsAtAll = 0;
+	int8 _noWalkBehindsAtAll = 0;
 	int _walkBehindLeft[MAX_WALK_BEHINDS], _walkBehindTop[MAX_WALK_BEHINDS];
 	int _walkBehindRight[MAX_WALK_BEHINDS], _walkBehindBottom[MAX_WALK_BEHINDS];
 	AGS::Engine::IDriverDependantBitmap *_walkBehindBitmap[MAX_WALK_BEHINDS];

--- a/engines/ags/plugins/ags_pal_render/ags_pal_render.cpp
+++ b/engines/ags/plugins/ags_pal_render/ags_pal_render.cpp
@@ -88,13 +88,13 @@ BITMAP *rcolormap;
 BITMAP *ralphamap;
 
 struct charrefopt {
-	char reflect;
+	int8 reflect;
 	int replaceview;
 };
 
 struct objrefopt {
-	char reflect;
-	char ignorescaling;
+	int8 reflect;
+	int8 ignorescaling;
 };
 
 struct reflectionopt {

--- a/engines/ags/plugins/ags_plugin.h
+++ b/engines/ags/plugins/ags_plugin.h
@@ -155,7 +155,7 @@ struct AGSCharacter {
 	short actx = 0, acty = 0;
 	char  name[40];
 	char  scrname[20];
-	char  on = 0;
+	int8  on = 0;
 };
 
 // AGSObject.flags
@@ -170,10 +170,10 @@ struct AGSObject {
 	short baseline = 0;       // <=0 to use Y co-ordinate; >0 for specific baseline
 	short view = 0, loop = 0, frame = 0; // only used to track animation - 'num' holds the current sprite
 	short wait = 0, moving = 0;
-	char  cycling = 0;        // is it currently animating?
-	char  overall_speed = 0;
-	char  on = 0;
-	char  flags = 0;
+	int8  cycling = 0;        // is it currently animating?
+	int8  overall_speed = 0;
+	int8  on = 0;
+	int8  flags = 0;
 };
 
 // AGSViewFrame.flags
@@ -199,7 +199,7 @@ struct AGSMouseCursor {
 	short hotx = 0, hoty = 0; // x,y hotspot co-ordinates
 	short view = 0;           // view (for animating cursors) or -1
 	char  name[10];           // name of cursor mode
-	char  flags = 0;          // MCF_flags above
+	int8  flags = 0;          // MCF_flags above
 };
 
 // The editor-to-plugin interface

--- a/engines/ags/shared/ac/character_info.h
+++ b/engines/ags/shared/ac/character_info.h
@@ -98,7 +98,7 @@ struct CharacterInfo {
 	short actx, acty;
 	char  name[40];
 	char  scrname[MAX_SCRIPT_NAME_LEN];
-	char  on;
+	int8  on;
 
 	int get_effective_y();   // return Y - Z
 	int get_baseline();      // return baseline, or Y if not set
@@ -154,7 +154,7 @@ struct OldCharacterInfo {
 	short actx, acty;
 	char  name[30];
 	char  scrname[16];
-	char  on;
+	int8  on;
 };
 
 #define COPY_CHAR_VAR(name) ci->name = oci->name

--- a/engines/ags/shared/ac/dynobj/script_audio_clip.h
+++ b/engines/ags/shared/ac/dynobj/script_audio_clip.h
@@ -54,10 +54,10 @@ struct ScriptAudioClip {
 	int id = 0;
 	Shared::String scriptName;
 	Shared::String fileName;
-	char bundlingType = AUCL_BUNDLE_EXE;
+	int8 bundlingType = AUCL_BUNDLE_EXE;
 	int8 type = 0;
-	char fileType = eAudioFileOGG;
-	char defaultRepeat = 0;
+	int8 fileType = eAudioFileOGG;
+	int8 defaultRepeat = 0;
 	short defaultPriority = 50;
 	short defaultVolume = 100;
 

--- a/engines/ags/shared/ac/game_struct_defines.h
+++ b/engines/ags/shared/ac/game_struct_defines.h
@@ -239,7 +239,7 @@ struct FontInfo {
 	// Factor to multiply base font size by
 	int           SizeMultiplier = 0;
 	// Outlining font index, or auto-outline flag
-	char          Outline = 0;
+	int8          Outline = 0;
 	// Custom vertical render offset, used mainly for fixing broken fonts
 	int           YOffset = 0;
 	// custom line spacing between two lines of text (0 = use font height)

--- a/engines/ags/shared/ac/interface_button.h
+++ b/engines/ags/shared/ac/interface_button.h
@@ -23,6 +23,8 @@
 #ifndef AGS_SHARED_AC_INTERFACE_BUTTON_H
 #define AGS_SHARED_AC_INTERFACE_BUTTON_H
 
+#include "ags/shared/core/types.h"
+
 namespace AGS3 {
 
 #define MAXBUTTON       20
@@ -33,7 +35,7 @@ struct InterfaceButton {
 	int x, y, pic, overpic, pushpic, leftclick;
 	int rightclick; // if inv, then leftclick = wid, rightclick = hit
 	int reserved_for_future;
-	char flags;
+	int8 flags;
 	void set(int xx, int yy, int picc, int overpicc, int actionn);
 };
 

--- a/engines/ags/shared/ac/interface_element.h
+++ b/engines/ags/shared/ac/interface_element.h
@@ -38,8 +38,8 @@ struct InterfaceElement {
 	int             flags;
 	int             reserved_for_future;
 	int             popupyp;   // pops up when _G(mousey) < this
-	char            popup;     // does it pop up? (like sierra icon bar)
-	char            on;
+	int8            popup;     // does it pop up? (like sierra icon bar)
+	int8            on;
 	InterfaceElement();
 };
 

--- a/engines/ags/shared/ac/inventory_item_info.h
+++ b/engines/ags/shared/ac/inventory_item_info.h
@@ -41,7 +41,7 @@ struct InventoryItemInfo {
 	int  pic;
 	int  cursorPic, hotx, hoty;
 	int32_t reserved[5];
-	char flags;
+	int8 flags;
 
 	void ReadFromFile(Shared::Stream *in);
 	void WriteToFile(Shared::Stream *out);

--- a/engines/ags/shared/ac/mouse_cursor.h
+++ b/engines/ags/shared/ac/mouse_cursor.h
@@ -23,6 +23,8 @@
 #ifndef AGS_SHARED_AC_MOUSE_CURSOR_H
 #define AGS_SHARED_AC_MOUSE_CURSOR_H
 
+#include "ags/shared/core/types.h"
+
 namespace AGS3 {
 
 namespace AGS {
@@ -44,7 +46,7 @@ struct MouseCursor {
 	short hotx, hoty;
 	short view;
 	char  name[10];
-	char  flags;
+	int8  flags;
 
 	MouseCursor();
 

--- a/engines/ags/shared/ac/old_game_setup_struct.h
+++ b/engines/ags/shared/ac/old_game_setup_struct.h
@@ -37,7 +37,7 @@ namespace AGS3 {
 
 struct OriGameSetupStruct {
 	char              gamename[30];
-	char              options[20];
+	int8              options[20];
 	unsigned char     paluses[256];
 	RGB               defpal[256];
 	InterfaceElement  iface[10];
@@ -72,7 +72,7 @@ struct OriGameSetupStruct {
 
 struct OriGameSetupStruct2 : public OriGameSetupStruct {
 	unsigned char   fontflags[10];
-	char            fontoutline[10];
+	int8            fontoutline[10];
 	int             numgui;
 	WordsDictionary *dict;
 	int             reserved2[8];

--- a/engines/ags/shared/game/room_file_deprecated.cpp
+++ b/engines/ags/shared/game/room_file_deprecated.cpp
@@ -42,8 +42,8 @@ struct AnimationStruct {
 	int   data;
 	int   object;
 	int   speed;
-	char  action;
-	char  wait;
+	int8  action;
+	int8  wait;
 	AnimationStruct() {
 		action = 0;
 		object = 0;

--- a/engines/ags/shared/game/room_struct.h
+++ b/engines/ags/shared/game/room_struct.h
@@ -240,8 +240,8 @@ struct WalkBehind {
 #define MSG_TIMELIMIT   0x02
 
 struct MessageInfo {
-	char    DisplayAs; // 0 - std display window, >=1 - as character's speech
-	char    Flags; // combination of MSG_xxx flags
+	int8    DisplayAs; // 0 - std display window, >=1 - as character's speech
+	int8    Flags; // combination of MSG_xxx flags
 
 	MessageInfo();
 };


### PR DESCRIPTION
This is done to explicitly specify that they should be treated as signed

Some ports may treat an (unspecified) "char" as unsigned by default. Android does this for its ARM architectures and while we did fix this by enforcing -fsigned-char to its compiler, the issue may come up for other ports. Also it should be better to clarify in the engine when a variable is not actually storing string characters.

I've spotted and changed the most "safe" cases I could find for this. As far as I can tell, out of these, only the Outline field and fontoutline[] array could potentially be assigned valid negative values which would cause bugs for ports treating chars as unsigned. 


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
