### PR TITLE
SCUMM: Fix CMS not playing a music midi track again

### DIFF
--- a/engines/scumm/players/player_v2cms.cpp
+++ b/engines/scumm/players/player_v2cms.cpp
@@ -98,6 +98,7 @@ void Player_V2CMS::stopAllSounds() {
 	}
 	_next_nr = _current_nr = 0;
 	_next_data = _current_data = nullptr;
+	_loadedMidiSong = 0;
 	_midiData = nullptr;
 	_midiSongBegin = nullptr;
 	_midiDelay = 0;
@@ -121,6 +122,7 @@ void Player_V2CMS::stopSound(int nr) {
 		chainNextSound();
 	}
 	if (_loadedMidiSong == nr) {
+		_loadedMidiSong = 0;
 		_midiData = nullptr;
 		_midiSongBegin = nullptr;
 		_midiDelay = 0;


### PR DESCRIPTION
Possible fix for bug #10696

Reason for not playing the Scumm Bar music again, after entering the kitchen, seemed to be that the _loadedMidiSong var did not clear its value, despite the music being stopped when entering the kitchen. Same issue would happen exiting the bar from the external door and re-entering; Same issue seems to be with church (mentioned in the bug ticket). 
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
