### PR TITLE
AGI: Add support for Mac Manhunter games

### DIFF
--- a/engines/agi/detection.h
+++ b/engines/agi/detection.h
@@ -37,14 +37,14 @@ enum AgiGameID {
 	GID_AGIDEMO,
 	GID_BC,
 	GID_DDP,
-	GID_GOLDRUSH,
+	GID_GOLDRUSH,	// V3
 	GID_KQ1,
 	GID_KQ2,
 	GID_KQ3,
 	GID_KQ4,
 	GID_LSL1,
-	GID_MH1,
-	GID_MH2,
+	GID_MH1,		// V3
+	GID_MH2,		// V3
 	GID_MIXEDUP,
 	GID_PQ1,
 	GID_SQ1,
@@ -65,10 +65,9 @@ enum AgiGameFeatures {
 	GF_AGIMOUSE    = (1 << 0), // this disables "Click-to-walk mouse interface"
 	GF_AGDS        = (1 << 1),
 	GF_AGI256      = (1 << 2), // marks fanmade AGI-256 games
-	GF_MACGOLDRUSH = (1 << 3), // use "grdir" instead of "dir" for volume loading
-	GF_FANMADE     = (1 << 4), // marks fanmade games
-	GF_OLDAMIGAV20 = (1 << 5),
-	GF_2GSOLDSOUND = (1 << 6)
+	GF_FANMADE     = (1 << 3), // marks fanmade games
+	GF_OLDAMIGAV20 = (1 << 4),
+	GF_2GSOLDSOUND = (1 << 5)
 };
 
 enum BooterDisks {

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -368,7 +368,7 @@ static const AGIGameDescription gameDescriptions[] = {
 		},
 		GID_GOLDRUSH,
 		GType_V3,
-		GF_MACGOLDRUSH,
+		0,
 		0x3149
 	},
 
@@ -609,10 +609,10 @@ static const AGIGameDescription gameDescriptions[] = {
 	GAME_PS("mh1", "updated", "d47da950c62289f8d4ccf36af73365f2", 495, 0x2440, GID_MH1, Common::kPlatformCoCo3),
 
 	{
-		// Manhunter NY (Mac) 1.22 7.21/89 [AGI 2.917]
+		// Manhunter NY (Mac) 1.22 8/31/88
 		{
 			"mh1",
-			"1.22 1989-07-21",
+			"1.22 1988-08-31",
 			AD_ENTRY2s("mhdir",	"0c7b86f05fe02c2e26cff1b07450b82a", 2123,
 					   "vol.0", "338d7053d8cf08b517edebad2807975d", 115078),
 			Common::EN_ANY,
@@ -621,9 +621,9 @@ static const AGIGameDescription gameDescriptions[] = {
 			GAMEOPTIONS_DEFAULT
 		},
 		GID_MH1,
-		GType_V2,
+		GType_V3,
 		0,
-		0x2917
+		0x3149
 	},
 
 	// Manhunter SF (ST) 1.0 7/29/89
@@ -642,10 +642,10 @@ static const AGIGameDescription gameDescriptions[] = {
 	GAME3("mh2", "3.03 1989-08-17 5.25\"", "mh2dir", "b90e4795413c43de469a715fb3c1fa93", 0x3149, GID_MH2),
 
 	{
-		// Manhunter SF (Mac) 1.81 10/23/89 [AGI 2.917]
+		// Manhunter SF (Mac) 3.03 10/23/89
 		{
 			"mh2",
-			"1.81 1989-10-23",
+			"3.03 1989-10-23",
 			AD_ENTRY2s("mh2dir", "b90e4795413c43de469a715fb3c1fa93", 2588,
 					   "vol.0", "b174bcf485bc348eae77782f9da4143e", 115338),
 			Common::EN_ANY,
@@ -654,9 +654,9 @@ static const AGIGameDescription gameDescriptions[] = {
 			GAMEOPTIONS_DEFAULT
 		},
 		GID_MH1,
-		GType_V2,
+		GType_V3,
 		0,
-		0x2917
+		0x3149
 	},
 
 	// Manhunter SF (CoCo3 720k) [AGI 2.023]

--- a/engines/agi/loader_v3.cpp
+++ b/engines/agi/loader_v3.cpp
@@ -46,9 +46,9 @@ int AgiLoader_v3::detectGame() {
 		Common::String f = file->getName();
 		f.toLowercase();
 
-		if (f.hasSuffix("vol.0")) {
+		if (f.hasSuffix("dir")) {
 			memset(_vm->_game.name, 0, 8);
-			strncpy(_vm->_game.name, f.c_str(), MIN((uint)8, f.size() > 5 ? f.size() - 5 : f.size()));
+			strncpy(_vm->_game.name, f.c_str(), MIN((uint)6, f.size() > 3 ? f.size() - 3 : f.size()));
 			debugC(3, kDebugLevelMain, "game.name = %s", _vm->_game.name);
 
 			ec = errOK;
@@ -110,9 +110,6 @@ int AgiLoader_v3::init() {
 
 	if (_vm->getPlatform() == Common::kPlatformAmiga) {
 		path = Common::String("dirs");
-		_vm->_game.name[0] = 0; // Empty prefix
-	} else if (_vm->getFeatures() & GF_MACGOLDRUSH) {
-		path = "grdir";
 		_vm->_game.name[0] = 0; // Empty prefix
 	} else {
 		path = Common::String(_vm->_game.name) + DIR_;
@@ -206,7 +203,11 @@ uint8 *AgiLoader_v3::loadVolRes(AgiDir *agid) {
 	Common::String path;
 
 	debugC(3, kDebugLevelResources, "(%p)", (void *)agid);
-	path = Common::String::format("%svol.%i", _vm->_game.name, agid->volume);
+	if (_vm->getPlatform() == Common::kPlatformMacintosh) {
+		path = Common::String::format("vol.%i", agid->volume);
+	} else {
+		path = Common::String::format("%svol.%i", _vm->_game.name, agid->volume);
+	}
 
 	if (agid->offset != _EMPTY && fp.open(path)) {
 		fp.seek(agid->offset, SEEK_SET);


### PR DESCRIPTION
Includes a change to how Mac data files are loaded for three games: Gold Rush and both Manhunter games - all AGI version 3.

I've tested this for all three games and all platforms: Amiga, Atari ST, DOS, Mac, Apple IIgs and Tandy CoCo 3. Testing involved detecting the game files, starting the game, playing the first couple screens, **restarting** the game, and quitting. Restart was tested because the resources are reloaded on restart.

I also tested the same on the fanmade V: The Graphic Adventure.

Everything seems to work fine. The ST version of MH1 hangs on startup for me, but that happens in the ScummVM 2.5.1 release as well (it's possible that I dumped the disk incorrectly). And the CoCo3 V3 games don't work yet anyway. That's a project for another day.