### PR TITLE
JANITORIAL: Fix typo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ For a more comprehensive changelog of the latest experimental code, see:
    - Added support for Hades Challenge.
 
  General:
-   - The project licesne has been upgraded to GPLv3+.
+   - The project license has been upgraded to GPLv3+.
    - Now ScummVM requires C++11 for building.
    - Implemented enhanced filtering in the Search box. See "Understanding
      the search box" in the documentation for details.


### PR DESCRIPTION
Just fixes a small typo in the word "license".