### PR TITLE
Cherry-pick commits from orgads to fix the check for overwriting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ For a more comprehensive changelog of the latest experimental code, see:
  General:
    - Ported ResidualVM GUI theme to remastered version.
    - Fixed edge case for Punycode.
+   - Fixed checking for savegame overwrite in autosave slot.
+   - Fixed moving savegame to new slot for most engines.
 
  AGOS:
    - Fixed old Waxworks AdLib music regression.

--- a/engines/access/metaengine.cpp
+++ b/engines/access/metaengine.cpp
@@ -135,7 +135,7 @@ SaveStateList AccessMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Access::AccessEngine::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 
 				delete in;
 			}
@@ -170,7 +170,7 @@ SaveStateDescriptor AccessMetaEngine::querySaveMetaInfos(const char *target, int
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(this, slot, header._saveName);
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/adl/metaengine.cpp
+++ b/engines/adl/metaengine.cpp
@@ -102,7 +102,6 @@ bool AdlMetaEngine::hasFeature(MetaEngineFeature f) const {
 	case kSavesSupportThumbnail:
 	case kSavesSupportCreationDate:
 	case kSavesSupportPlayTime:
-	case kSimpleSavesNames:
 		return true;
 	default:
 		return false;

--- a/engines/adl/metaengine.cpp
+++ b/engines/adl/metaengine.cpp
@@ -136,7 +136,7 @@ SaveStateDescriptor AdlMetaEngine::querySaveMetaInfos(const char *target, int sl
 		return SaveStateDescriptor();
 	}
 
-	SaveStateDescriptor sd(slot, name);
+	SaveStateDescriptor sd(this, slot, name);
 
 	int year = inFile->readUint16BE();
 	int month = inFile->readByte();
@@ -198,7 +198,7 @@ SaveStateList AdlMetaEngine::listSaves(const char *target) const {
 		delete inFile;
 
 		int slotNum = atoi(fileName.c_str() + fileName.size() - 2);
-		SaveStateDescriptor sd(slotNum, name);
+		SaveStateDescriptor sd(this, slotNum, name);
 		saveList.push_back(sd);
 	}
 

--- a/engines/agi/metaengine.cpp
+++ b/engines/agi/metaengine.cpp
@@ -214,7 +214,7 @@ SaveStateList AgiMetaEngine::listSaves(const char *target) const {
 
 				delete in;
 
-				saveList.push_back(SaveStateDescriptor(slotNr, description));
+				saveList.push_back(SaveStateDescriptor(this, slotNr, description));
 			}
 		}
 	}
@@ -257,11 +257,11 @@ SaveStateDescriptor AgiMetaEngine::querySaveMetaInfos(const char *target, int sl
 			// broken description, ignore it
 			delete in;
 
-			SaveStateDescriptor descriptor(slotNr, "[broken saved game]");
+			SaveStateDescriptor descriptor(this, slotNr, "[broken saved game]");
 			return descriptor;
 		}
 
-		SaveStateDescriptor descriptor(slotNr, description);
+		SaveStateDescriptor descriptor(this, slotNr, description);
 
 		char saveVersion = in->readByte();
 		if (saveVersion >= 4) {

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -128,7 +128,7 @@ SaveStateList AgosMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				saveDesc = file->c_str();
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}

--- a/engines/ags/metaengine.cpp
+++ b/engines/ags/metaengine.cpp
@@ -69,7 +69,7 @@ SaveStateList AGSMetaEngine::listSaves(const char *target) const {
 				if (slotNum > maxSlot)
 					continue;
 
-				SaveStateDescriptor desc(slotNum, rich_media_header.getSaveName());
+				SaveStateDescriptor desc(this, slotNum, rich_media_header.getSaveName());
 				saveList.push_back(desc);
 			}
 		}
@@ -111,7 +111,7 @@ SaveStateDescriptor AGSMetaEngine::querySaveMetaInfos(const char *target, int sl
 		rich_media_header.ReadFromFile(&saveFile);
 
 		if (rich_media_header.dwMagicNumber == RM_MAGICNUMBER) {
-			SaveStateDescriptor desc(slot, rich_media_header.getSaveName());
+			SaveStateDescriptor desc(this, slot, rich_media_header.getSaveName());
 
 			// Thumbnail handling
 			if (rich_media_header.dwThumbnailOffsetLowerDword != 0 &&

--- a/engines/avalanche/metaengine.cpp
+++ b/engines/avalanche/metaengine.cpp
@@ -126,7 +126,7 @@ SaveStateList AvalancheMetaEngine::listSaves(const char *target) const {
 				file->read(name, nameSize);
 				name[nameSize] = 0;
 
-				saveList.push_back(SaveStateDescriptor(slotNum, name));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, name));
 				delete[] name;
 				delete file;
 			}
@@ -172,7 +172,7 @@ SaveStateDescriptor AvalancheMetaEngine::querySaveMetaInfos(const char *target, 
 			description += actChar;
 		}
 
-		SaveStateDescriptor desc(slot, description);
+		SaveStateDescriptor desc(this, slot, description);
 
 		Graphics::Surface *thumbnail;
 		if (!Graphics::loadThumbnail(*f, thumbnail)) {

--- a/engines/bbvs/metaengine.cpp
+++ b/engines/bbvs/metaengine.cpp
@@ -87,7 +87,7 @@ SaveStateList BbvsMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Bbvs::BbvsEngine::readSaveHeader(in, header) == Bbvs::BbvsEngine::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.description));
 				}
 				delete in;
 			}
