### PR TITLE
AGS: Fix for transparency test being unintentionally in 3.5.0

### DIFF
--- a/engines/ags/globals.h
+++ b/engines/ags/globals.h
@@ -758,7 +758,10 @@ public:
 	int _our_eip = 0;
 
 	int _oldmouse = 0;
+	// Data format version of the loaded game
 	GameDataVersion _loaded_game_file_version = kGameVersion_Undefined;
+	// The version of the engine the loaded game was compiled for (if available)
+	Version _game_compiled_version;
 	int _game_paused = 0;
 	char _pexbuf[STD_BUFFER_SIZE] = { 0 };
 	unsigned int _load_new_game = 0;

--- a/engines/ags/shared/game/main_game_file.cpp
+++ b/engines/ags/shared/game/main_game_file.cpp
@@ -186,6 +186,7 @@ static HGameFileError OpenMainGameFileBase(Stream *in, MainGameSource &src) {
 	// rid of it too easily; the easy way is to set it whenever the main
 	// game file is opened.
 	_G(loaded_game_file_version) = src.DataVersion;
+	_G(game_compiled_version).SetFromString(src.CompiledWith);
 	return HGameFileError::None();
 }
 

--- a/engines/ags/shared/gui/gui_main.cpp
+++ b/engines/ags/shared/gui/gui_main.cpp
@@ -157,6 +157,11 @@ bool GUIMain::IsDisplayed() const {
 bool GUIMain::IsInteractableAt(int x, int y) const {
 	if (!IsDisplayed())
 		return false;
+	// The Transparency test was unintentionally added in 3.5.0 as a side effect,
+	// and unfortunately there are already games which require it to work.
+	if ((_G(game_compiled_version).AsNumber() == 30500) && (Transparency == 255)) {
+		return false;
+	}
 	if (!IsClickable())
 		return false;
 	if ((x >= X) & (y >= Y) & (x < X + Width) & (y < Y + Height))


### PR DESCRIPTION
Resolves bug #13251 for Zniw GUI language selection screen being non-interactable

The fix is from AGS' github repository commit: https://github.com/adventuregamestudio/ags/commit/a087584a26106d2fb6a17c13b0cb3f6857f4cbed
by @ivan-mogilko on 26 Dec, 2021.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
