### PR TITLE
ALL: Rework OpenGL detection

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -482,9 +482,9 @@ ifdef ENABLE_AGI
 DIST_FILES_ENGINEDATA+=$(srcdir)/dists/pred.dic
 endif
 
-# Shaders: install if USE_OPENGL_SHADERS or USE_GLES2 defined
+# Shaders: install if USE_OPENGL_SHADERS is defined
 DIST_FILES_SHADERS=
-ifneq ($(USE_OPENGL_SHADERS)$(USE_GLES2),)
+ifneq ($(USE_OPENGL_SHADERS),)
 ifdef ENABLE_GRIM
 DIST_FILES_SHADERS+=$(wildcard $(srcdir)/engines/grim/shaders/*)
 endif

--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -223,8 +223,7 @@ void AndroidGraphicsManager::touchControlNotifyChanged() {
 void *AndroidGraphicsManager::getProcAddress(const char *name) const {
 	ENTER("%s", name);
 
-	// TODO: Support dynamically loaded OpenGL
-	return nullptr;
+	return androidGLgetProcAddress(name);
 }
 
 bool AndroidGraphicsManager::notifyMousePosition(Common::Point &mouse) {

--- a/backends/graphics/opengl/opengl-sys.h
+++ b/backends/graphics/opengl/opengl-sys.h
@@ -23,44 +23,9 @@
 #define BACKENDS_GRAPHICS_OPENGL_OPENGL_SYS_H
 
 #include "common/scummsys.h"
+#include "graphics/opengl/system_headers.h"
 
 #include "backends/graphics/opengl/debug.h"
-
-// On OS X we only support GL contexts. The reason is that Apple's GL interface
-// uses "void *" for GLhandleARB which is not type compatible with GLint. This
-// kills our aliasing trick for extension functions and thus would force us to
-// supply two different Shader class implementations or introduce other
-// wrappers. OS X only supports GL contexts right now anyway (at least
-// according to SDL2 sources), thus it is not much of an issue.
-#if defined(MACOSX) && (!defined(USE_GLES_MODE) || USE_GLES_MODE != 0)
-//#warning "Only forced OpenGL mode is supported on Mac OS X. Overriding settings."
-#undef USE_GLES_MODE
-#define USE_GLES_MODE 0
-#endif
-
-// We allow to force GL or GLES modes on compile time.
-// For this the USE_GLES_MODE define is used. The following values represent
-// the given selection choices:
-//  0 - Force OpenGL context
-//  1 - Force OpenGL ES context
-//  2 - Force OpenGL ES 2.0 context
-#ifdef USE_GLES_MODE
-	#define USE_FORCED_GL    (USE_GLES_MODE == 0)
-	#define USE_FORCED_GLES  (USE_GLES_MODE == 1)
-	#define USE_FORCED_GLES2 (USE_GLES_MODE == 2)
-#else
-	#define USE_FORCED_GL    0
-	#define USE_FORCED_GLES  0
-	#define USE_FORCED_GLES2 0
-#endif
-
-#ifdef __ANDROID__
-	#include <GLES/gl.h>
-	#include <GLES2/gl2.h>
-#else
-	#include "graphics/opengl/glad.h"
-	#define USE_GLAD
-#endif
 
 // This is an addition from us to alias ARB shader object extensions to
 // OpenGL (ES) 2.0 style functions. It only works when GLhandleARB and GLuint

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -134,8 +134,6 @@ protected:
 
 	void refreshScreen();
 
-	void *getProcAddress(const char *name) const;
-
 private:
 	void initOverlay();
 

--- a/backends/graphics3d/opengl/framebuffer.cpp
+++ b/backends/graphics3d/opengl/framebuffer.cpp
@@ -28,8 +28,10 @@
 
 #include "graphics/opengl/context.h"
 
-#ifdef USE_GLES2
+#if !defined(GL_DEPTH24_STENCIL8)
 #define GL_DEPTH24_STENCIL8 GL_DEPTH24_STENCIL8_OES
+#endif
+#if !defined(GL_DEPTH_COMPONENT24)
 #define GL_DEPTH_COMPONENT24 GL_DEPTH_COMPONENT24_OES
 #endif
 
@@ -122,7 +124,7 @@ void FrameBuffer::detach() {
 	glViewport(_prevStateViewport[0], _prevStateViewport[1], _prevStateViewport[2], _prevStateViewport[3]);
 }
 
-#if !defined(USE_GLES2) && !defined(AMIGAOS) && !defined(__MORPHOS__)
+#if !USE_FORCED_GLES2 && !defined(AMIGAOS) && !defined(__MORPHOS__)
 MultiSampleFrameBuffer::MultiSampleFrameBuffer(uint width, uint height, int samples)
 		: FrameBuffer(width,height) {
 	if (!OpenGLContext.framebufferObjectMultisampleSupported) {
@@ -184,7 +186,7 @@ void MultiSampleFrameBuffer::detach() {
 	glViewport(_prevStateViewport[0], _prevStateViewport[1], _prevStateViewport[2], _prevStateViewport[3]);
 }
 
-#endif // !defined(USE_GLES2) && !defined(AMIGAOS) && !defined(__MORPHOS__)
+#endif // !USE_FORCED_GLES2 && !defined(AMIGAOS) && !defined(__MORPHOS__)
 
 } // End of namespace OpenGL
 

--- a/backends/graphics3d/opengl/framebuffer.h
+++ b/backends/graphics3d/opengl/framebuffer.h
@@ -56,7 +56,7 @@ private:
 	GLint _prevStateViewport[4];
 };
 
-#if !defined(USE_GLES2) && !defined(AMIGAOS) && !defined(__MORPHOS__)
+#if !USE_FORCED_GLES2 && !defined(AMIGAOS) && !defined(__MORPHOS__)
 class MultiSampleFrameBuffer : public FrameBuffer {
 public:
 	MultiSampleFrameBuffer(uint width, uint height, int samples);

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -83,7 +83,7 @@ OpenGLSdlGraphics3dManager::OpenGLSdlGraphics3dManager(SdlEventSource *eventSour
 		DEFAULT_GLES2_MINOR = 0
 	};
 
-#ifdef USE_GLES2
+#if USE_FORCED_GLES2
 	_glContextType = OpenGL::kOGLContextGLES2;
 	_glContextProfileMask = SDL_GL_CONTEXT_PROFILE_ES;
 	_glContextMajor = DEFAULT_GLES2_MAJOR;
@@ -581,7 +581,7 @@ void OpenGLSdlGraphics3dManager::drawOverlay() {
 
 #if !defined(__amigaos4__) && !defined(__MORPHOS__)
 OpenGL::FrameBuffer *OpenGLSdlGraphics3dManager::createFramebuffer(uint width, uint height) {
-#if !defined(USE_GLES2)
+#if !USE_FORCED_GLES2
 	if (_antialiasing && OpenGLContext.framebufferObjectMultisampleSupported) {
 		return new OpenGL::MultiSampleFrameBuffer(width, height, _antialiasing);
 	} else

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -8,10 +8,6 @@ MODULE_OBJS := \
 	events/default/default-events.o \
 	fs/abstract-fs.o \
 	fs/stdiostream.o \
-	graphics3d/opengl/framebuffer.o \
-	graphics3d/opengl/surfacerenderer.o \
-	graphics3d/opengl/texture.o \
-	graphics3d/opengl/tiledsurface.o \
 	keymapper/action.o \
 	keymapper/hardware-input.o \
 	keymapper/input-watcher.o \
@@ -148,7 +144,6 @@ MODULE_OBJS += \
 	events/sdl/sdl-events.o \
 	graphics/sdl/sdl-graphics.o \
 	graphics/surfacesdl/surfacesdl-graphics.o \
-	graphics3d/openglsdl/openglsdl-graphics3d.o \
 	mixer/sdl/sdl-mixer.o \
 	mutex/sdl/sdl-mutex.o \
 	plugins/sdl/sdl-provider.o \
@@ -162,7 +157,12 @@ endif
 
 ifdef USE_OPENGL
 MODULE_OBJS += \
-	graphics/openglsdl/openglsdl-graphics.o
+	graphics/openglsdl/openglsdl-graphics.o \
+	graphics3d/opengl/framebuffer.o \
+	graphics3d/opengl/surfacerenderer.o \
+	graphics3d/opengl/texture.o \
+	graphics3d/opengl/tiledsurface.o \
+	graphics3d/openglsdl/openglsdl-graphics3d.o
 endif
 
 ifdef USE_DISCORD
@@ -239,6 +239,10 @@ MODULE_OBJS += \
 	graphics/android/android-graphics.o \
 	graphics3d/android/android-graphics3d.o \
 	graphics3d/android/texture.o \
+	graphics3d/opengl/framebuffer.o \
+	graphics3d/opengl/surfacerenderer.o \
+	graphics3d/opengl/texture.o \
+	graphics3d/opengl/tiledsurface.o \
 	mutex/pthread/pthread-mutex.o
 endif
 

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -40,6 +40,7 @@
 // for the Android port
 #define FORBIDDEN_SYMBOL_EXCEPTION_printf
 
+#include <EGL/egl.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/system_properties.h>
@@ -119,6 +120,11 @@ void checkGlError(const char *expr, const char *file, int line) {
 		LOGE("GL ERROR: %s on %s (%s:%d)", getGlErrStr(error), expr, file, line);
 }
 #endif
+
+void *androidGLgetProcAddress(const char *name) {
+	// This exists since Android 2.3 (API Level 9)
+	return (void *)eglGetProcAddress(name);
+}
 
 OSystem_Android::OSystem_Android(int audio_sample_rate, int audio_buffer_size) :
 	_audio_sample_rate(audio_sample_rate),

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -93,6 +93,8 @@ extern void checkGlError(const char *expr, const char *file, int line);
 #define GLTHREADCHECK do {  } while (false)
 #endif
 
+void *androidGLgetProcAddress(const char *name);
+
 class OSystem_Android : public ModularGraphicsBackend, Common::EventSource {
 private:
 	// passed from the dark side

--- a/backends/platform/android3d/android.cpp
+++ b/backends/platform/android3d/android.cpp
@@ -40,6 +40,7 @@
 // for the Android port
 #define FORBIDDEN_SYMBOL_EXCEPTION_printf
 
+#include <EGL/egl.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/system_properties.h>
@@ -117,6 +118,11 @@ void checkGlError(const char *expr, const char *file, int line) {
 		LOGE("GL ERROR: %s on %s (%s:%d)", getGlErrStr(error), expr, file, line);
 }
 #endif
+
+void *androidGLgetProcAddress(const char *name) {
+       // This exists since Android 2.3 (API Level 9)
+       return (void *)eglGetProcAddress(name);
+}
 
 OSystem_Android::OSystem_Android(int audio_sample_rate, int audio_buffer_size) :
 	_audio_sample_rate(audio_sample_rate),

--- a/backends/platform/android3d/android.h
+++ b/backends/platform/android3d/android.h
@@ -100,6 +100,8 @@ extern void checkGlError(const char *expr, const char *file, int line);
 #define GLTHREADCHECK do {  } while (false)
 #endif
 
+void *androidGLgetProcAddress(const char *name);
+
 class OSystem_Android : public ModularGraphicsBackend, Common::EventSource {
 private:
 	// passed from the dark side

--- a/backends/platform/android3d/graphics.cpp
+++ b/backends/platform/android3d/graphics.cpp
@@ -464,7 +464,7 @@ void AndroidGraphicsManager::initSizeIntern(uint width, uint height,
 #else
 	_game_texture->allocBuffer(width, height);
 #endif
-#ifdef USE_GLES2
+#if USE_FORCED_GLES2
 	_frame_buffer = new OpenGL::FrameBuffer(_game_texture->getTextureName(), _game_texture->width(), _game_texture->height(), _game_texture->texWidth(), _game_texture->texHeight());
 	_frame_buffer->attach();
 #endif

--- a/backends/platform/android3d/graphics.h
+++ b/backends/platform/android3d/graphics.h
@@ -114,8 +114,6 @@ protected:
 
 	void refreshScreen();
 
-	void *getProcAddress(const char *name) const;
-
 private:
 	void setCursorPaletteInternal(const byte *colors, uint start, uint num);
 	void disableCursorPalette();

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -50,7 +50,7 @@
 #include "backends/graphics/openglsdl/openglsdl-graphics.h"
 #include "graphics/cursorman.h"
 #endif
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 #include "backends/graphics3d/openglsdl/openglsdl-graphics3d.h"
 #include "graphics/opengl/context.h"
 #endif
@@ -208,7 +208,7 @@ void OSystem_SDL::initBackend() {
 #endif
 	debug(1, "Using SDL Video Driver \"%s\"", sdlDriverName);
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	detectFramebufferSupport();
 	detectAntiAliasingSupport();
 #endif
@@ -305,10 +305,10 @@ void OSystem_SDL::initBackend() {
 	dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->activateManager();
 }
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 void OSystem_SDL::detectFramebufferSupport() {
 	_supportsFrameBuffer = false;
-#if defined(USE_GLES2)
+#if USE_FORCED_GLES2
 	// Framebuffers are always available with GLES2
 	_supportsFrameBuffer = true;
 #elif !defined(AMIGAOS) && !defined(__MORPHOS__)
@@ -476,7 +476,7 @@ void OSystem_SDL::setWindowCaption(const Common::U32String &caption) {
 	_window->setWindowCaption(cap);
 }
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 Common::Array<uint> OSystem_SDL::getSupportedAntiAliasingLevels() const {
 	return _antiAliasLevels;
 }
@@ -772,7 +772,7 @@ bool OSystem_SDL::setGraphicsMode(int mode, uint flags) {
 
 	// If the new mode and the current mode are not from the same graphics
 	// manager, delete and create the new mode graphics manager
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	if (render3d && !supports3D) {
 		debug(1, "switching to OpenGL 3D graphics");
 		sdlGraphicsManager->deactivateManager();

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -93,7 +93,7 @@ public:
 	//Screenshots
 	virtual Common::String getScreenshotsPath();
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	Common::Array<uint> getSupportedAntiAliasingLevels() const override;
 #endif
 
@@ -131,7 +131,7 @@ protected:
 
 	SdlGraphicsManager::State _gfxManagerState;
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	// Graphics capabilities
 	void detectFramebufferSupport();
 	void detectAntiAliasingSupport();

--- a/base/version.cpp
+++ b/base/version.cpp
@@ -199,7 +199,13 @@ const char gScummVMFeatures[] = ""
 	"(with shaders) "
 #endif
 #endif
-#ifdef USE_GLES2
-	"OpenGL ES 2 "
+#ifdef USE_GLES_MODE
+#if USE_GLES_MODE == 0
+	"OpenGL desktop only "
+#elif USE_GLES_MODE == 1
+	"OpenGL ES 1 only "
+#elif USE_GLES_MODE == 2
+	"OpenGL ES 2 only "
+#endif
 #endif
 	;

--- a/configure
+++ b/configure
@@ -159,10 +159,8 @@ _faad=auto
 _fluidsynth=auto
 _fluidlite=auto
 _opengl_mode=auto
-_opengl_game=auto
 _opengl_game_classic=auto
 _opengl_game_shaders=auto
-_opengl_game_es2=no
 _tinygl=yes
 _readline=auto
 _freetype2=auto
@@ -950,8 +948,8 @@ Optional Libraries:
 
   --with-opengl-prefix=DIR      prefix where OpenGL (ES) is installed (optional)
   --disable-opengl-game         disable OpenGL (ES) support in game [autodetect]
-  --disable-opengl-game-shaders disable use of modern OpenGL with shaders
-  --force-opengl-game-es2       only detect OpenGL ES2
+  --disable-opengl-game-classic disable OpenGL classic support in game
+  --disable-opengl-game-shaders disable use of modern OpenGL with shaders in game
 
   --with-jpeg-prefix=DIR   Prefix where libjpeg is installed (optional)
   --disable-jpeg           disable JPEG decoder [autodetect]
@@ -1165,19 +1163,21 @@ for ac_option in $@; do
 	--disable-tts)                _tts=no                ;;
 	--enable-gtk)                 _gtk=yes               ;;
 	--disable-gtk)                _gtk=no                ;;
-	--disable-opengl-game)        _opengl_game=no        ;;
+	--opengl-mode=*)
+		_opengl_mode=`echo $ac_option | cut -d '=' -f 2`
+		;;
+	--disable-opengl-game)
+		_opengl_game_classic=no
+		_opengl_game_shaders=no
+		;;
 	--disable-opengl-game-classic) _opengl_game_classic=no ;;
 	--disable-opengl-game-shaders) _opengl_game_shaders=no ;;
-	--force-opengl-game-es2)      _opengl_game_es2=yes   ;;
 	--enable-tinygl)              _tinygl=yes            ;;
 	--disable-tinygl)             _tinygl=no             ;;
 	--enable-bink)                _bink=yes              ;;
 	--disable-bink)               _bink=no               ;;
 	--enable-discord)             _discord=yes           ;;
 	--disable-discord)            _discord=no            ;;
-	--opengl-mode=*)
-		_opengl_mode=`echo $ac_option | cut -d '=' -f 2`
-		;;
 	--enable-verbose-build)      _verbose_build=yes      ;;
 	--enable-plugins)            _dynamic_modules=yes    ;;
 	--default-dynamic)           _plugins_default=dynamic;;
@@ -3077,6 +3077,7 @@ EOF
 		_port_mk="backends/platform/sdl/riscos/riscos.mk"
 		_pandoc=yes
 		_sdlconfig=sdl-config
+		# RiscOS has no OpenGL support at all even though it's SDL based
 		_opengl_mode=none
 		;;
 	solaris*)
@@ -3253,8 +3254,6 @@ if test -n "$_host"; then
 			HOSTEXEEXT=.html
 			_ar="emar cr"
 			_ranlib="emranlib"
-			_opengl_mode=gles2
-			_opengl_game_es2=yes
 			;;
 		raspberrypi)
 			_libcurlpath=$RPI_ROOT/usr/bin
@@ -3590,8 +3589,6 @@ if test -n "$_host"; then
 			# graphics. But OpenGL works when it is enabled from the start.
 			# This might be related to a known crash on OpenGL de-init due
 			# to the OpenGL implementation on this platform.
-			_opengl_mode=gles2
-			_opengl_game_es2=yes
 			_vkeybd=yes
 			_port_mk="backends/platform/sdl/switch/switch.mk"
 			;;
@@ -5330,26 +5327,27 @@ define_in_config_if_yes "$_freetype2" "USE_FREETYPE2"
 #
 echocheck "OpenGL"
 
-case $_backend in
-	openpandora)
-		# Only enable OpenGL ES on the OpanPandora if --opengl-mode=gles is passed in explicitly.
-		if test "$_opengl_mode" = "gles" ; then
-			append_var LIBS "-lGLES_CM -lEGL -lX11"
-			append_var LIBS_3D "-lGLES_CM -lEGL -lX11"
-		else
-			_opengl_mode=none
-		fi
-		;;
-esac
+_opengl_glad=no
 
-if test "$_opengl_mode" = auto ; then
+if test "$_opengl_mode" != none ; then
 	case $_backend in
 		android)
 			# We require API level 16 while GLES2 APIs have been added in level 8 so we are safe for compilation
 			_opengl_mode=gles2
-			_opengl_game_es2=yes
+			;;
+		android3d)
+			# We require API level 16 while GLES2 APIs have been added in level 8 so we are safe for compilation
+			_opengl_mode=gles2
+			;;
+		openpandora)
+			# Enable GLES only if user explicitely requested it
+			# Backend is SDL based so GLAD is supported
+			test "$_opengl_mode" != "gles" && _opengl_mode=none
+			test "$_opengl_mode" != "none" && _opengl_glad=yes
 			;;
 		sdl)
+			# This case is for pure SDL backend. Many platforms overload it and create a new backend
+			# They still make use of SDL but it's handled below in the default case
 			case $_sdlversion in
 				1.2.*)
 					# Stock SDL 1.2 only supports OpenGL contexts.
@@ -5366,17 +5364,112 @@ if test "$_opengl_mode" = auto ; then
 							;;
 
 						*)
-							_opengl_mode=any
+							# As SDL2 supports everything, let the user choose if he wants to
+							test "$_opengl_mode" = "auto" && _opengl_mode=any
 							;;
 					esac
 					;;
 			esac
+			_opengl_glad=yes
 			;;
-
+		switch)
+			_opengl_mode=gles2
+			_opengl_glad=yes
+			;;
+		wasm*-emscripten)
+			_opengl_mode=gles2
+			;;
 		*)
-			_opengl_mode=none
+			# On all other platforms, by default don't enable OpenGL
+			test "$_opengl_mode" = "auto" && _opengl_mode=none
+			# We only support OpenGL on SDL based backends and Android (already handled)
+			test "$_sdl" = "no" && _opengl_mode=none
+			# If it's a SDL based backend and OpenGL is really enabled, use GLAD
+			test "$_opengl_mode" != "none" && test "$_sdl" != "no" && _opengl_glad=yes
 			;;
 	esac
+fi
+
+if test "$_opengl_glad" = "no" -a "$_opengl_mode" != "none"; then
+	# Try different header filenames
+	# 1) GL/gl.h         This is usually used on POSIX and Windows systems
+	# 2) OpenGL/gl.h     This is used on Mac OS X
+	# 3) GLES2/gl2.h     This is used for OpenGL ES 2.x
+	_opengl_can_compile=no
+	for i in "GL/gl.h" "OpenGL/gl.h" "GLES2/gl2.h"; do
+		# Test the current header for OpenGL
+		if test "$_opengl_mode" = "gl" -o "$_opengl_mode" = "any" ; then
+			cat > $TMPC << EOF
+#include <$i>
+#include <stdio.h>
+int main(void) { printf("ANTIVIRUS FALSE POSITIVE WORKAROUND"); return GL_VERSION_1_1; }
+EOF
+			cc_check $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS && _opengl_can_compile=yes && break
+			# Desktop often has multiple implementations GL/GLES/GLES2
+		fi
+
+		# Test the current header for OpenGL ES2
+		if test "$_opengl_mode" = "gles2" -o "$_opengl_mode" = "any" ; then
+			cat > $TMPC << EOF
+#include <$i>
+int main(void) { return GL_ES_VERSION_2_0; }
+EOF
+			cc_check $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS && _opengl_can_compile=yes && _opengl_mode=gles2 && break
+		fi
+
+		# Test the current header for OpenGL ES
+		if test "$_opengl_mode" = "gles" -o "$_opengl_mode" = "any" ; then
+			cat > $TMPC << EOF
+#include <$i>
+int main(void) { return GL_VERSION_ES_CM_1_0; }
+EOF
+			cc_check $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS && _opengl_can_compile=yes && _opengl_mode=gles && break
+		fi
+	done
+
+	if test "$_opengl_can_compile" = yes; then
+		# Our simple test case
+		cat > $TMPC << EOF
+int main(void) { return 0; }
+EOF
+		_opengl_can_compile=no
+		# Try different library names
+		if test "$_opengl_mode" = "gles2" ; then
+			# 1) GLESv2    This is generally used by nearly all platforms for OpenGL ES 2
+			# 2) ogles2    This is used by AmigaOS4 for OpenGL ES 2
+			for lib in "-lGLESv2" "-logles2"; do
+				if cc_check_no_clean $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS $lib; then
+					append_var OPENGL_LIBS "$lib"
+					_opengl_can_compile=yes
+					break
+				fi
+			done
+		else
+			case $_host_os in
+			darwin*)
+				OPENGL_LIBS="-framework OpenGL"
+				;;
+			mingw*)
+				OPENGL_LIBS="-lopengl32"
+				;;
+			*)
+				OPENGL_LIBS="-lGL"
+				;;
+			esac
+			if cc_check_no_clean $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS; then
+				_opengl_can_compile=yes
+			fi
+		fi
+	fi
+
+	if test "$_opengl_can_compile" = yes ; then
+		append_var INCLUDES "$OPENGL_CFLAGS"
+		append_var LIBS "$OPENGL_LIBS"
+		append_var LIBS_3D "$OPENGL_LIBS"
+	fi
+	cc_check_clean
+elif test "$_opengl_glad" = "yes"; then
+	_opengl_can_compile=yes
 fi
 
 _opengl=yes
@@ -5424,110 +5517,45 @@ esac
 #
 echocheck "OpenGL for game"
 
-if test "$_opengl_game" = auto ; then
-	_opengl_game=no
-	if (test "$_backend" = "sdl" && test "$_opengl" = yes) || test "$_backend" = "android" || test "$_backend" = "android3d" \
-		|| test "$_backend" = "switch"; then
-		# Try different header filenames
-		# 1) GL/gl.h         This is usually used on POSIX and Windows systems
-		# 2) OpenGL/gl.h     This is used on Mac OS X
-		# 3) GLES2/gl2.h     This is used for OpenGL ES 2.x
-		for i in "GL/gl.h" "OpenGL/gl.h" "GLES2/gl2.h"; do
-			# Test the current header for OpenGL
-			if test "$_opengl_game_es2" = no ; then
-				cat > $TMPC << EOF
-#include <$i>
-#include <stdio.h>
-int main(void) { printf("ANTIVIRUS FALSE POSITIVE WORKAROUND"); return GL_VERSION_1_1; }
-EOF
-				cc_check $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS && _opengl_game=yes && break
-			fi
-
-			# Test the current header for OpenGL ES2
-			cat > $TMPC << EOF
-#include <$i>
-int main(void) { return GL_ES_VERSION_2_0; }
-EOF
-			cc_check $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS && _opengl_game=yes && _opengl_game_es2=yes && break
-		done
-	fi
-fi
-
-if test "$_opengl_game" = yes ; then
-	# Our simple test case
-	cat > $TMPC << EOF
-int main(void) { return 0; }
-EOF
-	_opengl_game=no
-	# Try different library names
-	if test "$_opengl_game_es2" = yes ; then
-		# 1) GLESv2    This is generally used by nearly all platforms for OpenGL ES 2
-		# 2) ogles2    This is used by AmigaOS4 for OpenGL ES 2
-		_opengl_game_es2=no
-		for lib in "-lGLESv2" "-logles2"; do
-			if cc_check_no_clean $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS $lib
-				then
-				_opengl_game_es2=yes
-				append_var OPENGL_LIBS "$lib"
-				break
-			fi
-		done
-	else
-		case $_host_os in
-		darwin*)
-			OPENGL_LIBS="-framework OpenGL"
-			;;
-		mingw*)
-			OPENGL_LIBS="-lopengl32"
-			;;
-		*)
-			OPENGL_LIBS="-lGL"
-			;;
-		esac
-		if cc_check_no_clean $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS
-			then
-			_opengl_game=yes
-		fi
-	fi
-
-	if test "$_opengl_game" = yes ; then
-		append_var INCLUDES "$OPENGL_CFLAGS"
-		append_var LIBS "$OPENGL_LIBS"
-		append_var LIBS_3D "$OPENGL_LIBS"
-		if test "$_opengl_game_classic" = auto ; then
-			_opengl_game_classic=yes
-		fi
-		if test "$_opengl_game_shaders" = auto; then
-			_opengl_game_shaders=yes
-		fi
-	elif test "$_opengl_game_es2" = "yes" ; then
-		append_var INCLUDES "$OPENGL_CFLAGS"
-		append_var LIBS "$OPENGL_LIBS"
-		append_var LIBS_3D "$OPENGL_LIBS"
-		_opengl_game_classic=no
-		if test "$_opengl_game_shaders" = auto ; then
-			_opengl_game_shaders=yes
-		fi
-	else
+if test "$_opengl_can_compile" = "yes"; then
+	if test "$_opengl_mode" = "gles"; then
+		# GLES 1.x is not supported for 3D games
 		_opengl_game_classic=no
 		_opengl_game_shaders=no
+	elif test "$_opengl_mode" = "gles2"; then
+		# GLES2 doesn't support GL classic
+		_opengl_game_classic=no
+		if test "$_opengl_game_shaders" != "no"; then
+			_opengl_game_shaders=yes
+		fi
+	else
+		# We can compile GL desktop
+		if test "$_opengl_game_classic" != "no"; then
+			_opengl_game_classic=yes
+		fi
+		if test "$_opengl_game_shaders" != "no"; then
+			_opengl_game_shaders=yes
+		fi
 	fi
-	cc_check_clean
+else
+	_opengl_game_classic=no
+	_opengl_game_shaders=no
 fi
 
-if test "$_opengl_game_es2" = "yes" ; then
-	echo "yes (OpenGL ES2)"
-else
-	if test "$_opengl_game_shaders" = "yes" ; then
-		echo "yes (shaders enabled)"
-	elif test "$_opengl_game_classic" = "yes" ; then
-		echo "yes (shaders disabled)"
+if test "$_opengl_game_shaders" = "yes" ; then
+	if test "$_opengl_mode" = "gles2" ; then
+		echo "yes (OpenGL ES2)"
 	else
-		echo "no"
+		echo "yes (shaders enabled)"
 	fi
+elif test "$_opengl_game_classic" = "yes" ; then
+	echo "yes (shaders disabled)"
+else
+	echo "no"
 fi
 
 define_in_config_if_yes "$_opengl" "USE_OPENGL"
+define_in_config_if_yes "$_opengl_glad" "USE_GLAD"
 define_in_config_if_yes "$_opengl_game_classic" "USE_OPENGL_GAME"
 define_in_config_if_yes "$_opengl_game_shaders" "USE_OPENGL_SHADERS"
 

--- a/configure
+++ b/configure
@@ -5334,10 +5334,12 @@ if test "$_opengl_mode" != none ; then
 		android)
 			# We require API level 16 while GLES2 APIs have been added in level 8 so we are safe for compilation
 			_opengl_mode=gles2
+			_opengl_glad=yes
 			;;
 		android3d)
 			# We require API level 16 while GLES2 APIs have been added in level 8 so we are safe for compilation
 			_opengl_mode=gles2
+			_opengl_glad=yes
 			;;
 		openpandora)
 			# Enable GLES only if user explicitely requested it
@@ -6125,7 +6127,7 @@ case $_host_os in
 		system_libs=''
 		for lib in $LIBS; do
 			case $lib in
-			-lz|-lm|-ldl|-lGLESv2)
+			-lz|-lm|-ldl)
 				system_libs="$system_libs $lib"
 				;;
 			*)
@@ -6137,7 +6139,7 @@ case $_host_os in
 		# -lgcc is carefully placed here - we want to catch
 		# all toolchain symbols in *our* libraries rather
 		# than pick up anything unhygenic from the Android libs.
-		LIBS="-Wl,-Bstatic $static_libs -Wl,-Bdynamic -lgcc $system_libs -llog -landroid -ljnigraphics -lGLESv2"
+		LIBS="-Wl,-Bstatic $static_libs -Wl,-Bdynamic -lgcc $system_libs -llog -landroid -ljnigraphics -lEGL"
 		;;
 	ds)
 		# Moved -Wl,--gc-sections here to avoid it interfering with the library checks

--- a/configure
+++ b/configure
@@ -5530,7 +5530,6 @@ fi
 define_in_config_if_yes "$_opengl" "USE_OPENGL"
 define_in_config_if_yes "$_opengl_game_classic" "USE_OPENGL_GAME"
 define_in_config_if_yes "$_opengl_game_shaders" "USE_OPENGL_SHADERS"
-define_in_config_if_yes "$_opengl_game_es2" "USE_GLES2"
 
 if test "$_dynamic_modules" = yes ; then
 	case $_host_os in

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -335,7 +335,6 @@ int main(int argc, char *argv[]) {
 	if (!getFeatureBuildState("opengl", setup.features)) {
 		setFeatureBuildState("opengl_game", setup.features, false);
 		setFeatureBuildState("opengl_shaders", setup.features, false);
-		setFeatureBuildState("opengles2", setup.features, false);
 	}
 
 	// Disable engines for which we are missing dependencies
@@ -440,6 +439,10 @@ int main(int argc, char *argv[]) {
 
 	if (setup.useStaticDetection) {
 		setup.defines.push_back("DETECTION_STATIC");
+	}
+
+	if (getFeatureBuildState("opengl", setup.features)) {
+		setup.defines.push_back("USE_GLAD");
 	}
 
 	// List of global warnings and map of project-specific warnings
@@ -1098,9 +1101,8 @@ const Feature s_features[] = {
 	{             "nasm",                      "USE_NASM", false, true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
 	{           "tinygl",                    "USE_TINYGL", false, true,  "TinyGL support" },
 	{           "opengl",                    "USE_OPENGL", false, true,  "OpenGL support" },
-	{      "opengl_game",               "USE_OPENGL_GAME", false, true,  "OpenGL support in 3d games" },
+	{      "opengl_game",               "USE_OPENGL_GAME", false, true,  "OpenGL support (classic) in 3d games" },
 	{   "opengl_shaders",            "USE_OPENGL_SHADERS", false, true,  "OpenGL support (shaders) in 3d games" },
-	{        "opengles2",                     "USE_GLES2", false, false, "forced OpenGL ES2 mode in 3d games" },
 	{          "taskbar",                   "USE_TASKBAR", false, true,  "Taskbar integration support" },
 	{            "cloud",                     "USE_CLOUD", false, true,  "Cloud integration support" },
 	{      "translation",               "USE_TRANSLATION", false, true,  "Translation support" },

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -114,7 +114,7 @@ xeen.ccs               FILE    "dists/engine-data/xeen.ccs"
 #if PLUGIN_ENABLED_STATIC(AGI)
 pred.dic               FILE    "dists/pred.dic"
 #endif
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 #if PLUGIN_ENABLED_STATIC(GRIM)
 shaders/grim_dim.fragment            FILE    "engines/grim/shaders/grim_dim.fragment"
 shaders/grim_dim.vertex              FILE    "engines/grim/shaders/grim_dim.vertex"

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -2178,7 +2178,7 @@ Bitmap *GfxOpenGLS::getScreenshot(int w, int h, bool useStored) {
 
 			glBindFramebuffer(GL_FRAMEBUFFER, 0);
 			glDeleteFramebuffers(1, &frameBuffer);
-#ifndef USE_GLES2
+#if !USE_FORCED_GLES2
 		} else {
 			glBindTexture(GL_TEXTURE_2D, _storedDisplay);
 			char *buffer = new char[_screenWidth * _screenHeight * 4];

--- a/engines/stark/gfx/opengltexture.cpp
+++ b/engines/stark/gfx/opengltexture.cpp
@@ -102,7 +102,7 @@ void OpenGlTexture::setLevelCount(uint32 count) {
 	_levelCount = count;
 
 	if (count >= 1) {
-#if !defined(USE_GLES2)
+#if !USE_FORCED_GLES2
 		// GLES2 does not allow setting the max provided mipmap level.
 		// It expects all the levels to be provided, which is not the case in TLJ.
 		// FIXME: Enable mipmapping on GLES2

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -38,6 +38,15 @@
 static GLADapiproc loadFunc(void *userptr, const char *name) {
 	return (GLADapiproc)SDL_GL_GetProcAddress(name);
 }
+
+#elif defined(__ANDROID__)
+// To keep includes light, don't include EGL here and don't include Android headers
+void *androidGLgetProcAddress(const char *name);
+
+static GLADapiproc loadFunc(void *userptr, const char *name) {
+	return (GLADapiproc)androidGLgetProcAddress(name);
+}
+
 #else
 #error Not implemented
 #endif

--- a/graphics/opengl/system_headers.h
+++ b/graphics/opengl/system_headers.h
@@ -52,7 +52,13 @@
 	#define USE_FORCED_GLES2 0
 #endif
 
-#if USE_FORCED_GLES2
+// Don't include any OpenGL stuff if we didn't enable it
+#ifdef USE_OPENGL
+#ifdef USE_GLAD
+
+	#include "graphics/opengl/glad.h"
+
+#elif USE_FORCED_GLES2
 
 	#define GL_GLEXT_PROTOTYPES
 	#if defined(IPHONE)
@@ -78,11 +84,7 @@
 		#define GL_MAX_SAMPLES 0x8D57
 	#endif
 
-#else
-
-	#define USE_GLAD
-	#include "graphics/opengl/glad.h"
-
+#endif
 #endif
 
 #endif

--- a/graphics/opengl/system_headers.h
+++ b/graphics/opengl/system_headers.h
@@ -24,35 +24,65 @@
 
 #include "common/scummsys.h"
 
-#ifdef USE_GLES2
+// On OS X we only support GL contexts. The reason is that Apple's GL interface
+// uses "void *" for GLhandleARB which is not type compatible with GLint. This
+// kills our aliasing trick for extension functions and thus would force us to
+// supply two different Shader class implementations or introduce other
+// wrappers. OS X only supports GL contexts right now anyway (at least
+// according to SDL2 sources), thus it is not much of an issue.
+#if defined(MACOSX) && (!defined(USE_GLES_MODE) || USE_GLES_MODE != 0)
+//#warning "Only forced OpenGL mode is supported on Mac OS X. Overriding settings."
+#undef USE_GLES_MODE
+#define USE_GLES_MODE 0
+#endif
 
-#define GL_GLEXT_PROTOTYPES
-#ifdef IPHONE
-#include <OpenGLES/ES2/gl.h>
-#include <OpenGLES/ES2/glext.h>
+// We allow to force GL or GLES modes on compile time.
+// For this the USE_GLES_MODE define is used. The following values represent
+// the given selection choices:
+//  0 - Force OpenGL context
+//  1 - Force OpenGL ES context
+//  2 - Force OpenGL ES 2.0 context
+#ifdef USE_GLES_MODE
+	#define USE_FORCED_GL    (USE_GLES_MODE == 0)
+	#define USE_FORCED_GLES  (USE_GLES_MODE == 1)
+	#define USE_FORCED_GLES2 (USE_GLES_MODE == 2)
 #else
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
-#endif
-#undef GL_GLEXT_PROTOTYPES
-
-#ifndef GL_BGRA
-#	define GL_BGRA GL_BGRA_EXT
+	#define USE_FORCED_GL    0
+	#define USE_FORCED_GLES  0
+	#define USE_FORCED_GLES2 0
 #endif
 
-#if !defined(GL_UNPACK_ROW_LENGTH)
-// The Android SDK does not declare GL_UNPACK_ROW_LENGTH_EXT
-#define GL_UNPACK_ROW_LENGTH 0x0CF2
-#endif
+#if USE_FORCED_GLES2
 
-#if !defined(GL_MAX_SAMPLES)
-// The Android SDK and SDL1 don't declare GL_MAX_SAMPLES
-#define GL_MAX_SAMPLES 0x8D57
-#endif
+	#define GL_GLEXT_PROTOTYPES
+	#if defined(IPHONE)
+		#include <OpenGLES/ES2/gl.h>
+		#include <OpenGLES/ES2/glext.h>
+	#else
+		#include <GLES2/gl2.h>
+		#include <GLES2/gl2ext.h>
+	#endif
+	#undef GL_GLEXT_PROTOTYPES
+
+	#ifndef GL_BGRA
+		#define GL_BGRA GL_BGRA_EXT
+	#endif
+
+	#if !defined(GL_UNPACK_ROW_LENGTH)
+		// The Android SDK does not declare GL_UNPACK_ROW_LENGTH_EXT
+		#define GL_UNPACK_ROW_LENGTH 0x0CF2
+	#endif
+
+	#if !defined(GL_MAX_SAMPLES)
+		// The Android SDK and SDL1 don't declare GL_MAX_SAMPLES
+		#define GL_MAX_SAMPLES 0x8D57
+	#endif
 
 #else
-#define USE_GLAD
-#include "graphics/opengl/glad.h"
+
+	#define USE_GLAD
+	#include "graphics/opengl/glad.h"
+
 #endif
 
 #endif

--- a/graphics/renderer.cpp
+++ b/graphics/renderer.cpp
@@ -29,7 +29,7 @@ static const RendererTypeDescription rendererTypes[] = {
 #if defined(USE_OPENGL_GAME)
 	{ "opengl", _s("OpenGL"), kRendererTypeOpenGL },
 #endif
-#if defined(USE_OPENGL_SHADERS) || defined(USE_GLES2)
+#if defined(USE_OPENGL_SHADERS)
 	{ "opengl_shaders", _s("OpenGL with shaders"), kRendererTypeOpenGLShaders },
 #endif
 #ifdef USE_TINYGL
@@ -73,19 +73,19 @@ RendererType getBestMatchingAvailableRendererType(RendererType desired) {
 		desired = kRendererTypeOpenGLShaders;
 	}
 
-#if !defined(USE_OPENGL_SHADERS) && !defined(USE_GLES2)
+#if !defined(USE_OPENGL_SHADERS)
 	if (desired == kRendererTypeOpenGLShaders) {
 		desired = kRendererTypeOpenGL;
 	}
 #endif
 
-#if (!defined(USE_OPENGL_GAME) && defined(USE_OPENGL_SHADERS)) || defined(USE_GLES2)
+#if (!defined(USE_OPENGL_GAME) && defined(USE_OPENGL_SHADERS))
 	if (desired == kRendererTypeOpenGL) {
 		desired = kRendererTypeOpenGLShaders;
 	}
 #endif
 
-#if !defined(USE_OPENGL_GAME) && !defined(USE_GLES2) && !defined(USE_OPENGL_SHADERS)
+#if !defined(USE_OPENGL_GAME) && !defined(USE_OPENGL_SHADERS)
 	if (desired == kRendererTypeOpenGL || desired == kRendererTypeOpenGLShaders) {
 		desired = kRendererTypeTinyGL;
 	}


### PR DESCRIPTION
With the advent of GLAD, OpenGL libraries don't need to be linked with ScummVM for those platforms.
In addition, GLAD support is known at configure step by knowing the platform to configure.
This PR also tries to merge two configure paths: the one for 2D engines, and the one for 3D engines.

It builds correctly on Linux and Android. No other tests have been done yet.
In addition, create_project still has a USE_GLES2 define and no USE_GLES_MODE.