### PR TITLE
Improve formatting of md5 commands result

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1388,8 +1388,9 @@ static void calcMD5(Common::FSNode &path, int32 length) {
 		}
 
 		Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
-		printf("(hash) : %s, (filename) : %s, (bytes) : %d%s\n", md5.c_str(), path.getName().c_str(), length && length <= stream->size() ? (int32)length : (int32)stream->size(), tail ? ", tail" : "");
-
+		if (length != 0 && length < stream->size())
+			md5 += Common::String::format(" (%s %d bytes)", tail ? "last" : "first", length);
+		printf("%s: %s, %llu bytes\n", path.getName().c_str(), md5.c_str(), (unsigned long long)stream->size());
 		delete stream;
 	} else {
 		printf("Usage : --md5 --md5-path=<PATH> [--md5-length=NUM]\n");

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -670,7 +670,9 @@ bool Debugger::cmdMd5(int argc, const char **argv) {
 				if (tail && stream->size() > length)
 					stream->seek(-length, SEEK_END);
 				Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
-				debugPrintf("%s  %s  %d%s\n", md5.c_str(), (*iter)->getName().c_str(), (int32)stream->size(), tail ? ", tail" : "");
+				if (length != 0 && length < stream->size())
+					md5 += Common::String::format(" (%s %d bytes)", tail ? "last" : "first", length);
+				debugPrintf("%s: %s, %llu bytes\n", (*iter)->getName().c_str(), md5.c_str(), (unsigned long long)stream->size());
 				delete stream;
 			}
 		}
@@ -720,14 +722,18 @@ bool Debugger::cmdMd5Mac(int argc, const char **argv) {
 				// The resource fork is probably the most relevant one.
 				if (macResMan.hasResFork()) {
 					Common::String md5 = macResMan.computeResForkMD5AsString(length, tail);
-					debugPrintf("%s  %s (resource)  %d%s\n", md5.c_str(), macResMan.getBaseFileName().toString().c_str(), macResMan.getResForkDataSize(), tail ? ", tail" : "");
+					if (length != 0 && length < macResMan.getResForkDataSize())
+						md5 += Common::String::format(" (%s %d bytes)", tail ? "last" : "first", length);
+					debugPrintf("%s (resource): %s, %llu bytes\n", macResMan.getBaseFileName().toString().c_str(), md5.c_str(), (unsigned long long)macResMan.getResForkDataSize());
 				}
 				if (macResMan.hasDataFork()) {
 					Common::SeekableReadStream *stream = macResMan.getDataFork();
 					if (tail && stream->size() > length)
 						stream->seek(-length, SEEK_END);
 					Common::String md5 = Common::computeStreamMD5AsString(*stream, length);
-					debugPrintf("%s  %s (data)  %d%s\n", md5.c_str(), macResMan.getBaseFileName().toString().c_str(), (int32)stream->size(), tail ? ", tail" : "");
+					if (length != 0 && length < stream->size())
+						md5 += Common::String::format(" (%s %d bytes)", tail ? "last" : "first", length);
+					debugPrintf("%s (data): %s, %llu bytes\n", macResMan.getBaseFileName().toString().c_str(), md5.c_str(), (unsigned long long)stream->size());
 				}
 			}
 			macResMan.close();


### PR DESCRIPTION
This pull request does two things:
1. Add the option to compute the tail md5 in the debugger (when passing a negative size, as is done for the command line `--md5` command).
2. Improve the formatting for the result

I am mostly looking for feedback on the second point (the first one should be fairly uncontroversial).

Currently there are three places where we can see the result of a md5 hash computation:
1. In the Advanced Detector (for example when starting a game) 
```
lang_fr.b25c: 690caf157387e06d2c3d1ca53c43f428, 1006043 bytes.
```
2. With the `md5` and `md5mac` debugger commands
```
) md5 lang_fr.b25c
94892fe8c58c39bd89502ca3e9f71f0a  lang_fr.b25c  1006043
) md5 -n 5000 lang_fr.b25c
690caf157387e06d2c3d1ca53c43f428  lang_fr.b25c  1006043
```
3. With the `--md5` command line command
```
criezy% ./scummvm --md5 --md5-path=/Games/BS25/lang_fr.b25c 
(hash) : 94892fe8c58c39bd89502ca3e9f71f0a, (filename) : lang_fr.b25c, (bytes) : 1006043
criezy% ./scummvm --md5 --md5-length=5000 --md5-path=/Games/BS25/lang_fr.b25c 
(hash) : 690caf157387e06d2c3d1ca53c43f428, (filename) : lang_fr.b25c, (bytes) : 5000
criezy% ./scummvm --md5 --md5-length=-5000 --md5-path=/Games/BS25/lang_fr.b25c 
(hash) : c41bc0b18a61a8f3a316a711d92476e9, (filename) : lang_fr.b25c, (bytes) : 5000, tail
```

So we have three different ways to format the result. And I wanted to add some consistency to this.
Also we can note that the advanced detector and the debugger both show the size of the full file and not the number of bytes used for the md5 computation. For the advanced detector this makes sense as this is the information used for the detection. But for the debugger I find this confusing.

The format I prefer is the one from the advanced detector. So I decided to use that as a base and leave it untouched.
For the command line and debugger I now have the same output, and it includes both the file size and the number of bytes used for the md5 hash computation (if they differ).

Debugger:
```
) md5 lang_fr.b25c
lang_fr.b25c: 94892fe8c58c39bd89502ca3e9f71f0a, 1006043 bytes
) md5 -n 5000 lang_fr.b25c
lang_fr.b25c: 690caf157387e06d2c3d1ca53c43f428 (first 5000 bytes), 1006043 bytes
) md5 -n -5000 lang_fr.b25c
lang_fr.b25c: c41bc0b18a61a8f3a316a711d92476e9 (last 5000 bytes), 1006043 bytes
```

Command line:
```
criezy% ./scummvm --md5 --md5-path=/Games/BS25/lang_fr.b25c                  
lang_fr.b25c: 94892fe8c58c39bd89502ca3e9f71f0a, 1006043 bytes
criezy% ./scummvm --md5 --md5-length=5000 --md5-path=/Games/BS25/lang_fr.b25c
lang_fr.b25c: 690caf157387e06d2c3d1ca53c43f428 (first 5000 bytes), 1006043 bytes
criezy% ./scummvm --md5 --md5-length=-5000 --md5-path=/Games/BS25/lang_fr.b25c
lang_fr.b25c: c41bc0b18a61a8f3a316a711d92476e9 (last 5000 bytes), 1006043 bytes
```

Does that format look good to you, or would you prefer something else?
I think the "(hash)" and "(filename)" labels in the current command line output are superfluous as this seems quite obvious to me. But do you think having those in the output could be useful?