### PR TITLE
DIRECTOR: Fix position of film loop subchannels

### DIFF
--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -610,7 +610,6 @@ Common::Array<Channel> *FilmLoopCastMember::getSubChannels(Common::Rect &bbox, C
 		chan._currentPoint = Common::Point(absX, absY);
 		chan._width = width;
 		chan._height = height;
-		chan.addRegistrationOffset(chan._currentPoint, true);
 
 		_subchannels.push_back(chan);
 		_subchannels[_subchannels.size() - 1].replaceWidget();
@@ -725,13 +724,21 @@ void FilmLoopCastMember::loadFilmLoopData(Common::SeekableReadStreamEndian &stre
 
 			frameSize -= msgWidth;
 
-			Common::Rect spriteBbox(
-				sprite._startPoint.x,
-				sprite._startPoint.y,
-				sprite._startPoint.x + sprite._width,
-				sprite._startPoint.y + sprite._height
-			);
 			newFrame.sprites.setVal(channel, sprite);
+		}
+
+		for (Common::HashMap<int, Sprite>::iterator s = newFrame.sprites.begin(); s != newFrame.sprites.end(); ++s) {
+			debugC(5, kDebugLoading, "Sprite: channel %d, castId %s, bbox %d %d %d %d", s->_key,
+					s->_value._castId.asString().c_str(), s->_value._startPoint.x, s->_value._startPoint.y,
+					s->_value._width, s->_value._height);
+
+			Common::Point topLeft = s->_value._startPoint + s->_value.getRegistrationOffset();
+			Common::Rect spriteBbox(
+				topLeft.x,
+				topLeft.y,
+				topLeft.x + s->_value._width,
+				topLeft.y + s->_value._height
+			);
 			if (!((spriteBbox.width() == 0) && (spriteBbox.height() == 0))) {
 				if ((_initialRect.width() == 0) && (_initialRect.height() == 0)) {
 					_initialRect = spriteBbox;
@@ -739,15 +746,8 @@ void FilmLoopCastMember::loadFilmLoopData(Common::SeekableReadStreamEndian &stre
 					_initialRect.extend(spriteBbox);
 				}
 			}
-		}
+			debugC(8, kDebugLoading, "New bounding box: %d %d %d %d", _initialRect.left, _initialRect.top, _initialRect.width(), _initialRect.height());
 
-		if (debugChannelSet(5, kDebugLoading)) {
-			for (Common::HashMap<int, Sprite>::iterator s = newFrame.sprites.begin(); s != newFrame.sprites.end(); ++s) {
-				debugC(5, kDebugLoading, "Sprite: channel %d, castId %s, bbox %d %d %d %d", s->_key,
-						s->_value._castId.asString().c_str(), s->_value._startPoint.x, s->_value._startPoint.y,
-						s->_value._width, s->_value._height);
-
-			}
 		}
 
 		_frames.push_back(newFrame);

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -619,30 +619,21 @@ void Channel::addRegistrationOffset(Common::Point &pos, bool subtract) {
 		return;
 
 	switch (_sprite->_cast->_type) {
-	case kCastBitmap: {
-		BitmapCastMember *bc = (BitmapCastMember *)(_sprite->_cast);
-
-		Common::Point point(0, 0);
-		// stretch the offset
-		if (!_sprite->_stretch && (_width != bc->_initialRect.width() || _height != bc->_initialRect.height())) {
-			point.x = (bc->_initialRect.left - bc->_regX) * _width / bc->_initialRect.width();
-			point.y = (bc->_initialRect.top - bc->_regY) * _height / bc->_initialRect.height();
-		} else {
-			point.x = bc->_initialRect.left - bc->_regX;
-			point.y = bc->_initialRect.top - bc->_regY;
+	case kCastBitmap:
+		{
+			if (subtract)
+				pos -= _sprite->getRegistrationOffset();
+			else
+				pos += _sprite->getRegistrationOffset();
 		}
-		if (subtract)
-			pos -= point;
-		else
-			pos += point;
-	} break;
+		break;
 	case kCastDigitalVideo:
 	case kCastFilmLoop:
-		pos -= Common::Point(_sprite->_cast->_initialRect.width() >> 1, _sprite->_cast->_initialRect.height() >> 1);
-		break;
+		pos -= _sprite->getRegistrationOffset();
 	default:
 		break;
 	}
+	return;
 }
 
 void Channel::addDelta(Common::Point pos) {

--- a/engines/director/sprite.h
+++ b/engines/director/sprite.h
@@ -84,6 +84,7 @@ public:
 	MacShape *getShape();
 	uint32 getForeColor();
 	uint32 getBackColor();
+	Common::Point getRegistrationOffset();
 
 	Frame *_frame;
 	Score *_score;


### PR DESCRIPTION
Sprites stored in frames are referenced by position (minus the
registration offset), width and height. Film loops are the same. As
such, fix the bounding box calculation for the film loop to use the
correct sprite positions (e.g. center for bitmaps), then fix the
subchannel generator to take these into account.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
