### PR TITLE
GLK: SCOTT: Replace non-trivial global objects.

### DIFF
--- a/engines/glk/scott/definitions.cpp
+++ b/engines/glk/scott/definitions.cpp
@@ -27,7 +27,7 @@ namespace Scott {
 GameInfo::GameInfo() {}
 
 GameInfo::GameInfo(
-					Common::String title,
+					const char *title,
 					GameIDType gameID,
 					GameType type,
 					Subtype subType,

--- a/engines/glk/scott/definitions.h
+++ b/engines/glk/scott/definitions.h
@@ -247,7 +247,7 @@ enum ActionTableType {
 
 struct GameInfo {
 	GameInfo();
-	GameInfo(Common::String title, GameIDType gameID, GameType type, Subtype subType, DictionaryType dictionary,
+	GameInfo(const char *title, GameIDType gameID, GameType type, Subtype subType, DictionaryType dictionary,
 			 int numberOfItems, int numberOfActions, int numberOfWords, int numberOfRooms, int maxCarried,
 			 int wordLength, int numberOfMessages, int numberOfVerbs, int numberOfNouns, int startOfHeader,
 			 HeaderType headerStyle, int startOfRoomImageList, int startOfItemFlags, int startOfItemImageList,
@@ -256,7 +256,7 @@ struct GameInfo {
 			 int startOfSystemMessages, int startOfDirections, int startOfCharacters, int startOfImageData,
 			 int imageAddressOffset, int numberOfPictures, PaletteType palette, int pictureFormatVersion,
 			 int startOfIntroText);
-	Common::String _title;
+	const char *_title;
 
 	GameIDType _gameID = UNKNOWN_GAME;
 	GameType _type = NO_TYPE;

--- a/engines/glk/scott/game_info.cpp
+++ b/engines/glk/scott/game_info.cpp
@@ -27,7 +27,7 @@
 namespace Glk {
 namespace Scott {
 
-Common::Array<GameInfo> g_games = {
+GameInfo g_games[NUMGAMES] = {
 	GameInfo("Pirate Adventure",
 		 PIRATE,
 		 OLD_STYLE,                 // type

--- a/engines/glk/scott/game_info.h
+++ b/engines/glk/scott/game_info.h
@@ -28,7 +28,7 @@
 namespace Glk {
 namespace Scott {
 
-extern Common::Array<GameInfo> g_games;
+extern GameInfo g_games[];
 extern const char *g_sysDict[];
 extern const char *g_sysDictIAm[];
 extern const char *g_sysDictZX[];


### PR DESCRIPTION
Fixes a crash when destructing global array `g_games` while exiting the program.