### PR TITLE
SCUMM: Lip syncing fixes for some HE games.

### DIFF
--- a/audio/decoders/wave.h
+++ b/audio/decoders/wave.h
@@ -74,7 +74,8 @@ extern bool loadWAVFromStream(
 	int &rate,
 	byte &flags,
 	uint16 *wavType = 0,
-	int *blockAlign = 0);
+	int *blockAlign = 0,
+	int *samplesPerBlock = 0);
 
 /**
  * Try to load a WAVE from the given seekable stream and create an AudioStream


### PR DESCRIPTION
This is a fix for [ticket 10630](https://bugs.scummvm.org/ticket/10630).

Backyard Baseball 2003 was missing dialog which was lip-synced to animations. It didn't use to be this way. I did a `git bisect`, and found the issue was caused by commit 6ac4c9d. 

It turns out the issue was do to it using the WAV block alignment as a count of bytes per sample. This is true for normal PCM wav files, but it is not true for the IMA ADPCM format used for speech in Backyard Baseball 2003.

The IMA ADPCM format includes extra parameters in the `fmt` section (the length of the `fmt` section is 20 instead of the normal 16). The significant extra parameter is the `SamplesPerBlock` parameter which is the number of samples per channel per block. (see [here](http://www.icculus.org/SDL_sound/downloads/external_documentation/wavecomp.htm) and search for `WAVE_FORMAT_IMA_ADPCM`).

Using the `SamplesPerBlock` parameter, I was able to accurately compute the heChannel timer. This fixes the regression, and makes it better (before the regression, the speech animation would continue for too long).

This is my first time modifying the scummvm source, but I think that I followed all the contribution guidelines.

Cheers! :beers: 