### PR TITLE
SCI: improve sound pause handling during auto-save (bug 13447)

### DIFF
--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -261,10 +261,17 @@ void SciMusic::clearPlayList() {
 
 void SciMusic::pauseAll(bool pause) {
 	const MusicList::iterator end = _playList.end();
+	bool alreadyUnpaused = (_globalPause <= 0);
+
 	if (pause)
 		_globalPause++;
 	else
-		_globalPause = MAX<int>(_globalPause - 1, 0);
+		_globalPause--;
+
+	bool stillUnpaused = (_globalPause <= 0);
+	if (alreadyUnpaused && stillUnpaused)
+		return;
+
 	for (MusicList::iterator i = _playList.begin(); i != end; ++i) {
 #ifdef ENABLE_SCI32
 		// The entire DAC will have been paused by the caller;
@@ -797,7 +804,7 @@ void SciMusic::soundResume(MusicEntry *pSnd) {
 		pSnd->pauseCounter--;
 	if (pSnd->pauseCounter != 0)
 		return;
-	if (pSnd->status != kSoundPaused || (_globalPause && !_needsResume))
+	if (pSnd->status != kSoundPaused || (_globalPause > 0 && !_needsResume))
 		return;
 	_needsResume = (_soundVersion > SCI_VERSION_0_LATE);
 	if (pSnd->pStreamAud) {

--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -269,6 +269,16 @@ void SciMusic::pauseAll(bool pause) {
 		_globalPause--;
 
 	bool stillUnpaused = (_globalPause <= 0);
+	// This check is for a specific situation (the ScummVM autosave) which will try to unpause the music,
+	// although it is already unpaused, and after the save it will then pause it again. We allow the
+	// _globalPause counter to go into the negative, so that the final outcome of both calls is a _globalPause
+	// counter of 0 (First: 0, then -1, then 0 again). However, the pause counters of the individual sounds
+	// do not support negatives. And it would be somewhat more likely to cause regressions to add that
+	// support than to just contain it here...
+	// So, for cases where the status of the _globalPause counter only changes in the range below or equal 0
+	// we return here. The individual sounds only need to get targeted if they ACTUALLY get paused or
+	// unpaused (_globalPause counter changes from 0 to 1 or from 1 to 0) or if the pause counter is
+	// increased above 1 (since positive counters are supported and required for the individual sounds).
 	if (alreadyUnpaused && stillUnpaused)
 		return;
 


### PR DESCRIPTION
The fix for bug no. 13447 addressed the saving via GMM, but it does not (always?) work correctly with auto saves.

You can just try the LSL3 scene in the bug report.

If your patience does not allow you to wait for the auto saving to kick in you can decrease the multiplier in `engines/engine.cpp, line 560`. Just change it from 1000 to 100 (or 50)...

There is the unpause before the save which can't lower the pause counter any more, because it is already 0. And then the sounds are paused (for the first time) after the save.  I've just changed it, so that the pause counter can go below 0 and then is restored to 0 after the save.
