### PR TITLE
TINSEL: Refactor a few Multi-object details

### DIFF
--- a/engines/tinsel/bmv.cpp
+++ b/engines/tinsel/bmv.cpp
@@ -735,10 +735,11 @@ void BMVPlayer::BmvDrawText(bool bDraw) {
 
 	for (int i = 0; i < 2; i++) {
 		if (texts[i].pText) {
-			x = MultiLeftmost(texts[i].pText);
-			y = MultiHighest(texts[i].pText);
-			w = MIN(MultiRightmost(texts[i].pText) + 1, (int)SCREEN_WIDTH) - x;
-			h = MIN(MultiLowest(texts[i].pText) + 1, SCREEN_HIGH) - y;
+			Common::Rect bounds = MultiBounds(texts[i].pText);
+			x = bounds.left;
+			y = bounds.top;
+			w = MIN(bounds.right + 1, (int)SCREEN_WIDTH) - x;
+			h = MIN(bounds.bottom + 1, SCREEN_HIGH) - y;
 
 			const byte *src = ScreenBeg + (y * SCREEN_WIDTH) + x;
 			byte *dest = (byte *)_vm->screen().getBasePtr(x, y);

--- a/engines/tinsel/bmv.cpp
+++ b/engines/tinsel/bmv.cpp
@@ -717,8 +717,7 @@ void BMVPlayer::FettleMovieText() {
 	for (i = 0; i < 2; i++) {
 		if (texts[i].pText) {
 			if (currentFrame > texts[i].dieFrame) {
-				MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), texts[i].pText);
-				texts[i].pText = nullptr;
+				MultiDeleteObjectIfExists(FIELD_STATUS, &texts[i].pText);
 			} else {
 				MultiForceRedraw(texts[i].pText);
 				bIsText = true;
@@ -785,8 +784,7 @@ void BMVPlayer::MovieText(CORO_PARAM, int stringId, int x, int y, int fontId, CO
 		index = 1;
 	}
 
-	if (texts[index].pText)
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), texts[index].pText);
+	MultiDeleteObjectIfExists(FIELD_STATUS, &texts[index].pText);
 
 	LoadSubString(stringId, 0, _vm->_font->TextBufferAddr(), TBUFSZ);
 
@@ -1025,10 +1023,7 @@ void BMVPlayer::FinishBMV() {
 
 	// Ditch any text objects
 	for (i = 0; i < 2; i++) {
-		if (texts[i].pText) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), texts[i].pText);
-			texts[i].pText = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &texts[i].pText);
 	}
 	bMovieOn = false;
 

--- a/engines/tinsel/cursor.cpp
+++ b/engines/tinsel/cursor.cpp
@@ -94,8 +94,7 @@ void Cursor::InitCurTrailObj(int i, int x, int y) {
 	PokeInPalette(pmi);
 
 	// Get rid of old object
-	if (_trailData[i].trailObj != NULL)
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _trailData[i].trailObj);
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_trailData[i].trailObj);
 
 	// Initialize and insert the object, set its Z-pos, and hide it
 	_trailData[i].trailObj = MultiInitObject(pmi);
@@ -234,10 +233,7 @@ void Cursor::DwHideCursor() {
 		MultiHideObject(_auxCursor);
 
 	for (int i = 0; i < _numTrails; i++) {
-		if (_trailData[i].trailObj != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _trailData[i].trailObj);
-			_trailData[i].trailObj = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_trailData[i].trailObj);
 	}
 }
 
@@ -283,10 +279,7 @@ void Cursor::HideCursorTrails() {
 	_hiddenTrails = true;
 
 	for (i = 0; i < _numTrails; i++)	{
-		if (_trailData[i].trailObj != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _trailData[i].trailObj);
-			_trailData[i].trailObj = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_trailData[i].trailObj);
 	}
 }
 
