### PR TITLE
OPENGL3D: Make use of the active rect provided by WindowedGraphicsManager

### DIFF
--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -32,6 +32,7 @@
 
 #include "common/config-manager.h"
 #include "common/file.h"
+#include "common/translation.h"
 
 #include "engines/engine.h"
 
@@ -51,12 +52,10 @@ OpenGLSdlGraphics3dManager::OpenGLSdlGraphics3dManager(SdlEventSource *eventSour
 	_glContext(nullptr),
 #endif
 	_supportsFrameBuffer(supportsFrameBuffer),
-	_overlayVisible(false),
 	_overlayScreen(nullptr),
 	_overlayBackground(nullptr),
-	_gameRect(),
 	_fullscreen(false),
-	_lockAspectRatio(true),
+	_stretchMode(STRETCH_FIT),
 	_frameBuffer(nullptr),
 	_surfaceRenderer(nullptr),
 	_engineRequestedWidth(0),
@@ -157,7 +156,7 @@ bool OpenGLSdlGraphics3dManager::hasFeature(OSystem::Feature f) const {
 		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
 #endif
 		(f == OSystem::kFeatureVSync) ||
-		(f == OSystem::kFeatureAspectRatioCorrection) ||
+		(f == OSystem::kFeatureStretchMode) ||
 		(f == OSystem::kFeatureOverlaySupportsAlpha && _overlayFormat.aBits() > 3);
 }
 
@@ -167,8 +166,6 @@ bool OpenGLSdlGraphics3dManager::getFeatureState(OSystem::Feature f) const {
 			return isVSyncEnabled();
 		case OSystem::kFeatureFullscreenMode:
 			return _fullscreen;
-		case OSystem::kFeatureAspectRatioCorrection:
-			return _lockAspectRatio;
 		default:
 			return false;
 	}
@@ -182,9 +179,6 @@ void OpenGLSdlGraphics3dManager::setFeatureState(OSystem::Feature f, bool enable
 				if (_transactionMode == kTransactionNone)
 					createOrUpdateScreen();
 			}
-			break;
-		case OSystem::kFeatureAspectRatioCorrection:
-			_lockAspectRatio = enable;
 			break;
 		default:
 			break;
@@ -230,6 +224,53 @@ int OpenGLSdlGraphics3dManager::getGraphicsMode() const {
 	return 0;
 }
 
+const OSystem::GraphicsMode glStretchModes[] = {
+	{"center", _s("Center"), STRETCH_CENTER},
+	{"pixel-perfect", _s("Pixel-perfect scaling"), STRETCH_INTEGRAL},
+	{"even-pixels", _s("Even pixels scaling"), STRETCH_INTEGRAL_AR},
+	{"fit", _s("Fit to window"), STRETCH_FIT},
+	{"stretch", _s("Stretch to window"), STRETCH_STRETCH},
+	{"fit_force_aspect", _s("Fit to window (4:3)"), STRETCH_FIT_FORCE_ASPECT},
+	{nullptr, nullptr, 0}
+};
+
+const OSystem::GraphicsMode *OpenGLSdlGraphics3dManager::getSupportedStretchModes() const {
+	return glStretchModes;
+}
+
+int OpenGLSdlGraphics3dManager::getDefaultStretchMode() const {
+	return STRETCH_FIT;
+}
+
+bool OpenGLSdlGraphics3dManager::setStretchMode(int mode) {
+	assert(_transactionMode != kTransactionNone);
+
+	if (mode == _stretchMode)
+		return true;
+
+	// Check this is a valid mode
+	const OSystem::GraphicsMode *sm = getSupportedStretchModes();
+	bool found = false;
+	while (sm->name) {
+		if (sm->id == mode) {
+			found = true;
+			break;
+		}
+		sm++;
+	}
+	if (!found) {
+		warning("unknown stretch mode %d", mode);
+		return false;
+	}
+
+	_stretchMode = mode;
+	return true;
+}
+
+int OpenGLSdlGraphics3dManager::getStretchMode() const {
+	return _stretchMode;
+}
+
 void OpenGLSdlGraphics3dManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
 	_engineRequestedWidth = w;
 	_engineRequestedHeight = h;
@@ -243,7 +284,6 @@ void OpenGLSdlGraphics3dManager::setupScreen() {
 	closeOverlay();
 
 	_antialiasing = ConfMan.getInt("antialiasing");
-	_lockAspectRatio = ConfMan.getBool("aspect_ratio");
 	_vsync = ConfMan.getBool("vsync");
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -342,45 +382,17 @@ void OpenGLSdlGraphics3dManager::createOrUpdateScreen() {
 	int obtainedHeight = effectiveHeight;
 #endif
 
-	handleResize(obtainedWidth, obtainedHeight);
-
-	// Compute the rectangle where to draw the game inside the effective screen
-	_gameRect = computeGameRect(renderToFrameBuffer, _engineRequestedWidth, _engineRequestedHeight,
-	                            obtainedWidth, obtainedHeight);
-
 	initializeOpenGLContext();
 	_surfaceRenderer = OpenGL::createBestSurfaceRenderer();
-
 	_overlayFormat = OpenGL::TextureGL::getRGBAPixelFormat();
-	_overlayScreen = new OpenGL::TiledSurface(obtainedWidth, obtainedHeight, _overlayFormat);
-
-	_screenChangeCount++;
 
 	if (renderToFrameBuffer) {
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 		_frameBuffer = createFramebuffer(_engineRequestedWidth, _engineRequestedHeight);
 		_frameBuffer->attach();
-	}
-}
-
-Math::Rect2d OpenGLSdlGraphics3dManager::computeGameRect(bool renderToFrameBuffer, uint gameWidth, uint gameHeight,
-													  uint screenWidth, uint screenHeight) {
-	if (renderToFrameBuffer) {
-		if (_lockAspectRatio) {
-			// The game is scaled to fit the screen, keeping the same aspect ratio
-			float scale = MIN(screenHeight / float(gameHeight), screenWidth / float(gameWidth));
-			float scaledW = scale * (gameWidth / float(screenWidth));
-			float scaledH = scale * (gameHeight / float(screenHeight));
-			return Math::Rect2d(
-					Math::Vector2d(0.5 - (0.5 * scaledW), 0.5 - (0.5 * scaledH)),
-					Math::Vector2d(0.5 + (0.5 * scaledW), 0.5 + (0.5 * scaledH))
-			);
-		} else {
-			// The game occupies the whole screen
-			return Math::Rect2d(Math::Vector2d(0, 0), Math::Vector2d(1, 1));
-		}
+		handleResize(_engineRequestedWidth, _engineRequestedHeight);
 	} else {
-		return Math::Rect2d(Math::Vector2d(0, 0), Math::Vector2d(1, 1));
+		handleResize(obtainedWidth, obtainedHeight);
 	}
 }
 
@@ -395,21 +407,26 @@ void OpenGLSdlGraphics3dManager::notifyResize(const int width, const int height)
 		return; // nothing to do
 	}
 
-	// Compute the rectangle where to draw the game inside the effective screen
-	_gameRect = computeGameRect(_frameBuffer != nullptr,
-	                            _engineRequestedWidth, _engineRequestedHeight,
-	                            newWidth, newHeight);
+	handleResize(newWidth, newHeight);
+#else
+	handleResize(width, height);
+#endif
+}
 
