### PR TITLE
MACOSX: Add dynamic plugin support to macOS bundles

### DIFF
--- a/backends/module.mk
+++ b/backends/module.mk
@@ -211,6 +211,11 @@ MODULE_OBJS += \
 	text-to-speech/macosx/macosx-text-to-speech.o
 endif
 
+ifdef SDL_BACKEND
+MODULE_OBJS += \
+	plugins/sdl/macosx/macosx-provider.o
+endif
+
 endif
 
 ifdef WIN32

--- a/backends/platform/sdl/macosx/macosx.cpp
+++ b/backends/platform/sdl/macosx/macosx.cpp
@@ -43,8 +43,8 @@
 #include "common/fs.h"
 #include "common/translation.h"
 
-#include "ApplicationServices/ApplicationServices.h"	// for LSOpenFSRef
-#include "CoreFoundation/CoreFoundation.h"	// for CF* stuff
+#include <ApplicationServices/ApplicationServices.h>	// for LSOpenFSRef
+#include <CoreFoundation/CoreFoundation.h>	// for CF* stuff
 
 // For querying number of MIDI devices
 #include <pthread.h>
@@ -132,17 +132,10 @@ void OSystem_MacOSX::addSysArchivesToSearchSet(Common::SearchSet &s, int priorit
 	OSystem_POSIX::addSysArchivesToSearchSet(s, priority);
 
 	// Get URL of the Resource directory of the .app bundle
-	CFURLRef fileUrl = CFBundleCopyResourcesDirectoryURL(CFBundleGetMainBundle());
-	if (fileUrl) {
-		// Try to convert the URL to an absolute path
-		UInt8 buf[MAXPATHLEN];
-		if (CFURLGetFileSystemRepresentation(fileUrl, true, buf, sizeof(buf))) {
-			// Success: Add it to the search path
-			Common::String bundlePath((const char *)buf);
-			// Search with a depth of 2 so the shaders are found
-			s.add("__OSX_BUNDLE__", new Common::FSDirectory(bundlePath, 2), priority);
-		}
-		CFRelease(fileUrl);
+	Common::String bundlePath = getResourceAppBundlePathMacOSX();
+	if (!bundlePath.empty()) {
+		// Success: search with a depth of 2 so the shaders are found
+		s.add("__OSX_BUNDLE__", new Common::FSDirectory(bundlePath, 2), priority);
 	}
 }
 

--- a/backends/platform/sdl/macosx/macosx_wrapper.h
+++ b/backends/platform/sdl/macosx/macosx_wrapper.h
@@ -29,5 +29,6 @@ bool hasTextInClipboardMacOSX();
 Common::U32String getTextFromClipboardMacOSX();
 bool setTextInClipboardMacOSX(const Common::U32String &text);
 Common::String getDesktopPathMacOSX();
+Common::String getResourceAppBundlePathMacOSX();
 
 #endif

--- a/backends/platform/sdl/macosx/macosx_wrapper.mm
+++ b/backends/platform/sdl/macosx/macosx_wrapper.mm
@@ -30,6 +30,7 @@
 #include <Foundation/NSPathUtilities.h>
 #include <AvailabilityMacros.h>
 #include <CoreFoundation/CFString.h>
+#include <CoreFoundation/CoreFoundation.h>
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6
 #define NSPasteboardTypeString NSStringPboardType
@@ -109,4 +110,19 @@ Common::String getDesktopPathMacOSX() {
 	if (path == nil)
 		return Common::String();
 	return Common::String([path fileSystemRepresentation]);
+}
+
+Common::String getResourceAppBundlePathMacOSX() {
+	CFURLRef fileUrl = CFBundleCopyResourcesDirectoryURL(CFBundleGetMainBundle());
+	if (fileUrl) {
+		// Try to convert the URL to an absolute path
+		UInt8 buf[MAXPATHLEN];
+		if (CFURLGetFileSystemRepresentation(fileUrl, true, buf, sizeof(buf))) {
+			CFRelease(fileUrl);
+			return Common::String((const char *)buf);
+		}
+		CFRelease(fileUrl);
+	}
+
+	return Common::String();
 }

--- a/backends/platform/sdl/macosx/macosx_wrapper.mm
+++ b/backends/platform/sdl/macosx/macosx_wrapper.mm
@@ -27,10 +27,10 @@
 
 #include <AppKit/NSPasteboard.h>
 #include <Foundation/NSArray.h>
+#include <Foundation/NSBundle.h>
 #include <Foundation/NSPathUtilities.h>
 #include <AvailabilityMacros.h>
 #include <CoreFoundation/CFString.h>
-#include <CoreFoundation/CoreFoundation.h>
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6
 #define NSPasteboardTypeString NSStringPboardType
@@ -113,16 +113,8 @@ Common::String getDesktopPathMacOSX() {
 }
 
 Common::String getResourceAppBundlePathMacOSX() {
-	CFURLRef fileUrl = CFBundleCopyResourcesDirectoryURL(CFBundleGetMainBundle());
-	if (fileUrl) {
-		// Try to convert the URL to an absolute path
-		UInt8 buf[MAXPATHLEN];
-		if (CFURLGetFileSystemRepresentation(fileUrl, true, buf, sizeof(buf))) {
-			CFRelease(fileUrl);
-			return Common::String((const char *)buf);
-		}
-		CFRelease(fileUrl);
-	}
-
-	return Common::String();
+	NSString *bundlePath = [[NSBundle mainBundle] resourcePath];
+	if (bundlePath == nil)
+		return Common::String();
+	return Common::String([bundlePath fileSystemRepresentation]);
 }

--- a/backends/plugins/sdl/macosx/macosx-provider.cpp
+++ b/backends/plugins/sdl/macosx/macosx-provider.cpp
@@ -21,32 +21,17 @@
 
 #include "common/scummsys.h"
 
-#ifdef MACOSX
+#if defined(DYNAMIC_MODULES) && defined(SDL_BACKEND) && defined(MACOSX)
 
-#include "backends/platform/sdl/macosx/macosx.h"
 #include "backends/plugins/sdl/macosx/macosx-provider.h"
-#include "base/main.h"
+#include "backends/platform/sdl/macosx/macosx_wrapper.h"
 
-int main(int argc, char *argv[]) {
+#include "common/fs.h"
 
-	// Create our OSystem instance
-	g_system = new OSystem_MacOSX();
-	assert(g_system);
-
-	// Pre initialize the backend
-	g_system->init();
-
-#ifdef DYNAMIC_MODULES
-	PluginManager::instance().addPluginProvider(new MacOSXPluginProvider());
-#endif
-
-	// Invoke the actual ScummVM main entry point:
-	int res = scummvm_main(argc, argv);
-
-	// Free OSystem
-	g_system->destroy();
-
-	return res;
+void MacOSXPluginProvider::addCustomDirectories(Common::FSList &dirs) const {
+	Common::String bundlePath = getResourceAppBundlePathMacOSX();
+	if (!bundlePath.empty())
+		dirs.push_back(Common::FSNode(bundlePath));
 }
 
-#endif
+#endif // defined(DYNAMIC_MODULES) && defined(SDL_BACKEND) && defined(MACOSX)

--- a/backends/plugins/sdl/macosx/macosx-provider.h
+++ b/backends/plugins/sdl/macosx/macosx-provider.h
@@ -19,34 +19,18 @@
  *
  */
 
-#include "common/scummsys.h"
+#ifndef BACKENDS_PLUGINS_SDL_MACOSX_PROVIDER_H
+#define BACKENDS_PLUGINS_SDL_MACOSX_PROVIDER_H
 
-#ifdef MACOSX
+#include "backends/plugins/sdl/sdl-provider.h"
 
-#include "backends/platform/sdl/macosx/macosx.h"
-#include "backends/plugins/sdl/macosx/macosx-provider.h"
-#include "base/main.h"
+#if defined(DYNAMIC_MODULES) && defined(SDL_BACKEND) && defined(MACOSX)
 
-int main(int argc, char *argv[]) {
+class MacOSXPluginProvider : public SDLPluginProvider {
+protected:
+	void addCustomDirectories(Common::FSList &dirs) const;
+};
 
-	// Create our OSystem instance
-	g_system = new OSystem_MacOSX();
-	assert(g_system);
-
-	// Pre initialize the backend
-	g_system->init();
-
-#ifdef DYNAMIC_MODULES
-	PluginManager::instance().addPluginProvider(new MacOSXPluginProvider());
-#endif
-
-	// Invoke the actual ScummVM main entry point:
-	int res = scummvm_main(argc, argv);
-
-	// Free OSystem
-	g_system->destroy();
-
-	return res;
-}
+#endif // defined(DYNAMIC_MODULES) && defined(SDL_BACKEND) && defined(MACOSX)
 
 #endif

--- a/configure
+++ b/configure
@@ -2159,7 +2159,7 @@ if test "$have_gcc" = yes ; then
 elif test "$have_icc" = yes ; then
 	# ICC does not support pedantic, while GCC and clang do.
 	add_line_to_config_mk 'CXX_UPDATE_DEP_FLAG = -MMD -MF "$(*D)/$(DEPDIR)/$(*F).d" -MQ "$@" -MP'
-fi;
+fi
 
 #
 # Set status about C++11 mode
@@ -2814,7 +2814,7 @@ EOF
 			fi
 		fi
 
-		# Avoid "file has no symbols" noise from ranlib, if it's new enough
+		# Avoid "file has no symbols" noise from ranlib, if it's new enough
 		ranlib_version=`$_ranlib -V 2>/dev/null`
 		if test -n "$ranlib_version" ; then
 			ranlib_version="`echo "${ranlib_version}" | sed -ne 's/.*cctools-\([0-9]\{1,\}\).*/\1/gp'`"
@@ -4090,6 +4090,7 @@ POST_OBJS_FLAGS := -Wl,-no-whole-archive
 		_plugin_prefix=""
 		_plugin_suffix=".plugin"
 		append_var LIBS "-ldl"
+		append_var _strip "-x"
 _mak_plugins='
 PLUGIN_EXTRA_DEPS = $(EXECUTABLE)
 PLUGIN_LDFLAGS  += -bundle -bundle_loader $(EXECUTABLE) -exported_symbols_list "$(srcdir)/plugin.exp"

--- a/ports.mk
+++ b/ports.mk
@@ -475,7 +475,7 @@ endif
 # We use -force_cpusubtype_ALL to ensure the binary runs on every
 # PowerPC machine.
 scummvm-static: $(DETECT_OBJS) $(OBJS)
-	+$(LD) $(LDFLAGS) -force_cpusubtype_ALL -o scummvm-static $(DETECT_OBJS) $(OBJS) \
+	+$(LD) $(LDFLAGS) -force_cpusubtype_ALL -o scummvm-static $(PRE_OBJS_FLAGS) $(DETECT_OBJS) $(OBJS) $(POST_OBJS_FLAGS) \
 		-framework CoreMIDI \
 		$(OSX_STATIC_LIBS) \
 		$(OSX_ZLIB)

--- a/ports.mk
+++ b/ports.mk
@@ -158,6 +158,9 @@ endif
 	cp $(bundle_name)/Contents/Resources/COPYING.FREEFONT $(bundle_name)/Contents/Resources/COPYING-FREEFONT
 	cp $(bundle_name)/Contents/Resources/COPYING.OFL $(bundle_name)/Contents/Resources/COPYING-OFL
 	cp $(bundle_name)/Contents/Resources/COPYING.BSD $(bundle_name)/Contents/Resources/COPYING-BSD
+ifdef DYNAMIC_MODULES
+	cp $(PLUGINS) $(bundle_name)/Contents/Resources/
+endif
 	chmod 644 $(bundle_name)/Contents/Resources/*
 ifneq ($(DIST_FILES_SHADERS),)
 	chmod 755 $(bundle_name)/Contents/Resources/shaders
@@ -172,9 +175,9 @@ endif
 	codesign -s - --deep --force $(bundle_name)
 
 ifdef USE_DOCKTILEPLUGIN
-bundle: scummvm-static scummvm.docktileplugin bundle-pack
+bundle: scummvm-static plugins scummvm.docktileplugin bundle-pack
 else
-bundle: scummvm-static bundle-pack
+bundle: scummvm-static plugins bundle-pack
 endif
 
 iphonebundle: iphone


### PR DESCRIPTION
This PR lets one build and run a macOS Bundle (= `ScummVM.app`) with dynamic plugins for the game engines.

I'm doing this to resurrect the Mac PowerPC port, where the old PowerPC linker can't cope with a single static ScummVM binary with all engines anymore (and Mach-O doesn't offer as many flags as ELF to work around this).

This is split into several smaller commits:

* split `OSystem_MacOSX::addSysArchivesToSearchSet()` so that we now have a separate `getResourceAppBundlePathMacOSX()` wrapper (so that both the shader and plugin loading code can use it).
* let macOS have its own `addCustomDirectories()` (like the Nintendo DS port does), so that plugins can be loaded from the current macOS bundle if it exists.
* use `strip -x` to strip the main scummvm binary when building plugins, in order to keep global symbols (otherwise the plugins will fail loading).
* use the `$(PRE_OBJS_FLAGS)` variable (i.e. `-all_load`) when linking `scummvm-static`, otherwise it will fail loading its dynamic plugins, too.
* let `ports.mk` install plugins to `Contents/Resources/` in the bundle, when dynamic plugins are enabled.

It should have no impact on default macOS Intel/ARM builds, which don't use dynamic plugins by default at the moment.

However, I don't have a lot of experience with macOS bundles and plugins, so I hope I'm not doing any big mistake here.

Tested on Tiger (which needs a couple of build fixes that I've put into PR #3878) and Monterey.