@@ -107,7 +107,7 @@ SaveStateDescriptor BbvsMetaEngine::querySaveMetaInfos(const char *target, int s
 		error = Bbvs::BbvsEngine::readSaveHeader(in, header, false);
 		delete in;
 		if (error == Bbvs::BbvsEngine::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(this, slot, header.description);
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveDate & 0xFFFF, (header.saveDate >> 16) & 0xFF, (header.saveDate >> 24) & 0xFF);
 			desc.setSaveTime((header.saveTime >> 16) & 0xFF, (header.saveTime >> 8) & 0xFF);

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -350,7 +350,7 @@ Common::Error BladeRunnerEngine::run() {
 
 	_system->showMouse(true);
 
-	bool hasSavegames = !SaveFileManager::list(_targetName).empty();
+	bool hasSavegames = !SaveFileManager::list(getMetaEngine(), _targetName).empty();
 
 	if (!startup(hasSavegames)) {
 		// shutting down
@@ -2401,7 +2401,7 @@ void BladeRunnerEngine::autoSaveGame(int textId, bool endgame) {
 	}
 	_gameIsAutoSaving = true;
 
-	SaveStateList saveList = BladeRunner::SaveFileManager::list(getTargetName());
+	SaveStateList saveList = BladeRunner::SaveFileManager::list(getMetaEngine(), getTargetName());
 
 	// Find first available save slot
 	int slot = -1;

--- a/engines/bladerunner/metaengine.cpp
+++ b/engines/bladerunner/metaengine.cpp
@@ -66,7 +66,7 @@ bool BladeRunnerMetaEngine::hasFeature(MetaEngineFeature f) const {
 }
 
 SaveStateList BladeRunnerMetaEngine::listSaves(const char *target) const {
-	return BladeRunner::SaveFileManager::list(target);
+	return BladeRunner::SaveFileManager::list(this, target);
 }
 
 int BladeRunnerMetaEngine::getMaximumSaveSlot() const {
@@ -78,7 +78,7 @@ void BladeRunnerMetaEngine::removeSaveState(const char *target, int slot) const 
 }
 
 SaveStateDescriptor BladeRunnerMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
-	return BladeRunner::SaveFileManager::queryMetaInfos(target, slot);
+	return BladeRunner::SaveFileManager::queryMetaInfos(this, target, slot);
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(BLADERUNNER)

--- a/engines/bladerunner/savefile.cpp
+++ b/engines/bladerunner/savefile.cpp
@@ -34,7 +34,7 @@
 
 namespace BladeRunner {
 
-SaveStateList SaveFileManager::list(const Common::String &target) {
+SaveStateList SaveFileManager::list(const MetaEngine *metaEngine, const Common::String &target) {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::StringArray files = saveFileMan->listSavefiles(target + ".###");
 
@@ -50,7 +50,7 @@ SaveStateList SaveFileManager::list(const Common::String &target) {
 		readHeader(*saveFile, header);
 
 		int slotNum = atoi(fileName->c_str() + fileName->size() - 3);
-		saveList.push_back(SaveStateDescriptor(slotNum, header._name));
+		saveList.push_back(SaveStateDescriptor(metaEngine, slotNum, header._name));
 
 		delete saveFile;
 	}
@@ -60,7 +60,7 @@ SaveStateList SaveFileManager::list(const Common::String &target) {
 	return saveList;
 }
 
-SaveStateDescriptor SaveFileManager::queryMetaInfos(const Common::String &target, int slot) {
+SaveStateDescriptor SaveFileManager::queryMetaInfos(const MetaEngine *metaEngine, const Common::String &target, int slot) {
 	Common::String filename = Common::String::format("%s.%03d", target.c_str(), slot);
 	Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(filename);
 
@@ -75,7 +75,7 @@ SaveStateDescriptor SaveFileManager::queryMetaInfos(const Common::String &target
 	}
 	delete saveFile;
 
-	SaveStateDescriptor desc(slot, header._name);
+	SaveStateDescriptor desc(metaEngine, slot, header._name);
 	desc.setThumbnail(header._thumbnail);
 	desc.setSaveDate(header._year, header._month, header._day);
 	desc.setSaveTime(header._hour, header._minute);

--- a/engines/bladerunner/savefile.h
+++ b/engines/bladerunner/savefile.h
@@ -73,8 +73,8 @@ public:
 	static const uint32 kNameLength    = 41;
 	static const uint32 kThumbnailSize = 9600; // 80x60x16bpp
 
-	static SaveStateList list(const Common::String &target);
-	static SaveStateDescriptor queryMetaInfos(const Common::String &target, int slot);
+	static SaveStateList list(const MetaEngine *metaEngine, const Common::String &target);
+	static SaveStateDescriptor queryMetaInfos(const MetaEngine *metaEngine, const Common::String &target, int slot);
 
 	static Common::InSaveFile *openForLoading(const Common::String &target, int slot);
 	static Common::OutSaveFile *openForSaving(const Common::String &target, int slot);

--- a/engines/bladerunner/ui/kia_section_load.cpp
+++ b/engines/bladerunner/ui/kia_section_load.cpp
@@ -65,7 +65,7 @@ void KIASectionLoad::open() {
 	_scrollBox->show();
 	_scrollBox->clearLines();
 
-	_saveList = SaveFileManager::list(_vm->getTargetName());
+	_saveList = SaveFileManager::list(_vm->getMetaEngine(), _vm->getTargetName());
 
 	if (!_saveList.empty()) {
 		_scrollBox->addLine(_vm->_textOptions->getText(36), -1, 4); // Load game:
@@ -106,7 +106,7 @@ void KIASectionLoad::draw(Graphics::Surface &surface) {
 	if (_hoveredLineId != selectedLineId) {
 		if (selectedLineId >= 0 && selectedLineId < (int)_saveList.size() && _displayingLineId != selectedLineId) {
 			if (_timeLeft == 0u) {
-				SaveStateDescriptor desc = SaveFileManager::queryMetaInfos(_vm->getTargetName(), selectedLineId);
+				SaveStateDescriptor desc = SaveFileManager::queryMetaInfos(_vm->getMetaEngine(), _vm->getTargetName(), selectedLineId);
 				const Graphics::Surface *thumbnail = desc.getThumbnail();
 				if (thumbnail != nullptr) {
 					_vm->_kia->playImage(*thumbnail);
@@ -126,7 +126,7 @@ void KIASectionLoad::draw(Graphics::Surface &surface) {
 		if (_timeLeft) {
 			uint32 timeDiff = now - _timeLast; // unsigned difference is intentional
 			if (timeDiff >= _timeLeft) {
-				SaveStateDescriptor desc = SaveFileManager::queryMetaInfos(_vm->getTargetName(), _saveList[selectedLineId].getSaveSlot());
+				SaveStateDescriptor desc = SaveFileManager::queryMetaInfos(_vm->getMetaEngine(), _vm->getTargetName(), _saveList[selectedLineId].getSaveSlot());
 				const Graphics::Surface *thumbnail = desc.getThumbnail();
 				if (thumbnail != nullptr) {
 					_vm->_kia->playImage(*thumbnail);

--- a/engines/bladerunner/ui/kia_section_save.cpp
+++ b/engines/bladerunner/ui/kia_section_save.cpp
@@ -94,7 +94,7 @@ void KIASectionSave::open() {
 
 	_scrollBox->show();
 
-	_saveList = SaveFileManager::list(_vm->getTargetName());
+	_saveList = SaveFileManager::list(_vm->getMetaEngine(), _vm->getTargetName());
 
 	bool ableToSaveGame = true;
 
@@ -186,7 +186,7 @@ void KIASectionSave::draw(Graphics::Surface &surface) {
 	if (selectedLineId != _hoveredLineId) {
 		if (selectedLineId >= 0 && selectedLineId < (int)_saveList.size() && _displayingLineId != selectedLineId) {
 			if (_timeLeft == 0u) {
-				SaveStateDescriptor desc = SaveFileManager::queryMetaInfos(_vm->getTargetName(), selectedLineId);
+				SaveStateDescriptor desc = SaveFileManager::queryMetaInfos(_vm->getMetaEngine(), _vm->getTargetName(), selectedLineId);
 				const Graphics::Surface *thumbnail = desc.getThumbnail();
 				if (thumbnail != nullptr) {
 					_vm->_kia->playImage(*thumbnail);
@@ -206,7 +206,7 @@ void KIASectionSave::draw(Graphics::Surface &surface) {
 		if (_timeLeft) {
 			uint32 timeDiff = now - _timeLast; // unsigned difference is intentional
 			if (timeDiff >= _timeLeft) {
-				SaveStateDescriptor desc = SaveFileManager::queryMetaInfos(_vm->getTargetName(), _saveList[selectedLineId].getSaveSlot());
+				SaveStateDescriptor desc = SaveFileManager::queryMetaInfos(_vm->getMetaEngine(), _vm->getTargetName(), _saveList[selectedLineId].getSaveSlot());
 				const Graphics::Surface *thumbnail = desc.getThumbnail();
 				if (thumbnail != nullptr) {
 					_vm->_kia->playImage(*thumbnail);

--- a/engines/buried/metaengine.cpp
+++ b/engines/buried/metaengine.cpp
@@ -75,15 +75,23 @@ Common::Language BuriedEngine::getLanguage() const {
 
 class BuriedMetaEngine : public AdvancedMetaEngine {
 public:
-	const char *getName() const {
+	const char *getName() const override {
 		return "buried";
 	}
 
-	virtual bool hasFeature(MetaEngineFeature f) const;
-	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const;
-	virtual SaveStateList listSaves(const char *target) const;
-	virtual int getMaximumSaveSlot() const { return 999; }
-	virtual void removeSaveState(const char *target, int slot) const;
+	virtual bool hasFeature(MetaEngineFeature f) const override;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	virtual SaveStateList listSaves(const char *target) const override;
+	virtual int getMaximumSaveSlot() const override { return 999; }
+	virtual void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("buried-*.sav");
+		else
+			return Common::String::format("buried-%s.sav", target);
+	}
 };
 
 bool BuriedMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/buried/metaengine.cpp
+++ b/engines/buried/metaengine.cpp
@@ -106,7 +106,7 @@ SaveStateList BuriedMetaEngine::listSaves(const char *target) const {
 		for (int j = 0; j < 4; j++)
 			desc.deleteLastChar();
 
-		saveList.push_back(SaveStateDescriptor(i, desc));
+		saveList.push_back(SaveStateDescriptor(this, i, desc));
 	}
 
 	return saveList;

--- a/engines/cge/metaengine.cpp
+++ b/engines/cge/metaengine.cpp
@@ -94,11 +94,11 @@ SaveStateList CGEMetaEngine::listSaves(const char *target) const {
 				if (!strncmp(buffer, CGE::savegameStr, kSavegameStrSize + 1)) {
 					// Valid savegame
 					if (CGE::CGEEngine::readSavegameHeader(file, header)) {
-						saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+						saveList.push_back(SaveStateDescriptor(this, slotNum, header.saveName));
 					}
 				} else {
 					// Must be an original format savegame
-					saveList.push_back(SaveStateDescriptor(slotNum, "Unknown"));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, "Unknown"));
 				}
 
 				delete file;
@@ -128,11 +128,11 @@ SaveStateDescriptor CGEMetaEngine::querySaveMetaInfos(const char *target, int sl
 
 		if (!hasHeader) {
 			// Original savegame perhaps?
-			SaveStateDescriptor desc(slot, "Unknown");
+			SaveStateDescriptor desc(this, slot, "Unknown");
 			return desc;
 		} else {
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(this, slot, header.saveName);
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveYear, header.saveMonth, header.saveDay);
 			desc.setSaveTime(header.saveHour, header.saveMinutes);

--- a/engines/cge2/metaengine.cpp
+++ b/engines/cge2/metaengine.cpp
@@ -94,11 +94,11 @@ SaveStateList CGE2MetaEngine::listSaves(const char *target) const {
 				if (!strncmp(buffer, kSavegameStr, kSavegameStrSize + 1)) {
 					// Valid savegame
 					if (CGE2::CGE2Engine::readSavegameHeader(file, header)) {
-						saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+						saveList.push_back(SaveStateDescriptor(this, slotNum, header.saveName));
 					}
 				} else {
 					// Must be an original format savegame
-					saveList.push_back(SaveStateDescriptor(slotNum, "Unknown"));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, "Unknown"));
 				}
 
 				delete file;
@@ -128,11 +128,11 @@ SaveStateDescriptor CGE2MetaEngine::querySaveMetaInfos(const char *target, int s
 
 		if (!hasHeader) {
 			// Original savegame perhaps?
-			SaveStateDescriptor desc(slot, "Unknown");
+			SaveStateDescriptor desc(this, slot, "Unknown");
 			return desc;
 		} else {
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(this, slot, header.saveName);
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveYear, header.saveMonth, header.saveDay);
 			desc.setSaveTime(header.saveHour, header.saveMinutes);

--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -127,7 +127,7 @@ SaveStateList CineMetaEngine::listSaves(const char *target) const {
 				strncpy(saveDesc, saveNames[slotNum], SAVEGAME_NAME_LEN);
 				saveDesc[sizeof(CommandeType) - 1] = 0;
 
-				SaveStateDescriptor saveStateDesc(slotNum, saveDesc);
+				SaveStateDescriptor saveStateDesc(this, slotNum, saveDesc);
 
 				if (saveStateDesc.getDescription().empty()) {
 					if (saveStateDesc.isAutosave()) {
@@ -150,7 +150,7 @@ SaveStateList CineMetaEngine::listSaves(const char *target) const {
 
 	// No saving on empty autosave slot
 	if (!foundAutosave) {
-		SaveStateDescriptor desc(getAutosaveSlot(), _("Empty autosave"));
+		SaveStateDescriptor desc(this, getAutosaveSlot(), _("Empty autosave"));
 		saveList.push_back(desc);
 	}
 
@@ -179,7 +179,7 @@ SaveStateDescriptor CineMetaEngine::querySaveMetaInfos(const char *target, int s
 
 	if (f) {
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, Common::U32String());
+		SaveStateDescriptor desc(this, slot, Common::U32String());
 
 		ExtendedSavegameHeader header;
 		if (readSavegameHeader(f.get(), &header, false)) {
@@ -213,7 +213,7 @@ SaveStateDescriptor CineMetaEngine::querySaveMetaInfos(const char *target, int s
 
 	// No saving on empty autosave slot
 	if (slot == getAutosaveSlot()) {
-		return SaveStateDescriptor(slot, _("Empty autosave"));
+		return SaveStateDescriptor(this, slot, _("Empty autosave"));
 	}
 
 	return SaveStateDescriptor();

--- a/engines/composer/metaengine.cpp
+++ b/engines/composer/metaengine.cpp
@@ -116,7 +116,7 @@ SaveStateList ComposerMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				saveDesc = getSaveName(in);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}

--- a/engines/composer/metaengine.cpp
+++ b/engines/composer/metaengine.cpp
@@ -76,6 +76,14 @@ public:
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char* target) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.##", target);
+		else
+			return Common::String::format("%s.%02d", target, saveGameIdx);
+	}
 };
 
 Common::Error ComposerMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
@@ -103,9 +111,8 @@ SaveStateList ComposerMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::StringArray filenames;
 	Common::String saveDesc;
-	Common::String pattern = Common::String::format("%s.##", target);
 
-	filenames = saveFileMan->listSavefiles(pattern);
+	filenames = saveFileMan->listSavefiles(getSavegameFilePattern(target));
 
 	SaveStateList saveList;
 	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {

--- a/engines/cruise/metaengine.cpp
+++ b/engines/cruise/metaengine.cpp
@@ -85,7 +85,7 @@ SaveStateList CruiseMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				Cruise::CruiseSavegameHeader header;
 				if (Cruise::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.saveName));
 				delete in;
 			}
 		}
@@ -114,7 +114,7 @@ SaveStateDescriptor CruiseMetaEngine::querySaveMetaInfos(const char *target, int
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header.saveName);
+		SaveStateDescriptor desc(this, slot, header.saveName);
 		desc.setThumbnail(header.thumbnail);
 
 		return desc;

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -113,7 +113,7 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveMan->openForLoading(*file);
 			if (in) {
 				if (in->read(saveName, kSaveDescriptionLen) == kSaveDescriptionLen) {
-					saveList.push_back(SaveStateDescriptor(slotNum - 1, saveName));
+					saveList.push_back(SaveStateDescriptor(this, slotNum - 1, saveName));
 				}
 				delete in;
 			}

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -93,8 +93,7 @@ bool CryOmni3DMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return
 		(f == kSupportsListSaves)
 		|| (f == kSupportsLoadingDuringStartup)
-		|| (f == kSupportsDeleteSave)
-		|| (f == kSimpleSavesNames);
+		|| (f == kSupportsDeleteSave);
 }
 
 SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -79,6 +79,14 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 999; }
 	void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.####", target);
+		else
+			return Common::String::format("%s.%04d", target, saveGameIdx + 1);
+	}
 };
 
 bool CryOmni3DMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -98,8 +106,7 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 
 	char saveName[kSaveDescriptionLen + 1];
 	saveName[kSaveDescriptionLen] = '\0';
-	Common::String pattern = Common::String::format("%s.????", target);
-	Common::StringArray filenames = saveMan->listSavefiles(pattern);
+	Common::StringArray filenames = saveMan->listSavefiles(getSavegameFilePattern(target));
 	sort(filenames.begin(), filenames.end());   // Sort (hopefully ensuring we are sorted numerically..)
 
 	int slotNum;
@@ -124,9 +131,7 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 }
 
 void CryOmni3DMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String filename = Common::String::format("%s.%04d", target, slot + 1);
-
-	g_system->getSavefileManager()->removeSavefile(filename);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 Common::Error CryOmni3DMetaEngine::createInstance(OSystem *syst, Engine **engine,

--- a/engines/dm/metaengine.cpp
+++ b/engines/dm/metaengine.cpp
@@ -77,7 +77,7 @@ public:
 				Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 				if (in) {
 					if (DM::readSaveGameHeader(in, &header))
-						saveList.push_back(SaveStateDescriptor(slotNum, header._descr.getDescription()));
+						saveList.push_back(SaveStateDescriptor(this, slotNum, header._descr.getDescription()));
 					delete in;
 				}
 			}
@@ -99,7 +99,7 @@ public:
 			delete in;
 
 			if (successfulRead) {
-				SaveStateDescriptor desc(slot, header._descr.getDescription());
+				SaveStateDescriptor desc(this, slot, header._descr.getDescription());
 
 				return header._descr;
 			}

--- a/engines/dm/metaengine.cpp
+++ b/engines/dm/metaengine.cpp
@@ -53,6 +53,7 @@ public:
 			(f == kSupportsLoadingDuringStartup) ||
 			(f == kSavesSupportThumbnail) ||
 			(f == kSavesSupportMetaInfo) ||
+			(f == kSimpleSavesNames) ||
 			(f == kSavesSupportCreationDate);
 	}
 

--- a/engines/draci/metaengine.cpp
+++ b/engines/draci/metaengine.cpp
@@ -70,7 +70,7 @@ SaveStateList DraciMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				Draci::DraciSavegameHeader header;
 				if (Draci::readSavegameHeader(in, header)) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.saveName));
 				}
 				delete in;
 			}
@@ -100,7 +100,7 @@ SaveStateDescriptor DraciMetaEngine::querySaveMetaInfos(const char *target, int 
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header.saveName);
+		SaveStateDescriptor desc(this, slot, header.saveName);
 		desc.setThumbnail(header.thumbnail);
 
 		int day = (header.date >> 24) & 0xFF;

--- a/engines/dragons/metaengine.cpp
+++ b/engines/dragons/metaengine.cpp
@@ -80,7 +80,7 @@ SaveStateList DragonsMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Dragons::DragonsEngine::readSaveHeader(in, header) == Dragons::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.description));
 				}
 				delete in;
 			}
@@ -99,7 +99,7 @@ SaveStateDescriptor DragonsMetaEngine::querySaveMetaInfos(const char *target, in
 		error = Dragons::DragonsEngine::readSaveHeader(in, header, false);
 		delete in;
 		if (error == Dragons::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(this, slot, header.description);
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveDate & 0xFFFF, (header.saveDate >> 16) & 0xFF, (header.saveDate >> 24) & 0xFF);
 			desc.setSaveTime((header.saveTime >> 16) & 0xFF, (header.saveTime >> 8) & 0xFF);

--- a/engines/dragons/metaengine.cpp
+++ b/engines/dragons/metaengine.cpp
@@ -53,6 +53,7 @@ bool DragonsMetaEngine::hasFeature(MetaEngineFeature f) const {
 			(f == kSupportsLoadingDuringStartup) ||
 			(f == kSavesSupportMetaInfo) ||
 			(f == kSavesSupportThumbnail) ||
+			(f == kSimpleSavesNames) ||
 			(f == kSavesSupportCreationDate);
 }
 
@@ -69,7 +70,7 @@ SaveStateList DragonsMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Dragons::SaveHeader header;
 	Common::String pattern = target;
-	pattern += ".???";
+	pattern += ".###";
 	Common::StringArray filenames;
 	filenames = saveFileMan->listSavefiles(pattern.c_str());
 	SaveStateList saveList;

--- a/engines/drascula/metaengine.cpp
+++ b/engines/drascula/metaengine.cpp
@@ -124,7 +124,7 @@ SaveStateDescriptor DrasculaMetaEngine::querySaveMetaInfos(const char *target, i
 
 	Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(fileName);
 
-	SaveStateDescriptor desc(slot, Common::U32String());
+	SaveStateDescriptor desc(this, slot, Common::U32String());
 	if (in) {
 		desc = Drascula::loadMetaData(in, slot, false);
 		if (desc.getSaveSlot() != slot) {

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -92,7 +92,7 @@ SaveStateList DreamWebMetaEngine::listSaves(const char *target) const {
 		delete stream;
 
 		int slotNum = atoi(file.c_str() + file.size() - 2);
-		SaveStateDescriptor sd(slotNum, name);
+		SaveStateDescriptor sd(this, slotNum, name);
 		saveList.push_back(sd);
 	}
 
@@ -123,7 +123,7 @@ SaveStateDescriptor DreamWebMetaEngine::querySaveMetaInfos(const char *target, i
 		for (i = 0; i < descSize; i++)
 			saveName += (char)in->readByte();
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(this, slot, saveName);
 
 		// Check if there is a ScummVM data block
 		if (header.len(6) == SCUMMVM_BLOCK_MAGIC_SIZE) {

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -43,6 +43,12 @@ public:
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("DREAMWEB.D##");
+		else
+			return Common::String::format("DREAMWEB.D%02d", saveGameIdx);
+	}
 };
 
 bool DreamWebMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/dreamweb/saveload.cpp
+++ b/engines/dreamweb/saveload.cpp
@@ -728,7 +728,7 @@ uint DreamWebEngine::scanForNames() {
 		delete stream;
 
 		int slotNum = atoi(file.c_str() + file.size() - 2);
-		SaveStateDescriptor sd(slotNum, name);
+		SaveStateDescriptor sd(getMetaEngine(), slotNum, name);
 		saveList.push_back(sd);
 		if (slotNum < 21)
 			Common::strlcpy(&_saveNames[17 * slotNum + 1], name, 16);	// the first character is unused

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -562,9 +562,7 @@ void Engine::handleAutoSave() {
 bool Engine::warnBeforeOverwritingAutosave() {
 	SaveStateDescriptor desc = getMetaEngine()->querySaveMetaInfos(
 		_targetName.c_str(), getAutosaveSlot());
-	if (desc.getSaveSlot() == -1)
-		return true;
-	if (desc.hasAutosaveName())
+	if (!desc.isValid() || desc.hasAutosaveName())
 		return true;
 	Common::U32StringArray altButtons;
 	altButtons.push_back(_("Overwrite"));

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -631,7 +631,8 @@ public:
 	}
 
 	/**
-	 * Return the slot that should be used for autosaves.
+	 * Return the slot that should be used for autosaves, or -1 for engines that
+	 * don't support autosave.
 	 *
 	 * @note	This should match the meta engine getAutosaveSlot() method.
 	 */

--- a/engines/glk/metaengine.cpp
+++ b/engines/glk/metaengine.cpp
@@ -249,7 +249,7 @@ SaveStateList GlkMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				Common::String saveName;
 				if (Glk::QuetzalReader::getSavegameDescription(in, saveName))
-					saveList.push_back(SaveStateDescriptor(slot, saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, saveName));
 
 				delete in;
 			}

--- a/engines/gnap/metaengine.cpp
+++ b/engines/gnap/metaengine.cpp
@@ -88,7 +88,7 @@ SaveStateList GnapMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Gnap::GnapEngine::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 				delete in;
 			}
 		}
@@ -117,7 +117,7 @@ SaveStateDescriptor GnapMetaEngine::querySaveMetaInfos(const char *target, int s
 		while ((ch = (char)file->readByte()) != '\0')
 			saveName += ch;
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(this, slot, saveName);
 
 		if (version != 1) {
 			Graphics::Surface *thumbnail;

--- a/engines/grim/metaengine.cpp
+++ b/engines/grim/metaengine.cpp
@@ -121,7 +121,7 @@ SaveStateList GrimMetaEngine::listSaves(const char *target) const {
 				strSize = savedState->readLESint32();
 				savedState->read(str, strSize);
 				savedState->endSection();
-				saveList.push_back(SaveStateDescriptor(slotNum, str));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, str));
 			}
 			delete savedState;
 		}

--- a/engines/groovie/metaengine.cpp
+++ b/engines/groovie/metaengine.cpp
@@ -61,6 +61,7 @@ bool GroovieMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsListSaves) ||
 		(f == kSupportsLoadingDuringStartup) ||
 		(f == kSupportsDeleteSave) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportMetaInfo);
 }
 

--- a/engines/hadesch/metaengine.cpp
+++ b/engines/hadesch/metaengine.cpp
@@ -38,6 +38,7 @@ public:
 			(f == kSavesSupportThumbnail) ||
 			(f == kSavesSupportCreationDate) ||
 			(f == kSavesSupportPlayTime) ||
+			(f == kSimpleSavesNames) ||
 			(f == kSavesUseExtendedFormat);
 	}
 

--- a/engines/hdb/metaengine.cpp
+++ b/engines/hdb/metaengine.cpp
@@ -86,6 +86,7 @@ bool HDBMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsDeleteSave) ||
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportPlayTime);
 }
 

--- a/engines/hopkins/metaengine.cpp
+++ b/engines/hopkins/metaengine.cpp
@@ -115,7 +115,7 @@ SaveStateList HopkinsMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Hopkins::SaveLoadManager::readSavegameHeader(in, header)) {
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 				}
 
 				delete in;
@@ -151,7 +151,7 @@ SaveStateDescriptor HopkinsMetaEngine::querySaveMetaInfos(const char *target, in
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(this, slot, header._saveName);
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -53,7 +53,14 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	void removeSaveState(const char *target, int slot) const override;
-
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s-##.SAV", target);
+		else
+			return Common::String::format("%s-%02d.SAV", target, saveGameIdx);
+	}
 };
 
 Common::Error HugoMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
@@ -123,8 +130,7 @@ SaveStateList HugoMetaEngine::listSaves(const char *target) const {
 }
 
 SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
-	Common::String fileName = Common::String::format("%s-%02d.SAV", target, slot);
-	Common::InSaveFile *file = g_system->getSavefileManager()->openForLoading(fileName);
+	Common::InSaveFile *file = g_system->getSavefileManager()->openForLoading(getSavegameFile(slot, target));
 
 	if (file) {
 		int saveVersion = file->readByte();
@@ -171,8 +177,7 @@ SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int s
 }
 
 void HugoMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String fileName = Common::String::format("%s-%02d.SAV", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 } // End of namespace Hugo

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -111,7 +111,7 @@ SaveStateList HugoMetaEngine::listSaves(const char *target) const {
 				file->read(name, nameSize);
 				name[nameSize] = 0;
 
-				saveList.push_back(SaveStateDescriptor(slotNum, name));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, name));
 				delete file;
 			}
 		}
@@ -140,7 +140,7 @@ SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int s
 		file->read(saveName, saveNameLength);
 		saveName[saveNameLength] = 0;
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(this, slot, saveName);
 
 		Graphics::Surface *thumbnail;
 		if (!Graphics::loadThumbnail(*file, thumbnail)) {

--- a/engines/illusions/metaengine.cpp
+++ b/engines/illusions/metaengine.cpp
@@ -94,7 +94,7 @@ SaveStateList IllusionsMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Illusions::IllusionsEngine::readSaveHeader(in, header) == Illusions::IllusionsEngine::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.description));
 				}
 				delete in;
 			}
@@ -113,7 +113,7 @@ SaveStateDescriptor IllusionsMetaEngine::querySaveMetaInfos(const char *target, 
 		error = Illusions::IllusionsEngine::readSaveHeader(in, header, false);
 		delete in;
 		if (error == Illusions::IllusionsEngine::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(this, slot, header.description);
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveDate & 0xFFFF, (header.saveDate >> 16) & 0xFF, (header.saveDate >> 24) & 0xFF);
 			desc.setSaveTime((header.saveTime >> 16) & 0xFF, (header.saveTime >> 8) & 0xFF);

--- a/engines/illusions/metaengine.cpp
+++ b/engines/illusions/metaengine.cpp
@@ -67,6 +67,7 @@ bool IllusionsMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsLoadingDuringStartup) ||
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportCreationDate);
 }
 

--- a/engines/kingdom/metaengine.cpp
+++ b/engines/kingdom/metaengine.cpp
@@ -92,7 +92,7 @@ SaveStateList KingdomMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Kingdom::KingdomGame::readSavegameHeader(in, header)) {
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 
 					header._thumbnail->free();
 					delete header._thumbnail;
@@ -123,7 +123,7 @@ SaveStateDescriptor KingdomMetaEngine::querySaveMetaInfos(const char *target, in
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(this, slot, header._saveName);
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/kingdom/metaengine.cpp
+++ b/engines/kingdom/metaengine.cpp
@@ -60,6 +60,7 @@ bool KingdomMetaEngine::hasFeature(MetaEngineFeature f) const {
 	    (f == kSupportsDeleteSave) ||
 	    (f == kSavesSupportMetaInfo) ||
 	    (f == kSavesSupportThumbnail) ||
+	    (f == kSimpleSavesNames) ||
 	    (f == kSavesSupportCreationDate);
 }
 

--- a/engines/kyra/metaengine.cpp
+++ b/engines/kyra/metaengine.cpp
@@ -162,7 +162,7 @@ SaveStateList KyraMetaEngine::listSaves(const char *target) const {
 					if (slotNum == 0 && header.gameID == Kyra::GI_KYRA3)
 						header.description = "New Game";
 
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.description));
 				}
 				delete in;
 			}
