### PR TITLE
SCUMM: Work around DOTT glitch when Bernard looks out of Chron-O-John

### DIFF
--- a/engines/scumm/costume.cpp
+++ b/engines/scumm/costume.cpp
@@ -910,32 +910,28 @@ byte ClassicCostumeRenderer::drawLimb(const Actor *a, int limb) {
 				_srcptr += 12;
 			}
 
-			// WORKAROUND: During the intro, when Bernard faces to
-			// the right or left it's apparently the same set of
-			// graphical sprites (limbs) except in one case they're
-			// mirrored. There are two limbs: Bernard's face, and
-			// the surrounding area of the Chron-O-John. I guess
-			// that it's done this way so that opening the lid is
-			// part of the actor animation.
+			// WORKAROUND: During the intro, there are a couple of
+			// glitches when Bernard looks out of his Chron-O-John.
+			// The actor has two limbs: The lid and the face. The
+			// lid is slightly misaligned, and when Bernard faces to
+			// the left both the lid and the face are mirrored when
+			// only his face should be.
 			//
-			// Of course, just because Bernard turns his head does
-			// not mean that the Chron-O-John should be mirrored
-			// along with it. We work around this drawing glitch by
-			// always having the appropriate mirroring flag for
-			// that limb. We also adjust the position of the head
-			// slightly to make it fit nicer into the framing area.
-			//
-			// Note that room 61 is used more than once, so just to
-			// be extra safe we also check that the expected script
-			// is running.
+			// We adjust the positioning a bit (though not while the
+			// lid is opening, since that causes further glitches),
+			// and make sure that the lid is always drawn the
+			// correct way.
 
 			bool mirror = _mirror;
 
-			if (_vm->_game.id == GID_TENTACLE && _vm->_currentRoom == 61 && a->_number == 1 && a->getFacing() == 270 && _vm->isScriptRunning(207) && _vm->_enableEnhancements) {
+			if (_vm->_game.id == GID_TENTACLE && _vm->_currentRoom == 61 && a->_number == 1 && _loaded._id == 324 && _vm->_enableEnhancements) {
 				if (limb == 0) {
 					_mirror = true;
-				} else if (!_mirror) {
-					xmoveCur += 2;
+					byte frm = a->_cost.curpos[3] & 0x0FF;
+					if (frm == 0x3D || frm == 0x3E)
+						xmoveCur--;
+				} else if (a->getFacing() == 270 && !_mirror) {
+					xmoveCur += 4;
 				}
 			}
 

--- a/engines/scumm/costume.cpp
+++ b/engines/scumm/costume.cpp
@@ -932,6 +932,8 @@ byte ClassicCostumeRenderer::drawLimb(const Actor *a, int limb) {
 						xmoveCur--;
 				} else if (a->getFacing() == 270 && !_mirror) {
 					xmoveCur += 4;
+				} else if (a->getFacing() == 90) {
+					xmoveCur--;
 				}
 			}
 

--- a/engines/scumm/costume.cpp
+++ b/engines/scumm/costume.cpp
@@ -910,7 +910,39 @@ byte ClassicCostumeRenderer::drawLimb(const Actor *a, int limb) {
 				_srcptr += 12;
 			}
 
-			return mainRoutine(xmoveCur, ymoveCur);
+			// WORKAROUND: During the intro, when Bernard faces to
+			// the right or left it's apparently the same set of
+			// graphical sprites (limbs) except in one case they're
+			// mirrored. There are two limbs: Bernard's face, and
+			// the surrounding area of the Chron-O-John. I guess
+			// that it's done this way so that opening the lid is
+			// part of the actor animation.
+			//
+			// Of course, just because Bernard turns his head does
+			// not mean that the Chron-O-John should be mirrored
+			// along with it. We work around this drawing glitch by
+			// always having the appropriate mirroring flag for
+			// that limb. We also adjust the position of the head
+			// slightly to make it fit nicer into the framing area.
+			//
+			// Note that room 61 is used more than once, so just to
+			// be extra safe we also check that the expected script
+			// is running.
+
+			bool mirror = _mirror;
+
+			if (_vm->_game.id == GID_TENTACLE && _vm->_currentRoom == 61 && a->_number == 1 && a->getFacing() == 270 && _vm->isScriptRunning(207) && _vm->_enableEnhancements) {
+				if (limb == 0) {
+					_mirror = true;
+				} else if (!_mirror) {
+					xmoveCur += 2;
+				}
+			}
+
+			bool result = mainRoutine(xmoveCur, ymoveCur);
+
+			_mirror = mirror;
+			return result;
 		}
 	}
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -287,7 +287,6 @@ class ScummEngine : public Engine, public Common::Serializable {
 	friend class ScummDebugger;
 	friend class CharsetRenderer;
 	friend class CharsetRendererTownsClassic;
-	friend class ClassicCostumeRenderer;
 	friend class ResourceManager;
 
 public:

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -287,6 +287,7 @@ class ScummEngine : public Engine, public Common::Serializable {
 	friend class ScummDebugger;
 	friend class CharsetRenderer;
 	friend class CharsetRendererTownsClassic;
+	friend class ClassicCostumeRenderer;
 	friend class ResourceManager;
 
 public:


### PR DESCRIPTION
One glitch I noticed recently in the Day of the Tentacle intro is that when Bernard looks out of the Chron-O-John, every time he faces to the left side of the screen part of the Chron-O-John is mirrored, like this:

![dott-glitch](https://user-images.githubusercontent.com/601765/164655680-8d39db66-4962-4d54-b3ba-94cc1f779da4.png)

This appears to be because part of the Chron-O-John is a limb on Bernard's costume, perhaps so that opening the lid can be handled as part of the character animation. The glitch was fixed in the remastered version, though it's still there when using the original graphics. This pull request attempts to get around that by always keeping that limb mirrored and adjusting the position of Bernard's head slightly. This is the result:

![dott-unglitch](https://user-images.githubusercontent.com/601765/164679989-aac22f56-a059-4f77-a7bb-671e3e72e335.png)

I've tested it with my English CD version, and with the English non-interactive demo. (The demo don't show this scene at all.)