### PR TITLE
OPENGL: Rework renderer selection functions

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -390,12 +390,14 @@ bool SdlGraphicsManager::notifyEvent(const Common::Event &event) {
 }
 
 void SdlGraphicsManager::toggleFullScreen() {
+	/* Don't use g_system for kFeatureOpenGLForGame as it's always supported
+	 * We want to check if we are a 3D graphics manager */
+	bool is3D = hasFeature(OSystem::kFeatureOpenGLForGame);
+
 	if (!g_system->hasFeature(OSystem::kFeatureFullscreenMode) ||
-	   (!g_system->hasFeature(OSystem::kFeatureFullscreenToggleKeepsContext) && g_system->hasFeature(OSystem::kFeatureOpenGLForGame))) {
+	   (!g_system->hasFeature(OSystem::kFeatureFullscreenToggleKeepsContext) && is3D)) {
 		return;
 	}
-
-	bool is3D = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
 
 	if (!is3D)
 		beginGFXTransaction();

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -506,6 +506,9 @@ bool OSystem_Android::hasFeature(Feature f) {
 			f == kFeatureClipboardSupport) {
 		return true;
 	}
+	/* Even if we are using the 2D graphics manager,
+	 * we are at one initGraphics3d call of supporting GLES2 */
+	if (f == kFeatureOpenGLForGame) return true;
 	return ModularGraphicsBackend::hasFeature(f);
 }
 

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -509,6 +509,8 @@ bool OSystem_Android::hasFeature(Feature f) {
 	/* Even if we are using the 2D graphics manager,
 	 * we are at one initGraphics3d call of supporting GLES2 */
 	if (f == kFeatureOpenGLForGame) return true;
+	/* GLES2 always supports shaders */
+	if (f == kFeatureShadersForGame) return true;
 	return ModularGraphicsBackend::hasFeature(f);
 }
 

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -192,6 +192,8 @@ public:
 	bool setGraphicsMode(int mode, uint flags) override;
 	int getGraphicsMode() const override;
 
+	OpenGL::ContextOGLType getOpenGLType() const override { return OpenGL::kOGLContextGLES2; }
+
 #ifdef ANDROID_DEBUG_GL_CALLS
 	bool isRunningInMainThread() { return pthread_self() == _main_thread; }
 #endif

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -180,6 +180,11 @@ bool OSystem_SDL::hasFeature(Feature f) {
 	if (f == kFeatureJoystickDeadzone || f == kFeatureKbdMouseSpeed) {
 		return _eventSource->isJoystickConnected();
 	}
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
+	/* Even if we are using the 2D graphics manager,
+	 * we are at one initGraphics3d call of supporting OpenGL */
+	if (f == kFeatureOpenGLForGame) return true;
+#endif
 	return ModularGraphicsBackend::hasFeature(f);
 }
 

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -95,6 +95,7 @@ public:
 
 #if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	Common::Array<uint> getSupportedAntiAliasingLevels() const override;
+	OpenGL::ContextOGLType getOpenGLType() const override { return _oglType; }
 #endif
 
 protected:
@@ -139,10 +140,12 @@ protected:
 
 #if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 	// Graphics capabilities
-	void detectFramebufferSupport();
+	void detectOpenGLFeaturesSupport();
 	void detectAntiAliasingSupport();
 
+	OpenGL::ContextOGLType _oglType;
 	bool _supportsFrameBuffer;
+	bool _supportsShaders;
 	Common::Array<uint> _antiAliasLevels;
 #endif
 

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -783,7 +783,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			END_OPTION
 
 			DO_LONG_OPTION("renderer")
-				Graphics::RendererType renderer = Graphics::parseRendererTypeCode(option);
+				Graphics::RendererType renderer = Graphics::Renderer::parseTypeCode(option);
 				if (renderer == Graphics::kRendererTypeDefault)
 					usage("Unrecognized renderer type '%s'", option);
 			END_OPTION