@@ -202,7 +202,7 @@ SaveStateDescriptor KyraMetaEngine::querySaveMetaInfos(const char *target, int s
 		delete in;
 
 		if (error == Kyra::KyraEngine_v1::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(this, slot, header.description);
 
 			// Slot 0 is used for the 'restart game' save in all three Kyrandia games, thus
 			// we prevent it from being deleted.
@@ -220,7 +220,7 @@ SaveStateDescriptor KyraMetaEngine::querySaveMetaInfos(const char *target, int s
 		}
 	}
 
-	SaveStateDescriptor desc(slot, Common::String());
+	SaveStateDescriptor desc(this, slot, Common::String());
 
 	// We don't allow quick saves (slot 990 till 998) to be overwritten.
 	// The same goes for the 'Autosave', which is slot 999. Slot 0 will also

--- a/engines/kyra/metaengine.cpp
+++ b/engines/kyra/metaengine.cpp
@@ -182,7 +182,8 @@ void KyraMetaEngine::removeSaveState(const char *target, int slot) const {
 	// In Kyra games slot 0 can't be deleted, it's for restarting the game(s).
 	// An exception makes Lands of Lore here, it does not have any way to restart the
 	// game except via its main menu.
-	if (slot == 0 && !ConfMan.getDomain(target)->getVal("gameid").equalsIgnoreCase("lol") && !ConfMan.getDomain(target)->getVal("gameid").equalsIgnoreCase("eob") && !ConfMan.getDomain(target)->getVal("gameid").equalsIgnoreCase("eob2"))
+	const Common::String gameId = ConfMan.getDomain(target)->getVal("gameid");
+	if (slot == 0 && !gameId.equalsIgnoreCase("lol") && !gameId.equalsIgnoreCase("eob") && !gameId.equalsIgnoreCase("eob2"))
 		return;
 
 	Common::String filename = Kyra::KyraEngine_v1::getSavegameFilename(target, slot);

--- a/engines/lab/metaengine.cpp
+++ b/engines/lab/metaengine.cpp
@@ -99,7 +99,7 @@ SaveStateList LabMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Lab::readSaveGameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slotNum, header._descr.getDescription()));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header._descr.getDescription()));
 				delete in;
 			}
 		}
