### PR TITLE
XEEN: fix out-of-bounds access when handling item drops

### DIFF
--- a/engines/xeen/combat.cpp
+++ b/engines/xeen/combat.cpp
@@ -102,7 +102,7 @@ static const int POW_WEAPON_VOCS[35] = {
 	5, 5, 5, 1, 3, 2, 5, 1, 1, 1, 0, 0, 0, 2, 2
 };
 
-static const int MONSTER_ITEM_RANGES[6] = { 10, 20, 50, 100, 100, 100 };
+static const int MONSTER_ITEM_RANGES[ITEM_DROP_MAX + 1] = { 10, 20, 50, 100, 100, 100, 100, 100 };
 
 #define monsterSavingThrow(MONINDEX) (_vm->getRandomNumber(1, 50 + (MONINDEX)) <= (MONINDEX))
 

--- a/engines/xeen/map.cpp
+++ b/engines/xeen/map.cpp
@@ -124,6 +124,7 @@ void MonsterStruct::synchronize(Common::SeekableReadStream &s) {
 	_gold = s.readUint16LE();
 	_gems = s.readByte();
 	_itemDrop = s.readByte();
+	assert(0 <= _itemDrop && _itemDrop <= ITEM_DROP_MAX);
 	_flying = s.readByte() != 0;
 	_imageNumber = s.readByte();
 	_loopAnimation = s.readByte();

--- a/engines/xeen/map.h
+++ b/engines/xeen/map.h
@@ -38,6 +38,7 @@ namespace Xeen {
 #define MAP_HEIGHT 16
 #define TOTAL_SURFACES 16
 #define INVALID_CELL 0x8888
+#define ITEM_DROP_MAX 7
 
 class XeenEngine;
 


### PR DESCRIPTION
An out-of-bounds access can be triggered [here](https://github.com/scummvm/scummvm/blob/master/engines/xeen/combat.cpp#L1529) when `MonsterStruct._itemDrop >= 5`.

The maximum value for `MonsterStruct._itemDrop` is 7, as seen by running with this patch:
```diff
diff --git i/engines/xeen/map.cpp w/engines/xeen/map.cpp
--- i/engines/xeen/map.cpp
+++ w/engines/xeen/map.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include <iostream>
+
 #include "common/serializer.h"
 #include "xeen/map.h"
 #include "xeen/interface.h"
@@ -124,6 +126,8 @@ void MonsterStruct::synchronize(Common::SeekableReadStream &s) {
 	_gold = s.readUint16LE();
 	_gems = s.readByte();
 	_itemDrop = s.readByte();
+	if (_itemDrop >= 6)
+		std::cout << _name.c_str() << ": " << _itemDrop << "\n";
 	assert(0 <= _itemDrop && _itemDrop <= ITEM_DROP_MAX);
 	_flying = s.readByte() != 0;
 	_imageNumber = s.readByte();
```
…and starting a new game:
```
Darzog: 6
```
And when traveling to the Darkside:
```
Darzog: 6
Death Knight: 6
Coven Leader: 6
Cult Leader: 6
Doom Knight: 7
Sandro: 7
Mega Mage: 6
Morgana: 6
Gurodel: 6
Xenoc: 6
Barkman: 6
```

Now, there's still something fishy about the code:
```c
static const int MONSTER_ITEM_RANGES[ITEM_DROP_MAX + 1] = { 10, 20, 50, 100, 100, 100, 100, 100 };

[…]
			if (itemDrop) {
				if (MONSTER_ITEM_RANGES[itemDrop] >= _vm->getRandomNumber(1, 100)) {
```

So the 10% drop rate is never used.

Maybe this should be rewritten as:
```c
static const int MONSTER_ITEM_RANGES[ITEM_DROP_MAX] = { 10, 20, 50, 100, 100, 100, 100 };
[…]
			if (itemDrop) {
				if (MONSTER_ITEM_RANGES[itemDrop - 1] >= _vm->getRandomNumber(1, 100)) {
```
…depending on what the original game does (@dreammaster do you have a way to check?).