### PR TITLE
SCUMM: Use correct variable for current room

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1357,9 +1357,9 @@ int ScummEngine::convertMessageToString(const byte *msg, byte *dst, int dstSize)
 			error("convertMessageToString: buffer overflow");
 	}
 
-	// WORKAROUND bug #12249 (occurs also in original): Missing actor animation in German version of SAMNMAX
+	// WORKAROUND bug #12249 (occurs also in original): Missing actor animation in German versions of SAMNMAX
 	// Adding the missing animation escape sequence while copying the text fixes it.
-	if (_game.id == GID_SAMNMAX && _roomResource == 56 && vm.slot[_currentScript].number == 200 && _language == Common::DE_DEU) {
+	if (_game.id == GID_SAMNMAX && _currentRoom == 56 && vm.slot[_currentScript].number == 200 && _language == Common::DE_DEU) {
 		// 0xE5E6 is the CD version, 0xE373 is for the floppy version
 		if (vm.slot[_currentScript].offs == 0xE5E6 || vm.slot[_currentScript].offs == 0xE373) {
 			*dst++ = 0xFF;


### PR DESCRIPTION
Use _currentRoom variable for current room. It works also with _roomResource, but that's not what's intended for.