### PR TITLE
KYRA: (LOL) - fix invalid use after free

### DIFF
--- a/engines/kyra/sound/sound_lol.cpp
+++ b/engines/kyra/sound/sound_lol.cpp
@@ -246,19 +246,15 @@ void LoLEngine::snd_playQueuedEffects() {
 }
 
 void LoLEngine::snd_loadSoundFile(int track) {
-	if (_sound->musicEnabled()) {
-		if (_flags.platform == Common::kPlatformDOS) {
-			int t = (track - 250) * 3;
-			if (t >= 0 && (_curMusicFileIndex != _musicTrackMap[t] || _curMusicFileExt != (char)_musicTrackMap[t + 1])) {
-				snd_stopMusic();
-				_sound->loadSoundFile(Common::String::format("LORE%02d%c", _musicTrackMap[t], (char)_musicTrackMap[t + 1]));
-				_curMusicFileIndex = _musicTrackMap[t];
-				_curMusicFileExt = (char)_musicTrackMap[t + 1];
-			} else {
-				snd_stopMusic();
-			}
-		}
-	}
+	if (!_sound->musicEnabled() || _flags.platform != Common::kPlatformDOS)
+		return;
+	snd_stopMusic();
+	int t = (track - 250) * 3;
+	if (t < 0 || (_curMusicFileIndex == _musicTrackMap[t] && _curMusicFileExt == (char)_musicTrackMap[t + 1]))
+		return;
+	_sound->loadSoundFile(Common::String::format("LORE%02d%c", _musicTrackMap[t], (char)_musicTrackMap[t + 1]));
+	_curMusicFileIndex = _musicTrackMap[t];
+	_curMusicFileExt = (char)_musicTrackMap[t + 1];
 }
 
 int LoLEngine::snd_playTrack(int track) {


### PR DESCRIPTION
It's possible for `snd_loadSoundFile` to be called with a negative track number (e.g. -1).

Attached a savegame to reproduce the problem ([lol-save.zip](https://github.com/scummvm/scummvm/files/7412263/lol-save.zip)): side step left, then forward 2 times to trigger a cutscene, and...

With the Address Sanitizer enabled at compilation, a crash:

```
==146255==ERROR: AddressSanitizer: heap-use-after-free on address 0x6110001e754f at pc 0x563b0ba6e4f0 bp 0x7ffc8d2edb60 sp 0x7ffc8d2edb50
READ of size 1 at 0x6110001e754f thread T0
    #0 0x563b0ba6e4ef in Kyra::LoLEngine::snd_loadSoundFile(int) engines/kyra/sound/sound_lol.cpp:252
    #1 0x563b0ba6e4ef in Kyra::LoLEngine::snd_loadSoundFile(int) engines/kyra/sound/sound_lol.cpp:248
    #2 0x563b0ba2fb8a in Kyra::LoLEngine::olol_loadSoundFile(Kyra::EMCState*) engines/kyra/script/script_lol.cpp:1338
    #3 0x563b0bc89afb in Kyra::EMCInterpreter::op_sysCall(Kyra::EMCState*) engines/kyra/script/script.cpp:317
    #4 0x563b0bc8ac0a in Kyra::EMCInterpreter::run(Kyra::EMCState*) engines/kyra/script/script.cpp:219
    #5 0x563b0ba3c3d3 in Kyra::LoLEngine::runLevelScriptCustom(int, int, int, int, int, int) engines/kyra/script/script_lol.cpp:88
    #6 0x563b0ba3c4c9 in Kyra::LoLEngine::runLevelScript(int, int) engines/kyra/script/script_lol.cpp:66
    #7 0x563b0b98da6c in Kyra::LoLEngine::moveParty(unsigned short, int, int, int) engines/kyra/engine/scene_lol.cpp:696
    #8 0x563b0b9b9686 in Kyra::LoLEngine::clickedUpArrow(Kyra::Button*) engines/kyra/gui/gui_lol.cpp:955
    #9 0x563b0b9ac4b3 in Kyra::GUI_LoL::processButtonList(Kyra::Button*, unsigned short, signed char) engines/kyra/gui/gui_lol.cpp:2175
    #10 0x563b0ba7abfa in Kyra::KyraEngine_v1::checkInput(Kyra::Button*, bool, int) engines/kyra/engine/kyra_v1.cpp:331
    #11 0x563b0b9d00e6 in Kyra::LoLEngine::gui_updateInput() engines/kyra/gui/gui_lol.cpp:767
    #12 0x563b0b964811 in Kyra::LoLEngine::runLoop() engines/kyra/engine/lol.cpp:907
    #13 0x563b0b96509c in Kyra::LoLEngine::go() engines/kyra/engine/lol.cpp:548
    #14 0x563b0b981f45 in Kyra::KyraEngine_v1::run() engines/kyra/kyra_v1.h:207
    #15 0x563b0b8fa6c5 in runGame base/main.cpp:318
    #16 0x563b0b900169 in scummvm_main base/main.cpp:626
    #17 0x563b0b7ef919 in main backends/platform/sdl/posix/posix-main.cpp:45
    #18 0x151fca249b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
    #19 0x563b0b7f2e4d in _start ([…]/scummvm+0x5c8e4d)

0x6110001e754f is located 207 bytes inside of 256-byte region [0x6110001e7480,0x6110001e7580)
freed by thread T0 here:
    #0 0x151fcbf78f19 in __interceptor_free /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:127
    #1 0x563b0c60765e in Common::Array<Common::FSNode>::freeStorage(Common::FSNode*, unsigned int) common/array.h:409
    #2 0x563b0c60765e in Common::Array<Common::FSNode>::insert_aux(Common::FSNode*, Common::FSNode const*, Common::FSNode const*) common/array.h:448
    #3 0x563b0c60765e in Common::Array<Common::FSNode>::push_back(Common::FSNode const&) common/array.h:150
    #4 0x563b0c60765e in Common::FSNode::getChildren(Common::FSList&, Common::FSNode::ListMode, bool) const common/fs.cpp:84
    #5 0x563b0c609a64 in Common::FSDirectory::cacheDirectoryRecursive(Common::FSNode, int, Common::Path const&) const common/fs.cpp:289
    #6 0x563b0c609f65 in Common::FSDirectory::cacheDirectoryRecursive(Common::FSNode, int, Common::Path const&) const common/fs.cpp:285
    #7 0x563b0c609f65 in Common::FSDirectory::cacheDirectoryRecursive(Common::FSNode, int, Common::Path const&) const common/fs.cpp:313
    #8 0x563b0c60b203 in Common::FSDirectory::cacheDirectoryRecursive(Common::FSNode, int, Common::Path const&) const common/fs.cpp:285
    #9 0x563b0c60b203 in Common::FSDirectory::ensureCached() const common/fs.cpp:333
    #10 0x563b0c60bcdd in Common::FSDirectory::ensureCached() const common/hashmap.h:212
    #11 0x563b0c60bcdd in Common::FSDirectory::listMatchingMembers(Common::List<Common::SharedPtr<Common::ArchiveMember> >&, Common::Path const&) const common/fs.cpp:342
    #12 0x563b0c5d9829 in Common::SearchSet::listMatchingMembers(Common::List<Common::SharedPtr<Common::ArchiveMember> >&, Common::Path const&) const common/archive.cpp:227
    #13 0x563b0c5d9829 in Common::SearchSet::listMatchingMembers(Common::List<Common::SharedPtr<Common::ArchiveMember> >&, Common::Path const&) const common/archive.cpp:227
    #14 0x563b0bb98692 in Kyra::Resource::listFiles(Common::String const&, Common::List<Common::SharedPtr<Common::ArchiveMember> >&) engines/kyra/resource/resource.cpp:277
    #15 0x563b0bc107af in Kyra::StaticResource::loadStaticResourceFile() engines/kyra/resource/staticres.cpp:142
    #16 0x563b0ba7ed90 in Kyra::KyraEngine_v1::init() engines/kyra/engine/kyra_v1.cpp:163
    #17 0x563b0b970379 in Kyra::LoLEngine::init() engines/kyra/engine/lol.cpp:370
    #18 0x563b0b981dcf in Kyra::KyraEngine_v1::run() engines/kyra/kyra_v1.h:204
    #19 0x563b0b8fa6c5 in runGame base/main.cpp:318
    #20 0x563b0b900169 in scummvm_main base/main.cpp:626
    #21 0x563b0b7ef919 in main backends/platform/sdl/posix/posix-main.cpp:45
    #22 0x151fca249b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)

previously allocated by thread T0 here:
    #0 0x151fcbf79279 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x563b0c607242 in Common::Array<Common::FSNode>::allocCapacity(unsigned int) common/array.h:397
    #2 0x563b0c607242 in Common::Array<Common::FSNode>::insert_aux(Common::FSNode*, Common::FSNode const*, Common::FSNode const*) common/array.h:437
    #3 0x563b0c607242 in Common::Array<Common::FSNode>::push_back(Common::FSNode const&) common/array.h:150
    #4 0x563b0c607242 in Common::FSNode::getChildren(Common::FSList&, Common::FSNode::ListMode, bool) const common/fs.cpp:84
    #5 0x563b0c609a64 in Common::FSDirectory::cacheDirectoryRecursive(Common::FSNode, int, Common::Path const&) const common/fs.cpp:289
    #6 0x563b0c609f65 in Common::FSDirectory::cacheDirectoryRecursive(Common::FSNode, int, Common::Path const&) const common/fs.cpp:285
    #7 0x563b0c609f65 in Common::FSDirectory::cacheDirectoryRecursive(Common::FSNode, int, Common::Path const&) const common/fs.cpp:313
    #8 0x563b0c60b203 in Common::FSDirectory::cacheDirectoryRecursive(Common::FSNode, int, Common::Path const&) const common/fs.cpp:285
    #9 0x563b0c60b203 in Common::FSDirectory::ensureCached() const common/fs.cpp:333
    #10 0x563b0c60bcdd in Common::FSDirectory::ensureCached() const common/hashmap.h:212
    #11 0x563b0c60bcdd in Common::FSDirectory::listMatchingMembers(Common::List<Common::SharedPtr<Common::ArchiveMember> >&, Common::Path const&) const common/fs.cpp:342
    #12 0x563b0c5d9829 in Common::SearchSet::listMatchingMembers(Common::List<Common::SharedPtr<Common::ArchiveMember> >&, Common::Path const&) const common/archive.cpp:227
    #13 0x563b0c5d9829 in Common::SearchSet::listMatchingMembers(Common::List<Common::SharedPtr<Common::ArchiveMember> >&, Common::Path const&) const common/archive.cpp:227
    #14 0x563b0bb98692 in Kyra::Resource::listFiles(Common::String const&, Common::List<Common::SharedPtr<Common::ArchiveMember> >&) engines/kyra/resource/resource.cpp:277
    #15 0x563b0bc107af in Kyra::StaticResource::loadStaticResourceFile() engines/kyra/resource/staticres.cpp:142
    #16 0x563b0ba7ed90 in Kyra::KyraEngine_v1::init() engines/kyra/engine/kyra_v1.cpp:163
    #17 0x563b0b970379 in Kyra::LoLEngine::init() engines/kyra/engine/lol.cpp:370
    #18 0x563b0b981dcf in Kyra::KyraEngine_v1::run() engines/kyra/kyra_v1.h:204
    #19 0x563b0b8fa6c5 in runGame base/main.cpp:318
    #20 0x563b0b900169 in scummvm_main base/main.cpp:626
    #21 0x563b0b7ef919 in main backends/platform/sdl/posix/posix-main.cpp:45
    #22 0x151fca249b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)

SUMMARY: AddressSanitizer: heap-use-after-free engines/kyra/sound/sound_lol.cpp:252 in Kyra::LoLEngine::snd_loadSoundFile(int)
Shadow bytes around the buggy address:
  0x0c2280034e50: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2280034e60: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c2280034e70: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2280034e80: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x0c2280034e90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c2280034ea0: fd fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd
  0x0c2280034eb0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c2280034ec0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c2280034ed0: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
  0x0c2280034ee0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c2280034ef0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==146255==ABORTING
```

Without it, no crash but a warning:

```
WARNING: Couldn't find music file: 'LORE128.ADL'!
```

Note: I kept the same behavior as the later: the music is stopped during the cutscene. Instead of returning early in the function (`if (track == -1) return;`), and keeping playing the same music track during said cutscene. I did not fancy replaying everything up to this point using DOSBox to make sure the behavior is indeed correct, but I think it is, if that [Youtube playthrough](https://youtu.be/DKdBs7Pc1JE?t=9319) is indicative (I assume it was not done with ScummVM, as it predates official support).
 
Additionally, I was sorely tempted to refactor the function as such:
```C
void LoLEngine::snd_loadSoundFile(int track) {
	if (!_sound->musicEnabled() || _flags.platform != Common::kPlatformDOS)
		return;
	snd_stopMusic();
	int t = (track - 250) * 3;
	if (t < 0 || (_curMusicFileIndex == _musicTrackMap[t] && _curMusicFileExt == (char)_musicTrackMap[t + 1]))
		return;
	_sound->loadSoundFile(Common::String::format("LORE%02d%c", _musicTrackMap[t], (char)_musicTrackMap[t + 1]));
	_curMusicFileIndex = _musicTrackMap[t];
	_curMusicFileExt = (char)_musicTrackMap[t + 1];
}
```
Let me know if that's something you'd want.