@@ -130,7 +130,7 @@ SaveStateDescriptor LabMetaEngine::querySaveMetaInfos(const char *target, int sl
 		delete in;
 
 		if (successfulRead) {
-			SaveStateDescriptor desc(slot, header._descr.getDescription());
+			SaveStateDescriptor desc(this, slot, header._descr.getDescription());
 			return header._descr;
 		}
 	}

--- a/engines/lilliput/metaengine.cpp
+++ b/engines/lilliput/metaengine.cpp
@@ -117,7 +117,7 @@ SaveStateList LilliputMetaEngine::listSaves(const char *target) const {
 				file->read(name, nameSize);
 				name[nameSize] = 0;
 
-				saveList.push_back(SaveStateDescriptor(slotNum, name));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, name));
 				delete file;
 			}
 		}
@@ -147,7 +147,7 @@ SaveStateDescriptor LilliputMetaEngine::querySaveMetaInfos(const char *target, i
 			saveName += curChr;
 		}
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(this, slot, saveName);
 
 		Graphics::Surface *thumbnail;
 		if (!Graphics::loadThumbnail(*file, thumbnail)) {

--- a/engines/lilliput/metaengine.cpp
+++ b/engines/lilliput/metaengine.cpp
@@ -57,6 +57,14 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s-##.SAV", target);
+		else
+			return Common::String::format("%s-%02d.SAV", target, saveGameIdx);
+	}
 };
 
 Common::Error LilliputMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
@@ -128,8 +136,7 @@ SaveStateList LilliputMetaEngine::listSaves(const char *target) const {
 }
 
 SaveStateDescriptor LilliputMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
-	Common::String fileName = Common::String::format("%s-%02d.SAV", target, slot);
-	Common::InSaveFile *file = g_system->getSavefileManager()->openForLoading(fileName);
+	Common::InSaveFile *file = g_system->getSavefileManager()->openForLoading(getSavegameFile(slot, target));
 
 	if (file) {
 		int saveVersion = file->readByte();
@@ -177,8 +184,7 @@ SaveStateDescriptor LilliputMetaEngine::querySaveMetaInfos(const char *target, i
 }
 
 void LilliputMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String fileName = Common::String::format("%s-%02d.SAV", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 } // End of namespace Lilliput

--- a/engines/lure/metaengine.cpp
+++ b/engines/lure/metaengine.cpp
@@ -69,6 +69,7 @@ bool LureMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return
 		(f == kSupportsListSaves) ||
 		(f == kSupportsLoadingDuringStartup) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSupportsDeleteSave);
 }
 

--- a/engines/lure/metaengine.cpp
+++ b/engines/lure/metaengine.cpp
@@ -101,7 +101,7 @@ SaveStateList LureMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				saveDesc = Lure::getSaveName(in);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}

--- a/engines/macventure/metaengine.cpp
+++ b/engines/macventure/metaengine.cpp
@@ -64,6 +64,7 @@ bool MacVentureMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportPlayTime);
 }
 

--- a/engines/macventure/metaengine.cpp
+++ b/engines/macventure/metaengine.cpp
@@ -85,7 +85,7 @@ SaveStateList MacVentureMetaEngine::listSaves(const char *target) const {
 	SaveStateList saveList;
 	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {
 		int slotNum = atoi(file->c_str() + file->size() - 3);
-		SaveStateDescriptor desc(slotNum, Common::U32String());
+		SaveStateDescriptor desc(this, slotNum, Common::U32String());
 		if (slotNum >= 0 && slotNum <= getMaximumSaveSlot()) {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {

--- a/engines/mads/metaengine.cpp
+++ b/engines/mads/metaengine.cpp
@@ -118,7 +118,7 @@ SaveStateList MADSMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (MADS::Game::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 				delete in;
 			}
 		}
@@ -151,7 +151,7 @@ SaveStateDescriptor MADSMetaEngine::querySaveMetaInfos(const char *target, int s
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(this, slot, header._saveName);
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -38,14 +38,16 @@
 #include "graphics/thumbnail.h"
 
 Common::String MetaEngine::getSavegameFile(int saveGameIdx, const char *target) const {
+	if (!target)
+		target = getEngineId();
 	if (saveGameIdx == kSavegameFilePattern) {
 		// Pattern requested
-		const char *pattern = hasFeature(kSavesUseExtendedFormat) ? "%s.###" : "%s.s##";
-		return Common::String::format(pattern, target == nullptr ? getEngineId() : target);
+		const char *pattern = hasFeature(kSimpleSavesNames) ? "%s.###" : "%s.s##";
+		return Common::String::format(pattern, target);
 	} else {
 		// Specific filename requested
-		const char *pattern = hasFeature(kSavesUseExtendedFormat) ? "%s.%03d" : "%s.s%02d";
-		return Common::String::format(pattern, target == nullptr ? getEngineId() : target, saveGameIdx);
+		const char *pattern = hasFeature(kSimpleSavesNames) ? "%s.%03d" : "%s.s%02d";
+		return Common::String::format(pattern, target, saveGameIdx);
 	}
 }
 
@@ -165,6 +167,7 @@ bool MetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
 		(f == kSupportsLoadingDuringStartup) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesUseExtendedFormat);
 }
 

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -361,7 +361,7 @@ SaveStateList MetaEngine::listSaves(const char *target, bool saveMode) const {
 
 	// No autosave yet. We want to add a dummy one in so that it can be marked as
 	// write protected, and thus be prevented from being saved in
-	SaveStateDescriptor desc(autosaveSlot, _("Autosave"));
+	SaveStateDescriptor desc(this, autosaveSlot, _("Autosave"));
 	saveList.push_back(desc);
 	Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
 
@@ -409,7 +409,7 @@ SaveStateDescriptor MetaEngine::querySaveMetaInfos(const char *target, int slot)
 		}
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, Common::U32String());
+		SaveStateDescriptor desc(this, slot, Common::U32String());
 		parseSavegameHeader(&header, &desc);
 		desc.setThumbnail(header.thumbnail);
 		return desc;

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -477,6 +477,9 @@ public:
 		* of detecting saves and slot numbers, this should be
 		* unavailable. In that case Save/Load dialog for the engine's
 		* games is locked during cloud saves sync.
+		*
+		* NOTE: This flag is used by cloud code, but also in
+		* MetaEngine::getSavegameFile(), for common save names.
 		*/
 		kSimpleSavesNames,
 

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -305,7 +305,8 @@ public:
 	SaveStateList listSaves(const char *target, bool saveMode) const;
 
 	/**
-	 * Return the slot number that is used for autosaves.
+	 * Return the slot number that is used for autosaves, or -1 for engines that
+	 * don't support autosave.
 	 *
 	 * @note This should match the engine getAutosaveSlot() method.
 	 */

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -167,7 +167,7 @@ SaveStateList MohawkMetaEngine::listSavesForPrefix(const char *prefix, const cha
 
 		int slotNum = atoi(slot);
 
-		saveList.push_back(SaveStateDescriptor(slotNum, ""));
+		saveList.push_back(SaveStateDescriptor(this, slotNum, ""));
 	}
 
 	Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
@@ -229,7 +229,7 @@ SaveStateDescriptor MohawkMetaEngine::querySaveMetaInfos(const char *target, int
 
 #ifdef ENABLE_MYST
 	if (gameId == "myst") {
-		return Mohawk::MystGameState::querySaveMetaInfos(slot);
+		return Mohawk::MystGameState::querySaveMetaInfos(this, slot);
 	}
 #endif
 #ifdef ENABLE_RIVEN

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -138,6 +138,24 @@ public:
 	Common::KeymapArray initKeymaps(const char *target) const override;
 
 	GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		Common::String gameId = ConfMan.get("gameid", target);
+		const char *suffix;
+		// Saved games are only supported in Myst/Riven currently.
+		if (gameId == "myst")
+			suffix = "mys";
+		else if (gameId == "riven")
+			suffix = "rvn";
+		else
+			return MetaEngine::getSavegameFile(saveGameIdx, target);
+
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s-###.%s", gameId.c_str(), suffix);
+		else
+			return Common::String::format("%s-%03d.%s", gameId.c_str(), saveGameIdx, suffix);
+	}
 };
 
 bool MohawkMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -268,8 +268,8 @@ bool MystGameState::saveMetadata(int slot, const Graphics::Surface *thumbnail) {
 	return true;
 }
 
