### PR TITLE
DIRECTOR: add RearWindow stub

### DIFF
--- a/engines/director/lingo/xlibs/winxobj.cpp
+++ b/engines/director/lingo/xlibs/winxobj.cpp
@@ -50,6 +50,7 @@ static MethodProto xlibMethods[] = {
 	{ "GetMemoryNeeded",	RearWindowXObj::m_getMemoryNeeded,		0,	0,	400 },	// D4
 	{ "PatToWindow",		RearWindowXObj::m_patToWindow,			1,	1,	400 },	// D4
 	{ "IndexColorToWindow",	RearWindowXObj::m_indexColorToWindow,	1,	1,	400 },	// D4
+	{ "RGBColorToWindow",   RearWindowXObj::m_rgbColorToWindow,     3,  3,  400 },  // D4
 	{ nullptr, nullptr, 0, 0, 0 }
 };
 
@@ -89,6 +90,15 @@ void RearWindowXObj::m_patToWindow(int nargs) {
 
 void RearWindowXObj::m_indexColorToWindow(int nargs) {
 	g_lingo->pop();
+}
+
+void RearWindowXObj::m_rgbColorToWindow(int nargs) {
+	Datum r = g_lingo->pop();
+	Datum g = g_lingo->pop();
+	Datum b = g_lingo->pop();
+	Graphics::MacWindowManager *window = g_director->getMacWindowManager();
+
+	window->setDesktopColor(r.asInt(), g.asInt(), b.asInt());
 }
 
 } // End of namespace Director

--- a/engines/director/lingo/xlibs/winxobj.h
+++ b/engines/director/lingo/xlibs/winxobj.h
@@ -42,6 +42,7 @@ void m_new(int nargs);
 void m_getMemoryNeeded(int nargs);
 void m_patToWindow(int nargs);
 void m_indexColorToWindow(int nargs);
+void m_rgbColorToWindow(int nargs);
 
 } // End of namespace RearWindowXObj
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -823,6 +823,21 @@ void MacWindowManager::loadDesktop() {
 	delete source;
 }
 
+void MacWindowManager::setDesktopColor(byte r, byte g, byte b) {
+	_desktopBmp = new Graphics::TransparentSurface();
+	uint32 color = TS_RGB(r, g, b);
+
+	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 0, 8, 16, 24);
+	Graphics::ManagedSurface *source = new Graphics::ManagedSurface();
+	source->create(10, 10, requiredFormat_4byte);
+	Common::Rect area = source->getBounds();
+	source->fillRect(area, color);
+
+	_desktopBmp->copyFrom(*source);
+	source->free();
+	delete source;
+}
+
 void MacWindowManager::drawDesktop() {
 	if (_desktopBmp) {
 		for (int i = 0; i < _desktop->w; ++i) {

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -317,6 +317,7 @@ public:
 	uint findBestColor(byte cr, byte cg, byte cb);
 	uint findBestColor(uint32 color);
 	void decomposeColor(uint32 color, byte &r, byte &g, byte &b);
+	void setDesktopColor(byte, byte, byte);
 
 	uint inverter(uint src);
 


### PR DESCRIPTION
This adds a stub implementation for a RearWindow method I saw being called by a D4 game, The Trip of Choroli. It appears to be an alternative to `IndexColorToWindow`, taking three integers for R, G, and B values instead of a single index colour.