### PR TITLE
ENGINES: Fix GCC warnings

### DIFF
--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -562,7 +562,7 @@ public:
 	/**
 	 * Read the extended savegame header from the given savegame file.
 	 */
-	static WARN_UNUSED_RESULT bool readSavegameHeader(Common::InSaveFile *in, ExtendedSavegameHeader *header, bool skipThumbnail = true);
+	WARN_UNUSED_RESULT static bool readSavegameHeader(Common::InSaveFile *in, ExtendedSavegameHeader *header, bool skipThumbnail = true);
 };
 
 /**


### PR DESCRIPTION
```
In file included from C:/Projects/scummvm/common/array.h:25,
                 from C:/Projects/scummvm/common/achievements.h:25,
                 from C:/Projects/scummvm/engines/metaengine.h:25,
                 from C:/Projects/scummvm/engines/advancedDetector.h:25,
                 from C:/Projects/scummvm/engines/sci/detection.cpp:22:
C:/Projects/scummvm/common/scummsys.h:400:44: warning: attribute ignored [-Wattributes]
  400 |                 #define WARN_UNUSED_RESULT [[nodiscard]]
      |                                            ^
C:/Projects/scummvm/engines/metaengine.h:565:16: note: in expansion of macro 'WARN_UNUSED_RESULT'
  565 |         static WARN_UNUSED_RESULT bool readSavegameHeader(Common::InSaveFile *in, ExtendedSavegameHeader *header, bool skipThumbnail = true);
      |                ^~~~~~~~~~~~~~~~~~
C:/Projects/scummvm/common/scummsys.h:400:44: note: an attribute that appertains to a type-specifier is ignored
  400 |                 #define WARN_UNUSED_RESULT [[nodiscard]]
      |                                            ^
C:/Projects/scummvm/engines/metaengine.h:565:16: note: in expansion of macro 'WARN_UNUSED_RESULT'
  565 |         static WARN_UNUSED_RESULT bool readSavegameHeader(Common::InSaveFile *in, ExtendedSavegameHeader *header, bool skipThumbnail = true);
      |                ^~~~~~~~~~~~~~~~~~
```