### PR TITLE
SDL: Fix mouse capture in HiDPI mode

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -221,8 +221,14 @@ bool SdlGraphicsManager::notifyMousePosition(Common::Point &mouse) {
 	if (_activeArea.drawRect.contains(mouse)) {
 		_cursorLastInActiveArea = true;
 	} else {
-		mouse.x = CLIP<int>(mouse.x, _activeArea.drawRect.left, _activeArea.drawRect.right - 1);
-		mouse.y = CLIP<int>(mouse.y, _activeArea.drawRect.top, _activeArea.drawRect.bottom - 1);
+		// The right/bottom edges are not part of the drawRect. As the clipping
+		// is done in drawable area coordinates, but the mouse position is set
+		// in window coordinates, we need to subtract as many pixels from the
+		// edges as corresponds to one pixel in the window coordinates.
+		mouse.x = CLIP<int>(mouse.x, _activeArea.drawRect.left,
+							_activeArea.drawRect.right - (int)(1 * dpiScale + 0.5f));
+		mouse.y = CLIP<int>(mouse.y, _activeArea.drawRect.top,
+							_activeArea.drawRect.bottom - (int)(1 * dpiScale + 0.5f));
 
 		if (_window->mouseIsGrabbed() ||
 			// Keep the mouse inside the game area during dragging to prevent an

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -168,10 +168,11 @@ void SdlWindow::grabMouse(bool grab) {
 }
 
 void SdlWindow::setMouseRect(const Common::Rect &rect) {
-	grabRect.x = rect.left;
-	grabRect.y = rect.top;
-	grabRect.w = rect.width();
-	grabRect.h = rect.height();
+	float dpiScale = getSdlDpiScalingFactor();
+	grabRect.x = (int)(rect.left / dpiScale + 0.5f);
+	grabRect.y = (int)(rect.top / dpiScale + 0.5f);
+	grabRect.w = (int)(rect.width() / dpiScale + 0.5f);
+	grabRect.h = (int)(rect.height() / dpiScale + 0.5f);
 
 #if SDL_VERSION_ATLEAST(2, 0, 18)
 	if (_inputGrabState || _lastFlags & fullscreenMask) {


### PR DESCRIPTION
This PR fixes two independent, but very similar issues in how the mouse is captured to the drawable area in HiDPI mode. Both are needed for proper mouse control in scaled HiDPI mode, when the drawable area doesn't fit the whole window. I was experiencing the issues on a MacBook with Retina display, when the ScummVM graphics mode was set to OpenGL.

### SDL: Fix mouse clip to game area in HiDPI mode

The mouse position is set in window coordinates, but it's clipped to the game area in drawable area coordinates. Previously, the scaling between these two was not taken into account when calculating the right/bottom edges of the game area. When the clipped mouse position was converted back to window coordinates and rounded to the nearest integer, it could end up on the edge of the game area, not inside of it. This leads to a loop in which the clipped mouse position is outside of the game area and needs to be clipped again.

https://bugs.scummvm.org/ticket/12646
https://bugs.scummvm.org/ticket/13075 (likely duplicate)

### SDL: Fix SDL_SetWindowMouseRect in HiDPI mode

In HiDPI mode, the window coordinates and the drawable area coordinates might be on a different scale. The allowed mouse area needs to be scaled accordingly before passing it to `SDL_SetWindowMouseRect()`.

This issue is likely the same as:
https://bugs.scummvm.org/ticket/13152
The description of that ticket is not very detailed, but the symptoms sounds very similar.