### PR TITLE
SCUMM HE: Couple patches for Moonbase Commander.

### DIFF
--- a/engines/scumm/he/script_v100he.cpp
+++ b/engines/scumm/he/script_v100he.cpp
@@ -2178,7 +2178,12 @@ void ScummEngine_v100he::o100_systemOps() {
 		break;
 	case 132:
 		// Confirm shutdown
-		confirmExitDialog();
+		if (_game.id == GID_MOONBASE)
+			// Moonbase uses this subOp to quit the game (The confirmation dialog
+			// exists inside the game).
+			quitGame();
+		else
+			confirmExitDialog();
 		break;
 	case 133:
 		quitGame();

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -2860,6 +2860,20 @@ int ScummEngine::getKeyState(int key) {
 }
 
 void ScummEngine_v6::o6_delayFrames() {
+	// WORKAROUND:  At startup, Moonbase Commander will pause for 20 frames before
+	// showing the Infogrames logo.  The purpose of this break is to give time for the
+	// GameSpy Arcade application to fill with the Online game infomation.
+	// 
+	// [0000] (84) localvar2 = max(readConfigFile.number(":var263:","user","wait-for-gamespy"),10)
+	// [0029] (08) delayFrames((localvar2 * 2))
+	// 
+	// But since we don't support GameSpy and have our own Online support, this break
+	// has become redundant and only wastes time.
+	if (_game.id == GID_MOONBASE && vm.slot[_currentScript].number == 69) {
+		pop();
+		return;
+	}
+
 	ScriptSlot *ss = &vm.slot[_currentScript];
 	if (ss->delayFrameCount == 0) {
 		ss->delayFrameCount = pop();


### PR DESCRIPTION
This PR includes a couple of patches to make playing Moonbase Commander a slightly better experience.  The first one skips over the unnecessary 20 frame pause when starting up the game, while the other fixes a bug where the ScummVM-based game quit confirmation message shows up when exiting the game (The game has its own confirmation prompt, rending showing the ScummVM one unnecessary).