### PR TITLE
SCUMM: Don't require Roland update for Loom demos

### DIFF
--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1316,6 +1316,13 @@ Common::Error ScummEngine::init() {
 
 	Common::String macResourceFile;
 
+	if (_game.id == GID_LOOM && _game.version == 3 && _game.platform == Common::kPlatformDOS) {
+		// There are several files in the full game that don't exist
+		// in either demo, but we look for just one of them.
+		if (!Common::File::exists("06.LFL"))
+			_game.features |= GF_DEMO;
+	}
+
 	if (_game.platform == Common::kPlatformMacintosh) {
 		Common::MacResManager resource;
 
@@ -2110,11 +2117,9 @@ void ScummEngine::setupMusic(int midi, const Common::String &macInstrumentFile) 
 	   &&  (_game.platform == Common::kPlatformDOS) && _sound->_musicType == MDT_MIDI) {
 		Common::String fileName;
 		bool missingFile = false;
-		if (_game.id == GID_LOOM) {
+		if (_game.id == GID_LOOM && !(_game.features & GF_DEMO)) {
 			Common::File f;
-			// The Roland Update does have an 85.LFL, but we don't
-			// test for it since the demo doesn't have it.
-			for (char c = '2'; c <= '4'; c++) {
+			for (char c = '2'; c <= '5'; c++) {
 				fileName = "8";
 				fileName += c;
 				fileName += ".LFL";


### PR DESCRIPTION
The Loom demos already have the Roland music included, so they don't need the Roland update. But to check for this, we need to set the GF_DEMO flag on the Loom demo. I don't know if this is the best way of doing so, but it's _one_ way at least.

With this done, we can now check if all of the Roland update files are present.