### PR TITLE
COMMON: Moved Node struct from private to public in HashMap

### DIFF
--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -88,16 +88,16 @@ class HashMap {
 public:
 	typedef uint size_type;
 
-private:
-
-	typedef HashMap<Key, Val, HashFunc, EqualFunc> HM_t;
-
 	struct Node {
 		Val _value;
 		const Key _key;
 		explicit Node(const Key &key) : _key(key), _value() {}
 		Node() : _key(), _value() {}
 	};
+
+private:
+
+	typedef HashMap<Key, Val, HashFunc, EqualFunc> HM_t;
 
 	enum {
 		HASHMAP_PERTURB_SHIFT = 5,


### PR DESCRIPTION
Moved Node Struct from private to public in HashMap container so that it can be used with Common::find_if from algorithm.h. 

At the moment it is possible to use find_if when iterating through other containers (e.g. Common::Array) because the type contained is typically public. However, attempting to do this with a Hashmap requires the use of the inner Node struct as part of the lambda or function object signature when it is passed to find_if as a predicate.

Using a range based for loop works in C++11, which is required to use lambdas, but this alternative would not be possible for code bases still relying on earlier versions of C++ where a function object would be used.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
