### PR TITLE
SCUMM: Attempt to improve timing (see bug #13354)

### DIFF
--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2445,10 +2445,11 @@ Common::Error ScummEngine::go() {
 			delta = 6;
 		}
 
-		// Wait, then start the stop watch. Assume that waiting is
-		// exact, even though it's almost certain to overshoot the
-		// target. That way we factor in the difference when timing
-		// how long the main loop takes.
+		// Wait and start the stop watch at the time the wait is assumed
+		// to end. There is no guarantee that the wait is that exact,
+		// but this way if it overshoots that time will count as part
+		// of the main loop.
+
 		int delayMsecs = delta * 1000 / 60 - diff;
 		diff = _system->getMillis() + delayMsecs;
 
@@ -2471,14 +2472,14 @@ Common::Error ScummEngine::go() {
 }
 
 void ScummEngine::waitForTimer(int msec_delay) {
-	uint32 start_time;
+	uint32 end_time;
 
 	if (_fastMode & 2)
 		msec_delay = 0;
 	else if (_fastMode & 1)
 		msec_delay = 10;
 
-	start_time = _system->getMillis();
+	end_time = _system->getMillis() + msec_delay;
 
 	while (!shouldQuit()) {
 		_sound->updateCD(); // Loop CD Audio if needed
@@ -2500,9 +2501,9 @@ void ScummEngine::waitForTimer(int msec_delay) {
 		_refreshDuration[_refreshArrayPos] = (int)(cur - screenUpdateTimerStart);
 		_refreshArrayPos = (_refreshArrayPos + 1) % ARRAYSIZE(_refreshDuration);
 #endif
-		if (cur >= start_time + msec_delay)
+		if (cur >= end_time)
 			break;
-		_system->delayMillis(10);
+		_system->delayMillis(MIN<uint32>(10, end_time - cur));
 	}
 }
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2445,11 +2445,14 @@ Common::Error ScummEngine::go() {
 			delta = 6;
 		}
 
-		// Wait...
-		waitForTimer(delta * 1000 / 60 - diff);
+		// Wait, then start the stop watch. Assume that waiting is
+		// exact, even though it's almost certain to overshoot the
+		// target. That way we factor in the difference when timing
+		// how long the main loop takes.
+		int delayMsecs = delta * 1000 / 60 - diff;
+		diff = _system->getMillis() + delayMsecs;
 
-		// Start the stop watch!
-		diff = _system->getMillis();
+		waitForTimer(delayMsecs);
 
 		// Run the main loop
 		scummLoop(delta);


### PR DESCRIPTION
According to https://bugs.scummvm.org/ticket/13354 ScummVM is running slightly too slow, so ScummVM takes too long to drown. My guess it's because ScummEngine::waitForTimer() isn't exact, and is likely to overshoot its target.

With this change, the "stop watch" will start at the time waitForTimer() theoretically finishes, so that the overshoot is factored into the measured time the main loop takes.

This seems slightly better to me than trying to fix waitForTimer(), since in the end it will probably be implemented in terms of SDL_Delay(), and that function is documented as not being completely accurate. See https://wiki.libsdl.org/SDL_Delay for details.