### PR TITLE
VIDEO: Fix QuickTimeDecoder bugs

### DIFF
--- a/common/quicktime.cpp
+++ b/common/quicktime.cpp
@@ -368,7 +368,6 @@ int QuickTimeParser::readTRAK(Atom atom) {
 	Track *track = new Track();
 
 	track->codecType = CODEC_TYPE_MOV_OTHER;
-	track->startTime = 0; // XXX: check
 	_tracks.push_back(track);
 
 	return readDefault(atom);
@@ -837,7 +836,6 @@ QuickTimeParser::Track::Track() {
 	codecType = CODEC_TYPE_MOV_OTHER;
 	frameCount = 0;
 	duration = 0;
-	startTime = 0;
 	mediaDuration = 0;
 }
 

--- a/common/quicktime.h
+++ b/common/quicktime.h
@@ -93,7 +93,7 @@ protected:
 
 	struct TimeToSampleEntry {
 		int count;
-		int duration;
+		int duration; // media time
 	};
 
 	struct SampleToChunkEntry {
@@ -103,9 +103,9 @@ protected:
 	};
 
 	struct EditListEntry {
-		uint32 trackDuration;
-		uint32 timeOffset;
-		int32 mediaTime;
+		uint32 trackDuration; // movie time
+		uint32 timeOffset;    // movie time
+		int32 mediaTime;      // media time
 		Rational mediaRate;
 	};
 
@@ -148,7 +148,7 @@ protected:
 		uint32 *sampleSizes;
 		uint32 keyframeCount;
 		uint32 *keyframes;
-		int32 timeScale;
+		int32 timeScale; // media time
 
 		uint16 width;
 		uint16 height;
@@ -158,18 +158,17 @@ protected:
 
 		Common::Array<EditListEntry> editList;
 
-		uint32 frameCount;
-		uint32 duration;
-		uint32 mediaDuration;
-		uint32 startTime;
+		uint32 frameCount;    // from stts
+		uint32 duration;      // movie time
+		uint32 mediaDuration; // media time
 		Rational scaleFactorX;
 		Rational scaleFactorY;
 	};
 
 	virtual SampleDesc *readSampleDesc(Track *track, uint32 format, uint32 descSize) = 0;
 
-	uint32 _timeScale;
-	uint32 _duration;
+	uint32 _timeScale;      // movie time
+	uint32 _duration;       // movie time
 	Rational _scaleFactorX;
 	Rational _scaleFactorY;
 	Array<Track *> _tracks;

--- a/engines/mohawk/riven_video.cpp
+++ b/engines/mohawk/riven_video.cpp
@@ -65,6 +65,7 @@ void RivenVideo::load(uint16 id) {
 	_video->setSoundType(Audio::Mixer::kSFXSoundType);
 	_video->setChunkBeginOffset(_vm->getResourceOffset(ID_TMOV, id));
 	_video->loadStream(_vm->getResource(ID_TMOV, id));
+	_video->enableEditListBoundsCheckQuirk(true); // for Spanish olw.mov
 }
 
 void RivenVideo::close() {

--- a/video/qt_decoder.cpp
+++ b/video/qt_decoder.cpp
@@ -294,7 +294,7 @@ QuickTimeDecoder::VideoTrackHandler::VideoTrackHandler(QuickTimeDecoder *decoder
 	checkEditListBounds();
 
 	_curEdit = 0;
-	enterNewEditList(false);
+	enterNewEditListEntry(false);
 
 	_curFrame = -1;
 	_durationOverride = -1;
@@ -379,12 +379,12 @@ bool QuickTimeDecoder::VideoTrackHandler::seek(const Audio::Timestamp &requested
 			_curEdit++;
 
 		if (!atLastEdit())
-			enterNewEditList(true);
+			enterNewEditListEntry(true);
 
 		return true;
 	}
 
-	enterNewEditList(false);
+	enterNewEditListEntry(false);
 
 	// One extra check for the end of a track
 	if (atLastEdit()) {
@@ -402,7 +402,7 @@ bool QuickTimeDecoder::VideoTrackHandler::seek(const Audio::Timestamp &requested
 			_nextFrameStartTime += _durationOverride;
 			_durationOverride = -1;
 		} else {
-			_nextFrameStartTime += getFrameDuration();
+			_nextFrameStartTime += getCurFrameDuration();
 		}
 	}
 
@@ -504,7 +504,7 @@ const Graphics::Surface *QuickTimeDecoder::VideoTrackHandler::decodeNextFrame() 
 		if (atLastEdit())
 			return 0;
 
-		enterNewEditList(true);
+		enterNewEditListEntry(true);
 	}
 
 	const Graphics::Surface *frame = bufferNextFrame();
@@ -516,7 +516,7 @@ const Graphics::Surface *QuickTimeDecoder::VideoTrackHandler::decodeNextFrame() 
 			_durationOverride = -1;
 		} else {
 			// Just need to subtract the time
-			_nextFrameStartTime -= getFrameDuration();
+			_nextFrameStartTime -= getCurFrameDuration();
 		}
 	} else {
 		if (_durationOverride >= 0) {
@@ -524,7 +524,7 @@ const Graphics::Surface *QuickTimeDecoder::VideoTrackHandler::decodeNextFrame() 
  			_nextFrameStartTime += _durationOverride;
 			_durationOverride = -1;
 		} else {
-			_nextFrameStartTime += getFrameDuration();
+			_nextFrameStartTime += getCurFrameDuration();
 		}
 	}
 
