### PR TITLE
GRAPHICS: Clean up OpenGL defines

### DIFF
--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -22,7 +22,7 @@
 
 #include "common/scummsys.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #include "backends/graphics3d/openglsdl/openglsdl-graphics3d.h"
 

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -27,7 +27,7 @@
 
 #include "math/rect2d.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 	class FrameBuffer;
@@ -194,6 +194,6 @@ protected:
 	TransactionMode _transactionMode;
 };
 
-#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #endif

--- a/configure
+++ b/configure
@@ -162,7 +162,7 @@ _fluidlite=auto
 _glew=auto
 _opengl_mode=auto
 _opengl_game=auto
-_opengl_game_classic=no
+_opengl_game_classic=auto
 _opengl_game_shaders=auto
 _opengl_game_es2=no
 _tinygl=yes
@@ -1170,6 +1170,7 @@ for ac_option in $@; do
 	--enable-glew)                _glew=yes              ;;
 	--disable-glew)               _glew=no               ;;
 	--disable-opengl-game)        _opengl_game=no        ;;
+	--disable-opengl-game-classic) _opengl_game_classic=no ;;
 	--disable-opengl-game-shaders) _opengl_game_shaders=no ;;
 	--force-opengl-game-es2)      _opengl_game_es2=yes   ;;
 	--enable-tinygl)              _tinygl=yes            ;;
@@ -5529,8 +5530,7 @@ EOF
 			if cc_check_no_clean $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS $lib
 				then
 				_opengl_game_es2=yes
-				append_var LIBS "$lib"
-				append_var LIBS_3D "$lib"
+				append_var OPENGL_LIBS "$lib"
 				break
 			fi
 		done
@@ -5556,7 +5556,9 @@ EOF
 		append_var INCLUDES "$OPENGL_CFLAGS"
 		append_var LIBS "$OPENGL_LIBS"
 		append_var LIBS_3D "$OPENGL_LIBS"
-		_opengl_game_classic=yes
+		if test "$_opengl_game_classic" = auto ; then
+			_opengl_game_classic=yes
+		fi
 		if test "$_opengl_game_shaders" = auto; then
 			_opengl_game_shaders=$_glew
 		fi
@@ -5564,7 +5566,16 @@ EOF
 			echo "WARNING: OpenGL Shader support requires GLEW!"
 			_opengl_game_shaders=no
 		fi
+	elif test "$_opengl_game_es2" = "yes" ; then
+		append_var INCLUDES "$OPENGL_CFLAGS"
+		append_var LIBS "$OPENGL_LIBS"
+		append_var LIBS_3D "$OPENGL_LIBS"
+		_opengl_game_classic=no
+		if test "$_opengl_game_shaders" = auto ; then
+			_opengl_game_shaders=yes
+		fi
 	else
+		_opengl_game_classic=no
 		_opengl_game_shaders=no
 	fi
 	cc_check_clean

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -24,7 +24,7 @@
 #include "common/system.h"
 #include "common/config-manager.h"
 
-#if defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 #include "graphics/surface.h"
 #include "graphics/pixelbuffer.h"

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -42,7 +42,7 @@
 #include "common/system.h"
 #include "common/textconsole.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/surface.h"
 #include "graphics/pixelbuffer.h"

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -42,7 +42,7 @@
 #include "graphics/pixelbuffer.h"
 #include "graphics/renderer.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 #include "graphics/opengl/context.h"
 #endif
 
@@ -272,7 +272,7 @@ GfxBase *GrimEngine::createRenderer(int screenW, int screenH) {
 		initGraphics(screenW, screenH, nullptr);
 	}
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	bool backendCapableOpenGL = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
 #endif
 
@@ -296,12 +296,12 @@ GfxBase *GrimEngine::createRenderer(int screenW, int screenH) {
 	}
 
 	GfxBase *renderer = nullptr;
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGLShaders) {
 		renderer = CreateGfxOpenGLShader();
 	}
 #endif
