### PR TITLE
DIRECTOR: allocate more than 2 audio channels for earlier Director versions

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -752,7 +752,7 @@ void Score::playSoundChannel(uint16 frameId) {
 	}
 
 	// Channels above 2 are only usable by Lingo.
-	if (g_director->getVersion() >= 400) {
+	if (g_director->getVersion() >= 300) {
 		sound->playPuppetSound(3);
 		sound->playPuppetSound(4);
 	}

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -44,7 +44,7 @@ namespace Director {
 
 DirectorSound::DirectorSound(Window *window) : _window(window) {
 	uint numChannels = 2;
-	if (g_director->getVersion() >= 400) {
+	if (g_director->getVersion() >= 300) {
 		numChannels = 4;
 	}
 


### PR DESCRIPTION
I've found a Director 3 game that tries to play back audio on channel 3, which currently leads to an assertion failure - see #3539. I'm not entirely clear how it was determined that older Director versions had only two channels; looking at the commit history D4 was given 4 channels in 88d8577cb3a1634bd23ead85ccfec8375d293aed, but it's not really clear to me if it was determined for sure that pre-D4 should only have two channels.

cc @moralrecordings for thoughts, since you bumped the number of channels for D4.