### PR TITLE
SCUMM: DiMUSE: Add a debugger/player and fix oversights

### DIFF
--- a/engines/scumm/debugger.cpp
+++ b/engines/scumm/debugger.cpp
@@ -29,6 +29,7 @@
 #include "scumm/boxes.h"
 #include "scumm/debugger.h"
 #include "scumm/imuse/imuse.h"
+#include "scumm/imuse_digi/dimuse_engine.h"
 #include "scumm/object.h"
 #include "scumm/resource.h"
 #include "scumm/scumm.h"
@@ -93,7 +94,12 @@ ScummDebugger::ScummDebugger(ScummEngine *s)
 	registerCmd("show",      WRAP_METHOD(ScummDebugger, Cmd_Show));
 	registerCmd("hide",      WRAP_METHOD(ScummDebugger, Cmd_Hide));
 
-	registerCmd("imuse",     WRAP_METHOD(ScummDebugger, Cmd_IMuse));
+	if (_vm->_game.version < 7)
+		registerCmd("imuse", WRAP_METHOD(ScummDebugger, Cmd_IMuse));
+#if defined(ENABLE_SCUMM_7_8)
+	else
+		registerCmd("imuse", WRAP_METHOD(ScummDebugger, Cmd_DiMuse));
+#endif
 
 	registerCmd("resetcursors",    WRAP_METHOD(ScummDebugger, Cmd_ResetCursors));
 }
@@ -112,6 +118,15 @@ void ScummDebugger::postEnter() {
 	// Boot params often need debugging switched on to work
 	if (_vm->_bootParam)
 		_vm->_debugMode = true;
+}
+
+void ScummDebugger::onFrame() {
+	Debugger::onFrame();
+#if defined(ENABLE_SCUMM_7_8)
+	if (_vm->_imuseDigital && !_vm->_imuseDigital->isEngineDisabled()) {
+		_vm->_imuseDigital->refreshScripts();
+	}
+#endif
 }
 
 ///////////////////////////////////////////////////
@@ -174,6 +189,176 @@ bool ScummDebugger::Cmd_IMuse(int argc, const char **argv) {
 	debugPrintf("  stop # - Stop a music resource\n");
 	return true;
 }
