### PR TITLE
SCUMM: Work around TurboGrafx-16 / PC Engine Loom glitch

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -361,7 +361,34 @@ void ScummEngine_v5::setupOpcodes() {
 }
 
 int ScummEngine_v5::getVar() {
-	return readVar(fetchScriptWord());
+	const byte *oldaddr = _scriptPointer - 1;
+
+	uint var = fetchScriptWord();
+	int result = readVar(var);
+
+	// WORKAROUND: Examining the dragon's pile of gold a second time causes
+	// Bobbin to animate as if he's talking, but no text is displayed. When
+	// running the game in an emulator, there's neither text nor animation
+	// when examining the pile again. While the symptoms are slightly
+	// different, this points to a script bug.
+	//
+	// I think this happens because in the PC Engine version the entire
+	// scene is a cutscene. In the EGA version, only the part where the
+	// dragon responds is. So the cutscene starts, the message is printed
+	// and then the cutscene immediately ends, which triggers an "end of
+	// cutscene" script. This is probably what clears the text.
+	//
+	// The script sets Bit[92] to indicate that the dragon has responded.
+	// If the bit has been set, we simulate a WaitForMessage() instruction
+	// here, so that the script pauses until the "Wow!" message is gone.
+
+	if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && vm.slot[_currentScript].number == 109 && var == 32860 && result == 1 && VAR(VAR_HAVE_MSG)) {
+		_scriptPointer = oldaddr;
+		o5_breakHere();
+		return 0;
+	}
+
+	return result;
 }
 
 int ScummEngine_v5::getVarOrDirectByte(byte mask) {


### PR DESCRIPTION
NOTE: This has _only_ been tested with the English version, but dwa has promised to try the Japanese version when he has the time. It should preferrably not be merged before this.

This is an attempt at working around a script bug in the TurboGrafx-16 / PC Engine version of Loom. It works by simulating a WaitForMessage() instruction if you examine the dragon's pile of gold a second time.

In the EGA version, script-109 does something like this:

```
[0000] (14) print(1,[Center(),Text("Wow!")]);
[0009] (28) if (!Var[217 Bit 4]) {
[000E] (28)   if (!Var[219 Bit 12]) {
[0013] (40)     cutscene([0]);
[0018] (1A)     Var[219 Bit 12] = 1;
[001D] (AE)     WaitForMessage();

... The dragon responds

[03A9] (80)     breakHere();
[03AA] (C0)     endCutscene();
[03AB] (**)   }
[03AB] (**) }
[03AB] (A0) stopObjectCode();
```

In the TurboGrafx-16 / PC Engine version, the cutscene() / endCutscene() calls have been moved:

```
[0000] (40) cutscene([1]);
[0005] (14) print(1,[Center(),Pos(160,152),Text("Wow!")]);
[0013] (28) if (!Bit[52]) {
[0018] (28)   if (!Bit[92]) {
[001D] (1A)     Bit[92] = 1;
[0022] (AE)     WaitForMessage();

... The dragon responds

[03AC] (80)     breakHere();
[03AD] (**)   }
[03AD] (**) }
[03AD] (C0) endCutscene();
[03AE] (A0) stopObjectCode();
```

I'm guessing this causes the text to be immediately cleared if the dragon doesn't respond, possibly by the "end of cutscene" script.

The placement of the workaround can be discussed. Right now it's in ScummEngine_v5::getVar(), which is presumably called a _lot_. But what's the alternative? I was considering putting it in o5_equalZero(), but surely that's called about as often, and it's more work to figure out which variable it's about to test.

I'm include the two versions of the script, and a gzipped savegame (because GitHub doesn't let me attach an uncompressed one).

[ega-script-109.txt](https://github.com/scummvm/scummvm/files/8108263/ega-script-109.txt)
[pce-script-109.txt](https://github.com/scummvm/scummvm/files/8108264/pce-script-109.txt)

[loom-pce.s07.gz](https://github.com/scummvm/scummvm/files/8108254/loom-pce.s07.gz)
