### PR TITLE
COMMON: logging hashes when starting a game

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -420,7 +420,7 @@ Common::Error AdvancedMetaEngineDetection::createInstance(OSystem *syst, Engine 
 
 	debug("Running %s", gameDescriptor.description.c_str());
 	for (FilePropertiesMap::const_iterator i = gameDescriptor.matchedFiles.begin(); i != gameDescriptor.matchedFiles.end(); ++i) {
-		debug("%s: %s, %llu bytes.", i->_key.c_str(), i->_value.md5.c_str(), unsigned long long(i->_value.size));
+		debug("%s: %s, %llu bytes.", i->_key.c_str(), i->_value.md5.c_str(), (unsigned long long)i->_value.size);
 	}
 	initSubSystems(agdDesc.desc);
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -418,7 +418,10 @@ Common::Error AdvancedMetaEngineDetection::createInstance(OSystem *syst, Engine 
 		return Common::kUserCanceled;
 	}
 
-	debugC(2, kDebugGlobalDetection, "Running %s", gameDescriptor.description.c_str());
+	debug("Running %s", gameDescriptor.description.c_str());
+	for (FilePropertiesMap::const_iterator i = gameDescriptor.matchedFiles.begin(); i != gameDescriptor.matchedFiles.end(); ++i) {
+		debug("%s: %s, %llu bytes.", i->_key.c_str(), i->_value.md5.c_str(), unsigned long long(i->_value.size));
+	}
 	initSubSystems(agdDesc.desc);
 
 	PluginList pl = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE);


### PR DESCRIPTION
I figure this would be helpful when people submit their log files, so we know what version of the game they're running.

Looks like this

```
[2021-09-15 15:27:24] ScummVM 2.4.0git (Sep 15 2021 12:10:44)
[2021-09-15 15:27:24] Vorbis FLAC MP3 RGB zLib FluidSynth Theora FreeType2 FriBiDi JPEG PNG taskbar TTS cloud (servers, local) TinyGL OpenGL (with shaders) GLEW 
[2021-09-15 15:27:24] --- Log opened.
[2021-09-15 15:27:29] Running The 11th Hour: The Sequel to The 7th Guest (Windows/English)
[2021-09-15 15:27:29] script.grv: bdb9a783d4debe477ac3856adc454c17, 62447 bytes.
[2021-09-15 15:27:29] introd1.gjd: 9ec3e727182fbe40ee23e786721180eb, 6437077 bytes.
[2021-09-15 15:27:36] --- Log closed successfully.
```

Ubuntu build initially failed, so this can be squash merged