### PR TITLE
SCUMM: RFC: (Obsolete?) Make certain workarounds optional

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,8 @@ For a more comprehensive changelog of the latest experimental code, see:
    - It is now possible to replace the music in the floppy versions of Loom
      with audio tracks. The ScummVM Wiki has a list of which parts of the Swan
      Lake ballet the game uses.
+   - Added options for whether or not ScummVM should restore some of the
+     original MI1 behavior and fix a typo in VGA Loom.
 
  Sherlock:
    - Fixed slowdown in Serrated Scalpel intro when playing the game from a small

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -227,6 +227,13 @@ static const ExtraGuiOption mi1RestoreClockTowerBehavior = {
 	true
 };
 
+static const ExtraGuiOption mi1RestoreLemonheadDialog = {
+	_s("Restore missing Lemonhead dialog"),
+	_s("Restore a few lines of Lemonhead dialog that was present in earlier versions."),
+	"restore_lemonhead_dialog",
+	true
+};
+
 const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
 	ExtraGuiOptions options;
 	// Query the GUI options
@@ -235,6 +242,7 @@ const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common:
 	const Common::String extra = ConfMan.get("extra", target);
 	const Common::String guiOptions = parseGameGUIOptions(guiOptionsString);
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", target));
+	const Common::Language lang = Common::parseLanguage(ConfMan.get("language"));
 
 	if (target.empty() || gameid == "comi") {
 		options.push_back(comiObjectLabelsOption);
@@ -291,6 +299,10 @@ const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common:
 		if (enhanced) {
 			options.push_back(mi1RestoreSmirkCigarSmoke);
 			options.push_back(mi1RestoreClockTowerBehavior);
+
+			if (lang == Common::EN_ANY || lang == Common::DE_DEU || lang == Common::IT_ITA || lang == Common::ES_ESP) {
+				options.push_back(mi1RestoreLemonheadDialog);
+			}
 		}
 	}
 

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -234,6 +234,13 @@ static const ExtraGuiOption mi1RestoreLemonheadDialog = {
 	true
 };
 
+static const ExtraGuiOption loomCorrectVillainTypo = {
+	_s("Correct villain typo"),
+	_s("Correct the misspelling of the villain's name in one scene."),
+	"correct_villain_typo",
+	true
+};
+
 const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
 	ExtraGuiOptions options;
 	// Query the GUI options
@@ -303,6 +310,12 @@ const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common:
 			if (lang == Common::EN_ANY || lang == Common::DE_DEU || lang == Common::IT_ITA || lang == Common::ES_ESP) {
 				options.push_back(mi1RestoreLemonheadDialog);
 			}
+		}
+	}
+
+	if (target.empty() || gameid == "loom") {
+		if (extra == "VGA" && lang == Common::EN_ANY) {
+			options.push_back(loomCorrectVillainTypo);
 		}
 	}
 

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -213,6 +213,13 @@ static const ExtraGuiOption smoothScrolling = {
 	true
 };
 
+static const ExtraGuiOption mi1RestoreSmirkCigarSmoke = {
+	_s("Restore cigar smoke"),
+	_s("Show animated cigar smoke in the close-up of captain Smirk."),
+	"restore_smirk_cigar_smoke",
+	true
+};
+
 const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
 	ExtraGuiOptions options;
 	// Query the GUI options
@@ -255,6 +262,28 @@ const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common:
 
 	if (target.empty() || (gameid == "indy3" && platform == Common::kPlatformMacintosh && extra != "Steam")) {
 		options.push_back(macV3CorrectFontSpacing);
+	}
+
+	// Add settings for turning off some of the more visible workarounds.
+	// The policy here is to add settings that make really noticeable
+	// changes, where people have expressed the desire to disable the
+	// workarounds.
+	//
+	// E.g. I don't think anyone's going to complain that ScummVM never
+	// draws Sam and Max in color when using the noir mode.
+
+	if (target.empty() || gameid == "monkey") {
+		// Note that we do not touch the unofficial talkie version,
+		// since that one patches a lot of scripts on its own.
+
+		bool enhanced = (extra == "CD" ||
+			platform == Common::kPlatformMacintosh ||
+			platform == Common::kPlatformFMTowns ||
+			platform == Common::kPlatformSegaCD);
+
+		if (enhanced) {
+			options.push_back(mi1RestoreSmirkCigarSmoke);
+		}
 	}
 
 	return options;

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -220,6 +220,13 @@ static const ExtraGuiOption mi1RestoreSmirkCigarSmoke = {
 	true
 };
 
