### PR TITLE
ANDROID: Use 24/32 bits textures when possible

### DIFF
--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -67,9 +67,17 @@ void AndroidGraphicsManager::initSurface() {
 	// Notify the OpenGL code about our context.
 	setContextType(OpenGL::kContextGLES2);
 
-	// We default to RGB565 and RGBA5551 which is closest to the actual output
-	// mode we setup.
-	notifyContextCreate(Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0), Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0));
+	if (JNI::egl_bits_per_pixel == 16) {
+		// We default to RGB565 and RGBA5551 which is closest to what we setup in Java side
+		notifyContextCreate(Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0), Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0));
+	} else {
+		// If not 16, this must be 24 or 32 bpp so make use of them
+#ifdef SCUMM_BIG_ENDIAN
+		notifyContextCreate(Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0), Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
+#else
+		notifyContextCreate(Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0), Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+#endif
+	}
 
 	handleResize(JNI::egl_surface_width, JNI::egl_surface_height);
 }

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -72,8 +72,7 @@ AndroidGraphics3dManager::AndroidGraphics3dManager() :
 	_mouse_texture_rgb(0),
 	_mouse_hotspot(),
 	_mouse_keycolor(0),
-	_show_mouse(false),
-	_use_mouse_palette(false) {
+	_show_mouse(false) {
 	_game_texture = new GLESFakePalette565Texture();
 	_overlay_texture = new GLES5551Texture();
 	_overlay_background = new GLES5551Texture();
@@ -388,12 +387,6 @@ bool AndroidGraphics3dManager::hasFeature(OSystem::Feature f) const {
 
 void AndroidGraphics3dManager::setFeatureState(OSystem::Feature f, bool enable) {
 	switch (f) {
-	case OSystem::kFeatureCursorPalette:
-		_use_mouse_palette = enable;
-		if (!enable) {
-			disableCursorPalette();
-		}
-		break;
 	case OSystem::kFeatureFullscreenMode:
 		_fullscreen = enable;
 		updateScreenRect();
@@ -410,7 +403,7 @@ void AndroidGraphics3dManager::setFeatureState(OSystem::Feature f, bool enable) 
 bool AndroidGraphics3dManager::getFeatureState(OSystem::Feature f) const {
 	switch (f) {
 	case OSystem::kFeatureCursorPalette:
-		return _use_mouse_palette;
+		return true;
 	case OSystem::kFeatureFullscreenMode:
 		return _fullscreen;
 	case OSystem::kFeatureAspectRatioCorrection:
@@ -539,81 +532,36 @@ int16 AndroidGraphics3dManager::getWidth() const {
 }
 
 void AndroidGraphics3dManager::setPalette(const byte *colors, uint start, uint num) {
-	ENTER("%p, %u, %u", colors, start, num);
-
-#ifdef USE_RGB_COLOR
-	assert(_game_texture->hasPalette());
-#endif
-
-	GLTHREADCHECK;
-
-	if (!_use_mouse_palette) {
-		setCursorPaletteInternal(colors, start, num);
-	}
-
-	const Graphics::PixelFormat &pf = _game_texture->getPalettePixelFormat();
-	// _game_texture is a GLESFakePalette565Texture so it's 16bits colors
-	assert(pf.bpp() == sizeof(uint16) * 8);
-	byte *p = _game_texture->palette() + start * sizeof(uint16);
-
-	for (uint i = 0; i < num; ++i, colors += 3, p += sizeof(uint16)) {
-		WRITE_UINT16(p, pf.RGBToColor(colors[0], colors[1], colors[2]));
-	}
+	// We should never end up here in 3D
+	assert(false);
 }
 
 void AndroidGraphics3dManager::grabPalette(byte *colors, uint start, uint num) const {
-	ENTER("%p, %u, %u", colors, start, num);
-
-#ifdef USE_RGB_COLOR
-	assert(_game_texture->hasPalette());
-#endif
-
-	GLTHREADCHECK;
-
-	const Graphics::PixelFormat &pf = _game_texture->getPalettePixelFormat();
-	// _game_texture is a GLESFakePalette565Texture so it's 16bits colors
-	assert(pf.bpp() == sizeof(uint16) * 8);
-	const byte *p = _game_texture->palette_const() + start * sizeof(uint16);
-
-	for (uint i = 0; i < num; ++i, colors += 3, p += sizeof(uint16)) {
-		pf.colorToRGB(READ_UINT16(p), colors[0], colors[1], colors[2]);
-	}
+	// We should never end up here in 3D
+	assert(false);
 }
 
 Graphics::Surface *AndroidGraphics3dManager::lockScreen() {
-	ENTER();
+	// We should never end up here in 3D
+	assert(false);
 
-	GLTHREADCHECK;
-
-	Graphics::Surface *surface = _game_texture->surface();
-	assert(surface->getPixels());
-
-	return surface;
+	return nullptr;
 }
 
 void AndroidGraphics3dManager::unlockScreen() {
-	ENTER();
-
-	GLTHREADCHECK;
-
-	assert(_game_texture->dirty());
+	// We should never end up here in 3D
+	assert(false);
 }
 
 void AndroidGraphics3dManager::fillScreen(uint32 col) {
-	ENTER("%u", col);
-
-	GLTHREADCHECK;
-
-	_game_texture->fillBuffer(col);
+	// We should never end up here in 3D
+	assert(false);
 }
 
 void AndroidGraphics3dManager::copyRectToScreen(const void *buf, int pitch,
         int x, int y, int w, int h) {
-	ENTER("%p, %d, %d, %d, %d, %d", buf, pitch, x, y, w, h);
-
-	GLTHREADCHECK;
-
-	_game_texture->updateBuffer(x, y, w, h, buf, pitch);
+	// We should never end up here in 3D
+	assert(false);
 }
 
 void AndroidGraphics3dManager::initSize(uint width, uint height,
@@ -817,34 +765,6 @@ void AndroidGraphics3dManager::setCursorPalette(const byte *colors,
 	}
 
 	setCursorPaletteInternal(colors, start, num);
-	_use_mouse_palette = true;
-}
-
-void AndroidGraphics3dManager::disableCursorPalette() {
-	// when disabling the cursor palette, and we're running a clut8 game,
-	// it expects the game palette to be used for the cursor
-	if (_game_texture->hasPalette()) {
-		// _game_texture and _mouse_texture_palette are GLESFakePalette565Texture so it's 16bits colors
-		const Graphics::PixelFormat &pf_src =
-		    _game_texture->getPalettePixelFormat();
-		const Graphics::PixelFormat &pf_dst =
-		    _mouse_texture_palette->getPalettePixelFormat();
-		assert(pf_src.bpp() == sizeof(uint16) * 8);
-		assert(pf_dst.bpp() == sizeof(uint16) * 8);
-
-		const byte *src = _game_texture->palette_const();
-		byte *dst = _mouse_texture_palette->palette();
-
-		uint8 r, g, b;
-
-		for (uint i = 0; i < 256; ++i, src += sizeof(uint16), dst += sizeof(uint16)) {
-			pf_src.colorToRGB(READ_UINT16(src), r, g, b);
-			WRITE_UINT16(dst, pf_dst.RGBToColor(r, g, b));
-		}
-
-		byte *p = _mouse_texture_palette->palette() + _mouse_keycolor * sizeof(uint16);
-		WRITE_UINT16(p, READ_UINT16(p) & ~1);
-	}
 }
 
 bool AndroidGraphics3dManager::lockMouse(bool lock) {
@@ -866,10 +786,8 @@ Graphics::PixelFormat AndroidGraphics3dManager::getScreenFormat() const {
 
 Common::List<Graphics::PixelFormat> AndroidGraphics3dManager::getSupportedFormats() const {
 	Common::List<Graphics::PixelFormat> res;
-	res.push_back(GLES565Texture::pixelFormat());
-	res.push_back(GLES5551Texture::pixelFormat());
-	res.push_back(GLES4444Texture::pixelFormat());
-	res.push_back(Graphics::PixelFormat::createFormatCLUT8());
+
+	// empty list
 
 	return res;
 }
@@ -990,14 +908,17 @@ AndroidCommonGraphics::State AndroidGraphics3dManager::getState() const {
 	state.fullscreen    = getFeatureState(OSystem::kFeatureFullscreenMode);
 	state.cursorPalette = getFeatureState(OSystem::kFeatureCursorPalette);
 #ifdef USE_RGB_COLOR
-	state.pixelFormat   = getScreenFormat();
+	state.pixelFormat   = _2d_pixel_format;
 #endif
 	return state;
 }
 
 bool AndroidGraphics3dManager::setState(const AndroidCommonGraphics::State &state) {
-	// In 3d we don't have a pixel format so we ignore it
+	// In 3d we don't have a pixel format so we ignore it but store it for when leaving 3d mode
 	initSize(state.screenWidth, state.screenHeight, nullptr);
+#ifdef USE_RGB_COLOR
+	_2d_pixel_format = state.pixelFormat;
+#endif
 	setFeatureState(OSystem::kFeatureAspectRatioCorrection, state.aspectRatio);
 	setFeatureState(OSystem::kFeatureFullscreenMode, state.fullscreen);
 	setFeatureState(OSystem::kFeatureCursorPalette, state.cursorPalette);

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -150,7 +150,7 @@ private:
 	bool _force_redraw;
 
 	// Game layer
-	GLESBaseTexture *_game_texture;
+	GLESTexture *_game_texture;
 	OpenGL::FrameBuffer *_frame_buffer;
 
 #ifdef USE_RGB_COLOR
@@ -164,14 +164,14 @@ private:
 	int _cursorX, _cursorY;
 
 	// Overlay layer
-	GLES5551Texture *_overlay_background;
-	GLES5551Texture *_overlay_texture;
+	GLESTexture *_overlay_background;
+	GLESTexture *_overlay_texture;
 	bool _show_overlay;
 
 	// Mouse layer
 	GLESBaseTexture *_mouse_texture;
-	GLESBaseTexture *_mouse_texture_palette;
-	GLES5551Texture *_mouse_texture_rgb;
+	GLESFakePaletteTexture *_mouse_texture_palette;
+	GLESTexture *_mouse_texture_rgb;
 	Common::Point _mouse_hotspot;
 	Common::Point _mouse_hotspot_scaled;
 	int _mouse_width_scaled, _mouse_height_scaled;

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -132,7 +132,6 @@ protected:
 
 private:
 	void setCursorPaletteInternal(const byte *colors, uint start, uint num);
-	void disableCursorPalette();
 	void initOverlay();
 
 	enum FixupType {
@@ -154,6 +153,11 @@ private:
 	GLESBaseTexture *_game_texture;
 	OpenGL::FrameBuffer *_frame_buffer;
 
+#ifdef USE_RGB_COLOR
+	// Backup of the previous pixel format to pass it back when we leave 3d
+	Graphics::PixelFormat _2d_pixel_format;
+#endif
+
 	/**
 	 * The position of the mouse cursor, in window coordinates.
 	 */
@@ -172,7 +176,6 @@ private:
 	uint32 _mouse_keycolor;
 	int _mouse_targetscale;
 	bool _show_mouse;
-	bool _use_mouse_palette;
 };
 
 #endif

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -119,6 +119,7 @@ public:
 
 protected:
 	void updateScreenRect();
+	void updateCursorScaling();
 	const GLESBaseTexture *getActiveTexture() const;
 	void clipMouse(Common::Point &p) const;
 
@@ -174,7 +175,9 @@ private:
 	GLES5551Texture *_mouse_texture_rgb;
 	Common::Point _mouse_hotspot;
 	uint32 _mouse_keycolor;
-	int _mouse_targetscale;
+	Common::Point _mouse_hotspot_scaled;
+	int _mouse_width_scaled, _mouse_height_scaled;
+	bool _mouse_dont_scale;
 	bool _show_mouse;
 };
 

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -132,7 +132,6 @@ protected:
 	void *getProcAddress(const char *name) const;
 
 private:
-	void setCursorPaletteInternal(const byte *colors, uint start, uint num);
 	void initOverlay();
 
 	enum FixupType {
@@ -174,7 +173,6 @@ private:
 	GLESBaseTexture *_mouse_texture_palette;
 	GLES5551Texture *_mouse_texture_rgb;
 	Common::Point _mouse_hotspot;
-	uint32 _mouse_keycolor;
 	Common::Point _mouse_hotspot_scaled;
 	int _mouse_width_scaled, _mouse_height_scaled;
 	bool _mouse_dont_scale;

--- a/backends/platform/android/jni-android.cpp
+++ b/backends/platform/android/jni-android.cpp
@@ -72,6 +72,7 @@ sem_t JNI::pause_sem = { 0 };
 int JNI::surface_changeid = 0;
 int JNI::egl_surface_width = 0;
 int JNI::egl_surface_height = 0;
+int JNI::egl_bits_per_pixel = 0;
 bool JNI::_ready_for_events = 0;
 
 jmethodID JNI::_MID_getDPI = 0;
@@ -113,7 +114,7 @@ const JNINativeMethod JNI::_natives[] = {
 		(void *)JNI::create },
 	{ "destroy", "()V",
 		(void *)JNI::destroy },
-	{ "setSurface", "(II)V",
+	{ "setSurface", "(III)V",
 		(void *)JNI::setSurface },
 	{ "main", "([Ljava/lang/String;)I",
 		(void *)JNI::main },
@@ -647,9 +648,10 @@ void JNI::destroy(JNIEnv *env, jobject self) {
 	JNI::getEnv()->DeleteGlobalRef(_jobj);
 }
 
-void JNI::setSurface(JNIEnv *env, jobject self, jint width, jint height) {
+void JNI::setSurface(JNIEnv *env, jobject self, jint width, jint height, jint bpp) {
 	egl_surface_width = width;
 	egl_surface_height = height;
+	egl_bits_per_pixel = bpp;
 	surface_changeid++;
 }
 

--- a/backends/platform/android/jni-android.h
+++ b/backends/platform/android/jni-android.h
@@ -48,6 +48,7 @@ public:
 	static int surface_changeid;
 	static int egl_surface_width;
 	static int egl_surface_height;
+	static int egl_bits_per_pixel;
 
 	static jint onLoad(JavaVM *vm);
 
@@ -146,7 +147,7 @@ private:
 						jint audio_buffer_size);
 	static void destroy(JNIEnv *env, jobject self);
 
-	static void setSurface(JNIEnv *env, jobject self, jint width, jint height);
+	static void setSurface(JNIEnv *env, jobject self, jint width, jint height, jint bpp);
 	static jint main(JNIEnv *env, jobject self, jobjectArray args);
 
 	static void pushEvent(JNIEnv *env, jobject self, int type, int arg1,

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -1007,7 +1007,14 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		//                            so app's internal space (which would be deleted on uninstall) was set as WORLD_READABLE which is no longer supported in newer versions of Android API
 		//                            In newer APIs we can set that path as Context.MODE_PRIVATE which is the default - but this makes the files inaccessible to other apps
 
-		_scummvm = new MyScummVM(_main_surface.getHolder(), new MyScummVMDestroyedCallback() {
+		SurfaceHolder main_surface_holder = _main_surface.getHolder();
+
+		// By default Android selects RGB_565 for backward compatibility, use the best one by querying the display
+		// It's deprecated on API level >= 17 and will always return RGBA_8888
+		// but on older versions it could return RGB_565 which could be more efficient for the GPU
+		main_surface_holder.setFormat(getDisplayPixelFormat());
+
+		_scummvm = new MyScummVM(main_surface_holder, new MyScummVMDestroyedCallback() {
 		                                                        @Override
 		                                                        public void handle(int exitResult) {
 		                                                        	Log.d(ScummVM.LOG_TAG, "Via callback: ScummVM native terminated with code: " + exitResult);
@@ -1383,6 +1390,13 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 	public void onVisibilityChanged(boolean visible) {
 //		Toast.makeText(HomeActivity.this, visible ? "Keyboard is active" : "Keyboard is Inactive", Toast.LENGTH_SHORT).show();
 		hideSystemUI();
+	}
+
+	@SuppressWarnings("deprecation")
+	private int getDisplayPixelFormat() {
+		// Since API level 17 this always returns PixelFormat.RGBA_8888
+		// so if we target more recent API levels, we could remove this function
+		return getWindowManager().getDefaultDisplay().getPixelFormat();
 	}
 
 	// Auxiliary function to overwrite a file (used for overwriting the scummvm.ini file with an existing other one)


### PR DESCRIPTION
This PR makes the 3D subsystem more flexible for various texture formats.
In addition, the 3D graphic backend is removed its 2D features and the cursor scaling is fixed.