-#if defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGL) {
 		renderer = CreateGfxOpenGL();
 	}

--- a/engines/myst3/gfx.cpp
+++ b/engines/myst3/gfx.cpp
@@ -29,7 +29,7 @@
 #include "graphics/renderer.h"
 #include "graphics/surface.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 #include "graphics/opengl/context.h"
 #endif
 
@@ -209,7 +209,7 @@ Renderer *createRenderer(OSystem *system) {
 		initGraphics(width, height, nullptr);
 	}
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	bool backendCapableOpenGL = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
 #endif
 
@@ -225,12 +225,12 @@ Renderer *createRenderer(OSystem *system) {
 		warning("Unable to create a '%s' renderer", rendererConfig.c_str());
 	}
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGLShaders) {
 		return CreateGfxOpenGLShader(system);
 	}
 #endif
-#if defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGL) {
 		return CreateGfxOpenGL(system);
 	}

--- a/engines/myst3/gfx_opengl.cpp
+++ b/engines/myst3/gfx_opengl.cpp
@@ -23,7 +23,7 @@
 #include "common/rect.h"
 #include "common/textconsole.h"
 
-#if defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 #include "graphics/opengl/context.h"
 #include "graphics/surface.h"

--- a/engines/myst3/gfx_opengl_shaders.cpp
+++ b/engines/myst3/gfx_opengl_shaders.cpp
@@ -39,7 +39,7 @@
 #include "common/rect.h"
 #include "common/textconsole.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/surface.h"
 

--- a/engines/myst3/gfx_opengl_texture.cpp
+++ b/engines/myst3/gfx_opengl_texture.cpp
@@ -22,7 +22,7 @@
 
 #include "common/scummsys.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #include "engines/myst3/gfx_opengl_texture.h"
 

--- a/engines/playground3d/gfx.cpp
+++ b/engines/playground3d/gfx.cpp
@@ -29,7 +29,7 @@
 #include "graphics/renderer.h"
 #include "graphics/surface.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 #include "graphics/opengl/context.h"
 #endif
 
@@ -130,7 +130,7 @@ Renderer *createRenderer(OSystem *system) {
 		initGraphics(width, height, nullptr);
 	}
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	bool backendCapableOpenGL = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
 #endif
 
@@ -146,12 +146,12 @@ Renderer *createRenderer(OSystem *system) {
 		warning("Unable to create a '%s' renderer", rendererConfig.c_str());
 	}
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGLShaders) {
 		return CreateGfxOpenGLShader(system);
 	}
 #endif
-#if defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGL) {
 		return CreateGfxOpenGL(system);
 	}

--- a/engines/playground3d/gfx_opengl.cpp
+++ b/engines/playground3d/gfx_opengl.cpp
@@ -23,7 +23,7 @@
 #include "common/rect.h"
 #include "common/textconsole.h"
 
-#if defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 #include "graphics/opengl/context.h"
 #include "graphics/surface.h"

--- a/engines/playground3d/gfx_opengl_shaders.cpp
+++ b/engines/playground3d/gfx_opengl_shaders.cpp
@@ -23,7 +23,7 @@
 #include "common/rect.h"
 #include "common/textconsole.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/surface.h"
 

--- a/engines/stark/gfx/driver.cpp
+++ b/engines/stark/gfx/driver.cpp
@@ -30,7 +30,7 @@
 
 #include "graphics/renderer.h"
 #include "graphics/surface.h"
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 #include "graphics/opengl/context.h"
 #endif
 
