### PR TITLE
TWINE: fixes from original source code

### DIFF
--- a/engines/twine/scene/actor.cpp
+++ b/engines/twine/scene/actor.cpp
@@ -263,7 +263,7 @@ void Actor::resetActor(int16 actorIdx) {
 	*actor = ActorStruct();
 
 	actor->_actorIdx = actorIdx;
-	actor->_pos = IVec3(0, -1, 0);
+	actor->_pos = IVec3(0, BRICK_HEIGHT, 0);
 
 	memset(&actor->_staticFlags, 0, sizeof(StaticFlagsStruct));
 	memset(&actor->_dynamicFlags, 0, sizeof(DynamicFlagsStruct));

--- a/engines/twine/scene/actor.h
+++ b/engines/twine/scene/actor.h
@@ -180,7 +180,7 @@ public:
 	int32 _strengthOfHit = 0;
 	int32 _hitBy = -1;
 	BonusParameter _bonusParameter;
-	int32 _angle = 0; // facing angle of actor. Minumum is 0 (SW). Going counter clock wise
+	int32 _angle = 0; // facing angle of actor. Minumum is 0 (SW). Going counter clock wise (BETA in original sources)
 	int32 _speed = 40; // speed of movement
 	ControlMode _controlMode = ControlMode::kNoMove;
 	int32 _delayInMillis = 0;
@@ -194,11 +194,11 @@ public:
 	int32 _armor = 1;
 	int32 _life = kActorMaxLife;
 
-	/** Process actor coordinate */
+	/** Process actor coordinate Nxw, Nyw, Nzw */
 	IVec3 _processActor;
 	/** Previous process actor coordinate */
 	IVec3 _previousActor;
-	IVec3 _collisionPos;
+	IVec3 _oldPos;
 
 	int32 _positionInMoveScript = -1;
 	uint8 *_moveScript = nullptr;
@@ -215,7 +215,7 @@ public:
 	/**
 	 * colliding actor id
 	 */
-	int32 _collision = -1;
+	int32 _collision = -1; // ObjCol
 	/**
 	 * actor id we are standing on
 	 */
@@ -229,7 +229,7 @@ public:
 	int32 _animPosition = 0;
 	AnimType _animType = AnimType::kAnimationTypeLoop;
 	int32 _spriteActorRotation = 0;
-	uint8 _brickSound = 0U;
+	uint8 _brickSound = 0U; // CodeJeu
 
 	BoundingBox _boundingBox;
 	ActorMoveStruct _move;
@@ -284,7 +284,7 @@ public:
 
 	ActorStruct *_processActorPtr = nullptr;
 
-	HeroBehaviourType _heroBehaviour = HeroBehaviourType::kNormal;
+	HeroBehaviourType _heroBehaviour = HeroBehaviourType::kNormal; // Comportement
 	/** Hero auto aggressive mode */
 	bool _autoAggressive = true;
 	/** Previous Hero behaviour */
@@ -354,7 +354,7 @@ public:
 	void processActorCarrier(int32 actorIdx);
 
 	/** Process actor extra bonus */
-	void processActorExtraBonus(int32 actorIdx);
+	void processActorExtraBonus(int32 actorIdx); // GiveExtraBonus
 };
 
 } // namespace TwinE

--- a/engines/twine/scene/animations.cpp
+++ b/engines/twine/scene/animations.cpp
@@ -467,7 +467,7 @@ void Animations::processActorAnimations(int32 actorIdx) {
 	}
 
 	IVec3 &previousActor = actor->_previousActor;
