### PR TITLE
IOS: Added support for GLAD

### DIFF
--- a/backends/platform/ios7/ios7_common.h
+++ b/backends/platform/ios7/ios7_common.h
@@ -112,6 +112,7 @@ bool iOS7_isBigDevice();
 
 void iOS7_buildSharedOSystemInstance();
 void iOS7_main(int argc, char **argv);
+void *iOS7_getProcAddress(const char *name);
 const char *iOS7_getDocumentsDir();
 bool iOS7_touchpadModeEnabled();
 

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -27,6 +27,7 @@
 
 #include <sys/time.h>
 #include <QuartzCore/QuartzCore.h>
+#include <dlfcn.h>
 
 #include "common/scummsys.h"
 #include "common/util.h"
@@ -411,4 +412,8 @@ void iOS7_main(int argc, char **argv) {
 		//*stderr = NULL;
 		fclose(newfp);
 	}
+}
+
+void *iOS7_getProcAddress(const char *name) {
+	return dlsym(RTLD_SELF, name);
 }

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -47,6 +47,13 @@ static GLADapiproc loadFunc(void *userptr, const char *name) {
 	return (GLADapiproc)androidGLgetProcAddress(name);
 }
 
+#elif defined(IPHONE_IOS7)
+#include "backends/platform/ios7/ios7_common.h"
+
+static GLADapiproc loadFunc(void *userptr, const char *name) {
+	return (GLADapiproc)iOS7_getProcAddress(name);
+}
+
 #else
 #error Not implemented
 #endif


### PR DESCRIPTION
This adds implementation for GLAD's `loadFunc` for iOS.
Implementation use dynamic library function `dlsym` to get function pointer from running app.
Backend code still use directly linked GLES2 library, but common OpenGL and engines will use GLAD header and loader.
This allows compile all engines OpenGL code and also runtime GL API binding.