@@ -301,10 +294,7 @@ void Cursor::UnHideCursorTrails() {
  * Delete auxillary cursor. Restore animation offsets in the image.
  */
 void Cursor::DelAuxCursor() {
-	if (_auxCursor != NULL) {
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _auxCursor);
-		_auxCursor = nullptr;
-	}
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_auxCursor);
 }
 
 /**
@@ -481,9 +471,9 @@ void Cursor::DwInitCursor(SCNHANDLE bfilm) {
 void Cursor::DropCursor() {
 	if (TinselVersion >= 2) {
 		if (_auxCursor)
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _auxCursor);
+			MultiDeleteObjectIfExists(FIELD_STATUS, &_auxCursor);
 		if (_mainCursor)
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _mainCursor);
+			MultiDeleteObjectIfExists(FIELD_STATUS, &_mainCursor);
 
 		_cursorProcessesRestarted = false;
 	}
@@ -495,10 +485,7 @@ void Cursor::DropCursor() {
 	_cursorProcessesStopped = true;		// Suspend cursor processes
 
 	for (int i = 0; i < _numTrails; i++) {
-		if (_trailData[i].trailObj != NULL)		{
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _trailData[i].trailObj);
-			_trailData[i].trailObj = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_trailData[i].trailObj);
 	}
 }
 
@@ -550,8 +537,7 @@ void Cursor::AnimateProcess() {
 	for (int i = 0; i < _vm->_cursor->NumTrails(); i++) {
 		if (_trailData[i].trailObj != NULL) {
 			if (StepAnimScript(&_trailData[i].trailAnim) == ScriptFinished) {
-				MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _trailData[i].trailObj);
-				_trailData[i].trailObj = nullptr;
+				MultiDeleteObjectIfExists(FIELD_STATUS, &_trailData[i].trailObj);
 			}
 		}
 	}

--- a/engines/tinsel/cursor.cpp
+++ b/engines/tinsel/cursor.cpp
@@ -99,8 +99,7 @@ void Cursor::InitCurTrailObj(int i, int x, int y) {
 	// Initialize and insert the object, set its Z-pos, and hide it
 	_trailData[i].trailObj = MultiInitObject(pmi);
 	MultiInsertObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _trailData[i].trailObj);
-	MultiSetZPosition(_trailData[i].trailObj, Z_CURSORTRAIL);
-	MultiSetAniXY(_trailData[i].trailObj, x, y);
+	MultiSetAniXYZ(_trailData[i].trailObj, x, y, Z_CURSORTRAIL);
 
 	// Initialize the animation script
 	InitStepAnimScript(&_trailData[i].trailAnim, _trailData[i].trailObj, FROM_32(pfr->script), ONE_SECOND / FROM_32(pFilm->frate));
@@ -336,8 +335,7 @@ void Cursor::SetAuxCursor(SCNHANDLE hFilm) {
 
 	// Initialize the animation and set its position
 	InitStepAnimScript(&_auxCursorAnim, _auxCursor, FROM_32(pfr->script), ONE_SECOND / FROM_32(pfilm->frate));
-	MultiSetAniXY(_auxCursor, x - _auxCursorOffsetX, y - _auxCursorOffsetY);
-	MultiSetZPosition(_auxCursor, Z_ACURSOR);
+	MultiSetAniXYZ(_auxCursor, x - _auxCursorOffsetX, y - _auxCursorOffsetY, Z_ACURSOR);
 
 	if (_hiddenCursor)
 		MultiHideObject(_auxCursor);

--- a/engines/tinsel/dialogs.cpp
+++ b/engines/tinsel/dialogs.cpp
@@ -1410,10 +1410,10 @@ void Dialogs::Select(int i, bool force) {
 	case FRGROUP:
 		_iconArray[HL2] = RectangleObject(_vm->_bg->BgPal(), COL_HILIGHT, cd.box[i].w + 6, cd.box[i].h + 6);
 		MultiInsertObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL2]);
-		MultiSetAniXY(_iconArray[HL2],
-		              _invD[_activeInv].inventoryX + cd.box[i].xpos - 2,
-		              _invD[_activeInv].inventoryY + cd.box[i].ypos - 2);
-		MultiSetZPosition(_iconArray[HL2], Z_INV_BRECT + 1);
+		MultiSetAniXYZ(_iconArray[HL2],
+		               _invD[_activeInv].inventoryX + cd.box[i].xpos - 2,
+		               _invD[_activeInv].inventoryY + cd.box[i].ypos - 2,
+		               Z_INV_BRECT + 1);
 
 		break;
 
@@ -2005,10 +2005,10 @@ void Dialogs::InvBoxes(bool InBody, int curX, int curY) {
 			                                   ((TinselVersion >= 2) ? HighlightColor() : COL_HILIGHT),
 			                                   cd.box[cd.pointBox].w, cd.box[cd.pointBox].h);
 			MultiInsertObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL1]);
-			MultiSetAniXY(_iconArray[HL1],
-			              _invD[_activeInv].inventoryX + cd.box[cd.pointBox].xpos,
-			              _invD[_activeInv].inventoryY + cd.box[cd.pointBox].ypos);
-			MultiSetZPosition(_iconArray[HL1], Z_INV_ICONS + 1);
+			MultiSetAniXYZ(_iconArray[HL1],
+			               _invD[_activeInv].inventoryX + cd.box[cd.pointBox].xpos,
+			               _invD[_activeInv].inventoryY + cd.box[cd.pointBox].ypos,
+			               Z_INV_ICONS + 1);
 		} else if (cd.box[cd.pointBox].boxType == AAGBUT ||
 		           cd.box[cd.pointBox].boxType == ARSGBUT ||
 		           cd.box[cd.pointBox].boxType == TOGGLE ||
@@ -2017,10 +2017,10 @@ void Dialogs::InvBoxes(bool InBody, int curX, int curY) {
 			pfilm = (const FILM *)_vm->_handle->LockMem(_hWinParts);
 
 			_iconArray[HL1] = AddObject(&pfilm->reels[cd.box[cd.pointBox].bi + HIGRAPH], -1);
-			MultiSetAniXY(_iconArray[HL1],
-			              _invD[_activeInv].inventoryX + cd.box[cd.pointBox].xpos,
-			              _invD[_activeInv].inventoryY + cd.box[cd.pointBox].ypos);
-			MultiSetZPosition(_iconArray[HL1], Z_INV_ICONS + 1);
+			MultiSetAniXYZ(_iconArray[HL1],
+			               _invD[_activeInv].inventoryX + cd.box[cd.pointBox].xpos,
+			               _invD[_activeInv].inventoryY + cd.box[cd.pointBox].ypos,
+			               Z_INV_ICONS + 1);
 		} else if (cd.box[cd.pointBox].boxType == ROTATE) {
 			if (_noLanguage)
 				return;
@@ -2030,16 +2030,16 @@ void Dialogs::InvBoxes(bool InBody, int curX, int curY) {
 			rotateIndex = cd.box[cd.pointBox].bi;
 			if (rotateIndex == IX2_LEFT1) {
 				_iconArray[HL1] = AddObject(&pfilm->reels[IX2_LEFT2], -1);
-				MultiSetAniXY(_iconArray[HL1],
-				              _invD[_activeInv].inventoryX + cd.box[cd.pointBox].xpos - ROTX1,
-				              _invD[_activeInv].inventoryY + cd.box[cd.pointBox].ypos);
-				MultiSetZPosition(_iconArray[HL1], Z_INV_ICONS + 1);
+				MultiSetAniXYZ(_iconArray[HL1],
+				               _invD[_activeInv].inventoryX + cd.box[cd.pointBox].xpos - ROTX1,
+				               _invD[_activeInv].inventoryY + cd.box[cd.pointBox].ypos,
+				               Z_INV_ICONS + 1);
 			} else if (rotateIndex == IX2_RIGHT1) {
 				_iconArray[HL1] = AddObject(&pfilm->reels[IX2_RIGHT2], -1);
-				MultiSetAniXY(_iconArray[HL1],
-				              _invD[_activeInv].inventoryX + cd.box[cd.pointBox].xpos + ROTX1,
-				              _invD[_activeInv].inventoryY + cd.box[cd.pointBox].ypos);
-				MultiSetZPosition(_iconArray[HL1], Z_INV_ICONS + 1);
+				MultiSetAniXYZ(_iconArray[HL1],
+				               _invD[_activeInv].inventoryX + cd.box[cd.pointBox].xpos + ROTX1,
+				               _invD[_activeInv].inventoryY + cd.box[cd.pointBox].ypos,
+				               Z_INV_ICONS + 1);
 			}
 		}
 	}
@@ -2196,8 +2196,10 @@ void Dialogs::FillInInventory() {
 			else if (_invD[_activeInv].contents[Index] != _heldItem) {
 				// Create a display object and position it
 				_iconArray[n] = AddInvObject(_invD[_activeInv].contents[Index], &pfr, &pfilm);
-				MultiSetAniXY(_iconArray[n], _invD[_activeInv].inventoryX + xpos, _invD[_activeInv].inventoryY + ypos);
-				MultiSetZPosition(_iconArray[n], Z_INV_ICONS);
+				MultiSetAniXYZ(_iconArray[n],
+				               _invD[_activeInv].inventoryX + xpos,
+				               _invD[_activeInv].inventoryY + ypos,
+				               Z_INV_ICONS);
 
 				InitStepAnimScript(&_iconAnims[n], _iconArray[n], FROM_32(pfr->script), ONE_SECOND / FROM_32(pfilm->frate));
 
@@ -2226,9 +2228,9 @@ void Dialogs::AddBackground(OBJECT **rect, OBJECT **title, int extraH, int extra
 
 	// add it to display list and position it
 	MultiInsertObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), *rect);
-	MultiSetAniXY(*rect, _invD[_activeInv].inventoryX + NM_BG_POS_X,
-	              _invD[_activeInv].inventoryY + NM_BG_POS_Y);
-	MultiSetZPosition(*rect, Z_INV_BRECT);
+	MultiSetAniXYZ(*rect, _invD[_activeInv].inventoryX + NM_BG_POS_X,
+	               _invD[_activeInv].inventoryY + NM_BG_POS_Y,
+	               Z_INV_BRECT);
 
 	if (title == NULL)
 		return;
@@ -2314,9 +2316,9 @@ OBJECT *Dialogs::AddObject(const FREEL *pfreel, int num) {
 
 void Dialogs::AddSlider(OBJECT **slide, const FILM *pfilm) {
 	_slideObject = *slide = AddObject(&pfilm->reels[IX_SLIDE], -1);
-	MultiSetAniXY(*slide, MultiRightmost(_rectObject) + ((TinselVersion >= 2) ? NM_SLX : -M_SXOFF + 2),
-	              _invD[_activeInv].inventoryY + _sliderYpos);
-	MultiSetZPosition(*slide, Z_INV_MFRAME);
+	MultiSetAniXYZ(*slide, MultiRightmost(_rectObject) + ((TinselVersion >= 2) ? NM_SLX : -M_SXOFF + 2),
+	               _invD[_activeInv].inventoryY + _sliderYpos,
+	               Z_INV_MFRAME);
 }
 
 /**
@@ -2339,8 +2341,7 @@ void Dialogs::AddBox(int *pi, const int i) {
 		_iconArray[*pi] = RectangleObject(_vm->_bg->BgPal(), (TinselVersion >= 2) ? BoxColor() : COL_BOX,
 		                                   cd.box[i].w, cd.box[i].h);
 		MultiInsertObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[*pi]);
-		MultiSetAniXY(_iconArray[*pi], x, y);
-		MultiSetZPosition(_iconArray[*pi], Z_INV_BRECT + 1);
+		MultiSetAniXYZ(_iconArray[*pi], x, y, Z_INV_BRECT + 1);
 		*pi += 1;
 
 		// Stick in the text
@@ -2401,8 +2402,7 @@ void Dialogs::AddBox(int *pi, const int i) {
 		pFilm = (const FILM *)_vm->_handle->LockMem(_hWinParts);
 
 		_iconArray[*pi] = AddObject(&pFilm->reels[cd.box[i].bi + NORMGRAPH], -1);
-		MultiSetAniXY(_iconArray[*pi], x, y);
-		MultiSetZPosition(_iconArray[*pi], Z_INV_BRECT + 1);
+		MultiSetAniXYZ(_iconArray[*pi], x, y, Z_INV_BRECT + 1);
 		*pi += 1;
 
 		break;
@@ -2416,8 +2416,7 @@ void Dialogs::AddBox(int *pi, const int i) {
 			cd.box[i].bi = FIX_USA;
 
 		_iconArray[*pi] = AddObject(&pFilm->reels[cd.box[i].bi], -1);
-		MultiSetAniXY(_iconArray[*pi], x, y);
-		MultiSetZPosition(_iconArray[*pi], Z_INV_BRECT + 2);
+		MultiSetAniXYZ(_iconArray[*pi], x, y, Z_INV_BRECT + 2);
 		*pi += 1;
 
 		break;
@@ -2429,8 +2428,7 @@ void Dialogs::AddBox(int *pi, const int i) {
 			_iconArray[*pi] = AddObject(&pFilm->reels[cd.box[i].bi], -1);
 		else
 			_iconArray[*pi] = AddObject(&pFilm->reels[cd.box[i].bi + 1], -1);
-		MultiSetAniXY(_iconArray[*pi], x, y);
-		MultiSetZPosition(_iconArray[*pi], Z_INV_BRECT + 1);
+		MultiSetAniXYZ(_iconArray[*pi], x, y, Z_INV_BRECT + 1);
 		*pi += 1;
 
 		// Stick in the text
@@ -2454,8 +2452,7 @@ void Dialogs::AddBox(int *pi, const int i) {
 
 		cd.box[i].bi = *pival ? IX_TICK1 : IX_CROSS1;
 		_iconArray[*pi] = AddObject(&pFilm->reels[cd.box[i].bi + NORMGRAPH], -1);
-		MultiSetAniXY(_iconArray[*pi], x, y);
-		MultiSetZPosition(_iconArray[*pi], Z_INV_BRECT + 1);
+		MultiSetAniXYZ(_iconArray[*pi], x, y, Z_INV_BRECT + 1);
 		*pi += 1;
 
 		// Stick in the text
@@ -2486,12 +2483,10 @@ void Dialogs::AddBox(int *pi, const int i) {
 		xdisp = SLIDE_RANGE * (*pival) / cd.box[i].w;
 
 		_iconArray[*pi] = AddObject(&pFilm->reels[IX_MDGROOVE], -1);
-		MultiSetAniXY(_iconArray[*pi], x, y);
-		MultiSetZPosition(_iconArray[*pi], Z_MDGROOVE);
+		MultiSetAniXYZ(_iconArray[*pi], x, y, Z_MDGROOVE);
 		*pi += 1;
 		_iconArray[*pi] = AddObject(&pFilm->reels[IX_MDSLIDER], -1);
-		MultiSetAniXY(_iconArray[*pi], x + SLIDE_MINX + xdisp, y);
-		MultiSetZPosition(_iconArray[*pi], Z_MDSLIDER);
+		MultiSetAniXYZ(_iconArray[*pi], x + SLIDE_MINX + xdisp, y, Z_MDSLIDER);
 		assert(_numMdSlides < MAXSLIDES);
 		_mdSlides[_numMdSlides].num = i;
 		_mdSlides[_numMdSlides].min = x + SLIDE_MINX;
@@ -2519,14 +2514,12 @@ void Dialogs::AddBox(int *pi, const int i) {
 		// Left one
 		if (!_noLanguage) {
 			_iconArray[*pi] = AddObject(&pFilm->reels[IX2_LEFT1], -1);
-			MultiSetAniXY(_iconArray[*pi], x - ROTX1, y);
-			MultiSetZPosition(_iconArray[*pi], Z_INV_BRECT + 1);
+			MultiSetAniXYZ(_iconArray[*pi], x - ROTX1, y, Z_INV_BRECT + 1);
 			*pi += 1;
 
 			// Right one
 			_iconArray[*pi] = AddObject(&pFilm->reels[IX2_RIGHT1], -1);
-			MultiSetAniXY(_iconArray[*pi], x + ROTX1, y);
-			MultiSetZPosition(_iconArray[*pi], Z_INV_BRECT + 1);
+			MultiSetAniXYZ(_iconArray[*pi], x + ROTX1, y, Z_INV_BRECT + 1);
 			*pi += 1;
 
 			// Stick in the text
@@ -2552,8 +2545,7 @@ void Dialogs::AddBox(int *pi, const int i) {
 		// Current language's flag
 		pFilm = (const FILM *)_vm->_handle->LockMem(LanguageFlag(_displayedLanguage));
 		_iconArray[*pi] = AddObject(&pFilm->reels[0], -1);
-		MultiSetAniXY(_iconArray[*pi], x + FLAGX, y + FLAGY);
-		MultiSetZPosition(_iconArray[*pi], Z_INV_BRECT + 1);
+		MultiSetAniXYZ(_iconArray[*pi], x + FLAGX, y + FLAGY, Z_INV_BRECT + 1);
 		*pi += 1;
 		break;
 	}
@@ -2610,8 +2602,7 @@ void Dialogs::AddBoxes(bool bPosnSlide) {
  */
 void Dialogs::AddEWSlider(OBJECT **slide, const FILM *pfilm) {
 	_slideObject = *slide = AddObject(&pfilm->reels[IX_SLIDE], -1);
-	MultiSetAniXY(*slide, _invD[_activeInv].inventoryX + 24 + 127, _sliderYpos);
-	MultiSetZPosition(*slide, Z_INV_MFRAME);
+	MultiSetAniXYZ(*slide, _invD[_activeInv].inventoryX + 24 + 127, _sliderYpos, Z_INV_MFRAME);
 }
 
 /**
@@ -2629,56 +2620,43 @@ int Dialogs::AddExtraWindow(int x, int y, OBJECT **retObj) {
 
 	// Draw the four corners
 	retObj[n] = AddObject(&pfilm->reels[IX_RTL], -1); // Top left
-	MultiSetAniXY(retObj[n], x, y);
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x, y, Z_INV_MFRAME);
 	retObj[n] = AddObject(&pfilm->reels[IX_NTR], -1); // Top right
-	MultiSetAniXY(retObj[n], x + ((TinselVersion >= 2) ? _TLwidth + 312 : 152), y);
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x + ((TinselVersion >= 2) ? _TLwidth + 312 : 152), y, Z_INV_MFRAME);
 	retObj[n] = AddObject(&pfilm->reels[IX_BL], -1); // Bottom left
-	MultiSetAniXY(retObj[n], x, y + ((TinselVersion >= 2) ? _TLheight + 208 : 124));
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x, y + ((TinselVersion >= 2) ? _TLheight + 208 : 124), Z_INV_MFRAME);
 	retObj[n] = AddObject(&pfilm->reels[IX_BR], -1); // Bottom right
-	MultiSetAniXY(retObj[n], x + ((TinselVersion >= 2) ? _TLwidth + 312 : 152),
-	              y + ((TinselVersion >= 2) ? _TLheight + 208 : 124));
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x + ((TinselVersion >= 2) ? _TLwidth + 312 : 152),
+	               y + ((TinselVersion >= 2) ? _TLheight + 208 : 124),
+	               Z_INV_MFRAME);
 
 	// Draw the edges
 	retObj[n] = AddObject(&pfilm->reels[IX_H156], -1); // Top
-	MultiSetAniXY(retObj[n], x + ((TinselVersion >= 2) ? _TLwidth : 6), y + NM_TBT);
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x + ((TinselVersion >= 2) ? _TLwidth : 6), y + NM_TBT, Z_INV_MFRAME);
 	retObj[n] = AddObject(&pfilm->reels[IX_H156], -1); // Bottom
-	MultiSetAniXY(retObj[n], x + ((TinselVersion >= 2) ? _TLwidth : 6), y + ((TinselVersion >= 2) ? _TLheight + 208 + _BLheight + NM_BSY : 143));
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x + ((TinselVersion >= 2) ? _TLwidth : 6),
+	               y + ((TinselVersion >= 2) ? _TLheight + 208 + _BLheight + NM_BSY : 143),
+	               Z_INV_MFRAME);
 	retObj[n] = AddObject(&pfilm->reels[IX_V104], -1); // Left
-	MultiSetAniXY(retObj[n], x + NM_LSX, y + ((TinselVersion >= 2) ? _TLheight : 20));
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x + NM_LSX, y + ((TinselVersion >= 2) ? _TLheight : 20), Z_INV_MFRAME);
 	retObj[n] = AddObject(&pfilm->reels[IX_V104], -1); // Right 1
-	MultiSetAniXY(retObj[n], x + ((TinselVersion >= 2) ? _TLwidth + 312 + _TRwidth + NM_RSX : 179),
-	              y + ((TinselVersion >= 2) ? _TLheight : 20));
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x + ((TinselVersion >= 2) ? _TLwidth + 312 + _TRwidth + NM_RSX : 179),
+	               y + ((TinselVersion >= 2) ? _TLheight : 20),
+	               Z_INV_MFRAME);
 	retObj[n] = AddObject(&pfilm->reels[IX_V104], -1); // Right 2
-	MultiSetAniXY(retObj[n], x + ((TinselVersion >= 2) ? _TLwidth + 312 + _TRwidth + NM_SBL : 188),
-	              y + ((TinselVersion >= 2) ? _TLheight : 20));
-	MultiSetZPosition(retObj[n], Z_INV_MFRAME);
-	n++;
+	MultiSetAniXYZ(retObj[n++], x + ((TinselVersion >= 2) ? _TLwidth + 312 + _TRwidth + NM_SBL : 188),
+	               y + ((TinselVersion >= 2) ? _TLheight : 20),
+	               Z_INV_MFRAME);
 
 	if (TinselVersion >= 2) {
 		_sliderYpos = _sliderYmin = y + 27;
 		_sliderYmax = y + 273;
 
 		retObj[n++] = _slideObject = AddObject(&pfilm->reels[IX_SLIDE], -1);
-		MultiSetAniXY(_slideObject,
-		              x + _TLwidth + 320 + _TRwidth - NM_BG_POS_X + NM_BG_SIZ_X - 2,
-		              _sliderYpos);
-		MultiSetZPosition(_slideObject, Z_INV_MFRAME);
+		MultiSetAniXYZ(_slideObject,
+		               x + _TLwidth + 320 + _TRwidth - NM_BG_POS_X + NM_BG_SIZ_X - 2,
+		               _sliderYpos,
+		               Z_INV_MFRAME);
 	} else {
 		_sliderYpos = _sliderYmin = y + 9;
 		_sliderYmax = y + 134;
@@ -2755,53 +2733,44 @@ void Dialogs::ConstructInventory(InventoryType filling) {
 
 	// Draw the four corners
 	retObj[n] = AddObject(&pfilm->reels[_TL], _TL);
-	MultiSetAniXY(retObj[n], invX, invY);
-	MultiSetZPosition(retObj[n], zpos);
+	MultiSetAniXYZ(retObj[n], invX, invY, zpos);
 	n++;
 	retObj[n] = AddObject(&pfilm->reels[_TR], _TR);
-	MultiSetAniXY(retObj[n], invX + _TLwidth + eH, invY);
-	MultiSetZPosition(retObj[n], zpos);
+	MultiSetAniXYZ(retObj[n], invX + _TLwidth + eH, invY, zpos);
 	n++;
 	retObj[n] = AddObject(&pfilm->reels[_BL], _BL);
-	MultiSetAniXY(retObj[n], invX, invY + _TLheight + eV);
-	MultiSetZPosition(retObj[n], zpos);
+	MultiSetAniXYZ(retObj[n], invX, invY + _TLheight + eV, zpos);
 	n++;
 	retObj[n] = AddObject(&pfilm->reels[_BR], _BR);
-	MultiSetAniXY(retObj[n], invX + _TLwidth + eH, invY + _TLheight + eV);
-	MultiSetZPosition(retObj[n], zpos);
+	MultiSetAniXYZ(retObj[n], invX + _TLwidth + eH, invY + _TLheight + eV, zpos);
 	n++;
 
 	// Draw extra Top and bottom parts
 	if (_invD[_activeInv].NoofHicons > 1) {
 		// Top side
 		retObj[n] = AddObject(&pfilm->reels[hFillers[_invD[_activeInv].NoofHicons - 2]], -1);
-		MultiSetAniXY(retObj[n], invX + _TLwidth, invY + NM_TBT);
-		MultiSetZPosition(retObj[n], zpos);
+		MultiSetAniXYZ(retObj[n], invX + _TLwidth, invY + NM_TBT, zpos);
 		n++;
 
 		// Bottom of header box
 		if (filling == FULL) {
 			if (TinselVersion >= 2) {
 				retObj[n] = AddObject(&pfilm->reels[hFillers[_invD[_activeInv].NoofHicons - 2]], -1);
-				MultiSetAniXY(retObj[n], invX + _TLwidth, invY + NM_TBB);
-				MultiSetZPosition(retObj[n], zpos);
+				MultiSetAniXYZ(retObj[n], invX + _TLwidth, invY + NM_TBB, zpos);
 				n++;
 			} else {
 				retObj[n] = AddObject(&pfilm->reels[hFillers[_invD[_activeInv].NoofHicons - 2]], -1);
-				MultiSetAniXY(retObj[n], invX + _TLwidth, invY + M_TBB + 1);
-				MultiSetZPosition(retObj[n], zpos);
+				MultiSetAniXYZ(retObj[n], invX + _TLwidth, invY + M_TBB + 1, zpos);
 				n++;
 
 				// Extra bits for conversation - hopefully temporary
 				if (_activeInv == INV_CONV) {
 					retObj[n] = AddObject(&pfilm->reels[IX_H26], -1);
-					MultiSetAniXY(retObj[n], invX + _TLwidth - 2, invY + M_TBB + 1);
-					MultiSetZPosition(retObj[n], zpos);
+					MultiSetAniXYZ(retObj[n], invX + _TLwidth - 2, invY + M_TBB + 1, zpos);
 					n++;
 
 					retObj[n] = AddObject(&pfilm->reels[IX_H52], -1);
-					MultiSetAniXY(retObj[n], invX + eH - 10, invY + M_TBB + 1);
-					MultiSetZPosition(retObj[n], zpos);
+					MultiSetAniXYZ(retObj[n], invX + eH - 10, invY + M_TBB + 1, zpos);
 					n++;
 				}
 			}
@@ -2809,9 +2778,7 @@ void Dialogs::ConstructInventory(InventoryType filling) {
 
 		// Bottom side
 		retObj[n] = AddObject(&pfilm->reels[hFillers[_invD[_activeInv].NoofHicons - 2]], -1);
-		MultiSetAniXY(retObj[n], invX + _TLwidth, invY + _TLheight + eV + _BLheight + NM_BSY);
-
-		MultiSetZPosition(retObj[n], zpos);
+		MultiSetAniXYZ(retObj[n], invX + _TLwidth, invY + _TLheight + eV + _BLheight + NM_BSY, zpos);
 		n++;
 	}
 	if (_SuppH) {
@@ -2821,15 +2788,12 @@ void Dialogs::ConstructInventory(InventoryType filling) {
 
 		// Top side extra
 		retObj[n] = AddObject(&pfilm->reels[IX_H26], -1);
-		MultiSetAniXY(retObj[n], invX + offx, invY + NM_TBT);
-		MultiSetZPosition(retObj[n], zpos);
+		MultiSetAniXYZ(retObj[n], invX + offx, invY + NM_TBT, zpos);
 		n++;
 
 		// Bottom side extra
 		retObj[n] = AddObject(&pfilm->reels[IX_H26], -1);
-		MultiSetAniXY(retObj[n], invX + offx, invY + _TLheight + eV + _BLheight + NM_BSY);
-
-		MultiSetZPosition(retObj[n], zpos);
+		MultiSetAniXYZ(retObj[n], invX + offx, invY + _TLheight + eV + _BLheight + NM_BSY, zpos);
 		n++;
 	}
 
@@ -2837,8 +2801,7 @@ void Dialogs::ConstructInventory(InventoryType filling) {
 	if (_invD[_activeInv].NoofVicons > 1) {
 		// Left side
 		retObj[n] = AddObject(&pfilm->reels[vFillers[_invD[_activeInv].NoofVicons - 2]], -1);
-		MultiSetAniXY(retObj[n], invX + NM_LSX, invY + _TLheight);
-		MultiSetZPosition(retObj[n], zpos);
+		MultiSetAniXYZ(retObj[n], invX + NM_LSX, invY + _TLheight, zpos);
 		n++;
 
 		// Left side of scroll bar
@@ -2854,8 +2817,7 @@ void Dialogs::ConstructInventory(InventoryType filling) {
 
 		// Right side
 		retObj[n] = AddObject(&pfilm->reels[vFillers[_invD[_activeInv].NoofVicons - 2]], -1);
-		MultiSetAniXY(retObj[n], invX + _TLwidth + eH + _TRwidth + NM_RSX, invY + _TLheight);
-		MultiSetZPosition(retObj[n], zpos);
+		MultiSetAniXYZ(retObj[n], invX + _TLwidth + eH + _TRwidth + NM_RSX, invY + _TLheight, zpos);
 		n++;
 	}
 	if (_SuppV) {
@@ -2866,14 +2828,12 @@ void Dialogs::ConstructInventory(InventoryType filling) {
 
 		// Left side extra
 		retObj[n] = AddObject(&pfilm->reels[IX_V26], -1);
-		MultiSetAniXY(retObj[n], invX + NM_LSX, invY + offy);
-		MultiSetZPosition(retObj[n], zpos);
+		MultiSetAniXYZ(retObj[n], invX + NM_LSX, invY + offy, zpos);
 		n++;
 
 		// Right side extra
 		retObj[n] = AddObject(&pfilm->reels[IX_V26], -1);
-		MultiSetAniXY(retObj[n], invX + _TLwidth + eH + _TRwidth + NM_RSX, invY + offy);
-		MultiSetZPosition(retObj[n], zpos);
+		MultiSetAniXYZ(retObj[n], invX + _TLwidth + eH + _TRwidth + NM_RSX, invY + offy, zpos);
 		n++;
 	}
 
@@ -5440,8 +5400,9 @@ static void ButtonPress(CORO_PARAM, CONFBOX *box) {
 	MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL1]);
 	pfilm = _vm->_dialogs->GetWindowData();
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + NORMGRAPH], -1);
-	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
-	MultiSetZPosition(_vm->_dialogs->_iconArray[HL1], Z_INV_ICONS + 1);
+	MultiSetAniXYZ(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos,
+	               _vm->_dialogs->CurrentInventoryY() + box->ypos,
+	               Z_INV_ICONS + 1);
 
 	// Hold normal image for 1 frame
 	CORO_SLEEP(1);
@@ -5452,8 +5413,9 @@ static void ButtonPress(CORO_PARAM, CONFBOX *box) {
 	pfilm = _vm->_dialogs->GetWindowData();
 	MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_iconArray[HL1]);
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + DOWNGRAPH], -1);
-	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
-	MultiSetZPosition(_vm->_dialogs->_iconArray[HL1], Z_INV_ICONS + 1);
+	MultiSetAniXYZ(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos,
+	               _vm->_dialogs->CurrentInventoryY() + box->ypos,
+	               Z_INV_ICONS + 1);
 
 	// Hold depressed image for 2 frames
 	CORO_SLEEP(2);
@@ -5464,8 +5426,9 @@ static void ButtonPress(CORO_PARAM, CONFBOX *box) {
 	pfilm = _vm->_dialogs->GetWindowData();
 	MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_iconArray[HL1]);
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + NORMGRAPH], -1);
-	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
-	MultiSetZPosition(_vm->_dialogs->_iconArray[HL1], Z_INV_ICONS + 1);
+	MultiSetAniXYZ(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos,
+	               _vm->_dialogs->CurrentInventoryY() + box->ypos,
+	               Z_INV_ICONS + 1);
 
 	CORO_SLEEP(1);
 
@@ -5493,8 +5456,10 @@ static void ButtonToggle(CORO_PARAM, CONFBOX *box) {
 	// Add depressed image
 	pfilm = _vm->_dialogs->GetWindowData();
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + DOWNGRAPH], -1);
-	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
-	MultiSetZPosition(_vm->_dialogs->_iconArray[HL1], Z_INV_ICONS + 1);
+	MultiSetAniXYZ(_vm->_dialogs->_iconArray[HL1],
+	               _vm->_dialogs->CurrentInventoryX() + box->xpos,
+	               _vm->_dialogs->CurrentInventoryY() + box->ypos,
+	               Z_INV_ICONS + 1);
 
 	// Hold depressed image for 1 frame
 	CORO_SLEEP(1);
@@ -5513,8 +5478,10 @@ static void ButtonToggle(CORO_PARAM, CONFBOX *box) {
 	pfilm = _vm->_dialogs->GetWindowData();
 	MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL1]);
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + DOWNGRAPH], -1);
-	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
-	MultiSetZPosition(_vm->_dialogs->_iconArray[HL1], Z_INV_ICONS + 1);
+	MultiSetAniXYZ(_vm->_dialogs->_iconArray[HL1],
+	               _vm->_dialogs->CurrentInventoryX() + box->xpos,
+	               _vm->_dialogs->CurrentInventoryY() + box->ypos,
+	               Z_INV_ICONS + 1);
 
 	// Hold new depressed image for 1 frame
 	CORO_SLEEP(1);
@@ -5533,8 +5500,10 @@ static void ButtonToggle(CORO_PARAM, CONFBOX *box) {
 	pfilm = _vm->_dialogs->GetWindowData();
 	MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL1]);
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + HIGRAPH], -1);
-	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
-	MultiSetZPosition(_vm->_dialogs->_iconArray[HL1], Z_INV_ICONS + 1);
+	MultiSetAniXYZ(_vm->_dialogs->_iconArray[HL1],
+	               _vm->_dialogs->CurrentInventoryX() + box->xpos,
+	               _vm->_dialogs->CurrentInventoryY() + box->ypos,
+	               Z_INV_ICONS + 1);
 
 	CORO_END_CODE;
 }

--- a/engines/tinsel/dialogs.cpp
+++ b/engines/tinsel/dialogs.cpp
@@ -1887,7 +1887,8 @@ int Dialogs::InvItemId(int x, int y) {
 int Dialogs::WhichMenuBox(int curX, int curY, bool bSlides) {
 	if (bSlides) {
 		for (int i = 0; i < _numMdSlides; i++) {
-			if (curY > MultiHighest(_mdSlides[i].obj) && curY < MultiLowest(_mdSlides[i].obj) && curX > MultiLeftmost(_mdSlides[i].obj) && curX < MultiRightmost(_mdSlides[i].obj))
+			Common::Rect bounds = MultiBounds(_mdSlides[i].obj);
+			if (curY > bounds.top && curY < bounds.bottom && curX > bounds.left && curX < bounds.right)
 				return _mdSlides[i].num | IS_SLIDER;
 		}
 	}
@@ -2258,6 +2259,15 @@ void Dialogs::AddBackground(OBJECT **rect, OBJECT **title, int extraH, int extra
  */
 void Dialogs::AddBackground(OBJECT **rect, int extraH, int extraV) {
 	AddBackground(rect, NULL, extraH, extraV, 0);
+}
+
+Common::Rect MultiBounds(OBJECT *obj) {
+	Common::Rect bounds;
+	bounds.left = MultiLeftmost(obj);
+	bounds.right = MultiRightmost(obj);
+	bounds.top = MultiHighest(obj);
+	bounds.bottom = MultiLowest(obj);
+	return bounds;
 }
 
 /**

--- a/engines/tinsel/dialogs.cpp
+++ b/engines/tinsel/dialogs.cpp
@@ -1040,10 +1040,7 @@ void Dialogs::HopAction() {
  */
 void Dialogs::DumpIconArray() {
 	for (int i = 0; i < MAX_ICONS; i++) {
-		if (_iconArray[i] != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[i]);
-			_iconArray[i] = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_iconArray[i]);
 	}
 }
 
