### PR TITLE
COMMON: Fix WeakPtr not being weak

### DIFF
--- a/common/ptr.h
+++ b/common/ptr.h
@@ -387,6 +387,11 @@ public:
 	WeakPtr(std::nullptr_t) : BasePtr<T>() {
 	}
 
+	WeakPtr(const WeakPtr<T> &r) : BasePtr<T>(r) {
+		if (this->_tracker)
+			this->_tracker->incWeak();
+	}
+
 	WeakPtr(const BasePtr<T> &r) : BasePtr<T>(r) {
 		if (this->_tracker)
 			this->_tracker->incWeak();

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -333,7 +333,7 @@ private:
  * a pointer. It needs to be converted to a SharedPtr to access it.
  */
 template<class T>
-class WeakPtr : public SafeBool<WeakPtr<T> > {
+class WeakPtr {
 	template<class T2>
 	friend class WeakPtr;
 	template<class T2>
@@ -372,15 +372,6 @@ public:
 	 */
 	SharedPtr<T> lock() const {
 		return SharedPtr<T>(*this);
-	}
-
-	/**
-	 * Implicit conversion operator to bool for convenience, to make
-	 * checks like "if (weakPtr) ..." possible.  This only checks if the
-	 * weak pointer contains a pointer, not that the pointer is live.
-	 */
-	bool operator_bool() const {
-		return _pointer != nullptr;
 	}
 
 	/**

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -425,6 +425,17 @@ public:
 		return this->_tracker == nullptr || this->_tracker->getStrongCount() == 0;
 	}
 
+	WeakPtr<T> &operator=(const WeakPtr<T> &r) {
+		reset(r);
+		return *this;
+	}
+
+	template<class T2>
+	WeakPtr<T> &operator=(const WeakPtr<T2> &r) {
+		reset(r);
+		return *this;
+	}
+
 	WeakPtr<T> &operator=(const BasePtr<T> &r) {
 		reset(r);
 		return *this;
@@ -454,10 +465,10 @@ public:
 
 		this->assign(r);
 
-		if (oldTracker)
-			oldTracker->incWeak();
 		if (this->_tracker)
-			this->_tracker->decWeak();
+			this->_tracker->incWeak();
+		if (oldTracker)
+			oldTracker->decWeak();
 	}
 
 	/**
@@ -469,10 +480,10 @@ public:
 
 		this->assign(r);
 
-		if (oldTracker)
-			oldTracker->incWeak();
 		if (this->_tracker)
-			this->_tracker->decWeak();
+			this->_tracker->incWeak();
+		if (oldTracker)
+			oldTracker->decWeak();
 	}
 };
 

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -101,7 +101,7 @@ template<class T, class DL>
 class BasePtrTrackerDeletionImpl : public BasePtrTrackerInternal {
 public:
 	BasePtrTrackerDeletionImpl(T *ptr, DL d) : _ptr(ptr), _deleter(d) {}
-	~BasePtrTrackerDeletionImpl() { _deleter(_ptr); }
+	~BasePtrTrackerDeletionImpl() { }
 
 private:
 	void destructObject() override {

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -101,7 +101,6 @@ template<class T, class DL>
 class BasePtrTrackerDeletionImpl : public BasePtrTrackerInternal {
 public:
 	BasePtrTrackerDeletionImpl(T *ptr, DL d) : _ptr(ptr), _deleter(d) {}
-	~BasePtrTrackerDeletionImpl() { }
 
 private:
 	void destructObject() override {

--- a/devtools/create_project/scripts/scummvm.natvis
+++ b/devtools/create_project/scripts/scummvm.natvis
@@ -135,7 +135,7 @@
     <DisplayString Condition="_pointer != 0">{*_pointer}</DisplayString>
     <Expand>
       <Item Condition="_pointer != 0" Name="[ptr]">_pointer</Item>
-      <Item Condition="_refCount != 0" Name="[refCount]">*_refCount</Item>
+      <Item Condition="_tracker != 0" Name="[refCount]">_tracker->_strongRefCount</Item>
     </Expand>
   </Type>
 </AutoVisualizer>

--- a/devtools/create_project/scripts/scummvm.natvis
+++ b/devtools/create_project/scripts/scummvm.natvis
@@ -130,6 +130,15 @@
     </Expand>
   </Type>
 
+  <Type Name="Common::WeakPtr&lt;*&gt;">
+    <DisplayString Condition="_pointer == 0">nullptr</DisplayString>
+    <DisplayString Condition="_pointer != 0">{*_pointer}</DisplayString>
+    <Expand>
+      <Item Condition="_pointer != 0" Name="[ptr]">_pointer</Item>
+      <Item Condition="_tracker != 0" Name="[refCount]">_tracker->_strongRefCount</Item>
+    </Expand>
+  </Type>
+
   <Type Name="Common::SharedPtr&lt;*&gt;">
     <DisplayString Condition="_pointer == 0">nullptr</DisplayString>
     <DisplayString Condition="_pointer != 0">{*_pointer}</DisplayString>

--- a/test/common/ptr.h
+++ b/test/common/ptr.h
@@ -156,6 +156,16 @@ class PtrTestSuite : public CxxTest::TestSuite {
 		Common::SharedPtr<A> a(b);
 		a = b;
 	}
+
+	void test_weak_ptr() {
+		Common::SharedPtr<B> b(new B);
+		Common::WeakPtr<A> a(b);
+		TS_ASSERT(a.lock() == b);
+		TS_ASSERT(!a.expired());
+		b.reset();
+		TS_ASSERT(a.expired());
+		TS_ASSERT(!a.lock());
+	}
 };
 
 int PtrTestSuite::InstanceCountingClass::count = 0;


### PR DESCRIPTION
Currently WeakPtr is functionally a SharedPtr because it does refcounting in the base class and as a result, prevents object deletion.

This refactors SharedPtr+WeakPtr to use a tracker object with 2 counters: The strong counter is non-zero if any SharedPtr refs are alive.  If it falls to zero, the object is deleted and weak counter is decremented.  The weak counter is non-zero if any SharedPtr OR WeakPtr refs are alive.  If it falls to zero, then the tracker is deleted.

Also adjusts the API slightly, e.g. it's no longer possible to construct or reset a WeakPtr to a regular pointer (because it has no way of tracking the lifetime).

Regression tested with AGS and fixed a bug so hopefully this should be good now.