### PR TITLE
ENGINES: Warn when autosave is overwritten by a newer game

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -570,7 +570,7 @@ bool Engine::warnBeforeOverwritingAutosave() {
 	if (desc.getSaveSlot() == -1)
 		return true;
 	if (desc.hasAutosaveName())
-		return true;
+		return desc.warnBeforeOverwritingOlder();
 	Common::U32StringArray altButtons;
 	altButtons.push_back(_("Overwrite"));
 	altButtons.push_back(_("Cancel autosave"));

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -23,6 +23,7 @@
 #include "engines/savestate.h"
 #include "engines/engine.h"
 #include "graphics/surface.h"
+#include "gui/message.h"
 #include "common/config-manager.h"
 #include "common/textconsole.h"
 #include "common/translation.h"
@@ -94,4 +95,21 @@ bool SaveStateDescriptor::isAutosave() const {
 bool SaveStateDescriptor::hasAutosaveName() const
 {
 	return _description.contains(_("Autosave"));
+}
+
+bool SaveStateDescriptor::warnBeforeOverwritingOlder() const
+{
+	if (!g_engine)
+		return true;
+	const int currentPlayTime = g_engine->getTotalPlayTime();
+	const int savedPlayTime = getPlayTimeMSecs();
+	if (currentPlayTime <= 0 || savedPlayTime <= 0 || currentPlayTime >= savedPlayTime)
+		return true;
+	const Common::U32String message = isAutosave()
+			? _("WARNING: Existing save has longer gameplay duration than the "
+				"current state. Are you sure you want to overwrite it?")
+			: _("WARNING: Existing autosave has longer gameplay duration than the "
+				"current state. Do you want to overwrite it?");
+	GUI::MessageDialog warn(message, _("Yes"), _("No"));
+	return warn.runModal() == GUI::kMessageOK;
 }

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -219,6 +219,13 @@ public:
 	 * Returns true if the save has an autosave name
 	 */
 	bool hasAutosaveName() const;
+
+	/**
+	 * Shows a warning dialog before overwriting an older game
+	 * Returns true if the current duration is longer, or the user confirmed overwriting.
+	 */
+	bool warnBeforeOverwritingOlder() const;
+
 private:
 	/**
 	 * The saveslot id, as it would be passed to the "-x" command line switch.

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -335,17 +335,8 @@ void SaveLoadChooserDialog::activate(int slot, const Common::U32String &descript
 	if (!_saveList.empty() && slot < int(_saveList.size())) {
 		const SaveStateDescriptor &desc = _saveList[slot];
 		if (_saveMode) {
-			if (g_engine) {
-				const int currentPlayTime = g_engine->getTotalPlayTime();
-				const int savedPlayTime = desc.getPlayTimeMSecs();
-				if (currentPlayTime > 0 && savedPlayTime > 0 && currentPlayTime < savedPlayTime) {
-					GUI::MessageDialog warn(
-								_("WARNING: Existing save has longer gameplay duration than the "
-								  "current state. Are you sure you want to overwrite it?"), _("Yes"), _("No"));
-					if (warn.runModal() != GUI::kMessageOK)
-						return;
-				}
-			}
+			if (!desc.warnBeforeOverwritingOlder())
+				return;
 			_resultString = description.empty() ? desc.getDescription() : description;
 		}
 		setResult(desc.getSaveSlot());


### PR DESCRIPTION
If the previous autosave had a longer gameplay duration, and the user
started a new game, warn before overwriting the more advanced autosave.