-SaveStateDescriptor MystGameState::querySaveMetaInfos(int slot) {
-	SaveStateDescriptor desc(slot, Common::U32String());
+SaveStateDescriptor MystGameState::querySaveMetaInfos(const MetaEngine *metaEngine, int slot) {
+	SaveStateDescriptor desc(metaEngine, slot, Common::U32String());
 
 	// Open the save file
 	Common::String filename = buildSaveFilename(slot);

--- a/engines/mohawk/myst_state.h
+++ b/engines/mohawk/myst_state.h
@@ -105,7 +105,7 @@ public:
 	MystGameState(MohawkEngine_Myst*, Common::SaveFileManager*);
 	~MystGameState();
 
-	static SaveStateDescriptor querySaveMetaInfos(int slot);
+	static SaveStateDescriptor querySaveMetaInfos(const MetaEngine *metaEngine, int slot);
 	static Common::String querySaveDescription(int slot);
 
 	void reset();

--- a/engines/mortevielle/metaengine.cpp
+++ b/engines/mortevielle/metaengine.cpp
@@ -51,6 +51,14 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.###", target); // There is also sav0.mor for slot 0
+		else
+			return Mortevielle::MortevielleEngine::generateSaveFilename(target, saveGameIdx);
+	}
 };
 
 Common::Error MortevielleMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {

--- a/engines/mortevielle/metaengine.cpp
+++ b/engines/mortevielle/metaengine.cpp
@@ -76,12 +76,12 @@ bool MortevielleMetaEngine::hasFeature(MetaEngineFeature f) const {
 int MortevielleMetaEngine::getMaximumSaveSlot() const { return 99; }
 
 SaveStateList MortevielleMetaEngine::listSaves(const char *target) const {
-	return Mortevielle::SavegameManager::listSaves(target);
+	return Mortevielle::SavegameManager::listSaves(this, target);
 }
 
 SaveStateDescriptor MortevielleMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
 	Common::String filename = Mortevielle::MortevielleEngine::generateSaveFilename(target, slot);
-	return Mortevielle::SavegameManager::querySaveMetaInfos(filename);
+	return Mortevielle::SavegameManager::querySaveMetaInfos(this, filename);
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(MORTEVIELLE)

--- a/engines/mortevielle/saveload.cpp
+++ b/engines/mortevielle/saveload.cpp
@@ -235,7 +235,7 @@ WARN_UNUSED_RESULT bool SavegameManager::readSavegameHeader(Common::InSaveFile *
 	return true;
 }
 
-SaveStateList SavegameManager::listSaves(const Common::String &target) {
+SaveStateList SavegameManager::listSaves(const MetaEngine *metaEngine, const Common::String &target) {
 	Common::String pattern = target;
 	pattern += ".###";
 
@@ -274,7 +274,7 @@ SaveStateList SavegameManager::listSaves(const Common::String &target) {
 
 			if (validFlag)
 				// Got a valid savegame
-				saveList.push_back(SaveStateDescriptor(slotNumber, saveDescription));
+				saveList.push_back(SaveStateDescriptor(metaEngine, slotNumber, saveDescription));
 
 			delete in;
 		}
@@ -284,7 +284,7 @@ SaveStateList SavegameManager::listSaves(const Common::String &target) {
 	return saveList;
 }
 
-SaveStateDescriptor SavegameManager::querySaveMetaInfos(const Common::String &fileName) {
+SaveStateDescriptor SavegameManager::querySaveMetaInfos(const MetaEngine *metaEngine, const Common::String &fileName) {
 	Common::InSaveFile *f = g_system->getSavefileManager()->openForLoading(fileName);
 
 	if (f) {
@@ -303,7 +303,7 @@ SaveStateDescriptor SavegameManager::querySaveMetaInfos(const Common::String &fi
 			// Original savegame perhaps?
 			delete f;
 
-			return SaveStateDescriptor(slot, Common::String::format("Savegame - %03d", slot));
+			return SaveStateDescriptor(metaEngine, slot, Common::String::format("Savegame - %03d", slot));
 		} else {
 			// Get the savegame header information
 			SavegameHeader header;
@@ -314,7 +314,7 @@ SaveStateDescriptor SavegameManager::querySaveMetaInfos(const Common::String &fi
 			delete f;
 
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(metaEngine, slot, header.saveName);
 			desc.setDeletableFlag(true);
 			desc.setWriteProtectedFlag(false);
 			desc.setThumbnail(header.thumbnail);

--- a/engines/mortevielle/saveload.h
+++ b/engines/mortevielle/saveload.h
@@ -67,8 +67,8 @@ public:
 
 	void writeSavegameHeader(Common::OutSaveFile *out, const Common::String &saveName);
 	WARN_UNUSED_RESULT static bool readSavegameHeader(Common::InSaveFile *in, SavegameHeader &header, bool skipThumbnail = true);
-	static SaveStateList listSaves(const Common::String &target);
-	static SaveStateDescriptor querySaveMetaInfos(const Common::String &fileName);
+	static SaveStateList listSaves(const MetaEngine *metaEngine, const Common::String &target);
+	static SaveStateDescriptor querySaveMetaInfos(const MetaEngine *metaEngine, const Common::String &fileName);
 };
 
 } // End of namespace Mortevielle

--- a/engines/mutationofjb/metaengine.cpp
+++ b/engines/mutationofjb/metaengine.cpp
@@ -72,7 +72,7 @@ public:
 
 				MutationOfJB::SaveHeader saveHdr;
 				if (saveHdr.sync(sz)) {
-					saveList.push_back(SaveStateDescriptor(slotNo, saveHdr._description));
+					saveList.push_back(SaveStateDescriptor(this, slotNo, saveHdr._description));
 				}
 			}
 		}

--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -132,6 +132,8 @@ public:
 	}
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+
+	// TODO: Add getSavegameFile()
 };
 
 Common::Error Myst3MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {

--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -56,7 +56,7 @@ public:
 
 		SaveStateList saveList;
 		for (uint32 i = 0; i < filenames.size(); i++)
-			saveList.push_back(SaveStateDescriptor(i, filenames[i]));
+			saveList.push_back(SaveStateDescriptor(this, i, filenames[i]));
 
 		return saveList;
 	}

--- a/engines/nancy/metaengine.cpp
+++ b/engines/nancy/metaengine.cpp
@@ -57,6 +57,7 @@ bool NancyMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesUseExtendedFormat);
 }
 

--- a/engines/neverhood/metaengine.cpp
+++ b/engines/neverhood/metaengine.cpp
@@ -112,7 +112,7 @@ SaveStateList NeverhoodMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Neverhood::NeverhoodEngine::readSaveHeader(in, header) == Neverhood::NeverhoodEngine::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.description));
 				}
 				delete in;
 			}
@@ -146,7 +146,7 @@ SaveStateDescriptor NeverhoodMetaEngine::querySaveMetaInfos(const char *target, 
 		delete in;
 
 		if (error == Neverhood::NeverhoodEngine::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(this, slot, header.description);
 
 			desc.setThumbnail(header.thumbnail);
 			int day = (header.saveDate >> 24) & 0xFF;

--- a/engines/ngi/metaengine.cpp
+++ b/engines/ngi/metaengine.cpp
@@ -110,11 +110,9 @@ SaveStateList NGIMetaEngine::listSaves(const char *target) const {
 					continue;
 				}
 
-				SaveStateDescriptor desc;
+				SaveStateDescriptor desc(this, slotNum, header.description);
 
 				NGI::parseSavegameHeader(header, desc);
-
-				desc.setSaveSlot(slotNum);
 
 				saveList.push_back(desc);
 			}
@@ -141,11 +139,10 @@ SaveStateDescriptor NGIMetaEngine::querySaveMetaInfos(const char *target, int sl
 		}
 
 		// Create the return descriptor
-		SaveStateDescriptor desc;
+		SaveStateDescriptor desc(this, slot, header.description);
 
 		NGI::parseSavegameHeader(header, desc);
 
-		desc.setSaveSlot(slot);
 		desc.setThumbnail(header.thumbnail);
 
 		return desc;

--- a/engines/ngi/metaengine.cpp
+++ b/engines/ngi/metaengine.cpp
@@ -69,6 +69,13 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		const Common::String prefix("fullpipe");
+		if (saveGameIdx == kSavegameFilePattern)
+			return prefix + ".s##";
+		else
+			return prefix + Common::String::format(".s%02d", saveGameIdx);
+	}
 };
 
 bool NGIMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -79,8 +86,7 @@ bool NGIMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
-		(f == kSupportsLoadingDuringStartup) ||
-		(f == kSimpleSavesNames);
+		(f == kSupportsLoadingDuringStartup);
 }
 
 bool NGI::NGIEngine::hasFeature(EngineFeature f) const {
@@ -93,9 +99,8 @@ bool NGI::NGIEngine::hasFeature(EngineFeature f) const {
 SaveStateList NGIMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::StringArray filenames;
-	Common::String pattern("fullpipe.s##");
 
-	filenames = saveFileMan->listSavefiles(pattern);
+	filenames = saveFileMan->listSavefiles(getSavegameFilePattern(target));
 
 	SaveStateList saveList;
 	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {

--- a/engines/ngi/modal.cpp
+++ b/engines/ngi/modal.cpp
@@ -2153,7 +2153,7 @@ bool ModalSaveGame::getFileInfo(int slot, FileInfo *fileinfo) {
 		return false;
 
 	// Create the return descriptor
-	SaveStateDescriptor desc(slot, header.saveName);
+	SaveStateDescriptor desc(g_nmi->getMetaEngine(), slot, header.description);
 	char res[17];
 
 	NGI::parseSavegameHeader(header, desc);

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -164,7 +164,7 @@ SaveStateList ParallactionMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				Common::String saveDesc = in->readLine();
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -57,11 +57,21 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		const Common::String prefix = ConfMan.getDomain(target)->getVal("gameid");
+		if (saveGameIdx == kSavegameFilePattern)
+			return prefix + ".###";
+		else
+			return prefix + Common::String::format(".%03d", saveGameIdx);
+	}
 };
 
 bool ParallactionMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return
 		(f == kSupportsListSaves) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSupportsDeleteSave);
 }
 
@@ -152,8 +162,7 @@ Common::KeymapArray ParallactionMetaEngine::initKeymaps(const char *target) cons
 SaveStateList ParallactionMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 
-	Common::String pattern(ConfMan.getDomain(target)->getVal("gameid") + ".0##");
-	Common::StringArray filenames = saveFileMan->listSavefiles(pattern);
+	Common::StringArray filenames = saveFileMan->listSavefiles(getSavegameFilePattern(target));
 
 	SaveStateList saveList;
 	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {
@@ -178,10 +187,7 @@ SaveStateList ParallactionMetaEngine::listSaves(const char *target) const {
 int ParallactionMetaEngine::getMaximumSaveSlot() const { return 99; }
 
 void ParallactionMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String filename = ConfMan.getDomain(target)->getVal("gameid");
-	filename += Common::String::format(".0%02d", slot);
-
-	g_system->getSavefileManager()->removeSavefile(filename);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(PARALLACTION)

--- a/engines/pegasus/metaengine.cpp
+++ b/engines/pegasus/metaengine.cpp
@@ -100,7 +100,7 @@ SaveStateList PegasusMetaEngine::listSaves(const char *target) const {
 		for (int j = 0; j < 4; j++)
 			desc.deleteLastChar();
 
-		saveList.push_back(SaveStateDescriptor(i, desc));
+		saveList.push_back(SaveStateDescriptor(this, i, desc));
 	}
 
 	return saveList;

--- a/engines/pegasus/metaengine.cpp
+++ b/engines/pegasus/metaengine.cpp
@@ -78,6 +78,18 @@ public:
 	int getMaximumSaveSlot() const override { return 999; }
 	void removeSaveState(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("pegasus-*.sav");
+		Common::StringArray fileNames = Pegasus::PegasusEngine::listSaveFiles();
+		if (saveGameIdx < fileNames.size())
+			return fileNames[saveGameIdx];
+		if (fileNames.empty())
+			return Common::String("pegasus-1.sav");
+		Common::String name = fileNames.back();
+		name.insertString("_last", name.size() - 4);
+		return name;
+	}
 };
 
 bool PegasusMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -702,8 +702,15 @@ void PegasusEngine::writeContinueStream(Common::WriteStream *stream) {
 }
 
 Common::StringArray PegasusEngine::listSaveFiles() {
+	const Common::String autoSaveName("pegasus-AutoSave.sav");
 	Common::StringArray fileNames = g_system->getSavefileManager()->listSavefiles("pegasus-*.sav");
+	// Autosave must be at slot 0, so remove it, then prepend (even if it doesn't exist,
+	// it will be prepended)
+	Common::StringArray::iterator it = Common::find(fileNames.begin(), fileNames.end(), autoSaveName);
+	if (it != fileNames.end())
+		fileNames.erase(it);
 	Common::sort(fileNames.begin(), fileNames.end());
+	fileNames.insert_at(0, autoSaveName);
 	return fileNames;
 }
 
@@ -733,10 +740,11 @@ static bool isValidSaveFileName(const Common::String &desc) {
 }
 
 Common::Error PegasusEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	if (!isValidSaveFileName(desc))
+	Common::String saveName = isAutosave ? Common::String("AutoSave") : desc;
+	if (!isValidSaveFileName(saveName))
 		return Common::Error(Common::kCreatingFileFailed, _("Invalid file name for saving"));
 
-	Common::String output = Common::String::format("pegasus-%s.sav", desc.c_str());
+	Common::String output = Common::String::format("pegasus-%s.sav", saveName.c_str());
 	Common::OutSaveFile *saveFile = _saveFileMan->openForSaving(output, false);
 	if (!saveFile)
 		return Common::kUnknownError;

--- a/engines/pink/metaengine.cpp
+++ b/engines/pink/metaengine.cpp
@@ -58,8 +58,7 @@ bool PinkMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
-		(f == kSupportsLoadingDuringStartup) ||
-		(f == kSimpleSavesNames);
+		(f == kSupportsLoadingDuringStartup);
 }
 
 SaveStateList PinkMetaEngine::listSaves(const char *target) const {

--- a/engines/prince/metaengine.cpp
+++ b/engines/prince/metaengine.cpp
@@ -104,11 +104,11 @@ SaveStateList PrinceMetaEngine::listSaves(const char *target) const {
 				if (!strncmp(buffer, kSavegameStr, kSavegameStrSize + 1)) {
 					// Valid savegame
 					if (Prince::PrinceEngine::readSavegameHeader(file, header)) {
-						saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+						saveList.push_back(SaveStateDescriptor(this, slotNum, header.saveName));
 					}
 				} else {
 					// Must be an original format savegame
-					saveList.push_back(SaveStateDescriptor(slotNum, "Unknown"));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, "Unknown"));
 				}
 
 				delete file;
