### PR TITLE
SCI: add "st" as an alias to the debug "stack" command

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -238,6 +238,7 @@ Console::Console(SciEngine *engine) : GUI::Debugger(),
 	registerCmd("vmvars",				WRAP_METHOD(Console, cmdVMVars));					// alias
 	registerCmd("vv",					WRAP_METHOD(Console, cmdVMVars));					// alias
 	registerCmd("stack",				WRAP_METHOD(Console, cmdStack));
+	registerCmd("st",					WRAP_METHOD(Console, cmdStack));					// alias
 	registerCmd("value_type",			WRAP_METHOD(Console, cmdValueType));
 	registerCmd("view_listnode",		WRAP_METHOD(Console, cmdViewListNode));
 	registerCmd("view_reference",		WRAP_METHOD(Console, cmdViewReference));


### PR DESCRIPTION
Since I am constantly evaluating the stack, please consider adding this alias for the stack command. 
  * Add `st` as an alias to `stack` command
  * I'm hoping this is a reasonable request since it also nicely models stack based addresses such as: `ST:0001`
  * I previously added an alias for the `registers` command as well named: `reg`