### PR TITLE
BUILD: Support SerenityOS in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -3992,7 +3992,7 @@ case $_host_os in
 	amigaos* | cygwin* | dreamcast | ds | gamecube | mingw* | morphos | n64 | ps3 | psp2 | psp | riscos | wii)
 		_posix=no
 		;;
-	3ds | android | androidsdl | beos* | bsd* | darwin* | freebsd* | gnu* | gph-linux | haiku* | hpux* | iphone | ios7 | irix*| k*bsd*-gnu* | linux* | maemo | mint* | netbsd* | openbsd* | solaris* | sunos* | switch | uclinux*)
+	3ds | android | androidsdl | beos* | bsd* | darwin* | freebsd* | gnu* | gph-linux | haiku* | hpux* | iphone | ios7 | irix*| k*bsd*-gnu* | linux* | maemo | mint* | netbsd* | openbsd* | serenity* | solaris* | sunos* | switch | uclinux*)
 		_posix=yes
 		;;
 	os2-emx*)


### PR DESCRIPTION
As discussed here: https://github.com/SerenityOS/serenity/commit/59b2bac3a53a5b7605fc85d10b307147f1702635

This adds SerenityOS as a valid POSIX target for ScummVM. ScummVM is supported as a port in SerenityOS, and this change allows us to remove the only patch needed to get everything to compile.

CC @sev- 