### PR TITLE
SCUMM: Fix Full Throttle drawing glitch (bug #13419)

### DIFF
--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -624,8 +624,16 @@ void ScummEngine::drawObject(int obj, int arg) {
 	const int xpos = od.x_pos / 8;
 	const int ypos = od.y_pos;
 
+	// In most cases we want to mask out the last three bits, though it is
+	// possible that this has already been done by resetRoomObject(). In
+	// later versions we need to keep those bits intact. See bug #13419 for
+	// an example of where this is important.
+
+	if (_game.version < 7)
+		od.height &= 0xFFFFFFF8;
+
 	width = od.width / 8;
-	height = od.height &= 0xFFFFFFF8;	// Mask out last 3 bits
+	height = od.height;
 
 	// Short circuit for objects which aren't visible at all.
 	if (width == 0 || xpos > _screenEndStrip || xpos + width < _screenStartStrip)


### PR DESCRIPTION
See https://bugs.scummvm.org/ticket/13419 for details.

The strips are drawn one column at a time. But because it's using the wrong height, the whole thing comes out skewed. It appears we always adjust the height of an object before drawing it by masking out the three least significant bits, making it a multiple of eight. This turns out not to be correct in Full Throttle. Apparently it's not correct in The Dig and The Curse of Monkey Island either, but there I have no example of it causing any problems.

I'm a bit uncertain if drawObject() needs to meddle with the height at all, or if this can safely be left to resetRoomObject() where it's already done for _most_ SCUMM versions. But if I'm erring, it's on the side of caution. At least until someone can tell me otherwise.