### PR TITLE
BASE: Don't check for config key presence when loading gfx mode

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -351,12 +351,10 @@ static void setupGraphics(OSystem &system) {
 
 		system.initSize(320, 200);
 
-		if (ConfMan.hasKey("aspect_ratio"))
-			system.setFeatureState(OSystem::kFeatureAspectRatioCorrection, ConfMan.getBool("aspect_ratio"));
-		if (ConfMan.hasKey("fullscreen"))
-			system.setFeatureState(OSystem::kFeatureFullscreenMode, ConfMan.getBool("fullscreen"));
-		if (ConfMan.hasKey("filtering"))
-			system.setFeatureState(OSystem::kFeatureFilteringMode, ConfMan.getBool("filtering"));
+		// Parse graphics configuration, implicit fallback to defaults set with RegisterDefaults()
+		system.setFeatureState(OSystem::kFeatureAspectRatioCorrection, ConfMan.getBool("aspect_ratio"));
+		system.setFeatureState(OSystem::kFeatureFullscreenMode, ConfMan.getBool("fullscreen"));
+		system.setFeatureState(OSystem::kFeatureFilteringMode, ConfMan.getBool("filtering"));
 	system.endGFXTransaction();
 
 	system.applyBackendSettings();


### PR DESCRIPTION
I noticed that while bilinear filtering is disabled by default with ``RegisterDefault();`` at startup, bilinear filtering is always applied when starting a game (at least on the OPENGLSDL backend) unless you explicitly set ``filtering=false`` in the configuration file by simply opening the options dialog, applying the settings and closing it again.

While researching this, I think the culprit is that main.cpp checks for ``ConfMan.hasKey("filtering")``, but ``registerDefault()`` technically won't set a configuration key. This means that this checks override our defaults.

I think that this check is not necessary. With the checks for ``hasKey`` removed, it will first try to load the values set in the configuration file and otherwise fall back to the values set by ``registerDefault()``  instead.

Since we only deal with ``bool`` values here, it shouldn't even break in case we don't use ``registerDefault`` for those values since in this case, ``ConfMan.getBool`` will simply return ``false`` as well (which are the default values we set with ``registerDefault``.