### PR TITLE
SCUMM: Work around Loom script bug to show correct sleepy Rusty close-up

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1496,6 +1496,25 @@ void ScummEngine_v5::o5_loadRoom() {
 		putState(25, 1);
 	}
 
+	// WORKAROUND: The first time you examine Rusty while he's sleeping,
+	// you will get a close-up of him. Which one should depend on whether
+	// or not you've used the Reflection draft on him. But in some, you
+	// will always get the close-up where he's wearing his own clothes.
+
+	if (_game.id == GID_LOOM && _game.version == 3 && room == 29 &&
+		vm.slot[_currentScript].number == 112 && _enableEnhancements) {
+		Actor *a = derefActorSafe(VAR(VAR_EGO), "o5_loadRoom");
+
+		// Bobbin's normal costume is number 1. If he's wearing anything
+		// else, he's presumably disguised as Rusty. The game also sets
+		// a variable, but uses different ones for different versions of
+		// the game. You can't even assume that every English version
+		// uses the same one!
+
+		if (a && a->_costume != 1)
+			room = 68;
+	}
+
 	// For small header games, we only call startScene if the room
 	// actually changed. This avoid unwanted (wrong) fades in Zak256
 	// and others. OTOH, it seems to cause a problem in newer games.


### PR DESCRIPTION
Some versions of Loom will always show the close-up of sleeping Rusty where he's wearing his own clothes. Later versions (e.g. FM Towns and VGA) will show different close-ups depending on if you've used the Reflection draft on him. So this adds that check to the older versions as well.

| Version | Has bug? |
| ----- | ----- |
| EGA | Yes |
| Macintosh | Yes |
| Atari ST | Yes |
| Amiga | Yes |
| TurboGrafx-16 | No |
| FM Towns | No |
| VGA | No |

The Macintosh version uses a different bit variable to keep track of Reflection, compared to the other three buggy versions. Thanks to eientei for verifying that the Amiga and Atari ST versions could be fixed the same way as the EGA version.

Steps to reproduce the bug if you don't have a nearby savegame:

* Play the game until you get the distaff
* Open the ScummVM debug console
* "drafts learn" to learn all drafts
* "drafts" to see what notes the Reflection draft uses
* "room 34"

At this point, either double-click on Rusty to see him sleeping, or cast Reflection on him (twice, since the first time he'll just wake up and talk to you) first. The close-up is only shown the first time you examine him.

The workaround is based on how later versions fixed the bug. As far as I can tell, this does not in any way interfere with the later cutscene where the dragon kills him.

But I need help testing the Atari ST and Amiga versions.