### PR TITLE
DEVTOOLS: New create_engine tool

### DIFF
--- a/devtools/create_engine/create_engine.cpp
+++ b/devtools/create_engine/create_engine.cpp
@@ -1,0 +1,181 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _CRT_SECURE_NO_WARNINGS
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <sys/stat.h>
+#include <Windows.h>
+
+// Specified engine name with different cases
+#define MAX_LINE_LENGTH 256
+char engineUppercase[MAX_LINE_LENGTH];
+char engineCamelcase[MAX_LINE_LENGTH];
+char engineLowercase[MAX_LINE_LENGTH];
+
+// List of files to be copied to create engine
+static const char *const FILENAMES[] = {
+	"configure.engine", "console.cpp", "console.h",
+	"credits.pl", "detection.cpp", "detection.h",
+	"detection_tables.h", "metaengine.cpp",
+	"metaengine.h", "module.mk", "xyzzy.cpp",
+	"xyzzy.h", nullptr
+};
+const char *const ENGINES = "create_project ..\\.. --use-canonical-lib-names --msvc\n";
+
+// Replaces any occurances of the xyzzy placeholder with
+// whatever engine name was specified
+void replace_placeholders(char line[MAX_LINE_LENGTH]) {
+	char buf[MAX_LINE_LENGTH];
+	char *pos;
+
+	while ((pos = strstr(line, "XYZZY"))) {
+		*pos = '\0';
+		snprintf(buf, MAX_LINE_LENGTH, "%s%s%s", line,
+			engineUppercase, pos + 5);
+		strncpy(line, buf, MAX_LINE_LENGTH);
+	}
+
+	while ((pos = strstr(line, "Xyzzy"))) {
+		*pos = '\0';
+		snprintf(buf, MAX_LINE_LENGTH, "%s%s%s", line,
+			engineCamelcase, pos + 5);
+		strncpy(line, buf, MAX_LINE_LENGTH);
+	}
+
+	while ((pos = strstr(line, "xyzzy"))) {
+		*pos = '\0';
+		snprintf(buf, MAX_LINE_LENGTH, "%s%s%s", line,
+			engineLowercase, pos + 5);
+		strncpy(line, buf, MAX_LINE_LENGTH);
+	}
+}
+
+// Loops through copying and processing a single file
+void process_file(FILE *in, FILE *out) {
+	char line[MAX_LINE_LENGTH] = { 0 };
+
+	// Get each line until there are none left
+	while (fgets(line, MAX_LINE_LENGTH, in)) {
+		// Do any replacements of engine name
+		replace_placeholders(line);
+
+		// Write out the line
+		fputs(line, out);
+	}
+}
+
+// Copies and processes the specified file
+void process_file(const char *filename) {
+	char srcFilename[128], destFilename[128];
+	sprintf(srcFilename, "files/%s", filename);
+	if (!strncmp(filename, "xyzzy.", 6))
+		sprintf(destFilename, "../../engines/%s/%s.%s",
+			engineLowercase, engineLowercase, filename + 6);
+	else
+		sprintf(destFilename, "../../engines/%s/%s",
+			engineLowercase, filename);
+
+	FILE *in, *out;
+	if (!(in = fopen(srcFilename, "r"))) {
+		printf("Could not locate file - %s\n", srcFilename);
+		exit(0);
+	}
+
+	if (!(out = fopen(destFilename, "w"))) {
+		printf("Could not create file - %s\n", destFilename);
+		exit(0);
+	}
+
+	process_file(in, out);
+
+	fclose(in);
+	fclose(out);
+}
+
+// For Visual Studio convenience, creates a copy of the
+// create_msvc.bat to <engine>.bat that allows creating
+// the ScummVM solution with just that engine enabled
+void create_batch_file() {
+	FILE *in, *out;
+	char line[MAX_LINE_LENGTH];
+
+	if (!(in = fopen("../../dists/msvc/create_msvc.bat", "r"))) {
+		printf("Could not open create_msvc.bat\n");
+		exit(0);
+	}
+
+	char destFilename[MAX_LINE_LENGTH];
+	sprintf(destFilename, "../../dists/msvc/%s.bat", engineLowercase);
+	if (!(out = fopen(destFilename, "w"))) {
+		printf("Could not create %s.bat\n", engineLowercase);
+		exit(0);
+	}
+
+	// Get each line until there are none left
+	while (fgets(line, MAX_LINE_LENGTH, in)) {
+		if (!strcmp(line, ENGINES)) {
+			sprintf(line + strlen(line) - 1,
+				" --disable-all-engines --enable-engine=%s\n",
+				engineLowercase);
+		}
+
+		// Write out the line
+		fputs(line, out);
+	}
+
+	fclose(in);
+	fclose(out);
+}
+
+int main(int argc, char *argv[]) {
+	if (argc != 2) {
+		printf("Please specify engine name as a parameter\n");
+		return 0;
+	}
+
+	// Set up different cased engine names
+	for (size_t i = 0; i < strlen(argv[1]) + 1; ++i) {
+		engineUppercase[i] = toupper(argv[1][i]);
+		engineLowercase[i] = tolower(argv[1][i]);
+		engineCamelcase[i] = (i == 0) ?
+			engineUppercase[i] : engineLowercase[i];
+	}
+
+	// Create a directory for the new engine
+	char folder[MAX_LINE_LENGTH];
+	sprintf(folder, "../../engines/%s", engineLowercase);
+	if (!CreateDirectoryA(folder, NULL)) {
+		printf("Could not create engine folder.\n");
+		return 0;
+	}
+
+	// Process the files
+	for (const char *const *filename = FILENAMES; *filename; ++filename)
+		process_file(*filename);
+
+	create_batch_file();
+
+	printf("Engine generation complete.\n");
+	return 0;
+}

