### PR TITLE
Fix aliasing bug in GOB engine

### DIFF
--- a/engines/gob/game.cpp
+++ b/engines/gob/game.cpp
@@ -513,9 +513,9 @@ void Game::prepareStart() {
 }
 
 void Game::playTot(int16 function) {
-	int16 *oldNestLevel      = _vm->_inter->_nestLevel;
-	int16 *oldBreakFrom      = _vm->_inter->_breakFromLevel;
-	int16 *oldCaptureCounter = _vm->_scenery->_pCaptureCounter;
+	int16 * volatile oldNestLevel      = _vm->_inter->_nestLevel;
+	int16 * volatile oldBreakFrom      = _vm->_inter->_breakFromLevel;
+	int16 * volatile oldCaptureCounter = _vm->_scenery->_pCaptureCounter;
 
 	_script->push();
 

--- a/engines/gob/inter.h
+++ b/engines/gob/inter.h
@@ -99,8 +99,8 @@ class Inter {
 public:
 	uint8 _terminate;
 
-	int16 *_breakFromLevel;
-	int16 *_nestLevel;
+	int16 * volatile _breakFromLevel;
+	int16 * volatile _nestLevel;
 
 	uint32 _soundEndTimeKey;
 	int16 _soundStopVal;

--- a/engines/gob/scenery.h
+++ b/engines/gob/scenery.h
@@ -103,7 +103,7 @@ public:
 	int16 _animBottom;
 	int16 _animRight;
 
-	int16 *_pCaptureCounter;
+	int16 * volatile _pCaptureCounter;
 
 	void init();
 	int16 loadStatic(char search);


### PR DESCRIPTION
This aliasing bug crashes gob3 in retroarch when compiled with -O3 optimization after the intro is shown and the goblin stretches in the first scene of the game.

This is due to gcc treating the local pointers oldNestLevel, oldBreakFrom, and oldCaptureCounter as aliases of the pointers in the _vm structure when -O3 optimization is enabled.

However, it appears to only lead to fault behavior within the libretro_scummvm core. After investigation, I determined the crash is due to these pointers being backed by xmm registers (specifically oldBreakFrom in the build I was using) which get clobbered in some cases due to the aliasing optimizations.

More specifically, within Retroarch one of the xmm registers that is used as backing for this variable get clobbered when the slowmotion_ratio is set on this [line of code](https://github.com/libretro/RetroArch/blob/91bf7b553acedaa9f8b31b204c18448c0a6ff823/runloop.c#L7392). This is then treated as the 'original' pointer address which ultimately leads to a deference of an invalid memory address later.

For whatever reason, these xmm registers don't appear to get clobbered in standalone scummvm. I speculate that it may only result in a fault when LIBCO is utilized for threading -- which is the case with the libretro core. I did disassemble the standalone version of scummvm as well, and it does use the xmm registers as backing; however, they don't end up clobbered.

The issue should be replicable using gob3 with:
- Stock x86_64 build of retroarch and libretro_scummvm.
- mingw-w64 compiled version of the libretro_scummvm core using -O3 optimization.
- mingw-w64 compiled version of this alternative wrapper [here](https://github.com/diablodiab/libretro-scummvm-backend).

Note, I did not test a Linux build or other architectures.