### PR TITLE
COMMON: Fix BufferedWriteStream::pos() method

### DIFF
--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -550,7 +550,7 @@ public:
 
 	bool flush() override { return flushBuffer(); }
 
-	int64 pos() const override { return _pos; }
+	int64 pos() const override { return _pos + _parentStream->pos(); }
 
 	bool seek(int64 offset, int whence) override {
 		flush();


### PR DESCRIPTION
The pos() method of BufferedWriteStream should return the stream position
but actually returns the buffer position. That completely breaks saving
the game in AGS engine on the platforms using BufferedWriteStream wrapper
for savefile handling, such as Nintendo Switch. AGS engine's save file
writing functions use GetPosition() with later Seek() on stream,
so an invalid return value from GetPosition() results in invalid save files
that cannot be loaded and are skipped by the engine.