### PR TITLE
MORPHOS: add morphos to use gnu++ (std_variant)

### DIFF
--- a/configure
+++ b/configure
@@ -2145,7 +2145,7 @@ if test "$have_gcc" = yes ; then
 		std_variant=gnu++
 		pedantic=no
 		;;
-	amigaos* | dreamcast | ds | mingw* | mint* | n64 | ps3 | psp2)
+	amigaos* | dreamcast | ds | mingw* | mint* | morphos | n64 | ps3 | psp2)
 		std_variant=gnu++
 		;;
 	*)


### PR DESCRIPTION
Missing this little edit on configure