### PR TITLE
SCUMM: Fix Lima bird glitch in Zak FM-TOWNS (bug #2762)

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1700,6 +1700,13 @@ void ScummEngine_v5::o5_putActor() {
 		} else if (x == 176 && y == 78) {
 			x = 172;
 		}
+	} else if (_game.id == GID_ZAK && _game.platform == Common::kPlatformFMTowns && _currentRoom == 42 && vm.slot[_currentScript].number == 201 && act == 6 && x == 136 && y == 0 && _enableEnhancements) {
+		// WORKAROUND: bug #2762: When switching back to Zak after using the blue
+		// crystal on the bird in Lima, the bird will disappear, come back and
+		// disappear again. This is really strange and only happens with the
+		// FM-TOWNS version, which adds an unconditional putActor(6,136,0) sequence
+		// that will always negate the getActorX()/getActorY() checks that follow.
+		return;
 	}
 
 	Actor *a = derefActor(act, "o5_putActor");


### PR DESCRIPTION
This is related to [Trac #2762](https://bugs.scummvm.org/ticket/2762), which I've just reopened.

This is an original script issue in the FM-TOWNS version of Zak that's said to happen under the Unz emulator too, and so in 2006 this was closed as not-a-bug, but nowadays the project is more open about fixing original script bugs.

If you use the blue crystal on the bird in Lima in that version, and then switch back from the bird to Zak, then the following will happen (I wish I could find a YouTube video for this, but it looks like every player immediately quits the room after switching back to Zak…):

* the bird will disappear
* then it will go back to its pedestal and eat again
* Zak will talk a bit
* then the bird will disappear again
* and then it will go back to its pedestal and eat yet again

while, in Zak V2, the bird just goes back to its pedestal, once, without disappearing/reappearing at any moment.

Anyway, here's the 629 script in Zak V2 (actor `6` is the bird):

```
[0013] (13) ActorOps(6,[Costume(14)]);
[0017] (7D) setActorElevation(6,Var[234]);
[001A] (13) ActorOps(6,[Sound(39)]);
[001E] (43) VAR_RESULT = getActorX(6);
[0021] (48) if (VAR_RESULT == 27) {
[0027] (23)   VAR_RESULT = getActorY(6);
[002A] (48)   if (VAR_RESULT == 31) {
[0030] (18)     goto 0048;
[0033] (**)   }
[0033] (**) }
[0033] (1E) walkActorTo(6,29,29);
[0037] (3B) waitForActor(6);
[0039] (11) animateActor(6,244);
[003C] (3B) waitForActor(6);
[003E] (2E) delay(60);
[0042] (1E) walkActorTo(6,27,31);
[0046] (3B) waitForActor(6);
[0048] (11) animateActor(6,244);
[004B] (17) clearState02(630);
[004E] (11) animateActor(6,24);
[0051] (2E) delay(180);
[0055] (11) animateActor(6,28);
[0058] (2E) delay(60);
[005C] (18) goto 004E;
[005F] (00) stopObjectCode();
```

and here's how it was translated in the 201 script of Zak FM-TOWNS (V3):

```
[0000] (2D) putActorInRoom(6,42);
[0003] (01) putActor(6,136,0);             # <===
[0009] (13) ActorOps(6,[Costume(14)]);
[000E] (13) ActorOps(6,[Elevation(0)]);
[0014] (43) VAR_RESULT = getActorX(6);     # <===
[0019] (48) if (VAR_RESULT == 226) {
[0020] (23)   VAR_RESULT = getActorY(6);   # <===
[0025] (48)   if (VAR_RESULT == 62) {
[002C] (18)     goto 004B;
[002F] (**)   }
[002F] (**) }
[002F] (1E) walkActorTo(6,232,58);
[0035] (AE) WaitForActor(6);
[0038] (11) animateCostume(6,244);
[003B] (AE) WaitForActor(6);
[003E] (2E) delay(60);
[0042] (1E) walkActorTo(6,226,62);
[0048] (AE) WaitForActor(6);
[004B] (11) animateCostume(6,244);
[004E] (5D) setClass(630,[24]);
[0055] (11) animateCostume(6,6);
[0058] (2E) delay(180);
[005C] (11) animateCostume(6,7);
[005F] (2E) delay(60);
[0063] (18) goto 0055;
[0066] (A0) stopObjectCode();
```

Notice the new `putActorInRoom(6,42)` and `putActor(6,136,0)` at the start of this script. From my modest understanding, this `putActor(6,136,0)` being unconditional, the `getActorX()`/`getActorY()` checks will never be true (they are the coordinates of the bird when it's on the bird feeder), and so what's between `[002F]` and `[004B]` will always be executed, triggering this bug.

Or maybe I'm wrong about this explanation, but anyway, the following diff just ignores this exact `putActor(6,136,0)` call in that room and script, and this appears to restore the original V2 behavior, i.e. the bird will just go back to its pedestal, without any strange teleportation.

To test this:

* download the FM-TOWNS version of Zak from GOG
* grab a savegame from the Trac issue above
* use the bread crumbs on the bird feeder, then the blue crystal on the bird, and then the "To Zak" action
* also try flying a bit, entering/leaving this room, waiting for the Caponian to arrest you…

This doesn't seem to cause any regression, but having a SCUMM expert check this would be cool, because I don't know what was the intent of this `putActor()` call (it looks like Zak FM-TOWNS was ported from V2 to V3 with some strange script mistakes, or limited testing).