### PR TITLE
Add bink as a dependency to icb

### DIFF
--- a/engines/icb/configure.engine
+++ b/engines/icb/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine icb "In Cold Blood" no "" "" "16bit highres zlib"
+add_engine icb "In Cold Blood" no "" "" "16bit highres zlib bink"


### PR DESCRIPTION
Very small change: I don't think icb can compile without having bink enabled (or I haven't figured out how).