### PR TITLE
CI: Fix MSVC builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: lukka/run-vcpkg@v7
         id: runvcpkg
         with:
-          vcpkgGitCommitId: b67fab9861239e33b722b9a44f5c96dec6ca807e
+          vcpkgGitCommitId: 70033dbb31527fb3e69654731f540f59c87787f9
           vcpkgTriplet: '${{ matrix.triplet }}'
           vcpkgArguments: '${{ matrix.vcpkgPackages }}'
 #      - name: Upload libs

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -69,7 +69,7 @@ std::string MSVCProvider::getLibraryFromFeature(const char *feature, const Build
 		{     "mpeg2", "mpeg2.lib",                 0,               0,                                                 "libmpeg2.lib" },
 		{    "theora", "theora.lib",                0,               0,                                                 "libtheora_static.lib" },
 		{  "freetype", "freetype.lib",              "freetyped.lib", 0,                                                 0 },
-		{      "jpeg", "jpeg.lib",                  "jpegd.lib",     0,                                                 "jpeg-static.lib" },
+		{      "jpeg", "jpeg.lib",                  0,               0,                                                 "jpeg-static.lib" },
 		{"fluidsynth", "fluidsynth.lib",            0,               0,                                                 "libfluidsynth.lib" },
 		{ "fluidlite", "fluidlite.lib",             0,               0,                                                 0 },
 		{   "libcurl", "libcurl.lib",               "libcurl-d.lib", "ws2_32.lib wldap32.lib crypt32.lib normaliz.lib", 0 },


### PR DESCRIPTION
The MSVC builds have been failing because PCRE changed their download server. https://github.com/microsoft/vcpkg/issues/21201

Fixed by updating vcpkg commit and dropping the "d" from the libjpeg-turbo debug library. There's no longer a suffix on this library when buildling with vcpkg.

I'm doing this as a PR so that someone with access can update the lib filename in http://downloads.scummvm.org/frs/build/scummvm_libs_2015.zip