### PR TITLE
XEEN: fix possible crash in exchange dialog

### DIFF
--- a/engines/xeen/dialogs/dialogs_exchange.cpp
+++ b/engines/xeen/dialogs/dialogs_exchange.cpp
@@ -51,7 +51,7 @@ void ExchangeDialog::execute(Character *&c, int &charIndex) {
 
 		if (_buttonValue >= Common::KEYCODE_F1 && _buttonValue <= Common::KEYCODE_F6) {
 			_buttonValue -= Common::KEYCODE_F1;
-			if (_buttonValue < (int)party._activeParty.size()) {
+			if (_buttonValue < (int)party._activeParty.size() && _buttonValue != charIndex) {
 				SWAP(party._activeParty[charIndex], party._activeParty[_buttonValue]);
 
 				charIndex = _buttonValue;


### PR DESCRIPTION
Don't try to exchange a character with themself...

Steps to reproduce:
- open the character panel
- press 'e' to exchange
- select the current character

→ trigger the assert in https://github.com/scummvm/scummvm/blob/master/engines/xeen/item.cpp#L138 because the source and destination array are the same.