### PR TITLE
SHERLOCK: Fix looking at room objects while inventory is open in Serrated Scalpel

### DIFF
--- a/engines/sherlock/scalpel/scalpel_inventory.cpp
+++ b/engines/sherlock/scalpel/scalpel_inventory.cpp
@@ -251,7 +251,7 @@ void ScalpelInventory::putInv(InvSlamMode slamIt) {
 	// Iterate through displaying up to 6 objects at a time
 	for (int idx = _invIndex; idx < _holdings && (idx - _invIndex) < (int)_invShapes.size(); ++idx) {
 		int itemNum = idx - _invIndex;
-		Surface &bb = slamIt == SLAM_SECONDARY_BUFFER ? screen._backBuffer2 : screen._backBuffer1;
+		Surface &bb = (slamIt == SLAM_SECONDARY_BUFFER) ? screen._backBuffer2 : *screen.getBackBuffer();
 		Common::Rect r(8 + itemNum * 52, 165, 51 + itemNum * 52, 194);
 
 		// Draw the background

--- a/engines/sherlock/scalpel/scalpel_user_interface.cpp
+++ b/engines/sherlock/scalpel/scalpel_user_interface.cpp
@@ -1266,12 +1266,13 @@ void ScalpelUserInterface::doLookControl() {
 	_keyboardInput = (_keyPress != '\0');
 
 	if (events._released || events._rightReleased || _keyboardInput) {
+		// Is there any remaining text to display?
+		if (!_descStr.empty()) {
+			printObjectDesc(_descStr, false);
+		}
 		// Is an inventory object being looked at?
-		if (!_invLookFlag) {
-			// Is there any remaining text to display?
-			if (!_descStr.empty()) {
-				printObjectDesc(_descStr, false);
-			} else if (!_lookHelp) {
+		else if (!_invLookFlag) {
+			if (!_lookHelp) {
 				// Need to close the window and depress the Look button
 				Common::Point pt(MENU_POINTS[0][0], MENU_POINTS[0][1]);
 				offsetButton3DO(pt, 0);


### PR DESCRIPTION
This pull request aims to fix two long-standing glitches in The Case of the Serrated Scalpel, both happening when examining objects in the room while the inventory is open.

- When the description window was closed, the inventory would show only empty slots. This appears to be because our putInv() function referred to _backBuffer1 directly, instead of using the current back buffer (which in this case was back buffer 2).
- When examining a room object, only the first page of the description was shown. This bug happens in the original as well, and the easiest way to test this is to examine the violin in the first room of the game. Hopefully fixing this will not cause any unwanted side effects.