### PR TITLE
TEENAGENT: Add missing callback 0x7962 for spider

### DIFF
--- a/engines/teenagent/callbacks.cpp
+++ b/engines/teenagent/callbacks.cpp
@@ -3116,6 +3116,7 @@ bool TeenAgentEngine::processCallback(uint16 addr) {
 		dialog->pop(scene, dsAddr_dialogStackJohnNotyEndgame, 0, 797, textColorMark, textColorJohnNoty, 0, 1);
 		break;
 
+	case 0x7962:
 	case 0x7966:
 		if (CHECK_FLAG(dsAddr_lightOnFlag, 1))
 			retVal = false;


### PR DESCRIPTION
Left-clicking the spider in the cellar raises unknown callback 0x7962.

This PR makes the spider callback the same as the shovel (0x7966)
which is identical to the behaviour of the DOS English game.