### PR TITLE
SCUMM: Fix costume palette glitch in Amiga Monkey2 (bug #13433)

### DIFF
--- a/engines/scumm/costume.cpp
+++ b/engines/scumm/costume.cpp
@@ -687,6 +687,11 @@ void ClassicCostumeRenderer::procPCEngine(Codec1 &v1) {
 	}
 }
 
+static const byte amigaMonkey2Costume55Room53[16] = {
+	0xfa, 0xca, 0xc2, 0xc0, 0xc1, 0xc3, 0xc4, 0xc5,
+	0xc6, 0xc7, 0xc8, 0xce, 0xcf, 0xcd, 0xc9, 0xcc
+};
+
 void ClassicCostumeLoader::loadCostume(int id) {
 	_id = id;
 	byte *ptr = _vm->getResourceAddress(rtCostume, id);
@@ -737,7 +742,6 @@ void ClassicCostumeLoader::loadCostume(int id) {
 		error("Costume %d with format 0x%X is invalid", id, _format);
 	}
 
-
 	// In GF_OLD_BUNDLE games, there is no actual palette, just a single color byte.
 	// Don't forget, these games were designed around a fixed 16 color HW palette :-)
 	// In addition, all offsets are shifted by 2; we accomodate that via a separate
@@ -755,6 +759,15 @@ void ClassicCostumeLoader::loadCostume(int id) {
 		_dataOffsets = ptr + 34;
 	}
 	_animCmds = _baseptr + READ_LE_UINT16(ptr);
+
+	// WORKAROUND bug #13433: Guybrush can give the stick to two dogs: the one
+	// guarding the jail, and the one in front of the mansion. But the palette
+	// for this costume is invalid in the second case on Amiga, causing a glitch.
+	if (_vm->_game.id == GID_MONKEY2 && _vm->_game.platform == Common::kPlatformAmiga && _vm->_currentRoom == 53 && id == 55 && _numColors == 16 && _vm->_enableEnhancements) {
+		// Note: handmade, trying to match the colors between rooms 53 and 29,
+		// and based on (similar) costume 1.
+		_palette = amigaMonkey2Costume55Room53;
+	}
 }
 
 byte NESCostumeRenderer::drawLimb(const Actor *a, int limb) {


### PR DESCRIPTION
See [Trac issue #13433](https://bugs.scummvm.org/ticket/13433) and this video from RetroSpeedruns: https://www.youtube.com/watch?v=lennSAcOqag.

## Context

In the Amiga version of Monkey Island 2, if you:

1. reach Phatt Island
2. pick up the stick under the mattress inside the jail
3. (escape the jail with the usual scenario)
4. go to Booty Island and use this stick on the dog at the front of the Governor's Mansion

then, Guybrush will switch to costume 55, which has a palette glitch on this version and room. (The Trac issue above also contains a savegame.)

From what I understand, this costume doesn't meet the palette contraints of room 53 (the mansion) but it's fine when used in room 29 (the jail).

So I've picked up the colors from Guybrush's default costume (cost. 1) which is very similar and which works in both rooms (so I guess it's "safe"), and reordered them until cost. 55. didn't glitch anymore. I've also compared the colors between room 53 and 29 (`actor 1 costume 55`, `actor 1 anim 13` in the debugger) while doing this.

## Comparison

Before:

![scummvm-monkey2-amiga-00001](https://user-images.githubusercontent.com/9024526/165751611-9b46bdad-0a0d-402f-8e5a-032acc9e7b21.png)

After:

![scummvm-monkey2-amiga-00002](https://user-images.githubusercontent.com/9024526/165751627-2ba33a34-6e6b-44b3-833a-aea455de3004.png)

I'm not sure `ClassicCostumeLoader::loadCostume()` is the best place for this workaround since it's called a lot, but we need some context to meet the proper conditions (so that the palette is *only* changed in room 53), and well, I'm just moving a pointer to a 16-byte array, so I thought this was OK.

Tested with the Amiga version from the Limited Run Games set.