### PR TITLE
SCUMM: Fix regression in saving/loading Mac music

### DIFF
--- a/engines/scumm/players/player_mac.cpp
+++ b/engines/scumm/players/player_mac.cpp
@@ -130,7 +130,15 @@ void Player_Mac::saveLoadWithSerializer(Common::Serializer &s) {
 
 		s.syncArray(_channel, _numberOfChannels, syncWithSerializer);
 		for (i = 0; i < _numberOfChannels; i++) {
-			syncWithSerializer(s, _channel[i]);
+			if (s.getVersion() >= 94 && s.getVersion() <= 103) {
+				// It was always the intention to save the instrument entries
+				// here. Unfortunately there was a regression in late 2017 that
+				// caused the channel data to be saved a second time, instead
+				// of the instrument data.
+				syncWithSerializer(s, _channel[i]);
+			} else {
+				syncWithSerializer(s, _channel[i]._instrument);
+			}
 		}
 
 		if (s.isLoading()) {

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -67,7 +67,7 @@ struct SaveInfoSection {
 
 #define SaveInfoSectionSize (4+4+4 + 4+4 + 4+2)
 
-#define CURRENT_VER 103
+#define CURRENT_VER 104
 #define INFOSECTION_VERSION 2
 
 #pragma mark -


### PR DESCRIPTION
I noticed that all my old savegames for the Mac version of The Secret of Monkey Island had been mysteriously broken. I tracked it down to this commit:

https://github.com/scummvm/scummvm/commit/9916b263831f20e5841275051a8ed014de1f24eb

As I understand it, in the old version of the code, mac_player.cpp would first save the channel entries, then the instrument entries. In the rewrite, the channel entries were saved twice and the instrument entries not at all.

Unfortunately I can't think of any way of fixing the savegames that were broken. This pull request is only for saving the correct data. But I'm not well versed in the save/load code, so I'm submitting this as a pull request so that others can point out if I made any mistakes along the way.