### PR TITLE
SCUMM: Fix text color when Mandible speaks with Goodmold (Loom Talkie)

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1830,7 +1830,7 @@ void ScummEngine_v5::o5_resourceRoutines() {
 		loadFlObject(getVarOrDirectWord(PARAM_2), resid);
 		break;
 
-	// TODO: For the following see also Hibarnatus' information on bug #7315.
+	// TODO: For the following see also Hibernatus' information on bug #7315.
 	case 32:
 		// TODO (apparently never used in FM-TOWNS)
 		debug(0, "o5_resourceRoutines %d not yet handled (script %d)", op, vm.slot[_currentScript].number);
@@ -2997,6 +2997,12 @@ void ScummEngine_v5::decodeParseString() {
 					// herself to bishop Mandible. Of all the places to put
 					// a typo...
 					printString(textSlot, (const byte *)"I am Chaos.");
+				} else if (_game.id == GID_LOOM && _game.version == 4 && _roomResource == 90 &&
+						vm.slot[_currentScript].number == 203 && _string[textSlot].color == 0x0F && _enableEnhancements) {
+					// WORKAROUND: When Mandible speaks with Goodmold, his second
+					// speech line is missing its color parameter.
+					_string[textSlot].color = 0x0A;
+					printString(textSlot, _scriptPointer);
 				} else if (_game.id == GID_INDY4 && _roomResource == 23 && vm.slot[_currentScript].number == 167 &&
 						len == 24 && 0==memcmp(_scriptPointer+16, "pregod", 6)) {
 					// WORKAROUND for bug #2961.


### PR DESCRIPTION
There's a minor subtitle color error in Loom Talkie.

Quick video here: https://www.youtube.com/watch?v=Nk2WtuOPYwI&t=15.

i.e. when Mandible speaks with Goodmold, Mandible's second line is suddenly printed in white, while all his other lines in this closeup are green.

Looking at `DISK_0001/LE/LF_0090/RO/LS_0203`, it looks like the script writers just forgot to set a color for the second line:

```
(14) print(255,[Center(),Pos(160,152),Color(10),Text("That all depends ^")]);
...
(14) print(255,[Center(),Pos(160,152),Text("on how far this sphere can help me see ^")]);
```

Quick way to reproduce it:

* Start Loom Talkie, with Bobbin next to the tree. Subtitles must be enabled.
* Type `room 17` into the debugger
* Exit the room, and go inside the tower that's next to it
* Listen to Bishop and Mandible's conversation

(Other versions of Loom appear to be unaffected.)

Some fan translations are made from the original talkie version, so I tried to write my conditions so that they're strict enough, so that they don't mess with anything else, *but* loose enough so that translators can benefit from it (or avoid it) if necessary. Since the script above mainly just deals with these two lines, I think it should be good enough, but I'm not a SCUMM expert!

(I also fixed a typo in Hibernatus' name, while here. I know him and the correct spelling is used in various other places in the repo.)