### PR TITLE
TINYGL: Use the existing list of rectangles when copying to the screen

### DIFF
--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -169,10 +169,19 @@ void GfxTinyGL::clearDepthBuffer() {
 }
 
 void GfxTinyGL::flipBuffer() {
-	TinyGL::presentBuffer();
+	Common::List<Common::Rect> dirtyAreas;
+	TinyGL::presentBuffer(dirtyAreas);
+
 	Graphics::Surface glBuffer;
 	TinyGL::getSurfaceRef(glBuffer);
-	g_system->copyRectToScreen(glBuffer.getPixels(), glBuffer.pitch, 0, 0, glBuffer.w, glBuffer.h);
+
+	if (!dirtyAreas.empty()) {
+		for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
+			g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch,
+			                           (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+		}
+	}
+
 	g_system->updateScreen();
 }
 

--- a/engines/myst3/gfx_tinygl.cpp
+++ b/engines/myst3/gfx_tinygl.cpp
@@ -272,10 +272,18 @@ Graphics::Surface *TinyGLRenderer::getScreenshot() {
 }
 
 void TinyGLRenderer::flipBuffer() {
-	TinyGL::presentBuffer();
+	Common::List<Common::Rect> dirtyAreas;
+	TinyGL::presentBuffer(dirtyAreas);
+
 	Graphics::Surface glBuffer;
 	TinyGL::getSurfaceRef(glBuffer);
-	g_system->copyRectToScreen(glBuffer.getPixels(), glBuffer.pitch, 0, 0, glBuffer.w, glBuffer.h);
+
+	if (!dirtyAreas.empty()) {
+		for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
+			g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch,
+			                           (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+		}
+	}
 }
 
 } // End of namespace Myst3

--- a/engines/playground3d/gfx_tinygl.cpp
+++ b/engines/playground3d/gfx_tinygl.cpp
@@ -229,10 +229,18 @@ void TinyGLRenderer::drawPolyOffsetTest(const Math::Vector3d &pos, const Math::V
 }
 
 void TinyGLRenderer::flipBuffer() {
-	TinyGL::presentBuffer();
+	Common::List<Common::Rect> dirtyAreas;
+	TinyGL::presentBuffer(dirtyAreas);
+
 	Graphics::Surface glBuffer;
 	TinyGL::getSurfaceRef(glBuffer);
-	g_system->copyRectToScreen(glBuffer.getPixels(), glBuffer.pitch, 0, 0, glBuffer.w, glBuffer.h);
+
+	if (!dirtyAreas.empty()) {
+		for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
+			g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch,
+			                           (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+		}
+	}
 }
 
 void TinyGLRenderer::dimRegionInOut(float fade) {

--- a/engines/stark/gfx/tinygl.cpp
+++ b/engines/stark/gfx/tinygl.cpp
@@ -93,10 +93,19 @@ void TinyGLDriver::clearScreen() {
 }
 
 void TinyGLDriver::flipBuffer() {
-	TinyGL::presentBuffer();
+	Common::List<Common::Rect> dirtyAreas;
+	TinyGL::presentBuffer(dirtyAreas);
+
 	Graphics::Surface glBuffer;
 	TinyGL::getSurfaceRef(glBuffer);
-	g_system->copyRectToScreen(glBuffer.getPixels(), glBuffer.pitch, 0, 0, glBuffer.w, glBuffer.h);
+
+	if (!dirtyAreas.empty()) {
+		for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
+			g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch,
+			                           (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+		}
+	}
+
 	g_system->updateScreen();
 }
 

--- a/graphics/tinygl/tinygl.h
+++ b/graphics/tinygl/tinygl.h
@@ -33,6 +33,7 @@ namespace TinyGL {
 void createContext(int screenW, int screenH, Graphics::PixelFormat pixelFormat, int textureSize, bool dirtyRectsEnable = true);
 void destroyContext();
 void presentBuffer();
+void presentBuffer(Common::List<Common::Rect> &dirtyAreas);
 void getSurfaceRef(Graphics::Surface &surface);
 Graphics::Surface *copyToBuffer(const Graphics::PixelFormat &dstFormat);
 

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -470,8 +470,8 @@ public:
 	void disposeResources();
 	void disposeDrawCallLists();
 
-	void presentBufferDirtyRects();
-	void presentBufferSimple();
+	void presentBufferDirtyRects(Common::List<Common::Rect> &dirtyAreas);
+	void presentBufferSimple(Common::List<Common::Rect> &dirtyAreas);
 	
 	GLSpecBuf *specbuf_get_buffer(const int shininess_i, const float shininess);
 	void specbuf_cleanup();


### PR DESCRIPTION
This seems to work, but is in draft mode until it can be tested more thoroughly.