### PR TITLE
ANDROID/AUDIO: Convert the output buffer size value given to the Mixer from bytes to frame size

### DIFF
--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -464,7 +464,10 @@ void OSystem_Android::initBackend() {
 
 	gettimeofday(&_startTime, 0);
 
-	_mixer = new Audio::MixerImpl(_audio_sample_rate, _audio_buffer_size);
+	// The division by four happens because the Mixer stores the size in frame units
+	// instead of bytes; this means that, since we have audio in stereo (2 channels)
+	// with a word size of 16 bit (2 bytes), we have to divide the effective size by 4.
+	_mixer = new Audio::MixerImpl(_audio_sample_rate, _audio_buffer_size / 4);
 	_mixer->setReady(true);
 
 	_timer_thread_exit = false;


### PR DESCRIPTION
This fixes a conceptual issue in which, while all the other platforms are handled correctly, Android used the frame size as the effective buffer size, a thing which caused the assertion in `mixer.cpp:mixCallback()` to be triggered on some devices. This was fixed on commit https://github.com/scummvm/scummvm/commit/466c8b8c76df8584f612f488cc5df4a0f9e25d72, but this meant I had effectively forgotten both to do what was done in the commit, and to divide the value passed to the mixer by `wordSize * numChannels`, or in our case, four.

This PR fixes the latter issue so that when the `getOutputBufSize()` function is called from Android it correctly yields the frame size instead of the byte size.