### PR TITLE
DOCS: Consistent and simplified Windows path descriptions

### DIFF
--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -18,30 +18,10 @@ The configuration file saves to different default locations, depending on the pl
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Windows Vista and later
-		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\scummvm.ini``
 
-		---
-		:column: col-lg-12 mb-2
+		For Windows 95/98/ME, the file is at ``C:\WINDOWS\scummvm.ini``
 
-		Windows 2000/XP
-		^^^^^^^^^^^^^^^
-		``\Documents and Settings\username\Application Data\ScummVM\scummvm.ini``
-
-		---
-		:column: col-lg-12 mb-2
-
-		Windows NT4
-		^^^^^^^^^^^
-		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\scummvm.ini``
-
-		---
-		:column: col-lg-12 mb-2
-
-		95/98/ME
-		^^^^^^^^
-		``C:\WINDOWS\scummvm.ini``
 
 .. tabbed:: macOS
 

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -18,33 +18,30 @@ The configuration file saves to different default locations, depending on the pl
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		95/98/ME
-		^^^^^^^^^^
-
-		``C:\WINDOWS\scummvm.ini``
-
-
-		---
-		:column: col-lg-12 mb-2
-
-		Windows NT4
-		^^^^^^^^^^^^
-
-		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\scummvm.ini``
+		Window Vista/7/8/10
+		^^^^^^^^^^^^^^^^^^^
+		``%APPDATA%\ScummVM\scummvm.ini``
 
 		---
 		:column: col-lg-12 mb-2
 
 		Windows 2000/XP
-		^^^^^^^^^^^^^^^^^
+		^^^^^^^^^^^^^^^
 		``\Documents and Settings\username\Application Data\ScummVM\scummvm.ini``
 
 		---
 		:column: col-lg-12 mb-2
 
-		Window Vista/7/8/10
-		^^^^^^^^^^^^^^^^^^^^^^
-		``%APPDATA%\ScummVM\scummvm.ini``
+		Windows NT4
+		^^^^^^^^^^^
+		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\scummvm.ini``
+
+		---
+		:column: col-lg-12 mb-2
+
+		95/98/ME
+		^^^^^^^^
+		``C:\WINDOWS\scummvm.ini``
 
 .. tabbed:: macOS
 

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -18,8 +18,8 @@ The configuration file saves to different default locations, depending on the pl
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Window Vista/7/8/10
-		^^^^^^^^^^^^^^^^^^^
+		Window Vista and later
+		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\scummvm.ini``
 
 		---

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -18,7 +18,7 @@ The configuration file saves to different default locations, depending on the pl
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Window Vista and later
+		Windows Vista and later
 		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\scummvm.ini``
 

--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -47,7 +47,7 @@ To help you report a bug, you can find error messages in the ScummVM log file. T
 	.. panels::
 		:column: col-lg-12 mb-2
 
-	        Window Vista/7/8/10
+		Window Vista and later
 		^^^^^^^^^^^^^^^^^^^^^^
 
                 ``%APPDATA%\ScummVM\Logs\scummvm.log``

--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -47,7 +47,7 @@ To help you report a bug, you can find error messages in the ScummVM log file. T
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Window Vista and later
+		Windows Vista and later
 		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\Logs\scummvm.log``
 

--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -49,7 +49,4 @@ To help you report a bug, you can find error messages in the ScummVM log file. T
 
 		Window Vista and later
 		^^^^^^^^^^^^^^^^^^^^^^
-
-                ``%APPDATA%\ScummVM\Logs\scummvm.log``
-
-
+		``%APPDATA%\ScummVM\Logs\scummvm.log``

--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -33,23 +33,7 @@ To help you report a bug, you can find error messages in the ScummVM log file. T
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Windows Vista and later
-		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\Logs\scummvm.log``
-
-		---
-		:column: col-lg-12 mb-2
-
-		Windows 2000/XP
-		^^^^^^^^^^^^^^^
-		``\Documents and Settings\username\Application Data\ScummVM\Logs\scummvm.log``
-
-		---
-		:column: col-lg-12 mb-2
-
-		Windows NT4
-		^^^^^^^^^^^
-		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\Logs\scummvm.log``
 
 .. tabbed:: macOS
 

--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -50,3 +50,18 @@ To help you report a bug, you can find error messages in the ScummVM log file. T
 		Window Vista and later
 		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\Logs\scummvm.log``
+
+		---
+		:column: col-lg-12 mb-2
+
+		Windows 2000/XP
+		^^^^^^^^^^^^^^^
+		``\Documents and Settings\username\Application Data\ScummVM\Logs\scummvm.log``
+
+		---
+		:column: col-lg-12 mb-2
+
+		Windows NT4
+		^^^^^^^^^^^
+		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\Logs\scummvm.log``
+

--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -28,20 +28,6 @@ The ScummVM log file
 To help you report a bug, you can find error messages in the ScummVM log file. The location of this file varies depending on your operating system.
 
 
-.. tabbed:: macOS
-
-	.. panels::
-		:column: col-lg-12 mb-2
-
-		``~/Library/Logs/scummvm.log``
-
-.. tabbed:: Linux
-
-	.. panels::
-		:column: col-lg-12 mb-2
-
-		We use the XDG Base Directory Specification, so by default the file will be ``~/.cache/scummvm/logs/scummvm.log`` but its location might vary depending on the value of the ``XDG_CACHE_HOME`` environment variable.
-
 .. tabbed:: Windows
 
 	.. panels::
