### PR TITLE
SCUMM: DIG/DiMUSE: Implement mouth sync times retrieval and handling

### DIFF
--- a/engines/scumm/imuse_digi/dimuse_cmds.cpp
+++ b/engines/scumm/imuse_digi/dimuse_cmds.cpp
@@ -81,6 +81,9 @@ int IMuseDigital::cmdsHandleCmd(int cmd, uint8 *ptr, int a, int b, int c, int d,
 		return _triggersHandler->clearTrigger(a, marker, c);
 	case 20:
 		return _triggersHandler->deferCommand(a, b, c, d, e, f, g, h, i, j, k, l, m, n);
+	case 21:
+		_vm->_sound->extractSyncsFromDiMUSEMarker((char *)ptr);
+		break;
 	case 25:
 		return waveStartStream(a, b, c);
 	case 26:

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -771,10 +771,6 @@ int IMuseDigital::diMUSESetTrigger(int soundId, int marker, int opcode, int d, i
 	return cmdsHandleCmd(17, nullptr, soundId, marker, opcode, d, e, f, g, h, i, j, k, l, m, n);
 }
 
-int IMuseDigital::diMUSEExtractMouthSyncTimes(char *marker) {
-	return cmdsHandleCmd(21, (uint8 *)marker);
-}
-
 int IMuseDigital::diMUSEStartStream(int soundId, int priority, int bufferId) {
 	return cmdsHandleCmd(25, nullptr, soundId, priority, bufferId);
 }

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -180,6 +180,12 @@ int IMuseDigital::startVoice(int soundId, const char *soundName, byte speakingAc
 			diMUSEStopSound(DIMUSE_SMUSH_SOUNDID + DIMUSE_BUFFER_SPEECH);
 		}
 
+		// Set up a trigger for extracting mouth sync times;
+		// see Sound::extractSyncsFromDiMUSEMarker() for details.
+		// Setting up a trigger with an empty marker is a shortcut for
+		// activating the trigger for any marker.
+		diMUSESetTrigger(kTalkSoundID, 0, 21);
+
 		diMUSEStartStream(kTalkSoundID, 127, DIMUSE_BUFFER_SPEECH);
 		diMUSESetParam(kTalkSoundID, DIMUSE_P_GROUP, DIMUSE_GROUP_SPEECH);
 		if (speakingActorId == _vm->VAR(_vm->VAR_EGO)) {
@@ -763,6 +769,10 @@ int IMuseDigital::diMUSESetHook(int soundId, int hookId) {
 
 int IMuseDigital::diMUSESetTrigger(int soundId, int marker, int opcode, int d, int e, int f, int g, int h, int i, int j, int k, int l, int m, int n) {
 	return cmdsHandleCmd(17, nullptr, soundId, marker, opcode, d, e, f, g, h, i, j, k, l, m, n);
+}
+
+int IMuseDigital::diMUSEExtractMouthSyncTimes(char *marker) {
+	return cmdsHandleCmd(21, (uint8 *)marker);
 }
 
 int IMuseDigital::diMUSEStartStream(int soundId, int priority, int bufferId) {

--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -354,7 +354,12 @@ public:
 	int diMUSEGetParam(int soundId, int paramId);
 	int diMUSEFadeParam(int soundId, int opcode, int destValue, int fadeLength);
 	int diMUSESetHook(int soundId, int hookId);
-	int diMUSESetTrigger(int soundId, int marker, int opcode, int d, int e, int f, int g, int h, int i, int j, int k, int l, int m, int n);
+
+	int diMUSESetTrigger(int soundId, int marker, int opcode,
+		int d = -1, int e = -1, int f = -1, int g = -1,
+		int h = -1, int i = -1, int j = -1, int k = -1,
+		int l = -1, int m = -1, int n = -1);
+
 	int diMUSEStartStream(int soundId, int priority, int groupId);
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, int fadeDelay, int fadeSyncFlag2, int fadeSyncFlag1);
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, uint8 *crossfadeBuffer, int crossfadeBufferSize, int vocLoopFlag);

--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -360,7 +360,6 @@ public:
 		int h = -1, int i = -1, int j = -1, int k = -1,
 		int l = -1, int m = -1, int n = -1);
 
-	int diMUSEExtractMouthSyncTimes(char *marker);
 	int diMUSEStartStream(int soundId, int priority, int groupId);
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, int fadeDelay, int fadeSyncFlag2, int fadeSyncFlag1);
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, uint8 *crossfadeBuffer, int crossfadeBufferSize, int vocLoopFlag);

--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -360,6 +360,7 @@ public:
 		int h = -1, int i = -1, int j = -1, int k = -1,
 		int l = -1, int m = -1, int n = -1);
 
