### PR TITLE
GRAPHICS: Split ScalerPluginObject into two classes

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -67,6 +67,7 @@ public:
 	virtual uint getDefaultScaleFactor() const { return 1; }
 	virtual bool setScaler(uint mode, int factor) { return false; }
 	virtual uint getScaler() const { return 0; }
+	virtual uint getScaleFactor() const { return 1; }
 
 #ifdef USE_RGB_COLOR
 	virtual Graphics::PixelFormat getScreenFormat() const = 0;

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -319,7 +319,7 @@ bool OpenGLGraphicsManager::setScaler(uint mode, int factor) {
 	else if (_scalerPlugins[mode]->get<ScalerPluginObject>().hasFactor(_oldState.scaleFactor))
 		newFactor = _oldState.scaleFactor;
 	else
-		newFactor = _scalerPlugins[mode]->get<ScalerPluginObject>().getFactor();
+		newFactor = _scalerPlugins[mode]->get<ScalerPluginObject>().getDefaultFactor();
 
 	_currentState.scalerIndex = mode;
 	_currentState.scaleFactor = newFactor;
@@ -329,6 +329,10 @@ bool OpenGLGraphicsManager::setScaler(uint mode, int factor) {
 
 uint OpenGLGraphicsManager::getScaler() const {
 	return _currentState.scalerIndex;
+}
+
+uint OpenGLGraphicsManager::getScaleFactor() const {
+	return _currentState.scaleFactor;
 }
 #endif
 
@@ -445,8 +449,6 @@ OSystem::TransactionError OpenGLGraphicsManager::endGFXTransaction() {
 	} while (_transactionMode == kTransactionRollback);
 
 	if (setupNewGameScreen) {
-		if (_gameScreen)
-			_gameScreen->unloadScaler();
 		delete _gameScreen;
 		_gameScreen = nullptr;
 

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -84,6 +84,7 @@ public:
 	uint getDefaultScaleFactor() const override;
 	bool setScaler(uint mode, int factor) override;
 	uint getScaler() const override;
+	uint getScaleFactor() const override;
 #endif
 
 	void beginGFXTransaction() override;

--- a/backends/graphics/opengl/texture.h
+++ b/backends/graphics/opengl/texture.h
@@ -30,7 +30,7 @@
 
 #include "common/rect.h"
 
-class ScalerPluginObject;
+class Scaler;
 
 namespace OpenGL {
 
@@ -232,7 +232,6 @@ public:
 	virtual void setPalette(uint start, uint colors, const byte *palData) {}
 
 	virtual void setScaler(uint scalerIndex, int scaleFactor) {}
-	virtual void unloadScaler() {}
 
 	/**
 	 * Update underlying OpenGL texture to reflect current state.
@@ -362,10 +361,10 @@ public:
 	virtual void updateGLTexture();
 
 	virtual void setScaler(uint scalerIndex, int scaleFactor);
-	virtual void unloadScaler();
 protected:
 	Graphics::Surface *_convData;
-	ScalerPluginObject *_scalerPlugin;
+	Scaler *_scaler;
+	uint _scalerIndex;
 	uint _extraPixels;
 	uint _scaleFactor;
 };

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -136,7 +136,7 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 	_enableFocusRectDebugCode(false), _enableFocusRect(false), _focusRect(),
 #endif
 	_transactionMode(kTransactionNone),
-	_scalerPlugins(ScalerMan.getPlugins()),
+	_scalerPlugins(ScalerMan.getPlugins()), _scalerPlugin(nullptr), _scaler(nullptr),
 	_needRestoreAfterOverlay(false) {
 
 	// allocate palette storage
@@ -157,7 +157,7 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 	_videoMode.aspectRatioCorrection = false;
 #endif
 
-	_scalerPlugin = nullptr;
+	_scaler = nullptr;
 	_maxExtraPixels = ScalerMan.getMaxExtraPixels();
 
 	_videoMode.fullscreen = ConfMan.getBool("fullscreen");
@@ -172,6 +172,7 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 
 SurfaceSdlGraphicsManager::~SurfaceSdlGraphicsManager() {
 	unloadGFXMode();
+	delete _scaler;
 	if (_mouseOrigSurface) {
 		SDL_FreeSurface(_mouseOrigSurface);
 		if (_mouseOrigSurface == _mouseSurface) {
@@ -592,7 +593,7 @@ bool SurfaceSdlGraphicsManager::setScaler(uint mode, int factor) {
 	else if (_scalerPlugins[mode]->get<ScalerPluginObject>().hasFactor(_oldVideoMode.scaleFactor))
 		newFactor = _oldVideoMode.scaleFactor;
 	else
-		newFactor = _scalerPlugins[mode]->get<ScalerPluginObject>().getFactor();
+		newFactor = _scalerPlugins[mode]->get<ScalerPluginObject>().getDefaultFactor();
 
 	if (_oldVideoMode.setup && _oldVideoMode.scaleFactor != newFactor)
 		_transactionDetails.needHotswap = true;
@@ -619,19 +620,18 @@ void SurfaceSdlGraphicsManager::setGraphicsModeIntern() {
 #endif
 		) {
 		Graphics::PixelFormat format = convertSDLPixelFormat(_hwScreen->format);
-		if (_scalerPlugin)
-			_scalerPlugin->deinitialize();
+		delete _scaler;
 
 		_scalerPlugin = &_scalerPlugins[_videoMode.scalerIndex]->get<ScalerPluginObject>();
-		_scalerPlugin->initialize(format);
+		_scaler = _scalerPlugin->createInstance(format);
 	}
 
-	_scalerPlugin->setFactor(_videoMode.scaleFactor);
+	_scaler->setFactor(_videoMode.scaleFactor);
 	_extraPixels = _scalerPlugin->extraPixels();
 	_useOldSrc = _scalerPlugin->useOldSource();
 	if (_useOldSrc) {
-		_scalerPlugin->enableSource(true);
-		_scalerPlugin->setSource((byte *)_tmpscreen->pixels, _tmpscreen->pitch,
+		_scaler->enableSource(true);
+		_scaler->setSource((byte *)_tmpscreen->pixels, _tmpscreen->pitch,
 									_videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
 	}
 
@@ -646,6 +646,11 @@ void SurfaceSdlGraphicsManager::setGraphicsModeIntern() {
 uint SurfaceSdlGraphicsManager::getScaler() const {
 	assert(_transactionMode == kTransactionNone);
 	return _videoMode.scalerIndex;
+}
+
+uint SurfaceSdlGraphicsManager::getScaleFactor() const {
+	assert(_transactionMode == kTransactionNone);
+	return _videoMode.scaleFactor;
 }
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -931,7 +936,7 @@ bool SurfaceSdlGraphicsManager::loadGFXMode() {
 
 	if (_useOldSrc) {
 		// Create surface containing previous frame's data to pass to scaler
-		_scalerPlugin->setSource((byte *)_tmpscreen->pixels, _tmpscreen->pitch,
+		_scaler->setSource((byte *)_tmpscreen->pixels, _tmpscreen->pitch,
 									_videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
 	}
 
@@ -1135,11 +1140,11 @@ void SurfaceSdlGraphicsManager::internUpdateScreen() {
 		if (_needRestoreAfterOverlay) {
 			// This is needed for the Edge scaler which seems to be the only scaler to use the "_useOldSrc" feature.
 			// Otherwise the screen will not be properly restored after removing the overlay. We need to trigger a
-			// regeneration of SourceScaler::_bufferedOutput. The call to _scalerPlugin->setFactor() down below could
+			// regeneration of SourceScaler::_bufferedOutput. The call to _scaler->setFactor() down below could
 			// do that in theory, but it won't unless the factor actually changes (which it doesn't). Now, the code
 			// in SourceScaler::setSource() looks a bit fishy, e. g. the *src argument isn't even used. But otherwise
 			// it does what we want here at least...
-			_scalerPlugin->setSource(nullptr, _tmpscreen->pitch, _videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
+			_scaler->setSource(nullptr, _tmpscreen->pitch, _videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
 		}
 
 		origSurf = _screen;
@@ -1154,7 +1159,7 @@ void SurfaceSdlGraphicsManager::internUpdateScreen() {
 		width = _videoMode.overlayWidth;
 		height = _videoMode.overlayHeight;
 		scale1 = 1;
-		oldScaleFactor = _scalerPlugin->setFactor(1);
+		oldScaleFactor = _scaler->setFactor(1);
 		_needRestoreAfterOverlay = _useOldSrc;
 	}
 
@@ -1228,7 +1233,7 @@ void SurfaceSdlGraphicsManager::internUpdateScreen() {
 				if (_videoMode.aspectRatioCorrection && !_overlayVisible)
 					dst_y = real2Aspect(dst_y);
 
-				_scalerPlugin->scale((byte *)srcSurf->pixels + (r->x + _maxExtraPixels) * 2 + (r->y + _maxExtraPixels) * srcPitch, srcPitch,
+				_scaler->scale((byte *)srcSurf->pixels + (r->x + _maxExtraPixels) * 2 + (r->y + _maxExtraPixels) * srcPitch, srcPitch,
 					(byte *)_hwScreen->pixels + dst_x * 2 + dst_y * dstPitch, dstPitch, r->w, dst_h, r->x, r->y);
 			}
 
@@ -1344,7 +1349,7 @@ void SurfaceSdlGraphicsManager::internUpdateScreen() {
 	}
 
 	// Set up the old scale factor
-	_scalerPlugin->setFactor(oldScaleFactor);
+	_scaler->setFactor(oldScaleFactor);
 
 	_numDirtyRects = 0;
 	_forceRedraw = false;
@@ -1703,7 +1708,7 @@ void SurfaceSdlGraphicsManager::clearOverlay() {
 	SDL_LockSurface(_tmpscreen);
 	SDL_LockSurface(_overlayscreen);
 
-	_scalerPlugin->scale((byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * 2, _tmpscreen->pitch,
+	_scaler->scale((byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * 2, _tmpscreen->pitch,
 	(byte *)_overlayscreen->pixels, _overlayscreen->pitch, _videoMode.screenWidth, _videoMode.screenHeight, 0, 0);
 
 #ifdef USE_ASPECT
@@ -2073,7 +2078,7 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 		// HACK: AdvMame4x requires a height of at least 4 pixels, so we
 		// fall back on the Normal scaler when a smaller cursor is supplied.
 		if (_scalerPlugin->canDrawCursor() && (uint)_mouseCurState.h >= _extraPixels) {
-			_scalerPlugin->scale(
+			_scaler->scale(
 					(byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * _mouseOrigSurface->format->BytesPerPixel,
 					_mouseOrigSurface->pitch, (byte *)_mouseSurface->pixels, _mouseSurface->pitch,
 					_mouseCurState.w, _mouseCurState.h, 0, 0);
@@ -2416,7 +2421,7 @@ void SurfaceSdlGraphicsManager::handleScalerHotkeys(uint mode, int factor) {
 			"%S %s%d\n%d x %d -> %d x %d",
 			_("Active graphics filter:").c_str(),
 			newScalerName,
-			_scalerPlugin->getFactor(),
+			_scaler->getFactor(),
 			_videoMode.screenWidth, _videoMode.screenHeight,
 			_hwScreen->w, _hwScreen->h);
 		displayMessageOnOSD(message);
@@ -2511,11 +2516,11 @@ bool SurfaceSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 #endif
 
 	case kActionIncreaseScaleFactor:
-		handleScalerHotkeys(_videoMode.scalerIndex, _scalerPlugin->increaseFactor());
+		handleScalerHotkeys(_videoMode.scalerIndex, _scaler->increaseFactor());
 		return true;
 
 	case kActionDecreaseScaleFactor:
-		handleScalerHotkeys(_videoMode.scalerIndex, _scalerPlugin->decreaseFactor());
+		handleScalerHotkeys(_videoMode.scalerIndex, _scaler->decreaseFactor());
 		return true;
 
 	case kActionNextScaleFilter: {
@@ -2524,7 +2529,7 @@ bool SurfaceSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 			scalerIndex = 0;
 		}
 
-		handleScalerHotkeys(scalerIndex, _scalerPlugins[scalerIndex]->get<ScalerPluginObject>().getFactor());
+		handleScalerHotkeys(scalerIndex, _scaler->getFactor());
 		return true;
 	}
 
@@ -2535,7 +2540,7 @@ bool SurfaceSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 		}
 		scalerIndex--;
 
-		handleScalerHotkeys(scalerIndex, _scalerPlugins[scalerIndex]->get<ScalerPluginObject>().getFactor());
+		handleScalerHotkeys(scalerIndex, _scaler->getFactor());
 		return true;
 	}
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -77,6 +77,7 @@ public:
 	uint getDefaultScaleFactor() const override;
 	bool setScaler(uint mode, int factor) override;
 	uint getScaler() const override;
+	uint getScaleFactor() const override;
 #ifdef USE_RGB_COLOR
 	Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
 	Common::List<Graphics::PixelFormat> getSupportedFormats() const override;
@@ -326,6 +327,7 @@ protected:
 
 	const PluginList &_scalerPlugins;
 	ScalerPluginObject *_scalerPlugin;
+	Scaler *_scaler;
 	uint _maxExtraPixels;
 	uint _extraPixels;
 

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -123,6 +123,10 @@ uint ModularGraphicsBackend::getScaler() const {
 	return _graphicsManager->getScaler();
 }
 
+uint ModularGraphicsBackend::getScaleFactor() const {
+	return _graphicsManager->getScaleFactor();
+}
+
 #ifdef USE_RGB_COLOR
 
 Graphics::PixelFormat ModularGraphicsBackend::getScreenFormat() const {

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -81,6 +81,7 @@ public:
 	using BaseBackend::setScaler;
 	bool setScaler(uint mode, int factor) override final;
 	uint getScaler() const override final;
+	uint getScaleFactor() const override final;
 #ifdef USE_RGB_COLOR
 	Graphics::PixelFormat getScreenFormat() const override final;
 	Common::List<Graphics::PixelFormat> getSupportedFormats() const override final;

--- a/common/system.h
+++ b/common/system.h
@@ -908,11 +908,18 @@ public:
 	virtual bool setScaler(const char *name, int factor) { return false; }
 
 	/**
-	 * Determine which stretch mode is currently active.
+	 * Determine which scaler is currently active.
 	 *
 	 * @return ID of the active stretch mode.
 	 */
 	virtual uint getScaler() const { return 0; }
+
+	/**
+	 * Determine which scale factor is currently active.
+	 *
+	 * @return The active scale factor.
+	 */
+	virtual uint getScaleFactor() const { return 1; }
 
 
 	/**

--- a/graphics/scaler/dotmatrix.cpp
+++ b/graphics/scaler/dotmatrix.cpp
@@ -22,13 +22,8 @@
 #include "graphics/scaler/dotmatrix.h"
 #include "graphics/scaler.h"
 
-DotMatrixPlugin::DotMatrixPlugin() {
+DotMatrixScaler::DotMatrixScaler(const Graphics::PixelFormat &format) : Scaler(format) {
 	_factor = 2;
-	_factors.push_back(2);
-}
-
-void DotMatrixPlugin::initialize(const Graphics::PixelFormat &format) {
-	ScalerPluginObject::initialize(format);
 
 	if (format.bytesPerPixel == 2) {
 		uint16 *lookup16 = (uint16 *)lookup;
@@ -53,7 +48,7 @@ void DotMatrixPlugin::initialize(const Graphics::PixelFormat &format) {
 	}
 }
 
-void DotMatrixPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void DotMatrixScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
 		scaleIntern<uint16>(srcPtr, srcPitch, dstPtr, dstPitch, width, height, x, y);
@@ -62,20 +57,12 @@ void DotMatrixPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 	}
 }
 
-uint DotMatrixPlugin::increaseFactor() {
+uint DotMatrixScaler::increaseFactor() {
 	return _factor;
 }
 
-uint DotMatrixPlugin::decreaseFactor() {
+uint DotMatrixScaler::decreaseFactor() {
 	return _factor;
-}
-
-const char *DotMatrixPlugin::getName() const {
-	return "dotmatrix";
-}
-
-const char *DotMatrixPlugin::getPrettyName() const {
-	return "DotMatrix";
 }
 
 template<typename Pixel>
@@ -84,7 +71,7 @@ static inline Pixel DOT(const Pixel *dotmatrix, Pixel c, int j, int i) {
 }
 
 template<typename Pixel>
-void DotMatrixPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch,
+void DotMatrixScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch,
 					int width, int height, int x, int y) {
 
 	const Pixel *dotmatrix = (Pixel *)lookup;
@@ -109,6 +96,35 @@ void DotMatrixPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch, uint8 *d
 		p += nextlineSrc;
 		q += nextlineDst << 1;
 	}
+}
+
+
+class DotMatrixPlugin final : public ScalerPluginObject {
+public:
+	DotMatrixPlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return false; }
+	uint extraPixels() const override { return 0; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+DotMatrixPlugin::DotMatrixPlugin() {
+	_factors.push_back(2);
+}
+
+Scaler *DotMatrixPlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new DotMatrixScaler(format);
+}
+
+const char *DotMatrixPlugin::getName() const {
+	return "dotmatrix";
+}
+
+const char *DotMatrixPlugin::getPrettyName() const {
+	return "DotMatrix";
 }
 
 REGISTER_PLUGIN_STATIC(DOTMATRIX, PLUGIN_TYPE_SCALER, DotMatrixPlugin);

--- a/graphics/scaler/dotmatrix.h
+++ b/graphics/scaler/dotmatrix.h
@@ -24,16 +24,11 @@
 
 #include "graphics/scalerplugin.h"
 
-class DotMatrixPlugin : public ScalerPluginObject {
+class DotMatrixScaler : public Scaler {
 public:
-	DotMatrixPlugin();
-	void initialize(const Graphics::PixelFormat &format) override;
+	DotMatrixScaler(const Graphics::PixelFormat &format);
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return false; }
-	uint extraPixels() const override { return 0; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
 protected:
 	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;

--- a/graphics/scaler/edge.cpp
+++ b/graphics/scaler/edge.cpp
@@ -307,7 +307,7 @@ uint16 convertTo16Bit(const typename ColorMask::PixelType p) {
 
 
 template<typename ColorMask>
-int16 *EdgePlugin::chooseGreyscale(typename ColorMask::PixelType *pixels) {
+int16 *EdgeScaler::chooseGreyscale(typename ColorMask::PixelType *pixels) {
 	int i, j;
 	int32 scores[3];
 
@@ -379,7 +379,7 @@ int16 *EdgePlugin::chooseGreyscale(typename ColorMask::PixelType *pixels) {
 
 
 template<typename ColorMask>
-int32 EdgePlugin::calcPixelDiffNosqrt(typename ColorMask::PixelType pixel1, typename ColorMask::PixelType pixel2) {
+int32 EdgeScaler::calcPixelDiffNosqrt(typename ColorMask::PixelType pixel1, typename ColorMask::PixelType pixel2) {
 	pixel1 = convertTo16Bit<ColorMask>(pixel1);
 	pixel2 = convertTo16Bit<ColorMask>(pixel2);
 
@@ -452,7 +452,7 @@ int32 EdgePlugin::calcPixelDiffNosqrt(typename ColorMask::PixelType pixel1, type
 }
 
 
-int EdgePlugin::findPrincipleAxis(int16 *diffs, int16 *bplane,
+int EdgeScaler::findPrincipleAxis(int16 *diffs, int16 *bplane,
 								  int8 *sim,
 								  int32 *return_angle) {
 	struct xy_point {
@@ -677,7 +677,7 @@ int EdgePlugin::findPrincipleAxis(int16 *diffs, int16 *bplane,
 
 
 template<typename Pixel>
-int EdgePlugin::checkArrows(int best_dir, Pixel *pixels, int8 *sim, int half_flag) {
+int EdgeScaler::checkArrows(int best_dir, Pixel *pixels, int8 *sim, int half_flag) {
 	Pixel center = pixels[4];
 
 	if (center == pixels[0] && center == pixels[2] &&
@@ -784,7 +784,7 @@ int EdgePlugin::checkArrows(int best_dir, Pixel *pixels, int8 *sim, int half_fla
 
 
 template<typename Pixel>
-int EdgePlugin::refineDirection(char edge_type, Pixel *pixels, int16 *bptr,
+int EdgeScaler::refineDirection(char edge_type, Pixel *pixels, int16 *bptr,
 								int8 *sim, double angle) {
 	int32 sums_dir[9] = { 0 };
 	int32 sum;
@@ -1625,7 +1625,7 @@ int EdgePlugin::refineDirection(char edge_type, Pixel *pixels, int16 *bptr,
 
 
 template<typename Pixel>
-int EdgePlugin::fixKnights(int sub_type, Pixel *pixels, int8 *sim) {
+int EdgeScaler::fixKnights(int sub_type, Pixel *pixels, int8 *sim) {
 	Pixel center = pixels[4];
 	int dir = sub_type;
 	int n = 0;
@@ -1772,7 +1772,7 @@ int EdgePlugin::fixKnights(int sub_type, Pixel *pixels, int8 *sim) {
 #define greenMask   0x07E0
 
 template<typename ColorMask>
-void EdgePlugin::antiAliasGridClean3x(uint8 *dptr, int dstPitch,
+void EdgeScaler::antiAliasGridClean3x(uint8 *dptr, int dstPitch,
 		typename ColorMask::PixelType *pixels, int sub_type, int16 *bptr) {
 	typedef typename ColorMask::PixelType Pixel;
 
@@ -2373,7 +2373,7 @@ void EdgePlugin::antiAliasGridClean3x(uint8 *dptr, int dstPitch,
 
 
 template<typename ColorMask>
-void EdgePlugin::antiAliasGrid2x(uint8 *dptr, int dstPitch,
+void EdgeScaler::antiAliasGrid2x(uint8 *dptr, int dstPitch,
 									typename ColorMask::PixelType *pixels, int sub_type, int16 *bptr,
 									int8 *sim,
 									int interpolate_2x) {
@@ -3309,7 +3309,7 @@ void drawUnchangedGrid2x(byte *dptr, int dstPitch,
 
 
 template<typename ColorMask>
-void EdgePlugin::antiAliasPass3x(const uint8 *src, uint8 *dst,
+void EdgeScaler::antiAliasPass3x(const uint8 *src, uint8 *dst,
 								 int w, int h,
 								 int srcPitch, int dstPitch,
 								 bool haveOldSrc,
@@ -3393,7 +3393,7 @@ void EdgePlugin::antiAliasPass3x(const uint8 *src, uint8 *dst,
 
 
 template<typename ColorMask>
-void EdgePlugin::antiAliasPass2x(const uint8 *src, uint8 *dst,
+void EdgeScaler::antiAliasPass2x(const uint8 *src, uint8 *dst,
 								 int w, int h,
 								 int srcPitch, int dstPitch,
 								 int interpolate_2x,
@@ -3478,7 +3478,7 @@ void EdgePlugin::antiAliasPass2x(const uint8 *src, uint8 *dst,
 }
 
 
-void EdgePlugin::initTables(const uint8 *srcPtr, uint32 srcPitch,
+void EdgeScaler::initTables(const uint8 *srcPtr, uint32 srcPitch,
 							int width, int height) {
 	double r_float, g_float, b_float;
 	int r, g, b;
@@ -3531,19 +3531,14 @@ void EdgePlugin::initTables(const uint8 *srcPtr, uint32 srcPitch,
 	}
 }
 
-EdgePlugin::EdgePlugin() : SourceScaler() {
+EdgeScaler::EdgeScaler(const Graphics::PixelFormat &format) : SourceScaler(format) {
 	_factor = 2;
-	_factors.push_back(2);
-	_factors.push_back(3);
-}
 
-void EdgePlugin::initialize(const Graphics::PixelFormat &format) {
-	SourceScaler::initialize(format);
 	initTables(0, 0, 0, 0);
 }
 
 #if 0
-void EdgePlugin::scale(const uint8 *srcPtr, uint32 srcPitch,
+void EdgeScaler::scale(const uint8 *srcPtr, uint32 srcPitch,
 					   uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
 		if (_factor == 2) {
@@ -3573,7 +3568,7 @@ void EdgePlugin::scale(const uint8 *srcPtr, uint32 srcPitch,
 }
 #endif
 
-void EdgePlugin::internScale(const uint8 *srcPtr, uint32 srcPitch,
+void EdgeScaler::internScale(const uint8 *srcPtr, uint32 srcPitch,
 					   uint8 *dstPtr, uint32 dstPitch, const uint8 *oldSrcPtr, uint32 oldSrcPitch, int width, int height, const uint8 *buffer, uint32 bufferPitch) {
 	bool enable = oldSrcPtr != NULL;
 	if (_format.bytesPerPixel == 2) {
@@ -3603,16 +3598,39 @@ void EdgePlugin::internScale(const uint8 *srcPtr, uint32 srcPitch,
 	}
 }
 
-uint EdgePlugin::increaseFactor() {
+uint EdgeScaler::increaseFactor() {
 	if (_factor == 2)
 		setFactor(_factor + 1);
 	return _factor;
 }
 
-uint EdgePlugin::decreaseFactor() {
+uint EdgeScaler::decreaseFactor() {
 	if (_factor == 3)
 		setFactor(_factor - 1);
 	return _factor;
+}
+
+
+class EdgePlugin final : public ScalerPluginObject {
+public:
+	EdgePlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return false; }
+	bool useOldSource() const override { return true; }
+	uint extraPixels() const override { return 1; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+EdgePlugin::EdgePlugin() {
+	_factors.push_back(2);
+	_factors.push_back(3);
+}
+
+Scaler *EdgePlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new EdgeScaler(format);
 }
 
 const char *EdgePlugin::getName() const {

--- a/graphics/scaler/edge.h
+++ b/graphics/scaler/edge.h
@@ -24,18 +24,12 @@
 
 #include "graphics/scalerplugin.h"
 
-class EdgePlugin : public SourceScaler {
+class EdgeScaler : public SourceScaler {
 public:
 
-	EdgePlugin();
-	void initialize(const Graphics::PixelFormat &format) override;
+	EdgeScaler(const Graphics::PixelFormat &format);
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return false; }
-	bool useOldSource() const override { return true; }
-	uint extraPixels() const override { return 1; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
 
 protected:
 

--- a/graphics/scaler/hq.cpp
+++ b/graphics/scaler/hq.cpp
@@ -4988,14 +4988,8 @@ static void HQ3x_implementation(const uint8 *srcPtr, uint32 srcPitch, uint8 *dst
 	}
 }
 
-HQPlugin::HQPlugin() {
+HQScaler::HQScaler(const Graphics::PixelFormat &format) : Scaler(format) {
 	_factor = 2;
-	_factors.push_back(2);
-	_factors.push_back(3);
-}
-
-void HQPlugin::initialize(const Graphics::PixelFormat &format) {
-	ScalerPluginObject::initialize(format);
 
 	if (format.bytesPerPixel == 2) {
 		InitLUT(format);
@@ -5008,12 +5002,12 @@ void HQPlugin::initialize(const Graphics::PixelFormat &format) {
 	}
 }
 
-void HQPlugin::deinitialize() {
+HQScaler::~HQScaler() {
 	free(RGBtoYUV);
 	RGBtoYUV = 0;
 }
 
-void HQPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void HQScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
 		switch (_factor) {
@@ -5065,16 +5059,38 @@ void HQPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 	}
 }
 
-uint HQPlugin::increaseFactor() {
+uint HQScaler::increaseFactor() {
 	if (_factor < 3)
 		setFactor(_factor + 1);
 	return _factor;
 }
 
-uint HQPlugin::decreaseFactor() {
+uint HQScaler::decreaseFactor() {
 	if (_factor > 2)
 		setFactor(_factor - 1);
 	return _factor;
+}
+
+
+class HQPlugin final : public ScalerPluginObject {
+public:
+	HQPlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return false; }
+	uint extraPixels() const override { return 1; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+HQPlugin::HQPlugin() {
+	_factors.push_back(2);
+	_factors.push_back(3);
+}
+
+Scaler *HQPlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new HQScaler(format);
 }
 
 const char *HQPlugin::getName() const {

--- a/graphics/scaler/hq.h
+++ b/graphics/scaler/hq.h
@@ -24,17 +24,12 @@
 
 #include "graphics/scalerplugin.h"
 
-class HQPlugin : public ScalerPluginObject {
+class HQScaler : public Scaler {
 public:
-	HQPlugin();
-	void initialize(const Graphics::PixelFormat &format) override;
-	void deinitialize() override;
+	HQScaler(const Graphics::PixelFormat &format);
+	~HQScaler();
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return false; }
-	uint extraPixels() const override { return 1; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
 protected:
 	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;

--- a/graphics/scaler/normal.cpp
+++ b/graphics/scaler/normal.cpp
@@ -21,17 +21,6 @@
 
 #include "graphics/scaler/normal.h"
 
-NormalPlugin::NormalPlugin() {
-	_factor = 1;
-	_factors.push_back(1);
-#ifdef USE_SCALERS
-	_factors.push_back(2);
-	_factors.push_back(3);
-	_factors.push_back(4);
-	_factors.push_back(5);
-#endif
-}
-
 #ifdef USE_SCALERS
 
 /**
@@ -217,7 +206,7 @@ void Normal5x(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPit
 }
 #endif
 
-void NormalPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void NormalScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 #ifdef USE_SCALERS
 	if (_format.bytesPerPixel == 2) {
@@ -259,7 +248,7 @@ void NormalPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 #endif
 }
 
-uint NormalPlugin::increaseFactor() {
+uint NormalScaler::increaseFactor() {
 #ifdef USE_SCALERS
 	if (_factor < 5)
 		setFactor(_factor + 1);
@@ -267,12 +256,39 @@ uint NormalPlugin::increaseFactor() {
 	return _factor;
 }
 
-uint NormalPlugin::decreaseFactor() {
+uint NormalScaler::decreaseFactor() {
 #ifdef USE_SCALERS
 	if (_factor > 1)
 		setFactor(_factor - 1);
 #endif
 	return _factor;
+}
+
+
+class NormalPlugin final : public ScalerPluginObject {
+public:
+	NormalPlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return true; }
+	uint extraPixels() const override { return 0; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+NormalPlugin::NormalPlugin() {
+	_factors.push_back(1);
+#ifdef USE_SCALERS
+	_factors.push_back(2);
+	_factors.push_back(3);
+	_factors.push_back(4);
+	_factors.push_back(5);
+#endif
+}
+
+Scaler *NormalPlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new NormalScaler(format);
 }
 
 const char *NormalPlugin::getName() const {

--- a/graphics/scaler/normal.h
+++ b/graphics/scaler/normal.h
@@ -24,15 +24,11 @@
 
 #include "graphics/scalerplugin.h"
 
-class NormalPlugin : public ScalerPluginObject {
+class NormalScaler : public Scaler {
 public:
-	NormalPlugin();
+	NormalScaler(const Graphics::PixelFormat &format) : Scaler(format) { _factor = 1; }
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return true; }
-	uint extraPixels() const override { return 0; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
 protected:
 	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;

--- a/graphics/scaler/pm.cpp
+++ b/graphics/scaler/pm.cpp
@@ -186,13 +186,7 @@ void scaleIntern(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dst
 
 }
 
-
-PMPlugin::PMPlugin() {
-	_factor = 2;
-	_factors.push_back(2);
-}
-
-void PMPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void PMScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
 		if (_format.gLoss == 2)
@@ -207,12 +201,34 @@ void PMPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 	}
 }
 
-uint PMPlugin::increaseFactor() {
+uint PMScaler::increaseFactor() {
 	return _factor;
 }
 
-uint PMPlugin::decreaseFactor() {
+uint PMScaler::decreaseFactor() {
 	return _factor;
+}
+
+
+class PMPlugin final : public ScalerPluginObject {
+public:
+	PMPlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return false; }
+	uint extraPixels() const override { return 1; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+
+PMPlugin::PMPlugin() {
+	_factors.push_back(2);
+}
+
+Scaler *PMPlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new PMScaler(format);
 }
 
 const char *PMPlugin::getName() const {

--- a/graphics/scaler/pm.h
+++ b/graphics/scaler/pm.h
@@ -24,17 +24,14 @@
 
 #include "graphics/scalerplugin.h"
 
-class PMPlugin : public ScalerPluginObject {
+class PMScaler : public Scaler {
 public:
-	PMPlugin();
-	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
-							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;
+	PMScaler(const Graphics::PixelFormat &format) : Scaler(format) { _factor = 2; }
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return false; }
-	uint extraPixels() const override { return 1; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
+protected:
+	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;
 };
 
 #endif

--- a/graphics/scaler/sai.cpp
+++ b/graphics/scaler/sai.cpp
@@ -392,12 +392,7 @@ void _2xSaITemplate(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 
 
 // SAI
 
-SAIPlugin::SAIPlugin() {
-	_factor = 2;
-	_factors.push_back(2);
-}
-
-void SAIPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void SAIScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
 		if (_format.gLoss == 2)
@@ -412,12 +407,33 @@ void SAIPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 	}
 }
 
-uint SAIPlugin::increaseFactor() {
+uint SAIScaler::increaseFactor() {
 	return _factor;
 }
 
-uint SAIPlugin::decreaseFactor() {
+uint SAIScaler::decreaseFactor() {
 	return _factor;
+}
+
+
+class SAIPlugin final : public ScalerPluginObject {
+public:
+	SAIPlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return false; }
+	uint extraPixels() const override { return 2; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+SAIPlugin::SAIPlugin() {
+	_factors.push_back(2);
+}
+
+Scaler *SAIPlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new SAIScaler(format);
 }
 
 const char *SAIPlugin::getName() const {
@@ -432,13 +448,7 @@ REGISTER_PLUGIN_STATIC(SAI, PLUGIN_TYPE_SCALER, SAIPlugin);
 
 // SuperSAI
 
-SuperSAIPlugin::SuperSAIPlugin() {
-	_factor = 2;
-	_factors.push_back(2);
-}
-
-
-void SuperSAIPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void SuperSAIScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
 		if (_format.gLoss == 2)
@@ -453,12 +463,33 @@ void SuperSAIPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 	}
 }
 
-uint SuperSAIPlugin::increaseFactor() {
+uint SuperSAIScaler::increaseFactor() {
 	return _factor;
 }
 
-uint SuperSAIPlugin::decreaseFactor() {
+uint SuperSAIScaler::decreaseFactor() {
 	return _factor;
+}
+
+
+class SuperSAIPlugin final : public ScalerPluginObject {
+public:
+	SuperSAIPlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return false; }
+	uint extraPixels() const override { return 2; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+SuperSAIPlugin::SuperSAIPlugin() {
+	_factors.push_back(2);
+}
+
+Scaler *SuperSAIPlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new SuperSAIScaler(format);
 }
 
 const char *SuperSAIPlugin::getName() const {
@@ -473,12 +504,7 @@ REGISTER_PLUGIN_STATIC(SUPERSAI, PLUGIN_TYPE_SCALER, SuperSAIPlugin);
 
 // SuperEagle
 
-SuperEaglePlugin::SuperEaglePlugin() {
-	_factor = 2;
-	_factors.push_back(2);
-}
-
-void SuperEaglePlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void SuperEagleScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
 		if (_format.gLoss == 2)
@@ -493,12 +519,33 @@ void SuperEaglePlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 	}
 }
 
-uint SuperEaglePlugin::increaseFactor() {
+uint SuperEagleScaler::increaseFactor() {
 	return _factor;
 }
 
-uint SuperEaglePlugin::decreaseFactor() {
+uint SuperEagleScaler::decreaseFactor() {
 	return _factor;
+}
+
+
+class SuperEaglePlugin final : public ScalerPluginObject {
+public:
+	SuperEaglePlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return false; }
+	uint extraPixels() const override { return 2; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+SuperEaglePlugin::SuperEaglePlugin() {
+	_factors.push_back(2);
+}
+
+Scaler *SuperEaglePlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new SuperEagleScaler(format);
 }
 
 const char *SuperEaglePlugin::getName() const {

--- a/graphics/scaler/sai.h
+++ b/graphics/scaler/sai.h
@@ -24,43 +24,31 @@
 
 #include "graphics/scalerplugin.h"
 
-class SAIPlugin : public ScalerPluginObject {
+class SAIScaler : public Scaler {
 public:
-	SAIPlugin();
+	SAIScaler(const Graphics::PixelFormat &format) : Scaler(format) { _factor = 2; }
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return false; }
-	uint extraPixels() const override { return 2; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
 protected:
 	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;
 };
 
-class SuperSAIPlugin : public ScalerPluginObject {
+class SuperSAIScaler : public Scaler {
 public:
-	SuperSAIPlugin();
+	SuperSAIScaler(const Graphics::PixelFormat &format) : Scaler(format) { _factor = 2; }
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return false; }
-	uint extraPixels() const override { return 2; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
 protected:
 	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;
 };
 
-class SuperEaglePlugin : public ScalerPluginObject {
+class SuperEagleScaler : public Scaler {
 public:
-	SuperEaglePlugin();
+	SuperEagleScaler(const Graphics::PixelFormat &format) : Scaler(format) { _factor = 2; }
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return false; }
-	uint extraPixels() const override { return 2; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
 protected:
 	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;

--- a/graphics/scaler/scalebit.cpp
+++ b/graphics/scaler/scalebit.cpp
@@ -352,14 +352,7 @@ void scale(unsigned scale, void* void_dst, unsigned dst_slice, const void* void_
 	}
 }
 
-AdvMamePlugin::AdvMamePlugin() {
-	_factor = 2;
-	_factors.push_back(2);
-	_factors.push_back(3);
-	_factors.push_back(4);
-}
-
-void AdvMamePlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void AdvMameScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_factor != 4)
 		::scale(_factor, dstPtr, dstPitch, srcPtr - srcPitch, srcPitch, _format.bytesPerPixel, width, height);
@@ -367,16 +360,39 @@ void AdvMamePlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 		::scale(_factor, dstPtr, dstPitch, srcPtr - srcPitch * 2, srcPitch, _format.bytesPerPixel, width, height);
 }
 
-uint AdvMamePlugin::increaseFactor() {
+uint AdvMameScaler::increaseFactor() {
 	if (_factor < 4)
 		setFactor(_factor + 1);
 	return _factor;
 }
 
-uint AdvMamePlugin::decreaseFactor() {
+uint AdvMameScaler::decreaseFactor() {
 	if (_factor > 2)
 		setFactor(_factor - 1);
 	return _factor;
+}
+
+
+class AdvMamePlugin final : public ScalerPluginObject {
+public:
+	AdvMamePlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return true; }
+	uint extraPixels() const override { return 4; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+AdvMamePlugin::AdvMamePlugin() {
+	_factors.push_back(2);
+	_factors.push_back(3);
+	_factors.push_back(4);
+}
+
+Scaler *AdvMamePlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new AdvMameScaler(format);
 }
 
 const char *AdvMamePlugin::getName() const {

--- a/graphics/scaler/scalebit.h
+++ b/graphics/scaler/scalebit.h
@@ -41,17 +41,14 @@
 int scale_precondition(unsigned scale, unsigned pixel, unsigned width, unsigned height);
 void scale(unsigned scale, void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height);
 
-class AdvMamePlugin : public ScalerPluginObject {
+class AdvMameScaler : public Scaler {
 public:
-	AdvMamePlugin();
-	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
-							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;
+	AdvMameScaler(const Graphics::PixelFormat &format) : Scaler(format) { _factor = 2; }
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return true; }
-	uint extraPixels() const override { return 4; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
+protected:
+	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;
 };
 
 #endif

--- a/graphics/scaler/tv.cpp
+++ b/graphics/scaler/tv.cpp
@@ -23,12 +23,7 @@
 #include "graphics/scaler.h"
 #include "graphics/colormasks.h"
 
-TVPlugin::TVPlugin() {
-	_factor = 2;
-	_factors.push_back(2);
-}
-
-void TVPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
+void TVScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
 		if (_format.gLoss == 2)
@@ -44,24 +39,16 @@ void TVPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 
 }
 
-uint TVPlugin::increaseFactor() {
+uint TVScaler::increaseFactor() {
 	return _factor;
 }
 
-uint TVPlugin::decreaseFactor() {
+uint TVScaler::decreaseFactor() {
 	return _factor;
-}
-
-const char *TVPlugin::getName() const {
-	return "tv";
-}
-
-const char *TVPlugin::getPrettyName() const {
-	return "TV";
 }
 
 template<typename ColorMask>
-void TVPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch,
+void TVScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch,
 					int width, int height) {
 	typedef typename ColorMask::PixelType Pixel;
 
@@ -92,6 +79,35 @@ void TVPlugin::scaleIntern(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, 
 		p += nextlineSrc;
 		q += nextlineDst << 1;
 	}
+}
+
+
+class TVPlugin final : public ScalerPluginObject {
+public:
+	TVPlugin();
+
+	Scaler *createInstance(const Graphics::PixelFormat &format) const override;
+
+	bool canDrawCursor() const override { return false; }
+	uint extraPixels() const override { return 0; }
+	const char *getName() const override;
+	const char *getPrettyName() const override;
+};
+
+TVPlugin::TVPlugin() {
+	_factors.push_back(2);
+}
+
+Scaler *TVPlugin::createInstance(const Graphics::PixelFormat &format) const {
+	return new TVScaler(format);
+}
+
+const char *TVPlugin::getName() const {
+	return "tv";
+}
+
+const char *TVPlugin::getPrettyName() const {
+	return "TV";
 }
 
 REGISTER_PLUGIN_STATIC(TV, PLUGIN_TYPE_SCALER, TVPlugin);

--- a/graphics/scaler/tv.h
+++ b/graphics/scaler/tv.h
@@ -24,15 +24,11 @@
 
 #include "graphics/scalerplugin.h"
 
-class TVPlugin : public ScalerPluginObject {
+class TVScaler : public Scaler {
 public:
-	TVPlugin();
+	TVScaler(const Graphics::PixelFormat &format) : Scaler(format) { _factor = 2; }
 	uint increaseFactor() override;
 	uint decreaseFactor() override;
-	bool canDrawCursor() const override { return false; }
-	uint extraPixels() const override { return 0; }
-	const char *getName() const override;
-	const char *getPrettyName() const override;
 private:
 	virtual void scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) override;

--- a/graphics/scalerplugin.cpp
+++ b/graphics/scalerplugin.cpp
@@ -21,10 +21,6 @@
 
 #include "graphics/scalerplugin.h"
 
-void ScalerPluginObject::initialize(const Graphics::PixelFormat &format) {
-	_format = format;
-}
-
 namespace {
 /**
  * Trivial 'scaler' - in fact it doesn't do any scaling but just copies the
@@ -47,7 +43,7 @@ void Normal1x(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPit
 }
 } // End of anonymous namespace
 
-void ScalerPluginObject::scale(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr,
+void Scaler::scale(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr,
 	                           uint32 dstPitch, int width, int height, int x, int y) {
 	if (_factor == 1) {
 		if (_format.bytesPerPixel == 2) {
@@ -60,17 +56,14 @@ void ScalerPluginObject::scale(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstP
 	}
 }
 
-SourceScaler::SourceScaler() : _width(0), _height(0), _oldSrc(NULL), _enable(false) {
+SourceScaler::SourceScaler(const Graphics::PixelFormat &format) : Scaler(format), _width(0), _height(0), _oldSrc(NULL), _enable(false) {
 }
 
 SourceScaler::~SourceScaler() {
 	if (_oldSrc != NULL)
 		delete[] _oldSrc;
-}
 
-void SourceScaler::deinitialize() {
 	_bufferedOutput.free();
-	ScalerPluginObject::deinitialize();
 }
 
 void SourceScaler::setSource(const byte *src, uint pitch, int width, int height, int padding) {

--- a/graphics/scalerplugin.h
+++ b/graphics/scalerplugin.h
@@ -26,23 +26,10 @@
 #include "graphics/pixelformat.h"
 #include "graphics/surface.h"
 
-class ScalerPluginObject : public PluginObject {
+class Scaler {
 public:
-
-	virtual ~ScalerPluginObject() {}
-
-	/**
-	 * This function will be called before any scaler is used.
-	 * Precomputed data should be generated here.
-	 * @param format The pixel format to scale.
-	 */
-	virtual void initialize(const Graphics::PixelFormat &format);
-
-	/**
-	 * This is called when the plugin is not needed. It should clean
-	 * up memory from the initialize method.
-	 */
-	virtual void deinitialize() {}
+	Scaler(const Graphics::PixelFormat &format) : _format(format) {}
+	virtual ~Scaler() {}
 
 	/**
 	 * Scale a rect.
@@ -73,18 +60,6 @@ public:
 
 	virtual uint getFactor() const { return _factor; }
 
-	virtual const Common::Array<uint> &getFactors() const { return _factors; }
-
-	virtual bool hasFactor(uint factor) {
-		const Common::Array<uint> &factors = getFactors();
-		for (Common::Array<uint>::const_iterator it = factors.begin(); it != factors.end(); it++) {
-			if ((*it) == factor)
-				return true;
-		}
-
-		return false;
-	}
-
 	/**
 	 * Set the scaling factor.
 	 * Intended to be used with GUI to set a known valid factor.
@@ -97,34 +72,6 @@ public:
 		_factor = factor;
 		return oldFactor;
 	}
-
-	/**
-	 * Indicates how far outside the scaling region this scaler "looks"
-	 * @return The number of pixels in any direction
-	 */
-	virtual uint extraPixels() const = 0;
-
-	/**
-	 * Some scalers are not suitable for scaling the cursor.
-	 * Blurring scalers should return false.
-	 */
-	virtual bool canDrawCursor() const = 0;
-
-	/**
-	 * This value will be displayed on the GUI.
-	 */
-	virtual const char *getPrettyName() const = 0;
-
-	/**
-	 * Computationally intense scalers can benefit from comparing new and old
-	 * source images and updating only the pixels necessary. If the function
-	 * returns true, this scaler prefers this method and the backend can
-	 * optionally use it.
-	 *
-	 * @see enableSource
-	 * @see setSource
-	 */
-	virtual bool useOldSource() const { return false; }
 
 	/**
 	 * Set the source to be used when scaling and copying to the old buffer.
@@ -156,7 +103,6 @@ protected:
 	                         uint32 dstPitch, int width, int height, int x, int y) = 0;
 
 	uint _factor;
-	Common::Array<uint> _factors;
 	Graphics::PixelFormat _format;
 };
 
@@ -164,14 +110,12 @@ protected:
  * Convenience class that implements some bookkeeping for keeping track of
  * old source images.
  */
-class SourceScaler : public ScalerPluginObject {
+class SourceScaler : public Scaler {
 
 public:
 
-	SourceScaler();
+	SourceScaler(const Graphics::PixelFormat &format);
 	virtual ~SourceScaler();
-
-	void deinitialize() override;
 
 	virtual void setSource(const byte *src, uint pitch, int width, int height, int padding) final;
 
@@ -202,6 +146,62 @@ private:
 	bool _enable;
 	byte *_oldSrc;
 	Graphics::Surface _bufferedOutput;
+};
+
+class ScalerPluginObject : public PluginObject {
+public:
+
+	virtual ~ScalerPluginObject() {}
+
+	virtual Scaler *createInstance(const Graphics::PixelFormat &format) const = 0;
+
+	const Common::Array<uint> &getFactors() const { return _factors; }
+
+	bool hasFactor(uint factor) const {
+		const Common::Array<uint> &factors = getFactors();
+		for (Common::Array<uint>::const_iterator it = factors.begin(); it != factors.end(); it++) {
+			if ((*it) == factor)
+				return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Indicates how far outside the scaling region this scaler "looks"
+	 * @return The number of pixels in any direction
+	 */
+	virtual uint extraPixels() const = 0;
+
+	/**
+	 * Some scalers are not suitable for scaling the cursor.
+	 * Blurring scalers should return false.
+	 */
+	virtual bool canDrawCursor() const = 0;
+
+	/**
+	 * This value will be displayed on the GUI.
+	 */
+	virtual const char *getPrettyName() const = 0;
+
+	/**
+	 * The default scale factor.
+	 */
+	virtual uint getDefaultFactor() const { return 2; }
+
+	/**
+	 * Computationally intense scalers can benefit from comparing new and old
+	 * source images and updating only the pixels necessary. If the function
+	 * returns true, this scaler prefers this method and the backend can
+	 * optionally use it.
+	 *
+	 * @see enableSource
+	 * @see setSource
+	 */
+	virtual bool useOldSource() const { return false; }
+
+protected:
+	Common::Array<uint> _factors;
 };
 
 /**

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -650,9 +650,10 @@ void OptionsDialog::apply() {
 				ConfMan.removeKey("scale_factor", _domain);
 
 				uint defaultScaler = g_system->getDefaultScaler();
+				uint defaultScaleFactor = g_system->getDefaultScaleFactor();
 				if (g_system->getScaler() != defaultScaler)
 					graphicsModeChanged = true;
-				else if (scalerPlugins[defaultScaler]->get<ScalerPluginObject>().getFactor() != g_system->getDefaultScaleFactor())
+				else if (g_system->getScaleFactor() != defaultScaleFactor)
 					graphicsModeChanged = true;
 			}
 
@@ -1861,7 +1862,12 @@ void OptionsDialog::updateScaleFactors(uint32 tag) {
 		for (Common::Array<uint>::const_iterator it = factors.begin(); it != factors.end(); it++) {
 			_scaleFactorPopUp->appendEntry(Common::U32String::format("%dx", (*it)), (*it));
 		}
-		_scaleFactorPopUp->setSelectedTag(scalerPlugins[tag]->get<ScalerPluginObject>().getFactor());
+
+		if (g_system->getScaler() == tag) {
+			_scaleFactorPopUp->setSelectedTag(g_system->getScaleFactor());
+		} else {
+			_scaleFactorPopUp->setSelectedTag(scalerPlugins[tag]->get<ScalerPluginObject>().getDefaultFactor());
+		}
 	} else {
 		_scaleFactorPopUp->clearEntries();
 		_scaleFactorPopUp->appendEntry(_("<default>"));


### PR DESCRIPTION
`ScalerPluginObject` now provides a function to create a `Scaler` object, which can have multiple independent instances that are owned by the backend instead of the plugin system. More work will be needed for the HQ scaler, which uses global variables for the assembly code, but once this is complete, it should be possible to restore cursor scaling in OpenGL mode.
