### PR TITLE
ENGINES: Fix getSavegameFile for almost all engines

### DIFF
--- a/engines/adl/metaengine.cpp
+++ b/engines/adl/metaengine.cpp
@@ -102,7 +102,6 @@ bool AdlMetaEngine::hasFeature(MetaEngineFeature f) const {
 	case kSavesSupportThumbnail:
 	case kSavesSupportCreationDate:
 	case kSavesSupportPlayTime:
-	case kSimpleSavesNames:
 		return true;
 	default:
 		return false;

--- a/engines/buried/metaengine.cpp
+++ b/engines/buried/metaengine.cpp
@@ -75,15 +75,23 @@ Common::Language BuriedEngine::getLanguage() const {
 
 class BuriedMetaEngine : public AdvancedMetaEngine {
 public:
-	const char *getName() const {
+	const char *getName() const override {
 		return "buried";
 	}
 
-	virtual bool hasFeature(MetaEngineFeature f) const;
-	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const;
-	virtual SaveStateList listSaves(const char *target) const;
-	virtual int getMaximumSaveSlot() const { return 999; }
-	virtual void removeSaveState(const char *target, int slot) const;
+	virtual bool hasFeature(MetaEngineFeature f) const override;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	virtual SaveStateList listSaves(const char *target) const override;
+	virtual int getMaximumSaveSlot() const override { return 999; }
+	virtual void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("buried-*.sav");
+		else
+			return Common::String::format("buried-%s.sav", target);
+	}
 };
 
 bool BuriedMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -93,8 +93,7 @@ bool CryOmni3DMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return
 		(f == kSupportsListSaves)
 		|| (f == kSupportsLoadingDuringStartup)
-		|| (f == kSupportsDeleteSave)
-		|| (f == kSimpleSavesNames);
+		|| (f == kSupportsDeleteSave);
 }
 
 SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {

--- a/engines/dm/metaengine.cpp
+++ b/engines/dm/metaengine.cpp
@@ -53,6 +53,7 @@ public:
 			(f == kSupportsLoadingDuringStartup) ||
 			(f == kSavesSupportThumbnail) ||
 			(f == kSavesSupportMetaInfo) ||
+			(f == kSimpleSavesNames) ||
 			(f == kSavesSupportCreationDate);
 	}
 

--- a/engines/dragons/metaengine.cpp
+++ b/engines/dragons/metaengine.cpp
@@ -53,6 +53,7 @@ bool DragonsMetaEngine::hasFeature(MetaEngineFeature f) const {
 			(f == kSupportsLoadingDuringStartup) ||
 			(f == kSavesSupportMetaInfo) ||
 			(f == kSavesSupportThumbnail) ||
+			(f == kSimpleSavesNames) ||
 			(f == kSavesSupportCreationDate);
 }
 
@@ -69,7 +70,7 @@ SaveStateList DragonsMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Dragons::SaveHeader header;
 	Common::String pattern = target;
-	pattern += ".???";
+	pattern += ".###";
 	Common::StringArray filenames;
 	filenames = saveFileMan->listSavefiles(pattern.c_str());
 	SaveStateList saveList;

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -43,6 +43,12 @@ public:
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("DREAMWEB.D##");
+		else
+			return Common::String::format("DREAMWEB.D%02d", saveGameIdx);
+	}
 };
 
 bool DreamWebMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/groovie/metaengine.cpp
+++ b/engines/groovie/metaengine.cpp
@@ -61,6 +61,7 @@ bool GroovieMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsListSaves) ||
 		(f == kSupportsLoadingDuringStartup) ||
 		(f == kSupportsDeleteSave) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportMetaInfo);
 }
 

--- a/engines/hadesch/metaengine.cpp
+++ b/engines/hadesch/metaengine.cpp
@@ -38,6 +38,7 @@ public:
 			(f == kSavesSupportThumbnail) ||
 			(f == kSavesSupportCreationDate) ||
 			(f == kSavesSupportPlayTime) ||
+			(f == kSimpleSavesNames) ||
 			(f == kSavesUseExtendedFormat);
 	}
 

--- a/engines/hdb/metaengine.cpp
+++ b/engines/hdb/metaengine.cpp
@@ -86,6 +86,7 @@ bool HDBMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsDeleteSave) ||
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportPlayTime);
 }
 

