### PR TITLE
WIN32: Fix --savepath command line argument

### DIFF
--- a/backends/saves/windows/windows-saves.cpp
+++ b/backends/saves/windows/windows-saves.cpp
@@ -37,6 +37,13 @@
 #include "backends/platform/sdl/win32/win32_wrapper.h"
 
 WindowsSaveFileManager::WindowsSaveFileManager() {
+	// if savepath was set on the command line then use it as the default
+	Common::String savepath = ConfMan.get("savepath", Common::ConfigManager::kTransientDomain);
+	if (!savepath.empty()) {
+		ConfMan.registerDefault("savepath", savepath);
+		return;
+	}
+
 	TCHAR defaultSavepath[MAX_PATH];
 
 	// Use the Application Data directory of the user profile.


### PR DESCRIPTION
Setting savepath on the command line had no effect in Windows builds.

Fixes bug #9664