### PR TITLE
CLOUD: Update Networking::Reader to increase file upload speed

### DIFF
--- a/backends/networking/sdl_net/reader.h
+++ b/backends/networking/sdl_net/reader.h
@@ -78,7 +78,7 @@ class Reader {
 	uint32 _bytesLeft;
 
 	byte *_window;
-	uint32 _windowUsed, _windowSize;
+	uint32 _windowUsed, _windowSize, _windowReadPosition, _windowWritePosition;
 
 	Common::MemoryReadWriteStream *_headersStream;
 

--- a/backends/networking/sdl_net/reader.h
+++ b/backends/networking/sdl_net/reader.h
@@ -79,6 +79,7 @@ class Reader {
 
 	byte *_window;
 	uint32 _windowUsed, _windowSize, _windowReadPosition, _windowWritePosition;
+	uint32 _windowHash;
 
 	Common::MemoryReadWriteStream *_headersStream;
 
@@ -105,7 +106,7 @@ class Reader {
 
 	void makeWindow(uint32 size);
 	void freeWindow();
-	bool readOneByteInStream(Common::WriteStream *stream, const Common::String &boundary);
+	bool readOneByteInStream(Common::WriteStream *stream, const Common::String &boundary, const uint32 boundaryHash);
 
 	byte readOne();
 	uint32 bytesLeft() const;


### PR DESCRIPTION
This only changes what's related to the local webserver (SDL_net), not to the Cloud sync (libcurl). 

I revisited Networking::Reader (remembering that file upload speed wasn't as fast as I wanted it to be). This class uses a "window" buffer to detect the boundaries in POST multipart requests.

First commit does what I actually intended to do back in the GSoC days: have a circular buffer, so we don't have to shift the whole buffer all the time.

The second commit tries to avoid doing unnecessary linear string comparisons all the time by calculating a "hash" of a boundary string and dynamically recalculating "hash" of what's in buffer. Strings are only compared if these "hashes" match. This is not exactly a hash, as it's just a xor sum of all the bytes in the string/buffer. If someone knows how to implement an actual hash there -- be my guest. Simple xor sum probably gives a lot of false positives, and a better hash would decrease the amount of unnecessary checks, resulting in the increased upload speed. UPD: I've tried using a simple hash, and it not only didn't increase the speed, but also slowed it down, so it seems xorsum works just fine.

I did a couple of measurements and it seems these two changes increase file upload speed by 1.5-1.7 times.