@@ -137,11 +137,11 @@ SaveStateDescriptor PrinceMetaEngine::querySaveMetaInfos(const char *target, int
 
 		if (!hasHeader) {
 			// Original savegame perhaps?
-			SaveStateDescriptor desc(slot, "Unknown");
+			SaveStateDescriptor desc(this, slot, "Unknown");
 			return desc;
 		} else {
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(this, slot, header.saveName);
 			desc.setThumbnail(header.thumbnail);
 			desc.setSaveDate(header.saveYear, header.saveMonth, header.saveDay);
 			desc.setSaveTime(header.saveHour, header.saveMinutes);

--- a/engines/queen/metaengine.cpp
+++ b/engines/queen/metaengine.cpp
@@ -69,7 +69,7 @@ SaveStateList QueenMetaEngine::listSaves(const char *target) const {
 				for (int i = 0; i < 4; i++)
 					in->readUint32BE();
 				in->read(saveDesc, 32);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -143,7 +143,7 @@ SaveStateList SagaMetaEngine::listSaves(const char *target) const {
 				for (int i = 0; i < 3; i++)
 					in->readUint32BE();
 				in->read(saveDesc, SAVE_TITLE_SIZE);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}
@@ -177,7 +177,7 @@ SaveStateDescriptor SagaMetaEngine::querySaveMetaInfos(const char *target, int s
 		char name[SAVE_TITLE_SIZE];
 		in->read(name, sizeof(name));
 
-		SaveStateDescriptor desc(slot, name);
+		SaveStateDescriptor desc(this, slot, name);
 
 		// Some older saves were not written in an endian safe fashion.
 		// We try to detect this here by checking for extremely high version values.

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -94,8 +94,7 @@ bool SagaMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
-		(f == kSavesSupportPlayTime) ||
-		(f == kSimpleSavesNames);
+		(f == kSavesSupportPlayTime);
 }
 
 bool Saga::SagaEngine::hasFeature(EngineFeature f) const {

--- a/engines/saga2/metaengine.cpp
+++ b/engines/saga2/metaengine.cpp
@@ -42,6 +42,7 @@ bool Saga2MetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesUseExtendedFormat);
 }
 

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -98,3 +98,8 @@ bool SaveStateDescriptor::hasAutosaveName() const
 {
 	return _description.contains(_("Autosave"));
 }
+
+bool SaveStateDescriptor::isValid() const
+{
+	return _slot >= 0 && !_description.empty();
+}

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -22,6 +22,7 @@
 
 #include "engines/savestate.h"
 #include "engines/engine.h"
+#include "engines/metaengine.h"
 #include "graphics/surface.h"
 #include "common/config-manager.h"
 #include "common/textconsole.h"
@@ -34,20 +35,22 @@ SaveStateDescriptor::SaveStateDescriptor()
 	_thumbnail(), _saveType(kSaveTypeUndetermined) {
 }
 
-SaveStateDescriptor::SaveStateDescriptor(int slot, const Common::U32String &d)
+SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::U32String &d)
 	: _slot(slot), _description(d), _isLocked(false), _playTimeMSecs(0) {
-	initSaveType();
+	initSaveType(metaEngine);
 }
 
-SaveStateDescriptor::SaveStateDescriptor(int slot, const Common::String &d)
+SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::String &d)
 	: _slot(slot), _description(Common::U32String(d)), _isLocked(false), _playTimeMSecs(0) {
-	initSaveType();
+	initSaveType(metaEngine);
 }
 
-void SaveStateDescriptor::initSaveType() {
+void SaveStateDescriptor::initSaveType(const MetaEngine *metaEngine) {
 	// Do not allow auto-save slot to be deleted or overwritten.
+	if (!metaEngine && g_engine)
+		metaEngine = g_engine->getMetaEngine();
 	const bool autosave =
-			g_engine && ConfMan.getInt("autosave_period") && _slot == g_engine->getAutosaveSlot();
+			metaEngine && ConfMan.getInt("autosave_period") && _slot == metaEngine->getAutosaveSlot();
 	_isWriteProtected = autosave;
 	_saveType = autosave ? kSaveTypeAutosave : kSaveTypeRegular;
 	_isDeletable = !autosave;

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -28,6 +28,8 @@
 #include "common/ustr.h"
 #include "common/ptr.h"
 
+class MetaEngine;
+
 namespace Graphics {
 struct Surface;
 }
@@ -60,11 +62,11 @@ private:
 		kSaveTypeAutosave
 	};
 
-	void initSaveType();
+	void initSaveType(const MetaEngine *metaEngine);
 public:
 	SaveStateDescriptor();
-	SaveStateDescriptor(int slot, const Common::U32String &d);
-	SaveStateDescriptor(int slot, const Common::String &d);
+	SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::U32String &d);
+	SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::String &d);
 
 	/**
 	 * @param slot The saveslot id, as it would be passed to the "-x" command line switch.

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -221,6 +221,11 @@ public:
 	 * Returns true if the save has an autosave name
 	 */
 	bool hasAutosaveName() const;
+
+	/**
+	 * Returns true if this entry is valid
+	 */
+	bool isValid() const;
 private:
 	/**
 	 * The saveslot id, as it would be passed to the "-x" command line switch.

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -310,6 +310,7 @@ bool SciMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportPlayTime);
 }
 

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -351,7 +351,7 @@ SaveStateList SciMetaEngine::listSaves(const char *target) const {
 					delete in;
 					continue;
 				}
-				SaveStateDescriptor descriptor(slotNr, meta.name);
+				SaveStateDescriptor descriptor(this, slotNr, meta.name);
 
 				if (descriptor.isAutosave()) {
 					hasAutosave = true;
@@ -364,7 +364,7 @@ SaveStateList SciMetaEngine::listSaves(const char *target) const {
 	}
 
 	if (!hasAutosave) {
-		SaveStateDescriptor descriptor(0, _("(Autosave)"));
+		SaveStateDescriptor descriptor(this, 0, _("(Autosave)"));
 		descriptor.setLocked(true);
 		saveList.push_back(descriptor);
 	}
@@ -377,7 +377,7 @@ SaveStateList SciMetaEngine::listSaves(const char *target) const {
 SaveStateDescriptor SciMetaEngine::querySaveMetaInfos(const char *target, int slotNr) const {
 	const Common::String fileName = Common::String::format("%s.%03d", target, slotNr);
 	Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(fileName);
-	SaveStateDescriptor descriptor(slotNr, "");
+	SaveStateDescriptor descriptor(this, slotNr, "");
 
 	if (in) {
 		SavegameMetadata meta;

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -476,7 +476,7 @@ SaveStateList ScummMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 			if (in) {
 				Scumm::getSavegameName(in, saveDesc, 0);	// FIXME: heversion?!?
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}
@@ -504,7 +504,7 @@ SaveStateDescriptor ScummMetaEngine::querySaveMetaInfos(const char *target, int 
 		return SaveStateDescriptor();
 	}
 
-	SaveStateDescriptor desc(slot, saveDesc);
+	SaveStateDescriptor desc(this, slot, saveDesc);
 	desc.setThumbnail(thumbnail);
 
 	if (infoPtr) {

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -228,8 +228,7 @@ bool ScummMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
 		(f == kSavesSupportCreationDate) ||
-		(f == kSavesSupportPlayTime) ||
-		(f == kSimpleSavesNames);
+		(f == kSavesSupportPlayTime);
 }
 
 bool ScummEngine::hasFeature(EngineFeature f) const {

--- a/engines/sherlock/metaengine.cpp
+++ b/engines/sherlock/metaengine.cpp
@@ -123,7 +123,7 @@ bool Sherlock::SherlockEngine::isDemo() const {
 }
 
 SaveStateList SherlockMetaEngine::listSaves(const char *target) const {
-	return Sherlock::SaveManager::getSavegameList(target);
+	return Sherlock::SaveManager::getSavegameList(this, target);
 }
 
 int SherlockMetaEngine::getMaximumSaveSlot() const {
@@ -148,7 +148,7 @@ SaveStateDescriptor SherlockMetaEngine::querySaveMetaInfos(const char *target, i
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(this, slot, header._saveName);
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/sherlock/saveload.cpp
+++ b/engines/sherlock/saveload.cpp
@@ -65,7 +65,7 @@ void SaveManager::createSavegameList() {
 	for (int idx = 0; idx < MAX_SAVEGAME_SLOTS; ++idx)
 		_savegames.push_back(EMPTY_SAVEGAME_SLOT);
 
-	SaveStateList saveList = getSavegameList(_target);
+	SaveStateList saveList = getSavegameList(_vm->getMetaEngine(), _target);
 	for (uint idx = 0; idx < saveList.size(); ++idx) {
 		int slot = saveList[idx].getSaveSlot();
 		if (slot >= 0 && slot < MAX_SAVEGAME_SLOTS)
@@ -85,7 +85,7 @@ void SaveManager::createSavegameList() {
 	}
 }
 
-SaveStateList SaveManager::getSavegameList(const Common::String &target) {
+SaveStateList SaveManager::getSavegameList(const MetaEngine *metaEngine, const Common::String &target) {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::StringArray filenames;
 	Common::String saveDesc;
@@ -104,7 +104,7 @@ SaveStateList SaveManager::getSavegameList(const Common::String &target) {
 
 			if (in) {
 				if (readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(metaEngine, slot, header._saveName));
 
 				delete in;
 			}

--- a/engines/sherlock/saveload.h
+++ b/engines/sherlock/saveload.h
@@ -89,7 +89,7 @@ public:
 	/**
 	 * Load a list of savegames
 	 */
