### PR TITLE
SHERLOCK: Calculate font height/width more accurately

### DIFF
--- a/engines/sherlock/fonts.cpp
+++ b/engines/sherlock/fonts.cpp
@@ -131,8 +131,8 @@ void Fonts::setFont(int fontNum) {
 	// Iterate through the frames to find the widest and tallest font characters
 	_fontHeight = _widestChar = 0;
 	for (uint idx = 0; idx < MIN<uint>(_charCount, 128 - 32); ++idx) {
-		_fontHeight = MAX((int16)_fontHeight, (*_font)[idx]._frame.h);
-		_widestChar = MAX((int16)_widestChar, (*_font)[idx]._frame.w);
+		_fontHeight = MAX(_fontHeight, (*_font)[idx]._frame.h + (*_font)[idx]._offset.y);
+		_widestChar = MAX(_widestChar, (*_font)[idx]._frame.w + (*_font)[idx]._offset.x);
 	}
 
 	// Initialize the Y offset table for the extended character set


### PR DESCRIPTION
When calculating the max height and width of characters in a font, we only took the size of the images into consideration. Not how much they were offset when drawing them. (And even with this patch, we don't take _yOffsets[] into consideration. I don't know if we have to?)

This is closer to what charWidth() and charHeight() already does, but those add 1 for reasons unknown to me. (Also, if you want to use them instead, not that they will call translateChar().)

This fixes a tiny glitch that I spotted when talking to a character who had a lot of things you could ask about. Scrolling down, the "Up" button would be enabled. When disabling it, the bottommost pixel of the "p" was still white.

I'm a bit concerned there may be things that depend on the font height that _could_ be broken by this. Of course, it's also possible that they could be fixed by it...