### PR TITLE
KYRA: HOF: Fix hebrew multiword object action strings

### DIFF
--- a/engines/kyra/engine/kyra_hof.cpp
+++ b/engines/kyra/engine/kyra_hof.cpp
@@ -872,7 +872,7 @@ void KyraEngine_HoF::showChapterMessage(int id, int16 palIndex) {
 void KyraEngine_HoF::updateCommandLineEx(int str1, int str2, int16 palIndex) {
 	Common::String str = getTableString(str1, _cCodeBuffer, true);
 
-	if (_flags.lang != Common::JA_JPN) {
+	if (_flags.lang != Common::JA_JPN && _flags.lang != Common::HE_ISR) {
 		if (uint32 i = (uint32)str.findFirstOf(' ') + 1) {
 			str.erase(0, i);
 			str.setChar(toupper(str[0]), 0);
@@ -880,9 +880,12 @@ void KyraEngine_HoF::updateCommandLineEx(int str1, int str2, int16 palIndex) {
 	}
 
 	if (str2 > 0) {
-		if (_flags.lang != Common::JA_JPN)
+		if (_flags.lang != Common::JA_JPN && _flags.lang != Common::HE_ISR)
 			str += " ";
-		str += getTableString(str2, _cCodeBuffer, 1);
+		if (_flags.lang != Common::HE_ISR)
+			str += getTableString(str2, _cCodeBuffer, 1);
+		else
+			str = getTableString(str2, _cCodeBuffer, 1) + " " + str + ".";
 	}
 
 	showMessage(str, palIndex);


### PR DESCRIPTION
Following #3277

This PR fixes the action string for multi-worded object in Hebrew fan translation of Kyrandia 2
as well as reversing the order of the sentence.

The game resource have objects names along with the indefinte article,
then, on command string, the engine removes the article and uppercase the first letter, e.g.
an empty flask -> Empty flask taken.

This logic caused object with multiple words to skip the first word in hebrew.

The reversing of the sentences is to avoid having to consider the object gender,
so the sentence become dependent on the player and not the object
(you (plural, indefinite) have dropped [object].) instead of ([object] placed (gender needs to match).)

Thanks
