### PR TITLE
SCUMM: Keep playing outdoors sound in CD version of MI1 during Smirk close-up

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2307,7 +2307,22 @@ void ScummEngine_v5::o5_stopMusic() {
 }
 
 void ScummEngine_v5::o5_stopSound() {
-	_sound->stopSound(getVarOrDirectByte(PARAM_1));
+	int sound = getVarOrDirectByte(PARAM_1);
+
+	// WORKAROUND: Don't stop the background audio when showing the close-up
+	// of captain Smirk. You are still outdoors, so it makes more sense if
+	// they keep playing like they do in the Special Edition. (Though there
+	// the background makes it more obvious.)
+	//
+	// The sound is stopped by the exit script, which always has number
+	// 10001 regardless of which room it is. We figure out which one by
+	// looking at which rooms we're moving between.
+
+	if (_game.id == GID_MONKEY && (_game.features & GF_AUDIOTRACKS) && sound == 126 && vm.slot[_currentScript].number == 10001 && VAR(VAR_ROOM) == 43 && VAR(VAR_NEW_ROOM) == 76) {
+		return;
+	}
+
+	_sound->stopSound(sound);
 }
 
 void ScummEngine_v5::o5_isSoundRunning() {


### PR DESCRIPTION
You're both still outside, so it doesn't make sense for the background sound to suddenly stop. I guess the makers of the Special Edition agree, because there the sound doesn't stop either:

https://www.youtube.com/watch?v=MPcL_eScS6I&start=4797

Of course, in the Special Edition it's much more obvious that you're still outside because of the detailed background.

The sound is stopped by the exit script. All exit scripts have the same internal number, so it tells which one by checking which room you're in and which room you're moving to.

You can test the scene with boot param 888. I've assumed that the workaround should apply to all versions that have CD audio tracks, though I've only tested it with the VGA CD version and the unofficial talkie. I don't have the FM Towns and SEGA CD versions, so I don't know if they use the same audio tracks.