### PR TITLE
DIRECTOR: Fix compilation with C++98

### DIFF
--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -71,7 +71,13 @@ Sprite::Sprite(Frame *frame) {
 	_stretch = 0;
 }
 
-Sprite::Sprite(const Sprite &sprite) {
+Sprite& Sprite::operator=(const Sprite &sprite) {
+	if (this == &sprite) {
+		return *this;
+	}
+
+	this->~Sprite();
+
 	_frame = sprite._frame;
 	_score = sprite._score;
 	_movie = sprite._movie;
@@ -108,6 +114,13 @@ Sprite::Sprite(const Sprite &sprite) {
 
 	_volume = sprite._volume;
 	_stretch = sprite._stretch;
+
+	return *this;
+}
+
+Sprite::Sprite(const Sprite &sprite) {
+	_matte = nullptr;
+	*this = sprite;
 }
 
 Sprite::~Sprite() {

--- a/engines/director/sprite.h
+++ b/engines/director/sprite.h
@@ -61,7 +61,7 @@ class Sprite {
 public:
 	Sprite(Frame *frame = nullptr);
 	Sprite(const Sprite &sprite);
-	Sprite& operator=(const Sprite &sprite) = default;
+	Sprite& operator=(const Sprite &sprite);
 	~Sprite();
 
 	Frame *getFrame() const { return _frame; }


### PR DESCRIPTION
The default assignment constructor just copies data over and we could
end up with _matte pointing twice to the same surface. It's now properly
reseted.
