### PR TITLE
DEVTOOLS: dumper companion - fix filename for mac command

### DIFF
--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -380,7 +380,7 @@ def collect_forks(args: argparse.Namespace) -> int:
                 file = machfs.File()
 
                 # Set the file times and convert them to Mac epoch
-                info = os.stat(filename)
+                info = os.stat(filepath)
                 file.crdate = 2082844800 + int(info.st_birthtime)
                 file.mddate = 2082844800 + int(info.st_mtime)
 


### PR DESCRIPTION
There's a bug with the dumper companion's `mac` subcomand; it's incorrectly trying to `stat` the base filename, instead of the fully-qualified filename. Without this, line 383 results in an exception about not being able to find the named file.