### PR TITLE
KYRA: (LOL) - fix possible accesses out of script' stack bounds

### DIFF
--- a/engines/kyra/script/script_lol.cpp
+++ b/engines/kyra/script/script_lol.cpp
@@ -1464,10 +1464,43 @@ int LoLEngine::olol_checkForCertainPartyMember(EMCState *script) {
 }
 
 int LoLEngine::olol_printMessage(EMCState *script) {
-	debugC(3, kDebugLevelScriptFuncs, "LoLEngine::olol_printMessage(%p) (%d, %d, %d, %d, %d, %d, %d, %d, %d, %d)", (const void *)script, stackPos(0), stackPos(1), stackPos(2), stackPos(3), stackPos(4), stackPos(5), stackPos(6), stackPos(7), stackPos(8), stackPos(9));
-	int snd = stackPos(2);
-	_txt->printMessage(stackPos(0), getLangString(stackPos(1)), stackPos(3), stackPos(4), stackPos(5), stackPos(6), stackPos(7), stackPos(8), stackPos(9));
+	int max_args = (sizeof (script->stack) / sizeof (script->stack[0])) - script->sp;
+	int fmt_args[7] = {-1, -1, -1, -1, -1, -1, -1};
+	int snd;
 
+	if (max_args > 10)
+		max_args = 10;
+	assert(max_args >= 3);
+
+	switch (max_args)
+        {
+	case 10:
+		fmt_args[6] = stackPos(9);
+		/* fallthrough */
+	case 9:
+		fmt_args[5] = stackPos(8);
+		/* fallthrough */
+	case 8:
+		fmt_args[4] = stackPos(7);
+		/* fallthrough */
+	case 7:
+		fmt_args[3] = stackPos(6);
+		/* fallthrough */
+	case 6:
+		fmt_args[2] = stackPos(5);
+		/* fallthrough */
+	case 5:
+		fmt_args[1] = stackPos(4);
+		/* fallthrough */
+	case 4:
+		fmt_args[0] = stackPos(3);
+	}
+
+	debugC(3, kDebugLevelScriptFuncs, "LoLEngine::olol_printMessage(%p) (%d, %d, %d, %d, %d, %d, %d, %d, %d, %d)", (const void *)script, stackPos(0), stackPos(1), stackPos(2), fmt_args[0], fmt_args[1], fmt_args[2], fmt_args[3], fmt_args[4], fmt_args[5], fmt_args[6]);
+
+	_txt->printMessage(stackPos(0), getLangString(stackPos(1)), fmt_args[0], fmt_args[1], fmt_args[2], fmt_args[3], fmt_args[4], fmt_args[5], fmt_args[6]);
+
+	snd = stackPos(2);
 	if (snd >= 0)
 		snd_playSoundEffect(snd, -1);
 


### PR DESCRIPTION
`LoLEngine::olol_printMessage` always assumes there are 10 available parameters on the script' stack, which can result in out-of-bounds accesses, as reported when compiling with the Address Sanitizer enabled:
```
User picked target 'lol-cd' (engine ID 'kyra', game ID 'lol')...
   Looking for a plugin supporting this target... Kyra
Running Lands of Lore: The Throne of Chaos (CD/DOS/English)
GENERAL.PAK: 05a4f588fb81dc9c0ef1f2ec20d89e24, 1225033 bytes.
L01.PAK: 759a0ac26808d77ea968bd392355ba1d, 68733 bytes.
=================================================================
==103132==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffdafda7e54 at pc 0x564cf4cf9281 bp 0x7ffdafda7bf0 sp 0x7ffdafda7be0
READ of size 2 at 0x7ffdafda7e54 thread T0
    #0 0x564cf4cf9280 in Kyra::LoLEngine::olol_printMessage(Kyra::EMCState*) engines/kyra/script/script_lol.cpp:1467
    #1 0x564cf4f5182b in Kyra::EMCInterpreter::op_sysCall(Kyra::EMCState*) engines/kyra/script/script.cpp:317
    #2 0x564cf4f5293a in Kyra::EMCInterpreter::run(Kyra::EMCState*) engines/kyra/script/script.cpp:219
    #3 0x564cf4d04103 in Kyra::LoLEngine::runLevelScriptCustom(int, int, int, int, int, int) engines/kyra/script/script_lol.cpp:88
    #4 0x564cf4d041f9 in Kyra::LoLEngine::runLevelScript(int, int) engines/kyra/script/script_lol.cpp:66
    #5 0x564cf4c5585d in Kyra::LoLEngine::moveParty(unsigned short, int, int, int) engines/kyra/engine/scene_lol.cpp:666
    #6 0x564cf4c81686 in Kyra::LoLEngine::clickedUpArrow(Kyra::Button*) engines/kyra/gui/gui_lol.cpp:955
    #7 0x564cf4c744b3 in Kyra::GUI_LoL::processButtonList(Kyra::Button*, unsigned short, signed char) engines/kyra/gui/gui_lol.cpp:2175
    #8 0x564cf4d4292a in Kyra::KyraEngine_v1::checkInput(Kyra::Button*, bool, int) engines/kyra/engine/kyra_v1.cpp:331
    #9 0x564cf4c980e6 in Kyra::LoLEngine::gui_updateInput() engines/kyra/gui/gui_lol.cpp:767
    #10 0x564cf4c2c811 in Kyra::LoLEngine::runLoop() engines/kyra/engine/lol.cpp:907
    #11 0x564cf4c2d09c in Kyra::LoLEngine::go() engines/kyra/engine/lol.cpp:548
    #12 0x564cf4c49f45 in Kyra::KyraEngine_v1::run() engines/kyra/kyra_v1.h:207
    #13 0x564cf4bc26c5 in runGame base/main.cpp:318
    #14 0x564cf4bc8169 in scummvm_main base/main.cpp:626
    #15 0x564cf4ab7919 in main backends/platform/sdl/posix/posix-main.cpp:45
    #16 0x14dc5dda7b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
    #17 0x564cf4abae4d in _start ([…]/scummvm/scummvm+0x5c8e4d)

Address 0x7ffdafda7e54 is located in stack of thread T0 at offset 324 in frame
    #0 0x564cf4d03cef in Kyra::LoLEngine::runLevelScriptCustom(int, int, int, int, int, int) engines/kyra/script/script_lol.cpp:69

  This frame has 1 object(s):
    [32, 320) 'scriptState' (line 70) <== Memory access at offset 324 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow engines/kyra/script/script_lol.cpp:1467 in Kyra::LoLEngine::olol_printMessage(Kyra::EMCState*)
Shadow bytes around the buggy address:
  0x100035facf70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100035facf80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100035facf90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100035facfa0: 00 00 f1 f1 f1 f1 00 00 00 00 00 00 00 00 00 00
  0x100035facfb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x100035facfc0: 00 00 00 00 00 00 00 00 00 00[f3]f3 f3 f3 f3 f3
  0x100035facfd0: f3 f3 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100035facfe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100035facff0: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
  0x100035fad000: 00 00 00 f2 f2 f2 f2 f2 00 00 00 f3 f3 f3 f3 f3
  0x100035fad010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==103132==ABORTING
``` 