### PR TITLE
JANITORIAL: typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -937,7 +937,7 @@ For a more comprehensive changelog of the latest experimental code, see:
 
  SCUMM:
    - Fixed missing translations in the in-game quit and restart dialogs in Pajama Sam 1.
-   - Fixed visual glitches in DOTT that occured after loading a savegame with the stereo
+   - Fixed visual glitches in DOTT that occurred after loading a savegame with the stereo
      in Green Tentacle's room turned on.
    - Improved timing and pathfinding in Maniac Mansion (C64 and Apple II versions).
    - Added support for the Dutch demo of Let's Explore the Airport with Buzzy.
@@ -968,7 +968,7 @@ For a more comprehensive changelog of the latest experimental code, see:
  General:
    - Removed TESTING flag from several supported games.
    - Added Chinese Pinyin translation.
-   - Fixed cursor stuttering in the launcher that occured on some systems.
+   - Fixed cursor stuttering in the launcher that occurred on some systems.
 
  BBVS:
    - Fixed game restart.

--- a/audio/decoders/asf.h
+++ b/audio/decoders/asf.h
@@ -34,7 +34,7 @@ namespace Audio {
  * @param stream          The SeekableReadStream from which to read the ASF data.
  * @param disposeAfterUse Whether to delete the stream after use.
  *
- * @return A new SeekableAudioStream, or 0, if an error occured.
+ * @return A new SeekableAudioStream, or 0, if an error occurred.
  */
 
 SeekableAudioStream *makeASFStream(

--- a/backends/cloud/box/boxstorage.h
+++ b/backends/cloud/box/boxstorage.h
@@ -100,7 +100,7 @@ public:
 
 	/**
 	 * Load token and user id from configs and return BoxStorage for those.
-	 * @return pointer to the newly created BoxStorage or 0 if some problem occured.
+	 * @return pointer to the newly created BoxStorage or 0 if some problem occurred.
 	 */
 	static BoxStorage *loadFromConfig(Common::String keyPrefix);
 

--- a/backends/cloud/dropbox/dropboxstorage.h
+++ b/backends/cloud/dropbox/dropboxstorage.h
@@ -95,7 +95,7 @@ public:
 
 	/**
 	 * Load token and user id from configs and return DropboxStorage for those.
-	 * @return pointer to the newly created DropboxStorage or 0 if some problem occured.
+	 * @return pointer to the newly created DropboxStorage or 0 if some problem occurred.
 	 */
 	static DropboxStorage *loadFromConfig(Common::String keyPrefix);
 

--- a/backends/cloud/googledrive/googledrivestorage.h
+++ b/backends/cloud/googledrive/googledrivestorage.h
@@ -102,7 +102,7 @@ public:
 
 	/**
 	 * Load token and user id from configs and return GoogleDriveStorage for those.
-	 * @return pointer to the newly created GoogleDriveStorage or 0 if some problem occured.
+	 * @return pointer to the newly created GoogleDriveStorage or 0 if some problem occurred.
 	 */
 	static GoogleDriveStorage *loadFromConfig(Common::String keyPrefix);
 

--- a/backends/cloud/onedrive/onedrivestorage.h
+++ b/backends/cloud/onedrive/onedrivestorage.h
@@ -99,7 +99,7 @@ public:
 
 	/**
 	 * Load token and user id from configs and return OneDriveStorage for those.
-	 * @return pointer to the newly created OneDriveStorage or 0 if some problem occured.
+	 * @return pointer to the newly created OneDriveStorage or 0 if some problem occurred.
 	 */
 	static OneDriveStorage *loadFromConfig(Common::String keyPrefix);
 

--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -146,7 +146,7 @@ void GLTexture::updateArea(const Common::Rect &area, const Graphics::Surface &sr
 
 	// Update the actual texture.
 	// Although we have the area of the texture buffer we want to update we
-	// cannot take advantage of the left/right boundries here because it is
+	// cannot take advantage of the left/right boundaries here because it is
 	// not possible to specify a pitch to glTexSubImage2D. To be precise, with
 	// plain OpenGL we could set GL_UNPACK_ROW_LENGTH to achieve this. However,
 	// OpenGL ES 1.0 does not support GL_UNPACK_ROW_LENGTH. Thus, we are left

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -406,7 +406,7 @@ bool OpenGLSdlGraphics3dManager::createOrUpdateGLContext(uint gameWidth, uint ga
 	pixelFormats.push_back(OpenGLPixelFormat(16, 5, 5, 5, 1, 0));
 	pixelFormats.push_back(OpenGLPixelFormat(16, 5, 6, 5, 0, 0));
 
-	// Unfortunatly, SDL does not provide a list of valid pixel formats
+	// Unfortunately, SDL does not provide a list of valid pixel formats
 	// for the current OpenGL implementation and hardware.
 	// SDL may not be able to create a screen with the preferred pixel format.
 	// Try all the pixel formats in the list until SDL returns a valid screen.

--- a/backends/platform/gph/gph-backend.cpp
+++ b/backends/platform/gph/gph-backend.cpp
@@ -121,7 +121,7 @@ void OSystem_GPH::initBackend() {
 	/* Set Default hardware mixer volume to a preset level (VOLUME_INITIAL). This is done to 'reset' volume level if set by other apps. */
 	WIZ_HW::mixerMoveVolume(0);
 
-	/* Up default volume values as we use a seperate system level volume anyway. */
+	/* Up default volume values as we use a separate system level volume anyway. */
 	ConfMan.registerDefault("music_volume", 192);
 	ConfMan.registerDefault("sfx_volume", 192);
 	ConfMan.registerDefault("speech_volume", 192);

--- a/common/archive.h
+++ b/common/archive.h
@@ -192,7 +192,7 @@ public:
 	 * Create and add a subdirectory by name (caseless).
 	 *
 	 * It is also possible to add subdirectories of subdirectories (of any depth) with this function.
-	 * The path seperator for this case is SLASH for all systems.
+	 * The path separator for this case is SLASH for all systems.
 	 *
 	 * Example:
 	 *
@@ -216,7 +216,7 @@ public:
 	 * Create and add subdirectories by pattern.
 	 *
 	 * It is also possible to add subdirectories of subdirectories (of any depth) with this function.
-	 * The path seperator for this case is SLASH for all systems.
+	 * The path separator for this case is SLASH for all systems.
 	 *
 	 * Example:
 	 *

--- a/dists/androidsdl/scummvm/AndroidAppSettings.cfg.in
+++ b/dists/androidsdl/scummvm/AndroidAppSettings.cfg.in
@@ -116,7 +116,7 @@ AppRecordsAudio=n
 
 # Application implements Android-specific routines to put to background, and will not draw anything to screen
 # between SDL_ACTIVEEVENT lost / gained notifications - you should check for them
-# rigth after SDL_Flip(), if (n) then SDL_Flip() will block till app in background (y) or (n)
+# right after SDL_Flip(), if (n) then SDL_Flip() will block till app in background (y) or (n)
 # This option is reported to be buggy, sometimes failing to restore video state
 NonBlockingSwapBuffers=n
 

--- a/dists/engine-data/create-playground3d-data.sh
+++ b/dists/engine-data/create-playground3d-data.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Create the directory structure
-# Avoided bash shortcuts / file-seperators in interest of portability
+# Avoided bash shortcuts / file-separators in interest of portability
 
 if [ -e playground3d ]; then
 	echo "Game-data already present as playground3d/"

--- a/dists/engine-data/create-testbed-data.sh
+++ b/dists/engine-data/create-testbed-data.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Create the directory structure
-# Avoided bash shortcuts / file-seperators in interest of portability
+# Avoided bash shortcuts / file-separators in interest of portability
 
 if [ -e testbed ]; then
 	echo "Game-data already present as testbed/"

--- a/engines/agi/module.mk
+++ b/engines/agi/module.mk
@@ -55,5 +55,5 @@ DETECT_OBJS += $(MODULE)/detection.o
 
 # External dependencies of detection.
 # This is unneeded by the engine module itself,
-# so seperate it completely.
+# so separate it completely.
 DETECT_OBJS += $(MODULE)/wagparser.o

--- a/engines/agi/saveload.cpp
+++ b/engines/agi/saveload.cpp
@@ -976,7 +976,7 @@ bool AgiEngine::loadGameDialog() {
 // If we fail, return false, so that the regular saved game dialog is called
 // Original AGI was limited to 12 saves, we are effectively limited to 100 saves at the moment.
 //
-// btw. this also means that entering an existant name in Mixed Up Mother Goose will effectively overwrite
+// btw. this also means that entering an existent name in Mixed Up Mother Goose will effectively overwrite
 // that saved game. This is also what original AGI did.
 bool AgiEngine::saveGameAutomatic() {
 	int16 automaticSaveGameSlotId = 0;

--- a/engines/agi/systemui.cpp
+++ b/engines/agi/systemui.cpp
@@ -286,7 +286,7 @@ int16 SystemUI::figureOutAutomaticSaveGameSlot(const char *automaticSaveDescript
 
 	// Walk through saved game slots
 	// check, if description matches and return the slot
-	// if no match can be found, return the first non-existant slot
+	// if no match can be found, return the first non-existent slot
 	// if all slots exist, return -1
 	figureOutAutomaticSavedGameSlot(automaticSaveDescription, matchedGameSlotId, freshGameSlotId);
 
@@ -294,7 +294,7 @@ int16 SystemUI::figureOutAutomaticSaveGameSlot(const char *automaticSaveDescript
 		return matchedGameSlotId; // return matched slot
 
 	if (freshGameSlotId >= 0)
-		return freshGameSlotId; // return first non-existant slot
+		return freshGameSlotId; // return first non-existent slot
 
 	return -1; // no slots exist, not match found
 }
@@ -304,7 +304,7 @@ int16 SystemUI::figureOutAutomaticRestoreGameSlot(const char *automaticSaveDescr
 	int16 freshGameSlotId   = -1;
 
 	// Fill saved game slot cache
-	readSavedGameSlots(true, false); // filter non-existant/invalid saves, also don't include auto-save slot
+	readSavedGameSlots(true, false); // filter non-existent/invalid saves, also don't include auto-save slot
 
 	// Walk through saved game slots
 	// check, if description matches and return the slot. Otherwise return -1

--- a/engines/agi/view.cpp
+++ b/engines/agi/view.cpp
@@ -481,7 +481,7 @@ void AgiEngine::setLoop(ScreenObjEntry *screenObj, int16 loopNr) {
 	}
 
 	if (loopNr >= screenObj->loopCount) {
-		// requested loop not existant
+		// requested loop not existent
 		// instead of error()ing out, we instead clip it
 		// At least required for possibly Manhunter 1 according to previous comment when leaving the arcade machine
 		// TODO: Check MH1
@@ -493,7 +493,7 @@ void AgiEngine::setLoop(ScreenObjEntry *screenObj, int16 loopNr) {
 
 		loopNr = screenObj->loopCount - 1;
 
-		warning("Non-existant loop requested for screen object %d", screenObj->objectNr);
+		warning("Non-existent loop requested for screen object %d", screenObj->objectNr);
 		warning("view %d, requested loop %d -> clipped to loop %d", screenObj->currentViewNr, requestedLoopNr, loopNr);
 	}
 
@@ -537,7 +537,7 @@ void AgiEngine::setCel(ScreenObjEntry *screenObj, int16 celNr) {
 	}
 
 	if (celNr >= screenObj->celCount) {
-		// requested cel not existant
+		// requested cel not existent
 		// instead of error()ing out, we instead clip it
 		// At least required for King's Quest 3 on Apple IIgs - walking the planks death cutscene
 		// see bug #5832, which is a game bug!
@@ -545,7 +545,7 @@ void AgiEngine::setCel(ScreenObjEntry *screenObj, int16 celNr) {
 
 		celNr = screenObj->celCount - 1;
 
-		warning("Non-existant cel requested for screen object %d", screenObj->objectNr);
+		warning("Non-existent cel requested for screen object %d", screenObj->objectNr);
 		warning("view %d, loop %d, requested cel %d -> clipped to cel %d", screenObj->currentViewNr, screenObj->currentLoopNr, requestedCelNr, celNr);
 	}
 

--- a/engines/ags/engine/ac/draw.cpp
+++ b/engines/ags/engine/ac/draw.cpp
@@ -1394,7 +1394,7 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
 
 
 
-// This is only called from draw_screen_background, but it's seperated
+// This is only called from draw_screen_background, but it's separated
 // to help with profiling the program
 void prepare_objects_for_drawing() {
 	_G(our_eip) = 32;
@@ -1472,7 +1472,7 @@ void tint_image(Bitmap *ds, Bitmap *srcimg, int red, int grn, int blu, int light
 		return;
 	}
 
-	// For performance reasons, we have a seperate blender for
+	// For performance reasons, we have a separate blender for
 	// when light is being adjusted and when it is not.
 	// If luminance >= 250, then normal brightness, otherwise darken
 	if (luminance >= 250)

--- a/engines/ags/engine/ac/game.cpp
+++ b/engines/ags/engine/ac/game.cpp
@@ -786,7 +786,7 @@ void serialize_bitmap(const Shared::Bitmap *thispic, Stream *out) {
 	}
 }
 
-// On Windows we could just use IIDFromString but this is _G(platform)-independant
+// On Windows we could just use IIDFromString but this is _G(platform)-independent
 void convert_guid_from_text_to_binary(const char *guidText, unsigned char *buffer) {
 	guidText++; // skip {
 	for (int bytesDone = 0; bytesDone < 16; bytesDone++) {

--- a/engines/ags/engine/ac/game.h
+++ b/engines/ags/engine/ac/game.h
@@ -161,12 +161,12 @@ void unload_game_file();
 void save_game(int slotn, const char *descript);
 bool read_savedgame_description(const Shared::String &savedgame, Shared::String &description);
 bool read_savedgame_screenshot(const Shared::String &savedgame, int &want_shot);
-// Tries to restore saved game and displays an error on failure; if the error occured
+// Tries to restore saved game and displays an error on failure; if the error occurred
 // too late, when the game data was already overwritten, shuts engine down.
 bool try_restore_save(int slot);
 bool try_restore_save(const Shared::String &path, int slot);
 void serialize_bitmap(const Shared::Bitmap *thispic, Shared::Stream *out);
-// On Windows we could just use IIDFromString but this is platform-independant
+// On Windows we could just use IIDFromString but this is platform-independent
 void convert_guid_from_text_to_binary(const char *guidText, unsigned char *buffer);
 Shared::Bitmap *read_serialized_bitmap(Shared::Stream *in);
 void skip_serialized_bitmap(Shared::Stream *in);

--- a/engines/ags/engine/ac/object.cpp
+++ b/engines/ags/engine/ac/object.cpp
@@ -305,7 +305,7 @@ void Object_Move(ScriptObject *objj, int x, int y, int speed, int blocking, int 
 	if ((blocking == BLOCKING) || (blocking == 1))
 		GameLoopUntilNotMoving(&_G(objs)[objj->id].moving);
 	else if ((blocking != IN_BACKGROUND) && (blocking != 0))
-		quit("Object.Move: invalid BLOCKING paramter");
+		quit("Object.Move: invalid BLOCKING parameter");
 }
 
 void Object_SetClickable(ScriptObject *objj, int clik) {

--- a/engines/ags/engine/game/savegame.cpp
+++ b/engines/ags/engine/game/savegame.cpp
@@ -668,7 +668,7 @@ HSaveError RestoreGameState(Stream *in, SavegameVersion svg_version) {
 
 
 void WriteSaveImage(Stream *out, const Bitmap *screenshot) {
-	// store the screenshot at the start to make it easily accesible
+	// store the screenshot at the start to make it easily accessible
 	out->WriteInt32((screenshot == nullptr) ? 0 : 1);
 
 	if (screenshot)

--- a/engines/ags/shared/ac/sprite_cache.cpp
+++ b/engines/ags/shared/ac/sprite_cache.cpp
@@ -869,7 +869,7 @@ HAGSError SpriteFile::OpenFile(const String &filename, const String &sprindex_fi
 	buff[13] = 0;
 	if (strcmp(buff, spriteFileSig)) {
 		_stream.reset();
-		return new Error("Uknown spriteset format.");
+		return new Error("Unknown spriteset format.");
 	}
 
 	if (vers == kSprfVersion_Uncompressed) {

--- a/engines/ags/shared/util/file_stream.cpp
+++ b/engines/ags/shared/util/file_stream.cpp
@@ -217,7 +217,7 @@ Common::OutSaveFile *FileStream::openForWriting(const String &saveName, FileOpen
 	if (work_mode == kFile_Read || work_mode == kFile_ReadWrite)
 		// In the original these modes result in [aw]+b, which seems to result
 		// in a file with arbitrary reading, but writing always appending
-		warning("FileOpen: independant read/write positions not supported");
+		warning("FileOpen: independent read/write positions not supported");
 
 	Common::InSaveFile *existing = nullptr;
 	if (open_mode == kFile_Create &&

--- a/engines/ags/shared/util/string.h
+++ b/engines/ags/shared/util/string.h
@@ -332,9 +332,9 @@ public:
 	}
 	// Prepends a single character
 	void    PrependChar(char c);
-	// Replaces all occurences of one character with another character
+	// Replaces all occurrences of one character with another character
 	void    Replace(char what, char with);
-	// Replaces all occurences of one substring with another substring
+	// Replaces all occurrences of one substring with another substring
 	void    Replace(const String &what, const String &with);
 	void    Replace(const char *what, const char *with) {
 		String whats = String::Wrapper(what), withs = String::Wrapper(with); Replace(whats, withs);

--- a/engines/avalanche/avalot.cpp
+++ b/engines/avalanche/avalot.cpp
@@ -1290,7 +1290,7 @@ void AvalancheEngine::gameOver() {
 void AvalancheEngine::minorRedraw() {
 	fadeOut();
 
-	enterRoom(_room, 0); // Ped unknown or non-existant.
+	enterRoom(_room, 0); // Ped unknown or non-existent.
 
 	for (int i = 0; i < 3; i++)
 		_scoreToDisplay[i] = -1; // impossible digits

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -272,7 +272,7 @@ Common::Error BladeRunnerEngine::loadGameState(int slot) {
 
 	setTotalPlayTime(header._playTime);
 	// this essentially does something similar with setTotalPlayTime
-	// reseting and updating Blade Runner's _pauseStart and offset before starting a loaded game
+	// resetting and updating Blade Runner's _pauseStart and offset before starting a loaded game
 	_time->resetPauseStart();
 
 	loadGame(*saveFile, header._version);

--- a/engines/bladerunner/debugger.cpp
+++ b/engines/bladerunner/debugger.cpp
@@ -1238,7 +1238,7 @@ bool Debugger::cmdOverlay(int argc, const char **argv) {
 
 				_vm->_scene->_vqaPlayer = new VQAPlayer(_vm, &_vm->_surfaceBack, origVqaName);
 				if (!_vm->_scene->_vqaPlayer->open()) {
-					debugPrintf("Error: Could not open player while reseting\nto scene VQA named: %s!\n", (origVqaName + ".VQA").c_str());
+					debugPrintf("Error: Could not open player while resetting\nto scene VQA named: %s!\n", (origVqaName + ".VQA").c_str());
 					return true;
 				}
 				_vm->_scene->startDefaultLoop();
@@ -1323,7 +1323,7 @@ bool Debugger::cmdOverlay(int argc, const char **argv) {
 				// even if it's not already loaded for the scene (in _vm->_overlays->_videos)
 				int overlayVideoIdx = _vm->_overlays->play(overlayName, overlayAnimationId, loopForever, startNowFlag, 0);
 				if ( overlayVideoIdx == -1 ) {
-					debugPrintf("Could not load the overlay animation: %s in this scene. Try reseting overlays first to free up slots!\n", overlayName.c_str());
+					debugPrintf("Could not load the overlay animation: %s in this scene. Try resetting overlays first to free up slots!\n", overlayName.c_str());
 				} else {
 					debugPrintf("Loading overlay animation: %s...\n", overlayName.c_str());
 

--- a/engines/bladerunner/script/scene/dr02.cpp
+++ b/engines/bladerunner/script/scene/dr02.cpp
@@ -95,7 +95,7 @@ void SceneScriptDR02::SceneLoaded() {
 	Clickable_Object("V2CANPIPE02");
 	// there are two objects named "TRASH CAN WITH FIRE" in the scene (but not visible)
 	// and none of them have to be set clickable
-	// and also reseting them here would only reset one of them - and one remains as clickable
+	// and also resetting them here would only reset one of them - and one remains as clickable
 	Unclickable_Object("TRASH CAN WITH FIRE");
 	Unclickable_Object("U2 CHEWDOOR");
 	Unclickable_Object("MMTRASHCAN");

--- a/engines/cine/sound.cpp
+++ b/engines/cine/sound.cpp
@@ -1534,7 +1534,7 @@ void PaulaSound::sfxTimerCallback() {
 	} else {
 		_sfxTimer = 0;
 		// Possible TODO: The original only ever started sounds here. This
-		// should not be noticable though. So we do not do it for now.
+		// should not be noticeable though. So we do not do it for now.
 	}
 }
 

--- a/engines/cruise/vars.h
+++ b/engines/cruise/vars.h
@@ -266,7 +266,7 @@ extern int16 ctp_routes[20][10];	// path-finding line information
 /* ctp_routes:
 
    correct size would be: ctp_routes[routeCoordCount * 20 * 2]
-   array is seperate in 20 * 2 bytes slices.
+   array is separate in 20 * 2 bytes slices.
    first 2 bytes of the slice indicate how many coordinates/lines are following (lineCount)
    after that there are lineCount * 2 bytes following with indexes pointing on the routeCoords table
    the root x,y for the lines is the coordinate in the routeCoords array, which fits to the current slice

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -1092,7 +1092,7 @@ void Cast::loadLingoContext(Common::SeekableReadStreamEndian &stream) {
 			}
 		}
 	} else {
-		error("Cast::loadLingoContext: unsuported Director version (%d)", _version);
+		error("Cast::loadLingoContext: unsupported Director version (%d)", _version);
 	}
 }
 

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1085,7 +1085,7 @@ void LB::b_getNthFileNameInFolder(int nargs) {
 	if (d.exists()) {
 		Common::FSList f;
 		if (!d.getChildren(f, Common::FSNode::kListAll)) {
-			warning("Cannot acces directory %s", path.c_str());
+			warning("Cannot access directory %s", path.c_str());
 		} else {
 			if ((uint)fileNum < f.size()) {
 				// here, we sort all the fileNames

--- a/engines/dm/projexpl.h
+++ b/engines/dm/projexpl.h
@@ -56,7 +56,7 @@ public:
 	void createProjectile(Thing thing, int16 mapX, int16 mapY, uint16 cell, Direction dir,
 							   byte kineticEnergy, byte attack, byte stepEnergy); // @ F0212_PROJECTILE_Create
 	bool hasProjectileImpactOccurred(int16 impactType, int16 mapXCombo, int16 mapYCombo,
-										  int16 cell, Thing projectileThing); // @ F0217_PROJECTILE_HasImpactOccured
+										  int16 cell, Thing projectileThing); // @ F0217_PROJECTILE_HasImpactOccurred
 	uint16 getProjectileImpactAttack(Projectile *projectile, Thing thing); // @ F0216_PROJECTILE_GetImpactAttack
 	void createExplosion(Thing explThing, uint16 attack, uint16 mapXCombo,
 							  uint16 mapYCombo, uint16 cell); // @ F0213_EXPLOSION_Create

--- a/engines/glk/agt/exec.cpp
+++ b/engines/glk/agt/exec.cpp
@@ -784,7 +784,7 @@ static char *match_string(char *ans, char *corr_ans, int n)
 static rbool check_answer(char *ans, long start, long size)
 /* qnum has already been fixed to start from 0 */
 /*   Master's edition answer checker. Master's edition answers can */
-/* be seperate by AND and OR characters. If there is one OR in the */
+/* be separate by AND and OR characters. If there is one OR in the */
 /* answer, all ANDs will also be treated as ORs */
 /*   Furthermore, AND-delimited strings must appear in the correct order */
 /* unless PURE_ANSWER is false */

--- a/engines/glk/agt/gamedata.cpp
+++ b/engines/glk/agt/gamedata.cpp
@@ -1244,7 +1244,7 @@ void sort_cmd(void) {
 	}
 
 	for (i = 0; i < TOTAL_VERB; i++)
-		if (verbptr[i] == last_cmd) /* No occurences of this verb */
+		if (verbptr[i] == last_cmd) /* No occurrences of this verb */
 			verbend[i] = last_cmd;
 		else verbend[i]++; /* Point *after* last occurance */
 

--- a/engines/glk/agt/interp.h
+++ b/engines/glk/agt/interp.h
@@ -300,7 +300,7 @@ global short last_he, last_she, last_it, last_they;
 #define ALL_MARK (-ext_code[wall])
 
 #define D_END  50    /* Marks end of disambiguation list */
-#define D_AND  51    /* Used to seperate multiple objects during disambig */
+#define D_AND  51    /* Used to separate multiple objects during disambig */
 #define D_NOUN 0   /* Noun match */
 #define D_SYN 1    /* Adjective/synonym only match */
 #define D_ADJ 2    /* Adj only match */

--- a/engines/glk/agt/object.cpp
+++ b/engines/glk/agt/object.cpp
@@ -972,7 +972,7 @@ void setprop(int obj, int prop, long val) {
 	integer *paddr;
 
 	if (prop >= NUM_WPROP) {
-		writeln("GAME ERROR: Read-only or non-existant property.");
+		writeln("GAME ERROR: Read-only or non-existent property.");
 		return;
 	}
 
@@ -997,7 +997,7 @@ void setattr(int obj, int prop, rbool val) {
 	rbool *paddr;
 
 	if (prop >= NUM_WATTR && prop != 24) {
-		writeln("GAME ERROR: Read-only or non-existant attribute.");
+		writeln("GAME ERROR: Read-only or non-existent attribute.");
 		return;
 	}
 

--- a/engines/glk/agt/runverb.cpp
+++ b/engines/glk/agt/runverb.cpp
@@ -282,7 +282,7 @@ static void v_eat(int vc, parse_rec *nounrec) {
 
 	if (noun[dobj_ - first_noun].movable) it_destroy(dobj_);
 	if (noun[dobj_ - first_noun].poisonous) {
-		sysmsgd(129, "Unfortunatly, $n_pro$ $n_was$ poisonous.", nounrec);
+		sysmsgd(129, "Unfortunately, $n_pro$ $n_was$ poisonous.", nounrec);
 		deadflag = 1;
 	}
 }
@@ -768,7 +768,7 @@ static void v_attack(uchar missile, parse_rec *targrec, parse_rec *weprec) {
 			if (noun[wep - first_noun].drinkable) { /* i.e. a liquid */
 				alt_sysmsg(msgnum + 1, "$You$ splash $the_o$$object$ with "
 				           "$the_n$$noun$, but the liquid quickly evaporates "
-				           "without noticable effect.", weprec, targrec);
+				           "without noticeable effect.", weprec, targrec);
 				it_destroy(wep);
 			} else {
 				alt_sysmsg(msgnum,

--- a/engines/glk/agt/util.cpp
+++ b/engines/glk/agt/util.cpp
@@ -1039,7 +1039,7 @@ static void read_filerec(file_info *rec_desc, const uchar *filedata) {
 			                                 filedata[2], filedata[3]);
 			break;
 		default:
-			fatal("Unreconized field type");
+			fatal("Unrecognized field type");
 		}
 		filedata += ft_leng[rec_desc->ftype];
 	}
@@ -1159,7 +1159,7 @@ static void write_filerec(file_info *rec_desc, uchar *filedata) {
 			break;
 		}
 		default:
-			fatal("Unreconized field type");
+			fatal("Unrecognized field type");
 		}
 		filedata += ft_leng[rec_desc->ftype];
 	}

--- a/engines/glk/window_pair.cpp
+++ b/engines/glk/window_pair.cpp
@@ -53,7 +53,7 @@ void PairWindow::rearrange(const Rect &box) {
 	_bbox = box;
 
 	if (_dir == winmethod_Arbitrary) {
-		// When a pair window is in "arbitrary" mode, each child window has it's own independant positioning,
+		// When a pair window is in "arbitrary" mode, each child window has it's own independent positioning,
 		// so thre's no need to be readjusting it
 		return;
 	}

--- a/engines/glk/zcode/processor_buffer.cpp
+++ b/engines/glk/zcode/processor_buffer.cpp
@@ -188,7 +188,7 @@ void Processor::runtimeError(ErrorCode errNum) {
 		if (_err_report_mode == ERR_REPORT_ONCE) {
 			print_string(" (will ignore further occurrences)");
 		} else {
-			print_string(" (occurence ");
+			print_string(" (occurrence ");
 			print_long(_errorCount[errNum - 1], 10);
 			print_char(')');
 		}

--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -108,7 +108,7 @@ uint16 Font::getCharIndex(unsigned char c) const {
 		if (_charIndex[i] == c2)
 			return i;
 	}
-	Debug::warning(Debug::Fonts, "The requsted character (code 0x%x) does not correspond to anything in the font data!", c2);
+	Debug::warning(Debug::Fonts, "The requested character (code 0x%x) does not correspond to anything in the font data!", c2);
 	// If we couldn't find the character then default to
 	// the first character in the font so that something
 	// gets loaded to prevent the game from crashing

--- a/engines/hugo/schedule.cpp
+++ b/engines/hugo/schedule.cpp
@@ -1381,7 +1381,7 @@ Event *Scheduler::doAction(Event *curEvent) {
 		break;
 	case INIT_STORY_MODE:                             // act39: Init story_mode flag
 		// This is similar to the QUIET path mode, except that it is
-		// independant of it and it additionally disables the ">" prompt
+		// independent of it and it additionally disables the ">" prompt
 		gameStatus._storyModeFl = action->_a39._storyModeFl;
 		break;
 	case WARN:                                        // act40: Text box (CF TEXT)

--- a/engines/icb/barriers.cpp
+++ b/engines/icb/barriers.cpp
@@ -630,7 +630,7 @@ void _barrier_handler::Form_route_barrier_list(PXreal x, PXreal y, PXreal z, PXr
 	_rect rb; // rb meaning 'Route-Box'
 	uint32 j;
 	_child_group *clist[MAX_child_groups_per_parent * 2];
-	uint32 total_childs = 0; // seperate total for safety
+	uint32 total_childs = 0; // separate total for safety
 	int32 expanded_this_go;
 	_route_barrier *bar;
 	uint32 k;

--- a/engines/icb/drawpoly_pc.cpp
+++ b/engines/icb/drawpoly_pc.cpp
@@ -1394,7 +1394,7 @@ void drawGUL3PC(uint32 *polyStart, const uint32 n, SVECTORPC *pVertex, SVECTOR *
 				setLineG4(line);
 				int32 cval;
 				if (_drawGouraud) {
-					// Give each vertex a seperate colour
+					// Give each vertex a separate colour
 					// Compute the colour scaling and clip it
 					if (rgbIn.r != 0) {
 						cval = ((wfrmRed * rgb0.r) / rgbIn.r);
@@ -2191,7 +2191,7 @@ void drawGTL3PC(uint32 *polyStart, const uint32 n, SVECTORPC *pVertex, SVECTOR *
 				setLineG4(line);
 				int32 cval;
 				if (_drawGouraud) {
-					// Give each vertex a seperate colour
+					// Give each vertex a separate colour
 					// Compute the colour scaling and clip it
 					if (rgbIn.r != 0) {
 						cval = ((wfrmRed * rgb0.r) / rgbIn.r);

--- a/engines/icb/event_manager.h
+++ b/engines/icb/event_manager.h
@@ -43,7 +43,7 @@ namespace ICB {
 #define EVENT_MANAGER_MAX_TIMERS 4
 
 // Keeps track of which object is interested in hearing about events from which other objects and stores
-// events which have occured until they can be handled.
+// events which have occurred until they can be handled.
 class _event_manager {
 public:
 	// Default constructor and destructor.

--- a/engines/icb/map_marker_pc.cpp
+++ b/engines/icb/map_marker_pc.cpp
@@ -36,7 +36,7 @@ namespace ICB {
 
 void _marker::___init() {
 	// read in the session markers file - this is the engine written file not the max Nico file
-	// read data into a structure as it needs to be modifiable and saveable which isnt posible with res_man files
+	// read data into a structure as it needs to be modifiable and saveable which isnt possible with res_man files
 	int32 len;
 
 	Zdebug("\n\n\n-------------*** Init marker file ***-------------");

--- a/engines/icb/options_manager_pc.cpp
+++ b/engines/icb/options_manager_pc.cpp
@@ -6143,7 +6143,7 @@ void OptionsManager::DrawSlideShow() {
 		uint32 art2DClusterHash = NULL_HASH;
 
 		if (!IsAValidSlide(m_currentSlide, slideFile))
-			Fatal_error("Trying to display a non-existant slide image!");
+			Fatal_error("Trying to display a non-existent slide image!");
 
 		// Set this up for resman and open the thb file
 		sprintf(art2DCluster, ICON_CLUSTER_PATH);

--- a/engines/icb/player_pc.cpp
+++ b/engines/icb/player_pc.cpp
@@ -96,7 +96,7 @@ void _player::Update_input_state() {
 
 	// note - analogue controllers return a direction which is different from forward-and-rotate schemes
 
-	// this routine requires seperate pc/psx coding
+	// this routine requires separate pc/psx coding
 
 	//				pc devices
 	//				----------

--- a/engines/icb/remora.cpp
+++ b/engines/icb/remora.cpp
@@ -872,7 +872,7 @@ void _remora::ClearAllText() {
 	m_nFirstLineToDraw = 0;
 
 	m_bScrollingRequired = FALSE8;
-	m_bScrolling = FALSE8; // these three need reseting so when we go to a new page we don't try scrolling off screen
+	m_bScrolling = FALSE8; // these three need resetting so when we go to a new page we don't try scrolling off screen
 	m_nStartYPixelOffset = 0;
 	m_eTextScroll = SCROLL_NONE;
 

--- a/engines/icb/res_man.cpp
+++ b/engines/icb/res_man.cpp
@@ -843,7 +843,7 @@ uint32 res_man::FindMemBlock(uint32 adj_len, RMParams *params) {
 			} while (search != -1);
 
 			if (!total_age)
-				Fatal_error("failed to build an age table - not really posible");
+				Fatal_error("failed to build an age table - not really possible");
 
 			//			now sort the ages
 			for (j = 0; j < total_age; j++)

--- a/engines/icb/route_manager.cpp
+++ b/engines/icb/route_manager.cpp
@@ -88,7 +88,7 @@ void _game_session::Reset_route_manager() {
 
 	// remove used routes - just keeps the memory limit down
 
-	Zdebug("--new sesssion: reseting route manager service--");
+	Zdebug("--new sesssion: resetting route manager service--");
 }
 
 bool8 _game_session::Is_route_required(PXreal startx, PXreal startz, PXreal destx, PXreal destz) {

--- a/engines/icb/sound.h
+++ b/engines/icb/sound.h
@@ -174,7 +174,7 @@ public:
 
 	CSfx *GetSfx(); // should be reasonably fast now...
 
-	// volume and pan together (faster than seperate)
+	// volume and pan together (faster than separate)
 	void GetVolumeAndPan(int32 &vol, int32 &pan);
 
 private:

--- a/engines/kyra/graphics/screen_eob_amiga.cpp
+++ b/engines/kyra/graphics/screen_eob_amiga.cpp
@@ -278,7 +278,7 @@ void AmigaDOSFont::errorDialog(int index) {
 	if (index == 0) {
 		::GUI::displayErrorDialog(_(
 			"This AMIGA version requires the following font files:\n\nEOBF6.FONT\nEOBF6/6\nEOBF8.FONT\nEOBF8/8\n\n"
-			"If you used the orginal installer for the installation these files\nshould be located in the AmigaDOS system 'Fonts/' folder.\n"
+			"If you used the original installer for the installation these files\nshould be located in the AmigaDOS system 'Fonts/' folder.\n"
 			"Please copy them into the EOB game data directory.\n"
 		));
 

--- a/engines/lure/sound.cpp
+++ b/engines/lure/sound.cpp
@@ -663,7 +663,7 @@ void SoundManager::musicInterface_ContinuePlaying() {
  * off again because of a bug. Also, TrashReverb being triggered by doors opening
  * offscreen would be a bug. There is a third problem: the door opening sound lasts
  * much longer than 40 ms, so turning reverb back on 40 ms after starting the door
- * opening sound still results in a noticable reverb. All in all this explanation
+ * opening sound still results in a noticeable reverb. All in all this explanation
  * is not entirely convicing.
  * Another explanation would be that reverb was only meant to be on for the first
  * part of the game and should be turned off from the town onwards (this is what

--- a/engines/mads/mads.cpp
+++ b/engines/mads/mads.cpp
@@ -129,7 +129,7 @@ void MADSEngine::loadOptions() {
 
 	// Note: MADS is weird in that sfx and music are handled by the same driver,
 	// and the game scripts themselves check for music being enabled before playing
-	// a "music" sound. Which means we can independantly mute music in ScummVM, but
+	// a "music" sound. Which means we can independently mute music in ScummVM, but
 	// otherwise all sound, music and sfx, is controlled by the SFX volume slider.
 	int soundVolume = MIN(255, ConfMan.getInt("sfx_volume"));
 	_sound->setVolume(soundVolume);

--- a/engines/mohawk/cstime_ui.cpp
+++ b/engines/mohawk/cstime_ui.cpp
@@ -285,7 +285,7 @@ void CSTimeInterface::mouseDown(Common::Point pos) {
 		return;
 	}
 
-	// TODO: case 20 ui craziness is handled seperately..
+	// TODO: case 20 ui craziness is handled separately..
 
 	CSTimeConversation *conv = _vm->getCase()->getCurrConversation();
 	if (_bookRect.contains(pos) || (_noteRect.contains(pos) && _note->havePiece(0xffff))) {
@@ -337,7 +337,7 @@ void CSTimeInterface::mouseMove(Common::Point pos) {
 	if (_note->getState() == 2)
 		return;
 
-	// TODO: case 20 ui craziness is handled seperately..
+	// TODO: case 20 ui craziness is handled separately..
 
 	if (_sceneRect.contains(pos) && !_vm->getCase()->getCurrScene()->eventIsActive()) {
 		_vm->getCase()->getCurrScene()->mouseMove(pos);
@@ -467,7 +467,7 @@ void CSTimeInterface::mouseUp(Common::Point pos) {
 
 	// TODO: if in sailing puzzle, sailing puzzle mouse up, return
 
-	// TODO: case 20 ui craziness is handled seperately..
+	// TODO: case 20 ui craziness is handled separately..
 
 	if (_sceneRect.contains(pos)) {
 		_vm->getCase()->getCurrScene()->mouseUp(pos);

--- a/engines/mohawk/livingbooks_code.cpp
+++ b/engines/mohawk/livingbooks_code.cpp
@@ -1911,7 +1911,7 @@ uint LBCode::parseCode(const Common::String &source) {
 				code.push_back(kTokenCloseBracket);
 			counterPositions.pop_back();
 			break;
-		// comma (seperating function params)
+		// comma (separating function params)
 		case ',':
 			{
 			if (counterPositions.empty())

--- a/engines/mohawk/myst_stacks/myst.cpp
+++ b/engines/mohawk/myst_stacks/myst.cpp
@@ -3347,7 +3347,7 @@ void Myst::o_forechamberDoor_init(uint16 var, const ArgumentsArray &args) {
 }
 
 void Myst::o_shipAccess_init(uint16 var, const ArgumentsArray &args) {
-	// Enable acces to the ship
+	// Enable access to the ship
 	if (_state.shipFloating) {
 		getInvokingResource<MystArea>()->setEnabled(true);
 	}

--- a/engines/myst3/database.cpp
+++ b/engines/myst3/database.cpp
@@ -881,7 +881,7 @@ void Database::patchLanguageMenu() {
 	// The scripts for the other languages only differ by the value set for AudioLanguage variable
 	// when the language selection is not English.
 	// This function patches the language selection script to set the appropriate value based
-	// on the detected game langage.
+	// on the detected game language.
 
 	// Script disassembly:
 	//	hotspot 5 > c[v1 != 0] (true)

--- a/engines/myst3/puzzles.cpp
+++ b/engines/myst3/puzzles.cpp
@@ -1407,7 +1407,7 @@ void Puzzles::railRoadSwitchs() {
 		endFrame = 12;
 		break;
 	default:
-		error("Bad railroad switchs start value %d", startFrame);
+		error("Bad railroad switches start value %d", startFrame);
 		return;
 	}
 

--- a/engines/neverhood/gamemodule.cpp
+++ b/engines/neverhood/gamemodule.cpp
@@ -191,9 +191,9 @@ void GameModule::initMemoryPuzzle() {
 			setSubVar(VA_DICE_MEMORY_SYMBOLS, diceIndices.getNumber(), tileSymbols.getNumber());
 		// Insert special symbols tiles
 		for (uint32 i = 0; i < 3; ++i) {
-			int tileSymbolOccurence = _vm->_rnd->getRandomNumber(4 - 1) * 2 + 2;
-			setSubVar(VA_GOOD_DICE_NUMBERS, i, tileSymbolOccurence);
-			while (tileSymbolOccurence--)
+			int tileSymbolOccurrence = _vm->_rnd->getRandomNumber(4 - 1) * 2 + 2;
+			setSubVar(VA_GOOD_DICE_NUMBERS, i, tileSymbolOccurrence);
+			while (tileSymbolOccurrence--)
 				setSubVar(VA_TILE_SYMBOLS, availableTiles.getNumber(), getSubVar(VA_DICE_MEMORY_SYMBOLS, i));
 		}
 		// Fill the remaining tiles

--- a/engines/saga2/floating.cpp
+++ b/engines/saga2/floating.cpp
@@ -726,7 +726,7 @@ void drawFloatingWindows(gPort &port, const Point16 &offset, const Rect16 &clip)
 			oldExtent = bound(newExtent, oldExtent);
 			updateWindowSection(oldExtent);
 		} else {
-			//  Otherwise, update new and old positions seperately
+			//  Otherwise, update new and old positions separately
 
 			updateWindowSection(newExtent);
 			updateWindowSection(oldExtent);

--- a/engines/saga2/grequest.cpp
+++ b/engines/saga2/grequest.cpp
@@ -41,7 +41,7 @@ const int           maxLines = 16,
                     buttonWidth = 60;
 
 //  This function takes a string which is composed of several
-//  substrings, each seperated by a delimiter character, and
+//  substrings, each separated by a delimiter character, and
 //  breaks it up into the individual sub-strings.
 
 int16 SplitString(

--- a/engines/saga2/gtext.cpp
+++ b/engines/saga2/gtext.cpp
@@ -118,7 +118,7 @@ void DrawChar(gFont *font, int drawchar, int xpos, uint8 *baseline, uint8 color,
     This function renders a single bitmapped character into an offscreen
     buffer. The character will be "ballooned", i.e. expanded, by 1 pixel
     in each direction. It does not render the center part of the outlined
-    character in a different color -- that must be done as a seperate
+    character in a different color -- that must be done as a separate
     step.
 
     'drawchar' is the ascii code of the character to be drawn.

--- a/engines/saga2/idtypes.h
+++ b/engines/saga2/idtypes.h
@@ -47,7 +47,7 @@ const ObjectID      Nothing = 0,            // a reference to no object
                     ActorLimbo = 2,         // where dead actors go
                     ImportantLimbo = 3,     // where dead important objects go
                     ActorBaseID = 0x8000,   // high bit set for actors
-                    WorldBaseID = 0xF000;   // 4K posible worlds
+                    WorldBaseID = 0xF000;   // 4K possible worlds
 
 /* ===================================================================== *
    TileID

--- a/engines/saga2/objects.h
+++ b/engines/saga2/objects.h
@@ -77,7 +77,7 @@ struct ResourceGameObject {
 //  Base class of all objects
 //
 //  Unlike the object prototypes, the only subclass of GameObject is
-//  the actor subclass, which is kept in an entirely seperate table.
+//  the actor subclass, which is kept in an entirely separate table.
 //  This allows all objects to be kept in an array (indexed by ID number)
 
 #include "common/pack-start.h"

--- a/engines/saga2/objproto.h
+++ b/engines/saga2/objproto.h
@@ -236,7 +236,7 @@ struct ResourceObjectPrototype {
 		objPropCharges      = (1 << 6),     // it's a missile weapon
 		objPropEdible       = (1 << 7),     // can be eaten
 		objPropFlipped      = (1 << 8),     // flipped left/right on ground
-		objPropVisOpen      = (1 << 9),     // Object has seperate "visible" sprite
+		objPropVisOpen      = (1 << 9),     // Object has separate "visible" sprite
 		objPropHidden       = (1 << 10),    // "How not to be seen".
 		objPropGhosted      = (1 << 11),    // Object permanently ghosted
 		objPropHardSurface  = (1 << 12),    // Object makes hard sound when struck

--- a/engines/saga2/panel.h
+++ b/engines/saga2/panel.h
@@ -75,7 +75,7 @@ void EventLoop(bool &running, bool modal = false);
  * ===================================================================== */
 
 enum gEventType {
-	gEventNone = 0,                         // no event occured
+	gEventNone = 0,                         // no event occurred
 	gEventMouseDown,                        // left button pressed
 	gEventMouseUp,                          // left button released
 	gEventRMouseDown,                       // right button pressed
@@ -98,7 +98,7 @@ enum gEventType {
 
 struct gEvent {
 	gPanel          *panel;                 // where event came from
-	enum gEventType eventType;              // type of event that occured
+	enum gEventType eventType;              // type of event that occurred
 	Point16         mouse;                  // mouse position
 	int32           value;                  // new value of control
 	gWindow         *window;                // active window

--- a/engines/saga2/script.h
+++ b/engines/saga2/script.h
@@ -38,7 +38,7 @@ typedef int16   ThreadID;
 
 enum scriptResult {
 
-	//  Code returned when attempt to run a non-existant script
+	//  Code returned when attempt to run a non-existent script
 	scriptResultNoScript = 0,
 
 	//  Code returned when script was aborted before completion

--- a/engines/saga2/tilemode.cpp
+++ b/engines/saga2/tilemode.cpp
@@ -798,7 +798,7 @@ void TileModeHandleTask() {
 			} else {
 				//  Calculate the mouse's position on the tilemap,
 				//  including the shape of the terrain. Actually
-				//  this returns two seperate coords: The exact point
+				//  this returns two separate coords: The exact point
 				//  clicked on, and the projection on the floor
 				//  beneath the clicked point.
 				tilePickExactPos = pickTile(lastMousePos,

--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -3656,7 +3656,7 @@ void Console::printKernelCallsFound(int kernelFuncNum, bool showFoundScripts) {
 	Common::sort(resources.begin(), resources.end());
 
 	if (showFoundScripts)
-		debugPrintf("%d scripts found, dissassembling...\n", resources.size());
+		debugPrintf("%d scripts found, disassembling...\n", resources.size());
 
 	int scriptSegment;
 	Script *script;

--- a/engines/sci/graphics/scifont.cpp
+++ b/engines/sci/graphics/scifont.cpp
@@ -297,7 +297,7 @@ void GfxFontFromResource::draw(uint16 chr, int16 top, int16 left, byte color, bo
 				if (0 <= screenX && screenX < screenWidth && 0 <= screenY && screenY < screenHeight) {
 					_screen->putFontPixel(top, screenX, y, color);
 				} else {
-					warning("%s glpyh %d drawn out of bounds: %d, %d", _resource->name().c_str(), chr, screenX, screenY);
+					warning("%s glyph %d drawn out of bounds: %d, %d", _resource->name().c_str(), chr, screenX, screenY);
 				}
 			}
 			b = b << 1;
@@ -334,7 +334,7 @@ void GfxFontFromResource::drawToBuffer(uint16 chr, int16 top, int16 left, byte c
 					int offset = bufY * bufWidth + bufX;
 					buffer[offset] = color;
 				} else {
-					warning("%s glpyh %d drawn out of bounds: %d, %d", _resource->name().c_str(), chr, bufX, bufY);
+					warning("%s glyph %d drawn out of bounds: %d, %d", _resource->name().c_str(), chr, bufX, bufY);
 				}
 			}
 			b = b << 1;

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -215,7 +215,7 @@ public:
 	 * Processes a multilanguage string based on the current language settings and
 	 * returns a string that is ready to be displayed.
 	 * @param str		the multilanguage string
-	 * @param sep		optional seperator between main language and subtitle language,
+	 * @param sep		optional separator between main language and subtitle language,
 	 *					if NULL is passed no subtitle will be added to the returned string
 	 * @return processed string
 	 */

--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -1328,7 +1328,7 @@ void CharsetRendererTownsV3::drawBits1(Graphics::Surface &dest, int x, int y, co
 	}
 
 	if (y + height > dest.h)
-		error("Trying to draw below screen boundries");
+		error("Trying to draw below screen boundaries");
 
 #ifndef DISABLE_TOWNS_DUAL_LAYER_MODE
 #ifdef USE_RGB_COLOR

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -269,7 +269,7 @@ void Gdi::init() {
 		// virtual screen strips don't match the display screen strips anymore. To
 		// overcome that problem, we simply use a screen pitch that is 8 pixel wider
 		// than the actual screen width, and always draw one strip more than needed to
-		// the backbuf (thus we have to treat the right border seperately).
+		// the backbuf (thus we have to treat the right border separately).
 		_numStrips += 1;
 	}
 }

--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1655,7 +1655,7 @@ void ScummEngine::applyWorkaroundIfNeeded(ResType type, int idx) {
 	// WORKAROUND: FM-TOWNS Zak used the extra 40 pixels at the bottom to increase the inventory to 10 items
 	// if we trim to 200 pixels, we can show only 6 items
 	// therefore we patch the inventory script (20)
-	// replacing the 5 occurences of 10 as limit to 6
+	// replacing the 5 occurrences of 10 as limit to 6
 	if (_game.platform == Common::kPlatformFMTowns && _game.id == GID_ZAK && ConfMan.getBool("trim_fmtowns_to_200_pixels")) {
 		if (type == rtScript && idx == 20) {
 			byte *ptr = getResourceAddress(rtScript, idx);

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -539,7 +539,7 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 		if (ConfMan.getBool("aspect_ratio") && !ConfMan.getBool("trim_fmtowns_to_200_pixels")) {
 			GUI::MessageDialog dialog(
 				_("You have enabled 'aspect ratio correction'. However, FM-TOWNS' natural resolution is 320x240, which doesn't allow aspect ratio correction.\n"
-				  "Aspect ratio correction can be acheived by trimming the resolution to 320x200, under 'engine' tab."));
+				  "Aspect ratio correction can be achieved by trimming the resolution to 320x200, under 'engine' tab."));
 			dialog.runModal();
 		}
 

--- a/engines/sherlock/tattoo/widget_quit.cpp
+++ b/engines/sherlock/tattoo/widget_quit.cpp
@@ -56,7 +56,7 @@ void WidgetQuit::show() {
 	_surface.writeString(FIXED(WishToQuit), Common::Point((_surface.width() - _surface.stringWidth(FIXED(WishToQuit))) / 2,
 		_surface.fontHeight() + 9), INFO_TOP);
 
-	// Draw the horizontal bars seperating the commands and the message
+	// Draw the horizontal bars separating the commands and the message
 	int yp = (_surface.fontHeight() + 4) * 2 + 3;
 	for (int idx = 0; idx < 2; ++idx) {
 		_surface.SHtransBlitFrom(images[4], Common::Point(0, yp - 1));

--- a/engines/sky/intro.cpp
+++ b/engines/sky/intro.cpp
@@ -704,7 +704,7 @@ bool Intro::nextPart(uint16 *&data) {
 		return true;
 	case FADEUP:
 		_skyScreen->paletteFadeUp(*data++);
-		_relDelay += 32 * 20; // hack: the screen uses a seperate delay function for the
+		_relDelay += 32 * 20; // hack: the screen uses a separate delay function for the
 							  // blocking fadeups. So add 32*20 msecs to out delay counter.
 		return true;
 	case FADEDOWN:

--- a/engines/sludge/builtin.cpp
+++ b/engines/sludge/builtin.cpp
@@ -825,7 +825,7 @@ builtIn(anim) {
 	// First store the frame numbers and take 'em off the stack
 	PersonaAnimation *ba = new PersonaAnimation(numParams - 1, fun->stack);
 
-	// Only remaining paramter is the file number
+	// Only remaining parameter is the file number
 	int fileNumber;
 	if (!fun->stack->thisVar.getValueType(fileNumber, SVT_FILE))
 		return BR_ERROR;

--- a/engines/stark/movement/movement.cpp
+++ b/engines/stark/movement/movement.cpp
@@ -44,7 +44,7 @@ Movement *Movement::construct(uint32 type, Resources::ItemVisual *item) {
 		case kTypeTurn:
 			return new Turn(Resources::Object::cast<Resources::FloorPositionedItem>(item));
 		default:
-			error("Unexepected movement type '%d'", type);
+			error("Unexpected movement type '%d'", type);
 	}
 }
 

--- a/engines/supernova/supernova1/state.cpp
+++ b/engines/supernova/supernova1/state.cpp
@@ -1212,20 +1212,20 @@ bool GameManager1::genericInteract(Action verb, Object &obj1, Object &obj2) {
 			_vm->renderBox(91, 99, 138, 9, kColorDarkBlue);
 			edit(input, 91, 100, 5);
 
-			int seperator = -1;
+			int separator = -1;
 			for (uint i = 0; i < input.size(); ++i) {
 				if (input[i] == ':') {
-					seperator = i;
+					separator = i;
 					break;
 				}
 			}
-			if ((seperator == -1) || (seperator > 2)) {
+			if ((separator == -1) || (separator > 2)) {
 				validInput = false;
 				continue;
 			}
 
 			int decimalPlace = 1;
-			for (int i = 0; i < seperator; ++i) {
+			for (int i = 0; i < separator; ++i) {
 				if (Common::isDigit(input[i])) {
 					hours = hours * decimalPlace + (input[i] - '0');
 					decimalPlace *= 10;
@@ -1235,7 +1235,7 @@ bool GameManager1::genericInteract(Action verb, Object &obj1, Object &obj2) {
 				}
 			}
 			decimalPlace = 1;
-			for (uint i = seperator + 1; i < input.size(); ++i) {
+			for (uint i = separator + 1; i < input.size(); ++i) {
 				if (Common::isDigit(input[i])) {
 					minutes = minutes * decimalPlace + (input[i] - '0');
 					decimalPlace *= 10;

--- a/engines/sword1/logic.cpp
+++ b/engines/sword1/logic.cpp
@@ -1552,19 +1552,19 @@ int Logic::fnGetPos(Object *cpt, int32 id, int32 targetId, int32 b, int32 c, int
 	}
 	_scriptVars[RETURN_VALUE_3] = target->o_dir;
 
-	int32 megaSeperation;
+	int32 megaSeparation;
 	if (targetId == DUANE)
-		megaSeperation = 70; // George & Duane stand with feet 70 pixels apart when at full scale
+		megaSeparation = 70; // George & Duane stand with feet 70 pixels apart when at full scale
 	else if (targetId == BENOIR)
-		megaSeperation = 61; // George & Benoir
+		megaSeparation = 61; // George & Benoir
 	else
-		megaSeperation = 42; // George & Nico/Goinfre stand with feet 42 pixels apart when at full scale
+		megaSeparation = 42; // George & Nico/Goinfre stand with feet 42 pixels apart when at full scale
 
 	if (target->o_status & STAT_SHRINK) {
 		int32 scale = (target->o_scale_a * target->o_ycoord + target->o_scale_b) / 256;
-		_scriptVars[RETURN_VALUE_4] = (megaSeperation * scale) / 256;
+		_scriptVars[RETURN_VALUE_4] = (megaSeparation * scale) / 256;
 	} else
-		_scriptVars[RETURN_VALUE_4] = megaSeperation;
+		_scriptVars[RETURN_VALUE_4] = megaSeparation;
 	return SCRIPT_CONT;
 }
 

--- a/engines/sword25/kernel/filesystemutil.h
+++ b/engines/sword25/kernel/filesystemutil.h
@@ -68,7 +68,7 @@ public:
 	static Common::String getUserdataDirectory();
 
 	/**
-	 * @return              Returns the path seperator
+	 * @return              Returns the path separator
 	 */
 	static Common::String  getPathSeparator();
 

--- a/engines/sword25/package/packagemanager.h
+++ b/engines/sword25/package/packagemanager.h
@@ -37,7 +37,7 @@
  * In the package manager, note the following:
  * 1. It creates a completely new (virtual) directory tree in the packages and directories
  *    can be mounted.
- * 2. To seperate elements of a directory path '/' must be used rather than '\'
+ * 2. To separate elements of a directory path '/' must be used rather than '\'
  * 3. LoadDirectoryAsPackage should only be used for testing. The final release will be
  *    have all files in packages.
  *
@@ -65,7 +65,7 @@ namespace Sword25 {
  *
  * 1. It creates a completely new (virtual) directory tree in the packages and directories
  *    can be mounted.
- * 2. To seperate elements of a directory path '/' must be used rather than '\'
+ * 2. To separate elements of a directory path '/' must be used rather than '\'
  * 3. LoadDirectoryAsPackage should only be used for testing. The final release will be
  *    have all files in packages.
  */

--- a/engines/tinsel/anim.cpp
+++ b/engines/tinsel/anim.cpp
@@ -162,7 +162,7 @@ SCRIPTSTATE DoNextFrame(ANIM *pAnim) {
 			// pFunc is a function pointer that's part of a union and is assumed to be 32-bits.
 			// There is no known place where a function pointer is stored inside the animation
 			// scripts, something which wouldn't have worked anyway. Having played through the
-			// entire game, there hasn't been any occurence of this case, so just error out here
+			// entire game, there hasn't been any occurrence of this case, so just error out here
 			// in case we missed something (highly unlikely though)
 			error("ANI_CALL opcode encountered! Please report this error to the ScummVM team");
 			//(*pAni[pAnim->scriptIndex].pFunc)(pAnim);

--- a/engines/tinsel/graphics.cpp
+++ b/engines/tinsel/graphics.cpp
@@ -765,7 +765,7 @@ static void t3TransWNZ(DRAWOBJECT *pObj, uint8 *srcP, uint8 *destP) {
 				t3getRGB(dstColor, dstR, dstG, dstB);
 
 				if ((pObj->colorFlags & 4) != 0) { // additive blending
-					// orginal algo:
+					// original algo:
 					// color &= 0b1111011111011111;
 					// color += dstColor & 0b1111011111011111;
 					// if (color > 0xFFFF) {

--- a/engines/titanic/core/multi_drop_target.cpp
+++ b/engines/titanic/core/multi_drop_target.cpp
@@ -49,17 +49,17 @@ void CMultiDropTarget::load(SimpleFile *file) {
 bool CMultiDropTarget::DropObjectMsg(CDropObjectMsg *msg) {
 	CStringParser parser1(_dropFrames);
 	CStringParser parser2(_dropNames);
-	CString seperatorChars = ",";
+	CString separatorChars = ",";
 
 	// WORKAROUND: The original didn't break out of loop if a drop target
 	// succeeded, nor did it return the item to the inventory if incorrect
-	while (parser2.parse(_itemMatchName, seperatorChars)) {
+	while (parser2.parse(_itemMatchName, separatorChars)) {
 		_dropFrame = parser1.readInt();
 		if (CDropTarget::DropObjectMsg(msg))
 			return true;
 
-		parser1.skipSeperators(seperatorChars);
-		parser2.skipSeperators(seperatorChars);
+		parser1.skipSeparators(separatorChars);
+		parser2.skipSeparators(separatorChars);
 	}
 
 	msg->_item->petAddToInventory();

--- a/engines/titanic/support/string_parser.cpp
+++ b/engines/titanic/support/string_parser.cpp
@@ -25,15 +25,15 @@
 
 namespace Titanic {
 
-void CStringParser::skipSeperators(const CString &seperatorChars) {
+void CStringParser::skipSeparators(const CString &separatorChars) {
 	for (; _index < size(); ++_index) {
 		char c = (*this)[_index];
-		if (seperatorChars.indexOf(c) == -1)
+		if (separatorChars.indexOf(c) == -1)
 			break;
 	}
 }
 
-bool CStringParser::parse(CString &resultStr, const CString &seperatorChars, bool allowQuotes) {
+bool CStringParser::parse(CString &resultStr, const CString &separatorChars, bool allowQuotes) {
 	if (_index >= size())
 		return false;
 
@@ -41,7 +41,7 @@ bool CStringParser::parse(CString &resultStr, const CString &seperatorChars, boo
 	bool quoteFlag = false;
 	while (_index < size()) {
 		char c = (*this)[_index];
-		if (!quoteFlag && seperatorChars.indexOf(c) >= 0)
+		if (!quoteFlag && separatorChars.indexOf(c) >= 0)
 			break;
 
 		if (allowQuotes) {

--- a/engines/titanic/support/string_parser.h
+++ b/engines/titanic/support/string_parser.h
@@ -50,19 +50,19 @@ public:
 	CStringParser(const CString &str) : CString(str), _index(0) {}
 
 	/**
-	 * Skips over any specified seperator characters in our string
+	 * Skips over any specified separator characters in our string
 	 * at the current index
 	 */
-	void skipSeperators(const CString &seperatorChars);
+	void skipSeparators(const CString &separatorChars);
 
 	/**
 	 * Parses out a string from a source string at the current index
 	 * @param resultStr			String to hold the resulting sring
-	 * @param seperatorChras	List of characters that seperate string values
+	 * @param separatorChras	List of characters that separate string values
 	 * @param allowQuotes		If true, handles double-quoted substrings
 	 * @returns		True if a string entry was extracted
 	 */
-	bool parse(CString &resultStr, const CString &seperatorChars, bool allowQuotes = false);
+	bool parse(CString &resultStr, const CString &separatorChars, bool allowQuotes = false);
 
 	/**
 	 * Reads an integer from the string

--- a/engines/tucker/tucker.cpp
+++ b/engines/tucker/tucker.cpp
@@ -3485,7 +3485,7 @@ int TuckerEngine::executeTableInstruction() {
 		//   Fixed: 61dw buw,148,125,wsm,buw,148,132,wsm,mof,pan,01,wat,050[...]
 		//                                               ^^^^^^^^^^
 		// To work around the issue in the problematic versions we inject these two
-		// instructions after the first occurence of the 'wsm' instruction (which
+		// instructions after the first occurrence of the 'wsm' instruction (which
 		// proves good enough).
 		if (_location == kLocationStoreRoom && _nextAction == 61) {
 			setCursorState(kCursorStateDisabledHidden);

--- a/engines/ultima/nuvie/core/converse_interpret.cpp
+++ b/engines/ultima/nuvie/core/converse_interpret.cpp
@@ -554,7 +554,7 @@ bool ConverseInterpret::op(stack<converse_typed_value> &i) {
 		// FIXME: probably need to do more real actor/object set-up here
 		cnpc = converse->actors->get_actor(npc_num(pop_arg(i)));
 		cnpc_obj = cnpc->make_obj();
-		cnpc_obj->frame_n = 0; // FIX for actors orginal direction.
+		cnpc_obj->frame_n = 0; // FIX for actors original direction.
 		cnpc_obj->obj_n = OBJ_U6_HORSE_WITH_RIDER; // mount up.
 		cnpc->init_from_obj(cnpc_obj);
 		delete_obj(cnpc_obj);

--- a/engines/ultima/nuvie/core/effect_manager.cpp
+++ b/engines/ultima/nuvie/core/effect_manager.cpp
@@ -52,7 +52,7 @@ void EffectManager::delete_effect(Effect *eff) {
 	}
 }
 
-/* Add an (already existant) effect to the list.
+/* Add an (already existent) effect to the list.
  */
 void EffectManager::add_effect(Effect *eff) {
 	effects.push_back(eff);

--- a/engines/ultima/nuvie/core/events.h
+++ b/engines/ultima/nuvie/core/events.h
@@ -421,7 +421,7 @@ public:
 	}
 // These cursor methods are use to make sure Events knows where the cursor is
 // when objects are selected with ENTER. (since MapWindow and InventoryView
-// may each independantly show/hide their own cursors)
+// may each independently show/hide their own cursors)
 	void moveCursorToMapWindow(bool ToggleCursor = false);
 	void moveCursorToInventory();
 

--- a/engines/ultima/nuvie/core/party.cpp
+++ b/engines/ultima/nuvie/core/party.cpp
@@ -528,7 +528,7 @@ bool Party::has_obj(uint16 obj_n, uint8 quality, bool match_zero_qual) {
 	return false;
 }
 
-// Removes the first occurence of an object in the party.
+// Removes the first occurrence of an object in the party.
 bool Party::remove_obj(uint16 obj_n, uint8 quality) {
 	uint16 i;
 	Obj *obj;

--- a/engines/ultima/nuvie/sound/adplug/u6m.cpp
+++ b/engines/ultima/nuvie/sound/adplug/u6m.cpp
@@ -308,7 +308,7 @@ void Cu6mPlayer::command_5(int channel) {
 
 
 // --------------------------------------------
-// Set vibrato paramters
+// Set vibrato parameters
 // Format: 6c mn
 // c = channel
 // m = vibrato double amplitude

--- a/engines/ultima/ultima1/u1gfx/drawing_support.h
+++ b/engines/ultima/ultima1/u1gfx/drawing_support.h
@@ -56,7 +56,7 @@ public:
 	void drawFrame();
 
 	/**
-	 * Draw a frame around the viewport area of the screen, and a vertical seperator line
+	 * Draw a frame around the viewport area of the screen, and a vertical separator line
 	 * to the bottom of the screen to separate the status and info areas
 	 */
 	void drawGameFrame();

--- a/engines/ultima/ultima4/core/utils.h
+++ b/engines/ultima/ultima4/core/utils.h
@@ -115,7 +115,7 @@ Common::String xu4_to_string(int val);
 
 /**
  * Splits a Common::String into substrings, divided by the charactars in
- * separators.  Multiple adjacent seperators are treated as one.
+ * separators.  Multiple adjacent separators are treated as one.
  */
 Std::vector<Common::String> split(const Common::String &s, const Common::String &separators);
 

--- a/engines/ultima/ultima4/gfx/screen.h
+++ b/engines/ultima/ultima4/gfx/screen.h
@@ -285,7 +285,7 @@ public:
 	 * Scale an image up.  The resulting image will be scale * the
 	 * original dimensions.  The original image is no longer deleted.
 	 * n is the number of tiles in the image; each tile is filtered
-	 * seperately. filter determines whether or not to filter the
+	 * separately. filter determines whether or not to filter the
 	 * resulting image.
 	 */
 	Image *screenScale(Image *src, int scale, int n, int filter);

--- a/engines/ultima/ultima8/usecode/uc_list.cpp
+++ b/engines/ultima/ultima8/usecode/uc_list.cpp
@@ -96,7 +96,7 @@ void UCList::assignString(uint32 index, uint16 str) {
 }
 
 void UCList::removeString(uint16 s, bool nodel) {
-	// do we need to erase all occurences of str or just the first one?
+	// do we need to erase all occurrences of str or just the first one?
 	// (deleting all, currently)
 	const Std::string &str = UCMachine::get_instance()->getString(s);
 	for (unsigned int i = 0; i < _size; i++) {

--- a/engines/ultima/ultima8/usecode/uc_list.h
+++ b/engines/ultima/ultima8/usecode/uc_list.h
@@ -37,7 +37,7 @@ namespace Ultima8 {
 // Question: how are unionList/subtractList supposed to know what to do?
 // their behaviour differs if this is a stringlist
 
-// Question: does subtractList remove _all_ occurences of elements or only 1?
+// Question: does subtractList remove _all_ occurrences of elements or only 1?
 
 class UCList {
 	Std::vector<uint8> _elements;
@@ -86,7 +86,7 @@ public:
 	}
 
 	void remove(const uint8 *e) {
-		// do we need to erase all occurences of e or just the first one?
+		// do we need to erase all occurrences of e or just the first one?
 		// (deleting all, currently)
 		for (unsigned int i = 0; i < _size; i++) {
 			bool equal = true;

--- a/engines/ultima/ultima8/world/actors/u8_avatar_mover_process.cpp
+++ b/engines/ultima/ultima8/world/actors/u8_avatar_mover_process.cpp
@@ -198,7 +198,7 @@ void U8AvatarMoverProcess::handleCombatMode() {
 	}
 
 	if (_mouseButton[1].isState(MBS_DOWN) && _mouseButton[1].isState(MBS_HANDLED)) {
-		// Note: Orginal game allowed a move animation on a single right click.
+		// Note: Original game allowed a move animation on a single right click.
 		// This implementation needs right mouse to be held.
 		setMovementFlag(MOVE_MOUSE_DIRECTION);
 
@@ -368,7 +368,7 @@ void U8AvatarMoverProcess::handleNormalMode() {
 	}
 
 	if (_mouseButton[1].isState(MBS_DOWN) && _mouseButton[1].isState(MBS_HANDLED)) {
-		// Note: Orginal game allowed a move animation on a single right click.
+		// Note: Original game allowed a move animation on a single right click.
 		// This implementation needs right mouse to be held.
 		setMovementFlag(MOVE_MOUSE_DIRECTION);
 	}

--- a/engines/ultima/ultima8/world/gravity_process.cpp
+++ b/engines/ultima/ultima8/world/gravity_process.cpp
@@ -174,7 +174,7 @@ void GravityProcess::run() {
 				int approx_v = ABS(_xSpeed) + ABS(_ySpeed) + _zSpeed;
 
 				// Apply an impulse on the x/y plane in a random direction
-				// in a 180 degree pie around the orginal vector in x/y
+				// in a 180 degree pie around the original vector in x/y
 				double heading_r = atan2((double)_ySpeed, (double)_xSpeed);
 				double deltah_r = static_cast<double>(getRandom())
 				                  * M_PI / U8_RAND_MAX - M_PI / 2;

--- a/engines/ultima/ultima8/world/item.cpp
+++ b/engines/ultima/ultima8/world/item.cpp
@@ -1717,7 +1717,7 @@ void Item::setupLerp(int32 gametick) {
 	// We use (tick % speed == 0) here. To be completely faithful to the original
 	// game it should be (tick % speed == tick % _objId).  That is how the game
 	// does it, but it also causes animation frame mismatches on multi-shape
-	// objects.  This is easily noticable on the waterfall West of Tenebrae,
+	// objects.  This is easily noticeable on the waterfall West of Tenebrae,
 	// which appears to tear slightly even on the original.
 	//
 	// In the original it was likely done to spread CPU time over different frames,

--- a/graphics/fonts/macfont.cpp
+++ b/graphics/fonts/macfont.cpp
@@ -163,7 +163,7 @@ bool MacFontFamily::load(Common::SeekableReadStream &stream) {
 			_ffBBoxes[i]._right  = stream.readSint16BE();
 			_ffBBoxes[i]._top    = stream.readSint16BE();
 
-			debug(10, "style: %d left: %g bottom: %g rigth: %g top: %g", _ffBBoxes[i]._style,
+			debug(10, "style: %d left: %g bottom: %g right: %g top: %g", _ffBBoxes[i]._style,
 					_ffBBoxes[i]._left / (double)(1<<12), _ffBBoxes[i]._bottom / (double)(1<<12),
 					_ffBBoxes[i]._right / (double)(1<<12), _ffBBoxes[i]._top / (double)(1<<12));
 		}

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -751,7 +751,7 @@ bool TTFFont::cacheGlyph(Glyph &glyph, uint32 chr) const {
 	glyph.slot = slot;
 
 	// We use the light target and render mode to improve the looks of the
-	// glyphs. It is most noticable in FreeSansBold.ttf, where otherwise the
+	// glyphs. It is most noticeable in FreeSansBold.ttf, where otherwise the
 	// 't' glyph looks like it is cut off on the right side.
 	if (FT_Load_Glyph(_face, slot, _loadFlags))
 		return false;

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -488,7 +488,7 @@ void GuiManager::runLoop() {
 
 	// WORKAROUND: When quitting we might not properly close the dialogs on
 	// the dialog stack, thus we do this here to avoid any problems.
-	// This is most noticable in bug #5954 "LAUNCHER: Can't quit from unsupported game dialog".
+	// This is most noticeable in bug #5954 "LAUNCHER: Can't quit from unsupported game dialog".
 	// It seems that Dialog::runModal never removes the dialog from the dialog
 	// stack, thus if the dialog does not call Dialog::close to close itself
 	// it will never be removed. Since we can have multiple run loops being

--- a/test/cxxtest/TODO
+++ b/test/cxxtest/TODO
@@ -8,7 +8,7 @@ It is not meant to be "human readable".
 Write some mocks
 
 *** Distribution
-Seperate packages (w/ binaries)?  How would that be used?
+Separate packages (w/ binaries)?  How would that be used?
 For Windows: .lib for "Real" and "Mock" parts.
 For Linux: Maybe. Different compilers etc.
 So probably only source release with Makefiles and .ds[pw]?  Or just Win32 binary.


### PR DESCRIPTION
Fix some typos in the variable names, some in the comments.
No change for the strings that interract with original games assets
that could break something.
No change in the generated .pot translation files.

The corrections were tipped by help of Debian's `lintian` tool running on 2.5.0 release.

(I try do this after each release)