### PR TITLE
SHERLOCK: Fix Scalpel user interface regression

### DIFF
--- a/engines/sherlock/talk.cpp
+++ b/engines/sherlock/talk.cpp
@@ -429,7 +429,7 @@ void Talk::talkTo(const Common::String filename) {
 
 				if (IS_SERRATED_SCALPEL) {
 					if (!ui._lookScriptFlag) {
-						ui.drawInterface(2);
+						ui.banishWindow();
 						ui._menuMode = STD_MODE;
 						ui._windowBounds.top = CONTROLS_Y1;
 					}


### PR DESCRIPTION
This attempts to fix a regression from 2175ee951ab2a62a0e3a3c6c28341fe447514072. I'm not sure of the exact circumstances, but I think it may be when a character starts talking to you. The first time I saw it was entering the scene of the murder at the beginning of the game. Lestrade greets you, and afterwards the user interface isn't displayed correctly.

I've played through almost the entire game with this fix, so I'm fairly confident that it works the way it should.