--- a/engines/illusions/metaengine.cpp
+++ b/engines/illusions/metaengine.cpp
@@ -67,6 +67,7 @@ bool IllusionsMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsLoadingDuringStartup) ||
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportCreationDate);
 }
 

--- a/engines/kingdom/metaengine.cpp
+++ b/engines/kingdom/metaengine.cpp
@@ -60,6 +60,7 @@ bool KingdomMetaEngine::hasFeature(MetaEngineFeature f) const {
 	    (f == kSupportsDeleteSave) ||
 	    (f == kSavesSupportMetaInfo) ||
 	    (f == kSavesSupportThumbnail) ||
+	    (f == kSimpleSavesNames) ||
 	    (f == kSavesSupportCreationDate);
 }
 

--- a/engines/kyra/metaengine.cpp
+++ b/engines/kyra/metaengine.cpp
@@ -182,7 +182,8 @@ void KyraMetaEngine::removeSaveState(const char *target, int slot) const {
 	// In Kyra games slot 0 can't be deleted, it's for restarting the game(s).
 	// An exception makes Lands of Lore here, it does not have any way to restart the
 	// game except via its main menu.
-	if (slot == 0 && !ConfMan.getDomain(target)->getVal("gameid").equalsIgnoreCase("lol") && !ConfMan.getDomain(target)->getVal("gameid").equalsIgnoreCase("eob") && !ConfMan.getDomain(target)->getVal("gameid").equalsIgnoreCase("eob2"))
+	const Common::String gameId = ConfMan.getDomain(target)->getVal("gameid");
+	if (slot == 0 && !gameId.equalsIgnoreCase("lol") && !gameId.equalsIgnoreCase("eob") && !gameId.equalsIgnoreCase("eob2"))
 		return;
 
 	Common::String filename = Kyra::KyraEngine_v1::getSavegameFilename(target, slot);

--- a/engines/lure/metaengine.cpp
+++ b/engines/lure/metaengine.cpp
@@ -69,6 +69,7 @@ bool LureMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return
 		(f == kSupportsListSaves) ||
 		(f == kSupportsLoadingDuringStartup) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSupportsDeleteSave);
 }
 

--- a/engines/macventure/metaengine.cpp
+++ b/engines/macventure/metaengine.cpp
@@ -64,6 +64,7 @@ bool MacVentureMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportPlayTime);
 }
 

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -38,14 +38,16 @@
 #include "graphics/thumbnail.h"
 
 Common::String MetaEngine::getSavegameFile(int saveGameIdx, const char *target) const {
+	if (!target)
+		target = getEngineId();
 	if (saveGameIdx == kSavegameFilePattern) {
 		// Pattern requested
-		const char *pattern = hasFeature(kSavesUseExtendedFormat) ? "%s.###" : "%s.s##";
-		return Common::String::format(pattern, target == nullptr ? getEngineId() : target);
+		const char *pattern = hasFeature(kSimpleSavesNames) ? "%s.###" : "%s.s##";
+		return Common::String::format(pattern, target);
 	} else {
 		// Specific filename requested
-		const char *pattern = hasFeature(kSavesUseExtendedFormat) ? "%s.%03d" : "%s.s%02d";
-		return Common::String::format(pattern, target == nullptr ? getEngineId() : target, saveGameIdx);
+		const char *pattern = hasFeature(kSimpleSavesNames) ? "%s.%03d" : "%s.s%02d";
+		return Common::String::format(pattern, target, saveGameIdx);
 	}
 }
 
@@ -165,6 +167,7 @@ bool MetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
 		(f == kSupportsLoadingDuringStartup) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesUseExtendedFormat);
 }
 

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -485,6 +485,9 @@ public:
 		* of detecting saves and slot numbers, this should be
 		* unavailable. In that case Save/Load dialog for the engine's
 		* games is locked during cloud saves sync.
+		*
+		* NOTE: This flag is used by cloud code, but also in
+		* MetaEngine::getSavegameFile(), for common save names.
 		*/
 		kSimpleSavesNames,
 

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -142,6 +142,24 @@ public:
 
 	void registerDefaultSettings(const Common::String &target) const override;
 	GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		Common::String gameId = ConfMan.get("gameid", target);
