### PR TITLE
ENGINES: Remove use of getEngineId() in MetaEngine subclasses

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -57,7 +57,7 @@ const char *Plugin::getName() const {
 
 const char *Plugin::getEngineId() const {
 	if (_type == PLUGIN_TYPE_ENGINE_DETECTION) {
-		return _pluginObject->getEngineId();
+		return get<MetaEngineDetection>().getEngineId();
 	}
 
 	return nullptr;

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -133,18 +133,6 @@ public:
 
 	/** Returns the name of the plugin. */
 	virtual const char *getName() const = 0;
-
-	/**
-	 * Returns the engine id of the plugin, if implemented.
-	 * This mostly has the use with MetaEngines, but if another
-	 * type of plugins request this, we return a nullptr.
-	 * This is used because MetaEngines are now available in the
-	 * executable, and querying this we can match a MetaEngine
-	 * with it's related engine.
-	 */
-	virtual const char *getEngineId() const {
-		return nullptr;
-	}
 };
 
 /**

--- a/engines/ags/metaengine.cpp
+++ b/engines/ags/metaengine.cpp
@@ -91,10 +91,10 @@ bool AGSMetaEngine::hasFeature(MetaEngineFeature f) const {
 Common::String AGSMetaEngine::getSavegameFile(int saveGameIdx, const char *target) const {
 	if (saveGameIdx == kSavegameFilePattern) {
 		// Pattern requested
-		return Common::String::format("%s.###", target == nullptr ? getEngineId() : target);
+		return Common::String::format("%s.###", target == nullptr ? getName() : target);
 	} else {
 		// Specific filename requested
-		return Common::String::format("%s.%03d", target == nullptr ? getEngineId() : target, saveGameIdx);
+		return Common::String::format("%s.%03d", target == nullptr ? getName() : target, saveGameIdx);
 	}
 }
 

--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -161,7 +161,7 @@ SaveStateList CineMetaEngine::listSaves(const char *target) const {
 int CineMetaEngine::getMaximumSaveSlot() const { return MAX_SAVEGAMES - 1; }
 
 Common::String CineMetaEngine::getSavegameFile(int saveGameIdx, const char *target) const {
-	return Common::String::format("%s.%d", target == nullptr ? getEngineId() : target, saveGameIdx);
+	return Common::String::format("%s.%d", target == nullptr ? getName() : target, saveGameIdx);
 }
 
 SaveStateDescriptor CineMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/composer/metaengine.cpp
+++ b/engines/composer/metaengine.cpp
@@ -77,7 +77,7 @@ public:
 	SaveStateList listSaves(const char* target) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		if (saveGameIdx == kSavegameFilePattern)
 			return Common::String::format("%s.##", target);
 		else

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -80,7 +80,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		if (saveGameIdx == kSavegameFilePattern)
 			return Common::String::format("%s.####", target);
 		else

--- a/engines/griffon/metaengine.cpp
+++ b/engines/griffon/metaengine.cpp
@@ -54,10 +54,10 @@ public:
 Common::String GriffonMetaEngine::getSavegameFile(int saveGameIdx, const char *target) const {
 	if (saveGameIdx == kSavegameFilePattern) {
 		// Pattern requested
-		return Common::String::format("%s.s##", target == nullptr ? getEngineId() : target);
+		return Common::String::format("%s.s##", target == nullptr ? getName() : target);
 	} else {
 		// Specific filename requested
-		return Common::String::format("%s.s%02d", target == nullptr ? getEngineId() : target, saveGameIdx);
+		return Common::String::format("%s.s%02d", target == nullptr ? getName() : target, saveGameIdx);
 	}
 }
 

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -54,7 +54,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		if (saveGameIdx == kSavegameFilePattern)
 			return Common::String::format("%s-##.SAV", target);
 		else

--- a/engines/lilliput/metaengine.cpp
+++ b/engines/lilliput/metaengine.cpp
@@ -58,7 +58,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		if (saveGameIdx == kSavegameFilePattern)
 			return Common::String::format("%s-##.SAV", target);
 		else

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -38,7 +38,7 @@
 
 Common::String MetaEngine::getSavegameFile(int saveGameIdx, const char *target) const {
 	if (!target)
-		target = getEngineId();
+		target = getName();
 	if (saveGameIdx == kSavegameFilePattern) {
 		// Pattern requested
 		const char *pattern = hasFeature(kSimpleSavesNames) ? "%s.###" : "%s.s##";

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -143,7 +143,7 @@ public:
 	GUI::OptionsContainerWidget *buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		Common::String gameId = ConfMan.get("gameid", target);
 		const char *suffix;
 		// Saved games are only supported in Myst/Riven currently.

--- a/engines/mortevielle/metaengine.cpp
+++ b/engines/mortevielle/metaengine.cpp
@@ -52,7 +52,7 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		if (saveGameIdx == kSavegameFilePattern)
 			return Common::String::format("%s.###", target); // There is also sav0.mor for slot 0
 		else

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -58,7 +58,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		const Common::String prefix = ConfMan.getDomain(target)->getVal("gameid");
 		if (saveGameIdx == kSavegameFilePattern)
 			return prefix + ".###";

--- a/engines/stark/metaengine.cpp
+++ b/engines/stark/metaengine.cpp
@@ -120,7 +120,7 @@ public:
 
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		if (saveGameIdx == kSavegameFilePattern)
 			return Common::String::format("%s-###.tlj", target);
 		else

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -60,7 +60,7 @@ public:
 
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		if (saveGameIdx == kSavegameFilePattern)
 			return Common::String::format("%s.##", target);
 		else

--- a/engines/touche/metaengine.cpp
+++ b/engines/touche/metaengine.cpp
@@ -41,7 +41,7 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		return Touche::generateGameStateFileName(target, saveGameIdx, saveGameIdx == kSavegameFilePattern);
 	}
 };

--- a/engines/tucker/metaengine.cpp
+++ b/engines/tucker/metaengine.cpp
@@ -147,7 +147,7 @@ public:
 
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
-			target = getEngineId();
+			target = getName();
 		return Tucker::generateGameStateFileName(target, saveGameIdx, saveGameIdx == kSavegameFilePattern);
 	}
 };


### PR DESCRIPTION
`getEngineId()` is only implemented in `MetaEngineDetection` subclasses; in `MetaEngine` subclasses, it always returns `nullptr`. This PR replaces all uses of `getEngineId()` in MetaEngines with `getName()` and removes the default implementation from the base `PluginObject` class.