### PR TITLE
KYRA: Don't require the Mac version of Legend of Kyrandia to be installed

### DIFF
--- a/common/stuffit.cpp
+++ b/common/stuffit.cpp
@@ -43,6 +43,7 @@ public:
 	~StuffItArchive() override;
 
 	bool open(const Common::String &filename);
+	bool open(Common::SeekableReadStream *stream);
 	void close();
 	bool isOpen() const { return _stream != nullptr; }
 
@@ -90,9 +91,14 @@ static const uint32 s_magicNumbers[] = {
 };
 
 bool StuffItArchive::open(const Common::String &filename) {
+	Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember(filename);
+	return open(stream);
+}
+
+bool StuffItArchive::open(Common::SeekableReadStream *stream) {
 	close();
 
-	_stream = SearchMan.createReadStreamForMember(filename);
+	_stream = stream;
 
 	if (!_stream)
 		return false;
@@ -195,7 +201,8 @@ bool StuffItArchive::open(const Common::String &filename) {
 }
 
 void StuffItArchive::close() {
-	delete _stream; _stream = nullptr;
+	delete _stream;
+	_stream = nullptr;
 	_map.clear();
 }
 
@@ -530,6 +537,17 @@ Common::Archive *createStuffItArchive(const Common::String &fileName) {
 	StuffItArchive *archive = new StuffItArchive();
 
 	if (!archive->open(fileName)) {
+		delete archive;
+		return nullptr;
+	}
+
+	return archive;
+}
+
+Common::Archive *createStuffItArchive(Common::SeekableReadStream *stream) {
+	StuffItArchive *archive = new StuffItArchive();
+
+	if (!archive->open(stream)) {
 		delete archive;
 		return nullptr;
 	}

--- a/common/stuffit.h
+++ b/common/stuffit.h
@@ -25,6 +25,7 @@
  * StuffIt decompressor used in engines:
  * - grim
  * - groovie
+ * - kyra
  */
 
 #ifndef COMMON_STUFFIT_H
@@ -43,6 +44,7 @@ namespace Common {
 
 class Archive;
 class String;
+class SeekableReadStream;
 
 /**
  * This factory method creates an Archive instance corresponding to the content
@@ -51,6 +53,7 @@ class String;
  * May return 0 in case of a failure.
  */
 Archive *createStuffItArchive(const String &fileName);
+Archive *createStuffItArchive(SeekableReadStream *stream);
 
 /** @} */
 

--- a/engines/kyra/detection_tables.h
+++ b/engines/kyra/detection_tables.h
@@ -325,6 +325,19 @@ const KYRAGameDescription adGameDescs[] = {
 		KYRA1_FLOPPY_FLAGS
 	},
 
+	{
+		{
+			"kyra1",
+			"StuffIt",
+			AD_ENTRY1s("xn--Install Legend of Kyrandia-jf8p", "1d763e991c787431cac3786afbbdae72", 53899),
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_MACRESFORK,
+			GUIO3(GUIO_NOSPEECH, GUIO_MIDIGM, GUIO_RENDERVGA)
+		},
+		KYRA1_FLOPPY_CMP_FLAGS
+	},
+
 	{ // FM-TOWNS version
 		{
 			"kyra1",

--- a/engines/kyra/engine/util.cpp
+++ b/engines/kyra/engine/util.cpp
@@ -130,13 +130,12 @@ Common::String Util::findMacResourceFile(const char *baseName) {
 		Common::kISO8859_1
 	};
 
+	Common::MacResManager resource;
 	Common::String tryName(baseName);
 	Common::String fileName;
 
 	for (int i = 0; i < 2; ++i) {
 		for (int ii = 0; ii < ARRAYSIZE(tryCodePages); ++ii) {
-			Common::MacResManager resource;
-
 			Common::U32String fn(tryName, tryCodePages[ii]);
 			fileName = fn.encode(Common::kUtf8);
 			if (resource.exists(fileName))

--- a/engines/kyra/engine/util.cpp
+++ b/engines/kyra/engine/util.cpp
@@ -133,20 +133,19 @@ Common::String Util::findMacResourceFile(const char *baseName) {
 	Common::String tryName(baseName);
 	Common::String fileName;
 
-	for (int i = 0; i < ARRAYSIZE(tryCodePages); ++i) {
-		for (int ii = 0; ii < 2; ++ii) {
+	for (int i = 0; i < 2; ++i) {
+		for (int ii = 0; ii < ARRAYSIZE(tryCodePages); ++ii) {
 			Common::MacResManager resource;
 
-			Common::U32String fn(tryName, tryCodePages[i]);
+			Common::U32String fn(tryName, tryCodePages[ii]);
 			fileName = fn.encode(Common::kUtf8);
 			if (resource.exists(fileName))
 				return fileName;
 			fileName = Common::punycode_encodefilename(fn);
 			if (resource.exists(fileName))
 				return fileName;
-
-			tryName += "\xAA";
 		}
+		tryName += "\xAA";
 	}
 
 	fileName.clear();

--- a/engines/kyra/engine/util.h
+++ b/engines/kyra/engine/util.h
@@ -40,6 +40,8 @@ public:
 	static Common::String convertUTF8ToDOS(Common::String &str);
 	static Common::String convertISOToUTF8(Common::String &str);
 	static void convertISOToDOS(char &c);
+
+	static Common::String findMacResourceFile(const char *baseName);
 };
 
 } // End of namespace Kyra

--- a/engines/kyra/resource/resource.cpp
+++ b/engines/kyra/resource/resource.cpp
@@ -29,8 +29,11 @@
 
 namespace Kyra {
 
-Resource::Resource(KyraEngine_v1 *vm) : _archiveCache(), _files(), _archiveFiles(), _protectedFiles(), _loaders(), _vm(vm), _bigEndianPlatForm(vm->gameFlags().platform == Common::kPlatformAmiga || vm->gameFlags().platform == Common::kPlatformSegaCD) {
+Resource::Resource(KyraEngine_v1 *vm) : _archiveCache(), _files(), _archiveFiles(), _protectedFiles(), _macResMan(), _loaders(), _vm(vm), _bigEndianPlatForm(vm->gameFlags().platform == Common::kPlatformAmiga || vm->gameFlags().platform == Common::kPlatformSegaCD) {
 	initializeLoaders();
+
+	if (_vm->gameFlags().useInstallerPackage)
+		_macResMan = new Common::MacResManager();
 
 	// Initialize directories for playing from CD or with original
 	// directory structure
@@ -53,7 +56,7 @@ Resource::~Resource() {
 	for (ArchiveMap::iterator i = _archiveCache.begin(); i != _archiveCache.end(); ++i)
 		delete i->_value;
 	_archiveCache.clear();
-	_macResMan.close();
+	delete _macResMan;
 }
 
 bool Resource::reset() {

--- a/engines/kyra/resource/resource.cpp
+++ b/engines/kyra/resource/resource.cpp
@@ -54,6 +54,7 @@ Resource::~Resource() {
 	for (ArchiveMap::iterator i = _archiveCache.begin(); i != _archiveCache.end(); ++i)
 		delete i->_value;
 	_archiveCache.clear();
+	_macResMan.close();
 }
 
 bool Resource::reset() {
@@ -425,7 +426,7 @@ Common::Archive *Resource::loadStuffItArchive(const Common::String &file) {
 	if (cachedArchive != _archiveCache.end())
 		return cachedArchive->_value;
 
-	Common::Archive *archive = StuffItLoader::load(this, file);
+	Common::Archive *archive = StuffItLoader::load(this, file, _macResMan);
 	if (!archive)
 		return nullptr;
 

--- a/engines/kyra/resource/resource.cpp
+++ b/engines/kyra/resource/resource.cpp
@@ -20,12 +20,13 @@
  *
  */
 
+#include "kyra/engine/util.h"
 #include "kyra/resource/resource.h"
 #include "kyra/resource/resource_intern.h"
 
 #include "common/config-manager.h"
-#include "common/macresman.h"
-#include "common/punycode.h"
+//#include "common/macresman.h"
+//#include "common/punycode.h"
 #include "common/fs.h"
 
 namespace Kyra {
@@ -66,33 +67,7 @@ bool Resource::reset() {
 		error("invalid game path '%s'", dir.getPath().c_str());
 
 	if (_vm->game() == GI_KYRA1 && _vm->gameFlags().platform == Common::kPlatformMacintosh && _vm->gameFlags().useInstallerPackage) {
-		const char *const tryFileNames[] = {
-			"Install Legend of Kyrandia",
-			"Install Legend of Kyrandia\xaa"
-		};
-
-		const Common::CodePage tryCodePages[] = {
-			Common::kMacRoman,
-			Common::kISO8859_1
-		};
-
-		Common::MacResManager resource;
-		Common::String kyraInstaller;
-
-		for (int i = 0; i < ARRAYSIZE(tryCodePages); ++i) {
-			for (int ii = 0; ii < ARRAYSIZE(tryFileNames); ++ii) {
-				Common::U32String fn(tryFileNames[ii], tryCodePages[i]);
-				kyraInstaller = fn.encode(Common::kUtf8);
-				if (resource.exists(kyraInstaller))
-					break;
-				kyraInstaller = Common::punycode_encodefilename(fn);
-				if (resource.exists(kyraInstaller))
-					break;
-				kyraInstaller.clear();
-			}
-			if (!kyraInstaller.empty())
-				break;
-		}
+		Common::String kyraInstaller = Util::findMacResourceFile("Install Legend of Kyrandia");
 
 		if (kyraInstaller.empty()) {
 			error("Could not find Legend of Kyrandia installer file");

--- a/engines/kyra/resource/resource.cpp
+++ b/engines/kyra/resource/resource.cpp
@@ -97,7 +97,16 @@ bool Resource::reset() {
 			error("Could not find Legend of Kyrandia installer file");
 		}
 
-		_files.add("installer", loadStuffItArchive(kyraInstaller));
+		Common::Archive *archive = loadStuffItArchive(kyraInstaller);
+		_files.add("installer", archive, 0, false);
+
+		Common::ArchiveMemberList members;
+		archive->listMatchingMembers(members, "*.PAK");
+		for (Common::ArchiveMemberList::const_iterator it = members.begin(); it != members.end(); ++it) {
+			Common::String name = (*it)->getName();
+			Common::Archive *pak = loadArchive(name, *it);
+			_files.add(name, pak, 0, false);
+		}
 	} else if (_vm->game() == GI_KYRA1 || _vm->game() == GI_EOB1) {
 		// We only need kyra.dat for the demo.
 		if (_vm->gameFlags().isDemo && !_vm->gameFlags().isTalkie)

--- a/engines/kyra/resource/resource.cpp
+++ b/engines/kyra/resource/resource.cpp
@@ -30,7 +30,7 @@
 
 namespace Kyra {
 
-Resource::Resource(KyraEngine_v1 *vm) : _archiveCache(), _files(), _archiveFiles(), _protectedFiles(), _loaders(), _vm(vm), _bigEndianPlatForm(vm->gameFlags().platform == Common::kPlatformAmiga || vm->gameFlags().platform == Common::kPlatformSegaCD) {
+Resource::Resource(KyraEngine_v1 *vm) : _archiveCache(), _files(), _archiveFiles(), _protectedFiles(), _loaders(), _vm(vm), _bigEndianPlatForm(vm->gameFlags().platform == Common::kPlatformAmiga || vm->gameFlags().platform == Common::kPlatformSegaCD), _installerArchive() {
 	initializeLoaders();
 
 	// Initialize directories for playing from CD or with original
@@ -98,11 +98,14 @@ bool Resource::reset() {
 			error("Could not find Legend of Kyrandia installer file");
 		}
 
-		Common::Archive *archive = loadStuffItArchive(kyraInstaller);
-		_files.add("installer", archive, 0, false);
+		_installerArchive = loadStuffItArchive(kyraInstaller);
+		if (!_installerArchive)
+			error("Failed to load Legend of Kyrandia installer file");
+
+		_files.add("installer", _installerArchive, 0, false);
 
 		Common::ArchiveMemberList members;
-		archive->listMatchingMembers(members, "*.PAK");
+		_installerArchive->listMatchingMembers(members, "*.PAK");
 		for (Common::ArchiveMemberList::const_iterator it = members.begin(); it != members.end(); ++it) {
 			Common::String name = (*it)->getName();
 			Common::Archive *pak = loadArchive(name, *it);

--- a/engines/kyra/resource/resource.h
+++ b/engines/kyra/resource/resource.h
@@ -96,7 +96,7 @@ protected:
 	Common::SearchSet _archiveFiles;
 	Common::SearchSet _protectedFiles;
 
-	Common::MacResManager _macResMan;
+	Common::MacResManager *_macResMan;
 
 	Common::Archive *loadArchive(const Common::String &name, Common::ArchiveMemberPtr member);
 	Common::Archive *loadInstallerArchive(const Common::String &file, const Common::String &ext, const uint8 offset);

--- a/engines/kyra/resource/resource.h
+++ b/engines/kyra/resource/resource.h
@@ -30,6 +30,7 @@
 #include "common/list.h"
 #include "common/hash-str.h"
 #include "common/hashmap.h"
+#include "common/macresman.h"
 #include "common/stream.h"
 #include "common/ptr.h"
 #include "common/archive.h"
@@ -91,6 +92,8 @@ protected:
 	Common::SearchSet _files;
 	Common::SearchSet _archiveFiles;
 	Common::SearchSet _protectedFiles;
+
+	Common::MacResManager _macResMan;
 
 	Common::Archive *loadArchive(const Common::String &name, Common::ArchiveMemberPtr member);
 	Common::Archive *loadInstallerArchive(const Common::String &file, const Common::String &ext, const uint8 offset);

--- a/engines/kyra/resource/resource.h
+++ b/engines/kyra/resource/resource.h
@@ -85,6 +85,10 @@ public:
 	Common::SeekableReadStreamEndian *createEndianAwareReadStream(const Common::String &file, int endianness = kPlatformEndianness);
 
 	bool loadFileToBuf(const char *file, void *buf, uint32 maxSize);
+
+	// This is only used for the Mac Stuffit Installer
+	Common::Archive *getInstallerArchive() const { return _installerArchive; }
+
 protected:
 	typedef Common::HashMap<Common::String, Common::Archive *, Common::CaseSensitiveString_Hash, Common::CaseSensitiveString_EqualTo> ArchiveMap;
 	ArchiveMap _archiveCache;
@@ -105,6 +109,8 @@ protected:
 
 	typedef Common::List<Common::SharedPtr<ResArchiveLoader> > LoaderList;
 	LoaderList _loaders;
+
+	Common::Archive *_installerArchive;
 
 	const bool _bigEndianPlatForm;
 	KyraEngine_v1 *_vm;

--- a/engines/kyra/resource/resource.h
+++ b/engines/kyra/resource/resource.h
@@ -94,6 +94,7 @@ protected:
 
 	Common::Archive *loadArchive(const Common::String &name, Common::ArchiveMemberPtr member);
 	Common::Archive *loadInstallerArchive(const Common::String &file, const Common::String &ext, const uint8 offset);
+	Common::Archive *loadStuffItArchive(const Common::String &file);
 
 	bool loadProtectedFiles(const char *const * list);
 

--- a/engines/kyra/resource/resource.h
+++ b/engines/kyra/resource/resource.h
@@ -86,8 +86,7 @@ public:
 
 	bool loadFileToBuf(const char *file, void *buf, uint32 maxSize);
 
-	// This is only used for the Mac Stuffit Installer
-	Common::Archive *getInstallerArchive() const { return _installerArchive; }
+	Common::Archive *getCachedArchive(const Common::String &file) const;
 
 protected:
 	typedef Common::HashMap<Common::String, Common::Archive *, Common::CaseSensitiveString_Hash, Common::CaseSensitiveString_EqualTo> ArchiveMap;
@@ -109,8 +108,6 @@ protected:
 
 	typedef Common::List<Common::SharedPtr<ResArchiveLoader> > LoaderList;
 	LoaderList _loaders;
-
-	Common::Archive *_installerArchive;
 
 	const bool _bigEndianPlatForm;
 	KyraEngine_v1 *_vm;

--- a/engines/kyra/resource/resource_intern.cpp
+++ b/engines/kyra/resource/resource_intern.cpp
@@ -26,6 +26,8 @@
 #include "common/endian.h"
 #include "common/memstream.h"
 #include "common/substream.h"
+#include "common/macresman.h"
+#include "common/stuffit.h"
 
 namespace Kyra {
 
@@ -927,7 +929,7 @@ struct InsArchive {
 	uint32 totalSize;
 };
 
-} // end of anonymouse namespace
+} // end of anonymous namespace
 
 class CmpVocDecoder {
 public:
@@ -1196,6 +1198,20 @@ Common::Archive *InstallerLoader::load(Resource *owner, const Common::String &fi
 
 	archives.clear();
 	return new CachedArchive(fileList);
+}
+
+Common::Archive *StuffItLoader::load(Resource *owner, const Common::String &filename) {
+	Common::MacResManager resource;
+
+	if (resource.open(filename)) {
+		Common::SeekableReadStream *stream = resource.getDataFork();
+		if (stream) {
+			Common::Archive *archive = Common::createStuffItArchive(stream);
+			return archive;
+		}
+	}
+
+	error("StuffItLoader::load: Could not load %s", filename.c_str());
 }
 
 CmpVocDecoder::CmpVocDecoder() {

--- a/engines/kyra/resource/resource_intern.cpp
+++ b/engines/kyra/resource/resource_intern.cpp
@@ -1200,13 +1200,9 @@ Common::Archive *InstallerLoader::load(Resource *owner, const Common::String &fi
 	return new CachedArchive(fileList);
 }
 
-Common::Archive *StuffItLoader::load(Resource *owner, const Common::String &filename) {
-	// TODO: The resource manager has to be alive for the duration of the
-	//       game but there has to be a better way...
-	static Common::MacResManager resource;
-
-	if (resource.open(filename)) {
-		Common::SeekableReadStream *stream = resource.getDataFork();
+Common::Archive *StuffItLoader::load(Resource *owner, const Common::String &filename, Common::MacResManager &macResMan) {
+	if (macResMan.open(filename)) {
+		Common::SeekableReadStream *stream = macResMan.getDataFork();
 		if (stream) {
 			Common::Archive *archive = Common::createStuffItArchive(stream);
 			return archive;

--- a/engines/kyra/resource/resource_intern.cpp
+++ b/engines/kyra/resource/resource_intern.cpp
@@ -1200,9 +1200,9 @@ Common::Archive *InstallerLoader::load(Resource *owner, const Common::String &fi
 	return new CachedArchive(fileList);
 }
 
-Common::Archive *StuffItLoader::load(Resource *owner, const Common::String &filename, Common::MacResManager &macResMan) {
-	if (macResMan.open(filename)) {
-		Common::SeekableReadStream *stream = macResMan.getDataFork();
+Common::Archive *StuffItLoader::load(Resource *owner, const Common::String &filename, Common::MacResManager *macResMan) {
+	if (macResMan->open(filename)) {
+		Common::SeekableReadStream *stream = macResMan->getDataFork();
 		if (stream) {
 			Common::Archive *archive = Common::createStuffItArchive(stream);
 			return archive;

--- a/engines/kyra/resource/resource_intern.cpp
+++ b/engines/kyra/resource/resource_intern.cpp
@@ -1201,7 +1201,9 @@ Common::Archive *InstallerLoader::load(Resource *owner, const Common::String &fi
 }
 
 Common::Archive *StuffItLoader::load(Resource *owner, const Common::String &filename) {
-	Common::MacResManager resource;
+	// TODO: The resource manager has to be alive for the duration of the
+	//       game but there has to be a better way...
+	static Common::MacResManager resource;
 
 	if (resource.open(filename)) {
 		Common::SeekableReadStream *stream = resource.getDataFork();

--- a/engines/kyra/resource/resource_intern.h
+++ b/engines/kyra/resource/resource_intern.h
@@ -142,6 +142,11 @@ public:
 	static Common::Archive *load(Resource *owner, const Common::String &filename, const Common::String &extension, const uint8 offset);
 };
 
+class StuffItLoader {
+public:
+	static Common::Archive *load(Resource *owner, const Common::String &filename);
+};
+
 class EndianAwareStreamWrapper : public Common::SeekableReadStreamEndian {
 public:
 	EndianAwareStreamWrapper(Common::SeekableReadStream *stream, bool bigEndian, bool disposeAfterUse = true) : Common::SeekableReadStreamEndian(bigEndian), Common::ReadStreamEndian(bigEndian), _stream(stream), _dispose(disposeAfterUse) {}

--- a/engines/kyra/resource/resource_intern.h
+++ b/engines/kyra/resource/resource_intern.h
@@ -28,6 +28,7 @@
 #include "common/hashmap.h"
 #include "common/str.h"
 #include "common/list.h"
+#include "common/macresman.h"
 #include "common/stream.h"
 
 namespace Kyra {
@@ -144,7 +145,7 @@ public:
 
 class StuffItLoader {
 public:
-	static Common::Archive *load(Resource *owner, const Common::String &filename);
+	static Common::Archive *load(Resource *owner, const Common::String &filename, Common::MacResManager &macResMan);
 };
 
 class EndianAwareStreamWrapper : public Common::SeekableReadStreamEndian {

--- a/engines/kyra/resource/resource_intern.h
+++ b/engines/kyra/resource/resource_intern.h
@@ -145,7 +145,7 @@ public:
 
 class StuffItLoader {
 public:
-	static Common::Archive *load(Resource *owner, const Common::String &filename, Common::MacResManager &macResMan);
+	static Common::Archive *load(Resource *owner, const Common::String &filename, Common::MacResManager *macResMan);
 };
 
 class EndianAwareStreamWrapper : public Common::SeekableReadStreamEndian {

--- a/engines/kyra/sound/sound_mac_lok.cpp
+++ b/engines/kyra/sound/sound_mac_lok.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include "kyra/engine/util.h"
 #include "kyra/resource/resource.h"
 #include "kyra/sound/sound_intern.h"
 #include "kyra/sound/sound_mac_res.h"
@@ -27,7 +28,6 @@
 
 #include "common/config-manager.h"
 #include "common/macresman.h"
-#include "common/punycode.h"
 #include "common/stuffit.h"
 
 #include "audio/mixer.h"
@@ -54,37 +54,7 @@ bool SoundMacRes::init() {
 		return false;
 
 	if (!_stuffItArchive) {
-		// The original executable has a TM char as its last character
-		// (character 0xaa from Mac code page). Depending on the emulator or
-		// platform used to copy the file it might have been reencoded to
-		// something else. So I look for multiple versions, also for punycode
-		// encoded files and also for the case where the user might have just
-		// removed the last character by renaming the file.
-
-		const Common::CodePage tryCodePages[] = {
-			Common::kMacRoman,
-			Common::kISO8859_1
-		};
-
-		const char *const tryExeNames[] = {
-			"Legend of Kyrandia\xaa",
-			"Legend of Kyrandia"
-		};
-
-		for (int i = 0; i < ARRAYSIZE(tryCodePages); ++i) {
-			for (int ii = 0; ii < ARRAYSIZE(tryExeNames); ++ii) {
-				Common::U32String fn(tryExeNames[ii], tryCodePages[i]);
-				_kyraMacExe = fn.encode(Common::kUtf8);
-				if (_macRes->exists(_kyraMacExe))
-					break;
-				_kyraMacExe = Common::punycode_encodefilename(fn);
-				if (_macRes->exists(_kyraMacExe))
-					break;
-				_kyraMacExe.clear();
-			}
-			if (!_kyraMacExe.empty())
-				break;
-		}
+		_kyraMacExe = Util::findMacResourceFile("Legend of Kyrandia");
 
 		if (_kyraMacExe.empty()) {
 			warning("SoundMacRes::init(): Legend of Kyrandia resource fork not found");

--- a/engines/kyra/sound/sound_mac_lok.cpp
+++ b/engines/kyra/sound/sound_mac_lok.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include "kyra/resource/resource.h"
 #include "kyra/sound/sound_intern.h"
 #include "kyra/sound/sound_mac_res.h"
 #include "kyra/sound/drivers/halestorm.h"
@@ -38,17 +39,15 @@
 
 namespace Kyra {
 
-SoundMacRes::SoundMacRes(KyraEngine_v1 *vm) : _macInstallerRes(nullptr), _macRes(nullptr), _stuffItArchive(nullptr) {
+SoundMacRes::SoundMacRes(KyraEngine_v1 *vm) : _macRes(nullptr), _stuffItArchive(nullptr) {
 	_useInstaller = vm->gameFlags().useInstallerPackage;
 	_macRes = new Common::MacResManager();
 	if (_useInstaller)
-		_macInstallerRes = new Common::MacResManager();
+		_stuffItArchive = vm->resource()->getInstallerArchive();
 }
 
 SoundMacRes::~SoundMacRes() {
-	delete _stuffItArchive;
 	delete _macRes;
-	delete _macInstallerRes;
 }
 
 bool SoundMacRes::init() {
@@ -106,12 +105,6 @@ bool SoundMacRes::init() {
 		warning("SoundMacRes::init(): Legend of Kyrandia %s not found",
 			_useInstaller ? "installer" : "resource fork");
 		return false;
-	}
-
-	if (_useInstaller) {
-		_macInstallerRes->open(_kyraMacExe);
-		Common::SeekableReadStream *stream = _macInstallerRes->getDataFork();
-		_stuffItArchive = Common::createStuffItArchive(stream);
 	}
 
 	setQuality(true);

--- a/engines/kyra/sound/sound_mac_lok.cpp
+++ b/engines/kyra/sound/sound_mac_lok.cpp
@@ -41,8 +41,14 @@ namespace Kyra {
 
 SoundMacRes::SoundMacRes(KyraEngine_v1 *vm) : _macRes(nullptr), _stuffItArchive(nullptr) {
 	_macRes = new Common::MacResManager();
-	if (vm->gameFlags().useInstallerPackage)
-		_stuffItArchive = vm->resource()->getInstallerArchive();
+	if (vm->gameFlags().useInstallerPackage) {
+		Common::String str = Util::findMacResourceFile("Install Legend of Kyrandia");
+		if (str.empty())
+			error("SoundMacRes::SoundMacRes(): Could not find Legend of Kyrandia installer file");
+		_stuffItArchive = vm->resource()->getCachedArchive(str);
+		if (!_stuffItArchive)
+			error("SoundMacRes::SoundMacRes(): Failed to load Legend of Kyrandia installer file");
+	}
 }
 
 SoundMacRes::~SoundMacRes() {

--- a/engines/kyra/sound/sound_mac_res.h
+++ b/engines/kyra/sound/sound_mac_res.h
@@ -24,6 +24,7 @@
 #define KYRA_SOUND_MACRES_H
 
 namespace Common {
+	class Archive;
 	class MacResManager;
 	class String;
 	template<class T> class Array;
@@ -33,16 +34,19 @@ namespace Kyra {
 
 class SoundMacRes {
 public:
-	SoundMacRes();
+	SoundMacRes(KyraEngine_v1 *vm);
 	~SoundMacRes();
 	bool init();
 	void setQuality(bool hi);
 	Common::SeekableReadStream *getResource(uint16 id, uint32 type);
 
 private:
+	bool _useInstaller;
+	Common::MacResManager *_macInstallerRes;
 	Common::MacResManager *_macRes;
 	Common::String _kyraMacExe;
 	Common::Array<Common::String> _resFiles;
+	Common::Archive *_stuffItArchive;
 };
 
 } // End of namespace Kyra

--- a/engines/kyra/sound/sound_mac_res.h
+++ b/engines/kyra/sound/sound_mac_res.h
@@ -42,7 +42,6 @@ public:
 
 private:
 	bool _useInstaller;
-	Common::MacResManager *_macInstallerRes;
 	Common::MacResManager *_macRes;
 	Common::String _kyraMacExe;
 	Common::Array<Common::String> _resFiles;

--- a/engines/kyra/sound/sound_mac_res.h
+++ b/engines/kyra/sound/sound_mac_res.h
@@ -41,7 +41,6 @@ public:
 	Common::SeekableReadStream *getResource(uint16 id, uint32 type);
 
 private:
-	bool _useInstaller;
 	Common::MacResManager *_macRes;
 	Common::String _kyraMacExe;
 	Common::Array<Common::String> _resFiles;


### PR DESCRIPTION
The Macintosh version of The Legend of Kyrandia that I have is a non-talkie version distributed on CD. This version is supported now that arthxx added a music driver for it.

Annoyingly though, the game data files aren't unpacked on the CD. Instead, everything is inside a self-extracting StuffIt installer. This means that in order to play the game in ScummVM, you have to install the game (probably using a Mac emulator) and then copy the files from the emulated hard disk. Not the smooth kind of experience we want people to have.

This is my attempt at adding support for playing the game directly from the files on the CD, without having to go through the installation process. This is the first time I've worked with the Archive class, but hopefully I got it right.

Obviously it needs more testing. I've only tried it a little bit past the intro. But it appears to work.