### PR TITLE
SCI: Patch to fix duplication of text with subtitles

### DIFF
--- a/engines/sci/engine/state.cpp
+++ b/engines/sci/engine/state.cpp
@@ -373,7 +373,8 @@ Common::String SciEngine::strSplitLanguage(const char *str, uint16 *languageSpli
 		return retval;
 
 	// Add subtitle, unless the subtitle language doesn't match the languages in the string
-	if ((subtitleLanguage == K_LANG_ENGLISH) || (subtitleLanguage == foundLanguage)) {
+	// Confirmed to work for Amiga SQ3 German/English, QFG1 Japanese/English, PQ2 Japanese/English
+	if ((activeLanguage == foundLanguage) || (subtitleLanguage == foundLanguage)) {
 		retval += sep;
 		retval += getSciLanguageString(str, subtitleLanguage);
 	}


### PR DESCRIPTION
On QFG1 for PC-98, the previous code would cause undue duplication of text
when using the following languge configuration :
- Japanese as main language
- Subtitles enabled (setting subtitle language to English)

Output would end up looking like :
```
日本語 (Japanese)
----------
日本語 (Japanese)
English
----------
English
```

On every dialog box, including the input box.

This fix has been tested for :
- Quest for Glory I (PC-98/Japanese)
- Space Quest III (Amiga/German)

(Ctrl+L to configure languages, attempt to type a "look" command)

For QFG1 for PC-98, the behavior therefore becomes identical
to what can be observed when running the game on a PC-98 emulator.

This fix is valid for any game relying on kStrSplit(),
and even though the following game has another mechanism
for handling multiple language strings,
it has also been confirmed to be regression free on the first screen :
- Police Quest II (PC-98/Japanese)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
