### PR TITLE
SLUDGE: Fix build with Clang >= 11.0.0

### DIFF
--- a/engines/sludge/saveload.cpp
+++ b/engines/sludge/saveload.cpp
@@ -192,7 +192,7 @@ bool loadGame(const Common::String &fname) {
 		headerBad = true;
 	if (headerBad) {
 		fatal(ERROR_GAME_LOAD_NO, fname);
-		return NULL;
+		return false;
 	}
 	char c;
 	c = fp->readByte();


### PR DESCRIPTION
Clang 11 and newer check the types of return values more strictly and
generate an error if there is a discrepancy.

However the "bool loadGame()" function, returns the value "NULL", if
loading of a savegame was unsucessful, whereas Clang expects a return
value of type "bool".

Remedy the issue by using "false" as return value instead of "NULL".