### PR TITLE
AMIGAOS: Let user choose the OpenGL implementation

### DIFF
--- a/backends/graphics3d/opengl/framebuffer.cpp
+++ b/backends/graphics3d/opengl/framebuffer.cpp
@@ -22,7 +22,7 @@
 #include "common/textconsole.h"
 #include "common/util.h"
 
-#if (defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)) && !defined(AMIGAOS) && !defined(__MORPHOS__)
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 #include "backends/graphics3d/opengl/framebuffer.h"
 
@@ -124,7 +124,7 @@ void FrameBuffer::detach() {
 	glViewport(_prevStateViewport[0], _prevStateViewport[1], _prevStateViewport[2], _prevStateViewport[3]);
 }
 
-#if !USE_FORCED_GLES2 && !defined(AMIGAOS) && !defined(__MORPHOS__)
+#if !USE_FORCED_GLES2
 MultiSampleFrameBuffer::MultiSampleFrameBuffer(uint width, uint height, int samples)
 		: FrameBuffer(width,height) {
 	if (!OpenGLContext.framebufferObjectMultisampleSupported) {
@@ -186,7 +186,7 @@ void MultiSampleFrameBuffer::detach() {
 	glViewport(_prevStateViewport[0], _prevStateViewport[1], _prevStateViewport[2], _prevStateViewport[3]);
 }
 
-#endif // !USE_FORCED_GLES2 && !defined(AMIGAOS) && !defined(__MORPHOS__)
+#endif // !USE_FORCED_GLES2
 
 } // End of namespace OpenGL
 

--- a/backends/graphics3d/opengl/framebuffer.h
+++ b/backends/graphics3d/opengl/framebuffer.h
@@ -34,17 +34,10 @@ class FrameBuffer : public TextureGL {
 public:
 	FrameBuffer(uint width, uint height);
 	FrameBuffer(GLuint texture_name, uint width, uint height, uint texture_width, uint texture_height);
-#if defined(AMIGAOS) || defined(__MORPHOS__)
-	virtual ~FrameBuffer() {}
-
-	void attach() {}
-	void detach() {}
-#else
 	virtual ~FrameBuffer();
 
 	virtual void attach();
 	virtual void detach();
-#endif
 
 protected:
 	GLuint getFrameBufferName() const { return _frameBuffer; }
@@ -56,7 +49,7 @@ private:
 	GLint _prevStateViewport[4];
 };
 
-#if !USE_FORCED_GLES2 && !defined(AMIGAOS) && !defined(__MORPHOS__)
+#if !USE_FORCED_GLES2
 class MultiSampleFrameBuffer : public FrameBuffer {
 public:
 	MultiSampleFrameBuffer(uint width, uint height, int samples);

--- a/backends/graphics3d/opengl/surfacerenderer.cpp
+++ b/backends/graphics3d/opengl/surfacerenderer.cpp
@@ -178,14 +178,23 @@ static const char *boxVertex =
 	"uniform vec2 offsetXY;\n"
 	"uniform vec2 sizeWH;\n"
 	"uniform vec2 texcrop;\n"
+// OGLES2 on AmigaOS doesn't support uniform booleans
+#if defined(AMIGAOS)
+	"uniform mediump int flipY;\n"
+#else
 	"uniform bool flipY;\n"
+#endif
 	"varying vec2 Texcoord;\n"
 	"void main() {\n"
 		"Texcoord = texcoord * texcrop;\n"
 		"vec2 pos = offsetXY + position * sizeWH;\n"
 		"pos.x = pos.x * 2.0 - 1.0;\n"
 		"pos.y = pos.y * 2.0 - 1.0;\n"
+#if defined(AMIGAOS)
+		"if (flipY != 0)\n"
+#else
 		"if (flipY)\n"
+#endif
 			"pos.y *= -1.0;\n"
 		"gl_Position = vec4(pos, 0.0, 1.0);\n"
 	"}\n";

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -356,13 +356,11 @@ void OpenGLSdlGraphics3dManager::createOrUpdateScreen() {
 
 	_screenChangeCount++;
 
-#if !defined(__amigaos4__) && !defined(__MORPHOS__)
 	if (renderToFrameBuffer) {
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 		_frameBuffer = createFramebuffer(_engineRequestedWidth, _engineRequestedHeight);
 		_frameBuffer->attach();
 	}
-#endif
 }
 
 Math::Rect2d OpenGLSdlGraphics3dManager::computeGameRect(bool renderToFrameBuffer, uint gameWidth, uint gameHeight,
@@ -579,7 +577,6 @@ void OpenGLSdlGraphics3dManager::drawOverlay() {
 	_surfaceRenderer->restorePreviousState();
 }
 
-#if !defined(__amigaos4__) && !defined(__MORPHOS__)
 OpenGL::FrameBuffer *OpenGLSdlGraphics3dManager::createFramebuffer(uint width, uint height) {
 #if !USE_FORCED_GLES2
 	if (_antialiasing && OpenGLContext.framebufferObjectMultisampleSupported) {
@@ -590,7 +587,6 @@ OpenGL::FrameBuffer *OpenGLSdlGraphics3dManager::createFramebuffer(uint width, u
 		return new OpenGL::FrameBuffer(width, height);
 	}
 }
-#endif
 
 void OpenGLSdlGraphics3dManager::updateScreen() {
 	if (_frameBuffer) {

--- a/backends/platform/sdl/amigaos/amigaos.cpp
+++ b/backends/platform/sdl/amigaos/amigaos.cpp
@@ -47,4 +47,58 @@ bool OSystem_AmigaOS::hasFeature(Feature f) {
 
 	return OSystem_SDL::hasFeature(f);
 }
+
+void OSystem_AmigaOS::initBackend() {
+	// AmigaOS4 SDL provides two OpenGL implementations (OpenGL 1.3 with miniGL and OpenGL ES with OGLES2)
+	// This is chosen by setting the profile mask attribute before the first window creation but after init
+	int force = 0;
+	if (ConfMan.hasKey("opengl_implementation")) {
+		Common::String implem = ConfMan.get("opengl_implementation");
+		if (implem == "gl") {
+			force = 1;;
+		} else if (implem == "gles2") {
+			force = 2;
+		}
+	}
+
+	// If not forcing, try OGLES2 first
+	if (!force || force == 2) {
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+		if (SDL_GL_LoadLibrary(NULL) < 0) {
+			if (force) {
+				warning("OpenGL implementation chosen is unsupported, falling back");
+				force = 0;
+			}
+			// SDL doesn't seem to be clean when loading fail
+			SDL_GL_UnloadLibrary();
+			SDL_GL_ResetAttributes();
+		} else {
+			// Loading succeeded, don't try anything more
+			force = 2;
+		}
+	}
+	// If not forcing, next try miniGL
+	if (!force || force == 1) {
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+		if (SDL_GL_LoadLibrary(NULL) < 0) {
+			if (force) {
+				warning("OpenGL implementation chosen is unsupported, falling back");
+				force = 0;
+			}
+			// SDL doesn't seem to be clean when loading fail
+			SDL_GL_UnloadLibrary();
+			SDL_GL_ResetAttributes();
+		} else {
+			// Loading succeeded, don't try anything more
+			force = 1;
+		}
+	}
+
+	OSystem_SDL::initBackend();
+}
+
 #endif

--- a/backends/platform/sdl/amigaos/amigaos.h
+++ b/backends/platform/sdl/amigaos/amigaos.h
@@ -32,6 +32,7 @@ public:
 	bool hasFeature(Feature f) override;
 
 	void init() override;
+	void initBackend() override;
 };
 
 #endif

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -41,6 +41,10 @@ ifdef DIST_FILES_THEMES
 	makedir all $(AMIGAOSPATH)/themes
 	cp $(DIST_FILES_THEMES) $(AMIGAOSPATH)/themes
 endif
+ifneq ($(DIST_FILES_SHADERS),)
+	makedir all $(AMIGAOSPATH)/shaders
+	cp $(DIST_FILES_SHADERS) $(AMIGAOSPATH)/shaders
+endif
 	# Strip and copy engine plugins.
 ifdef DYNAMIC_MODULES
 	makedir all $(AMIGAOSPATH)/plugins

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -328,7 +328,7 @@ void OSystem_SDL::detectOpenGLFeaturesSupport() {
 	_oglType = OpenGL::kOGLContextGLES2;
 	_supportsFrameBuffer = true;
 	_supportsShaders = true;
-#elif !defined(AMIGAOS) && !defined(__MORPHOS__)
+#else
 	// Spawn a 32x32 window off-screen with a GL context to test if framebuffers are supported
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_Window *window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 32, 32, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);

--- a/engines/grim/shaders/emi_actor.fragment
+++ b/engines/grim/shaders/emi_actor.fragment
@@ -2,7 +2,7 @@ in vec2 Texcoord;
 in vec4 Color;
 
 uniform sampler2D tex;
-uniform bool textured;
+uniform UBOOL textured;
 uniform float alphaRef;
 uniform float meshAlpha;
 
@@ -11,7 +11,7 @@ OUTPUT
 void main()
 {
 	outColor = Color;
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		vec4 texColor = texture(tex, Texcoord);
 		outColor.rgba *= texColor.rgba;
 		outColor.a *= meshAlpha;

--- a/engines/grim/shaders/emi_actor.vertex
+++ b/engines/grim/shaders/emi_actor.vertex
@@ -9,12 +9,12 @@ uniform highp mat4 projMatrix;
 uniform highp mat4 extraMatrix;
 uniform highp mat4 normalMatrix;
 uniform highp vec3 cameraPos;
-uniform bool textured;
-uniform bool useVertexAlpha;
+uniform UBOOL textured;
+uniform UBOOL useVertexAlpha;
 uniform vec4 uniformColor;
 
 struct shadow_info {
-	bool _active;
+	UBOOL _active;
 	vec3 _color;
 	vec3 _light;
 	vec3 _point;
@@ -32,7 +32,7 @@ void main()
 	pos = modelMatrix * pos;
 
 	// See http://en.wikipedia.org/wiki/Line-plane_intersection
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		pos /= pos.w;
 		vec3 l = pos.xyz - shadow._light;
 		float d = dot(shadow._point - shadow._light, shadow._normal) / dot(l, shadow._normal);
@@ -49,15 +49,15 @@ void main()
 
 	gl_Position = projectedPos;
 
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		Color = vec4(shadow._color, 1.0);
 	} else {
 		Color = color;
 	}
-	if (!useVertexAlpha)
+	if (!UBOOL_TEST(useVertexAlpha))
 		Color.a = 1.0;
 	Color *= uniformColor;
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		Texcoord = texcoord;
 	} else {
 		Texcoord = vec2(0.0, 0.0);

--- a/engines/grim/shaders/emi_actorlights.fragment
+++ b/engines/grim/shaders/emi_actorlights.fragment
@@ -2,7 +2,7 @@ in vec2 Texcoord;
 in vec4 Color;
 
 uniform sampler2D tex;
-uniform bool textured;
+uniform UBOOL textured;
 uniform float alphaRef;
 uniform float meshAlpha;
 
@@ -11,7 +11,7 @@ OUTPUT
 void main()
 {
 	outColor = Color;
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		vec4 texColor = texture(tex, Texcoord);
 		outColor.rgba *= texColor.rgba;
 		outColor.a *= meshAlpha;

--- a/engines/grim/shaders/emi_actorlights.vertex
+++ b/engines/grim/shaders/emi_actorlights.vertex
@@ -9,10 +9,10 @@ uniform highp mat4 projMatrix;
 uniform highp mat4 extraMatrix;
 uniform highp mat4 normalMatrix;
 uniform highp vec3 cameraPos;
-uniform bool textured;
-uniform bool useVertexAlpha;
+uniform UBOOL textured;
+uniform UBOOL useVertexAlpha;
 uniform vec4 uniformColor;
-uniform bool hasAmbient;
+uniform UBOOL hasAmbient;
 
 const int maxLights = 8;
 uniform vec4 lightsPosition[maxLights];
@@ -21,7 +21,7 @@ uniform vec4 lightsColor[maxLights];
 uniform vec4 lightsParams[maxLights];
 
 struct shadow_info {
-	bool _active;
+	UBOOL _active;
 	vec3 _color;
 	vec3 _light;
 	vec3 _point;
@@ -39,7 +39,7 @@ void main()
 	pos = modelMatrix * pos;
 
 	// See http://en.wikipedia.org/wiki/Line-plane_intersection
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		pos /= pos.w;
 		vec3 l = pos.xyz - shadow._light;
 		float d = dot(shadow._point - shadow._light, shadow._normal) / dot(l, shadow._normal);
@@ -56,15 +56,15 @@ void main()
 
 	gl_Position = projectedPos;
 
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		Color = vec4(shadow._color, 1.0);
 	} else {
 		Color = color;
 	}
-	if (!useVertexAlpha)
+	if (!UBOOL_TEST(useVertexAlpha))
 		Color.a = 1.0;
 	Color *= uniformColor;
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		Texcoord = texcoord;
 	} else {
 		Texcoord = vec2(0.0, 0.0);
@@ -109,7 +109,7 @@ void main()
 		light += lightsColor[i].xyz * intensity;
 	}
 
-	if (!hasAmbient)
+	if (!UBOOL_TEST(hasAmbient))
 		light += vec3(0.5, 0.5, 0.5);
 	light /= max(1.0, max(max(light.x, light.y), light.z));
 	Color *= vec4(light, 1.0);

--- a/engines/grim/shaders/emi_sprite.fragment
+++ b/engines/grim/shaders/emi_sprite.fragment
@@ -2,7 +2,7 @@ in vec2 Texcoord;
 in vec4 Color;
 
 uniform sampler2D tex;
-uniform bool textured;
+uniform UBOOL textured;
 uniform float alphaRef;
 uniform float meshAlpha;
 
@@ -11,7 +11,7 @@ OUTPUT
 void main()
 {
 	outColor = Color;
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		vec4 texColor = texture(tex, Texcoord);
 		outColor.rgba *= texColor.rgba;
 		outColor.a *= meshAlpha;

--- a/engines/grim/shaders/emi_sprite.vertex
+++ b/engines/grim/shaders/emi_sprite.vertex
@@ -9,12 +9,12 @@ uniform highp mat4 projMatrix;
 uniform highp mat4 extraMatrix;
 uniform highp mat4 normalMatrix;
 uniform highp vec3 cameraPos;
-uniform bool textured;
-uniform bool useVertexAlpha;
+uniform UBOOL textured;
+uniform UBOOL useVertexAlpha;
 uniform vec4 uniformColor;
 
 struct shadow_info {
-	bool _active;
+	UBOOL _active;
 	vec3 _color;
 	vec3 _light;
 	vec3 _point;
@@ -43,15 +43,15 @@ void main()
 
 	gl_Position = projectedPos;
 
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		Color = vec4(shadow._color, 1.0);
 	} else {
 		Color = color;
 	}
-	if (!useVertexAlpha)
+	if (!UBOOL_TEST(useVertexAlpha))
 		Color.a = 1.0;
 	Color *= uniformColor;
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		Texcoord = texcoord;
 	} else {
 		Texcoord = vec2(0.0, 0.0);

--- a/engines/grim/shaders/grim_actor.fragment
+++ b/engines/grim/shaders/grim_actor.fragment
@@ -3,8 +3,8 @@ in vec4 Color;
 
 uniform sampler2D tex;
 uniform sampler2D texZBuf;
-uniform bool textured;
-uniform bool hasZBuffer;
+uniform UBOOL textured;
+uniform UBOOL hasZBuffer;
 uniform vec2 texcropZBuf;
 uniform vec2 screenSize;
 uniform float alphaRef;
@@ -35,10 +35,10 @@ void checkZBuffer()
 
 void main()
 {
-	if (hasZBuffer)
+	if (UBOOL_TEST(hasZBuffer))
 		checkZBuffer();
 	outColor = Color;
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		outColor *= texture(tex, Texcoord);
 	}
 

--- a/engines/grim/shaders/grim_actor.vertex
+++ b/engines/grim/shaders/grim_actor.vertex
@@ -11,12 +11,12 @@ uniform highp mat4 modelMatrix;
 uniform highp mat4 viewMatrix;
 uniform highp mat4 projMatrix;
 uniform highp mat4 extraMatrix;
-uniform bool textured;
-uniform bool lightsEnabled;
+uniform UBOOL textured;
+uniform UBOOL lightsEnabled;
 uniform highp vec2 texScale;
 
 struct shadow_info {
-	bool _active;
+	UBOOL _active;
 	vec3 _color;
 	vec3 _light;
 	vec3 _point;
@@ -33,7 +33,7 @@ void main()
 	vec4 pos = modelMatrix * extraMatrix * vec4(position, 1.0);
 
 	// See http://en.wikipedia.org/wiki/Line-plane_intersection
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		pos /= pos.w;
 		vec3 l = pos.xyz - shadow._light;
 		float d = dot(shadow._point - shadow._light, shadow._normal) / dot(l, shadow._normal);
@@ -44,13 +44,13 @@ void main()
 	vec4 positionView = viewMatrix * pos;
 	gl_Position = projMatrix * positionView;
 
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		Color = vec4(shadow._color, 1.0);
 	} else {
 		Color = color;
 	}
 
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		Texcoord = vec2(0.0, 1.0) + (texcoord / texScale);
 	} else {
 		Texcoord = vec2(0.0, 0.0);

--- a/engines/grim/shaders/grim_actorlights.fragment
+++ b/engines/grim/shaders/grim_actorlights.fragment
@@ -3,8 +3,8 @@ in vec4 Color;
 
 uniform sampler2D tex;
 uniform sampler2D texZBuf;
-uniform bool textured;
-uniform bool hasZBuffer;
+uniform UBOOL textured;
+uniform UBOOL hasZBuffer;
 uniform vec2 texcropZBuf;
 uniform vec2 screenSize;
 uniform float alphaRef;
@@ -35,10 +35,10 @@ void checkZBuffer()
 
 void main()
 {
-	if (hasZBuffer)
+	if (UBOOL_TEST(hasZBuffer))
 		checkZBuffer();
 	outColor = Color;
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		outColor *= texture(tex, Texcoord);
 	}
 

--- a/engines/grim/shaders/grim_actorlights.vertex
+++ b/engines/grim/shaders/grim_actorlights.vertex
@@ -11,8 +11,8 @@ uniform highp mat4 modelMatrix;
 uniform highp mat4 viewMatrix;
 uniform highp mat4 projMatrix;
 uniform highp mat4 extraMatrix;
-uniform bool textured;
-uniform bool lightsEnabled;
+uniform UBOOL textured;
+uniform UBOOL lightsEnabled;
 uniform highp vec2 texScale;
 
 const int maxLights = 8;
@@ -22,7 +22,7 @@ uniform vec4 lightsColor[maxLights];
 uniform vec4 lightsParams[maxLights];
 
 struct shadow_info {
-	bool _active;
+	UBOOL _active;
 	vec3 _color;
 	vec3 _light;
 	vec3 _point;
@@ -39,7 +39,7 @@ void main()
 	vec4 pos = modelMatrix * extraMatrix * vec4(position, 1.0);
 
 	// See http://en.wikipedia.org/wiki/Line-plane_intersection
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		pos /= pos.w;
 		vec3 l = pos.xyz - shadow._light;
 		float d = dot(shadow._point - shadow._light, shadow._normal) / dot(l, shadow._normal);
@@ -50,13 +50,13 @@ void main()
 	vec4 positionView = viewMatrix * pos;
 	gl_Position = projMatrix * positionView;
 
-	if (shadow._active) {
+	if (UBOOL_TEST(shadow._active)) {
 		Color = vec4(shadow._color, 1.0);
 	} else {
 		Color = color;
 	}
 
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		Texcoord = vec2(0.0, 1.0) + (texcoord / texScale);
 	} else {
 		Texcoord = vec2(0.0, 0.0);

--- a/engines/grim/shaders/grim_smush.fragment
+++ b/engines/grim/shaders/grim_smush.fragment
@@ -3,13 +3,13 @@ in vec2 Texcoord;
 OUTPUT
 
 uniform sampler2D tex;
-uniform bool swap;
-uniform bool swizzle;
+uniform UBOOL swap;
+uniform UBOOL swizzle;
 
 void main()
 {
 	vec4 color = texture(tex, Texcoord);
-	if (swap) color.rgba = color.abgr;
-	if (swizzle) color.rgba = color.bgra;
+	if (UBOOL_TEST(swap)) color.rgba = color.abgr;
+	if (UBOOL_TEST(swizzle)) color.rgba = color.bgra;
 	outColor = vec4(color.rgb, 1.0);
 }

--- a/engines/myst3/shaders/myst3_box.fragment
+++ b/engines/myst3/shaders/myst3_box.fragment
@@ -2,13 +2,13 @@ in vec2 Texcoord;
 
 OUTPUT
 
-uniform bool textured;
+uniform UBOOL textured;
 uniform vec4 color;
 uniform sampler2D tex;
 
 void main()
 {
 	outColor = color;
-	if (textured)
+	if (UBOOL_TEST(textured))
 		outColor = outColor * texture(tex, Texcoord);
 }

--- a/engines/myst3/shaders/myst3_box.vertex
+++ b/engines/myst3/shaders/myst3_box.vertex
@@ -5,7 +5,7 @@ uniform vec2 texOffsetXY;
 uniform vec2 texSizeWH;
 uniform vec2 verOffsetXY;
 uniform vec2 verSizeWH;
-uniform bool flipY;
+uniform UBOOL flipY;
 
 out vec2 Texcoord;
 
@@ -18,7 +18,7 @@ void main()
 	pos.x = pos.x * 2.0 - 1.0;
 	pos.y = -1.0 * (pos.y * 2.0 - 1.0);
 
-	if (flipY) {
+	if (UBOOL_TEST(flipY)) {
 		pos.y *= -1.0;
 	}
 

--- a/engines/playground3d/shaders/playground3d_cube.fragment
+++ b/engines/playground3d/shaders/playground3d_cube.fragment
@@ -3,12 +3,12 @@ in vec3 Color;
 
 OUTPUT
 
-uniform bool textured;
+uniform UBOOL textured;
 uniform sampler2D tex;
 
 void main() {
 	outColor = vec4(Color, 1.0);
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		outColor *= texture(tex, Texcoord);
 	}
 }

--- a/engines/playground3d/shaders/playground3d_cube.vertex
+++ b/engines/playground3d/shaders/playground3d_cube.vertex
@@ -7,7 +7,7 @@ uniform mat4 mvpMatrix;
 uniform mat4 projMatrix;
 uniform mat4 modelMatrix;
 uniform mat4 rotateMatrix;
-uniform bool textured;
+uniform UBOOL textured;
 uniform vec3 modelPos;
 
 out vec2 Texcoord;
@@ -19,7 +19,7 @@ void main() {
 	vec4 pos = rotateMatrix * vec4(position, 1.0);
 	gl_Position = mvpMatrix * (pos + vec4(modelPos, 1.0));
 
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		Color = vec3(1.0);
 	} else {
 		Color = color;

--- a/engines/stark/shaders/stark_actor.fragment
+++ b/engines/stark/shaders/stark_actor.fragment
@@ -3,13 +3,13 @@ in vec3 Color;
 
 OUTPUT
 
-uniform bool textured;
+uniform UBOOL textured;
 uniform sampler2D tex;
 
 void main() {
 	outColor = vec4(Color, 1.0);
 
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		outColor *= texture(tex, Texcoord);
 	}
 }

--- a/engines/stark/shaders/stark_actor.vertex
+++ b/engines/stark/shaders/stark_actor.vertex
@@ -31,7 +31,7 @@ uniform vec3 bonePosition[maxBones];
 uniform Light lights[maxLights];
 uniform vec3 ambientColor;
 uniform vec3 color;
-uniform bool textured;
+uniform UBOOL textured;
 
 vec4 eyePosition;
 vec3 eyeNormal;
@@ -94,7 +94,7 @@ void main()
 	gl_Position = projectionMatrix * eyePosition;
 
 	// Set the initial vertex color
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		Color = vec3(1.0);
 	} else {
 		Color = color;

--- a/engines/stark/shaders/stark_prop.fragment
+++ b/engines/stark/shaders/stark_prop.fragment
@@ -3,14 +3,14 @@ in vec3 Color;
 
 OUTPUT
 
-uniform bool textured;
+uniform UBOOL textured;
 uniform vec3 color;
 uniform sampler2D tex;
 
 void main() {
 	outColor = vec4(Color, 1.0);
 
-	if (textured) {
+	if (UBOOL_TEST(textured)) {
 		outColor *= texture(tex, Texcoord);
 	} else {
 		outColor *= vec4(color, 1.0);

--- a/engines/stark/shaders/stark_prop.vertex
+++ b/engines/stark/shaders/stark_prop.vertex
@@ -21,7 +21,7 @@ const int maxLights = 10;
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
 uniform mat3 normalMatrix;
-uniform bool doubleSided;
+uniform UBOOL doubleSided;
 uniform vec3 ambientColor;
 uniform Light lights[maxLights];
 
@@ -62,7 +62,7 @@ vec3 spotLight(vec3 position, vec3 color, float falloffNear, float falloffFar, v
 }
 
 void main() {
-	if (doubleSided) {
+	if (UBOOL_TEST(doubleSided)) {
 		Texcoord = vec2(texcoord.x, 1.0 - texcoord.y);
 	} else {
 		Texcoord = vec2(1.0 - texcoord.x, 1.0 - texcoord.y);

--- a/engines/stark/shaders/stark_surface.vertex
+++ b/engines/stark/shaders/stark_surface.vertex
@@ -4,7 +4,7 @@ in vec2 texcoord;
 uniform vec2 verOffsetXY;
 uniform vec2 verSizeWH;
 uniform vec2 viewport;
-uniform bool snapToGrid;
+uniform UBOOL snapToGrid;
 
 out vec2 Texcoord;
 
@@ -14,7 +14,7 @@ void main() {
 	// Coordinates are [0.0; 1.0], transform to [-1.0; 1.0]
 	vec2 pos = verOffsetXY + position * verSizeWH;
 
-	if (snapToGrid) {
+	if (UBOOL_TEST(snapToGrid)) {
 		// Align vertex coordinates to the native pixel grid
 		// This ensures text does not get garbled by nearest neighbors scaling
 		pos.x = floor(pos.x * viewport.x + 0.5) / viewport.x;

--- a/engines/wintermute/base/gfx/opengl/shaders/wme_line.vertex
+++ b/engines/wintermute/base/gfx/opengl/shaders/wme_line.vertex
@@ -6,6 +6,6 @@ uniform vec4 color;
 out vec4 Color;
 
 void main() {
-	gl_Position = projMatrix * vec4(position, 0.0f, 1.0);
+	gl_Position = projMatrix * vec4(position, 0.0, 1.0);
 	Color = color;
 }

--- a/engines/wintermute/base/gfx/opengl/shaders/wme_sprite.fragment
+++ b/engines/wintermute/base/gfx/opengl/shaders/wme_sprite.fragment
@@ -3,7 +3,7 @@ in vec4 Color;
 
 uniform sampler2D tex;
 uniform float alphaRef;
-uniform bool alphaTest;
+uniform UBOOL alphaTest;
 
 OUTPUT
 
@@ -11,7 +11,7 @@ void main() {
 	vec4 texColor = texture(tex, Texcoord);
 	outColor = Color * texColor;
 
-	if (alphaTest && outColor.a < alphaRef) {
+	if (UBOOL_TEST(alphaTest) && outColor.a < alphaRef) {
 		discard;
 	}
 }

--- a/graphics/opengl/shader.cpp
+++ b/graphics/opengl/shader.cpp
@@ -64,6 +64,18 @@ static const char *compatFragment =
 		"#define OUTPUT out vec4 outColor;\n"
 	"#endif\n";
 
+// OGLES2 on AmigaOS doesn't support uniform booleans, let's introduce some shim
+#if defined(AMIGAOS)
+static const char *compatUniformBool =
+	"#define UBOOL mediump int\n"
+	"#define UBOOL_TEST(v) (v != 0)\n";
+#else
+static const char *compatUniformBool =
+	"#define UBOOL bool\n"
+	"#define UBOOL_TEST(v) v\n";
+#endif
+
+
 static const GLchar *readFile(const Common::String &filename) {
 	Common::File file;
 	Common::String shaderDir;
@@ -127,11 +139,12 @@ static GLuint createCompatShader(const char *shaderSource, GLenum shaderType, co
 	const GLchar *shaderSources[] = {
 		versionSource,
 		compatSource,
+		compatUniformBool,
 		shaderSource
 	};
 
 	GLuint shader = glCreateShader(shaderType);
-	glShaderSource(shader, 3, shaderSources, NULL);
+	glShaderSource(shader, 4, shaderSources, NULL);
 	glCompileShader(shader);
 
 	GLint status;


### PR DESCRIPTION
This is a follow-up of #3422 by @raziel-.

Now that we have GLAD which allows dynamic loading of OpenGL functions, it's possible to use set a SDL attribute to select between miniGL and OGLES2 implementation.

I also removed multiple ifdef regarding framebuffers.
I suspect these ifdef were here because miniGL doesn't provide definitions for these functions. As they are now provided by GLAD, code should build.
A runtime check before using the framebuffer was already in place so this should be safe.

Finally, the context created to check for framebuffer presence was assuming an OpenGL implementation. This is not always the case and depends on SDL defaults or what we have requested.

The TODO list:
- [x] make sure it builds on Amiga (I have to run tests on buildbot).
- [ ] do tests on real Amiga (@raziel- it's for you :wink:). I only tested the idea by patching OSystem_POSIX with the same piece of code
- [ ] make sure that if OGLES2 is not available, user won't be locked out and that SDL falls back on MiniGL
- [x] fix the label size to display the full text
- [x] make sure that no incompatible choice is done between 3D mode and OpenGL implementation chosen. (Done in #3781)
