### PR TITLE
ICB: Fix compilation errors for ptrdiff_t

### DIFF
--- a/engines/icb/common/ptr_util.cpp
+++ b/engines/icb/common/ptr_util.cpp
@@ -41,7 +41,7 @@ const int32 PTR_ARRAY_MAX(1024);
 uint32 encodePtr(uint8 *ptr) {
 	PointerReference ptrRef;
 
-	ptrdiff_t diff = ptr - (uint8 *)0;
+	std::ptrdiff_t diff = ptr - (uint8 *)0;
 	ptrRef.ref = (uint32)(diff & 0xFFFFFFFF);
 	ptrRef.ptr = ptr;
 


### PR DESCRIPTION
ICB: Fix compilation error for ptrdiff_t

```
../../../../engines/icb/common/ptr_util.cpp: In function ‘uint32 ICB::MemoryUtil::encodePtr(uint8*)’:
../../../../engines/icb/common/ptr_util.cpp:44:2: error: ‘ptrdiff_t’ was not declared in this scope
  ptrdiff_t diff = ptr - (uint8 *)0;
  ^
../../../../engines/icb/common/ptr_util.cpp:44:2: note: suggested alternative:
In file included from /usr/include/c++/5/new:39:0,
                 from ../../../../backends/platform/libretro/portdefs.h:32,
                 from ../../../../common/scummsys.h:44,
                 from ../../../../engines/icb/common/px_common.h:31,
                 from ../../../../engines/icb/common/ptr_util.cpp:28:
/usr/include/aarch64-linux-gnu/c++/5/bits/c++config.h:197:28: note:   ‘std::ptrdiff_t’
   typedef __PTRDIFF_TYPE__ ptrdiff_t;
                            ^
../../../../engines/icb/common/ptr_util.cpp:45:24: error: ‘diff’ was not declared in this scope
  ptrRef.ref = (uint32)(diff & 0xFFFFFFFF);
                        ^
Makefile:561: recipe for target 'engines/icb/common/ptr_util.o' failed
make: *** [engines/icb/common/ptr_util.o] Error 1
make: *** Waiting for unfinished jobs....
```