### PR TITLE
SHERLOCK: Fix Rose Tattoo glitch when opening map

### DIFF
--- a/engines/sherlock/tattoo/tattoo_map.cpp
+++ b/engines/sherlock/tattoo/tattoo_map.cpp
@@ -117,10 +117,7 @@ int TattooMap::show() {
 	screen._backBuffer2.create(SHERLOCK_SCREEN_WIDTH * 2, SHERLOCK_SCREEN_HEIGHT * 2);
 	screen._backBuffer2.SHblitFrom(screen._backBuffer1);
 
-	// Display the built map to the screen
-	screen.slamArea(0, 0, SHERLOCK_SCREEN_WIDTH, SHERLOCK_SCREEN_HEIGHT);
-
-	// Set initial scroll position
+	// Set initial scroll position, forcing the map to be displayed
 	_targetScroll = _bigPos;
 	screen._currentScroll = Common::Point(-1, -1);
 


### PR DESCRIPTION
This attempts to fix the bug described in https://bugs.scummvm.org/ticket/10850

Since the map always snaps to its saved position, there's no need to show the upper left corner for a split second first.
