### PR TITLE
SCUMM: Work around timing bug when Mandible uses the distaff in VGA Loom

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1338,7 +1338,8 @@ void ScummEngine_v5::o5_isLess() {
 }
 
 void ScummEngine_v5::o5_isLessEqual() {
-	int16 a = getVar();
+	int var = fetchScriptWord();
+	int16 a = readVar(var);
 	int16 b = getVarOrDirectWord(PARAM_1);
 
 	// WORKAROUND bug #1266 : Work around a bug in Indy3Town.
@@ -1347,6 +1348,16 @@ void ScummEngine_v5::o5_isLessEqual() {
 	    _currentRoom == 70 && b == -256) {
 		o5_jumpRelative();
 		return;
+	}
+
+	// WORKAROUND: When Mandible uses the distaff, it seems to light up
+	// only three times with no animation for the second note. Actually,
+	// the animations for the first and second notes are played so closely
+	// together that they look like one. This adjusts the timing of the
+	// second one.
+
+	if (_game.id == GID_LOOM && _game.version >= 4 && _language == Common::EN_ANY && vm.slot[_currentScript].number == 95 && var == VAR_MUSIC_TIMER && b == 1708) {
+		b = 1815;
 	}
 
 	jumpRelative(b <= a);


### PR DESCRIPTION
This fixes a timing bug when Mandible uses the distaff in VGA Loom. Right now it's restricted to English, because I actually have no idea if the VGA version was ever translated into other languages. And if it was, it may already work fine in those.

The bug is that it looks like the distaff only lights up three times, not four, when Mandible uses the distaff. Actually, the first two animations are so close that they look like one. The workaround is to make the second animation happen a bit later.

I'm pretty sure this happens in the original. These YouTube videos appear to be made with the original interpreter:

https://www.youtube.com/watch?v=0kEqyb5OhuQ
https://www.youtube.com/watch?v=Nk2WtuOPYwI
https://www.youtube.com/watch?v=QbokcgdGt5k

Here are savegames for that scene for all the Loom versions I own: [loom-savegames.tar.gz](https://github.com/scummvm/scummvm/files/8139980/loom-savegames.tar.gz)

Short video before the workaround: https://user-images.githubusercontent.com/601765/155688560-eeae6754-7f0c-4fd8-b120-b1f9253c7102.mp4
Short video after the workaround: https://user-images.githubusercontent.com/601765/155688623-4defae60-f813-4eb8-99d7-dba24f3ec606.mp4

Something you may notice in both videos is Mandible's head suddenly being redrawn. I _think_ this is caused by his line of speech timing out, which causes stopTalk() to be called. I haven't been able to think of any good way to avoid that. To the best of my knowledge, it only happens in the VGA talkie versions. Maybe it's because of the different SCUMM version they use, or maybe it's because of all the [ridiculous flailing of arms](https://tvtropes.org/pmwiki/pmwiki.php/Main/MilkingTheGiantCow) they added throughout the game, and not just to Mandible.