### PR TITLE
COMMON: Add error for unsupported manual save slot

### DIFF
--- a/common/error.cpp
+++ b/common/error.cpp
@@ -72,6 +72,9 @@ static String errorToString(ErrorCode errorCode) {
 	case kUserCanceled:
 		return _s("User canceled");
 
+	case kManualSaveSlotNotSupportedByNativeEngine:
+		return _s("Manual saving to this particular slot is not supported. Please try another slot");
+
 	case kUnknownError:
 	default:
 		return _s("Unknown error");

--- a/common/error.h
+++ b/common/error.h
@@ -73,6 +73,15 @@ enum ErrorCode {
 
 	kUserCanceled,			///< User has canceled the launching of the game.
 
+	/** Manually saving to this slot is not supported (yet or at all) by the game engine.
+	 * For example:
+	 * Some engines (eg. SKY) show their save slots starting from slot 1.
+	 * GMM allows saving to slot 0, and also that slot can optionally be used for autosaves, if the game engine supports them.
+	 * If the user manually saves, using GMM, to an unsupported slot by the in-game native UI, 
+	 * they won't be able to find and restore their save game from the native UI.
+	 */
+	kManualSaveSlotNotSupportedByNativeEngine,
+
 	kUnknownError				///< Catch-all error, used if no other error code matches.
 };
 

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -260,7 +260,7 @@ Common::Error SkyEngine::saveGameState(int slot, const Common::String &desc, boo
 	// This also secures _selectedGame which is unsigned integer (uint16)
 	// from overflowing in the subtraction below
 	if (slot < 0 || (!isAutosave && slot == 0)) {
-		return Common::kWritePermissionDenied;
+		return Common::kManualSaveSlotNotSupportedByNativeEngine;
 	}
 	// Set the save slot and save the game
 	// _selectedGame value is one unit lower than the ScummVM's Save File Manager's slot value


### PR DESCRIPTION
Addresses ticket https://bugs.scummvm.org/ticket/12766

Currently used by SKY engine.

Allow engines to prevent user from manually saving at selected slots, if they do not support them.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
