### PR TITLE
SCI: Disable autosave

### DIFF
--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -279,6 +279,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	int getAutosaveSlot() const override { return -1; }
 
 	// A fallback detection method. This is not ideal as all detection lives in MetaEngine, but
 	// here fb detection has many engine dependencies.

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -149,6 +149,8 @@ public:
 	bool canLoadGameStateCurrently() override;
 	bool canSaveGameStateCurrently() override;
 	void syncSoundSettings() override; ///< from ScummVM to the game
+	int getAutosaveSlot() const override { return -1; }
+
 	void updateSoundMixerVolumes();
 	uint32 getTickCount();
 	void setTickCount(const uint32 ticks);


### PR DESCRIPTION
SciEngine::canSaveGameStateCurrently() returns false unconditionally, so the feature doesn't work anyway.
