### PR TITLE
BUILD: Various macOS build fixes for Tiger/Leopard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+ifndef .FEATURES
+	$(error GNU Make 3.81 or higher is required)
+endif
 
 #######################################################################
 # Default compilation parameters. Normally don't edit these           #

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifndef .FEATURES
-	$(error GNU Make 3.81 or higher is required)
+$(error GNU Make 3.81 or higher is required)
 endif
 
 #######################################################################

--- a/backends/midi/coreaudio.cpp
+++ b/backends/midi/coreaudio.cpp
@@ -209,40 +209,13 @@ void MidiDriver_CORE::loadSoundFont(const char *soundfont) {
 	FSRef fsref;
 	err = FSPathMakeRef((const byte *)soundfont, &fsref, NULL);
 
-	SInt32 version;
-	err = Gestalt(gestaltSystemVersion, &version);
-
 	if (err == noErr) {
-		if (version >= 0x1030) {
-			// Use kMusicDeviceProperty_SoundBankFSRef in >= 10.3
-
-			// HACK HACK HACK HACK SUPER HACK: Using the value of 1012 instead of
-			// kMusicDeviceProperty_SoundBankFSRef so this compiles with the 10.2
-			// SDK (which does not have that symbol).
-			if (err == noErr) {
-				err = AudioUnitSetProperty(
-					_synth,
-					/*kMusicDeviceProperty_SoundBankFSRef*/ 1012, kAudioUnitScope_Global,
-					0,
-					&fsref, sizeof(fsref)
-				);
-			}
-		} else {
-			// In 10.2, only kMusicDeviceProperty_SoundBankFSSpec is available
-			FSSpec fsSpec;
-
-			if (err == noErr)
-				err = FSGetCatalogInfo(&fsref, kFSCatInfoNone, NULL, NULL, &fsSpec, NULL);
-
-			if (err == noErr) {
-				err = AudioUnitSetProperty(
-					_synth,
-					kMusicDeviceProperty_SoundBankFSSpec, kAudioUnitScope_Global,
-					0,
-					&fsSpec, sizeof(fsSpec)
-				);
-			}
-		}
+		err = AudioUnitSetProperty(
+			_synth,
+			kMusicDeviceProperty_SoundBankFSRef, kAudioUnitScope_Global,
+			0,
+			&fsref, sizeof(fsref)
+		);
 	}
 #else
 	// kMusicDeviceProperty_SoundBankURL was added in 10.5 as a replacement

--- a/configure
+++ b/configure
@@ -2802,9 +2802,9 @@ EOF
 
 		# Version-specific quirks
 		if test -n "$_macos_min_version" ; then
-			# When building for MacOS X 10.5 or below we need to use the legacy icon
+			# When building for MacOS X 10.5 or below
 			if test "$_macos_min_version" -lt 1060 ; then
-				add_line_to_config_mk 'MACOSX_USE_LEGACY_ICONS = 1'
+				add_line_to_config_mk 'MACOSX_LEOPARD_OR_BELOW = 1'
 			fi
 
 			# When building with SDK 10.14 or above, we cannot compile the 32 bits dock plugin

--- a/configure
+++ b/configure
@@ -2652,17 +2652,11 @@ case $_host_os in
 		exit 1
 		;;
 	darwin*)
-		# Pass -mlongcall to gcc so that it emits long calls
-		# which will allow for calls larger than 32MB. The linker
-		# will discard the calls if they are not needed, but we
-		# need to ensure the compiler emits them in the first place.
-		# Also the executable has grown to a size where using -Os is necessary to avoid a
-		# 'virtual memory exhausted' error when running the executable.
 		case $_host_cpu in
 		powerpc*)
-			append_var CFLAGS "-mlongcall"
-			append_var CXXFLAGS "-mlongcall"
-			_optimization_level=-Os
+			if test "$_dynamic_modules" = no ; then
+				echo "WARNING: Building static engines will probably fail at link time on Mac PowerPC"
+			fi
 			;;
 		esac
 

--- a/ports.mk
+++ b/ports.mk
@@ -150,10 +150,11 @@ ifneq ($(DIST_FILES_SHADERS),)
 endif
 	$(srcdir)/devtools/credits.pl --rtf > $(bundle_name)/Contents/Resources/AUTHORS.rtf
 	rm $(bundle_name)/Contents/Resources/AUTHORS
-	@sed -i'' -e "s/AUTHORS/AUTHORS.rtf/g" $(bundle_name)/Contents/Resources/README.md
+	@sed -i'.sed-orig' -e "s/AUTHORS/AUTHORS.rtf/g" $(bundle_name)/Contents/Resources/README.md
 ifdef USE_PANDOC