-	previousActor = actor->_collisionPos;
+	previousActor = actor->_oldPos;
 
 	IVec3 &processActor = actor->_processActor;
 	if (actor->_staticFlags.bIsSpriteActor) {
@@ -632,7 +632,7 @@ void Animations::processActorAnimations(int32 actorIdx) {
 	// actor standing on another actor
 	if (actor->_carryBy != -1) {
 		const ActorStruct *standOnActor = _engine->_scene->getActor(actor->_carryBy);
-		processActor -= standOnActor->_collisionPos;
+		processActor -= standOnActor->_oldPos;
 		processActor += standOnActor->pos();
 
 		if (!collision->standingOnActor(actorIdx, actor->_carryBy)) {
@@ -670,22 +670,22 @@ void Animations::processActorAnimations(int32 actorIdx) {
 			collision->stopFalling();
 		}
 
+		collision->setCollisionPos(processActor);
+
 		if (IS_HERO(actorIdx) && !actor->_staticFlags.bComputeLowCollision) {
 			// check hero collisions with bricks
 			const BoundingBox &aabb = actor->_boundingBox;
-			IVec3 collisionPos = actor->_processActor;
-			causeActorDamage |= collision->checkHeroCollisionWithBricks(collisionPos, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.mins.z);
-			causeActorDamage |= collision->checkHeroCollisionWithBricks(collisionPos, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.mins.z);
-			causeActorDamage |= collision->checkHeroCollisionWithBricks(collisionPos, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.maxs.z);
-			causeActorDamage |= collision->checkHeroCollisionWithBricks(collisionPos, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.maxs.z);
+			causeActorDamage |= collision->checkHeroCollisionWithBricks(processActor, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.mins.z);
+			causeActorDamage |= collision->checkHeroCollisionWithBricks(processActor, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.mins.z);
+			causeActorDamage |= collision->checkHeroCollisionWithBricks(processActor, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.maxs.z);
+			causeActorDamage |= collision->checkHeroCollisionWithBricks(processActor, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.maxs.z);
 		} else {
 			// check other actors collisions with bricks
 			const BoundingBox &aabb = actor->_boundingBox;
-			IVec3 collisionPos = actor->_processActor;
-			causeActorDamage |= collision->checkActorCollisionWithBricks(collisionPos, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.mins.z);
-			causeActorDamage |= collision->checkActorCollisionWithBricks(collisionPos, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.mins.z);
-			causeActorDamage |= collision->checkActorCollisionWithBricks(collisionPos, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.maxs.z);
-			causeActorDamage |= collision->checkActorCollisionWithBricks(collisionPos, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.maxs.z);
+			causeActorDamage |= collision->checkActorCollisionWithBricks(processActor, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.mins.z);
+			causeActorDamage |= collision->checkActorCollisionWithBricks(processActor, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.mins.z);
+			causeActorDamage |= collision->checkActorCollisionWithBricks(processActor, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.maxs.z);
+			causeActorDamage |= collision->checkActorCollisionWithBricks(processActor, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.maxs.z);
 		}
 
 		// process wall hit while running

--- a/engines/twine/scene/animations.cpp
+++ b/engines/twine/scene/animations.cpp
@@ -628,13 +628,14 @@ void Animations::processActorAnimations(int32 actorIdx) {
 		}
 	}
 
+	Collision* collision = _engine->_collision;
 	// actor standing on another actor
 	if (actor->_carryBy != -1) {
 		const ActorStruct *standOnActor = _engine->_scene->getActor(actor->_carryBy);
 		processActor -= standOnActor->_collisionPos;
 		processActor += standOnActor->pos();
 
-		if (!_engine->_collision->standingOnActor(actorIdx, actor->_carryBy)) {
+		if (!collision->standingOnActor(actorIdx, actor->_carryBy)) {
 			actor->_carryBy = -1; // no longer standing on other actor
 		}
 	}
@@ -645,9 +646,11 @@ void Animations::processActorAnimations(int32 actorIdx) {
 		processActor.y += _engine->_loopActorStep; // add step to fall
 	}
 
+	bool causeActorDamage = false;
+
 	// actor collisions with bricks
 	if (actor->_staticFlags.bComputeCollisionWithBricks) {
-		_engine->_collision->_collision.y = 0;
+		collision->_collision.y = 0;
 
 		ShapeType brickShape = _engine->_grid->getBrickShape(previousActor);
 
@@ -660,34 +663,33 @@ void Animations::processActorAnimations(int32 actorIdx) {
 		}
 
 		if (actor->_staticFlags.bComputeCollisionWithObj) {
-			_engine->_collision->checkCollisionWithActors(actorIdx);
+			collision->checkCollisionWithActors(actorIdx);
 		}
 
 		if (actor->_carryBy != -1 && actor->_dynamicFlags.bIsFalling) {
-			_engine->_collision->stopFalling();
+			collision->stopFalling();
 		}
-
-		_engine->_collision->_causeActorDamage = 0;
-
-		const IVec3 processActorSave = processActor;
 
 		if (IS_HERO(actorIdx) && !actor->_staticFlags.bComputeLowCollision) {
 			// check hero collisions with bricks
-			_engine->_collision->checkHeroCollisionWithBricks(actor, actor->_boundingBox.mins.x, actor->_boundingBox.mins.y, actor->_boundingBox.mins.z, 1);
-			_engine->_collision->checkHeroCollisionWithBricks(actor, actor->_boundingBox.maxs.x, actor->_boundingBox.mins.y, actor->_boundingBox.mins.z, 2);
-			_engine->_collision->checkHeroCollisionWithBricks(actor, actor->_boundingBox.maxs.x, actor->_boundingBox.mins.y, actor->_boundingBox.maxs.z, 4);
-			_engine->_collision->checkHeroCollisionWithBricks(actor, actor->_boundingBox.mins.x, actor->_boundingBox.mins.y, actor->_boundingBox.maxs.z, 8);
+			const BoundingBox &aabb = actor->_boundingBox;
+			IVec3 collisionPos = actor->_processActor;
+			causeActorDamage |= collision->checkHeroCollisionWithBricks(collisionPos, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.mins.z);
+			causeActorDamage |= collision->checkHeroCollisionWithBricks(collisionPos, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.mins.z);
+			causeActorDamage |= collision->checkHeroCollisionWithBricks(collisionPos, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.maxs.z);
+			causeActorDamage |= collision->checkHeroCollisionWithBricks(collisionPos, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.maxs.z);
 		} else {
 			// check other actors collisions with bricks
-			_engine->_collision->checkActorCollisionWithBricks(actor, actor->_boundingBox.mins.x, actor->_boundingBox.mins.y, actor->_boundingBox.mins.z, 1);
-			_engine->_collision->checkActorCollisionWithBricks(actor, actor->_boundingBox.maxs.x, actor->_boundingBox.mins.y, actor->_boundingBox.mins.z, 2);
-			_engine->_collision->checkActorCollisionWithBricks(actor, actor->_boundingBox.maxs.x, actor->_boundingBox.mins.y, actor->_boundingBox.maxs.z, 4);
-			_engine->_collision->checkActorCollisionWithBricks(actor, actor->_boundingBox.mins.x, actor->_boundingBox.mins.y, actor->_boundingBox.maxs.z, 8);
+			const BoundingBox &aabb = actor->_boundingBox;
+			IVec3 collisionPos = actor->_processActor;
+			causeActorDamage |= collision->checkActorCollisionWithBricks(collisionPos, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.mins.z);
+			causeActorDamage |= collision->checkActorCollisionWithBricks(collisionPos, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.mins.z);
+			causeActorDamage |= collision->checkActorCollisionWithBricks(collisionPos, actor->_previousActor, aabb.maxs.x, aabb.mins.y, aabb.maxs.z);
+			causeActorDamage |= collision->checkActorCollisionWithBricks(collisionPos, actor->_previousActor, aabb.mins.x, aabb.mins.y, aabb.maxs.z);
 		}
-		processActor = processActorSave;
 
 		// process wall hit while running
-		if (_engine->_collision->_causeActorDamage && !actor->_dynamicFlags.bIsFalling && IS_HERO(_currentlyProcessedActorIdx) && _engine->_actor->_heroBehaviour == HeroBehaviourType::kAthletic && actor->_anim == AnimationTypes::kForward) {
+		if (causeActorDamage && !actor->_dynamicFlags.bIsFalling && IS_HERO(_currentlyProcessedActorIdx) && _engine->_actor->_heroBehaviour == HeroBehaviourType::kAthletic && actor->_anim == AnimationTypes::kForward) {
 			IVec3 destPos = _engine->_movements->rotateActor(actor->_boundingBox.mins.x, actor->_boundingBox.mins.z, actor->_angle + ANGLE_360 + ANGLE_135);
 
 			destPos.x += processActor.x;
@@ -713,8 +715,8 @@ void Animations::processActorAnimations(int32 actorIdx) {
 		if (brickShape != ShapeType::kNone) {
 			if (brickShape == ShapeType::kSolid) {
 				if (actor->_dynamicFlags.bIsFalling) {
-					_engine->_collision->stopFalling();
-					processActor.y = (_engine->_collision->_collision.y * BRICK_HEIGHT) + BRICK_HEIGHT;
+					collision->stopFalling();
+					processActor.y = (collision->_collision.y * BRICK_HEIGHT) + BRICK_HEIGHT;
 				} else {
 					if (IS_HERO(actorIdx) && _engine->_actor->_heroBehaviour == HeroBehaviourType::kAthletic && actor->_anim == AnimationTypes::kForward && _engine->_cfgfile.WallCollision) { // avoid wall hit damage
 						_engine->_extra->addExtraSpecial(actor->_pos.x, actor->_pos.y + 1000, actor->_pos.z, ExtraSpecialType::kHitStars);
@@ -736,10 +738,10 @@ void Animations::processActorAnimations(int32 actorIdx) {
 				}
 			} else {
 				if (actor->_dynamicFlags.bIsFalling) {
-					_engine->_collision->stopFalling();
+					collision->stopFalling();
 				}
 
-				_engine->_collision->reajustActorPosition(processActor, brickShape);
+				collision->reajustActorPosition(processActor, brickShape);
 			}
 
 			actor->_dynamicFlags.bIsFalling = 0;
@@ -749,10 +751,10 @@ void Animations::processActorAnimations(int32 actorIdx) {
 
 				if (brickShape != ShapeType::kNone) {
 					if (actor->_dynamicFlags.bIsFalling) {
-						_engine->_collision->stopFalling();
+						collision->stopFalling();
 					}
 
-					_engine->_collision->reajustActorPosition(processActor, brickShape);
+					collision->reajustActorPosition(processActor, brickShape);
 				} else {
 					if (!actor->_dynamicFlags.bIsRotationByAnim) {
 						actor->_dynamicFlags.bIsFalling = 1;
@@ -781,16 +783,16 @@ void Animations::processActorAnimations(int32 actorIdx) {
 		}
 
 		// if under the map, than die
-		if (_engine->_collision->_collision.y == -1) {
+		if (collision->_collision.y == -1) {
 			actor->setLife(0);
 		}
 	} else {
 		if (actor->_staticFlags.bComputeCollisionWithObj) {
-			_engine->_collision->checkCollisionWithActors(actorIdx);
+			collision->checkCollisionWithActors(actorIdx);
 		}
 	}
 
-	if (_engine->_collision->_causeActorDamage) {
+	if (causeActorDamage) {
 		actor->setBrickCausesDamage();
 	}
 

--- a/engines/twine/scene/animations.h
+++ b/engines/twine/scene/animations.h
@@ -118,7 +118,7 @@ public:
 	 * Process main loop actor animations
 	 * @param actorIdx Actor index
 	 */
-	void processActorAnimations(int32 actorIdx);
+	void processActorAnimations(int32 actorIdx); // DoAnim
 };
 
 } // namespace TwinE

--- a/engines/twine/scene/collision.cpp
+++ b/engines/twine/scene/collision.cpp
@@ -294,70 +294,70 @@ int32 Collision::checkCollisionWithActors(int32 actorIdx) {
 }
 
 // DoCornerReajustTwinkel
-void Collision::checkHeroCollisionWithBricks(ActorStruct *actor, int32 x, int32 y, int32 z, int32 damageMask) {
-	IVec3 &processActor = actor->_processActor;
-	IVec3 &previousActor = actor->_previousActor;
-	ShapeType brickShape = _engine->_grid->getBrickShape(processActor);
+bool Collision::checkHeroCollisionWithBricks(IVec3 &pos, const IVec3 &previousPos, int32 x, int32 y, int32 z) {
+	ShapeType brickShape = _engine->_grid->getBrickShape(pos);
 
-	processActor.x += x;
-	processActor.y += y;
-	processActor.z += z;
+	pos.x += x;
+	pos.y += y;
+	pos.z += z;
 
-	if (processActor.x >= 0 && processActor.z >= 0 && processActor.x <= SCENE_SIZE_MAX && processActor.z <= SCENE_SIZE_MAX) {
+	bool causeActorDamage = false;
+	if (pos.x >= 0 && pos.z >= 0 && pos.x <= SCENE_SIZE_MAX && pos.z <= SCENE_SIZE_MAX) {
 		const BoundingBox &bbox = _engine->_actor->_processActorPtr->_boundingBox;
-		reajustActorPosition(processActor, brickShape);
-		brickShape = _engine->_grid->getBrickShapeFull(processActor, bbox.maxs.y);
+		reajustActorPosition(pos, brickShape);
+		brickShape = _engine->_grid->getBrickShapeFull(pos, bbox.maxs.y);
 
 		if (brickShape == ShapeType::kSolid) {
-			_causeActorDamage |= damageMask;
-			brickShape = _engine->_grid->getBrickShapeFull(processActor.x, processActor.y, previousActor.z + z, bbox.maxs.y);
+			causeActorDamage = true;
+			brickShape = _engine->_grid->getBrickShapeFull(pos.x, pos.y, previousPos.z + z, bbox.maxs.y);
 
 			if (brickShape == ShapeType::kSolid) {
-				brickShape = _engine->_grid->getBrickShapeFull(x + previousActor.x, processActor.y, processActor.z, bbox.maxs.y);
+				brickShape = _engine->_grid->getBrickShapeFull(x + previousPos.x, pos.y, pos.z, bbox.maxs.y);
 
 				if (brickShape != ShapeType::kSolid) {
-					_processCollision.x = previousActor.x;
+					_processCollision.x = previousPos.x;
 				}
 			} else {
-				_processCollision.z = previousActor.z;
+				_processCollision.z = previousPos.z;
 			}
 		}
 	}
 
-	processActor = _processCollision;
+	pos = _processCollision;
+	return causeActorDamage;
 }
 
 // DoCornerReajust
-void Collision::checkActorCollisionWithBricks(ActorStruct *actor, int32 x, int32 y, int32 z, int32 damageMask) {
-	IVec3 &processActor = actor->_processActor;
-	IVec3 &previousActor = actor->_previousActor;
-	ShapeType brickShape = _engine->_grid->getBrickShape(processActor);
+bool Collision::checkActorCollisionWithBricks(IVec3 &pos, const IVec3 &previousPos, int32 x, int32 y, int32 z) {
+	ShapeType brickShape = _engine->_grid->getBrickShape(pos);
 
-	processActor.x += x;
-	processActor.y += y;
-	processActor.z += z;
+	pos.x += x;
+	pos.y += y;
+	pos.z += z;
 
-	if (processActor.x >= 0 && processActor.z >= 0 && processActor.x <= SCENE_SIZE_MAX && processActor.z <= SCENE_SIZE_MAX) {
-		reajustActorPosition(processActor, brickShape);
-		brickShape = _engine->_grid->getBrickShape(processActor);
+	bool causeActorDamage = false;
+	if (pos.x >= 0 && pos.z >= 0 && pos.x <= SCENE_SIZE_MAX && pos.z <= SCENE_SIZE_MAX) {
+		reajustActorPosition(pos, brickShape);
+		brickShape = _engine->_grid->getBrickShape(pos);
 
 		if (brickShape == ShapeType::kSolid) {
-			_causeActorDamage |= damageMask;
-			brickShape = _engine->_grid->getBrickShape(processActor.x, processActor.y, previousActor.z + z);
+			causeActorDamage = true;
+			brickShape = _engine->_grid->getBrickShape(pos.x, pos.y, previousPos.z + z);
 
 			if (brickShape == ShapeType::kSolid) {
-				brickShape = _engine->_grid->getBrickShape(x + previousActor.x, processActor.y, processActor.z);
+				brickShape = _engine->_grid->getBrickShape(x + previousPos.x, pos.y, pos.z);
 
 				if (brickShape != ShapeType::kSolid) {
-					_processCollision.x = previousActor.x;
+					_processCollision.x = previousPos.x;
 				}
 			} else {
-				_processCollision.z = previousActor.z;
+				_processCollision.z = previousPos.z;
 			}
 		}
 	}
 
-	processActor = _processCollision;
+	pos = _processCollision;
+	return causeActorDamage != 0;
 }
 
 void Collision::stopFalling() { // ReceptionObj()

--- a/engines/twine/scene/collision.h
+++ b/engines/twine/scene/collision.h
@@ -44,9 +44,6 @@ public:
 	/** Actor collision coordinate */
 	IVec3 _collision;
 
-	/** Cause damage in current processed actor */
-	int32 _causeActorDamage = 0; //fieldCauseDamage
-
 	/**
 	 * Check if actor 1 is standing in actor 2
 	 * @param actorIdx1 Actor 1 index
@@ -73,18 +70,16 @@ public:
 	 * @param x Hero X coordinate
 	 * @param y Hero Y coordinate
 	 * @param z Hero Z coordinate
-	 * @param damageMask Cause damage mask
 	 */
-	void checkHeroCollisionWithBricks(ActorStruct *actor, int32 x, int32 y, int32 z, int32 damageMask);
+	bool checkHeroCollisionWithBricks(IVec3 &processActor, const IVec3 &previousActor, int32 x, int32 y, int32 z);
 
 	/**
 	 * Check other actor collision with bricks
 	 * @param x Actor X coordinate
 	 * @param y Actor Y coordinate
 	 * @param z Actor Z coordinate
-	 * @param damageMask Cause damage mask
 	 */
-	void checkActorCollisionWithBricks(ActorStruct *actor, int32 x, int32 y, int32 z, int32 damageMask);
+	bool checkActorCollisionWithBricks(IVec3 &processActor, const IVec3 &previousActor, int32 x, int32 y, int32 z);
 
 	/** Make actor to stop falling */
 	void stopFalling();

--- a/engines/twine/scene/collision.h
+++ b/engines/twine/scene/collision.h
@@ -38,7 +38,7 @@ private:
 	void handlePushing(const IVec3 &minsTest, const IVec3 &maxsTest, ActorStruct *actor, ActorStruct *actorTest);
 
 	/** Actor collision coordinate */
-	IVec3 _processCollision;
+	IVec3 _processCollision; // SaveNxw, SaveNyw, SaveNzw
 public:
 	Collision(TwinEEngine *engine);
 	/** Actor collision coordinate */
@@ -57,7 +57,7 @@ public:
 	 * Reajust actor position in scene according with brick shape bellow actor
 	 * @param brickShape Shape of brick bellow the actor
 	 */
-	void reajustActorPosition(IVec3 &processActor, ShapeType brickShape) const;
+	void reajustActorPosition(IVec3 &processActor, ShapeType brickShape) const; // ReajustPos
 
 	/**
 	 * Check collision with actors
@@ -65,13 +65,14 @@ public:
 	 */
 	int32 checkCollisionWithActors(int32 actorIdx);
 
+	void setCollisionPos(const IVec3 &pos);
 	/**
 	 * Check Hero collision with bricks
 	 * @param x Hero X coordinate
 	 * @param y Hero Y coordinate
 	 * @param z Hero Z coordinate
 	 */
-	bool checkHeroCollisionWithBricks(IVec3 &processActor, const IVec3 &previousActor, int32 x, int32 y, int32 z);
+	bool checkHeroCollisionWithBricks(IVec3 &processActor, const IVec3 &previousActor, int32 x, int32 y, int32 z); // DoCornerReajustTwinkel
 
 	/**
 	 * Check other actor collision with bricks
@@ -79,7 +80,7 @@ public:
 	 * @param y Actor Y coordinate
 	 * @param z Actor Z coordinate
 	 */
-	bool checkActorCollisionWithBricks(IVec3 &processActor, const IVec3 &previousActor, int32 x, int32 y, int32 z);
+	bool checkActorCollisionWithBricks(IVec3 &processActor, const IVec3 &previousActor, int32 x, int32 y, int32 z); // DoCornerReajust
 
 	/** Make actor to stop falling */
 	void stopFalling();

--- a/engines/twine/scene/grid.h
+++ b/engines/twine/scene/grid.h
@@ -286,13 +286,14 @@ public:
 	/** Redraw grid background */
 	void redrawGrid();
 
-	ShapeType getBrickShape(int32 x, int32 y, int32 z);
+	ShapeType getBrickShape(int32 x, int32 y, int32 z); // WorldColBrick
 
+	// FullWorldColBrick
 	ShapeType getBrickShapeFull(int32 x, int32 y, int32 z, int32 y2);
 
-	uint8 getBrickSoundType(int32 x, int32 y, int32 z);
+	uint8 getBrickSoundType(int32 x, int32 y, int32 z); // WorldCodeBrick
 
-	inline ShapeType getBrickShape(const IVec3 &pos) {
+	inline ShapeType getBrickShape(const IVec3 &pos) { // WorldColBrick
 		return getBrickShape(pos.x, pos.y, pos.z);
 	}
 

--- a/engines/twine/scene/movements.h
+++ b/engines/twine/scene/movements.h
@@ -189,7 +189,7 @@ public:
 	 */
 	void moveActor(int32 angleFrom, int32 angleTo, int32 speed, ActorMoveStruct *movePtr) const;
 
-	void processActorMovements(int32 actorIdx);
+	void processActorMovements(int32 actorIdx); // DoTrack
 };
 
 inline bool Movements::shouldTriggerZoneAction() const {

--- a/engines/twine/scene/scene.cpp
+++ b/engines/twine/scene/scene.cpp
@@ -201,7 +201,7 @@ bool Scene::loadSceneLBA2() {
 		act->_pos.x = (int16)stream.readUint16LE();
 		act->_pos.y = (int16)stream.readUint16LE();
 		act->_pos.z = (int16)stream.readUint16LE();
-		act->_collisionPos = act->pos();
+		act->_oldPos = act->pos();
 		act->_strengthOfHit = stream.readByte();
 		setBonusParameterFlags(act, stream.readUint16LE());
 		act->_angle = (int16)stream.readUint16LE();
@@ -333,7 +333,7 @@ bool Scene::loadSceneLBA1() {
 		act->_pos.x = (int16)stream.readUint16LE();
 		act->_pos.y = (int16)stream.readUint16LE();
 		act->_pos.z = (int16)stream.readUint16LE();
-		act->_collisionPos = act->pos();
+		act->_oldPos = act->pos();
 		act->_strengthOfHit = stream.readByte();
 		setBonusParameterFlags(act, stream.readUint16LE());
 		act->_bonusParameter.givenNothing = 0;
@@ -396,11 +396,11 @@ bool Scene::loadSceneLBA1() {
 	if (_enableEnhancements) {
 		switch (_currentSceneIdx) {
 		case LBA1SceneId::Hamalayi_Mountains_landing_place:
-			_sceneActors[21]._pos.x = _sceneActors[21]._collisionPos.x = 6656 + 256;
-			_sceneActors[21]._pos.z = _sceneActors[21]._collisionPos.z = 768;
+			_sceneActors[21]._pos.x = _sceneActors[21]._oldPos.x = 6656 + 256;
+			_sceneActors[21]._pos.z = _sceneActors[21]._oldPos.z = 768;
 			break;
 		case LBA1SceneId::Principal_Island_outside_the_fortress:
-			_sceneActors[29]._pos.z = _sceneActors[29]._collisionPos.z = 1795;
+			_sceneActors[29]._pos.z = _sceneActors[29]._oldPos.z = 1795;
 #if 0
 			_sceneZones[15].mins.x = 1104;
 			_sceneZones[15].mins.z = 8448;

--- a/engines/twine/scene/scene.h
+++ b/engines/twine/scene/scene.h
@@ -174,7 +174,7 @@ public:
 	ScenePositionType _heroPositionType = ScenePositionType::kNoPosition; // twinsenPositionModeInNewCube
 
 	// ACTORS
-	int32 _sceneNumActors = 0;
+	int32 _sceneNumActors = 0; // NbObjets
 	ActorStruct *_sceneHero = nullptr;
 
 	/** Meca penguin actor index */
@@ -221,7 +221,7 @@ public:
 	 * Process actor zones
 	 * @param actorIdx Process actor index
 	 */
-	void processActorZones(int32 actorIdx);
+	void processActorZones(int32 actorIdx); // CheckZoneSce
 };
 
 inline bool Scene::isGameRunning() const {

--- a/engines/twine/script/script_life_v1.h
+++ b/engines/twine/script/script_life_v1.h
@@ -42,7 +42,7 @@ public:
 	 * Process actor life script
 	 * @param actorIdx Current processed actor index
 	 */
-	void processLifeScript(int32 actorIdx);
+	void processLifeScript(int32 actorIdx); // DoLife
 };
 
 } // namespace TwinE

--- a/engines/twine/twine.cpp
+++ b/engines/twine/twine.cpp
@@ -943,7 +943,7 @@ bool TwinEEngine::runGameEngine() { // mainLoopInteration
 
 		_movements->processActorMovements(a);
 
-		actor->_collisionPos = actor->pos();
+		actor->_oldPos = actor->pos();
 
 		if (actor->_positionInMoveScript != -1) {
 			_scriptMove->processMoveScript(a);


### PR DESCRIPTION
This tries to sync our code base with the original code base that was released recently.

A few errors were found, but they still need testing.

- [ ] Tank driving (`change_scene 63`) (savegame at https://bugs.scummvm.org/ticket/13168#no1)
- [x] Sokoban in harbor (push crates) (`change_scene 35`)
- [x] General collision detection for actors
- [ ] Bullet collision