### PR TITLE
GUI: Don't apply values from disabled subtitle toggle

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -231,6 +231,7 @@ void OptionsDialog::init() {
 	_speechVolumeLabel = nullptr;
 	_muteCheckbox = nullptr;
 	_enableSubtitleSettings = false;
+	_enableSubtitleToggle = false;
 	_subToggleDesc = nullptr;
 	_subToggleGroup = nullptr;
 	_subToggleSubOnly = nullptr;
@@ -909,11 +910,9 @@ void OptionsDialog::apply() {
 	// Subtitle options
 	if (_subToggleGroup) {
 		if (_enableSubtitleSettings) {
-			bool subtitles, speech_mute;
-			int talkspeed;
-			int sliderMaxValue = _subSpeedSlider->getMaxValue();
-
-			switch (_subToggleGroup->getValue()) {
+			if (_enableSubtitleToggle) {
+				bool subtitles, speech_mute;
+				switch (_subToggleGroup->getValue()) {
 				case kSubtitlesSpeech:
 					subtitles = speech_mute = false;
 					break;
@@ -925,14 +924,19 @@ void OptionsDialog::apply() {
 				default:
 					subtitles = speech_mute = true;
 					break;
-			}
+				}
 
-			ConfMan.setBool("subtitles", subtitles, _domain);
-			ConfMan.setBool("speech_mute", speech_mute, _domain);
+				ConfMan.setBool("subtitles", subtitles, _domain);
+				ConfMan.setBool("speech_mute", speech_mute, _domain);
+			} else {
+				ConfMan.removeKey("subtitles", _domain);
+				ConfMan.removeKey("speech_mute", _domain);
+			}
 
 			// Engines that reuse the subtitle speed widget set their own max value.
 			// Scale the config value accordingly (see addSubtitleControls)
-			talkspeed = (_subSpeedSlider->getValue() * 255 + sliderMaxValue / 2) / sliderMaxValue;
+			int sliderMaxValue = _subSpeedSlider->getMaxValue();
+			int talkspeed = (_subSpeedSlider->getValue() * 255 + sliderMaxValue / 2) / sliderMaxValue;
 			ConfMan.setInt("talkspeed", talkspeed, _domain);
 
 		} else {
@@ -1218,6 +1222,7 @@ void OptionsDialog::setSubtitleSettingsState(bool enabled) {
 	if ((_guioptions.contains(GUIO_NOSUBTITLES)) || (_guioptions.contains(GUIO_NOSPEECH)))
 		ena = false;
 
+	_enableSubtitleToggle = ena;
 	_subToggleGroup->setEnabled(ena);
 	_subToggleDesc->setEnabled(ena);
 
@@ -1678,6 +1683,7 @@ void OptionsDialog::addSubtitleControls(GuiObject *boss, const Common::String &p
 	_subSpeedLabel->setFlags(WIDGET_CLEARBG);
 
 	_enableSubtitleSettings = true;
+	_enableSubtitleToggle = true;
 }
 
 void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &prefix) {

--- a/gui/options.h
+++ b/gui/options.h
@@ -208,6 +208,7 @@ private:
 	//
 	int getSubtitleMode(bool subtitles, bool speech_mute);
 	bool _enableSubtitleSettings;
+	bool _enableSubtitleToggle;
 	StaticTextWidget *_subToggleDesc;
 	RadiobuttonGroup *_subToggleGroup;
 	RadiobuttonWidget *_subToggleSubOnly;


### PR DESCRIPTION
Fixes bug #13007 where selecting "Override global audio settings" always mutes the (few) speech clips in Hoyle4.

The GUI's subtitle toggle controls are disabled in a game's options when GUIO_NOSUBTITLES or GUIO_NOSPEECH set. But the GUI reads from the subtitle toggle even if it's disabled and writes config values based on it. This means that selecting "Override global audio settings" has side effects that the user can't see or control, such as setting "mute_speech" and muting all kSpeechSoundType. That usually doesn't matter, given the games that disable the controls in the first place, but some games like Hoyle4 are GUIO_NOSPEECH but happen to use speech functions for a small number of things. (Hoyle4 is a floppy disk game and a few short message texts have accompanying speech audio like "I win!" or the rank and suit of a card.)

I made a separate member variable for tracking this state instead of querying the control's enabled status directly because _subToggleGroup is a RadiobuttonGroup and that's not a Widget so it doesn't have isEnabled(). This seemed cleaner than querying one of the subcontrols.

Another response is that if Hoyle4 is using any speech functionality then we should remove GUIO_NOSPEECH so that the toggle is enabled and the user can control it. That may be something we also do on the SCI side, though I don't think it makes much sense for this game, but the current toggle behavior doesn't seem intentional or expected so I'm starting here.