### PR TITLE
GUI: (SaveLoad) - remove unnecessary dialog

### DIFF
--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -333,20 +333,8 @@ void SaveLoadChooserDialog::listSaves() {
 void SaveLoadChooserDialog::activate(int slot, const Common::U32String &description) {
 	if (!_saveList.empty() && slot < int(_saveList.size())) {
 		const SaveStateDescriptor &desc = _saveList[slot];
-		if (_saveMode) {
-			if (g_engine) {
-				const int currentPlayTime = g_engine->getTotalPlayTime();
-				const int savedPlayTime = desc.getPlayTimeMSecs();
-				if (currentPlayTime > 0 && savedPlayTime > 0 && currentPlayTime < savedPlayTime) {
-					GUI::MessageDialog warn(
-								_("WARNING: Existing save has longer gameplay duration than the "
-								  "current state. Are you sure you want to overwrite it?"), _("Yes"), _("No"));
-					if (warn.runModal() != GUI::kMessageOK)
-						return;
-				}
-			}
+		if (_saveMode)
 			_resultString = description.empty() ? desc.getDescription() : description;
-		}
 		setResult(desc.getSaveSlot());
 	}
 	close();


### PR DESCRIPTION
This is about the removal of the dialog

"WARNING: Existing save has longer gameplay duration than the current state. Are you sure you want to overwrite it?"

I think it has more negative than positive impact on the user experience, so I'd remove it.

I recently asked in the discord dev channel about it, but there wasn't much response. @dreammaster, @sluicebox and myself really don't like that dialog, but it is unclear whether everyone else thinks it is a great idea to have it.
