### PR TITLE
SCUMM: DiMUSE: Fix several minor bugs

### DIFF
--- a/engines/scumm/imuse_digi/dimuse_defs.h
+++ b/engines/scumm/imuse_digi/dimuse_defs.h
@@ -51,7 +51,7 @@ namespace Scumm {
 #define DIMUSE_GROUP_MUSICEFF 4
 #define DIMUSE_BUFFER_SPEECH  1
 #define DIMUSE_BUFFER_MUSIC   2
-#define DIMUSE_BUFFER_SFX     3
+#define DIMUSE_BUFFER_SMUSH     3
 
 // Parameters IDs
 #define DIMUSE_P_BOGUS_ID       0x0

--- a/engines/scumm/imuse_digi/dimuse_defs.h
+++ b/engines/scumm/imuse_digi/dimuse_defs.h
@@ -51,7 +51,7 @@ namespace Scumm {
 #define DIMUSE_GROUP_MUSICEFF 4
 #define DIMUSE_BUFFER_SPEECH  1
 #define DIMUSE_BUFFER_MUSIC   2
-#define DIMUSE_BUFFER_SMUSH     3
+#define DIMUSE_BUFFER_SMUSH   3
 
 // Parameters IDs
 #define DIMUSE_P_BOGUS_ID       0x0

--- a/engines/scumm/imuse_digi/dimuse_dispatch.cpp
+++ b/engines/scumm/imuse_digi/dimuse_dispatch.cpp
@@ -261,6 +261,7 @@ int IMuseDigital::dispatchRelease(IMuseDigiTrack *trackPtr) {
 			do {
 				streamZoneList->useFlag = 0;
 				removeStreamZoneFromList(&dispatchToDeallocate->streamZoneList, streamZoneList);
+				streamZoneList = dispatchToDeallocate->streamZoneList;
 			} while (dispatchToDeallocate->streamZoneList);
 		}
 	}

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -191,6 +191,10 @@ int IMuseDigital::startVoice(int soundId, const char *soundName, byte speakingAc
 
 			diMUSESetParam(kTalkSoundID, DIMUSE_P_TRANSPOSE, a->_talkFrequency);
 			diMUSESetParam(kTalkSoundID, DIMUSE_P_PAN, a->_talkPan);
+
+			_currentSpeechVolume = a->_talkVolume;
+			_currentSpeechFrequency = a->_talkFrequency;
+			_currentSpeechPan = a->_talkPan;
 		}
 
 		// The interpreter really calls for processStreams two times in a row,

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -446,7 +446,7 @@ void IMuseDigital::stopSMUSHAudio() {
 				if (diMUSEGetParam(foundSoundId, DIMUSE_P_SND_HAS_STREAM)) {
 					diMUSEQueryStream(foundSoundId, bufSize, criticalSize, freeSpace, paused);
 
-					// Here, the disasm explicitly asks for "bufSize == 193900";
+					// Here, the original engine for DIG explicitly asks for "bufSize == 193900";
 					// since this works half of the time in ScummVM (because of how we handle sound buffers),
 					// we do the check but we alternatively check for the SMUSH channel soundId, so to cover the
 					// remaining cases. This fixes instances in which exiting from a cutscene leaves both

--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -190,6 +190,7 @@ private:
 	int tracksStopSound(int soundId);
 	int tracksStopAllSounds();
 	int tracksGetNextSound(int soundId);
+	void tracksQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
 	int tracksFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused);
 	void tracksClear(IMuseDigiTrack *trackPtr);
 	int tracksSetParam(int soundId, int opcode, int value);
@@ -267,6 +268,7 @@ private:
 	int waveSwitchStream(int oldSoundId, int newSoundId, int fadeLengthMs, int fadeSyncFlag2, int fadeSyncFlag1);
 	int waveSwitchStream(int oldSoundId, int newSoundId, uint8 *crossfadeBuffer, int crossfadeBufferSize, int vocLoopFlag);
 	int waveProcessStreams();
+	void waveQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
 	int waveFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused);
 	int waveLipSync(int soundId, int syncId, int msPos, int32 &width, int32 &height);
 
@@ -322,6 +324,7 @@ public:
 	void flushTracks();
 	void disableEngine();
 	bool isEngineDisabled();
+	void stopSMUSHAudio();
 
 	bool isFTSoundEngine(); // Used in the handlers to check if we're using the FT version of the engine
 
@@ -354,6 +357,7 @@ public:
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, int fadeDelay, int fadeSyncFlag2, int fadeSyncFlag1);
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, uint8 *crossfadeBuffer, int crossfadeBufferSize, int vocLoopFlag);
 	int diMUSEProcessStreams();
