### PR TITLE
ANDROID: New fixes for 3D support

### DIFF
--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -136,6 +136,14 @@ void AndroidGraphics3dManager::initSurface() {
 
 	if (_game_texture) {
 		_game_texture->reinit();
+		// We had a frame buffer initialized, we must renew it as the game textured got renewed
+		if (_frame_buffer) {
+			delete _frame_buffer;
+			_frame_buffer = new OpenGL::FrameBuffer(_game_texture->getTextureName(),
+	                                        _game_texture->width(), _game_texture->height(),
+	                                        _game_texture->texWidth(), _game_texture->texHeight());
+
+		}
 	}
 
 	// We don't have any content to display: just make sure surface is clean

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -334,6 +334,11 @@ void AndroidGraphics3dManager::updateScreen() {
 	// Restore game viewport
 	GLCALL(glViewport(savedViewport[0], savedViewport[1], savedViewport[2], savedViewport[3]));
 
+	// Don't keep our texture attached to avoid the engine writing on it if it forgets to setup its own texture
+	GLCALL(glBindTexture(GL_TEXTURE_2D, 0));
+	// Unload our program to make sure engine will use its own
+	GLESBaseTexture::unbindShader();
+
 	if (_frame_buffer) {
 		_frame_buffer->attach();
 	}

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -970,6 +970,17 @@ void AndroidGraphics3dManager::clearScreen(FixupType type, byte count) {
 	_force_redraw = true;
 }
 
+float AndroidGraphics3dManager::getHiDPIScreenFactor() const {
+	// TODO: Use JNI to get DisplayMetrics.density, which according to the documentation
+	// seems to be what we want.
+	// "On a medium-density screen, DisplayMetrics.density equals 1.0; on a high-density
+	//  screen it equals 1.5; on an extra-high-density screen, it equals 2.0; and on a
+	//  low-density screen, it equals 0.75. This figure is the factor by which you should
+	//  multiply the dp units in order to get the actual pixel count for the current screen."
+
+	return 2.f;
+}
+
 AndroidCommonGraphics::State AndroidGraphics3dManager::getState() const {
 	AndroidCommonGraphics::State state;
 

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -633,11 +633,8 @@ void AndroidGraphics3dManager::initSize(uint width, uint height,
 
 	GLTHREADCHECK;
 
-#ifdef USE_RGB_COLOR
-	initTexture(&_game_texture, width, height, format);
-#else
 	_game_texture->allocBuffer(width, height);
-#endif
+
 	delete _frame_buffer;
 	_frame_buffer = new OpenGL::FrameBuffer(_game_texture->getTextureName(),
 	                                        _game_texture->width(), _game_texture->height(),
@@ -973,58 +970,6 @@ void AndroidGraphics3dManager::clearScreen(FixupType type, byte count) {
 	_force_redraw = true;
 }
 
-#ifdef USE_RGB_COLOR
-void AndroidGraphics3dManager::initTexture(GLESBaseTexture **texture,
-        uint width, uint height,
-        const Graphics::PixelFormat *format) {
-	assert(texture);
-	Graphics::PixelFormat format_clut8 =
-	    Graphics::PixelFormat::createFormatCLUT8();
-	Graphics::PixelFormat format_current;
-	Graphics::PixelFormat format_new;
-
-	if (*texture) {
-		format_current = (*texture)->getPixelFormat();
-	} else {
-		format_current = Graphics::PixelFormat();
-	}
-
-	if (format) {
-		format_new = *format;
-	} else {
-		format_new = format_clut8;
-	}
-
-	if (format_current != format_new) {
-		if (*texture)
-			LOGD("switching pixel format from: %s",
-			     (*texture)->getPixelFormat().toString().c_str());
-
-		delete *texture;
-
-		if (format_new == GLES565Texture::pixelFormat()) {
-			*texture = new GLES565Texture();
-		} else if (format_new == GLES5551Texture::pixelFormat()) {
-			*texture = new GLES5551Texture();
-		} else if (format_new == GLES4444Texture::pixelFormat()) {
-			*texture = new GLES4444Texture();
-		} else {
-			// TODO what now?
-			if (format_new != format_clut8)
-				LOGE("unsupported pixel format: %s",
-				     format_new.toString().c_str());
-
-			*texture = new GLESFakePalette565Texture;
-		}
-
-		LOGD("new pixel format: %s",
-		     (*texture)->getPixelFormat().toString().c_str());
-	}
-
-	(*texture)->allocBuffer(width, height);
-}
-#endif
-
 AndroidCommonGraphics::State AndroidGraphics3dManager::getState() const {
 	AndroidCommonGraphics::State state;
 
@@ -1040,11 +985,8 @@ AndroidCommonGraphics::State AndroidGraphics3dManager::getState() const {
 }
 
 bool AndroidGraphics3dManager::setState(const AndroidCommonGraphics::State &state) {
-#ifdef USE_RGB_COLOR
-	initSize(state.screenWidth, state.screenHeight, &state.pixelFormat);
-#else
+	// In 3d we don't have a pixel format so we ignore it
 	initSize(state.screenWidth, state.screenHeight, nullptr);
-#endif
 	setFeatureState(OSystem::kFeatureAspectRatioCorrection, state.aspectRatio);
 	setFeatureState(OSystem::kFeatureFullscreenMode, state.fullscreen);
 	setFeatureState(OSystem::kFeatureCursorPalette, state.cursorPalette);

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -110,6 +110,7 @@ public:
 	                            const Graphics::PixelFormat *format) override;
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) override;
 
+	float getHiDPIScreenFactor() const override;
 
 #ifdef USE_RGB_COLOR
 	virtual Graphics::PixelFormat getScreenFormat() const override;

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -133,8 +133,6 @@ private:
 	void setCursorPaletteInternal(const byte *colors, uint start, uint num);
 	void disableCursorPalette();
 	void initOverlay();
-	void initViewport();
-	void initSizeIntern(uint width, uint height, const Graphics::PixelFormat *format);
 
 	enum FixupType {
 		kClear = 0,     // glClear

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -141,10 +141,6 @@ private:
 	};
 
 	void clearScreen(FixupType type, byte count = 1);
-#ifdef USE_RGB_COLOR
-	void initTexture(GLESBaseTexture **texture, uint width, uint height,
-	                 const Graphics::PixelFormat *format);
-#endif
 
 private:
 	int _screenChangeID;

--- a/backends/graphics3d/android/texture.cpp
+++ b/backends/graphics3d/android/texture.cpp
@@ -89,6 +89,12 @@ void GLESBaseTexture::initGL() {
 	                                   2 * sizeof(float), 0);
 }
 
+void GLESBaseTexture::unbindShader() {
+	if (_box_shader) {
+		_box_shader->unbind();
+	}
+}
+
 GLESBaseTexture::GLESBaseTexture(GLenum glFormat, GLenum glType,
                                  Graphics::PixelFormat pixelFormat) :
 	_glFormat(glFormat),

--- a/backends/graphics3d/android/texture.h
+++ b/backends/graphics3d/android/texture.h
@@ -39,6 +39,7 @@ class ShaderGL;
 class GLESBaseTexture {
 public:
 	static void initGL();
+	static void unbindShader();
 
 protected:
 	GLESBaseTexture(GLenum glFormat, GLenum glType,


### PR DESCRIPTION
With this PR, pausing and resuming a 3D game is fixed.
The game GLES state is preserved across drawing calls to ensure a consistent display in all cases.
The program and texture are unbound after the draw to prevent the engine from using them by accident.
Finally some cleanup is done and the HiDPI factor is applied to have a consistent overlay look'n'feel between 2D and 3D games.