### PR TITLE
SHERLOCK: Fix Scalpel animations not being resumed after conversation (bug #10931)

### DIFF
--- a/engines/sherlock/scalpel/scalpel_talk.cpp
+++ b/engines/sherlock/scalpel/scalpel_talk.cpp
@@ -891,16 +891,9 @@ int ScalpelTalk::talkLine(int lineNum, int stateNum, byte color, int lineY, bool
 }
 
 void ScalpelTalk::showTalk() {
-	People &people = *_vm->_people;
 	ScalpelScreen &screen = *(ScalpelScreen *)_vm->_screen;
 	ScalpelUserInterface &ui = *(ScalpelUserInterface *)_vm->_ui;
 	byte color = ui._endKeyActive ? COMMAND_FOREGROUND : COMMAND_NULL;
-
-	clearSequences();
-	pushSequence(_talkTo);
-	people.setListenSequence(_talkTo);
-
-	ui._selector = ui._oldSelector = -1;
 
 	if (!ui._windowOpen) {
 		// Draw the talk interface on the back buffer

--- a/engines/sherlock/talk.cpp
+++ b/engines/sherlock/talk.cpp
@@ -407,7 +407,11 @@ void Talk::talkTo(const Common::String filename) {
 				// If the new conversion is a reply first, then we don't need
 				// to display any choices, since the reply needs to be shown
 				if (!newStatement._statement.hasPrefix("*") && !newStatement._statement.hasPrefix("^")) {
+					clearSequences();
+					pushSequence(_talkTo);
+					people.setListenSequence(_talkTo, 129);
 					_talkIndex = select;
+					ui._selector = ui._oldSelector = -1;
 					showTalk();
 
 					// Break out of loop now that we're waiting for player input
@@ -549,6 +553,7 @@ void Talk::initTalk(int objNum) {
 				}
 			} else {
 				_talkIndex = select;
+				ui._selector = ui._oldSelector = -1;
 				showTalk();
 
 				// Break out of loop now that we're waiting for player input

--- a/engines/sherlock/tattoo/tattoo_talk.cpp
+++ b/engines/sherlock/tattoo/tattoo_talk.cpp
@@ -232,10 +232,7 @@ void TattooTalk::nothingToSay() {
 }
 
 void TattooTalk::showTalk() {
-	TattooPeople &people = *(TattooPeople *)_vm->_people;
 	TattooUserInterface &ui = *(TattooUserInterface *)_vm->_ui;
-
-	people.setListenSequence(_talkTo, 129);
 
 	_talkWidget.load();
 	_talkWidget.summonWindow();


### PR DESCRIPTION
This is an attempt at fixing long-standing bug https://bugs.scummvm.org/ticket/10931

If I understand it correctly, when you initiate a conversation (at least one where you get the first word), the engine pushes the current animation for the character on a stack. It may then push further animations while displaying the character portrait, but once the conversation is done it should be able to pull the original animation back from the stack.

But because of some unintentional code duplication, what it pulled at the end was the animation (or lack thereof) used when talking to you. You could see this pretty clearly at the scene of the murderer: Talk to the police, and he'll stop swinging his baton. He won't resume when the conversation is over, until you leave and re-enter the room.

Most of the time, this was just a cosmetic bug but when you get to the billiard players it actually caused a bug because they switch between you being able to talk to them and not.

Of this batch of Sherlock pull requests, this is the one I'm most worried that I may have gotten subtly wrong in some case. But I have played through the game from the billiard players to the end, so it looks promising.