### PR TITLE
DIRECTOR: close file handles when no stream created

### DIFF
--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -775,6 +775,7 @@ Audio::AudioStream *AudioFileDecoder::getAudioStream(bool looping, bool forPuppe
 	Common::File *file = new Common::File();
 	if (!file->open(Common::Path(pathMakeRelative(_path), g_director->_dirSeparator))) {
 		warning("Failed to open %s", _path.c_str());
+		delete file;
 		return nullptr;
 	}
 	uint32 magic1 = file->readUint32BE();
@@ -791,6 +792,7 @@ Audio::AudioStream *AudioFileDecoder::getAudioStream(bool looping, bool forPuppe
 		stream = Audio::makeAIFFStream(file, disposeAfterUse);
 	} else {
 		warning("Unknown file type for %s", _path.c_str());
+		delete file;
 	}
 
 	if (stream) {


### PR DESCRIPTION
`getAudioStream()` was leaking file descriptors. The caller closes the file if a stream could be created, but in the case one isn't then the file will never be closed. In the worst case scenario, it could hit the descriptor table size and prevent any further file open calls from working.

cc @moralrecordings 