### PR TITLE
AGOS: RFC: Fix Waxworks AdLib music (bug #13048)

### DIFF
--- a/engines/agos/drivers/accolade/adlib.cpp
+++ b/engines/agos/drivers/accolade/adlib.cpp
@@ -286,19 +286,16 @@ void MidiDriver_Accolade_AdLib::setTimerCallback(void *timerParam, Common::Timer
 
 void MidiDriver_Accolade_AdLib::noteOn(byte FMvoiceChannel, byte note, byte velocity) {
 	byte adjustedNote     = note;
-	byte adjustedVelocity = velocity;
 	byte regValueA0h      = 0;
 	byte regValueB0h      = 0;
 
 	// adjust velocity
-	int16 channelVolumeAdjust = _channels[FMvoiceChannel].volumeAdjust;
-	channelVolumeAdjust += adjustedVelocity;
+	int16 channelVolumeAdjust = velocity + _channels[FMvoiceChannel].volumeAdjust;
+	// adjust velocity with the master volume
+	channelVolumeAdjust = (channelVolumeAdjust * (128 + _masterVolume)) / 128;
 	channelVolumeAdjust = CLIP<int16>(channelVolumeAdjust, 0, 0x7F);
 
-	// adjust velocity with the master volume
-	byte volumeAdjust = adjustedVelocity * ((float) (128 + _masterVolume) / 128);
-
-	adjustedVelocity = volumeAdjust;
+	byte adjustedVelocity = channelVolumeAdjust;
 
 	if (!_musicDrvMode) {
 		// INSTR.DAT

--- a/engines/agos/drivers/accolade/adlib.h
+++ b/engines/agos/drivers/accolade/adlib.h
@@ -114,7 +114,7 @@ private:
 	void programChangeSetInstrument(byte FMvoiceChannel, byte mappedInstrumentNr, byte MIDIinstrumentNr);
 	void setRegister(int reg, int value);
 	void noteOn(byte FMvoiceChannel, byte note, byte velocity);
-	void noteOnSetVolume(byte FMvoiceChannel, byte operatorReg, byte adjustedVelocity);
+	void noteOnSetVolume(byte FMvoiceChannel, byte operatorReg, byte velocity);
 	void noteOff(byte FMvoiceChannel, byte note, bool dontCheckNote);
 };
 

--- a/engines/agos/midi.cpp
+++ b/engines/agos/midi.cpp
@@ -493,7 +493,7 @@ void MidiPlayer::pause(bool b) {
 	Common::StackLock lock(_mutex);
 	// if using the driver Accolade_AdLib call setVolume() to turn off\on the volume on all channels
 	if (musicType == MT_ADLIB && _musicMode == kMusicModeAccolade) {
-		static_cast <MidiDriver_Accolade_AdLib*> (_driver)->setVolume(_paused ? 0 : 128);
+		static_cast <MidiDriver_Accolade_AdLib*> (_driver)->setVolume(_paused ? 0 : ConfMan.getInt("music_volume"));
 	} else if (_musicMode == kMusicModePC98) {
 		_driver->property(0x30, _paused ? 1 : 0);
 	}
@@ -519,6 +519,8 @@ void MidiPlayer::setVolume(int musicVol, int sfxVol) {
 	if (_musicMode == kMusicModePC98) {
 		_driver->property(0x10, _musicVolume);
 		_driver->property(0x20, _sfxVolume);
+	} else if (_musicMode == kMusicModeAccolade && musicType == MT_ADLIB) {
+		static_cast <MidiDriver_Accolade_AdLib*> (_driver)->setVolume(_musicVolume);
 	}
 
 	// Now tell all the channels this.


### PR DESCRIPTION
This is an attempt at fixing the Waxworks AdLib music. See https://bugs.scummvm.org/ticket/13048 for some details.

The problem turned out to be that when calculating the value to be written to the 40 - 55 AdLib registerers, it could underflow so instead of 0 (max volume) it would write some negative value, probably close to the minimum volume.

Much of this calculation is done in the noteOn() function, but the `channelVolumeAdjust` variable (which is clipped to the appropriate interval) is never used. I assume that was the main error. I've also changed it so that the clipping is done after all the adjustments have been made. (And since we're working with small 16-bit integers, there is no need to use floating-point math either, so I've eliminated that.)

Is it correct? I don't know. At least for Waxworks, it seems that most notes end up being played at max volume, but perhaps that's how it should be? I'm just guessing here, and if anyone has a better fix I'd be happy to drop this one. Whatever the fix is, it should almost certainly go into the 2.5 branch as well.