### PR TITLE
DIRECTOR: handle macbinary audio streams

### DIFF
--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -25,6 +25,7 @@
 // License: GNU GPL v2 (see COPYING file for details)
 
 #include "common/file.h"
+#include "common/macresman.h"
 #include "common/substream.h"
 
 #include "audio/decoders/wave.h"
@@ -766,14 +767,22 @@ bool SNDDecoder::hasLoopBounds() {
 AudioFileDecoder::AudioFileDecoder(Common::String &path)
 		: AudioDecoder() {
 	_path = path;
+	_macresman = nullptr;
+}
+
+AudioFileDecoder::~AudioFileDecoder() {
+	delete _macresman;
 }
 
 Audio::AudioStream *AudioFileDecoder::getAudioStream(bool looping, bool forPuppet, DisposeAfterUse::Flag disposeAfterUse) {
 	if (_path.empty())
 		return nullptr;
 
-	Common::File *file = new Common::File();
-	if (!file->open(Common::Path(pathMakeRelative(_path), g_director->_dirSeparator))) {
+	_macresman = new Common::MacResManager();
+	_macresman->open(Common::Path(pathMakeRelative(_path), g_director->_dirSeparator));
+	Common::SeekableReadStream *file = _macresman->getDataFork();
+
+	if (file == nullptr) {
 		warning("Failed to open %s", _path.c_str());
 		delete file;
 		return nullptr;

--- a/engines/director/sound.h
+++ b/engines/director/sound.h
@@ -32,6 +32,10 @@ namespace Audio {
 	class RewindableAudioStream;
 }
 
+namespace Common {
+	class MacResManager;
+}
+
 namespace Director {
 
 class AudioDecoder;
@@ -244,7 +248,7 @@ private:
 class AudioFileDecoder : public AudioDecoder {
 public:
 	AudioFileDecoder(Common::String &path);
-	~AudioFileDecoder() {};
+	~AudioFileDecoder();
 
 	void setPath(Common::String &path);
 
@@ -252,6 +256,7 @@ public:
 
 private:
 	Common::String _path;
+	Common::MacResManager *_macresman;
 };
 
 } // End of namespace Director


### PR DESCRIPTION
Certain audio streams can (and often do) contain resource forks, so the dumper companion will write them as macbinary. Right now, the audio code will choke on them since it tries to read from the macbinary header assuming it's audio. This adds a check for whether the file is macbinary and handles it appropriately.

In the future, I might run a pass over the Director code to support native Mac files on HFS+/APFS macOS, but there's a lot I'd need to update for that.

To test this, you can try the Pippin/Mac version of Jungle Park run through the dumper companion. Without this patch, it'll fail to recognize `JUNGLE/JINGLE.AIFF`; it won't play the intro audio and will spam the console with errors about it. With this patch. it works fine.