+		const char *suffix;
+		// Saved games are only supported in Myst/Riven currently.
+		if (gameId == "myst")
+			suffix = "mys";
+		else if (gameId == "riven")
+			suffix = "rvn";
+		else
+			return MetaEngine::getSavegameFile(saveGameIdx, target);
+
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s-###.%s", gameId.c_str(), suffix);
+		else
+			return Common::String::format("%s-%03d.%s", gameId.c_str(), saveGameIdx, suffix);
+	}
 };
 
 bool MohawkMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/mortevielle/metaengine.cpp
+++ b/engines/mortevielle/metaengine.cpp
@@ -51,6 +51,14 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.###", target); // There is also sav0.mor for slot 0
+		else
+			return Mortevielle::MortevielleEngine::generateSaveFilename(target, saveGameIdx);
+	}
 };
 
 Common::Error MortevielleMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {

--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -132,6 +132,8 @@ public:
 	}
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+
+	// TODO: Add getSavegameFile()
 };
 
 Common::Error Myst3MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {

--- a/engines/nancy/metaengine.cpp
+++ b/engines/nancy/metaengine.cpp
@@ -58,6 +58,7 @@ bool NancyMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesUseExtendedFormat);
 }
 

--- a/engines/ngi/metaengine.cpp
+++ b/engines/ngi/metaengine.cpp
@@ -69,6 +69,13 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		const Common::String prefix("fullpipe");
+		if (saveGameIdx == kSavegameFilePattern)
+			return prefix + ".s##";
+		else
+			return prefix + Common::String::format(".s%02d", saveGameIdx);
+	}
 };
 
 bool NGIMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -79,8 +86,7 @@ bool NGIMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
-		(f == kSupportsLoadingDuringStartup) ||
-		(f == kSimpleSavesNames);
+		(f == kSupportsLoadingDuringStartup);
 }
 
 bool NGI::NGIEngine::hasFeature(EngineFeature f) const {
@@ -93,9 +99,8 @@ bool NGI::NGIEngine::hasFeature(EngineFeature f) const {
 SaveStateList NGIMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::StringArray filenames;
-	Common::String pattern("fullpipe.s##");
 
-	filenames = saveFileMan->listSavefiles(pattern);
+	filenames = saveFileMan->listSavefiles(getSavegameFilePattern(target));
 
 	SaveStateList saveList;
 	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -57,11 +57,21 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		const Common::String prefix = ConfMan.getDomain(target)->getVal("gameid");
+		if (saveGameIdx == kSavegameFilePattern)
+			return prefix + ".###";
+		else
+			return prefix + Common::String::format(".%03d", saveGameIdx);
+	}
 };
 
 bool ParallactionMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return
 		(f == kSupportsListSaves) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSupportsDeleteSave);
 }
 
@@ -152,8 +162,7 @@ Common::KeymapArray ParallactionMetaEngine::initKeymaps(const char *target) cons
 SaveStateList ParallactionMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 
