### PR TITLE
SCUMM: Get the workaround for bug #1025 closer to the original behavior

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -2963,12 +2963,6 @@ void ScummEngine::actorTalk(const byte *msg) {
 	} else {
 		int oldact;
 
-		// WORKAROUND bug #1025
-		if (_game.id == GID_LOOM && _roomResource == 23 &&
-			vm.slot[_currentScript].number == 232 && _actorToPrintStrFor == 0) {
-			_actorToPrintStrFor = 2;	// Could be anything from 2 to 5. Maybe compare to original?
-		}
-
 		a = derefActor(_actorToPrintStrFor, "actorTalk");
 
 		if (!a->isInCurrentRoom()) {

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2464,6 +2464,52 @@ void ScummEngine_v5::o5_startScript() {
 		data[1] = 10;
 	}
 
+	// WORKAROUND bug #1025: in Loom, using the stealth draft on the
+	// shepherds would crash the game because of a missing actor number for
+	// their first reaction line ("We are the masters of stealth"...).
+	if (_game.id == GID_LOOM && _game.version == 3 && _roomResource == 23 && script == 232 && data[0] == 0) {
+		byte shepherdActor;
+		bool buggyShepherdsEGArelease = false;
+
+		switch (vm.slot[_currentScript].number) {
+		case 422:
+		case 423:
+		case 424:
+		case 425:
+			// It is assumed that the original intent was that any shepherd could
+			// say this line.
+			shepherdActor = vm.slot[_currentScript].number % 10;
+			break;
+		default:
+			// Match the behavior of the Talkie version, if necessary
+			shepherdActor = 4;
+			break;
+		}
+
+		// WORKAROUND: in some EGA releases, actor 3 may have been removed from the
+		// current room, although he's still on screen (the EGA English 1.1 release
+		// fixed this). In ScummVM, this invalid use means that you'd see no reaction
+		// at all from any shepherd when using the stealth draft on him.  In the
+		// original interpreter, the leftmost shepherd still says his own line, though.
+		// Forcing his appearance or ignoring his removal doesn't fix this bug either.
+		//
+		// Having no reaction at all is confusing for the player, so if we detect this
+		// behavior, we force the workaround, for now.
+		if (isValidActor(3) && !_actors[3]->isInCurrentRoom()) {
+			buggyShepherdsEGArelease = true;
+			if (shepherdActor == 3)
+				shepherdActor = 4;
+		}
+
+		if (isValidActor(shepherdActor) && _actors[shepherdActor]->isInCurrentRoom() && (_enableEnhancements || buggyShepherdsEGArelease)) {
+			// Restore the missing line by attaching it to its actor
+			data[0] = shepherdActor;
+		} else {
+			// Otherwise, behave as the original, and just skip this line
+			return;
+		}
+	}
+
 	// Method used by original games to skip copy protection scheme
 	if (!_copyProtection) {
 		// Copy protection was disabled in LucasArts Classic Adventures (PC Disk)


### PR DESCRIPTION
This PR tries to improve the available workaround for [Trac issue #1025](https://bugs.scummvm.org/ticket/1025) in Loom. The diff and the the commit message are way shorter than my explanation below, but if you need my reasoning it's there :)

## Context

Most (probably all) v3 releases of Loom forget to set any `Local[0]` value when triggering the following `print()` call in script 232, room 23:

```
[0000] (01) putActor(1,4,16127);
[0006] (00) stopObjectCode();
[0007] (5D) setClass(422,[132]);
[000E] (94) print(Local[0],[Center(),Text("We are the masters of stealth," + newline() + "little wizard.")]); # <==
...
```

i.e. when you try to use the stealth draft on the shepherds. In the original interpreters, it seems that this line is just completely skipped. In ScummVM, it would have triggered a crash.

Here's what ScummVM currently does to work around this, in `actor.cpp:actorTalk()`:

```c++
// WORKAROUND bug #1025
if (_game.id == GID_LOOM && _roomResource == 23 &&
	vm.slot[_currentScript].number == 232 && _actorToPrintStrFor == 0) {
	_actorToPrintStrFor = 2;	// Could be anything from 2 to 5. Maybe compare to original?
}
```

There are 5 visible characters in this scene:

1. Bobbin (actor 1)
2. The leftmost, brown-haired shepherd with a mustache (actor 2)
3. The second, blond (or white)-haired shepherd (actor 3)
4. The third, brown-haired shepherd (actor 4)
5. The fourth, blond-haires shepherd (actor 5)

The current workaround always attaches the `"We are the masters of stealth"` line to actor 2.

In the Talkie version, the script is different, but a similar line is said by actor 4.

## Looking a bit more at the original scripts

Script 232 can be started by 4 actors objects, in room 23:

* OC_0422
* OC_0423
* OC_0424
* OC_0425

They're almost identical: 

```
[002B] (1A) Var[104] = 428;
[0030] (00) stopObjectCode();
[0031] (0A) startScript(209,[]);
[0034] (00) stopObjectCode();
[0035] (0A) startScript(210,[3,216]); # <== can be 2, 3, 4 or 5
[003E] (00) stopObjectCode();
[003F] (0A) startScript(229,[]);
[0042] (0A) startScript(232,[]);      # <== call to script 232 (with missing Local[0] content)
[0045] (00) stopObjectCode();
[0046] (0A) startScript(229,[]);
[0049] (0A) startScript(231,[]);
[004C] (00) stopObjectCode();
```

I think (but can't prove) that the original intent was to have a `startScript(232,[3])` call (with `[3]` being any shepherd actor number between 2 and 5, inclusive). Moreover, I don't see why `"We are the masters of stealth"` would accept a variable parameter from 4 different scripts if they would always use the same static value. 

Also, looking at the the first introduction with the shepherds, we can see that they all tend to talk a bit. Plus, Bobbin only turns to the leftmost shepherd when this character says `"That camouflage trick won't work on us."` (= the next line).

So I think that a proper workaround for this bug would be to let any shepherd say this line, if you clicked on their associated actor objects (OC_0422–OC_0425 mapping to actors 2–5).

Unfortunately, all v3 Loom versions that I have here (EGA DOS English 1.1, EGA DOS French, TG16 Japanese) have the same buggy call to script 232; I couldn't find any "fixed" version. The v4 versions I have (Talkie Steam, Talkie GOG) always hardcode this line to actor 4, but we know that this version doesn't follow Brian Moriarty's intent, and this talkie release is known for cutting a lot of the dialogue to save space on the CD.

## Part 1: Letting any shepherd output the missing line, and adding extra safety checks

The original workaround tried to fix the `print()` call that's inside script 23-232. I'm trying to fix this earlier, instead, when the call to `startScript(232)` misses its "actor number" parameter.

Then, we know that there are many Loom variants, most of them a bit hard to acquire and compare.

So:

* I'm moving the workaround from `actorTalk()` to `o5_startScript()`
* I only apply this fix to Loom v3, because we know that Loom v4 played and voiced this scene a bit differently
* if Bobbin interacted with actor-object 422, we'll add the missing `[2]` parameter
* (or `[3]` for actor-object 423, `[4]` for 424, `[5]` for 425…)
* if, for whatever reason, this script wasn't triggered by any of these actor-objects, default to `[4]` (since this is was the talkie version did)
* always check that the chosen actor exists and is in the current room, for extra safety (and also because of what has been found in the next part)
* if anything goes wrong, or if the user disabled the `_enableEnhancements` setting for that game, we'll go back to the safe behavior of the original interpreter: just skip the incomplete `"We are the masters of stealth"` line.

…and I'd be extremely happy if that was it.

### Part 2: Working around buggy actor 3

…but then I've tested this with my French EGA version, and I think I've hit another Loom bug.

In some 16-color Loom versions (I don't know specifically which ones), actor 3 (the second shepherd) is always being removed from that scene, although it's still in use. I have no idea why; in the buggy EGA releases you can see him disappear while repeatedly launching the `actors` command in the debugger, while he remains there in the EGA 1.1 release.

This bug exists in my EGA French version, but not in my EGA English 1.1 version. So, I think that it's a bug of the original EGA English **1.0** version, since it appears that most (but not necessarily all…) 16-color releases of Loom where made from the EGA 1.0 release.

I had a look at the scripts, but even if I try to force this actor to "stay" in this scene, or if I try to ignore its move to room 0, I still have some text bugs when triggering this actor. In the buggy versions, if you use the stealth draft on this shepherd, he'll remain silent, both in ScummVM and in the original interpreter. What's even weirder is that ScummVM has an extra bug: the leftmost shepherd remains silent, will doing this (he still says his own line in the original interpreter). This may be a behavior change between ScummVM and the original interpreters, when trying to interact with an actor which has been removed from the room, but which is still displayed.

Or maybe it's just a completely different bug in the EGA 1.0 release. Anyway. All I'm suggesting, for now, is to avoid any interaction with this actor when detecting its buggy status.

So:

* If we detect that actor 3 is in this "buggy", incomplete state, then we'll *always* apply the workaround, even if the user didn't enable `_enableEnhancements`
* moreover, if the user interacted with this buggy actor, we'll redirect its reaction line to actor 4.

I'm doing this, because otherwise the player would see *zero* reaction from the shepherds, which would be extremely confusing, since it's quite likely that a player would try to use this draft on them.

## How to test

Any version of Loom is welcome, but the behavior change should only by triggered by the non-talkie releases.

1. Start a new game
2. Grab the distaff
3. `room 15`, `drafts learn`, `drafts` (note the Invisible draft)
4. Go to the forest on the left, twice, in order to meet the shepherds
5. Let them talk. Once they're done, try using the Invisible draft on any shepherd.

Tested with Loom EGA English 1.1, Loom EGA French, Loom TG16 Japanese, Loom Talkie (GOG & Steam).