+	void diMUSEQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
 	int diMUSEFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused);
 	int diMUSELipSync(int soundId, int syncId, int msPos, int32 &width, int32 &height);
 	int diMUSESetMusicGroupVol(int volume);

--- a/engines/scumm/imuse_digi/dimuse_internalmixer.cpp
+++ b/engines/scumm/imuse_digi/dimuse_internalmixer.cpp
@@ -32,7 +32,7 @@
 namespace Scumm {
 
 IMuseDigiInternalMixer::IMuseDigiInternalMixer(Audio::Mixer *mixer) {
-	_stream = Audio::makeQueuingAudioStream(22050, true);
+	_stream = Audio::makeQueuingAudioStream(DIMUSE_SAMPLERATE, true);
 	_mixer = mixer;
 	_radioChatter = 0;
 	_amp8Table = nullptr;

--- a/engines/scumm/imuse_digi/dimuse_tracks.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tracks.cpp
@@ -282,6 +282,24 @@ int IMuseDigital::tracksGetNextSound(int soundId) {
 	return foundSoundId;
 }
 
+void IMuseDigital::tracksQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
+	if (!_trackList)
+		debug(5, "IMuseDigital::tracksQueryStream(): WARNING: empty trackList, ignoring call...");
+
+	IMuseDigiTrack *track = _trackList;
+	do {
+		if (track->soundId) {
+			if (soundId == track->soundId && track->dispatchPtr->streamPtr) {
+				streamerQueryStream(track->dispatchPtr->streamPtr, bufSize, criticalSize, freeSpace, paused);
+				return;
+			}
+		}
+		track = track->next;
+	} while (track);
+
+	debug(5, "IMuseDigital::tracksQueryStream(): WARNING: couldn't find sound %d in trackList, ignoring call...", soundId);
+}
+
 int IMuseDigital::tracksFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused) {
 	if (!_trackList)
 		return -1;

--- a/engines/scumm/imuse_digi/dimuse_wave.cpp
+++ b/engines/scumm/imuse_digi/dimuse_wave.cpp
@@ -116,6 +116,11 @@ int IMuseDigital::waveProcessStreams() {
 	return streamerProcessStreams();
 }
 
+void IMuseDigital::waveQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
+	Common::StackLock lock(_mutex);
+	tracksQueryStream(soundId, bufSize, criticalSize, freeSpace, paused);
+}
+
 int IMuseDigital::waveFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused) {
 	Common::StackLock lock(_mutex);
 	return tracksFeedStream(soundId, srcBuf, sizeToFeed, paused);

--- a/engines/scumm/smush/smush_player.cpp
+++ b/engines/scumm/smush/smush_player.cpp
@@ -506,7 +506,7 @@ void SmushPlayer::handleIACT(int32 subSize, Common::SeekableReadStream &b) {
 				bufId = DIMUSE_BUFFER_MUSIC;
 				volume = 2 * userId - 400;
 			} else if (userId >= 300 && userId <= 363) {
-				bufId = DIMUSE_BUFFER_SFX;
+				bufId = DIMUSE_BUFFER_SMUSH;
 				volume = 2 * userId - 600;
 			} else {
 				free(dataBuffer);
@@ -1344,6 +1344,7 @@ void SmushPlayer::play(const char *filename, int32 speed, int32 offset, int32 st
 			_vm->_mixer->stopHandle(*_compressedFileSoundHandle);
 			_vm->_mixer->stopHandle(*_IACTchannel);
 			_IACTpos = 0;
+			_imuseDigital->stopSMUSHAudio();
 			break;
 		}
 		_vm->_system->delayMillis(10);


### PR DESCRIPTION
Hiya, this PR contains several minor fixes for the DiMUSE engine:

1. A fix for [this ](https://bugs.scummvm.org/ticket/13084) bug;
2. A fix for an issue in which streamZone aren't correctly deallocated when terminating the engine or releasing a dispatch;
3. A fix for both DiMUSE streams being kept busy after skipping a SMUSH video in DIG full version (I simply forgot to implement the correct behavior...);