+void OpenGLSdlGraphics3dManager::handleResizeImpl(const int width, const int height) {
 	// Update the overlay
 	delete _overlayScreen;
-	_overlayScreen = new OpenGL::TiledSurface(newWidth, newHeight, _overlayFormat);
+	_overlayScreen = new OpenGL::TiledSurface(width, height, _overlayFormat);
 
 	// Clear the overlay background so it is not displayed distorted while resizing
 	delete _overlayBackground;
 	_overlayBackground = nullptr;
 
+	// Re-setup the scaling for the screen
+	recalculateDisplayAreas();
+
+	// Something changed, so update the screen change ID.
 	_screenChangeCount++;
-#endif
 }
 
 void OpenGLSdlGraphics3dManager::initializeOpenGLContext() const {
@@ -563,7 +580,7 @@ bool OpenGLSdlGraphics3dManager::isVSyncEnabled() const {
 void OpenGLSdlGraphics3dManager::drawOverlay() {
 	_surfaceRenderer->prepareState();
 
-	glViewport(0, 0, _overlayScreen->getWidth(), _overlayScreen->getHeight());
+	glViewport(_overlayDrawRect.left, _windowHeight - _overlayDrawRect.top - _overlayDrawRect.height(), _overlayDrawRect.width(), _overlayDrawRect.height());
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
 	if (_overlayBackground) {
@@ -592,9 +609,9 @@ void OpenGLSdlGraphics3dManager::updateScreen() {
 	if (_frameBuffer) {
 		_frameBuffer->detach();
 		_surfaceRenderer->prepareState();
-		glViewport(0, 0, _overlayScreen->getWidth(), _overlayScreen->getHeight());
+		glViewport(_gameDrawRect.left, _windowHeight - _gameDrawRect.top - _gameDrawRect.height(), _gameDrawRect.width(), _gameDrawRect.height());
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		_surfaceRenderer->render(_frameBuffer, _gameRect);
+		_surfaceRenderer->render(_frameBuffer, Math::Rect2d(Math::Vector2d(0, 0), Math::Vector2d(1, 1)));
 		_surfaceRenderer->restorePreviousState();
 	}
 
@@ -641,7 +658,7 @@ void OpenGLSdlGraphics3dManager::showOverlay() {
 	if (_overlayVisible) {
 		return;
 	}
-	_overlayVisible = true;
+	WindowedGraphicsManager::showOverlay();
 
 	delete _overlayBackground;
 	_overlayBackground = nullptr;
@@ -662,7 +679,7 @@ void OpenGLSdlGraphics3dManager::hideOverlay() {
 	if (!_overlayVisible) {
 		return;
 	}
-	_overlayVisible = false;
+	WindowedGraphicsManager::hideOverlay();
 
 	delete _overlayBackground;
 	_overlayBackground = nullptr;
@@ -712,37 +729,21 @@ int16 OpenGLSdlGraphics3dManager::getOverlayWidth() const {
 }
 
 bool OpenGLSdlGraphics3dManager::showMouse(bool visible) {
-	SDL_ShowCursor(visible);
+	SDL_ShowCursor(visible ? SDL_ENABLE : SDL_DISABLE);
 	return true;
 }
 
-void OpenGLSdlGraphics3dManager::warpMouse(int x, int y) {
-	if (!_overlayVisible && _frameBuffer) {
-		// Scale from game coordinates to screen coordinates
-		x = (x * _gameRect.getWidth() * _overlayScreen->getWidth()) / _frameBuffer->getWidth();
-		y = (y * _gameRect.getHeight() * _overlayScreen->getHeight()) / _frameBuffer->getHeight();
+bool OpenGLSdlGraphics3dManager::notifyMousePosition(Common::Point &mouse) {
+	// HACK: SdlGraphicsManager disables the system cursor when the mouse is in the
+	// active draw rect, however the 3D graphics manager uses it instead of the
+	// standard mouse graphic.
+	int showCursor = SDL_ShowCursor(SDL_QUERY);
 
-		x += _gameRect.getTopLeft().getX() * _overlayScreen->getWidth();
-		y += _gameRect.getTopLeft().getY() * _overlayScreen->getHeight();
-	}
+	bool valid = SdlGraphicsManager::notifyMousePosition(mouse);
 
-	_window->warpMouseInWindow(x, y);
-}
+	SDL_ShowCursor(showCursor);
 
-void OpenGLSdlGraphics3dManager::transformMouseCoordinates(Common::Point &point) {
-	if (_overlayVisible || !_frameBuffer)
-		return;
-
-	// Scale from screen coordinates to game coordinates
-	point.x -= _gameRect.getTopLeft().getX() * _overlayScreen->getWidth();
-	point.y -= _gameRect.getTopLeft().getY() * _overlayScreen->getHeight();
-
-	point.x = (point.x * _frameBuffer->getWidth())  / (_gameRect.getWidth() * _overlayScreen->getWidth());
-	point.y = (point.y * _frameBuffer->getHeight()) / (_gameRect.getHeight() * _overlayScreen->getHeight());
-
-	// Make sure we only supply valid coordinates.
-	point.x = CLIP<int16>(point.x, 0, _frameBuffer->getWidth() - 1);
-	point.y = CLIP<int16>(point.y, 0, _frameBuffer->getHeight() - 1);
+	return valid;
 }
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -57,6 +57,11 @@ public:
 	bool setGraphicsMode(int mode, uint flags = OSystem::kGfxModeNoFlags) override;
 	int getGraphicsMode() const override;
 
+	const OSystem::GraphicsMode *getSupportedStretchModes() const override;
+	int getDefaultStretchMode() const override;
+	bool setStretchMode(int mode) override;
+	int getStretchMode() const override;
+
 	void beginGFXTransaction() override;
 	OSystem::TransactionError endGFXTransaction() override;
 
@@ -95,11 +100,9 @@ public:
 	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
 	int16 getOverlayWidth() const override;
 	int16 getOverlayHeight() const override;
-	bool isOverlayVisible() const override { return _overlayVisible; }
 
 	// GraphicsManager API - Mouse
 	bool showMouse(bool visible) override;
-	void warpMouse(int x, int y) override;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override {}
 	void setCursorPalette(const byte *colors, uint start, uint num) override {}
 
@@ -109,12 +112,7 @@ public:
 
 	bool gameNeedsAspectRatioCorrection() const override { return false; }
 
-	void transformMouseCoordinates(Common::Point &point);
-	bool notifyMousePosition(Common::Point &mouse) override {
-		transformMouseCoordinates(mouse);
-
-		return true;
-	}
+	bool notifyMousePosition(Common::Point &mouse) override;
 
 protected:
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -126,8 +124,6 @@ protected:
 	OpenGL::ContextOGLType _glContextType;
 
 	bool _supportsFrameBuffer;
-
-	Math::Rect2d _gameRect;
 
 	struct OpenGLPixelFormat {
 		uint bytesPerPixel;
@@ -152,9 +148,7 @@ protected:
 	void createOrUpdateScreen();
 	void setupScreen();
 
-	/** Compute the size and position of the game rectangle in the screen */
-	Math::Rect2d computeGameRect(bool renderToFrameBuffer, uint gameWidth, uint gameHeight,
-	                             uint screenWidth, uint screenHeight);
+	void handleResizeImpl(const int width, const int height) override;
 
 	bool saveScreenshot(const Common::String &filename) const override;
 
@@ -162,10 +156,9 @@ protected:
 
 	int _screenChangeCount;
 	int _antialiasing;
+	int _stretchMode;
 	bool _vsync;
 	bool _fullscreen;
-	bool _lockAspectRatio;
-	bool _overlayVisible;
 
 	OpenGL::TiledSurface *_overlayScreen;
 	OpenGL::TiledSurface *_overlayBackground;

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -424,6 +424,7 @@ void initGraphics3d(int width, int height) {
 		g_system->initSize(width, height);
 		g_system->setFeatureState(OSystem::kFeatureFullscreenMode, ConfMan.getBool("fullscreen")); // TODO: Replace this with initCommonGFX()
 		g_system->setFeatureState(OSystem::kFeatureAspectRatioCorrection, ConfMan.getBool("aspect_ratio")); // TODO: Replace this with initCommonGFX()
+		g_system->setStretchMode(ConfMan.get("stretch_mode").c_str()); // TODO: Replace this with initCommonGFX()
 	g_system->endGFXTransaction();
 }
 

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -73,6 +73,7 @@ backends/graphics/opengl/opengl-graphics.cpp
 backends/graphics/openglsdl/openglsdl-graphics.cpp
 backends/graphics/surfacesdl/surfacesdl-graphics.cpp
 backends/graphics/sdl/sdl-graphics.cpp
+backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
 backends/keymapper/hardware-input.cpp
 backends/keymapper/remap-widget.cpp
 backends/keymapper/virtual-mouse.cpp


### PR DESCRIPTION
This has two main advantages:
- The mouse cursor is now restricted to the correct area when grabbing the cursor with SDL 2.0.18 or later. This fixes [Trac #13152](https://bugs.scummvm.org/ticket/13152).
- 3D games now make use of the selected stretch mode, which replaces the old aspect ratio code. This fixes [Trac #12475](https://bugs.scummvm.org/ticket/12475).

It looks like `WindowedGraphicsManager` is able to handle games that support arbitrary resolutions without any additional changes. The important thing is to make sure that `getWidth()` and `getHeight()` return the correct values when `recalculateDisplayAreas()` is called.