### PR TITLE
GUI: rename options buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For the impatient among you, here is how to get ScummVM running in five simple s
 
 3. Start ScummVM, choose 'Add game', select the directory containing the game datafiles (do not try to select the datafiles themselves!) and press Choose.
 
-4. The Edit Game dialog opens to allow configuration of various settings for the game. These can be reconfigured at any time, but for now everything should be OK at the default settings.
+4. The Game Options dialog opens to allow configuration of various settings for the game. These can be reconfigured at any time, but for now everything should be OK at the default settings.
 
 5. Select the game you want to play in the list, and press Start. To play a game next time, skip to step 5, unless you want to add more games.
 

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -227,7 +227,7 @@ void LauncherDialog::build() {
 #endif
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
 		new ButtonWidget(this, _title + ".QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
-	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out..."), _("About ScummVM"), kAboutCmd);
+	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out"), _("About ScummVM"), kAboutCmd);
 	if (g_system->getOverlayWidth() > 320)
 		new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
 	else

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -228,7 +228,7 @@ void LauncherDialog::build() {
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
 		new ButtonWidget(this, _title + ".QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
 	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out..."), _("About ScummVM"), kAboutCmd);
-	if (g_system->getOverlayWidth() > 440)
+	if (g_system->getOverlayWidth() > 320)
 		new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
 	else
 		new ButtonWidget(this, _title + ".OptionsButton", _c("Global ~O~pts...", "lowres"), _("Change global ScummVM options"), kOptionsCmd);
@@ -982,7 +982,7 @@ void LauncherSimple::build() {
 	_loadButton = loadButton;
 
 	// Add edit button
-	if (g_system->getOverlayWidth() > 410) {
+	if (g_system->getOverlayWidth() > 320) {
 		_editButton =
 			new ButtonWidget(this, "Launcher.EditGameButton", _("~G~ame Options..."), _("Change game options"), kEditGameCmd);
 	} else {

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -227,22 +227,22 @@ void LauncherDialog::build() {
 #endif
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
 		new ButtonWidget(this, _title + ".QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
-	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out"), _("About ScummVM"), kAboutCmd);
-	new ButtonWidget(this, _title + ".OptionsButton", _("~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
+	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out..."), _("About ScummVM"), kAboutCmd);
+	new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions"), _("Change global ScummVM options"), kOptionsCmd);
 
 	// Above the lowest button rows: two more buttons (directly below the list box)
 	if (g_system->getOverlayWidth() > 320) {
 		DropdownButtonWidget *addButton =
-			new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game..."), _("Add games to the list"), kAddGameCmd);
-		addButton->appendEntry(_("Mass Add..."), kMassAddGameCmd);
+			new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game"), _("Add games to the list"), kAddGameCmd);
+		addButton->appendEntry(_("Mass Add"), kMassAddGameCmd);
 		_addButton = addButton;
 
 		_removeButton =
 			new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd);
 	} else {
 		DropdownButtonWidget *addButton =
-			new DropdownButtonWidget(this, _title + ".AddGameButton", _c("~A~dd Game...", "lowres"), _("Add games to the list"), kAddGameCmd);
-		addButton->appendEntry(_c("Mass Add...", "lowres"), kMassAddGameCmd);
+			new DropdownButtonWidget(this, _title + ".AddGameButton", _c("~A~dd Game", "lowres"), _("Add games to the list"), kAddGameCmd);
+		addButton->appendEntry(_c("Mass Add", "lowres"), kMassAddGameCmd);
 		_addButton = addButton;
 
 		_removeButton =
@@ -972,19 +972,19 @@ void LauncherSimple::build() {
 		new ButtonWidget(this, "Launcher.StartButton", _("~S~tart"), _("Start selected game"), kStartCmd);
 
 	DropdownButtonWidget *loadButton =
-	        new DropdownButtonWidget(this, "Launcher.LoadGameButton", _("~L~oad..."), _("Load saved game for selected game"), kLoadGameCmd);
+	        new DropdownButtonWidget(this, "Launcher.LoadGameButton", _("~L~oad"), _("Load saved game for selected game"), kLoadGameCmd);
 #ifdef ENABLE_EVENTRECORDER
-	loadButton->appendEntry(_("Record..."), kRecordGameCmd);
+	loadButton->appendEntry(_("Record"), kRecordGameCmd);
 #endif
 	_loadButton = loadButton;
 
 	// Add edit button
 	if (g_system->getOverlayWidth() > 320) {
 		_editButton =
-			new ButtonWidget(this, "Launcher.EditGameButton", _("~E~dit Game..."), _("Change game options"), kEditGameCmd);
+			new ButtonWidget(this, "Launcher.EditGameButton", _("~G~ame Options"), _("Change game options"), kEditGameCmd);
 	} else {
 		_editButton =
-			new ButtonWidget(this, "Launcher.EditGameButton", _c("~E~dit Game...", "lowres"), _("Change game options"), kEditGameCmd);
+			new ButtonWidget(this, "Launcher.EditGameButton", _c("~G~ame Options", "lowres"), _("Change game options"), kEditGameCmd);
 	}
 
 	// Add list with game titles

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -228,21 +228,21 @@ void LauncherDialog::build() {
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
 		new ButtonWidget(this, _title + ".QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
 	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out..."), _("About ScummVM"), kAboutCmd);
-	new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions"), _("Change global ScummVM options"), kOptionsCmd);
+	new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
 
 	// Above the lowest button rows: two more buttons (directly below the list box)
 	if (g_system->getOverlayWidth() > 320) {
 		DropdownButtonWidget *addButton =
-			new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game"), _("Add games to the list"), kAddGameCmd);
-		addButton->appendEntry(_("Mass Add"), kMassAddGameCmd);
+			new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game..."), _("Add games to the list"), kAddGameCmd);
+		addButton->appendEntry(_("Mass Add..."), kMassAddGameCmd);
 		_addButton = addButton;
 
 		_removeButton =
 			new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd);
 	} else {
 		DropdownButtonWidget *addButton =
-			new DropdownButtonWidget(this, _title + ".AddGameButton", _c("~A~dd Game", "lowres"), _("Add games to the list"), kAddGameCmd);
-		addButton->appendEntry(_c("Mass Add", "lowres"), kMassAddGameCmd);
+			new DropdownButtonWidget(this, _title + ".AddGameButton", _c("~A~dd Game...", "lowres"), _("Add games to the list"), kAddGameCmd);
+		addButton->appendEntry(_c("Mass Add...", "lowres"), kMassAddGameCmd);
 		_addButton = addButton;
 
 		_removeButton =
@@ -972,19 +972,19 @@ void LauncherSimple::build() {
 		new ButtonWidget(this, "Launcher.StartButton", _("~S~tart"), _("Start selected game"), kStartCmd);
 
 	DropdownButtonWidget *loadButton =
-	        new DropdownButtonWidget(this, "Launcher.LoadGameButton", _("~L~oad"), _("Load saved game for selected game"), kLoadGameCmd);
+	        new DropdownButtonWidget(this, "Launcher.LoadGameButton", _("~L~oad..."), _("Load saved game for selected game"), kLoadGameCmd);
 #ifdef ENABLE_EVENTRECORDER
-	loadButton->appendEntry(_("Record"), kRecordGameCmd);
+	loadButton->appendEntry(_("Record..."), kRecordGameCmd);
 #endif
 	_loadButton = loadButton;
 
 	// Add edit button
 	if (g_system->getOverlayWidth() > 320) {
 		_editButton =
-			new ButtonWidget(this, "Launcher.EditGameButton", _("~G~ame Options"), _("Change game options"), kEditGameCmd);
+			new ButtonWidget(this, "Launcher.EditGameButton", _("~G~ame Options..."), _("Change game options"), kEditGameCmd);
 	} else {
 		_editButton =
-			new ButtonWidget(this, "Launcher.EditGameButton", _c("~G~ame Options", "lowres"), _("Change game options"), kEditGameCmd);
+			new ButtonWidget(this, "Launcher.EditGameButton", _c("~G~ame Options...", "lowres"), _("Change game options"), kEditGameCmd);
 	}
 
 	// Add list with game titles

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -228,7 +228,10 @@ void LauncherDialog::build() {
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
 		new ButtonWidget(this, _title + ".QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
 	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out..."), _("About ScummVM"), kAboutCmd);
-	new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
+	if (g_system->getOverlayWidth() > 440)
+		new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
+	else
+		new ButtonWidget(this, _title + ".OptionsButton", _c("Global ~O~pts...", "lowres"), _("Change global ScummVM options"), kOptionsCmd);
 
 	// Above the lowest button rows: two more buttons (directly below the list box)
 	if (g_system->getOverlayWidth() > 320) {
@@ -979,12 +982,12 @@ void LauncherSimple::build() {
 	_loadButton = loadButton;
 
 	// Add edit button
-	if (g_system->getOverlayWidth() > 320) {
+	if (g_system->getOverlayWidth() > 410) {
 		_editButton =
 			new ButtonWidget(this, "Launcher.EditGameButton", _("~G~ame Options..."), _("Change game options"), kEditGameCmd);
 	} else {
 		_editButton =
-			new ButtonWidget(this, "Launcher.EditGameButton", _c("~G~ame Options...", "lowres"), _("Change game options"), kEditGameCmd);
+			new ButtonWidget(this, "Launcher.EditGameButton", _c("~G~ame Opts...", "lowres"), _("Change game options"), kEditGameCmd);
 	}
 
 	// Add list with game titles


### PR DESCRIPTION
Rename Edit Game to Game Options and Options to Global Options to make it less confusing.

Remove ellipsis on launcher buttons.