### PR TITLE
CONFIGURE: Avoid "file has no symbols" noise from ranlib on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -2814,6 +2814,17 @@ EOF
 			fi
 		fi
 
+		# Avoid "file has no symbols" noise from ranlib, if it's new enough
+		ranlib_version=`$_ranlib -V 2>/dev/null`
+		if test -n "$ranlib_version" ; then
+			ranlib_version="`echo "${ranlib_version}" | sed -ne 's/.*cctools-\([0-9]\{1,\}\).*/\1/gp'`"
+			if test -n "$ranlib_version" && test "$ranlib_version" -ge 862 ; then
+				append_var _ranlib "-no_warning_for_no_symbols"
+				# Also tell ar not to do its own calls to ranlib
+				append_var _ar "-S"
+			fi
+		fi
+
 		# Use pandoc to generate README and NEWS file for the bundle
 		# Also default to  HTML rather than plain text as it gives a nicer
 		# formating, especially for the README. We could consider using RTF


### PR DESCRIPTION
On macOS, if you do some local builds where you `--disable` some stuff, you'll often see this:

```
    AR       audio/libaudio.a
    AR       math/libmath.a
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: audio/libaudio.a(qdm2.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: audio/libaudio.a(maxtrax.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: audio/libaudio.a(eas.o) has no symbols
    RANLIB   math/libmath.a
    RANLIB   audio/libaudio.a
    AR       common/libcommon.a
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: audio/libaudio.a(qdm2.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: audio/libaudio.a(maxtrax.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: audio/libaudio.a(eas.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: common/libcommon.a(translation.o) has no symbols
    RANLIB   common/libcommon.a
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: common/libcommon.a(translation.o) has no symbols
    AR       audio/softsynth/mt32/libmt32.a
    RANLIB   audio/softsynth/mt32/libmt32.a
    C++      base/version.o
    AR       base/libbase.a
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: base/libbase.a(test_new_standards.o) has no symbols
    RANLIB   base/libbase.a
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: base/libbase.a(test_new_standards.o) has no symbols
    LINK     scummvm
```

There's nothing wrong with this, but it's a bit noisy.

Circa 2014/2015, Apple added a new `-no_warning_for_no_symbols` flag to `ranlib`: https://github.com/opensource-apple/cctools/commit/8ad5c7ec9dba53a52bfb544ef716a0adf168e600.

If we check for this version of cctools in the configure script, we can tell ranlib to omit this noise. However, note that we use `ar cr && ranlib` by default (see rules.mk), so `ar` would still do its own calls to `ranlib` (for Unix conformance) which are unnecessary here and which would bring the default noise back. So, in this case, `ar` will now be called with the `-S` flag, so that ranlib isn't called twice.

The modified build was tested on macOS Monterey, and the new check was also tested not to cause any regression on macOS Tiger.

New result is:

```
    AR       audio/libaudio.a
    AR       math/libmath.a
    RANLIB   math/libmath.a
    RANLIB   audio/libaudio.a
    AR       common/libcommon.a
    RANLIB   common/libcommon.a
    AR       audio/softsynth/mt32/libmt32.a
    RANLIB   audio/softsynth/mt32/libmt32.a
    C++      base/version.o
    AR       base/libbase.a
    RANLIB   base/libbase.a
    LINK     scummvm
```