### PR TITLE
DRACI: Remove scummvm_lround() workaround for non-C99 compilers

### DIFF
--- a/engines/draci/animation.cpp
+++ b/engines/draci/animation.cpp
@@ -64,8 +64,8 @@ void Animation::setRelative(int relx, int rely) {
 
 Displacement Animation::getCurrentFrameDisplacement() const {
 	Displacement dis = _displacement;
-	dis.relX += scummvm_lround(dis.extraScaleX * _shift.x);
-	dis.relY += scummvm_lround(dis.extraScaleY * _shift.y);
+	dis.relX += lround(dis.extraScaleX * _shift.x);
+	dis.relY += lround(dis.extraScaleY * _shift.y);
 	return dis;
 }
 

--- a/engines/draci/draci.h
+++ b/engines/draci/draci.h
@@ -117,9 +117,6 @@ enum {
 	kDraciWalkingDebugLevel   = 1 << 6
 };
 
-// Macro to simulate lround() for non-C99 compilers
-static inline long scummvm_lround(double val) { return (long)floor(val + 0.5); }
-
 } // End of namespace Draci
 
 #endif // DRACI_DRACI_H

--- a/engines/draci/game.cpp
+++ b/engines/draci/game.cpp
@@ -381,10 +381,10 @@ void Game::handleOrdinaryLoop(int x, int y) {
 }
 
 int Game::inventoryPositionFromMouse() const {
-	const int column = CLIP(scummvm_lround(
+	const int column = CLIP(lround(
 		(_vm->_mouse->getPosX() - kInventoryX + kInventoryItemWidth / 2.) /
 		kInventoryItemWidth) - 1, 0L, (long) kInventoryColumns - 1);
-	const int line = CLIP(scummvm_lround(
+	const int line = CLIP(lround(
 		(_vm->_mouse->getPosY() - kInventoryY + kInventoryItemHeight / 2.) /
 		kInventoryItemHeight) - 1, 0L, (long) kInventoryLines - 1);
 	return line * kInventoryColumns + column;
@@ -1495,8 +1495,8 @@ void Game::positionAnimAsHero(Animation *anim) {
 	// click but sprites are drawn from their top-left corner so we subtract
 	// the current height of the dragon's sprite
 	Common::Point p = _hero;
-	p.x -= scummvm_lround(scale * frame->getWidth() / 2);
-	p.y -= scummvm_lround(scale * frame->getHeight());
+	p.x -= lround(scale * frame->getWidth() / 2);
+	p.y -= lround(scale * frame->getHeight());
 
 	// Since _persons[] is used for placing talking text, we use the non-adjusted x value
 	// so the text remains centered over the dragon.
@@ -1533,8 +1533,8 @@ void Game::positionHeroAsAnim(Animation *anim) {
 	// used in positionAnimAsHero() and even rounding errors are exactly
 	// the same.
 	Drawable *frame = anim->getCurrentFrame();
-	_hero.x += scummvm_lround(anim->getScaleX() * frame->getWidth() / 2);
-	_hero.y += scummvm_lround(anim->getScaleY() * frame->getHeight());
+	_hero.x += lround(anim->getScaleX() * frame->getWidth() / 2);
+	_hero.y += lround(anim->getScaleY() * frame->getHeight());
 }
 
 void Game::pushNewRoom() {

--- a/engines/draci/sprite.cpp
+++ b/engines/draci/sprite.cpp
@@ -119,8 +119,8 @@ int Sprite::getPixel(int x, int y, const Displacement &displacement) const {
 	double scaleX = double(rect.width()) / _width;
 	double scaleY = double(rect.height()) / _height;
 
-	int sy = scummvm_lround(dy / scaleY);
-	int sx = scummvm_lround(dx / scaleX);
+	int sy = lround(dy / scaleY);
+	int sx = lround(dx / scaleX);
 
 	if (_mirror)
 		return _data[sy * _width + (_width - sx)];
@@ -244,8 +244,8 @@ void Sprite::draw(Surface *surface, bool markDirty, int relX, int relY) const {
 
 Common::Rect Sprite::getRect(const Displacement &displacement) const {
 	return Common::Rect(_x + displacement.relX, _y + displacement.relY,
-	    _x + displacement.relX + scummvm_lround(_scaledWidth * displacement.extraScaleX),
-	    _y + displacement.relY + scummvm_lround(_scaledHeight * displacement.extraScaleY));
+	    _x + displacement.relX + lround(_scaledWidth * displacement.extraScaleX),
+	    _y + displacement.relY + lround(_scaledHeight * displacement.extraScaleY));
 }
 
 Text::Text(const Common::String &str, const Font *font, byte fontColor,


### PR DESCRIPTION
In the Draci engine, `lround()` was replaced with a custom `scummvm_lround()` inline for non-C99 compilers (i.e. old MSVC, I guess), but ScummVM now requires C++11 which implies it, as far as I can say (the wiki still mentions old MSVC versions, but it's probably out of date).

The sparc64 compiler/assembler on OpenBSD would also [complain about "Illegal operands"](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/games/scummvm/patches/patch-engines_draci_draci_h?rev=1.1&content-type=text/x-cvsweb-markup) with the `scummvm_lround()` trick, so they had to patch this for the last 10 years.

Tested with clang++ 13.1 on macOS 12, and g++ 10 on Debian 11. As for MSVC, I'm letting Github Actions do its job :)

(I see that AGS already uses plain `lround()` too, so it should be OK.)