+static const ExtraGuiOption mi1RestoreClockTowerBehavior = {
+	_s("Restore clock tower behavior"),
+	_s("Restore the original behavior of the clock tower."),
+	"restore_clock_tower_behavior",
+	true
+};
+
 const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
 	ExtraGuiOptions options;
 	// Query the GUI options
@@ -283,6 +290,7 @@ const ExtraGuiOptions ScummMetaEngineDetection::getExtraGuiOptions(const Common:
 
 		if (enhanced) {
 			options.push_back(mi1RestoreSmirkCigarSmoke);
+			options.push_back(mi1RestoreClockTowerBehavior);
 		}
 	}
 

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -533,10 +533,12 @@ GUI::OptionsContainerWidget *ScummMetaEngine::buildEngineOptionsWidgetDynamic(GU
 	if (ConfMan.get("gameid", target) != "loom")
 		return nullptr;
 
-	// These Loom settings are only relevant for the EGA version, so
-	// exclude non-DOS versions. If the game was added a long time ago,
-	// the platform may still be listed as unknown, and there may be no
-	// "extra" field to query.
+	// These Loom settings are only relevant for the EGA version, since
+	// that is the only one that has the Overture. So exclude non-DOS
+	// versions. If the game was added a long time ago, the platform may
+	// still be listed as unknown. Using the "extra" field should take
+	// care of any remaining cases, since ScummVM will update it if it's
+	// not set at all.
 
 	Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", target));
 	if (platform != Common::kPlatformUnknown && platform != Common::kPlatformDOS)
@@ -547,7 +549,9 @@ GUI::OptionsContainerWidget *ScummMetaEngine::buildEngineOptionsWidgetDynamic(GU
 	if (extra == "Steam" || extra == "VGA")
 		return nullptr;
 
-	// So we still can't be quite sure it's the EGA version. Oh well...
+	// Hopefully we can now be fairly confident that this is in fact the
+	// EGA version.
+
 	return new Scumm::LoomEgaGameOptionsWidget(boss, name, target);
 }
 

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -336,6 +336,12 @@ Common::Error ScummMetaEngine::createInstance(OSystem *syst, Engine **engine) {
 	// file transparently.
 	Common::updateGameGUIOptions(res.game.guioptions, getGameGUIOptionsDescriptionLanguage(res.language));
 
+	// If you added the game a long time ago, it may be missing its "extra"
+	// field. We need it to tell versions apart when adding game-specific
+	// settings to the options dialog.
+	if (res.game.variant && res.game.variant[0] && !ConfMan.hasKey("extra"))
+		ConfMan.setAndFlush("extra", res.game.variant);
+
 	// Check for a user override of the platform. We allow the user to override
 	// the platform, to make it possible to add games which are not yet in
 	// our MD5 database but require a specific platform setting.

--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1738,7 +1738,7 @@ void ScummEngine::applyWorkaroundIfNeeded(ResType type, int idx) {
 	// overwritten. This probably affects all CD versions, so we just have
 	// to add further patches as they are reported.
 
-	if (_game.id == GID_MONKEY && type == rtRoom && idx == 25) {
+	if (_game.id == GID_MONKEY && type == rtRoom && idx == 25 && ConfMan.getBool("restore_lemonhead_dialog")) {
 		tryPatchMI1CannibalScript(getResourceAddress(type, idx), size);
 	} else
 

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2927,7 +2927,7 @@ void ScummEngine_v5::decodeParseString() {
 		case 15:{	// SO_TEXTSTRING
 				const int len = resStrLen(_scriptPointer);
 
-				if (_game.id == GID_LOOM && vm.slot[_currentScript].number == 95 && strcmp((const char *)_scriptPointer, "I am Choas.") == 0) {
+				if (_game.id == GID_LOOM && vm.slot[_currentScript].number == 95 && strcmp((const char *)_scriptPointer, "I am Choas.") == 0 && ConfMan.getBool("correct_villain_typo")) {
 					// WORKAROUND: This happens when Chaos introduces
 					// herself to bishop Mandible. Of all the places to put
 					// a typo...

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -457,7 +457,7 @@ void ScummEngine_v5::o5_actorOps() {
 			// But in the VGA CD version, only costume 0 is used
 			// and the close-up is missing the cigar smoke.
 
-			if (_game.id == GID_MONKEY && _currentRoom == 76 && act == 12 && i == 0) {
+			if (_game.id == GID_MONKEY && _currentRoom == 76 && act == 12 && i == 0 && ConfMan.getBool("restore_smirk_cigar_smoke")) {
 				i = 76;
 			}
 
@@ -1627,7 +1627,7 @@ void ScummEngine_v5::o5_putActor() {
 	// other coordinates. The difference is never more than a single pixel,
 	// so there's not much reason to correct those.
 
-	if (_game.id == GID_MONKEY && _currentRoom == 76 && act == 12) {
+	if (_game.id == GID_MONKEY && _currentRoom == 76 && act == 12 && ConfMan.getBool("restore_smirk_cigar_smoke")) {
 		if (x == 176 && y == 80) {
 			x = 174;
 			y = 86;
@@ -1899,7 +1899,7 @@ void ScummEngine_v5::o5_roomOps() {
 			// we want the original color 3 for the cigar smoke. It
 			// should be ok since there is no GUI in this scene.
 
-			if (_game.id == GID_MONKEY && _currentRoom == 76 && d == 3)
+			if (_game.id == GID_MONKEY && _currentRoom == 76 && d == 3 && ConfMan.getBool("restore_smirk_cigar_smoke"))
 				break;
 
 			setPalColor(d, a, b, c);	/* index, r, g, b */

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -670,7 +670,7 @@ void ScummEngine_v5::o5_add() {
 	// We restore the old behavior by adding 0, not 1, to the second
 	// variable when examining the clock tower.
 
-	if (_game.id == GID_MONKEY && vm.slot[_currentScript].number == 210 && _currentRoom == 35 && _resultVarNumber == 248 && a == 1) {
+	if (_game.id == GID_MONKEY && vm.slot[_currentScript].number == 210 && _currentRoom == 35 && _resultVarNumber == 248 && a == 1 && ConfMan.getBool("restore_clock_tower_behavior")) {
 		a = 0;
 	}
 


### PR DESCRIPTION
Based on some posts in https://forums.mixnmojo.com/topic/200399-scummvm-versus-native-interpreters/ it seems that there are those who feel like ScummVM should offer some option to _not_ fix certain bugs. Well, that opens up a can of worms since a) I doubt ScummVM is _ever_ going to play every game pixel-perfect compared to the original, and b) that would be a _lot_ of options that hardly no one would ever want to touch. The SCI engine alone, where script patching is down to a fine art, there appear to be hundreds of them.

I mean, are there actually players who _want_ the green goo in Sam & Max's Hall of Oddities to be slightly misaligned, or want Sam and Max to sometimes appear in colour when noir mode is activated? I doubt it.

But let's say we make some concessions to those who want the see the original behavior without breaking out DOSBox? This patch adds four such settings to the SCUMM engine:

- An option for whether or not to restore the animated cigar smoke in the MI1 captain Smirk close-up. _The Art of Point-and-Click Adventure Games_ by Bitmap Books show a screenshot without the cigar smoke, so that's something people might notice.
- An option for whether or not to restore the original MI1 clock tower behavior. There was some discussion about whether or not to make it optional when this was worked around.
- An option for whether or not to restore the missing MI1 Lemonhead lines.
- An option for whether or not to fix the Chaos/Choas typo in VGA Loom. The typo was mentioned by Brian Moriarty in his GDC Loom retrospective, so that's something people may be aware of.

Is this a good idea or not?

The patch also forces the SCUMM engine to update the "extra" field in the config file, if it isn't set already, since it's needed to tell certain versions apart. So even if nothing else from this pull request is merged, that may still be a good idea?