### PR TITLE
DIRECTOR: add stub handler for some events

### DIFF
--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -266,6 +266,14 @@ void Movie::queueEvent(Common::Queue<LingoEvent> &queue, LEvent event, int targe
 			queueMovieEvent(queue, event, eventId);
 			break;
 
+		// no-op; only handled by the primary event handler above
+		// empty case avoids them generating logs from the default
+		// unhandled event case below.
+		case kEventKeyUp:
+		case kEventKeyDown:
+		case kEventTimeout:
+			break;
+
 		default:
 			warning("registerEvent: Unhandled event %s", _lingo->_eventHandlerTypes[event]);
 		}


### PR DESCRIPTION
These events are handled by the primary handler above, and in D2/D3 they don't have other handlers. However, not being handled at all in the switch statement means it's falling through to the default case below and printing spurious "unhandled event" logs.