### PR TITLE
DIRECTOR: remove some detection_paths entries

### DIFF
--- a/engines/director/detection_paths.h
+++ b/engines/director/detection_paths.h
@@ -183,14 +183,6 @@ const char *directoryGlobs[] = {
 	"bin",
 	"adam resources",				// ADAM Software Products
 	"material",						// NY Yankees Yearbook
-	"PANTOS",						// Pantos Story
-	"Pickle's Book",
-	"keron Folder",					// Ultra Resort Keroncuel Mac
-	"KERONFOL",						// Ultra Resort Keroncuel Win
-	"start",						// Ursa Minor Blue
-	"PEPPERON",						// Four Seasons in Pepperon Village
-	"YBR",							// Yellow Brick Road
-	"PINK GEAR",					// Pink Gear 2
 	"NAV",
 	"SSWARLCK",						// Spaceship Warlock (Windows)
 	"InsMilo",						// Milo and the Magical Stones

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -2030,7 +2030,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACDEMO1_l("peaceland", "Demo", "PeaceLand", "276bee761e48a6fd709df77d5c2f60dd", 393877, Common::JA_JPN, 313),
 
 	// Original Mac-only release
-	MACGAME1_l("picklesbook", "", "Pickle", "c9ec74eea228500976ba680a362308bb", 456728, Common::JA_JPN, 300),
+	MACGAME1_l("picklesbook", "", "Pickle's Book/Pickle", "c9ec74eea228500976ba680a362308bb", 456728, Common::JA_JPN, 300),
 	// On the same CD as the Windows version, but built with a different version?
 	MACGAME1("picklesbook", "", "Pickle", "276bee761e48a6fd709df77d5c2f60dd", 528017, 310),
 
@@ -2312,8 +2312,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 						   "START",		"9fad29c4cf9f7791e5dda075259e2fdd", 2418439, Common::JA_JPN, 300),
 	WINGAME2_l("ybr1", "", "YBR.EXE",	"2cc9e2dacb90fb130f6ee9519b66c5a8", 369007,
 						   "START.MMM",	"9e02f41270708101b1d5d04cb822a784", 2563274, Common::JA_JPN, 300),
-	WINGAME2_l("ybr1", "IBM release", "YBR.EXE",	"2cc9e2dacb90fb130f6ee9519b66c5a8", 369007,
-						   "START.MMM",	"6b913b1747abc48c230523e916e5e60a", 2554968, Common::JA_JPN, 310),
+	WINGAME2_l("ybr1", "IBM release", "YBR/YBR.EXE",	"2cc9e2dacb90fb130f6ee9519b66c5a8", 369007,
+						   "DATA/START.MMM",	"6b913b1747abc48c230523e916e5e60a", 2554968, Common::JA_JPN, 310),
 
 	// Original filename is 財閥銀行
 	MACDEMO1_l("zaibatsu", "Demo", "Zaibatsu Bank", "a03ae8a9bf211bcb26388b6b6da17c2b", 1830610, Common::JA_JPN, 311),
@@ -3729,7 +3729,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// French version titled "Valmaison au fil des saisons"
 	MACGAME1_l("pepperon", "", "Valmaison", "8b138db44d4421cc7294a9dc792ccf1b", 502569, Common::FR_FRA, 404),
-	WINGAME1_l("pepperon", "", "START95.EXE", "4086df04abc18956581cee17b48e81c1", 1805439, Common::FR_FRA, 404),
+	WINGAME1_l("pepperon", "", "PEPPERON/START95.EXE", "4086df04abc18956581cee17b48e81c1", 1805439, Common::FR_FRA, 404),
 	// Dutch version titled "Op avontuur in kabouterstad"
 	WINGAME1_l("pepperon", "", "START95.EXE", "e67abd6a890060fa8c41b7b363013254", 1088309, Common::NL_NLD, 404),
 