@@ -46,14 +46,14 @@ Driver *Driver::create() {
 	Graphics::RendererType desiredRendererType = Graphics::parseRendererTypeCode(rendererConfig);
 	Graphics::RendererType matchingRendererType = Graphics::getBestMatchingAvailableRendererType(desiredRendererType);
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	bool softRenderer = matchingRendererType == Graphics::kRendererTypeTinyGL;
 	if (!softRenderer) {
 		initGraphics3d(kOriginalWidth, kOriginalHeight);
 	} else {
 #endif
 		initGraphics(kOriginalWidth, kOriginalHeight, nullptr);
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	}
 #endif
 
@@ -64,13 +64,13 @@ Driver *Driver::create() {
 
 	Driver *driver = nullptr;
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 	bool backendCapableOpenGLShaders = g_system->hasFeature(OSystem::kFeatureOpenGLForGame) && OpenGLContext.shadersSupported;
 	if (backendCapableOpenGLShaders && matchingRendererType == Graphics::kRendererTypeOpenGLShaders) {
 		driver = new OpenGLSDriver();
 	}
 #endif
-#if defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 	bool backendCapableOpenGL = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGL) {
 		driver = new OpenGLDriver();

--- a/engines/stark/gfx/opengls.cpp
+++ b/engines/stark/gfx/opengls.cpp
@@ -26,7 +26,7 @@
 
 #include "math/matrix4.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "engines/stark/gfx/openglsactor.h"
 #include "engines/stark/gfx/openglsprop.h"
@@ -238,4 +238,4 @@ Graphics::Surface *OpenGLSDriver::getViewportScreenshot() const {
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/stark/gfx/opengls.h
+++ b/engines/stark/gfx/opengls.h
@@ -25,7 +25,7 @@
 
 #include "common/system.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "engines/stark/gfx/driver.h"
 
@@ -88,6 +88,6 @@ private:
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 #endif // STARK_GFX_OPENGLS_H

--- a/engines/stark/gfx/openglsactor.cpp
+++ b/engines/stark/gfx/openglsactor.cpp
@@ -30,7 +30,7 @@
 #include "engines/stark/gfx/opengls.h"
 #include "engines/stark/gfx/texture.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 
@@ -429,4 +429,4 @@ bool OpenGLSActorRenderer::getSpotLightContribution(LightEntry *light,
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/stark/gfx/openglsactor.h
+++ b/engines/stark/gfx/openglsactor.h
@@ -31,7 +31,7 @@
 
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 	class ShaderGL;
@@ -77,6 +77,6 @@ protected:
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 #endif // STARK_GFX_OPENGL_S_ACTOR_H

--- a/engines/stark/gfx/openglsfade.cpp
+++ b/engines/stark/gfx/openglsfade.cpp
@@ -24,7 +24,7 @@
 
 #include "engines/stark/gfx/opengls.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 
@@ -55,4 +55,4 @@ void OpenGLSFadeRenderer::render(float fadeLevel) {
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/stark/gfx/openglsfade.h
+++ b/engines/stark/gfx/openglsfade.h
@@ -25,7 +25,7 @@
 
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "engines/stark/gfx/faderenderer.h"
 
@@ -57,6 +57,6 @@ private:
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 #endif // STARK_GFX_OPENGL_S_FADE_H

--- a/engines/stark/gfx/openglsprop.cpp
+++ b/engines/stark/gfx/openglsprop.cpp
@@ -28,7 +28,7 @@
 #include "engines/stark/scene.h"
 #include "engines/stark/services/services.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 
@@ -191,4 +191,4 @@ void OpenGLSPropRenderer::setLightArrayUniform(const LightEntryArray &lights) {
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/stark/gfx/openglsprop.h
+++ b/engines/stark/gfx/openglsprop.h
@@ -31,7 +31,7 @@
 
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 	class ShaderGL;
@@ -74,4 +74,4 @@ protected:
 
 #endif // STARK_GFX_OPENGL_S_RENDERED_H
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/stark/gfx/openglssurface.cpp
+++ b/engines/stark/gfx/openglssurface.cpp
@@ -25,7 +25,7 @@
 #include "engines/stark/gfx/opengls.h"
 #include "engines/stark/gfx/texture.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 
@@ -83,4 +83,4 @@ Math::Vector2d OpenGLSSurfaceRenderer::normalizeCurrentCoordinates(int x, int y)
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // if defined(USE_OPENGL_SHADERS)

--- a/engines/stark/gfx/openglssurface.h
+++ b/engines/stark/gfx/openglssurface.h
@@ -27,7 +27,7 @@
 
 #include "math/vector2d.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 class ShaderGL;
@@ -62,6 +62,6 @@ private:
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 #endif // STARK_GFX_OPENGL_S_SURFACE_H

--- a/engines/stark/gfx/opengltexture.cpp
+++ b/engines/stark/gfx/opengltexture.cpp
@@ -26,7 +26,7 @@
 
 #include "graphics/surface.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 namespace Stark {
 namespace Gfx {
@@ -130,4 +130,4 @@ void OpenGlTexture::addLevel(uint32 level, const Graphics::Surface *surface, con
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_OPENGL_GAME) || defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)

--- a/engines/stark/gfx/opengltexture.h
+++ b/engines/stark/gfx/opengltexture.h
@@ -27,7 +27,7 @@
 
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 namespace Stark {
 namespace Gfx {
@@ -57,6 +57,6 @@ protected:
 } // End of namespace Gfx
 } // End of namespace Stark
 
-#endif // defined(USE_OPENGL_GAME) || defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #endif // STARK_GFX_OPENGL_TEXTURE_H

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -84,7 +84,7 @@
 #ifdef ENABLE_WME3D
 #include "graphics/renderer.h"
 #include "engines/util.h"
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 #include "graphics/opengl/context.h"
 #endif
 #endif
@@ -514,7 +514,7 @@ bool BaseGame::initialize2() { // we know whether we are going to be accelerated
 		return STATUS_OK;
 	}
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	initGraphics3d(_settings->getResWidth(), _settings->getResHeight());
 	bool backendCapableOpenGL = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
 #endif
@@ -531,11 +531,11 @@ bool BaseGame::initialize2() { // we know whether we are going to be accelerated
 		warning("Unable to create a '%s' renderer", rendererConfig.c_str());
 	}
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGLShaders) {
 		_renderer3D = makeOpenGL3DShaderRenderer(this);
 	}
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 #if defined(USE_OPENGL_GAME)
 	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGL) {
 		_renderer3D = makeOpenGL3DRenderer(this);
@@ -546,7 +546,7 @@ bool BaseGame::initialize2() { // we know whether we are going to be accelerated
 		error("3D software renderered is not supported yet");
 	}
 	_renderer = _renderer3D;
-#if !defined(USE_OPENGL_GAME) && !defined(USE_OPENGL_SHADERS) && !defined(USE_GLES2)
+#if !defined(USE_OPENGL_GAME) && !defined(USE_OPENGL_SHADERS)
 	if (!_playing3DGame && !_renderer3D)
 		_renderer = makeOSystemRenderer(this);
 #endif

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -29,7 +29,7 @@
 #include "graphics/opengl/system_headers.h"
 #include "math/glmath.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 #include "engines/wintermute/base/gfx/opengl/base_render_opengl3d.h"
 #include "engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h"
@@ -435,7 +435,7 @@ bool BaseRenderOpenGL3D::initRenderer(int width, int height, bool windowed) {
 	// Reset it!
 #if defined(USE_OPENGL_SHADERS)
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 	return true;
 }
@@ -853,4 +853,4 @@ ShadowVolume *BaseRenderOpenGL3D::createShadowVolume() {
 
 } // namespace Wintermute
 
-#endif // defined(USE_OPENGL) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME)

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.h
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.h
@@ -31,7 +31,7 @@
 #include "math/matrix4.h"
 #include "math/ray.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 #include "graphics/opengl/system_headers.h"
 #include "graphics/opengl/texture.h"
@@ -154,6 +154,6 @@ private:
 
 } // wintermute namespace
 
-#endif // defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME)
 
 #endif

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -28,7 +28,7 @@
 #include "graphics/opengl/system_headers.h"
 #include "math/glmath.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h"
 #include "engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h"
@@ -842,4 +842,4 @@ ShadowVolume *BaseRenderOpenGL3DShader::createShadowVolume() {
 
 } // namespace Wintermute
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h
@@ -33,7 +33,7 @@
 #include "math/matrix4.h"
 #include "math/ray.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 
@@ -161,6 +161,6 @@ private:
 
 } // namespace Wintermute
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 #endif

--- a/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.cpp
@@ -25,7 +25,7 @@
 #include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/base/gfx/base_image.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #include "engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h"
 #include "engines/wintermute/base/gfx/opengl/base_render_opengl3d.h"
@@ -303,4 +303,4 @@ void BaseSurfaceOpenGL3D::setTexture() {
 
 } // End of namespace Wintermute
 
-#endif // defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)

--- a/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h
+++ b/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h
@@ -26,7 +26,7 @@
 #include "engines/wintermute/base/gfx/base_surface.h"
 #include "graphics/opengl/texture.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 namespace Wintermute {
 
@@ -82,6 +82,6 @@ private:
 
 } // End of namespace Wintermute
 
-#endif // defined(USE_OPENGL) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #endif

--- a/engines/wintermute/base/gfx/opengl/mesh3ds_opengl.cpp
+++ b/engines/wintermute/base/gfx/opengl/mesh3ds_opengl.cpp
@@ -23,7 +23,7 @@
 #include "engines/wintermute/wintypes.h"
 #include "graphics/opengl/system_headers.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 #include "engines/wintermute/base/gfx/opengl/mesh3ds_opengl.h"
 
@@ -51,4 +51,4 @@ void Mesh3DSOpenGL::render() {
 
 } // namespace Wintermute
 
-#endif // defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME)

--- a/engines/wintermute/base/gfx/opengl/mesh3ds_opengl.h
+++ b/engines/wintermute/base/gfx/opengl/mesh3ds_opengl.h
@@ -25,7 +25,7 @@
 
 #include "engines/wintermute/base/gfx/3ds/mesh3ds.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 namespace Wintermute {
 
@@ -39,6 +39,6 @@ public:
 
 } // namespace Wintermute
 
-#endif // defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME)
 
 #endif

--- a/engines/wintermute/base/gfx/opengl/mesh3ds_opengl_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/mesh3ds_opengl_shader.cpp
@@ -23,7 +23,7 @@
 #include "engines/wintermute/wintypes.h"
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "engines/wintermute/base/gfx/opengl/mesh3ds_opengl_shader.h"
 
@@ -70,4 +70,4 @@ void Mesh3DSOpenGLShader::render() {
 
 } // namespace Wintermute
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/wintermute/base/gfx/opengl/mesh3ds_opengl_shader.h
+++ b/engines/wintermute/base/gfx/opengl/mesh3ds_opengl_shader.h
@@ -25,7 +25,7 @@
 
 #include "engines/wintermute/base/gfx/3ds/mesh3ds.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 
@@ -46,6 +46,6 @@ private:
 
 } // namespace Wintermute
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 #endif

