### PR TITLE
SCUMM: Reject the corrupted version of MONKEY1-EGA from Limited Run Games

### DIFF
--- a/engines/scumm/detection_internal.h
+++ b/engines/scumm/detection_internal.h
@@ -25,6 +25,8 @@
 #include "common/debug.h"
 #include "common/md5.h"
 
+#include "gui/error.h"
+
 #include "scumm/detection_tables.h"
 #include "scumm/scumm-md5.h"
 #include "scumm/file_nes.h"
@@ -109,7 +111,7 @@ static bool testGame(const GameSettings *g, const DescMap &fileMD5Map, const Com
 
 // Search for a node with the given "name", inside fslist. Ignores case
 // when performing the matching. The first match is returned, so if you
-// search for "resource" and two nodes "RESOURE and "resource" are present,
+// search for "resource" and two nodes "RESOURCE" and "resource" are present,
 // the first match is used.
 static bool searchFSNode(const Common::FSList &fslist, const Common::String &name, Common::FSNode &result) {
 	for (Common::FSList::const_iterator file = fslist.begin(); file != fslist.end(); ++file) {
@@ -330,6 +332,37 @@ static void computeGameSettingsFromMD5(const Common::FSList &fslist, const GameF
 			// The gameid either matches, or is empty. The latter indicates
 			// a generic entry, currently used for some generic HE settings.
 			if (g->variant == 0 || !scumm_stricmp(md5Entry->variant, g->variant)) {
+
+				// See https://dwatteau.github.io/scummfixes/corrupted-monkey1-ega-files-limitedrungames.html
+				if (g->id == GID_MONKEY_EGA && g->platform == Common::kPlatformDOS) {
+					Common::String md5Disk04, md5Lfl903;
+					Common::FSNode resFile;
+					Common::File f;
+
+					if (searchFSNode(fslist, "903.LFL", resFile))
+						f.open(resFile);
+					if (f.isOpen()) {
+						md5Lfl903 = Common::computeStreamMD5AsString(f, kMD5FileSizeLimit);
+						f.close();
+					}
+
+					if (searchFSNode(fslist, "DISK04.LEC", resFile))
+						f.open(resFile);
+					if (f.isOpen()) {
+						md5Disk04 = Common::computeStreamMD5AsString(f, kMD5FileSizeLimit);
+						f.close();
+					}
+
+					if ((!md5Lfl903.empty() && md5Lfl903 == "54d4e17df08953b483d17416043345b9") ||
+					    (!md5Disk04.empty() && md5Disk04 == "f338cc1d3117c1077a3a9d0c1d70b1e8")) {
+						::GUI::displayErrorDialog(_("This version of Monkey Island can't be played, because Limited Run Games "
+						    "provided corrupted DISK04.LEC and 903.LFL files.\n\nPlease contact their technical support for "
+						    "replacement files, or look online for some guides which can help you recover valid files from "
+						    "the KryoFlux dumps that Limited Run Games also provided."));
+						continue;
+					}
+				}
+
 				// Perfect match found, use it and stop the loop.
 				dr.game = *g;
 				dr.game.gameid = md5Entry->gameid;


### PR DESCRIPTION
In its [officially-licensed Monkey Island Anthology](https://limitedrungames.com/products/monkey-island-30th-anniversary-anthology-pc), Limited Run Games included a corrupted fourth disk for the EGA Version of Monkey Island 1. The affected files are `903.LFL` and `DISK04.LEC`, breaking a font, the Mêlée Island map, thus making the game unplayable very early on.

Fortunately, Limited Run Games also included a [KryoFlux](https://www.kryoflux.com) dump of the same floppy, so it's possible to restore working `903.LFL` and `DISK04.LEC` files from it.  But this is out of the scope of ScummVM.

ScummVM could maybe provide a binary patch for this, but unfortunately, `903.LFL` is almost entirely corrupted, so providing a binary patch for it would make it too close to the full and copyrighted resources.

The most useful thing that ScummVM can do, however, it to detect this version, warn the user about it (instead of letting them play it and see it crash), and mention that redirect them to the Limited Run Games technical support, or to the online guides explaining how to recover working `903.LFL` and `DISK04.LEC` files.

If the user replace those corrupted files, the game will be added, as expected.

---

Here's the small guide I wrote about this:  
https://dwatteau.github.io/scummfixes/corrupted-monkey1-ega-files-limitedrungames.html

Feel free to take what you need from it, if you wish to publish a FAQ or an official page on docs.scummvm.org about this.

Here are the *full*  MD5 sums of the recovered vs. corrupted files:

```
0c60481ff858c0e8ab136adab5fa5bdc  recovered/903.LFL # <== same MD5 as the one from Loom
436e23b452baa9b82dde3dd1a6fb39b6  recovered/DISK04.LEC

f338cc1d3117c1077a3a9d0c1d70b1e8  corrupted/DISK04.LEC
54d4e17df08953b483d17416043345b9  corrupted/903.LFL
```

As discussed with eientei on Discord today, the files have the proper length, but the corrupted files have quite a lot of wrong bytes. For example, `903.LFL` has 1971 wrong bytes out of 2019. That's why I think we can just *report* the problem to the users, at the moment.

(The Limited Run Games support also knows about this problem, but since it was sold on physical media, and just as a one-shot, I don't think they will easily issue legal replacement files for everyone…).

Anyway, the detection code of the SCUMM engine is a bit more old-school? than what is available in some other engines, so I did this as best as I could. But I'm absolutely not in expert in this, and it was mostly trial-and-error, so please review it carefully :)