### PR TITLE
AGI: set gameid according to *.wag file only if it's a known value

### DIFF
--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -275,8 +275,8 @@ ADDetectedGame AgiMetaEngineDetection::fallbackDetect(const FileMap &allFilesXXX
 			g_fallbackDesc.version = wagFileParser.convertToAgiVersionNumber(*wagAgiVer);
 		}
 
-		// Set gameid according to *.wag file information if it's present and it doesn't contain whitespace.
-		if (wagGameID != nullptr && !Common::String(wagGameID->getData()).contains(" ")) {
+		// Set gameid according to *.wag file information if it's present and it's a known value
+		if (wagGameID != nullptr && findPlainGameDescriptor(wagGameID->getData(), agiGames)) {
 			_gameid = wagGameID->getData();
 			debug(3, "Agi::fallbackDetector: Using game id (%s) from WAG file", _gameid.c_str());
 		}


### PR DESCRIPTION
While investigating https://bugs.scummvm.org/ticket/13414 I've discovered the problem addressed by this PR:

Before this PR, if an AGI game is modified with WinAGI, and its `GameID` is set to `ZZ`, the following message is printed:

    Your game version has been detected using fallback matching as a
    variant of ZZ ("" "" "14/04/2022 15:09:13").

which is not accurate, because there is no known `ZZ` game, which this game can be a variant of.

And in the suggested games list, the last entry is:
![image](https://user-images.githubusercontent.com/3908954/163704659-ca5648ba-1354-4f3c-a56b-0617960509f4.png)

which is not very helpful.

With this PR, the message is changed to:
  
    Your game version has been detected using fallback matching as a
    variant of agi-fanmade ("" "" "14/04/2022 15:09:13").

and the last entry in the suggested games list is:
![image](https://user-images.githubusercontent.com/3908954/163706608-4dc451f8-7594-47c7-9934-7ca1ccd9a6e8.png)




<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