-	Common::String pattern(ConfMan.getDomain(target)->getVal("gameid") + ".0##");
-	Common::StringArray filenames = saveFileMan->listSavefiles(pattern);
+	Common::StringArray filenames = saveFileMan->listSavefiles(getSavegameFilePattern(target));
 
 	SaveStateList saveList;
 	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {
@@ -178,10 +187,7 @@ SaveStateList ParallactionMetaEngine::listSaves(const char *target) const {
 int ParallactionMetaEngine::getMaximumSaveSlot() const { return 99; }
 
 void ParallactionMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String filename = ConfMan.getDomain(target)->getVal("gameid");
-	filename += Common::String::format(".0%02d", slot);
-
-	g_system->getSavefileManager()->removeSavefile(filename);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(PARALLACTION)

--- a/engines/pegasus/metaengine.cpp
+++ b/engines/pegasus/metaengine.cpp
@@ -78,6 +78,18 @@ public:
 	int getMaximumSaveSlot() const override { return 999; }
 	void removeSaveState(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("pegasus-*.sav");
+		Common::StringArray fileNames = Pegasus::PegasusEngine::listSaveFiles();
+		if (saveGameIdx < fileNames.size())
+			return fileNames[saveGameIdx];
+		if (fileNames.empty())
+			return Common::String("pegasus-1.sav");
+		Common::String name = fileNames.back();
+		name.insertString("_last", name.size() - 4);
+		return name;
+	}
 };
 
 bool PegasusMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -702,8 +702,15 @@ void PegasusEngine::writeContinueStream(Common::WriteStream *stream) {
 }
 
 Common::StringArray PegasusEngine::listSaveFiles() {
+	const Common::String autoSaveName("pegasus-AutoSave.sav");
 	Common::StringArray fileNames = g_system->getSavefileManager()->listSavefiles("pegasus-*.sav");
+	// Autosave must be at slot 0, so remove it, then prepend (even if it doesn't exist,
+	// it will be prepended)
+	Common::StringArray::iterator it = Common::find(fileNames.begin(), fileNames.end(), autoSaveName);
+	if (it != fileNames.end())
+		fileNames.erase(it);
 	Common::sort(fileNames.begin(), fileNames.end());
+	fileNames.insert_at(0, autoSaveName);
 	return fileNames;
 }
 
@@ -733,10 +740,11 @@ static bool isValidSaveFileName(const Common::String &desc) {
 }
 
 Common::Error PegasusEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	if (!isValidSaveFileName(desc))
+	Common::String saveName = isAutosave ? Common::String("AutoSave") : desc;
+	if (!isValidSaveFileName(saveName))
 		return Common::Error(Common::kCreatingFileFailed, _("Invalid file name for saving"));
 
-	Common::String output = Common::String::format("pegasus-%s.sav", desc.c_str());
+	Common::String output = Common::String::format("pegasus-%s.sav", saveName.c_str());
 	Common::OutSaveFile *saveFile = _saveFileMan->openForSaving(output, false);
 	if (!saveFile)
 		return Common::kUnknownError;

--- a/engines/pink/metaengine.cpp
+++ b/engines/pink/metaengine.cpp
@@ -58,8 +58,7 @@ bool PinkMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
-		(f == kSupportsLoadingDuringStartup) ||
-		(f == kSimpleSavesNames);
+		(f == kSupportsLoadingDuringStartup);
 }
 
 SaveStateList PinkMetaEngine::listSaves(const char *target) const {

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -94,8 +94,7 @@ bool SagaMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
-		(f == kSavesSupportPlayTime) ||
-		(f == kSimpleSavesNames);
+		(f == kSavesSupportPlayTime);
 }
 
 bool Saga::SagaEngine::hasFeature(EngineFeature f) const {

--- a/engines/saga2/metaengine.cpp
+++ b/engines/saga2/metaengine.cpp
@@ -42,6 +42,7 @@ bool Saga2MetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesUseExtendedFormat);
 }
 

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -314,6 +314,7 @@ bool SciMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportPlayTime);
 }
 

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -228,8 +228,7 @@ bool ScummMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
-		(f == kSavesSupportPlayTime) ||
-		(f == kSimpleSavesNames);
+		(f == kSavesSupportPlayTime);
 }
 
 bool ScummEngine::hasFeature(EngineFeature f) const {

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -52,6 +52,12 @@ class SkyMetaEngine : public MetaEngine {
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("SKY-VM.###");
+		else
+			return Common::String::format("SKY-VM.%03d", saveGameIdx);
+	}
 };
 
 bool SkyMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/supernova/metaengine.cpp
