### PR TITLE
SHERLOCK: Some more Serrated Scalpel fixes

### DIFF
--- a/engines/sherlock/scalpel/scalpel_talk.cpp
+++ b/engines/sherlock/scalpel/scalpel_talk.cpp
@@ -186,10 +186,11 @@ void ScalpelTalk::talkTo(const Common::String filename) {
 		// WORKAROUND: Original game bug causes the results of testing the powdery substance
 		// to disappear too quickly. Introduce a delay to allow it to be properly displayed
 		ui._menuCounter = 30;
-	} else if (filename == "Lesl24z.tlk") {
-		// WORKAROUND: Walking to the flower girl the first time triggers
-		// this automatic talk. This should abort any other action, such
-		// as trying to look at her, else the UI gets corrupted
+	} else if (filename == "Lesl24z.tlk" || filename == "Beal40y.tlk") {
+		// WORKAROUND: Walking to the flower girl or housekeeper the
+		// first time triggers this automatic talk. This should abort
+		// any other action, such as trying to look at her, else the UI
+		// gets corrupted
 		_talkToAbort = true;
 	}
 }

--- a/engines/sherlock/scalpel/scalpel_user_interface.cpp
+++ b/engines/sherlock/scalpel/scalpel_user_interface.cpp
@@ -533,6 +533,13 @@ void ScalpelUserInterface::examine() {
 	Talk &talk = *_vm->_talk;
 	Common::Point pt = events.mousePos();
 
+	if (_invLookFlag) {
+		// Don't close the inventory window when starting an examine display, since its
+		// window will slide up to replace the inventory display
+		_windowOpen = false;
+		_menuMode = LOOK_MODE;
+	}
+
 	if (pt.y < (CONTROLS_Y + 9)) {
 		Object &obj = scene._bgShapes[_bgFound];
 
@@ -558,13 +565,6 @@ void ScalpelUserInterface::examine() {
 		_cAnimStr = inv[_selector]._examine;
 		if (inv[_selector]._lookFlag)
 			_vm->setFlags(inv[_selector]._lookFlag);
-	}
-
-	if (_invLookFlag) {
-		// Don't close the inventory window when starting an examine display, since its
-		// window will slide up to replace the inventory display
-		_windowOpen = false;
-		_menuMode = LOOK_MODE;
 	}
 
 	if (!talk._talkToAbort) {


### PR DESCRIPTION
At the time of writing, this pull request contains two fixes, and I really hope that's the end of it.

The first one is an attempt at fixing https://bugs.scummvm.org/ticket/13195 which is a bug that I can reproduce with the original interpreter as well. The game's UI would get stuck in the wrong state. If I understand things correctly, it will happen when you have e.g. the inventory window open and then examine an object in the room that has a custom examination animation. The example used in the bug report is the corpse at the crime scene, which has Holmes bending down to get a closer look.

Normally, it would fix the UI mode in examine(), but that only happens for objects that _don't_ have an examination animation. So I've simply moved that piece of code to apply to both cases.

I have played through the entire game with this fix, and didn't notice any regressions. (This time, I played a small installation of the game since we had a bad regression for that recently. In my earlier playthrough and bug hunts I used a large installation.)

The second fix is for a bug I couldn't reproduce in the original. It happened when examining the housekeeper at Anna's flat. This would automatically move Holmes close to her, which would trigger a conversation. But it would still go on trying to print the description of the housekeeper, which messed up the UI. I'm stumped on why it doesn't happen in the original, but DreamMaster pointed out that we already have a workaround for a similar problem in another scene. I've simply extended it to cover the housekeeper as well.

I didn't restart my playthrough, so I've only played the game with this fix from the point where the bug happened. But I don't see how it could possibly cause regressions elsewhere.

So I'd say both changes should be in good shape for merging.