### PR TITLE
(WIP) SCUMM: DiMUSE: Implement music stream filling while loading resources

### DIFF
--- a/engines/scumm/imuse_digi/dimuse_dispatch.cpp
+++ b/engines/scumm/imuse_digi/dimuse_dispatch.cpp
@@ -830,7 +830,7 @@ void IMuseDigital::dispatchProcessDispatches(IMuseDigiTrack *trackPtr, int feedS
 }
 
 void IMuseDigital::dispatchPredictFirstStream() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 
 	for (int i = 0; i < _trackCount; i++) {
 		if (_dispatches[i].trackPtr->soundId && _dispatches[i].streamPtr && _dispatches[i].streamZoneList)

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -42,8 +42,8 @@ void IMuseDigital::timer_handler(void *refCon) {
 	diMUSE->callback();
 }
 
-IMuseDigital::IMuseDigital(ScummEngine_v7 *scumm, Audio::Mixer *mixer)
-	: _vm(scumm), _mixer(mixer) {
+IMuseDigital::IMuseDigital(ScummEngine_v7 *scumm, Audio::Mixer *mixer, Common::Mutex *mutex)
+	: _vm(scumm), _mixer(mixer), _mutex(mutex) {
 	assert(_vm);
 	assert(mixer);
 
@@ -231,7 +231,7 @@ int IMuseDigital::startVoice(const char *fileName, ScummFile *file, uint32 offse
 }
 
 void IMuseDigital::saveLoadEarly(Common::Serializer &s) {
-	Common::StackLock lock(_mutex, "IMuseDigital::saveLoadEarly()");
+	Common::StackLock lock(*_mutex, "IMuseDigital::saveLoadEarly()");
 
 	if (s.isLoading()) {
 		diMUSEStopAllSounds();
@@ -487,14 +487,14 @@ void IMuseDigital::stopSMUSHAudio() {
 }
 
 void IMuseDigital::floodMusicBuffer() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	while (!isMusicStreamIdle()) {
 		diMUSEProcessStreams();
 	}
 }
 
 void IMuseDigital::fillStreamsWhileMusicCritical(int fillTimesAfter) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	if (!isFTSoundEngine()) {
 		while (isMusicCritical()) {
 			diMUSEProcessStreams();

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -315,7 +315,7 @@ void IMuseDigital::callback() {
 void IMuseDigital::diMUSEHeartbeat() {
 	// This is what happens:
 	// - Usual audio stuff like fetching and playing sound (and everything
-	//   within waveapi_callback()) happens at a base 50Hz rate;
+	//   within waveOutCallback()) happens at a base 50Hz rate;
 	// - Triggers and fades handling happens at a (somewhat hacky) 60Hz rate;
 	// - Music gain reduction happens at a 10Hz rate.
 

--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -64,7 +64,7 @@ struct IMuseDigiStreamZone;
 
 class IMuseDigital : public MusicEngine {
 private:
-	Common::Mutex _mutex;
+	Common::Mutex *_mutex;
 	ScummEngine_v7 *_vm;
 	Audio::Mixer *_mixer;
 
@@ -298,7 +298,7 @@ private:
 	byte waveOutGetStreamFlags();
 
 public:
-	IMuseDigital(ScummEngine_v7 *scumm, Audio::Mixer *mixer);
+	IMuseDigital(ScummEngine_v7 *scumm, Audio::Mixer *mixer, Common::Mutex *mutex);
 	~IMuseDigital() override;
 
 	// Wrapper functions used by the main engine

--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -121,6 +121,8 @@ private:
 	void playComiMusic(const char *songName, const imuseComiTable *table, int attribPos, bool sequence);
 	void playComiDemoMusic(const char *songName, const imuseComiTable *table, int attribPos, bool sequence);
 	int getSoundIdByName(const char *soundName);
+	bool isMusicStreamIdle();
+	bool isMusicCritical();
 
 	// Script
 	int scriptParse(int cmd, int a, int b);
@@ -167,7 +169,7 @@ private:
 	int streamerSetLoadIndex(IMuseDigiStream *streamPtr, int offset);
 	int streamerGetFreeBufferAmount(IMuseDigiStream *streamPtr);
 	int streamerSetSoundToStreamFromOffset(IMuseDigiStream *streamPtr, int soundId, int32 offset);
-	int streamerQueryStream(IMuseDigiStream *streamPtr, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
+	void streamerQueryStream(IMuseDigiStream *streamPtr, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
 	int streamerFeedStream(IMuseDigiStream *streamPtr, uint8 *srcBuf, int32 sizeToFeed, int paused);
 	int streamerFetchData(IMuseDigiStream *streamPtr);
 	void streamerSetLoopFlag(IMuseDigiStream *streamPtr, int offset);
@@ -192,7 +194,7 @@ private:
 	int tracksStopSound(int soundId);
 	int tracksStopAllSounds();
 	int tracksGetNextSound(int soundId);
-	void tracksQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
+	int tracksQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
 	int tracksFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused);
 	void tracksClear(IMuseDigiTrack *trackPtr);
 	int tracksSetParam(int soundId, int opcode, int value);
@@ -270,7 +272,7 @@ private:
 	int waveSwitchStream(int oldSoundId, int newSoundId, int fadeLengthMs, int fadeSyncFlag2, int fadeSyncFlag1);
 	int waveSwitchStream(int oldSoundId, int newSoundId, uint8 *crossfadeBuffer, int crossfadeBufferSize, int vocLoopFlag);
 	int waveProcessStreams();
-	void waveQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
+	int waveQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
 	int waveFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused);
 	int waveLipSync(int soundId, int syncId, int msPos, int32 &width, int32 &height);
 
@@ -327,6 +329,9 @@ public:
 	void disableEngine();
 	bool isEngineDisabled();
 	void stopSMUSHAudio();
+	void floodMusicBuffer();
+	void fillStreamsWhileMusicCritical(int fillTimesAfter);
+	bool queryNextSoundFile(int &bufSize, int &criticalSize, int &freeSpace, int &paused);
 
 	bool isFTSoundEngine(); // Used in the handlers to check if we're using the FT version of the engine
 
@@ -359,7 +364,7 @@ public:
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, int fadeDelay, int fadeSyncFlag2, int fadeSyncFlag1);
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, uint8 *crossfadeBuffer, int crossfadeBufferSize, int vocLoopFlag);
 	int diMUSEProcessStreams();
-	void diMUSEQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
+	int diMUSEQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused);
 	int diMUSEFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused);
 	int diMUSELipSync(int soundId, int syncId, int msPos, int32 &width, int32 &height);
 	int diMUSESetMusicGroupVol(int volume);

--- a/engines/scumm/imuse_digi/dimuse_streamer.cpp
+++ b/engines/scumm/imuse_digi/dimuse_streamer.cpp
@@ -337,9 +337,9 @@ int IMuseDigital::streamerFetchData(IMuseDigiStream *streamPtr) {
 
 		_streamerBailFlag = 0;
 
-		Common::StackLock lock(_mutex);
+		Common::StackLock lock(*_mutex);
 		actualAmount = _filesHandler->read(streamPtr->soundId, &streamPtr->buf[streamPtr->loadIndex], requestedAmount, streamPtr->bufId);
-		Common::StackLock unlock(_mutex);
+		Common::StackLock unlock(*_mutex);
 
 		// FT has no bailFlag
 		if (!_isEarlyDiMUSE && _streamerBailFlag)

--- a/engines/scumm/imuse_digi/dimuse_streamer.cpp
+++ b/engines/scumm/imuse_digi/dimuse_streamer.cpp
@@ -227,13 +227,14 @@ int IMuseDigital::streamerSetSoundToStreamFromOffset(IMuseDigiStream *streamPtr,
 	return 0;
 }
 
-int IMuseDigital::streamerQueryStream(IMuseDigiStream *streamPtr, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
-	dispatchPredictFirstStream();
+void IMuseDigital::streamerQueryStream(IMuseDigiStream *streamPtr, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
+	if (!isFTSoundEngine())
+		dispatchPredictFirstStream();
+
 	bufSize = streamPtr->bufFreeSize;
-	criticalSize = streamPtr->criticalSize;
+	criticalSize = (isFTSoundEngine() && streamPtr->paused) ? 0 : streamPtr->criticalSize;
 	freeSpace = streamerGetFreeBufferAmount(streamPtr);
 	paused = streamPtr->paused;
-	return 0;
 }
 
 int IMuseDigital::streamerFeedStream(IMuseDigiStream *streamPtr, uint8 *srcBuf, int32 sizeToFeed, int paused) {

--- a/engines/scumm/imuse_digi/dimuse_tracks.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tracks.cpp
@@ -151,8 +151,6 @@ void IMuseDigital::tracksCallback() {
 		_tracksPauseTimer = 3;
 	}
 
-	Common::StackLock lock(_mutex);
-
 	// If we leave the number of queued streams unbounded, we fill the queue with streams faster than
 	// we can play them: this leads to a very noticeable audio latency and desync with the graphics.
 	if ((int)_internalMixer->_stream->numQueuedStreams() < _maxQueuedStreams) {
@@ -282,22 +280,43 @@ int IMuseDigital::tracksGetNextSound(int soundId) {
 	return foundSoundId;
 }
 
-void IMuseDigital::tracksQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
-	if (!_trackList)
-		debug(5, "IMuseDigital::tracksQueryStream(): WARNING: empty trackList, ignoring call...");
+int IMuseDigital::tracksQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
+	if (!_trackList) {
+		debug(5, "IMuseDigital::tracksQueryStream(): WARNING: empty trackList...");
+		return isFTSoundEngine() ? 0 : -1;
+	}
 
 	IMuseDigiTrack *track = _trackList;
-	do {
-		if (track->soundId) {
-			if (soundId == track->soundId && track->dispatchPtr->streamPtr) {
-				streamerQueryStream(track->dispatchPtr->streamPtr, bufSize, criticalSize, freeSpace, paused);
-				return;
-			}
-		}
-		track = track->next;
-	} while (track);
+	if (isFTSoundEngine()) {
+		IMuseDigiTrack *chosenTrack = nullptr;
 
-	debug(5, "IMuseDigital::tracksQueryStream(): WARNING: couldn't find sound %d in trackList, ignoring call...", soundId);
+		do {
+			if (track->soundId > soundId && (!chosenTrack || track->soundId < chosenTrack->soundId)) {
+				if (track->dispatchPtr->streamPtr)
+					chosenTrack = track;
+			}
+			track = track->next;
+		} while (track);
+
+		if (!chosenTrack)
+			return 0;
+
+		streamerQueryStream(chosenTrack->dispatchPtr->streamPtr, bufSize, criticalSize, freeSpace, paused);
+		return chosenTrack->soundId;
+	} else {
+		do {
+			if (track->soundId) {
+				if (soundId == track->soundId && track->dispatchPtr->streamPtr) {
+					streamerQueryStream(track->dispatchPtr->streamPtr, bufSize, criticalSize, freeSpace, paused);
+					return 0;
+				}
+			}
+			track = track->next;
+		} while (track);
+
+		debug(5, "IMuseDigital::tracksQueryStream(): WARNING: couldn't find sound %d in trackList, ignoring call...", soundId);
+		return -1;
+	}
 }
 
 int IMuseDigital::tracksFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused) {

--- a/engines/scumm/imuse_digi/dimuse_tracks.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tracks.cpp
@@ -72,7 +72,7 @@ void IMuseDigital::tracksResume() {
 }
 
 void IMuseDigital::tracksSaveLoad(Common::Serializer &ser) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	dispatchSaveLoad(ser);
 
 	for (int l = 0; l < _trackCount; l++) {
@@ -223,9 +223,9 @@ int IMuseDigital::tracksStartSound(int soundId, int tryPriority, int group) {
 		return -1;
 	}
 
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	addTrackToList(&_trackList, allocatedTrack);
-	Common::StackLock unlock(_mutex);
+	Common::StackLock unlock(*_mutex);
 
 	return 0;
 }
@@ -250,7 +250,7 @@ int IMuseDigital::tracksStopSound(int soundId) {
 }
 
 int IMuseDigital::tracksStopAllSounds() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	IMuseDigiTrack *nextTrack = _trackList;
 	IMuseDigiTrack *curTrack;
 

--- a/engines/scumm/imuse_digi/dimuse_wave.cpp
+++ b/engines/scumm/imuse_digi/dimuse_wave.cpp
@@ -116,9 +116,9 @@ int IMuseDigital::waveProcessStreams() {
 	return streamerProcessStreams();
 }
 
-void IMuseDigital::waveQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
+int IMuseDigital::waveQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
 	Common::StackLock lock(_mutex);
-	tracksQueryStream(soundId, bufSize, criticalSize, freeSpace, paused);
+	return tracksQueryStream(soundId, bufSize, criticalSize, freeSpace, paused);
 }
 
 int IMuseDigital::waveFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused) {

--- a/engines/scumm/imuse_digi/dimuse_wave.cpp
+++ b/engines/scumm/imuse_digi/dimuse_wave.cpp
@@ -35,39 +35,39 @@ int IMuseDigital::waveTerminate() {
 }
 
 int IMuseDigital::wavePause() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	tracksPause();
 	return 0;
 }
 
 int IMuseDigital::waveResume() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	tracksResume();
 	return 0;
 }
 
 void IMuseDigital::waveSaveLoad(Common::Serializer &ser) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	tracksSaveLoad(ser);
 }
 
 void IMuseDigital::waveUpdateGroupVolumes() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	tracksSetGroupVol();
 }
 
 int IMuseDigital::waveStartSound(int soundId, int priority) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return tracksStartSound(soundId, priority, 0);
 }
 
 int IMuseDigital::waveStopSound(int soundId) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return tracksStopSound(soundId);
 }
 
 int IMuseDigital::waveStopAllSounds() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return tracksStopAllSounds();
 }
 
