### PR TITLE
TEST: Fix cxxtestgen.py crash in Python 3 when digesting punycode.h

### DIFF
--- a/test/cxxtest/cxxtestgen.py
+++ b/test/cxxtest/cxxtestgen.py
@@ -174,7 +174,11 @@ def scanInputFiles(files):
 
 def scanInputFile(fileName):
     '''Scan single input file for test suites'''
-    file = open(fileName)
+    if sys.version_info.major >= 3:
+        file = open(fileName, encoding='utf-8')
+    else:
+        file = open(fileName)
+
     lineNo = 0
     while 1:
         line = file.readline()


### PR DESCRIPTION
Python on Windows seems to default encoding to Windows-1252, so cxxtestgen.py crashes when attempting to compile tests due to UTF-8 characters in punycode.h that are illegal on that code page.

This forces the encoding to UTF-8.

```
Traceback (most recent call last):
  File "D:\src2\scummvm\test\cxxtest\cxxtestgen.py", line 594, in <module>
    main()
  File "D:\src2\scummvm\test\cxxtest\cxxtestgen.py", line 54, in main
    scanInputFiles( files )
  File "D:\src2\scummvm\test\cxxtest\cxxtestgen.py", line 170, in scanInputFiles
    scanInputFile(file)
  File "D:\src2\scummvm\test\cxxtest\cxxtestgen.py", line 181, in scanInputFile
    line = file.readline()
  File "C:\Users\Eric\AppData\Local\Programs\Python\Python37-32\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 312: character maps to <undefined>
```