### PR TITLE
SHERLOCK: Fix Scalpel user interface being left in wrong mode

### DIFF
--- a/engines/sherlock/talk.cpp
+++ b/engines/sherlock/talk.cpp
@@ -342,7 +342,8 @@ void Talk::talkTo(const Common::String filename) {
 
 		// Handle replies until there's no further linked file,
 		// or the link file isn't a reply first cnversation
-		while (!_vm->shouldQuit()) {
+		bool done = false;
+		while (!done && !_vm->shouldQuit()) {
 			clearSequences();
 			_scriptSelect = select;
 			_speaker = _talkTo;
@@ -412,7 +413,7 @@ void Talk::talkTo(const Common::String filename) {
 
 					// Break out of loop now that we're waiting for player input
 					events.setCursor(ARROW);
-					break;
+					done = true;
 				} else {
 					// Add the statement into the journal and talk history
 					if (_talkTo != -1 && !_talkHistory[_converseNum][select])
@@ -438,7 +439,7 @@ void Talk::talkTo(const Common::String filename) {
 					ui.banishWindow();
 				}
 
-				break;
+				done = true;
 			}
 		}
 	}


### PR DESCRIPTION
I didn't encounter this bug until I met Lord Brumwell. Unlike most characters, he actually initiates conversation with you. This puts the engine in "talk mode". But if you had, say, the inventory window open at the time, it will first close that window. That puts the game in "standard mode".

Because the code then broke out of a loop instead of allowing it to run all of its final iteration, the game was never put back in "talk mode". It printed the conversation topic, but you couldn't click on it. And then the user interface got all messed up.

This is the fix that got the least testing since this is pretty close to the end of the game. But it seems pretty straightforward to me.