### PR TITLE
GUI: Fix debugger md5 to resolve paths.

### DIFF
--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -651,17 +651,17 @@ bool Debugger::cmdMd5(int argc, const char **argv) {
 			filename = filename + " " + argv[i];
 		}
 		Common::ArchiveMemberList list;
-		SearchMan.listMatchingMembers(list, filename);
-		if (list.empty()) {
-			debugPrintf("File '%s' not found\n", filename.c_str());
+		Common::Path Filename(filename, '/');
+		Common::FSNode path(Filename);
+		if (!path.exists()) {
+			debugPrintf("Non-existent file path\n");
+		} else if (!path.isReadable()) {
+			debugPrintf("Non-readable file path\n");
 		} else {
-			sort(list.begin(), list.end(), ArchiveMemberLess());
-			for (Common::ArchiveMemberList::iterator iter = list.begin(); iter != list.end(); ++iter) {
-				Common::SeekableReadStream *stream = (*iter)->createReadStream();
-				Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
-				debugPrintf("%s  %s  %d\n", md5.c_str(), (*iter)->getName().c_str(), (int32)stream->size());
-				delete stream;
-			}
+			Common::SeekableReadStream *stream = path.createReadStream();
+			Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
+			debugPrintf("%s  %s  %d\n", md5.c_str(), path.getName().c_str(), (int32)stream->size());
+			delete stream;
 		}
 	}
 	return true;


### PR DESCRIPTION
Fixes Trac [#13343](https://bugs.scummvm.org/ticket/13343)

The md5 command of debugger could only show hashes of files in the same directory as that of the scummvm executable, i.e. while ```md5 Makefile``` would give us its md5 hash, ```md5 ./LICENSES/COPYING.LUA``` would result in an error.

I changed the pattern resolution by using FSnode instead of Path. Now md5 command can resolve paths too.