--- a/devtools/create_engine/create_engine.sln
+++ b/devtools/create_engine/create_engine.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29509.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "create_engine", "create_engine.vcxproj", "{0D190ECD-00FD-4C15-A386-E612590F3664}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0D190ECD-00FD-4C15-A386-E612590F3664}.Debug|x64.ActiveCfg = Debug|x64
+		{0D190ECD-00FD-4C15-A386-E612590F3664}.Debug|x64.Build.0 = Debug|x64
+		{0D190ECD-00FD-4C15-A386-E612590F3664}.Debug|x86.ActiveCfg = Debug|Win32
+		{0D190ECD-00FD-4C15-A386-E612590F3664}.Debug|x86.Build.0 = Debug|Win32
+		{0D190ECD-00FD-4C15-A386-E612590F3664}.Release|x64.ActiveCfg = Release|x64
+		{0D190ECD-00FD-4C15-A386-E612590F3664}.Release|x64.Build.0 = Release|x64
+		{0D190ECD-00FD-4C15-A386-E612590F3664}.Release|x86.ActiveCfg = Release|Win32
+		{0D190ECD-00FD-4C15-A386-E612590F3664}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0D5A1E60-57F2-44F3-A003-D958B5BDF201}
+	EndGlobalSection
+EndGlobal

--- a/devtools/create_engine/create_engine.vcxproj
+++ b/devtools/create_engine/create_engine.vcxproj
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{0D190ECD-00FD-4C15-A386-E612590F3664}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>createengine</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions> _CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="create_engine.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/devtools/create_engine/create_engine.vcxproj.filters
+++ b/devtools/create_engine/create_engine.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="create_engine.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/devtools/create_engine/create_engine.vcxproj.user
+++ b/devtools/create_engine/create_engine.vcxproj.user
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>

--- a/devtools/create_engine/files/configure.engine
+++ b/devtools/create_engine/files/configure.engine
@@ -1,0 +1,3 @@
+# This file is included from the main "configure" script
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+add_engine xyzzy "Xyzzy" no "" "" ""

--- a/devtools/create_engine/files/console.cpp
+++ b/devtools/create_engine/files/console.cpp
@@ -1,0 +1,38 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "xyzzy/console.h"
+
+namespace Xyzzy {
+
+Console::Console() : GUI::Debugger() {
+	registerCmd("test",   WRAP_METHOD(Console, Cmd_test));
+}
+
+Console::~Console() {
+}
+
+bool Console::Cmd_test(int argc, const char **argv) {
+	debugPrintf("Test\n");
+	return true;
+}
+
+} // namespace Xyzzy

--- a/devtools/create_engine/files/console.h
+++ b/devtools/create_engine/files/console.h
@@ -1,0 +1,40 @@
+
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef XYZZY_CONSOLE_H
+#define XYZZY_CONSOLE_H
+
+#include "gui/debugger.h"
+
+namespace Xyzzy {
+
+class Console : public GUI::Debugger {
+private:
+	bool Cmd_test(int argc, const char **argv);
+public:
+	Console();
+	~Console() override;
+};
+
+} // End of namespace Xyzzy
+
+#endif

