### PR TITLE
DIRECTOR: Remove STUB for RightMouseUp, RightMouseDown and RomanLingo

### DIFF
--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -740,13 +740,16 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d = g_lingo->_theResult;
 		break;
 	case kTheRightMouseDown:
-		getTheEntitySTUB(kTheRightMouseDown);
+		d.type = INT;
+		d.u.i = g_system->getEventManager()->getButtonState() & (1 << Common::MOUSE_BUTTON_RIGHT) ? 1 : 0;
 		break;
 	case kTheRightMouseUp:
-		getTheEntitySTUB(kTheRightMouseUp);
+		d.type = INT;
+		d.u.i = g_system->getEventManager()->getButtonState() & (1 << Common::MOUSE_BUTTON_RIGHT) ? 0 : 1;
 		break;
 	case kTheRomanLingo:
-		getTheEntitySTUB(kTheRomanLingo);
+		d.type = INT;
+		d.u.i = 0;		//Set to FALSE to support non-roman character set in Lingo
 		break;
 	case kTheScummvmVersion:
 		d.type = INT;


### PR DESCRIPTION
This change implements `kTheRightMouseDown`, `kTheRightMouseUp` and  `kTheRomanLingo` cases of `getTheEntity()` function. The Right mouse implementation is very similar to `kTheMouseUp` and `kTheMouseDown` cases. TheRomanLingo is always set to false to support character sets of all languages.
Description of the romanLingo in Director 4 Lingo Dictionary:
```
Description 

System property; specifies whether Lingo uses a single-byte (true) or double-byte interpreter (false). 

The Lingo interpreter is faster with single-byte character sets. Some versions of Mac system software—Japanese, for 
example—use a double-byte character set. U.S. system software uses a single-byte character set. Normally, 
romanLingo is set when Director is first started and is determined by the local version of the system software. 

If you are using a non-Roman script system but don’t use any double-byte characters in your script, set this property 
to true for faster execution of your Lingo scripts.
```
