### PR TITLE
GLK: Fix glk_window_iterate.

### DIFF
--- a/engines/glk/glk_api.cpp
+++ b/engines/glk/glk_api.cpp
@@ -206,7 +206,7 @@ void GlkAPI::glk_window_get_arrangement(winid_t win, uint *method,
 }
 
 winid_t GlkAPI::glk_window_iterate(winid_t win, uint *rock) {
-	win = win ? win->_next : _windows->getRoot();
+	win = win ? win->_next : *_windows->begin();
 
 	if (win) {
 		if (rock)


### PR DESCRIPTION
[As per the Glk spec](https://www.eblong.com/zarf/glk/Glk-Spec-075.html#opaque_iteration), `glk_window_iterate` can be used to iterate over all the windows. In the scott sub-engine this is utilized to find a window with a specific rock value. 
To successfully iterate over all the windows we can call `glk_window_iterate(nullptr, &rockptr)` which should return the first window in the linked list of all active windows, after which we can repeatedly access the next element till we reach the end. However the value actually returned by this function in scummvm is the root of the tree. [This value isn't guaranteed to be the first element in the list](https://www.eblong.com/zarf/glk/Glk-Spec-075.html#other-window-functions). 

To fix this we can simply return the iterator to the beginning of the list and dereference it to obtain the first window.