@@ -1052,10 +1049,7 @@ void Dialogs::DumpIconArray() {
  */
 void Dialogs::DumpDobjArray() {
 	for (int i = 0; i < MAX_WCOMP; i++) {
-		if (_dispObjArray[i] != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _dispObjArray[i]);
-			_dispObjArray[i] = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_dispObjArray[i]);
 	}
 }
 
@@ -1064,10 +1058,7 @@ void Dialogs::DumpDobjArray() {
  */
 void Dialogs::DumpObjArray() {
 	for (int i = 0; i < MAX_WCOMP; i++) {
-		if (_objArray[i] != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _objArray[i]);
-			_objArray[i] = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_objArray[i]);
 	}
 }
 
@@ -1254,18 +1245,9 @@ void Dialogs::InvLoadGame() {
 	if (cd.selBox != NOBOX && (cd.selBox + cd.extraBase < cd.numSaved)) {
 		rGame = cd.selBox;
 		cd.selBox = NOBOX;
-		if (_iconArray[HL3] != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL3]);
-			_iconArray[HL3] = nullptr;
-		}
-		if (_iconArray[HL2] != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL2]);
-			_iconArray[HL2] = nullptr;
-		}
-		if (_iconArray[HL1] != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL1]);
-			_iconArray[HL1] = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_iconArray[HL3]);
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_iconArray[HL2]);
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_iconArray[HL1]);
 		RestoreGame(rGame + cd.extraBase);
 	}
 }
