### PR TITLE
DIRECTOR: fix Japanese continuation marker while preprocessing

### DIFF
--- a/engines/director/lingo/lingo-preprocessor.cpp
+++ b/engines/director/lingo/lingo-preprocessor.cpp
@@ -79,6 +79,31 @@ Common::U32String LingoCompiler::codePreprocessor(const Common::U32String &code,
 				break;
 			s++;
 			continue;
+		} else if (*s == 0xFF82) {	// Misparsed Japanese continuation
+			if (!*(s+1)) { // EOS - write as is and finish up
+				res += *s++;
+				break;
+			}
+			// Next character isn't a newline; write as is and keep
+			// going.
+			if (*(s+1) != 13) {
+				res += *s++;
+				continue;
+			}
+
+			s++;
+			// This is a bit of a hack; in MacJapanese the codepoint at
+			// C2 is the half-width katakana "tsu", so ScummVM is
+			// getting confused about what's here in the script after
+			// translating from MacJapanese to Unicode.
+			// Just swap the character out for the right Unicode character here.
+			// This can be removed if Lingo parsing is reworked to act
+			// on the original raw bytes instead of a Unicode translation.
+			res += CONTINUATION;
+			if (!*s)
+				break;
+			s++;
+			continue;
 		}
 		res += *s++;
 	}


### PR DESCRIPTION
The continuation marker is at the same codepoint in MacRoman as the half-width katakana tsu (ﾂ) in MacJapanese. Since parsing happens after Lingo source has been converted from its original encoding to Unicode, the continuation marker is being translated into the wrong character and treated as a syntax error. This patch works around it by checking for ﾂ and translating it back into the continuation character. While this could eventually be fixed by having the parser work on the raw bytes of the Lingo source instead of decoded strings, this is good enough for now to fix the affected games. I've tested several games with the issue - Difficult Book Game (henachoco03), The Seven Colors (the7colors), and Oz (erikotamuraoz).

Here's what the source code with the wrong continuation marker looks like:

```
on startMovie
    global theObjects,retdata1,retdata2,ladytime,selif,daiido,Xzahyo,Yzahyo,StageNum, ﾂ
```

This is the third fix needed to promote Difficult Book Game to fully-working status.

At least one of the three affected games has Japanese text on the same line as `ﾂ` as a continuation marker, so it might just be that `ﾂ` *is* the continuation marker in Japanese.