### PR TITLE
DIRECTOR: Rework film loops to render as channels

### DIFF
--- a/engines/director/castmember.h
+++ b/engines/director/castmember.h
@@ -202,7 +202,9 @@ public:
 	~FilmLoopCastMember();
 
 	virtual bool isModified() override;
-	virtual Graphics::MacWidget *createWidget(Common::Rect &bbox, Channel *channel, SpriteType spriteType) override;
+	//virtual Graphics::MacWidget *createWidget(Common::Rect &bbox, Channel *channel, SpriteType spriteType) override;
+
+	Common::Array<Channel> *getSubChannels(Common::Rect &bbox, Channel *channel);
 
 	void loadFilmLoopData(Common::SeekableReadStreamEndian &stream);
 
@@ -211,8 +213,8 @@ public:
 	bool _crop;
 	bool _center;
 
-	Common::Rect _bbox;
 	Common::Array<FilmLoopFrame> _frames;
+	Common::Array<Channel> _subchannels;
 };
 
 class SoundCastMember : public CastMember {

--- a/engines/director/channel.h
+++ b/engines/director/channel.h
@@ -39,6 +39,8 @@ class Cursor;
 class Channel {
 public:
 	Channel(Sprite *sp, int priority = 0);
+	Channel(const Channel &channel);
+	Channel& operator=(const Channel &channel);
 	~Channel();
 
 	DirectorPlotData getPlotData();
@@ -81,6 +83,12 @@ public:
 
 	void updateVideoTime();
 
+	// used for film loops
+	bool hasSubChannels();
+	Common::Array<Channel> *getSubChannels();
+
+	void addRegistrationOffset(Common::Point &pos, bool subtract = false);
+
 public:
 	Sprite *_sprite;
 	Cursor _cursor;
@@ -110,7 +118,6 @@ private:
 	Graphics::ManagedSurface *getSurface();
 	Common::Point getPosition();
 
-	void addRegistrationOffset(Common::Point &pos, bool subtract = false);
 };
 
 } // End of namespace Director

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -3394,6 +3394,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Mac executable name is TD MAC/PPC
 	MACGAME1("totaldistortion", "", "TD MACPPC", "17efee018a660458fae80de4364021ac", 486074, 404),
 	WINGAME1("totaldistortion", "", "TOTAL_DN.EXE", "461b407c321e80487ae4882056310f9f", 700747, 404),
+	WINGAME1("totaldistortion", "Demo", "TD_DEMO.EXE", "3ae9cfa4b020861b41f3bab9b28f3f5a", 696855, 404),
 
 	MACGAME1("toyota95", "", "Toyota 95", "01be45e7241194dad07938e7059b88e3", 486985, 404),
 

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -367,7 +367,7 @@ void Frame::readChannels(Common::ReadStreamEndian *stream, uint16 version) {
 		sprite._moveable = ((sprite._colorcode & 0x80) == 0x80);
 
 		if (sprite._castId.member) {
-			debugC(4, kDebugLoading, "CH: %-3d castId: %s [flags:%04x [ink: %x trails: %d line: %d], %dx%d@%d,%d type: %d fg: %d bg: %d] script: %s, flags2: %x, unk2: %x, unk3: %x",
+			debugC(4, kDebugLoading, "CH: %-3d castId: %s [inkData:%02x [ink: %x trails: %d line: %d], %dx%d@%d,%d type: %d fg: %d bg: %d] script: %s, flags2: %x, unk2: %x, unk3: %x",
 				i + 1, sprite._castId.asString().c_str(), sprite._inkData,
 				sprite._ink, sprite._trails, sprite._thickness, sprite._width, sprite._height,
 				sprite._startPoint.x, sprite._startPoint.y,

--- a/engines/director/window.cpp
+++ b/engines/director/window.cpp
@@ -161,9 +161,16 @@ bool Window::render(bool forceRedraw, Graphics::ManagedSurface *blitTo) {
 				}
 
 				if ((*j)->_visible) {
-					inkBlitFrom(*j, r, blitTo);
-					if ((*j) == hiliteChannel)
-						invertChannel(hiliteChannel, r);
+					if ((*j)->hasSubChannels()) {
+						Common::Array<Channel> *list = (*j)->getSubChannels();
+						for (Common::Array<Channel>::iterator k = list->begin(); k != list->end(); k++) {
+							inkBlitFrom(&(*k), r, blitTo);
+						}
+					} else {
+						inkBlitFrom(*j, r, blitTo);
+						if ((*j) == hiliteChannel)
+							invertChannel(hiliteChannel, r);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The engine treats film loops as N full channels getting rendered to the
screen in the space of one. As such, it's impossible to pre-blit together
the content, as any blitter mode can be used for each of the items.