### PR TITLE
CREATE_PROJECT: Add DETECTION_FULL feature

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1093,6 +1093,7 @@ const Feature s_features[] = {
 	{     "text-console", "USE_TEXT_CONSOLE_FOR_DEBUGGER", false, false, "Text console debugger" }, // This feature is always applied in xcode projects
 	{              "tts",                       "USE_TTS", false, true,  "Text to speech support"},
 	{"builtin-resources",             "BUILTIN_RESOURCES", false, true,  "include resources (e.g. engine data, fonts) into the binary"},
+	{   "detection-full",                "DETECTION_FULL", false, true,  "Include detection objects for all engines" },
 	{ "detection-static", "USE_DETECTION_FEATURES_STATIC", false, true,  "Static linking of detection objects for engines."},
 	{            "cxx11",                     "USE_CXX11", false, true,  "Compile with c++11 support"}
 };
@@ -1571,10 +1572,15 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 		ex.clear();
 		std::vector<std::string> detectionModuleDirs;
 		detectionModuleDirs.reserve(setup.engines.size());
+		bool detectAllEngines = getFeatureBuildState("detection-full", setup.features);
 
 		for (EngineDescList::const_iterator i = setup.engines.begin(), end = setup.engines.end(); i != end; ++i) {
 			// We ignore all sub engines here because they require no special handling.
 			if (isSubEngine(i->name, setup.engines)) {
+				continue;
+			}
+			// If we're not detecting all engines then ignore the disabled ones
+			if (!(detectAllEngines || i->enable)) {
 				continue;
 			}
 			detectionModuleDirs.push_back(setup.srcDir + "/engines/" + i->name);
@@ -2133,7 +2139,9 @@ void ProjectProvider::createEnginePluginsTable(const BuildSetup &setup) {
 		                   << "LINK_PLUGIN(" << engineName << ")\n"
 		                   << "#endif\n";
 
-		detectionTable << "LINK_PLUGIN(" << engineName << "_DETECTION)\n";
+		detectionTable << "#if defined(ENABLE_" << engineName << ") || defined(DETECTION_FULL)\n"
+					   << "LINK_PLUGIN(" << engineName << "_DETECTION)\n"
+					   << "#endif\n";
 	}
 }
 } // namespace CreateProjectTool


### PR DESCRIPTION
Allows disabling full detection with `--disable-detection-full`, just like the configure script. `detection_table.h` now has the same content as the one generated by the configure script. This doesn't change any default behavior.

Tested on msvc and xcode. Speeds up compiling my one-engine local builds. Also makes it possible to build again on older msvc versions that have trouble with some of the newer engine code that detection objects bring in, but that's just a bonus for me.