### PR TITLE
XEEN: sound related improvements

### DIFF
--- a/engines/xeen/map.cpp
+++ b/engines/xeen/map.cpp
@@ -901,8 +901,7 @@ void Map::load(int mapId) {
 		} else {
 			musName = "outdoors.m";
 		}
-		if (musName != sound._currentMusic)
-			sound.playSong(musName, 207);
+		sound.playSong(musName, 207);
 
 		// Load sprite sets needed for scene rendering
 		_groundSprites.load("water.out");
@@ -938,8 +937,7 @@ void Map::load(int mapId) {
 		} else {
 			musName = Res.MUSIC_FILES1[MUS_INDEXES[_mazeData->_wallKind]];
 		}
-		if (musName != sound._currentMusic)
-			sound.playSong(musName, 207);
+		sound.playSong(musName, 207);
 
 		// Load sprite sets needed for scene rendering
 		_skySprites[1].load(Common::String::format("%s.sky",

--- a/engines/xeen/sound.cpp
+++ b/engines/xeen/sound.cpp
@@ -77,13 +77,13 @@ void Sound::playSound(const Common::String &name, int ccNum, int unused) {
 }
 
 void Sound::playVoice(const Common::String &name, int ccMode) {
+	stopSound();
+	if (!_fxOn)
+		return;
 	File f;
 	bool result = (ccMode == -1) ? f.open(name) : f.open(name, ccMode);
 	if (!result)
 		error("Could not open sound - %s", name.c_str());
-
-	stopSound();
-
 	Common::SeekableReadStream *srcStream = f.readStream(f.size());
 	Audio::SeekableAudioStream *stream = Audio::makeVOCStream(srcStream,
 		Audio::FLAG_UNSIGNED, DisposeAfterUse::YES);
@@ -148,6 +148,8 @@ void Sound::loadEffectsData() {
 
 void Sound::playFX(uint effectId) {
 	stopFX();
+	if (!_fxOn)
+		return;
 	loadEffectsData();
 
 	if (effectId < _effectsOffsets.size()) {

--- a/engines/xeen/sound.cpp
+++ b/engines/xeen/sound.cpp
@@ -235,6 +235,8 @@ void Sound::updateSoundSettings() {
 	_musicOn = !ConfMan.getBool("music_mute");
 	if (!_musicOn)
 		stopSong();
+	else if (!_currentMusic.empty())
+		playSong(_currentMusic);
 
 	_subtitles = ConfMan.hasKey("subtitles") ? ConfMan.getBool("subtitles") : true;
 	_musicVolume = CLIP(ConfMan.getInt("music_volume"), 0, 255);

--- a/engines/xeen/sound.cpp
+++ b/engines/xeen/sound.cpp
@@ -195,6 +195,8 @@ void Sound::playSong(Common::SeekableReadStream &stream) {
 }
 
 void Sound::playSong(const Common::String &name, int param) {
+	if (isMusicPlaying() && name == _currentMusic)
+		return;
 	_currentMusic = name;
 
 	Common::File mf;

--- a/engines/xeen/sound.cpp
+++ b/engines/xeen/sound.cpp
@@ -109,6 +109,7 @@ void Sound::setFxOn(bool isOn) {
 	ConfMan.setBool("sfx_mute", !isOn);
 	if (isOn)
 		ConfMan.setBool("mute", false);
+	ConfMan.flushToDisk();
 
 	g_vm->syncSoundSettings();
 }
@@ -212,6 +213,7 @@ void Sound::setMusicOn(bool isOn) {
 	ConfMan.setBool("music_mute", !isOn);
 	if (isOn)
 		ConfMan.setBool("mute", false);
+	ConfMan.flushToDisk();
 
 	g_vm->syncSoundSettings();
 }

--- a/engines/xeen/sound.cpp
+++ b/engines/xeen/sound.cpp
@@ -193,7 +193,6 @@ void Sound::playSong(Common::SeekableReadStream &stream) {
 }
 
 void Sound::playSong(const Common::String &name, int param) {
-	_priorMusic = _currentMusic;
 	_currentMusic = name;
 
 	Common::File mf;

--- a/engines/xeen/sound.h
+++ b/engines/xeen/sound.h
@@ -87,11 +87,6 @@ public:
 	void stopSong() { songCommand(STOP_SONG); }
 
 	/**
-	 * Restart a previously playing song (which must still be loaded)
-	 */
-	void restartSong() { songCommand(RESTART_SONG); }
-
-	/**
 	 * Sets the in-game music volume percent. This is separate from the ScummVM volume
 	 */
 	void setMusicPercent(byte percent);
@@ -105,13 +100,6 @@ public:
 	 * Plays a song
 	 */
 	void playSong(const Common::String &name, int param = 0);
-
-	/**
-	 * Plays a song
-	 */
-	void playSong(const byte *data) {
-		_SoundDriver->playSong(data);
-	}
 
 	/**
 	 * Returns true if music is playing

--- a/engines/xeen/sound.h
+++ b/engines/xeen/sound.h
@@ -59,7 +59,7 @@ private:
 public:
 	bool _fxOn;
 	bool _musicOn;
-	Common::String _currentMusic, _priorMusic;
+	Common::String _currentMusic;
 	int _musicSide;
 	bool _subtitles;
 public:


### PR DESCRIPTION
* remove some dead code
* fix some sounds not being correctly muted when Efx is off (e.g. vendor voices, some combat FXs)
* fix missing music when loading a save from the main menu
* fix toggling music back on
* fix sound settings not getting saved