@@ -76,12 +76,12 @@ int IMuseDigital::waveGetNextSound(int soundId) {
 }
 
 int IMuseDigital::waveSetParam(int soundId, int opcode, int value) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return tracksSetParam(soundId, opcode, value);
 }
 
 int IMuseDigital::waveGetParam(int soundId, int opcode) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return tracksGetParam(soundId, opcode);
 }
 
@@ -97,32 +97,32 @@ int IMuseDigital::waveStartStream(int soundId, int priority, int bufferId) {
 	if (soundId == 0)
 		return -1;
 
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return tracksStartSound(soundId, priority, bufferId);
 }
 
 int IMuseDigital::waveSwitchStream(int oldSoundId, int newSoundId, int fadeLengthMs, int fadeSyncFlag2, int fadeSyncFlag1) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return dispatchSwitchStream(oldSoundId, newSoundId, fadeLengthMs, fadeSyncFlag2, fadeSyncFlag1);
 }
 
 int IMuseDigital::waveSwitchStream(int oldSoundId, int newSoundId, uint8 *crossfadeBuffer, int crossfadeBufferSize, int vocLoopFlag) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return dispatchSwitchStream(oldSoundId, newSoundId, crossfadeBuffer, crossfadeBufferSize, vocLoopFlag);
 }
 
 int IMuseDigital::waveProcessStreams() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return streamerProcessStreams();
 }
 
 int IMuseDigital::waveQueryStream(int soundId, int32 &bufSize, int32 &criticalSize, int32 &freeSpace, int &paused) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return tracksQueryStream(soundId, bufSize, criticalSize, freeSpace, paused);
 }
 
 int IMuseDigital::waveFeedStream(int soundId, uint8 *srcBuf, int32 sizeToFeed, int paused) {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	return tracksFeedStream(soundId, srcBuf, sizeToFeed, paused);
 }
 