@@ -1330,10 +1312,7 @@ static bool InvKeyIn(const Common::KeyState &kbd) {
 			* Delete display of text currently being edited,
 			* and replace it with freshly edited text.
 			*/
-			if (_vm->_dialogs->_iconArray[HL3] != NULL) {
-				MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_iconArray[HL3]);
-				_vm->_dialogs->_iconArray[HL3] = nullptr;
-			}
+			MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL3]);
 			_vm->_dialogs->_iconArray[HL3] = ObjectTextOut(
 			    _vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_saveGameDesc, 0,
 			    _vm->_dialogs->CurrentInventoryX() + cd.box[cd.selBox].xpos + 2,
@@ -1373,14 +1352,8 @@ void Dialogs::Select(int i, bool force) {
 	cd.selBox = i;
 
 	// Clear previous selected highlight and text
-	if (_iconArray[HL2] != NULL) {
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL2]);
-		_iconArray[HL2] = nullptr;
-	}
-	if (_iconArray[HL3] != NULL) {
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL3]);
-		_iconArray[HL3] = nullptr;
-	}
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_iconArray[HL2]);
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_iconArray[HL3]);
 
 	// New highlight box
 	switch (cd.box[i].boxType) {
@@ -2019,17 +1992,11 @@ void Dialogs::InvBoxes(bool InBody, int curX, int curY) {
 	if (index < 0) {
 		// unhigh-light box (if one was)
 		cd.pointBox = NOBOX;
-		if (_iconArray[HL1] != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL1]);
-			_iconArray[HL1] = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_iconArray[HL1]);
 	} else if (index != cd.pointBox) {
 		cd.pointBox = index;
 		// A new box is pointed to - high-light it
-		if (_iconArray[HL1] != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _iconArray[HL1]);
-			_iconArray[HL1] = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_iconArray[HL1]);
 		if ((cd.box[cd.pointBox].boxType == ARSBUT && cd.selBox != NOBOX) ||
 		    ///* I don't agree */ cd.box[cd.pointBox].boxType == RGROUP ||
 		    cd.box[cd.pointBox].boxType == AATBUT ||
@@ -5470,8 +5437,7 @@ static void ButtonPress(CORO_PARAM, CONFBOX *box) {
 
 	// Replace highlight image with normal image
 	pfilm = _vm->_dialogs->GetWindowData();
-	if (_vm->_dialogs->_iconArray[HL1] != NULL)
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_iconArray[HL1]);
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL1]);
 	pfilm = _vm->_dialogs->GetWindowData();
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + NORMGRAPH], -1);
 	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
