### PR TITLE
GRAPHICS3D: Use SDL_WINDOW_FULLSCREEN_DESKTOP for fullscreen in 3D games

### DIFF
--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -497,7 +497,7 @@ bool OpenGLSdlGraphics3dManager::createOrUpdateGLContext(uint gameWidth, uint ga
 				_window->createOrUpdateWindow(gameWidth, gameHeight, sdlflags);
 			}
 
-			sdlflags |= SDL_WINDOW_FULLSCREEN;
+			sdlflags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 		}
 
 		if (_window->createOrUpdateWindow(effectiveWidth, effectiveHeight, sdlflags)) {


### PR DESCRIPTION
This is a tiny change, code wise, but it may need a bit of testing/discussion nevertheless, thus pushing as a PR.

On macOS using SDL_WINDOW_FULLSCREEN leads to a fullscreen scenario where CMD-TAB and other ways to switch applications are disabled, which is inconvenient. This mode is also unaware of the notch that was added to the latest series of MacBooks, thus rendering in that part of the screen, and losing the bit that is covered by the notch.

If we instead use SDL_WINDOW_FULLSCREEN_DESKTOP (like we already do for 2D titles), both of these problems go away.

This resolves https://bugs.scummvm.org/ticket/13454

And since the new behaviour is seemingly the same as clicking the green window button (minus being able to see the window border in fullscreen), this also makes https://bugs.scummvm.org/ticket/13453 a non-issue.