### PR TITLE
CONFIGURE: Disable SEQ MIDI on Mac builds

### DIFF
--- a/configure
+++ b/configure
@@ -2671,6 +2671,7 @@ case $_host_os in
 		# SDL2 doesn't seem to add Cocoa for us.
 		append_var LIBS "-framework Cocoa"
 		add_line_to_config_mk 'MACOSX = 1'
+		_seq_midi=no
 
 		# Now we may have MacPorts or Fink installed
 		# Which put libraries and headers in non-standard places


### PR DESCRIPTION
Currently, SEQ MIDI (`/dev/sequencer`) is the default audio device on Mac builds, even though it does not exist on Mac. This means that the default behavior for Mixed-Up Mother Goose Deluxe on Mac is no music. Users have to know to change the audio device to Apple DLS Software Synthesizer. Presumably this affects other games whose only music is GM MIDI. https://bugs.scummvm.org/ticket/12817

To my knowledge, SEQ MIDI (`/dev/sequencer`) is never on Mac, so the simplest thing is to just exclude it from Mac builds as we do with other hosts. Apple DLS Software Synthesizer becomes the new default. We already exclude SEQ MIDI in `create_project` so Xcode builds already have this working behavior. 

Alternatively, if SEQ MIDI is in fact needed on Mac, we could add a check to `SeqMusicPlugin::checkDevice()` or `SeqMusicPlugin::getDevices()` so that it's only available at runtime if the device can be opened.