### PR TITLE
SHERLOCK: Fix missing haze when going to Cleopatra's Needle

### DIFF
--- a/engines/sherlock/tattoo/tattoo.cpp
+++ b/engines/sherlock/tattoo/tattoo.cpp
@@ -89,6 +89,15 @@ void TattooEngine::initialize() {
 void TattooEngine::startScene() {
 	TattooUserInterface &ui = *(TattooUserInterface *)_ui;
 
+	if (_scene->_goToScene == OVERHEAD_MAP || _scene->_goToScene == OVERHEAD_MAP2) {
+		// Show the map
+		_scene->_currentScene = OVERHEAD_MAP;
+		_scene->_goToScene = _map->show();
+
+		_people->_savedPos = Common::Point(-1, -1);
+		_people->_savedPos._facing = -1;
+	}
+
 	switch (_scene->_goToScene) {
 	case 7:
 	case 8:
@@ -106,16 +115,6 @@ void TattooEngine::startScene() {
 	case STARTING_INTRO_SCENE:
 		// Disable input so that the intro can't be skipped until the game's logo has been shown
 		ui._lockoutTimer = STARTUP_KEYS_DISABLED_DELAY;
-		break;
-
-	case OVERHEAD_MAP:
-	case OVERHEAD_MAP2:
-		// Show the map
-		_scene->_currentScene = OVERHEAD_MAP;
-		_scene->_goToScene = _map->show();
-
-		_people->_savedPos = Common::Point(-1, -1);
-		_people->_savedPos._facing = -1;
 		break;
 
 	case 101:


### PR DESCRIPTION
In The Case of the Rose Tattoo, certain rooms have a hard-coded haze. This is loaded in TattooEngine::startScene(), but this was bypassed if the room was loaded through the overhead map. (I think that only happens for Cleopatra's Needle.) This pull request fixes that by handling the map case first.

If this is the correct fix (and I've convinced myself that this is likely), it should probably be fixed in 2.5 as well.