### PR TITLE
DIRECTOR: do not error on missing cast resource

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -776,8 +776,10 @@ void Cast::loadCastDataVWCR(Common::SeekableReadStreamEndian &stream) {
 				tag = MKTAG('B', 'I', 'T', 'D');
 			else if (_castArchive->hasResource(MKTAG('D', 'I', 'B', ' '), id + _castIDoffset))
 				tag = MKTAG('D', 'I', 'B', ' ');
-			else
-				error("Cast::loadCastDataVWCR(): non-existent reference to BitmapCastMember");
+			else {
+				warning("Cast::loadCastDataVWCR(): non-existent reference to BitmapCastMember");
+				break;
+			}
 
 			_loadedCast->setVal(id, new BitmapCastMember(this, id, stream, tag, _version, flags1));
 			break;


### PR DESCRIPTION
While this should definitely be a warning, I don't think it should be an error that prevents execution from continuing.

I'm running into this in Aquaplanet, whose mystery resource I haven't figured out yet, but I'm able to get in-game if I allow this to continue.