### PR TITLE
DEVTOOLS: dumper-companion: work around bug

### DIFF
--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -481,7 +481,10 @@ def generate_parser() -> argparse.ArgumentParser:
 if __name__ == "__main__":
     parser = generate_parser()
     args = parser.parse_args()
-    exit(args.func(args))
+    try:
+        exit(args.func(args))
+    except AttributeError:
+        parser.error("too few arguments")
 
 ### Test functions
 


### PR DESCRIPTION
There's a Python bug in `argparse`, which has never been fixed, that doesn't correctly generate an error if `argparse` tries to parse arguments when no subcommand is passed: https://bugs.python.org/issue16308

This leads to a very confusing error instead of something helpful:

```
$ ./devtools/dumper-companion.py
Traceback (most recent call last):
  File "/Users/mistydemeo/github/scummvm/./devtools/dumper-companion.py", line 484, in <module>
    exit(args.func(args))
AttributeError: 'Namespace' object has no attribute 'func'
```

Looks like the best workaround right now is to catch the `AttributeError` and print the message that `argparse` should be doing itself.