### PR TITLE
GUI: Print compiler name/version in About dialog

### DIFF
--- a/base/version.cpp
+++ b/base/version.cpp
@@ -60,6 +60,23 @@ static const char *version_cookie __attribute__((used)) = "$VER: ScummVM " SCUMM
 #endif
 const char gScummVMBuildDate[] = __DATE__ " " __TIME__;
 const char gScummVMVersionDate[] = SCUMMVM_VERSION SCUMMVM_REVISION " (" __DATE__ " " __TIME__ ")";
+const char gScummVMCompiler[] = ""
+#define STR_HELPER(x)	#x
+#define STR(x)		STR_HELPER(x)
+#if defined(_MSC_VER)
+	"MSVC " STR(_MSC_FULL_VER)
+#elif defined(__INTEL_COMPILER)
+	"ICC " STR(__INTEL_COMPILER) "." STR(__INTEL_COMPILER_UPDATE)
+#elif defined(__clang__)
+	"Clang " STR(__clang_major__) "." STR(__clang_minor__) "." STR(__clang_patchlevel__)
+#elif defined(__GNUC__)
+	"GCC " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
+#else
+	"unknown compiler"
+#endif
+#undef STR
+#undef STR_HELPER
+	;
 const char gScummVMFullVersion[] = "ScummVM " SCUMMVM_VERSION SCUMMVM_REVISION " (" __DATE__ " " __TIME__ ")";
 const char gScummVMFeatures[] = ""
 #ifdef TAINTED_BUILD

--- a/base/version.h
+++ b/base/version.h
@@ -25,6 +25,7 @@
 extern const char gScummVMVersion[];     // e.g. "0.4.1"
 extern const char gScummVMBuildDate[];   // e.g. "2003-06-24"
 extern const char gScummVMVersionDate[]; // e.g. "0.4.1 (2003-06-24)"
+extern const char gScummVMCompiler[];    // e.g. "GCC 11.2.0"
 extern const char gScummVMFullVersion[]; // e.g. "ScummVM 0.4.1 (2003-06-24)"
 extern const char gScummVMFeatures[];    // e.g. "ALSA MPEG2 zLib"
 

