### PR TITLE
RFC: (Don't merge without discussion) Disable fullscreen/windowed toggle on 3D games on release branch

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -398,6 +398,9 @@ bool SdlGraphicsManager::notifyEvent(const Common::Event &event) {
 void SdlGraphicsManager::toggleFullScreen() {
 	if (!g_system->hasFeature(OSystem::kFeatureFullscreenMode) ||
 	   (!g_system->hasFeature(OSystem::kFeatureFullscreenToggleKeepsContext) && g_system->hasFeature(OSystem::kFeatureOpenGLForGame))) {
+#ifdef USE_OSD
+		displayMessageOnOSD(_("Switching between fullscreen and windwed mode is not supported"));
+#endif
 		return;
 	}
 

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -81,7 +81,7 @@ bool OpenGLSdlGraphics3dManager::hasFeature(OSystem::Feature f) const {
 		(f == OSystem::kFeatureFullscreenMode) ||
 		(f == OSystem::kFeatureOpenGLForGame) ||
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
+//		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
 #endif
 		(f == OSystem::kFeatureVSync) ||
 		(f == OSystem::kFeatureAspectRatioCorrection) ||


### PR DESCRIPTION
Since we have at least two reports about how toggling between fullscreen and windowed mode is completely broken in 3D games...

https://bugs.scummvm.org/ticket/12473
https://bugs.scummvm.org/ticket/12476

...and since no one has proposed a fix in the past five months, perhaps we should disable fullscreen/windowed switching in the release branch. It's beyond useless in its current state.

This seems like the cleanest way of doing it, if I understand things correctly. You can still switch fullscreen/windowed mode if you're using a software renderer.