### PR TITLE
ANDROID: Keep track of actual AudioTrack buffer size

### DIFF
--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -297,6 +297,10 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 				_buffer_size,
 				AudioTrack.MODE_STREAM,
 				AudioManager.AUDIO_SESSION_ID_GENERATE);
+
+			// Keep track of the actual obtained audio buffer size, if supported
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+				_buffer_size = _audio_track.getBufferSizeInFrames();
 		} else {
 			//support for Android KitKat or lower
 			_audio_track = new AudioTrack(AudioManager.STREAM_MUSIC,


### PR DESCRIPTION
This PR is complementary to [https://github.com/scummvm/scummvm/pull/3589](this one), except in this one I make a small but still sensitive change which doesn't appear to negatively affect other games or engine, but it's still a separate PR for good measure.

The same change has to be done for ANDROID3D, but:

- I admit I don't know which is the minimum SDK version being supported for that;
- I'd better be doing that after being done with the audio work on Grim Fandango.