### PR TITLE
DEVTOOLS: add Mac fonts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,8 @@ project.xcworkspace
 /dists/engine-data/testbed-audiocd-files/testbed.config
 /dists/engine-data/testbed-audiocd-files/testbed.out
 /dists/engine-data/playground3d
+/dists/engine-data/classicmacfonts.dat
+/dists/engine-data/japanesemacfonts.dat
 
 
 /doc/*.aux


### PR DESCRIPTION
A few other devtools-generated data files that aren't tracked in git are in this `.gitignore` to prevent them showing up as untracked files to git. I think it makes sense to add these two files as well. They're generated by two scripts in `devtools`.