### PR TITLE
SCUMM: Fix glitch when Bruno flees Bumpusville (bug #3832)

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1032,17 +1032,6 @@ void ScummEngine_v6::o6_setState() {
 	int state = pop();
 	int obj = pop();
 
-	// WORKAROUND for bug #3832: parts of Bruno are left on the screen when he
-	// escapes Bumpusville with Trixie. Bruno (act. 11) and Trixie (act. 12) are
-	// properly removed from the scene by the script, but not the combined actor
-	// which is used by this animation (act. 6). Fix this before the door gets closed.
-	if (_game.id == GID_SAMNMAX && _roomResource == 47 && vm.slot[_currentScript].number == 202 &&
-		obj == 451 && state == 0 && _enableEnhancements) {
-		Actor *a = derefActorSafe(6, "o6_setState");
-		if (a)
-			a->putActor(0, 0, 0);
-	}
-
 	putState(obj, state);
 	markObjectRectAsDirty(obj);
 	if (_bgNeedsRedraw)
@@ -1260,6 +1249,17 @@ void ScummEngine_v6::o6_animateActor() {
 			stopTalk();
 		}
 	}
+	if (_game.id == GID_SAMNMAX && _roomResource == 47 && vm.slot[_currentScript].number == 202 &&
+		act == 2 && anim == 249 && _enableEnhancements) {
+		// WORKAROUND for bug #3832: parts of Bruno are left on the screen when he
+		// escapes Bumpusville with Trixie. Bruno (act. 11) and Trixie (act. 12) are
+		// properly removed from the scene by the script, but not the combined actor
+		// which is used by this animation (act. 6).
+		Actor *a = derefActorSafe(6, "o6_animateActor");
+		if (a && a->_costume == 243)
+			a->putActor(0, 0, 0);
+	}
+
 	Actor *a = derefActor(act, "o6_animateActor");
 	a->animateActor(anim);
 }

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1032,6 +1032,17 @@ void ScummEngine_v6::o6_setState() {
 	int state = pop();
 	int obj = pop();
 
+	// WORKAROUND for bug #3832: parts of Bruno are left on the screen when he
+	// escapes Bumpusville with Trixie. Bruno (act. 11) and Trixie (act. 12) are
+	// properly removed from the scene by the script, but not the combined actor
+	// which is used by this animation (act. 6). Fix this before the door gets closed.
+	if (_game.id == GID_SAMNMAX && _roomResource == 47 && vm.slot[_currentScript].number == 202 &&
+		obj == 451 && state == 0 && _enableEnhancements) {
+		Actor *a = derefActorSafe(6, "o6_setState");
+		if (a)
+			a->putActor(0, 0, 0);
+	}
+
 	putState(obj, state);
 	markObjectRectAsDirty(obj);
 	if (_bgNeedsRedraw)


### PR DESCRIPTION
See [Trac #3832](https://bugs.scummvm.org/ticket/3832) for more context, screenshots and saves.

In Sam & Max, when Bruno and Trixie leave Bumpusville, a new actor is used for their escape animation, but the original script never removes this actor from the scene, so some parts of Bruno can still be seen on the wall when the door closes (although it's not extremely visible, since Bruno's colours match that of the wall… but once you've seen it…). So this PR forces the removal of this actor just before this happens.

This actually just follows @eriktorbjorn's initial suggestion. The original script (no. 202 in room 47) does this:

```
...
[06B4] (7F) putActorInXY(6,160,100,47)  # <== Combined Bruno+Trixie actor
[06C1] (82) animateActor(6,250)
[06C8] (82) animateActor(6,6)
[06CF] (7F) putActorInXY(12,0,0,0)      # <== Trixie
[06DC] (CA) delayFrames(23)
[06E0] (7F) putActorInXY(11,0,0,0)      # <== Bruno
[06ED] (CA) delayFrames(28)
[06F1] (B6) printDebug.begin()
[06F3] (B6) printDebug.msg(sound(0x9FC6ECA, 0xA) + " ")
[0707] (70) setState(451,0)             # <= The door gets closed
[070E] (43) bitvar2 = 0
[0714] (82) animateActor(2,249)
...
```

and so indeed I don't think there's a better place than `o6_setState()` to catch and fix this. I've just restricted the conditions a bit more.

In order to test this:

1. grab the savegames from the Trac issue above
2. insert the key in security mechanism on the right
3. wait for Bruno to leave the room.

Tested with my original French CD and with the English version from GOG.