### PR TITLE
NGI: Fix Inconsistent character state (bug #9669)

### DIFF
--- a/engines/ngi/fullpipe/scene32.cpp
+++ b/engines/ngi/fullpipe/scene32.cpp
@@ -91,7 +91,14 @@ void scene32_initScene(Scene *sc) {
 
 	g_nmi->initArcadeKeys("SC_32");
 
-	warning("cactus: %d, state: %d", g_nmi->getObjectState(sO_Cactus), g_vars->scene32_cactus->_statics->_staticsId);
+	if (g_nmi->getObjectState(sO_Cactus) == g_nmi->getObjectEnumState(sO_Cactus, sO_HasGrown)) {
+		g_nmi->_currentScene = sc;
+
+		g_vars->scene32_cactus->changeStatics2(ST_CTS_GROWUP);
+		g_vars->scene32_cactus->_priority = 22;
+
+		g_nmi->_currentScene = oldsc;
+	}
 }
 
 void scene32_setupMusic() {


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
Implemented Cactus HasGrown check in scene32.cpp which resolves [#9669](https://bugs.scummvm.org/ticket/9669)