### PR TITLE
DIRECTOR: stop sound before playing stream

### DIFF
--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -81,6 +81,7 @@ void DirectorSound::playFile(Common::String filename, uint8 soundChannel) {
 	Audio::AudioStream *sound = af.getAudioStream(false, false, DisposeAfterUse::YES);
 
 	cancelFade(soundChannel);
+	stopSound(soundChannel);
 	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_channels[soundChannel - 1].handle, sound, -1, getChannelVolume(soundChannel));
 
 	// Set the last played sound so that cast member 0 in the sound channel doesn't stop this file.


### PR DESCRIPTION
I've run into one game, Ganbare! Inu-chan (ganbareinuchan), which doesn't explicitly stop sounds before playing new ones in the same channel. With the original Director runtime, the previous sound in that channel is automatically stopped. In ScummVM, without this patch, the previous sound keeps playing and the new sound is added on top. It leads to multiple background songs playing simultaneously.