### PR TITLE
OPENDINGUX: Various improvements to building process

### DIFF
--- a/backends/platform/sdl/opendingux/README.BUILD
+++ b/backends/platform/sdl/opendingux/README.BUILD
@@ -6,12 +6,12 @@ Running Linux on an x86/amd64 machine:
 
 2. git clone the ScummVM repository
 
-3. Run 'target=x backends/platform/sdl/opendingux/build_odbeta.sh' 
+3. Run 'backends/platform/sdl/opendingux/build_odbeta.sh x'
    where x=gcw0|lepus|rg99 
 
    Or if you want a dual opk with one launcher capable of starting games directly 
    for e.g. simplemenu integration :
-   'target=x dualopk=yes backends/platform/sdl/opendingux/build_odbeta.s' 
+   'backends/platform/sdl/opendingux/build_odbeta.sh x dualopk'
 
 4. Copy the resulting file scummvm_$(target).opk or scummvm_$(target)_dual.opk to your device
 

--- a/backends/platform/sdl/opendingux/build_odbeta.sh
+++ b/backends/platform/sdl/opendingux/build_odbeta.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONFIG="./configure --host=opendingux --enable-release --disable-detection-full"
+CONFIG="./configure --host=opendingux-$target --enable-release --disable-detection-full"
 
 case $target in
 
@@ -10,14 +10,10 @@ case $target in
 
         lepus)
 	target2=$target
-	export DEFINES="-DLEPUS"
-        CONFIG+=" --disable-highres --disable-hq-scalers"
         ;;
 
         rg99)
 	target2=rs90
-	export DEFINES="-DRS90 -DDISABLE_FANCY_THEMES"
-        CONFIG+=" --disable-highres --disable-16bit --disable-scalers"
         ;;
         
         *)

--- a/backends/platform/sdl/opendingux/build_odbeta.sh
+++ b/backends/platform/sdl/opendingux/build_odbeta.sh
@@ -1,37 +1,46 @@
 #!/bin/bash
 
-CONFIG="./configure --host=opendingux-$target --enable-release --disable-detection-full"
+set -e
+
+target=$1
+if [ "$2" = "dualopk" ]; then
+	dualopk="dualopk=yes"
+else
+	dualopk=
+fi
 
 case $target in
 
         gcw0)
 	target2=$target
+	libc=uclibc
         ;;
 
         lepus)
 	target2=$target
+	libc=musl
         ;;
 
         rg99)
 	target2=rs90
+	libc=musl
         ;;
         
         *)
         echo "please provide a valid target for the build: gcw0, lepus or rg99"
-        exit 0
+        exit 1
         ;;
 esac
 
 TOOLCHAIN=/opt/$target2-toolchain
-
-if [ $target == "gcw0" ]; then
-	SYSROOT=$TOOLCHAIN/mipsel-$target2-linux-uclibc
-else
-	SYSROOT=$TOOLCHAIN/mipsel-$target2-linux-musl
-fi
+SYSROOT=$TOOLCHAIN/mipsel-$target2-linux-$libc
 
 export PATH=$TOOLCHAIN/usr/bin:$SYSROOT/usr/include:$TOOLCHAIN/bin:$PATH
 export CXX=mipsel-linux-g++
 export CXXFLAGS="-funsigned-char" # workaround for a scummvm tolower() bug when adding games
 
-$CONFIG && make -j12 od-make-opk && ls -lh scummvm_$target*.opk
+./configure --host=opendingux-$target --enable-release --disable-detection-full
+
+make -j12 od-make-opk $dualopk
+
+ls -lh scummvm_$target*.opk

--- a/backends/platform/sdl/opendingux/opendingux.mk
+++ b/backends/platform/sdl/opendingux/opendingux.mk
@@ -10,7 +10,7 @@ $(bundle): all
 	$(MKDIR) $(bundle)
 	$(CP) $(DIST_FILES_DOCS) $(bundle)/
 
-ifneq ($(target), rg99)
+ifneq ($(OPENDINGUX_TARGET), rg99)
 	$(MKDIR) $(bundle)/themes
 	$(CP) $(DIST_FILES_THEMES) $(bundle)/themes/
 endif
@@ -18,7 +18,7 @@ endif
 ifdef DIST_FILES_ENGINEDATA
 	$(MKDIR) $(bundle)/engine-data
 	$(CP) $(DIST_FILES_ENGINEDATA) $(bundle)/engine-data/
-ifeq ($(target), rg99)
+ifeq ($(OPENDINGUX_TARGET), rg99)
 	$(CP) $(srcdir)/dists/opendingux/fonts_mini.dat $(bundle)/engine-data/fonts.dat
 endif
 endif
@@ -35,9 +35,9 @@ endif
 	$(CP) $(EXECUTABLE) $(bundle)/scummvm
 
 	$(CP) $(srcdir)/dists/opendingux/scummvm.png $(bundle)/
-	$(CP) $(srcdir)/dists/opendingux/startUI.$(target).desktop $(bundle)/
+	$(CP) $(srcdir)/dists/opendingux/startUI.$(OPENDINGUX_TARGET).desktop $(bundle)/
 ifdef dualopk
