### PR TITLE
DEVTOOLS: fix encoding with the dumper companion `mac` command

### DIFF
--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -550,6 +550,7 @@ def test_decode_name():
         ["G3フォルダ", "xn--G3-3g4axdtexf"],
         ["Where \\ Do <you> Want / To: G* ? ;Unless=nowhere,or|\"(everything)/\":*|\\?%<>,;=", "xn--Where  Do you Want  To G  ;Unless=nowhere,or(everything),;=-5baedgdcbtamaaaaaaaaa99woa3wnnmb82aqb71ekb9g3c1f1cyb7bx6rfcv2pxa"],
         ["Buried in Timeｪ Demo", "xn--Buried in Time Demo-yp97h"],
+        ["ぱそすけPPC", "xn--PPC-873bpbxa3l"]
     ]
     for input, output in checks:
         assert punyencode(input) == output

--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -347,14 +347,14 @@ def punyencode_dir(directory: Path, verbose: bool = False) -> int:
     return count
 
 
-def has_resource_fork(dirpath: str, filename: str) -> bool:
+def has_resource_fork(dirpath: bytes, filename: bytes) -> bool:
     """
     Check if file has a resource fork
 
     Ease of compatibility between macOS and linux
     """
     filepath = os.path.join(dirpath, filename)
-    return os.path.exists(os.path.join(filepath, "..namedfork/rsrc"))
+    return os.path.exists(os.path.join(filepath, bytes("..namedfork/rsrc", "utf8")))
 
 
 def collect_forks(args: argparse.Namespace) -> int:
@@ -364,7 +364,7 @@ def collect_forks(args: argparse.Namespace) -> int:
     - combine them with the data fork when it's available
     - punyencode the filename when requested
     """
-    directory: Path = args.dir
+    directory: bytes = bytes(args.dir)
     punify: bool = args.punycode
     count_resources = 0
     count_renames = 0
@@ -373,7 +373,7 @@ def collect_forks(args: argparse.Namespace) -> int:
             if has_resource_fork(dirpath, filename):
                 print(f"Resource in {filename}")
                 count_resources += 1
-                resource_filename = filename + "/..namedfork/rsrc"
+                resource_filename = filename + bytes("/..namedfork/rsrc", "utf8")
                 to_filename = filename
 
                 filepath = os.path.join(dirpath, filename)
@@ -400,7 +400,7 @@ def collect_forks(args: argparse.Namespace) -> int:
                 with open(filepath, "rb") as data:
                     file.data = data.read()
                 with open(filepath, "wb") as to_file:
-                    to_file.write(file_to_macbin(file, to_filename.encode("mac_roman")))
+                    to_file.write(file_to_macbin(file, to_filename))
 
                     if to_filename != filename:
                         os.remove(filepath)  # Remove the original file

--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -484,9 +484,10 @@ if __name__ == "__main__":
     parser = generate_parser()
     args = parser.parse_args()
     try:
-        exit(args.func(args))
+        f = args.func
     except AttributeError:
         parser.error("too few arguments")
+    exit(f(args))
 
 ### Test functions
 


### PR DESCRIPTION
The `mac` command in the Python dumper companion tried to handle filename encodings, which is, if I'm being honest, a fool's errand. This led it to error out on certain Japanese filenames, for example:

```
Resource in ÇœÇªÇ∑ÇØPPC
Traceback (most recent call last):
  File "/Users/mistydemeo/github/scummvm/devtools/dumper-companion.py", line 488, in <module>
    exit(args.func(args))
  File "/Users/mistydemeo/github/scummvm/devtools/dumper-companion.py", line 404, in collect_forks
    to_file.write(file_to_macbin(file, to_filename.encode("mac_roman")))
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/encodings/mac_roman.py", line 12, in encode
    return codecs.charmap_encode(input,errors,encoding_table)
UnicodeEncodeError: 'charmap' codec can't encode character '\u0327' in position 1: character maps to <undefined>
```

I've switched the path handling to use pure bytes instead so it can rely on having just the filenames as they are on the filesystem. I've confirmed this lets me use the dumper companion with Japanese Mac discs now. More changes will be needed for punycode encoding to work, since that has to be aware of the underlying string encoding to work.

I've also added a second fix which addresses an overly-aggressive `AttributeError` catch I added previously, which ended up catching attribute errors not related to the argparse code.