### PR TITLE
DEVTOOLS: Bump minimum cmake version to 3.13

### DIFF
--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -76,7 +76,7 @@ void CMakeProvider::createWorkspace(const BuildSetup &setup) {
 	if (!workspace || !workspace.is_open())
 		error("Could not open \"" + filename + "\" for writing");
 
-	workspace << "cmake_minimum_required(VERSION 3.2)\n";
+	workspace << "cmake_minimum_required(VERSION 3.13)\n";
 	workspace << "project(" << setup.projectDescription << ")\n\n";
 
 	workspace << "set(CMAKE_EXPORT_COMPILE_COMMANDS ON)\n";


### PR DESCRIPTION
This mutes the following warning:
```
CMake Warning (dev) at CMakeLists.txt:1581 (target_sources):
  Policy CMP0076 is not set: target_sources() command converts relative paths
  to absolute.  Run "cmake --help-policy CMP0076" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

  An interface source of target "scummvm" has a relative path.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
