### PR TITLE
SHERLOCK: Fix missing Rose Tattoo talk animations (bug #7090)

### DIFF
--- a/engines/sherlock/people.cpp
+++ b/engines/sherlock/people.cpp
@@ -261,10 +261,8 @@ int People::findSpeaker(int speaker) {
 		Object &obj = scene._bgShapes[idx];
 
 		if (obj._type == ACTIVE_BG_SHAPE) {
-			Common::String name(obj._name.c_str(), obj._name.c_str() + 4);
-
-			if (name.equalsIgnoreCase(portrait)
-				&& obj._name[4] >= '0' && obj._name[4] <= '9')
+			if (scumm_strnicmp(portrait, obj._name.c_str(), 4) == 0
+				&& Common::isDigit(obj._name[4]))
 				return idx;
 		}
 	}

--- a/engines/sherlock/tattoo/tattoo_people.cpp
+++ b/engines/sherlock/tattoo/tattoo_people.cpp
@@ -1380,9 +1380,8 @@ int TattooPeople::findSpeaker(int speaker) {
 			TattooPerson &p = (*this)[idx];
 
 			if (p._type == CHARACTER) {
-				Common::String name(p._name.c_str(), p._name.c_str() + 4);
-
-				if (name.equalsIgnoreCase(portrait) && p._npcName[4] >= '0' && p._npcName[4] <= '9')
+				if (scumm_strnicmp(portrait, p._npcName.c_str(), 4) == 0
+					&& Common::isDigit(p._npcName[4]))
 					return idx + CHARACTERS_INDEX;
 			}
 		}


### PR DESCRIPTION
This is an attempt at fixing https://bugs.scummvm.org/ticket/7090 ("SHERLOCK: Watson isn't animated while talking"). If I understand it correctly, the problem is simply that we compare the wrong strings when looking up the talking actor, and therefore he's not animated.

I don't know if this affects any other actors than Watson.

If this is the correct fix, I'd suggest we apply it to the 2.5 branch as well.