### PR TITLE
GROOVIE: Clandestiny fixes

### DIFF
--- a/engines/groovie/clangame.cpp
+++ b/engines/groovie/clangame.cpp
@@ -25,15 +25,15 @@
 namespace Groovie {
 
 // This a list of files for background music. This list is hardcoded in the Clandestiny player.
-const char *kClanMusicFiles[] = {"mbf_arb1.mpg", "mbf_arm1.mpg", "mbf_bal1.mpg", "mbf_c2p2.mpg", "act18mus.mpg", "act15mus.mpg", "act21mus.mpg",
-										  "act05mus.mpg", "act04mus.mpg", "act23mus.mpg", "act17mus.mpg", "act03mus.mpg", "act06mus.mpg", "act19mus.mpg",
-										  "act07mus.mpg", "mbf_mne1.mpg", "act24mus.mpg", "act24mus.mpg", "act14mus.mpg", "act20mus.mpg", "act15mus.mpg",
-										  "act13mus.mpg", "act08mus.mpg", "mbf_uph1.mpg", "mbf_uph1.mpg", "act19mus.mpg", "mbf_bol1.mpg", "mbf_cbk1.mpg",
-										  "mbf_glf1.mpg", "mbf_bro1.mpg", "mbf_c1r1.mpg", "mbf_c1r1.mpg", "mbf_c1r1.mpg", "mbf_c1r1.mpg", "mbf_c2r1.mpg",
-										  "mbf_c2r1.mpg", "mbf_c2r1.mpg", "mbf_c2r1.mpg", "mbf_c3r1.mpg", "mbf_c3r1.mpg", "mbf_c3r1.mpg", "mbf_c4r1.mpg",
-										  "mbf_c4r1.mpg", "mbf_c1p2.mpg", "mbf_c3p3.mpg", "mbf_c1p3.mpg", "mbf_bro1.mpg", "mbf_c1p1.mpg", "act17mus.mpg",
-										  "mbf_c2p2.mpg", "mbf_c2p1.mpg", "act10mus.mpg", "mbf_c1p1.mpg", "mbf_mne1.mpg", "mbf_c3p3.mpg", "act17mus.mpg",
-										  "mbf_c3p2.mpg", "mbf_c3p1.mpg", "act25mus.mpg", "mbf_c4p2.mpg", "mbf_c4p1.mpg"};
+const char *kClanMusicFiles[] = {"mbf_arb1", "mbf_arm1", "mbf_bal1", "mbf_c2p2", "act18mus", "act15mus", "act21mus",
+										  "act05mus", "act04mus", "act23mus", "act17mus", "act03mus", "act06mus", "act19mus",
+										  "act07mus", "mbf_mne1", "act24mus", "act24mus", "act14mus", "act20mus", "act15mus",
+										  "act13mus", "act08mus", "mbf_uph1", "mbf_uph1", "act19mus", "mbf_bol1", "mbf_cbk1",
+										  "mbf_glf1", "mbf_bro1", "mbf_c1r1", "mbf_c1r1", "mbf_c1r1", "mbf_c1r1", "mbf_c2r1",
+										  "mbf_c2r1", "mbf_c2r1", "mbf_c2r1", "mbf_c3r1", "mbf_c3r1", "mbf_c3r1", "mbf_c4r1",
+										  "mbf_c4r1", "mbf_c1p2", "mbf_c3p3", "mbf_c1p3", "mbf_bro1", "mbf_c1p1", "act17mus",
+										  "mbf_c2p2", "mbf_c2p1", "act10mus", "mbf_c1p1", "mbf_mne1", "mbf_c3p3", "act17mus",
+										  "mbf_c3p2", "mbf_c3p1", "act25mus", "mbf_c4p2", "mbf_c4p1"};
 
 // Gets the filename of the background music file.
 const char *ClanGame::getClanMusicFilename(int musicId) {

--- a/engines/groovie/cursor.cpp
+++ b/engines/groovie/cursor.cpp
@@ -384,7 +384,7 @@ GrvCursorMan_v2::GrvCursorMan_v2(OSystem *system) :
 
 	// Open the icons file
 	Common::File iconsFile;
-	if (!iconsFile.open("icons.ph"))
+	if (!iconsFile.open("icons.ph") && !iconsFile.open("icons.bin"))
 		error("Groovie::Cursor: Couldn't open icons.ph");
 
 	// Verify the signature

--- a/engines/groovie/cursor.cpp
+++ b/engines/groovie/cursor.cpp
@@ -385,13 +385,13 @@ GrvCursorMan_v2::GrvCursorMan_v2(OSystem *system) :
 	// Open the icons file
 	Common::File iconsFile;
 	if (!iconsFile.open("icons.ph") && !iconsFile.open("icons.bin"))
-		error("Groovie::Cursor: Couldn't open icons.ph");
+		error("Groovie::Cursor: Couldn't open icons.ph or icons.bin");
 
 	// Verify the signature
 	uint32 tmp32 = iconsFile.readUint32BE();
 	uint16 tmp16 = iconsFile.readUint16LE();
 	if (tmp32 != MKTAG('i','c','o','n') || tmp16 != 1)
-		error("Groovie::Cursor: icons.ph signature failed: %s %d", tag2str(tmp32), tmp16);
+		error("Groovie::Cursor: %s signature failed: %s %d", iconsFile.getName(), tag2str(tmp32), tmp16);
 
 
 	// Read the number of icons

--- a/engines/groovie/detection.cpp
+++ b/engines/groovie/detection.cpp
@@ -276,6 +276,18 @@ static const GroovieGameDescription gameDescriptions[] = {
 		kGroovieCDY
 	},
 
+	// Clandestiny Mac App Store (identical to iOS?)
+    {
+        {
+            "clandestiny", "",
+            AD_ENTRY2s("CLANMAIN.GRV", "dd424120fa1daa9d6b576d0ba22a4936", 54253,
+                       "ACT01MUS.m4a", NULL, -1),
+            Common::EN_ANY, Common::kPlatformMacintosh, ADGF_UNSTABLE,
+            GUIO3(GUIO_NOMIDI, GUIO_NOLAUNCHLOAD, GUIO_NOASPECT)
+        },
+        kGroovieCDY
+    },
+
 	// Clandestiny iOS English
 	{
 		{

--- a/engines/groovie/music.cpp
+++ b/engines/groovie/music.cpp
@@ -793,8 +793,15 @@ bool MusicPlayerTlc::load(uint32 fileref, bool loop) {
 	unload();
 	_file = new Common::File();
 
-	// Create the audio stream from fileref
 	Common::String filename = getFilename(fileref);
+
+	// Apple platforms use m4a files instead of mpg
+	if (_vm->getPlatform() == Common::kPlatformMacintosh || _vm->getPlatform() == Common::kPlatformIOS)
+		filename += ".m4a";
+	else
+		filename += ".mpg";
+
+	// Create the audio stream from fileref
 	_file->open(filename);
 	Audio::SeekableAudioStream *seekStream = NULL;
 	if (_file->isOpen()) {

--- a/engines/groovie/music.cpp
+++ b/engines/groovie/music.cpp
@@ -40,6 +40,7 @@
 #include "audio/midiparser.h"
 #include "audio/miles.h"
 #include "audio/decoders/mp3.h"
+#include "audio/decoders/quicktime.h"
 
 namespace Groovie {
 
@@ -805,7 +806,10 @@ bool MusicPlayerTlc::load(uint32 fileref, bool loop) {
 	_file->open(filename);
 	Audio::SeekableAudioStream *seekStream = NULL;
 	if (_file->isOpen()) {
-		seekStream = Audio::makeMP3Stream(_file, DisposeAfterUse::NO);
+		if (filename.hasSuffix(".m4a"))
+			seekStream = Audio::makeQuickTimeStream(_file, DisposeAfterUse::NO);
+		else
+			seekStream = Audio::makeMP3Stream(_file, DisposeAfterUse::NO);
 	} else {
 		delete _file;
 		_file = NULL;

--- a/engines/groovie/script.h
+++ b/engines/groovie/script.h
@@ -150,6 +150,7 @@ private:
 	bool hotspot(Common::Rect rect, uint16 addr, uint8 cursor);
 
 	void loadgame(uint slot);
+	bool preview_loadgame(uint slot);
 	void savegame(uint slot);
 	bool playvideofromref(uint32 fileref, bool loopUntilAudioDone = false);
 	bool playBackgroundSound(uint32 fileref, uint32 loops);
@@ -256,6 +257,7 @@ private:
 	void o2_setscriptend();
 	void o2_playsound();
 	void o2_check_sounds_overlays();
+	void o2_preview_loadgame();
 };
 
 } // End of Groovie namespace

--- a/engines/groovie/tlcgame.cpp
+++ b/engines/groovie/tlcgame.cpp
@@ -34,12 +34,12 @@
 namespace Groovie {
 
 // This a list of files for background music. This list is hardcoded in the TLC player.
-const char *kTlcMusicFiles[] = {"ep01epm.mpg", "ep01tatm.mpg", "amb_hs.mpg", "amb_mr.mpg", "amb_kr.mpg", "amb_mo.mpg", "music_rc.mpg", "amb_ds.mpg", "amb_ds3.mpg",
-								"amb_jr.mpg", "amb_mr4.mpg", "amb_jr4.mpg", "amb_jr2.mpg", "amb_kr2.mpg", "amb_mr2.mpg", "amb_br.mpg", "amb_ds2.mpg", "amb_jr3.mpg",
-								"amb_ds4.mpg", "amb_kr3.mpg", "amb_to1.mpg", "amb_to2.mpg", "ep02epm.mpg", "ep02tatm.mpg", "ep03epm.mpg", "ep03tatm.mpg", "ep04epm.mpg",
-								"ep04tatm.mpg", "ep05epm.mpg", "ep05tatm.mpg", "ep06epm.mpg", "ep06tatm.mpg", "ep07epm.mpg", "ep07tatm.mpg", "ep08epm.mpg", "ep08tatm.mpg",
-								"ep09epm.mpg", "ep09tatm.mpg", "ep10epm.mpg", "ep10tatm.mpg", "ep11epm.mpg", "ep11tatm.mpg", "ep12epm.mpg", "ep12tatm.mpg", "ep13epm.mpg",
-								"ep13tatm.mpg", "ep14epm.mpg", "ep14tatm.mpg", "ep15epm.mpg", "ep15tatm.mpg" };
+const char *kTlcMusicFiles[] = {"ep01epm", "ep01tatm", "amb_hs", "amb_mr", "amb_kr", "amb_mo", "music_rc", "amb_ds", "amb_ds3",
+								"amb_jr", "amb_mr4", "amb_jr4", "amb_jr2", "amb_kr2", "amb_mr2", "amb_br", "amb_ds2", "amb_jr3",
+								"amb_ds4", "amb_kr3", "amb_to1", "amb_to2", "ep02epm", "ep02tatm", "ep03epm", "ep03tatm", "ep04epm",
+								"ep04tatm", "ep05epm", "ep05tatm", "ep06epm", "ep06tatm", "ep07epm", "ep07tatm", "ep08epm", "ep08tatm",
+								"ep09epm", "ep09tatm", "ep10epm", "ep10tatm", "ep11epm", "ep11tatm", "ep12epm", "ep12tatm", "ep13epm",
+								"ep13tatm", "ep14epm", "ep14tatm", "ep15epm", "ep15tatm" };
 const uint8 kTlcEpQuestToPlay[] = { 0x0E, 0x0F, 0x0B, 0x10, 0x11, 0x12, 0x0C, 0x0C, 0x09, 0x06, 0x0F, 0x0C, 0x0B, 0x0D, 0x0D };
 
 


### PR DESCRIPTION
Fixes crashes when you have saved games. Also makes the preview images on saved games work.

Also fixes Mac/iOS cursors and music, because they use slightly different filenames for them.