### PR TITLE
SCUMM: Fix file handle leak during dialogs in FT

### DIFF
--- a/engines/scumm/imuse_digi/dimuse_files.cpp
+++ b/engines/scumm/imuse_digi/dimuse_files.cpp
@@ -47,8 +47,7 @@ IMuseDigiFilesHandler::IMuseDigiFilesHandler(IMuseDigital *engine, ScummEngine_v
 }
 
 IMuseDigiFilesHandler::~IMuseDigiFilesHandler() {
-	if (_ftSpeechFile)
-		_ftSpeechFile->close();
+	delete _ftSpeechFile;
 	delete _sound;
 }
 
@@ -426,6 +425,7 @@ int IMuseDigiFilesHandler::setCurrentSpeechFilename(const char *fileName) {
 
 void IMuseDigiFilesHandler::setCurrentFtSpeechFile(const char *fileName, ScummFile *file, uint32 offset, uint32 size) {
 	Common::strlcpy(_ftSpeechFilename, fileName, sizeof(_ftSpeechFilename));
+	delete _ftSpeechFile;
 	_ftSpeechFile = file;
 	_ftSpeechSubFileOffset = offset;
 	_ftSpeechFileSize = size;


### PR DESCRIPTION
This fix removes a file handle leak during dialogs in Full Throttle. The leak caused the "monster.sou" file to be opened dozens of times in rapid succession, once during every speech snippet, without those opens ever being closed.

I am not sure this is the best fix, but it seems to work.

It can be tested by wrapping some printf output around the fopen and fclose calls, and monitoring whether every fopen is accompanied by a corresponding fclose.

The PSP is especially vulnerable to file handle leaks like this, because the PSP only allows very few open files at the same time. The leak caused dialogs to become silent after a few sentences on PSP, because all available open file handles that the OS allows were used up by the dozens of open monster.sou instances hanging around. The PPSSPP emulator does not enforce the restriction on numbers of simultaneous open file handles, that's why the problem only appeared on real hardware. 