### PR TITLE
AGS: Skip videos with unsupported video tracks rather than erroring

### DIFF
--- a/engines/ags/engine/ac/global_video.cpp
+++ b/engines/ags/engine/ac/global_video.cpp
@@ -48,9 +48,6 @@ void scrPlayVideo(const char *name, int skip, int flags) {
 		return;
 	if (_G(debug_flags) & DBG_NOVIDEO)
 		return;
-	// FIXME: Stargate Adventure videos used unsupported ix00 & ix01 audio tracks
-	if (::AGS::g_vm->getGameId() == "stargateadv")
-		return;
 
 	if ((flags < 10) && (_GP(usetup).audio_backend == 0)) {
 		// if game audio is disabled in Setup, then don't

--- a/engines/ags/engine/media/video/video.cpp
+++ b/engines/ags/engine/media/video/video.cpp
@@ -64,9 +64,7 @@ static bool play_video(Video::VideoDecoder *decoder, const char *name, int skip,
 	AGS::Shared::ScummVMReadStream *stream = new AGS::Shared::ScummVMReadStream(video_stream.get(), DisposeAfterUse::NO);
 
 	if (!decoder->loadStream(stream)) {
-		delete stream;
-		if (showError)
-			Display("Unable to decode video '%s'", name);
+		warning("Unable to decode video '%s'", name);
 		return false;
 	}
 

--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -225,6 +225,7 @@ protected:
 		void useInitialPalette();
 		bool canDither() const;
 		void setDither(const byte *palette);
+		bool isValid() const { return _videoCodec != nullptr; }
 
 		bool isTruemotion1() const;
 		void forceDimensions(uint16 width, uint16 height);


### PR DESCRIPTION
This is a commit that has a minor change to the AVIDecoder, and whilst it's only a minimal change, I'd like a second opinion on it before I push it to master and backport it to the release branch.

It basically makes two changes:
* A video track isn't added to the track list unless it has a known supported codec
* The loadStream method overall aborts the load, and returns false, if the loaded AVI video doesn't have a video track registered

Due to this, any AGS games which have unsupported video codecs like XVid will still be able to play.. they'll now simply skip the video rather than throwing an error like happened previously.
