### PR TITLE
DIRECTOR: decode movie paths before loading

### DIFF
--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -153,7 +153,7 @@ void Window::probeMacBinary(MacArchive *archive) {
 			if (num == 0)
 				error("No strings in Projector file");
 
-			Common::String sname = name->readPascalString();
+			Common::String sname = decodePlatformEncoding(name->readPascalString());
 			Common::String moviePath = pathMakeRelative(sname);
 			if (testPath(moviePath)) {
 				_nextMovie.movie = moviePath;

--- a/engines/director/util.cpp
+++ b/engines/director/util.cpp
@@ -983,4 +983,8 @@ Common::String castTypeToString(const CastType &type) {
 	return res;
 }
 
+Common::String decodePlatformEncoding(Common::String input) {
+	return input.decode(g_director->getPlatformEncoding());
+}
+
 } // End of namespace Director

--- a/engines/director/util.h
+++ b/engines/director/util.h
@@ -97,6 +97,8 @@ Common::String encodePathForDump(const Common::String &path);
 
 Common::String utf8ToPrintable(const Common::String &str);
 
+Common::String decodePlatformEncoding(Common::String input);
+
 } // End of namespace Director
 
 #endif


### PR DESCRIPTION
This fixes an issue where movies in `probeMacBinary` weren't being decoded before being loaded. In the case of Japanese games that used MacJapanese filenames, this could lead to errors loading them. Before the patch:

```
WARNING: Couldn't find score with name: WackyRaces: WackyRaces: Main:�Entrance!
```

After:

```
WARNING: Replaced score name with:  WackyRaces: Main:･Entrance (from WackyRaces: WackyRaces: Main:･Entrance)!
```

This fixes loading a scene in the Mac version of Wacky Races, though it still doesn't make it past the intro video.