### PR TITLE
GUI: Fix cursor stuttering with vsync enabled

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -548,8 +548,9 @@ void GuiManager::runLoop() {
 		redraw();
 
 		// Delay until the allocated frame time is elapsed to match the target frame rate.
-		// In case we have vsync enabled, we force a minimum frame duration of 1 millisecond
-		// since otherwise, we'd have a very sluggish cursor on 60Hz displays.
+		// In case we have vsync enabled, we should rely on vsync to do take care about frame times.
+		// With vsync enabled, we currently have to force a frame time of 1ms since otherwise
+		// CPU usage will skyrocket on one thread as soon as no updateScreen(); calls happening.
 		if (g_system->getFeatureState(OSystem::kFeatureVSync)) {
 			_system->delayMillis(1);
 		} else {

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -547,10 +547,16 @@ void GuiManager::runLoop() {
 
 		redraw();
 
-		// Delay until the allocated frame time is elapsed to match the target frame rate
-		uint32 actualFrameDuration = _system->getMillis(true) - frameStartTime;
-		if (actualFrameDuration < targetFrameDuration) {
-			_system->delayMillis(targetFrameDuration - actualFrameDuration);
+		// Delay until the allocated frame time is elapsed to match the target frame rate.
+		// In case we have vsync enabled, we force a minimum frame duration of 1 millisecond
+		// since otherwise, we'd have a very sluggish cursor on 60Hz displays.
+		if (ConfMan.getBool("vsync")) {
+			_system->delayMillis(1);
+		} else {
+			uint32 actualFrameDuration = _system->getMillis(true) - frameStartTime;
+			if (actualFrameDuration < targetFrameDuration) {
+				_system->delayMillis(targetFrameDuration - actualFrameDuration);
+			}
 		}
 		_system->updateScreen();
 	}

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -550,7 +550,7 @@ void GuiManager::runLoop() {
 		// Delay until the allocated frame time is elapsed to match the target frame rate.
 		// In case we have vsync enabled, we force a minimum frame duration of 1 millisecond
 		// since otherwise, we'd have a very sluggish cursor on 60Hz displays.
-		if (ConfMan.getBool("vsync")) {
+		if (g_system->getFeatureState(OSystem::kFeatureVSync)) {
 			_system->delayMillis(1);
 		} else {
 			uint32 actualFrameDuration = _system->getMillis(true) - frameStartTime;


### PR DESCRIPTION
Currently, with vsync enabled, the mouse cursor in the GUI Launcher feels very sluggish on a 60 Hz display. The issue is that the artificial waiting/frame times in the GUI launcher code cause a race condition between VSync an GUI manager's own frame timing.

This patch fixes this by skipping our own frametime calculation with VSync enabled. Hardcoding it to `delayMillis(1);` is required here since otherwise, ScummVM would always max out one CPU thread entirely.