-	$(CP) $(srcdir)/dists/opendingux/startGame.$(target).desktop $(bundle)/
+	$(CP) $(srcdir)/dists/opendingux/startGame.$(OPENDINGUX_TARGET).desktop $(bundle)/
 	$(CP) $(srcdir)/dists/opendingux/scummvm.sh $(bundle)/
 endif
 	$(CP) $(srcdir)/backends/platform/sdl/opendingux/README.OPENDINGUX $(bundle)/README.man.txt
@@ -50,7 +50,7 @@ od-make-opk: $(bundle)
 	$(STRIP) $(bundle)/scummvm
 
 ifdef dualopk
-	$(srcdir)/dists/opendingux/make-opk.sh -d $(bundle) -o scummvm_$(target)_dual
+	$(srcdir)/dists/opendingux/make-opk.sh -d $(bundle) -o scummvm_$(OPENDINGUX_TARGET)_dual
 else
-	$(srcdir)/dists/opendingux/make-opk.sh -d $(bundle) -o scummvm_$(target)
+	$(srcdir)/dists/opendingux/make-opk.sh -d $(bundle) -o scummvm_$(OPENDINGUX_TARGET)
 endif

--- a/configure
+++ b/configure
@@ -829,7 +829,9 @@ Special configuration feature:
                                            ios7-arm64 for Apple iPhone / iPad (iOS >= 7, 64-bit)
                                            maemo for Nokia Maemo
                                            n64 for Nintendo 64
-                                           opendingux for Opendingux Beta
+                                           opendingux-gcw0 for GCW0 with Opendingux Beta
+                                           opendingux-lepus for Lepus with Opendingux Beta
+                                           opendingux-rg99 for RG99 with Opendingux Beta
                                            openpandora for OpenPandora
                                            ouya for OUYA
                                            ps3 for PlayStation 3
@@ -1576,7 +1578,7 @@ caanoo)
 	_host_cpu=arm
 	_host_alias=arm-none-linux-gnueabi
 	;;
-dingux | gcw0 | opendingux)
+dingux | gcw0 | opendingux-*)
 	_host_os=linux
 	_host_cpu=mipsel
 	_host_alias=mipsel-linux
@@ -3491,7 +3493,7 @@ if test -n "$_host"; then
 			_build_hq_scalers=no
 			_mt32emu=no
 			;;
-		opendingux)
+		opendingux-*)
 			_sysroot=`$CXX --print-sysroot`
 			_sdlpath=$_sysroot/usr/bin
 			append_var DEFINES  "-DDINGUX -DOPENDINGUX -DREDUCE_MEMORY_USAGE"
@@ -3514,6 +3516,25 @@ if test -n "$_host"; then
 			_backend="opendingux"
 			_port_mk="backends/platform/sdl/opendingux/opendingux.mk"
 			add_line_to_config_mk 'OPENDINGUX = 1'
+			add_line_to_config_mk "OPENDINGUX_TARGET = ${_host#opendingux-}"
+			case "$_host" in
+				opendingux-gcw0)
+					;;
+				opendingux-lepus)
+					append_var DEFINES "-DLEPUS"
+					_highres=no
+					_build_hq_scalers=no
+					;;
+				opendingux-rg99)
+					append_var DEFINES "-DRS90 -DDISABLE_FANCY_THEMES"
+					_16bit=no
+					_highres=no
+					_build_hq_scalers=no
+					;;
+				*)
+					echo "WARNING: Unknown OpenDingux target"
+					;;
+			esac
 			;;
 		openpandora)
 			# Use -O3 on the OpenPandora for optimized builds.

--- a/dists/opendingux/make-opk.sh
+++ b/dists/opendingux/make-opk.sh
@@ -15,8 +15,8 @@ check_for_tool()
 	which $1 &> /dev/null
 	if [ "$?" -ne "0" ];
 	then
-		cecho "ERROR: Could not find the program '$1'. Please make sure
-that it is available in your PATH since it is required to complete your request." $red
+		echo "ERROR: Could not find the program '$1'. Please make sure
+that it is available in your PATH since it is required to complete your request."
 		exit 1
 	fi
 }

--- a/dists/opendingux/make-opk.sh
+++ b/dists/opendingux/make-opk.sh
@@ -91,12 +91,12 @@ fi
 echo "Creating an iso file based on '$FOLDER'."
 
 check_for_tool mksquashfs
-if [ $(/usr/bin/mksquashfs -version | awk 'BEGIN{r=0} $3>=4{r=1} END{print r}') -eq 0 ];
+if [ $(mksquashfs -version | awk 'BEGIN{r=0} $3>=4{r=1} END{print r}') -eq 0 ];
 then
 	echo "ERROR: Your squashfs version is older then version 4, please upgrade to 4.0 or later"
 	exit 1
 fi
-/usr/bin/mksquashfs $FOLDER $OPKNAME.opk -noappend -no-exports -no-xattrs
+mksquashfs $FOLDER $OPKNAME.opk -noappend -no-exports -no-xattrs
 
 # Final message
 if [ -f $OPKNAME.opk ];


### PR DESCRIPTION
This PR embeds the various platforms supported by OpenDingux beta directly in the configure script.
This will allow the buildbot to include builds for these platforms as it can't use the release build script.

In addition some autodetections are enabled back to allow make use of the features on GCW0 (Fluidsynth, Theora, SDL2) and OpenGL ES2 is enabled on GCW0 as the toolchain provides Mesa.

Some small fixes are provided to the make-opk script and the build_odbeta is reworked to make use of configure changes and to make use of arguments instead of environment variables to create the build.