### PR TITLE
SCUMM: DiMUSE: Fix bug #13080

### DIFF
--- a/audio/mixer.cpp
+++ b/audio/mixer.cpp
@@ -177,10 +177,11 @@ private:
 #pragma mark --- Mixer ---
 #pragma mark -
 
-MixerImpl::MixerImpl(uint sampleRate)
-	: _mutex(), _sampleRate(sampleRate), _mixerReady(false), _handleSeed(0), _soundTypeSettings() {
+MixerImpl::MixerImpl(uint sampleRate, uint outBufSize)
+	: _mutex(), _sampleRate(sampleRate), _outBufSize(outBufSize), _mixerReady(false), _handleSeed(0), _soundTypeSettings() {
 
 	assert(sampleRate > 0);
+	assert(outBufSize >= 0);
 
 	for (int i = 0; i != NUM_CHANNELS; i++)
 		_channels[i] = nullptr;
@@ -199,6 +200,10 @@ void MixerImpl::setReady(bool ready) {
 
 uint MixerImpl::getOutputRate() const {
 	return _sampleRate;
+}
+
+uint MixerImpl::getOutputBufSize() const {
+	return _outBufSize;
 }
 
 void MixerImpl::insertChannel(SoundHandle *handle, Channel *chan) {

--- a/audio/mixer.h
+++ b/audio/mixer.h
@@ -305,6 +305,13 @@ public:
 	 * @return The output sample rate in Hz.
 	 */
 	virtual uint getOutputRate() const = 0;
+
+	/**
+	 * Return the output sample buffer size of the system.
+	 *
+	 * @return The number of samples processed at each audio callback.
+	 */
+	virtual uint getOutputBufSize() const = 0;
 };
 
 /** @} */

--- a/audio/mixer_intern.h
+++ b/audio/mixer_intern.h
@@ -65,6 +65,7 @@ private:
 	Common::Mutex _mutex;
 
 	const uint _sampleRate;
+	const uint _outBufSize;
 	bool _mixerReady;
 	uint32 _handleSeed;
 
@@ -81,7 +82,7 @@ private:
 
 public:
 
-	MixerImpl(uint sampleRate);
+	MixerImpl(uint sampleRate, uint outBufSize = 0);
 	~MixerImpl();
 
 	virtual bool isReady() const { Common::StackLock lock(_mutex); return _mixerReady; }
@@ -129,6 +130,7 @@ public:
 	virtual int getVolumeForSoundType(SoundType type) const;
 
 	virtual uint getOutputRate() const;
+	virtual uint getOutputBufSize() const;
 
 protected:
 	void insertChannel(SoundHandle *handle, Channel *chan);

--- a/backends/mixer/null/null-mixer.cpp
+++ b/backends/mixer/null/null-mixer.cpp
@@ -37,7 +37,7 @@ NullMixerManager::~NullMixerManager() {
 }
 
 void NullMixerManager::init() {
-	_mixer = new Audio::MixerImpl(_outputRate);
+	_mixer = new Audio::MixerImpl(_outputRate, _samples);
 	assert(_mixer);
 	_mixer->setReady(true);
 }

--- a/backends/mixer/sdl/sdl-mixer.cpp
+++ b/backends/mixer/sdl/sdl-mixer.cpp
@@ -74,7 +74,7 @@ void SdlMixerManager::init() {
 		warning("Could not open audio device: %s", SDL_GetError());
 
 		// The mixer is not marked as ready
-		_mixer = new Audio::MixerImpl(desired.freq);
+		_mixer = new Audio::MixerImpl(desired.freq, desired.samples);
 		return;
 	}
 
@@ -89,7 +89,7 @@ void SdlMixerManager::init() {
 			warning("Could not open audio device: %s", SDL_GetError());
 
 			// The mixer is not marked as ready
-			_mixer = new Audio::MixerImpl(desired.freq);
+			_mixer = new Audio::MixerImpl(desired.freq, desired.samples);
 			return;
 		}
 
@@ -111,7 +111,7 @@ void SdlMixerManager::init() {
 		error("SDL mixer output requires stereo output device");
 #endif
 
-	_mixer = new Audio::MixerImpl(_obtained.freq);
+	_mixer = new Audio::MixerImpl(_obtained.freq, desired.samples);
 	assert(_mixer);
 	_mixer->setReady(true);
 

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -464,7 +464,7 @@ void OSystem_Android::initBackend() {
 
 	gettimeofday(&_startTime, 0);
 
-	_mixer = new Audio::MixerImpl(_audio_sample_rate);
+	_mixer = new Audio::MixerImpl(_audio_sample_rate, _audio_buffer_size);
 	_mixer->setReady(true);
 
 	_timer_thread_exit = false;

--- a/backends/platform/android3d/android.cpp
+++ b/backends/platform/android3d/android.cpp
@@ -368,7 +368,7 @@ void OSystem_Android::initBackend() {
 
 	gettimeofday(&_startTime, 0);
 
-	_mixer = new Audio::MixerImpl(_audio_sample_rate);
+	_mixer = new Audio::MixerImpl(_audio_sample_rate, _audio_buffer_size);
 	_mixer->setReady(true);
 
 	_timer_thread_exit = false;

--- a/backends/platform/ios7/ios7_osys_sound.cpp
+++ b/backends/platform/ios7/ios7_osys_sound.cpp
@@ -46,7 +46,7 @@ void OSystem_iOS7::mixCallback(void *sys, byte *samples, int len) {
 }
 
 void OSystem_iOS7::setupMixer() {
-	_mixer = new Audio::MixerImpl(AUDIO_SAMPLE_RATE);
+	_mixer = new Audio::MixerImpl(AUDIO_SAMPLE_RATE, WAVE_BUFFER_SIZE);
 
 	s_soundCallback = mixCallback;
 	s_soundParam = this;

--- a/backends/platform/iphone/osys_sound.cpp
+++ b/backends/platform/iphone/osys_sound.cpp
@@ -46,7 +46,7 @@ void OSystem_IPHONE::mixCallback(void *sys, byte *samples, int len) {
 }
 
 void OSystem_IPHONE::setupMixer() {
-	_mixer = new Audio::MixerImpl(AUDIO_SAMPLE_RATE);
+	_mixer = new Audio::MixerImpl(AUDIO_SAMPLE_RATE, WAVE_BUFFER_SIZE);
 
 	s_soundCallback = mixCallback;
 	s_soundParam = this;

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -103,6 +103,19 @@ IMuseDigital::IMuseDigital(ScummEngine_v7 *scumm, Audio::Mixer *mixer)
 
 	_filesHandler->allocSoundBuffer(DIMUSE_BUFFER_SMUSH, 198000, 0, 0);
 
+	if (_mixer->getOutputBufSize() != 0) {
+		_maxQueuedStreams = (_mixer->getOutputBufSize() / _waveOutPreferredFeedSize) + 1;
+		// This mixer's optimal output sample rate for this audio engine is 44100
+		// if it's higher than that, compensate the number of queued streams in order
+		// to try to achieve a better latency compromise
+		if (_mixer->getOutputRate() > DIMUSE_SAMPLERATE * 2) {
+			_maxQueuedStreams -= 2;
+		}
+	} else {
+		debug(5, "IMuseDigital::IMuseDigital(): WARNING: output audio buffer size not specified for this platform, defaulting _maxQueuedStreams to 4");
+		_maxQueuedStreams = 4;
+	}
+
 	_vm->getTimerManager()->installTimerProc(timer_handler, 1000000 / _callbackFps, this, "IMuseDigital");
 }
 

--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -86,6 +86,8 @@ private:
 	int _outputFeedSize;
 	int _outputSampleRate;
 
+	int _maxQueuedStreams; // maximum number of streams which can be queued before they are played
+
 	int _currentSpeechVolume, _currentSpeechFrequency, _currentSpeechPan;
 	int _curMixerMusicVolume, _curMixerSpeechVolume, _curMixerSFXVolume;
 	bool _radioChatterSFX;

--- a/engines/scumm/imuse_digi/dimuse_tracks.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tracks.cpp
@@ -155,7 +155,7 @@ void IMuseDigital::tracksCallback() {
 
 	// If we leave the number of queued streams unbounded, we fill the queue with streams faster than
 	// we can play them: this leads to a very noticeable audio latency and desync with the graphics.
-	if (_internalMixer->_stream->numQueuedStreams() < 3) {
+	if (_internalMixer->_stream->numQueuedStreams() < _maxQueuedStreams) {
 		if (!_isEarlyDiMUSE)
 			dispatchPredictFirstStream();
 


### PR DESCRIPTION
For [this bug](https://bugs.scummvm.org/ticket/13080) to be fixed, I needed to avoid setting an arbitrary `_maxQueuedStreams` value in `IMuseDigital::tracksCallback()`, and instead do a proper calculation based on the audio buffer size.

To do that I needed the audio backend to pass the buffer size along to the mixer (with which DiMUSE can communicate). This has been done for all the ports/platform I could be able to test. For the others I left a fallback value of 4 for the maximum number of queued streams (until someone can test all the other platforms).

The changes in this PR have also been tested with various manually inserted values for `output_rate` (22050, 44100, 48000) and `audio_buffer_size` (from 512 up to 8192) in the `scummvm.ini` config files, and I can happily report that everything works as it should both in DiMUSE and in a bunch of other games and engines which I didn't touch (just for good measure).

Unfortunately Android works in its own ways, and reports a much higher latency than the real one, resulting in a very high `_maxQueuedStreams`  value (and therefore high latency). I have solved this by getting the Android backend to record the actual audio buffer size, which I retrieved from the AudioTrack object _after_ its creation. But this fix will be put in a separate PR, just for safety.