### PR TITLE
ENGINE: Suppress autosave overwrite warning when description is empty

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -567,9 +567,7 @@ void Engine::handleAutoSave() {
 bool Engine::warnBeforeOverwritingAutosave() {
 	SaveStateDescriptor desc = getMetaEngine()->querySaveMetaInfos(
 		_targetName.c_str(), getAutosaveSlot());
-	if (desc.getSaveSlot() == -1)
-		return true;
-	if (desc.hasAutosaveName())
+	if (!desc.isValid() || desc.hasAutosaveName())
 		return true;
 	Common::U32StringArray altButtons;
 	altButtons.push_back(_("Overwrite"));

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -98,3 +98,8 @@ bool SaveStateDescriptor::hasAutosaveName() const
 {
 	return _description.contains(_("Autosave"));
 }
+
+bool SaveStateDescriptor::isValid() const
+{
+	return _slot >= 0 && !_description.empty();
+}

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -221,6 +221,11 @@ public:
 	 * Returns true if the save has an autosave name
 	 */
 	bool hasAutosaveName() const;
+
+	/**
+	 * Returns true if this entry is valid
+	 */
+	bool isValid() const;
 private:
 	/**
 	 * The saveslot id, as it would be passed to the "-x" command line switch.


### PR DESCRIPTION
Some engines (like kyra) return a SaveStateDescriptor with slot assigned,
even when the slot is free. The indication for an empty save is empty
description on these cases.
