### PR TITLE
BACKENDS: DIALOG: GTK: Keep main window updated during GTK+ dialog

### DIFF
--- a/backends/dialogs/gtk/gtk-dialogs.cpp
+++ b/backends/dialogs/gtk/gtk-dialogs.cpp
@@ -34,6 +34,16 @@
 
 #include <gtk/gtk.h>
 
+// TODO: Move this into the class? Probably possible, but I've been told that
+//       this might not necessarily work properly with all compilers.
+
+static gboolean _inDialog;
+
+static gboolean idleCallback(gpointer data) {
+	g_system->updateScreen();
+	return _inDialog;
+}
+
 Common::DialogManager::DialogResult GtkDialogManager::showFileBrowser(const Common::U32String &title, Common::FSNode &choice, bool isDirBrowser) {
 	if (!gtk_init_check(NULL, NULL))
 		return kDialogError;
@@ -65,6 +75,10 @@ Common::DialogManager::DialogResult GtkDialogManager::showFileBrowser(const Comm
 
 	// Show dialog
 	beginDialog();
+
+	_inDialog = TRUE;
+	g_idle_add(idleCallback, NULL);
+
 #if GTK_CHECK_VERSION(3,20,0)
 	int res = gtk_native_dialog_run(GTK_NATIVE_DIALOG(native));
 #else
@@ -78,6 +92,8 @@ Common::DialogManager::DialogResult GtkDialogManager::showFileBrowser(const Comm
 		result = kDialogOk;
 		g_free(path);
 	}
+
+	_inDialog = FALSE;
 
 #if GTK_CHECK_VERSION(3,20,0)
 	g_object_unref(native);


### PR DESCRIPTION
One thing that's always bothered me about the GTK+ dialogs is that the main window doesn't get updated while they are open. At least for me this causes ugly trails in the main window of anything that's moved across it while the dialog is open.

This patch adds an idle handler to keep the main window updated.

Maybe the idle handler should be part of the GtkDialogManager class, but https://stackoverflow.com/questions/21478803/member-function-as-callback-function-to-g-signal-connect suggested that it might be more portable to keep it outside the class? I don't know for sure.

I'd be grateful for feedback for anyone more familiar with GTK+ than me. (Which would be most people familiar with GTK+ at all.)