--- a/engines/wintermute/base/gfx/opengl/meshx_opengl.cpp
+++ b/engines/wintermute/base/gfx/opengl/meshx_opengl.cpp
@@ -29,7 +29,7 @@
 #include "engines/wintermute/base/gfx/x/material.h"
 #include "graphics/opengl/system_headers.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 #include "engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h"
 #include "engines/wintermute/base/gfx/opengl/meshx_opengl.h"
@@ -89,4 +89,4 @@ bool MeshXOpenGL::renderFlatShadowModel() {
 
 } // namespace Wintermute
 
-#endif // defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME)

--- a/engines/wintermute/base/gfx/opengl/meshx_opengl.h
+++ b/engines/wintermute/base/gfx/opengl/meshx_opengl.h
@@ -31,7 +31,7 @@
 
 #include "engines/wintermute/base/gfx/x/meshx.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 namespace Wintermute {
 
@@ -46,6 +46,6 @@ public:
 
 } // namespace Wintermute
 
-#endif // defined(USE_OPENGL) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME)
 
 #endif

--- a/engines/wintermute/base/gfx/opengl/meshx_opengl_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/meshx_opengl_shader.cpp
@@ -29,7 +29,7 @@
 #include "engines/wintermute/base/gfx/x/material.h"
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h"
 #include "engines/wintermute/base/gfx/opengl/meshx_opengl_shader.h"
