### PR TITLE
DIRECTOR: Do not override tail flag in fallback detection

### DIFF
--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -129,7 +129,7 @@ ADDetectedGame DirectorMetaEngineDetection::fallbackDetect(const FileMap &allFil
 	desc->desc.gameId = "director";
 	desc->desc.extra = "";
 	desc->desc.language = Common::UNK_LANG;
-	desc->desc.flags = ADGF_NO_FLAGS;
+	desc->desc.flags = ADGF_TAILMD5;
 	desc->desc.platform = Common::kPlatformWindows;
 	desc->desc.guiOptions = GUIO0();
 	desc->desc.filesDescriptions[0].fileName = 0;


### PR DESCRIPTION
Should fix the duplicate md5 issue.