### PR TITLE
WIN32: Add Portable Mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,11 @@ For a more comprehensive changelog of the latest experimental code, see:
    - Fix crash on startup loading constants from xeen.ccs.
    - Fix spell selection aborting when characters were switched.
    - Fixed some bad memory accesses.
+   
+ Windows port:
+   - Added "Portable Mode" in which the executable's directory is used to store
+     application files if a scummvm.ini file is present, instead of the user's
+	 profile directory.
 
 #### 2.5.0 "Twenty years ago today..." (2021-10-09)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@ For a more comprehensive changelog of the latest experimental code, see:
  Windows port:
    - Added "Portable Mode" in which the executable's directory is used to store
      application files if a scummvm.ini file is present, instead of the user's
-	 profile directory.
+     profile directory.
 
 #### 2.5.0 "Twenty years ago today..." (2021-10-09)
 

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -121,7 +121,9 @@ void OSystem_Win32::initBackend() {
 
 #if defined(USE_SPARKLE)
 	// Initialize updates manager
-	_updateManager = new Win32UpdateManager((SdlWindow_Win32*)_window);
+	if (!_isPortable) {
+		_updateManager = new Win32UpdateManager((SdlWindow_Win32*)_window);
+	}
 #endif
 
 	// Initialize text to speech

--- a/backends/platform/sdl/win32/win32.h
+++ b/backends/platform/sdl/win32/win32.h
@@ -28,6 +28,8 @@
 
 class OSystem_Win32 final : public OSystem_SDL {
 public:
+	OSystem_Win32();
+
 	virtual void init() override;
 	virtual void initBackend() override;
 
@@ -58,6 +60,10 @@ protected:
 	virtual AudioCDManager *createAudioCDManager() override;
 
 	HWND getHwnd() { return ((SdlWindow_Win32*)_window)->getHwnd(); }
+
+private:
+	bool _isPortable;
+	bool detectPortableConfigFile();
 };
 
 #endif

--- a/backends/platform/sdl/win32/win32_wrapper.h
+++ b/backends/platform/sdl/win32/win32_wrapper.h
@@ -32,6 +32,29 @@ HRESULT SHGetFolderPathFunc(HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, 
 namespace Win32 {
 
 /**
+ * Gets the full path to the ScummVM application data directory
+ * in the user's profile and creates it if it doesn't exist.
+ *
+ * @param profileDirectory MAX_PATH sized output array
+ *
+ * @return True if the user's profile directory was found, false if
+ * it was not.
+ *
+ * @note if the user's profile directory is found but the "ScummVM"
+ * subdirectory can't be created then this function calls error().
+ */
+bool getApplicationDataDirectory(TCHAR *profileDirectory);
+
+/**
+ * Gets the full path to the directory that the currently executing
+ * process resides in.
+ *
+ * @param processDirectory output array
+ * @param size size in characters of output array
+ */
+void getProcessDirectory(TCHAR *processDirectory, DWORD size);
+
+/**
  * Checks if the current running Windows version is greater or equal to the specified version.
  * See: https://docs.microsoft.com/en-us/windows/desktop/sysinfo/operating-system-version
  *
@@ -115,6 +138,6 @@ char **getArgvUtf8(int *argc);
 void freeArgvUtf8(int argc, char **argv);
 #endif
 
-}
+} // End of namespace Win32
 
 #endif

--- a/backends/saves/windows/windows-saves.cpp
+++ b/backends/saves/windows/windows-saves.cpp
@@ -36,27 +36,25 @@
 #include "backends/saves/windows/windows-saves.h"
 #include "backends/platform/sdl/win32/win32_wrapper.h"
 
-WindowsSaveFileManager::WindowsSaveFileManager() {
+WindowsSaveFileManager::WindowsSaveFileManager(bool isPortable) {
 	TCHAR defaultSavepath[MAX_PATH];
 
-	// Use the Application Data directory of the user profile.
-	if (SHGetFolderPathFunc(NULL, CSIDL_APPDATA, NULL, SHGFP_TYPE_CURRENT, defaultSavepath) == S_OK) {
-		_tcscat(defaultSavepath, TEXT("\\ScummVM"));
-		if (!CreateDirectory(defaultSavepath, NULL)) {
-			if (GetLastError() != ERROR_ALREADY_EXISTS)
-				error("Cannot create ScummVM application data folder");
-		}
-
-		_tcscat(defaultSavepath, TEXT("\\Saved games"));
-		if (!CreateDirectory(defaultSavepath, NULL)) {
-			if (GetLastError() != ERROR_ALREADY_EXISTS)
-				error("Cannot create ScummVM Saved games folder");
-		}
-
-		ConfMan.registerDefault("savepath", Win32::tcharToString(defaultSavepath));
+	if (isPortable) {
+		Win32::getProcessDirectory(defaultSavepath, MAX_PATH);
 	} else {
-		warning("Unable to access application data directory");
+		// Use the Application Data directory of the user profile
+		if (!Win32::getApplicationDataDirectory(defaultSavepath)) {
+			return;
+		}
 	}
+
+	_tcscat(defaultSavepath, TEXT("\\Saved games"));
+	if (!CreateDirectory(defaultSavepath, NULL)) {
+		if (GetLastError() != ERROR_ALREADY_EXISTS)
+			error("Cannot create ScummVM Saved games folder");
+	}
+
+	ConfMan.registerDefault("savepath", Win32::tcharToString(defaultSavepath));
 }
 
 #endif

--- a/backends/saves/windows/windows-saves.h
+++ b/backends/saves/windows/windows-saves.h
@@ -26,11 +26,11 @@
 #include "backends/saves/default/default-saves.h"
 
 /**
- * Provides a default savefile manager implementation for common platforms.
+ * Provides a savefile manager implementation for Windows.
  */
 class WindowsSaveFileManager final : public DefaultSaveFileManager {
 public:
-	WindowsSaveFileManager();
+	WindowsSaveFileManager(bool isPortable);
 };
 
 #endif

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2380,18 +2380,20 @@ void GlobalOptionsDialog::addMiscControls(GuiObject *boss, const Common::String 
 	}
 
 #ifdef USE_UPDATES
-	_updatesPopUpDesc = new StaticTextWidget(boss, prefix + "UpdatesPopupDesc", _("Update check:"), _("How often to check ScummVM updates"));
-	_updatesPopUp = new PopUpWidget(boss, prefix + "UpdatesPopup");
+	if (g_system->getUpdateManager()) {
+		_updatesPopUpDesc = new StaticTextWidget(boss, prefix + "UpdatesPopupDesc", _("Update check:"), _("How often to check ScummVM updates"));
+		_updatesPopUp = new PopUpWidget(boss, prefix + "UpdatesPopup");
 
-	const int *vals = Common::UpdateManager::getUpdateIntervals();
-	while (*vals != -1) {
-		_updatesPopUp->appendEntry(Common::UpdateManager::updateIntervalToString(*vals), *vals);
-		vals++;
+		const int *vals = Common::UpdateManager::getUpdateIntervals();
+		while (*vals != -1) {
+			_updatesPopUp->appendEntry(Common::UpdateManager::updateIntervalToString(*vals), *vals);
+			vals++;
+		}
+
+		_updatesPopUp->setSelectedTag(Common::UpdateManager::normalizeInterval(ConfMan.getInt("updates_check")));
+
+		new ButtonWidget(boss, prefix + "UpdatesCheckManuallyButton", _("Check now"), Common::U32String(), kUpdatesCheckCmd);
 	}
-
-	_updatesPopUp->setSelectedTag(Common::UpdateManager::normalizeInterval(ConfMan.getInt("updates_check")));
-
-	new ButtonWidget(boss, prefix + "UpdatesCheckManuallyButton", _("Check now"), Common::U32String(), kUpdatesCheckCmd);
 #endif // USE_UPDATES
 }
 
@@ -2660,9 +2662,9 @@ void GlobalOptionsDialog::apply() {
 		_autosavePeriodPopUp->setSelected(0);
 
 #ifdef USE_UPDATES
-	ConfMan.setInt("updates_check", _updatesPopUp->getSelectedTag());
-
 	if (g_system->getUpdateManager()) {
+		ConfMan.setInt("updates_check", _updatesPopUp->getSelectedTag());
+		
 		if (_updatesPopUp->getSelectedTag() == Common::UpdateManager::kUpdateIntervalNotSupported) {
 			g_system->getUpdateManager()->setAutomaticallyChecksForUpdates(Common::UpdateManager::kUpdateStateDisabled);
 		} else {


### PR DESCRIPTION
This PR adds a "portable mode" to Windows builds. This has been requested several times and produced some long threads in the forums. The idea is that if someone manually puts a scummvm.ini file in a directory along with the exe, ScummVM will operate in a self-contained portable mode and use that config file and directory for logs/saves/screenshots. In other words: in portable mode, ScummVM won't touch the user profile directory.

I'm not the one asking for this feature but I see why it's wanted, it opens up interesting possibilities for people to play with. I can think of some experiments of mine it would help with. Being able to easily have a self-contained copy of highly configurable software is still in fashion! More importantly: it's pretty easy to implement given the recent cleanups to the Windows backend.

Notepad++ is a good Windows citizen and has this feature, so I modeled this off of what it does. It also uses the presence of a local config file in the exe directory as a trigger. To ensure UAC compatibility, it does *not* do this if it's running out of Program Files on Vista+. I've included that same check. That's also a good way to make sure that if any normal users have a scummvm.ini laying around in their Program Files\ScummVM\ directory (for some weird reason) that the next upgrade doesn't immediately cause the real config file in their user profile to stop being used. I don't think that's a realistic scenario but it's a nice failsafe for the one thing that could go wrong on upgrade.

I see that this has been proposed before in https://github.com/scummvm/scummvm/pull/1504 and was closed, but that proposal was just a start. This PR adds portable mode as a formal full feature that takes all paths and UAC into account.

All that said, I don't feel too strongly about this, I just think it's kinda neat.