@@ -64,4 +50,18 @@ To help you report a bug, you can find error messages in the ScummVM log file. T
 		Windows NT4
 		^^^^^^^^^^^
 		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\Logs\scummvm.log``
+
+.. tabbed:: macOS
+
+	.. panels::
+		:column: col-lg-12 mb-2
+
+		``~/Library/Logs/scummvm.log``
+
+.. tabbed:: Linux
+
+	.. panels::
+		:column: col-lg-12 mb-2
+
+		We use the XDG Base Directory Specification, so by default the file will be ``~/.cache/scummvm/logs/scummvm.log`` but its location might vary depending on the value of the ``XDG_CACHE_HOME`` environment variable.
 

--- a/doc/docportal/use_scummvm/save_load_games.rst
+++ b/doc/docportal/use_scummvm/save_load_games.rst
@@ -62,14 +62,14 @@ Default saved game paths are shown below.
 		:column: col-lg-12 mb-2
 
 		Windows 2000/XP
-		^^^^^^^^^^^^^^^^^
+		^^^^^^^^^^^^^^^
 		``\Documents and Settings\username\Application Data\ScummVM\Saved games\``
 
 		---
 		:column: col-lg-12 mb-2
 
 		Windows NT4
-		^^^^^^^^^^^^
+		^^^^^^^^^^^
 		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\Saved games\``
 
 

--- a/doc/docportal/use_scummvm/save_load_games.rst
+++ b/doc/docportal/use_scummvm/save_load_games.rst
@@ -54,23 +54,7 @@ Default saved game paths are shown below.
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Windows Vista and later
-		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\Saved games``
-
-		---
-		:column: col-lg-12 mb-2
-
-		Windows 2000/XP
-		^^^^^^^^^^^^^^^
-		``\Documents and Settings\username\Application Data\ScummVM\Saved games\``
-
-		---
-		:column: col-lg-12 mb-2
-
-		Windows NT4
-		^^^^^^^^^^^
-		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\Saved games\``
 
 
 .. tabbed:: macOS

--- a/doc/docportal/use_scummvm/save_load_games.rst
+++ b/doc/docportal/use_scummvm/save_load_games.rst
@@ -54,10 +54,9 @@ Default saved game paths are shown below.
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Windows NT4
-		^^^^^^^^^^^^
-
-		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\Saved games\``
+		Window Vista/7/8/10
+		^^^^^^^^^^^^^^^^^^^
+		``%APPDATA%\ScummVM\Saved games``
 
 		---
 		:column: col-lg-12 mb-2
@@ -69,9 +68,9 @@ Default saved game paths are shown below.
 		---
 		:column: col-lg-12 mb-2
 
-		Window Vista/7/8/10
-		^^^^^^^^^^^^^^^^^^^^^^
-		``%APPDATA%\ScummVM\Saved games``
+		Windows NT4
+		^^^^^^^^^^^^
+		``C:\WINDOWS\Profiles\username\Application Data\ScummVM\Saved games\``
 
 
 .. tabbed:: macOS

--- a/doc/docportal/use_scummvm/save_load_games.rst
+++ b/doc/docportal/use_scummvm/save_load_games.rst
@@ -54,7 +54,7 @@ Default saved game paths are shown below.
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Window Vista and later
+		Windows Vista and later
 		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\Saved games``
 

--- a/doc/docportal/use_scummvm/save_load_games.rst
+++ b/doc/docportal/use_scummvm/save_load_games.rst
@@ -54,8 +54,8 @@ Default saved game paths are shown below.
 	.. panels::
 		:column: col-lg-12 mb-2
 
-		Window Vista/7/8/10
-		^^^^^^^^^^^^^^^^^^^
+		Window Vista and later
+		^^^^^^^^^^^^^^^^^^^^^^
 		``%APPDATA%\ScummVM\Saved games``
 
 		---


### PR DESCRIPTION
There are several sections in the documents that describe Windows paths. Each one of them did so in a slightly different way. This PR makes them all consistent.

Additionally, it was discovered that `%APPDATA%` resolves the same on Windows 2000/XP/Vista/7/8/10/11 (and we presume NT4). Therefore, there was no need to have separate instructions for versions before Vista.

## [Configuration file#Location](https://docs.scummvm.org/en/v2.5.1/advanced_topics/configuration_file.html#location)

### Before
<img width="705" alt="image" src="https://user-images.githubusercontent.com/6200170/151643077-5c248b46-6f0f-4984-b38d-1498a8881ad1.png">

### After
<img width="720" alt="image" src="https://user-images.githubusercontent.com/6200170/151642996-67100a9c-85ba-41e6-9eaa-2705f540785d.png">

## [Location of saved game files](https://docs.scummvm.org/en/v2.5.1/use_scummvm/save_load_games.html)

## Before

<img width="713" alt="image" src="https://user-images.githubusercontent.com/6200170/151643139-5b21d996-d82b-4d90-a91b-aae5db1773b8.png">

### After

<img width="721" alt="image" src="https://user-images.githubusercontent.com/6200170/151643021-d7ee6182-1957-4e5f-a6a8-3f79d5abb973.png">

## [The ScummVM log file](https://docs.scummvm.org/en/v2.5.1/help/report_bugs.html)

### Before

<img width="705" alt="image" src="https://user-images.githubusercontent.com/6200170/151643169-e71f5914-1d5e-4aa0-bdbf-c4601d93773c.png">

### After

<img width="715" alt="image" src="https://user-images.githubusercontent.com/6200170/151643038-3e33eb29-d963-41b8-ac50-194ac405ea64.png">
