### PR TITLE
XEEN: fix caster selection during non-combat spell casting

### DIFF
--- a/engines/xeen/dialogs/dialogs_spells.cpp
+++ b/engines/xeen/dialogs/dialogs_spells.cpp
@@ -521,7 +521,6 @@ int CastSpell::execute(Character *&c) {
 					intf.highlightChar(_buttonValue);
 					spells._lastCaster = _buttonValue;
 					redrawFlag = true;
-					break;
 				}
 			}
 


### PR DESCRIPTION
Steps to reproduce:
- bring the casting dialog while not in combat
- try selecting another character

→ instead of changing the caster, the spell is aborted