### PR TITLE
CONFIGURE: Do not undefine __STRICT_ANSI__ for mingw

### DIFF
--- a/configure
+++ b/configure
@@ -2185,7 +2185,7 @@ if test "$have_gcc" = yes ; then
 		case $_host_os in
 		# newlib-based system include files suppress non-C89 function
 		# declarations under __STRICT_ANSI__, undefine it
-		3ds | amigaos* | android | androidsdl | dreamcast | ds | gamecube | mingw* | mint* | n64 | psp | ps3 | psp2 | switch | wii )
+		3ds | amigaos* | android | androidsdl | dreamcast | ds | gamecube | mint* | n64 | psp | ps3 | psp2 | switch | wii )
 			append_var CXXFLAGS "-U__STRICT_ANSI__"
 			;;
 		*)


### PR DESCRIPTION
GCC11 warns if it is not defined.
