### PR TITLE
IMAGE: Add 16 bitmap support to raw decoder

### DIFF
--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -96,12 +96,18 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	/* uint16 planes = */ stream.readUint16LE();
 	uint16 bitsPerPixel = stream.readUint16LE();
 
-	if (bitsPerPixel != 4 && bitsPerPixel != 8 && bitsPerPixel != 24 && bitsPerPixel != 32) {
+	if (bitsPerPixel != 4 && bitsPerPixel != 8 && bitsPerPixel != 16 && bitsPerPixel != 24 && bitsPerPixel != 32) {
 		warning("%dbpp bitmaps not supported", bitsPerPixel);
 		return false;
 	}
 
 	uint32 compression = stream.readUint32BE();
+
+	if (bitsPerPixel == 16 && compression != SWAP_CONSTANT_32(0)) {
+		warning("only RGB555 raw mode supported for %dbpp bitmaps", bitsPerPixel);
+		return false;
+	}
+
 	uint32 imageSize = stream.readUint32LE();
 	/* uint32 pixelsPerMeterX = */ stream.readUint32LE();
 	/* uint32 pixelsPerMeterY = */ stream.readUint32LE();

--- a/image/codecs/bmp_raw.cpp
+++ b/image/codecs/bmp_raw.cpp
@@ -91,6 +91,20 @@ const Graphics::Surface *BitmapRawDecoder::decodeFrame(Common::SeekableReadStrea
 			stream.read(dst + (_flip ? i : _height - i - 1) * _width, _width);
 			stream.skip(extraDataLength);
 		}
+	} else if (_bitsPerPixel == 16) {
+		byte *dst = (byte *)_surface.getBasePtr(0, _height - 1);
+
+		for (int i = 0; i < _height; i++) {
+			for (int j = 0; j < _width; j++) {
+				uint16 color = stream.readUint16LE();
+
+				*(uint16 *)dst = color;
+				dst += format.bytesPerPixel;
+			}
+
+			stream.skip(extraDataLength);
+			dst -= _surface.pitch * 2;
+		}
 	} else if (_bitsPerPixel == 24) {
 		byte *dst = (byte *)_surface.getBasePtr(0, _height - 1);
 
@@ -144,6 +158,8 @@ Graphics::PixelFormat BitmapRawDecoder::getPixelFormat() const {
 	case 4:
 	case 8:
 		return Graphics::PixelFormat::createFormatCLUT8();
+	case 16:
+		return Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0);
 	case 24:
 	case 32:
 		return Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);


### PR DESCRIPTION
Added support for 16 bit bitmap images (using RGB555 format). Implemented according to the algorithm documented in the link below:

https://docs.microsoft.com/en-us/windows/win32/directshow/working-with-16-bit-rgb

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
