### PR TITLE
SCUMM: Make it easier to go back to the cave in VGA Loom (bug #13385)

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1081,6 +1081,15 @@ void ScummEngine_v5::o5_findObject() {
 		obj = 609;
 	}
 
+	// WORKAROUND bug #13385: Clicking on the cave entrance to go back into
+	// the dragon caves registers on the incorrect object. Since the object
+	// script is responsible for actually moving you to the other room and
+	// this script is empty, redirect the action to the cave object's
+	// script instead.
+	if (_game.id == GID_LOOM && _game.version == 4 && _currentRoom == 33 && obj == 482 && _enableEnhancements) {
+		obj = 468;
+	}
+
 	setResult(obj);
 }
 


### PR DESCRIPTION
This works around what appears to be an original bug in VGA Loom that makes it so that you have to click on a thin sliver below the cave entrance to enter it. Usually you have no reason to go back into the caves. Only if you forgot to learn the Reflection draft while you were in there.

I'm a bit torn on whether or not to mark this as an enhancement. I can't imagine anyone wanting to turn this off, so maybe I'm just being petty? :-)