--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -62,10 +62,8 @@ namespace Common {
  * @{
  */
 
-// The sgi IRIX MIPSpro Compiler has difficulties with nested templates.
-// This and the other __sgi conditionals below work around these problems.
-// The Intel C++ Compiler suffers from the same problems.
-#if (defined(__sgi) && !defined(__GNUC__)) || defined(__INTEL_COMPILER)
+// The Intel C++ Compiler has difficulties with nested templates.
+#if defined(__INTEL_COMPILER)
 template<class T> class IteratorImpl;
 #endif
 
@@ -158,9 +156,7 @@ private:
 	size_type lookupAndCreateIfMissing(const Key &key);
 	void expandStorage(size_type newCapacity);
 
-#if !defined(__sgi) || defined(__GNUC__)
 	template<class T> friend class IteratorImpl;
-#endif
 
 	/**
 	 * Simple HashMap iterator implementation.
@@ -168,7 +164,7 @@ private:
 	template<class NodeType>
 	class IteratorImpl {
 		friend class HashMap;
-#if (defined(__sgi) && !defined(__GNUC__)) || defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER)
 		template<class T> friend class Common::IteratorImpl;
 #else
 		template<class T> friend class IteratorImpl;

--- a/configure
+++ b/configure
@@ -2109,28 +2109,7 @@ else
 		echo non-gcc compiler version ${cxx_version}
 	fi
 	cxx_verc_fail=yes
-
-	case $_host_os in
-		irix*)
-			case $cxx_version in
-				7.4.4*)
-					# We just assume this is SGI MIPSpro
-					cxx_version="assumed SGI MIPSpro $cxx_version, ok"
-					cxx_verc_fail=no
-					_cxx_major=7
-					_cxx_minor=4
-					add_line_to_config_mk 'CXX_UPDATE_DEP_FLAG = -MDupdate "$(*D)/$(DEPDIR)/$(*F).d"'
-					add_line_to_config_mk '-include Makedepend'
-					;;
-				*)
-					cxx_version="$cxx_version, bad"
-					;;
-			esac
-			;;
-		*)
-			cxx_version="$cxx_version, bad"
-			;;
-	esac
+	cxx_version="$cxx_version, bad"
 fi
 
 echo "$cxx_version"

--- a/devtools/create_titanic/hashmap.h
+++ b/devtools/create_titanic/hashmap.h
@@ -56,10 +56,8 @@
 
 namespace Common {
 
-// The sgi IRIX MIPSpro Compiler has difficulties with nested templates.
-// This and the other __sgi conditionals below work around these problems.
-// The Intel C++ Compiler suffers from the same problems.
-#if (defined(__sgi) && !defined(__GNUC__)) || defined(__INTEL_COMPILER)
+// The Intel C++ Compiler has difficulties with nested templates.
+#if defined(__INTEL_COMPILER)
 template<class T> class IteratorImpl;
 #endif
 
@@ -152,9 +150,7 @@ private:
 	size_type lookupAndCreateIfMissing(const Key &key);
 	void expandStorage(size_type newCapacity);
 
-#if !defined(__sgi) || defined(__GNUC__)
 	template<class T> friend class IteratorImpl;
-#endif
 
 	/**
 	 * Simple HashMap iterator implementation.
@@ -162,7 +158,7 @@ private:
 	template<class NodeType>
 	class IteratorImpl {
 		friend class HashMap;
-#if (defined(__sgi) && !defined(__GNUC__)) || defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER)
 		template<class T> friend class Common::IteratorImpl;
 #else
 		template<class T> friend class IteratorImpl;

--- a/devtools/create_xeen/hashmap.h
+++ b/devtools/create_xeen/hashmap.h
@@ -56,10 +56,8 @@
 
 namespace Common {
 
-// The sgi IRIX MIPSpro Compiler has difficulties with nested templates.
-// This and the other __sgi conditionals below work around these problems.
-// The Intel C++ Compiler suffers from the same problems.
-#if (defined(__sgi) && !defined(__GNUC__)) || defined(__INTEL_COMPILER)
+// The Intel C++ Compiler has difficulties with nested templates.
+#if defined(__INTEL_COMPILER)
 template<class T> class IteratorImpl;
 #endif
 
@@ -152,9 +150,7 @@ private:
 	size_type lookupAndCreateIfMissing(const Key &key);
 	void expandStorage(size_type newCapacity);
 
-#if !defined(__sgi) || defined(__GNUC__)
 	template<class T> friend class IteratorImpl;
-#endif
 
 	/**
 	 * Simple HashMap iterator implementation.
@@ -162,7 +158,7 @@ private:
 	template<class NodeType>
 	class IteratorImpl {
 		friend class HashMap;
-#if (defined(__sgi) && !defined(__GNUC__)) || defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER)
 		template<class T> friend class Common::IteratorImpl;
 #else
 		template<class T> friend class IteratorImpl;

--- a/graphics/scaler/scale2x.h
+++ b/graphics/scaler/scale2x.h
@@ -26,11 +26,6 @@
 #define __restrict__
 #endif
 
-#ifdef __sgi
-#define __restrict__ __restrict
-#endif
-
-
 typedef unsigned char scale2x_uint8;
 typedef unsigned short scale2x_uint16;
 typedef unsigned scale2x_uint32;

--- a/graphics/scaler/scale3x.h
+++ b/graphics/scaler/scale3x.h
@@ -26,10 +26,6 @@
 #define __restrict__
 #endif
 
-#ifdef __sgi
-#define __restrict__ __restrict
-#endif
-
 typedef unsigned char scale3x_uint8;
 typedef unsigned short scale3x_uint16;
 typedef unsigned scale3x_uint32;

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -100,7 +100,7 @@ AboutDialog::AboutDialog()
 	version += gScummVMVersion;
 	_lines.push_back(version);
 
-	Common::U32String date = Common::U32String::format(_("(built on %s)"), gScummVMBuildDate);
+	Common::U32String date = Common::U32String::format(_("(built on %s with %s)"), gScummVMBuildDate, gScummVMCompiler);
 	_lines.push_back(Common::U32String("C2") + date);
 
 	for (i = 0; i < ARRAYSIZE(copyright_text); i++)


### PR DESCRIPTION
This is mostly a suggestion. This PR embeds the current compiler version number in `base/version.o` and includes it inside the `(built on [date])` line in the About dialog.

Supported compilers are: MSVC, ICC, Clang, GCC (couldn't test ICC, though), since the project now requires a C++11 compiler.

As for the why:

* some bugs or performance problems only happen with a particular compiler or a particular version of it (I remember GCC 4.2.1 on PowerPC producing buggy code with some complex multiple inheritance scheme in ScummVM 1.9.0). End-users don't necessarily know which compiler has been used, so this PR makes it easy to obtain this information.
* running `strings` on the ScummVM binary doesn't always print this information (I think that Mach-O binaries don't embed that by default, for example).
* it might help someone try to resurrect/maintain a port at some point, by giving some build context (e.g. I'm looking at restoring macOS PPC support, and knowing which compiler was in use is useful).
* I don't think that it would hurt anything or add too much bloat.
* I don't think that it would interfere with reproducible builds either, since the compiler version is something that should be controlled in those environments.

Of course, you may have some good reasons to think that this is unnecessary or a bad idea, hence this PR-as-a-suggestion :)

(While looking at our supported compilers, I also stumbled upon some code for very ancient versions of SGI MIPSpro; it seems like only some version from 20 years ago was supported, so there's no way it would compile any C++11 code. So I've cleaned that up, too.)