--- a/common/system.h
+++ b/common/system.h
@@ -29,6 +29,7 @@
 #include "common/ustr.h"
 #include "graphics/pixelformat.h"
 #include "graphics/mode.h"
+#include "graphics/opengl/context.h"
 
 namespace Audio {
 class Mixer;
@@ -407,6 +408,12 @@ public:
 		kFeatureOpenGLForGame,
 
 		/**
+		 * This feature flag can be used to check if shaders are supported
+		 * and can be used for 3D game rendering.
+		 */
+		kFeatureShadersForGame,
+
+		/**
 		 * If supported, this feature flag can be used to check if
 		 * waiting for vertical sync before refreshing the screen to reduce
 		 * tearing is enabled.
@@ -726,6 +733,20 @@ public:
 	 */
 	virtual Common::Array<uint> getSupportedAntiAliasingLevels() const {
 		return Common::Array<uint>();
+	}
+
+	/**
+	 * Return the chosen OpenGL type.
+	 *
+	 * This function works even when a 2D graphical manager is active and
+	 * let to select a proper renderer before changing mode.
+	 * Implementation having feature kFeatureOpenGLForGame are expected to
+	 * override this function.
+	 *
+	 * @return the OpenGL type of context which is supported.
+	 */
+	virtual OpenGL::ContextOGLType getOpenGLType() const {
+		return OpenGL::kOGLContextNone;
 	}
 
 	/**

--- a/engines/grim/debugger.cpp
+++ b/engines/grim/debugger.cpp
@@ -95,13 +95,13 @@ bool Debugger::cmd_set_renderer(int argc, const char **argv) {
 		return true;
 	}
 
-	Graphics::RendererType renderer = Graphics::parseRendererTypeCode(argv[1]);
+	Graphics::RendererType renderer = Graphics::Renderer::parseTypeCode(argv[1]);
 	if (renderer == Graphics::kRendererTypeDefault) {
 		debugPrintf("Invalid renderer '%s'\n", argv[1]);
 		return true;
 	}
 
-	ConfMan.set("renderer", Graphics::getRendererTypeCode(renderer));
+	ConfMan.set("renderer", Graphics::Renderer::getTypeCode(renderer));
 	g_grim->changeHardwareState();
 	return false;
 }

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -289,8 +289,18 @@ void Lua_V1::SetHardwareState() {
 	bool accel = getbool(1);
 
 	Graphics::RendererType renderer = accel ? Graphics::kRendererTypeOpenGL : Graphics::kRendererTypeTinyGL;
-	renderer = Graphics::getBestMatchingAvailableRendererType(renderer);
-	ConfMan.set("renderer", Graphics::getRendererTypeCode(renderer));
+	renderer = Graphics::Renderer::getBestMatchingAvailableType(renderer,
+#if defined(USE_OPENGL_GAME)
+			Graphics::kRendererTypeOpenGL |
+#endif
+#if defined(USE_OPENGL_SHADERS)
+			Graphics::kRendererTypeOpenGLShaders |
+#endif
+#if defined(USE_TINYGL)
+			Graphics::kRendererTypeTinyGL |
+#endif
+			0);
+	ConfMan.set("renderer", Graphics::Renderer::getTypeCode(renderer));
 
 	g_grim->changeHardwareState();
 }

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -127,8 +127,18 @@ Myst3Engine::~Myst3Engine() {
 bool Myst3Engine::hasFeature(EngineFeature f) const {
 	// The TinyGL renderer does not support arbitrary resolutions for now
 	Common::String rendererConfig = ConfMan.get("renderer");
-	Graphics::RendererType desiredRendererType = Graphics::parseRendererTypeCode(rendererConfig);
-	Graphics::RendererType matchingRendererType = Graphics::getBestMatchingAvailableRendererType(desiredRendererType);
+	Graphics::RendererType desiredRendererType = Graphics::Renderer::parseTypeCode(rendererConfig);
+	Graphics::RendererType matchingRendererType = Graphics::Renderer::getBestMatchingAvailableType(desiredRendererType,
+#if defined(USE_OPENGL_GAME)
+			Graphics::kRendererTypeOpenGL |
+#endif
+#if defined(USE_OPENGL_SHADERS)
+			Graphics::kRendererTypeOpenGLShaders |
+#endif
+#if defined(USE_TINYGL)
+			Graphics::kRendererTypeTinyGL |
+#endif
+			0);
 	bool softRenderer = matchingRendererType == Graphics::kRendererTypeTinyGL;
 
 	return

--- a/engines/playground3d/gfx.cpp
+++ b/engines/playground3d/gfx.cpp
@@ -113,8 +113,18 @@ void Renderer::setupCameraPerspective(float pitch, float heading, float fov) {
 
 Renderer *createRenderer(OSystem *system) {
 	Common::String rendererConfig = ConfMan.get("renderer");
-	Graphics::RendererType desiredRendererType = Graphics::parseRendererTypeCode(rendererConfig);
-	Graphics::RendererType matchingRendererType = Graphics::getBestMatchingAvailableRendererType(desiredRendererType);
+	Graphics::RendererType desiredRendererType = Graphics::Renderer::parseTypeCode(rendererConfig);
+	Graphics::RendererType matchingRendererType = Graphics::Renderer::getBestMatchingAvailableType(desiredRendererType,
+#if defined(USE_OPENGL_GAME)
+			Graphics::kRendererTypeOpenGL |
+#endif
+#if defined(USE_OPENGL_SHADERS)
+			Graphics::kRendererTypeOpenGLShaders |
+#endif
+#if defined(USE_TINYGL)
+			Graphics::kRendererTypeTinyGL |
+#endif
+			0);
 
 	bool isAccelerated = matchingRendererType != Graphics::kRendererTypeTinyGL;
 
@@ -127,29 +137,13 @@ Renderer *createRenderer(OSystem *system) {
 		initGraphics(width, height, nullptr);
 	}
 
-#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
-	bool backendCapableOpenGL = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
-#endif
-
-#if defined(USE_OPENGL_GAME)
-	// Check the OpenGL context actually supports shaders
-	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGLShaders && !OpenGLContext.shadersSupported) {
-		matchingRendererType = Graphics::kRendererTypeOpenGL;
-	}
-#endif
-
-	if (matchingRendererType != desiredRendererType && desiredRendererType != Graphics::kRendererTypeDefault) {
-		// Display a warning if unable to use the desired renderer
-		warning("Unable to create a '%s' renderer", rendererConfig.c_str());
-	}
-
 #if defined(USE_OPENGL_SHADERS)
-	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGLShaders) {
+	if (matchingRendererType == Graphics::kRendererTypeOpenGLShaders) {
 		return CreateGfxOpenGLShader(system);
 	}
 #endif
 #if defined(USE_OPENGL_GAME)
-	if (backendCapableOpenGL && matchingRendererType == Graphics::kRendererTypeOpenGL) {
+	if (matchingRendererType == Graphics::kRendererTypeOpenGL) {
 		return CreateGfxOpenGL(system);
 	}
 #endif
@@ -159,7 +153,8 @@ Renderer *createRenderer(OSystem *system) {
 	}
 #endif
 
-	error("Unable to create a '%s' renderer", rendererConfig.c_str());
+	/* We should never end up here, getBestMatchingRendererType would have failed before */
+	error("Unable to create a renderer");
 }
 
 } // End of namespace Playground3d

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -34,8 +34,18 @@ namespace Playground3d {
 bool Playground3dEngine::hasFeature(EngineFeature f) const {
 	// The TinyGL renderer does not support arbitrary resolutions for now
 	Common::String rendererConfig = ConfMan.get("renderer");
-	Graphics::RendererType desiredRendererType = Graphics::parseRendererTypeCode(rendererConfig);
-	Graphics::RendererType matchingRendererType = Graphics::getBestMatchingAvailableRendererType(desiredRendererType);
+	Graphics::RendererType desiredRendererType = Graphics::Renderer::parseTypeCode(rendererConfig);
+	Graphics::RendererType matchingRendererType = Graphics::Renderer::getBestMatchingAvailableType(desiredRendererType,
+#if defined(USE_OPENGL_GAME)
+			Graphics::kRendererTypeOpenGL |
+#endif
+#if defined(USE_OPENGL_SHADERS)
+			Graphics::kRendererTypeOpenGLShaders |
+#endif
+#if defined(USE_TINYGL)
+			Graphics::kRendererTypeTinyGL |
+#endif
+			0);
 	bool softRenderer = matchingRendererType == Graphics::kRendererTypeTinyGL;
 
 	return

--- a/engines/stark/stark.cpp
+++ b/engines/stark/stark.cpp
@@ -336,8 +336,18 @@ void StarkEngine::checkRecommendedDatafiles() {
 bool StarkEngine::hasFeature(EngineFeature f) const {
 	// The TinyGL renderer does not support arbitrary resolutions for now
 	Common::String rendererConfig = ConfMan.get("renderer");
-	Graphics::RendererType desiredRendererType = Graphics::parseRendererTypeCode(rendererConfig);
-	Graphics::RendererType matchingRendererType = Graphics::getBestMatchingAvailableRendererType(desiredRendererType);
+	Graphics::RendererType desiredRendererType = Graphics::Renderer::parseTypeCode(rendererConfig);
+	Graphics::RendererType matchingRendererType = Graphics::Renderer::getBestMatchingAvailableType(desiredRendererType,
+#if defined(USE_OPENGL_GAME)
+			Graphics::kRendererTypeOpenGL |
+#endif
+#if defined(USE_OPENGL_SHADERS)
+			Graphics::kRendererTypeOpenGLShaders |
+#endif
+#if defined(USE_TINYGL)
+			Graphics::kRendererTypeTinyGL |
+#endif
+			0);
 	bool softRenderer = matchingRendererType == Graphics::kRendererTypeTinyGL;
 
 	return

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -71,6 +71,7 @@ ContextGL::ContextGL() {
 }
 
 void ContextGL::reset() {
+	type = kOGLContextNone;
 	maxTextureSize = 0;
 
 	NPOTSupported = false;
@@ -86,6 +87,9 @@ void ContextGL::reset() {
 void ContextGL::initialize(ContextOGLType contextType) {
 	// Initialize default state.
 	reset();
+	if (contextType == kOGLContextNone) {
+		return;
+	}
 
 	type = contextType;
 
@@ -178,6 +182,9 @@ void ContextGL::initialize(ContextOGLType contextType) {
 
 	// Log context type.
 	switch (type) {
+		case kOGLContextNone:
+			/* Shouldn't happen */
+			break;
 		case kOGLContextGL:
 			debug(5, "OpenGL: GL context initialized");
 			break;

--- a/graphics/opengl/context.h
+++ b/graphics/opengl/context.h
@@ -27,6 +27,7 @@
 namespace OpenGL {
 
 enum ContextOGLType {
+	kOGLContextNone,
 	kOGLContextGL,
 	kOGLContextGLES2
 };

--- a/graphics/renderer.cpp
+++ b/graphics/renderer.cpp
@@ -22,6 +22,9 @@
 #include "graphics/renderer.h"
 
 #include "common/translation.h"
+#include "common/system.h"
+
+#include "graphics/opengl/context.h"
 
 namespace Graphics {
 
@@ -40,12 +43,12 @@ static const RendererTypeDescription rendererTypes[] = {
 
 DECLARE_TRANSLATION_ADDITIONAL_CONTEXT("OpenGL with shaders", "lowres")
 
-const RendererTypeDescription *listRendererTypes() {
+const RendererTypeDescription *Renderer::listTypes() {
 	return rendererTypes;
 }
 
-RendererType parseRendererTypeCode(const Common::String &code) {
-	const RendererTypeDescription *rt = listRendererTypes();
+RendererType Renderer::parseTypeCode(const Common::String &code) {
+	const RendererTypeDescription *rt = listTypes();
 	while (rt->code) {
 		if (rt->code == code) {
 			return rt->id;
@@ -56,8 +59,8 @@ RendererType parseRendererTypeCode(const Common::String &code) {
 	return kRendererTypeDefault;
 }
 
-Common::String getRendererTypeCode(RendererType type) {
-	const RendererTypeDescription *rt = listRendererTypes();
+Common::String Renderer::getTypeCode(RendererType type) {
+	const RendererTypeDescription *rt = listTypes();
 	while (rt->code) {
 		if (rt->id == type) {
 			return rt->code;
@@ -68,30 +71,62 @@ Common::String getRendererTypeCode(RendererType type) {
 	return "";
 }
 
-RendererType getBestMatchingAvailableRendererType(RendererType desired) {
-	if (desired == kRendererTypeDefault) {
-		desired = kRendererTypeOpenGLShaders;
-	}
+uint32 Renderer::getAvailableTypes() {
+	uint32 available = 0;
 
-#if !defined(USE_OPENGL_SHADERS)
-	if (desired == kRendererTypeOpenGLShaders) {
-		desired = kRendererTypeOpenGL;
-	}
+#if defined(USE_TINYGL)
+	/* TinyGL doesn't depend on hardware support */
+	available |= kRendererTypeTinyGL;
 #endif
 
-#if (!defined(USE_OPENGL_GAME) && defined(USE_OPENGL_SHADERS))
-	if (desired == kRendererTypeOpenGL) {
-		desired = kRendererTypeOpenGLShaders;
-	}
-#endif
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
+	bool backendCapableOpenGL = g_system->hasFeature(OSystem::kFeatureOpenGLForGame);
 
-#if !defined(USE_OPENGL_GAME) && !defined(USE_OPENGL_SHADERS)
-	if (desired == kRendererTypeOpenGL || desired == kRendererTypeOpenGLShaders) {
-		desired = kRendererTypeTinyGL;
-	}
+	if (backendCapableOpenGL) {
+		/* Backend either support OpenGL or OpenGL ES(2) */
+#if defined(USE_OPENGL_GAME)
+		/* OpenGL classic is compiled in, check if hardware supports it */
+		if (g_system->getOpenGLType() == OpenGL::kOGLContextGL) {
+			available |= kRendererTypeOpenGL;
+		}
 #endif
+#if defined(USE_OPENGL_SHADERS)
+		/* OpenGL with shaders is compiled in, check if hardware supports it */
+		if (g_system->hasFeature(OSystem::kFeatureShadersForGame)) {
+			available |= kRendererTypeOpenGLShaders;
+		}
+#endif
+	}
+#endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS
+	return available;
+}
 
-	return desired;
+RendererType Renderer::getBestMatchingType(RendererType desired, uint32 available) {
+	/* What we want is possible */
+	if (available & desired) {
+		return desired;
+	}
+
+	/* We apply the same logic when nothing is desired and when what we want is not possible */
+	if (desired != kRendererTypeDefault) {
+		warning("Unable to create a '%s' renderer", getTypeCode(desired).c_str());
+	}
+
+	/* Shaders are the best experience */
+	if (available & kRendererTypeOpenGLShaders) {
+		return kRendererTypeOpenGLShaders;
+	}
+	/* then OpenGL */
+	if (available & kRendererTypeOpenGL) {
+		return kRendererTypeOpenGL;
+	}
+	/* then TinyGL */
+	if (available & kRendererTypeTinyGL) {
+		return kRendererTypeTinyGL;
+	}
+
+	/* Failure is not an option */
+	error("Unable to create a renderer");
 }
 
 } // End of namespace Graphics

--- a/graphics/renderer.h
+++ b/graphics/renderer.h
@@ -41,11 +41,11 @@ namespace Graphics {
  *
  * It specifies which rendering driver to use
  */
-enum RendererType {
+enum RendererType : uint32 {
 	kRendererTypeDefault = 0,
 	kRendererTypeOpenGL = 1,
 	kRendererTypeOpenGLShaders = 2,
-	kRendererTypeTinyGL = 3
+	kRendererTypeTinyGL = 4
 };
 
 struct RendererTypeDescription {
@@ -54,16 +54,27 @@ struct RendererTypeDescription {
 	RendererType id;
 };
 
-const RendererTypeDescription *listRendererTypes();
+class Renderer {
+public:
+	static const RendererTypeDescription *listTypes();
 
-/** Convert a renderer code to a RendererType enum value */
-RendererType parseRendererTypeCode(const Common::String &code);
+	/** Convert a renderer code to a RendererType enum value */
+	static RendererType parseTypeCode(const Common::String &code);
 
-/** Get a character string code from a RendererType enum value */
-Common::String getRendererTypeCode(RendererType type);
+	/** Get a character string code from a RendererType enum value */
+	static Common::String getTypeCode(RendererType type);
 
-/** Get the best matching renderer among available renderers */
-RendererType getBestMatchingAvailableRendererType(RendererType desired);
+	/** Get a bitmask of available renderers */
+	static uint32 getAvailableTypes();
+
+	/** Perform renderer selection amongst available ones */
+	static RendererType getBestMatchingType(RendererType desired, uint32 available);
+
+	/** Get the best matching renderer among available and supported renderers */
+	static RendererType getBestMatchingAvailableType(RendererType desired, uint32 supported) {
+		return getBestMatchingType(desired, getAvailableTypes() & supported);
+	}
+};
  /** @} */
 } // End of namespace Graphics
 

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -403,7 +403,7 @@ void OptionsDialog::build() {
 		_vsyncCheckbox->setState(ConfMan.getBool("vsync", _domain));
 
 		_rendererTypePopUp->setEnabled(true);
-		_rendererTypePopUp->setSelectedTag(Graphics::parseRendererTypeCode(ConfMan.get("renderer", _domain)));
+		_rendererTypePopUp->setSelectedTag(Graphics::Renderer::parseTypeCode(ConfMan.get("renderer", _domain)));
 
 		_antiAliasPopUp->setEnabled(true);
 		if (ConfMan.hasKey("antialiasing", _domain)) {
@@ -642,7 +642,7 @@ void OptionsDialog::apply() {
 
 			if (_rendererTypePopUp->getSelectedTag() > 0) {
 				Graphics::RendererType selected = (Graphics::RendererType) _rendererTypePopUp->getSelectedTag();
-				ConfMan.set("renderer", Graphics::getRendererTypeCode(selected), _domain);
+				ConfMan.set("renderer", Graphics::Renderer::getTypeCode(selected), _domain);
 			} else {
 				ConfMan.removeKey("renderer", _domain);
 			}
@@ -1446,7 +1446,7 @@ void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &pr
 	_rendererTypePopUp = new PopUpWidget(boss, prefix + "grRendererTypePopup");
 	_rendererTypePopUp->appendEntry(_("<default>"), Graphics::kRendererTypeDefault);
 	_rendererTypePopUp->appendEntry("");
-	const Graphics::RendererTypeDescription *rt = Graphics::listRendererTypes();
+	const Graphics::RendererTypeDescription *rt = Graphics::Renderer::listTypes();
 	for (; rt->code; ++rt) {
 		if (g_system->getOverlayWidth() > 320)
 			_rendererTypePopUp->appendEntry(_(rt->description), rt->id);


### PR DESCRIPTION
This PR is over #3780 and takes its commits.

It's an attempt to have better and clearer decisions to choose the renderer to use in 3D games.
The selection algorithm is now shared to avoid the same bug being spread over all engines.

In addition, a new OSystem API is used to allow early detection of OpenGL features.
Before this PR, to detect which OpenGL version is available or if shaders are supported, one need to init 3D graphics which is not handy before being sure about what to do.