### PR TITLE
BASE: Allow search of shaders in extra

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -271,7 +271,7 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 	// Add extrapath (if any) to the directory search list
 	if (ConfMan.hasKey("extrapath")) {
 		dir = Common::FSNode(ConfMan.get("extrapath"));
-		SearchMan.addDirectory(dir.getPath(), dir);
+		SearchMan.addDirectory(dir.getPath(), dir, 0, 2);
 	}
 
 	// If a second extrapath is specified on the app domain level, add that as well.
@@ -282,7 +282,7 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 		Common::String extraPath = ConfMan.get("extrapath", Common::ConfigManager::kApplicationDomain);
 		if (!SearchMan.hasArchive(extraPath)) {
 			dir = Common::FSNode(extraPath);
-			SearchMan.addDirectory(dir.getPath(), dir);
+			SearchMan.addDirectory(dir.getPath(), dir, 0, 2);
 		}
 	}
 


### PR DESCRIPTION
Shaders are searched using a 'shaders' subdirectory.
When adding the extra path, if we don't specify a depth of 2 the shaders
can never been found.
