### PR TITLE
PSP: Remove .MIPS.abiflags* sections from plugins

### DIFF
--- a/backends/plugins/elf/elf-loader.cpp
+++ b/backends/plugins/elf/elf-loader.cpp
@@ -157,7 +157,7 @@ bool DLObject::readProgramHeaders(Elf32_Ehdr *ehdr, Elf32_Phdr *phdr, Elf32_Half
 
 	// Check program header values
 	if (phdr->p_type != PT_LOAD  || phdr->p_filesz > phdr->p_memsz) {
-		warning("elfloader: Invalid program header.");
+		warning("elfloader: Invalid program header %x", phdr->p_type);
 		return false;
 	}
 

--- a/backends/plugins/psp/plugin.ld
+++ b/backends/plugins/psp/plugin.ld
@@ -208,7 +208,7 @@ SECTIONS
   .debug_typenames 0 : { *(.debug_typenames) }
   .debug_varnames  0 : { *(.debug_varnames) }
   /DISCARD/ : { *(.comment) *(.pdr) }
-  /DISCARD/ : { *(.note.GNU-stack) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.MIPS.abiflags*) }
 
   . = __plugin_hole_start;
   .got            : { *(.got.plt) *(.got) } : shorts


### PR DESCRIPTION
The ELF loader can't handle plugins with these sections, and it doesn't appear to be needed for our purposes.