### PR TITLE
SCUMM: Fix no subtitles after Loom Talkie intro

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -632,7 +632,14 @@ void ScummEngine::writeVar(uint var, int value) {
 			if (_game.heversion >= 60 && vm.slot[_currentScript].number == 1)
 				return;
 			assert(value == 0 || value == 1);
-			ConfMan.setBool("subtitles", !value);
+			if (_game.id == GID_LOOM && _game.version == 4 && _currentRoom == 2 && vm.slot[_currentScript].number == 44 && value == 1) {
+				// Fix for bug: During the intro of LOOM CD Talkie, subtitles would be explicitly disabled
+				// after the LOOM logo is displayed and the swans have flown by between the logo letters.
+				// This would cause the game to not display subtitles for the messenger nymph or Bobbin's intro speech
+				// and moveover the gameplay would then start with subtitles disabled.
+			} else {
+				ConfMan.setBool("subtitles", !value);
+			}
 		}
 
 		if (var == VAR_CHARINC) {


### PR DESCRIPTION
Possible fix for bug https://bugs.scummvm.org/ticket/13022

If the game is allowed to play the intro without skipping it, then subtitles will be disabled for the messenger nymph speech, Bobbin's thoughts afterwards, and also the gameplay will start in no subtitles mode. 

This PR skips setting the subtitles to false at that point of the intro cutscene (after the logo) and as a result, subtitles will be shown and the game will start with a subtitles setting that respects the ScummVM configuration. 

**Edit**: I've re-read the old thread in the forums where this issue was first reported. It seems that a fix for this was rejected in the past, because of potential side-effects:
Forum thread:
https://forums.scummvm.org/viewtopic.php?f=2&t=3327
Feature Request discussion on sourceforge:
https://sourceforge.net/p/scummvm/feature-requests/94/

Since I'm not an expert on the SCUMM engine, I'll leave this open for review. It could be that the circumstances and the code has changed enough so that this can not be safely fixed, but I cannot tell if this is the case.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
