### PR TITLE
GUI: Changing "About..." button to "About"

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -227,7 +227,7 @@ void LauncherDialog::build() {
 #endif
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
 		new ButtonWidget(this, _title + ".QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
-	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out..."), _("About ScummVM"), kAboutCmd);
+	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out"), _("About ScummVM"), kAboutCmd);
 	new ButtonWidget(this, _title + ".OptionsButton", _("~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
 
 	// Above the lowest button rows: two more buttons (directly below the list box)


### PR DESCRIPTION
The current recommended and de factor behavior from both Microsoft and Apple is to have "About" menus be without trailing ellipses. Therefore, I think we should follow suit.

----

Traditionally, About menus and buttons had a trailing ellipsis. [This article](https://uxdesign.cc/dot-dot-dot-7ce6170bfc7f) demonstrates this behavior for  both Mac OS 1.0 (technically "System 1.0") and Windows 1.0.

However, current versions of macOS and Windows do not have a trailing ellipsis in About menus. Moreover, their design guidelines recommend not using them. From [Apple](https://developer.apple.com/design/human-interface-guidelines/macos/menus/menu-anatomy/):

> Use an ellipsis whenever choosing a menu item requires additional input from the user. The ellipsis character (…) means a dialog or separate window will open and prompt the user for additional information or to make a choice.

Since no additional input is required from the user for the About menu, it is inappropriate to use an ellipsis according to these guidlelines.

Microsoft [explicitly says](https://docs.microsoft.com/en-us/windows/win32/uxguide/ctrl-command-buttons) that About menus should not have an ellipsis (emphasis mine):

> This doesn't mean you should use an ellipsis whenever an action displays another window only when additional information is required to perform the action. Consequently, *any command button whose implicit verb is to "show another window" doesn't take an ellipsis, such as with the commands About*, Advanced, Help (or any other command linking to a Help topic), Options, Properties, or Settings.

Given all this, I think we should be in line with current best practices and remove it from the menu.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
