### PR TITLE
SCUMM: Rewrite player_v3a

### DIFF
--- a/audio/mods/paula.h
+++ b/audio/mods/paula.h
@@ -112,12 +112,15 @@ protected:
 		Offset offset;
 		byte panning; // For stereo mixing: 0 = far left, 255 = far right
 		int dmaCount;
+		bool interrupt;
 	};
 
 	bool _end;
 	Common::Mutex &_mutex;
 
 	virtual void interrupt() = 0;
+
+	virtual void interruptChannel(byte channel) { }
 
 	void startPaula() {
 		_playing = true;
@@ -147,6 +150,11 @@ protected:
 		// actually first 2 bytes are dropped?
 		ch.offset = Offset(0);
 		// ch.period = ch.periodRepeat;
+	}
+
+	void setChannelInterrupt(byte channel, bool enable) {
+		assert(channel < NUM_VOICES);
+		_voice[channel].interrupt = enable;
 	}
 
 	void setChannelPeriod(byte channel, int16 period) {

--- a/engines/scumm/players/player_v3a.h
+++ b/engines/scumm/players/player_v3a.h
@@ -24,8 +24,10 @@
 #define SCUMM_PLAYERS_PLAYER_V3A_H
 
 #include "common/scummsys.h"
+#include "common/util.h"
 #include "scumm/music.h"
-#include "scumm/players/player_mod.h"
+#include "audio/mixer.h"
+#include "audio/mods/paula.h"
 
 class Mixer;
 
@@ -36,64 +38,90 @@ class ScummEngine;
 /**
  * Scumm V3 Amiga sound/music driver.
  */
-class Player_V3A : public MusicEngine {
+class Player_V3A : public MusicEngine, Audio::Paula {
 public:
 	Player_V3A(ScummEngine *scumm, Audio::Mixer *mixer);
 	~Player_V3A() override;
 
+	// MusicEngine API
 	void setMusicVolume(int vol) override;
 	void startSound(int sound) override;
 	void stopSound(int sound) override;
 	void stopAllSounds() override;
-	int  getMusicTimer() override;
 	int  getSoundStatus(int sound) const override;
+	int  getMusicTimer() override;
+
+protected:
+	// Paula API
+	void interrupt() override;
+	void interruptChannel(byte channel) override;
 
 private:
-	enum {
-		V3A_MAXMUS = 24,
-		V3A_MAXSFX = 16
+	struct SndChan {
+		int period;	/* 16.16 fixed point */
+		int volume;	/* 8.8 fixed point */
+		int loopCount;	/* decrement once per loop, halt playback upon reaching zero */
+		int sweepRate;	/* add to period once per frame */
+		int haltTimer;	/* decrement once per frame, halt playback upon reaching zero */
+		int fadeRate;	/* if haltTimer is zero, subtract 0x100*this from volume once per frame */
+
+		int resourceId;
+		int priority;
+
+		// Both of these are used exclusively by the Loom music engine
+		int instrument;
+		int canOverride;
 	};
 
-	struct musChan {
-		int id;
-		int dur;
+	struct InstData {
+		int8 *mainData[6];
+		uint16 mainLen[6];
+		int8 *loopData[6];
+		uint16 loopLen[6];
+		int16 octave[6];
+		int16 pitchAdjust;
+		int16 volumeFade;
 	};
 
-	struct sfxChan {
-		int id;
-		int dur;
-		uint32 rate;
-		int32 delta;
+	ScummEngine *const _vm;
+	Audio::Mixer *const _mixer;
+	Audio::SoundHandle _soundHandle;
+
+	SndChan _channels[4];
+
+	const int SFX_CHANNEL_MAP[2][2] = {
+		{ 0, 1 },
+		{ 3, 2 }
 	};
-
-	struct instData {
-		char *_idat[6];
-		uint16 _ilen[6];
-		char *_ldat[6];
-		uint16 _llen[6];
-		uint16 _oct[6];
-		int16 _pitadjust;
+	const uint16 NOTE_FREQS[4][12] = {
+		{0x06B0, 0x0650, 0x05F4, 0x05A0, 0x054C, 0x0500, 0x04B8, 0x0474, 0x0434, 0x03F8, 0x03C0, 0x0388},
+		{0x0358, 0x0328, 0x02FA, 0x02D0, 0x02A6, 0x0280, 0x025C, 0x023A, 0x021A, 0x01FC, 0x01E0, 0x01C4},
+		{0x01AC, 0x0194, 0x017D, 0x0168, 0x0153, 0x0140, 0x012E, 0x011D, 0x010D, 0x00FE, 0x00F0, 0x00E2},
+		{0x00D6, 0x00CA, 0x00BE, 0x00B4, 0x00A9, 0x00A0, 0x0097, 0x008E, 0x0086, 0x007F, 0x00F0, 0x00E2}
 	};
-
-	ScummEngine *_vm;
-	Player_MOD *_mod;
-
-	musChan _mus[V3A_MAXMUS];
-	sfxChan _sfx[V3A_MAXSFX];
 
 	int _curSong;
-	uint8 *_songData;
+	int8 *_songData;
 	uint16 _songPtr;
 	uint16 _songDelay;
-	int _music_timer;
-	bool _isinit;
+	int _musicTimer;
 
-	instData **_wavetable;
+	enum {
+		kInitStateFailed = -1,
+		kInitStateNotReady = 0,
+		kInitStateReady = 1
+	} _initState;
 
-	int getMusChan (int id = 0) const;
-	int getSfxChan (int id = 0) const;
-	static void update_proc(void *param);
-	void playMusic();
+	int8 *_wavetableData;
+	InstData *_wavetablePtrs;
+
+	void updateProc();
+	void updateMusicIndy();
+	void updateMusicLoom();
+	void updateSounds();
+	void startNote(int channel, int instrument, int pitch, int volume, int duration);
+
+	bool init();
 };
 
 } // End of namespace Scumm


### PR DESCRIPTION
Back when I first wrote `player_v3a` many, many years ago, I based it on a loose understanding of a poorly-labeled disassembly, and its behavior was only loosely related to the original engines - music was allowed to use as many sound channels as it wanted (with a cap of 24), sounds could play on top of music, and some things were just plain done wrong.

With the aid of newer tools (namely, Ghidra), I've been able to much more closely analyze the sound engines in both Indy3 and Loom (which were actually significantly different from each other in several places) and rewrite `player_v3a` to function exactly as the original games did. In particular, music now correctly plays in stereo and is limited to 4 channels, and sound effects are now _also_ played in stereo (i.e. some play at different frequencies in each ear).

Note that this technically makes some things sound "worse" compared to my original code, but they're _supposed_ to sound that way, and I personally think accuracy is more important. That, and my old code sucked and I wanted to make it better.

A similar rewrite of `player_v2a` is in the works, though it might be a long time before it's ready.