--- a/engines/scumm/imuse_digi/dimuse_waveout.cpp
+++ b/engines/scumm/imuse_digi/dimuse_waveout.cpp
@@ -88,7 +88,7 @@ int IMuseDigital::waveOutDeinit() {
 }
 
 void IMuseDigital::waveOutCallback() {
-	Common::StackLock lock(_mutex);
+	Common::StackLock lock(*_mutex);
 	tracksCallback();
 }
 

--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -594,6 +594,8 @@ void ScummEngine::nukeCharset(int i) {
 }
 
 void ScummEngine::ensureResourceLoaded(ResType type, ResId idx) {
+	Common::StackLock lock(_resourceAccessMutex);
+
 	debugC(DEBUG_RESOURCE, "ensureResourceLoaded(%s,%d)", nameOfResType(type), idx);
 
 	if ((type == rtRoom) && idx > 0x7F && _game.version < 7 && _game.heversion <= 71) {
@@ -616,6 +618,17 @@ void ScummEngine::ensureResourceLoaded(ResType type, ResId idx) {
 
 	if (idx <= _res->_types[type].size() && _res->_types[type][idx]._address)
 		return;
+
+#if defined(ENABLE_SCUMM_7_8)
+	if (_imuseDigital) {
+		int bufSize, criticalSize, freeSpace, paused;
+		if (_imuseDigital->isFTSoundEngine() && _imuseDigital->queryNextSoundFile(bufSize, criticalSize, freeSpace, paused)) {
+			_imuseDigital->fillStreamsWhileMusicCritical(5);
+		} else {
+			_imuseDigital->fillStreamsWhileMusicCritical(_game.id == GID_DIG ? 30 : 20);
+		}
+	}
+#endif
 
 	loadResource(type, idx);
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1659,7 +1659,7 @@ void ScummEngine_v7::setupScumm(const Common::String &macResourceFile) {
 		filesAreCompressed |= _sound->isSfxFileCompressed();
 	}
 
-	_musicEngine = _imuseDigital = new IMuseDigital(this, _mixer);
+	_musicEngine = _imuseDigital = new IMuseDigital(this, _mixer, &_resourceAccessMutex);
 
 	if (filesAreCompressed) {
 		GUI::MessageDialog dialog(_(

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2880,11 +2880,7 @@ void ScummEngine_v7::scummLoop_handleSound() {
 	ScummEngine_v6::scummLoop_handleSound();
 	if (_imuseDigital) {
 		_imuseDigital->flushTracks();
-		// In CoMI and the Dig the full (non-demo) version invoke refreshScripts()
-		if (!(_game.id == GID_FT) && !(_game.id == GID_DIG && _game.features & GF_DEMO))
-			_imuseDigital->refreshScripts();
-		else
-			_imuseDigital->diMUSEProcessStreams();
+		_imuseDigital->refreshScripts();
 	}
 
 	if (_smixer) {

--- a/engines/scumm/smush/smush_player.cpp
+++ b/engines/scumm/smush/smush_player.cpp
@@ -1270,6 +1270,15 @@ void SmushPlayer::play(const char *filename, int32 speed, int32 offset, int32 st
 
 	_pauseTime = 0;
 
+	// This piece of code is used to ensure there are
+	// no audio hiccups while loading the SMUSH video;
+	// Each version of the engine does it in its own way.
+	if (_imuseDigital->isFTSoundEngine()) {
+		_imuseDigital->fillStreamsWhileMusicCritical(20);
+	} else {
+		_imuseDigital->floodMusicBuffer();
+	}
+
 	int skipped = 0;
 
 	for (;;) {


### PR DESCRIPTION
Hiya, this PR aims to implement the one thing missing from the original engine (admittedly because I couldn't understand its purpose until recently...).

There's a function in DiMUSE, `diMUSEProcessStreams()`, which is responsible for asking the engine to fill the audio streams (and consequently, the data buffers to be processed) up to a certain point; this function is called at every SCUMM engine loop, ensuring smooth audio playback.

That is, until SCUMM has to load a generic resource (graphics, sound, etc.), a speech file, or even a SMUSH movie: this process could take an indefinite amount of time, depending on the hardware you're playing on, therefore the main engine could not get to the `diMUSEProcessStreams()` call in time, and could leave the audio streams empty for a time which is small enough not to be game-breaking, but big enough to cause some major audio hiccups on some hardware configurations.

I have implemented what the original interpreter does in this case (for all the three variations: FT, DIG & COMI + demos) which is, stupidly enough, blast a lot of `diMUSEProcessStreams()` calls whenever a resource has to be loaded, a speech file has to be played, and a SMUSH movie has to be loaded. And sure enough, it works! (This has been tested on my underpowered-on-purpose Windows and Linux VMs, and on my Android phone which suffered the most from this issue)

There's a catch: doing so, exposed some mutex-related bugs which I'm really glad I found. 
Long story short: having two independent mutex objects (_resourceAccessMutex in `scumm.h`, and _mutex in `dimuse_engine.h`) seemed to work fine being that we previously only had accesses of this kind between the two relevant threads (main and audio callback):

> Do various audio stuff: *lock(_mutex)* ---> Use the resource manager: *lock(_resourceAccessMutex)*

...but: it actually didn't work so fine to begin with, since some very edge case deadlocks could be triggered even without the feature implemented above (I stumbled into them only recently, sorry).

With the new feature in the mix, the situation on both thread becomes the following:

> Do various audio stuff: *lock(_mutex)* ---> Use the resource manager: *lock(_resourceAccessMutex)*---> Process the streams: *lock(_mutex)*

This is highly simplified but I hope you get the idea that having two separate mutexes both being constantly locked and unlocked on two separate threads, was just me asking for trouble.

To solve this I passed the _resourceAccessMutex (which is the most external object, belonging to the SCUMM class) along to the DiMUSE engine, so that every access is regulated under a single mutex object.

I'm currently marking this PR as a WIP: I'd like your opinion on how I solved the mutex problem (because I'm pretty certain I'm doing it in a non-optimal way), and I want to test all three games + demos from scratch to make sure that this new feature works and doesn't crash anything since it will also be featured on Grim Fandango.