### PR TITLE
SDL: Use SDL_SetWindowMouseRect to confine the mouse area

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -282,6 +282,10 @@ void SdlGraphicsManager::setSystemMousePosition(const int x, const int y) {
 	}
 }
 
+void SdlGraphicsManager::notifyActiveAreaChanged() {
+	_window->setMouseRect(_activeArea.drawRect);
+}
+
 void SdlGraphicsManager::handleResizeImpl(const int width, const int height) {
 	_forceRedraw = true;
 }

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -182,6 +182,8 @@ protected:
 
 	void setSystemMousePosition(const int x, const int y) override;
 
+	void notifyActiveAreaChanged() override;
+
 	void handleResizeImpl(const int width, const int height) override;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -63,6 +63,7 @@ public:
 		_activeArea.height = getOverlayHeight();
 		_overlayVisible = true;
 		_forceRedraw = true;
+		notifyActiveAreaChanged();
 	}
 
 	void hideOverlay() override {
@@ -74,6 +75,7 @@ public:
 		_activeArea.height = getHeight();
 		_overlayVisible = false;
 		_forceRedraw = true;
+		notifyActiveAreaChanged();
 	}
 
 	bool isOverlayVisible() const override { return _overlayVisible; }
@@ -211,6 +213,7 @@ protected:
 			_activeArea.width = getWidth();
 			_activeArea.height = getHeight();
 		}
+		notifyActiveAreaChanged();
 	}
 
 	/**
@@ -221,6 +224,11 @@ protected:
 	 * @param y Y coordinate in window coordinates.
 	 */
 	virtual void setSystemMousePosition(const int x, const int y) = 0;
+
+	/**
+	 * Called whenever the active area has changed.
+	 */
+	virtual void notifyActiveAreaChanged() {}
 
 	bool showMouse(bool visible) override {
 		if (_cursorVisible == visible) {

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -52,6 +52,11 @@ public:
 	void grabMouse(bool grab);
 
 	/**
+	 * Specify the area of the window to confine the mouse cursor.
+	 */
+	void setMouseRect(const Common::Rect &rect);
+
+	/**
 	 * Lock or unlock the mouse cursor within the window.
 	 */
 	bool lockMouse(bool lock);
@@ -124,6 +129,7 @@ public:
 private:
 	Common::Rect _desktopRes;
 	bool _inputGrabState, _inputLockState;
+	SDL_Rect grabRect;
 
 protected:
 	void getDisplayDpi(float *dpi, float *defaultDpi) const;


### PR DESCRIPTION
The latest version of SDL2 from git adds a new function to confine the mouse to the specified area of the screen. Currently, ScummVM confines the mouse position by warping the mouse manually when it's grabbed and a stretch mode that leaves empty space is enabled, but that doesn't work with Wayland. While I did initially encounter issues with this in the Fedora 35 + Plasma 3.22.5 VM that I set up for Wayland testing, it seems to have been resolved somehow.

See also: https://github.com/libsdl-org/SDL/issues/4822