### PR TITLE
BASE: Add alsa to the opl-driver CLI help

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -157,6 +157,9 @@ static const char HELP_STRING[] =
 #ifndef DISABLE_NUKED_OPL
 																	 ", nuked"
 #endif
+#ifdef USE_ALSA
+																	 ", alsa"
+#endif
 #ifdef ENABLE_OPL2LPT
 																	 ", opl2lpt"
 #endif


### PR DESCRIPTION
This makes it clear that ALSA Direct FM can be selected for AdLib
FM synthesis on the CLI.
