### PR TITLE
NGI: Fix memory leak in PictureObject

### DIFF
--- a/engines/ngi/gfx.cpp
+++ b/engines/ngi/gfx.cpp
@@ -108,6 +108,10 @@ PictureObject::PictureObject(PictureObject *src) : GameObject(src) {
 	_objtype = kObjTypePictureObject;
 }
 
+PictureObject::~PictureObject() {
+	delete _picture;
+}
+
 bool PictureObject::load(MfcArchive &file, bool bigPicture) {
 	debugC(5, kDebugLoading, "PictureObject::load()");
 	GameObject::load(file);

--- a/engines/ngi/gfx.h
+++ b/engines/ngi/gfx.h
@@ -167,6 +167,7 @@ class GameObject : public CObject {
 class PictureObject : public GameObject {
 public:
 	PictureObject();
+	~PictureObject();
 
 	PictureObject(PictureObject *src);
 


### PR DESCRIPTION
The default destructor did not freed the picture data belonging
to the PictureObject instances, causing many memory leaks.

PR note: I controlled before and after with Valgrind.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
