### PR TITLE
DIRECTOR: Handle 0 byte Fmap in Cast::loadFontMapV4

### DIFF
--- a/engines/director/fonts.cpp
+++ b/engines/director/fonts.cpp
@@ -66,6 +66,9 @@ void Cast::loadFontMap(Common::SeekableReadStreamEndian &stream) {
 }
 
 void Cast::loadFontMapV4(Common::SeekableReadStreamEndian &stream) {
+	if (stream.size() == 0)
+		return;
+
 	debugC(2, kDebugLoading, "****** Loading FontMap Fmap");
 
 	uint32 mapLength = stream.readUint32();


### PR DESCRIPTION
Stephen Jay Gould demo has a 0 byte Fmap which makes ScummVM crash. This is basically a copy/paste from Cast::loadFont.

[Demo link](https://cdn.discordapp.com/attachments/636495083935629325/896308869599461427/Stephen_Jay_Gould.7z)