+++ b/engines/supernova/metaengine.cpp
@@ -45,6 +45,17 @@ public:
 		return 99;
 	}
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		const char *prefix = target;
+		if (!strncmp(target, "msn1", 4))
+			prefix = "msn_save";
+		if (!strncmp(target, "msn2", 4))
+			prefix = "ms2_save";
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.###", prefix);
+		else
+			return Common::String::format("%s.%03d", prefix, saveGameIdx);
+	}
 };
 
 bool SupernovaMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -69,11 +80,7 @@ Common::Error SupernovaMetaEngine::createInstance(OSystem *syst, Engine **engine
 
 SaveStateList SupernovaMetaEngine::listSaves(const char *target) const {
 	Common::StringArray filenames;
-	Common::String pattern;
-	if (!strncmp(target, "msn1", 4))
-		pattern = Common::String::format("msn_save.###");
-	if (!strncmp(target, "msn2", 4))
-		pattern = Common::String::format("ms2_save.###");
+	const Common::String pattern = getSavegameFilePattern(target);
 
 	filenames = g_system->getSavefileManager()->listSavefiles(pattern);
 
@@ -106,21 +113,11 @@ SaveStateList SupernovaMetaEngine::listSaves(const char *target) const {
 }
 
 void SupernovaMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String filename;
-	if (!strncmp(target, "msn1", 4))
-		filename = Common::String::format("msn_save.%03d", slot);
-	if (!strncmp(target, "msn2", 4))
-		filename = Common::String::format("ms2_save.%03d", slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 SaveStateDescriptor SupernovaMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
-	Common::String fileName;
-	if (!strncmp(target, "msn1", 4))
-		fileName = Common::String::format("msn_save.%03d", slot);
-	if (!strncmp(target, "msn2", 4))
-		fileName = Common::String::format("ms2_save.%03d", slot);
-	Common::InSaveFile *savefile = g_system->getSavefileManager()->openForLoading(fileName);
+	Common::InSaveFile *savefile = g_system->getSavefileManager()->openForLoading(getSavegameFile(slot, target));
 
 	if (savefile) {
 		uint saveHeader = savefile->readUint32LE();

--- a/engines/sword1/metaengine.cpp
+++ b/engines/sword1/metaengine.cpp
@@ -45,6 +45,12 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::Error createInstance(OSystem *syst, Engine **engine) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("sword1.###");
+		else
+			return Common::String::format("sword1.%03d", saveGameIdx);
+	}
 };
 
 bool SwordMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/sword25/metaengine.cpp
+++ b/engines/sword25/metaengine.cpp
@@ -51,7 +51,8 @@ Common::Error Sword25MetaEngine::createInstance(OSystem *syst, Engine **engine, 
 
 bool Sword25MetaEngine::hasFeature(MetaEngineFeature f) const {
 	return
-		(f == kSupportsListSaves);
+		(f == kSupportsListSaves) ||
+		(f == kSimpleSavesNames);
 }
 
 SaveStateList Sword25MetaEngine::listSaves(const char *target) const {

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -76,6 +76,8 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	void removeSaveState(const char *target, int slot) const override;
+
+	// TODO: Add getSavegameFile(). See comments in loadGameState and removeSaveState
 };
 
 bool TinselMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/tony/metaengine.cpp
+++ b/engines/tony/metaengine.cpp
@@ -72,6 +72,7 @@ bool TonyMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsLoadingDuringStartup) ||
 		(f == kSupportsDeleteSave) ||
 		(f == kSavesSupportMetaInfo) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportThumbnail);
 }
 

--- a/engines/touche/metaengine.cpp
+++ b/engines/touche/metaengine.cpp
@@ -40,6 +40,11 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		return Touche::generateGameStateFileName(target, saveGameIdx, saveGameIdx == kSavegameFilePattern);
+	}
 };
 
 bool ToucheMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/wintermute/metaengine.cpp
+++ b/engines/wintermute/metaengine.cpp
@@ -84,17 +84,13 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override {
 		switch (f) {
-		case MetaEngine::kSupportsListSaves:
-			return true;
-		case MetaEngine::kSupportsLoadingDuringStartup:
-			return true;
-		case MetaEngine::kSupportsDeleteSave:
-			return true;
-		case MetaEngine::kSavesSupportCreationDate:
-			return true;
-		case MetaEngine::kSavesSupportMetaInfo:
-			return true;
-		case MetaEngine::kSavesSupportThumbnail:
+		case kSupportsListSaves:
+		case kSupportsLoadingDuringStartup:
+		case kSupportsDeleteSave:
+		case kSavesSupportCreationDate:
+		case kSavesSupportMetaInfo:
+		case kSavesSupportThumbnail:
+		case kSimpleSavesNames:
 			return true;
 		default:
 			return false;


### PR DESCRIPTION
Use kSimpleSavesNames correctly, add where needed, remove where needed.

[Trac #12977](https://bugs.scummvm.org/ticket/12977)