--- a/devtools/create_engine/files/credits.pl
+++ b/devtools/create_engine/files/credits.pl
@@ -1,0 +1,3 @@
+begin_section("Xyzzy");
+	add_person("Name 1", "Handle 1", "");
+end_section();

--- a/devtools/create_engine/files/detection.cpp
+++ b/devtools/create_engine/files/detection.cpp
@@ -1,0 +1,45 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "base/plugins.h"
+#include "common/config-manager.h"
+#include "common/file.h"
+#include "common/md5.h"
+#include "common/str-array.h"
+#include "common/translation.h"
+#include "common/util.h"
+#include "xyzzy/detection.h"
+#include "xyzzy/detection_tables.h"
+
+const DebugChannelDef XyzzyMetaEngineDetection::debugFlagList[] = {
+	{ Xyzzy::kDebugGraphics, "Graphics", "Graphics debug level" },
+	{ Xyzzy::kDebugPath, "Path", "Pathfinding debug level" },
+	{ Xyzzy::kDebugFilePath, "FilePath", "File path debug level" },
+	{ Xyzzy::kDebugScan, "Scan", "Scan for unrecognised games" },
+	{ Xyzzy::kDebugScript, "Script", "Enable debug script dump" },
+	DEBUG_CHANNEL_END
+};
+
+XyzzyMetaEngineDetection::XyzzyMetaEngineDetection() : AdvancedMetaEngineDetection(Xyzzy::GAME_DESCRIPTIONS,
+	sizeof(ADGameDescription), Xyzzy::GAME_NAMES) {
+}
+
+REGISTER_PLUGIN_STATIC(XYZZY_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, XyzzyMetaEngineDetection);

--- a/devtools/create_engine/files/detection.h
+++ b/devtools/create_engine/files/detection.h
@@ -1,0 +1,67 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef XYZZY_DETECTION_H
+#define XYZZY_DETECTION_H
+
+#include "engines/advancedDetector.h"
+
+namespace Xyzzy {
+
+enum XyzzyDebugChannels {
+	kDebugGraphics = 1 << 0,
+	kDebugPath     = 1 << 1,
+	kDebugScan     = 1 << 2,
+	kDebugFilePath = 1 << 3,
+	kDebugScript   = 1 << 4
+};
+
+extern const PlainGameDescriptor GAME_NAMES[];
+
+extern const ADGameDescription GAME_DESCRIPTIONS[];
+
+} // namespace Xyzzy
+
+class XyzzyMetaEngineDetection : public AdvancedMetaEngineDetection {
+	static const DebugChannelDef debugFlagList[];
+
+public:
+	XyzzyMetaEngineDetection();
+	~XyzzyMetaEngineDetection() override {}
+
+	const char *getEngineId() const override {
+		return "xyzzy";
+	}
+
+	const char *getName() const override {
+		return "Xyzzy";
+	}
+
+	const char *getOriginalCopyright() const override {
+		return "Xyzzy (C)";
+	}
+
+	const DebugChannelDef *getDebugChannels() const override {
+		return debugFlagList;
+	}
+};
+
+#endif

--- a/devtools/create_engine/files/detection_tables.h
+++ b/devtools/create_engine/files/detection_tables.h
@@ -1,0 +1,43 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Xyzzy {
+
+const PlainGameDescriptor GAME_NAMES[] = {
+	{ "xyzzy", "Xyzzy" },
+	{ 0, 0 }
+};
+
+const ADGameDescription GAME_DESCRIPTIONS[] = {
+	{
+		"xyzzy",
+		nullptr,
+		AD_ENTRY1s("file1.bin", "00000000000000000000000000000000", 11111),
+		Common::EN_ANY,
+		Common::kPlatformDOS,
+		ADGF_UNSTABLE,
+		GUIO1(GUIO_NONE)
+	},
+
+	AD_TABLE_END_MARKER
+};
+
+} // namespace Xyzzy

