### PR TITLE
GRAPHICS: fix off-by-one errors when drawing a rounded rectangle

### DIFF
--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -4140,9 +4140,9 @@ drawInteriorRoundedSquareAlg(int x1, int y1, int r, int w, int h, PixelType colo
 	rsq = r*r;
 
 	PixelType *ptr_tl = (PixelType *)Base::_activeSurface->getBasePtr(x1 + r, y1 + r);
-	PixelType *ptr_tr = (PixelType *)Base::_activeSurface->getBasePtr(x1 + w - r, y1 + r);
-	PixelType *ptr_bl = (PixelType *)Base::_activeSurface->getBasePtr(x1 + r, y1 + h - r);
-	PixelType *ptr_br = (PixelType *)Base::_activeSurface->getBasePtr(x1 + w - r, y1 + h - r);
+	PixelType *ptr_tr = (PixelType *)Base::_activeSurface->getBasePtr(x1 + w - 1 - r, y1 + r);
+	PixelType *ptr_bl = (PixelType *)Base::_activeSurface->getBasePtr(x1 + r, y1 + h - 1 - r);
+	PixelType *ptr_br = (PixelType *)Base::_activeSurface->getBasePtr(x1 + w - 1 - r, y1 + h - 1 - r);
 	PixelType *ptr_fill = (PixelType *)Base::_activeSurface->getBasePtr(x1, y1);
 
 	int short_h = h - 2 * r;
@@ -4214,7 +4214,7 @@ drawInteriorRoundedSquareAlg(int x1, int y1, int r, int w, int h, PixelType colo
 
 		ptr_fill += pitch * r;
 		while (short_h-- >= 0) {
-			colorFill<PixelType>(ptr_fill, ptr_fill + w + 1, color);
+			colorFill<PixelType>(ptr_fill, ptr_fill + w, color);
 			ptr_fill += pitch;
 		}
 	}


### PR DESCRIPTION
The code would create a rectangle of width+1 by weight+1, resulting in buffer overflows when drawing at the bottom limit of a surface.

The crash occurs when not using the builtin/classic theme, since 6850297c3838c9d527429920e585911aa91e8c05 (which adds 2 buttons at the bottom of the GUI):

```
==280335==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x1488d826e86c at pc 0x562c57f47f34 bp 0x7ffc65483590 sp 0x7ffc65483580
WRITE of size 2 at 0x1488d826e86c thread T0
    #0 0x562c57f47f33 in void Graphics::colorFill<unsigned short>(unsigned short*, unsigned short*, unsigned short) graphics/VectorRendererSpec.cpp:452
    #1 0x562c57f0da70 in Graphics::VectorRendererAA<unsigned short>::drawInteriorRoundedSquareAlg(int, int, int, int, int, unsigned short, Graphics::VectorRenderer::FillMode) graphics/VectorRendererSpec.cpp:4210
    #2 0x562c57f0895f in Graphics::VectorRendererAA<unsigned short>::drawRoundedSquareAlg(int, int, int, int, int, unsigned short, Graphics::VectorRenderer::FillMode) graphics/VectorRendererSpec.cpp:4248
    #3 0x562c57efed01 in Graphics::VectorRendererSpec<unsigned short>::drawRoundedSquare(int, int, int, int, int) graphics/VectorRendererSpec.cpp:1289
    #4 0x562c57ba8c94 in Graphics::VectorRenderer::drawCallback_ROUNDSQ(Common::Rect const&, Graphics::DrawStep const&) graphics/VectorRenderer.h:433
    #5 0x562c57ef66c0 in Graphics::VectorRenderer::drawStep(Common::Rect const&, Common::Rect const&, Graphics::DrawStep const&, unsigned int) graphics/VectorRenderer.cpp:59
    #6 0x562c57b62c95 in GUI::ThemeEngine::drawDD(GUI::DrawData, Common::Rect const&, unsigned int, bool) gui/ThemeEngine.cpp:953
    #7 0x562c57b63b23 in GUI::ThemeEngine::drawButton(Common::Rect const&, Common::U32String const&, GUI::ThemeEngine::State, unsigned short) gui/ThemeEngine.cpp:1012
    #8 0x562c57bbb1dc in GUI::PicButtonWidget::drawWidget() gui/widget.cpp:654
    #9 0x562c57bb36e6 in GUI::Widget::draw() gui/widget.cpp:139
    #10 0x562c57a98400 in GUI::Dialog::drawWidgets() gui/dialog.cpp:189
    #11 0x562c57a982a1 in GUI::Dialog::drawDialog(GUI::DrawLayer) gui/dialog.cpp:177
    #12 0x562c57aa0489 in GUI::GuiManager::redraw() gui/gui-manager.cpp:388
    #13 0x562c57aa0e19 in GUI::GuiManager::runLoop() gui/gui-manager.cpp:463
    #14 0x562c57aaec6e in GUI::LauncherDialog::run() gui/launcher.cpp:301
    #15 0x562c57ab7bad in GUI::LauncherChooser::runModal() gui/launcher.cpp:938
    #16 0x562c577f1b46 in launcherDialog base/main.cpp:107
    #17 0x562c577f86a9 in scummvm_main base/main.cpp:573
    #18 0x562c577edf28 in main backends/platform/sdl/posix/posix-main.cpp:45
    #19 0x148910f5cb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
    #20 0x562c5774724d in _start ([…]/scummvm+0x5df24d)

0x1488d826e86c is located 108 bytes to the right of 512000-byte region [0x1488d81f1800,0x1488d826e800)
allocated by thread T0 here:
    #0 0x148912c8f459 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x562c57ebcfd1 in Graphics::Surface::create(short, short, Graphics::PixelFormat const&) graphics/surface.cpp:76
    #2 0x562c57e9d1be in Graphics::ManagedSurface::create(short, short, Graphics::PixelFormat const&) graphics/managed_surface.cpp:153
    #3 0x562c57b5cbc0 in GUI::ThemeEngine::setGraphicsMode(GUI::ThemeEngine::GraphicsMode) gui/ThemeEngine.cpp:457
    #4 0x562c57b5b209 in GUI::ThemeEngine::init() gui/ThemeEngine.cpp:328
    #5 0x562c57a9f6fc in GUI::GuiManager::loadNewTheme(Common::String, GUI::ThemeEngine::GraphicsMode, bool) gui/gui-manager.cpp:291
    #6 0x562c57a9b957 in GUI::GuiManager::GuiManager() gui/gui-manager.cpp:98
    #7 0x562c577fa7e3 in Common::Singleton<GUI::GuiManager>::makeInstance() common/singleton.h:61
    #8 0x562c577fa424 in Common::Singleton<GUI::GuiManager>::instance() common/singleton.h:84
    #9 0x562c577f5cc7 in setupGraphics base/main.cpp:374
    #10 0x562c577f85d1 in scummvm_main base/main.cpp:532
    #11 0x562c577edf28 in main backends/platform/sdl/posix/posix-main.cpp:45
    #12 0x148910f5cb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)

SUMMARY: AddressSanitizer: heap-buffer-overflow graphics/VectorRendererSpec.cpp:452 in void Graphics::colorFill<unsigned short>(unsigned short*, unsigned short*, unsigned short)
Shadow bytes around the buggy address:
  0x02919b045cb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x02919b045cc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x02919b045cd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x02919b045ce0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x02919b045cf0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x02919b045d00: fa fa fa fa fa fa fa fa fa fa fa fa fa[fa]fa fa
  0x02919b045d10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x02919b045d20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x02919b045d30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x02919b045d40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x02919b045d50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==280335==ABORTING
```
