### PR TITLE
COMMON: INIFile bugfixes and unit tests

### DIFF
--- a/common/ini-file.cpp
+++ b/common/ini-file.cpp
@@ -27,12 +27,25 @@
 
 namespace Common {
 
+bool INIFile::isValidChar(char c) const {
+	if (_allowNonEnglishCharacters) {
+		// Chars that can break parsing are never allowed
+		return !(c == '[' || c == ']' || c == '=' || c == '#' || c == '\r' || c == '\n');
+	} else {
+		// Only some chars are allowed
+		return isAlnum(c) || c == '-' || c == '_' || c == '.' || c == ' ' || c == ':';
+	}
+}
+
 bool INIFile::isValidName(const String &name) const {
-	if (_allowNonEnglishCharacters)
-		return true;
+	if (name.empty())
+		return false;
+
 	const char *p = name.c_str();
-	while (*p && (isAlnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == ' ' || *p == ':'))
+	while (*p && isValidChar(*p)) {
 		p++;
+	}
+
 	return *p == 0;
 }
 
@@ -237,6 +250,11 @@ bool INIFile::saveToStream(WriteStream &stream) {
 }
 
 void INIFile::addSection(const String &section) {
+	if (!isValidName(section)) {
+		warning("Invalid section name: %s", section.c_str());
+		return;
+	}
+
 	Section *s = getSection(section);
 	if (s)
 		return;

--- a/common/ini-file.h
+++ b/common/ini-file.h
@@ -57,9 +57,9 @@ class WriteStream;
 class INIFile {
 public:
 	struct KeyValue {
-		String key;     /*!< Key of the configuration entry. */
-		String value;   /*!< Value of the configuration entry. */
-		String comment; /*!< Comment within an INI file. */
+		String key;     /*!< Key of the configuration entry, whitespace trimmed. */
+		String value;   /*!< Value of the configuration entry, whitespace trimmed. */
+		String comment; /*!< Comment within an INI file, including #s and newlines. */
 	};
 
 	typedef List<KeyValue> SectionKeyList; /*!< A list of all key/value pairs in this section. */
@@ -75,9 +75,9 @@ public:
 	 * INI files manually.
 	 */
 	struct Section {
-		String name;         /*!< Name of the section. */
+		String name;         /*!< Name of the section, whitespace trimmed. */
 		List<KeyValue> keys; /*!< List of all keys in this section. */
-		String comment;      /*!< Comment within the section. */
+		String comment;      /*!< Comment within the section, including #s and newlines. */
 
 		bool hasKey(const String &key) const; /*!< Check whether the section has a @p key. */
 		const KeyValue* getKey(const String &key) const; /*!< Get the value assigned to a @p key. */
@@ -138,6 +138,7 @@ private:
 
 	Section *getSection(const String &section);
 	const Section *getSection(const String &section) const;
+	bool isValidChar(char c) const; /*!< Is given char allowed in section or key names*/
 };
 
 /** @} */


### PR DESCRIPTION
This adds a lot more unit tests for Common::INIFile and fixes some small problems identified during their creation.

Adding as a pull request as I'm changing some common code in a way I believe is safe, but would like some more eyes to check.

The biggest change is stricter rules on section and key names even in `allowNonEnglishCharacters` mode, which previously allowed anything (even things that would break when reading back in).  This feature is used by the PETKA and MOHAWK engines and my own use in the ULTIMA engine.

The other feature is enforcing section validity in `addSection`, which is only used by the MOHAWK engine.

The complete changes are: 

* addSection() did not check the validity of the section name, which meant it
  was possible to create a section that could not then be operated on by the
  other functions (which all check validity)
* If allowNonEnglishCharacters was set, it was possible to create a key or
  section name starting with '[' or '#', or including a carriage return.  This
  would not read back in correctly.
* Blank section and key names were considered valid, but neither would be
  read back in correctly.
* The struct documentation did not mention whitespcae handling or that comments
  include the '#' and carriage return.