### PR TITLE
AGI: *.wag fallback - use description and version only if not empty strings

### DIFF
--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -282,12 +282,12 @@ ADDetectedGame AgiMetaEngineDetection::fallbackDetect(const FileMap &allFilesXXX
 		}
 
 		// Set game description and extra according to *.wag file information if they're present
-		if (wagGameDesc != nullptr) {
+		if (wagGameDesc != nullptr && Common::String(wagGameDesc->getData()) != "\"\"") {
 			description = wagGameDesc->getData();
 			debug(3, "Agi::fallbackDetector: Game description (%s) from WAG file", wagGameDesc->getData());
 
 			// If there's game version in the *.wag file, set extra to it
-			if (wagGameVer != nullptr) {
+			if (wagGameVer != nullptr && Common::String(wagGameVer->getData()) != "\"\"") {
 				_extra = wagGameVer->getData();
 				debug(3, "Agi::fallbackDetector: Game version (%s) from WAG file", wagGameVer->getData());
 			}


### PR DESCRIPTION
If changing a game in WinAGI, and not setting `Description` and `Game Version` fields (and changing it's `GameID` - this is taken care of in https://github.com/scummvm/scummvm/pull/3814), the fallback message is:

    Your game version has been detected using fallback matching as a
    variant of ZZ ("" "" "17/04/2022 10:11:04").

With this PR it's:

    Your game version has been detected using fallback matching as a
    variant of ZZ (Unknown v2 Game).



<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