@@ -5517,10 +5483,7 @@ static void ButtonToggle(CORO_PARAM, CONFBOX *box) {
 	assert((box->boxType == TOGGLE) || (box->boxType == TOGGLE1) || (box->boxType == TOGGLE2));
 
 	// Remove hilight image
-	if (_vm->_dialogs->_iconArray[HL1] != NULL) {
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_iconArray[HL1]);
-		_vm->_dialogs->_iconArray[HL1] = nullptr;
-	}
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL1]);
 
 	// Hold normal image for 1 frame
 	CORO_SLEEP(1);
@@ -5548,8 +5511,7 @@ static void ButtonToggle(CORO_PARAM, CONFBOX *box) {
 
 	// New state, depressed image
 	pfilm = _vm->_dialogs->GetWindowData();
-	if (_vm->_dialogs->_iconArray[HL1] != NULL)
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_iconArray[HL1]);
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL1]);
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + DOWNGRAPH], -1);
 	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
 	MultiSetZPosition(_vm->_dialogs->_iconArray[HL1], Z_INV_ICONS + 1);
@@ -5560,8 +5522,7 @@ static void ButtonToggle(CORO_PARAM, CONFBOX *box) {
 		return;
 
 	// New state, normal
-	MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_iconArray[HL1]);
-	_vm->_dialogs->_iconArray[HL1] = nullptr;
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL1]);
 
 	// Hold normal image for 1 frame
 	CORO_SLEEP(1);