@@ -4190,9 +4190,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("jslearn", "1997 D5 Demo", "PREV32A.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1411155, 501),
 
 	// Multi-disc game but the executable is only on disc 1
-	MACGAME1_l("keroncuel", "", "KERONCUEL", "8f4da7096fa8725ad3ed3153811c9e38", 719664, Common::JA_JPN, 501),
-	MACGAME1_l("keroncuel", "", "KERONCUEL", "8f4da7096fa8725ad3ed3153811c9e38", 719664, Common::JA_JPN, 501),
-	WINGAME1t_l("keroncuel", "", "KERONCUE.EXE", "4bf5fa422a92233d03280dfb30df4ed9", 1418708, Common::JA_JPN, 501),
+	MACGAME1_l("keroncuel", "", "keron folder/KERONCUEL", "8f4da7096fa8725ad3ed3153811c9e38", 719664, Common::JA_JPN, 501),
+	WINGAME1t_l("keroncuel", "", "KERONFOL/KERONCUE.EXE", "4bf5fa422a92233d03280dfb30df4ed9", 1418708, Common::JA_JPN, 501),
 
 	// Bilingual English/Japanese
 	MACGAME1("llla", "",	  "LLLA",	 "f808a9f231b77617fa559cf9d2da66c1", 304804, 501),
@@ -4552,7 +4551,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	},
 
 	MACGAME1_l("ursaminorblue", "Hybrid release", "URSA (PPC)", "08166af62693ceab79b28d90d2f6c86b", 106927, Common::JA_JPN, 501),
-	WINGAME1_l("ursaminorblue", "Hybrid release", "UMB_32.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1405383, Common::JA_JPN, 501),
+	WINGAME1_l("ursaminorblue", "Hybrid release", "START/UMB_32.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1405383, Common::JA_JPN, 501),
 
 	MACGAME1("vp2", "", "VPhys2", "cb91232ecece0045461d236d5914c03d", 719261, 500),
 	MACDEMO1("vp2", "Demo", "VP2Demo", "cb91232ecece0045461d236d5914c03d", 719261, 500),
@@ -4951,9 +4950,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1_l("okaytruehero", "",	"ok39932.exe", 	"1b8d78ddca650041b8997cac7af3184b", 1883584, Common::DE_DEU, 650),
 
 	MACGAME2_l("pantosstory", "", "START", "7d0c7ae431938c53e64d443b05bf19fd", 1035232,
-								  "A00.Dxr", "a36c3a6044d0dbcfa30b147cbdfc4f5f", 1367720, Common::JA_JPN, 602),
-	WINGAME2_l("pantosstory", "", "START.EXE", "45871c12eb944f09f50ee742113a1e2d", 1861862,
-								  "A00.DXR", "a36c3a6044d0dbcfa30b147cbdfc4f5f", 1367720, Common::JA_JPN, 602),
+								  "PANTOS/A00.Dxr", "a36c3a6044d0dbcfa30b147cbdfc4f5f", 1367720, Common::JA_JPN, 602),
+	WINGAME2t_l("pantosstory", "", "START.EXE", "0aabeac068ad6048f8c7ed19ac7458ea", 1861862,
+								  "PANTOS/A00.DXR", "cadb6e5b4dd143c7754b31026f4c2676", 1367720, Common::JA_JPN, 602),
 
 	WINGAME2_l("pettson2", "", "START32.EXE", "518a98696fe1122e08410b0f157f21bf", 1723219,
 							   "START.DXR",	  "18d333b1b9b02d76b35a07252046d295", 37384, Common::SE_SWE, 602),
@@ -4970,8 +4969,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 								"Pintitle.dxr", "e02ebaad2b4c28914b9fe0fedd740a53", 498532, 650),
 
 	// Four disc game, but the Director executable is only on disc 1
-	MACGAME1_l("pinkgear2", "",		   "Go To PINK GEAR", "b8bf83e119ac8980193921b8c5eabb2c", 118654, Common::JA_JPN, 602),
-	WINGAME1_l("pinkgear2", "",		   "Go To PINK GEAR.exe", "45871c12eb944f09f50ee742113a1e2d", 2215164, Common::JA_JPN, 602),
+	MACGAME1_l("pinkgear2", "",		   "PINK GEAR/Go To PINK GEAR", "b8bf83e119ac8980193921b8c5eabb2c", 118654, Common::JA_JPN, 602),
+	WINGAME1_l("pinkgear2", "",		   "PINK GEAR/Go To PINK GEAR.exe", "45871c12eb944f09f50ee742113a1e2d", 2215164, Common::JA_JPN, 602),
 
 	WINGAME1_l("plcd", "Nº11 1998", "submarine.exe", "a593079aecf5bd938ce75264cac24b2d", 1700379, Common::RU_RUS, 600),
 	WINGAME2_l("plcd", "Nº12 1998", "Start.exe",	 "d62438566e44826960fc16c5c23dbe43", 1919710,


### PR DESCRIPTION
This removes several entries from the Director detection paths and switches over to the new in-place path specification that was added recently.