### PR TITLE
JANITORIAL: Force LF EOL for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 *.cpp text eol=lf
 *.h text eol=lf
 *.hpp text eol=lf
+*.sh text eol=lf
+/config* text eol=lf
+configure.engine text eol=lf


### PR DESCRIPTION
Needed when core.autocrlf is set on Windows, and building with WSL.
