### PR TITLE
COMMON: Fixing misspellings "occured" -> "occurred"

### DIFF
--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -400,7 +400,7 @@ struct AgiGame {
 
 	unsigned int numObjects;
 
-	bool controllerOccured[MAX_CONTROLLERS];  /**< keyboard keypress events */
+	bool controllerOccurred[MAX_CONTROLLERS];  /**< keyboard keypress events */
 	AgiControllerKeyMapping controllerKeyMapping[MAX_CONTROLLER_KEYMAPPINGS];
 
 	char strings[MAX_STRINGS + 1][MAX_STRINGLEN]; /**< strings */
@@ -495,8 +495,8 @@ struct AgiGame {
 
 		numObjects = 0;
 
-		for (uint16 i = 0; i < ARRAYSIZE(controllerOccured); i++) {
-			controllerOccured[i] = false;
+		for (uint16 i = 0; i < ARRAYSIZE(controllerOccurred); i++) {
+            controllerOccurred[i] = false;
 		}
 
 		// controllerKeyMapping defaulted by AgiControllerKeyMapping constructor

--- a/engines/agi/cycle.cpp
+++ b/engines/agi/cycle.cpp
@@ -125,7 +125,7 @@ void AgiEngine::resetControllers() {
 	int i;
 
 	for (i = 0; i < MAX_CONTROLLERS; i++) {
-		_game.controllerOccured[i] = false;
+		_game.controllerOccurred[i] = false;
 	}
 }
 
@@ -293,8 +293,8 @@ uint16 AgiEngine::processAGIEvents() {
 	// WORKAROUND: For Apple II gs we added a Speed menu; here the user choose some speed setting from the menu
 	if (getPlatform() == Common::kPlatformApple2GS && _game.appleIIgsSpeedControllerSlot != 0xffff)
 		for (int i = 0; i < 4; i++)
-			if (_game.controllerOccured[_game.appleIIgsSpeedControllerSlot + i]) {
-				_game.controllerOccured[_game.appleIIgsSpeedControllerSlot + i] = false;
+			if (_game.controllerOccurred[_game.appleIIgsSpeedControllerSlot + i]) {
+				_game.controllerOccurred[_game.appleIIgsSpeedControllerSlot + i] = false;
 				_game.setAppleIIgsSpeedLevel(i);
 			}
 

--- a/engines/agi/keyboard.cpp
+++ b/engines/agi/keyboard.cpp
@@ -474,7 +474,7 @@ bool AgiEngine::handleController(uint16 key) {
 	for (uint16 curMapping = 0; curMapping < MAX_CONTROLLER_KEYMAPPINGS; curMapping++) {
 		if (_game.controllerKeyMapping[curMapping].keycode == key) {
 			debugC(3, kDebugLevelInput, "event %d: key press", _game.controllerKeyMapping[curMapping].controllerSlot);
-			_game.controllerOccured[_game.controllerKeyMapping[curMapping].controllerSlot] = true;
+			_game.controllerOccurred[_game.controllerKeyMapping[curMapping].controllerSlot] = true;
 			return true;
 		}
 	}

--- a/engines/agi/menu.cpp
+++ b/engines/agi/menu.cpp
@@ -511,7 +511,7 @@ void GfxMenu::keyPress(uint16 newKey) {
 			return;
 
 		// Trigger controller
-		_vm->_game.controllerOccured[itemEntry->controllerSlot] = true;
+		_vm->_game.controllerOccurred[itemEntry->controllerSlot] = true;
 
 		_vm->cycleInnerLoopInactive(); // exit execute-loop
 		break;
@@ -622,7 +622,7 @@ void GfxMenu::mouseEvent(uint16 newKey) {
 				return;
 
 			// Trigger controller
-			_vm->_game.controllerOccured[itemEntry->controllerSlot] = true;
+			_vm->_game.controllerOccurred[itemEntry->controllerSlot] = true;
 
 			_vm->cycleInnerLoopInactive(); // exit execute-loop
 			return;
@@ -675,7 +675,7 @@ void GfxMenu::mouseEvent(uint16 newKey) {
 			GuiMenuItemEntry *itemEntry = _itemArray[activeItemNr];
 			if (itemEntry->enabled) {
 				// Trigger controller
-				_vm->_game.controllerOccured[itemEntry->controllerSlot] = true;
+				_vm->_game.controllerOccurred[itemEntry->controllerSlot] = true;
 			}
 		}
 

--- a/engines/agi/op_cmd.cpp
+++ b/engines/agi/op_cmd.cpp
@@ -2095,7 +2095,7 @@ void cmdSetKey(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	state->controllerKeyMapping[keyMappingSlot].keycode = key;
 	state->controllerKeyMapping[keyMappingSlot].controllerSlot = controllerSlot;
 
-	state->controllerOccured[controllerSlot] = false;
+	state->controllerOccurred[controllerSlot] = false;
 }
 
 void cmdSetString(AgiGame *state, AgiEngine *vm, uint8 *parameter) {

--- a/engines/agi/op_test.cpp
+++ b/engines/agi/op_test.cpp
@@ -280,7 +280,7 @@ uint8 AgiEngine::testCompareStrings(uint8 s1, uint8 s2) {
 }
 
 uint8 AgiEngine::testController(uint8 cont) {
-	return (_game.controllerOccured[cont] ? true : false);
+	return (_game.controllerOccurred[cont] ? true : false);
 }
 
 uint8 AgiEngine::testPosn(uint8 n, uint8 x1, uint8 y1, uint8 x2, uint8 y2) {

--- a/engines/agi/saveload.cpp
+++ b/engines/agi/saveload.cpp
@@ -549,7 +549,7 @@ int AgiEngine::loadGame(const Common::String &fileName, bool checkId) {
 
 	// Those are not serialized
 	for (i = 0; i < MAX_CONTROLLERS; i++) {
-		_game.controllerOccured[i] = false;
+		_game.controllerOccurred[i] = false;
 	}
 
 	if (saveVersion >= 7) {

--- a/engines/ags/engine/script/script.cpp
+++ b/engines/ags/engine/script/script.cpp
@@ -114,7 +114,7 @@ void run_function_on_non_blocking_thread(NonBlockingScriptFunction *funcToRun) {
 
 // Returns 0 normally, or -1 to indicate that the NewInteraction has
 // become invalid and don't run another interaction on it
-// (eg. a room change occured)
+// (eg. a room change occurred)
 int run_interaction_event(Interaction *nint, int evnt, int chkAny, int isInv) {
 
 	if (evnt < 0 || (size_t)evnt >= nint->Events.size() ||
@@ -154,7 +154,7 @@ int run_interaction_event(Interaction *nint, int evnt, int chkAny, int isInv) {
 
 // Returns 0 normally, or -1 to indicate that the NewInteraction has
 // become invalid and don't run another interaction on it
-// (eg. a room change occured)
+// (eg. a room change occurred)
 int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny, int isInv) {
 
 	if ((nint->ScriptFuncNames[evnt] == nullptr) || (nint->ScriptFuncNames[evnt][0u] == 0)) {

--- a/engines/glk/agt/metacommand.cpp
+++ b/engines/glk/agt/metacommand.cpp
@@ -56,9 +56,9 @@ run_metacommand
 	0 to go on to next metacommand,
 	1 to stop running metacommands,  and
 	2 to end the turn.
-	3 indicates that redirection has just occured
-	4 indicates a subcall has just occured.
-	5 to go on to next metacommand after a return has occured.
+	3 indicates that redirection has just occurred
+	4 indicates a subcall has just occurred.
+	5 to go on to next metacommand after a return has occurred.
 	-2 means we're doing disambiguation and just hit an action token.
 
 */
@@ -493,8 +493,8 @@ static int run_metacommand(int cnum, int *redir_offset)
 	  0 to go on to next metacommand,
 	  1 to stop running metacommands,  and
 	  2 to end the turn.
-	  3 indicates that redirection has just occured
-	  4 indicates a subcall has just occured.
+	  3 indicates that redirection has just occurred
+	  4 indicates a subcall has just occurred.
 	  5 Is used to go on to the next metacommand after a Return.
 	  -2 means we're doing disambiguation and just hit an action token. */
 {
@@ -990,8 +990,8 @@ int scan_metacommand(integer m_actor, int vcode,
 /* If doing disambiguation, then -2=end of cycle, something happened;
    0 or 1=end of cycle; nothing happened; 2=end of turn, nothing happened. */
 /* If redir_flag is non-NULL, it is set when redirection occurs:
-   1+=Redirection occured
-   2=Grammar-changing redirection occured. */
+   1+=Redirection occurred
+   2=Grammar-changing redirection occurred. */
 {
 	int i, oldi;
 	word m_verb;
@@ -1001,7 +1001,7 @@ int scan_metacommand(integer m_actor, int vcode,
 			 commands)-- this is used to hold the offset
 			 of the given redirect. */
 	long redirect_count;  /* This is a safety measure: this keeps track of how
-			many redirections have occured on a single turn, and
+			many redirections have occurred on a single turn, and
 			if there are "too many" it will issue an error message
 			and stop. This is to prevent the system from getting
 			into a redirection loop. The number should be set

--- a/engines/glk/jacl/parser.cpp
+++ b/engines/glk/jacl/parser.cpp
@@ -558,7 +558,7 @@ struct word_type *object_match(struct word_type *iterator, int noun_number) {
 		}
 
 		if (custom_error == TRUE) {
-			/* AN ERROR OCCURED IN THE FIRST OBJECT PLACEHOLDER, DON'T
+			/* AN ERROR OCCURRED IN THE FIRST OBJECT PLACEHOLDER, DON'T
 			 * TRY ANY OTHERS */
 			return (NULL);
 		}

--- a/engines/glk/tads/tads2/error_message.cpp
+++ b/engines/glk/tads/tads2/error_message.cpp
@@ -62,7 +62,7 @@ void lerfre(errcxdef *errcx) {
 }
 
 void errmsg(errcxdef *ctx, char *outbuf, uint outbufl, uint err) {
-	sprintf(outbuf, "Error #%d occured.", err);
+	sprintf(outbuf, "Error #%d occurred.", err);
 }
 
 } // End of namespace TADS2

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -532,7 +532,7 @@ void Lua_V2::GetMemoryCardId() {
 	// 0 - No mem card
 	// 1 - Not formatted
 	// 2 - Not enough space
-	// 3 - Error occured
+	// 3 - Error occurred
 	lua_pushnumber(4);
 }
 

--- a/engines/hdb/lua-script.cpp
+++ b/engines/hdb/lua-script.cpp
@@ -1873,7 +1873,7 @@ bool LuaScript::initScript(Common::SeekableReadStream *stream, const char *scrip
 	lua_insert(_state, -2);
 
 	if (lua_pcall(_state, 0, 0, -2)) {
-		error("LuaScript::initScript: An error occured while executing \"%s\": %s.", "level_init", lua_tostring(_state, -1));
+		error("LuaScript::initScript: An error occurred while executing \"%s\": %s.", "level_init", lua_tostring(_state, -1));
 		lua_pop(_state, -1);
 
 		return false;
@@ -1913,7 +1913,7 @@ void LuaScript::call(int args, int returns) {
 		return;
 
 	if (lua_pcall(_state, args, returns, -2)) {
-		error("LuaScript::call: An error occured while executing: %s.", lua_tostring(_state, -1));
+		error("LuaScript::call: An error occurred while executing: %s.", lua_tostring(_state, -1));
 		lua_pop(_state, -1);
 	}
 }
@@ -1926,7 +1926,7 @@ bool LuaScript::callFunction(const char *name, int returns) {
 	lua_getglobal(_state, name);
 
 	if (lua_pcall(_state, 0, returns, -2)) {
-		error("LuaScript::callFunction: An error occured while executing \"%s\": %s.", name, lua_tostring(_state, -1));
+		error("LuaScript::callFunction: An error occurred while executing \"%s\": %s.", name, lua_tostring(_state, -1));
 		lua_pop(_state, -1);
 
 		return false;
@@ -2042,7 +2042,7 @@ bool LuaScript::executeChunk(Common::String &chunk, const Common::String &chunkN
 
 	// Execute Chunk
 	if (lua_pcall(_state, 0, 0, -2)) {
-		error("LuaScript::executeChunk: An error occured while executing \"%s\": %s.", chunkName.c_str(), lua_tostring(_state, -1));
+		error("LuaScript::executeChunk: An error occurred while executing \"%s\": %s.", chunkName.c_str(), lua_tostring(_state, -1));
 		lua_pop(_state, -1);
 
 		return false;

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1525,7 +1525,7 @@ Common::Error Myst3Engine::loadGameState(Common::String fileName, TransitionType
 	}
 
 	if (saveFile->err()) {
-		warning("An error occured when reading '%s'", fileName.c_str());
+		warning("An error occrured when reading '%s'", fileName.c_str());
 		return Common::kReadingFailed;
 	}
 
@@ -1601,7 +1601,7 @@ Common::Error Myst3Engine::saveGameState(const Common::String &desc, const Graph
 	}
 
 	if (save->err()) {
-		warning("An error occured when writing '%s'", fileName.c_str());
+		warning("An error occurred when writing '%s'", fileName.c_str());
 		return Common::kWritingFailed;
 	}
 

--- a/engines/saga2/button.cpp
+++ b/engines/saga2/button.cpp
@@ -857,7 +857,7 @@ bool GfxSlider::pointerHit(gPanelMessage &msg) {
 	// update the image index
 	updateSliderIndexes(msg.pickPos);
 
-	// redraw the control should any visual change hath occured
+	// redraw the control should any visual change hath occurred
 	window.update(_extent);
 
 	activate(gEventMouseDown);
@@ -869,7 +869,7 @@ void GfxSlider::pointerMove(gPanelMessage &msg) {
 		// update the image index
 		updateSliderIndexes(msg.pickPos);
 
-		// redraw the control should any visual change hath occured
+		// redraw the control should any visual change hath occurred
 		window.update(_extent);
 
 		notify(gEventMouseMove, _slCurrent);
@@ -889,7 +889,7 @@ void GfxSlider::pointerDrag(gPanelMessage &msg) {
 	updateSliderIndexes(msg.pickPos);
 
 	notify(gEventNewValue, _slCurrent);       // notify App of successful hit
-	// redraw the control should any visual change hath occured
+	// redraw the control should any visual change hath occurred
 	window.update(_extent);
 }
 

--- a/engines/saga2/gtextbox.cpp
+++ b/engines/saga2/gtextbox.cpp
@@ -68,7 +68,7 @@ extern gFont        *mainFont;
 *
 *   /h2/NOTIFICATIONS
 *       This class sends a gEventNewValue whenever the text box becomes
-*       deactivated. If the deactivation occured because of the user
+*       deactivated. If the deactivation occurred because of the user
 *       hitting return, then the value of the event will be 1; In all
 *       other cases it is zero.
 *

--- a/engines/saga2/panel.cpp
+++ b/engines/saga2/panel.cpp
@@ -925,7 +925,7 @@ void gToolBase::handleMouse(Common::Event &event, uint32 time) {
 	        || prevState.right != _curMouseState.right) {
 
 		//  If both buttons were previously up, then a mouse
-		//  hit must have occured.
+		//  hit must have occurred.
 
 		if (prevState.left == 0 && prevState.right == 0) {
 

--- a/engines/saga2/tile.cpp
+++ b/engines/saga2/tile.cpp
@@ -3942,7 +3942,7 @@ StaticTilePoint pickTile(Point32 pos,
 	relPos.x = pos.x - curMap->mapHeight - (tileCoords.u - tileCoords.v) * kTileDX;
 	relPos.y = curMap->mapHeight - pos.y - (tileCoords.u + tileCoords.v) * kTileDY;
 
-	//  Compute which metatile the click occured on, and the tile
+	//  Compute which metatile the click occurred on, and the tile
 	//  within that metatile, and the origin coords of the metatile
 	mCoords = tileCoords >> kPlatShift;
 	tCoords.u = tileCoords.u & kPlatMask;

--- a/engines/stark/stark.cpp
+++ b/engines/stark/stark.cpp
@@ -384,7 +384,7 @@ Common::Error StarkEngine::loadGameState(int slot) {
 	}
 
 	if (stream.err()) {
-		warning("An error occured when reading '%s'", filename.c_str());
+		warning("An error occurred when reading '%s'", filename.c_str());
 		return Common::kReadingFailed;
 	}
 
@@ -453,7 +453,7 @@ Common::Error StarkEngine::saveGameState(int slot, const Common::String &desc, b
 	}
 
 	if (save->err()) {
-		warning("An error occured when writing '%s'", filename.c_str());
+		warning("An error occurred when writing '%s'", filename.c_str());
 		delete save;
 		return Common::kWritingFailed;
 	}


### PR DESCRIPTION
Fixing this misspelled word across multiple parts of the codebase.

See ["Occurred, Occured, or Ocurred—Which Spelling Is Right?"](https://www.grammarly.com/blog/occurred-occured-ocurred/)