@@ -5570,8 +5531,7 @@ static void ButtonToggle(CORO_PARAM, CONFBOX *box) {
 
 	// New state, highlighted
 	pfilm = _vm->_dialogs->GetWindowData();
-	if (_vm->_dialogs->_iconArray[HL1] != NULL)
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _vm->_dialogs->_iconArray[HL1]);
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_vm->_dialogs->_iconArray[HL1]);
 	_vm->_dialogs->_iconArray[HL1] = _vm->_dialogs->AddObject(&pfilm->reels[box->bi + HIGRAPH], -1);
 	MultiSetAniXY(_vm->_dialogs->_iconArray[HL1], _vm->_dialogs->CurrentInventoryX() + box->xpos, _vm->_dialogs->CurrentInventoryY() + box->ypos);
 	MultiSetZPosition(_vm->_dialogs->_iconArray[HL1], Z_INV_ICONS + 1);

--- a/engines/tinsel/movers.cpp
+++ b/engines/tinsel/movers.cpp
@@ -200,8 +200,7 @@ void SetMoverInEffect(int index, bool tf) {
 void KillMover(MOVER *pMover) {
 	if (pMover->bActive) {
 		pMover->bActive = false;
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_WORLD), pMover->actorObj);
-		pMover->actorObj = nullptr;
+		MultiDeleteObjectIfExists(FIELD_WORLD, &pMover->actorObj);
 		assert(CoroScheduler.getCurrentProcess() != pMover->pProc);
 		CoroScheduler.killProcess(pMover->pProc);
 	}

