### PR TITLE
SCUMM: Show subtitles on talkie versions without sound file

### DIFF
--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1487,8 +1487,12 @@ Common::Error ScummEngine::init() {
 	resetScumm();
 	resetScummVars();
 
-	if (_game.version >= 5 && _game.version <= 7)
+	if (_game.version >= 5 && _game.version <= 7) {
 		_sound->setupSound();
+		// In case of talkie edition without sfx file, enable subtitles
+		if (!_sound->hasSfxFile() && !ConfMan.getBool("subtitles"))
+			ConfMan.setBool("subtitles", true);
+	}
 
 	syncSoundSettings();
 

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -1002,6 +1002,11 @@ bool Sound::isSfxFileCompressed() {
 	return !(_soundMode == kVOCMode);
 }
 
+bool Sound::hasSfxFile() const
+{
+	return !_sfxFilename.empty();
+}
+
 ScummFile *Sound::restoreDiMUSESpeechFile(const char *fileName) {
 	Common::ScopedPtr<ScummFile> file;
 	file.reset(new ScummFile());

--- a/engines/scumm/sound.h
+++ b/engines/scumm/sound.h
@@ -121,6 +121,7 @@ public:
 	virtual void setupSound();
 	void pauseSounds(bool pause);
 	bool isSfxFileCompressed();
+	bool hasSfxFile() const;
 	ScummFile *restoreDiMUSESpeechFile(const char *fileName);
 
 	void startCDTimer();


### PR DESCRIPTION
If the game is a talkie version, on which the verbs reference sounds, but it is missing the sound file, and the user chose Voice Only, a warning appears for every playback attempt.

Force subtitles on this case, to avoid these warnings.

Fixes [trac 13151](https://bugs.scummvm.org/ticket/13151)
