### PR TITLE
COMMON: ignore null-terminator when reading line

### DIFF
--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -197,8 +197,10 @@ char *SeekableReadStream::readLine(char *buf, size_t bufSize, bool handleCR) {
 			c = LF;
 		}
 
-		*p++ = c;
-		len++;
+		if (c != '\0') {
+			*p++ = c;
+			len++;
+		}
 	}
 
 	// We always terminate the buffer if no error occurred


### PR DESCRIPTION
If the line includes null-terminators, we'll include them into string and because of that include next line.
This is the real case which occurs with ini.files in PETKA games.

![Screenshot 2022-02-08 at 20 39 20](https://user-images.githubusercontent.com/32491342/153054564-5ab70bd6-96e9-4524-9e07-52edc060ed14.png)

<!---

Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
