### PR TITLE
EVENTRECORDER: don't show the splash screen if event recorder is active

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -331,6 +331,10 @@ void initGraphics(int width, int height, const Graphics::PixelFormat *format) {
 
 	OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
+#ifdef ENABLE_EVENTRECORDER
+	// don't show splash screen for event recorder
+	if (!g_eventRec.isInitialized())
+#endif
 	if (!splash && !GUI::GuiManager::instance()._launched)
 		splashScreen();
 

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -80,6 +80,9 @@ public:
 
 	void init(const Common::String &recordFileName, RecordMode mode);
 	void deinit();
+	bool isInitialized() const {
+		return _initialized;
+	}
 	bool processDelayMillis();
 	uint32 getRandomSeed(const Common::String &name);
 	void processTimeAndDate(TimeDate &td, bool skipRecord);


### PR DESCRIPTION
The splash screen must get disabled or it consumes events and milliseconds of the event recorder.