### PR TITLE
GRAPHICS: Add support for loading oversized Mac CURS resources

### DIFF
--- a/graphics/maccursor.cpp
+++ b/graphics/maccursor.cpp
@@ -42,12 +42,14 @@ void MacCursor::clear() {
 	memset(_palette, 0, 256 * 3);
 }
 
-bool MacCursor::readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome, byte monochromeInvertedPixelColor) {
+bool MacCursor::readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome, byte monochromeInvertedPixelColor, bool forceCURSFormat) {
 	clear();
 
-	// Older Mac CURS monochrome cursors had a set size
+	const int minCursSize = 32 * 2 + 4;
+
+	// Older Mac CURS monochrome cursors had a set size, but sometimes contain extra unused bytes
 	// All crsr cursors are larger than this
-	if (stream.size() == 32 * 2 + 4)
+	if (stream.size() == minCursSize || (forceCURSFormat && stream.size() >= minCursSize))
 		return readFromCURS(stream, monochromeInvertedPixelColor);
 
 	return readFromCRSR(stream, forceMonochrome, monochromeInvertedPixelColor);

--- a/graphics/maccursor.h
+++ b/graphics/maccursor.h
@@ -68,7 +68,7 @@ public:
 	uint16 getPaletteCount() const { return 256; }
 
 	/** Read the cursor's data out of a stream. */
-	bool readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome = false, byte monochromeInvertedPixelColor = 0xff);
+	bool readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome = false, byte monochromeInvertedPixelColor = 0xff, bool forceCURSFormat = false);
 
 protected:
 	bool readFromCURS(Common::SeekableReadStream &stream, byte monochromeInvertedPixelColor);


### PR DESCRIPTION
This adds an optional flag for when the CURS data is oversized but the engine knows that it's in CURS format (i.e. because it loaded it from a "CURS" resource and not "crsr")

Needed for mTropolis (which has two 70-byte cursor resources in its standard cursor pack).