--- a/devtools/create_engine/files/metaengine.cpp
+++ b/devtools/create_engine/files/metaengine.cpp
@@ -1,0 +1,50 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "xyzzy/metaengine.h"
+#include "xyzzy/detection.h"
+#include "xyzzy/xyzzy.h"
+
+const char *XyzzyMetaEngine::getName() const {
+	return "xyzzy";
+}
+
+Common::Error XyzzyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new Xyzzy::XyzzyEngine(syst, desc);
+	return Common::kNoError;
+}
+
+bool XyzzyMetaEngine::hasFeature(MetaEngineFeature f) const {
+	return
+		(f == kSavesUseExtendedFormat) ||
+		(f == kSimpleSavesNames) ||
+	    (f == kSupportsListSaves) ||
+	    (f == kSupportsDeleteSave) ||
+	    (f == kSavesSupportMetaInfo) ||
+	    (f == kSavesSupportThumbnail) ||
+	    (f == kSupportsLoadingDuringStartup);
+}
+
+#if PLUGIN_ENABLED_DYNAMIC(XYZZY)
+REGISTER_PLUGIN_DYNAMIC(XYZZY, PLUGIN_TYPE_ENGINE, XyzzyMetaEngine);
+#else
+REGISTER_PLUGIN_STATIC(XYZZY, PLUGIN_TYPE_ENGINE, XyzzyMetaEngine);
+#endif

--- a/devtools/create_engine/files/metaengine.h
+++ b/devtools/create_engine/files/metaengine.h
@@ -1,0 +1,42 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef XYZZY_METAENGINE_H
+#define XYZZY_METAENGINE_H
+
+#include "common/achievements.h"
+#include "engines/advancedDetector.h"
+
+class XyzzyMetaEngine : public AdvancedMetaEngine {
+public:
+	const char *getName() const override;
+
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+
+	/**
+	 * Determine whether the engine supports the specified MetaEngine feature.
+	 *
+	 * Used by e.g. the launcher to determine whether to enable the Load button.
+	 */
+	bool hasFeature(MetaEngineFeature f) const override;
+};
+
+#endif

--- a/devtools/create_engine/files/module.mk
+++ b/devtools/create_engine/files/module.mk
@@ -1,0 +1,17 @@
+MODULE := engines/xyzzy
+
+MODULE_OBJS = \
+	xyzzy.o \
+	console.o \
+	metaengine.o
+
+# This module can be built as a plugin
+ifeq ($(ENABLE_XYZZY), DYNAMIC_PLUGIN)
+PLUGIN := 1
+endif
+
+# Include common rules
+include $(srcdir)/rules.mk
+
+# Detection objects
+DETECT_OBJS += $(MODULE)/detection.o

--- a/devtools/create_engine/files/xyzzy.cpp
+++ b/devtools/create_engine/files/xyzzy.cpp
@@ -1,0 +1,107 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "xyzzy/xyzzy.h"
+#include "xyzzy/detection.h"
+#include "xyzzy/console.h"
+#include "common/scummsys.h"
+#include "common/config-manager.h"
+#include "common/debug-channels.h"
+#include "common/events.h"
+#include "common/system.h"
+#include "engines/util.h"
+#include "graphics/palette.h"
+
+namespace Xyzzy {
+
+XyzzyEngine *g_engine;
+
+XyzzyEngine::XyzzyEngine(OSystem *syst, const ADGameDescription *gameDesc) : Engine(syst),
+	_gameDescription(gameDesc), _randomSource("Xyzzy") {
+	g_engine = this;
+}
+
+XyzzyEngine::~XyzzyEngine() {
+	delete _screen;
+}
+
+uint32 XyzzyEngine::getFeatures() const {
+	return _gameDescription->flags;
+}
+
+Common::String XyzzyEngine::getGameId() const {
+	return _gameDescription->gameId;
+}
+
+Common::Error XyzzyEngine::run() {
+	// Initialize 320x200 paletted graphics mode
+	initGraphics(320, 200);
+	_screen = new Graphics::Screen();
+
+	// Set the engine's debugger console
+	setDebugger(new Console());
+
+	// If a savegame was selected from the launcher, load it
+	int saveSlot = ConfMan.getInt("save_slot");
+	if (saveSlot != -1)
+		(void)loadGameState(saveSlot);
+
+	// Draw a series of boxes on screen as a sample
+	for (int i = 0; i < 100; ++i)
+		_screen->frameRect(Common::Rect(i, i, 320 - i, 200 - i), i);
+	_screen->update();
+
+	// Simple event handling loop
+	byte pal[256 * 3] = { 0 };
+	Common::Event e;
+	int offset = 0;
+
+	while (!shouldQuit()) {
+		while (g_system->getEventManager()->pollEvent(e)) {
+		}
+
+		// Cycle through a simple palette
+		++offset;
+		for (int i = 0; i < 256; ++i)
+			pal[i * 3 + 1] = (i + offset) % 256;
+		g_system->getPaletteManager()->setPalette(pal, 0, 256);
+		_screen->update();
+
+		// Delay for a bit. All events loops should have a delay
+		// to prevent the system being unduly loaded
+		g_system->delayMillis(10);
+	}
+
+	return Common::kNoError;
+}
+
+Common::Error XyzzyEngine::syncGame(Common::Serializer &s) {
+	// The Serializer has methods isLoading() and isSaving()
+	// if you need to specific steps; for example setting
+	// an array size after reading it's length, whereas
+	// for saving it would write the existing array's length
+	int dummy = 0;
+	s.syncAsUint32LE(dummy);
+
+	return Common::kNoError;
+}
+
+} // namespace Xyzzy

