### PR TITLE
PSP: Fix build failures with latest PSP toolchain

### DIFF
--- a/backends/fs/psp/psp-stream.cpp
+++ b/backends/fs/psp/psp-stream.cpp
@@ -200,12 +200,13 @@ uint32 PspIoStream::read(void *ptr, uint32 len) {
 		PSP_DEBUG_PRINT_FUNC("suspended\n");
 
 	// check if we need to seek
-	if (_pos != _physicalPos)
+	if (_pos != _physicalPos) {
 		PSP_DEBUG_PRINT("seeking from %x to %x\n", _physicalPos, _pos);
 		if (!physicalSeekFromCur(_pos - _physicalPos)) {
 			_error = true;
 			return 0;
 		}
+	}
 
 	int ret = sceIoRead(_handle, ptr, len);
 

--- a/backends/platform/psp/psp.spec
+++ b/backends/platform/psp/psp.spec
@@ -1,3 +1,3 @@
 %rename lib	old_lib
 *lib:
-%(old_lib) -lz -lstdc++ -lc -lm -lpspprof -lpspvfpu -lpspdebug -lpspgu -lpspge -lpspdisplay -lpspctrl -lpspsdk -lpsputility -lpspuser -lpsppower -lpsphprm  -lpsprtc -lpspaudio -lpspaudiocodec -lpspkernel -lpspnet_inet
+-lz -lstdc++ -lc %:if-exists(libcglue.a%s) -lm -lpspprof -lpspvfpu -lpspdebug -lpspgu -lpspge -lpspdisplay -lpspctrl -lpspsdk -lpsputility -lpspuser -lpsppower -lpsphprm  -lpsprtc -lpspaudio -lpspaudiocodec -lpspkernel -lpspnet_inet %(old_lib)

--- a/backends/plugins/psp/psp-provider.cpp
+++ b/backends/plugins/psp/psp-provider.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#define FORBIDDEN_SYMBOL_EXCEPTION_time_h
 #include "common/scummsys.h"
 
 #if defined(DYNAMIC_MODULES) && defined(__PSP__)


### PR DESCRIPTION
The new PSP toolchain automatically links system libraries which wasn't
the case before. The ordering of libraries builtin in GCC and our spec
file collided. This fixes the order.
PSP SDK includes time.h so it needs an exemption.
A warning was emitted about a if without curly braces which are needed.

The changes compile with both the old and the new toolchain. No test has been done.