### PR TITLE
AGS: Only load ttf font as outline for ttf font

### DIFF
--- a/engines/ags/shared/ac/game_struct_defines.h
+++ b/engines/ags/shared/ac/game_struct_defines.h
@@ -226,6 +226,10 @@ struct SpriteInfo {
 	}
 };
 
+// Font renderer flags
+#define FONT_TTF_RENDERER   0x01
+#define FONT_WFN_RENDERER   0x02
+
 // Various font parameters, defining and extending font rendering behavior.
 // While FontRenderer object's main goal is to render single line of text at
 // the strictly determined position on canvas, FontInfo may additionally
@@ -246,6 +250,23 @@ struct FontInfo {
 	int           LineSpacing = 0;
 
 	FontInfo();
+
+	inline bool isTTFFont() const {
+		return (Flags & FONT_TTF_RENDERER) != 0;
+	}
+
+	inline void setTTFFont() {
+		Flags |= FONT_TTF_RENDERER;
+	}
+
+	inline bool isWFNFont() const {
+		return (Flags & FONT_WFN_RENDERER) != 0;
+	}
+
+	inline void setWFNFont() {
+		Flags |= FONT_WFN_RENDERER;
+	}
+
 };
 
 } // namespace AGS3

--- a/engines/ags/shared/font/fonts.cpp
+++ b/engines/ags/shared/font/fonts.cpp
@@ -84,7 +84,7 @@ bool font_first_renderer_loaded() {
 }
 
 bool is_font_loaded(size_t fontNumber) {
-	return fontNumber < _GP(fonts).size() && _GP(fonts)[fontNumber].Renderer != nullptr;;
+	return fontNumber < _GP(fonts).size() && _GP(fonts)[fontNumber].Renderer != nullptr;
 }
 
 IAGSFontRenderer *font_replace_renderer(size_t fontNumber, IAGSFontRenderer *renderer) {
@@ -138,9 +138,9 @@ int get_font_outline(size_t font_number) {
 	return _GP(fonts)[font_number].Info.Outline;
 }
 
-int get_outline_font(size_t font_number) {
+int get_outline_ttf_font(size_t font_number) {
 	for (size_t fontNum = 0; fontNum < _GP(fonts).size(); ++fontNum) {
-		if (_GP(fonts)[fontNum].Info.Outline == (int)font_number)
+		if (_GP(fonts)[fontNum].Info.Outline == (int)font_number && _GP(fonts)[fontNum].Info.isTTFFont())
 			return fontNum;
 	}
 
@@ -325,6 +325,7 @@ void set_fontinfo(size_t fontNumber, const FontInfo &finfo) {
 
 // Loads a font from disk
 bool wloadfont_size(size_t fontNumber, const FontInfo &font_info) {
+
 	if (_GP(fonts).size() <= fontNumber)
 		_GP(fonts).resize(fontNumber + 1);
 	else
@@ -335,15 +336,18 @@ bool wloadfont_size(size_t fontNumber, const FontInfo &font_info) {
 	if (_GP(ttfRenderer).LoadFromDiskEx(fontNumber, font_info.SizePt, &params)) {
 		_GP(fonts)[fontNumber].Renderer = &_GP(ttfRenderer);
 		_GP(fonts)[fontNumber].Renderer2 = &_GP(ttfRenderer);
+		_GP(fonts)[fontNumber].Info.setTTFFont();
 	} else if (_GP(wfnRenderer).LoadFromDiskEx(fontNumber, font_info.SizePt, &params)) {
 		_GP(fonts)[fontNumber].Renderer = &_GP(wfnRenderer);
 		_GP(fonts)[fontNumber].Renderer2 = &_GP(wfnRenderer);
+		_GP(fonts)[fontNumber].Info.setWFNFont();
 	}
 
 	if (_GP(fonts)[fontNumber].Renderer) {
 		_GP(fonts)[fontNumber].Info = font_info;
 		return true;
 	}
+
 	return false;
 }
 

--- a/engines/ags/shared/font/fonts.h
+++ b/engines/ags/shared/font/fonts.h
@@ -84,7 +84,7 @@ int getfontlinespacing(size_t fontNumber);
 // Get is font is meant to use default line spacing
 bool use_default_linespacing(size_t fontNumber);
 int  get_font_outline(size_t font_number);
-int  get_outline_font(size_t font_number);
+int  get_outline_ttf_font(size_t font_number);
 void set_font_outline(size_t font_number, int outline_type);
 // Outputs a single line of text on the defined position on bitmap, using defined font, color and parameters
 int getfontlinespacing(size_t fontNumber);

--- a/engines/ags/shared/font/ttf_font_renderer.cpp
+++ b/engines/ags/shared/font/ttf_font_renderer.cpp
@@ -68,7 +68,7 @@ void TTFFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
 	if (y > destination->cb)  // optimisation
 		return;
 
-	int srcFontNum = get_outline_font(fontNumber);
+	int srcFontNum = get_outline_ttf_font(fontNumber);
 	ALFONT_FONT *srcFont = nullptr;
 	if (srcFontNum != FONT_OUTLINE_NONE) {
 		srcFont = _fontData[srcFontNum].AlFont;


### PR DESCRIPTION
Possible fix for https://bugs.scummvm.org/ticket/12923

This is quite an oblivious fix, though, since I use FontInfo Flags field (which as far as I can tell is unused) to set bit flags to track if a loaded font uses a TTF or WFN renderer and also I renamed a method (get_outline_font() to get_outline_ttf_font()) to specify that it's specifically for TTF fonts use cases.

Maybe there's a better way of fixing this.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
