### PR TITLE
DIRECTOR: Add AIFC detection

### DIFF
--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -786,7 +786,7 @@ Audio::AudioStream *AudioFileDecoder::getAudioStream(bool looping, bool forPuppe
 		magic2 == MKTAG('W', 'A', 'V', 'E')) {
 		stream = Audio::makeWAVStream(file, disposeAfterUse);
 	} else if (magic1 == MKTAG('F', 'O', 'R', 'M') &&
-				magic2 == MKTAG('A', 'I', 'F', 'F')) {
+				(magic2 == MKTAG('A', 'I', 'F', 'F') || magic2 == MKTAG('A', 'I', 'F', 'C'))) {
 		stream = Audio::makeAIFFStream(file, disposeAfterUse);
 	} else {
 		warning("Unknown file type for %s", _path.c_str());


### PR DESCRIPTION
`AIFC` is already handled by `makeAIFFStream`. This fixes audio in the Music Island games.