-	static SaveStateList getSavegameList(const Common::String &target);
+	static SaveStateList getSavegameList(const MetaEngine *metaEngine, const Common::String &target);
 
 	/**
 	 * Support method that generates a savegame name

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -176,7 +176,7 @@ SaveStateList SkyMetaEngine::listSaves(const char *target) const {
 		int slotNum = atoi(ext.c_str());
 		Common::InSaveFile *in = saveFileMan->openForLoading(*file);
 		if (in) {
-			saveList.push_back(SaveStateDescriptor(slotNum,
+			saveList.push_back(SaveStateDescriptor(this, slotNum,
 				(slotNum == 0) ? _("Autosave") : Common::U32String(savenames[slotNum - 1])));
 			delete in;
 		}
@@ -274,7 +274,7 @@ SaveStateDescriptor SkyMetaEngine::querySaveMetaInfos(const char *target, int sl
 		Common::InSaveFile *in = saveFileMan->openForLoading(fName);
 		if (in) {
 			delete in;
-			SaveStateDescriptor descriptor(slot, tmpSavename);
+			SaveStateDescriptor descriptor(this, slot, tmpSavename);
 			return descriptor;
 		}
 	}

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -52,6 +52,12 @@ class SkyMetaEngine : public MetaEngine {
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("SKY-VM.###");
+		else
+			return Common::String::format("SKY-VM.%03d", saveGameIdx);
+	}
 };
 
 bool SkyMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/stark/metaengine.cpp
+++ b/engines/stark/metaengine.cpp
@@ -66,7 +66,7 @@ public:
 				description = stream.readString();
 			}
 
-			saveList.push_back(SaveStateDescriptor(slot, description));
+			saveList.push_back(SaveStateDescriptor(this, slot, description));
 		}
 
 		Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());

--- a/engines/startrek/metaengine.cpp
+++ b/engines/startrek/metaengine.cpp
@@ -118,7 +118,7 @@ SaveStateList StarTrekMetaEngine::listSaves(const char *target) const {
 					strcpy(meta.description, "[broken saved game]");
 				}
 
-				saveList.push_back(SaveStateDescriptor(slotNr, meta.description));
+				saveList.push_back(SaveStateDescriptor(this, slotNr, meta.description));
 			}
 		}
 	}
@@ -157,11 +157,11 @@ SaveStateDescriptor StarTrekMetaEngine::querySaveMetaInfos(const char *target, i
 		}
 		if (descriptionPos >= sizeof(meta.description)) {
 			// broken meta.description, ignore it
-			SaveStateDescriptor descriptor(slotNr, "[broken saved game]");
+			SaveStateDescriptor descriptor(this, slotNr, "[broken saved game]");
 			return descriptor;
 		}
 
-		SaveStateDescriptor descriptor(slotNr, meta.description);
+		SaveStateDescriptor descriptor(this, slotNr, meta.description);
 
 		if (meta.thumbnail == nullptr) {
 			return SaveStateDescriptor();
@@ -175,7 +175,7 @@ SaveStateDescriptor StarTrekMetaEngine::querySaveMetaInfos(const char *target, i
 		return descriptor;
 
 	} else {
-		SaveStateDescriptor emptySave(slotNr, Common::U32String());
+		SaveStateDescriptor emptySave(this, slotNr, Common::U32String());
 		return emptySave;
 	}
 }

--- a/engines/supernova/metaengine.cpp
+++ b/engines/supernova/metaengine.cpp
@@ -45,6 +45,17 @@ public:
 		return 99;
 	}
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		const char *prefix = target;
+		if (!strncmp(target, "msn1", 4))
+			prefix = "msn_save";
+		if (!strncmp(target, "msn2", 4))
+			prefix = "ms2_save";
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.###", prefix);
+		else
+			return Common::String::format("%s.%03d", prefix, saveGameIdx);
+	}
 };
 
 bool SupernovaMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -69,11 +80,7 @@ Common::Error SupernovaMetaEngine::createInstance(OSystem *syst, Engine **engine
 
 SaveStateList SupernovaMetaEngine::listSaves(const char *target) const {
 	Common::StringArray filenames;
-	Common::String pattern;
-	if (!strncmp(target, "msn1", 4))
-		pattern = Common::String::format("msn_save.###");
-	if (!strncmp(target, "msn2", 4))
-		pattern = Common::String::format("ms2_save.###");
+	const Common::String pattern = getSavegameFilePattern(target);
 
 	filenames = g_system->getSavefileManager()->listSavefiles(pattern);
 
@@ -106,21 +113,11 @@ SaveStateList SupernovaMetaEngine::listSaves(const char *target) const {
 }
 
 void SupernovaMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String filename;
-	if (!strncmp(target, "msn1", 4))
-		filename = Common::String::format("msn_save.%03d", slot);
-	if (!strncmp(target, "msn2", 4))
-		filename = Common::String::format("ms2_save.%03d", slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 SaveStateDescriptor SupernovaMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
-	Common::String fileName;
-	if (!strncmp(target, "msn1", 4))
-		fileName = Common::String::format("msn_save.%03d", slot);
-	if (!strncmp(target, "msn2", 4))
-		fileName = Common::String::format("ms2_save.%03d", slot);
-	Common::InSaveFile *savefile = g_system->getSavefileManager()->openForLoading(fileName);
+	Common::InSaveFile *savefile = g_system->getSavefileManager()->openForLoading(getSavegameFile(slot, target));
 
 	if (savefile) {
 		uint saveHeader = savefile->readUint32LE();

--- a/engines/supernova/metaengine.cpp
+++ b/engines/supernova/metaengine.cpp
@@ -92,7 +92,7 @@ SaveStateList SupernovaMetaEngine::listSaves(const char *target) const {
 						int saveFileDescSize = savefile->readSint16LE();
 						char* saveFileDesc = new char[saveFileDescSize];
 						savefile->read(saveFileDesc, saveFileDescSize);
-						saveFileList.push_back(SaveStateDescriptor(saveSlot, saveFileDesc));
+						saveFileList.push_back(SaveStateDescriptor(this, saveSlot, saveFileDesc));
 						delete [] saveFileDesc;
 					}
 				}
@@ -138,7 +138,7 @@ SaveStateDescriptor SupernovaMetaEngine::querySaveMetaInfos(const char *target, 
 		int descriptionSize = savefile->readSint16LE();
 		char* description = new char[descriptionSize];
 		savefile->read(description, descriptionSize);
-		SaveStateDescriptor desc(slot, description);
+		SaveStateDescriptor desc(this, slot, description);
 		delete [] description;
 
 		uint32 saveDate = savefile->readUint32LE();

--- a/engines/sword1/metaengine.cpp
+++ b/engines/sword1/metaengine.cpp
@@ -88,7 +88,7 @@ SaveStateList SwordMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				in->readUint32LE(); // header
 				in->read(saveName, 40);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveName));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveName));
 				delete in;
 			}
 		}
@@ -118,7 +118,7 @@ SaveStateDescriptor SwordMetaEngine::querySaveMetaInfos(const char *target, int 
 		in->read(name, sizeof(name));
 		in->read(&versionSave, 1);      // version
 
-		SaveStateDescriptor desc(slot, name);
+		SaveStateDescriptor desc(this, slot, name);
 
 		if (versionSave < 2) // These older version of the savegames used a flag to signal presence of thumbnail
 			in->skip(1);

--- a/engines/sword1/metaengine.cpp
+++ b/engines/sword1/metaengine.cpp
@@ -45,6 +45,12 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::Error createInstance(OSystem *syst, Engine **engine) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("sword1.###");
+		else
+			return Common::String::format("sword1.%03d", saveGameIdx);
+	}
 };
 
 bool SwordMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/sword2/metaengine.cpp
+++ b/engines/sword2/metaengine.cpp
@@ -86,7 +86,7 @@ SaveStateList Sword2MetaEngine::listSaves(const char *target) const {
 			if (in) {
 				in->readUint32LE();
 				in->read(saveDesc, SAVE_DESCRIPTION_LEN);
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}

--- a/engines/sword25/metaengine.cpp
+++ b/engines/sword25/metaengine.cpp
@@ -67,7 +67,7 @@ SaveStateList Sword25MetaEngine::listSaves(const char *target) const {
 	for (uint i = 0; i < ps.getSlotCount(); ++i) {
 		if (ps.isSlotOccupied(i)) {
 			Common::String desc = ps.getSavegameDescription(i);
-			saveList.push_back(SaveStateDescriptor(i, desc));
+			saveList.push_back(SaveStateDescriptor(this, i, desc));
 		}
 	}
 

--- a/engines/sword25/metaengine.cpp
+++ b/engines/sword25/metaengine.cpp
@@ -51,7 +51,8 @@ Common::Error Sword25MetaEngine::createInstance(OSystem *syst, Engine **engine, 
 
 bool Sword25MetaEngine::hasFeature(MetaEngineFeature f) const {
 	return
-		(f == kSupportsListSaves);
+		(f == kSupportsListSaves) ||
+		(f == kSimpleSavesNames);
 }
 
 SaveStateList Sword25MetaEngine::listSaves(const char *target) const {

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -59,8 +59,13 @@ public:
 		return Common::kNoError;
 	}
 
-	static Common::String generateGameStateFileName(const char *target, int slot) {
-		return Common::String::format("%s.%02d", target, slot);
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		if (saveGameIdx == kSavegameFilePattern)
+			return Common::String::format("%s.##", target);
+		else
+			return Common::String::format("%s.%02d", target, saveGameIdx);
 	}
 
 	SaveStateList listSaves(const char *target) const override {
@@ -94,12 +99,11 @@ public:
 	}
 
 	void removeSaveState(const char *target, int slot) const override {
-		Common::String filename = generateGameStateFileName(target, slot);
-		g_system->getSavefileManager()->removeSavefile(filename);
+		g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 	}
 
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {
-		Common::String filename = generateGameStateFileName(target, slot);
+		Common::String filename = getSavegameFile(slot, target);
 		Common::ScopedPtr<Common::InSaveFile> in(g_system->getSavefileManager()->openForLoading(filename));
 		if (!in)
 			return SaveStateDescriptor();

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -81,7 +81,7 @@ public:
 				in->seek(0);
 				in->read(buf, 24);
 				buf[24] = 0;
-				saveList.push_back(SaveStateDescriptor(slot, buf));
+				saveList.push_back(SaveStateDescriptor(this, slot, buf));
 			}
 		}
 		// Sort saves based on slot number.
@@ -113,9 +113,9 @@ public:
 
 		in->seek(TeenAgent::saveStateSize);
 		if (!Graphics::checkThumbnailHeader(*in))
-			return SaveStateDescriptor(slot, desc);
+			return SaveStateDescriptor(this, slot, desc);
 
-		SaveStateDescriptor ssd(slot, desc);
+		SaveStateDescriptor ssd(this, slot, desc);
 
 		//checking for the thumbnail
 		Graphics::Surface *thumbnail;

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -76,6 +76,8 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	void removeSaveState(const char *target, int slot) const override;
+
+	// TODO: Add getSavegameFile(). See comments in loadGameState and removeSaveState
 };
 
 bool TinselMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -112,7 +112,7 @@ SaveStateDescriptor TinselMetaEngine::querySaveMetaInfos(const char *target, int
 	file->read(saveDesc, sizeof(saveDesc));
 
 	saveDesc[SG_DESC_LEN - 1] = 0;
-	SaveStateDescriptor desc(slot, saveDesc);
+	SaveStateDescriptor desc(this, slot, saveDesc);
 
 	int8 tm_year = file->readUint16LE();
 	int8 tm_mon = file->readSByte();
@@ -159,7 +159,7 @@ SaveStateList TinselMetaEngine::listSaves(const char *target) const {
 
 			saveDesc[SG_DESC_LEN - 1] = 0;
 
-			saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+			saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 			delete in;
 		}
 	}

--- a/engines/titanic/core/project_item.cpp
+++ b/engines/titanic/core/project_item.cpp
@@ -464,7 +464,7 @@ CViewItem *CProjectItem::findView(int roomNumber, int nodeNumber, int viewNumber
 	return nullptr;
 }
 
-SaveStateList CProjectItem::getSavegameList(const Common::String &target) {
+SaveStateList CProjectItem::getSavegameList(const MetaEngine *metaEngine, const Common::String &target) {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::StringArray filenames;
 	Common::String saveDesc;
@@ -486,7 +486,7 @@ SaveStateList CProjectItem::getSavegameList(const Common::String &target) {
 				SimpleFile f;
 				f.open(in);
 				if (readSavegameHeader(&f, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(metaEngine, slot, header._saveName));
 
 				delete in;
 			}

--- a/engines/titanic/core/project_item.h
+++ b/engines/titanic/core/project_item.h
@@ -145,7 +145,7 @@ public:
 	/**
 	 * Load a list of savegames
 	 */
