### PR TITLE
DIRECTOR: Implement kThePauseState STUB in getTheEntity

### DIFF
--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -711,7 +711,8 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d.u.i = (movie->_keyFlags & Common::KBD_ALT) ? 1 : 0;
 		break;
 	case kThePauseState:
-		getTheEntitySTUB(kThePauseState);
+		d.type = INT;
+		d.u.i = (int) g_director->_playbackPaused;
 		break;
 	case kThePerFrameHook:
 		d = _perFrameHook;


### PR DESCRIPTION
This change implements the STUB [here](https://github.com/scummvm/scummvm/blob/c8c4e04211d85579e6576e7749bee40fa919b7f4/engines/director/lingo/lingo-the.cpp#L714). Takes the current pause state and typecasts it into an integer. This change makes `pauseState` workshop movie work.