--- a/engines/tinsel/multiobj.cpp
+++ b/engines/tinsel/multiobj.cpp
@@ -20,6 +20,7 @@
  * This file contains utilities to handle multi-part objects.
  */
 
+#include "tinsel/background.h"
 #include "tinsel/multiobj.h"
 #include "tinsel/handle.h"
 #include "tinsel/object.h"
@@ -122,6 +123,19 @@ void MultiDeleteObject(OBJECT **pObjList, OBJECT *pMultiObj) {
 		// next obj in list
 		pMultiObj = pMultiObj->pSlave;
 	} while (pMultiObj != NULL);
+}
+
+/**
+ * Deletes all the pieces of a multi-part object from the
+ * specified playfield's object list, then sets the pointer to nullptr.
+ * @param which				The playfield whos object list we delete from.
+ * @param pMultiObj			Multi-part object to be deleted
+ */
+void MultiDeleteObjectIfExists(unsigned int playfield, OBJECT **pMultiObj) {
+	if (*pMultiObj) {
+		MultiDeleteObject(_vm->_bg->GetPlayfieldList(playfield), *pMultiObj);
+		*pMultiObj = nullptr;
+	}
 }
 
 /**

--- a/engines/tinsel/multiobj.cpp
+++ b/engines/tinsel/multiobj.cpp
@@ -297,6 +297,17 @@ void MultiSetAniXY(OBJECT *pMultiObj, int newAniX, int newAniY) {
 }
 
 /**
+ * Sets the x & y anim position of all pieces of a multi-part object, as well as the Z Position.
+ * @param pMultiObj			Multi-part object whose position is to be changed
+ * @param newAniX			New x animation position
+ * @param newAniY			New y animation position
+ */
+void MultiSetAniXYZ(OBJECT *pMultiObj, int newAniX, int newAniY, int zPosition) {
+	MultiSetAniXY(pMultiObj, newAniX, newAniY);
+	MultiSetZPosition(pMultiObj, zPosition);
+}
+
+/**
  * Sets the x anim position of all pieces of a multi-part object.
  * @param pMultiObj			Multi-part object whose x position is to be changed
  * @param newAniX			New x animation position

--- a/engines/tinsel/multiobj.h
+++ b/engines/tinsel/multiobj.h
@@ -111,20 +111,23 @@ void MultiSetZPosition(		// Sets the z position of a multi-part object
 void MultiReshape(		// Reshape a multi-part object
 	OBJECT *pMultiObj);	// multi-part object to re-shape
 
-int MultiLeftmost(		// Returns the left-most point of a multi-part object
-	OBJECT *pMulti);	// multi-part object
+Common::Rect MultiBounds( // Returns the bounds of a multi-part object
+	OBJECT *pMulti);      // multi-part object
 
-int MultiRightmost(		// Returns the right-most point of a multi-part object
-	OBJECT *pMulti);	// multi-part object
+int MultiLeftmost(		  // Returns the left-most point of a multi-part object
+	OBJECT *pMulti);	  // multi-part object
 
-int MultiHighest(		// Returns the highest point of a multi-part object
-	OBJECT *pMulti);	// multi-part object
+int MultiRightmost(		  // Returns the right-most point of a multi-part object
+	OBJECT *pMulti);	  // multi-part object
 
-int MultiLowest(		// Returns the lowest point of a multi-part object
-	OBJECT *pMulti);	// multi-part object
+int MultiHighest(		  // Returns the highest point of a multi-part object
+	OBJECT *pMulti);	  // multi-part object
 
-bool MultiHasShape(		// Returns TRUE if the object currently has an image
-	OBJECT *pMulti);	// multi-part object
+int MultiLowest(		  // Returns the lowest point of a multi-part object
+	OBJECT *pMulti);	  // multi-part object
+
+bool MultiHasShape(		  // Returns TRUE if the object currently has an image
+	OBJECT *pMulti);	  // multi-part object
 
 void MultiForceRedraw(
 	OBJECT *pMultiObj);	// multi-part object to be forced

--- a/engines/tinsel/multiobj.h
+++ b/engines/tinsel/multiobj.h
@@ -90,6 +90,12 @@ void MultiSetAniXY(		// Set the x & y anim position of a multi-part object
 	int newAniX,		// new x animation position
 	int newAniY);		// new y animation position
 
+void MultiSetAniXYZ(     // Set the x & y anim position of a multi-part object
+	OBJECT *pMultiObj,   // multi-part object whose position is to be changed
+	int newAniX,         // new x animation position
+	int newAniY,         // new y animation position
+	int zPosition);      // new Z order
+
 void MultiSetAniX(		// Set the x anim position of a multi-part object
 	OBJECT *pMultiObj,	// multi-part object whose x position is to be changed
 	int newAniX);		// new x animation position

--- a/engines/tinsel/multiobj.h
+++ b/engines/tinsel/multiobj.h
@@ -62,6 +62,10 @@ void MultiDeleteObject(		// Delete all the pieces of a multi-part object
 	OBJECT **pObjList,	// list to delete multi-part object from
 	OBJECT *pMultiObj);	// multi-part object to be deleted
 
+void MultiDeleteObjectIfExists( // Delete all the pieces of a multi-part object (if it exists)
+	unsigned int playfield, // playfield to delete the objects from
+	OBJECT **pMultiObj); // multi-part object to be deleted
+
 void MultiHideObject(		// Hide a multi-part object
 	OBJECT *pMultiObj);	// multi-part object to be hidden
 

--- a/engines/tinsel/pdisplay.cpp
+++ b/engines/tinsel/pdisplay.cpp
@@ -415,8 +415,7 @@ static bool ActorTag(int curX_, int curY_, HotSpotTag *pTag, OBJECT **ppText) {
 			SaveTaggedActor(actor);		// This actor tagged
 			SaveTaggedPoly(NOPOLY);		// No tagged polygon
 
-			if (*ppText)
-				MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), *ppText);
+			MultiDeleteObjectIfExists(FIELD_STATUS, ppText);
 
 			if (_vm->_actor->ActorTagIsWanted(actor)) {
 				_vm->_actor->GetActorTagPos(actor, &tagX, &tagY, false);
@@ -460,8 +459,7 @@ static bool ActorTag(int curX_, int curY_, HotSpotTag *pTag, OBJECT **ppText) {
 			if (newActor) {
 				// Display actor's tag
 
-				if (*ppText)
-					MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), *ppText);
+				MultiDeleteObjectIfExists(FIELD_STATUS, ppText);
 
 				*pTag = ACTOR_HOTSPOT_TAG;
 				SaveTaggedActor(ano);	// This actor tagged
@@ -522,10 +520,7 @@ static bool PolyTag(HotSpotTag *pTag, OBJECT **ppText) {
 		if ((hp != NOPOLY) && (PolyPointState(hp) == PS_POINTING) && (PolyTagState(hp) != TAG_ON)) {
 			// This poly is entitled to be tagged
 			if (hp != GetTaggedPoly()) {
-				if (*ppText) {
-					MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), *ppText);
-					*ppText = nullptr;
-				}
+				MultiDeleteObjectIfExists(FIELD_STATUS, ppText);
 				*pTag = POLY_HOTSPOT_TAG;
 				SaveTaggedActor(0);	// No tagged actor
 				SaveTaggedPoly(hp);	// This polygon tagged
@@ -689,8 +684,7 @@ void TagProcess(CORO_PARAM, const void *) {
 			// Remove tag, if there is one
 			if (_ctx->pText) {
 				// kill current text objects
-				MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _ctx->pText);
-				_ctx->pText = nullptr;
+				MultiDeleteObjectIfExists(FIELD_STATUS, &_ctx->pText);
 				_ctx->Tag = NO_HOTSPOT_TAG;
 			}
 		}

--- a/engines/tinsel/play.cpp
+++ b/engines/tinsel/play.cpp
@@ -637,9 +637,9 @@ static void t1PlayReel(CORO_PARAM, const PPINIT *ppi) {
 
 	// Ditch the object
 	if (!ppi->bTop)
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_WORLD), _ctx->pPlayObj);
+		MultiDeleteObjectIfExists(FIELD_WORLD, &_ctx->pPlayObj);
 	else
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _ctx->pPlayObj);
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_ctx->pPlayObj);
 
 	if (_ctx->mActor) {
 		if (!_ctx->replaced)

--- a/engines/tinsel/tinlib.cpp
+++ b/engines/tinsel/tinlib.cpp
@@ -2093,8 +2093,7 @@ static void Print(CORO_PARAM, int x, int y, SCNHANDLE text, int time, bool bSust
 	}
 
 	// Delete the text
-	if (_ctx->pText != NULL)
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _ctx->pText);
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_ctx->pText);
 	_vm->_mixer->stopHandle(_ctx->handle);
 
 	CORO_END_CODE;
@@ -2225,8 +2224,7 @@ static void PrintObj(CORO_PARAM, const SCNHANDLE hText, const INV_OBJECT *pinvo,
 					// Give way to non-POINTED-generated text
 					if (g_bNotPointedRunning) {
 						// Delete the text, and wait for the all-clear
-						MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _ctx->pText);
-						_ctx->pText = nullptr;
+						MultiDeleteObjectIfExists(FIELD_STATUS, &_ctx->pText);
 
 						while (g_bNotPointedRunning)
 							CORO_SLEEP(1);
@@ -2311,8 +2309,7 @@ static void PrintObj(CORO_PARAM, const SCNHANDLE hText, const INV_OBJECT *pinvo,
 		}
 
 		// Delete the text, if haven't already
-		if (_ctx->pText)
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _ctx->pText);
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_ctx->pText);
 
 		// If it hasn't already finished, stop sample
 		if (_ctx->bSample)
@@ -2342,8 +2339,7 @@ static void PrintObjPointed(CORO_PARAM, const SCNHANDLE text, const INV_OBJECT *
 			// Give way to non-POINTED-generated text
 			if (g_bNotPointedRunning) {
 				// Delete the text, and wait for the all-clear
-				MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), pText);
-				pText = nullptr;
+				MultiDeleteObjectIfExists(FIELD_STATUS, &pText);
 				while (g_bNotPointedRunning)
 					CORO_SLEEP(1);
 
@@ -3555,10 +3551,8 @@ static void TalkOrSay(CORO_PARAM, SPEECH_TYPE speechType, SCNHANDLE hText, int x
 			}
 		} while (1);
 
-		if (_ctx->pText != NULL) {
-			MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _ctx->pText);
-			_ctx->pText = nullptr;
-		}
+		MultiDeleteObjectIfExists(FIELD_STATUS, &_ctx->pText);
+
 		if ((TinselVersion >= 2) && _ctx->bSample)
 			_vm->_sound->stopSpecSample(hText, _ctx->sub);
 	}
@@ -3570,8 +3564,7 @@ static void TalkOrSay(CORO_PARAM, SPEECH_TYPE speechType, SCNHANDLE hText, int x
 	 */
 	if (_ctx->bTalkReel)
 		CORO_INVOKE_2(FinishTalkingReel, _ctx->pActor, _ctx->actor);
-	if (_ctx->pText != NULL)
-		MultiDeleteObject(_vm->_bg->GetPlayfieldList(FIELD_STATUS), _ctx->pText);
+	MultiDeleteObjectIfExists(FIELD_STATUS, &_ctx->pText);
 
 	if (TinselVersion >= 2) {
 		if ((_ctx->whatSort == IS_SAY) || (_ctx->whatSort == IS_SAYAT)) {


### PR DESCRIPTION
Some refactoring to simplify a few changes that are incoming with Noir:
* Add a convenience version of MultiDeleteObject that behaves similarly to free/delete when nullptr is passed. 
This simplifies code in a few places, as we can then avoid some nullptr checks.

* Combine MultiSetAniXY and MultiSetZPosition into MultiSetAniXYZ. 
The menu/inventory logic in Noir (but also the former games) does a lot of this.

* Add a MultiBounds function so that we can get all 4 bounds in one call.
Making for more readable code (this happens more often in Noir), as we can get shorter, more concise results when using Common::Rect