@@ -135,4 +135,4 @@ bool MeshXOpenGLShader::update(FrameNode *parentFrame) {
 
 } // namespace Wintermute
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/wintermute/base/gfx/opengl/meshx_opengl_shader.h
+++ b/engines/wintermute/base/gfx/opengl/meshx_opengl_shader.h
@@ -31,7 +31,7 @@
 
 #include "engines/wintermute/base/gfx/x/meshx.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 
@@ -57,6 +57,6 @@ protected:
 
 } // namespace Wintermute
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 #endif

--- a/engines/wintermute/base/gfx/opengl/shadow_volume_opengl.cpp
+++ b/engines/wintermute/base/gfx/opengl/shadow_volume_opengl.cpp
@@ -30,7 +30,7 @@
 #include "engines/wintermute/dcgf.h"
 #include "graphics/opengl/system_headers.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 #include "engines/wintermute/base/gfx/opengl/base_render_opengl3d.h"
 #include "engines/wintermute/base/gfx/opengl/shadow_volume_opengl.h"
@@ -185,5 +185,5 @@ bool ShadowVolumeOpenGL::initMask() {
 
 } // namespace Wintermute
 
-#endif // defined(USE_OPENGL) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME)
 

--- a/engines/wintermute/base/gfx/opengl/shadow_volume_opengl.h
+++ b/engines/wintermute/base/gfx/opengl/shadow_volume_opengl.h
@@ -31,7 +31,7 @@
 
 #include "engines/wintermute/base/gfx/shadow_volume.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME)
 
 namespace Wintermute {
 
@@ -51,6 +51,6 @@ private:
 
 } // namespace Wintermute
 
