### PR TITLE
STARK: Adding mechanism to correct subtitles

### DIFF
--- a/engines/stark/resources/speech.cpp
+++ b/engines/stark/resources/speech.cpp
@@ -149,8 +149,16 @@ int32 Speech::getPauseAfterSpeechDuration() const {
 void Speech::readData(Formats::XRCReadStream *stream) {
 	Object::readData(stream);
 
-	_phrase = stream->readString();
+	_phrase = correctSubtitle(stream->readString());
 	_character = stream->readSint32LE();
+}
+
+Common::String Speech::correctSubtitle(Common::String phrase) {
+	if (phrase.equals("Nyo! So it was a good thing I didn't stick my head out the door to look for you, then, si?")) {
+		// Cortez in the theater
+		Common::replace(phrase, "si?", "no?");
+	}
+	return phrase;
 }
 
 void Speech::onGameLoop() {

--- a/engines/stark/resources/speech.h
+++ b/engines/stark/resources/speech.h
@@ -99,6 +99,10 @@ protected:
 	Sound *_soundResource;
 	LipSync *_lipSync;
 	int32 _waitTimeRemaining;
+
+private:
+    /** Fix subtitles that do not match the spoken dialogue. */
+    Common::String correctSubtitle(Common::String phrase);
 };
 
 } // End of namespace Resources


### PR DESCRIPTION
Fixes [#12967](https://bugs.scummvm.org/ticket/12967)

If there are any additional subtitles that don't match the spoken dialogue, we can correct them too.

<img width="752" alt="Corrected subtitle" src="https://user-images.githubusercontent.com/6200170/135368364-d918976f-83e3-419b-b042-63776da7485c.png">