-	static SaveStateList getSavegameList(const Common::String &target);
+	static SaveStateList getSavegameList(const MetaEngine *metaEngine, const Common::String &target);
 
 	/**
 	 * Write out the header information for a savegame

--- a/engines/titanic/metaengine.cpp
+++ b/engines/titanic/metaengine.cpp
@@ -106,7 +106,7 @@ SaveStateList TitanicMetaEngine::listSaves(const char *target) const {
 				cf.open(in);
 
 				if (Titanic::CProjectItem::readSavegameHeader(&cf, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 
 				cf.close();
 			}
@@ -144,7 +144,7 @@ SaveStateDescriptor TitanicMetaEngine::querySaveMetaInfos(const char *target, in
 		file.close();
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(this, slot, header._saveName);
 
 		if (header._version) {
 			desc.setThumbnail(header._thumbnail);

--- a/engines/toltecs/metaengine.cpp
+++ b/engines/toltecs/metaengine.cpp
@@ -100,7 +100,7 @@ SaveStateList ToltecsMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (Toltecs::ToltecsEngine::readSaveHeader(in, header) == Toltecs::ToltecsEngine::kRSHENoError) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.description));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.description));
 				}
 				delete in;
 			}
@@ -152,7 +152,7 @@ SaveStateDescriptor ToltecsMetaEngine::querySaveMetaInfos(const char *target, in
 		delete in;
 
 		if (error == Toltecs::ToltecsEngine::kRSHENoError) {
-			SaveStateDescriptor desc(slot, header.description);
+			SaveStateDescriptor desc(this, slot, header.description);
 
 			desc.setThumbnail(header.thumbnail);
 

--- a/engines/tony/metaengine.cpp
+++ b/engines/tony/metaengine.cpp
@@ -107,7 +107,7 @@ SaveStateList TonyMetaEngine::listSaves(const char *target) const {
 
 			if (Tony::RMOptionScreen::loadThumbnailFromSaveState(slotNum, thumbnailData, saveName, difficulty)) {
 				// Add the save name to the savegame list
-				saveList.push_back(SaveStateDescriptor(slotNum, saveName));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveName));
 			}
 		}
 	}
@@ -141,7 +141,7 @@ SaveStateDescriptor TonyMetaEngine::querySaveMetaInfos(const char *target, int s
 			pixels[i] = READ_LE_UINT16(pixels + i);
 #endif
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(this, slot, saveName);
 		desc.setDeletableFlag(true);
 		desc.setWriteProtectedFlag(false);
 		desc.setThumbnail(to);

--- a/engines/tony/metaengine.cpp
+++ b/engines/tony/metaengine.cpp
@@ -72,6 +72,7 @@ bool TonyMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsLoadingDuringStartup) ||
 		(f == kSupportsDeleteSave) ||
 		(f == kSavesSupportMetaInfo) ||
+		(f == kSimpleSavesNames) ||
 		(f == kSavesSupportThumbnail);
 }
 

--- a/engines/toon/metaengine.cpp
+++ b/engines/toon/metaengine.cpp
@@ -94,7 +94,7 @@ SaveStateList ToonMetaEngine::listSaves(const char *target) const {
 				file->read(name, nameSize);
 				name[nameSize] = 0;
 
-				saveList.push_back(SaveStateDescriptor(slotNum, name));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, name));
 				delete file;
 			}
 		}
@@ -122,7 +122,7 @@ SaveStateDescriptor ToonMetaEngine::querySaveMetaInfos(const char *target, int s
 		file->read(saveName, saveNameLength);
 		saveName[saveNameLength] = 0;
 
-		SaveStateDescriptor desc(slot, saveName);
+		SaveStateDescriptor desc(this, slot, saveName);
 
 		Graphics::Surface *thumbnail = nullptr;
 		if (!Graphics::loadThumbnail(*file, thumbnail, false)) {

--- a/engines/touche/metaengine.cpp
+++ b/engines/touche/metaengine.cpp
@@ -40,6 +40,11 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		return Touche::generateGameStateFileName(target, saveGameIdx, saveGameIdx == kSavegameFilePattern);
+	}
 };
 
 bool ToucheMetaEngine::hasFeature(MetaEngineFeature f) const {

--- a/engines/touche/metaengine.cpp
+++ b/engines/touche/metaengine.cpp
@@ -82,7 +82,7 @@ SaveStateList ToucheMetaEngine::listSaves(const char *target) const {
 				char description[64];
 				Touche::readGameStateDescription(in, description, sizeof(description) - 1);
 				if (description[0]) {
-					saveList.push_back(SaveStateDescriptor(slot, description));
+					saveList.push_back(SaveStateDescriptor(this, slot, description));
 				}
 				delete in;
 			}

--- a/engines/trecision/metaengine.cpp
+++ b/engines/trecision/metaengine.cpp
@@ -61,7 +61,7 @@ SaveStateDescriptor TrecisionMetaEngine::querySaveMetaInfos(const char *target, 
 			// Original saved game, convert
 			Common::String saveName = saveFile->readString(0, 40);
 
-			SaveStateDescriptor desc(slot, saveName);
+			SaveStateDescriptor desc(this, slot, saveName);
 
 			// This is freed inside SaveStateDescriptor
 			const Graphics::PixelFormat kImageFormat(2, 5, 5, 5, 0, 10, 5, 0, 0);

--- a/engines/tsage/metaengine.cpp
+++ b/engines/tsage/metaengine.cpp
@@ -107,7 +107,7 @@ public:
 
 				if (in) {
 					if (TsAGE::Saver::readSavegameHeader(in, header)) {
-						saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+						saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 					}
 
 					delete in;
@@ -143,7 +143,7 @@ public:
 			delete f;
 
 			// Create the return descriptor
-			SaveStateDescriptor desc(slot, header._saveName);
+			SaveStateDescriptor desc(this, slot, header._saveName);
 			desc.setThumbnail(header._thumbnail);
 			desc.setSaveDate(header._saveYear, header._saveMonth, header._saveDay);
 			desc.setSaveTime(header._saveHour, header._saveMinutes);

--- a/engines/tucker/metaengine.cpp
+++ b/engines/tucker/metaengine.cpp
@@ -68,7 +68,7 @@ public:
 				Common::InSaveFile *in = g_system->getSavefileManager()->openForLoading(*file);
 				if (in) {
 					if (Tucker::TuckerEngine::readSavegameHeader(in, header) == Tucker::TuckerEngine::kSavegameNoError) {
-						saveList.push_back(SaveStateDescriptor(slot, header.description));
+						saveList.push_back(SaveStateDescriptor(this, slot, header.description));
 					}
 
 					delete in;
@@ -109,7 +109,7 @@ public:
 			return SaveStateDescriptor();
 		}
 
-		SaveStateDescriptor desc(slot, header.description);
+		SaveStateDescriptor desc(this, slot, header.description);
 
 		if (slot == Tucker::kAutoSaveSlot) {
 			bool autosaveAllowed = Tucker::TuckerEngine::isAutosaveAllowed(target);

--- a/engines/tucker/metaengine.cpp
+++ b/engines/tucker/metaengine.cpp
@@ -145,6 +145,12 @@ public:
 		delete file;
 		return desc;
 	}
+
+	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
+		if (!target)
+			target = getEngineId();
+		return Tucker::generateGameStateFileName(target, saveGameIdx, saveGameIdx == kSavegameFilePattern);
+	}
 };
 
 #if PLUGIN_ENABLED_DYNAMIC(TUCKER)

--- a/engines/voyeur/metaengine.cpp
+++ b/engines/voyeur/metaengine.cpp
@@ -109,7 +109,7 @@ SaveStateList VoyeurMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (header.read(in)) {
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 				}
 				delete in;
 			}
@@ -140,7 +140,7 @@ SaveStateDescriptor VoyeurMetaEngine::querySaveMetaInfos(const char *target, int
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(this, slot, header._saveName);
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._saveYear, header._saveMonth, header._saveDay);
 		desc.setSaveTime(header._saveHour, header._saveMinutes);

--- a/engines/wage/metaengine.cpp
+++ b/engines/wage/metaengine.cpp
@@ -101,7 +101,7 @@ SaveStateList WageMetaEngine::listSaves(const char *target) const {
 						in->read(saveDesc, 127);
 					}
 				}
-				saveList.push_back(SaveStateDescriptor(slotNum, saveDesc));
+				saveList.push_back(SaveStateDescriptor(this, slotNum, saveDesc));
 				delete in;
 			}
 		}

--- a/engines/wintermute/metaengine.cpp
+++ b/engines/wintermute/metaengine.cpp
@@ -84,17 +84,13 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override {
 		switch (f) {
-		case MetaEngine::kSupportsListSaves:
-			return true;
-		case MetaEngine::kSupportsLoadingDuringStartup:
-			return true;
-		case MetaEngine::kSupportsDeleteSave:
-			return true;
-		case MetaEngine::kSavesSupportCreationDate:
-			return true;
-		case MetaEngine::kSavesSupportMetaInfo:
-			return true;
-		case MetaEngine::kSavesSupportThumbnail:
+		case kSupportsListSaves:
+		case kSupportsLoadingDuringStartup:
+		case kSupportsDeleteSave:
+		case kSavesSupportCreationDate:
+		case kSavesSupportMetaInfo:
+		case kSavesSupportThumbnail:
+		case kSimpleSavesNames:
 			return true;
 		default:
 			return false;

--- a/engines/xeen/metaengine.cpp
+++ b/engines/xeen/metaengine.cpp
@@ -139,7 +139,7 @@ SaveStateList XeenMetaEngine::listSaves(const char *target) const {
 
 			if (in) {
 				if (Xeen::SavesManager::readSavegameHeader(in, header))
-					saveList.push_back(SaveStateDescriptor(slot, header._saveName));
+					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
 
 				delete in;
 			}
@@ -173,7 +173,7 @@ SaveStateDescriptor XeenMetaEngine::querySaveMetaInfos(const char *target, int s
 		delete f;
 
 		// Create the return descriptor
-		SaveStateDescriptor desc(slot, header._saveName);
+		SaveStateDescriptor desc(this, slot, header._saveName);
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);

--- a/engines/zvision/metaengine.cpp
+++ b/engines/zvision/metaengine.cpp
@@ -258,7 +258,7 @@ SaveStateList ZVisionMetaEngine::listSaves(const char *target) const {
 			Common::InSaveFile *in = saveFileMan->openForLoading(file->c_str());
 			if (in) {
 				if (zvisionSaveMan->readSaveGameHeader(in, header)) {
-					saveList.push_back(SaveStateDescriptor(slotNum, header.saveName));
+					saveList.push_back(SaveStateDescriptor(this, slotNum, header.saveName));
 				}
 				delete in;
 			}
@@ -295,7 +295,7 @@ SaveStateDescriptor ZVisionMetaEngine::querySaveMetaInfos(const char *target, in
 		delete in;
 
 		if (successfulRead) {
-			SaveStateDescriptor desc(slot, header.saveName);
+			SaveStateDescriptor desc(this, slot, header.saveName);
 
 			desc.setThumbnail(header.thumbnail);
 

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -321,7 +321,7 @@ void SaveLoadChooserDialog::listSaves() {
 				slotNum = slotNum * 10 + (c - '0');
 			}
 
-			SaveStateDescriptor slot(slotNum, files[i]);
+			SaveStateDescriptor slot(_metaEngine, slotNum, files[i]);
 			slot.setLocked(true);
 			_saveList.push_back(slot);
 		}
@@ -710,7 +710,7 @@ void SaveLoadChooserSimple::updateSaveList() {
 		saveSlot = x->getSaveSlot();
 		if (curSlot < saveSlot) {
 			while (curSlot < saveSlot) {
-				SaveStateDescriptor dummySave(curSlot, "");
+				SaveStateDescriptor dummySave(_metaEngine, curSlot, "");
 				_saveList.insert_at(curSlot, dummySave);
 				saveNames.push_back(dummySave.getDescription());
 				colors.push_back(ThemeEngine::kFontColorNormal);
@@ -754,7 +754,7 @@ void SaveLoadChooserSimple::updateSaveList() {
 	Common::String emptyDesc;
 	for (int i = curSlot; i <= maximumSaveSlots; i++) {
 		saveNames.push_back(emptyDesc);
-		SaveStateDescriptor dummySave(i, "");
+		SaveStateDescriptor dummySave(_metaEngine, i, "");
 		_saveList.push_back(dummySave);
 		colors.push_back(ThemeEngine::kFontColorNormal);
 	}


### PR DESCRIPTION
This cherry-picks to branch-2-5 commits from @orgads to fix the check for overwriting savegames in the autosave slot and moving the savegame to a different slots.

I think it would be a good idea to merge those to branch-2-5 as they fix annoying bugs with the check that autosave are not overwriting normal saves. But since they changes a lot of files in a lot of engines, I prefer to propose this as a pull request to check that others agree that they are good to merge.