-#endif // defined(USE_OPENGL_GAME) && !defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME)
 
 #endif

--- a/engines/wintermute/base/gfx/opengl/shadow_volume_opengl_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/shadow_volume_opengl_shader.cpp
@@ -30,7 +30,7 @@
 #include "engines/wintermute/dcgf.h"
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "engines/wintermute/base/gfx/opengl/base_render_opengl3d.h"
 #include "engines/wintermute/base/gfx/opengl/shadow_volume_opengl_shader.h"
@@ -204,4 +204,4 @@ bool ShadowVolumeOpenGLShader::initMask() {
 
 } // namespace Wintermute
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)

--- a/engines/wintermute/base/gfx/opengl/shadow_volume_opengl_shader.h
+++ b/engines/wintermute/base/gfx/opengl/shadow_volume_opengl_shader.h
@@ -32,7 +32,7 @@
 #include "engines/wintermute/base/gfx/shadow_volume.h"
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 
@@ -58,6 +58,6 @@ private:
 
 } // namespace Wintermute
 
-#endif // defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#endif // defined(USE_OPENGL_SHADERS)
 
 #endif

--- a/graphics/opengl/box_shaders.cpp
+++ b/graphics/opengl/box_shaders.cpp
@@ -22,7 +22,7 @@
 
 #include "common/scummsys.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 namespace BuiltinShaders {

--- a/graphics/opengl/compat_shaders.cpp
+++ b/graphics/opengl/compat_shaders.cpp
@@ -22,7 +22,7 @@
 
 #include "common/scummsys.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 namespace BuiltinShaders {

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -29,7 +29,7 @@
 
 #include "graphics/opengl/system_headers.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 namespace Common {
 DECLARE_SINGLETON(OpenGL::ContextGL);

--- a/graphics/opengl/control_shaders.cpp
+++ b/graphics/opengl/control_shaders.cpp
@@ -22,7 +22,7 @@
 
 #include "common/scummsys.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 namespace BuiltinShaders {

