### PR TITLE
SCUMM: Improve timing in Sam & Max intro (bug #13378)

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -648,6 +648,21 @@ void ScummEngine::writeVar(uint var, int value) {
 			}
 		}
 
+		// WORKAROUND bug #13378: For whatever reason, the German and
+		// Italian talkie versions (I can't check the floppy versions)
+		// set the game to run much too fast in some parts of the intro.
+		// Some differences are natural because of the different lengths
+		// of the spoken lines, but 1 or 2 is too fast.
+		//
+		// Any modifications here depend on knowing if the script will
+		// set the timer value back to something sensible afterwards.
+
+		if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 65 && var == VAR_TIMER_NEXT && _enableEnhancements) {
+			// "Wirst Du brutzeln, wie eine grobe Bratwurst!"
+			if (value == 1 && _language == Common::DE_DEU)
+				value = 4;
+		}
+
 		_scummVars[var] = value;
 
 		// Unlike the PC version, the Macintosh version of Loom appears

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -664,7 +664,9 @@ void ScummEngine::writeVar(uint var, int value) {
 
 			// Max beats up the scientist. This was probably to
 			// match the subtitles to the speech better, but this
-			// is just too much!
+			// is just too much! The floppy version doesn't do this
+			// but there's no need to explicitly test this since
+			// the script never sets the value to 2 there.
 			if (value == 2 && _language == Common::IT_ITA)
 				value = 3;
 		}

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -661,6 +661,12 @@ void ScummEngine::writeVar(uint var, int value) {
 			// "Wirst Du brutzeln, wie eine grobe Bratwurst!"
 			if (value == 1 && _language == Common::DE_DEU)
 				value = 4;
+
+			// Max beats up the scientist. This was probably to
+			// match the subtitles to the speech better, but this
+			// is just too much!
+			if (value == 2 && _language == Common::IT_ITA)
+				value = 3;
 		}
 
 		_scummVars[var] = value;

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1115,6 +1115,20 @@ void ScummEngine_v6::o6_setCameraAt() {
 
 void ScummEngine_v6::o6_loadRoom() {
 	int room = pop();
+
+	// WORKAROUND bug #13378: During Sam's reactions to Max beating up the
+	// scientist in the intro, we sometimes have to slow down animations
+	// artificially. This is where we speed them back up again.
+	if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 65 && room == 6 && _enableEnhancements) {
+		int actors[] = { 2, 3, 10 };
+
+		for (int i = 0; i < ARRAYSIZE(actors); i++) {
+			Actor *a = derefActorSafe(actors[i], "o6_animateActor");
+			if (a && a->getAnimSpeed() > 0)
+				a->setAnimSpeed(0);
+		}
+	}
+
 	startScene(room, nullptr, 0);
 	if (_game.heversion >= 61) {
 		setCameraAt(camera._cur.x, 0);

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -72,18 +72,31 @@ void ScummEngine::printString(int m, const byte *msg) {
 			return;
 		}
 
-		// WORKAROUND bug #13378: Sam's reactions during the intro run
-		// much too quick for the subtitles in some localizations. We
-		// get around this by slowing down that entire animation, while
-		// leaving the reset of the animations unchanged.
-		//
-		// The animation speed is not very fine grained, though.
+		// WORKAROUND bug #13378: In the German version, Sam's reactions
+		// to Max beating up the scientist run much too quick for the
+		// animation to match. We get around this by slowing down that
+		// animation.
+ 		//
+		// In the italian version, the whole scene is sped up to keep up
+		// with Sam's speech. We compensate for this by slowing down the
+		// other animations.
 		if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 65 && _enableEnhancements) {
+			Actor *a;
+
 			if (_language == Common::DE_DEU) {
 				if (memcmp(msg + 16, "Ohh!", 4) == 0) {
-					Actor *a = derefActorSafe(2, "printString");
+					a = derefActorSafe(2, "printString");
 					if (a)
 						a->setAnimSpeed(3);
+				}
+			} else if (_language == Common::IT_ITA) {
+				if (memcmp(msg + 16, "Ooh.", 4) == 0) {
+					a = derefActorSafe(3, "printString");
+					if (a)
+						a->setAnimSpeed(2);
+					a = derefActorSafe(10, "printString");
+				if (a)
+						a->setAnimSpeed(2);
 				}
 			}
 		}
@@ -404,10 +417,29 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					{ "Kann ich fahren?", 240, 0 }
 				};
 