+
+#if defined(ENABLE_SCUMM_7_8)
+bool ScummDebugger::Cmd_DiMuse(int argc, const char **argv) {
+	if (!_vm->_imuseDigital || _vm->_imuseDigital->isEngineDisabled()) {
+		debugPrintf("No Digital iMUSE engine is active.\n");
+		return true;
+	}
+
+	if (argc > 1) {
+		if (!strcmp(argv[1], "stop")) {
+			if (argc > 2 && (!strcmp(argv[2], "all") || atoi(argv[2]) != 0)) {
+				if (!strcmp(argv[2], "all")) {
+					_vm->_imuseDigital->diMUSEStopAllSounds();
+					debugPrintf("Stopping all sounds.\n");
+				} else {
+					_vm->_imuseDigital->diMUSEStopSound(atoi(argv[2]));
+					debugPrintf("Attempted to stop sound %d.\n", atoi(argv[2]));
+				}
+			} else {
+				debugPrintf("Specify a soundId or \"all\".\n");
+			}
+			return true;
+		} else if (!strcmp(argv[1], "stopSpeech")) {
+			debugPrintf("Attempting to stop the currently playing speech file, if any.\n");
+			_vm->_imuseDigital->diMUSEStopSound(kTalkSoundID);
+			return true;
+		} else if (!strcmp(argv[1], "list") || !strcmp(argv[1], "tracks")) {
+			_vm->_imuseDigital->listTracks();
+			return true;
+		} else if (!strcmp(argv[1], "playSfx")) {
+			if (argc > 2 && atoi(argv[2]) != 0 && atoi(argv[2]) <= _vm->_numSounds) {
+				debugPrintf("Attempting to play SFX %d...\n", atoi(argv[2]));
+				_vm->_imuseDigital->diMUSEStartSound(atoi(argv[2]), 126);
+			} else {
+				debugPrintf("Specify a SFX soundId from 0-%d.\n", _vm->_numSounds - 1);
+			}
+			return true;
+		} else if (!strcmp(argv[1], "playState") || !strcmp(argv[1], "setState")) {
+			if (argc > 2 && atoi(argv[2]) >= 0) {
+				debugPrintf("Attempting to play state %d...\n", atoi(argv[2]));
+				_vm->_imuseDigital->diMUSESetState(atoi(argv[2]));
+			} else {
+				debugPrintf("Specify a valid stateId; available states for this game:\n");
+				_vm->_imuseDigital->listStates();
+			}
+			return true;
+		} else if (!strcmp(argv[1], "playSeq") || !strcmp(argv[1], "setSeq")) {
+			if (argc > 2 && atoi(argv[2]) >= 0) {
+				debugPrintf("Attempting to play sequence %d...\n", atoi(argv[2]));
+				_vm->_imuseDigital->diMUSESetSequence(atoi(argv[2]));
+			} else {
+				debugPrintf("Specify a valid seqId; available sequences for this game:\n");
+				_vm->_imuseDigital->listSeqs();
+			}
+			return true;
+		} else if (!strcmp(argv[1], "playCue") || !strcmp(argv[1], "setCue")) {
+			if (_vm->_game.id != GID_FT || (_vm->_game.features & GF_DEMO)) {
+				debugPrintf("Cues are only available for Full Throttle (full version).\n");
+			} else {
+				if (argc > 2 && atoi(argv[2]) >= 0 && atoi(argv[2]) < 4) {
+					debugPrintf("Attempting to play cue %d...\n", atoi(argv[2]));
+					_vm->_imuseDigital->diMUSESetCuePoint(atoi(argv[2]));
+				} else {
+					debugPrintf("Specify a valid cueId; available sequences for this game:\n");
+					_vm->_imuseDigital->listCues();
+				}
+			}
+			return true;
+		} else if (!strcmp(argv[1], "hook")) {
+			if (argc > 3 && atoi(argv[3]) != 0) {
+				debugPrintf("Attempting to play set hookId %d for sound %d...\n", atoi(argv[2]), atoi(argv[3]));
+				_vm->_imuseDigital->diMUSESetHook(atoi(argv[3]), atoi(argv[2]));
+			} else {
+				debugPrintf("Specify a hookId and a soundId;\nuse \"list\" to get a list of currently playing sounds.\n");
+			}
+			return true;
+		} else if (!strcmp(argv[1], "states")) {
+			debugPrintf("Available states for this game:\n");
+			if (_vm->_imuseDigital->isFTSoundEngine() && _vm->_game.features & GF_DEMO) {
+				debugPrintf("  No states available for demo game with id %s.\n", _vm->_game.gameid);
+			} else {
+				_vm->_imuseDigital->listStates();
+			}
+			return true;
+		} else if (!strcmp(argv[1], "seqs")) {
+			debugPrintf("Available sequences for this game:\n");
+			if (_vm->_game.features & GF_DEMO) {
+				debugPrintf("  No sequences available for demo game with id %s.\n", _vm->_game.gameid);
+			} else {
+				_vm->_imuseDigital->listSeqs();
+			}
+			return true;
+		} else if (!strcmp(argv[1], "cues")) {
+			debugPrintf("Available cues for this game:\n");
+			if (_vm->_game.id == GID_FT && !(_vm->_game.features & GF_DEMO)) {
+				_vm->_imuseDigital->listCues();
+			} else {
+				debugPrintf("  No cues available for game with id %s.\n", _vm->_game.gameid);
+			}
+			return true;
+		} else if (!strcmp(argv[1], "groups") || !strcmp(argv[1], "vols")) {
+			_vm->_imuseDigital->listGroups();
+			return true;
+		} else if (!strcmp(argv[1], "getParam")) {
+			if (argc > 3) {
+				int result = _vm->_imuseDigital->diMUSEGetParam(atoi(argv[2]), strtol(argv[3], NULL, 16));
+				if (result != -5 && result != -4 && result != -1) {
+					debugPrintf("Parameter value for sound %d: %d\n", atoi(argv[2]), result);
+					return true;
+				}
+				debugPrintf("Invalid parameter id or soundId.\n");
+			}
+			debugPrintf("Usage: getParam <soundId> <param>.\nReadable params (use the hex id):\n");
+			debugPrintf("\tP_SND_TRACK_NUM  0x100 \n");
+			debugPrintf("\tP_MARKER         0x300 \n");
+			debugPrintf("\tP_GROUP          0x400 \n");
+			debugPrintf("\tP_PRIORITY       0x500 \n");
+			debugPrintf("\tP_VOLUME         0x600 \n");
+			debugPrintf("\tP_PAN            0x700 \n");
+			debugPrintf("\tP_DETUNE         0x800 \n");
+			debugPrintf("\tP_TRANSPOSE      0x900 \n");
+			debugPrintf("\tP_MAILBOX        0xA00 \n");
+			debugPrintf("\tP_SND_HAS_STREAM 0x1800\n");
+			debugPrintf("\tP_STREAM_BUFID   0x1900\n");
+			debugPrintf("\tP_SND_POS_IN_MS  0x1A00\n");
+			return true;
+		} else if (!strcmp(argv[1], "setParam")) {
+			if (argc > 4) {
+				int result = _vm->_imuseDigital->diMUSESetParam(atoi(argv[2]), strtol(argv[3], NULL, 16), atoi(argv[4]));
+				if (result != -5)
+					return true;
+
+				debugPrintf("Invalid parameter id, value or soundId.\n");
+			}
+			debugPrintf("Usage: setParam <soundId> <param> <val>.\nWritable params (use the hex id):\n");
+			debugPrintf("\tP_GROUP          0x400 \n");
+			debugPrintf("\tP_PRIORITY       0x500 \n");
+			debugPrintf("\tP_VOLUME         0x600 \n");
+			debugPrintf("\tP_PAN            0x700 \n");
+			debugPrintf("\tP_DETUNE         0x800 \n");
+			debugPrintf("\tP_TRANSPOSE      0x900 \n");
+			debugPrintf("\tP_MAILBOX        0xA00 \n");
+			debugPrintf("Please note that editing values for some parameters might lead to unexpected behavior.\n\n");
+			return true;
+		}
+
+		debugPrintf("Unknown command. ");
+	}
+
+	debugPrintf("Available Digital iMUSE commands:\n");
+	debugPrintf("\tstates                           - Display music states available for the current game\n");
+	debugPrintf("\tseqs                             - Display music sequences available for the current game\n");
+	debugPrintf("\tcues                             - Display music cues available for the current sequence (FT only)\n");
+	debugPrintf("\tplaySfx <soundId>                - Play a SFX resource by soundId\n");
+	debugPrintf("\tplayState|setState <stateId>     - Play a music state resource by soundId\n");
+	debugPrintf("\tplaySeq|setSeq <seqId>           - Play a music sequence resource by soundId\n");
+	debugPrintf("\tplayCue|setCue <cueId>           - Play a music cue between the ones available (FT only)\n");
+	debugPrintf("\tstop <soundId>|all               - Stop a SFX, speech or music resource by soundId\n");
+	debugPrintf("\tstopSpeech                       - Stop the current speech file, if any\n");
+	debugPrintf("\thook <soundId> <hookId>          - Set hookId for a sound\n");
+	debugPrintf("\tlist|tracks                      - Display info for every virtual audio track\n");
+	debugPrintf("\tgroups|vols                      - Show volume groups info\n");
+	debugPrintf("\tgetParam <soundId> <param>       - Get parameter info from a sound\n");
+	debugPrintf("\tsetParam <soundId> <param> <val> - Set parameter value for a sound (dangerous!)\n");
+	debugPrintf("\n");
+
+	return true;
+}
+
+#endif
 
 bool ScummDebugger::Cmd_Room(int argc, const char **argv) {
 	if (argc > 1) {

--- a/engines/scumm/debugger.h
+++ b/engines/scumm/debugger.h
@@ -38,6 +38,7 @@ private:
 
 	void preEnter() override;
 	void postEnter() override;
+	void onFrame() override;
 
 	// Commands
 	bool Cmd_Room(int argc, const char **argv);
@@ -65,6 +66,7 @@ private:
 	bool Cmd_Hide(int argc, const char **argv);
 
 	bool Cmd_IMuse(int argc, const char **argv);
+	bool Cmd_DiMuse(int argc, const char **argv);
 
 	bool Cmd_ResetCursors(int argc, const char **argv);
 

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -800,4 +800,97 @@ int IMuseDigital::diMUSESetAttribute(int attrIndex, int attrVal) {
 	return scriptParse(8, attrIndex, attrVal);
 }
 
+// Debugger utility functions
+
+void IMuseDigital::listStates() {
+	_vm->getDebugger()->debugPrintf("+---------------------------------+\n");
+	_vm->getDebugger()->debugPrintf("| stateId |         name          |\n");
+	_vm->getDebugger()->debugPrintf("+---------+-----------------------+\n");
+	if (_vm->_game.id == GID_CMI) {
+		if (_vm->_game.features & GF_DEMO) {
+			for (int i = 0; _comiDemoStateMusicTable[i].soundId != -1; i++) {
+				_vm->getDebugger()->debugPrintf("|  %4d   | %20s  |\n", _comiDemoStateMusicTable[i].soundId, _comiDemoStateMusicTable[i].name);
+			}
+		} else {
+			for (int i = 0; _comiStateMusicTable[i].soundId != -1; i++) {
+				_vm->getDebugger()->debugPrintf("|  %4d   | %20s  |\n", _comiStateMusicTable[i].soundId, _comiStateMusicTable[i].name);
+			}
+		}
+	} else if (_vm->_game.id == GID_DIG) {
+		for (int i = 0; _digStateMusicTable[i].soundId != -1; i++) {
+			_vm->getDebugger()->debugPrintf("|  %4d   | %20s  |\n", _digStateMusicTable[i].soundId, _digStateMusicTable[i].name);
+		}
+	} else if (_vm->_game.id == GID_FT) {
+		for (int i = 0; _ftStateMusicTable[i].name[0]; i++) {
+			_vm->getDebugger()->debugPrintf("|  %4d   | %21s |\n", i, _ftStateMusicTable[i].name);
+		}
+	}
+	_vm->getDebugger()->debugPrintf("+---------+-----------------------+\n\n");
+}
+
+void IMuseDigital::listSeqs() {
+	_vm->getDebugger()->debugPrintf("+--------------------------------+\n");
+	_vm->getDebugger()->debugPrintf("|  seqId  |         name         |\n");
+	_vm->getDebugger()->debugPrintf("+---------+----------------------+\n");
+	if (_vm->_game.id == GID_CMI) {
+		for (int i = 0; _comiSeqMusicTable[i].soundId != -1; i++) {
+			_vm->getDebugger()->debugPrintf("|  %4d   | %20s |\n", _comiSeqMusicTable[i].soundId, _comiSeqMusicTable[i].name);
+		}
+	} else if (_vm->_game.id == GID_DIG) {
+		for (int i = 0; _digSeqMusicTable[i].soundId != -1; i++) {
+			_vm->getDebugger()->debugPrintf("|  %4d   | %20s |\n", _digSeqMusicTable[i].soundId, _digSeqMusicTable[i].name);
+		}
+	} else if (_vm->_game.id == GID_FT) {
+		for (int i = 0; _ftSeqNames[i].name[0]; i++) {
+			_vm->getDebugger()->debugPrintf("|  %4d   | %20s |\n", i, _ftSeqNames[i].name);
+		}
+	}
+	_vm->getDebugger()->debugPrintf("+---------+----------------------+\n\n");
+}
+
+void IMuseDigital::listCues() {
+	int curId = -1;
+	if (_curMusicSeq) {
+		_vm->getDebugger()->debugPrintf("Available cues for current sequence:\n");
+		_vm->getDebugger()->debugPrintf("+---------------------------------------+\n");
+		_vm->getDebugger()->debugPrintf("|   cueName   | transitionType | volume |\n");
+		_vm->getDebugger()->debugPrintf("+-------------+----------------+--------+\n");
+		for (int i = 0; i < 4; i++) {
+			curId = ((_curMusicSeq - 1) * 4) + i;
+			_vm->getDebugger()->debugPrintf("|  %9s  |        %d       |  %3d   |\n",
+				_ftSeqMusicTable[curId].audioName, (int)_ftSeqMusicTable[curId].transitionType, (int)_ftSeqMusicTable[curId].volume);
+		}
+		_vm->getDebugger()->debugPrintf("+-------------+----------------+--------+\n\n");
+	} else {
+		_vm->getDebugger()->debugPrintf("Current sequence is NULL, no cues available.\n\n");
+	}
+}
+
+void IMuseDigital::listTracks() {
+	_vm->getDebugger()->debugPrintf("Virtual audio tracks currently playing:\n");
+	_vm->getDebugger()->debugPrintf("+-------------------------------------------------------------------------+\n");
+	_vm->getDebugger()->debugPrintf("| # | soundId | group | hasStream | vol/effVol/pan  | priority | jumpHook |\n");
+	_vm->getDebugger()->debugPrintf("+---+---------+-------+-----------+-----------------+----------+----------+\n");
+
+	for (int i = 0; i < _trackCount; i++) {
+		IMuseDigiTrack curTrack = _tracks[i];
+		if (curTrack.soundId != 0) {
+			_vm->getDebugger()->debugPrintf("| %1d |  %5d  |   %d   |     %d     |   %3d/%3d/%3d   |   %3d    |   %3d    |\n",
+				i, curTrack.soundId, curTrack.group, diMUSEGetParam(curTrack.soundId, DIMUSE_P_SND_HAS_STREAM),
+				curTrack.vol, curTrack.effVol, curTrack.pan, curTrack.priority, curTrack.jumpHook);
+		} else {
+			_vm->getDebugger()->debugPrintf("| %1d |   ---   |  ---  |    ---    |   ---/---/---   |   ---    |   ---    |\n", i);
+		}
+	}
+	_vm->getDebugger()->debugPrintf("+---+---------+-------+-----------+-----------------+----------+----------+\n\n");
+}
+
+void IMuseDigital::listGroups() {
+	_vm->getDebugger()->debugPrintf("Volume groups:\n");
+	_vm->getDebugger()->debugPrintf("\tSFX:      %3d\n", _groupsHandler->getGroupVol(DIMUSE_GROUP_SFX));
+	_vm->getDebugger()->debugPrintf("\tSPEECH:   %3d\n", _groupsHandler->getGroupVol(DIMUSE_GROUP_SPEECH));
+	_vm->getDebugger()->debugPrintf("\tMUSIC:    %3d\n", _groupsHandler->getGroupVol(DIMUSE_GROUP_MUSIC));
+	_vm->getDebugger()->debugPrintf("\tMUSICEFF: %3d\n\n", _groupsHandler->getGroupVol(DIMUSE_GROUP_MUSICEFF));
+}
+
 } // End of namespace Scumm

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -276,7 +276,9 @@ void IMuseDigital::saveLoadEarly(Common::Serializer &s) {
 }
 
 void IMuseDigital::refreshScripts() {
-	if (!_vm->isSmushActive()) {
+	if (isFTSoundEngine()) {
+		diMUSEProcessStreams();
+	} else if (!_vm->isSmushActive()) {
 		diMUSEProcessStreams();
 		diMUSERefreshScript();
 	}
@@ -780,7 +782,6 @@ int IMuseDigital::diMUSEInitializeScript() {
 }
 
 void IMuseDigital::diMUSERefreshScript() {
-	diMUSEProcessStreams();
 	scriptParse(4, -1, -1);
 }
 

--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -32,6 +32,7 @@
 #include "scumm/music.h"
 #include "scumm/sound.h"
 #include "scumm/file.h"
+#include "scumm/debugger.h"
 
 #include "scumm/imuse_digi/dimuse_defs.h"
 #include "scumm/imuse_digi/dimuse_internalmixer.h"
@@ -389,6 +390,13 @@ public:
 
 	// Script
 	int scriptTriggerCallback(char *marker);
+
+	// Debugger utility functions
+	void listStates();
+	void listSeqs();
+	void listCues();
+	void listTracks();
+	void listGroups();
 };
 
 } // End of namespace Scumm

--- a/engines/scumm/imuse_digi/dimuse_tables.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tables.cpp
@@ -541,6 +541,7 @@ const imuseFtStateTable _ftStateMusicTable[] = {
 	{"saveme",   2,  127,  "statePlaneControls"  },
 	{"",         4,  0,    "stateCliffHanger1"   },
 	{"",         4,  0,    "stateCliffHanger2"   },
+	{"",         0,  0,    ""                    },
 };
 
 const imuseFtNames _ftSeqNames[] = {
@@ -595,7 +596,8 @@ const imuseFtNames _ftSeqNames[] = {
 	{"seqFanBunnies"      },
 	{"seqRipDead"         },
 	{"seqFuneral"         },
-	{"seqCredits"         }
+	{"seqCredits"         },
+	{""                   }
 };
 
 const imuseFtSeqTable _ftSeqMusicTable[] = {

--- a/engines/scumm/imuse_digi/dimuse_tables.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tables.cpp
@@ -575,6 +575,7 @@ const imuseFtNames _ftSeqNames[] = {
 	{"seqNestolusAtRanch" },
 	{"seqRipLimo"         },
 	{"seqGorgeTurn"       },
+	{"seqStealRamp"       },
 	{"seqCavefishTalk"    },
 	{"seqArriveCorville"  },
 	{"seqSingleBunny"     },

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2879,11 +2879,7 @@ void ScummEngine_v7::scummLoop_handleSound() {
 	ScummEngine_v6::scummLoop_handleSound();
 	if (_imuseDigital) {
 		_imuseDigital->flushTracks();
-		// In CoMI and the Dig the full (non-demo) version invoke refreshScripts()
-		if (!(_game.id == GID_FT) && !(_game.id == GID_DIG && _game.features & GF_DEMO))
-			_imuseDigital->refreshScripts();
-		else
-			_imuseDigital->diMUSEProcessStreams();
+		_imuseDigital->refreshScripts();
 	}
 
 	if (_smixer) {


### PR DESCRIPTION
Ahoy!
This PR:

1. Adds a debugger for DiMUSE: you can now play and stop SFX/music, change parameters and check various internal information (that is, for all SCUMM v7-8 games);
2. Adds a missing sequence table entry for FT (it actually paid to implement this debugger); no matter how you can triple check a thing, you will always miss something :-)
3. Moves some DiMUSE specific code from SCUMM to DiMUSE itself, and removes a redundant function call to `diMUSEProcessStreams()` (now it is coherent with the interpreters).

EDIT: I forgot to say, the debugger can't currently tamper with speech files because in order to play those you would need the filename; needless to say, there's too many of those and I can't simply print a list on the console :-) I'll have to think of a clever way to do that