--- a/graphics/opengl/framebuffer.cpp
+++ b/graphics/opengl/framebuffer.cpp
@@ -23,7 +23,7 @@
 #include "common/textconsole.h"
 #include "common/util.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)) && !defined(AMIGAOS) && !defined(__MORPHOS__)
+#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(AMIGAOS) && !defined(__MORPHOS__)
 
 #if defined(SDL_BACKEND) && !defined(USE_GLEW) && !defined(USE_GLES2)
 #define GL_GLEXT_PROTOTYPES // For the GL_EXT_framebuffer_object extension

--- a/graphics/opengl/framebuffer.h
+++ b/graphics/opengl/framebuffer.h
@@ -26,7 +26,7 @@
 #include "graphics/opengl/system_headers.h"
 #include "graphics/opengl/texture.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 
@@ -75,6 +75,6 @@ private:
 
 } // End of namespace OpenGL
 
-#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #endif

--- a/graphics/opengl/shader.cpp
+++ b/graphics/opengl/shader.cpp
@@ -22,7 +22,7 @@
 
 #include "common/scummsys.h"
 
-#if defined(USE_GLES2) || defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/shader.h"
 

--- a/graphics/opengl/surfacerenderer.cpp
+++ b/graphics/opengl/surfacerenderer.cpp
@@ -22,27 +22,27 @@
 
 #include "common/scummsys.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/surfacerenderer.h"
 
 #include "graphics/opengl/context.h"
 #include "graphics/opengl/texture.h"
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 #include "graphics/opengl/shader.h"
 #endif
 
 namespace OpenGL {
 
 SurfaceRenderer *createBestSurfaceRenderer() {
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 	if (OpenGLContext.shadersSupported) {
 		return new ShaderSurfaceRenderer();
 	}
 #endif
 
-#ifndef USE_GLES2
+#if defined(USE_OPENGL_GAME)
 	return new FixedSurfaceRenderer();
 #else
 	error("Could not create an appropriate surface renderer for the current OpenGL context");
@@ -71,7 +71,7 @@ void SurfaceRenderer::enableAlphaBlending(bool enable) {
 	_alphaBlending = enable;
 }
 
-#ifndef USE_GLES2
+#if defined(USE_OPENGL_GAME)
 
 FixedSurfaceRenderer::~FixedSurfaceRenderer() {
 }
@@ -145,7 +145,7 @@ void FixedSurfaceRenderer::restorePreviousState() {
 
 #endif
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 ShaderSurfaceRenderer::ShaderSurfaceRenderer() {
 	const GLfloat vertices[] = {

--- a/graphics/opengl/surfacerenderer.h
+++ b/graphics/opengl/surfacerenderer.h
@@ -77,7 +77,7 @@ protected:
 	bool _alphaBlending;
 };
 
-#ifndef USE_GLES2
+#if defined(USE_OPENGL_GAME)
 
 class FixedSurfaceRenderer : public SurfaceRenderer {
 public:
@@ -91,7 +91,7 @@ public:
 
 #endif
 
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 
 class ShaderSurfaceRenderer : public SurfaceRenderer {
 public:

--- a/graphics/opengl/texture.cpp
+++ b/graphics/opengl/texture.cpp
@@ -22,7 +22,7 @@
 
 #include "common/textconsole.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/texture.h"
 #include "graphics/opengl/context.h"

--- a/graphics/opengl/texture.h
+++ b/graphics/opengl/texture.h
@@ -27,7 +27,7 @@
 
 #include "graphics/surface.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 namespace OpenGL {
 

--- a/graphics/opengl/tiledsurface.cpp
+++ b/graphics/opengl/tiledsurface.cpp
@@ -22,7 +22,7 @@
 
 #include "common/textconsole.h"
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #include "graphics/opengl/tiledsurface.h"
 


### PR DESCRIPTION
This is split out from PR #3463. With this PR, `USE_OPENGL_SHADERS` is defined in GLESv2 builds, and the `USE_GLES2` is just used for differences with desktop GL.