### PR TITLE
OSYSTEM: Use `-fileSystemRepresentation` for file-based paths.

### DIFF
--- a/backends/platform/sdl/macosx/macosx_wrapper.mm
+++ b/backends/platform/sdl/macosx/macosx_wrapper.mm
@@ -108,5 +108,5 @@ Common::String getDesktopPathMacOSX() {
 	NSString *path = [paths objectAtIndex:0];
 	if (path == nil)
 		return Common::String();
-	return Common::String([path cStringUsingEncoding:NSASCIIStringEncoding]);
+	return Common::String([path fileSystemRepresentation]);
 }


### PR DESCRIPTION
Use `-[NSString fileSystemRepresentation]` for file-based paths.

Use `-[NSString fileSystemRepresentation]` if you are going to use an
`NSString` path to a lower-level function. This allows the lower-level
functions, like `fopen()`, to get passed a c-string in a format it 
understands.
