### PR TITLE
Various small fixes on OpenGL

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -167,11 +167,13 @@ void GfxOpenGL::initExtensions() {
 			warning("Error compiling depth fragment program:\n%s", glGetString(GL_PROGRAM_ERROR_STRING_ARB));
 			_useDepthShader = false;
 		}
+	}
 
-
+	if (_useDimShader) {
 		glGenProgramsARB(1, &_dimFragProgram);
 		glBindProgramARB(GL_FRAGMENT_PROGRAM_ARB, _dimFragProgram);
 
+		GLint errorPos;
 		glProgramStringARB(GL_FRAGMENT_PROGRAM_ARB, GL_PROGRAM_FORMAT_ASCII_ARB, strlen(dimFragSrc), dimFragSrc);
 		glGetIntegerv(GL_PROGRAM_ERROR_POSITION_ARB, &errorPos);
 		if (errorPos != -1) {

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1275,7 +1275,9 @@ void GfxOpenGLS::createBitmap(BitmapData *bitmap) {
 				if (val == 0xf81f) {
 					val = 0;
 				}
-				zbufPtr[i] = 0xffff - ((uint32)val) * 0x10000 / 100 / (0x10000 - val);
+				// This is later read as a LA pair when filling texture
+				// with L being used as the LSB in fragment shader
+				zbufPtr[i] = TO_LE_16(0xffff - ((uint32)val) * 0x10000 / 100 / (0x10000 - val));
 			}
 		}
 	}

--- a/graphics/opengl/shader.cpp
+++ b/graphics/opengl/shader.cpp
@@ -189,9 +189,9 @@ ShaderGL::ShaderGL(const Common::String &name, GLuint vertexShader, GLuint fragm
 	glGetProgramiv(shaderProgram, GL_LINK_STATUS, &status);
 	if (status != GL_TRUE) {
 		GLint logSize;
-		glGetShaderiv(shaderProgram, GL_INFO_LOG_LENGTH, &logSize);
+		glGetProgramiv(shaderProgram, GL_INFO_LOG_LENGTH, &logSize);
 		GLchar *log = new GLchar[logSize];
-		glGetShaderInfoLog(shaderProgram, logSize, nullptr, log);
+		glGetProgramInfoLog(shaderProgram, logSize, nullptr, log);
 		error("Could not link shader %s: %s", name.c_str(), log);
 	}
 


### PR DESCRIPTION
This PR is a batch of fixes for bugs found during AmigaOS dynamic switch (#3679) development.
Each commit should explain itself.

Latest one is bigger and only makes sure that OpenGLContext is initialized using the OpenGL version which is really chosen by SDL.
When a GLES2 implementation is loaded by SDL, framebuffer support is now properly detected.