### PR TITLE
DOCS: Add RetroWave OPL3 documentation

### DIFF
--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -366,12 +366,14 @@ There are many recognized configuration keys. In the table below, each key is ei
 	- macintosh "
 		":ref:`retrowaveopl3_bus <adlib>`",string,,"
 	Specifies how the RetroWave OPL3 is connected:
+	
 	- serial (connected to a USB port using a PotatoPi)
 	- spi (connected as a HAT using SPI) "
 		":ref:`retrowaveopl3_disable_buffer <adlib>`",boolean,false,
 		":ref:`retrowaveopl3_port <adlib>`",string,,"
 	Specifies the serial port that the RetroWave OPL3 is connected to.
 	For example:
+	
 	- COM3
 	- ttyACM2 "
 		":ref:`retrowaveopl3_spi_cs <adlib>`",string,,"Specifies the GPIO chip and line that the RetroWave OPL3 is connected to. Use the format <chip>,<line>."

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -374,7 +374,7 @@ There are many recognized configuration keys. In the table below, each key is ei
 	For example:
 	- COM3
 	- ttyACM2 "
-		":ref:`retrowaveopl3_spi_cs <adlib>`",string,,Specifies the GPIO chip and line that the RetroWave OPL3 is connected to. Use the format <chip>,<line>.
+		":ref:`retrowaveopl3_spi_cs <adlib>`",string,,"Specifies the GPIO chip and line that the RetroWave OPL3 is connected to. Use the format <chip>,<line>."
 		":ref:`rootpath <rootpath>`",string,,
 		":ref:`savepath <savepath>`",string,,
 		save_slot,integer,autosave, Specifies the saved game slot to load

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -335,7 +335,8 @@ There are many recognized configuration keys. In the table below, each key is ei
 	- nuked
 	- alsa
 	- op2lpt
-	- op3lpt "
+	- op3lpt
+	- rwopl3 "
 		":ref:`originalsaveload <osl>`",boolean,false,
 		":ref:`output_rate <outputrate>`",integer,,"
 	Sensible values are:
@@ -363,6 +364,17 @@ There are many recognized configuration keys. In the table below, each key is ei
 	- 2gs
 	- atari
 	- macintosh "
+		":ref:`retrowaveopl3_bus <adlib>`",string,,"
+	Specifies how the RetroWave OPL3 is connected:
+	- serial (connected to a USB port using a PotatoPi)
+	- spi (connected as a HAT using SPI) "
+		":ref:`retrowaveopl3_disable_buffer <adlib>`",boolean,false,
+		":ref:`retrowaveopl3_port <adlib>`",string,,"
+	Specifies the serial port that the RetroWave OPL3 is connected to.
+	For example:
+	- COM3
+	- ttyACM2 "
+		":ref:`retrowaveopl3_spi_cs <adlib>`",string,,Specifies the GPIO chip and line that the RetroWave OPL3 is connected to. Use the format <chip>,<line>.
 		":ref:`rootpath <rootpath>`",string,,
 		":ref:`savepath <savepath>`",string,,
 		save_slot,integer,autosave, Specifies the saved game slot to load

--- a/doc/docportal/advanced_topics/understand_audio.rst
+++ b/doc/docportal/advanced_topics/understand_audio.rst
@@ -175,7 +175,7 @@ AdLib devices do not use MIDI. They instead have a chip that produces sound thro
 
 The AdLib emulator setting offers MAME, DOSBox and Nuked emulation, with MAME being the least accurate and using the least CPU power, and Nuked being the most accurate and also using the most CPU power - DOSBox is somewhere in between.
 
-There is also the option to select the OPL2LPT, OPL3LPT and RetroWave OPL3 devices, which are external hardware devices with a real OPL chip, connected through the parallel port (OPLxLPT) or a USB port (RetroWave OPL3) of a computer. To use these devices you must specify some configuration settings in the :doc:`configuration file <../advanced_topics/configuration_file>` (the keys start with ``opl2lpt_`` and ``retrowaveopl3_``).
+There is also the option to select the OPL2LPT, OPL3LPT and RetroWave OPL3 devices, which are external hardware devices with a real OPL chip, connected through the parallel port (OPLxLPT) or a USB port (RetroWave OPL3) of a computer. To use these devices you must specify some configuration settings in the :doc:`configuration file <../advanced_topics/configuration_file>`. The keys start with ``opl2lpt_`` and ``retrowaveopl3_``.
 
 AdLib does not require a SoundFont or ROMs, so for many games it might be the easiest to configure. However, if an MT-32 or GS emulator or device is available, ScummVM will prioritize this over AdLib.
 

--- a/doc/docportal/advanced_topics/understand_audio.rst
+++ b/doc/docportal/advanced_topics/understand_audio.rst
@@ -175,7 +175,7 @@ AdLib devices do not use MIDI. They instead have a chip that produces sound thro
 
 The AdLib emulator setting offers MAME, DOSBox and Nuked emulation, with MAME being the least accurate and using the least CPU power, and Nuked being the most accurate and also using the most CPU power - DOSBox is somewhere in between.
 
-There is also the option to select the OPL2LPT and OPL3LPT devices, which are external hardware devices with a real OPL chip, connected through the parallel port of a computer.
+There is also the option to select the OPL2LPT, OPL3LPT and RetroWave OPL3 devices, which are external hardware devices with a real OPL chip, connected through the parallel port (OPLxLPT) or a USB port (RetroWave OPL3) of a computer. To use these devices you must specify some configuration settings in the :doc:`configuration file <../advanced_topics/configuration_file>` (the keys start with ``opl2lpt_`` and ``retrowaveopl3_``).
 
 AdLib does not require a SoundFont or ROMs, so for many games it might be the easiest to configure. However, if an MT-32 or GS emulator or device is available, ScummVM will prioritize this over AdLib.
 


### PR DESCRIPTION
This adds info to the documentation on the RetroWave OPL3 and how to configure it.