### PR TITLE
CREATE_PROJECT: Add /Zc:__cplusplus so __cplusplus macro matches C++ feature level

### DIFF
--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -395,7 +395,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	           << "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>\n"
 	           << "\t\t\t<ConformanceMode>true</ConformanceMode>\n"
 	           << "\t\t\t<ObjectFileName>$(IntDir)dists\\msvc\\%(RelativeDir)</ObjectFileName>\n"
-	           << "\t\t\t<AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>\n"
+	           << "\t\t\t<AdditionalOptions>/utf-8 /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>\n"
 	           << "\t\t</ClCompile>\n"
 	           << "\t\t<Link>\n"
 	           << "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n";


### PR DESCRIPTION
Fixes https://bugs.scummvm.org/ticket/13471

By default, VS sets the __cplusplus macro to the C++98 value regardless of what feature level the compiler is configured to allow, so some code checking the value of the macro for C++11 feature support is not compiling.  This enables the compliant behavior.