### PR TITLE
GRIM: Partially revert 6bb4658ea6 to work around bug #12932

### DIFF
--- a/engines/grim/imuse/imuse.h
+++ b/engines/grim/imuse/imuse.h
@@ -65,7 +65,6 @@ private:
 	void fadeOutMusic(int fadeDelay);
 	void fadeOutMusicAndStartNew(int fadeDelay, const char *filename, int hookId, int vol, int pan);
 	Track *cloneToFadeOutTrack(Track *track, int fadeDelay);
-	Track *moveToFadeOutTrack(Track *track, int fadeDelay);
 
 	void playMusic(const ImuseTable *table, int atribPos, bool sequence);
 


### PR DESCRIPTION
The moveToFadeOutTrack() function was introduced many years ago to fix "sound skipping a bit when a fade out track starts". Unfortunately, while this may have worked flawlessly back then it causes crashes in certain cases now. See https://bugs.scummvm.org/ticket/12932 for details.

The point of this is to avoid the crash for the upcoming release. A more long-term solution should be in the works. See https://github.com/scummvm/scummvm/pull/3368

I did not revert this part, because it looked harmless to me. I could be wrong about that:

```
@@ -216,7 +216,7 @@ void Imuse::callback() {
			// Ignore tracks which are about to finish. Also, if it did finish in the meantime,
			// mark it as unused.
			if (!track->stream) {
-				if (!g_system->getMixer()->isSoundHandleActive(track->handle))
+				if (!track->soundDesc || !g_system->getMixer()->isSoundHandleActive(track->handle))
					memset(track, 0, sizeof(Track));
				continue;
			}
```