@@ -664,7 +664,7 @@ Common::SeekableReadStream *QuickTimeDecoder::VideoTrackHandler::getNextFramePac
 	return stream->readStream(_parent->sampleSizes[_curFrame]);
 }
 
-uint32 QuickTimeDecoder::VideoTrackHandler::getFrameDuration() {
+uint32 QuickTimeDecoder::VideoTrackHandler::getCurFrameDuration() {
 	uint32 curFrameIndex = 0;
 	for (int32 i = 0; i < _parent->timeToSampleCount; i++) {
 		curFrameIndex += _parent->timeToSample[i].count;
@@ -688,7 +688,7 @@ uint32 QuickTimeDecoder::VideoTrackHandler::findKeyFrame(uint32 frame) const {
 	return frame;
 }
 
-void QuickTimeDecoder::VideoTrackHandler::enterNewEditList(bool bufferFrames) {
+void QuickTimeDecoder::VideoTrackHandler::enterNewEditListEntry(bool bufferFrames) {
 	// Bypass all empty edit lists first
 	while (!atLastEdit() && _parent->editList[_curEdit].mediaTime == -1)
 		_curEdit++;
@@ -811,7 +811,7 @@ uint32 QuickTimeDecoder::VideoTrackHandler::getCurEditTimeOffset() const {
 }
 
 uint32 QuickTimeDecoder::VideoTrackHandler::getCurEditTrackDuration() const {
-	// Need to convert to the track scale
+	// convert from movie time scale to the track's media time scale
 	return _parent->editList[_curEdit].trackDuration * _parent->timeScale / _decoder->_timeScale;
 }
 

--- a/video/qt_decoder.cpp
+++ b/video/qt_decoder.cpp
@@ -51,6 +51,7 @@ namespace Video {
 QuickTimeDecoder::QuickTimeDecoder() {
 	_scaledSurface = 0;
 	_width = _height = 0;
+	_enableEditListBoundsCheckQuirk = false;
 }
 
 QuickTimeDecoder::~QuickTimeDecoder() {
@@ -291,7 +292,9 @@ Audio::SeekableAudioStream *QuickTimeDecoder::AudioTrackHandler::getSeekableAudi
 }
 
 QuickTimeDecoder::VideoTrackHandler::VideoTrackHandler(QuickTimeDecoder *decoder, Common::QuickTimeParser::Track *parent) : _decoder(decoder), _parent(parent) {
-	checkEditListBounds();
+	if (decoder->_enableEditListBoundsCheckQuirk) {
+		checkEditListBounds();
+	}
 
 	_curEdit = 0;
 	enterNewEditListEntry(false);
@@ -307,6 +310,12 @@ QuickTimeDecoder::VideoTrackHandler::VideoTrackHandler(QuickTimeDecoder *decoder
 	_ditherFrame = 0;
 }
 
+// FIXME: This check breaks valid QuickTime movies, such as the KQ6 Mac opening.
+// It doesn't take media rate into account and mixes up units that are in movie
+// time scale and media time scale, which is easy to do since they're often the
+// same value. Other decoder bugs have been fixed since this was written, so it
+// would be good to re-evaluate what the problem was with the Riven Spanish video.
+// It's now disabled for everything except Riven.
 void QuickTimeDecoder::VideoTrackHandler::checkEditListBounds() {
 	// Check all the edit list entries are within the bounds of the media
 	// In the Spanish version of Riven, the last edit of the video ogk.mov

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -171,6 +171,7 @@ private:
 		Common::SeekableReadStream *getNextFramePacket(uint32 &descId);
 		uint32 getCurFrameDuration();            // media time
 		uint32 findKeyFrame(uint32 frame) const;
+		bool isEmptyEdit() const;
 		void enterNewEditListEntry(bool bufferFrames);
 		const Graphics::Surface *bufferNextFrame();
 		uint32 getRateAdjustedFrameTime() const; // media time

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -71,6 +71,8 @@ public:
 	const Graphics::Surface *decodeNextFrame();
 	Audio::Timestamp getDuration() const { return Audio::Timestamp(0, _duration, _timeScale); }
 
+	void enableEditListBoundsCheckQuirk(bool enable) { _enableEditListBoundsCheckQuirk = enable; }
+
 protected:
 	Common::QuickTimeParser::SampleDesc *readSampleDesc(Common::QuickTimeParser::Track *track, uint32 format, uint32 descSize);
 
@@ -84,6 +86,8 @@ private:
 	Graphics::Surface *_scaledSurface;
 	void scaleSurface(const Graphics::Surface *src, Graphics::Surface *dst,
 			const Common::Rational &scaleFactorX, const Common::Rational &scaleFactorY);
+
+	bool _enableEditListBoundsCheckQuirk;
 
 	class VideoSampleDesc : public Common::QuickTimeParser::SampleDesc {
 	public:

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -134,7 +134,7 @@ private:
 		Graphics::PixelFormat getPixelFormat() const;
 		int getCurFrame() const { return _curFrame; }
 		int getFrameCount() const;
-		uint32 getNextFrameStartTime() const;
+		uint32 getNextFrameStartTime() const; // milliseconds
 		const Graphics::Surface *decodeNextFrame();
 		const byte *getPalette() const;
 		bool hasDirtyPalette() const { return _curPalette; }
@@ -151,9 +151,9 @@ private:
 		Common::QuickTimeParser::Track *_parent;
 		uint32 _curEdit;
 		int32 _curFrame;
-		uint32 _nextFrameStartTime;
+		uint32 _nextFrameStartTime; // media time
 		Graphics::Surface *_scaledSurface;
-		int32 _durationOverride;
+		int32 _durationOverride;    // media time
 		const byte *_curPalette;
 		mutable bool _dirtyPalette;
 		bool _reversed;
@@ -165,13 +165,13 @@ private:
 		const Graphics::Surface *forceDither(const Graphics::Surface &frame);
 
 		Common::SeekableReadStream *getNextFramePacket(uint32 &descId);
-		uint32 getFrameDuration();
+		uint32 getCurFrameDuration();            // media time
 		uint32 findKeyFrame(uint32 frame) const;
-		void enterNewEditList(bool bufferFrames);
+		void enterNewEditListEntry(bool bufferFrames);
 		const Graphics::Surface *bufferNextFrame();
-		uint32 getRateAdjustedFrameTime() const;
-		uint32 getCurEditTimeOffset() const;
-		uint32 getCurEditTrackDuration() const;
+		uint32 getRateAdjustedFrameTime() const; // media time
+		uint32 getCurEditTimeOffset() const;     // media time
+		uint32 getCurEditTrackDuration() const;  // media time
 		bool atLastEdit() const;
 		bool endOfCurEdit() const;
 		void checkEditListBounds();


### PR DESCRIPTION
The KQ6 Mac QuickTime opening movie doesn't play correctly in ScummVM. There are frozen frames and other problems at transitions between tracks and edits. https://bugs.scummvm.org/ticket/11085

There are two bugs preventing correct playback:

1. A workaround from three years ago for a video in a Spanish version of Riven. The workaround has several problems and it breaks valid movies. (Added in: b8abe400850a23d12fe5cdc24d7106820d0f13fd)
2. QuickTimeDecoder doesn't correctly handle tracks where the first edit is empty (a delay) and the second has a `mediaTime` offset. `mediaTime` is ignored in this case, causing the first frame of the media to be played instead of the intended later frame.

I've limited the Riven workaround to just Riven through a flag, this mitigates that regression. It's important to keep that workaround, even if buggy, since it prevents a crash. (Hopefully it can be fixed someday by someone with that video)

The decoder bug is an initialization/workflow problem. All tracks are constructed at the start where they each enter their first edit. Entering an edit calculates the next frame of the edit and next frame start time. But first, `enterNewEditList()` skips empty edits. That's a problem because the track constructor then resets the first frame, undoing the calculation. The edit is never re-initialized since it's already been entered. In other words, there are accidentally two paths to real edit initialization: the one during playback which correctly handles everything, and the one during track construction where the caller is unaware of skipping past edits or the need to buffer frames in case the first edit has a `mediaTime`.

The fix is to no longer skip empty edits, which are just delays until the next edit starts. Instead, a track's current edit can now happily be in an empty edit state during an empty edit. This is a more accurate representation of the movie playback model. This causes subsequent edits to now always be initialized during playback just like all other edits. The trade-off is to just add a check to `decodeNextFrame()` and `getRateAdjustedFrameTime()` so that they take empty edits into account.

Also we now buffer frames during track initialization, which fixes the case where the first edit in a track has `mediaTime`; otherwise the frame's keyframe wouldn't get processed.

I'm not going to admit how long I spent working on this, but...

![image](https://user-images.githubusercontent.com/22204938/141106120-c972e7c5-6bf6-4487-af66-121f1d3ac05b.png)

