### PR TITLE
SKY: Fix saving names for non selected save slots

### DIFF
--- a/engines/sky/control.cpp
+++ b/engines/sky/control.cpp
@@ -1141,6 +1141,10 @@ bool Control::loadSaveAllowed() {
 	return true;
 }
 
+bool Control::isControlPanelOpen() {
+	return _controlPanel;
+}
+
 int Control::displayMessage(const char *altButton, const char *message, ...) {
 	char buf[STRINGBUFLEN];
 	va_list va;

--- a/engines/sky/control.h
+++ b/engines/sky/control.h
@@ -226,7 +226,7 @@ private:
 	void drawCross(uint16 x, uint16 y);
 
 	uint16 saveRestorePanel(bool allowSave);
-	void setUpGameSprites(const Common::StringArray &saveGameNames, DataFileHeader **nameSprites, uint16 firstNum, uint16 selectedGame);
+	void setUpGameSprites(const Common::StringArray &saveGameNames, DataFileHeader **nameSprites, uint16 firstNum, uint16 selectedGame, const Common::String &dirtyString);
 	void showSprites(DataFileHeader **nameSprites, bool allowSave);
 	void handleKeyPress(Common::KeyState kbd, Common::String &textBuf);
 

--- a/engines/sky/control.h
+++ b/engines/sky/control.h
@@ -187,6 +187,7 @@ public:
 	void showGameQuitMsg();
 	uint16 quickXRestore(uint16 slot);
 	bool loadSaveAllowed();
+	bool isControlPanelOpen();
 
 	SkyEngine *_vm;
 

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -356,11 +356,15 @@ Common::Error SkyEngine::saveGameState(int slot, const Common::String &desc, boo
 }
 
 bool SkyEngine::canLoadGameStateCurrently() {
-	return _systemVars->pastIntro && _skyControl->loadSaveAllowed();
+	return _systemVars->pastIntro
+	    && _skyControl->loadSaveAllowed()
+	    && !_skyControl->isControlPanelOpen();
 }
 
 bool SkyEngine::canSaveGameStateCurrently() {
-	return _systemVars->pastIntro && _skyControl->loadSaveAllowed();
+	return _systemVars->pastIntro
+	    && _skyControl->loadSaveAllowed()
+	    && !_skyControl->isControlPanelOpen();
 }
 
 } // End of namespace Sky


### PR DESCRIPTION
Fix for bug #13218 "Can Populate More Than One Save Slot At A Time"

We use a dirty string buffer to temporary store the edited text for the selected slot

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