+	int diMUSEExtractMouthSyncTimes(char *marker);
 	int diMUSEStartStream(int soundId, int priority, int groupId);
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, int fadeDelay, int fadeSyncFlag2, int fadeSyncFlag1);
 	int diMUSESwitchStream(int oldSoundId, int newSoundId, uint8 *crossfadeBuffer, int crossfadeBufferSize, int vocLoopFlag);

--- a/engines/scumm/imuse_digi/dimuse_scripts.cpp
+++ b/engines/scumm/imuse_digi/dimuse_scripts.cpp
@@ -599,7 +599,7 @@ void IMuseDigital::playDigMusic(const char *songName, const imuseDigTable *table
 
 		if (table->transitionType == 4) {
 			_stopSequenceFlag = 0;
-			diMUSESetTrigger(table->soundId, MKTAG('_', 'e', 'n', 'd'), 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+			diMUSESetTrigger(table->soundId, MKTAG('_', 'e', 'n', 'd'), 0);
 		}
 
 		if (oldSoundId) {
@@ -645,7 +645,7 @@ void IMuseDigital::playDigMusic(const char *songName, const imuseDigTable *table
 		break;
 	case 6:
 		_stopSequenceFlag = 0;
-		diMUSESetTrigger(DIMUSE_SMUSH_SOUNDID + DIMUSE_BUFFER_MUSIC, MKTAG('_', 'e', 'n', 'd'), 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+		diMUSESetTrigger(DIMUSE_SMUSH_SOUNDID + DIMUSE_BUFFER_MUSIC, MKTAG('_', 'e', 'n', 'd'), 0);
 		break;
 	case 7:
 		if (oldSoundId)
@@ -821,7 +821,7 @@ void IMuseDigital::playComiMusic(const char *songName, const imuseComiTable *tab
 
 		if (table->transitionType == 4) {
 			_stopSequenceFlag = 0;
-			diMUSESetTrigger(table->soundId, MKTAG('_', 'e', 'n', 'd'), 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+			diMUSESetTrigger(table->soundId, MKTAG('_', 'e', 'n', 'd'), 0);
 		}
 
 		if (oldSoundId) {
@@ -852,10 +852,10 @@ void IMuseDigital::playComiMusic(const char *songName, const imuseComiTable *tab
 					switch (table->transitionType) {
 					case 12:
 						diMUSESetHook(oldSoundId, table->hookId);
-						diMUSESetTrigger(oldSoundId, MKTAG('e', 'x', 'i', 't'), 26, oldSoundId, table->soundId, fadeDelay, 1, 0, -1, -1, -1, -1, -1, -1);
-						diMUSESetTrigger(oldSoundId, MKTAG('e', 'x', 'i', 't'), 12, table->soundId, DIMUSE_P_VOLUME, 127, -1, -1, -1, -1, -1, -1, -1, -1);
-						diMUSESetTrigger(oldSoundId, MKTAG('e', 'x', 'i', 't'), 12, table->soundId, DIMUSE_P_GROUP, 4, -1, -1, -1, -1, -1, -1, -1, -1);
-						diMUSESetTrigger(oldSoundId, MKTAG('e', 'x', 'i', 't'), 15, table->soundId, hookId, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+						diMUSESetTrigger(oldSoundId, MKTAG('e', 'x', 'i', 't'), 26, oldSoundId, table->soundId, fadeDelay, 1, 0);
+						diMUSESetTrigger(oldSoundId, MKTAG('e', 'x', 'i', 't'), 12, table->soundId, DIMUSE_P_VOLUME, 127);
+						diMUSESetTrigger(oldSoundId, MKTAG('e', 'x', 'i', 't'), 12, table->soundId, DIMUSE_P_GROUP, 4);
+						diMUSESetTrigger(oldSoundId, MKTAG('e', 'x', 'i', 't'), 15, table->soundId, hookId);
 						diMUSEProcessStreams();
 						break;
 					default:
@@ -883,7 +883,7 @@ void IMuseDigital::playComiMusic(const char *songName, const imuseComiTable *tab
 		break;
 	case 6:
 		_stopSequenceFlag = 0;
-		diMUSESetTrigger(DIMUSE_SMUSH_SOUNDID + DIMUSE_BUFFER_MUSIC, MKTAG('_', 'e', 'n', 'd'), 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+		diMUSESetTrigger(DIMUSE_SMUSH_SOUNDID + DIMUSE_BUFFER_MUSIC, MKTAG('_', 'e', 'n', 'd'), 0);
 		break;
 	case 7:
 		if (oldSoundId)
@@ -897,7 +897,7 @@ void IMuseDigital::playComiMusic(const char *songName, const imuseComiTable *tab
 		if (oldSoundId)
 			diMUSESetHook(oldSoundId, table->hookId);
 		_stopSequenceFlag = 0;
-		diMUSESetTrigger(oldSoundId, MKTAG('_', 'e', 'n', 'd'), 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+		diMUSESetTrigger(oldSoundId, MKTAG('_', 'e', 'n', 'd'), 0);
 		break;
 	default:
 		debug(5, "IMuseDigital::playComiMusic(): bogus transition type, ignored");

--- a/engines/scumm/imuse_digi/dimuse_triggers.cpp
+++ b/engines/scumm/imuse_digi/dimuse_triggers.cpp
@@ -192,7 +192,7 @@ void IMuseDigiTriggersHandler::processTriggers(int soundId, char *marker) {
 		} else {
 			if (_trigs[l].opcode < 30) {
 				// Execute a command
-				_engine->cmdsHandleCmd(_trigs[l].opcode, nullptr,
+				_engine->cmdsHandleCmd(_trigs[l].opcode, (uint8 *)textBuffer,
 					_trigs[l].a, _trigs[l].b,
 					_trigs[l].c, _trigs[l].d,
 					_trigs[l].e, _trigs[l].f,

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -659,6 +659,10 @@ void Sound::startTalkSound(uint32 offset, uint32 b, int mode, Audio::SoundHandle
 	if (_vm->_game.id == GID_CMI || (_vm->_game.id == GID_DIG && !(_vm->_game.features & GF_DEMO))) {
 		// COMI (full & demo), DIG (full)
 		_sfxMode |= mode;
+
+		if (_vm->_game.id == GID_DIG)
+			_curSoundPos = 0;
+
 		return;
 	} else if (_vm->_game.id == GID_DIG && (_vm->_game.features & GF_DEMO)) {
 		_sfxMode |= mode;
@@ -927,6 +931,11 @@ bool Sound::isMouthSyncOff(uint pos) {
 	bool val = true;
 	uint16 *ms = _mouthSyncTimes;
 
+	if (_vm->_game.id == GID_DIG && !(_vm->_game.features & GF_DEMO)) {
+		pos = 1000 * pos / 60;
+		val = false;
+	}
+
 	_endOfMouthSync = false;
 	do {
 		val = !val;
@@ -1175,6 +1184,27 @@ ScummFile *Sound::restoreDiMUSESpeechFile(const char *fileName) {
 	}
 
 	return file.release();
+}
+
+/* The approach used by the full version of The Dig for obtaining mouth syncs is a bit weird:
+ * they are stored in a text marker found inside the DiMUSE map for each speech file, and when
+ * said engine reaches said marker, the function below is triggered.
+ *
+ * A good reason why this is the way it's done, is that in The Dig the whole speech file,
+ * including its map (and consequently, the text marker), is compressed with the same codec as
+ * sound data; this prevents us from getting the mouth syncs before the file has started playing.
+ * Also, although I can't confirm this, there might be more than one sync marker in a single
+ * speech file, so let's just be safe and follow what the original does.
+ */
+void Sound::extractSyncsFromDiMUSEMarker(const char *marker) {
+	int syncIdx = 0;
+
+	while (marker[syncIdx * 8]) {
+		_mouthSyncTimes[syncIdx] = (uint16)atoi(&marker[syncIdx * 8]);
+		syncIdx++;
+	}
+
+	_mouthSyncTimes[syncIdx] = 0xFFFF;
 }
 
 void Sound::setupSfxFile() {

--- a/engines/scumm/sound.h
+++ b/engines/scumm/sound.h
@@ -137,6 +137,7 @@ public:
 	bool isSfxFileCompressed();
 	bool hasSfxFile() const;
 	ScummFile *restoreDiMUSESpeechFile(const char *fileName);
+	void extractSyncsFromDiMUSEMarker(const char *marker);
 
 	void startCDTimer();
 	void stopCDTimer();


### PR DESCRIPTION
Months ago, when I started working on the current iteration of DiMUSE, I noticed that The Dig made a call to `diMUSESetTrigger()` every time it loaded a speech file. I couldn't make any sense of it so I just ignored it, as it didn't seem to do anything other than call a strange function everytime the trigger was activated.

Turns out, that "strange function" was in fact a procedure which retrieved mouth sync times from the text markers which every speech file had in its iMUSE map.

After retrieving the info, the sync is carried out like it's done on FT (with a couple of small differences -- see `Sound::isMouthSyncOff()`)

While I agree this is done in a very strange way, (quoting my own comment)...

>  A good reason why this is the way it's done, is that in The Dig the whole speech file,
>  including its map (and consequently, the text marker), is compressed with the same codec as
>  sound data; this prevents us from getting the mouth syncs before the file has started playing.
>  Also, although I can't confirm this, there might be more than one sync marker in a single
>  speech file, so let's just be safe and follow what the original does.

The changes in this PR implement what I've just described, yielding the same behavior as the original interpreter.
Maybe off by just a few milliseconds, but frankly the proper fix would require us to launch a 60Hz threaded timer instead of simulating the increments like we do now, and I don't want to embark in that little journey unless other more experienced devs expressely allow me to do it.