+				TimingAdjustment timingAdjustmentsIT[] = {
+					{ "E per questo^",    120, 0 },
+					{ "Forse sei",        75,  0 },
+					{ "^imprevedibile.",  170, 0 },
+					{ "Oh.",              20,  0 },
+					{ "Ehi, bel colpo.",  30,  0 },
+					{ "Yikes!",           90,  0 },
+					{ "Huh?",             50,  0 },
+					{ "Posso tenere",     100, 0 },
+					{ "Perch\x82 pensi",  120, 0 },
+					{ "Andiamocene",      250, 0 },
+					{ "Forse possiamo",   90,  0 },
+					{ "Ti dispiace",      200, 0 }
+				};
+
 				switch (_language) {
 				case Common::DE_DEU:
 					adjustments = timingAdjustmentsDE;
 					numAdjustments = ARRAYSIZE(timingAdjustmentsDE);
+					break;
+				case Common::IT_ITA:
+					adjustments = timingAdjustmentsIT;
+					numAdjustments = ARRAYSIZE(timingAdjustmentsIT);
 					break;
 				default:
 					adjustments = nullptr;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -432,6 +432,16 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					{ "Ti dispiace",      200, 0 }
 				};
 
+				TimingAdjustment timingAdjustmentsFRCD[] = {
+					{ "Oh.",              85,  0 },
+					{ "H\x82, pas mal.",  80,  0 },
+					{ "Yiik!",            110, 0 },
+					{ "Je peux garder",   130, 0 },
+					{ "Pourquoi est-ce",  120, 0 },
+					{ "Nous pourrons",    80,  0 },
+					{ "Je peux conduire", 220, 0 }
+				};
+
 				switch (_language) {
 				case Common::DE_DEU:
 					adjustments = timingAdjustmentsDE;
@@ -440,6 +450,12 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 				case Common::IT_ITA:
 					adjustments = timingAdjustmentsIT;
 					numAdjustments = ARRAYSIZE(timingAdjustmentsIT);
+					break;
+				case Common::FR_FRA:
+					if (strcmp(_game.variant, "Floppy") != 0) {
+						adjustments = timingAdjustmentsFRCD;
+						numAdjustments = ARRAYSIZE(timingAdjustmentsFRCD);
+					}
 					break;
 				default:
 					adjustments = nullptr;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -77,9 +77,9 @@ void ScummEngine::printString(int m, const byte *msg) {
 		// for the animation to match. We get around this by slowing
 		// down that animation.
  		//
-		// In the italian version, the whole scene is sped up to keep up
-		// with Sam's speech. We compensate for this by slowing down the
-		// other animations.
+		// In the italian CD version, the whole scene is sped up to
+		// keep up with Sam's speech. We compensate for this by slowing
+		// down the other animations.
 		if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 65 && _enableEnhancements) {
 			Actor *a;
 
@@ -89,7 +89,7 @@ void ScummEngine::printString(int m, const byte *msg) {
 					if (a)
 						a->setAnimSpeed(3);
 				}
-			} else if (_language == Common::IT_ITA) {
+			} else if (_language == Common::IT_ITA && strcmp(_game.variant, "Floppy") != 0) {
 				if (memcmp(msg + 16, "Ooh.", 4) == 0) {
 					a = derefActorSafe(3, "printString");
 					if (a)
@@ -442,7 +442,18 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					{ "Kann ich fahren?", 240, 0 }
 				};
 
-				TimingAdjustment timingAdjustmentsIT[] = {
+				TimingAdjustment timingAdjustmentsITFloppy[] = {
+					{ "E per questo^",    140, 0 },
+					{ "E' che^ecco^",     100, 0 },
+					{ "^imprevedibile.",  170, 0 },
+					{ "Huh?",             110, 0 },
+					{ "Perch\x82 pensi",  90,  0 },
+					{ "Andiamocene da",   230, 0 },
+					{ "Forse possiamo",   75,  0 },
+					{ "Ti dispiace",      160, 0 }
+				};
+
+				TimingAdjustment timingAdjustmentsITCD[] = {
 					{ "E per questo^",    120, 0 },
 					{ "Forse sei",        75,  0 },
 					{ "^imprevedibile.",  170, 0 },
@@ -504,8 +515,13 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					}
 					break;
 				case Common::IT_ITA:
-					adjustments = timingAdjustmentsIT;
-					numAdjustments = ARRAYSIZE(timingAdjustmentsIT);
+					if (strcmp(_game.variant, "Floppy") == 0) {
+						adjustments = timingAdjustmentsITFloppy;
+						numAdjustments = ARRAYSIZE(timingAdjustmentsITFloppy);
+					} else {
+						adjustments = timingAdjustmentsITCD;
+						numAdjustments = ARRAYSIZE(timingAdjustmentsITCD);
+					}
 					break;
 				case Common::FR_FRA:
 					if (strcmp(_game.variant, "Floppy") == 0) {

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -453,6 +453,16 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					{ "Je peux conduire", 220, 0 }
 				};
 
+				TimingAdjustment timingAdjustmentsES[] = {
+					{ "Y por eso^",       130, 0 },
+					{ "es simplemente",   100, 0 },
+					{ "eres DEMASIADO",   90,  0 },
+					{ "\xa8Hug?",         110, 0 },
+					{ "\xa8Por qu\x82",   110, 0 },
+					{ "Tal vez podamos",  75,  0 },
+					{ "\xa8Te importa",   160, 0 }
+				};
+
 				switch (_language) {
 				case Common::EN_ANY:
 					adjustments = timingAdjustmentsEN;
@@ -471,6 +481,10 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 						adjustments = timingAdjustmentsFRCD;
 						numAdjustments = ARRAYSIZE(timingAdjustmentsFRCD);
 					}
+					break;
+				case Common::ES_ESP:
+					adjustments = timingAdjustmentsES;
+					numAdjustments = ARRAYSIZE(timingAdjustmentsES);
 					break;
 				default:
 					adjustments = nullptr;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -457,6 +457,18 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					{ "Ti dispiace",      200, 0 }
 				};
 
+				TimingAdjustment timingAdjustmentsFRFloppy[] = {
+					{ "Et pour me",       120, 0 },
+					{ "C'est que^euh^",   100, 0 },
+					{ "vous \x88tes",     65,  0 },
+					{ "^impr\x82visible", 170, 0 },
+					{ "Pourquoi est-ce",  100, 0 },
+					{ "Filons de cet",    190, 0 },
+					{ "Nous pourrons",    65,  0 },
+					{ "Je peux conduire", 170, 0 },
+					{ "Je n'oublierai",   90,  0 }
+				};
+
 				TimingAdjustment timingAdjustmentsFRCD[] = {
 					{ "Oh.",              85,  0 },
 					{ "H\x82, pas mal.",  80,  0 },
@@ -496,7 +508,10 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					numAdjustments = ARRAYSIZE(timingAdjustmentsIT);
 					break;
 				case Common::FR_FRA:
-					if (strcmp(_game.variant, "Floppy") != 0) {
+					if (strcmp(_game.variant, "Floppy") == 0) {
+						adjustments = timingAdjustmentsFRFloppy;
+						numAdjustments = ARRAYSIZE(timingAdjustmentsFRFloppy);
+					} else {
 						adjustments = timingAdjustmentsFRCD;
 						numAdjustments = ARRAYSIZE(timingAdjustmentsFRCD);
 					}

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -72,10 +72,10 @@ void ScummEngine::printString(int m, const byte *msg) {
 			return;
 		}
 
-		// WORKAROUND bug #13378: In the German version, Sam's reactions
-		// to Max beating up the scientist run much too quick for the
-		// animation to match. We get around this by slowing down that
-		// animation.
+		// WORKAROUND bug #13378: In the German CD version, Sam's
+		// reactions to Max beating up the scientist run much too quick
+		// for the animation to match. We get around this by slowing
+		// down that animation.
  		//
 		// In the italian version, the whole scene is sped up to keep up
 		// with Sam's speech. We compensate for this by slowing down the
@@ -83,7 +83,7 @@ void ScummEngine::printString(int m, const byte *msg) {
 		if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 65 && _enableEnhancements) {
 			Actor *a;
 
-			if (_language == Common::DE_DEU) {
+			if (_language == Common::DE_DEU && strcmp(_game.variant, "Floppy") != 0) {
 				if (memcmp(msg + 16, "Ohh!", 4) == 0) {
 					a = derefActorSafe(2, "printString");
 					if (a)
@@ -415,7 +415,21 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					{ "Mind if I drive?", 160, 0 }
 				};
 
-				TimingAdjustment timingAdjustmentsDE[] = {
+				TimingAdjustment timingAdjustmentsDEFloppy[] = {
+					{ "Und daf\x81r^",    110, 0 },
+					{ "Es ist blo\xe1^",  120, 0 },
+					{ "Hey.",             50,  0 },
+					{ "Klasse Schlag!",   30,  0 },
+					{ "Uiii!",            80,  0 },
+					{ "H\x84h?",          60,  0 },
+					{ "Kann ich seine",   110, 0 },
+					{ "Warum, glaubst",   110, 0 },
+					{ "La\xe1 uns von",   220, 0 },
+					{ "Vielleicht",       90,  0 },
+					{ "Kann ich fahren?", 220, 0 }
+				};
+
+				TimingAdjustment timingAdjustmentsDECD[] = {
 					{ "Und daf\x81r^",    110, 0 },
 					{ "Es ist blo\xe1^",  120, 0 },
 					{ "Hey.",             130, 0 },
@@ -469,8 +483,13 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 					numAdjustments = ARRAYSIZE(timingAdjustmentsEN);
 					break;
 				case Common::DE_DEU:
-					adjustments = timingAdjustmentsDE;
-					numAdjustments = ARRAYSIZE(timingAdjustmentsDE);
+					if (strcmp(_game.variant, "Floppy") == 0) {
+						adjustments = timingAdjustmentsDEFloppy;
+						numAdjustments = ARRAYSIZE(timingAdjustmentsDEFloppy);
+					} else {
+						adjustments = timingAdjustmentsDECD;
+						numAdjustments = ARRAYSIZE(timingAdjustmentsDECD);
+					}
 					break;
 				case Common::IT_ITA:
 					adjustments = timingAdjustmentsIT;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -404,6 +404,17 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 				// We identify the broken up strings that need
 				// adjustment by the upcoming text.
 
+				TimingAdjustment timingAdjustmentsEN[] = {
+					{ "It's just that",   100, 0 },
+					{ "you're TOO nice",  90,  0 },
+					{ "^unpredictable.",  170, 0 },
+					{ "Yikes!",           120, 0 },
+					{ "Huh?",             90,  0 },
+					{ "Why do you",       110, 0 },
+					{ "Maybe we can",     75,  0 },
+					{ "Mind if I drive?", 160, 0 }
+				};
+
 				TimingAdjustment timingAdjustmentsDE[] = {
 					{ "Und daf\x81r^",    110, 0 },
 					{ "Es ist blo\xe1^",  120, 0 },
@@ -443,6 +454,10 @@ bool ScummEngine::handleNextCharsetCode(Actor *a, int *code) {
 				};
 
 				switch (_language) {
+				case Common::EN_ANY:
+					adjustments = timingAdjustmentsEN;
+					numAdjustments = ARRAYSIZE(timingAdjustmentsEN);
+					break;
 				case Common::DE_DEU:
 					adjustments = timingAdjustmentsDE;
 					numAdjustments = ARRAYSIZE(timingAdjustmentsDE);


### PR DESCRIPTION
This pull request attempts to improve the timing of the Sam & Max intro. See https://bugs.scummvm.org/ticket/13378 for further details.

It does so in a number of ways:

- The German version inexplicably speeds up the scene where the scientist says "Wirst Du brutzeln, wie eine grobe Bratwurst!" ("You'll fry like a pork sausage."). I've slowed that down to match the speech.
- Sam's German actor speaks quite slowly while Max beats up the scientist. I've slowed down Sam's animation to match that, and the other two animations (Sam fiddling with the rope and Max beating up the scientist) are played twice. This isn't quite seamless, but I think it looks better than just leaving them frozen.
- Several broken-up lines (i.e. lines with embedded "wait" instructions) have been re-timed so that the subtitles and speech are in sync. This may be a bit futile because for the rest of the game the timings are calculated guesses. But I needed it for the aforementioned Max-beats-up-the-scientist scene.

In the Italian version, Sam's actor speaks very quickly in the max-beats-up-the-scientist scene, so there that whole scene was sped up which made it look rather ridiculous. I've toned that down a bit, while slowing down the two background animations to make them look normal. I've also added re-timings of a couple of broken-up lines.

The other versions did not have any of the animation issues, but it seemed a shame not to re-time the broken-up lines, so I've added that for the French, English and Spanish versions as well. (Note that the Spanish version uses the English voices.)

However...

It was pointed out to me that the French floppy version uses a completely different recording than the CD version. I've restricted the French re-timings to the CD version, since that's all I have. (And so do you if, like me, you bought the game on GOG. I don't know about Steam.)

Do any of the other localized floppy versions use different recordings than their CD counterparts? I have absolutely no idea. Heck, I don't even know about the English floppy version but I _assume_ they used the same actors there.

Of course, all these changes are enhancements, so they can be turned off.