### PR TITLE
SHERLOCK: Remove music.lib from detection entries

### DIFF
--- a/engines/sherlock/detection_tables.h
+++ b/engines/sherlock/detection_tables.h
@@ -68,8 +68,7 @@ static const SherlockGameDescription gameDescriptions[] = {
 		{
 			"scalpel",
 			0,
-			AD_ENTRY2s("talk.lib",  "40a5f9f37c0e0d2ad48d8f44d8e393c9", 284278,
-					   "music.lib", "68ae2f7684ecf903bd60a00bb6bae195", 366465),
+			AD_ENTRY1s("talk.lib", "40a5f9f37c0e0d2ad48d8f44d8e393c9", 284278),
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -85,8 +84,7 @@ static const SherlockGameDescription gameDescriptions[] = {
 		{
 			"scalpel",
 			0,
-			AD_ENTRY2s("talk.lib",  "44652e54172e13b1b075b1ef7d89de24", 284043,
-					   "music.lib", "68ae2f7684ecf903bd60a00bb6bae195", 366465),
+			AD_ENTRY1s("talk.lib", "44652e54172e13b1b075b1ef7d89de24", 284043),
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -97,13 +95,12 @@ static const SherlockGameDescription gameDescriptions[] = {
 	},
 
 	{
-		// Case of the Serrated Scalpel - German
+		// Case of the Serrated Scalpel - German Floppy
 		// Provided by max565
 		{
 			"scalpel",
 			0,
-			AD_ENTRY2s("talk.lib",  "3d813fd8505b391a1f8b3a16b1aa7f2e", 284195,
-					   "music.lib", "68ae2f7684ecf903bd60a00bb6bae195", 366465),
+			AD_ENTRY1s("talk.lib", "3d813fd8505b391a1f8b3a16b1aa7f2e", 284195),
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -119,8 +116,7 @@ static const SherlockGameDescription gameDescriptions[] = {
 		{
 			"scalpel",
 			0,
-			AD_ENTRY2s("talk.lib",  "27697804b637a7f3b77234bf16f15dce", 171419,
-					   "music.lib", "68ae2f7684ecf903bd60a00bb6bae195", 366465),
+			AD_ENTRY1s("talk.lib", "27697804b637a7f3b77234bf16f15dce", 171419),
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -151,8 +147,7 @@ static const SherlockGameDescription gameDescriptions[] = {
 		{
 			"scalpel",
 			0,
-			AD_ENTRY2s("talk.lib",  "1a547f96476a3a50cf6f0d599a4f5bcc", 247406,
-					   "music.lib", "68ae2f7684ecf903bd60a00bb6bae195", 366465),
+			AD_ENTRY1s("talk.lib", "1a547f96476a3a50cf6f0d599a4f5bcc", 247406),
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE,
@@ -196,7 +191,7 @@ static const SherlockGameDescription gameDescriptions[] = {
 		// Provided by Strangerke
 		{
 			"scalpel",
-			"Non Interactive Demo",
+			"Non-Interactive Demo",
 			AD_ENTRY1s("music.lib", "ec19a09b7fef6fd90b1ab812ce6e9739", 38563),
 			Common::EN_ANY,
 			Common::kPlatformDOS,


### PR DESCRIPTION
This removes entries for "music.lib" in cases where "talk.lib" was already present. In all these entries, the "music.lib" hash given is identical to the English CD version. In a few cases, such as with the German floppy version (real MD5 of `8c91a1a6ea98d0a890bc2f9376ec4bf0`, 159485) and one of the German CD versions (as in https://bugs.scummvm.org/ticket/12992), this was incorrect.