### PR TITLE
GROOVIE: check for USE_MAD for MP3

### DIFF
--- a/engines/groovie/music.cpp
+++ b/engines/groovie/music.cpp
@@ -808,8 +808,10 @@ bool MusicPlayerTlc::load(uint32 fileref, bool loop) {
 	if (_file->isOpen()) {
 		if (filename.hasSuffix(".m4a"))
 			seekStream = Audio::makeQuickTimeStream(_file, DisposeAfterUse::NO);
+#ifdef USE_MAD
 		else
 			seekStream = Audio::makeMP3Stream(_file, DisposeAfterUse::NO);
+#endif
 	} else {
 		delete _file;
 		_file = NULL;


### PR DESCRIPTION
The groovie engine is unconditionally trying to acess the `Audio::makeMP3Stream` method, which won't exist if ScummVM is being compiled without MAD. Other consumers use this `#ifdef` to determine if they should try to call it, so I've made the same change here.