### PR TITLE
OPENPANDORA: Restore Fix For Touchscreen Issues with libSDL

### DIFF
--- a/backends/graphics/openpandora/op-graphics.cpp
+++ b/backends/graphics/openpandora/op-graphics.cpp
@@ -82,7 +82,7 @@ bool OPGraphicsManager::showMouse(bool visible) {
 			showCursor = SDL_ENABLE;
 		}
 	}
-	SDL_ShowCursor(showCursor);
+	//SDL_ShowCursor(showCursor);
 
 	return WindowedGraphicsManager::showMouse(visible);
 }
@@ -137,7 +137,7 @@ bool OPGraphicsManager::notifyMousePosition(Common::Point &mouse) {
 		}
 	}
 
-	SDL_ShowCursor(showCursor);
+	//SDL_ShowCursor(showCursor);
 	if (valid) {
 		setMousePosition(mouse.x, mouse.y);
 		mouse = convertWindowToVirtual(mouse.x, mouse.y);

--- a/backends/graphics/openpandora/op-graphics.cpp
+++ b/backends/graphics/openpandora/op-graphics.cpp
@@ -66,4 +66,83 @@ void OPGraphicsManager::unloadGFXMode() {
 	SurfaceSdlGraphicsManager::unloadGFXMode();
 }
 
+bool OPGraphicsManager::showMouse(bool visible) {
+	if (visible == _cursorVisible) {
+		return visible;
+	}
+
+	int showCursor = SDL_DISABLE;
+	if (visible) {
+		// _cursorX and _cursorY are currently always clipped to the active
+		// area, so we need to ask SDL where the system's mouse cursor is
+		// instead
+		int x, y;
+		SDL_GetMouseState(&x, &y);
+		if (!_activeArea.drawRect.contains(Common::Point(x, y))) {
+			showCursor = SDL_ENABLE;
+		}
+	}
+	SDL_ShowCursor(showCursor);
+
+	return WindowedGraphicsManager::showMouse(visible);
+}
+
+bool OPGraphicsManager::notifyMousePosition(Common::Point &mouse) {
+	mouse.x = CLIP<int16>(mouse.x, 0, _windowWidth - 1);
+	mouse.y = CLIP<int16>(mouse.y, 0, _windowHeight - 1);
+
+	int showCursor = SDL_DISABLE;
+	// Currently on macOS we need to scale the events for HiDPI screen, but on
+	// Windows we do not. We can find out if we need to do it by querying the
+	// SDL window size vs the SDL drawable size.
+	float dpiScale = _window->getSdlDpiScalingFactor();
+	mouse.x = (int)(mouse.x * dpiScale + 0.5f);
+	mouse.y = (int)(mouse.y * dpiScale + 0.5f);
+	bool valid = true;
+	if (_activeArea.drawRect.contains(mouse)) {
+		_cursorLastInActiveArea = true;
+	} else {
+		// The right/bottom edges are not part of the drawRect. As the clipping
+		// is done in drawable area coordinates, but the mouse position is set
+		// in window coordinates, we need to subtract as many pixels from the
+		// edges as corresponds to one pixel in the window coordinates.
+		mouse.x = CLIP<int>(mouse.x, _activeArea.drawRect.left,
+							_activeArea.drawRect.right - (int)(1 * dpiScale + 0.5f));
+		mouse.y = CLIP<int>(mouse.y, _activeArea.drawRect.top,
+							_activeArea.drawRect.bottom - (int)(1 * dpiScale + 0.5f));
+
+		if (_window->mouseIsGrabbed() ||
+			// Keep the mouse inside the game area during dragging to prevent an
+			// event mismatch where the mouseup event gets lost because it is
+			// performed outside of the game area
+			(_cursorLastInActiveArea && SDL_GetMouseState(nullptr, nullptr) != 0)) {
+			setSystemMousePosition(mouse.x, mouse.y);
+		} else {
+			// Allow the in-game mouse to get a final movement event to the edge
+			// of the window if the mouse was moved out of the game area
+			if (_cursorLastInActiveArea) {
+				_cursorLastInActiveArea = false;
+			} else if (_cursorVisible) {
+				// Keep sending events to the game if the cursor is invisible,
+				// since otherwise if a game lets you skip a cutscene by
+				// clicking and the user moved the mouse outside the active
+				// area, the clicks wouldn't do anything, which would be
+				// confusing
+				valid = false;
+			}
+
+			if (_cursorVisible) {
+				showCursor = SDL_ENABLE;
+			}
+		}
+	}
+
+	SDL_ShowCursor(showCursor);
+	if (valid) {
+		setMousePosition(mouse.x, mouse.y);
+		mouse = convertWindowToVirtual(mouse.x, mouse.y);
+	}
+	return valid;
+}
+
 #endif

--- a/backends/graphics/openpandora/op-graphics.h
+++ b/backends/graphics/openpandora/op-graphics.h
@@ -30,6 +30,9 @@ public:
 
 	bool loadGFXMode() override;
 	void unloadGFXMode() override;
+
+	bool showMouse(bool visible) override;
+	bool notifyMousePosition(Common::Point &mouse);
 };
 
 #endif /* BACKENDS_GRAPHICS_OP_H */

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -93,7 +93,7 @@ public:
 	 */
 	virtual bool notifyMousePosition(Common::Point &mouse);
 
-	bool showMouse(bool visible) override;
+	virtual bool showMouse(bool visible) override;
 	bool lockMouse(bool lock) override;
 
 	virtual bool saveScreenshot(const Common::String &filename) const { return false; }

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -157,8 +157,10 @@ void OSystem_SDL::init() {
 	SDL_EnableUNICODE(1);
 #endif
 
+#if !defined(OPENPANDORA)
 	// Disable OS cursor
 	SDL_ShowCursor(SDL_DISABLE);
+#endif
 
 	if (_window == nullptr)
 		_window = new SdlWindow();


### PR DESCRIPTION
This was reported on the forums as https://forums.scummvm.org/viewtopic.php?t=16560

This appears to be a regression since v1.8.0 where refactoring of the SDL backends code resulted in calls to disable SDL cursor which cause issues on OpenPandora. See:
https://web.archive.org/web/20200810044118/https://www.distant-earth.com/index.php/openpandora-using-custom-cursors-in-fullscreen-x11-sdl-windows-without-touchscreen-driftinggrabbing-issues/

This PR attempts to fix this by guarding these calls to disable them on OpenPandora in various ways. However, since I do not have a working OpenPandora toolchain, hardware or any way to test, it would be good to get team feedback and maybe some testing from OpenPandora maintainer before merging this.