### PR TITLE
GUI: auto shorten label for Options buttons

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -244,8 +244,7 @@ void LauncherDialog::build() {
 
 	// Above the lowest button rows: two more buttons (directly below the list box)
 	DropdownButtonWidget *addButton =
-		new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game..."), _("Add games to the list"), kAddGameCmd);
-	addButton->setLowresLabel(_c("~A~dd Game...", "lowres"));
+		new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game..."), _("Add games to the list"), kAddGameCmd, 0, _c("~A~dd Game...", "lowres"));
 	_addButton = addButton;
 	_removeButton =
 		new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd, 0, _c("~R~emove Game", "lowres"));

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -240,25 +240,19 @@ void LauncherDialog::build() {
 		new ButtonWidget(this, _title + ".QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
 
 	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out"), _("About ScummVM"), kAboutCmd);
-	new ButtonWidgetAutoRes(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _c("Global Opts...", "lowres"), _("Change global ScummVM options"), kOptionsCmd);
+	new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd, 0, _c("Global Opts...", "lowres"));
 
 	// Above the lowest button rows: two more buttons (directly below the list box)
+	DropdownButtonWidget *addButton =
+		new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game..."), _("Add games to the list"), kAddGameCmd);
+	addButton->setLowresLabel(_c("~A~dd Game...", "lowres"));
+	_addButton = addButton;
+	_removeButton =
+		new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd, 0, _c("~R~emove Game", "lowres"));
 	if (g_system->getOverlayWidth() > 320) {
-		DropdownButtonWidget *addButton =
-			new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game..."), _("Add games to the list"), kAddGameCmd);
 		addButton->appendEntry(_("Mass Add..."), kMassAddGameCmd);
-		_addButton = addButton;
-
-		_removeButton =
-			new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd);
 	} else {
-		DropdownButtonWidget *addButton =
-			new DropdownButtonWidget(this, _title + ".AddGameButton", _c("~A~dd Game...", "lowres"), _("Add games to the list"), kAddGameCmd);
 		addButton->appendEntry(_c("Mass Add...", "lowres"), kMassAddGameCmd);
-		_addButton = addButton;
-
-		_removeButton =
-		new ButtonWidget(this, _title + ".RemoveGameButton", _c("~R~emove Game", "lowres"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd);
 	}
 
 	// Search box
@@ -993,7 +987,7 @@ void LauncherSimple::build() {
 
 	// Add edit button
 	_editButton =
-		new ButtonWidgetAutoRes(this, "Launcher.EditGameButton", _("~G~ame Options..."), _c("Game Opts...", "lowres"), _("Change game options"), kEditGameCmd);
+		new ButtonWidget(this, "Launcher.EditGameButton", _("~G~ame Options..."), _("Change game options"), kEditGameCmd, 0, _c("Game Opts...", "lowres"));
 
 	// Add list with game titles
 	_list = new GroupedListWidget(this, "Launcher.GameList", Common::U32String(), kListSearchCmd);

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -238,11 +238,9 @@ void LauncherDialog::build() {
 #endif
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit))
 		new ButtonWidget(this, _title + ".QuitButton", _("~Q~uit"), _("Quit ScummVM"), kQuitCmd);
+
 	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out"), _("About ScummVM"), kAboutCmd);
-	if (g_system->getOverlayWidth() > 320)
-		new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd);
-	else
-		new ButtonWidget(this, _title + ".OptionsButton", _c("Global ~O~pts...", "lowres"), _("Change global ScummVM options"), kOptionsCmd);
+	new ButtonWidgetAutoRes(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _c("Global Opts...", "lowres"), _("Change global ScummVM options"), kOptionsCmd);
 
 	// Above the lowest button rows: two more buttons (directly below the list box)
 	if (g_system->getOverlayWidth() > 320) {
@@ -994,13 +992,8 @@ void LauncherSimple::build() {
 	_loadButton = loadButton;
 
 	// Add edit button
-	if (g_system->getOverlayWidth() > 320) {
-		_editButton =
-			new ButtonWidget(this, "Launcher.EditGameButton", _("~G~ame Options..."), _("Change game options"), kEditGameCmd);
-	} else {
-		_editButton =
-			new ButtonWidget(this, "Launcher.EditGameButton", _c("~G~ame Opts...", "lowres"), _("Change game options"), kEditGameCmd);
-	}
+	_editButton =
+		new ButtonWidgetAutoRes(this, "Launcher.EditGameButton", _("~G~ame Options..."), _c("Game Opts...", "lowres"), _("Change game options"), kEditGameCmd);
 
 	// Add list with game titles
 	_list = new GroupedListWidget(this, "Launcher.GameList", Common::U32String(), kListSearchCmd);

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -437,6 +437,23 @@ void ButtonWidget::setUnpressedState() {
 
 #pragma mark -
 
+ButtonWidgetAutoRes::ButtonWidgetAutoRes(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &lowresLabel, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
+	: ButtonWidget(boss, name, label, tooltip, cmd, hotkey) {
+	_lowresLabel = lowresLabel;
+}
+
+void ButtonWidgetAutoRes::setLowresLabel(const Common::U32String &label) {
+	_lowresLabel = label;
+}
+
+void ButtonWidgetAutoRes::drawWidget() {
+	bool useLowres = g_gui.theme()->getStringWidth(_label) > _w;
+	const Common::U32String &label = useLowres ? _lowresLabel : _label;
+	g_gui.theme()->drawButton(Common::Rect(_x, _y, _x + _w, _y + _h), label, _state, getFlags());
+}
+
+#pragma mark -
+
 DropdownButtonWidget::DropdownButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey) :
 		ButtonWidget(boss, x, y, w, h, label, tooltip, cmd, hotkey) {
 	setFlags(getFlags() | WIDGET_TRACK_MOUSE);

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -346,9 +346,10 @@ void StaticTextWidget::setFont(ThemeEngine::FontStyle font, Common::Language lan
 
 #pragma mark -
 
-ButtonWidget::ButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
+ButtonWidget::ButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey, const Common::U32String &lowresLabel)
 	: StaticTextWidget(boss, x, y, w, h, cleanupHotkey(label), Graphics::kTextAlignCenter, tooltip), CommandSender(boss),
 	  _cmd(cmd), _hotkey(hotkey), _duringPress(false) {
+	_lowresLabel = lowresLabel;
 
 	if (hotkey == 0)
 		_hotkey = parseHotkey(label);
@@ -357,11 +358,14 @@ ButtonWidget::ButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Co
 	_type = kButtonWidget;
 }
 
-ButtonWidget::ButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
+ButtonWidget::ButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey, const Common::U32String &lowresLabel)
 	: StaticTextWidget(boss, name, cleanupHotkey(label), tooltip), CommandSender(boss),
 	  _cmd(cmd), _hotkey(hotkey), _duringPress(false) {
+	_lowresLabel = lowresLabel;
+
 	if (hotkey == 0)
 		_hotkey = parseHotkey(label);
+
 	setFlags(WIDGET_ENABLED/* | WIDGET_BORDER*/ | WIDGET_CLEARBG);
 	_type = kButtonWidget;
 }
@@ -387,7 +391,7 @@ void ButtonWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 }
 
 void ButtonWidget::drawWidget() {
-	g_gui.theme()->drawButton(Common::Rect(_x, _y, _x + _w, _y + _h), _label, _state, getFlags());
+	g_gui.theme()->drawButton(Common::Rect(_x, _y, _x + _w, _y + _h), getLabel(), _state, getFlags());
 }
 
 void ButtonWidget::setLabel(const Common::U32String &label) {
@@ -396,6 +400,17 @@ void ButtonWidget::setLabel(const Common::U32String &label) {
 
 void ButtonWidget::setLabel(const Common::String &label) {
 	ButtonWidget::setLabel(Common::U32String(label));
+}
+
+void ButtonWidget::setLowresLabel(const Common::U32String &label) {
+	_lowresLabel = label;
+}
+
+const Common::U32String &ButtonWidget::getLabel() {
+	bool useLowres = false;
+	if (!_lowresLabel.empty())
+		useLowres = g_gui.theme()->getStringWidth(_label) > _w;
+	return useLowres ? _lowresLabel : _label;
 }
 
 ButtonWidget *addClearButton(GuiObject *boss, const Common::String &name, uint32 cmd, int x, int y, int w, int h) {
@@ -433,23 +448,6 @@ void ButtonWidget::setPressedState() {
 void ButtonWidget::setUnpressedState() {
 	clearFlags(WIDGET_PRESSED);
 	markAsDirty();
-}
-
-#pragma mark -
-
-ButtonWidgetAutoRes::ButtonWidgetAutoRes(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &lowresLabel, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
-	: ButtonWidget(boss, name, label, tooltip, cmd, hotkey) {
-	_lowresLabel = lowresLabel;
-}
-
-void ButtonWidgetAutoRes::setLowresLabel(const Common::U32String &label) {
-	_lowresLabel = label;
-}
-
-void ButtonWidgetAutoRes::drawWidget() {
-	bool useLowres = g_gui.theme()->getStringWidth(_label) > _w;
-	const Common::U32String &label = useLowres ? _lowresLabel : _label;
-	g_gui.theme()->drawButton(Common::Rect(_x, _y, _x + _w, _y + _h), label, _state, getFlags());
 }
 
 #pragma mark -
@@ -551,9 +549,9 @@ void DropdownButtonWidget::clearEntries() {
 void DropdownButtonWidget::drawWidget() {
 	if (_entries.empty()) {
 		// Degrade to a regular button
-		g_gui.theme()->drawButton(Common::Rect(_x, _y, _x + _w, _y + _h), _label, _state);
+		g_gui.theme()->drawButton(Common::Rect(_x, _y, _x + _w, _y + _h), getLabel(), _state);
 	} else {
-		g_gui.theme()->drawDropDownButton(Common::Rect(_x, _y, _x + _w, _y + _h), _dropdownWidth, _label,
+		g_gui.theme()->drawDropDownButton(Common::Rect(_x, _y, _x + _w, _y + _h), _dropdownWidth, getLabel(),
 										  _state, _inButton, _inDropdown, (g_gui.useRTL() && _useRTL));
 	}
 }
@@ -722,7 +720,7 @@ void CheckboxWidget::setState(bool state) {
 }
 
 void CheckboxWidget::drawWidget() {
-	g_gui.theme()->drawCheckbox(Common::Rect(_x, _y, _x + _w, _y + _h), _spacing, _label, _state, Widget::_state, (g_gui.useRTL() && _useRTL));
+	g_gui.theme()->drawCheckbox(Common::Rect(_x, _y, _x + _w, _y + _h), _spacing, getLabel(), _state, Widget::_state, (g_gui.useRTL() && _useRTL));
 }
 
 #pragma mark -
@@ -794,7 +792,7 @@ void RadiobuttonWidget::setState(bool state, bool setGroup) {
 }
 
 void RadiobuttonWidget::drawWidget() {
-	g_gui.theme()->drawRadiobutton(Common::Rect(_x, _y, _x + _w, _y + _h), _spacing, _label, _state, Widget::_state, (g_gui.useRTL() && _useRTL));
+	g_gui.theme()->drawRadiobutton(Common::Rect(_x, _y, _x + _w, _y + _h), _spacing, getLabel(), _state, Widget::_state, (g_gui.useRTL() && _useRTL));
 }
 
 #pragma mark -

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -452,15 +452,15 @@ void ButtonWidget::setUnpressedState() {
 
 #pragma mark -
 
-DropdownButtonWidget::DropdownButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey) :
-		ButtonWidget(boss, x, y, w, h, label, tooltip, cmd, hotkey) {
+DropdownButtonWidget::DropdownButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey, const Common::U32String &lowresLabel) :
+		ButtonWidget(boss, x, y, w, h, label, tooltip, cmd, hotkey, lowresLabel) {
 	setFlags(getFlags() | WIDGET_TRACK_MOUSE);
 
 	reset();
 }
 
-DropdownButtonWidget::DropdownButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey) :
-		ButtonWidget(boss, name, label, tooltip, cmd, hotkey) {
+DropdownButtonWidget::DropdownButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey, const Common::U32String &lowresLabel) :
+		ButtonWidget(boss, name, label, tooltip, cmd, hotkey, lowresLabel) {
 	setFlags(getFlags() | WIDGET_TRACK_MOUSE);
 
 	reset();

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -225,9 +225,10 @@ class ButtonWidget : public StaticTextWidget, public CommandSender {
 protected:
 	uint32	_cmd;
 	uint8	_hotkey;
+	Common::U32String _lowresLabel;
 public:
-	ButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
-	ButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
+	ButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
+	ButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
 
 	void getMinSize(int &minWidth, int &minHeight) override;
 
@@ -236,6 +237,8 @@ public:
 
 	void setLabel(const Common::U32String &label);
 	void setLabel(const Common::String &label);
+	void setLowresLabel(const Common::U32String &label);
+	const Common::U32String &getLabel();
 
 	void handleMouseUp(int x, int y, int button, int clickCount) override;
 	void handleMouseDown(int x, int y, int button, int clickCount) override;
@@ -248,18 +251,6 @@ public:
 protected:
 	void drawWidget() override;
 	bool _duringPress;
-};
-
-/* ButtonWidgetAutoRes */
-class ButtonWidgetAutoRes : public ButtonWidget {
-	Common::U32String _lowresLabel;
-
-public:
-	ButtonWidgetAutoRes(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &lowresLabel, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
-	void setLowresLabel(const Common::U32String &label);
-
-protected:
-	void drawWidget() override;
 };
 
 /* DropdownButtonWidget */

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -250,6 +250,18 @@ protected:
 	bool _duringPress;
 };
 
+/* ButtonWidgetAutoRes */
+class ButtonWidgetAutoRes : public ButtonWidget {
+	Common::U32String _lowresLabel;
+
+public:
+	ButtonWidgetAutoRes(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &lowresLabel, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
+	void setLowresLabel(const Common::U32String &label);
+
+protected:
+	void drawWidget() override;
+};
+
 /* DropdownButtonWidget */
 class DropdownButtonWidget : public ButtonWidget {
 public:

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -256,8 +256,8 @@ protected:
 /* DropdownButtonWidget */
 class DropdownButtonWidget : public ButtonWidget {
 public:
-	DropdownButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
-	DropdownButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
+	DropdownButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
+	DropdownButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
 
 	void handleMouseMoved(int x, int y, int button) override;
 	void handleMouseUp(int x, int y, int button, int clickCount) override;


### PR DESCRIPTION
just an idea I had as opposed to manually calling setLabel in reflowLayout and using hardcoded 320 pixels screen width

we could convert all of the buttons to use this, or even just bake it into the ButtonWidget class and make lowresLabel required in the constructor