### PR TITLE
SHERLOCK: Make the Serrated Scalpel darts minigame harder (to better match original)

### DIFF
--- a/engines/sherlock/scalpel/scalpel_darts.cpp
+++ b/engines/sherlock/scalpel/scalpel_darts.cpp
@@ -419,7 +419,7 @@ int Darts::dartHit() {
 	Events &events = *_vm->_events;
 
 	// Process pending events
-	events.pollEventsAndWait();
+	events.pollEvents();
 
 	if (events.kbHit()) {
 		// Key was pressed, so return it


### PR DESCRIPTION
The power bars in the Serrated Scalpel darts minigame moves a lot slower in ScummVM than they do in the original, making the game trivially easy since you're pretty much guaranteed to always score 25 or 50 points per throw if you want to. They also move a lot slower than when your opponent plays.

The reason for this is that in addition to the regular delay, ScummVM adds an extra delay when polling events. Changing that makes it match the original speed much better.

This makes the minigame more frustrating, of course, but as far as I know it's completely optional since you can blackmail the bartender for the information instead.