### PR TITLE
DOCS: Adding Windows 11 to bug report page

### DIFF
--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -47,7 +47,7 @@ To help you report a bug, you can find error messages in the ScummVM log file. T
 	.. panels::
 		:column: col-lg-12 mb-2
 
-	        Window Vista/7/8/10
+	        Window Vista/7/8/10/11
 		^^^^^^^^^^^^^^^^^^^^^^
 
                 ``%APPDATA%\ScummVM\Logs\scummvm.log``


### PR DESCRIPTION
[Report a bug](https://docs.scummvm.org/en/v2.5.1/help/report_bugs.html#the-scummvm-log-file) lists Windows Vista, 7, 8, and 10. Adding 11.

## Before

<img width="444" alt="image" src="https://user-images.githubusercontent.com/6200170/151303623-f3bb0846-8bd2-4c9a-9f1c-6a281c5b8348.png">

## After

<img width="358" alt="image" src="https://user-images.githubusercontent.com/6200170/151303664-e99a75c7-de06-4b69-8d5b-de755f9f28ff.png">