### PR TITLE
PRINCE: Fix reading translation texts on big-endian systems

### DIFF
--- a/engines/prince/prince.cpp
+++ b/engines/prince/prince.cpp
@@ -504,7 +504,7 @@ void PrinceEngine::loadMobTranslationTexts() {
 }
 
 void PrinceEngine::setMobTranslationTexts() {
-	int locationOffset = READ_UINT16(_mobTranslationData + (_locationNr - 1) * 2);
+	int locationOffset = READ_LE_UINT16(_mobTranslationData + (_locationNr - 1) * 2);
 	if (locationOffset) {
 		byte *locationText = _mobTranslationData + locationOffset;
 		for (uint i = 0; i < _mobList.size(); i++) {


### PR DESCRIPTION
The following diff prevents a crash on big-endian PowerPC when any subtitle is about to be printed in Galador.

It looks like `PrinceEngine::setMobTranslationTexts()` is the only place where the `READ_()` macro missed its endianness value, so it would just read in native endianness (and thus fail on big-endian systems, since this value is always little-endian).

Tested with the English version from GOG, on big-endian PowerPC and little-endian arm64.