### PR TITLE
ENGINES: Fix autosave name check

### DIFF
--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -95,7 +95,12 @@ bool SaveStateDescriptor::isAutosave() const {
 
 bool SaveStateDescriptor::hasAutosaveName() const
 {
-	return _description.contains(_("Autosave"));
+	Common::U32String autosave = _("Autosave");
+	if (autosave.size() < 14)
+		return autosave == _description;
+	if (_description.size() < 14)
+		return false;
+	return autosave.substr(0, _description.size()) == _description;
 }
 
 bool SaveStateDescriptor::isValid() const

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -96,6 +96,8 @@ bool SaveStateDescriptor::isAutosave() const {
 bool SaveStateDescriptor::hasAutosaveName() const
 {
 	Common::U32String autosave = _("Autosave");
+	if (_description.size() >= autosave.size())
+		return _description.contains(autosave);
 	if (autosave.size() < 14)
 		return autosave == _description;
 	if (_description.size() < 14)

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -95,7 +95,7 @@ bool SaveStateDescriptor::isAutosave() const {
 
 bool SaveStateDescriptor::hasAutosaveName() const
 {
-	Common::U32String autosave = _("Autosave");
+	const Common::U32String &autosave = _("Autosave");
 	if (_description.size() >= autosave.size())
 		return _description.contains(autosave);
 	if (_description.size() < 14)

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -96,8 +96,12 @@ bool SaveStateDescriptor::isAutosave() const {
 bool SaveStateDescriptor::hasAutosaveName() const
 {
 	const Common::U32String &autosave = _("Autosave");
+
+	// if the save file name is long enough, just check if it starts with "Autosave"
 	if (_description.size() >= autosave.size())
-		return _description.contains(autosave);
+		return _description.substr(0, autosave.size()) == autosave;
+
+	// if the save name has been trimmed, as long as it isn't too short, use fallback logic
 	if (_description.size() < 14)
 		return false;
 	return autosave.substr(0, _description.size()) == _description;

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -98,8 +98,6 @@ bool SaveStateDescriptor::hasAutosaveName() const
 	Common::U32String autosave = _("Autosave");
 	if (_description.size() >= autosave.size())
 		return _description.contains(autosave);
-	if (autosave.size() < 14)
-		return autosave == _description;
 	if (_description.size() < 14)
 		return false;
 	return autosave.substr(0, _description.size()) == _description;


### PR DESCRIPTION
Save names in Groovie are limited to 15 characters, and it's probably not the only engine with a similar limit, I wanted to see if there was any interest in a global fix that could help many engines.

The length of the German translation for Autosave is 23 characters. This meant you would get a warning on every autosave, even though you just told it to overwrite.

I currently have it set to a minimum of 14 characters for confidence that the name is a match and not a false positive, but this could definitely be reduced.