### PR TITLE
Allow the checking of other audio tracks than number 1

### DIFF
--- a/backends/audiocd/audiocd.h
+++ b/backends/audiocd/audiocd.h
@@ -109,7 +109,7 @@ public:
 	 * Checks whether the extracted audio cd tracks exists as files in
 	 * the search paths.
 	 */
-	virtual bool existExtractedCDAudioFiles() = 0;
+	virtual bool existExtractedCDAudioFiles(uint track) = 0;
 };
 
 #endif

--- a/backends/audiocd/default/default-audiocd.cpp
+++ b/backends/audiocd/default/default-audiocd.cpp
@@ -64,7 +64,7 @@ void DefaultAudioCDManager::fillPotentialTrackNames(Common::Array<Common::String
 	trackNames.push_back(Common::String::format("track_%02d", track));
 }
 
-bool DefaultAudioCDManager::existExtractedCDAudioFiles() {
+bool DefaultAudioCDManager::existExtractedCDAudioFiles(uint track) {
 	// keep this in sync with STREAM_FILEFORMATS
 	const char *extensions[] = {
 #ifdef USE_VORBIS
@@ -82,7 +82,7 @@ bool DefaultAudioCDManager::existExtractedCDAudioFiles() {
 	};
 
 	Common::Array<Common::String> trackNames;
-	fillPotentialTrackNames(trackNames, 1);
+	fillPotentialTrackNames(trackNames, track);
 
 	for (Common::Array<Common::String>::iterator i = trackNames.begin(); i != trackNames.end(); ++i) {
 		for (const char **ext = extensions; *ext; ++ext) {

--- a/backends/audiocd/default/default-audiocd.h
+++ b/backends/audiocd/default/default-audiocd.h
@@ -48,7 +48,7 @@ public:
 	virtual void setBalance(int8 balance);
 	virtual void update();
 	virtual Status getStatus() const; // Subclasses should override for better status results
-	virtual bool existExtractedCDAudioFiles();
+	virtual bool existExtractedCDAudioFiles(uint track);
 
 private:
 	void fillPotentialTrackNames(Common::Array<Common::String> &trackNames, int track) const;

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -486,8 +486,8 @@ void GUIErrorMessageFormat(Common::U32String fmt, ...) {
  * @return			true if audio files of the expected naming scheme are found, as long as ScummVM
  *					is also built with support to the respective audio format (eg. ogg, flac, mad/mp3)
  */
-bool Engine::existExtractedCDAudioFiles() {
-	return g_system->getAudioCDManager()->existExtractedCDAudioFiles();
+bool Engine::existExtractedCDAudioFiles(uint track) {
+	return g_system->getAudioCDManager()->existExtractedCDAudioFiles(track);
 }
 
 /**

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -602,7 +602,7 @@ public:
 	/**
 	 * Check if extracted CD Audio files are found.
 	 */
-	bool existExtractedCDAudioFiles();
+	bool existExtractedCDAudioFiles(uint track = 1);
 	/**
 	 * On some systems, check whether the game appears to be run
 	 * from the same CD drive, which also should play CD audio.

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1514,7 +1514,21 @@ void ScummEngine::setupScumm(const Common::String &macResourceFile) {
 
 	// On some systems it's not safe to run CD audio games from the CD.
 	if (_game.features & GF_AUDIOTRACKS && !Common::File::exists("CDDA.SOU")) {
-		if (!existExtractedCDAudioFiles()
+		uint track;
+
+		// Usually we check if track 1 is present, but the FM Towns demos use
+		// different ones.
+
+		if (strcmp(_game.gameid, "indyzak") == 0) {
+			// Has only track 17 and 18
+			track = 17;
+		} else if (strcmp(_game.gameid, "zakloom") == 0) {
+			// Has only track 15 and 16
+			track = 15;
+		} else
+			track = 1;
+
+		if (!existExtractedCDAudioFiles(track)
 		    && !isDataAndCDAudioReadFromSameCD()) {
 			warnMissingExtractedCDAudio();
 		}


### PR DESCRIPTION
ScummVM currently warns that the FM Towns SCUMM demos (indyzak and zakloom) are missing the audio tracks. That's because we always check for track 1, and neither demo has that.

This could be extended further, if we want to, e.g. if we want to verify that _all_ tracks are present instead of just one. But I don't know if that's worth bothering with?