--- a/devtools/create_engine/files/xyzzy.h
+++ b/devtools/create_engine/files/xyzzy.h
@@ -1,0 +1,105 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef XYZZY_XYZZY_H
+#define XYZZY_XYZZY_H
+
+#include "common/scummsys.h"
+#include "common/system.h"
+#include "common/error.h"
+#include "common/fs.h"
+#include "common/hash-str.h"
+#include "common/random.h"
+#include "common/serializer.h"
+#include "common/util.h"
+#include "engines/engine.h"
+#include "engines/savestate.h"
+#include "graphics/screen.h"
+
+#include "xyzzy/detection.h"
+
+namespace Xyzzy {
+
+struct XyzzyGameDescription;
+
+class XyzzyEngine : public Engine {
+private:
+	const ADGameDescription *_gameDescription;
+	Common::RandomSource _randomSource;
+protected:
+	// Engine APIs
+	Common::Error run() override;
+public:
+	Graphics::Screen *_screen = nullptr;
+public:
+	XyzzyEngine(OSystem *syst, const ADGameDescription *gameDesc);
+	~XyzzyEngine() override;
+
+	uint32 getFeatures() const;
+
+	/**
+	 * Returns the game Id
+	 */
+	Common::String getGameId() const;
+
+	/**
+	 * Gets a random number
+	 */
+	uint32 getRandomNumber(uint maxNum) {
+		return _randomSource.getRandomNumber(maxNum);
+	}
+
+	bool hasFeature(EngineFeature f) const override {
+		return
+		    (f == kSupportsLoadingDuringRuntime) ||
+		    (f == kSupportsSavingDuringRuntime) ||
+		    (f == kSupportsReturnToLauncher);
+	};
+
+	bool canLoadGameStateCurrently() override {
+		return true;
+	}
+	bool canSaveGameStateCurrently() override {
+		return true;
+	}
+
+	/**
+	 * Uses a serializer to allow implementing savegame
+	 * loading and saving using a single method
+	 */
+	Common::Error syncGame(Common::Serializer &s);
+
+	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) {
+		Common::Serializer s(nullptr, stream);
+		return syncGame(s);
+	}
+	Common::Error loadGameStream(Common::SeekableReadStream *stream) {
+		Common::Serializer s(stream, nullptr);
+		return syncGame(s);
+	}
+};
+
+extern XyzzyEngine *g_engine;
+#define SHOULD_QUIT ::Xyzzy::g_engine->shouldQuit()
+
+} // namespace Xyzzy
+
+#endif


### PR DESCRIPTION
Following on from a musing I had on Discord recently, I decided to try my hand at making a tool for creating the skeletons of new engines, saving potential authors the trouble of copying and pasting from existing engines or Quux, and trying to properly rename everything. The tool is fairly simple, it:
1) Takes in a single command line parameter specifying the engine name
2) Creates a folder for it in engines/
3) Copies the files from the files/ subfolder included with the tool, replacing occurances of a "Xyzzy" placeholder with the engine name, maintaining the upper/lower/camel case of the Xyzzy being replaced.
4) Finally, for those of us using Visual Studio, creates a batch file in dists/msvc/ to simply creating a solution file with just that engine enabled.

At the moment I've only built it as a Visual Studio project that can be compiled and then run similar to create_project, but someone familiar with Linux can probably fairly easily extend with a proper makefile and an ifdef block for using mkdir rather than the Window CreateDirectoryA.

Just thought I'd do this as a pull request first before pushing it to master in case of any feedback or further suggestions for inclusions in the skeleton files.
