### PR TITLE
TWINE: Additional stream checks when loading the body data

### DIFF
--- a/engines/twine/parser/body.cpp
+++ b/engines/twine/parser/body.cpp
@@ -37,6 +37,9 @@ void BodyData::reset() {
 
 void BodyData::loadVertices(Common::SeekableReadStream &stream) {
 	const uint16 numVertices = stream.readUint16LE();
+	if (stream.eos())
+		return;
+
 	_vertices.reserve(numVertices);
 	for (uint16 i = 0U; i < numVertices; ++i) {
 		const int16 x = stream.readSint16LE();
@@ -49,6 +52,9 @@ void BodyData::loadVertices(Common::SeekableReadStream &stream) {
 
 void BodyData::loadBones(Common::SeekableReadStream &stream) {
 	const uint16 numBones = stream.readUint16LE();
+	if (stream.eos())
+		return;
+
 	_bones.reserve(numBones);
 	for (uint16 i = 0; i < numBones; ++i) {
 		const int16 firstPoint = stream.readSint16LE() / 6;
@@ -88,6 +94,9 @@ void BodyData::loadBones(Common::SeekableReadStream &stream) {
 
 void BodyData::loadShades(Common::SeekableReadStream &stream) {
 	const uint16 numShades = stream.readUint16LE();
+	if (stream.eos())
+		return;
+
 	_shades.reserve(numShades);
 	for (uint16 i = 0; i < numShades; ++i) {
 		BodyShade shape;
@@ -101,6 +110,9 @@ void BodyData::loadShades(Common::SeekableReadStream &stream) {
 
 void BodyData::loadPolygons(Common::SeekableReadStream &stream) {
 	const uint16 numPolygons = stream.readUint16LE();
+	if (stream.eos())
+		return;
+
 	_polygons.reserve(numPolygons);
 	for (uint16 i = 0; i < numPolygons; ++i) {
 		BodyPolygon poly;
@@ -130,6 +142,9 @@ void BodyData::loadPolygons(Common::SeekableReadStream &stream) {
 
 void BodyData::loadLines(Common::SeekableReadStream &stream) {
 	const uint16 numLines = stream.readUint16LE();
+	if (stream.eos())
+		return;
+
 	_lines.reserve(numLines);
 	for (uint16 i = 0; i < numLines; ++i) {
 		BodyLine line;
@@ -144,6 +159,9 @@ void BodyData::loadLines(Common::SeekableReadStream &stream) {
 
 void BodyData::loadSpheres(Common::SeekableReadStream &stream) {
 	const uint16 numSpheres = stream.readUint16LE();
+	if (stream.eos())
+		return;
+
 	_spheres.reserve(numSpheres);
 	for (uint16 i = 0; i < numSpheres; ++i) {
 		BodySphere sphere;

--- a/engines/twine/scene/grid.h
+++ b/engines/twine/scene/grid.h
@@ -180,14 +180,13 @@ private:
 	const BrickEntry* getBrickEntry(int32 j, int32 i) const;
 
 	const IVec3 &updateCollisionCoordinates(int32 x, int32 y, int32 z);
+
+	BlockEntry getBlockEntry(int32 x, int32 y, int32 z) const;
 public:
 	Grid(TwinEEngine *engine);
 	~Grid();
 
 	void init(int32 w, int32 h);
-
-	/** Grid block entry types */
-	typedef struct BlockEntry blockMap[GRID_SIZE_X][GRID_SIZE_Z][GRID_SIZE_Y];
 
 	/**
 	 * search down until either ground is found or lower border of the cube is reached


### PR DESCRIPTION
This fixes a crash on startup on RISC OS. It doesn't get in game however, since it hits the following assert:

```
"./common/array.h", line 244: const T& Common::Array<T>::operator[](Common::Array<T>::size_type) const [with T = TwinE::BlockDataEntry; Common::Array<T>::size_type = unsigned int]: Assertion failed: idx < _size

Fatal signal received: Aborted

Stack backtrace:

Running thread 0xab6848 (Main Thread)
  (  bf8758) pc:   56b6ec lr:   56bb98 sp:   bf875c  __write_backtrace()
  (  bf87c8) pc:   56b80c lr:   56bef8 sp:   bf87cc  __unixlib_raise_signal()
  (  bf87d8) pc:   56bedc lr:   573bc0 sp:   bf87dc  raise()
  (  bf87ec) pc:   573b84 lr:   54e808 sp:   bf87f0  abort()
  (  bf8810) pc:   54e7b0 lr:   563b78 sp:   bf8814  __assert2()
  (  bf8824) pc:    a8bcc lr:    a9844 sp:   bf8828  TwinE::Grid::getBlockPointer(int, int) const
  (  bf8868) pc:    a982c lr:    a9ba0 sp:   bf886c  TwinE::Grid::drawColumnGrid(int, int, int, int, int)
  (  bf889c) pc:    a9a8c lr:    95364 sp:   bf88a0  TwinE::Grid::redrawGrid()
  (  bf96cc) pc:    952d8 lr:    7c4e8 sp:   bf96d0  TwinE::Redraw::redrawEngineActions(bool)
  (  bf9720) pc:    7bc88 lr:    7ca3c sp:   bf9724  TwinE::TwinEEngine::runGameEngine()
  (  bf9740) pc:    7c9c4 lr:    7cee4 sp:   bf9744  TwinE::TwinEEngine::gameEngineLoop()
  (  bf9990) pc:    7cadc lr:    5989c sp:   bf9994  TwinE::TwinEEngine::run()
  (  abc490) pc:    5934c lr:   5798a0 sp:   abc494  runGame(Plugin const*, Plugin const*, OSystem&, Common::String const&)
  (  abcfc8) pc:    5abbc lr:     f3b4 sp:   abcfcc  scummvm_main()
  (  abcfec) pc:     f320 lr:   579374 sp:   abcff0  main()


Thread 0xadc570 (scummvm)
  (  bf873c) pc:   563c5c lr:   3f2d90 sp:   addf80  __pthread_yield_return()
  (  addf8c) pc:   563bd4 lr:   3f2d90 sp:   addf90  pthread_yield()
  (  addfb0) pc:   3f2d28 lr:   3f2e14 sp:   addfb4  ?()
  (  addfc8) pc:   3f2dec lr:   3e9c70 sp:   addfcc  ?()
  (  addfe4) pc:   3e9c34 lr:   3f15a4 sp:   addfe8  ?()
  (  addff4) pc:   3f1598 lr:   561d14 sp:   addff8  ?()
  (  ade004) pc:   561cfc lr:        0 sp:   ade008  __pthread_create()


Thread 0xad8cf8 (scummvm)
  (  bf873c) pc:   563c5c lr:   5aa40c sp:   ad9f28  __pthread_yield_return()
  (  ad9f34) pc:   563bd4 lr:   5aa40c sp:   ad9f38  pthread_yield()
  (  ad9f60) pc:   5aa378 lr:   583a8c sp:   ad9f64  __dspwrite()
  (  ad9f88) pc:   5839d4 lr:   3f0698 sp:   ad9f8c  write()
  (  ad9f9c) pc:   3f0678 lr:   3e3c18 sp:   ad9fa0  ?()
  (  ad9fc8) pc:   3e3b50 lr:   3e9c70 sp:   ad9fcc  ?()
  (  ad9fe4) pc:   3e9c34 lr:   3f15a4 sp:   ad9fe8  ?()
  (  ad9ff4) pc:   3f1598 lr:   561d14 sp:   ad9ff8  ?()
  (  ada004) pc:   561cfc lr:        0 sp:   ada008  __pthread_create()
```