### PR TITLE
NEVERHOOD: Possible fix for bug #12930 (crash on exit)

### DIFF
--- a/engines/neverhood/sound.cpp
+++ b/engines/neverhood/sound.cpp
@@ -421,6 +421,11 @@ void SoundMan::deleteSoundGroup(uint32 groupNameHash) {
 		_soundIndex2 = -1;
 	}
 
+	if (_soundIndex3 != -1 && _soundItems[_soundIndex3]->getGroupNameHash() == groupNameHash) {
+		deleteSoundByIndex(_soundIndex3);
+		_soundIndex3 = -1;
+	}
+
 	for (uint index = 0; index < _soundItems.size(); ++index)
 		if (_soundItems[index] && _soundItems[index]->getGroupNameHash() == groupNameHash)
 			deleteSoundByIndex(index);


### PR DESCRIPTION
This is the fix I suggested on https://bugs.scummvm.org/ticket/12930

I don't know if it's correct - I never got any feedback on it - but it does seem to fix the game crashing on exit for me. If I'm right, it was trying to keep playing a sound after the audio data for it had been freed. With the change, sound 3 is handled the same way as sounds 1 and 2, i.e. stopped first.