-	@sed -i'' -e "s|href=\"AUTHORS\"|href=\"https://www.scummvm.org/credits/\"|g" $(bundle_name)/Contents/Resources/README$(PANDOCEXT)
+	@sed -i'.sed-orig' -e "s|href=\"AUTHORS\"|href=\"https://www.scummvm.org/credits/\"|g" $(bundle_name)/Contents/Resources/README$(PANDOCEXT)
 endif
+	@rm $(bundle_name)/Contents/Resources/*.sed-orig
 	cp $(bundle_name)/Contents/Resources/COPYING.LGPL $(bundle_name)/Contents/Resources/COPYING-LGPL
 	cp $(bundle_name)/Contents/Resources/COPYING.FREEFONT $(bundle_name)/Contents/Resources/COPYING-FREEFONT
 	cp $(bundle_name)/Contents/Resources/COPYING.OFL $(bundle_name)/Contents/Resources/COPYING-OFL

--- a/ports.mk
+++ b/ports.mk
@@ -128,7 +128,7 @@ ifdef USE_SPARKLE
 	rm -rf $(bundle_name)/Contents/Frameworks/Sparkle.framework
 	cp -RP $(SPARKLEPATH)/Sparkle.framework $(bundle_name)/Contents/Frameworks/
 endif
-ifdef MACOSX_USE_LEGACY_ICONS
+ifdef MACOSX_LEOPARD_OR_BELOW
 	cp $(srcdir)/icons/scummvm_legacy.icns $(bundle_name)/Contents/Resources/scummvm.icns
 else
 	cp $(srcdir)/icons/scummvm.icns $(bundle_name)/Contents/Resources/scummvm.icns
@@ -169,7 +169,9 @@ ifdef USE_DOCKTILEPLUGIN
 	mkdir -p $(bundle_name)/Contents/PlugIns
 	cp -r scummvm.docktileplugin $(bundle_name)/Contents/PlugIns/
 endif
+ifndef MACOSX_LEOPARD_OR_BELOW
 	codesign -s - --deep --force $(bundle_name)
+endif
 
 ifdef USE_DOCKTILEPLUGIN
 bundle: scummvm-static scummvm.docktileplugin bundle-pack


### PR DESCRIPTION
ScummVM 2.2.0 was the last official release for Mac PowerPC; it still builds if you set up a C++11 toolchain for it, but you need dynamic plugins now (see PR #3877) because a single binary with all engines is too big for the PowerPC Mach-O linker.

You also need this small set of fixes:

* don't use the `-Os -mlongcall` workaround on Mac PPC anymore: the engines are too big for a single Mach-O PowerPC binary, now (ELF has better workarounds for this). I tried some other linker or compiler workarounds, but it wouldn't be enough, or it would cause internal linker errors. So I suggest relying on dynamic plugins for a full build in this particular setup (see PR #3877 for this).
    * Going back to default GCC flags could also mean fewer GCC bugs on this old platform with its old toolchain.
* don't run `codesign` when targeting Leopard or Tiger: Tiger didn't have it at all, and Leopard didn't have the `--deep` flag. The OS didn't really care for that yet, anyway.
* work around limited `sed -i''` before macOS 10.9: it's just impossible to have a `sed -i''` syntax that will be accepted by older BSD sed, newer BSD sed, and GNU sed ([source](https://stackoverflow.com/questions/4247068/#4247319)). So here, always use a suffix, and delete the backup files afterward (otherwise, the bundle will embed some strange `-e` files).
    * (There are other calls to `sed -i''` but the Tiger/Leopard build doesn't hit them.)
* reject GNU Make 3.80 and older: that's the default version on macOS Tiger, but it's very old and it has some bugs and parsing issues, so it shouldn't be used.
    * It's easy to have at least GNU Make 3.81 everywhere, and we know that 3.81 is OK because that's what Apple still ships on modern macOS (because of GPLv3).
    * Parsing `$(MAKE_VERSION)` is quite inconvenient and not very reliable, so it's usually easier to look for a feature which appeared in the minimum version you require (here, the `.FEATURES` variable). Putting this at the top of the main Makefile will also "help" BSD `make` fail early on (since we require GNU Make but don't use `GNUmakefile`).
* remove old hacks for CoreAudio on macOS 10.2 and 10.3. I'm pretty sure the rest of the macOS code didn't compile on macOS 10.2/10.3 for a long time, and there's no C++11 toolchain before macOS 10.4 anyway.

Tested on macos Tiger, Leopard and Monterey.