### PR TITLE
MOHAWK: Fix typo in script builder function

### DIFF
--- a/engines/mohawk/riven_scripts.cpp
+++ b/engines/mohawk/riven_scripts.cpp
@@ -167,7 +167,7 @@ RivenScriptPtr RivenScriptManager::createScriptFromData(uint commandCount, ...) 
 		uint16 argumentCount = va_arg(args, int);
 		writeStream.writeUint16BE(argumentCount);
 
-		for (uint j = 0; j < commandCount; j++) {
+		for (uint j = 0; j < argumentCount; j++) {
 			uint16 argument = va_arg(args, int);
 			writeStream.writeUint16BE(argument);
 		}


### PR DESCRIPTION
It seems that the stop condition in this loop is incorrect. See https://bugs.scummvm.org/ticket/13416.