### PR TITLE
DIRECTOR: patch henachoco03

### DIFF
--- a/engines/director/lingo/lingo-patcher.cpp
+++ b/engines/director/lingo/lingo-patcher.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include "common/punycode.h"
 #include "director/director.h"
 #include "director/cast.h"
 #include "director/movie.h"
@@ -193,7 +194,8 @@ Common::U32String LingoCompiler::patchLingoCode(const Common::U32String &line, L
 		}
 
 		// Now expensive ones
-		if (movie.compareToIgnoreCase(patch->movie) || strcmp(patch->gameId, g_director->getGameId())
+		U32String moviename = punycode_decode(patch->movie);
+		if (movie.compareToIgnoreCase(moviename) || strcmp(patch->gameId, g_director->getGameId())
 				|| (patch->extra && strcmp(patch->extra, g_director->getExtra()))) {
 			patch++;
 			continue;

--- a/engines/director/lingo/lingo-patcher.cpp
+++ b/engines/director/lingo/lingo-patcher.cpp
@@ -174,6 +174,12 @@ struct ScriptPatch {
 	{"snh", "", kPlatformWindows, "SNHstart", kMovieScript, 0, 0,
 			14, "set mytest3 = FileIO(mnew, \"read\" mymovie)", "set mytest3 = FileIO(mnew, \"read\", mymovie)"},
 
+	// Ambiguous syntax that's parsed differently between D3 and later versions
+	{"henachoco03", "", kPlatformMacintosh, "xn--oj7cxalkre7cjz1d2agc0e8b1cm", kMovieScript, 0, 0,
+			183, "locaobject(mLHizikaraHand (rhenka + 1),dotti)", "locaobject(mLHizikaraHand,(rhenka + 1),dotti)"},
+	{"henachoco03", "", kPlatformMacintosh, "xn--oj7cxalkre7cjz1d2agc0e8b1cm", kMovieScript, 0, 0,
+			196, "locaobject(mRHizikaraHand (rhenka + 1),dotti)", "locaobject(mRHizikaraHand,(rhenka + 1),dotti)"},
+
 	{nullptr, nullptr, kPlatformUnknown, nullptr, kNoneScript, 0, 0, 0, nullptr, nullptr}
 };
 


### PR DESCRIPTION
This adds a patch for Difficult Book Game (henachoco03) that fixes up a couple ambiguous lines that are being misparsed. From talking with djsrv, this is parsed differently between D3 and D4/later, and would be really difficult to handle properly.

I've also added the ability to handle Punycode filenames in patches.

This is one of three fixes needed to promote this game to fully working status.