### PR TITLE
Allow specifying the screenshot path on the command line

### DIFF
--- a/backends/platform/sdl/macosx/macosx.cpp
+++ b/backends/platform/sdl/macosx/macosx.cpp
@@ -269,12 +269,15 @@ Common::String OSystem_MacOSX::getDefaultLogFileName() {
 }
 
 Common::String OSystem_MacOSX::getScreenshotsPath() {
-	Common::String path = ConfMan.get("screenshotpath");
-	if (path.empty())
-		path = getDesktopPathMacOSX();
-	if (!path.empty() && !path.hasSuffix("/"))
-		path += "/";
-	return path;
+	// If the user has configured a screenshots path, use it
+	const Common::String path = OSystem_SDL::getScreenshotsPath();
+	if (!path.empty())
+		return path;
+
+	Common::String desktopPath = getDesktopPathMacOSX();
+	if (!desktopPath.empty() && !desktopPath.hasSuffix("/"))
+		desktopPath += "/";
+	return desktopPath;
 }
 
 AudioCDManager *OSystem_MacOSX::createAudioCDManager() {

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -196,6 +196,13 @@ void OSystem_SDL::initBackend() {
 			_logger->open(logFile);
 	}
 
+	// In case the user specified the screenshot path, we get it here.
+	// That way if it was specified on the command line we will not lose it
+	// when the launcher is started (as it clears the ConfMan transient domain).
+	_userScreenshotPath = ConfMan.get("screenshotpath");
+	if (!_userScreenshotPath.empty() && !_userScreenshotPath.hasSuffix("/"))
+		_userScreenshotPath += "/";
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	const char *sdlDriverName = SDL_GetCurrentVideoDriver();
 	// Allow the screen to turn off
@@ -716,10 +723,7 @@ Common::SaveFileManager *OSystem_SDL::getSavefileManager() {
 
 //Not specified in base class
 Common::String OSystem_SDL::getScreenshotsPath() {
-	Common::String path = ConfMan.get("screenshotpath");
-	if (!path.empty() && !path.hasSuffix("/"))
-		path += "/";
-	return path;
+	return _userScreenshotPath;
 }
 
 #ifdef USE_OPENGL

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -119,6 +119,12 @@ protected:
 	Common::String _logFilePath;
 
 	/**
+	 * A path specified by the user where screenshots are created.
+	 * This may be empty, in which case a OS-dependent default path is used.
+	 */
+	Common::String _userScreenshotPath;
+
+	/**
 	 * The event source we use for obtaining SDL events.
 	 */
 	SdlEventSource *_eventSource;

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -238,10 +238,15 @@ Common::String OSystem_Win32::getSystemLanguage() const {
 }
 
 Common::String OSystem_Win32::getScreenshotsPath() {
-	Common::String screenshotsPath = ConfMan.get("screenshotpath");
+	// If the user has configured a screenshots path, use it
+	Common::String screenshotsPath = OSystem_SDL::getScreenshotsPath();
 	if (!screenshotsPath.empty()) {
-		if (!screenshotsPath.hasSuffix("\\") && !screenshotsPath.hasSuffix("/"))
-			screenshotsPath += "\\";
+		// OSystem_SDL may have appended a '/' at the end
+		if (screenshotsPath.hasSuffix("/")) {
+			screenshotsPath.deleteLastChar();
+			if (!screenshotsPath.hasSuffix("\\") && !screenshotsPath.hasSuffix("/"))
+				screenshotsPath += "\\";
+		}
 		return screenshotsPath;
 	}
 

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -98,6 +98,7 @@ static const char HELP_STRING[] =
 	"  -c, --config=CONFIG      Use alternate configuration file\n"
 #if defined(SDL_BACKEND)
 	"  -l, --logfile=PATH       Use alternate path for log file\n"
+	"  --screenshotpath=PATH    Specify path where screenshot files are created\n"
 #endif
 	"  -p, --path=PATH          Path to where the game is installed\n"
 	"  -x, --save-slot[=NUM]    Save game slot to load (default: autosave)\n"
@@ -596,6 +597,15 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 
 #if defined(SDL_BACKEND)
 			DO_OPTION('l', "logfile")
+			END_OPTION
+
+			DO_LONG_OPTION("screenshotpath")
+				Common::FSNode path(option);
+				if (!path.exists()) {
+					usage("Non-existent game path '%s'", option);
+				} else if (!path.isWritable()) {
+					usage("Non-writable screenshot path '%s'", option);
+				}
 			END_OPTION
 #endif
 

--- a/doc/docportal/advanced_topics/command_line.rst
+++ b/doc/docportal/advanced_topics/command_line.rst
@@ -157,6 +157,7 @@ Short options are listed where they are available.
         ``--render-mode=MODE``,,":ref:`Enables additional render modes <render>`"
         ``--save-slot=NUM``,``-x``,"Specifies the saved game slot to load (default: autosave)"
         ``--savepath=PATH``,,":ref:`Specifies path to where saved games are stored <savepath>`"
+        ``--screenshotpath=PATH``,,"Specify path where screenshot files are created (SDL backend only)"
         ``--sfx-volume=NUM``,``-s``,":ref:`Sets the sfx volume <sfx>`, 0-255 (default: 192)"
         ``--soundfont=FILE``,,":ref:`Selects the SoundFont for MIDI playback. <soundfont>`. Only supported by some MIDI drivers."
         ``--speech-volume=NUM``,``-r``,":ref:`Sets the speech volume <speechvol>`, 0-255 (default: 192)"


### PR DESCRIPTION
This allow specifying a path where to save screenshots on the command line.

See pull request #3675 for another pull request that attempt this. That pull request was however incorrect with no feedback from the author since it was open. So I decided to rewrite it.

See also https://bugs.scummvm.org/ticket/13245.

There are two questions I have in this pull request:
1. Should we only commit the first commit or all three?
2. Is there a better way to handle the terminating '\\' or Windows, and does the code I have work for all cases.

### Description of the changes ###

The first commit is simple and corresponds to what was done in the earlier pull request but without the bugs (and with an update to the documentation). It adds a command line option that, when used, adds a screenshotpath to the transient domain of `ConfMan`. Since the SDL backend already queries `ConfMan` for this key, this just works™ 

The other two commits are maybe more controversial and the reason why I am proposing this as a pull request instead of pushing the code directly. Since the transient domain in `ConfMan` is cleared when starting the launcher, this means that the path is only used if a game is also specified on the command line, and only until returning to the launcher. It seems to me that it would make more sense to use it even when starting with the launcher (i.e. no game is specified on the command line), and until the user quits ScummVM (so potentially for multiple games). This is what is implemented in those two commits. And this is also more or less how the `--logfile=PATH` option behaves (since the log file is opened when starting ScummVM at a point where the transient domain has not yet been cleared). This however diverges from the behaviour for most other options we can pass on the command line.

### Handling of path separator on Windows ###

Also I am not completely sure how Windows handles paths with a mixture of '/' and '\\'. So I was a bit cautious with my changes to the `OSystem_Win32` class in 9e9a3a7e5d4e5692aa7a2a3b1d5e2781dc1b25aa. But maybe the code could be simplified.

And also if the user specifies a path that ends with a '/', it is now replaced by a '\\', which was not the case before. Could that be an issue? Or is it actually better? If needed there is a simple way to get back the path as it exactly was before my changes by adding the following to `OSystem_Win32::initBackend()` after it calls `OSystem_SDL::initBackend()` and removing the handling of the backslash from `OSystem_Win32::getScreenshotsPath()`:
```c++
	// Invoke parent implementation of this method
	OSystem_SDL::initBackend();

	// Make sure that if the user specified a screenshot path we have the correct path separator at the end
	_userScreenshotPath = ConfMan.get("screenshotpath");
	if (!_userScreenshotPath.empty() && !_userScreenshotPath.hasSuffix("\\") && !_userScreenshotPath.hasSuffix("/"))
		_userScreenshotPath += "\\";
}
```
However to me this seems less clean than what I did.
