### PR TITLE
ENGINES: Add missing getSavegameFile overrides

### DIFF
--- a/engines/composer/metaengine.cpp
+++ b/engines/composer/metaengine.cpp
@@ -76,6 +76,14 @@ public:
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char* target) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.##", target);
+		else
+			return Common::String::format("%s.%02d", target, saveGameIdx);
+	}
 };
 
 Common::Error ComposerMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
@@ -103,9 +111,8 @@ SaveStateList ComposerMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::StringArray filenames;
 	Common::String saveDesc;
-	Common::String pattern = Common::String::format("%s.##", target);
 
-	filenames = saveFileMan->listSavefiles(pattern);
+	filenames = saveFileMan->listSavefiles(getSavegameFilePattern(target));
 
 	SaveStateList saveList;
 	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -79,6 +79,14 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 999; }
 	void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.####", target);
+		else
+			return Common::String::format("%s.%04d", target, saveGameIdx + 1);
+	}
 };
 
 bool CryOmni3DMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -98,8 +106,7 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 
 	char saveName[kSaveDescriptionLen + 1];
 	saveName[kSaveDescriptionLen] = '\0';
-	Common::String pattern = Common::String::format("%s.????", target);
-	Common::StringArray filenames = saveMan->listSavefiles(pattern);
+	Common::StringArray filenames = saveMan->listSavefiles(getSavegameFilePattern(target));
 	sort(filenames.begin(), filenames.end());   // Sort (hopefully ensuring we are sorted numerically..)
 
 	int slotNum;
@@ -124,9 +131,7 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 }
 
 void CryOmni3DMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String filename = Common::String::format("%s.%04d", target, slot + 1);
-
-	g_system->getSavefileManager()->removeSavefile(filename);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 Common::Error CryOmni3DMetaEngine::createInstance(OSystem *syst, Engine **engine,

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -53,7 +53,14 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	void removeSaveState(const char *target, int slot) const override;
-
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s-##.SAV", target);
+		else
+			return Common::String::format("%s-%02d.SAV", target, saveGameIdx);
+	}
 };
 
 Common::Error HugoMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
@@ -123,8 +130,7 @@ SaveStateList HugoMetaEngine::listSaves(const char *target) const {
 }
 
 SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
-	Common::String fileName = Common::String::format("%s-%02d.SAV", target, slot);
-	Common::InSaveFile *file = g_system->getSavefileManager()->openForLoading(fileName);
+	Common::InSaveFile *file = g_system->getSavefileManager()->openForLoading(getSavegameFile(slot, target));
 
 	if (file) {
 		int saveVersion = file->readByte();
@@ -171,8 +177,7 @@ SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int s
 }
 
 void HugoMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String fileName = Common::String::format("%s-%02d.SAV", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 } // End of namespace Hugo

--- a/engines/lilliput/metaengine.cpp
+++ b/engines/lilliput/metaengine.cpp
@@ -57,6 +57,14 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s-##.SAV", target);
+		else
+			return Common::String::format("%s-%02d.SAV", target, saveGameIdx);
+	}
 };
 
 Common::Error LilliputMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
@@ -128,8 +136,7 @@ SaveStateList LilliputMetaEngine::listSaves(const char *target) const {
 }
 
 SaveStateDescriptor LilliputMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
-	Common::String fileName = Common::String::format("%s-%02d.SAV", target, slot);
-	Common::InSaveFile *file = g_system->getSavefileManager()->openForLoading(fileName);
+	Common::InSaveFile *file = g_system->getSavefileManager()->openForLoading(getSavegameFile(slot, target));
 
 	if (file) {
 		int saveVersion = file->readByte();
@@ -177,8 +184,7 @@ SaveStateDescriptor LilliputMetaEngine::querySaveMetaInfos(const char *target, i
 }
 
 void LilliputMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String fileName = Common::String::format("%s-%02d.SAV", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 } // End of namespace Lilliput

--- a/engines/stark/metaengine.cpp
+++ b/engines/stark/metaengine.cpp
@@ -118,6 +118,15 @@ public:
 		*engine = new StarkEngine(syst, desc);
 		return Common::kNoError;
 	}
+
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s-###.tlj", target);
+		else
+			return StarkEngine::formatSaveName(target, saveGameIdx);
+	}
 };
 
 } // End of namespace Stark

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -59,8 +59,13 @@ public:
 		return Common::kNoError;
 	}
 
-	static Common::String generateGameStateFileName(const char *target, int slot) {
-		return Common::String::format("%s.%02d", target, slot);
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.##", target);
+		else
+			return Common::String::format("%s.%02d", target, saveGameIdx);
 	}
 
 	SaveStateList listSaves(const char *target) const override {
@@ -94,12 +99,11 @@ public:
 	}
 
 	void removeSaveState(const char *target, int slot) const override {
-		Common::String filename = generateGameStateFileName(target, slot);
-		g_system->getSavefileManager()->removeSavefile(filename);
+		g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 	}
 
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {
-		Common::String filename = generateGameStateFileName(target, slot);
+		Common::String filename = getSavegameFile(slot, target);
 		Common::ScopedPtr<Common::InSaveFile> in(g_system->getSavefileManager()->openForLoading(filename));
 		if (!in)
 			return SaveStateDescriptor();

--- a/engines/tucker/metaengine.cpp
+++ b/engines/tucker/metaengine.cpp
@@ -145,6 +145,12 @@ public:
 		delete file;
 		return desc;
 	}
+
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		return Tucker::generateGameStateFileName(target, saveGameIdx, saveGameIdx == kSavegameFilePattern);
+	}
 };
 
 #if PLUGIN_ENABLED_DYNAMIC(TUCKER)


### PR DESCRIPTION
... for non-default names.

Fixes moving autosave to a new slot.

[Trac #12977](https://bugs.scummvm.org/ticket/12977)
