### PR TITLE
SCUMM: Fix a-grave character in French Monkey1 904.LFL font

### DIFF
--- a/engines/scumm/resource_v4.cpp
+++ b/engines/scumm/resource_v4.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include "common/md5.h"
+#include "common/memstream.h"
 
 #include "scumm/scumm_v4.h"
 #include "scumm/file.h"
@@ -159,6 +161,7 @@ void ScummEngine_v4::loadCharset(int no) {
 
 	Common::File file;
 	char buf[20];
+	byte *data;
 
 	sprintf(buf, "%03d.LFL", 900 + no);
 	file.open(buf);
@@ -168,7 +171,28 @@ void ScummEngine_v4::loadCharset(int no) {
 	}
 
 	size = file.readUint32LE() + 11;
-	file.read(_res->createResource(rtCharset, no, size), size);
+	data = _res->createResource(rtCharset, no, size);
+	file.read(data, size);
+
+	// WORKAROUND: The French floppy EGA and VGA versions of Monkey Island 1
+	// don't properly follow CP850 for the \x85 character in the 904.LFL font.
+	// It should be the `à` letter, but it will print the `ç` letter (which is
+	// already at \x87) instead, breaking at least the "Non!  Ce n'est pas tout
+	// \x85 fait \x87a." line in the copy protection screen. The `à` character
+	// does exist, but at the invalid \x86 position.  So we replace \x85 with
+	// \x86 (and then \x86 with \x87 so that the whole charset resource keeps
+	// the same size), but only when detecting the faulty 904.LFL file.
+	if ((_game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA) && no == 4 && size == 4857 && _language == Common::FR_FRA && _enableEnhancements) {
+		Common::MemoryReadStream stream(data, size);
+		Common::String md5 = Common::computeStreamMD5AsString(stream);
+
+		if (md5 == "f273c26bbcdfb9f87e42748c3e2729d8") {
+			warning("Fixing the invalid content of the 904.LFL a-grave character");
+			memmove(data + 4457,      data + 4457 + 37,      40); // replace \x85 with \x86
+			memmove(data + 4457 + 40, data + 4457 + 37 + 40, 37); // replace \x86 with \x87
+			WRITE_LE_UINT32(data + 557, READ_LE_UINT32(data + 557) + (40 - 37)); // adjust \x86 start offset
+		}
+	}
 }
 
 void ScummEngine_v4::readMAXS(int blockSize) {


### PR DESCRIPTION
It looks like the French versions of the various SCUMM games tend to follow [CP850](https://en.wikipedia.org/wiki/Code_page_850) for their text and associated font resources (while the English versions mostly used CP437, especially in the first games).

## Original problem

But, well, not *all* French versions… one small game of indomitable monkeys still holds out against that convention: the floppy EGA/VGA versions of Monkey Island 1. They messed up the (frequent) « à » letter, at `\x85`, and put a « ç » there instead (although that one *is* already available at its usual `\x87` place) in that particular font.

| Source / code point | `\x82` | `\x83` | `\x84` | `\x85` | `\x86` | `\x87` | `\x88` |
|--------|-------|-------|-------|-------|-------|-------|-------|
| CP850, MONKEY1-CD-FR | é | â | ä | **à** ← | **å** ← | ç | ê |
| MONKEY1-EGA/VGA 904.LFL (original) | é | â | ä | **ç** ← | **à** ← | ç | ê |
| MONKEY1-EGA/VGA 904.LFL (with this PR) | é | â | ä | **à** ← | **ç** ← | ç | ê |

So, whenever the « à » letter in used with this font, a « ç » is printed instead, which just looks like someone missed a key on their keyboard when translating this. But actually, the original text resource is fine; it's the font resource that's wrong. The « à » *is* there, but not at the right code point!

Here's an obvious example; the copy protection screen:

![scummvm-monkey-ega-fr-00000](https://user-images.githubusercontent.com/9024526/163018350-5d0af011-0a4f-4c06-8024-b8a9d1f2cd28.png)

## How to reproduce

If you:

* start the original **French** floppy EGA or VGA version (not the CD version) with `--copy-protection`
* type an invalid year, such as `2222`
* and then be "lucky" enough (the reply is random when you're wrong, you need to completely restart the game until you reach this particular reply)…

…then, script 151 inside room 90 loads the `"Non!  Ce n'est pas tout \x85 fait \x87a."` string, which *is* properly encoded, but since `\x85` contains the `\x87` glyph by mistake, you obtain a very big typo in the middle of the screen just a few seconds after you've started the game.

## How to fix this?

So, one very simple solution would be to detect that string in ScummVM, and replace `\x85` with `\x86` (same as the `"I am Choas."` / `"I am Chaos."` typo fix).

But:

* It's not a typo in the text: it's the font that's wrong. So every time a « à » should be displayed with this font, you'll see a « ç » instead.
* I'm not sure that this particular line is the only one displaying that character with that font.
* If one does their own French (re)translation with this font, then all the « à » characters they'll type will be wrong too.
* If one were to fix the original font or text resources, then this initial approach could actually *undo* their fix, or cause a mismatch between the DOS and ScummVM versions.
* This faulty font has probably been reused for some other non-English versions of Monkey1-EGA/VGA; I don't know if they're impacted by this, or if they worked around it in a different way. So I'd rather only target this particular glyph and only when playing a French version, *but* every time it is potentially used.

## Proposed fix

So I think that the best approach is to:

* detect if the known-to-be-faulty 904.LFL font is in use, and *only* this particular one
* replace the (duplicate) "ç" glyph with the intended "à", on the fly, while loading the charset resource
* and only do this when this exact font is detected, and only when playing a French version, to avoid any possible side effect.

So here's what this PR tries to do:

* only operate on MONKEY1-EGA-FR/MONKEY1-VGA-FR  and the 904.LFL resource
* only do this with the `_enableEnhancements` setting is enabled
* make sure that 904.LFL has the intended size and MD5 sum
* since we only accept this unique file, we can now use hardcoded offsets to fix its content on the fly:
    * replace the content of `\x85` with `\x86` (note: the new one is bigger and thus overlaps with its source, hence the use of `memmove()` instead of `memcpy()`)
    * replace `\x86` with `\x87`, itself a copy of `\x85`. Since there are two "ç" characters there, this avoids having to handle a swap.
    * actually, replacing  `\x86` is meaningless since that's not the right place for "ç" either, but since \x87 is 3-byte bigger than \x86, I do the opposite with \x87, so that the total size of the charset resource remains the same, simplifying the workaround.
* since the `\x86` character now starts 3 bytes later (but is 3-byte-shorter too), we adjust the offset table for it. The values are hardcoded, but the MD5/size check ensures that this file is unique.

And here's the end result:

![scummvm-monkey-ega-fr-00001](https://user-images.githubusercontent.com/9024526/163020183-b84bb0e5-410d-49b4-9832-203d8985ff5c.png)

You'll notice that I'm losing the Nordic `å` glyph with this approach, but:

* we don't use it at all in French, and this PR only applies to the `Common::FR_FRA` version
* the idea is just to restore the `à` character while keeping the workaround small and safe (thus, keeping the same size as the original charset resource).