### PR TITLE
BURIED: Fix door opening transition to Da Vinci study (bug 12885)

### DIFF
--- a/engines/buried/environ/da_vinci.cpp
+++ b/engines/buried/environ/da_vinci.cpp
@@ -829,15 +829,18 @@ int CodexTowerOutsideDoor::mouseUp(Window *viewWindow, const Common::Point &poin
 			DestinationScene destData;
 			destData.destinationScene = _staticData.location;
 			destData.destinationScene.depth = 1;
-			destData.transitionType = TRANSITION_VIDEO;
-			destData.transitionData = 2;
-			destData.transitionStartFrame = -1;
-			destData.transitionLength = -1;
+			destData.transitionType = TRANSITION_WALK;
+			destData.transitionData = 11;
+			destData.transitionStartFrame = 196;
+			destData.transitionLength = 20;
 
 			// Play a different video otherwise
 			if (((SceneViewWindow *)viewWindow)->getGlobalFlags().dsCTViewedAgent3 == 0) {
 				destData.transitionType = TRANSITION_VIDEO;
 				destData.transitionData = 1;
+				destData.transitionStartFrame = -1;
+				destData.transitionLength = -1;
+				((SceneViewWindow *)viewWindow)->getGlobalFlags().dsCTViewedAgent3 = 1;
 			}
 
 			((SceneViewWindow *)viewWindow)->moveToDestination(destData);


### PR DESCRIPTION
This should hopefully fix https://bugs.scummvm.org/ticket/12885 but needs to be tested by someone who knows the game.

I take no credit for this, since the code was handed to me through sev from "Keith" (Kaisershot?). There seems to have been some cut and paste error, because instead of choosing between the regular and first time door opening animation, it was choosing between the first time and breaking in animation, always picking the first time one.

The break in animation is presumably always handled by droppedItem(), so it shouldn't even have come into consideration here. I think. The regular door opening animation isn't even the same type of transition, which may explain why I was completely unable to find it.
