### PR TITLE
Fix restoring window size when exiting fullscreen

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -349,27 +349,29 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	bool isMaximized = ConfMan.getBool("window_maximized", Common::ConfigManager::kApplicationDomain);
-	if (isMaximized && !_wantsFullScreen && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
-		// Set the window size to the values stored when the window was maximized
-		// for the last time.
-		requestedWidth  = ConfMan.getInt("window_maximized_width", Common::ConfigManager::kApplicationDomain);
-		requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
+	if (!_wantsFullScreen) {
+		if (isMaximized && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
+			// Set the window size to the values stored when the window was maximized
+			// for the last time.
+			requestedWidth  = ConfMan.getInt("window_maximized_width", Common::ConfigManager::kApplicationDomain);
+			requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
 
-	} else if (!isMaximized && !_wantsFullScreen && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
-		// Load previously stored window dimensions.
-		requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
-		requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);
+		} else if (!isMaximized && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
+			// Load previously stored window dimensions.
+			requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
+			requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);
 
-	} else {
-		// Set the basic window size based on the desktop resolution
-		// since we have no values stored, e.g. on first launch.
-		requestedWidth  = MAX<uint>(desktopRes.width() / 2, 640);
-		requestedHeight = requestedWidth * 3 / 4;
+		} else {
+			// Set the basic window size based on the desktop resolution
+			// since we have no values stored, e.g. on first launch.
+			requestedWidth  = MAX<uint>(desktopRes.width() / 2, 640);
+			requestedHeight = requestedWidth * 3 / 4;
 
-		// Save current window dimensions
-		ConfMan.setInt("last_window_width", requestedWidth, Common::ConfigManager::kApplicationDomain);
-		ConfMan.setInt("last_window_height", requestedHeight, Common::ConfigManager::kApplicationDomain);
-		ConfMan.flushToDisk();
+			// Save current window dimensions
+			ConfMan.setInt("last_window_width", requestedWidth, Common::ConfigManager::kApplicationDomain);
+			ConfMan.setInt("last_window_height", requestedHeight, Common::ConfigManager::kApplicationDomain);
+			ConfMan.flushToDisk();
+		}
 	}
 
 #else

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -348,8 +348,7 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	Common::Rect desktopRes = _window->getDesktopResolution();
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	SDL_Window *window = _window->getSDLWindow();
-	bool isMaximized = window ? (SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED) : false;
+	bool isMaximized = ConfMan.getBool("window_maximized", Common::ConfigManager::kApplicationDomain);
 	if (isMaximized && !_wantsFullScreen && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
 		// Set the window size to the values stored when the window was maximized
 		// for the last time.


### PR DESCRIPTION
There were two different issues:
 - On macOS the window was always restored to the maximum window size and not to the previous window size.
 - The window was restored to the default size and not to the previous window size.

The first issue might be specific to macOS, for which fullscreen more or less means maximized, and in particular when requesting a `SDL_WINDOW_FULLSCREEN_DESKTOP` window, the `SDL_WINDOW_MAXIMIZED` flag gets also set. As a result, when we exit fullscreen, `loadVideoMode()` gets called while the window is still fullscreen, and checking the window flag indicate it is maximized. As a result it tries to restore the maximized size. Since we store in the config if the window was maximized, instead of looking at the SDL window flag we can use the flag we stored in the config.

That issue only occurred if maximized size was stored in the config file (i.e. if the window had been maximized by the user at least once in the past).

The second issue was more general. In `loadVideoMode()` when switching to fullscreen, it was storing the default size in the config, overwriting the current window size. So when exiting fullscreen, the size was restored to the default size (since this is what was stored in the config). I don't think this was intended, and at least it seems to me that restoring to the size the window had before entering fullscreen would be what is expected.

As the SDL behaviour may be different on other systems, it would be good to test that this works as expected on other systems (e.g. Windows and Linux) before merging this change.

Note: On macOS setting the `SDL_WINDOW_MAXIMIZED` does not quite work properly. The window is resized to fill the screen, but with the menubar and title bar still visible. That means that if we maximize the window (maximize button in window title bar), then go fullscreen (Alt+Enter) and then exit fullscreen (Alt+Enter), we get an almost-maximised window but not exactly what we had before entering fullscreen.