### PR TITLE
PACo: mark method as override

### DIFF
--- a/video/paco_decoder.h
+++ b/video/paco_decoder.h
@@ -49,7 +49,7 @@ public:
 	PacoDecoder();
 	virtual ~PacoDecoder();
 
-	virtual bool loadStream(Common::SeekableReadStream *stream);
+	virtual bool loadStream(Common::SeekableReadStream *stream) override;
 
 	const Common::List<Common::Rect> *getDirtyRects() const;
 	void clearDirtyRects();


### PR DESCRIPTION
This is a minor tweak to a file introduced recently in 24b7267b8beade20342822e3e29484590758beb4. The compiler flags the member function as needing `override`:

```
In file included from video/paco_decoder.cpp:29:
./video/paco_decoder.h:52:15: warning: 'loadStream' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual bool loadStream(Common::SeekableReadStream *stream);
                     ^
./video/video_decoder.h:82:15: note: overridden virtual function is here
        virtual bool loadStream(Common::SeekableReadStream *stream) = 0;
                     ^
1 warning generated.
```

A few other `override`s were added in fa9f8850bfaa8ec7dc9cf750e5861a5bf6140add, but looks like this one got missed.