### PR TITLE
SHERLOCK: Disable autosave

### DIFF
--- a/engines/sherlock/metaengine.cpp
+++ b/engines/sherlock/metaengine.cpp
@@ -82,6 +82,11 @@ public:
 	 * Given a specified savegame slot, returns extended information for the save
 	 */
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+
+	/**
+	 * Disable autosave. It conflicts with built-in save dialog, which doesn't block the slot.
+	 */
+	int getAutosaveSlot() const override { return -1; }
 };
 
 Common::Error SherlockMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {

--- a/engines/sherlock/sherlock.h
+++ b/engines/sherlock/sherlock.h
@@ -166,6 +166,11 @@ public:
 	void syncSoundSettings() override;
 
 	/**
+	 * Disable autosave
+	 */
+	int getAutosaveSlot() const override { return -1; }
+
+	/**
 	 * Saves game configuration information
 	 */
 	virtual void saveConfig();


### PR DESCRIPTION
When using original game dialogs for save/load, the user can save on slot
0, and the when autosave is triggered, a warning appears.
