### PR TITLE
WIN32: Detect SHGetSpecialFolderPath at runtime

### DIFF
--- a/backends/platform/sdl/win32/win32_wrapper.cpp
+++ b/backends/platform/sdl/win32/win32_wrapper.cpp
@@ -78,7 +78,7 @@ HRESULT SHGetFolderPathFunc(HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, 
 #endif
 	);
 	if (pSHGetSpecialFolderPath)
-		return pSHGetSpecialFolderPath(hwnd, pszPath, csidl & !CSIDL_FLAG_MASK, csidl & CSIDL_FLAG_CREATE) ? S_OK : E_FAIL;
+		return pSHGetSpecialFolderPath(hwnd, pszPath, csidl & ~CSIDL_FLAG_MASK, csidl & CSIDL_FLAG_CREATE) ? S_OK : E_FAIL;
 
 	return E_NOTIMPL;
 }

--- a/backends/platform/sdl/win32/win32_wrapper.cpp
+++ b/backends/platform/sdl/win32/win32_wrapper.cpp
@@ -68,7 +68,19 @@ HRESULT SHGetFolderPathFunc(HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, 
 	if (pSHGetFolderPath)
 		return pSHGetFolderPath(hwnd, csidl, hToken, dwFlags, pszPath);
 
-	return SHGetSpecialFolderPath(hwnd, pszPath, csidl & !CSIDL_FLAG_MASK, csidl & CSIDL_FLAG_CREATE) ? S_OK : E_NOTIMPL;
+	typedef BOOL (WINAPI *SHGetSpecialFolderPathFunc)(HWND hwnd, LPTSTR pszPath, int csidl, BOOL fCreate);
+
+	SHGetSpecialFolderPathFunc pSHGetSpecialFolderPath = (SHGetSpecialFolderPathFunc)(void *)GetProcAddress(GetModuleHandle(TEXT("shell32.dll")),
+#ifndef UNICODE
+		"SHGetSpecialFolderPathA"
+#else
+		"SHGetSpecialFolderPathW"
+#endif
+	);
+	if (pSHGetSpecialFolderPath)
+		return pSHGetSpecialFolderPath(hwnd, pszPath, csidl & !CSIDL_FLAG_MASK, csidl & CSIDL_FLAG_CREATE) ? S_OK : E_FAIL;
+
+	return E_NOTIMPL;
 }
 
 namespace Win32 {


### PR DESCRIPTION
`SHGetSpecialFolderPath` was introduced as part of the Microsoft Internet Explorer 4.0 Desktop Update, and is not in stock Windows 95 installations prior to OSR 2.5.

See also scummvm/dockerized-bb#43.
