### PR TITLE
SAGA: Fix ITE digial music looping regression

### DIFF
--- a/engines/saga/music.cpp
+++ b/engines/saga/music.cpp
@@ -349,7 +349,7 @@ bool Music::playDigital(uint32 resourceId, MusicFlags flags) {
 	int realTrackNumber = 0;
 
 	if (_vm->getGameId() == GID_ITE) {
-		if (flags == MUSIC_NORMAL && (resourceId == 13 || resourceId == 19))
+		if (resourceId != 13 && resourceId != 19)
 			flags = MUSIC_LOOP;
 		realTrackNumber = resourceId - 8;
 	} else if (_vm->getGameId() == GID_IHNM) {


### PR DESCRIPTION
This attempts to fix the music looping regression described in https://forums.scummvm.org/viewtopic.php?t=16434

See commit message for details about where the regression came from.

I was tempted to commit it right away, but I'd appreciate if someone much more familiar with Inherit the Earth could comment on it first. After that, it's probably a good candidate for the 2.5 branch as well.