### PR TITLE
GUI: Fix various memory leaks related to grid widget

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -172,8 +172,8 @@ LauncherDialog::LauncherDialog(const Common::String &dialogName)
 		}
 		if (_metadataParser.parse() == false) {
 			warning("Failed to parse XML file '%s'", (*md)->getDisplayName().encode().c_str());
-			_metadataParser.close();
 		}
+		_metadataParser.close();
 	}
 }
 

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -317,6 +317,9 @@ Graphics::ManagedSurface *loadSurfaceFromFile(const Common::String &name, int re
 			Common::SeekableReadStream *stream = g_gui.getIconsSet().createReadStreamForMember(name);
 			Graphics::SVGBitmap *image = nullptr;
 			image = new Graphics::SVGBitmap(stream);
+
+			delete stream;
+
 			surf = new Graphics::ManagedSurface(renderWidth, renderHeight, *image->getPixelFormat());
 			image->render(*surf, renderWidth, renderHeight);
 			delete image;


### PR DESCRIPTION
These were found with ASan.
I am not sure why `themepath` and `iconspath` handling are different.