### PR TITLE
CGE/CGE2: Don't pass the engine object to EncryptedStream

### DIFF
--- a/engines/cge/bitmap.cpp
+++ b/engines/cge/bitmap.cpp
@@ -40,7 +40,7 @@ Bitmap::Bitmap(CGEEngine *vm, const char *fname) : _m(nullptr), _v(nullptr), _ma
 	forceExt(pat, fname, ".VBM");
 
 	if (_vm->_resman->exist(pat)) {
-		EncryptedStream file(_vm, pat);
+		EncryptedStream file(_vm->_resman, pat);
 		if (file.err())
 			error("Unable to find VBM [%s]", fname);
 		if (!loadVBM(&file))

--- a/engines/cge/cge_main.cpp
+++ b/engines/cge/cge_main.cpp
@@ -197,7 +197,7 @@ bool CGEEngine::loadGame(int slotNumber, SavegameHeader *header, bool tiny) {
 
 	if (slotNumber == -1) {
 		// Loading the data for the initial game state
-		EncryptedStream file = EncryptedStream(this, kSavegame0Name);
+		EncryptedStream file = EncryptedStream(_resman, kSavegame0Name);
 		int size = file.size();
 		byte *dataBuffer = (byte *)malloc(size);
 		file.read(dataBuffer, size);
@@ -487,7 +487,7 @@ void CGEEngine::tooFar() {
 void CGEEngine::loadHeroXY() {
 	debugC(1, kCGEDebugEngine, "CGEEngine::loadHeroXY()");
 
-	EncryptedStream cf(this, "CGE.HXY");
+	EncryptedStream cf(_resman, "CGE.HXY");
 	uint16 x, y;
 
 	for (uint i = 0; i < ARRAYSIZE(_heroXY); i++) {
@@ -510,7 +510,7 @@ void CGEEngine::loadMapping() {
 	debugC(1, kCGEDebugEngine, "CGEEngine::loadMapping()");
 
 	if (_now <= kSceneMax) {
-		EncryptedStream cf(this, "CGE.TAB");
+		EncryptedStream cf(_resman, "CGE.TAB");
 		if (!cf.err()) {
 			// Move to the data for the given room
 			cf.seek((_now - 1) * kMapArrSize);
@@ -1044,7 +1044,7 @@ void CGEEngine::loadSprite(const char *fname, int ref, int scene, int col = 0, i
 	mergeExt(tmpStr, fname, kSprExt);
 
 	if (_resman->exist(tmpStr)) {      // sprite description file exist
-		EncryptedStream sprf(this, tmpStr);
+		EncryptedStream sprf(_resman, tmpStr);
 		if (sprf.err())
 			error("Bad SPR [%s]", tmpStr);
 
@@ -1151,7 +1151,7 @@ void CGEEngine::loadSprite(const char *fname, int ref, int scene, int col = 0, i
 }
 
 void CGEEngine::loadScript(const char *fname) {
-	EncryptedStream scrf(this, fname);
+	EncryptedStream scrf(_resman, fname);
 
 	if (scrf.err())
 		return;

--- a/engines/cge/fileio.cpp
+++ b/engines/cge/fileio.cpp
@@ -201,15 +201,15 @@ uint16 ResourceManager::catRead(byte *buf, uint16 length) {
 /*-----------------------------------------------------------------------
  * EncryptedStream
  *-----------------------------------------------------------------------*/
-EncryptedStream::EncryptedStream(CGEEngine *vm, const char *name) : _vm(vm) {
+EncryptedStream::EncryptedStream(ResourceManager *resman, const char *name) {
 	debugC(3, kCGEDebugFile, "EncryptedStream::EncryptedStream(%s)", name);
 
 	_error = false;
-	BtKeypack *kp = _vm->_resman->find(name);
+	BtKeypack *kp = resman->find(name);
 	if (scumm_stricmp(kp->_key, name) != 0)
 		_error = true;
 
-	_vm->_resman->seek(kp->_pos);
+	resman->seek(kp->_pos);
 	byte *dataBuffer;
 	int bufSize;
 
@@ -219,7 +219,7 @@ EncryptedStream::EncryptedStream(CGEEngine *vm, const char *name) : _vm(vm) {
 		// Therefore, we remove this ending 0x1A and add extra new lines.
 		// This fixes bug #6060
 		dataBuffer = (byte *)malloc(kp->_size + 2);
-		_vm->_resman->read(dataBuffer, kp->_size);
+		resman->read(dataBuffer, kp->_size);
 		if (dataBuffer[kp->_size - 1] == 0x1A)
 			dataBuffer[kp->_size - 1] = '\n';
 		dataBuffer[kp->_size] = '\n';
@@ -227,7 +227,7 @@ EncryptedStream::EncryptedStream(CGEEngine *vm, const char *name) : _vm(vm) {
 		bufSize = kp->_size + 2;
 	} else {
 		dataBuffer = (byte *)malloc(kp->_size);
-		_vm->_resman->read(dataBuffer, kp->_size);
+		resman->read(dataBuffer, kp->_size);
 		bufSize = kp->_size;
 	}
 

--- a/engines/cge/fileio.h
+++ b/engines/cge/fileio.h
@@ -32,8 +32,6 @@
 
 namespace CGE {
 
-class CGEEngine;
-
 #define kBtSize       1024
 #define kBtKeySize    13
 #define kBtLevel      2
@@ -99,11 +97,10 @@ public:
 
 class EncryptedStream {
 private:
-	CGEEngine *_vm;
 	Common::SeekableReadStream *_readStream;
 	bool _error;
 public:
-	EncryptedStream(CGEEngine *vm, const char *name);
+	EncryptedStream(ResourceManager *resman, const char *name);
 	~EncryptedStream();
 	bool err();
 	bool eos();

--- a/engines/cge/sound.cpp
+++ b/engines/cge/sound.cpp
@@ -152,7 +152,7 @@ void Fx::preload(int ref0) {
 
 	for (int ref = ref0; ref < ref0 + 10; ref++) {
 		sprintf(filename, "FX%05d.WAV", ref);
-		EncryptedStream file(_vm, filename);
+		EncryptedStream file(_vm->_resman, filename);
 		DataCk *wav = loadWave(&file);
 		if (wav) {
 			Handler *p = &_cache[find(0)];
@@ -173,7 +173,7 @@ DataCk *Fx::load(int idx, int ref) {
 	char filename[12];
 	sprintf(filename, "FX%05d.WAV", ref);
 
-	EncryptedStream file(_vm, filename);
+	EncryptedStream file(_vm->_resman, filename);
 	DataCk *wav = loadWave(&file);
 	if (wav) {
 		Handler *p = &_cache[idx];
@@ -254,7 +254,7 @@ void MusicPlayer::loadMidi(int ref) {
 	killMidi();
 
 	// Read in the data for the file
-	EncryptedStream mid(_vm, filename.c_str());
+	EncryptedStream mid(_vm->_resman, filename.c_str());
 	_dataSize = mid.size();
 	_data = (byte *)malloc(_dataSize);
 	mid.read(_data, _dataSize);

--- a/engines/cge/talk.cpp
+++ b/engines/cge/talk.cpp
@@ -51,7 +51,7 @@ Font::~Font() {
 }
 
 void Font::load() {
-	EncryptedStream f(_vm, _path);
+	EncryptedStream f(_vm->_resman, _path);
 	assert(!f.err());
 
 	f.read(_widthArr, kWidSize);

--- a/engines/cge/text.cpp
+++ b/engines/cge/text.cpp
@@ -56,7 +56,7 @@ Text::~Text() {
 }
 
 int16 Text::count() {
-	EncryptedStream tf(_vm, _fileName);
+	EncryptedStream tf(_vm->_resman, _fileName);
 	if (tf.err())
 		return -1;
 
@@ -90,7 +90,7 @@ void Text::clear() {
 }
 
 void Text::load() {
-	EncryptedStream tf(_vm, _fileName);
+	EncryptedStream tf(_vm->_resman, _fileName);
 	assert(!tf.err());
 
 	Common::String line;

--- a/engines/cge/vga13h.cpp
+++ b/engines/cge/vga13h.cpp
@@ -205,7 +205,7 @@ Sprite *Sprite::expand() {
 	CommandHandler::Command *takeList = nullptr;
 	_vm->mergeExt(fname, _file, kSprExt);
 	if (_vm->_resman->exist(fname)) { // sprite description file exist
-		EncryptedStream sprf(_vm, fname);
+		EncryptedStream sprf(_vm->_resman, fname);
 		if (sprf.err())
 			error("Bad SPR [%s]", fname);
 		Common::String line;

--- a/engines/cge2/bitmap.cpp
+++ b/engines/cge2/bitmap.cpp
@@ -56,7 +56,7 @@ Bitmap::Bitmap(CGE2Engine *vm, const char *fname) : _w(0), _h(0), _v(nullptr), _
 	path = setExtension(path, ".VBM");
 
 	if (_vm->_resman->exist(path.c_str())) {
-		EncryptedStream file(_vm, path.c_str());
+		EncryptedStream file(_vm->_resman, path.c_str());
 		if (file.err())
 			error("Unable to find VBM [%s]", fname);
 		if (!loadVBM(&file))

--- a/engines/cge2/cge2_main.cpp
+++ b/engines/cge2/cge2_main.cpp
@@ -172,7 +172,7 @@ Sprite *CGE2Engine::loadSprite(const char *fname, int ref, int scene, V3D &pos) 
 	mergeExt(tmpStr, fname, kSprExt);
 
 	if (_resman->exist(tmpStr)) { // sprite description file exist
-		EncryptedStream sprf(this, tmpStr);
+		EncryptedStream sprf(_resman, tmpStr);
 		if (sprf.err())
 			error("Bad SPR [%s]", tmpStr);
 
@@ -309,7 +309,7 @@ Sprite *CGE2Engine::loadSprite(const char *fname, int ref, int scene, V3D &pos) 
 }
 
 void CGE2Engine::loadScript(const char *fname, bool onlyToolbar) {
-	EncryptedStream scrf(this, fname);
+	EncryptedStream scrf(_resman, fname);
 
 	if (scrf.err())
 		return;
@@ -698,7 +698,7 @@ void CGE2Engine::loadPos() {
 		for (int cav = 0; cav < kSceneMax; cav++)
 			_heroTab[1]->_posTab[cav] = new V2D(this, 180, 10);
 
-		EncryptedStream file(this, "CGE.HXY");
+		EncryptedStream file(_resman, "CGE.HXY");
 
 		for (int cav = 0; cav < kSceneMax; cav++) {
 			_heroTab[0]->_posTab[cav] = new V2D(this);
@@ -720,7 +720,7 @@ void CGE2Engine::loadTab() {
 		*(_eyeTab[i]) = *_eye;
 
 	if  (_resman->exist(kTabName)) {
-		EncryptedStream f(this, kTabName);
+		EncryptedStream f(_resman, kTabName);
 
 		for (int i = 0; i < kSceneMax; i++) {
 			uint32 v = f.readUint32LE();

--- a/engines/cge2/fileio.cpp
+++ b/engines/cge2/fileio.cpp
@@ -196,13 +196,13 @@ uint16 ResourceManager::catRead(byte *buf, uint16 length) {
 /*-----------------------------------------------------------------------
  * EncryptedStream
  *-----------------------------------------------------------------------*/
-EncryptedStream::EncryptedStream(CGE2Engine *vm, const char *name) : _vm(vm), _lineCount(0) {
+EncryptedStream::EncryptedStream(ResourceManager *resman, const char *name) : _lineCount(0) {
 	_error = false;
-	BtKeypack *kp = _vm->_resman->find(name);
+	BtKeypack *kp = resman->find(name);
 	if (scumm_stricmp(kp->_key, name) != 0)
 		_error = true;
 
-	_vm->_resman->seek(kp->_pos);
+	resman->seek(kp->_pos);
 	byte *dataBuffer;
 	int bufSize;
 
@@ -212,7 +212,7 @@ EncryptedStream::EncryptedStream(CGE2Engine *vm, const char *name) : _vm(vm), _l
 		// Therefore, we remove this ending 0x1A and add extra new lines.
 		// This fixes bug #6060
 		dataBuffer = (byte *)malloc(kp->_size + 2);
-		_vm->_resman->read(dataBuffer, kp->_size);
+		resman->read(dataBuffer, kp->_size);
 		if (dataBuffer[kp->_size - 1] == 0x1A)
 			dataBuffer[kp->_size - 1] = '\n';
 		dataBuffer[kp->_size] = '\n';
@@ -220,7 +220,7 @@ EncryptedStream::EncryptedStream(CGE2Engine *vm, const char *name) : _vm(vm), _l
 		bufSize = kp->_size + 2;
 	} else {
 		dataBuffer = (byte *)malloc(kp->_size);
-		_vm->_resman->read(dataBuffer, kp->_size);
+		resman->read(dataBuffer, kp->_size);
 		bufSize = kp->_size;
 	}
 

--- a/engines/cge2/fileio.h
+++ b/engines/cge2/fileio.h
@@ -31,8 +31,6 @@
 
 namespace CGE2 {
 
-class CGE2Engine;
-
 #define kBtSize       2048
 #define kBtKeySize    13
 #define kBtLevel      2
@@ -106,12 +104,11 @@ public:
 
 class EncryptedStream {
 private:
-	CGE2Engine *_vm;
 	Common::SeekableReadStream *_readStream;
 	int _lineCount;
 	bool _error;
 public:
-	EncryptedStream(CGE2Engine *vm, const char *name);
+	EncryptedStream(ResourceManager *resman, const char *name);
 	~EncryptedStream();
 	bool err();
 	bool eos();

--- a/engines/cge2/hero.cpp
+++ b/engines/cge2/hero.cpp
@@ -89,7 +89,7 @@ Sprite *Hero::expand() {
 		curSeq = new Seq[_seqCnt];
 
 	if (_vm->_resman->exist(fname)) { // sprite description file exist
-		EncryptedStream sprf(_vm, fname);
+		EncryptedStream sprf(_vm->_resman, fname);
 		if (sprf.err())
 			error("Bad SPR [%s]", fname);
 

--- a/engines/cge2/map.cpp
+++ b/engines/cge2/map.cpp
@@ -46,7 +46,7 @@ void Map::load(int scene) {
 	if (!_vm->_resman->exist(fileName.c_str()))
 		return;
 
-	EncryptedStream file(_vm, fileName.c_str());
+	EncryptedStream file(_vm->_resman, fileName.c_str());
 
 	Common::String line;
 	for (line = file.readLine(); !file.eos(); line = file.readLine()) {

--- a/engines/cge2/sound.cpp
+++ b/engines/cge2/sound.cpp
@@ -160,7 +160,7 @@ bool Fx::exist(int ref, int sub) {
 
 DataCk *Fx::load(int ref, int sub) {
 	Common::String filename = name(ref, sub);
-	EncryptedStream file(_vm, filename.c_str());
+	EncryptedStream file(_vm->_resman, filename.c_str());
 	clear();
 	return (_current = loadWave(&file));
 }
@@ -222,7 +222,7 @@ void MusicPlayer::loadMidi(int ref) {
 	killMidi();
 
 	// Read in the data for the file
-	EncryptedStream mid(_vm, filename.c_str());
+	EncryptedStream mid(_vm->_resman, filename.c_str());
 	_dataSize = mid.size();
 	_data = (byte *)malloc(_dataSize);
 	mid.read(_data, _dataSize);

--- a/engines/cge2/talk.cpp
+++ b/engines/cge2/talk.cpp
@@ -65,7 +65,7 @@ void Font::load() {
 	if (!_vm->_resman->exist(path))
 		error("Missing Font file! %s", path);
 
-	EncryptedStream fontFile(_vm, path);
+	EncryptedStream fontFile(_vm->_resman, path);
 	assert(!fontFile.err());
 
 	fontFile.read(_widthArr, kWidSize);
@@ -83,7 +83,7 @@ void Font::load() {
 		error("Missing Color file! %s", path);
 
 	// Reading in _colorSet:
-	EncryptedStream colorFile(_vm, path);
+	EncryptedStream colorFile(_vm->_resman, path);
 	assert(!colorFile.err());
 
 	char tmpStr[kLineMax + 1];

--- a/engines/cge2/text.cpp
+++ b/engines/cge2/text.cpp
@@ -56,7 +56,7 @@ Text::~Text() {
 }
 
 int16 Text::count() {
-	EncryptedStream tf(_vm, _fileName);
+	EncryptedStream tf(_vm->_resman, _fileName);
 	if (tf.err())
 		return -1;
 
@@ -90,7 +90,7 @@ void Text::clear() {
 }
 
 void Text::load() {
-	EncryptedStream tf(_vm, _fileName);
+	EncryptedStream tf(_vm->_resman, _fileName);
 	assert(!tf.err());
 
 	Common::String line;

--- a/engines/cge2/vga13h.cpp
+++ b/engines/cge2/vga13h.cpp
@@ -246,7 +246,7 @@ int Sprite::labVal(Action snq, int lab) {
 		_vm->mergeExt(tmpStr, _file, kSprExt);
 
 		if (_vm->_resman->exist(tmpStr)) { // sprite description file exist
-			EncryptedStream sprf(_vm, tmpStr);
+			EncryptedStream sprf(_vm->_resman, tmpStr);
 			if (sprf.err())
 				error("Bad SPR [%s]", tmpStr);
 
@@ -336,7 +336,7 @@ Sprite *Sprite::expand() {
 		curSeq = new Seq[_seqCnt];
 
 	if (_vm->_resman->exist(fname)) { // sprite description file exist
-		EncryptedStream sprf(_vm, fname);
+		EncryptedStream sprf(_vm->_resman, fname);
 		if (sprf.err())
 			error("Bad SPR [%s]", fname);
 


### PR DESCRIPTION
It doesn't need it and when linked with detection and with UBSan enabled build fails because CGEEngine and CGE2Engine aren't linked in