### PR TITLE
GUI: fix game item coloring bug

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1023,7 +1023,6 @@ void LauncherSimple::build() {
 void LauncherSimple::updateListing() {
 	Common::U32StringArray l;
 	Common::Array<const Common::ConfigManager::Domain *> attrs;
-	ListWidget::ColorList colors;
 	ThemeEngine::FontColor color;
 	int numEntries = ConfMan.getInt("gui_list_max_scan_entries");
 
@@ -1078,14 +1077,14 @@ void LauncherSimple::updateListing() {
 				// description += Common::String::format(" (%s)", _("Not found"));
 			}
 		}
-		l.push_back(iter->description);
-		colors.push_back(color);
+		Common::String game_item = GUI::ListWidget::getThemeColor(color) + iter->description;
+		l.push_back(game_item);
 		attrs.push_back(iter->domain);
 		_domains.push_back(iter->key);
 	}
 
 	const int oldSel = _list->getSelected();
-	_list->setList(l, &colors);
+	_list->setList(l);
 
 	groupEntries(attrs);
 

--- a/gui/widgets/groupedlist.h
+++ b/gui/widgets/groupedlist.h
@@ -46,7 +46,7 @@ public:
 	GroupedListWidget(Dialog *boss, const Common::String &name, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	GroupedListWidget(Dialog *boss, int x, int y, int w, int h, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 
-	void setList(const Common::U32StringArray &list, const ColorList *colors = nullptr);
+	void setList(const Common::U32StringArray &list);
 	void setAttributeValues(const Common::U32StringArray &attrValues);
 	void setMetadataNames(const Common::StringMap &metadata);
 	const Common::U32StringArray &getList() const { return _dataList; }

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -814,4 +814,34 @@ void ListWidget::setFilter(const Common::U32String &filter, bool redraw) {
 	}
 }
 
+Common::String ListWidget::stripGUIformatting(const Common::String &str) {
+	char* stripped = new char[str.size() + 1];
+	char* d = stripped;
+	const char* s = str.c_str();
+	while (*s) {
+		if (*s != '\001') { // normal symbol
+			*d++ = *s++;
+			continue;
+		}
+
+		s++; // skip \001
+		switch (*s) {
+			case '\001':  // \001\001
+				*d++ = *s++;
+				break;
+			case 'c': // \001cRRGGBB
+				s += 7; // check length?
+				break;
+			case 'C': // \001C{color-name}
+				while (*s && *s++ != '}')
+					;
+				break;
+			default:
+				error("Wrong string format (%c)", *s);
+		}
+	}
+	*d = '\0'; // null terminate
+	return Common::String(stripped);
+}
+
 } // End of namespace GUI

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -147,7 +147,7 @@ public:
 		return Common::String::format("\001c%02x%02x%02x", r, g, b);
 	}
 	
-	static Common::String getThemeColor(const ThemeEngine::FontColor &color) {
+	static Common::String getThemeColor(const ThemeEngine::FontColor color) {
 		switch (color) {
 		case ThemeEngine::kFontColorNormal:
 			return Common::String("\001C{normal}");
@@ -157,6 +157,8 @@ public:
 			return Common::String("\001C{unknown}");
 		}
 	}
+
+	static Common::String stripGUIformatting(const Common::String &str);
 
 protected:
 	void drawWidget() override;

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -143,6 +143,21 @@ public:
 
 	bool wantsFocus() override { return true; }
 
+	static Common::String getThemeColor(byte r, byte g, byte b) {
+		return Common::String::format("\001c%02x%02x%02x", r, g, b);
+	}
+	
+	static Common::String getThemeColor(const ThemeEngine::FontColor &color) {
+		switch (color) {
+		case ThemeEngine::kFontColorNormal:
+			return Common::String("\001C{normal}");
+		case ThemeEngine::kFontColorAlternate:
+			return Common::String("\001C{alternate}");
+		default:
+			return Common::String("\001C{unknown}");
+		}
+	}
+
 protected:
 	void drawWidget() override;
 


### PR DESCRIPTION
Pass only one list to GroupedListWidget::setList so that content and color will not go out of sync. The new list items are formatted as `\001cRRBBGG#game_name` or `\001C{#color_mode}#game_name` where `#color_mode` is either `normal` or `alternate`.