### PR TITLE
PARALLACTION: Partially fix stuck verbs bug in Nippon Safes (bug #4815)

### DIFF
--- a/engines/parallaction/dialogue.cpp
+++ b/engines/parallaction/dialogue.cpp
@@ -157,6 +157,7 @@ DialogueManager::DialogueManager(Parallaction *vm, ZonePtr z) : _vm(vm), _z(z) {
 }
 
 void DialogueManager::start() {
+	_vm->_gfx->hideFloatingLabel();
 	assert(_dialogue);
 	_q = _dialogue->_questions[0];
 	_state = DIALOGUE_START;


### PR DESCRIPTION
Addresses following issue: https://bugs.scummvm.org/ticket/4815

The bug report details multiple instances of explanation verbs staying on the screen when they shouldn't. The one I managed to fix was the one at the Eternal Rest Hotel. This video shows a simple before and after: https://drive.google.com/file/d/1U8hKCHt1-78LaAgYNM9fFk0kqKdwJ9iH/view?usp=sharing
