### PR TITLE
SDL: Fix full screen toggling for 3D games

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -401,9 +401,13 @@ void SdlGraphicsManager::toggleFullScreen() {
 		return;
 	}
 
-	beginGFXTransaction();
+	bool is3D = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
+
+	if (!is3D)
+		beginGFXTransaction();
 	setFeatureState(OSystem::kFeatureFullscreenMode, !getFeatureState(OSystem::kFeatureFullscreenMode));
-	endGFXTransaction();
+	if (!is3D)
+		endGFXTransaction();
 #ifdef USE_OSD
 	if (getFeatureState(OSystem::kFeatureFullscreenMode))
 		displayMessageOnOSD(_("Fullscreen mode"));


### PR DESCRIPTION
The previous SdlGraphics3dManager::toggleFullScreen() was not using
beginGFXTransaction / endGFXTransaction in toggleFullScreen().
Restore this logic for 3D games, as using transactions in such games
results in a black screen for 3D games when switching to full screen

A regression from d33487f64

Alternate fix for the situation reported in PR #3387