### PR TITLE
NGI: Fixing Rolling bridge state in Scene 13

### DIFF
--- a/engines/ngi/fullpipe/scene13.cpp
+++ b/engines/ngi/fullpipe/scene13.cpp
@@ -84,6 +84,7 @@ void scene13_initScene(Scene *sc) {
 
 void sceneHandler13_openBridge() {
 	Movement *mov = g_vars->scene13_bridge->_movement;
+	g_nmi->setObjectState(sO_Bridge, g_nmi->getObjectEnumState(sO_Bridge, sO_IsFree));
 
 	if (mov && mov->_id == MV_BDG_CLOSE) {
 		int sz;


### PR DESCRIPTION
Bug [#10396](https://bugs.scummvm.org/ticket/10396) would set a wrong bridge state if someone initiated a bridge unroll and teleported before the animation was complete. This change fixes [#10396](https://bugs.scummvm.org/ticket/10396) by giving the bridge a state before it starts unrolling. While checking this bug, I found another one. Will post it on the tracker and drop the link here.