### PR TITLE
SDL: Fix warning with GCC 11 on MinGW

### DIFF
--- a/backends/platform/sdl/win32/win32-main.cpp
+++ b/backends/platform/sdl/win32/win32-main.cpp
@@ -23,7 +23,9 @@
 // Disable symbol overrides so that we can use system headers.
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 // HACK: Mingw32 doesn't define _argc _argv in strict ANSI mode
+#if !defined(__GNUC__) || __GNUC__ < 11
 #undef __STRICT_ANSI__
+#endif
 
 #include "common/scummsys.h"
 


### PR DESCRIPTION
```
In file included from C:/msys64/mingw64/include/c++/11.2.0/cstdlib:41,
                 from C:/msys64/mingw64/include/c++/11.2.0/stdlib.h:36,
                 from ../scummvm/common/scummsys.h:120,
                 from ../scummvm/backends/platform/sdl/win32/win32-main.cpp:28:
C:/msys64/mingw64/include/c++/11.2.0/x86_64-w64-mingw32/bits/c++config.h:573:2: warning: #warning "__STRICT_ANSI__ seems to have been undefined; this is not supported" [-Wcpp]
  573 | #warning "__STRICT_ANSI__ seems to have been undefined; this is not supported"
      |  ^~~~~~~
```