### PR TITLE
SCUMM: Fix MM NES dark rooms colors on strict-alignment archs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,8 @@ For a more comprehensive changelog of the latest experimental code, see:
      of The Secret of Monkey Island.
    - Fixed Full Throttle distorted graphics when Ben runs past the Corley
      Motors entrance.
+   - Fixed incorrect dark rooms colors in MM NES on strict-alignment ports such
+     as Dreamcast, Apple silicon and various handheld devices.
 
  Sherlock:
    - Fixed slowdown in Serrated Scalpel intro when playing the game from a small

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -1256,10 +1256,13 @@ static void copy8Col(byte *dst, int dstPitch, const byte *src, int height, uint8
 static void clear8Col(byte *dst, int dstPitch, int height, uint8 bitDepth) {
 	do {
 #if defined(SCUMM_NEED_ALIGNMENT)
-		memset(dst, 0, 8 * bitDepth);
+		if (g_scumm->_game.platform == Common::kPlatformNES)
+			memset(dst, 0x1d, 8 * bitDepth);
+		else
+			memset(dst, 0, 8 * bitDepth);
 #else
 		if (g_scumm->_game.platform == Common::kPlatformNES) {
-			memset(dst, 0x1d, 8);
+			memset(dst, 0x1d, 8 * bitDepth);
 		} else {
 			((uint32*)dst)[0] = 0;
 			((uint32*)dst)[1] = 0;


### PR DESCRIPTION
Commit 985ccfa8dff9560af7f38a41368f82879684d55d ("SCUMM: Fix MM NES dark rooms and flashlight") forgot to update the `SCUMM_NEED_ALIGNMENT` case in `gfx.cpp`, and thus on strict-alignment archs the various dark rooms in Maniac Mansion NES would still be displayed with the wrong color (i.e. light grey instead of plain black).

Tested on Apple M1, but Dreamcast and iOS/Android were probably impacted, too. Mentioning it in the NEWS file, since this platform disparity was here since ScummVM 2.2.0 AFAICS.

To reproduce:

1. Have a strict-alignment platform and make the following test with and without this diff, OR manually trigger the `SCUMM_NEED_ALIGNMENT` cases if your platform doesn't define that
2. Start Maniac Mansion NES, pick up the key under the doormat, unlock the door with it, enter the mansion and go the rightmost room until it's all dark. It should be black in that case, not grey.